### PR TITLE
lldpd: always depend on libbsd

### DIFF
--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lldpd
 PKG_VERSION:=1.0.13
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://media.luffy.cx/files/lldpd
@@ -30,7 +30,7 @@ define Package/lldpd
   SUBMENU:=Routing and Redirection
   TITLE:=Link Layer Discovery Protocol daemon
   URL:=https://vincentbernat.github.io/lldpd/
-  DEPENDS:=+libcap +libevent2 +USE_GLIBC:libbsd +LLDPD_WITH_JSON:libjson-c +LLDPD_WITH_SNMP:libnetsnmp
+  DEPENDS:=+libcap +libevent2 +libbsd +LLDPD_WITH_JSON:libjson-c +LLDPD_WITH_SNMP:libnetsnmp
   USERID:=lldp=121:lldp=129
   MENU:=1
 endef
@@ -107,8 +107,7 @@ CONFIGURE_ARGS += \
 	$(if $(CONFIG_LLDPD_WITH_CUSTOM),,--disable-custom) \
 	$(if $(CONFIG_LLDPD_WITH_SONMP),,--disable-sonmp) \
 	$(if $(CONFIG_LLDPD_WITH_JSON),--enable-json0,) \
-	$(if $(CONFIG_LLDPD_WITH_SNMP),--with-snmp,) \
-	$(if $(CONFIG_USE_GLIBC),,--without-libbsd)
+	$(if $(CONFIG_LLDPD_WITH_SNMP),--with-snmp,)
 
 TARGET_CFLAGS += -flto
 TARGET_LDFLAGS += -flto -Wl,--gc-sections,--as-needed


### PR DESCRIPTION
lldpd calls setproctitle() and strtonum(); its configure.ac script has fallbacks for when they're not found, but they should come from libbsd instead.

Signed-off-by: Guilherme Janczak <guilherme.janczak@yandex.com>

Build tested: x64 glibc toolchain I built from commit f757a8a09885e3c8bb76371e037b8c0731111980, openwrt-sdk-22.03.0-rc1-x86-64_gcc-11.2.0_musl.Linux-x86_64

Edit: mentioning I found this while working on https://github.com/openwrt/openwrt/pull/9714