### PR TITLE
ramips: decrease SPI frequency for Phicomm K2P

### DIFF
--- a/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
+++ b/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
@@ -50,7 +50,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
+++ b/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
@@ -51,7 +51,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <50000000>;
-		m25p,fast-read;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
Some K2P comes with the worse boards with GD25Q128 (may be A2), which only works with 50MHz frequency and less. Reduce spi frequency so that these routers can boot.