### PR TITLE
mediatek: remove crypto-hw-mtk package

### DIFF
--- a/target/linux/mediatek/modules.mk
+++ b/target/linux/mediatek/modules.mk
@@ -38,26 +38,3 @@ define KernelPackage/sdhci-mtk
 endef
 
 $(eval $(call KernelPackage,sdhci-mtk))
-
-define KernelPackage/crypto-hw-mtk
-  TITLE:= MediaTek's Crypto Engine module
-  DEPENDS:=@TARGET_mediatek
-  KCONFIG:= \
-	CONFIG_CRYPTO_HW=y \
-	CONFIG_CRYPTO_AES=y \
-	CONFIG_CRYPTO_AEAD=y \
-	CONFIG_CRYPTO_SHA1=y \
-	CONFIG_CRYPTO_SHA256=y \
-	CONFIG_CRYPTO_SHA512=y \
-	CONFIG_CRYPTO_HMAC=y \
-	CONFIG_CRYPTO_DEV_MEDIATEK
-  FILES:=$(LINUX_DIR)/drivers/crypto/mediatek/mtk-crypto.ko
-  AUTOLOAD:=$(call AutoLoad,90,mtk-crypto)
-  $(call AddDepends/crypto)
-endef
-
-define KernelPackage/crypto-hw-mtk/description
-  MediaTek's EIP97 Cryptographic Engine driver.
-endef
-
-$(eval $(call KernelPackage,crypto-hw-mtk))


### PR DESCRIPTION
The MediaTek's Crypto Engine module is only available for mt7623, in which case it is built into the kernel.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---
This was run-tested on the mt7622 side of the change.  The net effect is the removal of some crypto drivers (sha1, sha512) in-kernel that would not be otherwise installed if the package is not selected.  So it affects the bot-built images that build all kernel packages.  If their inclusion built into the kernel is desired, we should add the arm-ce accelerated versions.