### PR TITLE
lantiq: fix network port GPIO settings for Fritzbox 3390

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
@@ -149,12 +149,12 @@
 &gswip_mdio {
 	phy0: ethernet-phy@0 {
 		reg = <0x0>;
-		gpios = <&gpio 32 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
 	};
 
 	phy1: ethernet-phy@1 {
 		reg = <0x1>;
-		gpios = <&gpio 44 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
 	};
 
 	phy11: ethernet-phy@11 {


### PR DESCRIPTION
There are forum reports that 2 LAN ports are not working, the
GPIO settings are adjusted based on stock firmware to fix the problem.
As suggested this is a spin-of from PR 5075.

Signed-off-by: Daniel Kestrel <kestrel1974@t-online.de>