### PR TITLE
ramips: add i2c in dts for GL-MT300N-V2

### DIFF
--- a/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
@@ -131,6 +131,10 @@
 	};
 };
 
+&i2c {
+	status = "okay";
+};
+
 &uart1 {
 	status = "okay";
 };


### PR DESCRIPTION
According GL-iNet [wiki](https://docs.gl-inet.com/en/2/hardware/mt300n-v2/) GL-MT300N-V2 have I2C interface on GPIO4, GPIO5. Adding I2C in device tree make possible using I2C on this device.

Signed-off-by: Ptilopsis Leucotis <PtilopsisLeucotis@yandex.com>