### PR TITLE
base-files: fix sysupgrade for kernel-out-of-UBI

### DIFF
--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -305,7 +305,11 @@ nand_upgrade_tar() {
 	local ubi_kernel_length
 	if [ "$kernel_length" ]; then
 		if [ "$kernel_mtd" ]; then
-			mtd erase "$CI_KERNPART"
+			# On some devices, the raw kernel and ubi partitions overlap.
+			# These devices brick if the kernel partition is erased.
+			dd if=/dev/zero bs=512 count=1 2>/dev/null | \
+				mtd write - "$CI_KERNPART"
+			#mtd erase "$CI_KERNPART"
 		else
 			ubi_kernel_length="$kernel_length"
 		fi
@@ -322,7 +326,8 @@ nand_upgrade_tar() {
 	if [ "$kernel_length" ]; then
 		if [ "$kernel_mtd" ]; then
 			tar xf "$tar_file" "$board_dir/kernel" -O | \
-				mtd -n write - "$CI_KERNPART"
+				mtd write - "$CI_KERNPART"
+				#mtd -n write - "$CI_KERNPART"
 		else
 			local kern_ubivol="$( nand_find_volume $ubidev "$CI_KERNPART" )"
 			tar xf "$tar_file" "$board_dir/kernel" -O | \


### PR DESCRIPTION
Commit ecbcc0b59551 bricks devices on which the raw kernel and UBI mtd
partitions overlap.

This is the case of the ZyXEL NR7101 for example. Its OEM bootloader has
no UBI support. OpenWrt splits the stock kernel mtd partition into a raw
kernel part used by the bootloader and a UBI part used to store rootfs
and rootfs_data. Running mtd erase on the complete partition during
sysupgrade erases the UBI part and results in a soft brick.

Arguably the best solution would be to fix the partition layouts so that
kernel and UBI partitions do not overlap, also including a stock_kernel
partition to help reverting to stock firmware. This would have the added
benefit of protecting UBI from kernel images that are excessively large.

Reported by Bjørn Mork <bjorn@mork.no>