### PR TITLE
ramips: allow USB power control on TP-Link MR3020v3

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
@@ -75,6 +75,17 @@
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usbpower {
+			gpio-export,name = "usbpower";
+			gpio-export,output = <1>;
+			gpios = <&gpio 39 GPIO_ACTIVE_HIGH>;
+		};
+	};
 };
 
 &spi0 {
@@ -120,7 +131,7 @@
 
 &state_default {
 	gpio {
-		groups = "i2s", "refclk", "wdt", "p2led_an", "p1led_an", "p0led_an", "wled_an";
+		groups = "i2s", "refclk", "wdt", "p4led_an", "p2led_an", "p1led_an", "p0led_an", "wled_an";
 		function = "gpio";
 	};
 };


### PR DESCRIPTION
By switching EPHY_LED4_N_JTRST_N from EPHY_LED4_N to GPIO#39
we can control USB port power an all current revisions of MR3020v3.
It was not a thing on some first revisions, pin was unused.
But for now on all current MR3020v3 boards EPHY_LED4_N_JTRST_N pin
is connected to USB power key.
Also it was not used as EPHY indicator on any revision of the board.

Signed-off-by: Dmitry Chigiryov dmitry.chigiryov@ya.ru
