### PR TITLE
ramips: improve support for MSG1500 X.00

### DIFF
--- a/target/linux/generic/hack-5.10/601-of_net-add-mac-address-ascii-support.patch
+++ b/target/linux/generic/hack-5.10/601-of_net-add-mac-address-ascii-support.patch
@@ -1,19 +1,19 @@
 From: Yousong Zhou <yszhou4tech@gmail.com>
-Subject: [PATCH] ath79: add nvmem cell mac-address-ascii support
+Subject: [PATCH] of: net: add nvmem cell mac-address-ascii support
 
-This is needed for devices with mac address stored in ascii format, e.g.
-HiWiFi HC6361 to be ported in the following patch.
+This is needed for devices with mac address stored in ascii format,
+e.g. HiWiFi HC6361 to be ported in the following patch.
 
 Submitted-by: Yousong Zhou <yszhou4tech@gmail.com>
 ---
- net/ethernet/eth.c                            | 83 ++++++++++++------
+ net/core/of_net.c | 83 ++++++++++++------
  1 files changed, 72 insertions(+), 11 deletions(-)
 
---- a/net/ethernet/eth.c
-+++ b/net/ethernet/eth.c
-@@ -539,6 +539,63 @@ int eth_platform_get_mac_address(struct
+--- a/drivers/of/of_net.c
++++ b/drivers/of/of_net.c
+@@ -57,13 +57,70 @@ static int of_get_mac_addr(struct device
+ 	return -ENODEV;
  }
- EXPORT_SYMBOL(eth_platform_get_mac_address);
  
 +static void *nvmem_cell_get_mac_address(struct nvmem_cell *cell)
 +{
@@ -72,35 +72,40 @@ Submitted-by: Yousong Zhou <yszhou4tech@gmail.com>
 +	},
 +};
 +
- /**
-  * Obtain the MAC address from an nvmem cell named 'mac-address' associated
-  * with given device.
-@@ -550,21 +607,28 @@ EXPORT_SYMBOL(eth_platform_get_mac_addre
-  */
- int nvmem_get_mac_address(struct device *dev, void *addrbuf)
+ static int of_get_mac_addr_nvmem(struct device_node *np, u8 *addr)
  {
+ 	struct platform_device *pdev = of_find_device_by_node(np);
 +	struct nvmem_cell_mac_address_property *property;
  	struct nvmem_cell *cell;
  	const void *mac;
 -	size_t len;
-+	int i;
-+
+-	int ret;
++	int ret, i;
+ 
+ 	/* Try lookup by device first, there might be a nvmem_cell_lookup
+ 	 * associated with a given device.
+@@ -74,17 +131,26 @@ static int of_get_mac_addr_nvmem(struct
+ 		return ret;
+ 	}
+ 
+-	cell = of_nvmem_cell_get(np, "mac-address");
 +	for (i = 0; i < ARRAY_SIZE(nvmem_cell_mac_address_properties); i++) {
 +		property = &nvmem_cell_mac_address_properties[i];
-+		cell = nvmem_cell_get(dev, property->name);
-+		/* For -EPROBE_DEFER don't try other properties. We'll get back to this one. */
++		cell = of_nvmem_cell_get(np, property->name);
++		/* For -EPROBE_DEFER don't try other properties.
++		 * We'll get back to this one.
++		 */
 +		if (!IS_ERR(cell) || PTR_ERR(cell) == -EPROBE_DEFER)
 +			break;
 +	}
- 
--	cell = nvmem_cell_get(dev, "mac-address");
++
  	if (IS_ERR(cell))
  		return PTR_ERR(cell);
  
 -	mac = nvmem_cell_read(cell, &len);
 +	mac = property->read(cell);
  	nvmem_cell_put(cell);
--
+ 
  	if (IS_ERR(mac))
  		return PTR_ERR(mac);
  

--- a/target/linux/generic/hack-5.15/601-of_net-add-mac-address-ascii-support.patch
+++ b/target/linux/generic/hack-5.15/601-of_net-add-mac-address-ascii-support.patch
@@ -1,19 +1,19 @@
 From: Yousong Zhou <yszhou4tech@gmail.com>
-Subject: [PATCH] ath79: add nvmem cell mac-address-ascii support
+Subject: [PATCH] of: net: add nvmem cell mac-address-ascii support
 
-This is needed for devices with mac address stored in ascii format, e.g.
-HiWiFi HC6361 to be ported in the following patch.
+This is needed for devices with mac address stored in ascii format,
+e.g. HiWiFi HC6361 to be ported in the following patch.
 
 Submitted-by: Yousong Zhou <yszhou4tech@gmail.com>
 ---
- net/ethernet/eth.c                            | 83 ++++++++++++------
+ net/core/of_net.c | 83 ++++++++++++------
  1 files changed, 72 insertions(+), 11 deletions(-)
 
