### PR TITLE
ramips: support ZLT S12 PRO

### DIFF
--- a/target/linux/ramips/dts/mt7621_sztozed_zlt-s12-pro.dts
+++ b/target/linux/ramips/dts/mt7621_sztozed_zlt-s12-pro.dts
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "sztozed,zlt-s12-pro", "mediatek,mt7621-soc";
+	model = "ZLT S12 PRO";
+
+	aliases {
+		led-boot = &led_power_yellow;
+		led-failsafe = &led_power_yellow;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		modem-blue {
+			label = "blue:modem";
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+		};
+
+		modem-red {
+			label = "red:modem";
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_blue: power-blue {
+			label = "blue:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_yellow: power-yellow {
+			label = "yellow:power";
+			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "blue:wifi";
+			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
+		};
+
+		signal1 {
+			label = "blue:signal1";
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+		};
+
+		signal2 {
+			label = "blue:signal2";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+		};
+
+		signal3 {
+			label = "blue:signal3";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		signal4 {
+			label = "blue:signal4";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		signal5 {
+			label = "blue:signal5";
+			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
+		};
+
+		phone {
+			label = "blue:phone";
+			gpios = <&gpio 31 GPIO_ACTIVE_LOW>;
+		};
+
+		slic_clk_switch {
+			label = "slic_clk_switch";
+			gpios = <&gpio 32 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+
+		lt72_ant0 {
+			gpio-export,name = "lt72_ant0";
+			gpio-export,input = <0>;
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		lt72_ant1 {
+			gpio-export,name = "lt72_ant1";
+			gpio-export,input = <0>;
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		lt72_power {
+			gpio-export,name = "lt72_power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	spidev@1 {
+		spi-cpol = <0x01>;
+		compatible = "rohm,dh2228fv";
+		spi-cpha = <0x01>;
+		linux,modalias = "spidev";
+		status = "okay";
+		reg = <0x01>;
+		spi-max-frequency = <0x1f4000>;
+	};
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x8000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@38000 {
+				label = "tozed-conf";
+				reg = <0x38000 0x8000>;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&state_default {
+	pcm {
+		groups = "uart2";
+		function = "pcm";
+	};
+
+	gpio {
+		groups = "wdt", "rgmii2", "jtag", "uart3";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 {
+		reg = <0x4 0x6>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_sztozed_zlt-s12-pro.dts
+++ b/target/linux/ramips/dts/mt7621_sztozed_zlt-s12-pro.dts
@@ -225,7 +225,7 @@
 			label = "lan2";
 		};
 
-		port@3 {
+		port@4 {
 			status = "okay";
 			label = "lan1";
 		};

--- a/target/linux/ramips/dts/mt7621_sztozed_zlt-s12-pro.dts
+++ b/target/linux/ramips/dts/mt7621_sztozed_zlt-s12-pro.dts
@@ -86,8 +86,7 @@
 	};
 
 	keys {
-		compatible = "gpio-keys-polled";
-		poll-interval = <20>;
+		compatible = "gpio-keys";
 
 		reset {
 			label = "reset";

--- a/target/linux/ramips/dts/mt7621_sztozed_zlt-s12-pro.dts
+++ b/target/linux/ramips/dts/mt7621_sztozed_zlt-s12-pro.dts
@@ -10,7 +10,7 @@
 	model = "ZLT S12 PRO";
 
 	aliases {
-		led-boot = &led_power_yellow;
+		led-boot = &led_power_blue;
 		led-failsafe = &led_power_yellow;
 		led-running = &led_power_blue;
 		led-upgrade = &led_power_blue;

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2173,6 +2173,16 @@ define Device/zio_freezio
 endef
 TARGET_DEVICES += zio_freezio
 
+define Device/sztozed_zlt-s12-pro
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := ZLT
+  DEVICE_MODEL := S12 PRO
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-serial-option comgt-ncm
+endef
+TARGET_DEVICES += sztozed_zlt-s12-pro
+
 define Device/zyxel_nr7101
   $(Device/dsa-migration)
   BLOCKSIZE := 128k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -155,6 +155,9 @@ xiaomi,redmi-router-ac2100)
 youhua,wr1200js)
 	ucidef_set_led_netdev "internet" "INTERNET" "green:wan" "wan"
 	;;
+sztozed,zlt-s12-pro)
+	ucidef_set_led_netdev "wifi" "WiFi" "blue:wifi" "wlan0"
+	;;
 zbtlink,zbt-wg1608-16m)
 	ucidef_set_led_netdev "lan1" "LAN1" "green:lan-1" "lan1"
 	ucidef_set_led_netdev "lan2" "LAN2" "green:lan-2" "lan2"


### PR DESCRIPTION
Specifications:
- CPU: MediaTek MT7621A
- RAM: 256MB DDR3
- NOR Flash: MX25L12833FM2I 16MB SPI Flash
- Wi-Fi 2.4Ghz: MT7603E
- Wi-Fi 5Ghz: MT7612E
- Switch: MT7530 4x 1Gbit Ports
- WWAN: Unisoc SL8563 based CAT6 internal LTE modem.
- USB: 1x optional USB2.0 external port.
- Switches/Buttons: WPS, WiFi, Reset, Power Switch
- LEDs: Power, Wi-Fi, Data, Signal 1-5, Phone

Serial Pins:
Located at the bottom right when looking from the front.
Right under the Reset/WPS buttons.
The pinout from the left is:
- RX
- GND
- TX
Baudrate is 115200

If connecting from a powered off state,
you'll need to disconnect RX as it blocks the boot process.

Installation:
- Run the script linked to get superadmin access
https://gist.github.com/1Conan/d61af10158d4eb77b5f354cba44df864
- Login at the web UI using the credentials superadmin:backspace
- Go to Management -> System Upgrade

Signed-off-by: 1Conan <me@1conan.com>
