### PR TITLE
mediatek: disable unsupported background radar detection on totolink-…

### DIFF
--- a/target/linux/mediatek/dts/mt7622-totolink-a8000ru.dts
+++ b/target/linux/mediatek/dts/mt7622-totolink-a8000ru.dts
@@ -105,10 +105,12 @@
 };
 
 &slot0 {
-	mt7615@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x5000>;
 		ieee80211-freq-limit = <5490000 6000000>;
+		mediatek,disable-radar-background;
 	};
 };
 
@@ -119,10 +121,12 @@
 };
 
 &slot1 {
-	mt7615@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x10000>;
 		ieee80211-freq-limit = <5000000 5490000>;
+		mediatek,disable-radar-background;
 	};
 };
 


### PR DESCRIPTION
…a8000ru

Disable this feature also on the totolink-a8000ru adding it to the devices already included here:
https://github.com/openwrt/openwrt/commit/60384d8a743666f8cbda6446b86067ef6246d032

Signed-off-by: Andrew Sim <andrewsimz@gmail.com>