### PR TITLE
iproute2: Fix KERNEL_INCLUDE in SDK

### DIFF
--- a/package/network/utils/iproute2/Makefile
+++ b/package/network/utils/iproute2/Makefile
@@ -176,7 +176,7 @@ TARGET_LDFLAGS += -Wl,--gc-sections -Wl,--as-needed
 TARGET_CPPFLAGS += -I$(STAGING_DIR)/usr/include/libnl-tiny
 
 MAKE_FLAGS += \
-	KERNEL_INCLUDE="$(LINUX_DIR)/user_headers/include" \
+	KERNEL_INCLUDE="$(LINUX_DIR)/include/uapi" \
 	SHARED_LIBS=$(SHARED_LIBS) \
 	IP_CONFIG_TINY=$(IP_CONFIG_TINY) \
 	BUILD_VARIANT=$(BUILD_VARIANT) \


### PR DESCRIPTION
In the SDK the folder $(LINUX_DIR)/user_headers/include does not exist,
but it more or less contains the same content as
$(LINUX_DIR)/include/uapi which also exists in the SDK.

Since iproute2 commit 1d819dcc741e ("configure: fix parsing issue on
include_dir option") it checks if this folder exists and aborts the
build if it does not exists.
https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/commit/?id=1d819dcc741e25958190e31f8186c940713fa0a8

With this commit the KERNEL_INCLUDE variable points to a valid folder
with the kernel include headers. I am not sure if they are actually
needed because the build worked before even with an invalid path.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
