### PR TITLE
CI: add runtime tests in qemu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,108 @@
+name: QEMU Test
+on:
+  - pull_request
+  - push
+
+jobs:
+  build:
+    name: Build OpenWrt
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - armvirt/64
+          - malta/be
+          - x86/64
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install \
+            build-essential \
+            ccache \
+            clang-12 \
+            ecj \
+            fastjar \
+            file \
+            g++ \
+            gawk \
+            gettext \
+            git \
+            java-propose-classpath \
+            libelf-dev \
+            libncurses-dev \
+            libssl-dev \
+            mkisofs \
+            python3 \
+            python3-dev \
+            python3-distutils \
+            python3-setuptools \
+            qemu-utils \
+            rsync \
+            subversion \
+            swig \
+            unzip \
+            wget \
+            xsltproc \
+            zlib1g-dev
+
+          sudo apt-get -y install \
+            python3-pexpect \
+            python3-pytest \
+            qemu-system-arm \
+            qemu-system-mips \
+            qemu-system-x86
+
+      - name: Initialization environment
+        run: |
+          TARGET=$(echo ${{ matrix.target }} | cut -d "/" -f 1)
+          SUBTARGET=$(echo ${{ matrix.target }} | cut -d "/" -f 2)
+          echo "TARGET=$TARGET" >> "$GITHUB_ENV"
+          echo "SUBTARGET=$SUBTARGET" >> "$GITHUB_ENV"
+
+      - name: Create config
+        run: |
+          echo CONFIG_TARGET_${{ env.TARGET }}=y >> .config
+          echo CONFIG_TARGET_${{ env.TARGET }}_${{ env.SUBTARGET }}=y >> .config
+          echo CONFIG_TARGET_${{ env.TARGET }}_${{ env.SUBTARGET }}_Default=y >> .config
+          echo CONFIG_FEED_luci=y >> .config
+          echo CONFIG_FEED_packages=y >> .config
+          echo CONFIG_FEED_routing=y >> .config
+          echo CONFIG_FEED_telephony=y >> .config
+
+      - name: Create defconfig
+        run: make defconfig
+
+      - name: diffconfig
+        run: ./scripts/diffconfig.sh
+
+      - name: Compile
+        run: make -j$(nproc) BUILD_LOG=1
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.TARGET }}-${{ env.SUBTARGET }}-logs
+          path: ./logs/
+
+      - name: Upload images
+        if: success()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.TARGET }}-${{ env.SUBTARGET }}-bin
+          path: ./bin/
+
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          repository: aparcar/openwrt-tests
+          path: tests
+
+      - name: Run tests
+        run: pytest-3 tests/tests/ --target ${{ matrix.target }}


### PR DESCRIPTION
This adds a github action which will build the MIPS malta 32 BE and the
armvirt 64 target and then starts it in qemu. In qemu we execute some
automated tests to check if basic functionality is working.

The script which starts and controls the qemu system is written in
python and intentionally not directly coupled with github, this allows
to run it also with other CI systems. The qenum script checks if
changing variables in uci work, that https client works and that we can
do an ssh login to the system. This should get extended in the future.

The github action is split into two parts by intention, this allows us
to later build the image in the cloud and then run it on an own github
action runner which can interact with real hardware.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
[use external repository with tests]
Signed-off-by: Paul Spooren <mail@aparcar.org>
