### PR TITLE
base-files: Add MAC address validation helper

### DIFF
--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -239,6 +239,90 @@ macaddr_unsetbit_mc() {
 	printf "%02x:%s" $((0x${mac%%:*} & ~0x01)) ${mac#*:}
 }
 
+macaddr_type() {
+	case "${1:-}" in
+	'01'[:-]'00'[:-]'5'[eE][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f])
+		echo 'multicast'
+		;;
+	[fF][fF][:-][fF][fF][:-][fF][fF][:-][fF][fF][:-][fF][fF][:-][fF][fF])
+		echo 'broadcast'
+		;;
+	[0-9A-Fa-f][048Cc][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f])
+		echo 'ucua'
+		;;
+	[0-9A-Fa-f][159Dd][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f])
+		echo 'mcua'
+		;;
+	[0-9A-Fa-f][26AEae][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f])
+		echo 'ucla'
+		;;
+	[0-9A-Fa-f][37BFbf][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f][:-][0-9A-Fa-f][0-9A-Fa-f])
+		echo 'mcla'
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+macaddr_valid() {
+	local mac="${1:-}"
+
+	if ! macaddr_type "${mac}" > '/dev/null'; then
+		return 1
+	fi
+
+	printf '%s' "${mac}"
+}
+
+macaddr_unicast() {
+	local addr_type
+	local mac="${1:-}"
+
+	addr_type="$(macaddr_type "${mac}")"
+	if [ -n "${addr_type%'uc'*}" ]; then
+		return 1
+	fi
+
+	printf '%s' "${mac}"
+}
+
+macaddr_multicast() {
+	local addr_type
+	local mac="${1:-}"
+
+	addr_type="$(macaddr_type "${mac}")"
+	if [ -n "${addr_type%'mc'*}" ]; then
+		return 1
+	fi
+
+	printf '%s' "${mac}"
+}
+
+macaddr_localadmin() {
+	local addr_type
+	local mac="${1:-}"
+
+	addr_type="$(macaddr_type "${mac}")"
+	if [ -n "${addr_type#*'la'}" ]; then
+		return 1
+	fi
+
+	printf '%s' "${mac}"
+}
+
+macaddr_uniadmin() {
+	local addr_type
+	local mac="${1:-}"
+
+	addr_type="$(macaddr_type "${mac}")"
+	if [ -n "${addr_type#*'ua'}" ]; then
+		return 1
+	fi
+
+	printf '%s' "${mac}"
+}
+
 macaddr_random() {
 	local randsrc=$(get_mac_binary /dev/urandom 0)
 	


### PR DESCRIPTION
Rather then checking if a (mac address containing) variable is empty or not, lets instead allow a user to validate a MAC address.

This function can be used in one of two ways. Either just called as a function, where the return value (of grep) actually tells you if the MAC address matches (0) or not (1). Alternatively, capture the output, the MAC address matches (the MAC address is repeated) or not (empty).

Currently, this check only supports byte separated mac addresses, but could be extended to support word-dot separated addresses as well. Since this is however a format not really used by OpenWRT, lets keep it simple for now.

The used regex, `^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]){2}$` can be put into regexr.com or similar to get a nice textual explanation for those curious.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>