### PR TITLE
[21.02] Backport tools/libressl updates from OpenWrt master

### DIFF
--- a/tools/libressl/Makefile
+++ b/tools/libressl/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libressl
-PKG_VERSION:=3.3.1
-PKG_HASH:=a6d331865e0164a13ac85a228e52517f7cf8f8488f2f95f34e7857302f97cfdb
+PKG_VERSION:=3.3.3
+PKG_HASH:=a471565b36ccd1a70d0bd7d37c6e95c43a26a62829b487d9d2cdebfe58be3066
 PKG_RELEASE:=1
 
 PKG_CPE_ID:=cpe:/a:openbsd:libressl
@@ -25,7 +25,7 @@ include $(INCLUDE_DIR)/host-build.mk
 
 HOSTCC := $(HOSTCC_NOCACHE)
 HOST_CONFIGURE_ARGS += --enable-static --disable-shared --disable-tests
-HOST_CFLAGS += $(FPIC)
+HOST_CFLAGS += $(HOST_FPIC)
 
 ifeq ($(GNU_HOST_NAME),x86_64-linux-gnux32)
 HOST_CONFIGURE_ARGS += --disable-asm

--- a/tools/libressl/Makefile
+++ b/tools/libressl/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libressl
-PKG_VERSION:=3.4.1
-PKG_HASH:=107ceae6ca800e81cb563584c16afa36d6c7138fade94a2b3e9da65456f7c61c
+PKG_VERSION:=3.4.2
+PKG_HASH:=cb82ca7d547336917352fbd23db2fc483c6c44d35157b32780214ec74197b3ce
 PKG_RELEASE:=1
 
 PKG_CPE_ID:=cpe:/a:openbsd:libressl

--- a/tools/libressl/Makefile
+++ b/tools/libressl/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libressl
-PKG_VERSION:=3.3.4
-PKG_HASH:=bcce767a3fed252bfd1210f8a7e3505a2b54d3008f66e43d9b95e3f30c072931
+PKG_VERSION:=3.4.1
+PKG_HASH:=107ceae6ca800e81cb563584c16afa36d6c7138fade94a2b3e9da65456f7c61c
 PKG_RELEASE:=1
 
 PKG_CPE_ID:=cpe:/a:openbsd:libressl

--- a/tools/libressl/Makefile
+++ b/tools/libressl/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libressl
-PKG_VERSION:=3.3.3
-PKG_HASH:=a471565b36ccd1a70d0bd7d37c6e95c43a26a62829b487d9d2cdebfe58be3066
+PKG_VERSION:=3.3.4
+PKG_HASH:=bcce767a3fed252bfd1210f8a7e3505a2b54d3008f66e43d9b95e3f30c072931
 PKG_RELEASE:=1
 
 PKG_CPE_ID:=cpe:/a:openbsd:libressl


### PR DESCRIPTION
I want to propose updating ``tools/libressl`` for OpenWrt 21.02. The reason is that it allow me and others to build U-boot tools newer than 2021.10.
(Reference: https://github.com/openwrt/openwrt/pull/4709) w/o introducing additional patches.

These are cherry-picks from master branch. I triggered full builds with all the packages for three routers:

- Turris MOX (mvebu/cortex-a53)
- Turris Omnia (mvebu/cortex-a9)
- Turris 1.x (powerpc8540)

No regression was introduced. My goal is to provide and have an up-to-date U-boot version, especially for Turris Omnia, in the stable branch. So we can cooperate more with upstream (testing and using the OpenWrt U-boot) and drop our U-boot variant from Turris OS packages.

I decided to send things one by one instead of having one large pull request with many things.

With these tools, I was able to compile the latest U-boot version and as well with added Turris Omnia U-boot support on Ubuntu 21.10. It could be possible that referenced PR would me somehow needed, but I will try it also on Debian 10.