### PR TITLE
mac80211: fix tx_burst parameter reading for tx bursting when using VHT

### DIFF
--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -138,7 +138,8 @@ mac80211_hostapd_setup_base() {
 		append base_cfg "acs_exclude_dfs=1" "$N"
 
 	json_get_vars noscan ht_coex min_tx_power:0
-	json_get_values ht_capab_list ht_capab tx_burst
+	json_get_values ht_capab_list ht_capab
+	json_get_vars tx_burst
 	json_get_values channel_list channels
 
 	[ "$auto_channel" = 0 ] && [ -z "$channel_list" ] && \


### PR DESCRIPTION
By default, BE tx queue TXOP limit is set by default to 2.0 in the hostapd config. Without this fix "option tx_burst" won't be read properly and tx_queue_data2_burst value won't be updated in hostapd-phy*.conf.