### PR TITLE
ath79: add support for TP-Link Deco M4R v1 and v2

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_deco-m4r-v1.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_deco-m4r-v1.dts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	compatible = "tplink,deco-m4r-v1", "qca,qca9563";
+	model = "TP-Link Deco M4R v1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan2g {
+			label = "red:wlan2g";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+		
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+
+	keys {
+		compatible = "gpio-keys";
+		
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		qca,mib-poll-interval = <500>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			>;
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x080000>;
+				read-only;
+			};
+			
+			partition@80000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x080000 0xe00000>;
+			};
+			
+			partition@e80000 {
+				label = "product-info";
+				reg = <0xe80000 0x05000>;
+				read-only;
+			};
+
+			config: partition@e85000 {
+				label = "config";
+				reg = <0xe85000 0x16b000>;
+				read-only;
+			};
+			
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+	
+	nvmem-cells = <&macaddr_config_8>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	nvmem-cells = <&macaddr_config_8>;
+	nvmem-cell-names = "mac-address";
+};
+
+&config {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_config_8: macaddr@8 {
+		reg = <0x8 0x6>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -508,6 +508,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan"
 		;;
+	tplink,deco-m4r-v1)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "3:lan:1" "5:lan:2"
+		;;
 	hiwifi,hc6361|\
 	xiaomi,mi-router-4q|\
 	zbtlink,zbt-wd323)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -269,6 +269,12 @@ case "$FIRMWARE" in
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9984/hw1.0/board.bin
 		;;
+	tplink,deco-m4r-v1)
+		caldata_extract "art" 0x5000 0x2f20
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary config 0x8) -1)
+		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
+			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+		;;
 	yuncore,a782|\
 	yuncore,xd4200)
 		caldata_extract "art" 0x5000 0x2f20

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -456,6 +456,18 @@ define Device/tplink_eap245-v3
 endef
 TARGET_DEVICES += tplink_eap245-v3
 
+define Device/tplink_deco-m4r-v1
+  $(Device/tplink-safeloader-uimage)
+  SOC := qca9563
+  IMAGE_SIZE := 13824k
+  DEVICE_MODEL := Deco M4R
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  SUPPORTED_DEVICES += deco-m4r-v1
+  TPLINK_BOARD_ID := DECO-M4R-V1
+endef
+TARGET_DEVICES += tplink_deco-m4r-v1
+
 define Device/tplink_re350k-v1
   $(Device/tplink-safeloader)
   SOC := qca9558


### PR DESCRIPTION
This commit adds support for the TP-Link Deco M4R (it can also be M4, TP-Link uses both names) v1 and v2. It is similar hardware-wise to the Archer C6 v2. Software-wise it is very different. V2 has a bit different layout from V1 but the chips are the same and the OEM firmware is the same for both versions.

Specifications:
SoC: QCA9563-AL3A
RAM: Zentel A3R1GE40JBF
Wireless 2.4GHz: QCA9563-AL3A (main SoC)
Wireless 5GHz: QCA9886
Ethernet Switch: QCA8337N-AL3C
Flash: 16 MB SPI NOR

Flashing:

The device's bootloader only accepts images that are signed using TP-Link's RSA key, therefore this way of flashing is not possible. The device has a web GUI that should be accessible after setting up the device using the app (it requires the app to set it up first because the web GUI asks for the TP-Link account password) but for unknown reasons, the web GUI also refuses custom images.

There is a debug firmware image that has been shared on the device's OpenWrt forum thread that has telnet unlocked, which the bootloader will accept because it is signed. It can be used to transfer an OpenWrt image file over to the device and then be used with mtd to flash the device.

Pre-requisites:

- Debug firmware.
- A way of transferring the file to the router, you can use an FTP server as an example.
- Set a static IP of 192.168.0.2/255.255.255.0 on your computer.
- OpenWrt image.

Installation:

- Unplug your router and turn it upside down. Using a long and thin object like a SIM unlock tool, press and hold the reset button on the router and replug it. Keep holding it until the LED flashes yellow.
- Open 192.168.0.1. You should see the bootloader recovery's webpage. Choose the debug firmware that you downloaded and flash it. Wait until the router reboots (at this stage you can remove the static IP).
- Open a terminal window and connect to the router via telnet (the primary router should have a 192.168.0.1 IP address, secondary routers are different).
- Transfer the file over to the router, you can use curl to download it from the internet (use the insecure flag and make sure your source accepts insecure downloads) or from an FTP server.
- The router's default mtd partition scheme has kernel and rootfs separated. We can use dd to split the OpenWrt image file and flash it with mtd.
`dd if=openwrt.bin of=kernel.bin skip=0 count=8192 bs=256`
`dd if=openwrt.bin of=rootfs.bin skip=8192 bs=256`

- Once the images are ready, you have to flash the device using mtd (make sure to flash the correct partitions or you may be left with a hard bricked router).
`mtd write kernel.bin kernel`
`mtd write rootfs.bin rootfs`

- Flashing is done, reboot the device now.

Signed-off-by: Foica David superh552@gmail.com