### PR TITLE
[19.07] dropbear: rebuild libs on config change

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -128,6 +128,10 @@ define Build/Configure
 
 	# Enforce rebuild of svr-chansession.c
 	rm -f $(PKG_BUILD_DIR)/svr-chansession.o
+
+	# Rebuild them on config change
+	+$(MAKE) -C $(PKG_BUILD_DIR)/libtomcrypt clean
+	+$(MAKE) -C $(PKG_BUILD_DIR)/libtommath clean
 endef
 
 define Build/Compile


### PR DESCRIPTION
Required as dependency on dropbear config headers is not tracked in
dropbear build system

Fixes FS#2275

Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>

This fix was not backported to the openwrt-19.07 branch, so I cherry-picked it.

(cherry-picked from commit 289d532ddd9427a9071d85966d38fff9d78837bd)
Signed-off-by: Gajdos Tamás <gajdipajti@gmail.com>
