### PR TITLE
base-files: add sleep wait after sysupgrade

### DIFF
--- a/package/base-files/files/lib/upgrade/do_stage2
+++ b/package/base-files/files/lib/upgrade/do_stage2
@@ -20,6 +20,7 @@ sleep 1
 
 v "Rebooting system..."
 umount -a
+echo "wait 30s to reboot" && sleep 30
 reboot -f
 sleep 5
 echo b 2>/dev/null >/proc/sysrq-trigger

--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -237,6 +237,7 @@ nand_do_upgrade_success() {
 		echo "sysupgrade successful"
 	fi
 	umount -a
+	echo "wait 30s to reboot" && sleep 30
 	reboot -f
 }
 


### PR DESCRIPTION
for some unknown reason sysupgrade with nand_upgrade_ubinized is likely lost config, this workaroud just to resolve it.