### PR TITLE
ath79: add support for Buffalo WZR-300HP B0A1

### DIFF
--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-300hp-b0a1.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-300hp-b0a1.dts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7242.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "buffalo,wzr-300hp-b0a1", "qca,ar7242";
+	model = "Buffalo WZR-300HP B0A1";
+
+	aliases {
+		led-boot = &led_diag;
+		led-failsafe = &led_diag;
+		led-upgrade = &led_diag;
+	};
+
+	extosc: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <40000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		usb {
+			label = "usb";
+			linux,code = <BTN_2>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		router_on {
+			label = "router_on";
+			linux,code = <BTN_5>;
+			linux,input-type = <EV_SW>;
+			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		movie_engine {
+			label = "movie_engine";
+			linux,code = <BTN_3>;
+			linux,input-type = <EV_SW>;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_diag: diag {
+			label = "red:diag";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		usb {
+			label = "blue:usb";
+			gpios = <&ath9k 4 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port>;
+			linux,default-trigger = "usbport";
+		};
+
+		wireless {
+			label = "green:wireless";
+			gpios = <&ath9k 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		security {
+			label = "orange:security";
+			gpios = <&ath9k 6 GPIO_ACTIVE_LOW>;
+		};
+
+		router {
+			label = "green:router";
+			gpios = <&ath9k 7 GPIO_ACTIVE_LOW>;
+		};
+
+		movie_engine_on {
+			label = "blue:movie_engine_on";
+			gpios = <&ath9k 8 GPIO_ACTIVE_LOW>;
+		};
+
+		movie_engine_off {
+			label = "blue:movie_engine_off";
+			gpios = <&ath9k 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		gpio_usb_power {
+			gpio-export,name = "buffalo:usb-power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&flash0 &flash1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x40000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			partition@40000 {
+				reg = <0x40000 0x10000>;
+				label = "u-boot-env";
+			};
+
+			art: partition@50000 {
+				reg = <0x50000 0x10000>;
+				label = "art";
+				read-only;
+			};
+
+			partition@60000 {
+				compatible = "denx,uimage";
+				reg = <0x60000 0x1f90000>;
+				label = "firmware";
+			};
+
+			partition@1ff0000 {
+				reg = <0x1ff0000 0x10000>;
+				label = "user_property";
+				read-only;
+			};
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash0: flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+	};
+
+	flash1: flash@1 {
+		compatible = "jedec,spi-nor";
+		reg = <1>;
+		spi-max-frequency = <25000000>;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x1>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x1c000000 0x00000101 0x00001616>;
+
+	nvmem-cells = <&macaddr_art_120c>;
+	nvmem-cell-names = "mac-address";
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,002a";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&macaddr_art_120c>;
+		nvmem-cell-names = "mac-address";
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&pll {
+	clocks = <&extosc>;
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_120c: macaddr@120c {
+		reg = <0x120c 0x6>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -184,6 +184,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "5@eth0"
 		;;
+	buffalo,wzr-300hp-b0a1|\
 	buffalo,wzr-hp-g302h-a1a0)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "3:lan:4" "4:lan:3" "5:lan:2" "2:wan"

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -91,6 +91,7 @@ case "$FIRMWARE" in
 	avm,fritz300e)
 		caldata_extract_reverse "urloader" 0x1541 0x440
 		;;
+	buffalo,wzr-300hp-b0a1|\
 	buffalo,wzr-hp-g302h-a1a0|\
 	ubnt,unifi-ap-outdoor-plus)
 		caldata_extract "art" 0x1000 0xeb8

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -524,6 +524,19 @@ define Device/buffalo_wzr_ar7161
   SUPPORTED_DEVICES += wzr-hp-ag300h
 endef
 
+define Device/buffalo_wzr-300hp-b0a1
+  $(Device/buffalo_common)
+  SOC := ar7242
+  DEVICE_MODEL := WZR-300HP
+  DEVICE_VARIANT := B0A1
+  BUFFALO_PRODUCT := WZR-300HP
+  BUFFALO_HWVER := 4
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
+  IMAGE_SIZE := 32320k
+  SUPPORTED_DEVICES += wzr-hp-g300nh2 buffalo,wzr-hp-g302h-a1a0
+endef
+TARGET_DEVICES += buffalo_wzr-300hp-b0a1
+
 define Device/buffalo_wzr-600dhp
   $(Device/buffalo_wzr_ar7161)
   DEVICE_MODEL := WZR-600DHP


### PR DESCRIPTION
ath79: add support for Buffalo WZR-300HP B0A1

The device is a renamed WZR-HP-G302H A1A0; it has also been sold under the name WZR-HP-G300NH2 and
possibly others though I don't have the hardware to verify this.

This commit provides a build for the B0A1 rev that reflects the exterior labeling and provides a clear installation path
so that it is not necessary to search the forums to find a mention of compatibility.

It is essentially a clone of the WZR-HP-G302H A1A0 commit and it will cleanly sysupgrade over previous installs of the
WZR-HP-G302H A1A0 and WZR-HP-G300NH2 builds without incident.  The only real difference is that I cleaned up the
flash layout a bit to take advantage of some otherwise wasted space.

Specifications:

    Atheros AR7242
    64 MB of RAM (DDR2)
    32 MB of Flash
        2x 16 MB SPI-NOR flash
    2.4 GHz 2T2R wifi
        Atheros AR9283
    5x 10/100/1000 Mbps Ethernet
        Atheros AR8316
    7x LEDs, 5x keys
        LED: 1x gpio-leds, 6x ath9k-leds
        key: 3x buttons, 2x slide switches
    UART header on PCB
        Vcc, GND, TX, RX from ethernet port side
        115200n8

Signed-off-by: Tim Thorpe <tim@tfthorpe.net>