### PR TITLE
ramips: add support for TP-Link TL-WR841HP v5

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr841hp-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr841hp-v5.dts
@@ -1,0 +1,88 @@
+#include "mt7628an_tplink_8m.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr841hp-v5", "mediatek,mt7628an-soc";
+	model = "TP-Link TL-WR841HP v5";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		
+		reset {
+			label = "reset";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+		
+		wps {
+			label = "wps";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "green:wps";
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+		
+		wan_green {
+			label = "green:wan";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_orange {
+			label = "orange:wan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&state_default {
+	gpio {
+		groups = "gpio", "p0led_an", "p1led_an", "p2led_an", "p3led_an", "p4led_an", "perst", "refclk", "uart1", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -701,6 +701,21 @@ define Device/tplink_tl-wr840n-v5
 endef
 TARGET_DEVICES += tplink_tl-wr840n-v5
 
+define Device/tplink_tl-wr841hp-v5
+  $(Device/tplink-v2)
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := TL-WR841HP
+  DEVICE_VARIANT := v5
+  TPLINK_FLASHLAYOUT := 8Mmtk
+  TPLINK_HWID := 0x08411005
+  TPLINK_HWREV := 0x269
+  TPLINK_HWREVADD := 0x5
+  IMAGES := sysupgrade.bin tftp-recovery.bin
+  IMAGE/tftp-recovery.bin := pad-extra 128k | $$(IMAGE/factory.bin)
+  SUPPORTED_DEVICES += tl-wr841hp-v5
+endef
+TARGET_DEVICES += tplink_tl-wr841hp-v5
+
 define Device/tplink_tl-wr841n-v13
   $(Device/tplink-v2)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -83,6 +83,7 @@ tplink,tl-wa801nd-v5)
 	;;
 tplink,tl-mr3420-v5|\
 tplink,tl-wr840n-v4|\
+tplink,tl-wr841hp-v5|\
 tplink,tl-wr842n-v5)
 	ucidef_set_led_wlan "wlan2g" "wlan2g" "green:wlan" "phy0tpt"
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x1e"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -47,6 +47,7 @@ ramips_setup_interfaces()
 	tplink,tl-mr3420-v5|\
 	tplink,tl-wr840n-v4|\
 	tplink,tl-wr840n-v5|\
+	tplink,tl-wr841hp-v5|\
 	tplink,tl-wr841n-v13|\
 	tplink,tl-wr841n-v14|\
 	tplink,tl-wr842n-v5|\


### PR DESCRIPTION
Initial support for TP-Link TL-WR841HP v5.
TP-Link TL-WR841HP v5 is a router based on the MediaTek MT7628AN SoC. It is similar to the TP-Link TL-WR841N v13 with the exception of additional RF booster chips and detachable antennas.

Specifications:
 - SOC:		MediaTek MT7628AN
 - RAM:		64 MB
 - ROM:		8 MB
 - Antennas: 	2x2:2 2.4 Ghz detachable
 - Buttons: 	reset *1 + rfkill *1 + wps *2
 - Ethernet: 	lan *3 + wan *1 (10/100 Mbps)
 - TTL baudrate: 	115200

Installation:

It is advisable to perform the installation through tftp recovery method

 - Configure your computer with the static IP of 192.168.0.66/24 and start a tftp server of your choice
 - Copy the 'openwrt-ramips-mt76x8-tplink_tl-wr841hp-v5-squashfs-factory.bin' file to the root directory of the tftp server and rename it to 'tp_recovery.bin'
 - Connect your computer to one of the LAN ports on the router then press and hold the reset button while powering the device on
 - Keep it pressed for about 5-6 seconds until the router starts downloading the file
 - Wait for the router to install the newly downloaded firmware and reboot
 
Signed-off-by: Đào Anh <lap1234.lpo@gmail.com>
