### PR TITLE
bcm53xx: Re-enable Buffalo WZR-900DHP

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,8 +1,4 @@
-src-git-full packages https://git.openwrt.org/feed/packages.git
-src-git-full luci https://git.openwrt.org/project/luci.git
-src-git-full routing https://git.openwrt.org/feed/routing.git
-src-git-full telephony https://git.openwrt.org/feed/telephony.git
-#src-git-full video https://github.com/openwrt/video.git
-#src-git-full targets https://github.com/openwrt/targets.git
-#src-git-full oldpackages http://git.openwrt.org/packages.git
-#src-link custom /usr/src/openwrt/custom-feed
+src-git-full packages https://git.openwrt.org/feed/packages.git;openwrt-22.03
+src-git-full luci https://git.openwrt.org/project/luci.git;openwrt-22.03
+src-git-full routing https://git.openwrt.org/feed/routing.git;openwrt-22.03
+src-git-full telephony https://git.openwrt.org/feed/telephony.git;openwrt-22.03

--- a/include/version.mk
+++ b/include/version.mk
@@ -23,13 +23,13 @@ PKG_CONFIG_DEPENDS += \
 sanitize = $(call tolower,$(subst _,-,$(subst $(space),-,$(1))))
 
 VERSION_NUMBER:=$(call qstrip,$(CONFIG_VERSION_NUMBER))
-VERSION_NUMBER:=$(if $(VERSION_NUMBER),$(VERSION_NUMBER),SNAPSHOT)
+VERSION_NUMBER:=$(if $(VERSION_NUMBER),$(VERSION_NUMBER),22.03-SNAPSHOT)
 
 VERSION_CODE:=$(call qstrip,$(CONFIG_VERSION_CODE))
 VERSION_CODE:=$(if $(VERSION_CODE),$(VERSION_CODE),$(REVISION))
 
 VERSION_REPO:=$(call qstrip,$(CONFIG_VERSION_REPO))
-VERSION_REPO:=$(if $(VERSION_REPO),$(VERSION_REPO),https://downloads.openwrt.org/snapshots)
+VERSION_REPO:=$(if $(VERSION_REPO),$(VERSION_REPO),http://downloads.openwrt.org/releases/22.03-SNAPSHOT)
 
 VERSION_DIST:=$(call qstrip,$(CONFIG_VERSION_DIST))
 VERSION_DIST:=$(if $(VERSION_DIST),$(VERSION_DIST),OpenWrt)

--- a/include/version.mk
+++ b/include/version.mk
@@ -29,7 +29,7 @@ VERSION_CODE:=$(call qstrip,$(CONFIG_VERSION_CODE))
 VERSION_CODE:=$(if $(VERSION_CODE),$(VERSION_CODE),$(REVISION))
 
 VERSION_REPO:=$(call qstrip,$(CONFIG_VERSION_REPO))
-VERSION_REPO:=$(if $(VERSION_REPO),$(VERSION_REPO),http://downloads.openwrt.org/releases/22.03-SNAPSHOT)
+VERSION_REPO:=$(if $(VERSION_REPO),$(VERSION_REPO),https://downloads.openwrt.org/releases/22.03-SNAPSHOT)
 
 VERSION_DIST:=$(call qstrip,$(CONFIG_VERSION_DIST))
 VERSION_DIST:=$(if $(VERSION_DIST),$(VERSION_DIST),OpenWrt)

--- a/package/base-files/image-config.in
+++ b/package/base-files/image-config.in
@@ -183,7 +183,7 @@ if VERSIONOPT
 	config VERSION_REPO
 		string
 		prompt "Release repository"
-		default "https://downloads.openwrt.org/snapshots"
+		default "https://downloads.openwrt.org/releases/22.03-SNAPSHOT"
 		help
 			This is the repository address embedded in the image, it defaults
 			to the trunk snapshot repo; the url may contain the following placeholders:

--- a/package/system/openwrt-keyring/Makefile
+++ b/package/system/openwrt-keyring/Makefile
@@ -34,5 +34,6 @@ define Package/openwrt-keyring/install
 	$(INSTALL_DIR) $(1)/etc/opkg/keys/
 	# Public usign key for 22.03 release builds
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/usign/4d017e6f1ed5d616 $(1)/etc/opkg/keys/
+endef
 
 $(eval $(call BuildPackage,openwrt-keyring))

--- a/package/system/openwrt-keyring/Makefile
+++ b/package/system/openwrt-keyring/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openwrt-keyring
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/keyring.git
@@ -32,8 +32,7 @@ Build/Compile=
 
 define Package/openwrt-keyring/install
 	$(INSTALL_DIR) $(1)/etc/opkg/keys/
-	# Public usign key for unattended snapshot builds
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/usign/b5043e70f9a75cde $(1)/etc/opkg/keys/
-endef
+	# Public usign key for 22.03 release builds
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/usign/4d017e6f1ed5d616 $(1)/etc/opkg/keys/
 
 $(eval $(call BuildPackage,openwrt-keyring))

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -218,8 +218,7 @@ define Device/buffalo_wzr-900dhp
 	buffalo-enc WZR-900DHP2 $$(BUFFALO_TAG_VERSION) | \
 	buffalo-tag-dhp WZR-900DHP2 JP jp | buffalo-enc-tag | \
 	buffalo-dhp-image
-  BROKEN := y
-endef
+ endef
 TARGET_DEVICES += buffalo_wzr-900dhp
 
 define Device/buffalo_wzr-1750dhp

--- a/target/linux/bcm53xx/patches-5.10/304-ARM-dts-BCM5301X-Specify-switch-ports-for-remaining-.patch
+++ b/target/linux/bcm53xx/patches-5.10/304-ARM-dts-BCM5301X-Specify-switch-ports-for-remaining-.patch
@@ -665,3 +665,47 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
  &spi_nor {
  	status = "okay";
  
+--- a/arch/arm/boot/dts/bcm47081-buffalo-wzr-900dhp.dts
++++ b/arch/arm/boot/dts/bcm47081-buffalo-wzr-900dhp.dts
+@@ -107,3 +107,41 @@
+ &usb3_phy {
+ 	status = "okay";
+ };
++
++&srab {
++	status = "okay";
++
++	ports {
++		port@0 {
++			reg = <0>;
++			label = "lan1";
++		};
++
++		port@1 {
++			reg = <1>;
++			label = "lan2";
++		};
++
++		port@2 {
++			reg = <2>;
++			label = "lan3";
++		};
++
++		port@3 {
++			reg = <3>;
++			label = "lan4";
++		};
++
++		port@4 {
++			reg = <4>;
++			label = "wan";
++		};
++
++		port@5 {
++			reg = <5>;
++			label = "cpu";
++			ethernet = <&gmac0>;
++		};
++	};
++};
++


### PR DESCRIPTION
Hi !

I found out about the WZR-900DHP being disabled by https://github.com/openwrt/openwrt/commit/e9672b1a8fa4714cbc35d5964caf704b2e571f35 via a Tweet by @musashino_205.
I have made a patch to re-enable it and will pull request it. https://github.com/openwrt/openwrt/pull/9567/commits/062bcd122ba6f9e95dbebbb8412d53300a9e5523

I squashed to get rid of unnecessary whitespace. https://github.com/openwrt/openwrt/commit/ae0aa73f31ed97a26a46c424f7dce3d75548637a

Re-enable the WZR-900DHP.
Specify the switch port in the DTS file.

Signed-off-by: SHIMAMOTO Takayoshi <takayoshi.shimamoto.360@gmail.com>