### PR TITLE
uboot-rockchip: drop CONFIG_IDENT_STRING

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -92,7 +92,6 @@ ifneq ($(OF_PLATDATA),)
 endif
 
 	$(SED) 's#CONFIG_MKIMAGE_DTC_PATH=.*#CONFIG_MKIMAGE_DTC_PATH="$(PKG_BUILD_DIR)/scripts/dtc/dtc"#g' $(PKG_BUILD_DIR)/.config
-	echo 'CONFIG_IDENT_STRING=" OpenWrt"' >> $(PKG_BUILD_DIR)/.config
 endef
 
 define Build/InstallDev


### PR DESCRIPTION
This row is no longer necessary as it was replaced by LOCALVERSION in
uboot.mk, which explicitly sets OpenWrt version to all U-boot packages accross
OpenWrt. [1]

[1] https://github.com/openwrt/openwrt/commit/d6aa9d9e071d9f23ed26f5142991bc66aefe20f5
