### PR TITLE
kernel: backport gnu11 upgrade

### DIFF
--- a/target/linux/generic/backport-5.10/005-v5.17-01-Kbuild-use-Wdeclaration-after-statement.patch
+++ b/target/linux/generic/backport-5.10/005-v5.17-01-Kbuild-use-Wdeclaration-after-statement.patch
@@ -1,0 +1,73 @@
+From 2fd7e7f9317d3048a14026816d081b08ba98ea8e Mon Sep 17 00:00:00 2001
+From: Mark Rutland <mark.rutland@arm.com>
+Date: Tue, 8 Mar 2022 22:56:13 +0100
+Subject: [PATCH 1/3] Kbuild: use -Wdeclaration-after-statement
+
+The kernel is moving from using `-std=gnu89` to `-std=gnu11`, permitting
+the use of additional C11 features such as for-loop initial declarations.
+
+One contentious aspect of C99 is that it permits mixed declarations and
+code, and for now at least, it seems preferable to enforce that
+declarations must come first.
+
+These warnings were already enabled in the kernel itself, but not
+for KBUILD_USERCFLAGS or the compat VDSO on arch/arm64, which uses
+a separate set of CFLAGS.
+
+This patch fixes an existing violation in modpost.c, which is not
+reported because of the missing flag in KBUILD_USERCFLAGS:
+
+| scripts/mod/modpost.c: In function ‘match’:
+| scripts/mod/modpost.c:837:3: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
+|   837 |   const char *endp = p + strlen(p) - 1;
+|       |   ^~~~~
+
+Signed-off-by: Mark Rutland <mark.rutland@arm.com>
+[arnd: don't add a duplicate flag to the default set, update changelog]
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+Reviewed-by: Nathan Chancellor <nathan@kernel.org>
+Reviewed-by: Nick Desaulniers <ndesaulniers@google.com>
+Tested-by: Sedat Dilek <sedat.dilek@gmail.com> # LLVM/Clang v13.0.0 (x86-64)
+Signed-off-by: Masahiro Yamada <masahiroy@kernel.org>
+---
+ Makefile                          | 3 ++-
+ arch/arm64/kernel/vdso32/Makefile | 1 +
+ scripts/mod/modpost.c             | 4 +++-
+ 3 files changed, 6 insertions(+), 2 deletions(-)
+
+--- a/Makefile
++++ b/Makefile
+@@ -416,7 +416,8 @@ HOSTCXX	= g++
+ endif
+
+ export KBUILD_USERCFLAGS := -Wall -Wmissing-prototypes -Wstrict-prototypes \
+-			      -O2 -fomit-frame-pointer -std=gnu89
++			      -O2 -fomit-frame-pointer -std=gnu89 \
++			      -Wdeclaration-after-statement
+ export KBUILD_USERLDFLAGS :=
+
+ KBUILD_HOSTCFLAGS   := $(KBUILD_USERCFLAGS) $(HOST_LFS_CFLAGS) $(HOSTCFLAGS)
+--- a/arch/arm64/kernel/vdso32/Makefile
++++ b/arch/arm64/kernel/vdso32/Makefile
+@@ -76,6 +76,7 @@ VDSO_CFLAGS += -Wall -Wundef -Wstrict-pr
+                -fno-strict-aliasing -fno-common \
+                -Werror-implicit-function-declaration \
+                -Wno-format-security \
++               -Wdeclaration-after-statement \
+                -std=gnu89
+ VDSO_CFLAGS  += -O2
+ # Some useful compiler-dependent flags from top-level Makefile
+--- a/scripts/mod/modpost.c
++++ b/scripts/mod/modpost.c
+@@ -844,8 +844,10 @@ static int match(const char *sym, const
+ {
+	const char *p;
+	while (*pat) {
++		const char *endp;
++
+		p = *pat++;
+-		const char *endp = p + strlen(p) - 1;
++		endp = p + strlen(p) - 1;
+
+		/* "*foo*" */
+		if (*p == '*' && *endp == '*') {

--- a/target/linux/generic/backport-5.10/005-v5.17-02-Kbuild-move-to-std-gnu11.patch
+++ b/target/linux/generic/backport-5.10/005-v5.17-02-Kbuild-move-to-std-gnu11.patch
@@ -1,0 +1,60 @@
+From b810c8e719ea082e47c7a8f7cf878bc84fa2455d Mon Sep 17 00:00:00 2001
+From: Arnd Bergmann <arnd@arndb.de>
+Date: Tue, 8 Mar 2022 22:56:14 +0100
+Subject: [PATCH 2/3] Kbuild: move to -std=gnu11
+
+During a patch discussion, Linus brought up the option of changing
+the C standard version from gnu89 to gnu99, which allows using variable
+declaration inside of a for() loop. While the C99, C11 and later standards
+introduce many other features, most of these are already available in
+gnu89 as GNU extensions as well.
+
+An earlier attempt to do this when gcc-5 started defaulting to
+-std=gnu11 failed because at the time that caused warnings about
+designated initializers with older compilers. Now that gcc-5.1 is
+the minimum compiler version used for building kernels, that is no
+longer a concern. Similarly, the behavior of 'inline' functions changes
+between gnu89 using gnu_inline behavior and gnu11 using standard c99+
+behavior, but this was taken care of by defining 'inline' to include
+__attribute__((gnu_inline)) in order to allow building with clang a
+while ago.
+
+Nathan Chancellor reported a new -Wdeclaration-after-statement
+warning that appears in a system header on arm, this still needs a
+workaround.
+
+The differences between gnu99, gnu11, gnu1x and gnu17 are fairly
+minimal and mainly impact warnings at the -Wpedantic level that the
+kernel never enables. Between these, gnu11 is the newest version
+that is supported by all supported compiler versions, though it is
+only the default on gcc-5, while all other supported versions of
+gcc or clang default to gnu1x/gnu17.
+
+Link: https://lore.kernel.org/lkml/CAHk-=wiyCH7xeHcmiFJ-YgXUy2Jaj7pnkdKpcovt8fYbVFW3TA@mail.gmail.com/
+Link: https://github.com/ClangBuiltLinux/linux/issues/1603
+Suggested-by: Linus Torvalds <torvalds@linux-foundation.org>
+Acked-by: Marco Elver <elver@google.com>
+Acked-by: Jani Nikula <jani.nikula@intel.com>
+Acked-by: David Sterba <dsterba@suse.com>
+Tested-by: Sedat Dilek <sedat.dilek@gmail.com>
+Reviewed-by: Alex Shi <alexs@kernel.org>
+Reviewed-by: Nick Desaulniers <ndesaulniers@google.com>
+Reviewed-by: Miguel Ojeda <ojeda@kernel.org>
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+Reviewed-by: Nathan Chancellor <nathan@kernel.org>
+Signed-off-by: Masahiro Yamada <masahiroy@kernel.org>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/Makefile
++++ b/Makefile
+@@ -498,7 +498,7 @@ KBUILD_CFLAGS   := -Wall -Wundef -Werror
+		   -fno-strict-aliasing -fno-common -fshort-wchar -fno-PIE \
+		   -Werror=implicit-function-declaration -Werror=implicit-int \
+		   -Werror=return-type -Wno-format-security \
+-		   -std=gnu89
++		   -std=gnu11
+ KBUILD_CPPFLAGS := -D__KERNEL__
+ KBUILD_AFLAGS_KERNEL :=
+ KBUILD_CFLAGS_KERNEL :=

--- a/target/linux/generic/backport-5.10/005-v5.17-03-Kbuild-use-std-gnu11-for-KBUILD_USERCFLAGS.patch
+++ b/target/linux/generic/backport-5.10/005-v5.17-03-Kbuild-use-std-gnu11-for-KBUILD_USERCFLAGS.patch
@@ -1,0 +1,42 @@
+From 40337d6f3d677aee7ad3052ae662d3f53dd4d5cb Mon Sep 17 00:00:00 2001
+From: Arnd Bergmann <arnd@arndb.de>
+Date: Tue, 8 Mar 2022 22:56:15 +0100
+Subject: [PATCH 3/3] Kbuild: use -std=gnu11 for KBUILD_USERCFLAGS
+
+As we change the C language standard for the kernel from gnu89 to
+gnu11, it makes sense to also update the version for user space
+compilation.
+
+Some users have older native compilers than what they use for
+kernel builds, so I considered using gnu99 as the default version
+for wider compatibility with gcc-4.6 and earlier.
+
+However, testing with older compilers showed that we already require
+HOSTCC version 5.1 as well because a lot of host tools include
+linux/compiler.h that uses __has_attribute():
+
+  CC      tools/objtool/exec-cmd.o
+In file included from tools/include/linux/compiler_types.h:36:0,
+                 from tools/include/linux/compiler.h:5,
+                 from exec-cmd.c:2:
+tools/include/linux/compiler-gcc.h:19:5: error: "__has_attribute" is not defined [-Werror=undef]
+
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+Reviewed-by: Nathan Chancellor <nathan@kernel.org>
+Reviewed-by: Nick Desaulniers <ndesaulniers@google.com>
+Tested-by: Sedat Dilek <sedat.dilek@gmail.com>
+Signed-off-by: Masahiro Yamada <masahiroy@kernel.org>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/Makefile
++++ b/Makefile
+@@ -416,7 +416,7 @@ HOSTCXX	= g++
+ endif
+
+ export KBUILD_USERCFLAGS := -Wall -Wmissing-prototypes -Wstrict-prototypes \
+-			      -O2 -fomit-frame-pointer -std=gnu89 \
++			      -O2 -fomit-frame-pointer -std=gnu11 \
+			      -Wdeclaration-after-statement
+ export KBUILD_USERLDFLAGS :=

--- a/target/linux/generic/backport-5.15/005-v5.17-01-Kbuild-use-Wdeclaration-after-statement.patch
+++ b/target/linux/generic/backport-5.15/005-v5.17-01-Kbuild-use-Wdeclaration-after-statement.patch
@@ -1,0 +1,81 @@
+From 2fd7e7f9317d3048a14026816d081b08ba98ea8e Mon Sep 17 00:00:00 2001
+From: Mark Rutland <mark.rutland@arm.com>
+Date: Tue, 8 Mar 2022 22:56:13 +0100
+Subject: [PATCH 1/3] Kbuild: use -Wdeclaration-after-statement
+
+The kernel is moving from using `-std=gnu89` to `-std=gnu11`, permitting
+the use of additional C11 features such as for-loop initial declarations.
+
+One contentious aspect of C99 is that it permits mixed declarations and
+code, and for now at least, it seems preferable to enforce that
+declarations must come first.
+
+These warnings were already enabled in the kernel itself, but not
+for KBUILD_USERCFLAGS or the compat VDSO on arch/arm64, which uses
+a separate set of CFLAGS.
+
+This patch fixes an existing violation in modpost.c, which is not
+reported because of the missing flag in KBUILD_USERCFLAGS:
+
+| scripts/mod/modpost.c: In function ‘match’:
+| scripts/mod/modpost.c:837:3: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
+|   837 |   const char *endp = p + strlen(p) - 1;
+|       |   ^~~~~
+
+Signed-off-by: Mark Rutland <mark.rutland@arm.com>
+[arnd: don't add a duplicate flag to the default set, update changelog]
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+Reviewed-by: Nathan Chancellor <nathan@kernel.org>
+Reviewed-by: Nick Desaulniers <ndesaulniers@google.com>
+Tested-by: Sedat Dilek <sedat.dilek@gmail.com> # LLVM/Clang v13.0.0 (x86-64)
+Signed-off-by: Masahiro Yamada <masahiroy@kernel.org>
+---
+ Makefile                          | 3 ++-
+ arch/arm64/kernel/vdso32/Makefile | 1 +
+ scripts/mod/modpost.c             | 4 +++-
+ 3 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index b9e0b5c604af..cfe400032f96 100644
+--- a/Makefile
++++ b/Makefile
+@@ -416,7 +416,8 @@ HOSTCXX	= g++
+ endif
+
+ export KBUILD_USERCFLAGS := -Wall -Wmissing-prototypes -Wstrict-prototypes \
+-			      -O2 -fomit-frame-pointer -std=gnu89
++			      -O2 -fomit-frame-pointer -std=gnu89 \
++			      -Wdeclaration-after-statement
+ export KBUILD_USERLDFLAGS :=
+
+ KBUILD_HOSTCFLAGS   := $(KBUILD_USERCFLAGS) $(HOST_LFS_CFLAGS) $(HOSTCFLAGS)
+diff --git a/arch/arm64/kernel/vdso32/Makefile b/arch/arm64/kernel/vdso32/Makefile
+index abad38c576e1..33cd7ed3f94f 100644
+--- a/arch/arm64/kernel/vdso32/Makefile
++++ b/arch/arm64/kernel/vdso32/Makefile
+@@ -76,6 +76,7 @@ VDSO_CFLAGS += -Wall -Wundef -Wstrict-prototypes -Wno-trigraphs \
+                -fno-strict-aliasing -fno-common \
+                -Werror-implicit-function-declaration \
+                -Wno-format-security \
++               -Wdeclaration-after-statement \
+                -std=gnu89
+ VDSO_CFLAGS  += -O2
+ # Some useful compiler-dependent flags from top-level Makefile
+diff --git a/scripts/mod/modpost.c b/scripts/mod/modpost.c
+index 3c27a177b28b..d2b17ed27e6e 100644
+--- a/scripts/mod/modpost.c
++++ b/scripts/mod/modpost.c
+@@ -844,8 +844,10 @@ static int match(const char *sym, const char * const pat[])
+ {
+	const char *p;
+	while (*pat) {
++		const char *endp;
++
+		p = *pat++;
+-		const char *endp = p + strlen(p) - 1;
++		endp = p + strlen(p) - 1;
+
+		/* "*foo*" */
+		if (*p == '*' && *endp == '*') {
+--
+2.37.2

--- a/target/linux/generic/backport-5.15/005-v5.17-02-Kbuild-move-to-std-gnu11.patch
+++ b/target/linux/generic/backport-5.15/005-v5.17-02-Kbuild-move-to-std-gnu11.patch
@@ -1,0 +1,64 @@
+From b810c8e719ea082e47c7a8f7cf878bc84fa2455d Mon Sep 17 00:00:00 2001
+From: Arnd Bergmann <arnd@arndb.de>
+Date: Tue, 8 Mar 2022 22:56:14 +0100
+Subject: [PATCH 2/3] Kbuild: move to -std=gnu11
+
+During a patch discussion, Linus brought up the option of changing
+the C standard version from gnu89 to gnu99, which allows using variable
+declaration inside of a for() loop. While the C99, C11 and later standards
+introduce many other features, most of these are already available in
+gnu89 as GNU extensions as well.
+
+An earlier attempt to do this when gcc-5 started defaulting to
+-std=gnu11 failed because at the time that caused warnings about
+designated initializers with older compilers. Now that gcc-5.1 is
+the minimum compiler version used for building kernels, that is no
+longer a concern. Similarly, the behavior of 'inline' functions changes
+between gnu89 using gnu_inline behavior and gnu11 using standard c99+
+behavior, but this was taken care of by defining 'inline' to include
+__attribute__((gnu_inline)) in order to allow building with clang a
+while ago.
+
+Nathan Chancellor reported a new -Wdeclaration-after-statement
+warning that appears in a system header on arm, this still needs a
+workaround.
+
+The differences between gnu99, gnu11, gnu1x and gnu17 are fairly
+minimal and mainly impact warnings at the -Wpedantic level that the
+kernel never enables. Between these, gnu11 is the newest version
+that is supported by all supported compiler versions, though it is
+only the default on gcc-5, while all other supported versions of
+gcc or clang default to gnu1x/gnu17.
+
+Link: https://lore.kernel.org/lkml/CAHk-=wiyCH7xeHcmiFJ-YgXUy2Jaj7pnkdKpcovt8fYbVFW3TA@mail.gmail.com/
+Link: https://github.com/ClangBuiltLinux/linux/issues/1603
+Suggested-by: Linus Torvalds <torvalds@linux-foundation.org>
+Acked-by: Marco Elver <elver@google.com>
+Acked-by: Jani Nikula <jani.nikula@intel.com>
+Acked-by: David Sterba <dsterba@suse.com>
+Tested-by: Sedat Dilek <sedat.dilek@gmail.com>
+Reviewed-by: Alex Shi <alexs@kernel.org>
+Reviewed-by: Nick Desaulniers <ndesaulniers@google.com>
+Reviewed-by: Miguel Ojeda <ojeda@kernel.org>
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+Reviewed-by: Nathan Chancellor <nathan@kernel.org>
+Signed-off-by: Masahiro Yamada <masahiroy@kernel.org>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index cfe400032f96..fe86758acaaa 100644
+--- a/Makefile
++++ b/Makefile
+@@ -498,7 +498,7 @@ KBUILD_CFLAGS   := -Wall -Wundef -Werror=strict-prototypes -Wno-trigraphs \
+		   -fno-strict-aliasing -fno-common -fshort-wchar -fno-PIE \
+		   -Werror=implicit-function-declaration -Werror=implicit-int \
+		   -Werror=return-type -Wno-format-security \
+-		   -std=gnu89
++		   -std=gnu11
+ KBUILD_CPPFLAGS := -D__KERNEL__
+ KBUILD_AFLAGS_KERNEL :=
+ KBUILD_CFLAGS_KERNEL :=
+--
+2.37.2

--- a/target/linux/generic/backport-5.15/005-v5.17-03-Kbuild-use-std-gnu11-for-KBUILD_USERCFLAGS.patch
+++ b/target/linux/generic/backport-5.15/005-v5.17-03-Kbuild-use-std-gnu11-for-KBUILD_USERCFLAGS.patch
@@ -1,0 +1,47 @@
+From 40337d6f3d677aee7ad3052ae662d3f53dd4d5cb Mon Sep 17 00:00:00 2001
+From: Arnd Bergmann <arnd@arndb.de>
+Date: Tue, 8 Mar 2022 22:56:15 +0100
+Subject: [PATCH 3/3] Kbuild: use -std=gnu11 for KBUILD_USERCFLAGS
+
+As we change the C language standard for the kernel from gnu89 to
+gnu11, it makes sense to also update the version for user space
+compilation.
+
+Some users have older native compilers than what they use for
+kernel builds, so I considered using gnu99 as the default version
+for wider compatibility with gcc-4.6 and earlier.
+
+However, testing with older compilers showed that we already require
+HOSTCC version 5.1 as well because a lot of host tools include
+linux/compiler.h that uses __has_attribute():
+
+  CC      tools/objtool/exec-cmd.o
+In file included from tools/include/linux/compiler_types.h:36:0,
+                 from tools/include/linux/compiler.h:5,
+                 from exec-cmd.c:2:
+tools/include/linux/compiler-gcc.h:19:5: error: "__has_attribute" is not defined [-Werror=undef]
+
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+Reviewed-by: Nathan Chancellor <nathan@kernel.org>
+Reviewed-by: Nick Desaulniers <ndesaulniers@google.com>
+Tested-by: Sedat Dilek <sedat.dilek@gmail.com>
+Signed-off-by: Masahiro Yamada <masahiroy@kernel.org>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index fe86758acaaa..e569fccfb009 100644
+--- a/Makefile
++++ b/Makefile
+@@ -416,7 +416,7 @@ HOSTCXX	= g++
+ endif
+
+ export KBUILD_USERCFLAGS := -Wall -Wmissing-prototypes -Wstrict-prototypes \
+-			      -O2 -fomit-frame-pointer -std=gnu89 \
++			      -O2 -fomit-frame-pointer -std=gnu11 \
+			      -Wdeclaration-after-statement
+ export KBUILD_USERLDFLAGS :=
+
+--
+2.37.2


### PR DESCRIPTION
Upstream has switched to gnu11 not too long ago. One advantage of
backporting this to these older kernels is, that we can encourage and
write better upstreamable kernels. E.g. the kernel devs prefer loop
declarations. Shrinking the master/local gap will be useful in these
cases.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>