### PR TITLE
ath79: ZTE MF286[A,R]: add "Power button blocker" GPIO switch

### DIFF
--- a/target/linux/ath79/nand/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/nand/base-files/etc/board.d/03_gpio_switches
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2022 OpenWrt.org
+#
+
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+board=$(board_name)
+
+case "$board" in
+zte,mf286a|\
+zte,mf286r)
+	ucidef_add_gpio_switch "power_btn_block" "Power button blocker" "20" "0"
+	;;
+esac
+
+board_config_flush
+
+exit 0


### PR DESCRIPTION
ZTE MF286A and MF286R feature a "power switch override" GPIO in stock
firmware as means to prevent power interruption during firmware update,
especially when used with internal battery.
To ensure that this GPIO is
properly driven as in stock firmware, configure it with userspace GPIO
switch.

It was observed that on some units, the modem would not be
restarted together with the board itself on reboot, this should help
with that as well.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>