### PR TITLE
ipq40xx: 5.15: fix ar40xx driver

### DIFF
--- a/target/linux/ipq40xx/files-5.15/drivers/net/mdio/ar40xx.c
+++ b/target/linux/ipq40xx/files-5.15/drivers/net/mdio/ar40xx.c
@@ -936,6 +936,7 @@ ar40xx_malibu_psgmii_ess_reset(struct ar40xx_priv *priv)
 		  */
 		mdelay(2);
 	}
+	mdelay(50);
 
 	/*check malibu psgmii calibration done end..*/
 
@@ -954,6 +955,7 @@ ar40xx_malibu_psgmii_ess_reset(struct ar40xx_priv *priv)
 		/* Polling interval to check PSGMII PLL in ESS is ready */
 		mdelay(2);
 	}
+	mdelay(50);
 
 	/* check dakota psgmii calibration done end..*/
 
@@ -961,6 +963,7 @@ ar40xx_malibu_psgmii_ess_reset(struct ar40xx_priv *priv)
 	mdiobus_write(bus, 5, 0x1a, 0x3230);
 	/* release phy psgmii RX 20bit */
 	mdiobus_write(bus, 5, 0x0, 0x005f);
+	mdelay(200);
 }
 
 static void


### PR DESCRIPTION
Also apply commit ab7e53e5cce7 ("ipq40xx: 5.10: fix ar40xx driver") to
5.15 driver.

The commit fixes the data corruption on TX packets. Packets are
transmitted, but their contents are replaced with zeros. This error is
caused by the lack of guard (50 ms) intervals between calibration phases.
This error is treated by adding mdelay(50) to the calibration function
code. In the original qca-ssda code, these mdelays were existing, but in
the ar41xx.c they are gone.

Fixes: 87318eb17936 ("ipq40xx: 5:15: copy config and patch from 5.10")

