### PR TITLE
ath79: fix LibreRouter-v1 watchdog and poe_pass

### DIFF
--- a/target/linux/ath79/dts/qca9558_librerouter_librerouter-v1.dts
+++ b/target/linux/ath79/dts/qca9558_librerouter_librerouter-v1.dts
@@ -40,6 +40,10 @@
 	keys {
 		compatible = "gpio-keys";
 
+		pinctrl-names = "default";
+		/* GPIO1 (poe_pass) and GPIO2 (watchdog) requires jtag disabled */
+		pinctrl-0 = <&jtag_disable_pins>;
+
 		reset {
 			label = "Reset";
 			linux,code = <KEY_RESTART>;


### PR DESCRIPTION
Signed-off-by: Santiago Piccinini <spiccinini@altermundi.net>

Fixes #10856 

Should be backported to 22.03