### PR TITLE
ath79: add support for TP-Link TL-AP301C v4.0

### DIFF
--- a/target/linux/ath79/dts/qca9533_tplink_tl-ap301c-v4.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-ap301c-v4.dts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,tl-ap301c-v4", "qca,qca9533";
+	model = "TP-Link TL-AP301C v4";
+
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+		label-mac-device = &eth0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: status {
+			label = "blue:status";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		fit-fat-switch {
+			label = "fit-fat-switch";
+			linux,input-type = <EV_SW>;
+			linux,code = <BTN_0>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "factoryBoot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "factoryInfo";
+				reg = <0x020000 0x010000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factoryInfo_4: macaddr@4 {
+					reg = <0x4 0xc>;
+				};
+			};
+
+			art: partition@30000 {
+				label = "art";
+				reg = <0x030000 0x010000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x40000 0x7c0000>;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	nvmem-cells = <&macaddr_factoryInfo_4>;
+	nvmem-cell-names = "mac-address-ascii";
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	nvmem-cells = <&macaddr_factoryInfo_4>;
+	nvmem-cell-names = "mac-address-ascii";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -85,6 +85,7 @@ ath79_setup_interfaces()
 	tplink,re450-v2|\
 	tplink,re450-v3|\
 	tplink,re455-v1|\
+	tplink,tl-ap301c-v4|\
 	tplink,tl-wa1201-v2|\
 	tplink,tl-wr902ac-v1|\
 	ubnt,bullet-ac|\

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -543,6 +543,15 @@ define Device/tplink_re455-v1
 endef
 TARGET_DEVICES += tplink_re455-v1
 
+define Device/tplink_tl-ap301c-v4
+  SOC := qca9533
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := TL-AP301C
+  DEVICE_VARIANT := v4
+  IMAGE_SIZE := 7936k
+endef
+TARGET_DEVICES += tplink_tl-ap301c-v4
+
 define Device/tplink_tl-mr6400-v1
   $(Device/tplink-8mlzma)
   SOC := qca9531

--- a/target/linux/ath79/patches-5.10/600-of_net-add-mac-address-ascii-support.patch
+++ b/target/linux/ath79/patches-5.10/600-of_net-add-mac-address-ascii-support.patch
@@ -29,7 +29,7 @@
 +	mac_ascii = nvmem_cell_read(cell, &len);
 +	if (IS_ERR(mac_ascii))
 +		return PTR_ERR(mac_ascii);
-+	if (len != ETH_ALEN*2+5) {
++	if (len != ETH_ALEN*2+5 && len != ETH_ALEN*2) {
 +		kfree(mac_ascii);
 +		return ERR_PTR(-EINVAL);
 +	}
@@ -38,9 +38,9 @@
 +		kfree(mac_ascii);
 +		return ERR_PTR(-ENOMEM);
 +	}
-+	ret = sscanf(mac_ascii, "%2hhx:%2hhx:%2hhx:%2hhx:%2hhx:%2hhx",
-+				&mac[0], &mac[1], &mac[2],
-+				&mac[3], &mac[4], &mac[5]);
++	ret = sscanf(mac_ascii, (len == ETH_ALEN*2) ? "%2hhx%2hhx%2hhx%2hhx%2hhx"
++				"%2hhx" : "%2hhx%*c%2hhx%*c%2hhx%*c%2hhx%*c%2hhx%*c%2hhx",
++				&mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]);
 +	kfree(mac_ascii);
 +	if (ret == ETH_ALEN)
 +		return mac;

--- a/target/linux/ath79/patches-5.15/600-of_net-add-mac-address-ascii-support.patch
+++ b/target/linux/ath79/patches-5.15/600-of_net-add-mac-address-ascii-support.patch
@@ -29,7 +29,7 @@
 +	mac_ascii = nvmem_cell_read(cell, &len);
 +	if (IS_ERR(mac_ascii))
 +		return PTR_ERR(mac_ascii);
-+	if (len != ETH_ALEN*2+5) {
++	if (len != ETH_ALEN*2+5 && len != ETH_ALEN*2) {
 +		kfree(mac_ascii);
 +		return ERR_PTR(-EINVAL);
 +	}
@@ -38,9 +38,9 @@
 +		kfree(mac_ascii);
 +		return ERR_PTR(-ENOMEM);
 +	}
-+	ret = sscanf(mac_ascii, "%2hhx:%2hhx:%2hhx:%2hhx:%2hhx:%2hhx",
-+				&mac[0], &mac[1], &mac[2],
-+				&mac[3], &mac[4], &mac[5]);
++	ret = sscanf(mac_ascii, (len == ETH_ALEN*2) ? "%2hhx%2hhx%2hhx%2hhx%2hhx"
++				"%2hhx" : "%2hhx%*c%2hhx%*c%2hhx%*c%2hhx%*c%2hhx%*c%2hhx",
++				&mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]);
 +	kfree(mac_ascii);
 +	if (ret == ETH_ALEN)
 +		return mac;


