### PR TITLE
rockchip: reliably distribute net interrupts

### DIFF
--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -4,8 +4,15 @@
 
 get_device_irq() {
 	local device="$1"
+	local line
+	local seconds="0"
 
-	local line=$(grep -m 1 "${device}\$" /proc/interrupts)
+	# wait up to 10 seconds for the irq/device to appear
+	while [ "${seconds}" -le 10 ]; do
+		line=$(grep -m 1 "${device}\$" /proc/interrupts) && break
+		seconds="$(( seconds + 2 ))"
+		sleep 2
+	done
 	echo ${line} | sed 's/:.*//'
 }
 


### PR DESCRIPTION
This is a backport of https://github.com/openwrt/openwrt/pull/4456 for `openwrt-22.03`.