### PR TITLE
ipq806x: fix init.d bootcount build not found warning

### DIFF
--- a/target/linux/ipq806x/base-files/etc/init.d/bootcount
+++ b/target/linux/ipq806x/base-files/etc/init.d/bootcount
@@ -2,9 +2,9 @@
 
 START=99
 
-. "$IPKG_INSTROOT/lib/upgrade/asrock.sh"
-
 boot() {
+	. /lib/upgrade/asrock.sh
+
 	case $(board_name) in
 	asrock,g10)
 		asrock_bootconfig_mangle "bootcheck" && reboot


### PR DESCRIPTION
On firmware build, the compiling process complain about
/lib/upgrade/asrock.sh not found. This is not true as
on a running system it will be correctly available.
Problem is that init.d are enabled in the compiling
process and the rootfs is not actually mounted so /lib
is referring to the host /lib and not /lib of a running
firmware.

Move the inclusion of this lib in the boot() function to
correctly fix this warning.
Fixes: #9350

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>

@ynezz  Don't know if we should first revert the old commit... but putting compile time variable in a running system (that works just because the variable is not found and is replaced with an empty value) seems fundamentally wrong. (but could be 100% wrong)

In any case in theory the error comes from bootcount init.d script getting enabled. This is present from ages but never wanted to fix it as... mhe not a priority honestly... We should put some effort in fixing all the dts warning IMHO.