### PR TITLE
lantiq: xrx200: backport upstream network fixes

### DIFF
--- a/target/linux/lantiq/patches-5.10/0717-v6.0-net-lantiq_xrx200-confirm-skb-is-allocated-before-us.patch
+++ b/target/linux/lantiq/patches-5.10/0717-v6.0-net-lantiq_xrx200-confirm-skb-is-allocated-before-us.patch
@@ -1,0 +1,33 @@
+From c8b043702dc0894c07721c5b019096cebc8c798f Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Wed, 24 Aug 2022 23:54:06 +0200
+Subject: [PATCH] net: lantiq_xrx200: confirm skb is allocated before using
+
+xrx200_hw_receive() assumes build_skb() always works and goes straight
+to skb_reserve(). However, build_skb() can fail under memory pressure.
+
+Add a check in case build_skb() failed to allocate and return NULL.
+
+Fixes: e015593573b3 ("net: lantiq_xrx200: convert to build_skb")
+Reported-by: Eric Dumazet <edumazet@google.com>
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/lantiq_xrx200.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/drivers/net/ethernet/lantiq_xrx200.c
++++ b/drivers/net/ethernet/lantiq_xrx200.c
+@@ -239,6 +239,12 @@ static int xrx200_hw_receive(struct xrx2
+ 	}
+ 
+ 	skb = build_skb(buf, priv->rx_skb_size);
++	if (!skb) {
++		skb_free_frag(buf);
++		net_dev->stats.rx_dropped++;
++		return -ENOMEM;
++	}
++
+ 	skb_reserve(skb, NET_SKB_PAD);
+ 	skb_put(skb, len);
+ 

--- a/target/linux/lantiq/patches-5.10/0718-v6.0-net-lantiq_xrx200-fix-lock-under-memory-pressure.patch
+++ b/target/linux/lantiq/patches-5.10/0718-v6.0-net-lantiq_xrx200-fix-lock-under-memory-pressure.patch
@@ -1,0 +1,33 @@
+From c4b6e9341f930e4dd089231c0414758f5f1f9dbd Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Wed, 24 Aug 2022 23:54:07 +0200
+Subject: [PATCH] net: lantiq_xrx200: fix lock under memory pressure
+
+When the xrx200_hw_receive() function returns -ENOMEM, the NAPI poll
+function immediately returns an error.
+This is incorrect for two reasons:
+* the function terminates without enabling interrupts or scheduling NAPI,
+* the error code (-ENOMEM) is returned instead of the number of received
+packets.
+
+After the first memory allocation failure occurs, packet reception is
+locked due to disabled interrupts from DMA..
+
+Fixes: fe1a56420cf2 ("net: lantiq: Add Lantiq / Intel VRX200 Ethernet driver")
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/lantiq_xrx200.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/lantiq_xrx200.c
++++ b/drivers/net/ethernet/lantiq_xrx200.c
+@@ -294,7 +294,7 @@ static int xrx200_poll_rx(struct napi_st
+ 			if (ret == XRX200_DMA_PACKET_IN_PROGRESS)
+ 				continue;
+ 			if (ret != XRX200_DMA_PACKET_COMPLETE)
+-				return ret;
++				break;
+ 			rx++;
+ 		} else {
+ 			break;

--- a/target/linux/lantiq/patches-5.10/0719-v6.0-net-lantiq_xrx200-restore-buffer-if-memory-allocatio.patch
+++ b/target/linux/lantiq/patches-5.10/0719-v6.0-net-lantiq_xrx200-restore-buffer-if-memory-allocatio.patch
@@ -1,0 +1,27 @@
+From c9c3b1775f80fa21f5bff874027d2ccb10f5d90c Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Wed, 24 Aug 2022 23:54:08 +0200
+Subject: [PATCH] net: lantiq_xrx200: restore buffer if memory allocation
+ failed
+
+In a situation where memory allocation fails, an invalid buffer address
+is stored. When this descriptor is used again, the system panics in the
+build_skb() function when accessing memory.
+
+Fixes: 7ea6cd16f159 ("lantiq: net: fix duplicated skb in rx descriptor ring")
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/lantiq_xrx200.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/net/ethernet/lantiq_xrx200.c
++++ b/drivers/net/ethernet/lantiq_xrx200.c
+@@ -193,6 +193,7 @@ static int xrx200_alloc_buf(struct xrx20
+ 
+ 	ch->rx_buff[ch->dma.desc] = alloc(priv->rx_skb_size);
+ 	if (!ch->rx_buff[ch->dma.desc]) {
++		ch->rx_buff[ch->dma.desc] = buf;
+ 		ret = -ENOMEM;
+ 		goto skip;
+ 	}


### PR DESCRIPTION
This series contains bug fixes that may occur under memory pressure.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>