### PR TITLE
build: don't remove BUILD_LOG_DIR in _clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ printdb:
 prepare: $(target/stamp-compile)
 
 _clean: FORCE
-	rm -rf $(BUILD_DIR) $(STAGING_DIR) $(BIN_DIR) $(OUTPUT_DIR)/packages/$(ARCH_PACKAGES) $(BUILD_LOG_DIR) $(TOPDIR)/staging_dir/packages
+	rm -rf $(BUILD_DIR) $(STAGING_DIR) $(BIN_DIR) $(OUTPUT_DIR)/packages/$(ARCH_PACKAGES) $(TOPDIR)/staging_dir/packages
 
 clean: _clean
 	rm -rf $(BUILD_LOG_DIR)


### PR DESCRIPTION
targetclean should not remove BUILD_LOG
Fixes: db34b93331e91bdb2cbc15d17632aaaab7217a6d (add a version that can be bumped to force toolchain/target rebuild)
