### PR TITLE
ipq40xx: add support for MikroTik hAP ac3 LTE6 kit

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -71,6 +71,14 @@ mikrotik,hap-ac3)
 	ucidef_set_led_netdev "lan4" "LAN4" "green:lan4" "lan4"
 	ucidef_set_led_gpio "poe" "POE" "red:poe" "452" "0"
 	;;
+mikrotik,hap-ac3-lte6-kit)
+        ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
+        ucidef_set_led_netdev "lan1" "LAN1" "green:lan1" "lan1"
+        ucidef_set_led_netdev "lan2" "LAN2" "green:lan2" "lan2"
+        ucidef_set_led_netdev "lan3" "LAN3" "green:lan3" "lan3"
+        ucidef_set_led_netdev "lan4" "LAN4" "green:lan4" "lan4"
+        ;;
+
 mikrotik,sxtsq-5-ac)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "rssilow" "green:rssilow" "wlan0" "1" "100"

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -19,6 +19,7 @@ ipq40xx_setup_interfaces()
 	linksys,mr8300|\
 	mikrotik,hap-ac2|\
 	mikrotik,hap-ac3|\
+	mikrotik,hap-ac3-lte6-kit|\
 	p2w,r619ac-64m|\
 	p2w,r619ac-128m|\
 	zyxel,nbg6617)
@@ -120,7 +121,8 @@ ipq40xx_setup_macs()
 		;;
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2|\
-	mikrotik,hap-ac3)
+	mikrotik,hap-ac3|\
+	mikrotik,hap-ac3-lte6-kit)
 		wan_mac=$(cat /sys/firmware/mikrotik/hard_config/mac_base)
 		lan_mac=$(macaddr_add $wan_mac 1)
 		label_mac="$wan_mac"

--- a/target/linux/ipq40xx/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ipq40xx/base-files/etc/board.d/03_gpio_switches
@@ -24,6 +24,11 @@ mikrotik,cap-ac)
 mikrotik,hap-ac3)
 	ucidef_add_gpio_switch "poe_passtrough" "PoE Passthrough" "452" "0"
 	;;
+mikrotik,hap-ac3-lte6-kit)
+	ucidef_add_gpio_switch "lte_ant_sw1" "LTE Antenna SW 1" "457" "0"
+	ucidef_add_gpio_switch "lte_ant_sw2" "LTE Antenna SW 2" "458" "0"
+	ucidef_add_gpio_switch "lte_reset" "LTE reset" "461" "0"
+	;;
 sony,ncp-hg100-cellular)
 	ucidef_add_gpio_switch "uart_dbgcon_en" "debug console enable" "427" "1"
 	;;

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -120,6 +120,7 @@ case "$FIRMWARE" in
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2 |\
 	mikrotik,hap-ac3 |\
+	mikrotik,hap-ac3-lte6-kit |\
 	mikrotik,wap-ac)
 		wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"
 		( [ -f "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data" 0x0 0x2f20 ) || \
@@ -216,6 +217,7 @@ case "$FIRMWARE" in
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2 |\
 	mikrotik,hap-ac3 |\
+	mikrotik,hap-ac3-lte6-kit |\
 	mikrotik,sxtsq-5-ac |\
 	mikrotik,wap-ac)
 		wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"
@@ -252,6 +254,7 @@ case "$FIRMWARE" in
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2 |\
 	mikrotik,hap-ac3 |\
