### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -3,6 +3,9 @@ name: Test Formalities
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Test Formalities

--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -7,6 +7,10 @@ on:
       - 'include/kernel-*'
       - 'package/kernel/**'
       - 'target/linux/generic/**'
+
+permissions:
+  contents: read
+
 jobs:
   determine_targets:
     name: Set targets

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,8 +2,15 @@ name: 'Pull Request Labeler'
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   labeler:
+    permissions:
+      contents: read # to determine modified files (actions/labeler)
+      pull-requests: write # to add labels to PRs (actions/labeler)
+
     name: Pull Request Labeler
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -6,6 +6,9 @@ on:
       - 'tools/**'
       - '.github/workflows/tools.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: tools-${{ matrix.os }}


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.