### PR TITLE
libpcap: fix PKG_CONFIG_DEPENDS for rpcapd

### DIFF
--- a/package/libs/libpcap/Makefile
+++ b/package/libs/libpcap/Makefile
@@ -21,6 +21,8 @@ PKG_LICENSE_FILES:=LICENSE
 
 PKG_ASLR_PIE_REGULAR:=1
 
+PKG_CONFIG_DEPENDS := CONFIG_PACKAGE_rpcapd
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 


### PR DESCRIPTION
This fix allows trigger a rerun of Build/Configure when rpcapd was selected.