### PR TITLE
mbedtls: update to version 2.28.1

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=2.28.0
+PKG_VERSION:=2.28.1
 PKG_RELEASE:=$(AUTORELEASE)
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ARMmbed/mbedtls/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=6519579b836ed78cc549375c7c18b111df5717e86ca0eeff4cb64b2674f424cc
+PKG_HASH:=6797a7b6483ef589deeab8d33d401ed235d7be25eeecda1be8ddfed406d40ff4
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=gpl-2.0.txt

--- a/package/libs/mbedtls/patches/100-fix-compile.patch
+++ b/package/libs/mbedtls/patches/100-fix-compile.patch
@@ -1,0 +1,20 @@
+Fix a compile problem introduced in commit 331c3421d1f0 ("Address review comments")
+
+--- a/programs/ssl/ssl_server2.c
++++ b/programs/ssl/ssl_server2.c
+@@ -2511,7 +2511,6 @@ int main( int argc, char *argv[] )
+         }
+         key_cert_init2 = 2;
+ #endif /* MBEDTLS_ECDSA_C */
+-    }
+ 
+ #if defined(MBEDTLS_USE_PSA_CRYPTO)
+     if( opt.key_opaque != 0 )
+@@ -2540,6 +2539,7 @@ int main( int argc, char *argv[] )
+     }
+ #endif /* MBEDTLS_USE_PSA_CRYPTO */
+ #endif /* MBEDTLS_CERTS_C */
++    }
+ 
+     mbedtls_printf( " ok (key types: %s - %s)\n", mbedtls_pk_get_name( &pkey ), mbedtls_pk_get_name( &pkey2 ) );
+ #endif /* MBEDTLS_X509_CRT_PARSE_C */

--- a/package/libs/mbedtls/patches/200-config.patch
+++ b/package/libs/mbedtls/patches/200-config.patch
@@ -1,6 +1,6 @@
 --- a/include/mbedtls/config.h
 +++ b/include/mbedtls/config.h
-@@ -665,14 +665,14 @@
+@@ -670,14 +670,14 @@
   *
   * Enable Output Feedback mode (OFB) for symmetric ciphers.
   */
@@ -17,7 +17,7 @@
  
  /**
   * \def MBEDTLS_CIPHER_NULL_CIPHER
-@@ -790,20 +790,20 @@
+@@ -795,20 +795,20 @@
   * Comment macros to disable the curve and functions for it
   */
  /* Short Weierstrass curves (supporting ECP, ECDH, ECDSA) */
@@ -47,7 +47,7 @@
  
  /**
   * \def MBEDTLS_ECP_NIST_OPTIM
-@@ -956,7 +956,7 @@
+@@ -961,7 +961,7 @@
   *             See dhm.h for more details.
   *
   */
@@ -56,7 +56,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
-@@ -976,7 +976,7 @@
+@@ -981,7 +981,7 @@
   *      MBEDTLS_TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA
   *      MBEDTLS_TLS_ECDHE_PSK_WITH_RC4_128_SHA
   */
@@ -65,7 +65,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
-@@ -1001,7 +1001,7 @@
+@@ -1006,7 +1006,7 @@
   *      MBEDTLS_TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA
   *      MBEDTLS_TLS_RSA_PSK_WITH_RC4_128_SHA
   */
@@ -74,7 +74,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
-@@ -1135,7 +1135,7 @@
+@@ -1140,7 +1140,7 @@
   *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
   *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
   */
@@ -83,7 +83,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
-@@ -1159,7 +1159,7 @@
+@@ -1164,7 +1164,7 @@
   *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256
   *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384
   */
@@ -92,7 +92,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
-@@ -1263,7 +1263,7 @@
+@@ -1268,7 +1268,7 @@
   * This option is only useful if both MBEDTLS_SHA256_C and
   * MBEDTLS_SHA512_C are defined. Otherwise the available hash module is used.
   */
