### PR TITLE
base-files: rework system.sh functions

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -11,6 +11,15 @@ debug () {
 N="
 "
 
+# class of ASCII printable delimiters
+delimiter="[ ,-./:;\_]"
+
+# class of ASCII block chars, "'` escaped, ] at start
+blockchar="[]\"\'()<>[\`{}]"
+
+# class of ASCII shell operators, ! at end
+operators="[#$%&*+=?@^|~!]"
+
 _C=0
 NO_EXPORT=1
 LOAD_STATE=1

--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -278,6 +278,23 @@ macaddr_2bin() {
 	echo -ne \\x${mac//:/\\x}
 }
 
+macaddr_split() {
+	local sub="$1"
+	local mod="${2:-2}"
+	local mac
+
+	[ $((${#sub} % mod)) -eq 1 ] &&
+		mac="${sub%${sub#?}}" &&
+		sub="${sub#?}"
+
+	while [ "${#sub}" -ge 2 ]; do
+		mac="${mac}${mac:+ }${sub%${sub#??}}"
+		sub="${sub#??}"
+	done
+
+	printf '%s' "$mac"
+}
+
 macaddr_canonicalize() {
 	local mac="$1"
 	local canon=""
@@ -287,22 +304,7 @@ macaddr_canonicalize() {
 	[ -n "${mac//[a-fA-F0-9\.: -]/}" ] && return
 
 	for octet in ${mac//[\.:-]/ }; do
-		case "${#octet}" in
-		1)
-			octet="0${octet}"
-			;;
-		2)
-			;;
-		4)
-			octet="${octet:0:2} ${octet:2:2}"
-			;;
-		12)
-			octet="${octet:0:2} ${octet:2:2} ${octet:4:2} ${octet:6:2} ${octet:8:2} ${octet:10:2}"
-			;;
-		*)
-			return
-			;;
-		esac
+		[ "${#octet}" -le 2 ] || octet=$(macaddr_split "$octet")
 		canon=${canon}${canon:+ }${octet}
 	done
 

--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -179,14 +179,13 @@ mtd_get_mac_binary_ubi() {
 }
 
 mtd_get_part_size() {
-	local part_name=$1
-	local first dev size erasesize name
+	local mtdname="$1"
+	local dev size erasesize name
+
 	while read dev size erasesize name; do
-		name=${name#'"'}; name=${name%'"'}
-		if [ "$name" = "$part_name" ]; then
-			echo $((0x$size))
-			break
-		fi
+		case "$name" in
+			*"$mtdname"*) printf '%d' $((0x${size})); break ;;
+		esac
 	done < /proc/mtd
 }
 

--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -217,11 +217,25 @@ macaddr_generate_from_mmc_cid() {
 	echo "$(macaddr_unsetbit_mc "$(macaddr_setbit_la "${mac_base}")")"
 }
 
-macaddr_geteui() {
-	local mac=$1
-	local sep=$2
+macaddr_octet() {
+	local mac="$1"
+	local off="${2:-3}"
+	local len="${3:-3}"
+	local sep="$4"
+	local oct=""
 
-	echo ${mac:9:2}$sep${mac:12:2}$sep${mac:15:2}
+	while [ "$off" -ne 0 ]; do
+		mac="${mac#*$delimiter}"
+		off=$((off - 1))
+	done
+
+	while [ "$len" -ne 0 ]; do
+		oct="${oct}${oct:+$sep}${mac%%$delimiter*}"
+		mac="${mac#*$delimiter}"
+		len=$((len - 1))
+	done
+
+	printf '%s' "$oct"
 }
 
 macaddr_setbit() {

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -716,7 +716,7 @@ ath79_setup_macs()
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
 	tplink,deco-s4-v2)
-		lan_mac=$(mtd_get_mac_encrypted_deco $(find_mtd_part config))
+		lan_mac=$(mtd_get_mac_encrypted_deco config)
 		label_mac=$lan_mac
 		;;
 	nec,wf1200cr|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -70,7 +70,7 @@ case "$FIRMWARE" in
 		;;
 	tplink,deco-s4-v2)
 		caldata_extract "art" 0x1000 0x440
-		base_mac=$(mtd_get_mac_encrypted_deco $(find_mtd_part config))
+		base_mac=$(mtd_get_mac_encrypted_deco config)
 		ath9k_patch_mac $(macaddr_add $base_mac 1)
 		;;
 	*)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -254,7 +254,7 @@ case "$FIRMWARE" in
 		;;
 	tplink,deco-s4-v2)
 		caldata_extract "art" 0x5000 0x2f20
-		base_mac=$(mtd_get_mac_encrypted_deco $(find_mtd_part config))
+		base_mac=$(mtd_get_mac_encrypted_deco config)
 		ath10k_patch_mac $(macaddr_add $base_mac 2)
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin

--- a/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -29,7 +29,7 @@ preinit_set_mac_address() {
 		ip link set dev eth0 address $(mtd_get_mac_text u-boot 0x3ff80 12)
 		;;
 	tplink,deco-s4-v2)
-		base_mac=$(mtd_get_mac_encrypted_deco $(find_mtd_part config))
+		base_mac=$(mtd_get_mac_encrypted_deco config)
 		ip link set dev eth0 address $base_mac
 		;;
 	zyxel,nbg6616)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -278,8 +278,8 @@ ramips_setup_macs()
 		label_mac=$lan_mac
 		;;
 	raisecom,msg1500-x-00)
-		lan_mac=$(mtd_get_mac_ascii Config protest_lan_mac)
-		wan_mac=$(mtd_get_mac_ascii Config protest_wan_mac)
+		lan_mac=$(mtd_get_mac_ascii Config protest_lan_mac "tail -c +$((0x8005))")
+		wan_mac=$(mtd_get_mac_ascii Config protest_wan_mac "tail -c +$((0x8005))")
 		label_mac=$lan_mac
 		;;
 	yuncore,ax820)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -141,7 +141,7 @@ case "$board" in
 		;;
 	raisecom,msg1500-x-00)
 		[ "$PHYNBR" = "0" ] && \
-			macaddr_setbit_la "$(mtd_get_mac_ascii Config protest_lan_mac)" \
+			macaddr_setbit_la $(mtd_get_mac_ascii Config protest_lan_mac "tail -c +$((0x8005))") \
 				> /sys${DEVPATH}/macaddress
 		;;
 	snr,snr-cpe-me2-sfp)


### PR DESCRIPTION
all functions in system.sh (mostly for MAC) reworked and cleaned up
with a focus on:

 - readable code
 - function reuse
 - exposing parameter options
 - stronger filtering
 - strict syntax

Summary:

 - prefer head/tail/builtins over hexdump/dd/sed (maybe switch to od in future)
 - mtd_get_mac_ascii	fully rewritten to handle corner cases, string filtering
 - macaddr_geteui	converted to new function macaddr_octet with options
 - macaddr_canonicalize	handle all possible sets of delimiters between octets
 - all functions	syntax cleaned up, checked with shellcheck

Signed-off-by: Michael Pratt <mcpratt@pm.me>