### PR TITLE
base-files: fix invalid usage of nand_do_platform_check

### DIFF
--- a/target/linux/imx/cortexa9/base-files/lib/upgrade/platform.sh
+++ b/target/linux/imx/cortexa9/base-files/lib/upgrade/platform.sh
@@ -46,7 +46,7 @@ platform_check_image() {
 	gw,imx6q-gw5910|\
 	gw,imx6q-gw5912|\
 	gw,imx6q-gw5913)
-		nand_do_platform_check $board $1
+		nand_do_platform_check "${board//,/_}" $1
 		return $?;
 		;;
 	toradex,apalis_imx6q-eval|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -47,8 +47,8 @@ platform_check_image() {
 		return 0
 		;;
 	*)
-		nand_do_platform_check "$board" "$1"
-		return 0
+		nand_do_platform_check "${board//,/_}" "$1"
+		return $?
 		;;
 	esac
 

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
@@ -72,7 +72,8 @@ platform_check_image() {
 	mediatek,mt7622-rfb1-ubi|\
 	totolink,a8000ru|\
 	xiaomi,redmi-router-ax6s)
-		nand_do_platform_check "$board" "$1"
+		nand_do_platform_check "${board//,/_}" "$1"
+		return $?
 		;;
 	*)
 		[ "$magic" != "d00dfeed" ] && {

--- a/target/linux/pistachio/base-files/lib/upgrade/platform.sh
+++ b/target/linux/pistachio/base-files/lib/upgrade/platform.sh
@@ -10,7 +10,7 @@ platform_check_image()
 {
 	local board=$(board_name)
 
-	nand_do_platform_check $board $1
+	nand_do_platform_check "${board//,/_}" $1
 	return $?
 }
 


### PR DESCRIPTION
board_name contains with no ',' so replace it with '_'

Also make sure nand_do_platform_check exit code return in platform_check_image().