### PR TITLE
lldpd: update to 1.0.15

### DIFF
--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lldpd
-PKG_VERSION:=1.0.14
+PKG_VERSION:=1.0.15
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/lldpd/lldpd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=0cb77fd7634401347b8311db1bf64d4fc3890acba90915e2cc2c5f79045ddbf0
+PKG_HASH:=bdb1f9e29f61c3be99e421e88a431536c53e62f1ab7189a6d5b8e1d2d55d8899
 
 PKG_MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
 PKG_LICENSE:=ISC


### PR DESCRIPTION
Release Notes:
https://github.com/lldpd/lldpd/releases/tag/1.0.15

Run-Tested: Linksys E8450