### PR TITLE
ramips: add support for TP-Link MR600 V2(EU)

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_mr600-v2-eu.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_mr600-v2-eu.dts
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tplink,mr600-v2-eu", "mediatek,mt7621-soc";
+	model = "TP-Link MR600 v2 (EU)";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wlan {
+			label = "wlan";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WLAN>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "white:power";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+		wlan {
+			label = "white:wlan";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+		wan {
+			label = "white:wan";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		signal1 {
+			label = "white:signal1";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		signal2 {
+			label = "white:signal2";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		signal3 {
+			label = "white:signal3";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		4g {
+			label = "white:4g";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+		lan {
+			label = "white:lan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "uboot";
+				reg = <0x00000 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "openwrt,uimage";
+				openwrt,offset = <512>; /* account for the 512-byte long header */
+				label = "firmware";
+				reg = <0x20000 0xfa0000>;
+			};
+
+			romfile: partition@fc0000 {
+				label = "romfile";
+				reg = <0xfc0000 0x10000>;
+				read-only;
+			};
+
+			partition@fd0000 {
+				label = "config";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			radio: partition@fe0000 {
+				label = "radio";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+
+&pcie0 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&macaddr_romfile_f100>;
+		nvmem-cell-names = "mac-address";
+		mediatek,mtd-eeprom = <&radio 0x0>;
+		mtd-mac-address = <&romfile 0xf100>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&macaddr_romfile_f100>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <(-1)>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_romfile_f100>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_romfile_f100>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+	};
+};
+
+&romfile {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_romfile_f100: romfile@f100 {
+		reg = <0xf100 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1868,6 +1868,21 @@ define Device/tplink_eap615-wall-v1
 endef
 TARGET_DEVICES += tplink_eap615-wall-v1
 
+define Device/tplink_mr600-v2-eu
+  $(Device/dsa-migration)
+  $(Device/tplink-v2)
+  DEVICE_MODEL := MR600
+  DEVICE_VARIANT := v2 (EU)
+  TPLINK_FLASHLAYOUT := 16Mltq
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
+		kmod-usb-net-qmi-wwan uqmi kmod-usb3
+  KERNEL := $(KERNEL_DTB) | uImage lzma
+  KERNEL_INITRAMFS := $$(KERNEL) | tplink-v2-header
+  TPLINK_BOARD_ID := MR600-V2-EU
+  IMAGE_SIZE := 16384k
+endef
+TARGET_DEVICES += tplink_mr600-v2-eu
+
 define Device/tplink_re350-v1
   $(Device/dsa-migration)
   $(Device/tplink-safeloader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -147,6 +147,11 @@ tplink,re350-v1)
 	ucidef_set_led_netdev "eth_act" "LAN act" "green:eth_act" "lan" "tx rx"
 	ucidef_set_led_netdev "eth_link" "LAN link" "green:eth_link" "lan" "link"
 	;;
+tplink,mr600-v2-eu)
+	ucidef_set_led_netdev "lan" "LAN" "white:lan" "br-lan"
+	ucidef_set_led_netdev "wan" "WAN" "white:wan" "wan"
+	ucidef_set_led_netdev "4g" "4G" "white:4g" "wwan0"
+	;;
 tplink,re500-v1|\
 tplink,re650-v1|\
 tplink,re650-v2)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -98,6 +98,9 @@ ramips_setup_interfaces()
 	tplink,tl-wpa8631p-v3)
 		ucidef_set_interface_lan "lan1 lan2 lan3 plc0"
 		;;
+	tplink,mr600-v2-eu)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
+		;;
 	ubnt,edgerouter-x)
 		ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4" "eth0"
 		;;
@@ -213,6 +216,11 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii Config lan_hwaddr)
 		wan_mac=$(mtd_get_mac_ascii Config wan_hwaddr)
 		label_mac=$lan_mac
+		;;
+	tplink,mr600-v2-eu)
+		label_mac=$(cat "/sys/class/net/eth0/address")
+		wwan_mac=$(macaddr_add $label_mac 1)
+		ucidef_set_interface "wwan0" device "/dev/cdc-wdm0" protocol "qmi" macaddr "$wwan_mac"
 		;;
 	mikrotik,routerboard-750gr3|\
 	mikrotik,routerboard-760igs|\


### PR DESCRIPTION
MR600 V2(EU) is an LTE router that also supports 4G+ band aggregation etc. and can reportedly achieve higher bandwidth with it.

## Specifications:

* SoC: Mediatek MT7621DAT 880MHz
* RAM: 128MB DDR3
* Flash: 16MB SPI NOR flash (GD25Q128C)
* LTE Modem: Qualcomm MDM9240
* WiFi 5GHz: Mediatek MT7613BEN
* WiFi 2.4GHz: Mediatek MT7603EN
* Ethernet: MT7530, 4x 1000Base-T.
* UART: Serial console (115200 8n1), J1(GND:3)
* Buttons: Reset, WPS.
* LED: Power, WAN, LTE, WiFi 2GHz and 5GHz, LAN, Signal1, Signal2, Signal3

## MAC Addresses:

OEM firmware configuration:
54:af:97:xx:xx:7b : 2.4G
54:af:97:xx:xx:7a : 5G
54:af:97:xx:xx:7c : LTE
54:af:97:xx:xx:7b : LAN (label)
54:af:97:xx:xx:7c : WAN

## Installation:

1. Download the OpenWrt initramfs-image.

Place it into a TFTP server root directory and rename it to openwrt.img
Configure the TFTP server to listen at 192.168.0.5/24.

3. Connect to the serial console.

Attach power and interrupt the boot procedure when prompted (type `tpl`).

Credentials are admin / 1234

4. Configure U-Boot for booting OpenWrt from ram

 $ tftpboot
 $ bootm

5. Transfer the OpenWrt sysupgrade image to the device.

## LTE:

In order to setup the wwan0 interface:
1. Add a `qmi` proto interface under `/etc/config/network`, e.g.:
```
config interface 'wwan0'
        option device '/dev/cdc-wdm0'
        option proto 'qmi'
        option pincode 'XXXX'
        option apn 'your_isp_apn'
```

2. Add `wwan0` interface to the `wan` firewall zone
3. `/etc/init.d/network restart`

Signed-off-by: Linos Giannopoulos <linosgian00@gmail.com>
