### PR TITLE
uqmi: set CID during 'query-data-status' operation

### DIFF
--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -285,7 +285,7 @@ proto_qmi_setup() {
 		fi
 
 		# Check data connection state
-		connstat=$(uqmi -s -d "$device" --get-data-status)
+		connstat=$(uqmi -s -d "$device" --set-client-id wds,"$cid_4" --get-data-status)
 		[ "$connstat" == '"connected"' ] || {
 			echo "No data link!"
 			uqmi -s -d "$device" --set-client-id wds,"$cid_4" --release-client-id wds > /dev/null 2>&1
@@ -322,7 +322,7 @@ proto_qmi_setup() {
 		fi
 
 		# Check data connection state
-		connstat=$(uqmi -s -d "$device" --get-data-status)
+		connstat=$(uqmi -s -d "$device" --set-client-id wds,"$cid_6" --get-data-status)
 		[ "$connstat" == '"connected"' ] || {
 			echo "No data link!"
 			uqmi -s -d "$device" --set-client-id wds,"$cid_6" --release-client-id wds > /dev/null 2>&1


### PR DESCRIPTION
Modems used in ZTE mobile broadband routers require to query the data
session status using the same CID as one used to establish the session,
otherwise they will report the session as "disconnected" despite
reporting correct PDH in previous step. Without this change, IPv6
connection on these modems doesn't establish properly. In IPv4 this bug
is present as well, but for some reason querying of IPv4 status works
using temporary CID, this however seems noncompliant with QMI
specifications, so fix it as well.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>
Run-tested-on: ZTE MF283+, MF286 and MF286D - both IPv4 and IPv6.
