### PR TITLE
[21.02] ipq40xx: fix ar40xx driver

### DIFF
--- a/target/linux/ipq40xx/files/drivers/net/phy/ar40xx.c
+++ b/target/linux/ipq40xx/files/drivers/net/phy/ar40xx.c
@@ -935,6 +935,7 @@ ar40xx_malibu_psgmii_ess_reset(struct ar40xx_priv *priv)
 		  */
 		mdelay(2);
 	}
+	mdelay(50);
 
 	/*check malibu psgmii calibration done end..*/
 
@@ -953,6 +954,7 @@ ar40xx_malibu_psgmii_ess_reset(struct ar40xx_priv *priv)
 		/* Polling interval to check PSGMII PLL in ESS is ready */
 		mdelay(2);
 	}
+	mdelay(50);
 
 	/* check dakota psgmii calibration done end..*/
 
@@ -960,6 +962,7 @@ ar40xx_malibu_psgmii_ess_reset(struct ar40xx_priv *priv)
 	mdiobus_write(bus, 5, 0x1a, 0x3230);
 	/* release phy psgmii RX 20bit */
 	mdiobus_write(bus, 5, 0x0, 0x005f);
+	mdelay(200);
 }
 
 static void


### PR DESCRIPTION
This commit is completely based on the work of adron-s:
https://github.com/openwrt/openwrt/pull/4721#issuecomment-1101108651

The commit fixes the data corruption on TX packets. Packets are
transmitted, but their contents are replaced with zeros. This error is
caused by the lack of guard (50 ms) intervals between calibration phases.
This error is treated by adding mdelay(50) to the calibration function
code. In the original qca-ssda code [0], these mdelays were existing, but
in the ar41xx.c they are gone.

Tested on:
- Fritz!Box 4040
- Fritz!Box 7530
- Mikrotik SXTsq 5AC
- ZyXEL NBG6617

- [0] https://git.codelinaro.org/clo/qsdk/oss/lklm/qca-ssdk/-/blob/NHSS.QSDK.11.4/src/init/ssdk_init.c#L2072

Suggested-by: Serhii Serhieiev <adron@mstnt.com>
Reviewed-by: Robert Marko <robimarko@gmail.com>
Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit ab7e53e5cce703c7a62efbe1d41fb94c2228a178)
