### PR TITLE
elfutils: fix host compilation with Alpine Linux

### DIFF
--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -24,6 +24,8 @@ PKG_INSTALL:=1
 PKG_USE_MIPS16:=1
 PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
 
+HOST_BUILD_DEPENDS:=argp-standalone/host musl-fts/host
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
 include $(INCLUDE_DIR)/host-build.mk
@@ -62,6 +64,8 @@ CONFIGURE_ARGS += --disable-nls
 endif
 
 HOST_CONFIGURE_ARGS += \
+	--disable-shared \
+	--disable-nls \
 	--disable-debuginfod \
 	--disable-libdebuginfod \
 	--without-lzma \


### PR DESCRIPTION
intl is not included in libc, disable it as is done with the target
package.

argp is also not included. Add build depends for argp-standalone.

Disable shared libraries to avoid having to manually add rpath.

Signed-off-by: Rosen Penev <rosenp@gmail.com>