### PR TITLE
ipq40xx: revert Cell-C RTL30VW to legacy caldata extraction

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -76,6 +76,7 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C800 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1") || \
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3D000 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
+	cellc,rtl30vw |\
 	openmesh,a42 |\
 	openmesh,a62 |\
 	plasmacloud,pa1200 |\
@@ -155,6 +156,7 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3D000 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1") || \
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C000 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
+	cellc,rtl30vw |\
 	openmesh,a42 |\
 	openmesh,a62 |\
 	plasmacloud,pa1200 |\

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rtl30vw.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rtl30vw.dts
@@ -267,17 +267,6 @@
 				label = "0:ART";
 				reg = <0x170000 0x10000>;
 				read-only;
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				precal_art_1000: precal@1000 {
-					reg = <0x1000 0x2f20>;
-				};
-
-				precal_art_5000: precal@5000 {
-					reg = <0x5000 0x2f20>;
-				};
 			};
 
 			partition@180000 {
@@ -387,14 +376,10 @@
 
 &wifi0 {
 	status = "okay";
-	nvmem-cell-names = "pre-calibration";
-	nvmem-cells = <&precal_art_1000>;
 	qcom,ath10k-calibration-variant = "cellc,rtl30vw";
 };
 
 &wifi1 {
 	status = "okay";
-	nvmem-cell-names = "pre-calibration";
-	nvmem-cells = <&precal_art_5000>;
 	qcom,ath10k-calibration-variant = "cellc,rtl30vw";
 };


### PR DESCRIPTION
This partially reverts commit cfc13c44595d ("ipq40xx: utilize nvmem-cells for macs & (pre-)calibration data").

After switching to nvmem RTL30VW, wifi was broken:

```
[   19.118319] ath10k_ahb a000000.wifi: qca4019 hw1.0 target 0x01000000 chip_id 0x003b00ff sub 0000:0000
[   19.118377] ath10k_ahb a000000.wifi: kconfig debug 0 debugfs 1 tracing 0 dfs 1 testmode 0
[   19.130285] ath10k_ahb a000000.wifi: firmware ver 10.4b-ct-4019-fW-13-5ae337bb1 api 5 features mfp,peer-flow-ctrl,txstatus-noack,wmi-10.x-CT,ratemask-CT,regdump-CT,txrate-CT,flush-all-CT,pingpong-CT,ch-regs-CT,nop-CT,set-special-CT,tx-rc-CT,cust-stats-CT,txrate2-CT,beacon-cb-CT,wmi-block-ack-CT,wmi-bcn-rc-CT crc32 6b2b5c5b
[   19.159092] ath10k_ahb a000000.wifi: failed to fetch board data for bus=ahb,vendor=0000,device=0000,subsystem-vendor=0000,subsystem-device=0000,variant=cellc,rtl30vw from ath10k/QCA4019/hw1.0/board-2.bin
[   19.238764] ath10k_ahb a000000.wifi: failed to fetch board-2.bin or board.bin from ath10k/QCA4019/hw1.0
[   19.238847] ath10k_ahb a000000.wifi: failed to fetch board file: -12
[   19.247362] ath10k_ahb a000000.wifi: could not probe fw (-12)
[   20.190797] ath10k_ahb a800000.wifi: qca4019 hw1.0 target 0x01000000 chip_id 0x003b00ff sub 0000:0000
[   20.190853] ath10k_ahb a800000.wifi: kconfig debug 0 debugfs 1 tracing 0 dfs 1 testmode 0
[   20.202893] ath10k_ahb a800000.wifi: firmware ver 10.4b-ct-4019-fW-13-5ae337bb1 api 5 features mfp,peer-flow-ctrl,txstatus-noack,wmi-10.x-CT,ratemask-CT,regdump-CT,txrate-CT,flush-all-CT,pingpong-CT,ch-regs-CT,nop-CT,set-special-CT,tx-rc-CT,cust-stats-CT,txrate2-CT,beacon-cb-CT,wmi-block-ack-CT,wmi-bcn-rc-CT crc32 6b2b5c5b
[   20.231357] ath10k_ahb a800000.wifi: failed to fetch board data for bus=ahb,vendor=0000,device=0000,subsystem-vendor=0000,subsystem-device=0000,variant=cellc,rtl30vw from ath10k/QCA4019/hw1.0/board-2.bin
[   20.317318] ath10k_ahb a800000.wifi: failed to fetch board-2.bin or board.bin from ath10k/QCA4019/hw1.0
[   20.317399] ath10k_ahb a800000.wifi: failed to fetch board file: -12
[   20.326098] ath10k_ahb a800000.wifi: could not probe fw (-12)
```

Bootloader mangles in NOR partitions aned removes precal@X nodes in
working system:

````
root@OpenWrt:~# echo $(cat /sys/firmware/devicetree/base/soc/spi@78b5000/flash@0/partitions/partition@170000/label)
0:ART
root@OpenWrt:~# ls /sys/firmware/devicetree/base/soc/spi@78b5000/flash@0/partitions/partition@170000/
label  name   reg
````

Revert to legacy method fixed problem.

Fixes: cfc13c44595d ("ipq40xx: utilize nvmem-cells for macs & (pre-)calibration data")

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
