### PR TITLE
Makefile: remove stray \ before /

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ $(if $(findstring $(space),$(TOPDIR)),$(error ERROR: The path to the OpenWrt dir
 
 world:
 
-DISTRO_PKG_CONFIG:=$(shell $(TOPDIR)/scripts/command_all.sh pkg-config | grep -E '\/usr' -m 1)
+DISTRO_PKG_CONFIG:=$(shell $(TOPDIR)/scripts/command_all.sh pkg-config | grep -E '/usr' -m 1)
 export PATH:=$(TOPDIR)/staging_dir/host/bin:$(PATH)
 
 ifneq ($(OPENWRT_BUILD),1)


### PR DESCRIPTION
There is a harmless but annoying grep warning displayed when cross compiling on hosts running grep >=3.8:
```
% make nconfig
grep: warning: stray \ before /
grep: warning: stray \ before /
grep: warning: stray \ before /
...
```
This is due to grep 3.8 replacing pcre with pcre2[1] and  can be silenced by removing the backslash in the grep statement.

Tested on Arch Linux using grep-3.8-2 and by downgrading to grep-3.7-1 to verify functionality pre-version 3.8.

1. https://git.savannah.gnu.org/cgit/grep.git/commit/?id=e0d39a9133e1507345d73ac5aff85f037f39aa54

Signed-off-by: John Audia <therealgraysky@proton.me>