### PR TITLE
kernel: Fix patch header

### DIFF
--- a/target/linux/generic/backport-5.10/738-v5.14-01-net-dsa-qca8k-fix-an-endian-bug-in-qca8k-get-ethtool.patch
+++ b/target/linux/generic/backport-5.10/738-v5.14-01-net-dsa-qca8k-fix-an-endian-bug-in-qca8k-get-ethtool.patch
@@ -1,4 +1,4 @@
-aFrom aa3d020b22cb844ab7bdbb9e5d861a64666e2b74 Mon Sep 17 00:00:00 2001
+From aa3d020b22cb844ab7bdbb9e5d861a64666e2b74 Mon Sep 17 00:00:00 2001
 From: Dan Carpenter <dan.carpenter@oracle.com>
 Date: Wed, 9 Jun 2021 12:52:12 +0300
 Subject: [PATCH] net: dsa: qca8k: fix an endian bug in


### PR DESCRIPTION
Remove "a" character from the first line of patch
  738-v5.14-01-net-dsa-qca8k-fix-an-endian-bug-in-qca8k-get-ethtool.patch

Otherwise `git am` fails to apply this patch which is annoying when
trying to do some development / rebasing.

Signed-off-by: Marek Behún <kabel@kernel.org>