### PR TITLE
toolchain/gcc: cleanup options and disable zstd explicitly

### DIFF
--- a/toolchain/binutils/Makefile
+++ b/toolchain/binutils/Makefile
@@ -43,8 +43,12 @@ HOST_CONFIGURE_ARGS = \
 	--host=$(GNU_HOST_NAME) \
 	--target=$(REAL_GNU_TARGET_NAME) \
 	--with-sysroot=$(TOOLCHAIN_DIR) \
+	--with-system-zlib \
+	--without-zstd \
 	--enable-deterministic-archives \
 	--enable-plugins \
+	--enable-lto \
+	--disable-gprofng \
 	--disable-multilib \
 	--disable-werror \
 	--disable-nls \

--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -106,6 +106,8 @@ GCC_CONFIGURE:= \
 			--with-abi=$(call qstrip,$(CONFIG_MIPS64_ABI))) \
 		$(if $(CONFIG_arc),--with-cpu=$(CONFIG_CPU_TYPE)) \
 		$(if $(CONFIG_powerpc64), $(if $(CONFIG_USE_MUSL),--with-abi=elfv2)) \
+		--with-system-zlib=$(STAGING_DIR_HOST) \
+		--without-zstd \
 		--with-gmp=$(STAGING_DIR_HOST) \
 		--with-mpfr=$(STAGING_DIR_HOST) \
 		--with-mpc=$(STAGING_DIR_HOST) \

--- a/toolchain/gcc/final/Makefile
+++ b/toolchain/gcc/final/Makefile
@@ -8,6 +8,7 @@ GCC_CONFIGURE += \
 	--enable-shared \
 	--enable-threads \
 	--with-slibdir=$(TOOLCHAIN_DIR)/lib \
+	--enable-plugins \
 	--enable-lto \
 	--with-libelf=$(STAGING_DIR_HOST)
 

--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -38,8 +38,6 @@ HOST_CONFIGURE_ARGS := \
 	--system-zstd \
 	--generator=Ninja
 
-HOST_LDFLAGS += -Wl,-rpath,$(STAGING_DIR_HOST)/lib
-
 define Host/Compile/Default
 	+$(NINJA) -C $(HOST_BUILD_DIR) $(1)
 endef

--- a/tools/zstd/Makefile
+++ b/tools/zstd/Makefile
@@ -17,9 +17,9 @@ include $(INCLUDE_DIR)/meson.mk
 MESON_HOST_BUILD_DIR:=$(HOST_BUILD_DIR)/build/meson/openwrt-build
 
 HOSTCC:= $(HOSTCC_NOCACHE)
-HOST_LDFLAGS += -Wl,-rpath,$(STAGING_DIR_HOST)/lib
 
 MESON_HOST_ARGS += \
+	-Ddefault_library=static \
 	-Dlegacy_level=7 \
 	-Ddebug_level=0 \
 	-Dbacktrace=false \


### PR DESCRIPTION
Currently, toolchain/gcc picks up host zstd as it seems to be available in every Linux distro by default, even the minimal ones.

This PR as is has been tested to work perfectly fine on Debian 10 and Fedora 37. It has also been tested to completely break on Ubuntu 22.04 and 20.04.

As I can't seem to figure out what's going on with Ubuntu, posting this here.

edit: let's add more detail.

toolchain/gcc + --with-zstd=$(TOPDIR)/staging_dir/host + shared libzstd == rpath linking issue.
toolchain/gcc + --with-zstd=$(TOPDIR)/staging_dir/host + static libzstd == works except with Ubuntu
toolchain/gcc + system libzstd == works

Ubuntu error is that a zstd API call is failing during LTO. Two possibilities I can see.

1: Ubuntu's gcc has some out of tree patch that causes libzstd to be miscompiled and misbehave.
2: zstd source code has some Ubuntu specific workaround that needs to be removed.

I can't think of anything else.

edit2: specifically the error is during decompression, which indicates that either something is compressed wrong or the decompression routine is failing.