### PR TITLE
uboot-mvebu: add __u64 patch as present in others

### DIFF
--- a/package/boot/uboot-mvebu/patches/260-add-missing-type-u64.patch
+++ b/package/boot/uboot-mvebu/patches/260-add-missing-type-u64.patch
@@ -1,0 +1,10 @@
+--- a/include/linux/types.h
++++ b/include/linux/types.h
+@@ -1,6 +1,7 @@
+ #ifndef _LINUX_TYPES_H
+ #define _LINUX_TYPES_H
+ 
++typedef unsigned long long __u64;
+ #include <linux/posix_types.h>
+ #include <asm/types.h>
+ #include <stdbool.h>


### PR DESCRIPTION
Needed for compilation under macOS.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Thanks for your contribution to OpenWrt!

@svlobanov I don't know of a good way to upstream this. Any ideas?