### PR TITLE
ramips: update MAC address configuration for Buffalo WSR-1166DHP

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -147,9 +147,9 @@ ramips_setup_macs()
 		lan_mac=$label_mac
 		;;
 	buffalo,wsr-1166dhp)
-		local index="$(find_mtd_index "board_data")"
-		wan_mac="$(grep -m1 mac= "/dev/mtd${index}" | cut -d= -f2)"
+		wan_mac=$(mtd_get_mac_ascii board_data "mac")
 		lan_mac=$wan_mac
+		label_mac=$wan_mac
 		;;
 	dlink,dir-860l-b1)
 		lan_mac=$(mtd_get_mac_ascii factory lanmac)


### PR DESCRIPTION
Convert MAC address and label_mac configuration of Buffalo WSR-1166DHP to use the generic function of OpenWrt.

This commit applies commit 770cfe9 for WCR-1166DS to WSR-1166DHP too.
