### PR TITLE
ath79: add support for MikroTik RouterBOARD hAP ac lite

### DIFF
--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-952ui-5ac2nd.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-952ui-5ac2nd.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9533_mikrotik_routerboard-95x.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-952ui-5ac2nd", "qca,qca9533";
+	model = "MikroTik RouterBOARD 952Ui-5ac2nD (hAP ac lite)";
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0 0 0 0 0>;
+	};
+};
+

--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-95x.dtsi
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-95x.dtsi
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9533_mikrotik_routerboard-16m.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_user;
+		led-failsafe = &led_user;
+		led-running = &led_user;
+		led-upgrade = &led_user;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_user: user {
+			label = "green:user";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		port1 {
+			label = "green:port1";
+			gpios = <&gpio_ext 0 GPIO_ACTIVE_LOW>;
+		};
+
+		port2 {
+			label = "green:port2";
+			gpios = <&gpio_ext 1 GPIO_ACTIVE_LOW>;
+		};
+
+		port3 {
+			label = "green:port3";
+			gpios = <&gpio_ext 2 GPIO_ACTIVE_LOW>;
+		};
+
+		port4 {
+			label = "green:port4";
+			gpios = <&gpio_ext 3 GPIO_ACTIVE_LOW>;
+		};
+
+		port5 {
+			label = "green:port5";
+			gpios = <&gpio_ext 4 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		usb_power {
+			gpio-export,name = "usb-power";
+			gpio-export,output = <1>;
+			gpios = <&gpio_ext 5 GPIO_ACTIVE_LOW>;
+		};
+
+		enable_poe_port5 {
+			gpio-export,name = "enable-poe:port5";
+			gpio-export,output = <0>;
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pin_spi_cs1>;
+
+	gpio_ext: gpio_ext@1 {
+		compatible = "fairchild,74hc595";
+		reg = <1>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		registers-number = <1>;
+		spi-max-frequency = <25000000>;
+	};
+};
+
+
+&pinmux {
+	pin_spi_cs1: pinmux_spi_cs1 {
+		pinctrl-single,bits = <0x8 0x0a000000 0xff000000>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -38,6 +38,16 @@ define Device/mikrotik_routerboard-922uags-5hpacd
 endef
 TARGET_DEVICES += mikrotik_routerboard-922uags-5hpacd
 
+define Device/mikrotik_routerboard-952ui-5ac2nd
+  $(Device/mikrotik_nor)
+  SOC := qca9533
+  DEVICE_MODEL := RouterBOARD 952Ui-5ac2nD (hAP ac lite)
+  DEVICE_PACKAGES += kmod-ath10k-ct-smallbuffers ath10k-firmware-qca9887-ct
+  IMAGE_SIZE := 16256k
+  SUPPORTED_DEVICES += rb-952ui-5ac2nd
+endef
+TARGET_DEVICES += mikrotik_routerboard-952ui-5ac2nd
+
 define Device/mikrotik_routerboard-962uigs-5hact2hnt
   $(Device/mikrotik_nor)
   SOC := qca9558

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
@@ -6,6 +6,13 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+mikrotik,routerboard-952ui-5ac2nd)
+	ucidef_set_led_netdev "port1" "port1" "green:port1" "eth1"
+	ucidef_set_led_switch "port2" "port2" "green:port2" "switch0" "0x10"
+	ucidef_set_led_switch "port3" "port3" "green:port3" "switch0" "0x08"
+	ucidef_set_led_switch "port4" "port4" "green:port4" "switch0" "0x04"
+	ucidef_set_led_switch "port5" "port5" "green:port5" "switch0" "0x02"
+	;;
 mikrotik,routerboard-lhg-2nd|\
 mikrotik,routerboard-mapl-2nd|\
 mikrotik,routerboard-wap-2nd)

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -24,6 +24,11 @@ ath79_setup_interfaces()
 	mikrotik,routerboard-wapr-2nd)
 		ucidef_set_interface_lan "eth0"
 		;;
+	mikrotik,routerboard-952ui-5ac2nd)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
+		;;
 	mikrotik,routerboard-962uigs-5hact2hnt)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:lan" "4:lan" "5:lan" "1:wan"

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -35,6 +35,9 @@ case "$FIRMWARE" in
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" 2)
 		;;
+	mikrotik,routerboard-952ui-5ac2nd)
+		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" 6)
+		;;
 	mikrotik,routerboard-962uigs-5hact2hnt)
 		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" 7)
 		;;

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -12,6 +12,7 @@ case "$FIRMWARE" in
 "ath10k/cal-pci-0000:00:00.0.bin")
 	case $board in
 	mikrotik,routerboard-921gs-5hpacd-15s|\
+	mikrotik,routerboard-952ui-5ac2nd|\
 	mikrotik,routerboard-962uigs-5hact2hnt|\
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		caldata_sysfsload_from_file $wlan_data 0x5000 0x844


### PR DESCRIPTION
The MikroTik RB952Ui-5ac2nD (sold as hAP ac lite) is an indoor 2.4Ghz
and 5GHz AP/router with a 2 dBi integrated antenna.

See https://mikrotik.com/product/RB952Ui-5ac2nD for more details.

Specifications:
 - SoC: QCA9533
 - RAM: 64MB
 - Storage: 16MB NOR
 - Wireless: QCA9531 802.11b/g/n 2x2 / QCA9887 802.11a/n/ac 2x2
 - Ethernet: AR934X switch, 5x 10/100 ports,
    10-28 V passive PoE in port 1, 500 mA PoE out on port 5
 - 6 user-controllable LEDs:
   - 1x user (green)
   - 5x port status (green)

This PR intends to replace #3348 which has a number of issues (wrong GPIOs, incorrect DTS, wrong makefile) and seems to be abandoned.

This PR preserves the original (ar71xx) naming conventions for LEDs, for smoother transition.

I have successfully tested this PR on my own hAP AC lite.