### PR TITLE
treewide: a few shebang fixes

### DIFF
--- a/package/libs/libcap/patches/900-use-more-compatible-shebang.patch
+++ b/package/libs/libcap/patches/900-use-more-compatible-shebang.patch
@@ -1,0 +1,8 @@
+--- a/progs/mkcapshdoc.sh
++++ b/progs/mkcapshdoc.sh
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/usr/bin/env bash
+ # This script generates some C code for inclusion in the capsh binary.
+ # The Makefile generally only generates the .c code and compares it
+ # with the checked in code in the progs directory.

--- a/tools/bc/patches/002-fix-libmath.patch
+++ b/tools/bc/patches/002-fix-libmath.patch
@@ -10,7 +10,7 @@
 -w
 -q
 -EOS-EOS
-+#! /bin/bash
++#!/usr/bin/env bash
 +sed -e '1   s/^/{"/' \
 +    -e     's/$/",/' \
 +    -e '2,$ s/^/"/'  \


### PR DESCRIPTION
This helps with building OpenWRT on systems that don't have a /bin/bash, e.g. NixOS.