### PR TITLE
ramips: mt76x8: fix ephy led always blinking

### DIFF
--- a/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dts
+++ b/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dts
@@ -123,6 +123,7 @@
 
 &esw {
 	mediatek,portmap = <0x3e>;
+	mediatek,eee-disable;
 };
 
 &wmac {

--- a/target/linux/ramips/dts/mt7628an_iptime.dtsi
+++ b/target/linux/ramips/dts/mt7628an_iptime.dtsi
@@ -89,6 +89,10 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&esw {
+	mediatek,eee-disable;
+};
+
 &pcie {
 	status = "okay";
 };

--- a/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-nano.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-nano.dts
@@ -67,6 +67,7 @@
 &esw {
 	mediatek,portmap = <0x2f>;
 	mediatek,portdisable = <0x2a>;
+	mediatek,eee-disable;
 };
 
 &wmac {


### PR DESCRIPTION
Many MT7628 devices are using software control for their Ethernet LEDs,
but there have been reports of devices using hardware control that when
the Ethernet port is connected, the corresponding LED starts blinking
even if there is no traffic. By comparing the esw driver with the
ethernet driver from MTK SDK, it was found that disabling EEE fixes the
issue. Add a device tree property "mediatek,eee-disable" to apply the
fix only to selected boards.

Reported-at: https://github.com/openwrt/openwrt/pull/911
Reported-at: https://github.com/openwrt/openwrt/pull/5044