### PR TITLE
xdp-tools: include staging_dir bpf-headers to fix compiling with sdk

### DIFF
--- a/package/network/utils/xdp-tools/Makefile
+++ b/package/network/utils/xdp-tools/Makefile
@@ -85,11 +85,11 @@ CONFIGURE_VARS += \
 	CFLAGS="$(TARGET_CFLAGS)" \
 	LDFLAGS="$(TARGET_LDFLAGS)" \
 	CLANG="$(CLANG)" \
-	BPF_CFLAGS="$(BPF_CFLAGS)" \
 	BPF_TARGET="$(BPF_TARGET)" \
 	LLC="$(LLVM_LLC)"
 
 MAKE_VARS += \
+	BPF_CFLAGS="-I$(STAGING_DIR)/bpf-headers/tools/lib/" \
 	PREFIX=/usr \
 	RUNDIR=/tmp/run
 


### PR DESCRIPTION
Using the sdk clang was not able to find the bpf_helpers when compiling
the bpf programs:
  xsk_def_xdp_prog.c:4:10: fatal error: 'bpf/bpf_helpers.h' file not found
  #include <bpf/bpf_helpers.h>

Set the correct BPF_CFLAGS so clang can include the correct headers.

ping @dangowrt @tohojo 