### PR TITLE
ath79: add USB power control for GL-AR300M series

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar300m-lite.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar300m-lite.dts
@@ -7,6 +7,8 @@
 	model = "GL.iNet GL-AR300M-Lite";
 };
 
+/delete-node/ &reg_usb_vbus;
+
 /delete-node/ &nand_flash;
 
 &nor_firmware {
@@ -26,4 +28,8 @@
 
 &led_wlan {
 	label = "green:wlan";
+};
+
+&usb0 {
+	/delete-property/ vbus-supply;
 };

--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar300m.dtsi
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar300m.dtsi
@@ -37,6 +37,16 @@
 		};
 	};
 
+	reg_usb_vbus: reg_usb_vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 
@@ -134,6 +144,7 @@
 &usb0 {
 	#address-cells = <1>;
 	#size-cells = <0>;
+	vbus-supply = <&reg_usb_vbus>;
 	status = "okay";
 };
 


### PR DESCRIPTION
This PR add USB power control via GPIO2 in DTS for GL-AR300M series, except GL-AR300M-Lite (this model unable to control USB power).

According official [GL.Inet documentation](https://docs.gl-inet.com/en/2/hardware/ar300m/) GL-AR300M device have USB power control via GPIO2. I tested it on my AR300M16 with Openwrt 21.02.2 installed and this code work perfect:
```
# export gpio
echo 2 > /sys/class/gpio/export

# setup gpio as out
echo out > /sys/class/gpio/gpio2/direction

# power on usb
echo 1 > /sys/class/gpio/gpio2/value

# power off usb
echo 0 > /sys/class/gpio/gpio2/value
```

On stock vendor's firmware output of command `cat /sys/kernel/debug/gpio` look like this:
> gpiochip0: GPIOs 0-31, parent: platform/ath79-gpio, ath79-gpio:
> gpio-0   (                    |button right        ) in  lo
> gpio-1   (                    |button left         ) in  lo
> gpio-2   (                    |gl-ar300m:green:usb ) out hi
> gpio-3   (                    |reset               ) in  hi
> gpio-12  (                    |gl-ar300m:green:syst) out lo
> gpio-13  (                    |gl-ar300m:green:lan ) out lo
> gpio-14  (                    |gl-ar300m:green:wlan) out lo
> gpiochip1: GPIOs 494-511, parent: platform/qca953x_wmac, ath9k-phy0:
> gpio-495 (                    |ath9k-phy0          ) in  lo

It is easy to see that GPIO2 controls the USB power.

Signed-off-by: PtilopsisLeucotis <PtilopsisLeucotis@yandex.com>
