### PR TITLE
Master+som1 sdmmc0

### DIFF
--- a/package/boot/at91bootstrap/Makefile
+++ b/package/boot/at91bootstrap/Makefile
@@ -193,7 +193,7 @@ AT91BOOTSTRAP_TARGETS := \
 	sama5d4_xplainednf_uboot_secure \
 	sama5d4_xplaineddf_uboot_secure \
 	sama5d4_xplainedsd_uboot_secure \
-	sama5d27_som1_eksd1_uboot \
+	sama5d27_som1_eksd_uboot \
 	sama5d27_som1_ekqspi_uboot \
 	sama5d27_wlsom1_eksd_uboot \
 	sama5d27_wlsom1_ekdf_qspi_uboot \

--- a/package/boot/uboot-at91/Makefile
+++ b/package/boot/uboot-at91/Makefile
@@ -107,6 +107,12 @@ define U-Boot/sama5d4_xplained_nandflash
   BUILD_DEVICES:=microchip_sama5d3-xplained
 endef
 
+define U-Boot/sama5d27_som1_ek_mmc
+  NAME:=SAMA5D27 SOM1 Ek (SDCard0)
+  BUILD_SUBTARGET:=sama5
+  BUILD_DEVICES:=microchip_sama5d27-som1-ek
+endef
+
 define U-Boot/sama5d27_som1_ek_mmc1
   NAME:=SAMA5D27 SOM1 Ek (SDCard1)
   BUILD_SUBTARGET:=sama5
@@ -163,7 +169,7 @@ UBOOT_TARGETS := \
 	sama5d4_xplained_mmc \
 	sama5d4_xplained_spiflash \
 	sama5d4_xplained_nandflash\
-	sama5d27_som1_ek_mmc1 \
+	sama5d27_som1_ek_mmc \
 	sama5d27_som1_ek_qspiflash \
 	sama5d27_wlsom1_ek_mmc \
 	sama5d27_wlsom1_ek_qspiflash \

--- a/target/linux/at91/image/sama5.mk
+++ b/target/linux/at91/image/sama5.mk
@@ -19,13 +19,13 @@ define Build/at91-sdcard
 	$(BIN_DIR)/u-boot-$(DEVICE_DTS:at91-%=%)_mmc/u-boot.bin \
 	::u-boot.bin
 
-      $(if $(findstring sama5d4-xplained,$@), \
-          mcopy -i $@.boot \
+  $(if $(findstring sama5d4-xplained,$@), \
+	  mcopy -i $@.boot \
               $(BIN_DIR)/at91bootstrap-$(DEVICE_DTS:at91-%=%)sd_uboot_secure/at91bootstrap.bin \
               ::BOOT.bin,
           mcopy -i $@.boot \
               $(BIN_DIR)/at91bootstrap-$(DEVICE_DTS:at91-%=%)sd_uboot/at91bootstrap.bin \
-              ::BOOT.bin))
+              ::BOOT.bin)
 
   $(CP) uboot-env.txt $@-uboot-env.txt
   sed -i '2d;3d' $@-uboot-env.txt

--- a/target/linux/at91/image/sama5.mk
+++ b/target/linux/at91/image/sama5.mk
@@ -15,16 +15,10 @@ define Build/at91-sdcard
 	$(KDIR)/$(DEVICE_NAME)-fit-zImage.itb \
 	::$(DEVICE_NAME)-fit.itb
 
-  $(if $(findstring sama5d27-som1-ek,$@), \
-      mcopy -i $@.boot \
-          $(BIN_DIR)/u-boot-$(DEVICE_DTS:at91-%=%)_mmc1/u-boot.bin \
-          ::u-boot.bin
-      mcopy -i $@.boot \
-          $(BIN_DIR)/at91bootstrap-$(DEVICE_DTS:at91-%=%)sd1_uboot/at91bootstrap.bin \
-          ::BOOT.bin,
-      mcopy -i $@.boot \
-          $(BIN_DIR)/u-boot-$(DEVICE_DTS:at91-%=%)_mmc/u-boot.bin \
-          ::u-boot.bin
+  mcopy -i $@.boot \
+	$(BIN_DIR)/u-boot-$(DEVICE_DTS:at91-%=%)_mmc/u-boot.bin \
+	::u-boot.bin
+
       $(if $(findstring sama5d4-xplained,$@), \
           mcopy -i $@.boot \
               $(BIN_DIR)/at91bootstrap-$(DEVICE_DTS:at91-%=%)sd_uboot_secure/at91bootstrap.bin \


### PR DESCRIPTION
Hi,

It has been reported in [1] that starting w/ v21.02.0 SAMA5D27 SOM1 EK fails to boot.
It is due to the fact that default booting media has been changed in b/w w/o any reason.
Revert back to SDMMC0 as this is the default booting media for this board in all the
other Microchip supported distribution for this board (Buildroot, Yocto Project).

@DennisDNguy: could you check if this fixes the problem on your side as I don't have
a board available to check it.

Thank you,
Claudiu Beznea

[1] https://github.com/openwrt/openwrt/issues/10276