### PR TITLE
ath79: glinet-x750: fix usb support

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_gl-x750.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-x750.dts
@@ -53,6 +53,16 @@
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	reg_usb_vbus: reg_usb_vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
 &pcie0 {


### PR DESCRIPTION
This fixes the USB port of the Spitz. Without this gpio export, the usb port is not usable (not detecting any devices we can possibly plug in it).

