### PR TITLE
ath79: ag71xx: reuse skbuff_head with napi skb api

### DIFF
--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -1278,7 +1278,7 @@ static int ag71xx_tx_packets(struct ag71xx *ag, bool flush)
 		if (!skb)
 			continue;
 
-		dev_kfree_skb_any(skb);
+		napi_consume_skb(skb, !flush);
 		ring->buf[i].skb = NULL;
 
 		bytes_compl += ring->buf[i].len;
@@ -1352,7 +1352,11 @@ static int ag71xx_rx_packets(struct ag71xx *ag, int limit)
 		dev->stats.rx_packets++;
 		dev->stats.rx_bytes += pktlen;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
 		skb = build_skb(ring->buf[i].rx_buf, ag71xx_buffer_size(ag));
+#else
+		skb = napi_build_skb(ring->buf[i].rx_buf, ag71xx_buffer_size(ag));
+#endif
 		if (!skb) {
 			skb_free_frag(ring->buf[i].rx_buf);
 			goto next;


### PR DESCRIPTION
napi_build_skb() reuses NAPI skbuff_head cache in order to save some
cycles on freeing/allocating skbuff_heads on every new Rx or completed
Tx.
Use napi_consume_skb() to feed the cache with skbuff_heads of completed
Tx so it's never empty.

PS: Appreciate if anyone can give some performance numbers.
Tested on bcm63xx [BCM6328] which had 1-2% uplift in iperf3.