### PR TITLE
[22.03] ath79: support Ruckus Zoneflex 7372 and 7321

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -125,6 +125,9 @@ plasmacloud,pa300e)
 qihoo,c301)
 	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x10000" "0x10000"
 	;;
+ruckus,zf7372)
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x40000" "0x10000"
+	;;
 sophos,ap55|\
 sophos,ap55c|\
 sophos,ap100|\

--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -125,6 +125,7 @@ plasmacloud,pa300e)
 qihoo,c301)
 	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x10000" "0x10000"
 	;;
+ruckus,zf7321|\
 ruckus,zf7372)
 	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x40000" "0x10000"
 	;;

--- a/target/linux/ath79/dts/ar9342_ruckus_zf7321.dts
+++ b/target/linux/ath79/dts/ar9342_ruckus_zf7321.dts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar934x_ruckus_zf73xx.dtsi"
+
+/ {
+	model = "Ruckus ZoneFlex 7321[-U]";
+	compatible = "ruckus,zf7321", "qca,ar9342";
+
+	leds {
+		air-green {
+			label = "green:air";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		dir-green {
+			label = "green:dir";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		power_red: power-red {
+			label = "red:power";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		wlan2g-green {
+			label = "green:wlan2g";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0assoc";
+		};
+
+		wlan2g-yellow {
+			label = "yellow:wlan2g";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g-green {
+			label = "green:wlan5g";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0assoc";
+		};
+
+		wlan5g-yellow {
+			label = "yellow:wlan5g";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&eth0 {
+	nvmem-cells = <&macaddr_board_data_66>;
+};

--- a/target/linux/ath79/dts/ar9344_ruckus_zf7372.dts
+++ b/target/linux/ath79/dts/ar9344_ruckus_zf7372.dts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar934x_ruckus_zf73xx.dtsi"
+
+/ {
+	model = "Ruckus ZoneFlex 7352/7372[-E/-U]";
+	compatible = "ruckus,zf7372", "qca,ar9344";
+
+	leds {
+		air-green {
+			label = "green:air";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		air-yellow {
+			label = "yellow:air";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		dir-green {
+			label = "green:dir";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		eth1-green {
+			label = "green:eth1";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		power_red: power-red {
+			label = "red:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		wlan2g-green {
+			label = "green:wlan2g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0assoc";
+		};
+
+		wlan2g-yellow {
+			label = "yellow:wlan2g";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g-green {
+			label = "green:wlan5g";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1assoc";
+		};
+
+		wlan5g-yellow {
+			label = "yellow:wlan5g";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	beamforming-2g-spi {
+		compatible = "spi-gpio";
+		mosi-gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		sck-gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <0>;
+
+		beamforming-2g-gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			registers-number = <1>;
+			spi-max-frequency = <24000000>;
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	beamforming-5g-spi {
+		compatible = "spi-gpio";
+		mosi-gpios = <&ath9k 15 GPIO_ACTIVE_HIGH>;
+		sck-gpios = <&ath9k 14 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <0>;
+
+		beamforming-5g-gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			registers-number = <1>;
+			spi-max-frequency = <24000000>;
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+};
+
+&eth0 {
+	nvmem-cells = <&macaddr_board_data_6c>;
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_board_data_66>;
+	nvmem-cell-names = "mac-address";
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <0>;
+		switch-only-mode = <1>;
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,0033";
+		reg = <0x0000 0 0 0 0>;
+		gpio-controller;
+		#gpio-cells = <2>;
+
+		nvmem-cells = <&macaddr_board_data_76>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&board_data {
+	macaddr_board_data_6c: macaddr@6c {
+		reg = <0x6c 0x6>;
+	};
+
+	macaddr_board_data_76: macaddr@76 {
+		reg = <0x76 0x6>;
+	};
+};

--- a/target/linux/ath79/dts/ar934x_ruckus_zf73xx.dtsi
+++ b/target/linux/ath79/dts/ar934x_ruckus_zf73xx.dtsi
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	aliases {
+		led-boot = &power_green;
+		led-failsafe = &power_red;
+		led-running = &power_green;
+		led-upgrade = &power_red;
+	};
+
+	firmware-concat {
+		compatible = "mtd-concat";
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x1f00000>;
+				label = "firmware";
+				compatible = "openwrt,uimage", "denx,uimage";
+			};
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			label = "Reset button";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <50>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&enable_gpio_11>,
+			    <&enable_gpio_16>,
+			    <&enable_gpio_4>,
+			    <&clks_disable_pins>;
+
+		power_green: power-green {
+			label = "green:power";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		ruckus-himem@7ff0000 {
+			/* Ruckus Himem area used to control
+			 * redundant boot image selection
+			 */
+			compatible = "nvmem-rmem";
+			reg = <0x7ff0000 0x10000>;
+			no-map;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			fwconcat0: partition@40000 {
+				label = "fwconcat0";
+				reg = <0x040000 0xf00000>;
+			};
+
+			partition@f40000 {
+				compatible = "u-boot,env";
+				label = "u-boot-env";
+				reg = <0xf40000 0x040000>;
+			};
+
+			board_data: partition@f80000 {
+				label = "board-data";
+				reg = <0xf80000 0x080000>;
+				read-only;
+			};
+
+			fwconcat1: partition@1000000 {
+				label = "fwconcat1";
+				reg = <0x1000000 0x1000000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy: ethernet-phy@6 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <6>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	pll-data = <0x02000000 0x00000101 0x00001313>;
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy>;
+
+	nvmem-cell-names = "mac-address";
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-gmac0 = <1>;
+		rxdv-delay = <3>;
+		rxd-delay = <3>;
+	};
+};
+
+&pinmux {
+	clks_disable_pins: pinmux_clks_disable_pins {
+		pinctrl-single,bits = <0x40 0x0 0x20>;
+	};
+
+	enable_gpio_4: pinctrl_enable_gpio_4 {
+		pinctrl-single,bits = <0x4 0x0 0xff>;
+	};
+
+	enable_gpio_11: pinctrl_enable_gpio_11 {
+		pinctrl-single,bits = <0x8 0x0 0xff000000>;
+	};
+
+	enable_gpio_16: pinctrl_enable_gpio_16 {
+		pinctrl-single,bits = <0x10 0x0 0xff>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_board_data_60>, <&cal_board_data_41000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};
+
+&usb {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&board_data {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_board_data_60: macaddr@60 {
+		reg = <0x60 0x6>;
+	};
+
+	macaddr_board_data_66: macaddr@66 {
+		reg = <0x66 0x6>;
+	};
+
+	cal_board_data_41000: cal@41000 {
+		reg = <0x41000 0x440>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -310,6 +310,9 @@ qca,ap143-16m)
 qihoo,c301)
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
+ruckus,zf7372)
+	ucidef_set_led_switch "lan" "LAN" "green:eth1" "switch0" "0x02"
+	;;
 samsung,wam250)
 	ucidef_set_led_netdev "lan" "LAN" "white:lan" "eth0"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -64,6 +64,7 @@ ath79_setup_interfaces()
 	pisen,ts-d084|\
 	pisen,wmb001n|\
 	pisen,wmm003n|\
+	ruckus,zf7321|\
 	siemens,ws-ap3610|\
 	sophos,ap55|\
 	sophos,ap55c|\
@@ -685,6 +686,7 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_binary factory 0x0)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
 		;;
+	ruckus,zf7321|\
 	ruckus,zf7372)
 		lan_mac=$(mtd_get_mac_binary board-data 0x807E)
 		label_mac=$lan_mac

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -123,6 +123,7 @@ ath79_setup_interfaces()
 	engenius,enstationac-v1|\
 	engenius,ews511ap|\
 	ocedo,ursus|\
+	ruckus,zf7372|\
 	ubnt,unifi-ap-outdoor-plus)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;
@@ -683,6 +684,10 @@ ath79_setup_macs()
 	rosinson,wr818)
 		wan_mac=$(mtd_get_mac_binary factory 0x0)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
+		;;
+	ruckus,zf7372)
+		lan_mac=$(mtd_get_mac_binary board-data 0x807E)
+		label_mac=$lan_mac
 		;;
 	sitecom,wlr-7100|\
 	sitecom,wlr-8100)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2336,6 +2336,22 @@ define Device/rosinson_wr818
 endef
 TARGET_DEVICES += rosinson_wr818
 
+define Device/ruckus_zf73xx_common
+  DEVICE_VENDOR := Ruckus
+  DEVICE_PACKAGES := -swconfig kmod-usb2 kmod-usb-chipidea2
+  IMAGE_SIZE := 31744k
+  LOADER_TYPE := bin
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
+endef
+
+define Device/ruckus_zf7372
+  $(Device/ruckus_zf73xx_common)
+  SOC := ar9344
+  DEVICE_MODEL := ZoneFlex 7352/7372[-E/-U]
+endef
+TARGET_DEVICES += ruckus_zf7372
+
 define Device/samsung_wam250
   SOC := ar9344
   DEVICE_VENDOR := Samsung

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2345,6 +2345,13 @@ define Device/ruckus_zf73xx_common
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
 endef
 
+define Device/ruckus_zf7321
+  $(Device/ruckus_zf73xx_common)
+  SOC := ar9342
+  DEVICE_MODEL := ZoneFlex 7321[-U]
+endef
+TARGET_DEVICES += ruckus_zf7321
+
 define Device/ruckus_zf7372
   $(Device/ruckus_zf73xx_common)
   SOC := ar9344


### PR DESCRIPTION
Since the devices didn't make it in time for 22.03 release, and I care for using them with it, I'd like to backport them.
The support was cherry-picked straight from master - the only (resolved) conflict was found in uboot-envtools configuration.
More details and discussion in #9972 

Compile and run-rested on ath79, Ruckus ZF7372 and ZF7321.