### PR TITLE
realtek: add support for D-Link DGS-1210-20

### DIFF
--- a/package/boot/uboot-envtools/files/realtek
+++ b/package/boot/uboot-envtools/files/realtek
@@ -9,6 +9,7 @@ board=$(board_name)
 
 case "$board" in
 d-link,dgs-1210-16|\
+d-link,dgs-1210-20|\
 d-link,dgs-1210-28|\
 d-link,dgs-1210-10p|\
 zyxel,gs1900-8|\

--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-20.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-20.dts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl8382_d-link_dgs-1210.dtsi"
+
+/ {
+	compatible = "d-link,dgs-1210-20", "realtek,rtl838x-soc";
+	model = "D-Link DGS-1210-20";
+
+	gpio-restart {
+		compatible = "gpio-restart";
+		gpios = <&gpio1 34 GPIO_ACTIVE_LOW>;
+		open-source;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 33 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio1: rtl8231-gpio {
+		compatible = "realtek,rtl8231-gpio";
+		#gpio-cells = <2>;
+		gpio-controller;
+		indirect-access-bus-id = <0>;
+	};
+};
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		EXTERNAL_PHY(0)
+		EXTERNAL_PHY(1)
+		EXTERNAL_PHY(2)
+		EXTERNAL_PHY(3)
+		EXTERNAL_PHY(4)
+		EXTERNAL_PHY(5)
+		EXTERNAL_PHY(6)
+		EXTERNAL_PHY(7)
+
+		INTERNAL_PHY(8)
+		INTERNAL_PHY(9)
+		INTERNAL_PHY(10)
+		INTERNAL_PHY(11)
+		INTERNAL_PHY(12)
+		INTERNAL_PHY(13)
+		INTERNAL_PHY(14)
+		INTERNAL_PHY(15)
+
+		EXTERNAL_SFP_PHY(24)
+		EXTERNAL_SFP_PHY(25)
+		EXTERNAL_SFP_PHY(26)
+		EXTERNAL_SFP_PHY(27)
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, internal)
+		SWITCH_PORT(9, 10, internal)
+		SWITCH_PORT(10, 11, internal)
+		SWITCH_PORT(11, 12, internal)
+		SWITCH_PORT(12, 13, internal)
+		SWITCH_PORT(13, 14, internal)
+		SWITCH_PORT(14, 15, internal)
+		SWITCH_PORT(15, 16, internal)
+
+		SWITCH_PORT(24, 17, qsgmii)
+		SWITCH_PORT(25, 18, qsgmii)
+		SWITCH_PORT(26, 19, qsgmii)
+		SWITCH_PORT(27, 20, qsgmii)
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -30,6 +30,12 @@ define Device/d-link_dgs-1210-16
 endef
 TARGET_DEVICES += d-link_dgs-1210-16
 
+define Device/d-link_dgs-1210-20
+  $(Device/d-link_dgs-1210)
+  DEVICE_MODEL := DGS-1210-20
+endef
+TARGET_DEVICES += d-link_dgs-1210-20
+
 define Device/d-link_dgs-1210-28
   $(Device/d-link_dgs-1210)
   DEVICE_MODEL := DGS-1210-28


### PR DESCRIPTION
 Hardware specification
 ----------------------

 * RTL8382M SoC, 1 MIPS 4KEc core @ 500MHz
 * 128MB DRAM
 * 32MB NOR Flash
 * 16 x 10/100/1000BASE-T ports
    - Internal PHY with 8 ports (RTL8218B)
    - External PHY with 8 ports (RTL8218B)
 * 4 x Gigabit RJ45/SFP Combo ports
    - External PHY with 4 SFP ports (RTL8214FC)
 * Power LED
 * Reset button on front panel
 * UART (115200 8N1) via unpopulated standard 0.1" pin header marked J6

 UART pinout
 -----------

```
  [o]ooo|J6
   | ||`------ GND
   | |`------- RX
   | `-------- TX
   `---------- Vcc (3V3)
```

 Boot initramfs image from U-Boot
 --------------------------------

  1. Press Escape key during `Hit Esc key to stop autoboot` prompt
  2. Press CTRL+C keys to get into real U-Boot prompt
  3. Init network with `rtk network on` command
  4. Load image with `tftpboot 0x8f000000 openwrt-rtl838x-generic-d-link_dgs-1210-20-initramfs-kernel.bin` command
  5. Boot the image with `bootm` command

To install, upload the sysupgrade image to the OEM webpage or sysupgrade
from the system running from initramfs image.

It has been developed and tested on device with F1 revision.

Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
