### PR TITLE
ramips: add support for H3C TX1800 Plus / TX1801 Plus / TX1806 

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -44,14 +44,17 @@ zbtlink,zbt-wg2626|\
 zte,mf283plus)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
 	;;
+h3c,tx1800-plus|\
+h3c,tx1801-plus|\
+h3c,tx1806|\
+jcg,q20)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	;;
 hootoo,ht-tm05|\
 ravpower,rp-wd03)
 	idx="$(find_mtd_index u-boot-env)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x4000" "0x1000" "0x1000"
-	;;
-jcg,q20)
-	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;
 beeline,smartbox-flash|\
 linksys,ea6350-v4|\

--- a/target/linux/ramips/dts/mt7621_h3c_tx1800-plus.dts
+++ b/target/linux/ramips/dts/mt7621_h3c_tx1800-plus.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_h3c_tx180x.dtsi"
+
+/ {
+	compatible = "h3c,tx1800-plus", "mediatek,mt7621-soc";
+	model = "H3C TX1800 Plus";
+};

--- a/target/linux/ramips/dts/mt7621_h3c_tx1801-plus.dts
+++ b/target/linux/ramips/dts/mt7621_h3c_tx1801-plus.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_h3c_tx180x.dtsi"
+
+/ {
+	compatible = "h3c,tx1801-plus", "mediatek,mt7621-soc";
+	model = "H3C TX1801 Plus";
+};

--- a/target/linux/ramips/dts/mt7621_h3c_tx1806.dts
+++ b/target/linux/ramips/dts/mt7621_h3c_tx1806.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_h3c_tx180x.dtsi"
+
+/ {
+	compatible = "h3c,tx1806", "mediatek,mt7621-soc";
+	model = "H3C TX1806";
+};

--- a/target/linux/ramips/dts/mt7621_h3c_tx180x.dtsi
+++ b/target/linux/ramips/dts/mt7621_h3c_tx180x.dtsi
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_status_amber;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_amber;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_amber: led-0 {
+			label = "amber:status";
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-1 {
+			label = "green:status";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&nand {
+	status = "okay";
+
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+	mediatek,bmt-remap-range = <0x0000000 0x0a00000>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0000000 0x0080000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x0080000 0x0080000>;
+		};
+
+		partition@100000 {
+			label = "exp";
+			reg = <0x0100000 0x0080000>;
+			read-only;
+		};
+
+		factory: partition@180000 {
+			label = "factory";
+			reg = <0x0180000 0x0080000>;
+			read-only;
+		};
+
+		partition@200000 {
+			label = "firmware";
+			reg = <0x0200000 0x7600000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0000000 0x0800000>;
+			};
+
+			partition@800000 {
+				label = "ubi";
+				reg = <0x0800000 0x6e00000>;
+			};
+		};
+
+		/* last 8 MiB is reserved for NMBM bad block table */
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		mediatek,disable-radar-background;
+	};
+};
+
+&pcie2 {
+	status = "disabled";
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -31,6 +31,12 @@ define Build/gemtek-trailer
 	printf "%s%08X" ".GEMTEK." "$$(cksum $@ | cut -d ' ' -f1)" >> $@
 endef
 
+define Build/h3c-blank-header
+	dd if=/dev/zero of=$@.blank bs=160 count=1
+	cat $@ >> $@.blank
+	mv $@.blank $@
+endef
+
 define Build/iodata-factory
 	$(eval fw_size=$(word 1,$(1)))
 	$(eval fw_type=$(word 2,$(1)))
@@ -751,6 +757,40 @@ define Device/gnubee_gb-pc2
   IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += gnubee_gb-pc2
+
+define Device/h3c_tx180x
+  $(Device/dsa-migration)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 8192k
+  IMAGE_SIZE := 120832k
+  UBINIZE_OPTS := -E 5
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL_INITRAMFS := kernel-bin | relocate-kernel 0x80001000 | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL := $$(KERNEL_INITRAMFS) | h3c-blank-header
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_VENDOR := H3C
+  DEVICE_PACKAGES := kmod-mt7915e uboot-envtools
+endef
+
+define Device/h3c_tx1800-plus
+  $(Device/h3c_tx180x)
+  DEVICE_MODEL := TX1800 Plus
+endef
+TARGET_DEVICES += h3c_tx1800-plus
+
+define Device/h3c_tx1801-plus
+  $(Device/h3c_tx180x)
+  DEVICE_MODEL := TX1801 Plus
+endef
+TARGET_DEVICES += h3c_tx1801-plus
+
+define Device/h3c_tx1806
+  $(Device/h3c_tx180x)
+  DEVICE_MODEL := TX1806
+endef
+TARGET_DEVICES += h3c_tx1806
 
 define Device/hilink_hlk-7621a-evb
   $(Device/dsa-migration)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -28,6 +28,9 @@ ramips_setup_interfaces()
 		;;
 	ampedwireless,ally-r1900k|\
 	gehua,ghl-r-001|\
+	h3c,tx1800-plus|\
+	h3c,tx1801-plus|\
+	h3c,tx1806|\
 	hiwifi,hc5962|\
 	netgear,wax202|\
 	xiaomi,mi-router-3-pro|\
@@ -157,6 +160,13 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		label_mac=$wan_mac
+		;;
+	h3c,tx1800-plus|\
+	h3c,tx1801-plus|\
+	h3c,tx1806)
+		label_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		lan_mac=$(macaddr_add "$label_mac" 1)
+		wan_mac=$label_mac
 		;;
 	hiwifi,hc5962)
 		lan_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac ")

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -37,6 +37,13 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1 > /sys${DEVPATH}/macaddress
 		;;
