### PR TITLE
uqmi: IPv6 connectivity fixes

### DIFF
--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -192,6 +192,7 @@ proto_qmi_setup() {
 
 	# Cleanup current state if any
 	uqmi -s -d "$device" --stop-network 0xffffffff --autoconnect > /dev/null 2>&1
+	uqmi -s -d "$device" --set-ip-family ipv6 --stop-network 0xffffffff --autoconnect > /dev/null 2>&1
 
 	# Go online
 	uqmi -s -d "$device" --set-device-operating-mode online > /dev/null 2>&1

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -326,7 +326,7 @@ proto_qmi_setup() {
 		fi
 
 		# Check data connection state
-		connstat=$(uqmi -s -d "$device" --set-client-id wds,"$cid_6" --get-data-status)
+		connstat=$(uqmi -s -d "$device" --set-client-id wds,"$cid_6" --set-ip-family ipv6 --get-data-status)
 		[ "$connstat" == '"connected"' ] || {
 			echo "No data link!"
 			uqmi -s -d "$device" --set-client-id wds,"$cid_6" --release-client-id wds > /dev/null 2>&1


### PR DESCRIPTION
Two short fixes which allow IPv6 connectivity to work reliably on Telit LE910C4 and ZTE MF286 series built-in modems, which sometilmes fail to establish IPv6 session if the modem is not the right state, for example wasn't disconnected properly, or the router was rebooted without properly bringing the interface down.

Compile and run-tested at ath79 and ipq40xx: ZTE MF286, ZTE MF286D, TP-Link Archer C7v2.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>