### PR TITLE
ath79: add support for ASUS RP-AC51

### DIFF
--- a/target/linux/ath79/dts/qca9531_asus_rp-ac51.dts
+++ b/target/linux/ath79/dts/qca9531_asus_rp-ac51.dts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "ASUS RP-AC51";
+	compatible = "asus,rp-ac51", "qca,qca9531";
+
+	aliases {
+		led-boot = &led_wps;
+		led-failsafe = &led_wps;
+		led-running = &led_wps;
+		led-upgrade = &led_wps;
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "blue:power";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_wps: wps {
+			label = "red:wps";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan {
+			label = "blue:lan";
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x10000>;
+				read-only;
+			};
+
+			art: partition@50000 {
+				label = "art";
+				reg = <0x050000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_art_0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_art_1002: macaddr@1002 {
+					reg = <0x1002 0x6>;
+				};
+			};
+
+			partition@60000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x060000 0xfa0000>;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth1 {
+	nvmem-cells = <&macaddr_art_1002>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -56,6 +56,11 @@ alfa-network,tube-2hq)
 	ucidef_set_led_rssi "signal3" "SIGNAL3" "green:signal3" "wlan0" "50" "100"
 	ucidef_set_led_rssi "signal4" "SIGNAL4" "green:signal4" "wlan0" "75" "100"
 	;;
+asus,rp-ac51)
+	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0"
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan2G" "wlan1" "link"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan5G" "wlan0" "link"
+	;;
 asus,rp-ac66)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_rssimon "wlan1" "200000" "1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -19,6 +19,7 @@ ath79_setup_interfaces()
 	araknis,an-700-ap-i-ac|\
 	arduino,yun|\
 	aruba,ap-105|\
+	asus,rp-ac51|\
 	asus,rp-ac66|\
 	avm,fritz1750e|\
 	avm,fritz300e|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -12,6 +12,7 @@ case "$FIRMWARE" in
 	8dev,lima)
 		caldata_extract "art" 0x1000 0x800
 		;;
+	asus,rp-ac51|\
 	asus,rp-ac66)
 		caldata_extract "art" 0x1000 0x440
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -174,6 +174,13 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0000:00:00.0.bin")
 	case $board in
+	asus,rp-ac51|\
+	yuncore,a782|\
+	yuncore,xd4200)
+		caldata_extract "art" 0x5000 0x2f20
+		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
+			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+		;;
 	comfast,cf-e313ac)
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(mtd_get_mac_binary art 0x6)
@@ -246,12 +253,6 @@ case "$FIRMWARE" in
 	tplink,deco-m4r-v1)
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary config 0x8) -1)
-		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
-			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
-		;;
-	yuncore,a782|\
-	yuncore,xd4200)
-		caldata_extract "art" 0x5000 0x2f20
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -376,6 +376,17 @@ define Device/aruba_ap-105
 endef
 TARGET_DEVICES += aruba_ap-105
 
+define Device/asus_rp-ac51
+  SOC := qca9531
+  DEVICE_VENDOR := ASUS
+  DEVICE_MODEL := RP-AC51
+  IMAGE_SIZE := 16000k
+  IMAGES += factory.bin
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct \
+	-swconfig
+endef
+TARGET_DEVICES += asus_rp-ac51
+
 define Device/asus_rp-ac66
   SOC := qca9563
   DEVICE_VENDOR := ASUS


### PR DESCRIPTION
Asus RP-AC51 Repeater
Category:
AC750 300+433 (OEM w. unstable driver)
AC1200 300+866 (OpenWrt w. stable driver)

Hardware specifications:
Board: AP147
SoC: QCA9531 2.4G b/g/n
WiFi: QCA9886 5G n/ac
DRAM: 128MB DDR2
Flash: gd25q128 16MB SPI-NOR
LAN/WAN: AR8229 1x100M
Clocks: CPU:650MHz, DDR:600MHz, AHB:200MHz

MAC addresses as verified by OEM firmware:
use            address      source
Lan/W2G        *:C8         art 0x1002 (label)
5G             *:CC         art 0x5006

Installation:

Asus windows recovery tool:
 - install the Asus firmware restoration utility
 - unplug the router, hold the reset button while powering it on
 - release when the power LED flashes slowly
 - specify a static IP on your computer:
     IP address: 192.168.1.75
     Subnet mask 255.255.255.0
 - Start the Asus firmware restoration utility, specify the factory image
    and press upload
 - Do not power off the device after OpenWrt has booted until the LED flashing.

TFTP Recovery method:
 - set computer to a static ip, 192.168.1.10
 - connect computer to the LAN 1 port of the router
 - hold the reset button while powering on the router for a few seconds
 - send firmware image using a tftp client; i.e from linux:
 $ tftp
 tftp> binary
 tftp> connect 192.168.1.1
 tftp> put factory.bin
 tftp> quit

Signed-off-by: Tamas Balogh <tamasbalogh@hotmail.com>
