### PR TITLE
[21.02] Backport bpftools: fix feature override for masking clang

### DIFF
--- a/package/network/utils/bpftools/Makefile
+++ b/package/network/utils/bpftools/Makefile
@@ -128,7 +128,7 @@ define Build/Configure
 		| sort | uniq > FEATURE-DUMP.openwrt)
 	$(SED) 's/feature-libbfd=1/feature-libbfd=$(HAVE_LIBBFD)/' \
 		-e 's/feature-libcap=1/feature-libcap=$(HAVE_LIBCAP)/' \
-		-e 's/feature-clang-bpf-global-var=1/feature-clang-bpf-global-var=$(HAVE_CLANG)/' \
+		-e 's/feature-clang-bpf-co-re=1/feature-clang-bpf-co-re=$(HAVE_CLANG)/' \
 		$(PKG_BUILD_DIR)/FEATURE-DUMP.openwrt
 endef
 


### PR DESCRIPTION
This will allow building bpftool-full and dependent packages for OpenWrt 21.02 on recent releases of certain Linux distributions (e.g. Fedora 35+, Void Linux).

#### Backported commit message follows:

Rename feature variable clang-bpf-global-var following upstream changes.
This restores the HAVE_CLANG feature override and should avoid rare build
errors where a recent host clang and BTF-enabled host kernel are present.

Fixes: 23be333401f0 ("bpftools: update to 5.10.10")
Signed-off-by: Tony Ambardar <itugrok@yahoo.com>
(cherry picked from commit cf20f1bb5f0479c2509dd651d08e235a3b9e8755)