### PR TITLE
ramips: add support for Wavlink WL-WN531A3

### DIFF
--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn531a3.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn531a3.dts
@@ -1,0 +1,148 @@
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "wavlink,wl-wn531a3", "mediatek,mt7628an-soc";
+	model = "Wavlink WL-WN531A3";
+
+	aliases {
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_red;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		turbo {
+			label = "turbo";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		touchlink {
+			label = "touchlink";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wifi {
+			label = "blue:wifi";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_status_blue: led_status_blue {
+			label = "blue:status";
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: led_status_red {
+			label = "red:status";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "wled_an", "gpio", "wdt";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_28: macaddr@28 {
+		reg = <0x28 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -776,6 +776,17 @@ define Device/vocore_vocore2-lite
 endef
 TARGET_DEVICES += vocore_vocore2-lite
 
+define Device/wavlink_wl-wn531a3
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := WL-WN531A3
+  DEVICE_ALT0_VENDOR := Wavlink
+  DEVICE_ALT0_MODEL := QUANTUM D4
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci
+  SUPPORTED_DEVICES += wl-wn531a3
+endef
+TARGET_DEVICES += wavlink_wl-wn531a3
+
 define Device/wavlink_wl-wn570ha1
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Wavlink

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -117,7 +117,8 @@ ramips_setup_interfaces()
 		;;
 	netgear,r6020|\
 	netgear,r6080|\
-	netgear,r6120)
+	netgear,r6120|\
+	wavlink,wl-wn531a3)
 		ucidef_add_switch "switch0" \
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
 		;;
@@ -190,6 +191,7 @@ ramips_setup_macs()
 	cudy,wr1000|\
 	hilink,hlk-7628n|\
 	hilink,hlk-7688a|\
+	wavlink,wl-wn531a3|\
 	wavlink,wl-wn577a2|\
 	wavlink,wl-wn578a2)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)


### PR DESCRIPTION
The Wavlink WL-WN531A3 is an AC1200 router with 5 fast ethernet ports
and one USB 2.0 port.
It's also known as Wavlink QUANTUM D4.

```
Hardware
--------
SoC:   Mediatek MT7628AN
RAM:   64MB
FLASH: 8MB NOR (GigaDevice GD25Q64CSIG3)
ETH:
  - 5x 10/100 Mbps Ethernet (4x LAN + 1x WAN)
WIFI:
  - 2.4GHz: 1x (integrated in SOC) (2x2:2)
  - 5GHz:   1x MT7612E (2x2:2)
  - 4 external antennas
BTN:
  - 1x Reset button
  - 1x WPS button
  - 1x Turbo button
  - 1x Touchlink button
  - 1x ON/OFF switch
LEDS:
  - 1x Red led (system status)
  - 1x Blue led (system status)
  - 7x Blue leds (wifi led + 5 ethernet ports + power)
USB:
  - 1x USB 2.0 port
UART:
  - 57600-8-N-1
    J1
      O VCC +3,3V (near lan ports)
      o RX
      o TX
      o GND
```

Everything works correctly.

Currently there is no firmware update available. Because of this, in
order to restore the OEM firmware, you must firstly dump the OEM
firmware from your router before you flash the OpenWrt image.

Backup the OEM Firmware
-----------------------
The following steps are to be intended for users having little to none
experience in linux. Obviously there are many ways to backup the OEM
firmware, but probably this is the easiest way for this router.
Procedure tested on M31A3.V4300.200420 firmware version.

1) Go to http://192.168.10.1/webcmd.shtml

2) Type the following line in the "Command" input box and then press enter:
	mkdir /etc_ro/lighttpd/www/dev; cp /dev/mtd0ro /etc_ro/lighttpd/www/dev/mtd0ro; ls -la /etc_ro/lighttpd/www/dev/mtd0ro

3) After few seconds in the textarea should appear this output:
	-rw-r--r--    1 0        0         8388608 /etc_ro/lighttpd/www/dev/mtd0ro

   If your output doesn't match mine, stop reading and ask for
   help in the forum.

4) Open in another tab http://192.168.10.1/dev/mtd0ro to download the
   content of the whole NOR. If the file size is 0 byte, stop reading
   and ask for help in the forum.

5) Come back to the http://192.168.10.1/webcmd.shtml webpage and type:
	rm /etc_ro/lighttpd/www/dev/mtd0ro; for i in 1 2 3 4 ; do cp /dev/mtd${i}ro /etc_ro/lighttpd/www/dev/mtd${i}ro; done; ls -la /etc_ro/lighttpd/www/dev/

6) After few seconds, in the textarea should appear this output:
	-rw-r--r--    1 0        0          196608 mtd1ro
	-rw-r--r--    1 0        0           65536 mtd2ro
	-rw-r--r--    1 0        0           65536 mtd3ro
	-rw-r--r--    1 0        0         8060928 mtd4ro
	drwxr-xr-x    7 0        0               0 ..
	drwxr-xr-x    2 0        0               0 .

   If your output doesn't match mine, stop reading and ask for
   help in the forum.

7) Open the following links to download the partitions of the OEM FW:
	http://192.168.10.1/dev/mtd1ro
	http://192.168.10.1/dev/mtd2ro
	http://192.168.10.1/dev/mtd3ro
	http://192.168.10.1/dev/mtd4ro

   If one (or more) of these files are 0 byte, stop reading and ask
   for help in the forum.

8) Store these downloaded files in a safe place.

9) Reboot your router to remove any temporary file in ram.

Installation
------------
Flash the initramfs image in the OEM firmware interface
(http://192.168.10.1/update.shtml).
When Openwrt boots, flash the sysupgrade image otherwise you won't be
able to keep configuration between reboots.

Restore OEM Firmware
--------------------
Flash the "mtd4ro" file you previously backed-up directly from LUCI.
Warning: Remember to not keep settings!
Warning2: Remember to force the flash.

Notes
-----
1) Router mac addresses:
   LAN		XX:XX:XX:XX:XX:9B (factory @ 0x28)
   WAN		XX:XX:XX:XX:XX:9C (factory @ 0x2e)
   WIFI 2G	XX:XX:XX:XX:XX:9D (factory @ 0x04)
   WIFI 5G	XX:XX:XX:XX:XX:9E (factory @ 0x8004)

   LABEL	XX:XX:XX:XX:XX:9D

2) There is just one wifi led for both wifi interfaces.
   It currently shows only the 2.4 GHz wifi activity.

Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>