### PR TITLE
mbedtls: update to 2.28.0 LTS branch

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=2.16.12
+PKG_VERSION:=2.28.0
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ARMmbed/mbedtls/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=294871ab1864a65d0b74325e9219d5bcd6e91c34a3c59270c357bb9ae4d5c393
+PKG_HASH:=6519579b836ed78cc549375c7c18b111df5717e86ca0eeff4cb64b2674f424cc
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=gpl-2.0.txt
@@ -111,6 +111,9 @@ define Build/Configure
 	     END { exit(rc) }' $(PKG_BUILD_DIR)/include/mbedtls/config.h \
 	     >$(PKG_BUILD_DIR)/include/mbedtls/config.h.new && \
 	mv $(PKG_BUILD_DIR)/include/mbedtls/config.h.new $(PKG_BUILD_DIR)/include/mbedtls/config.h
+
+	sed -i '/fuzz/d' $(PKG_BUILD_DIR)/programs/CMakeLists.txt
+	sed -i '/test/d' $(PKG_BUILD_DIR)/programs/CMakeLists.txt
 endef
 
 define Build/InstallDev

--- a/package/libs/mbedtls/patches/200-config.patch
+++ b/package/libs/mbedtls/patches/200-config.patch
@@ -1,6 +1,6 @@
 --- a/include/mbedtls/config.h
 +++ b/include/mbedtls/config.h
-@@ -692,14 +692,14 @@
+@@ -665,14 +665,14 @@
   *
   * Enable Output Feedback mode (OFB) for symmetric ciphers.
   */
@@ -17,10 +17,10 @@
  
  /**
   * \def MBEDTLS_CIPHER_NULL_CIPHER
-@@ -816,19 +816,19 @@
-  *
+@@ -790,20 +790,20 @@
   * Comment macros to disable the curve and functions for it
   */
+ /* Short Weierstrass curves (supporting ECP, ECDH, ECDSA) */
 -#define MBEDTLS_ECP_DP_SECP192R1_ENABLED
 -#define MBEDTLS_ECP_DP_SECP224R1_ENABLED
 +//#define MBEDTLS_ECP_DP_SECP192R1_ENABLED
@@ -40,13 +40,14 @@
 +//#define MBEDTLS_ECP_DP_BP256R1_ENABLED
 +//#define MBEDTLS_ECP_DP_BP384R1_ENABLED
 +//#define MBEDTLS_ECP_DP_BP512R1_ENABLED
+ /* Montgomery curves (supporting ECP) */
  #define MBEDTLS_ECP_DP_CURVE25519_ENABLED
 -#define MBEDTLS_ECP_DP_CURVE448_ENABLED
 +//#define MBEDTLS_ECP_DP_CURVE448_ENABLED
  
  /**
   * \def MBEDTLS_ECP_NIST_OPTIM
-@@ -952,7 +952,7 @@
+@@ -956,7 +956,7 @@
   *             See dhm.h for more details.
   *
   */
@@ -55,7 +56,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
-@@ -972,7 +972,7 @@
+@@ -976,7 +976,7 @@
   *      MBEDTLS_TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA
   *      MBEDTLS_TLS_ECDHE_PSK_WITH_RC4_128_SHA
   */
@@ -64,7 +65,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
-@@ -997,7 +997,7 @@
+@@ -1001,7 +1001,7 @@
   *      MBEDTLS_TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA
   *      MBEDTLS_TLS_RSA_PSK_WITH_RC4_128_SHA
   */
@@ -73,7 +74,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
-@@ -1131,7 +1131,7 @@
+@@ -1135,7 +1135,7 @@
   *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
   *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
   */
@@ -82,7 +83,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
-@@ -1155,7 +1155,7 @@
+@@ -1159,7 +1159,7 @@
   *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256
   *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384
   */
@@ -91,7 +92,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
-@@ -1259,7 +1259,7 @@
+@@ -1263,7 +1263,7 @@
   * This option is only useful if both MBEDTLS_SHA256_C and
   * MBEDTLS_SHA512_C are defined. Otherwise the available hash module is used.
   */
