### PR TITLE
ath79: support Ruckus ZoneFlex 7372 and ZoneFlex 7321

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -126,6 +126,7 @@ plasmacloud,pa300e)
 qihoo,c301)
 	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x10000" "0x10000"
 	;;
+ruckus,zf7321|\
 ruckus,zf7372)
 	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x40000" "0x10000"
 	;;

--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -126,6 +126,9 @@ plasmacloud,pa300e)
 qihoo,c301)
 	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x10000" "0x10000"
 	;;
+ruckus,zf7372)
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x40000" "0x10000"
+	;;
 sophos,ap15|\
 sophos,ap55|\
 sophos,ap55c|\

--- a/target/linux/ath79/dts/ar9342_ruckus_zf7321.dts
+++ b/target/linux/ath79/dts/ar9342_ruckus_zf7321.dts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar934x_ruckus_zf73xx.dtsi"
+
+/ {
+	model = "Ruckus ZoneFlex 7321[-U]";
+	compatible = "ruckus,zf7321", "qca,ar9342";
+
+	leds {
+		air-green {
+			label = "green:air";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		dir-green {
+			label = "green:dir";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		power_red: power-red {
+			label = "red:power";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		wlan2g-green {
+			label = "green:wlan2g";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0assoc";
+		};
+
+		wlan2g-yellow {
+			label = "yellow:wlan2g";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g-green {
+			label = "green:wlan5g";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0assoc";
+		};
+
+		wlan5g-yellow {
+			label = "yellow:wlan5g";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&eth0 {
+	nvmem-cells = <&macaddr_board_data_66>;
+};

--- a/target/linux/ath79/dts/ar9344_ruckus_zf7372.dts
+++ b/target/linux/ath79/dts/ar9344_ruckus_zf7372.dts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar934x_ruckus_zf73xx.dtsi"
+
+/ {
+	model = "Ruckus ZoneFlex 7352/7372[-E/-U]";
+	compatible = "ruckus,zf7372", "qca,ar9344";
+
+	leds {
+		air-green {
+			label = "green:air";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		air-yellow {
+			label = "yellow:air";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		dir-green {
+			label = "green:dir";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		eth1-green {
+			label = "green:eth1";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		power_red: power-red {
+			label = "red:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		wlan2g-green {
+			label = "green:wlan2g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0assoc";
+		};
+
+		wlan2g-yellow {
+			label = "yellow:wlan2g";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g-green {
+			label = "green:wlan5g";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1assoc";
+		};
+
+		wlan5g-yellow {
+			label = "yellow:wlan5g";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	beamforming-2g-spi {
+		compatible = "spi-gpio";
+		mosi-gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		sck-gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <0>;
+
+		beamforming-2g-gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			registers-number = <1>;
+			spi-max-frequency = <24000000>;
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	beamforming-5g-spi {
+		compatible = "spi-gpio";
+		mosi-gpios = <&ath9k 15 GPIO_ACTIVE_HIGH>;
+		sck-gpios = <&ath9k 14 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <0>;
+
+		beamforming-5g-gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			registers-number = <1>;
+			spi-max-frequency = <24000000>;
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+};
+
+&eth0 {
+	nvmem-cells = <&macaddr_board_data_6c>;
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_board_data_66>;
+	nvmem-cell-names = "mac-address";
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <0>;
+		switch-only-mode = <1>;
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,0033";
+		reg = <0x0000 0 0 0 0>;
+		gpio-controller;
+		#gpio-cells = <2>;
+
+		nvmem-cells = <&macaddr_board_data_76>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&board_data {
+	macaddr_board_data_6c: macaddr@6c {
+		reg = <0x6c 0x6>;
+	};
+
+	macaddr_board_data_76: macaddr@76 {
+		reg = <0x76 0x6>;
+	};
+};

--- a/target/linux/ath79/dts/ar934x_ruckus_zf73xx.dtsi
+++ b/target/linux/ath79/dts/ar934x_ruckus_zf73xx.dtsi
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	aliases {
+		led-boot = &power_green;
+		led-failsafe = &power_red;
+		led-running = &power_green;
+		led-upgrade = &power_red;
+	};
+
+	firmware-concat {
+		compatible = "mtd-concat";
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x1f00000>;
+				label = "firmware";
+				compatible = "openwrt,uimage", "denx,uimage";
+			};
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			label = "Reset button";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <50>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&enable_gpio_11>,
+			    <&enable_gpio_16>,
+			    <&enable_gpio_4>,
+			    <&clks_disable_pins>;
+
+		power_green: power-green {
+			label = "green:power";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		ruckus-himem@7ff0000 {
+			/* Ruckus Himem area used to control
+			 * redundant boot image selection
+			 */
+			compatible = "nvmem-rmem";
+			reg = <0x7ff0000 0x10000>;
+			no-map;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			fwconcat0: partition@40000 {
+				label = "fwconcat0";
+				reg = <0x040000 0xf00000>;
+			};
+
+			partition@f40000 {
+				compatible = "u-boot,env";
+				label = "u-boot-env";
+				reg = <0xf40000 0x040000>;
+			};
+
+			board_data: partition@f80000 {
+				label = "board-data";
+				reg = <0xf80000 0x080000>;
+				read-only;
+			};
+
+			fwconcat1: partition@1000000 {
+				label = "fwconcat1";
+				reg = <0x1000000 0x1000000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy: ethernet-phy@6 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <6>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	pll-data = <0x02000000 0x00000101 0x00001313>;
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy>;
+
+	nvmem-cell-names = "mac-address";
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-gmac0 = <1>;
+		rxdv-delay = <3>;
+		rxd-delay = <3>;
+	};
+};
+
+&pinmux {
+	clks_disable_pins: pinmux_clks_disable_pins {
+		pinctrl-single,bits = <0x40 0x0 0x20>;
+	};
+
+	enable_gpio_4: pinctrl_enable_gpio_4 {
+		pinctrl-single,bits = <0x4 0x0 0xff>;
+	};
+
+	enable_gpio_11: pinctrl_enable_gpio_11 {
+		pinctrl-single,bits = <0x8 0x0 0xff000000>;
+	};
+
+	enable_gpio_16: pinctrl_enable_gpio_16 {
+		pinctrl-single,bits = <0x10 0x0 0xff>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_board_data_60>, <&cal_board_data_41000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};
+
+&usb {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&board_data {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_board_data_60: macaddr@60 {
+		reg = <0x60 0x6>;
+	};
+
+	macaddr_board_data_66: macaddr@66 {
+		reg = <0x66 0x6>;
+	};
+
+	cal_board_data_41000: cal@41000 {
+		reg = <0x41000 0x440>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -324,6 +324,9 @@ qca,ap143-16m)
 qihoo,c301)
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
+ruckus,zf7372)
+	ucidef_set_led_switch "lan" "LAN" "green:eth1" "switch0" "0x02"
+	;;
 samsung,wam250)
 	ucidef_set_led_netdev "lan" "LAN" "white:lan" "eth0"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -131,6 +131,7 @@ ath79_setup_interfaces()
 	engenius,enstationac-v1|\
 	engenius,ews511ap|\
 	ocedo,ursus|\
+	ruckus,zf7372|\
 	ubnt,unifi-ap-outdoor-plus)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;
@@ -697,6 +698,10 @@ ath79_setup_macs()
 	rosinson,wr818)
 		wan_mac=$(mtd_get_mac_binary factory 0x0)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
+		;;
+	ruckus,zf7372)
+		lan_mac=$(mtd_get_mac_binary board-data 0x807E)
+		label_mac=$lan_mac
 		;;
 	sitecom,wlr-7100|\
 	sitecom,wlr-8100)

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -65,6 +65,7 @@ ath79_setup_interfaces()
 	pisen,ts-d084|\
 	pisen,wmb001n|\
 	pisen,wmm003n|\
+	ruckus,zf7321|\
 	siemens,ws-ap3610|\
 	sophos,ap15|\
 	sophos,ap55|\
@@ -699,6 +700,7 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_binary factory 0x0)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
 		;;
+	ruckus,zf7321|\
 	ruckus,zf7372)
 		lan_mac=$(mtd_get_mac_binary board-data 0x807E)
 		label_mac=$lan_mac

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2389,6 +2389,13 @@ define Device/ruckus_zf73xx_common
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
 endef
 
+define Device/ruckus_zf7321
+  $(Device/ruckus_zf73xx_common)
+  SOC := ar9342
+  DEVICE_MODEL := ZoneFlex 7321[-U]
+endef
+TARGET_DEVICES += ruckus_zf7321
+
 define Device/ruckus_zf7372
   $(Device/ruckus_zf73xx_common)
   SOC := ar9344

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2380,6 +2380,22 @@ define Device/rosinson_wr818
 endef
 TARGET_DEVICES += rosinson_wr818
 
+define Device/ruckus_zf73xx_common
+  DEVICE_VENDOR := Ruckus
+  DEVICE_PACKAGES := -swconfig kmod-usb2 kmod-usb-chipidea2
+  IMAGE_SIZE := 31744k
+  LOADER_TYPE := bin
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
+endef
+
+define Device/ruckus_zf7372
+  $(Device/ruckus_zf73xx_common)
+  SOC := ar9344
+  DEVICE_MODEL := ZoneFlex 7352/7372[-E/-U]
+endef
+TARGET_DEVICES += ruckus_zf7372
+
 define Device/samsung_wam250
   SOC := ar9344
   DEVICE_VENDOR := Samsung


### PR DESCRIPTION
Ruckus ZoneFlex 7372 is a dual-band, dual radio 802.11n 2x2 MIMO enterprise access
point.

Ruckus ZoneFlex 7321 is a dual-band, single radio 802.11n 2x2 MIMO enterprise access
point.

Hardware highligts:
ZoneFlex 7372:
- CPU: Atheros AR9344 SoC at 560 MHz
- RAM: 128MB DDR2
- Flash: 32MB SPI-NOR
- Wi-Fi 2.4GHz: AR9344 built-in 2x2 MIMO radio
- Wi-Fi 5Ghz: AR9582 2x2 MIMO radio
- Ethernet 1: single Gigabit Ethernet port through AR8035 gigabit PHY
- Ethernet 2: single Fast Ethernet port through AR9344 built-in switch
- PoE: input through Gigabit port
- Standalone 12V/1A power input
- USB: optional single USB 2.0 host port on some variants.

ZoneFlex 7321:
- CPU: Atheros AR9342 SoC at 533 MHz
- RAM: 64MB DDR2
- Flash: 32MB SPI-NOR
- Wi-Fi: AR9344 built-in dual-band 2x2 MIMO radio
- Ethernet: single Gigabit Ethernet port through AR8035 gigabit PHY
- PoE: input through Gigabit port
- Standalone 12V/1A power input
- USB: optional single USB 2.0 host port on some variants.

Serial console: 115200-8-N-1 on internal H1 header.

Installation:

0. Connect serial console to H1 header. Ensure the serial converter
   does not back-power the board, otherwise it will fail to boot.

1. Power-on the board. Then quickly connect serial converter to PC and
   hit Ctrl+C in the terminal to break boot sequence. If you're lucky,
   you'll enter U-boot shell. Then skip to point 3.

2. Allow the board to boot.  Press the reset button, so the board
   reboots into U-boot again and go back to point 1.

3. Boot the OpenWrt initramfs using TFTP. Replace IP addresses as needed:
```
   setenv serverip 192.168.1.2
   setenv ipaddr 192.168.1.1
   tftpboot 0x81000000 openwrt-ath79-generic-ruckus_zf7372-initramfs-kernel.bin
   bootm 0x81000000
```

4. (Optionally) back up contents of "firmware" partition
```
   ssh root@192.168.1.1 cat /dev/mtd1 > ruckus_zf7372_fw1_backup.bin
   ssh root@192.168.1.1 cat /dev/mtd5 > ruckus_zf7372_fw2_backup.bin
```
5. Set the "bootcmd" variable to disable the dual-boot feature of the
   system and ensure that uImage is loaded. This is critical step, and
   needs to be done only on initial installation:
```
   fw_setenv bootcmd "bootm 0x9f040000"
```

6. Copy over sysupgrade image, and perform actual installation:
```
   sysupgrade -n openwrt-ath79-generic-ruckus_zf7372-squashfs-sysupgrade.bin
```

Return to factory firmware:

1. Boot into OpenWrt initramfs as for initial installation.
2. Unset the "bootcmd" variable:
```
   fw_setenv bootcmd ""
```
3. Write factory images downloaded from manufacturer images into
   fwconcat0 and fwconcat1 MTD partitions, or restore backup you took
   before installation:
```
   mtd write ruckus_zf7372_fw1_backup.bin /dev/mtd1
   mtd write ruckus_zf7372_fw2_backup.bin /dev/mtd5
```
4. Reboot the system, it should load into factory firmware again.

Quirks and known issues:
- This is first device in ath79 target to support link state reporting
  on FE port attached trough the built-in switch.
- Flash layout is changed from the factory, to use both firmware image
  partitions for storage using mtd-concat, and uImage format is used to
  actually boot the system, which rules out the dual-boot capability.
- The stock firmware has dual-boot capability, which is not supported in
  OpenWrt by choice.
  It is controlled by data in the top 64kB of RAM which is unmapped,
  to avoid   the interference in the boot process and accidental
  switch to the inactive image, although boot script presence in
  form of "bootcmd" variable should prevent this entirely.
- U-boot disables JTAG when starting. To re-enable it, you need to
  execute the following command before booting:
  mw.l 1804006c 40
  And also you need to disable the reset button in device tree if you
  intend to debug Linux, because reset button on GPIO0 shares the TCK
  pin.
- On some versions of stock firmware, it is possible to obtain root shell,
  however not much is available in terms of debugging facitilies.
  1. Login to the rkscli
  2. Execute hidden command "Ruckus"
  3. Copy and paste ";/bin/sh;" including quotes. This is required only
     once, the payload will be stored in writable filesystem.
  4. Execute hidden command "!v54!". Press Enter leaving empty reply for
     "What's your chow?" prompt.
  5. Busybox shell shall open.
  Source: https://alephsecurity.com/vulns/aleph-2019014

This PR includes changes from RFC PR #9971, but can be updated to drop them if needed, so that PR can be handled separately.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>