### PR TITLE
bcm27xx: bcm2711: add kmod-usb-net-lan78xx

### DIFF
--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -158,7 +158,8 @@ define Device/rpi-4
   DEVICE_PACKAGES := \
 	cypress-firmware-43455-sdio \
 	cypress-nvram-43455-sdio-rpi-4b \
-	kmod-brcmfmac wpad-basic-wolfssl
+	kmod-brcmfmac wpad-basic-wolfssl \
+	kmod-usb-net-lan78xx
   IMAGE/sysupgrade.img.gz := boot-common | boot-2711 | sdcard-img | gzip | append-metadata
   IMAGE/factory.img.gz := boot-common | boot-2711 | sdcard-img | gzip
 endef


### PR DESCRIPTION
Some vendors like Seeedstudio in their product [1] with Raspberry Pi
Compute Module 4 uses Microchip LAN7800 (USB 3.0 to Gigabit
Ethernet Bridge) - USB 3.0 extended from PCIe of CM4.

lsusb output:
```
Bus 002 Device 002: ID 0424:7800 Microchip LAN7800
```

Raspberry Pi 4 and even Compute Module 4 has many resources available
and for just one kernel module it is not necessary to add additional specific CM4 profiles.
Let's include it by default, so the both Ethernet ports will be usable
to have better user-experience. Because previous generation of Raspberry
Pi included LAN7800 Gigabit Ethernet by default and it is enabled there
[2] in kernel without additional kernel module, which was added recently [3].

After this commit in dmesg can be found this:

```
root@OpenWrt:~# dmesg | grep lan
[    7.038889] lan78xx 2-3:1.0 (unnamed net_device) (uninitialized): int urb period 64
[    7.090484] usbcore: registered new interface driver lan78xx
```

Tested and works with sysupgrade image.

[1] https://www.seeedstudio.com/Dual-GbE-Carrier-Board-with-4GB-RAM-32GB-eMMC-RPi-CM4-Case-p-5029.html
[2] https://github.com/openwrt/openwrt/blob/32c74552b2310531af593ee0f859a3935a3a7cbd/target/linux/bcm27xx/bcm2709/config-5.4#L437
[3] https://github.com/openwrt/openwrt/commit/31647d8be8c60bfb6690c87c739b8abe6dc03950

___

Related to https://github.com/openwrt/openwrt/pull/4191