### PR TITLE
uboot-mvebu: remove enabled CONFIG_CMD_SETEXPR

### DIFF
--- a/package/boot/uboot-mvebu/Makefile
+++ b/package/boot/uboot-mvebu/Makefile
@@ -62,13 +62,6 @@ UBOOT_TARGETS:= \
 	espressobin \
 	uDPU
 
-define Build/Configure
-	# enable additional options beyond <device>_defconfig
-	echo CONFIG_CMD_SETEXPR=y >> $(PKG_BUILD_DIR)/configs/$(UBOOT_CONFIG)_defconfig
-
-	$(call Build/Configure/U-Boot)
-endef
-
 define Package/u-boot/install
 	$(if $(findstring cortexa53,$(BUILD_SUBTARGET)),,$(Package/u-boot/install/default))
 endef

--- a/package/boot/uboot-mvebu/patches/103-arm-mvebu-clearfog_defconfig-enable-setexpr-command.patch
+++ b/package/boot/uboot-mvebu/patches/103-arm-mvebu-clearfog_defconfig-enable-setexpr-command.patch
@@ -1,0 +1,36 @@
+From 40a67a9403deafdac05564b7350af49a71e12373 Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Fri, 29 Apr 2022 17:34:53 +0200
+Subject: [PATCH] arm: mvebu: clearfog_defconfig: enable setexpr command
+
+This command is useful in U-boot scripts and it is being used by
+OpenWrt bootscript for this board [1]. Otherwise shell scripting
+commands are enabled by default in cmd/Kconfig.
+
+[1] https://github.com/openwrt/openwrt/blob/852126680e21edc71c0c66561ae5a6d7479dcc67/target/linux/mvebu/image/clearfog.bootscript#L7
+
+[2] https://source.denx.de/u-boot/u-boot/-/blob/e95afa56753cebcd20a5114b6d121f281b789006/cmd/Kconfig#L1504
+
+Fixes: 0299c90f396c5b2971a4bac596339f4b03661c27 ("arm: mvebu: Add
+SolidRun ClearFog Armada 38x initial support")
+
+Signed-off-by: Josef Schlehofer <pepe.schlehofer@gmail.com>
+---
+ configs/clearfog_defconfig | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/configs/clearfog_defconfig b/configs/clearfog_defconfig
+index 880f16a6e0..1e9c389deb 100644
+--- a/configs/clearfog_defconfig
++++ b/configs/clearfog_defconfig
+@@ -34,7 +34,6 @@ CONFIG_CMD_MMC=y
+ CONFIG_CMD_PCI=y
+ CONFIG_CMD_SPI=y
+ CONFIG_CMD_USB=y
+-# CONFIG_CMD_SETEXPR is not set
+ CONFIG_CMD_TFTPPUT=y
+ CONFIG_CMD_CACHE=y
+ CONFIG_CMD_TIME=y
+-- 
+2.34.1
+


### PR DESCRIPTION
This U-boot option is already enabled for Turris Omnia in defconfig.
Other devices like Helios4 and Clearfog has this option as not set. If
it is used somehow, then it should be corrected in defconfigs for
related boards.

It is useful when passing initramfs end address.

It was introduced by this commit https://github.com/openwrt/openwrt/commit/0a3e07b2f5a5a8b20da173663007cb1f4b8f3eb8 (cc: @artox) , unfortunately, the commit itself is not explaining why it needs to be enabled for all boards and why it is necessary. 