### PR TITLE
realtek: add ZyXEL GS1900-24HP v1 support

### DIFF
--- a/package/boot/uboot-envtools/files/realtek
+++ b/package/boot/uboot-envtools/files/realtek
@@ -16,6 +16,7 @@ zyxel,gs1900-8hp-v1|\
 zyxel,gs1900-8hp-v2|\
 zyxel,gs1900-10hp|\
 zyxel,gs1900-24-v1|\
+zyxel,gs1900-24hp-v1|\
 zyxel,gs1900-24hp-v2)
 	idx="$(find_mtd_index u-boot-env)"
 	[ -n "$idx" ] && \

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -57,6 +57,7 @@ zyxel,gs1900-8hp-v1|\
 zyxel,gs1900-8hp-v2)
 	ucidef_set_poe 70 "$lan_list"
 	;;
+zyxel,gs1900-24hp-v1|\
 zyxel,gs1900-24hp-v2)
 	ucidef_set_poe 170 "$lan_list"
 	;;

--- a/target/linux/realtek/dts-5.10/rtl8382_zyxel_gs1900-24hp-v1.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_zyxel_gs1900-24hp-v1.dts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_zyxel_gs1900.dtsi"
+
+/ {
+	compatible = "zyxel,gs1900-24hp-v1", "realtek,rtl838x-soc";
+	model = "ZyXEL GS1900-24HP v1";
+
+	memory@0 {
+		reg = <0x0 0x4000000>;
+	};
+
+	/* i2c of the left SFP cage: port 25 */
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 24 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 25 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp0: sfp-p25 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 27 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 26 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* i2c of the right SFP cage: port 26 */
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 30 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 31 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp-p26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 33 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio1 28 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 32 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&mdio {
+	EXTERNAL_PHY(0)
+	EXTERNAL_PHY(1)
+	EXTERNAL_PHY(2)
+	EXTERNAL_PHY(3)
+	EXTERNAL_PHY(4)
+	EXTERNAL_PHY(5)
+	EXTERNAL_PHY(6)
+	EXTERNAL_PHY(7)
+
+	EXTERNAL_PHY(16)
+	EXTERNAL_PHY(17)
+	EXTERNAL_PHY(18)
+	EXTERNAL_PHY(19)
+	EXTERNAL_PHY(20)
+	EXTERNAL_PHY(21)
+	EXTERNAL_PHY(22)
+	EXTERNAL_PHY(23)
+
+	INTERNAL_PHY(24)
+	INTERNAL_PHY(26)
+};
+
+&switch0 {
+	ports {
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, internal)
+		SWITCH_PORT(9, 10, internal)
+		SWITCH_PORT(10, 11, internal)
+		SWITCH_PORT(11, 12, internal)
+		SWITCH_PORT(12, 13, internal)
+		SWITCH_PORT(13, 14, internal)
+		SWITCH_PORT(14, 15, internal)
+		SWITCH_PORT(15, 16, internal)
+
+		SWITCH_PORT(16, 17, qsgmii)
+		SWITCH_PORT(17, 18, qsgmii)
+		SWITCH_PORT(18, 19, qsgmii)
+		SWITCH_PORT(19, 20, qsgmii)
+		SWITCH_PORT(20, 21, qsgmii)
+		SWITCH_PORT(21, 22, qsgmii)
+		SWITCH_PORT(22, 23, qsgmii)
+		SWITCH_PORT(23, 24, qsgmii)
+
+		port@24 {
+			reg = <24>;
+			label = "lan25";
+			phy-mode = "1000base-x";
+			managed = "in-band-status";
+			sfp = <&sfp0>;
+		};
+
+		port@26 {
+			reg = <26>;
+			label = "lan26";
+			phy-mode = "1000base-x";
+			managed = "in-band-status";
+			sfp = <&sfp1>;
+		};
+	};
+};
+

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -145,6 +145,15 @@ define Device/zyxel_gs1900-24-v1
 endef
 TARGET_DEVICES += zyxel_gs1900-24-v1
 
