### PR TITLE
introduce swconfig migration script (WIP)

### DIFF
--- a/package/base-files/files/etc/uci-defaults/14_migrate-swconfig
+++ b/package/base-files/files/etc/uci-defaults/14_migrate-swconfig
@@ -1,0 +1,72 @@
+findPorts()
+# Differentiate ports between user and cpu ports. Display DSA interface name of user ports.
+# Check compiled devicetree to do this.
+
+{
+	local port=$1
+
+	# Devicetree path is currently hardcoded for Linksys WRT32X.
+	# It should be changed to automatically find the "ports/port@" directory in "/proc/device-tree".
+	# Check dsa-port.yaml for other accepted node names like "ethernet-ports/ethernet-port@".
+
+	# A port may be missing from DSA bindings (it's usually the second CPU port), ignore these ports.
+	if [[ ! -d "/proc/device-tree/soc/internal-regs/mdio@72004/switch@0/ports/port@${port}" ]]
+	then
+	  return
+	fi
+
+	# Check if ethernet property exists to find CPU ports, only CPU ports use this property.
+	if [[ -f "/proc/device-tree/soc/internal-regs/mdio@72004/switch@0/ports/port@${port}/ethernet" ]]
+	then
+	  echo "${port} = cpu_port"
+
+	# If it doesn't exist, it must be a user port.
+	else
+	  echo "${port} = user_port"
+
+	  for user_port in ${port}
+	  do
+	    # Print the name of the DSA interface.
+	    echo "$(cat /proc/device-tree/soc/internal-regs/mdio@72004/switch@0/ports/port@${user_port}/label)"
+	  done
+	fi
+}
+
+findDSAInterfaces()
+# Read old UCI config with swconfig options.
+
+{
+#	echo "ports = ${ports}"
+#	echo "vlan = ${vlan}"
+	for port in ${ports}
+	do
+	  # swconfig configuration can either have a number or a number with "t" next to it.
+	  case $port in
+	  *t)
+#	    echo "tagged_port = ${port}"
+
+	    # string manipulation (substring removal) %*t prints before "t".
+	    # Feed this to findPorts with "t" removed.
+	    findPorts ${port%*t}
+	    ;;
+	  *)
+#	    echo "port = ${port}"
+	    findPorts ${port}
+	    ;;
+	  esac
+	done
+}
+
+validate_section_swconfig_ports()
+# Take related config options from UCI.
+{
+	uci_load_validate network-old switch_vlan "$1" "$2" \
+		'vlan:uinteger' \
+		'ports:string'
+}
+
+	. /lib/functions.sh
+	. /lib/functions/procd.sh
+
+	config_load "network-old"
+	config_foreach validate_section_swconfig_ports switch_vlan findDSAInterfaces

--- a/package/base-files/files/etc/uci-defaults/14_migrate-swconfig
+++ b/package/base-files/files/etc/uci-defaults/14_migrate-swconfig
@@ -1,5 +1,13 @@
 # To-do:
+
+# Use config_foreach for mapping information to variables.
+# Create a new function for printing the new config using the variables.
+
+# ---
+
 # - Add every DSA interface under "option device" with "list ports".
+
+# - If the CPU port doesn't exist on a switch_vlan, "local option '0'" must be issued for that bridge-vlan.
 
 # - Increment the bridge number if it already exists until the incremented bridge doesn't exist on the config.
 
@@ -26,7 +34,7 @@
 # UCI doesn't support untagged CPU ports on Bridge VLAN filtering. You'd have to manually associate the VLAN to the bridge interface as untagged with the bridge(8) tool.
 
 # DO NOT USE MULTIPLE TAGGED CPU PORTS ON A SINGLE VLAN
-# DSA only has one CPU port, you cannot have multiple networks on the same VLAN using multiple ethX.X interfaces anymore.
+# DSA uses only one CPU port, you cannot have multiple networks on the same VLAN using multiple ethX.X interfaces anymore.
 
 findDSASwitch()
 {
@@ -35,6 +43,7 @@ findDSASwitch()
 	# Hardcode bridge interface name for now.
 	bridgeInterface=br0
 	echo -e "\toption name '$bridgeInterface'"
+	echo -e "\tlist ports ''"
 }
 
 findDSAInterfaces()
