### PR TITLE
ramips: add support for Cudy M1800

### DIFF
--- a/target/linux/generic/backport-5.10/422-v5.19-mtd-spi-nor-support-eon-en25qh256a.patch
+++ b/target/linux/generic/backport-5.10/422-v5.19-mtd-spi-nor-support-eon-en25qh256a.patch
@@ -1,0 +1,49 @@
+From 6abef37d16d0c570ef5a149e63762fba2a30804b Mon Sep 17 00:00:00 2001
+From: "Leon M. George" <leon@georgemail.eu>
+Date: Wed, 30 Mar 2022 16:16:56 +0200
+Subject: [PATCH] mtd: spi-nor: support eon en25qh256a variant
+
+The EN25QH256A variant of the EN25QH256 doesn't initialize correctly from SFDP
+alone and only accesses memory below 8m (addr_width is 4 but read_opcode takes
+only 3 bytes).
+
+Set SNOR_F_4B_OPCODES if the flash chip variant was detected using hwcaps.
+
+The fix submitted upstream uses the PARSE_SFDP initializer that is not
+available in the kernel used with Openwrt.
+
+Signed-off-by: Leon M. George <leon@georgemail.eu>
+---
+ drivers/mtd/spi-nor/eon.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+--- a/drivers/mtd/spi-nor/eon.c
++++ b/drivers/mtd/spi-nor/eon.c
+@@ -8,6 +8,16 @@
+ 
+ #include "core.h"
+ 
++static void en25qh256_post_sfdp_fixups(struct spi_nor *nor)
++{
++	if (nor->params->hwcaps.mask & SNOR_HWCAPS_READ_1_1_4)
++		nor->flags |= SNOR_F_4B_OPCODES;
++}
++
++static const struct spi_nor_fixups en25qh256_fixups = {
++	.post_sfdp = en25qh256_post_sfdp_fixups,
++};
++
+ static const struct flash_info eon_parts[] = {
+ 	/* EON -- en25xxx */
+ 	{ "en25f32",    INFO(0x1c3116, 0, 64 * 1024,   64, SECT_4K) },
+@@ -23,7 +33,9 @@ static const struct flash_info eon_parts
+ 	{ "en25qh64",   INFO(0x1c7017, 0, 64 * 1024,  128,
+ 			     SECT_4K | SPI_NOR_DUAL_READ) },
+ 	{ "en25qh128",  INFO(0x1c7018, 0, 64 * 1024,  256, 0) },
+-	{ "en25qh256",  INFO(0x1c7019, 0, 64 * 1024,  512, 0) },
++	{ "en25qh256",  INFO(0x1c7019, 0, 64 * 1024,  512,
++		SPI_NOR_DUAL_READ)
++		.fixups = &en25qh256_fixups },
+ 	{ "en25s64",	INFO(0x1c3817, 0, 64 * 1024,  128, SECT_4K) },
+ };
+ 

--- a/target/linux/generic/backport-5.15/422-v5.19-mtd-spi-nor-support-eon-en25qh256a.patch
+++ b/target/linux/generic/backport-5.15/422-v5.19-mtd-spi-nor-support-eon-en25qh256a.patch
@@ -1,0 +1,49 @@
+From 6abef37d16d0c570ef5a149e63762fba2a30804b Mon Sep 17 00:00:00 2001
+From: "Leon M. George" <leon@georgemail.eu>
+Date: Wed, 30 Mar 2022 16:16:56 +0200
+Subject: [PATCH] mtd: spi-nor: support eon en25qh256a variant
+
+The EN25QH256A variant of the EN25QH256 doesn't initialize correctly from SFDP
+alone and only accesses memory below 8m (addr_width is 4 but read_opcode takes
+only 3 bytes).
+
+Set SNOR_F_4B_OPCODES if the flash chip variant was detected using hwcaps.
+
+The fix submitted upstream uses the PARSE_SFDP initializer that is not
+available in the kernel used with Openwrt.
+
+Signed-off-by: Leon M. George <leon@georgemail.eu>
+---
+ drivers/mtd/spi-nor/eon.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+--- a/drivers/mtd/spi-nor/eon.c
++++ b/drivers/mtd/spi-nor/eon.c
+@@ -8,6 +8,16 @@
+ 
+ #include "core.h"
+ 
++static void en25qh256_post_sfdp_fixups(struct spi_nor *nor)
++{
++	if (nor->params->hwcaps.mask & SNOR_HWCAPS_READ_1_1_4)
++		nor->flags |= SNOR_F_4B_OPCODES;
++}
++
++static const struct spi_nor_fixups en25qh256_fixups = {
++	.post_sfdp = en25qh256_post_sfdp_fixups,
++};
++
+ static const struct flash_info eon_parts[] = {
+ 	/* EON -- en25xxx */
+ 	{ "en25f32",    INFO(0x1c3116, 0, 64 * 1024,   64, SECT_4K) },
+@@ -23,7 +33,9 @@ static const struct flash_info eon_parts
+ 	{ "en25qh64",   INFO(0x1c7017, 0, 64 * 1024,  128,
+ 			     SECT_4K | SPI_NOR_DUAL_READ) },
+ 	{ "en25qh128",  INFO(0x1c7018, 0, 64 * 1024,  256, 0) },
+-	{ "en25qh256",  INFO(0x1c7019, 0, 64 * 1024,  512, 0) },
++	{ "en25qh256",  INFO(0x1c7019, 0, 64 * 1024,  512,
++		SPI_NOR_DUAL_READ)
++		.fixups = &en25qh256_fixups },
+ 	{ "en25s64",	INFO(0x1c3817, 0, 64 * 1024,  128, SECT_4K) },
+ };
+ 

--- a/target/linux/generic/pending-5.10/476-mtd-spi-nor-add-eon-en25q128.patch
+++ b/target/linux/generic/pending-5.10/476-mtd-spi-nor-add-eon-en25q128.patch
@@ -8,7 +8,7 @@ Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>
 
 --- a/drivers/mtd/spi-nor/eon.c
 +++ b/drivers/mtd/spi-nor/eon.c
-@@ -15,6 +15,7 @@ static const struct flash_info eon_parts
+@@ -25,6 +25,7 @@ static const struct flash_info eon_parts
  	{ "en25q32b",   INFO(0x1c3016, 0, 64 * 1024,   64, 0) },
  	{ "en25p64",    INFO(0x1c2017, 0, 64 * 1024,  128, 0) },
  	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },

