### PR TITLE
ramips: add support for ZyXEL Keenetic 4G Rev.B Device

### DIFF
--- a/target/linux/ramips/dts/rt5350_zyxel_keenetic-4g-b.dts
+++ b/target/linux/ramips/dts/rt5350_zyxel_keenetic-4g-b.dts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rt5350.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "zyxel,keenetic-4g-b", "ralink,rt5350-soc";
+	model = "ZyXEL Keenetic 4G Rev.B";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "green:usb";
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		reserved {
+			label = "green:reserved";
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		internet {
+			label = "green:internet";
+			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+		};
+
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <30000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uartf";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+	mediatek,led_polarity = <0x17>;
+};
+
+&wmac {
+	ralink,led-polarity = <1>;
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_28: macaddr@28 {
+		reg = <0x28 0x6>;
+	};
+};

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -1206,6 +1206,16 @@ define Device/zyxel_keenetic
 endef
 TARGET_DEVICES += zyxel_keenetic
 
+define Device/zyxel_keenetic-4g-b
+  $(Device/uimage-lzma-loader)
+  SOC := rt5350
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := ZyXEL
+  DEVICE_MODEL := Keenetic 4G
+  DEVICE_VARIANT := B
+endef
+TARGET_DEVICES += zyxel_keenetic-4g-b
+
 define Device/zyxel_keenetic-lite-b
   $(Device/uimage-lzma-loader)
   SOC := rt5350

--- a/target/linux/ramips/rt305x/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/rt305x/base-files/etc/board.d/02_network
@@ -167,6 +167,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "6@eth0"
 		;;
+	zyxel,keenetic-4g-b)
+		ucidef_add_switch "switch0" \
+			"0:lan:1" "1:lan:0" "4:wan" "6@eth0"
+		;;
 	zyxel,keenetic-lite-b|\
 	zyxel,keenetic-start)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
Specification:
SoC: RT5350
CPU Frequency: 360 MHz
Flash Chip: Macronix MX25L6406E (8192 KiB)
RAM: Winbond W9825G6JH-6 (32768 KiB)
3x 10/100 Mbps Ethernet (2x LAN, 1x WAN)
1x external antenna
UART (J1) header on PCB (57800 8n1)
Wireless: SoC-intergated: 2.4GHz 802.11bgn
USB: Yes
8x LED, 2x button

Flash instruction:
Configure PC with static IP 192.168.99.8/24 and start TFTP server.
Rename "openwrt-ramips-rt305x-zyxel_keenetic-4g-b-squashfs-sysupgrade.bin"
to "rt305x_firmware.bin" and place it in TFTP server directory.
Connect PC with one of LAN ports, press the reset button, power up
the router and keep button pressed until power LED start blinking.
Router will download file from TFTP server, write it to flash and reboot.

Signed-off-by: Sergei Burakov <senior.anonymous@mail.ru>