@@ -109,9 +118,9 @@ findPorts()
 		# This checks for tagged/untagged status of the CPU ports.
 		# Move this part to somewhere else where it takes CPU port information from both checks.
 		if [ "$tag_type" == "untagged" ]; then
-			echo "${all_cpu_ports} = cpu_port untagged"
+			echo "${port} = cpu_port untagged"
 		else
-			echo "${all_cpu_ports} = cpu_port tagged"
+			echo "${port} = cpu_port tagged"
 		fi
 
 	# Anything else must be a user port.
@@ -131,6 +140,10 @@ findPorts()
 	fi
 }
 
+#print_new_config()
+#{
+#}
+
 validate_section_switch()
 # Take sections in switch option from UCI.
 {
@@ -148,6 +161,7 @@ validate_section_switch_vlan()
 }
 
 validate_section_device()
+# Take sections in device option from UCI.
 {
 	uci_load_validate network-test device "$1" "$2" \
 		'ifname:string'
@@ -159,4 +173,4 @@ validate_section_device()
 	config_load "network-test"
 	config_foreach validate_section_switch switch findDSASwitch
 	config_foreach validate_section_switch_vlan switch_vlan findDSAInterfaces
-	config_foreach validate_section_device device replaceToBridgeInterface
+	# config_foreach validate_section_device device replaceToBridgeInterface

--- a/package/base-files/files/etc/uci-defaults/14_migrate-swconfig
+++ b/package/base-files/files/etc/uci-defaults/14_migrate-swconfig
@@ -9,7 +9,6 @@
 findPorts()
 # Differentiate ports between user and cpu ports. Display DSA interface name of user ports.
 # Check compiled devicetree to do this.
-
 {
 	local port=$1
 	local tag_type=$2
@@ -21,84 +20,76 @@ findPorts()
 	dsa_dt_path=$(echo "$dsa_dt_path" | sed 's/ports\/port.*$/ports\//g' | sed 's/ports\/ethernet-port.*$//g')
 
 	# A port may be missing from DSA bindings (it's usually the second CPU port), ignore these ports.
-	if [[ ! -d "${dsa_dt_path}port@${port}" ]]
-	then
-	  return
+	if [[ ! -d "${dsa_dt_path}port@${port}" ]]; then
+		return
 	fi
 
 	# Check if ethernet property exists to find CPU ports, only CPU ports use this property.
-	if [[ -f "${dsa_dt_path}port@${port}/ethernet" ]]
-	then
-	
-	 if [ "$tag_type" == "untagged" ]; then
-		echo "${port} = cpu_port untagged"
-	 else
-		echo "${port} = cpu_port tagged"
-	 fi
+	if [[ -f "${dsa_dt_path}port@${port}/ethernet" ]]; then
+		if [ "$tag_type" == "untagged" ]; then
+			echo "${port} = cpu_port untagged"
+		else
+			echo "${port} = cpu_port tagged"
+		fi
 
 	# If it doesn't exist, it must be a user port.
 	else
-	  #echo "${port} = user_port"
+		# echo "${port} = user_port"
 
-	  for user_port in ${port}
-	  do
-		if [[ ! -z "$user_port" ]]; then
-	#	echo "$tag_type $user_port"
-	    # Print the name of the DSA interface.
-	   		if [ "$tag_type" == "tagged" ]; then
-	            		echo "$(cat ${dsa_dt_path}port@${user_port}/label):t"
-	   		else
-	            		echo "$(cat ${dsa_dt_path}port@${user_port}/label)"
-	   		fi
-		fi
-	  done
+		for user_port in ${port}; do
+			if [[ ! -z "$user_port" ]]; then
+				# echo "$tag_type $user_port"
+				# Print the name of the DSA interface.
+				if [ "$tag_type" == "tagged" ]; then
+					echo "$(cat ${dsa_dt_path}port@${user_port}/label):t"
+				else
+					echo "$(cat ${dsa_dt_path}port@${user_port}/label)"
+				fi
+			fi
+		done
 	fi
 }
 
 findDSAInterfaces()
 # Read old UCI config with swconfig options.
-
 {
-#	echo "ports = ${ports}"
-#	echo "vlan = ${vlan}"
-#	echo "$device"
-
+	# echo "ports = ${ports}"
+	# echo "vlan = ${vlan}"
+	# echo "$device"
 
 	echo "config bridge-vlan"
 	echo "	option vlan '$vlan'"
 
-	test=""
-	for port in ${ports}
-	do
-	 if [[ ! -z "$port" ]]; then
-	  # swconfig configuration can either have a number or a number with "t" next to it.
-	  case $port in
-	  *t)
-	    # echo "tagged_port = ${port%.t}"
-	    # string manipulation (substring removal) %*t prints before "t".
-	    # Feed this to findPorts with "t" removed.
-	   test="tagged"
-#	    echo $(echo "list ports" && findPorts ${port%*t} "tagged")
-	    ;;
-	  *)
-		test="untagged"
-#	    echo "port = ${port}"
-#	   test = $(findPorts ${port} "untagged")
-#	    echo $(echo "list ports" && findPorts ${port} "untagged")
-	    ;;
-	  esac
-		is_valid=$(findPorts ${port%*t} "$test")
-		if [[ ! -z "$is_valid" ]]; then
-			if [[ "$(echo $is_valid | grep "cpu_port tagged")" ]]; then
-				echo "	option local '0'"
-			else
-	                        echo "	list ports" "'$is_valid'"
+	for port in ${ports}; do
+		if [[ ! -z "$port" ]]; then
+			# swconfig configuration can either have a number or a number with "t" next to it.
+			case $port in
+				*t)
+					# echo "tagged_port = ${port%.t}"
+					# string manipulation (substring removal) %*t prints before "t".
+					# Feed this to findPorts with "t" removed.
+					test="tagged"
+					# echo $(echo "list ports" && findPorts ${port%*t} "tagged")
+					;;
+				*)
+					test="untagged"
+					#echo "port = ${port}"
+					#test = $(findPorts ${port} "untagged")
+					#echo $(echo "list ports" && findPorts ${port} "untagged")
+					;;
+			esac
+
+			is_valid=$(findPorts ${port%*t} "$test")
+
+			if [[ ! -z "$is_valid" ]]; then
+				if [[ "$(echo $is_valid | grep "cpu_port tagged")" ]]; then
+					echo "	option local '0'"
+				else
+					echo "	list ports" "'$is_valid'"
+				fi
 			fi
 		fi
