### PR TITLE
ramips: add support for ZyXEL LTE3301-Plus

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -68,6 +68,9 @@ xiaomi,mi-router-ac2100|\
 xiaomi,redmi-router-ac2100)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
 	;;
+zyxel,lte3301-plus)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x80000"
+	;;
 zyxel,nr7101)
 	idx="$(find_mtd_index Config)"
 	[ -n "$idx" ] && \

--- a/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
@@ -1,0 +1,217 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "zyxel,lte3301-plus", "mediatek,mt7621-soc";
+	model = "ZyXEL LTE3301-Plus";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		power_modem {
+			gpio-export,name = "power_modem";
+			gpio-export,output = <1>;
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "lte3301-plus:white:power";
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi {
+			label = "lte3301-plus:white:wifi";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			label = "lte3301-plus:white:internet";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "lte3301-plus:white:usb";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+		};
+
+		lte {
+			label = "lte3301-plus:white:lte";
+			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
+		};
+
+		mobile_green {
+			label = "lte3301-plus:green:mobile";
+			gpios = <&gpio 31 GPIO_ACTIVE_LOW>;
+		};
+
+		mobile_orange {
+			label = "lte3301-plus:orange:mobile";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		mobile_red {
+			label = "lte3301-plus:red:mobile";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+};
+
+&gpio {
+	status = "okay";
+
+	enable_usb_power {
+		gpio-hog;
+		line-name = "enable USB power";
+		gpios = <7 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "uboot";
+			reg = <0x00000 0x80000>; /* 64 KB */
+		};
+		partition@80000 {
+			label = "uboot_env";
+			reg = <0x80000 0x80000>; /* 64 KB */
+		};
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+		};
+		partition@140000 {
+			label = "Kernel";
+			reg = <0x140000 0x1ec0000>;
+		};
+		partition@2140000 {
+			label = "kernel2";
+			reg = <0x2140000 0x1ec0000>;
+		};
+		partition@4000000 {
+			label = "wwan";
+			reg = <0x4000000 0x100000>;
+		};
+		partition@4100000 {
+			label = "ubi";
+			reg = <0x4100000 0x3ee0000>;
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "rgmii2", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_fe6e>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+	mt7615d@0,0 {
+		/* In reality  at hangs at pcie1, this is a driver bug */
+		compatible = "pci14c3,7615";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,firmware-eeprom = "mt7615e_eeprom.bin";
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&macaddr_factory_fe6e>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <(1)>;
+	};
+
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+	mtd-mac-address = <&factory 0xfe6e>;
+
+	macaddr_factory_fe6e: macaddr@fe6e {
+		reg = <0xfe6e 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2159,6 +2159,25 @@ define Device/zio_freezio
 endef
 TARGET_DEVICES += zio_freezio
 
+define Device/zyxel_lte3301-plus
+  $(Device/dsa-migration)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  DEVICE_VENDOR := ZyXEL
+  DEVICE_MODEL := LTE3301-PLUS
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware kmod-usb3 \
+	uboot-envtools kmod-usb-ledtrig-usbport kmod-usb-net-qmi-wwan \
+	kmod-usb-serial-option uqmi
+  KERNEL := $(KERNEL_DTB) | uImage lzma | \
+	zytrx-header $$(DEVICE_MODEL) $$(VERSION_DIST)-$$(REVISION)
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | uImage lzma | \
+	zytrx-header $$(DEVICE_MODEL) 9.99(ABQU.1)$$(VERSION_DIST)-recovery
+  KERNEL_INITRAMFS_SUFFIX := -recovery.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += zyxel_lte3301-plus
+
 define Device/zyxel_nr7101
   $(Device/dsa-migration)
   BLOCKSIZE := 128k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -161,6 +161,9 @@ zbtlink,zbt-wg1608-16m)
 	ucidef_set_led_netdev "lan4" "LAN4" "green:lan-4" "lan4"
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
 	;;
+zyxel,lte3301-plus)
+	ucidef_set_led_netdev "internet" "internet" "white:internet" "wwan0"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -68,7 +68,8 @@ ramips_setup_interfaces()
 		ucidef_set_interface_lan "lan1 lan2"
 		;;
 	linksys,re6500|\
-	netgear,wac104)
+	netgear,wac104|\
+	zyxel,lte3301-plus)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
 	mikrotik,routerboard-750gr3)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -22,6 +22,10 @@ ubnt,edgerouter-x-sfp)
 	ucidef_add_gpio_switch "poe_power_port3" "PoE Power Port3" "403"
 	ucidef_add_gpio_switch "poe_power_port4" "PoE Power Port4" "404"
 	;;
