### PR TITLE
pkg-config: always use correct path for pkg-config.real

### DIFF
--- a/tools/pkgconf/files/pkg-config
+++ b/tools/pkgconf/files/pkg-config
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-pkg-config.real \
+${STAGING_DIR_HOST}/bin/pkg-config.real \
 --keep-system-cflags \
 --keep-system-libs \
 --define-variable=prefix="${STAGING_PREFIX}" \


### PR DESCRIPTION
Before this commit, it was assumed that pkg-config.real is in the PATH. While
this was fine for the normal build workflow, this led to some issues if

    make TOPDIR="$(pwd)" -C "$pkgdir" compile

was called manually. The command failed with

    Makefile:15: *** No libnl-tiny development libraries found!.  Stop.
    make[1]: Leaving directory

since pkg-config of the host system was used.

After the commit, the package is built sucessfully.

Signed-off-by: Leonardo Mörlein <me@irrelefant.net>