### PR TITLE
base-files: Do not break on non-eth ports

### DIFF
--- a/package/base-files/files/lib/preinit/10_indicate_preinit
+++ b/package/base-files/files/lib/preinit/10_indicate_preinit
@@ -95,8 +95,6 @@ preinit_config_board() {
 		json_select "network_device"
 			json_select "$netdev"
 				json_get_vars path path
-				next_eth="$(echo "$netdev" | grep 'eth[0-9]*' | tr -dc '[0-9]')"
-				[ "$next_eth" -gt "$max_eth" ] && max_eth=$next_eth
 				if [ -n "$path" -a -h "/sys/class/net/$netdev" ]; then
 					ip link set "$netdev" down
 					ip link set "$netdev" name eth$((++max_eth))


### PR DESCRIPTION
When using OpenWRT with DSA and 'lan' ports, we could get an empty `next_eth`. This is of course not desirable, as this causes `sh: out of range` errors when trying to determine which one would be greater.

Fixes: b688bf83f9d6 ("base-files: rename ethernet devs on known boards")

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>