### PR TITLE
target: drop urngd from default packages

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -24,8 +24,7 @@ DEFAULT_PACKAGES:=\
 	opkg \
 	uci \
 	uclient-fetch \
-	urandom-seed \
-	urngd
+	urandom-seed
 
 ifneq ($(CONFIG_SELINUX),)
 DEFAULT_PACKAGES+=busybox-selinux procd-selinux


### PR DESCRIPTION
The package is superseeded by other tools like seedrnd, drop it.

Signed-off-by: Paul Spooren <mail@aparcar.org>