### PR TITLE
realtek: add support for DGS-1210-52 (relaunch)

### DIFF
--- a/target/linux/realtek/dts-5.10/rtl8380_d-link_dgs-1210-10mp-f.dts
+++ b/target/linux/realtek/dts-5.10/rtl8380_d-link_dgs-1210-10mp-f.dts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "rtl838x_d-link_dgs-1210_common.dtsi"
+#include "rtl838x.dtsi"
+#include "rtl83xx_d-link_dgs-1210_common.dtsi"
 #include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
 
 / {

--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-10p.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-10p.dts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "rtl838x_d-link_dgs-1210_common.dtsi"
+#include "rtl838x.dtsi"
+#include "rtl83xx_d-link_dgs-1210_common.dtsi"
 
 / {
 	compatible = "d-link,dgs-1210-10p", "realtek,rtl838x-soc";

--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-16.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-16.dts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "rtl838x_d-link_dgs-1210_common.dtsi"
+#include "rtl838x.dtsi"
+#include "rtl83xx_d-link_dgs-1210_common.dtsi"
 
 / {
 	compatible = "d-link,dgs-1210-16", "realtek,rtl838x-soc";

--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-20.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-20.dts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "rtl838x_d-link_dgs-1210_common.dtsi"
+#include "rtl838x.dtsi"
+#include "rtl83xx_d-link_dgs-1210_common.dtsi"
 #include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
 
 / {

--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-28.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-28.dts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "rtl838x_d-link_dgs-1210_common.dtsi"
+#include "rtl838x.dtsi"
+#include "rtl83xx_d-link_dgs-1210_common.dtsi"
 #include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
 
 / {

--- a/target/linux/realtek/dts-5.10/rtl8393_d-link_dgs-1210-52.dts
+++ b/target/linux/realtek/dts-5.10/rtl8393_d-link_dgs-1210-52.dts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl839x.dtsi"
+#include "rtl83xx_d-link_dgs-1210_common.dtsi"
+#include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
+#include "rtl839x_d-link_dgs-1210_gpio.dtsi"
+
+/ {
+	compatible = "d-link,dgs-1210-52", "realtek,rtl8393-soc";
+	model = "D-Link DGS-1210-52";
+};
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* External phy RTL8218B #1 */
+		EXTERNAL_PHY(0)
+		EXTERNAL_PHY(1)
+		EXTERNAL_PHY(2)
+		EXTERNAL_PHY(3)
+		EXTERNAL_PHY(4)
+		EXTERNAL_PHY(5)
+		EXTERNAL_PHY(6)
+		EXTERNAL_PHY(7)
+
+		/* External phy RTL8218B #2 */
+		EXTERNAL_PHY(8)
+		EXTERNAL_PHY(9)
+		EXTERNAL_PHY(10)
+		EXTERNAL_PHY(11)
+		EXTERNAL_PHY(12)
+		EXTERNAL_PHY(13)
+		EXTERNAL_PHY(14)
+		EXTERNAL_PHY(15)
+
+		/* External phy RTL8218B #3 */
+		EXTERNAL_PHY(16)
+		EXTERNAL_PHY(17)
+		EXTERNAL_PHY(18)
+		EXTERNAL_PHY(19)
+		EXTERNAL_PHY(20)
+		EXTERNAL_PHY(21)
+		EXTERNAL_PHY(22)
+		EXTERNAL_PHY(23)
+
+		/* External phy RTL8218B #4 */
+		EXTERNAL_PHY(24)
+		EXTERNAL_PHY(25)
+		EXTERNAL_PHY(26)
+		EXTERNAL_PHY(27)
+		EXTERNAL_PHY(28)
+		EXTERNAL_PHY(29)
+		EXTERNAL_PHY(30)
+		EXTERNAL_PHY(31)
+
+		/* External phy RTL8218B #5 */
+		EXTERNAL_PHY(32)
+		EXTERNAL_PHY(33)
+		EXTERNAL_PHY(34)
+		EXTERNAL_PHY(35)
+		EXTERNAL_PHY(36)
+		EXTERNAL_PHY(37)
+		EXTERNAL_PHY(38)
+		EXTERNAL_PHY(39)
+
+		/* External phy RTL8218B #6 */
+		EXTERNAL_PHY(40)
+		EXTERNAL_PHY(41)
+		EXTERNAL_PHY(42)
+		EXTERNAL_PHY(43)
+		EXTERNAL_PHY(44)
+		EXTERNAL_PHY(45)
+		EXTERNAL_PHY(46)
+		EXTERNAL_PHY(47)
+
+		/* External phy RTL8214FC */
+		EXTERNAL_SFP_PHY_FULL(48, 0)
+		EXTERNAL_SFP_PHY_FULL(49, 1)
+		EXTERNAL_SFP_PHY_FULL(50, 2)
+		EXTERNAL_SFP_PHY_FULL(51, 3)
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, qsgmii)
+		SWITCH_PORT(9, 10, qsgmii)
+		SWITCH_PORT(10, 11, qsgmii)
+		SWITCH_PORT(11, 12, qsgmii)
+		SWITCH_PORT(12, 13, qsgmii)
+		SWITCH_PORT(13, 14, qsgmii)
+		SWITCH_PORT(14, 15, qsgmii)
+		SWITCH_PORT(15, 16, qsgmii)
+
+		SWITCH_PORT(16, 17, qsgmii)
+		SWITCH_PORT(17, 18, qsgmii)
+		SWITCH_PORT(18, 19, qsgmii)
+		SWITCH_PORT(19, 20, qsgmii)
+		SWITCH_PORT(20, 21, qsgmii)
+		SWITCH_PORT(21, 22, qsgmii)
+		SWITCH_PORT(22, 23, qsgmii)
+		SWITCH_PORT(23, 24, qsgmii)
+
+		SWITCH_PORT(24, 25, qsgmii)
+		SWITCH_PORT(25, 26, qsgmii)
+		SWITCH_PORT(26, 27, qsgmii)
+		SWITCH_PORT(27, 28, qsgmii)
+		SWITCH_PORT(28, 29, qsgmii)
+		SWITCH_PORT(29, 30, qsgmii)
+		SWITCH_PORT(30, 31, qsgmii)
+		SWITCH_PORT(31, 32, qsgmii)
+
+		SWITCH_PORT(32, 33, qsgmii)
+		SWITCH_PORT(33, 34, qsgmii)
+		SWITCH_PORT(34, 35, qsgmii)
+		SWITCH_PORT(35, 36, qsgmii)
+		SWITCH_PORT(36, 37, qsgmii)
+		SWITCH_PORT(37, 38, qsgmii)
+		SWITCH_PORT(38, 39, qsgmii)
+		SWITCH_PORT(39, 40, qsgmii)
+
+		SWITCH_PORT(40, 41, qsgmii)
+		SWITCH_PORT(41, 42, qsgmii)
+		SWITCH_PORT(42, 43, qsgmii)
+		SWITCH_PORT(43, 44, qsgmii)
+		SWITCH_PORT(44, 45, qsgmii)
+		SWITCH_PORT(45, 46, qsgmii)
+		SWITCH_PORT(46, 47, qsgmii)
+		SWITCH_PORT(47, 48, qsgmii)
+
+		SWITCH_PORT(48, 49, qsgmii)
+		SWITCH_PORT(49, 50, qsgmii)
+		SWITCH_PORT(50, 51, qsgmii)
+		SWITCH_PORT(51, 52, qsgmii)
+
+		/* CPU-Port */
+		port@52 {
+			ethernet = <&ethernet0>;
+			reg = <52>;
+			phy-mode = "qsgmii";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/dts-5.10/rtl839x.dtsi
+++ b/target/linux/realtek/dts-5.10/rtl839x.dtsi
@@ -29,6 +29,13 @@
 		reg = <##n>; \
 	};
 
+#define EXTERNAL_SFP_PHY_FULL(n, s) \
+	phy##n: ethernet-phy@##n { \
+		compatible = "ethernet-phy-ieee802.3-c22"; \
+		sfp = <&sfp##s>; \
+		reg = <##n>; \
+	};
+
 #define SWITCH_PORT(n, s, m) \
 	port@##n { \
 		reg = <##n>; \

--- a/target/linux/realtek/dts-5.10/rtl839x_d-link_dgs-1210_gpio.dtsi
+++ b/target/linux/realtek/dts-5.10/rtl839x_d-link_dgs-1210_gpio.dtsi
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/ {
+	/*
+	 * GPIO when SFP is connected:
+	 *
+	 * rtl8231: base 451
+	 * gpio459 : LAN49
+	 * gpio454 : LAN50
+	 * gpio475 : LAN51
+	 * gpio464 : LAN52
+	 *
+	 * sda-gpios, scl-gpios, los-gpio and other settings are just guesses based on dsg-1210-16
+	 * from https://github.com/openwrt/openwrt/commit/b05cc25704f554d73b8b6772e844c3afddc4821c
+	 */
+
+	/* Lan 49 */
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp0: sfp-p49 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		/* tx-disable-gpio handled by RTL8214FC based on media setting */
+	};
+
+	/* Lan 50 */
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp-p50 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		/* tx-disable-gpio handled by RTL8214FC based on media setting */
+	};
+
+	/* Lan 51 */
+	i2c2: i2c-gpio-2 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 23 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp2: sfp-p51 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		los-gpio = <&gpio1 25 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 24 GPIO_ACTIVE_LOW>;
+		// tx-disable-gpio handled by RTL8214FC based on media setting
+	};
+
+	/* Lan 52 */
+	i2c3: i2c-gpio-3 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 11 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 12 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp3: sfp-p52 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		los-gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 13 GPIO_ACTIVE_LOW>;
+		/* tx-disable-gpio handled by RTL8214FC based on media setting */
+	};
+};

