### PR TITLE
[21.02] openssl: bump to 1.1.1q

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.1.1
-PKG_BUGFIX:=p
+PKG_BUGFIX:=q
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
@@ -26,7 +26,7 @@ PKG_SOURCE_URL:= \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/old/$(PKG_BASE)/
 
-PKG_HASH:=bf61b62aaa66c7c7639942a94de4c9ae8280c08f17d4eac2e44644d9fc8ace6f
+PKG_HASH:=d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Maintainer: @cotequeiroz
Run and compile tested for all Turris routers
- Turris 1.x, powerpc8540
- Turris Omnia, mvebu/cortex-a9
- Turris MOX, mvebu/cortex-a53

Patch and commit description taken from @dhewg's patch, which was sent to the [mailing list](https://lists.openwrt.org/pipermail/openwrt-devel/2022-June/038949.html) and to [patchwork](https://patchwork.ozlabs.org/project/openwrt/patch/20220623070807.133443-1-a.heider@gmail.com/):
```

Changes between 1.1.1o and 1.1.1p [21 Jun 2022]

  *) In addition to the c_rehash shell command injection identified in
     CVE-2022-1292, further bugs where the c_rehash script does not
     properly sanitise shell metacharacters to prevent command injection have been
     fixed.

     When the CVE-2022-1292 was fixed it was not discovered that there
     are other places in the script where the file names of certificates
     being hashed were possibly passed to a command executed through the shell.

     This script is distributed by some operating systems in a manner where
     it is automatically executed.  On such operating systems, an attacker
     could execute arbitrary commands with the privileges of the script.

     Use of the c_rehash script is considered obsolete and should be replaced
     by the OpenSSL rehash command line tool.
     (CVE-2022-2068)
     [Daniel Fiala, Tomáš Mráz]

  *) When OpenSSL TLS client is connecting without any supported elliptic
     curves and TLS-1.3 protocol is disabled the connection will no longer fail
     if a ciphersuite that does not use a key exchange based on elliptic
     curves can be negotiated.
     [Tomáš Mráz]
 ```
 
 Reference: https://github.com/openwrt/openwrt/pull/10028