### PR TITLE
wolfssl: Do not activate HW acceleration on armvirt

### DIFF
--- a/package/libs/wolfssl/Config.in
+++ b/package/libs/wolfssl/Config.in
@@ -72,7 +72,7 @@ config WOLFSSL_ASM_CAPABLE
 
 choice
 	prompt "Hardware Acceleration"
-	default WOLFSSL_HAS_CPU_CRYPTO if WOLFSSL_ASM_CAPABLE
+	default WOLFSSL_HAS_CPU_CRYPTO if WOLFSSL_ASM_CAPABLE && !TARGET_armvirt
 	default WOLFSSL_HAS_NO_HW
 
 	config WOLFSSL_HAS_NO_HW


### PR DESCRIPTION
The armvirt target is also used to run OpenWrt in lxc on other targets
like a raspberry pi. If we set CONFIG_WOLFSSL_ASM_CAPABLE wolfssl is
only working when the CPU supports the hardware extension.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>