### PR TITLE
uencrypt: add package to decrypt WG4хх223 config

### DIFF
--- a/package/utils/uencrypt/Makefile
+++ b/package/utils/uencrypt/Makefile
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022 Eneas Ulir de Queiroz
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=uencrypt
+PKG_RELEASE:=1
+
+PKG_FLAGS:=nonshared
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_MAINTAINER:=Eneas U de Queiroz <cotequeiroz@gmail.com>
+PKG_CONFIG_DEPENDS:=\
+	CONFIG_UENCRYPT_OPENSSL \
+	CONFIG_UENCRYPT_WOLFSSL
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+CMAKE_INSTALL:=1
+CMAKE_OPTIONS+=$(if $(CONFIG_UENCRYPT_WOLFSSL),-DUSE_WOLFSSL=1)
+
+define Package/uencrypt
+  SECTION:=utils
+  CATEGORY:=Base system
+  TITLE:=Decryption utility for Arcadyan WG4xx223
+  DEPENDS:=@TARGET_ramips_mt7621 +UENCRYPT_WOLFSSL:libwolfssl +UENCRYPT_OPENSSL:libopenssl
+endef
+
+define Package/uencrypt/description
+  This is a small AES-128-CBC encrypton/decryption program.
+  Even though it can be used for regular encryption and
+  decryption operations using AES-128-CBC, it is included
+  here to unencrypt the configuration from mtd on Arcadyan
+  WG430223 and WG443223 routers.
+endef
+
+define Package/uencrypt/config
+  if PACKAGE_uencrypt
+    choice
+	prompt "Crypto provider"
+	default UENCRYPT_WOLFSSL
+
+	config UENCRYPT_OPENSSL
+	bool "OpenSSL"
+
+	config UENCRYPT_WOLFSSL
+	bool "wolfSSL"
+    endchoice
+  endif
+endef
+
+define Package/uencrypt/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/uencrypt $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,uencrypt))

--- a/package/utils/uencrypt/src/CMakeLists.txt
+++ b/package/utils/uencrypt/src/CMakeLists.txt
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2022 Eneas Ulir de Queiroz
+
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+project(uencrypt LANGUAGES C)
+
+option(USE_WOLFSSL "Use WolfSSL as crypto provider" OFF)
+if (USE_WOLFSSL)
+	add_definitions(-DUSE_WOLFSSL)
+	find_library(WOLFSSL_LIBRARY wolfssl REQUIRED)
+	set(CRYPTO_LIBRARIES ${WOLFSSL_LIBRARY})
+else()
+	find_package(OpenSSL REQUIRED)
+	set(CRYPTO_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY})
+endif()
+
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.c)
+target_link_libraries(${PROJECT_NAME} ${CRYPTO_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)

--- a/package/utils/uencrypt/src/uencrypt.c
+++ b/package/utils/uencrypt/src/uencrypt.c
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later
+ * Copyright (C) 2022 Eneas Ulir de Queiroz
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#ifdef USE_WOLFSSL
+# include <wolfssl/options.h>
+# include <wolfssl/openssl/evp.h>
+#else
+# include <openssl/evp.h>
+#endif
+
+int do_crypt(FILE *infile, FILE *outfile, const char *key, const char *iv,
+	     int enc, int padding)
+{
+    EVP_CIPHER_CTX *ctx;
+    unsigned char inbuf[1024], outbuf[1024 + EVP_MAX_BLOCK_LENGTH];
+    int inlen, outlen;
+
+    ctx = EVP_CIPHER_CTX_new();
+    EVP_CipherInit_ex(ctx, EVP_aes_128_cbc(), NULL, key, iv, enc);
+    EVP_CIPHER_CTX_set_padding(ctx, padding);
+
+    for (;;) {
+	inlen = fread(inbuf, 1, 1024, infile);
+	if (inlen <= 0)
+	    break;
+	if (!EVP_CipherUpdate(ctx, outbuf, &outlen, inbuf, inlen)) {
+	    EVP_CIPHER_CTX_free(ctx);
+	    return -1;
+	}
+	fwrite(outbuf, 1, outlen, outfile);
+    }
+    if (!EVP_CipherFinal_ex(ctx, outbuf, &outlen)) {
+	EVP_CIPHER_CTX_free(ctx);
+	return -1;
+    }
+    fwrite(outbuf, 1, outlen, outfile);
+
+    EVP_CIPHER_CTX_free(ctx);
+    return 0;
+}
+
+static void check_enc_dec(const int enc)
+{
+    if (enc == -1)
+	return;
+    fprintf(stderr, "Error: both -d and -e were specified.\n");
+    exit(EXIT_FAILURE);
+}
+
+static void show_usage(const char* name)
+{
+    fprintf(stderr, "Usage: %s: [-d | -e] [-n] -k key -i iv\n"
+		    "-d = decrypt; -e = encrypt; -n = no padding\n", name);
+}
+
+int main(int argc, char *argv[])
+{
+    int enc = -1;
+    unsigned char *iv = NULL;
+    unsigned char *key = NULL;
+    long len;
+    int opt;
+    int padding = 1;
+    int ret;
+
+    while ((opt = getopt(argc, argv, "dei:k:n")) != -1) {
+	switch (opt) {
+	case 'd':
+	    check_enc_dec(enc);
+	    enc = 0;
+	    break;
+	case 'e':
+	    check_enc_dec(enc);
+	    enc = 1;
+	    break;
+	case 'i':
+	    iv = OPENSSL_hexstr2buf((const char *)optarg, &len);
+	    if (iv == NULL || len != 16) {
+		fprintf(stderr, "Error setting IV to %s. The IV should be 16 bytes, encoded in hex.\n",
+			optarg);
+		exit(EINVAL);
+	    }
+	    break;
+	case 'k':
+	    key = OPENSSL_hexstr2buf((const char *)optarg, &len);
+	    if (key == NULL || len != 16) {
+		fprintf(stderr, "Error setting key to %s. The key should be 16 bytes, encoded in hex.\n",
+			optarg);
+		exit(EINVAL);
+	    }
+	    break;
+	case 'n':
+	    padding = 0;
+	    break;
+	default:
+	    show_usage(argv[0]);
+	    exit(EINVAL);
+	}
+    }
+    if (iv == NULL || key == NULL) {
+	fprintf(stderr, "Error: %s not set.\n", key ? "iv" : (iv ? "key" : "key and iv"));
+	show_usage(argv[0]);
+	exit(EXIT_FAILURE);
+    }
+    ret = do_crypt(stdin, stdout, key, iv, !!enc, padding);
+    if (ret)
+	fprintf(stderr, "Error during crypt operation.\n");
+    OPENSSL_free(iv);
+    OPENSSL_free(key);
+    return ret;
+}


### PR DESCRIPTION
This adds a simple AES-128-CBC encryption/decryption program using
either wolfSSL or OpenSSL as backend to decrypt Arcadyan WG4xx223
configuration partitions.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

----

Discussion about the need for this program can be found in #10062.

This has been run-tested on x86_64 (after taking out `@TARGET_ramips_mt7621` ) with qemu, comparing the output to the equivalent `openssl aes-128-cbc` operation.
