### PR TITLE
ath79: Add Aruba AP-175 support

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -88,6 +88,18 @@ ziking,cpe46b|\
 zyxel,nbg6616)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
 	;;
+aruba,ap-105|\
+aruba,ap-175|\
+dongwon,dw02-412h-64m|\
+dongwon,dw02-412h-128m|\
+glinet,gl-ar300m-lite|\
+glinet,gl-ar300m-nand|\
+glinet,gl-ar300m-nor|\
+glinet,gl-ar300m16)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000"
+	;;
 buffalo,wzr-hp-ag300h)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x10000"
 	;;
@@ -98,16 +110,6 @@ linksys,ea4500-v3)
 	;;
 domywifi,dw33d)
 	ubootenv_add_uci_config "/dev/mtd4" "0x0" "0x10000" "0x10000"
-	;;
-dongwon,dw02-412h-64m|\
-dongwon,dw02-412h-128m|\
-glinet,gl-ar300m-lite|\
-glinet,gl-ar300m-nand|\
-glinet,gl-ar300m-nor|\
-glinet,gl-ar300m16)
-	idx="$(find_mtd_index u-boot-env)"
-	[ -n "$idx" ] && \
-		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000"
 	;;
 glinet,gl-ar150)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x8000" "0x10000"

--- a/target/linux/ath79/dts/ar7161_aruba_ap-175.dts
+++ b/target/linux/ath79/dts/ar7161_aruba_ap-175.dts
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7100.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "aruba,ap-175", "qca,ar7161";
+	model = "Aruba AP-175";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	aliases {
+		led-boot = &led_power_amber;
+		led-failsafe = &led_power_amber;
+		led-upgrade = &led_power_amber;
+		label-mac-device = &eth0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		/* These internal LEDs cannot be seen when case is closed */
+		internal_2g_green {
+			label = "green:internal_2g";
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		internal_5g_green {
+			label = "green:internal_5g";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+        /* These external LEDs are visible from the bottom panel */
+
+		led_power_amber: power_amber {
+			label = "amber:power";
+			gpios = <&gpio_ext 5 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		r1_act_blue {
+			label = "blue:r1_act";
+			gpios = <&gpio_ext 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		r1_rssi1_blue {
+			label = "blue:r1_rssi1";
+			gpios = <&gpio_ext 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		r1_rssi2_blue {
+			label = "blue:r1_rssi2";
+			gpios = <&gpio_ext 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		r1_rssi3_blue {
+			label = "blue:r1_rssi3";
+			gpios = <&gpio_ext 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		r1_rssi4_blue {
+			label = "blue:r1_rssi4";
+			gpios = <&gpio_ext 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		r0_act_amber {
+			label = "amber:r0_act";
+			gpios = <&gpio_ext 8 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		r0_rssi1_amber {
+			label = "amber:r0_rssi1";
+			gpios = <&gpio_ext 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		r0_rssi2_amber {
+			label = "amber:r0_rssi2";
+			gpios = <&gpio_ext 10 GPIO_ACTIVE_HIGH>;
+		};
+
+		r0_rssi3_amber {
+			label = "amber:r0_rssi3";
+			gpios = <&gpio_ext 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		r0_rssi4_amber {
+			label = "amber:r0_rssi4";
+			gpios = <&gpio_ext 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	i2c0: i2c {
+		compatible = "i2c-gpio";
+		i2c-gpio,delay-us = <10>;
+		i2c-gpio,timeout-ms = <1>;
+		sda-gpios = <&gpio 1 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio 2 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	ath9k0: wifi@0,11 {
+		compatible = "pci168c,0029";
+		nvmem-cells = <&macaddr_hwinfo_1c>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <1>;
+		reg = <0x8800 0 0 0 0>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+
+	ath9k1: wifi@0,12 {
+		compatible = "pci168c,0029";
+		nvmem-cells = <&macaddr_hwinfo_1c>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <2>;
+		reg = <0x9000 0 0 0 0>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy1: ethernet-phy@1 {
+		reg = <0x1>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	nvmem-cells = <&macaddr_hwinfo_1c>;
+	nvmem-cell-names = "mac-address";
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy1>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "firmware";
+				reg = <0x40000 0xfa0000>;
+				compatible = "denx,uimage";
+			};
+
+			hwinfo: partition@fe0000 {
+				label = "hwinfo";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "u-boot-env";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&hwinfo {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_hwinfo_1c: macaddr@1c {
+		reg = <0x1c 0x6>;
+	};
+};
+
+&i2c0 {
+	gpio_ext: gpio@21 {
+		status = "okay";
+
+		compatible = "ti,tca6416";
+		reg = <0x21>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+	};
+
+	temp-sensor@4a {
+		 compatible = "national,lm75";
+		 reg = <0x4a>;
+	};
+
+	eeprom@50 { /* 24lc2561 */
+		compatible = "atmel,24c256","at24";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x50>;
+		size = <256>;
+	};
+
+	ds1374c: rtc@68 {
+		status = "okay";
+
+		compatible = "dallas,ds1374";
+		reg = <0x68>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -19,6 +19,7 @@ ath79_setup_interfaces()
 	araknis,an-700-ap-i-ac|\
 	arduino,yun|\
 	aruba,ap-105|\
+	aruba,ap-175|\
 	asus,rp-ac51|\
 	asus,rp-ac66|\
 	avm,fritz1750e|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -395,6 +395,15 @@ define Device/aruba_ap-105
 endef
 TARGET_DEVICES += aruba_ap-105
 
+define Device/aruba_ap-175
+  SOC := ar7161
+  DEVICE_VENDOR := Aruba
+  DEVICE_MODEL := AP-175
+  IMAGE_SIZE := 16000k
+  DEVICE_PACKAGES := kmod-gpio-pca953x kmod-hwmon-lm75 kmod-i2c-gpio kmod-rtc-ds1374
+endef
+TARGET_DEVICES += aruba_ap-175
+
 define Device/asus_pl-ac56
   SOC := qca9563
   DEVICE_VENDOR := ASUS


### PR DESCRIPTION

This board is very similar to the Aruba AP-105, but is
outdoor-first. It is very similar to the MSR2000 (though certain
MSR2000 models have a different PHY[^1]).

A U-Boot replacement is required to install OpenWrt on these
devices[^2].

Specifications
--------------
* Device:       Aruba AP-175
* SoC:          Atheros AR7161 680 MHz MIPS
* RAM:          128MB - 2x Mira P3S12D40ETP
* Flash:        16MB MXIC MX25L12845EMI-10G (SPI-NOR)
* WiFi:         2 x DNMA-H92 Atheros AR9220-AC1A 802.11abgn
* ETH:          IC+ IP1001 Gigabit + PoE PHY
* LED:          2x int., plus 12 ext. on TCA6416 GPIO expander
* Console:      CP210X linking USB-A Port to CPU console @ 115200
* RTC:          DS1374C, with internal battery
* Temp:         LM75 temperature sensor

Factory installation:

- Needs a u-boot replacement. The process is almost identical to that
  of the AP105, except that the case is easier to open, and that you
  need to compile u-boot from a slightly different branch:
  https://github.com/Hurricos/u-boot-ap105/tree/ap175

  The instructions for performing an in-circuit reflash with an
  SPI-Flasher like a CH314A can be found on the OpenWrt Wiki
  (https://openwrt.org/toh/aruba/ap-105); in addition a detailed guide
  may be found on YouTube[^3].

- Once u-boot has been replaced, a USB-A-to-A cable may be used to
  connect your PC to the CP210X inside the AP at 115200 baud; at this
  point, the normal u-boot serial flashing procedure will work (set up
  networking; tftpboot and boot an OpenWrt initramfs; sysupgrade to
  OpenWrt proper.)

- There is no built-in functionality to revert back to stock firmware,
  because the AP-175 has been declared by the vendor[^4] end-of-life
  as of 31 Jul 2020. If for some reason you wish to return to stock
  firmware, take a backup of the 16MiB flash before flashing u-boot.

[^1]: https://github.com/shalzz/aruba-ap-310/blob/master/platform/bootloader/apboot-11n/include/configs/msr2k.h#L186

[^2]: https://github.com/Hurricos/u-boot-ap105/tree/ap175

[^3]: https://www.youtube.com/watch?v=Vof__dPiprs

[^4]: https://www.arubanetworks.com/support-services/end-of-life/#product=access-points&version=0

Signed-off-by: Martin Kennedy <hurricos@gmail.com>