### PR TITLE
[22.03] ath79: cherry-pick ubnt-xm tiny targets and low_mem

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -432,19 +432,11 @@ ubnt,powerbeam-5ac-gen2)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "blue:rssi2" "wlan0" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "blue:rssi3" "wlan0" "76" "100"
 	;;
-ubnt,bullet-m-ar7240|\
-ubnt,bullet-m-ar7241|\
 ubnt,bullet-m-xw|\
-ubnt,nanobridge-m|\
-ubnt,nanostation-loco-m|\
 ubnt,nanostation-loco-m-xw|\
-ubnt,nanostation-m|\
 ubnt,nanostation-m-xw|\
-ubnt,picostation-m|\
 ubnt,powerbeam-m2-xw|\
-ubnt,powerbeam-m5-xw|\
-ubnt,powerbridge-m|\
-ubnt,rocket-m)
+ubnt,powerbeam-m5-xw)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "red:link1" "wlan0" "1" "100"
 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "orange:link2" "wlan0" "26" "100"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -89,25 +89,18 @@ ath79_setup_interfaces()
 	tplink,tl-wa1201-v2|\
 	tplink,tl-wr902ac-v1|\
 	ubnt,bullet-ac|\
-	ubnt,bullet-m-ar7240|\
-	ubnt,bullet-m-ar7241|\
 	ubnt,bullet-m-xw|\
 	ubnt,lap-120|\
 	ubnt,litebeam-ac-gen2|\
 	ubnt,nanobeam-ac|\
 	ubnt,nanobeam-ac-xc|\
-	ubnt,nanobridge-m|\
 	ubnt,nanostation-ac-loco|\
-	ubnt,nanostation-loco-m|\
 	ubnt,nanostation-loco-m-xw|\
-	ubnt,picostation-m|\
 	ubnt,powerbeam-5ac-500|\
 	ubnt,powerbeam-5ac-gen2|\
 	ubnt,powerbeam-m2-xw|\
 	ubnt,powerbeam-m5-xw|\
-	ubnt,powerbridge-m|\
 	ubnt,rocket-5ac-lite|\
-	ubnt,rocket-m|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-lr|\
 	ubnt,unifiac-mesh|\
@@ -177,8 +170,7 @@ ath79_setup_interfaces()
 	tplink,archer-c60-v3|\
 	tplink,tl-wdr3500-v1|\
 	tplink,tl-wr842n-v1|\
-	tplink,tl-wr842n-v3|\
-	ubnt,airrouter)
+	tplink,tl-wr842n-v3)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
@@ -213,7 +205,6 @@ ath79_setup_interfaces()
 	tplink,wbs210-v2|\
 	tplink,wbs510-v1|\
 	tplink,wbs510-v2|\
-	ubnt,nanostation-m|\
 	ubnt,routerstation)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
@@ -713,15 +704,6 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_text mac 0x18)
 		label_mac=$wan_mac
 		;;
-	ubnt,airrouter|\
-	ubnt,bullet-m-ar7240|\
-	ubnt,bullet-m-ar7241|\
-	ubnt,nanobridge-m|\
-	ubnt,nanostation-loco-m|\
-	ubnt,nanostation-m|\
-	ubnt,picostation-m|\
-	ubnt,powerbridge-m|\
-	ubnt,rocket-m|\
 	ubnt,unifi)
 		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -119,16 +119,7 @@ case "$FIRMWARE" in
 	netgear,wnr2200-16m|\
 	pcs,cap324|\
 	tplink,tl-wr2543-v1|\
-	tplink,tl-wr842n-v1|\
-	ubnt,airrouter|\
-	ubnt,bullet-m-ar7240|\
-	ubnt,bullet-m-ar7241|\
-	ubnt,nanobridge-m|\
-	ubnt,nanostation-loco-m|\
-	ubnt,nanostation-m|\
-	ubnt,picostation-m|\
-	ubnt,powerbridge-m|\
-	ubnt,rocket-m)
+	tplink,tl-wr842n-v1)
 		caldata_extract "art" 0x1000 0x1000
 		;;
 	openmesh,mr600-v1|\

