### PR TITLE
sunxi: add support for Banana Pi M2 Berry

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -301,6 +301,12 @@ define U-Boot/Bananapi_M2_Ultra
   BUILD_DEVICES:=sinovoip_bananapi-m2-ultra
 endef
 
+define U-Boot/bananapi_m2_berry
+  BUILD_SUBTARGET:=cortexa7
+  NAME:=Bananapi M2 Berry
+  BUILD_DEVICES:=sinovoip_bananapi-m2-berry
+endef
+
 UBOOT_TARGETS := \
 	a64-olinuxino \
 	a64-olinuxino-emmc \
@@ -312,6 +318,7 @@ UBOOT_TARGETS := \
 	A20-OLinuXino_MICRO \
 	bananapi_m2_plus_h3 \
 	Bananapi \
+	bananapi_m2_berry \
 	Bananapi_M2_Ultra \
 	Bananapro \
 	Cubieboard \

--- a/target/linux/sunxi/image/cortexa7.mk
+++ b/target/linux/sunxi/image/cortexa7.mk
@@ -77,6 +77,16 @@ define Device/lemaker_bananapi
 endef
 TARGET_DEVICES += lemaker_bananapi
 
+define Device/sinovoip_bananapi-m2-berry
+  DEVICE_VENDOR := Sinovoip
+  DEVICE_MODEL := Banana Pi M2 Berry
+  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi kmod-brcmfmac \
+	brcmfmac-firmware-43430-sdio wpad-basic-wolfssl
+  SUPPORTED_DEVICES:=lemaker,bananapi-m2-berry
+  SOC := sun8i-v40
+endef
+TARGET_DEVICES += sinovoip_bananapi-m2-berry
+
 define Device/sinovoip_bananapi-m2-ultra
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Ultra


### PR DESCRIPTION
CPU: Allwinner V40 quad-core Cortex A7 @ 1.2GHz
Memory: 1GB DDR3
Storage: SDcard, native SATA
Network: 10/100/1000M ethernet, Ampak AP6212 wifi + BT
USB: 4x USB 2.0

Installation:
Use the standard sunxi installation to an SD-card.

While the board is very similar to the M2 Ultra board
(the V40 is the automotive version of the R40), as both
the u-boot and kernel supports them separately, and some
pins are different, let's add a separate device spec.

Signed-off-by: Zoltan HERPAI <wigyori@uid0.hu>