### PR TITLE
ipq40xx: Convert mikrotik,wap-ac to DSA

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -50,11 +50,14 @@ ipq40xx_setup_interfaces()
 	cellc,rtl30vw)
 		ucidef_set_interface_lan "lan1 lan2"
 		;;
+	compex,wpj428)
+		ucidef_set_interface_lan "lan1 lan2"
+		;;
 	glinet,gl-b1300)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
-	compex,wpj428)
-		ucidef_set_interface_lan "lan1 lan2"
+	mikrotik,wap-ac)
+		ucidef_set_interface_lan "sw-eth1 sw-eth2"
 		;;
 	zte,mf286d)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "wan"

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -26,8 +26,8 @@ preinit_set_mac_address() {
 		;;
 	mikrotik,wap-ac)
 		base_mac=$(cat /sys/firmware/mikrotik/hard_config/mac_base)
-		ip link set dev eth0 address "$base_mac"
-		ip link set dev eth1 address $(macaddr_add "$base_mac" 1)
+		ip link set dev sw-eth1 address "$base_mac"
+		ip link set dev sw-eth2 address $(macaddr_add "$base_mac" 1)
 		;;
 	zyxel,nbg6617)
 		base_mac=$(cat /sys/class/net/eth0/address)

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-wap-ac.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-wap-ac.dts
@@ -187,6 +187,24 @@
 	status = "okay";
 };
 
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+	label = "sw-eth2";
+};
+
+&swport5 {
+	status = "okay";
+	label = "sw-eth1";
+};
+
 &wifi0 {
 	status = "okay";
 

--- a/target/linux/ipq40xx/image/mikrotik.mk
+++ b/target/linux/ipq40xx/image/mikrotik.mk
@@ -69,5 +69,4 @@ define Device/mikrotik_wap-ac
 	SOC := qcom-ipq4018
 	DEVICE_PACKAGES := -kmod-ath10k-ct kmod-ath10k-ct-smallbuffers
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += mikrotik_wap-ac
+TARGET_DEVICES += mikrotik_wap-ac


### PR DESCRIPTION
As done previously, this preserves the MAC addresses of they physical Ethernet ports. The interfaces are renamed as `eth0` is in use for the native GMAC; the new interface naming matches the physical port labels.
 - `sw-eth1` corresponds to the physical port labeled ETH1 and has the base MAC address. This port can be used to power the device.
 - `sw-eth2` corresponds to the physical port labeled ETH2 and has a MAC address one greater than the base.

As this device has 2 physical ports, they are each connected to their respective PHYs, allowing the link status to be visible to software. Since they are not marked on the case with any role (such as LAN or WAN), both are bridged to the `lan` network by default, although this can easily be changed if needed.

Signed-off-by: Mark Mentovai \<mark@mentovai.com>