### PR TITLE
[21.02] openssl: bump to 1.1.1o

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.1.1
-PKG_BUGFIX:=n
+PKG_BUGFIX:=o
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
@@ -26,7 +26,7 @@ PKG_SOURCE_URL:= \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/old/$(PKG_BASE)/
 
-PKG_HASH:=40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a
+PKG_HASH:=9384a2b0570dd80358841464677115df785edb941c71211f75076d72fe6b438f
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE

--- a/package/libs/openssl/patches/430-e_devcrypto-make-the-dev-crypto-engine-dynamic.patch
+++ b/package/libs/openssl/patches/430-e_devcrypto-make-the-dev-crypto-engine-dynamic.patch
@@ -23,7 +23,7 @@ diff --git a/crypto/init.c b/crypto/init.c
 index 1b0d523bea..ee3e2eb075 100644
 --- a/crypto/init.c
 +++ b/crypto/init.c
-@@ -329,18 +329,6 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_engine_openssl)
+@@ -328,18 +328,6 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_engine_openssl)
      engine_load_openssl_int();
      return 1;
  }
@@ -42,7 +42,7 @@ index 1b0d523bea..ee3e2eb075 100644
  
  # ifndef OPENSSL_NO_RDRAND
  static CRYPTO_ONCE engine_rdrand = CRYPTO_ONCE_STATIC_INIT;
-@@ -365,6 +353,18 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_engine_dynamic)
+@@ -364,6 +352,18 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_engine_dynamic)
      return 1;
  }
  # ifndef OPENSSL_NO_STATIC_ENGINE
@@ -61,7 +61,7 @@ index 1b0d523bea..ee3e2eb075 100644
  #  if !defined(OPENSSL_NO_HW) && !defined(OPENSSL_NO_HW_PADLOCK)
  static CRYPTO_ONCE engine_padlock = CRYPTO_ONCE_STATIC_INIT;
  DEFINE_RUN_ONCE_STATIC(ossl_init_engine_padlock)
-@@ -713,11 +713,6 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
+@@ -704,11 +704,6 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
      if ((opts & OPENSSL_INIT_ENGINE_OPENSSL)
              && !RUN_ONCE(&engine_openssl, ossl_init_engine_openssl))
          return 0;
@@ -73,7 +73,7 @@ index 1b0d523bea..ee3e2eb075 100644
  # ifndef OPENSSL_NO_RDRAND
      if ((opts & OPENSSL_INIT_ENGINE_RDRAND)
              && !RUN_ONCE(&engine_rdrand, ossl_init_engine_rdrand))
-@@ -727,6 +722,11 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
+@@ -718,6 +713,11 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
              && !RUN_ONCE(&engine_dynamic, ossl_init_engine_dynamic))
          return 0;
  # ifndef OPENSSL_NO_STATIC_ENGINE


### PR DESCRIPTION
Fixes: https://github.com/openwrt/openwrt/commit/7a5ddc0d06895bde7538d78c8dad2c863d70f946#commitcomment-75462000

Backport of https://github.com/openwrt/openwrt/pull/9866

```
This release comes with a security fix related to c_rehash.  OpenWrt
does not ship or use it, so it was not affected by the bug.

There is a fix for a possible crash in ERR_load_strings() when
configured with no-err, which OpenWrt does by default.
```