### PR TITLE
ramips: some fixes for uboot-envtools

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -47,7 +47,8 @@ zte,mf283plus)
 h3c,tx1800-plus|\
 h3c,tx1801-plus|\
 h3c,tx1806|\
-jcg,q20)
+jcg,q20|\
+netgear,wax202)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;
 hootoo,ht-tm05|\

--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -95,6 +95,6 @@ xiaomi,mi-router-cr6609)
 esac
 
 config_load ubootenv
-config_foreach ubootenv_add_app_config ubootenv
+config_foreach ubootenv_add_app_config
 
 exit 0


### PR DESCRIPTION
 ### ramips: support fw_printenv for Netgear WAX202

Config partition contains uboot env for the first 0x20000 bytes.
The rest of the partition contains other data including the device MAC
address and the password printed on the label.

NOTE: This change leaves the Config partition as read-only. Unless there is some reason to change the uboot env, it's probably safer to leave this read-only so that the critical info is not overwritten.

Links to relevant discussion: https://forum.openwrt.org/t/netgear-wax202-wifi-6-30-at-amazon/130029/57 https://github.com/openwrt/openwrt/pull/9690

### ramips: fix fw_setsys

This change was included in the original pull request but later omitted
for some reason:

https://github.com/openwrt/openwrt/pull/4936 @remittor