### PR TITLE
lantiq: fritz7362sl: Fix SPI flash node reg property

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7362sl.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7362sl.dts
@@ -22,7 +22,7 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
-		reg = <4 0>;
+		reg = <4>;
 		spi-max-frequency = <1000000>;
 
 		urlader: partition@0 {


### PR DESCRIPTION
The &spi node has #address-cells = <1> and #size-cells = <0>. Drop the
extra 0 in the reg property of the SPI flash node to ensure it has the
correct number of cells. This also makes the reg property for the SPI
flash node consistent with all other VR9 boards.

I don't have this board so this fix is compile-tested only.