### PR TITLE
lantiq: fix lan port 3+4 phy-mode settings for Fritzbox 3390

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
@@ -170,14 +170,14 @@
 	port@0 {
 		reg = <0>;
 		label = "lan3";
-		phy-mode = "rgmii";
+		phy-mode = "rgmii-rxid";
 		phy-handle = <&phy0>;
 	};
 
 	port@1 {
 		reg = <1>;
 		label = "lan4";
-		phy-mode = "rgmii";
+		phy-mode = "rgmii-rxid";
 		phy-handle = <&phy1>;
 	};
 


### PR DESCRIPTION
There are forum reports that 2 LAN ports are still not working,
the phy-mode settings are adjusted to fix the problem.

Fixes: #10371
Signed-off-by: Daniel Kestrel <kestrel1974@t-online.de>