### PR TITLE
build: touch stampfile after subtarget run

### DIFF
--- a/include/subdir.mk
+++ b/include/subdir.mk
@@ -16,6 +16,7 @@ subtarget-default = $(filter-out ., \
 
 define subtarget
   $(call warn_eval,$(1),t,T,$(1)/$(2): $($(1)/) $(foreach bd,$(call subtarget-default,$(1),$(2)),$(1)/$(bd)/$(2)))
+	-touch $($(1)/stamp-$(2))
 
 endef
 


### PR DESCRIPTION
Each individual build directory has stampfiles
that are touched as part of their build process
when each stage of the build process completes.

However, the subtargets themselves do not touch
the stampfiles that are defined for them.
They are only touched when a target that has
that stampfile as a prerequisite is ran.

For example,
"make tools/compile" will not touch .tools_compile_... but "make toolchain/compile" will,
after each build directory in tools/ is checked again, because the stampfile is a prerequisite,
not the tools/compile target itself.

This makes each subtarget touch a stampfile, if defined, when the subtarget has completed successfully.

A small amount of build time is expected to be saved.

Signed-off-by: Michael Pratt <mcpratt@pm.me>