### PR TITLE
mpc85xx: enable inside secure driver for PowerPC platforms

### DIFF
--- a/target/linux/mpc85xx/Makefile
+++ b/target/linux/mpc85xx/Makefile
@@ -21,6 +21,6 @@ include $(INCLUDE_DIR)/target.mk
 DEFAULT_PACKAGES += \
 	kmod-input-core kmod-input-gpio-keys kmod-button-hotplug \
 	kmod-leds-gpio swconfig kmod-ath9k wpad-basic-mbedtls kmod-usb2 \
-	uboot-envtools
+	uboot-envtools kmod-crypto-hw-talitos
 
 $(eval $(call BuildTarget))


### PR DESCRIPTION
Freescale procesor has Securite Engine driver called Talitos. [1]
This driver is already packaged for OpenWrt since commit
bf57f33f0229564828f576b2dfb897aa0b57e85c ("kernel: Allow talitos crypto
hw module selection"), but many users don't know about it.

Let's include this kernel module package to default packages as it was
 recently done for MediaTek in commit 06c4fc6d5e1eea00e6a3ea208102407408590af8
("kernel: enable inside secure driver for MediaTek platforms")

[1] https://cateee.net/lkddb/web-lkddb/CRYPTO_DEV_TALITOS.html

Once this driver is loaded, then you can see this in system log:
```
root@turris:~# cat /var/log/messages | grep talitos
Aug 30 09:12:38 turris kernel: [   14.737139] talitos ffe30000.crypto: hwrng
Aug 30 09:12:38 turris kernel: [   14.751731] talitos ffe30000.crypto: fsl,sec3.1 algorithms registered in /proc/crypto
```

Tested on CZ.NIC Turris 1.1 router, mpc85xx, OpenWrt 21.02.3 with kernel 5.15 