### PR TITLE
ltq-vdsl-app: extend ubus with dsl statistics

### DIFF
--- a/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
+++ b/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
@@ -431,7 +431,7 @@ static void g977_get_snr(int fd, DSL_AccessDir_t direction) {
 	void *c = blobmsg_open_array(&b, "data");
 	
 	for (uint16_t i  = 0  ; i < out.data.deltSnr.nNumData ; i++) { //uint16_t i = 0; i < len; ++i
-		if (out.data.deltSnr.nNSCData[i] != 255) {
+		if (out.data.deltSnr.nNSCData[i] != 255 && out.data.deltSnr.nNSCData[i] != 255 != 0) {
 			m_double("", -32 + (double)out.data.deltSnr.nNSCData[i] / 2); // SNR -32 ... 95 dB
 		} else {
 			m_str("", "NaN");
@@ -449,7 +449,7 @@ static void g977_get_qln(int fd, DSL_AccessDir_t direction) {
 	void *c = blobmsg_open_array(&b, "data");
 	
 	for (uint16_t i  = 0  ; i < out.data.deltQln.nNumData ; i++) {
-		if (out.data.deltQln.nNSCData[i] != 255) {
+		if (out.data.deltQln.nNSCData[i] != 255 && out.data.deltQln.nNSCData[i] != 0) {
 			m_double("", -23 - (double)out.data.deltQln.nNSCData[i] / 2); // QLN -150 ... -23 dBm/Hz
 		} else {
 			m_str("", "NaN");
@@ -468,7 +468,7 @@ static void g977_get_hlog(int fd, DSL_AccessDir_t direction) {
 	void *c = blobmsg_open_array(&b, "data");
 	
 	for (uint16_t i  = 0  ; i < out.data.deltHlog.nNumData ; i++) {
-		if (out.data.deltHlog.nNSCData[i] != 1023) {
+		if (out.data.deltHlog.nNSCData[i] != 1023 && out.data.deltHlog.nNSCData[i] != 0) {
 			m_double("", 6 - (double)out.data.deltHlog.nNSCData[i] / 10); // HLOG +6 ... -96 dB
 		} else {
 			m_str("", "NaN");

--- a/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
+++ b/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <math.h>
 
 #include "dsl_cpe_control.h"
 #include <drv_dsl_cpe_api_ioctl.h>
@@ -138,7 +139,11 @@ static struct ubus_context *ctx;
 static struct blob_buf b;
 
 static inline void m_double(const char *id, double value) {
-	blobmsg_add_double(&b, id, value);
+	if (!isnan(value)) {
+		blobmsg_add_double(&b, id, value);
+	} else {
+		blobmsg_add_string(&b, id, "none");
+	}
 }
 
 static inline void m_bool(const char *id, bool value) {
@@ -431,10 +436,10 @@ static void g977_get_snr(int fd, DSL_AccessDir_t direction) {
 	void *c = blobmsg_open_array(&b, "data");
 	
 	for (uint16_t i  = 0  ; i < out.data.deltSnr.nNumData ; i++) { //uint16_t i = 0; i < len; ++i
-		if (out.data.deltSnr.nNSCData[i] != 255 && out.data.deltSnr.nNSCData[i] != 255 != 0) {
+		if (out.data.deltSnr.nNSCData[i] != 255 && out.data.deltSnr.nNSCData[i] != 0) {
 			m_double("", -32 + (double)out.data.deltSnr.nNSCData[i] / 2); // SNR -32 ... 95 dB
 		} else {
-			m_str("", "NaN");
+                        m_double("", NAN);
 		}
 	};
 	
@@ -452,7 +457,7 @@ static void g977_get_qln(int fd, DSL_AccessDir_t direction) {
 		if (out.data.deltQln.nNSCData[i] != 255 && out.data.deltQln.nNSCData[i] != 0) {
 			m_double("", -23 - (double)out.data.deltQln.nNSCData[i] / 2); // QLN -150 ... -23 dBm/Hz
 		} else {
-			m_str("", "NaN");
+                        m_double("", NAN);
 		}
 	};
 	
@@ -471,7 +476,7 @@ static void g977_get_hlog(int fd, DSL_AccessDir_t direction) {
 		if (out.data.deltHlog.nNSCData[i] != 1023 && out.data.deltHlog.nNSCData[i] != 0) {
 			m_double("", 6 - (double)out.data.deltHlog.nNSCData[i] / 10); // HLOG +6 ... -96 dB
 		} else {
-			m_str("", "NaN");
+                        m_double("", NAN);
 		}
 	};
 

--- a/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
+++ b/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
@@ -464,7 +464,6 @@ static void g977_get_qln(int fd, DSL_AccessDir_t direction) {
 	blobmsg_close_array(&b, c);
 }
 
-
 static void g977_get_hlog(int fd, DSL_AccessDir_t direction) {
 	IOCTL_DIR_DELT(DSL_G997_DeltHlog_t, DSL_FIO_G997_DELT_HLOG_GET, direction, DSL_DELT_DATA_SHOWTIME);
 	m_u32("groupsize", out.data.nGroupSize);
@@ -482,7 +481,6 @@ static void g977_get_hlog(int fd, DSL_AccessDir_t direction) {
 
 	blobmsg_close_array(&b, c);
 }
-
 
 static void g997_power_management_status(int fd) {
 	IOCTL(DSL_G997_PowerManagementStatus_t, DSL_FIO_G997_POWER_MANAGEMENT_STATUS_GET)

--- a/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
+++ b/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
@@ -138,12 +138,12 @@ static DSL_CPE_ThreadCtrl_t thread;
 static struct ubus_context *ctx;
 static struct blob_buf b;
 
+static inline void m_null() {
+	blobmsg_add_field(&b, BLOBMSG_TYPE_UNSPEC, "", NULL, 0);
+}
+
 static inline void m_double(const char *id, double value) {
-	if (!isnan(value)) {
-		blobmsg_add_double(&b, id, value);
-	} else {
-		blobmsg_add_string(&b, id, "none");
-	}
+	blobmsg_add_double(&b, id, value);
 }
 
 static inline void m_bool(const char *id, bool value) {
@@ -439,7 +439,7 @@ static void g977_get_snr(int fd, DSL_AccessDir_t direction) {
 		if (out.data.deltSnr.nNSCData[i] != 255 && out.data.deltSnr.nNSCData[i] != 0) {
 			m_double("", -32 + (double)out.data.deltSnr.nNSCData[i] / 2); // SNR -32 ... 95 dB
 		} else {
-                        m_double("", NAN);
+                        m_null();
 		}
 	};
 	
@@ -457,7 +457,7 @@ static void g977_get_qln(int fd, DSL_AccessDir_t direction) {
 		if (out.data.deltQln.nNSCData[i] != 255 && out.data.deltQln.nNSCData[i] != 0) {
 			m_double("", -23 - (double)out.data.deltQln.nNSCData[i] / 2); // QLN -150 ... -23 dBm/Hz
 		} else {
-                        m_double("", NAN);
+                        m_null();
 		}
 	};
 	
@@ -476,7 +476,7 @@ static void g977_get_hlog(int fd, DSL_AccessDir_t direction) {
 		if (out.data.deltHlog.nNSCData[i] != 1023 && out.data.deltHlog.nNSCData[i] != 0) {
 			m_double("", 6 - (double)out.data.deltHlog.nNSCData[i] / 10); // HLOG +6 ... -96 dB
 		} else {
-                        m_double("", NAN);
+                        m_null();
 		}
 	};
 


### PR DESCRIPTION
This pull requests introduces an extension the the ubus dsl integration with a command to 
expose the DSL statistics data required to render the dsl charts. Statistics include bit-allocation,
SNR, QLN and HLOG data.

With this extension `ubus` calls will look like
```
root:~# ubus -v list dsl
'dsl' @88f73b6b
        "metrics":{}
        "statistics":{}
```

Output of `ubus call dsl statistics` looks like (trailer):
```
{
        "bits": {
                "downstream": {
                        "groups": 4096,
                        "data": [
                                0,
                                0,
                                0,
                                0,
                                0,
                                0,
```
This total output is a kind of long but follows similar structure for upstream as for downstream and continues
with SNR, QLN and HLog data.
