### PR TITLE
libiconv-full: add host build

### DIFF
--- a/package/libs/libiconv-full/Makefile
+++ b/package/libs/libiconv-full/Makefile
@@ -15,6 +15,7 @@ PKG_SOURCE:=libiconv-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/libiconv
 PKG_HASH:=8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313
 PKG_BUILD_DIR:=$(BUILD_DIR)/libiconv-$(PKG_VERSION)
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/libiconv-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=LGPL-2.1-or-later
@@ -25,6 +26,7 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 
 define Package/libiconv-full/Default
   URL:=https://www.gnu.org/software/libiconv/
@@ -61,6 +63,10 @@ CONFIGURE_ARGS += \
 	--disable-rpath \
 	--enable-relocatable
 
+HOST_CONFIGURE_ARGS += \
+	--disable-shared \
+	--with-pic
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib/libiconv-full/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/iconv.h $(1)/usr/lib/libiconv-full/include/
@@ -88,3 +94,4 @@ endef
 $(eval $(call BuildPackage,libcharset))
 $(eval $(call BuildPackage,libiconv-full))
 $(eval $(call BuildPackage,iconv))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Now that libiconv-stub is gone, a replacement for its host build is
needed.

Fixes: c0ba4201f8372eee579584b7f5900e073b207b0c

Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @Ansuel 