### PR TITLE
ath79: add low_mem to tiny image

### DIFF
--- a/target/linux/ath79/tiny/target.mk
+++ b/target/linux/ath79/tiny/target.mk
@@ -1,5 +1,5 @@
 BOARDNAME:=Devices with small flash
-FEATURES += small_flash
+FEATURES += low_mem small_flash
 
 DEFAULT_PACKAGES += wpad-basic-wolfssl
 


### PR DESCRIPTION
Devices with SMALL_FLASH enabled have "SQUASHFS_BLOCK_SIZE=1024" in
their config. This significantly increases the cache memory required by
squashfs [0]. This commit enables low_mem leading to a much better
performance because the SQUASHFS_BLOCK_SIZE is reduced to 256.

Example Nanostation M5 (XM):
The image size increases by 128 KiB. However, the memory statisitcs look
much better:

Default tiny build:
------
MemTotal:          26020 kB
MemFree:            5648 kB
MemAvailable:       6112 kB
Buffers:               0 kB
Cached:             3044 kB

low_mem enabled:
-----
MemTotal:          26976 kB
MemFree:            6748 kB
MemAvailable:      11504 kB
Buffers:               0 kB
Cached:             7204 kB

[0] - https://github.com/freifunk-gluon/gluon/commit/7e8af99cf504ca1dc389f282a0c94f4a911571be

