### PR TITLE
ramips: add support for Netgear WAX202

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -112,6 +112,15 @@ define Build/append-squashfs-fakeroot-be
 	cat $@.fakesquashfs >> $@
 endef
 
+define Build/append-squashfs4-fakeroot
+	rm -rf $@.fakefs $@.fakesquashfs
+	mkdir $@.fakefs
+	$(STAGING_DIR_HOST)/bin/mksquashfs4 \
+		$@.fakefs $@.fakesquashfs \
+		-nopad -noappend -root-owned
+	cat $@.fakesquashfs >> $@
+endef
+
 define Build/append-string
 	echo -n $(1) >> $@
 endef
@@ -374,6 +383,19 @@ define Build/netgear-dni
 		-r "$(1)" \
 		-i $@ -o $@.new
 	mv $@.new $@
+endef
+
+define Build/netgear-encrypted-factory
+	$(TOPDIR)/scripts/netgear-encrypted-factory.py \
+		--input-file $@ \
+		--output-file $@ \
+		--model $(NETGEAR_ENC_MODEL) \
+		--region $(NETGEAR_ENC_REGION) \
+		--version V1.0.0.0.$(VERSION_DIST).$(firstword $(subst -, ,$(REVISION))) \
+		--encryption-block-size 0x20000 \
+		--openssl-bin "$(STAGING_DIR_HOST)/bin/openssl" \
+		--key 6865392d342b4d212964363d6d7e7765312c7132613364316e26322a5a5e2538 \
+		--iv 4a253169516c38243d6c6d2d3b384145
 endef
 
 define Build/openmesh-image

--- a/scripts/netgear-encrypted-factory.py
+++ b/scripts/netgear-encrypted-factory.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import struct
+import subprocess
+import zlib
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input-file', type=str, required=True)
+    parser.add_argument('--output-file', type=str, required=True)
+    parser.add_argument('--model', type=str, required=True)
+    parser.add_argument('--region', type=str, required=True)
+    parser.add_argument('--version', type=str, required=True)
+    parser.add_argument('--encryption-block-size', type=str, required=True)
+    parser.add_argument('--openssl-bin', type=str, required=True)
+    parser.add_argument('--key', type=str, required=True)
+    parser.add_argument('--iv', type=str, required=True)
+    args = parser.parse_args()
+
+    assert re.match(r'V[0-9]\.[0-9]\.[0-9]\.[0-9]',
+                    args.version), 'Version must start with Vx.x.x.x'
+    encryption_block_size = int(args.encryption_block_size, 0)
+    assert (encryption_block_size > 0 and encryption_block_size % 16 ==
+            0), 'Encryption block size must be a multiple of the AES block size (16)'
+
+    image = open(args.input_file, 'rb').read()
+    image_enc = []
+    for i in range(0, len(image), encryption_block_size):
+        chunk = image[i:i + encryption_block_size]
+        chunk += b'\x00' * ((-len(chunk)) % 16)  # pad to AES block size (16)
+        res = subprocess.run([
+            args.openssl_bin,
+            'enc',
+            '-aes-256-cbc',
+            '-nosalt',
+            '-nopad',
+            '-K', args.key,
+            '-iv', args.iv
+        ],
+            check=True, input=chunk, stdout=subprocess.PIPE)
+        image_enc.append(res.stdout)
+    image_enc = b''.join(image_enc)
+
+    image_with_header = struct.pack(
+        '>32s32s64s64s64s256s12sII',
+        args.model.encode('ascii'),
+        args.region.encode('ascii'),
+        args.version.encode('ascii'),
+        b'Thu Jan 1 00:00:00 1970',  # static date for reproducibility
+        b'',  # reserved
+        b'',  # RSA signature - omitted for now
+        b'encrpted_img',
+        len(image_enc),
+        encryption_block_size,
+    ) + image_enc
+
+    checksum = zlib.crc32(image_with_header, 0xffffffff) ^ 0xffffffff
+
+    with open(args.output_file, 'wb') as outfile:
+        outfile.write(image_with_header)
+        outfile.write(struct.pack('>I', checksum))
+
+
+if __name__ == "__main__":
+    main()

