### PR TITLE
uboot-at91: fix build on buildbots

### DIFF
--- a/package/boot/uboot-at91/Makefile
+++ b/package/boot/uboot-at91/Makefile
@@ -175,7 +175,8 @@ define Build/Compile
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
 		CROSS_COMPILE=$(TARGET_CROSS) \
 		KCFLAGS="$(filter-out -fstack-protector \
-		-mfloat-abi=hard, $(TARGET_CFLAGS)) -mfloat-abi=soft"
+		-mfloat-abi=hard, $(TARGET_CFLAGS)) -mfloat-abi=soft" \
+		$(UBOOT_MAKE_FLAGS)
 endef
 
 $(eval $(call BuildPackage/U-Boot))


### PR DESCRIPTION
Buidbots are throwing the following compile error:

In file included from tools/aisimage.c:9:
include/image.h:1133:12: fatal error: openssl/evp.h: No such file or directory
            ^~~~~~~~~~~~~~~
compilation terminated.

Fix it by passing `UBOOT_MAKE_FLAGS` variable to make.
