### PR TITLE
build: move not copy files to BIN_DIR

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -474,7 +474,7 @@ define Device/Build/initramfs
   $(KDIR)/$$(KERNEL_INITRAMFS_NAME):: image_prepare
   $(1)-images: $$(if $$(KERNEL_INITRAMFS),$(BIN_DIR)/$$(KERNEL_INITRAMFS_IMAGE))
   $(BIN_DIR)/$$(KERNEL_INITRAMFS_IMAGE): $(KDIR)/tmp/$$(KERNEL_INITRAMFS_IMAGE)
-	cp $$^ $$@
+	mv $$^ $$@
 
   $(KDIR)/tmp/$$(KERNEL_INITRAMFS_IMAGE): $(KDIR)/$$(KERNEL_INITRAMFS_NAME) $(CURDIR)/Makefile $$(KERNEL_DEPENDS) image_prepare
 	@rm -f $$@
@@ -487,7 +487,7 @@ define Device/Build/initramfs
 	DEVICE_ID="$(1)" \
 	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
 	FILE_NAME="$$(notdir $$^)" \
-	FILE_DIR="$(KDIR)/tmp" \
+	BIN_DIR="$(BIN_DIR)" \
 	FILE_TYPE="kernel" \
 	FILE_FILESYSTEM="initramfs" \
 	DEVICE_IMG_PREFIX="$$(DEVICE_IMG_PREFIX)" \
@@ -547,7 +547,7 @@ define Device/Build/kernel
   $$(_TARGET): $$(if $$(KERNEL_INSTALL),$(BIN_DIR)/$$(KERNEL_IMAGE))
   $(call Device/Export,$$(KDIR_KERNEL_IMAGE),$(1))
   $(BIN_DIR)/$$(KERNEL_IMAGE): $$(KDIR_KERNEL_IMAGE)
-	cp $$^ $$@
+	mv $$^ $$@
   ifndef IB
     ifdef CONFIG_IB
       install: $$(KDIR_KERNEL_IMAGE)
@@ -585,16 +585,17 @@ define Device/Build/image
 
   $(BIN_DIR)/$(call DEVICE_IMG_NAME,$(1),$(2)).gz: $(KDIR)/tmp/$(call DEVICE_IMG_NAME,$(1),$(2))
 	gzip -c -9n $$^ > $$@
+	rm $$^
 
   $(BIN_DIR)/$(call DEVICE_IMG_NAME,$(1),$(2)): $(KDIR)/tmp/$(call DEVICE_IMG_NAME,$(1),$(2))
-	cp $$^ $$@
+	mv $$^ $$@
 
   $(BUILD_DIR)/json_info_files/$(call DEVICE_IMG_NAME,$(1),$(2)).json: $(BIN_DIR)/$(call DEVICE_IMG_NAME,$(1),$(2))$$(GZ_SUFFIX)
 	@mkdir -p $$(shell dirname $$@)
 	DEVICE_ID="$(DEVICE_NAME)" \
 	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
 	FILE_NAME="$(DEVICE_IMG_NAME)" \
-	FILE_DIR="$(KDIR)/tmp" \
+	BIN_DIR="$(BIN_DIR)" \
 	FILE_TYPE=$(word 1,$(subst ., ,$(2))) \
 	FILE_FILESYSTEM="$(1)" \
 	DEVICE_IMG_PREFIX="$(DEVICE_IMG_PREFIX)" \
@@ -633,14 +634,14 @@ define Device/Build/artifact
   .IGNORE: $(BIN_DIR)/$(DEVICE_IMG_PREFIX)-$(1)
 
   $(BIN_DIR)/$(DEVICE_IMG_PREFIX)-$(1): $(KDIR)/tmp/$(DEVICE_IMG_PREFIX)-$(1)
-	cp $$^ $$@
+	mv $$^ $$@
 
   $(BUILD_DIR)/json_info_files/$(DEVICE_IMG_PREFIX)-$(1).json: $(BIN_DIR)/$(DEVICE_IMG_PREFIX)-$(1)
 	@mkdir -p $$(shell dirname $$@)
 	DEVICE_ID="$(DEVICE_NAME)" \
 	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
 	FILE_NAME="$(DEVICE_IMG_PREFIX)-$(1)" \
-	FILE_DIR="$(KDIR)/tmp" \
+	BIN_DIR="$(BIN_DIR)" \
 	FILE_TYPE="$(1)" \
 	DEVICE_IMG_PREFIX="$(DEVICE_IMG_PREFIX)" \
 	DEVICE_VENDOR="$(DEVICE_VENDOR)" \

--- a/scripts/json_add_image_info.py
+++ b/scripts/json_add_image_info.py
@@ -11,7 +11,7 @@ if len(argv) != 2:
     exit(1)
 
 json_path = Path(argv[1])
-file_path = Path(getenv("FILE_DIR")) / getenv("FILE_NAME")
+file_path = Path(getenv("BIN_DIR")) / getenv("FILE_NAME")
 
 
 if not file_path.is_file():


### PR DESCRIPTION
Building images usally stores them in KDIR_TMP and then copies them over to BIN_DIR. This is fine as rebuilding of images overwrites existing images. When using the EXTRA_IMAGE_NAME variable frequently this fills up the ImageBuilder KDIR_TMP folder since every built image is stored forever.

This commit moves every image instead of copying it. I couldn't find any reason which this shouldn't be done. While at it rename FILE_DIR to BIN_DIR to lower the entropy inside the codebase.

Below an example how sysupgrade.openwrt.org filled up after the release of 22.03.0 where every created image contains a hash of the package selction in the filename:

     aparcar@asu-01:~/asu/worker1/cache/22.03.0$ du -d 1 -h
     400M    ./kirkwood
     260M    ./gemini
     2.0G    ./ipq806x
     1.7G    ./ipq40xx
     8.1G    ./ramips
     4.0K    ./octeon
     495M    ./sunxi
     728M    ./lantiq
     1.8G    ./rockchip
     3.7G    ./mediatek
     4.0K    ./realtek
     5.4G    ./mvebu
     8.9G    ./ath79
     3.0G    ./bcm47xx
     14G     ./bcm27xx
     11G     ./x86
     4.0K    ./bcm63xx
     312M    ./mpc85xx
     600M    ./apm821xx
     5.4G    ./bcm53xx
     66G     .

Signed-off-by: Paul Spooren <mail@aparcar.org>