### PR TITLE
mac80211: add patch for mwifiex to fix cryptic errors/warnings

### DIFF
--- a/package/kernel/mac80211/patches/mwl/950-mwifiex-Print-stringified-name-of-command-in-error-l.patch
+++ b/package/kernel/mac80211/patches/mwl/950-mwifiex-Print-stringified-name-of-command-in-error-l.patch
@@ -1,0 +1,200 @@
+From f7252b1b5755150535af226e806594bbefd45e0f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Sun, 26 Sep 2021 14:39:44 +0200
+Subject: [PATCH] mwifiex: Print stringified name of command in error log
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Failed hex command number in error log is hard to understand.
+So add also more human readable stringified command name into error log.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+---
+ drivers/net/wireless/marvell/mwifiex/cmdevt.c | 96 +++++++++++++++++--
+ drivers/net/wireless/marvell/mwifiex/main.h   |  2 +
+ .../wireless/marvell/mwifiex/sta_cmdresp.c    |  5 +-
+ .../net/wireless/marvell/mwifiex/uap_cmd.c    |  3 +-
+ 4 files changed, 95 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/net/wireless/marvell/mwifiex/cmdevt.c b/drivers/net/wireless/marvell/mwifiex/cmdevt.c
+index 5a2788955f1c..1b05002330ff 100644
+--- a/drivers/net/wireless/marvell/mwifiex/cmdevt.c
++++ b/drivers/net/wireless/marvell/mwifiex/cmdevt.c
+@@ -28,6 +28,85 @@
+ 
+ static void mwifiex_cancel_pending_ioctl(struct mwifiex_adapter *adapter);
+ 
++const char *
++mwifiex_cmd_to_str(u16 command)
++{
++	switch (command) {
++	case HostCmd_CMD_GET_HW_SPEC:			return "GET_HW_SPEC";
++	case HostCmd_CMD_802_11_SCAN:			return "SCAN";
++	case HostCmd_CMD_802_11_GET_LOG:		return "GET_LOG";
++	case HostCmd_CMD_MAC_MULTICAST_ADR:		return "MAC_MULTICAST_ADR";
++	case HostCmd_CMD_802_11_EEPROM_ACCESS:		return "EEPROM_ACCESS";
++	case HostCmd_CMD_802_11_ASSOCIATE:		return "ASSOCIATE";
++	case HostCmd_CMD_802_11_SNMP_MIB:		return "SNMP_MIB";
++	case HostCmd_CMD_MAC_REG_ACCESS:		return "MAC_REG_ACCESS";
++	case HostCmd_CMD_BBP_REG_ACCESS:		return "BBP_REG_ACCESS";
++	case HostCmd_CMD_RF_REG_ACCESS:			return "RF_REG_ACCESS";
++	case HostCmd_CMD_PMIC_REG_ACCESS:		return "PMIC_REG_ACCESS";
++	case HostCmd_CMD_RF_TX_PWR:			return "RF_TX_PWR";
++	case HostCmd_CMD_RF_ANTENNA:			return "RF_ANTENNA";
++	case HostCmd_CMD_802_11_DEAUTHENTICATE:		return "DEAUTHENTICATE";
++	case HostCmd_CMD_MAC_CONTROL:			return "MAC_CONTROL";
++	case HostCmd_CMD_802_11_AD_HOC_START:		return "AD_HOC_START";
++	case HostCmd_CMD_802_11_AD_HOC_JOIN:		return "AD_HOC_JOIN";
++	case HostCmd_CMD_802_11_AD_HOC_STOP:		return "AD_HOC_STOP";
++	case HostCmd_CMD_802_11_MAC_ADDRESS:		return "MAC_ADDRESS";
++	case HostCmd_CMD_802_11D_DOMAIN_INFO:		return "DOMAIN_INFO";
++	case HostCmd_CMD_802_11_KEY_MATERIAL:		return "KEY_MATERIAL";
++	case HostCmd_CMD_802_11_BG_SCAN_CONFIG:		return "BG_SCAN_CONFIG";
++	case HostCmd_CMD_802_11_BG_SCAN_QUERY:		return "BG_SCAN_QUERY";
++	case HostCmd_CMD_WMM_GET_STATUS:		return "WMM_GET_STATUS";
++	case HostCmd_CMD_802_11_SUBSCRIBE_EVENT:	return "SUBSCRIBE_EVENT";
++	case HostCmd_CMD_802_11_TX_RATE_QUERY:		return "TX_RATE_QUERY";
++	case HostCmd_CMD_802_11_IBSS_COALESCING_STATUS:	return "IBSS_COALESCING_STATUS";
++	case HostCmd_CMD_MEM_ACCESS:			return "MEM_ACCESS";
++	case HostCmd_CMD_CFG_DATA:			return "CFG_DATA";
++	case HostCmd_CMD_VERSION_EXT:			return "VERSION_EXT";
++	case HostCmd_CMD_MEF_CFG:			return "MEF_CFG";
++	case HostCmd_CMD_RSSI_INFO:			return "RSSI_INFO";
++	case HostCmd_CMD_FUNC_INIT:			return "FUNC_INIT";
++	case HostCmd_CMD_FUNC_SHUTDOWN:			return "FUNC_SHUTDOWN";
++	case HOST_CMD_APCMD_SYS_RESET:			return "SYS_RESET";
++	case HostCmd_CMD_UAP_SYS_CONFIG:		return "UAP_SYS_CONFIG";
++	case HostCmd_CMD_UAP_BSS_START:			return "UAP_BSS_START";
++	case HostCmd_CMD_UAP_BSS_STOP:			return "UAP_BSS_STOP";
++	case HOST_CMD_APCMD_STA_LIST:			return "STA_LIST";
++	case HostCmd_CMD_UAP_STA_DEAUTH:		return "UAP_STA_DEAUTH";
++	case HostCmd_CMD_11N_CFG:			return "11N_CFG";
++	case HostCmd_CMD_11N_ADDBA_REQ:			return "ADDBA_REQ";
++	case HostCmd_CMD_11N_ADDBA_RSP:			return "ADDBA_RSP";
++	case HostCmd_CMD_11N_DELBA:			return "DELBA";
++	case HostCmd_CMD_RECONFIGURE_TX_BUFF:		return "RECONFIGURE_TX_BUFF";
++	case HostCmd_CMD_CHAN_REPORT_REQUEST:		return "CHAN_REPORT_REQUEST";
++	case HostCmd_CMD_AMSDU_AGGR_CTRL:		return "AMSDU_AGGR_CTRL";
++	case HostCmd_CMD_TXPWR_CFG:			return "TXPWR_CFG";
++	case HostCmd_CMD_TX_RATE_CFG:			return "TX_RATE_CFG";
++	case HostCmd_CMD_ROBUST_COEX:			return "ROBUST_COEX";
++	case HostCmd_CMD_802_11_PS_MODE_ENH:		return "PS_MODE_ENH";
++	case HostCmd_CMD_802_11_HS_CFG_ENH:		return "HS_CFG_ENH";
++	case HostCmd_CMD_P2P_MODE_CFG:			return "P2P_MODE_CFG";
++	case HostCmd_CMD_CAU_REG_ACCESS:		return "CAU_REG_ACCESS";
++	case HostCmd_CMD_SET_BSS_MODE:			return "SET_BSS_MODE";
++	case HostCmd_CMD_PCIE_DESC_DETAILS:		return "PCIE_DESC_DETAILS";
++	case HostCmd_CMD_802_11_SCAN_EXT:		return "SCAN_EXT";
++	case HostCmd_CMD_COALESCE_CFG:			return "COALESCE_CFG";
++	case HostCmd_CMD_MGMT_FRAME_REG:		return "MGMT_FRAME_REG";
++	case HostCmd_CMD_REMAIN_ON_CHAN:		return "REMAIN_ON_CHAN";
++	case HostCmd_CMD_GTK_REKEY_OFFLOAD_CFG:		return "GTK_REKEY_OFFLOAD_CFG";
++	case HostCmd_CMD_11AC_CFG:			return "11AC_CFG";
++	case HostCmd_CMD_HS_WAKEUP_REASON:		return "HS_WAKEUP_REASON";
++	case HostCmd_CMD_TDLS_CONFIG:			return "TDLS_CONFIG";
++	case HostCmd_CMD_MC_POLICY:			return "MC_POLICY";
++	case HostCmd_CMD_TDLS_OPER:			return "TDLS_OPER";
++	case HostCmd_CMD_FW_DUMP_EVENT:			return "FW_DUMP_EVENT";
++	case HostCmd_CMD_SDIO_SP_RX_AGGR_CFG:		return "SDIO_SP_RX_AGGR_CFG";
++	case HostCmd_CMD_STA_CONFIGURE:			return "STA_CONFIGURE";
++	case HostCmd_CMD_CHAN_REGION_CFG:		return "CHAN_REGION_CFG";
++	case HostCmd_CMD_PACKET_AGGR_CTRL:		return "PACKET_AGGR_CTRL";
++	default:					return "UNKNOWN";
++	}
++}
++
+ /*
+  * This function initializes a command node.
+  *
+@@ -205,8 +284,8 @@ static int mwifiex_dnld_cmd_to_fw(struct mwifiex_private *priv,
+ 	    cmd_code != HostCmd_CMD_FUNC_SHUTDOWN &&
+ 	    cmd_code != HostCmd_CMD_FUNC_INIT) {
+ 		mwifiex_dbg(adapter, ERROR,
+-			    "DNLD_CMD: FW in reset state, ignore cmd %#x\n",
+-			cmd_code);
++			    "DNLD_CMD: FW in reset state, ignore cmd %s (%#x)\n",
++			    mwifiex_cmd_to_str(cmd_code), cmd_code);
+ 		mwifiex_recycle_cmd_node(adapter, cmd_node);
+ 		queue_work(adapter->workqueue, &adapter->main_work);
+ 		return -1;
+@@ -660,8 +739,8 @@ int mwifiex_send_cmd(struct mwifiex_private *priv, u16 cmd_no,
+ 	/* Return error, since the command preparation failed */
+ 	if (ret) {
+ 		mwifiex_dbg(adapter, ERROR,
+-			    "PREP_CMD: cmd %#x preparation failed\n",
+-			cmd_no);
++			    "PREP_CMD: cmd %s (%#x) preparation failed\n",
++			    mwifiex_cmd_to_str(cmd_no), cmd_no);
+ 		mwifiex_insert_cmd_to_free_q(adapter, cmd_node);
+ 		return -1;
+ 	}
+@@ -900,8 +979,9 @@ int mwifiex_process_cmdresp(struct mwifiex_adapter *adapter)
+ 	if (adapter->hw_status == MWIFIEX_HW_STATUS_INITIALIZING) {
+ 		if (ret) {
+ 			mwifiex_dbg(adapter, ERROR,
+-				    "%s: cmd %#x failed during\t"
+-				    "initialization\n", __func__, cmdresp_no);
++				    "%s: cmd %s (%#x) failed during\t"
++				    "initialization\n", __func__,
++				    mwifiex_cmd_to_str(cmdresp_no), cmdresp_no);
+ 			mwifiex_init_fw_complete(adapter);
+ 			//if (adapter->if_ops.card_reset)
+ 			//	adapter->if_ops.card_reset(adapter);
+@@ -1266,8 +1346,8 @@ mwifiex_process_sleep_confirm_resp(struct mwifiex_adapter *adapter,
+ 
+ 	if (command != HostCmd_CMD_802_11_PS_MODE_ENH) {
+ 		mwifiex_dbg(adapter, ERROR,
+-			    "%s: rcvd unexpected resp for cmd %#x, result = %x\n",
+-			    __func__, command, result);
++			    "%s: rcvd unexpected resp for cmd %s (%#x), result = %x\n",
++			    __func__, mwifiex_cmd_to_str(command), command, result);
+ 		return;
+ 	}
+ 
+diff --git a/drivers/net/wireless/marvell/mwifiex/main.h b/drivers/net/wireless/marvell/mwifiex/main.h
+index 5923c5c14c8d..0d30f61a9d3c 100644
+--- a/drivers/net/wireless/marvell/mwifiex/main.h
++++ b/drivers/net/wireless/marvell/mwifiex/main.h
+@@ -1106,6 +1106,8 @@ void mwifiex_cancel_all_pending_cmd(struct mwifiex_adapter *adapter);
+ void mwifiex_cancel_pending_scan_cmd(struct mwifiex_adapter *adapter);
+ void mwifiex_cancel_scan(struct mwifiex_adapter *adapter);
+ 
++const char *mwifiex_cmd_to_str(u16 command);
++
+ void mwifiex_recycle_cmd_node(struct mwifiex_adapter *adapter,
+ 			      struct cmd_ctrl_node *cmd_node);
+ 
+diff --git a/drivers/net/wireless/marvell/mwifiex/sta_cmdresp.c b/drivers/net/wireless/marvell/mwifiex/sta_cmdresp.c
+index 6b5d35d9e69f..ae6554f7b583 100644
+--- a/drivers/net/wireless/marvell/mwifiex/sta_cmdresp.c
++++ b/drivers/net/wireless/marvell/mwifiex/sta_cmdresp.c
+@@ -48,8 +48,9 @@ mwifiex_process_cmdresp_error(struct mwifiex_private *priv,
+ 	struct host_cmd_ds_802_11_ps_mode_enh *pm;
+ 
+ 	mwifiex_dbg(adapter, ERROR,
+-		    "CMD_RESP: cmd %#x error, result=%#x\n",
+-		    resp->command, resp->result);
++		    "CMD_RESP: cmd %s (%#x) error, result=%#x\n",
++		    mwifiex_cmd_to_str(le16_to_cpu(resp->command)),
++		    le16_to_cpu(resp->command), le16_to_cpu(resp->result));
+ 
+ 	if (adapter->curr_cmd->wait_q_enabled)
+ 		adapter->cmd_wait_q.status = -1;
+diff --git a/drivers/net/wireless/marvell/mwifiex/uap_cmd.c b/drivers/net/wireless/marvell/mwifiex/uap_cmd.c
+index 18e89777b784..29b8af55f522 100644
+--- a/drivers/net/wireless/marvell/mwifiex/uap_cmd.c
++++ b/drivers/net/wireless/marvell/mwifiex/uap_cmd.c
+@@ -806,7 +806,8 @@ int mwifiex_uap_prepare_cmd(struct mwifiex_private *priv, u16 cmd_no,
+ 		break;
+ 	default:
+ 		mwifiex_dbg(priv->adapter, ERROR,
+-			    "PREP_CMD: unknown cmd %#x\n", cmd_no);
++			    "PREP_CMD: unknown cmd (%s) %#x\n",
++			    mwifiex_cmd_to_str(cmd_no), cmd_no);
+ 		return -1;
+ 	}
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
In Turris MOX SDIO card [1], which uses Marvell 88W997 and its driver
mwifiex, you might get cryptic messages, which are not helpful to use.
@pali created patch, which improves messages by the driver and he will
send this to Linux kernel soon.

Before:
[   81.026156] mwifiex_sdio mmc1:0001:1: CMD_RESP: cmd 0x20 error, result=0x1

After:
[   15.784018] mwifiex_sdio mmc1:0001:1: CMD_RESP: cmd RF_ANTENNA (0x20) error, result=0x1
