### PR TITLE
ramips: add support for NetGear WN3100RPv2

### DIFF
--- a/target/linux/ramips/dts/mt7620a_netgear_wn3100rp-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_netgear_wn3100rp-v2.dts
@@ -6,6 +6,6 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "netgear,wn3000rp-v3", "ralink,mt7620a-soc";
-	model = "Netgear WN3000RP v3";
+	compatible = "netgear,wn3100rp-v2", "ralink,mt7620a-soc";
+	model = "Netgear WN3100RP v2";
 };

--- a/target/linux/ramips/dts/mt7620a_netgear_wn3x00rp.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_wn3x00rp.dtsi
@@ -1,0 +1,158 @@
+/* This file is released into the public domain */
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_green;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_green: power_g {
+			label = "green:power";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		power_r {
+			label = "red:power";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		client_g {
+			label = "green:client";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		client_r {
+			label = "red:client";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+
+		router_g {
+			label = "green:router";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+
+		router_r {
+			label = "red:router";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "green:wps";
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+		};
+
+		l_arrow {
+			label = "blue:leftarrow";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		};
+
+		r_arrow {
+			label = "blue:rightarrow";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x40000 0x7b0000>;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&art 0x1000>;
+
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&state_default {
+	default {
+		groups = "i2c", "uartf", "spi refclk";
+		function = "gpio";
+	};
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+
+	macaddr_art_6: macaddr@6 {
+		reg = <0x6 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -804,6 +804,22 @@ define Device/netgear_wn3000rp-v3
 endef
 TARGET_DEVICES += netgear_wn3000rp-v3
 
+define Device/netgear_wn3100rp-v2
+  SOC := mt7620a
+  IMAGE_SIZE := 7872k
+  NETGEAR_HW_ID := 29764883+8+0+32+2x2+0
+  NETGEAR_BOARD_ID := WN3100RPv2
+  BLOCKSIZE := 4k
+  IMAGES += factory.bin
+  KERNEL := $(KERNEL_DTB) | uImage lzma | pad-offset 64k 64 | \
+	append-uImage-fakehdr filesystem
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | netgear-dni
+  DEVICE_VENDOR := NETGEAR
+  DEVICE_MODEL := WN3100RP
+  DEVICE_VARIANT := v2
+endef
+TARGET_DEVICES += netgear_wn3100rp-v2
+
 define Device/netis_wf2770
   SOC := mt7620a
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -157,7 +157,8 @@ lenovo,newifi-y1s)
 	ucidef_set_led_netdev "wan" "WAN" "blue:internet" "eth0.2" "tx rx"
 	;;
 netgear,ex2700|\
-netgear,wn3000rp-v3)
+netgear,wn3000rp-v3|\
+netgear,wn3100rp-v2)
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:router" "wlan0"
 	;;
 netgear,ex3700|\

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -54,6 +54,7 @@ ramips_setup_interfaces()
 	netgear,ex6120|\
 	netgear,ex6130|\
 	netgear,wn3000rp-v3|\
+	netgear,wn3100rp-v2|\
 	planex,cs-qr10|\
 	planex,mzk-ex300np|\
 	planex,mzk-ex750np|\


### PR DESCRIPTION
This device is the same as the WN3000RPv3.
Last versions of official firmware for this device are in fact WN3000RPv3 firmware.

Signed-off-by: Rodolphe de Saint Léger <rdesaintleger@gmail.com>

