### PR TITLE
tools/expat: update to 2.4.9

### DIFF
--- a/tools/expat/Makefile
+++ b/tools/expat/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
 PKG_CPE_ID:=cpe:/a:libexpat:expat
-PKG_VERSION:=2.4.8
+PKG_VERSION:=2.4.9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=a247a7f6bbb21cf2ca81ea4cbb916bfb9717ca523631675f99b3d4a5678dcd16
+PKG_HASH:=7f44d1469b110773a94b0d5abeeeffaef79f8bd6406b07e52394bcf48126437a
 PKG_SOURCE_URL:=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$(PKG_VERSION))
 
 HOST_BUILD_PARALLEL:=1

--- a/tools/expat/Makefile
+++ b/tools/expat/Makefile
@@ -11,8 +11,8 @@ PKG_NAME:=expat
 PKG_CPE_ID:=cpe:/a:libexpat:expat
 PKG_VERSION:=2.4.9
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=7f44d1469b110773a94b0d5abeeeffaef79f8bd6406b07e52394bcf48126437a
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_HASH:=6e8c0728fe5c7cd3f93a6acce43046c5e4736c7b4b68e032e9350daa0efc0354
 PKG_SOURCE_URL:=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$(PKG_VERSION))
 
 HOST_BUILD_PARALLEL:=1


### PR DESCRIPTION
Fixes CVE-2022-40674.

Release Notes:
https://github.com/libexpat/libexpat/blob/R_2_4_9/expat/Changes
