### PR TITLE
ath79: add support for Devolo dlan pro wireless 500+

### DIFF
--- a/target/linux/ath79/dts/ar9344_devolo_dlan-pro-500-wp.dts
+++ b/target/linux/ath79/dts/ar9344_devolo_dlan-pro-500-wp.dts
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Devolo dLAN pro wireless 500+";
+	compatible = "devolo,dlan-pro-500-wp", "qca,ar9344";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_wlan_blue;
+		led-running = &led_status_green;
+		led-upgrade = &led_wlan_blue;
+		label-mac-device = &eth0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan_green {
+			label = "green:wlan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_wlan_blue: wlan_blue {
+			label = "blue:wlan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		eth_green {
+			label = "green:eth";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		dlan_green {
+			label = "green:dlan";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "WIFI button";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		dlan {
+			label = "DLAN button";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	plc-regulator {
+		compatible = "regulator-fixed";
+		gpio = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		regulator-name = "plc_vcc";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		enable-active-high;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+};
+
+// Overwrite the register for GMAC0 connection
+&gmac {
+	// 0b010001 = 0x11
+	//    |   +- RGMII_GMAC0
+	//    +-> MII_GMAC0_SLAVE
+	reg = <0x18070000 0x11>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "Config1";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "Config2";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+
+			partition@70000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x70000 0x780000>;
+			};
+
+			partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				cal_ath9k: calibration@1000 {
+					reg = <0x1000 0x440>;
+				};
+				macaddr_art_1002: macaddr@1002 {
+					reg = <0x1002 0x6>;
+					};
+			};
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+// GMAC0 is connected to a AR7400 PLC in PHY mode
+&eth0 {
+	status = "okay";
+
+	// This is <PLL_1000 PLL_100 PLL_10>
+	pll-data = <0x0e000000 0x00000101 0x00001616>;
+
+	nvmem-cells = <&macaddr_art_1002>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <3>;
+
+	phy-mode = "rgmii";
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-gmac0 = <1>;
+	};
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+// GMAC1 is connected to the internal switch
+&eth1 {
+	status = "okay";
+
+	pll-data = <0x16000000 0x00000101 0x00001616>;
+
+	nvmem-cells = <&macaddr_art_1002>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+
+	phy-mode = "gmii";
+	phy-handle = <&phy1>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&cal_ath9k>;
+	nvmem-cell-names = "calibration";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+		phy-mode = "gmii"; 
+
+		// Configure the internal switch
+		qca,ar8327-initvals = <
+			0x04 0x02000000 // PORT0: rgmii
+			0x08 0x00000000 // PORT5 PAD MODE CTRL
+			0x0c 0x00000000 // PORT6 PAD MODE CTRL
+			0x7c 0x0000007e // PORT0_STATUS: speed 1000, full duplex
+		>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -216,6 +216,9 @@ devolo,dlan-pro-1200plus-ac|\
 devolo,magic-2-wifi)
 	ucidef_set_led_netdev "plcw" "dLAN" "white:dlan" "eth0.1" "rx"
 	;;
+devolo,dlan-pro-500-wp)
+	ucidef_set_led_netdev "lan" "Ethernet Activity" "green:eth" "br-lan"
+	;;
 dlink,dap-1330-a1|\
 dlink,dap-1365-a1)
 	ucidef_set_rssimon "wlan0" "200000" "1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -259,6 +259,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:wan" "3:lan" "4:lan"
 		;;
+        devolo,dlan-pro-500-wp)
+		ucidef_set_interface_lan "eth0 eth1.1"
+		ucidef_add_switch "switch0" \
+			"0@eth1" "2:lan:3" "3:lan:2" "4:lan:1"
+		;;
 	dlink,dap-2695-a1)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:wan" "6@eth1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
@@ -34,6 +34,7 @@ telco,t1)
 	ucidef_add_gpio_switch "lte_poweroff" "LTE Poweroff" "1" "1"
 	ucidef_add_gpio_switch "lte_reset" "LTE Reset" "12" "1"
 	;;
+devolo,dlan-pro-500-wp|\
 devolo,dlan-pro-1200plus-ac)
 	ucidef_add_gpio_switch "plc_enable" "PLC enable" "13" "0"
 	;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -784,6 +784,14 @@ define Device/devolo_dlan-pro-1200plus-ac
 endef
 TARGET_DEVICES += devolo_dlan-pro-1200plus-ac
 
+define Device/devolo_dlan-pro-500-wp
+  SOC := ar9344
+  DEVICE_VENDOR := Devolo
+  DEVICE_MODEL := dLAN pro wireless 500+
+  IMAGE_SIZE := 7680k
+endef
+TARGET_DEVICES += devolo_dlan-pro-500-wp
+
 define Device/devolo_dvl1200e
   SOC := qca9558
   DEVICE_VENDOR := devolo


### PR DESCRIPTION
This device was supported in 19.07 . Respective wiki page is
https://openwrt.org/toh/devolo/dlan_pro_wireless_500_plus

PR https://github.com/openwrt/openwrt/pull/3892 and the 19.07 ar71xx
mach-file served as guidance for this commit.

Hardware:
  SoC:       AR9344
  CPU:       560MHz
  Flash:     8MiB
  RAM:       128MiB 
  PLC:       AR7400
  PLC-Link:  RGMII, GMAC0 of SoC
  Switch:    QCA8337, GMAC1 of SoC, Port0: CPU, Port{2,3,4}: LAN
  WiFi:      Atheros AR9340 (via ath9k driver)
  LEDs:      5 LEDs (status, plc, eth, wifi-green, wifi-blue)
  GPIO Switches: (based on 19.07 code, not tested):
              4 reset
             22 rfkill
             21 plc pairing
  GPIO exports:
             13 plc power

MAC-address details (confirmed by device label sticker)
  radio0: loaded from art-location 0x1002
  eth:    radio0 + 1
  plc:    radio0 + 3

The PLC requires 3rd-party firmware and feed. The vendor-provided feed
at https://github.com/devolo/dlan-openwrt needs to be ported to support
the 21.02 board names. A WIP-state port can be found at
https://github.com/eikevons/dlan-openwrt/tree/openwrt-21.02-dlan-500-wp
In the long-run this should be merged with
https://github.com/0xFelix/dlan-openwrt .

Signed-off-by: Eike von Seggern <eike@vonseggern.space>