### PR TITLE
mediatek/mt7622: default to libwolfsslcpu-crypto

### DIFF
--- a/target/linux/mediatek/mt7622/target.mk
+++ b/target/linux/mediatek/mt7622/target.mk
@@ -2,7 +2,7 @@ ARCH:=aarch64
 SUBTARGET:=mt7622
 BOARDNAME:=MT7622
 CPU_TYPE:=cortex-a53
-DEFAULT_PACKAGES += kmod-mt7615e kmod-mt7615-firmware wpad-basic-wolfssl uboot-envtools
+DEFAULT_PACKAGES += kmod-mt7615e kmod-mt7615-firmware libwolfsslcpu-crypto wpad-basic-wolfssl uboot-envtools
 KERNELNAME:=Image dtbs
 
 define Target/Description


### PR DESCRIPTION
This adds libwolfsslcpu-crypto to `DEFAULT_PACKAGES`.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

Continuing from #10414

The intention is to install libwolfssl-cpu-crypto as default for supported targets.  I'm doing mt7622 first, since I have tested it myself.  If there are no problems with this, we can proceed with the rest of the supported targets.

Here's a `.config` diff:
```
--- a/.config       	2022-09-19 18:24:37.526114989 -0300
+++ b/.config    	2022-09-19 18:25:31.234898247 -0300
@@ -95,6 +95,7 @@
 CONFIG_DEFAULT_libc=y
 CONFIG_DEFAULT_libgcc=y
 CONFIG_DEFAULT_libustream-wolfssl=y
+CONFIG_DEFAULT_libwolfssl-cpu-crypto=y
 CONFIG_DEFAULT_logd=y
 CONFIG_DEFAULT_mkf2fs=y
 CONFIG_DEFAULT_mtd=y
@@ -4807,7 +4808,7 @@
 CONFIG_PACKAGE_libopenssl-conf=m
 CONFIG_PACKAGE_libopenssl-devcrypto=m
 CONFIG_PACKAGE_libopenssl-gost_engine=m
-CONFIG_PACKAGE_libwolfssl=y
+CONFIG_PACKAGE_libwolfssl=m

 #
 # wolfSSL Library Configuration
@@ -4838,7 +4839,7 @@
 # CONFIG_WOLFSSL_HAS_DEVCRYPTO_FULL is not set
 # end of wolfSSL Library Configuration

-CONFIG_PACKAGE_libwolfssl-cpu-crypto=m
+CONFIG_PACKAGE_libwolfssl-cpu-crypto=y
 CONFIG_PACKAGE_libwolfssl-benchmark=m
 # end of SSL

```

`.config` was generated with `make defconfig` from:
```
CONFIG_TARGET_mediatek=y
CONFIG_TARGET_mediatek_mt7622=y
CONFIG_ALL=y
```