### PR TITLE
cypress-firmware: drop several packagees

### DIFF
--- a/package/firmware/cypress-firmware/Makefile
+++ b/package/firmware/cypress-firmware/Makefile
@@ -208,42 +208,6 @@ endef
 
 $(eval $(call BuildPackage,cypress-firmware-43570-pcie))
 
-# Cypress 4359 PCIe Firmware
-define Package/cypress-firmware-4359-pcie
-  $(Package/cypress-firmware-default)
-  TITLE:=CYW4359 FullMac PCIe firmware
-endef
-
-define Package/cypress-firmware-4359-pcie/install
-	$(INSTALL_DIR) $(1)/lib/firmware/brcm
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/cyfmac4359-pcie.bin \
-		$(1)/lib/firmware/brcm/brcmfmac4359-pcie.bin
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/cyfmac4359-pcie.clm_blob \
-		$(1)/lib/firmware/brcm/brcmfmac4359-pcie.clm_blob
-endef
-
-$(eval $(call BuildPackage,cypress-firmware-4359-pcie))
-
-# Cypress 4359 SDIO Firmware
-define Package/cypress-firmware-4359-sdio
-  $(Package/cypress-firmware-default)
-  TITLE:=CYW4359 FullMac SDIO firmware
-endef
-
-define Package/cypress-firmware-4359-sdio/install
-	$(INSTALL_DIR) $(1)/lib/firmware/brcm
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/cyfmac4359-sdio.bin \
-		$(1)/lib/firmware/brcm/brcmfmac4359-sdio.bin
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/cyfmac4359-sdio.clm_blob \
-		$(1)/lib/firmware/brcm/brcmfmac4359-sdio.clm_blob
-endef
-
-$(eval $(call BuildPackage,cypress-firmware-4359-sdio))
-
 # Cypress 4373 SDIO Firmware
 define Package/cypress-firmware-4373-sdio
   $(Package/cypress-firmware-default)
@@ -297,21 +261,3 @@ define Package/cypress-firmware-54591-pcie/install
 endef
 
 $(eval $(call BuildPackage,cypress-firmware-54591-pcie))
-
-# Cypress 89459 PCIe Firmware
-define Package/cypress-firmware-89459-pcie
-  $(Package/cypress-firmware-default)
-  TITLE:=CYW89459 FullMac PCIe firmware
-endef
-
-define Package/cypress-firmware-89459-pcie/install
-	$(INSTALL_DIR) $(1)/lib/firmware/brcm
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/cyfmac89459-pcie.bin \
-		$(1)/lib/firmware/brcm/brcmfmac89459-pcie.bin
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/cyfmac89459-pcie.clm_blob \
-		$(1)/lib/firmware/brcm/brcmfmac89459-pcie.clm_blob
-endef
-
-$(eval $(call BuildPackage,cypress-firmware-89459-pcie))


### PR DESCRIPTION
1. Drop package: cypress-firmware-4359-pcie
This binary is no longer provided and there are not many details what
happened.

2. Drop package: cypress-firmware-4359-sdio
This binary is no longer provided, but in this case, to compare it with
PCIe package mention as first, there was added
support in Linux-firmware [1], but no sign of firmware file.

4. Drop package: cypress-firmware-89459-pcie [2]
According to Infineon: "CYW89459 is an automotive Wi-Fi chip which is not
supported in the broad market community."

[1] https://patchwork.kernel.org/project/linux-wireless/patch/20191211235253.2539-6-smoch@web.de/

[2] https://community.infineon.com/t5/Wi-Fi-Bluetooth-for-Linux/the-wifi-driver-for-CYW89459-in-linux4-14-98-2-3-00/m-p/138971

Fixes: 7ca7e0b22de6e629f5df12b8a935a168073bcca3 ("cypress-firmware:
update it to version 5.4.18-2021_0812")