### PR TITLE
ramips: ASUS RT-ACx5P phy[01]radio to phy[01]tpt

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_rt-acx5p.dtsi
+++ b/target/linux/ramips/dts/mt7621_asus_rt-acx5p.dtsi
@@ -40,13 +40,13 @@
 		wlan5g {
 			label = "blue:wlan5g";
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1radio";
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wlan2g {
 			label = "blue:wlan2g";
 			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0radio";
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };


### PR DESCRIPTION
phy[01]radio leaves the leds always on, if they are set through sysfs the leds
get off.
Set the triggers to phy[01]tpt to make them work.

Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>