### PR TITLE
wolfssl: add libwolfssl-cpu-crypto package

### DIFF
--- a/package/libs/wolfssl/Config.in
+++ b/package/libs/wolfssl/Config.in
@@ -1,4 +1,4 @@
-if PACKAGE_libwolfssl
+menu "wolfSSL Library Configuration"
 
 config WOLFSSL_HAS_AES_CCM
 	bool "Include AES-CCM support"
@@ -66,38 +66,31 @@ config WOLFSSL_ALT_NAMES
 config WOLFSSL_HAS_DEVCRYPTO
 	bool
 
-config WOLFSSL_ASM_CAPABLE
-	bool
-	default x86_64 || (aarch64 && !TARGET_bcm27xx)
+if PACKAGE_libwolfssl
+	if PACKAGE_libwolfssl-cpu-crypto
+		comment "Hardware Acceleration does not apply to libwolfssl-cpu-crypto"
+	endif
+	choice
+		prompt "Hardware Acceleration"
+		default WOLFSSL_HAS_NO_HW
 
-choice
-	prompt "Hardware Acceleration"
-	default WOLFSSL_HAS_NO_HW
+		config WOLFSSL_HAS_NO_HW
+			bool "None"
 
-	config WOLFSSL_HAS_NO_HW
-		bool "None"
+		config WOLFSSL_HAS_AFALG
+			bool "AF_ALG"
 
-	config WOLFSSL_HAS_CPU_CRYPTO
-		bool "Use CPU crypto instructions"
-		depends on WOLFSSL_ASM_CAPABLE
-		help
-		This will use Intel AESNI insturctions or armv8 Crypto Extensions.
-		Either of them should easily outperform hardware crypto in WolfSSL.
+		config WOLFSSL_HAS_DEVCRYPTO_CBC
+			bool "/dev/crytpo - AES-CBC-only"
+			select WOLFSSL_HAS_DEVCRYPTO
 
-	config WOLFSSL_HAS_AFALG
-		bool "AF_ALG"
+		config WOLFSSL_HAS_DEVCRYPTO_AES
+			bool "/dev/crypto - AES-only (all supported modes)"
+			select WOLFSSL_HAS_DEVCRYPTO
 
-	config WOLFSSL_HAS_DEVCRYPTO_CBC
-		bool "/dev/crytpo - AES-CBC-only"
-		select WOLFSSL_HAS_DEVCRYPTO
-
-	config WOLFSSL_HAS_DEVCRYPTO_AES
-		bool "/dev/crypto - AES-only (all supported modes)"
-		select WOLFSSL_HAS_DEVCRYPTO
-
-	config WOLFSSL_HAS_DEVCRYPTO_FULL
-		bool "/dev/crypto - full"
-		select WOLFSSL_HAS_DEVCRYPTO
-endchoice
-
+		config WOLFSSL_HAS_DEVCRYPTO_FULL
+			bool "/dev/crypto - full"
+			select WOLFSSL_HAS_DEVCRYPTO
+	endchoice
 endif
+endmenu