@@ -100,7 +101,7 @@
  
  /**
   * \def MBEDTLS_ENTROPY_NV_SEED
-@@ -1354,14 +1354,14 @@
+@@ -1478,14 +1478,14 @@
   * Uncomment this macro to disable the use of CRT in RSA.
   *
   */
@@ -117,7 +118,7 @@
  
  /**
   * \def MBEDTLS_SHA256_SMALLER
-@@ -1515,7 +1515,7 @@
+@@ -1756,7 +1756,7 @@
   *          configuration of this extension).
   *
   */
@@ -126,7 +127,7 @@
  
  /**
   * \def MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO
-@@ -1720,7 +1720,7 @@
+@@ -2017,7 +2017,7 @@
   *
   * Comment this macro to disable support for truncated HMAC in SSL
   */
@@ -135,7 +136,7 @@
  
  /**
   * \def MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT
-@@ -1796,7 +1796,7 @@
+@@ -2185,7 +2185,7 @@
   *
   * Comment this to disable run-time checking and save ROM space
   */
@@ -144,7 +145,7 @@
  
  /**
   * \def MBEDTLS_X509_ALLOW_EXTENSIONS_NON_V3
-@@ -2126,7 +2126,7 @@
+@@ -2534,7 +2534,7 @@
   *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256
   *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256
   */
@@ -153,7 +154,7 @@
  
  /**
   * \def MBEDTLS_ARIA_C
-@@ -2192,7 +2192,7 @@
+@@ -2600,7 +2600,7 @@
   * This module enables the AES-CCM ciphersuites, if other requisites are
   * enabled as well.
   */
@@ -162,7 +163,7 @@
  
  /**
   * \def MBEDTLS_CERTS_C
-@@ -2204,7 +2204,7 @@
+@@ -2612,7 +2612,7 @@
   *
   * This module is used for testing (ssl_client/server).
   */
@@ -171,7 +172,7 @@
  
  /**
   * \def MBEDTLS_CHACHA20_C
-@@ -2312,7 +2312,7 @@
+@@ -2725,7 +2725,7 @@
   * \warning   DES is considered a weak cipher and its use constitutes a
   *            security risk. We recommend considering stronger ciphers instead.
   */
@@ -180,7 +181,7 @@
  
  /**
   * \def MBEDTLS_DHM_C
-@@ -2475,7 +2475,7 @@
+@@ -2890,7 +2890,7 @@
   * This module adds support for the Hashed Message Authentication Code
   * (HMAC)-based key derivation function (HKDF).
   */
@@ -189,7 +190,7 @@
  
  /**
   * \def MBEDTLS_HMAC_DRBG_C
-@@ -2785,7 +2785,7 @@
+@@ -3203,7 +3203,7 @@
   *
   * This module enables abstraction of common (libc) functions.
   */
@@ -198,7 +199,7 @@
  
  /**
   * \def MBEDTLS_POLY1305_C
-@@ -2806,7 +2806,7 @@
+@@ -3279,7 +3279,7 @@
   * Caller:  library/md.c
   *
   */
@@ -207,7 +208,7 @@
  
  /**
   * \def MBEDTLS_RSA_C
-@@ -3013,7 +3013,7 @@
+@@ -3486,7 +3486,7 @@
   *
   * This module provides run-time version information.
   */
@@ -216,7 +217,7 @@
  
  /**
   * \def MBEDTLS_X509_USE_C
-@@ -3123,7 +3123,7 @@
+@@ -3596,7 +3596,7 @@
   * Module:  library/xtea.c
   * Caller:
   */


### PR DESCRIPTION
this is needed for uacme ualpn support

size changes
221586 libmbedtls12_2.28.0-1_mips_24kc.ipk
182742 libmbedtls12_2.16.12-1_mips_24kc.ipk


Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Tested on
x86, mips, kirkwood

2.16.12 long-time support branch was the last release.
`Users who want a long-time branch should move to mbedtls-2.28, which is backward-compatible and will be supported for at least 3 years.`