### PR TITLE
tools/expat: update to 2.4.6

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -46,6 +46,7 @@ $(curdir)/bison/compile := $(curdir)/flex/compile
 $(curdir)/cbootimage/compile += $(curdir)/automake/compile
 $(curdir)/cmake/compile += $(curdir)/libressl/compile $(curdir)/ninja/compile
 $(curdir)/dosfstools/compile := $(curdir)/autoconf/compile $(curdir)/automake/compile
+$(curdir)/expat/compile := $(curdir)/cmake/compile
 $(curdir)/e2fsprogs/compile := $(curdir)/libtool/compile
 $(curdir)/fakeroot/compile := $(curdir)/libtool/compile
 $(curdir)/findutils/compile := $(curdir)/bison/compile

--- a/tools/expat/Makefile
+++ b/tools/expat/Makefile
@@ -9,21 +9,25 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
 PKG_CPE_ID:=cpe:/a:libexpat:expat
-PKG_VERSION:=2.2.10
+PKG_VERSION:=2.4.6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=b2c160f1b60e92da69de8e12333096aeb0c3bf692d41c60794de278af72135a5
+PKG_HASH:=ce317706b07cae150f90cddd4253f5b4fba929607488af5ac47bf2bc08e31f09
 PKG_SOURCE_URL:=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$(PKG_VERSION))
 
-HOST_BUILD_PARALLEL:=1
-
 include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/cmake.mk
 
-HOST_CONFIGURE_ARGS += \
-	--without-docbook
-
-define Host/Install
-	$(MAKE) -C $(HOST_BUILD_DIR) install
-endef
+CMAKE_HOST_OPTIONS += \
+	-DDOCBOOK_TO_MAN=OFF \
+	-DEXPAT_BUILD_TOOLS=OFF \
+	-DEXPAT_BUILD_EXAMPLES=OFF \
+	-DEXPAT_BUILD_TESTS=OFF \
+	-DEXPAT_BUILD_DOCS=OFF \
+	-DEXPAT_WITH_LIBBSD=OFF \
+	-DEXPAT_ENABLE_INSTALL=ON \
+	-DEXPAT_DTD=OFF \
+	-DEXPAT_NS=OFF \
+	-DEXPAT_DEV_URANDOM=OFF
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
Switched to CMake for faster compilation and greater parallel
friendliness.

Added CMake options from the packages feed.

This release fixes various CVEs.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @BKPepe 