### PR TITLE
ramips: add support for xiaomi RA75 Range Extender

### DIFF
--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-ra75.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-ra75.dts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_xiaomi_mi-router-4.dtsi"
+
+/ {
+	compatible = "xiaomi,mi-ra75", "mediatek,mt7628an-soc";
+	model = "Xiaomi Mi AC1200 WLAN Range Extender RA75";
+	aliases {
+		led-boot = &led_system_amber;
+		led-failsafe = &led_system_amber;
+		led-running = &led_system_blue;
+		led-upgrade = &led_system_amber;
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system_blue: system_blue {
+			label = "blue:system";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+		led_system_amber: system_amber {
+			label = "amber:system";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+		led_signal_blue: signal_blue {
+			label = "blue:signal";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+		led_signal_amber: signal_amber {
+			label = "amber:signal";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+		wps {
+			label = "wps";
+			gpios = <&gpio 67 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+};
+
+&partitions {
+	partition@60000 {
+		label = "overlay";
+		reg = <0x60000 0x100000>;
+		read-only;
+	};
+
+	partition@160000 {
+		label = "firmware";
+		reg = <0x160000 0xea0000>;
+		compatible = "denx,uimage";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+
+&esw {
+	mediatek,portmap = <0x3e>;
+	mediatek,portdisable = <0x2a>;
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 {
+		reg = <0x4 0x6>;
+	};
+
+	macaddr_factory_28: macaddr@28 {
+		reg = <0x28 0x6>;
+	};
+	macaddr_factory_8004: macaddr@8004 {
+		reg = <0x8004 0x6>;
+	};
+};
+
+

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4.dtsi
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4.dtsi
@@ -6,35 +6,8 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	aliases {
-		led-boot = &led_power_yellow;
-		led-failsafe = &led_power_yellow;
-		led-running = &led_power_blue;
-		led-upgrade = &led_power_yellow;
-		label-mac-device = &ethernet;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led_power_blue: power_blue {
-			label = "blue:power";
-			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
-		};
-
-		led_power_yellow: power_yellow {
-			label = "yellow:power";
-			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
-		};
-
-		wan {
-			label = "blue:wan";
-			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
-		};
 	};
 
 	keys {

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m-intl.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m-intl.dts
@@ -5,6 +5,34 @@
 / {
 	compatible = "xiaomi,mi-router-4a-100m-intl", "mediatek,mt7628an-soc";
 	model = "Xiaomi Mi Router 4A (100M International Edition)";
+
+	aliases {
+		led-boot = &led_power_yellow;
+		led-failsafe = &led_power_yellow;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_yellow;
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_yellow: power_yellow {
+			label = "yellow:power";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "blue:wan";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+	};
+
 };
 
 &partitions {

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m.dts
@@ -5,6 +5,34 @@
 / {
 	compatible = "xiaomi,mi-router-4a-100m", "mediatek,mt7628an-soc";
 	model = "Xiaomi Mi Router 4A (100M Edition)";
+
+	aliases {
+		led-boot = &led_power_yellow;
+		led-failsafe = &led_power_yellow;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_yellow;
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_yellow: power_yellow {
+			label = "yellow:power";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "blue:wan";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+	};
+
 };
 
 &partitions {

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4c.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4c.dts
@@ -7,8 +7,33 @@
 	model = "Xiaomi Mi Router 4C";
 
 	aliases {
+		led-boot = &led_power_yellow;
+		led-failsafe = &led_power_yellow;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_yellow;
 		label-mac-device = &ethernet;
 	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_yellow: power_yellow {
+			label = "yellow:power";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "blue:wan";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
 };
 
 &flash0 {

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -1011,6 +1011,16 @@ define Device/xiaomi_miwifi-nano
 endef
 TARGET_DEVICES += xiaomi_miwifi-nano
 
+define Device/xiaomi_mi-ra75
+  IMAGE_SIZE := 14976k
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := MiWiFi Range Extender AC1200 
+  DEVICE_VARIANT := RA75
+  DEVICE_PACKAGES := kmod-mt76x2
+  SUPPORTED_DEVICES += xiaomi,mira75
+endef
+TARGET_DEVICES += xiaomi_mi-ra75
+
 define Device/zbtlink_zbt-we1226
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Zbtlink


### PR DESCRIPTION
This device is a close relation to the xiaomi 4A router (100m chinese
variante).
Its a 'wall wart' / Range extender form factor with one 100M LAN port
and a WPS button
Signed-off-by: Jo Deisenhofer <jo.deisenhofer@gmail.com>