### PR TITLE
ath79: add support for Netgear PGZNG1 (ADT Pulse Gateway)

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -104,6 +104,7 @@ netgear,wndr3700-v2|\
 netgear,wndrmac-v1)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x10000"
 	;;
+netgear,pgzng1|\
 netgear,wndr3700-v4|\
 netgear,wndr4300|\
 netgear,wndr4300tn|\

--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -131,6 +131,25 @@ endef
 $(eval $(call KernelPackage,leds-apu))
 
 
+define KernelPackage/leds-pca955x
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=LED driver for PCA955x I2C chips
+  DEPENDS:=@GPIO_SUPPORT +kmod-i2c-core
+  KCONFIG:=CONFIG_LEDS_PCA955X \
+    CONFIG_LEDS_PCA955X_GPIO=y
+  FILES:=$(LINUX_DIR)/drivers/leds/leds-pca955x.ko
+  AUTOLOAD:=$(call AutoLoad,60,leds-pca955x,1)
+endef
+
+define KernelPackage/leds-pca955x/description
+ This option enables support for LEDs connected to PCA955x
+ LED driver chips accessed via the I2C bus.  Supported
+ devices include PCA9550, PCA9551, PCA9552, and PCA9553.
+endef
+
+$(eval $(call KernelPackage,leds-pca955x))
+
+
 define KernelPackage/leds-pca963x
   SUBMENU:=$(LEDS_MENU)
   TITLE:=PCA963x LED support

