### PR TITLE
tools/meson: update to 0.61.2

### DIFF
--- a/tools/meson/Makefile
+++ b/tools/meson/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=meson
-PKG_VERSION:=0.61.1
+PKG_VERSION:=0.61.2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/mesonbuild/meson/releases/download/$(PKG_VERSION)
-PKG_HASH:=feb2cefb325b437dbf36146df7c6b87688ddff0b0205caa31dc64055c6da410c
+PKG_HASH:=0233a7f8d959079318f6052b0939c27f68a5de86ba601f25c9ee6869fb5f5889
 
 PKG_MAINTAINER:=Andre Heider <a.heider@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Seems to be minor bugfixes with Cygwin and Windows.

Signed-off-by: Rosen Penev <rosenp@gmail.com>