### PR TITLE
[22.03] ath10k: backport encapsulation offload support

### DIFF
--- a/package/kernel/mac80211/patches/ath10k/081-01-ath10k-improve-tx-status-reporting.patch
+++ b/package/kernel/mac80211/patches/ath10k/081-01-ath10k-improve-tx-status-reporting.patch
@@ -1,0 +1,69 @@
+From 2587d5198aa5adcbd8896aae4a2404dc13d48637 Mon Sep 17 00:00:00 2001
+From: Sergey Ryazanov <ryazanov.s.a@gmail.com>
+Date: Wed, 18 May 2022 10:27:26 +0300
+Subject: ath10k: improve tx status reporting
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We use ieee80211_tx_status() to report each completed tx frame.
+Internally, this function calls sta_info_get_by_addrs(), what has a
+couple of drawbacks:
+1. additional station lookup causes a performance degradation;
+2. mac80211 can not properly account Ethernet encapsulated frames due
+   to the inability to properly determine the destination (station) MAC
+   address since ieee80211_tx_status() assumes the frame has a 802.11
+   header.
+
+The latter is especially destructive if we want to use hardware frames
+encapsulation.
+
+To fix both of these issues, replace ieee80211_tx_status() with
+ieee80211_tx_status_ext() call and feed it station pointer from the tx
+queue associated with the transmitted frame.
+
+Tested-on: QCA9888 hw2.0 PCI 10.4-3.9.0.2-00131
+Tested-on: QCA6174 hw3.2 PCI WLAN.RM.4.4.1-00157-QCARMSWPZ-1
+
+Signed-off-by: Sergey Ryazanov <ryazanov.s.a@gmail.com>
+Tested-by: Oldřich Jedlička <oldium.pro@gmail.com> # TP-Link Archer C7 v4 & v5 (QCA9563 + QCA9880)
+Tested-by: Edward Matijevic <motolav@gmail.com> # TP-Link Archer C2600 (IPQ8064 + QCA9980 10.4.1.00030-1)
+Tested-by: Edward Matijevic <motolav@gmail.com> # QCA9377 PCI in Sta mode
+Tested-by: Zhijun You <hujy652@gmail.com> # NETGEAR R7800 (QCA9984 10.4-3.9.0.2-00159)
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20220516032519.29831-2-ryazanov.s.a@gmail.com
+---
+ drivers/net/wireless/ath/ath10k/txrx.c | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/wireless/ath/ath10k/txrx.c
++++ b/drivers/net/wireless/ath/ath10k/txrx.c
+@@ -43,6 +43,7 @@ out:
+ int ath10k_txrx_tx_unref(struct ath10k_htt *htt,
+ 			 const struct htt_tx_done *tx_done)
+ {
++	struct ieee80211_tx_status status;
+ 	struct ath10k *ar = htt->ar;
+ 	struct device *dev = ar->dev;
+ 	struct ieee80211_tx_info *info;
+@@ -128,7 +129,19 @@ int ath10k_txrx_tx_unref(struct ath10k_h
+ 		info->status.is_valid_ack_signal = true;
+ 	}
+ 
+-	ieee80211_tx_status(htt->ar->hw, msdu);
++	memset(&status, 0, sizeof(status));
++	status.skb = msdu;
++	status.info = info;
++
++	rcu_read_lock();
++
++	if (txq)
++		status.sta = txq->sta;
++
++	ieee80211_tx_status_ext(htt->ar->hw, &status);
++
++	rcu_read_unlock();
++
+ 	/* we do not own the msdu anymore */
+ 
+ 	return 0;

--- a/package/kernel/mac80211/patches/ath10k/081-02-ath10k-turn-rawmode-into-frame-mode.patch
+++ b/package/kernel/mac80211/patches/ath10k/081-02-ath10k-turn-rawmode-into-frame-mode.patch
@@ -1,0 +1,74 @@
+From a09740548275a74b897654b3aca5af589289b57a Mon Sep 17 00:00:00 2001
+From: Sergey Ryazanov <ryazanov.s.a@gmail.com>
+Date: Mon, 16 May 2022 13:26:00 +0300
+Subject: ath10k: turn rawmode into frame_mode
+
+Turn boolean rawmode module param into integer frame_mode param that
+contains value from ath10k_hw_txrx_mode enum. As earlier the default
+param value is non-RAW (native Wi-Fi) encapsulation. The param name
+is selected to be consistent with the similar ath11k param.
+
+This is a preparation step for upcoming encapsulation offloading
+support.
+
+Signed-off-by: Sergey Ryazanov <ryazanov.s.a@gmail.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20220516032519.29831-4-ryazanov.s.a@gmail.com
+---
+ drivers/net/wireless/ath/ath10k/core.c | 11 +++++++----
+ drivers/net/wireless/ath/ath10k/core.h |  1 +
+ 2 files changed, 8 insertions(+), 4 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -32,9 +32,11 @@ EXPORT_SYMBOL(ath10k_debug_mask);
+ static unsigned int ath10k_cryptmode_param;
+ static bool uart_print;
+ static bool skip_otp;
+-static bool rawmode;
+ static bool fw_diag_log;
+ 
++/* frame mode values are mapped as per enum ath10k_hw_txrx_mode */
++unsigned int ath10k_frame_mode = ATH10K_HW_TXRX_NATIVE_WIFI;
++
+ unsigned long ath10k_coredump_mask = BIT(ATH10K_FW_CRASH_DUMP_REGISTERS) |
+ 				     BIT(ATH10K_FW_CRASH_DUMP_CE_DATA);
+ 
+@@ -43,15 +45,16 @@ module_param_named(debug_mask, ath10k_de
+ module_param_named(cryptmode, ath10k_cryptmode_param, uint, 0644);
+ module_param(uart_print, bool, 0644);
+ module_param(skip_otp, bool, 0644);
+-module_param(rawmode, bool, 0644);
+ module_param(fw_diag_log, bool, 0644);
++module_param_named(frame_mode, ath10k_frame_mode, uint, 0644);
+ module_param_named(coredump_mask, ath10k_coredump_mask, ulong, 0444);
+ 
+ MODULE_PARM_DESC(debug_mask, "Debugging mask");
+ MODULE_PARM_DESC(uart_print, "Uart target debugging");
+ MODULE_PARM_DESC(skip_otp, "Skip otp failure for calibration in testmode");
+ MODULE_PARM_DESC(cryptmode, "Crypto mode: 0-hardware, 1-software");
+-MODULE_PARM_DESC(rawmode, "Use raw 802.11 frame datapath");
++MODULE_PARM_DESC(frame_mode,
++		 "Datapath frame mode (0: raw, 1: native wifi (default))");
+ MODULE_PARM_DESC(coredump_mask, "Bitfield of what to include in firmware crash file");
+ MODULE_PARM_DESC(fw_diag_log, "Diag based fw log debugging");
+ 
+@@ -2487,7 +2490,7 @@ static int ath10k_core_init_firmware_fea
+ 	ar->htt.max_num_amsdu = ATH10K_HTT_MAX_NUM_AMSDU_DEFAULT;
+ 	ar->htt.max_num_ampdu = ATH10K_HTT_MAX_NUM_AMPDU_DEFAULT;
+ 
+-	if (rawmode) {
++	if (ath10k_frame_mode == ATH10K_HW_TXRX_RAW) {
+ 		if (!test_bit(ATH10K_FW_FEATURE_RAW_MODE_SUPPORT,
+ 			      fw_file->fw_features)) {
+ 			ath10k_err(ar, "rawmode = 1 requires support from firmware");
+--- a/drivers/net/wireless/ath/ath10k/core.h
++++ b/drivers/net/wireless/ath/ath10k/core.h
+@@ -1311,6 +1311,7 @@ static inline bool ath10k_peer_stats_ena
+ 	return false;
+ }
+ 
++extern unsigned int ath10k_frame_mode;
+ extern unsigned long ath10k_coredump_mask;
+ 
+ void ath10k_core_napi_sync_disable(struct ath10k *ar);

--- a/package/kernel/mac80211/patches/ath10k/081-03-ath10k-htt-tx-do-not-interpret-Eth-frames-as-WiFi.patch
+++ b/package/kernel/mac80211/patches/ath10k/081-03-ath10k-htt-tx-do-not-interpret-Eth-frames-as-WiFi.patch
@@ -1,0 +1,163 @@
+From 70f119fb82af7f7417dc659faf02c91e1f853739 Mon Sep 17 00:00:00 2001
+From: Sergey Ryazanov <ryazanov.s.a@gmail.com>
+Date: Mon, 16 May 2022 13:26:00 +0300
+Subject: ath10k: htt_tx: do not interpret Eth frames as WiFi
+
+The xmit path for the Ethernet encapsulated frames become more or less
+usable since d740d8fd2439 ("ath10k: unify tx mode and dispatch"). This
+change reorganize the xmit path in a manageable way to properly support
+various tx modes, but misses that the Ethernet encapsulated frame is a
+special case. We do not have an IEEE 802.11 header at the begining of
+them. But the HTT Tx handler still interprets first bytes of each frame
+as an IEEE 802.11 Frame Control field.
+
+Than this code was copied by e62ee5c381c5 ("ath10k: Add support for
+htt_data_tx_desc_64 descriptor") and a2097d6444c3 ("ath10k: htt: High
+latency TX support") to another handlers. In fact the issue in the high
+latency (HL) handler was introduced by 83ac260151e7 ("ath10k: add mic
+bytes for pmf management packet").
+
+Ethernet encapsulated frame tx mode stay unused until 75d85fd9993c
+("ath10k: introduce basic tdls functionality") started using it for TDLS
+frames to avoid key selection issue in some firmwares.
+
+Trying to interpret the begining of an Ethernet encapsulated frame as an
+IEEE 802.11 header was not hurt us noticeably since we need to meet two
+conditions: (1) xmit should be performed towards a TDLS peer, and (2)
+the TDLS peer should have a specific OUI part of its MAC address. Looks
+like that the rareness in TDLS communications of OUIs that can be
+interpreted as an 802.11 management frame saves users from facing this
+issue earlier.
+
+Improve Ethernet tx mode support in the HTT Tx handler by avoiding
+interpreting its first bytes as an IEEE 802.11 header. While at it, make
+the ieee80211_hdr variable local to the code block that is guarded by
+!is_eth check. In this way, we clarify in which cases a frame can be
+interpreted as IEEE 802.11, and saves us from similar issues in the
+future.
+
+Credits: this change as part of xmit encapsulation offloading support
+was originally made by QCA and then submitted for inclusion by John
+Crispin [1]. But the whole work was not accepted due to the lack of a
+part for 64-bits descriptors [2]. Zhijun You then pointed this out to me
+in a reply to my initial RFC patch series. And I made this slightly
+reworked version that covered all the HTT Tx handler variants.
+
+1. https://lore.kernel.org/all/20191216092207.31032-1-john@phrozen.org/
+2. https://patchwork.kernel.org/project/linux-wireless/patch/20191216092207.31032-1-john@phrozen.org/
+
+Reported-by: Zhijun You <hujy652@gmail.com>
+Signed-off-by: Vasanthakumar Thiagarajan <vthiagar@qti.qualcomm.com>
+Signed-off-by: John Crispin <john@phrozen.org>
+Signed-off-by: Sergey Ryazanov <ryazanov.s.a@gmail.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20220516032519.29831-3-ryazanov.s.a@gmail.com
+---
+ drivers/net/wireless/ath/ath10k/htt_tx.c | 61 ++++++++++++++++++--------------
+ 1 file changed, 35 insertions(+), 26 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath10k/htt_tx.c
++++ b/drivers/net/wireless/ath/ath10k/htt_tx.c
+@@ -1295,7 +1295,6 @@ static int ath10k_htt_tx_hl(struct ath10
+ 	struct ath10k *ar = htt->ar;
+ 	int res, data_len;
+ 	struct htt_cmd_hdr *cmd_hdr;
+-	struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)msdu->data;
+ 	struct htt_data_tx_desc *tx_desc;
+ 	struct ath10k_skb_cb *skb_cb = ATH10K_SKB_CB(msdu);
+ 	struct sk_buff *tmp_skb;
+@@ -1306,11 +1305,15 @@ static int ath10k_htt_tx_hl(struct ath10
+ 	u16 flags1 = 0;
+ 	u16 msdu_id = 0;
+ 
+-	if ((ieee80211_is_action(hdr->frame_control) ||
+-	     ieee80211_is_deauth(hdr->frame_control) ||
+-	     ieee80211_is_disassoc(hdr->frame_control)) &&
+-	     ieee80211_has_protected(hdr->frame_control)) {
+-		skb_put(msdu, IEEE80211_CCMP_MIC_LEN);
++	if (!is_eth) {
++		struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)msdu->data;
++
++		if ((ieee80211_is_action(hdr->frame_control) ||
++		     ieee80211_is_deauth(hdr->frame_control) ||
++		     ieee80211_is_disassoc(hdr->frame_control)) &&
++		     ieee80211_has_protected(hdr->frame_control)) {
++			skb_put(msdu, IEEE80211_CCMP_MIC_LEN);
++		}
+ 	}
+ 
+ 	data_len = msdu->len;
+@@ -1407,7 +1410,6 @@ static int ath10k_htt_tx_32(struct ath10
+ {
+ 	struct ath10k *ar = htt->ar;
+ 	struct device *dev = ar->dev;
+-	struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)msdu->data;
+ 	struct ieee80211_tx_info *info = IEEE80211_SKB_CB(msdu);
+ 	struct ath10k_skb_cb *skb_cb = ATH10K_SKB_CB(msdu);
+ 	struct ath10k_hif_sg_item sg_items[2];
+@@ -1439,15 +1441,19 @@ static int ath10k_htt_tx_32(struct ath10
+ 	txbuf_paddr = htt->txbuf.paddr +
+ 		      (sizeof(struct ath10k_htt_txbuf_32) * msdu_id);
+ 
+-	if ((ieee80211_is_action(hdr->frame_control) ||
+-	     ieee80211_is_deauth(hdr->frame_control) ||
+-	     ieee80211_is_disassoc(hdr->frame_control)) &&
+-	     ieee80211_has_protected(hdr->frame_control)) {
+-		skb_put(msdu, IEEE80211_CCMP_MIC_LEN);
+-	} else if (!(skb_cb->flags & ATH10K_SKB_F_NO_HWCRYPT) &&
+-		   txmode == ATH10K_HW_TXRX_RAW &&
+-		   ieee80211_has_protected(hdr->frame_control)) {
+-		skb_put(msdu, IEEE80211_CCMP_MIC_LEN);
++	if (!is_eth) {
++		struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)msdu->data;
++
++		if ((ieee80211_is_action(hdr->frame_control) ||
++		     ieee80211_is_deauth(hdr->frame_control) ||
++		     ieee80211_is_disassoc(hdr->frame_control)) &&
++		     ieee80211_has_protected(hdr->frame_control)) {
++			skb_put(msdu, IEEE80211_CCMP_MIC_LEN);
++		} else if (!(skb_cb->flags & ATH10K_SKB_F_NO_HWCRYPT) &&
++			   txmode == ATH10K_HW_TXRX_RAW &&
++			   ieee80211_has_protected(hdr->frame_control)) {
++			skb_put(msdu, IEEE80211_CCMP_MIC_LEN);
++		}
+ 	}
+ 
+ 	skb_cb->paddr = dma_map_single(dev, msdu->data, msdu->len,
+@@ -1609,7 +1615,6 @@ static int ath10k_htt_tx_64(struct ath10
+ {
+ 	struct ath10k *ar = htt->ar;
+ 	struct device *dev = ar->dev;
+-	struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)msdu->data;
+ 	struct ieee80211_tx_info *info = IEEE80211_SKB_CB(msdu);
+ 	struct ath10k_skb_cb *skb_cb = ATH10K_SKB_CB(msdu);
+ 	struct ath10k_hif_sg_item sg_items[2];
+@@ -1641,15 +1646,19 @@ static int ath10k_htt_tx_64(struct ath10
+ 	txbuf_paddr = htt->txbuf.paddr +
+ 		      (sizeof(struct ath10k_htt_txbuf_64) * msdu_id);
+ 
+-	if ((ieee80211_is_action(hdr->frame_control) ||
+-	     ieee80211_is_deauth(hdr->frame_control) ||
+-	     ieee80211_is_disassoc(hdr->frame_control)) &&
+-	     ieee80211_has_protected(hdr->frame_control)) {
+-		skb_put(msdu, IEEE80211_CCMP_MIC_LEN);
+-	} else if (!(skb_cb->flags & ATH10K_SKB_F_NO_HWCRYPT) &&
+-		   txmode == ATH10K_HW_TXRX_RAW &&
+-		   ieee80211_has_protected(hdr->frame_control)) {
+-		skb_put(msdu, IEEE80211_CCMP_MIC_LEN);
++	if (!is_eth) {
++		struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)msdu->data;
++
++		if ((ieee80211_is_action(hdr->frame_control) ||
++		     ieee80211_is_deauth(hdr->frame_control) ||
++		     ieee80211_is_disassoc(hdr->frame_control)) &&
++		     ieee80211_has_protected(hdr->frame_control)) {
++			skb_put(msdu, IEEE80211_CCMP_MIC_LEN);
++		} else if (!(skb_cb->flags & ATH10K_SKB_F_NO_HWCRYPT) &&
++			   txmode == ATH10K_HW_TXRX_RAW &&
++			   ieee80211_has_protected(hdr->frame_control)) {
++			skb_put(msdu, IEEE80211_CCMP_MIC_LEN);
++		}
+ 	}
+ 
+ 	skb_cb->paddr = dma_map_single(dev, msdu->data, msdu->len,

--- a/package/kernel/mac80211/patches/ath10k/081-04-ath10k-add-encapsulation-offloading-support.patch
+++ b/package/kernel/mac80211/patches/ath10k/081-04-ath10k-add-encapsulation-offloading-support.patch
@@ -1,0 +1,194 @@
+From af6d8265c47e46881b80c6b073f53c8c4af52d28 Mon Sep 17 00:00:00 2001
+From: Sergey Ryazanov <ryazanov.s.a@gmail.com>
+Date: Mon, 16 May 2022 13:26:00 +0300
+Subject: ath10k: add encapsulation offloading support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Frame encapsulation from Ethernet into the IEEE 802.11 frame format
+takes a considerable host CPU time on the xmit path. The firmware is
+able to do this operation for us, so enable encapsulation offloading for
+AP and Sta interface types to improve overall system performance.
+
+The driver is almost ready for encapsulation offloading support. There
+are only a few places where the driver assumes the frame format is IEEE
+802.11 that need to be fixed.
+
+Encapsulation offloading is currently disabled by default and the driver
+utilizes mac80211 encapsulation support. To activate offloading, the
+frame_mode=2 parameter should be passed during module loading.
+
+On a QCA9563+QCA9888-based access point in bridged mode, encapsulation
+offloading increases TCP 16-streams DL throughput from 365 to 396 mbps
+(+8%) and UDP DL throughput from 436 to 483 mbps (+11%).
+
+Tested-on: QCA9888 hw2.0 PCI 10.4-3.9.0.2-00131
+Tested-on: QCA6174 hw3.2 PCI WLAN.RM.4.4.1-00157-QCARMSWPZ-1
+Signed-off-by: Sergey Ryazanov <ryazanov.s.a@gmail.com>
+Tested-by: Oldřich Jedlička <oldium.pro@gmail.com> # TP-Link Archer C7 v4 & v5 (QCA9563 + QCA9880)
+Tested-by: Edward Matijevic <motolav@gmail.com> # TP-Link Archer C2600 (IPQ8064 + QCA9980 10.4.1.00030-1)
+Tested-by: Edward Matijevic <motolav@gmail.com> # QCA9377 PCI in Sta mode
+Tested-by: Zhijun You <hujy652@gmail.com> # NETGEAR R7800 (QCA9984 10.4-3.9.0.2-00159)
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20220516032519.29831-5-ryazanov.s.a@gmail.com
+---
+ drivers/net/wireless/ath/ath10k/core.c |  2 +-
+ drivers/net/wireless/ath/ath10k/mac.c  | 67 +++++++++++++++++++++++++++-------
+ 2 files changed, 55 insertions(+), 14 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -54,7 +54,7 @@ MODULE_PARM_DESC(uart_print, "Uart targe
+ MODULE_PARM_DESC(skip_otp, "Skip otp failure for calibration in testmode");
+ MODULE_PARM_DESC(cryptmode, "Crypto mode: 0-hardware, 1-software");
+ MODULE_PARM_DESC(frame_mode,
+-		 "Datapath frame mode (0: raw, 1: native wifi (default))");
++		 "Datapath frame mode (0: raw, 1: native wifi (default), 2: ethernet)");
+ MODULE_PARM_DESC(coredump_mask, "Bitfield of what to include in firmware crash file");
+ MODULE_PARM_DESC(fw_diag_log, "Diag based fw log debugging");
+ 
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -3710,6 +3710,9 @@ ath10k_mac_tx_h_get_txmode(struct ath10k
+ 	const struct ath10k_skb_cb *skb_cb = ATH10K_SKB_CB(skb);
+ 	__le16 fc = hdr->frame_control;
+ 
++	if (IEEE80211_SKB_CB(skb)->flags & IEEE80211_TX_CTL_HW_80211_ENCAP)
++		return ATH10K_HW_TXRX_ETHERNET;
++
+ 	if (!vif || vif->type == NL80211_IFTYPE_MONITOR)
+ 		return ATH10K_HW_TXRX_RAW;
+ 
+@@ -3870,6 +3873,12 @@ static void ath10k_mac_tx_h_fill_cb(stru
+ 	bool noack = false;
+ 
+ 	cb->flags = 0;
++
++	if (info->flags & IEEE80211_TX_CTL_HW_80211_ENCAP) {
++		cb->flags |= ATH10K_SKB_F_QOS;	/* Assume data frames are QoS */
++		goto finish_cb_fill;
++	}
++
+ 	if (!ath10k_tx_h_use_hwcrypto(vif, skb))
+ 		cb->flags |= ATH10K_SKB_F_NO_HWCRYPT;
+ 
+@@ -3908,6 +3917,7 @@ static void ath10k_mac_tx_h_fill_cb(stru
+ 		cb->flags |= ATH10K_SKB_F_RAW_TX;
+ 	}
+ 
++finish_cb_fill:
+ 	cb->vif = vif;
+ 	cb->txq = txq;
+ 	cb->airtime_est = airtime;
+@@ -4031,7 +4041,11 @@ static int ath10k_mac_tx(struct ath10k *
+ 		ath10k_tx_h_seq_no(vif, skb);
+ 		break;
+ 	case ATH10K_HW_TXRX_ETHERNET:
+-		ath10k_tx_h_8023(skb);
++		/* Convert 802.11->802.3 header only if the frame was erlier
++		 * encapsulated to 802.11 by mac80211. Otherwise pass it as is.
++		 */
++		if (!(info->flags & IEEE80211_TX_CTL_HW_80211_ENCAP))
++			ath10k_tx_h_8023(skb);
+ 		break;
+ 	case ATH10K_HW_TXRX_RAW:
+ 		if (!test_bit(ATH10K_FLAG_RAW_MODE, &ar->dev_flags) &&
+@@ -4643,12 +4657,10 @@ static void ath10k_mac_op_tx(struct ieee
+ 	struct ieee80211_vif *vif = info->control.vif;
+ 	struct ieee80211_sta *sta = control->sta;
+ 	struct ieee80211_txq *txq = NULL;
+-	struct ieee80211_hdr *hdr = (void *)skb->data;
+ 	enum ath10k_hw_txrx_mode txmode;
+ 	enum ath10k_mac_tx_path txpath;
+ 	bool is_htt;
+ 	bool is_mgmt;
+-	bool is_presp;
+ 	int ret;
+ 	u16 airtime;
+ 
+@@ -4662,8 +4674,14 @@ static void ath10k_mac_op_tx(struct ieee
+ 	is_mgmt = (txpath == ATH10K_MAC_TX_HTT_MGMT);
+ 
+ 	if (is_htt) {
++		bool is_presp = false;
++
+ 		spin_lock_bh(&ar->htt.tx_lock);
+-		is_presp = ieee80211_is_probe_resp(hdr->frame_control);
++		if (!(info->flags & IEEE80211_TX_CTL_HW_80211_ENCAP)) {
++			struct ieee80211_hdr *hdr = (void *)skb->data;
++
++			is_presp = ieee80211_is_probe_resp(hdr->frame_control);
++		}
+ 
+ 		ret = ath10k_htt_tx_inc_pending(htt);
+ 		if (ret) {
+@@ -5447,6 +5465,30 @@ static int ath10k_mac_set_txbf_conf(stru
+ 					 ar->wmi.vdev_param->txbf, value);
+ }
+ 
++static void ath10k_update_vif_offload(struct ieee80211_hw *hw,
++				      struct ieee80211_vif *vif)
++{
++	struct ath10k_vif *arvif = (void *)vif->drv_priv;
++	struct ath10k *ar = hw->priv;
++	u32 vdev_param;
++	int ret;
++
++	if (ath10k_frame_mode != ATH10K_HW_TXRX_ETHERNET ||
++	    ar->wmi.vdev_param->tx_encap_type == WMI_VDEV_PARAM_UNSUPPORTED ||
++	     (vif->type != NL80211_IFTYPE_STATION &&
++	      vif->type != NL80211_IFTYPE_AP))
++		vif->offload_flags &= ~IEEE80211_OFFLOAD_ENCAP_ENABLED;
++
++	vdev_param = ar->wmi.vdev_param->tx_encap_type;
++	ret = ath10k_wmi_vdev_set_param(ar, arvif->vdev_id, vdev_param,
++					ATH10K_HW_TXRX_NATIVE_WIFI);
++	/* 10.X firmware does not support this VDEV parameter. Do not warn */
++	if (ret && ret != -EOPNOTSUPP) {
++		ath10k_warn(ar, "failed to set vdev %i TX encapsulation: %d\n",
++			    arvif->vdev_id, ret);
++	}
++}
++
+ /*
+  * TODO:
+  * Figure out how to handle WMI_VDEV_SUBTYPE_P2P_DEVICE,
+@@ -5656,15 +5698,7 @@ static int ath10k_add_interface(struct i
+ 
+ 	arvif->def_wep_key_idx = -1;
+ 
+-	vdev_param = ar->wmi.vdev_param->tx_encap_type;
+-	ret = ath10k_wmi_vdev_set_param(ar, arvif->vdev_id, vdev_param,
+-					ATH10K_HW_TXRX_NATIVE_WIFI);
+-	/* 10.X firmware does not support this VDEV parameter. Do not warn */
+-	if (ret && ret != -EOPNOTSUPP) {
+-		ath10k_warn(ar, "failed to set vdev %i TX encapsulation: %d\n",
+-			    arvif->vdev_id, ret);
+-		goto err_vdev_delete;
+-	}
++	ath10k_update_vif_offload(hw, vif);
+ 
+ 	/* Configuring number of spatial stream for monitor interface is causing
+ 	 * target assert in qca9888 and qca6174.
+@@ -9352,6 +9386,7 @@ static const struct ieee80211_ops ath10k
+ 	.stop				= ath10k_stop,
+ 	.config				= ath10k_config,
+ 	.add_interface			= ath10k_add_interface,
++	.update_vif_offload		= ath10k_update_vif_offload,
+ 	.remove_interface		= ath10k_remove_interface,
+ 	.configure_filter		= ath10k_configure_filter,
+ 	.bss_info_changed		= ath10k_bss_info_changed,
+@@ -10021,6 +10056,12 @@ int ath10k_mac_register(struct ath10k *a
+ 	if (test_bit(WMI_SERVICE_TDLS_UAPSD_BUFFER_STA, ar->wmi.svc_map))
+ 		ieee80211_hw_set(ar->hw, SUPPORTS_TDLS_BUFFER_STA);
+ 
++	if (ath10k_frame_mode == ATH10K_HW_TXRX_ETHERNET) {
++		if (ar->wmi.vdev_param->tx_encap_type !=
++		    WMI_VDEV_PARAM_UNSUPPORTED)
++			ieee80211_hw_set(ar->hw, SUPPORTS_TX_ENCAP_OFFLOAD);
++	}
++
+ 	ar->hw->wiphy->flags |= WIPHY_FLAG_HAS_REMAIN_ON_CHANNEL;
+ 	ar->hw->wiphy->flags |= WIPHY_FLAG_HAS_CHANNEL_SWITCH;
+ 	ar->hw->wiphy->max_remain_on_channel_duration = 5000;

--- a/package/kernel/mac80211/patches/ath10k/120-ath10k-fetch-calibration-data-via-nvmem-subsystem.patch
+++ b/package/kernel/mac80211/patches/ath10k/120-ath10k-fetch-calibration-data-via-nvmem-subsystem.patch
@@ -34,7 +34,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
  #include <asm/byteorder.h>
  
  #include "core.h"
-@@ -952,7 +953,8 @@ static int ath10k_core_get_board_id_from
+@@ -955,7 +956,8 @@ static int ath10k_core_get_board_id_from
  	}
  
  	if (ar->cal_mode == ATH10K_PRE_CAL_MODE_DT ||
@@ -44,7 +44,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
  		bmi_board_id_param = BMI_PARAM_GET_FLASH_BOARD_ID;
  	else
  		bmi_board_id_param = BMI_PARAM_GET_EEPROM_BOARD_ID;
-@@ -1743,7 +1745,8 @@ static int ath10k_download_and_run_otp(s
+@@ -1746,7 +1748,8 @@ static int ath10k_download_and_run_otp(s
  
  	/* As of now pre-cal is valid for 10_4 variants */
  	if (ar->cal_mode == ATH10K_PRE_CAL_MODE_DT ||
@@ -54,7 +54,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
  		bmi_otp_exe_param = BMI_PARAM_FLASH_SECTION_ALL;
  
  	ret = ath10k_bmi_execute(ar, address, bmi_otp_exe_param, &result);
-@@ -1870,6 +1873,39 @@ out_free:
+@@ -1873,6 +1876,39 @@ out_free:
  	return ret;
  }
  
@@ -94,7 +94,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
  int ath10k_core_fetch_firmware_api_n(struct ath10k *ar, const char *name,
  				     struct ath10k_fw_file *fw_file)
  {
-@@ -2104,6 +2140,18 @@ static int ath10k_core_pre_cal_download(
+@@ -2107,6 +2143,18 @@ static int ath10k_core_pre_cal_download(
  {
  	int ret;
  
@@ -113,7 +113,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
  	ret = ath10k_download_cal_file(ar, ar->pre_cal_file);
  	if (ret == 0) {
  		ar->cal_mode = ATH10K_PRE_CAL_MODE_FILE;
-@@ -2170,6 +2218,18 @@ static int ath10k_download_cal_data(stru
+@@ -2173,6 +2221,18 @@ static int ath10k_download_cal_data(stru
  		   "pre cal download procedure failed, try cal file: %d\n",
  		   ret);
  

--- a/package/kernel/mac80211/patches/ath10k/921-ath10k_init_devices_synchronously.patch
+++ b/package/kernel/mac80211/patches/ath10k/921-ath10k_init_devices_synchronously.patch
@@ -14,7 +14,7 @@ Signed-off-by: Sven Eckelmann <sven@open-mesh.com>
 
 --- a/drivers/net/wireless/ath/ath10k/core.c
 +++ b/drivers/net/wireless/ath/ath10k/core.c
-@@ -3429,6 +3429,16 @@ int ath10k_core_register(struct ath10k *
+@@ -3432,6 +3432,16 @@ int ath10k_core_register(struct ath10k *
  
  	queue_work(ar->workqueue, &ar->register_work);
  

--- a/package/kernel/mac80211/patches/ath10k/930-ath10k_add_tpt_led_trigger.patch
+++ b/package/kernel/mac80211/patches/ath10k/930-ath10k_add_tpt_led_trigger.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/wireless/ath/ath10k/mac.c
 +++ b/drivers/net/wireless/ath/ath10k/mac.c
-@@ -9843,6 +9843,21 @@ static int ath10k_mac_init_rd(struct ath
+@@ -9878,6 +9878,21 @@ static int ath10k_mac_init_rd(struct ath
  	return 0;
  }
  
@@ -22,7 +22,7 @@
  int ath10k_mac_register(struct ath10k *ar)
  {
  	static const u32 cipher_suites[] = {
-@@ -10195,6 +10210,12 @@ int ath10k_mac_register(struct ath10k *a
+@@ -10236,6 +10251,12 @@ int ath10k_mac_register(struct ath10k *a
  
  	ar->hw->weight_multiplier = ATH10K_AIRTIME_WEIGHT_MULTIPLIER;
  

--- a/package/kernel/mac80211/patches/ath10k/974-ath10k_add-LED-and-GPIO-controlling-support-for-various-chipsets.patch
+++ b/package/kernel/mac80211/patches/ath10k/974-ath10k_add-LED-and-GPIO-controlling-support-for-various-chipsets.patch
@@ -132,7 +132,7 @@ v13:
  
  unsigned int ath10k_debug_mask;
  EXPORT_SYMBOL(ath10k_debug_mask);
-@@ -62,6 +63,7 @@ static const struct ath10k_hw_params ath
+@@ -65,6 +66,7 @@ static const struct ath10k_hw_params ath
  		.dev_id = QCA988X_2_0_DEVICE_ID,
  		.bus = ATH10K_BUS_PCI,
  		.name = "qca988x hw2.0",
@@ -140,7 +140,7 @@ v13:
  		.patch_load_addr = QCA988X_HW_2_0_PATCH_LOAD_ADDR,
  		.uart_pin = 7,
  		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_ALL,
-@@ -135,6 +137,7 @@ static const struct ath10k_hw_params ath
+@@ -138,6 +140,7 @@ static const struct ath10k_hw_params ath
  		.dev_id = QCA9887_1_0_DEVICE_ID,
  		.bus = ATH10K_BUS_PCI,
  		.name = "qca9887 hw1.0",
@@ -148,7 +148,7 @@ v13:
  		.patch_load_addr = QCA9887_HW_1_0_PATCH_LOAD_ADDR,
  		.uart_pin = 7,
  		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_ALL,
-@@ -352,6 +355,7 @@ static const struct ath10k_hw_params ath
+@@ -355,6 +358,7 @@ static const struct ath10k_hw_params ath
  		.dev_id = QCA99X0_2_0_DEVICE_ID,
  		.bus = ATH10K_BUS_PCI,
  		.name = "qca99x0 hw2.0",
@@ -156,7 +156,7 @@ v13:
  		.patch_load_addr = QCA99X0_HW_2_0_PATCH_LOAD_ADDR,
  		.uart_pin = 7,
  		.otp_exe_param = 0x00000700,
-@@ -394,6 +398,7 @@ static const struct ath10k_hw_params ath
+@@ -397,6 +401,7 @@ static const struct ath10k_hw_params ath
  		.dev_id = QCA9984_1_0_DEVICE_ID,
  		.bus = ATH10K_BUS_PCI,
  		.name = "qca9984/qca9994 hw1.0",
@@ -164,7 +164,7 @@ v13:
  		.patch_load_addr = QCA9984_HW_1_0_PATCH_LOAD_ADDR,
  		.uart_pin = 7,
  		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_EACH,
-@@ -443,6 +448,7 @@ static const struct ath10k_hw_params ath
+@@ -446,6 +451,7 @@ static const struct ath10k_hw_params ath
  		.dev_id = QCA9888_2_0_DEVICE_ID,
  		.bus = ATH10K_BUS_PCI,
  		.name = "qca9888 hw2.0",
@@ -172,7 +172,7 @@ v13:
  		.patch_load_addr = QCA9888_HW_2_0_PATCH_LOAD_ADDR,
  		.uart_pin = 7,
  		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_EACH,
-@@ -3144,6 +3150,10 @@ int ath10k_core_start(struct ath10k *ar,
+@@ -3147,6 +3153,10 @@ int ath10k_core_start(struct ath10k *ar,
  		goto err_hif_stop;
  	}
  
@@ -183,7 +183,7 @@ v13:
  	return 0;
  
  err_hif_stop:
-@@ -3402,9 +3412,18 @@ static void ath10k_core_register_work(st
+@@ -3405,9 +3415,18 @@ static void ath10k_core_register_work(st
  		goto err_spectral_destroy;
  	}
  
@@ -202,7 +202,7 @@ v13:
  err_spectral_destroy:
  	ath10k_spectral_destroy(ar);
  err_debug_destroy:
-@@ -3450,6 +3469,8 @@ void ath10k_core_unregister(struct ath10
+@@ -3453,6 +3472,8 @@ void ath10k_core_unregister(struct ath10
  	if (!test_bit(ATH10K_FLAG_CORE_REGISTERED, &ar->dev_flags))
  		return;
  

--- a/package/kernel/mac80211/patches/ath10k/975-ath10k-use-tpt-trigger-by-default.patch
+++ b/package/kernel/mac80211/patches/ath10k/975-ath10k-use-tpt-trigger-by-default.patch
@@ -42,7 +42,7 @@ Signed-off-by: Mathias Kresin <dev@kresin.me>
  	if (ret)
 --- a/drivers/net/wireless/ath/ath10k/mac.c
 +++ b/drivers/net/wireless/ath/ath10k/mac.c
-@@ -10212,7 +10212,7 @@ int ath10k_mac_register(struct ath10k *a
+@@ -10253,7 +10253,7 @@ int ath10k_mac_register(struct ath10k *a
  	ar->hw->weight_multiplier = ATH10K_AIRTIME_WEIGHT_MULTIPLIER;
  
  #ifdef CPTCFG_MAC80211_LEDS

--- a/package/kernel/mac80211/patches/ath10k/984-ath10k-Try-to-get-mac-address-from-dts.patch
+++ b/package/kernel/mac80211/patches/ath10k/984-ath10k-Try-to-get-mac-address-from-dts.patch
@@ -26,7 +26,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  #include <linux/property.h>
  #include <linux/dmi.h>
  #include <linux/ctype.h>
-@@ -3320,6 +3321,8 @@ static int ath10k_core_probe_fw(struct a
+@@ -3323,6 +3324,8 @@ static int ath10k_core_probe_fw(struct a
  
  	device_get_mac_address(ar->dev, ar->mac_addr, sizeof(ar->mac_addr));
  

--- a/package/kernel/mac80211/patches/ath9k/580-ath9k_ar9561_fix_bias_level.patch
+++ b/package/kernel/mac80211/patches/ath9k/580-ath9k_ar9561_fix_bias_level.patch
@@ -29,8 +29,6 @@ v2: Adjust #define per Felix's suggestion
  drivers/net/wireless/ath/ath9k/ar9003_phy.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/drivers/net/wireless/ath/ath9k/ar9003_phy.h b/drivers/net/wireless/ath/ath9k/ar9003_phy.h
-index a171dbb29..ad949eb02 100644
 --- a/drivers/net/wireless/ath/ath9k/ar9003_phy.h
 +++ b/drivers/net/wireless/ath/ath9k/ar9003_phy.h
 @@ -720,7 +720,7 @@
@@ -42,6 +40,3 @@ index a171dbb29..ad949eb02 100644
  
  #define AR_CH0_XTAL		(AR_SREV_9300(ah) ? 0x16294 : \
  				 ((AR_SREV_9462(ah) || AR_SREV_9565(ah)) ? 0x16298 : \
--- 
-2.30.2
-


### PR DESCRIPTION
This backports encap offload support from upstream.
On some ath10k devices there can be about 10% improvement on tx throughput.
Users can turn it on by setting frame_mode=2.

Signed-off-by: Zhijun You <hujy652@gmail.com>
(cherry picked from commit 00f64ed)