### PR TITLE
ramips: add support for BOLT! Arion

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -70,6 +70,7 @@ zyxel,nr7101)
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x80000"
 	;;
+bolt,arion|\
 xiaomi,mi-router-cr6606|\
 xiaomi,mi-router-cr6608|\
 xiaomi,mi-router-cr6609)

--- a/target/linux/ramips/dts/mt7621_bolt_arion.dts
+++ b/target/linux/ramips/dts/mt7621_bolt_arion.dts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "bolt,arion", "mediatek,mt7621-soc";
+	model = "Bolt Arion";
+
+	aliases {
+		label-mac-device = &wan;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wlan_blue: wlan_blue {
+			label = "blue:wlan";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wlan_red: wlan_red {
+			label = "red:wlan";
+			gpios = <&gpio 86 GPIO_ACTIVE_LOW>;
+		};
+
+		led_tel_blue: tel_blue {
+			label = "blue:tel";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		led_sig1_blue: sig1_blue {
+			label = "blue:sig1";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		led_sig1_red: sig1_red {
+			label = "red:sig1";
+			gpios = <&gpio 87 GPIO_ACTIVE_LOW>;
+		};
+
+		led_sig2_blue: sig2_blue {
+			label = "blue:sig2";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+		};
+
+		led_sig3_blue: sig3_blue {
+			label = "blue:sig3";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "WPS";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x20000 0x20000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "pci14c3,7603";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "pci14c3,7662";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4000>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <3>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "modem";
+		};
+
+		wan: port@1 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_4000>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4000: macaddr@4000 {
+		reg = <0x28 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -250,6 +250,16 @@ define Device/buffalo_wsr-600dhp
 endef
 TARGET_DEVICES += buffalo_wsr-600dhp
 
+define Device/bolt_arion
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 32448k
+  DEVICE_VENDOR := BOLT
+  DEVICE_MODEL := Arion
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 uboot-envtools
+endef
+TARGET_DEVICES += bolt_arion
+
 define Device/cudy_wr1300
   $(Device/dsa-migration)
   IMAGE_SIZE := 15872k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -50,6 +50,13 @@ ramips_setup_interfaces()
 	xiaomi,mi-router-4a-gigabit)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
+	bolt,arion)
+		ucidef_set_interfaces_lan_wan "lan" "wan"
+		ucidef_set_interface "eth_data" device "modem.103" protocol "static" ipaddr "10.22.127.222" netmask "255.255.255.255"
+		ucidef_set_interface "eth_om" device "modem.4094" protocol "static" ipaddr "169.254.0.2" netmask "255.255.255.252"
+		uci add_list firewall.@zone[1].network='eth_data'
+		uci add_list firewall.@zone[1].network='eth_om'
+		;;
 	gnubee,gb-pc1|\
 	gnubee,gb-pc2)
 		ucidef_set_interface_lan "lan1 lan2"


### PR DESCRIPTION
This device is from now-defunct BOLT! ISP in Indonesia.
The original firmware is based on mediatek SDK running linux 2.6 or 3.x in later revision.

Specifications:

- SoC:      MediaTek MT7621
- Flash:    32 MiB NOR SPI
- RAM:      128 MiB DDR3
- Ethernet: 2x 10/100/1000 Mbps (switched, LAN + WAN)
- WIFI0:    MT7603E 2.4GHz 802.11b/g/n
- WIFI1:    MT7612E 5GHz 802.11ac
- Antennas: 2x internal, non-detachable
- LEDs:     Programmable LEDs: 5 blue LEDs (wlan, tel, sig1-3) and 2 red LEDs (wlan and sig1)
            Non-programmable "Power"  LED
- Buttons:  Reset and WPS

Instalation:
Install from TFTP

Set your PC IP to 10.10.10.3 and gateway to 10.10.10.123
Press "1" when turning on the router, and type the initramfs file name

You also need to solder pin header or cable to J4 or neighboring test points (T19-T21)
Pinouts from top to bottom: GND, TX, RX, VCC (3.3v)
Baudrate: 57600n8

There's also an additional gigabit transformer and RTL8211FD for the LTE module on the backside of the PCB.

Signed-off-by: Abdul Aziz Amar <abdulaziz.amar@gmail.com>
