### PR TITLE
tools/cmake: fix download url with make variables

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -8,12 +8,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
 PKG_VERSION:=3.24.1
+PKG_VERSION_MAJOR:=$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:kitware:cmake
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Kitware/CMake/releases/download/v$(PKG_VERSION)/ \
-		https://cmake.org/files/v3.24/
+		https://cmake.org/files/v$(PKG_VERSION_MAJOR)/
 PKG_HASH:=4931e277a4db1a805f13baa7013a7757a0cbfe5b7932882925c7061d9d1fa82b
 
 HOST_BUILD_PARALLEL:=1


### PR DESCRIPTION
Use a make variable pattern for the url
so that only one version number needs to be changed when version is bumped.

Signed-off-by: Michael Pratt <mcpratt@pm.me>