### PR TITLE
realtek: add support for power LED on Netgear GS308Tv1

### DIFF
--- a/target/linux/realtek/dts-5.10/rtl8380_netgear_gs308t-v1.dts
+++ b/target/linux/realtek/dts-5.10/rtl8380_netgear_gs308t-v1.dts
@@ -2,7 +2,34 @@
 
 #include "rtl8380_netgear_gigabit_3xx.dtsi"
 
+#include <dt-bindings/leds/common.h>
+
 / {
 	compatible = "netgear,gs308t-v1", "realtek,rtl838x-soc";
 	model = "Netgear GS308T v1";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_amber;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_amber;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_amber: led-0 {
+			label = "amber:power";
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio1 32 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: led-1 {
+			label = "green:power";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio1 31 GPIO_ACTIVE_LOW>;
+		};
+	};
 };


### PR DESCRIPTION
The Netgear GS308Tv1 is already supported by OpenWrt, but is missing LED
support. After OpenWrt installation, all LEDs are off which makes the
installation quite confusing.
This enables support for the green/amber power LED to give feedback
about the current status.

Signed-off-by: Andreas Böhler <dev@aboehler.at>