### PR TITLE
Wolfssl cpu crypto

### DIFF
--- a/target/linux/bcm4908/Makefile
+++ b/target/linux/bcm4908/Makefile
@@ -22,6 +22,7 @@ KERNELNAME:=Image dtbs
 DEFAULT_PACKAGES += \
 	bcm4908img fdt-utils uboot-envtools \
 	kmod-gpio-button-hotplug \
-	kmod-usb-ohci kmod-usb2 kmod-usb3
+	kmod-usb-ohci kmod-usb2 kmod-usb3 \
+	libwolfsslcpu-crypto
 
 $(eval $(call BuildTarget))

--- a/target/linux/layerscape/armv8_64b/target.mk
+++ b/target/linux/layerscape/armv8_64b/target.mk
@@ -5,6 +5,7 @@
 ARCH:=aarch64
 BOARDNAME:=ARMv8 64-bit based boards
 KERNELNAME:=Image dtbs
+DEFAULT_PACKAGES+=libwolfsslcpu-crypto
 
 define Target/Description
 	Build firmware images for NXP Layerscape ARMv8 64-bit based boards.

--- a/target/linux/mediatek/filogic/target.mk
+++ b/target/linux/mediatek/filogic/target.mk
@@ -2,7 +2,8 @@ ARCH:=aarch64
 SUBTARGET:=filogic
 BOARDNAME:=Filogic 830 (MT7986)
 CPU_TYPE:=cortex-a53
-DEFAULT_PACKAGES += kmod-crypto-hw-safexcel kmod-mt7915e kmod-mt7986-firmware wpad-basic-wolfssl uboot-envtools
+DEFAULT_PACKAGES += kmod-crypto-hw-safexcel kmod-mt7915e kmod-mt7986-firmware \
+		    libwolfsslcpu-crypto wpad-basic-wolfssl uboot-envtools
 KERNELNAME:=Image dtbs
 
 define Target/Description

--- a/target/linux/mvebu/cortexa53/target.mk
+++ b/target/linux/mvebu/cortexa53/target.mk
@@ -8,6 +8,6 @@ ARCH:=aarch64
 BOARDNAME:=Marvell Armada 3700LP (ARM64)
 CPU_TYPE:=cortex-a53
 FEATURES+=ext4
-DEFAULT_PACKAGES+=e2fsprogs ethtool mkf2fs partx-utils
+DEFAULT_PACKAGES+=e2fsprogs ethtool libwolfsslcpu-crypto mkf2fs partx-utils
 
 KERNELNAME:=Image dtbs

--- a/target/linux/mvebu/cortexa72/target.mk
+++ b/target/linux/mvebu/cortexa72/target.mk
@@ -8,6 +8,6 @@ ARCH:=aarch64
 BOARDNAME:=Marvell Armada 7k/8k (ARM64)
 CPU_TYPE:=cortex-a72
 FEATURES+=ext4
-DEFAULT_PACKAGES+=e2fsprogs ethtool mkf2fs partx-utils
+DEFAULT_PACKAGES+=e2fsprogs ethtool libwolfsslcpu-crypto mkf2fs partx-utils
 
 KERNELNAME:=Image dtbs

--- a/target/linux/octeontx/Makefile
+++ b/target/linux/octeontx/Makefile
@@ -17,6 +17,7 @@ endef
 
 include $(INCLUDE_DIR)/target.mk
 
+DEFAULT_PACKAGES+=libwolfsslcpu-crypto
 KERNELNAME:=Image
 
 $(eval $(call BuildTarget))

--- a/target/linux/rockchip/armv8/target.mk
+++ b/target/linux/rockchip/armv8/target.mk
@@ -1,6 +1,7 @@
 ARCH:=aarch64
 SUBTARGET:=armv8
 BOARDNAME:=RK33xx boards (64 bit)
+DEFAULT_PACKAGES+=libwolfsslcpu-crypto
 
 define Target/Description
 	Build firmware image for Rockchip RK33xx devices.

--- a/target/linux/sunxi/cortexa53/target.mk
+++ b/target/linux/sunxi/cortexa53/target.mk
@@ -8,3 +8,4 @@ ARCH:=aarch64
 BOARDNAME:=Allwinner A64/H5
 CPU_TYPE:=cortex-a53
 KERNELNAME:=Image dtbs
+DEFAULT_PACKAGES+=libwolfsslcpu-crypto

--- a/target/linux/x86/64/target.mk
+++ b/target/linux/x86/64/target.mk
@@ -1,5 +1,6 @@
 ARCH:=x86_64
 BOARDNAME:=x86_64
+DEFAULT_PACKAGES+=libwolfsslcpu-crypto
 
 define Target/Description
         Build images for 64 bit systems including virtualized guests.


### PR DESCRIPTION
Continuing from #10414 & #10764

The intention is to install libwolfsslcpu-crypto as default for supported targets. #10764 should be merged first to test this on mt7622 If there are no problems with this, we can proceed with the rest of the supported targets here.