### PR TITLE
tools: remove prerequisite ccache if CONFIG_CCACHE is unset

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -89,11 +89,11 @@ else
   tools-y += elfutils
 endif
 
-ifneq ($(CONFIG_CCACHE)$(CONFIG_SDK),)
+ifneq ($(CONFIG_CCACHE),)
 $(foreach tool, $(filter-out zstd zlib xz pkgconf patch ninja meson libressl expat cmake,$(tools-y)), $(eval $(curdir)/$(tool)/compile += $(curdir)/ccache/compile))
-tools-y += ccache
-$(curdir)/ccache/compile := $(curdir)/cmake/compile
 endif
+tools-$(if $(CONFIG_CCACHE)$(CONFIG_SDK),y) += ccache
+$(curdir)/ccache/compile := $(curdir)/cmake/compile
 
 # in case there is no patch tool on the host we need to make patch tool a
 # dependency for tools which have patches directory


### PR DESCRIPTION
It's not necessary to compile ccache if `CONFIG_SDK=y` and `CONFIG_CCACHE is not set` when execute commands such as `make tools/automake/compile`.