--- a/target/linux/realtek/dts-5.10/rtl83xx_d-link_dgs-1210_common.dtsi
+++ b/target/linux/realtek/dts-5.10/rtl83xx_d-link_dgs-1210_common.dtsi
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "rtl838x.dtsi"
-
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 

--- a/target/linux/realtek/image/rtl839x.mk
+++ b/target/linux/realtek/image/rtl839x.mk
@@ -1,5 +1,27 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
+define Device/d-link_dgs-1210
+  SOC := rtl8393
+  IMAGE_SIZE := 13824k
+  DEVICE_VENDOR := D-Link
+  DLINK_KERNEL_PART_SIZE := 1572864
+  KERNEL := kernel-bin | append-dtb | gzip | uImage gzip | dlink-cameo
+  CAMEO_KERNEL_PART := 2
+  CAMEO_ROOTFS_PART := 3
+  CAMEO_CUSTOMER_SIGNATURE := 2
+  CAMEO_BOARD_VERSION := 32
+  IMAGES += factory_image1.bin
+  IMAGE/factory_image1.bin := append-kernel | pad-to 64k | \
+        append-rootfs | pad-rootfs | pad-to 16 | check-size | \
+        dlink-version | dlink-headers
+endef
+
+define Device/d-link_dgs-1210-52
+  $(Device/d-link_dgs-1210)
+  DEVICE_MODEL := DGS-1210-52
+endef
+TARGET_DEVICES += d-link_dgs-1210-52
+
 define Device/panasonic_m48eg-pn28480k
   SOC := rtl8393
   IMAGE_SIZE := 16384k


### PR DESCRIPTION
Since a few weks PR #10227 is open to provide support for the DGS-1210-52 device. In between the D-Link device tree was rebuilt and the PR has not yet been adapted to that. Compiling the clock/timer drivers all the day long with not yet published fixes I relaunch the support request with a new PR.

Thanks to @luizluca who provided the initial PR and the work to identify the GPIOs. In case the contribution should be reflected in the commits do not hesitate to request changes.