### PR TITLE
nftables: add CONFLICT between versions

### DIFF
--- a/package/network/utils/nftables/Makefile
+++ b/package/network/utils/nftables/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nftables
 PKG_VERSION:=1.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://netfilter.org/projects/$(PKG_NAME)/files
@@ -45,6 +45,7 @@ define Package/nftables-nojson
   TITLE+= no JSON support
   VARIANT:=nojson
   DEFAULT_VARIANT:=1
+  CONFLICTS:=nftables-json
 endef
 
 define Package/nftables-json


### PR DESCRIPTION
Have nftables-json conflict with nftables-nojson.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>