### PR TITLE
iptables: rename *tables-nft packages

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=iptables
 PKG_VERSION:=1.8.7
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE_URL:=https://netfilter.org/projects/iptables/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -104,7 +104,7 @@ endef
 define Package/xtables-nft
 $(call Package/iptables/Default)
   TITLE:=IP firewall administration tool nft
-  DEPENDS:=@IPTABLES_NFTABLES +libnftnl +libiptext +IPV6:libiptext6 +libiptext-nft +kmod-nft-compat
+  DEPENDS:=+libnftnl +libiptext +IPV6:libiptext6 +libiptext-nft +kmod-nft-compat
 endef
 
 define Package/arptables-nft
@@ -134,6 +134,8 @@ $(call Package/iptables/Default)
   TITLE:=IP firewall administration tool nft
   DEPENDS:=+kmod-ipt-core +xtables-nft
   PROVIDES:=iptables
+  VARIANT:=nft
+  DEFAULT_VARIANT:=1
   ALTERNATIVES:=\
     300:/usr/sbin/iptables:/usr/sbin/xtables-nft-multi \
     300:/usr/sbin/iptables-restore:/usr/sbin/xtables-nft-multi \
@@ -500,6 +502,8 @@ $(call Package/iptables/Default)
   DEPENDS:=@IPV6 +kmod-ip6tables +xtables-nft
   TITLE:=IP firewall administration tool nft
   PROVIDES:=ip6tables
+  VARIANT:=nft
+  DEFAULT_VARIANT:=1
   ALTERNATIVES:=\
     300:/usr/sbin/ip6tables:/usr/sbin/xtables-nft-multi \
     300:/usr/sbin/ip6tables-restore:/usr/sbin/xtables-nft-multi \
@@ -575,7 +579,7 @@ define Package/libiptext-nft
  CATEGORY:=Libraries
  TITLE:=IPv4/IPv6 firewall - shared libiptext nft library
  ABI_VERSION:=0
- DEPENDS:=@IPTABLES_NFTABLES +libxtables
+ DEPENDS:=+libxtables
 endef
 
 define Package/libxtables
@@ -594,12 +598,6 @@ define Package/libxtables/config
 	default n
 	help
 		This enable connlabel support in iptables.
-
-  config IPTABLES_NFTABLES
-	bool "Enable Nftables support"
-	default y
-	help
-		This enable nftables support in iptables.
 endef
 
 TARGET_CPPFLAGS := \
@@ -624,7 +622,6 @@ CONFIGURE_ARGS += \
 	--with-xtlibdir=/usr/lib/iptables \
 	--with-xt-lock-name=/var/run/xtables.lock \
 	$(if $(CONFIG_IPTABLES_CONNLABEL),,--disable-connlabel) \
-	$(if $(CONFIG_IPTABLES_NFTABLES),,--disable-nftables) \
 	$(if $(CONFIG_IPV6),,--disable-ipv6)
 
 MAKE_FLAGS := \


### PR DESCRIPTION
It only makes sense that we only have one PROVIDES definition for the
iptables packages, because a  mix of nft and legacy iptables backend
is not recommended at the same time.

Since the firewall4 is now the default firewall in openwrt, the
iptables-nft/ip6tables-nft backend for iptables must installed,
if a package wants to use the iptables/ip6tables commands.

@champtar @bluewavenet @hnyman 
In order to get further, I have now set up this pullreqest, as suggested in https://github.com/openwrt/openwrt/issues/9540, only set the PROVIDE for the iptables-nft and ip6tables-nft packages

Fixes #9540