### PR TITLE
ath79: add support for MikroTik RouterBOARD wAP-2nD (wAP)

### DIFF
--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-wap-2nd.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-wap-2nd.dts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9533_mikrotik_routerboard-16m.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-wap-2nd", "qca,qca9533";
+	model = "MikroTik RouterBOARD wAP-2nD (wAP)";
+
+	aliases {
+		led-boot = &led_user;
+		led-failsafe = &led_user;
+		led-running = &led_user;
+		led-upgrade = &led_user;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&led_lan_pin>;
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_user: user {
+			label = "green:user";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};
+
+&pinmux {
+	led_lan_pin: pinmux_led_lan_pin {
+		pinctrl-single,bits = <0x4 0x0 0xff>;
+	};
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -90,3 +90,11 @@ define Device/mikrotik_routerboard-wapr-2nd
   IMAGE_SIZE := 16256k
 endef
 TARGET_DEVICES += mikrotik_routerboard-wapr-2nd
+
+define Device/mikrotik_routerboard-wap-2nd
+  $(Device/mikrotik_nor)
+  SOC := qca9533
+  DEVICE_MODEL := RouterBOARD wAP-2nD (wAP)
+  IMAGE_SIZE := 16256k
+endef
+TARGET_DEVICES += mikrotik_routerboard-wap-2nd

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
@@ -7,7 +7,8 @@ board=$(board_name)
 
 case "$board" in
 mikrotik,routerboard-lhg-2nd|\
-mikrotik,routerboard-mapl-2nd)
+mikrotik,routerboard-mapl-2nd|\
+mikrotik,routerboard-wap-2nd)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	;;
 mikrotik,routerboard-lhg-5nd)

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -19,6 +19,7 @@ ath79_setup_interfaces()
 	mikrotik,routerboard-lhg-5nd|\
 	mikrotik,routerboard-mapl-2nd|\
 	mikrotik,routerboard-sxt-5nd-r2|\
+	mikrotik,routerboard-wap-2nd|\
 	mikrotik,routerboard-wap-g-5hact2hnd|\
 	mikrotik,routerboard-wapr-2nd)
 		ucidef_set_interface_lan "eth0"
@@ -43,6 +44,7 @@ ath79_setup_macs()
 	mikrotik,routerboard-lhg-5nd|\
 	mikrotik,routerboard-mapl-2nd|\
 	mikrotik,routerboard-sxt-5nd-r2|\
+	mikrotik,routerboard-wap-2nd|\
 	mikrotik,routerboard-wap-g-5hact2hnd|\
 	mikrotik,routerboard-wapr-2nd)
 		label_mac="$mac_base"

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -27,6 +27,7 @@ case "$FIRMWARE" in
 	mikrotik,routerboard-lhg-2nd|\
 	mikrotik,routerboard-lhg-5nd|\
 	mikrotik,routerboard-sxt-5nd-r2|\
+	mikrotik,routerboard-wap-2nd|\
 	mikrotik,routerboard-wapr-2nd)
 		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" 1)
 		;;


### PR DESCRIPTION
The MikroTik RouterBOARD wAP-2nd (sold as wAP) is a small
2.4 GHz 802.11b/g/n PoE-capable AP.

Specifications:
 - SoC: Qualcomm Atheros QCA9533
 - Flash: 16 MB (SPI)
 - RAM: 64 MB
 - Ethernet: 1x 10/100 Mbps (PoE in)
 - WiFi: AR9531 2T2R 2.4 GHz (SoC)
 - 3x green LEDs (1x lan, 1x wlan, 1x user)

 See https://mikrotik.com/product/RBwAP2nD for more info.

Flashing:
 TFTP boot initramfs image and then perform sysupgrade. Follow common
 MikroTik procedure as in https://openwrt.org/toh/mikrotik/common.

Note: following 781d4bfb397cdd12ee0151eb66c577f470e3377d
 The network setup avoids using the integrated switch and connects the
 single Ethernet port directly. This way, link speed (10/100 Mbps) is
 properly reported by eth0.

Signed-off-by: David Musil <0x444d@protonmail.com>
