### PR TITLE
mediatek: mt7623: fix thermal zone

### DIFF
--- a/target/linux/mediatek/patches-5.15/193-dts-mt7623-thermal_zone_fix.patch
+++ b/target/linux/mediatek/patches-5.15/193-dts-mt7623-thermal_zone_fix.patch
@@ -1,0 +1,48 @@
+From 824d56e753a588fcfd650db1822e34a02a48bb77 Mon Sep 17 00:00:00 2001
+From: Bruno Umuarama <anonimou_eu@hotmail.com>
+Date: Thu, 13 Oct 2022 21:18:21 +0000
+Subject: [PATCH] mediatek: mt7623: fix thermal zone
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Raising the temperatures for passive and active trips. @VA1DER
+proposed at issue 9396 to remove passive trip. This commit relates to
+his suggestion.
+
+Without this patch. the CPU will be throttled all the way down to 98MHz
+if the temperature rises even a degree above the trip point, and it was
+further discovered that if the internal temperature of the device is
+above the first trip point temperature when it boots then it will start
+in a throttled state and even
+$ echo disabled > /sys/class/thermal/thermal_zone0/mode
+will have no effect.
+
+The patch increases the passive trip point and active cooling map. The
+throttling temperature will then be at 77°C and 82°C, which is still a
+low enough temperature for ARM devices to not be in the real danger
+zone, and gives some operational headroom.
+
+Signed-off-by: Bruno Umuarama <anonimou_eu@hotmail.com>
+---
+ arch/arm/boot/dts/mt7623.dtsi | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/arch/arm/boot/dts/mt7623.dtsi
++++ b/arch/arm/boot/dts/mt7623.dtsi
+@@ -160,13 +160,13 @@
+ 
+ 				trips {
+ 					cpu_passive: cpu-passive {
+-						temperature = <57000>;
++						temperature = <77000>;
+ 						hysteresis = <2000>;
+ 						type = "passive";
+ 					};
+ 
+ 					cpu_active: cpu-active {
+-						temperature = <67000>;
++						temperature = <82000>;
+ 						hysteresis = <2000>;
+ 						type = "active";
+ 					};


### PR DESCRIPTION
As discussed on #9396 , using @VA1DER patch posted there and the tests done, I'm trying to create this pull request.

Text from @VA1DER:

The CPU will be throttled all the way down to 98MHz if the temperature rises even a degree above the trip point, and I have further discovered that if the internal temperature of the device is above the first trip point temperature when it boots, 

The patch deletes the first two trip points and cooling maps. The throttling temperature will then be at 87°C, which is still a low enough temperature for ARM devices to not be in the real danger zone, and gives some operational headroom.