### PR TITLE
ramips: add support for OrayBox X3A

### DIFF
--- a/target/linux/ramips/dts/mt7621_oraybox_x3a.dts
+++ b/target/linux/ramips/dts/mt7621_oraybox_x3a.dts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "oraybox,x3a", "mediatek,mt7621-soc";
+	model = "OrayBox X3A";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_green;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status-red {
+			label = "red:status";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: status-blue {
+			label = "blue:status";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: status-green {
+			label = "green:status";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <30000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf00000>;
+			};
+
+			partition@fe0000 {
+				label = "bdinfo";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_bdinfo_9: macaddr@9 {
+					reg = <0x9 0x6>;
+				};
+			};
+
+			partition@ff0000 {
+				label = "reserve";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_9>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {		
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_bdinfo_9>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <1>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1319,6 +1319,16 @@ define Device/netis_wf2881
 endef
 TARGET_DEVICES += netis_wf2881
 
+define Device/oraybox_x3a
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 15360k
+  DEVICE_VENDOR := OrayBox
+  DEVICE_MODEL := X3A
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware
+endef
+TARGET_DEVICES += oraybox_x3a
+
 define Device/phicomm_k2p
   $(Device/dsa-migration)
   IMAGE_SIZE := 15744k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -100,6 +100,10 @@ netgear,r7450)
 	ucidef_set_led_netdev "lan3" "LAN3" "white:lan3" "lan3"
 	ucidef_set_led_netdev "lan4" "LAN4" "white:lan4" "lan4"
 	;;
+oraybox,x3a)
+	ucidef_set_led_netdev "wan" "wan link" "red:status" "wan"
+	ucidef_set_led_netdev "lan" "lan link" "green:status" "br-lan"
+	;;
 tplink,archer-a6-v3|\
 tplink,archer-c6-v3|\
 tplink,archer-c6u-v1)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -43,6 +43,7 @@ ramips_setup_interfaces()
 	jcg,q20|\
 	lenovo,newifi-d1|\
 	mikrotik,routerboard-m33g|\
+	oraybox,x3a|\
 	renkforce,ws-wn530hp3-a|\
 	xiaomi,mi-router-3g|\
 	xiaomi,mi-router-3g-v2|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -53,6 +53,12 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		;;
+	oraybox,x3a)
+		if [ "$PHYNBR" = "1" ]; then
+			hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"
+			macaddr_setbit_la "$(macaddr_add $hw_mac_addr 0x100000)" > /sys${DEVPATH}/macaddress
+		fi
+		;;
 	raisecom,msg1500-x-00)
 		[ "$PHYNBR" = "0" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_ascii Config protest_lan_mac)" \


### PR DESCRIPTION
OrayBox X3A is a 2.4/5GHz dual band AC router, based on MediaTek MT7621.

Specification:
```
* SoC: MT7621
* RAM: DDR3 128 MiB
* Flash: 16 MiB NOR (XM25Q128)
* Wi-Fi: (single chip hosting both 2.4G and 5G)
  * 2.4GHz: MT7615
  * 5GHz: MT7615
* Ethernet: 3x 1000Mbps
  * Switch: MT7530
* LED:
  * Ethernet LEDs: On the back of the router, hardware-controlled.
  * Status LEDs: One "pixel-like" RGB LED in the front of the router,
                 which is actually made up of 3 individual LEDs (with
                 dedicated GPIO pins) with the color of Red, Green,
                 and Blue.
                 The OEM firmware only lights up one color at a time to
                 indicate status, but that's very boring, and the colors
                 actually look great when combined, so I've improvised a
                 little and made them indicate netdev activities.
                 My test results:
                 GPIO 13/14/15
                 000 white (actually more like bright green or cyan
                            because the brightness of the green LED is
                            higher than red and blue)
                 001 bright purple
                 010 bright green
                 011 red
                 100 bright cyan
                 101 blue
                 110 green
                 111 off
```

Flash Layout:
```
 0x0000000-0x0030000 : "u-boot"
 0x0030000-0x0040000 : "u-boot-env"
 0x0040000-0x0050000 : "factory"
 0x0050000-0x0f50000 : "firmware"
 /*0x0f50000 to 0x0fe0000 is undefined, same as OEM firmware*/
 0x0fe0000-0x0ff0000 : "bdinfo"
 0x0ff0000-0x1000000 : "reserve"
```

MAC address:
```
 MAC               Source                          Description    Fix
 A0:CX:XX:BX:XX:0D BDINFO_9                        LAN(LABEL)     DTS
 A0:CX:XX:BX:XX:0E BDINFO_9 + 1                    WAN            DTS
 A2:CX:XX:BX:XX:0F FACTORY_4                       WIFI2G         DTS
 A2:CX:XX:CX:XX:0F SETBIT 7 (FACTORY_4 + 0x100000) WIFI5G         HOTPLUG
 A6:CX:XX:BX:XX:0F N/A                             WIFI2G_CLIENT  N/A
 A6:DX:XX:BX:XX:0F N/A                             WIFI5G_CLIENT  N/A
```
Stock dmesg:
https://pastebin.com/2t2jwLdf

Stock Dumps:
https://pastebin.com/LDLxSWX3

Installation via SSH (does not void your warranty):
```
1.  -----UNLOCK SSH-----
1.1 Set computer IP to DHCP mode, load 'http://10.168.1.1/cgi-bin/luci' in
    your browser. Password is 'admin'.
1.2 Click the "备份且导出" (backup and export) button, and download the
    config file.
1.3 Open the downloaded file with 7zip, navigate to '/etc/config/'.
1.4 Edit the file './system'. Change the '0' into '1' under
    "config sys 'ssh'".
1.5 Save the file.
1.6 Upload the file by clicking the "导入且恢复" (import and recover)
    button. The router will automatically reboot.
2.  -----FLASH THE OPENWRT FIRMWARE-----
2.1 Use any scp tool to upload the 'sysupgrade' firmware to the '/tmp/'
    folder to your router. It should be root@10.168.1.1 and the password
	is 'admin'.
2.2 SSH into the router, also root@10.168.1.1 and the password is 'admin'.
2.3 **IMPORTANT** Type command 'dd if=/dev/mtd3 of=/tmp/firmware.bin', to
    backup the stock firmware. Since the OEM does not provide firmware
	download on their website, this is the only way to get it.
2.3 **ALSO IMPORTANT** Use any scp tool to download your backed-up stock
    firmware from '/tmp/' to your local drive. Then you'd better use a hex
	reading tool to have a rough look at it to make sure nothing is
	corrupt. Or u can just back up again and cross check the MD5.
2.4 Type command 'mtd write /tmp/XXX.bin firmware', and it should flash
    the firmware.
2.5 Verify that nothing went wrong. If you're confident, type 'reboot' and
    reboot the router.
```

Revert to stock firmware:
```
1.  load stock firmware using mtd (make sure u have a backup).
```

Signed-off-by: Ray Wang <raywang777@foxmail.com>