### PR TITLE
    ath79: add support for MikroTik SXT-R LTE

### DIFF
--- a/target/linux/ath79/dts/qca9531_mikrotik_routerboard-sxtr.dts
+++ b/target/linux/ath79/dts/qca9531_mikrotik_routerboard-sxtr.dts
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9533_mikrotik_routerboard-16m.dtsi"
+
+/ {
+    compatible = "mikrotik,routerboard-sxtr", "qca,qca9533";
+    model = "MikroTik RouterBOARD SXTR (SXT-LTE)";
+
+    aliases {
+        led-boot = &led_power;
+        led-failsafe = &led_power;
+        led-upgrade = &led_power;
+        led-running = &led_power;
+    };
+
+    leds {
+        compatible = "gpio-leds";
+        pinctrl-names = "default";
+
+        led_power: power {
+            label = "green:power";
+            gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+        };
+
+        lte {
+            label = "green:lte";
+            gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+        };
+
+        eth1green {
+            label = "green:eth1";
+            gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+        };
+
+        eth2green {
+            label = "green:eth2";
+            gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+        };
+
+        eth2yellow {
+            label = "yellow:eth2";
+            gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+        };
+
+        signal0 {
+            label = "green:rssilow";
+            gpios = <&gpio_ext 2 GPIO_ACTIVE_LOW>;
+        };
+
+        signal1 {
+            label = "green:rssimediumlow";
+            gpios = <&gpio_ext 3 GPIO_ACTIVE_LOW>;
+        };
+
+        signal2 {
+            label = "green:rssimedium";
+            gpios = <&gpio_ext 4 GPIO_ACTIVE_LOW>;
+        };
+
+        signal3 {
+            label = "green:rssimediumhigh";
+            gpios = <&gpio_ext 5 GPIO_ACTIVE_LOW>;
+        };
+
+        signal4 {
+            label = "green:rssihigh";
+            gpios = <&gpio_ext 6 GPIO_ACTIVE_LOW>;
+        };
+
+    };
+
+    gpio-export {
+        compatible = "gpio-export";
+
+        modem_power {
+            gpio-export,name = "modem_power";
+            gpio-export,output = <0>;
+            gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+        };
+
+        poe_out {
+            gpio-export,name = "poe_out";
+            gpio-export,output = <0>;
+            gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+        };
+
+        poe_status {
+            gpio-export,name = "poe_status";
+            gpio-export,input;
+            gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+        };
+
+        sim_select {
+            gpio-export,name = "sim_select";
+            gpio-export,output = <0>;
+            gpios = <&gpio_ext 7 GPIO_ACTIVE_HIGH>;
+        };
+
+        modem_reset {
+            gpio-export,name = "modem_reset";
+            gpio-export,output = <0>;
+            gpios = <&gpio_ext 0 GPIO_ACTIVE_HIGH>;
+        };
+
+        modem_rfkill {
+            gpio-export,name = "modem_rfkill";
+            gpio-export,output = <0>;
+            gpios = <&gpio_ext 1 GPIO_ACTIVE_HIGH>;
+        };
+    };
+
+    keys {
+        compatible = "gpio-keys";
+
+        mode {
+            label = "MODE button";
+            linux,code = <KEY_RFKILL>;
+            gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+            debounce-interval = <60>;
+        };
+    };
+};
+
+&spi {
+    status = "okay";
+    num-cs = <2>;
+    cs-gpios = <0>, <0>;
+
+    pinctrl-names = "default";
+    pinctrl-0 = <&pmx_spi_ext>;
+
+    gpio_ext: gpio_ext@1 {
+        compatible = "fairchild,74hc595";
+        reg = <1>;
+        gpio-controller;
+        #gpio-cells = <2>;
+        registers-number = <1>;
+        spi-max-frequency = <10000000>;
+    };
+};
+
+&pinmux {
+    pmx_spi_ext: spi_ext {
+        pinctrl-single,bits = <0x08 0x0a000000 0xff000000>;  // Route SPI_CS1 to GPIO 11 for 74HC595.
+    };
+
+    pmx_gpios: pmx_gpios {
+        pinctrl-single,bits = <0x00 0x00000000 0x00ff00ff>,  // port green leds normal GPIO
+                        <0x08 0x00001600 0x0000ff00>,  // 10 is serial out -- shared eth1 yellow LED
+                        <0x10 0x00000000 0x0000ff00>;  // i7 normal mode for LED
+    };
+};
+
+&gpio {
+    pinctrl-names = "default";
+    pinctrl-0 = <&pmx_gpios>;
+};
+
+&usb0 {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    status = "okay";
+
+    hub_port: port@1 {
+        eg = <1>;
+        #trigger-source-cells = <0>;
+    };
+};
+
+&usb_phy {
+    status = "okay";
+};
+
+&eth0 {
+    status = "okay";
+    mtd-mac-address = <&hard_config 0x10>;
+    mtd-mac-address-increment = <1>;
+    phy-handle = <&swphy0>;
+
+    gmac-config {
+        device = <&gmac>;
+        switch-phy-swap = <1>;
+    };
+};
+
+&eth1 {
+    status = "okay";
+    mtd-mac-address = <&hard_config 0x10>;
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -72,6 +72,15 @@ define Device/mikrotik_routerboard-sxt-5nd-r2
 endef
 TARGET_DEVICES += mikrotik_routerboard-sxt-5nd-r2
 
+define Device/mikrotik_routerboard-sxtr
+  $(Device/mikrotik_nor)
+  SOC := qca9531
+  DEVICE_MODEL := RouterBOARD SXTR (SXT-LTE)
+  DEVICE_PACKAGES += kmod-usb2 kmod-gpio-nxp-74hc164
+  IMAGE_SIZE := 16256k
+endef
+TARGET_DEVICES += mikrotik_routerboard-sxtr
+
 define Device/mikrotik_routerboard-wap-g-5hact2hnd
   $(Device/mikrotik_nor)
   SOC := qca9556

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
@@ -33,6 +33,10 @@ mikrotik,routerboard-sxt-5nd-r2)
 	ucidef_set_led_rssi "rssimediumhigh" "rssimediumhigh" "green:rssimediumhigh" "wlan0" "60" "100"
 	ucidef_set_led_rssi "rssihigh" "rssihigh" "green:rssihigh" "wlan0" "80" "100"
 	;;
