### PR TITLE
mac80211: ath9k-htc: support "eeprom" and "chanbw" in debugfs

### DIFF
--- a/package/kernel/mac80211/patches/ath9k/500-ath9k_eeprom_debugfs.patch
+++ b/package/kernel/mac80211/patches/ath9k/500-ath9k_eeprom_debugfs.patch
@@ -1,14 +1,24 @@
 --- a/drivers/net/wireless/ath/ath9k/debug.c
 +++ b/drivers/net/wireless/ath/ath9k/debug.c
-@@ -1413,6 +1413,54 @@ void ath9k_deinit_debug(struct ath_softc
- 	ath9k_cmn_spectral_deinit_debug(&sc->spec_priv);
- }
+@@ -1471,6 +1471,7 @@ int ath9k_init_debug(struct ath_hw *ah)
  
+ 	ath9k_cmn_debug_base_eeprom(sc->debug.debugfs_phy, sc->sc_ah);
+ 	ath9k_cmn_debug_modal_eeprom(sc->debug.debugfs_phy, sc->sc_ah);
++	ath9k_cmn_debug_eeprom(sc->debug.debugfs_phy, sc->sc_ah);
+ 
+ 	debugfs_create_u32("gpio_mask", 0600,
+ 			   sc->debug.debugfs_phy, &sc->sc_ah->gpio_mask);
+--- a/drivers/net/wireless/ath/ath9k/common-debug.c
++++ b/drivers/net/wireless/ath/ath9k/common-debug.c
+@@ -260,3 +260,58 @@ void ath9k_cmn_debug_phy_err(struct dent
+ 			    &fops_phy_err);
+ }
+ EXPORT_SYMBOL(ath9k_cmn_debug_phy_err);
++
 +static ssize_t read_file_eeprom(struct file *file, char __user *user_buf,
 +			     size_t count, loff_t *ppos)
 +{
-+	struct ath_softc *sc = file->private_data;
-+	struct ath_hw *ah = sc->sc_ah;
++	struct ath_hw *ah = file->private_data;
 +	struct ath_common *common = ath9k_hw_common(ah);
 +	int bytes = 0;
 +	int pos = *ppos;
@@ -52,15 +62,31 @@
 +	.owner = THIS_MODULE
 +};
 +
