### PR TITLE
procd: Add ability to provide "instance" zeroconf field through `procd_add_mdns()`

### DIFF
--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -597,6 +597,7 @@ procd_add_mdns_service() {
 	proto=$1; shift
 	port=$1; shift
 	json_add_object "${service}_$port"
+	[ -n "$MDNS_INSTANCE_NAME" ] && json_add_string "instance" "$MDNS_INSTANCE_NAME"
 	json_add_string "service" "_$service._$proto.local"
 	json_add_int port "$port"
 	[ -n "$1" ] && {


### PR DESCRIPTION
Be default `procd_add_mdns()` creates zeroconf service without instance field. Due to this `mdns` announced services are found with hostname instead of services or devices names. 

This MR adds ability to provide instance zeroconf field through environment variable instead of changing `procd_add_mdns()` interface.

![p910nd-mdns](https://user-images.githubusercontent.com/975689/190198172-9ec610a5-e7b0-472e-9a00-95c297e14e43.png)

This PR is a part of possible fix of [this issue](https://github.com/openwrt/packages/issues/10496).