### PR TITLE
ramips: add support for SIM AX18T and Haier HAR-20S2U1

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -56,6 +56,11 @@ linksys,e7350|\
 netgear,wax202)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;
+haier,har-20s2u1|\
+sim,simax1800t)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	ubootenv_add_uci_sys_config "/dev/mtd1" "0x40000" "0x40000" "0x20000"
+	;;
 hootoo,ht-tm05|\
 ravpower,rp-wd03)
 	idx="$(find_mtd_index u-boot-env)"

--- a/target/linux/ramips/dts/mt7621_haier-sim_wr1800k.dtsi
+++ b/target/linux/ramips/dts/mt7621_haier-sim_wr1800k.dtsi
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		label-mac-device = &gmac1;
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+	};
+
+	chosen {
+		bootargs-override = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: led-0 {
+			label = "blue:status";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-1 {
+			label = "green:status";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: led-2 {
+			label = "red:status";
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_8004>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_8004>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <(-3)>;
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0000000 0x0080000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x0080000 0x0080000>;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x0100000 0x0080000>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_factory_8004: macaddr@8004 {
+				reg = <0x8004 0x6>;
+			};
+		};
+
+		partition@180000 {
+			label = "firmware";
+			reg = <0x0180000 0x7a80000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0000000 0x0400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x0400000 0x7680000>;
+			};
+		};
+
+		/* last 128KiB *32 is reserved for bad blocks management */
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		mediatek,disable-radar-background;
+	};
+};
+
+&pcie2 {
+	status = "disabled";
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart3", "wdt";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/dts/mt7621_haier_har-20s2u1.dts
+++ b/target/linux/ramips/dts/mt7621_haier_har-20s2u1.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_haier-sim_wr1800k.dtsi"
+
+/ {
+	compatible = "haier,har-20s2u1", "mediatek,mt7621-soc";
+	model = "Haier HAR-20S2U1";
+};

--- a/target/linux/ramips/dts/mt7621_sim_simax1800t.dts
+++ b/target/linux/ramips/dts/mt7621_sim_simax1800t.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_haier-sim_wr1800k.dtsi"
+
+/ {
+	compatible = "sim,simax1800t", "mediatek,mt7621-soc";
+	model = "SIM SIMAX1800T";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -37,6 +37,18 @@ define Build/h3c-blank-header
 	mv $@.blank $@
 endef
 
+define Build/haier-sim_wr1800k-factory
+  -[ -e $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) ] && \
+  mkdir -p "$(1).tmp" && \
+  $(CP) $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) "$(1).tmp/UploadBrush-bin.img" && \
+  $(MKHASH) md5 "$(1).tmp/UploadBrush-bin.img" | head -c32 > "$(1).tmp/check_MD5.txt" && \
+  $(TAR) -czf $(1).tmp.tgz -C "$(1).tmp" UploadBrush-bin.img check_MD5.txt && \
+  $(STAGING_DIR_HOST)/bin/openssl aes-256-cbc -e -salt -in $(1).tmp.tgz -out "$(1)" -k QiLunSmartWL && \
+  printf %32s "$(DEVICE_MODEL)" >> "$(1)" && \
+  rm -rf "$(1).tmp" $(1).tmp.tgz && \
+  $(CP) $(1) $(BIN_DIR)/
+endef
+
 define Build/iodata-factory
 	$(eval fw_size=$(word 1,$(1)))
 	$(eval fw_type=$(word 2,$(1)))
@@ -868,6 +880,29 @@ define Device/h3c_tx1806
   DEVICE_MODEL := TX1806
 endef
 TARGET_DEVICES += h3c_tx1806
+
+define Device/haier-sim_wr1800k
+  $(Device/dsa-migration)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 125440k
+  UBINIZE_OPTS := -E 5
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel 0x80001000 | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := $$(KERNEL) | \
+	haier-sim_wr1800k-factory $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915e uboot-envtools
+endef
+
+define Device/haier_har-20s2u1
+  $(Device/haier-sim_wr1800k)
+  DEVICE_VENDOR := Haier
+  DEVICE_MODEL := HAR-20S2U1
+endef
+TARGET_DEVICES += haier_har-20s2u1
 
 define Device/hilink_hlk-7621a-evb
   $(Device/dsa-migration)
