### PR TITLE
base-files: no pause if failsafe wait time is 0

### DIFF
--- a/package/base-files/files/lib/preinit/30_failsafe_wait
+++ b/package/base-files/files/lib/preinit/30_failsafe_wait
@@ -87,6 +87,7 @@ fs_wait_for_key () {
 
 failsafe_wait() {
 	FAILSAFE=
+	[ "$fs_failsafe_wait_timeout" -eq 0 ] && return
 	[ "$pi_preinit_no_failsafe" = "y" ] && {
 		fs_wait_for_key "" "" $fs_failsafe_wait_timeout
 		return


### PR DESCRIPTION
If `CONFIG_TARGET_PREINIT_TIMEOUT` is set to 0 neither failsafe nor
debug level should be asked, instead both should be skipped directly.

However even with a value of 0 the script still causes a pause of two
seconds by calling the `fs_wait_for_key` function. To avoid that, skip
the call entirely if timeout equals 0. While this doesn't seem much, for
automated tests this sums up.

Before:

[    2.211722] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    2.226905] init: - preinit -
[    4.101444] mount_root: overlay filesystem in /dev/loop0 has not been formatted yet
[    4.325641] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)

After:

[    2.104445] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    2.116366] init: - preinit -
[    2.732007] mount_root: overlay filesystem in /dev/loop0 has not been formatted yet
[    2.961084] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)

Signed-off-by: Paul Spooren <mail@aparcar.org>