### PR TITLE
ramips: add support for Cudy WR1300 v2

### DIFF
--- a/target/linux/ramips/dts/mt7621_cudy_wr1300-v1.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr1300-v1.dts
@@ -6,8 +6,8 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
-	compatible = "cudy,wr1300", "mediatek,mt7621-soc";
-	model = "Cudy WR1300";
+	compatible = "cudy,wr1300-v1", "mediatek,mt7621-soc";
+	model = "Cudy WR1300 v1";
 
 	aliases {
 		led-boot = &led_sys;

--- a/target/linux/ramips/dts/mt7621_cudy_wr1300-v2.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr1300-v2.dts
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "cudy,wr1300-v2", "mediatek,mt7621-soc";
+	model = "Cudy WR1300 v2";
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: sys {
+			label = "green:sys";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "green:wps";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf80000>;
+			};
+
+			partition@fd0000 {
+				label = "debug";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "backup";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			bdinfo: partition@ff0000 {
+				label = "bdinfo";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&macaddr_bdinfo_de00>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&macaddr_bdinfo_de00>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <2>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "i2c", "jtag";
+		function = "gpio";
+	};
+};
+
+&bdinfo {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_bdinfo_de00: macaddr@de00 {
+		reg = <0xde00 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -431,15 +431,28 @@ define Device/bolt_arion
 endef
 TARGET_DEVICES += bolt_arion
 
-define Device/cudy_wr1300
+define Device/cudy_wr1300-v1
   $(Device/dsa-migration)
   IMAGE_SIZE := 15872k
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := WR1300
+  DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb2 kmod-usb3 \
 	kmod-usb-ledtrig-usbport
+  SUPPORTED_DEVICES += cudy,wr1300 R10
 endef
-TARGET_DEVICES += cudy_wr1300
+TARGET_DEVICES += cudy_wr1300-v1
+
+define Device/cudy_wr1300-v2
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 15872k
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := WR1300
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
+  SUPPORTED_DEVICES += cudy,wr1300 R23
+endef
+TARGET_DEVICES += cudy_wr1300-v2
 
 define Device/cudy_wr2100
   $(Device/dsa-migration)


### PR DESCRIPTION
Specifications:
 - SoC: MediaTek MT7621AT
 - RAM: 128 MB (DDR3)
 - Flash: 16 MB (SPI NOR)
 - WiFi: MediaTek MT7603E, MediaTek MT7613BE
 - Switch: 1 WAN, 4 LAN (Gigabit)
 - Ports: 1 USB 3.0
 - Buttons: Reset, WPS
 - LEDs: System, Wan, Lan 1-4, WiFi 2.4G, WiFi 5G, WPS
 - Power: DC 12V 1A tip positive

Download and flash the manufacturer's built OpenWRT image available at http://www.cudytech.com/openwrt_software_download
Install the new OpenWRT image via luci (System -> Backup/Flash firmware) Be sure to NOT keep settings. The force upgrade may need to be checked due to differences in router naming conventions.

Recovery:
 - Loads only signed manufacture firmware due to bootloader RSA verification
 - serve tftp-recovery image as /recovery.bin on 192.168.1.88/24
 - connect to any lan ethernet port
 - power on the device while holding the reset button
 - wait at least 8 seconds before releasing reset button for image to download
 - See http://www.cudytech.com/newsinfo/547425.html

Signed-off-by: Óscar García Amor <ogarcia@connectical.com>

**NOTE**
 
It works correctly, the only problem I have is that when updating the firmware it gives the following message:
![image_check_failed](https://user-images.githubusercontent.com/572924/191534301-af808f06-a965-42a4-9206-a12d5ebead9b.png)

I don't understand why it gives the error, because in the dts it is specifically set:
```
compatible = "cudy,wr1300"
```

Maybe it is a problem of how I have compiled the firmware, let me know.
