### PR TITLE
kirkwood: add support for Cisco CVR328W-K9-CN

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -574,6 +574,7 @@ define Build/tplink-v2-image
 endef
 
 define Build/uImage
+	$(if $(UIMAGE_TIME),SOURCE_DATE_EPOCH="$(UIMAGE_TIME)") \
 	mkimage \
 		-A $(LINUX_KARCH) \
 		-O linux \

--- a/package/boot/uboot-envtools/files/kirkwood
+++ b/package/boot/uboot-envtools/files/kirkwood
@@ -13,6 +13,7 @@ board=$(board_name)
 
 case "$board" in
 checkpoint,l-50|\
+cisco,cvr328w|\
 cloudengines,pogoe02|\
 cloudengines,pogoplugv4|\
 globalscale,sheevaplug|\

--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -13,6 +13,9 @@ kirkwood_setup_interfaces()
 	checkpoint,l-50)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5 lan6 lan7 lan8 dmz" "eth0"
 		;;
+	cisco,cvr328w)
+		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3 lan4 lan5 lan6 lan7 lan8" "wan0"
+		;;
 	cisco,on100)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;
@@ -56,6 +59,11 @@ kirkwood_setup_macs()
 	local label_mac=""
 
 	case "$board" in
+	cisco,cvr328w)
+		wan_mac=$(mtd_get_mac_ascii nvram wan_hwaddr)
+		lan_mac=$(mtd_get_mac_ascii nvram lan_hwaddr)
+		label_mac=$wan_mac
+		;;
 	iptime,nas1)
 		lan_mac=$(mtd_get_mac_binary u-boot 0x3ffa8)
 		label_mac=$lan_mac

--- a/target/linux/kirkwood/base-files/etc/init.d/bootcount
+++ b/target/linux/kirkwood/base-files/etc/init.d/bootcount
@@ -4,6 +4,13 @@ START=99
 
 boot() {
 	case $(board_name) in
+	cisco,cvr328w)
+		local i=$(fw_printenv cur_booted_runtime_image -n)
+		[ -n "$i" ] && fw_setenv -s - << EOF
+runtime_image${i}_stable
+runtime_image${i}_try_num
+EOF
+		;;
 	linksys,e4200-v2|\
 	linksys,ea3500|\
 	linksys,ea4500)

