### PR TITLE
ltq-vdsl-app: Fixing counter overflow resulting in negative values

### DIFF
--- a/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
+++ b/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
@@ -146,7 +146,7 @@ static inline void m_bool(const char *id, bool value) {
 }
 
 static inline void m_u32(const char *id, uint32_t value) {
-	blobmsg_add_u32(&b, id, value);
+	blobmsg_add_u64(&b, id, value);
 }
 
 static inline void m_str(const char *id, const char *value) {


### PR DESCRIPTION
The re-transmit counters can overflow the 32 bit representation resulting in negative values being displayed.
Background being that the numbers are treated at some point as signed INT rather than unsigned INT.
Change the counters from 32 bit to 64 bit, resp 8 to 16 bit  should provide sufficient room to avoid any overflow.
Not the nicest solution but it works

Fixes: https://github.com/openwrt/openwrt/issues/10077
Signed-off-by: Roland Barenbrug <roland@treslong.com>