### PR TITLE
[RFC] toolchain: binutils: remove --disable-werror

### DIFF
--- a/toolchain/binutils/Makefile
+++ b/toolchain/binutils/Makefile
@@ -58,7 +58,6 @@ HOST_CONFIGURE_ARGS = \
 	--enable-deterministic-archives \
 	--enable-plugins \
 	--disable-multilib \
-	--disable-werror \
 	--disable-nls \
 	--disable-sim \
 	--disable-gdb \


### PR DESCRIPTION
We should fix all warnings instead of hiding them.