### PR TITLE
realtek: make DGS-1210 u-boot-env partition writeable

### DIFF
--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210.dtsi
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210.dtsi
@@ -52,7 +52,6 @@
 			partition@80000 {
 				label = "u-boot-env";
 				reg = <0x00080000 0x40000>;
-				read-only;
 			};
 			partition@c0000 {
 				label = "board-name";


### PR DESCRIPTION
We are close to provide enduser friendly OpenWrt images for DGS-1210
switches that do not need serial console. Nevertheless a small bit is
missing. We cannot switch back to the vendor partition or initiate a
TFTP download of a vendor firmware image. To issue this from inside
OpenWrt we need write access to U-Boot environment.

Case 1: Switch back to secondary (vendor) image
> fw_setenv bootcmd run addargs\; bootm 0xb4e80000
> fw_setenv image /dev/mtdblock7
> reboot

Case 2: Issue TFTP download on next reboot (not yet explored)
> fw_setenv bootstop on
> reboot

Allow these commands by opening up u-boot-env for write access.
Tested on DGS-1210-20.

Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
