### PR TITLE
argp-standalone: fix compilation with Alpine Linux

### DIFF
--- a/package/libs/argp-standalone/Makefile
+++ b/package/libs/argp-standalone/Makefile
@@ -34,8 +34,10 @@ define Package/argp-standalone/description
 endef
 
 MAKE_FLAGS += \
-	CFLAGS="$(TARGET_CFLAGS) $(FPIC)"
+	CFLAGS="$(TARGET_CFLAGS) $(FPIC) -std=gnu89"
 
+HOST_MAKE_FLAGS += \
+	CFLAGS="$(HOST_CFLAGS) $(FPIC) -std=gnu89"
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
This package is a C89 one. Add the proper CFLAG to fix compilation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>