### PR TITLE
realtek: fix SMP startup (v2)

### DIFF
--- a/target/linux/realtek/files-5.10/arch/mips/rtl838x/prom.c
+++ b/target/linux/realtek/files-5.10/arch/mips/rtl838x/prom.c
@@ -35,11 +35,17 @@ static struct plat_smp_ops rtl_smp_ops;
 
 static void rtl_init_secondary(void)
 {
+#ifndef CONFIG_CEVT_R4K
 /*
- * MIPS timer interrupt might fire like crazy if not used or initialized
- * properly. Silence it by setting the maximum possible interval.
+ * These devices are low on resources. There might be the chance that CEVT_R4K
+ * is not enabled in kernel build. Nevertheless the timer and interrupt 7 might
+ * be active by default after startup of secondary VPE. With no registered
+ * handler that leads to continuous unhandeled interrupts. In this case disable
+ * counting (DC) in the core and confirm a pending interrupt.
  */
+	write_c0_cause(read_c0_cause() | CAUSE_DC);
 	write_c0_compare(0);
+#endif /* CONFIG_CEVT_R4K */
 /*
  * Enable all CPU interrupts, as everything is managed by the external
  * controller. TODO: Standard vsmp_init_secondary() has special treatment for
@@ -50,7 +56,7 @@ static void rtl_init_secondary(void)
 	else
 		set_c0_status(ST0_IM);
 }
-#endif
+#endif /* CONFIG_MIPS_MT_SMP */
 
 const char *get_system_type(void)
 {

--- a/target/linux/realtek/files-5.10/arch/mips/rtl838x/prom.c
+++ b/target/linux/realtek/files-5.10/arch/mips/rtl838x/prom.c
@@ -31,6 +31,7 @@ const void *fdt;
 
 #ifdef CONFIG_MIPS_MT_SMP
 extern const struct plat_smp_ops vsmp_smp_ops;
+static struct plat_smp_ops rtl_smp_ops;
 
 static void rtl_init_secondary(void)
 {
@@ -220,8 +221,6 @@ void __init prom_init(void)
 
 #ifdef CONFIG_MIPS_MT_SMP
 	if (cpu_has_mipsmt) {
-		struct plat_smp_ops rtl_smp_ops;
-
 		rtl_smp_ops = vsmp_smp_ops;
 		rtl_smp_ops.init_secondary = rtl_init_secondary;
 		register_smp_ops(&rtl_smp_ops);


### PR DESCRIPTION
The scope of the SMP startup structure is wrong. It is created on the stack and not as a global variable. This can lead to startup failures.

Fixes: 3f41360eb70c ("realtek: use upstream recommendation for CPU start")
Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de