### PR TITLE
mpc85xx: Make AP3825i boot env partition writable

### DIFF
--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/ws-ap3825i.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/ws-ap3825i.dts
@@ -126,13 +126,11 @@
 				partition@3f00000 {
 					reg = <0x3f00000 0x20000>;
 					label = "cfg2";
-					read-only;
 				};
 
 				partition@3f20000 {
 					reg = <0x3f20000 0x20000>;
 					label = "cfg1";
-					read-only;
 				};
 			};
 		};


### PR DESCRIPTION
End-users may need to be able to rewrite u-boot configuration on the
WS-AP3825i, which has had repeated issues with the exact configuration
of u-boot, e.g. commit 1d06277407 ("mpc85xx: Fix output location of
padded dtb") (alongside other failures documented for example in this
post[^1] from the main AP3825i porting thread).

To assist with this, remove the `read-only` property from the u-boot
configuration partitions cfg1 and cfg2.

[^1]: https://forum.openwrt.org/t/adding-openwrt-support-for-ws-ap3825i/101168/107

Signed-off-by: Martin Kennedy <hurricos@gmail.com>
