### PR TITLE
ramips: add Ubiquiti EdgePoint R6 as alt name

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1546,6 +1546,8 @@ TARGET_DEVICES += ubnt_edgerouter-x
 define Device/ubnt_edgerouter-x-sfp
   $(Device/ubnt_edgerouter_common)
   DEVICE_MODEL := EdgeRouter X SFP
+  DEVICE_ALT0_VENDOR := Ubiquiti
+  DEVICE_ALT0_MODEL := EdgePoint R6
   DEVICE_PACKAGES += kmod-i2c-algo-pca kmod-gpio-pca953x kmod-sfp
   SUPPORTED_DEVICES += ubnt-erx-sfp ubiquiti,edgerouterx-sfp
 endef


### PR DESCRIPTION
    ramips: add Ubiquiti EdgePoint R6 as alt name
    
    The Ubiquiti EdgePoint R6 is identical to the EdgeRouter X SFP.
    However, it fits well into outdoor environments due to its water-proven
    case.
    
    More specifications: 9715beb04c74 ("ramips: add support for Ubiquiti
    EdgeRouter X-SFP")
