### PR TITLE
busybox: fix busybox lock applet pidstr buffer overflow

### DIFF
--- a/package/utils/busybox/patches/220-add_lock_util.patch
+++ b/package/utils/busybox/patches/220-add_lock_util.patch
@@ -72,9 +72,9 @@
 +
 +static int do_lock(void)
 +{
-+	int pid;
++	pid_t pid;
 +	int flags;
-+	char pidstr[8];
++	char pidstr[12];
 +
 +	if ((fd = open(file, O_RDWR | O_CREAT | O_EXCL, 0700)) < 0) {
 +		if ((fd = open(file, O_RDWR)) < 0) {
@@ -109,7 +109,7 @@
 +		if (!waitonly) {
 +			lseek(fd, 0, SEEK_SET);
 +			ftruncate(fd, 0);
-+			sprintf(pidstr, "%d\n", pid);
++			snprintf(sizeof(pidstr), pidstr, "%d\n", pid);
 +			write(fd, pidstr, strlen(pidstr));
 +			close(fd);
 +		}


### PR DESCRIPTION
Kernel setting `/proc/sys/kernel/pid_max` can be set up to 4194304(7 digits) which will cause buffer overflow in busbox lock patch, this often happens when running in a rootfs container environment.
This commit enlarges `pidstr` to 10 bytes to ensure a sufficient buffer for pid number and an additional char '\n'.