### PR TITLE
build: use numeric-owner in ipkg-build

### DIFF
--- a/scripts/ipkg-build
+++ b/scripts/ipkg-build
@@ -179,20 +179,20 @@ for file_mode in $file_modes; do
 	chown "$uid:$gid" "$pkg_dir/$path"
 	chmod  "$mode" "$pkg_dir/$path"
 done
-$TAR -X "$tmp_dir"/tarX --format=gnu --sort=name -cpf - --mtime="$TIMESTAMP" . | gzip -n - > "$tmp_dir"/data.tar.gz
+$TAR -X "$tmp_dir"/tarX --format=gnu --numeric-owner --sort=name -cpf - --mtime="$TIMESTAMP" . | gzip -n - > "$tmp_dir"/data.tar.gz
 
 installed_size=$(stat -c "%s" "$tmp_dir"/data.tar.gz)
 sed -i -e "s/^Installed-Size: .*/Installed-Size: $installed_size/" \
 	"$pkg_dir"/$CONTROL/control
 
-( cd "$pkg_dir"/$CONTROL && $TAR --format=gnu --sort=name -cf -  --mtime="$TIMESTAMP" . | gzip -n - > "$tmp_dir"/control.tar.gz )
+( cd "$pkg_dir"/$CONTROL && $TAR --format=gnu --numeric-owner --sort=name -cf -  --mtime="$TIMESTAMP" . | gzip -n - > "$tmp_dir"/control.tar.gz )
 rm "$tmp_dir"/tarX
 
 echo "2.0" > "$tmp_dir"/debian-binary
 
 pkg_file=$dest_dir/${pkg}_${version}_${arch}.ipk
 rm -f "$pkg_file"
-( cd "$tmp_dir" && $TAR --format=gnu --sort=name -cf -  --mtime="$TIMESTAMP" ./debian-binary ./data.tar.gz ./control.tar.gz | gzip -n - > "$pkg_file" )
+( cd "$tmp_dir" && $TAR --format=gnu --numeric-owner --sort=name -cf -  --mtime="$TIMESTAMP" ./debian-binary ./data.tar.gz ./control.tar.gz | gzip -n - > "$pkg_file" )
 
 rm "$tmp_dir"/debian-binary "$tmp_dir"/data.tar.gz "$tmp_dir"/control.tar.gz
 rmdir "$tmp_dir"


### PR DESCRIPTION
To create packages the `ipkg-build` script is used which double packs
`control.tar.gz` and `data.tar.gz` to a single package. By default it's
using a verbose username instead of a numeric value for files.

Official OpenWrt images (artifacts) are created within docker containers
which do not seem to contain those verbose usernames and instead
defaults to numeric values.

This becomes a problem when rebuilding public artifacts because other
build environments may offer verbose usernames and there the created
packages is different from the official ones.

With this commit `ipkg-build` always uses numeric values for user/group
and thereby making it easier to reproduce official artifacts.

Signed-off-by: Paul Spooren <mail@aparcar.org>