### PR TITLE
Add {arp,eb}tables-nft, rename curent versions to {arp,eb}tables-legacy

### DIFF
--- a/package/network/utils/arptables/Makefile
+++ b/package/network/utils/arptables/Makefile
@@ -19,22 +19,25 @@ PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/arptables
+define Package/arptables-legacy
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Firewall
   TITLE:=ARP firewalling software
   DEPENDS:=+kmod-arptables
   URL:=https://git.netfilter.org/arptables/
+  PROVIDES:=arptables
+  ALTERNATIVES:=\
+    200:/usr/sbin/arptables:/usr/sbin/arptables-legacy
 endef
 
 MAKE_FLAGS += \
 	COPT_FLAGS="$(TARGET_CFLAGS) -D__OPTIMIZE__=1" \
 	KERNEL_DIR="$(LINUX_DIR)"
 
-define Package/arptables/install
+define Package/arptables-legacy/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(CP) $(PKG_BUILD_DIR)/$(PKG_NAME) $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/arptables $(1)/usr/sbin/arptables-legacy
 endef
 
-$(eval $(call BuildPackage,arptables))
+$(eval $(call BuildPackage,arptables-legacy))

--- a/package/network/utils/ebtables/Makefile
+++ b/package/network/utils/ebtables/Makefile
@@ -20,30 +20,36 @@ PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/ebtables
+define Package/ebtables-legacy
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Firewall
   DEPENDS:=+kmod-ebtables
   TITLE:=Ethernet bridge firewall administration utility
   URL:=http://ebtables.sourceforge.net/
+  PROVIDES:=ebtables
+  ALTERNATIVES:=\
+    200:/usr/sbin/ebtables:/usr/sbin/ebtables-legacy
 endef
 
-define Package/ebtables-utils
-  $(call Package/ebtables)
-  DEPENDS += ebtables
+define Package/ebtables-legacy-utils
+  $(call Package/ebtables-legacy)
+  DEPENDS:=ebtables-legacy
   TITLE:=ebtables save/restore utilities
+  PROVIDES:=ebtables-utils
+  ALTERNATIVES:=\
+    200:/usr/sbin/ebtables-restore:/usr/sbin/ebtables-legacy-restore
 endef
 
-define Package/ebtables/description
+define Package/ebtables-legacy/description
 	The ebtables program is a filtering tool for a bridging firewall. The
 	filtering is focussed on the Link Layer Ethernet frame fields. Apart
 	from filtering, it also gives the ability to alter the Ethernet MAC
 	addresses and implement a brouter.
 endef
 
-define Package/ebtables-utils/description
-	$(call Package/ebtables/description)
+define Package/ebtables-legacy-utils/description
+	$(call Package/ebtables-legacy/description)
 endef
 
 MAKE_VARS += EXT_LIBSI="$(LIBGCC_S)"
@@ -52,21 +58,22 @@ MAKE_FLAGS += \
 	CFLAGS="$(TARGET_CFLAGS)" \
 	LIBDIR="/usr/lib/ebtables"
 
