### PR TITLE
base-files: Add more mtd helpers

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -15,6 +15,7 @@ _C=0
 NO_EXPORT=1
 LOAD_STATE=1
 LIST_SEP=" "
+MTD_REGEX="mtd\([0-9]\+\):[[:space:]]*\([0-9A-Fa-f]\+\)[[:space:]]*\([0-9A-Fa-f]\+\)[[:space:]]*"
 
 # xor multiple hex values of the same length
 xor() {
@@ -316,10 +317,7 @@ include() {
 }
 
 find_mtd_index() {
-	local PART="$(grep "\"$1\"" /proc/mtd | awk -F: '{print $1}')"
-	local INDEX="${PART##mtd}"
-
-	echo ${INDEX}
+	sed -n "s|^${MTD_REGEX}\"${1:?}\"$|\1|p" '/proc/mtd'
 }
 
 find_mtd_part() {

--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -320,6 +320,22 @@ find_mtd_index() {
 	sed -n "s|^${MTD_REGEX}\"${1:?}\"$|\1|p" '/proc/mtd'
 }
 
+find_mtd_size() {
+	sed -n "s|^${MTD_REGEX}\"${1:?}\"$|0x\2|p" '/proc/mtd'
+}
+
+find_mtd_erasesize() {
+	sed -n "s|^${MTD_REGEX}\"${1:?}\"$|0x\3|p" '/proc/mtd'
+}
+
+find_mtd_env() {
+	if [ "${1:?}" != "${1#'/dev/mtd'}" ]; then
+		sed -n "s|^mtd${1#${1%%[0-9]*}}:[[:space:]]*\([0-9A-Fa-f]\+\)[[:space:]]*\([0-9A-Fa-f]\+\)[[:space:]]*\".*\"$|${1:?} ${2:-0x0} 0x\1 0x\2|p" '/proc/mtd'
+	else
+		sed -n "s|^${MTD_REGEX}\"${1:?}\"$|/dev/mtd\1 ${2:-0x0} 0x\2 0x\3|p" '/proc/mtd'
+	fi
+}
+
 find_mtd_part() {
 	local INDEX=$(find_mtd_index "$1")
 	local PREFIX=/dev/mtdblock


### PR DESCRIPTION
A lot of files in [uboot-envtools](package/boot/uboot-envtools/files) repeat the same pattern; they all duplicate data that already lives in `/proc/mtd`. This is not only prone to errors, we have this data at runtime already!

With this new helper, we can probably reduce the sizes/complexity of a lot of files in in the aforementioned location.

For example, on the realtek platform, this becomes as simple as:
```
case "$board" in
*)
	envconf="$(find_mtd_env 'u-boot-env')"
	if [ -n "${envconf}" ]; then
		ubootenv_add_uci_config "${envconf}"
	fi

	sysenvconf="$(find_mtd_env 'u-boot-sys')"
	if [ -n "${sysconf}" ]; then
		ubootenv_add_uci_sys_config "${sysenvconf}"
	fi
esac
```
where the switch/case only survives to allow easy expansion for platforms that are somewhat quirky, with a side effect of keeping a nicer diff ;)

While I haven't looked at ath79 in detail, I do know (my own router, wdr4300) doesn't have an environment by default. This means, the current switch case simply doesn't set it up via its default case, though I think the above should work there equally well, because if we don't find the variable, we skip the configuration setup. But this will be tested and supplied via a separate MR after landing this one.