### PR TITLE
elfutils: update to 0.187

### DIFF
--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=elfutils
-PKG_VERSION:=0.186
+PKG_VERSION:=0.187
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceware.org/$(PKG_NAME)/ftp/$(PKG_VERSION)
-PKG_HASH:=7f6fb9149b1673d38d9178a0d3e0fb8a1ec4f53a9f4c2ff89469609879641177
+PKG_HASH:=e70b0dfbe610f90c4d1fe0d71af142a4e25c3c4ef9ebab8d2d72b65159d454c8
 
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
Changes:
debuginfod: Support -C option for connection thread pooling.

debuginfod-client: Negative cache file are now zero sized instead of
                   no-permission files.

addr2line: The -A, --absolute option, which shows file names including
           the full compilation directory is now the default.  To get the
           old behavior use the new option --relative.

readelf, elflint: Recognize FDO Packaging Metadata ELF notes

libdw, debuginfo-client: Load libcurl lazily only when files need to
                         be fetched remotely. libcurl is now never
                         loaded when DEBUGINFOD_URLS is unset. And when
                         DEBUGINFOD_URLS is set, libcurl is only loaded
                         when the debuginfod_begin function is called.
