### PR TITLE
realtek: new dgs-1210 device tree and add support for dgs-1210-10mp

### DIFF
--- a/package/boot/uboot-envtools/files/realtek
+++ b/package/boot/uboot-envtools/files/realtek
@@ -8,10 +8,11 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 case "$board" in
+d-link,dgs-1210-10mp|\
+d-link,dgs-1210-10p|\
 d-link,dgs-1210-16|\
 d-link,dgs-1210-20|\
 d-link,dgs-1210-28|\
-d-link,dgs-1210-10p|\
 zyxel,gs1900-8|\
 zyxel,gs1900-8hp-v1|\
 zyxel,gs1900-8hp-v2|\

--- a/target/linux/realtek/dts-5.10/rtl8380_d-link_dgs-1210-10mp.dts
+++ b/target/linux/realtek/dts-5.10/rtl8380_d-link_dgs-1210-10mp.dts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl838x_d-link_dgs-1210_common.dtsi"
+#include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
+
+/ {
+	compatible = "d-link,dgs-1210-10mp",
+	"realtek,rtl8382-soc",
+	"realtek,rtl838x-soc";
+
+	model = "D-Link DGS-1210-10MP";
+};
+
+&leds {
+	link_act {
+		label = "green:link_act";
+		gpios = <&gpio1 28 GPIO_ACTIVE_LOW>;
+	};
+
+	poe {
+		label = "green:poe";
+		gpios = <&gpio1 29 GPIO_ACTIVE_LOW>;
+	};
+
+	poe_max {
+		label = "yellow:poe_max";
+		gpios = <&gpio1 27 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&keys {
+	mode {
+		label = "mode";
+		gpios = <&gpio1 30 GPIO_ACTIVE_LOW>;
+		linux,code = <KEY_LIGHTS_TOGGLE>;
+	};
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		INTERNAL_PHY(8)
+		INTERNAL_PHY(9)
+		INTERNAL_PHY(10)
+		INTERNAL_PHY(11)
+		INTERNAL_PHY(12)
+		INTERNAL_PHY(13)
+		INTERNAL_PHY(14)
+		INTERNAL_PHY(15)
+		INTERNAL_PHY(24)
+		INTERNAL_PHY(26)
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT(8, 1, internal)
+		SWITCH_PORT(9, 2, internal)
+		SWITCH_PORT(10, 3, internal)
+		SWITCH_PORT(11, 4, internal)
+		SWITCH_PORT(12, 5, internal)
+		SWITCH_PORT(13, 6, internal)
+		SWITCH_PORT(14, 7, internal)
+		SWITCH_PORT(15, 8, internal)
+		SWITCH_SFP_PORT(24, 9, rgmii-id)
+		SWITCH_SFP_PORT(26, 10, rgmii-id)
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-10p.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-10p.dts
@@ -1,37 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "rtl838x.dtsi"
-
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/gpio/gpio.h>
+#include "rtl838x_d-link_dgs-1210_common.dtsi"
 
 / {
 	compatible = "d-link,dgs-1210-10p", "realtek,rtl838x-soc";
 	model = "D-Link DGS-1210-10P";
-
-	aliases {
-		led-boot = &led_power;
-		led-failsafe = &led_power;
-		led-running = &led_power;
-		led-upgrade = &led_power;
-	};
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
-	leds {
-		pinctrl-names = "default";
-		pinctrl-0 = <&pinmux_disable_sys_led>;
-		compatible = "gpio-leds";
-
-		led_power: power {
-			// GPIO 0 seems to provide power to the leds
-			label = "green:power";
-			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
-		};
-	};
 
 	keys {
 		compatible = "gpio-keys-polled";
@@ -50,58 +23,6 @@
 		#gpio-cells = <2>;
 		gpio-controller;
 		indirect-access-bus-id = <0>;
-	};
-};
-
-
-&spi0 {
-	status = "okay";
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <10000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x00000000 0x80000>;
-				read-only;
-			};
-			partition@80000 {
-				label = "u-boot-env";
-				reg = <0x00080000 0x40000>;
-				read-only;
-			};
-			partition@c0000 {
-				label = "u-boot-env2";
-				reg = <0x000c0000 0x40000>;
-			};
-			partition@280000 {
-				label = "firmware";
-				compatible = "denx,uimage";
-				reg = <0x00100000 0xd80000>;
-			};
-			partition@be80000 {
-				label = "kernel2";
-				reg = <0x00e80000 0x180000>;
-			};
-			partition@1000000 {
-				label = "sysinfo";
-				reg = <0x01000000 0x40000>;
-			};
-			partition@1040000 {
-				label = "rootfs2";
-				reg = <0x01040000 0xc00000>;
-			};
-			partition@1c40000 {
-				label = "jffs2";
-				reg = <0x01c40000 0x3c0000>;
-			};
-		};
 	};
 };
 

