### PR TITLE
ramips: mt7621: add support for Zbtlink ZBT-WG1608

### DIFF
--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1608-16m.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1608-16m.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_zbtlink_zbt-wg1608.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-wg1608-16m", "zbtlink,zbt-wg1608", "mediatek,mt7621-soc";
+	model = "Zbtlink ZBT-WG1608 (16M)";
+};
+
+&firmware {
+	reg = <0x50000 0xfb0000>;
+};

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1608.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1608.dtsi
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "zbtlink,zbt-wg1608", "mediatek,mt7621-soc";
+
+	aliases {
+		led-boot = &led_internet;
+		led-failsafe = &led_internet;
+		led-running = &led_internet;
+		led-upgrade = &led_internet;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_internet: internet {
+			label = "green:internet";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wwan {
+			label = "green:wwan";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "usbport";
+			trigger-sources = <&hub_port2>;
+		};
+
+		wifi5g {
+			label = "green:wifi5g";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		lan1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&switch0 0 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&switch0 3 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&switch0 6 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			gpios = <&switch0 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&switch0 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
+
+			};
+
+			firmware: partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	gpio-controller;
+	#gpio-cells = <2>;
+
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e006>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "uart2", "jtag";
+		function = "gpio";
+	};
+};
+
+&xhci_ehci_port1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	hub_port2: port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
+	};
+
+	port@4 {
+		reg = <4>;
+		#trigger-source-cells = <0>;
+	};
+};
+

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1876,6 +1876,18 @@ define Device/zbtlink_zbt-wg1602-16m
 endef
 TARGET_DEVICES += zbtlink_zbt-wg1602-16m
 
+define Device/zbtlink_zbt-wg1608-16m
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Zbtlink
+  DEVICE_MODEL := ZBT-WG1608
+  DEVICE_VARIANT := 16M
+  DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt7603 kmod-mt7615e \
+	kmod-mt7663-firmware-ap kmod-usb3 kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += zbtlink_zbt-wg1608-16m
+
 define Device/zbtlink_zbt-wg2626
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -131,6 +131,13 @@ xiaomi,redmi-router-ac2100)
 youhua,wr1200js)
 	ucidef_set_led_netdev "internet" "INTERNET" "green:wan" "wan"
 	;;
+zbtlink,zbt-wg1608-16m)
+	ucidef_set_led_netdev "lan1" "LAN1" "green:lan-1" "lan1"
+	ucidef_set_led_netdev "lan2" "LAN2" "green:lan-2" "lan2"
+	ucidef_set_led_netdev "lan3" "LAN3" "green:lan-3" "lan3"
+	ucidef_set_led_netdev "lan4" "LAN4" "green:lan-4" "lan4"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
+	;;
 esac
 
 board_config_flush


### PR DESCRIPTION
Zbtlink ZBT-WG1608 is a Wi-Fi router intendent to use with WWAN (4G/5G)
modems.

Specifications:
* SoC: MediaTek MT7621A
* RAM: 256/512 MiB
* Flash: 16/32 MiB (SPI NOR)
* Wi-Fi:
  * MediaTek MT7603E : 2.4Ghz
  * MediaTek MT7613BE : 5Ghz
* Ethernet: 10/100/1000 Mbps Ethernet x5 ports (4xLAN + WAN)
* M.2: 1x slot with USB&SIM
  * EM7455/EM12-G/EM160R/RM500Q-AE
* USB: 1x 3.0 Type-A port
* External storage: 1x microSD (SDXC) slot
* UART: console (115200 baud)
* LED:
  * 1 power indicator
  * 1 WLAN 2.4G controlled (wlan 2G)
  * 3 SoC controlled (wlan 5G, wwan, internet)
  * 5 per Eth phy (4xLAN + WAN)

MAC Addresses:
* LAN    : f8:5e:3c:xx:xx:e0 (Factory, 0xe000 (hex))
* WAN    : f8:5e:3c:xx:xx:e1 (Factory, 0xe006 (hex))
* 2.4 GHz: f8:5e:3c:xx:xx:de (Factory, 0x0004 (hex))
* 5 GHz  : f8:5e:3c:xx:xx:df (Factory, 0x8004 (hex))

Installation:
* Vendor's firmware is OpenWrt (LEDE) based, so the sysupgrade image can
  be directly used to install OpenWrt. Firmware must be upgraded using the
  'force' and 'do not save configuration' command line options (or
  correspondig web interface checkboxes) since the vendor firmware is from
  the pre-DSA era.

Recovery Mode:
 * Press reset button, power up the device, wait for about 10sec.
 * Upload sysupgrade image through the firmware recovery mode web page at
  192.168.1.1.