### PR TITLE
ath79: TP-Link EAP225-Outdoor v1: use pre-calibration nvmem-cell

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_eap225-outdoor-v1.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_eap225-outdoor-v1.dts
@@ -55,6 +55,6 @@
 		mac-address-increment = <1>;
 
 		nvmem-cells = <&macaddr_info_8>, <&calibration_ath10k>;
-		nvmem-cell-names = "mac-address", "calibration";
+		nvmem-cell-names = "mac-address", "pre-calibration";
 	};
 };


### PR DESCRIPTION
Fixes errors in the form of:
  ath10k_pci 0000:00:00.0: failed to fetch board data for bus=pci,
  vendor=168c,device=0056,subsystem-vendor=0000,subsystem-device
  =0000 from ath10k/QCA9888/hw2.0/board-2.bin
  ath10k_pci 0000:00:00.0: failed to fetch board-2.bin or board.bin
  from ath10k/QCA9888/hw2.0
  ath10k_pci 0000:00:00.0: failed to fetch board file: -12
  ath10k_pci 0000:00:00.0: could not probe fw (-12)

As described already in 2d3321619b2b ("ath79: TP-Link EAP245 v3: use
pre-calibration nvmem-cell"):
  Ath10k Wave-2 hardware requires an nvmem-cell called "pre-calibration"
  to load the device specific caldata, not "calibration".

Fixes: 23b904074500 ("ath79: TP-Link EAP225-Outdoor v1: convert ath10k
to nvmem-cells")

Suggested-by: Sander Vanheule <sander@svanheule.net>
Signed-off-by: Nick Hainke <vincent@systemli.org>


Seems to fix everything:
```
[   72.304066] ath10k_pci 0000:00:00.0: 10.4 wmi init: vdevs: 16  peers: 48  tid: 96
[   72.312001] ath10k_pci 0000:00:00.0: msdu-desc: 2500  skid: 32
[   72.362030] ath10k_pci 0000:00:00.0: wmi print 'P 48/48 V 16 K 144 PH 176 T 186  msdu-desc: 2500  sw-crypt: 0 ct-sta: 0'
[   72.373368] ath10k_pci 0000:00:00.0: wmi print 'free: 114572 iram: 12644 sram: 29508'
[   72.691400] ath10k_pci 0000:00:00.0: rts threshold -1
[   72.697179] ath10k_pci 0000:00:00.0: Firmware lacks feature flag indicating a retry limit of > 2 is OK, requested limit: 4
...
[   73.074922] ath10k_pci 0000:00:00.0: NOTE:  Firmware DBGLOG output disabled in debug_mask: 0x10000000
[   73.085070] ath10k_pci 0000:00:00.0: rts threshold -1
```

ping @svanheule 