### PR TITLE
scripts/download.pl: fix mirrors regression for curl and wget

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -78,7 +78,7 @@ sub download_cmd {
 	my $additional_mirrors = join(" ", map "$_/$filename", @_);
 
 	my @chArray = ('a'..'z', 'A'..'Z', 0..9);
-	my $rfn = join '', map{ $chArray[int rand @chArray] } 0..9;
+	my $rfn = join '', "${filename}_", map{ $chArray[int rand @chArray] } 0..9;
 	if (open CURL, '-|', 'curl', '--version') {
 		if (defined(my $line = readline CURL)) {
 			$have_curl = 1 if $line =~ /^curl /;
@@ -94,13 +94,15 @@ sub download_cmd {
 
 	if ($have_aria2c) {
 		@mirrors=();
-		return join(" ", "touch /dev/shm/${rfn}_spp;",
+		return join(" ", "[ -d $ENV{'TMPDIR'}/aria2c ] || mkdir $ENV{'TMPDIR'}/aria2c;",
+			"touch $ENV{'TMPDIR'}/aria2c/${rfn}_spp;",
 			qw(aria2c --stderr -c -x2 -s10 -j10 -k1M), $url, $additional_mirrors,
 			$check_certificate ? () : '--check-certificate=false',
-			"--server-stat-of=/dev/shm/${rfn}_spp",
-			"--server-stat-if=/dev/shm/${rfn}_spp",
-			"-d /dev/shm -o $rfn;",
-			"cat /dev/shm/$rfn;", "rm /dev/shm/$rfn /dev/shm/${rfn}_spp");
+			"--server-stat-of=$ENV{'TMPDIR'}/aria2c/${rfn}_spp",
+			"--server-stat-if=$ENV{'TMPDIR'}/aria2c/${rfn}_spp",
+			"-d $ENV{'TMPDIR'}/aria2c -o $rfn;",
+			"cat $ENV{'TMPDIR'}/aria2c/$rfn;",
+			"rm $ENV{'TMPDIR'}/aria2c/$rfn $ENV{'TMPDIR'}/aria2c/${rfn}_spp");
 	} elsif ($have_curl) {
 		return (qw(curl -f --connect-timeout 20 --retry 5 --location),
 			$check_certificate ? () : '--insecure',

--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -93,6 +93,7 @@ sub download_cmd {
 	}
 
 	if ($have_aria2c) {
+		@mirrors=();
 		return join(" ", "touch /dev/shm/${rfn}_spp;",
 			qw(aria2c --stderr -c -x2 -s10 -j10 -k1M), $url, $additional_mirrors,
 			$check_certificate ? () : '--check-certificate=false',
@@ -321,7 +322,6 @@ while (!-f "$target/$filename") {
 	if (!-f "$target/$filename" && $url_filename ne $filename) {
 		download($mirror, $filename, @mirrors);
 	}
-	@mirrors=();
 }
 
 $SIG{INT} = \&cleanup;


### PR DESCRIPTION
With the introduction of aria2c support, curl and wget no longer try to download the file from mirrors. Fix this regression by emptying the remaining mirrors list only when aria2c is used.

Fixes: d39123626931 ("download.pl: add aria2c support")
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>