### PR TITLE
ath79: add support for MikroTik RouterBOARD mAP lite

### DIFF
--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-mapl-2nd.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-mapl-2nd.dts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9533_mikrotik_routerboard-16m.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-mapl-2nd", "qca,qca9533";
+	model = "MikroTik RouterBOARD mAPL-2nD (mAP lite)";
+
+	aliases {
+		led-boot = &led_user;
+		led-failsafe = &led_user;
+		led-running = &led_user;
+		led-upgrade = &led_user;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&led_power_pin &led_lan_pin>;
+
+		power {
+			label = "green:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_user: user {
+			label = "green:user";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};
+
+&pinmux {
+	led_lan_pin: pinmux_led_lan_pin {
+		pinctrl-single,bits = <0x4 0x0 0xff>;
+	};
+
+	led_power_pin: pinmux_led_power_pin {
+		pinctrl-single,bits = <0x10 0x0 0xff00>;
+	};
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -55,6 +55,14 @@ define Device/mikrotik_routerboard-lhg-5nd
 endef
 TARGET_DEVICES += mikrotik_routerboard-lhg-5nd
 
+define Device/mikrotik_routerboard-mapl-2nd
+  $(Device/mikrotik_nor)
+  SOC := qca9533
+  DEVICE_MODEL := RouterBOARD mAPL-2nD (mAP lite)
+  IMAGE_SIZE := 16256k
+endef
+TARGET_DEVICES += mikrotik_routerboard-mapl-2nd
+
 define Device/mikrotik_routerboard-sxt-5nd-r2
   $(Device/mikrotik_nand)
   SOC := ar9344

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
@@ -6,7 +6,8 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
-mikrotik,routerboard-lhg-2nd)
+mikrotik,routerboard-lhg-2nd|\
+mikrotik,routerboard-mapl-2nd)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	;;
 mikrotik,routerboard-lhg-5nd)

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -17,6 +17,7 @@ ath79_setup_interfaces()
 	mikrotik,routerboard-912uag-2hpnd|\
 	mikrotik,routerboard-lhg-2nd|\
 	mikrotik,routerboard-lhg-5nd|\
+	mikrotik,routerboard-mapl-2nd|\
 	mikrotik,routerboard-sxt-5nd-r2|\
 	mikrotik,routerboard-wap-g-5hact2hnd|\
 	mikrotik,routerboard-wapr-2nd)
@@ -40,6 +41,7 @@ ath79_setup_macs()
 	mikrotik,routerboard-912uag-2hpnd|\
 	mikrotik,routerboard-lhg-2nd|\
 	mikrotik,routerboard-lhg-5nd|\
+	mikrotik,routerboard-mapl-2nd|\
 	mikrotik,routerboard-sxt-5nd-r2|\
 	mikrotik,routerboard-wap-g-5hact2hnd|\
 	mikrotik,routerboard-wapr-2nd)

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -30,6 +30,7 @@ case "$FIRMWARE" in
 	mikrotik,routerboard-wapr-2nd)
 		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" 1)
 		;;
+	mikrotik,routerboard-mapl-2nd|\
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" 2)
 		;;


### PR DESCRIPTION
The MikroTik RouterBOARD mAPL-2nd (sold as mAP Lite) is a small
2.4 GHz 802.11b/g/n PoE-capable AP.

See https://mikrotik.com/product/RBmAPL-2nD for more info.

Specifications:
 - SoC: Qualcomm Atheros QCA9533
 - RAM: 64 MB
 - Storage: 16 MB NOR
 - Wireless: Atheros AR9531 (SoC) 802.11b/g/n 2x2:2, 1.5 dBi antenna
 - Ethernet: Atheros AR8229 (SoC), 1x 10/100 port, 802.3af/at PoE in
 - 4 user-controllable LEDs:
   · 1x power (green)
   · 1x user (green)
   · 1x lan (green)
   · 1x wlan (green)

Flashing:
 TFTP boot initramfs image and then perform sysupgrade. Follow common
 MikroTik procedure as in https://openwrt.org/toh/mikrotik/common.

Note: following 781d4bfb397cdd12ee0151eb66c577f470e3377d
 The network setup avoids using the integrated switch and connects the
 single Ethernet port directly. This way, link speed (10/100 Mbps) is
 properly reported by eth0.

Full dmesg from device attached.
[boot.log](https://github.com/openwrt/openwrt/files/8154134/boot.log)

This PR intends to replace #3818, using standard pinctrl bindings instead of adding custom new ones, and using the same LED naming convention and usage (including status LED) as used on other MikroTik devices (which also matches what was done in ar71xx). MAC addresses are correct, everything works as expected.
