### PR TITLE
tools/meson: update to 0.61.4

### DIFF
--- a/include/meson.mk
+++ b/include/meson.mk
@@ -65,6 +65,7 @@ define Meson/CreateNativeFile
 		-e "s|@CXX@|$(foreach BIN,$(HOSTCXX),'$(BIN)',)|" \
 		-e "s|@PKGCONFIG@|$(PKG_CONFIG)|" \
 		-e "s|@CMAKE@|$(STAGING_DIR_HOST)/bin/cmake|" \
+		-e "s|@PYTHON@|$(STAGING_DIR_HOST)/bin/python3|" \
 		-e "s|@CFLAGS@|$(foreach FLAG,$(HOST_CFLAGS) $(HOST_CPPFLAGS),'$(FLAG)',)|" \
 		-e "s|@CXXFLAGS@|$(foreach FLAG,$(HOST_CXXFLAGS) $(HOST_CPPFLAGS),'$(FLAG)',)|" \
 		-e "s|@LDFLAGS@|$(foreach FLAG,$(HOST_LDFLAGS),'$(FLAG)',)|" \
@@ -82,6 +83,7 @@ define Meson/CreateCrossFile
 		-e "s|@NM@|$(TARGET_NM)|" \
 		-e "s|@PKGCONFIG@|$(PKG_CONFIG)|" \
 		-e "s|@CMAKE@|$(STAGING_DIR_HOST)/bin/cmake|" \
+		-e "s|@PYTHON@|$(STAGING_DIR_HOST)/bin/python3|" \
 		-e "s|@CFLAGS@|$(foreach FLAG,$(TARGET_CFLAGS) $(EXTRA_CFLAGS) $(TARGET_CPPFLAGS) $(EXTRA_CPPFLAGS),'$(FLAG)',)|" \
 		-e "s|@CXXFLAGS@|$(foreach FLAG,$(TARGET_CXXFLAGS) $(EXTRA_CXXFLAGS) $(TARGET_CPPFLAGS) $(EXTRA_CPPFLAGS),'$(FLAG)',)|" \
 		-e "s|@LDFLAGS@|$(foreach FLAG,$(TARGET_LDFLAGS) $(EXTRA_LDFLAGS),'$(FLAG)',)|" \

--- a/tools/meson/Makefile
+++ b/tools/meson/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=meson
-PKG_VERSION:=0.61.2
+PKG_VERSION:=0.61.4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/mesonbuild/meson/releases/download/$(PKG_VERSION)
-PKG_HASH:=0233a7f8d959079318f6052b0939c27f68a5de86ba601f25c9ee6869fb5f5889
+PKG_HASH:=4e3733ddc66bac38e38c63b739c9b8b8fc5a866de5333396b0c85c2b144ddee9
 
 PKG_MAINTAINER:=Andre Heider <a.heider@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/tools/meson/files/openwrt-cross.txt.in
+++ b/tools/meson/files/openwrt-cross.txt.in
@@ -6,6 +6,7 @@ strip = '@STRIP@'
 nm = '@NM@'
 pkgconfig = '@PKGCONFIG@'
 cmake = '@CMAKE@'
+python = '@PYTHON@'
 
 [built-in options]
 c_args = [@CFLAGS@]

--- a/tools/meson/files/openwrt-native.txt.in
+++ b/tools/meson/files/openwrt-native.txt.in
@@ -3,6 +3,7 @@ c = [@CC@]
 cpp = [@CXX@]
 pkgconfig = '@PKGCONFIG@'
 cmake = '@CMAKE@'
+python = '@PYTHON@'
 
 [built-in options]
 c_args = [@CFLAGS@]


### PR DESCRIPTION
Override python to use the one in host instead of hostpkg. There's no
need to use the latter.

Signed-off-by: Rosen Penev <rosenp@gmail.com>