### PR TITLE
ath79: improve support for ELECOM devices

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -218,6 +218,11 @@ define Build/copy-file
 	cat "$(1)" > "$@"
 endef
 
+define Build/edimax-header
+	$(STAGING_DIR_HOST)/bin/mkedimaximg -i $@ -o $@.new $(1)
+	@mv $@.new $@
+endef
+
 define Build/elecom-product-header
 	$(eval product=$(word 1,$(1)))
 	$(eval fw=$(if $(word 2,$(1)),$(word 2,$(1)),$@))

--- a/target/linux/ath79/dts/qca9563_elecom_wrc-1750ghbk2-i.dts
+++ b/target/linux/ath79/dts/qca9563_elecom_wrc-1750ghbk2-i.dts
@@ -44,11 +44,34 @@
 		label = "art";
 		reg = <0xff0000 0x010000>;
 		read-only;
+
+		compatible = "nvmem-cells";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		cal_art_1000: cal@1000 {
+			reg = <0x1000 0x440>;
+		};
+
+		macaddr_art_1002: macaddr@1002 {
+			reg = <0x1002 0x6>;
+		};
+
+		cal_art_5000: cal@5000 {
+			reg = <0x5000 0x844>;
+		};
 	};
 };
 
 &pcie {
 	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0 0 0 0 0>;
+		nvmem-cells = <&cal_art_5000>;
+		nvmem-cell-names = "calibration";
+	};
 };
 
 &eth0 {
@@ -58,15 +81,6 @@
 };
 
 &wmac {
-	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_1002: macaddr@1002 {
-		reg = <0x1002 0x6>;
-	};
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/dts/qca9563_elecom_wrc-300ghbk2-i.dts
+++ b/target/linux/ath79/dts/qca9563_elecom_wrc-300ghbk2-i.dts
@@ -38,6 +38,18 @@
 		label = "art";
 		reg = <0x7f0000 0x010000>;
 		read-only;
+
+		compatible = "nvmem-cells";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		cal_art_1000: cal@1000 {
+			reg = <0x1000 0x440>;
+		};
+
+		macaddr_art_1002: macaddr@1002 {
+			reg = <0x1002 0x6>;
+		};
 	};
 };
 
@@ -48,15 +60,6 @@
 };
 
 &wmac {
-	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_1002: macaddr@1002 {
-		reg = <0x1002 0x6>;
-	};
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -634,7 +634,8 @@ ath79_setup_macs()
 		;;
 	elecom,wrc-1750ghbk2-i|\
 	elecom,wrc-300ghbk2-i)
-		wan_mac=$(macaddr_add "$(mtd_get_mac_binary art 0x1002)" -2)
+		wan_mac=$(mtd_get_mac_ascii hwconfig "HW.WAN.MAC.Address")
+		label_mac=$wan_mac
 		;;
 	engenius,ecb1200|\
 	engenius,ecb1750)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -74,9 +74,6 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(mtd_get_mac_ascii devdata "wlan5mac")
 		;;
-	elecom,wrc-1750ghbk2-i)
-		caldata_extract "art" 0x5000 0x844
-		;;
 	engenius,ecb1200|\
 	engenius,ecb1750)
 		caldata_extract "art" 0x5000 0x844

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -11,24 +11,6 @@ DEVICE_VARS += KERNEL_INITRAMFS_PREFIX DAP_SIGNATURE
 DEVICE_VARS += EDIMAX_HEADER_MAGIC EDIMAX_HEADER_MODEL
 DEVICE_VARS += OPENMESH_CE_TYPE ZYXEL_MODEL_STRING
 
-define Build/add-elecom-factory-initramfs
-  $(eval edimax_model=$(word 1,$(1)))
-  $(eval product=$(word 2,$(1)))
-
-  $(STAGING_DIR_HOST)/bin/mkedimaximg \
-	-b -s CSYS -m $(edimax_model) \
-	-f 0x70000 -S 0x01100000 \
-	-i $@ -o $@.factory
-
-  $(call Build/elecom-product-header,$(product) $@.factory)
-
-  if [ "$$(stat -c%s $@.factory)" -le $$(($(subst k,* 1024,$(subst m, * 1024k,$(IMAGE_SIZE))))) ]; then \
-	mv $@.factory $(BIN_DIR)/$(KERNEL_INITRAMFS_PREFIX)-factory.bin; \
-  else \
-	echo "WARNING: initramfs kernel image too big, cannot generate factory image" >&2; \
-  fi
-endef
-
 define Build/addpattern
 	-$(STAGING_DIR_HOST)/bin/addpattern -B $(ADDPATTERN_ID) \
 		-v v$(ADDPATTERN_VERSION) -i $@ -o $@.new
@@ -1106,8 +1088,12 @@ define Device/elecom_wrc-1750ghbk2-i
   DEVICE_VENDOR := ELECOM
   DEVICE_MODEL := WRC-1750GHBK2-I/C
   IMAGE_SIZE := 15808k
-  KERNEL_INITRAMFS := $$(KERNEL) | pad-to 2 | \
-	add-elecom-factory-initramfs RN68 WRC-1750GHBK2
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  ARTIFACTS := initramfs-factory.bin
+  ARTIFACT/initramfs-factory.bin := append-image initramfs-kernel.bin | \
+	pad-to 2 | edimax-header -b -s CSYS -m RN68 -f 0x70000 -S 0x01100000 | \
+	elecom-product-header WRC-1750GHBK2 | check-size
+endif
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
 endef
 TARGET_DEVICES += elecom_wrc-1750ghbk2-i
@@ -1117,8 +1103,12 @@ define Device/elecom_wrc-300ghbk2-i
   DEVICE_VENDOR := ELECOM
   DEVICE_MODEL := WRC-300GHBK2-I
   IMAGE_SIZE := 7616k
-  KERNEL_INITRAMFS := $$(KERNEL) | pad-to 2 | \
-	add-elecom-factory-initramfs RN51 WRC-300GHBK2-I
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  ARTIFACTS := initramfs-factory.bin
+  ARTIFACT/initramfs-factory.bin := append-image initramfs-kernel.bin | \
+	pad-to 2 | edimax-header -b -s CSYS -m RN51 -f 0x70000 -S 0x01100000 | \
+	elecom-product-header WRC-300GHBK2-I | check-size
+endif
 endef
 TARGET_DEVICES += elecom_wrc-300ghbk2-i
 

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -28,11 +28,6 @@ LOADER_FLASH_START := $(ldrflashstart-y)
 
 KERNEL_DTB = kernel-bin | append-dtb | lzma
 
-define Build/edimax-header
-	$(STAGING_DIR_HOST)/bin/mkedimaximg -i $@ -o $@.new $(1)
-	@mv $@.new $@
-endef
-
 define Build/jcg-header
 	$(STAGING_DIR_HOST)/bin/jcgimage -v $(1) \
 		$(if $(JCG_MAXSIZE), -m $$(($(subst k, * 1024,$(JCG_MAXSIZE)))),) \


### PR DESCRIPTION
This PR converts redundant initramfs-factory recipe to ARTIFACTS.

- move Build/edimax-header to image-commands.mk
- use ARTIFACTS for initramfs-factory of ELECOM devices
- use NVMEM for wlan caldata on ELECOM devices
- improve MAC address configuration of ELECOM devices

compiled & tested on WRC-300GHBK2-I, WRC-1750GHBK2-I