### PR TITLE
ath79: Add green power LED to Airtight C-75

### DIFF
--- a/target/linux/ath79/dts/qca9550_airtight_c-75.dts
+++ b/target/linux/ath79/dts/qca9550_airtight_c-75.dts
@@ -32,12 +32,14 @@
 		compatible = "gpio-leds";
 
 		led_power_amber: power-amber {
+			label = "amber:power";
 			color = <LED_COLOR_ID_AMBER>;
 			function = LED_FUNCTION_POWER;
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power_green: power-green {
+			label = "green:power";
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_POWER;
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;


### PR DESCRIPTION
In addition to the missing green LED definition, the polarity of the
amber power LED was incorrect which is fixed here.

Signed-off-by: Sven Schwermer <sven@svenschwermer.de>