### PR TITLE
ramips: add support for ASUS RT-AC1200-V2

### DIFF
--- a/target/linux/ramips/dts/mt7628an_asus_rt-ac1200-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_asus_rt-ac1200-v2.dts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_asus_rt-ac1200.dtsi"
+
+/ {
+	compatible = "asus,rt-ac1200-v2", "mediatek,mt7628an-soc";
+	model = "ASUS RT-AC1200 V2";
+};
+
+&state_default {
+	spis {
+		groups = "spis";
+		function = "spis";
+	};
+
+	gpio {
+		groups = "refclk", "i2c", "wled_an";
+		function = "gpio";
+	};
+};
+
+&usbphy {
+	status = "disabled";
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};

--- a/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dts
+++ b/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dts
@@ -2,149 +2,20 @@
 // Copyright (c) 2022 Ray Wang
 // Copyright (c) 2022 Ivan Pavlov
 
-#include "mt7628an.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "mt7628an_asus_rt-ac1200.dtsi"
 
 / {
 	compatible = "asus,rt-ac1200", "mediatek,mt7628an-soc";
 	model = "Asus RT-AC1200";
 
-	aliases {
-		led-boot = &led_power;
-		led-failsafe = &led_power;
-		led-running = &led_power;
-		led-upgrade = &led_power;
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "reset";
-			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-
-		wps {
-			label = "wps";
-			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WPS_BUTTON>;
-		};
-	};
-
 	leds {
 		compatible = "gpio-leds";
-
-		led_power: power {
-			label = "blue:power";
-			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
-		};
-
-		wlan2g {
-			label = "blue:wlan2g";
-			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
 
 		usb {
 			label = "blue:usb";
 			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
 			trigger-sources = <&ohci_port1>, <&ehci_port1>;
 			linux,default-trigger = "usbport";
-		};
-	};
-
-	gpio-export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		led-all {
-			gpio-export,name = "led_all";
-			gpio-export,output = <0>;
-			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
-		};
-	};
-};
-
-&spi0 {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <40000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "bootloader";
-				reg = <0x0 0x30000>;
-				read-only;
-			};
-
-			partition@30000 {
-				label = "nvram";
-				reg = <0x30000 0x10000>;
-				read-only;
-			};
-
-			factory: partition@40000 {
-				label = "factory";
-				reg = <0x40000 0x10000>;
-				read-only;
-
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				macaddr_factory_28: macaddr@28 {
-					reg = <0x28 0x6>;
-				};
-			};
-
-			partition@50000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x50000 0xfb0000>;
-			};
-		};
-	};
-};
-
-&ethernet {
-	nvmem-cells = <&macaddr_factory_28>;
-	nvmem-cell-names = "mac-address";
-};
-
-&esw {
-	mediatek,portmap = <0x3e>;
-};
-
-&wmac {
-	status = "okay";
-
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&pcie {
-	status = "okay";
-};
-
-&pcie0 {
-	wifi@0,0 {
-		compatible = "mediatek,mt76";
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
-		ieee80211-freq-limit = <5000000 6000000>;
-
-		led {
-			led-sources = <2>;
-			led-active-low;
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dtsi
+++ b/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dtsi
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_wps;
+		led-failsafe = &led_wps;
+		led-running = &led_wps;
+		led-upgrade = &led_wps;
+		label-mac-device = &ethernet;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wps: wps {
+			label = "blue:wps";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <58000000>;
+		m25p,fast-read;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&gpio {
+	enable-leds {
+		gpio-hog;
+		line-name = "enable-leds";
+		output-low;
+		gpios = <4 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};
+
+&wmac {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -47,6 +47,19 @@ define Device/asus_rt-ac1200
 endef
 TARGET_DEVICES += asus_rt-ac1200
 
+define Device/asus_rt-ac1200-v2
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Asus
+  DEVICE_MODEL := RT-AC1200
+  DEVICE_VARIANT := V2
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap
+endef
+TARGET_DEVICES += asus_rt-ac1200-v2
+
 define Device/asus_rt-n10p-v3
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Asus

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -35,6 +35,7 @@ ramips_setup_interfaces()
 		ucidef_set_interface_lan "eth0"
 		;;
 	asus,rt-ac1200|\
+	asus,rt-ac1200-v2|\
 	hilink,hlk-7628n|\
 	hilink,hlk-7688a|\
 	hiwifi,hc5861b|\
@@ -177,7 +178,9 @@ ramips_setup_macs()
 	local label_mac=""
 
 	case $board in
-	asus,rt-ac1200|\
+	asus,rt-ac1200)
+		wan_mac=$(mtd_get_mac_binary factory 0x22)
+		;;
 	elecom,wrc-1167fs)
 		wan_mac=$(mtd_get_mac_binary factory 0x22)
 		label_mac=$wan_mac


### PR DESCRIPTION
Asus RT-AC1200-V2 wireless router

Hardware specifications:
SoC: MT7628DAN MIPS_24KEc@580MHz 2.4G-n 2x2
WiFi: MT7613BEN 5G-ac 160MHz 2x2
Switch: 4x100M built-in SoC
Flash: 16MB W25Q128JVSQ SPI-NOR
DRAM: 64MB built-in SoC

MAC addresses as verified by OEM firmware:
use            address      source
Lan/Wan/2G     *:60         factory 0x4 (label)
5G             *:64         factory 0x8000

Serial console: 57600,8n1

Installation:

Asus windows recovery tool:
 - install the Asus firmware restoration utility
 - unplug the router, hold the reset button while powering it on
 - release when the power LED flashes slowly
 - specify a static IP on your computer:
    IP address: 192.168.1.75
    Subnet mask 255.255.255.0
 - start the Asus firmware restoration utility, specify the factory image
    and press upload
 - do NOT power off the device after OpenWrt has booted until the LED flashing
 - after flashing OpenWrt, there will be first no 5GHz Wifi available probably,
    wait until blinking finishes and do a reboot

TFTP Recovery method:
 - set computer to a static ip, 192.168.1.75
 - connect computer to the LAN 1 port of the router
 - hold the reset button while powering on the router for a few seconds
 - send firmware image using a tftp client; i.e from linux:
    $ tftp
    tftp> binary
    tftp> connect 192.168.1.1
    tftp> put factory.bin
    tftp> quit
 - do NOT power off the device after OpenWrt has booted until the LED flashing
 - after flashing OpenWrt, there will be first no 5GHz Wifi available probably,
    wait until blinking finishes and do a reboot

Signed-off-by: Tamas Balogh <tamasbalogh@hotmail.com>
