### PR TITLE
dnsmasq: add procd interface index tracking

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1156,6 +1156,16 @@ dnsmasq_start()
 	[ -n "$user_dhcpscript" ] && procd_set_param env USER_DHCPSCRIPT="$user_dhcpscript"
 	procd_set_param respawn
 
+	local instance_ifc instance_netdev
+	config_get instance_ifc "$cfg" interface
+	if [ -n "$instance_ifc" ]; then
+		if network_get_device instance_netdev "$instance_ifc"; then
+			if [ -n "$instance_netdev" ]; then
+				procd_set_param netdev $instance_netdev
+			fi
+		fi
+	fi
+
 	procd_add_jail dnsmasq ubus log
 	procd_add_jail_mount $CONFIGFILE $DHCPBOGUSHOSTNAMEFILE $DHCPSCRIPT $DHCPSCRIPT_DEPENDS
 	procd_add_jail_mount $EXTRA_MOUNT $RFC6761FILE $TRUSTANCHORSFILE


### PR DESCRIPTION
Problem exist when dnsmasq is exclusively bind to particular interface.
After reconfiguring or restarting this interface, its index changes, but
dnsmasq uses the old one. When this problem occurs, dnsmasq does not
listen on the correct interface so DHCP does not work, and clients do not
get an IP address. Procd netdev param can be added to restart dnsmasq when
the interface index is changed.

Signed-off-by: Valentyn Datsko <valikk.d@gmail.com>