### PR TITLE
realtek: make "u-boot-env" partition writable for Netgear 3xx series

### DIFF
--- a/target/linux/realtek/dts-5.10/rtl8380_netgear_gigabit_3xx.dtsi
+++ b/target/linux/realtek/dts-5.10/rtl8380_netgear_gigabit_3xx.dtsi
@@ -24,7 +24,6 @@
 			partition@e0000 {
 				label = "u-boot-env";
 				reg = <0x00e0000 0x0010000>;
-				read-only;
 			};
 
 			partition@f0000 {


### PR DESCRIPTION
The Netgear GS3xx devices do not properly initialise the port LEDs during
startup unless the boot command in U-Boot is changed. Making the U-Boot
env partition writable allows this modification to be done from within
OpenWrt by calling "fw_setenv bootcmd rtk network on\; boota".