--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-16.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-16.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "rtl8382_d-link_dgs-1210.dtsi"
+#include "rtl838x_d-link_dgs-1210_common.dtsi"
 
 / {
 	compatible = "d-link,dgs-1210-16", "realtek,rtl838x-soc";

--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-20.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-20.dts
@@ -1,34 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "rtl8382_d-link_dgs-1210.dtsi"
+#include "rtl838x_d-link_dgs-1210_common.dtsi"
+#include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
 
 / {
 	compatible = "d-link,dgs-1210-20", "realtek,rtl838x-soc";
 	model = "D-Link DGS-1210-20";
-
-	gpio-restart {
-		compatible = "gpio-restart";
-		gpios = <&gpio1 34 GPIO_ACTIVE_LOW>;
-		open-source;
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		poll-interval = <20>;
-
-		reset {
-			label = "reset";
-			gpios = <&gpio1 33 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-	};
-
-	gpio1: rtl8231-gpio {
-		compatible = "realtek,rtl8231-gpio";
-		#gpio-cells = <2>;
-		gpio-controller;
-		indirect-access-bus-id = <0>;
-	};
 };
 
 &ethernet0 {

--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-28.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-28.dts
@@ -1,34 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "rtl8382_d-link_dgs-1210.dtsi"
+#include "rtl838x_d-link_dgs-1210_common.dtsi"
+#include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
 
 / {
 	compatible = "d-link,dgs-1210-28", "realtek,rtl838x-soc";
 	model = "D-Link DGS-1210-28";
-
-	gpio-restart {
-		compatible = "gpio-restart";
-		gpios = <&gpio1 34 GPIO_ACTIVE_LOW>;
-		open-source;
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		poll-interval = <20>;
-
-		reset {
-			label = "reset";
-			gpios = <&gpio1 33 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-	};
-
-	gpio1: rtl8231-gpio {
-		compatible = "realtek,rtl8231-gpio";
-		#gpio-cells = <2>;
-		gpio-controller;
-		indirect-access-bus-id = <0>;
-	};
 };
 
 &ethernet0 {

--- a/target/linux/realtek/dts-5.10/rtl838x_d-link_dgs-1210_common.dtsi
+++ b/target/linux/realtek/dts-5.10/rtl838x_d-link_dgs-1210_common.dtsi
@@ -18,10 +18,9 @@
 		reg = <0x0 0x8000000>;
 	};
 
-	leds {
+	leds: leds {
 		pinctrl-names = "default";
 		pinctrl-0 = <&pinmux_disable_sys_led>;
-
 		compatible = "gpio-leds";
 
 		led_power: power {

--- a/target/linux/realtek/dts-5.10/rtl83xx_d-link_dgs-1210_gpio.dtsi
+++ b/target/linux/realtek/dts-5.10/rtl83xx_d-link_dgs-1210_gpio.dtsi
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/ {
+	gpio-restart {
+		compatible = "gpio-restart";
+		gpios = <&gpio1 34 GPIO_ACTIVE_LOW>;
+		open-source;
+	};
+
+	keys: keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 33 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio1: rtl8231-gpio {
+		compatible = "realtek,rtl8231-gpio";
+		#gpio-cells = <2>;
+		gpio-controller;
+		indirect-access-bus-id = <0>;
+	};
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -27,6 +27,14 @@ define Device/d-link_dgs-1210
 	dlink-version | dlink-headers
 endef
 
+define Device/d-link_dgs-1210-10mp
+  $(Device/d-link_dgs-1210)
+  SOC := rtl8380
+  DEVICE_MODEL := DGS-1210-10MP
+  DEVICE_PACKAGES += realtek-poe
+endef
+TARGET_DEVICES += d-link_dgs-1210-10mp
+
 define Device/d-link_dgs-1210-10p
   $(Device/d-link_dgs-1210)
   DEVICE_MODEL := DGS-1210-10P


### PR DESCRIPTION
Commit topics: (2022-08-04)

1. A new updated modular dgs-1210 family Device Tree that can more easily be expandable and configured to all devices in the family. This device tree will also be able to handle different SoC series in combination with common gpio and poe hardware everything more easily controlled from the dts file. Also implementing the new Device Tree for the dgs-1210 devices in OpenWrt.

2. Adding support for rtl8380 based D-Link DGS-1210-10MP.