### PR TITLE
mpc85xx: Fix output location of padded dtb

### DIFF
--- a/target/linux/mpc85xx/image/Makefile
+++ b/target/linux/mpc85xx/image/Makefile
@@ -5,8 +5,8 @@ include $(INCLUDE_DIR)/image.mk
 
 DEVICE_VARS += DTB_SIZE
 
-define Build/dtb
-	$(call Image/BuildDTB,$(DTS_DIR)/$(DEVICE_DTS).dts,$@.dtb,,--space $(DTB_SIZE))
+define Build/pad-dtb
+	$(call Image/BuildDTB,$(DTS_DIR)/$(DEVICE_DTS).dts,$(dir $@)/image-$(DEVICE_DTS).dtb,,--space $(DTB_SIZE))
 endef
 
 define Device/Default

--- a/target/linux/mpc85xx/image/p1020.mk
+++ b/target/linux/mpc85xx/image/p1020.mk
@@ -74,7 +74,7 @@ define Device/extreme-networks_ws-ap3825i
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
   BLOCKSIZE := 128k
   DTB_SIZE := 20480
-  KERNEL = kernel-bin | lzma | dtb | fit lzma $(KDIR)/image-$$(DEVICE_DTS).dtb
+  KERNEL = kernel-bin | lzma | pad-dtb | fit lzma $(KDIR)/image-$$(DEVICE_DTS).dtb
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
 endef


### PR DESCRIPTION
In commit 7e614820a892 ("mpc85xx: add support for Extreme Networks
WS-AP3825i"), we borrowed a recipe convention from apm821xx for device
tree blob padding. Unfortunately, in the apm821xx target, the image
recipes name the device tree blob differently, meaning that in
mpc85xx, the padded dtb is never consumed.

Change the definition of `Build/dtb` so that it outputs the padded dtb
to the correct location for it to be consumed.

Also, rename the recipe to `Build/pad-dtb`, so it is clear we
are building and padding the device tree blob.

This change fixes Github issue #9779 [1].

[1]: https://github.com/openwrt/openwrt/issues/9779

Fixes: 7e614820a892 ("mpc85xx: add support for Extreme Networks
WS-AP3825i")

Signed-off-by: Martin Kennedy <hurricos@gmail.com>