### PR TITLE
Prevent unused crypto lib dependencies from being compiled

### DIFF
--- a/package/libs/ustream-ssl/Makefile
+++ b/package/libs/ustream-ssl/Makefile
@@ -44,7 +44,7 @@ endef
 define Package/libustream-mbedtls
   $(Package/libustream/default)
   TITLE += (mbedtls)
-  DEPENDS += +libmbedtls
+  DEPENDS += +PACKAGE_libustream-mbedtls:libmbedtls
   CONFLICTS := libustream-openssl libustream-wolfssl
   VARIANT:=mbedtls
   DEFAULT_VARIANT:=1

--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -166,7 +166,7 @@ define Package/hostapd-openssl
 $(call Package/hostapd/Default,$(1))
   TITLE+= (OpenSSL full)
   VARIANT:=full-openssl
-  DEPENDS+=+libopenssl
+  DEPENDS+=+PACKAGE_hostapd-openssl:libopenssl
 endef
 
 Package/hostapd-openssl/description = $(Package/hostapd/description)
@@ -175,7 +175,7 @@ define Package/hostapd-wolfssl
 $(call Package/hostapd/Default,$(1))
   TITLE+= (wolfSSL full)
   VARIANT:=full-wolfssl
-  DEPENDS+=+libwolfssl
+  DEPENDS+=+PACKAGE_hostapd-wolfssl:libwolfssl
 endef
 
 Package/hostapd-wolfssl/description = $(Package/hostapd/description)
@@ -194,7 +194,7 @@ define Package/hostapd-basic-openssl
 $(call Package/hostapd/Default,$(1))
   TITLE+= (WPA-PSK, 11r and 11w)
   VARIANT:=basic-openssl
-  DEPENDS+=+libopenssl
+  DEPENDS+=+PACKAGE_hostapd-basic-openssl:libopenssl
 endef
 
 define Package/hostapd-basic-openssl/description
@@ -205,7 +205,7 @@ define Package/hostapd-basic-wolfssl
 $(call Package/hostapd/Default,$(1))
   TITLE+= (WPA-PSK, 11r and 11w)
   VARIANT:=basic-wolfssl
-  DEPENDS+=+libwolfssl
+  DEPENDS+=+PACKAGE_hostapd-basic-wolfssl:libwolfssl
 endef
 
 define Package/hostapd-basic-wolfssl/description
@@ -253,7 +253,7 @@ define Package/wpad-openssl
 $(call Package/wpad/Default,$(1))
   TITLE+= (OpenSSL full)
   VARIANT:=wpad-full-openssl
-  DEPENDS+=+libopenssl
+  DEPENDS+=+PACKAGE_wpad-openssl:libopenssl
 endef
 
 Package/wpad-openssl/description = $(Package/wpad/description)
@@ -262,7 +262,7 @@ define Package/wpad-wolfssl
 $(call Package/wpad/Default,$(1))
   TITLE+= (wolfSSL full)
   VARIANT:=wpad-full-wolfssl
-  DEPENDS+=+libwolfssl
+  DEPENDS+=+PACKAGE_wpad-wolfssl:libwolfssl
 endef
 
 Package/wpad-wolfssl/description = $(Package/wpad/description)
@@ -281,7 +281,7 @@ define Package/wpad-basic-openssl
 $(call Package/wpad/Default,$(1))
   TITLE+= (OpenSSL, 11r, 11w)
   VARIANT:=wpad-basic-openssl
-  DEPENDS+=+libopenssl
+  DEPENDS+=+PACKAGE_wpad-basic-openssl:libopenssl
 endef
 
 define Package/wpad-basic-openssl/description
@@ -292,7 +292,7 @@ define Package/wpad-basic-wolfssl
 $(call Package/wpad/Default,$(1))
   TITLE+= (wolfSSL, 11r, 11w)
   VARIANT:=wpad-basic-wolfssl
