### PR TITLE
base-files: config_foreach exit non-zero return

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -155,7 +155,7 @@ config_foreach() {
 	for section in ${CONFIG_SECTIONS}; do
 		config_get cfgtype "$section" TYPE
 		[ -n "$___type" ] && [ "x$cfgtype" != "x$___type" ] && continue
-		eval "$___function \"\$section\" \"\$@\""
+		eval "$___function \"\$section\" \"\$@\"" || break
 	done
 }
 

--- a/package/kernel/mac80211/files/lib/wifi/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/wifi/mac80211.sh
@@ -54,6 +54,8 @@ check_mac80211_device() {
 		config_get phy "$1" phy
 	}
 	[ "$phy" = "$dev" ] && found=1
+
+	return 0
 }
 
 


### PR DESCRIPTION
The config_foreach will exit if the processing function returns with a non-zero value as per the documentation. The mac80211.sh function check_mac80211_device was fixed to not return a non-zero.

Signed-off-by: Anthony Sepa <protectivedad@gmail.com>
