### PR TITLE
kernel: backport DSA patches fixing null-pointer dereference for 5.10

### DIFF
--- a/target/linux/generic/backport-5.10/773-v5.18-1-net-dsa-Move-VLAN-filtering-syncing-out-of-dsa_switc.patch
+++ b/target/linux/generic/backport-5.10/773-v5.18-1-net-dsa-Move-VLAN-filtering-syncing-out-of-dsa_switc.patch
@@ -1,0 +1,88 @@
+From 7164a8cde4b42f76474088ccaf53f1e463d4e2f6 Mon Sep 17 00:00:00 2001
+From: Tobias Waldekranz <tobias@waldekranz.com>
+Date: Mon, 24 Jan 2022 22:09:43 +0100
+Subject: [PATCH 5.10 1/2] net: dsa: Move VLAN filtering syncing out of
+ dsa_switch_bridge_leave
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+commit 381a730182f1d174e1950cd4e63e885b1c302051 upstream.
+
+Most of dsa_switch_bridge_leave was, in fact, dealing with the syncing
+of VLAN filtering for switches on which that is a global
+setting. Separate the two phases to prepare for the cross-chip related
+bugfix in the following commit.
+
+Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
+Reviewed-by: Vladimir Oltean <olteanv@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ net/dsa/switch.c | 39 ++++++++++++++++++++++++++-------------
+ 1 file changed, 26 insertions(+), 13 deletions(-)
+
+diff --git a/net/dsa/switch.c b/net/dsa/switch.c
+index a44035872cff..659fd979cc0a 100644
+--- a/net/dsa/switch.c
++++ b/net/dsa/switch.c
+@@ -104,23 +104,12 @@ static int dsa_switch_bridge_join(struct dsa_switch *ds,
+ 	return 0;
+ }
+ 
+-static int dsa_switch_bridge_leave(struct dsa_switch *ds,
+-				   struct dsa_notifier_bridge_info *info)
++static int dsa_switch_sync_vlan_filtering(struct dsa_switch *ds,
++					  struct dsa_notifier_bridge_info *info)
+ {
+ 	bool unset_vlan_filtering = br_vlan_enabled(info->br);
+-	struct dsa_switch_tree *dst = ds->dst;
+ 	int err, i;
+ 
+-	if (dst->index == info->tree_index && ds->index == info->sw_index &&
+-	    ds->ops->port_bridge_leave)
+-		ds->ops->port_bridge_leave(ds, info->port, info->br);
+-
+-	if ((dst->index != info->tree_index || ds->index != info->sw_index) &&
+-	    ds->ops->crosschip_bridge_leave)
+-		ds->ops->crosschip_bridge_leave(ds, info->tree_index,
+-						info->sw_index, info->port,
+-						info->br);
+-
+ 	/* If the bridge was vlan_filtering, the bridge core doesn't trigger an
+ 	 * event for changing vlan_filtering setting upon slave ports leaving
+ 	 * it. That is a good thing, because that lets us handle it and also
+@@ -153,6 +142,30 @@ static int dsa_switch_bridge_leave(struct dsa_switch *ds,
+ 		if (err && err != EOPNOTSUPP)
+ 			return err;
+ 	}
++
++	return 0;
++}
++
++static int dsa_switch_bridge_leave(struct dsa_switch *ds,
++				   struct dsa_notifier_bridge_info *info)
++{
++	struct dsa_switch_tree *dst = ds->dst;
++	int err;
++
++	if (dst->index == info->tree_index && ds->index == info->sw_index &&
++	    ds->ops->port_bridge_leave)
++		ds->ops->port_bridge_leave(ds, info->port, info->br);
++
++	if ((dst->index != info->tree_index || ds->index != info->sw_index) &&
++	    ds->ops->crosschip_bridge_leave)
++		ds->ops->crosschip_bridge_leave(ds, info->tree_index,
++						info->sw_index, info->port,
++						info->br);
++
++	err = dsa_switch_sync_vlan_filtering(ds, info);
++	if (err)
++		return err;
++
+ 	return 0;
+ }
+ 
+-- 
+2.34.1
+

--- a/target/linux/generic/backport-5.10/773-v5.18-2-net-dsa-Avoid-cross-chip-syncing-of-VLAN-filtering.patch
+++ b/target/linux/generic/backport-5.10/773-v5.18-2-net-dsa-Avoid-cross-chip-syncing-of-VLAN-filtering.patch
@@ -1,0 +1,63 @@
+From 6948a6654ffc878fc0258b363da77e7fd775b2d9 Mon Sep 17 00:00:00 2001
+From: Tobias Waldekranz <tobias@waldekranz.com>
+Date: Mon, 24 Jan 2022 22:09:44 +0100
+Subject: [PATCH 5.10 2/2] net: dsa: Avoid cross-chip syncing of VLAN filtering
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+commit 108dc8741c203e9d6ce4e973367f1bac20c7192b upstream.
+
+Changes to VLAN filtering are not applicable to cross-chip
+notifications.
+
+On a system like this:
+
+.-----.   .-----.   .-----.
+| sw1 +---+ sw2 +---+ sw3 |
+'-1-2-'   '-1-2-'   '-1-2-'
+
+Before this change, upon sw1p1 leaving a bridge, a call to
+dsa_port_vlan_filtering would also be made to sw2p1 and sw3p1.
+
+In this scenario:
+
+.---------.   .-----.   .-----.
+|   sw1   +---+ sw2 +---+ sw3 |
+'-1-2-3-4-'   '-1-2-'   '-1-2-'
+
+When sw1p4 would leave a bridge, dsa_port_vlan_filtering would be
+called for sw2 and sw3 with a non-existing port - leading to array
+out-of-bounds accesses and crashes on mv88e6xxx.
+
+Fixes: d371b7c92d19 ("net: dsa: Unset vlan_filtering when ports leave the bridge")
+Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
+Reviewed-by: Vladimir Oltean <olteanv@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ net/dsa/switch.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/net/dsa/switch.c b/net/dsa/switch.c
+index 659fd979cc0a..2fe2f328d2d2 100644
+--- a/net/dsa/switch.c
++++ b/net/dsa/switch.c
+@@ -162,9 +162,11 @@ static int dsa_switch_bridge_leave(struct dsa_switch *ds,
+ 						info->sw_index, info->port,
+ 						info->br);
+ 
+-	err = dsa_switch_sync_vlan_filtering(ds, info);
+-	if (err)
+-		return err;
++	if (dst->index == info->tree_index && ds->index == info->sw_index) {
++		err = dsa_switch_sync_vlan_filtering(ds, info);
++		if (err)
++			return err;
++	}
+ 
+ 	return 0;
+ }
+-- 
+2.34.1
+


### PR DESCRIPTION
Backport patches
  381a730182f1 ("net: dsa: Move VLAN filtering syncing out of dsa_switch_bridge_leave")
  108dc8741c20 ("net: dsa: Avoid cross-chip syncing of VLAN filtering")
from upstream (currently in net-next) to fix null-pointer dereference.

Signed-off-by: Marek Behún <kabel@kernel.org>