### PR TITLE
ath79: add LTE led for GL.iNet GL-XE300

### DIFF
--- a/target/linux/ath79/nand/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/nand/base-files/etc/board.d/01_leds
@@ -17,6 +17,7 @@ glinet,gl-ar300m-nor)
 glinet,gl-xe300)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x10"
+	ucidef_set_led_netdev "3gnet" "LTE" "green:lte" "wwan0"
 	;;
 netgear,pgzng1)
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"


### PR DESCRIPTION
This PR adds the LTE led for GL.iNet GL-XE300 to the default leds config.
