### PR TITLE
mpc85xx: Drop pci aliases to avoid domain changes 

### DIFF
--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/hiveap-330.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/hiveap-330.dts
@@ -300,3 +300,16 @@
 	};
 };
 /include/ "fsl/p1020si-post.dtsi"
+
+/*
+ * For the OpenWrt 22.03 release, since Linux 5.10.138 now uses
+ * aliases to determine PCI domain numbers, drop aliases so as not to
+ * change the sysfs path of our wireless netdevs.
+ */
+
+/ {
+	aliases {
+		/delete-property/ pci0;
+		/delete-property/ pci1;
+	};
+};

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/panda.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/panda.dts
@@ -265,3 +265,17 @@
 	};
 };
 /include/ "fsl/p1020si-post.dtsi"
+
+/*
+ * For the OpenWrt 22.03 release, since Linux 5.10.138 now uses
+ * aliases to determine PCI domain numbers, drop aliases so as not to
+ * change the sysfs path of our wireless netdevs.
+ */
+
+/ {
+	aliases {
+		/delete-property/ pci0;
+		/delete-property/ pci1;
+	};
+};
+

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/red-15w-rev1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/red-15w-rev1.dts
@@ -214,3 +214,17 @@
 };
 
 /include/ "fsl/p1010si-post.dtsi"
+
+/*
+ * For the OpenWrt 22.03 release, since Linux 5.10.138 now uses
+ * aliases to determine PCI domain numbers, drop aliases so as not to
+ * change the sysfs path of our wireless netdevs.
+ */
+
+/ {
+	aliases {
+		/delete-property/ pci0;
+		/delete-property/ pci1;
+	};
+};
+

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
@@ -302,3 +302,16 @@
 		/delete-node/ crypto@30000; /* Pulled in by p1010si-post */
 	};
 };
+
+/*
+ * For the OpenWrt 22.03 release, since Linux 5.10.138 now uses
+ * aliases to determine PCI domain numbers, drop aliases so as not to
+ * change the sysfs path of our wireless netdevs.
+ */
+
+/ {
+	aliases {
+		/delete-property/ pci0;
+		/delete-property/ pci1;
+	};
+};

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/ws-ap3710i.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/ws-ap3710i.dts
@@ -173,3 +173,16 @@
 
 };
 /include/ "fsl/p1020si-post.dtsi"
+
+/*
+ * For the OpenWrt 22.03 release, since Linux 5.10.138 now uses
+ * aliases to determine PCI domain numbers, drop aliases so as not to
+ * change the sysfs path of our wireless netdevs.
+ */
+
+/ {
+	aliases {
+		/delete-property/ pci0;
+		/delete-property/ pci1;
+	};
+};

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/ws-ap3825i.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/ws-ap3825i.dts
@@ -253,3 +253,16 @@
 };
 
 /include/ "fsl/p1020si-post.dtsi"
+
+/*
+ * For the OpenWrt 22.03 release, since Linux 5.10.138 now uses
+ * aliases to determine PCI domain numbers, drop aliases so as not to
+ * change the sysfs path of our wireless netdevs.
+ */
+
+/ {
+	aliases {
+		/delete-property/ pci0;
+		/delete-property/ pci1;
+	};
+};


### PR DESCRIPTION
As of upstream Linux commit 0fe1e96fef0a ("powerpc/pci: Prefer PCI
domain assignment via DT 'linux,pci-domain' and alias"), the PCIe
domain address is no longer numbered by the lowest 16 bits of the PCI
register address after a fallthrough. Instead of the fallthrough, the
enumeration process accepts the alias ID (as determined by
`of_alias_scan()`). This causes e.g.:

9000:00:00.0 PCI bridge: Freescale Semiconductor Inc P1020E (rev 11)
9000:01:00.0 Network controller: Qualcomm Atheros AR958x 802.11abgn ...

to become

0000:00:00.0 PCI bridge: Freescale Semiconductor Inc P1020E (rev 11)
0000:01:00.0 Network controller: Qualcomm Atheros AR958x 802.11abgn ...

... which then causes the sysfs path of the netdev to change,
invalidating the `wifi_device.path`s enumerated in
`/etc/config/wireless`.

One other solution might be to migrate the uci configuration, as was
done for mvebu in commit https://github.com/openwrt/openwrt/commit/0bd5aa89fcf20dc5db073d925d5a08e779ae6292 ("mvebu: Migrate uci config to
new PCIe path"). However, there are concerns that the sysfs path will
change once again once some upstream patches[^2][^3] are merged and
backported (and `CONFIG_PPC_PCI_BUS_NUM_DOMAIN_DEPENDENT` is enabled).

Instead, remove the aliases and allow the fallthrough to continue for
now. We will provide a migration in a later release.

This was first reported as a Github issue[^1].

[^1]: https://github.com/openwrt/openwrt/issues/10530
[^2]: https://lore.kernel.org/linuxppc-dev/20220706104308.5390-1-pali@kernel.org/t/#u
[^3]: https://lore.kernel.org/linuxppc-dev/20220706101043.4867-1-pali@kernel.org/

Tested-by: Martin Kennedy <hurricos@gmail.com>
[Tested on the Aerohive HiveAP 330 and Extreme Networks WS-AP3825i]
Signed-off-by: Martin Kennedy <hurricos@gmail.com>