--- a/target/linux/generic/pending-5.10/477-mtd-spi-nor-add-eon-en25qx128a.patch
+++ b/target/linux/generic/pending-5.10/477-mtd-spi-nor-add-eon-en25qx128a.patch
@@ -11,7 +11,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/mtd/spi-nor/eon.c
 +++ b/drivers/mtd/spi-nor/eon.c
-@@ -16,6 +16,7 @@ static const struct flash_info eon_parts
+@@ -26,6 +26,7 @@ static const struct flash_info eon_parts
  	{ "en25p64",    INFO(0x1c2017, 0, 64 * 1024,  128, 0) },
  	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },
  	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256, SECT_4K) },

--- a/target/linux/generic/pending-5.15/476-mtd-spi-nor-add-eon-en25q128.patch
+++ b/target/linux/generic/pending-5.15/476-mtd-spi-nor-add-eon-en25q128.patch
@@ -8,7 +8,7 @@ Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>
 
 --- a/drivers/mtd/spi-nor/eon.c
 +++ b/drivers/mtd/spi-nor/eon.c
-@@ -15,6 +15,7 @@ static const struct flash_info eon_parts
+@@ -25,6 +25,7 @@ static const struct flash_info eon_parts
  	{ "en25q32b",   INFO(0x1c3016, 0, 64 * 1024,   64, 0) },
  	{ "en25p64",    INFO(0x1c2017, 0, 64 * 1024,  128, 0) },
  	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },

--- a/target/linux/generic/pending-5.15/477-mtd-spi-nor-add-eon-en25qx128a.patch
+++ b/target/linux/generic/pending-5.15/477-mtd-spi-nor-add-eon-en25qx128a.patch
@@ -11,7 +11,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/mtd/spi-nor/eon.c
 +++ b/drivers/mtd/spi-nor/eon.c
-@@ -16,6 +16,7 @@ static const struct flash_info eon_parts
+@@ -26,6 +26,7 @@ static const struct flash_info eon_parts
  	{ "en25p64",    INFO(0x1c2017, 0, 64 * 1024,  128, 0) },
  	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },
  	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256, SECT_4K) },

--- a/target/linux/ramips/dts/mt7621_cudy_m1800.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_m1800.dts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "cudy,m1800", "mediatek,mt7621-soc";
+	model = "Cudy M1800";
+
+	aliases {
+		led-boot = &led_internet_white;
+		led-failsafe = &led_internet_white;
+		led-running = &led_internet_white;
+		led-upgrade = &led_internet_white;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_internet_white: internet-white {
+			label = "white:internet";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		internet-red {
+			label = "red:internet";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&gmac1 {
+	status = "okay";
+	label = "lan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		mediatek,disable-radar-background;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+		broken-flash-reset;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+
+			partition@1000000 {
+				label = "app";
+				reg = <0x1000000 0xfd0000>;
+				read-only;
+			};
+
+			partition@1fd0000 {
+				label = "debug";
+				reg = <0x1fd0000 0x10000>;
+				read-only;
+			};
+
+			partition@1fe0000 {
+				label = "backup";
+				reg = <0x1fe0000 0x10000>;
+				read-only;
+			};
+
+			partition@1ff0000 {
+				label = "bdinfo";
+				reg = <0x1ff0000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_bdinfo_de00: macaddr@de00 {
+					reg = <0xde00 0x6>;
+				};
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart3";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@3 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -426,6 +426,16 @@ define Device/bolt_arion
 endef
 TARGET_DEVICES += bolt_arion
 
+define Device/cudy_m1800
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := M1800
+  IMAGE_SIZE := 16064k
+  UIMAGE_NAME := R17
+  DEVICE_PACKAGES := kmod-mt7915e
+endef
+TARGET_DEVICES += cudy_m1800
+
 define Device/cudy_wr1300-v1
   $(Device/dsa-migration)
   IMAGE_SIZE := 15872k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -78,6 +78,11 @@ ramips_setup_interfaces()
 		uci add_list firewall.@zone[1].network='eth_data'
 		uci add_list firewall.@zone[1].network='eth_om'
 		;;
+	cudy,m1800|\
+	yuncore,ax820|\
+	zyxel,nt7101)
+		ucidef_set_interfaces_lan_wan "lan" "wan"
+		;;
 	gnubee,gb-pc1)
 		ucidef_set_interface_lan "ethblack ethblue"
 		;;
@@ -116,10 +121,6 @@ ramips_setup_interfaces()
 		;;
 	ubnt,usw-flex)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"
-		;;
-	yuncore,ax820|\
-	zyxel,nr7101)
-		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
 	zyxel,wap6805)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"


### PR DESCRIPTION
Current state:

I'm happy with it. Removing "WIP".
The patch for spi-nor works differently upstream (adding `PARSE_SFDP` instead of manually fiddling around with capabs and opcodes).


Previous message:

The image boots.

Known to not work:
- WiFi (no calibration in the factory partition. entries in `/sys/class/phy` exist, `iw phy` output is empty.)

Notable changes:

- A patch adds the `SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ` flags to the SPI-NOR flags of the en25qh256.

Previous message:

<details><summary>LAN port</summary>


```
6: wan@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master br-n_0 state UP mode DEFAULT group default qlen 1000
    link/ether b4:4b:d6:2e:cd:f1 brd ff:ff:ff:ff:ff:ff
7: lan@eth0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether b4:4b:d6:2e:cd:f0 brd ff:ff:ff:ff:ff:ff
```

</details>

<details><summary>factory partition dump (WiFi)</summary>

