### PR TITLE
ca-certificates: reproducible ca-bundle file

### DIFF
--- a/package/system/ca-certificates/Makefile
+++ b/package/system/ca-certificates/Makefile
@@ -64,7 +64,9 @@ endef
 
 define Package/ca-bundle/install
 	$(INSTALL_DIR) $(1)/etc/ssl/certs
-	cat $(PKG_INSTALL_DIR)/usr/share/ca-certificates/*/*.crt >$(1)/etc/ssl/certs/ca-certificates.crt
+	for CERTFILE in `find $(PKG_INSTALL_DIR)/usr/share/ca-certificates/ -name "*.crt" | sort`; do \
+		cat $$$$CERTFILE >> $(1)/etc/ssl/certs/ca-certificates.crt; \
+	done;
 	$(LN) /etc/ssl/certs/ca-certificates.crt $(1)/etc/ssl/cert.pem
 endef
 $(eval $(call BuildPackage,ca-bundle))


### PR DESCRIPTION
The file was generated by a glob matching on all certificates. If the
filesystem was alphabetically sorted it would cause undeterministic
results. Instead use `find` and sort all found certificates.

Signed-off-by: Paul Spooren <mail@aparcar.org>