### PR TITLE
wolfssl: Make shared again

### DIFF
--- a/package/libs/wolfssl/Config.in
+++ b/package/libs/wolfssl/Config.in
@@ -68,11 +68,11 @@ config WOLFSSL_HAS_DEVCRYPTO
 
 config WOLFSSL_ASM_CAPABLE
 	bool
-	default x86_64 || (aarch64 && !TARGET_bcm27xx)
+	default x86_64
 
 choice
 	prompt "Hardware Acceleration"
-	default WOLFSSL_HAS_CPU_CRYPTO if WOLFSSL_ASM_CAPABLE && !TARGET_armvirt
+	default WOLFSSL_HAS_CPU_CRYPTO if WOLFSSL_ASM_CAPABLE
 	default WOLFSSL_HAS_NO_HW
 
 	config WOLFSSL_HAS_NO_HW

--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -61,7 +61,6 @@ endef
 define Package/libwolfssl
 $(call Package/libwolfssl/Default)
   TITLE:=wolfSSL library
-  PKGFLAGS:=nonshared
   MENU:=1
   PROVIDES:=libcyassl
   DEPENDS:=+WOLFSSL_HAS_DEVCRYPTO:kmod-cryptodev +WOLFSSL_HAS_AFALG:kmod-crypto-user


### PR DESCRIPTION
Make the wolfssl package shared again. To do so we have to deactivate
CPU crypto extension support on aarch64 by default again.

Shared packages are constantly updated against the branch snapshot SDK.
The none shared packages are getting only updated with a new release.

wolfssl gets security updated pretty often, because it is a SSL library.
When we update it, the none shared packages like ustream-ssl are getting
rebuild against the new version from the snapshot and it does not work
with the old version any more. The user only gets the wolfssl update
with the next minor update.

We ran into such a problem after the 22.03.0-rc5 release. The wolfssl
package was updated after that release and ustream-ssl was rebuild
against it. After this change the image builder from OpenWrt 22.03.0-rc5
does not work anymore because ustream-ssl has an unsolved dependency.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
