### PR TITLE
packages/px5g-wolfssl: Add version to Makefile

### DIFF
--- a/package/utils/px5g-wolfssl/Makefile
+++ b/package/utils/px5g-wolfssl/Makefile
@@ -5,6 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=px5g-wolfssl
+PKG_VERSION:=1.0.2
 PKG_RELEASE:=$(COMMITCOUNT)
 PKG_LICENSE:=GPL-2.0-or-later
 


### PR DESCRIPTION
The lack of a version in the Makefile was causing a clean build to fail.  I have no idea what version the original author would want.  I just used the commit history to make a guess.  Adding this line fixes the build.

Signed-off-by: Tim Thorpe <timfthorpe@gmail.com>