```
[root@996 /sys/class/phy] $ hexdump -C /dev/mtd2
00000000  15 79 00 00 00 0c 43 26  46 28 00 0c 43 26 59 97  |.y....C&F(..C&Y.|
00000010  15 79 c3 14 00 80 02 00  15 79 c3 14 ec 90 01 00  |.y.......y......|
00000020  16 79 c3 14 00 80 02 00  16 79 c3 14 ec 94 01 00  |.y.......y......|
00000030  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000040  00 00 00 00 00 00 00 00  00 00 80 00 00 00 00 00  |................|
00000050  01 00 80 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000060  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000070  30 1c 0b 00 00 00 07 ab  8e 00 00 00 00 00 00 00  |0...............|
00000080  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
000000a0  00 00 00 00 00 00 00 00  bf 87 a1 40 f5 a7 9e 7e  |...........@...~|
000000b0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000190  92 52 06 aa 28 00 00 15  00 00 00 00 00 00 00 00  |.R..(...........|
000001a0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
000001d0  01 00 fe fd fd fd f8 f9  01 00 fe fd fd fd f8 f9  |................|
000001e0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000230  00 00 00 00 00 00 00 00  00 00 e4 e4 ee ee fa fa  |................|
00000240  06 06 16 16 df df e7 e7  f3 f3 fb fb 03 03 0b 0b  |................|
00000250  25 25 c2 c2 c2 c2 c2 c1  00 c2 00 c2 c2 c1 81 81  |%%..............|
00000260  84 85 c2 c2 c2 c1 80 81  83 84 00 c2 c2 c2 c1 81  |................|
00000270  81 84 84 87 87 c2 c2 c2  c1 00 81 83 84 87 87 c2  |................|
00000280  c2 c2 c1 81 81 84 84 87  87 c2 c2 c2 c1 81 81 84  |................|
00000290  84 87 87 c2 c2 c2 c1 81  81 84 84 87 87 c4 c4 c2  |................|
000002a0  c1 00 c4 00 c4 c2 c1 00  82 83 85 c4 c4 c2 c1 00  |................|
000002b0  82 83 85 00 c4 c4 c2 c1  00 82 83 85 00 00 00 c4  |................|
000002c0  c4 c2 c1 00 82 83 85 86  86 c4 c4 c2 c1 00 82 83  |................|
000002d0  85 86 86 c4 c4 c2 c1 00  82 83 85 86 86 c4 c4 c2  |................|
000002e0  c1 00 82 83 85 86 86 c4  c4 c2 c1 00 82 83 85 86  |................|
000002f0  86 c4 c4 c2 c1 00 82 83  85 86 86 02 27 00 02 27  |............'..'|
00000300  00 02 27 00 02 27 00 00  aa aa aa aa aa aa aa aa  |..'..'..........|
00000310  aa 33 33 33 33 33 33 33  33 33 00 00 00 00 00 00  |.333333333......|
00000320  00 00 00 00 00 00 00 00  00 00 00 00 00 4c 58 65  |.............LXe|
00000330  71 7d 00 4d 59 65 72 7e  00 4c 58 64 70 7c 00 4c  |q}.MYer~.LXdp|.L|
00000340  58 64 70 7c 88 88 88 88  03 03 03 26 26 26 26 26  |Xdp|.......&&&&&|
00000350  26 26 26 00 03 03 03 26  26 26 26 26 26 26 26 00  |&&&....&&&&&&&&.|
00000360  03 03 03 26 26 26 26 26  26 26 26 00 03 03 03 26  |...&&&&&&&&....&|
00000370  26 26 26 26 26 26 26 00  00 00 00 00 00 00 00 00  |&&&&&&&.........|
00000380  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
000003e0  00 00 00 00 00 00 dd dd  dd aa aa aa 22 22 22 33  |............"""3|
000003f0  33 33 33 33 33 99 99 99  99 99 99 11 11 11 aa aa  |33333...........|
00000400  aa ff ff ff ff ff ff 99  99 99 99 99 99 cc cc cc  |................|
00000410  00 00 00 00 00 00 aa aa  aa 11 11 11 44 44 44 44  |............DDDD|
00000420  44 44 44 44 44 88 88 88  88 88 88 11 11 11 99 99  |DDDDD...........|
00000430  99 ee ee ee cc cc cc 11  11 11 11 11 11 aa aa aa  |................|
00000440  08 42 51 51 63 74 08 42  51 51 64 74 08 42 51 51  |.BQQct.BQQdt.BQQ|
00000450  64 74 08 42 51 51 64 74  08 42 51 51 64 74 08 42  |dt.BQQdt.BQQdt.B|
00000460  51 51 64 74 08 43 54 54  66 74 08 42 56 56 68 74  |QQdt.CTTft.BVVht|
00000470  08 42 51 51 63 72 08 42  51 51 63 74 08 42 50 50  |.BQQcr.BQQct.BPP|
00000480  63 74 08 42 51 51 63 75  08 42 51 51 63 74 08 42  |ct.BQQcu.BQQct.B|
00000490  51 51 63 74 08 42 53 53  65 76 08 42 55 55 66 79  |QQct.BSSev.BUUfy|
000004a0  08 42 51 51 64 74 08 42  51 51 64 75 08 42 51 51  |.BQQdt.BQQdu.BQQ|
000004b0  64 75 08 42 51 51 65 75  08 43 51 51 64 75 08 44  |du.BQQeu.CQQdu.D|
000004c0  52 52 65 76 08 44 54 54  67 78 08 43 56 56 68 7a  |RRev.DTTgx.CVVhz|
000004d0  08 42 51 51 63 74 08 43  52 52 64 76 08 42 51 51  |.BQQct.CRRdv.BQQ|
000004e0  64 74 08 42 51 51 64 74  08 44 53 53 66 77 08 44  |dt.BQQdt.DSSfw.D|
000004f0  53 53 66 77 08 44 55 55  68 79 08 43 57 57 69 7b  |SSfw.DUUhy.CWWi{|
00000500  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
*
00000520  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
000007b0  00 00 00 00 00 00 00 00  00 00 00 00 00 26 25 00  |.............&%.|
000007c0  00 00 00 00 00 00 00 00  00 00 00 00 00 88 00 90  |................|
000007d0  00 90 00 88 00 00 00 00  00 00 00 00 00 00 00 00  |................|
000007e0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000800  00 00 da 97 64 42 11 00  87 00 e9 a8 65 32 22 00  |....dB......e2".|
00000810  86 00 eb b9 75 53 22 00  86 00 ba 86 54 33 02 00  |....uS".....T3..|
00000820  86 00 0c 0c 0c 0c 0d 0d  0d 0d 00 00 00 00 00 03  |................|
00000830  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
000008c0  86 84 85 83 00 00 00 00  00 00 00 00 00 00 00 00  |................|
000008d0  00 e8 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
000008e0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000900  43 c0 c3 c0 43 c1 43 c1  c0 cd 40 cc 40 cb 42 ca  |C...C.C...@.@.B.|
00000910  3e cc 3e cc 3d cc 40 ca  be cb be ca 3e cb c0 ca  |>.>.=.@.....>...|
00000920  3e cc 3e cc 3e cc be ca  c0 cd c0 cb 40 cb 42 ca  |>.>.>.......@.B.|
00000930  be cb 3e cb 3e cb 3e cc  40 ce c0 ca 40 ca c0 c9  |..>.>.>.@...@...|
00000940  40 c9 40 c9 40 c9 40 c9  00 00 00 00 00 00 00 00  |@.@.@.@.........|
00000950  41 cd 41 cd 41 cd 41 cd  00 00 00 00 00 00 00 00  |A.A.A.A.........|
00000960  c0 cf c0 cf c0 cf c0 cf  c0 cf c0 cf c0 cf c0 cf  |................|
00000970  c0 ce c0 ce c0 ce c0 ce  c0 ce c0 ce c0 ce c0 ce  |................|
00000980  c0 d3 c0 d1 40 d1 c0 d0  c0 d1 c0 d1 c0 d1 40 d3  |....@.........@.|
00000990  40 d4 40 d1 c0 d0 40 d0  c0 d0 c0 d0 c0 d0 40 d0  |@.@...@.......@.|
000009a0  02 ab 00 00 00 01 c0 00  b9 84 84 00 00 00 00 00  |................|
000009b0  db eb 79 00 6b 6c 89 65  18 18 18 18 18 18 18 18  |..y.kl.e........|
000009c0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00000a00  00 4c 58 64 70 7b 00 4c  58 64 71 7c 00 4b 58 63  |.LXdp{.LXdq|.KXc|
00000a10  70 7a 00 4b 58 63 70 7a  00 00 00 00 08 48 48 5a  |pz.KXcpz.....HHZ|
00000a20  69 7a 08 48 48 5a 69 7a  08 48 48 5a 69 7a 08 48  |iz.HHZiz.HHZiz.H|
00000a30  48 5a 69 7a 08 48 48 5a  69 7a 08 48 48 5a 69 7a  |HZiz.HHZiz.HHZiz|
00000a40  08 48 48 5a 69 7a 08 48  48 5a 69 7a 08 48 48 5a  |.HHZiz.HHZiz.HHZ|
00000a50  6c 75 08 48 48 5a 6c 75  08 48 48 5a 6c 75 08 48  |lu.HHZlu.HHZlu.H|
00000a60  48 5a 6c 75 08 48 48 5a  6c 75 08 48 48 5a 6c 75  |HZlu.HHZlu.HHZlu|
00000a70  08 48 48 5a 6c 75 08 48  48 5a 6c 75 08 47 47 5a  |.HHZlu.HHZlu.GGZ|
00000a80  69 7a 08 49 49 59 6c 79  08 48 48 59 6b 79 08 48  |iz.IIYly.HHYky.H|
00000a90  48 5a 6c 78 08 49 49 58  69 78 08 49 49 58 69 78  |HZlx.IIXix.IIXix|
00000aa0  08 48 48 58 6b 78 08 4a  4a 5b 6d 79 08 46 46 58  |.HHXkx.JJ[my.FFX|
00000ab0  69 79 08 48 48 59 6b 79  08 48 48 59 6b 78 08 48  |iy.HHYky.HHYkx.H|
00000ac0  48 59 6c 78 08 49 49 58  68 78 08 49 49 58 68 78  |HYlx.IIXhx.IIXhx|
00000ad0  08 49 49 57 6b 78 08 4a  4a 5b 6c 79 00 00 00 00  |.IIWkx.JJ[ly....|
00000ae0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000af0  00 00 00 00 00 00 00 00  00 00 00 00 00 01 ff fe  |................|
00000b00  fd fb 00 ff ff fe fd fa  00 ff ff fe fd fa 00 ff  |................|
00000b10  ff fe fd fa 00 ff ff fe  fd fa 00 00 fe fc fb fa  |................|
00000b20  00 ff fe fc fc f9 00 ff  fe fc fb f8 00 ff fe fc  |................|
00000b30  fa fa 00 ff fe fc fa fa  00 01 ff fd fa fa 00 fe  |................|
00000b40  00 fd fc fc 00 fe ff fd  fb fb 00 fe 00 fd fc fb  |................|
00000b50  00 fe 00 fd fb fc 00 02  ff ff ff fe 00 fd ff fe  |................|
00000b60  00 fe 00 fd ff ff 00 fe  00 fd ff fe 00 fe 00 fe  |................|
00000b70  ff ff 00 fe 13 00 f0 d6  c6 af a0 86 13 00 f0 d6  |................|
00000b80  c6 af a0 86 13 00 f0 d8  c6 af 9e 86 13 00 f0 d8  |................|
00000b90  c6 af 9e 86 13 00 f3 d8  c8 b1 a0 87 13 00 f3 d8  |................|
00000ba0  c8 b1 a0 87 10 00 ed d5  c5 ac 9b 84 10 00 ed d5  |................|
00000bb0  c5 ac 9b 84 10 00 f0 d5  c5 ad 9e 86 10 00 f0 d5  |................|
00000bc0  c5 ad 9e 86 10 00 f0 d8  c5 af 9e 88 10 00 f0 d8  |................|
00000bd0  c5 af 9e 88 0e 00 ee d6  c3 ad 9d 83 0e 00 ee d6  |................|
00000be0  c3 ad 9d 83 10 00 f0 da  c7 ac 9e 84 10 00 f0 da  |................|
00000bf0  c7 ac 9e 84 0f 00 ef d5  c6 ae 9f 86 0f 00 ef d5  |................|
00000c00  c6 ae 9f 86 10 00 ef da  c7 ae 9d 85 10 00 ef da  |................|
00000c10  c7 ae 9d 85 0f 00 ef d5  c7 af 9f 86 0f 00 ef d5  |................|
00000c20  c7 af 9f 86 10 00 f0 d8  c6 ae 9d 87 10 00 f0 d8  |................|
00000c30  c6 ae 9d 87 12 00 ef d7  c8 af 9f 89 12 00 ef d7  |................|
00000c40  c8 af 9f 89 10 00 ef d7  c7 ae a0 88 10 00 ef d7  |................|
00000c50  c7 ae a0 88 10 00 f1 d9  ca b0 a1 89 10 00 f1 d9  |................|
00000c60  ca b0 a1 89 10 00 ee d8  c9 b0 a0 86 10 00 ee d8  |................|
00000c70  c9 b0 a0 86 ff 00 fe 00  04 06 02 01 ff 00 fe 00  |................|
00000c80  04 06 02 01 03 00 fc fa  fa fb f5 f6 03 00 fc fa  |................|
00000c90  fa fb f5 f6 02 00 fc f9  f9 fa f3 f3 02 00 fc f9  |................|
00000ca0  f9 fa f3 f3 01 00 fc f9  f8 f9 f2 f2 01 00 fc f9  |................|
00000cb0  f8 f9 f2 f2 00 00 fd fa  fa fa f5 f4 00 00 fd fa  |................|
00000cc0  fa fa f5 f4 00 00 fe fc  fd fd f8 fa 00 00 fe fc  |................|
00000cd0  fd fd f8 fa ff 00 fe fc  fd fe f7 f9 ff 00 fe fc  |................|
00000ce0  fd fe f7 f9 fe 00 fe fc  ff fe f9 f7 fe 00 fe fc  |................|
00000cf0  ff fe f9 f7 ff 00 ff 00  05 07 03 04 ff 00 ff 00  |................|
00000d00  05 07 03 04 01 00 fc fa  fa fb f5 f6 01 00 fc fa  |................|
00000d10  fa fb f5 f6 01 00 fd fb  fb fc f7 f7 01 00 fd fb  |................|
00000d20  fb fc f7 f7 00 00 fd fb  fc fd f8 f9 00 00 fd fb  |................|
00000d30  fc fd f8 f9 ff 00 fc fc  fc fe f7 fa ff 00 fc fc  |................|
00000d40  fc fe f7 fa 00 00 fd fd  fe 00 fd fe 00 00 fd fd  |................|
00000d50  fe 00 fd fe ff 00 fd fd  fe 01 fc fb ff 00 fd fd  |................|
00000d60  fe 01 fc fb ff 00 fd fe  00 01 fe 04 ff 00 fd fe  |................|
00000d70  00 01 fe 04 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000d80  de e8 f4 00 0c d9 e1 ed  f5 01 09 11 00 00 00 00  |................|
00000d90  01 00 fc f9 f9 f8 f2 f3  01 00 fc f9 f9 f8 f2 f3  |................|
00000da0  02 00 fd fa fa f8 f2 f3  02 00 fd fa fa f8 f2 f3  |................|
00000db0  00 00 fd fc fc fc f7 f5  00 00 fd fc fc fc f7 f5  |................|
00000dc0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
00010000
```

