### PR TITLE
f2fs-tools: import patch to fix compilation

### DIFF
--- a/package/utils/f2fs-tools/Makefile
+++ b/package/utils/f2fs-tools/Makefile
@@ -99,7 +99,9 @@ endef
 
 CONFIGURE_ARGS += \
 	--disable-static \
-	--without-blkid
+	--without-blkid \
+	--without-lzo2 \
+	--without-lz4
 
 ifneq ($(BUILD_VARIANT),selinux)
   CONFIGURE_ARGS += --without-selinux

--- a/package/utils/f2fs-tools/patches/101-configure.ac-fix-cross-compilation.patch
+++ b/package/utils/f2fs-tools/patches/101-configure.ac-fix-cross-compilation.patch
@@ -1,0 +1,80 @@
+From 821a1d3fcce31c234512a8f4dc4fc97dfbd7ae32 Mon Sep 17 00:00:00 2001
+From: Nick Hainke <vincent@systemli.org>
+Date: Mon, 4 Jul 2022 09:46:10 +0200
+Subject: [PATCH] configure.ac: fix cross compilation
+
+AC_CHECK_LIB seems to not work correctly with OpenWrt. Add possibility
+to disable lz4 and lzo2 manually.
+
+Fixes errors in the form of:
+  Package f2fsck is missing dependencies for the following libraries:
+  liblz4.so.1
+  liblzo2.so.2
+
+Signed-off-by: Nick Hainke <vincent@systemli.org>
+---
+ configure.ac | 44 ++++++++++++++++++++++++++++++++++----------
+ 1 file changed, 34 insertions(+), 10 deletions(-)
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -50,6 +50,18 @@ AC_ARG_WITH([blkid],
+ 	[],
+ 	[with_blkid=check])
+ 
++AC_ARG_WITH([lzo2],
++	[AS_HELP_STRING([--without-lzo2],
++	  [Ignore presence of liblzo2 and disable lzo2 support])],
++	[],
++	[with_lzo2=check])
++
++AC_ARG_WITH([lz4],
++	[AS_HELP_STRING([--without-lz4],
++	  [Ignore presence of liblz4 and disable lz4 support])],
++	[],
++	[with_lz4=check])
++
+ # Checks for programs.
+ AC_PROG_CC
+ AM_PROG_AR
+@@ -71,17 +83,29 @@ AS_IF([test "x$with_blkid" != xno],
+         fi
+ 	], -lblkid)])
+ 
+-AC_CHECK_LIB([lzo2], [main],
+-	[AC_SUBST([liblzo2_LIBS], ["-llzo2"])
+-		AC_DEFINE([HAVE_LIBLZO2], [1],
+-		[Define if you have liblzo2])
+-	], [], [])
+-
+-AC_CHECK_LIB([lz4], [main],
+-	[AC_SUBST([liblz4_LIBS], ["-llz4"])
+-		AC_DEFINE([HAVE_LIBLZ4], [1],
+-		[Define if you have liblz4])
+-	], [], [])
++AS_IF([test "x$with_lzo2" != xno],
++	[AC_CHECK_LIB([lzo2], [main],
++		[AC_SUBST([liblzo2_LIBS], ["-llzo2"])
++			AC_DEFINE([HAVE_LIBLZO2], [1],
++			[Define if you have liblzo2])
++		],
++		[if test "x$with_lzo2" != xcheck; then
++			AC_MSG_FAILURE(
++                [--with-lzo2 was given, but test for lzo2 failed])
++        fi
++	], -llzo2)])
++
++AS_IF([test "x$with_lz4" != xno],
++	[AC_CHECK_LIB([lz4], [main],
++		[AC_SUBST([liblz4_LIBS], ["-llz4"])
++			AC_DEFINE([HAVE_LIBLZ4], [1],
++			[Define if you have liblz4])
++		],
++		[if test "x$with_lz4" != xcheck; then
++			AC_MSG_FAILURE(
++                [--with-lz4 was given, but test for lz4 failed])
++        fi
++	], -llz4)])
+ 
+ AS_IF([test "x$with_selinux" != xno],
+ 	[AC_CHECK_LIB([selinux], [getcon],


### PR DESCRIPTION
Disable lz4 and lzo2 manually.

Fixes errors in the form of:
 Package f2fsck is missing dependencies for the following libraries:
 liblz4.so.1
 liblzo2.so.2

@thuehn Can you test?