### PR TITLE
realtek: add support for power LED on Netgear GS108Tv3

### DIFF
--- a/target/linux/realtek/dts-5.10/rtl8380_netgear_gs108t-v3.dts
+++ b/target/linux/realtek/dts-5.10/rtl8380_netgear_gs108t-v3.dts
@@ -2,7 +2,34 @@
 
 #include "rtl8380_netgear_gigabit_1xx.dtsi"
 
+#include <dt-bindings/leds/common.h>
+
 / {
 	compatible = "netgear,gs108t-v3", "realtek,rtl838x-soc";
 	model = "Netgear GS108T v3";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_amber;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_amber;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_amber: led-0 {
+			label = "amber:power";
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio1 32 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: led-1 {
+			label = "green:power";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio1 31 GPIO_ACTIVE_LOW>;
+		};
+	};
 };


### PR DESCRIPTION
The Netgear GS108Tv3 is already supported by OpenWrt, but is missing LED
support. After OpenWrt installation, all LEDs are off which makes the
installation quite confusing.
This enables support for the green/amber power LED to give feedback
about the current status.

This is basically just a verbatim copy of commit
https://github.com/openwrt/openwrt/commit/c4927747d25af59db8233a66a59fdf9e8c0e395d.

Please note that both LEDs are wired up in an anti-parallel fashion,
which means that only one of both LEDs/colors can be switched on at the
same time. If both LEDs/colors are switched on simultanously, the LED
goes dark.

Tested-by: Pascal Ernster <git@hardfalcon.net>
Signed-off-by: Pascal Ernster <git@hardfalcon.net>