### PR TITLE
LED: Support inverted heartbeat trigger

### DIFF
--- a/package/base-files/files/etc/init.d/led
+++ b/package/base-files/files/etc/init.d/led
@@ -29,7 +29,7 @@ load_led() {
 	config_get delay $1 delay "150"
 	config_get message $1 message ""
 	config_get gpio $1 gpio "0"
-	config_get inverted $1 inverted "0"
+	config_get_bool inverted $1 inverted "0"
 
 	# execute application led trigger
 	[ -f "/usr/libexec/led-trigger/${trigger}" ] && {

--- a/package/base-files/files/etc/init.d/led
+++ b/package/base-files/files/etc/init.d/led
@@ -69,6 +69,10 @@ load_led() {
 			return 1
 		}
 		case "$trigger" in
+		"heartbeat")
+			echo "${inverted}" > "/sys/class/leds/${sysfs}/invert"
+			;;
+
 		"netdev")
 			[ -n "$dev" ] && {
 				echo $dev > /sys/class/leds/${sysfs}/device_name


### PR DESCRIPTION
This patch set introduces inverted heartbeat support to openwrt. It does this by honoring a uci configuration option 'inverted' in the LED section. It re-uses the existing `inverted` property we already use for the GPIO.

As a boyscout commit, the inverted property is now read as a boolean, to ensure we do not write incorrect values in to either sysfs properties.
