### PR TITLE
dnsmasq: fix can't start when procd-ujail is not installed

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1168,16 +1168,18 @@ dnsmasq_start()
 	[ -n "$instance_ifc" ] && network_get_device instance_netdev "$instance_ifc" &&
 		[ -n "$instance_netdev" ] && procd_set_param netdev $instance_netdev
 
-	procd_add_jail dnsmasq ubus log
-	procd_add_jail_mount $CONFIGFILE $DHCPBOGUSHOSTNAMEFILE $DHCPSCRIPT $DHCPSCRIPT_DEPENDS
-	procd_add_jail_mount $EXTRA_MOUNT $RFC6761FILE $TRUSTANCHORSFILE
-	procd_add_jail_mount $dnsmasqconffile $dnsmasqconfdir $resolvdir $user_dhcpscript
-	procd_add_jail_mount /etc/passwd /etc/group /etc/TZ /etc/hosts /etc/ethers
-	procd_add_jail_mount_rw /var/run/dnsmasq/ $leasefile
-	case "$logfacility" in */*)
-		[ ! -e "$logfacility" ] && touch "$logfacility"
-		procd_add_jail_mount_rw "$logfacility"
-	esac
+	[ -x /sbin/ujail ] && {
+		procd_add_jail dnsmasq ubus log
+		procd_add_jail_mount $CONFIGFILE $DHCPBOGUSHOSTNAMEFILE $DHCPSCRIPT $DHCPSCRIPT_DEPENDS
+		procd_add_jail_mount $EXTRA_MOUNT $RFC6761FILE $TRUSTANCHORSFILE
+		procd_add_jail_mount $dnsmasqconffile $dnsmasqconfdir $resolvdir $user_dhcpscript
+		procd_add_jail_mount /etc/passwd /etc/group /etc/TZ /etc/hosts /etc/ethers
+		procd_add_jail_mount_rw /var/run/dnsmasq/ $leasefile
+		case "$logfacility" in */*)
+			[ ! -e "$logfacility" ] && touch "$logfacility"
+			procd_add_jail_mount_rw "$logfacility"
+		esac
+	}
 
 	procd_close_instance
 }


### PR DESCRIPTION
There is no permission to do mount /dev/log to /tmp/ujailxxx/dev/log with remount and bind flags if OpenWrt is running in systemd-nspawn container.

A workaround is uninstalled procd-ujail, so dnsmasq should support to run without ujail.

Signed-off-by: hev <r@hev.cc>