### PR TITLE
kernel: fix mvneta Ethernet after generic phylink validate

### DIFF
--- a/target/linux/generic/backport-5.15/703-00-v5.16-net-convert-users-of-bitmap_foo-to-linkmode_foo.patch
+++ b/target/linux/generic/backport-5.15/703-00-v5.16-net-convert-users-of-bitmap_foo-to-linkmode_foo.patch
@@ -1,0 +1,948 @@
+From 4973056cceacc70966396039fae99867dfafd796 Mon Sep 17 00:00:00 2001
+From: Sean Anderson <sean.anderson@seco.com>
+Date: Fri, 22 Oct 2021 18:41:04 -0400
+Subject: [PATCH] net: convert users of bitmap_foo() to linkmode_foo()
+
+This converts instances of
+	bitmap_foo(args..., __ETHTOOL_LINK_MODE_MASK_NBITS)
+to
+	linkmode_foo(args...)
+
+I manually fixed up some lines to prevent them from being excessively
+long. Otherwise, this change was generated with the following semantic
+patch:
+
+// Generated with
+// echo linux/linkmode.h > includes
+// git grep -Flf includes include/ | cut -f 2- -d / | cat includes - \
+// | sort | uniq | tee new_includes | wc -l && mv new_includes includes
+// and repeating until the number stopped going up
+@i@
+@@
+
+(
+ #include <linux/acpi_mdio.h>
+|
+ #include <linux/brcmphy.h>
+|
+ #include <linux/dsa/loop.h>
+|
+ #include <linux/dsa/sja1105.h>
+|
+ #include <linux/ethtool.h>
+|
+ #include <linux/ethtool_netlink.h>
+|
+ #include <linux/fec.h>
+|
+ #include <linux/fs_enet_pd.h>
+|
+ #include <linux/fsl/enetc_mdio.h>
+|
+ #include <linux/fwnode_mdio.h>
+|
+ #include <linux/linkmode.h>
+|
+ #include <linux/lsm_audit.h>
+|
+ #include <linux/mdio-bitbang.h>
+|
+ #include <linux/mdio.h>
+|
+ #include <linux/mdio-mux.h>
+|
+ #include <linux/mii.h>
+|
+ #include <linux/mii_timestamper.h>
+|
+ #include <linux/mlx5/accel.h>
+|
+ #include <linux/mlx5/cq.h>
+|
+ #include <linux/mlx5/device.h>
+|
+ #include <linux/mlx5/driver.h>
+|
+ #include <linux/mlx5/eswitch.h>
+|
+ #include <linux/mlx5/fs.h>
+|
+ #include <linux/mlx5/port.h>
+|
+ #include <linux/mlx5/qp.h>
+|
+ #include <linux/mlx5/rsc_dump.h>
+|
+ #include <linux/mlx5/transobj.h>
+|
+ #include <linux/mlx5/vport.h>
+|
+ #include <linux/of_mdio.h>
+|
+ #include <linux/of_net.h>
+|
+ #include <linux/pcs-lynx.h>
+|
+ #include <linux/pcs/pcs-xpcs.h>
+|
+ #include <linux/phy.h>
+|
+ #include <linux/phy_led_triggers.h>
+|
+ #include <linux/phylink.h>
+|
+ #include <linux/platform_data/bcmgenet.h>
+|
+ #include <linux/platform_data/xilinx-ll-temac.h>
+|
+ #include <linux/pxa168_eth.h>
+|
+ #include <linux/qed/qed_eth_if.h>
+|
+ #include <linux/qed/qed_fcoe_if.h>
+|
+ #include <linux/qed/qed_if.h>
+|
+ #include <linux/qed/qed_iov_if.h>
+|
+ #include <linux/qed/qed_iscsi_if.h>
+|
+ #include <linux/qed/qed_ll2_if.h>
+|
+ #include <linux/qed/qed_nvmetcp_if.h>
+|
+ #include <linux/qed/qed_rdma_if.h>
+|
+ #include <linux/sfp.h>
+|
+ #include <linux/sh_eth.h>
+|
+ #include <linux/smsc911x.h>
+|
+ #include <linux/soc/nxp/lpc32xx-misc.h>
+|
+ #include <linux/stmmac.h>
+|
+ #include <linux/sunrpc/svc_rdma.h>
+|
+ #include <linux/sxgbe_platform.h>
+|
+ #include <net/cfg80211.h>
+|
+ #include <net/dsa.h>
+|
+ #include <net/mac80211.h>
+|
+ #include <net/selftests.h>
+|
+ #include <rdma/ib_addr.h>
+|
+ #include <rdma/ib_cache.h>
+|
+ #include <rdma/ib_cm.h>
+|
+ #include <rdma/ib_hdrs.h>
+|
+ #include <rdma/ib_mad.h>
+|
+ #include <rdma/ib_marshall.h>
+|
+ #include <rdma/ib_pack.h>
+|
+ #include <rdma/ib_pma.h>
+|
+ #include <rdma/ib_sa.h>
+|
+ #include <rdma/ib_smi.h>
+|
+ #include <rdma/ib_umem.h>
+|
+ #include <rdma/ib_umem_odp.h>
+|
+ #include <rdma/ib_verbs.h>
+|
+ #include <rdma/iw_cm.h>
+|
+ #include <rdma/mr_pool.h>
+|
+ #include <rdma/opa_addr.h>
+|
+ #include <rdma/opa_port_info.h>
+|
+ #include <rdma/opa_smi.h>
+|
+ #include <rdma/opa_vnic.h>
+|
+ #include <rdma/rdma_cm.h>
+|
+ #include <rdma/rdma_cm_ib.h>
+|
+ #include <rdma/rdmavt_cq.h>
+|
+ #include <rdma/rdma_vt.h>
+|
+ #include <rdma/rdmavt_qp.h>
+|
+ #include <rdma/rw.h>
+|
+ #include <rdma/tid_rdma_defs.h>
+|
+ #include <rdma/uverbs_ioctl.h>
+|
+ #include <rdma/uverbs_named_ioctl.h>
+|
+ #include <rdma/uverbs_std_types.h>
+|
+ #include <rdma/uverbs_types.h>
+|
+ #include <soc/mscc/ocelot.h>
+|
+ #include <soc/mscc/ocelot_ptp.h>
+|
+ #include <soc/mscc/ocelot_vcap.h>
+|
+ #include <trace/events/ib_mad.h>
+|
+ #include <trace/events/rdma_core.h>
+|
+ #include <trace/events/rdma.h>
+|
+ #include <trace/events/rpcrdma.h>
+|
+ #include <uapi/linux/ethtool.h>
+|
+ #include <uapi/linux/ethtool_netlink.h>
+|
+ #include <uapi/linux/mdio.h>
+|
+ #include <uapi/linux/mii.h>
+)
+
+@depends on i@
+expression list args;
+@@
+
+(
+- bitmap_zero(args, __ETHTOOL_LINK_MODE_MASK_NBITS)
++ linkmode_zero(args)
+|
+- bitmap_copy(args, __ETHTOOL_LINK_MODE_MASK_NBITS)
++ linkmode_copy(args)
+|
+- bitmap_and(args, __ETHTOOL_LINK_MODE_MASK_NBITS)
++ linkmode_and(args)
+|
+- bitmap_or(args, __ETHTOOL_LINK_MODE_MASK_NBITS)
++ linkmode_or(args)
+|
+- bitmap_empty(args, ETHTOOL_LINK_MODE_MASK_NBITS)
++ linkmode_empty(args)
+|
+- bitmap_andnot(args, __ETHTOOL_LINK_MODE_MASK_NBITS)
++ linkmode_andnot(args)
+|
+- bitmap_equal(args, __ETHTOOL_LINK_MODE_MASK_NBITS)
++ linkmode_equal(args)
+|
+- bitmap_intersects(args, __ETHTOOL_LINK_MODE_MASK_NBITS)
++ linkmode_intersects(args)
+|
+- bitmap_subset(args, __ETHTOOL_LINK_MODE_MASK_NBITS)
++ linkmode_subset(args)
+)
+
+Add missing linux/mii.h include to mellanox. -DaveM
+
+Signed-off-by: Sean Anderson <sean.anderson@seco.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/b53/b53_common.c              |  6 ++----
+ drivers/net/dsa/bcm_sf2.c                     |  8 +++----
+ drivers/net/dsa/hirschmann/hellcreek.c        |  6 ++----
+ drivers/net/dsa/lantiq_gswip.c                | 14 ++++++-------
+ drivers/net/dsa/microchip/ksz8795.c           |  8 +++----
+ drivers/net/dsa/mv88e6xxx/chip.c              |  5 ++---
+ drivers/net/dsa/ocelot/felix_vsc9959.c        |  8 +++----
+ drivers/net/dsa/ocelot/seville_vsc9953.c      |  8 +++----
+ drivers/net/dsa/qca/ar9331.c                  | 10 ++++-----
+ drivers/net/dsa/sja1105/sja1105_main.c        |  7 +++----
+ drivers/net/dsa/xrs700x/xrs700x.c             |  8 +++----
+ drivers/net/ethernet/amd/xgbe/xgbe-ethtool.c  |  8 +++----
+ drivers/net/ethernet/atheros/ag71xx.c         |  8 +++----
+ drivers/net/ethernet/cadence/macb_main.c      | 11 +++++-----
+ .../net/ethernet/freescale/enetc/enetc_pf.c   |  8 +++----
+ .../net/ethernet/huawei/hinic/hinic_ethtool.c | 10 ++++-----
+ .../net/ethernet/intel/ixgbe/ixgbe_ethtool.c  |  5 ++---
+ drivers/net/ethernet/marvell/mvneta.c         | 10 ++++-----
+ .../net/ethernet/marvell/mvpp2/mvpp2_main.c   |  7 +++----
+ .../marvell/octeontx2/nic/otx2_ethtool.c      |  5 ++---
+ drivers/net/ethernet/marvell/pxa168_eth.c     |  3 +--
+ .../net/ethernet/mellanox/mlx4/en_ethtool.c   | 21 +++++++------------
+ .../microchip/sparx5/sparx5_phylink.c         |  7 +++----
+ drivers/net/ethernet/mscc/ocelot_net.c        |  7 +++----
+ .../ethernet/pensando/ionic/ionic_ethtool.c   |  3 +--
+ .../net/ethernet/xilinx/xilinx_axienet_main.c |  8 +++----
+ drivers/net/pcs/pcs-xpcs.c                    |  2 +-
+ drivers/net/phy/sfp-bus.c                     |  2 +-
+ net/ethtool/ioctl.c                           |  7 +++----
+ 29 files changed, 87 insertions(+), 133 deletions(-)
+
+--- a/drivers/net/dsa/b53/b53_common.c
++++ b/drivers/net/dsa/b53/b53_common.c
+@@ -1349,10 +1349,8 @@ void b53_phylink_validate(struct dsa_swi
+ 		phylink_set(mask, 100baseT_Full);
+ 	}
+ 
+-	bitmap_and(supported, supported, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ 
+ 	phylink_helper_basex_speed(state);
+ }
+--- a/drivers/net/dsa/bcm_sf2.c
++++ b/drivers/net/dsa/bcm_sf2.c
+@@ -686,7 +686,7 @@ static void bcm_sf2_sw_validate(struct d
+ 	    state->interface != PHY_INTERFACE_MODE_GMII &&
+ 	    state->interface != PHY_INTERFACE_MODE_INTERNAL &&
+ 	    state->interface != PHY_INTERFACE_MODE_MOCA) {
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		if (port != core_readl(priv, CORE_IMP0_PRT_ID))
+ 			dev_err(ds->dev,
+ 				"Unsupported interface: %d for port %d\n",
+@@ -714,10 +714,8 @@ static void bcm_sf2_sw_validate(struct d
+ 	phylink_set(mask, 100baseT_Half);
+ 	phylink_set(mask, 100baseT_Full);
+ 
+-	bitmap_and(supported, supported, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ }
+ 
+ static void bcm_sf2_sw_mac_config(struct dsa_switch *ds, int port,
+--- a/drivers/net/dsa/hirschmann/hellcreek.c
++++ b/drivers/net/dsa/hirschmann/hellcreek.c
+@@ -1476,10 +1476,8 @@ static void hellcreek_phylink_validate(s
+ 	else
+ 		phylink_set(mask, 1000baseT_Full);
+ 
+-	bitmap_and(supported, supported, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ }
+ 
+ static int
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -1452,10 +1452,8 @@ static void gswip_phylink_set_capab(unsi
+ 	phylink_set(mask, 100baseT_Half);
+ 	phylink_set(mask, 100baseT_Full);
+ 
+-	bitmap_and(supported, supported, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ }
+ 
+ static void gswip_xrx200_phylink_validate(struct dsa_switch *ds, int port,
+@@ -1483,7 +1481,7 @@ static void gswip_xrx200_phylink_validat
+ 			goto unsupported;
+ 		break;
+ 	default:
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		dev_err(ds->dev, "Unsupported port: %i\n", port);
+ 		return;
+ 	}
+@@ -1493,7 +1491,7 @@ static void gswip_xrx200_phylink_validat
+ 	return;
+ 
+ unsupported:
+-	bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_zero(supported);
+ 	dev_err(ds->dev, "Unsupported interface '%s' for port %d\n",
+ 		phy_modes(state->interface), port);
+ }
+@@ -1523,7 +1521,7 @@ static void gswip_xrx300_phylink_validat
+ 			goto unsupported;
+ 		break;
+ 	default:
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		dev_err(ds->dev, "Unsupported port: %i\n", port);
+ 		return;
+ 	}
+@@ -1533,7 +1531,7 @@ static void gswip_xrx300_phylink_validat
+ 	return;
+ 
+ unsupported:
+-	bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_zero(supported);
+ 	dev_err(ds->dev, "Unsupported interface '%s' for port %d\n",
+ 		phy_modes(state->interface), port);
+ }
+--- a/drivers/net/dsa/microchip/ksz8795.c
++++ b/drivers/net/dsa/microchip/ksz8795.c
+@@ -1542,15 +1542,13 @@ static void ksz8_validate(struct dsa_swi
+ 	phylink_set(mask, 100baseT_Half);
+ 	phylink_set(mask, 100baseT_Full);
+ 
+-	bitmap_and(supported, supported, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ 
+ 	return;
+ 
+ unsupported:
+-	bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_zero(supported);
+ 	dev_err(ds->dev, "Unsupported interface: %s, port: %d\n",
+ 		phy_modes(state->interface), port);
+ }
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -683,9 +683,8 @@ static void mv88e6xxx_validate(struct ds
+ 	if (chip->info->ops->phylink_validate)
+ 		chip->info->ops->phylink_validate(chip, port, mask, state);
+ 
+-	bitmap_and(supported, supported, mask, __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ 
+ 	/* We can only operate at 2500BaseX or 1000BaseX.  If requested
+ 	 * to advertise both, only report advertising at 2500BaseX.
+--- a/drivers/net/dsa/ocelot/felix_vsc9959.c
++++ b/drivers/net/dsa/ocelot/felix_vsc9959.c
+@@ -944,7 +944,7 @@ static void vsc9959_phylink_validate(str
+ 
+ 	if (state->interface != PHY_INTERFACE_MODE_NA &&
+ 	    state->interface != ocelot_port->phy_mode) {
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		return;
+ 	}
+ 
+@@ -966,10 +966,8 @@ static void vsc9959_phylink_validate(str
+ 		phylink_set(mask, 2500baseX_Full);
+ 	}
+ 
+-	bitmap_and(supported, supported, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ }
+ 
+ static int vsc9959_prevalidate_phy_mode(struct ocelot *ocelot, int port,
+--- a/drivers/net/dsa/ocelot/seville_vsc9953.c
++++ b/drivers/net/dsa/ocelot/seville_vsc9953.c
+@@ -1000,7 +1000,7 @@ static void vsc9953_phylink_validate(str
+ 
+ 	if (state->interface != PHY_INTERFACE_MODE_NA &&
+ 	    state->interface != ocelot_port->phy_mode) {
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		return;
+ 	}
+ 
+@@ -1019,10 +1019,8 @@ static void vsc9953_phylink_validate(str
+ 		phylink_set(mask, 2500baseX_Full);
+ 	}
+ 
+-	bitmap_and(supported, supported, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ }
+ 
+ static int vsc9953_prevalidate_phy_mode(struct ocelot *ocelot, int port,
+--- a/drivers/net/dsa/qca/ar9331.c
++++ b/drivers/net/dsa/qca/ar9331.c
+@@ -522,7 +522,7 @@ static void ar9331_sw_phylink_validate(s
+ 			goto unsupported;
+ 		break;
+ 	default:
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		dev_err(ds->dev, "Unsupported port: %i\n", port);
+ 		return;
+ 	}
+@@ -536,15 +536,13 @@ static void ar9331_sw_phylink_validate(s
+ 	phylink_set(mask, 100baseT_Half);
+ 	phylink_set(mask, 100baseT_Full);
+ 
+-	bitmap_and(supported, supported, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ 
+ 	return;
+ 
+ unsupported:
+-	bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_zero(supported);
+ 	dev_err(ds->dev, "Unsupported interface: %d, port: %d\n",
+ 		state->interface, port);
+ }
+--- a/drivers/net/dsa/sja1105/sja1105_main.c
++++ b/drivers/net/dsa/sja1105/sja1105_main.c
+@@ -1360,7 +1360,7 @@ static void sja1105_phylink_validate(str
+ 	 */
+ 	if (state->interface != PHY_INTERFACE_MODE_NA &&
+ 	    sja1105_phy_mode_mismatch(priv, port, state->interface)) {
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		return;
+ 	}
+ 
+@@ -1380,9 +1380,8 @@ static void sja1105_phylink_validate(str
+ 		phylink_set(mask, 2500baseX_Full);
+ 	}
+ 
+-	bitmap_and(supported, supported, mask, __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ }
+ 
+ static int
+--- a/drivers/net/dsa/xrs700x/xrs700x.c
++++ b/drivers/net/dsa/xrs700x/xrs700x.c
+@@ -456,7 +456,7 @@ static void xrs700x_phylink_validate(str
+ 		phylink_set(mask, 1000baseT_Full);
+ 		break;
+ 	default:
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		dev_err(ds->dev, "Unsupported port: %i\n", port);
+ 		return;
+ 	}
+@@ -467,10 +467,8 @@ static void xrs700x_phylink_validate(str
+ 	phylink_set(mask, 10baseT_Full);
+ 	phylink_set(mask, 100baseT_Full);
+ 
+-	bitmap_and(supported, supported, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ }
+ 
+ static void xrs700x_mac_link_up(struct dsa_switch *ds, int port,
+--- a/drivers/net/ethernet/amd/xgbe/xgbe-ethtool.c
++++ b/drivers/net/ethernet/amd/xgbe/xgbe-ethtool.c
+@@ -369,9 +369,8 @@ static int xgbe_set_link_ksettings(struc
+ 		  __ETHTOOL_LINK_MODE_MASK_NBITS, cmd->link_modes.advertising,
+ 		  __ETHTOOL_LINK_MODE_MASK_NBITS, lks->link_modes.supported);
+ 
+-	bitmap_and(advertising,
+-		   cmd->link_modes.advertising, lks->link_modes.supported,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(advertising, cmd->link_modes.advertising,
++		     lks->link_modes.supported);
+ 
+ 	if ((cmd->base.autoneg == AUTONEG_ENABLE) &&
+ 	    bitmap_empty(advertising, __ETHTOOL_LINK_MODE_MASK_NBITS)) {
+@@ -384,8 +383,7 @@ static int xgbe_set_link_ksettings(struc
+ 	pdata->phy.autoneg = cmd->base.autoneg;
+ 	pdata->phy.speed = speed;
+ 	pdata->phy.duplex = cmd->base.duplex;
+-	bitmap_copy(lks->link_modes.advertising, advertising,
+-		    __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_copy(lks->link_modes.advertising, advertising);
+ 
+ 	if (cmd->base.autoneg == AUTONEG_ENABLE)
+ 		XGBE_SET_ADV(lks, Autoneg);
+--- a/drivers/net/ethernet/atheros/ag71xx.c
++++ b/drivers/net/ethernet/atheros/ag71xx.c
+@@ -1082,14 +1082,12 @@ static void ag71xx_mac_validate(struct p
+ 		phylink_set(mask, 1000baseX_Full);
+ 	}
+ 
+-	bitmap_and(supported, supported, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ 
+ 	return;
+ unsupported:
+-	bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_zero(supported);
+ }
+ 
+ static void ag71xx_mac_pcs_get_state(struct phylink_config *config,
+--- a/drivers/net/ethernet/cadence/macb_main.c
++++ b/drivers/net/ethernet/cadence/macb_main.c
+@@ -523,21 +523,21 @@ static void macb_validate(struct phylink
+ 	    state->interface != PHY_INTERFACE_MODE_SGMII &&
+ 	    state->interface != PHY_INTERFACE_MODE_10GBASER &&
+ 	    !phy_interface_mode_is_rgmii(state->interface)) {
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		return;
+ 	}
+ 
+ 	if (!macb_is_gem(bp) &&
+ 	    (state->interface == PHY_INTERFACE_MODE_GMII ||
+ 	     phy_interface_mode_is_rgmii(state->interface))) {
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		return;
+ 	}
+ 
+ 	if (state->interface == PHY_INTERFACE_MODE_10GBASER &&
+ 	    !(bp->caps & MACB_CAPS_HIGH_SPEED &&
+ 	      bp->caps & MACB_CAPS_PCS)) {
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		return;
+ 	}
+ 
+@@ -576,9 +576,8 @@ static void macb_validate(struct phylink
+ 			phylink_set(mask, 1000baseT_Half);
+ 	}
+ out:
+-	bitmap_and(supported, supported, mask, __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ }
+ 
+ static void macb_usx_pcs_link_up(struct phylink_pcs *pcs, unsigned int mode,
+--- a/drivers/net/ethernet/freescale/enetc/enetc_pf.c
++++ b/drivers/net/ethernet/freescale/enetc/enetc_pf.c
+@@ -940,7 +940,7 @@ static void enetc_pl_mac_validate(struct
+ 	    state->interface != PHY_INTERFACE_MODE_2500BASEX &&
+ 	    state->interface != PHY_INTERFACE_MODE_USXGMII &&
+ 	    !phy_interface_mode_is_rgmii(state->interface)) {
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		return;
+ 	}
+ 
+@@ -963,10 +963,8 @@ static void enetc_pl_mac_validate(struct
+ 		phylink_set(mask, 2500baseX_Full);
+ 	}
+ 
+-	bitmap_and(supported, supported, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ }
+ 
+ static void enetc_pl_mac_config(struct phylink_config *config,
+--- a/drivers/net/ethernet/huawei/hinic/hinic_ethtool.c
++++ b/drivers/net/ethernet/huawei/hinic/hinic_ethtool.c
+@@ -322,12 +322,10 @@ static int hinic_get_link_ksettings(stru
+ 		}
+ 	}
+ 
+-	bitmap_copy(link_ksettings->link_modes.supported,
+-		    (unsigned long *)&settings.supported,
+-		    __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_copy(link_ksettings->link_modes.advertising,
+-		    (unsigned long *)&settings.advertising,
+-		    __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_copy(link_ksettings->link_modes.supported,
++		      (unsigned long *)&settings.supported);
++	linkmode_copy(link_ksettings->link_modes.advertising,
++		      (unsigned long *)&settings.advertising);
+ 
+ 	return 0;
+ }
+--- a/drivers/net/ethernet/intel/ixgbe/ixgbe_ethtool.c
++++ b/drivers/net/ethernet/intel/ixgbe/ixgbe_ethtool.c
+@@ -467,9 +467,8 @@ static int ixgbe_set_link_ksettings(stru
+ 		 * this function does not support duplex forcing, but can
+ 		 * limit the advertising of the adapter to the specified speed
+ 		 */
+-		if (!bitmap_subset(cmd->link_modes.advertising,
+-				   cmd->link_modes.supported,
+-				   __ETHTOOL_LINK_MODE_MASK_NBITS))
++		if (!linkmode_subset(cmd->link_modes.advertising,
++				     cmd->link_modes.supported))
+ 			return -EINVAL;
+ 
+ 		/* only allow one speed at a time if no autoneg */
+--- a/drivers/net/ethernet/marvell/mvneta.c
++++ b/drivers/net/ethernet/marvell/mvneta.c
+@@ -3835,14 +3835,14 @@ static void mvneta_validate(struct phyli
+ 	 */
+ 	if (phy_interface_mode_is_8023z(state->interface)) {
+ 		if (!phylink_test(state->advertising, Autoneg)) {
+-			bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++			linkmode_zero(supported);
+ 			return;
+ 		}
+ 	} else if (state->interface != PHY_INTERFACE_MODE_NA &&
+ 		   state->interface != PHY_INTERFACE_MODE_QSGMII &&
+ 		   state->interface != PHY_INTERFACE_MODE_SGMII &&
+ 		   !phy_interface_mode_is_rgmii(state->interface)) {
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		return;
+ 	}
+ 
+@@ -3871,10 +3871,8 @@ static void mvneta_validate(struct phyli
+ 		phylink_set(mask, 100baseT_Full);
+ 	}
+ 
+-	bitmap_and(supported, supported, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ 
+ 	/* We can only operate at 2500BaseX or 1000BaseX.  If requested
+ 	 * to advertise both, only report advertising at 2500BaseX.
+--- a/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c
++++ b/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c
+@@ -6347,15 +6347,14 @@ static void mvpp2_phylink_validate(struc
+ 		goto empty_set;
+ 	}
+ 
+-	bitmap_and(supported, supported, mask, __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ 
+ 	phylink_helper_basex_speed(state);
+ 	return;
+ 
+ empty_set:
+-	bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_zero(supported);
+ }
+ 
+ static void mvpp2_xlg_config(struct mvpp2_port *port, unsigned int mode,
+--- a/drivers/net/ethernet/marvell/octeontx2/nic/otx2_ethtool.c
++++ b/drivers/net/ethernet/marvell/octeontx2/nic/otx2_ethtool.c
+@@ -1168,9 +1168,8 @@ static int otx2_set_link_ksettings(struc
+ 	otx2_get_link_ksettings(netdev, &cur_ks);
+ 
+ 	/* Check requested modes against supported modes by hardware */
+-	if (!bitmap_subset(cmd->link_modes.advertising,
+-			   cur_ks.link_modes.supported,
+-			   __ETHTOOL_LINK_MODE_MASK_NBITS))
++	if (!linkmode_subset(cmd->link_modes.advertising,
++			     cur_ks.link_modes.supported))
+ 		return -EINVAL;
+ 
+ 	mutex_lock(&mbox->lock);
+--- a/drivers/net/ethernet/marvell/pxa168_eth.c
++++ b/drivers/net/ethernet/marvell/pxa168_eth.c
+@@ -977,8 +977,7 @@ static int pxa168_init_phy(struct net_de
+ 	cmd.base.phy_address = pep->phy_addr;
+ 	cmd.base.speed = pep->phy_speed;
+ 	cmd.base.duplex = pep->phy_duplex;
+-	bitmap_copy(cmd.link_modes.advertising, PHY_BASIC_FEATURES,
+-		    __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_copy(cmd.link_modes.advertising, PHY_BASIC_FEATURES);
+ 	cmd.base.autoneg = AUTONEG_ENABLE;
+ 
+ 	if (cmd.base.speed != 0)
+--- a/drivers/net/ethernet/mellanox/mlx4/en_ethtool.c
++++ b/drivers/net/ethernet/mellanox/mlx4/en_ethtool.c
+@@ -39,6 +39,7 @@
+ #include <linux/in.h>
+ #include <net/ip.h>
+ #include <linux/bitmap.h>
++#include <linux/mii.h>
+ 
+ #include "mlx4_en.h"
+ #include "en_port.h"
+@@ -643,10 +644,8 @@ static unsigned long *ptys2ethtool_link_
+ 		unsigned int i;						\
+ 		cfg = &ptys2ethtool_map[reg_];				\
+ 		cfg->speed = speed_;					\
+-		bitmap_zero(cfg->supported,				\
+-			    __ETHTOOL_LINK_MODE_MASK_NBITS);		\
+-		bitmap_zero(cfg->advertised,				\
+-			    __ETHTOOL_LINK_MODE_MASK_NBITS);		\
++		linkmode_zero(cfg->supported);				\
++		linkmode_zero(cfg->advertised);				\
+ 		for (i = 0 ; i < ARRAY_SIZE(modes) ; ++i) {		\
+ 			__set_bit(modes[i], cfg->supported);		\
+ 			__set_bit(modes[i], cfg->advertised);		\
+@@ -702,10 +701,8 @@ static void ptys2ethtool_update_link_mod
+ 	int i;
+ 	for (i = 0; i < MLX4_LINK_MODES_SZ; i++) {
+ 		if (eth_proto & MLX4_PROT_MASK(i))
+-			bitmap_or(link_modes, link_modes,
+-				  ptys2ethtool_link_mode(&ptys2ethtool_map[i],
+-							 report),
+-				  __ETHTOOL_LINK_MODE_MASK_NBITS);
++			linkmode_or(link_modes, link_modes,
++				    ptys2ethtool_link_mode(&ptys2ethtool_map[i], report));
+ 	}
+ }
+ 
+@@ -716,11 +713,9 @@ static u32 ethtool2ptys_link_modes(const
+ 	u32 ptys_modes = 0;
+ 
+ 	for (i = 0; i < MLX4_LINK_MODES_SZ; i++) {
+-		if (bitmap_intersects(
+-			    ptys2ethtool_link_mode(&ptys2ethtool_map[i],
+-						   report),
+-			    link_modes,
+-			    __ETHTOOL_LINK_MODE_MASK_NBITS))
++		ulong *map_mode = ptys2ethtool_link_mode(&ptys2ethtool_map[i],
++							 report);
++		if (linkmode_intersects(map_mode, link_modes))
+ 			ptys_modes |= 1 << i;
+ 	}
+ 	return ptys_modes;
+--- a/drivers/net/ethernet/microchip/sparx5/sparx5_phylink.c
++++ b/drivers/net/ethernet/microchip/sparx5/sparx5_phylink.c
+@@ -92,12 +92,11 @@ static void sparx5_phylink_validate(stru
+ 		}
+ 		break;
+ 	default:
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		return;
+ 	}
+-	bitmap_and(supported, supported, mask, __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ }
+ 
+ static void sparx5_phylink_mac_config(struct phylink_config *config,
+--- a/drivers/net/ethernet/mscc/ocelot_net.c
++++ b/drivers/net/ethernet/mscc/ocelot_net.c
+@@ -1509,7 +1509,7 @@ static void vsc7514_phylink_validate(str
+ 
+ 	if (state->interface != PHY_INTERFACE_MODE_NA &&
+ 	    state->interface != ocelot_port->phy_mode) {
+-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(supported);
+ 		return;
+ 	}
+ 
+@@ -1528,9 +1528,8 @@ static void vsc7514_phylink_validate(str
+ 	phylink_set(mask, 2500baseT_Full);
+ 	phylink_set(mask, 2500baseX_Full);
+ 
+-	bitmap_and(supported, supported, mask, __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ }
+ 
+ static void vsc7514_phylink_mac_config(struct phylink_config *config,
+--- a/drivers/net/ethernet/pensando/ionic/ionic_ethtool.c
++++ b/drivers/net/ethernet/pensando/ionic/ionic_ethtool.c
+@@ -228,8 +228,7 @@ static int ionic_get_link_ksettings(stru
+ 		break;
+ 	}
+ 
+-	bitmap_copy(ks->link_modes.advertising, ks->link_modes.supported,
+-		    __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_copy(ks->link_modes.advertising, ks->link_modes.supported);
+ 
+ 	ethtool_link_ksettings_add_link_mode(ks, supported, FEC_BASER);
+ 	ethtool_link_ksettings_add_link_mode(ks, supported, FEC_RS);
+--- a/drivers/net/ethernet/xilinx/xilinx_axienet_main.c
++++ b/drivers/net/ethernet/xilinx/xilinx_axienet_main.c
+@@ -1565,7 +1565,7 @@ static void axienet_validate(struct phyl
+ 			netdev_warn(ndev, "Cannot use PHY mode %s, supported: %s\n",
+ 				    phy_modes(state->interface),
+ 				    phy_modes(lp->phy_mode));
+-			bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++			linkmode_zero(supported);
+ 			return;
+ 		}
+ 	}
+@@ -1598,10 +1598,8 @@ static void axienet_validate(struct phyl
+ 		break;
+ 	}
+ 
+-	bitmap_and(supported, supported, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
+-	bitmap_and(state->advertising, state->advertising, mask,
+-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_and(supported, supported, mask);
++	linkmode_and(state->advertising, state->advertising, mask);
+ }
+ 
+ static void axienet_mac_pcs_get_state(struct phylink_config *config,
+--- a/drivers/net/pcs/pcs-xpcs.c
++++ b/drivers/net/pcs/pcs-xpcs.c
+@@ -646,7 +646,7 @@ void xpcs_validate(struct dw_xpcs *xpcs,
+ 	if (state->interface == PHY_INTERFACE_MODE_NA)
+ 		return;
+ 
+-	bitmap_zero(xpcs_supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_zero(xpcs_supported);
+ 
+ 	compat = xpcs_find_compat(xpcs->id, state->interface);
+ 
+--- a/drivers/net/phy/sfp-bus.c
++++ b/drivers/net/phy/sfp-bus.c
+@@ -379,7 +379,7 @@ void sfp_parse_support(struct sfp_bus *b
+ 	if (bus->sfp_quirk)
+ 		bus->sfp_quirk->modes(id, modes);
+ 
+-	bitmap_or(support, support, modes, __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_or(support, support, modes);
+ 
+ 	phylink_set(support, Autoneg);
+ 	phylink_set(support, Pause);
+--- a/net/ethtool/ioctl.c
++++ b/net/ethtool/ioctl.c
+@@ -335,7 +335,7 @@ EXPORT_SYMBOL(ethtool_intersect_link_mas
+ void ethtool_convert_legacy_u32_to_link_mode(unsigned long *dst,
+ 					     u32 legacy_u32)
+ {
+-	bitmap_zero(dst, __ETHTOOL_LINK_MODE_MASK_NBITS);
++	linkmode_zero(dst);
+ 	dst[0] = legacy_u32;
+ }
+ EXPORT_SYMBOL(ethtool_convert_legacy_u32_to_link_mode);
+@@ -350,11 +350,10 @@ bool ethtool_convert_link_mode_to_legacy
+ 	if (__ETHTOOL_LINK_MODE_MASK_NBITS > 32) {
+ 		__ETHTOOL_DECLARE_LINK_MODE_MASK(ext);
+ 
+-		bitmap_zero(ext, __ETHTOOL_LINK_MODE_MASK_NBITS);
++		linkmode_zero(ext);
+ 		bitmap_fill(ext, 32);
+ 		bitmap_complement(ext, ext, __ETHTOOL_LINK_MODE_MASK_NBITS);
+-		if (bitmap_intersects(ext, src,
+-				      __ETHTOOL_LINK_MODE_MASK_NBITS)) {
++		if (linkmode_intersects(ext, src)) {
+ 			/* src mask goes beyond bit 31 */
+ 			retval = false;
+ 		}

--- a/target/linux/generic/backport-5.15/703-16-v5.16-net-mvneta-populate-supported_interfaces-member.patch
+++ b/target/linux/generic/backport-5.15/703-16-v5.16-net-mvneta-populate-supported_interfaces-member.patch
@@ -1,0 +1,48 @@
+From fdedb695e6a8657302341cda81d519ef04f9acaa Mon Sep 17 00:00:00 2001
+From: Russell King <rmk+kernel@armlinux.org.uk>
+Date: Wed, 27 Oct 2021 10:03:43 +0100
+Subject: [PATCH] net: mvneta: populate supported_interfaces member
+
+Populate the phy_interface_t bitmap for the Marvell mvneta driver with
+interfaces modes supported by the MAC.
+
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/marvell/mvneta.c | 25 +++++++++++++++++++++++++
+ 1 file changed, 25 insertions(+)
+
+--- a/drivers/net/ethernet/marvell/mvneta.c
++++ b/drivers/net/ethernet/marvell/mvneta.c
+@@ -5180,6 +5180,31 @@ static int mvneta_probe(struct platform_
+ 
+ 	pp->phylink_config.dev = &dev->dev;
+ 	pp->phylink_config.type = PHYLINK_NETDEV;
++	phy_interface_set_rgmii(pp->phylink_config.supported_interfaces);
++	__set_bit(PHY_INTERFACE_MODE_QSGMII,
++		  pp->phylink_config.supported_interfaces);
++	if (comphy) {
++		/* If a COMPHY is present, we can support any of the serdes
++		 * modes and switch between them.
++		 */
++		__set_bit(PHY_INTERFACE_MODE_SGMII,
++			  pp->phylink_config.supported_interfaces);
++		__set_bit(PHY_INTERFACE_MODE_1000BASEX,
++			  pp->phylink_config.supported_interfaces);
++		__set_bit(PHY_INTERFACE_MODE_2500BASEX,
++			  pp->phylink_config.supported_interfaces);
++	} else if (phy_mode == PHY_INTERFACE_MODE_2500BASEX) {
++		/* No COMPHY, with only 2500BASE-X mode supported */
++		__set_bit(PHY_INTERFACE_MODE_2500BASEX,
++			  pp->phylink_config.supported_interfaces);
++	} else if (phy_mode == PHY_INTERFACE_MODE_1000BASEX ||
++		   phy_mode == PHY_INTERFACE_MODE_SGMII) {
++		/* No COMPHY, we can switch between 1000BASE-X and SGMII */
++		__set_bit(PHY_INTERFACE_MODE_1000BASEX,
++			  pp->phylink_config.supported_interfaces);
++		__set_bit(PHY_INTERFACE_MODE_SGMII,
++			  pp->phylink_config.supported_interfaces);
++	}
+ 
+ 	phylink = phylink_create(&pp->phylink_config, pdev->dev.fwnode,
+ 				 phy_mode, &mvneta_phylink_ops);

--- a/target/linux/generic/backport-5.15/703-17-v5.16-net-mvneta-remove-interface-checks-in-mvneta_validat.patch
+++ b/target/linux/generic/backport-5.15/703-17-v5.16-net-mvneta-remove-interface-checks-in-mvneta_validat.patch
@@ -1,0 +1,35 @@
+From d9ca72807ecb236f679b960c70ef5b7d4a5f0222 Mon Sep 17 00:00:00 2001
+From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
+Date: Wed, 27 Oct 2021 10:03:48 +0100
+Subject: [PATCH] net: mvneta: remove interface checks in mvneta_validate()
+
+As phylink checks the interface mode against the supported_interfaces
+bitmap, we no longer need to validate the interface mode in the
+validation function. Remove this to simplify it.
+
+Signed-off-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/marvell/mvneta.c | 11 ++---------
+ 1 file changed, 2 insertions(+), 9 deletions(-)
+
+--- a/drivers/net/ethernet/marvell/mvneta.c
++++ b/drivers/net/ethernet/marvell/mvneta.c
+@@ -3833,15 +3833,8 @@ static void mvneta_validate(struct phyli
+ 	 * "Bit 2 Field InBandAnEn In-band Auto-Negotiation enable. ...
+ 	 * When <PortType> = 1 (1000BASE-X) this field must be set to 1."
+ 	 */
+-	if (phy_interface_mode_is_8023z(state->interface)) {
+-		if (!phylink_test(state->advertising, Autoneg)) {
+-			linkmode_zero(supported);
+-			return;
+-		}
+-	} else if (state->interface != PHY_INTERFACE_MODE_NA &&
+-		   state->interface != PHY_INTERFACE_MODE_QSGMII &&
+-		   state->interface != PHY_INTERFACE_MODE_SGMII &&
+-		   !phy_interface_mode_is_rgmii(state->interface)) {
++	if (phy_interface_mode_is_8023z(state->interface) &&
++	    !phylink_test(state->advertising, Autoneg)) {
+ 		linkmode_zero(supported);
+ 		return;
+ 	}

--- a/target/linux/generic/backport-5.15/703-18-v5.16-net-mvneta-drop-use-of-phylink_helper_basex_speed.patch
+++ b/target/linux/generic/backport-5.15/703-18-v5.16-net-mvneta-drop-use-of-phylink_helper_basex_speed.patch
@@ -1,0 +1,55 @@
+From 099cbfa286ab937d8213c2dc5c0b401969b78042 Mon Sep 17 00:00:00 2001
+From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
+Date: Wed, 27 Oct 2021 10:03:53 +0100
+Subject: [PATCH] net: mvneta: drop use of phylink_helper_basex_speed()
+
+Now that we have a better method to select SFP interface modes, we
+no longer need to use phylink_helper_basex_speed() in a driver's
+validation function, and we can also get rid of our hack to indicate
+both 1000base-X and 2500base-X if the comphy is present to make that
+work. Remove this hack and use of phylink_helper_basex_speed().
+
+Signed-off-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/marvell/mvneta.c | 12 +++---------
+ 1 file changed, 3 insertions(+), 9 deletions(-)
+
+--- a/drivers/net/ethernet/marvell/mvneta.c
++++ b/drivers/net/ethernet/marvell/mvneta.c
+@@ -3824,8 +3824,6 @@ static void mvneta_validate(struct phyli
+ 			    unsigned long *supported,
+ 			    struct phylink_link_state *state)
+ {
+-	struct net_device *ndev = to_net_dev(config->dev);
+-	struct mvneta_port *pp = netdev_priv(ndev);
+ 	__ETHTOOL_DECLARE_LINK_MODE_MASK(mask) = { 0, };
+ 
+ 	/* We only support QSGMII, SGMII, 802.3z and RGMII modes.
+@@ -3847,11 +3845,12 @@ static void mvneta_validate(struct phyli
+ 	phylink_set(mask, Pause);
+ 
+ 	/* Half-duplex at speeds higher than 100Mbit is unsupported */
+-	if (pp->comphy || state->interface != PHY_INTERFACE_MODE_2500BASEX) {
++	if (state->interface != PHY_INTERFACE_MODE_2500BASEX) {
+ 		phylink_set(mask, 1000baseT_Full);
+ 		phylink_set(mask, 1000baseX_Full);
+ 	}
+-	if (pp->comphy || state->interface == PHY_INTERFACE_MODE_2500BASEX) {
++
++	if (state->interface == PHY_INTERFACE_MODE_2500BASEX) {
+ 		phylink_set(mask, 2500baseT_Full);
+ 		phylink_set(mask, 2500baseX_Full);
+ 	}
+@@ -3866,11 +3865,6 @@ static void mvneta_validate(struct phyli
+ 
+ 	linkmode_and(supported, supported, mask);
+ 	linkmode_and(state->advertising, state->advertising, mask);
+-
+-	/* We can only operate at 2500BaseX or 1000BaseX.  If requested
+-	 * to advertise both, only report advertising at 2500BaseX.
+-	 */
+-	phylink_helper_basex_speed(state);
+ }
+ 
+ static void mvneta_mac_pcs_get_state(struct phylink_config *config,

--- a/target/linux/generic/backport-5.15/703-19-v5.17-net-mvneta-use-phylink_generic_validate.patch
+++ b/target/linux/generic/backport-5.15/703-19-v5.17-net-mvneta-use-phylink_generic_validate.patch
@@ -1,0 +1,72 @@
+From 02a0988b98930491db95966fb8086072e47dabb6 Mon Sep 17 00:00:00 2001
+From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
+Date: Mon, 15 Nov 2021 10:00:32 +0000
+Subject: [PATCH] net: mvneta: use phylink_generic_validate()
+
+Convert mvneta to use phylink_generic_validate() for the bulk of its
+validate() implementation. This network adapter has a restriction
+that for 802.3z links, autonegotiation must be enabled.
+
+Signed-off-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/marvell/mvneta.c | 34 ++++-----------------------
+ 1 file changed, 4 insertions(+), 30 deletions(-)
+
+--- a/drivers/net/ethernet/marvell/mvneta.c
++++ b/drivers/net/ethernet/marvell/mvneta.c
+@@ -3824,8 +3824,6 @@ static void mvneta_validate(struct phyli
+ 			    unsigned long *supported,
+ 			    struct phylink_link_state *state)
+ {
+-	__ETHTOOL_DECLARE_LINK_MODE_MASK(mask) = { 0, };
+-
+ 	/* We only support QSGMII, SGMII, 802.3z and RGMII modes.
+ 	 * When in 802.3z mode, we must have AN enabled:
+ 	 * "Bit 2 Field InBandAnEn In-band Auto-Negotiation enable. ...
+@@ -3837,34 +3835,7 @@ static void mvneta_validate(struct phyli
+ 		return;
+ 	}
+ 
+-	/* Allow all the expected bits */
+-	phylink_set(mask, Autoneg);
+-	phylink_set_port_modes(mask);
+-
+-	/* Asymmetric pause is unsupported */
+-	phylink_set(mask, Pause);
+-
+-	/* Half-duplex at speeds higher than 100Mbit is unsupported */
+-	if (state->interface != PHY_INTERFACE_MODE_2500BASEX) {
+-		phylink_set(mask, 1000baseT_Full);
+-		phylink_set(mask, 1000baseX_Full);
+-	}
+-
+-	if (state->interface == PHY_INTERFACE_MODE_2500BASEX) {
+-		phylink_set(mask, 2500baseT_Full);
+-		phylink_set(mask, 2500baseX_Full);
+-	}
+-
+-	if (!phy_interface_mode_is_8023z(state->interface)) {
+-		/* 10M and 100M are only supported in non-802.3z mode */
+-		phylink_set(mask, 10baseT_Half);
+-		phylink_set(mask, 10baseT_Full);
+-		phylink_set(mask, 100baseT_Half);
+-		phylink_set(mask, 100baseT_Full);
+-	}
+-
+-	linkmode_and(supported, supported, mask);
+-	linkmode_and(state->advertising, state->advertising, mask);
++	phylink_generic_validate(config, supported, state);
+ }
+ 
+ static void mvneta_mac_pcs_get_state(struct phylink_config *config,
+@@ -5167,6 +5138,9 @@ static int mvneta_probe(struct platform_
+ 
+ 	pp->phylink_config.dev = &dev->dev;
+ 	pp->phylink_config.type = PHYLINK_NETDEV;
++	pp->phylink_config.mac_capabilities = MAC_SYM_PAUSE | MAC_10 |
++		MAC_100 | MAC_1000FD | MAC_2500FD;
++
+ 	phy_interface_set_rgmii(pp->phylink_config.supported_interfaces);
+ 	__set_bit(PHY_INTERFACE_MODE_QSGMII,
+ 		  pp->phylink_config.supported_interfaces);

--- a/target/linux/generic/backport-5.15/703-20-v5.17-net-mvneta-mark-as-a-legacy_pre_march2020-driver.patch
+++ b/target/linux/generic/backport-5.15/703-20-v5.17-net-mvneta-mark-as-a-legacy_pre_march2020-driver.patch
@@ -1,0 +1,29 @@
+From 2106be4fdf3223d9c5bd485e6ef094139e3197ba Mon Sep 17 00:00:00 2001
+From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
+Date: Sun, 12 Dec 2021 13:01:21 +0000
+Subject: [PATCH] net: mvneta: mark as a legacy_pre_march2020 driver
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+mvneta provides mac_an_restart and mac_pcs_get_state methods, so needs
+to be marked as a legacy driver. Marek spotted that mvneta had stopped
+working in 2500base-X mode - thanks for reporting.
+
+Reported-by: Marek Behún <kabel@kernel.org>
+Signed-off-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/marvell/mvneta.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/net/ethernet/marvell/mvneta.c
++++ b/drivers/net/ethernet/marvell/mvneta.c
+@@ -5138,6 +5138,7 @@ static int mvneta_probe(struct platform_
+ 
+ 	pp->phylink_config.dev = &dev->dev;
+ 	pp->phylink_config.type = PHYLINK_NETDEV;
++	pp->phylink_config.legacy_pre_march2020 = true;
+ 	pp->phylink_config.mac_capabilities = MAC_SYM_PAUSE | MAC_10 |
+ 		MAC_100 | MAC_1000FD | MAC_2500FD;
+ 

--- a/target/linux/generic/backport-5.15/743-v5.16-0001-net-dsa-b53-Include-all-ports-in-enabled_ports.patch
+++ b/target/linux/generic/backport-5.15/743-v5.16-0001-net-dsa-b53-Include-all-ports-in-enabled_ports.patch
@@ -22,7 +22,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/dsa/b53/b53_common.c
 +++ b/drivers/net/dsa/b53/b53_common.c
-@@ -2302,7 +2302,7 @@ static const struct b53_chip_data b53_sw
+@@ -2300,7 +2300,7 @@ static const struct b53_chip_data b53_sw
  		.chip_id = BCM5325_DEVICE_ID,
  		.dev_name = "BCM5325",
  		.vlans = 16,
@@ -31,7 +31,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.arl_bins = 2,
  		.arl_buckets = 1024,
  		.imp_port = 5,
-@@ -2313,7 +2313,7 @@ static const struct b53_chip_data b53_sw
+@@ -2311,7 +2311,7 @@ static const struct b53_chip_data b53_sw
  		.chip_id = BCM5365_DEVICE_ID,
  		.dev_name = "BCM5365",
  		.vlans = 256,
@@ -40,7 +40,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.arl_bins = 2,
  		.arl_buckets = 1024,
  		.imp_port = 5,
-@@ -2324,7 +2324,7 @@ static const struct b53_chip_data b53_sw
+@@ -2322,7 +2322,7 @@ static const struct b53_chip_data b53_sw
  		.chip_id = BCM5389_DEVICE_ID,
  		.dev_name = "BCM5389",
  		.vlans = 4096,
@@ -49,7 +49,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
-@@ -2338,7 +2338,7 @@ static const struct b53_chip_data b53_sw
+@@ -2336,7 +2336,7 @@ static const struct b53_chip_data b53_sw
  		.chip_id = BCM5395_DEVICE_ID,
  		.dev_name = "BCM5395",
  		.vlans = 4096,
@@ -58,7 +58,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
-@@ -2352,7 +2352,7 @@ static const struct b53_chip_data b53_sw
+@@ -2350,7 +2350,7 @@ static const struct b53_chip_data b53_sw
  		.chip_id = BCM5397_DEVICE_ID,
  		.dev_name = "BCM5397",
  		.vlans = 4096,
@@ -67,7 +67,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
-@@ -2366,7 +2366,7 @@ static const struct b53_chip_data b53_sw
+@@ -2364,7 +2364,7 @@ static const struct b53_chip_data b53_sw
  		.chip_id = BCM5398_DEVICE_ID,
  		.dev_name = "BCM5398",
  		.vlans = 4096,
@@ -76,7 +76,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
-@@ -2380,7 +2380,7 @@ static const struct b53_chip_data b53_sw
+@@ -2378,7 +2378,7 @@ static const struct b53_chip_data b53_sw
  		.chip_id = BCM53115_DEVICE_ID,
  		.dev_name = "BCM53115",
  		.vlans = 4096,
@@ -85,7 +85,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.vta_regs = B53_VTA_REGS,
-@@ -2394,7 +2394,7 @@ static const struct b53_chip_data b53_sw
+@@ -2392,7 +2392,7 @@ static const struct b53_chip_data b53_sw
  		.chip_id = BCM53125_DEVICE_ID,
  		.dev_name = "BCM53125",
  		.vlans = 4096,
@@ -94,7 +94,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
-@@ -2436,7 +2436,7 @@ static const struct b53_chip_data b53_sw
+@@ -2434,7 +2434,7 @@ static const struct b53_chip_data b53_sw
  		.chip_id = BCM53010_DEVICE_ID,
  		.dev_name = "BCM53010",
  		.vlans = 4096,
@@ -103,7 +103,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
-@@ -2478,7 +2478,7 @@ static const struct b53_chip_data b53_sw
+@@ -2476,7 +2476,7 @@ static const struct b53_chip_data b53_sw
  		.chip_id = BCM53018_DEVICE_ID,
  		.dev_name = "BCM53018",
  		.vlans = 4096,
@@ -112,7 +112,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
-@@ -2492,7 +2492,7 @@ static const struct b53_chip_data b53_sw
+@@ -2490,7 +2490,7 @@ static const struct b53_chip_data b53_sw
  		.chip_id = BCM53019_DEVICE_ID,
  		.dev_name = "BCM53019",
  		.vlans = 4096,
@@ -121,7 +121,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
-@@ -2634,7 +2634,6 @@ static int b53_switch_init(struct b53_de
+@@ -2632,7 +2632,6 @@ static int b53_switch_init(struct b53_de
  			dev->cpu_port = 5;
  	}
  

--- a/target/linux/generic/backport-5.15/743-v5.16-0004-net-dsa-b53-Drop-unused-cpu_port-field.patch
+++ b/target/linux/generic/backport-5.15/743-v5.16-0004-net-dsa-b53-Drop-unused-cpu_port-field.patch
@@ -19,7 +19,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/dsa/b53/b53_common.c
 +++ b/drivers/net/dsa/b53/b53_common.c
-@@ -2300,7 +2300,6 @@ static const struct b53_chip_data b53_sw
+@@ -2298,7 +2298,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 2,
  		.arl_buckets = 1024,
  		.imp_port = 5,
@@ -27,7 +27,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.duplex_reg = B53_DUPLEX_STAT_FE,
  	},
  	{
-@@ -2311,7 +2310,6 @@ static const struct b53_chip_data b53_sw
+@@ -2309,7 +2308,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 2,
  		.arl_buckets = 1024,
  		.imp_port = 5,
@@ -35,7 +35,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.duplex_reg = B53_DUPLEX_STAT_FE,
  	},
  	{
-@@ -2322,7 +2320,6 @@ static const struct b53_chip_data b53_sw
+@@ -2320,7 +2318,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -43,7 +43,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2336,7 +2333,6 @@ static const struct b53_chip_data b53_sw
+@@ -2334,7 +2331,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -51,7 +51,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2350,7 +2346,6 @@ static const struct b53_chip_data b53_sw
+@@ -2348,7 +2344,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -59,7 +59,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS_9798,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2364,7 +2359,6 @@ static const struct b53_chip_data b53_sw
+@@ -2362,7 +2357,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -67,7 +67,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS_9798,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2379,7 +2373,6 @@ static const struct b53_chip_data b53_sw
+@@ -2377,7 +2371,6 @@ static const struct b53_chip_data b53_sw
  		.arl_buckets = 1024,
  		.vta_regs = B53_VTA_REGS,
  		.imp_port = 8,
@@ -75,7 +75,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
  		.jumbo_size_reg = B53_JUMBO_MAX_SIZE,
-@@ -2392,7 +2385,6 @@ static const struct b53_chip_data b53_sw
+@@ -2390,7 +2383,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -83,7 +83,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2406,7 +2398,6 @@ static const struct b53_chip_data b53_sw
+@@ -2404,7 +2396,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -91,7 +91,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2420,7 +2411,6 @@ static const struct b53_chip_data b53_sw
+@@ -2418,7 +2409,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -99,7 +99,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS_63XX,
  		.duplex_reg = B53_DUPLEX_STAT_63XX,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK_63XX,
-@@ -2434,7 +2424,6 @@ static const struct b53_chip_data b53_sw
+@@ -2432,7 +2422,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -107,7 +107,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2448,7 +2437,6 @@ static const struct b53_chip_data b53_sw
+@@ -2446,7 +2435,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -115,7 +115,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2462,7 +2450,6 @@ static const struct b53_chip_data b53_sw
+@@ -2460,7 +2448,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -123,7 +123,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2476,7 +2463,6 @@ static const struct b53_chip_data b53_sw
+@@ -2474,7 +2461,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -131,7 +131,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2490,7 +2476,6 @@ static const struct b53_chip_data b53_sw
+@@ -2488,7 +2474,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -139,7 +139,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2504,7 +2489,6 @@ static const struct b53_chip_data b53_sw
+@@ -2502,7 +2487,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -147,7 +147,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2518,7 +2502,6 @@ static const struct b53_chip_data b53_sw
+@@ -2516,7 +2500,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -155,7 +155,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2547,7 +2530,6 @@ static const struct b53_chip_data b53_sw
+@@ -2545,7 +2528,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 1024,
  		.imp_port = 8,
@@ -163,7 +163,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2561,7 +2543,6 @@ static const struct b53_chip_data b53_sw
+@@ -2559,7 +2541,6 @@ static const struct b53_chip_data b53_sw
  		.arl_bins = 4,
  		.arl_buckets = 256,
  		.imp_port = 8,
@@ -171,7 +171,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		.vta_regs = B53_VTA_REGS,
  		.duplex_reg = B53_DUPLEX_STAT_GE,
  		.jumbo_pm_reg = B53_JUMBO_PORT_MASK,
-@@ -2587,7 +2568,6 @@ static int b53_switch_init(struct b53_de
+@@ -2585,7 +2566,6 @@ static int b53_switch_init(struct b53_de
  			dev->vta_regs[2] = chip->vta_regs[2];
  			dev->jumbo_pm_reg = chip->jumbo_pm_reg;
  			dev->imp_port = chip->imp_port;
@@ -179,7 +179,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  			dev->num_vlans = chip->vlans;
  			dev->num_arl_bins = chip->arl_bins;
  			dev->num_arl_buckets = chip->arl_buckets;
-@@ -2619,13 +2599,6 @@ static int b53_switch_init(struct b53_de
+@@ -2617,13 +2597,6 @@ static int b53_switch_init(struct b53_de
  			break;
  #endif
  		}

--- a/target/linux/generic/hack-5.15/711-net-dsa-mv88e6xxx-disable-ATU-violation.patch
+++ b/target/linux/generic/hack-5.15/711-net-dsa-mv88e6xxx-disable-ATU-violation.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] net/dsa/mv88e6xxx: disable ATU violation
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -2981,6 +2981,9 @@ static int mv88e6xxx_setup_port(struct m
+@@ -2980,6 +2980,9 @@ static int mv88e6xxx_setup_port(struct m
  	else
  		reg = 1 << port;
  

--- a/target/linux/generic/pending-5.15/768-net-dsa-mv88e6xxx-Request-assisted-learning-on-CPU-port.patch
+++ b/target/linux/generic/pending-5.15/768-net-dsa-mv88e6xxx-Request-assisted-learning-on-CPU-port.patch
@@ -17,7 +17,7 @@ Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -6320,6 +6320,7 @@ static int mv88e6xxx_register_switch(str
+@@ -6319,6 +6319,7 @@ static int mv88e6xxx_register_switch(str
  	ds->ops = &mv88e6xxx_switch_ops;
  	ds->ageing_time_min = chip->info->age_time_coeff;
  	ds->ageing_time_max = chip->info->age_time_coeff * U8_MAX;


### PR DESCRIPTION
Import patches from Linux v5.16 and v5.17 to get 2500Base-X SFP working again with mvneta driver after the generic phylink validate backport.

Fixes: aab466f422 ("kernel: backport generic phylink validate")
Signed-off-by: Daniel Golle <daniel@makrotopia.org>

Fixes #10612