### PR TITLE
ath79: fix network initialization of NanoBeam M5

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -95,6 +95,7 @@ ath79_setup_interfaces()
 	ubnt,litebeam-ac-gen2|\
 	ubnt,nanobeam-ac|\
 	ubnt,nanobeam-ac-xc|\
+	ubnt,nanobeam-m5-xw|\
 	ubnt,nanobridge-m|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,nanostation-loco-m|\


### PR DESCRIPTION
Initialize eth0 as lan interface like all other ath79 single port devices.

Fixes: 4cd3ff8a7973 ("ath79: add support for Ubiquiti NanoBeam M5")

**Only compile tested!** Not sure why it is missing. @blocktrron @AiyionPrime ?