-	fi
 	done
-
-	
 }
 
 findDSASwitch()

--- a/package/base-files/files/etc/uci-defaults/14_migrate-swconfig
+++ b/package/base-files/files/etc/uci-defaults/14_migrate-swconfig
@@ -1,10 +1,66 @@
 # To-do:
-# - Fix "option local '0'". It's still being set even though CPU port is tagged.
+# - Check for tagged/untagged status for CPU ports which are not defined on DSA binding as well.
+# Therefore set "local option '0'" if it's anything other than tagged.
 # - Add every DSA interfaces under "option device" with "list ports".
 # - Change ethX interfaces on the old config to the bridge interface.
 # - Support multiple switch configuration.
 #   - Create a bridge per switch?
 #   - Create a single bridge and put all DSA interfaces of multiple switches on it?
+# - Increment the bridge number if it already exists until the incremented bridge doesn't exist on the config.
+
+findDSASwitch()
+{
+	echo "config device"
+	echo -e "\toption type 'bridge'"
+	# Hardcode bridge interface name for now.
+	bridgeInterface=br0
+	echo -e "\toption name '$bridgeInterface'"
+}
+
+findDSAInterfaces()
+# Read old UCI config with swconfig options.
+{
+	# echo "ports = ${ports}"
+	# echo "vlan = ${vlan}"
+	# echo "$device"
+
+	echo "config bridge-vlan"
+	echo -e "\toption device '$bridgeInterface'"
+	echo -e "\toption vlan '$vlan'"
+
+	for port in ${ports}; do
+		if [[ ! -z "$port" ]]; then
+			# swconfig configuration can either have a number or a number with "t" next to it.
+			case $port in
+				*t)
+					# echo "tagged_port = ${port%.t}"
+					# string manipulation (substring removal) %*t prints before "t".
+					# Feed this to findPorts with "t" removed.
+					tag_type="tagged"
+					# echo $(echo "list ports" && findPorts ${port%*t} "tagged")
+					;;
+				*)
+					tag_type="untagged"
+					#echo "port = ${port}"
+					#test = $(findPorts ${port} "untagged")
+					#echo $(echo "list ports" && findPorts ${port} "untagged")
+					;;
+			esac
+
+			is_valid=$(findPorts ${port%*t} "$tag_type")
+
+			if [[ ! -z "$is_valid" ]]; then
+				if [[ ! -z "$(echo $is_valid | grep "cpu_port")" ]]; then
+					if [[ -z "$(echo $is_valid | grep "cpu_port tagged")" ]]; then
+						echo -e "\toption local '0'"
+					fi
+				else
+					echo -e "\tlist ports" "'$is_valid'"
+				fi
+			fi
+		fi
+	done
+}
 
 findPorts()
 # Differentiate ports between user and cpu ports. Display DSA interface name of user ports.
