### PR TITLE
ath79: fix label MAC address for D-Link DIR-825B1

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -597,6 +597,7 @@ ath79_setup_macs()
 	dlink,dir-825-b1)
 		lan_mac=$(mtd_get_mac_text "caldata" 0xffa0)
 		wan_mac=$(mtd_get_mac_text "caldata" 0xffb4)
+		label_mac=$wan_mac
 		;;
 	dlink,dir-505)
 		lan_mac=$(mtd_get_mac_text "mac" 0x4)


### PR DESCRIPTION
The label MAC address for DIR-825 Rev. B1 is the WAN address located
at 0xffb4 in `caldata`, which equals LAN MAC at 0xffa0 incremented by 1.

Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>