### PR TITLE
ipq40xx: dts: remove leftover nodes after DSA conversion 

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-whw01-v1.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-whw01-v1.dts
@@ -31,19 +31,7 @@
 			};
 		};
 
-		ess-psgmii@98000 {
-			status = "okay";
-		};
-
 		ess_tcsr@1953000 {
-			status = "okay";
-		};
-
-		ess-switch@c000000 {
-			status = "okay";
-		};
-
-		edma@c080000 {
 			status = "okay";
 		};
 	};

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-mf286d.dts
@@ -85,10 +85,6 @@
 			reset-delay-us = <2000>;
 		};
 
-		ess-psgmii@98000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-ncp-hg100-cellular.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-ncp-hg100-cellular.dts
@@ -57,21 +57,7 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		ess-psgmii@98000 {
-			status = "okay";
-		};
-
 		dma@7984000 {
-			status = "okay";
-		};
-
-		ess-switch@c000000 {
-			status = "okay";
-			switch_mac_mode = <0x0>; /* mac mode for RGMII RMII */
-			switch_initvlas = <0x0007c 0x54>; /* PORT0_STATUS */
-		};
-
-		edma@c080000 {
 			status = "okay";
 		};
 	};

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rt-ac42u.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rt-ac42u.dts
@@ -31,10 +31,6 @@
 			status = "okay";
 		};
 
-		ess-psgmii@98000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -83,14 +79,6 @@
 		};
 
 		watchdog@b017000 {
-			status = "okay";
-		};
-
-		ess-switch@c000000 {
-			status = "okay";
-		};
-
-		edma@c080000 {
 			status = "okay";
 		};
 	};

--- a/target/linux/ipq40xx/patches-5.15/900-dts-ipq4019-ap-dk01.1.patch
+++ b/target/linux/ipq40xx/patches-5.15/900-dts-ipq4019-ap-dk01.1.patch
@@ -56,24 +56,12 @@
  		};
  
  		serial@78af000 {
-@@ -109,5 +128,41 @@
+@@ -109,5 +128,29 @@
  		wifi@a800000 {
  			status = "okay";
  		};
 +
 +		mdio@90000 {
-+			status = "okay";
-+		};
-+
-+		ess-switch@c000000 {
-+			status = "okay";
-+		};
-+
-+		ess-psgmii@98000 {
-+			status = "okay";
-+		};
-+
-+		edma@c080000 {
 +			status = "okay";
 +		};
 +


### PR DESCRIPTION
Remove ess-psgmii@98000, edma@c080000 and ess-switch@c000000 nodes.
These nodes are not used after the DSA conversion, but were left over
in a few devices added recently.

ZTE MF289F is omitted on purpose, as for it, these nodes will be removed
together with DSA conversion.

Build tested only, as I only have MF286D from those devices.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>