--- a/target/linux/ath79/image/Makefile
+++ b/target/linux/ath79/image/Makefile
@@ -97,6 +97,7 @@ endif
 ifeq ($(SUBTARGET),tiny)
 include tiny-netgear.mk
 include tiny-tp-link.mk
+include tiny-ubnt.mk
 endif
 
 $(eval $(call BuildImage))

--- a/target/linux/ath79/image/common-ubnt.mk
+++ b/target/linux/ath79/image/common-ubnt.mk
@@ -1,0 +1,142 @@
+DEVICE_VARS += UBNT_BOARD UBNT_CHIP UBNT_TYPE UBNT_VERSION UBNT_REVISION
+
+# On M (XW) devices the U-Boot as of version 1.1.4-s1039 doesn't like
+# VERSION_DIST being on the place of major(?) version number, so we need to
+# use some number.
+UBNT_REVISION := $(VERSION_DIST)-$(REVISION)
+
+# mkubntimage is using the kernel image direct
+# routerboard creates partitions out of the ubnt header
+define Build/mkubntimage
+	-$(STAGING_DIR_HOST)/bin/mkfwimage -B $(UBNT_BOARD) \
+		-v $(UBNT_TYPE).$(UBNT_CHIP).v6.0.0-$(VERSION_DIST)-$(REVISION) \
+		-k $(IMAGE_KERNEL) -r $@ -o $@
+endef
+
+define Build/mkubntimage2
+	-$(STAGING_DIR_HOST)/bin/mkfwimage2 -f 0x9f000000 \
+		-v $(UBNT_TYPE).$(UBNT_CHIP).v6.0.0-$(VERSION_DIST)-$(REVISION) \
+		-p jffs2:0x50000:0xf60000:0:0:$@ \
+		-o $@.new
+	@mv $@.new $@
+endef
+
+# all UBNT XM/WA devices expect the kernel image to have 1024k while flash, when
+# booting the image, the size doesn't matter.
+define Build/mkubntimage-split
+	-[ -f $@ ] && ( \
+	dd if=$@ of=$@.old1 bs=1024k count=1; \
+	dd if=$@ of=$@.old2 bs=1024k skip=1; \
+	$(STAGING_DIR_HOST)/bin/mkfwimage -B $(UBNT_BOARD) \
+		-v $(UBNT_TYPE).$(UBNT_CHIP).v$(UBNT_VERSION)-$(UBNT_REVISION) \
+		-k $@.old1 -r $@.old2 -o $@; \
+	rm $@.old1 $@.old2 )
+endef
+
+# UBNT_BOARD e.g. one of (XS2, XS5, RS, XM)
+# UBNT_TYPE e.g. one of (BZ, XM, XW)
+# UBNT_CHIP e.g. one of (ar7240, ar933x, ar934x)
+# UBNT_VERSION e.g. one of (6.0.0, 8.5.3)
+define Device/ubnt
+  DEVICE_VENDOR := Ubiquiti
+  DEVICE_PACKAGES := kmod-usb2
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | mkubntimage-split
+endef
+
+define Device/ubnt-bz
+  $(Device/ubnt)
+  SOC := ar7241
+  IMAGE_SIZE := 7448k
+  UBNT_BOARD := XM
+  UBNT_CHIP := ar7240
+  UBNT_TYPE := BZ
+  UBNT_VERSION := 6.0.0
+endef
+
+define Device/ubnt-sw
+  $(Device/ubnt)
+  SOC := ar7242
+  DEVICE_PACKAGES += kmod-usb-ohci
+  IMAGE_SIZE := 7552k
+  UBNT_BOARD := SW
+  UBNT_CHIP := ar7240
+  UBNT_TYPE := SW
+  UBNT_VERSION := 1.4.1
+  KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma | uImage lzma
+endef
+
+define Device/ubnt-2wa
+  $(Device/ubnt)
+  SOC := ar9342
+  IMAGE_SIZE := 15744k
+  UBNT_BOARD := WA
+  UBNT_CHIP := ar934x
+  UBNT_TYPE := 2WA
+  UBNT_VERSION := 8.5.3
+endef
+
+define Device/ubnt-wa
+  $(Device/ubnt)
+  SOC := ar9342
+  IMAGE_SIZE := 15744k
+  UBNT_BOARD := WA
+  UBNT_CHIP := ar934x
+  UBNT_TYPE := WA
+  UBNT_VERSION := 8.5.3
+endef
+
+define Device/ubnt-xc
+  $(Device/ubnt)
+  IMAGE_SIZE := 15744k
+  UBNT_BOARD := XC
+  UBNT_CHIP := qca955x
+  UBNT_TYPE := XC
+  UBNT_VERSION := 8.5.3
+endef
+
+define Device/ubnt-xm
+  $(Device/ubnt)
+  DEVICE_VARIANT := XM
+  DEVICE_PACKAGES += kmod-usb-ohci
+  IMAGE_SIZE := 7448k
+  UBNT_BOARD := XM
+  UBNT_CHIP := ar7240
+  UBNT_REVISION := 42.$(UBNT_REVISION)
+  UBNT_TYPE := XM
+  UBNT_VERSION := 6.0.0
+  KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma | uImage lzma
+endef
+
+define Device/ubnt-xw
+  $(Device/ubnt)
+  SOC := ar9342
+  DEVICE_VARIANT := XW
+  IMAGE_SIZE := 7552k
+  UBNT_BOARD := XM
+  UBNT_CHIP := ar934x
+  UBNT_REVISION := 42.$(UBNT_REVISION)
+  UBNT_TYPE := XW
+  UBNT_VERSION := 6.0.4
+endef
+
+define Device/ubnt-unifi-jffs2
+  $(Device/ubnt)
+  KERNEL_SIZE := 3072k
+  IMAGE_SIZE := 15744k
+  UBNT_TYPE := BZ
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma | jffs2 kernel0
+  IMAGES := sysupgrade.bin factory.bin
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs |\
+	pad-rootfs | check-size | append-metadata
+  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | mkubntimage2
+endef
+
+define Device/ubnt-acb
+  $(Device/ubnt)
+  IMAGE_SIZE := 15744k
+  UBNT_BOARD := ACB
+  UBNT_TYPE := ACB
+  UBNT_VERSION := 2.5.0
+endef

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -1,145 +1,4 @@
-DEVICE_VARS += UBNT_BOARD UBNT_CHIP UBNT_TYPE UBNT_VERSION UBNT_REVISION
-
-# On M (XW) devices the U-Boot as of version 1.1.4-s1039 doesn't like
-# VERSION_DIST being on the place of major(?) version number, so we need to
-# use some number.
-UBNT_REVISION := $(VERSION_DIST)-$(REVISION)
-
-# mkubntimage is using the kernel image direct
-# routerboard creates partitions out of the ubnt header
-define Build/mkubntimage
-	-$(STAGING_DIR_HOST)/bin/mkfwimage -B $(UBNT_BOARD) \
-		-v $(UBNT_TYPE).$(UBNT_CHIP).v6.0.0-$(VERSION_DIST)-$(REVISION) \
-		-k $(IMAGE_KERNEL) -r $@ -o $@
-endef
-
-define Build/mkubntimage2
-	-$(STAGING_DIR_HOST)/bin/mkfwimage2 -f 0x9f000000 \
-		-v $(UBNT_TYPE).$(UBNT_CHIP).v6.0.0-$(VERSION_DIST)-$(REVISION) \
-		-p jffs2:0x50000:0xf60000:0:0:$@ \
-		-o $@.new
-	@mv $@.new $@
-endef
-
-# all UBNT XM/WA devices expect the kernel image to have 1024k while flash, when
-# booting the image, the size doesn't matter.
-define Build/mkubntimage-split
-	-[ -f $@ ] && ( \
-	dd if=$@ of=$@.old1 bs=1024k count=1; \
-	dd if=$@ of=$@.old2 bs=1024k skip=1; \
-	$(STAGING_DIR_HOST)/bin/mkfwimage -B $(UBNT_BOARD) \
-		-v $(UBNT_TYPE).$(UBNT_CHIP).v$(UBNT_VERSION)-$(UBNT_REVISION) \
-		-k $@.old1 -r $@.old2 -o $@; \
-	rm $@.old1 $@.old2 )
-endef
-
-# UBNT_BOARD e.g. one of (XS2, XS5, RS, XM)
-# UBNT_TYPE e.g. one of (BZ, XM, XW)
-# UBNT_CHIP e.g. one of (ar7240, ar933x, ar934x)
-# UBNT_VERSION e.g. one of (6.0.0, 8.5.3)
-define Device/ubnt
-  DEVICE_VENDOR := Ubiquiti
-  DEVICE_PACKAGES := kmod-usb2
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size | mkubntimage-split
-endef
-
-define Device/ubnt-bz
-  $(Device/ubnt)
-  SOC := ar7241
-  IMAGE_SIZE := 7448k
-  UBNT_BOARD := XM
-  UBNT_CHIP := ar7240
-  UBNT_TYPE := BZ
-  UBNT_VERSION := 6.0.0
-endef
-
-define Device/ubnt-sw
-  $(Device/ubnt)
-  SOC := ar7242
-  DEVICE_PACKAGES += kmod-usb-ohci
-  IMAGE_SIZE := 7552k
-  UBNT_BOARD := SW
-  UBNT_CHIP := ar7240
-  UBNT_TYPE := SW
-  UBNT_VERSION := 1.4.1
-  KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma | uImage lzma
-endef
-
-define Device/ubnt-2wa
-  $(Device/ubnt)
-  SOC := ar9342
-  IMAGE_SIZE := 15744k
-  UBNT_BOARD := WA
-  UBNT_CHIP := ar934x
-  UBNT_TYPE := 2WA
-  UBNT_VERSION := 8.5.3
-endef
-
-define Device/ubnt-wa
-  $(Device/ubnt)
-  SOC := ar9342
-  IMAGE_SIZE := 15744k
-  UBNT_BOARD := WA
-  UBNT_CHIP := ar934x
-  UBNT_TYPE := WA
-  UBNT_VERSION := 8.5.3
-endef
-
-define Device/ubnt-xc
-  $(Device/ubnt)
-  IMAGE_SIZE := 15744k
-  UBNT_BOARD := XC
-  UBNT_CHIP := qca955x
-  UBNT_TYPE := XC
-  UBNT_VERSION := 8.5.3
-endef
-
-define Device/ubnt-xm
-  $(Device/ubnt)
-  DEVICE_VARIANT := XM
-  DEVICE_PACKAGES += kmod-usb-ohci
-  IMAGE_SIZE := 7448k
-  UBNT_BOARD := XM
-  UBNT_CHIP := ar7240
-  UBNT_REVISION := 42.$(UBNT_REVISION)
-  UBNT_TYPE := XM
-  UBNT_VERSION := 6.0.0
-  KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma | uImage lzma
-endef
-
-define Device/ubnt-xw
-  $(Device/ubnt)
-  SOC := ar9342
-  DEVICE_VARIANT := XW
-  IMAGE_SIZE := 7552k
-  UBNT_BOARD := XM
-  UBNT_CHIP := ar934x
-  UBNT_REVISION := 42.$(UBNT_REVISION)
-  UBNT_TYPE := XW
-  UBNT_VERSION := 6.0.4
-endef
-
-define Device/ubnt-unifi-jffs2
-  $(Device/ubnt)
-  KERNEL_SIZE := 3072k
-  IMAGE_SIZE := 15744k
-  UBNT_TYPE := BZ
-  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma | jffs2 kernel0
-  IMAGES := sysupgrade.bin factory.bin
-  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs |\
-	pad-rootfs | check-size | append-metadata
-  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | mkubntimage2
-endef
-
-define Device/ubnt-acb
-  $(Device/ubnt)
-  IMAGE_SIZE := 15744k
-  UBNT_BOARD := ACB
-  UBNT_TYPE := ACB
-  UBNT_VERSION := 2.5.0
-endef
+include ./common-ubnt.mk
 
 define Device/ubnt_aircube-ac
   $(Device/ubnt-acb)