</details>

This is the current state of my port for the Cudy M1800.
It's very similar to the WR2100 - notable differences being the case (cylinder) and the flash size (32MB).
The case is more difficult to open but the UART works without having to solder anything :-)

Again, Cudy has shared their DTS with me and I've adapted it to the current state of openwrt.

Original Message:
The firmware that was created from this branch doesn't boot because the rootfs partition isn't detected.

I've dug through `drivers/mtd/mtdpart.c` and created a few images, fiddling around with sizes and labels, but now I'm out of options.
Can someone help me?

This is the error:
```
[    1.708114] /dev/root: Can't open blockdev
[    1.712298] VFS: Cannot open root device "(null)" or unknown-block(0,0): error -6
[    1.719743] Please append a correct "root=" boot option; here are the available partitions:
[    1.728122] 1f00             192 mtdblock0 
[    1.728128]  (driver?)
[    1.734663] 1f01              64 mtdblock1 
[    1.734668]  (driver?)
[    1.741195] 1f02              64 mtdblock2 
[    1.741200]  (driver?)
[    1.747705] 1f03           16064 mtdblock3 
[    1.747709]  (driver?)
[    1.754235] 1f04           16192 mtdblock4 
[    1.754240]  (driver?)
[    1.760766] 1f05              64 mtdblock5 
[    1.760770]  (driver?)
[    1.767275] 1f06              64 mtdblock6 
[    1.767279]  (driver?)
[    1.773805] 1f07              64 mtdblock7 
[    1.773810]  (driver?)
[    1.780338] Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(0,0)
[    1.788591] Rebooting in 1 seconds..
```

