### PR TITLE
lantiq: fritz736x: Move GPIO resets to the inidvidual board.dts files

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360-v2.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360-v2.dts
@@ -7,11 +7,23 @@
 	model = "AVM FRITZ!Box 7360 V2";
 };
 
-&state_default {
-	pcie-rst {
-		lantiq,pins = "io21";
-		lantiq,pull = <0>;
-		lantiq,output = <1>;
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		pcie-rst {
+			lantiq,pins = "io21";
+			lantiq,pull = <0>;
+			lantiq,output = <1>;
+		};
+
+		phy-rst {
+			lantiq,pins = "io37", "io44";
+			lantiq,pull = <0>;
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
 	};
 };
 
@@ -56,6 +68,14 @@
 	nvmem-cells = <&macaddr_urlader_a91>;
 	nvmem-cell-names = "mac-address";
 	mac-address-increment = <(-2)>;
+};
+
+&phy0 {
+	reset-gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+};
+
+&phy1 {
+	reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
 };
 
 &urlader {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360sl.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360sl.dts
@@ -7,12 +7,25 @@
 	model = "AVM FRITZ!Box 7360 SL";
 };
 
-&state_default {
-	pcie-rst {
-		lantiq,pins = "io38";
-		lantiq,pull = <0>;
-		lantiq,output = <1>;
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		pcie-rst {
+			lantiq,pins = "io21";
+			lantiq,pull = <0>;
+			lantiq,output = <1>;
+		};
+
+		phy-rst {
+			lantiq,pins = "io37", "io44";
+			lantiq,pull = <0>;
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
 	};
+
 };
 
 &localbus {
@@ -56,6 +69,14 @@
 	nvmem-cells = <&macaddr_urlader_a91>;
 	nvmem-cell-names = "mac-address";
 	mac-address-increment = <(-2)>;
+};
+
+&phy0 {
+	reset-gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+};
+
+&phy1 {
+	reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
 };
 
 &urlader {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7362sl.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7362sl.dts
@@ -7,12 +7,25 @@
 	model = "AVM FRITZ!Box 7362 SL";
 };
 
-&state_default {
-	pcie-rst {
-		lantiq,pins = "io21";
-		lantiq,open-drain = <1>;
-		lantiq,output = <1>;
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		pcie-rst {
+			lantiq,pins = "io21";
+			lantiq,pull = <0>;
+			lantiq,output = <1>;
+		};
+
+		phy-rst {
+			lantiq,pins = "io44", "io45";
+			lantiq,pull = <0>;
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
 	};
+
 };
 
 &spi {
@@ -94,6 +107,14 @@
 	nvmem-cells = <&macaddr_urlader_a91>;
 	nvmem-cell-names = "mac-address";
 	mac-address-increment = <(-2)>;
+};
+
+&phy0 {
+	reset-gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+};
+
+&phy1 {
+	reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
 };
 
 &urlader {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
@@ -88,21 +88,6 @@
 	lantiq,gphy-mode = <GPHY_MODE_GE>;
 };
 
-&gpio {
-	pinctrl-names = "default";
-	pinctrl-0 = <&state_default>;
-
-	state_default: pinmux {
-		phy-rst {
-			lantiq,pins = "io37", "io44";
-			lantiq,pull = <0>;
-			lantiq,open-drain;
-			lantiq,output = <1>;
-		};
-	};
-
-};
-
 &gswip {
 	pinctrl-0 = <&mdio_pins>;
 	pinctrl-names = "default";
@@ -111,12 +96,10 @@
 &gswip_mdio {
 	phy0: ethernet-phy@0 {
 		reg = <0x00>;
-		reset-gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
 	};
 
 	phy1: ethernet-phy@1 {
 		reg = <0x01>;
-		reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
 	};
 
 	phy11: ethernet-phy@11 {


### PR DESCRIPTION

I'm not an author of this commit . This was an part of the idea to handle switch regression #8833 . It failed but at least I can confirm GPIO 45 (port3)   and GPIO 44 (port4) on my FB7262SL . 
Below author comment:

FRITZ!Box 7360 V2 and FRITZ!Box 7360 SL both use GPIOs 37 (for &phy0)
and GPIO 44 (for &phy1) to control the PHY's reset lines. FRITZ!Box 7362
SL however uses GPIO 45 (for &phy0) and GPIO 44 (for &phy1). Move the
GPIO reset definitions to each individual board .dts and while at it,
fix the GPIOs for the FRITZ!Box 7362 SL.

Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com

