### PR TITLE
airoha: fix imagebuilder generation by introducing generic target

### DIFF
--- a/target/linux/airoha/generic/target.mk
+++ b/target/linux/airoha/generic/target.mk
@@ -1,0 +1,1 @@
+BOARDNAME:=Generic


### PR DESCRIPTION
The generic imagebuilder does not have a generic in the name, although this is the default naming scheme. Apply the same fix as for the octeon target. Thanks to @dangowrt for reporting that the same issues applies also for the airoha target.

Before the fix:
openwrt-imagebuilder-airoha.Linux-x86_64.tar.xz

After:
openwrt-imagebuilder-airoha-generic.Linux-x86_64.tar.xz
