### PR TITLE
realtek: Engenius EWS2910P: Embiggen rootfs and lock out PoE GPIO

### DIFF
--- a/target/linux/realtek/dts-5.10/rtl8380_engenius_ews2910p.dts
+++ b/target/linux/realtek/dts-5.10/rtl8380_engenius_ews2910p.dts
@@ -144,7 +144,7 @@
 				reg = <0x90000 0x10000>;
 			};
 			partition@a0000 {
-				label = "jffs2-cfg";
+				label = "rootfs_data";
 				reg = <0xa0000 0xd60000>;
 			};
 			partition@e00000 {


### PR DESCRIPTION
These are two patches that I have been using on the Engenius EWS2910P. I did not include them in the original PR, as I felt more research was needed.

The first change is to use a bigger partition as the rootfs overlay. "jffs2-cfg", or mtd3. This is something the vendor firmware or bootloader won't erase unless doing a factory reset. It's well protected in that regard. It's also comfortably big.

the second change is there to prevent users from accidentally disabling the poe-enable line. This goes to the PoE MCU via an isolator. If low, this line forces the MCU to shut down all outputs, and is notoriously irritating to debug.

@svanheule, You had mentioned in the past about the possibility of combining "firmware" and "firmware2" partitions. I'm not sure what happens if the bootloader decides to boot from the wrong partition, and doesn't find a kernel there. Will it go back to the other partition? Will it soft brick? Will it drop to a uboot shell?
I think it's too risky to go down that path.