### PR TITLE
[22.03] mpc85xx: add patch to fix gpio mpc8xxx

### DIFF
--- a/target/linux/mpc85xx/patches-5.10/110-gpio-mpc8xxx-Fix-support-for-IRQ_TYPE_LEVEL_LOW-flow.patch
+++ b/target/linux/mpc85xx/patches-5.10/110-gpio-mpc8xxx-Fix-support-for-IRQ_TYPE_LEVEL_LOW-flow.patch
@@ -1,0 +1,42 @@
+From 29af30435022442ec4eccf3166956b8e0b8a2134 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Mon, 5 Sep 2022 23:13:47 +0200
+Subject: [PATCH] gpio: mpc8xxx: Fix support for IRQ_TYPE_LEVEL_LOW flow_type
+ in mpc85xx
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Commit e39d5ef67804 ("powerpc/5xxx: extend mpc8xxx_gpio driver to support
+mpc512x gpios") implemented support for IRQ_TYPE_LEVEL_LOW flow type in
+mpc512x via falling edge type. Do same for mpc85xx which support was added
+in commit 345e5c8a1cc3 ("powerpc: Add interrupt support to mpc8xxx_gpio").
+
+Fixes probing of lm90 hwmon driver on mpc85xx based board which use level
+interrupt. Without it kernel prints error and refuse lm90 to work:
+
+    [   15.258370] genirq: Setting trigger mode 8 for irq 49 failed (mpc8xxx_irq_set_type+0x0/0xf8)
+    [   15.267168] lm90 0-004c: cannot request IRQ 49
+    [   15.272708] lm90: probe of 0-004c failed with error -22
+
+Fixes: 345e5c8a1cc3 ("powerpc: Add interrupt support to mpc8xxx_gpio")
+Signed-off-by: Pali Rohár <pali@kernel.org>
+---
+ drivers/gpio/gpio-mpc8xxx.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpio/gpio-mpc8xxx.c b/drivers/gpio/gpio-mpc8xxx.c
+index d60d5520707d..60c2533a39a5 100644
+--- a/drivers/gpio/gpio-mpc8xxx.c
++++ b/drivers/gpio/gpio-mpc8xxx.c
+@@ -169,6 +169,7 @@ static int mpc8xxx_irq_set_type(struct irq_data *d, unsigned int flow_type)
+ 
+ 	switch (flow_type) {
+ 	case IRQ_TYPE_EDGE_FALLING:
++	case IRQ_TYPE_LEVEL_LOW:
+ 		raw_spin_lock_irqsave(&mpc8xxx_gc->lock, flags);
+ 		gc->write_reg(mpc8xxx_gc->regs + GPIO_ICR,
+ 			gc->read_reg(mpc8xxx_gc->regs + GPIO_ICR)
+-- 
+2.34.1
+


### PR DESCRIPTION
Backports Linux kernel patch [1] for kernel 5.10 where it applies cleanly. This was tested on CZ.NIC Turris 1.1 router running OpenWrt 22.03 release.

Before:

- In /var/log/messages:
```
[   16.392988] lm90 0-004c: cannot request IRQ 48
[   16.398280] lm90: probe of 0-004c failed with error -22
```

- Sensors does not work:
```
root@turris:~# sensors
No sensors found!
Make sure you loaded all the kernel drivers you need.
Try sensors-detect to find out which these are.
```

After:

```
root@turris:/# sensors
sa56004-i2c-0-4c
Adapter: MPC adapter (i2c@3000)
temp1:        +44.0°C  (low  =  +0.0°C, high = +70.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp2:        +73.8°C  (low  =  +0.0°C, high = +70.0°C)  ALARM (HIGH)
                       (crit = +85.0°C, hyst = +75.0°C)
```

[1] https://lore.kernel.org/linux-gpio/20220906105431.30911-1-pali@kernel.org/

This is backport of https://github.com/openwrt/openwrt/pull/10621 with one exception that I removed patch for kernel 5.15. And also, the patch was applied to Linux kernel, thus I changed (adopted) slightly commit message for that.