### PR TITLE
ramips: enable LZMA loader to fix Linksys RE6500 boot

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1270,6 +1270,7 @@ TARGET_DEVICES += linksys_ea8100-v2
 
 define Device/linksys_re6500
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Linksys
   DEVICE_MODEL := RE6500


### PR DESCRIPTION
At some point after 21.02.3 and before 22.03.0, the size limits of the Linksys RE6500 were reached and prevent booting from the 22.03.0 release or builds of current SNAPSHOT. This patch allows builds of master to boot again and has been tested on my device.

Closes https://github.com/openwrt/openwrt/issues/8577

cc @arinc9

Signed-off-by: Mark King <mark@vemek.co>