### PR TITLE
octeon: fix imagebuilder generation by introducing generic target

### DIFF
--- a/target/linux/octeon/generic/target.mk
+++ b/target/linux/octeon/generic/target.mk
@@ -1,0 +1,1 @@
+BOARDNAME:=Generic

--- a/target/linux/octeon/profiles/000-Generic.mk
+++ b/target/linux/octeon/profiles/000-Generic.mk
@@ -2,13 +2,12 @@
 #
 # Copyright (C) 2013 OpenWrt.org
 
-define Profile/Default
-  NAME:=Default Profile
-  PRIORITY:=1
+define Profile/Generic
+  NAME:=Octeon SoC
 endef
 
-define Profile/Default/Description
+define Profile/Generic/Description
    Base packages for Octeon boards.
 endef
 
-$(eval $(call Profile,Default))
+$(eval $(call Profile,Generic))


### PR DESCRIPTION
The generic imagebuilder does not have a generic in the name, although this is the default naming scheme. Use bcm53xx as template for this fix.

Before the fix:
  openwrt-imagebuilder-octeon.Linux-x86_64.tar.xz

After:
  openwrt-imagebuilder-octeon-generic.Linux-x86_64.tar.xz
