### PR TITLE
ipq806x: Increase kernel partition size to 4 MB for EA8500/EA7500v1 

### DIFF
--- a/target/linux/ipq806x/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/ipq806x/base-files/etc/uci-defaults/05_fix-compat-version
@@ -1,0 +1,11 @@
+. /lib/functions.sh
+
+case "$(board_name)" in
+	linksys,ea7500-v1|\
+	linksys,ea8500)
+		uci set system.@system[0].compat_version="2.0"
+		uci commit system
+	;;
+esac
+
+exit 0

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-eax500.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-eax500.dtsi
@@ -133,12 +133,12 @@
 
 			partition@f80000 {
 				label = "kernel1";
-				reg = <0x0f80000 0x2800000>;  /* 3 MB spill to rootfs */
+				reg = <0x0f80000 0x2800000>;  /* 4 MB, spill to rootfs */
 			};
 
-			partition@1280000 {
+			partition@1380000 {
 				label = "rootfs1";
-				reg = <0x1280000 0x2500000>;
+				reg = <0x1380000 0x2400000>;
 			};
 
 			partition@3780000 {
@@ -146,9 +146,9 @@
 				reg = <0x3780000 0x2800000>;
 			};
 
-			partition@3a80000 {
+			partition@3b80000 {
 				label = "rootfs2";
-				reg = <0x3a80000 0x2500000>;
+				reg = <0x3b80000 0x2400000>;
 			};
 		};
 	};

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -1,6 +1,13 @@
 DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID
 DEVICE_VARS += TPLINK_BOARD_ID
 
+define Device/kernel-size-migration
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := *** Kernel partition size has changed from earlier \
+	versions. You need to sysupgrade with the OpenWrt factory image and \
+	use the force flag when image check fails. Settings will be lost. ***
+endef
+
 define Build/buffalo-rootfs-cksum
 	( \
 		echo -ne "\x$$(od -A n -t u1 $@ | tr -s ' ' '\n' | \
@@ -128,13 +135,14 @@ TARGET_DEVICES += edgecore_ecw5410
 
 define Device/linksys_ea7500-v1
 	$(call Device/LegacyImage)
+	$(Device/kernel-size-migration)
 	DEVICE_VENDOR := Linksys
 	DEVICE_MODEL := EA7500
 	DEVICE_VARIANT := v1
 	SOC := qcom-ipq8064
 	PAGESIZE := 2048
 	BLOCKSIZE := 128k
-	KERNEL_SIZE := 3072k
+	KERNEL_SIZE := 4096k
 	KERNEL = kernel-bin | append-dtb | uImage none | \
 		append-uImage-fakehdr filesystem
 	UBINIZE_OPTS := -E 5
@@ -148,12 +156,13 @@ TARGET_DEVICES += linksys_ea7500-v1
 
 define Device/linksys_ea8500
 	$(call Device/LegacyImage)
+	$(Device/kernel-size-migration)
 	DEVICE_VENDOR := Linksys
 	DEVICE_MODEL := EA8500
 	SOC := qcom-ipq8064
 	PAGESIZE := 2048
 	BLOCKSIZE := 128k
-	KERNEL_SIZE := 3072k
+	KERNEL_SIZE := 4096k
 	KERNEL = kernel-bin | append-dtb | uImage none | \
 		append-uImage-fakehdr filesystem
 	BOARD_NAME := ea8500

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -150,7 +150,6 @@ define Device/linksys_ea7500-v1
 	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
 		append-ubi | pad-to $$$$(PAGESIZE)
 	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct
-	DEFAULT := n
 endef
 TARGET_DEVICES += linksys_ea7500-v1
 
@@ -172,7 +171,6 @@ define Device/linksys_ea8500
 	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
 		append-ubi
 	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct
-	DEFAULT := n
 endef
 TARGET_DEVICES += linksys_ea8500
 


### PR DESCRIPTION
Increase the kernel size from 3 MB to 4 MB for EA8500 and EA7500v1 to enable building them in master.
* modify the common .dtsi
* modify the kernel size in the image recipes
* Define compat-version 2.0 to force factory image usage for sysupgrade. Add explanation message.

Reference to forum discussion at 
https://forum.openwrt.org/t/increasing-ea8500-ea7500-kernel-size-to-enable-builds/121039

cc @chunkeey 
