### PR TITLE
rework ipcalc.sh and avoid faulty range calculations

### DIFF
--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -10,14 +10,20 @@ function bitcount(c) {
 }
 
 function ip2int(ip) {
-	for (ret=0,n=split(ip,a,"\."),x=1;x<=n;x++) ret=or(lshift(ret,8),a[x])
+	ret=0
+	n=split(ip,a,"\.")
+	for (x=1;x<=n;x++)
+		ret=or(lshift(ret,8),a[x])
 	return ret
 }
 
 function int2ip(ip,ret,x) {
 	ret=and(ip,255)
 	ip=rshift(ip,8)
-	for(;x<3;ret=and(ip,255)"."ret,ip=rshift(ip,8),x++);
+	for(;x<3;x++) {
+		ret=and(ip,255)"."ret
+		ip=rshift(ip,8)
+	}
 	return ret
 }
 

--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -61,10 +61,17 @@ BEGIN {
 	start=or(network,and(ip2int(ARGV[3]),compl32(netmask)))
 	limit=network+1
 	if (start<limit) start=limit
+	if (start==ipaddr) start=ipaddr+1
 
 	end=start+ARGV[4]
 	limit=or(network,compl32(netmask))-1
 	if (end>limit) end=limit
+	if (end==ipaddr) end=ipaddr-1
+
+	if (ipaddr > start && ipaddr < end) {
+		print "ipaddr inside range" > "/dev/stderr"
+		exit(1)
+	}
 
 	print "START="int2ip(start)
 	print "END="int2ip(end)

--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -11,7 +11,7 @@ function bitcount(c) {
 
 function ip2int(ip) {
 	ret=0
-	n=split(ip,a,"\.")
+	n=split(ip,a,"\\.")
 	for (x=1;x<=n;x++)
 		ret=or(lshift(ret,8),a[x])
 	return ret

--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -44,13 +44,14 @@ BEGIN {
 	}
 
 	network=and(ipaddr,netmask)
+	prefix=32-bitcount(compl32(netmask))
 	broadcast=or(network,compl32(netmask))
 
 	print "IP="int2ip(ipaddr)
 	print "NETMASK="int2ip(netmask)
 	print "BROADCAST="int2ip(broadcast)
 	print "NETWORK="int2ip(network)
-	print "PREFIX="32-bitcount(compl32(netmask))
+	print "PREFIX="prefix
 
 	# range calculations:
 	# ipcalc <ip> <netmask> <start> <num>
@@ -67,6 +68,11 @@ BEGIN {
 	limit=or(network,compl32(netmask))-1
 	if (end>limit) end=limit
 	if (end==ipaddr) end=ipaddr-1
+
+	if (start>end) {
+		print "network ("int2ip(network)"/"prefix") too small" > "/dev/stderr"
+		exit(1)
+	}
 
 	if (ipaddr > start && ipaddr < end) {
 		print "ipaddr inside range" > "/dev/stderr"

--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -46,14 +46,6 @@ BEGIN {
 	network=and(ipaddr,netmask)
 	broadcast=or(network,compl32(netmask))
 
-	start=or(network,and(ip2int(ARGV[3]),compl32(netmask)))
-	limit=network+1
-	if (start<limit) start=limit
-
-	end=start+ARGV[4]
-	limit=or(network,compl32(netmask))-1
-	if (end>limit) end=limit
-
 	print "IP="int2ip(ipaddr)
 	print "NETMASK="int2ip(netmask)
 	print "BROADCAST="int2ip(broadcast)
@@ -63,9 +55,18 @@ BEGIN {
 	# range calculations:
 	# ipcalc <ip> <netmask> <start> <num>
 
-	if (ARGC > 3) {
-		print "START="int2ip(start)
-		print "END="int2ip(end)
-	}
+	if (ARGC <= 3)
+		exit(0)
+
+	start=or(network,and(ip2int(ARGV[3]),compl32(netmask)))
+	limit=network+1
+	if (start<limit) start=limit
+
+	end=start+ARGV[4]
+	limit=or(network,compl32(netmask))-1
+	if (end>limit) end=limit
+
+	print "START="int2ip(start)
+	print "END="int2ip(end)
 }
 EOF

--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -1,6 +1,5 @@
-#!/bin/sh
+#!/usr/bin/awk -f
 
-awk -f - $* <<EOF
 function bitcount(c) {
 	c=and(rshift(c, 1),0x55555555)+and(c,0x55555555)
 	c=and(rshift(c, 2),0x33333333)+and(c,0x33333333)
@@ -82,4 +81,3 @@ BEGIN {
 	print "START="int2ip(start)
 	print "END="int2ip(end)
 }
-EOF

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -584,18 +584,17 @@ dhcp_add() {
 		limit=$((limit-1))
 	fi
 
-	eval "$(ipcalc.sh "${subnet%%/*}" $netmask $start $limit)"
+	# make sure the DHCP range is not empty
+	if [ "$dhcpv4" != "disabled" ] && eval "$(ipcalc.sh "${subnet%%/*}" "$netmask" "$start" "$limit")" ; then
+		[ "$dynamicdhcp" = "0" ] && END="static"
+
+		xappend "--dhcp-range=$tags$nettag$START,$END,$NETMASK,$leasetime${options:+ $options}"
+	fi
 
 	if [ "$dynamicdhcp" = "0" ] ; then
-		END="static"
 		dhcp6range="::,static"
 	else
 		dhcp6range="::1000,::ffff"
-	fi
-
-
-	if [ "$dhcpv4" != "disabled" ] ; then
-		xappend "--dhcp-range=$tags$nettag$START,$END,$NETMASK,$leasetime${options:+ $options}"
 	fi
 
 


### PR DESCRIPTION
`ipcalc.sh` doesn't work well with very small networks.
This PR also aims to improve the automatic correction of the range.
If no correction is possible, it returns with an error status code.

And, move the invokation of awk to the shebang.
This means passing arguments behaves differently (like with `$*` -> `"$@"`).
I would like to rename the script to `ipcalc` because, even without this PR, it hardly deserves being called a "shell" script.
That would break packages using it, though (I see only dnsmasq and isc-dhcp from the `packages` feed EDIT: + netifd and 6rd. they don't use the range calculation. @zhanhb pointed them out).

<details><summary>Examples of errors prior to this PR (click)</summary>

```
$ subnet=192.168.0.250/32; start=2; limit=500
$ ipcalc.sh "${subnet%%/*}" "${subnet##*/}" $start $limit
IP=192.168.0.2
NETMASK=255.255.255.255
# no broadcast in /32 - not fixed
BROADCAST=192.168.0.250
NETWORK=192.168.0.250
PREFIX=32
# doesn't make sense to calculate start and end for a /32
# these two are outside of the range:
START=192.168.0.251
END=192.168.0.249
```

```
$ subnet=192.168.0.2/30; start=2; limit=50
$ ipcalc.sh "${subnet%%/*}" "${subnet##*/}" $start $limit
IP=192.168.0.2
NETMASK=255.255.255.252
BROADCAST=192.168.0.3
NETWORK=192.168.0.0
PREFIX=30
# don't allow start or end to be equal to ipaddr
START=192.168.0.2
END=192.168.0.2
# 192.168.0.1 would be the only other available address
# not doing anything about that
```

```
$ subnet=192.168.0.2/31; start=2; limit=50
$ ipcalc.sh "${subnet%%/*}" "${subnet##*/}" $start $limit
IP=192.168.0.2
NETMASK=255.255.255.254
# there are no network broadcast addresses (/31 networks are point-to-point)
# this PR doesn't fix this
BROADCAST=192.168.0.3
NETWORK=192.168.0.2
PREFIX=31
START=192.168.0.3
END=192.168.0.2
```

</details>