@@ -159,40 +18,12 @@ define Device/ubnt_aircube-isp
 endef
 TARGET_DEVICES += ubnt_aircube-isp
 
-define Device/ubnt_airrouter
-  $(Device/ubnt-xm)
-  SOC := ar7241
-  DEVICE_MODEL := AirRouter
-  SUPPORTED_DEVICES += airrouter
-endef
-TARGET_DEVICES += ubnt_airrouter
-
 define Device/ubnt_bullet-ac
   $(Device/ubnt-2wa)
   DEVICE_MODEL := Bullet AC
   DEVICE_PACKAGES += kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct rssileds
 endef
 TARGET_DEVICES += ubnt_bullet-ac
-
-define Device/ubnt_bullet-m-ar7240
-  $(Device/ubnt-xm)
-  SOC := ar7240
-  DEVICE_MODEL := Bullet M
-  DEVICE_VARIANT := XM (AR7240)
-  DEVICE_PACKAGES += rssileds
-  SUPPORTED_DEVICES += bullet-m
-endef
-TARGET_DEVICES += ubnt_bullet-m-ar7240
-
-define Device/ubnt_bullet-m-ar7241
-  $(Device/ubnt-xm)
-  SOC := ar7241
-  DEVICE_MODEL := Bullet M
-  DEVICE_VARIANT := XM (AR7241)
-  DEVICE_PACKAGES += rssileds
-  SUPPORTED_DEVICES += bullet-m ubnt,bullet-m
-endef
-TARGET_DEVICES += ubnt_bullet-m-ar7241
 
 define Device/ubnt_bullet-m-xw
   $(Device/ubnt-xw)
