### PR TITLE
tool:xz enable shared

### DIFF
--- a/tools/xz/Makefile
+++ b/tools/xz/Makefile
@@ -24,7 +24,7 @@ HOSTCXX := $(HOSTCXX_NOCACHE)
 
 HOST_CONFIGURE_ARGS += \
 	--enable-static=yes \
-	--enable-shared=no \
+	--enable-shared=yes \
 	--disable-doc \
 	--disable-nls \
 	--with-pic


### PR DESCRIPTION
xz library missing when compile on macOS Monterey 
Signed-off-by: doorxp <doorxp@msn.com>