-define Package/ebtables/install
+define Package/ebtables-legacy/install
 	$(INSTALL_DIR) $(1)/etc
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/ethertypes $(1)/etc/
 	$(INSTALL_DIR) $(1)/usr/lib/ebtables
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib*.so $(1)/usr/lib/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/extensions/*.so $(1)/usr/lib/ebtables/
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ebtables $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ebtables $(1)/usr/sbin/ebtables-legacy
 endef
 
-define Package/ebtables-utils/install
+define Package/ebtables-legacy-utils/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ebtables-save $(1)/usr/sbin/
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ebtables-restore $(1)/usr/sbin/
+	#ebtables-save depends on perl and is just broken
+	#$(INSTALL_BIN) $(PKG_BUILD_DIR)/ebtables-save $(1)/usr/sbin/ebtables-legacy-save
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ebtables-restore $(1)/usr/sbin/ebtables-legacy-restore
 endef
 
-$(eval $(call BuildPackage,ebtables))
-$(eval $(call BuildPackage,ebtables-utils))
+$(eval $(call BuildPackage,ebtables-legacy))
+$(eval $(call BuildPackage,ebtables-legacy-utils))

--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -107,6 +107,28 @@ $(call Package/iptables/Default)
   DEPENDS:=@IPTABLES_NFTABLES +libnftnl +libiptext +IPV6:libiptext6 +libiptext-nft +kmod-nft-compat
 endef
 
+define Package/arptables-nft
+$(call Package/iptables/Default)
+  DEPENDS:=+kmod-nft-arp +xtables-nft +kmod-arptables
+  TITLE:=ARP firewall administration tool nft
+  PROVIDES:=arptables
+  ALTERNATIVES:=\
+    300:/usr/sbin/arptables:/usr/sbin/xtables-nft-multi \
+    300:/usr/sbin/arptables-restore:/usr/sbin/xtables-nft-multi \
+    300:/usr/sbin/arptables-save:/usr/sbin/xtables-nft-multi
+endef
+
+define Package/ebtables-nft
+$(call Package/iptables/Default)
+  DEPENDS:=+kmod-nft-bridge +xtables-nft +kmod-ebtables
+  TITLE:=Bridge firewall administration tool nft
+  PROVIDES:=ebtables
+  ALTERNATIVES:=\
+    300:/usr/sbin/ebtables:/usr/sbin/xtables-nft-multi \
+    300:/usr/sbin/ebtables-restore:/usr/sbin/xtables-nft-multi \
+    300:/usr/sbin/ebtables-save:/usr/sbin/xtables-nft-multi
+endef
+
 define Package/iptables-nft
 $(call Package/iptables/Default)
   TITLE:=IP firewall administration tool nft
@@ -666,6 +688,20 @@ define Package/xtables-nft/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/xtables-nft-multi $(1)/usr/sbin/
 endef
 
+define Package/arptables-nft/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/arptables-nft{,-restore,-save} $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/lib/iptables
+	$(CP) $(PKG_BUILD_DIR)/extensions/libarpt_*.so $(1)/usr/lib/iptables/
+endef
+
+define Package/ebtables-nft/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/ebtables-nft{,-restore,-save} $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/lib/iptables
+	$(CP) $(PKG_BUILD_DIR)/extensions/libebt_*.so $(1)/usr/lib/iptables/
+endef
+
 define Package/iptables-nft/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/iptables-nft{,-restore,-save} $(1)/usr/sbin/
@@ -737,6 +773,8 @@ $(eval $(call BuildPackage,libiptext-nft))
 $(eval $(call BuildPackage,xtables-legacy))
 $(eval $(call BuildPackage,iptables-legacy))
 $(eval $(call BuildPackage,xtables-nft))
+$(eval $(call BuildPackage,arptables-nft))
+$(eval $(call BuildPackage,ebtables-nft))
 $(eval $(call BuildPackage,iptables-nft))
 $(eval $(call BuildPlugin,iptables-mod-conntrack-extra,$(IPT_CONNTRACK_EXTRA-m)))
 $(eval $(call BuildPlugin,iptables-mod-conntrack-label,$(IPT_CONNTRACK_LABEL-m)))

--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -101,10 +101,16 @@ IP firewall administration tool.
 
 endef
 
+define Package/xtables-nft
+$(call Package/iptables/Default)
+  TITLE:=IP firewall administration tool nft
+  DEPENDS:=@IPTABLES_NFTABLES +libnftnl +libiptext +IPV6:libiptext6 +libiptext-nft +kmod-nft-compat
+endef
+
 define Package/iptables-nft
 $(call Package/iptables/Default)
   TITLE:=IP firewall administration tool nft
-  DEPENDS:=@IPTABLES_NFTABLES +libnftnl +libiptext +IPV6:libiptext6 +libiptext-nft +kmod-ipt-core +kmod-nft-compat
+  DEPENDS:=+kmod-ipt-core +xtables-nft
   PROVIDES:=iptables
   ALTERNATIVES:=\
     300:/usr/sbin/iptables:/usr/sbin/xtables-nft-multi \
@@ -469,7 +475,7 @@ endef
 
 define Package/ip6tables-nft
 $(call Package/iptables/Default)
-  DEPENDS:=@IPV6 +kmod-ip6tables +iptables-nft
+  DEPENDS:=@IPV6 +kmod-ip6tables +xtables-nft
   TITLE:=IP firewall administration tool nft
   PROVIDES:=ip6tables
   ALTERNATIVES:=\
@@ -655,9 +661,13 @@ define Package/iptables-legacy/install
 	$(INSTALL_DIR) $(1)/usr/lib/iptables
 endef
 
-define Package/iptables-nft/install
+define Package/xtables-nft/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/xtables-nft-multi $(1)/usr/sbin/
+endef
+
+define Package/iptables-nft/install
+	$(INSTALL_DIR) $(1)/usr/sbin
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/iptables-nft{,-restore,-save} $(1)/usr/sbin/
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/iptables{,-restore}-translate $(1)/usr/sbin/
 endef
@@ -726,6 +736,7 @@ $(eval $(call BuildPackage,libiptext6))
 $(eval $(call BuildPackage,libiptext-nft))
 $(eval $(call BuildPackage,xtables-legacy))
 $(eval $(call BuildPackage,iptables-legacy))
+$(eval $(call BuildPackage,xtables-nft))
 $(eval $(call BuildPackage,iptables-nft))
 $(eval $(call BuildPlugin,iptables-mod-conntrack-extra,$(IPT_CONNTRACK_EXTRA-m)))
 $(eval $(call BuildPlugin,iptables-mod-conntrack-label,$(IPT_CONNTRACK_LABEL-m)))

--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -44,10 +44,16 @@ $(call Package/iptables/Default)
   DEPENDS:=+libxtables $(1)
 endef
 
-define Package/iptables-legacy
+define Package/xtables-legacy
 $(call Package/iptables/Default)
   TITLE:=IP firewall administration tool
   DEPENDS+= +kmod-ipt-core +libip4tc +IPV6:libip6tc +libiptext +IPV6:libiptext6 +libxtables
+endef
+
+define Package/iptables-legacy
+$(call Package/iptables/Default)
+  TITLE:=IP firewall administration tool
+  DEPENDS+= +xtables-legacy
   PROVIDES:=iptables
   ALTERNATIVES:=\
     200:/usr/sbin/iptables:/usr/sbin/xtables-legacy-multi \
@@ -451,7 +457,7 @@ endef
 
 define Package/ip6tables-legacy
 $(call Package/iptables/Default)
-  DEPENDS:=@IPV6 +kmod-ip6tables +iptables-legacy
+  DEPENDS:=@IPV6 +kmod-ip6tables +xtables-legacy
   CATEGORY:=Network
   TITLE:=IPv6 firewall administration tool
   PROVIDES:=ip6tables
@@ -638,9 +644,13 @@ define Build/InstallDev
 	$(CP) $(PKG_BUILD_DIR)/extensions/libiptext*.so $(1)/usr/lib/
 endef
 
-define Package/iptables-legacy/install
+define Package/xtables-legacy/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/xtables-legacy-multi $(1)/usr/sbin/
+endef
+
+define Package/iptables-legacy/install
+	$(INSTALL_DIR) $(1)/usr/sbin
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/iptables-legacy{,-restore,-save} $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/usr/lib/iptables
 endef
@@ -714,6 +724,7 @@ $(eval $(call BuildPackage,libip6tc))
 $(eval $(call BuildPackage,libiptext))
 $(eval $(call BuildPackage,libiptext6))
 $(eval $(call BuildPackage,libiptext-nft))
+$(eval $(call BuildPackage,xtables-legacy))
 $(eval $(call BuildPackage,iptables-legacy))
 $(eval $(call BuildPackage,iptables-nft))
 $(eval $(call BuildPlugin,iptables-mod-conntrack-extra,$(IPT_CONNTRACK_EXTRA-m)))

--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=iptables
 PKG_VERSION:=1.8.7
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_URL:=https://netfilter.org/projects/iptables/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/package/network/utils/iptables/patches/002-xtables-Call-init_extensions_a_b.patch
+++ b/package/network/utils/iptables/patches/002-xtables-Call-init_extensions_a_b.patch
@@ -1,0 +1,107 @@
+A modified version of this patch was commited upstream
+as part of a fixup series
+https://bugzilla.netfilter.org/show_bug.cgi?id=1593
+https://git.netfilter.org/iptables/commit/?id=0836524f093c0fd9c39604a46a949e43d9b47ef2
+
+--- a/iptables/xtables-monitor.c
++++ b/iptables/xtables-monitor.c
+@@ -629,6 +629,8 @@ int xtables_monitor_main(int argc, char
+ 	init_extensions();
+ 	init_extensions4();
+ 	init_extensions6();
++	init_extensionsa();
++	init_extensionsb();
+ #endif
+ 
+ 	if (nft_init(&h, AF_INET, xtables_ipv4)) {
+--- a/iptables/xtables-restore.c
++++ b/iptables/xtables-restore.c
+@@ -368,9 +368,17 @@ xtables_restore_main(int family, const c
+ #endif
+ 		break;
+ 	case NFPROTO_ARP:
++#if defined(ALL_INCLUSIVE) || defined(NO_SHARED_LIBS)
++		init_extensions();
++		init_extensionsa();
++#endif
+ 		tables = xtables_arp;
+ 		break;
+ 	case NFPROTO_BRIDGE:
++#if defined(ALL_INCLUSIVE) || defined(NO_SHARED_LIBS)
++		init_extensions();
++		init_extensionsb();
++#endif
+ 		tables = xtables_bridge;
+ 		break;
+ 	default:
+--- a/iptables/xtables-save.c
++++ b/iptables/xtables-save.c
+@@ -208,9 +208,17 @@ xtables_save_main(int family, int argc,
+ 		d.commit = true;
+ 		break;
+ 	case NFPROTO_ARP:
++#if defined(ALL_INCLUSIVE) || defined(NO_SHARED_LIBS)
++		init_extensions();
++		init_extensionsa();
++#endif
+ 		tables = xtables_arp;
+ 		break;
+ 	case NFPROTO_BRIDGE: {
++#if defined(ALL_INCLUSIVE) || defined(NO_SHARED_LIBS)
++		init_extensions();
++		init_extensionsb();
++#endif
+ 		const char *ctr = getenv("EBTABLES_SAVE_COUNTER");
+ 
+ 		if (!(d.format & FMT_NOCOUNTS)) {
+--- a/iptables/xtables-standalone.c
++++ b/iptables/xtables-standalone.c
+@@ -58,6 +58,8 @@ xtables_main(int family, const char *pro
+ 	init_extensions();
+ 	init_extensions4();
+ 	init_extensions6();
++	init_extensionsa();
++	init_extensionsb();
+ #endif
+ 
+ 	if (nft_init(&h, family, xtables_ipv4) < 0) {
+--- a/iptables/xtables-translate.c
++++ b/iptables/xtables-translate.c
+@@ -474,9 +474,17 @@ static int xtables_xlate_main_common(str
+ 		tables = xtables_ipv4;
+ 		break;
+ 	case NFPROTO_ARP:
++#if defined(ALL_INCLUSIVE) || defined(NO_SHARED_LIBS)
++		init_extensions();
++		init_extensionsa();
++#endif
+ 		tables = xtables_arp;
+ 		break;
+ 	case NFPROTO_BRIDGE:
++#if defined(ALL_INCLUSIVE) || defined(NO_SHARED_LIBS)
++		init_extensions();
++		init_extensionsb();
++#endif
+ 		tables = xtables_bridge;
+ 		break;
+ 	default:
+--- a/iptables/xtables-arp.c
++++ b/iptables/xtables-arp.c
+@@ -438,6 +438,7 @@ int nft_init_arp(struct nft_handle *h, c
+ 	}
+ 
+ #if defined(ALL_INCLUSIVE) || defined(NO_SHARED_LIBS)
++	init_extensions();
+ 	init_extensionsa();
+ #endif
+ 
+--- a/iptables/xtables-eb.c
++++ b/iptables/xtables-eb.c
+@@ -685,6 +685,7 @@ int nft_init_eb(struct nft_handle *h, co
+ 	}
+ 
+ #if defined(ALL_INCLUSIVE) || defined(NO_SHARED_LIBS)
++	init_extensions();
+ 	init_extensionsb();
+ #endif
+ 


### PR DESCRIPTION
Need to send the patch upstream but it should be ready for testing

Some future work in netfilter.mk is to split out all the legacy tables (arptable_* / ebtable_* / iptable_* / ip6table_*)
in separate packages