### PR TITLE
wolfssl: disable AES-NI by default for x86_64

### DIFF
--- a/package/libs/wolfssl/Config.in
+++ b/package/libs/wolfssl/Config.in
@@ -68,7 +68,7 @@ config WOLFSSL_ASM_CAPABLE
 
 choice
 	prompt "Hardware Acceleration"
-	default WOLFSSL_HAS_CPU_CRYPTO if WOLFSSL_ASM_CAPABLE
+	default WOLFSSL_HAS_CPU_CRYPTO if WOLFSSL_ASM_CAPABLE && !x86_64
 	default WOLFSSL_HAS_NO_HW
 
 	config WOLFSSL_HAS_NO_HW
@@ -80,6 +80,7 @@ choice
 		help
 		This will use Intel AESNI insturctions or armv8 Crypto Extensions.
 		Either of them should easily outperform hardware crypto in WolfSSL.
+		Beware that for Intel, the CPU has to support SSE4 instructions.
 
 	config WOLFSSL_HAS_AFALG
 		bool "AF_ALG"
@@ -96,5 +97,9 @@ choice
 		bool "/dev/crypto - full"
 		select WOLFSSL_HAS_DEVCRYPTO
 endchoice
+if x86_64 && WOLFSSL_HAS_CPU_CRYPTO
+	comment "WARNING: make sure your CPU supports SSE4 instructions"
+	comment "WolfSSL may crash with an invalid opcode exception"
+endif
 
 endif


### PR DESCRIPTION
WolfSSL is crashing with an illegal opcode in some x86_64 CPUs that have
AES instructions but lack other extensions that are used by WolfSSL
when AES-NI is enabled.

Disable the option by default for now until the issue is properly fixed.
People can enable them in a custom build if they are sure it will work
for them.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

This was reported in https://github.com/openwrt/openwrt/pull/9738#issuecomment-1162041335
