### PR TITLE
packages/base-files: Eliminate firstboot overlay race

### DIFF
--- a/package/base-files/files/lib/preinit/80_mount_root
+++ b/package/base-files/files/lib/preinit/80_mount_root
@@ -30,6 +30,8 @@ do_mount_root() {
 		# Prevent configuration corruption on a power loss
 		sync
 	}
+	mount_root done
+	sync
 }
 
 [ "$INITRAMFS" = "1" ] || boot_hook_add preinit_main do_mount_root


### PR DESCRIPTION
Hello!  It's been a little while since I've submitted an OpenWRT patch.  This patch increases time required for firstboot by a non-trivial amount but closes a race condition where data potentially can fall into a bit bucket.

Using tempfs as an overlay upon first boot is a nice way to speed it up,
but it is inherently racy. This is because we don't have control over
what processes will be started in the processing of /etc/rc.d/S* and
these processes could have open files in the tempfs overlay.

Thus, when /etc/rc.d/S95done is run, and runs `mount_root done` where
jffs2_switch() [1] is called, it copies the files in /tmp/root/upper,
switches the filesystem and then copies the files again to "try hard to
be in sync". While this certainly increases the changes of being in
sync, it cannot guarantee it because files can still be open and
continue to be modified. A process may have writes pending in it's
process space that are buffered and not yet flushed to the file system,
etc.

This patch is an intermediate solution that eliminates the race and
provides integrity guarantee.

[1] https://git.openwrt.org/?p=project/fstools.git;a=blob;f=libfstools/overlay.c;h=67903372d567602cac20fbab0fdc64cbabc1acde;hb=93369be040612c906bcbb1631f44a92fa4122d24#l316

Signed-off-by: Daniel Santos <daniel@gsat.us>
