### PR TITLE
arptables: update to 0.0.5 and cleanup

### DIFF
--- a/package/network/utils/arptables/Makefile
+++ b/package/network/utils/arptables/Makefile
@@ -1,21 +1,20 @@
-# Copyright (C) 2006-2016 OpenWrt.org
+# SPDX-License-Identifier: GPL-2.0-only
 #
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
+# Copyright (C) 2006-2016 OpenWrt.org
 #
 
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=arptables
+PKG_VERSION:=0.0.5
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=https://git.netfilter.org/arptables
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_DATE:=2015-05-20
-PKG_SOURCE_VERSION:=f4ab8f63f11a72f14687a6646d04ae1bae3fa45f
-PKG_MIRROR_HASH:=84bc660be4c9f70be91046acfd87785add930eceab7c543036058e1a9de2e9d9
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://ftp.netfilter.org/pub/arptables
+PKG_HASH:=4f9a0656ce5c90868f551cd4deeb2d04f33899667e1fb2818b64e432fe8f629c
 
 PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -37,7 +36,7 @@ MAKE_FLAGS += \
 
 define Package/arptables-legacy/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/arptables $(1)/usr/sbin/arptables-legacy
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/arptables-legacy $(1)/usr/sbin/arptables-legacy
 endef
 
 $(eval $(call BuildPackage,arptables-legacy))


### PR DESCRIPTION
Update to 0.0.5:

efae894 arptables 0.0.5 release
1f3c6bc libarptc: Simplify alloc_handle by using calloc()
4e5e23a Eliminate compiler warning about size passed to strncmp()
bf11d72 Add .gitignore
28b22d5 arptables: legacy renaming
988d6a4 arptables: cleanup sysvinit script
f4ab8f6 src: Remove support for libc5
047f37b src: Use stdint types
4bb2f83 arptables: Add MARK target
dbbe9f7 arptables: Add revision field for arptables userspace
935acea src: fix compilation warning
5700dbf src: cache in tree and use x_tables.h
4b7d6b0 arptables: remove dead dynamic hooks code
c299484 arptables: fix potential buffer overflow (author: dcb)
9fcaf70 arptables: add missing long option --set-counters and update documentation
36daba3 arptables: install man pages
f79b957 Add man pages for arptables-{save,restore}
c492c16 add GPL text
8f58693 fix potential buffer overflows reported by static analysis
ee4ec13 make static analysis tool happy (false positive)
b064d44 build an libarptc.a archive

Cleanup Makefile:
- Switch to release versions
- Use ftp(http) mirror
- Add PKG_LICENSE_FILES

**Only compile tested**
