### PR TITLE
ipq40xx: convert to DSA and enable Netgear Orbi devices

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -64,6 +64,12 @@ ipq40xx_setup_interfaces()
 	mikrotik,wap-ac)
 		ucidef_set_interface_lan "sw-eth1 sw-eth2"
 		;;
+	netgear,rbr50|\
+	netgear,rbs50|\
+	netgear,srr60|\
+	netgear,srs60)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
+		;;
 	zte,mf286d)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "wan"
 		;;
@@ -142,6 +148,10 @@ ipq40xx_setup_macs()
 		lan_mac=$(cat /sys/firmware/mikrotik/hard_config/mac_base)
 		label_mac="$lan_mac"
 		;;
+	netgear,rbr50|\
+	netgear,rbs50|\
+	netgear,srr60|\
+	netgear,srs60|\
 	pakedge,wr-1)
 		wan_mac=$(macaddr_add $(get_mac_label) 1)
 		;;

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-orbi.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-orbi.dtsi
@@ -11,6 +11,7 @@
 		led-failsafe = &led_status_red;
 		led-running = &led_status_green;
 		led-upgrade = &led_status_blue;
+		label-mac-device = &gmac;
 	};
 
 	soc {
@@ -264,6 +265,42 @@
 
 &cryptobam {
 	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport1 {
+	status = "okay";
+
+	label = "wan";
+};
+
+&swport2 {
+	status = "okay";
+
+	label = "lan1";
+};
+
+&swport3 {
+	status = "okay";
+
+	label = "lan2";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "lan3";
+};
+
+&ethphy4 {
+	status = "disabled";
 };
 
 &pcie0 {

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -815,8 +815,7 @@ define Device/netgear_rbr50
 	DEVICE_VARIANT := v1
 	NETGEAR_BOARD_ID := RBR50
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += netgear_rbr50
+TARGET_DEVICES += netgear_rbr50
 
 define Device/netgear_rbs50
 	$(call Device/netgear_rbx50)
@@ -824,8 +823,7 @@ define Device/netgear_rbs50
 	DEVICE_VARIANT := v1
 	NETGEAR_BOARD_ID := RBS50
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += netgear_rbs50
+TARGET_DEVICES += netgear_rbs50
 
 define Device/netgear_srx60
 	$(call Device/netgear_orbi)
@@ -840,16 +838,14 @@ define Device/netgear_srr60
 	DEVICE_MODEL := SRR60
 	NETGEAR_BOARD_ID := SRR60
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += netgear_srr60
+TARGET_DEVICES += netgear_srr60
 
 define Device/netgear_srs60
 	$(call Device/netgear_srx60)
 	DEVICE_MODEL := SRS60
 	NETGEAR_BOARD_ID := SRS60
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += netgear_srs60
+TARGET_DEVICES += netgear_srs60
 
 define Device/netgear_wac510
 	$(call Device/FitImage)


### PR DESCRIPTION
Convert to DSA and enable again Netgear Orbi devices:
 - RBR50
 - RBS50
 - SRR60
 - SRS60