### PR TITLE
ramips: mt7621: make u_env partition r/w for Linksys EA7xxx devices

### DIFF
--- a/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
+++ b/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
@@ -95,7 +95,6 @@
 		partition@80000 {
 			label = "u_env";
 			reg = <0x80000 0x40000>;
-			read-only;
 		};
 
 		factory: partition@c0000 {


### PR DESCRIPTION
Linksys EA7300 (all versions)
Make u_env partition read/write - currently cannot write to it, which blocks fw_setenv
This in turn breaks features like Advanced Reboot, which rely on setting the environment variable boot_part (1 or 2)

Thanks!