### PR TITLE
ath79: add support for ASUS PL-AC56

### DIFF
--- a/target/linux/ath79/dts/qca9563_asus_pl-ac56.dts
+++ b/target/linux/ath79/dts/qca9563_asus_pl-ac56.dts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "ASUS PL-AC56";
+	compatible = "asus,pl-ac56", "qca,qca9563";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <BTN_0>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "red:power";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "green:wlan2g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "green:wlan5g";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x10000>;
+				read-only;
+			};
+
+			art: partition@50000 {
+				label = "art";
+				reg = <0x050000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_art_1002: macaddr@1002 {
+					reg = <0x1002 0x6>;
+				};
+			};
+
+			partition@60000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x060000 0xf20000>;
+			};
+
+			partition@f80000 {
+				label = "plc";
+				reg = <0xf80000 0x80000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		qca,mib-poll-interval = <500>;
+
+		qca,ar8327-initvals = <
+			0x04 0x80000080 /* AR8327_REG_PAD0_MODE */
+			0x08 0x01000000 /* AR8327_REG_PAD5_MODE */
+			0x0c 0x07500000 /* AR8327_REG_PAD6_MODE */
+			0x10 0x602613a0 /* AR8327_REG_POWER_ON_STRAP */
+			0x50 0xcc35cc35 /* AR8327_REG_LED_CTRL0 */
+			0x54 0xca35ca35 /* AR8327_REG_LED_CTRL1 */
+			0x58 0xc935c935 /* AR8327_REG_LED_CTRL2 */
+			0x5c 0x03ffff00 /* AR8327_REG_LED_CTRL3 */
+			0x7c 0x0000007e /* AR8327_REG_PORT_STATUS(0) */
+			0x94 0x0000007e /* AR8327_REG_PORT_STATUS(6) */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	nvmem-cells = <&macaddr_art_1002>;
+	nvmem-cell-names = "mac-address";
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -56,6 +56,11 @@ alfa-network,tube-2hq)
 	ucidef_set_led_rssi "signal3" "SIGNAL3" "green:signal3" "wlan0" "50" "100"
 	ucidef_set_led_rssi "signal4" "SIGNAL4" "green:signal4" "wlan0" "75" "100"
 	;;
+asus,pl-ac56)
+	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x3e"
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wlan2g" "wlan1" "link"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan5g" "wlan0" "link"
+	;;
 asus,rp-ac66)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_rssimon "wlan1" "200000" "1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -127,6 +127,11 @@ ath79_setup_interfaces()
 	ubnt,unifi-ap-outdoor-plus)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;
+	asus,pl-ac56)
+		# port 6 (internal) is the power-line port
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:1" "2:lan:2" "3:lan:3" "6:lan:4"
+		;;
 	atheros,db120)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:lan" "4:lan" "5:lan" "1:wan"

--- a/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
@@ -24,6 +24,9 @@ adtran,bsap1840)
 	ucidef_add_gpio_switch "wifi0_ext_c" "2.4GHz External Antenna C" "509" "1"
 	ucidef_add_gpio_switch "wifi0_int_c" "2.4GHz Internal Antenna C" "510"
 	;;
+asus,pl-ac56)
+	ucidef_add_gpio_switch "plc_enable" "PLC enable" "14" "1"
+	;;
 comfast,cf-e5|\
 telco,t1)
 	ucidef_add_gpio_switch "lte_power" "LTE Power" "14" "1"

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -12,6 +12,7 @@ case "$FIRMWARE" in
 	8dev,lima)
 		caldata_extract "art" 0x1000 0x800
 		;;
+	asus,pl-ac56|\
 	asus,rp-ac66)
 		caldata_extract "art" 0x1000 0x440
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -19,6 +19,7 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) 2)
 		;;
+	asus,pl-ac56|\
 	asus,rp-ac66|\
 	comfast,cf-wr650ac-v1|\
 	comfast,cf-wr650ac-v2|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -376,6 +376,19 @@ define Device/aruba_ap-105
 endef
 TARGET_DEVICES += aruba_ap-105
 
+define Device/asus_pl-ac56
+  SOC := qca9563
+  DEVICE_VENDOR := ASUS
+  DEVICE_MODEL := PL-AC56
+  DEVICE_VARIANT := A1
+  IMAGE_SIZE := 15488k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs
+  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
+endef
+TARGET_DEVICES += asus_pl-ac56
+
 define Device/asus_rp-ac66
   SOC := qca9563
   DEVICE_VENDOR := ASUS


### PR DESCRIPTION
Asus PL-AC56 Powerline Range Extender Rev.A1
(in kit with Asus PL-E56P Powerline-slave)

Hardware specifications:
Board: AP152
SoC: QCA9563 2.4G n 3x3
PLC: QCA7500
WiFi: QCA9882 5G ac 2x2
Switch: QCA8337 3x1000M
Flash: 16MB 25L12835F SPI-NOR
DRAM SoC: 64MB w9751g6kb-25
DRAM PLC: 128MB w631gg6kb-15

Clocks: CPU:775.000MHz, DDR:650.000MHz, AHB:258.333MHz, Ref:25.000MHz

MAC addresses as verified by OEM firmware:
use            address      source
Lan/Wan/PLC    *:10         art 0x1002 (label)
2G             *:10         art 0x1000
5G             *:14         art 0x5000

Important notes:
 - the PLC firmware has to be provided and copied manually onto the
    device! The PLC here has no dedicated flash, thus the firmware file
    has to be uploaded to the PLC controller at every system start
 - the PLC functionality is managed by the script /etc/init.d/plc_basic,
    a very basic script based on the the one from Netadair (netadair dot de)

Installation:

Asus windows recovery tool:
 - have to have the latest Asus firmware flashed before continuing!
 - install the Asus firmware restoration utility
 - unplug the router, hold the reset button while powering it on
 - release when the power LED flashes slowly
 - specify a static IP on your computer:
    IP address: 192.168.1.75
    Subnet mask 255.255.255.0
 - start the Asus firmware restoration utility, specify the factory image
    and press upload
 - do NOT power off the device after OpenWrt has booted until the LED flashing

TFTP Recovery method:
 - have to have the latest Asus firmware flashed before continuing!
 - set computer to a static ip, 192.168.1.75
 - connect computer to the LAN 1 port of the router
 - hold the reset button while powering on the router for a few seconds
 - send firmware image using a tftp client; i.e from linux:
    $ tftp
    tftp> binary
    tftp> connect 192.168.1.1
    tftp> put factory.bin
    tftp> quit
 - do NOT power off the device after OpenWrt has booted until the LED flashing

Additional notes:
 - the pairing buttons have to have pressed for at least half a second,
    it doesn't matter on which plc device (master or slave) first
 - it is possible to pair the devices without the button-pairing requirement
    simply by pressing reset on the slave device. This will default to the
    firmware settings, which is also how the plc_basic script is setting up
    the master device, i.e. configuring it to firmware defaults
 - the PL-E56P slave PLC has its dedicated 4MByte SPI, thus it is capable
    to store all firmware currently available. Note that some other
    slave devices are not guarantied to have the capacity for the newer
    ~1MByte firmware blobs!
    To have a good overlook about the slave device, here are its specs:
    same QCA7500 PLC controller, same w631gg6kb-15 128MB RAM,
    25L3233F 4MB SPI-NOR and an AR8035-A 1000M-Transceiver

Signed-off-by: Tamas Balogh <tamasbalogh@hotmail.com>