--- a/target/linux/ramips/dts/mt7621_netgear_wax202.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_wax202.dts
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "netgear,wax202", "mediatek,mt7621-soc";
+	model = "Netgear WAX202";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_orange;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_orange;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_orange: power_orange {
+			label = "orange:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_net_green: net_green {
+			label = "green:net";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		led_net_blue: net_blue {
+			label = "blue:net";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan1_green: lan1_green {
+			label = "green:lan1";
+			gpios = <&switch0 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan1_orange: lan1_orange {
+			label = "orange:lan1";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan2_green: lan2_green {
+			label = "green:lan2";
+			gpios = <&switch0 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan2_orange: lan2_orange {
+			label = "orange:lan2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan3_green: lan3_green {
+			label = "green:lan3";
+			gpios = <&switch0 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan3_orange: lan3_orange {
+			label = "orange:lan3";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wifi2g_green: wifi2g_green {
+			label = "green:wifi2g";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		led_wifi2g_blue: wifi2g_blue {
+			label = "blue:wifi2g";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wifi5g_green: wifi5g_green {
+			label = "green:wifi5g";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+
+		led_wifi5g_blue: wifi5g_blue {
+			label = "blue:wifi5g";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "Factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+		};
+
+		partition@180000 {
+			label = "firmware";
+			reg = <0x180000 0x2600000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x2200000>;
+			};
+		};
+
+		partition@2780000 {
+			label = "firmware_backup";
+			reg = <0x2780000 0x2600000>;
+			read-only;
+		};
+
+		partition@4d80000 {
+			label = "CFG";
+			reg = <0x4d80000 0x800000>;
+			read-only;
+		};
+
+		partition@5580000 {
+			label = "RAE";
+			reg = <0x5580000 0x400000>;
+			read-only;
+		};
+
+		partition@5980000 {
+			label = "POT";
+			reg = <0x5980000 0x100000>;
+			read-only;
+		};
+
+		partition@5a80000 {
+			label = "Language";
+			reg = <0x5a80000 0x400000>;
+			read-only;
+		};
+
+		partition@5e80000 {
+			label = "Traffic";
+			reg = <0x5e80000 0x200000>;
+			read-only;
+		};
+
+		partition@6080000 {
+			label = "Cert";
+			reg = <0x6080000 0x100000>;
+			read-only;
+		};
+
+		partition@6180000 {
+			label = "NTGRcryptK";
+			reg = <0x6180000 0x100000>;
+			read-only;
+		};
+
+		partition@6280000 {
+			label = "NTGRcryptD";
+			reg = <0x6280000 0x500000>;
+			read-only;
+		};
+
+		partition@6780000 {
+			label = "LOG";
+			reg = <0x6780000 0x100000>;
+			read-only;
+		};
+
+		partition@6880000 {
+			label = "User_data";
+			reg = <0x6880000 0x640000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&pcie2 {
+	status = "disabled";
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "uart2", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	gpio-controller;
+	#gpio-cells = <2>;
+
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		/* port@3 is not used */
+
+		port@4 {
+			status = "okay";
+			label = "lan3";
+		};
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1413,6 +1413,29 @@ define Device/netgear_wac124
 endef
 TARGET_DEVICES += netgear_wac124
 
+define Device/netgear_wax202
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := NETGEAR
+  DEVICE_MODEL := WAX202
+  DEVICE_PACKAGES := kmod-mt7915e
+  NETGEAR_ENC_MODEL := WAX202
+  NETGEAR_ENC_REGION := US
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  IMAGE_SIZE := 38912k
+  KERNEL_SIZE := 4096k
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel 0x80001000 | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
+	append-squashfs4-fakeroot
+  IMAGES += factory.img
+  IMAGE/factory.img := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size | netgear-encrypted-factory
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += netgear_wax202
+
 define Device/netgear_wndr3700-v5
   $(Device/dsa-migration)
   $(Device/netgear_sercomm_nor)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -115,6 +115,12 @@ netgear,r7450)
 	ucidef_set_led_netdev "lan3" "LAN3" "white:lan3" "lan3"
 	ucidef_set_led_netdev "lan4" "LAN4" "white:lan4" "lan4"
 	;;
+netgear,wax202)
+	ucidef_set_led_netdev "internet" "Internet" "green:net" "wan"
+	ucidef_set_led_netdev "lan1" "LAN1" "green:lan1" "lan1"
+	ucidef_set_led_netdev "lan2" "LAN2" "green:lan2" "lan2"
+	ucidef_set_led_netdev "lan3" "LAN3" "green:lan3" "lan3"
+	;;
 oraybox,x3a)
 	ucidef_set_led_netdev "wan" "wan link" "red:status" "wan"
 	ucidef_set_led_netdev "lan" "lan link" "green:status" "br-lan"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -27,6 +27,7 @@ ramips_setup_interfaces()
 	ampedwireless,ally-r1900k|\
 	gehua,ghl-r-001|\
 	hiwifi,hc5962|\
+	netgear,wax202|\
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-ac2100|\
 	xiaomi,mi-router-cr6606|\
@@ -195,6 +196,11 @@ ramips_setup_macs()
 		label_mac=$(cat "/sys/firmware/mikrotik/hard_config/mac_base")
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add $label_mac 1)
+		;;
+	netgear,wax202)
+		lan_mac=$(mtd_get_mac_ascii Config mac)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
+		label_mac=$lan_mac
 		;;
 	raisecom,msg1500-x-00)
 		lan_mac=$(mtd_get_mac_ascii Config protest_lan_mac)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -76,6 +76,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		;;
+	netgear,wax202)
+		hw_mac_addr=$(mtd_get_mac_ascii Config mac)
+		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 3 > /sys${DEVPATH}/macaddress
+		;;
 	oraybox,x3a)
 		if [ "$PHYNBR" = "1" ]; then
 			hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -83,6 +83,7 @@ platform_do_upgrade() {
 	netgear,r7450|\
 	netgear,wac104|\
 	netgear,wac124|\
+	netgear,wax202|\
 	netis,wf2881|\
 	raisecom,msg1500-x-00|\
 	sercomm,na502|\


### PR DESCRIPTION
Netgear WAX202 is an 802.11ax (Wi-Fi 6) router.

Specifications:
* SoC: MT7621A
* RAM: 512 MiB NT5CC256M16ER-EK
* Flash: NAND 128 MiB F59L1G81MB-25T
* Wi-Fi:
  * MT7915D: 2.4/5 GHz (DBDC)
* Ethernet: 4x 1GbE
  * Switch: SoC built-in
* USB: None
* UART: 115200 baud (labeled on board)

Load addresses (same as ipTIME AX2004M):
* stock
  * 0x80010000: FIT image
  * 0x81001000: kernel image -> entry
* OpenWrt
  * 0x80010000: FIT image
  * 0x82000000: uncompressed kernel+relocate image
  * 0x80001000: relocated kernel image -> entry

Installation:
* Flash the factory image through the stock web interface, or TFTP to
  the bootloader. NMRP can be used to TFTP without opening the case.
* Note that the bootloader accepts both encrypted and unencrypted
  images, while the stock web interface only accepts encrypted ones.

Revert to stock firmware:
* Flash the stock firmware to the bootloader using TFTP/NMRP.

References in WAX202 GPL source:
https://www.downloads.netgear.com/files/GPL/WAX202_V1.0.5.1_Source.rar

* openwrt/target/linux/ramips/dts/mt7621-ax-nand-wax202.dts
  DTS file for this device.

* openwrt/bootloader/u-boot-mt7621-2018.09-gitb178829-20200526/board/ralink/common/dual_image.c
  Bootloader code that verifies the presence of a squashfs4 image, thus
  a dummy image is added here.

* openwrt/tools/imgencoder/src/gj_enc.c
  Contains code that generates the encrypted image. There is support for
  adding an RSA signature, but it does not look like the signature is
  verified by the stock firmware or bootloader.

* openwrt/tools/imgencoder/src/imagekey.h
  Contains the encryption key and IV. It appears the same key/IV is used
  for other Netgear devices including WAX206 and EX6400v3.

<details><summary>Stock boot log</summary>

```
===================================================================
     		MT7621   stage1 code Dec 16 2019 17:45:55 (ASIC)
     		CPU=500000000 HZ BUS=166666666 HZ
==================================================================
Change MPLL source from XTAL to CR...
do MEMPLL setting..
MEMPLL Config : 0x11000000
3PLL mode + External loopback
=== XTAL-40Mhz === DDR-1200Mhz ===
PLL4 FB_DL: 0x15, 1/0 = 596/428 55000000
PLL2 FB_DL: 0x16, 1/0 = 515/509 59000000
PLL3 FB_DL: 0x17, 1/0 = 581/443 5D000000
DDR patch working
do DDR setting..[01F40000]
Apply DDR3 Setting...(use default AC)
          0    8   16   24   32   40   48   56   64   72   80   88   96  104  112  120
      --------------------------------------------------------------------------------
0000:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0001:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0002:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0003:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0004:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0005:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0006:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0007:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0008:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0009:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
000A:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
000B:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
000C:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
000D:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    1
000E:|    0    0    0    0    0    0    0    0    0    1    1    1    1    1    1    1
000F:|    0    0    0    0    1    1    1    1    1    1    1    1    1    1    0    0
0010:|    1    1    1    1    1    1    1    1    1    0    0    0    0    0    0    0
0011:|    1    1    1    0    0    0    0    0    0    0    0    0    0    0    0    0
0012:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0013:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0014:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0015:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0016:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0017:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0018:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0019:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001A:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001B:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001C:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001D:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001E:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001F:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
DRAMC_DQSCTL1[0e0]=13000000
DRAMC_DQSGCTL[124]=80000033
rank 0 coarse = 15
rank 0 fine = 72
B:|    0    0    0    0    0    0    0    1    1    1    0    0    0    0    0    0
opt_dle value:8
DRAMC_DDR2CTL[07c]=C287220D
DRAMC_PADCTL4[0e4]=000022B3
DRAMC_DQIDLY1[210]=0B0B0A0A
DRAMC_DQIDLY2[214]=070A070A
DRAMC_DQIDLY3[218]=0D0C0909
DRAMC_DQIDLY4[21c]=0C0A0C0A
DRAMC_R0DELDLY[018]=00002120
==================================================================
		RX	DQS perbit delay software calibration 
==================================================================
1.0-15 bit dq delay value
==================================================================
bit|     0  1  2  3  4  5  6  7  8  9
--------------------------------------
0 |    8 9 9 11 10 7 9 7 7 7 
10 |    9 10 10 9 10 10 
--------------------------------------

==================================================================
2.dqs window
x=pass dqs delay value (min~max)center 
y=0-7bit DQ of every group
input delay:DQS0 =32 DQS1 = 33
==================================================================
bit	DQS0	 bit      DQS1
0  (1~60)30  8  (1~62)31
1  (1~61)31  9  (1~61)31
2  (1~60)30  10  (1~60)30
3  (1~64)32  11  (0~61)30
4  (1~63)32  12  (1~66)33
5  (1~64)32  13  (1~60)30
6  (1~62)31  14  (1~65)33
7  (1~64)32  15  (1~62)31
==================================================================
3.dq delay value last
==================================================================
bit|    0  1  2  3  4  5  6  7  8   9
--------------------------------------
0 |    10 10 11 11 10 7 10 7 9 9 
10 |    12 13 10 12 10 12 
==================================================================
==================================================================
     TX  perbyte calibration 
==================================================================
DQS loop = 15, cmp_err_1 = ffff0000 
dqs_perbyte_dly.last_dqsdly_pass[0]=15,  finish count=1 
dqs_perbyte_dly.last_dqsdly_pass[1]=15,  finish count=2 
DQ loop=15, cmp_err_1 = ffff0000
dqs_perbyte_dly.last_dqdly_pass[0]=15,  finish count=1 
dqs_perbyte_dly.last_dqdly_pass[1]=15,  finish count=2 
byte:0, (DQS,DQ)=(8,8)
byte:1, (DQS,DQ)=(8,8)
DRAMC_DQODLY1[200]=88888888
DRAMC_DQODLY2[204]=88888888
20,data:88
[EMI] DRAMC calibration passed

===================================================================
     		MT7621   stage1 code done 
     		CPU=500000000 HZ BUS=166666666 HZ
===================================================================

U-Boot SPL 2018.09 (Jun 11 2021 - 15:25:38 +0800)
Trying to boot from NAND


U-Boot 2018.09 (Jun 11 2021 - 15:25:38 +0800)

CPU:   MediaTek MT7621AT ver 1, eco 3
Clocks: CPU: 880MHz, DDR: 600MHz, Bus: 220MHz, XTAL: 40MHz
Model: MediaTek MT7621 reference board (NAND)
DRAM:  448 MiB
NAND:  128 MiB
Loading Environment from NAND... OK
In:    uartlite0@1e000c00
Out:   uartlite0@1e000c00
Err:   uartlite0@1e000c00
Net:   eth0: eth@1e100000
nmrp activated
nmrp listen timeout.
nmrp Nmrp_cleanup.
Hit any key to stop autoboot:  0 
  *** U-Boot Boot Menu ***  Press UP/DOWN to move, ENTER to select     1. Startup system (Default)     2. Upgrade firmware     3. Upgrade bootloader     4. Upgrade bootloader (advanced mode)     5. Load image     0. U-Boot console  Hit any key to stop autoboot:  1  0 
Starting dual image checking ...

NAND read: device 0 offset 0x180000, size 0x20000
 131072 bytes read: OK
image tag:    MTD_IMAGEA_TAG
get size :    0x16a0000

NAND read: device 0 offset 0x180000, size 0x16c0000
 23855104 bytes read: OK
image tag:    MTD_IMAGEA_TAG
image size:   0x16a0000
checksum:     0x1606f03f
image crc:    0x1606f03f
Verifying main image at 0x1a0000 size 0x25e0000...
## Checking hash(es) for FIT Image at 80010000 ...
   Hash(es) for Image 0 (kernel@1): crc32+ sha1+ 
   Hash(es) for Image 1 (fdt@1): crc32+ sha1+ 

NAND read: device 0 offset 0x2780000, size 0x20000
 131072 bytes read: OK
image tag:    MTD_IMAGEA_TAG
get size :    0x16a0000

NAND read: device 0 offset 0x2780000, size 0x16c0000
 23855104 bytes read: OK
image tag:    MTD_IMAGEA_TAG
image size:   0x16a0000
checksum:     0x1606f03f
image crc:    0x1606f03f
Verifying backup image at 0x27a0000 size 0x25e0000...
## Checking hash(es) for FIT Image at 80010000 ...
   Hash(es) for Image 0 (kernel@1): crc32+ sha1+ 
   Hash(es) for Image 1 (fdt@1): crc32+ sha1+ 
Passed

Loading from nand0, offset 0x180000
** Unknown image type
no partition number specified

Loading from nand0, offset 0x1a0000
Fit image detected...
   FIT description: MIPS OpenWrt FIT (Flattened Image Tree)
    Image 0 (kernel@1)
     Description:  MIPS OpenWrt Linux-4.4.198
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x800100e4
     Data Size:    3548387 Bytes = 3.4 MiB
     Architecture: MIPS
     OS:           Linux
     Load Address: 0x81001000
     Entry Point:  0x81001000
     Hash algo:    crc32
     Hash value:   f9121699
     Hash algo:    sha1
     Hash value:   2bef473c4f3a567f5cb4c3ba22a80e741fd7bfcd
    Image 1 (fdt@1)
     Description:  MIPS OpenWrt mt7621-ax-nand-wax202 device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x8037270c
     Data Size:    12909 Bytes = 12.6 KiB
     Architecture: MIPS
     Hash algo:    crc32
     Hash value:   b4a82fcf
     Hash algo:    sha1
     Hash value:   e624bf494011f0ed2cddf8d92188508cd58105b0
    Default Configuration: 'config@1'
    Configuration 0 (config@1)
     Description:  OpenWrt
     Kernel:       kernel@1
     FDT:          fdt@1
Automatic boot of image at addr 0x80010000 ...
## Loading kernel from FIT Image at 80010000 ...
   Using 'config@1' configuration
   Trying 'kernel@1' kernel subimage
     Description:  MIPS OpenWrt Linux-4.4.198
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x800100e4
     Data Size:    3548387 Bytes = 3.4 MiB
     Architecture: MIPS
     OS:           Linux
     Load Address: 0x81001000
     Entry Point:  0x81001000
     Hash algo:    crc32
     Hash value:   f9121699
     Hash algo:    sha1
     Hash value:   2bef473c4f3a567f5cb4c3ba22a80e741fd7bfcd
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt from FIT Image at 80010000 ...
   Using 'config@1' configuration
   Trying 'fdt@1' fdt subimage
     Description:  MIPS OpenWrt mt7621-ax-nand-wax202 device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x8037270c
     Data Size:    12909 Bytes = 12.6 KiB
     Architecture: MIPS
     Hash algo:    crc32
     Hash value:   b4a82fcf
     Hash algo:    sha1
     Hash value:   e624bf494011f0ed2cddf8d92188508cd58105b0
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x8037270c
   Uncompressing Kernel Image ... OK
   Loading Device Tree to 9be76000, end 9be7c26c ... OK
[    0.000000] Linux version 4.4.198 (build@Ubuntu18-BuildServer) (gcc version 7.5.0 (OpenWrt GCC 7.5.0 r0-c9bc004e7) ) #0 SMP Mon Jun 21 13:26:27 UTC 2021
[    0.000000] SoC Type: MediaTek MT7621 ver:1 eco:3
[    0.000000] bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 0001992f (MIPS 1004Kc)
[    0.000000] MIPS: machine is MediaTek MT7621 WAX202 (802.11ax,NAND)
[    0.000000] Determined physical RAM map:
[    0.000000]  memory: 1c000000 @ 00000000 (usable)
[    0.000000]  memory: 04000000 @ 20000000 (usable)
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000000000000-0x0000000000ffffff]
[    0.000000]   Normal   [mem 0x0000000001000000-0x000000000fffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000] On node 0 totalpages: 65536
[    0.000000] free_area_init_node: node 0, pgdat 818db580, node_mem_map 81d36000
[    0.000000]   DMA zone: 32 pages used for memmap
[    0.000000]   DMA zone: 0 pages reserved
[    0.000000]   DMA zone: 4096 pages, LIFO batch:0
[    0.000000]   Normal zone: 480 pages used for memmap
[    0.000000]   Normal zone: 61440 pages, LIFO batch:15
[    0.000000] VPE topology {2,2} total 4
[    0.000000] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.000000] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.000000] PERCPU: Embedded 10 pages/cpu @81f48000 s8544 r8192 d24224 u40960
[    0.000000] pcpu-alloc: s8544 r8192 d24224 u40960 alloc=10*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3 
[    0.000000] Built 1 zonelists in Zone order, mobility grouping on.  Total pages: 65024
[    0.000000] Kernel command line: console=ttyS0,115200 slub_debug=- loglevel=8 mtdoops.mtddev=LOG mtdoops.record_size=16384 rootfstype=squashfs,jffs2
[    0.000000] PID hash table entries: 1024 (order: 0, 4096 bytes)
[    0.000000] Dentry cache hash table entries: 32768 (order: 5, 131072 bytes)
[    0.000000] Inode-cache hash table entries: 16384 (order: 4, 65536 bytes)
[    0.000000] Writing ErrCtl register=0001441d
[    0.000000] Readback ErrCtl register=0001441d
[    0.000000] Memory: 246120K/262144K available (7282K kernel code, 4042K rwdata, 1708K rodata, 204K init, 270K bss, 16024K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] Hierarchical RCU implementation.
[    0.000000] NR_IRQS:256
[    0.000000] clocksource: GIC: mask: 0xffffffffffffffff max_cycles: 0xcaf478abb4, max_idle_ns: 440795247997 ns
[    0.000000] clocksource: MIPS: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 4343773742 ns
[    0.000009] sched_clock: 32 bits at 440MHz, resolution 2ns, wraps every 4880645118ns
[    0.007776] Calibrating delay loop... 586.13 BogoMIPS (lpj=2930688)
[    0.070401] pid_max: default: 32768 minimum: 301
[    0.075098] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes)
[    0.081621] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes)
[    6.150098] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    6.150108] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    6.150118] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    6.150264] CPU1 revision is: 0001992f (MIPS 1004Kc)
[    0.177424] Synchronize counters for CPU 1: done.
[    5.910333] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    5.910340] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    5.910346] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    5.910416] CPU2 revision is: 0001992f (MIPS 1004Kc)
[    0.267762] Synchronize counters for CPU 2: done.
[    6.000434] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    6.000440] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    6.000446] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    6.000529] CPU3 revision is: 0001992f (MIPS 1004Kc)
[    0.352936] Synchronize counters for CPU 3: done.
[    0.357672] Brought up 4 CPUs
[    0.365839] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.375640] futex hash table entries: 1024 (order: 3, 32768 bytes)
[    0.381945] pinctrl core: initialized pinctrl subsystem
[    0.388591] NET: Registered protocol family 16
[    0.401472] FPU Affinity set after 11720 emulations
[    0.427461] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.433134] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.438745] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.444913] mt7621-pci 1e140000.pcie: Failed to get gpio for PCIe1
[    0.451025] mt7621-pci 1e140000.pcie: Failed to get gpio for PCIe2
[    0.657504] PCIe port 2 link down
[    0.660737] PCI coherence region base: 0x60000000, mask/settings: 0xf0000002
[    0.700265] mtkmips-pinmux pinctrl: pin io3 already requested by pinctrl; cannot claim for 1e000000.palmbus:i2c@0
[    0.710469] mtkmips-pinmux pinctrl: pin-3 (1e000000.palmbus:i2c@0) status -22
[    0.717497] mtkmips-pinmux pinctrl: could not request pin 3 (io3) from group i2c  on device rt2880-pinmux
[    0.727019] i2c-gpio 1e000000.palmbus:i2c@0: Error applying setting, reverse things back
[    0.735267] i2c-gpio 1e000000.palmbus:i2c@0: using pins 3 (SDA) and 4 (SCL)
[    0.742698] PCI host bridge to bus 0000:00
[    0.746730] pci_bus 0000:00: root bus resource [mem 0x60000000-0x6fffffff]
[    0.753567] pci_bus 0000:00: root bus resource [io  0x1e160000-0x1e16ffff]
[    0.760375] pci_bus 0000:00: root bus resource [??? 0x00000000 flags 0x0]
[    0.767121] pci_bus 0000:00: No busn resource found for root bus, will use [bus 00-ff]
[    0.775012] pci 0000:00:00.0: [0e8d:0801] type 01 class 0x060400
[    0.780989] pci 0000:00:00.0: reg 0x14: [mem 0x00000000-0x0000ffff]
[    0.787203] pci 0000:00:00.0: supports D1
[    0.791141] pci 0000:00:00.0: PME# supported from D0 D1 D3hot
[    0.797057] pci 0000:00:01.0: [0e8d:0801] type 01 class 0x060400
[    0.803012] pci 0000:00:01.0: reg 0x14: [mem 0x00000000-0x0000ffff]
[    0.809225] pci 0000:00:01.0: supports D1
[    0.813169] pci 0000:00:01.0: PME# supported from D0 D1 D3hot
[    0.819110] pci 0000:00:00.0: bridge configuration invalid ([bus 00-00]), reconfiguring
[    0.827030] pci 0000:00:01.0: bridge configuration invalid ([bus 00-00]), reconfiguring
[    0.835144] pci 0000:01:00.0: [14c3:7916] type 00 class 0x000280
[    0.841136] pci 0000:01:00.0: reg 0x10: [mem 0x00000000-0x000fffff 64bit pref]
[    0.848273] pci 0000:01:00.0: reg 0x18: [mem 0x00000000-0x00003fff 64bit pref]
[    0.855455] pci 0000:01:00.0: reg 0x20: [mem 0x00000000-0x00000fff 64bit pref]
[    0.862692] pci 0000:01:00.0: supports D1 D2
[    0.866882] pci 0000:01:00.0: PME# supported from D0 D1 D2 D3hot D3cold
[    0.873632] pci_bus 0000:01: busn_res: [bus 01-ff] end is updated to 01
[    0.880344] pci 0000:02:00.0: [14c3:7915] type 00 class 0x000280
[    0.886311] pci 0000:02:00.0: reg 0x10: [mem 0x00000000-0x000fffff 64bit pref]
[    0.893468] pci 0000:02:00.0: reg 0x18: [mem 0x00000000-0x00003fff 64bit pref]
[    0.900620] pci 0000:02:00.0: reg 0x20: [mem 0x00000000-0x00000fff 64bit pref]
[    0.907878] pci 0000:02:00.0: supports D1 D2
[    0.912052] pci 0000:02:00.0: PME# supported from D0 D1 D2 D3hot D3cold
[    0.918843] pci_bus 0000:02: busn_res: [bus 02-ff] end is updated to 02
[    0.925358] pci_bus 0000:00: busn_res: [bus 00-ff] end is updated to 02
[    0.931998] pci 0000:00:00.0: BAR 9: assigned [mem 0x60000000-0x601fffff pref]
[    0.939119] pci 0000:00:01.0: BAR 9: assigned [mem 0x60200000-0x603fffff pref]
[    0.946301] pci 0000:00:00.0: BAR 1: assigned [mem 0x60400000-0x6040ffff]
[    0.953032] pci 0000:00:01.0: BAR 1: assigned [mem 0x60410000-0x6041ffff]
[    0.959794] pci 0000:01:00.0: BAR 0: assigned [mem 0x60000000-0x600fffff 64bit pref]
[    0.967467] pci 0000:01:00.0: BAR 2: assigned [mem 0x60100000-0x60103fff 64bit pref]
[    0.975179] pci 0000:01:00.0: BAR 4: assigned [mem 0x60104000-0x60104fff 64bit pref]
[    0.982851] pci 0000:00:00.0: PCI bridge to [bus 01]
[    0.987776] pci 0000:00:00.0:   bridge window [mem 0x60000000-0x601fffff pref]
[    0.994940] pci 0000:02:00.0: BAR 0: assigned [mem 0x60200000-0x602fffff 64bit pref]
[    1.002655] pci 0000:02:00.0: BAR 2: assigned [mem 0x60300000-0x60303fff 64bit pref]
[    1.010329] pci 0000:02:00.0: BAR 4: assigned [mem 0x60304000-0x60304fff 64bit pref]
[    1.018027] pci 0000:00:01.0: PCI bridge to [bus 02]
[    1.022927] pci 0000:00:01.0:   bridge window [mem 0x60200000-0x603fffff pref]
[    1.031778] clocksource: Switched to clocksource GIC
[    1.038526] NET: Registered protocol family 2
[    1.043545] TCP established hash table entries: 2048 (order: 1, 8192 bytes)
[    1.050428] TCP bind hash table entries: 2048 (order: 2, 16384 bytes)
[    1.056869] TCP: Hash tables configured (established 2048 bind 2048)
[    1.063219] UDP hash table entries: 256 (order: 1, 8192 bytes)
[    1.068968] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes)
[    1.075486] NET: Registered protocol family 1
[    1.079849] PCI: CLS 80 bytes, default 32
[    1.098208] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    1.104062] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    1.116709] io scheduler noop registered
[    1.120549] io scheduler deadline registered (default)
[    1.127340] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    1.134757] console [ttyS0] disabled
[    1.138285] 1e000c00.uartlite: ttyS0 at MMIO 0x1e000c00 (irq = 33, base_baud = 3125000) is a 16550A
\DB		R&)\D3Ӧ&LW\90\AC\CBk׋\AB\D2+W\AF*LW\90Y\B7X\B1\B6ed
[    1.147310] console [ttyS0] enabled
[    1.154219] bootconsole [early0] disabled
[    1.154219] bootconsole [early0] disabled
[    1.162661] 1e000d00.uartfull: ttyS1 at MMIO 0x1e000d00 (irq = 34, base_baud = 3125000) is a 16550A
[    1.172170] 1e000e00.uartfull: ttyS2 at MMIO 0x1e000e00 (irq = 35, base_baud = 3125000) is a 16550A
[    1.184172] libphy: Fixed MDIO Bus: probed
[    1.222037] libphy: mdio: probed
[    1.225798] mtk_soc_eth 1e100000.ethernet: generated random MAC address ba:c6:04:7a:e7:e1
[    1.234551] mtk_soc_eth 1e100000.ethernet: connected mac 0 to PHY at fixed-0:00 [uid=00000000, driver=Generic PHY]
[    1.245793] mtk_soc_eth 1e100000.ethernet eth0: mediatek frame engine at 0xbe100000, irq 10
[    1.254259] mtk_soc_eth 1e100000.ethernet: generated random MAC address be:50:b7:d3:88:93
[    1.263014] mtk_soc_eth 1e100000.ethernet: connected mac 1 to PHY at fixed-0:01 [uid=00000000, driver=Generic PHY]
[    1.274206] mtk_soc_eth 1e100000.ethernet eth1: mediatek frame engine at 0xbe100000, irq 10
[    1.282869] register mt_drv
[    1.285858] <--mt7916_hif_init()
[    1.289612] Rx[0] Ring: total 24576 bytes allocated
[    1.299174] Rx[1] Ring: total 16384 bytes allocated
[    1.304189] <-- pci_alloc_tx_rx_ring_mem, Status=0
[    1.343003] 
[    1.343003] 
[    1.343003] === pAd = c0301000, size = 13590592 ===
[    1.343003] 
[    1.354169] <-- RTMPAllocAdapterBlock, Status=0
[    1.358715] PCI CSRBaseAddress =0xc0200000, csr_addr=0xc0200000!
[    1.364765] RTMPInitPCIeDevice():device_id=0x7915
[    1.369473] mt7915_init()-->
[    1.372364] Use the default iPAiLNA bin image!
[    1.376882] <--mt7915_init()
[    1.380035] RtmpOSFileOpen(): Error 2 opening /etc/wireless/l1profile.dat
[    1.387920] wdev_init(caller:RTMP_COM_IoctlHandle+0x36c/0x18c0), wdev(0)
[    1.395565] Rx[0] Ring: total 24576 bytes allocated
[    1.400629] Rx[1] Ring: total 24576 bytes allocated
[    1.408047] Rx[2] Ring: total 8192 bytes allocated
[    1.417411] Rx[3] Ring: total 16384 bytes allocated
[    1.424800] Rx[4] Ring: total 8192 bytes allocated
[    1.429651] <-- pci_alloc_tx_rx_ring_mem, Status=0
[    1.435876] i2c /dev entries driver
[    1.440078] mt7621_wdt 1e000100.wdt: Initialized
[    1.445158] pkt_redirect_init complete
[    1.450189] NET: Registered protocol family 10
[    1.456218] NET: Registered protocol family 17
[    1.460736] bridge: automatic filtering via arp/ip/ip6tables has been deprecated. Update your scripts to load br_netfilter if you need this.
[    1.473466] 8021q: 802.1Q VLAN Support v1.8
[    1.480157] mtkmips-pinmux pinctrl: spi is already enabled
[    1.485733] mtk-nand 1e003000.nand: Error applying setting, reverse things back
[    1.493579] nand: device found, Manufacturer ID: 0xc8, Chip ID: 0xd1
[    1.499930] nand: GD/ESMT PSU1GA30DT
[    1.503519] nand: 128 MiB, SLC, erase size: 128 KiB, page size: 2048, OOB size: 64
[    1.511643] Scanning device for bad blocks
[    2.358465] 16 ofpart partitions found on MTD device mtk-nand
[    2.364236] Creating 16 MTD partitions on "mtk-nand":
[    2.369294] 0x000000000000-0x000000080000 : "Bootloader"
[    2.375991] 0x000000080000-0x000000100000 : "Config"
[    2.382195] 0x000000100000-0x000000180000 : "Factory"
[    2.388389] 0x000000180000-0x000002780000 : "ImageA"
[    2.394856] 0x0000001a0000-0x000002780000 : "firmware"
[    2.653517] 2 fit-fw partitions found on MTD device firmware
[    2.659194] 0x0000001a0000-0x000000520000 : "kernel"
[    2.665509] 0x000000520000-0x000002780000 : "rootfs"
[    2.672091] mtd: device 6 (rootfs) set to be root filesystem
[    2.678060] 1 squashfs-split partitions found on MTD device rootfs
[    2.684268] 0x000001840000-0x000002780000 : "rootfs_var"
[    2.691017] 0x000002780000-0x000004d80000 : "firmware_backup"
[    2.698380] 0x000004d80000-0x000005580000 : "CFG"
[    2.704406] 0x000005580000-0x000005980000 : "RAE"
[    2.710258] 0x000005980000-0x000005a80000 : "POT"
[    2.716203] 0x000005a80000-0x000005e80000 : "Language"
[    2.722595] 0x000005e80000-0x000006080000 : "Traffic"
[    2.728813] 0x000006080000-0x000006180000 : "Cert"
[    2.734811] 0x000006180000-0x000006280000 : "NTGRcryptK"
[    2.741250] 0x000006280000-0x000006780000 : "NTGRcryptD"
[    2.747785] 0x000006780000-0x000006880000 : "LOG"
[    2.805692] mtdoops: ready 0, 1 (no erase)
[    2.809792] mtdoops: Attached to MTD device 17
[    2.815130] 0x000006880000-0x000006ec0000 : "User_data"
[    2.861846] mt753x gsw: Switch is MediaTek MT7530 rev 1
[    2.888550] libphy: mt753x_mdio: probed
[    2.898467] hctosys: unable to open rtc device (rtc0)
[    2.914682] VFS: Mounted root (squashfs filesystem) readonly on device 31:6.
[    2.922255] Freeing unused kernel memory: 204K
[    2.926706] This architecture does not have kernel memory protection.
[    3.651406] init: Console is alive
[    3.655069] init: - watchdog -
[    4.676014] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    4.758154] usbcore: registered new interface driver usbfs
[    4.763809] usbcore: registered new interface driver hub
[    4.769322] usbcore: registered new device driver usb
[    4.805048] SCSI subsystem initialized
[    4.824374] usbcore: registered new interface driver usb-storage
[    4.832793] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    4.852004] init: - preinit -
[    7.080067] jffs2: notice: (520) jffs2_build_xattr_subsystem: complete building xattr subsystem, 0 of xdatum (0 unchecked, 0 orphan) and 0 of xref (0 dead, 0 orphan) found.
[    7.947160] jffs2: notice: (542) jffs2_build_xattr_subsystem: complete building xattr subsystem, 0 of xdatum (0 unchecked, 0 orphan) and 0 of xref (0 dead, 0 orphan) found.
uci: Invalid argument
7530 need fix 100base reg!
Set 0 port
Set 1 port
Set 2 port
Set 3 port
Set 4 port
Check 0 port
 Phy read reg=0x1, value=0x1c0
 Phy read reg=0x7, value=0x3c0
 Phy read reg=0x4, value=0x209
 Phy read reg=0xa, value=0xc
Check 1 port
 Phy read reg=0x1, value=0x1c0
 Phy read reg=0x7, value=0x3c0
 Phy read reg=0x4, value=0x209
 Phy read reg=0xa, value=0xc
Check 2 port
 Phy read reg=0x1, value=0x1c0
 Phy read reg=0x7, value=0x3c0
 Phy read reg=0x4, value=0x209
 Phy read reg=0xa, value=0xc
Check 3 port
 Phy read reg=0x1, value=0x1c0
 Phy read reg=0x7, value=0x3c0
 Phy read reg=0x4, value=0x209
 Phy read reg=0xa, value=0xc
Check 4 port
 Phy read reg=0x1, value=0x1c0
 Phy read reg=0x7, value=0x3c0
 Phy read reg=0x4, value=0x209
 Phy read reg=0xa, value=0xc
Green on when link with 1000M!
7530 need modify collision reg!
 Write reg=30e0, value=200b
model is WAX202
[    9.605401] random: jshn: uninitialized urandom read (4 bytes read, 70 bits of entropy available)
[    9.753983] random: jshn: uninitialized urandom read (4 bytes read, 70 bits of entropy available)
[    9.827942] random: jshn: uninitialized urandom read (4 bytes read, 73 bits of entropy available)
[    9.899301] random: jshn: uninitialized urandom read (4 bytes read, 75 bits of entropy available)
[    9.946383] random: jshn: uninitialized urandom read (4 bytes read, 75 bits of entropy available)
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[truncated]
```
</details>


<details><summary>OpenWrt boot log</summary>

```
===================================================================
     		MT7621   stage1 code Dec 16 2019 17:45:55 (ASIC)
     		CPU=500000000 HZ BUS=166666666 HZ
==================================================================
Change MPLL source from XTAL to CR...
do MEMPLL setting..
MEMPLL Config : 0x11000000
3PLL mode + External loopback
=== XTAL-40Mhz === DDR-1200Mhz ===
PLL4 FB_DL: 0x14, 1/0 = 603/421 51000000
PLL2 FB_DL: 0x15, 1/0 = 585/439 55000000
PLL3 FB_DL: 0x16, 1/0 = 659/365 59000000
DDR patch working
do DDR setting..[01F40000]
Apply DDR3 Setting...(use default AC)
          0    8   16   24   32   40   48   56   64   72   80   88   96  104  112  120
      --------------------------------------------------------------------------------
0000:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0001:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0002:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0003:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0004:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0005:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0006:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0007:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0008:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0009:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
000A:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
000B:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
000C:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
000D:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    1
000E:|    0    0    0    0    0    0    0    0    0    1    1    1    1    1    1    1
000F:|    0    0    0    0    1    1    1    1    1    1    1    1    1    1    0    0
0010:|    1    1    1    1    1    1    1    1    1    0    0    0    0    0    0    0
0011:|    1    1    1    1    0    0    0    0    0    0    0    0    0    0    0    0
0012:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0013:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0014:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0015:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0016:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0017:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0018:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
0019:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001A:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001B:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001C:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001D:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001E:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
001F:|    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0    0
DRAMC_DQSCTL1[0e0]=13000000
DRAMC_DQSGCTL[124]=80000033
rank 0 coarse = 15
rank 0 fine = 72
B:|    0    0    0    0    0    0    0    1    1    1    0    0    0    0    0    0
opt_dle value:8
DRAMC_DDR2CTL[07c]=C287220D
DRAMC_PADCTL4[0e4]=000022B3
DRAMC_DQIDLY1[210]=0C0B0B0B
DRAMC_DQIDLY2[214]=080A080B
DRAMC_DQIDLY3[218]=0C0C0908
DRAMC_DQIDLY4[21c]=0A0A0B09
DRAMC_R0DELDLY[018]=00001F1F
==================================================================
		RX	DQS perbit delay software calibration 
==================================================================
1.0-15 bit dq delay value
==================================================================
bit|     0  1  2  3  4  5  6  7  8  9
--------------------------------------
0 |    9 9 9 11 10 8 9 8 8 7 
10 |    9 11 9 9 10 10 
--------------------------------------

==================================================================
2.dqs window
x=pass dqs delay value (min~max)center 
y=0-7bit DQ of every group
input delay:DQS0 =31 DQS1 = 31
==================================================================
bit	DQS0	 bit      DQS1
0  (1~58)29  8  (1~61)31
1  (1~58)29  9  (1~58)29
2  (1~57)29  10  (1~56)28
3  (1~60)30  11  (1~60)30
4  (1~59)30  12  (0~62)31
5  (1~61)31  13  (1~58)29
6  (1~60)30  14  (1~62)31
7  (1~61)31  15  (1~61)31
==================================================================
3.dq delay value last
==================================================================
bit|    0  1  2  3  4  5  6  7  8   9
--------------------------------------
0 |    11 11 11 12 11 8 10 8 8 9 
10 |    12 12 9 11 10 10 
==================================================================
==================================================================
     TX  perbyte calibration 
==================================================================
DQS loop = 15, cmp_err_1 = ffff0000 
dqs_perbyte_dly.last_dqsdly_pass[0]=15,  finish count=1 
dqs_perbyte_dly.last_dqsdly_pass[1]=15,  finish count=2 
DQ loop=15, cmp_err_1 = ffff0000
dqs_perbyte_dly.last_dqdly_pass[0]=15,  finish count=1 
dqs_perbyte_dly.last_dqdly_pass[1]=15,  finish count=2 
byte:0, (DQS,DQ)=(8,8)
byte:1, (DQS,DQ)=(8,8)
DRAMC_DQODLY1[200]=88888888
DRAMC_DQODLY2[204]=88888888
20,data:88
[EMI] DRAMC calibration passed

===================================================================
     		MT7621   stage1 code done 
     		CPU=500000000 HZ BUS=166666666 HZ
===================================================================

U-Boot SPL 2018.09 (Jun 11 2021 - 15:25:38 +0800)
Trying to boot from NAND


U-Boot 2018.09 (Jun 11 2021 - 15:25:38 +0800)

CPU:   MediaTek MT7621AT ver 1, eco 3
Clocks: CPU: 880MHz, DDR: 600MHz, Bus: 220MHz, XTAL: 40MHz
Model: MediaTek MT7621 reference board (NAND)
DRAM:  448 MiB
NAND:  128 MiB
Loading Environment from NAND... OK
In:    uartlite0@1e000c00
Out:   uartlite0@1e000c00
Err:   uartlite0@1e000c00
Net:   eth0: eth@1e100000
nmrp activated
nmrp listen timeout.
nmrp Nmrp_cleanup.
Hit any key to stop autoboot:  0 
  *** U-Boot Boot Menu ***  Press UP/DOWN to move, ENTER to select     1. Startup system (Default)     2. Upgrade firmware     3. Upgrade bootloader     4. Upgrade bootloader (advanced mode)     5. Load image     0. U-Boot console  Hit any key to stop autoboot:  1  0 
Starting dual image checking ...

NAND read: device 0 offset 0x180000, size 0x20000
 131072 bytes read: OK
tag error!try no tag mode...
Verifying main image at 0x180000 size 0x2600000...
## Checking hash(es) for FIT Image at 80010000 ...
   Hash(es) for Image 0 (kernel-1): crc32+ sha1+ 
   Hash(es) for Image 1 (fdt-1): crc32+ sha1+ 

NAND read: device 0 offset 0x2780000, size 0x20000
 131072 bytes read: OK
image tag:    MTD_IMAGEA_TAG
get size :    0x16a0000

NAND read: device 0 offset 0x2780000, size 0x16c0000
 23855104 bytes read: OK
image tag:    MTD_IMAGEA_TAG
image size:   0x16a0000
checksum:     0x1606f03f
image crc:    0x1606f03f
Verifying backup image at 0x27a0000 size 0x25e0000...
## Checking hash(es) for FIT Image at 80010000 ...
   Hash(es) for Image 0 (kernel@1): crc32+ sha1+ 
   Hash(es) for Image 1 (fdt@1): crc32+ sha1+ 
Passed

Loading from nand0, offset 0x180000
Fit image detected...
   FIT description: MIPS OpenWrt FIT (Flattened Image Tree)
    Image 0 (kernel-1)
     Description:  MIPS OpenWrt Linux-5.10.109
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x800100e4
     Data Size:    2734593 Bytes = 2.6 MiB
     Architecture: MIPS
     OS:           Linux
     Load Address: 0x82000000
     Entry Point:  0x82000000
     Hash algo:    crc32
     Hash value:   43e17d42
     Hash algo:    sha1
     Hash value:   ff30f52fa3ac1be5f17cfcaa854e87d65c0a227f
    Image 1 (fdt-1)
     Description:  MIPS OpenWrt netgear_wax202 device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x802abc28
     Data Size:    11703 Bytes = 11.4 KiB
     Architecture: MIPS
     Hash algo:    crc32
     Hash value:   7d015a28
     Hash algo:    sha1
     Hash value:   5060bc2d2bb306a2fe9ce725cbe6e99672dce613
    Default Configuration: 'config-1'
    Configuration 0 (config-1)
     Description:  OpenWrt netgear_wax202
     Kernel:       kernel-1
     FDT:          fdt-1
Automatic boot of image at addr 0x80010000 ...
## Loading kernel from FIT Image at 80010000 ...
   Using 'config-1' configuration
   Trying 'kernel-1' kernel subimage
     Description:  MIPS OpenWrt Linux-5.10.109
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x800100e4
     Data Size:    2734593 Bytes = 2.6 MiB
     Architecture: MIPS
     OS:           Linux
     Load Address: 0x82000000
     Entry Point:  0x82000000
     Hash algo:    crc32
     Hash value:   43e17d42
     Hash algo:    sha1
     Hash value:   ff30f52fa3ac1be5f17cfcaa854e87d65c0a227f
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt from FIT Image at 80010000 ...
   Using 'config-1' configuration
   Trying 'fdt-1' fdt subimage
     Description:  MIPS OpenWrt netgear_wax202 device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x802abc28
     Data Size:    11703 Bytes = 11.4 KiB
     Architecture: MIPS
     Hash algo:    crc32
     Hash value:   7d015a28
     Hash algo:    sha1
     Hash value:   5060bc2d2bb306a2fe9ce725cbe6e99672dce613
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x802abc28
   Uncompressing Kernel Image ... OK
   Loading Device Tree to 9be77000, end 9be7cdb6 ... OK
[    0.000000] Linux version 5.10.109 (ubuntu@openwrt) (mipsel-openwrt-linux-musl-gcc (OpenWrt GCC 11.2.0 r19040-247eaa4416) 11.2.0, GNU ld (GNU Binutils) 2.37) #0 SMP Sat Apr 9 20:54:26 2022
[    0.000000] SoC Type: MediaTek MT7621 ver:1 eco:3
[    0.000000] printk: bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 0001992f (MIPS 1004Kc)
[    0.000000] MIPS: machine is Netgear WAX202
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] VPE topology {2,2} total 4
[    0.000000] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.000000] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000]   HighMem  [mem 0x0000000010000000-0x0000000023ffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x000000001bffffff]
[    0.000000]   node   0: [mem 0x0000000020000000-0x0000000023ffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x0000000023ffffff]
[    0.000000] percpu: Embedded 15 pages/cpu s30096 r8192 d23152 u61440
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 130496
[    0.000000] Kernel command line: console=ttyS0,115200 rootfstype=squashfs,jffs2
[    0.000000] Dentry cache hash table entries: 32768 (order: 5, 131072 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 4, 65536 bytes, linear)
[    0.000000] Writing ErrCtl register=00010400
[    0.000000] Readback ErrCtl register=00010400
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 508372K/524288K available (6733K kernel code, 617K rwdata, 1368K rodata, 1252K init, 235K bss, 15916K reserved, 0K cma-reserved, 262144K highmem)
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] NR_IRQS: 256
[    0.000000] random: get_random_bytes called from start_kernel+0x3cc/0x5e4 with crng_init=0
[    0.000000] CPU Clock: 880MHz
[    0.000000] clocksource: GIC: mask: 0xffffffffffffffff max_cycles: 0xcaf478abb4, max_idle_ns: 440795247997 ns
[    0.000014] sched_clock: 64 bits at 880MHz, resolution 1ns, wraps every 4398046511103ns
[    0.007958] clocksource: MIPS: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 4343773742 ns
[    0.016923] Calibrating delay loop... 586.13 BogoMIPS (lpj=2930688)
[    0.083088] pid_max: default: 32768 minimum: 301
[    0.087858] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.095060] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.105536] rcu: Hierarchical SRCU implementation.
[    0.110543] dyndbg: Ignore empty _ddebug table in a CONFIG_DYNAMIC_DEBUG_CORE build
[    0.118609] smp: Bringing up secondary CPUs ...
[    0.123783] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.123796] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.123807] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.123884] CPU1 revision is: 0001992f (MIPS 1004Kc)
[    0.178433] Synchronize counters for CPU 1: done.
[    0.210469] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.210480] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.210489] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.210544] CPU2 revision is: 0001992f (MIPS 1004Kc)
[    0.269621] Synchronize counters for CPU 2: done.
[    0.300178] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.300188] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.300197] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.300258] CPU3 revision is: 0001992f (MIPS 1004Kc)
[    0.354836] Synchronize counters for CPU 3: done.
[    0.384731] smp: Brought up 1 node, 4 CPUs
[    0.393143] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.402984] futex hash table entries: 1024 (order: 3, 32768 bytes, linear)
[    0.410001] pinctrl core: initialized pinctrl subsystem
[    0.417283] NET: Registered protocol family 16
[    0.422909] thermal_sys: Registered thermal governor 'step_wise'
[    0.423960] cpuidle: using governor teo
[    0.458834] random: fast init done
[    0.479692] clocksource: Switched to clocksource GIC
[    0.487091] NET: Registered protocol family 2
[    0.491688] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.499821] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 6144 bytes, linear)
[    0.508139] TCP established hash table entries: 2048 (order: 1, 8192 bytes, linear)
[    0.515745] TCP bind hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.522828] TCP: Hash tables configured (established 2048 bind 2048)
[    0.529258] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.535755] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.542914] NET: Registered protocol family 1
[    0.547233] PCI: CLS 0 bytes, default 32
[    0.554080] workingset: timestamp_bits=14 max_order=17 bucket_order=3
[    0.564710] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.570495] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.581420] bounce: pool size: 64 pages
[    0.586977] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.593005] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.598930] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.605586] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.613934] printk: console [ttyS0] disabled
[    0.618245] 1e000c00.uartlite: ttyS0 at MMIO 0x1e000c00 (irq = 19, base_baud = 3125000) is a 16550A
[    0.627271] printk: console [ttyS0] enabled
[    0.627271] printk: console [ttyS0] enabled
[    0.635539] printk: bootconsole [early0] disabled
[    0.635539] printk: bootconsole [early0] disabled
[    0.647875] nand: device found, Manufacturer ID: 0xc8, Chip ID: 0xd1
[    0.654265] nand: ESMT PSU1GA30DT
[    0.657574] nand: 128 MiB, SLC, erase size: 128 KiB, page size: 2048, OOB size: 64
[    0.665189] mt7621-nand 1e003000.nand: ECC strength adjusted to 4 bits
[    0.671861] 15 fixed-partitions partitions found on MTD device mt7621-nand
[    0.678707] Creating 15 MTD partitions on "mt7621-nand":
[    0.684022] 0x000000000000-0x000000080000 : "Bootloader"
[    0.698087] 0x000000080000-0x000000100000 : "Config"
[    0.711941] 0x000000100000-0x000000180000 : "Factory"
[    0.725862] 0x000000180000-0x000002780000 : "firmware"
[    1.315107] 2 fixed-partitions partitions found on MTD device firmware
[    1.321692] Creating 2 MTD partitions on "firmware":
[    1.326649] 0x000000000000-0x000000400000 : "kernel"
[    1.394482] 0x000000400000-0x000002600000 : "ubi"
[    1.921570] 0x000002780000-0x000004d80000 : "firmware_backup"
[    2.511011] 0x000004d80000-0x000005580000 : "CFG"
[    2.639715] 0x000005580000-0x000005980000 : "RAE"
[    2.706969] 0x000005980000-0x000005a80000 : "POT"
[    2.728258] 0x000005a80000-0x000005e80000 : "Language"
[    2.796018] 0x000005e80000-0x000006080000 : "Traffic"
[    2.833056] 0x000006080000-0x000006180000 : "Cert"
[    2.854425] 0x000006180000-0x000006280000 : "NTGRcryptK"
[    2.876401] 0x000006280000-0x000006780000 : "NTGRcryptD"
[    2.959768] 0x000006780000-0x000006880000 : "LOG"
[    2.981130] 0x000006880000-0x000006ec0000 : "User_data"
[    3.141115] mt7530 mdio-bus:1f: MT7530 adapts as multi-chip module
[    3.150128] mtk_soc_eth 1e100000.ethernet: generated random MAC address 82:e3:51:f1:f7:f2
[    3.159245] mtk_soc_eth 1e100000.ethernet eth0: mediatek frame engine at 0xbe100000, irq 20
[    3.169148] i2c /dev entries driver
[    3.175585] mt7621-pci 1e140000.pcie: host bridge /pcie@1e140000 ranges:
[    3.182348] mt7621-pci 1e140000.pcie:   No bus range found for /pcie@1e140000, using [bus 00-ff]
[    3.191160] mt7621-pci 1e140000.pcie:      MEM 0x0060000000..0x006fffffff -> 0x0000000000
[    3.199337] mt7621-pci 1e140000.pcie:       IO 0x001e160000..0x001e16ffff -> 0x0000000000
[    3.207600] mt7621-pci 1e140000.pcie: Parsing DT failed
[    3.215315] NET: Registered protocol family 10
[    3.221482] Segment Routing with IPv6
[    3.225248] NET: Registered protocol family 17
[    3.230173] 8021q: 802.1Q VLAN Support v1.8
[    3.237794] mt7530 mdio-bus:1f: MT7530 adapts as multi-chip module
[    3.263457] mt7530 mdio-bus:1f wan (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7530 PHY] (irq=25)
[    3.275781] mt7530 mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7530 PHY] (irq=26)
[    3.288121] mt7530 mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7530 PHY] (irq=27)
[    3.301166] mt7530 mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:04] driver [MediaTek MT7530 PHY] (irq=28)
[    3.313953] mt7530 mdio-bus:1f: configuring for fixed/rgmii link mode
[    3.324426] DSA: tree 0 setup
[    3.327817] rt2880-pinmux pinctrl: pcie is already enabled
[    3.333408] mt7621-pci 1e140000.pcie: host bridge /pcie@1e140000 ranges:
[    3.340152] mt7621-pci 1e140000.pcie:   No bus range found for /pcie@1e140000, using [bus 00-ff]
[    3.348933] mt7621-pci 1e140000.pcie:      MEM 0x0060000000..0x006fffffff -> 0x0000000000
[    3.357105] mt7621-pci 1e140000.pcie:       IO 0x001e160000..0x001e16ffff -> 0x0000000000
[    3.365399] mt7621-pci-phy 1e149000.pcie-phy: PHY for 0xbe149000 (dual port = 1)
[    3.373243] mt7621-pci 1e140000.pcie: failed to parse bus ranges property: -22
[    3.480721] mt7621-pci-phy 1e149000.pcie-phy: Xtal is 40MHz
[    3.586525] mt7621-pci 1e140000.pcie: PCIE0 enabled
[    3.591406] mt7621-pci 1e140000.pcie: PCIE1 enabled
[    3.596268] mt7621-pci 1e140000.pcie: PCI coherence region base: 0x60000000, mask/settings: 0xf0000002
[    3.605772] mt7621-pci 1e140000.pcie: PCI host bridge to bus 0000:00
[    3.612162] pci_bus 0000:00: root bus resource [io  0x1e160000-0x1e16ffff]
[    3.619019] pci_bus 0000:00: root bus resource [mem 0x60000000-0x6fffffff]
[    3.625894] pci_bus 0000:00: root bus resource [bus 00-ff]
[    3.631386] pci_bus 0000:00: root bus resource [mem 0x60000000-0x6fffffff] (bus address [0x00000000-0x0fffffff])
[    3.641611] pci 0000:00:00.0: [0e8d:0801] type 01 class 0x060400
[    3.647611] pci 0000:00:00.0: reg 0x10: [mem 0x00000000-0x7fffffff]
[    3.653874] pci 0000:00:00.0: reg 0x14: [mem 0x60600000-0x6060ffff]
[    3.660204] pci 0000:00:00.0: supports D1
[    3.664201] pci 0000:00:00.0: PME# supported from D0 D1 D3hot
[    3.670454] pci 0000:00:01.0: [0e8d:0801] type 01 class 0x060400
[    3.676485] pci 0000:00:01.0: reg 0x10: [mem 0x00000000-0x7fffffff]
[    3.682768] pci 0000:00:01.0: reg 0x14: [mem 0x60610000-0x6061ffff]
[    3.689093] pci 0000:00:01.0: supports D1
[    3.693115] pci 0000:00:01.0: PME# supported from D0 D1 D3hot
[    3.700774] pci 0000:01:00.0: [14c3:7916] type 00 class 0x000280
[    3.706843] pci 0000:01:00.0: reg 0x10: initial BAR value 0x00000000 invalid
[    3.713903] pci 0000:01:00.0: reg 0x10: [mem size 0x00100000 64bit pref]
[    3.720620] pci 0000:01:00.0: reg 0x18: initial BAR value 0x00000000 invalid
[    3.727640] pci 0000:01:00.0: reg 0x18: [mem size 0x00004000 64bit pref]
[    3.734342] pci 0000:01:00.0: reg 0x20: initial BAR value 0x00000000 invalid
[    3.741384] pci 0000:01:00.0: reg 0x20: [mem size 0x00001000 64bit pref]
[    3.748184] pci 0000:01:00.0: supports D1 D2
[    3.752452] pci 0000:01:00.0: PME# supported from D0 D1 D2 D3hot D3cold
[    3.759082] pci 0000:01:00.0: 2.000 Gb/s available PCIe bandwidth, limited by 2.5 GT/s PCIe x1 link at 0000:00:00.0 (capable of 4.000 Gb/s with 5.0 GT/s PCIe x1 link)
[    3.775376] pci 0000:00:00.0: PCI bridge to [bus 01-ff]
[    3.780639] pci 0000:00:00.0:   bridge window [io  0x0000-0x0fff]
[    3.786713] pci 0000:00:00.0:   bridge window [mem 0x60000000-0x600fffff]
[    3.793493] pci 0000:00:00.0:   bridge window [mem 0x60100000-0x602fffff pref]
[    3.800726] pci_bus 0000:01: busn_res: [bus 01-ff] end is updated to 01
[    3.807622] pci 0000:02:00.0: [14c3:7915] type 00 class 0x000280
[    3.813691] pci 0000:02:00.0: reg 0x10: initial BAR value 0x00000000 invalid
[    3.820760] pci 0000:02:00.0: reg 0x10: [mem size 0x00100000 64bit pref]
[    3.827449] pci 0000:02:00.0: reg 0x18: initial BAR value 0x00000000 invalid
[    3.834489] pci 0000:02:00.0: reg 0x18: [mem size 0x00004000 64bit pref]
[    3.841201] pci 0000:02:00.0: reg 0x20: initial BAR value 0x00000000 invalid
[    3.848220] pci 0000:02:00.0: reg 0x20: [mem size 0x00001000 64bit pref]
[    3.855031] pci 0000:02:00.0: supports D1 D2
[    3.859286] pci 0000:02:00.0: PME# supported from D0 D1 D2 D3hot D3cold
[    3.865937] pci 0000:02:00.0: 2.000 Gb/s available PCIe bandwidth, limited by 2.5 GT/s PCIe x1 link at 0000:00:01.0 (capable of 4.000 Gb/s with 5.0 GT/s PCIe x1 link)
[    3.882285] pci 0000:00:01.0: PCI bridge to [bus 02-ff]
[    3.887518] pci 0000:00:01.0:   bridge window [io  0x0000-0x0fff]
[    3.893626] pci 0000:00:01.0:   bridge window [mem 0x60300000-0x603fffff]
[    3.900416] pci 0000:00:01.0:   bridge window [mem 0x60400000-0x605fffff pref]
[    3.907617] pci_bus 0000:02: busn_res: [bus 02-ff] end is updated to 02
[    3.914297] pci 0000:00:00.0: BAR 0: no space for [mem size 0x80000000]
[    3.920914] pci 0000:00:00.0: BAR 0: failed to assign [mem size 0x80000000]
[    3.927852] pci 0000:00:01.0: BAR 0: no space for [mem size 0x80000000]
[    3.934454] pci 0000:00:01.0: BAR 0: failed to assign [mem size 0x80000000]
[    3.941424] pci 0000:00:00.0: BAR 8: assigned [mem 0x60000000-0x600fffff]
[    3.948186] pci 0000:00:00.0: BAR 9: assigned [mem 0x60100000-0x602fffff pref]
[    3.955404] pci 0000:00:01.0: BAR 8: assigned [mem 0x60300000-0x603fffff]
[    3.962192] pci 0000:00:01.0: BAR 9: assigned [mem 0x60400000-0x605fffff pref]
[    3.969386] pci 0000:00:00.0: BAR 1: assigned [mem 0x60600000-0x6060ffff]
[    3.976170] pci 0000:00:01.0: BAR 1: assigned [mem 0x60610000-0x6061ffff]
[    3.982960] pci 0000:00:00.0: BAR 7: assigned [io  0x1e160000-0x1e160fff]
[    3.989742] pci 0000:00:01.0: BAR 7: assigned [io  0x1e161000-0x1e161fff]
[    3.996519] pci 0000:01:00.0: BAR 0: assigned [mem 0x60100000-0x601fffff 64bit pref]
[    4.004267] pci 0000:01:00.0: BAR 2: assigned [mem 0x60200000-0x60203fff 64bit pref]
[    4.012021] pci 0000:01:00.0: BAR 4: assigned [mem 0x60204000-0x60204fff 64bit pref]
[    4.019774] pci 0000:00:00.0: PCI bridge to [bus 01]
[    4.024721] pci 0000:00:00.0:   bridge window [io  0x1e160000-0x1e160fff]
[    4.031497] pci 0000:00:00.0:   bridge window [mem 0x60000000-0x600fffff]
[    4.038256] pci 0000:00:00.0:   bridge window [mem 0x60100000-0x602fffff pref]
[    4.045486] pci 0000:02:00.0: BAR 0: assigned [mem 0x60400000-0x604fffff 64bit pref]
[    4.053233] pci 0000:02:00.0: BAR 2: assigned [mem 0x60500000-0x60503fff 64bit pref]
[    4.060995] pci 0000:02:00.0: BAR 4: assigned [mem 0x60504000-0x60504fff 64bit pref]
[    4.068719] pci 0000:00:01.0: PCI bridge to [bus 02]
[    4.073687] pci 0000:00:01.0:   bridge window [io  0x1e161000-0x1e161fff]
[    4.080472] pci 0000:00:01.0:   bridge window [mem 0x60300000-0x603fffff]
[    4.087233] pci 0000:00:01.0:   bridge window [mem 0x60400000-0x605fffff pref]
[    4.099161] UBI: auto-attach mtd5
[    4.102570] ubi0: attaching mtd5
[    4.106123] mt7530 mdio-bus:1f: Link is Up - 1Gbps/Full - flow control rx/tx
[    4.980281] ubi0: scanning is finished
[    5.000769] ubi0: attached mtd5 (name "ubi", size 34 MiB)
[    5.006180] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    5.013068] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    5.019868] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    5.026799] ubi0: good PEBs: 272, bad PEBs: 0, corrupted PEBs: 0
[    5.032794] ubi0: user volume: 2, internal volumes: 1, max. volumes count: 128
[    5.040010] ubi0: max/mean erase counter: 2/1, WL threshold: 4096, image sequence number: 1649533977
[    5.049102] ubi0: available PEBs: 0, total reserved PEBs: 272, PEBs reserved for bad PEB handling: 20
[    5.058340] ubi0: background thread "ubi_bgt0d" started, PID 461
[    5.061033] block ubiblock0_0: created from ubi0:0(rootfs)
[    5.069867] ubiblock: device ubiblock0_0 (rootfs) set to be root filesystem
[    5.085426] VFS: Mounted root (squashfs filesystem) readonly on device 254:0.
[    5.097109] Freeing unused kernel memory: 1252K
[    5.101675] This architecture does not have kernel memory protection.
[    5.108112] Run /sbin/init as init process
[    5.632681] init: Console is alive
[    5.636557] init: - watchdog -
[    6.447089] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    6.540988] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    6.560159] init: - preinit -
[    7.434472] random: jshn: uninitialized urandom read (4 bytes read)
[    7.513787] random: jshn: uninitialized urandom read (4 bytes read)
[    7.849788] random: jshn: uninitialized urandom read (4 bytes read)
[    8.141493] mtk_soc_eth 1e100000.ethernet eth0: configuring for fixed/rgmii link mode
[    8.149921] mtk_soc_eth 1e100000.ethernet eth0: Link is Up - 1Gbps/Full - flow control rx/tx
[    8.158848] mt7530 mdio-bus:1f lan1: configuring for phy/gmii link mode
[    8.165847] 8021q: adding VLAN 0 to HW filter on device lan1
[    8.174180] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[   12.381760] UBIFS (ubi0:1): Mounting in unauthenticated mode
[   12.387740] UBIFS (ubi0:1): background thread "ubifs_bgt0_1" started, PID 593
[   12.590967] UBIFS (ubi0:1): UBIFS: mounted UBI device 0, volume 1, name "rootfs_data"
[   12.598792] UBIFS (ubi0:1): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[   12.608704] UBIFS (ubi0:1): FS size: 25649152 bytes (24 MiB, 202 LEBs), journal size 1269760 bytes (1 MiB, 10 LEBs)
[   12.619109] UBIFS (ubi0:1): reserved for root: 1211472 bytes (1183 KiB)
[   12.625713] UBIFS (ubi0:1): media format: w5/r0 (latest is w5/r0), UUID FAC86A8A-9B64-46B7-BE80-770E8A7B5CBA, small LPT model
[   12.639559] mount_root: overlay filesystem has not been fully initialized yet
[   12.647911] mount_root: switching to ubifs overlay
- config restore -
[   13.234680] urandom-seed: Saving 4096 bits of non-creditable seed for next boot
[   13.271438] procd: - early -
[   13.274613] procd: - watchdog -
[   13.869844] procd: - watchdog -
[   13.873504] procd: - ubus -
[   13.970383] procd: - init -
Please press Enter to activate this console.
[   14.781412] kmodloader: loading kernel modules from /etc/modules.d/*
[   14.983982] Loading modules backported from Linux version v5.15.8-0-g43e577d7a2cb
[   14.991536] Backport generated by backports.git v5.15.8-1-0-g83f664bb
[   15.027684] urngd: v1.0.2 started.
[   15.207698] mt7621-pci 1e140000.pcie: bus=1 slot=0 irq=21
[   15.208824] random: crng init done
[   15.213192] pci 0000:00:00.0: enabling device (0006 -> 0007)
[   15.216570] random: 7 urandom warning(s) missed due to ratelimiting
[   15.222230] mt7915e_hif 0000:01:00.0: enabling device (0000 -> 0002)
[   15.235363] mt7621-pci 1e140000.pcie: bus=2 slot=1 irq=22
[   15.240855] pci 0000:00:01.0: enabling device (0006 -> 0007)
[   15.246522] mt7915e 0000:02:00.0: enabling device (0000 -> 0002)
[   15.509753] mt7915e 0000:02:00.0: HW/SW Version: 0x8a108a10, Build Time: 20201105222230a
[   15.509753] 
[   15.838400] mt7915e 0000:02:00.0: WM Firmware Version: ____000000, Build Time: 20201105222304
[   15.872542] mt7915e 0000:02:00.0: WA Firmware Version: DEV_000000, Build Time: 20201105222323
[   16.061292] PPP generic driver version 2.4.2
[   16.067988] NET: Registered protocol family 24
```

</details>