### PR TITLE
mvebu: add support SolidRun ClearFog GT 8K

### DIFF
--- a/target/linux/mvebu/cortexa72/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/cortexa72/base-files/etc/board.d/02_network
@@ -29,6 +29,9 @@ marvell,armada8040-db)
 marvell,armada7040-db)
 	ucidef_set_interfaces_lan_wan "eth0 eth2" "eth1"
 	;;
+marvell,armada8040-clearfog-gt-8k)
+	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 eth2" "eth0 eth1"
+	;;
 *)
 	ucidef_set_interface_lan "eth0"
 	;;

--- a/target/linux/mvebu/cortexa72/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/cortexa72/base-files/lib/upgrade/platform.sh
@@ -13,7 +13,8 @@ platform_check_image() {
 	iei,puzzle-m901|\
 	iei,puzzle-m902|\
 	marvell,armada8040-mcbin-doubleshot|\
-	marvell,armada8040-mcbin-singleshot)
+	marvell,armada8040-mcbin-singleshot|\
+	marvell,armada8040-clearfog-gt-8k)
 		legacy_sdcard_check_image "$1"
 		;;
 	*)
@@ -30,7 +31,8 @@ platform_do_upgrade() {
 		;;
 	globalscale,mochabin|\
 	marvell,armada8040-mcbin-doubleshot|\
-	marvell,armada8040-mcbin-singleshot)
+	marvell,armada8040-mcbin-singleshot|\
+	marvell,armada8040-clearfog-gt-8k)
 		legacy_sdcard_do_upgrade "$1"
 		;;
 	*)
@@ -44,7 +46,8 @@ platform_copy_config() {
 	iei,puzzle-m901|\
 	iei,puzzle-m902|\
 	marvell,armada8040-mcbin-doubleshot|\
-	marvell,armada8040-mcbin-singleshot)
+	marvell,armada8040-mcbin-singleshot|\
+	marvell,armada8040-clearfog-gt-8k)
 		legacy_sdcard_copy_config
 		;;
 	esac

--- a/target/linux/mvebu/image/cortexa72.mk
+++ b/target/linux/mvebu/image/cortexa72.mk
@@ -52,6 +52,17 @@ define Device/marvell_macchiatobin-singleshot
 endef
 TARGET_DEVICES += marvell_macchiatobin-singleshot
 
+define Device/marvell_clearfog-gt-8k
+  $(call Device/Default-arm64)
+  DEVICE_VENDOR := SolidRun
+  DEVICE_MODEL := Clearfog
+  DEVICE_VARIANT := GT-8K
+  DEVICE_PACKAGES += kmod-i2c-mux-pca954x kmod-crypto-hw-safexcel
+  DEVICE_DTS := armada-8040-clearfog-gt-8k
+  SUPPORTED_DEVICES := marvell,armada8040-clearfog-gt-8k
+endef
+TARGET_DEVICES += marvell_clearfog-gt-8k
+
 define Device/iei_puzzle-m901
   $(call Device/Default-arm64)
   DEVICE_VENDOR := iEi


### PR DESCRIPTION
The device tree file for this board is upstream. This commit adds the board to the build system. 
This board has a marvel 88E6141 which also uses the DSA subsystem.

This work was initially done by skeletor and discussed in the openwrt [forum](https://forum.openwrt.org/t/support-for-clearfog-gt-8k/36845/18). 

This is my first PR to openwrt so apologies if I am missing something obvious. 

I expect this patch series to change based on some questions I have: 
1. The device tree (https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/boot/dts/marvell/armada-8040-clearfog-gt-8k.dts#n535) file lists eth2 as what I think of as the management port of the switch chip. In this PR `eth0` is listed in `/etc/config/network` for the port in `br-lan`. I think it should be eth2
2. I would like to know if there are any other device packages I should be adding
3. In my environment I would like to use the mSATA port for my root filesystem. which I think would need a modification to the uboot boot file, can someone assist me with that? 

Signed-off-by: Logan Blyth mr.bo.jangles3@gmail.com