+	h3c,tx1800-plus|\
+	h3c,tx1801-plus|\
+	h3c,tx1806)
+		addr=$(macaddr_setbit $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) 2) 7)
+		[ "$PHYNBR" = "0" ] && echo -n ${addr:0:9}'1'${addr:10:7} > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && echo -n ${addr:0:9}'7'${addr:10:7} > /sys${DEVPATH}/macaddress
+		;;
 	hiwifi,hc5962)
 		label_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac ")
 		[ "$PHYNBR" = "0" ] && [ -n "$label_mac" ] && \

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -60,6 +60,9 @@ platform_do_upgrade() {
 	dlink,dir-2640-a1|\
 	dlink,dir-2660-a1|\
 	dlink,dir-853-a3|\
+	h3c,tx1800-plus|\
+	h3c,tx1801-plus|\
+	h3c,tx1806|\
 	hiwifi,hc5962|\
 	iptime,a3004t|\
 	iptime,ax2004m|\


### PR DESCRIPTION
```
H3C TX180x series WiFi6 routers are customized by different carrier.
While these three devices look different, they use the same motherboard
inside. Another minor difference comes from the model name definition
in the u-boot environment variable.

Specifications:
 SOC:      MT7621 + MT7915
 ROM:      128 MiB
 RAM:      256 MiB
 LED:      status *2
 Button:   reset *1 + wps/mesh *1
 Ethernet:        lan *3 + wan *1 (10/100/1000Mbps)
 TTL Baudrate:    115200
 TFTP server IP:  192.168.124.99

MAC Address:
 use        address(sample 1)   address(sample 2)    source
 label      88:xx:xx:98:xx:12   88:xx:xx:a2:xx:a5   u-boot-env@ethaddr
 lan        88:xx:xx:98:xx:13   88:xx:xx:a2:xx:a6   $label +1
 wan        88:xx:xx:98:xx:12   88:xx:xx:a2:xx:a5   $label
 WiFi4_2G   8a:xx:xx:58:xx:14   8a:xx:xx:52:xx:a7   (Compatibility mode)
 WiFi5_5G   8a:xx:xx:b8:xx:14   8a:xx:xx:b2:xx:a7   (Compatibility mode)
 WiFi6_2G   8a:xx:xx:18:xx:14   8a:xx:xx:12:xx:a7
 WiFi6_5G   8a:xx:xx:78:xx:14   8a:xx:xx:72:xx:a7

Compatibility mode is used to guarantee the connection of old devices
that only support WiFi4 or WiFi5.

TFTP + TTL Installation:
Although a TTL connection is required for installation, we do not need
to tear down it. We can find the TTL port from the cooling hole at the
bottom. It is located below LAN3 and the pins are defined as follows:
|LAN1|LAN2|LAN3|----|WAN|
--------------------
    |GND|TX|RX|VCC|

1. Set tftp server IP to 192.168.124.99 and put initramfs firmware in
   server's root directory, rename it to a simple name "initramfs.bin".
2. Plug in the power supply and wait for power on, connect the TTL cable
   and open a TTL session, enter "reboot", then enter "Y" to confirm.
   Finally push "0" to interruput boot while booting.
3. Execute command to install a initramfs system:
   # tftp 0x80010000 192.168.124.99:initramfs.bin
   # bootm 0x80010000
4. Backup nand flash by OpenWrt LuCI or dd instruction. We need those
   partitions if we want to back to stock firmwre due to official
   website does not provide download link.
   # dd if=/dev/mtd1 of=/tmp/u-boot-env.bin
   # dd if=/dev/mtd4 of=/tmp/firmware.bin
5. Edit u-boot env to ensure use default bootargs and first image slot:
   # fw_setenv bootargs
   # fw_setenv bootflag 0
6. Upgrade sysupgrade firmware.
7. About restore stock firmware: flash the "firmware" and "u-boot-env"
   partitions that we backed up in step 4.
   # mtd write /tmp/u-boot-env.bin u-boot-env
   # mtd write /tmp/firmware.bin firmware

Additional Info:
The H3C stock firmware has a 160-byte firmware header that appears to
use a non-standard CRC32 verification algorithm. For this part of the
data, the u-boot does not check it so we can just directly replace it
with a placeholder.
```
**Next Steps:**
- [x] Test the `2 Gbps CPU bandwidth #10238` feature (later when I have time) and wait until it is merged.
- [x] Add support for another variant `H3C TX1801 Plus`.

Test Branch: [DragonBluep:pr_add_support_for_H3C_TX1806_test](https://github.com/DragonBluep/openwrt/tree/pr_add_support_for_H3C_TX1806_test)