### PR TITLE
realtek: build sane factory images for all DGS-1210 models

### DIFF
--- a/target/linux/realtek/image/Makefile
+++ b/target/linux/realtek/image/Makefile
@@ -21,6 +21,11 @@ define Build/dlink-cameo
 	$(SCRIPT_DIR)/cameo-tag.py $@ $(DLINK_KERNEL_PART_SIZE)
 endef
 
+define Build/dlink-version
+	echo -n "OpenWrt" >> $@
+	dd if=/dev/zero bs=25 count=1 >> $@
+endef
+
 define Build/dlink-headers
         dd if=$@ bs=$(DLINK_KERNEL_PART_SIZE) count=1 of=$@.kernel_part; \
         dd if=$@ bs=$(DLINK_KERNEL_PART_SIZE) skip=1 of=$@.rootfs_part; \

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -23,7 +23,8 @@ define Device/d-link_dgs-1210
   CAMEO_BOARD_VERSION := 32
   IMAGES += factory_image1.bin
   IMAGE/factory_image1.bin := append-kernel | pad-to 64k | \
-	append-rootfs | pad-rootfs | pad-to 16 | check-size | dlink-headers
+	append-rootfs | pad-rootfs | pad-to 16 | check-size | \
+	dlink-version | dlink-headers
 endef
 
 define Device/d-link_dgs-1210-10p

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -17,6 +17,13 @@ define Device/d-link_dgs-1210
   DEVICE_VENDOR := D-Link
   DLINK_KERNEL_PART_SIZE := 1572864
   KERNEL := kernel-bin | append-dtb | gzip | uImage gzip | dlink-cameo
+  CAMEO_KERNEL_PART := 2
+  CAMEO_ROOTFS_PART := 3
+  CAMEO_CUSTOMER_SIGNATURE := 2
+  CAMEO_BOARD_VERSION := 32
+  IMAGES += factory_image1.bin
+  IMAGE/factory_image1.bin := append-kernel | pad-to 64k | \
+	append-rootfs | pad-rootfs | pad-to 16 | check-size | dlink-headers
 endef
 
 define Device/d-link_dgs-1210-10p
@@ -41,13 +48,6 @@ TARGET_DEVICES += d-link_dgs-1210-20
 define Device/d-link_dgs-1210-28
   $(Device/d-link_dgs-1210)
   DEVICE_MODEL := DGS-1210-28
-  CAMEO_KERNEL_PART := 2
-  CAMEO_ROOTFS_PART := 3
-  CAMEO_CUSTOMER_SIGNATURE := 2
-  CAMEO_BOARD_VERSION := 32
-  IMAGES += factory_image1.bin
-  IMAGE/factory_image1.bin := append-kernel | pad-to 64k | \
-        append-rootfs | pad-rootfs | pad-to 16 | check-size | dlink-headers
 endef
 TARGET_DEVICES += d-link_dgs-1210-28
 


### PR DESCRIPTION
Currently we build factory images only for DGS-1210-28 model. Relax
that constraint and take care about all models. The initial commit forgot
to label the image in the right way. Therefore WebUI and CLI show
strange version information. Fix this too.

```
Before:
DGS-1210-20> show firmware information
IMAGE ONE:
Version      : xfo/QE~WQD"A\Scxq...
Size         : 5505185 Bytes

After:
DGS-1210-20> show firmware information
IMAGE ONE:
Version      : OpenWrt
Size         : 5505200 Bytes
```
