### PR TITLE
mt76: mt7921e: add firmware for mt7922  wireless chips

### DIFF
--- a/package/kernel/mt76/Makefile
+++ b/package/kernel/mt76/Makefile
@@ -243,6 +243,12 @@ define KernelPackage/mt7921-firmware
   TITLE:=MediaTek MT7921 firmware
 endef
 
+define KernelPackage/mt7922-firmware
+  $(KernelPackage/mt76-default)
+  DEPENDS+=+kmod-mt7921-common
+  TITLE:=MediaTek MT7922 firmware
+endef
+
 define KernelPackage/mt7921-common
   $(KernelPackage/mt76-default)
   TITLE:=MediaTek MT7615 wireless driver common code
@@ -501,6 +507,14 @@ define KernelPackage/mt7921-firmware/install
 		$(1)/lib/firmware/mediatek
 endef
 
+define KernelPackage/mt7922-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
+	cp \
+		$(PKG_BUILD_DIR)/firmware/WIFI_MT7922_patch_mcu_1_1_hdr.bin \
+		$(PKG_BUILD_DIR)/firmware/WIFI_RAM_CODE_MT7922_1.bin \
+		$(1)/lib/firmware/mediatek
+endef
+
 define Package/mt76-test/install
 	mkdir -p $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tools/mt76-test $(1)/usr/sbin
@@ -531,6 +545,7 @@ $(eval $(call KernelPackage,mt7915e))
 $(eval $(call KernelPackage,mt7916-firmware))
 $(eval $(call KernelPackage,mt7986-firmware))
 $(eval $(call KernelPackage,mt7921-firmware))
+$(eval $(call KernelPackage,mt7922-firmware))
 $(eval $(call KernelPackage,mt7921-common))
 $(eval $(call KernelPackage,mt7921u))
 $(eval $(call KernelPackage,mt7921s))


### PR DESCRIPTION
This patch add the firmware file for MT7922 Wi-Fi 6E wireless chips.
Tested on a rockchip/x86-64
Some relevant information;
```
root@OpenWrt:~# lspci -s 0001:01:00.0 -v
0001:01:00.0 Network controller: MEDIATEK Corp. Device 7922
        Subsystem: AzureWave Device 5300
        Flags: bus master, fast devsel, latency 0, IRQ 77
        Memory at 340100000 (64-bit, prefetchable) [size=1M]
        Memory at 340000000 (64-bit, non-prefetchable) [size=32K]
        Capabilities: [80] Express Endpoint, MSI 00
        Capabilities: [e0] MSI: Enable+ Count=1/32 Maskable+ 64bit+
        Capabilities: [f8] Power Management version 3
        Capabilities: [100] Vendor Specific Information: ID=1556 Rev=1 Len=008 <?>
        Capabilities: [108] Latency Tolerance Reporting
        Capabilities: [110] L1 PM Substates
        Capabilities: [200] Advanced Error Reporting
        Kernel driver in use: mt7921e
root@OpenWrt:~# dmesg | grep -i mt7921e
[    6.942301] mt7921e 0000:01:00.0: enabling device (0000 -> 0002)
[    6.961494] mt7921e 0000:01:00.0: ASIC revision: 79220010
[    7.102479] mt7921e 0000:01:00.0: HW/SW Version: 0x8a108a10, Build Time: 20220322163923a
[    7.509139] mt7921e 0000:01:00.0: WM Firmware Version: ____000000, Build Time: 20220322164011
root@OpenWrt:~# iw dev wlan0 station dump
Station a6:2d:c9:14:95:ba (on wlan0)
        inactive time:  101027 ms
        rx bytes:       4333429587
        rx packets:     3293640
        tx bytes:       5056401442
        tx packets:     3689684
        tx retries:     0
        tx failed:      0
        rx drop misc:   1
        signal:         -53 [-59, -54] dBm
        signal avg:     -52 [-58, -54] dBm
        tx bitrate:     1200.9 MBit/s 80MHz HE-MCS 11 HE-NSS 2 HE-GI 0 HE-DCM 0
        tx duration:    4343919225 us
        rx bitrate:     960.7 MBit/s 80MHz HE-MCS 9 HE-NSS 2 HE-GI 0 HE-DCM 0
        rx duration:    36552294 us
        airtime weight: 256
        authorized:     yes
        authenticated:  yes
        associated:     yes
        preamble:       long
        WMM/WME:        yes
        MFP:            no
        TDLS peer:      no
        DTIM period:    2
        beacon interval:100
        short slot time:yes
        connected time: 1395 seconds
        associated at [boottime]:       6720.968s
        associated at:  1661910643996 ms
        current time:   1661912039031 ms
```