--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -45,7 +45,6 @@ PKG_ABI_VERSION:=$(patsubst %-stable,%,$(PKG_VERSION)).$(call version_abbrev,$(c
 
 PKG_CONFIG_DEPENDS+=\
 	CONFIG_WOLFSSL_HAS_AFALG \
-	CONFIG_WOLFSSL_HAS_CPU_CRYPTO \
 	CONFIG_WOLFSSL_HAS_DEVCRYPTO_AES \
 	CONFIG_WOLFSSL_HAS_DEVCRYPTO_CBC \
 	CONFIG_WOLFSSL_HAS_DEVCRYPTO_FULL
@@ -66,6 +65,9 @@ $(call Package/libwolfssl/Default)
   PROVIDES:=libcyassl
   DEPENDS:=+WOLFSSL_HAS_DEVCRYPTO:kmod-cryptodev +WOLFSSL_HAS_AFALG:kmod-crypto-user
   ABI_VERSION:=$(PKG_ABI_VERSION)
+  VARIANT:=regular
+  DEFAULT_VARIANT:=1
+  CONFLICTS:=libwolfssl-cpu-crypto
 endef
 
 define Package/libwolfssl/description
@@ -77,10 +79,36 @@ define Package/libwolfssl/config
 	source "$(SOURCE)/Config.in"
 endef
 
+define Package/libwolfssl-cpu-crypto
+$(call Package/libwolfssl/Default)
+  TITLE:=wolfSSL library with AES CPU instructions
+  PROVIDES:=libwolfssl libcyassl
+  DEPENDS:=@((aarch64||x86_64)&&(m||!TARGET_bcm27xx))
+  ABI_VERSION:=$(PKG_ABI_VERSION)
+  VARIANT:=cpu-crypto
+endef
+
 define Package/libwolfssl-benchmark
 $(call Package/libwolfssl/Default)
   TITLE:=wolfSSL Benchmark Utility
   DEPENDS:=libwolfssl
+endef
+
+define Package/libwolfssl-cpu-crypto/description
+$(call Package/libwolfssl/description)
+This variant uses AES CPU instructions (Intel AESNI or ARMv8 Crypto Extension)
+endef
+
+define Package/libwolfssl-cpu-crypto/config
+    if TARGET_armvirt && PACKAGE_libwolfssl-cpu-crypto = y
+	comment "You are about to build libwolfssl-cpu-crypto into an armvirt_64 image."
+	comment "Ensure all of your installation targets support the Crypto Extension. "
+	comment "Look for the 'aes' feature in /proc/cpuinfo. This library does not do "
+	comment "run-time detection and will crash if the CPU does not support it.     "
+    endif
+    if TARGET_bcm27xx && PACKAGE_libwolfssl-cpu-crypto
+	comment "Beware that libwolfssl-cpu-crypto will not run in a bcm27xx target.   "
+    endif
 endef
 
 define Package/libwolfssl-benchmark/description
@@ -121,11 +149,23 @@ CONFIGURE_ARGS += \
 	--$(if $(CONFIG_WOLFSSL_HAS_DTLS),enable,disable)-dtls \
 	--$(if $(CONFIG_WOLFSSL_HAS_ECC25519),enable,disable)-curve25519 \
 	--$(if $(CONFIG_WOLFSSL_HAS_ECC448),enable,disable)-curve448 \
+	--$(if $(CONFIG_WOLFSSL_HAS_OPENVPN),enable,disable)-openvpn
+
+ifeq ($(BUILD_VARIANT),regular)
+CONFIGURE_ARGS += \
 	--$(if $(CONFIG_WOLFSSL_HAS_AFALG),enable,disable)-afalg \
-	--$(if $(CONFIG_WOLFSSL_HAS_OPENVPN),enable,disable)-openvpn \
 	--enable-devcrypto=$(if $(CONFIG_WOLFSSL_HAS_DEVCRYPTO_CBC),cbc\
 			  ,$(if $(CONFIG_WOLFSSL_HAS_DEVCRYPTO_AES),aes\
 			  ,$(if $(CONFIG_WOLFSSL_HAS_DEVCRYPTO_FULL),yes,no)))
+else ifdef CONFIG_aarch64
+    CONFIGURE_ARGS += --enable-armasm
+    TARGET_CFLAGS:=$(TARGET_CFLAGS:-mcpu%=-mcpu%+crypto)
+    WOLFSSL_NOASM_REGEX:=^bcm27xx/.*
+    Package/libwolfssl-cpu-crypto/preinst=\
+	$(subst @@WOLFSSL_NOASM_REGEX@@,$(WOLFSSL_NOASM_REGEX),$(file <preinst.arm-ce))
+else ifdef CONFIG_TARGET_x86_64
+	CONFIGURE_ARGS += --enable-intelasm
+endif
 
 ifeq ($(CONFIG_WOLFSSL_HAS_OCSP),y)
 CONFIGURE_ARGS += \
@@ -135,15 +175,6 @@ endif
 ifeq ($(CONFIG_WOLFSSL_HAS_WPAS),y)
 CONFIGURE_ARGS += \
 	--enable-wpas --enable-fortress --enable-fastmath
-endif
-
-ifdef CONFIG_WOLFSSL_HAS_CPU_CRYPTO
-    ifdef CONFIG_aarch64
-	CONFIGURE_ARGS += --enable-armasm
-	TARGET_CFLAGS:=$(TARGET_CFLAGS:-mcpu%=-mcpu%+crypto)
-    else ifdef CONFIG_TARGET_x86_64
-	CONFIGURE_ARGS += --enable-intelasm
-    endif
 endif
 
 define Build/InstallDev
@@ -163,10 +194,13 @@ define Package/libwolfssl/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libwolfssl.so.* $(1)/usr/lib/
 endef
 
+Package/libwolfssl-cpu-crypto/install=$(Package/libwolfssl/install)
+
 define Package/libwolfssl-benchmark/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(CP) $(PKG_BUILD_DIR)/wolfcrypt/benchmark/.libs/benchmark $(1)/usr/bin/wolfssl-benchmark
 endef
 
 $(eval $(call BuildPackage,libwolfssl))
+$(eval $(call BuildPackage,libwolfssl-cpu-crypto))
 $(eval $(call BuildPackage,libwolfssl-benchmark))

--- a/package/libs/wolfssl/preinst.arm-ce
+++ b/package/libs/wolfssl/preinst.arm-ce
@@ -1,0 +1,25 @@
+#!/bin/sh
+exec >&2
+printf "[libwolfssl-cpu-crypto] Checking for Arm v8-A Cryptographic Extension support: "
+if [ -n "${IPKG_INSTROOT}" ]; then
+    printf "...[offline]... "
+    eval "$(grep '^DISTRIB_TARGET=' "${IPKG_INSTROOT}/etc/openwrt_release")"
+    ### @@WOLFSSL_NOASM_REGEX@@ is expanded from WOLFSSL_NOASM_REGEX in the Makefile
+    echo "${DISTRIB_TARGET}" | grep '@@WOLFSSL_NOASM_REGEX@@' > /dev/null && {
+	echo "not supported"
+	echo "Error: Target ${DISTRIB_TARGET} does not support Arm Cryptographic Extension."
+	echo "Install the regular libwolfssl package instead of libwolfssl-cpu-crypto."
+	exit 1
+    }
+else
+    grep -q '^Features.*\baes\b' /proc/cpuinfo || {
+	echo "not supported"
+	echo "Error: Arm v8-A Cryptographic Extension not supported."
+	echo "Install the regular libwolfssl package instead of libwolfssl-cpu-crypto."
+	echo "Contents of /proc/cpuinfo:"
+	cat /proc/cpuinfo
+	exit 1
+    }
+fi
+echo OK
+exit 0


### PR DESCRIPTION
libwolfssl-cpu-crypto is a variant of libwolfssl with support for
cryptographic CPU instructions on x86_64 and aarch64.

On aarch64, wolfSSL does not perform run-time detection, so the library
will crash when the AES functions are called.  A preinst script attempts
to check for support by querying /proc/cpuinfo, if installed in a
running system.  When building an image, the script will check the
DISTRIB_TARGET value in /etc/openwrt_release, and will abort
installation if target is bcm27xx.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

----

This was tested on mediatek, using the regular build system, installing it into a running system, and building an image with the image builder.