### PR TITLE
ramips: mt7620: add support for ZyXEL LTE3302-M432

### DIFF
--- a/target/linux/ramips/dts/mt7620n_zyxel_lte-3302-m432.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_lte-3302-m432.dts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * ZyXEL LTE3302-M432 Board Description
+ * Copyright 2022 Pawel Dembicki <paweldembicki@gmail.com>
+ */
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "zyxel,lte-3302-m432", "ralink,mt7620n-soc";
+	model = "ZyXEL LTE3302-M432";
+
+	aliases {
+		led-boot = &led_signal_green;
+		led-failsafe = &led_signal_red;
+		led-running = &led_signal_green;
+		led-upgrade = &led_signal_red;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-1 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_signal_green: led-2 {
+			label = "green:signal";
+			function = LED_FUNCTION_INDICATOR;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led_signal_red: led-3 {
+			label = "red:signal";
+			function = LED_FUNCTION_INDICATOR;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		lte_modem_enable {
+			gpio-export,name = "lte_modem_enable";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "jboot";
+				reg = <0x0 0x10000>;
+				read-only;
+			};
+
+			partition@10000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+				openwrt,offset = <0x10000>;
+				label = "firmware";
+				reg = <0x10000 0xfe0000>;
+			};
+
+			config: partition@ff0000 {
+				label = "config";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&state_default {
+	default {
+		groups = "spi refclk", "i2c", "ephy", "wled";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1455,3 +1455,17 @@ define Device/zyxel_keenetic-viva
   SUPPORTED_DEVICES += kng_rc
 endef
 TARGET_DEVICES += zyxel_keenetic-viva
+
+define Device/zyxel_lte-3302-m432
+  $(Device/amit_jboot)
+  SOC := mt7620n
+  IMAGE_SIZE := 16256k
+  DEVICE_VENDOR := ZyXEL
+  DEVICE_MODEL := LTE3302
+  DEVICE_VARIANT := M432
+  DLINK_ROM_ID := ZXL6E2431003
+  DLINK_FAMILY_MEMBER := 0x6E24
+  DLINK_FIRMWARE_SIZE := 0xFE0000
+  DEVICE_PACKAGES += kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+endef
+TARGET_DEVICES += zyxel_lte-3302-m432

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -245,6 +245,10 @@ zbtlink,zbt-we1026-h-32m)
 zbtlink,zbt-we2026)
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan" "wlan0"
 	;;
+zyxel,lte-3302-m432)
+	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x03"
+	ucidef_set_led_netdev "wwan" "wwan" "green:wan" "wwan0"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -250,6 +250,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch1" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "7t@eth0"
 		;;
+	zyxel,lte-3302-m432)
+		ucidef_add_switch "switch0" \
+			"0:lan:1" "1:lan:2" "6@eth0"
+		;;
 	esac
 }
 
@@ -393,6 +397,10 @@ ramips_setup_macs()
 	zyxel,keenetic-omni-ii|\
 	zyxel,keenetic-viva)
 		wan_mac=$(mtd_get_mac_binary factory 0x28)
+		;;
+	zyxel,lte-3302-m432)
+		lan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
+		label_mac=$lan_mac
 		;;
 	esac
 

--- a/target/linux/ramips/mt7620/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/ramips/mt7620/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -41,6 +41,11 @@ case "$FIRMWARE" in
 		caldata_extract "factory" 0x0 0x200
 		caldata_patch_mac $wifi_mac 0x4
 		;;
+	zyxel,lte-3302-m432)
+		wifi_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
+		jboot_eeprom_extract "config" 0xE000
+		caldata_patch_mac $wifi_mac 0x4
+		;;
 	*)
 		caldata_die "Please define mtd-eeprom in $board DTS file!"
 		;;


### PR DESCRIPTION
The ZyXEL LTE3302-M432 Wireless Router is based on the MT7620N SoC.

Specification:

- MediaTek MT7620N (580 Mhz)
- 64 MB of RAM
- 16 MB of FLASH
- 1x 802.11bgn radio
- 2x 10/100 Mbps Ethernet: 2xLAN
- 3x internal, non-detachable antennas (1x Wifi 2.4G, 2x LTE)
- 2x external, detachable antennas (2x LTE)
- 1x LTE modem cat 6
- UART (J8) solder-points on PCB (57600 8n1) (tx/rx described on silk)
- 5x LED, 2x button
- JBOOT bootloader
- Battery slot (Charger is standalone BQ24133)

**Known issues:
Modem stuck at sim card checking. Don't know if my device is broken or
some issue with software.** Every idea how to find solution are welcome.

Always it stop at:
`uqmi -s -d /dev/cdc-wdm0 --get-pin-status` or after manually process kill sometimes stuck at `uqmi -s -d /dev/cdc-wdm0 --uim-get-sim-state`

Notes:
This commit adds support for Teila branded version with different ROMID
than stock ZyXEL device. Isn't possible to install it in stock version.
If someone have stock, please let me know. I could prepare support for
it.

Installation:
Apply factory image via http web-gui or JBOOT recovery page

How to revert to OEM firmware:
- push the reset button and turn on the power. Wait until LED start
  blinking (~10sec.)
- upload original factory image via JBOOT http (IP: 192.168.123.254)

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>

