### PR TITLE
realtek/mips/Kconfig: Fix typo

### DIFF
--- a/target/linux/realtek/patches-5.10/300-mips-add-rtl838x-platform.patch
+++ b/target/linux/realtek/patches-5.10/300-mips-add-rtl838x-platform.patch
@@ -49,7 +49,7 @@
 +	select SYS_SUPPORTS_MULTITHREADING
 +
 +config RTL930X
-+	bool "Realtek RTL839X based platforms"
++	bool "Realtek RTL930X based platforms"
 +	depends on RTL83XX
 +	select MIPS_CPU_SCACHE
 +	select CSRC_R4K


### PR DESCRIPTION
As the symbol RTL930x shows, the bool enables the RTL930x platform, not
the RTL839x one.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>