### PR TITLE
ath79: support for TP-Link EAP225 v4

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_eap225-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_eap225-v4.dts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9563_tplink_eap2x5-1port.dtsi"
+
+/ {
+	compatible = "tplink,eap225-v4", "qca,qca9563";
+	model = "TP-Link EAP225 v4";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_amber;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_amber;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led_status_amber: status_amber {
+			label = "amber:status";
+			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&art {
+	precalibration_ath10k: pre-calibration@5000 {
+		reg = <0x5000 0x2f20>;
+	};
+};
+
+&eth0 {
+	phy-handle = <&phy6>;
+	phy-mode = "sgmii";
+};
+
+&mdio0 {
+	phy6: ethernet-phy@6 {
+		reg = <6>;
+	};
+};
+
+&pcie {
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0 0 0 0 0>;
+
+		mac-address-increment = <1>;
+
+		nvmem-cells = <&macaddr_info_8>, <&precalibration_ath10k>;
+		nvmem-cell-names = "mac-address", "pre-calibration";
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -79,6 +79,7 @@ ath79_setup_interfaces()
 	tplink,eap225-outdoor-v3|\
 	tplink,eap225-v1|\
 	tplink,eap225-v3|\
+	tplink,eap225-v4|\
 	tplink,eap245-v1|\
 	tplink,re350k-v1|\
 	tplink,re355-v1|\

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -434,6 +434,17 @@ define Device/tplink_eap225-v3
 endef
 TARGET_DEVICES += tplink_eap225-v3
 
+define Device/tplink_eap225-v4
+  $(Device/tplink-eap2x5)
+  SOC := qca9563
+  IMAGE_SIZE := 13824k
+  DEVICE_MODEL := EAP225
+  DEVICE_VARIANT := v4
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  TPLINK_BOARD_ID := EAP225-V3
+endef
+TARGET_DEVICES += tplink_eap225-v4
+
 define Device/tplink_eap225-wall-v2
   $(Device/tplink-eap2x5)
   SOC := qca9561


### PR DESCRIPTION
These commits add support for TP-Link EAP225 v4. The main difference between v3 and v4 is the PHY `RTL8211FS`.
The second commit tries to circumvents a design decision of TP-Link:
The reset line of the PHY is not connected. Using the external Watchdog as reset line for the whole system allows the PHY to work after a reboot.