### PR TITLE
ipq40xx: Add support for Teltonika RUTX11

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -37,7 +37,8 @@ ipq40xx_setup_interfaces()
 		ucidef_set_interface_lan "eth0"
 		;;
 	aruba,ap-303h|\
-	teltonika,rutx10)
+	teltonika,rutx10|\
+	teltonika,rutx11)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		ucidef_add_switch "switch0" \
 			"0u@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "0u@eth1" "5:wan"

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -127,6 +127,10 @@ case "$FIRMWARE" in
 		caldata_extract_mmc "0:ART" 0x1000 0x2f20
 		ath10k_patch_mac $(mmc_get_mac_binary ARTMTD 0x0)
 		;;
+	teltonika,rutx11)
+		caldata_extract "0:ART" 0x1000 0x2f20
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary "0:CONFIG" 0x0) 2)
+		;;
 	zyxel,nbg6617 |\
 	zyxel,wre6606)
 		caldata_extract "ART" 0x1000 0x2f20
@@ -207,6 +211,10 @@ case "$FIRMWARE" in
 	netgear,srs60)
 		caldata_extract_mmc "0:ART" 0x5000 0x2f20
 		ath10k_patch_mac $(mmc_get_mac_binary ARTMTD 0xc)
+		;;
+	teltonika,rutx11)
+		caldata_extract "0:ART" 0x5000 0x2f20
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary "0:CONFIG" 0x0) 3)
 		;;
 	zyxel,nbg6617 |\
 	zyxel,wre6606)

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -193,6 +193,7 @@ platform_do_upgrade() {
 		platform_do_upgrade_dualboot_datachk "$1"
 		;;
 	teltonika,rutx10 |\
+	teltonika,rutx11 |\
 	zte,mf286d)
 		CI_UBIPART="rootfs"
 		nand_do_upgrade "$1"

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-rutx11.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-rutx11.dts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4018-rutx.dtsi"
+
+/ {
+	model = "Teltonika RUTX11";
+	compatible = "teltonika,rutx11";
+	
+	aliases {
+		led-boot = &led_rssi;
+		led-failsafe = &led_rssi;
+		led-upgrade = &led_rssi;
+	};
+
+	soc {
+		
+		usb3: usb3@8af8800 {
+			dwc3@8a00000 {
+				snps,dis_u2_susphy_quirk;
+				snps,dis_u3_susphy_quirk;
+			};
+		};
+
+		usb2: usb2@60f8800 {
+			dwc3@6000000 {
+				snps,dis_u2_susphy_quirk;
+			};
+		};
+
+		gpio-export {
+			compatible = "gpio-export";
+			#size-cells = <0>;
+
+			gpio_modem_reset {
+				gpio-export,name = "modem_reset";
+				gpio-export,output = <0>;
+				gpios = <&stm32_io 21 GPIO_ACTIVE_HIGH>;
+			};
+
+			gpio_modem_power {
+				gpio-export,name = "modem_power";
+				gpio-export,output = <0>;
+				gpios = <&stm32_io 20 GPIO_ACTIVE_HIGH>;
+			};
+
+			gpio_modem2_reset {
+				gpio-export,name = "modem2_reset";
+				gpio-export,output = <0>;
+				gpios = <&stm32_io 13 GPIO_ACTIVE_HIGH>;
+			};
+
+			gpio_modem2_power {
+				gpio-export,name = "modem2_power";
+				gpio-export,output = <0>;
+				gpios = <&stm32_io 14 GPIO_ACTIVE_HIGH>;
+			};
+
+			gpio_sim_select {
+				gpio-export,name = "sim_sel";
+				gpio-export,output = <1>;
+				gpios = <&stm32_io 22 GPIO_ACTIVE_LOW>;
+			};
+		};
+
+		leds {
+			compatible = "gpio-leds";
+
+			wlan2g {
+				label = "green:wlan2g";
+				gpios = <&stm32_io 19 GPIO_ACTIVE_HIGH>;
+				linux,default-trigger = "phy0tpt";
+			};
+
+			wlan5g {
+				label = "green:wlan5g";
+				gpios = <&stm32_io 18 GPIO_ACTIVE_HIGH>;
+				linux,default-trigger = "phy1tpt";
+			};
+
+			sim1 {
+				label = "green:sim1";
+				gpios = <&stm32_io 0 GPIO_ACTIVE_HIGH>;
+			};
+
+			sim2 {
+				label = "green:sim2";
+				gpios = <&stm32_io 1 GPIO_ACTIVE_HIGH>;
+			};
+
+			wanwifi {
+				label = "green:wanwifi";
+				gpios = <&stm32_io 3 GPIO_ACTIVE_HIGH>;
+			};
+
+			waneth {
+				label = "green:waneth";
+				gpios = <&stm32_io 2 GPIO_ACTIVE_HIGH>;
+			};
+
+			wan2g {
+				label = "green:wan2g";
+				gpios = <&stm32_io 4 GPIO_ACTIVE_HIGH>;
+			};
+
+			wan3g {
+				label = "green:wan3g";
+				gpios = <&stm32_io 5 GPIO_ACTIVE_HIGH>;
+			};
+
+			wan4g {
+				label = "green:wan4g";
+				gpios = <&stm32_io 6 GPIO_ACTIVE_HIGH>;
+			};
+
+			led_rssi: rssilow {
+				label = "green:rssilow";
+				gpios = <&stm32_io 7 GPIO_ACTIVE_HIGH>;
+			};
+
+			rssimediumlow {
+				label = "green:rssimediumlow";
+				gpios = <&stm32_io 8 GPIO_ACTIVE_HIGH>;
+			};
+
+			rssimedium {
+				label = "green:rssimedium";
+				gpios = <&stm32_io 9 GPIO_ACTIVE_HIGH>;
+			};
+
+			rssimediumhigh {
+				label = "green:rssimediumhigh";
+				gpios = <&stm32_io 10 GPIO_ACTIVE_HIGH>;
+			};
+
+			rssihigh {
+				label = "green:rssihigh";
+				gpios = <&stm32_io 11 GPIO_ACTIVE_HIGH>;
+				panic-indicator;
+			};
+		};
+	};
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -979,6 +979,22 @@ define Device/teltonika_rutx10
 endef
 TARGET_DEVICES += teltonika_rutx10
 
+define Device/teltonika_rutx11
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Teltonika
+	DEVICE_MODEL := RUTX11
+	SOC := qcom-ipq4018
+	DEVICE_DTS_CONFIG := config@5
+	KERNEL_INSTALL := 1
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	FILESYSTEMS := squashfs
+	IMAGE/nand-factory.ubi := append-ubi | qsdk-ipq-factory-nand | append-rutx-metadata
+	DEVICE_PACKAGES := ipq-wifi-teltonika_rutx kmod-bluetooth
+endef
+TARGET_DEVICES += teltonika_rutx11
+
 define Device/tel_x1pro
 	$(call Device/FitImage)
 	DEVICE_VENDOR := Telco

--- a/target/linux/ipq40xx/patches-5.10/901-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq40xx/patches-5.10/901-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -903,11 +903,77 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -903,11 +903,78 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8074-dragonboard.dtb \
  	qcom-apq8084-ifc6540.dtb \
  	qcom-apq8084-mtp.dtb \
@@ -39,6 +39,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq4018-pa1200.dtb \
 +	qcom-ipq4018-rt-ac58u.dtb \
 +	qcom-ipq4018-rutx10.dtb \
++ 	qcom-ipq4018-rutx11.dtb \
 +	qcom-ipq4018-wac510.dtb \
 +	qcom-ipq4018-whw01-v1.dtb \
 +	qcom-ipq4018-wre6606.dtb \

--- a/target/linux/ipq40xx/patches-5.15/901-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq40xx/patches-5.15/901-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -951,11 +951,76 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -951,11 +951,77 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4018-ap120c-ac.dtb \
  	qcom-ipq4018-ap120c-ac-bit.dtb \
  	qcom-ipq4018-jalapeno.dtb \
@@ -38,6 +38,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq4018-pa1200.dtb \
 +	qcom-ipq4018-rt-ac58u.dtb \
 +	qcom-ipq4018-rutx10.dtb \
++ 	qcom-ipq4018-rutx11.dtb \
 +	qcom-ipq4018-wac510.dtb \
 +	qcom-ipq4018-whw01-v1.dtb \
 +	qcom-ipq4018-wre6606.dtb \


### PR DESCRIPTION
ipq40xx: Add support for Teltonika RUTX11

This patch adds support for Teltonika RUTX11. It's an industrial DIN rail router, with 4 ethernet
ports, 2.4G/5G dualband WiFi, Bluetooth, LTE modem with SIM switch capabilities, USB 2.0 port
and two GPIOs.

This device is very similar to RUTX10, with main difference of having a 2 SIM LTE modem.

See https://teltonika-networks.com/product/rutx11/ for more info.

Hardware:
	SoC:                 Qualcomm IPQ4018
	RAM:                 256MB DDR3
	SPI Flash 1:         XTX XT25F128B (16MB, NOR)
	SPI Flash 2:         XTX XT26G02AWS (256MB, NAND)
	Ethernet:            Built-in IPQ4018 (SoC, QCA8075), 4x 10/100/1000 ports
	WiFi 1:              Qualcomm QCA4019 IEEE 802.11b/g/n
	Wifi 2:              Qualcomm QCA4019 IEEE 802.11a/n/ac
	USB Hub:             Genesys Logic GL852GT
	Bluetooth:           Qualcomm CSR8510 (A10U)
	LED/GPIO controller: STM32F030 with custom firmware
	Buttons:             Reset button
	Leds:                Power (green, cannot be controlled)
                             WiFi 2.4G activity (green)
                             WiFi 5G activity (green)
                             SIM 1 insert status(green)
		             SIM 2 insert status(green)
			     WWAN WiFi (green)
			     WWAN Ethernet (green)
			     Mobile 3g (green)
			     Mobile 4g (green)
		             Mobile level 1 (green)
			     Mobile level 2 (green)
			     Mobile level 3 (green)
			     Mobile level 4 (green)
			     Mobile level 5 (green)

LED's and LTE controlling GPIO's are driven by external STM32 chip, which needs a separate kernel
driver. It can be extracted from official Teltonika GPL sources, or from a following feed:
https://github.com/0xFelix/teltonika-rutx-openwrt

Software can be flashed two ways - OEM web interface or u-boot web recovery.

Flashing with OEM web interface:
1. Log into the router web interface (stock address is 192.168.1.1)
2. Navigate to System->Firmware
3. Set "Keep settings" to off
4. Upload openwrt-ipq40xx-generic-teltonika_rutx11-squashfs-nand-factory.ubi
5. Wait until upgrade completes

Flashing with u-boot web recovery:
1. Set PC static ip to 192.168.1.2, gateway to 192.168.1.1
2. Remove power cable and push the reset button
3. Insert power cable with reset button still pressed
4. After 5 seconds release the button and open web interface at 192.168.1.1
(Sometimes cache persists, so open private browsing)
5. Upload openwrt-ipq40xx-generic-teltonika_rutx11-squashfs-nand-factory.ubi
6. Wait until upgrade completes

Note: Mobile is work in progress.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Signed-off-by: Kasparas Elzbutas <elzkas@gmail.com>