@@ -263,15 +94,6 @@ define Device/ubnt_nanobeam-m5-xw
 endef
 TARGET_DEVICES += ubnt_nanobeam-m5-xw
 
-define Device/ubnt_nanobridge-m
-  $(Device/ubnt-xm)
-  SOC := ar7241
-  DEVICE_MODEL := NanoBridge M
-  DEVICE_PACKAGES += rssileds
-  SUPPORTED_DEVICES += bullet-m
-endef
-TARGET_DEVICES += ubnt_nanobridge-m
-
 define Device/ubnt_nanostation-ac
   $(Device/ubnt-wa)
   DEVICE_MODEL := Nanostation AC
@@ -286,15 +108,6 @@ define Device/ubnt_nanostation-ac-loco
 endef
 TARGET_DEVICES += ubnt_nanostation-ac-loco
 
-define Device/ubnt_nanostation-loco-m
-  $(Device/ubnt-xm)
-  SOC := ar7241
-  DEVICE_MODEL := Nanostation Loco M
-  DEVICE_PACKAGES += rssileds
-  SUPPORTED_DEVICES += bullet-m
-endef
-TARGET_DEVICES += ubnt_nanostation-loco-m
-
 define Device/ubnt_nanostation-loco-m-xw
   $(Device/ubnt-xw)
   DEVICE_MODEL := Nanostation Loco M
