### PR TITLE
ipq40xx: ZTE MF289F: convert to DSA

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -33,7 +33,8 @@ ipq40xx_setup_interfaces()
 	glinet,gl-b2200|\
 	luma,wrtq-329acn|\
 	mikrotik,cap-ac|\
-	netgear,wac510)
+	netgear,wac510|\
+	zte,mf289f)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
 	aruba,ap-303|\
@@ -58,11 +59,6 @@ ipq40xx_setup_interfaces()
 		;;
 	zte,mf286d)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "wan"
-		;;
-	zte,mf289f)
-		ucidef_set_interfaces_lan_wan "eth0" "eth1"
-		ucidef_add_switch "switch0" \
-			"0u@eth0" "0u@eth1" "2:lan:1" "5:lan:2"
 		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-mf289f.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-mf289f.dts
@@ -71,10 +71,6 @@
 	};
 
 	soc {
-		ess-psgmii@98000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -99,14 +95,6 @@
 			compatible = "qcom,tcsr";
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
-		};
-
-		ess-switch@c000000 {
-			status = "okay";
-		};
-
-		edma@c080000 {
-			status = "okay";
 		};
 	};
 };
@@ -319,17 +307,31 @@
 	status = "okay";
 };
 
-&gmac0 {
+&gmac {
+	status = "okay";
 	nvmem-cell-names = "mac-address";
 	nvmem-cells = <&macaddr_mac_0>;
 };
 
-&gmac1 {
+&switch {
+	status = "okay";
+};
+
+&swport2 {
+	status = "okay";
+
+	label = "wan";
+
 	nvmem-cell-names = "mac-address";
 	nvmem-cells = <&macaddr_mac_0>;
 	mac-address-increment = <1>;
 };
 
+&swport5 {
+	status = "okay";
+
+	label = "lan";
+};
 
 &qpic_bam {
 	status = "okay";

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -1119,8 +1119,7 @@ define Device/zte_mf289f
 	DEVICE_MODEL := MF289F
 	DEVICE_PACKAGES += ipq-wifi-zte_mf289f ath10k-firmware-qca9984-ct
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += zte_mf289f
+TARGET_DEVICES += zte_mf289f
 
 define Device/zyxel_nbg6617
 	$(call Device/FitImageLzma)


### PR DESCRIPTION
Convert ZTE MF289F device to DSA, re-order network ports to match the labels on the case and re-enable the device.

Signed-off-by: Dirk Buchwalder <buchwalder@posteo.de>

@stich86 @Leo-PL : would you please so kind and test this on your devices as well?