### PR TITLE
ath79: add Netgear WNDAP360

### DIFF
--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7100.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "netgear,wndap360", "qca,ar7161";
+	model = "Netgear WNDAP360";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_orange;
+		led-running = &led_power_orange;
+		led-upgrade = &led_power_orange;
+	};
+
+	extosc: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-output-names = "ref";
+		clock-frequency = <40000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: power_orange {
+			label = "orange:power";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wifi_2g_green {
+			label = "green:wlan2g";
+			gpios = <&ath9k0 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi_5g_green {
+			label = "green:wlan5g";
+			gpios = <&ath9k1 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x0f>;
+	phy1: ethernet-phy@1 {
+		reg = <0x1>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy1>;
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x790000>;
+			};
+
+			partition@7e0000 {
+				label = "nvram";
+				reg = <0x7e0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	ath9k0: wifi@0,11 {
+		compatible = "pci168c,0029";
+		reg = <0x8800 0 0 0 0>;
+		qca,no-eeprom;
+		nvmem-cells = <&macaddr_art_120c>;
+		nvmem-cell-names = "mac-address";
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+
+	ath9k1: wifi@0,12 {
+		compatible = "pci168c,0029";
+		reg = <0x9000 0 0 0 0>;
+		qca,no-eeprom;
+		nvmem-cells = <&macaddr_art_520c>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <1>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+
+	macaddr_art_120c: macaddr@120c {
+		reg = <0x120c 0x6>;
+	};
+
+	macaddr_art_520c: macaddr@520c {
+		reg = <0x520c 0x6>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -49,6 +49,7 @@ ath79_setup_interfaces()
 	netgear,ex6400|\
 	netgear,ex7300|\
 	netgear,ex7300-v2|\
+	netgear,wndap360|\
 	ocedo,koala|\
 	ocedo,raccoon|\
 	onion,omega|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -152,7 +152,8 @@ case "$FIRMWARE" in
 "ath9k-eeprom-pci-0000:00:11.0.bin")
 	case $board in
 	buffalo,wzr-600dhp|\
-	buffalo,wzr-hp-ag300h)
+	buffalo,wzr-hp-ag300h|\
+	netgear,wndap360)
 		caldata_extract "art" 0x1000 0xeb8
 		;;
 	dlink,dir-825-b1)
@@ -170,7 +171,8 @@ case "$FIRMWARE" in
 "ath9k-eeprom-pci-0000:00:12.0.bin")
 	case $board in
 	buffalo,wzr-600dhp|\
-	buffalo,wzr-hp-ag300h)
+	buffalo,wzr-hp-ag300h|\
+	netgear,wndap360)
 		caldata_extract "art" 0x5000 0xeb8
 		;;
 	dlink,dir-825-b1)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1642,6 +1642,21 @@ define Device/netgear_ex7300-v2
 endef
 TARGET_DEVICES += netgear_ex7300-v2
 
+define Device/netgear_wndap360
+  $(Device/netgear_generic)
+  SOC := ar7161
+  DEVICE_MODEL := WNDAP360
+  DEVICE_PACKAGES := kmod-leds-reset kmod-owl-loader
+  IMAGE_SIZE := 7744k
+  BLOCKSIZE := 256k
+  KERNEL := kernel-bin | append-dtb | gzip | uImage gzip
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | uImage none
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-rootfs | pad-rootfs | \
+	check-size | append-metadata
+endef
+TARGET_DEVICES += netgear_wndap360
+
 define Device/netgear_wndr3x00
   $(Device/netgear_generic)
   SOC := ar7161


### PR DESCRIPTION
[ath79: add Netgear WNDAP360](https://github.com/openwrt/openwrt/pull/9685/commits/7c158568bb5a489096a12d0ad29023a4331cbd0a)

SoC: Atheros AR7161
RAM: DDR 128 MiB (hynix h5dU5162ETR-E3C)
Flash: SPI-NOR 8 MiB (mx25l6406em2i-12g)
WLAN: 2.4/5 GHz
2.4 GHz: Atheros AR9220
5 GHz: Atheros AR9223
Ethernet: 4x 10/100/1000 Mbps (Atheros AR8021)
LEDs/Keys: 2/2 (Internet + System LED, Mesh button + Reset pin)
UART: RJ45 9600,8N1
Power: 12 VDC, 1.0 A

Installation instruction:
0. Make sure you have latest original firmware (3.7.11.4)
1. Connect to the Serial Port with a Serial Cable RJ45 to DB9/RS232
   (9600,8N1)
   screen  /dev/ttyUSB0 9600,cs8,-parenb,-cstopb,-hupcl,-crtscts,clocal
2. Configure your IP-Address to 192.168.1.42
3. When device boots hit spacebar
3. Configure the device for tftpboot
   setenv ipaddr 192.168.1.1
   setenv serverip 192.168.1.42
   saveenv
4. Reset the device
   reset
5. Hit again the spacebar
6. Now load the image via tftp:
   tftpboot 0x81000000 INITRAMFS.bin
7. Boot the image:
   bootm 0x81000000
8. Copy the squashfs-image to the device.
9. Do a sysupgrade.

https://openwrt.org/toh/netgear/wndap360

The device should be converted from kmod-owl-loader to nvmem-cells in the
future. Nvmem cells were not working. Maybe ATH9K_PCI_NO_EEPROM is missing.
That is why this commit is still using kmod-owl-loader. In the future
the device tree may look like this:

&ath9k0 {
       nvmem-cells = <&macaddr_art_120c>, <&cal_art_1000>;
       nvmem-cell-names = "mac-address", "calibration";
};

&ath9k1 {
       nvmem-cells = <&macaddr_art_520c>, <&cal_art_5000>;
       nvmem-cell-names = "mac-address", "calibration";
};

&art {
	...
	cal_art_1000: cal@1000 {
		reg = <0x1000 0xeb8>;
	};

	cal_art_5000: cal@5000 {
		reg = <0x5000 0xeb8>;
	};
};

ar71xx commit:
https://github.com/openwrt/openwrt/commit/10b3ca5ccbd602c6d38456431631269018809b87
