### PR TITLE
imagebuilder: clean KDIR_TMP before building

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -756,6 +756,7 @@ define BuildImage
 
   else
     image_prepare:
+		rm -rf $(KDIR)/tmp
 		mkdir -p $(BIN_DIR) $(KDIR)/tmp
   endif
 


### PR DESCRIPTION
Building images usally stores them in KDIR_TMP and then copies them over
to BIN_DIR. This is fine as rebuilding of images overwrites existing
images. When using the EXTRA_IMAGE_NAME variable frequently this fills
up the ImageBuilder KDIR_TMP folder since every built image is stored
forever.

This commit clears the KDIR_TMP folder before building a new image.

Below an example how sysupgrade.openwrt.org filled up after the release
of 22.03.0 where every created image contains a hash of the package
selction in the filename:

     aparcar@asu-01:~/asu/worker1/cache/22.03.0$ du -d 1 -h
     400M    ./kirkwood
     260M    ./gemini
     2.0G    ./ipq806x
     1.7G    ./ipq40xx
     8.1G    ./ramips
     4.0K    ./octeon
     495M    ./sunxi
     728M    ./lantiq
     1.8G    ./rockchip
     3.7G    ./mediatek
     4.0K    ./realtek
     5.4G    ./mvebu
     8.9G    ./ath79
     3.0G    ./bcm47xx
     14G     ./bcm27xx
     11G     ./x86
     4.0K    ./bcm63xx
     312M    ./mpc85xx
     600M    ./apm821xx
     5.4G    ./bcm53xx
     66G     .

Signed-off-by: Paul Spooren <mail@aparcar.org>
