### PR TITLE
wolfssl: have wpa_supplicant support select DH

### DIFF
--- a/package/libs/wolfssl/Config.in
+++ b/package/libs/wolfssl/Config.in
@@ -43,6 +43,7 @@ config WOLFSSL_HAS_OCSP
 config WOLFSSL_HAS_WPAS
 	bool "Include wpa_supplicant support"
 	select WOLFSSL_HAS_ARC4
+	select WOLFSSL_HAS_DH
 	select WOLFSSL_HAS_OCSP
 	select WOLFSSL_HAS_SESSION_TICKET
 	default y


### PR DESCRIPTION
If wolfssl is configured with `--enable-wpas` and without `--enable-dh`, then build will fail:
```
configure: error: Anonymous suite requires DH.
```

Let's not allow such combination.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

Supersedes #3801