### PR TITLE
base-files: derive zonename from timezone

### DIFF
--- a/package/base-files/files/etc/init.d/system
+++ b/package/base-files/files/etc/init.d/system
@@ -22,9 +22,13 @@ system_config() {
 	echo "$hostname" > /proc/sys/kernel/hostname
 	[ -z "$conloglevel" -a -z "$buffersize" ] || dmesg ${conloglevel:+-n $conloglevel} ${buffersize:+-s $buffersize}
 	echo "$timezone" > /tmp/TZ
-	[ -n "$zonename" ] && [ -f "/usr/share/zoneinfo/${zonename// /_}" ] \
-		&& ln -sf "/usr/share/zoneinfo/${zonename// /_}" /tmp/localtime \
-		&& rm -f /tmp/TZ
+	if [ -n "$zonename" ] && [ -f "/usr/share/zoneinfo/${zonename// /_}" ]; then
+		ln -sf "/usr/share/zoneinfo/${zonename// /_}" /tmp/localtime
+		rm -f /tmp/TZ
+	elif [ -n "$timezone" ] && [ -f "/usr/share/zoneinfo/${timezone%%,*}" ]; then
+		ln -sf "/usr/share/zoneinfo/${timezone%%,*}" /tmp/localtime
+		rm -f /tmp/TZ
+	fi
 
 	# apply timezone to kernel
 	hwclock -u --systz


### PR DESCRIPTION
If you've installed only `zoneinfo-core`, and have a configuration
similar to:

```
config system
	...
	option timezone 'MST7MDT,M3.2.0,M11.1.0'
	option zonename 'America/Boise'
	...
```

And your `/usr/share/zoneinfo` looks like:

```
CET        GMT        GMT+4      GMT-10     GMT-5      MET        UTC
CST6CDT    GMT+0      GMT+5      GMT-11     GMT-6      MST        Universal
EET        GMT+1      GMT+6      GMT-12     GMT-7      MST7MDT    W-SU
EST        GMT+10     GMT+7      GMT-13     GMT-8      PRC        WET
EST5EDT    GMT+11     GMT+8      GMT-14     GMT-9      PST8PDT    Zulu
Eire       GMT+12     GMT+9      GMT-2      GMT0       ROC        zone.tab
GB         GMT+2      GMT-0      GMT-3      Greenwich  ROK
GB-Eire    GMT+3      GMT-1      GMT-4      HST        UCT
```

then you should be able to trim the daylight savings time stop and start
information, and use the first field as the zonename.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
