### PR TITLE
binutils: update to 2.39

### DIFF
--- a/package/devel/binutils/Makefile
+++ b/package/devel/binutils/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=binutils
-PKG_VERSION:=2.38
+PKG_VERSION:=2.39
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@GNU/binutils
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_VERSION:=$(PKG_VERSION)
-PKG_HASH:=e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024
+PKG_HASH:=645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00
 
 PKG_FIXUP:=patch-libtool
 PKG_LIBTOOL_PATHS:=. gas bfd opcodes gprof binutils ld libiberty gold intl


### PR DESCRIPTION
Changes:

* The ELF linker will now generate a warning message if the stack is made
  executable.  Similarly it will warn if the output binary contains a
  segment with all three of the read, write and execute permission
  bits set.  These warnings are intended to help developers identify
  programs which might be vulnerable to attack via these executable
  memory regions.
  The warnings are enabled by default but can be disabled via a command
  line option.  It is also possible to build a linker with the warnings
  disabled, should that be necessary.
* The ELF linker now supports a --package-metadata option that allows
  embedding a JSON payload in accordance to the Package Metadata
  specification.
* In linker scripts it is now possible to use TYPE=<type> in an output
  section description to set the section type value.
* The objdump program now supports coloured/colored syntax
  highlighting of its disassembler output for some architectures.
  (Currently: AVR, RiscV, s390, x86, x86_64).
* The nm program now supports a --no-weak/-W option to make it ignore
  weak symbols.
* The readelf and objdump programs now support a -wE option to prevent
  them from attempting to access debuginfod servers when following
  links.
* The objcopy program's --weaken, --weaken-symbol, and
  --weaken-symbols options now works with unique symbols as well.

Announcement:
https://sourceware.org/pipermail/binutils/2022-August/122246.html

