### PR TITLE
realtek: add support for DGS-1210-52

### DIFF
--- a/package/boot/uboot-envtools/files/realtek
+++ b/package/boot/uboot-envtools/files/realtek
@@ -11,6 +11,7 @@ case "$board" in
 d-link,dgs-1210-16|\
 d-link,dgs-1210-20|\
 d-link,dgs-1210-28|\
+d-link,dgs-1210-52|\
 d-link,dgs-1210-10p|\
 zyxel,gs1900-8|\
 zyxel,gs1900-8hp-v1|\

--- a/target/linux/realtek/dts-5.10/rtl8393_d-link_dgs-1210-52.dts
+++ b/target/linux/realtek/dts-5.10/rtl8393_d-link_dgs-1210-52.dts
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl839x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/* Combo ports not working if unused during u-boot */
+/* #define DGS1210_52_TEST_SFP */
+
+#ifdef DGS1210_52_TEST_SFP
+#define COMBO_SFP_PHY(n, s) \
+	phy##n: ethernet-phy@##n { \
+		compatible = "ethernet-phy-ieee802.3-c22"; \
+		sfp = <&sfp##s>; \
+		reg = <##n>; \
+	};
+
+#define COMBO_PORT(n, s, m) \
+	port@##n { \
+		reg = <##n>; \
+		label = SWITCH_PORT_LABEL(s) ; \
+		phy-handle = <&phy##n>; \
+		phy-mode = #m ; \
+	};
+#endif
+
+/ {
+	compatible = "d-link,dgs-1210-52", "realtek,rtl8393-soc";
+	model = "D-Link DGS-1210-52";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio1: rtl8231-gpio {
+		compatible = "realtek,rtl8231-gpio";
+		#gpio-cells = <2>;
+		indirect-access-bus-id = <0>;
+		gpio-controller;
+	};
+
+	gpio-restart {
+		compatible = "gpio-restart";
+		gpios = <&gpio1 34 GPIO_ACTIVE_LOW>;
+		open-source;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 33 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+#ifdef DGS1210_52_TEST_SFP
+	/*
+	 *
+	 * GPIO when SFP is connected:
+	 *
+	 * rtl8231: base 451
+	 * gpio459 : LAN49
+	 * gpio454 : LAN50
+	 * gpio475 : LAN51
+	 * gpio464 : LAN52
+	 *
+	 * sda-gpios, scl-gpios, los-gpio and other settings are just guesses based on dsg-1210-16
+	 * from https://github.com/openwrt/openwrt/commit/b05cc25704f554d73b8b6772e844c3afddc4821c
+	 */
+
+	/* Lan 49 */
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp0: sfp-p49 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		/* tx-disable-gpio handled by RTL8214FC based on media setting */
+	};
+
+	/* Lan 50 */
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp-p50 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		/* tx-disable-gpio handled by RTL8214FC based on media setting */
+	};
+
+	/* Lan 51 */
+	i2c2: i2c-gpio-2 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 23 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp2: sfp-p51 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		los-gpio = <&gpio1 25 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 24 GPIO_ACTIVE_LOW>;
+		// tx-disable-gpio handled by RTL8214FC based on media setting
+	};
+
+	/* Lan 52 */
+	i2c3: i2c-gpio-3 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 11 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 12 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp3: sfp-p52 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		los-gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 13 GPIO_ACTIVE_LOW>;
+		/* tx-disable-gpio handled by RTL8214FC based on media setting */
+	};
+#endif
+};
+
+&spi0 {
+	status = "okay";
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x00000000 0x80000>;
+				read-only;
+			};
+			partition@80000 {
+				label = "u-boot-env";
+				reg = <0x00080000 0x40000>;
+			};
+			partition@c0000 {
+				label = "board-name";
+				reg = <0x000c0000 0x40000>;
+			};
+			partition@280000 {
+				label = "firmware";
+				compatible = "denx,uimage";
+				reg = <0x00100000 0xd80000>;
+			};
+			partition@be80000 {
+				label = "kernel2";
+				reg = <0x00e80000 0x180000>;
+			};
+			partition@1000000 {
+				label = "sysinfo";
+				reg = <0x01000000 0x40000>;
+			};
+			partition@1040000 {
+				label = "rootfs2";
+				reg = <0x01040000 0xc00000>;
+			};
+			partition@1c40000 {
+				label = "jffs2";
+				reg = <0x01c40000 0x3c0000>;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* External phy RTL8218B #1 */
+		EXTERNAL_PHY(0)
+		EXTERNAL_PHY(1)
+		EXTERNAL_PHY(2)
+		EXTERNAL_PHY(3)
+		EXTERNAL_PHY(4)
+		EXTERNAL_PHY(5)
+		EXTERNAL_PHY(6)
+		EXTERNAL_PHY(7)
+
+		/* External phy RTL8218B #2 */
+		EXTERNAL_PHY(8)
+		EXTERNAL_PHY(9)
+		EXTERNAL_PHY(10)
+		EXTERNAL_PHY(11)
+		EXTERNAL_PHY(12)
+		EXTERNAL_PHY(13)
+		EXTERNAL_PHY(14)
+		EXTERNAL_PHY(15)
+
+		/* External phy RTL8218B #3 */
+		EXTERNAL_PHY(16)
+		EXTERNAL_PHY(17)
+		EXTERNAL_PHY(18)
+		EXTERNAL_PHY(19)
+		EXTERNAL_PHY(20)
+		EXTERNAL_PHY(21)
+		EXTERNAL_PHY(22)
+		EXTERNAL_PHY(23)
+
+		/* External phy RTL8218B #4 */
+		EXTERNAL_PHY(24)
+		EXTERNAL_PHY(25)
+		EXTERNAL_PHY(26)
+		EXTERNAL_PHY(27)
+		EXTERNAL_PHY(28)
+		EXTERNAL_PHY(29)
+		EXTERNAL_PHY(30)
+		EXTERNAL_PHY(31)
+
+		/* External phy RTL8218B #5 */
+		EXTERNAL_PHY(32)
+		EXTERNAL_PHY(33)
+		EXTERNAL_PHY(34)
+		EXTERNAL_PHY(35)
+		EXTERNAL_PHY(36)
+		EXTERNAL_PHY(37)
+		EXTERNAL_PHY(38)
+		EXTERNAL_PHY(39)
+
+		/* External phy RTL8218B #6 */
+		EXTERNAL_PHY(40)
+		EXTERNAL_PHY(41)
+		EXTERNAL_PHY(42)
+		EXTERNAL_PHY(43)
+		EXTERNAL_PHY(44)
+		EXTERNAL_PHY(45)
+		EXTERNAL_PHY(46)
+		EXTERNAL_PHY(47)
+
+#ifdef DGS1210_52_TEST_SFP
+		/* External phy RTL8214FC? or
+		  2xRTL8393 SERDES + 2xRealtek RTL8218B (external)? */
+		COMBO_SFP_PHY(48, 0)
+		COMBO_SFP_PHY(49, 1)
+		COMBO_SFP_PHY(50, 2)
+		COMBO_SFP_PHY(51, 3)
+#endif
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, qsgmii)
+		SWITCH_PORT(9, 10, qsgmii)
+		SWITCH_PORT(10, 11, qsgmii)
+		SWITCH_PORT(11, 12, qsgmii)
+		SWITCH_PORT(12, 13, qsgmii)
+		SWITCH_PORT(13, 14, qsgmii)
+		SWITCH_PORT(14, 15, qsgmii)
+		SWITCH_PORT(15, 16, qsgmii)
+
+		SWITCH_PORT(16, 17, qsgmii)
+		SWITCH_PORT(17, 18, qsgmii)
+		SWITCH_PORT(18, 19, qsgmii)
+		SWITCH_PORT(19, 20, qsgmii)
+		SWITCH_PORT(20, 21, qsgmii)
+		SWITCH_PORT(21, 22, qsgmii)
+		SWITCH_PORT(22, 23, qsgmii)
+		SWITCH_PORT(23, 24, qsgmii)
+
+		SWITCH_PORT(24, 25, qsgmii)
+		SWITCH_PORT(25, 26, qsgmii)
+		SWITCH_PORT(26, 27, qsgmii)
+		SWITCH_PORT(27, 28, qsgmii)
+		SWITCH_PORT(28, 29, qsgmii)
+		SWITCH_PORT(29, 30, qsgmii)
+		SWITCH_PORT(30, 31, qsgmii)
+		SWITCH_PORT(31, 32, qsgmii)
+
+		SWITCH_PORT(32, 33, qsgmii)
+		SWITCH_PORT(33, 34, qsgmii)
+		SWITCH_PORT(34, 35, qsgmii)
+		SWITCH_PORT(35, 36, qsgmii)
+		SWITCH_PORT(36, 37, qsgmii)
+		SWITCH_PORT(37, 38, qsgmii)
+		SWITCH_PORT(38, 39, qsgmii)
+		SWITCH_PORT(39, 40, qsgmii)
+
+		SWITCH_PORT(40, 41, qsgmii)
+		SWITCH_PORT(41, 42, qsgmii)
+		SWITCH_PORT(42, 43, qsgmii)
+		SWITCH_PORT(43, 44, qsgmii)
+		SWITCH_PORT(44, 45, qsgmii)
+		SWITCH_PORT(45, 46, qsgmii)
+		SWITCH_PORT(46, 47, qsgmii)
+		SWITCH_PORT(47, 48, qsgmii)
+
+#ifdef DGS1210_52_TEST_SFP
+		COMBO_PORT(48, 49, qsgmii)
+		COMBO_PORT(49, 50, qsgmii)
+		COMBO_PORT(50, 51, qsgmii)
+		COMBO_PORT(51, 52, qsgmii)
+#endif
+		/* CPU-Port */
+		port@52 {
+			ethernet = <&ethernet0>;
+			reg = <52>;
+			phy-mode = "qsgmii";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/Makefile
+++ b/target/linux/realtek/image/Makefile
@@ -52,6 +52,21 @@ define Device/Default
 	check-size | append-metadata
 endef
 
+define Device/d-link_dgs-1210
+  IMAGE_SIZE := 13824k
+  DEVICE_VENDOR := D-Link
+  DLINK_KERNEL_PART_SIZE := 1572864
+  KERNEL := kernel-bin | append-dtb | gzip | uImage gzip | dlink-cameo
+  CAMEO_KERNEL_PART := 2
+  CAMEO_ROOTFS_PART := 3
+  CAMEO_CUSTOMER_SIGNATURE := 2
+  CAMEO_BOARD_VERSION := 32
+  IMAGES += factory_image1.bin
+  IMAGE/factory_image1.bin := append-kernel | pad-to 64k | \
+	append-rootfs | pad-rootfs | pad-to 16 | check-size | \
+	dlink-version | dlink-headers
+endef
+
 # "NGE" refers to the uImage magic
 define Device/netgear_nge
   KERNEL := kernel-bin | append-dtb | lzma | uImage lzma

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -11,24 +11,9 @@ define Device/allnet_all-sg8208m
 endef
 TARGET_DEVICES += allnet_all-sg8208m
 
-define Device/d-link_dgs-1210
-  SOC := rtl8382
-  IMAGE_SIZE := 13824k
-  DEVICE_VENDOR := D-Link
-  DLINK_KERNEL_PART_SIZE := 1572864
-  KERNEL := kernel-bin | append-dtb | gzip | uImage gzip | dlink-cameo
-  CAMEO_KERNEL_PART := 2
-  CAMEO_ROOTFS_PART := 3
-  CAMEO_CUSTOMER_SIGNATURE := 2
-  CAMEO_BOARD_VERSION := 32
-  IMAGES += factory_image1.bin
-  IMAGE/factory_image1.bin := append-kernel | pad-to 64k | \
-	append-rootfs | pad-rootfs | pad-to 16 | check-size | \
-	dlink-version | dlink-headers
-endef
-
 define Device/d-link_dgs-1210-10p
   $(Device/d-link_dgs-1210)
+  SOC := rtl8382
   DEVICE_MODEL := DGS-1210-10P
   DEVICE_PACKAGES += lua-rs232
 endef
@@ -36,18 +21,21 @@ TARGET_DEVICES += d-link_dgs-1210-10p
 
 define Device/d-link_dgs-1210-16
   $(Device/d-link_dgs-1210)
+  SOC := rtl8382
   DEVICE_MODEL := DGS-1210-16
 endef
 TARGET_DEVICES += d-link_dgs-1210-16
 
 define Device/d-link_dgs-1210-20
   $(Device/d-link_dgs-1210)
+  SOC := rtl8382
   DEVICE_MODEL := DGS-1210-20
 endef
 TARGET_DEVICES += d-link_dgs-1210-20
 
 define Device/d-link_dgs-1210-28
   $(Device/d-link_dgs-1210)
+  SOC := rtl8382
   DEVICE_MODEL := DGS-1210-28
 endef
 TARGET_DEVICES += d-link_dgs-1210-28

--- a/target/linux/realtek/image/rtl839x.mk
+++ b/target/linux/realtek/image/rtl839x.mk
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
+define Device/d-link_dgs-1210-52
+  $(Device/d-link_dgs-1210)
+  SOC := rtl8393
+  DEVICE_MODEL := DGS-1210-52
+  DEVICE_PACKAGES += uboot-envtools
+endef
+TARGET_DEVICES += d-link_dgs-1210-52
+
 define Device/zyxel_gs1900-48
   SOC := rtl8393
   IMAGE_SIZE := 13952k


### PR DESCRIPTION
Hardware specification
----------------------

* RTL8393M SoC, 1 MIPS 34Kc core @ 700MHz
* 128MB DRAM
* 32MB NOR Flash
* 48 x 10/100/1000BASE-T ports
  - 6 x External PHY with 8 ports (RTL8218D)
* 4 x Gigabit RJ45/SFP Combo ports
- External PHY with 4 SFP ports (RTL8214FC) (accoding to u-boot)
* Power LED
* Reset button on front panel
* UART (115200 8N1) via unpopulated standard 0.1" pin header marked J14

The reset-gpio is not required but it does reset the switch.

The 4 combo ports were not stable and were commented out. The RTL8214FC
is what the u-boot reported. However, the Linux kernel reported 49 and
50 as "External RTL8393 SERDES" and 51 and 52 as "RTL8218B (external)".
Those ports only work if u-boot initialize it (for example, loading
initramfs image using one of those ports).

The firmware recovery using U-Boot is broken for all DGS-1210 tested
devices as pressing RESET does not trigger it (only if pressed from a
running stock image)

UART pinout
-----------

[o]ooo|J14
 | ||`------ GND
 | |`------- RX
 | `-------- TX
 `---------- Vcc (3V3)

Installation using OEM upgrade
------------------------------

1. Make sure you are running OEM firmware in image2 slot (logged as admin):
   - > config firmware image_id 2 boot_up
   - > reboot
2. Install squashfs-factory_image1.bin to image1 using (logged as admin):
   - > download firmware_fromTFTP <tftpserver> factory_image1.bin
   - > config firmware image_id 1 boot_up
   - > reboot

Installation using serial interface
-----------------------------------

1. Press Escape key during `Hit Esc key to stop autoboot` prompt
2. Press CTRL+C keys to get into real U-Boot prompt
3. Init network with `rtk network on` command
4. Load image with `tftpboot 0x8f000000 openwrt-realtek-rtl838x-d-link_dgs-1210-52-initramfs-kernel.bin` command
5. Boot the image with `bootm` command

Once booted the initramfs, install the squashfs-sysupgrade.bin as a
normal OpenWrt system.

Dual-boot with stock firmware using writable u-boot-env
-------------------------------------------------------

From stock to OpenWrt / boot image 1 (CLI as admin):
   - > config firmware image_id 1 boot_up
   - > reboot

From OpenWrt to stock / boot image 2: (shell as root)
   - # fw_setenv bootcmd 'run addargs ; bootm 0xb4e80000'
   - # fw_setenv image '/dev/mtdblock7'
   - # reboot

Debrick using serial interface
------------------------------

1. Press Escape key during `Hit Esc key to stop autoboot` prompt
2. In a Windows PC, run 'D-Link Network Assistant v2.0.2.4'. It should
   detect the switch
3. Flash the firmware.

Back to stock firmware using dual-boot
--------------------------------------

If you have serial interface, you can change u-boot env vars
interrupting the boot process. If not but you are running OpenWrt, you
can dual-boot (as mentioned eariler) and skip to step 4:

1. Press Escape key during `Hit Esc key to stop autoboot` prompt
2. Press CTRL+C keys to get into real U-Boot prompt
3. Boot the image 2:
   - set image /dev/mtdblock7; run addargs; bootm 0xb4e80000
4. Once booted, log as admin and change the boot image to 2
   - > config firmware image_id 2 boot_up
   - > reboot
5. After the boot, flash image1 with the vendor image

Back to stock firmware using DNA
--------------------------------

1. From an OpenWrt:
   - # fw_setenv bootstop on
   - # reboot
2. In a Windows PC, run 'D-Link Network Assistant v2.0.2.4'. It should
   detect the switch
3. Flash the firmware.

It has been developed and tested on device with F3 revision.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
