### PR TITLE
mediatek: mt7622: fix banana pi r64 wps button

### DIFF
--- a/target/linux/generic/hack-5.15/402-mtd-blktrans-call-add-disks-after-mtd-device.patch
+++ b/target/linux/generic/hack-5.15/402-mtd-blktrans-call-add-disks-after-mtd-device.patch
@@ -77,7 +77,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  #include "mtdcore.h"
  
-@@ -1002,6 +1003,8 @@ int mtd_device_parse_register(struct mtd
+@@ -1012,6 +1013,8 @@ int mtd_device_parse_register(struct mtd
  
  	ret = mtd_otp_nvmem_add(mtd);
  

--- a/target/linux/generic/hack-5.15/420-mtd-set-rootfs-to-be-root-dev.patch
+++ b/target/linux/generic/hack-5.15/420-mtd-set-rootfs-to-be-root-dev.patch
@@ -20,7 +20,7 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
  #include <linux/nvmem-provider.h>
  
  #include <linux/mtd/mtd.h>
-@@ -697,6 +698,16 @@ int add_mtd_device(struct mtd_info *mtd)
+@@ -707,6 +708,16 @@ int add_mtd_device(struct mtd_info *mtd)
  	   of this try_ nonsense, and no bitching about it
  	   either. :) */
  	__module_get(THIS_MODULE);

--- a/target/linux/generic/pending-5.15/495-mtd-core-add-get_mtd_device_by_node.patch
+++ b/target/linux/generic/pending-5.15/495-mtd-core-add-get_mtd_device_by_node.patch
@@ -17,7 +17,7 @@ Reviewed-by: Miquel Raynal <miquel.raynal@bootlin.com>
 
 --- a/drivers/mtd/mtdcore.c
 +++ b/drivers/mtd/mtdcore.c
-@@ -1203,6 +1203,44 @@ out_unlock:
+@@ -1213,6 +1213,44 @@ out_unlock:
  }
  EXPORT_SYMBOL_GPL(get_mtd_device_nm);
  

--- a/target/linux/mediatek/patches-5.15/510-net-mediatek-add-flow-offload-for-mt7623.patch
+++ b/target/linux/mediatek/patches-5.15/510-net-mediatek-add-flow-offload-for-mt7623.patch
@@ -14,7 +14,7 @@ Signed-off-by: Frank Wunderlich <frank-w@public-files.de>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -3678,6 +3678,7 @@ static const struct mtk_soc_data mt2701_
+@@ -3675,6 +3675,7 @@ static const struct mtk_soc_data mt2701_
  	.hw_features = MTK_HW_FEATURES,
  	.required_clks = MT7623_CLKS_BITMAP,
  	.required_pctl = true,

--- a/target/linux/mediatek/patches-5.15/920-dts-mt7622-bpi-r64-fix-wps-button.patch
+++ b/target/linux/mediatek/patches-5.15/920-dts-mt7622-bpi-r64-fix-wps-button.patch
@@ -1,0 +1,45 @@
+From dd1d420f40e75c3881a04001e6f2798492ee83c2 Mon Sep 17 00:00:00 2001
+From: Nick Hainke <vincent@systemli.org>
+Date: Thu, 30 Jun 2022 12:32:20 +0200
+Subject: [PATCH] arm64: dts: mt7622: fix BPI-R64 WPS button
+
+The bananapi R64 (BPI-R64) experiences wrong WPS button signals.
+In OpenWrt pushing the WPS button while powering on the device will set
+it to recovery mode. Currently, this also happens without any user
+interaction. In particular, the wrong signals appear while booting the
+device or restarting it, e.g. after doing a system upgrade. If the
+device is in recovery mode the user needs to manually power cycle or
+restart it.
+
+The official BPI-R64 sources set the WPS button to GPIO_ACTIVE_LOW in
+the device tree. This setting seems to suppress the unwanted WPS button
+press signals. So this commit changes the button from GPIO_ACTIVE_HIGH to
+GPIO_ACTIVE_LOW.
+
+The official BPI-R64 sources can be found on
+https://github.com/BPI-SINOVOIP/BPI-R64-openwrt
+
+Fixes: 0b6286dd96c0 ("arm64: dts: mt7622: add bananapi BPI-R64 board")
+
+Suggested-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+Signed-off-by: Nick Hainke <vincent@systemli.org>
+---
+ arch/arm64/boot/dts/mediatek/mt7622-bananapi-bpi-r64.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/mediatek/mt7622-bananapi-bpi-r64.dts b/arch/arm64/boot/dts/mediatek/mt7622-bananapi-bpi-r64.dts
+index 2b9bf8dd14ec..7538918c7a82 100644
+--- a/arch/arm64/boot/dts/mediatek/mt7622-bananapi-bpi-r64.dts
++++ b/arch/arm64/boot/dts/mediatek/mt7622-bananapi-bpi-r64.dts
+@@ -49,7 +49,7 @@ factory {
+ 		wps {
+ 			label = "wps";
+ 			linux,code = <KEY_WPS_BUTTON>;
+-			gpios = <&pio 102 GPIO_ACTIVE_HIGH>;
++			gpios = <&pio 102 GPIO_ACTIVE_LOW>;
+ 		};
+ 	};
+ 
+-- 
+2.37.0
+

--- a/target/linux/mediatek/patches-5.15/920-dts-mt7622-bpi-r64-fix-wps-button.patch
+++ b/target/linux/mediatek/patches-5.15/920-dts-mt7622-bpi-r64-fix-wps-button.patch
@@ -27,11 +27,9 @@ Signed-off-by: Nick Hainke <vincent@systemli.org>
  arch/arm64/boot/dts/mediatek/mt7622-bananapi-bpi-r64.dts | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/arch/arm64/boot/dts/mediatek/mt7622-bananapi-bpi-r64.dts b/arch/arm64/boot/dts/mediatek/mt7622-bananapi-bpi-r64.dts
-index 2b9bf8dd14ec..7538918c7a82 100644
 --- a/arch/arm64/boot/dts/mediatek/mt7622-bananapi-bpi-r64.dts
 +++ b/arch/arm64/boot/dts/mediatek/mt7622-bananapi-bpi-r64.dts
-@@ -49,7 +49,7 @@ factory {
+@@ -54,7 +54,7 @@
  		wps {
  			label = "wps";
  			linux,code = <KEY_WPS_BUTTON>;
@@ -40,6 +38,3 @@ index 2b9bf8dd14ec..7538918c7a82 100644
  		};
  	};
  
--- 
-2.37.0
-


### PR DESCRIPTION
Fix the wps button to prevent wrongly detected recovery procedures.
In the official banana pi r64 git the wps button is set to
GPIO_ACTIVE_LOW and not GPIO_ACTIVE_HIGH.

Fixes on boot unwanted recovery entering:

  Press the [f] key and hit [enter] to enter failsafe mode
  Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
  - failsafe button wps was pressed -
  - failsafe -

Refresh patches:
- 402-mtd-blktrans-call-add-disks-after-mtd-device.patch
- 420-mtd-set-rootfs-to-be-root-dev.patch
- 495-mtd-core-add-get_mtd_device_by_node.patch
- 510-net-mediatek-add-flow-offload-for-mt7623.patch
