### PR TITLE
Update mt7621_xiaomi_mi-router-4a-3g-v2.dtsi

### DIFF
--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-3g-v2.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-3g-v2.dtsi
@@ -69,40 +69,16 @@
 				read-only;
 			};
 
-			partition@40000 {
-				label = "Bdata";
+			factory: partition@40000 {
+				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
 			};
 
-			factory: partition@50000 {
-				label = "factory";
-				reg = <0x50000 0x10000>;
-				read-only;
-			};
-
-			partition@60000 {
-				label = "crash";
-				reg = <0x60000 0x10000>;
-				read-only;
-			};
-
-			partition@70000 {
-				label = "cfg_bak";
-				reg = <0x70000 0x10000>;
-				read-only;
-			};
-
-			partition@80000 {
-				label = "overlay";
-				reg = <0x80000 0x100000>;
-				read-only;
-			};
-
-			firmware: partition@180000 {
+			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
-				reg = <0x180000 0xe80000>;
+				reg = <0x50000 0xfb0000>;
 			};
 		};
 	};


### PR DESCRIPTION
Fix the kernel panic;
But 5Ghz WIFI can't connect the internet.
Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(0,0)