### PR TITLE
ramips: adding support for Asus RP-AC56

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_rp-ac56.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rp-ac56.dts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "asus,rp-ac56", "mediatek,mt7621-soc";
+	model = "Asus RP-AC56";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_orange;
+		led-running = &led_power_white;
+		led-upgrade = &led_power_blue;
+		label-mac-device = &gmac0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan2g_red {
+			label = "red:wlan2g";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan2g_blue {
+			label = "blue:wlan2g";
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan2g_green {
+			label = "green:wlan2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g_red {
+			label = "red:wlan5g";
+			gpios = <&gpio 45 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan5g_blue {
+			label = "blue:wlan5g";
+			gpios = <&gpio 43 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan5g_green {
+			label = "green:wlan5g";
+			gpios = <&gpio 44 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led_power_white: power_white {
+			label = "white:power";
+			gpios = <&gpio 48 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_orange: power_orange {
+			label = "orange:power";
+			gpios = <&gpio 47 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio 46 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	sound {
+		compatible = "simple-audio-card";
+		simple-audio-card,name = "Audio-I2S";
+		simple-audio-card,format = "i2s";
+		simple-audio-card,bitclock-master = <&dailink0_master>;
+		simple-audio-card,frame-master = <&dailink0_master>;
+		simple-audio-card,routing =
+			"Headphone Jack", "HP_L",
+			"Headphone Jack", "HP_R";
+		simple-audio-card,mclk-fs = <256>;
+
+		simple-audio-card,cpu {
+			sound-dai = <&i2s>;
+		};
+
+		dailink0_master: simple-audio-card,codec {
+			sound-dai = <&codec>;
+		};
+	};
+};
+
+&gpio {
+       status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "nvram";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfa0000>;
+			};
+
+			radio: partition@ff0000 {
+				label = "radio";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2";
+		function = "gpio";
+	};
+};
+
+&pinctrl {
+	i2s_pins: i2s {
+		i2s {
+			groups = "uart3";
+			function = "i2s";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+        ports {
+                port@0 {
+                        status = "okay";
+                        label = "lan";
+                };
+        };
+};
+
+&xhci {
+	status = "disabled";
+};
+
+&i2c {
+	status = "okay";
+
+	codec: wm8960@18 {
+		#sound-dai-cells = <0>;
+		compatible = "wlf,wm8960";
+		reg = <0x18>;
+		wlf,shared-lrclk;
+	};
+};
+
+&gdma {
+	status = "okay";
+};
+
+&i2s {
+	#sound-dai-cells = <0>;
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2s_pins>;
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -189,6 +189,22 @@ define Device/asiarf_ap7621-nv1
 endef
 TARGET_DEVICES += asiarf_ap7621-nv1
 
+define Device/asus_rp-ac56
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  DEVICE_VENDOR := ASUS
+  DEVICE_MODEL := RP-AC56
+  IMAGE_SIZE := 16000k
+  BLOCKSIZE := 64k
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 \
+	kmod-i2c-ralink kmod-sound-mt7620
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | check-size
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
+        check-size | append-metadata
+endef
+TARGET_DEVICES += asus_rp-ac56
+
 define Device/asus_rp-ac87
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -9,6 +9,7 @@ ramips_setup_interfaces()
 
 	case $board in
 	ampedwireless,ally-00x19k|\
+	asus,rp-ac56|\
 	asus,rp-ac87|\
 	edimax,re23s|\
 	mikrotik,routerboard-m11g|\


### PR DESCRIPTION
The [original PR](https://github.com/openwrt/openwrt/pull/2813) was created by Vitaly Makarov \<vit.macarrow@gmail.com\>.

---

Specifications:

	CPU:     MT7621A dual-core 880MHz
	RAM:     64MB DDR2
	FLASH:   16MB MX25L12805D NOR SPI
	WIFI:    2.4GHz 2x2 MT7603 b/g/n PCI
	WIFI:    5GHz 2x2 MT7662 a/b/ac PCI
	ETH:     1xLAN 1000base-T integrated
	SWITCH:  MT7530 Port 0: LAN, Port 6: CPU
	LED:     Power, 2.4GHz WiFi, 5GHz WiFi
	BTN:     WPS, Reset
	UART:    Near ETH port, from ETH: 3V3-TxD-GND-RxD 57600 8n1
	MISC:    Audio support

Installation:

	1. Update using recovery mode
	   - while holdig "reset" button, power on the device
	   - keep holding "reset" until power led is flashing yellow
	   - set own IP to 192.168.1.75, subnet mask: 255.255.255.0
	   - push firmware image (can be factory.bin or sysupgrade.bin)
	     using tftp client in binary mode to 192.168.1.1

Notes:

	This board has only two MAC addresses programmed in the "factory" partition:

	- MAC for wlan0 (2.4GHz) at offset 0x0004
	- MAC for wlan1 (5GHz) at offset 0x8004
	- stock firmware re-uses wlan0 MAC for ethernet
	- no valid addresses found in 0x28, 0x2e, 0xe000 and 0xe006

---

Few caveats I've stumbled upon:

- In the original PR the nvram partition was designated as u-boot-env. However, the OEM firmware refers to it as nvram and stores the devices configuration in it (configurable via the nvram utility). I was unable to find the u-boot environment in it.
- There are two errors which I couldn't fix myself. On this one I'm not certain if it's actually an error as there is no third PCIe device:

`mt7621-pci 1e140000.pcie: Parsing DT failed`
<...>
`rt2880-pinmux pinctrl: pcie is already enabled`
<...>
`mt7621-pci 1e140000.pcie: failed to parse bus ranges property: -22`
<...>
`mt7621-pci 1e140000.pcie: pcie2 no card, disable it (RST & CLK)`

- This error only appears when flashing the factory image via tftp, after a reboot it disappears:

`daemon.err mount_root: failed to sync jffs2 overlay`

I've uploaded the whole system log if context is required: https://paste.debian.net/plain/1248543

---

Besides that, the device works as expected, the issues do not appear to impair its functioning.