### PR TITLE
lantiq: dts: fix reset controller reference on Danube and AR9

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9.dtsi
@@ -416,7 +416,7 @@
 
 			device_type = "pci";
 
-			resets = <&reset0 13 13>;
+			resets = <&reset 13 13>;
 		};
 	};
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube.dtsi
@@ -329,7 +329,7 @@
 
 			device_type = "pci";
 
-			resets = <&reset0 13 13>;
+			resets = <&reset 13 13>;
 		};
 	};
 


### PR DESCRIPTION
@chunkeey reports in https://github.com/openwrt/openwrt/commit/087f2cba26faf085f825128b78ba2e662a66cbbd#commitcomment-76541441
> @xdarklight
> 
> Looks like ar9.dtsi and danube.dtsi do not have the &reset0 label. This is unfortunately causing a build failure. Is it save to replace it with &reset on the affect devices, or do they also have different p-handle values?
> 
> Reference https://buildbot.openwrt.org/master/images/#/builders/6/builds/611
> 
> ```
> make[4]: *** Waiting for unfinished jobs....
> make[4]: *** [Makefile:168: /builder/shared-workdir/build/build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_arcadyan_arv4510pw.dtb] Error 2
> make[4]: *** [Makefile:168: /builder/shared-workdir/build/build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_arcadyan_arv7506pw11.dtb] Error 2
> /builder/shared-workdir/build/build_dir/target-mips_24kc_musl/linux-lantiq_xway/linux-5.10.120/arch/mips/boot/dts/lantiq/danube.dtsi:313.21-333.5: ERROR (phandle_references): /fpi@10000000/pci@e105400: Reference to non-existent node or label "reset0"
>   also defined at /builder/shared-workdir/build/build_dir/target-mips_24kc_musl/linux-lantiq_xway/linux-5.10.120/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7510pw22.dts:161.7-183.3
> ERROR: Input tree has errors, aborting (use -f to force output)
> ```
> 
> https://buildbot.openwrt.org/master/images/#/builders/13/builds/588
> 
> ```
> /builder/shared-workdir/build/build_dir/target-mips_24kc_musl/linux-lantiq_xway_legacy/linux-5.10.120/arch/mips/boot/dts/lantiq/danube.dtsi:313.21-333.5: ERROR (phandle_references): /fpi@10000000/pci@e105400: Reference to non-existent node or label "reset0"
>   also defined at /builder/shared-workdir/build/build_dir/target-mips_24kc_musl/linux-lantiq_xway_legacy/linux-5.10.120/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4518pwr01.dtsi:178.7-187.3
>   also defined at /builder/shared-workdir/build/build_dir/target-mips_24kc_musl/linux-lantiq_xway_legacy/linux-5.10.120/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4518pwr01a.dts:8.7-10.3
> ERROR: Input tree has errors, aborting (use -f to force output)
> make[4]: *** [Makefile:168: /builder/shared-workdir/build/build_dir/target-mips_24kc_musl/linux-lantiq_xway_legacy/image-danube_arcadyan_arv4518pwr01.dtb] Error 2
> make[4]: *** Waiting for unfinished jobs....
> ```

This patch fixes building ar9 and danube targets:
```
$ ls -Gl build_dir/target-mips_24kc_musl/linux-lantiq_xway/*.dtb
-rw-r--r-- 1 xdarklight 9434 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-ar9_avm_fritz7312.dtb
-rw-r--r-- 1 xdarklight 9682 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-ar9_avm_fritz7320.dtb
-rw-r--r-- 1 xdarklight 9614 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-ar9_bt_homehub-v3a.dtb
-rw-r--r-- 1 xdarklight 9628 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-ar9_buffalo_wbmr-hp-g300h.dtb
-rw-r--r-- 1 xdarklight 9247 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-ar9_netgear_dgn3500b.dtb
-rw-r--r-- 1 xdarklight 9243 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-ar9_netgear_dgn3500.dtb
-rw-r--r-- 1 xdarklight 9099 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-ar9_zte_h201l.dtb
-rw-r--r-- 1 xdarklight 9209 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-ar9_zyxel_p-2601hn.dtb
-rw-r--r-- 1 xdarklight 8407 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_arcadyan_arv4510pw.dtb
-rw-r--r-- 1 xdarklight 8497 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_arcadyan_arv4519pw.dtb
-rw-r--r-- 1 xdarklight 8073 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_arcadyan_arv7506pw11.dtb
-rw-r--r-- 1 xdarklight 8405 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_arcadyan_arv7510pw22.dtb
-rw-r--r-- 1 xdarklight 8969 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_arcadyan_arv7518pw.dtb
-rw-r--r-- 1 xdarklight 8519 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_arcadyan_arv7519pw.dtb
-rw-r--r-- 1 xdarklight 7659 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_arcadyan_arv7525pw.dtb
-rw-r--r-- 1 xdarklight 9815 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_arcadyan_arv752dpw22.dtb
-rw-r--r-- 1 xdarklight 9182 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_arcadyan_arv752dpw.dtb
-rw-r--r-- 1 xdarklight 8095 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_arcadyan_arv8539pw22.dtb
-rw-r--r-- 1 xdarklight 6796 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_audiocodes_mp-252.dtb
-rw-r--r-- 1 xdarklight 8747 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_bt_homehub-v2b.dtb
-rw-r--r-- 1 xdarklight 6305 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_lantiq_easy50712.dtb
-rw-r--r-- 1 xdarklight 6886 Jun 20 19:25 build_dir/target-mips_24kc_musl/linux-lantiq_xway/image-danube_siemens_gigaset-sx76x.dtb
```