### PR TITLE
ipset: add backport patch for IPv6 nftables ipset-translation

### DIFF
--- a/package/network/utils/ipset/patches/0001-Fix-IPv6-sets-nftables-translation.patch
+++ b/package/network/utils/ipset/patches/0001-Fix-IPv6-sets-nftables-translation.patch
@@ -1,0 +1,91 @@
+From 50ef784944c60cd291970c47e4b831ff7ef9c923 Mon Sep 17 00:00:00 2001
+From: Pablo Neira Ayuso <pablo@netfilter.org>
+Date: Mon, 28 Feb 2022 20:02:17 +0100
+Subject: [PATCH] Fix IPv6 sets nftables translation
+
+The parser assumes the set is an IPv4 ipset because IPSET_OPT_FAMILY is
+not set.
+
+ # ipset-translate restore < ./ipset-mwan3_set_connected_ipv6.dump
+ add table inet global
+ add set inet global mwan3_connected_v6 { type ipv6_addr; flags interval; }
+ flush set inet global mwan3_connected_v6
+ ipset v7.15: Error in line 4: Syntax error: '64' is out of range 0-32
+
+Remove ipset_xlate_type_get(), call ipset_xlate_set_get() instead to
+obtain the set type and family.
+
+Reported-by: Florian Eckert <fe@dev.tdt.de>
+Fixes: 325af556cd3a ("add ipset to nftables translation infrastructure")
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ lib/ipset.c             | 24 ++++++++++--------------
+ tests/xlate/xlate.t     |  2 ++
+ tests/xlate/xlate.t.nft |  2 ++
+ 3 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/lib/ipset.c b/lib/ipset.c
+index 73e67db..50f86ae 100644
+--- a/lib/ipset.c
++++ b/lib/ipset.c
+@@ -949,18 +949,6 @@ ipset_xlate_set_get(struct ipset *ipset, const char *name)
+ 	return NULL;
+ }
+ 
+-static const struct ipset_type *ipset_xlate_type_get(struct ipset *ipset,
+-						     const char *name)
+-{
+-	const struct ipset_xlate_set *set;
+-
+-	set = ipset_xlate_set_get(ipset, name);
+-	if (!set)
+-		return NULL;
+-
+-	return set->type;
+-}
+-
+ static int
+ ipset_parser(struct ipset *ipset, int oargc, char *oargv[])
+ {
+@@ -1282,8 +1270,16 @@ ipset_parser(struct ipset *ipset, int oargc, char *oargv[])
+ 		if (!ipset->xlate) {
+ 			type = ipset_type_get(session, cmd);
+ 		} else {
+-			type = ipset_xlate_type_get(ipset, arg0);
+-			ipset_session_data_set(session, IPSET_OPT_TYPE, type);
++			const struct ipset_xlate_set *xlate_set;
++
++			xlate_set = ipset_xlate_set_get(ipset, arg0);
++			if (xlate_set) {
++				ipset_session_data_set(session, IPSET_OPT_TYPE,
++						       xlate_set->type);
++				ipset_session_data_set(session, IPSET_OPT_FAMILY,
++						       &xlate_set->family);
++				type = xlate_set->type;
++			}
+ 		}
+ 		if (type == NULL)
+ 			return ipset->standard_error(ipset, p);
+diff --git a/tests/xlate/xlate.t b/tests/xlate/xlate.t
+index b1e7d28..f09cb20 100644
+--- a/tests/xlate/xlate.t
++++ b/tests/xlate/xlate.t
+@@ -53,3 +53,5 @@ create bp1 bitmap:port range 1-1024
+ add bp1 22
+ create bim1 bitmap:ip,mac range 1.1.1.0/24
+ add bim1 1.1.1.1,aa:bb:cc:dd:ee:ff
++create hn6 hash:net family inet6
++add hn6 fe80::/64
+diff --git a/tests/xlate/xlate.t.nft b/tests/xlate/xlate.t.nft
+index 96eba3b..0152a30 100644
+--- a/tests/xlate/xlate.t.nft
++++ b/tests/xlate/xlate.t.nft
+@@ -54,3 +54,5 @@ add set inet global bp1 { type inet_service; }
+ add element inet global bp1 { 22 }
+ add set inet global bim1 { type ipv4_addr . ether_addr; }
+ add element inet global bim1 { 1.1.1.1 . aa:bb:cc:dd:ee:ff }
++add set inet global hn6 { type ipv6_addr; flags interval; }
++add element inet global hn6 { fe80::/64 }
+-- 
+2.20.1
+


### PR DESCRIPTION
@nbd168 @hauke 
When porting mwan3 from iptables to nftables I tried the new translation
tool for ipset ipset-translate. I noticed that no IPv6 ipset can be
created with the tool. I have reported the problem to the upstream
project and the following patch fixes the problem.

Until this upsream is included in a new release, this patch should be
used in Openwrt.

https://lore.kernel.org/netfilter-devel/20220228190217.2256371-1-pablo@netfilter.org/T/#m09cc3cb738f2e42024c7aecf5b7240d9f6bbc19c