### PR TITLE
mt76: move mt7921 firmware from mt7921e to mt7921-firmware

### DIFF
--- a/package/kernel/mt76/Makefile
+++ b/package/kernel/mt76/Makefile
@@ -246,6 +246,11 @@ define KernelPackage/mt7921-common
   FILES:= $(PKG_BUILD_DIR)/mt7921/mt7921-common.ko
 endef
 
+define KernelPackage/mt7921-firmware
+  $(KernelPackage/mt76-default)
+  TITLE:=MediaTek MT7921 firmware
+endef
+
 define KernelPackage/mt7921u
   $(KernelPackage/mt76-default)
   TITLE:=MediaTek MT7921U wireless driver
@@ -488,7 +493,7 @@ define KernelPackage/mt7986-firmware/install
 		$(1)/lib/firmware/mediatek
 endef
 
-define KernelPackage/mt7921e/install
+define KernelPackage/mt7921-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
 	cp \
 		$(PKG_BUILD_DIR)/firmware/WIFI_MT7961_patch_mcu_1_2_hdr.bin \
@@ -526,6 +531,7 @@ $(eval $(call KernelPackage,mt7915e))
 $(eval $(call KernelPackage,mt7916-firmware))
 $(eval $(call KernelPackage,mt7986-firmware))
 $(eval $(call KernelPackage,mt7921-common))
+$(eval $(call KernelPackage,mt7921-firmware))
 $(eval $(call KernelPackage,mt7921u))
 $(eval $(call KernelPackage,mt7921s))
 $(eval $(call KernelPackage,mt7921e))


### PR DESCRIPTION
<s>as others kmod-mt7921x need firmware files too, it is better to
package it with kmod-mt7921-common rather than only with kmod-mt7921e</s>

As others kmod-mt7921x need firmware files too, it is better to
move it to its own package rather than in kmod-mt7921e package.
It could have been moved to mt7921-common but with mt7922 support
comming and needing another firmware it is better to package both
firmwares individually.

Signed-off-by: Pascal Coudurier <coudu@gmx.com>