### PR TITLE
base-files: Actually set default name

### DIFF
--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -96,7 +96,7 @@ ucidef_set_interfaces_lan_wan() {
 
 ucidef_set_bridge_device() {
 	json_select_object bridge
-	json_add_string name "${1:switch0}"
+	json_add_string name "${1:-switch0}"
 	json_select ..
 }
 


### PR DESCRIPTION
The currently used shell expansion doesn't seem to exist [0] and also does not work. This surely was not intended, so lets allow default naming to actually work.

Fixes: be09c5a3cd65 ("base-files: add board.d support for bridge device")

[0]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>