### PR TITLE
ramips: improve support for ASUS RT-AX53U

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -28,8 +28,44 @@
 
 		led_power: led-0 {
 			color = <LED_COLOR_ID_BLUE>;
-                        function = LED_FUNCTION_POWER;
+			function = LED_FUNCTION_POWER;
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_usb: led-7 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_USB;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+
+		lan1 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&switch0 3 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&switch0 6 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&switch0 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&switch0 0 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -127,6 +163,9 @@
 };
 
 &switch0 {
+	gpio-controller;
+	#gpio-cells = <2>;
+
 	ports {
 		port@0 {
 			status = "okay";
@@ -146,11 +185,6 @@
 		port@3 {
 			status = "okay";
 			label = "lan3";
-		};
-
-		port@4 {
-			status = "okay";
-			label = "lan4";
 		};
 	};
 };

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -289,7 +289,8 @@ define Device/asus_rt-ax53u
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
-  DEVICE_PACKAGES := kmod-mt7915e kmod-usb3 uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915e kmod-usb3 kmod-usb-ledtrig-usbport \
+	uboot-envtools
 endef
 TARGET_DEVICES += asus_rt-ax53u
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -23,6 +23,12 @@ asus,rt-n56u-b1)
 	ucidef_set_led_netdev "lan" "LAN link" "blue:lan" "br-lan"
 	ucidef_set_led_netdev "wan" "WAN link" "blue:wan" "wan"
 	;;
+asus,rt-ax53u)
+	ucidef_set_led_netdev "lan1" "lan1" "blue:lan-1" "lan1"
+	ucidef_set_led_netdev "lan2" "lan2" "blue:lan-2" "lan2"
+	ucidef_set_led_netdev "lan3" "lan3" "blue:lan-3" "lan3"
+	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
+	;;
 beeline,smartbox-flash|\
 beeline,smartbox-giga)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"


### PR DESCRIPTION
- remove nonexistent lan4 port
- add control for leds: lan1-lan3, wan, usb
- set pwr led on by default
- formatting fix

Signed-off-by: Rozhuk Ivan <rozhuk.im@gmail.com>
