### PR TITLE
build: align SOURCE path for build system and SDK

### DIFF
--- a/include/package-defaults.mk
+++ b/include/package-defaults.mk
@@ -20,7 +20,7 @@ define Package/Default
   PROVIDES:=
   EXTRA_DEPENDS:=
   MAINTAINER:=$(PKG_MAINTAINER)
-  SOURCE:=$(patsubst $(TOPDIR)/%,%,$(CURDIR))
+  SOURCE:=$(patsubst $(TOPDIR)/%,%,$(patsubst $(TOPDIR)/package/%,feeds/base/%,$(CURDIR)))
   ifneq ($(PKG_VERSION),)
     ifneq ($(PKG_RELEASE),)
       VERSION:=$(PKG_VERSION)-$(PKG_RELEASE)

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -106,7 +106,8 @@ PROFILE_LIST = $(foreach p,$(PROFILE_NAMES), \
 	@$(SCRIPT_DIR)/target-metadata.pl profile_mk $< '$(BOARD)$(if $(SUBTARGET),/$(SUBTARGET))' > $@
 
 staging_dir/host/.prereq-build: include/prereq-build.mk
-	mkdir -p tmp
+	mkdir -p tmp feeds
+	ln -sf $(TOPDIR)/package $(TOPDIR)/feeds/base
 	@$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f $(TOPDIR)/include/prereq-build.mk prereq IB=1 2>/dev/null || { \
 		echo "Prerequisite check failed. Use FORCE=1 to override."; \
 		false; \


### PR DESCRIPTION
Building a package in the build system or the SDK results in different
values for the `SOURCE` property, it's either `packages/<package name>`
or `feeds/base/<package name>`. The reason is that the SDK handles
`openwrt.git` as an external feed called while the build system contains
the *base* packages directly.

Since packages created with either method are (ideally) the same (bit
for bit), align the content of SOURCE. To do so this commit creates a
symlink from `feeds/base` to `$(TOPDIR)/package` and adopts the SOURCE
when building from inside the build system.

Signed-off-by: Paul Spooren <mail@aparcar.org>