### PR TITLE
lantiq: dts: td-w8980: Remove duplicate PCI properties

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_tdw8980.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_tdw8980.dts
@@ -24,8 +24,6 @@
 
 &pci0 {
 	status = "okay";
-	lantiq,bus-clock = <33333333>;
-	interrupt-map-mask = <0xf800 0x0 0x0 0x7>;
-	interrupt-map = <0x7000 0 0 1 &icu0 30 1>;
+
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 };


### PR DESCRIPTION
lantiq,bus-clock, interrupt-map-mask and interrupt-map are already
defined with these exact values in vr9.dtsi. Drop them from
vr9_tplink_tdw8980.dts to just have one place where these are
maintained.

There are no functional changes with this commit - it's a simple cleanup, so no need to backport to a stable release either.