### PR TITLE
bcm27xx: fix sound-soc-justboom-* and sound-soc-hifiberry-digi packages

### DIFF
--- a/target/linux/bcm27xx/modules/sound.mk
+++ b/target/linux/bcm27xx/modules/sound.mk
@@ -806,17 +806,23 @@ define KernelPackage/sound-soc-justboom-both
   KCONFIG:= \
     CONFIG_SND_BCM2708_SOC_JUSTBOOM_BOTH \
     CONFIG_SND_SOC_PCM512x \
-    CONFIG_SND_SOC_WM8804
+    CONFIG_SND_SOC_PCM512x_I2C \
+    CONFIG_SND_SOC_WM8804 \
+    CONFIG_SND_SOC_WM8804_I2C
   FILES:= \
     $(LINUX_DIR)/sound/soc/bcm/snd-soc-justboom-both.ko \
     $(LINUX_DIR)/sound/soc/codecs/snd-soc-pcm512x.ko \
-    $(LINUX_DIR)/sound/soc/codecs/snd-soc-wm8804.ko
-  AUTOLOAD:=$(call AutoLoad,68,snd-soc-pcm512x snd-soc-wm8804 \
+    $(LINUX_DIR)/sound/soc/codecs/snd-soc-pcm512x-i2c.ko \
+    $(LINUX_DIR)/sound/soc/codecs/snd-soc-wm8804.ko \
+    $(LINUX_DIR)/sound/soc/codecs/snd-soc-wm8804-i2c.ko
+  AUTOLOAD:=$(call AutoLoad,68,snd-soc-pcm512x-i2c snd-soc-pcm512x \
+    snd-soc-wm8804-i2c snd-soc-wm8804 \
     snd-soc-justboom-both)
   DEPENDS:= \
     kmod-sound-soc-bcm2835-i2s \
     +kmod-sound-soc-rpi-wm8804-soundcard \
-    +kmod-i2c-bcm2835
+    +kmod-i2c-bcm2835 \
+    +kmod-regmap-i2c
   $(call AddDepends/sound)
 endef
 
@@ -831,14 +837,18 @@ define KernelPackage/sound-soc-justboom-dac
   TITLE:=Support for JustBoom DAC
   KCONFIG:= \
     CONFIG_SND_BCM2708_SOC_JUSTBOOM_DAC \
-    CONFIG_SND_SOC_PCM512x
+    CONFIG_SND_SOC_PCM512x \
+    CONFIG_SND_SOC_PCM512x_I2C
   FILES:= \
     $(LINUX_DIR)/sound/soc/bcm/snd-soc-justboom-dac.ko \
-    $(LINUX_DIR)/sound/soc/codecs/snd-soc-pcm512x.ko
-  AUTOLOAD:=$(call AutoLoad,68,snd-soc-pcm512x snd-soc-justboom-dac)
+    $(LINUX_DIR)/sound/soc/codecs/snd-soc-pcm512x.ko \
+    $(LINUX_DIR)/sound/soc/codecs/snd-soc-pcm512x-i2c.ko
+  AUTOLOAD:=$(call AutoLoad,68,snd-soc-pcm512x-i2c snd-soc-pcm512x \
+    snd-soc-justboom-dac)
   DEPENDS:= \
     kmod-sound-soc-bcm2835-i2s \
-    +kmod-i2c-bcm2835
+    +kmod-i2c-bcm2835 \
+    +kmod-regmap-i2c
   $(call AddDepends/sound)
 endef
 
@@ -853,14 +863,17 @@ define KernelPackage/sound-soc-justboom-digi
   TITLE:=Support for JustBoom Digi
   KCONFIG:= \
     CONFIG_SND_BCM2708_SOC_JUSTBOOM_DIGI \
-    CONFIG_SND_SOC_WM8804
+    CONFIG_SND_SOC_WM8804 \
+    CONFIG_SND_SOC_WM8804_I2C
   FILES:= \
-    $(LINUX_DIR)/sound/soc/codecs/snd-soc-wm8804.ko
-  AUTOLOAD:=$(call AutoLoad,68,snd-soc-wm8804)
+    $(LINUX_DIR)/sound/soc/codecs/snd-soc-wm8804.ko \
+    $(LINUX_DIR)/sound/soc/codecs/snd-soc-wm8804-i2c.ko
+  AUTOLOAD:=$(call AutoLoad,68,snd-soc-wm8804-i2c snd-soc-wm8804)
   DEPENDS:= \
     kmod-sound-soc-bcm2835-i2s \
     +kmod-sound-soc-rpi-wm8804-soundcard \
-    +kmod-i2c-bcm2835
+    +kmod-i2c-bcm2835 \
+    +kmod-regmap-i2c
   $(call AddDepends/sound)
 endef
 

--- a/target/linux/bcm27xx/modules/sound.mk
+++ b/target/linux/bcm27xx/modules/sound.mk
@@ -660,14 +660,17 @@ define KernelPackage/sound-soc-hifiberry-digi
   TITLE:=Support for HifiBerry Digi / Digi+ / Digi+ Pro
   KCONFIG:= \
     CONFIG_SND_BCM2708_SOC_HIFIBERRY_DIGI \
-    CONFIG_SND_SOC_WM8804
+    CONFIG_SND_SOC_WM8804 \
+    CONFIG_SND_SOC_WM8804_I2C
   FILES:= \
-    $(LINUX_DIR)/sound/soc/codecs/snd-soc-wm8804.ko
-  AUTOLOAD:=$(call AutoLoad,68,snd-soc-wm8804)
+    $(LINUX_DIR)/sound/soc/codecs/snd-soc-wm8804.ko \
+    $(LINUX_DIR)/sound/soc/codecs/snd-soc-wm8804-i2c.ko
+  AUTOLOAD:=$(call AutoLoad,68,snd-soc-wm8804 snd-soc-wm8804-i2c)
   DEPENDS:= \
     kmod-sound-soc-bcm2835-i2s \
     +kmod-sound-soc-rpi-wm8804-soundcard \
-    +kmod-i2c-bcm2835
+    +kmod-i2c-bcm2835 \
+    +kmod-regmap-i2c
   $(call AddDepends/sound)
 endef
 


### PR DESCRIPTION
Fix `sound-soc-justboom-both`, `sound-soc-justboom-dac`, `sound-soc-justboom-digi` and `sound-soc-hifiberry-digi` packages.

Changes:
* Add `snd-soc-wm8804-i2c` and/or `snd-soc-pcm512x-i2c` kernel module.
* Add `kmod-regmap-i2c` package dependency.