### PR TITLE
uboot-mvebu: backport patch to fix nvme detail crash

### DIFF
--- a/package/boot/uboot-mvebu/patches/012-nvme-Do-not-allocate-8kB-buffer-on-stack.patch
+++ b/package/boot/uboot-mvebu/patches/012-nvme-Do-not-allocate-8kB-buffer-on-stack.patch
@@ -1,0 +1,180 @@
+From patchwork Thu Dec  9 10:06:39 2021
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+X-Patchwork-Submitter: =?utf-8?q?Pali_Roh=C3=A1r?= <pali@kernel.org>
+X-Patchwork-Id: 1565708
+X-Patchwork-Delegate: trini@ti.com
+Return-Path: <u-boot-bounces@lists.denx.de>
+X-Original-To: incoming@patchwork.ozlabs.org
+Delivered-To: patchwork-incoming@bilbo.ozlabs.org
+Authentication-Results: bilbo.ozlabs.org;
+	dkim=pass (2048-bit key;
+ unprotected) header.d=kernel.org header.i=@kernel.org header.a=rsa-sha256
+ header.s=k20201202 header.b=owBTw6Y0;
+	dkim-atps=neutral
+Authentication-Results: ozlabs.org;
+ spf=pass (sender SPF authorized) smtp.mailfrom=lists.denx.de
+ (client-ip=85.214.62.61; helo=phobos.denx.de;
+ envelope-from=u-boot-bounces@lists.denx.de; receiver=<UNKNOWN>)
+Received: from phobos.denx.de (phobos.denx.de [85.214.62.61])
+	(using TLSv1.3 with cipher TLS_AES_256_GCM_SHA384 (256/256 bits)
+	 key-exchange X25519 server-signature RSA-PSS (4096 bits))
+	(No client certificate requested)
+	by bilbo.ozlabs.org (Postfix) with ESMTPS id 4J8qTM708Zz9s1l
+	for <incoming@patchwork.ozlabs.org>; Thu,  9 Dec 2021 21:07:19 +1100 (AEDT)
+Received: from h2850616.stratoserver.net (localhost [IPv6:::1])
+	by phobos.denx.de (Postfix) with ESMTP id 3FB4F80F68;
+	Thu,  9 Dec 2021 11:07:13 +0100 (CET)
+Authentication-Results: phobos.denx.de;
+ dmarc=pass (p=none dis=none) header.from=kernel.org
+Authentication-Results: phobos.denx.de;
+ spf=pass smtp.mailfrom=u-boot-bounces@lists.denx.de
+Authentication-Results: phobos.denx.de;
+	dkim=pass (2048-bit key;
+ unprotected) header.d=kernel.org header.i=@kernel.org header.b="owBTw6Y0";
+	dkim-atps=neutral
+Received: by phobos.denx.de (Postfix, from userid 109)
+ id 322AF804C8; Thu,  9 Dec 2021 11:07:11 +0100 (CET)
+X-Spam-Checker-Version: SpamAssassin 3.4.2 (2018-09-13) on phobos.denx.de
+X-Spam-Level: 
+X-Spam-Status: No, score=-2.7 required=5.0 tests=BAYES_00,DKIMWL_WL_HIGH,
+ DKIM_SIGNED,DKIM_VALID,DKIM_VALID_AU,DKIM_VALID_EF,SPF_HELO_NONE,
+ SPF_PASS autolearn=ham autolearn_force=no version=3.4.2
+Received: from sin.source.kernel.org (sin.source.kernel.org
+ [IPv6:2604:1380:40e1:4800::1])
+ (using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+ (No client certificate requested)
+ by phobos.denx.de (Postfix) with ESMTPS id 0C66F8141A
+ for <u-boot@lists.denx.de>; Thu,  9 Dec 2021 11:07:06 +0100 (CET)
+Authentication-Results: phobos.denx.de;
+ dmarc=pass (p=none dis=none) header.from=kernel.org
+Authentication-Results: phobos.denx.de; spf=pass smtp.mailfrom=pali@kernel.org
+Received: from smtp.kernel.org (relay.kernel.org [52.25.139.140])
+ (using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+ (No client certificate requested)
+ by sin.source.kernel.org (Postfix) with ESMTPS id F3CBCCE2558;
+ Thu,  9 Dec 2021 10:07:02 +0000 (UTC)
+Received: by smtp.kernel.org (Postfix) with ESMTPSA id 08E4FC004DD;
+ Thu,  9 Dec 2021 10:07:01 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=kernel.org;
+ s=k20201202; t=1639044421;
+ bh=I+fGxic7rMpZ1Zi/AiSsyXnETuTbDPyFD0r2i9AvE1U=;
+ h=From:To:Cc:Subject:Date:From;
+ b=owBTw6Y0CrNu6IANkBdCI137prowS2jox7v683lpE8Jl/tYuBGelQiAp3RFcDL93T
+ AZP4oj+NqytlNGcX5PVl0PYgxu2U+CvxSfQDlFftiOs14sQh0sktMZOskimGdNgPql
+ AjYkDRtwUwBqqyNmfECvNg1uQLppkjkwX3TFQ+9RQD4F56BR+kV0bykG42/+72RSjj
+ hMUYNhrC0yyCtHmUcg2X1LMMVHj90bCuk543sT3vHxMjsMxbZJofMVfb9EDmXtAwBW
+ EdNTDZxY7B2YDuKcl52hClMQF6JfqisZR5TPZtgReBdxJv1eQLLYl4+b4Z+s4Z+/bv
+ ViR8ipON4V6rA==
+Received: by pali.im (Postfix)
+ id 2F6E3111E; Thu,  9 Dec 2021 11:06:58 +0100 (CET)
+From: =?utf-8?q?Pali_Roh=C3=A1r?= <pali@kernel.org>
+To: Bin Meng <bmeng.cn@gmail.com>
+Cc: =?utf-8?q?Marek_Beh=C3=BAn?= <marek.behun@nic.cz>,
+ Patrick Wildt <patrick@blueri.se>, u-boot@lists.denx.de
+Subject: [PATCH] nvme: Do not allocate 8kB buffer on stack
+Date: Thu,  9 Dec 2021 11:06:39 +0100
+Message-Id: <20211209100639.21530-1-pali@kernel.org>
+X-Mailer: git-send-email 2.20.1
+MIME-Version: 1.0
+X-BeenThere: u-boot@lists.denx.de
+X-Mailman-Version: 2.1.38
+Precedence: list
+List-Id: U-Boot discussion <u-boot.lists.denx.de>
+List-Unsubscribe: <https://lists.denx.de/options/u-boot>,
+ <mailto:u-boot-request@lists.denx.de?subject=unsubscribe>
+List-Archive: <https://lists.denx.de/pipermail/u-boot/>
+List-Post: <mailto:u-boot@lists.denx.de>
+List-Help: <mailto:u-boot-request@lists.denx.de?subject=help>
+List-Subscribe: <https://lists.denx.de/listinfo/u-boot>,
+ <mailto:u-boot-request@lists.denx.de?subject=subscribe>
+Errors-To: u-boot-bounces@lists.denx.de
+Sender: "U-Boot" <u-boot-bounces@lists.denx.de>
+X-Virus-Scanned: clamav-milter 0.103.2 at phobos.denx.de
+X-Virus-Status: Clean
+
+Calling 'nvme scan' followed by 'nvme detail' crashes U-Boot on Turris
+Omnia with the following error:
+
+  undefined instruction
+  pc : [<0a000000>]          lr : [<7ff80bfc>]
+  reloc pc : [<8a8c0000>]    lr : [<00840bfc>]
+  sp : 7fb2b908  ip : 0000002a     fp : 02000000
+  r10: 04000000  r9 : 7fb2fed0     r8 : e1000000
+  r7 : 0c000000  r6 : 03000000     r5 : 06000000  r4 : 01000000
+  r3 : 7fb30928  r2 : 7fb30928     r1 : 00000000  r0 : 00000000
+  Flags: nZCv  IRQs off  FIQs off  Mode SVC_32
+  Code: 0f0fb4f0 0f0fb4f0 0f0fb4f0 0f0fb4f0 (f0f04b0f)
+  Resetting CPU ...
+
+This happens when nvme_print_info() tries to return to the caller. It
+looks like this error is caused by trying to allocate 8 KiB of memory
+on the stack by the two uses of ALLOC_CACHE_ALIGN_BUFFER().
+
+Use malloc_cache_aligned() to allocate this memory dynamically instead.
+
+This fixes 'nvme detail' on Turris Omnia.
+
+Note that similar change was applied to file drivers/nvme/nvme.c in past by
+commit 2f83481dff9c ("nvme: use page-aligned buffer for identify command").
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <marek.behun@nic.cz>
+---
+ drivers/nvme/nvme_show.c | 35 ++++++++++++++++++++++++++---------
+ 1 file changed, 26 insertions(+), 9 deletions(-)
+
+--- a/drivers/nvme/nvme_show.c
++++ b/drivers/nvme/nvme_show.c
+@@ -106,24 +106,41 @@ int nvme_print_info(struct udevice *udev
+ {
+ 	struct nvme_ns *ns = dev_get_priv(udev);
+ 	struct nvme_dev *dev = ns->dev;
+-	ALLOC_CACHE_ALIGN_BUFFER(char, buf_ns, sizeof(struct nvme_id_ns));
+-	struct nvme_id_ns *id = (struct nvme_id_ns *)buf_ns;
+-	ALLOC_CACHE_ALIGN_BUFFER(char, buf_ctrl, sizeof(struct nvme_id_ctrl));
+-	struct nvme_id_ctrl *ctrl = (struct nvme_id_ctrl *)buf_ctrl;
++	struct nvme_id_ctrl *ctrl;
++	struct nvme_id_ns *id;
++	int ret = 0;
+ 
+-	if (nvme_identify(dev, 0, 1, (dma_addr_t)(long)ctrl))
+-		return -EIO;
++	ctrl = memalign(dev->page_size, sizeof(struct nvme_id_ctrl));
++	if (!ctrl)
++		return -ENOMEM;
++
++	if (nvme_identify(dev, 0, 1, (dma_addr_t)(long)ctrl)) {
++		ret = -EIO;
++		goto free_ctrl;
++	}
+ 
+ 	print_optional_admin_cmd(le16_to_cpu(ctrl->oacs), ns->devnum);
+ 	print_optional_nvm_cmd(le16_to_cpu(ctrl->oncs), ns->devnum);
+ 	print_format_nvme_attributes(ctrl->fna, ns->devnum);
+ 
+-	if (nvme_identify(dev, ns->ns_id, 0, (dma_addr_t)(long)id))
+-		return -EIO;
++	id = memalign(dev->page_size, sizeof(struct nvme_id_ns));
++	if (!id) {
++		ret = -ENOMEM;
++		goto free_ctrl;
++	}
++
++	if (nvme_identify(dev, ns->ns_id, 0, (dma_addr_t)(long)id)) {
++		ret = -EIO;
++		goto free_id;
++	}
+ 
+ 	print_formats(id, ns);
+ 	print_data_protect_cap(id->dpc, ns->devnum);
+ 	print_metadata_cap(id->mc, ns->devnum);
+ 
+-	return 0;
++free_id:
++	free(id);
++free_ctrl:
++	free(ctrl);
++	return ret;
+ }


### PR DESCRIPTION
Steps to reproduce:
1. Insert NVMe disk with a reduction to Turris Omnia
2. Go to U-boot
3. Run following these commands:
a) ``nvme scan``
b) ``nvme detail``
4. Wait for crash

This is backported from U-boot upstream repository.
It should be included in the upcoming release - 2022.04 [1].

It was tested on Turris Omnia, mvebu, cortex-a9, OpenWrt master.

[1] https://patchwork.ozlabs.org/project/uboot/patch/20211209100639.21530-1-pali@kernel.org/