### PR TITLE
trace-cmd: import patch to fix autodetection of libzstd

### DIFF
--- a/package/devel/trace-cmd/Makefile
+++ b/package/devel/trace-cmd/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=trace-cmd
 PKG_VERSION:=v3.1.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/snapshot/
@@ -34,6 +34,7 @@ endef
 MAKE_FLAGS += \
 	NO_PYTHON=1 \
 	NO_AUDIT=1 \
+	NO_LIBZSTD=1 \
 	prefix=/usr
 
 TARGET_CFLAGS += --std=gnu99 -D_GNU_SOURCE

--- a/package/devel/trace-cmd/patches/100-tracecmd-add-NO_LIBZSTD-option-to-disable-libzstd.patch
+++ b/package/devel/trace-cmd/patches/100-tracecmd-add-NO_LIBZSTD-option-to-disable-libzstd.patch
@@ -1,0 +1,38 @@
+From 4fcc23ee4291f445cada012b6bef6879274a25f1 Mon Sep 17 00:00:00 2001
+From: Nick Hainke <vincent@systemli.org>
+Date: Sun, 7 Aug 2022 10:11:06 +0200
+Subject: [PATCH] tracecmd: add NO_LIBZSTD option to disable libzstd
+
+Other Linux kernel tools like perf already include options to disable
+libzstd manually. Add this option also to trace-cmd.
+
+The OpenWrt SDK fails to build trace-cmd due to the autodetection of
+libzstd. The package is present in some feed repositories but should
+not be used by trace-cmd. The compilation will fail with:
+
+  Package trace-cmd is missing dependencies for the following libraries:
+  libzstd.so.1
+
+Signed-off-by: Nick Hainke <vincent@systemli.org>
+---
+ Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/Makefile
++++ b/Makefile
+@@ -320,6 +320,7 @@ CFLAGS += -DHAVE_ZLIB
+ $(info    Have zlib compression support)
+ endif
+ 
++ifndef NO_LIBZSTD
+ TEST_LIBZSTD = $(shell sh -c "$(PKG_CONFIG) --atleast-version 1.4.0 libzstd > /dev/null 2>&1 && echo y")
+ 
+ ifeq ("$(TEST_LIBZSTD)", "y")
+@@ -335,6 +336,7 @@ $(info	  *******************************
+ endif
+ 
+ export LIBZSTD_CFLAGS LIBZSTD_LDLAGS ZSTD_INSTALLED
++endif
+ 
+ CUNIT_INSTALLED := $(shell if (printf "$(pound)include <CUnit/Basic.h>\n void main(){CU_initialize_registry();}" | $(CC) -o /dev/null -x c - -lcunit >/dev/null 2>&1) ; then echo 1; else echo 0 ; fi)
+ export CUNIT_INSTALLED


### PR DESCRIPTION
libzstd from the packages feed gets picked up. Add patch adding
NO_LIBZSTD option like in perf and enable it.

Signed-off-by: Nick Hainke <vincent@systemli.org>