### PR TITLE
generic: fix warning orphan section from module exports in aarch64

### DIFF
--- a/target/linux/generic/hack-5.10/221-module_exports.patch
+++ b/target/linux/generic/hack-5.10/221-module_exports.patch
@@ -89,6 +89,30 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	    "__kstrtab_" #sym ":					\n"	\
  	    "	.asciz 	\"" #sym "\"					\n"	\
  	    "__kstrtabns_" #sym ":					\n"	\
+--- a/include/asm-generic/export.h
++++ b/include/asm-generic/export.h
+@@ -26,6 +26,12 @@
+ #endif
+ .endm
+ 
++#ifdef MODULE
++#define __EXPORT_SUFFIX(name)
++#else
++#define __EXPORT_SUFFIX(name) + #name
++#endif
++
+ /*
+  * note on .section use: we specify progbits since usage of the "M" (SHF_MERGE)
+  * section flag requires it. Use '%progbits' instead of '@progbits' since the
+@@ -42,7 +42,7 @@
+ __ksymtab_\name:
+ 	__put \val, __kstrtab_\name
+ 	.previous
+-	.section __ksymtab_strings,"aMS",%progbits,1
++	.section __ksymtab_strings __EXPORT_SUFFIX(name),"aMS",%progbits,1
+ __kstrtab_\name:
+ 	.asciz "\name"
+ 	.previous
 --- a/scripts/Makefile.build
 +++ b/scripts/Makefile.build
 @@ -367,7 +367,7 @@ targets += $(lib-y) $(always-y) $(MAKECM

--- a/target/linux/generic/hack-5.15/221-module_exports.patch
+++ b/target/linux/generic/hack-5.15/221-module_exports.patch
@@ -89,6 +89,30 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	    "__kstrtab_" #sym ":					\n"	\
  	    "	.asciz 	\"" #sym "\"					\n"	\
  	    "__kstrtabns_" #sym ":					\n"	\
+--- a/include/asm-generic/export.h
++++ b/include/asm-generic/export.h
+@@ -26,6 +26,12 @@ struct kernel_symbol {
+ #endif
+ .endm
+ 
++#ifdef MODULE
++#define __EXPORT_SUFFIX(name)
++#else
++#define __EXPORT_SUFFIX(name) + #name
++#endif
++
+ /*
+  * note on .section use: we specify progbits since usage of the "M" (SHF_MERGE)
+  * section flag requires it. Use '%progbits' instead of '@progbits' since the
+@@ -42,7 +42,7 @@ struct kernel_symbol {
+ __ksymtab_\name:
+ 	__put \val, __kstrtab_\name
+ 	.previous
+-	.section __ksymtab_strings,"aMS",%progbits,1
++	.section __ksymtab_strings __EXPORT_SUFFIX(name),"aMS",%progbits,1
+ __kstrtab_\name:
+ 	.asciz "\name"
+ 	.previous
 --- a/scripts/Makefile.build
 +++ b/scripts/Makefile.build
 @@ -396,7 +396,7 @@ targets += $(real-dtb-y) $(lib-y) $(alwa


### PR DESCRIPTION
kernel linux now have 2 different export.h include, one from
linux/export.h and one from asm-generic/export.h

While most of our target user linux/export.h, aarch64 based target use
asm-generic/export.h that is not patched with the changes of
221-module_exports.

Patch also this additional header to fix multiple

```
aarch64-openwrt-linux-musl-ld: warning: orphan section `__ksymtab_strings' from `arch/arm64/kernel/head.o' being placed in section `__ksymtab_strings'
```

warning during kernel compilation.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>