### PR TITLE
lantiq: ARV7519RW22 remove kernel size and enable

### DIFF
--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -24,11 +24,9 @@ define Device/arcadyan_arv7519rw22
   DEVICE_ALT0_VARIANT := 2.1
   DEVICE_ALT1_VENDOR := Astoria Networks
   DEVICE_ALT1_MODEL := ARV7519RW22
-  KERNEL_SIZE := 2048k
   IMAGE_SIZE := 31232k
   DEVICE_PACKAGES := kmod-usb-dwc2
   SUPPORTED_DEVICES += ARV7519RW22
-  DEFAULT := n
 endef
 TARGET_DEVICES += arcadyan_arv7519rw22
 


### PR DESCRIPTION
This PR requires that  #9742 is merged before.

ARV7519RW22 was set a 2 MB kernel size and disabled because stated that stock uboot couldn't boot kernels bigger than 2 MB. In fact this is not true, the stock bootloader is a BRNBoot one and we change it to a uboot generated one. Actually uboot for this device has been added to uboot-lantiq with kernels up to 16 MB support.

Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>