### PR TITLE
kernel: backports: add Huawei MA5671A tx-fault workaround

### DIFF
--- a/target/linux/generic/backport-5.10/890-v5.19-net-sfp-Add-tx-fault-workaround-for-Huawei-MA5671A-SFP-ON.patch
+++ b/target/linux/generic/backport-5.10/890-v5.19-net-sfp-Add-tx-fault-workaround-for-Huawei-MA5671A-SFP-ON.patch
@@ -1,0 +1,56 @@
+From f81d97cb646ab8b90fb181d66fccaf9589990de6 Mon Sep 17 00:00:00 2001
+From: Matthew Hagan <mnhagan88@gmail.com>
+Date: Sat, 30 Apr 2022 11:00:49 +0100
+Subject: [PATCH v2] net: sfp: Add tx-fault workaround for Huawei MA5671A SFP
+ ONT
+
+As noted elsewhere, various GPON SFP modules exhibit non-standard
+TX-fault behaviour. In the tested case, the Huawei MA5671A, when used
+in combination with a Marvell mv88e6085 switch, was found to
+persistently assert TX-fault, resulting in the module being disabled.
+
+This patch adds a quirk to ignore the SFP_F_TX_FAULT state, allowing the
+module to function.
+
+Change from v1: removal of erroneous return statment (Andrew Lunn)
+
+Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>
+---
+ drivers/net/phy/sfp.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -249,6 +249,7 @@ struct sfp {
+ 	struct sfp_eeprom_id id;
+ 	unsigned int module_power_mW;
+ 	unsigned int module_t_start_up;
++	bool tx_fault_ignore;
+ 
+ #if IS_ENABLED(CONFIG_HWMON)
+ 	struct sfp_diag diag;
+@@ -1893,6 +1894,12 @@ static int sfp_sm_mod_probe(struct sfp *
+ 	else
+ 		sfp->module_t_start_up = T_START_UP;
+ 
++	if (!memcmp(id.base.vendor_name, "HUAWEI          ", 16) &&
++	    !memcmp(id.base.vendor_pn, "MA5671A         ", 16))
++		sfp->tx_fault_ignore = true;
++	else
++		sfp->tx_fault_ignore = false;
++
+ 	return 0;
+ }
+ 
+@@ -2320,7 +2327,10 @@ static void sfp_check_state(struct sfp *
+ 	mutex_lock(&sfp->st_mutex);
+ 	state = sfp_get_state(sfp);
+ 	changed = state ^ sfp->state;
+-	changed &= SFP_F_PRESENT | SFP_F_LOS | SFP_F_TX_FAULT;
++	if (sfp->tx_fault_ignore)
++		changed &= SFP_F_PRESENT | SFP_F_LOS;
++	else
++		changed &= SFP_F_PRESENT | SFP_F_LOS | SFP_F_TX_FAULT;
+ 
+ 	for (i = 0; i < GPIO_MAX; i++)
+ 		if (changed & BIT(i))

--- a/target/linux/generic/backport-5.15/890-v5.19-net-sfp-Add-tx-fault-workaround-for-Huawei-MA5671A-SFP-ON.patch
+++ b/target/linux/generic/backport-5.15/890-v5.19-net-sfp-Add-tx-fault-workaround-for-Huawei-MA5671A-SFP-ON.patch
@@ -1,0 +1,56 @@
+From f81d97cb646ab8b90fb181d66fccaf9589990de6 Mon Sep 17 00:00:00 2001
+From: Matthew Hagan <mnhagan88@gmail.com>
+Date: Sat, 30 Apr 2022 11:00:49 +0100
+Subject: [PATCH v2] net: sfp: Add tx-fault workaround for Huawei MA5671A SFP
+ ONT
+
+As noted elsewhere, various GPON SFP modules exhibit non-standard
+TX-fault behaviour. In the tested case, the Huawei MA5671A, when used
+in combination with a Marvell mv88e6085 switch, was found to
+persistently assert TX-fault, resulting in the module being disabled.
+
+This patch adds a quirk to ignore the SFP_F_TX_FAULT state, allowing the
+module to function.
+
+Change from v1: removal of erroneous return statment (Andrew Lunn)
+
+Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>
+---
+ drivers/net/phy/sfp.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -250,6 +250,7 @@ struct sfp {
+ 	struct sfp_eeprom_id id;
+ 	unsigned int module_power_mW;
+ 	unsigned int module_t_start_up;
++	bool tx_fault_ignore;
+ 
+ #if IS_ENABLED(CONFIG_HWMON)
+ 	struct sfp_diag diag;
+@@ -1945,6 +1946,12 @@ static int sfp_sm_mod_probe(struct sfp *
+ 	else
+ 		sfp->module_t_start_up = T_START_UP;
+ 
++	if (!memcmp(id.base.vendor_name, "HUAWEI          ", 16) &&
++	    !memcmp(id.base.vendor_pn, "MA5671A         ", 16))
++		sfp->tx_fault_ignore = true;
++	else
++		sfp->tx_fault_ignore = false;
++
+ 	return 0;
+ }
+ 
+@@ -2397,7 +2404,10 @@ static void sfp_check_state(struct sfp *
+ 	mutex_lock(&sfp->st_mutex);
+ 	state = sfp_get_state(sfp);
+ 	changed = state ^ sfp->state;
+-	changed &= SFP_F_PRESENT | SFP_F_LOS | SFP_F_TX_FAULT;
++	if (sfp->tx_fault_ignore)
++		changed &= SFP_F_PRESENT | SFP_F_LOS;
++	else
++		changed &= SFP_F_PRESENT | SFP_F_LOS | SFP_F_TX_FAULT;
+ 
+ 	for (i = 0; i < GPIO_MAX; i++)
+ 		if (changed & BIT(i))


### PR DESCRIPTION
This workaround will allow the MA5671A to function, ignoring the
persistently asserted tx-fault.

Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>