### PR TITLE
ath79: ZTE MF286R: add comgt-ncm to DEVICE_PACKAGES

### DIFF
--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -334,7 +334,8 @@ TARGET_DEVICES += zte_mf286a
 define Device/zte_mf286r
   $(Device/zte_mf286_common)
   DEVICE_MODEL := MF286R
-  DEVICE_PACKAGES += ath10k-firmware-qca9888-ct kmod-usb-net-rndis kmod-usb-acm
+  DEVICE_PACKAGES += ath10k-firmware-qca9888-ct kmod-usb-net-rndis kmod-usb-acm \
+	comgt-ncm
 endef
 TARGET_DEVICES += zte_mf286r
 


### PR DESCRIPTION
When adding support to the router's built-in modem, this required
package was omitted, because it was already enabled in the image
configuration in use for testing, and this went unnoticed.
In result, the modem still isn't fully supported in official images.
As it is the primary WAN interface, add the missing package.

Fixes: e02fb42c53ba ("comgt: support ZTE MF286R modem")
Signed-off-by: Lech Perczak <lech.perczak@gmail.com>

Again, this probably deserves cherry-picking to 22.03 branch.