### PR TITLE
tools/cmake: use other tools

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -45,7 +45,7 @@ $(curdir)/b43-tools/compile := $(curdir)/bison/compile
 $(curdir)/bc/compile := $(curdir)/bison/compile $(curdir)/libtool/compile
 $(curdir)/bison/compile := $(curdir)/flex/compile
 $(curdir)/cbootimage/compile += $(curdir)/automake/compile
-$(curdir)/cmake/compile += $(curdir)/libressl/compile $(curdir)/ninja/compile
+$(curdir)/cmake/compile += $(curdir)/libressl/compile $(curdir)/ninja/compile $(curdir)/expat/compile $(curdir)/xz/compile $(curdir)/zlib/compile $(curdir)/zstd/compile
 $(curdir)/dosfstools/compile := $(curdir)/autoconf/compile $(curdir)/automake/compile
 $(curdir)/e2fsprogs/compile := $(curdir)/libtool/compile
 $(curdir)/fakeroot/compile := $(curdir)/libtool/compile
@@ -90,9 +90,9 @@ else
 endif
 
 ifneq ($(CONFIG_CCACHE)$(CONFIG_SDK),)
-$(foreach tool, $(filter-out zstd zlib xz pkgconf patch ninja meson libressl cmake,$(tools-y)), $(eval $(curdir)/$(tool)/compile += $(curdir)/ccache/compile))
+$(foreach tool, $(filter-out zstd zlib xz pkgconf patch ninja meson libressl expat cmake,$(tools-y)), $(eval $(curdir)/$(tool)/compile += $(curdir)/ccache/compile))
 tools-y += ccache
-$(curdir)/ccache/compile := $(curdir)/cmake/compile $(curdir)/zstd/compile
+$(curdir)/ccache/compile := $(curdir)/cmake/compile
 endif
 
 # in case there is no patch tool on the host we need to make patch tool a

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -75,7 +75,6 @@ $(curdir)/quilt/compile := $(curdir)/autoconf/compile $(curdir)/findutils/compil
 $(curdir)/sdcc/compile := $(curdir)/bison/compile
 $(curdir)/squashfs/compile := $(curdir)/lzma-old/compile
 $(curdir)/squashfskit4/compile := $(curdir)/xz/compile $(curdir)/zlib/compile
-$(curdir)/zlib/compile := $(curdir)/cmake/compile
 $(curdir)/zstd/compile := $(curdir)/meson/compile
 
 ifneq ($(HOST_OS),Linux)
@@ -92,7 +91,7 @@ else
 endif
 
 ifneq ($(CONFIG_CCACHE)$(CONFIG_SDK),)