- int ath9k_init_debug(struct ath_hw *ah)
- {
- 	struct ath_common *common = ath9k_hw_common(ah);
-@@ -1432,6 +1480,8 @@ int ath9k_init_debug(struct ath_hw *ah)
- 	ath9k_tx99_init_debug(sc);
- 	ath9k_cmn_spectral_init_debug(&sc->spec_priv, sc->debug.debugfs_phy);
- 
-+	debugfs_create_file("eeprom", S_IRUSR, sc->debug.debugfs_phy, sc,
++void ath9k_cmn_debug_eeprom(struct dentry *debugfs_phy,
++			    struct ath_hw *ah)
++{
++	debugfs_create_file("eeprom", S_IRUSR, debugfs_phy, ah,
 +			    &fops_eeprom);
- 	debugfs_create_devm_seqfile(sc->dev, "dma", sc->debug.debugfs_phy,
- 				    read_file_dma);
- 	debugfs_create_devm_seqfile(sc->dev, "interrupt", sc->debug.debugfs_phy,
++}
++EXPORT_SYMBOL(ath9k_cmn_debug_eeprom);
+--- a/drivers/net/wireless/ath/ath9k/common-debug.h
++++ b/drivers/net/wireless/ath/ath9k/common-debug.h
+@@ -69,6 +69,8 @@ void ath9k_cmn_debug_modal_eeprom(struct
+ 				  struct ath_hw *ah);
+ void ath9k_cmn_debug_base_eeprom(struct dentry *debugfs_phy,
+ 				 struct ath_hw *ah);
++void ath9k_cmn_debug_eeprom(struct dentry *debugfs_phy,
++			    struct ath_hw *ah);
+ void ath9k_cmn_debug_stat_rx(struct ath_rx_stats *rxstats,
+ 			     struct ath_rx_status *rs);
+ void ath9k_cmn_debug_recv(struct dentry *debugfs_phy,
+--- a/drivers/net/wireless/ath/ath9k/htc_drv_debug.c
++++ b/drivers/net/wireless/ath/ath9k/htc_drv_debug.c
+@@ -519,6 +519,7 @@ int ath9k_htc_init_debug(struct ath_hw *
+ 
+ 	ath9k_cmn_debug_base_eeprom(priv->debug.debugfs_phy, priv->ah);
+ 	ath9k_cmn_debug_modal_eeprom(priv->debug.debugfs_phy, priv->ah);
++	ath9k_cmn_debug_eeprom(priv->debug.debugfs_phy, priv->ah);
+ 
+ 	return 0;
+ }

--- a/package/kernel/mac80211/patches/ath9k/512-ath9k_channelbw_debugfs.patch
+++ b/package/kernel/mac80211/patches/ath9k/512-ath9k_channelbw_debugfs.patch
@@ -1,67 +1,13 @@
 --- a/drivers/net/wireless/ath/ath9k/debug.c
 +++ b/drivers/net/wireless/ath/ath9k/debug.c
-@@ -1413,6 +1413,52 @@ void ath9k_deinit_debug(struct ath_softc
- 	ath9k_cmn_spectral_deinit_debug(&sc->spec_priv);
- }
+@@ -1472,6 +1472,7 @@ int ath9k_init_debug(struct ath_hw *ah)
+ 	ath9k_cmn_debug_base_eeprom(sc->debug.debugfs_phy, sc->sc_ah);
+ 	ath9k_cmn_debug_modal_eeprom(sc->debug.debugfs_phy, sc->sc_ah);
+ 	ath9k_cmn_debug_eeprom(sc->debug.debugfs_phy, sc->sc_ah);
++	ath9k_cmn_debug_chanbw(sc->debug.debugfs_phy, sc->sc_ah);
  
-+
-+static ssize_t read_file_chan_bw(struct file *file, char __user *user_buf,
-+			     size_t count, loff_t *ppos)
-+{
-+	struct ath_softc *sc = file->private_data;
-+	struct ath_common *common = ath9k_hw_common(sc->sc_ah);
-+	char buf[32];
-+	unsigned int len;
-+
-+	len = sprintf(buf, "0x%08x\n", common->chan_bw);
-+	return simple_read_from_buffer(user_buf, count, ppos, buf, len);
-+}
-+
-+static ssize_t write_file_chan_bw(struct file *file, const char __user *user_buf,
-+			     size_t count, loff_t *ppos)
-+{
-+	struct ath_softc *sc = file->private_data;
-+	struct ath_common *common = ath9k_hw_common(sc->sc_ah);
-+	unsigned long chan_bw;
-+	char buf[32];
-+	ssize_t len;
-+
-+	len = min(count, sizeof(buf) - 1);
-+	if (copy_from_user(buf, user_buf, len))
-+		return -EFAULT;
-+
-+	buf[len] = '\0';
-+	if (kstrtoul(buf, 0, &chan_bw))
-+		return -EINVAL;
-+
-+	common->chan_bw = chan_bw;
-+	if (!test_bit(ATH_OP_INVALID, &common->op_flags))
-+		ath9k_ops.config(sc->hw, IEEE80211_CONF_CHANGE_CHANNEL);
-+
-+	return count;
-+}
-+
-+static const struct file_operations fops_chanbw = {
-+	.read = read_file_chan_bw,
-+	.write = write_file_chan_bw,
-+	.open = simple_open,
-+	.owner = THIS_MODULE,
-+	.llseek = default_llseek,
-+};
-+
-+
- int ath9k_init_debug(struct ath_hw *ah)
- {
- 	struct ath_common *common = ath9k_hw_common(ah);
-@@ -1432,6 +1478,8 @@ int ath9k_init_debug(struct ath_hw *ah)
- 	ath9k_tx99_init_debug(sc);
- 	ath9k_cmn_spectral_init_debug(&sc->spec_priv, sc->debug.debugfs_phy);
- 
-+	debugfs_create_file("chanbw", S_IRUSR | S_IWUSR, sc->debug.debugfs_phy,
-+			    sc, &fops_chanbw);
- 	debugfs_create_devm_seqfile(sc->dev, "dma", sc->debug.debugfs_phy,
- 				    read_file_dma);
- 	debugfs_create_devm_seqfile(sc->dev, "interrupt", sc->debug.debugfs_phy,
+ 	debugfs_create_u32("gpio_mask", 0600,
+ 			   sc->debug.debugfs_phy, &sc->sc_ah->gpio_mask);
 --- a/drivers/net/wireless/ath/ath.h
 +++ b/drivers/net/wireless/ath/ath.h
 @@ -153,6 +153,7 @@ struct ath_common {
@@ -72,6 +18,14 @@
  
  	struct ath_ani ani;
  
+@@ -181,6 +182,7 @@ struct ath_common {
+ 	const struct ath_ops *ops;
+ 	const struct ath_bus_ops *bus_ops;
+ 	const struct ath_ps_ops *ps_ops;
++	const struct ieee80211_ops *ieee_ops;
+ 
+ 	bool btcoex_enabled;
+ 	bool disable_ani;
 --- a/drivers/net/wireless/ath/ath9k/common.c
 +++ b/drivers/net/wireless/ath/ath9k/common.c
 @@ -297,11 +297,13 @@ EXPORT_SYMBOL(ath9k_cmn_get_hw_crypto_ke
@@ -123,3 +77,115 @@
  
  	return channel;
  }
+--- a/drivers/net/wireless/ath/ath9k/common-debug.c
++++ b/drivers/net/wireless/ath/ath9k/common-debug.c
+@@ -316,3 +316,55 @@ void ath9k_cmn_debug_eeprom(struct dentr
+ 			    &fops_eeprom);
+ }
+ EXPORT_SYMBOL(ath9k_cmn_debug_eeprom);
++
++static ssize_t read_file_chan_bw(struct file *file, char __user *user_buf,
++			     size_t count, loff_t *ppos)
++{
++	struct ath_hw *ah = file->private_data;
++	struct ath_common *common = ath9k_hw_common(ah);
++	char buf[32];
++	unsigned int len;
++
++	len = sprintf(buf, "0x%08x\n", common->chan_bw);
++	return simple_read_from_buffer(user_buf, count, ppos, buf, len);
++}
++
++static ssize_t write_file_chan_bw(struct file *file, const char __user *user_buf,
++			     size_t count, loff_t *ppos)
++{
++	struct ath_hw *ah = file->private_data;
++	struct ath_common *common = ath9k_hw_common(ah);
++	unsigned long chan_bw;
++	char buf[32];
++	ssize_t len;
++
++	len = min(count, sizeof(buf) - 1);
++	if (copy_from_user(buf, user_buf, len))
++		return -EFAULT;
++
++	buf[len] = '\0';
++	if (kstrtoul(buf, 0, &chan_bw))
++		return -EINVAL;
++
++	common->chan_bw = chan_bw;
++	if (!test_bit(ATH_OP_INVALID, &common->op_flags))
++		common->ieee_ops->config(ah->hw, IEEE80211_CONF_CHANGE_CHANNEL);
++
++	return count;
++}
++
++static const struct file_operations fops_chanbw = {
++	.read = read_file_chan_bw,
++	.write = write_file_chan_bw,
++	.open = simple_open,
++	.owner = THIS_MODULE,
++	.llseek = default_llseek,
++};
++
++void ath9k_cmn_debug_chanbw(struct dentry *debugfs_phy,
++			    struct ath_hw *ah)
++{
++	debugfs_create_file("chanbw", S_IRUSR | S_IWUSR, debugfs_phy, ah,
++			    &fops_chanbw);
++}
++EXPORT_SYMBOL(ath9k_cmn_debug_chanbw);
+--- a/drivers/net/wireless/ath/ath9k/htc_drv_debug.c
++++ b/drivers/net/wireless/ath/ath9k/htc_drv_debug.c
+@@ -520,6 +520,7 @@ int ath9k_htc_init_debug(struct ath_hw *
+ 	ath9k_cmn_debug_base_eeprom(priv->debug.debugfs_phy, priv->ah);
+ 	ath9k_cmn_debug_modal_eeprom(priv->debug.debugfs_phy, priv->ah);
+ 	ath9k_cmn_debug_eeprom(priv->debug.debugfs_phy, priv->ah);
++	ath9k_cmn_debug_chanbw(priv->debug.debugfs_phy, priv->ah);
+ 
+ 	return 0;
+ }
+--- a/drivers/net/wireless/ath/ath9k/common-debug.h
++++ b/drivers/net/wireless/ath/ath9k/common-debug.h
+@@ -71,6 +71,8 @@ void ath9k_cmn_debug_base_eeprom(struct
+ 				 struct ath_hw *ah);
+ void ath9k_cmn_debug_eeprom(struct dentry *debugfs_phy,
+ 			    struct ath_hw *ah);
++void ath9k_cmn_debug_chanbw(struct dentry *debugfs_phy,
++			    struct ath_hw *ah);
+ void ath9k_cmn_debug_stat_rx(struct ath_rx_stats *rxstats,
+ 			     struct ath_rx_status *rs);
+ void ath9k_cmn_debug_recv(struct dentry *debugfs_phy,
+--- a/drivers/net/wireless/ath/ath9k/htc_drv_init.c
++++ b/drivers/net/wireless/ath/ath9k/htc_drv_init.c
+@@ -631,6 +631,7 @@ static int ath9k_init_priv(struct ath9k_
+ 	priv->ah = ah;
+ 
+ 	common = ath9k_hw_common(ah);
++	common->ieee_ops = &ath9k_htc_ops;
+ 	common->ops = &ah->reg_ops;
+ 	common->ps_ops = &ath9k_htc_ps_ops;
+ 	common->bus_ops = &ath9k_usb_bus_ops;
+@@ -746,9 +747,9 @@ static void ath9k_set_hw_capab(struct at
+ 
+ 	hw->wiphy->flags |= WIPHY_FLAG_IBSS_RSN |
+ 			    WIPHY_FLAG_HAS_REMAIN_ON_CHANNEL |
+-			    WIPHY_FLAG_HAS_CHANNEL_SWITCH;
+-
+-	hw->wiphy->flags |= WIPHY_FLAG_SUPPORTS_TDLS;
++			    WIPHY_FLAG_HAS_CHANNEL_SWITCH |
++			    WIPHY_FLAG_SUPPORTS_5_10_MHZ |
++			    WIPHY_FLAG_SUPPORTS_TDLS;
+ 
+ 	hw->queues = 4;
+ 	hw->max_listen_interval = 1;
+--- a/drivers/net/wireless/ath/ath9k/init.c
++++ b/drivers/net/wireless/ath/ath9k/init.c
+@@ -733,6 +733,7 @@ static int ath9k_init_softc(u16 devid, s
+ 	if (!ath9k_is_chanctx_enabled())
+ 		sc->cur_chan->hw_queue_base = 0;
+ 
++	common->ieee_ops = &ath9k_ops;
+ 	common->ops = &ah->reg_ops;
+ 	common->bus_ops = bus_ops;
+ 	common->ps_ops = &ath9k_ps_ops;

--- a/package/kernel/mac80211/patches/ath9k/512-ath9k_channelbw_debugfs.patch
+++ b/package/kernel/mac80211/patches/ath9k/512-ath9k_channelbw_debugfs.patch
@@ -1,8 +1,8 @@
 --- a/drivers/net/wireless/ath/ath9k/debug.c
 +++ b/drivers/net/wireless/ath/ath9k/debug.c
-@@ -1461,6 +1461,52 @@ static const struct file_operations fops
- 	.owner = THIS_MODULE
- };
+@@ -1413,6 +1413,52 @@ void ath9k_deinit_debug(struct ath_softc
+ 	ath9k_cmn_spectral_deinit_debug(&sc->spec_priv);
+ }
  
 +
 +static ssize_t read_file_chan_bw(struct file *file, char __user *user_buf,
@@ -53,10 +53,10 @@
  int ath9k_init_debug(struct ath_hw *ah)
  {
  	struct ath_common *common = ath9k_hw_common(ah);
-@@ -1482,6 +1528,8 @@ int ath9k_init_debug(struct ath_hw *ah)
+@@ -1432,6 +1478,8 @@ int ath9k_init_debug(struct ath_hw *ah)
+ 	ath9k_tx99_init_debug(sc);
+ 	ath9k_cmn_spectral_init_debug(&sc->spec_priv, sc->debug.debugfs_phy);
  
- 	debugfs_create_file("eeprom", S_IRUSR, sc->debug.debugfs_phy, sc,
- 			    &fops_eeprom);
 +	debugfs_create_file("chanbw", S_IRUSR | S_IWUSR, sc->debug.debugfs_phy,
 +			    sc, &fops_chanbw);
  	debugfs_create_devm_seqfile(sc->dev, "dma", sc->debug.debugfs_phy,
@@ -64,7 +64,7 @@
  	debugfs_create_devm_seqfile(sc->dev, "interrupt", sc->debug.debugfs_phy,
 --- a/drivers/net/wireless/ath/ath.h
 +++ b/drivers/net/wireless/ath/ath.h
-@@ -151,6 +151,7 @@ struct ath_common {
+@@ -153,6 +153,7 @@ struct ath_common {
  	int debug_mask;
  	enum ath_device_state state;
  	unsigned long op_flags;

--- a/package/kernel/mac80211/patches/ath9k/530-ath9k_extra_leds.patch
+++ b/package/kernel/mac80211/patches/ath9k/530-ath9k_extra_leds.patch
@@ -181,7 +181,7 @@
  
 --- a/drivers/net/wireless/ath/ath9k/init.c
 +++ b/drivers/net/wireless/ath/ath9k/init.c
-@@ -1088,7 +1088,7 @@ int ath9k_init_device(u16 devid, struct
+@@ -1089,7 +1089,7 @@ int ath9k_init_device(u16 devid, struct
  
  #ifdef CPTCFG_MAC80211_LEDS
  	/* must be initialized before ieee80211_register_hw */
@@ -192,9 +192,9 @@
  #endif
 --- a/drivers/net/wireless/ath/ath9k/debug.c
 +++ b/drivers/net/wireless/ath/ath9k/debug.c
-@@ -1506,6 +1506,61 @@ static const struct file_operations fops
- 	.llseek = default_llseek,
- };
+@@ -128,6 +128,61 @@ static const struct file_operations fops
+ 
+ #define DMA_BUF_LEN 1024
  
 +#ifdef CONFIG_MAC80211_LEDS
 +
@@ -252,12 +252,12 @@
 +#endif
 +
  
- int ath9k_init_debug(struct ath_hw *ah)
- {
-@@ -1530,6 +1585,10 @@ int ath9k_init_debug(struct ath_hw *ah)
- 			    &fops_eeprom);
- 	debugfs_create_file("chanbw", S_IRUSR | S_IWUSR, sc->debug.debugfs_phy,
- 			    sc, &fops_chanbw);
+ static ssize_t read_file_ani(struct file *file, char __user *user_buf,
+ 			     size_t count, loff_t *ppos)
+@@ -1432,6 +1487,10 @@ int ath9k_init_debug(struct ath_hw *ah)
+ 	ath9k_tx99_init_debug(sc);
+ 	ath9k_cmn_spectral_init_debug(&sc->spec_priv, sc->debug.debugfs_phy);
+ 
 +#ifdef CONFIG_MAC80211_LEDS
 +	debugfs_create_file("gpio_led", S_IWUSR,
 +			   sc->debug.debugfs_phy, sc, &fops_gpio_led);


### PR DESCRIPTION
ath9k-htc USB-based adapters also support 5/10MHz channel bandwidth and
EEPROM dump features. Move the code handling the features in debugfs
to common-debug.c, and create proper registration functions to use in
debug.c and htc_drv_debug.c, leaving only debugfs registration there.

While at that, refresh one patch that would conflict otherwise.

Tested on TP-Link Archer C7v2 (ath79) and TP-Link WN722Nv1 (AR9287)
and WN822Nv2 (AR7010+AR9287).

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>