### PR TITLE
wolfssl: make WOLFSSL_HAS_OPENVPN default to y

### DIFF
--- a/package/libs/wolfssl/Config.in
+++ b/package/libs/wolfssl/Config.in
@@ -53,7 +53,7 @@ config WOLFSSL_HAS_ECC25519
 
 config WOLFSSL_HAS_OPENVPN
 	bool "Include OpenVPN support"
-	default n
+	default y
 
 config WOLFSSL_ALT_NAMES
 	bool "Include SAN (Subject Alternative Name) support"


### PR DESCRIPTION
Openvpn forces CONFIG_WOLFSSL_HAS_OPENVPN=y.  When the phase1 bots build
the now non-shared package, openvpn will not be selected, and WolfSSL
will be built without it.  Then phase2 bots have CONFIG_ALL=y, which
will select openvpn and force CONFIG_WOLFSSL_HAS_OPENVPN=y.  This
changes the version hash, causing dependency failures, as shared
packages expect the phase2 hash.

Fixes: #9738

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>