### PR TITLE
ramips: add missing WAN LED for Xiaomi Mi Router 4A / 4C

### DIFF
--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4.dtsi
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4.dtsi
@@ -30,6 +30,11 @@
 			label = "yellow:power";
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
 		};
+
+		wan {
+			label = "blue:wan";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
 	};
 
 	keys {
@@ -93,7 +98,7 @@
 
 &state_default {
 	gpio {
-		groups = "gpio", "wdt", "wled_an";
+		groups = "gpio", "refclk", "wdt", "wled_an";
 		function = "gpio";
 	};
 };

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -144,6 +144,13 @@ wavlink,wl-wn578a2)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x8"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
+xiaomi,mi-router-4a-100m|\
+xiaomi,mi-router-4a-100m-intl)
+	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x01"
+	;;
+xiaomi,mi-router-4c)
+	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x02"
+	;;
 zbtlink,zbt-we1226)
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan" "wlan0"
 	ucidef_set_led_switch "lan1" "LAN1" "green:lan1" "switch0" "0x01"


### PR DESCRIPTION
The blue WAN LED connected to GPIO37 is missing, so re-add it.
Tested on MI 4C.