### PR TITLE
ipq806x: add support for Arris TR4400 v2 / RAC2V1A

### DIFF
--- a/package/boot/uboot-envtools/files/ipq806x
+++ b/package/boot/uboot-envtools/files/ipq806x
@@ -30,6 +30,7 @@ ubootenv_mtdinfo () {
 }
 
 case "$board" in
+arris,tr4400-v2|\
 askey,rt4230w-rev6)
 	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x40000" "0x20000"
 	;;

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -11,6 +11,11 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+arris,tr4400-v2)
+	ucidef_set_interfaces_lan_wan "eth1" "eth2"
+	ucidef_add_switch "switch0" \
+		"1:lan" "2:lan" "3:lan" "4:lan" "6u@eth1" "0u@eth0"
+	;;
 askey,rt4230w-rev6 |\
 asrock,g10 |\
 nec,wg2600hp)

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -10,6 +10,7 @@ platform_check_image() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
+	arris,tr4400-v2 |\
 	askey,rt4230w-rev6 |\
 	compex,wpq864|\
 	netgear,d7800 |\

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-tr4400-v2.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-tr4400-v2.dts
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qcom-ipq8065.dtsi"
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Arris TR4400 v2";
+	compatible = "arris,tr4400-v2", "qcom,ipq8065", "qcom,ipq8064";
+
+	memory@0 {
+		reg = <0x42000000 0x1e000000>;
+		device_type = "memory";
+	};
+
+	aliases {
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_red;
+	};
+
+	chosen {
+		bootargs = "rootfstype=squashfs noinitrd";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_blue: status_blue {
+			label = "blue:status";
+			gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&qcom_pinmux {
+	button_pins: button_pins {
+		mux {
+			pins = "gpio6", "gpio54";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	led_pins: led_pins {
+		mux {
+			pins = "gpio7", "gpio8";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-down;
+		};
+	};
+
+	rgmii2_pins: rgmii2_pins {
+		tx {
+			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32";
+			input-disable;
+		};
+	};
+
+	spi_pins: spi_pins {
+		cs {
+			pins = "gpio20";
+			drive-strength = <12>;
+		};
+	};
+};
+
+&gsbi5 {
+	qcom,mode = <GSBI_PROT_SPI>;
+	status = "okay";
+
+	spi@1a280000 {
+		status = "okay";
+
+		pinctrl-0 = <&spi_pins>;
+		pinctrl-names = "default";
+
+		cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
+
+		flash@0 {
+			compatible = "everspin,mr25h256";
+			spi-max-frequency = <40000000>;
+			reg = <0>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+
+	nand@0 {
+		reg = <0>;
+		compatible = "qcom,nandcs";
+
+		nand-ecc-strength = <4>;
+		nand-bus-width = <8>;
+		nand-ecc-step-size = <512>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x0000000 0x0040000>;
+				read-only;
+			};
+			partition@40000 {
+				label = "0:MIBIB";
+				reg = <0x0040000 0x0140000>;
+				read-only;
+			};
+			partition@180000 {
+				label = "0:SBL2";
+				reg = <0x0180000 0x0140000>;
+				read-only;
+			};
+			partition@2c0000 {
+				label = "0:SBL3";
+				reg = <0x02c0000 0x0280000>;
+				read-only;
+			};
+			partition@540000 {
+				label = "0:DDRCONFIG";
+				reg = <0x0540000 0x0120000>;
+				read-only;
+			};
+			partition@660000 {
+				label = "0:SSD";
+				reg = <0x0660000 0x0120000>;
+				read-only;
+			};
+			partition@780000 {
+				label = "0:TZ";
+				reg = <0x0780000 0x0280000>;
+				read-only;
+			};
+			partition@a00000 {
+				label = "0:RPM";
+				reg = <0x0a00000 0x0280000>;
+				read-only;
+			};
+			partition@c80000 {
+				label = "0:APPSBL";
+				reg = <0x0c80000 0x0500000>;
+				read-only;
+			};
+			partition@1180000 {
+				label = "0:APPSBLENV";
+				reg = <0x1180000 0x0080000>;
+			};
+			partition@1200000 {
+				label = "0:ART";
+				reg = <0x1200000 0x0140000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				precal_ART_1000: precal@1000 {
+					reg = <0x1000 0x2f20>;
+				};
+				precal_ART_5000: precal@5000 {
+					reg = <0x5000 0x2f20>;
+				};
+			};
+			stock_partition@1340000 {
+				label = "stock_rootfs";
+				reg = <0x1340000 0x4000000>;
+			};
+			partition@5340000 {
+				label = "0:BOOTCONFIG";
+				reg = <0x5340000 0x0060000>;
+				read-only;
+			};
+			partition@53a0000 {
+				label = "0:SBL2_1";
+				reg = <0x53a0000 0x0140000>;
+				read-only;
+			};
+			partition@54e0000 {
+				label = "0:SBL3_1";
+				reg = <0x54e0000 0x0280000>;
+				read-only;
+			};
+			partition@5760000 {
+				label = "0:DDRCONFIG_1";
+				reg = <0x5760000 0x0120000>;
+				read-only;
+			};
+			partition@5880000 {
+				label = "0:SSD_1";
+				reg = <0x5880000 0x0120000>;
+				read-only;
+			};
+			partition@59a0000 {
+				label = "0:TZ_1";
+				reg = <0x59a0000 0x0280000>;
+				read-only;
+			};
+			partition@5c20000 {
+				label = "0:RPM_1";
+				reg = <0x5c20000 0x0280000>;
+				read-only;
+			};
+			partition@5ea0000 {
+				label = "0:BOOTCONFIG1";
+				reg = <0x5ea0000 0x0060000>;
+				read-only;
+			};
+			partition@5f00000 {
+				label = "0:APPSBL_1";
+				reg = <0x5f00000 0x0500000>;
+				read-only;
+			};
+			stock_partition@6400000 {
+				label = "stock_rootfs_1";
+				reg = <0x6400000 0x4000000>;
+			};
+			stock_partition@a400000 {
+				label = "stock_fw_env";
+				reg = <0xa400000 0x0100000>;
+			};
+			stock_partition@a500000 {
+				label = "stock_config";
+				reg = <0xa500000 0x0800000>;
+			};
+			stock_partition@ad00000 {
+				label = "stock_PKI";
+				reg = <0xad00000 0x0200000>;
+			};
+			stock_partition@af00000 {
+				label = "stock_scfgmgr";
+				reg = <0xaf00000 0x0100000>;
+			};
+
+			partition@6400000 {
+				label = "fw_env";
+				reg = <0x6400000 0x0100000>;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_fw_env_0: macaddr@0 {
+					reg = <0x00 0x6>;
+				};
+				macaddr_fw_env_6: macaddr@6 {
+					reg = <0x06 0x6>;
+				};
+				macaddr_fw_env_c: macaddr@c {
+					reg = <0x0c 0x6>;
+				};
+				macaddr_fw_env_12: macaddr@12 {
+					reg = <0x12 0x6>;
+				};
+				macaddr_fw_env_18: macaddr@18 {
+					reg = <0x18 0x6>;
+				};
+			};
+			partition@6500000 {
+				label = "ubi";
+				reg = <0x6500000 0x9b00000>;
+			};
+			partition@1340000 {
+				label = "extra";
+				reg = <0x1340000 0x4000000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+
+	ethernet-phy@0 {
+		reg = <0x0>;
+		qca,ar8327-initvals = <
+			0x00004 0x7600000   /* PAD0_MODE */
+			0x00008 0x1000000   /* PAD5_MODE */
+			0x0000c 0x80        /* PAD6_MODE */
+			0x000e4 0xaa545     /* MAC_POWER_SEL */
+			0x000e0 0xc74164de  /* SGMII_CTRL */
+			0x0007c 0x4e        /* PORT0_STATUS */
+			0x00094 0x4e        /* PORT6_STATUS */
+			>;
+	};
+
+	phy7: ethernet-phy@7 {
+		reg = <7>;
+	};
+};
+
+&gmac0 {
+	status = "okay";
+	phy-mode = "rgmii";
+	qcom,id = <0>;
+
+	nvmem-cells = <&macaddr_fw_env_18>;
+	nvmem-cell-names = "mac-address";
+
+	pinctrl-0 = <&rgmii2_pins>;
+	pinctrl-names = "default";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	phy-mode = "sgmii";
+	qcom,id = <1>;
+
+	nvmem-cells = <&macaddr_fw_env_0>;
+	nvmem-cell-names = "mac-address";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gmac3 {
+	status = "okay";
+	phy-mode = "sgmii";
+	qcom,id = <3>;
+	phy-handle = <&phy7>;
+
+	nvmem-cells = <&macaddr_fw_env_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&adm_dma {
+	status = "okay";
+};
+
+&usb3_1 {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+	reset-gpio = <&qcom_pinmux 3 GPIO_ACTIVE_HIGH>;
+	pinctrl-0 = <&pcie0_pins>;
+	pinctrl-names = "default";
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi0: wifi@1,0 {
+			compatible = "pci168c,0046";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&precal_ART_1000>, <&macaddr_fw_env_12>;
+			nvmem-cell-names = "pre-calibration", "mac-address";
+		};
+	};
+};
+
+&pcie1 {
+	status = "okay";
+	reset-gpio = <&qcom_pinmux 48 GPIO_ACTIVE_HIGH>;
+	pinctrl-0 = <&pcie1_pins>;
+	pinctrl-names = "default";
+	max-link-speed = <1>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi1: wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&precal_ART_5000>, <&macaddr_fw_env_c>;
+			nvmem-cell-names = "pre-calibration", "mac-address";
+		};
+	};
+};

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -65,6 +65,19 @@ define Device/ZyXELImage
 		append-metadata
 endef
 
+define Device/arris_tr4400-v2
+	$(call Device/LegacyImage)
+	DEVICE_VENDOR := Arris
+	DEVICE_MODEL := TR4400
+	DEVICE_VARIANT := v2
+	SOC := qcom-ipq8065
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct ath10k-firmware-qca99x0-ct
+	KERNEL_IN_UBI := 1
+endef
+TARGET_DEVICES += arris_tr4400-v2
+
 define Device/askey_rt4230w-rev6
 	$(call Device/LegacyImage)
 	DEVICE_VENDOR := Askey

--- a/target/linux/ipq806x/patches-5.10/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-5.10/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -908,8 +908,29 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -908,8 +908,30 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4019-ap.dk04.1-c3.dtb \
  	qcom-ipq4019-ap.dk07.1-c1.dtb \
  	qcom-ipq4019-ap.dk07.1-c2.dtb \
@@ -33,6 +33,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8065-nbg6817.dtb \
 +	qcom-ipq8065-r7800.dtb \
 +	qcom-ipq8065-rt4230w-rev6.dtb \
++	qcom-ipq8065-tr4400-v2.dtb \
 +	qcom-ipq8065-xr500.dtb \
 +	qcom-ipq8068-ecw5410.dtb \
 +	qcom-ipq8068-mr42.dtb \


### PR DESCRIPTION
note that this port requires moving the contents of a stock partition to consolidate usable flash space. the stock rom does not allow firmware upgrades and i did not find it vulnerable to known hacks, so the installation is non-trivial and requires serial access. thus, moving this partition data only requires a singled added command to a kind of long list of required actions and duplicates the available space for openwrt. the partition move can be easily rolled back to return to stock.

~i am in the process of documenting a detailed and safe install procedure which will be posted to the device page. the procedure includes a complete off-device backup of the flash.~

~also note that the device ends up with a main 155 MB `ubi` partition and an unused 64MB `extra` partition. i am including the `uvol` package in the build to ease usage of this extra partition if the user so desires, but i don't know if this inclusion will be frowned upon (the package could be installed manually if needed). i just want to provide an easy way for users to have an on-device partition that survives sysupgrades and wipes and is easey to remount afterwards.~

PS. i don't know how device additions are handled in the release cycle. i suppose it's way too late to backport to 22.x?