### PR TITLE
mpc85xx: enable NAND support for all subtargets

### DIFF
--- a/target/linux/mpc85xx/Makefile
+++ b/target/linux/mpc85xx/Makefile
@@ -8,7 +8,7 @@ ARCH:=powerpc
 BOARD:=mpc85xx
 BOARDNAME:=Freescale MPC85xx
 CPU_TYPE:=8540
-FEATURES:=squashfs ramdisk
+FEATURES:=squashfs ramdisk nand
 SUBTARGETS:=p1010 p1020 p2020
 
 KERNEL_PATCHVER:=5.10

--- a/target/linux/mpc85xx/p1010/target.mk
+++ b/target/linux/mpc85xx/p1010/target.mk
@@ -1,5 +1,4 @@
 BOARDNAME:=P1010
-FEATURES+=nand
 KERNELNAME:=simpleImage.tl-wdr4900-v1
 
 define Target/Description

--- a/target/linux/mpc85xx/p1020/target.mk
+++ b/target/linux/mpc85xx/p1020/target.mk
@@ -1,5 +1,4 @@
 BOARDNAME:=P1020
-FEATURES+=nand
 
 define Target/Description
 	Build firmware images for Freescale P1020 based boards.


### PR DESCRIPTION
In subtarget p2020, there wasn't enabled nand support, and because of
that there weren't available tools from mtd-utils package, which has
utilities for NAND flash memory even though reference board, which
is the only currently supported device in p2020 subtarget has NAND [1].

All subtargets in mpc85xx has already enabled nand support, let's do it
globally.

[1] https://www.nxp.com/design/qoriq-developer-resources/p2020-reference-design-board:P2020RDB

cc: @CHKDSK88, who added support for the reference board, I tested this on Turris 1.1 router, which has Freescale P2020 procesor, but this router is not supported in OpenWrt, yet.