### PR TITLE
[21.02] base-files: add support for heartbeat led trigger

### DIFF
--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -418,6 +418,15 @@ ucidef_set_led_default() {
 	json_select ..
 }
 
+ucidef_set_led_heartbeat() {
+	_ucidef_set_led_common "$1" "$2" "$3"
+
+	json_add_string trigger heartbeat
+	json_select ..
+
+	json_select ..
+}
+
 ucidef_set_led_gpio() {
 	local gpio="$4"
 	local inverted="$5"


### PR DESCRIPTION
This patch adds support for creation heartbeat led trigger with, for example, this command:

	ucidef_set_led_heartbeat "..." "..." "..."

from /etc/board.d/01_leds.

___

This is already included in the master branch and ``openwrt-22.03`` branch. It would be helpful to have it also in OpenWrt 21.02. Cherry-picked from 66071729a27919e555752fce25210b1b035eb319