I was expecting something like this:

```
[    2.623437] 2 uimage-fw partitions found on MTD device firmware
[    2.629367] 0x000000050000-0x00000039aec2 : "kernel"
[    2.635508] 0x00000039aec2-0x000001000000 : "rootfs"
[    2.641604] mtd: device 9 (rootfs) set to be root filesystem
[    2.647391] 1 squashfs-split partitions found on MTD device rootfs
```

<details><summary>whole boot</summary>
<p>

```
===================================================================
     		MT7621   stage1 code 10:33:55 (ASIC)
     		CPU=500000000 HZ BUS=166666666 HZ
==================================================================
Change MPLL source from XTAL to CR...
do MEMPLL setting..
MEMPLL Config : 0x11100000
3PLL mode + External loopback
=== XTAL-40Mhz === DDR-1200Mhz ===
PLL2 FB_DL: 0xc, 1/0 = 605/419 31000000
PLL3 FB_DL: 0x16, 1/0 = 625/399 59000000
PLL4 FB_DL: 0x16, 1/0 = 741/283 59000000
do DDR setting..[01F40000]
Apply DDR3 Setting...(use customer AC)
          0    8   16   24   32   40   48   56   64   72   80   88   96  104  112  120
      --------------------------------------------------------------------------------
0000:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0001:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0002:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0003:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0004:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0005:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0006:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0007:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0008:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0009:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
000A:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
000B:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
000C:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
000D:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    1
000E:|    0    0    0    0    0    0    0    0    0    1    1    1    1    1    1    1
000F:|    0    0    0    0    1    1    1    1    1    1    1    1    1    1    0    0
0010:|    1    1    1    1    1    1    1    1    0    0    0    0    0    0    0    0
0011:|    1    1    1    0    0    0    0    0    0    0    0    0    0    0    0    0
0012:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0013:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0014:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0015:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0016:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0017:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0018:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0019:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001A:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001B:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001C:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001D:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001E:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001F:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
rank 0 coarse = 15
rank 0 fine = 72
B:|    0    0    0    0    0    0    0    0    0    0    1    1    1    0    0    0
opt_dle value:11
DRAMC_R0DELDLY[018]=00002123
==================================================================
		RX	DQS perbit delay software calibration 
==================================================================
1.0-15 bit dq delay value
==================================================================
bit|     0  1  2  3  4  5  6  7  8  9
--------------------------------------
0 |    12 11 11 13 10 12 11 9 6 7 
10 |    9 9 8 11 9 11 
--------------------------------------

==================================================================
2.dqs window
x=pass dqs delay value (min~max)center 
y=0-7bit DQ of every group
input delay:DQS0 =35 DQS1 = 33
==================================================================
bit	DQS0	 bit      DQS1
0  (1~63)32  8  (1~62)31
1  (2~67)34  9  (2~64)33
2  (1~66)33  10  (1~62)31
3  (1~66)33  11  (1~61)31
4  (1~67)34  12  (1~61)31
5  (2~68)35  13  (2~62)32
6  (1~62)31  14  (1~66)33
7  (1~66)33  15  (1~62)31
==================================================================
3.dq delay value last
==================================================================
bit|    0  1  2  3  4  5  6  7  8   9
--------------------------------------
0 |    15 12 13 15 11 12 15 11 8 7 
10 |    11 11 10 12 9 13 
==================================================================
==================================================================
     TX  perbyte calibration 
==================================================================
DQS loop = 15, cmp_err_1 = ffff0000 
dqs_perbyte_dly.last_dqsdly_pass[0]=15,  finish count=1 
dqs_perbyte_dly.last_dqsdly_pass[1]=15,  finish count=2 
DQ loop=15, cmp_err_1 = ffff0000
dqs_perbyte_dly.last_dqdly_pass[0]=15,  finish count=1 
dqs_perbyte_dly.last_dqdly_pass[1]=15,  finish count=2 
byte:0, (DQS,DQ)=(8,8)
byte:1, (DQS,DQ)=(8,8)
20,data:88
[EMI] DRAMC calibration passed

===================================================================
     		MT7621   stage1 code done 
     		CPU=500000000 HZ BUS=166666666 HZ
===================================================================


U-Boot 1.1.3 (Mar  3 2022 - 11:36:47)

Board: Ralink APSoC DRAM:  256 MB
mtest end addr: 8ff31f88
relocate_code Pointer at: 8ff94000

Config XHCI 40M PLL 
******************************
Software System Reset Occurred
******************************
flash manufacture id: 1c, device id 70 19
find flash: en25qh256
*** Warning - bad CRC, using default environment

#Reset_MT7530
set LAN/WAN WLLLL
   
3: System Boot system code via Flash.
## Booting image at bc050000 ...
   Image Name:   R17
   Image Type:   MIPS Linux Kernel Image (lzma compressed)
   Data Size:    2740595 Bytes =  2.6 MB
   Load Address: 80001000
   Entry Point:  80001000
   Verifying Checksum ... OK
   Uncompressing Kernel Image ... OK
No initrd
## Transferring control to Linux (at address 80001000) ...
## Giving linux memsize in MB, 256

Starting kernel ...

[    0.000000] Linux version 5.10.100 (leon@brot) (mipsel-openwrt-linux-musl-gcc (OpenWrt GCC 11.2.0 r15812+2444-46b6ee7ffc) 11.2.0, GNU ld (GNU Binutils) 2.37) #0 SMP Fri Mar 11 19:57:11 2022
[    0.000000] SoC Type: MediaTek MT7621 ver:1 eco:3
[    0.000000] printk: bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 0001992f (MIPS 1004Kc)
[    0.000000] MIPS: machine is Cudy M1800
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] VPE topology {2,2} total 4
[    0.000000] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.000000] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000]   HighMem  empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000] percpu: Embedded 15 pages/cpu s30096 r8192 d23152 u61440
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 64960
[    0.000000] Kernel command line: console=ttyS0,115200 rootfstype=squashfs,jffs2
[    0.000000] Dentry cache hash table entries: 32768 (order: 5, 131072 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 4, 65536 bytes, linear)
[    0.000000] Writing ErrCtl register=000745cc
[    0.000000] Readback ErrCtl register=000745cc
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 249176K/262144K available (6687K kernel code, 619K rwdata, 1356K rodata, 1244K init, 235K bss, 12968K reserved, 0K cma-reserved, 0K highmem)
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] NR_IRQS: 256
[    0.000000] random: get_random_bytes called from start_kernel+0x3cc/0x5e4 with crng_init=0
[    0.000000] CPU Clock: 880MHz
[    0.000000] clocksource: GIC: mask: 0xffffffffffffffff max_cycles: 0xcaf478abb4, max_idle_ns: 440795247997 ns
[    0.000012] sched_clock: 64 bits at 880MHz, resolution 1ns, wraps every 4398046511103ns
[    0.007942] clocksource: MIPS: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 4343773742 ns
[    0.016918] Calibrating delay loop... 586.13 BogoMIPS (lpj=2930688)
[    0.083089] pid_max: default: 32768 minimum: 301
[    0.087852] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.095054] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.105416] rcu: Hierarchical SRCU implementation.
[    0.110408] dyndbg: Ignore empty _ddebug table in a CONFIG_DYNAMIC_DEBUG_CORE build
[    0.118424] smp: Bringing up secondary CPUs ...
[    0.123582] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.123593] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.123604] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.123681] CPU1 revision is: 0001992f (MIPS 1004Kc)
[    0.178312] Synchronize counters for CPU 1: done.
[    0.210649] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.210658] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.210666] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.210712] CPU2 revision is: 0001992f (MIPS 1004Kc)
[    0.269583] Synchronize counters for CPU 2: done.
[    0.300034] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.300042] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.300050] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.300098] CPU3 revision is: 0001992f (MIPS 1004Kc)
[    0.354762] Synchronize counters for CPU 3: done.
[    0.384625] smp: Brought up 1 node, 4 CPUs
[    0.392680] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.402495] futex hash table entries: 1024 (order: 3, 32768 bytes, linear)
[    0.409508] pinctrl core: initialized pinctrl subsystem
[    0.416721] NET: Registered protocol family 16
[    0.423552] cpuidle: using governor teo
[    0.450112] random: fast init done
[    0.470028] clocksource: Switched to clocksource GIC
[    0.477115] NET: Registered protocol family 2
[    0.481739] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.489686] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 6144 bytes, linear)
[    0.498034] TCP established hash table entries: 2048 (order: 1, 8192 bytes, linear)
[    0.505628] TCP bind hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.512716] TCP: Hash tables configured (established 2048 bind 2048)
[    0.519128] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.525605] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.532733] NET: Registered protocol family 1
[    0.537027] PCI: CLS 0 bytes, default 32
[    0.543170] workingset: timestamp_bits=14 max_order=16 bucket_order=2
[    0.553857] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.559605] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.572367] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.578184] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.584056] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.590649] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.598503] printk: console [ttyS0] disabled
[    0.602875] 1e000c00.uartlite: ttyS0 at MMIO 0x1e000c00 (irq = 19, base_baud = 3125000) is a 16550A
[    0.611873] printk: console [ttyS0] enabled
[    0.611873] printk: console [ttyS0] enabled
[    0.620134] printk: bootconsole [early0] disabled
[    0.620134] printk: bootconsole [early0] disabled
[    0.632267] spi-mt7621 1e000b00.spi: sys_freq: 220000000
[    0.639019] spi-nor spi0.0: en25qh256 (32768 Kbytes)
[    0.644217] 8 fixed-partitions partitions found on MTD device spi0.0
[    0.650566] Creating 8 MTD partitions on "spi0.0":
[    0.655341] 0x000000000000-0x000000030000 : "u-boot"
[    0.661433] 0x000000030000-0x000000040000 : "u-boot-env"
[    0.667720] 0x000000040000-0x000000050000 : "factory"
[    0.673842] 0x000000050000-0x000001000000 : "firmware"
[    0.690342] 0x000001000000-0x000001fd0000 : "app"
[    0.696057] 0x000001fd0000-0x000001fe0000 : "debug"
[    0.702013] 0x000001fe0000-0x000001ff0000 : "backup"
[    0.707949] 0x000001ff0000-0x000002000000 : "bdinfo"
[    0.761743] mt7530 mdio-bus:1f: MT7530 adapts as multi-chip module
[    0.771316] mtk_soc_eth 1e100000.ethernet eth0: mediatek frame engine at 0xbe100000, irq 21
[    0.780378] i2c /dev entries driver
[    0.786370] mt7621-pci 1e140000.pcie: host bridge /pcie@1e140000 ranges:
[    0.793106] mt7621-pci 1e140000.pcie:   No bus range found for /pcie@1e140000, using [bus 00-ff]
[    0.801907] mt7621-pci 1e140000.pcie:      MEM 0x0060000000..0x006fffffff -> 0x0000000000
[    0.810084] mt7621-pci 1e140000.pcie:       IO 0x001e160000..0x001e16ffff -> 0x0000000000
[    0.818322] mt7621-pci 1e140000.pcie: Parsing DT failed
[    0.825735] NET: Registered protocol family 10
[    0.831646] Segment Routing with IPv6
[    0.835415] NET: Registered protocol family 17
[    0.840351] 8021q: 802.1Q VLAN Support v1.8
[    0.847837] mt7530 mdio-bus:1f: MT7530 adapts as multi-chip module
[    0.875339] mt7530 mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7530 PHY] (irq=26)
[    0.887582] mt7530 mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7530 PHY] (irq=27)
[    0.899754] mt7530 mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7530 PHY] (irq=28)
[    0.911945] mt7530 mdio-bus:1f lan4 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7530 PHY] (irq=29)
[    0.924295] mt7530 mdio-bus:1f wan (uninitialized): PHY [mt7530-0:04] driver [MediaTek MT7530 PHY] (irq=30)
[    0.936713] mt7530 mdio-bus:1f: configuring for fixed/rgmii link mode
[    0.947151] DSA: tree 0 setup
[    0.950447] rt2880-pinmux pinctrl: pcie is already enabled
[    0.956005] mt7621-pci 1e140000.pcie: host bridge /pcie@1e140000 ranges:
[    0.962714] mt7621-pci 1e140000.pcie:   No bus range found for /pcie@1e140000, using [bus 00-ff]
[    0.971549] mt7621-pci 1e140000.pcie:      MEM 0x0060000000..0x006fffffff -> 0x0000000000
[    0.979704] mt7621-pci 1e140000.pcie:       IO 0x001e160000..0x001e16ffff -> 0x0000000000
[    0.987962] mt7621-pci-phy 1e149000.pcie-phy: PHY for 0xbe149000 (dual port = 1)
[    0.995711] mt7621-pci-phy 1e14a000.pcie-phy: PHY for 0xbe14a000 (dual port = 0)
[    1.003355] mt7621-pci 1e140000.pcie: failed to parse bus ranges property: -22
[    1.110741] mt7621-pci-phy 1e149000.pcie-phy: Xtal is 40MHz
[    1.116307] mt7621-pci-phy 1e14a000.pcie-phy: Xtal is 40MHz
[    1.222044] mt7621-pci 1e140000.pcie: pcie2 no card, disable it (RST & CLK)
[    1.228980] mt7621-pci 1e140000.pcie: PCIE0 enabled
[    1.233849] mt7621-pci 1e140000.pcie: PCIE1 enabled
[    1.238710] mt7621-pci 1e140000.pcie: PCI coherence region base: 0x60000000, mask/settings: 0xf0000002
[    1.248163] mt7621-pci 1e140000.pcie: PCI host bridge to bus 0000:00
[    1.254525] pci_bus 0000:00: root bus resource [io  0x1e160000-0x1e16ffff]
[    1.261392] pci_bus 0000:00: root bus resource [mem 0x60000000-0x6fffffff]
[    1.268239] pci_bus 0000:00: root bus resource [bus 00-ff]
[    1.273721] pci_bus 0000:00: root bus resource [mem 0x60000000-0x6fffffff] (bus address [0x00000000-0x0fffffff])
[    1.283915] pci 0000:00:00.0: [0e8d:0801] type 01 class 0x060400
[    1.289914] pci 0000:00:00.0: reg 0x10: [mem 0x00000000-0x7fffffff]
[    1.296179] pci 0000:00:00.0: reg 0x14: [mem 0x60400000-0x6040ffff]
[    1.302516] pci 0000:00:00.0: supports D1
[    1.306510] pci 0000:00:00.0: PME# supported from D0 D1 D3hot
[    1.312816] pci 0000:00:01.0: [0e8d:0801] type 01 class 0x060400
[    1.318836] pci 0000:00:01.0: reg 0x10: [mem 0x00000000-0x7fffffff]
[    1.325106] pci 0000:00:01.0: reg 0x14: [mem 0x60410000-0x6041ffff]
[    1.331425] pci 0000:00:01.0: supports D1
[    1.335418] pci 0000:00:01.0: PME# supported from D0 D1 D3hot
[    1.342817] pci 0000:01:00.0: [14c3:7916] type 00 class 0x000280
[    1.348852] pci 0000:01:00.0: reg 0x10: initial BAR value 0x00000000 invalid
[    1.355897] pci 0000:01:00.0: reg 0x10: [mem size 0x00100000 64bit pref]
[    1.362611] pci 0000:01:00.0: reg 0x18: initial BAR value 0x00000000 invalid
[    1.369628] pci 0000:01:00.0: reg 0x18: [mem size 0x00004000 64bit pref]
[    1.376328] pci 0000:01:00.0: reg 0x20: initial BAR value 0x00000000 invalid
[    1.383362] pci 0000:01:00.0: reg 0x20: [mem size 0x00001000 64bit pref]
[    1.390171] pci 0000:01:00.0: supports D1 D2
[    1.394425] pci 0000:01:00.0: PME# supported from D0 D1 D2 D3hot D3cold
[    1.401069] pci 0000:01:00.0: 2.000 Gb/s available PCIe bandwidth, limited by 2.5 GT/s PCIe x1 link at 0000:00:00.0 (capable of 4.000 Gb/s with 5.0 GT/s PCIe x1 link)
[    1.417305] pci 0000:00:00.0: PCI bridge to [bus 01-ff]
[    1.422559] pci 0000:00:00.0:   bridge window [io  0x0000-0x0fff]
[    1.428631] pci 0000:00:00.0:   bridge window [mem 0x60000000-0x601fffff pref]
[    1.435842] pci_bus 0000:01: busn_res: [bus 01-ff] end is updated to 01
[    1.442690] pci 0000:02:00.0: [14c3:7915] type 00 class 0x000280
[    1.448716] pci 0000:02:00.0: reg 0x10: initial BAR value 0x00000000 invalid
[    1.455757] pci 0000:02:00.0: reg 0x10: [mem size 0x00100000 64bit pref]
[    1.462462] pci 0000:02:00.0: reg 0x18: initial BAR value 0x00000000 invalid
[    1.469480] pci 0000:02:00.0: reg 0x18: [mem size 0x00004000 64bit pref]
[    1.476181] pci 0000:02:00.0: reg 0x20: initial BAR value 0x00000000 invalid
[    1.483233] pci 0000:02:00.0: reg 0x20: [mem size 0x00001000 64bit pref]
[    1.490058] pci 0000:02:00.0: supports D1 D2
[    1.494313] pci 0000:02:00.0: PME# supported from D0 D1 D2 D3hot D3cold
[    1.500956] pci 0000:02:00.0: 2.000 Gb/s available PCIe bandwidth, limited by 2.5 GT/s PCIe x1 link at 0000:00:01.0 (capable of 4.000 Gb/s with 5.0 GT/s PCIe x1 link)
[    1.517202] pci 0000:00:01.0: PCI bridge to [bus 02-ff]
[    1.522446] pci 0000:00:01.0:   bridge window [io  0x0000-0x0fff]
[    1.528516] pci 0000:00:01.0:   bridge window [mem 0x60200000-0x603fffff pref]
[    1.535735] pci_bus 0000:02: busn_res: [bus 02-ff] end is updated to 02
[    1.542393] pci 0000:00:00.0: BAR 0: no space for [mem size 0x80000000]
[    1.548978] pci 0000:00:00.0: BAR 0: failed to assign [mem size 0x80000000]
[    1.555928] pci 0000:00:01.0: BAR 0: no space for [mem size 0x80000000]
[    1.562529] pci 0000:00:01.0: BAR 0: failed to assign [mem size 0x80000000]
[    1.569465] pci 0000:00:00.0: BAR 9: assigned [mem 0x60000000-0x601fffff pref]
[    1.576674] pci 0000:00:01.0: BAR 9: assigned [mem 0x60200000-0x603fffff pref]
[    1.583885] pci 0000:00:00.0: BAR 1: assigned [mem 0x60400000-0x6040ffff]
[    1.590670] pci 0000:00:01.0: BAR 1: assigned [mem 0x60410000-0x6041ffff]
[    1.597431] pci 0000:00:00.0: BAR 7: assigned [io  0x1e160000-0x1e160fff]
[    1.604214] pci 0000:00:01.0: BAR 7: assigned [io  0x1e161000-0x1e161fff]
[    1.611002] pci 0000:01:00.0: BAR 0: assigned [mem 0x60000000-0x600fffff 64bit pref]
[    1.618724] pci 0000:01:00.0: BAR 2: assigned [mem 0x60100000-0x60103fff 64bit pref]
[    1.626463] pci 0000:01:00.0: BAR 4: assigned [mem 0x60104000-0x60104fff 64bit pref]
[    1.634201] pci 0000:00:00.0: PCI bridge to [bus 01]
[    1.639145] pci 0000:00:00.0:   bridge window [io  0x1e160000-0x1e160fff]
[    1.645922] pci 0000:00:00.0:   bridge window [mem 0x60000000-0x601fffff pref]
[    1.653144] pci 0000:02:00.0: BAR 0: assigned [mem 0x60200000-0x602fffff 64bit pref]
[    1.660891] pci 0000:02:00.0: BAR 2: assigned [mem 0x60300000-0x60303fff 64bit pref]
[    1.668612] pci 0000:02:00.0: BAR 4: assigned [mem 0x60304000-0x60304fff 64bit pref]
[    1.676347] pci 0000:00:01.0: PCI bridge to [bus 02]
[    1.681308] pci 0000:00:01.0:   bridge window [io  0x1e161000-0x1e161fff]
[    1.688068] pci 0000:00:01.0:   bridge window [mem 0x60200000-0x603fffff pref]
[    1.697467] /dev/root: Can't open blockdev
[    1.701632] VFS: Cannot open root device "(null)" or unknown-block(0,0): error -6
[    1.709079] Please append a correct "root=" boot option; here are the available partitions:
[    1.717427] 1f00             192 mtdblock0 
[    1.717433]  (driver?)
[    1.723969] 1f01              64 mtdblock1 
[    1.723973]  (driver?)
[    1.730494] 1f02              64 mtdblock2 
[    1.730499]  (driver?)
[    1.737003] 1f03           16064 mtdblock3 
[    1.737007]  (driver?)
[    1.743529] 1f04           16192 mtdblock4 
[    1.743534]  (driver?)
[    1.750053] 1f05              64 mtdblock5 
[    1.750057]  (driver?)
[    1.756562] 1f06              64 mtdblock6 
[    1.756566]  (driver?)
[    1.763088] 1f07              64 mtdblock7 
[    1.763093]  (driver?)
[    1.769595] Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(0,0)
[    1.777847] Rebooting in 1 seconds..
```

</p>
</details>