### PR TITLE
build: image: use printf for string prefix

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -4,7 +4,7 @@ IMAGE_KERNEL = $(word 1,$^)
 IMAGE_ROOTFS = $(word 2,$^)
 
 define ModelNameLimit16
-$(shell expr substr "$(word 2, $(subst _, ,$(1)))" 1 16)
+$(shell printf %.16s "$(word 2, $(subst _, ,$(1)))")
 endef
 
 define rootfs_align


### PR DESCRIPTION
syntax error on macos, for substr is undefined results according to the POSIX standard.

The manual of expr on macos says
```
     According to the POSIX standard, the use of string arguments length,
     substr, index, or match produces undefined results.  In this version of
     expr, these arguments are treated just as their respective string values.
```
