### PR TITLE
mt7622: remove 300 Hz from dts

### DIFF
--- a/target/linux/mediatek/patches-5.15/722-remove-300Hz-to-prevent-freeze.patch
+++ b/target/linux/mediatek/patches-5.15/722-remove-300Hz-to-prevent-freeze.patch
@@ -1,0 +1,25 @@
+--- a/arch/arm64/boot/dts/mediatek/mt7622.dtsi
++++ b/arch/arm64/boot/dts/mediatek/mt7622.dtsi
+@@ -23,11 +23,17 @@
+ 	cpu_opp_table: opp-table {
+ 		compatible = "operating-points-v2";
+ 		opp-shared;
+-		opp-300000000 {
+-			opp-hz = /bits/ 64 <300000000>;
+-			opp-microvolt = <950000>;
+-		};
+-
++		/* Due to the bug described at the link below, remove the 300 MHz clock to avoid a low
++		 * voltage condition that can cause a hang when rebooting the RT3200/E8450.
++		 *
++		 * https://forum.openwrt.org/t/belkin-rt3200-linksys-e8450-wifi-ax-discussion/94302/1490
++		 *
++		 * opp-300000000 {
++		 *	opp-hz = /bits/ 64 <300000000>;
++		 *	opp-microvolt = <950000>;
++		 * };
++		 *
++		 */
+ 		opp-437500000 {
+ 			opp-hz = /bits/ 64 <437500000>;
+ 			opp-microvolt = <1000000>;


### PR DESCRIPTION
Due to the bug described here[1], remove the 300 MHz clock to avoid the low voltage condition that can causes a hang on rebooting RT3200/E8450.

This solution is probably better than the script-based work-around[2].

1. https://forum.openwrt.org/t/belkin-rt3200-linksys-e8450-wifi-ax-discussion/94302/1490
2. https://github.com/openwrt/openwrt/pull/5025

Signed-off-by: John Audia <therealgraysky@proton.me>
Tested-by: Rui Salvaterra <rsalvaterra@gmail.com>
Tested-by: John Audia <therealgraysky@proton.me>