### PR TITLE
ramips: add support for bolt_bl201 board

### DIFF
--- a/target/linux/ramips/dts/mt7620a_bolt_bl201.dts
+++ b/target/linux/ramips/dts/mt7620a_bolt_bl201.dts
@@ -1,0 +1,219 @@
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "bolt,bl201", "ralink,mt7620a-soc";
+	model = "Bolt BL 201";
+
+	aliases {
+		led-boot = &power_blue;
+		led-failsafe = &power_red;
+		led-running = &power_blue;
+		led-upgrade = &power_red;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wan {
+			label = "blue:wan";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+
+		power_red: power_red {
+			label = "red:power";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+
+		power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+
+		lte_s1_blue {
+			label = "blue:lte_s1";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		lte_s2_blue {
+			label = "blue:lte_s2";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+		};
+
+		lte_s3_blue {
+			label = "blue:lte_s3";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		};
+		
+		lte_s4_blue {
+			label = "blue:lte_s4";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wps_blue {
+			label = "blue:wps";
+			gpios = <&gpio2 22 GPIO_ACTIVE_LOW>;
+		};
+
+		lte_s1s2_red {
+			label = "red:lte_s1s2";
+			gpios = <&gpio2 24 GPIO_ACTIVE_LOW>;
+		};
+
+		lte_s3s4_red {
+			label = "red:lte_s3s4";
+			gpios = <&gpio2 25 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan_blue {
+			label = "blue:wlan";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		
+		wps {
+			label = "wps";
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		// m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf80000>;
+			};
+
+			partition@fd0000 {
+				label = "crash";
+				reg = <0xfd0000 0x10000>;
+			};
+
+			partition@fe0000 {
+				label = "reserved";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "Bdata";
+				reg = <0xff0000 0x10000>;
+			};
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+
+	mediatek,portmap = "llllw";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pa_pins>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wled", "i2c", "rgmii1";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_28: macaddr@28 {
+		reg = <0x28 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1273,6 +1273,15 @@ define Device/xiaomi_miwifi-mini
 endef
 TARGET_DEVICES += xiaomi_miwifi-mini
 
+define Device/bolt_bl201
+  SOC := mt7620a
+  IMAGE_SIZE := 15872k
+  DEVICE_VENDOR := Bolt
+  DEVICE_MODEL := BL 201
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += bolt_bl201
+
 define Device/youku_yk-l1
   SOC := mt7620a
   IMAGE_SIZE := 32448k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -225,6 +225,10 @@ xiaomi,miwifi-mini)
 	ucidef_set_led_switch "lan2" "lan2" "green:lan2" "switch0" "0x01"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
+bolt,bl201)
+	ucidef_set_led_netdev "wlan0" "wlan0-link" "blue:wlan" "wlan0"
+	ucidef_set_led_netdev "wan" "eth0.2-link" "blue:wan" "eth0.2" "link"
+	;;
 zbtlink,zbt-ape522ii)
 	ucidef_set_led_netdev "wlan2g4" "wlan1-link" "green:wlan2g4" "wlan1"
 	ucidef_set_led_netdev "sys1" "wlan1" "green:sys1" "wlan1" "tx rx"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -190,6 +190,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:2" "1:lan:1" "4:wan" "6@eth0"
 		;;
+	bolt,bl201)
+		ucidef_add_switch "switch0" \
+			"3:lan" "4:wan" "6@eth0"
+		;;
 	lenovo,newifi-y1s)
 		ucidef_add_switch "switch0" \
 			"1:lan:4" "2:lan:3" "4:lan:2" "5:lan:1" "0:wan" "6@eth0"


### PR DESCRIPTION
# Bolt BL201

<div class="column">
  <img src="https://user-images.githubusercontent.com/32604312/188253918-47f6475d-11c4-412d-9ec6-dc365ffa8748.png" alt="drawing" width="250"/>
  <img src="https://user-images.githubusercontent.com/32604312/188254117-22edb541-0c16-4b41-9aa3-800d56289e19.png" alt="drawing" width="250"/>
</div>

## Specs

| Category           | Name                                   |
| ------------------ | -------------------------------------- |
| SoC                | Mediatek MT7620A                         |
| SPI Flash          | Winbond W25Q128BV                      |
| Flash Size         | 16 MB                                  |
| RAM                | 64MB DDR2                              |
| Serial Baudrate    | 57600 (Default)                        |
| USB                | 1x2.0 (Not Mounted, No USB Power)      |
| Switch             | Integrated MT7620 10/100Mbps with VLAN |
| LAN                | 2 Ports. 1 LAN, 1 WAN                  |
| Wireless Frequency | 2.4Ghz, 5Ghz(some of)                  |

> **Notes :** This device actually supports lte cards since BL201 and BL100 using the same boards. I dont implement LTE yet bcs only have this devices.

## Device Tree

**GPIO 1**

  | id  | gpio | direction | desc               |
  | --- | ---- | --------- | ------------------ |
  | 1   | 25   | IN        | BUTTON_WPS (L)     |
  | 2   | 26   | IN        | BUTTON_RESTART (L) |
  | 3   | 27   | -         | -                  |
  | 4   | 28   | -         | -                  |
  | 5   | 29   | OUT       | LED_WAN (L)        |
  | 6   | 30   | OUT       | LED_LTE_SIG_2 (L)  |
  | 7   | 31   | OUT       | LED_LTE_SIG_1 (L)  |
  | 8   | 32   | OUT       | LED_POWER_RED (L)  |
  | 9   | 33   | OUT       | LED_POWER_BLUE (L) |
  | 10  | 34   | OUT       | LED_LTE_SIG_3 (L)  |
  | 11  | 35   | OUT       | LED_LTE_SIG_4 (L)  |


**Partition from Factory**

| dev  | addr , size         | name                |
| ---- | ------------------- | ------------------- |
| MTD0 | 0x000000, 0x1000000 | ALL                 |
| MTD1 | 0x000000, 0x030000  | Bootloader (U-boot) |
| MTD2 | 0x030000, 0x010000  | Config (U-boot env) |
| MTD3 | 0x040000, 0x010000  | Factory             |
| MTD4 | 0x050000, 0x050000  | Kernel              |
| MTD5 | 0x0a0000, 0xf50000  | Kernel2             |
| MTD6 | 0xff0000, 0x010000  | SmsInfo (Bdata)     |

**Partition from OpenWRT**

| dev      | addr , size          | name                      |
| -------- | -------------------- | ------------------------- |
| **MTD0** | 0x000000, 0x030000   | u-boot                    |
| **MTD1** | 0x030000, 0x010000   | u-boot env                |
| **MTD2** | 0x040000, 0x010000   | factory                   |
| **MTD3** | 0x050000, 0xf80000   | firmware                  |
| _MTD4_   | _0x000000, 0x1ec30e_ | _kernel (uimage)_         |
| _MTD5_   | _0x1ec30e, 0xD93CF2_ | _rootfs (uimage)_         |
| _MTD6_   | _0x000000, 0x030000_ | _\_rootfs_data (split)_\_ |
| **MTD7** | 0xfd0000, 0x010000   | crash                     |
| **MTD8** | 0xfe0000, 0x010000   | reserved                  |
| **MTD9** | 0xff0000, 0x010000   | Bdata                     |

What configuration added:
  - leds
  - network
  - button

## Installation Guide

**via BREED**

Boot and Recovery Environment for Embedded Devices (BREED) is A multi-task bootloader with real-time firmware upgrading progress. For more checkout [this](https://openwrt.org/docs/techref/bootloader/breed) page. This method allow flashing without disassembly the router.

1. Preparation
   - Prepare **Breed Translator Extension**, then install to browser
   - Prepare **breed** image from [here](https://breed.hackpascal.net/), then select this file `breed-mt7620-reset26.bin`.
   - Prepare **OpenWRT** sysupgrade image from the official link.
     > router are compatible with **Xiaomi Mi WiFi Mini** image
   - Prepare telnet client software like `putty`, `telnet`

<!-- 1. Prepare sysupgrade images from official link.
   > compatible with Xiaomi MiWiFi Mini -->

2. Get telnet access from router.

   - Modify router configuration. Take a backup configuration first, then extract.
   - Edit `2860.dat` using text editor.
   - Find `MGMT_TELNET_WAN` and `MGMT_TELNET_LAN`.
   - Change both **value** to **1**.
   - **Reboot** the router.

3. Flash **BREED**

   - Connect **telnet** to router IP then login using this creds

     ```
     telnet 192.168.1.1

     login        : admin
     password     : db40
     ```

   - Open `/tmp` directory, then copy breed images using `wget`. Try to create local web server for transfering data.

     ```
     cd /tmp

     wget [url] -O uboot.bin
     ```

   - Flash `uboot.bin` to `Bootloader` using `mtd_write`
     ```
     mtd_write -r write uboot.bin Bootloader
     ```
   - Wait router for reboot. Then, turn off the router.

4. Flash **OpenWRT**
   - Hold reset button, then turn on the router. Wait for 2s-3s.
   - Open **BREED Web Recovery** url `http://192.168.1.1/` using browser, then select firmware upgrade. Make sure **Breed Translator Extension** installed on browser. Otherwise, it needs manually translate.
   - Select Flash layout `0x50000`.
   - Check **firmware** tab and choose file, locate the **sysupgrade** image.
   - Check **Auto Restart** box, then select **Upload**.
   - Make sure your firmware match. Then go **Update**.
   - Wait for 3min - 5min. OpenWRT installation is done.

## Log

<details>

   ```
   U-Boot 1.1.3 (Jul 10 2017 - 09:34:46)


   Board:  APSoC DRAM:  64 MB

   relocate_code Pointer at: 83fb8000

   enable ephy clock...done. rf reg 29 = 5

   SSC disabled.

   spi_wait_nsec: 29

   spi device id: ef 40 18 0 0 (40180000)

   find flash: W25Q128BV

   raspi_read: from:30000 len:1000

   raspi_read: from:30000 len:1000

   ============================================

   LTE Router Version: 2.0.5

   --------------------------------------------

   ASIC 7620_MP (Port5<->None)

   DRAM component: 512 Mbits DDR, width 16

   DRAM bus: 16 bit

   Total memory: 64 MBytes

   Flash component: 16 MBytes NOR Flash

   Date:Jul 10 2017  Time:09:34:46

   ============================================
   ```
   <summary>
      Uboot Log
   </summary>
</details>


<details>

```
Linux version 2.6.36 (rd8sw2@rd8sw2-desktop) (gcc version 3.4.2) #1 PREEMPT Mon Jul 10 09:47:03 CST 2017

The CPU feqenuce set to 580 MHz

MIPS CPU sleep mode enabled.
PCIE: bypass PCIe DLL.
PCIE: Elastic buffer control: Addr:0x68 -> 0xB4
disable all power about PCIe
CPU revision is: 00019650 (MIPS 24Kc)
Software DMA cache coherency
Determined physical RAM map:
memory: 04000000 @ 00000000 (usable)
Initrd not found or empty - disabling initrd
Zone PFN ranges:
Normal   0x00000000 -> 0x00004000
Movable zone start PFN for each node
early_node_map[1] active PFN ranges
   0: 0x00000000 -> 0x00004000
Built 1 zonelists in Zone order, mobility grouping on.  Total pages: 16256
Kernel command line: console=ttyS1,57600n8 root=/dev/ram0 console=ttyS0
PID hash table entries: 256 (order: -2, 1024 bytes)
Dentry cache hash table entries: 8192 (order: 3, 32768 bytes)
Inode-cache hash table entries: 4096 (order: 2, 16384 bytes)
Primary instruction cache 64kB, VIPT, , 4-waylinesize 32 bytes.
Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
Writing ErrCtl register=00000007
Readback ErrCtl register=00000007
Memory: 54612k/65536k available (4955k kernel code, 10924k reserved, 1219k data, 3880k init, 0k highmem)
NR_IRQS:128
console [ttyS1] enabled
Calibrating delay loop... 385.84 BogoMIPS (lpj=1929216)
pid_max: default: 32768 minimum: 301
Mount-cache hash table entries: 512
NET: Registered protocol family 16
RALINK_GPIOMODE = 141710
RALINK_GPIOMODE = 141710
PPLL_CFG1=0xe74000
MT7620 PPLL lock
PPLL_DRV =0x80080504
start PCIe register access
RALINK_RSTCTRL = 2400000
RALINK_CLKCFG1 = 75afffc0

*************** MT7620 PCIe RC mode *************
PCIE0 enabled
Port 0 N_FTS = 1b105000
init_rt2880pci done
bio: create slab <bio-0> at 0
vgaarb: loaded
SCSI subsystem initialized
usbcore: registered new interface driver usbfs
usbcore: registered new interface driver hub
usbcore: registered new device driver usb
pci 0000:00:00.0: BAR 0: can't assign mem (size 0x80000000)
pci 0000:00:00.0: BAR 8: assigned [mem 0x20000000-0x200fffff]
pci 0000:00:00.0: BAR 9: assigned [mem 0x20100000-0x201fffff pref]
pci 0000:00:00.0: BAR 1: assigned [mem 0x20200000-0x2020ffff]
pci 0000:00:00.0: BAR 1: set to [mem 0x20200000-0x2020ffff] (PCI address [0x20200000-0x2020ffff]
pci 0000:01:00.0: BAR 0: assigned [mem 0x20000000-0x200fffff 64bit]
pci 0000:01:00.0: BAR 0: set to [mem 0x20000000-0x200fffff 64bit] (PCI address [0x20000000-0x200fffff]
pci 0000:01:00.0: BAR 6: assigned [mem 0x20100000-0x2010ffff pref]
pci 0000:00:00.0: PCI bridge to [bus 01-01]
pci 0000:00:00.0:   bridge window [io  disabled]
pci 0000:00:00.0:   bridge window [mem 0x20000000-0x200fffff]
pci 0000:00:00.0:   bridge window [mem 0x20100000-0x201fffff pref]
BAR0 at slot 0 = 0
bus=0x0, slot = 0x0
res[0]->start = 0
res[0]->end = 0
res[1]->start = 20200000
res[1]->end = 2020ffff
res[2]->start = 0
res[2]->end = 0
res[3]->start = 0
res[3]->end = 0
res[4]->start = 0
res[4]->end = 0
res[5]->start = 0
res[5]->end = 0
bus=0x1, slot = 0x0
res[0]->start = 20000000
res[0]->end = 200fffff
res[1]->start = 0
res[1]->end = 0
res[2]->start = 0
res[2]->end = 0
res[3]->start = 0
res[3]->end = 0
res[4]->start = 0
res[4]->end = 0
res[5]->start = 0
res[5]->end = 0
Switching to clocksource Ralink Systick timer
NET: Registered protocol family 2
IP route cache hash table entries: 1024 (order: 0, 4096 bytes)
TCP established hash table entries: 2048 (order: 2, 16384 bytes)
TCP bind hash table entries: 2048 (order: 1, 8192 bytes)
TCP: Hash tables configured (established 2048 bind 2048)
TCP reno registered
UDP hash table entries: 256 (order: 0, 4096 bytes)
UDP-Lite hash table entries: 256 (order: 0, 4096 bytes)
NET: Registered protocol family 1
```

   <summary>
      Factory Firmware Log
   </summary>
   </details>

<details>

```
[    0.000000] Linux version 5.4.188 (raf@x300) (gcc version 8.4.0 (OpenWrt GCC 8.4.0 r16554-1d4dea6d4f)) #0 Sat Apr 16 12:59:34 2022
[    0.000000] Board has DDR2
[    0.000000] Analog PMU set to hw control
[    0.000000] Digital PMU set to hw control
[    0.000000] SoC Type: MediaTek MT7620A ver:2 eco:6
[    0.000000] printk: bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 00019650 (MIPS 24KEc)
[    0.000000] MIPS: machine is Bolt BL 201
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] Primary instruction cache 64kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x0000000003ffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x0000000003ffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x0000000003ffffff]
[    0.000000] On node 0 totalpages: 16384
[    0.000000]   Normal zone: 144 pages used for memmap
[    0.000000]   Normal zone: 0 pages reserved
[    0.000000]   Normal zone: 16384 pages, LIFO batch:3
[    0.000000] pcpu-alloc: s0 r0 d32768 u32768 alloc=1*32768
[    0.000000] pcpu-alloc: [0] 0
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 16240
[    0.000000] Kernel command line: console=ttyS0,115200 rootfstype=squashfs,jffs2
[    0.000000] Dentry cache hash table entries: 8192 (order: 3, 32768 bytes, linear)
[    0.000000] Inode-cache hash table entries: 4096 (order: 2, 16384 bytes, linear)
[    0.000000] Writing ErrCtl register=00000000
[    0.000000] Readback ErrCtl register=00000000
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 57372K/65536K available (4791K kernel code, 200K rwdata, 1056K rodata, 1176K init, 205K bss, 8164K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] NR_IRQS: 256
[    0.000000] random: get_random_bytes called from start_kernel+0x358/0x54c with crng_init=0
[    0.000000] CPU Clock: 580MHz
[    0.000000] clocksource: systick: mask: 0xffff max_cycles: 0xffff, max_idle_ns: 583261500 ns
[    0.000000] systick: enable autosleep mode
[    0.000000] systick: running - mult: 214748, shift: 32
[    0.000000] clocksource: MIPS: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 6590553264 ns
[    0.000011] sched_clock: 32 bits at 290MHz, resolution 3ns, wraps every 7405115902ns
[    0.007968] Calibrating delay loop... 385.02 BogoMIPS (lpj=770048)
[    0.046151] pid_max: default: 32768 minimum: 301
[    0.051053] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.058443] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.073459] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.083384] futex hash table entries: 256 (order: -1, 3072 bytes, linear)
[    0.090385] pinctrl core: initialized pinctrl subsystem
[    0.096297] NET: Registered protocol family 16
[    0.363708] PCI host bridge /pcie@10140000 ranges:
[    0.368546]  MEM 0x0000000020000000..0x000000002fffffff
[    0.373844]   IO 0x0000000010160000..0x000000001016ffff
[    0.402226] rt2880_gpio 10000600.gpio: registering 24 gpios
[    0.407961] rt2880_gpio 10000600.gpio: registering 24 irq handlers
[    0.414607] rt2880_gpio 10000638.gpio: registering 16 gpios
[    0.420300] rt2880_gpio 10000638.gpio: registering 16 irq handlers
[    0.427409] PCI host bridge to bus 0000:00
[    0.431583] pci_bus 0000:00: root bus resource [mem 0x20000000-0x2fffffff]
[    0.438527] pci_bus 0000:00: root bus resource [io  0x10160000-0x1016ffff]
[    0.445524] pci_bus 0000:00: root bus resource [??? 0x00000000 flags 0x0]
[    0.452429] pci_bus 0000:00: No busn resource found for root bus, will use [bus 00-ff]
[    0.460540] pci 0000:00:00.0: [1814:0801] type 01 class 0x060400
[    0.466634] pci 0000:00:00.0: reg 0x10: [mem 0x00000000-0x7fffffff]
[    0.472980] pci 0000:00:00.0: reg 0x14: [mem 0x20200000-0x2020ffff]
[    0.479430] pci 0000:00:00.0: supports D1
[    0.483452] pci 0000:00:00.0: PME# supported from D0 D1 D3hot
[    0.491812] pci 0000:01:00.0: [14c3:7662] type 00 class 0x028000
[    0.497970] pci 0000:01:00.0: reg 0x10: [mem 0x00000000-0x000fffff 64bit]
[    0.504872] pci 0000:01:00.0: reg 0x30: [mem 0x00000000-0x0000ffff pref]
[    0.511763] pci 0000:01:00.0: PME# supported from D0 D3hot D3cold
[    0.520336] pci_bus 0000:01: busn_res: [bus 01-ff] end is updated to 01
[    0.527053] pci_bus 0000:00: busn_res: [bus 00-ff] end is updated to 01
[    0.533777] pci 0000:00:00.0: BAR 0: no space for [mem size 0x80000000]
[    0.540477] pci 0000:00:00.0: BAR 0: failed to assign [mem size 0x80000000]
[    0.547566] pci 0000:00:00.0: BAR 8: assigned [mem 0x20000000-0x200fffff]
[    0.554473] pci 0000:00:00.0: BAR 9: assigned [mem 0x20100000-0x201fffff pref]
[    0.561820] pci 0000:00:00.0: BAR 1: assigned [mem 0x20200000-0x2020ffff]
[    0.568736] pci 0000:01:00.0: BAR 0: assigned [mem 0x20000000-0x200fffff 64bit]
[    0.576185] pci 0000:01:00.0: BAR 6: assigned [mem 0x20100000-0x2010ffff pref]
[    0.583513] pci 0000:00:00.0: PCI bridge to [bus 01]
[    0.588563] pci 0000:00:00.0:   bridge window [mem 0x20000000-0x200fffff]
[    0.595468] pci 0000:00:00.0:   bridge window [mem 0x20100000-0x201fffff pref]
[    0.608006] clocksource: Switched to clocksource systick
[    0.614862] NET: Registered protocol family 2
[    0.619509] IP idents hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.627629] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.636169] TCP established hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.643926] TCP bind hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.651094] TCP: Hash tables configured (established 1024 bind 1024)
[    0.657707] UDP hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.664364] UDP-Lite hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.671716] NET: Registered protocol family 1
[    0.676197] PCI: CLS 0 bytes, default 32
[    0.683084] rt-timer 10000100.timer: maximum frequency is 1220Hz
[    0.691538] workingset: timestamp_bits=14 max_order=14 bucket_order=0
[    0.706700] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.712638] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.740842] Serial: 8250/16550 driver, 2 ports, IRQ sharing disabled
[    0.748557] printk: console [ttyS0] disabled
[    0.752960] 10000c00.uartlite: ttyS0 at MMIO 0x10000c00 (irq = 20, base_baud = 2500000) is a Palmchip BK-3103
[    0.763031] printk: console [ttyS0] enabled
[    0.771497] printk: bootconsole [early0] disabled
[    0.787415] spi spi0.0: force spi mode3
[    0.801362] spi-nor spi0.0: w25q128 (16384 Kbytes)
[    0.806348] 7 fixed-partitions partitions found on MTD device spi0.0
[    0.812844] Creating 7 MTD partitions on "spi0.0":
[    0.817754] 0x000000000000-0x000000030000 : "u-boot"
[    0.823885] 0x000000030000-0x000000040000 : "u-boot-env"
[    0.830421] 0x000000040000-0x000000050000 : "factory"
[    0.836738] 0x000000050000-0x000000fd0000 : "firmware"
[    0.846477] 2 uimage-fw partitions found on MTD device firmware
[    0.852603] Creating 2 MTD partitions on "firmware":
[    0.857694] 0x000000000000-0x0000001ec30e : "kernel"
[    0.863855] 0x0000001ec30e-0x000000f80000 : "rootfs"
[    0.869949] mtd: device 5 (rootfs) set to be root filesystem
[    0.877647] 1 squashfs-split partitions found on MTD device rootfs
[    0.884050] 0x00000059f000-0x000000f80000 : "rootfs_data"
[    0.890624] 0x000000fd0000-0x000000fe0000 : "crash"
[    0.896760] 0x000000fe0000-0x000000ff0000 : "reserved"
[    0.903124] 0x000000ff0000-0x000001000000 : "Bdata"
[    0.922390] gsw: setting port4 to ephy mode
[    0.926761] mtk_soc_eth 10100000.ethernet eth0 (uninitialized): port 3 link up (100Mbps/Full duplex)
[    0.936081] mtk_soc_eth 10100000.ethernet eth0 (uninitialized): port 4 link up (100Mbps/Full duplex)
[    0.945880] mtk_soc_eth 10100000.ethernet: loaded mt7620 driver
[    0.952730] mtk_soc_eth 10100000.ethernet eth0: mediatek frame engine at 0xb0100000, irq 5
[    0.961748] rt2880_wdt 10000120.watchdog: Initialized
[    0.968505] NET: Registered protocol family 10
[    0.977363] Segment Routing with IPv6
[    0.981344] NET: Registered protocol family 17
[    0.985966] 8021q: 802.1Q VLAN Support v1.8
[    1.002649] VFS: Mounted root (squashfs filesystem) readonly on device 31:5.
[    1.016557] Freeing unused kernel memory: 1176K
[    1.021207] This architecture does not have kernel memory protection.
[    1.027786] Run /sbin/init as init process
[    1.239954] random: fast init done
[    2.732761] init: Console is alive
[    2.736603] init: - watchdog -
[    5.503568] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    5.883689] usbcore: registered new interface driver usbfs
[    5.889477] usbcore: registered new interface driver hub
[    5.895042] usbcore: registered new device driver usb
[    5.907639] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
[    5.916514] ehci-fsl: Freescale EHCI Host controller driver
[    5.924016] ehci-platform: EHCI generic platform driver
[    5.939701] phy phy-usbphy.0: remote usb device wakeup disabled
[    5.945764] phy phy-usbphy.0: UTMI 16bit 30MHz
[    5.950316] ehci-platform 101c0000.ehci: EHCI Host Controller
[    5.956234] ehci-platform 101c0000.ehci: new USB bus registered, assigned bus number 1
[    5.964475] ehci-platform 101c0000.ehci: irq 26, io mem 0x101c0000
[    5.975534] ehci-platform 101c0000.ehci: USB 2.0 started, EHCI 1.00
[    5.983076] hub 1-0:1.0: USB hub found
[    5.987444] hub 1-0:1.0: 1 port detected
[    5.997777] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
[    6.005605] ohci-platform: OHCI generic platform driver
[    6.011315] ohci-platform 101c1000.ohci: Generic Platform OHCI controller
[    6.018331] ohci-platform 101c1000.ohci: new USB bus registered, assigned bus number 2
[    6.026550] ohci-platform 101c1000.ohci: irq 26, io mem 0x101c1000
[    6.057949] hub 2-0:1.0: USB hub found
[    6.062311] hub 2-0:1.0: 1 port detected
[    6.072850] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    6.084795] init: - preinit -
[    8.044657] random: jshn: uninitialized urandom read (4 bytes read)
[    8.141288] random: jshn: uninitialized urandom read (4 bytes read)
[    8.281900] random: jshn: uninitialized urandom read (4 bytes read)
[    9.102331] 8021q: adding VLAN 0 to HW filter on device eth0
[    9.179132] urandom_read: 4 callbacks suppressed
[    9.179142] random: procd: uninitialized urandom read (4 bytes read)
[   12.157303] jffs2: notice: (471) jffs2_build_xattr_subsystem: complete building xattr subsystem, 11 of xdatum (8 unchecked, 3 orphan) and 13 of xref (3 dead, 0 orphan) found.
[   12.176418] mount_root: switching to jffs2 overlay
[   12.190893] overlayfs: upper fs does not support tmpfile.
[   12.208235] urandom-seed: Seeding with /etc/urandom.seed
[   12.348250] procd: - early -
[   12.351319] procd: - watchdog -
[   12.783902] procd: - watchdog -
[   12.790184] procd: - ubus -
[   12.874811] random: ubusd: uninitialized urandom read (4 bytes read)
[   12.883634] random: ubusd: uninitialized urandom read (4 bytes read)
[   12.894350] procd: - init -
[   14.260899] kmodloader: loading kernel modules from /etc/modules.d/*
[   14.528587] GACT probability on
[   14.538492] Mirror/redirect action on
[   14.543691] urngd: jent-rng init failed, err: 2
[   14.565040] u32 classifier
[   14.567895]     input device check on
[   14.571650]     Actions configured
[   14.611786] Loading modules backported from Linux version v5.10.110-0-g3238bffaf992
[   14.619709] Backport generated by backports.git v5.10.110-1-0-g1fbde860
[   14.718918] xt_time: kernel timezone is -0000
[   14.896278] mt76x2e 0000:01:00.0: card - bus=0x1, slot = 0x0 irq=4
[   14.902947] mt76x2e 0000:01:00.0: ASIC revision: 76120044
[   15.107296] mt76x2e 0000:01:00.0: ROM patch build: 20141115060606a
[   15.119472] mt76x2e 0000:01:00.0: Firmware Version: 0.0.00
[   15.125147] mt76x2e 0000:01:00.0: Build: 1
[   15.129339] mt76x2e 0000:01:00.0: Build Time: 201507311614____
[   15.144755] mt76x2e 0000:01:00.0: Firmware running!
[   15.152069] ieee80211 phy0: Selected rate control algorithm 'minstrel_ht'
[   15.304639] PPP generic driver version 2.4.2
[   15.312854] NET: Registered protocol family 24
[   15.356057] rt2800_wmac 10180000.wmac: loaded eeprom from mtd device "factory"
[   15.363536] ieee80211 phy1: rt2x00_set_rt: Info - RT chipset 6352, rev 0500 detected
[   15.371482] ieee80211 phy1: rt2x00_set_rf: Info - RF chipset 7620 detected
[   15.378649] ieee80211 phy1: Selected rate control algorithm 'minstrel_ht'
[   15.405084] kmodloader: done loading kernel modules from /etc/modules.d/*
[   22.565812] crng init done
[   33.969980] 8021q: adding VLAN 0 to HW filter on device eth0
[   34.014141] br-lan: port 1(eth0.1) entered blocking state
[   34.019728] br-lan: port 1(eth0.1) entered disabled state
[   34.025685] device eth0.1 entered promiscuous mode
[   34.030640] device eth0 entered promiscuous mode
[   34.098021] br-lan: port 1(eth0.1) entered blocking state
[   34.103593] br-lan: port 1(eth0.1) entered forwarding state
[   34.590238] br-lan: port 2(eth0.2) entered blocking state
[   34.595836] br-lan: port 2(eth0.2) entered disabled state
[   34.601818] device eth0.2 entered promiscuous mode
[   34.606926] br-lan: port 2(eth0.2) entered blocking state
[   34.612494] br-lan: port 2(eth0.2) entered forwarding state
[   34.998406] IPv6: ADDRCONF(NETDEV_CHANGE): br-lan: link becomes ready
[   38.364233] ieee80211 phy1: rt2800_rf_self_txdc_cal: Info - RF Tx self calibration start
[   38.373053] ieee80211 phy1: rt2800_rf_self_txdc_cal: Info - RF Tx self calibration end
[   40.948425] ieee80211 phy1: rt2800_loft_iq_calibration: Info - LOFT Calibration Done!
[   41.461345] ieee80211 phy1: rt2800_iq_search: Info - IQCalibration Start!
[   41.482658] ieee80211 phy1: rt2800_iq_search: Info - IQCalibration Done! CH = 0, (gain= 1, phase=3d)
[   41.492898] ieee80211 phy1: rt2800_iq_search: Info - IQCalibration Start!
[   41.514204] ieee80211 phy1: rt2800_iq_search: Info - IQCalibration Done! CH = 1, (gain= 1, phase=3e)
[   41.523565] ieee80211 phy1: rt2800_loft_iq_calibration: Info - TX IQ Calibration Done!
[   42.032859] ieee80211 phy1: rt2800_rxiq_calibration: Warning - Wait MAC Status to MAX !!!
[   42.057827] ieee80211 phy1: rt2800_rxiq_calibration: Info - RXIQ G_imb=-2, Ph_rx=2
[   42.075829] ieee80211 phy1: rt2800_rxiq_calibration: Info - RXIQ G_imb=-1, Ph_rx=3
[   42.121078] br-lan: port 3(wlan1) entered blocking state
[   42.126597] br-lan: port 3(wlan1) entered disabled state
[   42.132465] device wlan1 entered promiscuous mode
[   44.700098] IPv6: ADDRCONF(NETDEV_CHANGE): wlan1: link becomes ready
[   44.707037] br-lan: port 3(wlan1) entered blocking state
[   44.712532] br-lan: port 3(wlan1) entered forwarding state
[   45.489307] br-lan: port 4(wlan0) entered blocking state
[   45.494963] br-lan: port 4(wlan0) entered disabled state
[   45.500920] device wlan0 entered promiscuous mode
[   45.505956] br-lan: port 4(wlan0) entered blocking state
[   45.511433] br-lan: port 4(wlan0) entered forwarding state
[   45.721874] br-lan: port 4(wlan0) entered disabled state
[   47.088067] IPv6: ADDRCONF(NETDEV_CHANGE): wlan0: link becomes ready
[   47.094905] br-lan: port 4(wlan0) entered blocking state
[   47.100389] br-lan: port 4(wlan0) entered forwarding state
```
<summary>
OpenWRT Log
</summary>
</details>

>**notes :** this is my first contribution on github. if the format wrong please tell me, i'll fix it.

Signed-off-by: Rafi H Adi <rafiheldiansyahadi@gmail.com>