### PR TITLE
ramips: ASUS RT-AX53U use space in NAND

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -53,6 +53,8 @@
 &nand {
 	status = "okay";
 
+	mediatek,nmbm;
+
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -97,12 +99,7 @@
 
 		partition@7e0000 {
 			label = "ubi";
-			reg = <0x7e0000 0x2e00000>;
-		};
-
-		partition@35e0000 {
-			label = "firmware2";
-			reg = <0x35e0000 0x3200000>;
+			reg = <0x7e0000 0x7020000>;
 		};
 
 		/* Last 8M possibly store the bad block table */

--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -54,6 +54,9 @@
 	status = "okay";
 
 	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+	mediatek,bmt-remap-range = <0x000000 0x7e0000>;
 
 	partitions {
 		compatible = "fixed-partitions";

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -290,6 +290,8 @@ define Device/asus_rt-ax53u
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
   DEVICE_PACKAGES := kmod-mt7915e kmod-usb3 uboot-envtools
+  DEVICE_COMPAT_VERSION := 1.2
+  DEVICE_COMPAT_MESSAGE := ubi partition has been resized
 endef
 TARGET_DEVICES += asus_rt-ax53u
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
@@ -8,6 +8,9 @@
 board_config_update
 
 case "$(board_name)" in
+	asus,rt-ax53u)
+		ucidef_set_compat_version "1.2"
+		;;
 	*)
 		ucidef_set_compat_version "1.1"
 		;;


### PR DESCRIPTION
This is mostly the same patch for this router as this one https://github.com/openwrt/openwrt/pull/10502

I left the last 8MB unallocated and added Alisa900's suggestion about NMBM https://github.com/openwrt/openwrt/pull/10502#issuecomment-1236708434

The changes have been tested and do not brick the device, but to see the extra partition space, the settings must be reset during sysupdate.

kernel log: https://gist.github.com/gabest11/d545327c99041ae76fd5ab00dc9bd237