### PR TITLE
scripts/download.pl: make the download tool configurable

### DIFF
--- a/config/Config-devel.in
+++ b/config/Config-devel.in
@@ -17,6 +17,20 @@ menuconfig DEVEL
 		  Store built firmware images and filesystem images in this directory.
 		  If not set, uses './bin/$(BOARD)'
 
+	config DOWNLOAD_TOOL_CUSTOM
+		string "Use custom download tool" if DEVEL
+		default ""
+		help
+		  Use and force custom download tool instead of relying on autoselection
+		  between curl if available and wget as a fallback.
+
+		  download.pl supports 3 tools officially aria2c, curl and wget.
+		  If one of the tool is used in this config, download.pl will use the
+		  default args to make use of them.
+
+		  If the provided string is different than aria2c, curl or wget, the command
+		  is used as is and the download url will be appended at the end of such command.
+
 	config DOWNLOAD_FOLDER
 		string "Download folder" if DEVEL
 		default ""

--- a/include/download.mk
+++ b/include/download.mk
@@ -20,6 +20,7 @@ DOWNLOAD_RDEP=$(STAMP_PREPARED) $(HOST_STAMP_PREPARED)
 
 # Export options for download.pl
 export DOWNLOAD_CHECK_CERTIFICATE:=$(CONFIG_DOWNLOAD_CHECK_CERTIFICATE)
+export DOWNLOAD_TOOL_CUSTOM:=$(CONFIG_DOWNLOAD_TOOL_CUSTOM)
 
 define dl_method_git
 $(if $(filter https://github.com/% git://github.com/%,$(1)),github_archive,git)

--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -25,6 +25,8 @@ my @mirrors;
 my $ok;
 
 my $check_certificate = $ENV{DOWNLOAD_CHECK_CERTIFICATE} eq "y";
+my $custom_tool = $ENV{DOWNLOAD_TOOL_CUSTOM};
+my $download_tool;
 
 $url_filename or $url_filename = $filename;
 
@@ -85,16 +87,42 @@ sub tool_present {
 	return $present
 }
 
+sub select_tool {
+	$custom_tool =~ tr/"//d;
+	if ($custom_tool) {
+		return $custom_tool;
+	}
+
+	# Try to use curl if available
+	if (tool_present("curl", "curl")) {
+		return "curl";
+	}
+
+	# No tool found, fallback to wget
+	return "wget";
+}
+
 sub download_cmd {
 	my $url = shift;
 	my $filename = shift;
-	my $additional_mirrors = join(" ", map "$_/$filename", @_);
 
-	my @chArray = ('a'..'z', 'A'..'Z', 0..9);
-	my $rfn = join '', "${filename}_", map{ $chArray[int rand @chArray] } 0..9;
+	if ($download_tool eq "curl") {
+		return (qw(curl -f --connect-timeout 20 --retry 5 --location),
+			$check_certificate ? () : '--insecure',
+			shellwords($ENV{CURL_OPTIONS} || ''),
+			$url);
+	} elsif ($download_tool eq "wget") {
+		return (qw(wget --tries=5 --timeout=20 --output-document=-),
+			$check_certificate ? () : '--no-check-certificate',
+			shellwords($ENV{WGET_OPTIONS} || ''),
+			$url);
+	} elsif ($download_tool eq "aria2c") {
+		my $additional_mirrors = join(" ", map "$_/$filename", @_);
+		my @chArray = ('a'..'z', 'A'..'Z', 0..9);
+		my $rfn = join '', "${filename}_", map{ $chArray[int rand @chArray] } 0..9;
 
-	if (tool_present('aria2c', 'aria2')) {
 		@mirrors=();
+
 		return join(" ", "[ -d $ENV{'TMPDIR'}/aria2c ] || mkdir $ENV{'TMPDIR'}/aria2c;",
 			"touch $ENV{'TMPDIR'}/aria2c/${rfn}_spp;",
 			qw(aria2c --stderr -c -x2 -s10 -j10 -k1M), $url, $additional_mirrors,
@@ -104,16 +132,8 @@ sub download_cmd {
 			"-d $ENV{'TMPDIR'}/aria2c -o $rfn;",
 			"cat $ENV{'TMPDIR'}/aria2c/$rfn;",
 			"rm $ENV{'TMPDIR'}/aria2c/$rfn $ENV{'TMPDIR'}/aria2c/${rfn}_spp");
-	} elsif (tool_present('curl', 'curl')) {
-		return (qw(curl -f --connect-timeout 20 --retry 5 --location),
-			$check_certificate ? () : '--insecure',
-			shellwords($ENV{CURL_OPTIONS} || ''),
-			$url);
 	} else {
-		return (qw(wget --tries=5 --timeout=20 --output-document=-),
-			$check_certificate ? () : '--no-check-certificate',
-			shellwords($ENV{WGET_OPTIONS} || ''),
-			$url);
+		return join(" ", $download_tool, $url);
 	}
 }
 
@@ -325,6 +345,8 @@ if (-f "$target/$filename") {
 		unlink "$target/$filename";
 	};
 }
+
+$download_tool = select_tool();
 
 while (!-f "$target/$filename") {
 	my $mirror = shift @mirrors;


### PR DESCRIPTION
Introduce a new option in the "Advanced configuration options" to
configure a custom download tool.

By declaring a string in "Use custom download tool" an user can force
what command to use to download package. With the string empty the
default tool used is curl, with wget as a fallback if not available.

download.pl supports 3 tools officially aria2c, curl and wget.
If one of the tool is used in this config, download.pl will use the
default args to make use of them.

If the provided string is different than aria2c, curl or wget, the command
is used as is and the download url will be appended at the end of such command.

While at it also tweak the tool selection logic and chose the tool only
once when the script is called and move aria2c specific variables in the
relevant section.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

----

This was requested by an user on IRC as aria2c can't be used for proxy... For some reason he use a distro that doesn't support removing aria2c so nothing is downloaded.

2 example alternative to use this option.
(an user can provide the single program and download.pl will use default args if supported or just take what is passed in this string)

![image](https://user-images.githubusercontent.com/20289090/194056960-c4484b6d-946a-478c-a606-10657d6dea3e.png)
![image](https://user-images.githubusercontent.com/20289090/194057017-78ee1766-0cf7-4baa-a465-2b05403bf49a.png)

