### PR TITLE
ramips: fix wifi mac address of HiWiFi series devices

### DIFF
--- a/target/linux/ramips/mt7620/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7620/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -1,0 +1,26 @@
+[ "$ACTION" == "add" ] || exit 0
+
+PHYNBR=${DEVPATH##*/phy}
+
+[ -n $PHYNBR ] || exit 0
+
+. /lib/functions.sh
+. /lib/functions/system.sh
+
+board=$(board_name)
+
+case "$board" in
+	hiwifi,hc5661)
+		label_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac ")
+		[ "$PHYNBR" = "0" ] && [ -n "$label_mac" ] && \
+		echo -n "$label_mac" > /sys${DEVPATH}/macaddress
+		;;
+	hiwifi,hc5761|\
+	hiwifi,hc5861)
+		label_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac ")
+		[ "$PHYNBR" = "1" ] && [ -n "$label_mac" ] && \
+		echo -n "$label_mac" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "0" ] && [ -n "$label_mac" ] && \
+		macaddr_unsetbit "$label_mac" 6 > /sys${DEVPATH}/macaddress
+		;;
+esac

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -26,6 +26,13 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1 > /sys${DEVPATH}/macaddress
 		;;
+	hiwifi,hc5962)
+		label_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac ")
+		[ "$PHYNBR" = "0" ] && [ -n "$label_mac" ] && \
+		echo -n "$label_mac" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && [ -n "$label_mac" ] && \
+		macaddr_unsetbit "$label_mac" 6 > /sys${DEVPATH}/macaddress
+		;;
 	iptime,a3002mesh|\
 	iptime,a3004t)
 		hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"

--- a/target/linux/ramips/mt76x8/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt76x8/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -1,0 +1,22 @@
+[ "$ACTION" == "add" ] || exit 0
+
+PHYNBR=${DEVPATH##*/phy}
+
+[ -n $PHYNBR ] || exit 0
+
+. /lib/functions.sh
+. /lib/functions/system.sh
+
+board=$(board_name)
+
+case "$board" in
+	hiwifi,hc5661a|\
+	hiwifi,hc5761a|\
+	hiwifi,hc5861b)
+		label_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac ")
+		[ "$PHYNBR" = "0" ] && [ -n "$label_mac" ] && \
+		echo -n "$label_mac" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && [ -n "$label_mac" ] && \
+		macaddr_unsetbit "$label_mac" 6 > /sys${DEVPATH}/macaddress
+		;;
+esac


### PR DESCRIPTION
For HiWiFi series devices, label_mac can be read from bdinfo partition,
and lan_mac, wlan2g_mac are same as the label_mac. Converting label_mac
to wlan5g_mac only needs to unset 6th bit. (It seems that all HiWiFi's
label_mac start with D4:EE)

For example:
label	D4:EE:07:32:84:88
lan	D4:EE:07:32:84:88
wan	D4:EE:07:32:84:89
wlan2g	D4:EE:07:32:84:88
wlan5g	D0:EE:07:32:84:88

Tested on HiWiFi HC5661.