### PR TITLE
image-commands: add gzip-libdeflate advanced compressor

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -305,7 +305,7 @@ define Build/fit
 endef
 
 define Build/gzip
-	gzip -f -9n -c $@ $(1) > $@.new
+	$(STAGING_DIR_HOST)/bin/gzip-libdeflate -f -12 -c $@ $(1) > $@.new
 	@mv $@.new $@
 endef
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -22,7 +22,7 @@ ifneq ($(CONFIG_SDK)$(CONFIG_PACKAGE_kmod-b43)$(CONFIG_PACKAGE_b43legacy-firmwar
 endif
 
 tools-y += autoconf autoconf-archive automake bc bison cmake cpio dosfstools
-tools-y += e2fsprogs expat fakeroot findutils firmware-utils flex gengetopt
+tools-y += e2fsprogs expat fakeroot findutils firmware-utils flex gengetopt libdeflate
 tools-y += libressl libtool lzma m4 make-ext4fs meson missing-macros mkimage
 tools-y += mklibs mtd-utils mtools ninja padjffs2 patch-image
 tools-y += patchelf pkgconf quilt squashfskit4 sstrip zip zlib zstd

--- a/tools/libdeflate/Makefile
+++ b/tools/libdeflate/Makefile
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2022 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libdeflate
+PKG_VERSION:=1.12
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE_URL:=https://github.com/ebiggers/libdeflate.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=6b5b57116c5b1672a2407aa68f3a49c72f877cb3
+PKG_MIRROR_HASH:=ba89fb167a5ab6bbdfa6ee3b1a71636e8140fa8471cce8a311697584948e4d06
+
+include $(INCLUDE_DIR)/host-build.mk
+
+define Host/Install
+	$(CP) $(HOST_BUILD_DIR)/gzip $(STAGING_DIR_HOST)/bin/gzip-libdeflate
+endef
+
+define Host/Clean
+	rm -f $(STAGING_DIR_HOST)/bin/gzip-libdeflate
+endef
+
+$(eval $(call HostBuild))


### PR DESCRIPTION
Several devices provide U-Boot versions with only gzip compressed kernel
support (e.g. Realtek switches). To avoid going the hard way with lzma-loader
we can make use of enhanced gzip tool based on libdeflate compression library
from https://github.com/ebiggers/libdeflate. Output is fully gzip compatible.
Add new tool to image-commands and make use of it for Realtek targets.

Image sizes before (gzip)
```
6402370 openwrt-realtek-rtl838x-d-link_dgs-1210-28-initramfs-kernel.bin
6030127 openwrt-realtek-rtl838x-d-link_dgs-1210-28-squashfs-sysupgrade.bin
```

Image sizes after (gzip-libdeflate)
```
6118634 openwrt-realtek-rtl838x-d-link_dgs-1210-28-initramfs-kernel.bin
5767983 openwrt-realtek-rtl838x-d-link_dgs-1210-28-squashfs-sysupgrade.bin
```