---- a/net/ethernet/eth.c
-+++ b/net/ethernet/eth.c
-@@ -538,6 +538,63 @@ int eth_platform_get_mac_address(struct
+--- a/net/core/of_net.c
++++ b/net/core/of_net.c
+@@ -57,13 +57,70 @@ static int of_get_mac_addr(struct device
+ 	return -ENODEV;
  }
- EXPORT_SYMBOL(eth_platform_get_mac_address);
  
 +static void *nvmem_cell_get_mac_address(struct nvmem_cell *cell)
 +{
@@ -72,35 +72,40 @@ Submitted-by: Yousong Zhou <yszhou4tech@gmail.com>
 +	},
 +};
 +
- /**
-  * nvmem_get_mac_address - Obtain the MAC address from an nvmem cell named
-  * 'mac-address' associated with given device.
-@@ -549,21 +606,28 @@ EXPORT_SYMBOL(eth_platform_get_mac_addre
-  */
- int nvmem_get_mac_address(struct device *dev, void *addrbuf)
+ static int of_get_mac_addr_nvmem(struct device_node *np, u8 *addr)
  {
+ 	struct platform_device *pdev = of_find_device_by_node(np);
 +	struct nvmem_cell_mac_address_property *property;
  	struct nvmem_cell *cell;
  	const void *mac;
 -	size_t len;
-+	int i;
-+
+-	int ret;
++	int ret, i;
+ 
+ 	/* Try lookup by device first, there might be a nvmem_cell_lookup
+ 	 * associated with a given device.
+@@ -74,17 +131,26 @@ static int of_get_mac_addr_nvmem(struct
+ 		return ret;
+ 	}
+ 
+-	cell = of_nvmem_cell_get(np, "mac-address");
 +	for (i = 0; i < ARRAY_SIZE(nvmem_cell_mac_address_properties); i++) {
 +		property = &nvmem_cell_mac_address_properties[i];
-+		cell = nvmem_cell_get(dev, property->name);
-+		/* For -EPROBE_DEFER don't try other properties. We'll get back to this one. */
++		cell = of_nvmem_cell_get(np, property->name);
++		/* For -EPROBE_DEFER don't try other properties.
++		 * We'll get back to this one.
++		 */
 +		if (!IS_ERR(cell) || PTR_ERR(cell) == -EPROBE_DEFER)
 +			break;
 +	}
- 
--	cell = nvmem_cell_get(dev, "mac-address");
++
  	if (IS_ERR(cell))
  		return PTR_ERR(cell);
  
 -	mac = nvmem_cell_read(cell, &len);
 +	mac = property->read(cell);
  	nvmem_cell_put(cell);
--
+ 
  	if (IS_ERR(mac))
  		return PTR_ERR(mac);
  

--- a/target/linux/ramips/dts/mt7621_raisecom_msg1500-x-00.dts
+++ b/target/linux/ramips/dts/mt7621_raisecom_msg1500-x-00.dts
@@ -13,6 +13,7 @@
 		led-boot = &led_usb;
 		led-failsafe = &led_usb;
 		led-upgrade = &led_usb;
+		label-mac-device = &gmac0;
 	};
 
 	leds {
@@ -79,12 +80,32 @@
 			label = "Config";
 			reg = <0x80000 0x80000>;
 			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_config_8014: macaddr@8014 {
+				reg = <0x8014 0x11>;
+			};
+
+			macaddr_config_8036: macaddr@8036 {
+				reg = <0x8036 0x11>;
+			};
 		};
 
 		factory: partition@100000 {
 			label = "Factory";
 			reg = <0x100000 0x40000>;
 			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_factory_4: macaddr@4 {
+				reg = <0x4 0x6>;
+			};
 		};
 
 		partition@140000 {
@@ -115,10 +136,18 @@
 	};
 };
 
+&gmac0 {
+	nvmem-cells = <&macaddr_config_8014>;
+	nvmem-cell-names = "mac-address-ascii";
+};
+
 &gmac1 {
 	status = "okay";
 	label = "wan";
 	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_config_8036>;
+	nvmem-cell-names = "mac-address-ascii";
 };
 
 &mdio {
@@ -155,15 +184,5 @@
 	gpio {
 		groups = "i2c", "jtag", "uart3", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -277,11 +277,6 @@ ramips_setup_macs()
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		label_mac=$lan_mac
 		;;
-	raisecom,msg1500-x-00)
-		lan_mac=$(mtd_get_mac_ascii Config protest_lan_mac)
-		wan_mac=$(mtd_get_mac_ascii Config protest_wan_mac)
-		label_mac=$lan_mac
-		;;
 	yuncore,ax820)
 		label_mac=$(mtd_get_mac_binary Factory 0x4)
 		;;

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -141,8 +141,7 @@ case "$board" in
 		;;
 	raisecom,msg1500-x-00)
 		[ "$PHYNBR" = "0" ] && \
-			macaddr_setbit_la "$(mtd_get_mac_ascii Config protest_lan_mac)" \
-				> /sys${DEVPATH}/macaddress
+			macaddr_setbit_la "$(get_mac_label)" > /sys${DEVPATH}/macaddress
 		;;
 	snr,snr-cpe-me2-sfp)
 		hw_mac_addr="$(mtd_get_mac_binary factory 0x8004)"


### PR DESCRIPTION
The Config partition of some machines is special, and the openwrt script cannot read the protest_lan_mac correctly (like #9468). This problem can be solved by reading the mac address (ascii) in dts. Also add another alternative name for this machine.