### PR TITLE
qosify: change tc-full dependency to tc-bpf

### DIFF
--- a/package/network/config/qosify/Makefile
+++ b/package/network/config/qosify/Makefile
@@ -31,7 +31,7 @@ define Package/qosify
   SECTION:=utils
   CATEGORY:=Base system
   TITLE:=A simple QoS solution based eBPF + CAKE
-  DEPENDS:=+libbpf +libubox +libubus +kmod-sched-cake +kmod-sched-bpf +kmod-ifb +tc-full $(BPF_DEPENDS)
+  DEPENDS:=+libbpf +libubox +libubus +kmod-sched-cake +kmod-sched-bpf +kmod-ifb +tc-bpf $(BPF_DEPENDS)
 endef
 
 TARGET_CFLAGS += -Wno-error=deprecated-declarations


### PR DESCRIPTION
tc-full brings in iptables stuff that qosify doesn't need, so change the
dependency from tc-full to tc-bpf that better fits the package.

I tested this and it seems to be working as before,but some other users should test this, yet, I believe that if @nbd168 gives this the ok it should be fine since he is the maintainer of this package.

Signed-off-by: Tiago Gaspar <tiagogaspar8@gmail.com>