### PR TITLE
realtek: add support for NEXT 7255GH switch

### DIFF
--- a/target/linux/realtek/dts-5.15/rtl9303_next_7255gh.dts
+++ b/target/linux/realtek/dts-5.15/rtl9303_next_7255gh.dts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "next,7255gh", "realtek,rtl838x-soc";
+	model = "NEXT 7255GH Switch";
+
+	led_set: led_set@0 {
+		compatible = "realtek,rtl9300-leds";
+		led_set0 = <0x0000 0xffff 0x0aa0 0x0a08>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0xe0000>;
+				read-only;
+			};
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0xe0000 0x10000>;
+			};
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0xf0000 0x10000>;
+				read-only;
+			};
+			partition@100000 {
+				label = "jffs";
+				reg = <0x100000 0x100000>;
+			};
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x200000 0x100000>;
+			};
+			partition@300000 {
+				label = "firmware";
+				reg = <0x300000 0xd00000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy1: ethernet-phy@1 {
+			reg = <1>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <0 1>;
+			sds = <2>;
+		};
+		phy2: ethernet-phy@2 {
+			reg = <2>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <0 2>;
+			sds = <3>;
+		};
+		phy3: ethernet-phy@3 {
+			reg = <3>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <0 3>;
+			sds = <4>;
+		};
+		phy4: ethernet-phy@4 {
+			reg = <4>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <0 4>;
+			sds = <5>;
+		};
+		phy5: ethernet-phy@5 {
+			reg = <5>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <0 5>;
+			sds = <6>;
+		};
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+			phy-handle = <&phy1>;
+			phy-mode = "hsgmii";
+			led-set = <0>;
+		};
+		port@8 {
+			reg = <8>;
+			label = "lan2";
+			phy-handle = <&phy2>;
+			phy-mode = "hsgmii";
+			led-set = <0>;
+		};
+		port@16 {
+			reg = <16>;
+			label = "lan3";
+			phy-handle = <&phy3>;
+			phy-mode = "hsgmii";
+			led-set = <0>;
+		};
+		port@20 {
+			reg = <20>;
+			label = "lan4";
+			phy-handle = <&phy4>;
+			phy-mode = "hsgmii";
+			led-set = <0>;
+		};
+		port@24 {
+			reg = <24>;
+			label = "lan5";
+			phy-handle = <&phy5>;
+			phy-mode = "hsgmii";
+			led-set = <0>;
+		};
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -15,3 +15,13 @@ define Device/zyxel_xgs1250-12
 	uImage gzip
 endef
 TARGET_DEVICES += zyxel_xgs1250-12
+
+define Device/next_7255gh
+  SOC := rtl9303
+  DEVICE_VENDOR := NEXT
+  DEVICE_MODEL := 7255GH
+    IMAGE_SIZE := 13312k
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | gzip | uImage gzip
+endef
+
+TARGET_DEVICES += next_7255gh


### PR DESCRIPTION
NEXT 7255GH is unmanaged 5 port 2.5GbE switch.

Hardware:
- SoC: Realtek RTL9303 SoC
- RAM: DDR3 128MB
- Flash: Macronix MX25L12835F (SPI-NOR 16MB)
- Ethernet: RTL8226 5x 2.5GbE PHY
- UART: [GND, RX, TX, 3.3V] (115200)

Known issues:
- Packet loss on MTU over 1472
- DHCP client not working
- No MAC address
- No recovery methods except UART console
- Switch malfunction. Device network works but switching is not working for unknown reason.

Note:
- Rev. A2 only. Rev.B has RTL8371 and no memory.