### PR TITLE
ipq40xx: switch to 5.15 as default kernel

### DIFF
--- a/target/linux/ipq40xx/Makefile
+++ b/target/linux/ipq40xx/Makefile
@@ -8,8 +8,7 @@ CPU_TYPE:=cortex-a7
 CPU_SUBTYPE:=neon-vfpv4
 SUBTARGETS:=generic chromium mikrotik
 
-KERNEL_PATCHVER:=5.10
-KERNEL_TESTING_PATCHVER:=5.15
+KERNEL_PATCHVER:=5.15
 
 KERNELNAME:=zImage Image dtbs
 


### PR DESCRIPTION
The testing kernel received now multiple months of testing. Set 5.15 as
default to give it a test with a broader audience.

Tested on:
- MikroTik SXTsq 5 AC
- FritzBox 4040/7530
- ZyXEL NBG6617