### PR TITLE
base-files: rename ethernet devs on known boards

### DIFF
--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -114,6 +114,14 @@ ucidef_set_network_device_mac() {
 	json_select ..
 }
 
+ucidef_set_network_device_path() {
+	json_select_object "network_device"
+	json_select_object "$1"
+	json_add_string path "$2"
+	json_select ..
+	json_select ..
+}
+
 _ucidef_add_switch_port() {
 	# inherited: $num $device $need_tag $want_untag $role $index $prev_role
 	# inherited: $n_cpu $n_ports $n_vlan $cpu0 $cpu1 $cpu2 $cpu3 $cpu4 $cpu5

--- a/package/base-files/files/lib/preinit/10_indicate_preinit
+++ b/package/base-files/files/lib/preinit/10_indicate_preinit
@@ -63,6 +63,20 @@ preinit_config_switch() {
 	json_select ..
 }
 
+preinit_config_port() {
+	local original
+
+	local netdev="$1"
+	local path="$2"
+
+	[ -d "/sys/devices/$path/net" ] || return
+	original="$(ls "/sys/devices/$path/net" | head -1)"
+
+	[ "$netdev" = "$original" ] && return
+
+	ip link set "$original" name "$netdev"
+}
+
 preinit_config_board() {
 	/bin/board_detect /tmp/board.json
 
@@ -72,6 +86,35 @@ preinit_config_board() {
 
 	json_init
 	json_load "$(cat /tmp/board.json)"
+
+	# Find the current highest eth*
+	max_eth=$(grep -o '^ *eth[0-9]*:' /proc/net/dev | tr -dc '[0-9]\n' | sort -n | tail -1)
+	# Find and move netdevs using eth*s we are configuring
+	json_get_keys keys "network_device"
+	for netdev in $keys; do
+		json_select "network_device"
+			json_select "$netdev"
+				json_get_vars path path
+				next_eth="$(echo "$netdev" | grep 'eth[0-9]*' | tr -dc '[0-9]')"
+				[ "$next_eth" -gt "$max_eth" ] && max_eth=$next_eth
+				if [ -n "$path" -a -h "/sys/class/net/$netdev" ]; then
+					ip link set "$netdev" down
+					ip link set "$netdev" name eth$((++max_eth))
+				fi
+			json_select ..
+		json_select ..
+	done
+
+	# Move interfaces by path to their netdev name
+	json_get_keys keys "network_device"
+	for netdev in $keys; do
+		json_select "network_device"
+			json_select "$netdev"
+				json_get_vars path path
+				[ -n "$path" ] && preinit_config_port "$netdev" "$path"
+			json_select ..
+		json_select ..
+	done
 
 	json_select network
 		json_select "lan"

--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -9,7 +9,19 @@ board_config_update
 
 case "$(board_name)" in
 cisco-mx100-hw)
-	ucidef_set_interfaces_lan_wan "eth0 eth1 eth2 eth3 eth4 eth5 eth7 eth8 eth9 eth10 eth11" "eth6"
+	ucidef_set_network_device_path "mgmt" "pci0000:00/0000:00:01.2/0000:03:00.3"
+	ucidef_set_network_device_path "wan" "pci0000:00/0000:00:01.2/0000:03:00.2"
+	ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:01.2/0000:03:00.1"
+	ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:01.2/0000:03:00.0"
+	ucidef_set_network_device_path "eth4" "pci0000:00/0000:00:01.0/0000:01:00.2"
+	ucidef_set_network_device_path "eth5" "pci0000:00/0000:00:01.0/0000:01:00.1"
+	ucidef_set_network_device_path "eth6" "pci0000:00/0000:00:01.0/0000:01:00.4"
+	ucidef_set_network_device_path "eth7" "pci0000:00/0000:00:01.0/0000:01:00.3"
+	ucidef_set_network_device_path "eth8" "pci0000:00/0000:00:01.1/0000:02:00.1"
+	ucidef_set_network_device_path "eth9" "pci0000:00/0000:00:01.1/0000:02:00.0"
+	ucidef_set_network_device_path "eth10" "pci0000:00/0000:00:01.1/0000:02:00.3"
+	ucidef_set_network_device_path "eth11" "pci0000:00/0000:00:01.1/0000:02:00.2"
+	ucidef_set_interfaces_lan_wan "mgmt eth2 eth3 eth4 eth5 eth6 eth7 eth8 eth9 eth10 eth11" "wan"
 	;;
 pc-engines-apu1|pc-engines-apu2|pc-engines-apu3)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"


### PR DESCRIPTION
Some platforms lack an established way to name netdevs; for example,
on x86, PCIe-based ethernet interfaces will be named starting from
eth0 in the order they are probed. This is a problem for many devices
supported explicitly by OpenWrt which have hard-wired, standalone or
on-CPU NICs not supported by DSA (which is usually used to rename the
ports based on their ostensible function).

To fix this, add a mapping between ethernet device name and sysfs
device path to board.json; this allows us to configure ethernet device
names we know about for a given board so that they correspond to
external labeling.

This PR also contains an example application of the new
`ucidef_set_network_device_path`.

Finally, see https://forum.openwrt.org/t/x86-64-network-device-naming/135154
for my initial commentary which lead to this PR.

Signed-off-by: Martin Kennedy <hurricos@gmail.com>
