### PR TITLE
[22.03] kernel: add kmod-leds-turris-omnia

### DIFF
--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -59,7 +59,7 @@ define Device/cznic_turris-omnia
   DEVICE_PACKAGES :=  \
     mkf2fs e2fsprogs kmod-fs-vfat kmod-nls-cp437 kmod-nls-iso8859-1 \
     wpad-basic-wolfssl kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct \
-    partx-utils kmod-i2c-mux-pca954x
+    partx-utils kmod-i2c-mux-pca954x kmod-leds-turris-omnia
   IMAGES := $$(DEVICE_IMG_PREFIX)-sysupgrade.img.gz omnia-medkit-$$(DEVICE_IMG_PREFIX)-initramfs.tar.gz
   IMAGE/$$(DEVICE_IMG_PREFIX)-sysupgrade.img.gz := boot-scr | boot-img | sdcard-img | gzip | append-metadata
   IMAGE/omnia-medkit-$$(DEVICE_IMG_PREFIX)-initramfs.tar.gz := omnia-medkit-initramfs | gzip

--- a/target/linux/mvebu/modules.mk
+++ b/target/linux/mvebu/modules.mk
@@ -15,3 +15,19 @@ define KernelPackage/linkstation-poweroff/description
 endef
 
 $(eval $(call KernelPackage,linkstation-poweroff))
+
+
+define KernelPackage/leds-turris-omnia
+   SUBMENU:=$(LEDS_MENU)
+   TITLE:=LED support for CZ.NIC's Turris Omnia
+   DEPENDS:=@TARGET_mvebu_cortexa9
+   KCONFIG:=CONFIG_LEDS_TURRIS_OMNIA
+   FILES:=$(LINUX_DIR)/drivers/leds/leds-turris-omnia.ko
+   AUTOLOAD:=$(call AutoLoad,60,leds-turris-omnia,1)
+endef
+
+define KernelPackage/leds-turris-omnia/description
+   This option enables support for the LEDs of the CZ.NIC Turris Omnia.
+endef
+
+$(eval $(call KernelPackage,leds-turris-omnia))


### PR DESCRIPTION
Add support for LEDs of the CZ.NIC Turris Omnia using the upstream
driver.

There is no generic way to control the LEDs in UCI manner, however
the kernel module is the first step to actually use the RGB LEDs in
custom logic.