### PR TITLE
mkhash: fix build errors on FreeBSD 13.0

### DIFF
--- a/scripts/mkhash.c
+++ b/scripts/mkhash.c
@@ -105,7 +105,6 @@ be32enc(void *buf, uint32_t u)
 	p[2] = ((uint8_t) ((u >> 8) & 0xff));
 	p[3] = ((uint8_t) (u & 0xff));
 }
-#endif
 
 static void
 be64enc(void *buf, uint64_t u)
@@ -132,6 +131,7 @@ be32dec(const void *buf)
 
 	return (((uint32_t) be16dec(p)) << 16) | be16dec(p + 2);
 }
+#endif
 
 #define MD5_DIGEST_LENGTH	16
 


### PR DESCRIPTION
The functions `be64enc`, `be16dec`, and `be32dec` are already declared on FreeBSD 13.0, in `/usr/include/sys/endian.h` so we should not re-declare them. Fixes the following error:
```
./scripts/feeds update -a

Prerequisite check failed. Use FORCE=1 to override.
gmake: *** [/usr/home/g/wrt/mkhash/openwrt/include/toplevel.mk:180: staging_dir/host/.prereq-build] Error 1
bash: line 3: /usr/home/g/wrt/mkhash/openwrt/staging_dir/host/bin/mkhash: No such file or directory

gcc scripts/mkhash.c
scripts/mkhash.c:111:1: error: redefinition of 'be64enc'
  111 | be64enc(void *buf, uint64_t u)
      | ^~~~~~~
In file included from scripts/mkhash.c:85:
/usr/include/sys/endian.h:170:1: note: previous definition of 'be64enc' was here
  170 | be64enc(void *pp, uint64_t u)
      | ^~~~~~~
scripts/mkhash.c:121:1: error: redefinition of 'be16dec'
  121 | be16dec(const void *buf)
      | ^~~~~~~
In file included from scripts/mkhash.c:85:
/usr/include/sys/endian.h:102:1: note: previous definition of 'be16dec' was here
  102 | be16dec(const void *pp)
      | ^~~~~~~
scripts/mkhash.c:129:1: error: redefinition of 'be32dec'
  129 | be32dec(const void *buf)
      | ^~~~~~~
In file included from scripts/mkhash.c:85:
/usr/include/sys/endian.h:110:1: note: previous definition of 'be32dec' was here
  110 | be32dec(const void *pp)
```

Tested on FreeBSD 13.0, macOS 12.2.1, Ubuntu 20.04.4.