### PR TITLE
fix: add pci reset_gpios for R6220

### DIFF
--- a/target/linux/ramips/dts/mt7621_netgear_r6220.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_r6220.dts
@@ -55,6 +55,13 @@
 	};
 };
 
+&pcie {
+    status = "okay";
+
+    reset-gpios = <&gpio 19 GPIO_ACTIVE_LOW>,
+                  <&gpio 8 GPIO_ACTIVE_LOW>;
+};
+
 &gmac0 {
 	nvmem-cells = <&macaddr_factory_4>;
 	nvmem-cell-names = "mac-address";


### PR DESCRIPTION
This PR fix issue with wireless Radio 2.4ghz on Netgear R6220 after upgrade to 21.x. The pci card are missing after reboot fresh installation.

The solution is mentioned on openwork forum (https://forum.openwrt.org/t/r6220-could-not-find-phy-for-device-radio0-mt76x2-issue-continues/116665/4), but nobody add  the solution to the repository

I have build my own openwrt image with the fix and now, when I reboot my netgear router, the pci wireless card are present