### PR TITLE
realtek: add support for I-O DATA BSH-G24MB

### DIFF
--- a/package/boot/uboot-envtools/files/realtek
+++ b/package/boot/uboot-envtools/files/realtek
@@ -23,6 +23,14 @@ zyxel,gs1900-24hp-v2)
 	[ -n "$idx2" ] && \
 		ubootenv_add_uci_sys_config "/dev/mtd$idx2" "0x0" "0x1000" "0x10000"
 	;;
+iodata,bsh-g24mb)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000"
+	idx2="$(find_mtd_index u-boot-env2)"
+	[ -n "$idx2" ] && \
+		ubootenv_add_uci_sys_config "/dev/mtd$idx2" "0x0" "0x3800" "0x10000"
+	;;
 *)
 	idx="$(find_mtd_index u-boot-env)"
 	[ -n "$idx" ] && \

--- a/target/linux/realtek/dts-5.10/rtl8382_iodata_bsh-g24mb.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_iodata_bsh-g24mb.dts
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl838x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "iodata,bsh-g24mb", "realtek,rtl838x-soc";
+	model = "I-O DATA BSH-G24MB";
+
+	aliases {
+		led-boot = &led_sys_loop;
+		led-failsafe = &led_sys_loop;
+		led-upgrade = &led_sys_loop;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	leds {
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>;
+		compatible = "gpio-leds";
+
+		led_sys_loop: led {
+			label = "red:sys_loop";
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio1: rtl8231-gpio {
+		compatible = "realtek,rtl8231-gpio";
+		#gpio-cells = <2>;
+		gpio-controller;
+		indirect-access-bus-id = <0>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "u-boot-env";
+				reg = <0x80000 0x10000>;
+				read-only;
+			};
+
+			partition@90000 {
+				label = "u-boot-env2";
+				reg = <0x90000 0x10000>;
+			};
+
+			partition@a0000 {
+				label = "jffs2_cfg";
+				reg = <0xa0000 0x100000>;
+				read-only;
+			};
+
+			partition@1a0000 {
+				label = "jffs2_log";
+				reg = <0x1a0000 0x100000>;
+				read-only;
+			};
+
+			/*
+			 * use 2x OS partitions in OpenWrt
+			 *
+			 * 0x2A0000-0x94FFFF: RUNTIME
+			 * 0x950000-0xFFFFFF: RUNTIME2 (not used in stock)
+			 */
+			partition@2a0000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x2a0000 0xd60000>;
+				openwrt,ih-magic = <0x83800013>;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		EXTERNAL_PHY(0)
+		EXTERNAL_PHY(1)
+		EXTERNAL_PHY(2)
+		EXTERNAL_PHY(3)
+		EXTERNAL_PHY(4)
+		EXTERNAL_PHY(5)
+		EXTERNAL_PHY(6)
+		EXTERNAL_PHY(7)
+
+		INTERNAL_PHY(8)
+		INTERNAL_PHY(9)
+		INTERNAL_PHY(10)
+		INTERNAL_PHY(11)
+		INTERNAL_PHY(12)
+		INTERNAL_PHY(13)
+		INTERNAL_PHY(14)
+		INTERNAL_PHY(15)
+
+		EXTERNAL_PHY(16)
+		EXTERNAL_PHY(17)
+		EXTERNAL_PHY(18)
+		EXTERNAL_PHY(19)
+		EXTERNAL_PHY(20)
+		EXTERNAL_PHY(21)
+		EXTERNAL_PHY(22)
+		EXTERNAL_PHY(23)
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, internal)
+		SWITCH_PORT(9, 10, internal)
+		SWITCH_PORT(10, 11, internal)
+		SWITCH_PORT(11, 12, internal)
+		SWITCH_PORT(12, 13, internal)
+		SWITCH_PORT(13, 14, internal)
+		SWITCH_PORT(14, 15, internal)
+		SWITCH_PORT(15, 16, internal)
+
+		SWITCH_PORT(16, 17, qsgmii)
+		SWITCH_PORT(17, 18, qsgmii)
+		SWITCH_PORT(18, 19, qsgmii)
+		SWITCH_PORT(19, 20, qsgmii)
+		SWITCH_PORT(20, 21, qsgmii)
+		SWITCH_PORT(21, 22, qsgmii)
+		SWITCH_PORT(22, 23, qsgmii)
+		SWITCH_PORT(23, 24, qsgmii)
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -45,6 +45,15 @@ define Device/inaba_aml2-17gp
 endef
 TARGET_DEVICES += inaba_aml2-17gp
 
+define Device/iodata_bsh-g24mb
+  SOC := rtl8382
+  IMAGE_SIZE := 13696k
+  DEVICE_VENDOR := I-O DATA
+  DEVICE_MODEL := BSH-G24MB
+  UIMAGE_MAGIC := 0x83800013
+endef
+TARGET_DEVICES += iodata_bsh-g24mb
+
 define Device/netgear_gs108t-v3
   $(Device/netgear_nge)
   DEVICE_MODEL := GS108T


### PR DESCRIPTION
- u-boot-envtools: add support for I-O DATA BSH-G24MB
- realtek: add support for I-O DATA BSH-G24MB