+define Device/zyxel_gs1900-24hp-v1
+  $(Device/zyxel_gs1900)
+  SOC := rtl8382
+  DEVICE_MODEL := GS1900-24HP
+  DEVICE_VARIANT := v1
+  ZYXEL_VERS := AAHM
+endef
+TARGET_DEVICES += zyxel_gs1900-24hp-v1
+
 define Device/zyxel_gs1900-24hp-v2
   $(Device/zyxel_gs1900)
   SOC := rtl8382


### PR DESCRIPTION
The ZyXEL GS1900-24HP v1 is a 24 port PoE switch with two SFP ports,
similar to the other GS1900 switches.

Specifications
--------------
* Device:    ZyXEL GS1900-24HP v1
* SoC:       Realtek RTL8382M 500 MHz MIPS 4KEc
* Flash:     16 MiB
* RAM:       Winbond W9751G8KB-25 64 MiB DDR2 SDRAM
* Ethernet:  24x 10/100/1000 Mbps, 2x SFP 100/1000 Mbps
* LEDs:
  * 1 PWR LED (green, not configurable)
  * 1 SYS LED (green, configurable)
  * 24 ethernet port link/activity LEDs (green, SoC controlled)
  * 24 ethernet port PoE status LEDs
  * 2 SFP status/activity LEDs (green, SoC controlled)
* Buttons:
  * 1 "RESET" button on front panel (soft reset)
  * 1 button ('SW1') behind right hex grate (hardwired power-off)
* Power:     120-240V AC C13
* UART:      Internal populated 10-pin header ('J5') providing RS232;
             connected to SoC UART through a TI or SIPEX 3232C for voltage
             level shifting.

* 'J5' RS232 Pinout (dot as pin 1):
  2) SoC RXD
  3) GND
  10) SoC TXD

Serial connection parameters: 115200 8N1.

Installation
------------

OEM upgrade method:

* Log in to OEM management web interface

* Navigate to Maintenance > Firmware > Management

* If "Active Image" has the first option selected, OpenWrt will need to be
  flashed to the "Active" partition. If the second option is selected,
  OpenWrt will need to be flashed to the "Backup" partition.

* Navigate to Maintenance > Firmware > Upload

* Upload the openwrt-realtek-rtl838x-zyxel_gs1900-24hp-v1-initramfs-kernel.bin
  file by your preferred method to the previously determined partition.
  When prompted, select to boot from the newly flashed image, and reboot
  the switch.

* Once OpenWrt has booted, scp the sysupgrade image to /tmp and flash it:

  > sysupgrade /tmp/openwrt-realtek-rtl838x-zyxel_gs1900-24hp-v1-squashfs-sysupgrade.bin

U-Boot TFTP method:

* Configure your client with a static 192.168.1.x IP (e.g. 192.168.1.10).

* Set up a TFTP server on your client and make it serve the initramfs
  image.

* Connect serial, power up the switch, interrupt U-boot by hitting the
  space bar, and enable the network:

  > rtk network on

* Since the GS1900-24HP v1 is a dual-partition device, you want to keep the
  OEM firmware on the backup partition for the time being. OpenWrt can
  only be installed in the first partition anyway (hardcoded in the
  DTS). To ensure we are set to boot from the first partition, issue the
  following commands:

  > setsys bootpartition 0
  > savesys

* Download the image onto the device and boot from it:

  > tftpboot 0x81f00000 192.168.1.10:openwrt-realtek-rtl838x-zyxel_gs1900-24hp-v1-initramfs-kernel.bin
  > bootm

* Once OpenWrt has booted, scp the sysupgrade image to /tmp and flash it:

  > sysupgrade /tmp/openwrt-realtek-rtl838x-zyxel_gs1900-24hp-v1-squashfs-sysupgrade.bin

Other notes
----------------

This PR is very nearly identical to https://github.com/openwrt/openwrt/pull/9400, because the operation of the board is very nearly identical.

Signed-off-by: Martin Kennedy <hurricos@gmail.com>
