### PR TITLE
ath79: support ZTE MF286R built-in modem

### DIFF
--- a/package/network/utils/comgt/Makefile
+++ b/package/network/utils/comgt/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=comgt
 PKG_VERSION:=0.32
-PKG_RELEASE:=33
+PKG_RELEASE:=34
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=@SF/comgt

--- a/package/network/utils/comgt/files/ncm.json
+++ b/package/network/utils/comgt/files/ncm.json
@@ -74,5 +74,27 @@
 		"connect": "AT+CGACT=1,${profile}",
 		"finalize": "AT+CGDATA=\\\"M-MBIM\\\",${profile},1",
 		"disconnect": "AT+CGACT=0,${profile}"
+	},
+	"\"zte": {
+		"initialize": [
+			"AT+CFUN=1"
+		],
+		"configure": [
+			"AT+ZGDCONT=${profile},\\\"${pdptype}\\\",\\\"${apn}\\\",\\\"\\\",0,0",
+			"AT+ZGPCOAUTH=${profile},\\\"${username}\\\",\\\"${password}\\\",0"
+		],
+		"connect": "AT+ZGACT=1,${profile}",
+		"disconnect": "AT+ZGACT=0,${profile}"
+	},
+	"\"marvell\"": {
+		"initialize": [
+			"AT+CFUN=1"
+		],
+		"configure": [
+			"AT+ZGDCONT=${profile},\\\"${pdptype}\\\",\\\"${apn}\\\",\\\"\\\",0,0",
+			"AT+ZGPCOAUTH=${profile},\\\"${username}\\\",\\\"${password}\\\",0"
+		],
+		"connect": "AT+ZGACT=1,${profile}",
+		"disconnect": "AT+ZGACT=0,${profile}"
 	}
 }

