### PR TITLE
Cudy LT500 v2 (nano sim)

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -779,7 +779,7 @@ hostapd_set_bss_options() {
 		;;
 	esac
 
-	local auth_algs=$((($auth_mode_shared << 1) | $auth_mode_open))
+	local auth_algs="$((($auth_mode_shared << 1) | $auth_mode_open))"
 	append bss_conf "auth_algs=${auth_algs:-1}" "$N"
 	append bss_conf "wpa=$wpa" "$N"
 	[ -n "$wpa_pairwise" ] && append bss_conf "wpa_pairwise=$wpa_pairwise" "$N"

--- a/target/linux/ramips/dts/mt7628an_cudy_lt500-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_lt500-v2.dts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "cudy,lt500-v2", "mediatek,mt7628an-soc";
+	model = "Cudy LT500 v2";
+
+	aliases {
+		led-boot = &led_internet_blue;
+		led-failsafe = &led_internet_blue;
+		led-running = &led_internet_blue;
+		led-upgrade = &led_internet_blue;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		// TODO shoo?
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_internet_blue: internet_blue {
+			label = "blue:internet";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		internet_red {
+			label = "red:internet";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "green:lan1";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "green:lan2";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "green:lan3";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "green:lan4";
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	// TODO hog these? which values? what are they used for?
+	// gpio_export {
+	// 	compatible = "gpio-export";
+	// 	#size-cells = <0>;
+	// 
+	// 	pwr {
+	// 		gpio-export,name = "pwr";
+	// 		gpio-export,output = <0>;
+	// 		gpios = <&gpio 38 GPIO_ACTIVE_HIGH>;
+	// 	};
+	// 
+	// 	usb4g {
+	// 		gpio-export,name = "4g";
+	// 		gpio-export,output = <0>;
+	// 		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+	// 	};
+	// };
+
+	// TODO shoo
+	//memory@0 {
+	//	device_type = "memory";
+	//	reg = <0x0 0x8000000>;
+	//};
+};
+
+&bdinfo {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_bdinfo_de00: macaddr@de00 {
+		reg = <0xde00 0x6>;
+	};
+};
+
+&ethernet {
+  nvmem-cells = <&macaddr_bdinfo_de00>;
+  nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	// TODO cudy uses llllwl. 3 lan/1 wan according to sales doc
+	mediatek,portmap = <0x2f>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+// TODO pcie nodes
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		// TODO try
+		//spi-max-frequency = <50000000>;
+		//m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf80000>;
+			};
+
+			partition@fd0000 {
+				label = "debug";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "backup";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			bdinfo: partition@ff0000 {
+				label = "bdinfo";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		ralink,group = "gpio", "i2c", "i2s", "p0led_an", "p1led_an", "p2led_an", "p4led_an";
+		ralink,function = "gpio";
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -144,6 +144,16 @@ define Device/comfast_cf-wr758ac-v2
 endef
 TARGET_DEVICES += comfast_cf-wr758ac-v2
 
+define Device/cudy_lt500_v2
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := LT500 v2
+  # TODO confirm this works:
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap
+  SUPPORTED_DEVICES += lt500_v2
+endef
+TARGET_DEVICES += cudy_wr1000
+
 define Device/cudy_wr1000
   IMAGE_SIZE := 7872k
   IMAGES += factory.bin

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -137,6 +137,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "6@eth0"
 		;;
+	// TODO don't know yet
+	cudy,lt500-v2|\
 	tplink,tl-mr6400-v4)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"


### PR DESCRIPTION
This is the current state of my attempt to to port the Cudy LT500 (4G).

DTS still needs some finishing touches.
Most notably, the board also uses the `XM25QH128C` with which the WR1300 had some problems. Maybe a patch is required.


Stock dmesg from v1 (micro SIM, working to acquire a v2 model) (via web interface):
```
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.000000] Linux version 4.4.140 (jenkins@cudy_release) (gcc version 5.4.0 (LEDE GCC 5.4.0 1.3.5) ) #0 Sat Oct 9 09:40:17 2021
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Board has DDR2
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Analog PMU set to hw control
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Digital PMU set to hw control
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] SoC Type: MediaTek MT7628AN ver:1 eco:2
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] bootconsole [early0] enabled
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] CPU0 revision is: 00019655 (MIPS 24KEc)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] MIPS: machine is R9
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Determined physical RAM map:
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000]  memory: 08000000 @ 00000000 (usable)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Initrd not found or empty - disabling initrd
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Zone ranges:
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000]   Normal   [mem 0x0000000000000000-0x0000000007ffffff]
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Movable zone start for each node
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Early memory node ranges
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000]   node   0: [mem 0x0000000000000000-0x0000000007ffffff]
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x0000000007ffffff]
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.000000] On node 0 totalpages: 32768
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.000000] free_area_init_node: node 0, pgdat 803b2570, node_mem_map 81000000
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.000000]   Normal zone: 256 pages used for memmap
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.000000]   Normal zone: 0 pages reserved
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.000000]   Normal zone: 32768 pages, LIFO batch:7
Sat Oct  9 11:41:21 2021 kern.warn kernel: [    0.000000] Primary instruction cache 64kB, VIPT, 4-way, linesize 32 bytes.
Sat Oct  9 11:41:21 2021 kern.warn kernel: [    0.000000] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.000000] pcpu-alloc: s0 r0 d32768 u32768 alloc=1*32768
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.000000] pcpu-alloc: [0] 0 
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Built 1 zonelists in Zone order, mobility grouping on.  Total pages: 32512
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.000000] Kernel command line: console=ttyS0,115200 rootfstype=squashfs,jffs2
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] PID hash table entries: 512 (order: -1, 2048 bytes)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Dentry cache hash table entries: 16384 (order: 4, 65536 bytes)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Inode-cache hash table entries: 8192 (order: 3, 32768 bytes)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Writing ErrCtl register=00044e7f
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Readback ErrCtl register=00044e7f
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] Memory: 125552K/131072K available (3034K kernel code, 145K rwdata, 712K rodata, 196K init, 196K bss, 5520K reserved, 0K cma-reserved)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] NR_IRQS:256
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] intc: using register map from devicetree
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] CPU Clock: 580MHz
Sat Oct  9 11:41:21 2021 kern.crit kernel: [    0.000000] clocksource_probe: no matching clocksources found
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000000] clocksource: MIPS: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 6590553264 ns
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.000009] sched_clock: 32 bits at 290MHz, resolution 3ns, wraps every 7405115902ns
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.007523] Calibrating delay loop... 385.84 BogoMIPS (lpj=1929216)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.070038] pid_max: default: 32768 minimum: 301
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.074615] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.080952] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.093823] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.103324] futex hash table entries: 256 (order: -1, 3072 bytes)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.109352] pinctrl core: initialized pinctrl subsystem
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.115107] NET: Registered protocol family 16
Sat Oct  9 11:41:21 2021 kern.err kernel: [    0.224122] mt7620-pci 10140000.pcie: Port 0 N_FTS = 1b105000
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.379397] PCI host bridge /pcie@10140000 ranges:
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.383973]  MEM 0x0000000020000000..0x000000002fffffff
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.388996]   IO 0x0000000010160000..0x000000001016ffff
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.406145] mt7621_gpio 10000600.gpio: registering 32 gpios
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.411621] mt7621_gpio 10000600.gpio: registering 32 gpios
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.417100] mt7621_gpio 10000600.gpio: registering 32 gpios
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.423175] PCI host bridge to bus 0000:00
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.427123] pci_bus 0000:00: root bus resource [mem 0x20000000-0x2fffffff]
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.433705] pci_bus 0000:00: root bus resource [io  0xffffffff]
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.439427] pci_bus 0000:00: root bus resource [??? 0x00000000 flags 0x0]
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.445969] pci_bus 0000:00: No busn resource found for root bus, will use [bus 00-ff]
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.453670] pci 0000:00:00.0: [14c3:0801] type 01 class 0x060400
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.453714] pci 0000:00:00.0: reg 0x10: [mem 0x00000000-0x7fffffff]
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.453736] pci 0000:00:00.0: reg 0x14: [mem 0x00000000-0x0000ffff]
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.453808] pci 0000:00:00.0: supports D1
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.453825] pci 0000:00:00.0: PME# supported from D0 D1 D3hot
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.454075] pci 0000:00:00.0: bridge configuration invalid ([bus 00-00]), reconfiguring
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.461910] pci 0000:01:00.0: [14c3:7662] type 00 class 0x028000
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.461976] pci 0000:01:00.0: reg 0x10: [mem 0x00000000-0x000fffff 64bit]
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.462039] pci 0000:01:00.0: reg 0x30: [mem 0x00000000-0x0000ffff pref]
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.462122] pci 0000:01:00.0: PME# supported from D0 D3hot D3cold
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.462338] pci_bus 0000:01: busn_res: [bus 01-ff] end is updated to 01
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.462362] pci_bus 0000:00: busn_res: [bus 00-ff] end is updated to 01
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.462419] pci 0000:00:00.0: BAR 0: no space for [mem size 0x80000000]
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.468793] pci 0000:00:00.0: BAR 0: failed to assign [mem size 0x80000000]
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.475471] pci 0000:00:00.0: BAR 8: assigned [mem 0x20000000-0x200fffff]
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.482031] pci 0000:00:00.0: BAR 9: assigned [mem 0x20100000-0x201fffff pref]
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.488993] pci 0000:00:00.0: BAR 1: assigned [mem 0x20200000-0x2020ffff]
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.495565] pci 0000:01:00.0: BAR 0: assigned [mem 0x20000000-0x200fffff 64bit]
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.502615] pci 0000:01:00.0: BAR 6: assigned [mem 0x20100000-0x2010ffff pref]
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.509580] pci 0000:00:00.0: PCI bridge to [bus 01]
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.514362] pci 0000:00:00.0:   bridge window [mem 0x20000000-0x200fffff]
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.520920] pci 0000:00:00.0:   bridge window [mem 0x20100000-0x201fffff pref]
Sat Oct  9 11:41:21 2021 kern.err kernel: [    0.527898] pci 0000:00:00.0: card - bus=0x0, slot = 0x0 irq=0
Sat Oct  9 11:41:21 2021 kern.err kernel: [    0.533525] pci 0000:01:00.0: card - bus=0x1, slot = 0x0 irq=4
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.540141] clocksource: Switched to clocksource MIPS
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.546457] NET: Registered protocol family 2
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.551627] TCP established hash table entries: 1024 (order: 0, 4096 bytes)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.558316] TCP bind hash table entries: 1024 (order: 0, 4096 bytes)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.564503] TCP: Hash tables configured (established 1024 bind 1024)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.570696] UDP hash table entries: 256 (order: 0, 4096 bytes)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.576292] UDP-Lite hash table entries: 256 (order: 0, 4096 bytes)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.582630] NET: Registered protocol family 1
Sat Oct  9 11:41:21 2021 kern.debug kernel: [    0.586859] PCI: CLS 80 bytes, default 32
Sat Oct  9 11:41:21 2021 kern.warn kernel: [    0.592103] Crashlog allocated RAM at address 0x3f00000
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.613323] squashfs: version 4.0 (2009/01/31) Phillip Lougher
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.618907] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.631138] io scheduler noop registered
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.634874] io scheduler deadline registered (default)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.640785] gpio-export gpio_export: 2 gpio(s) exported
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.646016] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.653351] console [ttyS0] disabled
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.656782] 10000c00.uartlite: ttyS0 at MMIO 0x10000c00 (irq = 28, base_baud = 2500000) is a 16550A
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.665557] console [ttyS0] enabled
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.672546] bootconsole [early0] disabled
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.682083] spi-mt7621 10000b00.spi: sys_freq: 193333333
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.691264] m25p80 spi32766.0: using chunked io (size=32)
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.696754] m25p80 spi32766.0: XM25QH128C (16384 Kbytes)
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.702280] 7 ofpart partitions found on MTD device spi32766.0
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.708190] Creating 7 MTD partitions on "spi32766.0":
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.713416] 0x000000000000-0x000000030000 : "u-boot"
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.720217] 0x000000030000-0x000000040000 : "u-boot-env"
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.727338] 0x000000040000-0x000000050000 : "factory"
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.734272] 0x000000fd0000-0x000000fe0000 : "debug"
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.741020] 0x000000fe0000-0x000000ff0000 : "backup"
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.747761] 0x000000ff0000-0x000001000000 : "bdinfo"
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.754559] 0x000000050000-0x000000fd0000 : "firmware"
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.811106] 2 uimage-fw partitions found on MTD device firmware
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.817130] 0x000000050000-0x00000018fa1e : "kernel"
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.823696] 0x00000018fa1e-0x000000fd0000 : "rootfs"
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.830484] mtd: device 8 (rootfs) set to be root filesystem
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.836327] 1 squashfs-split partitions found on MTD device rootfs
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.842638] 0x000000980000-0x000000fd0000 : "rootfs_data"
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.859819] rt3050-esw 10110000.esw: link changed 0x00
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.866856] mtk_soc_eth 10100000.ethernet eth0: mediatek frame engine at 0xb0100000, irq 5
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.875825] mt7621_wdt 10000120.watchdog: Initialized
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.882421] NET: Registered protocol family 10
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.890099] NET: Registered protocol family 17
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.894774] bridge: automatic filtering via arp/ip/ip6tables has been deprecated. Update your scripts to load br_netfilter if you need this.
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    0.907629] Bridge firewalling registered
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.911713] 8021q: 802.1Q VLAN Support v1.8
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.926631] VFS: Mounted root (squashfs filesystem) readonly on device 31:8.
Sat Oct  9 11:41:21 2021 kern.info kernel: [    0.934933] Freeing unused kernel memory: 196K
Sat Oct  9 11:41:21 2021 user.info kernel: [    2.793060] init: Console is alive
Sat Oct  9 11:41:21 2021 user.info kernel: [    2.796718] init: - watchdog -
Sat Oct  9 11:41:21 2021 user.info kernel: [    5.376280] kmodloader: loading kernel modules from /etc/modules-boot.d/*
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.514407] usbcore: registered new interface driver usbfs
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.520119] usbcore: registered new interface driver hub
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.525672] usbcore: registered new device driver usb
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.536614] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.545059] ehci-platform: EHCI generic platform driver
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.560715] phy phy-10120000.usbphy.0: remote usb device wakeup disabled
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.567517] phy phy-10120000.usbphy.0: UTMI 16bit 30MHz
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.572852] ehci-platform 101c0000.ehci: EHCI Host Controller
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.578713] ehci-platform 101c0000.ehci: new USB bus registered, assigned bus number 1
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.586885] ehci-platform 101c0000.ehci: irq 26, io mem 0x101c0000
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.610178] ehci-platform 101c0000.ehci: USB 2.0 started, EHCI 1.00
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.617575] hub 1-0:1.0: USB hub found
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.621813] hub 1-0:1.0: 1 port detected
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.629107] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.637106] ohci-platform: OHCI generic platform driver
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.642715] ohci-platform 101c1000.ohci: Generic Platform OHCI controller
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.649632] ohci-platform 101c1000.ohci: new USB bus registered, assigned bus number 2
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.657785] ohci-platform 101c1000.ohci: irq 26, io mem 0x101c1000
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.725269] hub 2-0:1.0: USB hub found
Sat Oct  9 11:41:21 2021 kern.info kernel: [    5.729426] hub 2-0:1.0: 1 port detected
Sat Oct  9 11:41:21 2021 user.info kernel: [    5.738025] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
Sat Oct  9 11:41:21 2021 user.info kernel: [    5.746785] init: - preinit -
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    6.527767] random: procd: uninitialized urandom read (4 bytes read, 11 bits of entropy available)
Sat Oct  9 11:41:21 2021 user.warn kernel: [    6.566355] boot from spi
Sat Oct  9 11:41:21 2021 user.info kernel: [    6.708794] mount_root: loading kmods from internal overlay
Sat Oct  9 11:41:21 2021 user.info kernel: [    6.750755] kmodloader: loading kernel modules from //etc/modules-boot.d/*
Sat Oct  9 11:41:21 2021 user.info kernel: [    6.759245] kmodloader: done loading kernel modules from //etc/modules-boot.d/*
Sat Oct  9 11:41:21 2021 kern.info kernel: [    8.074559] usb 1-1: new high-speed USB device number 2 using ehci-platform
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    9.345149] jffs2: notice: (337) jffs2_build_xattr_subsystem: complete building xattr subsystem, 0 of xdatum (0 unchecked, 0 orphan) and 0 of xref (0 dead, 0 orphan) found.
Sat Oct  9 11:41:21 2021 user.info kernel: [    9.361492] block: attempting to load /tmp/jffs_cfg/upper/etc/config/fstab
Sat Oct  9 11:41:21 2021 user.info kernel: [    9.383741] block: extroot: not configured
Sat Oct  9 11:41:21 2021 kern.notice kernel: [    9.564398] jffs2: notice: (334) jffs2_build_xattr_subsystem: complete building xattr subsystem, 0 of xdatum (0 unchecked, 0 orphan) and 0 of xref (0 dead, 0 orphan) found.
Sat Oct  9 11:41:21 2021 user.info kernel: [   11.520241] block: attempting to load /tmp/jffs_cfg/upper/etc/config/fstab
Sat Oct  9 11:41:21 2021 user.info kernel: [   11.538119] block: extroot: not configured
Sat Oct  9 11:41:21 2021 user.info kernel: [   11.543547] mount_root: switching to jffs2 overlay
Sat Oct  9 11:41:21 2021 user.warn kernel: [   11.560831] urandom-seed: Seeding with /etc/urandom.seed
Sat Oct  9 11:41:21 2021 user.info kernel: [   13.168379] procd: - early -
Sat Oct  9 11:41:21 2021 user.info kernel: [   13.172143] procd: - watchdog -
Sat Oct  9 11:41:21 2021 user.info kernel: [   13.880684] procd: - watchdog -
Sat Oct  9 11:41:21 2021 user.info kernel: [   13.884185] procd: - ubus -
Sat Oct  9 11:41:21 2021 kern.notice kernel: [   14.005539] random: ubusd: uninitialized urandom read (4 bytes read, 23 bits of entropy available)
Sat Oct  9 11:41:21 2021 kern.notice kernel: [   14.311990] random: jshn: uninitialized urandom read (4 bytes read, 23 bits of entropy available)
Sat Oct  9 11:41:21 2021 kern.notice kernel: [   14.321189] random: ubusd: uninitialized urandom read (4 bytes read, 23 bits of entropy available)
Sat Oct  9 11:41:21 2021 kern.notice kernel: [   14.338824] random: ubusd: uninitialized urandom read (4 bytes read, 23 bits of entropy available)
Sat Oct  9 11:41:21 2021 kern.notice kernel: [   14.355035] random: ubusd: uninitialized urandom read (4 bytes read, 23 bits of entropy available)
Sat Oct  9 11:41:21 2021 kern.notice kernel: [   14.367652] random: ubusd: uninitialized urandom read (4 bytes read, 23 bits of entropy available)
Sat Oct  9 11:41:21 2021 kern.notice kernel: [   14.376876] random: ubusd: uninitialized urandom read (4 bytes read, 23 bits of entropy available)
Sat Oct  9 11:41:21 2021 kern.notice kernel: [   14.386238] random: ubusd: uninitialized urandom read (4 bytes read, 24 bits of entropy available)
Sat Oct  9 11:41:21 2021 kern.notice kernel: [   14.395568] random: ubusd: uninitialized urandom read (4 bytes read, 24 bits of entropy available)
Sat Oct  9 11:41:21 2021 user.info kernel: [   14.405434] procd: - init -
Sat Oct  9 11:41:21 2021 user.info kernel: [   16.095165] kmodloader: loading kernel modules from /etc/modules.d/*
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.414861] zram: Added device: zram0
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.425760] Initializing XFRM netlink socket
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.433304] NET: Registered protocol family 15
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.452619] tun: Universal TUN/TAP device driver, 1.6
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.457752] tun: (C) 1999-2004 Max Krasnyansky <maxk@qualcomm.com>
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.535839] l2tp_core: L2TP core driver, V2.0
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.545374] l2tp_netlink: L2TP netlink interface
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.629603] gre: GRE over IPv4 demultiplexor driver
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.637306] ip_gre: GRE over IPv4 tunneling driver
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.651707] ip6_tables: (C) 2000-2006 Netfilter Core Team
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.669639] Netfilter messages via NETLINK v0.30.
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.678474] ip_set: protocol 6
Sat Oct  9 11:41:21 2021 kern.warn kernel: [   16.741427] QCA Hy-Fi multicast installation successfully
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.825654] GobiNet: Quectel_Linux&Android_GobiNet_Driver_V1.6.1
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.831983] usbcore: registered new interface driver GobiNet
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.855187] u32 classifier
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.857940]     input device check on
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.861715]     Actions configured
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.868343] Mirror/redirect action on
Sat Oct  9 11:41:21 2021 kern.info kernel: [   16.886511] nf_conntrack version 0.5.0 (1964 buckets, 7856 max)
Sat Oct  9 11:41:21 2021 kern.warn kernel: [   18.002254] MT7628 module init
Sat Oct  9 11:41:21 2021 kern.warn kernel: [   18.058465] MT7628 AP Driver version-4.1.0.0
Sat Oct  9 11:41:21 2021 kern.warn kernel: [   19.306544] mt7628_set_ed_cca: TURN OFF EDCCA  mac 0x10618 = 0xd7083f0f, EDCCA_Status=0
Sat Oct  9 11:41:21 2021 kern.warn kernel: [   19.314766] mt7628 nlwifi attach
Sat Oct  9 11:41:21 2021 kern.warn kernel: [   20.213873] MT7612E module init
Sat Oct  9 11:41:21 2021 kern.warn kernel: [   20.238342] MT76x2 AP Driver version-3.0.4.0.P2.20160308
Sat Oct  9 11:41:21 2021 kern.warn kernel: [   20.773618] mt76x2_read_tx_alc_info_from_eeprom:: is_ePA_mode=0, ePA_type=3
Sat Oct  9 11:41:21 2021 kern.warn kernel: [   20.780741] mt76x2_get_external_lna_gain::LNA type=0x11, BLNAGain=0x0, ALNAGain0=0x0, ALNAGain1=0x0, ALNAGain2=0x0
Sat Oct  9 11:41:21 2021 kern.warn kernel: [   21.317534] mt7612 nlwifi attach
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.351569] cdc_ether 1-1:1.0 usb0: register 'cdc_ether' at usb-101c0000.ehci-1, CDC Ethernet Device, 02:0c:29:a3:9b:6d
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.362801] usbcore: registered new interface driver cdc_ether
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.390639] usbcore: registered new interface driver cdc_ncm
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.419058] usbcore: registered new interface driver cdc_wdm
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.438988] ip_tables: (C) 2000-2006 Netfilter Core Team
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.498848] ctnetlink v0.93: registering with nfnetlink.
Sat Oct  9 11:41:21 2021 kern.warn kernel: [   21.523967] nf_conntrack_rtsp v0.7 loading
Sat Oct  9 11:41:21 2021 kern.warn kernel: [   21.604186] nf_nat_rtsp v0.7 loading
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.625959] usbcore: registered new interface driver rndis_host
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.666912] usbcore: registered new interface driver usbserial
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.673037] usbcore: registered new interface driver usbserial_generic
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.679778] usbserial: USB Serial support registered for generic
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.709464] wireguard: WireGuard 1.0.20210219 loaded. See www.wireguard.com for information.
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.718138] wireguard: Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.774105] xt_time: kernel timezone is -0000
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.806933] PPP generic driver version 2.4.2
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.814144] PPP MPPE Compression module registered
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.821334] NET: Registered protocol family 24
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.828101] PPTP driver version 0.8.5
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.843652] l2tp_ppp: PPPoL2TP kernel driver, V2.0
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.851394] usbcore: registered new interface driver option
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.857160] usbserial: USB Serial support registered for GSM modem (1-port)
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.865201] option 1-1:1.2: GSM modem (1-port) converter detected
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.871763] usb 1-1: GSM modem (1-port) converter now attached to ttyUSB0
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.879162] option 1-1:1.3: GSM modem (1-port) converter detected
Sat Oct  9 11:41:21 2021 kern.info kernel: [   21.885708] usb 1-1: GSM modem (1-port) converter now attached to ttyUSB1
Sat Oct  9 11:41:21 2021 user.info kernel: [   22.002794] kmodloader: done loading kernel modules from /etc/modules.d/*
Sat Oct  9 11:41:22 2021 user.warn wireless[1118]: MSG_INFO: softapd start
Sat Oct  9 11:41:22 2021 daemon.debug zram_start: activating '/dev/zram0' for swapping (61 MegaBytes)
Sat Oct  9 11:41:22 2021 daemon.notice procd: /etc/rc.d/S15zram: zram_start: activating '/dev/zram0' for swapping (61 MegaBytes)
Sat Oct  9 11:41:22 2021 daemon.debug zram_reset: enforcing defaults via /sys/block/zram0/reset
Sat Oct  9 11:41:22 2021 daemon.notice procd: /etc/rc.d/S15zram: zram_reset: enforcing defaults via /sys/block/zram0/reset
Sat Oct  9 11:41:22 2021 kern.info kernel: [   25.279866] zram0: detected capacity change from 0 to 63963136
Sat Oct  9 11:41:22 2021 daemon.notice procd: /etc/rc.d/S15zram: Setting up swapspace version 1, size = 63959040 bytes
Sat Oct  9 11:41:22 2021 kern.info kernel: [   25.300098] Adding 62460k swap on /dev/zram0.  Priority:-1 extents:1 across:62460k SS
Sat Oct  9 11:41:23 2021 daemon.info gcom: gcom start
Sat Oct  9 11:41:23 2021 daemon.info hyfibr: hyfibr start
Sat Oct  9 11:41:25 2021 daemon.err insmod: module is already loaded - nf_nat_pptp
Sat Oct  9 11:41:25 2021 daemon.err insmod: module is already loaded - nf_nat_ftp
Sat Oct  9 11:41:25 2021 daemon.err insmod: module is already loaded - nf_nat_tftp
Sat Oct  9 11:41:25 2021 daemon.err insmod: module is already loaded - nf_nat_h323
Sat Oct  9 11:41:25 2021 daemon.err insmod: module is already loaded - nf_nat_sip
Sat Oct  9 11:41:25 2021 daemon.err insmod: module is already loaded - nf_nat_rtsp
Sat Oct  9 11:41:25 2021 user.notice vpn: firewall delete vpn policy
Sat Oct  9 11:41:26 2021 kern.info kernel: [   28.924764] rt3050-esw 10110000.esw: link changed 0x00
Sat Oct  9 11:41:26 2021 user.notice : Added device handler type: 8021ad
Sat Oct  9 11:41:26 2021 user.notice : Added device handler type: 8021q
Sat Oct  9 11:41:26 2021 user.notice : Added device handler type: macvlan
Sat Oct  9 11:41:26 2021 user.notice : Added device handler type: bridge
Sat Oct  9 11:41:26 2021 user.notice : Added device handler type: Network device
Sat Oct  9 11:41:26 2021 user.notice : Added device handler type: tunnel
Sat Oct  9 11:41:27 2021 user.notice wireless: procd[1]-->network[1293]-->wifi reload_legacy
Sat Oct  9 11:41:27 2021 daemon.notice procd: /etc/init.d/network: wireless: procd[1]-->network[1293]-->wifi reload_legacy
Sat Oct  9 11:41:28 2021 user.warn wireless[1118]: MSG_INFO: ubus_handle_notify ifname: wlan00, command: device, argu: up
Sat Oct  9 11:41:28 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set ra0, command: device, argu: up
Sat Oct  9 11:41:28 2021 user.warn wireless[1118]: MSG_INFO: ubus_handle_up ra0
Sat Oct  9 11:41:28 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set ra0, command: iface, argu: up
Sat Oct  9 11:41:29 2021 user.warn wireless[1118]: MSG_INFO: up interface ra0
Sat Oct  9 11:41:29 2021 user.warn wireless[1118]: MSG_INFO: wpa_init_auth: ra0 init wpa success, ssid: Cudy-DCE4
Sat Oct  9 11:41:29 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set ra0, command: hidden, argu: (null)
Sat Oct  9 11:41:29 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set ra0, command: isolate, argu: (null)
Sat Oct  9 11:41:29 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set ra0, command: lowrssi, argu: (null)
Sat Oct  9 11:41:29 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set ra0, command: maxsta, argu: 64
Sat Oct  9 11:41:29 2021 user.warn wireless[1118]: MSG_INFO: ra0: update GTK
Sat Oct  9 11:41:29 2021 user.notice wireless: iface { "iface": "wlan00", "action": "up" }
Sat Oct  9 11:41:29 2021 user.warn wireless[1118]: MSG_INFO: neighbor add bss:Cudy-DCE4 (B4:4B:D6:2F:DC:E4)
Sat Oct  9 11:41:29 2021 kern.info kernel: [   32.581567] device eth0.1 entered promiscuous mode
Sat Oct  9 11:41:29 2021 kern.info kernel: [   32.586442] device eth0 entered promiscuous mode
Sat Oct  9 11:41:30 2021 kern.info kernel: [   32.640402] br-lan: port 1(eth0.1) entered forwarding state
Sat Oct  9 11:41:30 2021 kern.info kernel: [   32.646154] br-lan: port 1(eth0.1) entered forwarding state
Sat Oct  9 11:41:30 2021 daemon.notice netifd: Interface 'lan' is enabled
Sat Oct  9 11:41:30 2021 daemon.notice netifd: Interface 'lan' is setting up now
Sat Oct  9 11:41:30 2021 daemon.notice netifd: Interface 'lan' is now up
Sat Oct  9 11:41:30 2021 daemon.notice netifd: Interface 'loopback' is enabled
Sat Oct  9 11:41:30 2021 daemon.notice netifd: Interface 'loopback' is setting up now
Sat Oct  9 11:41:30 2021 daemon.notice netifd: Interface 'loopback' is now up
Sat Oct  9 11:41:30 2021 daemon.notice netifd: bridge 'br-lan' link is up
Sat Oct  9 11:41:30 2021 daemon.notice netifd: Interface 'lan' has link connectivity 
Sat Oct  9 11:41:30 2021 daemon.notice netifd: Network device 'eth0' link is up
Sat Oct  9 11:41:30 2021 daemon.notice netifd: VLAN 'eth0.1' link is up
Sat Oct  9 11:41:30 2021 daemon.notice netifd: Network device 'lo' link is up
Sat Oct  9 11:41:30 2021 daemon.notice netifd: Interface 'loopback' has link connectivity 
Sat Oct  9 11:41:30 2021 daemon.info hyfibr: ubus init br-lan as relovr
Sat Oct  9 11:41:30 2021 kern.info kernel: [   33.137915] rt3050-esw 10110000.esw: link changed 0x04
Sat Oct  9 11:41:30 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set ra2, command: delwds, argu: 68:F7:28:55:C9:CA
Sat Oct  9 11:41:30 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set rai2, command: delwds, argu: 68:F7:28:55:C9:CA
Sat Oct  9 11:41:30 2021 kern.notice kernel: [   33.260717] gmac: port2 linkup
Sat Oct  9 11:41:31 2021 user.notice 4gup: check lan up 1
Sat Oct  9 11:41:31 2021 user.notice 4gup: start 2c7c:6026 for ttyUSB0
Sat Oct  9 11:41:31 2021 kern.info kernel: [   33.821895] rt3050-esw 10110000.esw: link changed 0x00
Sat Oct  9 11:41:31 2021 daemon.notice netifd: Network device 'ra0' link is up
Sat Oct  9 11:41:31 2021 kern.info kernel: [   33.859330] device ra0 entered promiscuous mode
Sat Oct  9 11:41:31 2021 kern.info kernel: [   33.864078] br-lan: port 2(ra0) entered forwarding state
Sat Oct  9 11:41:31 2021 kern.info kernel: [   33.869511] br-lan: port 2(ra0) entered forwarding state
Sat Oct  9 11:41:31 2021 user.warn wireless[1118]: MSG_INFO: ubus_event_cb set ra0 relay w2
Sat Oct  9 11:41:31 2021 daemon.info hyfibr: ubus set ra0 relay w2
Sat Oct  9 11:41:31 2021 user.notice 4gup: vendor quectel
Sat Oct  9 11:41:31 2021 user.warn wireless[1118]: MSG_INFO: ubus_handle_up ra2
Sat Oct  9 11:41:31 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set ra2, command: iface, argu: up
Sat Oct  9 11:41:31 2021 kern.notice kernel: [   34.279123] gmac: port2 linkdown
Sat Oct  9 11:41:32 2021 kern.info kernel: [   34.640198] br-lan: port 1(eth0.1) entered forwarding state
Sat Oct  9 11:41:32 2021 user.warn wireless[1118]: MSG_INFO: up interface ra2
Sat Oct  9 11:41:32 2021 user.warn wireless[1118]: MSG_INFO: wpa_init_auth: ra2 init wpa success, ssid: be2c6300a1c9932d6c0547e9d9a836fc
Sat Oct  9 11:41:32 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set ra2, command: hidden, argu: 1
Sat Oct  9 11:41:32 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set ra2, command: isolate, argu: (null)
Sat Oct  9 11:41:32 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set ra2, command: lowrssi, argu: (null)
Sat Oct  9 11:41:32 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set ra2, command: maxsta, argu: (null)
Sat Oct  9 11:41:32 2021 user.warn wireless[1118]: MSG_INFO: ra2: update GTK
Sat Oct  9 11:41:32 2021 user.notice wireless: iface { "iface": "wlan03", "action": "up" }
Sat Oct  9 11:41:32 2021 user.warn wireless[1118]: MSG_INFO: neighbor add bss:be2c6300a1c9932d6c0547e9d9a836fc (B6:4B:D6:2F:DC:E4)
Sat Oct  9 11:41:33 2021 kern.info kernel: [   35.860220] br-lan: port 2(ra0) entered forwarding state
Sat Oct  9 11:41:33 2021 daemon.info gcom: add device /dev/ttyUSB1
Sat Oct  9 11:41:33 2021 user.notice 4gup: 4g detect sim status
Sat Oct  9 11:41:33 2021 user.notice firewall: Reloading firewall due to ifup of lan (br-lan)
Sat Oct  9 11:41:33 2021 user.notice 4gup: AT+CFUN=1 -> AT+CFUN=1 OK
Sat Oct  9 11:41:34 2021 user.notice 4gup: AT+CGMR -> AT+CGMR EC200TEUHAR02A10M16  OK
Sat Oct  9 11:41:34 2021 user.notice 4gup: 4g cgmr EC200TEUHAR02A10M16
Sat Oct  9 11:41:34 2021 daemon.notice netifd: Network device 'ra2' link is up
Sat Oct  9 11:41:34 2021 kern.info kernel: [   36.756813] device ra2 entered promiscuous mode
Sat Oct  9 11:41:34 2021 kern.info kernel: [   36.761595] br-lan: port 3(ra2) entered forwarding state
Sat Oct  9 11:41:34 2021 kern.info kernel: [   36.767008] br-lan: port 3(ra2) entered forwarding state
Sat Oct  9 11:41:34 2021 user.warn wireless[1118]: MSG_INFO: ubus_event_cb set ra2 relay w2
Sat Oct  9 11:41:34 2021 daemon.info hyfibr: ubus set ra2 relay w2
Sat Oct  9 11:41:34 2021 user.notice 4gup: AT+QSIMDET? -> AT+QSIMDET? +QSIMDET: 1,1  OK
Sat Oct  9 11:41:34 2021 user.warn wireless[1118]: MSG_INFO: ubus_handle_notify ifname: wlan00, command: channel, argu: 0
Sat Oct  9 11:41:34 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set ra0, command: channel, argu: 0
Sat Oct  9 11:41:34 2021 user.warn wireless[1118]: MSG_INFO: ubus_handle_notify ifname: wlan10, command: device, argu: up
Sat Oct  9 11:41:34 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set rai0, command: device, argu: up
Sat Oct  9 11:41:35 2021 kern.warn kernel: [   37.298977] RTMPSetPhyMode: channel is out of range, use first channel=36 
Sat Oct  9 11:41:35 2021 user.notice 4gup: AT+QSIMSTAT? -> AT+QSIMSTAT? +QSIMSTAT: 0,0  OK
Sat Oct  9 11:41:35 2021 kern.info kernel: [   38.006839] rt3050-esw 10110000.esw: link changed 0x04
Sat Oct  9 11:41:35 2021 kern.notice kernel: [   38.290264] gmac: port2 linkup
Sat Oct  9 11:41:36 2021 daemon.err insmod: module is already loaded - nf_nat_pptp
Sat Oct  9 11:41:36 2021 kern.info kernel: [   38.760218] br-lan: port 3(ra2) entered forwarding state
Sat Oct  9 11:41:36 2021 daemon.err insmod: module is already loaded - nf_nat_ftp
Sat Oct  9 11:41:36 2021 daemon.err insmod: module is already loaded - nf_nat_tftp
Sat Oct  9 11:41:36 2021 daemon.err insmod: module is already loaded - nf_nat_h323
Sat Oct  9 11:41:36 2021 daemon.err insmod: module is already loaded - nf_nat_sip
Sat Oct  9 11:41:36 2021 daemon.err insmod: module is already loaded - nf_nat_rtsp
Sat Oct  9 11:41:36 2021 user.notice vpn: firewall delete vpn policy
Sat Oct  9 11:41:36 2021 user.warn wireless[1118]: MSG_INFO: ubus_handle_up rai0
Sat Oct  9 11:41:36 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set rai0, command: iface, argu: up
Sat Oct  9 11:41:37 2021 daemon.info dnsmasq[1832]: started, version 2.78 cachesize 150
Sat Oct  9 11:41:37 2021 daemon.info dnsmasq[1832]: DNS service limited to local subnets
Sat Oct  9 11:41:37 2021 daemon.info dnsmasq[1832]: compile time options: IPv6 GNU-getopt no-DBus no-i18n no-IDN DHCP DHCPv6 no-Lua TFTP conntrack ipset auth DNSSEC no-ID loop-detect inotify
Sat Oct  9 11:41:37 2021 daemon.info dnsmasq-dhcp[1832]: DHCP, IP range 192.168.10.100 -- 192.168.10.199, lease time 12h
Sat Oct  9 11:41:37 2021 daemon.info dnsmasq[1832]: using local addresses only for domain lan
Sat Oct  9 11:41:37 2021 daemon.warn dnsmasq[1832]: no servers found in /tmp/resolv.conf.auto, will retry
Sat Oct  9 11:41:37 2021 daemon.info dnsmasq[1832]: read /etc/hosts - 4 addresses
Sat Oct  9 11:41:37 2021 daemon.info dnsmasq[1832]: read /tmp/hosts/dhcp.cfg02411c - 0 addresses
Sat Oct  9 11:41:37 2021 daemon.info dnsmasq-dhcp[1832]: read /etc/ethers - 0 addresses
Sat Oct  9 11:41:37 2021 user.warn wireless[1118]: MSG_INFO: up interface rai0
Sat Oct  9 11:41:37 2021 user.warn wireless[1118]: MSG_INFO: wpa_init_auth: rai0 init wpa success, ssid: Cudy-DCE4-5G
Sat Oct  9 11:41:37 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set rai0, command: hidden, argu: (null)
Sat Oct  9 11:41:37 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set rai0, command: isolate, argu: (null)
Sat Oct  9 11:41:37 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set rai0, command: lowrssi, argu: (null)
Sat Oct  9 11:41:37 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set rai0, command: maxsta, argu: 64
Sat Oct  9 11:41:37 2021 user.warn wireless[1118]: MSG_INFO: rai0: update GTK
Sat Oct  9 11:41:37 2021 user.notice wireless: iface { "iface": "wlan10", "action": "up" }
Sat Oct  9 11:41:38 2021 user.warn wireless[1118]: MSG_INFO: neighbor add bss:Cudy-DCE4-5G (B4:4B:D6:2F:DC:E6)
Sat Oct  9 11:41:38 2021 user.notice 4gup: AT+CPIN? -> AT+CPIN? +CME ERROR: 10
Sat Oct  9 11:41:39 2021 daemon.notice netifd: Network device 'rai0' link is up
Sat Oct  9 11:41:39 2021 kern.info kernel: [   41.659527] device rai0 entered promiscuous mode
Sat Oct  9 11:41:39 2021 kern.info kernel: [   41.664430] br-lan: port 4(rai0) entered forwarding state
Sat Oct  9 11:41:39 2021 kern.info kernel: [   41.669931] br-lan: port 4(rai0) entered forwarding state
Sat Oct  9 11:41:39 2021 user.warn wireless[1118]: MSG_INFO: ubus_event_cb set rai0 relay w5
Sat Oct  9 11:41:39 2021 daemon.info hyfibr: ubus set rai0 relay w5
Sat Oct  9 11:41:39 2021 user.warn wireless[1118]: MSG_INFO: ubus_handle_up rai2
Sat Oct  9 11:41:39 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set rai2, command: iface, argu: up
Sat Oct  9 11:41:39 2021 user.warn wireless[1118]: MSG_INFO: up interface rai2
Sat Oct  9 11:41:39 2021 user.warn wireless[1118]: MSG_INFO: wpa_init_auth: rai2 init wpa success, ssid: be2c6300a1c9932d6c0547e9d9a836fc
Sat Oct  9 11:41:39 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set rai2, command: hidden, argu: 1
Sat Oct  9 11:41:39 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set rai2, command: isolate, argu: (null)
Sat Oct  9 11:41:39 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set rai2, command: lowrssi, argu: (null)
Sat Oct  9 11:41:39 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set rai2, command: maxsta, argu: (null)
Sat Oct  9 11:41:39 2021 user.warn wireless[1118]: MSG_INFO: rai2: update GTK
Sat Oct  9 11:41:39 2021 user.notice wireless: iface { "iface": "wlan13", "action": "up" }
Sat Oct  9 11:41:40 2021 daemon.err block: /dev/mtdblock8 is already mounted on /rom
Sat Oct  9 11:41:40 2021 daemon.err block: /dev/mtdblock9 is already mounted on /overlay
Sat Oct  9 11:41:40 2021 user.warn wireless[1118]: MSG_INFO: neighbor add bss:be2c6300a1c9932d6c0547e9d9a836fc (B6:4B:D6:2F:DC:E5)
Sat Oct  9 11:41:40 2021 user.warn wireless[1118]: MSG_INFO: ra0 change channel to 9
Sat Oct  9 11:41:41 2021 kern.info kernel: [   43.660182] br-lan: port 4(rai0) entered forwarding state
Sat Oct  9 11:41:41 2021 daemon.notice netifd: Network device 'rai2' link is up
Sat Oct  9 11:41:41 2021 kern.info kernel: [   44.029691] device rai2 entered promiscuous mode
Sat Oct  9 11:41:41 2021 kern.info kernel: [   44.034553] br-lan: port 5(rai2) entered forwarding state
Sat Oct  9 11:41:41 2021 kern.info kernel: [   44.040075] br-lan: port 5(rai2) entered forwarding state
Sat Oct  9 11:41:41 2021 user.warn wireless[1118]: MSG_INFO: ubus_event_cb set rai2 relay w5
Sat Oct  9 11:41:41 2021 daemon.info hyfibr: ubus set rai2 relay w5
Sat Oct  9 11:41:41 2021 user.warn wireless[1118]: MSG_INFO: ubus_handle_notify ifname: wlan10, command: channel, argu: 0
Sat Oct  9 11:41:41 2021 user.warn wireless[1118]: MSG_INFO: nlwifi set rai0, command: channel, argu: 0
Sat Oct  9 11:41:43 2021 daemon.err insmod: module is already loaded - xt_multiport
Sat Oct  9 11:41:43 2021 daemon.err insmod: module is already loaded - xt_connmark
Sat Oct  9 11:41:43 2021 daemon.err insmod: module is already loaded - xt_comment
Sat Oct  9 11:41:43 2021 daemon.err insmod: module is already loaded - xt_length
Sat Oct  9 11:41:43 2021 kern.info kernel: [   46.030229] br-lan: port 5(rai2) entered forwarding state
Sat Oct  9 11:41:44 2021 user.warn wireless[1118]: MSG_INFO: rai0 change channel to 40
Sat Oct  9 11:41:44 2021 user.warn wireless[1118]: MSG_INFO: ra0 do auto htbw for apcnt 12, dirtyness 68
Sat Oct  9 11:41:46 2021 daemon.err insmod: module is already loaded - xt_multiport
Sat Oct  9 11:41:46 2021 daemon.err insmod: module is already loaded - xt_connmark
Sat Oct  9 11:41:46 2021 daemon.err insmod: module is already loaded - xt_comment
Sat Oct  9 11:41:46 2021 daemon.err insmod: module is already loaded - xt_length
Sat Oct  9 11:41:48 2021 kern.notice kernel: [   50.650243] random: nonblocking pool is initialized
Sat Oct  9 11:41:48 2021 user.info : htpdate version 1.1.1 started
Sat Oct  9 11:41:51 2021 daemon.notice cmagent: cmagent start
Sat Oct  9 11:41:51 2021 daemon.notice cmagent: mqtt id CD63731415|000000000000
Sat Oct  9 11:41:51 2021 daemon.notice procd: /etc/rc.d/S90zerotier: disabled in config
Sat Oct  9 11:41:51 2021 user.warn wireless[1118]: MSG_INFO: rai0 do auto htbw for apcnt 9, dirtyness 99
Sat Oct  9 11:41:52 2021 daemon.info pingcheck[2734]: Configured interface 'wan' interval 10 timeout 120 host @dns ICMP (80)
Sat Oct  9 11:41:52 2021 daemon.info pingcheck[2734]: Configured interface 'wisp' interval 10 timeout 120 host @dns ICMP (80)
Sat Oct  9 11:41:52 2021 daemon.info pingcheck[2734]: Configured interface '4g' interval 10 timeout 120 host @dns ICMP (80)
Sat Oct  9 11:41:52 2021 daemon.info pingcheck[2734]: Interface 'wan' not found or error
Sat Oct  9 11:41:52 2021 daemon.info pingcheck[2734]: Interface 'wisp' not found or error
Sat Oct  9 11:41:52 2021 daemon.info pingcheck[2734]: Interface '4g' not up
Sat Oct  9 11:41:52 2021 daemon.info dnsmasq-dhcp[1832]: DHCPDISCOVER(br-lan) 192.168.0.34 68:f7:28:55:c9:ca 
Sat Oct  9 11:41:52 2021 daemon.info dnsmasq-dhcp[1832]: DHCPOFFER(br-lan) 192.168.10.117 68:f7:28:55:c9:ca 
Sat Oct  9 11:41:52 2021 daemon.info dnsmasq-dhcp[1832]: DHCPREQUEST(br-lan) 192.168.10.117 68:f7:28:55:c9:ca 
Sat Oct  9 11:41:52 2021 daemon.info dnsmasq-dhcp[1832]: DHCPACK(br-lan) 192.168.10.117 68:f7:28:55:c9:ca brot
Sat Oct  9 11:41:53 2021 daemon.notice cmagent: connect to mqtt server ok
Sat Oct  9 11:41:53 2021 kern.info kernel: [   55.725406] S95done (2767): drop_caches: 3
Sat Oct  9 11:41:54 2021 daemon.notice procd: /etc/rc.d/S96led: setting up led LAN1
Sat Oct  9 11:41:55 2021 daemon.notice procd: /etc/rc.d/S96led: setting up led LAN2
Sat Oct  9 11:41:55 2021 daemon.notice procd: /etc/rc.d/S96led: setting up led LAN3
Sat Oct  9 11:41:55 2021 daemon.notice procd: /etc/rc.d/S96led: setting up led LAN4
Sat Oct  9 11:41:57 2021 daemon.info cmagent[2657]: connection: 000000000000 connected
Sat Oct  9 11:41:57 2021 user.notice ddns-scripts[2766]: myddns: PID '2766' started at 2021-10-09 10:41
Sat Oct  9 11:41:58 2021 user.warn ddns-scripts[2766]: myddns: Service section disabled! - TERMINATE
Sat Oct  9 11:41:58 2021 user.warn ddns-scripts[2766]: myddns: PID '2766' exit WITH ERROR '1' at 2021-10-09 10:41
Sat Oct  9 11:41:58 2021 daemon.notice procd: /etc/rc.d/S99smp: run smp.sh....
Sat Oct  9 11:42:00 2021 daemon.info procd: - init complete -
Sat Oct  9 11:42:00 2021 daemon.info cmagent[2657]: clients: 000000000000 connected
Thu Sep 15 10:15:24 2022 user.info : htpdate version 1.1.1 started
Thu Sep 15 10:15:42 2022 user.notice luci: network dhcp odhcpd luci
Thu Sep 15 10:15:43 2022 kern.info kernel: [  102.243936] rt3050-esw 10110000.esw: link changed 0x00
Thu Sep 15 10:15:43 2022 kern.notice kernel: [  102.249235] gmac: port2 linkdown
Thu Sep 15 10:15:44 2022 user.notice wireless: procd[1]-->sh[3278]-->network[3287]-->wifi reload_legacy
Thu Sep 15 10:15:44 2022 user.warn wireless[1118]: MSG_INFO: down interface ra0
Thu Sep 15 10:15:44 2022 daemon.notice netifd: Network device 'ra0' link is down
Thu Sep 15 10:15:44 2022 kern.info kernel: [  102.825322] br-lan: port 2(ra0) entered disabled state
Thu Sep 15 10:15:44 2022 user.warn wireless[1118]: MSG_INFO: down interface ra2
Thu Sep 15 10:15:44 2022 daemon.notice netifd: Network device 'ra2' link is down
Thu Sep 15 10:15:44 2022 kern.info kernel: [  102.981916] br-lan: port 3(ra2) entered disabled state
Thu Sep 15 10:15:44 2022 user.notice wireless: iface { "iface": "wlan00", "action": "down" }
Thu Sep 15 10:15:44 2022 user.notice wireless: iface { "iface": "wlan03", "action": "down" }
Thu Sep 15 10:15:44 2022 user.warn wireless[1118]: MSG_INFO: down interface rai0
Thu Sep 15 10:15:44 2022 daemon.notice netifd: Network device 'rai0' link is down
Thu Sep 15 10:15:44 2022 kern.info kernel: [  103.249660] br-lan: port 4(rai0) entered disabled state
Thu Sep 15 10:15:44 2022 user.notice wireless: iface { "iface": "wlan10", "action": "down" }
Thu Sep 15 10:15:44 2022 user.warn wireless[1118]: MSG_INFO: down interface rai2
Thu Sep 15 10:15:44 2022 daemon.notice netifd: Network device 'rai2' link is down
Thu Sep 15 10:15:44 2022 kern.info kernel: [  103.399776] br-lan: port 5(rai2) entered disabled state
Thu Sep 15 10:15:45 2022 user.notice wireless: iface { "iface": "wlan13", "action": "down" }
Thu Sep 15 10:15:45 2022 user.warn wireless[1118]: MSG_INFO: ubus_handle_notify ifname: wlan00, command: device, argu: up
Thu Sep 15 10:15:45 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set ra0, command: device, argu: up
Thu Sep 15 10:15:45 2022 user.warn wireless[1118]: MSG_INFO: ubus_handle_up ra0
Thu Sep 15 10:15:45 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set ra0, command: iface, argu: up
Thu Sep 15 10:15:45 2022 user.warn wireless[1118]: MSG_INFO: up interface ra0
Thu Sep 15 10:15:45 2022 daemon.notice netifd: Network device 'ra0' link is up
Thu Sep 15 10:15:45 2022 user.warn wireless[1118]: MSG_INFO: wpa_init_auth: ra0 init wpa success, ssid: Cudy-DCE4
Thu Sep 15 10:15:45 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set ra0, command: hidden, argu: (null)
Thu Sep 15 10:15:45 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set ra0, command: isolate, argu: (null)
Thu Sep 15 10:15:45 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set ra0, command: lowrssi, argu: (null)
Thu Sep 15 10:15:45 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set ra0, command: maxsta, argu: 64
Thu Sep 15 10:15:45 2022 user.warn wireless[1118]: MSG_INFO: ra0: update GTK
Thu Sep 15 10:15:45 2022 user.notice wireless: iface { "iface": "wlan00", "action": "up" }
Thu Sep 15 10:15:45 2022 user.warn wireless[1118]: MSG_INFO: neighbor add bss:Cudy-DCE4 (B4:4B:D6:2F:DC:E4)
Thu Sep 15 10:15:45 2022 user.warn wireless[1118]: MSG_INFO: ubus_handle_up ra2
Thu Sep 15 10:15:45 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set ra2, command: iface, argu: up
Thu Sep 15 10:15:46 2022 user.warn wireless[1118]: MSG_INFO: up interface ra2
Thu Sep 15 10:15:46 2022 daemon.notice netifd: Network device 'ra2' link is up
Thu Sep 15 10:15:46 2022 kern.info kernel: [  104.618102] br-lan: port 3(ra2) entered forwarding state
Thu Sep 15 10:15:46 2022 kern.info kernel: [  104.623613] br-lan: port 3(ra2) entered forwarding state
Thu Sep 15 10:15:46 2022 user.warn wireless[1118]: MSG_INFO: wpa_init_auth: ra2 init wpa success, ssid: be2c6300a1c9932d6c0547e9d9a836fc
Thu Sep 15 10:15:46 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set ra2, command: hidden, argu: 1
Thu Sep 15 10:15:46 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set ra2, command: isolate, argu: (null)
Thu Sep 15 10:15:46 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set ra2, command: lowrssi, argu: (null)
Thu Sep 15 10:15:46 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set ra2, command: maxsta, argu: (null)
Thu Sep 15 10:15:46 2022 user.warn wireless[1118]: MSG_INFO: ra2: update GTK
Thu Sep 15 10:15:46 2022 user.notice wireless: iface { "iface": "wlan03", "action": "up" }
Thu Sep 15 10:15:46 2022 user.warn wireless[1118]: MSG_INFO: neighbor add bss:be2c6300a1c9932d6c0547e9d9a836fc (B6:4B:D6:2F:DC:E4)
Thu Sep 15 10:15:46 2022 kern.info kernel: [  104.860459] br-lan: port 2(ra0) entered forwarding state
Thu Sep 15 10:15:46 2022 kern.info kernel: [  104.865924] br-lan: port 2(ra0) entered forwarding state
Thu Sep 15 10:15:46 2022 user.warn wireless[1118]: MSG_INFO: ubus_handle_notify ifname: wlan00, command: channel, argu: 0
Thu Sep 15 10:15:46 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set ra0, command: channel, argu: 0
Thu Sep 15 10:15:46 2022 user.warn wireless[1118]: MSG_INFO: ubus_handle_notify ifname: wlan10, command: device, argu: up
Thu Sep 15 10:15:46 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set rai0, command: device, argu: up
Thu Sep 15 10:15:47 2022 user.warn wireless[1118]: MSG_INFO: ubus_handle_up rai0
Thu Sep 15 10:15:47 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set rai0, command: iface, argu: up
Thu Sep 15 10:15:47 2022 user.warn wireless[1118]: MSG_INFO: up interface rai0
Thu Sep 15 10:15:47 2022 kern.info kernel: [  106.150445] br-lan: port 4(rai0) entered forwarding state
Thu Sep 15 10:15:47 2022 kern.info kernel: [  106.155966] br-lan: port 4(rai0) entered forwarding state
Thu Sep 15 10:15:47 2022 daemon.notice netifd: Network device 'rai0' link is up
Thu Sep 15 10:15:47 2022 user.warn wireless[1118]: MSG_INFO: wpa_init_auth: rai0 init wpa success, ssid: Cudy-DCE4-5G
Thu Sep 15 10:15:47 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set rai0, command: hidden, argu: (null)
Thu Sep 15 10:15:47 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set rai0, command: isolate, argu: (null)
Thu Sep 15 10:15:47 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set rai0, command: lowrssi, argu: (null)
Thu Sep 15 10:15:47 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set rai0, command: maxsta, argu: 64
Thu Sep 15 10:15:47 2022 user.warn wireless[1118]: MSG_INFO: rai0: update GTK
Thu Sep 15 10:15:47 2022 user.notice wireless: iface { "iface": "wlan10", "action": "up" }
Thu Sep 15 10:15:47 2022 kern.info kernel: [  106.411017] rt3050-esw 10110000.esw: link changed 0x04
Thu Sep 15 10:15:47 2022 kern.notice kernel: [  106.416279] gmac: port2 linkup
Thu Sep 15 10:15:48 2022 user.warn wireless[1118]: MSG_INFO: neighbor add bss:Cudy-DCE4-5G (B4:4B:D6:2F:DC:E6)
Thu Sep 15 10:15:48 2022 kern.info kernel: [  106.620180] br-lan: port 3(ra2) entered forwarding state
Thu Sep 15 10:15:48 2022 kern.info kernel: [  106.860213] br-lan: port 2(ra0) entered forwarding state
Thu Sep 15 10:15:48 2022 user.warn wireless[1118]: MSG_INFO: ubus_handle_up rai2
Thu Sep 15 10:15:48 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set rai2, command: iface, argu: up
Thu Sep 15 10:15:48 2022 user.warn wireless[1118]: MSG_INFO: up interface rai2
Thu Sep 15 10:15:48 2022 kern.info kernel: [  107.249769] br-lan: port 5(rai2) entered forwarding state
Thu Sep 15 10:15:48 2022 kern.info kernel: [  107.255361] br-lan: port 5(rai2) entered forwarding state
Thu Sep 15 10:15:48 2022 daemon.notice netifd: Network device 'rai2' link is up
Thu Sep 15 10:15:48 2022 user.warn wireless[1118]: MSG_INFO: wpa_init_auth: rai2 init wpa success, ssid: be2c6300a1c9932d6c0547e9d9a836fc
Thu Sep 15 10:15:48 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set rai2, command: hidden, argu: 1
Thu Sep 15 10:15:48 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set rai2, command: isolate, argu: (null)
Thu Sep 15 10:15:48 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set rai2, command: lowrssi, argu: (null)
Thu Sep 15 10:15:48 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set rai2, command: maxsta, argu: (null)
Thu Sep 15 10:15:48 2022 user.warn wireless[1118]: MSG_INFO: rai2: update GTK
Thu Sep 15 10:15:48 2022 user.notice wireless: iface { "iface": "wlan13", "action": "up" }
Thu Sep 15 10:15:48 2022 user.warn wireless[1118]: MSG_INFO: neighbor add bss:be2c6300a1c9932d6c0547e9d9a836fc (B6:4B:D6:2F:DC:E5)
Thu Sep 15 10:15:49 2022 user.warn wireless[1118]: MSG_INFO: ubus_handle_notify ifname: wlan10, command: channel, argu: 0
Thu Sep 15 10:15:49 2022 user.warn wireless[1118]: MSG_INFO: nlwifi set rai0, command: channel, argu: 0
Thu Sep 15 10:15:49 2022 kern.info kernel: [  108.150207] br-lan: port 4(rai0) entered forwarding state
Thu Sep 15 10:15:50 2022 kern.info kernel: [  109.250207] br-lan: port 5(rai2) entered forwarding state
Thu Sep 15 10:15:52 2022 user.warn wireless[1118]: MSG_INFO: rai0 change channel to 36
Thu Sep 15 10:15:53 2022 user.warn wireless[1118]: MSG_INFO: ra0 change channel to 9
Thu Sep 15 10:15:57 2022 user.warn wireless[1118]: MSG_INFO: ra0 do auto htbw for apcnt 12, dirtyness 68
Thu Sep 15 10:15:59 2022 user.warn wireless[1118]: MSG_INFO: rai0 do auto htbw for apcnt 9, dirtyness 35
```