@@ -13,29 +69,32 @@ findPorts()
 	local port=$1
 	local tag_type=$2
 
-	# Find the DSA binding path on the devicetree.
-	# Automatically find the directory for "port@" and "ethernet-port@" in "/proc/device-tree".
-	# Check dsa.yaml for reference.
+	# Find the path for the DSA bindings on the devicetree.
+	# Automatically find the directory for "port@" or "ethernet-port@" in "/proc/device-tree".
+	# Refer to dsa.yaml.
 	dsa_dt_path=$(find /proc/device-tree/ -name "*port@*" | head -1)
-	dsa_dt_path=$(echo "$dsa_dt_path" | sed 's/ports\/port.*$/ports\//g' | sed 's/ports\/ethernet-port.*$//g')
+	dsa_dt_path=$(echo "$dsa_dt_path" | sed 's/ethernet-port@.*$\|port@.*$//g')
 
-	# A port may be missing from DSA bindings (it's usually the second CPU port), ignore these ports.
+	# Some ports may be missing from DSA bindings (it's always another CPU port), ignore these ports.
 	if [[ ! -d "${dsa_dt_path}port@${port}" ]]; then
+		undefined_cpu_ports=$(echo "$port")
+		#echo $undefined_cpu_ports
 		return
 	fi
 
-	# Check if ethernet property exists to find CPU ports, only CPU ports use this property.
+	# Check if ethernet property exists, to find CPU ports. Only CPU ports use this property.
 	if [[ -f "${dsa_dt_path}port@${port}/ethernet" ]]; then
+		all_cpu_ports=$(echo "$undefined_cpu_ports" "$port")
+		#echo $all_cpu_ports
 		if [ "$tag_type" == "untagged" ]; then
-			echo "${port} = cpu_port untagged"
+			echo "${all_cpu_ports} = cpu_port untagged"
 		else
-			echo "${port} = cpu_port tagged"
+			echo "${all_cpu_ports} = cpu_port tagged"
 		fi
 
 	# If it doesn't exist, it must be a user port.
 	else
 		# echo "${port} = user_port"
-
 		for user_port in ${port}; do
 			if [[ ! -z "$user_port" ]]; then
 				# echo "$tag_type $user_port"
@@ -50,58 +109,15 @@ findPorts()
 	fi
 }
 
-findDSAInterfaces()
-# Read old UCI config with swconfig options.
+validate_section_switch()
+# Take sections in switch option from UCI.
 {
-	# echo "ports = ${ports}"
-	# echo "vlan = ${vlan}"
-	# echo "$device"
-
-	echo "config bridge-vlan"
-	echo "	option vlan '$vlan'"
-
-	for port in ${ports}; do
-		if [[ ! -z "$port" ]]; then
-			# swconfig configuration can either have a number or a number with "t" next to it.
-			case $port in
-				*t)
-					# echo "tagged_port = ${port%.t}"
-					# string manipulation (substring removal) %*t prints before "t".
-					# Feed this to findPorts with "t" removed.
-					test="tagged"
-					# echo $(echo "list ports" && findPorts ${port%*t} "tagged")
-					;;
-				*)
-					test="untagged"
-					#echo "port = ${port}"
-					#test = $(findPorts ${port} "untagged")
-					#echo $(echo "list ports" && findPorts ${port} "untagged")
-					;;
-			esac
-
-			is_valid=$(findPorts ${port%*t} "$test")
-
-			if [[ ! -z "$is_valid" ]]; then
-				if [[ "$(echo $is_valid | grep "cpu_port tagged")" ]]; then
-					echo "	option local '0'"
-				else
-					echo "	list ports" "'$is_valid'"
-				fi
-			fi
-		fi
-	done
+	uci_load_validate network-test switch "$1" "$2" \
+		'name:string'
 }
 
