### PR TITLE
ath79: fix MAC address assignment for TP-Link ar7241 devices

### DIFF
--- a/target/linux/ath79/dts/ar7241_tplink.dtsi
+++ b/target/linux/ath79/dts/ar7241_tplink.dtsi
@@ -94,18 +94,17 @@
 	};
 };
 
-&eth0 {
+&eth0 {		/* WAN interface, initialized last as eth1 */
 	status = "okay";
 
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-1)>;
+	mac-address-increment = <1>;
 };
 
-&eth1 {
+&eth1 {		/* LAN interface, initialized first as eth0 */
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &uboot {


### PR DESCRIPTION
On TP-Link ar7241 devices LAN and WAN interfaces are swapped. Keeping
that in mind fix MAC address assignment as used in vendor firmware:
LAN MAC - main MAC stored in u-boot and printed on label
WAN MAC - LAN MAC + 1