### PR TITLE
mediatek: mt7622: add missing vbus regulator node to totolink-a8000ru dts

### DIFF
--- a/target/linux/mediatek/dts/mt7622-totolink-a8000ru.dts
+++ b/target/linux/mediatek/dts/mt7622-totolink-a8000ru.dts
@@ -80,6 +80,15 @@
 		regulator-always-on;
 	};
 
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
 	rtkgsw: rtkgsw@0 {
 		compatible = "mediatek,rtk-gsw";
 		mediatek,ethsys = <&ethsys>;
@@ -312,6 +321,7 @@
 
 &ssusb {
 	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_5v>;
 	status = "okay";
 };
 


### PR DESCRIPTION
On boot, kernel log complains no vbus supply is found:

`xhci-mtk 1a0c0000.usb: supply vbus not found, using dummy regulator`

so add the dts reg_5V node and ssusb node vbus-supply property to solve the issue

Signed-off-by: Andrew Sim <andrewsimz@gmail.com>