### PR TITLE
build: fix find warning

### DIFF
--- a/include/scan.mk
+++ b/include/scan.mk
@@ -72,7 +72,7 @@ endif
 
 $(FILELIST): $(OVERRIDELIST)
 	rm -f $(TMP_DIR)/info/.files-$(SCAN_TARGET)-*
-	find -L $(SCAN_DIR) $(SCAN_EXTRA) -mindepth 1 $(if $(SCAN_DEPTH),-maxdepth $(SCAN_DEPTH)) -name Makefile | xargs grep -aHE 'call $(GREP_STRING)' | sed -e 's#^$(SCAN_DIR)/##' -e 's#/Makefile:.*##' | uniq | awk -v of=$(OVERRIDELIST) -f include/scan.awk > $@
+	find -L $(SCAN_DIR) -mindepth 1 $(if $(SCAN_DEPTH),-maxdepth $(SCAN_DEPTH)) $(SCAN_EXTRA) -name Makefile | xargs grep -aHE 'call $(GREP_STRING)' | sed -e 's#^$(SCAN_DIR)/##' -e 's#/Makefile:.*##' | uniq | awk -v of=$(OVERRIDELIST) -f include/scan.awk > $@
 
 $(TMP_DIR)/info/.files-$(SCAN_TARGET).mk: $(FILELIST)
 	( \


### PR DESCRIPTION
hi,

if you change SCAN_EXTRA variable with "-path target/linux/xxxx" in
include/toplevel.mk for speed up scan. 

`$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="targetinfo" SCAN_DIR="target/linux" SCAN_NAME="target" SCAN_DEPTH=3 SCAN_EXTRA="" SCAN_MAKEOPTS="TARGET_BUILD=1"`

the find will warning:

> find: warning: you have specified the global option -maxdepth after
> the argument -path, but global options are not positional, i.e.,
> -maxdepth affects tests specified before it as well as those specified
> after it.  Please specify global options before other arguments.

the find option -mindepth -maxdepth is global options must before any
path option. so change order of $(SCAN_EXTRA) after -mindepth and
-maxdepth.

Signed-off-by: leo chung <gewalalb@gmail.com>

