### PR TITLE
ramips: add support for Wavlink WL-WN533A8 

### DIFF
--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn531a6.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn531a6.dts
@@ -1,203 +1,32 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "mt7621.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "mt7621_wavlink_wl-wn53xax.dtsi"
 
 / {
 	compatible = "wavlink,wl-wn531a6", "mediatek,mt7621-soc";
 	model = "Wavlink WL-WN531A6";
-
-	aliases {
-		led-boot = &led_status_red;
-		led-failsafe = &led_status_red;
-		led-running = &led_status_blue;
-		led-upgrade = &led_status_red;
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "Reset Button";
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-
-		touch { /* RH6015C touch sensor -> GPIO 14 */
-			label = "Touch Button";
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-			linux,code = <BTN_0>;
-		};
-
-		turbo {
-			label = "Turbo Button";
-			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
-			linux,code = <BTN_1>;
-		};
-
-		wps {
-			label = "WPS Button";
-			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WPS_BUTTON>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led_status_blue: status_blue {
-			label = "blue:power";
-			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
-		};
-
-		led_status_red: status_red {
-			label = "red:power";
-			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
-		};
-
-		wifi2g {
-			label = "blue:wifi2g";
-			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-	};
 };
 
-&i2c {
-	status = "okay";
+&wifi0{
+	ieee80211-freq-limit = <2400000 2500000>;
 };
 
-&spi0 {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <40000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x0 0x30000>;
-				read-only;
-			};
-
-			partition@30000 {
-				label = "config";
-				reg = <0x30000 0x10000>;
-				read-only;
-			};
-
-			factory: partition@40000 {
-				label = "factory";
-				reg = <0x40000 0x10000>;
-				read-only;
-			};
-
-			partition@50000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x50000 0xeb0000>;
-			};
-
-			partition@f00000 {
-				label = "vendor";
-				reg = <0xf00000 0x100000>;
-				read-only;
-			};
-		};
-	};
+&wifi1{
+	ieee80211-freq-limit = <5000000 6000000>;
 };
 
