### PR TITLE
add protocol qmi/mbim support for ucidef_set_interface()

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -207,6 +207,14 @@ generate_network() {
 				EOF
 			}
 		;;
+
+		qmi|\
+		mbim)
+			uci -q batch <<-EOF
+				set network.$1.proto='${protocol}'
+				set network.$1.pdptype='ipv4'
+			EOF
+		;;
 	esac
 }
 


### PR DESCRIPTION
useful for default wan configuration of devices with modem

Fixes #10569

Device using it: #10972 

@Linaro1985 @hauke 