### PR TITLE
libcap: update to 2.66

### DIFF
--- a/package/libs/libcap/Makefile
+++ b/package/libs/libcap/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libcap
-PKG_VERSION:=2.65
+PKG_VERSION:=2.66
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/libs/security/linux-privs/libcap2
-PKG_HASH:=73e350020cc31fe15360879d19384ffa3395a825f065fcf6bda3a5cdf965bebd
+PKG_HASH:=15c40ededb3003d70a283fe587a36b7d19c8b3b554e33f86129c059a4bb466b2
 
 PKG_MAINTAINER:=Paul Wassi <p.wassi@gmx.at>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
4f96e67 Up the release version to 2.66
60ff008 Fix typos in the cap_from_text.3 man page. 281b6e4 Add captrace to .gitignore file
09a2c1d Add an example of using BPF kprobing to trace capability use. 26e3a09 Clean up getpcaps code.
fc804ac getpcaps: catch PID parsing errors.
fc437fd Fix an issue with bash displaying an error. 7db9589 Some more simplifications for building
27e801b Fix for "make clean ; make -j48 test"
