### PR TITLE
ath10k: enable encapsulation offload by default

### DIFF
--- a/package/kernel/mac80211/ath.mk
+++ b/package/kernel/mac80211/ath.mk
@@ -260,7 +260,8 @@ define KernelPackage/ath10k
   FILES:= \
 	$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath10k/ath10k_core.ko \
 	$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath10k/ath10k_pci.ko
-  AUTOLOAD:=$(call AutoProbe,ath10k_pci)
+  AUTOLOAD:=$(call AutoProbe,ath10k_core ath10k_pci)
+  MODPARAMS.ath10k_core:=frame_mode=2
   VARIANT:=regular
 endef
 


### PR DESCRIPTION
Enable ath10k offload by default. This improves wireless performance without requiring user configuration.

Reports suggest that on some ath10k devices there can be about 10% improvement on tx throughput.

Signed-off-by: Tiago Gaspar <tiagogaspar8@gmail.com>