### PR TITLE
CI: include automatic Pull Request Labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,103 @@
+# target/*
+"target/airoha":
+  - "target/linux/airoha/**"
+"target/apm821xx":
+  - "target/linux/apm821xx/**"
+"target/archs38":
+  - "target/linux/archs38/**"
+"target/armvirt":
+  - "target/linux/armvirt/**"
+"target/at91":
+  - "target/linux/at91/**"
+"target/ath25":
+  - "target/linux/ath25/**"
+"target/ath79":
+  - "target/linux/ath79/**"
+"target/bcm27xx":
+  - "target/linux/bcm27xx/**"
+"target/bcm47xx":
+  - "target/linux/bcm47xx/**"
+"target/bcm4908":
+  - "target/linux/bcm4908/**"
+"target/bcm53xx":
+  - "target/linux/bcm53xx/**"
+"target/bcm63xx":
+  - "target/linux/bcm63xx/**"
+"target/bmips":
+  - "target/linux/bmips/**"
+"target/gemini":
+  - "target/linux/gemini/**"
+"target/imx":
+  - "target/linux/imx/**"
+"target/ipq40xx":
+  - "target/linux/ipq40xx/**"
+"target/ipq806x":
+  - "target/linux/ipq806x/**"
+"target/kirkwood":
+  - "target/linux/kirkwood/**"
+"target/lantiq":
+  - "target/linux/lantiq/**"
+"target/layerscape":
+  - "target/linux/layerscape/**"
+"target/malta":
+  - "target/linux/malta/**"
+"target/mediatek":
+  - "target/linux/mediatek/**"
+"target/mpc85xx":
+  - "target/linux/mpc85xx/**"
+"target/mvebu":
+  - "target/linux/mvebu/**"
+"target/mxs":
+  - "target/linux/mxs/**"
+"target/octeon":
+  - "target/linux/octeon/**"
+"target/octeontx":
+  - "target/linux/octeontx/**"
+"target/omap":
+  - "target/linux/omap/**"
+"target/oxnas":
+  - "target/linux/oxnas/**"
+"target/pistachio":
+  - "target/linux/pistachio/**"
+"target/qoriq":
+  - "target/linux/qoriq/**"
+"target/ramips":
+  - "target/linux/ramips/**"
+"target/realtek":
+  - "target/linux/realtek/**"
+"target/rockchip":
+  - "target/linux/rockchip/**"
+"target/sunxi":
+  - "target/linux/sunxi/**"
+"target/tegra":
+  - "target/linux/tegra/**"
+"target/uml":
+  - "target/linux/uml/**"
+"target/x86":
+  - "target/linux/x86/**"
+"target/zynq":
+  - "target/linux/zynq/**"
+# target/imagebuilder
+"target/imagebuilder":
+  - "target/imagebuilder/**"
+# kernel
+"kernel":
+  - "target/linux/generic/**"
+  - "target/linux/**/config-*"
+  - "target/linux/**/patches-*"
+  - "target/linux/**/files/**"
+  - "package/kernel/linux/**"
+# core packages
+"core packages":
+  - "package/**"
+# build/scripts/tools
+"build/scripts/tools":
+  - "include/**"
+  - "scripts/**"
+  - "tools/**"
+# toolchain
+"toolchain":
+  - "toolchain/**"
+# GitHub/CI
+"GitHub/CI":
+  - ".github/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: 'Pull Request Labeler'
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    name: Pull Request Labeler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4.0.1
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
This adds GitHub CI action which makes use of 'Labeler', allowing automatic labeling of new PRs, based on the modified files paths.

Below labels are supported and more can be added later:
- 'target/*'
- 'target/imagebuilder'
- 'kernel'
- 'core packages'
- 'build/scripts/tools'
- 'toolchain'
- 'GitHub/CI'

For more information: https://github.com/marketplace/actions/labeler