### PR TITLE
Remove state as match in iptables pkg description

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -75,7 +75,6 @@ IP firewall administration tool.
   - mark
   - multiport
   - set
-  - state
   - time
 
  Targets:


### PR DESCRIPTION
`conntrack` has obsoleted `state` per #6136 and is not available.  Package description should accurately reflect that.

Fixes #6136 
Fixes #6736

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
