### PR TITLE
ramips: add support for Zbtlink ZBT-WG1602-V04

### DIFF
--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04-16m.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04-16m.dts
@@ -1,0 +1,10 @@
+#include "mt7621_zbtlink_zbt-wg1602-v04.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-wg1602-v04-16m", "zbtlink,zbt-wg1602-v04", "mediatek,mt7621-soc";
+	model = "Zbtlink ZBT-WG1602-V04 (16M)";
+};
+
+&firmware {
+	reg = <0x50000 0xfb0000>;
+};

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04-32m.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04-32m.dts
@@ -1,0 +1,10 @@
+#include "mt7621_zbtlink_zbt-wg1602-v04.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-wg1602-v04-32m", "zbtlink,zbt-wg1602-v04", "mediatek,mt7621-soc";
+	model = "Zbtlink ZBT-WG1602-V04 (32M)";
+};
+
+&firmware {
+	reg = <0x50000 0x1fb0000>;
+};

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
@@ -1,0 +1,215 @@
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "zbtlink,zbt-wg1602", "mediatek,mt7621-soc";
+
+	aliases {
+		led-boot = &led_sm;
+		led-failsafe = &led_sm;
+		led-running = &led_sm;
+		led-upgrade = &led_sm;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sm: sm {
+			label = "green:sm";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		4g1 {
+			label = "green:4g1";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		4g2 {
+			label = "green:4g2";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		/* hw_margin_ms is actually ~120s but driver limits it to 60s */
+		hw_margin_ms = <60000>;
+		always-running;
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		4g1-pwr {
+			gpio-export,name = "4g1-pwr";
+			gpio-export,output = <1>;
+			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		4g2-pwr {
+			gpio-export,name = "4g2-pwr";
+			gpio-export,output = <1>;
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		ext-usb {
+			gpio-export,name = "ext-usb";
+			gpio-export,output = <1>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			firmware: partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi0: wifi@0,0 {
+		compatible = "pci14c3,7603";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&pcie1 {
+	wifi1: wifi@0,0 {
+		compatible = "pci14c3,7662";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart2", "wdt";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2279,6 +2279,30 @@ define Device/zbtlink_zbt-wg1602-16m
 endef
 TARGET_DEVICES += zbtlink_zbt-wg1602-16m
 
+define Device/zbtlink_zbt-wg1602-v04-16m
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Zbtlink
+  DEVICE_MODEL := ZBT-WG1602-V04
+  DEVICE_VARIANT := 16M
+  DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt7603 kmod-mt76x2 kmod-usb3 \
+        kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += zbtlink_zbt-wg1602-v04-16m
+
+define Device/zbtlink_zbt-wg1602-v04-32m
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 32128k
+  DEVICE_VENDOR := Zbtlink
+  DEVICE_MODEL := ZBT-WG1602-V04
+  DEVICE_VARIANT := 32M
+  DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt7603 kmod-mt76x2 kmod-usb3 \
+        kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += zbtlink_zbt-wg1602-v04-32m
+
 define Device/zbtlink_zbt-wg1608-16m
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)


### PR DESCRIPTION
Description heavily based on commit 7e89421a7c3855d66a20350a5bf9ca4cc7a2caf9 by Sergey Ryazanov <ryazanov.s.a@gmail.com> Details I cannot confirm have been removed

Completed with great help from \x on IRC. Thanks, \x!

Zbtlink ZBT-WG1602-V04 is a Wi-Fi router intendend for use with WWAN (UMTS/LTE/3G/4G) modems. The router board offers a couple of miniPCIe slots with USB and SIM only and another one which is a pure miniPCIe slot as well as five Gigabit Ethernet ports (4xLAN + WAN).

### Specification:

* SoC: MT7621A
* RAM: 256/512 MiB
* Flash: 16/32 MiB
* Eth: 10/100/1000 Mbps Ethernet x5 ports (4xLAN + WAN)
* WLAN 2GHz: MT7603E (.11bgn, MIMO 2x2)
* WLAN 5GHz: MT7662E (.11nac, MIMO 2x2)
* WLAN Ants: detachable x2, shared by 2GHz & 5GHz radios
* miniPCIe: 2x slots with USB&SIM + 1x slot with regular PCIe bus
* WWAN Ants: detachable x4
* External storage: microSD (SDXC) slot
* USB: 3.0 Type-A port
* LED: 11 (5 per Eth phy, 3 SoC controlled, 2 WLAN 2/5 controlled, 1 power indicator)
* Button: 1 (reset)
* UART: console (115200 baud)
* Power: DC jack (12 V / 2.5 A)

### Additional HW information:

* SoC USB port 1 is shared by internal miniPCIe slot and external Type-A USB port, USB D+/D- lines are toggled between ports using a GPIO controlled DPDT switch.

### Installation:

The kernel image can be installed directly onto the device via a browser to 192.168.1.1 using the built in firmware recovery Web UI available. It can be accessed by pushing the reset button in, applying power and holding the reset button for approximately 10 seconds. When the kernel image has been flashed, you can access LuCI and upload the sysupgrade as normal.

Signed-off-by: Alexander Horner <ahorner@programmer.net>