### PR TITLE
ath79: add support for Linksys EA4500 v3

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -83,7 +83,8 @@ buffalo,wzr-hp-ag300h)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x10000"
 	;;
 buffalo,wzr-hp-g300nh-rb|\
-buffalo,wzr-hp-g300nh-s)
+buffalo,wzr-hp-g300nh-s|\
+linksys,ea4500-v3)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;
 domywifi,dw33d)

--- a/target/linux/ath79/dts/qca9558_linksys_ea4500-v3.dts
+++ b/target/linux/ath79/dts/qca9558_linksys_ea4500-v3.dts
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "linksys,ea4500-v3", "qca,qca9558";
+	model = "Linksys EA4500 v3";
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &eth1;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "green:system";
+			gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,0033";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&cal_ath9k_pci>;
+		nvmem-cell-names = "calibration";
+	};
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "uboot";
+			reg = <0x0 0x100000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "u_env";
+			reg = <0x100000 0x40000>;
+		};
+
+		partition@140000 {
+			label = "caldata";
+			reg = <0x140000 0x40000>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cal_macaddr: macaddr@0 {
+				reg = <0x6 0x6>;
+			};
+
+			cal_ath9k_soc: cal_ath9k@1000 {
+				reg = <0x1000 0x440>;
+			};
+
+			cal_ath9k_pci: cal_ath9k@5000 {
+				reg = <0x5000 0x440>;
+			};
+		};
+
+		partition@180000 {
+			label = "s_env";
+			reg = <0x180000 0x40000>;
+			read-only;
+		};
+
+		partition@1c0000 {
+			label = "devinfo";
+			reg = <0x1c0000 0x100000>;
+			read-only;
+		};
+
+		partition@2c0000 {
+			label = "firmware";
+			reg = <0x2c0000 0x5000000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x4c00000>;
+			};
+
+			/* Original layout for secondary partitions */
+			/* partition@2800000 {
+				label = "kernel2";
+				reg = <0x2800000 0x400000>;
+			};
+
+			partition@2c00000 {
+				label = "ubi2";
+				reg = <0x2c00000 0x2400000>;
+			}; */
+		};
+
+		partition@52c0000 {
+			label = "syscfg";
+			reg = <0x52c0000 0x2d40000>;
+			read-only;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL: RGMII, to eth0 */
+			0x0c 0x00000080 /* PORT6 PAD MODE CTRL: SGMII, to eth1 */
+			0x50 0xc833c833 /* LED_CTRL0: orange, blinking with act */
+			0x54 0xcf85cf85 /* LED_CTRL1: green, on with link */
+			0x58 0x00000000	/* LED_CTRL2: unpopulated */
+			0x5c 0x00f3cf00 /* LED_CTRL3: enable led 0 and 1 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x0000007e /* PORT6 STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&cal_macaddr>;
+	nvmem-cell-names = "mac-address";
+	phy-handle = <&phy0>;
+	pll-data = <0x96000000 0x00000101 0x00001616>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&cal_macaddr>;
+	nvmem-cell-names = "mac-address";
+	pll-data = <0x03000101 0x00000101 0x00001616>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&cal_ath9k_soc>;
+	nvmem-cell-names = "calibration";
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -211,6 +211,25 @@ define Device/glinet_gl-xe300
 endef
 TARGET_DEVICES += glinet_gl-xe300
 
+define Device/linksys_ea4500-v3
+  SOC := qca9558
+  DEVICE_VENDOR := Linksys
+  DEVICE_MODEL := EA4500
+  DEVICE_VARIANT := v3
+  DEVICE_PACKAGES := kmod-usb2
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 81920k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  LINKSYS_HWNAME := EA4500V3
+  IMAGES += factory.img
+  IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
+	append-ubi | check-size | linksys-image type=$$$$(LINKSYS_HWNAME)
+  UBINIZE_OPTS := -E 5
+endef
+TARGET_DEVICES += linksys_ea4500-v3
+
 # fake rootfs is mandatory, pad-offset 129 equals (2 * uimage_header + 0xff)
 define Device/netgear_ath79_nand
   DEVICE_VENDOR := NETGEAR

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -30,6 +30,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "4:lan"
 		;;
+	linksys,ea4500-v3)
+		ucidef_add_switch "switch0" \
+			"6@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0@eth0"
+		;;
 	netgear,pgzng1)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;

--- a/target/linux/ath79/nand/base-files/etc/init.d/bootcount
+++ b/target/linux/ath79/nand/base-files/etc/init.d/bootcount
@@ -8,5 +8,9 @@ boot() {
 	glinet,gl-ar300m-nand)
 		fw_setenv bootcount 0
 		;;
+	linksys,ea4500-v3)
+		[ $(fw_printenv -n auto_recovery) = yes ] && \
+			fw_setenv auto_recovery no
+		;;
 	esac
 }


### PR DESCRIPTION
# ath79: add support for Linksys EA4500 v3

Add support for the Linksys EA4500 v3 wireless router

Hardware
--------
SoC:    Qualcomm Atheros QCA9558
RAM:    128M DDR2 (Winbond W971GG6KB-25)
FLASH:  128M SPI-NAND (Spansion S34ML01G100TFI00)
WLAN:   QCA9558 3T3R 802.11 bgn
        QCA9580 3T3R 802.11 an
ETH:    Qualcomm Atheros QCA8337
UART:   115200 8n1, same as ea4500 v2
USB:	1 single USB 2.0 host port
BUTTON: Reset - WPS
LED:    1x system-LED
        LEDs besides the ethernet ports are controlled
        by the ethernet switch

Installation
------------

1. Connect to the serial console. Power up the device and interrupt
   autoboot when prompted

2. Connect a TFTP server reachable at 192.168.1.0/24
   (e.g. 192.168.1.66) to the ethernet port. Serve the OpenWrt
   initramfs image as "openwrt.bin"

3. To test OpenWrt only, go to step 4 and never execute step 5;
   To install, auto_recovery should be disabled first:

```
   ath> setenv auto_recovery no
   ath> saveenv
```

4. Boot the initramfs image using U-Boot

```
   ath> setenv serverip 192.168.1.66
   ath> tftpboot 0x84000000 openwrt.bin
   ath> bootm
```
5. Copy the OpenWrt sysupgrade image to the device using scp and
   install it like a normal upgrade (with no need to keeping config
   since no config from "previous OpenWRT installation" could be kept
   at all)

```
   # sysupgrade -n /path/to/openwrt/sysupgrade.bin
```
Signed-off-by: Edward Chow <equu@openmail.cc>
