### PR TITLE
libusb: fix missing link

### DIFF
--- a/package/libs/libusb/Makefile
+++ b/package/libs/libusb/Makefile
@@ -56,7 +56,7 @@ endef
 
 define Package/libusb-1.0/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libusb-1.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libusb-1.0.so* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libusb-1.0))


### PR DESCRIPTION
This commit fixes the missing `libusb-1.0.so` link on the target root, broken by [3d2dab5](https://github.com/openwrt/openwrt/commit/43539a6aabbee86b5fb2fbb5c36c477407d98765).

Some packages that depend on `libusb-1.0` might fail building with if this is link is not available in the target root.

Example:

```
Package example-app is missing dependencies for the following libraries:
libusb-1.0.so
```

this affects [openwrt-22.03](https://github.com/openwrt/openwrt/tree/openwrt-22.03) and [master](https://github.com/openwrt/openwrt)
