### PR TITLE
ramips: zbt-wg2626: Add the reset gpio for PCIe port 1

### DIFF
--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg2626.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg2626.dts
@@ -88,6 +88,9 @@
 
 &pcie {
 	status = "okay";
+
+	reset-gpios = <&gpio 19 GPIO_ACTIVE_LOW>,
+			<&gpio 8 GPIO_ACTIVE_LOW>;
 };
 
 &pcie0 {


### PR DESCRIPTION
The 2.4GHz interface doesn't come up properly with the log showing:

    mt7621-pci 1e140000.pcie: pcie1 no card, disable it (RST & CLK)

As seen on other MT7621 boards this is caused by a missing reset GPIO.
The MT7621 dtsi set GPIO 19 as PCIe reset GPIO, which on this board
reset the 5GHz interface on port 0. Add GPIO 8 to the PCIe reset GPIO
list to also reset the 2.4GHz interface on port 1.

Signed-off-by: Alban Bedel <albeu@free.fr>