### PR TITLE
kernel: Fix readid method and oob layout of XTX XT26G0xA.

### DIFF
--- a/target/linux/generic/pending-5.10/483-mtd-spinand-add-support-for-xtx-xt26g0xa.patch
+++ b/target/linux/generic/pending-5.10/483-mtd-spinand-add-support-for-xtx-xt26g0xa.patch
@@ -125,7 +125,7 @@ Signed-off-by: Felix Matouschek <felix@matouschek.org>
 +
 +static const struct spinand_info xtx_spinand_table[] = {
 +	SPINAND_INFO("XT26G01A",
-+		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xE1),
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_ADDR, 0xE1),
 +		     NAND_MEMORG(1, 2048, 64, 64, 1024, 20, 1, 1, 1),
 +		     NAND_ECCREQ(8, 512),
 +		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
@@ -135,7 +135,7 @@ Signed-off-by: Felix Matouschek <felix@matouschek.org>
 +		     SPINAND_ECCINFO(&xt26g0xa_ooblayout,
 +				     xt26g0xa_ecc_get_status)),
 +	SPINAND_INFO("XT26G02A",
-+		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xE2),
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_ADDR, 0xE2),
 +		     NAND_MEMORG(1, 2048, 64, 64, 2048, 40, 1, 1, 1),
 +		     NAND_ECCREQ(8, 512),
 +		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
@@ -145,7 +145,7 @@ Signed-off-by: Felix Matouschek <felix@matouschek.org>
 +		     SPINAND_ECCINFO(&xt26g0xa_ooblayout,
 +				     xt26g0xa_ecc_get_status)),
 +	SPINAND_INFO("XT26G04A",
-+		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xE3),
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_ADDR, 0xE3),
 +		     NAND_MEMORG(1, 2048, 64, 128, 2048, 40, 1, 1, 1),
 +		     NAND_ECCREQ(8, 512),
 +		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,

--- a/target/linux/generic/pending-5.10/483-mtd-spinand-add-support-for-xtx-xt26g0xa.patch
+++ b/target/linux/generic/pending-5.10/483-mtd-spinand-add-support-for-xtx-xt26g0xa.patch
@@ -83,8 +83,8 @@ Signed-off-by: Felix Matouschek <felix@matouschek.org>
 +	if (section)
 +		return -ERANGE;
 +
-+	region->offset = 8;
-+	region->length = 40;
++	region->offset = 48;
++	region->length = 16;
 +
 +	return 0;
 +}
@@ -96,7 +96,7 @@ Signed-off-by: Felix Matouschek <felix@matouschek.org>
 +		return -ERANGE;
 +
 +	region->offset = 1;
-+	region->length = 7;
++	region->length = 47;
 +
 +	return 0;
 +}


### PR DESCRIPTION
Fix readid method and oob layout of XTX XT26G0xA.

This fixes https://github.com/openwrt/openwrt/issues/5091 in `openwrt-22.03`.