### PR TITLE
hostapd: SAE - Enable hunting-and-pecking and H2E

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -620,10 +620,12 @@ hostapd_set_bss_options() {
 		sae|owe|eap192|eap-eap192)
 			set_default ieee80211w 2
 			set_default sae_require_mfp 1
+			set_default sae_pwe 2
 		;;
 		psk-sae)
 			set_default ieee80211w 1
 			set_default sae_require_mfp 1
+			set_default sae_pwe 2
 		;;
 	esac
 	[ -n "$sae_require_mfp" ] && append bss_conf "sae_require_mfp=$sae_require_mfp" "$N"


### PR DESCRIPTION
Enable both the hunting-and-pecking loop and hash-to-element mechanisms
by default in OpenWRT with SAE.

Commercial Wi-Fi solutions increasingly frequently now ship with both
hunting-and-pecking and hash-to-element (H2E) enabled by default as this
is more secure and more performant than offering hunting-and-pecking
alone for H2E capable clients.

The hunting and pecking loop mechanism is inherently fragile and prone to
timing-based side channels in its design and is more computationally
intensive to perform. Hash-to-element (H2E) is its long-term
replacement to address these concerns.

For clients that only support the hunting-and-pecking loop mechanism,
this is still available to use by default.

For clients that in addition support, or were to require, the
hash-to-element (H2E) mechanism, this is then available for use.

Signed-off-by: Nick Lowe <nick.lowe@gmail.com>