### PR TITLE
ramips: improve YunCore AX820 LEDs

### DIFF
--- a/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
@@ -10,10 +10,10 @@
 	model = "YunCore AX820";
 
 	aliases {
-		led-boot = &led_status_green;
-		led-failsafe = &led_status_green;
-		led-running = &led_status_green;
-		led-upgrade = &led_status_green;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
 	};
 
 	chosen {
@@ -23,9 +23,29 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_status_green: status_green {
-			label = "green:status";
+		/* At least 2 AX820 variants are known and cannot be distinguished (same hw rev):
+		   - System LED green GPIO 15; red and blue apparently not connected
+		   - System LED red GPIO 15, WLAN2G LED green GPIO 14, WLAN5G LED blue GPIO 16
+		   The canonical values taken from a Yuncore datasheet are:
+		   - System LED green GPIO 15, WLAN2G LED blue GPIO 14, WLAN5G LED red GPIO 16
+		   All 3 colors relate to the same single RGB LED showing up on the front lightpipe.
+		   As a result, all 3 LEDs are defined even if only one may be available, and
+		   the color information is absent as it is not reliable */
+		wlan2g {
+			label = "wlan2g";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		led_system: system {
+			label = "system";
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "wlan5g";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
 		};
 	};
 


### PR DESCRIPTION
At least two AX820 hardware variants are known to exist, but they cannot
be distinguished (same hardware revision, no specific markings).

They appear to have the same LED hardware, but wired differently:

- One has a red system LED at GPIO 15, a green wlan2g LED at GPIO 14 and
  a blue wlan5g LED at GPIO 16;
- The other only offers a green system LED at GPIO 15, with GPIO 14 and
  16 being apparently not connected

Finally, a Yuncore datasheet says the canonical wiring should be:
- Blue wlan2g GPIO 14, green system GPIO 15, red wlan5g GPIO 16

All GPIOs are tied to a single RGB LED which is exposed via lightpipe on
the device front casing.

Considering the above, this patch exposes all three LEDs, preserves the
common system LED (GPIO 15) as the openwrt status LED, and removes the
color information from the LEDs names since it is not consistent across
hardware. The LED naming is made consistent with other YunCore devices.
A note is added in DTS to ensure this information is always available
and prevent unwanted changes in the future.

Fixes: #10131

*Ideally this should be backported to 22.03*