### PR TITLE
ramips: add led_source for Asus RT-AC1200 devices

### DIFF
--- a/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dtsi
+++ b/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dtsi
@@ -111,6 +111,7 @@
 
 &esw {
 	mediatek,portmap = <0x3e>;
+	mediatek,led_source = <4>;
 };
 
 &wmac {


### PR DESCRIPTION
this adds the mediatek,led_source dts binding for
Asus RT-AC1200 devices' dtsi, for correct switch LED
behavior.

The dts-binding is introduced in commit:
65dc9e0980255b15402c45b840f239b85be59b3d

Without this, we only have constantly very fast
blinking LEDs, which don't react on any traffic or
LAN events at all.

Signed-off-by: Tamas Balogh <tamasbalogh@hotmail.com>
