### PR TITLE
kernel: crypto: Compile the aarch64 crypto-extensions for ghash

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -288,9 +288,7 @@ $(eval $(call KernelPackage,crypto-gf128))
 define KernelPackage/crypto-ghash
   TITLE:=GHASH digest CryptoAPI module
   DEPENDS:=+kmod-crypto-gf128 +kmod-crypto-hash
-  KCONFIG:= \
-	CONFIG_CRYPTO_GHASH \
-	CONFIG_CRYPTO_GHASH_ARM_CE
+  KCONFIG:=CONFIG_CRYPTO_GHASH
   FILES:=$(LINUX_DIR)/crypto/ghash-generic.ko
   AUTOLOAD:=$(call AutoLoad,09,ghash-generic)
   $(call AddDepends/crypto)
@@ -298,12 +296,24 @@ endef
 
 define KernelPackage/crypto-ghash/arm-ce
   FILES+= $(LINUX_DIR)/arch/arm/crypto/ghash-arm-ce.ko
+  KCONFIG+=CONFIG_CRYPTO_GHASH_ARM_CE
   AUTOLOAD+=$(call AutoLoad,09,ghash-arm-ce)
 endef
 
 KernelPackage/crypto-ghash/imx=$(KernelPackage/crypto-ghash/arm-ce)
 KernelPackage/crypto-ghash/ipq40xx=$(KernelPackage/crypto-ghash/arm-ce)
 KernelPackage/crypto-ghash/mvebu/cortexa9=$(KernelPackage/crypto-ghash/arm-ce)
+
+define KernelPackage/crypto-ghash/aarch64
+  FILES+=$(LINUX_DIR)/arch/arm64/crypto/ghash-ce.ko
+  KCONFIG+=CONFIG_CRYPTO_GHASH_ARM64_CE
+  AUTOLOAD+=$(call AutoLoad,09,ghash-ce)
+endef
+
+ifdef KernelPackage/crypto-ghash/$(ARCH)
+  KernelPackage/crypto-ghash/$(CRYPTO_TARGET)=\
+	  $(KernelPackage/crypto-ghash/$(ARCH))
+endif
 
 $(eval $(call KernelPackage,crypto-ghash))
 


### PR DESCRIPTION
GHASH is used in GCM. Without these, only the generic C implementation
is included.

While investigating #10551, it appears that while there is an aarch64-specific
version of ghash, it was probably omitted in our build files.

I'm not sure if this is the right way to go about doing it; comments welcome.

This should be able to be backported to 22.03 also.

Strongswan package maintainers: @pprindeville @Thermi
Recent committers to crypto.mk: @dangowrt @hauke @chunkeey @stintel

Compile-tested: Linksys E8450 target (aarch64) off master. Relevant build logs:
```
removed '/openwrt/bin/targets/mediatek/mt7622/packages/kmod-crypto-ghash_5.15.63-1_aarch64_cortex-a53.ipk'
NOTICE: module '/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_mt7622/linux-5.15.63/crypto/ghash-generic.ko' is built-in.
NOTICE: module '/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_mt7622/linux-5.15.63/arch/arm64/crypto/ghash-ce.ko' is built-in.
Packaged contents of /home/joel/.cache/openwrt-build/target-aarch64_cortex-a53_musl/linux-mediatek_mt7622/packages/ipkg-aarch64_cortex-a53/kmod-crypto-ghash into /openwrt/bin/targets/mediatek/mt7622/packages/kmod-crypto-ghash_5.15.63-1_aarch64_cortex-a53.ipk
removed '/openwrt/bin/targets/mediatek/mt7622/packages/kmod-crypto-gcm_5.15.63-1_aarch64_cortex-a53.ipk'
```

(without this patch, the ghash-ce.ko line doesn't show up.)