### PR TITLE
busybox: enable telnet on normal devices

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -2552,7 +2552,7 @@ config BUSYBOX_DEFAULT_UDPSVD
 	default n
 config BUSYBOX_DEFAULT_TELNET
 	bool
-	default n
+	default y if !SMALL_FLASH
 config BUSYBOX_DEFAULT_FEATURE_TELNET_TTYPE
 	bool
 	default n


### PR DESCRIPTION
There is no telnet compatible tool available for OpenWrt ever since it
was removed with the switch to OpenSSH for logins.

This commits adds telnet if the device is not a small flash one.

Signed-off-by: Paul Spooren <mail@aparcar.org>