### PR TITLE
gpio-cdev: re-add nu801 userspace driver

### DIFF
--- a/package/system/gpio-cdev/nu801/Makefile
+++ b/package/system/gpio-cdev/nu801/Makefile
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nu801
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/chunkeey/nu801.git
+PKG_SOURCE_VERSION:=d9942c0ceb949080b93366a9431028de3608e535
+
+PKG_MAINTAINER:=Christian Lamparter <chunkeey@gmail.com>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/nu801
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Userspace GPIO Drivers
+  DEPENDS:=+kmod-leds-uleds
+  KCONFIG:= \
+    CONFIG_GPIO_CDEV=y
+  TITLE:=NU801 LED Driver
+endef
+
+define Package/nu801/description
+This package contains a userspace driver to power the NUMEN Tech. NU801 LED Driver.
+endef
+
+define Package/nu801/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nu801 $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/nu801.init $(1)/etc/init.d/nu801
+
+endef
+
+$(eval $(call BuildPackage,nu801))

--- a/package/system/gpio-cdev/nu801/files/nu801.init
+++ b/package/system/gpio-cdev/nu801/files/nu801.init
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+START=11
+
+boot() {
+	. /lib/functions.sh
+	/usr/sbin/nu801 "$(board_name)"
+
+	# Because this is a userspace driver, we need to trigger diag.sh after 
+	# we start the driver, but before boot is complete so we blink.
+	. /etc/diag.sh
+	set_state preinit_regular 
+}

--- a/target/linux/x86/base-files/etc/board.d/01_leds
+++ b/target/linux/x86/base-files/etc/board.d/01_leds
@@ -9,7 +9,7 @@ board_config_update
 case "$(board_name)" in
 cisco-mx100-hw)
 	ucidef_set_led_usbport "usb" "USB" "mx100:green:usb" "1-1-port2"
-	ucidef_set_led_default "diag" "DIAG" "mx100:green:ha" "1"
+	ucidef_set_led_default "diag" "DIAG" "mx100:green:tricolor" "1"
 	;;
 pc-engines-apu1|pc-engines-apu2|pc-engines-apu3)
 	ucidef_set_led_netdev "wan" "WAN" "apu:green:3" "eth0"

--- a/target/linux/x86/modules.mk
+++ b/target/linux/x86/modules.mk
@@ -88,7 +88,7 @@ define KernelPackage/meraki-mx100
   SUBMENU:=$(OTHER_MENU)
   TITLE:=Cisco Meraki MX100 Platform Driver
   DEPENDS:=@TARGET_x86 @!LINUX_5_4 +kmod-tg3 +kmod-gpio-button-hotplug +kmod-leds-gpio \
-    +kmod-usb-ledtrig-usbport +kmod-itco-wdt
+    +kmod-usb-ledtrig-usbport +nu801 +kmod-itco-wdt
   KCONFIG:=CONFIG_MERAKI_MX100
   FILES:=$(LINUX_DIR)/drivers/platform/x86/meraki-mx100.ko
   AUTOLOAD:=$(call AutoLoad,60,meraki-mx100,1)


### PR DESCRIPTION
This reverts commit 80b7a8a7f5a0a88fde6dd19f097df4d7cac9ff04.

Now that 5.10 is the default kernel for all platforms, we can
bring back the NU801 userspace driver for platforms that rely
on it. Currently it's used on the MX100 x86_64 target, but
other Meraki platforms use this controller.

Note that we also now change how we load nu801. The way we did
this previously with procd worked, but it meant it didn't load
until everything was up and working.

To fix this, let's call nu801 from boot and re-trigger the
preinit blink sequence. Since nu801 runs as a daemon this is
now something we can do.

Tested on a Meraki MX100 on latest snapshot.

CC @chunkeey 