--- a/target/linux/ath79/dts/ar9344_netgear_pgzng1.dts
+++ b/target/linux/ath79/dts/ar9344_netgear_pgzng1.dts
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/leds/leds-pca955x.h>
+
+/ {
+	model = "Netgear PGZNG1";
+	compatible = "netgear,pgzng1", "qca,ar9344";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+		label-mac-device = &eth0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	i2c {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio 14 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio 13 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		expander0: pca9551@60 {
+			compatible = "nxp,pca9551";
+			reg = <0x60>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led_power_green: led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_BOOT;
+				type = <PCA955X_TYPE_LED>;
+				chan-name = "green:boot";
+			};
+
+			led_power_red: led@1 {
+				reg = <1>;
+				color = <LED_COLOR_ID_RED>;
+				function = LED_FUNCTION_BOOT;
+				type = <PCA955X_TYPE_LED>;
+				chan-name = "red:boot";
+			};
+
+			led@2 {
+				reg = <2>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+				function-enumerator = <1>;
+				type = <PCA955X_TYPE_LED>;
+			};
+
+			led@3 {
+				reg = <3>;
+				color = <LED_COLOR_ID_RED>;
+				function = LED_FUNCTION_WAN;
+				type = <PCA955X_TYPE_LED>;
+			};
+
+			led@4 {
+				reg = <4>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WLAN;
+				type = <PCA955X_TYPE_LED>;
+			};
+
+			led@5 {
+				reg = <5>;
+				color = <LED_COLOR_ID_RED>;
+				function = LED_FUNCTION_WLAN;
+				type = <PCA955X_TYPE_LED>;
+			};
+
+			led@6 {
+				reg = <6>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_INDICATOR;
+				type = <PCA955X_TYPE_LED>;
+			};
+
+			led@7 {
+				reg = <7>;
+				color = <LED_COLOR_ID_RED>;
+				function = LED_FUNCTION_INDICATOR;
+				type = <PCA955X_TYPE_LED>;
+			};
+		};
+
+		expander1: pca9551@61 { 
+			compatible = "nxp,pca9551";
+			reg = <0x61>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			/* zwave_rst - Resets ZWave */
+			gpio@4 {
+				reg = <4>;
+				type = <PCA955X_TYPE_GPIO>;
+			};
+
+			/* em_rst - Unknown */
+			gpio@5 {
+				reg = <5>;
+				type = <PCA955X_TYPE_GPIO>;
+			};
+
+			/* tp34 - Test point on PCB? */
+			gpio@6 {
+				reg = <6>;
+				type = <PCA955X_TYPE_GPIO>;
+			};
+
+			/* sw_rst - resets SoC */
+			gpio@7 {
+				reg = <7>;
+				type = <PCA955X_TYPE_GPIO>;
+			};
+		};
+
+		rtc@6f {
+			compatible = "isil,isl1208";
+			reg = <0x6f>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		eth1_link {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		eth1_act {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		eth0_link {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			function-enumerator = <0>;
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		eth0_act {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+	phy-handle = <&swphy0>;
+
+	nvmem-cells = <&macaddr_caldata_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth1 {
+	status = "okay";
+	phy-handle = <&swphy4>;
+
+	nvmem-cells = <&macaddr_caldata_0>;
+	nvmem-cell-names = "mac-address";
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+		switch-only-mode = <1>;
+	};
+};
+
+&gpio {
+	gpio_ext_lna0 {
+		gpio-hog;
+		line-name = "ext:lna0";
+		gpios = <18 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+
+	gpio_ext_lna1 {
+		gpio-hog;
+		line-name = "ext:lna1";
+		gpios = <19 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+
+	gpio_enable_rs422 {
+		gpio-hog;
+		line-name = "power:rs422";
+		gpios = <20 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x40000>;
+			read-only;
+		};
+
+		partition@40000 {
+			label = "u-boot-env";
+			reg = <0x40000 0x40000>;
+			read-only;
+		};
+
+		/* factory kernel used to be reg = <0x80000 0x200000> */
+		partition@80000 {
+			label = "kernel";
+			reg = <0x80000 0x500000>;
+		};
+
+		/* factory rootfs used to be reg = <0x280000 0x5000000> */
+		partition@580000 {
+			label = "ubi";
+			reg = <0x580000 0x4d00000>;
+		};
+
+		partition@5280000 {
+			label = "uImage2";
+			reg = <0x5280000 0x200000>;
+			read-only;
+		};
+
+		partition@5480000 {
+			label = "rootfs_bak";
+			reg = <0x5480000 0x5000000>;
+			read-only;
+		};
+
+		partition@a480000 {
+			label = "config";
+			reg = <0xa480000 0x1400000>;
+			read-only;
+		};
+
+		partition@b880000 {
+			label = "storage";
+			reg = <0xb880000 0x4700000>;
+			read-only;
+		};
+
+		partition@ff80000 {
+			label = "dummy";
+			reg = <0xff80000 0x60000>;
+			read-only;
+		};
+
+		caldata: partition@ffe0000 {
+			label = "caldata";
+			reg = <0xffe0000 0x20000>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_caldata_0: macaddr@0 {
+				reg = <0x0 0x6>;
+			};
+
+			macaddr_caldata_6: macaddr@6 {
+				reg = <0x6 0x6>;
+			};
+
+			cal_caldata_1000: cal@1000 {
+				reg = <0x1000 0x440>;
+			};
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+/* zWave is wired up via SPI and UART1 (no idea on pins sadly) */
+&spi {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&cal_caldata_1000>;
+	nvmem-cell-names = "calibration";
+};
+
+&usb {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -231,6 +231,23 @@ define Device/netgear_ath79_nand
   UBINIZE_OPTS := -E 5
 endef
 
+define Device/netgear_pgzng1
+  SOC := ar9344
+  DEVICE_MODEL := PGZNG1
+  DEVICE_VENDOR := NETGEAR
+  DEVICE_ALT0_MODEL := Pulse Gateway
+  DEVICE_ALT0_VENDOR := ADT
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-i2c-gpio \
+    kmod-leds-pca955x kmod-rtc-isl1208 kmod-spi-dev
+  KERNEL_SIZE := 5120k
+  IMAGE_SIZE := 83968k
+  PAGESIZE := 2048
+  BLOCKSIZE := 128k
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma
+  IMAGE/sysupgrade.bin := sysupgrade-tar | check-size | append-metadata
+endef
+TARGET_DEVICES += netgear_pgzng1
+
 define Device/netgear_r6100
   SOC := ar9344
   DEVICE_MODEL := R6100

--- a/target/linux/ath79/nand/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/nand/base-files/etc/board.d/01_leds
@@ -18,6 +18,14 @@ glinet,gl-xe300)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x10"
 	;;
+netgear,pgzng1)
+	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
+	ucidef_set_led_switch "wan" "WAN" "green:wan-1" "switch0" "0x02" "0xf" "link tx rx"
+	ucidef_set_led_switch "wan-green" "wan link" "green:wan-0" "switch0" "0x02" "0xf" "link"
+	ucidef_set_led_switch "wan-amber" "wan act" "amber:wan" "switch0" "0x02" "0xf" "tx rx"
+	ucidef_set_led_netdev "lan-green" "lan link" "green:lan" "eth1" "link"
+	ucidef_set_led_netdev "lan-amber" "lan act" "amber:lan" "eth1" "tx rx"
+	;;
 netgear,r6100)
 	ucidef_set_led_netdev "wan-green" "WAN (green)" "green:wan" "eth1"
 	;;

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -30,6 +30,9 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "4:lan"
 		;;
+	netgear,pgzng1)
+		ucidef_set_interfaces_lan_wan "eth1" "eth0"
+		;;
 	netgear,r6100)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/nand/base-files/etc/init.d/boot-leds
+++ b/target/linux/ath79/nand/base-files/etc/init.d/boot-leds
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+# SPDX-License-Identifier: GPL-2.0-only
+
+START=11
+
+# To support LEDs on boards that have drivers loaded after rootfs, let's
+# re-run diag.sh AFTER kmodloader has finished, but before boot is complete.
+# This is useful for userspace LED drivers, LEDs that rely on i2c, etc.
+
+boot() {
+    case $(board_name) in
+    netgear,pgzng1)
+        . /etc/diag.sh
+        set_led_state preinit_regular 
+        ;;
+    esac
+}

--- a/target/linux/generic/backport-5.10/840-v5.15-leds-pca955x-clean-up-code-formatting.patch
+++ b/target/linux/generic/backport-5.10/840-v5.15-leds-pca955x-clean-up-code-formatting.patch
@@ -1,0 +1,178 @@
+From 2420ae02ce0a926819ebe18f809a57bff3edeac2 Mon Sep 17 00:00:00 2001
+From: Eddie James <eajames@linux.ibm.com>
+Date: Fri, 16 Jul 2021 17:03:27 -0500
+Subject: [PATCH] leds: pca955x: Clean up code formatting
+
+Format the code. Add some variables to help shorten lines.
+
+Signed-off-by: Eddie James <eajames@linux.ibm.com>
+Signed-off-by: Pavel Machek <pavel@ucw.cz>
+---
+ drivers/leds/leds-pca955x.c | 63 ++++++++++++++++++-------------------
+ 1 file changed, 30 insertions(+), 33 deletions(-)
+
+diff --git a/drivers/leds/leds-pca955x.c b/drivers/leds/leds-pca955x.c
+index 7087ca4592fc96..f0d841cb59fcc8 100644
+--- a/drivers/leds/leds-pca955x.c
++++ b/drivers/leds/leds-pca955x.c
+@@ -166,11 +166,10 @@ static inline u8 pca955x_ledsel(u8 oldval, int led_num, int state)
+ static int pca955x_write_psc(struct i2c_client *client, int n, u8 val)
+ {
+ 	struct pca955x *pca955x = i2c_get_clientdata(client);
++	u8 cmd = pca95xx_num_input_regs(pca955x->chipdef->bits) + (2 * n);
+ 	int ret;
+ 
+-	ret = i2c_smbus_write_byte_data(client,
+-		pca95xx_num_input_regs(pca955x->chipdef->bits) + 2*n,
+-		val);
++	ret = i2c_smbus_write_byte_data(client, cmd, val);
+ 	if (ret < 0)
+ 		dev_err(&client->dev, "%s: reg 0x%x, val 0x%x, err %d\n",
+ 			__func__, n, val, ret);
+@@ -187,11 +186,10 @@ static int pca955x_write_psc(struct i2c_client *client, int n, u8 val)
+ static int pca955x_write_pwm(struct i2c_client *client, int n, u8 val)
+ {
+ 	struct pca955x *pca955x = i2c_get_clientdata(client);
++	u8 cmd = pca95xx_num_input_regs(pca955x->chipdef->bits) + 1 + (2 * n);
+ 	int ret;
+ 
+-	ret = i2c_smbus_write_byte_data(client,
+-		pca95xx_num_input_regs(pca955x->chipdef->bits) + 1 + 2*n,
+-		val);
++	ret = i2c_smbus_write_byte_data(client, cmd, val);
+ 	if (ret < 0)
+ 		dev_err(&client->dev, "%s: reg 0x%x, val 0x%x, err %d\n",
+ 			__func__, n, val, ret);
+@@ -205,11 +203,10 @@ static int pca955x_write_pwm(struct i2c_client *client, int n, u8 val)
+ static int pca955x_write_ls(struct i2c_client *client, int n, u8 val)
+ {
+ 	struct pca955x *pca955x = i2c_get_clientdata(client);
++	u8 cmd = pca95xx_num_input_regs(pca955x->chipdef->bits) + 4 + n;
+ 	int ret;
+ 
+-	ret = i2c_smbus_write_byte_data(client,
+-		pca95xx_num_input_regs(pca955x->chipdef->bits) + 4 + n,
+-		val);
++	ret = i2c_smbus_write_byte_data(client, cmd, val);
+ 	if (ret < 0)
+ 		dev_err(&client->dev, "%s: reg 0x%x, val 0x%x, err %d\n",
+ 			__func__, n, val, ret);
+@@ -223,10 +220,10 @@ static int pca955x_write_ls(struct i2c_client *client, int n, u8 val)
+ static int pca955x_read_ls(struct i2c_client *client, int n, u8 *val)
+ {
+ 	struct pca955x *pca955x = i2c_get_clientdata(client);
++	u8 cmd = pca95xx_num_input_regs(pca955x->chipdef->bits) + 4 + n;
+ 	int ret;
+ 
+-	ret = i2c_smbus_read_byte_data(client,
+-		pca95xx_num_input_regs(pca955x->chipdef->bits) + 4 + n);
++	ret = i2c_smbus_read_byte_data(client, cmd);
+ 	if (ret < 0) {
+ 		dev_err(&client->dev, "%s: reg 0x%x, err %d\n",
+ 			__func__, n, ret);
+@@ -371,6 +368,7 @@ static struct pca955x_platform_data *
+ pca955x_get_pdata(struct i2c_client *client, struct pca955x_chipdef *chip)
+ {
+ 	struct pca955x_platform_data *pdata;
++	struct pca955x_led *led;
+ 	struct fwnode_handle *child;
+ 	int count;
+ 
+@@ -401,13 +399,13 @@ pca955x_get_pdata(struct i2c_client *client, struct pca955x_chipdef *chip)
+ 		if ((res != 0) && is_of_node(child))
+ 			name = to_of_node(child)->name;
+ 
+-		snprintf(pdata->leds[reg].name, sizeof(pdata->leds[reg].name),
+-			 "%s", name);
++		led = &pdata->leds[reg];
++		snprintf(led->name, sizeof(led->name), "%s", name);
+ 
+-		pdata->leds[reg].type = PCA955X_TYPE_LED;
+-		fwnode_property_read_u32(child, "type", &pdata->leds[reg].type);
++		led->type = PCA955X_TYPE_LED;
++		fwnode_property_read_u32(child, "type", &led->type);
+ 		fwnode_property_read_string(child, "linux,default-trigger",
+-					&pdata->leds[reg].default_trigger);
++					    &led->default_trigger);
+ 	}
+ 
+ 	pdata->num_leds = chip->bits;
+@@ -426,11 +424,12 @@ static const struct of_device_id of_pca955x_match[] = {
+ MODULE_DEVICE_TABLE(of, of_pca955x_match);
+ 
+ static int pca955x_probe(struct i2c_client *client,
+-					const struct i2c_device_id *id)
++			 const struct i2c_device_id *id)
+ {
+ 	struct pca955x *pca955x;
+ 	struct pca955x_led *pca955x_led;
+ 	struct pca955x_chipdef *chip;
++	struct led_classdev *led;
+ 	struct i2c_adapter *adapter;
+ 	int i, err;
+ 	struct pca955x_platform_data *pdata;
+@@ -449,13 +448,13 @@ static int pca955x_probe(struct i2c_client *client,
+ 	if ((client->addr & ~((1 << chip->slv_addr_shift) - 1)) !=
+ 	    chip->slv_addr) {
+ 		dev_err(&client->dev, "invalid slave address %02x\n",
+-				client->addr);
++			client->addr);
+ 		return -ENODEV;
+ 	}
+ 
+ 	dev_info(&client->dev, "leds-pca955x: Using %s %d-bit LED driver at "
+-			"slave address 0x%02x\n",
+-			client->name, chip->bits, client->addr);
++		 "slave address 0x%02x\n", client->name, chip->bits,
++		 client->addr);
+ 
+ 	if (!i2c_check_functionality(adapter, I2C_FUNC_SMBUS_BYTE_DATA))
+ 		return -EIO;
+@@ -471,8 +470,8 @@ static int pca955x_probe(struct i2c_client *client,
+ 	if (!pca955x)
+ 		return -ENOMEM;
+ 
+-	pca955x->leds = devm_kcalloc(&client->dev,
+-			chip->bits, sizeof(*pca955x_led), GFP_KERNEL);
++	pca955x->leds = devm_kcalloc(&client->dev, chip->bits,
++				     sizeof(*pca955x_led), GFP_KERNEL);
+ 	if (!pca955x->leds)
+ 		return -ENOMEM;
+ 
+@@ -501,27 +500,25 @@ static int pca955x_probe(struct i2c_client *client,
+ 			 */
+ 			if (pdata->leds[i].name[0] == '\0')
+ 				snprintf(pdata->leds[i].name,
+-					sizeof(pdata->leds[i].name), "%d", i);
++					 sizeof(pdata->leds[i].name), "%d", i);
+ 
+-			snprintf(pca955x_led->name,
+-				sizeof(pca955x_led->name), "pca955x:%s",
+-				pdata->leds[i].name);
++			snprintf(pca955x_led->name, sizeof(pca955x_led->name),
++				 "pca955x:%s", pdata->leds[i].name);
+ 
++			led = &pca955x_led->led_cdev;
+ 			if (pdata->leds[i].default_trigger)
+-				pca955x_led->led_cdev.default_trigger =
++				led->default_trigger =
+ 					pdata->leds[i].default_trigger;
+ 
+-			pca955x_led->led_cdev.name = pca955x_led->name;
+-			pca955x_led->led_cdev.brightness_set_blocking =
+-				pca955x_led_set;
++			led->name = pca955x_led->name;
++			led->brightness_set_blocking = pca955x_led_set;
+ 
+-			err = devm_led_classdev_register(&client->dev,
+-							&pca955x_led->led_cdev);
++			err = devm_led_classdev_register(&client->dev, led);
+ 			if (err)
+ 				return err;
+ 
+ 			/* Turn off LED */
+-			err = pca955x_led_set(&pca955x_led->led_cdev, LED_OFF);
++			err = pca955x_led_set(led, LED_OFF);
+ 			if (err)
+ 				return err;
+ 		}

--- a/target/linux/generic/backport-5.10/841-v5.15-leds-pca955x-add-brightness-get-function.patch
+++ b/target/linux/generic/backport-5.10/841-v5.15-leds-pca955x-add-brightness-get-function.patch
@@ -1,0 +1,83 @@
+From 7086625fde6538b2c0623eb767ad23c7ac3d7f3a Mon Sep 17 00:00:00 2001
+From: Eddie James <eajames@linux.ibm.com>
+Date: Fri, 16 Jul 2021 17:03:28 -0500
+Subject: [PATCH] leds: pca955x: Add brightness_get function
+
+Add a function to fetch the state of the hardware LED.
+
+Signed-off-by: Eddie James <eajames@linux.ibm.com>
+Signed-off-by: Pavel Machek <pavel@ucw.cz>
+---
+ drivers/leds/leds-pca955x.c | 52 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 52 insertions(+)
+
+diff --git a/drivers/leds/leds-pca955x.c b/drivers/leds/leds-pca955x.c
+index f0d841cb59fcc8..e47ba7c3b7c7d8 100644
+--- a/drivers/leds/leds-pca955x.c
++++ b/drivers/leds/leds-pca955x.c
+@@ -233,6 +233,57 @@ static int pca955x_read_ls(struct i2c_client *client, int n, u8 *val)
+ 	return 0;
+ }
+ 
++static int pca955x_read_pwm(struct i2c_client *client, int n, u8 *val)
++{
++	struct pca955x *pca955x = i2c_get_clientdata(client);
++	u8 cmd = pca95xx_num_input_regs(pca955x->chipdef->bits) + 1 + (2 * n);
++	int ret;
++
++	ret = i2c_smbus_read_byte_data(client, cmd);
++	if (ret < 0) {
++		dev_err(&client->dev, "%s: reg 0x%x, err %d\n",
++			__func__, n, ret);
++		return ret;
++	}
++	*val = (u8)ret;
++	return 0;
++}
++
++static enum led_brightness pca955x_led_get(struct led_classdev *led_cdev)
++{
++	struct pca955x_led *pca955x_led = container_of(led_cdev,
++						       struct pca955x_led,
++						       led_cdev);
++	struct pca955x *pca955x = pca955x_led->pca955x;
++	u8 ls, pwm;
++	int ret;
++
++	ret = pca955x_read_ls(pca955x->client, pca955x_led->led_num / 4, &ls);
++	if (ret)
++		return ret;
++
++	ls = (ls >> ((pca955x_led->led_num % 4) << 1)) & 0x3;
++	switch (ls) {
++	case PCA955X_LS_LED_ON:
++		ret = LED_FULL;
++		break;
++	case PCA955X_LS_LED_OFF:
++		ret = LED_OFF;
++		break;
++	case PCA955X_LS_BLINK0:
++		ret = LED_HALF;
++		break;
++	case PCA955X_LS_BLINK1:
++		ret = pca955x_read_pwm(pca955x->client, 1, &pwm);
++		if (ret)
++			return ret;
++		ret = 255 - pwm;
++		break;
++	}
++
++	return ret;
++}
++
+ static int pca955x_led_set(struct led_classdev *led_cdev,
+ 			    enum led_brightness value)
+ {
+@@ -512,6 +563,7 @@ static int pca955x_probe(struct i2c_client *client,
+ 
+ 			led->name = pca955x_led->name;
+ 			led->brightness_set_blocking = pca955x_led_set;
++			led->brightness_get = pca955x_led_get;
+ 
+ 			err = devm_led_classdev_register(&client->dev, led);
+ 			if (err)

--- a/target/linux/generic/backport-5.10/842-v5.15-leds-pca955x-implement-the-default-state-property.patch
+++ b/target/linux/generic/backport-5.10/842-v5.15-leds-pca955x-implement-the-default-state-property.patch
@@ -1,0 +1,119 @@
+From e46cb6d0c760a5b15e38138845fad99628fafcb8 Mon Sep 17 00:00:00 2001
+From: Eddie James <eajames@linux.ibm.com>
+Date: Fri, 16 Jul 2021 17:03:29 -0500
+Subject: [PATCH] leds: pca955x: Implement the default-state property
+
+In order to retain the LED state after a system reboot, check the
+documented default-state device tree property during initialization.
+Modify the behavior of the probe according to the property.
+
+Signed-off-by: Eddie James <eajames@linux.ibm.com>
+Signed-off-by: Pavel Machek <pavel@ucw.cz>
+---
+ drivers/leds/leds-pca955x.c | 54 +++++++++++++++++++++++++++++++------
+ 1 file changed, 46 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/leds/leds-pca955x.c b/drivers/leds/leds-pca955x.c
+index e47ba7c3b7c7d8..fa1d77d86ef67b 100644
+--- a/drivers/leds/leds-pca955x.c
++++ b/drivers/leds/leds-pca955x.c
+@@ -129,6 +129,7 @@ struct pca955x_led {
+ 	int			led_num;	/* 0 .. 15 potentially */
+ 	char			name[32];
+ 	u32			type;
++	int			default_state;
+ 	const char		*default_trigger;
+ };
+ 
+@@ -439,6 +440,7 @@ pca955x_get_pdata(struct i2c_client *client, struct pca955x_chipdef *chip)
+ 
+ 	device_for_each_child_node(&client->dev, child) {
+ 		const char *name;
++		const char *state;
+ 		u32 reg;
+ 		int res;
+ 
+@@ -457,6 +459,18 @@ pca955x_get_pdata(struct i2c_client *client, struct pca955x_chipdef *chip)
+ 		fwnode_property_read_u32(child, "type", &led->type);
+ 		fwnode_property_read_string(child, "linux,default-trigger",
+ 					    &led->default_trigger);
++
++		if (!fwnode_property_read_string(child, "default-state",
++						 &state)) {
++			if (!strcmp(state, "keep"))
++				led->default_state = LEDS_GPIO_DEFSTATE_KEEP;
++			else if (!strcmp(state, "on"))
++				led->default_state = LEDS_GPIO_DEFSTATE_ON;
++			else
++				led->default_state = LEDS_GPIO_DEFSTATE_OFF;
++		} else {
++			led->default_state = LEDS_GPIO_DEFSTATE_OFF;
++		}
+ 	}
+ 
+ 	pdata->num_leds = chip->bits;
+@@ -485,6 +499,7 @@ static int pca955x_probe(struct i2c_client *client,
+ 	int i, err;
+ 	struct pca955x_platform_data *pdata;
+ 	int ngpios = 0;
++	bool keep_pwm = false;
+ 
+ 	chip = &pca955x_chipdefs[id->driver_data];
+ 	adapter = client->adapter;
+@@ -565,14 +580,35 @@ static int pca955x_probe(struct i2c_client *client,
+ 			led->brightness_set_blocking = pca955x_led_set;
+ 			led->brightness_get = pca955x_led_get;
+ 
++			if (pdata->leds[i].default_state ==
++			    LEDS_GPIO_DEFSTATE_OFF) {
++				err = pca955x_led_set(led, LED_OFF);
++				if (err)
++					return err;
++			} else if (pdata->leds[i].default_state ==
++				   LEDS_GPIO_DEFSTATE_ON) {
++				err = pca955x_led_set(led, LED_FULL);
++				if (err)
++					return err;
++			}
++
+ 			err = devm_led_classdev_register(&client->dev, led);
+ 			if (err)
+ 				return err;
+ 
+-			/* Turn off LED */
+-			err = pca955x_led_set(led, LED_OFF);
+-			if (err)
+-				return err;
++			/*
++			 * For default-state == "keep", let the core update the
++			 * brightness from the hardware, then check the
++			 * brightness to see if it's using PWM1. If so, PWM1
++			 * should not be written below.
++			 */
++			if (pdata->leds[i].default_state ==
++			    LEDS_GPIO_DEFSTATE_KEEP) {
++				if (led->brightness != LED_FULL &&
++				    led->brightness != LED_OFF &&
++				    led->brightness != LED_HALF)
++					keep_pwm = true;
++			}
+ 		}
+ 	}
+ 
+@@ -581,10 +617,12 @@ static int pca955x_probe(struct i2c_client *client,
+ 	if (err)
+ 		return err;
+ 
+-	/* PWM1 is used for variable brightness, default to OFF */
+-	err = pca955x_write_pwm(client, 1, 0);
+-	if (err)
+-		return err;
++	if (!keep_pwm) {
++		/* PWM1 is used for variable brightness, default to OFF */
++		err = pca955x_write_pwm(client, 1, 0);
++		if (err)
++			return err;
++	}
+ 
+ 	/* Set to fast frequency so we do not see flashing */
+ 	err = pca955x_write_psc(client, 0, 0);

--- a/target/linux/generic/backport-5.10/843-v5.15-leds-pca955x-let-the-core-process-the-fwnode.patch
+++ b/target/linux/generic/backport-5.10/843-v5.15-leds-pca955x-let-the-core-process-the-fwnode.patch
@@ -1,0 +1,138 @@
+From 7c4815929276b2e223eb6f2e49afe5071d4294a5 Mon Sep 17 00:00:00 2001
+From: Eddie James <eajames@linux.ibm.com>
+Date: Fri, 16 Jul 2021 17:03:30 -0500
+Subject: [PATCH] leds: pca955x: Let the core process the fwnode
+
+Much of the fwnode processing in the PCA955x driver is now in the
+LEDs core driver, so pass the fwnode in the init data when
+registering the LED device. In order to preserve the existing naming
+scheme, check for an empty name and set it to the LED number.
+
+Signed-off-by: Eddie James <eajames@linux.ibm.com>
+Signed-off-by: Pavel Machek <pavel@ucw.cz>
+---
+ drivers/leds/leds-pca955x.c | 58 +++++++++++++++++++------------------
+ 1 file changed, 30 insertions(+), 28 deletions(-)
+
+diff --git a/drivers/leds/leds-pca955x.c b/drivers/leds/leds-pca955x.c
+index fa1d77d86ef67b..a6aa4b9abde8c4 100644
+--- a/drivers/leds/leds-pca955x.c
++++ b/drivers/leds/leds-pca955x.c
+@@ -127,10 +127,9 @@ struct pca955x_led {
+ 	struct pca955x	*pca955x;
+ 	struct led_classdev	led_cdev;
+ 	int			led_num;	/* 0 .. 15 potentially */
+-	char			name[32];
+ 	u32			type;
+ 	int			default_state;
+-	const char		*default_trigger;
++	struct fwnode_handle	*fwnode;
+ };
+ 
+ struct pca955x_platform_data {
+@@ -439,7 +438,6 @@ pca955x_get_pdata(struct i2c_client *client, struct pca955x_chipdef *chip)
+ 		return ERR_PTR(-ENOMEM);
+ 
+ 	device_for_each_child_node(&client->dev, child) {
+-		const char *name;
+ 		const char *state;
+ 		u32 reg;
+ 		int res;
+@@ -448,17 +446,10 @@ pca955x_get_pdata(struct i2c_client *client, struct pca955x_chipdef *chip)
+ 		if ((res != 0) || (reg >= chip->bits))
+ 			continue;
+ 
+-		res = fwnode_property_read_string(child, "label", &name);
+-		if ((res != 0) && is_of_node(child))
+-			name = to_of_node(child)->name;
+-
+ 		led = &pdata->leds[reg];
+-		snprintf(led->name, sizeof(led->name), "%s", name);
+-
+ 		led->type = PCA955X_TYPE_LED;
++		led->fwnode = child;
+ 		fwnode_property_read_u32(child, "type", &led->type);
+-		fwnode_property_read_string(child, "linux,default-trigger",
+-					    &led->default_trigger);
+ 
+ 		if (!fwnode_property_read_string(child, "default-state",
+ 						 &state)) {
+@@ -495,11 +486,14 @@ static int pca955x_probe(struct i2c_client *client,
+ 	struct pca955x_led *pca955x_led;
+ 	struct pca955x_chipdef *chip;
+ 	struct led_classdev *led;
++	struct led_init_data init_data;
+ 	struct i2c_adapter *adapter;
+ 	int i, err;
+ 	struct pca955x_platform_data *pdata;
+ 	int ngpios = 0;
++	bool set_default_label = false;
+ 	bool keep_pwm = false;
++	char default_label[8];
+ 
+ 	chip = &pca955x_chipdefs[id->driver_data];
+ 	adapter = client->adapter;
+@@ -547,6 +541,9 @@ static int pca955x_probe(struct i2c_client *client,
+ 	pca955x->client = client;
+ 	pca955x->chipdef = chip;
+ 
++	init_data.devname_mandatory = false;
++	init_data.devicename = "pca955x";
++
+ 	for (i = 0; i < chip->bits; i++) {
+ 		pca955x_led = &pca955x->leds[i];
+ 		pca955x_led->led_num = i;
+@@ -560,23 +557,7 @@ static int pca955x_probe(struct i2c_client *client,
+ 			ngpios++;
+ 			break;
+ 		case PCA955X_TYPE_LED:
+-			/*
+-			 * Platform data can specify LED names and
+-			 * default triggers
+-			 */
+-			if (pdata->leds[i].name[0] == '\0')
+-				snprintf(pdata->leds[i].name,
+-					 sizeof(pdata->leds[i].name), "%d", i);
+-
+-			snprintf(pca955x_led->name, sizeof(pca955x_led->name),
+-				 "pca955x:%s", pdata->leds[i].name);
+-
+ 			led = &pca955x_led->led_cdev;
+-			if (pdata->leds[i].default_trigger)
+-				led->default_trigger =
+-					pdata->leds[i].default_trigger;
+-
+-			led->name = pca955x_led->name;
+ 			led->brightness_set_blocking = pca955x_led_set;
+ 			led->brightness_get = pca955x_led_get;
+ 
+@@ -592,7 +573,28 @@ static int pca955x_probe(struct i2c_client *client,
+ 					return err;
+ 			}
+ 
+-			err = devm_led_classdev_register(&client->dev, led);
++			init_data.fwnode = pdata->leds[i].fwnode;
++
++			if (is_of_node(init_data.fwnode)) {
++				if (to_of_node(init_data.fwnode)->name[0] ==
++				    '\0')
++					set_default_label = true;
++				else
++					set_default_label = false;
++			} else {
++				set_default_label = true;
++			}
++
++			if (set_default_label) {
++				snprintf(default_label, sizeof(default_label),
++					 "%d", i);
++				init_data.default_label = default_label;
++			} else {
++				init_data.default_label = NULL;
++			}
++
++			err = devm_led_classdev_register_ext(&client->dev, led,
++							     &init_data);
+ 			if (err)
+ 				return err;
+ 

--- a/target/linux/generic/backport-5.10/844-v5.15-leds-pca955x-switch-to-i2c-probe-new.patch
+++ b/target/linux/generic/backport-5.10/844-v5.15-leds-pca955x-switch-to-i2c-probe-new.patch
@@ -1,0 +1,64 @@
+From 239f32b4f161c1584cd4b386d6ab8766432a6ede Mon Sep 17 00:00:00 2001
+From: Eddie James <eajames@linux.ibm.com>
+Date: Fri, 16 Jul 2021 17:03:31 -0500
+Subject: [PATCH] leds: pca955x: Switch to i2c probe_new
+
+The deprecated i2c probe functionality doesn't work with OF
+compatible strings, as it only checks for the i2c device id. Switch
+to the new way of probing and grab the match data to select the
+chip type.
+
+Signed-off-by: Eddie James <eajames@linux.ibm.com>
+Signed-off-by: Pavel Machek <pavel@ucw.cz>
+---
+ drivers/leds/leds-pca955x.c | 23 +++++++++++++++++++----
+ 1 file changed, 19 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/leds/leds-pca955x.c b/drivers/leds/leds-pca955x.c
+index a6aa4b9abde8c4..a6b5699aeae4fe 100644
+--- a/drivers/leds/leds-pca955x.c
++++ b/drivers/leds/leds-pca955x.c
+@@ -479,8 +479,7 @@ static const struct of_device_id of_pca955x_match[] = {
+ };
+ MODULE_DEVICE_TABLE(of, of_pca955x_match);
+ 
+-static int pca955x_probe(struct i2c_client *client,
+-			 const struct i2c_device_id *id)
++static int pca955x_probe(struct i2c_client *client)
+ {
+ 	struct pca955x *pca955x;
+ 	struct pca955x_led *pca955x_led;
+@@ -494,8 +493,24 @@ static int pca955x_probe(struct i2c_client *client,
+ 	bool set_default_label = false;
+ 	bool keep_pwm = false;
+ 	char default_label[8];
++	enum pca955x_type chip_type;
++	const void *md = device_get_match_data(&client->dev);
+ 
+-	chip = &pca955x_chipdefs[id->driver_data];
++	if (md) {
++		chip_type = (enum pca955x_type)md;
++	} else {
++		const struct i2c_device_id *id = i2c_match_id(pca955x_id,
++							      client);
++
++		if (id) {
++			chip_type = (enum pca955x_type)id->driver_data;
++		} else {
++			dev_err(&client->dev, "unknown chip\n");
++			return -ENODEV;
++		}
++	}
++
++	chip = &pca955x_chipdefs[chip_type];
+ 	adapter = client->adapter;
+ 	pdata = dev_get_platdata(&client->dev);
+ 	if (!pdata) {
+@@ -670,7 +685,7 @@ static struct i2c_driver pca955x_driver = {
+ 		.name	= "leds-pca955x",
+ 		.of_match_table = of_pca955x_match,
+ 	},
+-	.probe	= pca955x_probe,
++	.probe_new = pca955x_probe,
+ 	.id_table = pca955x_id,
+ };


### PR DESCRIPTION
The following PR adds 3x commits that are required to add support for the Netgear PGZNG1 (ADT Pulse Gateway).

This is a really unique ar9344 board due to the large amount of RAM and Storage, since the stock OS runs a java applet. It also has onboard Z-Wave and RS422, but neither are working in OpenWRT.


