### PR TITLE
AVM FRITZ!Box 7530: Add support for Toshiba NAND (8 bit ECC)

### DIFF
--- a/target/linux/generic/pending-5.10/444-mtd-nand-rawnand-add-support-for-Toshiba-TC58NVG0S3H.patch
+++ b/target/linux/generic/pending-5.10/444-mtd-nand-rawnand-add-support-for-Toshiba-TC58NVG0S3H.patch
@@ -1,0 +1,36 @@
+From 35ca7e3e6ccd120d694a3425f37fc6374ad2e11e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Andreas=20B=C3=B6hler?= <dev@aboehler.at>
+Date: Wed, 20 Apr 2022 12:08:38 +0200
+Subject: [PATCH] mtd: rawnand: add support for Toshiba TC58NVG0S3HTA00
+ NAND flash
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Toshiba TC58NVG0S3HTA00 is detected with 64 byte OOB while the flash
+has 128 bytes OOB. This adds a static NAND ID entry to correct this.
+
+Tested on FRITZ!Box 7530 flashed with OpenWrt.
+
+Signed-off-by: Andreas Böhler <dev@aboehler.at>
+---
+ drivers/mtd/nand/raw/nand_ids.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/mtd/nand/raw/nand_ids.c b/drivers/mtd/nand/raw/nand_ids.c
+index 6e41902be35f..d64adbd1ce6b 100644
+--- a/drivers/mtd/nand/raw/nand_ids.c
++++ b/drivers/mtd/nand/raw/nand_ids.c
+@@ -29,6 +29,9 @@ struct nand_flash_dev nand_flash_ids[] = {
+ 	{"TC58NVG0S3E 1G 3.3V 8-bit",
+ 		{ .id = {0x98, 0xd1, 0x90, 0x15, 0x76, 0x14, 0x01, 0x00} },
+ 		  SZ_2K, SZ_128, SZ_128K, 0, 8, 64, NAND_ECC_INFO(1, SZ_512), },
++	{"TC58NVG0S3HTA00 1G 3.3V 8-bit",
++		{ .id = {0x98, 0xf1, 0x80, 0x15} },
++		  SZ_2K, SZ_128, SZ_128K, 0, 4, 128, NAND_ECC_INFO(8, SZ_512), },
+ 	{"TC58NVG2S0F 4G 3.3V 8-bit",
+ 		{ .id = {0x98, 0xdc, 0x90, 0x26, 0x76, 0x15, 0x01, 0x08} },
+ 		  SZ_4K, SZ_512, SZ_256K, 0, 8, 224, NAND_ECC_INFO(4, SZ_512) },
+-- 
+2.35.1
+

--- a/target/linux/generic/pending-5.15/444-mtd-nand-rawnand-add-support-for-Toshiba-TC58NVG0S3H.patch
+++ b/target/linux/generic/pending-5.15/444-mtd-nand-rawnand-add-support-for-Toshiba-TC58NVG0S3H.patch
@@ -1,0 +1,36 @@
+From 35ca7e3e6ccd120d694a3425f37fc6374ad2e11e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Andreas=20B=C3=B6hler?= <dev@aboehler.at>
+Date: Wed, 20 Apr 2022 12:08:38 +0200
+Subject: [PATCH] mtd: rawnand: add support for Toshiba TC58NVG0S3HTA00
+ NAND flash
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Toshiba TC58NVG0S3HTA00 is detected with 64 byte OOB while the flash
+has 128 bytes OOB. This adds a static NAND ID entry to correct this.
+
+Tested on FRITZ!Box 7530 flashed with OpenWrt.
+
+Signed-off-by: Andreas Böhler <dev@aboehler.at>
+---
+ drivers/mtd/nand/raw/nand_ids.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/mtd/nand/raw/nand_ids.c b/drivers/mtd/nand/raw/nand_ids.c
+index 6e41902be35f..d64adbd1ce6b 100644
+--- a/drivers/mtd/nand/raw/nand_ids.c
++++ b/drivers/mtd/nand/raw/nand_ids.c
+@@ -29,6 +29,9 @@ struct nand_flash_dev nand_flash_ids[] = {
+ 	{"TC58NVG0S3E 1G 3.3V 8-bit",
+ 		{ .id = {0x98, 0xd1, 0x90, 0x15, 0x76, 0x14, 0x01, 0x00} },
+ 		  SZ_2K, SZ_128, SZ_128K, 0, 8, 64, NAND_ECC_INFO(1, SZ_512), },
++	{"TC58NVG0S3HTA00 1G 3.3V 8-bit",
++		{ .id = {0x98, 0xf1, 0x80, 0x15} },
++		  SZ_2K, SZ_128, SZ_128K, 0, 4, 128, NAND_ECC_INFO(8, SZ_512), },
+ 	{"TC58NVG2S0F 4G 3.3V 8-bit",
+ 		{ .id = {0x98, 0xdc, 0x90, 0x26, 0x76, 0x15, 0x01, 0x08} },
+ 		  SZ_4K, SZ_512, SZ_256K, 0, 8, 224, NAND_ECC_INFO(4, SZ_512) },
+-- 
+2.35.1
+

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-fritzbox-7530.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-fritzbox-7530.dts
@@ -173,6 +173,9 @@
 	status = "okay";
 
 	nand@0 {
+		/delete-property/ nand-ecc-strength;
+		/delete-property/ nand-ecc-step-size;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;


### PR DESCRIPTION
Add support for FRITZ!7530 with Toshiba NAND (8 bit ECC)

Some revisions of the FRITZ!7530 use a Toshiba NAND with 8 bit ECC in contrast to the Macronix NAND with 4 bit ECC. Since the ECC information is hardcoded in qcom-ipq4019.dtsi, this restrictions is removed from the device DTS.

An additional kernel patch is necessary to identify the NAND chip. The autodetection misdetects 64 byte OOB where the NAND uses 128 byte. A proper fixup was already merged into the respective U-Boot code.