-&pcie {
-	status = "okay";
+&port0{
+	label = "lan1";
 };
 
-&pcie0 {
-	mt76@0,0 {
-		compatible = "mediatek,mt76";
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
-		ieee80211-freq-limit = <2400000 2500000>;
-	};
+&port1{
+	label = "lan2";
 };
 
-&pcie1 {
-	mt76@0,0 {
-		compatible = "mediatek,mt76";
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
-		ieee80211-freq-limit = <5000000 6000000>;
-	};
+&port2{
+	label = "lan3";
 };
 
-&ethernet {
-	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_factory_e000>;
-	nvmem-cell-names = "mac-address";
-};
-
-&switch0 {
-	ports {
-		port@0 {
-			status = "okay";
-			label = "lan1";
-		};
-
-		port@1 {
-			status = "okay";
-			label = "lan2";
-		};
-
-		port@2 {
-			status = "okay";
-			label = "lan3";
-		};
-
-		port@3 {
-			status = "okay";
-			label = "lan4";
-		};
-
-		port@4 {
-			status = "okay";
-			label = "wan";
-			nvmem-cells = <&macaddr_factory_e006>;
-			nvmem-cell-names = "mac-address";
-		};
-	};
-};
-
-&state_default {
-	gpio {
-		groups = "rgmii2", "jtag", "wdt";
-		function = "gpio";
-	};
-};
-
-&uartlite2 {
-	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
-	};
+&port3{
+	label = "lan4";
 };

--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn533a8.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn533a8.dts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_wavlink_wl-wn53xax.dtsi"
+
+/ {
+	compatible = "wavlink,wl-wn533a8", "mediatek,mt7621-soc";
+	model = "Wavlink WL-WN533A8";
+};
+
+&wifi0{
+	ieee80211-freq-limit = <2400000 5490000>;
+};
+
+&wifi1{
+	ieee80211-freq-limit = <5490000 6000000>;
+};
+
+&port0{
+	label = "lan4";
+};
+
+&port1{
+	label = "lan3";
+};
+
+&port2{
+	label = "lan2";
+};
+
+&port3{
+	label = "lan1";
+};

--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn53xax.dtsi
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn53xax.dtsi
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_red;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset Button";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		touch { /* RH6015C touch sensor -> GPIO 14 */
+			label = "Touch Button";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		turbo {
+			label = "Turbo Button";
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+		};
+
+		wps {
+			label = "WPS Button";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status_blue {
+			label = "blue:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: status_red {
+			label = "red:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi2g {
+			label = "blue:wifi2g";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xeb0000>;
+			};
+
+			partition@f00000 {
+				label = "vendor";
+				reg = <0xf00000 0x100000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi0: mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&pcie1 {
+	wifi1: mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+	};
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port0: port@0 {
+			status = "okay";
+		};
+
+		port1: port@1 {
+			status = "okay";
+		};
+
+		port2: port@2 {
+			status = "okay";
+		};
+
+		port3: port@3 {
+			status = "okay";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e006>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "rgmii2", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&uartlite2 {
+	status = "okay";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1741,6 +1741,16 @@ define Device/wavlink_wl-wn531a6
 endef
 TARGET_DEVICES += wavlink_wl-wn531a6
 
+define Device/wavlink_wl-wn533a8
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := WL-WN533A8
+  KERNEL_INITRAMFS_SUFFIX := -WN533A8$$(KERNEL_SUFFIX)
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware kmod-usb3
+  IMAGE_SIZE := 15040k
+endef
+TARGET_DEVICES += wavlink_wl-wn533a8
+
 define Device/wevo_11acnas
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -163,6 +163,7 @@ ramips_setup_macs()
 		;;
 	jcg,y2|\
 	wavlink,wl-wn531a6|\
+	wavlink,wl-wn533a8|\
 	winstars,ws-wn583a6|\
 	zbtlink,zbt-we1326|\
 	zbtlink,zbt-wg3526-16m|\


### PR DESCRIPTION
The Wavlink WL-WN533A8 is an AC3000 router with 5 gigabit ethernet ports
and one USB 3.0 port.
It's also known as Wavlink QUANTUM T8.

```
Hardware
--------
SoC:   Mediatek MT7621A
RAM:   128MB (Nanya NT5CB64M16GP-EK)
FLASH: 16MB NOR (GigaDevice GD25Q127CSIG3)
ETH:
  - 5x 10/100/1000 Mbps Ethernet (4x LAN + 1x WAN)
WIFI:
  - 1x MT7615DN (2x 2x2:2) 2.4GHz and 5GHz DBDC
  - 1x MT7615NE (4x4:4) 5GHz
  - 8 external antennas
BTN:
  - 1x Reset button
  - 1x WPS button
  - 1x Turbo button
  - 1x Touchlink button
  - 1x ON/OFF switch
LEDS:
  - 1x Red led (system status)
  - 1x Blue led (system status)
  - 7x Blue leds (wifi led + 5 ethernet ports + power)
USB:
  - 1x USB 3.0 port
UART:
  - 57600-8-N-1
    J4

```
Everything works correctly.

Installation
------------
Flash the initramfs image in the OEM firmware interface
(http://192.168.10.1/update.shtml).
When Openwrt boots, flash the sysupgrade image otherwise you won't be
able to keep configuration between reboots.
(Procedure tested on fw M33A8.V5030.190716 and M33A8.V5030.201204)

Restore OEM Firmware
--------------------
Flash the firmware update available online directly from LUCI.
You can download it from:
https://www.wavlink.com/en_us/firmware/details/f2d247ecba.html
Warning: Remember to not keep settings!
Warning2: Remember to force the flash.

Notes
-----
1) Router mac addresses:
   LAN		XX:XX:XX:XX:XX:63 (factory @ 0xe006)
   WAN		XX:XX:XX:XX:XX:64 (factory @ 0xe000)
   WIFI 2G/5G	XX:XX:XX:XX:XX:65 (factory @ 0x04)
   WIFI 5G	XX:XX:XX:XX:XX:66 (factory @ 0x8004)

   LABEL	XX:XX:XX:XX:XX:65

   In OEM firmware the DBDC wifi interfaces have these mac addresses:
     2G) 82:XX:XX:XX:XX:65
     5G) 80:XX:XX:XX:XX:65

   While in OpenWrt the addresses are:
     2G) 80:XX:XX:XX:XX:65
     5G) 02:XX:XX:XX:XX:65

2) radio0 will show as 2G/5G interface but only 2G is really usable.

3) There is just one wifi led for all wifi interfaces.
   It currently shows only the radio0 GHz wifi activity.

4) My unit was shipped with M33A8.V5030.190716 firmware which contains
   the http://192.168.10.1/webcmd.shtml page. Entering "telnetd" in
   the input box it will start the telnet daemon. Now you can access
   the telnet console on port 2323 with these credentials:
     username: admin2860
     password: admin

5) The M33A8.V5030.201204 firmware version, doesn't contain anymore the
   webcmd.shtml page. If your router is shipped with a previous firmware
   version and you want to back it up, you can follow the back up
   procedure of the WS-WN583A6.