### PR TITLE
ipq40xx: enable USB quirks on ZTE MF286D

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-mf286d.dts
@@ -117,10 +117,24 @@
 
 		usb2@60f8800 {
 			status = "okay";
+
+			dwc3@6000000 {
+				usb2-susphy-quirk;
+				usb2-host-discon-quirk;
+				usb2-host-discon-phy-misc-reg = <0x24>;
+				usb2-host-discon-mask = <0x100>;
+			};
 		};
 
 		usb3@8af8800 {
 			status = "okay";
+
+			dwc3@8a00000 {
+				usb2-susphy-quirk;
+				usb2-host-discon-quirk;
+				usb2-host-discon-phy-misc-reg = <0x24>;
+				usb2-host-discon-mask = <0x100>;
+			};
 		};
 
 		crypto@8e3a000 {


### PR DESCRIPTION
ZTE MF286D built-in USB controller is prone to crashing on the modem
disconnection events or when entering low-power mode in the USB2 part,
causing either built-in modem or external USB device to drop until
system reboot. This can be seen in the kernel logs in this way:

usb 3-1: USB disconnect, device number 2
option1 ttyUSB3: GSM modem (1-port) converter now disconnected from ttyUSB3
option 3-1:1.0: device disconnected
option1 ttyUSB4: GSM modem (1-port) converter now disconnected from ttyUSB4
option 3-1:1.1: device disconnected
option1 ttyUSB5: GSM modem (1-port) converter now disconnected from ttyUSB5
option 3-1:1.2: device disconnected
xhci-hcd xhci-hcd.1.auto: xHCI host not responding to stop endpoint command.
xhci-hcd xhci-hcd.1.auto: Host halt failed, -110
xhci-hcd xhci-hcd.1.auto: xHCI host controller not responding, assume dead
xhci-hcd xhci-hcd.1.auto: HC died; cleaning up
xhci-hcd.1.auto-1, WWAN/QMI device

Enable the quirks which were present in stock firmware device tree, to
fix that. This was tested by connecting an external QMI modem and
resetting in a loop for two hours. Without the quirks, the controller
would crash usually in a few first iterations, requiring reboot to
re-enumerate the device - reloading module was not sufficient.

Fixes: a91ab8bc05b7 ("ipq40xx: add support for ZTE MF286D")
Signed-off-by: Lech Perczak <lech.perczak@gmail.com>