### PR TITLE
ath79: ZTE MF286[,A,R]: fix WLAN LED mapping 

### DIFF
--- a/target/linux/ath79/dts/qca9563_zte_mf286.dtsi
+++ b/target/linux/ath79/dts/qca9563_zte_mf286.dtsi
@@ -18,6 +18,8 @@
 
 	leds {
 		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&enable_wlan_led_gpio>;
 
 		/* Hidden SMD LED below signal strength LEDs.
 		 * Visible through slits underside of the case,
@@ -134,6 +136,12 @@
 	wifi_ath10k: wifi@0,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x0 0 0 0 0>;
+	};
+};
+
+&pinmux {
+	enable_wlan_led_gpio: pinmux_wlan_led_gpio {
+		pinctrl-single,bits = <0x10 0x0 0xff000000>;
 	};
 };
 

--- a/target/linux/ath79/dts/qca9563_zte_mf286.dtsi
+++ b/target/linux/ath79/dts/qca9563_zte_mf286.dtsi
@@ -30,6 +30,13 @@
 			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};
+
+		led-1 {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
 	};
 
 	keys {
@@ -63,20 +70,6 @@
 		gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
 		active-delay = <3000>;
 		inactive-delay = <1000>;
-	};
-};
-
-&gpio {
-	/* GPIO19 is used as a mask to enable WLAN LED
-	 * in stock firmware, which is controlled directly
-	 * by 5GHz Wi-Fi chip, which currently is inactive
-	 * in OpenWrt
-	 */
-	led-wlan {
-		gpio-hog;
-		gpios = <19 GPIO_ACTIVE_LOW>;
-		output-high;
-		line-name = "led:wlan";
 	};
 };
 


### PR DESCRIPTION
This series fixes WLAN LED mapping for the ath79-based part of ZTE MF286 family, and completes the suport of the devices, fixing their last quirk.

First commit ensures the pinctrl mapping of GPIO19 is set as GPIO properly, which isn't the case after U-boot ends.
Second commit redefines the GPIO hog as LED again and maps it to throughput trigger of 2.4GHz radio, so the actual LED shows activity of both radios by default - using onboard logic - and can be configured from userspace.

Run tested on both MF286 (the older version) and MF286R, which shares mainboard with MF286A.
This series should be cherry-picked for 22.03 release, to ensure complete device support.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>