### PR TITLE
kernel: FQ-PIE as an optional sched kmod

### DIFF
--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -892,6 +892,22 @@ endef
 $(eval $(call KernelPackage,sched-flower))
 
 
+define KernelPackage/sched-fq-pie
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
+  TITLE:=Flow Queue Proportional Integral Enhanced (FQ-PIE)
+  DEPENDS:=+kmod-sched-core +kmod-sched-pie
+  KCONFIG:=CONFIG_NET_SCH_FQ_PIE
+  FILES:=$(LINUX_DIR)/net/sched/sch_fq_pie.ko
+  AUTOLOAD:=$(call AutoProbe, sch_fq_pie)
+endef
+
+define KernelPackage/sched-fq-pie/description
+  A queuing discipline that combines Flow Queuing with the PIE AQM.
+endef
+
+$(eval $(call KernelPackage,sched-fq-pie))
+
+
 define KernelPackage/sched-ipset
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=Traffic shaper ipset support
@@ -920,6 +936,22 @@ define KernelPackage/sched-mqprio/description
 endef
 
 $(eval $(call KernelPackage,sched-mqprio))
+
+
+define KernelPackage/sched-pie
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
+  TITLE:=Proportional Integral controller-Enhanced AQM (PIE)
+  DEPENDS:=+kmod-sched-core
+  KCONFIG:=CONFIG_NET_SCH_PIE
+  FILES:=$(LINUX_DIR)/net/sched/sch_pie.ko
+  AUTOLOAD:=$(call AutoProbe, sch_pie)
+endef
+
+define KernelPackage/sched-pie/description
+  A control theoretic active queue management scheme.
+endef
+
+$(eval $(call KernelPackage,sched-pie))
 
 
 define KernelPackage/sched-prio
@@ -964,7 +996,7 @@ endef
 $(eval $(call KernelPackage,bpf-test))
 
 
-SCHED_MODULES_EXTRA = sch_codel sch_dsmark sch_gred sch_multiq sch_sfq sch_teql sch_fq sch_pie act_pedit act_simple act_csum em_cmp em_nbyte em_meta em_text
+SCHED_MODULES_EXTRA = sch_codel sch_dsmark sch_gred sch_multiq sch_sfq sch_teql sch_fq act_pedit act_simple act_csum em_cmp em_nbyte em_meta em_text
 SCHED_FILES_EXTRA = $(foreach mod,$(SCHED_MODULES_EXTRA),$(LINUX_DIR)/net/sched/$(mod).ko)
 
 define KernelPackage/sched
@@ -979,7 +1011,6 @@ define KernelPackage/sched
 	CONFIG_NET_SCH_SFQ \
 	CONFIG_NET_SCH_TEQL \
 	CONFIG_NET_SCH_FQ \
-	CONFIG_NET_SCH_PIE \
 	CONFIG_NET_ACT_PEDIT \
 	CONFIG_NET_ACT_SIMP \
 	CONFIG_NET_ACT_CSUM \


### PR DESCRIPTION
add Flow Queuing w Proportional Integral controller Enhanced as an optional kmod in network support

updated variation of [PR10088 (stalled?)](https://github.com/openwrt/openwrt/pull/10088), but optional rather than adding to sched_modules_extra, kmod is ~10k

```
root@mamba:/lib/modules/5.15.59# ls -las *pie*
    11 -rw-r--r--    1 root     root         10920 Aug  7 08:17 sch_fq_pie.ko
    11 -rw-r--r--    1 root     root         11636 Aug  7 08:17 sch_pie.ko
```

compile / test : mvebu (mamba, rango)

Signed-off-by: Kabuli Chana <newtownBuild@gmail.com>
