### PR TITLE
bmips: update ethernet driver

### DIFF
--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
@@ -374,7 +374,7 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 		if (len < priv->copybreak) {
 			struct sk_buff *nskb;
 
-			nskb = napi_alloc_skb(&priv->napi, len);
+			nskb = netdev_alloc_skb(dev, len);
 			if (!nskb) {
 				/* forget packet, just rearm desc */
 				dev->stats.rx_dropped++;

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
@@ -268,6 +268,7 @@ static int bcm6368_enetsw_refill_rx(struct net_device *dev, bool napi_mode)
 
 		if (!priv->rx_buf[desc_idx]) {
 			unsigned char *buf;
+                        dma_addr_t p;
 
 			if (likely(napi_mode))
 				buf = napi_alloc_frag(priv->rx_frag_size);
@@ -276,11 +277,16 @@ static int bcm6368_enetsw_refill_rx(struct net_device *dev, bool napi_mode)
 
 			if (unlikely(!buf))
 				break;
+			
+			p = dma_map_single(&priv->pdev->dev, buf + NET_SKB_PAD,
+                                           priv->rx_buf_size, DMA_FROM_DEVICE);
+                        if (unlikely(dma_mapping_error(&priv->pdev->dev, p))) {
+                                skb_free_frag(buf);
+                                break;
+                        }
+
 			priv->rx_buf[desc_idx] = buf;
-			desc->address = dma_map_single(&priv->pdev->dev,
-										   buf + NET_SKB_PAD,
-					   					   priv->rx_buf_size,
-					   					   DMA_FROM_DEVICE);
+                        desc->address = p;
 		}
 
 		len_stat = priv->rx_buf_size << DMADESC_LENGTH_SHIFT;
@@ -559,6 +565,7 @@ bcm6368_enetsw_start_xmit(struct sk_buff *skb, struct net_device *dev)
 	struct bcm6368_enetsw_desc *desc;
 	u32 len_stat;
 	netdev_tx_t ret;
+        dma_addr_t p;
 
 	/* lock against tx reclaim */
 	spin_lock(&priv->tx_lock);
@@ -593,13 +600,19 @@ bcm6368_enetsw_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		data = skb_put_zero(skb, needed);
 	}
 
-	/* point to the next available desc */
+	/* fill descriptor */
+	p = dma_map_single(&priv->pdev->dev, skb->data, skb->len,
+                           DMA_TO_DEVICE);
+        if (unlikely(dma_mapping_error(&priv->pdev->dev, p))) {
+                dev_kfree_skb(skb);
+                ret = NETDEV_TX_OK;
+                goto out_unlock;
+        }
+
+        /* point to the next available desc */
 	desc = &priv->tx_desc_cpu[priv->tx_curr_desc];
 	priv->tx_skb[priv->tx_curr_desc] = skb;
-
-	/* fill descriptor */
-	desc->address = dma_map_single(&priv->pdev->dev, skb->data, skb->len,
-				       DMA_TO_DEVICE);
+        desc->address = p;
 
 	len_stat = (skb->len << DMADESC_LENGTH_SHIFT) & DMADESC_LENGTH_MASK;
 	len_stat |= DMADESC_ESOP_MASK | DMADESC_APPEND_CRC |

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
@@ -331,6 +331,7 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 	struct bcm6368_enetsw *priv = netdev_priv(dev);
 	struct device *kdev = &priv->pdev->dev;
 	struct list_head rx_list;
+	struct sk_buff *skb;
 	int processed = 0;
 
 	INIT_LIST_HEAD(&rx_list);
@@ -343,7 +344,6 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 	do {
 		struct bcm6368_enetsw_desc *desc;
 		unsigned int frag_size;
-		struct sk_buff *skb;
 		unsigned char *buf;
 		int desc_idx;
 		u32 len_stat;
@@ -414,12 +414,13 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 
 		skb_reserve(skb, NET_SKB_PAD);
 		skb_put(skb, len);
-		skb->protocol = eth_type_trans(skb, dev);
 		dev->stats.rx_packets++;
 		dev->stats.rx_bytes += len;
 		list_add_tail(&skb->list, &rx_list);
 	} while (processed < budget);
 
+	list_for_each_entry(skb, &rx_list, list)
+		skb->protocol = eth_type_trans(skb, dev);
 	netif_receive_skb_list(&rx_list);
 	priv->rx_desc_count -= processed;
 

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
@@ -441,6 +441,7 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 static int bcm6368_enetsw_tx_reclaim(struct net_device *dev, int force)
 {
 	struct bcm6368_enetsw *priv = netdev_priv(dev);
+	unsigned int bytes = 0;
 	int released = 0;
 
 	while (priv->tx_desc_count < priv->tx_ring_size) {
@@ -477,9 +478,12 @@ static int bcm6368_enetsw_tx_reclaim(struct net_device *dev, int force)
 		if (desc->len_stat & DMADESC_UNDER_MASK)
 			dev->stats.tx_errors++;
 
+		bytes += skb->len;
 		napi_consume_skb(skb, !force);
 		released++;
 	}
+
+	netdev_completed_queue(dev, released, bytes);
 
 	if (netif_queue_stopped(dev) && released)
 		netif_wake_queue(dev);
@@ -612,6 +616,8 @@ bcm6368_enetsw_start_xmit(struct sk_buff *skb, struct net_device *dev)
 	wmb();
 	desc->len_stat = len_stat;
 	wmb();
+
+	netdev_sent_queue(dev, skb->len);
 
 	/* kick tx dma */
 	dmac_writel(priv, priv->dma_chan_en_mask, DMAC_CHANCFG_REG,
@@ -871,6 +877,8 @@ static int bcm6368_enetsw_stop(struct net_device *dev)
 	if (priv->irq_tx != -1)
 		free_irq(priv->irq_tx, dev);
 	free_irq(priv->irq_rx, dev);
+
+	netdev_reset_queue(dev);
 
 	return 0;
 }

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
@@ -363,7 +363,6 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 		priv->rx_curr_desc++;
 		if (priv->rx_curr_desc == priv->rx_ring_size)
 			priv->rx_curr_desc = 0;
-		priv->rx_desc_count--;
 
 		/* if the packet does not have start of packet _and_
 		 * end of packet flag set, then just recycle it */
@@ -416,7 +415,9 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 		dev->stats.rx_packets++;
 		dev->stats.rx_bytes += len;
 		netif_receive_skb(skb);
-	} while (--budget > 0);
+	} while (processed < budget);
+
+	priv->rx_desc_count -= processed;
 
 	if (processed || !priv->rx_desc_count) {
 		bcm6368_enetsw_refill_rx(dev, true);

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
@@ -438,7 +438,7 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 /*
  * try to or force reclaim of transmitted buffers
  */
-static int bcm6368_enetsw_tx_reclaim(struct net_device *dev, int force)
+static int bcm6368_enetsw_tx_reclaim(struct net_device *dev, int force, int budget)
 {
 	struct bcm6368_enetsw *priv = netdev_priv(dev);
 	unsigned int bytes = 0;
@@ -479,7 +479,7 @@ static int bcm6368_enetsw_tx_reclaim(struct net_device *dev, int force)
 			dev->stats.tx_errors++;
 
 		bytes += skb->len;
-		napi_consume_skb(skb, !force);
+		napi_consume_skb(skb, budget);
 		released++;
 	}
 
@@ -507,7 +507,7 @@ static int bcm6368_enetsw_poll(struct napi_struct *napi, int budget)
 			 DMAC_IR_REG, priv->tx_chan);
 
 	/* reclaim sent skb */
