### PR TITLE
Add Midea morr qr001 device support

### DIFF
--- a/target/linux/ramips/dts/mt7621_midea_morr-qr011.dts
+++ b/target/linux/ramips/dts/mt7621_midea_morr-qr011.dts
@@ -1,0 +1,119 @@
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "midea,morr-qr011", "mediatek,mt7621-soc";
+	model = "MIDEA MORR-QR011";
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		broken-flash-reset;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e006>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "wdt";
+		function = "gpio";
+	};
+};
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1244,6 +1244,16 @@ define Device/mediatek_mt7621-eval-board
 endef
 TARGET_DEVICES += mediatek_mt7621-eval-board
 
+define Device/midea_morr-qr011
+  IMAGE_SIZE := 32448k
+  DEVICE_VENDOR := MIDEA
+  DEVICE_MODEL := MORR-QR011
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_PACKAGES := -wpad-openssl
+  SUPPORTED_DEVICES += mt7621
+endef
+TARGET_DEVICES += midea_morr-qr011
+
 define Device/MikroTik
   $(Device/dsa-migration)
   DEVICE_VENDOR := MikroTik


### PR DESCRIPTION
I have another Midea device. I have adapted openwrt to it and perfectly supported the device.

### Specifications:

SoC: MTK7621
Flash: 32 MiB
RAM: 256 MiB 
Ethernet: 1x 10/100/1000 Mbps And 4x 10/100/1000 Mbps with PoE (4 ports)
Buttons: 1x "Reset" button on front panel
### Works:
(8) RJ-45 ethernet ports
Switch functions
System LED