### PR TITLE
generic: 5.15: fix aardvak pci pending patch

### DIFF
--- a/target/linux/generic/pending-5.15/850-0013-PCI-aardvark-Add-support-for-ERR-interrupt-on-emulat.patch
+++ b/target/linux/generic/pending-5.15/850-0013-PCI-aardvark-Add-support-for-ERR-interrupt-on-emulat.patch
@@ -78,7 +78,7 @@ Signed-off-by: Marek Behún <kabel@kernel.org>
  		if (mask & (PCI_BRIDGE_CTL_BUS_RESET << 16)) {
  			u32 val = advk_readl(pcie, PCIE_CORE_CTRL1_REG);
  			if (new & (PCI_BRIDGE_CTL_BUS_RESET << 16))
-@@ -1459,6 +1480,19 @@ static void advk_pcie_handle_int(struct
+@@ -1459,6 +1480,18 @@ static void advk_pcie_handle_int(struct
  	isr1_mask = advk_readl(pcie, PCIE_ISR1_MASK_REG);
  	isr1_status = isr1_val & ((~isr1_mask) & PCIE_ISR1_ALL_MASK);
  
@@ -90,8 +90,7 @@ Signed-off-by: Marek Behún <kabel@kernel.org>
 +		 * Aardvark HW returns zero for PCI_ERR_ROOT_AER_IRQ, so use
 +		 * PCIe interrupt 0
 +		 */
-+		virq = irq_find_mapping(pcie->irq_domain, 0);
-+		if (generic_handle_irq(virq) == -EINVAL)
++		if (generic_handle_domain_irq(pcie->irq_domain, 0) == -EINVAL)
 +			dev_err_ratelimited(&pcie->pdev->dev, "unhandled ERR IRQ\n");
 +	}
 +

--- a/target/linux/generic/pending-5.15/850-0016-PCI-aardvark-Add-support-for-PME-interrupts.patch
+++ b/target/linux/generic/pending-5.15/850-0016-PCI-aardvark-Add-support-for-PME-interrupts.patch
@@ -25,7 +25,7 @@ Signed-off-by: Marek Behún <kabel@kernel.org>
 
 --- a/drivers/pci/controller/pci-aardvark.c
 +++ b/drivers/pci/controller/pci-aardvark.c
-@@ -1484,6 +1484,19 @@ static void advk_pcie_handle_int(struct
+@@ -1484,6 +1484,18 @@ static void advk_pcie_handle_int(struct
  	isr1_mask = advk_readl(pcie, PCIE_ISR1_MASK_REG);
  	isr1_status = isr1_val & ((~isr1_mask) & PCIE_ISR1_ALL_MASK);
  
@@ -37,8 +37,7 @@ Signed-off-by: Marek Behún <kabel@kernel.org>
 +		 * root bridge. Aardvark HW returns zero for PCI_EXP_FLAGS_IRQ,
 +		 * so use PCIe interrupt 0.
 +		 */
-+		virq = irq_find_mapping(pcie->irq_domain, 0);
-+		if (generic_handle_irq(virq) == -EINVAL)
++		if (generic_handle_domain_irq(pcie->irq_domain, 0) == -EINVAL)
 +			dev_err_ratelimited(&pcie->pdev->dev, "unhandled PME IRQ\n");
 +	}
 +

--- a/target/linux/generic/pending-5.15/850-0017-PCI-aardvark-Fix-support-for-PME-requester-on-emulat.patch
+++ b/target/linux/generic/pending-5.15/850-0017-PCI-aardvark-Fix-support-for-PME-requester-on-emulat.patch
@@ -114,14 +114,13 @@ Signed-off-by: Marek Behún <kabel@kernel.org>
  
  	case PCI_EXP_DEVCTL:
  	case PCI_EXP_DEVCTL2:
-@@ -1445,6 +1436,34 @@ static void advk_pcie_remove_irq_domain(
+@@ -1445,6 +1436,32 @@ static void advk_pcie_remove_irq_domain(
  	irq_domain_remove(pcie->irq_domain);
  }
  
 +static void advk_pcie_handle_pme(struct advk_pcie *pcie)
 +{
 +	u32 requester = advk_readl(pcie, PCIE_MSG_LOG_REG) >> 16;
-+	int virq;
 +
 +	advk_writel(pcie, PCIE_MSG_PM_PME_MASK, PCIE_ISR0_REG);
 +
@@ -140,8 +139,7 @@ Signed-off-by: Marek Behún <kabel@kernel.org>
 +		if (!(le16_to_cpu(pcie->bridge.pcie_conf.rootctl) & PCI_EXP_RTCTL_PMEIE))
 +			return;
 +
-+		virq = irq_find_mapping(pcie->irq_domain, 0);
-+		if (generic_handle_irq(virq) == -EINVAL)
++		if (generic_handle_domain_irq(pcie->irq_domain, 0) == -EINVAL)
 +			dev_err_ratelimited(&pcie->pdev->dev, "unhandled PME IRQ\n");
 +	}
 +}
@@ -149,7 +147,7 @@ Signed-off-by: Marek Behún <kabel@kernel.org>
  static void advk_pcie_handle_msi(struct advk_pcie *pcie)
  {
  	u32 msi_val, msi_mask, msi_status, msi_idx;
-@@ -1484,18 +1503,9 @@ static void advk_pcie_handle_int(struct
+@@ -1484,17 +1503,9 @@ static void advk_pcie_handle_int(struct
  	isr1_mask = advk_readl(pcie, PCIE_ISR1_MASK_REG);
  	isr1_status = isr1_val & ((~isr1_mask) & PCIE_ISR1_ALL_MASK);
  
@@ -161,8 +159,7 @@ Signed-off-by: Marek Behún <kabel@kernel.org>
 -		 * root bridge. Aardvark HW returns zero for PCI_EXP_FLAGS_IRQ,
 -		 * so use PCIe interrupt 0.
 -		 */
--		virq = irq_find_mapping(pcie->irq_domain, 0);
--		if (generic_handle_irq(virq) == -EINVAL)
+-		if (generic_handle_domain_irq(pcie->irq_domain, 0) == -EINVAL)
 -			dev_err_ratelimited(&pcie->pdev->dev, "unhandled PME IRQ\n");
 -	}
 +	/* Process PME interrupt as the first one to do not miss PME requester id */

--- a/target/linux/generic/pending-5.15/850-0018-PCI-aardvark-Use-separate-INTA-interrupt-for-emulate.patch
+++ b/target/linux/generic/pending-5.15/850-0018-PCI-aardvark-Use-separate-INTA-interrupt-for-emulate.patch
@@ -90,20 +90,20 @@ Signed-off-by: Marek Behún <kabel@kernel.org>
  		if (!(le16_to_cpu(pcie->bridge.pcie_conf.rootctl) & PCI_EXP_RTCTL_PMEIE))
  			return;
  
--		virq = irq_find_mapping(pcie->irq_domain, 0);
-+		virq = irq_find_mapping(pcie->rp_irq_domain, 0);
- 		if (generic_handle_irq(virq) == -EINVAL)
+-		if (generic_handle_domain_irq(pcie->irq_domain, 0) == -EINVAL)
++		if (generic_handle_domain_irq(pcie->rp_irq_domain, 0) == -EINVAL)
  			dev_err_ratelimited(&pcie->pdev->dev, "unhandled PME IRQ\n");
  	}
+ 
 @@ -1515,7 +1554,7 @@ static void advk_pcie_handle_int(struct
  		 * Aardvark HW returns zero for PCI_ERR_ROOT_AER_IRQ, so use
  		 * PCIe interrupt 0
  		 */
--		virq = irq_find_mapping(pcie->irq_domain, 0);
-+		virq = irq_find_mapping(pcie->rp_irq_domain, 0);
- 		if (generic_handle_irq(virq) == -EINVAL)
+-		if (generic_handle_domain_irq(pcie->irq_domain, 0) == -EINVAL)
++		if (generic_handle_domain_irq(pcie->rp_irq_domain, 0) == -EINVAL)
  			dev_err_ratelimited(&pcie->pdev->dev, "unhandled ERR IRQ\n");
  	}
+ 
 @@ -1560,6 +1599,21 @@ static void advk_pcie_irq_handler(struct
  	chained_irq_exit(chip, desc);
  }


### PR DESCRIPTION
Fix aardvak pci controller pending patch. Use generic_handle_domain_irq
and fix rebase error.

@rsalvaterra can you test this? The driver should compile correctly now.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
