### PR TITLE
scripts/diffconfig.sh: ensure config/conf is built

### DIFF
--- a/scripts/diffconfig.sh
+++ b/scripts/diffconfig.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+make ./scripts/config/conf >/dev/null || { make ./scripts/config/conf; exit 1; }
 grep \^CONFIG_TARGET_ .config | head -n3 > tmp/.diffconfig.head
 grep \^CONFIG_TARGET_DEVICE_ .config >> tmp/.diffconfig.head
 grep '^CONFIG_ALL=y' .config >> tmp/.diffconfig.head


### PR DESCRIPTION
diffconfig.sh runs `./scripts/config/conf`, but it does not get built with `make {menu,x,n}config.  Call 'make ./scripts/config/conf` to ensure it's been built before running it, aborting in case of failure.

Fixes: c0849c1d9c scripts/diffconfig.sh: ensure config/conf is built

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
Closes: #9297 