@@ -303,15 +116,6 @@ define Device/ubnt_nanostation-loco-m-xw
 endef
 TARGET_DEVICES += ubnt_nanostation-loco-m-xw
 
-define Device/ubnt_nanostation-m
-  $(Device/ubnt-xm)
-  SOC := ar7241
-  DEVICE_MODEL := Nanostation M
-  DEVICE_PACKAGES += rssileds
-  SUPPORTED_DEVICES += nanostation-m
-endef
-TARGET_DEVICES += ubnt_nanostation-m
-
 define Device/ubnt_nanostation-m-xw
   $(Device/ubnt-xw)
   DEVICE_MODEL := Nanostation M
@@ -319,15 +123,6 @@ define Device/ubnt_nanostation-m-xw
   SUPPORTED_DEVICES += nanostation-m-xw
 endef
 TARGET_DEVICES += ubnt_nanostation-m-xw
-
-define Device/ubnt_picostation-m
-  $(Device/ubnt-xm)
-  SOC := ar7241
-  DEVICE_MODEL := Picostation M
-  DEVICE_PACKAGES += rssileds
-  SUPPORTED_DEVICES += bullet-m
-endef
-TARGET_DEVICES += ubnt_picostation-m
 
 define Device/ubnt_powerbeam-5ac-500
   $(Device/ubnt-xc)