-	bcm6368_enetsw_tx_reclaim(dev, 0);
+	bcm6368_enetsw_tx_reclaim(dev, 0, budget);
 
 	spin_lock(&priv->rx_lock);
 	rx_work_done = bcm6368_enetsw_receive_queue(dev, budget);
@@ -851,7 +851,7 @@ static int bcm6368_enetsw_stop(struct net_device *dev)
 	bcm6368_enetsw_disable_dma(priv, priv->rx_chan);
 
 	/* force reclaim of all tx buffers */
-	bcm6368_enetsw_tx_reclaim(dev, 1);
+	bcm6368_enetsw_tx_reclaim(dev, 1, 0);
 
 	/* free the rx buffer ring */
 	for (i = 0; i < priv->rx_ring_size; i++) {

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
@@ -403,7 +403,7 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 			frag_size = priv->rx_frag_size;
 		}
 
-		skb = build_skb(buf, frag_size);
+		skb = napi_build_skb(buf, frag_size);
 		if (unlikely(!skb)) {
 			skb_free_frag(buf);
 			dev->stats.rx_dropped++;
@@ -471,7 +471,7 @@ static int bcm6368_enetsw_tx_reclaim(struct net_device *dev, int force)
 		if (desc->len_stat & DMADESC_UNDER_MASK)
 			dev->stats.tx_errors++;
 
-		dev_kfree_skb(skb);
+		napi_consume_skb(skb, !force);
 		released++;
 	}
 

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
@@ -269,10 +269,11 @@ static int bcm6368_enetsw_refill_rx(struct net_device *dev, bool napi_mode)
 		if (!priv->rx_buf[desc_idx]) {
 			unsigned char *buf;
 
-			if(likely(napi_mode))
+			if (likely(napi_mode))
 				buf = napi_alloc_frag(priv->rx_frag_size);
 			else
 				buf = netdev_alloc_frag(priv->rx_frag_size);
+
 			if (unlikely(!buf))
 				break;
 			priv->rx_buf[desc_idx] = buf;
@@ -383,7 +384,7 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 
 		if (len < priv->copybreak) {
 			unsigned int nfrag_size = SKB_DATA_ALIGN(NET_SKB_PAD + len +
-													 SKB_DATA_ALIGN(sizeof(struct skb_shared_info)));
+								 SKB_DATA_ALIGN(sizeof(struct skb_shared_info)));
 			unsigned char *nbuf = napi_alloc_frag(nfrag_size);
 			if (unlikely(!nbuf)) {
 				/* forget packet, just rearm desc */
@@ -400,7 +401,7 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 			frag_size = nfrag_size;
 		} else {
 			dma_unmap_single(kdev, desc->address,
-							 priv->rx_buf_size, DMA_FROM_DEVICE);
+					 priv->rx_buf_size, DMA_FROM_DEVICE);
 			priv->rx_buf[desc_idx] = NULL;
 			frag_size = priv->rx_frag_size;
 		}
