### PR TITLE
pcre: disable shared libraries for host builds

### DIFF
--- a/package/libs/pcre/Makefile
+++ b/package/libs/pcre/Makefile
@@ -62,6 +62,7 @@ define Package/libpcrecpp
 endef
 
 HOST_CONFIGURE_ARGS += \
+	--disable-shared \
 	--enable-utf8 \
 	--enable-unicode-properties \
 	--enable-pcre16 \


### PR DESCRIPTION
Getting rid of shared libraries for hostpkg avoids having to use rpath
hacks to find the library. It also fixes compilation with host glib2
binaries.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

https://downloads.openwrt.org/snapshots/faillogs/aarch64_cortex-a53/packages/libsoup/compile.txt
https://downloads.openwrt.org/snapshots/faillogs/aarch64_cortex-a53/packages/libdmapsharing/compile.txt