@@ -101,7 +101,7 @@
  
  /**
   * \def MBEDTLS_ENTROPY_NV_SEED
-@@ -1478,14 +1478,14 @@
+@@ -1483,14 +1483,14 @@
   * Uncomment this macro to disable the use of CRT in RSA.
   *
   */
@@ -118,7 +118,7 @@
  
  /**
   * \def MBEDTLS_SHA256_SMALLER
-@@ -1756,7 +1756,7 @@
+@@ -1761,7 +1761,7 @@
   *          configuration of this extension).
   *
   */
@@ -127,7 +127,7 @@
  
  /**
   * \def MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO
-@@ -2017,7 +2017,7 @@
+@@ -2022,7 +2022,7 @@
   *
   * Comment this macro to disable support for truncated HMAC in SSL
   */
@@ -136,7 +136,7 @@
  
  /**
   * \def MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT
-@@ -2185,7 +2185,7 @@
+@@ -2201,7 +2201,7 @@
   *
   * Comment this to disable run-time checking and save ROM space
   */
@@ -145,7 +145,7 @@
  
  /**
   * \def MBEDTLS_X509_ALLOW_EXTENSIONS_NON_V3
-@@ -2534,7 +2534,7 @@
+@@ -2550,7 +2550,7 @@
   *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256
   *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256
   */
@@ -154,7 +154,7 @@
  
  /**
   * \def MBEDTLS_ARIA_C
-@@ -2600,7 +2600,7 @@
+@@ -2616,7 +2616,7 @@
   * This module enables the AES-CCM ciphersuites, if other requisites are
   * enabled as well.
   */
@@ -163,7 +163,7 @@
  
  /**
   * \def MBEDTLS_CERTS_C
-@@ -2612,7 +2612,7 @@
+@@ -2628,7 +2628,7 @@
   *
   * This module is used for testing (ssl_client/server).
   */
@@ -172,7 +172,7 @@
  
  /**
   * \def MBEDTLS_CHACHA20_C
-@@ -2725,7 +2725,7 @@
+@@ -2741,7 +2741,7 @@
   * \warning   DES is considered a weak cipher and its use constitutes a
   *            security risk. We recommend considering stronger ciphers instead.
   */
@@ -181,7 +181,7 @@
  
  /**
   * \def MBEDTLS_DHM_C
-@@ -2890,7 +2890,7 @@
+@@ -2906,7 +2906,7 @@
   * This module adds support for the Hashed Message Authentication Code
   * (HMAC)-based key derivation function (HKDF).
   */
@@ -190,7 +190,7 @@
  
  /**
   * \def MBEDTLS_HMAC_DRBG_C
-@@ -3203,7 +3203,7 @@
+@@ -3219,7 +3219,7 @@
   *
   * This module enables abstraction of common (libc) functions.
   */
@@ -199,7 +199,7 @@
  
  /**
   * \def MBEDTLS_POLY1305_C
-@@ -3279,7 +3279,7 @@
+@@ -3295,7 +3295,7 @@
   * Caller:  library/md.c
   *
   */
@@ -208,7 +208,7 @@
  
  /**
   * \def MBEDTLS_RSA_C
-@@ -3486,7 +3486,7 @@
+@@ -3506,7 +3506,7 @@
   *
   * This module provides run-time version information.
   */
@@ -217,12 +217,12 @@
  
  /**
   * \def MBEDTLS_X509_USE_C
-@@ -3596,7 +3596,7 @@
+@@ -3616,7 +3616,7 @@
   * Module:  library/xtea.c
   * Caller:
   */
 -#define MBEDTLS_XTEA_C
 +//#define MBEDTLS_XTEA_C
  
- /* \} name SECTION: mbed TLS modules */
+ /** \} name SECTION: mbed TLS modules */
  


### PR DESCRIPTION
Changelog: https://github.com/Mbed-TLS/mbedtls/releases/tag/v2.28.1
This release of Mbed TLS provides bug fixes and minor enhancements. This
release includes fixes for security issues.

The build problem was reported upstream:
https://github.com/Mbed-TLS/mbedtls/issues/6243

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
