### PR TITLE
mediatek: mt7622: Fix ubi detection and add support fw_printsys for Xiaomi AX6S

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_mt7622
+++ b/package/boot/uboot-envtools/files/mediatek_mt7622
@@ -43,10 +43,11 @@ ubnt,unifi-6-lr-ubootmod)
 	;;
 xiaomi,redmi-router-ax6s)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x40000"
+	ubootenv_add_uci_sys_config "/dev/mtd4" "0x0" "0x10000" "0x40000"
 	;;
 esac
 
 config_load ubootenv
-config_foreach ubootenv_add_app_config ubootenv
+config_foreach ubootenv_add_app_config
 
 exit 0

--- a/target/linux/mediatek/dts/mt7622-xiaomi-redmi-router-ax6s.dts
+++ b/target/linux/mediatek/dts/mt7622-xiaomi-redmi-router-ax6s.dts
@@ -295,7 +295,6 @@
 			 */
 			partition@2c0000 {
 				label = "kernel";
-				compatible = "denx,fit";
 				reg = <0x2c0000 0x400000>;
 			};
 
@@ -308,7 +307,7 @@
 			 */
 			partition@6c0000 {
 				label = "ubi";
-				reg = <0x6C0000 0x6f00000>;
+				reg = <0x6c0000 0x6f00000>;
 			};
 		};
 	};

--- a/target/linux/mediatek/mt7622/base-files/etc/init.d/bootcount
+++ b/target/linux/mediatek/mt7622/base-files/etc/init.d/bootcount
@@ -7,5 +7,13 @@ boot() {
 	linksys,e8450)
 		mtd erase senv || true
 		;;
+	xiaomi,redmi-router-ax6s)
+		local boot_wait=$( fw_printenv boot_wait | cut -d = -f 2 )
+		[ "$boot_wait" != "on" ] && fw_setenv boot_wait on
+		local bootdelay=$( fw_printenv bootdelay | cut -d = -f 2 )
+		[ "$bootdelay" != "3" ] && fw_setenv bootdelay 3
+		local uart_en=$( fw_printenv uart_en | cut -d = -f 2 )
+		[ "$uart_en" != "1" ] && fw_setenv uart_en 1
+		;;
 	esac
 }


### PR DESCRIPTION
For a full description of the problem with the detection of partition ubi, look here: https://forum.openwrt.org/t/adding-openwrt-support-for-xiaomi-redmi-router-ax6s-xiaomi-router-ax3200/111085/1042

Problem:
If you specify flag "denx,fit" for partition "kernel", then the kernel tries to find rootfs in the same partition during boot. But in fact, the placement of rootfs is precisely determined by the name of another partition - "ubi".
And on some devices (there is another NAND chip), the "Denx search engine" manages to find rootfs at the end of partition "kernel". But in fact it is empty there.

Fix:
You just need to remove the "denx,fit" flag from partition "kernel". After that, the kernel will definitely search for rootfs in partition "ubi".

Another fixes:
1) Add support fw_printsys and fw_setsys.
2) Setting the nvram parameters necessary for recovery via UART.