-findDSASwitch()
-{
-	echo "config device"
-	echo "	option type 'bridge'"
-	# increment the bridge number if it already exists until the incremented bridge doesn't exist on the config.
-	echo "	option name 'br0'"
-}
-
-validate_section_swconfig_ports()
-# Take related config options from UCI.
+validate_section_switch_vlan()
+# Take sections in switch_vlan option from UCI.
 {
 	uci_load_validate network-test switch_vlan "$1" "$2" \
 		'device:string' \
@@ -109,15 +125,16 @@ validate_section_swconfig_ports()
 		'ports:string'
 }
 
-validate_section_swconfig_switch()
+validate_section_device()
 {
-	uci_load_validate network-test switch "$1" "$2" \
-		'name:string'
+	uci_load_validate network-test device "$1" "$2" \
+		'ifname:string'
 }
 
 	. /lib/functions.sh
 	. /lib/functions/procd.sh
 
 	config_load "network-test"
-	config_foreach validate_section_swconfig_ports switch_vlan findDSAInterfaces
-	config_foreach validate_section_swconfig_switch switch findDSASwitch
+	config_foreach validate_section_switch switch findDSASwitch
+	config_foreach validate_section_switch_vlan switch_vlan findDSAInterfaces
+	config_foreach validate_section_device device replaceToBridgeInterface

--- a/package/base-files/files/etc/uci-defaults/14_migrate-swconfig
+++ b/package/base-files/files/etc/uci-defaults/14_migrate-swconfig
@@ -1,12 +1,32 @@
 # To-do:
+# - Add every DSA interface under "option device" with "list ports".
+
+# - Increment the bridge number if it already exists until the incremented bridge doesn't exist on the config.
+
 # - Check for tagged/untagged status for CPU ports which are not defined on DSA binding as well.
 # Therefore set "local option '0'" if it's anything other than tagged.
-# - Add every DSA interfaces under "option device" with "list ports".
-# - Change ethX interfaces on the old config to the bridge interface.
+# This is just minor a inconvinience. There will be just an unused brX.X interface since the local option won't be disabled.
+
+# - Change ethX.X interfaces on the old config to the bridge interface.
+# There can be multiple CPU ports set as tagged on a single VLAN.
+# In that case, there will be multiple br0.1 interfaces after converting eth0.1, eth1.1, etc. to bridge interface.
+# Check to make sure we don't have duplicate bridge interfaces.
+
 # - Support multiple switch configuration.
 #   - Create a bridge per switch?
 #   - Create a single bridge and put all DSA interfaces of multiple switches on it?
