### PR TITLE
octeon: add SUPPORTED_DEVICES to er/erlite

### DIFF
--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -48,6 +48,7 @@ define Device/ubnt_edgerouter
   DEVICE_MODEL := EdgeRouter
   BOARD_NAME := er
   CMDLINE := $(ER_CMDLINE)
+  SUPPORTED_DEVICES += er
 endef
 TARGET_DEVICES += ubnt_edgerouter
 
@@ -79,6 +80,7 @@ define Device/ubnt_edgerouter-lite
   DEVICE_MODEL := EdgeRouter Lite
   BOARD_NAME := erlite
   CMDLINE := $(ERLITE_CMDLINE)
+  SUPPORTED_DEVICES += erlite
 endef
 TARGET_DEVICES += ubnt_edgerouter-lite
 


### PR DESCRIPTION
Using the BOARD_NAME variable results for both er and erlite devices to
identify themselfs as `er` and `erlite` (via `ubus call system board`).

This is problematic when devices search for firmware upgrades since the
OpenWrt profile is actually called `ubnt_edgerouter` and
`ubnt_edgerouter-lite`.

By adding the `SUPPORTED_DEVICE` a mapping is created to point devices
called `er` or `erlite` to the corresponding profile.

FIXES: https://github.com/openwrt/asu/issues/348

Signed-off-by: Paul Spooren <mail@aparcar.org>