### PR TITLE
tools/zstd: build libraries as static

### DIFF
--- a/tools/zstd/Makefile
+++ b/tools/zstd/Makefile
@@ -17,9 +17,9 @@ include $(INCLUDE_DIR)/meson.mk
 MESON_HOST_BUILD_DIR:=$(HOST_BUILD_DIR)/build/meson/openwrt-build
 
 HOSTCC:= $(HOSTCC_NOCACHE)
-HOST_LDFLAGS += -Wl,-rpath,$(STAGING_DIR_HOST)/lib
 
 MESON_HOST_ARGS += \
+	-Ddefault_library=static \
 	-Dlegacy_level=7 \
 	-Ddebug_level=0 \
 	-Dbacktrace=false \


### PR DESCRIPTION
Enables to get rid of rpath hack for all users.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Requires https://github.com/openwrt/openwrt/pull/10808