### PR TITLE
ramips: add RT-N600 alternative name to RT-AC1200

### DIFF
--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -42,6 +42,8 @@ define Device/asus_rt-ac1200
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RT-AC1200
+  DEVICE_ALT0_VENDOR := Asus
+  DEVICE_ALT0_MODEL := RT-N600
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci \
 	kmod-usb-ledtrig-usbport
 endef


### PR DESCRIPTION
RT-N600 is internally the same as RT-AC1200, as veryfied by @russinnes .
Adding alt_name so that people can find it in firmware selector.

Signed-off-by: Ray Wang <raywang777@foxmail.com>
Tested-by: Russ Innes <russ.innes@gmail.com>