### PR TITLE
toolchain/gcc: use zstd from tools

### DIFF
--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -117,6 +117,7 @@ GCC_CONFIGURE:= \
 		--with-gmp=$(TOPDIR)/staging_dir/host \
 		--with-mpfr=$(TOPDIR)/staging_dir/host \
 		--with-mpc=$(TOPDIR)/staging_dir/host \
+		--with-zstd=$(TOPDIR)/staging_dir/host \
 		--disable-decimal-float \
 		--with-diagnostics-color=auto-if-env \
 		--enable-__cxa_atexit \


### PR DESCRIPTION
pkgconfig is not used for some reason. Match other used tools.

Signed-off-by: Rosen Penev <rosenp@gmail.com>