### PR TITLE
ipq806x: provide ramoops for R7800/XR500 by default

### DIFF
--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -304,7 +304,7 @@ define Device/netgear_r7800
 	PAGESIZE := 2048
 	BOARD_NAME := r7800
 	SUPPORTED_DEVICES += r7800
-	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct
+	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct kmod-ramoops
 endef
 TARGET_DEVICES += netgear_r7800
 
@@ -318,7 +318,7 @@ define Device/netgear_xr500
 	NETGEAR_HW_ID := 29764958+0+256+512+4x4+4x4+cascade
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
-	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct
+	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct kmod-ramoops
 endef
 TARGET_DEVICES += netgear_xr500
 


### PR DESCRIPTION
Add kmod-ramoops to the default set of device packages in R7800 and XR500, so that the ramoops kernel crash logs are provided by default for these routers.

The possible kernel crashes are stored into /sys/fs/pstore/*

The capability was earlier defined by 97158fe1 and cf346dfa, but the feature was not yet turned on by default.

Tested with R7800.

cc @chunkeey 
I should probably have does this already with the earlier PR when I created the kmod and defined the ramoops reserved memory area for R7800/XR500, but let's do it separately. 
