### PR TITLE
uboot-envtools: fix ipq platform ubootenv sectors size not hex format

### DIFF
--- a/package/boot/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-envtools/files/ipq40xx
@@ -25,7 +25,7 @@ ubootenv_mtdinfo () {
 		ubootenv_size=0x40000
 	fi
 
-	sectors=$(( $ubootenv_size / $mtd_erase ))
+	sectors=$(printf 0x%x $(( ubootenv_size / mtd_erase )))
 	echo /dev/$mtd_dev 0x0 $ubootenv_size $mtd_erase $sectors
 }
 

--- a/package/boot/uboot-envtools/files/ipq806x
+++ b/package/boot/uboot-envtools/files/ipq806x
@@ -25,7 +25,7 @@ ubootenv_mtdinfo () {
 		ubootenv_size=0x40000
 	fi
 
-	sectors=$(( $ubootenv_size / $mtd_erase ))
+	sectors=$(printf 0x%x $(( ubootenv_size / mtd_erase )))
 	echo /dev/$mtd_dev 0x0 $ubootenv_size $mtd_erase $sectors
 }
 


### PR DESCRIPTION
uboot-envtools: fix ipq platform ubootenv sectors size not hex format

ubootenv_size = mtd_erase * sectors, all values must in hexadecimal, but ipq platform sectors is not hex value. When fw_setenv erases the flash, the calculated erase length is greater than the actual length. If it is greater than the length of a flash block, the flash driver will report an error

Signed-off-by: Ang Liu <ang.liu@muxi-connect.com>
