### PR TITLE
ath79: switch to 5.15 as default kernel

### DIFF
--- a/target/linux/ath79/Makefile
+++ b/target/linux/ath79/Makefile
@@ -8,8 +8,7 @@ SUBTARGETS:=generic mikrotik nand tiny
 
 FEATURES:=ramdisk squashfs usbgadget
 
-KERNEL_PATCHVER:=5.10
-KERNEL_TESTING_PATCHVER:=5.15
+KERNEL_PATCHVER:=5.15
 
 include $(INCLUDE_DIR)/target.mk
 


### PR DESCRIPTION
The 5.15 kernel has new interesting features like MGLRU. Most of the targets already have added support for testing kernel 5.15 since April
2022. Set 5.15 as default for all subtargets.

Testing support was added here:
- ae6bfb7d67c1 ("ath79: tiny: add 5.15 support for tiny subtarget")
- 9a0155bc4fa3 ("ath79: add 5.15 support for generic subtarget")
- 5af9aafabbc0 ("ath79: mikrotik: add 5.15 support for mikrotik subtarget")
- f3fa68e5153b ("ath79: nand: add 5.15 support for nand subtarget")

Tested on:
- Nanostation M5 XM (tiny)
- TP-Link EAP-225 Outdoor (generic)
- TP-Link CPE210 (generic)
