### PR TITLE
ipq806x: fix wrong CPU OPP for ipq8062

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8062.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8062.dtsi
@@ -49,31 +49,31 @@
 	 * Voltage thresholds are <target min max>
 	 */
 	opp-384000000 {
-		opp-microvolt-speed0-pvs0-v0 = <950000 902500 997500>;
-		opp-microvolt-speed0-pvs1-v0 = <900000 855000 945000>;
-		opp-microvolt-speed0-pvs2-v0 = <850000 807500 892500>;
-		opp-microvolt-speed0-pvs3-v0 = <800000 760000 840000>;
+		opp-microvolt-speed0-pvs0-v0 = <1000000 950000 1050000>;
+		opp-microvolt-speed0-pvs1-v0 = < 925000 878750  971250>;
+		opp-microvolt-speed0-pvs2-v0 = < 875000 831250  918750>;
+		opp-microvolt-speed0-pvs3-v0 = < 800000 760000  840000>;
 	};
 
 	opp-600000000 {
-		opp-microvolt-speed0-pvs0-v0 = <1000000 950000 1050000>;
-		opp-microvolt-speed0-pvs1-v0 = <950000  945000  955000>;
-		opp-microvolt-speed0-pvs2-v0 = <900000  895000  905000>;
-		opp-microvolt-speed0-pvs3-v0 = <850000  845000  855000>;
+		opp-microvolt-speed0-pvs0-v0 = <1050000 997500 1102500>;
+		opp-microvolt-speed0-pvs1-v0 = < 975000 926250 1023750>;
+		opp-microvolt-speed0-pvs2-v0 = < 925000 878750  971250>;
+		opp-microvolt-speed0-pvs3-v0 = < 850000 807500  892500>;
 	};
 
 	opp-800000000 {
-		opp-microvolt-speed0-pvs0-v0 = <1050000 997500 1102500>;
-		opp-microvolt-speed0-pvs1-v0 = <1000000 995000 1005000>;
-		opp-microvolt-speed0-pvs2-v0 = <950000  945000  955000>;
-		opp-microvolt-speed0-pvs3-v0 = <900000  895000  905000>;
+		opp-microvolt-speed0-pvs0-v0 = <1100000 1045000 1155000>;
+		opp-microvolt-speed0-pvs1-v0 = <1025000  973750 1076250>;
+		opp-microvolt-speed0-pvs2-v0 = < 995000  945250 1044750>;
+		opp-microvolt-speed0-pvs3-v0 = < 900000  855000  945000>;
 	};
 
 	opp-1000000000 {
-		opp-microvolt-speed0-pvs0-v0 = <1100000 1045000 1155000>;
-		opp-microvolt-speed0-pvs1-v0 = <1050000  997500 1102500>;
-		opp-microvolt-speed0-pvs2-v0 = <1000000  995000 1005000>;
-		opp-microvolt-speed0-pvs3-v0 = <950000   945000  955000>;
+		opp-microvolt-speed0-pvs0-v0 = <1150000 1092500 1207500>;
+		opp-microvolt-speed0-pvs1-v0 = <1075000 1021250 1128750>;
+		opp-microvolt-speed0-pvs2-v0 = <1025000  973750 1076250>;
+		opp-microvolt-speed0-pvs3-v0 = < 950000  902500  997500>;
 	};
 };
 


### PR DESCRIPTION
Fix wrong CPU OPP for ipq8062. Revision of the SoC added an
extra 25mV for every pvs. Also fix the voltage min/max value
that were wrong.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>