### PR TITLE
[21.02] cypress-firmware: update it to version 5.4.18-2021_0812

### DIFF
--- a/package/firmware/cypress-firmware/Makefile
+++ b/package/firmware/cypress-firmware/Makefile
@@ -208,42 +208,6 @@ endef
 
 $(eval $(call BuildPackage,cypress-firmware-43570-pcie))
 
-# Cypress 4359 PCIe Firmware
-define Package/cypress-firmware-4359-pcie
-  $(Package/cypress-firmware-default)
-  TITLE:=CYW4359 FullMac PCIe firmware
-endef
-
-define Package/cypress-firmware-4359-pcie/install
-	$(INSTALL_DIR) $(1)/lib/firmware/brcm
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/cyfmac4359-pcie.bin \
-		$(1)/lib/firmware/brcm/brcmfmac4359-pcie.bin
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/cyfmac4359-pcie.clm_blob \
-		$(1)/lib/firmware/brcm/brcmfmac4359-pcie.clm_blob
-endef
-
-$(eval $(call BuildPackage,cypress-firmware-4359-pcie))
-
-# Cypress 4359 SDIO Firmware
-define Package/cypress-firmware-4359-sdio
-  $(Package/cypress-firmware-default)
-  TITLE:=CYW4359 FullMac SDIO firmware
-endef
-
-define Package/cypress-firmware-4359-sdio/install
-	$(INSTALL_DIR) $(1)/lib/firmware/brcm
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/cyfmac4359-sdio.bin \
-		$(1)/lib/firmware/brcm/brcmfmac4359-sdio.bin
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/cyfmac4359-sdio.clm_blob \
-		$(1)/lib/firmware/brcm/brcmfmac4359-sdio.clm_blob
-endef
-
-$(eval $(call BuildPackage,cypress-firmware-4359-sdio))
-
 # Cypress 4373 SDIO Firmware
 define Package/cypress-firmware-4373-sdio
   $(Package/cypress-firmware-default)
@@ -297,21 +261,3 @@ define Package/cypress-firmware-54591-pcie/install
 endef
 
 $(eval $(call BuildPackage,cypress-firmware-54591-pcie))
-
-# Cypress 89459 PCIe Firmware
-define Package/cypress-firmware-89459-pcie
-  $(Package/cypress-firmware-default)
-  TITLE:=CYW89459 FullMac PCIe firmware
-endef
-
-define Package/cypress-firmware-89459-pcie/install
-	$(INSTALL_DIR) $(1)/lib/firmware/brcm
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/cyfmac89459-pcie.bin \
-		$(1)/lib/firmware/brcm/brcmfmac89459-pcie.bin
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/cyfmac89459-pcie.clm_blob \
-		$(1)/lib/firmware/brcm/brcmfmac89459-pcie.clm_blob
-endef
-
-$(eval $(call BuildPackage,cypress-firmware-89459-pcie))

--- a/package/firmware/cypress-firmware/Makefile
+++ b/package/firmware/cypress-firmware/Makefile
@@ -7,25 +7,24 @@
 
 include $(TOPDIR)/rules.mk
 
-UNPACK_CMD=unzip -q -p $(DL_DIR)/$(PKG_SOURCE) $(PKG_SOURCE_UNZIP) | gzip -dc | $(HOST_TAR) -C $(1) $(TAR_OPTIONS)
-
 PKG_NAME:=cypress-firmware
-PKG_VERSION:=v5.4.18-2020_0402
-PKG_RELEASE:=3
+PKG_VERSION:=5.4.18-2021_0812
+PKG_RELEASE:=1
 
-PKG_SOURCE_UNZIP:=cypress-firmware-$(PKG_VERSION).tar.gz
-PKG_SOURCE:=cypress-fmac-$(PKG_VERSION).zip
-PKG_SOURCE_URL:=https://community.cypress.com/gfawx74859/attachments/gfawx74859/resourcelibrary/1016/1/
-PKG_HASH:=b12b0570f462c2f3c26dde98b10235a845a7109037def1e7e51af728bcc1a958
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/Infineon/ifx-linux-firmware/
+PKG_MIRROR_HASH:=ac882b482dd401b53cdecc6004cd2bd3d65e888c19206dcf10931a28033ada4d
+PKG_SOURCE_VERSION:=release-v$(PKG_VERSION)
 
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
+PKG_LICENSE_FILES:=LICENCE
 
 include $(INCLUDE_DIR)/package.mk
 
 define Package/cypress-firmware-default
   SECTION:=firmware
   CATEGORY:=Firmware
-  URL:=https://community.cypress.com/community/linux
+  URL:=https://community.infineon.com/
 endef
 
 define Build/Compile
@@ -41,10 +40,10 @@ endef
 define Package/cypress-firmware-43012-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43012-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43012-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43012-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43012-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43012-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac43012-sdio.clm_blob
 endef
 
@@ -59,7 +58,7 @@ endef
 define Package/cypress-firmware-43340-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43340-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43340-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43340-sdio.bin
 endef
 
@@ -76,7 +75,7 @@ endef
 define Package/cypress-firmware-43362-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43362-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43362-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43362-sdio.bin
 endef
 
