### PR TITLE
kernel: add dual-boot mtd partition rename via cmdline

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
@@ -194,8 +194,6 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 		   const struct mtd_partition **pparts,
 	           struct mtd_part_parser_data *data)
 {
-	struct device_node *np = mtd_get_of_node(mtd);
-	const char *cmdline_match = NULL;
 	struct fdt_header hdr;
 	size_t hdr_len, retlen;
 	size_t offset;
@@ -206,10 +204,6 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 	int ret, ndepth, noffset, images_noffset;
 	const void *img_data;
 	void *fit;
-
-	of_property_read_string(np, "openwrt,cmdline-match", &cmdline_match);
-	if (cmdline_match && !strstr(saved_command_line, cmdline_match))
-		return -ENODEV;
 
 	hdr_len = sizeof(struct fdt_header);
 

--- a/target/linux/generic/hack-5.10/940-mtd-add-dual-boot-device-rename.patch
+++ b/target/linux/generic/hack-5.10/940-mtd-add-dual-boot-device-rename.patch
@@ -1,0 +1,62 @@
+From 414dfe2c48cbe537584d0d186d7c4c5e3472d839 Mon Sep 17 00:00:00 2001
+From: David Yang <mmyangfl@gmail.com>
+Date: Sun, 11 Sep 2022 15:45:15 +0800
+Subject: [PATCH] mtd: add dual-boot device rename
+
+---
+ drivers/mtd/parsers/ofpart_core.c | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/drivers/mtd/parsers/ofpart_core.c b/drivers/mtd/parsers/ofpart_core.c
+index 193dd5a..677f0a4 100644
+--- a/drivers/mtd/parsers/ofpart_core.c
++++ b/drivers/mtd/parsers/ofpart_core.c
+@@ -15,6 +15,7 @@
+ #include <linux/mtd/mtd.h>
+ #include <linux/slab.h>
+ #include <linux/mtd/partitions.h>
++#include <linux/ctype.h>
+ 
+ #include "ofpart_bcm4908.h"
+ #include "ofpart_linksys_ns.h"
+@@ -103,6 +104,10 @@
+ 		const __be32 *reg;
+ 		int len;
+ 		int a_cells, s_cells;
++		const char *cmdline_match = NULL;
++		const char *match_partname;
++		char match_partname_auto[64];
++		int i;
+ 
+ 		if (!dedicated && node_has_compatible(pp))
+ 			continue;
+@@ -136,6 +141,26 @@
+ 		partname = of_get_property(pp, "label", &len);
+ 		if (!partname)
+ 			partname = of_get_property(pp, "name", &len);
++
++		/* Support dual-boot */
++		of_property_read_string(pp, "openwrt,cmdline-match", &cmdline_match);
++		if (cmdline_match && strstr(saved_command_line, cmdline_match)) {
++			match_partname = of_get_property(pp, "openwrt,cmdline-match-label", &len);
++
++			if (match_partname)
++				partname = match_partname;
++			else {
++				/* If no openwrt,cmdline-match-label provided, remove any digital suffix */
++				strlcpy(match_partname_auto, partname, sizeof(match_partname_auto));
++				for (i = strlen(match_partname_auto) - 1; i >= 0; i--) {
++					if (!isdigit(match_partname_auto[i]))
++						break;
++					match_partname_auto[i] = '\0';
++				}
++				partname = match_partname_auto;
++			}
++		}
++
+ 		parts[i].name = partname;
+ 
+ 		if (of_get_property(pp, "read-only", &len))
+-- 
+2.35.1
+

--- a/target/linux/generic/hack-5.15/940-mtd-add-dual-boot-device-rename.patch
+++ b/target/linux/generic/hack-5.15/940-mtd-add-dual-boot-device-rename.patch
@@ -1,0 +1,62 @@
+From 414dfe2c48cbe537584d0d186d7c4c5e3472d839 Mon Sep 17 00:00:00 2001
+From: David Yang <mmyangfl@gmail.com>
+Date: Sun, 11 Sep 2022 15:45:15 +0800
+Subject: [PATCH] mtd: add dual-boot device rename
+
+---
+ drivers/mtd/parsers/ofpart_core.c | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/drivers/mtd/parsers/ofpart_core.c b/drivers/mtd/parsers/ofpart_core.c
+index 193dd5a..677f0a4 100644
+--- a/drivers/mtd/parsers/ofpart_core.c
++++ b/drivers/mtd/parsers/ofpart_core.c
+@@ -15,6 +15,7 @@
+ #include <linux/mtd/mtd.h>
+ #include <linux/slab.h>
+ #include <linux/mtd/partitions.h>
++#include <linux/ctype.h>
+ 
+ #include "ofpart_bcm4908.h"
+ #include "ofpart_linksys_ns.h"
+@@ -103,6 +104,10 @@
+ 		const __be32 *reg;
+ 		int len;
+ 		int a_cells, s_cells;
++		const char *cmdline_match = NULL;
++		const char *match_partname;
++		char match_partname_auto[64];
++		int i;
+ 
+ 		if (!dedicated && node_has_compatible(pp))
+ 			continue;
+@@ -136,6 +141,26 @@
+ 		partname = of_get_property(pp, "label", &len);
+ 		if (!partname)
+ 			partname = of_get_property(pp, "name", &len);
++
++		/* Support dual-boot */
++		of_property_read_string(pp, "openwrt,cmdline-match", &cmdline_match);
++		if (cmdline_match && strstr(saved_command_line, cmdline_match)) {
++			match_partname = of_get_property(pp, "openwrt,cmdline-match-label", &len);
++
++			if (match_partname)
++				partname = match_partname;
++			else {
++				/* If no openwrt,cmdline-match-label provided, remove any digital suffix */
++				strlcpy(match_partname_auto, partname, sizeof(match_partname_auto));
++				for (i = strlen(match_partname_auto) - 1; i >= 0; i--) {
++					if (!isdigit(match_partname_auto[i]))
++						break;
++					match_partname_auto[i] = '\0';
++				}
++				partname = match_partname_auto;
++			}
++		}
++
+ 		parts[i].name = partname;
+ 
+ 		if (of_get_property(pp, "read-only", &len))
+-- 
+2.35.1
+

--- a/target/linux/kirkwood/patches-5.10/202-linksys-find-active-root.patch
+++ b/target/linux/kirkwood/patches-5.10/202-linksys-find-active-root.patch
@@ -5,7 +5,7 @@ Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
 ---
 --- a/drivers/mtd/parsers/ofpart_core.c
 +++ b/drivers/mtd/parsers/ofpart_core.c
-@@ -38,6 +38,8 @@ static bool node_has_compatible(struct d
+@@ -39,6 +39,8 @@ static bool node_has_compatible(struct d
  	return of_get_property(pp, "compatible", NULL);
  }
  
@@ -14,7 +14,7 @@ Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
  static int parse_fixed_partitions(struct mtd_info *master,
  				  const struct mtd_partition **pparts,
  				  struct mtd_part_parser_data *data)
-@@ -47,6 +49,7 @@ static int parse_fixed_partitions(struct
+@@ -48,6 +50,7 @@ static int parse_fixed_partitions(struct
  	struct mtd_partition *parts;
  	struct device_node *mtd_node;
  	struct device_node *ofpart_node;
@@ -22,7 +22,7 @@ Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
  	const char *partname;
  	struct device_node *pp;
  	int nr_parts, i, ret = 0;
-@@ -133,9 +136,15 @@ static int parse_fixed_partitions(struct
+@@ -138,9 +141,14 @@ static int parse_fixed_partitions(struct
  		parts[i].size = of_read_number(reg + a_cells, s_cells);
  		parts[i].of_node = pp;
  
@@ -37,11 +37,10 @@ Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
 +			if (!partname)
 +				partname = of_get_property(pp, "name", &len);
 +		}
-+
- 		parts[i].name = partname;
  
- 		if (of_get_property(pp, "read-only", &len))
-@@ -252,6 +261,18 @@ static int __init ofpart_parser_init(voi
+ 		/* Support dual-boot */
+ 		of_property_read_string(pp, "openwrt,cmdline-match", &cmdline_match);
+@@ -277,6 +285,18 @@ static int __init ofpart_parser_init(voi
  	return 0;
  }
  


### PR DESCRIPTION
This is useful for dual-boot setups where the loader sets variables depending on the flash boot partition. For example the Linksys E8450 sets `mtdparts=master` for the first partition and `mtdparts=slave` for the second one.

If you write

  partition@xxx {
    label = "firmware2";
    openwrt,cmdline-match = "mtdparts=slave";
  };

  partition@xxx {
    label = "alt_firmware";
    openwrt,cmdline-match = "mtdparts=slave";
    openwrt,cmdline-match-label = "firmware";
  };

in dts, then when `mtdparts=slave` is found in bootargs, they will all be renamed into 'firmware', thus firmware detection of MTD_SPLIT_FIRMWARE will work with those bootloaders.

This patch improves 7a6d074.

Signed-off-by: David Yang <mmyangfl@gmail.com>