### PR TITLE
build: fixup for AUTOREMOVE config

### DIFF
--- a/include/depends.mk
+++ b/include/depends.mk
@@ -11,7 +11,7 @@
 
 DEP_FINDPARAMS := -x "*/.svn*" -x ".*" -x "*:*" -x "*\!*" -x "* *" -x "*\\\#*" -x "*/.*_check" -x "*/.*.swp" -x "*/.pkgdir*"
 
-find_md5=find $(wildcard $(1)) -type f $(patsubst -x,-and -not -path,$(DEP_FINDPARAMS) $(2)) -printf "%p%T@\n" | sort | $(MKHASH) md5
+find_md5=find $(wildcard $(1)) -type f $(patsubst -x,-and -not -path,$(DEP_FINDPARAMS) $(2)) -printf "%p%T@\n" | sort | awk -v srch="$TOPDIR" -v repl="" '{ sub(srch,repl,$0); print $0 }' | $(MKHASH) md5
 
 define rdep
   .PRECIOUS: $(2)


### PR DESCRIPTION
Hi, i'm experimenting with the AUTOREMOVE config and i'm trying to fix some thing

This have one minor fix
- some package may have whitespace in directory name. Currently xargs doesn't handle that. We fix this. In theory should work in both new disto and macos.

This have one major fix
- Currently we generate the hash based on the TOPDIR path. This is problematic as the hash will change based on where the buildroot is placed (refer to the commit description for example)
- We change the logic to strip TOPDIR from the path before calculating the hash.

This will cause every package to get recompiled as the stamp files will have a different hash. Aside from that in theory this should only improve things and permit more reproducible bins on the same system.

Only concern is with user that move the buildroot to a different system, in that corner case package won't be recompiled but this is so rare that I think we should ignore this and flag this kind of thing as **USER ERROR**
