### PR TITLE
strace: replace PKG_CPE_ID

### DIFF
--- a/package/devel/strace/Makefile
+++ b/package/devel/strace/Makefile
@@ -19,7 +19,7 @@ PKG_HASH:=aa3dc1c8e60e4f6ff3d396514aa247f3c7bf719d8a8dc4dd4fa793be786beca3
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:paul_kranenburg:strace
+PKG_CPE_ID:=cpe:/a:strace_project:strace
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1


### PR DESCRIPTION
Searching for strace in nvd.nist.gov/products/cpe/search [0] will result
in "cpe:/a:strace_project:strace". Replace the current PKG_CPE_ID with
it.

[0] - https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.2&keyword=strace