### PR TITLE
ath79: Fix the problem that the LED of pisen_ts-d084 cannot be used

### DIFF
--- a/target/linux/ath79/dts/ar9331_pisen_ts-d084.dts
+++ b/target/linux/ath79/dts/ar9331_pisen_ts-d084.dts
@@ -33,7 +33,7 @@
 
 		led_system: system {
 			label = "blue:system";
-			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };


### PR DESCRIPTION
Fix the problem that the LED of pisen_ts-d084 cannot be used
*The device's LED enable state is high

Signed-off-by: ski little <ski@ancgk.com>