### PR TITLE
[21.02] uclibc++: fix compilation with long file paths

### DIFF
--- a/package/libs/uclibc++/patches/006-buildsys-shorten-abi-deb-file-names.patch
+++ b/package/libs/uclibc++/patches/006-buildsys-shorten-abi-deb-file-names.patch
@@ -1,0 +1,86 @@
+From 6687fc9276fa52defaf8592f2001c19b826aec93 Mon Sep 17 00:00:00 2001
+From: Bernhard Reutner-Fischer <rep.dot.nop@gmail.com>
+Date: Thu, 4 Jun 2020 10:21:43 +0200
+Subject: buildsys: shorten abi dep-file names
+
+certain crypto-layers encode required information in the
+filename hence crippling NAME_MAX from 255 down to about 143
+ascii chars.
+
+Since the dependency files of libgcc_eh and libsupc encode the full
+path to the corresponding libraries, the names of the dep files can
+get quite large. Shorten them by some (arbitrary, short) hash.
+
+Signed-off-by: Bernhard Reutner-Fischer <rep.dot.nop@gmail.com>
+---
+ Rules.mak                     | 2 ++
+ src/abi/libgcc_eh/Makefile.in | 4 ++--
+ src/abi/libsupc/Makefile.in   | 4 ++--
+ 3 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/Rules.mak b/Rules.mak
+index 1b5ed30..9162c64 100644
+--- a/Rules.mak
++++ b/Rules.mak
+@@ -50,6 +50,7 @@ RM      = rm -f
+ TAR     = tar
+ SED     = sed
+ AWK     = awk
++MD5SUM  = md5sum
+ 
+ ARFLAGS:= cr
+ 
+@@ -249,6 +250,7 @@ endif
+ 
+ list-archive-members = $(if $(1),$(shell $(AR) t $(1)))
+ variablify = $(strip $(subst /,_,$(subst :,_,$(subst ;,_,$(subst |,_,$(subst >,_,$(subst <,_,$(1))))))))
++print-hash = $(strip $(if $(1),$(shell printf "%s" "$(1)" | $(MD5SUM) | $(SED) 's/[^0-9a-zA-Z]//g')))
+ 
+ GEN_LIBS:= -lc
+ ifneq ($(LIBGCC_DIR),$(UCLIBCXX_RUNTIME_LIBDIR))
+diff --git a/src/abi/libgcc_eh/Makefile.in b/src/abi/libgcc_eh/Makefile.in
+index 46b0017..1553b34 100644
+--- a/src/abi/libgcc_eh/Makefile.in
++++ b/src/abi/libgcc_eh/Makefile.in
+@@ -4,7 +4,7 @@ OBJS = $(call list-archive-members,$(LIBGCC_EH))
+ libgcc_eh-$(IMPORT_LIBGCC_EH) := $(OBJS)
+ 
+ LIBGCC_EH_VAR := $(call variablify,$(LIBGCC_EH))
+-LIBGCC_EH_DEP := $(LIBGCC_EH_OUT).$(LIBGCC_EH_VAR).dep
++LIBGCC_EH_DEP := $(LIBGCC_EH_OUT).$(call print-hash,$(LIBGCC_EH_VAR)).dep
+ 
+ ifeq ($(filter $(noconfig_targets),$(MAKECMDGOALS)),)
+ -include $(LIBGCC_EH_DEP)
+@@ -17,7 +17,7 @@ endif
+ $(LIBGCC_EH_DEP): $(LIBGCC_EH)
+ 	$(Q)$(RM) $(LIBGCC_EH_OUT).*dep $(LIBGCC_EH_OUT)*.o
+ 	$(Q)$(if $(LIBGCC_EH),(cd $(LIBGCC_EH_OUT) && $(AR) x $(LIBGCC_EH)))
+-	$(Q)echo "libgcc_eh-y := \$$(addprefix \$$(LIBGCC_EH_OUT),$(libgcc_eh-y))" > $@
++	$(Q)printf "# %s\n\n%s\n" "$(LIBGCC_EH)" "libgcc_eh-y := \$$(addprefix \$$(LIBGCC_EH_OUT),$(libgcc_eh-y))" > $@
+ 
+ CLEAN_src/abi/libgcc_eh: ;
+ DISTCLEAN_src/abi/libgcc_eh:
+diff --git a/src/abi/libsupc/Makefile.in b/src/abi/libsupc/Makefile.in
+index 89e0e8a..9c00df0 100644
+--- a/src/abi/libsupc/Makefile.in
++++ b/src/abi/libsupc/Makefile.in
+@@ -5,7 +5,7 @@ OBJS-OMIT = $(filter new_op%.o del_op%.o pure.o new_handler.o eh_alloc.o eh_glob
+ libsupc-$(IMPORT_LIBSUP) := $(filter-out $(OBJS-OMIT),$(OBJS))
+ 
+ LIBSUP_VAR := $(call variablify,$(LIBSUP))
+-LIBSUP_DEP :=$(LIBSUPC_OUT).$(LIBSUP_VAR).dep
++LIBSUP_DEP := $(LIBSUPC_OUT).$(call print-hash,$(LIBSUP_VAR)).dep
+ 
+ ifeq ($(filter $(noconfig_targets),$(MAKECMDGOALS)),)
+ -include $(LIBSUP_DEP)
+@@ -17,7 +17,7 @@ endif
+ $(LIBSUP_DEP): $(LIBSUP) $(LIBSUPC_OUT)Makefile.in
+ 	$(Q)$(RM) $(LIBSUPC_OUT).*dep $(LIBSUPC_OUT)*.o
+ 	$(Q)$(if $(LIBSUP),(cd $(LIBSUPC_OUT) && $(AR) x $(LIBSUP) && $(RM) $(OBJS-OMIT)))
+-	$(Q)echo "libsupc-y := \$$(addprefix \$$(LIBSUPC_OUT),$(libsupc-y))" > $@
++	$(Q)printf "# %s\n\n%s\n" "$(LIBSUP)" "libsupc-y := \$$(addprefix \$$(LIBSUPC_OUT),$(libsupc-y))" > $@
+ 
+ CLEAN_src/abi/libsupc: ;
+ DISTCLEAN_src/abi/libsupc:
+-- 
+cgit v1.2.3


### PR DESCRIPTION
Currently, uClic++ 0.2.5 fails to compile when using a long filepath.

For example, if the openwrt directory is in the path: `/tmp/this_directory_name_is_very_long/more_long_paths/.../openwrt`, then uclibc++ will cause a very obtuse error.

Although the uclibc++ makefiles do print a "File name too long" error, it's not the final error that's printed, so it's a bit confusing:

> ```
> /bin/sh: 1: cannot create src/abi/libsupc/<SNIP>_libsupc++.a.dep: File name too long
> <SNIP: some other makefile output here>
> array_type_info.o: No such file or directory
> ```

Although **OpenWRT 22.03 and current master branch have removed uClib++** (see https://github.com/openwrt/openwrt/commit/6b2ed6101e4c97691ba3aa94f25895be536b3870), I thought I'd make a PR for OpenWRT 21.02, since I encountered it and there seems to be quite a few other people experiencing the same issue.

Other people experiencing this issue:
  - https://forum.openwrt.org/t/buid-package-uclibc-failed-by-using-openwrt-sdk/64377
  - https://lists.openwrt.org/pipermail/openwrt-devel/2021-May/035321.html
  - https://github.com/trojan-gfw/trojan/issues/588
  - https://github.com/openwrt/packages/issues/7901#issuecomment-529181915
  - Closes https://github.com/openwrt/openwrt/issues/7878

It especially happens when using the SDK, (or when using an encrypted fs) since the pre-packaged SDKs have very long filenames.

This patch is already in [upstream][1], but has not yet been released.

[1]: https://git.busybox.net/uClibc++/commit/?id=6687fc9276fa52defaf8592f2001c19b826aec93

I haven't yet added `Reported-by:` tag to my commit description, but I believe it should be the user `wt` from https://github.com/openwrt/openwrt/issues/7878. It looks like they were the one to report it uClibc++ upstream too.