### PR DESCRIPTION
TP-Link TL-AP301C v4.0 is an indoor 2.4GHz AP.

Specifications:
 - SoC: QCA9533-BL3A
 - RAM: 64MB
 - Storage: 8MB NOR (GD25Q64CSIG)
 - Wireless: QCA9533 802.11b/g/n 2x2
 - Ethernet: 1x 10/100 port
 - 1 status LED
 - 1 Fit/Fat AP mode switch

MAC Address(es):
 eth0 / wifi0 / label are the same (as label).

Flash Layout:
```
 0x000000 - 0x020000 "factoryBoot"
 0x020000 - 0x030000 "factoryInfo"
 0x030000 - 0x040000 "art"
 0x040000 - 0x800000 "firmware"
```
 Note:
   The OEM firmware starts at 0x060000, and there's a second U-Boot at
   0x040000 - 0x060000. However, that second U-Boot is the same as the
   first one, not even off by one bit, and it's never executed / used. So
   we can safely override that partition.

Edits to Kernel Patch 600-of_net-add-mac-address-ascii-support.patch:
 1. Modified function "nvmem_cell_get_mac_address_ascii" so that it can
    recognise seperators other than ':'. (like '-' or '.' in some devices)
 2. It now also takes nvmem cells of length 12, which is mac address in
    ascii representation but without seperators. (like this device)

Caveats:
 1. Verbose flashing procedure.
 2. Due to a bug in the OEM U-Boot, a third party bootloader is needed.
    Otherwise you would have to manually boot each time because the eth
    phy cannot be initialized when using U-Boot autoboot.

Flashing:
 1. Unscrew 4 screws on the bottom, open the device.
 2. Find the TTL pad, solder 3 wires to it. Definition:
    https://imgur.com/a/H2G8FI9
 3. On the back of the PCB, use solder to connect the pads
    of two zero ohm resistors. Instructions:
    https://imgur.com/a/PhRqqfO
 4. Connect the device to a computer using USB-TTL console.
    You might need to set baud rate to 117000 if it outputs
    gibberish. Otherwise try the standard rate of 115200.
 5. Set computer IP address 192.168.1.10/255.255.255.0,
    gateway 192.168.1.1
 6. Setup tftp server and host the sysupgrade image.
 7. Power on the device, press Ctrl + B to interrupt autoboot,
    and then use the following commands to flash the firmware:
```
tftp 0x80000000 sysupgrade.bin
erase 0x9f040000 +0x7c0000
cp.b 0x80000000 0x9f040000 0x7c0000
```
 8. Download breed bootloader from
    https://breed.hackpascal.net/breed-qca953x-letv-lba-047-ch.bin
    Rename it to breed.bin, and then host it in the tftp server.
 9. Use the following commands to flash the breed bootloader:
 ```
tftp 0x80000000 breed.bin
erase 0x9f000000 +0x20000
cp.b 0x80000000 0x9f000000 0x20000
```
10. Reboot the router.
11. Go to breed web environment at 192.168.1.1
    Enable environment variable editing, then reboot.
12. Go to breed web environment, add a new environment variable:
        `KEY: "autoboot.command"    VALUE: "boot flash 0x40000"`
    (without quotation marks). Then save and reboot.

Signed-off-by: Ray Wang <raywang777@foxmail.com>