### PR TITLE
tools: use https for bc mirrors

### DIFF
--- a/tools/bc/Makefile
+++ b/tools/bc/Makefile
@@ -1,5 +1,5 @@
 # 
-# Copyright (C) 2013 OpenWrt.org
+# Copyright (C) 2013-2022 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -10,10 +10,10 @@ PKG_NAME:=bc
 PKG_VERSION:=1.06.95
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=http://alpha.gnu.org/gnu/bc \
-	http://gnualpha.uib.no/bc/ \
-	http://mirrors.fe.up.pt/pub/gnu-alpha/bc/ \
-	http://www.nic.funet.fi/pub/gnu/alpha/gnu/bc/
+PKG_SOURCE_URL:=https://alpha.gnu.org/gnu/bc \
+	https://gnualpha.uib.no/bc/ \
+	https://mirrors.fe.up.pt/pub/gnu-alpha/bc/ \
+	https://www.nic.funet.fi/pub/gnu/alpha/gnu/bc/
 PKG_HASH:=7ee4abbcfac03d8a6e1a8a3440558a3d239d6b858585063e745c760957725ecc
 
 PKG_FIXUP := autoreconf


### PR DESCRIPTION
All mirrors offer encrypted downloads, use it.

Signed-off-by: Paul Spooren <mail@aparcar.org>