### PR TITLE
ath79: add support for TP-Link TL-WR941ND v5

### DIFF
--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr941nd-v5.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr941nd-v5.dts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9341_tplink.dtsi"
+
+/ {
+	model = "TP-Link TL-WR941ND v5";
+	compatible = "tplink,tl-wr941nd-v5", "qca,ar9341";
+
+	aliases {
+		label-mac-device = &wmac;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		rfkill {
+			label = "WiFi";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "Reset/WPS";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&leds {
+
+	lan3 {
+		gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+	};
+
+	lan4 {
+		gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x3d0000>;
+			};
+
+			art: partition@3f0000 {
+				label = "art";
+				reg = <0x3f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {		// WAN port, initialized last as eth1
+	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&eth1 {		// LAN ports, initialized first as eth0
+	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	mtd-cal-data = <&art 0x1000>;
+
+	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cell-names = "mac-address";
+};
+
+&uboot {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_uboot_1fc00: macaddr@1fc00 {
+		reg = <0x1fc00 0x6>;
+	};
+};

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -503,6 +503,16 @@ define Device/tplink_tl-wr941-v4
 endef
 TARGET_DEVICES += tplink_tl-wr941-v4
 
+define Device/tplink_tl-wr941nd-v5
+  $(Device/tplink-4mlzma)
+  SOC := ar9341
+  DEVICE_MODEL := TL-WR941ND
+  DEVICE_VARIANT := v5
+  TPLINK_HWID := 0x09410005
+  SUPPORTED_DEVICES += tl-wr941nd-v5
+endef
+TARGET_DEVICES += tplink_tl-wr941nd-v5
+
 define Device/tplink_tl-wr941nd-v6
   $(Device/tplink-4mlzma)
   SOC := tp9343

--- a/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
@@ -65,7 +65,8 @@ tplink,tl-mr3420-v2|\
 tplink,tl-wr740n-v4|\
 tplink,tl-wr740n-v5|\
 tplink,tl-wr741nd-v4|\
-tplink,tl-wr841-v8)
+tplink,tl-wr841-v8|\
+tplink,tl-wr941nd-v5)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "green:lan1" "switch0" "0x04"
 	ucidef_set_led_switch "lan2" "LAN2" "green:lan2" "switch0" "0x08"

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -84,7 +84,8 @@ ath79_setup_interfaces()
 	tplink,tl-wr740n-v4|\
 	tplink,tl-wr740n-v5|\
 	tplink,tl-wr741nd-v4|\
-	tplink,tl-wr841-v8)
+	tplink,tl-wr841-v8|\
+	tplink,tl-wr941nd-v5)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"


### PR DESCRIPTION
Specifications:
- SoC: ar9341
- RAM: 32M
- Flash: 4M
- Ethernet: 5x FE ports
- WiFi: ar9341-wmac

Flash instruction:
Upload generated factory firmware on vendor's web interface.

This device is very similar to the TL-WR841N v8, only two LED GPIOs are
different.
Buttons configuration is similar to TL-WR842ND v2 but both buttons are
active low.