### PR TITLE
build, json: introduce sha256_unsigned

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -81,6 +81,7 @@ metadata_json = \
 
 define Build/append-metadata
 	$(if $(SUPPORTED_DEVICES),-echo $(call metadata_json) | fwtool -I - $@)
+	sha256sum "$@" | cut -d" " -f1 > "$@.sha256sum"
 	[ ! -s "$(BUILD_KEY)" -o ! -s "$(BUILD_KEY).ucert" -o ! -s "$@" ] || { \
 		cp "$(BUILD_KEY).ucert" "$@.ucert" ;\
 		usign -S -m "$@" -s "$(BUILD_KEY)" -x "$@.sig" ;\

--- a/include/image.mk
+++ b/include/image.mk
@@ -494,9 +494,9 @@ define Device/Build/initramfs
   $(BUILD_DIR)/json_info_files/$$(KERNEL_INITRAMFS_IMAGE).json: $(BIN_DIR)/$$(KERNEL_INITRAMFS_IMAGE)
 	@mkdir -p $$(shell dirname $$@)
 	DEVICE_ID="$(1)" \
-	BIN_DIR="$(BIN_DIR)" \
 	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
 	FILE_NAME="$$(notdir $$^)" \
+	FILE_DIR="$(KDIR)/tmp" \
 	FILE_TYPE="kernel" \
 	FILE_FILESYSTEM="initramfs" \
 	DEVICE_IMG_PREFIX="$$(DEVICE_IMG_PREFIX)" \
@@ -601,9 +601,9 @@ define Device/Build/image
   $(BUILD_DIR)/json_info_files/$(call DEVICE_IMG_NAME,$(1),$(2)).json: $(BIN_DIR)/$(call DEVICE_IMG_NAME,$(1),$(2))$$(GZ_SUFFIX)
 	@mkdir -p $$(shell dirname $$@)
 	DEVICE_ID="$(DEVICE_NAME)" \
-	BIN_DIR="$(BIN_DIR)" \
 	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
 	FILE_NAME="$(DEVICE_IMG_NAME)" \
+	FILE_DIR="$(KDIR)/tmp" \
 	FILE_TYPE=$(word 1,$(subst ., ,$(2))) \
 	FILE_FILESYSTEM="$(1)" \
 	DEVICE_IMG_PREFIX="$(DEVICE_IMG_PREFIX)" \
@@ -647,9 +647,9 @@ define Device/Build/artifact
   $(BUILD_DIR)/json_info_files/$(DEVICE_IMG_PREFIX)-$(1).json: $(BIN_DIR)/$(DEVICE_IMG_PREFIX)-$(1)
 	@mkdir -p $$(shell dirname $$@)
 	DEVICE_ID="$(DEVICE_NAME)" \
-	BIN_DIR="$(BIN_DIR)" \
 	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
 	FILE_NAME="$(DEVICE_IMG_PREFIX)-$(1)" \
+	FILE_DIR="$(KDIR)/tmp" \
 	FILE_TYPE="$(1)" \
 	DEVICE_IMG_PREFIX="$(DEVICE_IMG_PREFIX)" \
 	DEVICE_VENDOR="$(DEVICE_VENDOR)" \

--- a/scripts/json_add_image_info.py
+++ b/scripts/json_add_image_info.py
@@ -11,8 +11,8 @@ if len(argv) != 2:
     exit(1)
 
 json_path = Path(argv[1])
-bin_dir = Path(getenv("BIN_DIR"))
-file_path = bin_dir / getenv("FILE_NAME")
+file_path = Path(getenv("FILE_DIR")) / getenv("FILE_NAME")
+
 
 if not file_path.is_file():
     print("Skip JSON creation for non existing file", file_path)
@@ -37,7 +37,14 @@ def get_titles():
 
 
 device_id = getenv("DEVICE_ID")
-file_hash = hashlib.sha256(file_path.read_bytes()).hexdigest()
+hash_file = hashlib.sha256(file_path.read_bytes()).hexdigest()
+
+if file_path.with_suffix(file_path.suffix + ".sha256sum").exists():
+    hash_unsigned = (
+        file_path.with_suffix(file_path.suffix + ".sha256sum").read_text().strip()
+    )
+else:
+    hash_unsigned = hash_file
 
 file_info = {
     "metadata_version": 1,
@@ -52,7 +59,8 @@ file_info = {
                 {
                     "type": getenv("FILE_TYPE"),
                     "name": getenv("FILE_NAME"),
-                    "sha256": file_hash,
+                    "sha256": hash_file,
+                    "sha256_unsigned": hash_unsigned,
                 }
             ],
             "device_packages": getenv("DEVICE_PACKAGES").split(),


### PR DESCRIPTION
Introduce `sha256_unsigned` which is a checksum of the image _before_ a
signature is attached. This is helpful to compare image reproducibility.

Since the `.sha256sum` file is located in the $(KDIR) folder, switch
$(BIN_DIR) with $(KDIR) to simplify the code. The value of $(BIN_DIR)
itself is not stored inside the resulting JSON file, so it can be
replaced.