### PR TITLE
Print error message in non-verbose mode if image size is too big.

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -191,7 +191,7 @@ define Build/check-size
 	@imagesize="$$(stat -c%s $@)"; \
 	limitsize="$$(($(subst k,* 1024,$(subst m, * 1024k,$(if $(1),$(1),$(IMAGE_SIZE))))))"; \
 	[ $$limitsize -ge $$imagesize ] || { \
-		echo "WARNING: Image file $@ is too big: $$imagesize > $$limitsize" >&2; \
+		$(call ERROR_MESSAGE,    WARNING: Image file $@ is too big: $$imagesize > $$limitsize); \
 		rm -f $@; \
 	}
 endef

--- a/include/verbose.mk
+++ b/include/verbose.mk
@@ -29,13 +29,13 @@ ifeq ($(IS_TTY),1)
   endif
 endif
 
+define ERROR_MESSAGE
+  printf "$(_R)%s$(_N)\n" "$(1)" >&8
+endef
+
 ifeq ($(findstring s,$(OPENWRT_VERBOSE)),)
   define MESSAGE
 	printf "$(_Y)%s$(_N)\n" "$(1)" >&8
-  endef
-
-  define ERROR_MESSAGE
-	printf "$(_R)%s$(_N)\n" "$(1)" >&8
   endef
 
   ifeq ($(QUIET),1)
@@ -60,5 +60,4 @@ else
   define MESSAGE
     printf "%s\n" "$(1)"
   endef
-  ERROR_MESSAGE=$(MESSAGE)
 endif


### PR DESCRIPTION
Fixes #7604, it's only been 6 years.