### PR TITLE
ramips: Add support for TP-Link TL-WPA8631P v3

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_tl-wpa8631p-v3.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_tl-wpa8631p-v3.dts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,tl-wpa8631p-v3", "mediatek,mt7621-soc";
+	model = "TP-Link WPA8631P v3";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 31 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		led {
+			label = "led";
+			linux,code = <KEY_LIGHTS_TOGGLE>;
+			gpios = <&gpio 30 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		pair {
+			label = "pair";
+			linux,code = <BTN_1>;
+			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wifi {
+			label = "wifi";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2g {
+			label = "green:wifi2g";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi5g {
+			label = "green:wifi5g";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+        gpio-export {
+                compatible = "gpio-export";
+
+                led_control {
+                        gpio-export,name = "tp-link:led:control";
+                        gpio-export,output = <0>;
+                        gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+                };
+        };
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x20000 0x710000>;
+			};
+
+			config: partition@730000 {
+				label = "config";
+				reg = <0x730000 0xc0000>;
+				read-only;
+			};
+
+			radio: partition@7f0000 {
+				label = "radio";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "rgmii2", "wdt";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x0>;
+		nvmem-cells = <&macaddr_config_2008>;
+		nvmem-cell-names = "mac-address";
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x8000>;
+		nvmem-cells = <&macaddr_config_2008>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <1>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_config_2008>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "plc0";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+	};
+};
+
+&config {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_config_2008: macaddr@2008 {
+		reg = <0x2008 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1523,6 +1523,17 @@ define Device/tplink_re650-v1
 endef
 TARGET_DEVICES += tplink_re650-v1
 
+define Device/tplink_tl-wpa8631p-v3
+  $(Device/dsa-migration)
+  $(Device/tplink-safeloader)
+  DEVICE_MODEL := TL-WPA8631P
+  DEVICE_VARIANT := v3
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
+  TPLINK_BOARD_ID := TL-WPA8631P-V3
+  IMAGE_SIZE := 7232k
+endef
+TARGET_DEVICES += tplink_tl-wpa8631p-v3
+
 define Device/ubnt_edgerouter_common
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -117,6 +117,9 @@ tplink,re650-v1)
 	ucidef_set_led_netdev "eth_act" "LAN act" "green:eth_act" "lan" "tx rx"
 	ucidef_set_led_netdev "eth_link" "LAN link" "green:eth_link" "lan" "link"
 	;;
+tplink,tl-wpa8631p-v3)
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "br-lan"
+	;;
 xiaomi,mi-router-ac2100)
 	ucidef_set_led_netdev "wan-blue" "WAN (blue)" "blue:wan" "wan"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -65,6 +65,9 @@ ramips_setup_interfaces()
 	tplink,eap235-wall-v1)
 		ucidef_set_interface_lan "lan0 lan1 lan2 lan3"
 		;;
+	tplink,tl-wpa8631p-v3)
+		ucidef_set_interface_lan "lan1 lan2 lan3 plc0"
+		;;
 	ubnt,edgerouter-x)
 		ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4" "eth0"
 		;;


### PR DESCRIPTION
AV1300 Gigabit Passthrough Powerline ac Wi-Fi Extender

Specifications
--------------
* SoC: MediaTek MT7621AT
* CPU: 880 MHz MIPS 1004KEc dual-core CPU
* RAM: 64 MiB DDR2 (Zentel A3R12E40DBF-8E)
* Flash: 8 MiB SPI NOR (GigaDevice GD25Q64CSIG)
* Ethernet: SoC built-in 5x 1GbE
  * Port 0: PLC (connected through AR8035-A)
  * Port 1-3: LAN
* WLAN: 2x2 2.4GHz 300 Mbps + 2x2 5GHz 867 Mbps (MT7603EN + MT7613BEN)
* PLC: HomePlug AV2 (Qualcomm QCA7500)
* PLC Flash: 2MiB SPI NOR (GigaDevice GD25Q16CSIG)
* Buttons: Reset, LED, Pair, Wi-Fi
* LEDs: Power (green), PLC (green/amber), LAN (green), 2.4G (green),
  5G (green)
* UART: J1 (57600 baud)
  * Pinout: (3V3) (GND) (RX) (TX)
  * Visually identify GND from connection to PCB ground plane

Installation
------------
Installation is possible from the OEM web interface. Make sure to install
the latest OEM firmware first, so that the PLC firmware is at the latest
version. However, please first check the OpenWRT Wiki page for
confirmation that your OEM firmware version is supported.

Signed-off-by: Joe Mullally <jwmullally@gmail.com>

---

This device is basically a MT7621 version of the [WPA8630 v1](https://openwrt.org/toh/hwdata/tp-link/tp-link_tl-wpa8630) and [the WPA8630 v2](https://openwrt.org/toh/tp-link/tl-wpa8630p_v2).

## Tested

[openwrt_boot.log](https://github.com/openwrt/openwrt/files/8121048/openwrt_boot.log)


* Factory flash, sysupgrade, revert to stock, factory flash
* LAN: 1GbE OK, same labels as OEM)
* 2.4GHz WLAN: AP, Client
* 5GHHz WLAN: AP, Client
* PLC: plctool info,join,leave. PLC as part of br-lan bridge (default) & as seperate interface
* Buttons: Pair, Wi-Fi, LED, Reset
* LED toggle GPIO

All functionality tests OK, no known issues or limitations.

## Partition layout compared to TL-WPA8630Pv2

(See related firmware-utils tplink-safeloader patch threads [here](http://lists.openwrt.org/pipermail/openwrt-devel/2022-February/038075.html) and [here](https://patchwork.ozlabs.org/project/openwrt/patch/20220222235951.12151-1-jwmullally@gmail.com/) ).

Are the partition layout across regions sane now? It appears so, see [this report](https://github.com/jwmullally/openwrt_stuff/tree/master/tl-wpa8631-v3). This time there is 7M for kernel + rootfs, compared to 6M on the v2. The layout is also universal between all current region firmwares (AU, EU, US). 

On the device wiki, we will still list all known safe OEM firmware versions in a table to be safe just in case the partitions change with later OEM firmwares (and to tell early EU users to upgrade to the latest compatible version).

## User visible differences in this patch compared to ath79 TL-WPA8630Pv2

Maybe people will disagree with these, but considering this is a new unit model we don't have to be tied to the naming conventions on the older models. This device will be getting its own wiki page anyway.

* PLC switch interface renamed from "Lan 4" to "plc0". This is hardwired anyway, and its difficult to distinguish between this port and the regular LAN ports when editing network configuration.
* Button labels renamed from `"Reset button"` to "reset" to match style of other OpenWRT devices.

---

Forum thread: <https://forum.openwrt.org/t/adding-support-for-tp-link-wpa8631p-v3-0/121070>