### PR TITLE
ramips: get MAC from the encrypted partition (WG4хх223) - fix issue #10062

### DIFF
--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -79,6 +79,37 @@ mtd_get_mac_ascii() {
 	[ -n "$mac_dirty" ] && macaddr_canonicalize "$mac_dirty"
 }
 
+mtd_get_mac_encrypted_arcadyan() {
+	local iv="00000000000000000000000000000000"
+	local key="2A4B303D7644395C3B2B7053553C5200"
+	local mac_dirty
+	local mtdname="$1"
+	local part
+	local size
+
+	part=$(find_mtd_part "$mtdname")
+	if [ -z "$part" ]; then
+		echo "mtd_get_mac_encrypted_arcadyan: partition $mtdname not found!" >&2
+		return
+	fi
+
+	# Config decryption and getting mac. Trying uencrypt and openssl utils.
+	size=$((0x$(dd if=$part skip=9 bs=1 count=4 2>/dev/null | hexdump -v -e '1/4 "%08x"')))
+	if [[ -f  "/usr/bin/uencrypt" ]]; then
+		mac_dirty=$(dd if=$part bs=1 count=$size skip=$((0x100)) 2>/dev/null | \
+			uencrypt -d -n -k $key -i $iv | grep mac | cut -c 5-)
+	elif [[ -f  "/usr/bin/openssl" ]]; then
+		mac_dirty=$(dd if=$part bs=1 count=$size skip=$((0x100)) 2>/dev/null | \
+			openssl aes-128-cbc -d -nopad -K $key -iv $iv | grep mac | cut -c 5-)
+	else
+		echo "mtd_get_mac_encrypted_arcadyan: Neither uencrypt nor openssl was found!" >&2
+		return
+	fi
+
+	# "canonicalize" mac
+	[ -n "$mac_dirty" ] && macaddr_canonicalize "$mac_dirty"
+}
+
 mtd_get_mac_text() {
 	local mtdname=$1
 	local offset=$(($2))

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -282,7 +282,7 @@ define Device/beeline_smartbox-flash
   IMAGE/factory.trx := append-kernel | append-ubi | check-size
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   DEVICE_PACKAGES := kmod-usb3 kmod-mt7615e kmod-mt7615-firmware \
-	uboot-envtools
+	uboot-envtools uencrypt
 endef
 TARGET_DEVICES += beeline_smartbox-flash
 
@@ -1251,7 +1251,7 @@ define Device/mts_wg430223
   IMAGES += factory.trx
   IMAGE/factory.trx := append-kernel | append-ubi | check-size
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware uboot-envtools uencrypt
 endef
 TARGET_DEVICES += mts_wg430223
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -131,11 +131,10 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii u-boot-env et1macaddr)
 		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
-	beeline,smartbox-flash|\
-	mts,wg430223)
-		lan_mac=$(mtd_get_mac_ascii u-boot-env eth2macaddr)
-		wan_mac=$(mtd_get_mac_ascii u-boot-env eth3macaddr)
-		label_mac=$lan_mac
+	beeline,smartbox-flash)
+		wan_mac=$(mtd_get_mac_encrypted_arcadyan "board_data")
+		label_mac=$(macaddr_add "$wan_mac" 3)
+		lan_mac=$label_mac
 		;;
 	buffalo,wsr-1166dhp)
 		local index="$(find_mtd_index "board_data")"
@@ -197,6 +196,11 @@ ramips_setup_macs()
 		label_mac=$(cat "/sys/firmware/mikrotik/hard_config/mac_base")
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add $label_mac 1)
+		;;
+	mts,wg430223)
+		wan_mac=$(mtd_get_mac_encrypted_arcadyan "board_data")
+		label_mac=$wan_mac
+		lan_mac=$(macaddr_add "$wan_mac" 2)
 		;;
 	netgear,wax202)
 		lan_mac=$(mtd_get_mac_ascii Config mac)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -10,12 +10,13 @@ PHYNBR=${DEVPATH##*/phy}
 board=$(board_name)
 
 case "$board" in
-	beeline,smartbox-flash|\
-	mts,wg430223)
-		hw_mac_addr_ra0="$(mtd_get_mac_ascii u-boot-env ra0macaddr)"
-		hw_mac_addr_rax0="$(mtd_get_mac_ascii u-boot-env rax0macaddr)"
-		[ "$PHYNBR" = "0" ] && echo -n $hw_mac_addr_ra0 > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && echo -n $hw_mac_addr_rax0 > /sys${DEVPATH}/macaddress
+	beeline,smartbox-flash)
+		hw_mac_addr=$(macaddr_add $(mtd_get_mac_encrypted_arcadyan "board_data") 1)
+		[ "$PHYNBR" = "0" ] && echo -n "$hw_mac_addr" > /sys${DEVPATH}/macaddress
+		hw_mac_addr=$(macaddr_setbit   $hw_mac_addr 26)
+		hw_mac_addr=$(macaddr_unsetbit $hw_mac_addr 27)
+		hw_mac_addr=$(macaddr_unsetbit $hw_mac_addr 28)
+		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $hw_mac_addr > /sys${DEVPATH}/macaddress
 		;;
 	cudy,x6)
 		hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"
@@ -80,6 +81,14 @@ case "$board" in
 		hw_mac_addr=$(mtd_get_mac_ascii Config mac)
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 3 > /sys${DEVPATH}/macaddress
+		;;
+	mts,wg430223)
+		hw_mac_addr=$(macaddr_add $(mtd_get_mac_encrypted_arcadyan "board_data") 1)
+		[ "$PHYNBR" = "0" ] && echo -n "$hw_mac_addr" > /sys${DEVPATH}/macaddress
+		hw_mac_addr=$(macaddr_unsetbit $hw_mac_addr 26)
+		hw_mac_addr=$(macaddr_setbit   $hw_mac_addr 27)
+		hw_mac_addr=$(macaddr_unsetbit $hw_mac_addr 28)
+		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $hw_mac_addr > /sys${DEVPATH}/macaddress
 		;;
 	oraybox,x3a)
 		if [ "$PHYNBR" = "1" ]; then


### PR DESCRIPTION
~~**This depends on** https://github.com/openwrt/openwrt/pull/10222~~ (merged)

This commit adds decryption of the Arcadyan WG4xx223 configuration
partition (board_data) and get MAC address from it. After this change
the hack with saving MAC addressees to u-boot-env before installation
of OpenWrt is no longer necessary.

Affected routers
----------------
- Beeline Smartbox Flash (Arcadyan WG443223)
- MTS WG430223 (Arcadyan WG430223)

Related issue
-------------
Arcadyan WG4хх223 routers: getting MACs from the encrypted partitions)
Link:
https://github.com/openwrt/openwrt/issues/10062

Related PR
----------
uencrypt: add package to decrypt WG4хх223 config
Link:
https://github.com/openwrt/openwrt/pull/10222

