### PR TITLE
ramips: Add suport for COMFAST CF-WR617AC

### DIFF
--- a/target/linux/ramips/dts/mt7628an_comfast_cf-wr617ac.dts
+++ b/target/linux/ramips/dts/mt7628an_comfast_cf-wr617ac.dts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "comfast,cf-wr617ac", "mediatek,mt7628an-soc";
+	model = "Comfast CF-WR617AC";
+
+	keys {
+		compatible = "gpio-keys";
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led_status_blue: status_blue {
+			label = "blue:status";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_red;
+	};
+
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x760000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		mtd-mac-address = < 0x8004>;
+		mac-address-increment = <2>;
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+};
+
+&wmac {
+	status = "okay";
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+	macaddr_factory_e000: macaddr@4 {
+		reg = <0xe000 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -101,6 +101,15 @@ define Device/buffalo_wcr-1166ds
 endef
 TARGET_DEVICES += buffalo_wcr-1166ds
 
+define Device/comfast_cf-wr617ac
+  IMAGE_SIZE := 7872k
+  DTS := CF-WR617AC
+  DEVICE_VENDOR := Comfast
+  DEVICE_MODEL := CF-WR617AC
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-rt2800-pci
+endef
+TARGET_DEVICES += comfast_cf-wr617ac
+
 define Device/comfast_cf-wr758ac
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := COMFAST

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -77,6 +77,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"3:lan" "4:wan" "6@eth0"
 		;;
+	comfast,cf-wr617ac)
+		ucidef_add_switch "switch0" \
+			"1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
+		;;
 	comfast,cf-wr758ac-v1|\
 	comfast,cf-wr758ac-v2|\
 	tplink,tl-wr902ac-v3|\
@@ -191,6 +195,10 @@ ramips_setup_macs()
 		lan_mac=$wan_mac
 		label_mac=$wan_mac
 		;;
+	comfast,cf-wr617ac)
+		lan_mac=$(mtd_get_mac_binary factory 0xe000)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
+                ;;
 	cudy,wr1000|\
 	hilink,hlk-7628n|\
 	hilink,hlk-7688a|\


### PR DESCRIPTION
Specifications:
Chipset:MT7628DA+MT7612E
Antenna : 2.4Ghz:2x5dbi Antenna + 5.8Ghz:2x5dbi Antenna
Wireless Rate:2.4Ghz 300Mbps , 5.8Ghz 867Mbps
Output Power :100mW(20dbm)
Physical port:110/100Mbps RJ45 WAN Port , 310/100Mbps RJ45 LAN Port
Flash: 8Mb
DRam: 64Mb
Flashing: default bootloader attempts to boot from tftp://192.168.1.10/firmware_auto.bin using 192.168.1.1

Known issues:
mac-address-increment for 5GHZ doesnt work, i failed to figure out why. Original firmware using +1 from original value in factory partition.

Signed-off-by: Sergei Iudin <tsipa740@gmail.com>