--- a/package/network/utils/comgt/files/ncm.sh
+++ b/package/network/utils/comgt/files/ncm.sh
@@ -26,7 +26,7 @@ proto_ncm_init_config() {
 proto_ncm_setup() {
 	local interface="$1"
 
-	local manufacturer initialize setmode connect finalize devname devpath
+	local manufacturer initialize setmode connect finalize devname devpath ifpath
 
 	local device ifname  apn auth username password pincode delay mode pdptype profile $PROTO_DEFAULT_OPTIONS
 	json_get_vars device ifname apn auth username password pincode delay mode pdptype profile $PROTO_DEFAULT_OPTIONS
@@ -59,13 +59,14 @@ proto_ncm_setup() {
 		case "$devname" in
 		'tty'*)
 			devpath="$(readlink -f /sys/class/tty/$devname/device)"
-			ifname="$( ls "$devpath"/../../*/net )"
+			ifpath="$devpath/../../*/net"
 			;;
 		*)
 			devpath="$(readlink -f /sys/class/usbmisc/$devname/device/)"
-			ifname="$( ls "$devpath"/net )"
+			ifpath="$devpath/net"
 			;;
 		esac
+		ifname="$(ls $(ls -1 -d $ifpath | head -n 1))"
 	}
 
 	[ -n "$ifname" ] || {

--- a/package/network/utils/comgt/files/ncm.sh
+++ b/package/network/utils/comgt/files/ncm.sh
@@ -57,6 +57,10 @@ proto_ncm_setup() {
 	[ -z "$ifname" ] && {
 		devname="$(basename "$device")"
 		case "$devname" in
+		'ttyACM'*)
+			devpath="$(readlink -f /sys/class/tty/$devname/device)"
+			ifpath="$devpath/../*/net"
+			;;
 		'tty'*)
 			devpath="$(readlink -f /sys/class/tty/$devname/device)"
 			ifpath="$devpath/../../*/net"

--- a/package/network/utils/comgt/files/ncm.sh
+++ b/package/network/utils/comgt/files/ncm.sh
@@ -10,6 +10,7 @@ proto_ncm_init_config() {
 	no_device=1
 	available=1
 	proto_config_add_string "device:device"
+	proto_config_add_string ifname
 	proto_config_add_string apn
 	proto_config_add_string auth
 	proto_config_add_string username
@@ -25,10 +26,10 @@ proto_ncm_init_config() {
 proto_ncm_setup() {
 	local interface="$1"
 
-	local manufacturer initialize setmode connect finalize ifname devname devpath
+	local manufacturer initialize setmode connect finalize devname devpath
 
-	local device apn auth username password pincode delay mode pdptype profile $PROTO_DEFAULT_OPTIONS
-	json_get_vars device apn auth username password pincode delay mode pdptype profile $PROTO_DEFAULT_OPTIONS
+	local device ifname  apn auth username password pincode delay mode pdptype profile $PROTO_DEFAULT_OPTIONS
+	json_get_vars device ifname apn auth username password pincode delay mode pdptype profile $PROTO_DEFAULT_OPTIONS
 
 	[ "$metric" = "" ] && metric="0"
 
@@ -53,17 +54,20 @@ proto_ncm_setup() {
 		return 1
 	}
 
-	devname="$(basename "$device")"
-	case "$devname" in
-	'tty'*)
-		devpath="$(readlink -f /sys/class/tty/$devname/device)"
-		ifname="$( ls "$devpath"/../../*/net )"
-		;;
-	*)
-		devpath="$(readlink -f /sys/class/usbmisc/$devname/device/)"
-		ifname="$( ls "$devpath"/net )"
-		;;
-	esac
+	[ -z "$ifname" ] && {
+		devname="$(basename "$device")"
+		case "$devname" in
+		'tty'*)
+			devpath="$(readlink -f /sys/class/tty/$devname/device)"
+			ifname="$( ls "$devpath"/../../*/net )"
+			;;
+		*)
+			devpath="$(readlink -f /sys/class/usbmisc/$devname/device/)"
+			ifname="$( ls "$devpath"/net )"
+			;;
+		esac
+	}
+
 	[ -n "$ifname" ] || {
 		echo "The interface could not be found."
 		proto_notify_error "$interface" NO_IFACE

--- a/target/linux/generic/backport-5.10/880-v5.19-cdc_ether-export-usbnet_cdc_zte_rx_fixup.patch
+++ b/target/linux/generic/backport-5.10/880-v5.19-cdc_ether-export-usbnet_cdc_zte_rx_fixup.patch
@@ -1,0 +1,65 @@
+From d91a03b72c5f9c25e5b976f8f67bcf279601d644 Mon Sep 17 00:00:00 2001
+From: Lech Perczak <lech.perczak@gmail.com>
+Date: Fri, 1 Apr 2022 22:03:55 +0200
+Subject: [PATCH 1/3] cdc_ether: export usbnet_cdc_zte_rx_fixup
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Commit bfe9b9d2df66 ("cdc_ether: Improve ZTE MF823/831/910 handling")
+introduces a workaround for certain ZTE modems reporting invalid MAC
+addresses over CDC-ECM.
+The same issue was present on their RNDIS interface,which was fixed in
+commit a5a18bdf7453 ("rndis_host: Set valid random MAC on buggy devices").
+
+However, internal modem of ZTE MF286R router, on its RNDIS interface, also
+exhibits a second issue fixed already in CDC-ECM, of the device not
+respecting configured random MAC address. In order to share the fixup for
+this with rndis_host driver, export the workaround function, which will
+be re-used in the following commit in rndis_host.
+
+Cc: Kristian Evensen <kristian.evensen@gmail.com>
+Cc: Bjørn Mork <bjorn@mork.no>
+Cc: Oliver Neukum <oliver@neukum.org>
+Signed-off-by: Lech Perczak <lech.perczak@gmail.com>
+---
+ drivers/net/usb/cdc_ether.c | 3 ++-
+ include/linux/usb/usbnet.h  | 1 +
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/usb/cdc_ether.c b/drivers/net/usb/cdc_ether.c
+index 6aaa0675c28a..d78197343602 100644
+--- a/drivers/net/usb/cdc_ether.c
++++ b/drivers/net/usb/cdc_ether.c
+@@ -466,7 +466,7 @@ static int usbnet_cdc_zte_bind(struct usbnet *dev, struct usb_interface *intf)
+  * device MAC address has been updated). Always set MAC address to that of the
+  * device.
+  */
+-static int usbnet_cdc_zte_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
++int usbnet_cdc_zte_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
+ {
+ 	if (skb->len < ETH_HLEN || !(skb->data[0] & 0x02))
+ 		return 1;
+@@ -476,6 +476,7 @@ static int usbnet_cdc_zte_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
+ 
+ 	return 1;
+ }
++EXPORT_SYMBOL_GPL(usbnet_cdc_zte_rx_fixup);
+ 
+ /* Ensure correct link state
+  *
+diff --git a/include/linux/usb/usbnet.h b/include/linux/usb/usbnet.h
+index 8110c29fab42..3133b695fc21 100644
+--- a/include/linux/usb/usbnet.h
++++ b/include/linux/usb/usbnet.h
+@@ -215,6 +215,7 @@ extern int usbnet_ether_cdc_bind(struct usbnet *dev, struct usb_interface *intf)
+ extern int usbnet_cdc_bind(struct usbnet *, struct usb_interface *);
+ extern void usbnet_cdc_unbind(struct usbnet *, struct usb_interface *);
+ extern void usbnet_cdc_status(struct usbnet *, struct urb *);
++extern int usbnet_cdc_zte_rx_fixup(struct usbnet *dev, struct sk_buff *skb);
+ 
+ /* CDC and RNDIS support the same host-chosen packet filters for IN transfers */
+ #define	DEFAULT_FILTER	(USB_CDC_PACKET_TYPE_BROADCAST \
+-- 
+2.30.2
+