+zyxel,lte3301-plus)
+	ucidef_add_gpio_switch "usb_power" "Power USB Port" "usb_power" "1"
+	ucidef_add_gpio_switch "lte_power" "Power LTE modem" "lte_power" "1"
+	;;
 zyxel,nr7101)
 	ucidef_add_gpio_switch "lte_reset" "Reset LTE/5G modem" "483"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -20,6 +20,11 @@ boot() {
 	samknows,whitebox-v8)
 		fw_setenv bootcount 0
 		;;
+	zyxel,lte3301-plus)
+		[ $(printf %d $(fw_printenv -n DebugFlag)) -gt 0 ] || fw_setenv DebugFlag 1
+		[ $(printf %d $(fw_printenv -n Image1Stable)) -gt 0 ] || fw_setenv Image1Stable 1
+		[ $(printf %d $(fw_printenv -n Image1Try)) -gt 0 ] && fw_setenv Image1Try 0
+		;;
 	zyxel,nr7101)
 		[ $(printf %d $(fw_printenv -n DebugFlag)) -gt 0 ] || fw_setenv DebugFlag 0x1
 		[ $(printf %d $(fw_printenv -n Image1Stable)) -gt 0 ] || fw_setenv Image1Stable 1

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -112,6 +112,7 @@ platform_do_upgrade() {
 	ubnt,edgerouter-x-sfp)
 		platform_upgrade_ubnt_erx "$1"
 		;;
+	zyxel,lte3301-plus|\
 	zyxel,nr7101)
 		fw_setenv CheckBypass 0
 		fw_setenv Image1Stable 0


### PR DESCRIPTION
The ZyXEL LTE3301-PLUS is an 4G indoor CPE with 2 external LTE antennas.

Specifications:

 - SoC: MediaTek MT7621AT
 - RAM: 256 MB
 - Flash: 128 MB MB NAND (MX30LF1G18AC)
 - WiFi: MediaTek MT7615E
 - Switch: 4 LAN ports (Gigabit)
 - LTE: Quectel EG506 connected by USB3 to SoC
 - SIM: 1 micro-SIM slot
 - USB: USB3 port
 - Buttons: Reset, WPS
 - LEDs: Multicolour power, internet, LTE, signal, Wifi, USB
 - Power: 12V, 1.5A

The device is built as an indoor ethernet to LTE bridge or router with
Wifi.

UART Serial:

57600N1
Located on populated 5 pin header J5:

 [o] GND
 [ ] key - no pin
 [o] RX
 [o] TX
 [o] 3.3V Vcc

MAC assignment:
lan:  98:0d:67:ee:85:54 (base, on the device back)
wlan: 98:0d:67:ee:85:55

Installation from web GUI:

- Log in as "admin" on http://192.168.1.1/
- Upload OpenWrt initramfs-recovery.bin image on the
  Maintenance -> Firmware page
- Wait for OpenWrt to boot and ssh to root@192.168.1.1
- format ubi device: ubiformat /dev/mtd6
- attach ubi device: ubiattach -m6
- create rootfs volume: ubimkvol /dev/ubi0 -n0 -N rootfs -s 1MiB
- rootfs_data volume: ubimkvol /dev/ubi0 -n1 -N rootfs_data -s 1MiB
- run sysupgrade with sysupgrade image

For more details about flashing see
commit 2449a632084b ("ramips: mt7621: Add support for ZyXEL NR7101").

Please note that this commit is needed:
firmware-utils: Add support for ZyXEL LTE3301-Plus
https://patchwork.ozlabs.org/project/openwrt/patch/20220617182627.2215324-1-avalentin@marcant.net/

Signed-off-by: André Valentin <avalentin@marcant.net>