### PR TITLE
mvebu: add targz feature flag

### DIFF
--- a/target/linux/mvebu/Makefile
+++ b/target/linux/mvebu/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 BOARD:=mvebu
 BOARDNAME:=Marvell EBU Armada
-FEATURES:=fpu usb pci pcie gpio nand squashfs ramdisk boot-part rootfs-part legacy-sdcard
+FEATURES:=fpu usb pci pcie gpio nand squashfs ramdisk boot-part rootfs-part legacy-sdcard targz
 SUBTARGETS:=cortexa9 cortexa53 cortexa72
 
 KERNEL_PATCHVER:=5.10


### PR DESCRIPTION
Adding the feature flag automatically creates a a rootfs.tar.gz files
which can be used for Docker rootfs containers.

Signed-off-by: Paul Spooren <mail@aparcar.org>