### PR TITLE
musl-fts: remove shared libraries from host

### DIFF
--- a/package/libs/musl-fts/Makefile
+++ b/package/libs/musl-fts/Makefile
@@ -44,6 +44,7 @@ define Package/musl-fts/description
   The musl-fts package implements the fts(3) functions fts_open, fts_read, fts_children, fts_set and fts_close, which are missing in musl libc.
 endef
 
+HOST_CONFIGURE_ARGS += --disable-shared --with-pic
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
Avoids having to add rpath to the various packages using it. Also add
PIC to fix compilation as static libraries do not use PIC by default.

Fixes: 1fb099341e5879a8c5247020e5056676ba2f0745
Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @chunkeey oversight from the other PR. I had this change locally but did not update the PR.