### PR TITLE
sdk: prevent recompiling SDK host binaries

### DIFF
--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -24,7 +24,6 @@ BUNDLER_PATH := $(subst $(space),:,$(filter-out $(TOPDIR)/%,$(subst :,$(space),$
 BUNDLER_COMMAND := PATH=$(BUNDLER_PATH) $(XARGS) $(SCRIPT_DIR)/bundle-libraries.sh $(SDK_BUILD_DIR)/$(STAGING_SUBDIR_HOST)
 
 EXCLUDE_DIRS:= \
-	*/stamp \
 	*/stampfiles \
 	*/man \
 	*/info \
@@ -102,6 +101,10 @@ $(BIN_DIR)/$(SDK_NAME).tar.xz: clean
 
 	# Copy usbip sources, this is required for the usbip userspace packages to be buildable by the SDK.
 	$(TAR) -cf - -C $(TOPDIR) $(KDIR_BASE)/tools/usb/usbip/ | \
+		$(TAR) -xf - -C $(SDK_BUILD_DIR)
+
+	# Copy install stamps, so packages which provide host part, won't be rebuilt again and link to host libc instead of a bundled one.
+	$(TAR) -cf - -C $(TOPDIR) staging_dir/hostpkg/stamp/ | \
 		$(TAR) -xf - -C $(SDK_BUILD_DIR)
 
 	(cd $(SDK_BUILD_DIR); find $(STAGING_SUBDIR_HOST)/bin $(STAGING_SUBDIR_HOST)/usr/bin \


### PR DESCRIPTION
Currently, when building packages with the OpenWRT SDK, the pre-packaged binaries in `./staging_dir/host/bin` may be overwritten with newly created binaries.

However, if the SDK was built with an older GLIBC version, the new binary will not work with the SDK, as it's built for the host's GLIBC version. This would result in a Segmentation Fault on older OSes. Newer OSes print the better following error:

> ```
> ./staging_dir/host/bin/.ucert.bin:
>      ./staging_dir/host/bin/../lib/libc.so.6:
>      version `GLIBC_2.33' not found
>      (required by ./staging_dir/host/bin/../lib/libblobmsg_json.so)
> ```

To avoid this, this commit adds the `./staging_dir/host/stamp/*` files to the SDK, and modifies `include/host-build.mk` to avoid recompiling and reinstalling host tools if CONFIG_IN_SDK==y and the HOST_STAMP_INSTALLED stamp file already exists.

---

This patch is based on the idea from @jow- in https://github.com/openwrt/openwrt/issues/7299#issuecomment-1040311681, and modified from the patch created by @tmn505 in https://github.com/openwrt/openwrt/issues/7299#issuecomment-1132892546 with their permission (I've added them as a `Co-authored-by: ...` tag in the patch description).

Fixes https://github.com/openwrt/openwrt/issues/7299

Also reported in:
  - https://forum.openwrt.org/t/segfault-in-ucert-docker-debian-signing/30838
  - https://github.com/Andy2244/openwrt-package-builder/issues/3

I've tested this on:
  - `master` branch
  - `openwrt-22.03` branch.
  -  **Not tested for 21.02** (as this patch does not apply cleanly)

#### Testing Process

- First, build the SDK on an older OS. For example, Ubuntu 20.04
- Next, try running the SDK on a newer OS, for example Ubuntu 22.04. `./staging_dir/host/bin/ucert` should work fine.
- Next, try building `base-files` on the SDK on the newer OS. It should rebuild `ucert` (incorrectly) and `./staging_dir/host/bin/ucert` will throw a segmentation fault or `GLIBC_2.33` not found error, as long as the OS is quite a bit newer than the OS the SDK was created in.

These are the bash commands I used for testing on Ubuntu 20.04. I used `podman` for my container, but you should just be able to `alias podman=docker` to get it working with docker.

```bash
# make sure you build the SDK on an old OS (e.g. Ubuntu 20.04)
# enable 'Build the OpenWrt SDK'
make menuconfig
nice -n19 make -j15

# then in new terminal 2 (must be a newer OS than where you built OpenWRT)
# you should be able to replace all podman commands with docker
podman run --rm -it ubuntu:jammy bash

# then in terminal 1
podman ps # find container name
podman cp bin/targets/ath79/generic/openwrt-sdk-ath79-generic_gcc-11.3.0_musl.Linux-x86_64.tar.xz <CONTAINER_NAME>:/home

# then, in container terminal, install SDK dependencies
apt update && apt install xz-utils build-essential gawk gcc-multilib flex git gettext libncurses5-dev libssl-dev python3-distutils zlib1g-dev rsync unzip wget file
cd /home
tar xf openwrt-sdk-ath79-generic_gcc-11.3.0_musl.Linux-x86_64.tar.xz
cd openwrt-sdk-ath79-generic_gcc-11.3.0_musl.Linux-x86_64
./staging_dir/host/bin/ucert # works!
./scripts/feeds update -a
./scripts/feeds install base-files
make defconfig
nice -n19 make --jobs=15 # should fail with GLIBC_2.33 not found
./staging_dir/host/bin/ucert # doesn't work (or works if you use this patch)!
```
