### PR TITLE
wolfssl: re-enable AES-NI by default for x86_64

### DIFF
--- a/package/libs/wolfssl/Config.in
+++ b/package/libs/wolfssl/Config.in
@@ -72,7 +72,7 @@ config WOLFSSL_ASM_CAPABLE
 
 choice
 	prompt "Hardware Acceleration"
-	default WOLFSSL_HAS_CPU_CRYPTO if WOLFSSL_ASM_CAPABLE && !x86_64
+	default WOLFSSL_HAS_CPU_CRYPTO if WOLFSSL_ASM_CAPABLE
 	default WOLFSSL_HAS_NO_HW
 
 	config WOLFSSL_HAS_NO_HW
@@ -84,7 +84,6 @@ choice
 		help
 		This will use Intel AESNI insturctions or armv8 Crypto Extensions.
 		Either of them should easily outperform hardware crypto in WolfSSL.
-		Beware that for Intel, the CPU has to support SSE4 instructions.
 
 	config WOLFSSL_HAS_AFALG
 		bool "AF_ALG"
@@ -101,9 +100,5 @@ choice
 		bool "/dev/crypto - full"
 		select WOLFSSL_HAS_DEVCRYPTO
 endchoice
-if x86_64 && WOLFSSL_HAS_CPU_CRYPTO
-	comment "WARNING: make sure your CPU supports SSE4 instructions"
-	comment "WolfSSL may crash with an invalid opcode exception"
-endif
 
 endif

--- a/package/libs/wolfssl/patches/300-AESNI-fix-configure-to-use-minimal-compiler-flags.patch
+++ b/package/libs/wolfssl/patches/300-AESNI-fix-configure-to-use-minimal-compiler-flags.patch
@@ -1,0 +1,44 @@
+From 9ba77300f9f5dea9f53aed00bf6c33d10b7b2fce Mon Sep 17 00:00:00 2001
+From: Sean Parkinson <sean@wolfssl.com>
+Date: Thu, 7 Jul 2022 09:30:48 +1000
+Subject: [PATCH] AESNI: fix configure to use minimal compiler flags
+
+
+diff --git a/configure.ac b/configure.ac
+index df97ac75c..6abb0c744 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2142,21 +2142,19 @@ then
+     if test "$ENABLED_AESNI" = "yes" || test "$ENABLED_INTELASM" = "yes"
+     then
+         AM_CFLAGS="$AM_CFLAGS -DWOLFSSL_AESNI"
+-        if test "$GCC" = "yes"
++        if test "$CC" != "icc"
+         then
+-            # clang needs these flags
+-            if test "$CC" = "clang"
+-            then
+-                AM_CFLAGS="$AM_CFLAGS -maes -mpclmul"
+-            else
+-                # GCC needs these flags, icc doesn't
+-                # opt levels greater than 2 may cause problems on systems w/o
+-                # aesni
+-                if test "$CC" != "icc"
+-                then
+-                    AM_CFLAGS="$AM_CFLAGS -maes -msse4 -mpclmul"
+-                fi
+-            fi
++            case $host_os in
++            mingw*)
++                # Windows uses intrinsics for GCM which uses SSE4 instructions.
++                # MSVC has own build files.
++                AM_CFLAGS="$AM_CFLAGS -maes -msse4 -mpclmul"
++                ;;
++            *)
++                # Intrinsics used in AES_set_decrypt_key (TODO: rework)
++                AM_CFLAGS="$AM_CFLAGS -maes"
++                ;;
++            esac
+         fi
+         AS_IF([test "x$ENABLED_AESGCM" != "xno"],[AM_CCASFLAGS="$AM_CCASFLAGS -DHAVE_AESGCM"])
+     fi


### PR DESCRIPTION
Apply an upstream patch that removes unnecessary CFLAGs, avoiding generation of incompatible code.

Commit 0bd536723303ccd178e289690d073740c928bb34 is reverted so the accelerated version builds by default on x86_64.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

Tested with qemu; confirmed there's no change in soname: `libwolfssl.so.5.3.0.e624513f`.