### PR TITLE
netfilter.mk: package libip6t_icmp6.so into ip6tables-extra

### DIFF
--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -158,9 +158,6 @@ $(eval $(if $(NF_KMOD),$(call nf_add,IPT_IPV6,CONFIG_IP6_NF_FILTER, $(P_V6)ip6ta
 $(eval $(if $(NF_KMOD),$(call nf_add,IPT_IPV6,CONFIG_IP6_NF_MANGLE, $(P_V6)ip6table_mangle),))
 $(eval $(if $(NF_KMOD),$(call nf_add,IPT_IPV6,CONFIG_NF_LOG_IPV6, $(P_V6)nf_log_ipv6),))
 
-$(eval $(if $(NF_KMOD),,$(call nf_add,IPT_IPV6,CONFIG_IP6_NF_IPTABLES, ip6t_icmp6)))
-
-
 $(eval $(call nf_add,IPT_IPV6,CONFIG_IP6_NF_TARGET_REJECT, $(P_V6)ip6t_REJECT))
 
 # ipv6 extra
@@ -171,6 +168,8 @@ $(eval $(call nf_add,IPT_IPV6_EXTRA,CONFIG_IP6_NF_MATCH_EUI64, $(P_V6)ip6t_eui64
 $(eval $(call nf_add,IPT_IPV6_EXTRA,CONFIG_IP6_NF_MATCH_OPTS, $(P_V6)ip6t_hbh))
 $(eval $(call nf_add,IPT_IPV6_EXTRA,CONFIG_IP6_NF_MATCH_FRAG, $(P_V6)ip6t_frag))
 $(eval $(call nf_add,IPT_IPV6_EXTRA,CONFIG_IP6_NF_MATCH_RT, $(P_V6)ip6t_rt))
+# userland only
+$(eval $(if $(NF_KMOD),,$(call nf_add,IPT_IPV6_EXTRA,CONFIG_IP6_NF_IPTABLES, ip6t_icmp6)))
 
 # nat
 


### PR DESCRIPTION
@hauke @yousong @champtar
The iptables match `libip6t_icmp6` is added to the binary iptables as
builtin according to the compilation log. When testing, if the mwan3
also works with the iptables-nft, I noticed that the `icmp6` rules could
not be loaded. I get the following output that the shard object icmp6 is
not present on the system.

ip6tables-nft-restore v1.8.7 (nf_tables): Couldn't load match icmp6:No
such file or directory Error occurred at line: 11 Try
ip6tables-nft-restore -h or'ip6tables-nft-restore --help' for more
information.

If I add this change, then the shard object is built, and can be
installed via the ip6tables-extra.

fixes #9430 
