### PR TITLE
[21.02] exfat: update to 5.19.1

### DIFF
--- a/package/kernel/exfat/Makefile
+++ b/package/kernel/exfat/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=exfat
-PKG_VERSION:=5.12.3
+PKG_VERSION:=5.19.1
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/namjaejeon/linux-exfat-oot/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=43889c73af76c466bbc904aff80354a62ecaa24c7b20e354ff735f5949907982
+PKG_HASH:=80750bfa3bcdf743ca0d027be8244cc7b6ccd78f20304c2cabbb4011c88e4f0a
 PKG_BUILD_DIR:=$(KERNEL_BUILD_DIR)/linux-exfat-oot-$(PKG_VERSION)
 
 PKG_MAINTAINER:=


### PR DESCRIPTION
Major changes are:
  4 cleanups & typos fixes.
  Add keep_last_dots mount option to allow access to paths with trailing dots.
  Avoid repetitive volume dirty bit set/clear to improve storage life time.
  Fix ->i_blocks truncation issue caused by wrong 32bit mask.
  Fix ->i_blocks truncation issue that still exists elsewhere.
  Fix missing REQ_SYNC in exfat_update_bhs().
  Fix referencing wrong parent directory information during rename.
  Fix slab-out-bounds in exat_clear_bitmap() reported from syzbot.
  Improve performance while zeroing a cluster with dirsync mount option.
  Introduce a sys_tz mount option to use system timezone.
  Move super block magic number to magic.h
