### PR TITLE
uboot-envtools: ignore u-boot-env2 for DGS-1210

### DIFF
--- a/package/boot/uboot-envtools/files/realtek
+++ b/package/boot/uboot-envtools/files/realtek
@@ -11,7 +11,11 @@ case "$board" in
 d-link,dgs-1210-16|\
 d-link,dgs-1210-20|\
 d-link,dgs-1210-28|\
-d-link,dgs-1210-10p|\
+d-link,dgs-1210-10p)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x400" "0x10000"
+	;;
 zyxel,gs1900-8|\
 zyxel,gs1900-8hp-v1|\
 zyxel,gs1900-8hp-v2|\


### PR DESCRIPTION
Although there is a partition named u-boot-env2, it only stores a null
terminated string with the device model name.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>