+mikrotik,routerboard-sxtr)
+	ucidef_set_led_netdev "eth1" "eth1" "green:eth1" "eth1"
+	ucidef_set_led_switch "eth2" "eth2" "green:eth2" "switch0" "4" "6" "link tx rx"
+	;;        
 esac
 
 board_config_flush

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -23,6 +23,9 @@ ath79_setup_interfaces()
 	mikrotik,routerboard-wapr-2nd)
 		ucidef_set_interface_lan "eth0"
 		;;
+	mikrotik,routerboard-sxtr)
+		ucidef_set_interfaces_lan_wan "eth1" "eth0"
+		;;
 	*)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		;;

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/03_gpioswitch
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/03_gpioswitch
@@ -1,0 +1,17 @@
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+board=$(board_name)
+
+case "$board" in
+mikrotik,routerboard-sxtr)
+	ucidef_add_gpio_switch "poe_out" "poe_out" "poe_out" "0"
+	ucidef_add_gpio_switch "modem_power" "modem_power" "modem_power" "1"
+	ucidef_add_gpio_switch "sim_select" "sim_select" "sim_select" "0" 
+	;;
+esac
+
+board_config_flush
+
+exit 0


### PR DESCRIPTION
    This adds support for the Mikrotik SXT-R LTE device, which is an
    outdoor router that can host an LTE modem mini PCIe card as its WAN
    connection.  The LTE antenna system claims a 9 dBi gain.

    Hardware:
        - SoC: QCA9531 @ 650MHz
        - Flash: 16 MiB SPI NOR
        - RAM: 64 MiB DDR2
        - WiFi: None.  No antenna is provided for the SoC radio.
        - Ethernet: 2 x 10/100 Mb
        - PoE: Passive or 802.3af input to port 1. Unit must be powered
	       by PoE.  GPIO switchable passive PoE out on port 2.  PoE
               output status LED blinks by hardware if overloaded.
        - Modem support: Mini PCIe slot is wired only for USB2. The PCIe
               SoC bus is not wired to the slot. Two MicroSIM slots--
               SIM card to use is selected by a GPIO output.  A GPIO can
               switch off the power to the modem.  Modem control pins
               22 and 20 (typically reset and RF kill) may be pulled to
               ground by GPIOs.
        - Serial: There is a set of 10 test pads on board near the flash
               chip.  Pin 6 is RX and pin 7 is Tx.  Tx GPIO pin (10) is
               shared with the yellow LED on the eth1 socket.  This DTS
               sets it as serial output allowing OpenWrt to use the
               port.  The bootloader does not use serial.
        - LEDs: Power, LTE, 2x Ethernet Link, PoE out, 5x RSSI bars
        - Buttons: Reset, Mode

    Installation:  Standard MikroTik-- RouterBOOT netboot the OpenWrt
        initramfs image, then flash the sysupgrade image from within
        OpenWrt.  Under OpenWrt, the eth1 port (with PoE in) defaults to
        be LAN, and eth2 is WAN.

    Signed-off-by: Mike Keitz <keitz24@gmail.com>
