### PR TITLE
ipq40xx: add MikroTik wAP ac (RBwAPG-5HacD2HnD) support

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -90,7 +90,8 @@ ipq40xx_setup_interfaces()
 		;;
 	compex,wpj419|\
 	compex,wpj428|\
-	engenius,eap2200)
+	engenius,eap2200|\
+	mikrotik,wap-ac)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;
 	buffalo,wtr-m2133hp)

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -117,7 +117,8 @@ case "$FIRMWARE" in
 		;;
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2 |\
-	mikrotik,hap-ac3)
+	mikrotik,hap-ac3 |\
+	mikrotik,wap-ac)
 		wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"
 		( [ -f "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data" 0x0 0x2f20 ) || \
 		( [ -d "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data/data_0" 0x0 0x2f20 )
@@ -199,7 +200,8 @@ case "$FIRMWARE" in
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2 |\
 	mikrotik,hap-ac3 |\
-	mikrotik,sxtsq-5-ac)
+	mikrotik,sxtsq-5-ac |\
+	mikrotik,wap-ac)
 		wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"
 		( [ -f "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data" 0x8000 0x2f20 ) || \
 		( [ -d "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data/data_2" 0x0 0x2f20 )
@@ -222,7 +224,8 @@ case "$FIRMWARE" in
 	case "$board" in
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2 |\
-	mikrotik,hap-ac3)
+	mikrotik,hap-ac3 |\
+	mikrotik,wap-ac)
 		wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"
 		( [ -f "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data" 0x2f20 0x2f20 ) || \
 		( [ -d "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data/data_0" 0x2f20 0x2f20 )
@@ -234,7 +237,8 @@ case "$FIRMWARE" in
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2 |\
 	mikrotik,hap-ac3 |\
-	mikrotik,sxtsq-5-ac)
+	mikrotik,sxtsq-5-ac |\
+	mikrotik,wap-ac)
 		wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"
 		( [ -f "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data" 0xaf20 0x2f20 ) || \
 		( [ -d "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data/data_2" 0x2f20 0x2f20 )

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -26,6 +26,11 @@ preinit_set_mac_address() {
 		mac_lan=$(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 0x66)
 		[ -n "$mac_lan" ] && ip link set dev eth0 address "$mac_lan"
 		;;
+	mikrotik,wap-ac)
+		base_mac=$(cat /sys/firmware/mikrotik/hard_config/mac_base)
+		ip link set dev eth0 address "$base_mac"
+		ip link set dev eth1 address $(macaddr_add "$base_mac" 1)
+		;;
 	zyxel,nbg6617)
 		base_mac=$(cat /sys/class/net/eth0/address)
 		ip link set dev eth0 address $(macaddr_add "$base_mac" 2)

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -173,7 +173,8 @@ platform_do_upgrade() {
 	mikrotik,cap-ac|\
 	mikrotik,hap-ac2|\
 	mikrotik,lhgg-60ad|\
-	mikrotik,sxtsq-5-ac)
+	mikrotik,sxtsq-5-ac|\
+	mikrotik,wap-ac)
 		[ "$(rootfs_type)" = "tmpfs" ] && mtd erase firmware
 		default_do_upgrade "$1"
 		;;

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-wap-ac.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-wap-ac.dts
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2020, Robert Marko <robimarko@gmail.com> */
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "MikroTik wAP ac";
+	compatible = "mikrotik,wap-ac";
+
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x08000000>;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	aliases {
+		led-boot = &led_user;
+		led-failsafe = &led_user;
+		led-running = &led_user;
+		led-upgrade = &led_user;
+	};
+
+	soc {
+		counter@4a1000 {
+			compatible = "qcom,qca-gcnt";
+			reg = <0x4a1000 0x4>;
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+
+		ess-switch@c000000 {
+			status = "okay";
+		};
+
+		edma@c080000 {
+			status = "okay";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "blue:power";
+			gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
+		};
+
+		led_user: user {
+			label = "green:user";
+			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+	};
+};
+
+&prng {
+	status = "okay";
+};
+
+&tlmm {
+	serial_pins: serial_pinmux {
+		mux {
+			pins = "gpio60", "gpio61";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		pin {
+			function = "blsp_spi0";
+			pins = "gpio55", "gpio56", "gpio57";
+			drive-strength = <2>;
+			bias-disable;
+		};
+		pin_cs {
+			function = "gpio";
+			pins = "gpio54";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&blsp1_spi1 {
+	status = "okay";
+
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
+
+	flash@0 {
+		reg = <0>;
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Qualcomm";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				compatible = "mikrotik,routerboot-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				label = "RouterBoot";
+				reg = <0x80000 0x80000>;
+
+				hard_config {
+					read-only;
+					size = <0x2000>;
+				};
+
+				dtb_config {
+					read-only;
+				};
+
+				soft_config {
+				};
+			};
+
+			partition@100000 {
+				compatible = "mikrotik,minor";
+				label = "firmware";
+				reg = <0x100000 0xf00000>;
+			};
+		};
+	};
+};
+
+&blsp1_uart1 {
+	status = "okay";
+
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+};
+
+&gmac0 {
+	qcom,phy_mdio_addr = <4>;
+	qcom,poll_required = <1>;
+	qcom,forced_speed = <1000>;
+	qcom,forced_duplex = <1>;
+	vlan_tag = <2 0x20>;
+};
+
+&gmac1 {
+	qcom,phy_mdio_addr = <3>;
+	vlan_tag = <1 0x10>;
+};
+
+&wifi0 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "MikroTik-wAP-ac";
+};
+
+&wifi1 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "MikroTik-wAP-ac";
+};

--- a/target/linux/ipq40xx/image/mikrotik.mk
+++ b/target/linux/ipq40xx/image/mikrotik.mk
@@ -62,3 +62,11 @@ define Device/mikrotik_sxtsq-5-ac
 	DEVICE_PACKAGES := rssileds
 endef
 TARGET_DEVICES += mikrotik_sxtsq-5-ac
+
+define Device/mikrotik_wap-ac
+	$(call Device/mikrotik_nor)
+	DEVICE_MODEL := wAP ac
+	SOC := qcom-ipq4018
+	DEVICE_PACKAGES := -kmod-ath10k-ct kmod-ath10k-ct-smallbuffers
+endef
+TARGET_DEVICES += mikrotik_wap-ac

--- a/target/linux/ipq40xx/patches-5.10/901-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq40xx/patches-5.10/901-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -903,11 +903,78 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -903,11 +903,79 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8074-dragonboard.dtb \
  	qcom-apq8084-ifc6540.dtb \
  	qcom-apq8084-mtp.dtb \
@@ -40,6 +40,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq4018-rt-ac58u.dtb \
 +	qcom-ipq4018-rutx10.dtb \
 +	qcom-ipq4018-wac510.dtb \
++	qcom-ipq4018-wap-ac.dtb \
 +	qcom-ipq4018-whw01-v1.dtb \
 +	qcom-ipq4018-wre6606.dtb \
 +	qcom-ipq4018-wrtq-329acn.dtb \

--- a/target/linux/ipq40xx/patches-5.15/901-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq40xx/patches-5.15/901-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -951,11 +951,77 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -951,11 +951,78 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4018-ap120c-ac.dtb \
  	qcom-ipq4018-ap120c-ac-bit.dtb \
  	qcom-ipq4018-jalapeno.dtb \
@@ -39,6 +39,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq4018-rt-ac58u.dtb \
 +	qcom-ipq4018-rutx10.dtb \
 +	qcom-ipq4018-wac510.dtb \
++	qcom-ipq4018-wap-ac.dtb \
 +	qcom-ipq4018-whw01-v1.dtb \
 +	qcom-ipq4018-wre6606.dtb \
 +	qcom-ipq4018-wrtq-329acn.dtb \


### PR DESCRIPTION
I don’t love doing this, because there’s [another pull request pending for this device](https://github.com/openwrt/openwrt/pull/3806), but it’s languished for a year and a half, perhaps due to lack of interest or perceived problems. I’ve been using this independently-developed version for nine months on a handful of devices, and it has some properties that the other pull request doesn’t. Namely:

 - This PR builds a usable firmware image for the device. [The other PR](https://github.com/openwrt/openwrt/pull/3806) looks like it wasn’t ever implemented for anything other than kernel 5.4, which is a problem now that ipq40xx has moved on to 5.10—as it stands now, it won’t build a usable image for this device at all.
 - This PR attaches the two Ethernet ports to their respective PHYs in the DTS, so link status tracking actually works in software.
 - This PR sets up MAC addresses in `/lib/preinit/05_set_iface_mac_ipq40xx.sh` instead of `/etc/board.d/02_network`, so that the correct MAC addresses are in use during preinit (including failsafe).
 - In this PR, I’ve taken extreme care to make both Ethernet ports work and have reasonable settings (MAC address, interface name).
 - This PR adheres to the product naming convention consistent with other ipq40xx devices, using the MikroTik “marketing” name for the device, wAP ac. There should be no confusion with the older [ath79-based wAP ac](https://mikrotik.com/product/RBwAPG-5HacT2HnD), as it’s in an entirely different target. MikroTik marketing vs. internal naming is always a bit tricky, but it’s important to remain consistent with the handling of other ipq40xx-based devices, and “RBwAPG-5HacD2HnD” is quite a mouthful.

I’m keen on having this support merged into OpenWrt because I’m also following the [ipq40xx DSA work](https://github.com/openwrt/openwrt/pull/4721). Maintaining support locally for both DSA and this device leads to constant merge conflicts. I do have a [DSA conversion](https://github.com/markmentovai/openwrt/tree/ipq40xx_mikrotik%2Cwap_ac_dsa) for this device ready to go, and I’m happy to contribute it to the DSA conversion effort once this is merged into OpenWrt.

Cc @robimarko (another use of your base Mikrotik ipq40xx DTS).

@Ansuel, you’re a fresh OpenWrt committer and now the [ipq40xx maintainer](https://openwrt.org/docs/techref/targets/ipq40xx). Can you help out?

---

The MikroTik wAP ac (RBwAPG-5HacD2HnD) is a dual-band dual-radio 802.11ac wireless access point with integrated antenna and two Ethernet ports in a weatherproof enclosure. See https://mikrotik.com/product/wap_ac for more information.

Important: this is the new ipq40xx-based wAP ac, not the older ath79-based wAP AC (RBwAPG-5HacT2HnD), already supported in OpenWrt.

Specifications
--
 - SoC: Qualcomm Atheros IPQ4018
 - CPU: 4× ARM Cortex A7
 - RAM: 128MB
 - Storage: 16MB NOR flash
 - Wireless
    - 2.4GHz: Built-in IPQ4018 (SoC) 802.11b/g/n 2×2:2, 2.5 dBi antennae
    - 5GHz: Built-in IPQ4018 (SoC) 802.11a/n/ac 2×2:2, 2.5 dBi antennae
 - Ethernet: Built-in IPQ4018 (SoC, QCA8075), 2× 1000/100/10Mb/s ports, one with 802.3af/at PoE in

Installation
--
Boot the initramfs image via TFTP, then flash the sysupgrade image using `sysupgrade`. Details at https://openwrt.org/toh/mikrotik/common.

Notes
--
This preserves the MAC addresses of the physical Ethernet ports:
 - `eth0` corresponds to the physical port labeled ETH1 and has the base MAC address. This port can be used to power the device.
 - `eth1` corresponds to the physical port labeled ETH2 and has a MAC address one greater than the base.

MAC addresses are set from `/lib/preinit/05_set_iface_mac_ipq40xx.sh` rather than `/etc/board.d/02_network` so that they are in effect for preinit. This should likely be done for other MikroTik devices and possibly other non-MikroTik devices as well.

As this device has 2 physical ports, they are each connected to their respective PHYs, allowing the link status to be visible to software. Since they are not marked on the case with any role (such as LAN or WAN), both are bridged to the `lan` network by default, although this can easily be changed if needed.

Signed-off-by: Mark Mentovai \<mark@mentovai.com>