### PR TITLE
gpio-button-hotplug: fix data race

### DIFF
--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -107,7 +107,7 @@ static struct bh_map button_map[] = {
 static __printf(3, 4)
 int bh_event_add_var(struct bh_event *event, int argv, const char *format, ...)
 {
-	static char buf[128];
+	char buf[128];
 	char *s;
 	va_list args;
 	int len;


### PR DESCRIPTION
On our hardware, there is an action triggering 2 GPIO button interrupts simultaneously. If you're lucky, `procd` will receive correct netlink datagrams:
```
procd: {{"HOME":"/","PATH":"/sbin:/bin:/usr/sbin:/usr/bin","SUBSYSTEM":"button","ACTION":"released","BUTTON":"BTN_6","SEEN":"2","SEQNUM":"1262"}}
procd: {{"HOME":"/","PATH":"/sbin:/bin:/usr/sbin:/usr/bin","SUBSYSTEM":"button","ACTION":"pressed","BUTTON":"BTN_4","SEEN":"2","SEQNUM":"1263"}}
```
but sometimes (actually, quite often, the following examples occurred in a row) `procd` receives some gibberish, like the following one:
```
procd: {{"HOME":"/","PATH":"/sbin:/bin:/usr/sbin:/usr/bin","SUBSYSTEM":"button","ACTION":"released","BUTTON":"BTN_4","SEQNUM":"1276"}}
procd: {{"HOME":"/","PATH":"/sbin:/bin:/usr/sbin:/usr/bin","SUBSY0TEM":"button","c000400bBUTTON":"BTN_6","SEQNUM":"1276"}}
```
(`SUBSY0TEM` instead of `SUBSYSTEM`, `c000400bBUTTON`, no `ACTION` for `BTN_6`, same `SEQNUM`)
or the following:
```
procd: {{"HOME":"/","PATH":"/sbin:/bin:/usr/sbin:/usr/bin","SUBSYSTEM":"button","ACTION":"release","BUTTON":"BTN_6","SEEN":"1","SEQNUM":"1278"}}
procd: {{"HOME":"/","PATH":"/sbin:/bin:/usr/sbin:/usr/bin","SUBSYSTEM":"button","ACTION":"release","9BUTTON":"BTN_6","SEEN":"1","SEQNUM":"1278"}}
```
Yes, 2 datagrams for `BTN_6`, the second is with `9BUTTON`.

The change seems to fix the issue for us. (Prolly it shoulda been part of https://github.com/openwrt/openwrt/commit/69517e88bea6ac19626dbff16cdc5e4a9f55cc25)