### PR TITLE
[22.03] ramips: add support for YunCore AX820/HWAP-AX820

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -23,7 +23,8 @@ sitecom,wlr-4100-v1-002)
 	;;
 allnet,all0256n-4m|\
 allnet,all0256n-8m|\
-allnet,all5002)
+allnet,all5002|\
+yuncore,ax820)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
 	;;
 ampedwireless,ally-00x19k|\

--- a/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "yuncore,ax820", "mediatek,mt7621-soc";
+	model = "YunCore AX820";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		hw_margin_ms = <200>;
+		always-running;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			/* range 0x40000 to 0x50000 is empty in vendor
+			 * firmware, so we do not use it either
+			 */
+
+			factory: partition@50000 {
+				label = "Factory";
+				reg = <0x50000 0x40000>;
+				read-only;
+			};
+
+			partition@90000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x90000 0xf70000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e000>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <1>;
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1952,6 +1952,15 @@ define Device/youku_yk-l2
 endef
 TARGET_DEVICES += youku_yk-l2
 
+define Device/yuncore_ax820
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 15808k
+  DEVICE_VENDOR := YunCore
+  DEVICE_MODEL := AX820
+  DEVICE_PACKAGES := kmod-mt7915e
+endef
+TARGET_DEVICES += yuncore_ax820
+
 define Device/zbtlink_zbt-we1326
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -89,6 +89,7 @@ ramips_setup_interfaces()
 	ubnt,usw-flex)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"
 		;;
+	yuncore,ax820|\
 	zyxel,nr7101)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
@@ -193,6 +194,9 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii Config protest_lan_mac)
 		wan_mac=$(mtd_get_mac_ascii Config protest_wan_mac)
 		label_mac=$lan_mac
+		;;
+	yuncore,ax820)
+		label_mac=$(mtd_get_mac_binary Factory 0x4)
 		;;
 	esac
 

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -79,4 +79,8 @@ case "$board" in
 		hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"
 		[ "$PHYNBR" = "1" ] &&  macaddr_add $hw_mac_addr "0x100000" > /sys${DEVPATH}/macaddress
 		;;
+	yuncore,ax820)
+		[ "$PHYNBR" = "1" ] && \
+			macaddr_setbit_la "$(mtd_get_mac_binary Factory 0xe000)" > /sys${DEVPATH}/macaddress
+		;;
 esac


### PR DESCRIPTION
```
There are two versions which are identical apart from the enclosure:
  YunCore AX820: indoor ceiling mount AP with integrated antennas
  YunCore HWAP-AX820: outdoor enclosure with external (N) connectors

Hardware specs:
  SoC: MediaTek MT7621DAT
  Flash: 16 MiB SPI NOR
  RAM: 128MiB (DDR3, integrated)
  WiFi: MT7905DAN+MT7975DN 2.4/5GHz 2T2R 802.11ax
  Ethernet: 10/100/1000 Mbps x2 (WAN/PoE+LAN)
  LED: Status (green)
  Button: Reset
  Power: 802.11af/at PoE; DC 12V,1A
  Antennas: AX820(indoor): 4dBi internal; HWAP-AX820(outdoor): external

Flash instructions:
  The "OpenWRT support" version of the AX820 comes with a LEDE-based
  firmware with proprietary MTK drivers and a luci webinterface and
  ssh accessible under 192.168.1.1 on LAN; user root, no password.
  The sysupgrade.bin can be flashed using luci or sysupgrade via ssh,
  you will have to force the upgrade due to a different factory name.
  Remember: Do *not* preserve factory configuration!

MAC addresses as used by OEM firmware:
  use   address            source
  2g    44:D1:FA:*:0b      Factory 0x0004 (label)
  5g    46:D1:FA:*:0b      LAA of 2g
  lan   44:D1:FA:*:0c      Factory 0xe000
  wan   44:D1:FA:*:0d      Factory 0xe000 + 1
The wan MAC can also be found in 0xe006 but is not used by OEM dtb.

Due to different MAC handling in mt76 the LAA derived from lan is used
for 2g to prevent duplicate MACs when creating multiple interfaces.

Signed-off-by: Clemens Hopfer <openwrt@wireloss.net>
(cherry picked from commit 4891b865380e2b7f32acf0893df9c1ca9db8d4ea)
```
this is  a direct cherry-pick backport of https://github.com/openwrt/openwrt/pull/4390, no adaptations were necessary.