### PR TITLE
uboot-mvebu: backport patch to fix compilation on non-glibc system and the other one for older LibreSSL

### DIFF
--- a/package/boot/uboot-mvebu/patches/0001-tools-termios_linux.h-Fix-compilation-on-non-glibc-s.patch
+++ b/package/boot/uboot-mvebu/patches/0001-tools-termios_linux.h-Fix-compilation-on-non-glibc-s.patch
@@ -1,0 +1,49 @@
+From 82a6da13c3a113eefdb378ff53635f32a6184d6f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Thu, 8 Sep 2022 16:59:36 +0200
+Subject: [PATCH] tools: termios_linux.h: Fix compilation on non-glibc systems
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+TCGETS2 is defined in header file asm/ioctls.h provided by linux kernel.
+On glib systems it is automatically included by some other glibc include
+header file and therefore TCGETS2 is present in termios_linux.h when
+linux kernel provides it.
+
+On non-glibc systems (e.g. musl) asm/ioctls.h is not automatically included
+which results in the strange error that BOTHER is supported, TCGETS2 not
+defined and struct termios does not provide c_ispeed member.
+
+    tools/kwboot.c: In function 'kwboot_tty_change_baudrate':
+    tools/kwboot.c:662:6: error: 'struct termios' has no member named 'c_ospeed'
+      662 |   tio.c_ospeed = tio.c_ispeed = baudrate;
+          |      ^
+
+Fix this issue by explicitly including asm/ioctls.h file which provides
+TCGETS2 macro (if supported on selected architecture) to not depending on
+glibc auto-include behavior and because termios_linux.h requires it.
+
+With this change it is possible compile kwboot with musl libc.
+
+Reported-by: Michal Vasilek <michal.vasilek@nic.cz>
+Signed-off-by: Pali Rohár <pali@kernel.org>
+---
+ tools/termios_linux.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tools/termios_linux.h b/tools/termios_linux.h
+index e100c8e4eb..ef8cae3cb6 100644
+--- a/tools/termios_linux.h
++++ b/tools/termios_linux.h
+@@ -29,6 +29,7 @@
+ #include <errno.h>
+ #include <sys/ioctl.h>
+ #include <sys/types.h>
++#include <asm/ioctls.h>
+ #include <asm/termbits.h>
+ 
+ #if defined(BOTHER) && defined(TCGETS2)
+-- 
+2.34.1
+

