### PR TITLE
base-files: improve compatibility of "mtd_get_mac_ascii"

### DIFF
--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -74,6 +74,9 @@ mtd_get_mac_ascii() {
 	fi
 
 	mac_dirty=$(strings "$part" | sed -n 's/^'"$key"'=//p')
+	if [ -z "$mac_dirty" ]; then
+		mac_dirty=$(strings "$part" | sed -n 's/^.*'"$key"'=//p' | sed -n '2,$dp' )
+	fi
 
 	# "canonicalize" mac
 	[ -n "$mac_dirty" ] && macaddr_canonicalize "$mac_dirty"


### PR DESCRIPTION
The crc value of the environment variable may generate some extra visible characters in front of "$key" and make it impossible to match "$key". This commit handles this special case.