### PR TITLE
ramips: fix DEVICE_VENDOR for unbranded devices

### DIFF
--- a/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-4m.dts
+++ b/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-4m.dts
@@ -2,7 +2,7 @@
 
 / {
 	compatible = "unbranded,wr512-3gn-4m", "unbranded,wr512-3gn", "ralink,rt3052-soc";
-	model = "WR512-3GN (4M)";
+	model = "Unbranded WR512-3GN (4M)";
 
 	flash@1f000000 {
 		compatible = "cfi-flash";

--- a/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-8m.dts
+++ b/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-8m.dts
@@ -2,7 +2,7 @@
 
 / {
 	compatible = "unbranded,wr512-3gn-8m", "unbranded,wr512-3gn", "ralink,rt3052-soc";
-	model = "WR512-3GN (8M)";
+	model = "Unbranded WR512-3GN (8M)";
 
 	flash@1f000000 {
 		compatible = "cfi-flash";

--- a/target/linux/ramips/dts/rt3052_unbranded_xdx-rn502j.dts
+++ b/target/linux/ramips/dts/rt3052_unbranded_xdx-rn502j.dts
@@ -5,7 +5,7 @@
 
 / {
 	compatible = "unbranded,xdx-rn502j", "ralink,rt3052-soc";
-	model = "XDX RN502J";
+	model = "Unbranded XDX-RN502J";
 
 	aliases {
 		led-boot = &led_power;

--- a/target/linux/ramips/dts/rt5350_unbranded_a5-v11.dts
+++ b/target/linux/ramips/dts/rt5350_unbranded_a5-v11.dts
@@ -5,7 +5,7 @@
 
 / {
 	compatible = "unbranded,a5-v11", "ralink,rt5350-soc";
-	model = "A5-V11";
+	model = "Unbranded A5-V11";
 
 	aliases {
 		led-boot = &led_power;

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -1071,7 +1071,7 @@ define Device/unbranded_a5-v11
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	poray-header -B A5-V11 -F 4M
-  DEVICE_VENDOR :=
+  DEVICE_VENDOR := Unbranded
   DEVICE_MODEL := A5-V11
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2
   SUPPORTED_DEVICES += a5-v11
@@ -1082,7 +1082,7 @@ TARGET_DEVICES += unbranded_a5-v11
 define Device/unbranded_wr512-3gn-4m
   SOC := rt3052
   IMAGE_SIZE := 3776k
-  DEVICE_VENDOR := Ralink
+  DEVICE_VENDOR := Unbranded
   DEVICE_MODEL := WR512-3GN
   DEVICE_VARIANT := 4M
   SUPPORTED_DEVICES += wr512-3gn-4M
@@ -1093,7 +1093,7 @@ TARGET_DEVICES += unbranded_wr512-3gn-4m
 define Device/unbranded_wr512-3gn-8m
   SOC := rt3052
   IMAGE_SIZE := 7872k
-  DEVICE_VENDOR := Ralink
+  DEVICE_VENDOR := Unbranded
   DEVICE_MODEL := WR512-3GN
   DEVICE_VARIANT := 8M
   SUPPORTED_DEVICES += wr512-3gn-8M
@@ -1104,8 +1104,8 @@ define Device/unbranded_xdx-rn502j
   SOC := rt3052
   BLOCKSIZE := 64k
   IMAGE_SIZE := 3776k
-  DEVICE_VENDOR := XDX
-  DEVICE_MODEL := RN502J
+  DEVICE_VENDOR := Unbranded
+  DEVICE_MODEL := XDX-RN502J
   SUPPORTED_DEVICES += xdxrn502j
   DEFAULT := n
 endef


### PR DESCRIPTION
In commit ee66fe4ea9a6 ("ramips: convert DEVICE_TITLE to new variables"),
DEVICE_VENDOR of some unbranded devices were set incorrectly:
* WR512-3GN is not a dev board from Ralink.
* "XDX-RN502J" is the whole model name and should be not split.

This patch sets their DEVICE_VENDOR to empty values.

Ref: d0bf15f23595 ("ramips: add support for A5-V11 board (resubmit)")
Ref: 9085b05d9e71 ("ramips: rt305x: support for wr512-3gn-like routers")
Ref: 0e486d2fd297 ("ramips: add support for unbranded XDX-RN502J board")

---

I'm not sure if it's a proper way to handle unbranded devices. Do you think that explicit `DEVICE_VENDOR := Unbranded` would be better?
I failed to find any other unbranded boards other than rt305x subtarget, please let me know if you find some.