### PR TITLE
realtek: add reset button and reboot fix for D-Link DGS-1210-28

### DIFF
--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-28.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-28.dts
@@ -6,6 +6,12 @@
 	compatible = "d-link,dgs-1210-28", "realtek,rtl838x-soc";
 	model = "D-Link DGS-1210-28";
 
+	gpio-restart {
+		compatible = "gpio-restart";
+		gpios = <&gpio1 34 GPIO_ACTIVE_LOW>;
+		open-source;
+	};
+
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;

--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-28.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-28.dts
@@ -5,6 +5,24 @@
 / {
 	compatible = "d-link,dgs-1210-28", "realtek,rtl838x-soc";
 	model = "D-Link DGS-1210-28";
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 33 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio1: rtl8231-gpio {
+		compatible = "realtek,rtl8231-gpio";
+		#gpio-cells = <2>;
+		gpio-controller;
+		indirect-access-bus-id = <0>;
+	};
 };
 
 &ethernet0 {


### PR DESCRIPTION
Tested in a DGS-1210-28 F3, both triggering failsafe and reboot.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>