### PR TITLE
ipq806x: sysupgrade NBG6817 with non-standard rootfs

### DIFF
--- a/target/linux/ipq806x/base-files/lib/upgrade/zyxel.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/zyxel.sh
@@ -92,6 +92,12 @@ zyxel_do_upgrade() {
 	zyxel,nbg6817)
 		local dualflagmtd="$(find_mtd_part 0:dual_flag)"
 		[ -b $dualflagmtd ] || return 1
+		local dualflag=`dd if=$dualflagmtd bs=1 count=1 | hexdump -e '2/1 "%X"'`
+		if [ "$dualflag" == "FF" ]; then
+			kernel="/dev/mmcblk0p4"
+		elif [ "$dualflag" == "01" ]; then
+			kernel="/dev/mmcblk0p7"
+		fi
 
 		case "$rootfs" in
 			"/dev/mmcblk0p5")
@@ -107,7 +113,7 @@ zyxel_do_upgrade() {
 				rootfs="/dev/mmcblk0p5"
 			;;
 			*)
-				return 1
+				[ -z $kernel ] && return 1
 			;;
 		esac
 		;;


### PR DESCRIPTION
After changing uboot-env to load rootfs from /dev/mmcblk0p10 partition, sysupgrade fails.
This patch allows you to update to the same partition from which it was launched.
Devices that have not been changed to uboot-env are not affected.

Signed-off-by: Max S Kash <asukms@ya.ru>

Zyxel NBG6817 has unresolved problems (#7352 ) with the block-mount, due to which most of the mmc (> 3gb) remains unused.
An alternative solution is to move rootfs by changing uboot-env.
Read more here: https://github.com/openwrt/openwrt/issues/7352#issuecomment-1061234576
