### PR TITLE
linux: mt7531 switch: fix 100mbit limitation on rgmii links

### DIFF
--- a/target/linux/generic/hack-5.10/730-mt7531-move-core-pll-init-disable-port-5-sgmii-p.patch
+++ b/target/linux/generic/hack-5.10/730-mt7531-move-core-pll-init-disable-port-5-sgmii-p.patch
@@ -1,0 +1,50 @@
+From 61bc085c21ba4dfd4f841308dc3030afe94bb1b4 Mon Sep 17 00:00:00 2001
+From: Alexander Couzens <lynxis@fe80.eu>
+Date: Tue, 26 Jul 2022 02:07:44 +0200
+Subject: [PATCH] mt7531: move pll init to setup
+
+The plls shouldn't be reset twice after the reset.
+The pad_setup should only change settings of the specified port.
+Fixes a 100mbit limit on traffic from a switch port towards SoC via port 5 in rgmii.
+
+---
+ drivers/net/dsa/mt7530.c | 22 ++++++++++++++++++----
+ drivers/net/dsa/mt7530.h |  4 ++++
+ 2 files changed, 22 insertions(+), 4 deletions(-)
+
+Index: linux-5.15.53/drivers/net/dsa/mt7530.c
+===================================================================
+--- linux-5.15.53.orig/drivers/net/dsa/mt7530.c
++++ linux-5.15.53/drivers/net/dsa/mt7530.c
+@@ -501,7 +501,12 @@ static bool mt7531_dual_sgmii_supported(
+ static int
+ mt7531_pad_setup(struct dsa_switch *ds, phy_interface_t interface)
+ {
+-	struct mt7530_priv *priv = ds->priv;
++	return 0;
++}
++
++static int
++mt7531_pll_setup(struct mt7530_priv *priv)
++{
+ 	u32 top_sig;
+ 	u32 hwstrap;
+ 	u32 xtal;
+@@ -2292,6 +2297,8 @@ mt7531_setup(struct dsa_switch *ds)
+ 		     SYS_CTRL_PHY_RST | SYS_CTRL_SW_RST |
+ 		     SYS_CTRL_REG_RST);
+ 
++	mt7531_pll_setup(priv);
++
+ 	if (mt7531_dual_sgmii_supported(priv)) {
+ 		priv->p5_intf_sel = P5_INTF_SEL_GMAC5_SGMII;
+ 
+@@ -2867,8 +2874,6 @@ mt7531_cpu_port_config(struct dsa_switch
+ 	case 6:
+ 		interface = PHY_INTERFACE_MODE_2500BASEX;
+ 
+-		mt7531_pad_setup(ds, interface);
+-
+ 		priv->p6_interface = interface;
+ 		break;
+ 	default:

--- a/target/linux/generic/hack-5.10/731-mt7531-shutdown-external-port-before-reset.patch
+++ b/target/linux/generic/hack-5.10/731-mt7531-shutdown-external-port-before-reset.patch
@@ -1,0 +1,24 @@
+From: Alexander Couzens <lynxis@fe80.eu>
+Date: Tue, 26 Jul 2022 02:07:44 +0200
+Subject: [PATCH] mt7531: shutdown the port 5 and 6 before resetting
+
+All MACs should be shutdown before calling the soft reset registers
+according to the datasheet MT7531 Reference Manual for
+Development Board revision 1.0 2019-09-05"
+Also u-boot source code does it similar.
+
+Index: linux-5.15.53/drivers/net/dsa/mt7530.c
+===================================================================
+--- linux-5.15.53.orig/drivers/net/dsa/mt7530.c
++++ linux-5.15.53/drivers/net/dsa/mt7530.c
+@@ -2292,6 +2292,10 @@ mt7531_setup(struct dsa_switch *ds)
+ 		return -ENODEV;
+ 	}
+ 
++	/* shutdown port 5 & 6 before initiating a reset */
++	mt7530_write(priv, MT7530_PMCR_P(5), MT7531_FORCE_LNK);
++	mt7530_write(priv, MT7530_PMCR_P(6), MT7531_FORCE_LNK);
++
+ 	/* Reset the switch through internal reset */
+ 	mt7530_write(priv, MT7530_SYS_CTRL,
+ 		     SYS_CTRL_PHY_RST | SYS_CTRL_SW_RST |

--- a/target/linux/generic/hack-5.10/732-mt7531-phy-reset.patch
+++ b/target/linux/generic/hack-5.10/732-mt7531-phy-reset.patch
@@ -1,0 +1,23 @@
+From: Alexander Couzens <lynxis@fe80.eu>
+Date: Tue, 26 Jul 2022 02:07:44 +0200
+Subject: [PATCH] mt7531: do not reset PHY_RST on mt7531
+
+Neither the datasheet [1] nor the related u-boot source code
+describe a PHY_RST on the mt7531.
+
+[1] MT7531 Reference Manual for Development Board 1.0 2019-09-05
+
+Index: linux-5.15.53/drivers/net/dsa/mt7530.c
+===================================================================
+--- linux-5.15.53.orig/drivers/net/dsa/mt7530.c
++++ linux-5.15.53/drivers/net/dsa/mt7530.c
+@@ -2298,8 +2298,7 @@ mt7531_setup(struct dsa_switch *ds)
+ 
+ 	/* Reset the switch through internal reset */
+ 	mt7530_write(priv, MT7530_SYS_CTRL,
+-		     SYS_CTRL_PHY_RST | SYS_CTRL_SW_RST |
+-		     SYS_CTRL_REG_RST);
++		     SYS_CTRL_SW_RST | SYS_CTRL_REG_RST);
+ 
+ 	mt7531_pll_setup(priv);
+ 

--- a/target/linux/generic/hack-5.15/730-mt7531-move-core-pll-init-disable-port-5-sgmii-p.patch
+++ b/target/linux/generic/hack-5.15/730-mt7531-move-core-pll-init-disable-port-5-sgmii-p.patch
@@ -1,0 +1,50 @@
+From 61bc085c21ba4dfd4f841308dc3030afe94bb1b4 Mon Sep 17 00:00:00 2001
+From: Alexander Couzens <lynxis@fe80.eu>
+Date: Tue, 26 Jul 2022 02:07:44 +0200
+Subject: [PATCH] mt7531: move pll init to setup
+
+The plls shouldn't be reset twice after the reset.
+The pad_setup should only change settings of the specified port.
+Fixes a 100mbit limit on traffic from a switch port towards SoC via port 5 in rgmii.
+
+---
+ drivers/net/dsa/mt7530.c | 22 ++++++++++++++++++----
+ drivers/net/dsa/mt7530.h |  4 ++++
+ 2 files changed, 22 insertions(+), 4 deletions(-)
+
+Index: linux-5.15.53/drivers/net/dsa/mt7530.c
+===================================================================
+--- linux-5.15.53.orig/drivers/net/dsa/mt7530.c
++++ linux-5.15.53/drivers/net/dsa/mt7530.c
+@@ -501,7 +501,12 @@ static bool mt7531_dual_sgmii_supported(
+ static int
+ mt7531_pad_setup(struct dsa_switch *ds, phy_interface_t interface)
+ {
+-	struct mt7530_priv *priv = ds->priv;
++	return 0;
++}
++
++static int
++mt7531_pll_setup(struct mt7530_priv *priv)
++{
+ 	u32 top_sig;
+ 	u32 hwstrap;
+ 	u32 xtal;
+@@ -2292,6 +2297,8 @@ mt7531_setup(struct dsa_switch *ds)
+ 		     SYS_CTRL_PHY_RST | SYS_CTRL_SW_RST |
+ 		     SYS_CTRL_REG_RST);
+ 
++	mt7531_pll_setup(priv);
++
+ 	if (mt7531_dual_sgmii_supported(priv)) {
+ 		priv->p5_intf_sel = P5_INTF_SEL_GMAC5_SGMII;
+ 
+@@ -2867,8 +2874,6 @@ mt7531_cpu_port_config(struct dsa_switch
+ 	case 6:
+ 		interface = PHY_INTERFACE_MODE_2500BASEX;
+ 
+-		mt7531_pad_setup(ds, interface);
+-
+ 		priv->p6_interface = interface;
+ 		break;
+ 	default:

--- a/target/linux/generic/hack-5.15/731-mt7531-shutdown-external-port-before-reset.patch
+++ b/target/linux/generic/hack-5.15/731-mt7531-shutdown-external-port-before-reset.patch
@@ -1,0 +1,24 @@
+From: Alexander Couzens <lynxis@fe80.eu>
+Date: Tue, 26 Jul 2022 02:07:44 +0200
+Subject: [PATCH] mt7531: shutdown the port 5 and 6 before resetting
+
+All MACs should be shutdown before calling the soft reset registers
+according to the datasheet MT7531 Reference Manual for
+Development Board revision 1.0 2019-09-05"
+Also u-boot source code does it similar.
+
+Index: linux-5.15.53/drivers/net/dsa/mt7530.c
+===================================================================
+--- linux-5.15.53.orig/drivers/net/dsa/mt7530.c
++++ linux-5.15.53/drivers/net/dsa/mt7530.c
+@@ -2292,6 +2292,10 @@ mt7531_setup(struct dsa_switch *ds)
+ 		return -ENODEV;
+ 	}
+ 
++	/* shutdown port 5 & 6 before initiating a reset */
++	mt7530_write(priv, MT7530_PMCR_P(5), MT7531_FORCE_LNK);
++	mt7530_write(priv, MT7530_PMCR_P(6), MT7531_FORCE_LNK);
++
+ 	/* Reset the switch through internal reset */
+ 	mt7530_write(priv, MT7530_SYS_CTRL,
+ 		     SYS_CTRL_PHY_RST | SYS_CTRL_SW_RST |

--- a/target/linux/generic/hack-5.15/732-mt7531-phy-reset.patch
+++ b/target/linux/generic/hack-5.15/732-mt7531-phy-reset.patch
@@ -1,0 +1,23 @@
+From: Alexander Couzens <lynxis@fe80.eu>
+Date: Tue, 26 Jul 2022 02:07:44 +0200
+Subject: [PATCH] mt7531: do not reset PHY_RST on mt7531
+
+Neither the datasheet [1] nor the related u-boot source code
+describe a PHY_RST on the mt7531.
+
+[1] MT7531 Reference Manual for Development Board 1.0 2019-09-05
+
+Index: linux-5.15.53/drivers/net/dsa/mt7530.c
+===================================================================
+--- linux-5.15.53.orig/drivers/net/dsa/mt7530.c
++++ linux-5.15.53/drivers/net/dsa/mt7530.c
+@@ -2298,8 +2298,7 @@ mt7531_setup(struct dsa_switch *ds)
+ 
+ 	/* Reset the switch through internal reset */
+ 	mt7530_write(priv, MT7530_SYS_CTRL,
+-		     SYS_CTRL_PHY_RST | SYS_CTRL_SW_RST |
+-		     SYS_CTRL_REG_RST);
++		     SYS_CTRL_SW_RST | SYS_CTRL_REG_RST);
+ 
+ 	mt7531_pll_setup(priv);
+ 


### PR DESCRIPTION
- [ ] test Belkin rt3200 / linksys e8450

When using mt7531 via RGMII over port 5 there is a 100mbit limit
for traffic from a switch port towards the SoC on port. The reverse
traffic flows with 1gbit.

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>