### PR TITLE
ipq806x: fix USB bug in 5.10 dtsi additions 

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-r7500.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-r7500.dts
@@ -148,12 +148,10 @@
 };
 
 &usb3_0 {
-	clocks = <&gcc USB30_1_MASTER_CLK>;
 	status = "okay";
 };
 
 &usb3_1 {
-	clocks = <&gcc USB30_0_MASTER_CLK>;
 	status = "okay";
 };
 

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-rt4230w-rev6.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-rt4230w-rev6.dts
@@ -283,12 +283,10 @@
 
 &usb3_0 {
 	status = "okay";
-	clocks = <&gcc USB30_1_MASTER_CLK>;
 };
 
 &usb3_1 {
 	status = "okay";
-	clocks = <&gcc USB30_0_MASTER_CLK>;
 };
 
 &pcie0 {

--- a/target/linux/ipq806x/patches-5.10/083-ipq8064-dtsi-additions.patch
+++ b/target/linux/ipq806x/patches-5.10/083-ipq8064-dtsi-additions.patch
@@ -681,7 +681,7 @@
 +
 +		hs_phy_0: hs_phy_0 {
 +			compatible = "qcom,ipq806x-usb-phy-hs";
-+			reg = <0x110f8800 0x30>;
++			reg = <0x100f8800 0x30>;
 +			clocks = <&gcc USB30_0_UTMI_CLK>;
 +			clock-names = "ref";
 +			#phy-cells = <0>;
@@ -689,17 +689,17 @@
 +
 +		ss_phy_0: ss_phy_0 {
 +			compatible = "qcom,ipq806x-usb-phy-ss";
-+			reg = <0x110f8830 0x30>;
++			reg = <0x100f8830 0x30>;
 +			clocks = <&gcc USB30_0_MASTER_CLK>;
 +			clock-names = "ref";
 +			#phy-cells = <0>;
 +		};
 +
-+		usb3_0: usb3@110f8800 {
++		usb3_0: usb3@100f8800 {
 +			compatible = "qcom,dwc3", "syscon";
 +			#address-cells = <1>;
 +			#size-cells = <1>;
-+			reg = <0x110f8800 0x8000>;
++			reg = <0x100f8800 0x8000>;
 +			clocks = <&gcc USB30_0_MASTER_CLK>;
 +			clock-names = "core";
 +
@@ -710,10 +710,10 @@
 +
 +			status = "disabled";
 +
-+			dwc3_0: dwc3@11000000 {
++			dwc3_0: dwc3@10000000 {
 +				compatible = "snps,dwc3";
-+				reg = <0x11000000 0xcd00>;
-+				interrupts = <GIC_SPI 110 IRQ_TYPE_LEVEL_HIGH>;
++				reg = <0x10000000 0xcd00>;
++				interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL_HIGH>;
 +				phys = <&hs_phy_0>, <&ss_phy_0>;
 +				phy-names = "usb2-phy", "usb3-phy";
 +				dr_mode = "host";
@@ -723,7 +723,7 @@
 +
 +		hs_phy_1: hs_phy_1 {
 +			compatible = "qcom,ipq806x-usb-phy-hs";
-+			reg = <0x100f8800 0x30>;
++			reg = <0x110f8800 0x30>;
 +			clocks = <&gcc USB30_1_UTMI_CLK>;
 +			clock-names = "ref";
 +			#phy-cells = <0>;
@@ -731,17 +731,17 @@
 +
 +		ss_phy_1: ss_phy_1 {
 +			compatible = "qcom,ipq806x-usb-phy-ss";
-+			reg = <0x100f8830 0x30>;
++			reg = <0x110f8830 0x30>;
 +			clocks = <&gcc USB30_1_MASTER_CLK>;
 +			clock-names = "ref";
 +			#phy-cells = <0>;
 +		};
 +
-+		usb3_1: usb3@100f8800 {
++		usb3_1: usb3@110f8800 {
 +			compatible = "qcom,dwc3", "syscon";
 +			#address-cells = <1>;
 +			#size-cells = <1>;
-+			reg = <0x100f8800 0x8000>;
++			reg = <0x110f8800 0x8000>;
 +			clocks = <&gcc USB30_1_MASTER_CLK>;
 +			clock-names = "core";
 +
@@ -752,10 +752,10 @@
 +
 +			status = "disabled";
 +
-+			dwc3_1: dwc3@10000000 {
++			dwc3_1: dwc3@11000000 {
 +				compatible = "snps,dwc3";
-+				reg = <0x10000000 0xcd00>;
-+				interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL_HIGH>;
++				reg = <0x11000000 0xcd00>;
++				interrupts = <GIC_SPI 110 IRQ_TYPE_LEVEL_HIGH>;
 +				phys = <&hs_phy_1>, <&ss_phy_1>;
 +				phy-names = "usb2-phy", "usb3-phy";
 +				dr_mode = "host";


### PR DESCRIPTION
@mans0n 
the global fixes, as per [your request](https://github.com/openwrt/openwrt/pull/9657#issuecomment-1093840071).

i strongly advice to backport this to 22.03 for reasons explained in the commit.

tested on my ipq8065 device.

fixes: https://github.com/openwrt/openwrt/pull/9657

thanks!