### PR TITLE
ramips: zbt-wg2626: Fix the LAN ports names

### DIFF
--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg2626.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg2626.dts
@@ -119,22 +119,22 @@
 	ports {
 		port@0 {
 			status = "okay";
-			label = "lan1";
+			label = "lan4";
 		};
 
 		port@1 {
 			status = "okay";
-			label = "lan2";
+			label = "lan3";
 		};
 
 		port@2 {
 			status = "okay";
-			label = "lan3";
+			label = "lan2";
 		};
 
 		port@3 {
 			status = "okay";
-			label = "lan4";
+			label = "lan1";
 		};
 
 		port@4 {


### PR DESCRIPTION
The current names don't match with the labels on the case, reverse
the LAN ports order so they match.

Signed-off-by: Alban Bedel <albeu@free.fr>