### PR TITLE
ramips: add support for ASUS RP-AC87

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_rp-ac87.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rp-ac87.dts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "asus,rp-ac87", "mediatek,mt7621-soc";
+	model = "ASUS RP-AC87";
+
+	aliases {
+		led-boot = &led_wps;
+		led-failsafe = &led_wps;
+		led-running = &led_wps;
+		led-upgrade = &led_wps;
+		label-mac-device = &gmac0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wps: wps {
+			label = "green:wps";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		rssilow-wlan0 {
+			label = "green:rssilow-wlan0";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimedlow-wlan0 {
+			label = "green:rssimedlow-wlan0";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimed-wlan0 {
+			label = "green:rssimed-wlan0";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		rssihigh-wlan0 {
+			label = "green:rssihigh-wlan0";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		rssilow-wlan1 {
+			label = "green:rssilow-wlan1";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimedlow-wlan1 {
+			label = "green:rssimedlow-wlan1";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimed-wlan1 {
+			label = "green:rssimed-wlan1";
+			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+		};
+
+		rssihigh-wlan1 {
+			label = "green:rssihigh-wlan1";
+			gpios = <&gpio 48 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory_8004: macaddr@8004 {
+					reg = <0x8004 0x6>;
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_8004>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@4 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -175,6 +175,20 @@ define Device/asiarf_ap7621-nv1
 endef
 TARGET_DEVICES += asiarf_ap7621-nv1
 
+define Device/asus_rp-ac87
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := ASUS
+  DEVICE_MODEL := RP-AC87
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | check-size
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
+	check-size | append-metadata
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware rssileds
+endef
+TARGET_DEVICES += asus_rp-ac87
+
 define Device/asus_rt-ac57u
   $(Device/dsa-migration)
   DEVICE_VENDOR := ASUS

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -7,6 +7,18 @@ board=$(board_name)
 board_config_update
 
 case $board in
+asus,rp-ac87)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_rssimon "wlan1" "200000" "1"
+	ucidef_set_led_rssi "rssilow-wlan0" "RSSILOW" "green:rssilow-wlan0" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimedlow-wlan0" "RSSIMEDLOW" "green:rssimedlow-wlan0" "wlan0" "20" "100"
+	ucidef_set_led_rssi "rssimed-wlan0" "RSSIMED" "green:rssimed-wlan0" "wlan0" "40" "100"
+	ucidef_set_led_rssi "rssihigh-wlan0" "RSSIHIGH" "green:rssihigh-wlan0" "wlan0" "70" "100"
+	ucidef_set_led_rssi "rssilow-wlan1" "RSSILOW" "green:rssilow-wlan1" "wlan1" "1" "100"
+	ucidef_set_led_rssi "rssimedlow-wlan1" "RSSIMEDLOW" "green:rssimedlow-wlan1" "wlan1" "20" "100"
+	ucidef_set_led_rssi "rssimed-wlan1" "RSSIMED" "green:rssimed-wlan1" "wlan1" "40" "100"
+	ucidef_set_led_rssi "rssihigh-wlan1" "RSSIHIGH" "green:rssihigh-wlan1" "wlan1" "70" "100"
+	;;
 asus,rt-n56u-b1)
 	ucidef_set_led_netdev "lan" "LAN link" "blue:lan" "br-lan"
 	ucidef_set_led_netdev "wan" "WAN link" "blue:wan" "wan"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -9,6 +9,7 @@ ramips_setup_interfaces()
 
 	case $board in
 	ampedwireless,ally-00x19k|\
+	asus,rp-ac87|\
 	edimax,re23s|\
 	mikrotik,routerboard-m11g|\
 	netgear,ex6150|\


### PR DESCRIPTION
Asus RP-AC87 ac2600 Repeater
2.4GHz 800Mbps
5GHz 1733Mbps

Hardware specifications:
SoC: MT7621A 2 cores 4 threads @880MHz
WiFi2G: MT7615E 2G 4x4 b/g/n
Wifi5G: MT7615E 5G 4x4 n/ac
DRAM: 128MB DDR3 @1200MHz
Flash: 16MB MX25L12805D SPI-NOR
LAN/WAN: MT7530 1x1000M

MAC addresses as verified by OEM firmware:
use       address   source
Lan/W5G   *:B0      factory 0x8004 (label)
W2G       *:B4      factory 0x0

Installation:

Asus windows recovery tool:
 - install the Asus firmware restoration utility
 - unplug the router, hold the reset button while powering it on
 - release when the power LED flashes slowly
 - specify a static IP on your computer:
     IP address: 192.168.1.75
     Subnet mask 255.255.255.0
 - Start the Asus firmware restoration utility, specify the factory image
    and press upload
 - Do not power off the device after OpenWrt has booted until the LED flashing.

TFTP Recovery method:
 - set computer to a static ip, 192.168.1.2
 - connect computer to the LAN 1 port of the router
 - hold the reset button while powering on the router for a few seconds
 - send firmware image using a tftp client; i.e from linux:
 $ tftp
 tftp> binary
 tftp> connect 192.168.1.1
 tftp> put factory.bin
 tftp> quit

Signed-off-by: Tamas Balogh <tamasbalogh@hotmail.com>
