### PR TITLE
ramips: add support for OrayBox X1

### DIFF
--- a/target/linux/ramips/dts/mt7628an_oraybox_x1.dts
+++ b/target/linux/ramips/dts/mt7628an_oraybox_x1.dts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "oraybox,x1", "mediatek,mt7628an-soc";
+	model = "OrayBox X1";
+
+	aliases {
+		led-boot = &led_status_white;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_white;
+		led-upgrade = &led_status_red;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status-blue {
+			label = "blue:status";
+			gpios = <&gpio 37 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: status-red {
+			label = "red:status";
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_white: status-white {
+			label = "white:status";
+			gpios = <&gpio 44 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "kpanic";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf00000>;
+			};
+
+			bdinfo: partition@fe0000 {
+				label = "bdinfo";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "reserve";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_bdinfo_9>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+};
+
+&bdinfo {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_bdinfo_9: macaddr@9 {
+		reg = <0x9 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -474,6 +474,14 @@ define Device/onion_omega2p
 endef
 TARGET_DEVICES += onion_omega2p
 
+define Device/oraybox_x1
+  IMAGE_SIZE := 15360k
+  DEVICE_VENDOR := OrayBox
+  DEVICE_MODEL := X1
+  DEVICE_PACKAGES:= kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += oraybox_x1
+
 define Device/rakwireless_rak633
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Rakwireless

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -59,6 +59,9 @@ keenetic,kn-1613)
 mediatek,linkit-smart-7688)
 	ucidef_set_led_wlan "wifi" "wifi" "orange:wifi" "phy0tpt"
 	;;
+oraybox,x1)
+	ucidef_set_led_netdev "wifi" "wifi" "blue:status" "wlan0"
+	;;
 rakwireless,rak633)
 	ucidef_set_led_netdev "wifi_led" "wifi" "blue:wifi" "wlan0"
 	;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -141,6 +141,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
 		;;
+	oraybox,x1)
+		ucidef_add_switch "switch0" \
+			"3:lan" "6@eth0"
+		;;
 	rakwireless,rak633)
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"


### PR DESCRIPTION
Add support for OrayBox X1. It is a 802.11n router, based on MediaTek MT7628N.

Specifications:
SoC: MediaTek MT7628N (580MHz)
RAM: 64 MiB
Flash: 16 MiB NOR (Winbond W25Q128JVSIQ)
Wireless: 802.11b/g/n 2x2 2.4GHz (Built In)
Ethernet: 1x 100Mbps only
USB: 1x USB Type-A 2.0 Host Port
Button: 1x "Reset" button
LED: 1x Blue LED + 1x Red LED + 1x White LED
Power: 5V Micro-USB input

Manufacturer Page:
https://pgy.oray.com/router/x1.html/parameter

Flash Layout:
0x000000000000-0x000000030000 : "u-boot"
0x000000030000-0x000000040000 : "kpanic"
0x000000040000-0x000000050000 : "factory"
0x000000050000-0x000000fe0000 : "firmware"
0x000000fe0000-0x000000ff0000 : "bdinfo"
0x000000ff0000-0x000001000000 : "reserve"

Install via SSH:
Original firmware is based on OpenWRT, but SSH is not start by default,
You should enable it first

1. Login into web admin (10.168.1.1), default password is 'admin'
2. Check your OrayBox firmware version

if firmware version is 4.1.0:

3. Open the following link, and the result should be {"code":0}, and
your ssh user is 'root', password is same as web admin password.
http://10.168.1.1/cgi-bin/oraybox?_api=ssh_set&enabled=1

if firmware version is 5.5.0:

3. Open the following link, and the result should be {"sn": "serial number"},
your ssh user is 'oray', password is same as web admin password.
http://10.168.1.1/cgi-bin/oraybox?_api=ping&hostname=localhost%27%20%26%20sed%20-i%20%27s/osh/ash/g%27%20/etc/passwd%20%26%20/etc/init.d/dropbear%20restart%20%27

You can flash firmware via mtd: mtd write /tmp/firmware_image.bin firmware

Signed-off-by: Bin We <me@udp.pw>