### PR TITLE
tools/coreutils: update to 9.1

### DIFF
--- a/tools/coreutils/Makefile
+++ b/tools/coreutils/Makefile
@@ -8,13 +8,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coreutils
 PKG_CPE_ID:=cpe:/a:gnu:coreutils
-PKG_VERSION:=8.32
+PKG_VERSION:=9.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/coreutils
-PKG_HASH:=4458d8de7849df44ccab15e16b1548b285224dbba5f08fac070c1c0e0bcc4cfa
+PKG_HASH:=61a1f410d78ba7e7f37a5a4f50e6d1320aca33375484a3255eddf17a38580423
 
 HOST_BUILD_PARALLEL := 1
+PKG_FIXUP:=autoreconf
 
 BUILD_PROGRAMS = date readlink touch ln chown ginstall
 

--- a/tools/coreutils/patches/001-m4.patch
+++ b/tools/coreutils/patches/001-m4.patch
@@ -1,0 +1,95 @@
+--- a/m4/gnulib-comp.m4
++++ b/m4/gnulib-comp.m4
+@@ -2671,7 +2671,7 @@ changequote([, ])dnl
+   fi
+   gl_SYS_SOCKET_MODULE_INDICATOR([socket])
+   AC_REQUIRE([gt_TYPE_WCHAR_T])
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
+   gl_FUNC_STRERROR_R
+   AS_IF([test $HAVE_DECL_STRERROR_R = 0 || test $REPLACE_STRERROR_R = 1], [
+     AC_LIBOBJ([strerror_r])
+--- a/m4/stdint.m4
++++ b/m4/stdint.m4
+@@ -15,7 +15,7 @@ AC_DEFUN_ONCE([gl_STDINT_H],
+   AC_REQUIRE([AC_CANONICAL_HOST]) dnl for cross-compiles
+ 
+   AC_REQUIRE([gl_LIMITS_H])
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
+ 
+   dnl For backward compatibility. Some packages may still be testing these
+   dnl macros.
+--- a/m4/vasnprintf.m4
++++ b/m4/vasnprintf.m4
+@@ -33,7 +33,7 @@ AC_DEFUN([gl_REPLACE_VASNPRINTF],
+ AC_DEFUN([gl_PREREQ_PRINTF_ARGS],
+ [
+   AC_REQUIRE([gt_TYPE_WCHAR_T])
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
+ ])
+ 
+ # Prerequisites of lib/printf-parse.h, lib/printf-parse.c.
+@@ -41,7 +41,7 @@ AC_DEFUN([gl_PREREQ_PRINTF_PARSE],
+ [
+   AC_REQUIRE([gl_FEATURES_H])
+   AC_REQUIRE([gt_TYPE_WCHAR_T])
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
+   AC_REQUIRE([AC_TYPE_SIZE_T])
+   AC_CHECK_TYPE([ptrdiff_t], ,
+     [AC_DEFINE([ptrdiff_t], [long],
+@@ -55,7 +55,7 @@ AC_DEFUN_ONCE([gl_PREREQ_VASNPRINTF],
+ [
+   AC_REQUIRE([AC_FUNC_ALLOCA])
+   AC_REQUIRE([gt_TYPE_WCHAR_T])
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
+   AC_CHECK_FUNCS([snprintf strnlen wcslen wcsnlen mbrtowc wcrtomb])
+   dnl Use the _snprintf function only if it is declared (because on NetBSD it
+   dnl is defined as a weak alias of snprintf; we prefer to use the latter).
+--- a/m4/wchar_h.m4
++++ b/m4/wchar_h.m4
+@@ -27,7 +27,7 @@ AC_DEFUN_ONCE([gl_WCHAR_H],
+ 
+   AC_REQUIRE([gl_FEATURES_H])
+ 
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
+   if test $gt_cv_c_wint_t = yes; then
+     HAVE_WINT_T=1
+   else
+--- a/m4/wctype_h.m4
++++ b/m4/wctype_h.m4
+@@ -22,7 +22,7 @@ AC_DEFUN_ONCE([gl_WCTYPE_H],
+   fi
+   AC_SUBST([HAVE_ISWCNTRL])
+ 
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
+   if test $gt_cv_c_wint_t = yes; then
+     HAVE_WINT_T=1
+   else
+--- a/m4/wcwidth.m4
++++ b/m4/wcwidth.m4
+@@ -13,7 +13,7 @@ AC_DEFUN([gl_FUNC_WCWIDTH],
+   AC_REQUIRE([AC_USE_SYSTEM_EXTENSIONS])
+ 
+   AC_REQUIRE([gt_TYPE_WCHAR_T])
+-  AC_REQUIRE([gt_TYPE_WINT_T])
++  AC_REQUIRE([gt_TYPE_WINT_T_GNUTLS])
+ 
+   AC_CHECK_HEADERS_ONCE([wchar.h])
+   AC_CHECK_FUNCS_ONCE([wcwidth])
+--- a/m4/wint_t.m4
++++ b/m4/wint_t.m4
+@@ -9,7 +9,7 @@ dnl Test whether <wchar.h> has the 'wint
+ dnl <wchar.h> or <wctype.h> would, if present, override 'wint_t'.
+ dnl Prerequisite: AC_PROG_CC
+ 
+-AC_DEFUN([gt_TYPE_WINT_T],
++AC_DEFUN([gt_TYPE_WINT_T_GNUTLS],
+ [
+   AC_CACHE_CHECK([for wint_t], [gt_cv_c_wint_t],
+     [AC_COMPILE_IFELSE(


### PR DESCRIPTION
In addition to the version update, this commit also applies a fixup to allow building on MacOS involving renaming: [gt_TYPE_WINT_T] --> [gt_TYPE_WINT_T_GNUTLS] suggested by zhanhb.

Build system: x86_64
Build-tested: bcm2711/RPi4B

Signed-off-by: John Audia <graysky@archlinux.us>