### PR TITLE
ath79: support ZTE MF286A/R

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -122,7 +122,9 @@ qihoo,c301)
 wallys,dr531)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0xf800" "0x10000"
 	;;
-zte,mf286)
+zte,mf286|\
+zte,mf286a|\
+zte,mf286r)
 	ubootenv_add_uci_config "/dev/mtd7" "0x0" "0x20000" "0x10000"
 	;;
 esac

--- a/target/linux/ath79/dts/qca9563_zte_mf286.dtsi
+++ b/target/linux/ath79/dts/qca9563_zte_mf286.dtsi
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// Copyright (c) 2021 Cezary Jackiewicz
+// Copyright (c) 2021, 2022 Lech Perczak
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_debug;
+		led-failsafe = &led_debug;
+		led-running = &led_debug;
+		led-upgrade = &led_debug;
+		label-mac-device = &eth0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		/* Hidden SMD LED below signal strength LEDs.
+		 * Visible through slits underside of the case,
+		 * and slightly through the case below signal state LEDs
+		 */
+		led_debug: led-0 {
+			function = LED_FUNCTION_DEBUG;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wifi {
+			label = "wifi";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	/* This GPIO is used to reset whole board _including_ the modem */
+	gpio-restart {
+		compatible = "gpio-restart";
+		gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		active-delay = <3000>;
+		inactive-delay = <1000>;
+	};
+};
+
+&gpio {
+	/* GPIO19 is used as a mask to enable WLAN LED
+	 * in stock firmware, which is controlled directly
+	 * by 5GHz Wi-Fi chip, which currently is inactive
+	 * in OpenWrt
+	 */
+	led-wlan {
+		gpio-hog;
+		gpios = <19 GPIO_ACTIVE_LOW>;
+		output-high;
+		line-name = "led:wlan";
+	};
+};
+
+&spi {
+	status = "okay";
+
+	boot_flash: flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+	};
+
+	system_flash: flash@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&pcie {
+	status = "okay";
+
+	wifi_ath10k: wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0 0 0 0 0>;
+	};
+};
+
+&wmac {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/qca9563_zte_mf286a.dts
+++ b/target/linux/ath79/dts/qca9563_zte_mf286a.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// Copyright (c) 2021 Cezary Jackiewicz
+// Copyright (c) 2021, 2022 Lech Perczak
+#include "qca9563_zte_mf286ar.dtsi"
+
+/ {
+	model = "ZTE MF286A";
+	compatible = "zte,mf286a", "qca,qca9563";
+};

--- a/target/linux/ath79/dts/qca9563_zte_mf286ar.dtsi
+++ b/target/linux/ath79/dts/qca9563_zte_mf286ar.dtsi
@@ -4,9 +4,6 @@
 #include "qca9563_zte_mf286.dtsi"
 
 / {
-	model = "ZTE MF286";
-	compatible = "zte,mf286", "qca,qca9563";
-
 	ubi-concat {
 		compatible = "mtd-concat";
 		devices = <&ubiconcat0 &ubiconcat1>;
@@ -17,7 +14,7 @@
 			#size-cells = <1>;
 
 			partition@0 {
-				reg = <0x0 0x7840000>;
+				reg = <0x0 0x7a60000>;
 				label = "ubi";
 			};
 		};
@@ -25,25 +22,31 @@
 };
 
 &led_debug {
-	/* Hidden green SMD LED below signal strength LEDs
+	/* Hidden blue SMD LED below signal strength LEDs
 	 * Visible through slits underside of the case,
 	 * and slightly through the case below signal state LEDs
 	 */
-	color = <LED_COLOR_ID_GREEN>;
-	label = "green:debug";
+	color = <LED_COLOR_ID_BLUE>;
+	label = "blue:debug";
 };
 
 &boot_flash {
 	partitions {
 		partition@0 {
 			label = "u-boot";
-			reg = <0x000000 0x080000>;
+			reg = <0x000000 0x0a0000>;
 			read-only;
 		};
 
-		partition@80000 {
+		partition@a0000 {
 			label = "u-boot-env";
-			reg = <0x080000 0x020000>;
+			reg = <0x0a0000 0x020000>;
+			read-only;
+		};
+
+		partition@c0000 {
+			label = "reserved1";
+			reg = <0x0c0000 0x140000>;
 			read-only;
 		};
 	};
@@ -53,62 +56,63 @@
 	partitions {
 		partition@0 {
 			label = "fota-flag";
-			reg = <0x000000 0x140000>;
+			reg = <0x00000 0xa0000>;
 			read-only;
 		};
 
-		partition@140000 {
-			label = "caldata";
-			reg = <0x140000 0x140000>;
+		partition@a0000 {
+			label = "art";
+			reg = <0xa0000 0x80000>;
 			read-only;
 
 			compatible = "nvmem-cells";
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			cal_caldata_1000: cal@1000 {
+			cal_art_1000: cal@1000 {
 				reg = <0x1000 0x440>;
 			};
 
-			cal_caldata_5000: cal@5000 {
-				reg = <0x5000 0x844>;
+			precal_art_5000: precal@5000 {
+				reg = <0x5000 0x2f20>;
 			};
 		};
 
-		partition@280000 {
+		partition@120000 {
 			label = "mac";
-			reg = <0x280000 0x140000>;
+			reg = <0x120000 0x80000>;
 			read-only;
 
 			compatible = "nvmem-cells";
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			macaddr_mac_0: macaddr@0 {
+			macaddr_mac_0: mac-address@0 {
 				reg = <0x0 0x6>;
 			};
 		};
 
-		/* This encompasses stock cfg-param, oops, web partitions,
+		/* This encompasses stock reserved2, cfg-param, log, oops,
+		 * reserved3, web partitions,
 		 * which can be overwritten safely
 		 */
-		ubiconcat0: partition@3c0000 {
+		ubiconcat0: partition@1a0000 {
 			label = "ubiconcat0";
-			reg = <0x3c0000 0xf40000>;
+			reg = <0x1a0000 0x1660000>;
 		};
 
 		/* Kernel MTD size is increased to 4MB from stock 3MB */
-		partition@1300000 {
+		partition@1800000 {
 			label = "kernel";
-			reg = <0x1300000 0x400000>;
+			reg = <0x1800000 0x400000>;
 		};
 
 		/* This encompasses stock rootfs, data, fota partitions,
 		 * which can be overwritten safely
 		 */
-		ubiconcat1: partition@1600000 {
+		ubiconcat1: partition@1c00000 {
 			label = "ubiconcat1";
-			reg = <0x1700000 0x6900000>;
+			reg = <0x1c00000 0x6400000>;
 		};
 	};
 };
@@ -119,12 +123,12 @@
 };
 
 &wifi_ath10k {
-	nvmem-cells = <&macaddr_mac_0>, <&cal_caldata_5000>;
-	nvmem-cell-names = "mac-address", "calibration";
-	mac-address-increment = <1>;
+	nvmem-cells = <&macaddr_mac_0>, <&precal_art_5000>;
+	nvmem-cell-names = "mac-address", "pre-calibration";
+	mac-address-increment = <0x20000>;
 };
 
 &wmac {
-	nvmem-cells = <&macaddr_mac_0>, <&cal_caldata_1000>;
+	nvmem-cells = <&macaddr_mac_0>, <&cal_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
 };

--- a/target/linux/ath79/dts/qca9563_zte_mf286r.dts
+++ b/target/linux/ath79/dts/qca9563_zte_mf286r.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// Copyright (c) 2021 Cezary Jackiewicz
+// Copyright (c) 2021, 2022 Lech Perczak
+#include "qca9563_zte_mf286ar.dtsi"
+
+/ {
+	model = "ZTE MF286R";
+	compatible = "zte,mf286r", "qca,qca9563";
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -305,19 +305,38 @@ define Device/netgear_wndr4500-v3
 endef
 TARGET_DEVICES += netgear_wndr4500-v3
 
-define Device/zte_mf286
+define Device/zte_mf286_common
   SOC := qca9563
   DEVICE_VENDOR := ZTE
-  DEVICE_MODEL := MF286
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct \
-	ath10k-firmware-qca988x-ct kmod-usb-net-qmi-wwan kmod-usb-serial-option \
-	uqmi
+  DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   KERNEL_SIZE := 4096k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
+
+define Device/zte_mf286
+  $(Device/zte_mf286_common)
+  DEVICE_MODEL := MF286
+  DEVICE_PACKAGES += ath10k-firmware-qca988x-ct kmod-usb-net-qmi-wwan \
+	kmod-usb-serial-option uqmi
+endef
 TARGET_DEVICES += zte_mf286
+
+define Device/zte_mf286a
+  $(Device/zte_mf286_common)
+  DEVICE_MODEL := MF286A
+  DEVICE_PACKAGES += ath10k-firmware-qca9888-ct kmod-usb-net-qmi-wwan \
+	kmod-usb-serial-option uqmi
+endef
+TARGET_DEVICES += zte_mf286a
+
+define Device/zte_mf286r
+  $(Device/zte_mf286_common)
+  DEVICE_MODEL := MF286R
+  DEVICE_PACKAGES += ath10k-firmware-qca9888-ct kmod-usb-net-rndis kmod-usb-acm
+endef
+TARGET_DEVICES += zte_mf286r
 
 define Device/zyxel_nbg6716
   SOC := qca9558

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -45,7 +45,9 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
 		;;
-	zte,mf286)
+	zte,mf286|\
+	zte,mf286a|\
+	zte,mf286r)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "5:lan:1"
 		;;


### PR DESCRIPTION
ZTE MF286A and MF286R are indoor LTE category 6/7 CPE router with simultaneous
dual-band 802.11ac plus 802.11n Wi-Fi radios and quad-port gigabit
Ethernet switch, FXS and external USB 2.0 port.

Hardware highlights:
- CPU: QCA9563 SoC at 775MHz,
- RAM: 128MB DDR2,
- NOR Flash: MX25L1606E 2MB SPI Flash, for U-boot only,
- NAND Flash: W25N01GV 128MB SPI NAND-Flash, for all other data,
- Wi-Fi 5GHz: QCA9886 2x2 MIMO 802.11ac Wave2 radio,
- WI-Fi 2.4GHz: QCA9563 3x3 MIMO 802.11n radio,
- Switch: QCA8337v2 4-port gigabit Ethernet, with single SGMII CPU port,
- WWAN:
  [MF286A] MDM9230-based category 6 internal LTE modem
  [MF286R] PXA1826-based category 7 internal LTE modem
  in extended  mini-PCIE form factor, with 3 internal antennas and
  2 external antenna connections, single mini-SIM slot.
- FXS: one external ATA port (handled entirely by modem part) with two
  physical connections in parallel,
- USB: Single external USB 2.0 port,
- Switches: power switch, WPS, Wi-Fi and reset buttons,
- LEDs: Wi-Fi, Test (internal). Rest of LEDs (Phone, WWAN, Battery,
  Signal state) handled entirely by modem. 4 link status LEDs handled by
  the switch on the backside.
- Battery: 3Ah 1-cell Li-Ion replaceable battery, with charging and
  monitoring handled by modem.
- Label MAC device: eth0

The device shares many components with previous model, MF286, differing
mostly by a Wave2 5GHz radio, flash layout and internal LED color.
In case of MF286A, the modem is the same as in MF286. MF286R uses a
different modem based on Marvell PXA1826 chip.

Internal modem of MF286A is supported via uqmi, MF286R modem isn't fully
supported, but it is expected to use comgt-ncm for connection, as it
uses standard 3GPP AT commands for connection establishment.

Console connection: connector X2 is the console port, with the following
pinout, starting from pin 1, which is the topmost pin when the board is
upright:
- VCC (3.3V). Do not use unless you need to source power for the
  converer from it.
- TX
- RX
- GND
Default port configuration in U-boot as well as in stock firmware is
115200-8-N-1.

Installation:
Due to different flash layout from stock firmware, sysupgrade from
within stock firmware is impossible, despite it's based on QSDK which
itself is based on OpenWrt.

STEP 0: Stock firmware update:
As installing OpenWrt cuts you off from official firmware updates for
the modem part, it is recommended to update the stock firmware to latest
version before installation, to have built-in modem at the latest firmware
version.

STEP 1: gaining root shell:

Method 1:
This works if busybox has telnetd compiled in the binary.
If this does not work, try method 2.

Using well-known exploit to start telnetd on your router - works
only if Busybox on stock firmware has telnetd included:
- Open stock firmware web interface
- Navigate to "URL filtering" section by going to "Advanced settings",
  then "Firewall" and finally "URL filter".
- Add an entry ending with "&&telnetd&&", for example
  "http://hostname/&&telnetd&&".
- telnetd will immediately listen on port 4719.
- After connecting to telnetd use "admin/admin" as credentials.

Method 2:
This works if busybox does not have telnetd compiled in. Notably, this
is the case in DNA.fi firmware.
If this does not work, try method 3.

- Set IP of your computer to 192.168.0.22. (or appropriate subnet if
  changed)
- Have a TFTP server running at that address
- Download MIPS build of busybox including telnetd, for example from:
  https://busybox.net/downloads/binaries/1.21.1/busybox-mips
  and put it in it's root directory. Rename it as "telnetd".
- As previously, login to router's web UI and navigate to "URL
  filtering"
- Using "Inspect" feature, extend "maxlength" property of the input
  field named "addURLFilter", so it looks like this:
  <input type="text" name="addURLFilter" id="addURLFilter" maxlength="332"
    class="required form-control">
- Stay on the page - do not navigate anywhere
- Enter "http://aa&zte_debug.sh 192.168.0.22 telnetd" as a filter.
- Save the settings. This will download the telnetd binary over tftp and
  execute it. You should be able to log in at port 23, using
  "admin/admin" as credentials.

Method 3:
If the above doesn't work, use the serial console - it exposes root shell
directly without need for login. Some stock firmwares, notably one from
finnish DNA operator lack telnetd in their builds.

STEP 2: Backing up original software:
As the stock firmware may be customized by the carrier and is not
officially available in the Internet, IT IS IMPERATIVE to back up the
stock firmware, if you ever plan to returning to stock firmware.
It is highly recommended to perform backup using both methods, to avoid
hassle of reassembling firmware images in future, if a restore is
needed.

Method 1: after booting OpenWrt initramfs image via TFTP:
PLEASE NOTE: YOU CANNOT DO THIS IF USING INTERMEDIATE FIRMWARE FOR INSTALLATION.
- Dump stock firmware located on stock kernel and ubi partitions:

```
  ssh root@192.168.1.1: cat /dev/mtd4 > mtd4_kernel.bin
  ssh root@192.168.1.1: cat /dev/mtd9 > mtd9_ubi.bin
```

And keep them in a safe place, should a restore be needed in future.

Method 2: using stock firmware:
- Connect an external USB drive formatted with FAT or ext4 to the USB
  port.
- The drive will be auto-mounted to /var/usb_disk
- Check the flash layout of the device:

```
  cat /proc/mtd
```

  It should show the following:
```
  mtd0: 000a0000 00010000 "u-boot"
  mtd1: 00020000 00010000 "u-boot-env"
  mtd2: 00140000 00010000 "reserved1"
  mtd3: 000a0000 00020000 "fota-flag"
  mtd4: 00080000 00020000 "art"
  mtd5: 00080000 00020000 "mac"
  mtd6: 000c0000 00020000 "reserved2"
  mtd7: 00400000 00020000 "cfg-param"
  mtd8: 00400000 00020000 "log"
  mtd9: 000a0000 00020000 "oops"
  mtd10: 00500000 00020000 "reserved3"
  mtd11: 00800000 00020000 "web"
  mtd12: 00300000 00020000 "kernel"
  mtd13: 01a00000 00020000 "rootfs"
  mtd14: 01900000 00020000 "data"
  mtd15: 03200000 00020000 "fota"
  mtd16: 01d00000 00020000 "firmware"
```

  Differences might indicate that this is NOT a MF286A device but
  one of other variants.
- Copy over all MTD partitions, for example by executing the following:

```
  for i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do cat /dev/mtd$i > \
  /var/usb_disk/mtd$i; done
```

  "Firmware" partition can be skipped, it is a concatenation
  of "kernel" and "rootfs".

- If the count of MTD partitions is different, this might indicate that
  this is not a MF286A device, but one of its other variants.
- (optionally) rename the files according to MTD partition names from
  /proc/mtd
- Unmount the filesystem:

```
  umount /var/usb_disk; sync
```

  and then remove the drive.
- Store the files in safe place if you ever plan to return to stock
  firmware. This is especially important, because stock firmware for
  this device is not available officially, and is usually customized by
  the mobile providers.

STEP 3: Booting initramfs image:

Method 1: using serial console (RECOMMENDED):
- Have TFTP server running, exposing the OpenWrt initramfs image, and
  set your computer's IP address as 192.168.0.22. This is the default
  expected by U-boot. You may wish to change that, and alter later
  commands accordingly.
- Connect the serial console if you haven't done so already,
- Interrupt boot sequence by pressing any key in U-boot when prompted
- Use the following commands to boot OpenWrt initramfs through TFTP:

```
  setenv serverip 192.168.0.22
  setenv ipaddr 192.168.0.1
  tftpboot 0x81000000 openwrt-ath79-nand-zte_mf286a-initramfs-kernel.bin
  bootm 0x81000000
```

  (Replace server IP and router IP as needed). There is no  emergency
  TFTP boot sequence triggered by buttons, contrary to MF283+.
- When OpenWrt initramfs finishes booting, proceed to actual
  installation.

Method 2: using initramfs image as temporary boot kernel
This exploits the fact, that kernel and rootfs MTD devices are
consecutive on NAND flash, so from within stock image, an initramfs can
be written to this area and booted by U-boot on next reboot, because it
uses "nboot" command which isn't limited by kernel partition size.
- Download the initramfs-kernel.bin image
- After backing up the previous MTD contents, write the images to the
  "firmware" MTD device, which conveniently concatenates "kernel" and
  "rootfs" partitions that can fit the initramfs image:

```
  nandwrite -p /dev/<firmware-mtd> \
  /var/usb_disk/openwrt-ath79-zte_mf286a-initramfs-kernel.bin
```

- If write is OK, reboot the device, it will reboot to OpenWrt
  initramfs:

```
  reboot -f
```

- After rebooting, SSH into the device and use sysupgrade to perform
  proper installation.

Method 3: using built-in TFTP recovery (LAST RESORT):
- With that method, ensure you have complete backup of system's NAND
  flash first. It involves deliberately erasing the kernel.
- Download "-initramfs-kernel.bin" image for the device.
- Prepare the recovery image by prepending 8MB of zeroes to the image,
  and name it root_uImage:

```
  dd if=/dev/zero of=padding.bin bs=8M count=1
  cat padding.bin openwrt-ath79-nand-zte_mf286a-initramfs-kernel.bin >
  root_uImage
```
- Set up a TFTP server at 192.0.0.1/8. Router will use random address
  from that range.
- Put the previously generated "root_uImage" into TFTP server root
  directory.
- Deliberately erase "kernel" partition" using stock firmware after
  taking backup. THIS IS POINT OF NO RETURN.
- Restart the device. U-boot will attempt flashing the recovery
  initramfs image, which will let you perform actual installation using
  sysupgrade. This might take a considerable time, sometimes the router
  doesn't establish Ethernet link properly right after booting. Be
  patient.
- After U-boot finishes flashing, the LEDs of switch ports will all
  light up. At this moment, perform power-on reset, and wait for OpenWrt
  initramfs to finish booting. Then proceed to actual installation.

STEP 4: Actual installation:
- Set your computer IP to 192.168.1.22/24
- scp the sysupgrade image to the device:

```
  scp openwrt-ath79-nand-zte_mf286a-squashfs-sysupgrade.bin \
  root@192.168.1.1:/tmp/
```

- ssh into the device and execute sysupgrade:

```
  sysupgrade -n /tmp/openwrt-ath79-nand-zte_mf286a-squashfs-sysupgrade.bin
```

- Wait for router to reboot to full OpenWrt.

STEP 5: WAN connection establishment
Since the router is equipped with LTE modem as its main WAN interface, it
might be useful to connect to the Internet right away after
installation. To do so, please put the following entries in
/etc/config/network, replacing the specific configuration entries with
one needed for your ISP:

```
config interface 'wan'
        option proto 'qmi'
        option device '/dev/cdc-wdm0'
        option auth '<auth>' # As required, usually 'none'
        option pincode '<pin>' # If required by SIM
        option apn '<apn>' # As required by ISP
        option pdptype '<pdp>' # Typically 'ipv4', or 'ipv4v6' or 'ipv6'
```

For example, the following works for most polish ISPs
```
config interface 'wan'
        option proto 'qmi'
        option device '/dev/cdc-wdm0'
        option auth 'none'
        option apn 'internet'
        option pdptype 'ipv4'
```

The required minimum is:
```
config interface 'wan'
        option proto 'qmi'
        option device '/dev/cdc-wdm0'
```
In this case, the modem will use last configured APN from stock
firmware - this should work out of the box, unless your SIM requires
PIN which can't be switched off.

If you have build with LuCI, installing luci-proto-qmi helps with this
task.

Restoring the stock firmware:

Preparation:
If you took your backup using stock firmware, you will need to
reassemble the partitions into images to be restored onto the flash. The
layout might differ from ISP to ISP, this example is based on generic stock
firmware
The only partitions you really care about are "web", "kernel", and
"rootfs". These are required to restore the stock firmware through
factory TFTP recovery.

Because kernel partition was enlarged, compared to stock
firmware, the kernel and rootfs MTDs don't align anymore, and you need
to carve out required data if you only have backup from stock FW:
- Prepare kernel image

```
  cat mtd12_kernel.bin mtd13_rootfs.bin > owrt_kernel.bin
  truncate -s 4M owrt_kernel_restore.bin
```

- Cut off first 1MB from rootfs

```
  dd if=mtd13_rootfs.bin of=owrt_rootfs.bin bs=1M skip=1
```

- Prepare image to write to "ubi" meta-partition:

```
  cat mtd6_reserved2.bi mtd7_cfg-param.bin mtd8_log.bin mtd9_oops.bin \
  mtd10_reserved3.bin mtd11_web.bin owrt_rootfs.bin > \
  owrt_ubi_ubi_restore.bin
```

You can skip the "fota" partition altogether,
it is used only for stock firmware update purposes and can be overwritten
safely anyway. The same is true for "data" partition which on my device
was found to be unused at all. Restoring mtd5_cfg-param.bin will restore
the stock firmware configuration you had before.

Method 1: Using initramfs:
This method is recmmended if you took your backup from within OpenWrt
initramfs, as the reassembly is not needed.
- Boot to initramfs as in step 3:
- Completely detach ubi0 partition using ubidetach /dev/ubi0_0
- Look up the kernel and ubi partitions in /proc/mtd
- Copy over the stock kernel image using scp to /tmp
- Erase kernel and restore stock kernel:
```
  (scp mtd4_kernel.bin root@192.168.1.1:/tmp/)
  mtd write <kernel_mtd> mtd4_kernel.bin
  rm mtd4_kernel.bin
```
- Copy over the stock partition backups one-by-one using scp to /tmp, and
  restore them individually. Otherwise you might run out of space in
  tmpfs:
```
  (scp mtd3_ubiconcat0.bin root@192.168.1.1:/tmp/)

  mtd write <ubiconcat0_mtd> mtd3_ubiconcat0.bin
  rm mtd3_ubiconcat0.bin

  (scp mtd5_ubiconcat1.bin root@192.168.1.1:/tmp/)

  mtd write <ubiconcat1_mtd> mtd5_ubiconcat1.bin
  rm mtd5_ubiconcat1.bin
```
- If the write was correct, force a device reboot with

  reboot -f

Method 2: Using live OpenWrt system (NOT RECOMMENDED):
- Prepare a USB flash drive contatining MTD backup files
- Ensure you have kmod-usb-storage and filesystem driver installed for
  your drive
- Mount your flash drive

```
  mkdir /tmp/usb
  mount /dev/sda1 /tmp/usb
```

- Remount your UBI volume at /overlay to R/O

```
  mount -o remount,ro /overlay
```

- Write back the kernel and ubi partitions from USB drive

```
  cd /tmp/usb
  mtd write mtd4_kernel.bin /dev/<kernel_mtd>
  mtd write mtd9_ubi.bin /dev/<kernel_ubi>
```
- If everything went well, force a device reboot with

```
  reboot -f
```

Last image may be truncated a bit due to lack of space in RAM, but this will happen over "fota"
MTD partition which may be safely erased after reboot anyway.

Method 3: using built-in TFTP recovery:
This method is recommended if you took backups using stock firmware.
- Assemble a recovery rootfs image from backup of stock partitions by
  concatenating "web", "kernel", "rootfs" images dumped from the device,
  as "root_uImage"
- Use it in place of "root_uImage" recovery initramfs image as in the
  TFTP pre-installation method.

Quirks and known issuesa
- It was observed, that CH340-based USB-UART converters output garbage
  during U-boot phase of system boot. At least CP2102 is known to work
  properly.
- Kernel partition size is increased to 4MB compared to stock 3MB, to
  accomodate future kernel updates - at this moment OpenWrt 5.10 kernel
  image is at 2.5MB which is dangerously close to the limit. This has no
  effect on booting the system - but keep that in mind when reassembling
  an image to restore stock firmware.
- uqmi seems to be unable to change APN manually, so please use the one
  you used before in stock firmware first. If you need to change it,
  please use protocok '3g' to establish connection once, or use the
  following command to change APN (and optionally IP type) manually:
  echo -ne 'AT+CGDCONT=1,"IP","<apn>' > /dev/ttyUSB0
- The only usable LED as a "system LED" is the blue debug LED hidden
  inside the case. All other LEDs are controlled by modem, on which the
  router part has some influence only on Wi-Fi LED.
- Wi-Fi LED currently doesn't work while under OpenWrt, despite having
  correct GPIO mapping. All other LEDs are controlled by modem,
  including this one in stock firmware. GPIO19, mapped there only acts
  as a gate, while the actual signal source seems to be 5GHz Wi-Fi
  radio, however it seems it is not the LED exposed by ath10k as
  ath10k-phy0.
- GPIO5 used for modem reset is a suicide switch, causing a hardware
  reset of whole board, not only the modem. It is attached to
  gpio-restart driver, to restart the modem on reboot as well, to ensure
  QMI connectivity after reboot, which tends to fail otherwise.
- Modem, as in MF283+, exposes root shell over ADB - while not needed
  for OpenWrt operation at all - have fun lurking around.
  The same modem module is used as in older MF286.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>

While at that - fix wrong MTD set for U-boot environment of "vanilla" MF286 from previous PR. 