### PR TITLE
kernel: crypto: add kmod-crypto-chacha20poly1305 for strongswan

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -101,6 +101,18 @@ endef
 $(eval $(call KernelPackage,crypto-ccm))
 
 
+define KernelPackage/crypto-chacha20poly1305
+  TITLE:=ChaCha20-Poly1305 AEAD support, RFC7539 (used by strongSwan IPsec VPN)
+  DEPENDS:=+kmod-crypto-aead +kmod-crypto-manager
+  KCONFIG:=CONFIG_CRYPTO_CHACHA20POLY1305
+  FILES:=$(LINUX_DIR)/crypto/chacha20poly1305.ko
+  AUTOLOAD:=$(call AutoLoad,09,chacha20poly1305)
+  $(call AddDepends/crypto)
+endef
+
+$(eval $(call KernelPackage,crypto-chacha20poly1305))
+
+
 define KernelPackage/crypto-cmac
   TITLE:=Support for Cipher-based Message Authentication Code (CMAC)
   DEPENDS:=+kmod-crypto-hash


### PR DESCRIPTION
Needed by strongSwan IPsec VPN for `strongswan-mod-chapoly`. Not to be confused with kmod-crypto-LIB-chacha20poly1305, which is an 8-byte nonce version used by wireguard.

When this change is accepted, `strongswan-mod-chapoly` package can be updated to depend on this kmod.

This will fix [#18192](https://github.com/openwrt/packages/issues/18192).

reporter: @ru67tm
strongswan package maintainers: @pprindeville @Thermi

Please **also backport this to 22.03** because strongswan-mod-chapoly was first introduced there.

Compile & run tested: mvebu, WRT3200ACM, `22.03-SNAPSHOT, r19381-b42511c007`
Compile & run tested: mvebu, WRT3200ACM, `SNAPSHOT, r19704-efff48529b`