### PR TITLE
bcm27xx: add USB boot support to Raspberry Pi's

### DIFF
--- a/target/linux/bcm27xx/base-files/lib/preinit/79_move_config
+++ b/target/linux/bcm27xx/base-files/lib/preinit/79_move_config
@@ -2,16 +2,16 @@
 
 . /lib/upgrade/common.sh
 
-BOOTPART=/dev/mmcblk0p1
-
 move_config() {
-	if [ -b $BOOTPART ]; then
+	local partdev
+
+	if export_bootdevice && export_partdevice partdev 1; then
 		insmod nls_cp437
 		insmod nls_iso8859-1
 		insmod fat
 		insmod vfat
 		mkdir -p /boot
-		mount -t vfat -o rw,noatime $BOOTPART /boot
+		mount -t vfat -o rw,noatime "/dev/$partdev" /boot
 		[ -f "/boot/$BACKUP_FILE" ] && mv -f "/boot/$BACKUP_FILE" /
 	fi
 }

--- a/target/linux/bcm27xx/image/cmdline.txt
+++ b/target/linux/bcm27xx/image/cmdline.txt
@@ -1,1 +1,1 @@
-console=serial0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=squashfs,ext4 rootwait
+console=serial0,115200 console=tty1 root=PARTUUID=5452574f-02 rootfstype=squashfs,ext4 rootwait


### PR DESCRIPTION
This PR aims to add USB boot support to Raspberry Pi.

I have had success with USB booting a Raspberry Pi 4 Model B into OpenWrt, however this may need to serve as a discussion as I'm sure that there might be more to OpenWrt supporting USB booting on a Pi, than simply changing /dev/mmcblk0p2 to the PARTUUID=5452574f-02 in /boot/cmdline.txt 

I can see that there are is a reference to `/dev/mmcblk0p1` in [79_move_config](https://github.com/openwrt/openwrt/blob/master/target/linux/bcm27xx/base-files/lib/preinit/79_move_config#L5) which might be able to be changed to `5452574f-01`? but feel free to chime in as I'm not that familar with OpenWrt.

Thanks.

Signed-off-by: Michael Rook <michael@rook.net.au>