### PR TITLE
kernel: set --build-id to none

### DIFF
--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -46,6 +46,7 @@ else
 	if [ -d $(LINUX_DIR)/user_headers ]; then \
 		rm -rf $(LINUX_DIR)/user_headers; \
 	fi
+	$(SED) -i $(LINUX_DIR)/Makefile  -e 's/--build-id=.*/--build-id=none/g'
   endef
 endif
 


### PR DESCRIPTION
The Build ID is meant to help distinguish between build environments. In
our case it makes it very harder to reproduce binaries we offer to
download.

Set the Build ID to `none` and drop it from the resulting vmlinux.

Suggested-by: Daniel Golle <daniel@makrotopia.org>
Signed-off-by: Paul Spooren <mail@aparcar.org>