### PR TITLE
mac80211: mwl: add patch to raise global limit of SSID up to 4

### DIFF
--- a/package/kernel/mac80211/patches/mwl/900-mwifiex-increase-the-global-limit-up-to-4-SSID.patch
+++ b/package/kernel/mac80211/patches/mwl/900-mwifiex-increase-the-global-limit-up-to-4-SSID.patch
@@ -1,0 +1,46 @@
+From ef8098cd6cb8b5989afef2e8461fe6ba9570a854 Mon Sep 17 00:00:00 2001
+From: Josef Schlehofer <pepe.schlehofer@gmail.com>
+Date: Wed, 24 Nov 2021 12:47:40 +0100
+Subject: [PATCH] mwifiex: increase the global limit up to 4 SSID
+
+Firmware for SDIO (88W8997), which is used in Turris MOX SDIO addon [1],
+allows up to 4 SSID. Unfortunately, driver (even in mainline kernel)
+has a global limit for all Marvell cards up to 3 SSID.
+
+Pali Rohár tested this patch and verified that the SDIO Wi-Fi addon works
+with the 4 SSID. So, let's increase the global limit from 3 to 4.
+
+Ideally, this patch should be done differently before sending
+it to Linux kernel. It means that limit definition should be moved to
+the card-specific structure.
+
+[1] https://docs.turris.cz/hw/mox/addons/#wi-fi-sdio
+---
+ drivers/net/wireless/marvell/mwifiex/decl.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/wireless/marvell/mwifiex/decl.h b/drivers/net/wireless/marvell/mwifiex/decl.h
+index cdc9972..f9bcbf5 100644
+--- a/drivers/net/wireless/marvell/mwifiex/decl.h
++++ b/drivers/net/wireless/marvell/mwifiex/decl.h
+@@ -30,7 +30,7 @@
+ #include <net/cfg80211.h>
+
+ #define MWIFIEX_BSS_COEX_COUNT	     2
+-#define MWIFIEX_MAX_BSS_NUM         (3)
++#define MWIFIEX_MAX_BSS_NUM         (4)
+
+ #define MWIFIEX_DMA_ALIGN_SZ	    64
+ #define MWIFIEX_RX_HEADROOM	    64
+@@ -112,7 +112,7 @@
+ #define MWIFIEX_RATE_INDEX_OFDM0   4
+
+ #define MWIFIEX_MAX_STA_NUM		3
+-#define MWIFIEX_MAX_UAP_NUM		3
++#define MWIFIEX_MAX_UAP_NUM		4
+ #define MWIFIEX_MAX_P2P_NUM		3
+
+ #define MWIFIEX_A_BAND_START_FREQ	5000
+--
+2.30.2
+


### PR DESCRIPTION
SDIO chip 88W9997 from NXP [1] is quite limited by its firmware and
driver. Add hacky patch to allow up to 4 SSID instead of 3 SSID.

I was able to test this only on [Turris MOX SDIO add-on](https://github.com/turris-cz/openwrt/pull/new/mwifiex), I don't have others SDIO cards.