@@ -1728,6 +1763,13 @@ define Device/sercomm_na502s
   		kmod-usb-serial-xr_usb_serial_common
 endef
 TARGET_DEVICES += sercomm_na502s
+
+define Device/sim_simax1800t
+  $(Device/haier-sim_wr1800k)
+  DEVICE_VENDOR := SIM
+  DEVICE_MODEL := SIMAX1800T
+endef
+TARGET_DEVICES += sim_simax1800t
 
 define Device/snr_snr-cpe-me2-lite
   $(Device/dsa-migration)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -35,8 +35,10 @@ ramips_setup_interfaces()
 	h3c,tx1800-plus|\
 	h3c,tx1801-plus|\
 	h3c,tx1806|\
+	haier,har-20s2u1|\
 	hiwifi,hc5962|\
 	netgear,wax202|\
+	sim,simax1800t|\
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-ac2100|\
 	xiaomi,mi-router-cr6606|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -45,6 +45,12 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && echo -n ${addr:0:9}'1'${addr:10:7} > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && echo -n ${addr:0:9}'7'${addr:10:7} > /sys${DEVPATH}/macaddress
 		;;
+	haier,har-20s2u1|\
+	jcg,y2|\
+	sim,simax1800t)
+		[ "$PHYNBR" = "1" ] && \
+			macaddr_setbit_la "$(mtd_get_mac_binary factory 0x4)" > /sys${DEVPATH}/macaddress
+		;;
 	hiwifi,hc5962)
 		label_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac ")
 		[ "$PHYNBR" = "0" ] && [ -n "$label_mac" ] && \