@@ -91,7 +90,7 @@ endef
 define Package/cypress-firmware-4339-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4339-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4339-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4339-sdio.bin
 endef
 
@@ -108,10 +107,10 @@ endef
 define Package/cypress-firmware-43430-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43430-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43430-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43430-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43430-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43430-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
 endef
 
@@ -128,10 +127,10 @@ endef
 define Package/cypress-firmware-43455-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43455-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43455-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43455-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43455-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43455-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac43455-sdio.clm_blob
 endef
 
@@ -146,10 +145,10 @@ endef
 define Package/cypress-firmware-4354-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4354-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4354-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4354-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4354-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4354-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4354-sdio.clm_blob
 endef
 
@@ -164,10 +163,10 @@ endef
 define Package/cypress-firmware-4356-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4356-pcie.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4356-pcie.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4356-pcie.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4356-pcie.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4356-pcie.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4356-pcie.clm_blob
 endef
 
@@ -182,10 +181,10 @@ endef
 define Package/cypress-firmware-4356-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4356-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4356-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4356-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4356-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4356-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4356-sdio.clm_blob
 endef
 
@@ -200,10 +199,10 @@ endef
 define Package/cypress-firmware-43570-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43570-pcie.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43570-pcie.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43570-pcie.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43570-pcie.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43570-pcie.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac43570-pcie.clm_blob
 endef
 
@@ -218,10 +217,10 @@ endef
 define Package/cypress-firmware-4359-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4359-pcie.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4359-pcie.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4359-pcie.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4359-pcie.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4359-pcie.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4359-pcie.clm_blob
 endef
 
@@ -236,10 +235,10 @@ endef
 define Package/cypress-firmware-4359-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4359-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4359-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4359-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4359-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4359-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4359-sdio.clm_blob
 endef
 
@@ -254,10 +253,10 @@ endef
 define Package/cypress-firmware-4373-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4373-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4373-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4373-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4373-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4373-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4373-sdio.clm_blob
 endef
 
@@ -272,10 +271,10 @@ endef
 define Package/cypress-firmware-4373-usb/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4373-usb.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4373-usb.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4373-usb.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4373.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4373.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4373.clm_blob
 endef
 
@@ -290,10 +289,10 @@ endef
 define Package/cypress-firmware-54591-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac54591-pcie.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac54591-pcie.bin \
 		$(1)/lib/firmware/brcm/brcmfmac54591-pcie.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac54591-pcie.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac54591-pcie.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac54591-pcie.clm_blob
 endef
 
@@ -308,10 +307,10 @@ endef
 define Package/cypress-firmware-89459-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac89459-pcie.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac89459-pcie.bin \
 		$(1)/lib/firmware/brcm/brcmfmac89459-pcie.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac89459-pcie.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac89459-pcie.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac89459-pcie.clm_blob
 endef
 


### PR DESCRIPTION
- Binary files were renamed to cyfmac from brcmfmac, but the files needs
  to be on the router with the previous naming

[    6.656165] brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac43455-sdio for chip BCM4345/6
[    6.665182] brcmfmac mmc1:0001:1: Direct firmware load for brcm/brcmfmac43455-sdio.bin failed with error -2
[    6.674928] brcmfmac mmc1:0001:1: Falling back to sysfs fallback for: brcm/brcmfmac43455-sdio.bin

- Cypress were acquired by Infineon Technologies
Thus change the project URL and switch to download files from their
GitHub repository. This is much better than the previous solution, which
requires finding new threads on their community forum about new driver
updates, and it will be necessary to change the URL each time.

Unfortunately, it seems that there is not published changelog, but
according to this forum thread [1], be careful by opening the link from
solution since it contains ending bracket ), it brings fixes for various
security vulnerabilities, which were fixed in 7_45_234.

Fixes:
- FragAttacks
- Kr00k

Also add LICENSE file

Run tested on Seeedstudio router powered by Raspberry Pi 4 CM with
package cypress-firmware-43455-sdio.

Before:
```
root@OpenWrt:~# dmesg | grep 'Firmware: BCM4345/6'
[    6.895050] brcmfmac: brcmf_c_preinit_dcmds: Firmware: BCM4345/6 wl0: Mar 23 2020 02:20:01 version 7.45.206 (r725000 CY) FWID 01-febaba43
```

After:
```
root@OpenWrt:~# dmesg | grep 'Firmware: BCM4345/6'
[    6.829805] brcmfmac: brcmf_c_preinit_dcmds: Firmware: BCM4345/6 wl0: Apr 15 2021 03:03:20 version 7.45.234 (4ca95bb CY) FWID 01-996384e2
```

[1] https://community.infineon.com/t5/Wi-Fi-Bluetooth-for-Linux/Outdated-brcmfmac-firmware-for-Raspberry-Pi-4-in-OpenWrt-21-02-1/m-p/331593#M2269

Signed-off-by: Josef Schlehofer <pepe.schlehofer@gmail.com>
(cherry picked from commit 7ca7e0b22de6e629f5df12b8a935a168073bcca3)

Backported from https://github.com/openwrt/openwrt/pull/9483
Fixes https://github.com/openwrt/openwrt/issues/9324 in the stable branch