### PR TITLE
Improvements to nand sysupgrade

### DIFF
--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -158,13 +158,11 @@ nand_upgrade_prepare_ubi() {
 	local ubidev="$( nand_find_ubi "$CI_UBIPART" )"
 	if [ ! "$ubidev" ]; then
 		ubiattach -m "$mtdnum"
-		sync
 		ubidev="$( nand_find_ubi "$CI_UBIPART" )"
 
 		if [ ! "$ubidev" ]; then
 			ubiformat /dev/mtd$mtdnum -y
 			ubiattach -m "$mtdnum"
-			sync
 			ubidev="$( nand_find_ubi "$CI_UBIPART" )"
 
 			if [ ! "$ubidev" ]; then
@@ -229,7 +227,7 @@ nand_upgrade_prepare_ubi() {
 			fi
 		fi
 	fi
-	sync
+
 	return 0
 }
 
@@ -255,7 +253,6 @@ nand_upgrade_ubinized() {
 
 	local mtddev="/dev/mtd${mtdnum}"
 	ubidetach -p "${mtddev}" || :
-	sync
 	ubiformat "${mtddev}" -y -f "${ubi_file}"
 	ubiattach -p "${mtddev}"
 

--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -98,10 +98,10 @@ identify_tar() {
 
 nand_restore_config() {
 	sync
-	local ubidev=$( nand_find_ubi $CI_UBIPART )
+	local ubidev=$( nand_find_ubi "$CI_UBIPART" )
 	local ubivol="$( nand_find_volume $ubidev rootfs_data )"
 	[ ! "$ubivol" ] &&
-		ubivol="$( nand_find_volume $ubidev $CI_ROOTPART )"
+		ubivol="$( nand_find_volume $ubidev "$CI_ROOTPART" )"
 	mkdir /tmp/new_root
 	if ! mount -t ubifs /dev/$ubivol /tmp/new_root; then
 		echo "mounting ubifs $ubivol failed"
@@ -167,8 +167,8 @@ nand_upgrade_prepare_ubi() {
 		fi
 	fi
 
-	local kern_ubivol="$( nand_find_volume $ubidev $CI_KERNPART )"
-	local root_ubivol="$( nand_find_volume $ubidev $CI_ROOTPART )"
+	local kern_ubivol="$( nand_find_volume $ubidev "$CI_KERNPART" )"
+	local root_ubivol="$( nand_find_volume $ubidev "$CI_ROOTPART" )"
 	local data_ubivol="$( nand_find_volume $ubidev rootfs_data )"
 	[ "$root_ubivol" = "$kern_ubivol" ] && root_ubivol=
 
@@ -178,13 +178,13 @@ nand_upgrade_prepare_ubi() {
 	[ "$data_ubivol" ] && { nand_remove_ubiblock $data_ubivol || return 1; }
 
 	# kill volumes
-	[ "$kern_ubivol" ] && ubirmvol /dev/$ubidev -N $CI_KERNPART || :
-	[ "$root_ubivol" ] && ubirmvol /dev/$ubidev -N $CI_ROOTPART || :
+	[ "$kern_ubivol" ] && ubirmvol /dev/$ubidev -N "$CI_KERNPART" || :
+	[ "$root_ubivol" ] && ubirmvol /dev/$ubidev -N "$CI_ROOTPART" || :
 	[ "$data_ubivol" ] && ubirmvol /dev/$ubidev -N rootfs_data || :
 
 	# create kernel vol
 	if [ -n "$kernel_length" ]; then
-		if ! ubimkvol /dev/$ubidev -N $CI_KERNPART -s $kernel_length; then
+		if ! ubimkvol /dev/$ubidev -N "$CI_KERNPART" -s $kernel_length; then
 			echo "cannot create kernel volume"
 			return 1;
 		fi
@@ -198,7 +198,7 @@ nand_upgrade_prepare_ubi() {
 		else
 			rootfs_size_param="-s $rootfs_length"
 		fi
-		if ! ubimkvol /dev/$ubidev -N $CI_ROOTPART $rootfs_size_param; then
+		if ! ubimkvol /dev/$ubidev -N "$CI_ROOTPART" $rootfs_size_param; then
 			echo "cannot create rootfs volume"
 			return 1;
 		fi
@@ -258,7 +258,7 @@ nand_upgrade_ubifs() {
 	nand_upgrade_prepare_ubi "$rootfs_length" "ubifs" "" ""
 
 	local ubidev="$( nand_find_ubi "$CI_UBIPART" )"
-	local root_ubivol="$(nand_find_volume $ubidev $CI_ROOTPART)"
+	local root_ubivol="$(nand_find_volume $ubidev "$CI_ROOTPART")"
 	ubiupdatevol /dev/$root_ubivol -s $rootfs_length $1
 
 	nand_do_upgrade_success

--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -335,15 +335,16 @@ nand_upgrade_tar() {
 
 # Recognize type of passed file and start the upgrade process
 nand_do_upgrade() {
-	local file_type=$(identify $1)
+	local file_type=$(identify "$1")
 
 	[ ! "$(find_mtd_index "$CI_UBIPART")" ] && CI_UBIPART=rootfs
 
+	sync
 	case "$file_type" in
-		"fit")		nand_upgrade_fit $1;;
-		"ubi")		nand_upgrade_ubinized $1;;
-		"ubifs")	nand_upgrade_ubifs $1;;
-		*)		nand_upgrade_tar $1;;
+		"fit")		nand_upgrade_fit "$1";;
+		"ubi")		nand_upgrade_ubinized "$1";;
+		"ubifs")	nand_upgrade_ubifs "$1";;
+		*)		nand_upgrade_tar "$1";;
 	esac
 }
 

--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -182,7 +182,7 @@ nand_upgrade_prepare_ubi() {
 	[ "$root_ubivol" ] && ubirmvol /dev/$ubidev -N $CI_ROOTPART || :
 	[ "$data_ubivol" ] && ubirmvol /dev/$ubidev -N rootfs_data || :
 
-	# update kernel
+	# create kernel vol
 	if [ -n "$kernel_length" ]; then
 		if ! ubimkvol /dev/$ubidev -N $CI_KERNPART -s $kernel_length; then
 			echo "cannot create kernel volume"
@@ -190,7 +190,7 @@ nand_upgrade_prepare_ubi() {
 		fi
 	fi
 
-	# update rootfs
+	# create rootfs vol
 	if [ -n "$rootfs_length" ]; then
 		local rootfs_size_param
 		if [ "$rootfs_type" = "ubifs" ]; then
@@ -204,7 +204,7 @@ nand_upgrade_prepare_ubi() {
 		fi
 	fi
 
-	# create rootfs_data for non-ubifs rootfs
+	# create rootfs_data vol for non-ubifs rootfs
 	if [ "$rootfs_type" != "ubifs" ]; then
 		local rootfs_data_size_param="-m"
 		if [ -n "$rootfs_data_max" ]; then

--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -288,7 +288,7 @@ nand_upgrade_tar() {
 	local board_dir=$(tar tf "$tar_file" | grep -m 1 '^sysupgrade-.*/$')
 	board_dir=${board_dir%/}
 
-	kernel_length=$( (tar xf "$tar_file" ${board_dir}/kernel -O | wc -c) 2> /dev/null)
+	local kernel_length=$( (tar xf "$tar_file" ${board_dir}/kernel -O | wc -c) 2> /dev/null)
 	local has_rootfs=0
 	local rootfs_length
 	local rootfs_type
@@ -311,16 +311,16 @@ nand_upgrade_tar() {
 	nand_upgrade_prepare_ubi "$rootfs_length" "$rootfs_type" "${has_kernel:+$kernel_length}" "$has_env"
 
 	local ubidev="$( nand_find_ubi "$CI_UBIPART" )"
-	[ "$has_kernel" = "1" ] && {
-		local kern_ubivol="$( nand_find_volume $ubidev $CI_KERNPART )"
-		tar xf "$tar_file" ${board_dir}/kernel -O | \
-			ubiupdatevol /dev/$kern_ubivol -s $kernel_length -
-	}
-
 	[ "$has_rootfs" = "1" ] && {
 		local root_ubivol="$( nand_find_volume $ubidev $CI_ROOTPART )"
 		tar xf "$tar_file" ${board_dir}/root -O | \
 			ubiupdatevol /dev/$root_ubivol -s $rootfs_length -
+	}
+
+	[ "$has_kernel" = "1" ] && {
+		local kern_ubivol="$( nand_find_volume $ubidev $CI_KERNPART )"
+		tar xf "$tar_file" ${board_dir}/kernel -O | \
+			ubiupdatevol /dev/$kern_ubivol -s $kernel_length -
 	}
 	nand_do_upgrade_success
 }

--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -236,11 +236,6 @@ nand_upgrade_ubinized() {
 	local ubi_file="$1"
 	local mtdnum="$(find_mtd_index "$CI_UBIPART")"
 
-	[ ! "$mtdnum" ] && {
-		CI_UBIPART="rootfs"
-		mtdnum="$(find_mtd_index "$CI_UBIPART")"
-	}
-
 	if [ ! "$mtdnum" ]; then
 		echo "cannot find mtd device $CI_UBIPART"
 		umount -a
@@ -248,10 +243,11 @@ nand_upgrade_ubinized() {
 	fi
 
 	local mtddev="/dev/mtd${mtdnum}"
-	ubidetach -p "${mtddev}" || true
+	ubidetach -p "${mtddev}" || :
 	sync
 	ubiformat "${mtddev}" -y -f "${ubi_file}"
 	ubiattach -p "${mtddev}"
+
 	nand_do_upgrade_success
 }
 
@@ -333,7 +329,7 @@ nand_upgrade_tar() {
 nand_do_upgrade() {
 	local file_type=$(identify $1)
 
-	[ ! "$(find_mtd_index "$CI_UBIPART")" ] && CI_UBIPART="rootfs"
+	[ ! "$(find_mtd_index "$CI_UBIPART")" ] && CI_UBIPART=rootfs
 
 	case "$file_type" in
 		"fit")		nand_upgrade_fit $1;;

--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -136,18 +136,23 @@ nand_upgrade_prepare_ubi() {
 		ubiattach -m "$mtdnum"
 		sync
 		ubidev="$( nand_find_ubi "$CI_UBIPART" )"
-	fi
 
-	if [ ! "$ubidev" ]; then
-		ubiformat /dev/mtd$mtdnum -y
-		ubiattach -m "$mtdnum"
-		sync
-		ubidev="$( nand_find_ubi "$CI_UBIPART" )"
-		[ ! "$ubidev" ] && return 1
-		[ "$has_env" -gt 0 ] && {
-			ubimkvol /dev/$ubidev -n 0 -N ubootenv -s 1MiB
-			ubimkvol /dev/$ubidev -n 1 -N ubootenv2 -s 1MiB
-		}
+		if [ ! "$ubidev" ]; then
+			ubiformat /dev/mtd$mtdnum -y
+			ubiattach -m "$mtdnum"
+			sync
+			ubidev="$( nand_find_ubi "$CI_UBIPART" )"
+
+			if [ ! "$ubidev" ]; then
+				echo "cannot attach ubi mtd partition $CI_UBIPART"
+				return 1
+			fi
+
+			if [ "$has_env" -gt 0 ]; then
+				ubimkvol /dev/$ubidev -n 0 -N ubootenv -s 1MiB
+				ubimkvol /dev/$ubidev -n 1 -N ubootenv2 -s 1MiB
+			fi
+		fi
 	fi
 
 	local kern_ubivol="$( nand_find_volume $ubidev $CI_KERNPART )"

--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -303,7 +303,7 @@ nand_upgrade_tar() {
 	local has_env=0
 
 	[ "$kernel_length" != 0 -a -n "$kernel_mtd" ] && {
-		tar xf "$tar_file" ${board_dir}/kernel -O | mtd write - $CI_KERNPART
+		mtd erase $CI_KERNPART
 	}
 	[ "$kernel_length" = 0 -o ! -z "$kernel_mtd" ] && has_kernel=
 	[ "$CI_KERNPART" = "none" ] && has_kernel=
@@ -317,6 +317,10 @@ nand_upgrade_tar() {
 			ubiupdatevol /dev/$root_ubivol -s $rootfs_length -
 	}
 
+	[ "$kernel_length" != 0 -a -n "$kernel_mtd" ] && {
+		tar xf "$tar_file" ${board_dir}/kernel -O | \
+			mtd -n write - $CI_KERNPART
+	}
 	[ "$has_kernel" = "1" ] && {
 		local kern_ubivol="$( nand_find_volume $ubidev $CI_KERNPART )"
 		tar xf "$tar_file" ${board_dir}/kernel -O | \


### PR DESCRIPTION
@dangowrt 

hi Daniel,

here is the first part. next comes:
- nand tar sysupgrade that will guarantee the possibility entering failsafe if interrupted at any time (without needing a recovery and without sacrificing space)
- nand tar sysupgrade that will guarantee total automatic rollback if interrupted at any time (optional mode, sacrifices space for robustness)

this PR is broken in small commits as you asked. my expectation is not that you merge the whole PR, but that you cherrypick commits that you want and veto what you don't.

i will wait and see the outcome of this before continuing any further. if enough is cherrypicked so that the code base is a little cleaner, then i'll be able to continue work.

here is a little info about the commits in commit order:

- 8a9d00b9ec base-files: emit diagnostics on nand sysupgrade abort (plus cleanup)
optional. was there to fix stuff, but you beat me to it. fully tested.

- 43ff2a01d4 base-files: only remove ubiblock devices required for nand sysupgrade
optional. was there to fix stuff, but you beat me to it. fully tested.

- a80b8a3e82 base-files: fix nand sysupgrade comments
trivial.

- 09fdeb8147 base-files: safer tar sysupgrade for kernel-in-UBI nand devices
fully tested.

- 01d9124252 base-files: safer tar sysupgrade for kernel-out-of-UBI nand devices
i cannot test this.

- bc5e306f95 base-files: clean up nand tar sysupgrade code
all tested except the kernel-out-of-UBI lines. necessary for me to continue work.

- dd89f80f08 base-files: remove repeated check in ubinized sysupgrade code
i cannot test this.

- 9c3ba5aeaa base-files: fix some inconsistent quoting in nand sysupgrade code
trivial/tested.

- 3563d0a1c0 base-files: fix issues saving configuration during nand sysupgrade
tested.

- dbef2fb166 base-files: remove unnecessary sync commands in nand sysupgrade
trivial.

- 31454e4b9f (origin/nand-sysupgrade) base-files: minimize critical time for nand sysupgrade
trivial.

thanks!