### PR TITLE
ath79: tiny: add 5.15 support for tiny subtarget

### DIFF
--- a/target/linux/ath79/Makefile
+++ b/target/linux/ath79/Makefile
@@ -9,6 +9,7 @@ SUBTARGETS:=generic mikrotik nand tiny
 FEATURES:=ramdisk squashfs usbgadget
 
 KERNEL_PATCHVER:=5.10
+KERNEL_TESTING_PATCHVER:=5.15
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/linux/ath79/generic/target.mk
+++ b/target/linux/ath79/generic/target.mk
@@ -2,8 +2,6 @@ BOARDNAME:=Generic
 
 DEFAULT_PACKAGES += wpad-basic-wolfssl
 
-KERNEL_TESTING_PATCHVER:=5.15
-
 define Target/Description
 	Build firmware images for generic Atheros AR71xx/AR913x/AR934x based boards.
 endef

--- a/target/linux/ath79/mikrotik/target.mk
+++ b/target/linux/ath79/mikrotik/target.mk
@@ -5,8 +5,6 @@ IMAGES_DIR := ../../..
 
 DEFAULT_PACKAGES += wpad-basic-wolfssl
 
-KERNEL_TESTING_PATCHVER:=5.15
-
 define Target/Description
 	Build firmware images for MikroTik devices based on Qualcomm Atheros
 	MIPS SoCs (AR71xx, AR72xx, AR91xx, AR93xx, QCA95xx).

--- a/target/linux/ath79/nand/target.mk
+++ b/target/linux/ath79/nand/target.mk
@@ -4,8 +4,6 @@ FEATURES += nand
 
 DEFAULT_PACKAGES += wpad-basic-wolfssl
 
-KERNEL_TESTING_PATCHVER:=5.15
-
 define Target/Description
 	Firmware for boards using Qualcomm Atheros, MIPS-based SoCs
 	in the ar72xx and subsequent series, with support for NAND flash

--- a/target/linux/ath79/tiny/target.mk
+++ b/target/linux/ath79/tiny/target.mk
@@ -3,8 +3,6 @@ FEATURES += small_flash
 
 DEFAULT_PACKAGES += wpad-basic-wolfssl
 
-KERNEL_TESTING_PATCHVER:=5.15
-
 define Target/Description
 	Build firmware images for Atheros AR71xx/AR913x/AR934x based boards with small flash
 endef

--- a/target/linux/ath79/tiny/target.mk
+++ b/target/linux/ath79/tiny/target.mk
@@ -3,6 +3,8 @@ FEATURES += small_flash
 
 DEFAULT_PACKAGES += wpad-basic-wolfssl
 
+KERNEL_TESTING_PATCHVER:=5.15
+
 define Target/Description
 	Build firmware images for Atheros AR71xx/AR913x/AR934x based boards with small flash
 endef


### PR DESCRIPTION
Tested on Ubiquiti Nanostation M5 XM with low_mem.

Needs: https://github.com/openwrt/openwrt/pull/10478

