### PR TITLE
x86: Add support for Sophos XG 85 and XG 86 devices

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -24,7 +24,8 @@ sophos-sg-105wr2|sophos-xg-105wr2| \
 sophos-sg-115r1|sophos-xg-115r1| \
 sophos-sg-115wr1|sophos-xg-115wr1| \
 sophos-sg-115r2|sophos-xg-115r2| \
-sophos-sg-115wr2|sophos-xg-115wr2)
+sophos-sg-115wr2|sophos-xg-115wr2| \
+sophos-xg-85*|sophos-xg-86*)
 	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3" "eth1"
 	;;
 sophos-sg-125r1|sophos-xg-125r1| \

--- a/target/linux/x86/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/x86/base-files/lib/preinit/01_sysinfo
@@ -38,7 +38,7 @@ do_sysinfo_x86() {
 			local product_version
 			product_version="$(cat /sys/devices/virtual/dmi/id/product_version 2>/dev/null)"
 			case "$product_version" in
-			105*|115*|125*|135*)
+			105*|115*|125*|135*|85*|86*)
 				product="${product}-${product_version}"
 				break
 				;;


### PR DESCRIPTION
This commit builds on previous efforts to add support
for Sophos devices. 

* Add support for Sophos XG 85 with/without wireless
* Add support for Sophos XG 86 with/without wireless

Tested on Sophos XG 85w rev1 and XG 86 rev 1

Signed-off-by: Raylynn Knight <rayknight@me.com>