### PR TITLE
selinux: add missing PKG_CPE_ID

### DIFF
--- a/package/libs/libselinux/Makefile
+++ b/package/libs/libselinux/Makefile
@@ -17,6 +17,7 @@ HOST_BUILD_DEPENDS:=libsepol/host pcre/host
 PKG_LICENSE:=libselinux-1.0
 PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+PKG_CPE_ID:=cpe:/a:selinuxproject:libselinux
 
 HOST_BUILD_DEPENDS:=libsepol/host musl-fts/host pcre/host
 

--- a/package/libs/libsepol/Makefile
+++ b/package/libs/libsepol/Makefile
@@ -14,6 +14,7 @@ PKG_SOURCE_URL:=https://github.com/SELinuxProject/selinux/releases/download/$(PK
 PKG_HASH:=2d97df3eb8466169b389c3660acbb90c54200ac96e452eca9f41a9639f4f238b
 
 PKG_MAINTAINER:=Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+PKG_CPE_ID:=cpe:/a:selinuxproject:libsepol
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk


### PR DESCRIPTION
Add PKG_CPE_IDs for:
- libselinux
- libsepol