### PR TITLE
quilt.mk: fix typo in the Host section

### DIFF
--- a/include/quilt.mk
+++ b/include/quilt.mk
@@ -116,7 +116,7 @@ define Quilt/RefreshDir
 endef
 
 define Quilt/Refresh/Host
-	$(call Quilt/RefreshDir,$(HOST_BUILD_DIR),$(PATCH_DIR))
+	$(call Quilt/RefreshDir,$(HOST_BUILD_DIR),$(HOST_PATCH_DIR))
 endef
 
 define Quilt/Refresh/Package


### PR DESCRIPTION
HOST_PATCH_DIR is used for host patches, not PATCH_DIR.

Fixes refreshing patches with a custom HOST_PATCH_DIR.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

I recently hit this when fixing glib2 compilation under Alpine Linux.