### PR TITLE
ath79: allow use GPIO17 as regular gpio on GL-AR300M devices

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar300m.dtsi
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar300m.dtsi
@@ -72,9 +72,6 @@
 	i2c: i2c {
 		compatible = "i2c-gpio";
 
-		pinctrl-names = "default";
-		pinctrl-0 = <&enable_gpio17>;
-
 		sda-gpios = <&gpio 17 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
 		scl-gpios = <&gpio 16 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
 	};
@@ -186,6 +183,9 @@
 };
 
 &pinmux {
+	pinctrl-names = "default";
+	pinctrl-0 = <&enable_gpio17>;
+
 	enable_gpio17: pinmux_enable_gpio17 {
 		pinctrl-single,bits = <0x10 0x0000 0xff00>;
 	};


### PR DESCRIPTION
Small update to my previous path 'fix I2C on GL-AR300M devices'. This update allow using `GPIO17` as regular GPIO in case it not used as I2C SDA line.
I tested this patch on my device and it work as expected: without I2C kernel modules loaded gpio17 can be controlled as regular gpio via `sysfs` or `gpoiset`, and when I2C kernel modules are loaded, gpio17 work as I2C SDA line.

Signed-off-by: Ptilopsis Leucotis <PtilopsisLeucotis@yandex.com>