### PR TITLE
mediatek/ramips: disable unsupported background radar detection

### DIFF
--- a/target/linux/mediatek/dts/mt7622-linksys-e8450.dtsi
+++ b/target/linux/mediatek/dts/mt7622-linksys-e8450.dtsi
@@ -336,9 +336,11 @@
 };
 
 &slot0 {
-	wmac1: mt7915@0,0 {
+	wmac1: wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
+		mediatek,disable-radar-background;
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7622-ruijie-rg-ew3200gx-pro.dts
+++ b/target/linux/mediatek/dts/mt7622-ruijie-rg-ew3200gx-pro.dts
@@ -164,10 +164,12 @@
 };
 
 &slot0 {
-	mt7915@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x5000>;
 		ieee80211-freq-limit = <5000000 6000000>;
+		mediatek,disable-radar-background;
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7622-xiaomi-redmi-router-ax6s.dts
+++ b/target/linux/mediatek/dts/mt7622-xiaomi-redmi-router-ax6s.dts
@@ -328,6 +328,7 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x5000>;
 		ieee80211-freq-limit = <5000000 6000000>;
+		mediatek,disable-radar-background;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -118,6 +118,7 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
+		mediatek,disable-radar-background;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_cudy_x6.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_x6.dts
@@ -120,6 +120,7 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
+		mediatek,disable-radar-background;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_jcg_q20.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_q20.dts
@@ -140,6 +140,7 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
+		mediatek,disable-radar-background;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_totolink_x5000r.dts
+++ b/target/linux/ramips/dts/mt7621_totolink_x5000r.dts
@@ -93,6 +93,7 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
+		mediatek,disable-radar-background;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts
@@ -144,6 +144,7 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&radio 0x0>;
+		mediatek,disable-radar-background;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr660x.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr660x.dtsi
@@ -136,6 +136,7 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
+		mediatek,disable-radar-background;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
@@ -135,6 +135,7 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
+		mediatek,disable-radar-background;
 	};
 };
 


### PR DESCRIPTION
Devices with MT7905, or MT7915 but lacking a DFS antenna do not support background radar detection, so just disable it.

All OpenWrt supported devices that using MT7905/MT7911/MT7915:

**Already Disabled:**
- [x] h3c,tx1800-plus
- [x] h3c,tx1801-plus
- [x] h3c,tx1806
- [x] tenbay,t-mb5eu-v01
- [x] ubnt,unifi-6-lite

**MT7905:**
- [x] asus,rt-ax53u 8c00fd9b4519bf0ef8fb3470a6df421b9f38c03c
- [x] jcg,q20 https://www.acwifi.net/14024.html
- [x] tplink,eap615-wall-v1 a1b8a4d7b3ff3fa671623e2bccafd43a3c141e07
- [x] xiaomi,mi-router-cr6606 3343ca7e6837b2ac5f237ea78bf73d50831dea20 https://www.acwifi.net/18380.html
- [x] xiaomi,mi-router-cr6608 3343ca7e6837b2ac5f237ea78bf73d50831dea20 same as cr6606/cr6608
- [x] xiaomi,mi-router-cr6609 3343ca7e6837b2ac5f237ea78bf73d50831dea20 https://www.acwifi.net/13821.html
- [x] yuncore,ax820 4891b865380e2b7f32acf0893df9c1ca9db8d4ea

**MT7911/MT7915 without DFS antenna:**
- [x] totolink,x5000r https://www.acwifi.net/14722.html
- [x] cudy,x6 https://forum.openwrt.org/t/add-support-for-cudy-x6-wifi-6-router/98197/13
- [x] mediatek: linksys,e8450 reported by @dangowrt
- [x] mediatek: ruijie,rg-ew3200gx-pro https://www.acwifi.net/14783.html
- [x] mediatek: xiaomi,redmi-router-ax6s https://www.acwifi.net/16612.html

**MT7915 with DFS antenna:**
- [x] iptime,ax2004m reported by @mans0n
- [x] netgear,wax202 https://fccid.io/PY321100518/Internal-Photos/Internal-Photos-5257807.pdf
- [x] mediatek: ubnt,unifi-6-lr reported by @dangowrt

**Not sure, but maintainers can add them individually later:**
**(Usually if the router only has 2 or 4 antennas, then it is probably not supported)**
- [ ] zyxel,nwa50ax
- [ ] mediatek: elecom,wrc-x3200gst3

[MT7905 datasheet](https://oss.komect.com/openhomeres/static/images/chipAndModel/%E7%BB%84%E7%BD%91%E8%8A%AF%E7%89%87/MT7905DAN.pdf)
[MT7915 datasheet](https://edit.wpgdadawant.com/uploads/news_file/blog/2020/2406/tech_files/blog_2406_suggest_other_file.pdf)