### PR TITLE
kernel: backport two intel igc patches from 5.15

### DIFF
--- a/target/linux/generic/backport-5.10/774-v5.15-1-igc-remove-_I_PHY_ID-checking.patch
+++ b/target/linux/generic/backport-5.10/774-v5.15-1-igc-remove-_I_PHY_ID-checking.patch
@@ -1,0 +1,82 @@
+From 7c496de538eebd8212dc2a3c9a468386b264d0d4 Mon Sep 17 00:00:00 2001
+From: Sasha Neftin <sasha.neftin@intel.com>
+Date: Wed, 7 Jul 2021 08:14:40 +0300
+Subject: igc: Remove _I_PHY_ID checking
+
+i225 devices have only one PHY vendor. There is no point checking
+_I_PHY_ID during the link establishment and auto-negotiation process.
+This patch comes to clean up these pointless checkings.
+
+Signed-off-by: Sasha Neftin <sasha.neftin@intel.com>
+Tested-by: Dvora Fuxbrumer <dvorax.fuxbrumer@linux.intel.com>
+Signed-off-by: Tony Nguyen <anthony.l.nguyen@intel.com>
+---
+ drivers/net/ethernet/intel/igc/igc_base.c | 10 +---------
+ drivers/net/ethernet/intel/igc/igc_main.c |  3 +--
+ drivers/net/ethernet/intel/igc/igc_phy.c  |  6 ++----
+ 3 files changed, 4 insertions(+), 15 deletions(-)
+
+(limited to 'drivers/net/ethernet/intel/igc')
+
+diff --git a/drivers/net/ethernet/intel/igc/igc_base.c b/drivers/net/ethernet/intel/igc/igc_base.c
+index d0700d48ecf9b..84f142f5e472e 100644
+--- a/drivers/net/ethernet/intel/igc/igc_base.c
++++ b/drivers/net/ethernet/intel/igc/igc_base.c
+@@ -187,15 +187,7 @@ static s32 igc_init_phy_params_base(struct igc_hw *hw)
+ 
+ 	igc_check_for_copper_link(hw);
+ 
+-	/* Verify phy id and set remaining function pointers */
+-	switch (phy->id) {
+-	case I225_I_PHY_ID:
+-		phy->type	= igc_phy_i225;
+-		break;
+-	default:
+-		ret_val = -IGC_ERR_PHY;
+-		goto out;
+-	}
++	phy->type = igc_phy_i225;
+ 
+ out:
+ 	return ret_val;
+diff --git a/drivers/net/ethernet/intel/igc/igc_main.c b/drivers/net/ethernet/intel/igc/igc_main.c
+index f7cf979163906..a5278a8f491fb 100644
+--- a/drivers/net/ethernet/intel/igc/igc_main.c
++++ b/drivers/net/ethernet/intel/igc/igc_main.c
+@@ -4189,8 +4189,7 @@ bool igc_has_link(struct igc_adapter *adapter)
+ 		break;
+ 	}
+ 
+-	if (hw->mac.type == igc_i225 &&
+-	    hw->phy.id == I225_I_PHY_ID) {
++	if (hw->mac.type == igc_i225) {
+ 		if (!netif_carrier_ok(adapter->netdev)) {
+ 			adapter->flags &= ~IGC_FLAG_NEED_LINK_UPDATE;
+ 		} else if (!(adapter->flags & IGC_FLAG_NEED_LINK_UPDATE)) {
+diff --git a/drivers/net/ethernet/intel/igc/igc_phy.c b/drivers/net/ethernet/intel/igc/igc_phy.c
+index 83aeb5e7076fd..5cad31c3c7b09 100644
+--- a/drivers/net/ethernet/intel/igc/igc_phy.c
++++ b/drivers/net/ethernet/intel/igc/igc_phy.c
+@@ -249,8 +249,7 @@ static s32 igc_phy_setup_autoneg(struct igc_hw *hw)
+ 			return ret_val;
+ 	}
+ 
+-	if ((phy->autoneg_mask & ADVERTISE_2500_FULL) &&
+-	    hw->phy.id == I225_I_PHY_ID) {
++	if (phy->autoneg_mask & ADVERTISE_2500_FULL) {
+ 		/* Read the MULTI GBT AN Control Register - reg 7.32 */
+ 		ret_val = phy->ops.read_reg(hw, (STANDARD_AN_REG_MASK <<
+ 					    MMD_DEVADDR_SHIFT) |
+@@ -390,8 +389,7 @@ static s32 igc_phy_setup_autoneg(struct igc_hw *hw)
+ 		ret_val = phy->ops.write_reg(hw, PHY_1000T_CTRL,
+ 					     mii_1000t_ctrl_reg);
+ 
+-	if ((phy->autoneg_mask & ADVERTISE_2500_FULL) &&
+-	    hw->phy.id == I225_I_PHY_ID)
++	if (phy->autoneg_mask & ADVERTISE_2500_FULL)
+ 		ret_val = phy->ops.write_reg(hw,
+ 					     (STANDARD_AN_REG_MASK <<
+ 					     MMD_DEVADDR_SHIFT) |
+-- 
+cgit 
+

--- a/target/linux/generic/backport-5.10/774-v5.15-2-igc-remove-phy-type-checking.patch
+++ b/target/linux/generic/backport-5.10/774-v5.15-2-igc-remove-phy-type-checking.patch
@@ -1,0 +1,48 @@
+From 47bca7de6a4fb8dcb564c7ca14d885c91ed19e03 Mon Sep 17 00:00:00 2001
+From: Sasha Neftin <sasha.neftin@intel.com>
+Date: Sat, 10 Jul 2021 20:57:50 +0300
+Subject: igc: Remove phy->type checking
+
+i225 devices have only one phy->type: copper. There is no point checking
+phy->type during the igc_has_link method from the watchdog that
+invoked every 2 seconds.
+This patch comes to clean up these pointless checkings.
+
+Signed-off-by: Sasha Neftin <sasha.neftin@intel.com>
+Tested-by: Dvora Fuxbrumer <dvorax.fuxbrumer@linux.intel.com>
+Signed-off-by: Tony Nguyen <anthony.l.nguyen@intel.com>
+---
+ drivers/net/ethernet/intel/igc/igc_main.c | 15 ++++-----------
+ 1 file changed, 4 insertions(+), 11 deletions(-)
+
+(limited to 'drivers/net/ethernet/intel/igc')
+
+diff --git a/drivers/net/ethernet/intel/igc/igc_main.c b/drivers/net/ethernet/intel/igc/igc_main.c
+index a5278a8f491fb..31e489ed3f8d5 100644
+--- a/drivers/net/ethernet/intel/igc/igc_main.c
++++ b/drivers/net/ethernet/intel/igc/igc_main.c
+@@ -4177,17 +4177,10 @@ bool igc_has_link(struct igc_adapter *adapter)
+ 	 * false until the igc_check_for_link establishes link
+ 	 * for copper adapters ONLY
+ 	 */
+-	switch (hw->phy.media_type) {
+-	case igc_media_type_copper:
+-		if (!hw->mac.get_link_status)
+-			return true;
+-		hw->mac.ops.check_for_link(hw);
+-		link_active = !hw->mac.get_link_status;
+-		break;
+-	default:
+-	case igc_media_type_unknown:
+-		break;
+-	}
++	if (!hw->mac.get_link_status)
++		return true;
++	hw->mac.ops.check_for_link(hw);
++	link_active = !hw->mac.get_link_status;
+ 
+ 	if (hw->mac.type == igc_i225) {
+ 		if (!netif_carrier_ok(adapter->netdev)) {
+-- 
+cgit 
+


### PR DESCRIPTION
kernel: backport two intel igc patches from 5.15
to allow proper initialization of device

- igc: Remove _I_PHY_ID checking
- igc: Remove phy->type checking

Signed-off-by: Pascal Coudurier <coudu@wanadoo.fr>

Intel pushed those two patches in kernel 5.15-rc1:
* https://git.kernel.org/pub/scm/linux/kernel/git/tnguy/next-queue.git/commit/drivers/net/ethernet/intel/igc?h=dev-queue&id=7c496de538eebd8212dc2a3c9a468386b264d0d4
* https://git.kernel.org/pub/scm/linux/kernel/git/tnguy/next-queue.git/commit/drivers/net/ethernet/intel/igc?h=dev-queue&id=47bca7de6a4fb8dcb564c7ca14d885c91ed19e03

They are needed in kernel between 5.8 to 5.14 to allow a proper initialization of network device using igc module.
without them you get this error in log:
Intel(R) 2.5G Ethernet Linux Driver
Copyright(c) 2018 Intel Corporation.
igc: probe of 0000:04:00.0 failed with error -2