-# - Increment the bridge number if it already exists until the incremented bridge doesn't exist on the config.
+#   - Check Linksys EA9500 on OpenWrt 19.07. See how multiple switches are configured with swconfig.
+
+# Along with the migration script, increment the image version for specific (sub)targets and make these warnings on the info section for image version mismatch.
+
+# This update automatically converts swconfig configuration to DSA with bridge VLAN filtering.
+# Before updating, read below to make ready your current configuration.
+
+# DO NOT USE UNTAGGED FOR CPU PORTS
+# UCI doesn't support untagged CPU ports on Bridge VLAN filtering. You'd have to manually associate the VLAN to the bridge interface as untagged with the bridge(8) tool.
+
+# DO NOT USE MULTIPLE TAGGED CPU PORTS ON A SINGLE VLAN
+# DSA only has one CPU port, you cannot have multiple networks on the same VLAN using multiple ethX.X interfaces anymore.
 
 findDSASwitch()
 {
@@ -70,29 +90,31 @@ findPorts()
 	local tag_type=$2
 
 	# Find the path for the DSA bindings on the devicetree.
-	# Automatically find the directory for "port@" or "ethernet-port@" in "/proc/device-tree".
+	# Automatically find the directory for "ethernet-port@" or "port@" in "/proc/device-tree/".
 	# Refer to dsa.yaml.
 	dsa_dt_path=$(find /proc/device-tree/ -name "*port@*" | head -1)
 	dsa_dt_path=$(echo "$dsa_dt_path" | sed 's/ethernet-port@.*$\|port@.*$//g')
 
-	# Some ports may be missing from DSA bindings (it's always another CPU port), ignore these ports.
+	# Some ports may be missing from DSA bindings, it's always another CPU port.
+	# These must be treated as CPU ports along with the ones on the second check.
 	if [[ ! -d "${dsa_dt_path}port@${port}" ]]; then
 		undefined_cpu_ports=$(echo "$port")
-		#echo $undefined_cpu_ports
 		return
 	fi
 
 	# Check if ethernet property exists, to find CPU ports. Only CPU ports use this property.
 	if [[ -f "${dsa_dt_path}port@${port}/ethernet" ]]; then
 		all_cpu_ports=$(echo "$undefined_cpu_ports" "$port")
-		#echo $all_cpu_ports
+
+		# This checks for tagged/untagged status of the CPU ports.
+		# Move this part to somewhere else where it takes CPU port information from both checks.
 		if [ "$tag_type" == "untagged" ]; then
 			echo "${all_cpu_ports} = cpu_port untagged"
 		else
 			echo "${all_cpu_ports} = cpu_port tagged"
 		fi
 
-	# If it doesn't exist, it must be a user port.
+	# Anything else must be a user port.
 	else
 		# echo "${port} = user_port"
 		for user_port in ${port}; do

--- a/package/base-files/files/etc/uci-defaults/14_migrate-swconfig
+++ b/package/base-files/files/etc/uci-defaults/14_migrate-swconfig
@@ -1,33 +1,56 @@
+# To-do:
+# - Fix "option local '0'". It's still being set even though CPU port is tagged.
+# - Add every DSA interfaces under "option device" with "list ports".
+# - Change ethX interfaces on the old config to the bridge interface.
+# - Support multiple switch configuration.
+#   - Create a bridge per switch?
+#   - Create a single bridge and put all DSA interfaces of multiple switches on it?
+
 findPorts()
 # Differentiate ports between user and cpu ports. Display DSA interface name of user ports.
 # Check compiled devicetree to do this.
 
 {
 	local port=$1
+	local tag_type=$2
 
-	# Devicetree path is currently hardcoded for Linksys WRT32X.
-	# It should be changed to automatically find the "ports/port@" directory in "/proc/device-tree".
-	# Check dsa-port.yaml for other accepted node names like "ethernet-ports/ethernet-port@".
+	# Find the DSA binding path on the devicetree.
+	# Automatically find the directory for "port@" and "ethernet-port@" in "/proc/device-tree".
+	# Check dsa.yaml for reference.
+	dsa_dt_path=$(find /proc/device-tree/ -name "*port@*" | head -1)
+	dsa_dt_path=$(echo "$dsa_dt_path" | sed 's/ports\/port.*$/ports\//g' | sed 's/ports\/ethernet-port.*$//g')
 
 	# A port may be missing from DSA bindings (it's usually the second CPU port), ignore these ports.
-	if [[ ! -d "/proc/device-tree/soc/internal-regs/mdio@72004/switch@0/ports/port@${port}" ]]
+	if [[ ! -d "${dsa_dt_path}port@${port}" ]]
 	then
 	  return
 	fi
 
 	# Check if ethernet property exists to find CPU ports, only CPU ports use this property.
-	if [[ -f "/proc/device-tree/soc/internal-regs/mdio@72004/switch@0/ports/port@${port}/ethernet" ]]
+	if [[ -f "${dsa_dt_path}port@${port}/ethernet" ]]
 	then
-	  echo "${port} = cpu_port"
+	
+	 if [ "$tag_type" == "untagged" ]; then
+		echo "${port} = cpu_port untagged"
+	 else
+		echo "${port} = cpu_port tagged"
+	 fi
 
 	# If it doesn't exist, it must be a user port.
 	else
-	  echo "${port} = user_port"
+	  #echo "${port} = user_port"
 
 	  for user_port in ${port}
 	  do
+		if [[ ! -z "$user_port" ]]; then
+	#	echo "$tag_type $user_port"
 	    # Print the name of the DSA interface.
-	    echo "$(cat /proc/device-tree/soc/internal-regs/mdio@72004/switch@0/ports/port@${user_port}/label)"
+	   		if [ "$tag_type" == "tagged" ]; then
+	            		echo "$(cat ${dsa_dt_path}port@${user_port}/label):t"
+	   		else
+	            		echo "$(cat ${dsa_dt_path}port@${user_port}/label)"
+	   		fi
+		fi
 	  done
 	fi
 }
@@ -38,35 +61,72 @@ findDSAInterfaces()
 {
 #	echo "ports = ${ports}"
 #	echo "vlan = ${vlan}"
+#	echo "$device"
+
+
+	echo "config bridge-vlan"
+	echo "	option vlan '$vlan'"
+
+	test=""
 	for port in ${ports}
 	do
+	 if [[ ! -z "$port" ]]; then
 	  # swconfig configuration can either have a number or a number with "t" next to it.
 	  case $port in
 	  *t)
-#	    echo "tagged_port = ${port}"
-
+	    # echo "tagged_port = ${port%.t}"
 	    # string manipulation (substring removal) %*t prints before "t".
 	    # Feed this to findPorts with "t" removed.
-	    findPorts ${port%*t}
+	   test="tagged"
+#	    echo $(echo "list ports" && findPorts ${port%*t} "tagged")
 	    ;;
 	  *)
