### PR TITLE
rules: drop -Wno-error additional flags from default TARGET_CFLAGS

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -184,7 +184,7 @@ ifndef DUMP
     -include $(TOOLCHAIN_DIR)/info.mk
     export GCC_HONOUR_COPTS:=0
     TARGET_CROSS:=$(if $(TARGET_CROSS),$(TARGET_CROSS),$(OPTIMIZE_FOR_CPU)-openwrt-linux$(if $(TARGET_SUFFIX),-$(TARGET_SUFFIX))-)
-    TARGET_CFLAGS+= -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result
+    TARGET_CFLAGS+= -fhonour-copts
     TARGET_CPPFLAGS+= -I$(TOOLCHAIN_DIR)/usr/include
     ifeq ($(CONFIG_USE_MUSL),y)
       TARGET_CPPFLAGS+= -I$(TOOLCHAIN_DIR)/include/fortify


### PR DESCRIPTION
We currently enable -Wno-error=unused-but-set-variable and
-Wno-error=unused-result by default on every compile package.

While this is (relatively) unharmful, we should follow other project
direction and starts enforcing good code quality. For example the linux
kernel recently started to enforce Wall by default and clean code is
mandatory for inclusion.

Drop for good these flags and and make it mandatory to correctly handle
return values at least with a warning log if they are not strictly error
condition.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

----

This comes from a discussion on the mailing list and a problem I encountered while working
on supporting EXTERNAL_TOOLCHAIN.

I notice that archs38/generic was failing with these error... With some investigation I notice that
we have these extra flags in rules.mk but they are only applied to internal toolchains and not set
with EXTERNAL_TOOLCHAIN.

It wasn't clear from the start to me but thanks to @neheb, I notice that archs38/generic is the only
target that use glibc instead of musl. Glibc enforce for some function the unused return while
musl doesn't.

I fixed the packages that would fail with glibc (and the flags removed) but I'm not sure if feeds
package would have some problem so i'm posting here as RFC hoping for some feedback and
the correct way to handle feeds package...

IMHO we should fix them and we will have a transition period with some broken package but
I can't take this decision alone so I'm asking how to proceed.

(In the meantime I fixed core packages so I can continue my work on EXTERNAL_TOOLCHAIN)