### PR TITLE
realtek: Use built-in functionality for timeout loop

### DIFF
--- a/target/linux/realtek/files-5.10/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-5.10/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1809,7 +1809,8 @@ int rtl838x_smi_wait_op(int timeout)
 	int ret = 0;
 	u32 val;
 
-	ret = readx_poll_timeout(sw_r32, RTL838X_SMI_ACCESS_PHY_CTRL_1, val, val & 0x1, 20, timeout);
+	ret = readx_poll_timeout(sw_r32, RTL838X_SMI_ACCESS_PHY_CTRL_1,
+				 val, !(val & 0x1), 20, timeout);
 	if (ret)
 		pr_err("%s: timeout\n", __func__);
 


### PR DESCRIPTION
realtek: rtl838x: Fix ethernet polling timeout on probe
    
Due to an oversight we accidentally inverted the timeout check. This
patch corrects this.
    
Fixes: 9cec4a0ea45b ("realtek: Use built-in functionality for timeout loop")
