### PR TITLE
CI: allow dots in commit subject area

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -43,7 +43,7 @@ jobs:
             fi
 
             subject="$(git show -s --format=%s $commit)"
-            if echo "$subject" | grep -q -e '^[0-9A-Za-z,+/_-]\+: ' -e '^Revert '; then
+            if echo "$subject" | grep -q -e '^[0-9A-Za-z,+/_\.-]\+: ' -e '^Revert '; then
               success "Commit subject line seems ok ($subject)"
             else
               err "Commit subject line MUST start with '<area>: ' ($subject)"


### PR DESCRIPTION
Due to a limited grep pattern, subjects containing dots like `image.mk`
were falsely reported as problematic. Extend pattern to allow dots.

Signed-off-by: Paul Spooren <mail@aparcar.org>