### PR TITLE
realtek: Add support for EnGenius EWS2910P

### DIFF
--- a/target/linux/realtek/dts-5.10/rtl8380_engenius_ews2910p.dts
+++ b/target/linux/realtek/dts-5.10/rtl8380_engenius_ews2910p.dts
@@ -42,6 +42,25 @@
 		#gpio-cells = <2>;
 		gpio-controller;
 		indirect-access-bus-id = <0>;
+
+		sff_p9_gpios {
+			gpio-hog;
+			gpios = < 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>,
+				< 11 GPIO_ACTIVE_HIGH>, /* los-gpio */
+				< 12 GPIO_ACTIVE_LOW>;   /* mod-def0-gpio */
+			input;
+			line-name = "sff-p9-gpios";
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		sff-p9-tx-disable {
+			gpio-export,name = "sff-p9-tx-disable";
+			gpio-export,output = <1>;
+			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+		};
 	};
 
 	gpio-restart {
@@ -71,6 +90,22 @@
 			label = "amber:poe-max";
 			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
+	};
+
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 31 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+	sfp1: sfp-p10 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		tx-disable-gpio = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+		los-gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 21 GPIO_ACTIVE_LOW>;
 	};
 };
 
@@ -138,6 +173,9 @@
 		INTERNAL_PHY(13)
 		INTERNAL_PHY(14)
 		INTERNAL_PHY(15)
+
+		INTERNAL_PHY(24)
+		INTERNAL_PHY(26)
 	};
 };
 
@@ -154,6 +192,17 @@
 		SWITCH_PORT(13, 6, internal)
 		SWITCH_PORT(14, 7, internal)
 		SWITCH_PORT(15, 8, internal)
+
+		SWITCH_SFP_PORT(24, 9, 1000base-x)
+
+		port@26 {
+			reg = <26>;
+			label = "lan10";
+			phy-mode = "1000base-x";
+			phy-handle = <&phy26>;
+			managed = "in-band-status";
+			sfp = <&sfp1>;
+		};
 
 		port@28 {
 			ethernet = <&ethernet0>;

--- a/target/linux/realtek/dts-5.10/rtl8380_engenius_ews2910p.dts
+++ b/target/linux/realtek/dts-5.10/rtl8380_engenius_ews2910p.dts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl838x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "engenius,ews2910p", "realtek,rtl838x-soc";
+	model = "EnGenius EWS2910P";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_fault;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		led_mode {
+			label = "led-mode";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+	};
+
+	gpio1: rtl8231-gpio {
+		compatible = "realtek,rtl8231-gpio";
+		#gpio-cells = <2>;
+		gpio-controller;
+		indirect-access-bus-id = <0>;
+	};
+
+	gpio-restart {
+		compatible = "gpio-restart";
+		gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan_mode: lan_mode {
+			label = "green:lan-mode";
+			gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led_fault: fault {
+			label = "amber:fault";
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led_poe_max: poe_max {
+			label = "amber:poe-max";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+			partition@80000 {
+				label = "u-boot-env";
+				reg = <0x80000 0x10000>;
+				read-only;
+			};
+			partition@90000 {
+				label = "u-boot-env2";
+				reg = <0x90000 0x10000>;
+			};
+			partition@a0000 {
+				label = "jffs2-cfg";
+				reg = <0xa0000 0xd60000>;
+			};
+			partition@e00000 {
+				label = "jffs2-log";
+				reg = <0xe00000 0x200000>;
+			};
+			partition@1000000 {
+				compatible = "openwrt,uimage";
+				label = "firmware";
+				reg = <0x1000000 0x800000>;
+				openwrt,ih-magic = <0x03802910>;
+			};
+			partition@1800000 {
+				label = "firmware2";
+				reg = <0x1800000 0x800000>;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		INTERNAL_PHY(8)
+		INTERNAL_PHY(9)
+		INTERNAL_PHY(10)
+		INTERNAL_PHY(11)
+		INTERNAL_PHY(12)
+		INTERNAL_PHY(13)
+		INTERNAL_PHY(14)
+		INTERNAL_PHY(15)
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT(8, 1, internal)
+		SWITCH_PORT(9, 2, internal)
+		SWITCH_PORT(10, 3, internal)
+		SWITCH_PORT(11, 4, internal)
+		SWITCH_PORT(12, 5, internal)
+		SWITCH_PORT(13, 6, internal)
+		SWITCH_PORT(14, 7, internal)
+		SWITCH_PORT(15, 8, internal)
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&uart1 {
+	status = "okay";
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -42,6 +42,19 @@ define Device/d-link_dgs-1210-28
 endef
 TARGET_DEVICES += d-link_dgs-1210-28
 
+# The "IMG-" uImage name allows flashing the iniramfs from the vendor Web UI.
+# Avoided for sysupgrade, as the vendor FW would do an incomplete flash.
+define Device/engenius_ews2910p
+  SOC := rtl8380
+  IMAGE_SIZE := 8192k
+  DEVICE_VENDOR := EnGenius
+  DEVICE_MODEL := EWP2910P
+  UIMAGE_MAGIC := 0x03802910
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | gzip | \
+	uImage gzip -n 'IMG-0.00.00-c0.0.00'
+endef
+TARGET_DEVICES += engenius_ews2910p
+
 define Device/inaba_aml2-17gp
   SOC := rtl8382
   IMAGE_SIZE := 13504k


### PR DESCRIPTION
Add support for the Engenius EWS2910P PoE switch. This is an RTL8380
based switch with two SFP slots, and PoE 802.3af on every RJ-45 port.

Works:
------
  - (8) RJ-45 ethernet ports
  - Switch functions
  - LEDs and buttons

Does not work:
-------------
  - Power-over-Ethernet
  - SFP ports

While I appreciate the vendor's effort in getting me into contact with
their engineering team for GPL sources, and even being promised the
sources a few years back, the sources have not been delivered. Thus, I
cannot promise I will be able to fix these points.

Install via web interface:
-------------------------

The factory firmware will accept and flash either the initramfs or
sysupgrade image. The sysupgrade must be flashed to "Partition 0". On
the other hand, the initramfs will work in either slot.

The factory web GUI will show the following warning:

```
The firmware version v2.00.42-c2.0.69 is incompatible with current
managed AP, controller may require AP firmware upgrade as well.
```

This is expected when flashing OpenWRT.

Install via serial console/tftp:
--------------------------------

The u-boot firmware will not stop the boot, regardless of which key is
pressed. To access the u-boot console, short out the CLK (pin 16) of
the ROM when u-boot is reading the linux image. If timed correctly,
the image CRC will fail, and u-boot will drop to a shell:

    > rtk network on
    > setenv ipaddr <address of tftp server>
    > tftp $(freemem) <name-of-image.bin>
    > bootm
