### PR TITLE
mediatek: add support for Unifi 6 LR v2

### DIFF
--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-ubootmod.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "mt7622-ubnt-unifi-6-lr.dtsi"
+#include "mt7622-ubnt-unifi-6-lr-v1.dtsi"
 
 / {
 	model = "Ubiquiti UniFi 6 LR (U-Boot mod)";

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1-ubootmod.dts
@@ -3,7 +3,7 @@
 #include "mt7622-ubnt-unifi-6-lr-v1.dtsi"
 
 / {
-	model = "Ubiquiti UniFi 6 LR (U-Boot mod)";
+	model = "Ubiquiti UniFi 6 LR v1 (U-Boot mod)";
 	compatible = "ubnt,unifi-6-lr-ubootmod", "mediatek,mt7622";
 };
 

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1.dts
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1.dts
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "mt7622-ubnt-unifi-6-lr.dtsi"
+#include "mt7622-ubnt-unifi-6-lr-v1.dtsi"
 
 / {
-	model = "Ubiquiti UniFi 6 LR";
+	model = "Ubiquiti UniFi 6 LR v1";
 	compatible = "ubnt,unifi-6-lr", "mediatek,mt7622";
 };
 

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1.dtsi
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1.dtsi
@@ -1,0 +1,27 @@
+#include "mt7622-ubnt-unifi-6-lr.dtsi"
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+	status = "okay";
+
+	led-controller@30 {
+		compatible = "ubnt,ledbar";
+		reg = <0x30>;
+
+		enable-gpio = <&pio 59 0>;
+
+		red {
+			label = "red";
+		};
+
+		green {
+			label = "green";
+		};
+
+		led_blue: blue {
+			label = "blue";
+		};
+	};
+};
+

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v2-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v2-ubootmod.dts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7622-ubnt-unifi-6-lr-v2.dtsi"
+
+/ {
+	model = "Ubiquiti UniFi 6 LR v2 (U-Boot mod)";
+	compatible = "ubnt,unifi-6-lr-ubootmod-v2", "mediatek,mt7622";
+};
+
+&nor_partitions {
+	partition@0 {
+		label = "bl2";
+		reg = <0x0 0x20000>;
+	};
+
+	partition@20000 {
+		label = "fip";
+		reg = <0x20000 0xa0000>;
+	};
+
+	partition@c0000 {
+		label = "u-boot-env";
+		reg = <0xc0000 0x10000>;
+	};
+
+	factory: partition@d0000 {
+		label = "factory";
+		reg = <0xd0000 0x40000>;
+		read-only;
+	};
+
+	eeprom: partition@110000 {
+		label = "eeprom";
+		reg = <0x110000 0x10000>;
+		read-only;
+	};
+
+	partition@120000 {
+		label = "recovery";
+		reg = <0x120000 0xee0000>;
+	};
+
+	partition@1000000 {
+		compatible = "denx,fit";
+		label = "firmware";
+		reg = <0x1000000 0x3000000>;
+	};
+};
+
+&wmac {
+	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&macaddr_eeprom_0>;
+	nvmem-cell-names = "mac-address";
+	status = "okay";
+};
+
+&slot0 {
+	wifi@0,0 {
+		reg = <0x0 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x20000>;
+		nvmem-cells = <&macaddr_eeprom_6>;
+		nvmem-cell-names = "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_eeprom_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eeprom {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_eeprom_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+
+	macaddr_eeprom_6: macaddr@6 {
+		reg = <0x6 0x6>;
+	};
+};

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v2.dts
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v2.dts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7622-ubnt-unifi-6-lr-v2.dtsi"
+
+/ {
+	model = "Ubiquiti UniFi 6 LR v2";
+	compatible = "ubnt,unifi-6-lr-v2", "mediatek,mt7622";
+};
+
+&nor_partitions {
+	partition@0 {
+		label = "preloader";
+		reg = <0x0 0x40000>;
+	};
+
+	partition@40000 {
+		label = "atf";
+		reg = <0x40000 0x20000>;
+	};
+
+	partition@60000 {
+		label = "u-boot";
+		reg = <0x60000 0x60000>;
+	};
+
+	partition@c0000 {
+		label = "u-boot-env";
+		reg = <0xc0000 0x10000>;
+	};
+
+	factory: partition@d0000 {
+		label = "factory";
+		reg = <0xd0000 0x40000>;
+		read-only;
+	};
+
+	eeprom: partition@110000 {
+		label = "eeprom";
+		reg = <0x110000 0x10000>;
+		read-only;
+	};
+
+	partition@120000 {
+		label = "bs";
+		reg = <0x120000 0x10000>;
+	};
+
+	partition@130000 {
+		label = "cfg";
+		reg = <0x130000 0x100000>;
+		read-only;
+	};
+
+	partition@230000 {
+		compatible = "denx,fit";
+		label = "firmware";
+		reg = <0x230000 0x1ee0000>;
+	};
+
+	partition@2110000 {
+		label = "kernel1";
+		reg = <0x2110000 0x1ee0000>;
+	};
+};
+
+&wmac {
+	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&macaddr_eeprom_0>;
+	nvmem-cell-names = "mac-address";
+	status = "okay";
+};
+
+&slot0 {
+	wifi@0,0 {
+		reg = <0x0 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x20000>;
+		nvmem-cells = <&macaddr_eeprom_6>;
+		nvmem-cell-names = "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_eeprom_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eeprom {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_eeprom_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+
+	macaddr_eeprom_6: macaddr@6 {
+		reg = <0x6 0x6>;
+	};
+};

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v2.dtsi
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v2.dtsi
@@ -1,0 +1,26 @@
+#include "mt7622-ubnt-unifi-6-lr.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_white;
+		led-failsafe = &led_white;
+		led-running = &led_blue;
+		led-upgrade = &led_blue;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_white: dome_white {
+			label = "white:dome";
+			linux,default-trigger = "default-on";
+			gpios = <&pio 0x43 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_blue: dome_blue {
+			label = "blue:dome";
+			default-state = "off";
+			gpios = <&pio 0x44 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr.dtsi
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr.dtsi
@@ -217,31 +217,6 @@
 	/* MT7915 Bluetooth */
 };
 
-&i2c0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&i2c0_pins>;
-	status = "okay";
-
-	led-controller@30 {
-		compatible = "ubnt,ledbar";
-		reg = <0x30>;
-
-		enable-gpio = <&pio 59 0>;
-
-		red {
-			label = "red";
-		};
-
-		green {
-			label = "green";
-		};
-
-		led_blue: blue {
-			label = "blue";
-		};
-	};
-};
-
 &watchdog {
 	pinctrl-names = "default";
 	pinctrl-0 = <&watchdog_pins>;

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -253,11 +253,11 @@ define Device/ubnt_unifi-6-lr-v1
 endef
 TARGET_DEVICES += ubnt_unifi-6-lr-v1
 
-define Device/ubnt_unifi-6-lr-ubootmod
+define Device/ubnt_unifi-6-lr-v1-ubootmod
   DEVICE_VENDOR := Ubiquiti
   DEVICE_MODEL := UniFi 6 LR
-  DEVICE_VARIANT := U-Boot mod
-  DEVICE_DTS := mt7622-ubnt-unifi-6-lr-ubootmod
+  DEVICE_VARIANT := v1 U-Boot mod
+  DEVICE_DTS := mt7622-ubnt-unifi-6-lr-v1-ubootmod
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7915e kmod-leds-ubnt-ledbar
   KERNEL := kernel-bin | lzma
@@ -269,7 +269,7 @@ define Device/ubnt_unifi-6-lr-ubootmod
   ARTIFACT/preloader.bin := bl2 nor-2ddr
   ARTIFACT/bl31-uboot.fip := bl31-uboot ubnt_unifi-6-lr
 endef
-TARGET_DEVICES += ubnt_unifi-6-lr-ubootmod
+TARGET_DEVICES += ubnt_unifi-6-lr-v1-ubootmod
 
 define Device/xiaomi_redmi-router-ax6s
   DEVICE_VENDOR := Xiaomi

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -271,6 +271,35 @@ define Device/ubnt_unifi-6-lr-v1-ubootmod
 endef
 TARGET_DEVICES += ubnt_unifi-6-lr-v1-ubootmod
 
+define Device/ubnt_unifi-6-lr-v2
+  DEVICE_VENDOR := Ubiquiti
+  DEVICE_MODEL := UniFi 6 LR
+  DEVICE_VARIANT := v2
+  DEVICE_DTS_CONFIG := config@1
+  DEVICE_DTS := mt7622-ubnt-unifi-6-lr-v2
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e
+endef
+TARGET_DEVICES += ubnt_unifi-6-lr-v2
+
+define Device/ubnt_unifi-6-lr-v2-ubootmod
+  DEVICE_VENDOR := Ubiquiti
+  DEVICE_MODEL := UniFi 6 LR
+  DEVICE_VARIANT := v2 U-Boot mod
+  DEVICE_DTS := mt7622-ubnt-unifi-6-lr-v2-ubootmod
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e
+  KERNEL := kernel-bin | lzma
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGES := sysupgrade.itb
+  IMAGE/sysupgrade.itb := append-kernel | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | pad-rootfs | append-metadata
+  ARTIFACTS := preloader.bin bl31-uboot.fip
+  ARTIFACT/preloader.bin := bl2 nor-2ddr
+  ARTIFACT/bl31-uboot.fip := bl31-uboot ubnt_unifi-6-lr
+endef
+TARGET_DEVICES += ubnt_unifi-6-lr-v2-ubootmod
+
 define Device/xiaomi_redmi-router-ax6s
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := Redmi Router AX6S

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -242,15 +242,16 @@ define Device/totolink_a8000ru
 endef
 TARGET_DEVICES += totolink_a8000ru
 
-define Device/ubnt_unifi-6-lr
+define Device/ubnt_unifi-6-lr-v1
   DEVICE_VENDOR := Ubiquiti
   DEVICE_MODEL := UniFi 6 LR
+  DEVICE_VARIANT := v1
   DEVICE_DTS_CONFIG := config@1
-  DEVICE_DTS := mt7622-ubnt-unifi-6-lr
+  DEVICE_DTS := mt7622-ubnt-unifi-6-lr-v1
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7915e kmod-leds-ubnt-ledbar
 endef
-TARGET_DEVICES += ubnt_unifi-6-lr
+TARGET_DEVICES += ubnt_unifi-6-lr-v1
 
 define Device/ubnt_unifi-6-lr-ubootmod
   DEVICE_VENDOR := Ubiquiti


### PR DESCRIPTION
* Renames the current Unifi 6 LR target to v1
* Introduces a new target type Unifi 6 LR v2

v1 contains a RGB LED-bar, the v2 target only have two GPIO controlled LEDs one white and one blue.

Closes #9256