-  DEPENDS+=+libwolfssl
+  DEPENDS+=+PACKAGE_wpad-basic-wolfssl:libwolfssl
 endef
 
 define Package/wpad-basic-wolfssl/description
@@ -322,7 +322,7 @@ endef
 define Package/wpad-mesh-openssl
 $(call Package/wpad-mesh,$(1))
   TITLE+= (OpenSSL, 11s, SAE)
-  DEPENDS+=+libopenssl
+  DEPENDS+=+PACKAGE_wpad-mesh-openssl:libopenssl
   VARIANT:=wpad-mesh-openssl
 endef
 
@@ -331,7 +331,7 @@ Package/wpad-mesh-openssl/description = $(Package/wpad-mesh/description)
 define Package/wpad-mesh-wolfssl
 $(call Package/wpad-mesh,$(1))
   TITLE+= (wolfSSL, 11s, SAE)
-  DEPENDS+=+libwolfssl
+  DEPENDS+=+PACKAGE_wpad-mesh-wolfssl:libwolfssl
   VARIANT:=wpad-mesh-wolfssl
 endef
 
@@ -362,14 +362,14 @@ define Package/wpa-supplicant-openssl
 $(call Package/wpa-supplicant/Default,$(1))
   TITLE+= (OpenSSL full)
   VARIANT:=supplicant-full-openssl
-  DEPENDS+=+libopenssl
+  DEPENDS+=+PACKAGE_wpa-supplicant-openssl:libopenssl
 endef
 
 define Package/wpa-supplicant-wolfssl
 $(call Package/wpa-supplicant/Default,$(1))
   TITLE+= (wolfSSL full)
   VARIANT:=supplicant-full-wolfssl
-  DEPENDS+=+libwolfssl
+  DEPENDS+=+PACKAGE_wpa-supplicant-wolfssl:libwolfssl
 endef
 
 define Package/wpa-supplicant/config
@@ -393,14 +393,14 @@ define Package/wpa-supplicant-mesh-openssl
 $(call Package/wpa-supplicant-mesh/Default,$(1))
   TITLE+= (OpenSSL, 11s, SAE)
   VARIANT:=supplicant-mesh-openssl
-  DEPENDS+=+libopenssl
+  DEPENDS+=+PACKAGE_wpa-supplicant-mesh-openssl:libopenssl
 endef
 
 define Package/wpa-supplicant-mesh-wolfssl
 $(call Package/wpa-supplicant-mesh/Default,$(1))
   TITLE+= (wolfSSL, 11s, SAE)
   VARIANT:=supplicant-mesh-wolfssl
-  DEPENDS+=+libwolfssl
+  DEPENDS+=+PACKAGE_wpa-supplicant-mesh-wolfssl:libwolfssl
 endef
 
 define Package/wpa-supplicant-basic
@@ -466,7 +466,7 @@ define Package/eapol-test-openssl
   TITLE+= (OpenSSL full)
   VARIANT:=supplicant-full-openssl
   CONFLICTS:=$(filter-out eapol-test-openssl ,$(EAPOL_TEST_PROVIDERS))
-  DEPENDS+=+libopenssl
+  DEPENDS+=+PACKAGE_eapol-test-openssl:libopenssl
   PROVIDES:=eapol-test
 endef
 
@@ -475,7 +475,7 @@ define Package/eapol-test-wolfssl
   TITLE+= (wolfSSL full)
   VARIANT:=supplicant-full-wolfssl
   CONFLICTS:=$(filter-out eapol-test-openssl ,$(filter-out eapol-test-wolfssl ,$(EAPOL_TEST_PROVIDERS)))
-  DEPENDS+=+libwolfssl
+  DEPENDS+=+PACKAGE_eapol-test-wolfssl:libwolfssl
   PROVIDES:=eapol-test
 endef
 


### PR DESCRIPTION
This prevents building of unused packages during OpenWRT image build