### PR TITLE
lantiq: dts: Add the reset line for the PCI controller

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9.dtsi
@@ -415,6 +415,8 @@
 			req-mask = <0x1>;
 
 			device_type = "pci";
+
+			resets = <&reset0 13 13>;
 		};
 	};
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube.dtsi
@@ -328,6 +328,8 @@
 			req-mask = <0x1>; /* GNT1 */
 
 			device_type = "pci";
+
+			resets = <&reset0 13 13>;
 		};
 	};
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
@@ -555,6 +555,8 @@
 			req-mask = <0x1>; /* GNT1 */
 
 			device_type = "pci";
+
+			resets = <&reset0 13 13>;
 		};
 	};
 


### PR DESCRIPTION
While investigating #9829 I found that the PCI controller has a reset line which we don't describe so far.
Add this reset line even if it's not used by the driver (yet).