### PR TITLE
wolfssl: fix math library build

### DIFF
--- a/package/libs/wolfssl/patches/101-update-sp_rand_prime-s-preprocessor-gating-to-match.patch
+++ b/package/libs/wolfssl/patches/101-update-sp_rand_prime-s-preprocessor-gating-to-match.patch
@@ -1,0 +1,25 @@
+From dc92ec2aa9cb76b782bdba3fc5203267ebf39994 Mon Sep 17 00:00:00 2001
+From: Kareem <kareem@wolfssl.com>
+Date: Fri, 22 Jul 2022 11:07:46 -0700
+Subject: [PATCH] Update sp_rand_prime's preprocessor gating to match
+ wolfSSL_BN_generate_prime_ex's.
+
+---
+ wolfcrypt/src/sp_int.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/wolfcrypt/src/sp_int.c b/wolfcrypt/src/sp_int.c
+index 66b40969fd..db44e3ca06 100644
+--- a/wolfcrypt/src/sp_int.c
++++ b/wolfcrypt/src/sp_int.c
+@@ -15672,8 +15672,8 @@ int sp_radix_size(sp_int* a, int radix, int* size)
+  * Prime number generation and checking.
+  ***************************************/
+ 
+-#if defined(WOLFSSL_KEY_GEN) && (!defined(NO_DH) || !defined(NO_DSA)) && \
+-    !defined(WC_NO_RNG)
++#if defined(WOLFSSL_KEY_GEN) && (!defined(NO_RSA) || !defined(NO_DH) || \
++    !defined(NO_DSA)) && !defined(WC_NO_RNG)
+ /* Generate a random prime for RSA only.
+  *
+  * @param  [out]  r     SP integer to hold result.


### PR DESCRIPTION
Apply upstream patch[1] to fix breakage around math libraries.  This can likely be removed when 5.5.0-stable is tagged and released.

Build system: x86_64
Build-tested: bcm2711/RPi4B
Run-tested: bcm2711/RPi4B

1. https://github.com/wolfSSL/wolfssl/pull/5390

Signed-off-by: John Audia <therealgraysky@proton.me>