### PR TITLE
Use SOURCE_DATE_EPOCH for reproducible make_ext4fs

### DIFF
--- a/scripts/gen_image_generic.sh
+++ b/scripts/gen_image_generic.sh
@@ -34,7 +34,7 @@ if [ -n "$GUID" ]; then
     mkfs.fat -n kernel -C "$OUTPUT.kernel" -S 512 "$((KERNELSIZE / 1024))"
     mcopy -s -i "$OUTPUT.kernel" "$KERNELDIR"/* ::/
 else
-    make_ext4fs -J -L kernel -l "$KERNELSIZE" "$OUTPUT.kernel" "$KERNELDIR"
+    make_ext4fs -J -L kernel -l "$KERNELSIZE" ${SOURCE_DATE_EPOCH:+-T ${SOURCE_DATE_EPOCH}} "$OUTPUT.kernel" "$KERNELDIR"
 fi
 dd if="$OUTPUT.kernel" of="$OUTPUT" bs=512 seek="$KERNELOFFSET" conv=notrunc
 rm -f "$OUTPUT.kernel"

--- a/target/linux/layerscape/image/Makefile
+++ b/target/linux/layerscape/image/Makefile
@@ -36,7 +36,9 @@ endef
 define Build/ls-append-kernel
 	mkdir -p $@.tmp && \
 	cp $(IMAGE_KERNEL) $@.tmp/fitImage && \
-	make_ext4fs -J -L kernel -l "$(LS_SD_KERNELPART_SIZE)M" "$@.kernel.part" "$@.tmp" && \
+	make_ext4fs -J -L kernel -l "$(LS_SD_KERNELPART_SIZE)M" \
+		$(if $(SOURCE_DATE_EPOCH),-T $(SOURCE_DATE_EPOCH)) \
+		"$@.kernel.part" "$@.tmp" && \
 	dd if=$@.kernel.part >> $@ && \
 	rm -rf $@.tmp && \
 	rm -f $@.kernel.part

--- a/target/linux/mvebu/image/Makefile
+++ b/target/linux/mvebu/image/Makefile
@@ -34,7 +34,9 @@ define Build/boot-img-ext4
 	$(foreach dts,$(DEVICE_DTS), $(CP) $(KDIR)/image-$(dts).dtb $@.boot/$(dts).dtb;)
 	$(CP) $(IMAGE_KERNEL) $@.boot/$(KERNEL_NAME)
 	-$(CP) $@-boot.scr $@.boot/boot.scr
-	make_ext4fs -J -L kernel -l $(CONFIG_TARGET_KERNEL_PARTSIZE)M $@.bootimg $@.boot
+	make_ext4fs -J -L kernel -l $(CONFIG_TARGET_KERNEL_PARTSIZE)M \
+		$(if $(SOURCE_DATE_EPOCH),-T $(SOURCE_DATE_EPOCH)) \
+		$@.bootimg $@.boot
 endef
 
 define Build/buffalo-kernel-jffs2


### PR DESCRIPTION
Make use of SOURCE_DATE_EPOCH to set fixed timestamps in filesystems generated using `make_ext4fs`.
This should helping making images of several targets reproducible.