### PR TITLE
ath79: mikrotik: fix initram image booting

### DIFF
--- a/target/linux/ath79/image/common-mikrotik.mk
+++ b/target/linux/ath79/image/common-mikrotik.mk
@@ -1,8 +1,10 @@
 define Device/mikrotik
 	DEVICE_VENDOR := MikroTik
+	LOADER_TYPE := elf
 	KERNEL_NAME := vmlinuz
 	KERNEL := kernel-bin | append-dtb-elf
-	KERNEL_INITRAMFS := kernel-bin | append-dtb-elf
+	KERNEL_INITRAMFS_NAME := vmlinux-initramfs
+	KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel
 endef
 
 define Device/mikrotik_nor


### PR DESCRIPTION
Return to using the OpenWrt kernel loader to decompress and load kernel.

Mikrotik's bootloader RouterBOOT on some ath79 devices is
failing to boot the current initram image, due to the size of the it.

On the ath79 wAP-ac:
a 5.7MiB initram image would fail to boot
After this change:
a 6.6MiB initram image successfully loads

This reverts commit e91344776b9ba7c864be88d915c9c0df0eb790dd.

An alternative of using RouterBOOT's capability of loading an initrd ELF
section was investigated, but the OpenWrt kernel loader allows larger image.

Signed-off-by: John Thomson <git@johnthomson.fastmail.com.au>

---

Have tested on ath79 wap ac
Want to see it tested more widely.