### PR TITLE
patches: Convert incorrect patches

### DIFF
--- a/target/linux/ath79/patches-5.10/0034-MIPS-ath79-ath9k-exports.patch
+++ b/target/linux/ath79/patches-5.10/0034-MIPS-ath79-ath9k-exports.patch
@@ -1,3 +1,12 @@
+From: John Crispin <john@phrozen.org>
+Subject: [PATCH] ath79: make ahb wifi work
+
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ arch/mips/ath79/common.c                      | 3 +++
+ mips/include/asm/mach-ath79/ath79.h           | 1+
+ 1 file changed, 4 insertions(+)
+
 --- a/arch/mips/ath79/common.c
 +++ b/arch/mips/ath79/common.c
 @@ -31,11 +31,13 @@ EXPORT_SYMBOL_GPL(ath79_ddr_freq);

--- a/target/linux/ath79/patches-5.10/0036-MIPS-ath79-remove-irq-code-from-pci.patch
+++ b/target/linux/ath79/patches-5.10/0036-MIPS-ath79-remove-irq-code-from-pci.patch
@@ -1,3 +1,13 @@
+From: John Crispin <john@phrozen.org>
+Subject: ath79: fix remove irq code from pci driver patch
+
+This patch got mangled in the void while rebasing it.
+
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ arch/mips/pci/pci-ar71xx.c                    | 107 ------------------
+ 1 file changed, 141 deletions(-)
+
 --- a/arch/mips/pci/pci-ar71xx.c
 +++ b/arch/mips/pci/pci-ar71xx.c
 @@ -51,11 +51,9 @@

--- a/target/linux/ath79/patches-5.10/0037-missing-registers.patch
+++ b/target/linux/ath79/patches-5.10/0037-missing-registers.patch
@@ -1,6 +1,5 @@
-commit f3ffac90bc7266b7d917616f3233f58e8c08a196
-Author: Christian Lamparter <chunkeey@gmail.com>
-Date:   Fri Aug 10 23:24:47 2018 +0200
+From: Christian Lamparter <chunkeey@gmail.com>
+Subject: [PATCH] ath79: gmac: add parsers for rxd(v)- and tx(d|en)-delay for
 
     ath79: gmac: add parsers for rxd(v)- and tx(d|en)-delay for AR9344
 