+	mikrotik,hap-ac3-lte6-kit |\
 	mikrotik,wap-ac)
 		wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"
 		( [ -f "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data" 0x2f20 0x2f20 ) || \
@@ -264,6 +267,7 @@ case "$FIRMWARE" in
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2 |\
 	mikrotik,hap-ac3 |\
+        mikrotik,hap-ac3-lte6-kit |\
 	mikrotik,sxtsq-5-ac |\
 	mikrotik,wap-ac)
 		wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -173,6 +173,7 @@ platform_do_upgrade() {
 		;;
 	mikrotik,cap-ac|\
 	mikrotik,hap-ac2|\
+	mikrotik,hap-ac3-lte6-kit|\
 	mikrotik,lhgg-60ad|\
 	mikrotik,sxtsq-5-ac|\
 	mikrotik,wap-ac)

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-hap-ac3-lte6-kit.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-hap-ac3-lte6-kit.dts
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2021, Robert Marko <robimarko@gmail.com> */
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "MikroTik hAP ac3 LTE6 kit";
+	compatible = "mikrotik,hap-ac3-lte6-kit";
+
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x10000000>;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	aliases {
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_red;
+	};
+
+	soc {
+		counter@4a1000 {
+			compatible = "qcom,qca-gcnt";
+			reg = <0x4a1000 0x4>;
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			/* select hostmode */
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+			status = "okay";
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status-blue {
+			label = "blue:status";
+			gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: status-red {
+			label = "red:status";
+			gpios = <&tlmm 1 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		led_status_green: status-green {
+			label = "green:status";
+			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&tlmm 23 GPIO_ACTIVE_HIGH>;
+		};
+
+		ethernet {
+			label = "green:ethernet";
+			gpios = <&tlmm 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&tlmm 28 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan1 {
+			label = "green:lan1";
+			gpios = <&tlmm 29 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan2 {
+			label = "green:lan2";
+			gpios = <&tlmm 30 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan3 {
+			label = "green:lan3";
+			gpios = <&tlmm 31 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan4 {
+			label = "green:lan4";
+			gpios = <&tlmm 32 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&tlmm {
+	serial_pins: serial_pinmux {
+		mux {
+			pins = "gpio16", "gpio17";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		pin {
+			function = "blsp_spi0";
+			pins = "gpio13", "gpio14", "gpio15";
+			drive-strength = <12>;
+			bias-disable;
+		};
+
+		pin_cs {
+			function = "gpio";
+			pins = "gpio12";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+
+	enable-usb-power {
+		gpio-hog;
+		gpios = <44 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "enable USB power";
+	};
+
+        enable-mpcie-power {
+                gpio-hog;
+                gpios = <51 GPIO_ACTIVE_HIGH>;
+                output-high;
+                line-name = "enable mPCI-E power";
+        };
+
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&blsp1_spi1 {
+	status = "okay";
+
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	cs-gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>;
+
+	flash@0 {
+		reg = <0>;
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <10000000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+
+		partitions {
+			compatible = "fixed-partitions";
+
+			partition@0 {
+				label = "Qualcomm";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				compatible = "mikrotik,routerboot-partitions";
+				label = "RouterBoot";
+				reg = <0x80000 0x80000>;
+
+				hard_config {
+					size = <0x2000>;
+				};
+
+				dtb_config {
+					read-only;
+				};
+
+				soft_config {
+				};
+			};
+
+			partition@110000 {
+				compatible = "mikrotik,minor";
+				label = "firmware";
+				reg = <0x110000 0xef0000>;
+			};
+		};
+	};
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&blsp1_uart1 {
+	status = "okay";
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport1 {
+	status = "okay";
+	label = "lan4";
+};
+
+&swport2 {
+	status = "okay";
+	label = "lan3";
+};
+
+&swport3 {
+	status = "okay";
+	label = "lan2";
+};
+
+&swport4 {
+	status = "okay";
+	label = "lan1";
+};
+
+&swport5 {
+	status = "okay";
+};
+
+&wifi0 {
+	status = "okay";
+};
+
+&wifi1 {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};

--- a/target/linux/ipq40xx/image/mikrotik.mk
+++ b/target/linux/ipq40xx/image/mikrotik.mk
@@ -47,6 +47,14 @@ define Device/mikrotik_hap-ac3
 endef
 TARGET_DEVICES += mikrotik_hap-ac3
 
+define Device/mikrotik_hap-ac3-lte6-kit
+        $(call Device/mikrotik_nor)
+        DEVICE_MODEL := hAP ac3 LTE6 kit
+        SOC := qcom-ipq4019
+        DEVICE_PACKAGES := kmod-ledtrig-gpio kmod-usb-acm kmod-usb-net-rndis
+endef
+TARGET_DEVICES += mikrotik_hap-ac3-lte6-kit
+
 define Device/mikrotik_lhgg-60ad
 	$(call Device/mikrotik_nor)
 	DEVICE_MODEL := Wireless Wire Dish LHGG-60ad


### PR DESCRIPTION
This adds support for the MikroTik RouterBOARD RBD53GR-5HacD2HnD (hAP ac³ LTE6 kit), an  indoor dual band, dual-radio 802.11ac wireless AP with built-in Mini PCI-E LTE modem, one USB port, five 10/100/1000 Mbps Ethernet ports.

See https://mikrotik.com/product/hap_ac3_lte6_kit for more info.

Specifications:
 - SoC: Qualcomm Atheros IPQ4019
 - RAM: 256 MB
 - Storage: 16 MB NOR
 - Wireless: · Built-in IPQ4019 (SoC) 802.11b/g/n 2x2:2, 3 dBi internal antennae · Built-in IPQ4019 (SoC) 802.11a/n/ac 2x2:2, 5.5 dBi internal antennae
 - Ethernet: Built-in IPQ4019 (SoC, QCA8075) , 5x 1000/100/10 port
 - 1x USB Type A port
 - 1x Mini PCI-E port (supporting USB)
 - 1x Mini PCI-E LTE modem (MikroTik R11e-LTE6, Cat.6)

Installation:

Make sure your unit is runnning RouterOS v6 and RouterBOOT v6 (tested on 6.49.6).

0. Export your MikroTik license key (in case you want to use the device with RouterOS later)
1. Boot the initramfs image via TFTP
2. Upload the "openwrt-ipq40xx-mikrotik-mikrotik_hap-ac3-lte6-kit-squashfs-sysupgrade.bin" via SCP to the /tmp folder
3. Use sysupgrade to flash the image: sysupgrade -n /tmp/openwrt-ipq40xx-mikrotik-mikrotik_hap-ac3-lte6-kit-squashfs-sysupgrade.bin
4. Recovery to factory software is possible via Netinstall: https://help.mikrotik.com/docs/display/ROS/Netinstall

Signed-off-by: Csaba Sipos <metro4@freemail.hu>