@@ -362,15 +157,6 @@ define Device/ubnt_powerbeam-m5-xw
 endef
 TARGET_DEVICES += ubnt_powerbeam-m5-xw
 
-define Device/ubnt_powerbridge-m
-  $(Device/ubnt-xm)
-  SOC := ar7241
-  DEVICE_MODEL := PowerBridge M
-  DEVICE_PACKAGES += rssileds
-  SUPPORTED_DEVICES += bullet-m
-endef
-TARGET_DEVICES += ubnt_powerbridge-m
-
 define Device/ubnt_rocket-5ac-lite
   $(Device/ubnt-xc)
   SOC := qca9558
@@ -379,15 +165,6 @@ define Device/ubnt_rocket-5ac-lite
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
 endef
 TARGET_DEVICES += ubnt_rocket-5ac-lite
-
-define Device/ubnt_rocket-m
-  $(Device/ubnt-xm)
-  SOC := ar7241
-  DEVICE_MODEL := Rocket M
-  DEVICE_PACKAGES += rssileds
-  SUPPORTED_DEVICES += rocket-m
-endef
-TARGET_DEVICES += ubnt_rocket-m
 
 define Device/ubnt_routerstation_common
   DEVICE_PACKAGES := -kmod-ath9k -wpad-basic-wolfssl -uboot-envtools kmod-usb-ohci \

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -3,6 +3,7 @@ include ./common-netgear.mk
 include ./common-senao.mk
 include ./common-tp-link.mk
 include ./common-yuncore.mk
+include ./common-ubnt.mk
 
 DEVICE_VARS += ADDPATTERN_ID ADDPATTERN_VERSION
 DEVICE_VARS += SEAMA_SIGNATURE SEAMA_MTDBLOCK

--- a/target/linux/ath79/image/tiny-ubnt.mk
+++ b/target/linux/ath79/image/tiny-ubnt.mk
@@ -1,0 +1,83 @@
+include ./common-ubnt.mk
+
+define Device/ubnt_airrouter
+  $(Device/ubnt-xm)
+  SOC := ar7241
+  DEVICE_MODEL := AirRouter
+  SUPPORTED_DEVICES += airrouter
+endef
+TARGET_DEVICES += ubnt_airrouter
+
+define Device/ubnt_nanobridge-m
+  $(Device/ubnt-xm)
+  SOC := ar7241
+  DEVICE_MODEL := NanoBridge M
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += bullet-m
+endef
+TARGET_DEVICES += ubnt_nanobridge-m
+
+define Device/ubnt_bullet-m-ar7240
+  $(Device/ubnt-xm)
+  SOC := ar7240
+  DEVICE_MODEL := Bullet M
+  DEVICE_VARIANT := XM (AR7240)
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += bullet-m
+endef
+TARGET_DEVICES += ubnt_bullet-m-ar7240
+
+define Device/ubnt_bullet-m-ar7241
+  $(Device/ubnt-xm)
+  SOC := ar7241
+  DEVICE_MODEL := Bullet M
+  DEVICE_VARIANT := XM (AR7241)
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += bullet-m ubnt,bullet-m
+endef
+TARGET_DEVICES += ubnt_bullet-m-ar7241
+
+define Device/ubnt_picostation-m
+  $(Device/ubnt-xm)
+  SOC := ar7241
+  DEVICE_MODEL := Picostation M
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += bullet-m
+endef
+TARGET_DEVICES += ubnt_picostation-m
+
+define Device/ubnt_nanostation-m
+  $(Device/ubnt-xm)
+  SOC := ar7241
+  DEVICE_MODEL := Nanostation M
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += nanostation-m
+endef
+TARGET_DEVICES += ubnt_nanostation-m
+
+define Device/ubnt_nanostation-loco-m
+  $(Device/ubnt-xm)
+  SOC := ar7241
+  DEVICE_MODEL := Nanostation Loco M
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += bullet-m
+endef
+TARGET_DEVICES += ubnt_nanostation-loco-m
+
+define Device/ubnt_powerbridge-m
+  $(Device/ubnt-xm)
+  SOC := ar7241
+  DEVICE_MODEL := PowerBridge M
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += bullet-m
+endef
+TARGET_DEVICES += ubnt_powerbridge-m
+
+define Device/ubnt_rocket-m
+  $(Device/ubnt-xm)
+  SOC := ar7241
+  DEVICE_MODEL := Rocket M
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += rocket-m
+endef
+TARGET_DEVICES += ubnt_rocket-m

