### PR TITLE
Fix warnings from grep

### DIFF
--- a/target/sdk/files/Makefile
+++ b/target/sdk/files/Makefile
@@ -14,7 +14,7 @@ export TOPDIR LC_ALL LANG SDK
 
 world:
 
-DISTRO_PKG_CONFIG:=$(shell $(TOPDIR)/scripts/command_all.sh pkg-config | grep -E '\/usr' -m 1)
+DISTRO_PKG_CONFIG:=$(shell $(TOPDIR)/scripts/command_all.sh pkg-config | grep '/usr' -m 1)
 export PATH:=$(TOPDIR)/staging_dir/host/bin:$(PATH)
 
 ifneq ($(OPENWRT_BUILD),1)


### PR DESCRIPTION
Newer versions of grep will issue a warning for invalid "escaped" slashes which in turn causes a bunch of warnings to appear while building.
```
grep (GNU grep) 3.8
grep: warning: stray \ before /
```