### PR TITLE
tools/libressl: update to version 3.4.2

### DIFF
--- a/tools/libressl/Makefile
+++ b/tools/libressl/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libressl
-PKG_VERSION:=3.4.1
-PKG_HASH:=107ceae6ca800e81cb563584c16afa36d6c7138fade94a2b3e9da65456f7c61c
+PKG_VERSION:=3.4.2
+PKG_HASH:=cb82ca7d547336917352fbd23db2fc483c6c44d35157b32780214ec74197b3ce
 PKG_RELEASE:=1
 
 PKG_CPE_ID:=cpe:/a:openbsd:libressl


### PR DESCRIPTION
Release notes:
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.4.2-relnotes.txt

```
It includes the following security fix

  * In some situations the X.509 verifier would discard an error on an
    unverified certificate chain, resulting in an authentication bypass.
    Thanks to Ilya Shipitsin and Timo Steinlein for reporting.
```
