### PR TITLE
ipq40xx: fix power LED colour ID in Netgear WAC510 dts

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-wac510.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-wac510.dts
@@ -114,7 +114,7 @@
 
 		led_power_green: led-1 {
 			label = "green:power";
-			color = <LED_COLOR_ID_AMBER>;
+			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_POWER;
 			gpios = <&ssr 5 GPIO_ACTIVE_LOW>;
 		};


### PR DESCRIPTION
led_power_green color ID in dts is mistakenly set to amber so lets correct it by setting it to green

Signed-off-by: Andrew Sim <andrewsimz@gmail.com>
