### PR TITLE
scripts/download.pl: pass aria2 config in ENV only

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -129,6 +129,7 @@ sub download_cmd {
 			$check_certificate ? () : '--check-certificate=false',
 			"--server-stat-of=$ENV{'TMPDIR'}/aria2c/${rfn}_spp",
 			"--server-stat-if=$ENV{'TMPDIR'}/aria2c/${rfn}_spp",
+			"--daemon=false --no-conf", shellwords($ENV{ARIA2C_OPTIONS} || ''),
 			"-d $ENV{'TMPDIR'}/aria2c -o $rfn;",
 			"cat $ENV{'TMPDIR'}/aria2c/$rfn;",
 			"rm $ENV{'TMPDIR'}/aria2c/$rfn $ENV{'TMPDIR'}/aria2c/${rfn}_spp");


### PR DESCRIPTION
The aria2c command tries to load config from
`${XDG_CONFIG_HOME:-${HOME}/.config}/aria2/aria2.conf` by default, which may result unexpected behavior.

As a replacement, people can use environment variable `ARIA2C_OPTIONS` to custom arguments passed to aria2c like curl and wget below.

Signed-off-by: Zhang Hua <zhanghuadedn@gmail.com>
