### PR TITLE
ipq40xx: RUTX10 wi-fi calibration fix

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -129,6 +129,10 @@ case "$FIRMWARE" in
 		caldata_extract_mmc "0:ART" 0x1000 0x2f20
 		ath10k_patch_mac $(mmc_get_mac_binary ARTMTD 0x0)
 		;;
+	teltonika,rutx10)
+		caldata_extract "0:ART" 0x1000 0x2f20
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary "0:CONFIG" 0x0) 2)
+		;;
 	zyxel,nbg6617 |\
 	zyxel,wre6606)
 		caldata_extract "ART" 0x1000 0x2f20
@@ -210,6 +214,10 @@ case "$FIRMWARE" in
 	netgear,srs60)
 		caldata_extract_mmc "0:ART" 0x5000 0x2f20
 		ath10k_patch_mac $(mmc_get_mac_binary ARTMTD 0xc)
+		;;
+	teltonika,rutx10)
+		caldata_extract "0:ART" 0x5000 0x2f20
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary "0:CONFIG" 0x0) 3)
 		;;
 	zyxel,nbg6617 |\
 	zyxel,wre6606)

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-rutx.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-rutx.dtsi
@@ -188,30 +188,12 @@
 				label = "0:ART";
 				reg = <0x2e0000 0x10000>;
 				read-only;
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				precal_art_1000: precal@1000 {
-					reg = <0x1000 0x2f20>;
-				};
-
-				precal_art_5000: precal@5000 {
-					reg = <0x5000 0x2f20>;
-				};
 			};
 
 			config: partition@2f0000 {
 				label = "0:CONFIG";
 				reg = <0x2f0000 0x10000>;
 				read-only;
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				macaddr_config_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
 			};
 
 			partition@300000 {
@@ -266,16 +248,4 @@
 	pinctrl-0 = <&mdio_pins>;
 	pinctrl-names = "default";
 	phy-reset-gpio = <&tlmm 62 0>;
-};
-
-&wifi0 {
-	nvmem-cell-names = "pre-calibration", "mac-address";
-	nvmem-cells = <&precal_art_1000>, <&macaddr_config_0>;
-	mac-address-increment = <2>;
-};
-
-&wifi1 {
-	nvmem-cell-names = "pre-calibration", "mac-address";
-	nvmem-cells = <&precal_art_5000>, <&macaddr_config_0>;
-	mac-address-increment = <3>;
 };


### PR DESCRIPTION
ipq40xx: RUTX10 wi-fi calibration fix

RUXT10 doesn't get proper (pre-)calibration data from nvmem-cells in device-tree.
This patch returns (pre-)calibration to 11-ath10k-caldata file.

Signed-off-by: Kasparas Elzbutas <elzkas@gmail.com>