--- a/package/boot/uboot-mvebu/patches/0002-tools-mkimage-fix-build-with-LibreSSL.patch
+++ b/package/boot/uboot-mvebu/patches/0002-tools-mkimage-fix-build-with-LibreSSL.patch
@@ -1,0 +1,33 @@
+From aed6107ae96870cd190b23d6da34a7e616799ed3 Mon Sep 17 00:00:00 2001
+From: Michal Vasilek <michal.vasilek@nic.cz>
+Date: Fri, 22 Jul 2022 19:55:53 +0200
+Subject: [PATCH 1/2] tools: mkimage: fix build with LibreSSL
+
+RSA_get0_* functions are not available in LibreSSL
+
+Signed-off-by: Michal Vasilek <michal.vasilek@nic.cz>
+Reviewed-by: Simon Glass <sjg@chromium.org>
+---
+ tools/sunxi_toc0.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/tools/sunxi_toc0.c b/tools/sunxi_toc0.c
+index bab5d17b7d..56200bd927 100644
+--- a/tools/sunxi_toc0.c
++++ b/tools/sunxi_toc0.c
+@@ -34,6 +34,12 @@
+ #define pr_warn(fmt, args...)	fprintf(stderr, pr_fmt(fmt), "warning", ##args)
+ #define pr_info(fmt, args...)	fprintf(stderr, pr_fmt(fmt), "info", ##args)
+ 
++#if defined(LIBRESSL_VERSION_NUMBER)
++#define RSA_get0_n(key) (key)->n
++#define RSA_get0_e(key) (key)->e
++#define RSA_get0_d(key) (key)->d
++#endif
++
+ struct __packed toc0_key_item {
+ 	__le32  vendor_id;
+ 	__le32  key0_n_len;
+-- 
+2.34.1
+

--- a/package/boot/uboot-mvebu/patches/0003-tools-mkimage-fix-build-with-recent-LibreSSL.patch
+++ b/package/boot/uboot-mvebu/patches/0003-tools-mkimage-fix-build-with-recent-LibreSSL.patch
@@ -1,0 +1,32 @@
+From 16b94d211b18ae0204c4f850fdf23573b19170ec Mon Sep 17 00:00:00 2001
+From: Mark Kettenis <kettenis@openbsd.org>
+Date: Mon, 29 Aug 2022 13:34:01 +0200
+Subject: [PATCH 2/2] tools: mkimage: fix build with recent LibreSSL
+
+LibreSSL 3.5.0 and later (also shipped as part of OpenBSD 7.1 and
+and later) have an opaque RSA object and do provide the
+RSA_get0_* functions that OpenSSL provides.
+
+Fixes: 2ecc354b8e46 ("tools: mkimage: fix build with LibreSSL")
+Signed-off-by: Mark Kettenis <kettenis@openbsd.org>
+Reviewed-by: Jonathan Gray <jsg@jsg.id.au>
+---
+ tools/sunxi_toc0.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/sunxi_toc0.c b/tools/sunxi_toc0.c
+index 56200bd927..7a8d74bb8e 100644
+--- a/tools/sunxi_toc0.c
++++ b/tools/sunxi_toc0.c
+@@ -34,7 +34,7 @@
+ #define pr_warn(fmt, args...)	fprintf(stderr, pr_fmt(fmt), "warning", ##args)
+ #define pr_info(fmt, args...)	fprintf(stderr, pr_fmt(fmt), "info", ##args)
+ 
+-#if defined(LIBRESSL_VERSION_NUMBER)
++#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3050000fL
+ #define RSA_get0_n(key) (key)->n
+ #define RSA_get0_e(key) (key)->e
+ #define RSA_get0_d(key) (key)->d
+-- 
+2.34.1
+


### PR DESCRIPTION
First commit [1]:
This issue was reported by @paper42, who is using Void Linux with musl
to compile OpenWrt and its packages and found out it is not possible to
compile U-boot for Turris Omnia (neither any other).

It fixes following output:
```
  HOSTCC  tools/kwboot
tools/kwboot.c: In function 'kwboot_tty_change_baudrate':
tools/kwboot.c:662:6: error: 'struct termios' has no member named 'c_ospeed'
  662 |   tio.c_ospeed = tio.c_ispeed = baudrate;
      |      ^
tools/kwboot.c:662:21: error: 'struct termios' has no member named 'c_ispeed'
  662 |   tio.c_ospeed = tio.c_ispeed = baudrate;
      |                     ^
tools/kwboot.c:690:31: error: 'struct termios' has no member named 'c_ospeed'
  690 |  if (!_is_within_tolerance(tio.c_ospeed, baudrate, 3))
      |                               ^
tools/kwboot.c:693:31: error: 'struct termios' has no member named 'c_ispeed'
  693 |  if (!_is_within_tolerance(tio.c_ispeed, baudrate, 3))
      |
```

___


Second commit [2] [3]:

If you would like to compile the newest version of U-boot together with the stable
OpenWrt version, which does not have LibreSSL >= 3.5, which was updated
in the master branch by commit https://github.com/openwrt/openwrt/commit/5451b03b7ceb2315445c683fe174e28bbdd49c2f
("tools/libressl: bump to v3.5.3"), then you need these two patches to
fix it. They are backported from U-boot repository.

**This should be backported to stable OpenWrt versions.**

[1] https://source.denx.de/u-boot/u-boot/-/commit/634aa8e586c6cd3c4b8a068586af6f0f86d35572
[2] https://source.denx.de/u-boot/u-boot/-/commit/2ecc354b8e461c7ecf0189601a8ed7b304596224
[3] https://source.denx.de/u-boot/u-boot/-/commit/1a4af2d9507b54ccf91d5616d5544915f695e64d

cc: @dhewg 