@@ -996,7 +997,7 @@ static int bcm6368_enetsw_probe(struct platform_device *pdev)
 				  priv->dma_maxburst * 4);
 
 	priv->rx_frag_size = SKB_DATA_ALIGN(NET_SKB_PAD + priv->rx_buf_size +
-										SKB_DATA_ALIGN(sizeof(struct skb_shared_info)));
+					    SKB_DATA_ALIGN(sizeof(struct skb_shared_info)));
 
 	priv->num_clocks = of_clk_get_parent_count(node);
 	if (priv->num_clocks) {

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
@@ -170,13 +170,16 @@ struct bcm6368_enetsw {
 	/* next dirty rx descriptor to refill */
 	int rx_dirty_desc;
 
-	/* size of allocated rx skbs */
-	unsigned int rx_skb_size;
+	/* size of allocated rx buffer */
+	unsigned int rx_buf_size;
 
-	/* list of skb given to hw for rx */
-	struct sk_buff **rx_skb;
+	/* size of allocated rx frag */
+	unsigned int rx_frag_size;
 
-	/* used when rx skb allocation failed, so we defer rx queue
+	/* list of buffer given to hw for rx */
+	unsigned char **rx_buf;
+
+	/* used when rx buffer allocation failed, so we defer rx queue
 	 * refill */
 	struct timer_list rx_timeout;
 
@@ -257,26 +260,24 @@ static int bcm6368_enetsw_refill_rx(struct net_device *dev)
 
 	while (priv->rx_desc_count < priv->rx_ring_size) {
 		struct bcm6368_enetsw_desc *desc;
-		struct sk_buff *skb;
-		dma_addr_t p;
 		int desc_idx;
 		u32 len_stat;
 
 		desc_idx = priv->rx_dirty_desc;
 		desc = &priv->rx_desc_cpu[desc_idx];
 
-		if (!priv->rx_skb[desc_idx]) {
-			skb = netdev_alloc_skb(dev, priv->rx_skb_size);
-			if (!skb)
+		if (!priv->rx_buf[desc_idx]) {
+			unsigned char *buf = netdev_alloc_frag(priv->rx_frag_size);
+			if (unlikely(!buf))
 				break;
-			priv->rx_skb[desc_idx] = skb;
-			p = dma_map_single(&priv->pdev->dev, skb->data,
-					   priv->rx_skb_size,
-					   DMA_FROM_DEVICE);
-			desc->address = p;
+			priv->rx_buf[desc_idx] = buf;
+			desc->address = dma_map_single(&priv->pdev->dev,
+										   buf + NET_SKB_PAD,
+					   					   priv->rx_buf_size,
+					   					   DMA_FROM_DEVICE);
 		}
 
-		len_stat = priv->rx_skb_size << DMADESC_LENGTH_SHIFT;
+		len_stat = priv->rx_buf_size << DMADESC_LENGTH_SHIFT;
 		len_stat |= DMADESC_OWNER_MASK;
 		if (priv->rx_dirty_desc == priv->rx_ring_size - 1) {
 			len_stat |= DMADESC_WRAP_MASK;
@@ -333,7 +334,9 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 
 	do {
 		struct bcm6368_enetsw_desc *desc;
+		unsigned int frag_size;
 		struct sk_buff *skb;
+		unsigned char *buf;
 		int desc_idx;
 		u32 len_stat;
 		unsigned int len;
@@ -365,17 +368,17 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 		}
 
 		/* valid packet */
-		skb = priv->rx_skb[desc_idx];
+		buf = priv->rx_buf[desc_idx];
 		len = (len_stat & DMADESC_LENGTH_MASK)
 		      >> DMADESC_LENGTH_SHIFT;
 		/* don't include FCS */
 		len -= 4;
 
 		if (len < priv->copybreak) {
-			struct sk_buff *nskb;
-
-			nskb = netdev_alloc_skb(dev, len);
-			if (!nskb) {
+			unsigned int nfrag_size = SKB_DATA_ALIGN(NET_SKB_PAD + len +
+													 SKB_DATA_ALIGN(sizeof(struct skb_shared_info)));
+			unsigned char *nbuf = napi_alloc_frag(nfrag_size);
+			if (unlikely(!nbuf)) {
 				/* forget packet, just rearm desc */
 				dev->stats.rx_dropped++;
 				continue;
@@ -383,16 +386,26 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 
 			dma_sync_single_for_cpu(kdev, desc->address,
 						len, DMA_FROM_DEVICE);
-			memcpy(nskb->data, skb->data, len);
+			memcpy(nbuf + NET_SKB_PAD, buf + NET_SKB_PAD, len);
 			dma_sync_single_for_device(kdev, desc->address,
 						   len, DMA_FROM_DEVICE);
-			skb = nskb;
+			buf = nbuf;
+			frag_size = nfrag_size;
 		} else {
-			dma_unmap_single(&priv->pdev->dev, desc->address,
-					 priv->rx_skb_size, DMA_FROM_DEVICE);
-			priv->rx_skb[desc_idx] = NULL;
+			dma_unmap_single(kdev, desc->address,
+							 priv->rx_buf_size, DMA_FROM_DEVICE);
+			priv->rx_buf[desc_idx] = NULL;
+			frag_size = priv->rx_frag_size;
 		}
 
+		skb = build_skb(buf, frag_size);
+		if (unlikely(!skb)) {
+			skb_free_frag(buf);
+			dev->stats.rx_dropped++;
+			continue;
+		}
+
+		skb_reserve(skb, NET_SKB_PAD);
 		skb_put(skb, len);
 		skb->protocol = eth_type_trans(skb, dev);
 		dev->stats.rx_packets++;
@@ -680,7 +693,7 @@ static int bcm6368_enetsw_open(struct net_device *dev)
 	priv->tx_skb = kzalloc(sizeof(struct sk_buff *) * priv->tx_ring_size,
 			       GFP_KERNEL);
 	if (!priv->tx_skb) {
-		dev_err(kdev, "cannot allocate rx skb queue\n");
+		dev_err(kdev, "cannot allocate tx skb queue\n");
 		ret = -ENOMEM;
 		goto out_free_tx_ring;
 	}
@@ -690,11 +703,11 @@ static int bcm6368_enetsw_open(struct net_device *dev)
 	priv->tx_curr_desc = 0;
 	spin_lock_init(&priv->tx_lock);
 
-	/* init & fill rx ring with skbs */
-	priv->rx_skb = kzalloc(sizeof(struct sk_buff *) * priv->rx_ring_size,
+	/* init & fill rx ring with buffers */
+	priv->rx_buf = kzalloc(sizeof(unsigned char *) * priv->rx_ring_size,
 			       GFP_KERNEL);
-	if (!priv->rx_skb) {
-		dev_err(kdev, "cannot allocate rx skb queue\n");
+	if (!priv->rx_buf) {
+		dev_err(kdev, "cannot allocate rx buffer queue\n");
 		ret = -ENOMEM;
 		goto out_free_tx_skb;
 	}
@@ -708,7 +721,7 @@ static int bcm6368_enetsw_open(struct net_device *dev)
 		   DMA_BUFALLOC_REG(priv->rx_chan));
 
 	if (bcm6368_enetsw_refill_rx(dev)) {
-		dev_err(kdev, "cannot allocate rx skb queue\n");
+		dev_err(kdev, "cannot allocate rx buffer queue\n");
 		ret = -ENOMEM;
 		goto out;
 	}
@@ -770,15 +783,15 @@ out:
 	for (i = 0; i < priv->rx_ring_size; i++) {
 		struct bcm6368_enetsw_desc *desc;
 
-		if (!priv->rx_skb[i])
+		if (!priv->rx_buf[i])
 			continue;
 
 		desc = &priv->rx_desc_cpu[i];
-		dma_unmap_single(kdev, desc->address, priv->rx_skb_size,
+		dma_unmap_single(kdev, desc->address, priv->rx_buf_size,
 				 DMA_FROM_DEVICE);
-		kfree_skb(priv->rx_skb[i]);
+		skb_free_frag(priv->rx_buf[i]);
 	}
-	kfree(priv->rx_skb);
+	kfree(priv->rx_buf);
 
 out_free_tx_skb:
 	kfree(priv->tx_skb);
@@ -823,22 +836,22 @@ static int bcm6368_enetsw_stop(struct net_device *dev)
 	/* force reclaim of all tx buffers */
 	bcm6368_enetsw_tx_reclaim(dev, 1);
 
-	/* free the rx skb ring */
+	/* free the rx buffer ring */
 	for (i = 0; i < priv->rx_ring_size; i++) {
 		struct bcm6368_enetsw_desc *desc;
 
-		if (!priv->rx_skb[i])
+		if (!priv->rx_buf[i])
 			continue;
 
 		desc = &priv->rx_desc_cpu[i];
-		dma_unmap_single_attrs(kdev, desc->address, priv->rx_skb_size,
+		dma_unmap_single_attrs(kdev, desc->address, priv->rx_buf_size,
 				       DMA_FROM_DEVICE,
 				       DMA_ATTR_SKIP_CPU_SYNC);
-		kfree_skb(priv->rx_skb[i]);
+		skb_free_frag(priv->rx_buf[i]);
 	}
 
 	/* free remaining allocated memory */
-	kfree(priv->rx_skb);
+	kfree(priv->rx_buf);
 	kfree(priv->tx_skb);
 	dma_free_coherent(kdev, priv->rx_desc_alloc_size,
 			  priv->rx_desc_cpu, priv->rx_desc_dma);
@@ -960,8 +973,11 @@ static int bcm6368_enetsw_probe(struct platform_device *pdev)
 		dev_info(dev, "random mac %pM\n", ndev->dev_addr);
 	}
 
-	priv->rx_skb_size = ALIGN(ndev->mtu + ENETSW_MTU_OVERHEAD,
+	priv->rx_buf_size = ALIGN(ndev->mtu + ENETSW_MTU_OVERHEAD,
 				  priv->dma_maxburst * 4);
+
+	priv->rx_frag_size = SKB_DATA_ALIGN(NET_SKB_PAD + priv->rx_buf_size +
+										SKB_DATA_ALIGN(sizeof(struct skb_shared_info)));
 
 	priv->num_clocks = of_clk_get_parent_count(node);
 	if (priv->num_clocks) {

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
@@ -330,7 +330,10 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 {
 	struct bcm6368_enetsw *priv = netdev_priv(dev);
 	struct device *kdev = &priv->pdev->dev;
+	struct list_head rx_list;
 	int processed = 0;
+
+	INIT_LIST_HEAD(&rx_list);
 
 	/* don't scan ring further than number of refilled
 	 * descriptor */
@@ -414,9 +417,10 @@ static int bcm6368_enetsw_receive_queue(struct net_device *dev, int budget)
 		skb->protocol = eth_type_trans(skb, dev);
 		dev->stats.rx_packets++;
 		dev->stats.rx_bytes += len;
-		netif_receive_skb(skb);
+		list_add_tail(&skb->list, &rx_list);
 	} while (processed < budget);
 
+	netif_receive_skb_list(&rx_list);
 	priv->rx_desc_count -= processed;
 
 	if (processed || !priv->rx_desc_count) {


### PR DESCRIPTION
Improve performance and add features to the bmips ethernet driver to bring it to
parity with bcm63xx.
- don't use NET_IP_ALIGN in copybreak which messes up alignment with DSA tag
- convert to napi_build_skb()
- use rx batch processing
- add BQL support

Tested on BCM6328 using iperf3.
The use of DSA in bmips actually lowered throughput to ~47Mbps from the max
100Mbps under bcm63xx. This series of changes uplift performance by ~20% to
~54Mbps (with flow offload ~74Mbps).
