### PR TITLE
realtek: Remove specific targets from generic image/Makefile

### DIFF
--- a/target/linux/realtek/image/Makefile
+++ b/target/linux/realtek/image/Makefile
@@ -101,15 +101,6 @@ define Device/hpe_1920
   	pad-rootfs | check-size | append-metadata
 endef
 
-# "NGE" refers to the uImage magic
-define Device/netgear_nge
-  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma
-  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | uImage lzma
-  SOC := rtl8380
-  IMAGE_SIZE := 14848k
-  UIMAGE_MAGIC := 0x4e474520
-  DEVICE_VENDOR := NETGEAR
-endef
 
 include $(SUBTARGET).mk
 

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -116,6 +116,16 @@ define Device/iodata_bsh-g24mb
 endef
 TARGET_DEVICES += iodata_bsh-g24mb
 
+# "NGE" refers to the uImage magic
+define Device/netgear_nge
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | uImage lzma
+  SOC := rtl8380
+  IMAGE_SIZE := 14848k
+  UIMAGE_MAGIC := 0x4e474520
+  DEVICE_VENDOR := NETGEAR
+endef
+
 define Device/netgear_gs108t-v3
   $(Device/netgear_nge)
   DEVICE_MODEL := GS108T


### PR DESCRIPTION
There seems to be no reason to have the HP 1920 and Netgear switches as part of the main Makefile. Move them to their specific submakefiles.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>