### PR TITLE
iptables: backport missing init_extensions6() calls

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=iptables
 PKG_VERSION:=1.8.7
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_URL:=https://netfilter.org/projects/iptables/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/package/network/utils/iptables/patches/001-xtables-Call-init_extensions6-for-static-builds.patch
+++ b/package/network/utils/iptables/patches/001-xtables-Call-init_extensions6-for-static-builds.patch
@@ -1,0 +1,81 @@
+From e727ccad036e2cdba3339536c65c7ceef43c0740 Mon Sep 17 00:00:00 2001
+From: Erik Wilson <erik.e.wilson@gmail.com>
+Date: Tue, 13 Jul 2021 16:48:23 -0700
+Subject: [PATCH] xtables: Call init_extensions6() for static builds
+
+Initialize extensions from libext6 for cases where xtables is built statically.
+
+Closes: https://bugzilla.netfilter.org/show_bug.cgi?id=1550
+Signed-off-by: Erik Wilson <Erik.E.Wilson@gmail.com>
+Signed-off-by: Florian Westphal <fw@strlen.de>
+---
+ iptables/xtables-monitor.c    | 1 +
+ iptables/xtables-restore.c    | 1 +
+ iptables/xtables-save.c       | 1 +
+ iptables/xtables-standalone.c | 1 +
+ iptables/xtables-translate.c  | 1 +
+ 5 files changed, 5 insertions(+)
+
+diff --git a/iptables/xtables-monitor.c b/iptables/xtables-monitor.c
+index 4b980980..21d4bec0 100644
+--- a/iptables/xtables-monitor.c
++++ b/iptables/xtables-monitor.c
+@@ -628,6 +628,7 @@ int xtables_monitor_main(int argc, char *argv[])
+ #if defined(ALL_INCLUSIVE) || defined(NO_SHARED_LIBS)
+ 	init_extensions();
+ 	init_extensions4();
++	init_extensions6();
+ #endif
+ 
+ 	if (nft_init(&h, AF_INET, xtables_ipv4)) {
+diff --git a/iptables/xtables-restore.c b/iptables/xtables-restore.c
+index d2739497..72832103 100644
+--- a/iptables/xtables-restore.c
++++ b/iptables/xtables-restore.c
+@@ -364,6 +364,7 @@ xtables_restore_main(int family, const char *progname, int argc, char *argv[])
+ #if defined(ALL_INCLUSIVE) || defined(NO_SHARED_LIBS)
+ 		init_extensions();
+ 		init_extensions4();
++		init_extensions6();
+ #endif
+ 		break;
+ 	case NFPROTO_ARP:
+diff --git a/iptables/xtables-save.c b/iptables/xtables-save.c
+index cfce0472..98cd0ed3 100644
+--- a/iptables/xtables-save.c
++++ b/iptables/xtables-save.c
+@@ -203,6 +203,7 @@ xtables_save_main(int family, int argc, char *argv[],
+ #if defined(ALL_INCLUSIVE) || defined(NO_SHARED_LIBS)
+ 		init_extensions();
+ 		init_extensions4();
++		init_extensions6();
+ #endif
+ 		tables = xtables_ipv4;
+ 		d.commit = true;
+diff --git a/iptables/xtables-standalone.c b/iptables/xtables-standalone.c
+index 7b71db62..1a6b7cf7 100644
+--- a/iptables/xtables-standalone.c
++++ b/iptables/xtables-standalone.c
+@@ -57,6 +57,7 @@ xtables_main(int family, const char *progname, int argc, char *argv[])
+ #if defined(ALL_INCLUSIVE) || defined(NO_SHARED_LIBS)
+ 	init_extensions();
+ 	init_extensions4();
++	init_extensions6();
+ #endif
+ 
+ 	if (nft_init(&h, family, xtables_ipv4) < 0) {
+diff --git a/iptables/xtables-translate.c b/iptables/xtables-translate.c
+index 33ba68ec..49f44b6f 100644
+--- a/iptables/xtables-translate.c
++++ b/iptables/xtables-translate.c
+@@ -482,6 +482,7 @@ static int xtables_xlate_main_common(struct nft_handle *h,
+ #if defined(ALL_INCLUSIVE) || defined(NO_SHARED_LIBS)
+ 	init_extensions();
+ 	init_extensions4();
++	init_extensions6();
+ #endif
+ 		tables = xtables_ipv4;
+ 		break;
+-- 
+2.27.0
+


### PR DESCRIPTION
This fixes ip6tables-nft no being able to use built-in
extensions like icmp6.