### PR TITLE
ramips: add support for ELECOM WRC-2533GHBK2-T

### DIFF
--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533ghbk-i.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533ghbk-i.dts
@@ -1,206 +1,46 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "mt7621.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "mt7621_elecom_wrc-2533ghbk.dtsi"
 
 / {
 	compatible = "elecom,wrc-2533ghbk-i", "mediatek,mt7621-soc";
 	model = "ELECOM WRC-2533GHBK-I";
-
-	aliases {
-		led-boot = &led_power;
-		led-failsafe = &led_power;
-		led-running = &led_power;
-		led-upgrade = &led_power;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		wps {
-			label = "red:wps";
-			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
-		};
-
-		led_power: power {
-			label = "white:power";
-			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
-		};
-
-		wlan2g {
-			label = "white:wlan2g";
-			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "phy0radio";
-		};
-
-		wlan5g {
-			label = "white:wlan5g";
-			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "phy1radio";
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		auto {
-			label = "auto";
-			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-			linux,code = <BTN_0>;
-			linux,input-type = <EV_SW>;
-		};
-
-		reset {
-			label = "reset";
-			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-
-		wps {
-			label = "wps";
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WPS_BUTTON>;
-		};
-	};
 };
 
-&spi0 {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <40000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x0 0x30000>;
-				read-only;
-			};
-
-			partition@30000 {
-				label = "u-boot-env";
-				reg = <0x30000 0x10000>;
-				read-only;
-			};
-
-			factory: partition@40000 {
-				label = "factory";
-				reg = <0x40000 0x10000>;
-				read-only;
-			};
-
-			partition@50000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x50000 0x9a0000>;
-			};
-
-			partition@9f0000 {
-				label = "TM_1";
-				reg = <0x9f0000 0x200000>;
-				read-only;
-			};
-
-			partition@bf0000 {
-				label = "TM_2";
-				reg = <0xbf0000 0x200000>;
-				read-only;
-			};
-
-			partition@df0000 {
-				label = "manufacture";
-				reg = <0xdf0000 0x180000>;
-				read-only;
-			};
-
-			partition@f70000 {
-				label = "backup";
-				reg = <0xf70000 0x10000>;
-				read-only;
-			};
-
-			partition@f80000 {
-				label = "storage";
-				reg = <0xf80000 0x80000>;
-				read-only;
-			};
-		};
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0x9a0000>;
 	};
-};
 
-&gmac1 {
-	status = "okay";
-	label = "wan";
-	phy-handle = <&ethphy0>;
-};
-
-&mdio {
-	ethphy0: ethernet-phy@0 {
-		reg = <0>;
+	partition@9f0000 {
+		label = "TM_1";
+		reg = <0x9f0000 0x200000>;
+		read-only;
 	};
-};
 
-&switch0 {
-	ports {
-		port@1 {
-			status = "okay";
-			label = "lan4";
-		};
-
-		port@2 {
-			status = "okay";
-			label = "lan3";
-		};
-
-		port@3 {
-			status = "okay";
-			label = "lan2";
-		};
-
-		port@4 {
-			status = "okay";
-			label = "lan1";
-		};
+	partition@bf0000 {
+		label = "TM_2";
+		reg = <0xbf0000 0x200000>;
+		read-only;
 	};
-};
 
-&state_default {
-	gpio {
-		groups = "uart2", "uart3", "jtag", "wdt";
-		function = "gpio";
+	partition@df0000 {
+		label = "manufacture";
+		reg = <0xdf0000 0x180000>;
+		read-only;
 	};
-};
 
-&pcie {
-	status = "okay";
-};
-
-&pcie0 {
-	wifi@0,0 {
-		compatible = "mediatek,mt76";
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
-		ieee80211-freq-limit = <2400000 2500000>;
+	partition@f70000 {
+		label = "backup";
+		reg = <0xf70000 0x10000>;
+		read-only;
 	};
-};
 
-&pcie1 {
-	wifi@0,0 {
-		compatible = "mediatek,mt76";
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
-		ieee80211-freq-limit = <5000000 6000000>;
+	partition@f80000 {
+		label = "storage";
+		reg = <0xf80000 0x80000>;
+		read-only;
 	};
-};
-
-&xhci {
-	status = "disabled";
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533ghbk.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533ghbk.dtsi
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "red:wps";
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WPS;
+		};
+
+		led_power: power {
+			label = "white:power";
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		wlan2g {
+			label = "white:wlan2g";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <1>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g {
+			label = "white:wlan5g";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <2>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		auto {
+			label = "auto";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+};
+
+&mdio {
+	ethphy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533ghbk2-t.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533ghbk2-t.dts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_elecom_wrc-2533ghbk.dtsi"
+
+/ {
+	compatible = "elecom,wrc-2533ghbk2-t", "mediatek,mt7621-soc";
+	model = "ELECOM WRC-2533GHBK2-T";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0x7a0000>;
+	};
+
+	partition@7f0000 {
+		label = "TM_1";
+		reg = <0x7f0000 0x200000>;
+		read-only;
+	};
+
+	partition@9f0000 {
+		label = "TM_2";
+		reg = <0x9f0000 0x400000>;
+		read-only;
+	};
+
+	partition@df0000 {
+		label = "manufacture";
+		reg = <0xdf0000 0x190000>;
+		read-only;
+	};
+
+	partition@f80000 {
+		label = "storage";
+		reg = <0xf80000 0x80000>;
+		read-only;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -789,6 +789,20 @@ define Device/elecom_wrc-1900gst
 endef
 TARGET_DEVICES += elecom_wrc-1900gst
 
+define Device/elecom_wrc-2533ghbk2-t
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  DEVICE_VENDOR := ELECOM
+  DEVICE_MODEL := WRC-2533GHBK2-T
+  IMAGE_SIZE := 7808k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
+	elx-header 0107003b 8844A2D168B45A2D | \
+	elecom-product-header WRC-2533GHBK2-T
+  DEVICE_PACKAGES := kmod-mt7615-firmware
+endef
+TARGET_DEVICES += elecom_wrc-2533ghbk2-t
+
 define Device/elecom_wrc-2533ghbk-i
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -174,6 +174,7 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		;;
+	elecom,wrc-2533ghbk2-t|\
 	elecom,wrc-2533ghbk-i)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)


### PR DESCRIPTION
- separate and update dtsi of WRC-2533GHBK-I and WRC-2533GHBK2-T
- add support for ELECOM WRC-2533GHBK2-T