### PR TITLE
ramips: Add suport for WL-WN572HP3

### DIFF
--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn572hp3.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn572hp3.dts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "wavlink,wl-wn572hp3", "mediatek,mt7621-soc";
+	model = "Wavlink WL-WN572HP3";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		reset {
+			label = "Reset Button";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_high {
+			label = "green:rssi-high";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_low {
+			label = "red:rssi-low";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf30000>;
+			};
+
+			partition@f00000 {
+				label = "vendor";
+				reg = <0xf80000 0x80000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi0: mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&pcie1 {
+	wifi1: mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+	};
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port1: port@1 {
+			status = "okay";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e006>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "rgmii2", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&uartlite2 {
+	status = "okay";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};
+
+&wifi0{
+	ieee80211-freq-limit = <2400000 2500000>;
+};
+
+&wifi1{
+	ieee80211-freq-limit = <5000000 6000000>;
+};
+
+&port1{
+	label = "lan1";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1798,6 +1798,16 @@ define Device/wavlink_wl-wn533a8
 endef
 TARGET_DEVICES += wavlink_wl-wn533a8
 
+define Device/wavlink_wl-wn572hp3
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := WL-WN572HP3
+  KERNEL_INITRAMFS_SUFFIX := -WN572HP3$$(KERNEL_SUFFIX)
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7663-firmware-ap kmod-mt7615e rssileds
+  IMAGE_SIZE := 15040k
+endef
+TARGET_DEVICES += wavlink_wl-wn572hp3
+
 define Device/wevo_11acnas
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -168,6 +168,7 @@ ramips_setup_macs()
 	jcg,y2|\
 	wavlink,wl-wn531a6|\
 	wavlink,wl-wn533a8|\
+	wavlink,wl-wn572hp3|\
 	winstars,ws-wn583a6|\
 	zbtlink,zbt-we1326|\
 	zbtlink,zbt-wg3526-16m|\


### PR DESCRIPTION
WL-WN572HP3 is a dual-radio wireless router with a 2 ethernet port.
It has 4*5dBi antennas

Chipset: MT7621 + MT7603 + MT7663
Antenna : 2.4Ghz:2x5dbi Antenna + 5.8Ghz:2x5dbi Antenna
Wireless Rate: 2.4Ghz 300Mbps , 5.8Ghz 867Mbps
Output Power :100mW(20dbm)
Physical ports: 1 x 1Gb RJ45 WAN/LAN backhaul with "passive POE", 1 x 1Gb RJ45 LAN
Flashing: disassemble -> hook uart -> reboot to uboot -> flash over tftp

Known issues: i failed to make LEDs work correctly - "high" rssi and "status" do nothing on available gpios

