### PR TITLE
ath79: fix I2C on GL-AR300M devices

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar300m.dtsi
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar300m.dtsi
@@ -72,6 +72,9 @@
 	i2c: i2c {
 		compatible = "i2c-gpio";
 
+		pinctrl-names = "default";
+		pinctrl-0 = <&enable_gpio17>;
+
 		sda-gpios = <&gpio 17 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
 		scl-gpios = <&gpio 16 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
 	};
@@ -179,5 +182,11 @@
 
 	macaddr_art_0: macaddr@0 {
 		reg = <0x0 0x6>;
+	};
+};
+
+&pinmux {
+	enable_gpio17: pinmux_enable_gpio17 {
+		pinctrl-single,bits = <0x10 0x0000 0xff00>;
 	};
 };


### PR DESCRIPTION
On 'GL-AR300M' Series `GPIO17` described as I2C SDA in Device Tree. Because of `GPIO_OUT_FUNCTION4` register was not initialized on start, `GPIO17` was uncontrollable, it always in high state. According to 'QCA9531' documentation, default setting of `GPIO17` is `SYS_RST_L`. In order to make `GPIO17` controllable, it should write value `0x00` on bits `[15:8]` of `GPIO_OUT_FUNCTION4` register, located at `0x1804003C` address.

Signed-off-by: Ptilopsis Leucotis <PtilopsisLeucotis@yandex.com>