@@ -68,10 +74,6 @@ case "$board" in
 	jcg,q20)
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary Factory 0x4)" > /sys${DEVPATH}/macaddress
-		;;
-	jcg,y2)
-		[ "$PHYNBR" = "1" ] && \
-			macaddr_setbit_la "$(mtd_get_mac_binary factory 0x4)" > /sys${DEVPATH}/macaddress
 		;;
 	linksys,e5600|\
 	linksys,ea6350-v4|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -65,6 +65,7 @@ platform_do_upgrade() {
 	h3c,tx1800-plus|\
 	h3c,tx1801-plus|\
 	h3c,tx1806|\
+	haier,har-20s2u1|\
 	hiwifi,hc5962|\
 	iptime,a3004t|\
 	iptime,ax2004m|\
@@ -95,6 +96,7 @@ platform_do_upgrade() {
 	raisecom,msg1500-x-00|\
 	sercomm,na502|\
 	sercomm,na502s|\
+	sim,simax1800t|\
 	xiaomi,mi-router-3g|\
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-4|\


### PR DESCRIPTION
SIM AX18T and Haier HAR-20S2U1 Wi-Fi6 AX1800 routers are designed based on Tenbay WR1800K. They have the same hardware circuits and u-boot. SIM AX18T has three carrier customized models: SIMAX1800M (China Mobile), SIMAX1800T (China Telecom) and SIMAX1800U (China Unicom). All of these models can run the same firmware.

Specifications:
SOC: MT7621 + MT7905 + MT7975
ROM: 128 MiB
RAM: 256 MiB
LED: status *3 R/G/B
Button: reset *1 + wps/mesh *1
Ethernet: lan *3 + wan *1 (10/100/1000Mbps)
TTL Baudrate: 115200

<details>
<summary>Boot Log</summary>

```
[    0.000000] Linux version 5.15.69 (dragon@Aspire-V-Nitro) (mipsel-openwrt-linux-musl-gcc (OpenWrt GCC 11.3.0 r20793-505d17ffe3) 11.3.0, GNU ld (GNU Binutils) 2.37) #0 SMP Mon Sep 26 08:05:19 2022
[    0.000000] SoC Type: MediaTek MT7621 ver:1 eco:3
[    0.000000] printk: bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 0001992f (MIPS 1004Kc)
[    0.000000] MIPS: machine is SIM AX18T
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] VPE topology {2,2} total 4
[    0.000000] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.000000] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000]   HighMem  empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000] percpu: Embedded 11 pages/cpu s15632 r8192 d21232 u45056
[    0.000000] pcpu-alloc: s15632 r8192 d21232 u45056 alloc=11*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3 
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 64960
[    0.000000] Kernel command line: console=ttyS0,115200 firmware1 rootfstype=squashfs,jffs2
[    0.000000] Unknown kernel command line parameters "firmware1", will be passed to user space.
[    0.000000] Dentry cache hash table entries: 32768 (order: 5, 131072 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 4, 65536 bytes, linear)
[    0.000000] Writing ErrCtl register=00042820
[    0.000000] Readback ErrCtl register=00042820
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 248636K/262144K available (7147K kernel code, 624K rwdata, 1448K rodata, 1264K init, 242K bss, 13508K reserved, 0K cma-reserved, 0K highmem)
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] NR_IRQS: 256
[    0.000000] clocksource: GIC: mask: 0xffffffffffffffff max_cycles: 0xcaf478abb4, max_idle_ns: 440795247997 ns
[    0.000004] sched_clock: 64 bits at 880MHz, resolution 1ns, wraps every 4398046511103ns
[    0.008056] Calibrating delay loop... 586.13 BogoMIPS (lpj=2930688)
[    0.066209] pid_max: default: 32768 minimum: 301
[    0.071041] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.078253] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.089074] rcu: Hierarchical SRCU implementation.
[    0.094119] dyndbg: Ignore empty _ddebug table in a CONFIG_DYNAMIC_DEBUG_CORE build
[    0.102263] smp: Bringing up secondary CPUs ...
[    0.107573] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.107601] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.107615] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.107661] CPU1 revision is: 0001992f (MIPS 1004Kc)
[    0.162013] Synchronize counters for CPU 1: done.
[    0.194132] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.194155] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.194168] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.194201] CPU2 revision is: 0001992f (MIPS 1004Kc)
[    0.253333] Synchronize counters for CPU 2: done.
[    0.284029] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.284054] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.284066] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.284101] CPU3 revision is: 0001992f (MIPS 1004Kc)
[    0.338556] Synchronize counters for CPU 3: done.
[    0.368434] smp: Brought up 1 node, 4 CPUs
[    0.376587] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.386387] futex hash table entries: 1024 (order: 3, 32768 bytes, linear)
[    0.393387] pinctrl core: initialized pinctrl subsystem
[    0.399893] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.406354] thermal_sys: Registered thermal governor 'step_wise'
[    0.406969] cpuidle: using governor teo
[    0.427036] FPU Affinity set after 11720 emulations
[    0.439574] clocksource: Switched to clocksource GIC
[    0.445336] NET: Registered PF_INET protocol family
[    0.450445] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.458355] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 6144 bytes, linear)
[    0.466683] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.474356] TCP established hash table entries: 2048 (order: 1, 8192 bytes, linear)
[    0.481978] TCP bind hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.489048] TCP: Hash tables configured (established 2048 bind 2048)
[    0.495502] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.501991] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.509217] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.514849] PCI: CLS 0 bytes, default 32
[    0.521624] workingset: timestamp_bits=14 max_order=16 bucket_order=2
[    0.532596] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.538354] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.552790] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.558843] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.564809] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.571031] mt7621-pci 1e140000.pcie: host bridge /pcie@1e140000 ranges:
[    0.577713] mt7621-pci 1e140000.pcie:   No bus range found for /pcie@1e140000, using [bus 00-ff]
[    0.586478] mt7621-pci 1e140000.pcie:      MEM 0x0060000000..0x006fffffff -> 0x0060000000
[    0.594592] mt7621-pci 1e140000.pcie:       IO 0x001e160000..0x001e16ffff -> 0x0000000000
[    0.839562] mt7621-pci 1e140000.pcie: PCIE0 enabled
[    0.844375] mt7621-pci 1e140000.pcie: PCIE1 enabled
[    0.849235] PCI coherence region base: 0x60000000, mask/settings: 0xf0000002
[    0.856399] mt7621-pci 1e140000.pcie: PCI host bridge to bus 0000:00
[    0.862690] pci_bus 0000:00: root bus resource [bus 00-ff]
[    0.868096] pci_bus 0000:00: root bus resource [mem 0x60000000-0x6fffffff]
[    0.874939] pci_bus 0000:00: root bus resource [io  0x0000-0xffff]
[    0.881125] pci 0000:00:00.0: [0e8d:0801] type 01 class 0x060400
[    0.887050] pci 0000:00:00.0: reg 0x10: [mem 0x00000000-0x7fffffff]
[    0.893275] pci 0000:00:00.0: reg 0x14: [mem 0x60600000-0x6060ffff]
[    0.899581] pci 0000:00:00.0: supports D1
[    0.903500] pci 0000:00:00.0: PME# supported from D0 D1 D3hot
[    0.910083] pci 0000:00:01.0: [0e8d:0801] type 01 class 0x060400
[    0.916066] pci 0000:00:01.0: reg 0x10: [mem 0x00000000-0x7fffffff]
[    0.922288] pci 0000:00:01.0: reg 0x14: [mem 0x60610000-0x6061ffff]
[    0.928548] pci 0000:00:01.0: supports D1
[    0.932476] pci 0000:00:01.0: PME# supported from D0 D1 D3hot
[    0.940378] pci 0000:01:00.0: [14c3:7916] type 00 class 0x000280
[    0.946357] pci 0000:01:00.0: reg 0x10: [mem 0x00000000-0x000fffff 64bit pref]
[    0.953525] pci 0000:01:00.0: reg 0x18: [mem 0x00000000-0x00003fff 64bit pref]
[    0.960694] pci 0000:01:00.0: reg 0x20: [mem 0x00000000-0x00000fff 64bit pref]
[    0.967952] pci 0000:01:00.0: supports D1 D2
[    0.972138] pci 0000:01:00.0: PME# supported from D0 D1 D2 D3hot D3cold
[    0.978729] pci 0000:01:00.0: 2.000 Gb/s available PCIe bandwidth, limited by 2.5 GT/s PCIe x1 link at 0000:00:00.0 (capable of 4.000 Gb/s with 5.0 GT/s PCIe x1 link)
[    0.994733] pci 0000:00:00.0: PCI bridge to [bus 01-ff]
[    0.999916] pci 0000:00:00.0:   bridge window [io  0x0000-0x0fff]
[    1.005935] pci 0000:00:00.0:   bridge window [mem 0x60000000-0x600fffff]
[    1.012688] pci 0000:00:00.0:   bridge window [mem 0x60100000-0x602fffff pref]
[    1.019872] pci_bus 0000:01: busn_res: [bus 01-ff] end is updated to 01
[    1.026689] pci 0000:02:00.0: [14c3:7915] type 00 class 0x000280
[    1.032666] pci 0000:02:00.0: reg 0x10: [mem 0x00000000-0x000fffff 64bit pref]
[    1.039831] pci 0000:02:00.0: reg 0x18: [mem 0x00000000-0x00003fff 64bit pref]
[    1.046981] pci 0000:02:00.0: reg 0x20: [mem 0x00000000-0x00000fff 64bit pref]
[    1.054282] pci 0000:02:00.0: supports D1 D2
[    1.058460] pci 0000:02:00.0: PME# supported from D0 D1 D2 D3hot D3cold
[    1.065080] pci 0000:02:00.0: 2.000 Gb/s available PCIe bandwidth, limited by 2.5 GT/s PCIe x1 link at 0000:00:01.0 (capable of 4.000 Gb/s with 5.0 GT/s PCIe x1 link)
[    1.081128] pci 0000:00:01.0: PCI bridge to [bus 02-ff]
[    1.086284] pci 0000:00:01.0:   bridge window [io  0x0000-0x0fff]
[    1.092351] pci 0000:00:01.0:   bridge window [mem 0x60300000-0x603fffff]
[    1.099066] pci 0000:00:01.0:   bridge window [mem 0x60400000-0x605fffff pref]
[    1.106258] pci_bus 0000:02: busn_res: [bus 02-ff] end is updated to 02
[    1.112867] pci 0000:00:00.0: BAR 0: no space for [mem size 0x80000000]
[    1.119382] pci 0000:00:00.0: BAR 0: failed to assign [mem size 0x80000000]
[    1.126313] pci 0000:00:01.0: BAR 0: no space for [mem size 0x80000000]
[    1.132874] pci 0000:00:01.0: BAR 0: failed to assign [mem size 0x80000000]
[    1.139801] pci 0000:00:00.0: BAR 8: assigned [mem 0x60000000-0x600fffff]
[    1.146514] pci 0000:00:00.0: BAR 9: assigned [mem 0x60100000-0x602fffff pref]
[    1.153700] pci 0000:00:01.0: BAR 8: assigned [mem 0x60300000-0x603fffff]
[    1.160456] pci 0000:00:01.0: BAR 9: assigned [mem 0x60400000-0x605fffff pref]
[    1.167595] pci 0000:00:00.0: BAR 1: assigned [mem 0x60600000-0x6060ffff]
[    1.174359] pci 0000:00:01.0: BAR 1: assigned [mem 0x60610000-0x6061ffff]
[    1.181094] pci 0000:00:00.0: BAR 7: assigned [io  0x0000-0x0fff]
[    1.187121] pci 0000:00:01.0: BAR 7: assigned [io  0x1000-0x1fff]
[    1.193198] pci 0000:01:00.0: BAR 0: assigned [mem 0x60100000-0x601fffff 64bit pref]
[    1.200898] pci 0000:01:00.0: BAR 2: assigned [mem 0x60200000-0x60203fff 64bit pref]
[    1.208558] pci 0000:01:00.0: BAR 4: assigned [mem 0x60204000-0x60204fff 64bit pref]
[    1.216267] pci 0000:00:00.0: PCI bridge to [bus 01]
[    1.221180] pci 0000:00:00.0:   bridge window [io  0x0000-0x0fff]
[    1.227212] pci 0000:00:00.0:   bridge window [mem 0x60000000-0x600fffff]
[    1.233966] pci 0000:00:00.0:   bridge window [mem 0x60100000-0x602fffff pref]
[    1.241145] pci 0000:02:00.0: BAR 0: assigned [mem 0x60400000-0x604fffff 64bit pref]
[    1.248822] pci 0000:02:00.0: BAR 2: assigned [mem 0x60500000-0x60503fff 64bit pref]
[    1.256529] pci 0000:02:00.0: BAR 4: assigned [mem 0x60504000-0x60504fff 64bit pref]
[    1.264226] pci 0000:00:01.0: PCI bridge to [bus 02]
[    1.269114] pci 0000:00:01.0:   bridge window [io  0x1000-0x1fff]
[    1.275179] pci 0000:00:01.0:   bridge window [mem 0x60300000-0x603fffff]
[    1.281918] pci 0000:00:01.0:   bridge window [mem 0x60400000-0x605fffff pref]
[    1.291677] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    1.299878] printk: console [ttyS0] disabled
[    1.304249] 1e000c00.uartlite: ttyS0 at MMIO 0x1e000c00 (irq = 19, base_baud = 3125000) is a 16550A
[    1.313259] printk: console [ttyS0] enabled
[    1.321529] printk: bootconsole [early0] disabled
[    1.334066] nand: device found, Manufacturer ID: 0x98, Chip ID: 0xf1
[    1.340497] nand: Toshiba NAND 128MiB 3,3V 8-bit
[    1.345104] nand: 128 MiB, SLC, erase size: 128 KiB, page size: 2048, OOB size: 64
[    1.352661] mt7621-nand 1e003000.nand: ECC strength adjusted to 4 bits
[    1.359252] 4 fixed-partitions partitions found on MTD device mt7621-nand
[    1.366933] Creating 4 MTD partitions on "mt7621-nand":
[    1.372219] 0x000000000000-0x000000080000 : "u-boot"
[    1.383574] 0x000000080000-0x000000100000 : "u-boot-env"
[    1.395108] 0x000000100000-0x000000180000 : "factory"
[    1.406736] 0x000000180000-0x000007800000 : "firmware"
[    2.643873] 2 fixed-partitions partitions found on MTD device firmware
[    2.650484] Creating 2 MTD partitions on "firmware":
[    2.655450] 0x000000000000-0x000000800000 : "kernel"
[    2.744979] 0x000000800000-0x000007680000 : "ubi"
[    3.921075] mt7530 mdio-bus:1f: MT7530 adapts as multi-chip module
[    3.932892] mtk_soc_eth 1e100000.ethernet eth0: mediatek frame engine at 0xbe100000, irq 20
[    3.942298] mtk_soc_eth 1e100000.ethernet wan: mediatek frame engine at 0xbe100000, irq 20
[    3.952390] i2c_dev: i2c /dev entries driver
[    3.960654] NET: Registered PF_INET6 protocol family
[    3.967917] Segment Routing with IPv6
[    3.971782] In-situ OAM (IOAM) with IPv6
[    3.975814] NET: Registered PF_PACKET protocol family
[    3.981395] 8021q: 802.1Q VLAN Support v1.8
[    3.991676] mt7530 mdio-bus:1f: MT7530 adapts as multi-chip module
[    4.024333] mt7530 mdio-bus:1f: configuring for fixed/rgmii link mode
[    4.034686] mt7530 mdio-bus:1f: Link is Up - 1Gbps/Full - flow control rx/tx
[    4.040893] mt7530 mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7530 PHY] (irq=22)
[    4.054515] mt7530 mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7530 PHY] (irq=23)
[    4.066976] mt7530 mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7530 PHY] (irq=24)
[    4.079503] DSA: tree 0 setup
[    4.085887] UBI: auto-attach mtd5
[    4.089236] ubi0: attaching mtd5
[    6.392913] ubi0: scanning is finished
[    6.414383] ubi0: attached mtd5 (name "ubi", size 110 MiB)
[    6.419956] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    6.426821] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    6.433593] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    6.440548] ubi0: good PEBs: 883, bad PEBs: 1, corrupted PEBs: 0
[    6.446538] ubi0: user volume: 2, internal volumes: 1, max. volumes count: 128
[    6.453740] ubi0: max/mean erase counter: 1/0, WL threshold: 4096, image sequence number: 808689209
[    6.462766] ubi0: available PEBs: 0, total reserved PEBs: 883, PEBs reserved for bad PEB handling: 19
[    6.472009] ubi0: background thread "ubi_bgt0d" started, PID 254
[    6.474355] block ubiblock0_0: created from ubi0:0(rootfs)
[    6.483541] ubiblock: device ubiblock0_0 (rootfs) set to be root filesystem
[    6.498100] VFS: Mounted root (squashfs filesystem) readonly on device 254:0.
[    6.509822] Freeing unused kernel image (initmem) memory: 1264K
[    6.515786] This architecture does not have kernel memory protection.
[    6.522235] Run /sbin/init as init process
[    6.526320]   with arguments:
[    6.526325]     /sbin/init
[    6.526331]     firmware1
[    6.526336]   with environment:
[    6.526341]     HOME=/
[    6.526346]     TERM=linux
[    7.081605] init: Console is alive
[    7.085419] init: - watchdog -
[    7.906464] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    8.033064] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    8.060027] init: - preinit -
[    8.834215] random: jshn: uninitialized urandom read (4 bytes read)
[    8.915290] random: jshn: uninitialized urandom read (4 bytes read)
[    8.955514] random: jshn: uninitialized urandom read (4 bytes read)
[    9.245996] mtk_soc_eth 1e100000.ethernet eth0: configuring for fixed/rgmii link mode
[    9.254466] mtk_soc_eth 1e100000.ethernet eth0: Link is Up - 1Gbps/Full - flow control rx/tx
[    9.260130] mt7530 mdio-bus:1f lan1: configuring for phy/gmii link mode
[    9.270043] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[   11.479245] UBIFS (ubi0:1): default file-system created
[   11.485908] UBIFS (ubi0:1): Mounting in unauthenticated mode
[   11.492001] UBIFS (ubi0:1): background thread "ubifs_bgt0_1" started, PID 376
[   11.621476] UBIFS (ubi0:1): UBIFS: mounted UBI device 0, volume 1, name "rootfs_data"
[   11.629313] UBIFS (ubi0:1): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[   11.639240] UBIFS (ubi0:1): FS size: 103485440 bytes (98 MiB, 815 LEBs), max 826 LEBs, journal size 5206016 bytes (4 MiB, 41 LEBs)
[   11.650994] UBIFS (ubi0:1): reserved for root: 4887873 bytes (4773 KiB)
[   11.657591] UBIFS (ubi0:1): media format: w5/r0 (latest is w5/r0), UUID A6FE58BD-12F9-42A5-A0D6-B8A78D6FF658, small LPT model
[   11.672441] mount_root: overlay filesystem has not been fully initialized yet
[   11.680522] mount_root: switching to ubifs overlay
[   11.693705] urandom-seed: Seed file not found (/etc/urandom.seed)
[   11.870786] procd: - early -
[   11.873947] procd: - watchdog -
[   12.519733] procd: - watchdog -
[   12.631627] procd: - ubus -
[   12.773490] random: ubusd: uninitialized urandom read (4 bytes read)
[   12.790637] random: ubusd: uninitialized urandom read (4 bytes read)
[   12.797571] random: ubusd: uninitialized urandom read (4 bytes read)
[   12.810989] procd: - init -
[   13.632669] kmodloader: loading kernel modules from /etc/modules.d/*
[   13.772300] urngd: v1.0.2 started.
[   13.940770] Loading modules backported from Linux version v5.15.58-0-g7d8048d4e064
[   13.946785] random: crng init done
[   13.948342] Backport generated by backports.git v5.15.58-1-0-g42a95ce7
[   13.958376] random: 30 urandom warning(s) missed due to ratelimiting
[   14.125010] pci 0000:00:00.0: enabling device (0006 -> 0007)
[   14.130756] mt7915e_hif 0000:01:00.0: enabling device (0000 -> 0002)
[   14.137772] pci 0000:00:01.0: enabling device (0006 -> 0007)
[   14.143549] mt7915e 0000:02:00.0: enabling device (0000 -> 0002)
[   14.410187] mt7915e 0000:02:00.0: HW/SW Version: 0x8a108a10, Build Time: 20220803150806a
[   14.410187] 
[   14.745784] mt7915e 0000:02:00.0: WM Firmware Version: ____000000, Build Time: 20220803150839
[   14.780138] mt7915e 0000:02:00.0: WA Firmware Version: DEV_000000, Build Time: 20220803150859
[   16.628496] mtdblock: MTD device 'factory' is NAND, please consider using UBI block devices instead.
[   20.224475] PPP generic driver version 2.4.2
[   20.230761] NET: Registered PF_PPPOX protocol family
[   20.244728] kmodloader: done loading kernel modules from /etc/modules.d/*
[   54.465403] mtk_soc_eth 1e100000.ethernet eth0: Link is Down
[   54.485715] mtk_soc_eth 1e100000.ethernet eth0: configuring for fixed/rgmii link mode
[   54.493995] mtk_soc_eth 1e100000.ethernet eth0: Link is Up - 1Gbps/Full - flow control rx/tx
[   54.496766] mt7530 mdio-bus:1f lan1: configuring for phy/gmii link mode
[   54.509776] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[   54.516864] br-lan: port 1(lan1) entered blocking state
[   54.522260] br-lan: port 1(lan1) entered disabled state
[   54.529437] device lan1 entered promiscuous mode
[   54.534314] device eth0 entered promiscuous mode
[   54.572169] mt7530 mdio-bus:1f lan2: configuring for phy/gmii link mode
[   54.580846] br-lan: port 2(lan2) entered blocking state
[   54.586131] br-lan: port 2(lan2) entered disabled state
[   54.593841] device lan2 entered promiscuous mode
[   54.612500] mt7530 mdio-bus:1f lan3: configuring for phy/gmii link mode
[   54.620994] br-lan: port 3(lan3) entered blocking state
[   54.626285] br-lan: port 3(lan3) entered disabled state
[   54.634297] device lan3 entered promiscuous mode
[   54.661422] mtk_soc_eth 1e100000.ethernet wan: PHY [mdio-bus:04] driver [MediaTek MT7530 PHY] (irq=POLL)
[   54.671035] mtk_soc_eth 1e100000.ethernet wan: configuring for phy/rgmii link mode
[   57.607338] br-lan: port 4(wlan0) entered blocking state
[   57.612769] br-lan: port 4(wlan0) entered disabled state
[   57.618638] device wlan0 entered promiscuous mode
[   57.726780] IPv6: ADDRCONF(NETDEV_CHANGE): wlan0: link becomes ready
[   57.733762] br-lan: port 4(wlan0) entered blocking state
[   57.739132] br-lan: port 4(wlan0) entered forwarding state
[   57.746666] IPv6: ADDRCONF(NETDEV_CHANGE): br-lan: link becomes ready
[   58.006773] br-lan: port 5(wlan1) entered blocking state
[   58.012283] br-lan: port 5(wlan1) entered disabled state
[   58.018200] device wlan1 entered promiscuous mode
[   58.023599] br-lan: port 5(wlan1) entered blocking state
[   58.028967] br-lan: port 5(wlan1) entered forwarding state
[   58.158913] IPv6: ADDRCONF(NETDEV_CHANGE): wlan1: link becomes ready
```
</details>

[Device Page](http://www.sim.com/cp/info.aspx?itemid=4272&lcid=1053)
[Stock Firmware](https://github.com/DragonBluep/archive/tree/main/SIM%20SIMAX1800T)
