### PR TITLE
readline: add host PIC

### DIFF
--- a/package/libs/readline/Makefile
+++ b/package/libs/readline/Makefile
@@ -53,6 +53,7 @@ CONFIGURE_VARS += \
 	bash_cv_func_sigsetjmp=yes \
 
 TARGET_CFLAGS += $(FPIC)
+HOST_CFLAGS += $(FPIC)
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
Python seems to fail to link to libreadline properly because of this.
Not a fatal error but an error nontheless.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @jefferyto 