+		test="untagged"
 #	    echo "port = ${port}"
-	    findPorts ${port}
+#	   test = $(findPorts ${port} "untagged")
+#	    echo $(echo "list ports" && findPorts ${port} "untagged")
 	    ;;
 	  esac
+		is_valid=$(findPorts ${port%*t} "$test")
+		if [[ ! -z "$is_valid" ]]; then
+			if [[ "$(echo $is_valid | grep "cpu_port tagged")" ]]; then
+				echo "	option local '0'"
+			else
+	                        echo "	list ports" "'$is_valid'"
+			fi
+		fi
+	fi
 	done
+
+	
+}
+
+findDSASwitch()
+{
+	echo "config device"
+	echo "	option type 'bridge'"
+	# increment the bridge number if it already exists until the incremented bridge doesn't exist on the config.
+	echo "	option name 'br0'"
 }
 
 validate_section_swconfig_ports()
 # Take related config options from UCI.
 {
-	uci_load_validate network-old switch_vlan "$1" "$2" \
+	uci_load_validate network-test switch_vlan "$1" "$2" \
+		'device:string' \
 		'vlan:uinteger' \
 		'ports:string'
+}
+
+validate_section_swconfig_switch()
+{
+	uci_load_validate network-test switch "$1" "$2" \
+		'name:string'
 }
 
 	. /lib/functions.sh
 	. /lib/functions/procd.sh
 
-	config_load "network-old"
+	config_load "network-test"
 	config_foreach validate_section_swconfig_ports switch_vlan findDSAInterfaces
+	config_foreach validate_section_swconfig_switch switch findDSASwitch


### PR DESCRIPTION
This is a big step that I've been wanting to do for more than a year. This is all work in progress and in dire need of contributors to help out however they can. On 21 September 2022, I've made a presentation to explain how we can convert swconfig configuration to DSA interfaces with Bridge VLAN Filtering. You can find the slide on https://www.battlemesh.org/BattleMeshV14. We've put in some work with the time I had together with Marek.

Second commit is of the efforts of my friend, Mithat.

Current state of the script:
- Partially convert swconfig UCI configuration to DSA with bridge vlan filtering.
  - Read old UCI config which includes swconfig configuration.
  - Map ports from swconfig configuration to DSA ports and find DSA interface name.

To-do:
- [x] Find devicetree path automatically.
- [ ] Find edge cases (there's going to be a lot).
- [ ] Start modifying the network configuration file.


Read more to-dos on the script file.