### PR TITLE
xdp-tools: import patches fixing cross platform compiling

### DIFF
--- a/package/network/utils/xdp-tools/patches/100-util-use-pid_t-to-avoid-64bit-datatype-fixing-cross.patch
+++ b/package/network/utils/xdp-tools/patches/100-util-use-pid_t-to-avoid-64bit-datatype-fixing-cross.patch
@@ -1,0 +1,35 @@
+From 32614090bbd77ced96ba71e355b936f8edee4b1d Mon Sep 17 00:00:00 2001
+From: Nick Hainke <vincent@systemli.org>
+Date: Sat, 9 Jul 2022 07:08:40 +0200
+Subject: [PATCH 1/2] util: use pid_t to avoid 64bit datatype fixing cross
+ platform
+
+The pid_t is a data type representing a process ID. In GNUC C this is an
+int. This commit replaces the long unsigned because it avoids using a
+64bit data type improving cross platorm usage.
+
+Signed-off-by: Nick Hainke <vincent@systemli.org>
+---
+ lib/util/util.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/lib/util/util.c
++++ b/lib/util/util.c
+@@ -793,7 +793,7 @@ int prog_lock_get(const char *progname)
+ 	if (prog_lock_fd < 0) {
+ 		err = -errno;
+ 		if (err == -EEXIST) {
+-			unsigned long pid = 0;
++			pid_t pid = 0;
+ 			char buf[100];
+ 			ssize_t len;
+ 			int fd;
+@@ -818,7 +818,7 @@ int prog_lock_get(const char *progname)
+ 					strerror(-err));
+ 				return err;
+ 			}
+-			pr_warn("Unable to get program lock: Already held by pid %lu\n",
++			pr_warn("Unable to get program lock: Already held by pid %d\n",
+ 				pid);
+ 		} else {
+ 			pr_warn("Unable to get program lock: %s\n", strerror(-err));

--- a/package/network/utils/xdp-tools/patches/101-treewide-replace-lu-for-64bit-with-PRId64-macro.patch
+++ b/package/network/utils/xdp-tools/patches/101-treewide-replace-lu-for-64bit-with-PRId64-macro.patch
@@ -1,0 +1,54 @@
+From 342392dc1ae4b9c67bab463e044673e4066f667e Mon Sep 17 00:00:00 2001
+From: Nick Hainke <vincent@systemli.org>
+Date: Sat, 9 Jul 2022 07:14:24 +0200
+Subject: [PATCH 2/2] treewide: replace %lu for 64bit with PRId64 macro fixing
+ cross platform
+
+PRId64 is a macro helping to handle cross platform prints of 64bit
+datatypes. This commit replaces the %lu for 64bit data types.
+
+Signed-off-by: Nick Hainke <vincent@systemli.org>
+---
+ lib/util/stats.c   | 3 ++-
+ xdp-dump/xdpdump.c | 4 ++--
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+--- a/lib/util/stats.c
++++ b/lib/util/stats.c
+@@ -6,6 +6,7 @@
+ #include <errno.h>
+ #include <getopt.h>
+ 
++#include <inttypes.h>
+ #include <locale.h>
+ #include <unistd.h>
+ #include <time.h>
+@@ -107,7 +108,7 @@ int stats_print(struct stats_record *sta
+ 			return 0;
+ 
+ 		if (first) {
+-			printf("Period of %fs ending at %lu.%06lu\n", period,
++			printf("Period of %fs ending at %" PRId64 ".%06lu\n", period,
+ 			       t.tv_sec, t.tv_nsec / 1000);
+ 			first = false;
+ 		}
+--- a/xdp-dump/xdpdump.c
++++ b/xdp-dump/xdpdump.c
+@@ -644,7 +644,7 @@ static bool capture_on_legacy_interface(
+ 			char hline[SNPRINTH_MIN_BUFFER_SIZE];
+ 
+ 			if (cfg->hex_dump) {
+-				printf("%lu.%06lu: packet size %u bytes, "
++				printf( PRId64 ".%06" PRId64 ": packet size %u bytes, "
+ 				       "captured %u bytes on if_name \"%s\"\n",
+ 				       h.ts.tv_sec, h.ts.tv_usec,
+ 				       h.len, h.caplen, cfg->iface.ifname);
+@@ -655,7 +655,7 @@ static bool capture_on_legacy_interface(
+ 					printf("  %s\n", hline);
+ 				}
+ 			} else {
+-				printf("%lu.%06lu: packet size %u bytes on "
++				printf( PRId64 ".%06" PRId64 ": packet size %u bytes on "
+ 				       "if_name \"%s\"\n",
+ 				       h.ts.tv_sec, h.ts.tv_usec,
+ 				       h.len, cfg->iface.ifname);


### PR DESCRIPTION
xdp-tools has issues with 64bit data types. The patches are fixing those
issues.