--- a/target/linux/ath79/patches-5.10/0039-MIPS-ath79-export-UART1-reference-clock.patch
+++ b/target/linux/ath79/patches-5.10/0039-MIPS-ath79-export-UART1-reference-clock.patch
@@ -1,3 +1,18 @@
+From: Daniel Golle <daniel@makrotopia.org>
+Subject: [PATCH] ath79: add support for Atheros AR934x HS UART
+
+AR934x chips also got the 'old' qca,ar9330-uart in addition to the
+'new' ns16550a compatible one. Add support for UART1 clock selector as
+well as device-tree bindings in ar934x.dtsi to make use of that uart.
+
+Reported-by: Piotr Dymacz <pepe2k@gmail.com>
+Submitted-by: Daniel Golle <daniel@makrotopia.org>
+---
+ arch/mips/ath79/clock.c                       | 7 +++++++
+ .../mips/include/asm/mach-ath79/ar71xx_regs.h | 1 +
+ include/dt-bindings/clock/ath79-clk.h         | 3 ++-
+ 3 files changed, 10 insertions(+), 1 deletion(-)
+
 --- a/arch/mips/ath79/clock.c
 +++ b/arch/mips/ath79/clock.c
 @@ -40,6 +40,7 @@ static const char * const clk_names[ATH7

--- a/target/linux/ath79/patches-5.10/004-register_gpio_driver_earlier.patch
+++ b/target/linux/ath79/patches-5.10/004-register_gpio_driver_earlier.patch
@@ -1,5 +1,13 @@
+From: John Crispin <john@phrozen.org>
+Subject: ath79: Register GPIO driver earlier
+
 HACK: register the GPIO driver earlier to ensure that gpio_request calls
 from mach files succeed.
+
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ drivers/gpio/gpio-ath79.c                     | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
 
 --- a/drivers/gpio/gpio-ath79.c
 +++ b/drivers/gpio/gpio-ath79.c

--- a/target/linux/ath79/patches-5.10/0040-ath79-sgmii-config.patch
+++ b/target/linux/ath79/patches-5.10/0040-ath79-sgmii-config.patch
@@ -1,3 +1,24 @@
+From: David Bauer <mail@david-bauer.net>
+Subject: [PATCH] ath79: force SGMII SerDes mode to MAC operation
+
+The mode on the SGMII SerDes on the QCA9563 is 1000 Base-X by default.
+This only allows for 1000 Mbit/s links, however when used with an SGMII
+PHY in 100 Mbit/s link mode, the link remains dead.
+
+This strictly has nothing to do with the SerDes calibration, however it
+is done at the same point in the QCA reference U-Boot which is the
+blueprint for everything happening here. As the current state is more or
+less a hack, this should be fine.
+
+This fixes the issues outlined above on a TP-Link EAP-225 Outdoor.
+
+Reported-by: Tom Herbers <freifunk@tomherbers.de>
+Tested-by: Tom Herbers <freifunk@tomherbers.de>
+Submitted-by: David Bauer <mail@david-bauer.net>
+---
+ arch/mips/include/asm/mach-ath79/ar71xx_regs.h           | 1 +
+ 1 files changed, 1 insertion(+)
+
 --- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
 +++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
 @@ -1376,5 +1376,6 @@

--- a/target/linux/ath79/patches-5.10/404-mtd-cybertan-trx-parser.patch
+++ b/target/linux/ath79/patches-5.10/404-mtd-cybertan-trx-parser.patch
@@ -1,3 +1,21 @@
+From: Christian Lamparter <chunkeey@gmail.com>
+Subject: [PATCH] ath79: port cybertan_part from ar71xx
+
+This patch ports the cybertan_part code from ar71xx and converts the
+driver to a DT-supported mtd parser. As a result, it will no longer
+add the u-boot, nvram and art partitions, which were never part of
+the special Cybertan header.
+
+Instead these partitions have to be specified in the DT, which has the
+upside of making it possible to add properties (i.e.: read-only), labels
+and references to these important partitions.
+
+Submitted-by: Christian Lamparter <chunkeey@gmail.com>
+---
+ drivers/mtd/parsers/Makefile                  | 1 +
+ drivers/mtd/parsers/Kconfig                   | 8 ++++++++
+ 2 files changed, 9 insertions(+)
+
 --- a/drivers/mtd/parsers/Makefile
 +++ b/drivers/mtd/parsers/Makefile
 @@ -8,6 +8,7 @@ obj-$(CONFIG_MTD_OF_PARTS)		+= ofpart.o

--- a/target/linux/ath79/patches-5.10/420-net-use-downstream-ag71xx.patch
+++ b/target/linux/ath79/patches-5.10/420-net-use-downstream-ag71xx.patch
@@ -1,3 +1,16 @@
+From: John Crispin <john@phrozen.org>
+Subject: [PATCH] ath79: add new OF only target for QCA MIPS silicon
+
+This target aims to replace ar71xx mid-term. The big part that is still
+missing is making the MMIO/AHB wifi work using OF. NAND and mikrotik
+subtargets will follow.
+
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ drivers/net/ethernet/atheros/Kconfig          | 8 +-------
+ drivers/net/ethernet/atheros/Makefile         | 2 +-
+ 2 files changed, 2 insertions(+), 8 deletions(-)
+
 --- a/drivers/net/ethernet/atheros/Kconfig
 +++ b/drivers/net/ethernet/atheros/Kconfig
 @@ -17,13 +17,7 @@ config NET_VENDOR_ATHEROS

--- a/target/linux/ath79/patches-5.10/425-at803x-allow-sgmii-aneg-override.patch
+++ b/target/linux/ath79/patches-5.10/425-at803x-allow-sgmii-aneg-override.patch
@@ -1,3 +1,19 @@
+From: David Bauer <mail@david-bauer.net>
+Subject: [PATCH] ath79: allow to override AR8033 SGMII aneg status
+
+In order to make the QCA955x SGMII workaround work, the unsuccessful
+SGMII autonegotiation on the AR8033 should not block the PHY
+state-machine.
+
+Otherwise, the ag71xx driver never becomes aware of the copper-side
+link-establishment and the workaround is never executed.
+
+Submitted-by: David Bauer <mail@david-bauer.net>
+Submitted-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
+---
+ drivers/net/phy/at803x.c-override.patch          | 7 +++++++
+ 1 files changed, 7 insertions(+)
+
 --- a/drivers/net/phy/at803x.c
 +++ b/drivers/net/phy/at803x.c
 @@ -830,6 +830,13 @@ static int at803x_aneg_done(struct phy_d

--- a/target/linux/ath79/patches-5.10/430-drivers-link-spi-before-mtd.patch
+++ b/target/linux/ath79/patches-5.10/430-drivers-link-spi-before-mtd.patch
@@ -1,3 +1,11 @@
+From: Gabor Juhos <juhosg@openwrt.org>
+Subject: [PATCH] ar71xx: Link SPI before MTD
+
+SVN-Revision: 22863
+---
+ drivers/Makefile                              |   2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
 @@ -81,8 +81,8 @@ obj-y				+= scsi/

--- a/target/linux/ath79/patches-5.10/440-mtd-ar934x-nand-driver.patch
+++ b/target/linux/ath79/patches-5.10/440-mtd-ar934x-nand-driver.patch
@@ -1,3 +1,12 @@
+From: Gabor Juhos <juhosg@openwrt.org>
+Subject: ar71xx: ar934x_nfc: experimental NAND Flash Controller driver for AR934x
+
+SVN-Revision: 33385
+---
+ drivers/mtd/nand/raw/Kconfig                  | 8 ++++++++
+ drivers/mtd/nand/raw/Makefile                 | 1 +
+ 2 files changed, 9 insertions(+)
+
 --- a/drivers/mtd/nand/raw/Kconfig
 +++ b/drivers/mtd/nand/raw/Kconfig
 @@ -556,4 +556,12 @@ config MTD_NAND_DISKONCHIP_BBTWRITE

--- a/target/linux/ath79/patches-5.10/470-MIPS-ath79-swizzle-pci-address-for-ar71xx.patch
+++ b/target/linux/ath79/patches-5.10/470-MIPS-ath79-swizzle-pci-address-for-ar71xx.patch
@@ -1,3 +1,14 @@
+From: Gabor Juhos <juhosg@openwrt.org>
+Subject: [PATCH] ar71xx: swizzle address for PCI byte/word access on AR71xx
+
+Closes #11683.
+
+SVN-Revision: 32639
+---
+ .../mips/include/asm/mach-ath79/mangle-port.h | 111 ++++++++++++++++++
+ 1 file changed, 111 insertions(+)
+ create mode 100644 arch/mips/include/asm/mach-ath79/mangle-port.h
+
 --- /dev/null
 +++ b/arch/mips/include/asm/mach-ath79/mangle-port.h
 @@ -0,0 +1,37 @@

--- a/target/linux/ath79/patches-5.10/600-of_net-add-mac-address-ascii-support.patch
+++ b/target/linux/ath79/patches-5.10/600-of_net-add-mac-address-ascii-support.patch
@@ -1,3 +1,14 @@
+From: Yousong Zhou <yszhou4tech@gmail.com>
+Subject: [PATCH] ath79: add nvmem cell mac-address-ascii support
+
+This is needed for devices with mac address stored in ascii format, e.g.
+HiWiFi HC6361 to be ported in the following patch.
+
+Submitted-by: Yousong Zhou <yszhou4tech@gmail.com>
+---
+ net/ethernet/eth.c                            | 83 ++++++++++++------
+ 1 files changed, 72 insertions(+), 11 deletions(-)
+
 --- a/net/ethernet/eth.c
 +++ b/net/ethernet/eth.c
 @@ -545,6 +545,63 @@ int eth_platform_get_mac_address(struct

--- a/target/linux/ath79/patches-5.10/900-mdio_bitbang_ignore_ta_value.patch
+++ b/target/linux/ath79/patches-5.10/900-mdio_bitbang_ignore_ta_value.patch
@@ -1,3 +1,15 @@
+From: Jonas Gorski <jogo@openwrt.org>
+Subject: ar71xx: add a workaround for ar8316 not always driving the TA bit to low
+
+AR8316 behind a GPIO bitbanged MDIO bus fails to drive the turnaround bit
+to low despite returning a valid value. Ignore it and just use the
+returned value anyway.
+
+SVN-Revision: 28422
+---
+ drivers/net/mdio/mdio-bitbang.c               | 16 ++-----------------
+ 1 file changed, 2 insertions(+), 14 deletions(-)
+
 --- a/drivers/net/mdio/mdio-bitbang.c
 +++ b/drivers/net/mdio/mdio-bitbang.c
 @@ -152,7 +152,7 @@ static int mdiobb_cmd_addr(struct mdiobb

--- a/target/linux/ath79/patches-5.10/910-unaligned_access_hacks.patch
+++ b/target/linux/ath79/patches-5.10/910-unaligned_access_hacks.patch
@@ -1,3 +1,47 @@
+From: Felix Fietkau <nbd@openwrt.org>
+Subject: [PATCH] ar71xx: fix unaligned access in a few more places
+
+SVN-Revision: 35130
+---
+ arch/mips/include/asm/checksum.h              | 83 +++---------------
+ include/uapi/linux/ip.h                       |  2 +-
+ include/uapi/linux/ipv6.h                     |  2 +-
+ include/uapi/linux/tcp.h                      |  4 ++--
+ include/uapi/linux/udp.h                      |  2 +-
+ net/netfilter/nf_conntrack_core.c             |  4 ++--
+ include/uapi/linux/icmp.h                     |  2 +-
+ include/uapi/linux/in6.h                      |  2 +-
+ net/ipv6/tcp_ipv6.c                           |  9 +++--
+ net/ipv6/datagram.c                           |  6 ++--
+ net/ipv6/exthdrs.c                            |  2 +-
+ include/linux/types.h                         |  5 +++
+ net/ipv4/af_inet.c                            |  4 ++--
+ net/ipv4/tcp_output.c                         | 69 +++++++++--------
+ include/uapi/linux/igmp.h                     |  8 +++---
+ net/core/flow_dissector.c                     |  2 +-
+ include/uapi/linux/icmpv6.h                   |  2 +-
+ include/net/ndisc.h                           | 10 ++++----
+ net/sched/cls_u32.c                           |  6 +++---
+ net/ipv6/ip6_offload.c                        |  2 +-
+ include/net/addrconf.h                        |  2 +-
+ include/net/inet_ecn.h                        |  4 ++--
+ include/net/ipv6.h                            | 23 +++++----
+ include/net/secure_seq.h                      |  1 +
+ include/uapi/linux/in.h                       |  2 +-
+ net/ipv6/ip6_fib.h                            |  2 +-
+ net/netfilter/nf_conntrack_proto_tcp.c        |  2 +-
+ net/xfrm/xfrm_input.c                         |  4 ++--
+ net/ipv4/tcp_input.c                          | 12 ++++---
+ include/uapi/linux/if_pppox.h                 |  1 +
+ net/ipv6/netfilter/nf_log_ipv6.c              |  4 ++--
+ include/net/neighbour.h                       |  6 +++--
+ include/uapi/linux/netfilter_arp/arp_tables.h |  2 +-
+ net/core/utils.c                              | 10 +++++--
+ include/linux/etherdevice.h                   | 11 ++++---
+ net/ipv4/tcp_offload.c                        |  6 +++---
+ net/ipv6/netfilter/ip6table_mangle.c          |  4 ++--
+ 37 file changed, 171 insertions(+), 141 deletions(-)
+
 --- a/arch/mips/include/asm/checksum.h
 +++ b/arch/mips/include/asm/checksum.h
 @@ -100,26 +100,30 @@ static inline __sum16 ip_fast_csum(const
@@ -229,16 +273,6 @@
  	}
  
  #ifdef CONFIG_TCP_MD5SIG
---- a/include/linux/ipv6.h
-+++ b/include/linux/ipv6.h
-@@ -6,6 +6,7 @@
- 
- #define ipv6_optlen(p)  (((p)->hdrlen+1) << 3)
- #define ipv6_authlen(p) (((p)->hdrlen+2) << 2)
-+
- /*
-  * This structure contains configuration options per IPv6 link.
-  */
 --- a/net/ipv6/datagram.c
 +++ b/net/ipv6/datagram.c
 @@ -492,7 +492,7 @@ int ipv6_recv_error(struct sock *sk, str

--- a/target/linux/ath79/patches-5.10/920-mikrotik-rb4xx.patch
+++ b/target/linux/ath79/patches-5.10/920-mikrotik-rb4xx.patch
@@ -1,3 +1,48 @@
+From: Christopher Hill <ch6574@gmail.com>
+Subject: [PATCH] ath79: add Mikrotik rb4xx series drivers
+
+This adds 3 Mikrotik rb4xx series drivers as follows:
+
+rb4xx-cpld: This is in the mfd subsystem, and is the parent CPLD device
+that interfaces between the SoC SPI bus and its two children below.
+rb4xx-gpio: This is the GPIO expander.
+rb4xx-nand: This is the NAND driver.
+
+The history of this code comes in three phases.
+
+1. The first is a May 2015 attempt to push the equivalient ar71xx rb4xx
+drivers upstream. See https://lore.kernel.org/patchwork/patch/940880/.
+
+Module-author: Gabor Juhos <juhosg@openwrt.org>
+Module-author: Imre Kaloz <kaloz@openwrt.org>
+Module-author: Bert Vermeulen <bert@biot.com>
+
+2. Next several ar71xx patches were applied bringing the code current.
+
+commit 7bbf4117c6fe4b764d9d7c62fb2bcf6dd93bff2c
+Submitted-by: Hauke Mehrtens <hauke@hauke-m.de>
+
+commit af79fdbe4af32a287798b579141204bda056b8aa
+commit 889272d92db689fd9c910243635e44c9d8323095
+commit e21cb649a235180563363b8af5ba8296b9ac0baa
+commit 7c09fa4a7492ca436f2c94bd9a465b7c5bbeed6f
+Submitted-by: Felix Fietkau <nbd@nbd.name>
+
+3. Finally a heavy refactor to split the driver into the three new
+subsystems, and updated to work with the device tree configuration, plus
+updates and review feedback incorporated
+
+Reviewed-by: Thibaut VARÈNE <hacks@slashdirt.org>
+Submitted-by: Christopher Hill <ch6574@gmail.com>
+---
+ drivers/mfd/Kconfig                           | 8 ++++++++
+ drivers/mfd/Makefile                          | 1 +
+ drivers/gpio/Kconfig                          | 6 ++++++
+ drivers/gpio/Makefile                         | 1 +
+ drivers/mtd/nand/raw/Kconfig                  | 7 +++++++
+ drivers/mtd/nand/raw/Makefile                 | 1 +
+ 6 files changed, 24 insertions(+)
+
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
 @@ -2142,6 +2142,14 @@ config RAVE_SP_CORE

--- a/target/linux/ath79/patches-5.10/939-mikrotik-rb91x.patch
+++ b/target/linux/ath79/patches-5.10/939-mikrotik-rb91x.patch
@@ -1,3 +1,32 @@
+From: Denis Kalashnikov <denis281089@gmail.com>
+Subject: [PATCH] ath79: add support for reset key on MikroTik RB912UAG-2HPnD
+
+On MikroTik RB91x board series a reset key shares SoC gpio
+line #15 with NAND ALE and NAND IO7. So we need a custom
+gpio driver to manage this non-trivial connection schema.
+Also rb91x-nand needs to have an ability to disable a polling
+of the key while it works with NAND.
+
+While we've been integrating rb91x-key into a firmware, we've
+figured out that:
+* In the gpio-latch driver we need to add a "cansleep" suffix to
+several gpiolib calls,
+* When gpio-latch and rb91x-nand fail to get a gpio and an error
+is -EPROBE_DEFER, they shouldn't report about this, since this
+actually is not an error and occurs when the gpio-latch probe
+function is called before the rb91x-key probe.
+We fix these related things here too.
+
+Submitted-by: Denis Kalashnikov <denis281089@gmail.com>
+Reviewed-by: Sergey Ryazanov <ryazanov.s.a@gmail.com>
+Tested-by: Koen Vandeputte <koen.vandeputte@ncentric.com>
+---
+ drivers/gpio/Kconfig                          | 11 +++++++++++
+ drivers/gpio/Makefile                         |  2 ++
+ drivers/mtd/nand/raw/Kconfig                  |  6 ++++++
+ drivers/mtd/nand/raw/Makefile                 |  1 +
+ 7 files changed, 20 insertions(+)
+
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -341,6 +341,13 @@ config GPIO_IXP4XX

--- a/target/linux/ath79/patches-5.15/0034-MIPS-ath79-ath9k-exports.patch
+++ b/target/linux/ath79/patches-5.15/0034-MIPS-ath79-ath9k-exports.patch
@@ -1,3 +1,12 @@
+From: John Crispin <john@phrozen.org>
+Subject: [PATCH] ath79: make ahb wifi work
+
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ arch/mips/ath79/common.c                      | 3 +++
+ mips/include/asm/mach-ath79/ath79.h           | 1+
+ 1 file changed, 4 insertions(+)
+
 --- a/arch/mips/ath79/common.c
 +++ b/arch/mips/ath79/common.c
 @@ -31,11 +31,13 @@ EXPORT_SYMBOL_GPL(ath79_ddr_freq);

--- a/target/linux/ath79/patches-5.15/0036-MIPS-ath79-remove-irq-code-from-pci.patch
+++ b/target/linux/ath79/patches-5.15/0036-MIPS-ath79-remove-irq-code-from-pci.patch
@@ -1,3 +1,13 @@
+From: John Crispin <john@phrozen.org>
+Subject: ath79: fix remove irq code from pci driver patch
+
+This patch got mangled in the void while rebasing it.
+
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ arch/mips/pci/pci-ar71xx.c                    | 107 ------------------
+ 1 file changed, 141 deletions(-)
+
 --- a/arch/mips/pci/pci-ar71xx.c
 +++ b/arch/mips/pci/pci-ar71xx.c
 @@ -51,11 +51,9 @@

--- a/target/linux/ath79/patches-5.15/0037-missing-registers.patch
+++ b/target/linux/ath79/patches-5.15/0037-missing-registers.patch
@@ -1,6 +1,5 @@
-commit f3ffac90bc7266b7d917616f3233f58e8c08a196
-Author: Christian Lamparter <chunkeey@gmail.com>
-Date:   Fri Aug 10 23:24:47 2018 +0200
+From: Christian Lamparter <chunkeey@gmail.com>
+Subject: [PATCH] ath79: gmac: add parsers for rxd(v)- and tx(d|en)-delay for
 
     ath79: gmac: add parsers for rxd(v)- and tx(d|en)-delay for AR9344
 

--- a/target/linux/ath79/patches-5.15/0039-MIPS-ath79-export-UART1-reference-clock.patch
+++ b/target/linux/ath79/patches-5.15/0039-MIPS-ath79-export-UART1-reference-clock.patch
@@ -1,3 +1,18 @@
+From: Daniel Golle <daniel@makrotopia.org>
+Subject: [PATCH] ath79: add support for Atheros AR934x HS UART
+
+AR934x chips also got the 'old' qca,ar9330-uart in addition to the
+'new' ns16550a compatible one. Add support for UART1 clock selector as
+well as device-tree bindings in ar934x.dtsi to make use of that uart.
+
+Reported-by: Piotr Dymacz <pepe2k@gmail.com>
+Submitted-by: Daniel Golle <daniel@makrotopia.org>
+---
+ arch/mips/ath79/clock.c                       | 7 +++++++
+ .../mips/include/asm/mach-ath79/ar71xx_regs.h | 1 +
+ include/dt-bindings/clock/ath79-clk.h         | 3 ++-
+ 3 files changed, 10 insertions(+), 1 deletion(-)
+
 --- a/arch/mips/ath79/clock.c
 +++ b/arch/mips/ath79/clock.c
 @@ -40,6 +40,7 @@ static const char * const clk_names[ATH7

--- a/target/linux/ath79/patches-5.15/004-register_gpio_driver_earlier.patch
+++ b/target/linux/ath79/patches-5.15/004-register_gpio_driver_earlier.patch
@@ -1,5 +1,13 @@
+From: John Crispin <john@phrozen.org>
+Subject: ath79: Register GPIO driver earlier
+
 HACK: register the GPIO driver earlier to ensure that gpio_request calls
 from mach files succeed.
+
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ drivers/gpio/gpio-ath79.c                     | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
 
 --- a/drivers/gpio/gpio-ath79.c
 +++ b/drivers/gpio/gpio-ath79.c

--- a/target/linux/ath79/patches-5.15/0040-ath79-sgmii-config.patch
+++ b/target/linux/ath79/patches-5.15/0040-ath79-sgmii-config.patch
@@ -1,3 +1,24 @@
+From: David Bauer <mail@david-bauer.net>
+Subject: [PATCH] ath79: force SGMII SerDes mode to MAC operation
+
+The mode on the SGMII SerDes on the QCA9563 is 1000 Base-X by default.
+This only allows for 1000 Mbit/s links, however when used with an SGMII
+PHY in 100 Mbit/s link mode, the link remains dead.
+
+This strictly has nothing to do with the SerDes calibration, however it
+is done at the same point in the QCA reference U-Boot which is the
+blueprint for everything happening here. As the current state is more or
+less a hack, this should be fine.
+
+This fixes the issues outlined above on a TP-Link EAP-225 Outdoor.
+
+Reported-by: Tom Herbers <freifunk@tomherbers.de>
+Tested-by: Tom Herbers <freifunk@tomherbers.de>
+Submitted-by: David Bauer <mail@david-bauer.net>
+---
+ arch/mips/include/asm/mach-ath79/ar71xx_regs.h           | 1 +
+ 1 files changed, 1 insertion(+)
+
 --- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
 +++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
 @@ -1376,5 +1376,6 @@

--- a/target/linux/ath79/patches-5.15/404-mtd-cybertan-trx-parser.patch
+++ b/target/linux/ath79/patches-5.15/404-mtd-cybertan-trx-parser.patch
@@ -1,3 +1,21 @@
+From: Christian Lamparter <chunkeey@gmail.com>
+Subject: [PATCH] ath79: port cybertan_part from ar71xx
+
+This patch ports the cybertan_part code from ar71xx and converts the
+driver to a DT-supported mtd parser. As a result, it will no longer
+add the u-boot, nvram and art partitions, which were never part of
+the special Cybertan header.
+
+Instead these partitions have to be specified in the DT, which has the
+upside of making it possible to add properties (i.e.: read-only), labels
+and references to these important partitions.
+
+Submitted-by: Christian Lamparter <chunkeey@gmail.com>
+---
+ drivers/mtd/parsers/Makefile                  | 1 +
+ drivers/mtd/parsers/Kconfig                   | 8 ++++++++
+ 2 files changed, 9 insertions(+)
+
 --- a/drivers/mtd/parsers/Makefile
 +++ b/drivers/mtd/parsers/Makefile
 @@ -8,6 +8,7 @@ obj-$(CONFIG_MTD_OF_PARTS)		+= ofpart.o

--- a/target/linux/ath79/patches-5.15/420-net-use-downstream-ag71xx.patch
+++ b/target/linux/ath79/patches-5.15/420-net-use-downstream-ag71xx.patch
@@ -1,3 +1,16 @@
+From: John Crispin <john@phrozen.org>
+Subject: [PATCH] ath79: add new OF only target for QCA MIPS silicon
+
+This target aims to replace ar71xx mid-term. The big part that is still
+missing is making the MMIO/AHB wifi work using OF. NAND and mikrotik
+subtargets will follow.
+
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ drivers/net/ethernet/atheros/Kconfig          | 8 +-------
+ drivers/net/ethernet/atheros/Makefile         | 2 +-
+ 2 files changed, 2 insertions(+), 8 deletions(-)
+
 --- a/drivers/net/ethernet/atheros/Kconfig
 +++ b/drivers/net/ethernet/atheros/Kconfig
 @@ -17,14 +17,7 @@ config NET_VENDOR_ATHEROS

--- a/target/linux/ath79/patches-5.15/430-drivers-link-spi-before-mtd.patch
+++ b/target/linux/ath79/patches-5.15/430-drivers-link-spi-before-mtd.patch
@@ -1,3 +1,11 @@
+From: Gabor Juhos <juhosg@openwrt.org>
+Subject: [PATCH] ar71xx: Link SPI before MTD
+
+SVN-Revision: 22863
+---
+ drivers/Makefile                              |   2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
 @@ -80,8 +80,8 @@ obj-y				+= scsi/

--- a/target/linux/ath79/patches-5.15/440-mtd-ar934x-nand-driver.patch
+++ b/target/linux/ath79/patches-5.15/440-mtd-ar934x-nand-driver.patch
@@ -1,3 +1,12 @@
+From: Gabor Juhos <juhosg@openwrt.org>
+Subject: ar71xx: ar934x_nfc: experimental NAND Flash Controller driver for AR934x
+
+SVN-Revision: 33385
+---
+ drivers/mtd/nand/raw/Kconfig                  | 8 ++++++++
+ drivers/mtd/nand/raw/Makefile                 | 1 +
+ 2 files changed, 9 insertions(+)
+
 --- a/drivers/mtd/nand/raw/Kconfig
 +++ b/drivers/mtd/nand/raw/Kconfig
 @@ -555,4 +555,12 @@ config MTD_NAND_DISKONCHIP_BBTWRITE

--- a/target/linux/ath79/patches-5.15/470-MIPS-ath79-swizzle-pci-address-for-ar71xx.patch
+++ b/target/linux/ath79/patches-5.15/470-MIPS-ath79-swizzle-pci-address-for-ar71xx.patch
@@ -1,3 +1,14 @@
+From: Gabor Juhos <juhosg@openwrt.org>
+Subject: [PATCH] ar71xx: swizzle address for PCI byte/word access on AR71xx
+
+Closes #11683.
+
+SVN-Revision: 32639
+---
+ .../mips/include/asm/mach-ath79/mangle-port.h | 111 ++++++++++++++++++
+ 1 file changed, 111 insertions(+)
+ create mode 100644 arch/mips/include/asm/mach-ath79/mangle-port.h
+
 --- /dev/null
 +++ b/arch/mips/include/asm/mach-ath79/mangle-port.h
 @@ -0,0 +1,37 @@

--- a/target/linux/ath79/patches-5.15/600-of_net-add-mac-address-ascii-support.patch
+++ b/target/linux/ath79/patches-5.15/600-of_net-add-mac-address-ascii-support.patch
@@ -1,3 +1,14 @@
+From: Yousong Zhou <yszhou4tech@gmail.com>
+Subject: [PATCH] ath79: add nvmem cell mac-address-ascii support
+
+This is needed for devices with mac address stored in ascii format, e.g.
+HiWiFi HC6361 to be ported in the following patch.
+
+Submitted-by: Yousong Zhou <yszhou4tech@gmail.com>
+---
+ net/ethernet/eth.c                            | 83 ++++++++++++------
+ 1 files changed, 72 insertions(+), 11 deletions(-)
+
 --- a/net/ethernet/eth.c
 +++ b/net/ethernet/eth.c
 @@ -544,6 +544,63 @@ int eth_platform_get_mac_address(struct

--- a/target/linux/ath79/patches-5.15/900-mdio_bitbang_ignore_ta_value.patch
+++ b/target/linux/ath79/patches-5.15/900-mdio_bitbang_ignore_ta_value.patch
@@ -1,3 +1,15 @@
+From: Jonas Gorski <jogo@openwrt.org>
+Subject: ar71xx: add a workaround for ar8316 not always driving the TA bit to low
+
+AR8316 behind a GPIO bitbanged MDIO bus fails to drive the turnaround bit
+to low despite returning a valid value. Ignore it and just use the
+returned value anyway.
+
+SVN-Revision: 28422
+---
+ drivers/net/mdio/mdio-bitbang.c               | 16 ++-----------------
+ 1 file changed, 2 insertions(+), 14 deletions(-)
+
 --- a/drivers/net/mdio/mdio-bitbang.c
 +++ b/drivers/net/mdio/mdio-bitbang.c
 @@ -152,7 +152,7 @@ static int mdiobb_cmd_addr(struct mdiobb

--- a/target/linux/ath79/patches-5.15/910-unaligned_access_hacks.patch
+++ b/target/linux/ath79/patches-5.15/910-unaligned_access_hacks.patch
@@ -1,3 +1,47 @@
+From: Felix Fietkau <nbd@openwrt.org>
+Subject: [PATCH] ar71xx: fix unaligned access in a few more places
+
+SVN-Revision: 35130
+---
+ arch/mips/include/asm/checksum.h              | 83 +++---------------
+ include/uapi/linux/ip.h                       |  2 +-
+ include/uapi/linux/ipv6.h                     |  2 +-
+ include/uapi/linux/tcp.h                      |  4 ++--
+ include/uapi/linux/udp.h                      |  2 +-
+ net/netfilter/nf_conntrack_core.c             |  4 ++--
+ include/uapi/linux/icmp.h                     |  2 +-
+ include/uapi/linux/in6.h                      |  2 +-
+ net/ipv6/tcp_ipv6.c                           |  9 +++--
+ net/ipv6/datagram.c                           |  6 ++--
+ net/ipv6/exthdrs.c                            |  2 +-
+ include/linux/types.h                         |  5 +++
+ net/ipv4/af_inet.c                            |  4 ++--
+ net/ipv4/tcp_output.c                         | 69 +++++++++--------
+ include/uapi/linux/igmp.h                     |  8 +++---
+ net/core/flow_dissector.c                     |  2 +-
+ include/uapi/linux/icmpv6.h                   |  2 +-
+ include/net/ndisc.h                           | 10 ++++----
+ net/sched/cls_u32.c                           |  6 +++---
+ net/ipv6/ip6_offload.c                        |  2 +-
+ include/net/addrconf.h                        |  2 +-
+ include/net/inet_ecn.h                        |  4 ++--
+ include/net/ipv6.h                            | 23 +++++----
+ include/net/secure_seq.h                      |  1 +
+ include/uapi/linux/in.h                       |  2 +-
+ net/ipv6/ip6_fib.h                            |  2 +-
+ net/netfilter/nf_conntrack_proto_tcp.c        |  2 +-
+ net/xfrm/xfrm_input.c                         |  4 ++--
+ net/ipv4/tcp_input.c                          | 12 ++++---
+ include/uapi/linux/if_pppox.h                 |  1 +
+ net/ipv6/netfilter/nf_log_ipv6.c              |  4 ++--
+ include/net/neighbour.h                       |  6 +++--
+ include/uapi/linux/netfilter_arp/arp_tables.h |  2 +-
+ net/core/utils.c                              | 10 +++++--
+ include/linux/etherdevice.h                   | 11 ++++---
+ net/ipv4/tcp_offload.c                        |  6 +++---
+ net/ipv6/netfilter/ip6table_mangle.c          |  4 ++--
+ 37 file changed, 171 insertions(+), 141 deletions(-)
+
 --- a/arch/mips/include/asm/checksum.h
 +++ b/arch/mips/include/asm/checksum.h
 @@ -100,26 +100,30 @@ static inline __sum16 ip_fast_csum(const

--- a/target/linux/ath79/patches-5.15/920-mikrotik-rb4xx.patch
+++ b/target/linux/ath79/patches-5.15/920-mikrotik-rb4xx.patch
@@ -1,3 +1,48 @@
+From: Christopher Hill <ch6574@gmail.com>
+Subject: [PATCH] ath79: add Mikrotik rb4xx series drivers
+
+This adds 3 Mikrotik rb4xx series drivers as follows:
+
+rb4xx-cpld: This is in the mfd subsystem, and is the parent CPLD device
+that interfaces between the SoC SPI bus and its two children below.
+rb4xx-gpio: This is the GPIO expander.
+rb4xx-nand: This is the NAND driver.
+
+The history of this code comes in three phases.
+
+1. The first is a May 2015 attempt to push the equivalient ar71xx rb4xx
+drivers upstream. See https://lore.kernel.org/patchwork/patch/940880/.
+
+Module-author: Gabor Juhos <juhosg@openwrt.org>
+Module-author: Imre Kaloz <kaloz@openwrt.org>
+Module-author: Bert Vermeulen <bert@biot.com>
+
+2. Next several ar71xx patches were applied bringing the code current.
+
+commit 7bbf4117c6fe4b764d9d7c62fb2bcf6dd93bff2c
+Submitted-by: Hauke Mehrtens <hauke@hauke-m.de>
+
+commit af79fdbe4af32a287798b579141204bda056b8aa
+commit 889272d92db689fd9c910243635e44c9d8323095
+commit e21cb649a235180563363b8af5ba8296b9ac0baa
+commit 7c09fa4a7492ca436f2c94bd9a465b7c5bbeed6f
+Submitted-by: Felix Fietkau <nbd@nbd.name>
+
+3. Finally a heavy refactor to split the driver into the three new
+subsystems, and updated to work with the device tree configuration, plus
+updates and review feedback incorporated
+
+Reviewed-by: Thibaut VARÈNE <hacks@slashdirt.org>
+Submitted-by: Christopher Hill <ch6574@gmail.com>
+---
+ drivers/mfd/Kconfig                           | 8 ++++++++
+ drivers/mfd/Makefile                          | 1 +
+ drivers/gpio/Kconfig                          | 6 ++++++
+ drivers/gpio/Makefile                         | 1 +
+ drivers/mtd/nand/raw/Kconfig                  | 7 +++++++
+ drivers/mtd/nand/raw/Makefile                 | 1 +
+ 6 files changed, 24 insertions(+)
+
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
 @@ -2174,6 +2174,14 @@ config RAVE_SP_CORE
@@ -13,7 +58,7 @@
 +	  Routerboard RB4xx series.
 +
  config SGI_MFD_IOC3
- 	bool "SGI IOC3 core driver"
+	bool "SGI IOC3 core driver"
  	depends on PCI && MIPS && 64BIT
 --- a/drivers/mfd/Makefile
 +++ b/drivers/mfd/Makefile

--- a/target/linux/ath79/patches-5.15/939-mikrotik-rb91x.patch
+++ b/target/linux/ath79/patches-5.15/939-mikrotik-rb91x.patch
@@ -1,3 +1,32 @@
+From: Denis Kalashnikov <denis281089@gmail.com>
+Subject: [PATCH] ath79: add support for reset key on MikroTik RB912UAG-2HPnD
+
+On MikroTik RB91x board series a reset key shares SoC gpio
+line #15 with NAND ALE and NAND IO7. So we need a custom
+gpio driver to manage this non-trivial connection schema.
+Also rb91x-nand needs to have an ability to disable a polling
+of the key while it works with NAND.
+
+While we've been integrating rb91x-key into a firmware, we've
+figured out that:
+* In the gpio-latch driver we need to add a "cansleep" suffix to
+several gpiolib calls,
+* When gpio-latch and rb91x-nand fail to get a gpio and an error
+is -EPROBE_DEFER, they shouldn't report about this, since this
+actually is not an error and occurs when the gpio-latch probe
+function is called before the rb91x-key probe.
+We fix these related things here too.
+
+Submitted-by: Denis Kalashnikov <denis281089@gmail.com>
+Reviewed-by: Sergey Ryazanov <ryazanov.s.a@gmail.com>
+Tested-by: Koen Vandeputte <koen.vandeputte@ncentric.com>
+---
+ drivers/gpio/Kconfig                          | 11 +++++++++++
+ drivers/gpio/Makefile                         |  2 ++
+ drivers/mtd/nand/raw/Kconfig                  |  6 ++++++
+ drivers/mtd/nand/raw/Makefile                 |  1 +
+ 7 files changed, 20 insertions(+)
+
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -353,6 +353,13 @@ config GPIO_IXP4XX
@@ -15,8 +44,8 @@
  	tristate "Xylon LogiCVC GPIO support"
  	depends on MFD_SYSCON && OF
 @@ -529,6 +536,10 @@ config GPIO_ROCKCHIP
- 	help
- 	  Say yes here to support GPIO on Rockchip SoCs.
+	help
+	  Say yes here to support GPIO on Rockchip SoCs.
  
 +config GPIO_RB91X_KEY
 +	tristate "MikroTik RB91x board series reset key support"

--- a/target/linux/generic/backport-5.15/600-v5.18-page_pool-Add-allocation-stats.patch
+++ b/target/linux/generic/backport-5.15/600-v5.18-page_pool-Add-allocation-stats.patch
@@ -1,30 +1,36 @@
-commit 8610037e8106b48c79cfe0afb92b2b2466e51c3d
-Author: Joe Damato <jdamato@fastly.com>
-Date:   Tue Mar 1 23:55:47 2022 -0800
+From 8610037e8106b48c79cfe0afb92b2b2466e51c3d Mon Sep 17 00:00:00 2001
+From: Joe Damato <jdamato@fastly.com>
+Date: Tue, 1 Mar 2022 23:55:47 -0800
+Subject: [PATCH] page_pool: Add allocation stats
 
-    page_pool: Add allocation stats
-    
-    Add per-pool statistics counters for the allocation path of a page pool.
-    These stats are incremented in softirq context, so no locking or per-cpu
-    variables are needed.
-    
-    This code is disabled by default and a kernel config option is provided for
-    users who wish to enable them.
-    
-    The statistics added are:
-            - fast: successful fast path allocations
-            - slow: slow path order-0 allocations
-            - slow_high_order: slow path high order allocations
-            - empty: ptr ring is empty, so a slow path allocation was forced.
-            - refill: an allocation which triggered a refill of the cache
-            - waive: pages obtained from the ptr ring that cannot be added to
-              the cache due to a NUMA mismatch.
-    
-    Signed-off-by: Joe Damato <jdamato@fastly.com>
-    Acked-by: Jesper Dangaard Brouer <brouer@redhat.com>
-    Reviewed-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
-    Signed-off-by: David S. Miller <davem@davemloft.net>
+Add per-pool statistics counters for the allocation path of a page pool.
+These stats are incremented in softirq context, so no locking or per-cpu
+variables are needed.
 
+This code is disabled by default and a kernel config option is provided for
+users who wish to enable them.
+
+The statistics added are:
+	- fast: successful fast path allocations
+	- slow: slow path order-0 allocations
+	- slow_high_order: slow path high order allocations
+	- empty: ptr ring is empty, so a slow path allocation was forced.
+	- refill: an allocation which triggered a refill of the cache
+	- waive: pages obtained from the ptr ring that cannot be added to
+	  the cache due to a NUMA mismatch.
+
+Signed-off-by: Joe Damato <jdamato@fastly.com>
+Acked-by: Jesper Dangaard Brouer <brouer@redhat.com>
+Reviewed-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ include/net/page_pool.h | 18 ++++++++++++++++++
+ net/Kconfig             | 13 +++++++++++++
+ net/core/page_pool.c    | 24 ++++++++++++++++++++----
+ 3 files changed, 51 insertions(+), 4 deletions(-)
+
+diff --git a/include/net/page_pool.h b/include/net/page_pool.h
+index 97c3c19872ff..1f27e8a48830 100644
 --- a/include/net/page_pool.h
 +++ b/include/net/page_pool.h
 @@ -82,6 +82,19 @@ struct page_pool_params {

--- a/target/linux/generic/backport-5.15/601-v5.18-page_pool-Add-recycle-stats.patch
+++ b/target/linux/generic/backport-5.15/601-v5.18-page_pool-Add-recycle-stats.patch
@@ -1,21 +1,26 @@
-commit ad6fa1e1ab1b8164f1ba296b1b4dc556a483bcad
-Author: Joe Damato <jdamato@fastly.com>
-Date:   Tue Mar 1 23:55:48 2022 -0800
+From ad6fa1e1ab1b8164f1ba296b1b4dc556a483bcad Mon Sep 17 00:00:00 2001
+From: Joe Damato <jdamato@fastly.com>
+Date: Tue, 1 Mar 2022 23:55:48 -0800
+Subject: [PATCH 2/3] page_pool: Add recycle stats
 
-    page_pool: Add recycle stats
-    
-    Add per-cpu stats tracking page pool recycling events:
-            - cached: recycling placed page in the page pool cache
-            - cache_full: page pool cache was full
-            - ring: page placed into the ptr ring
-            - ring_full: page released from page pool because the ptr ring was full
-            - released_refcnt: page released (and not recycled) because refcnt > 1
-    
-    Signed-off-by: Joe Damato <jdamato@fastly.com>
-    Acked-by: Jesper Dangaard Brouer <brouer@redhat.com>
-    Reviewed-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
-    Signed-off-by: David S. Miller <davem@davemloft.net>
+Add per-cpu stats tracking page pool recycling events:
+	- cached: recycling placed page in the page pool cache
+	- cache_full: page pool cache was full
+	- ring: page placed into the ptr ring
+	- ring_full: page released from page pool because the ptr ring was full
+	- released_refcnt: page released (and not recycled) because refcnt > 1
 
+Signed-off-by: Joe Damato <jdamato@fastly.com>
+Acked-by: Jesper Dangaard Brouer <brouer@redhat.com>
+Reviewed-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ include/net/page_pool.h | 16 ++++++++++++++++
+ net/core/page_pool.c    | 30 ++++++++++++++++++++++++++++--
+ 2 files changed, 44 insertions(+), 2 deletions(-)
+
+diff --git a/include/net/page_pool.h b/include/net/page_pool.h
+index 1f27e8a48830..298af95bbf96 100644
 --- a/include/net/page_pool.h
 +++ b/include/net/page_pool.h
 @@ -93,6 +93,18 @@ struct page_pool_alloc_stats {

--- a/target/linux/generic/backport-5.15/602-v5.18-page_pool-Add-function-to-batch-and-return-stats.patch
+++ b/target/linux/generic/backport-5.15/602-v5.18-page_pool-Add-function-to-batch-and-return-stats.patch
@@ -1,17 +1,22 @@
-commit 6b95e3388b1ea0ca63500c5a6e39162dbf828433
-Author: Joe Damato <jdamato@fastly.com>
-Date:   Tue Mar 1 23:55:49 2022 -0800
+From 6b95e3388b1ea0ca63500c5a6e39162dbf828433 Mon Sep 17 00:00:00 2001
+From: Joe Damato <jdamato@fastly.com>
+Date: Tue, 1 Mar 2022 23:55:49 -0800
+Subject: [PATCH 3/3] page_pool: Add function to batch and return stats
 
-    page_pool: Add function to batch and return stats
-    
-    Adds a function page_pool_get_stats which can be used by drivers to obtain
-    stats for a specified page_pool.
-    
-    Signed-off-by: Joe Damato <jdamato@fastly.com>
-    Acked-by: Jesper Dangaard Brouer <brouer@redhat.com>
-    Reviewed-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
-    Signed-off-by: David S. Miller <davem@davemloft.net>
+Adds a function page_pool_get_stats which can be used by drivers to obtain
+stats for a specified page_pool.
 
+Signed-off-by: Joe Damato <jdamato@fastly.com>
+Acked-by: Jesper Dangaard Brouer <brouer@redhat.com>
+Reviewed-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ include/net/page_pool.h | 17 +++++++++++++++++
+ net/core/page_pool.c    | 25 +++++++++++++++++++++++++
+ 2 files changed, 42 insertions(+)
+
+diff --git a/include/net/page_pool.h b/include/net/page_pool.h
+index 298af95bbf96..ea5fb70e5101 100644
 --- a/include/net/page_pool.h
 +++ b/include/net/page_pool.h
 @@ -105,6 +105,23 @@ struct page_pool_recycle_stats {

--- a/target/linux/generic/backport-5.15/603-v5.19-page_pool-Add-recycle-stats-to-page_pool_put_page_bu.patch
+++ b/target/linux/generic/backport-5.15/603-v5.19-page_pool-Add-recycle-stats-to-page_pool_put_page_bu.patch
@@ -1,17 +1,21 @@
-commit 590032a4d2133ecc10d3078a8db1d85a4842f12c
-Author: Lorenzo Bianconi <lorenzo@kernel.org>
-Date:   Mon Apr 11 16:05:26 2022 +0200
+From 590032a4d2133ecc10d3078a8db1d85a4842f12c Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Mon, 11 Apr 2022 16:05:26 +0200
+Subject: [PATCH] page_pool: Add recycle stats to page_pool_put_page_bulk
 
-    page_pool: Add recycle stats to page_pool_put_page_bulk
-    
-    Add missing recycle stats to page_pool_put_page_bulk routine.
-    
-    Reviewed-by: Joe Damato <jdamato@fastly.com>
-    Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
-    Reviewed-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
-    Link: https://lore.kernel.org/r/3712178b51c007cfaed910ea80e68f00c916b1fa.1649685634.git.lorenzo@kernel.org
-    Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+Add missing recycle stats to page_pool_put_page_bulk routine.
 
+Reviewed-by: Joe Damato <jdamato@fastly.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Reviewed-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+Link: https://lore.kernel.org/r/3712178b51c007cfaed910ea80e68f00c916b1fa.1649685634.git.lorenzo@kernel.org
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ net/core/page_pool.c | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/net/core/page_pool.c b/net/core/page_pool.c
+index 1943c0f0307d..4af55d28ffa3 100644
 --- a/net/core/page_pool.c
 +++ b/net/core/page_pool.c
 @@ -36,6 +36,12 @@

--- a/target/linux/generic/backport-5.15/604-v5.19-net-page_pool-introduce-ethtool-stats.patch
+++ b/target/linux/generic/backport-5.15/604-v5.19-net-page_pool-introduce-ethtool-stats.patch
@@ -1,17 +1,22 @@
-commit f3c5264f452a5b0ac1de1f2f657efbabdea3c76a
-Author: Lorenzo Bianconi <lorenzo@kernel.org>
-Date:   Tue Apr 12 18:31:58 2022 +0200
+From f3c5264f452a5b0ac1de1f2f657efbabdea3c76a Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Tue, 12 Apr 2022 18:31:58 +0200
+Subject: [PATCH] net: page_pool: introduce ethtool stats
 
-    net: page_pool: introduce ethtool stats
-    
-    Introduce page_pool APIs to report stats through ethtool and reduce
-    duplicated code in each driver.
-    
-    Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
-    Reviewed-by: Jakub Kicinski <kuba@kernel.org>
-    Reviewed-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
-    Signed-off-by: David S. Miller <davem@davemloft.net>
+Introduce page_pool APIs to report stats through ethtool and reduce
+duplicated code in each driver.
 
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Reviewed-by: Jakub Kicinski <kuba@kernel.org>
+Reviewed-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ include/net/page_pool.h | 21 ++++++++++++++
+ net/core/page_pool.c    | 63 ++++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 83 insertions(+), 1 deletion(-)
+
+diff --git a/include/net/page_pool.h b/include/net/page_pool.h
+index ea5fb70e5101..813c93499f20 100644
 --- a/include/net/page_pool.h
 +++ b/include/net/page_pool.h
 @@ -115,6 +115,10 @@ struct page_pool_stats {

--- a/target/linux/generic/backport-5.15/605-v5.18-xdp-introduce-flags-field-in-xdp_buff-xdp_frame.patch
+++ b/target/linux/generic/backport-5.15/605-v5.18-xdp-introduce-flags-field-in-xdp_buff-xdp_frame.patch
@@ -1,25 +1,29 @@
-commit 2e88d4ff03013937028f5397268b21e10cf68713
-Author: Lorenzo Bianconi <lorenzo@kernel.org>
-Date:   Fri Jan 21 11:09:45 2022 +0100
+From 2e88d4ff03013937028f5397268b21e10cf68713 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 21 Jan 2022 11:09:45 +0100
+Subject: [PATCH] xdp: introduce flags field in xdp_buff/xdp_frame
 
-    xdp: introduce flags field in xdp_buff/xdp_frame
-    
-    Introduce flags field in xdp_frame and xdp_buffer data structures
-    to define additional buffer features. At the moment the only
-    supported buffer feature is frags bit (XDP_FLAGS_HAS_FRAGS).
-    frags bit is used to specify if this is a linear buffer
-    (XDP_FLAGS_HAS_FRAGS not set) or a frags frame (XDP_FLAGS_HAS_FRAGS
-    set). In the latter case the driver is expected to initialize the
-    skb_shared_info structure at the end of the first buffer to link together
-    subsequent buffers belonging to the same frame.
-    
-    Acked-by: Toke Hoiland-Jorgensen <toke@redhat.com>
-    Acked-by: John Fastabend <john.fastabend@gmail.com>
-    Acked-by: Jesper Dangaard Brouer <brouer@redhat.com>
-    Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
-    Link: https://lore.kernel.org/r/e389f14f3a162c0a5bc6a2e1aa8dd01a90be117d.1642758637.git.lorenzo@kernel.org
-    Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+Introduce flags field in xdp_frame and xdp_buffer data structures
+to define additional buffer features. At the moment the only
+supported buffer feature is frags bit (XDP_FLAGS_HAS_FRAGS).
+frags bit is used to specify if this is a linear buffer
+(XDP_FLAGS_HAS_FRAGS not set) or a frags frame (XDP_FLAGS_HAS_FRAGS
+set). In the latter case the driver is expected to initialize the
+skb_shared_info structure at the end of the first buffer to link together
+subsequent buffers belonging to the same frame.
 
+Acked-by: Toke Hoiland-Jorgensen <toke@redhat.com>
+Acked-by: John Fastabend <john.fastabend@gmail.com>
+Acked-by: Jesper Dangaard Brouer <brouer@redhat.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://lore.kernel.org/r/e389f14f3a162c0a5bc6a2e1aa8dd01a90be117d.1642758637.git.lorenzo@kernel.org
+Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+---
+ include/net/xdp.h | 29 +++++++++++++++++++++++++++++
+ 1 file changed, 29 insertions(+)
+
+diff --git a/include/net/xdp.h b/include/net/xdp.h
+index 8f0812e4996d..485e9495a690 100644
 --- a/include/net/xdp.h
 +++ b/include/net/xdp.h
 @@ -66,6 +66,10 @@ struct xdp_txq_info {

--- a/target/linux/generic/backport-5.15/606-v5.18-xdp-add-frags-support-to-xdp_return_-buff-frame.patch
+++ b/target/linux/generic/backport-5.15/606-v5.18-xdp-add-frags-support-to-xdp_return_-buff-frame.patch
@@ -1,19 +1,24 @@
-commit 7c48cb0176c6d6d3b55029f7ff4ffa05faee6446
-Author: Lorenzo Bianconi <lorenzo@kernel.org>
-Date:   Fri Jan 21 11:09:50 2022 +0100
+From 7c48cb0176c6d6d3b55029f7ff4ffa05faee6446 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 21 Jan 2022 11:09:50 +0100
+Subject: [PATCH] xdp: add frags support to xdp_return_{buff/frame}
 
-    xdp: add frags support to xdp_return_{buff/frame}
-    
-    Take into account if the received xdp_buff/xdp_frame is non-linear
-    recycling/returning the frame memory to the allocator or into
-    xdp_frame_bulk.
-    
-    Acked-by: Toke Hoiland-Jorgensen <toke@redhat.com>
-    Acked-by: John Fastabend <john.fastabend@gmail.com>
-    Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
-    Link: https://lore.kernel.org/r/a961069febc868508ce1bdf5e53a343eb4e57cb2.1642758637.git.lorenzo@kernel.org
-    Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+Take into account if the received xdp_buff/xdp_frame is non-linear
+recycling/returning the frame memory to the allocator or into
+xdp_frame_bulk.
 
+Acked-by: Toke Hoiland-Jorgensen <toke@redhat.com>
+Acked-by: John Fastabend <john.fastabend@gmail.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://lore.kernel.org/r/a961069febc868508ce1bdf5e53a343eb4e57cb2.1642758637.git.lorenzo@kernel.org
+Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+---
+ include/net/xdp.h | 18 ++++++++++++++--
+ net/core/xdp.c    | 54 ++++++++++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 69 insertions(+), 3 deletions(-)
+
+diff --git a/include/net/xdp.h b/include/net/xdp.h
+index 1f8641ec658e..8463dea8b4db 100644
 --- a/include/net/xdp.h
 +++ b/include/net/xdp.h
 @@ -275,10 +275,24 @@ void __xdp_release_frame(void *data, str

--- a/target/linux/generic/backport-5.15/607-v5.18-net-skbuff-add-size-metadata-to-skb_shared_info-for-.patch
+++ b/target/linux/generic/backport-5.15/607-v5.18-net-skbuff-add-size-metadata-to-skb_shared_info-for-.patch
@@ -1,22 +1,26 @@
-commit d16697cb6261d4cc23422e6b1cb2759df8aa76d0
-Author: Lorenzo Bianconi <lorenzo@kernel.org>
-Date:   Fri Jan 21 11:09:44 2022 +0100
+From d16697cb6261d4cc23422e6b1cb2759df8aa76d0 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 21 Jan 2022 11:09:44 +0100
+Subject: [PATCH] net: skbuff: add size metadata to skb_shared_info for xdp
 
-    net: skbuff: add size metadata to skb_shared_info for xdp
-    
-    Introduce xdp_frags_size field in skb_shared_info data structure
-    to store xdp_buff/xdp_frame frame paged size (xdp_frags_size will
-    be used in xdp frags support). In order to not increase
-    skb_shared_info size we will use a hole due to skb_shared_info
-    alignment.
-    
-    Acked-by: Toke Hoiland-Jorgensen <toke@redhat.com>
-    Acked-by: John Fastabend <john.fastabend@gmail.com>
-    Acked-by: Jesper Dangaard Brouer <brouer@redhat.com>
-    Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
-    Link: https://lore.kernel.org/r/8a849819a3e0a143d540f78a3a5add76e17e980d.1642758637.git.lorenzo@kernel.org
-    Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+Introduce xdp_frags_size field in skb_shared_info data structure
+to store xdp_buff/xdp_frame frame paged size (xdp_frags_size will
+be used in xdp frags support). In order to not increase
+skb_shared_info size we will use a hole due to skb_shared_info
+alignment.
 
+Acked-by: Toke Hoiland-Jorgensen <toke@redhat.com>
+Acked-by: John Fastabend <john.fastabend@gmail.com>
+Acked-by: Jesper Dangaard Brouer <brouer@redhat.com>
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://lore.kernel.org/r/8a849819a3e0a143d540f78a3a5add76e17e980d.1642758637.git.lorenzo@kernel.org
+Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+---
+ include/linux/skbuff.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/linux/skbuff.h b/include/linux/skbuff.h
+index bf11e1fbd69b..8131d0de7559 100644
 --- a/include/linux/skbuff.h
 +++ b/include/linux/skbuff.h
 @@ -567,6 +567,7 @@ struct skb_shared_info {

--- a/target/linux/generic/backport-5.15/608-v5.18-net-veth-Account-total-xdp_frame-len-running-ndo_xdp.patch
+++ b/target/linux/generic/backport-5.15/608-v5.18-net-veth-Account-total-xdp_frame-len-running-ndo_xdp.patch
@@ -1,22 +1,27 @@
-commit 5142239a22219921a7863cf00c9ab853c00689d8
-Author: Lorenzo Bianconi <lorenzo@kernel.org>
-Date:   Fri Mar 11 10:14:18 2022 +0100
+From 5142239a22219921a7863cf00c9ab853c00689d8 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 11 Mar 2022 10:14:18 +0100
+Subject: [PATCH] net: veth: Account total xdp_frame len running ndo_xdp_xmit
 
-    net: veth: Account total xdp_frame len running ndo_xdp_xmit
-    
-    Even if this is a theoretical issue since it is not possible to perform
-    XDP_REDIRECT on a non-linear xdp_frame, veth driver does not account
-    paged area in ndo_xdp_xmit function pointer.
-    Introduce xdp_get_frame_len utility routine to get the xdp_frame full
-    length and account total frame size running XDP_REDIRECT of a
-    non-linear xdp frame into a veth device.
-    
-    Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
-    Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
-    Acked-by: Toke Hoiland-Jorgensen <toke@redhat.com>
-    Acked-by: John Fastabend <john.fastabend@gmail.com>
-    Link: https://lore.kernel.org/bpf/54f9fd3bb65d190daf2c0bbae2f852ff16cfbaa0.1646989407.git.lorenzo@kernel.org
+Even if this is a theoretical issue since it is not possible to perform
+XDP_REDIRECT on a non-linear xdp_frame, veth driver does not account
+paged area in ndo_xdp_xmit function pointer.
+Introduce xdp_get_frame_len utility routine to get the xdp_frame full
+length and account total frame size running XDP_REDIRECT of a
+non-linear xdp frame into a veth device.
 
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
+Acked-by: Toke Hoiland-Jorgensen <toke@redhat.com>
+Acked-by: John Fastabend <john.fastabend@gmail.com>
+Link: https://lore.kernel.org/bpf/54f9fd3bb65d190daf2c0bbae2f852ff16cfbaa0.1646989407.git.lorenzo@kernel.org
+---
+ drivers/net/veth.c |  4 ++--
+ include/net/xdp.h  | 14 ++++++++++++++
+ 2 files changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/veth.c b/drivers/net/veth.c
+index 58b20ea171dd..b77ce3fdcfe8 100644
 --- a/drivers/net/veth.c
 +++ b/drivers/net/veth.c
 @@ -501,7 +501,7 @@ static int veth_xdp_xmit(struct net_devi

--- a/target/linux/generic/backport-5.15/609-v5.18-veth-Allow-jumbo-frames-in-xdp-mode.patch
+++ b/target/linux/generic/backport-5.15/609-v5.18-veth-Allow-jumbo-frames-in-xdp-mode.patch
@@ -1,18 +1,25 @@
-commit 7cda76d858a4e71ac4a04066c093679a12e1312c
-Author: Lorenzo Bianconi <lorenzo@kernel.org>
-Date:   Fri Mar 11 10:14:20 2022 +0100
+From 7cda76d858a4e71ac4a04066c093679a12e1312c Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 11 Mar 2022 10:14:20 +0100
+Subject: [PATCH] veth: Allow jumbo frames in xdp mode
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
-    veth: Allow jumbo frames in xdp mode
-    
-    Allow increasing the MTU over page boundaries on veth devices
-    if the attached xdp program declares to support xdp fragments.
-    
-    Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
-    Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
-    Acked-by: Toke Høiland-Jørgensen <toke@redhat.com>
-    Acked-by: John Fastabend <john.fastabend@gmail.com>
-    Link: https://lore.kernel.org/bpf/d5dc039c3d4123426e7023a488c449181a7bc57f.1646989407.git.lorenzo@kernel.org
+Allow increasing the MTU over page boundaries on veth devices
+if the attached xdp program declares to support xdp fragments.
 
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
+Acked-by: Toke Høiland-Jørgensen <toke@redhat.com>
+Acked-by: John Fastabend <john.fastabend@gmail.com>
+Link: https://lore.kernel.org/bpf/d5dc039c3d4123426e7023a488c449181a7bc57f.1646989407.git.lorenzo@kernel.org
+---
+ drivers/net/veth.c | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/veth.c b/drivers/net/veth.c
+index bfae15ec902b..1b5714926d81 100644
 --- a/drivers/net/veth.c
 +++ b/drivers/net/veth.c
 @@ -1470,9 +1470,14 @@ static int veth_xdp_set(struct net_devic

--- a/target/linux/generic/hack-5.10/205-kconfig-exit.patch
+++ b/target/linux/generic/hack-5.10/205-kconfig-exit.patch
@@ -1,3 +1,20 @@
+From: David Bauer <mail@david-bauer.net>
+Subject: Kconfig: exit on unset symbol
+
+When a target configuration has unset Kconfig symbols, the build will
+fail when OpenWrt is compiled with V=s and stdin is connected to a tty.
+
+In case OpenWrt is compiled without either of these preconditions, the
+build will succeed with the symbols in question being unset.
+
+Modify the kernel configuration in a way it fails on unset symbols
+regardless of the aforementioned preconditions.
+
+Submitted-by: David Bauer <mail@david-bauer.net>
+---
+ scripts/kconfig/conf.c                                |  2 +
+ 1 files changed, 2 insertions(+)
+
 --- a/scripts/kconfig/conf.c
 +++ b/scripts/kconfig/conf.c
 @@ -215,6 +215,8 @@ static int conf_sym(struct menu *menu)

--- a/target/linux/generic/hack-5.10/253-ksmbd-config.patch
+++ b/target/linux/generic/hack-5.10/253-ksmbd-config.patch
@@ -1,3 +1,15 @@
+From: Rosen Penev <rosenp@gmail.com>
+Subject: Kconfig: add help text to kernel config
+
+These options will be used for ksmbd. Once kernel 5.15
+makes it in, this patch can go away.
+
+Submitted-by: Rosen Penev <rosenp@gmail.com>
+---
+ init/Kconfig | 2 +-
+ lib/Kconfig  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -2384,7 +2384,7 @@ config PADATA
@@ -19,4 +31,3 @@
 +	tristate "OID"
  	help
  	  Enable fast lookup object identifier registry.
- 

--- a/target/linux/generic/hack-5.10/261-lib-arc4-unhide.patch
+++ b/target/linux/generic/hack-5.10/261-lib-arc4-unhide.patch
@@ -1,6 +1,19 @@
+From: Koen Vandeputte <koen.vandeputte@ncentric.com>
+Subject: crypto: arc4 unhide
+
 This makes it possible to select CONFIG_CRYPTO_LIB_ARC4 directly. We 
 need this to be able to compile this into the kernel and make use of it 
 from backports.
+
+Submitted-by: Koen Vandeputte <koen.vandeputte@ncentric.com>
+Submitted-by: David Bauer <mail@david-bauer.net>
+Submitted-by: Christian Lamparter <chunkeey@gmail.com>
+Submitted-by: Ansuel Smith <ansuelsmth@gmail.com>
+Submitted-by: Robert Marko <robimarko@gmail.com>
+Submitted-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ lib/crypto/Kconfig                            |   2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 --- a/lib/crypto/Kconfig
 +++ b/lib/crypto/Kconfig

--- a/target/linux/generic/hack-5.10/410-block-fit-partition-parser.patch
+++ b/target/linux/generic/hack-5.10/410-block-fit-partition-parser.patch
@@ -1,3 +1,30 @@
+From: Daniel Golle <daniel@makrotopia.org>
+Subject: [PATCH] kernel: fix FIT partition parser compatibility issues
+
+The uImage.FIT partition parser used to squeeze in FIT partitions in
+the range where partition editor tools (fdisk and such) expect the
+regular partition. This is confusing people and tools when adding
+additional partitions on top of the partition used for OpenWrt's
+uImage.FIT.
+Instead of squeezing in the additional partitions, rather start with
+all uImage.FIT partitions at offset 64.
+
+Submitted-by: Daniel Golle <daniel@makrotopia.org>
+---
+ block/blk.h                                            |  2 ++
+ block/partitions/Kconfig                               |  7 +++
+ block/partitions/Makefile                              |  1 +
+ block/partitions/check.h                               |  3 ++
+ block/partitions/core.c                                | 15 +++++++
+ drivers/mtd/ubi/block.c                                |  7 +++
+ block/partitions/efi.c                                 |  8 +++++++
+ block/partitions/efi.h                                 |  3 ++
+ drivers/mtd/mtdblock.c                                 |  4 +++
+ drivers/mtd/mtd_blkdevs.c                              | 14 +------
+ block/partitions/msdos.c                               | 10 ++++++
+ include/linux/msdos_partition.h                        |  1 +
+ 12 files changed, 52 insertions(+), 13 deletions(-)
+
 --- a/block/blk.h
 +++ b/block/blk.h
 @@ -361,6 +361,8 @@ char *disk_name(struct gendisk *hd, int
@@ -221,4 +248,3 @@
 +	FIT_PARTITION = 0x2e,		/* U-Boot uImage.FIT */
  	SOLARIS_X86_PARTITION =	0x82,	/* also Linux swap partitions */
  	NEW_SOLARIS_X86_PARTITION = 0xbf,
- 

--- a/target/linux/generic/hack-5.10/430-mtk-bmt-support.patch
+++ b/target/linux/generic/hack-5.10/430-mtk-bmt-support.patch
@@ -1,3 +1,14 @@
+From 11425c9de29c8b9c5e4d7eec163a6afbb7fbdce2 Mon Sep 17 00:00:00 2001
+From: Felix Fietkau <nbd@nbd.name>
+Date: Thu, 9 Apr 2020 09:53:24 +0200
+Subject: mediatek: Implement bad-block management table support
+
+Submitted-by: Felix Fietkau <nbd@nbd.name>
+---
+ drivers/mtd/nand/Kconfig                      |   4 ++++
+ drivers/mtd/nand/Makefile                     |   1 +
+ 2 files changed, 5 insertions(+)
+
 --- a/drivers/mtd/nand/Kconfig
 +++ b/drivers/mtd/nand/Kconfig
 @@ -15,6 +15,10 @@ config MTD_NAND_ECC

--- a/target/linux/generic/hack-5.10/600-bridge_offload.patch
+++ b/target/linux/generic/hack-5.10/600-bridge_offload.patch
@@ -1,3 +1,31 @@
+From: Felix Fietkau <nbd@nbd.name>
+Subject: bridge: Add a fast path for the bridge code
+
+This caches flows between MAC addresses on separate ports, including their VLAN
+in order to bypass the normal bridge forwarding code.
+In my test on MT7622, this reduces LAN->WLAN bridging CPU usage by 6-10%,
+potentially even more on weaker platforms
+
+Submitted-by: Felix Fietkau <nbd@nbd.name>
+---
+ include/linux/if_bridge.h                     |   1 +
+ net/bridge/Makefile                           |   2 +-
+ net/bridge/br.c                               |   8 +++
+ net/bridge/br_device.c                        |   7 +++
+ net/bridge/br_forward.c                       |   3 ++
+ net/bridge/br_if.c                            |   7 ++-
+ net/bridge/br_input.c                         |   5 ++
+ net/bridge/br_offload.c                       | 436 +++++++++++++++
+ net/bridge/br_private.h                       |  22 ++++-
+ net/bridge/br_private_offload.h               |  21 +++++
+ net/bridge/br_stp.c                           |   3 +
+ net/bridge/br_sysfs_br.c                      |  35 ++++++
+ net/bridge/br_sysfs_if.c                      |   2 +
+ net/bridge/br_vlan_tunnel.c                   |   3 ++
+ 14 files changed, 552 insertions(+), 3 deletions(-)
+ create mode 100644 net/bridge/br_offload.c
+ create mode 100644 net/bridge/br_private_offload.h
+
 --- a/include/linux/if_bridge.h
 +++ b/include/linux/if_bridge.h
 @@ -57,6 +57,7 @@ struct br_ip_list {

--- a/target/linux/generic/hack-5.10/711-net-dsa-mv88e6xxx-disable-ATU-violation.patch
+++ b/target/linux/generic/hack-5.10/711-net-dsa-mv88e6xxx-disable-ATU-violation.patch
@@ -1,3 +1,32 @@
+From: DENG Qingfang <dqfext@gmail.com>
+Subject: DSA: roaming fix for Marvell mv88e6xxx
+
+Marvell mv88e6xxx switch series cannot perform MAC learning from
+CPU-injected (FROM_CPU) DSA frames, which results in 2 issues.
+- excessive flooding, due to the fact that DSA treats those addresses
+as unknown
+- the risk of stale routes, which can lead to temporary packet loss
+
+Backport those patch series from netdev mailing list, which solve these
+issues by adding and clearing static entries to the switch's FDB.
+
+Add a hack patch to set default VID to 1 in port_fdb_{add,del}. Otherwise
+the static entries will be added to the switch's private FDB if VLAN
+filtering disabled, which will not work.
+
+The switch may generate an "ATU violation" warning when a client moves
+from the CPU port to a switch port because the static ATU entry added by
+DSA core still points to the CPU port. DSA core will then clear the static
+entry so it is not fatal. Disable the warning so it will not confuse users.
+
+Link: https://lore.kernel.org/netdev/20210106095136.224739-1-olteanv@gmail.com/
+Link: https://lore.kernel.org/netdev/20210116012515.3152-1-tobias@waldekranz.com/
+Ref: https://gitlab.nic.cz/turris/turris-build/-/issues/165
+Submitted-by: DENG Qingfang <dqfext@gmail.com>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c              | 3 +++
+ 3 files changed, 3 insertions(+)
+
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
 @@ -2705,6 +2705,9 @@ static int mv88e6xxx_setup_port(struct m

--- a/target/linux/generic/hack-5.10/760-net-usb-r8152-add-LED-configuration-from-OF.patch
+++ b/target/linux/generic/hack-5.10/760-net-usb-r8152-add-LED-configuration-from-OF.patch
@@ -36,7 +36,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 +
 +	if (ret)
 +		return ret;
-+	
++
 +	ocp_write_word(tp, MCU_TYPE_PLA, PLA_LEDSEL, led_data);
 +
 +	return 0;

--- a/target/linux/generic/hack-5.10/780-usb-net-MeigLink_modem_support.patch
+++ b/target/linux/generic/hack-5.10/780-usb-net-MeigLink_modem_support.patch
@@ -1,3 +1,17 @@
+From: Daniel Golle <daniel@makrotopia.org>
+Subject: wwan: Add MeigLink SLM750 modem support
+
+Add patch found in Teltonika RUT9_R_00.07.01.4 GPL SDK download[1]
+adding USB IDs of the MeigLink SLM750 to the relevant kernel drivers.
+Newer versions of Teltonika's 2G/3G/4G RUT9XX WWAN router series come
+with this kind of modem.
+
+[1]: https://wiki.teltonika-networks.com/view/GPL
+Submitted-by: Daniel Golle <daniel@makrotopia.org>
+---
+ drivers/net/usb/qmi_wwan.c                    | 8 ++++++
+ 1 file changed, 8 insertions(+)
+
 --- a/drivers/net/usb/qmi_wwan.c
 +++ b/drivers/net/usb/qmi_wwan.c
 @@ -1024,6 +1024,7 @@ static const struct usb_device_id produc

--- a/target/linux/generic/hack-5.10/901-debloat_sock_diag.patch
+++ b/target/linux/generic/hack-5.10/901-debloat_sock_diag.patch
@@ -33,7 +33,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  obj-y		     += dev.o dev_addr_lists.o dst.o netevent.o \
  			neighbour.o rtnetlink.o utils.o link_watch.o filter.o \
 -			sock_diag.o dev_ioctl.o tso.o sock_reuseport.o \
-+ 			dev_ioctl.o tso.o sock_reuseport.o \
++			dev_ioctl.o tso.o sock_reuseport.o \
  			fib_notifier.o xdp.o flow_offload.o
  
 +obj-$(CONFIG_SOCK_DIAG) += sock_diag.o

--- a/target/linux/generic/hack-5.10/920-device_tree_cmdline.patch
+++ b/target/linux/generic/hack-5.10/920-device_tree_cmdline.patch
@@ -1,3 +1,19 @@
+From a9968d9cb8cb10030491fa05e24b00bd42f6d3a9 Mon Sep 17 00:00:00 2001
+From: John Crispin <john@openwrt.org>
+Date: Thu, 30 May 2013 16:00:42 +0000
+Subject: fdt: enable retrieving kernel args from bootloader
+
+This patch is a device tree enhancement that IMHO is worthy of mainline.
+It allows the bootloader's commandline to be preserved even when the
+device tree specifies one.
+
+Submitted-by: Daniel Gimpelevich <daniel@gimpelevich.san-francisco.ca.us>
+
+SVN-Revision: 36780
+---
+ drivers/of/fdt.c                                     | 3 +++
+ 1 file changed, 3 insertions(+)
+
 --- a/drivers/of/fdt.c
 +++ b/drivers/of/fdt.c
 @@ -1055,6 +1055,9 @@ int __init early_init_dt_scan_chosen(uns

--- a/target/linux/generic/pending-5.10/101-Use-stddefs.h-instead-of-compiler.h.patch
+++ b/target/linux/generic/pending-5.10/101-Use-stddefs.h-instead-of-compiler.h.patch
@@ -1,3 +1,11 @@
+From: Felix Fietkau <nbd@nbd.name>
+Subject: uapi: Fix an issue with kernel headers that broke perf
+
+Submitted-by: Felix Fietkau <nbd@nbd.name>
+---
+ include/uapi/linux/swab.h                             | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 --- a/include/uapi/linux/swab.h
 +++ b/include/uapi/linux/swab.h
 @@ -3,7 +3,7 @@

--- a/target/linux/generic/pending-5.10/332-arc-add-OWRTDTB-section.patch
+++ b/target/linux/generic/pending-5.10/332-arc-add-OWRTDTB-section.patch
@@ -74,7 +74,7 @@ Signed-off-by: Evgeniy Didin <Evgeniy.Didin@synopsys.com>
 +	*
 +	* Note: "OWRTDTB:" won't be overwritten with .dtb, .dtb will follow it.
 +	*/
-+ 	.owrt : {
++	.owrt : {
 +		*(.owrt)
 +	. = ALIGN(PAGE_SIZE);
 +	}

--- a/target/linux/generic/pending-5.10/400-mtd-mtdsplit-support.patch
+++ b/target/linux/generic/pending-5.10/400-mtd-mtdsplit-support.patch
@@ -1,3 +1,25 @@
+From: Gabor Juhos <juhosg@openwrt.org>
+Subject: mtd: Add new Kconfig option for firmware partition split
+
+Add a new kernel config option for generic firmware partition
+split support and change the uImage split support to depend on
+the new option. Aslo rename the MTD_UIMAGE_SPLIT_NAME option to
+MTD_SPLIT_FIRMWARE_NAME to make it more generic.
+
+The patch is in preparation for multiple firmware format
+support.
+
+Submitted-by: Gabor Juhos <juhosg@openwrt.org>
+
+SVN-Revision: 38002
+---
+ drivers/mtd/Kconfig                           |  19 +
+ drivers/mtd/mtdpart.c                         | 144 +++++++++++++-----
+ include/linux/mtd/partitions.h                |   7 +
+ drivers/mtd/Makefile                          |   2 +
+ include/linux/mtd/mtd.h                       |  25 +
+ 5 files changed, 171 insertions(+), 25 deletions(-)
+
 --- a/drivers/mtd/Kconfig
 +++ b/drivers/mtd/Kconfig
 @@ -12,6 +12,25 @@ menuconfig MTD

--- a/target/linux/generic/pending-5.10/483-mtd-spi-nor-add-gd25q512.patch
+++ b/target/linux/generic/pending-5.10/483-mtd-spi-nor-add-gd25q512.patch
@@ -1,3 +1,12 @@
+From: Roman Yeryomin <roman@advem.lv>
+Subject: mtd/spi-nor/gigadevice: Add gd25q512 SPI NOR flash
+
+Submitted-by: Roman Yeryomin <roman@advem.lv>
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ drivers/mtd/spi-nor/gigadevice.c              |    3 +++
+ 1 files changed, 3 insertions(+)
+
 --- a/drivers/mtd/spi-nor/gigadevice.c
 +++ b/drivers/mtd/spi-nor/gigadevice.c
 @@ -53,6 +53,9 @@ static const struct flash_info gigadevic

--- a/target/linux/generic/pending-5.10/484-mtd-spi-nor-add-esmt-f25l16pa.patch
+++ b/target/linux/generic/pending-5.10/484-mtd-spi-nor-add-esmt-f25l16pa.patch
@@ -1,3 +1,16 @@
+From: Jihoon Han <rapid_renard@renard.ga>
+Subject: mtd/spi-nor/esmt: Add support for ESMT F25L16PA(2S) SPI-NOR
+
+This fixes support for Dongwon T&I DW02-412H which uses F25L16PA(2S) flash.
+
+Submitted-by: Jihoon Han <rapid_renard@renard.ga>
+Reviewed-by: Sungbo Eo <mans0n@gorani.run>
+[refresh patches]
+Submitted-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
+---
+ drivers/mtd/spi-nor/esmt.c                            |  2 ++
+ 1 files changed, 2 insertions(+)
+
 --- a/drivers/mtd/spi-nor/esmt.c
 +++ b/drivers/mtd/spi-nor/esmt.c
 @@ -10,6 +10,8 @@

--- a/target/linux/generic/pending-5.10/485-mtd-spi-nor-add-xmc-xm25qh128c.patch
+++ b/target/linux/generic/pending-5.10/485-mtd-spi-nor-add-xmc-xm25qh128c.patch
@@ -1,3 +1,14 @@
+From: Langhua Ye <y1248289414@outlook.com>
+Subject: mtd/spi-nor/xmc: add support for XMC XM25QH128C
+
+The XMC XM25QH128C is a 16MB SPI NOR chip. The patch is verified on Ruijie RG-EW3200GX PRO.
+Datasheet available at https://www.xmcwh.com/uploads/435/XM25QH128C.pdf
+
+Submitted-by: Langhua Ye <y1248289414@outlook.com>
+---
+ drivers/mtd/spi-nor/xmc.c                             | 2 ++
+ 1 file changed, 2 insertions(+)
+
 --- a/drivers/mtd/spi-nor/xmc.c
 +++ b/drivers/mtd/spi-nor/xmc.c
 @@ -14,6 +14,8 @@ static const struct flash_info xmc_parts

--- a/target/linux/generic/pending-5.10/500-fs_cdrom_dependencies.patch
+++ b/target/linux/generic/pending-5.10/500-fs_cdrom_dependencies.patch
@@ -1,3 +1,14 @@
+From: Felix Fietkau <nbd@nbd.name>
+Subject: fs: Add CDROM dependencies
+
+Submitted-by: Felix Fietkau <nbd@nbd.name>
+---
+ fs/hfs/Kconfig                                |    1 +
+ fs/hfsplus/Kconfig                            |    1 +
+ fs/isofs/Kconfig                              |    1 +
+ fs/udf/Kconfig                                |    1 +
+ 4 files changed, 4 insertions(+)
+
 --- a/fs/hfs/Kconfig
 +++ b/fs/hfs/Kconfig
 @@ -2,6 +2,7 @@

--- a/target/linux/generic/pending-5.10/683-of_net-add-mac-address-to-of-tree.patch
+++ b/target/linux/generic/pending-5.10/683-of_net-add-mac-address-to-of-tree.patch
@@ -1,3 +1,19 @@
+From: David Bauer <mail@david-bauer.net>
+Subject: of/net: Add MAC address to of tree
+
+The label-mac logic relies on the mac-address property of a netdev
+devices of-node. However, the mac address can also be stored as a
+different property or read from e.g. an mtd device.
+
+Create this node when reading a mac-address from OF if it does not
+already exist and copy the mac-address used for the device to this
+property. This way, the MAC address can be accessed using procfs.
+
+Submitted-by: David Bauer <mail@david-bauer.net>
+---
+ drivers/of/of_net.c                           | 22 ++++++++++++++
+ 1 files changed, 22 insertions(+)
+
 --- a/drivers/of/of_net.c
 +++ b/drivers/of/of_net.c
 @@ -95,6 +95,27 @@ static int of_get_mac_addr_nvmem(struct

--- a/target/linux/generic/pending-5.15/487-mtd-spinand-Add-support-for-Etron-EM73D044VCx.patch
+++ b/target/linux/generic/pending-5.15/487-mtd-spinand-Add-support-for-Etron-EM73D044VCx.patch
@@ -1,3 +1,43 @@
+From f32085fc0b87049491b07e198d924d738a1a2834 Mon Sep 17 00:00:00 2001
+From: Daniel Danzberger <daniel@dd-wrt.com>
+Date: Wed, 3 Aug 2022 17:31:03 +0200
+Subject: [PATCH] mtd: spinand: Add support for Etron EM73D044VCx
+
+Airoha is a new ARM platform based on Cortex-A53 which has recently been
+merged into linux-next.
+
+Due to BootROM limitations on this platform, the Cortex-A53 can't run in
+Aarch64 mode and code must be compiled for 32-Bit ARM.
+
+This support is based mostly on those linux-next commits backported
+for kernel 5.15.
+
+Patches:
+1 - platform support = linux-next
+2 - clock driver = linux-next
+3 - gpio driver = linux-next
+4 - linux,usable-memory-range dts support = linux-next
+5 - mtd spinand driver
+6 - spi driver
+7 - pci driver (kconfig only, uses mediatek PCI) = linux-next
+
+Still missing:
+- Ethernet driver
+- Sysupgrade support
+
+A.t.m there exists one subtarget EN7523 with only one evaluation
+board.
+
+The initramfs can be run with the following commands from u-boot:
+-
+u-boot> setenv bootfile \
+	openwrt-airoha-airoha_en7523-evb-initramfs-kernel.bin
+u-boot> tftpboot
+u-boot> bootm 0x81800000
+-
+
+Submitted-by: Daniel Danzberger <daniel@dd-wrt.com>
+
 --- a/drivers/mtd/nand/spi/Makefile
 +++ b/drivers/mtd/nand/spi/Makefile
 @@ -1,3 +1,3 @@

--- a/target/linux/realtek/patches-5.10/007-5.16-gpio-realtek-realtek-otto-fix-gpio-line-irq-offset.patch
+++ b/target/linux/realtek/patches-5.10/007-5.16-gpio-realtek-realtek-otto-fix-gpio-line-irq-offset.patch
@@ -1,4 +1,5 @@
-gpio: realtek-otto: fix GPIO line IRQ offset
+From: Sander Vanheule <sander@svanheule.net>
+Subject: gpio: realtek-otto: fix GPIO line IRQ offset
 
 The irqchip uses one domain for all GPIO lines, so th line offset should be
 determined w.r.t. the first line of the first port, not the first line of the

--- a/target/linux/realtek/patches-5.10/300-mips-add-rtl838x-platform.patch
+++ b/target/linux/realtek/patches-5.10/300-mips-add-rtl838x-platform.patch
@@ -1,3 +1,18 @@
+From fce11f68491b46b93df69de0630cd9edb90bc772 Mon Sep 17 00:00:00 2001
+From: Birger Koblitz <git@birger-koblitz.de>
+Date: Wed, 29 Dec 2021 21:54:21 +0100
+Subject: [PATCH] realtek: Create 4 different Realtek Platforms
+
+Creates RTL83XX as a basic kernel config parameter for the
+RTL838X, RTL839x, RTL930X and RTL931X platforms with respective
+configurations for the SoCs, which are introduced in addition.
+
+Submitted-by: Birger Koblitz <git@birger-koblitz.de>
+---
+ arch/mips/Kbuild.platforms                    |  1 +
+ arch/mips/Kconfig                             | 57 ++++++++++++++
+ 2 files changed, 58 insertions(+)
+
 --- a/arch/mips/Kbuild.platforms
 +++ b/arch/mips/Kbuild.platforms
 @@ -23,6 +23,7 @@ platform-$(CONFIG_PIC32MZDA)		+= pic32/

--- a/target/linux/realtek/patches-5.10/301-gpio-add-rtl8231-driver.patch
+++ b/target/linux/realtek/patches-5.10/301-gpio-add-rtl8231-driver.patch
@@ -1,3 +1,28 @@
+From 2b88563ee5aafd9571d965b7f2093a0f58d98a31 Mon Sep 17 00:00:00 2001
+From: John Crispin <john@phrozen.org>
+Date: Thu, 26 Nov 2020 12:02:21 +0100
+Subject: [PATCH] realtek: update the tree to the latest refactored version
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+* rename the target to realtek
+* add refactored DSA driver
+* add latest gpio driver
+* lots of arch cleanups
+* new irq driver
+* additional boards
+
+Submitted-by: Bert Vermeulen <bert@biot.com>
+Submitted-by: Birger Koblitz <mail@birger-koblitz.de>
+Submitted-by: Sander Vanheule <sander@svanheule.net>
+Submitted-by: Bjørn Mork <bjorn@mork.no>
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ drivers/gpio/Kconfig                          |    6 ++++++
+ drivers/gpio/Makefile                         |    1 +
+ 2 files changed, 7 insertions(+)
+
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -508,6 +508,12 @@ config GPIO_REG

--- a/target/linux/realtek/patches-5.10/303-gpio-update-dependencies-for-gpio-realtek-otto.patch
+++ b/target/linux/realtek/patches-5.10/303-gpio-update-dependencies-for-gpio-realtek-otto.patch
@@ -1,3 +1,16 @@
+From 9bac1c20b8f39f2e0e342b087add5093b94feaed Mon Sep 17 00:00:00 2001
+From: INAGAKI Hiroshi <musashino.open@gmail.com>
+Date: Wed, 5 May 2021 22:05:39 +0900
+Subject: realtek: backport gpio-realtek-otto driver from 5.13 to 5.10
+
+This patch backports "gpio-realtek-otto" driver to Kernel 5.10.
+"MACH_REALTEK_RTL" is used as a platform name in upstream, but "RTL838X"
+is used in OpenWrt, so update the dependency by the additional patch.
+
+Submitted-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+---
+ drivers/gpio/Kconfig                          |   4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
 --- a/drivers/gpio/Kconfig
 +++ b/drivers/gpio/Kconfig
 @@ -491,8 +491,8 @@ config GPIO_RDA

--- a/target/linux/realtek/patches-5.10/304-spi-update-dependency-for-spi-realtek-rtl.patch
+++ b/target/linux/realtek/patches-5.10/304-spi-update-dependency-for-spi-realtek-rtl.patch
@@ -1,3 +1,17 @@
+From 0b000cbfe0aa0323bffa855ef8449c0687a4c071 Mon Sep 17 00:00:00 2001
+From: INAGAKI Hiroshi <musashino.open@gmail.com>
+Date: Thu, 6 May 2021 19:30:58 +0900
+Subject: realtek: backport spi-realtek-rtl driver from 5.12 to 5.10
+
+This patch backports "spi-realtek-rtl" driver to Kernel 5.10 from 5.12.
+"MACH_REALTEK_RTL" is used as a platform name in upstream, but "RTL838X"
+is used in OpenWrt, so update the dependency by the additional patch.
+
+Submitted-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+---
+ drivers/spi/Makefile                          |  2 +-
+ 1 files changed, 1 insertion(+), 1 deletion(-)
+
 --- a/drivers/spi/Makefile
 +++ b/drivers/spi/Makefile
 @@ -94,7 +94,7 @@ obj-$(CONFIG_SPI_QCOM_QSPI)		+= spi-qcom

--- a/target/linux/realtek/patches-5.10/305-irqchip-update-dependency-for-irq-realtek-rtl.patch
+++ b/target/linux/realtek/patches-5.10/305-irqchip-update-dependency-for-irq-realtek-rtl.patch
@@ -1,3 +1,17 @@
+From 2cd00b51470a30198b048a5fca48a04db77e29cc Mon Sep 17 00:00:00 2001
+From: INAGAKI Hiroshi <musashino.open@gmail.com>
+Date: Fri, 21 May 2021 23:16:37 +0900
+Subject: [PATCH] realtek: backport irq-realtek-rtl driver from 5.12 to 5.10
+
+This patch backports "irq-realtek-rtl" driver to Kernel 5.10 from 5.12.
+"MACH_REALTEK_RTL" is used as a platform name in upstream, but "RTL838X"
+is used in OpenWrt, so update the dependency by the additional patch.
+
+Submitted-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+---
+ drivers/irqchip/Makefile                      | 2 +-
+ 1 files changed, 1 insertion(+), 1 deletion(-)
+
 --- a/drivers/irqchip/Makefile
 +++ b/drivers/irqchip/Makefile
 @@ -114,4 +114,4 @@ obj-$(CONFIG_LOONGSON_PCH_PIC)		+= irq-l

--- a/target/linux/realtek/patches-5.10/307-wdt-update-dependency-for-realtek-otto-wdt.patch
+++ b/target/linux/realtek/patches-5.10/307-wdt-update-dependency-for-realtek-otto-wdt.patch
@@ -1,3 +1,20 @@
+From b8fc5eecdc5d33cf261986436597b5482ab856da Mon Sep 17 00:00:00 2001
+From: Sander Vanheule <sander@svanheule.net>
+Date: Sun, 14 Nov 2021 19:45:32 +0100
+Subject: [PATCH] realtek: Backport Realtek Otto WDT driver
+
+Add patch submitted upstream to linux-watchdog and replace the MIPS
+architecture symbols. Requires one extra patch for the DIV_ROUND_*
+macros, which have moved to a different header since 5.10.
+
+Submitted-by: Sander Vanheule <sander@svanheule.net>
+Tested-by: Stijn Segers <foss@volatilesystems.org>
+Tested-by: Paul Fertser <fercerpav@gmail.com>
+Tested-by: Stijn Tintel <stijn@linux-ipv6.be>
+---
+ drivers/watchdog/Kconfig                      | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
 --- a/drivers/watchdog/Kconfig
 +++ b/drivers/watchdog/Kconfig
 @@ -997,10 +997,10 @@ config RTD119X_WATCHDOG

--- a/target/linux/realtek/patches-5.10/308-otto-wdt-fix-missing-math-header.patch
+++ b/target/linux/realtek/patches-5.10/308-otto-wdt-fix-missing-math-header.patch
@@ -1,3 +1,20 @@
+From b8fc5eecdc5d33cf261986436597b5482ab856da Mon Sep 17 00:00:00 2001
+From: Sander Vanheule <sander@svanheule.net>
+Date: Sun, 14 Nov 2021 19:45:32 +0100
+Subject: [PATCH] realtek: Backport Realtek Otto WDT driver
+
+Add patch submitted upstream to linux-watchdog and replace the MIPS
+architecture symbols. Requires one extra patch for the DIV_ROUND_*
+macros, which have moved to a different header since 5.10.
+
+Submitted-by: Sander Vanheule <sander@svanheule.net>
+Tested-by: Stijn Segers <foss@volatilesystems.org>
+Tested-by: Paul Fertser <fercerpav@gmail.com>
+Tested-by: Stijn Tintel <stijn@linux-ipv6.be>
+---
+ drivers/watchdog/realtek_otto_wdt.c           | 2 +-
+ 1 files changed, 1 insertion(+), 1 deletion(-)
+
 --- a/drivers/watchdog/realtek_otto_wdt.c
 +++ b/drivers/watchdog/realtek_otto_wdt.c
 @@ -21,7 +21,7 @@

--- a/target/linux/realtek/patches-5.10/309-cevt-rtl9300-support.patch
+++ b/target/linux/realtek/patches-5.10/309-cevt-rtl9300-support.patch
@@ -1,3 +1,24 @@
+From 775d903216a08c2a8009863d2f9c33f62657ba94 Mon Sep 17 00:00:00 2001
+From: Birger Koblitz <git@birger-koblitz.de>
+Date: Thu, 6 Jan 2022 20:27:01 +0100
+Subject: [PATCH] realtek: Replace the RTL9300 generic timer with a CEVT timer
+
+The RTL9300 has a broken R4K MIPS timer interrupt, however, the
+R4K clocksource works. We replace the RTL9300 timer with a
+Clock Event Timer (CEVT), which is VSMP aware and can be instantiated
+as part of brining a VSMTP cpu up instead of the R4K CEVT source.
+For this we place the RTL9300 CEVT timer in arch/mips/kernel
+together with other MIPS CEVT timers, initialize the SoC IRQs
+from a modified smp-mt.c and instantiate each timer as part
+of the MIPS time setup in arch/mips/include/asm/time.h instead
+of the R4K CEVT, similarly as is done by other MIPS CEVT timers.
+
+Submitted-by: Birger Koblitz <git@birger-koblitz.de>
+---
+ arch/mips/kernel/Makefile                     | 1 +
+ arch/mips/include/asm/time.h                  | 7 +++++++
+ 2 files changed, 8 insertions(+)
+
 --- a/arch/mips/kernel/Makefile
 +++ b/arch/mips/kernel/Makefile
 @@ -27,6 +27,7 @@ obj-$(CONFIG_CEVT_BCM1480)	+= cevt-bcm14

--- a/target/linux/realtek/patches-5.10/310-add-i2c-rtl9300-support.patch
+++ b/target/linux/realtek/patches-5.10/310-add-i2c-rtl9300-support.patch
@@ -1,3 +1,20 @@
+From 63a0a4d85bc900464c5b046b13808a582345f8c8 Mon Sep 17 00:00:00 2001
+From: Birger Koblitz <git@birger-koblitz.de>
+Date: Sat, 11 Dec 2021 20:14:47 +0100
+Subject: [PATCH] realtek: Add support for RTL9300/RTL9310 I2C controller
+
+This adds support for the RTL9300 and RTL9310 I2C controller.
+The controller implements the SMBus protocol for SMBus transfers
+over an I2C bus. The driver supports selecting one of the 2 possible
+SCL pins and any of the 8 possible SDA pins. Bus speeds of
+100kHz (standard speed) and 400kHz (high speed I2C) are supported.
+
+Submitted-by: Birger Koblitz <git@birger-koblitz.de>
+---
+ drivers/i2c/busses/Kconfig                    | 10 +++++++++
+ drivers/i2c/busses/Makefile                   |  1 +
+ 2 files changed, 11 insertions(+)
+
 --- a/drivers/i2c/busses/Kconfig
 +++ b/drivers/i2c/busses/Kconfig
 @@ -954,6 +954,16 @@ config I2C_RK3X

--- a/target/linux/realtek/patches-5.10/311-add-i2c-mux-rtl9300-support.patch
+++ b/target/linux/realtek/patches-5.10/311-add-i2c-mux-rtl9300-support.patch
@@ -1,3 +1,22 @@
+From f4bdb7fdccdfe3fa382abe77f72a16c2f2e6add0 Mon Sep 17 00:00:00 2001
+From: Birger Koblitz <git@birger-koblitz.de>
+Date: Sat, 11 Dec 2021 20:25:37 +0100
+Subject: [PATCH] realtek: Add support for RTL9300/RTL9310 I2C multiplexing
+
+The RTL9300/RTL9310 I2C controllers have support for 2 independent I2C
+masters, each with a fixed SCL pin, that cannot be changed. Each of these
+masters can use 8 (RTL9300) or 16 (RTL9310) different pins for SDA.
+This multiplexer directly controls the two masters and their shared
+IO configuration registers to allow multiplexing between any of these
+busses. The two masters cannot be used in parallel as the multiplex
+is protected by a standard multiplex lock.
+
+Submitted-by: Birger Koblitz <git@birger-koblitz.de>
+---
+ drivers/i2c/muxes/Kconfig                     |  9 +++++++
+ drivers/i2c/muxes/Makefile                    |  1 +
+ 2 files changed, 10 insertions(+)
+
 --- a/drivers/i2c/muxes/Kconfig
 +++ b/drivers/i2c/muxes/Kconfig
 @@ -99,6 +99,15 @@ config I2C_MUX_REG

--- a/target/linux/realtek/patches-5.10/312-rt9313-support.patch
+++ b/target/linux/realtek/patches-5.10/312-rt9313-support.patch
@@ -1,3 +1,19 @@
+From 0b8dfe085180b58b81d2657c76b080168e3bc8df Mon Sep 17 00:00:00 2001
+From: Birger Koblitz <git@birger-koblitz.de>
+Date: Wed, 19 Jan 2022 18:14:02 +0100
+Subject: [PATCH] realtek: Add RTL931X sub-target
+
+We add the RTL931X sub-target with kernel configuration for
+a dual core MIPS InterAptive CPU.
+
+Submitted-by: Sebastian Gottschall <s.gottschall@dd-wrt.com>
+Submitted-by: Birger Koblitz <git@birger-koblitz.de>
+---
+ arch/mips/Makefile                            | 10 +++++++++++++--
+ arch/mips/kernel/head.S                       |  4 ++++
+ aarch/mips/kernel/vmlinux.lds.S               |  4 ++++
+ 3 files changed, 18 insertions(+), 2 deletions(-)
+
 --- a/arch/mips/Makefile
 +++ b/arch/mips/Makefile
 @@ -307,14 +307,24 @@ endif

--- a/target/linux/realtek/patches-5.10/315-irqchip-irq-realtek-rtl-add-VPE-support.patch
+++ b/target/linux/realtek/patches-5.10/315-irqchip-irq-realtek-rtl-add-VPE-support.patch
@@ -1,3 +1,17 @@
+From 6c18e9c491959ac0674ebe36b09f9ddc3f2c9bce Mon Sep 17 00:00:00 2001
+From: Birger Koblitz <git@birger-koblitz.de>
+Date: Fri, 31 Dec 2021 11:56:49 +0100
+Subject: [PATCH] realtek: Add VPE support for the IRQ driver
+
+In order to support VSMP, enable support for both VPEs
+of the RTL839X and RTL930X SoCs in the irq-realtek-rtl
+driver. Add support for IRQ affinity setting.
+
+Submitted-by: Birger Koblitz <git@birger-koblitz.de>
+---
+ drivers/irqchip/irq-realtek-rtl.c             | 152 +++++++++++++++---
+ 1 file changed, 73 insertions(+), 76 deletions(-)
+
 --- a/drivers/irqchip/irq-realtek-rtl.c
 +++ b/drivers/irqchip/irq-realtek-rtl.c
 @@ -21,21 +21,63 @@

--- a/target/linux/realtek/patches-5.10/316-otto-gpio-uniprocessor-irq-mask.patch
+++ b/target/linux/realtek/patches-5.10/316-otto-gpio-uniprocessor-irq-mask.patch
@@ -1,3 +1,25 @@
+From bde6311569ef25a00c3beaeabfd6b78b19651872 Mon Sep 17 00:00:00 2001
+From: Sander Vanheule <sander@svanheule.net>
+Date: Sun, 29 May 2022 19:38:09 +0200
+Subject: [PATCH] realtek: don't unmask non-maskable GPIO IRQs
+
+On uniprocessor builds, for_each_cpu(cpu, mask) will assume 'mask'
+always contains exactly one CPU, and ignore the actual mask contents.
+This causes the loop to run, even when it shouldn't on an empty mask,
+and tries to access an uninitialised pointer.
+
+Fix this by wrapping the loop in a cpumask_empty() check, to ensure it
+will not run on uniprocessor builds if the CPU mask is empty.
+
+Fixes: af6cd37f42f3 ("realtek: replace RTL93xx GPIO patches")
+Reported-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+Reported-by: Robert Marko <robimarko@gmail.com>
+Tested-by: Robert Marko <robimarko@gmail.com>
+Submitted-by: Sander Vanheule <sander@svanheule.net>
+---
+ drivers/gpio/gpio-realtek-otto.c              | 9 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
 --- a/drivers/gpio/gpio-realtek-otto.c
 +++ b/drivers/gpio/gpio-realtek-otto.c
 @@ -304,6 +304,7 @@ static int realtek_gpio_irq_set_affinity

--- a/target/linux/realtek/patches-5.10/318-add-rtl83xx-clk-support.patch
+++ b/target/linux/realtek/patches-5.10/318-add-rtl83xx-clk-support.patch
@@ -1,3 +1,16 @@
+From 800d5fb3c6a16661932c932bacd660e38d06b727 Mon Sep 17 00:00:00 2001
+From: Markus Stockhausen <markus.stockhausen@gmx.de>
+Date: Thu, 25 Aug 2022 08:22:36 +0200
+Subject: [PATCH] realtek: add patch to enable new clock driver in kernel
+
+Allow building the clock driver with kernel config options.
+
+Submitted-by: Markus Stockhausen <markus.stockhausen@gmx.de>
+---
+ drivers/clk/Kconfig                           | 1 +
+ drivers/clk/Makefile                          | 1 +
+ 2 files changed, 2 insertions(+)
+
 --- a/drivers/clk/Kconfig
 +++ b/drivers/clk/Kconfig
 @@ -372,6 +372,7 @@ source "drivers/clk/mediatek/Kconfig"

--- a/target/linux/realtek/patches-5.10/319-irqchip-irq-realtek-rtl-fix-VPE-affinity.patch
+++ b/target/linux/realtek/patches-5.10/319-irqchip-irq-realtek-rtl-fix-VPE-affinity.patch
@@ -1,3 +1,17 @@
+From 2cd00b51470a30198b048a5fca48a04db77e29cc Mon Sep 17 00:00:00 2001
+From: INAGAKI Hiroshi <musashino.open@gmail.com>
+Date: Fri, 21 May 2021 23:16:37 +0900
+Subject: [PATCH] realtek: backport irq-realtek-rtl driver from 5.12 to 5.10
+
+This patch backports "irq-realtek-rtl" driver to Kernel 5.10 from 5.12.
+"MACH_REALTEK_RTL" is used as a platform name in upstream, but "RTL838X"
+is used in OpenWrt, so update the dependency by the additional patch.
+
+Submitted-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+---
+ drivers/irqchip/irq-realtek-rtl.c             | 38 +++++++++++------
+ 1 files changed, 58 insertions(+), 20 deletions(-)
+
 --- a/drivers/irqchip/irq-realtek-rtl.c
 +++ b/drivers/irqchip/irq-realtek-rtl.c
 @@ -28,6 +28,7 @@ static DEFINE_RAW_SPINLOCK(irq_lock);

--- a/target/linux/realtek/patches-5.10/700-net-dsa-add-support-for-rtl838x-switch.patch
+++ b/target/linux/realtek/patches-5.10/700-net-dsa-add-support-for-rtl838x-switch.patch
@@ -1,3 +1,25 @@
+From 2b88563ee5aafd9571d965b7f2093a0f58d98a31 Mon Sep 17 00:00:00 2001
+From: John Crispin <john@phrozen.org>
+Date: Thu, 26 Nov 2020 12:02:21 +0100
+Subject: net: dsa: Add support for rtl838x switch
+
+* rename the target to realtek
+* add refactored DSA driver
+* add latest gpio driver
+* lots of arch cleanups
+* new irq driver
+* additional boards
+
+Submitted-by: Bert Vermeulen <bert@biot.com>
+Submitted-by: Birger Koblitz <mail@birger-koblitz.de>
+Submitted-by: Sander Vanheule <sander@svanheule.net>
+Submitted-by: Bjørn Mork <bjorn@mork.no>
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ drivers/net/dsa/rtl83xx/Kconfig               | 2 ++
+ drivers/net/dsa/rtl83xx/Makefile              | 1 +
+ 2 files changed, 3 insertions(+)
+
 --- a/drivers/net/dsa/Kconfig
 +++ b/drivers/net/dsa/Kconfig
 @@ -68,6 +68,8 @@ config NET_DSA_QCA8K

--- a/target/linux/realtek/patches-5.10/701-net-dsa-add-rtl838x-support-for-tag-trailer.patch
+++ b/target/linux/realtek/patches-5.10/701-net-dsa-add-rtl838x-support-for-tag-trailer.patch
@@ -1,3 +1,24 @@
+From 2b88563ee5aafd9571d965b7f2093a0f58d98a31 Mon Sep 17 00:00:00 2001
+From: John Crispin <john@phrozen.org>
+Date: Thu, 26 Nov 2020 12:02:21 +0100
+Subject: net: dsa: Add rtl838x support for tag trailer
+
+* rename the target to realtek
+* add refactored DSA driver
+* add latest gpio driver
+* lots of arch cleanups
+* new irq driver
+* additional boards
+
+Submitted-by: Bert Vermeulen <bert@biot.com>
+Submitted-by: Birger Koblitz <mail@birger-koblitz.de>
+Submitted-by: Sander Vanheule <sander@svanheule.net>
+Submitted-by: Bjørn Mork <bjorn@mork.no>
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ net/dsa/tag_trailer.c                         | 16 +++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
 --- a/net/dsa/tag_trailer.c
 +++ b/net/dsa/tag_trailer.c
 @@ -17,7 +17,12 @@ static struct sk_buff *trailer_xmit(stru

--- a/target/linux/realtek/patches-5.10/702-net-dsa-increase-dsa-max-ports-for-rtl838x.patch
+++ b/target/linux/realtek/patches-5.10/702-net-dsa-increase-dsa-max-ports-for-rtl838x.patch
@@ -1,3 +1,24 @@
+From 2b88563ee5aafd9571d965b7f2093a0f58d98a31 Mon Sep 17 00:00:00 2001
+From: John Crispin <john@phrozen.org>
+Date: Thu, 26 Nov 2020 12:02:21 +0100
+Subject: net: dsa: Increase max ports for rtl838x
+
+* rename the target to realtek
+* add refactored DSA driver
+* add latest gpio driver
+* lots of arch cleanups
+* new irq driver
+* additional boards
+
+Submitted-by: Bert Vermeulen <bert@biot.com>
+Submitted-by: Birger Koblitz <mail@birger-koblitz.de>
+Submitted-by: Sander Vanheule <sander@svanheule.net>
+Submitted-by: Bjørn Mork <bjorn@mork.no>
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ include/linux/platform_data/dsa.h             | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 --- a/include/linux/platform_data/dsa.h
 +++ b/include/linux/platform_data/dsa.h
 @@ -6,7 +6,7 @@ struct device;

--- a/target/linux/realtek/patches-5.10/702-net-ethernet-add-support-for-rtl838x-ethernet.patch
+++ b/target/linux/realtek/patches-5.10/702-net-ethernet-add-support-for-rtl838x-ethernet.patch
@@ -1,3 +1,25 @@
+From 2b88563ee5aafd9571d965b7f2093a0f58d98a31 Mon Sep 17 00:00:00 2001
+From: John Crispin <john@phrozen.org>
+Date: Thu, 26 Nov 2020 12:02:21 +0100
+Subject: net: ethernet: Add support for RTL838x ethernet
+
+* rename the target to realtek
+* add refactored DSA driver
+* add latest gpio driver
+* lots of arch cleanups
+* new irq driver
+* additional boards
+
+Submitted-by: Bert Vermeulen <bert@biot.com>
+Submitted-by: Birger Koblitz <mail@birger-koblitz.de>
+Submitted-by: Sander Vanheule <sander@svanheule.net>
+Submitted-by: Bjørn Mork <bjorn@mork.no>
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ drivers/net/ethernet/Kconfig                  | 7 +-
+ drivers/net/ethernet/Makefile                 | 1 +
+ 2 files changed, 8 insertions(+)
+
 --- a/drivers/net/ethernet/Kconfig
 +++ b/drivers/net/ethernet/Kconfig
 @@ -163,6 +163,13 @@ source "drivers/net/ethernet/rdc/Kconfig

--- a/target/linux/realtek/patches-5.10/703-include-linux-add-phy-ops-for-rtl838x.patch
+++ b/target/linux/realtek/patches-5.10/703-include-linux-add-phy-ops-for-rtl838x.patch
@@ -1,3 +1,24 @@
+From 2b88563ee5aafd9571d965b7f2093a0f58d98a31 Mon Sep 17 00:00:00 2001
+From: John Crispin <john@phrozen.org>
+Date: Thu, 26 Nov 2020 12:02:21 +0100
+Subject: phy: Add PHY ops for rtl838x EEE
+
+* rename the target to realtek
+* add refactored DSA driver
+* add latest gpio driver
+* lots of arch cleanups
+* new irq driver
+* additional boards
+
+Submitted-by: Bert Vermeulen <bert@biot.com>
+Submitted-by: Birger Koblitz <mail@birger-koblitz.de>
+Submitted-by: Sander Vanheule <sander@svanheule.net>
+Submitted-by: Bjørn Mork <bjorn@mork.no>
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ include/linux/phy.h                           | 4 ++++
+ 1 file changed, 4 insertions(+)
+
 --- a/include/linux/phy.h
 +++ b/include/linux/phy.h
 @@ -885,6 +885,10 @@ struct phy_driver {

--- a/target/linux/realtek/patches-5.10/704-drivers-net-phy-eee-support-for-rtl838x.patch
+++ b/target/linux/realtek/patches-5.10/704-drivers-net-phy-eee-support-for-rtl838x.patch
@@ -1,3 +1,24 @@
+From 2b88563ee5aafd9571d965b7f2093a0f58d98a31 Mon Sep 17 00:00:00 2001
+From: John Crispin <john@phrozen.org>
+Date: Thu, 26 Nov 2020 12:02:21 +0100
+Subject: net: phy: EEE support for rtl838x
+
+* rename the target to realtek
+* add refactored DSA driver
+* add latest gpio driver
+* lots of arch cleanups
+* new irq driver
+* additional boards
+
+Submitted-by: Bert Vermeulen <bert@biot.com>
+Submitted-by: Birger Koblitz <mail@birger-koblitz.de>
+Submitted-by: Sander Vanheule <sander@svanheule.net>
+Submitted-by: Bjørn Mork <bjorn@mork.no>
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ drivers/net/phy/phylink.                      | 14 +++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
 --- a/drivers/net/phy/phylink.c
 +++ b/drivers/net/phy/phylink.c
 @@ -1449,6 +1449,11 @@ int phylink_ethtool_ksettings_set(struct

--- a/target/linux/realtek/patches-5.10/704-include-linux-add-phy-hsgmii-mode.patch
+++ b/target/linux/realtek/patches-5.10/704-include-linux-add-phy-hsgmii-mode.patch
@@ -1,3 +1,17 @@
+From 9d9bf16aa8d966834ac1280f96c37d22552c33d1 Mon Sep 17 00:00:00 2001
+From: Birger Koblitz <git@birger-koblitz.de>
+Date: Wed, 8 Sep 2021 16:13:18 +0200
+Subject: phy: Add PHY hsgmii mode
+
+This adds RTL93xx-specific MAC configuration routines that allow also configuration
+of 10GBit links for phylink. There is support for the Realtek-specific HISGMI
+protocol.
+
+Submitted-by: Birger Koblitz <git@birger-koblitz.de>
+---
+ include/linux/phy.h                           | 3 +++
+ 1 file changed, 3 insertions(+)
+
 --- a/include/linux/phy.h
 +++ b/include/linux/phy.h
 @@ -134,6 +134,7 @@ typedef enum {

--- a/target/linux/realtek/patches-5.10/705-add-rtl-phy.patch
+++ b/target/linux/realtek/patches-5.10/705-add-rtl-phy.patch
@@ -1,3 +1,17 @@
+From 89f71ebb355c624320c2b0ace8ae9488ff53cbeb Mon Sep 17 00:00:00 2001
+From: Birger Koblitz <mail@birger-koblitz.de>
+Date: Tue, 5 Jan 2021 20:40:52 +0100
+Subject: PHY: Add realtek PHY
+
+This fixes the build problems for the REALTEK target by adding a proper
+configuration option for the phy module.
+
+Submitted-by: Birger Koblitz <mail@birger-koblitz.de>
+---
+ drivers/net/phy/Kconfig                       | 6 ++++++
+ drivers/net/phy/Makefile                      | 1 +
+ 2 files changed, 7 insertions(+)
+
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
 @@ -330,6 +330,12 @@ config REALTEK_PHY

--- a/target/linux/realtek/patches-5.10/705-include-linux-phy-increase-phy-address-number-for-rtl839x.patch
+++ b/target/linux/realtek/patches-5.10/705-include-linux-phy-increase-phy-address-number-for-rtl839x.patch
@@ -1,3 +1,24 @@
+From 2b88563ee5aafd9571d965b7f2093a0f58d98a31 Mon Sep 17 00:00:00 2001
+From: John Crispin <john@phrozen.org>
+Date: Thu, 26 Nov 2020 12:02:21 +0100
+Subject: PHY: Increase max PHY adddress number
+
+* rename the target to realtek
+* add refactored DSA driver
+* add latest gpio driver
+* lots of arch cleanups
+* new irq driver
+* additional boards
+
+Submitted-by: Bert Vermeulen <bert@biot.com>
+Submitted-by: Birger Koblitz <mail@birger-koblitz.de>
+Submitted-by: Sander Vanheule <sander@svanheule.net>
+Submitted-by: Bjørn Mork <bjorn@mork.no>
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ include/linux/phy.h                           | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 --- a/include/linux/phy.h
 +++ b/include/linux/phy.h
 @@ -233,7 +233,7 @@ static inline const char *phy_modes(phy_

--- a/target/linux/realtek/patches-5.10/708-brflood-api.patch
+++ b/target/linux/realtek/patches-5.10/708-brflood-api.patch
@@ -1,3 +1,21 @@
+From afa3ab54c03d5126b14651f367b38165fab5b3cc Mon Sep 17 00:00:00 2001
+From: Birger Koblitz <git@birger-koblitz.de>
+Date: Tue, 18 Jan 2022 17:18:43 +0100
+Subject: net: brflood API
+
+Adds the DSA API for bridge configuration (flooding, L2 learning,
+and aging) offload as found in Linux 5.12 so that we can implement
+it in our drivver.
+
+Submitted-by: Sebastian Gottschall <s.gottschall@dd-wrt.com>
+Submitted-by: Birger Koblitz <git@birger-koblitz.de>
+---
+ include/net/dsa.h                             |  6 +++++++--
+ net/dsa/dsa_priv.h                            |  6 +++---
+ net/dsa/port.c                                | 28 ++++++++----
+ net/dsa/slave.c                               |  6 +++---
+ 4 file changed, 29 insertions(+), 13 deletions(-)
+
 --- a/include/net/dsa.h
 +++ b/include/net/dsa.h
 @@ -552,8 +552,14 @@ struct dsa_switch_ops {

--- a/target/linux/realtek/patches-5.10/709-lag-offloading.patch
+++ b/target/linux/realtek/patches-5.10/709-lag-offloading.patch
@@ -1,3 +1,25 @@
+From afa3ab54c03d5126b14651f367b38165fab5b3cc Mon Sep 17 00:00:00 2001
+From: Birger Koblitz <git@birger-koblitz.de>
+Date: Tue, 18 Jan 2022 17:18:43 +0100
+Subject: [PATCH] realtek: Backport bridge configuration for DSA
+
+Adds the DSA API for bridge configuration (flooding, L2 learning,
+and aging) offload as found in Linux 5.12 so that we can implement
+it in our drivver.
+
+Submitted-by: Sebastian Gottschall <s.gottschall@dd-wrt.com>
+Submitted-by: Birger Koblitz <git@birger-koblitz.de>
+---
+ drivers/net/bonding/bond_main.c               |  2 ++
+ include/net/dsa.h                             | 79 ++++++++++++++++-
+ net/dsa/dsa2.c                                | 88 +++++++++++++++++++
+ net/dsa/dsa_priv.h                            | 74 ++++++++++++++
+ net/dsa/port.c                                | 92 ++++++++++++++++++++
+ net/dsa/slave.c                               | 88 ++++++++++++++++---
+ net/dsa/switch.c                              | 49 ++++++++++
+ net/sda/tag_dsa.c                             | 13 +++++-
+ 8 file changed, 460 insertions(+), 25 deletions(-)
+
 --- a/drivers/net/bonding/bond_main.c
 +++ b/drivers/net/bonding/bond_main.c
 @@ -2046,6 +2046,8 @@ int bond_enslave(struct net_device *bond


### PR DESCRIPTION
OpenWRT's developer guide prefers having actual patches so they an be sent upstream more easily.

However, in this case, Adding proper fields also allows for `git am` to properly function. Some of these patches are quite old, and lack much traceable history.

This commit tries to rectify that, by digging in the history to find where and how it was first added.

It is by no means perfect and also shows some patches that should have been long gone.

Noted, that the histogram was done manually, so probably isn't 100% accurate, but it's only informal anyway.
Secondly, where git was very adamant about whitespace issues, these where corrected as git was refusing to accept them otherwise.