### PR TITLE
ramips: introduce `seama-lzma-loader` and use it for the SEAMA devices

### DIFF
--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -218,7 +218,15 @@ endef
 
 define Device/uimage-lzma-loader
   LOADER_TYPE := bin
-  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
+  KERNEL/lzma-loader := kernel-bin | append-dtb | lzma | loader-kernel
+  KERNEL := $$(KERNEL/lzma-loader) | uImage none
+endef
+
+define Device/seama-lzma-loader
+  $(Device/seama)
+  $(Device/uimage-lzma-loader)
+  KERNEL := $$(KERNEL/lzma-loader) | relocate-kernel | lzma -a0
+  KERNEL_INITRAMFS := $$(KERNEL/lzma-loader) | uImage none
 endef
 
 include $(SUBTARGET).mk

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -538,11 +538,8 @@ TARGET_DEVICES += dlink_dir-853-r1
 
 define Device/dlink_dir-860l-b1
   $(Device/dsa-migration)
-  $(Device/seama)
+  $(Device/seama-lzma-loader)
   SEAMA_SIGNATURE := wrgac13_dlink.2013gui_dir860lb
-  LOADER_TYPE := bin
-  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | relocate-kernel | \
-	lzma -a0 | uImage lzma
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-860L

--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -32,12 +32,10 @@ endef
 TARGET_DEVICES += belkin_f9k1109v1
 
 define Device/dlink_dir-645
-  $(Device/seama)
-  $(Device/uimage-lzma-loader)
+  $(Device/seama-lzma-loader)
   SOC := rt3662
   BLOCKSIZE := 4k
   IMAGE_SIZE := 7872k
-  KERNEL := kernel-bin | append-dtb | lzma -d10
   SEAMA_SIGNATURE := wrgn39_dlob.hans_dir645
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-645

--- a/target/linux/ramips/rt3883/target.mk
+++ b/target/linux/ramips/rt3883/target.mk
@@ -4,7 +4,7 @@
 
 SUBTARGET:=rt3883
 BOARDNAME:=RT3662/RT3883 based boards
-FEATURES+=usb pci small_flash
+FEATURES+=usb pci ramdisk small_flash
 CPU_TYPE:=74kc
 
 DEFAULT_PACKAGES += kmod-rt2800-pci kmod-rt2800-soc wpad-basic-wolfssl swconfig


### PR DESCRIPTION
like D-Link DIR-645 (to fix #10634) and DIR-860L B1 (see commit ce1957100411b0a751d6431d36def9c28048b4dc)