Looks good:
```
root@OpenWrt:~# dmesg
[    0.000000] Linux version 5.15.62 (nick@coolnew) (mips-openwrt-linux-musl-gcc (OpenWrt GCC 11.3.0 r20375-d6994c53cd) 11.3.0, GNU ld (GNU Binutils) 2.37) #0 Tue Aug 23 16:45:29 2022
[    0.000000] printk: bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 00019374 (MIPS 24Kc)
[    0.000000] MIPS: machine is Ubiquiti Nanostation M (XM)
[    0.000000] SoC: Atheros AR7241 rev 1
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] Primary instruction cache 64kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, VIPT, cache aliases, linesize 32 bytes
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x0000000001ffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x0000000001ffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x0000000001ffffff]
[    0.000000] pcpu-alloc: s0 r0 d32768 u32768 alloc=1*32768
[    0.000000] pcpu-alloc: [0] 0 
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 8128
[    0.000000] Kernel command line: console=ttyS0,115200 rootfstype=squashfs,jffs2
[    0.000000] Dentry cache hash table entries: 4096 (order: 2, 16384 bytes, linear)
[    0.000000] Inode-cache hash table entries: 2048 (order: 1, 8192 bytes, linear)
[    0.000000] Writing ErrCtl register=00000000
[    0.000000] Readback ErrCtl register=00000000
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 25492K/32768K available (4279K kernel code, 533K rwdata, 680K rodata, 1220K init, 196K bss, 7276K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] NR_IRQS: 51
[    0.000000] CPU clock: 390.000 MHz
[    0.000000] clocksource: MIPS: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 9801335621 ns
[    0.000002] sched_clock: 32 bits at 195MHz, resolution 5ns, wraps every 11012737021ns
[    0.007993] Calibrating delay loop... 259.27 BogoMIPS (lpj=1296384)
[    0.084203] pid_max: default: 32768 minimum: 301
[    0.089178] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.096485] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.107147] dyndbg: Ignore empty _ddebug table in a CONFIG_DYNAMIC_DEBUG_CORE build
[    0.119019] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.128892] futex hash table entries: 256 (order: -1, 3072 bytes, linear)
[    0.135753] pinctrl core: initialized pinctrl subsystem
[    0.143422] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.167457] clocksource: Switched to clocksource MIPS
[    0.174056] NET: Registered PF_INET protocol family
[    0.179446] IP idents hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.187868] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.196253] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.204030] TCP established hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.211699] TCP bind hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.218761] TCP: Hash tables configured (established 1024 bind 1024)
[    0.225308] UDP hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.231914] UDP-Lite hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.239340] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.245043] PCI: CLS 0 bytes, default 32
[    0.253819] workingset: timestamp_bits=30 max_order=13 bucket_order=0
[    0.267166] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.273069] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.285972] pinctrl-single 18040028.pinmux: 64 pins, size 8
[    0.293248] Serial: 8250/16550 driver, 1 ports, IRQ sharing disabled
[    0.300856] printk: console [ttyS0] disabled
[    0.305259] 18020000.uart: ttyS0 at MMIO 0x18020000 (irq = 9, base_baud = 12187500) is a 16550A
[    0.314046] printk: console [ttyS0] enabled
[    0.322459] printk: bootconsole [early0] disabled
[    0.350929] spi-nor spi0.0: mx25l6405d (8192 Kbytes)
[    0.356050] 6 fixed-partitions partitions found on MTD device spi0.0
[    0.362586] OF: Bad cell count for /ahb/spi@1f000000/flash@0/partitions
[    0.369326] OF: Bad cell count for /ahb/spi@1f000000/flash@0/partitions
[    0.376481] OF: Bad cell count for /ahb/spi@1f000000/flash@0/partitions
[    0.383239] OF: Bad cell count for /ahb/spi@1f000000/flash@0/partitions
[    0.390721] Creating 6 MTD partitions on "spi0.0":
[    0.395562] 0x000000000000-0x000000040000 : "u-boot"
[    0.408140] 0x000000040000-0x000000050000 : "u-boot-env"
[    0.415018] 0x000000050000-0x0000007a0000 : "firmware"
[    0.424935] 2 uimage-fw partitions found on MTD device firmware
[    0.430987] Creating 2 MTD partitions on "firmware":
[    0.435984] 0x000000000000-0x0000001b0000 : "kernel"
[    0.442541] 0x0000001b0000-0x000000750000 : "rootfs"
[    0.451284] mtd: device 4 (rootfs) set to be root filesystem
[    0.457192] 1 squashfs-split partitions found on MTD device rootfs
[    0.463488] 0x0000004ca000-0x000000750000 : "rootfs_data"
[    0.470579] 0x0000007a0000-0x0000007b0000 : "board_config"
[    0.480010] 0x0000007b0000-0x0000007f0000 : "cfg"
[    0.486286] 0x0000007f0000-0x000000800000 : "art"
[    0.858600] ag71xx 19000000.eth: Could not connect to PHY device. Deferring probe.
[    1.544661] switch0: Atheros AR724X/AR933X built-in rev. 2 switch registered on mdio.0
[    1.595145] ag71xx 1a000000.eth: connected to PHY at fixed-0:00 [uid=00000000, driver=Generic PHY]
[    1.605346] eth0: Atheros AG71xx at 0xba000000, irq 5, mode: gmii
[    1.615687] NET: Registered PF_INET6 protocol family
[    1.635874] Segment Routing with IPv6
[    1.639816] In-situ OAM (IOAM) with IPv6
[    1.643985] NET: Registered PF_PACKET protocol family
[    1.649606] 8021q: 802.1Q VLAN Support v1.8
[    1.655437] PCI host bridge to bus 0000:00
[    1.659669] pci_bus 0000:00: root bus resource [mem 0x10000000-0x13ffffff]
[    1.666596] pci_bus 0000:00: root bus resource [io  0x0000]
[    1.672215] pci_bus 0000:00: No busn resource found for root bus, will use [bus 00-ff]
[    1.680262] pci 0000:00:00.0: [168c:002a] type 00 class 0x028000
[    1.686357] pci 0000:00:00.0: reg 0x10: [mem 0x10000000-0x1000ffff 64bit]
[    1.693399] pci 0000:00:00.0: supports D1
[    1.697475] pci 0000:00:00.0: PME# supported from D0 D1 D3hot
[    1.705180] pci_bus 0000:00: busn_res: [bus 00-ff] end is updated to 00
[    1.711932] pci 0000:00:00.0: BAR 0: assigned [mem 0x10000000-0x1000ffff 64bit]
[    2.138150] ag71xx 19000000.eth: connected to PHY at mdio.0:1f:04 [uid=004dd041, driver=Qualcomm Atheros AR9331 built-in PHY]
[    2.151168] eth1: Atheros AG71xx at 0xb9000000, irq 4, mode: mii
[    2.184655] VFS: Mounted root (squashfs filesystem) readonly on device 31:4.
[    2.202292] Freeing unused kernel image (initmem) memory: 1220K
[    2.208290] This architecture does not have kernel memory protection.
[    2.214776] Run /sbin/init as init process
[    2.218903]   with arguments:
[    2.218914]     /sbin/init
[    2.218925]   with environment:
[    2.218935]     HOME=/
[    2.218945]     TERM=linux
[    3.590032] init: Console is alive
[    3.594211] init: - watchdog -
[    3.597981] init: Watchdog has previously reset the system
[    5.945272] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    6.029459] usbcore: registered new interface driver usbfs
[    6.035110] usbcore: registered new interface driver hub
[    6.040705] usbcore: registered new device driver usb
[    6.060150] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
[    6.069413] ehci-fsl: Freescale EHCI Host controller driver
[    6.079027] ehci-platform: EHCI generic platform driver
[    6.092605] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
[    6.101105] ohci-platform: OHCI generic platform driver
[    6.109280] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    6.127325] init: - preinit -
[    7.849025] random: jshn: uninitialized urandom read (4 bytes read)
[    8.059600] random: jshn: uninitialized urandom read (4 bytes read)
[    8.214768] random: jshn: uninitialized urandom read (4 bytes read)
[    8.952743] random: procd: uninitialized urandom read (4 bytes read)
[   10.979307] eth1: link up (100Mbps/Full duplex)
[   10.983947] IPv6: ADDRCONF(NETDEV_CHANGE): eth1: link becomes ready
[   11.296353] mount_root: no usable overlay filesystem found, using tmpfs overlay
[   11.311562] urandom-seed: Seed file not found (/etc/urandom.seed)
[   11.490229] eth1: link down
[   11.513268] procd: - early -
[   11.516722] procd: - watchdog -
[   11.520581] procd: Watchdog has previously reset the system
[   12.301177] procd: - watchdog -
[   12.304537] procd: Watchdog has previously reset the system
[   12.364100] procd: - ubus -
[   12.564892] random: ubusd: uninitialized urandom read (4 bytes read)
[   12.575026] random: ubusd: uninitialized urandom read (4 bytes read)
[   12.598750] random: ubusd: uninitialized urandom read (4 bytes read)
[   12.624488] procd: - init -
[   14.157942] random: jshn: uninitialized urandom read (4 bytes read)
[   14.212639] random: ubusd: uninitialized urandom read (4 bytes read)
[   14.238098] random: ubus: uninitialized urandom read (4 bytes read)
[   14.368402] kmodloader: loading kernel modules from /etc/modules.d/*
[   15.324580] Loading modules backported from Linux version v5.15.58-0-g7d8048d4e064
[   15.332314] Backport generated by backports.git v5.15.58-1-0-g42a95ce7
[   15.357549] urngd: v1.0.2 started.
[   16.185667] PPP generic driver version 2.4.2
[   16.199168] NET: Registered PF_PPPOX protocol family
[   16.447170] ath9k 0000:00:00.0: Direct firmware load for ath9k-eeprom-pci-0000:00:00.0.bin failed with error -2
[   16.457419] ath9k 0000:00:00.0: Falling back to sysfs fallback for: ath9k-eeprom-pci-0000:00:00.0.bin
[   16.535371] random: crng init done
[   16.538928] random: 22 urandom warning(s) missed due to ratelimiting
[   16.814117] ath: phy0: Ignoring endianness difference in EEPROM magic bytes.
[   16.822861] ath: EEPROM regdomain: 0x0
[   16.822878] ath: EEPROM indicates default country code should be used
[   16.822891] ath: doing EEPROM country->regdmn map search
[   16.822915] ath: country maps to regdmn code: 0x3a
[   16.822931] ath: Country alpha2 being used: US
[   16.822946] ath: Regpair used: 0x3a
[   16.840103] ieee80211 phy0: Selected rate control algorithm 'minstrel_ht'
[   16.843836] ieee80211 phy0: Atheros AR9280 Rev:2 mem=0xb0000000, irq=13
[   16.898102] kmodloader: done loading kernel modules from /etc/modules.d/*
[   55.507548] jffs2_scan_eraseblock(): End of filesystem marker found at 0x6000
[   55.515093] jffs2_build_filesystem(): unlocking the mtd device... 
[   55.537563] done.
[   55.545734] jffs2_build_filesystem(): erasing all blocks after the end marker... 
[   65.580683] br-lan: port 1(eth1) entered blocking state
[   65.593559] br-lan: port 1(eth1) entered disabled state
[   65.599353] device eth1 entered promiscuous mode
[   65.793069] eth0: link up (1000Mbps/Full duplex)
[   65.827584] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[   70.739433] eth1: link up (100Mbps/Full duplex)
[   70.744089] br-lan: port 1(eth1) entered blocking state
[   70.749413] br-lan: port 1(eth1) entered forwarding state
[   70.845898] IPv6: ADDRCONF(NETDEV_CHANGE): br-lan: link becomes ready
[   90.756874] done.
[   90.758915] jffs2: notice: (1395) jffs2_build_xattr_subsystem: complete building xattr subsystem, 0 of xdatum (0 unchecked, 0 orphan) and 0 of xref (0 dead, 0 orphan) found.
[   91.124565] overlayfs: upper fs does not support tmpfile.
```