--- a/target/linux/generic/backport-5.10/881-v5.19-rndis_host-enable-the-bogus-MAC-fixup-for-ZTE-device.patch
+++ b/target/linux/generic/backport-5.10/881-v5.19-rndis_host-enable-the-bogus-MAC-fixup-for-ZTE-device.patch
@@ -1,0 +1,125 @@
+From 69a9efb689b43fedf5f19431f1889aa6b8d35d55 Mon Sep 17 00:00:00 2001
+From: Lech Perczak <lech.perczak@gmail.com>
+Date: Fri, 1 Apr 2022 22:04:01 +0200
+Subject: [PATCH 2/3] rndis_host: enable the bogus MAC fixup for ZTE devices
+ from cdc_ether
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Certain ZTE modems, namely: MF823. MF831, MF910, built-in modem from
+MF286R, expose both CDC-ECM and RNDIS network interfaces.
+They have a trait of ignoring the locally-administered MAC address
+configured on the interface both in CDC-ECM and RNDIS part,
+and this leads to dropping of incoming traffic by the host.
+However, the workaround was only present in CDC-ECM, and MF286R
+explicitly requires it in RNDIS mode.
+
+Re-use the workaround in rndis_host as well, to fix operation of MF286R
+module, some versions of which expose only the RNDIS interface. Do so by
+introducing new flag, RNDIS_DRIVER_DATA_DST_MAC_FIXUP, and testing for it
+in rndis_rx_fixup. This is required, as RNDIS uses frame batching, and all
+of the packets inside the batch need the fixup. This might introduce a
+performance penalty, because test is done for every returned Ethernet
+frame.
+
+Apply the workaround to both "flavors" of RNDIS interfaces, as older ZTE
+modems, like MF823 found in the wild, report the USB_CLASS_COMM class
+interfaces, while MF286R reports USB_CLASS_WIRELESS_CONTROLLER.
+
+Suggested-by: Bjørn Mork <bjorn@mork.no>
+Cc: Kristian Evensen <kristian.evensen@gmail.com>
+Cc: Oliver Neukum <oliver@neukum.org>
+Signed-off-by: Lech Perczak <lech.perczak@gmail.com>
+---
+ drivers/net/usb/rndis_host.c   | 32 ++++++++++++++++++++++++++++++++
+ include/linux/usb/rndis_host.h |  1 +
+ 2 files changed, 33 insertions(+)
+
+diff --git a/drivers/net/usb/rndis_host.c b/drivers/net/usb/rndis_host.c
+index f9b359d4e293..5eaa453c32a8 100644
+--- a/drivers/net/usb/rndis_host.c
++++ b/drivers/net/usb/rndis_host.c
+@@ -485,10 +485,14 @@ EXPORT_SYMBOL_GPL(rndis_unbind);
+  */
+ int rndis_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
+ {
++	bool dst_mac_fixup;
++
+ 	/* This check is no longer done by usbnet */
+ 	if (skb->len < dev->net->hard_header_len)
+ 		return 0;
+ 
++	dst_mac_fixup = !!(dev->driver_info->data & RNDIS_DRIVER_DATA_DST_MAC_FIXUP);
++
+ 	/* peripheral may have batched packets to us... */
+ 	while (likely(skb->len)) {
+ 		struct rndis_data_hdr	*hdr = (void *)skb->data;
+@@ -523,10 +527,17 @@ int rndis_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
+ 			break;
+ 		skb_pull(skb, msg_len - sizeof *hdr);
+ 		skb_trim(skb2, data_len);
++
++		if (unlikely(dst_mac_fixup))
++			usbnet_cdc_zte_rx_fixup(dev, skb2);
++
+ 		usbnet_skb_return(dev, skb2);
+ 	}
+ 
+ 	/* caller will usbnet_skb_return the remaining packet */
++	if (unlikely(dst_mac_fixup))
++		usbnet_cdc_zte_rx_fixup(dev, skb);
++
+ 	return 1;
+ }
+ EXPORT_SYMBOL_GPL(rndis_rx_fixup);
+@@ -600,6 +611,17 @@ static const struct driver_info	rndis_poll_status_info = {
+ 	.tx_fixup =	rndis_tx_fixup,
+ };
+ 
++static const struct driver_info	zte_rndis_info = {
++	.description =	"ZTE RNDIS device",
++	.flags =	FLAG_ETHER | FLAG_POINTTOPOINT | FLAG_FRAMING_RN | FLAG_NO_SETINT,
++	.data =		RNDIS_DRIVER_DATA_DST_MAC_FIXUP,
++	.bind =		rndis_bind,
++	.unbind =	rndis_unbind,
++	.status =	rndis_status,
++	.rx_fixup =	rndis_rx_fixup,
++	.tx_fixup =	rndis_tx_fixup,
++};
++
+ /*-------------------------------------------------------------------------*/
+ 
+ static const struct usb_device_id	products [] = {
+@@ -608,6 +630,16 @@ static const struct usb_device_id	products [] = {
+ 	USB_DEVICE_AND_INTERFACE_INFO(0x1630, 0x0042,
+ 				      USB_CLASS_COMM, 2 /* ACM */, 0x0ff),
+ 	.driver_info = (unsigned long) &rndis_poll_status_info,
++}, {
++	/* ZTE WWAN modules */
++	USB_VENDOR_AND_INTERFACE_INFO(0x19d2,
++				      USB_CLASS_WIRELESS_CONTROLLER, 1, 3),
++	.driver_info = (unsigned long)&zte_rndis_info,
++}, {
++	/* ZTE WWAN modules, ACM flavour */
++	USB_VENDOR_AND_INTERFACE_INFO(0x19d2,
++				      USB_CLASS_COMM, 2 /* ACM */, 0x0ff),
++	.driver_info = (unsigned long)&zte_rndis_info,
+ }, {
+ 	/* RNDIS is MSFT's un-official variant of CDC ACM */
+ 	USB_INTERFACE_INFO(USB_CLASS_COMM, 2 /* ACM */, 0x0ff),
+diff --git a/include/linux/usb/rndis_host.h b/include/linux/usb/rndis_host.h
+index 809bccd08455..cc42db51bbba 100644
+--- a/include/linux/usb/rndis_host.h
++++ b/include/linux/usb/rndis_host.h
+@@ -197,6 +197,7 @@ struct rndis_keepalive_c {	/* IN (optionally OUT) */
+ 
+ /* Flags for driver_info::data */
+ #define RNDIS_DRIVER_DATA_POLL_STATUS	1	/* poll status before control */
++#define RNDIS_DRIVER_DATA_DST_MAC_FIXUP	2	/* device ignores configured MAC address */
+ 
+ extern void rndis_status(struct usbnet *dev, struct urb *urb);
+ extern int
+-- 
+2.30.2
+

--- a/target/linux/generic/backport-5.10/882-v5.19-rndis_host-limit-scope-of-bogus-MAC-address-detectio.patch
+++ b/target/linux/generic/backport-5.10/882-v5.19-rndis_host-limit-scope-of-bogus-MAC-address-detectio.patch
@@ -1,0 +1,68 @@
+From 1bfbe1799b9ec5d00f7f032d6e7db1980e466aeb Mon Sep 17 00:00:00 2001
+From: Lech Perczak <lech.perczak@gmail.com>
+Date: Sat, 2 Apr 2022 02:19:57 +0200
+Subject: [PATCH 3/3] rndis_host: limit scope of bogus MAC address detection to
+ ZTE devices
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Reporting of bogus MAC addresses and ignoring configuration of new
+destination address wasn't observed outside of a range of ZTE devices,
+among which this seems to be the common bug. Align rndis_host driver
+with implementation found in cdc_ether, which also limits this workaround
+to ZTE devices.
+
+Suggested-by: Bjørn Mork <bjorn@mork.no>
+Cc: Kristian Evensen <kristian.evensen@gmail.com>
+Cc: Oliver Neukum <oliver@neukum.org>
+Signed-off-by: Lech Perczak <lech.perczak@gmail.com>
+---
+ drivers/net/usb/rndis_host.c | 17 ++++++++++++-----
+ 1 file changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/usb/rndis_host.c b/drivers/net/usb/rndis_host.c
+index 5eaa453c32a8..c4c9f2407740 100644
+--- a/drivers/net/usb/rndis_host.c
++++ b/drivers/net/usb/rndis_host.c
+@@ -418,10 +418,7 @@ generic_rndis_bind(struct usbnet *dev, struct usb_interface *intf, int flags)
+ 		goto halt_fail_and_release;
+ 	}
+ 
+-	if (bp[0] & 0x02)
+-		eth_hw_addr_random(net);
+-	else
+-		ether_addr_copy(net->dev_addr, bp);
++	ether_addr_copy(net->dev_addr, bp);
+ 
+ 	/* set a nonzero filter to enable data transfers */
+ 	memset(u.set, 0, sizeof *u.set);
+@@ -463,6 +460,16 @@ static int rndis_bind(struct usbnet *dev, struct usb_interface *intf)
+ 	return generic_rndis_bind(dev, intf, FLAG_RNDIS_PHYM_NOT_WIRELESS);
+ }
+ 
++static int zte_rndis_bind(struct usbnet *dev, struct usb_interface *intf)
++{
++	int status = rndis_bind(dev, intf);
++
++	if (!status && (dev->net->dev_addr[0] & 0x02))
++		eth_hw_addr_random(dev->net);
++
++	return status;
++}
++
+ void rndis_unbind(struct usbnet *dev, struct usb_interface *intf)
+ {
+ 	struct rndis_halt	*halt;
+@@ -615,7 +622,7 @@ static const struct driver_info	zte_rndis_info = {
+ 	.description =	"ZTE RNDIS device",
+ 	.flags =	FLAG_ETHER | FLAG_POINTTOPOINT | FLAG_FRAMING_RN | FLAG_NO_SETINT,
+ 	.data =		RNDIS_DRIVER_DATA_DST_MAC_FIXUP,
+-	.bind =		rndis_bind,
++	.bind =		zte_rndis_bind,
+ 	.unbind =	rndis_unbind,
+ 	.status =	rndis_status,
+ 	.rx_fixup =	rndis_rx_fixup,
+-- 
+2.30.2
+

--- a/target/linux/generic/backport-5.15/880-v5.19-cdc_ether-export-usbnet_cdc_zte_rx_fixup.patch
+++ b/target/linux/generic/backport-5.15/880-v5.19-cdc_ether-export-usbnet_cdc_zte_rx_fixup.patch
@@ -1,0 +1,65 @@
+From a79a5613e1907e1bf09bb6ba6fd5ff43b66c1afe Mon Sep 17 00:00:00 2001
+From: Lech Perczak <lech.perczak@gmail.com>
+Date: Fri, 1 Apr 2022 22:03:55 +0200
+Subject: [PATCH 1/3] cdc_ether: export usbnet_cdc_zte_rx_fixup
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Commit bfe9b9d2df66 ("cdc_ether: Improve ZTE MF823/831/910 handling")
+introduces a workaround for certain ZTE modems reporting invalid MAC
+addresses over CDC-ECM.
+The same issue was present on their RNDIS interface,which was fixed in
+commit a5a18bdf7453 ("rndis_host: Set valid random MAC on buggy devices").
+
+However, internal modem of ZTE MF286R router, on its RNDIS interface, also
+exhibits a second issue fixed already in CDC-ECM, of the device not
+respecting configured random MAC address. In order to share the fixup for
+this with rndis_host driver, export the workaround function, which will
+be re-used in the following commit in rndis_host.
+
+Cc: Kristian Evensen <kristian.evensen@gmail.com>
+Cc: Bjørn Mork <bjorn@mork.no>
+Cc: Oliver Neukum <oliver@neukum.org>
+Signed-off-by: Lech Perczak <lech.perczak@gmail.com>
+---
+ drivers/net/usb/cdc_ether.c | 3 ++-
+ include/linux/usb/usbnet.h  | 1 +
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/usb/cdc_ether.c b/drivers/net/usb/cdc_ether.c
+index 9b4dfa3001d6..2de09ad5bac0 100644
+--- a/drivers/net/usb/cdc_ether.c
++++ b/drivers/net/usb/cdc_ether.c
+@@ -479,7 +479,7 @@ static int usbnet_cdc_zte_bind(struct usbnet *dev, struct usb_interface *intf)
+  * device MAC address has been updated). Always set MAC address to that of the
+  * device.
+  */
+-static int usbnet_cdc_zte_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
++int usbnet_cdc_zte_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
+ {
+ 	if (skb->len < ETH_HLEN || !(skb->data[0] & 0x02))
+ 		return 1;
+@@ -489,6 +489,7 @@ static int usbnet_cdc_zte_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
+ 
+ 	return 1;
+ }
++EXPORT_SYMBOL_GPL(usbnet_cdc_zte_rx_fixup);
+ 
+ /* Ensure correct link state
+  *
+diff --git a/include/linux/usb/usbnet.h b/include/linux/usb/usbnet.h
+index 8336e86ce606..1b4d72d5e891 100644
+--- a/include/linux/usb/usbnet.h
++++ b/include/linux/usb/usbnet.h
+@@ -214,6 +214,7 @@ extern int usbnet_ether_cdc_bind(struct usbnet *dev, struct usb_interface *intf)
+ extern int usbnet_cdc_bind(struct usbnet *, struct usb_interface *);
+ extern void usbnet_cdc_unbind(struct usbnet *, struct usb_interface *);
+ extern void usbnet_cdc_status(struct usbnet *, struct urb *);
++extern int usbnet_cdc_zte_rx_fixup(struct usbnet *dev, struct sk_buff *skb);
+ 
+ /* CDC and RNDIS support the same host-chosen packet filters for IN transfers */
+ #define	DEFAULT_FILTER	(USB_CDC_PACKET_TYPE_BROADCAST \
+-- 
+2.30.2
+

--- a/target/linux/generic/backport-5.15/881-v5.19-rndis_host-enable-the-bogus-MAC-fixup-for-ZTE-device.patch
+++ b/target/linux/generic/backport-5.15/881-v5.19-rndis_host-enable-the-bogus-MAC-fixup-for-ZTE-device.patch
@@ -1,0 +1,125 @@
+From aa8aff10e969aca0cb64f5e54ff7489355582667 Mon Sep 17 00:00:00 2001
+From: Lech Perczak <lech.perczak@gmail.com>
+Date: Fri, 1 Apr 2022 22:04:01 +0200
+Subject: [PATCH 2/3] rndis_host: enable the bogus MAC fixup for ZTE devices
+ from cdc_ether
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Certain ZTE modems, namely: MF823. MF831, MF910, built-in modem from
+MF286R, expose both CDC-ECM and RNDIS network interfaces.
+They have a trait of ignoring the locally-administered MAC address
+configured on the interface both in CDC-ECM and RNDIS part,
+and this leads to dropping of incoming traffic by the host.
+However, the workaround was only present in CDC-ECM, and MF286R
+explicitly requires it in RNDIS mode.
+
+Re-use the workaround in rndis_host as well, to fix operation of MF286R
+module, some versions of which expose only the RNDIS interface. Do so by
+introducing new flag, RNDIS_DRIVER_DATA_DST_MAC_FIXUP, and testing for it
+in rndis_rx_fixup. This is required, as RNDIS uses frame batching, and all
+of the packets inside the batch need the fixup. This might introduce a
+performance penalty, because test is done for every returned Ethernet
+frame.
+
+Apply the workaround to both "flavors" of RNDIS interfaces, as older ZTE
+modems, like MF823 found in the wild, report the USB_CLASS_COMM class
+interfaces, while MF286R reports USB_CLASS_WIRELESS_CONTROLLER.
+
+Suggested-by: Bjørn Mork <bjorn@mork.no>
+Cc: Kristian Evensen <kristian.evensen@gmail.com>
+Cc: Oliver Neukum <oliver@neukum.org>
+Signed-off-by: Lech Perczak <lech.perczak@gmail.com>
+---
+ drivers/net/usb/rndis_host.c   | 32 ++++++++++++++++++++++++++++++++
+ include/linux/usb/rndis_host.h |  1 +
+ 2 files changed, 33 insertions(+)
+
+diff --git a/drivers/net/usb/rndis_host.c b/drivers/net/usb/rndis_host.c
+index bedd36ab5cf0..8d187c424cc5 100644
+--- a/drivers/net/usb/rndis_host.c
++++ b/drivers/net/usb/rndis_host.c
+@@ -485,10 +485,14 @@ EXPORT_SYMBOL_GPL(rndis_unbind);
+  */
+ int rndis_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
+ {
++	bool dst_mac_fixup;
++
+ 	/* This check is no longer done by usbnet */
+ 	if (skb->len < dev->net->hard_header_len)
+ 		return 0;
+ 
++	dst_mac_fixup = !!(dev->driver_info->data & RNDIS_DRIVER_DATA_DST_MAC_FIXUP);
++
+ 	/* peripheral may have batched packets to us... */
+ 	while (likely(skb->len)) {
+ 		struct rndis_data_hdr	*hdr = (void *)skb->data;
+@@ -523,10 +527,17 @@ int rndis_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
+ 			break;
+ 		skb_pull(skb, msg_len - sizeof *hdr);
+ 		skb_trim(skb2, data_len);
++
++		if (unlikely(dst_mac_fixup))
++			usbnet_cdc_zte_rx_fixup(dev, skb2);
++
+ 		usbnet_skb_return(dev, skb2);
+ 	}
+ 
+ 	/* caller will usbnet_skb_return the remaining packet */
++	if (unlikely(dst_mac_fixup))
++		usbnet_cdc_zte_rx_fixup(dev, skb);
++
+ 	return 1;
+ }
+ EXPORT_SYMBOL_GPL(rndis_rx_fixup);
+@@ -600,6 +611,17 @@ static const struct driver_info	rndis_poll_status_info = {
+ 	.tx_fixup =	rndis_tx_fixup,
+ };
+ 
++static const struct driver_info	zte_rndis_info = {
++	.description =	"ZTE RNDIS device",
++	.flags =	FLAG_ETHER | FLAG_POINTTOPOINT | FLAG_FRAMING_RN | FLAG_NO_SETINT,
++	.data =		RNDIS_DRIVER_DATA_DST_MAC_FIXUP,
++	.bind =		rndis_bind,
++	.unbind =	rndis_unbind,
++	.status =	rndis_status,
++	.rx_fixup =	rndis_rx_fixup,
++	.tx_fixup =	rndis_tx_fixup,
++};
++
+ /*-------------------------------------------------------------------------*/
+ 
+ static const struct usb_device_id	products [] = {
+@@ -613,6 +635,16 @@ static const struct usb_device_id	products [] = {
+ 	USB_VENDOR_AND_INTERFACE_INFO(0x238b,
+ 				      USB_CLASS_COMM, 2 /* ACM */, 0x0ff),
+ 	.driver_info = (unsigned long)&rndis_info,
++}, {
++	/* ZTE WWAN modules */
++	USB_VENDOR_AND_INTERFACE_INFO(0x19d2,
++				      USB_CLASS_WIRELESS_CONTROLLER, 1, 3),
++	.driver_info = (unsigned long)&zte_rndis_info,
++}, {
++	/* ZTE WWAN modules, ACM flavour */
++	USB_VENDOR_AND_INTERFACE_INFO(0x19d2,
++				      USB_CLASS_COMM, 2 /* ACM */, 0x0ff),
++	.driver_info = (unsigned long)&zte_rndis_info,
+ }, {
+ 	/* RNDIS is MSFT's un-official variant of CDC ACM */
+ 	USB_INTERFACE_INFO(USB_CLASS_COMM, 2 /* ACM */, 0x0ff),
+diff --git a/include/linux/usb/rndis_host.h b/include/linux/usb/rndis_host.h
+index 809bccd08455..cc42db51bbba 100644
+--- a/include/linux/usb/rndis_host.h
++++ b/include/linux/usb/rndis_host.h
+@@ -197,6 +197,7 @@ struct rndis_keepalive_c {	/* IN (optionally OUT) */
+ 
+ /* Flags for driver_info::data */
+ #define RNDIS_DRIVER_DATA_POLL_STATUS	1	/* poll status before control */
++#define RNDIS_DRIVER_DATA_DST_MAC_FIXUP	2	/* device ignores configured MAC address */
+ 
+ extern void rndis_status(struct usbnet *dev, struct urb *urb);
+ extern int
+-- 
+2.30.2
+

--- a/target/linux/generic/backport-5.15/882-v5.19-rndis_host-limit-scope-of-bogus-MAC-address-detectio.patch
+++ b/target/linux/generic/backport-5.15/882-v5.19-rndis_host-limit-scope-of-bogus-MAC-address-detectio.patch
@@ -1,0 +1,68 @@
+From 9bfb4bcda7ba32d73ea322ea56a8ebe32e9247f6 Mon Sep 17 00:00:00 2001
+From: Lech Perczak <lech.perczak@gmail.com>
+Date: Sat, 2 Apr 2022 02:19:57 +0200
+Subject: [PATCH 3/3] rndis_host: limit scope of bogus MAC address detection to
+ ZTE devices
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Reporting of bogus MAC addresses and ignoring configuration of new
+destination address wasn't observed outside of a range of ZTE devices,
+among which this seems to be the common bug. Align rndis_host driver
+with implementation found in cdc_ether, which also limits this workaround
+to ZTE devices.
+
+Suggested-by: Bjørn Mork <bjorn@mork.no>
+Cc: Kristian Evensen <kristian.evensen@gmail.com>
+Cc: Oliver Neukum <oliver@neukum.org>
+Signed-off-by: Lech Perczak <lech.perczak@gmail.com>
+---
+ drivers/net/usb/rndis_host.c | 17 ++++++++++++-----
+ 1 file changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/usb/rndis_host.c b/drivers/net/usb/rndis_host.c
+index 8d187c424cc5..fe2d347b817d 100644
+--- a/drivers/net/usb/rndis_host.c
++++ b/drivers/net/usb/rndis_host.c
+@@ -418,10 +418,7 @@ generic_rndis_bind(struct usbnet *dev, struct usb_interface *intf, int flags)
+ 		goto halt_fail_and_release;
+ 	}
+ 
+-	if (bp[0] & 0x02)
+-		eth_hw_addr_random(net);
+-	else
+-		ether_addr_copy(net->dev_addr, bp);
++	ether_addr_copy(net->dev_addr, bp);
+ 
+ 	/* set a nonzero filter to enable data transfers */
+ 	memset(u.set, 0, sizeof *u.set);
+@@ -463,6 +460,16 @@ static int rndis_bind(struct usbnet *dev, struct usb_interface *intf)
+ 	return generic_rndis_bind(dev, intf, FLAG_RNDIS_PHYM_NOT_WIRELESS);
+ }
+ 
++static int zte_rndis_bind(struct usbnet *dev, struct usb_interface *intf)
++{
++	int status = rndis_bind(dev, intf);
++
++	if (!status && (dev->net->dev_addr[0] & 0x02))
++		eth_hw_addr_random(dev->net);
++
++	return status;
++}
++
+ void rndis_unbind(struct usbnet *dev, struct usb_interface *intf)
+ {
+ 	struct rndis_halt	*halt;
+@@ -615,7 +622,7 @@ static const struct driver_info	zte_rndis_info = {
+ 	.description =	"ZTE RNDIS device",
+ 	.flags =	FLAG_ETHER | FLAG_POINTTOPOINT | FLAG_FRAMING_RN | FLAG_NO_SETINT,
+ 	.data =		RNDIS_DRIVER_DATA_DST_MAC_FIXUP,
+-	.bind =		rndis_bind,
++	.bind =		zte_rndis_bind,
+ 	.unbind =	rndis_unbind,
+ 	.status =	rndis_status,
+ 	.rx_fixup =	rndis_rx_fixup,
+-- 
+2.30.2
+


### PR DESCRIPTION
This series completes the support of ZTE MF286R router added in commit 7ac8da00609f42b8aba74b7efc6b0d055b7cef3e.

First patch contains required kernel fixes to rndis_host driver, which is the primary network interface of the modem, without which the modem would set wrong MAC on outgoing traffic towards the router over RNDIS interface. The patches were just sent to LKML for upstreaming

Second patch allows NCM protocol handler to use explicitly configure network interface name - which is useful if a modem exposes multilple network interfaces, as is the case with some (not all) variants of MF286R's modem, which expose ECM and RNDIS at the same time.

Third patch fixes error in NCM protocol handler in modems exposing >1 interface, by selecting the network interface bound to the lowest USB interface of the device. 

Fourth patch allows to detect network ports on modems exposing ttyACM ports, which have a minor diffference in their sysfs semantics.

Finally, fifth patch adds the requisite AT commands to configure the MF286R internal modem and establish the connection. 

With that series, the support for MF286R is on par with other devices of MF286 series, and thus it probably deserves to be cherry-picked to 22.03 release. 

CC @obsy @chunkeey @bmork @kristrev