### PR TITLE
Change default domain from "lan" to "home.arpa"

### DIFF
--- a/package/network/services/dnsmasq/files/dhcp.conf
+++ b/package/network/services/dnsmasq/files/dhcp.conf
@@ -6,8 +6,8 @@ config dnsmasq
 	option rebind_protection 1  # disable if upstream must serve RFC1918 addresses
 	option rebind_localhost 1  # enable for RBL checking and similar services
 	#list rebind_domain example.lan  # whitelist RFC1918 responses for domains
-	option local	'/lan/'
-	option domain	'lan'
+	option local	'/home.arpa/'
+	option domain	'home.arpa'
 	option expandhosts	1
 	option nonegcache	0
 	option authoritative	1


### PR DESCRIPTION
RFC 6762 (https://datatracker.ietf.org/doc/html/rfc6762#appendix-G) specifies:

> **We do not recommend use of unregistered top-level
> domains at all**, but should network operators decide to do this, the
> following top-level domains have been used on private internal
> networks without the problems caused by trying to reuse ".local." for
> this purpose:

The (still) unregistered "lan." TLD is being used right now. RFC 8375 (https://datatracker.ietf.org/doc/html/rfc8375) designates and registers "home.arpa." for non-unique use in residential home networks.

Also see pfSense's commit (https://redmine.pfsense.org/issues/10533).