--- a/target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-cvr328w.dts
+++ b/target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-cvr328w.dts
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "kirkwood.dtsi"
+#include "kirkwood-6282.dtsi"
+
+/ {
+	model = "Cisco Systems CVR328W-K9-CN";
+	compatible = "cisco,cvr328w", "cybertan,cvr328w", "marvell,kirkwood-88f6282", "marvell,kirkwood";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_sys_red;
+		led-running = &led_power;
+		led-upgrade = &led_sys_green;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		/*
+		 * "root" argument from the stock bootloader should be ignored
+		 * as it'll prevent the kernel from finding the correct rootfs.
+		 */
+		bootargs-append = " ro root=";
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&pmx_buttons>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&pmx_leds>;
+		pinctrl-names = "default";
+
+		led_sys_green: sys-green {
+			label = "green:sys";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+
+		/* Note: sys-green and sys-red cannot be activated simultaneously */
+		led_sys_red: sys-red {
+			label = "red:sys";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		};
+
+		vpn {
+			label = "green:vpn";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "green:usb";
+			gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&hub_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		3g {
+			label = "green:3g";
+			gpios = <&gpio1 16 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&hub_port4>;
+			linux,default-trigger = "usbport";
+		};
+
+		nms {
+			label = "green:nms";
+			gpios = <&gpio1 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	ethernet0-port@0 {
+		phy-mode = "gmii";
+		speed = <1000>;
+		duplex = <1>;
+	};
+};
+
+/* Need to "set" eth1 to "MII mode", so eth0 can enter GMII mode */
+&eth1 {
+	status = "okay";
+
+	ethernet1-port@0 {
+		phy-mode = "internal";
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	switch@0 {
+		/* Marvell 88E6095F */
+		compatible = "marvell,mv88e6085";
+		reg = <0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan1";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan2";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan4";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "lan5";
+			};
+
+			port@5 {
+				reg = <5>;
+				label = "lan6";
+			};
+
+			port@6 {
+				reg = <6>;
+				label = "lan7";
+			};
+
+			port@7 {
+				reg = <7>;
+				label = "lan8";
+			};
+
+			port@8 {
+				reg = <8>;
+				label = "lan0";
+			};
+
+			port@9 {
+				reg = <9>;
+				label = "cpu";
+				phy-mode = "gmii";
+				ethernet = <&eth0port>;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+
+			port@a {
+				reg = <10>;
+				label = "wan0";
+			};
+		};
+
+		mdio {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			switch0phy0@0 {
+				reg = <0>;
+			};
+
+			switch0phy1@1 {
+				reg = <1>;
+			};
+
+			switch0phy2@2 {
+				reg = <2>;
+			};
+
+			switch0phy3@3 {
+				reg = <3>;
+			};
+
+			switch0phy4@4 {
+				reg = <4>;
+			};
+
+			switch0phy5@5 {
+				reg = <5>;
+			};
+
+			switch0phy6@6 {
+				reg = <6>;
+			};
+
+			switch0phy7@7 {
+				reg = <7>;
+			};
+
+			ethernet-phy@8 {
+				/* Marvell 88E1114 */
+				reg = <8>;
+				/* Disable WAN1 LED */
+				marvell,reg-init = <3 16 0xff0f 0x80>;
+			};
+
+			ethernet-phy@a {
+				/* Marvell 88E1114 */
+				reg = <10>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0xa0000>;
+			read-only;
+		};
+
+		partition@a0000 {
+			label = "u-boot-env";
+			reg = <0xa0000 0x20000>;
+		};
+
+		/* Looks like something related to bad block management */
+		partition@c0000 {
+			label = "unknown";
+			reg = <0xc0000 0x40000>;
+			read-only;
+		};
+
+		partition@100000 {
+			compatible = "denx,uimage";
+			label = "firmware1";
+			reg = <0x100000 0x2800000>;
+			openwrt,cmdline-match = "cur_runtime_image_num=1";
+		};
+
+		partition@2900000 {
+			compatible = "denx,uimage";
+			label = "firmware";
+			reg = <0x2900000 0x5540000>;
+			openwrt,cmdline-match = "cur_runtime_image_num=2";
+		};
+
+		partition@7e40000 {
+			label = "nvram";
+			reg = <0x7e40000 0x100000>;
+			read-only;
+		};
+
+		/* There is a JFFS2 filesystem at offset 0x80000 mounted at /etc/ca */
+		partition@7f40000 {
+			label = "CA_DATA";
+			reg = <0x7f40000 0xc0000>;
+			read-only;
+		};
+	};
+};
+
+&pinctrl {
+	pmx_buttons: pmx-buttons {
+		marvell,pins = "mpp17";
+		marvell,function = "gpio";
+	};
+
+	pmx_leds: pmx-leds {
+		marvell,pins = "mpp40", "mpp41", "mpp42", "mpp43", "mpp44", "mpp48";
+		marvell,function = "gpio";
+	};
+};
+
+/*
+ * There is no battery on the board, so the RTC does not keep
+ * time when there is no power, making it useless.
+ */
+&rtc {
+	status = "disabled";
+};
+
+&pciec {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	port@1 {
+		reg = <1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		#trigger-source-cells = <0>;
+
+		hub_port1: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
+
+		hub_port4: port@4 {
+			reg = <4>;
+			#trigger-source-cells = <0>;
+		};
+	};
+};

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -98,6 +98,19 @@ define Device/checkpoint_l-50
 endef
 TARGET_DEVICES += checkpoint_l-50
 
+define Device/cisco_cvr328w
+  DEVICE_VENDOR := Cisco Systems
+  DEVICE_MODEL := CVR328W
+  UIMAGE_NAME := CVR9cybertan_rom_bin
+  UIMAGE_TIME := -1
+  KERNEL_IN_UBI :=
+  UBINIZE_OPTS := -E 5
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-ubi
+  DEVICE_PACKAGES := kmod-ath9k kmod-usb2 wpad-basic-wolfssl
+  SUPPORTED_DEVICES += cvr328w
+endef
+TARGET_DEVICES += cisco_cvr328w
+
 define Device/cisco_on100
   DEVICE_VENDOR := Cisco Systems
   DEVICE_MODEL := ON100

--- a/target/linux/kirkwood/patches-5.10/700-v6.2-net-mv643xx_eth-support-MII-GMII-RGMII-modes-for-.patch
+++ b/target/linux/kirkwood/patches-5.10/700-v6.2-net-mv643xx_eth-support-MII-GMII-RGMII-modes-for-.patch
@@ -1,0 +1,125 @@
+From d08cb25556773c65efb21761b75f92c804ad0975 Mon Sep 17 00:00:00 2001
+From: David Yang <mmyangfl@gmail.com>
+Date: Fri, 28 Oct 2022 10:01:01 +0800
+Subject: net: mv643xx_eth: support MII/GMII/RGMII modes for Kirkwood
+
+Support mode switch properly, which is not available before.
+
+If SoC has two Ethernet controllers, by setting both of them into MII
+mode, the first controller enters GMII mode, while the second
+controller is effectively disabled. This requires configuring (and
+maybe enabling) the second controller in the device tree, even though
+it cannot be used.
+
+Signed-off-by: David Yang <mmyangfl@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/marvell/mv643xx_eth.c | 49 +++++++++++++++++++++++++-----
+ include/linux/mv643xx_eth.h                |  2 ++
+ 2 files changed, 44 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/net/ethernet/marvell/mv643xx_eth.c b/drivers/net/ethernet/marvell/mv643xx_eth.c
+index 707993b445d1e..4389a33a2ea6a 100644
+--- a/drivers/net/ethernet/marvell/mv643xx_eth.c
++++ b/drivers/net/ethernet/marvell/mv643xx_eth.c
+@@ -108,6 +108,7 @@ static char mv643xx_eth_driver_version[] = "1.4";
+ #define TXQ_COMMAND			0x0048
+ #define TXQ_FIX_PRIO_CONF		0x004c
+ #define PORT_SERIAL_CONTROL1		0x004c
++#define  RGMII_EN			0x00000008
+ #define  CLK125_BYPASS_EN		0x00000010
+ #define TX_BW_RATE			0x0050
+ #define TX_BW_MTU			0x0058
+@@ -2761,6 +2762,8 @@ static int mv643xx_eth_shared_of_add_port(struct platform_device *pdev,
+ 	mv643xx_eth_property(pnp, "rx-sram-addr", ppd.rx_sram_addr);
+ 	mv643xx_eth_property(pnp, "rx-sram-size", ppd.rx_sram_size);
+ 
++	of_get_phy_mode(pnp, &ppd.interface);
++
+ 	ppd.phy_node = of_parse_phandle(pnp, "phy-handle", 0);
+ 	if (!ppd.phy_node) {
+ 		ppd.phy_addr = MV643XX_ETH_PHY_NONE;
+@@ -3092,6 +3095,7 @@ static int mv643xx_eth_probe(struct platform_device *pdev)
+ 	struct mv643xx_eth_private *mp;
+ 	struct net_device *dev;
+ 	struct phy_device *phydev = NULL;
++	u32 psc1r;
+ 	int err, irq;
+ 
+ 	pd = dev_get_platdata(&pdev->dev);
+@@ -3119,14 +3123,45 @@ static int mv643xx_eth_probe(struct platform_device *pdev)
+ 
+ 	mp->dev = dev;
+ 
+-	/* Kirkwood resets some registers on gated clocks. Especially
+-	 * CLK125_BYPASS_EN must be cleared but is not available on
+-	 * all other SoCs/System Controllers using this driver.
+-	 */
+ 	if (of_device_is_compatible(pdev->dev.of_node,
+-				    "marvell,kirkwood-eth-port"))
+-		wrlp(mp, PORT_SERIAL_CONTROL1,
+-		     rdlp(mp, PORT_SERIAL_CONTROL1) & ~CLK125_BYPASS_EN);
++				    "marvell,kirkwood-eth-port")) {
++		psc1r = rdlp(mp, PORT_SERIAL_CONTROL1);
++
++		/* Kirkwood resets some registers on gated clocks. Especially
++		 * CLK125_BYPASS_EN must be cleared but is not available on
++		 * all other SoCs/System Controllers using this driver.
++		 */
++		psc1r &= ~CLK125_BYPASS_EN;
++
++		/* On Kirkwood with two Ethernet controllers, if both of them
++		 * have RGMII_EN disabled, the first controller will be in GMII
++		 * mode and the second one is effectively disabled, instead of
++		 * two MII interfaces.
++		 *
++		 * To enable GMII in the first controller, the second one must
++		 * also be configured (and may be enabled) with RGMII_EN
++		 * disabled too, even though it cannot be used at all.
++		 */
++		switch (pd->interface) {
++		/* Use internal to denote second controller being disabled */
++		case PHY_INTERFACE_MODE_INTERNAL:
++		case PHY_INTERFACE_MODE_MII:
++		case PHY_INTERFACE_MODE_GMII:
++			psc1r &= ~RGMII_EN;
++			break;
++		case PHY_INTERFACE_MODE_RGMII:
++		case PHY_INTERFACE_MODE_RGMII_ID:
++		case PHY_INTERFACE_MODE_RGMII_RXID:
++		case PHY_INTERFACE_MODE_RGMII_TXID:
++			psc1r |= RGMII_EN;
++			break;
++		default:
++			/* Unknown; don't touch */
++			break;
++		}
++
++		wrlp(mp, PORT_SERIAL_CONTROL1, psc1r);
++	}
+ 
+ 	/*
+ 	 * Start with a default rate, and if there is a clock, allow
+diff --git a/include/linux/mv643xx_eth.h b/include/linux/mv643xx_eth.h
+index 3682ae75c7aa3..145169be2ed8a 100644
+--- a/include/linux/mv643xx_eth.h
++++ b/include/linux/mv643xx_eth.h
+@@ -8,6 +8,7 @@
+ 
+ #include <linux/mbus.h>
+ #include <linux/if_ether.h>
++#include <linux/phy.h>
+ 
+ #define MV643XX_ETH_SHARED_NAME		"mv643xx_eth"
+ #define MV643XX_ETH_NAME		"mv643xx_eth_port"
+@@ -59,6 +60,7 @@ struct mv643xx_eth_platform_data {
+ 	 */
+ 	int			speed;
+ 	int			duplex;
++	phy_interface_t		interface;
+ 
+ 	/*
+ 	 * How many RX/TX queues to use.
+-- 
+cgit 
+

--- a/target/linux/kirkwood/patches-5.15/700-v6.2-net-mv643xx_eth-support-MII-GMII-RGMII-modes-for-.patch
+++ b/target/linux/kirkwood/patches-5.15/700-v6.2-net-mv643xx_eth-support-MII-GMII-RGMII-modes-for-.patch
@@ -1,0 +1,125 @@
+From d08cb25556773c65efb21761b75f92c804ad0975 Mon Sep 17 00:00:00 2001
+From: David Yang <mmyangfl@gmail.com>
+Date: Fri, 28 Oct 2022 10:01:01 +0800
+Subject: net: mv643xx_eth: support MII/GMII/RGMII modes for Kirkwood
+
+Support mode switch properly, which is not available before.
+
+If SoC has two Ethernet controllers, by setting both of them into MII
+mode, the first controller enters GMII mode, while the second
+controller is effectively disabled. This requires configuring (and
+maybe enabling) the second controller in the device tree, even though
+it cannot be used.
+
+Signed-off-by: David Yang <mmyangfl@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/marvell/mv643xx_eth.c | 49 +++++++++++++++++++++++++-----
+ include/linux/mv643xx_eth.h                |  2 ++
+ 2 files changed, 44 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/net/ethernet/marvell/mv643xx_eth.c b/drivers/net/ethernet/marvell/mv643xx_eth.c
+index 707993b445d1e..4389a33a2ea6a 100644
+--- a/drivers/net/ethernet/marvell/mv643xx_eth.c
++++ b/drivers/net/ethernet/marvell/mv643xx_eth.c
+@@ -108,6 +108,7 @@ static char mv643xx_eth_driver_version[] = "1.4";
+ #define TXQ_COMMAND			0x0048
+ #define TXQ_FIX_PRIO_CONF		0x004c
+ #define PORT_SERIAL_CONTROL1		0x004c
++#define  RGMII_EN			0x00000008
+ #define  CLK125_BYPASS_EN		0x00000010
+ #define TX_BW_RATE			0x0050
+ #define TX_BW_MTU			0x0058
+@@ -2761,6 +2762,8 @@ static int mv643xx_eth_shared_of_add_port(struct platform_device *pdev,
+ 	mv643xx_eth_property(pnp, "rx-sram-addr", ppd.rx_sram_addr);
+ 	mv643xx_eth_property(pnp, "rx-sram-size", ppd.rx_sram_size);
+ 
++	of_get_phy_mode(pnp, &ppd.interface);
++
+ 	ppd.phy_node = of_parse_phandle(pnp, "phy-handle", 0);
+ 	if (!ppd.phy_node) {
+ 		ppd.phy_addr = MV643XX_ETH_PHY_NONE;
+@@ -3092,6 +3095,7 @@ static int mv643xx_eth_probe(struct platform_device *pdev)
+ 	struct mv643xx_eth_private *mp;
+ 	struct net_device *dev;
+ 	struct phy_device *phydev = NULL;
++	u32 psc1r;
+ 	int err, irq;
+ 
+ 	pd = dev_get_platdata(&pdev->dev);
+@@ -3119,14 +3123,45 @@ static int mv643xx_eth_probe(struct platform_device *pdev)
+ 
+ 	mp->dev = dev;
+ 
+-	/* Kirkwood resets some registers on gated clocks. Especially
+-	 * CLK125_BYPASS_EN must be cleared but is not available on
+-	 * all other SoCs/System Controllers using this driver.
+-	 */
+ 	if (of_device_is_compatible(pdev->dev.of_node,
+-				    "marvell,kirkwood-eth-port"))
+-		wrlp(mp, PORT_SERIAL_CONTROL1,
+-		     rdlp(mp, PORT_SERIAL_CONTROL1) & ~CLK125_BYPASS_EN);
++				    "marvell,kirkwood-eth-port")) {
++		psc1r = rdlp(mp, PORT_SERIAL_CONTROL1);
++
++		/* Kirkwood resets some registers on gated clocks. Especially
++		 * CLK125_BYPASS_EN must be cleared but is not available on
++		 * all other SoCs/System Controllers using this driver.
++		 */
++		psc1r &= ~CLK125_BYPASS_EN;
++
++		/* On Kirkwood with two Ethernet controllers, if both of them
++		 * have RGMII_EN disabled, the first controller will be in GMII
++		 * mode and the second one is effectively disabled, instead of
++		 * two MII interfaces.
++		 *
++		 * To enable GMII in the first controller, the second one must
++		 * also be configured (and may be enabled) with RGMII_EN
++		 * disabled too, even though it cannot be used at all.
++		 */
++		switch (pd->interface) {
++		/* Use internal to denote second controller being disabled */
++		case PHY_INTERFACE_MODE_INTERNAL:
++		case PHY_INTERFACE_MODE_MII:
++		case PHY_INTERFACE_MODE_GMII:
++			psc1r &= ~RGMII_EN;
++			break;
++		case PHY_INTERFACE_MODE_RGMII:
++		case PHY_INTERFACE_MODE_RGMII_ID:
++		case PHY_INTERFACE_MODE_RGMII_RXID:
++		case PHY_INTERFACE_MODE_RGMII_TXID:
++			psc1r |= RGMII_EN;
++			break;
++		default:
++			/* Unknown; don't touch */
++			break;
++		}
++
++		wrlp(mp, PORT_SERIAL_CONTROL1, psc1r);
++	}
+ 
+ 	/*
+ 	 * Start with a default rate, and if there is a clock, allow
+diff --git a/include/linux/mv643xx_eth.h b/include/linux/mv643xx_eth.h
+index 3682ae75c7aa3..145169be2ed8a 100644
+--- a/include/linux/mv643xx_eth.h
++++ b/include/linux/mv643xx_eth.h
+@@ -8,6 +8,7 @@
+ 
+ #include <linux/mbus.h>
+ #include <linux/if_ether.h>
++#include <linux/phy.h>
+ 
+ #define MV643XX_ETH_SHARED_NAME		"mv643xx_eth"
+ #define MV643XX_ETH_NAME		"mv643xx_eth_port"
+@@ -59,6 +60,7 @@ struct mv643xx_eth_platform_data {
+ 	 */
+ 	int			speed;
+ 	int			duplex;
++	phy_interface_t		interface;
+ 
+ 	/*
+ 	 * How many RX/TX queues to use.
+-- 
+cgit 
+


### PR DESCRIPTION
This patch adds support for Cisco CVR328W-K9-CN, sold as "2.4GHz Wireless VPN Router".

Specifications:
--------------

* SoC: Marvell 88F6282
* RAM: 256MB DDR3
* Flash: 128MB NAND flash (Hynix H27U1G8F2BTR-BC)
* WiFi 2.4GHz: Atheros AR9280 via Mini-PCIe (card with no label)
* Ethernet: Marvell 88E6095F-LG01 (8 FEs, 2 GbEs with 88E1114-NNC1, 1 uplink)
* LED: Power, Sys, USB, 3G, VPN, NMS, WLAN (via AR9280), 8 LANs (via 88E6095F), 2 WANs/ 1 LAN (via 88E1114)
* Buttons: Reset (GPIO 17)
* UART: Serial console (115200 8n1)
* USB: 2 x USB2

SPECIAL NOTES:
-------------

* At the time of this patch, the boot sequence is affected by the malfunctioned MANGLE_BOOTARGS. Either you should apply the fix for MANGLE_BOOTARGS, or disable it completely, or you will need to adjust the U-Boot environment variable manually, by deleting bootargs_root=root=/dev/mtdblock3 rw using `uboot_setenv` via console or `set` via U-Boot. Alternatively, you can `set bootargs console=ttyS0,115200` manually before U-Boot kernel booting.
* The bootloader blindly sets the creation time to -1 before deciding uImage size. If that check fails, kernel load size will be set to a fixed value (about 2M).

Installation:
------------

You can access the device console via the following methods.

* Go to web interface, navigate to System Management -> Remote Management -> SSH and enable SSH. Please note the SSH server only support
  diffie-hellman-group1-sha1, you won't be able to connect it with an up-to-
  date ssh client.
* Open the shell and use a UART2USB convert to gain TTY access (at JP1, from 1 to 5: VCC, TXD, RXD, NC, GND).

Please back up firmware if you want to go back to the original.

After you can control the device, flash the firmware as usual. Here are some hints for that.

!!! Please read SPECIAL NOTES before using any of the following methods.

Option 1 (via web interface):

  Flash factory.bin via OEM web interface.

Option 2 (via U-Boot):

  tftpboot $(loadaddr) <factory.bin>
  nand erase 0x2900000 $(filesize)
  nand write.e $(loadaddr) 0x2900000 $(filesize)
  # switch to second firmware
  set cur_booted_runtime_image 2
  saveenv
  # boot newly flash OpenWrt directly
  bootm $(loadaddr)

Option 3 (via OEM console):

  cd /tmp
  wget http://<your-computer-host>/<factory.bin>
  dd if=<factory.bin> of=/dev/mtdblock4 bs=64k
  # switch to second firmware
  uboot_setenv cur_booted_runtime_image 2

* Please do check mtdblock part num by /proc/mtd.

To go back to OEM firmware, flash cvr328w_rv315w_<ver>.img just like factory.bin or simply switch the dual boot partition.

Dual boot:
---------

The device supports dual boot. The patch for dual boot support of OpenWrt is still waiting for reviews, currently the patch use the second firmware partition only.

The firmware to boot is controlled by U-Boot env `cur_booted_runtime_image`. If `runtime_image<i>_try_num` reaches 3, bootloader will switch to another partition. If both firmwares fail to boot, bootloader will start a TFTP server waiting for new firmware (this feature is not tested). This process times out after ~30s.

If one firmware boots failed for 2 times, once the OEM firmware in another partition is booted, it will try to overwrite the former firmware with itself.

To switch between firmwares without console, power on the device, wait ~10s, then power it off, repeat these steps for 3 times.

MAC addresses:
-------------

The MAC addresses and other OEM configs are stored in NVRAM partition using U-Boot env format.

Signed-off-by: David Yang <mmyangfl@gmail.com>