### PR TITLE
realtek: rename u-boot-env2 to board-name

### DIFF
--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210.dtsi
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210.dtsi
@@ -55,7 +55,7 @@
 				read-only;
 			};
 			partition@c0000 {
-				label = "u-boot-env2";
+				label = "board-name";
 				reg = <0x000c0000 0x40000>;
 			};
 			partition@280000 {


### PR DESCRIPTION
Some realtek boards have two u-boot-env partitions. However, in the
DGS-1210 series, the mtdblock2 partition is not a valid u-boot env
and simply contains the board/device name, followed by nulls.

00000000  44 47 53 2d 31 32 31 30  2d 32 38 2d 46 31 00 00 |DGS-1210-28-F1..|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
*
00040000

00000000  44 47 53 2d 31 32 31 30  2d 35 32 2d 46 31 00 00 |DGS-1210-52-F1..|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
*
00040000

The misleading u-boot-env2 name also confuses uboot-envtools.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
