### PR TITLE
CI: kernel: test all subtarget instead of limiting it to only the first

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -26,7 +26,7 @@ jobs:
         id: find_targets
         run: |
           export TARGETS="$(perl ./scripts/dump-target-info.pl targets 2>/dev/null \
-            | sort -u -t '/' -k1,1 \
+            | sort -u -t '/' -k1 \
             | awk '{ print $1 }')"
 
           JSON='['


### PR DESCRIPTION
Currently we test only the first subtarget of each target. This is not enough as a subtarget may have many different between one another.

Test all subtarget to discover problems on kernel bump or when new drivers are introduced.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>