### PR TITLE
rockchip: add support for NanoPi M4 2GB

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -48,6 +48,16 @@ define U-Boot/nanopi-r4s-rk3399
   ATF:=rk3399_bl31.elf
 endef
 
+define U-Boot/nanopi-m4-2gb-rk3399
+  BUILD_SUBTARGET:=armv8
+  NAME:=NanoPi M4 2GB
+  BUILD_DEVICES:= \
+    friendlyarm_nanopi-m4-2gb
+  DEPENDS:=+PACKAGE_u-boot-nanopi-m4-2gb-rk3399:arm-trusted-firmware-rockchip
+  PKG_BUILD_DEPENDS:=arm-trusted-firmware-rockchip
+  ATF:=rk3399_bl31.elf
+endef
+
 define U-Boot/rock-pi-4-rk3399
   BUILD_SUBTARGET:=armv8
   NAME:=Rock Pi 4
@@ -70,6 +80,7 @@ endef
 
 UBOOT_TARGETS := \
   nanopi-r4s-rk3399 \
+  nanopi-m4-2gb-rk3399 \
   rock-pi-4-rk3399 \
   rockpro64-rk3399 \
   nanopi-r2s-rk3328

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -23,6 +23,16 @@ define Device/friendlyarm_nanopi-r4s
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r4s
 
+define Device/friendlyarm_nanopi-m4-2gb
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPi M4
+  DEVICE_VARIANT := 2GB DDR3
+  SOC := rk3399
+  UBOOT_DEVICE_NAME := nanopi-m4-2gb-rk3399
+  IMAGE/sysupgrade.img.gz := boot-common | boot-script nanopi-r4s | pine64-img | gzip | append-metadata
+endef
+TARGET_DEVICES += friendlyarm_nanopi-m4
+
 define Device/pine64_rockpro64
   DEVICE_VENDOR := Pine64
   DEVICE_MODEL := RockPro64


### PR DESCRIPTION
Hardware
--------
RockChip RK3399 ARM64 (6 cores)
2GB DDR3 RAM
1x 1000 Base-T
1 LED (SYS)
1 Button (Soft Power, optional)
1 PCI-E 2.0 x2 Interface
Micro-SD slot
4x USB 3.0 Port

Installation
------------
Decompress sysupgrade image and flash to micro SD card using dd or other
 similar image flashing tools (Etcher, Rufus, Win32DiskImager etc).

Current Support Limitations
---------------------------
Support for WiFi, Bluetooth, USB devices, AV output and soft reboot are
currently untested and likely not present.

Signed-off-by: Matt Forrest <matt.three@outlook.com>