### PR TITLE
binutils: update to 2.38

### DIFF
--- a/package/devel/binutils/Makefile
+++ b/package/devel/binutils/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=binutils
-PKG_VERSION:=2.37
-PKG_RELEASE:=2
+PKG_VERSION:=2.38
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@GNU/binutils
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_VERSION:=$(PKG_VERSION)
-PKG_HASH:=820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c
+PKG_HASH:=e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024
 
 PKG_FIXUP:=patch-libtool
 PKG_LIBTOOL_PATHS:=. gas bfd opcodes gprof binutils ld libiberty gold intl


### PR DESCRIPTION
Changelog:

 Assembler:
    General:
      * Add support for the LoongArch architecture.

      * Add an option to control how multibyte characters are handled in
        the assembler.  Using the option warnings can be generated when
        such characters are encountered in symbol names, or anywhere in
        the input source file(s).

    AArch64 and ARM:
      * Add support for more system registers.
      * Add support for Scalable Matrix Extension.
      * Add support for Cortex-R52+, Cortex-A510, Cortex-A710,
        Cortex-X2, Cortex-A710 cores.
      * Add support for 'v8.7-a', 'v8.8-a', 'v9-a', 'v9.1-a',
        'armv9.2-a' and 'armv9.3-a' architecture extensions.

    X86:
      * Add a command-line option to encode aligned vector move as
        unaligned vector move.
      * Add support for Intel AVX512_FP16 instructions.
      * The outputs of .ds.x directive and .tfloat directive with hex
        input have been reduced from 12 bytes to 10 bytes to match the
        output of .tfloat directive.

Linker:
    * Add support for the LoongArch architecture.

    * Add -z pack-relative-relocs/-z no pack-relative-relocs to x86 ELF
     linker to pack relative relocations in the DT_RELR section.

    * Add -z indirect-extern-access/-z noindirect-extern-access to x86
      ELF linker to control canonical function pointers and copy
      relocation.

Other Binary Tools:

    * elfedit: Add --output-abiversion option to update ABIVERSION.

    * Tools which display symbols or strings (readelf, strings, nm,
      objdump) have a new command line option which controls how unicode
      characters are handled.  By default they are treated as normal for
      the tool.  Using --unicode=locale will display them according to
      the current locale.  Using --unicode=hex will display them as hex
      byte values, whilst --unicode=escape will display them as escape
      sequences.  In addition using --unicode=highlight will display
      them as unicode escape sequences highlighted in red (if supported
      by the output device).

    * readelf -r dumps RELR relative relocations now.

    * Support for efi-app-aarch64, efi-rtdrv-aarch64 and
      efi-bsdrv-aarch64 has been added to objcopy in order to enable
      UEFI development using binutils.

    * ar: Add --thin for creating thin archives. -T is a deprecated
      alias without diagnostics. In many ar implementations -T has a
      different meaning, as specified by X/Open System Interface.

