### PR TITLE
ath79: allow link state reporting on ports attached to built-in switch

### DIFF
--- a/target/linux/ath79/dts/ar7240.dtsi
+++ b/target/linux/ath79/dts/ar7240.dtsi
@@ -90,6 +90,7 @@
 	reset-names = "mac";
 
 	phy-mode = "gmii";
+	builtin-switch;
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/dts/ar7241.dtsi
+++ b/target/linux/ath79/dts/ar7241.dtsi
@@ -94,6 +94,7 @@
 	reset-names = "mac";
 
 	phy-mode = "gmii";
+	builtin-switch;
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/dts/ar7242.dtsi
+++ b/target/linux/ath79/dts/ar7242.dtsi
@@ -85,6 +85,7 @@
 	reset-names = "mac";
 
 	phy-mode = "gmii";
+	builtin-switch;
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -221,6 +221,7 @@
 
 	pll-data = <0x00110000 0x00001099 0x00991099>;
 	phy-mode = "gmii";
+	builtin-switch;
 
 	resets = <&rst 13>;
 	reset-names = "mac";

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-16m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-16m.dts
@@ -35,9 +35,12 @@
 &eth1 {
 	status = "okay";
 
+	phy-handle = <&swphy0>;
+
 	nvmem-cells = <&macaddr_pridata_400 0>;
 	nvmem-cell-names = "mac-address";
 
+	/delete-node/ fixed-link;
 	gmac-config {
 		device = <&gmac>;
 		switch-phy-swap = <0>;

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-8m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-8m.dts
@@ -35,9 +35,12 @@
 &eth1 {
 	status = "okay";
 
+	phy-handle = <&swphy0>;
+
 	nvmem-cells = <&macaddr_pridata_400 0>;
 	nvmem-cell-names = "mac-address";
 
+	/delete-node/ fixed-link;
 	gmac-config {
 		device = <&gmac>;
 		switch-phy-swap = <0>;

--- a/target/linux/ath79/dts/ar9344_ruckus_zf7372.dts
+++ b/target/linux/ath79/dts/ar9344_ruckus_zf7372.dts
@@ -104,10 +104,12 @@
 
 &eth1 {
 	status = "okay";
+	phy-handle = <&swphy0>;
 
 	nvmem-cells = <&macaddr_board_data_66>;
 	nvmem-cell-names = "mac-address";
 
+	/delete-node/ fixed-link;
 	gmac-config {
 		device = <&gmac>;
 		switch-phy-swap = <0>;

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -283,6 +283,7 @@
 	clocks = <&pll ATH79_CLK_AHB>, <&pll ATH79_CLK_AHB>;
 	clock-names = "eth", "mdio";
 	phy-mode = "gmii";
+	builtin-switch;
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/dts/qca9531_comfast_cf-ew72.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-ew72.dts
@@ -138,8 +138,12 @@
 };
 
 &eth1 {
+	phy-handle = <&swphy0>;
+
 	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
+
+	/delete-node/ fixed-link;
 };
 
 &wdt {

--- a/target/linux/ath79/dts/qca9531_qxwlan_e600g.dtsi
+++ b/target/linux/ath79/dts/qca9531_qxwlan_e600g.dtsi
@@ -136,8 +136,12 @@
 };
 
 &eth1 {
+	phy-handle = <&swphy0>;
+
 	nvmem-cells = <&macaddr_pridata_400 0>;
 	nvmem-cell-names = "mac-address";
+
+	/delete-node/ fixed-link;
 };
 
 &wmac {

--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-map-2nd.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-map-2nd.dts
@@ -114,6 +114,15 @@
 	};
 };
 
+&swphy1 {
+	status = "okay";
+};
+
+&eth1 {
+	phy-handle = <&swphy1>;
+	/delete-node/ fixed-link;
+};
+
 &usb0 {
 	status = "okay";
 };

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -283,6 +283,7 @@
 	reset-names = "mac";
 
 	phy-mode = "gmii";
+	builtin-switch;
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -267,6 +267,12 @@
 				phy-mode = "mii";
 			};
 
+			swphy1: ethernet-phy@1 {
+				status = "disabled";
+				reg = <1>;
+				phy-mode = "mii";
+			};
+
 			swphy4: ethernet-phy@4 {
 				reg = <4>;
 				phy-mode = "mii";

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -324,6 +324,7 @@
 	compatible = "qca,qca9560-eth", "syscon";
 
 	phy-mode = "gmii";
+	builtin-switch;
 
 	resets = <&rst 13>;
 	reset-names = "mac";

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
@@ -160,6 +160,7 @@ struct ag71xx {
 	u16			rx_buf_size;
 	u8			rx_buf_offset;
 	u8			tx_hang_workaround:1;
+	u8			builtin_switch:1;
 
 	struct net_device	*dev;
 	struct platform_device  *pdev;

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -868,6 +868,7 @@ __ag71xx_link_adjust(struct ag71xx *ag, bool update)
 	u32 cfg2;
 	u32 ifctl;
 	u32 fifo5;
+	unsigned int speed;
 
 	if (!ag->link && update) {
 		ag71xx_hw_stop(ag);
@@ -883,7 +884,7 @@ __ag71xx_link_adjust(struct ag71xx *ag, bool update)
 
 	cfg2 = ag71xx_rr(ag, AG71XX_REG_MAC_CFG2);
 	cfg2 &= ~(MAC_CFG2_IF_1000 | MAC_CFG2_IF_10_100 | MAC_CFG2_FDX);
-	cfg2 |= (ag->duplex) ? MAC_CFG2_FDX : 0;
+	cfg2 |= (ag->duplex || ag->builtin_switch) ? MAC_CFG2_FDX : 0;
 
 	ifctl = ag71xx_rr(ag, AG71XX_REG_MAC_IFCTL);
 	ifctl &= ~(MAC_IFCTL_SPEED);
@@ -891,7 +892,11 @@ __ag71xx_link_adjust(struct ag71xx *ag, bool update)
 	fifo5 = ag71xx_rr(ag, AG71XX_REG_FIFO_CFG5);
 	fifo5 &= ~FIFO_CFG5_BM;
 
-	switch (ag->speed) {
+	speed = ag->speed;
+	if (ag->builtin_switch)
+		speed = SPEED_1000;
+
+	switch (speed) {
 	case SPEED_1000:
 		cfg2 |= MAC_CFG2_IF_1000;
 		fifo5 |= FIFO_CFG5_BM;
@@ -1567,6 +1572,9 @@ static int ag71xx_probe(struct platform_device *pdev)
 		dev_dbg(&pdev->dev, "failed to read pll-handle property\n");
 		ag->pllregmap = NULL;
 	}
+
+	if (of_property_read_bool(np, "builtin-switch"))
+		ag->builtin_switch = 1;
 
 	ag->mac_base = devm_ioremap(&pdev->dev, res->start,
 				    res->end - res->start + 1);


### PR DESCRIPTION
During development of support for Ruckus ZoneFlex 7372, I discovered that link state reporting for ports attached to built-in switches through GMAC1 of most Atheros SoCs is not possible on ath79 target. To allow for that, internal link parameters (1000FD) must be maintained regardless of actual PHY link parameters, even if the "fixed-link" node is removed from inside eth1 node, to be replaced by phy-handle pointing at one of built-in switch PHYs. 

To achieve that, a device tree property "builtin-switch" is added to the Ethernet controller node, taking an existing property in MDIO subnodes as an example, which causes the internal link to stay at 1Gbps/full-duplex, while the external link state and parameters of selected port is correctly reported to userspace. This way, two-port devices can be updated to allow reporting link state on both ports.  Ruckus ZF7372 in upcoming PR is an example of that. 

Compile and run tested on Ruckus ZF7372, as seen in #9972