### PR TITLE
of_net: add patch to do mac-address-increment only once

### DIFF
--- a/target/linux/generic/pending-5.10/684-of_net-do-mac-address-increment-only-once.patch
+++ b/target/linux/generic/pending-5.10/684-of_net-do-mac-address-increment-only-once.patch
@@ -1,0 +1,31 @@
+From dd07dd394d8bfdb5d527fab18ca54f20815ec4e4 Mon Sep 17 00:00:00 2001
+From: Will Moss <willormos@gmail.com>
+Date: Wed, 3 Aug 2022 13:48:55 +0000
+Subject: [PATCH] of_net: do mac-address-increment only once
+
+Remove mac-address-increment and mac-address-increment-byte
+DT property after incrementing process to make sure MAC address
+would not get incremented more if this function is stared again.
+It could happen if device initialization is deferred after
+unsuccessful attempt.
+
+Signed-off-by: Will Moss <willormos@gmail.com>
+---
+ drivers/of/of_net.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/drivers/of/of_net.c
++++ b/drivers/of/of_net.c
+@@ -190,6 +190,12 @@ found:
+ 		addr[3] = (mac_val >> 16) & 0xff;
+ 		addr[4] = (mac_val >> 8) & 0xff;
+ 		addr[5] = (mac_val >> 0) & 0xff;
++
++		/* Remove mac-address-increment and mac-address-increment-byte
++		 * DT property to make sure MAC address would not get incremented
++		 * more if this function is stared again. */
++		of_remove_property(np, of_find_property(np, "mac-address-increment", NULL));
++		of_remove_property(np, of_find_property(np, "mac-address-increment-byte", NULL));
+ 	}
+ 
+ 	of_add_mac_address(np, addr);

--- a/target/linux/generic/pending-5.15/684-of_net-do-mac-address-increment-only-once.patch
+++ b/target/linux/generic/pending-5.15/684-of_net-do-mac-address-increment-only-once.patch
@@ -1,0 +1,31 @@
+From dd07dd394d8bfdb5d527fab18ca54f20815ec4e4 Mon Sep 17 00:00:00 2001
+From: Will Moss <willormos@gmail.com>
+Date: Wed, 3 Aug 2022 13:48:55 +0000
+Subject: [PATCH] of_net: do mac-address-increment only once
+
+Remove mac-address-increment and mac-address-increment-byte
+DT property after incrementing process to make sure MAC address
+would not get incremented more if this function is stared again.
+It could happen if device initialization is deferred after
+unsuccessful attempt.
+
+Signed-off-by: Will Moss <willormos@gmail.com>
+---
+ drivers/of/of_net.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/net/core/of_net.c
++++ b/net/core/of_net.c
+@@ -194,6 +194,12 @@ found:
+ 		addr[3] = (mac_val >> 16) & 0xff;
+ 		addr[4] = (mac_val >> 8) & 0xff;
+ 		addr[5] = (mac_val >> 0) & 0xff;
++
++		/* Remove mac-address-increment and mac-address-increment-byte
++		 * DT property to make sure MAC address would not get incremented
++		 * more if this function is stared again. */
++		of_remove_property(np, of_find_property(np, "mac-address-increment", NULL));
++		of_remove_property(np, of_find_property(np, "mac-address-increment-byte", NULL));
+ 	}
+ 
+ 	of_add_mac_address(np, addr);


### PR DESCRIPTION
Fixes situations where MAC address gets incremented multiple times
if device initialization fails at first and then is deferred.
This happens at least on TP-Link ar7241 and ar9341 devices.

Not sure if hack-5.xx directory is appropriate for this patch.
