### PR TITLE
improve WWAN options and handling

### DIFF
--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -27,8 +27,8 @@ _proto_mbim_setup() {
 	local tid=2
 	local ret
 
-	local device apn pincode delay allow_roaming allow_partner ip4table ip6table $PROTO_DEFAULT_OPTIONS
-	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner ip4table ip6table $PROTO_DEFAULT_OPTIONS
+	local device apn pincode delay allow_roaming allow_partner ifname want_ifname ip4table ip6table $PROTO_DEFAULT_OPTIONS
+	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner ifname ip4table ip6table $PROTO_DEFAULT_OPTIONS
 
 	[ -n "$ctl_device" ] && device=$ctl_device
 
@@ -45,15 +45,23 @@ _proto_mbim_setup() {
 		return 1
 	}
 
+	want_ifname="$ifname"
+
 	devname="$(basename "$device")"
 	devpath="$(readlink -f /sys/class/usbmisc/$devname/device/)"
-	ifname="$( ls "$devpath"/net )"
+	ifname="$(ls "$devpath"/net)"
 
 	[ -n "$ifname" ] || {
 		echo "mbim[$$]" "Failed to find matching interface"
 		proto_notify_error "$interface" NO_IFNAME
 		proto_set_available "$interface" 0
 		return 1
+	}
+
+	[ -n "$want_ifname" -a "$ifname" != "$want_ifname" ] && {
+		ip l set "$ifname" down
+		ip l set "$ifname" name "$want_ifname" && ifname="$want_ifname"
+		ip l set "$ifname" up
 	}
 
 	[ -n "$apn" ] || {

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -27,8 +27,8 @@ _proto_mbim_setup() {
 	local tid=2
 	local ret
 
-	local device apn pincode delay allow_roaming allow_partner $PROTO_DEFAULT_OPTIONS
-	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner $PROTO_DEFAULT_OPTIONS
+	local device apn pincode delay allow_roaming allow_partner ip4table ip6table $PROTO_DEFAULT_OPTIONS
+	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner ip4table ip6table $PROTO_DEFAULT_OPTIONS
 
 	[ -n "$ctl_device" ] && device=$ctl_device
 
@@ -163,6 +163,7 @@ _proto_mbim_setup() {
 	json_add_string name "${interface}_4"
 	json_add_string ifname "@$interface"
 	json_add_string proto "dhcp"
+	[ -n "$ip4table" ] && json_add_string ip4table "$ip4table"
 	proto_add_dynamic_defaults
 	json_close_object
 	ubus call network add_dynamic "$(json_dump)"
@@ -172,6 +173,7 @@ _proto_mbim_setup() {
 	json_add_string ifname "@$interface"
 	json_add_string proto "dhcpv6"
 	json_add_string extendprefix 1
+	[ -n "$ip6table" ] && json_add_string ip6table "$ip6table"
 	proto_add_dynamic_defaults
 	json_close_object
 	ubus call network add_dynamic "$(json_dump)"

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -202,6 +202,8 @@ proto_qmi_setup() {
 	uqmi -s -d "$device" --wda-set-data-format 802.3 > /dev/null 2>&1
 	dataformat="$(uqmi -s -d "$device" --wda-get-data-format)"
 
+	ip l set "$ifname" down
+
 	if [ "$dataformat" = '"raw-ip"' ]; then
 
 		[ -f /sys/class/net/$ifname/qmi/raw_ip ] || {
@@ -214,6 +216,8 @@ proto_qmi_setup() {
 	fi
 
 	uqmi -s -d "$device" --sync > /dev/null 2>&1
+
+	ip l set "$ifname" up
 
 	uqmi -s -d "$device" --network-register > /dev/null 2>&1
 

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -54,7 +54,7 @@ proto_qmi_setup() {
 
 	[ "$metric" = "" ] && metric="0"
 
-	[ -n "$ctl_device" ] && device=$ctl_device
+	[ -n "$ctl_device" ] && device="$ctl_device"
 
 	[ -n "$device" ] || {
 		echo "No control device specified"
@@ -65,7 +65,7 @@ proto_qmi_setup() {
 
 	[ -n "$delay" ] && sleep "$delay"
 
-	device="$(readlink -f $device)"
+	device="$(readlink -f "$device")"
 	[ -c "$device" ] || {
 		echo "The specified control device does not exist"
 		proto_notify_error "$interface" NO_DEVICE
@@ -92,7 +92,7 @@ proto_qmi_setup() {
 
 	[ -n "$mtu" ] && {
 		echo "Setting MTU to $mtu"
-		/sbin/ip link set dev $ifname mtu $mtu
+		/sbin/ip link set dev "$ifname" mtu "$mtu"
 	}
 
 	proto_qmi_inject_uqmi
@@ -190,8 +190,8 @@ proto_qmi_setup() {
 				echo "Setting PLMN to auto"
 			fi
 		elif [ "$mcc" -ne "${plmn:0:3}" -o "$mnc" -ne "${plmn:3}" ]; then
-			mcc=${plmn:0:3}
-			mnc=${plmn:3}
+			mcc="${plmn:0:3}"
+			mnc="${plmn:3}"
 			echo "Setting PLMN to $plmn"
 		else
 			mcc=""
@@ -224,13 +224,13 @@ proto_qmi_setup() {
 
 	if [ "$dataformat" = '"raw-ip"' ]; then
 
-		[ -f /sys/class/net/$ifname/qmi/raw_ip ] || {
+		[ -f "/sys/class/net/$ifname/qmi/raw_ip" ] || {
 			echo "Device only supports raw-ip mode but is missing this required driver attribute: /sys/class/net/$ifname/qmi/raw_ip"
 			return 1
 		}
 
 		echo "Device does not support 802.3 mode. Informing driver of raw-ip only for $ifname .."
-		echo "Y" > /sys/class/net/$ifname/qmi/raw_ip
+		echo "Y" > "/sys/class/net/$ifname/qmi/raw_ip"
 	fi
 
 	uqmi -s -d "$device" --sync > /dev/null 2>&1
@@ -244,7 +244,7 @@ proto_qmi_setup() {
 	local registration_timeout=0
 	local registration_state=""
 	while true; do
-		registration_state=$(uqmi -s -d "$device" --get-serving-system 2>/dev/null | jsonfilter -e "@.registration" 2>/dev/null)
+		registration_state="$(uqmi -s -d "$device" --get-serving-system 2>/dev/null | jsonfilter -e "@.registration" 2>/dev/null)"
 
 		[ "$registration_state" = "registered" ] && break
 
@@ -480,7 +480,7 @@ proto_qmi_teardown() {
 	local device cid_4 pdh_4 cid_6 pdh_6
 	json_get_vars device
 
-	[ -n "$ctl_device" ] && device=$ctl_device
+	[ -n "$ctl_device" ] && device="$ctl_device"
 
 	echo "Stopping network $interface"
 

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -6,6 +6,14 @@
 	init_proto "$@"
 }
 
+proto_qmi_inject_uqmi() {
+	uqmi() {
+		local t="${TIMEOUT-10}"
+
+		timeout -k "$(( t + 2 ))" "$(( t + 1 ))" /sbin/uqmi -t "$(( t * 1000 ))" "$@"
+	}
+}
+
 proto_qmi_init_config() {
 	available=1
 	no_device=1
@@ -78,6 +86,8 @@ proto_qmi_setup() {
 		echo "Setting MTU to $mtu"
 		/sbin/ip link set dev $ifname mtu $mtu
 	}
+
+	proto_qmi_inject_uqmi
 
 	echo "Waiting for SIM initialization"
 	local uninitialized_timeout=0
@@ -469,6 +479,8 @@ proto_qmi_teardown() {
 	json_load "$(ubus call network.interface.$interface status)"
 	json_select data
 	json_get_vars cid_4 pdh_4 cid_6 pdh_6
+
+	proto_qmi_inject_uqmi
 
 	qmi_wds_stop "$cid_4" "$pdh_4"
 	qmi_wds_stop "$cid_6" "$pdh_6"

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -262,10 +262,10 @@ proto_qmi_setup() {
 		else
 			# registration_state is 'registration_denied' or 'unknown' or ''
 			echo "Network registration failed (reason: '$registration_state')"
+			proto_block_restart "$interface"
 		fi
 
 		proto_notify_error "$interface" NETWORK_REGISTRATION_FAILED
-		proto_block_restart "$interface"
 		return 1
 	done
 

--- a/package/network/utils/wwan/files/data/2c7c-0306
+++ b/package/network/utils/wwan/files/data/2c7c-0306
@@ -1,0 +1,4 @@
+{
+	"desc": "Quectel EP06-E",
+	"type": "qmi",
+}

--- a/package/network/utils/wwan/files/data/2c7c-0800
+++ b/package/network/utils/wwan/files/data/2c7c-0800
@@ -1,0 +1,4 @@
+{
+	"desc": "Quectel RM502Q-AE",
+	"type": "qmi",
+}

--- a/package/network/utils/wwan/files/wwan.sh
+++ b/package/network/utils/wwan/files/wwan.sh
@@ -30,15 +30,16 @@ proto_wwan_init_config() {
 	proto_config_add_string username
 	proto_config_add_string password
 	proto_config_add_string pincode
+	proto_config_add_string pdptype
 	proto_config_add_string delay
 	proto_config_add_string modes
 	proto_config_add_string bus
 }
 
 proto_wwan_setup() {
-	local driver usb devicename desc bus
+	local driver usb devicename desc bus ip4table ip6table pdptype
 
-	json_get_vars bus
+	json_get_vars bus ip4table ip6table pdptype
 
 	if [ -L "/sys/bus/usb/devices/${bus}" ]; then
 		if [ -f "/sys/bus/usb/devices/${bus}/idVendor" ] \
@@ -118,6 +119,9 @@ proto_wwan_setup() {
 	uci_set_state network "$interface" driver "$driver"
 	uci_set_state network "$interface" ctl_device "$ctl_device"
 	uci_set_state network "$interface" dat_device "$dat_device"
+	[ -n "$ip4table" ] && uci_set_state network "$interface" ip4table "$ip4table"
+	[ -n "$ip6table" ] && uci_set_state network "$interface" ip6table "$ip6table"
+	[ -n "$pdptype" ] && uci_set_state network "$interface" pdptype "$pdptype"
 
 	case $driver in
 	qmi_wwan)		proto_qmi_setup $@ ;;

--- a/package/network/utils/wwan/files/wwan.sh
+++ b/package/network/utils/wwan/files/wwan.sh
@@ -37,9 +37,9 @@ proto_wwan_init_config() {
 }
 
 proto_wwan_setup() {
-	local driver usb devicename desc bus ip4table ip6table pdptype
+	local driver usb devicename ifname desc bus ip4table ip6table pdptype
 
-	json_get_vars bus ip4table ip6table pdptype
+	json_get_vars bus ifname ip4table ip6table pdptype
 
 	if [ -L "/sys/bus/usb/devices/${bus}" ]; then
 		if [ -f "/sys/bus/usb/devices/${bus}/idVendor" ] \
@@ -122,6 +122,7 @@ proto_wwan_setup() {
 	[ -n "$ip4table" ] && uci_set_state network "$interface" ip4table "$ip4table"
 	[ -n "$ip6table" ] && uci_set_state network "$interface" ip6table "$ip6table"
 	[ -n "$pdptype" ] && uci_set_state network "$interface" pdptype "$pdptype"
+	[ -n "$ifname" ] && uci_set_state network "$interface" ifname "$ifname"
 
 	case $driver in
 	qmi_wwan)		proto_qmi_setup $@ ;;

--- a/package/network/utils/wwan/files/wwan.usb
+++ b/package/network/utils/wwan/files/wwan.usb
@@ -5,19 +5,44 @@
 . /lib/functions.sh
 . /lib/netifd/netifd-proto.sh
 
-vid=$(cat /sys$DEVPATH/idVendor)
-pid=$(cat /sys$DEVPATH/idProduct)
-[ -f "/lib/network/wwan/$vid:$pid" ] || exit 0
+handle() {
+	local cfg="$1"
+
+	proto_set_available "$cfg" 1
+	ifup "$cfg"
+}
+
+first_unbound_wwan=
 
 find_wwan_iface() {
 	local cfg="$1"
-	local proto
+	local bus= proto
+
 	config_get proto "$cfg" proto
 	[ "$proto" = wwan ] || return 0
-	proto_set_available "$cfg" 1
-	ifup $cfg
+
+	config_get bus "$cfg" bus
+	if [ -z "$bus" ]; then
+		[ -n "$first_unbound_wwan" ] || first_unbound_wwan="$cfg"
+		return 0
+	fi
+
+	[ "$bus" = "$DEVICENAME" ] || return 0
+
+	handle "$cfg"
 	exit 0
 }
 
 config_load network
+
 config_foreach find_wwan_iface interface
+
+# if the device is known to be a modem, try to bring up the first
+# interface that has no bus set
+
+vid=$(cat /sys$DEVPATH/idVendor)
+pid=$(cat /sys$DEVPATH/idProduct)
+[ -f "/lib/network/wwan/$vid:$pid" ] || exit 0
+
+[ -n "$first_unbound_wwan" ] && handle "$first_unbound_wwan"
+exit 0

--- a/package/network/utils/wwan/files/wwan.usbmisc
+++ b/package/network/utils/wwan/files/wwan.usbmisc
@@ -6,23 +6,53 @@
 . /lib/functions.sh
 . /lib/netifd/netifd-proto.sh
 
-find_wwan_iface() {
+handle() {
 	local cfg="$1"
 
-	local proto device
-	config_get proto "$cfg" proto
-	config_get device "$cfg" device
-
-	[ "$proto" = wwan ] || [ "$proto" = mbim ] || [ "$proto" = qmi ] || [ "$proto" = ncm ] || return 0
-	[ -z "$device" -a "$proto" = wwan ] || [ "$device" = "/dev/$DEVNAME" ] || return 0
 	if [ "$ACTION" = add ]; then
 		proto_set_available "$cfg" 1
 	fi
 	if [ "$ACTION" = remove ]; then
 		proto_set_available "$cfg" 0
 	fi
+}
+
+first_unbound_wwan=
+
+find_wwan_iface() {
+	local cfg="$1"
+
+	local bus proto device
+	config_get proto "$cfg" proto
+	config_get device "$cfg" device
+	config_get bus "$cfg" bus
+
+	case "$proto" in
+	mbim|\
+	ncm|\
+	qmi)
+		[ "$device" = "/dev/$DEVNAME" ] || return 0
+		;;
+	wwan)
+		if [ -n "$bus" ]; then
+			[ -n "$first_unbound_wwan" ] || first_unbound_wwan="$cfg"
+			return 0
+		fi
+
+		device="$(readlink -f "/sys$DEVPATH/device")"
+		dev_bus="$(readlink -f "$device/..")"
+		find "/sys/bus/usb/devices/$bus/" -maxdepth 1 | xargs -n 1 readlink -f | grep -q "$dev_bus" || return 0
+		;;
+	*)
+		return 0
+	esac
+
+	handle "$cfg"
 	exit 0
 }
 
 config_load network
 config_foreach find_wwan_iface interface
+
+[ -n "$first_unbound_wwan" ] && handle "$first_unbound_wwan"
+exit 0


### PR DESCRIPTION
This PR adds a few quality-of-life features to the wwan/umbim/uqmi packages.
Most notably, a connection script is added for uqmi.
I could go on changing more and more but this PR is already rather large for my taste.

Message from before:

This is now a small collection of changes I implemented to make the use of the WWAN modems easier.

These are open topics I see as being relevant:

- ~~the `ifname` option is ineffective~~ (implemented)
- ~~`network reload` sometimes doesn't do anything either if the interface is down~~ (that is probably the right thing to do. hardly any options change behaviour leading to `proto_block_restart` are affected, except for plmn - ignoring that for now)
- increase ability to automatically recover from these events:
  - ~~screwing in the antennas a while after the router has booted~~
  - ~~patch of clouds during boot~~
  - ~~a particular SIM card takes a while longer to register~~ (one of mine does)
  - ~~address change (needs testing)~~ (postponed to later PR)
- netifd considers the interface to be up despite:
  - ~~automatic regular disconnect by the provider (needs testing)~~ (postponed to later PR)
  - USB device was detached
  - ~~involuntary modem reset (USB device reappears)~~
- ~~pdptype 'auto' - connect to ipv4/ipv6 as available but require at least one~~ (at least for uqmi, the interface stays up if both are configured and only one is used)

Just imagine having to reboot after plugging in the ethernet cable for a DHCP interface because the network device is locked up (happens with dangling uqmi instances blocking `/dev/cdc-wdm*`).
The error recovery and restart logic *really* need more love.
Often, bringing the interface down and up is enough for the long registration but sometimes it isn't - because uqmi hangs and it's quicker to just always reboot.
This is not a complaint - I just want to provide motivation for the changes.

Original message:

The netifd handler `qmi.sh` sets `raw-ip` and calls `uqmi --sync` both of which fail if the interface is up.

```
Thu Oct  6 08:36:31 2022 daemon.notice netifd: n_fb2 (27090): Device does not support 802.3 mode. Informing driver of raw-ip only for wwan-n_fb2 ..
Thu Oct  6 08:36:31 2022 daemon.notice netifd: n_fb2 (27090): + echo Y
# this is from `echo "Y" > /sys/class/net/$ifname/qmi/raw_ip`:
Thu Oct  6 08:36:31 2022 daemon.notice netifd: n_fb2 (27090): sh: write error: Resource busy
Thu Oct  6 08:36:31 2022 daemon.notice netifd: n_fb2 (27090): + uqmi -s -d /dev/cdc-wdm0 --sync
Thu Oct  6 08:36:31 2022 kern.err kernel: [ 3494.189112] qmi_wwan 1-2:1.4 wwan-n_fb2: Cannot change a running device
```

I'm not sure this is the right way but as it should be an improvement nonetheless..
"works for me"

Open for feedback :-)