### PR TITLE
CI: Add workaround for github uppercase usernames

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -17,10 +17,18 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       target: ${{ steps.find_targets.outputs.target }}
+      owner_lc: ${{ steps.lower_owner.outputs.owner_lc }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set lower case owner name
+        id: lower_owner
+        run: |
+          OWNER_LC=$(echo "${{ github.repository_owner }}" \
+            | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=owner_lc::$OWNER_LC"
 
       - name: Set targets
         id: find_targets
@@ -53,7 +61,7 @@ jobs:
        matrix:
          target: ${{fromJson(needs.determine_targets.outputs.target)}}
 
-    container: ghcr.io/${{ github.repository_owner }}/tools:latest
+    container: ghcr.io/${{ needs.determine_targets.outputs.owner_lc }}/tools:latest
 
     permissions:
       contents: read

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -167,6 +167,12 @@ jobs:
       packages: write
 
     steps:
+      - name: Set lower case owner name
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >> "$GITHUB_ENV"
+
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -190,5 +196,5 @@ jobs:
         with:
           context: openwrt
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/tools:latest
+          tags: ghcr.io/${{ env.OWNER_LC }}/tools:latest
           file: openwrt/.github/workflows/Dockerfile.tools


### PR DESCRIPTION
The workflow defined in .github/workflows/tools.yml used to fail on forked repositories of contributers whose github username contains uppercase letters.

A workaround mentioned in
https://github.com/orgs/community/discussions/27086 is applied.

Signed-off-by: Edward Chow <equu@openmail.cc>
