### PR TITLE
opkg: patch: don't filter out directories when claiming ownership of file

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -188,7 +188,7 @@ default_prerm() {
 	fi
 
 	local shell="$(command -v bash)"
-	for i in $(grep -s "^/etc/init.d/" "$root/usr/lib/opkg/info/${pkgname}.list"); do
+	for i in $(grep -s "^/etc/init.d/." "$root/usr/lib/opkg/info/${pkgname}.list"); do
 		if [ -n "$root" ]; then
 			${shell:-/bin/sh} "$root/etc/rc.common" "$root$i" disable
 		else
@@ -293,7 +293,7 @@ default_postinst() {
 	fi
 
 	local shell="$(command -v bash)"
-	for i in $(grep -s "^/etc/init.d/" "$root$filelist"); do
+	for i in $(grep -s "^/etc/init.d/." "$root$filelist"); do
 		if [ -n "$root" ]; then
 			${shell:-/bin/sh} "$root/etc/rc.common" "$root$i" enable
 		else

--- a/package/system/opkg/patches/100-empty-dirs.patch
+++ b/package/system/opkg/patches/100-empty-dirs.patch
@@ -1,0 +1,37 @@
+From 28efcf36b5c3e5a04473dce0834d7bada584bf49 Mon Sep 17 00:00:00 2001
+From: Michal Vasilek <michal.vasilek@nic.cz>
+Date: Fri, 6 May 2022 14:39:43 +0200
+Subject: [PATCH] Don't filter out directories when claiming ownership of a file.
+
+Directories are now owned by a particular package, which ensures their
+deletion in the event that a package leaves an empty directory during package
+removal.
+
+From Roman Khimov <khimov@altell.ru>.
+
+git-svn-id: http://opkg.googlecode.com/svn/trunk@624 e8e0d7a0-c8d9-11dd-a880-a1081c7ac358
+
+Backported from: https://git.yoctoproject.org/opkg/commit/?h=opkg-0.2.x&id=3d697f6303f381a507f37f8d63129151d745dc6c
+Fixes: https://github.com/openwrt/openwrt/issues/7519
+
+[add link to an openwrt issue and to the original commit from
+yoctoproject]
+Signed-off-by: Michal Vasilek <michal.vasilek@nic.cz>
+
+---
+ libopkg/pkg_hash.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+--- a/libopkg/pkg_hash.c
++++ b/libopkg/pkg_hash.c
+@@ -755,10 +755,6 @@ pkg_t *file_hash_get_file_owner(const ch
+ void file_hash_set_file_owner(const char *file_name, pkg_t * owning_pkg)
+ {
+ 	pkg_t *old_owning_pkg;
+-	int file_name_len = strlen(file_name);
+-
+-	if (file_name[file_name_len - 1] == '/')
+-		return;
+ 
+ 	file_name = strip_offline_root(file_name);
+ 


### PR DESCRIPTION
Directories are now owned by a particular package, which ensures their
deletion in the event that a package leaves an empty directory during package
removal.

Fixes: https://github.com/openwrt/openwrt/issues/7519, https://github.com/openwrt/packages/issues/10136, https://gitlab.nic.cz/turris/os/packages/-/issues/576

Sent via emailing list for [opkg repository](https://git.openwrt.org/?p=project/opkg-lede.git;a=summary):
- https://lists.openwrt.org/pipermail/openwrt-devel/2022-May/038613.html