### PR TITLE
[21.02] hostapd: ubus: fix uninitialized pointer

### DIFF
--- a/package/network/services/hostapd/patches/600-ubus_support.patch
+++ b/package/network/services/hostapd/patches/600-ubus_support.patch
@@ -441,7 +441,7 @@
  {
  	u8 dialog_token, status_code, bss_termination_delay;
 -	const u8 *pos, *end;
-+	const u8 *pos, *end, *target_bssid;
++	const u8 *pos, *end, *target_bssid = NULL;
  	int enabled = hapd->conf->bss_transition;
  	struct sta_info *sta;
  


### PR DESCRIPTION
This fixes passing a bogus non-null pointer to the ubus handler in case
the transition request is rejected.

Signed-off-by: David Bauer <mail@david-bauer.net>
(cherry picked from commit 9b880f09f394049e0629e3c9d4061f431a6b19a8)
Signed-off-by: Nick Hainke <vincent@systemli.org>
