### PR TITLE
add download tool aria2 support

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -70,27 +70,52 @@ sub hash_cmd() {
 	return undef;
 }
 
-sub download_cmd($) {
+sub download_cmd {
 	my $url = shift;
 	my $have_curl = 0;
+	my $have_aria2c = 0;
+	my $filename = shift;
+	my @additional_mirrors = @_;
+	my $mirrors_url = "'$url'";
 
-	if (open CURL, "curl --version 2>/dev/null |") {
+	my @chArray = ('a'..'z', 'A'..'Z', 0..9);
+	my $rfn = join '', map{ $chArray[int rand @chArray] } 0..9;
+	if (open CURL, '-|', 'curl', '--version') {
 		if (defined(my $line = readline CURL)) {
 			$have_curl = 1 if $line =~ /^curl /;
 		}
 		close CURL;
 	}
+	if (open ARIA2C, '-|', 'aria2c', '--version') {
+		if (defined(my $line = readline ARIA2C)) {
+			$have_aria2c = 1 if $line =~ /^aria2 /;
+		}
+		close ARIA2C;
+	}
 
-	return $have_curl
-		? (qw(curl -f --connect-timeout 20 --retry 5 --location),
+	for my $mirror (@additional_mirrors ) {
+		$mirrors_url = $mirrors_url ." '$mirror /$filename'";
+	}
+
+	if ($have_aria2c) {
+		return join(" ", "touch /dev/shm/${rfn}_spp;",
+			qw(aria2c --stderr -c -x2 -s10 -j10 -k1M), $mirrors_url ,
+			$check_certificate ? () : '--check-certificate=false',
+			"--server-stat-of=/dev/shm/${rfn}_spp",
+			"--server-stat-if=/dev/shm/${rfn}_spp",
+			"-d /dev/shm -o $rfn;",
+			"cat /dev/shm/$rfn;", "rm /dev/shm/$rfn /dev/shm/${rfn}_spp");
+	} elsif ($have_curl) {
+		return (qw(curl -f --connect-timeout 20 --retry 5 --location),
 			$check_certificate ? () : '--insecure',
 			shellwords($ENV{CURL_OPTIONS} || ''),
-			$url)
-		: (qw(wget --tries=5 --timeout=20 --output-document=-),
+			$url);
+	} else {
+		return (qw(wget --tries=5 --timeout=20 --output-document=-),
 			$check_certificate ? () : '--no-check-certificate',
 			shellwords($ENV{WGET_OPTIONS} || ''),
-			$url)
-	;
+			$url);
+	}
 }
 
 my $hash_cmd = hash_cmd();
@@ -100,6 +125,7 @@ sub download
 {
 	my $mirror = shift;
 	my $download_filename = shift;
+	my @additional_mirrors = @_;
 
 	$mirror =~ s!/$!!;
 
@@ -146,9 +172,9 @@ sub download
 			}
 		};
 	} else {
-		my @cmd = download_cmd("$mirror/$download_filename");
+		my @cmd = download_cmd("$mirror/$download_filename", $download_filename, @additional_mirrors);
 		print STDERR "+ ".join(" ",@cmd)."\n";
-		open(FETCH_FD, '-|', @cmd) or die "Cannot launch curl or wget.\n";
+		open(FETCH_FD, '-|', @cmd) or die "Cannot launch aria2c, curl or wget.\n";
 		$hash_cmd and do {
 			open MD5SUM, "| $hash_cmd > '$target/$filename.hash'" or die "Cannot launch $hash_cmd.\n";
 		};
@@ -296,10 +322,11 @@ while (!-f "$target/$filename") {
 	my $mirror = shift @mirrors;
 	$mirror or die "No more mirrors to try - giving up.\n";
 
-	download($mirror, $url_filename);
+	download($mirror, $url_filename, @mirrors);
 	if (!-f "$target/$filename" && $url_filename ne $filename) {
-		download($mirror, $filename);
+		download($mirror, $filename, @mirrors);
 	}
+	@mirrors=();
 }
 
 $SIG{INT} = \&cleanup;


### PR DESCRIPTION
Because of some countries' network problem such as China, compilers can't download smoothly. If use aria2, it can train your own server download speed memory, and automatically select a mirror that is more suitable for you in the next crawl