### PR TITLE
ath25: fix ELF and initramfs image generation

### DIFF
--- a/target/linux/ath25/image/Makefile
+++ b/target/linux/ath25/image/Makefile
@@ -54,6 +54,9 @@ endef
 define Device/Default
   PROFILES = Default $$(DEVICE_NAME)
   KERNEL := copy-kernel | lzma-kernel
+  KERNEL_INITRAMFS = kernel-bin
+  KERNEL_INITRAMFS_NAME := vmlinux-initramfs.elf
+  KERNEL_INITRAMFS_SUFFIX := -kernel.elf
   IMAGES := sysupgrade.bin
   FILESYSTEMS := squashfs
 endef

--- a/target/linux/ath25/image/Makefile
+++ b/target/linux/ath25/image/Makefile
@@ -43,7 +43,7 @@ endef
 define Build/copy-kernel
 	rm -f $@ $@.elf
 	cp $< $@
-	cp $< $@.elf
+	cp $<.elf $@.elf
 endef
 
 define Build/elf-kernel


### PR DESCRIPTION
This PR contains two fixes which restore the correct contents of ELF images, which were not restored correctly in 21f460a5dbef.
First patch selects correct source artifact for generic kernel.elf.
Second patch restores initramfs build recipe to use just vmlinux-initramfs.elf as the source, and adjusts artifact suffix to match the non-initramfs.

Run tested on D-Link DWR-3200AP A1.
