### PR TITLE
ramips: use lzma-loader on Sitecom WLR-6000

### DIFF
--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -108,6 +108,7 @@ endef
 TARGET_DEVICES += samsung_cy-swr1100
 
 define Device/sitecom_wlr-6000
+  $(Device/uimage-lzma-loader)
   SOC := rt3883
   BLOCKSIZE := 4k
   IMAGE_SIZE := 7244k


### PR DESCRIPTION
The Sitecom WLR-6000 cannot boot OpenWrt newer than 19.07.
This commit fixes this issue as it did with many other ramips targets.

Prior to fix:
```
3: System Boot system code via Flash.
raspi_read: from:50000 len:40
.raspi_read: from:50040 len:184f03
.........................LZMA ERROR 1 - must RESET board to recover
```
After:
```
OpenWrt kernel loader for MIPS based SoC
Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org>
Decompressing kernel... done!
Starting kernel at 80000000...

[    0.000000] Linux version 5.10.134 (user@development) (mipsel-openwrt-linux-musl-gcc (OpenWrt GCC 11.2.0 r19590-042d558536) 11.2.0, GNU ld (GNU Binutils) 2.37) #0 Sun Jul 31 15:12:47 2022
[    0.000000] SoC Type: Ralink RT3883 ver:1 eco:5
```

Compile and run-time tested on: `wlr-6000 v1 001`