### PR TITLE
[WIP] xdp-tools: mark as nonshared

### DIFF
--- a/package/network/utils/xdp-tools/Makefile
+++ b/package/network/utils/xdp-tools/Makefile
@@ -12,6 +12,7 @@ PKG_ABI_VERSION:=$(call abi_version_str,$(PKG_VERSION))
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 
 PKG_BUILD_DEPENDS:=bpf-headers
+PKG_FLAGS:=nonshared
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/bpf.mk


### PR DESCRIPTION
The SDK does not have the LLVM toolchain yet?

Hopefully fixes errors in the form:
```
  xsk_def_xdp_prog.c:4:10: fatal error: 'bpf/bpf_helpers.h' file not found
  #include <bpf/bpf_helpers.h>
```

Fixes: 6ad1bea2a603 ("xdp-tools: add package")

ping @dangowrt @tohojo 
