### PR TITLE
bcm63xx: fix description fix name case

### DIFF
--- a/target/linux/bcm63xx/profiles/default.mk
+++ b/target/linux/bcm63xx/profiles/default.mk
@@ -8,7 +8,7 @@ define Profile/Default
   PRIORITY:=1
 endef
 
-define Profile/Default/description
+define Profile/Default/Description
   Package set compatible with most boards.
 endef
 


### PR DESCRIPTION
The `Description` should be capital.
