### PR TITLE
ramips: Add support for D-Link DIR-3060 A1

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-3060-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-3060-a1.dts
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dir-3060-a1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-3060 A1";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_white;
+		led-running = &led_power_white;
+		led-upgrade = &led_net_orange;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: power_orange {
+			label = "orange:power";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_white: power_white {
+			label = "white:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_net_orange: net_orange {
+			label = "orange:net";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		net_white {
+			label = "white:net";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+		
+		usb2_white {
+			label = "white:usb2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+
+		usb3_white {
+			label = "white:usb3";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		wlan2g {
+			label = "white:wlan2g";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		wlan5glb {
+			label = "white:wlan5glb";
+			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1radio";
+		};
+
+		wlan5ghb {
+			label = "white:wlan5ghb";
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy2radio";
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "config2";
+			reg = <0x140000 0x40000>;
+			read-only;
+		};
+
+		partition@180000 {
+			label = "firmware";
+			compatible = "openwrt,uimage", "denx,uimage";
+			openwrt,padding = <96>;
+			reg = <0x180000 0x2800000>;
+		};
+
+		partition@2980000 {
+			label = "private";
+			reg = <0x2980000 0x2000000>;
+			read-only;
+		};
+
+		partition@4980000 {
+			label = "firmware2";
+			reg = <0x4980000 0x2800000>;
+			read-only;
+		};
+
+		partition@7180000 {
+			label = "mydlink";
+			reg = <0x7180000 0x600000>;
+			read-only;
+		};
+
+		partition@7780000 {
+			label = "reserved";
+			reg = <0x7780000 0x880000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi0: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+                ieee80211-freq-limit = <2400000 6000000>;
+		nvmem-cells = <&macaddr_factory_e000>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <1>;
+	};
+};
+
+&pcie1 {
+	wifi1: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&macaddr_factory_e000>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <3>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e006>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -521,6 +521,13 @@ define Device/dlink_dir-2660-a1
 endef
 TARGET_DEVICES += dlink_dir-2660-a1
 
+define Device/dlink_dir-3060-a1
+  $(Device/dlink_dir-xx60-a1)
+  DEVICE_MODEL := DIR-3060
+  DEVICE_VARIANT := A1
+endef
+TARGET_DEVICES += dlink_dir-3060-a1
+
 define Device/dlink_dir-853-a3
   $(Device/dlink_dir-xx60-a1)
   DEVICE_MODEL := DIR-853

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -52,7 +52,11 @@ xzwifi,creativebox-v1)
 dlink,dir-1960-a1|\
 dlink,dir-2640-a1|\
 dlink,dir-2660-a1)
-	ucidef_set_led_netdev "wan" "wan" "white:net" "wan"
+        ucidef_set_led_netdev "wan" "wan" "white:net" "wan"
+        ;;
+dlink,dir-3060-a1)
+	ucidef_set_led_netdev "net_white" "WAN Link" "white:net" "wan" "link"
+        ucidef_set_led_netdev "net_orange" "WAN Activity" "orange:net" "wan" "tx rx"
 	;;
 dlink,dir-853-a3)
 	ucidef_set_led_netdev "wan" "wan" "blue:net" "wan"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -61,6 +61,7 @@ platform_do_upgrade() {
 	dlink,dir-1960-a1|\
 	dlink,dir-2640-a1|\
 	dlink,dir-2660-a1|\
+	dlink,dir-3060-a1|\
 	dlink,dir-853-a3|\
 	h3c,tx1800-plus|\
 	h3c,tx1801-plus|\


### PR DESCRIPTION
Hardware specification:
SoC: MediaTek MT7621AT
Flash: Winbond W29N01HVSINA 128MB
RAM: Micron MT41K128M16JT-125 256MB
Ethernet: 4x 10/100/1000 Mbps
WiFi1: MT7615DN 2.4GHz N 2x2:2
WiFi2: MT7615DN 5GHz AC 2x2:2
WiFi3: MT7615N 5GHz AC 4x4:4
Button: WPS, Reset

Flash instructions:
OpenWrt can be installed via [D-Link Recovery GUI](https://openwrt.org/docs/guide-user/installation/installation_methods/d-link_recovery_gui):

1. Push and hold reset button (on the bottom of the device) until power led starts flashing (about 10 secs or so) while plugging in the power cable.
2. Give it ~30 seconds, to boot the recovery mode GUI
3. Connect your client computer to LAN1 of the device
4. Set your client IP address manually to 192.168.0.2 / 255.255.255.0.
5. Call the recovery page for the device at http://192.168.0.1/
6. Use the provided emergency web GUI to upload and flash a new firmware to the device

Thanks to Lucky1 for creating the DTS file and modifying other, so it was possible for me to build images, test and fix minor issues.

Checklist:

- [x] nand
- [x] ethernet
- [x] button
- [x] Wifi2g
- [x] wifi5g
- [x] wifi5g
- [x] mac
- [x] led
