### PR TITLE
iproute2: add missing libbpf dependency

### DIFF
--- a/package/network/utils/iproute2/Makefile
+++ b/package/network/utils/iproute2/Makefile
@@ -82,7 +82,7 @@ define Package/tc-mod-iptables
 $(call Package/iproute2/Default)
   TITLE:=Traffic control module - iptables action
   VARIANT:=tcfull
-  DEPENDS:=+libxtables
+  DEPENDS:=+libxtables +libbpf
 endef
 
 define Package/genl


### PR DESCRIPTION
This patch adds libbpf to the dependencies of tc-mod-iptables.

The package tc-mod-iptables is missing libbpf as a dependency, which leads to the build failure described in bug #9491

    LIBBPF_FORCE=on set, but couldn't find a usable libbpf

Signed-off-by: Kien Truong <duckientruong@gmail.com>
