### PR TITLE
ipq40xx: convert GL-AP1300 to DSA

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -53,7 +53,7 @@ engenius,ens620ext)
 	ucidef_set_led_netdev "lan2" "LAN2" "green:lan2" "eth1"
 	;;
 glinet,gl-ap1300)
-	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
+	ucidef_set_led_netdev "wan" "WAN" "white:wan" "wan"
 	;;
 glinet,gl-b1300 |\
 mikrotik,lhgg-60ad)

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -32,6 +32,7 @@ ipq40xx_setup_interfaces()
 	asus,map-ac2200|\
 	cilab,meshpoint-one|\
 	edgecore,ecw5211|\
+	glinet,gl-ap1300|\
 	glinet,gl-b2200|\
 	google,wifi|\
 	linksys,whw03v2|\

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-gl-ap1300.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-gl-ap1300.dts
@@ -14,7 +14,6 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
-		label-mac-device = &gmac0;
 	};
 
 	memory {
@@ -92,13 +91,13 @@
 		compatible = "gpio-leds";
 
 		led_power: power {
-			label = "green:power";
+			label = "white:power";
 			gpios = <&tlmm 2 GPIO_ACTIVE_HIGH>;
 			default-state = "on";
 		};
 
 		wan {
-			label = "green:wan";
+			label = "white:wan";
 			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
 		};
 	};
@@ -180,6 +179,14 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 
+				macaddr_art_0: mac-address@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_art_6: mac-address@6 {
+					reg = <0x6 0x6>;
+				};
+
 				precal_art_1000: precal@1000 {
 					reg = <0x1000 0x2f20>;
 				};
@@ -254,6 +261,30 @@
 
 &usb3_ss_phy {
 	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+	label = "lan";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&swport5 {
+	status = "okay";
+	label = "wan";
+
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -590,8 +590,7 @@ define Device/glinet_gl-ap1300
 	KERNEL_INSTALL := 1
 	DEVICE_PACKAGES := ipq-wifi-glinet_gl-ap1300 kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += glinet_gl-ap1300
+TARGET_DEVICES += glinet_gl-ap1300
 
 define Device/glinet_gl-b1300
 	$(call Device/FitzImage)


### PR DESCRIPTION
Convert GL-AP1300 to DSA and enable it.

Tested-by: Rob White <rob@blue-wave.net>
Signed-off-by: Nick Hainke <vincent@systemli.org>

Thanks to @bluewavenet . Can you maybe test again this latest image? :)