### PR TITLE
mvebu: cortex-a53: enable inside secure driver for Armada 37xx/7k/8k SoCs

### DIFF
--- a/target/linux/mvebu/cortexa53/target.mk
+++ b/target/linux/mvebu/cortexa53/target.mk
@@ -8,6 +8,6 @@ ARCH:=aarch64
 BOARDNAME:=Marvell Armada 3700LP (ARM64)
 CPU_TYPE:=cortex-a53
 FEATURES+=ext4
-DEFAULT_PACKAGES+=e2fsprogs ethtool mkf2fs partx-utils
+DEFAULT_PACKAGES+=e2fsprogs ethtool mkf2fs partx-utils kmod-crypto-hw-safexcel
 
 KERNELNAME:=Image dtbs


### PR DESCRIPTION
Marvell Armada 37xx/7k/8k SoCs comes with
inside-secure,safexcel-eip97(eip197). This includes it in the default
installation as it enables SafeXcel cryptographic engine driver for it [1], which is packaged
in OpenWrt since version 21.02 [2].

Firmware should not be required as in Marvell Armada 3720 should be eip97, which works without firmware. Firmware is required only for eip197.

[1] https://cateee.net/lkddb/web-lkddb/CRYPTO_DEV_SAFEXCEL.html
[2] https://github.com/openwrt/openwrt/blob/23c77384f3d191a825fff5e58807ab6d539d5e0e/package/kernel/linux/modules/crypto.mk#L406

___

Similarly as it was done recently for MediaTek platforms in https://github.com/openwrt/openwrt/commit/06c4fc6d5e1eea00e6a3ea208102407408590af8