### PR TITLE
464xlat: delete SNATed conntracks on interface teardown

### DIFF
--- a/package/network/ipv6/464xlat/files/464xlat.sh
+++ b/package/network/ipv6/464xlat/files/464xlat.sh
@@ -98,6 +98,9 @@ proto_464xlat_teardown() {
 		ip -6 rule del from all lookup local
 		ip -6 rule add from all lookup local pref 0
 	fi
+
+	# Kill conntracks SNATed to 192.0.0.1
+	echo 192.0.0.1 > /proc/net/nf_conntrack
 }
 
 proto_464xlat_init_config() {


### PR DESCRIPTION
Existing conntracks will continue to be SNATed to 192.0.0.1 even after
464xlat interface gets teared down. To prevent this, matching
conntracks must be killed.

Signed-off-by: Alin Nastac <alin.nastac@gmail.com>

