### PR TITLE
openssl: bump to 1.1.1o

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.1.1
-PKG_BUGFIX:=n
+PKG_BUGFIX:=o
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_USE_MIPS16:=0
@@ -25,7 +25,7 @@ PKG_SOURCE_URL:= \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/old/$(PKG_BASE)/
 
-PKG_HASH:=40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a
+PKG_HASH:=9384a2b0570dd80358841464677115df785edb941c71211f75076d72fe6b438f
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
This is a bugfix release. Changelog:

  *) Fixed a bug in the c_rehash script which was not properly
     sanitising shell metacharacters to prevent command injection.
     This script is distributed by some operating systems in a manner
      where it is automatically executed. On such operating systems,
      an attacker could execute arbitrary commands
      with the privileges of the script.

      Use of the c_rehash script is considered obsolete and should be
      replaced by the OpenSSL rehash command line tool. (CVE-2022-1292)

Signed-off-by: QinGuang <topeqin@gmail.com>