-$(foreach tool, $(filter-out xz zstd pkgconf patch ninja meson libressl cmake,$(tools-y)), $(eval $(curdir)/$(tool)/compile += $(curdir)/ccache/compile))
+$(foreach tool, $(filter-out zstd zlib xz pkgconf patch ninja meson libressl cmake,$(tools-y)), $(eval $(curdir)/$(tool)/compile += $(curdir)/ccache/compile))
 tools-y += ccache
 $(curdir)/ccache/compile := $(curdir)/cmake/compile $(curdir)/zstd/compile
 endif

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -22,13 +22,13 @@ ifneq ($(CONFIG_SDK)$(CONFIG_PACKAGE_kmod-b43)$(CONFIG_PACKAGE_b43legacy-firmwar
 endif
 
 tools-y += autoconf autoconf-archive automake bc bison cmake cpio dosfstools
-tools-y += e2fsprogs fakeroot findutils firmware-utils flex gengetopt
+tools-y += e2fsprogs expat fakeroot findutils firmware-utils flex gengetopt
 tools-y += libressl libtool lzma m4 make-ext4fs meson missing-macros mkimage
 tools-y += mklibs mtd-utils mtools ninja padjffs2 patch-image
 tools-y += patchelf pkgconf quilt squashfskit4 sstrip zip zlib zstd
 tools-$(BUILD_B43_TOOLS) += b43-tools
 tools-$(BUILD_ISL) += isl
-tools-$(BUILD_TOOLCHAIN) += expat gmp mpc mpfr
+tools-$(BUILD_TOOLCHAIN) += gmp mpc mpfr
 tools-$(CONFIG_TARGET_apm821xx)$(CONFIG_TARGET_gemini) += genext2fs
 tools-$(CONFIG_TARGET_ath79) += lzma-old squashfs
 tools-$(CONFIG_TARGET_mxs) += elftosb sdimage
@@ -47,7 +47,6 @@ $(curdir)/bison/compile := $(curdir)/flex/compile
 $(curdir)/cbootimage/compile += $(curdir)/automake/compile
 $(curdir)/cmake/compile += $(curdir)/libressl/compile $(curdir)/ninja/compile
 $(curdir)/dosfstools/compile := $(curdir)/autoconf/compile $(curdir)/automake/compile
-$(curdir)/expat/compile := $(curdir)/cmake/compile
 $(curdir)/e2fsprogs/compile := $(curdir)/libtool/compile
 $(curdir)/fakeroot/compile := $(curdir)/libtool/compile
 $(curdir)/findutils/compile := $(curdir)/bison/compile

--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -32,7 +32,13 @@ HOST_CONFIGURE_VARS += \
 HOST_CONFIGURE_ARGS := \
 	$(if $(MAKE_JOBSERVER),--parallel="$(MAKE_JOBSERVER)") \
 	--prefix="$(STAGING_DIR_HOST)" \
+	--system-expat \
+	--system-liblzma \
+	--system-zlib \
+	--system-zstd \
 	--generator=Ninja
+
+HOST_LDFLAGS += -Wl,-rpath,$(STAGING_DIR_HOST)/lib
 
 define Host/Compile/Default
 	+$(NINJA) -C $(HOST_BUILD_DIR) $(1)

--- a/tools/cmake/patches/110-liblzma.patch
+++ b/tools/cmake/patches/110-liblzma.patch
@@ -1,0 +1,17 @@
+--- a/Modules/FindLibLZMA.cmake
++++ b/Modules/FindLibLZMA.cmake
+@@ -43,7 +43,13 @@ This module will set the following varia
+   version number as a string (ex: "5.0.3")
+ #]=======================================================================]
+ 
+-find_path(LIBLZMA_INCLUDE_DIR lzma.h )
++if(UNIX)
++  find_package(PkgConfig QUIET)
++  pkg_search_module(PC_liblzma liblzma)
++endif()
++
++find_path(LIBLZMA_INCLUDE_DIR lzma.h HINTS ${PC_liblzma_INCLUDEDIR} ${PC_liblzma_INCLUDE_DIRS})
++find_library(LIBLZMA_LIBRARY NAMES lzma HINTS ${PC_liblzma_LIBDIR} ${PC_liblzma_LIBRARY_DIRS})
+ if(NOT LIBLZMA_LIBRARY)
+   find_library(LIBLZMA_LIBRARY_RELEASE NAMES lzma liblzma NAMES_PER_DIR PATH_SUFFIXES lib)
+   find_library(LIBLZMA_LIBRARY_DEBUG NAMES lzmad liblzmad NAMES_PER_DIR PATH_SUFFIXES lib)

--- a/tools/cmake/patches/140-zlib.patch
+++ b/tools/cmake/patches/140-zlib.patch
@@ -1,0 +1,20 @@
+--- a/Modules/FindZLIB.cmake
++++ b/Modules/FindZLIB.cmake
+@@ -85,10 +85,13 @@ else()
+   set(ZLIB_NAMES_DEBUG zd zlibd zdlld zlibd1 zlib1d zlibstaticd zlibwapid zlibvcd zlibstatd)
+ endif()
+ 
+-# Try each search configuration.
+-foreach(search ${_ZLIB_SEARCHES})
+-  find_path(ZLIB_INCLUDE_DIR NAMES zlib.h ${${search}} PATH_SUFFIXES include)
+-endforeach()
++if(UNIX)
++  find_package(PkgConfig QUIET)
++  pkg_search_module(PC_zlib zlib)
++endif()
++
++find_path(ZLIB_INCLUDE_DIR zlib.h HINTS ${PC_zlib_INCLUDEDIR} ${PC_zlib_INCLUDE_DIRS})
++find_library(ZLIB_LIBRARY NAMES z HINTS ${PC_zlib_LIBDIR} ${PC_zlib_LIBRARY_DIRS})
+ 
+ # Allow ZLIB_LIBRARY to be set manually, as the location of the zlib library
+ if(NOT ZLIB_LIBRARY)

--- a/tools/expat/Makefile
+++ b/tools/expat/Makefile
@@ -15,19 +15,19 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_HASH:=a247a7f6bbb21cf2ca81ea4cbb916bfb9717ca523631675f99b3d4a5678dcd16
 PKG_SOURCE_URL:=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$(PKG_VERSION))
 
-include $(INCLUDE_DIR)/host-build.mk
-include $(INCLUDE_DIR)/cmake.mk
+HOST_BUILD_PARALLEL:=1
 
-CMAKE_HOST_OPTIONS += \
-	-DDOCBOOK_TO_MAN=OFF \
-	-DEXPAT_BUILD_TOOLS=OFF \
-	-DEXPAT_BUILD_EXAMPLES=OFF \
-	-DEXPAT_BUILD_TESTS=OFF \
-	-DEXPAT_BUILD_DOCS=OFF \
-	-DEXPAT_WITH_LIBBSD=OFF \
-	-DEXPAT_ENABLE_INSTALL=ON \
-	-DEXPAT_DTD=ON \
-	-DEXPAT_NS=OFF \
-	-DEXPAT_DEV_URANDOM=OFF
+include $(INCLUDE_DIR)/host-build.mk
+
+HOSTCC := $(HOSTCC_NOCACHE)
+
+HOST_CONFIGURE_ARGS += \
+	--disable-shared \
+	--without-docbook \
+	--with-pic
+
+define Host/Uninstall
+	-$(call Host/Compile/Default,uninstall)
+endef
 
 $(eval $(call HostBuild))

--- a/tools/zlib/Makefile
+++ b/tools/zlib/Makefile
@@ -20,23 +20,23 @@ PKG_LICENSE:=Zlib
 PKG_LICENSE_FILES:=README
 PKG_CPE_ID:=cpe:/a:gnu:zlib
 
+HOST_BUILD_PARALLEL:=1
+
 include $(INCLUDE_DIR)/host-build.mk
-include $(INCLUDE_DIR)/cmake.mk
 
-HOST_CFLAGS +=-fPIC
+HOSTCC := $(HOSTCC_NOCACHE)
+HOST_CFLAGS += $(HOST_FPIC)
 
-define Host/Install
-	$(CP) $(HOST_BUILD_DIR)/libz.a $(STAGING_DIR_HOST)/lib/
-	$(CP) $(HOST_BUILD_DIR)/zconf.h $(STAGING_DIR_HOST)/include/
-	$(CP) $(HOST_BUILD_DIR)/zlib.h $(STAGING_DIR_HOST)/include/
-	$(CP) $(HOST_BUILD_DIR)/zlib.pc $(STAGING_DIR_HOST)/lib/pkgconfig/
-endef
+HOST_CONFIGURE_ARGS = \
+	--prefix=$(STAGING_DIR_HOST) \
+	--sysconfdir=$(STAGING_DIR_HOST)/etc \
+	--localstatedir=$(STAGING_DIR_HOST)/var \
+	--libdir=$(STAGING_DIR_HOST)/lib \
+	--includedir=$(STAGING_DIR_HOST)/include \
+	--static
 
-define Host/Clean
-	rm -f $(STAGING_DIR_HOST)/lib/libz.a
-	rm -f $(STAGING_DIR_HOST)/include/zconf.h
-	rm -f $(STAGING_DIR_HOST)/include/zlib.h
-	rm -f $(STAGING_DIR_HOST)/lib/pkgconfig//zlib.pc
+define Host/Uninstall
+	-$(call Host/Compile/Default,uninstall)
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
The idea is to reduce compilation times of tools/cmake

Current issues:

```
> ldd ./staging_dir/host/bin/cmake
        linux-vdso.so.1 (0x00007fff5818d000)
        liblzma.so.5 => /lib64/liblzma.so.5 (0x00007fdad7de5000)
        libzstd.so.1 => /home/mangix/devstuff/openwrt/staging_dir/host/lib/libzstd.so.1 (0x00007fdad7d3d000)
        libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007fdad7b09000)
        libm.so.6 => /lib64/libm.so.6 (0x00007fdad7a2b000)
        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fdad7a0b000)
        libc.so.6 => /lib64/libc.so.6 (0x00007fdad7831000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fdad7e26000)
```

- FindLibLZMA.cmake is totally broken and does not use pkgconfig, as it should. <-- FIXED with simple patch.
- tools/zlib can also be converted to use its Makefile and thus a dependency of tools/cmake . Need to look into this. <---FIXED by extra commit
- tools/zstd is built shared because of toolchain/gcc needing zstd for LTO. Need to look into how to make it compatible with static libzstd. FindZstd.cmake does use pkgconfig. <--- FIXED by https://github.com/openwrt/openwrt/pull/10808