### PR TITLE
wolfssl: fix compilation with /dev/crypto

### DIFF
--- a/package/libs/wolfssl/patches/400-wolfcrypt-src-port-devcrypto-devcrypto_aes.c-remove-.patch
+++ b/package/libs/wolfssl/patches/400-wolfcrypt-src-port-devcrypto-devcrypto_aes.c-remove-.patch
@@ -1,0 +1,19 @@
+From 096889927d9528d4fbeb3aab56d1fe8225d2e7ec Mon Sep 17 00:00:00 2001
+From: Daniel Pouzzner <douzzer@wolfssl.com>
+Date: Thu, 14 Apr 2022 20:23:31 -0500
+Subject: [PATCH] wolfcrypt/src/port/devcrypto/devcrypto_aes.c: remove
+ redundant "int ret" in wc_AesCtrEncrypt() (supersedes #5052).
+
+
+diff --git a/wolfcrypt/src/port/devcrypto/devcrypto_aes.c b/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
+index 3bc1d5bb1..28e145e27 100644
+--- a/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
++++ b/wolfcrypt/src/port/devcrypto/devcrypto_aes.c
+@@ -208,7 +208,6 @@ int wc_AesCtrEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
+     int ret;
+     struct crypt_op crt;
+     byte* tmp;
+-    int ret;
+ 
+     if (aes == NULL || out == NULL || in == NULL) {
+         return BAD_FUNC_ARG;


### PR DESCRIPTION
This is trivial fix of a duplicate definition of 'int ret'.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

Patch is an upstream commit.  
Compile-tested on mediatek/mt7622.