### PR TITLE
kernel: reduce size for SMALL_FLASH by disabling options

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -22,7 +22,7 @@ config KERNEL_BUILD_DOMAIN
 
 config KERNEL_PRINTK
 	bool "Enable support for printk"
-	default y
+	default y if !SMALL_FLASH
 
 config KERNEL_SWAP
 	bool "Support for paging of anonymous memory (swap)"
@@ -34,7 +34,7 @@ config KERNEL_PROC_STRIPPED
 
 config KERNEL_DEBUG_FS
 	bool "Compile the kernel with debug filesystem enabled"
-	default y
+	default y if !SMALL_FLASH
 	help
 	  debugfs is a virtual file system that kernel developers use to put
 	  debugging files into. Enable this option to be able to read and
@@ -524,7 +524,7 @@ config KERNEL_HUGETLB_PAGE
 
 config KERNEL_MAGIC_SYSRQ
 	bool "Compile the kernel with SysRq support"
-	default y
+	default y if !SMALL_FLASH
 
 config KERNEL_DEBUG_PINCTRL
 	bool "Compile the kernel with pinctrl debugging"
@@ -605,7 +605,7 @@ config KERNEL_DEBUG_VM
 
 config KERNEL_PRINTK_TIME
 	bool "Enable printk timestamps"
-	default y
+	default y if !SMALL_FLASH
 
 config KERNEL_SLUB_DEBUG
 	bool


### PR DESCRIPTION
Based on the recommendations found in [0] disable some kernel config
options:

KERNEL_PRINTK
Disable printing of kernel messages. Debugging will become harder.
However, it if debugging is needed people can just enable it again.

KERNEL_PRINTK_TIME
We disable printk, so also disable the code necessary for output timing
data.

KERNEL_DEBUG_FS
Disable the debugfs. It is not needed for basic wifi access point
operation.

KERNEL_MAGIC_SYSRQ
Disable the various low-level commands typically used when the system is
in a bad state to rescue it.

Runtested on Ubiquiti Nanostation M5 (XM).

[0] - https://openwrt.org/docs/guide-user/additional-software/saving_space