### PR TITLE
x86/64: Add Intel SOC Arizona Beach platform.

### DIFF
--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -7,4 +7,15 @@ define Device/generic
 	kmod-tg3
   GRUB2_VARIANT := generic
 endef
+
 TARGET_DEVICES += generic
+
+define Device/AZB_MT110
+  DEVICE_VENDOR := Intel Arizona Beach (NEXSEC MT110)
+  DEVICE_PACKAGES += \
+	kmod-e1000e kmod-e1000 kmod-fs-vfat kmod-igb kmod-ixgbe kmod-igc kmod-i40e \
+	kmod-iwlwifi kmod-usb-net-rndis kmod-usb-net-cdc-mbim kmod-i2c-i801
+  GRUB2_VARIANT := generic
+endef
+
+TARGET_DEVICES += AZB_MT110

--- a/target/linux/x86/patches-5.15/120-usb-net-for-fm350.patch
+++ b/target/linux/x86/patches-5.15/120-usb-net-for-fm350.patch
@@ -1,0 +1,59 @@
+Author: Ji Li <liji@huachen.link>
+Date:   Thu Jun 23 16:56:44 2022 +0800
+
+    USB: serial: option: add MEDIATEK FM350-GL module support
+    
+    Add usb product id of the MEDIATEK FM350-GL module.
+    
+    FM350-GL provides 2 mandatory interfaces to Linux host after enumeration.
+     - /dev/ttyUSB0: this is a serial interface for control path. User needs
+       to write AT commands to this device node to query status, set APN,
+       set PIN code, and enable/disable the data connection to 5G network.
+     - ethX: this is the data path provided as a RNDIS devices. After the
+       data connection has been established, Linux host can access 5G data
+       network via this interface.
+    
+    "RNDIS": RNDIS + ADB + AT (/dev/ttyUSB0) + MODEM COMs
+    
+    usb-devices output for 0x7127:
+    [ 2378.774113] usb 1-1: new high-speed USB device number 8 using xhci_hcd
+	[ 2378.923601] usb 1-1: New USB device found, idVendor=0e8d, idProduct=7127, bcdDevice= 0.01
+	[ 2378.923607] usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=0
+	[ 2378.923611] usb 1-1: Product: FM350-GL
+	[ 2378.923614] usb 1-1: Manufacturer: Fibocom Wireless Inc.
+	[ 2378.936326] rndis_host 1-1:1.0 eth1: register 'rndis_host' at usb-0000:00:14.0-1, RNDIS device, 00:00:11:12:1
+3:14
+	[ 2378.938863] Discovery the interface for Fibocom & MEDIATEK.
+	…
+	[ 2378.940613] option 1-1:1.6: GSM modem (1-port) converter detected
+	[ 2378.940692] usb 1-1: GSM modem (1-port) converter now attached to ttyUSB0
+    
+    Signed-off-by: Ji Li <liji@huachen.link>
+---
+===================================================================
+--- linux-5.10.108.orig/drivers/usb/serial/option.c	2022-09-23 14:27:17.184479952 +0800
++++ linux-5.10.108/drivers/usb/serial/option.c	2022-09-23 14:33:22.907036605 +0800
+@@ -589,6 +589,7 @@
+ 
+ 
+ static const struct usb_device_id option_ids[] = {
++	{ USB_DEVICE(MEDIATEK_VENDOR_ID, 0x7127) },
+ 	{ USB_DEVICE(OPTION_VENDOR_ID, OPTION_PRODUCT_COLT) },
+ 	{ USB_DEVICE(OPTION_VENDOR_ID, OPTION_PRODUCT_RICOLA) },
+ 	{ USB_DEVICE(OPTION_VENDOR_ID, OPTION_PRODUCT_RICOLA_LIGHT) },
+@@ -2210,6 +2211,15 @@
+ 	if (device_flags & NUMEP2 && iface_desc->bNumEndpoints != 2)
+ 		return -ENODEV;
+ 
++	if(id->idVendor == MEDIATEK_VENDOR_ID &&
++ 	     (id->idProduct == cpu_to_le16(0x7127) &&
++	        ((serial->interface->cur_altsetting->desc.bInterfaceNumber <= 5) ||
++		(serial->interface->cur_altsetting->desc.bInterfaceNumber >= 7))))
++	{
++	    printk(KERN_INFO "Discovery the interface for Fibocom & MEDIATEK.");
++	    return -ENODEV;
++	}
++
+ 	/* Store the device flags so we can use them during attach. */
+ 	usb_set_serial_data(serial, (void *)device_flags);
+ 


### PR DESCRIPTION
Arizona Beach is a derivative of the Alder Lake-M series product targeted specifically at networking applications.
Nexsec MT110 is a uCPE power by Intel Atom SOC Arizona Beach

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
