### PR TITLE
realtek: Interrupt handling fixes (v3)

### DIFF
--- a/target/linux/realtek/files-5.10/arch/mips/rtl838x/prom.c
+++ b/target/linux/realtek/files-5.10/arch/mips/rtl838x/prom.c
@@ -29,6 +29,28 @@ extern const char __appended_dtb;
 struct rtl83xx_soc_info soc_info;
 const void *fdt;
 
+#ifdef CONFIG_MIPS_MT_SMP
+extern const struct plat_smp_ops vsmp_smp_ops;
+
+static void rtl_init_secondary(void)
+{
+/*
+ * MIPS timer interrupt might fire like crazy if not used or initialized
+ * properly. Silence it by setting the maximum possible interval.
+ */
+	write_c0_compare(0);
+/*
+ * Enable all CPU interrupts, as everything is managed by the external
+ * controller. TODO: Standard vsmp_init_secondary() has special treatment for
+ * Malta if external GIC is available. Maybe we need this too.
+ */
+	if (mips_gic_present())
+		pr_warn("%s: GIC present. Maybe interrupt enabling required.\n", __func__);
+	else
+		set_c0_status(ST0_IM);
+}
+#endif
+
 const char *get_system_type(void)
 {
 	return soc_info.name;
@@ -193,15 +215,19 @@ void __init prom_init(void)
 
 	prom_init_cmdline();
 
-#ifdef  CONFIG_MIPS_CPS
-	if (!register_cps_smp_ops()) {
+	if (!register_cps_smp_ops())
 		return;
-	}
-#endif
+
 #ifdef CONFIG_MIPS_MT_SMP
-	if (!register_vsmp_smp_ops()) {
+	if (cpu_has_mipsmt) {
+		struct plat_smp_ops rtl_smp_ops;
+
+		rtl_smp_ops = vsmp_smp_ops;
+		rtl_smp_ops.init_secondary = rtl_init_secondary;
+		register_smp_ops(&rtl_smp_ops);
 		return;
 	}
 #endif
+
 	register_up_smp_ops();
 }

--- a/target/linux/realtek/patches-5.10/309-cevt-rtl9300-support.patch
+++ b/target/linux/realtek/patches-5.10/309-cevt-rtl9300-support.patch
@@ -31,24 +31,3 @@
  #ifdef CONFIG_CEVT_R4K
  	return r4k_clockevent_init();
  #else
---- a/arch/mips/kernel/smp-mt.c
-+++ b/arch/mips/kernel/smp-mt.c
-@@ -108,12 +108,18 @@ static void __init smvp_tc_init(unsigned
- static void vsmp_init_secondary(void)
- {
- 	/* This is Malta specific: IPI,performance and timer interrupts */
-+
-+	/* RTL9300 Clear internal timer interrupt */
-+	write_c0_compare(0);
-+
- 	if (mips_gic_present())
- 		change_c0_status(ST0_IM, STATUSF_IP2 | STATUSF_IP3 |
- 					 STATUSF_IP4 | STATUSF_IP5 |
- 					 STATUSF_IP6 | STATUSF_IP7);
- 	else
- 		change_c0_status(ST0_IM, STATUSF_IP0 | STATUSF_IP1 |
-+					 STATUSF_IP2 | STATUSF_IP3 |
-+					 STATUSF_IP4 | STATUSF_IP5 |
- 					 STATUSF_IP6 | STATUSF_IP7);
- }
- 

--- a/target/linux/realtek/patches-5.10/319-irqchip-irq-realtek-rtl-fix-VPE-affinity.patch
+++ b/target/linux/realtek/patches-5.10/319-irqchip-irq-realtek-rtl-fix-VPE-affinity.patch
@@ -1,0 +1,145 @@
+--- a/drivers/irqchip/irq-realtek-rtl.c
++++ b/drivers/irqchip/irq-realtek-rtl.c
+@@ -28,6 +28,7 @@ static DEFINE_RAW_SPINLOCK(irq_lock);
+ 
+ #define REG(offset, cpu)	(realtek_ictl_base[cpu] + offset)
+ 
++static u32 realtek_ictl_unmask[NR_CPUS];
+ static void __iomem *realtek_ictl_base[NR_CPUS];
+ static cpumask_t realtek_ictl_cpu_configurable;
+ 
+@@ -41,11 +42,29 @@ struct realtek_ictl_output {
+ };
+ 
+ /*
+- * IRR0-IRR3 store 4 bits per interrupt, but Realtek uses inverted numbering,
+- * placing IRQ 31 in the first four bits. A routing value of '0' means the
+- * interrupt is left disconnected. Routing values {1..15} connect to output
+- * lines {0..14}.
++ * Per CPU we have a set of 5 registers that determine interrupt handling for
++ * 32 external interrupts. GIMR (enable/disable interrupt) plus IRR0-IRR3 that
++ * contain "routing" or "priority" values. GIMR uses one bit for each interrupt
++ * and IRRx store 4 bits per interrupt. Realtek uses inverted numbering,
++ * placing IRQ 31 in the first four bits. The register combinations give the
++ * following results for a single interrupt in the wild:
++ *
++ * a) GIMR = 0 / IRRx > 0 -> no interrupts
++ * b) GIMR = 0 / IRRx = 0 -> no interrupts
++ * c) GIMR = 1 / IRRx > 0 -> interrupts
++ * d) GIMR = 1 / IRRx = 0 -> rare interrupts in SMP environment
++ *
++ * Combination d) seems to trigger interrupts only on a VPE if the other VPE
++ * has GIMR = 0 and IRRx > 0. E.g. busy without interrupts allowed. To provide
++ * IRQ balancing features in SMP this driver will handle the registers as
++ * follows:
++ *
++ * 1) set IRRx > 0 for VPE where the interrupt is desired
++ * 2) set IRRx = 0 for VPE where the interrupt is not desired
++ * 3) set both GIMR = 0 to mask (disabled) interrupt
++ * 4) set GIMR = 1 to unmask (enable) interrupt but only for VPE where IRRx > 0
+  */
++
+ #define IRR_OFFSET(idx)		(4 * (3 - (idx * 4) / 32))
+ #define IRR_SHIFT(idx)		((idx * 4) % 32)
+ 
+@@ -65,19 +84,33 @@ static inline void write_irr(void __iomem *irr0, int idx, u32 value)
+ 	writel(irr, irr0 + offset);
+ }
+ 
++static inline void enable_gimr(int hwirq, int cpu)
++{
++	u32 value;
++
++	value = readl(REG(RTL_ICTL_GIMR, cpu));
++	value |= (BIT(hwirq) & realtek_ictl_unmask[cpu]);
++	writel(value, REG(RTL_ICTL_GIMR, cpu));
++}
++
++static inline void disable_gimr(int hwirq, int cpu)
++{
++	u32 value;
++
++	value = readl(REG(RTL_ICTL_GIMR, cpu));
++	value &= ~BIT(hwirq);
++	writel(value, REG(RTL_ICTL_GIMR, cpu));
++}
++
+ static void realtek_ictl_unmask_irq(struct irq_data *i)
+ {
+ 	unsigned long flags;
+-	u32 value;
+ 	int cpu;
+ 
+ 	raw_spin_lock_irqsave(&irq_lock, flags);
+ 
+-	for_each_cpu(cpu, &realtek_ictl_cpu_configurable) {
+-		value = readl(REG(RTL_ICTL_GIMR, cpu));
+-		value |= BIT(i->hwirq);
+-		writel(value, REG(RTL_ICTL_GIMR, cpu));
+-	}
++	for_each_cpu(cpu, &realtek_ictl_cpu_configurable)
++		enable_gimr(i->hwirq, cpu);
+ 
+ 	raw_spin_unlock_irqrestore(&irq_lock, flags);
+ }
+@@ -85,16 +118,12 @@ static void realtek_ictl_unmask_irq(struct irq_data *i)
+ static void realtek_ictl_mask_irq(struct irq_data *i)
+ {
+ 	unsigned long flags;
+-	u32 value;
+ 	int cpu;
+ 
+ 	raw_spin_lock_irqsave(&irq_lock, flags);
+ 
+-	for_each_cpu(cpu, &realtek_ictl_cpu_configurable) {
+-		value = readl(REG(RTL_ICTL_GIMR, cpu));
+-		value &= ~BIT(i->hwirq);
+-		writel(value, REG(RTL_ICTL_GIMR, cpu));
+-	}
++	for_each_cpu(cpu, &realtek_ictl_cpu_configurable)
++		disable_gimr(i->hwirq, cpu);
+ 
+ 	raw_spin_unlock_irqrestore(&irq_lock, flags);
+ }
+@@ -116,11 +145,17 @@ static int __maybe_unused realtek_ictl_irq_affinity(struct irq_data *i,
+ 	cpumask_and(&cpu_enable, &cpu_configure, dest);
+ 	cpumask_andnot(&cpu_disable, &cpu_configure, dest);
+ 
+-	for_each_cpu(cpu, &cpu_disable)
++	for_each_cpu(cpu, &cpu_disable) {
+ 		write_irr(REG(RTL_ICTL_IRR0, cpu), i->hwirq, 0);
++		realtek_ictl_unmask[cpu] &= ~BIT(i->hwirq);
++		disable_gimr(i->hwirq, cpu);
++	}
+ 
+-	for_each_cpu(cpu, &cpu_enable)
++	for_each_cpu(cpu, &cpu_enable) {
+ 		write_irr(REG(RTL_ICTL_IRR0, cpu), i->hwirq, output->output_index + 1);
++		realtek_ictl_unmask[cpu] |= BIT(i->hwirq);
++		enable_gimr(i->hwirq, cpu);
++	}
+ 
+ 	irq_data_update_effective_affinity(i, &cpu_enable);
+ 
+@@ -149,6 +184,7 @@ static int intc_map(struct irq_domain *d, unsigned int irq, irq_hw_number_t hw)
+ 
+ 	output->child_mask |= BIT(hw);
+ 	write_irr(REG(RTL_ICTL_IRR0, 0), hw, output->output_index + 1);
++	realtek_ictl_unmask[0] |= BIT(hw);
+ 
+ 	raw_spin_unlock_irqrestore(&irq_lock, flags);
+ 
+@@ -279,9 +315,11 @@ static int __init realtek_rtl_of_init(struct device_node *node, struct device_no
+ 			cpumask_set_cpu(cpu, &realtek_ictl_cpu_configurable);
+ 
+ 			/* Disable all cascaded interrupts and clear routing */
+-			writel(0, REG(RTL_ICTL_GIMR, cpu));
+-			for (soc_irq = 0; soc_irq < RTL_ICTL_NUM_INPUTS; soc_irq++)
++			for (soc_irq = 0; soc_irq < RTL_ICTL_NUM_INPUTS; soc_irq++) {
+ 				write_irr(REG(RTL_ICTL_IRR0, cpu), soc_irq, 0);
++				realtek_ictl_unmask[cpu] &= ~BIT(soc_irq);
++				disable_gimr(soc_irq, cpu);
++			}
+ 		}
+ 	}
+ 


### PR DESCRIPTION
Continuation of #10562 after a messed up rebase.

Thinking about this patch and reading [this conversation](https://lore.kernel.org/all/763394a6e5c83006eb4628a9d0242b7eb04b889d.camel@svanheule.net/) I strongly believe that IRR is indeed a routing priority for the interrupts. With this my patch will read "use routing priority 0 to disable interrupts at all". If the "priority idea" makes sense then [something like this](https://elixir.bootlin.com/linux/v5.10.139/source/Documentation/devicetree/bindings/interrupt-controller/ti,c64x+megamod-pic.txt) might closely match our observation