### PR TITLE
tools/meson: backport WSL2 fix

### DIFF
--- a/tools/meson/patches/010-wsl2.patch
+++ b/tools/meson/patches/010-wsl2.patch
@@ -1,0 +1,21 @@
+From 7d1ef4343ed5b2b7ab51469177a42c32c47f0528 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 6 Sep 2022 01:36:17 -0700
+Subject: [PATCH] minstall: handle extra error for selinuxenabled
+
+Microsoft's WSL2 uses a Plan 9 filesystem, which returns IOError when file is missing.
+---
+ mesonbuild/minstall.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/mesonbuild/minstall.py
++++ b/mesonbuild/minstall.py
+@@ -229,7 +229,7 @@ def restore_selinux_contexts() -> None:
+     '''
+     try:
+         subprocess.check_call(['selinuxenabled'])
+-    except (FileNotFoundError, NotADirectoryError, PermissionError, subprocess.CalledProcessError):
++    except (FileNotFoundError, NotADirectoryError, OSError, PermissionError, subprocess.CalledProcessError):
+         # If we don't have selinux or selinuxenabled returned 1, failure
+         # is ignored quietly.
+         return


### PR DESCRIPTION
For some reason, Microsoft's Plan9 driver returns IOError on missing file.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Fixes: https://github.com/openwrt/openwrt/issues/10609

well, for master at least. Needs to be backported to 22.03.