### PR TITLE
realtek: add support for ZyXEL GS1900-16

### DIFF
--- a/package/boot/uboot-envtools/files/realtek
+++ b/package/boot/uboot-envtools/files/realtek
@@ -15,6 +15,7 @@ zyxel,gs1900-8|\
 zyxel,gs1900-8hp-v1|\
 zyxel,gs1900-8hp-v2|\
 zyxel,gs1900-10hp|\
+zyxel,gs1900-16|\
 zyxel,gs1900-24-v1|\
 zyxel,gs1900-24hp-v2)
 	idx="$(find_mtd_index u-boot-env)"

--- a/target/linux/realtek/dts-5.10/rtl8382_zyxel_gs1900-16.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_zyxel_gs1900-16.dts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_zyxel_gs1900.dtsi"
+
+/ {
+	compatible = "zyxel,gs1900-16", "realtek,rtl838x-soc";
+	model = "ZyXEL GS1900-16";
+};
+
+&mdio {
+	EXTERNAL_PHY(16)
+	EXTERNAL_PHY(17)
+	EXTERNAL_PHY(18)
+	EXTERNAL_PHY(19)
+	EXTERNAL_PHY(20)
+	EXTERNAL_PHY(21)
+	EXTERNAL_PHY(22)
+	EXTERNAL_PHY(23)
+};
+
+&switch0 {
+	ports {
+		SWITCH_PORT(16, 9, qsgmii)
+		SWITCH_PORT(17, 10, qsgmii)
+		SWITCH_PORT(18, 11, qsgmii)
+		SWITCH_PORT(19, 12, qsgmii)
+		SWITCH_PORT(20, 13, qsgmii)
+		SWITCH_PORT(21, 14, qsgmii)
+		SWITCH_PORT(22, 15, qsgmii)
+		SWITCH_PORT(23, 16, qsgmii)
+	};
+};
+
+&gpio1 {
+	/delete-node/ poe_enable;
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -111,6 +111,14 @@ define Device/zyxel_gs1900-10hp
 endef
 TARGET_DEVICES += zyxel_gs1900-10hp
 
+define Device/zyxel_gs1900-16
+  $(Device/zyxel_gs1900)
+  SOC := rtl8382
+  DEVICE_MODEL := GS1900-16
+  ZYXEL_VERS := AAHJ
+endef
+TARGET_DEVICES += zyxel_gs1900-16
+
 define Device/zyxel_gs1900-8
   $(Device/zyxel_gs1900)
   DEVICE_MODEL := GS1900-8


### PR DESCRIPTION
realtek: add support for ZyXEL GS1900-16

The ZyXEL GS1900-16 is a 16 port gigabit switch similar to other GS1900 switches.

Specifications
--------------
* Device: ZyXEL GS1900-16
* SoC: Realtek RTL8382M 500 MHz MIPS 4KEc
* Flash: 16 MiB Macronix MX25L12835F
* RAM: 128 MiB DDR2 SDRAM Nanya NT5TU128M8HE
* Ethernet: 16x 10/100/1000 Mbps
* LEDs: 1 PWR LED (green, not configurable)
1 SYS LED (green, configurable)
16 ethernet port link/activity LEDs (green, SoC controlled)
* Buttons: 1 "RESET" button on front panel
* Power 120-240V AC C13
* UART: 1 serial header (J12) with populated standard pin connector on
the right back of the PCB.
Pinout (front to back):
+ Pin 1 - VCC marked with white dot
+ Pin 2 - RX
+ Pin 3 - TX
+ PIn 4 - GND

Serial connection parameters: 115200 8N1.

Installation
------------

OEM upgrade method:

* Log in to OEM management web interface
* Navigate to Maintenance > Firmware
* Select the HTTP radio button
* Select the Active radio button
* Use the browse button to locate the
realtek-generic-zyxel_gs1900-16-initramfs-kernel.bin
file amd select open so File Path is update with filename.
* Select the Apply button. Screen will display "Prepare
for firmware upgrade ...".
*Wait until screen shows "Do you really want to reboot?"
then select the OK button
* Once OpenWrt has booted, scp the sysupgrade image to /tmp and flash it:
> sysupgrade -n /tmp/realtek-generic-zyxel_gs1900-16-squashfs-sysupgrade.bin
it may be necessary to restart the network (/etc/init.d/network restart) on
the running initramfs image.

U-Boot TFTP method:

* Configure your client with a static 192.168.1.x IP (e.g. 192.168.1.10).
* Set up a TFTP server on your client and make it serve the initramfs image.
* Connect serial, power up the switch, interrupt U-boot by hitting the
space bar, and enable the network:
> rtk network on
* Since the GS1900-16 is a dual-partition device, you want to keep the OEM
firmware on the backup partition for the time being. OpenWrt can only boot
from the first partition anyway (hardcoded in the DTS). To make sure we are
manipulating the first partition, issue the following commands:
> setsys bootpartition 0
> savesys
* Download the image onto the device and boot from it:
> tftpboot 0x84f00000 192.168.1.10:openwrt-realtek-generic-zyxel_gs1900-16-initramfs-kernel.bin
> bootm
* Once OpenWrt has booted, scp the sysupgrade image to /tmp and flash it:
> sysupgrade -n /tmp/openwrt-realtek-generic-zyxel_gs1900-16-squashfs-sysupgrade.bin
it may be necessary to restart the network (/etc/init.d/network restart) on
the running initramfs image.

Signed-off-by: Raylynn Knight <rayknight@me.com>