### PR TITLE
tools/cmake: refresh patches

### DIFF
--- a/tools/cmake/patches/120-curl-fix-libressl-linking.patch
+++ b/tools/cmake/patches/120-curl-fix-libressl-linking.patch
@@ -20,7 +20,7 @@ Signed-off-by: Jo-Philipp Wich <jo@mein.io>
 ---
 --- a/Utilities/cmcurl/CMakeLists.txt
 +++ b/Utilities/cmcurl/CMakeLists.txt
-@@ -565,6 +565,14 @@ if(CMAKE_USE_OPENSSL)
+@@ -594,6 +594,14 @@ if(CURL_USE_OPENSSL)
    endif()
    set(SSL_ENABLED ON)
    set(USE_OPENSSL ON)

--- a/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
+++ b/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
@@ -1,6 +1,6 @@
 --- a/bootstrap
 +++ b/bootstrap
-@@ -1423,7 +1423,10 @@ int main(){ printf("1%c", (char)0x0a); r
+@@ -1441,7 +1441,10 @@ int main(){ printf("1%c", (char)0x0a); r
  ' > "test.c"
  cmake_original_make_flags="${cmake_make_flags}"
  if test "x${cmake_parallel_make}" != "x"; then


### PR DESCRIPTION
Previous commit forgot to refresh the patches.
This commit refreshes the patches:
- 120-curl-fix-libressl-linking.patch
- 130-bootstrap_parallel_make_flag.patch

Fixes: 3b2f19271cc2 ("tools/cmake: update to 3.24.1")