### PR TITLE
ramips: add support for Mikrotik LtAP

### DIFF
--- a/target/linux/ramips/dts/mt7621_mikrotik_ltap-2hnd.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_ltap-2hnd.dts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_mikrotik.dtsi"
+
+/ {
+	compatible = "mikrotik,ltap-2hnd", "mediatek,mt7621-soc";
+	model = "MikroTik RouterBOARD LtAP-2HnD";
+
+	aliases {
+		led-boot = &led_usr;
+		led-failsafe = &led_usr;
+		led-running = &led_usr;
+		led-upgrade = &led_usr;
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		rssi0 {
+			label = "green:rssi0";
+			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
+		};
+		rssi1 {
+			label = "green:rssi1";
+			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
+		};
+		rssi2 {
+			label = "green:rssi2";
+			gpios = <&ath9k 2 GPIO_ACTIVE_LOW>;
+		};
+		rssi3 {
+			label = "green:rssi3";
+			gpios = <&ath9k 3 GPIO_ACTIVE_LOW>;
+		};
+		rssi4 {
+			label = "green:rssi4";
+			gpios = <&ath9k 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pwr {
+			label = "blue:pwr";
+			gpios = <&gpio 23 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led_usr: usr {
+			label = "green:usr";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		gps {
+			label = "green:gps";
+			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	/* TODO: find GPIOs for the WLAN antenna switches */
+	gpio-export {
+		compatible = "gpio-export";
+
+		usb-select {
+			gpio-export,name = "usb-select";
+			gpio-export,output = <1>;
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		};
+		gps-reset {
+			gpio-export,name = "gps-reset";
+			gpio-export,output = <1>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+		sim-select {
+			gpio-export,name = "sim-select";
+			gpio-export,output = <1>;
+			gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
+		};
+		gps-ant-select {
+			/* internal antenna = 0 */
+			gpio-export,name = "gps-ant-select";
+			gpio-export,output = <0>;
+			gpios = <&gpio 27 GPIO_ACTIVE_HIGH>;
+		};
+		lte-reset {
+			gpio-export,name = "lte-reset";
+			gpio-export,output = <1>;
+			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	pps {
+		compatible = "pps-gpio";
+		gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+	};
+
+	pcie1_vcc_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "pcie1_vcc";
+
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&gpio 10 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+	};
+
+	pcie2_vcc_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "pcie2_vcc";
+
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+	};
+};
+
+&partitions {
+	partition@40000 {
+		compatible = "mikrotik,minor";
+		label = "firmware";
+		reg = <0x040000 0xfc0000>;
+	};
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,0030";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+		gpio-controller;
+		#gpio-cells = <2>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "wdt", "rgmii2";
+		function = "gpio";
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&uartlite3 {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1350,6 +1350,13 @@ define Device/MikroTik
 	append-metadata
 endef
 
+define Device/mikrotik_ltap-2hnd
+  $(Device/MikroTik)
+  DEVICE_MODEL := LtAP-2HnD
+  DEVICE_PACKAGES += kmod-ath9k kmod-pps-gpio rssileds
+endef
+TARGET_DEVICES += mikrotik_ltap-2hnd
+
 define Device/mikrotik_routerboard-750gr3
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD 750Gr3

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -95,6 +95,7 @@ linksys,ea8100-v2)
 mikrotik,routerboard-760igs)
 	ucidef_set_led_netdev "sfp" "SFP" "blue:sfp" "sfp"
 	;;
+mikrotik,ltap-2hnd|\
 mikrotik,routerboard-m11g)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "green:rssi0" "wlan0" "1" "100"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -12,6 +12,7 @@ ramips_setup_interfaces()
 	asus,rp-ac56|\
 	asus,rp-ac87|\
 	edimax,re23s|\
+	mikrotik,ltap-2hnd|\
 	mikrotik,routerboard-m11g|\
 	netgear,ex6150|\
 	sercomm,na502|\
@@ -218,6 +219,9 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii Config lan_hwaddr)
 		wan_mac=$(mtd_get_mac_ascii Config wan_hwaddr)
 		label_mac=$lan_mac
+	mikrotik,ltap-2hnd)
+		label_mac=$(cat "/sys/firmware/mikrotik/hard_config/mac_base")
+		lan_mac=$label_mac
 		;;
 	tplink,mr600-v2-eu)
 		label_mac=$(cat "/sys/class/net/eth0/address")

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+[ -e /lib/firmware/$FIRMWARE ] && exit 0
+
+. /lib/functions/caldata.sh
+
+caldata_mikrotik_ath9k() {
+	local offset=$(($1))
+	local count=$(($2))
+	local macaddr=$3
+	local wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"
+
+	caldata_from_file $wlan_data $offset $count /tmp/$FIRMWARE
+	ath9k_patch_mac "$macaddr" /tmp/$FIRMWARE
+	caldata_sysfsload_from_file /tmp/$FIRMWARE 0x0 $count
+	rm -f /tmp/$FIRMWARE
+}
+
+board=$(board_name)
+
+case "$FIRMWARE" in
+"ath9k-eeprom-pci-0000:01:00.0.bin")
+	case $board in
+	mikrotik,ltap-2hnd)
+		mac_base="$(cat /sys/firmware/mikrotik/hard_config/mac_base)"
+		caldata_mikrotik_ath9k 0x5000 0x440 $(macaddr_add "$mac_base" 1)
+		;;
+	*)
+		caldata_die "board $board is not supported yet"
+		;;
+	esac
+	;;
+esac

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -33,6 +33,7 @@ platform_do_upgrade() {
 			fw_setenv --lock / bootImage 0 || exit 1
 		fi
 		;;
+	mikrotik,ltap-2hnd|\
 	mikrotik,routerboard-750gr3|\
 	mikrotik,routerboard-760igs|\
 	mikrotik,routerboard-m11g|\


### PR DESCRIPTION
ramips: add support for Mikrotik LtAP-2HnD

Mikrotik LtAP-2HnD is a outdoor/car WLAN 4 router with integrated GPS receiver and two mPCIe slots.

Specifications:
* SoC: MT7621A
* RAM: 128 MiB Nanya NT5CC64M16GP-DI
* Flash: 16 MiB winbond W25Q128JV
* WLAN: 
  * Atheros AR9382 with power amplifier SKY 85330 (2x2 internal antennas, with RF switches for external connectors)
* Ethernet: 1 Gbps, single port
* USB Host: USB 2.0 Speeds
* Serial: 115200 baud
* LEDs: Power, System, GPS, 5* RSSI
*  mPCIe:
   * miniPCIe slot 1: PCIe and USB 2.0 Host (via switch shared with USB Host interface on outside)
   * miniPCIe slot 2: USB 2.0 and 3.0
* SIM Cards:
  * Slot 1 Connected to mPCIe slot 1
  * Slot 2 and 3 connected to mPCIe slot 2 via switch
* GPS: MTK 3333 on serial port 2 (/dev/ttyS1), 115200 baud and PPS on pin gpiochip0, pin 14

Installation:

1. TFTP boot openwrt
2. sysupgrade