--- a/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
@@ -110,6 +110,20 @@ tplink,tl-wr941nd-v6)
 tplink,tl-wr940n-v6)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
 	;;
+ubnt,bullet-m-ar7240|\
+ubnt,bullet-m-ar7241|\
+ubnt,nanobridge-m|\
+ubnt,nanostation-loco-m|\
+ubnt,nanostation-m|\
+ubnt,picostation-m|\
+ubnt,powerbridge-m|\
+ubnt,rocket-m)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "red:link1" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "orange:link2" "wlan0" "26" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:link3" "wlan0" "51" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:link4" "wlan0" "76" "100"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -49,7 +49,14 @@ ath79_setup_interfaces()
 	tplink,tl-wa901nd-v5|\
 	tplink,tl-wr703n|\
 	tplink,tl-wr802n-v1|\
-	tplink,tl-wr802n-v2)
+	tplink,tl-wr802n-v2|\
+	ubnt,bullet-m-ar7240|\
+	ubnt,bullet-m-ar7241|\
+	ubnt,nanobridge-m|\
+	ubnt,picostation-m|\
+	ubnt,nanostation-loco-m|\
+	ubnt,powerbridge-m|\
+	ubnt,rocket-m)
 		ucidef_set_interface_lan "eth0"
 		;;
 	engenius,enh202-v1)
@@ -96,6 +103,14 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
 		;;
+	ubnt,airrouter)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
+		;;
+	ubnt,nanostation-m)
+		ucidef_set_interfaces_lan_wan "eth1" "eth0"
+		;;
 	*)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		;;
@@ -112,7 +127,16 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii "nvram" "wan_mac")
 		label_mac=$wan_mac
 		;;
-	engenius,enh202-v1)
+	engenius,enh202-v1|\
+	ubnt,airrouter|\
+	ubnt,bullet-m-ar7240|\
+	ubnt,bullet-m-ar7241|\
+	ubnt,nanobridge-m|\
+	ubnt,nanostation-loco-m|\
+	ubnt,nanostation-m|\
+	ubnt,picostation-m|\
+	ubnt,powerbridge-m|\
+	ubnt,rocket-m)
 		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;
 	tplink,tl-wr941-v2|\

--- a/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -36,7 +36,16 @@ case "$FIRMWARE" in
 	tplink,tl-wr740n-v3|\
 	tplink,tl-wr741-v1|\
 	tplink,tl-wr743nd-v1|\
-	tplink,tl-wr841-v7)
+	tplink,tl-wr841-v7|\
+	ubnt,airrouter|\
+	ubnt,bullet-m-ar7240|\
+	ubnt,bullet-m-ar7241|\
+	ubnt,nanobridge-m|\
+	ubnt,nanostation-loco-m|\
+	ubnt,nanostation-m|\
+	ubnt,picostation-m|\
+	ubnt,powerbridge-m|\
+	ubnt,rocket-m)
 		caldata_extract "art" 0x1000 0x1000
 		;;
 	pqi,air-pen)

--- a/target/linux/ath79/tiny/target.mk
+++ b/target/linux/ath79/tiny/target.mk
@@ -1,5 +1,5 @@
 BOARDNAME:=Devices with small flash
-FEATURES += small_flash
+FEATURES += low_mem small_flash
 
 DEFAULT_PACKAGES += wpad-basic-wolfssl
 


### PR DESCRIPTION
Cherry-pick latest ath79 changes that saves ram and resources for older ubnt-xm devices. 
