### PR TITLE
prereq-build: add additional git detection

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -177,7 +177,8 @@ $(eval $(call TestHostCommand,python3-distutils, \
 	$(STAGING_DIR_HOST)/bin/python3 -c 'import distutils'))
 
 $(eval $(call SetupHostCommand,git,Please install Git (git-core) >= 1.7.12.2, \
-	git --exec-path | xargs -I % -- grep -q -- --recursive %/git-submodule))
+	git --exec-path | xargs -I % -- grep -q -- --recursive %/git-submodule, \
+	git submodule --help | grep -- --recursive))
 
 $(eval $(call SetupHostCommand,file,Please install the 'file' package, \
 	file --version 2>&1 | grep file))


### PR DESCRIPTION
With some OS (Guix) the git submodule command is wrapped in
a script. Current logic parse the git submodule script directly.
If it's wrapped the prereq check wrongly fails while 'git submodule
--recursive' is actually available.
Add an additional check that try to directly use the 'git submodule'
command to check if the prereq is satisfied.

Fixes: https://github.com/openwrt/openwrt/issues/9986
Reported-by: Attila Lendvai <attila@lendvai.name>
Suggested-by: Attila Lendvai <attila@lendvai.name>
Signed-off-by: Christian 'Ansuel' Marangi <ansuelsmth@gmail.com>