### PR TITLE
pcre: pass -fPIC under host as well

### DIFF
--- a/package/libs/pcre/Makefile
+++ b/package/libs/pcre/Makefile
@@ -67,9 +67,8 @@ HOST_CONFIGURE_ARGS += \
 	--enable-unicode-properties \
 	--enable-pcre16 \
 	--with-match-limit-recursion=16000 \
-	--enable-cpp
-
-TARGET_CFLAGS += $(FPIC)
+	--enable-cpp \
+	--with-pic
 
 CONFIGURE_ARGS += \
 	--enable-utf8 \
@@ -78,7 +77,8 @@ CONFIGURE_ARGS += \
 	--enable-pcre32 \
 	$(if $(CONFIG_PCRE_JIT_ENABLED),--enable-jit,--disable-jit) \
 	--with-match-limit-recursion=16000 \
-	--$(if $(CONFIG_PACKAGE_libpcrecpp),en,dis)able-cpp
+	--$(if $(CONFIG_PACKAGE_libpcrecpp),en,dis)able-cpp \
+	--with-pic
 
 MAKE_FLAGS += \
 	CFLAGS="$(TARGET_CFLAGS)"


### PR DESCRIPTION
static libraries need them as they are not PIC by default.

Signed-off-by: Rosen Penev <rosenp@gmail.com>