### PR TITLE
scripts: make sure conffiles are sorted

### DIFF
--- a/scripts/ipkg-build
+++ b/scripts/ipkg-build
@@ -58,7 +58,8 @@ pkg_appears_sane() {
 
 		rm "$CONTROL"/conffiles
 		if [ -f "$CONTROL"/conffiles.resolved ]; then
-			mv "$CONTROL"/conffiles.resolved "$CONTROL"/conffiles
+			sort -o  "$CONTROL"/conffiles "$CONTROL"/conffiles.resolved
+			rm "$CONTROL"/conffiles.resolved
 			chmod 0644 "$CONTROL"/conffiles
 		fi
 	fi


### PR DESCRIPTION
It may happen that conffiles are in different order on different builds.
Make sure they have the same order by sorting them.

FIX: #9612

Signed-off-by: Paul Spooren <mail@aparcar.org>