### PR TITLE
ramips: update WLAN MAC address for some mt7615d boards

### DIFF
--- a/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
+++ b/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
@@ -96,9 +96,15 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
+
+		/* 5 GHz (phy1) does not take the address from calibration data,
+		   but setting it manually here works */
+		nvmem-cells = <&macaddr_factory_4>;
+		nvmem-cell-names = "mac-address";
 	};
 };
 
@@ -149,6 +155,10 @@
 	compatible = "nvmem-cells";
 	#address-cells = <1>;
 	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 {
+		reg = <0x4 0x6>;
+	};
 
 	macaddr_factory_e000: macaddr@e000 {
 		reg = <0xe000 0x6>;

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -15,7 +15,8 @@ case "$board" in
 			macaddr_setbit_la "$(mtd_get_mac_binary factory 0xe000)" \
 				> /sys${DEVPATH}/macaddress
 		;;
-	dlink,dir-853-r1)
+	dlink,dir-853-r1|\
+	phicomm,k2p)
 		if [ "$PHYNBR" = "0" ]; then
 			base_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" -1)
 			macaddr_setbit_la "$base_mac" > /sys${DEVPATH}/macaddress

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -43,6 +43,10 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary Factory 0x4)" > /sys${DEVPATH}/macaddress
 		;;
+	jcg,y2)
+		[ "$PHYNBR" = "1" ] && \
+			macaddr_setbit_la "$(mtd_get_mac_binary factory 0x4)" > /sys${DEVPATH}/macaddress
+		;;
 	linksys,e5600|\
 	linksys,ea6350-v4|\
 	linksys,ea7300-v1|\


### PR DESCRIPTION
- ramips: update WLAN MAC address of Phicomm K2P:
The wireless mac address difference of this machine is similar
to that of D-Link DIR-853-R1, so use the same practice.
- ramips: update WLAN MAC address of JCG Y2:
MAC addresses on OEM firmware:
```
  04:xx:xx:xx:xx:c8  factory 0x4     wlan2g
  06:xx:xx:xx:xx:c8  [not on flash]  wlan5g
```
