### PR TITLE
ramips: use lzma-loader on JCG Q20

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1133,6 +1133,7 @@ TARGET_DEVICES += jcg_jhr-ac876m
 
 define Device/jcg_q20
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   UBINIZE_OPTS := -E 5


### PR DESCRIPTION
The commit fixes the LZMA uncompression issue on JCG Q20 and has been tested on my device.

Before:
```
Loading from nand0, offset 0x180000
   Image Name:   MIPS OpenWrt Linux-5.10.138
   Image Type:   MIPS Linux Kernel Image (lzma compressed)
   Data Size:    2753060 Bytes = 2.6 MiB
   Load Address: 80001000
   Entry Point:  80001000
Automatic boot of image at addr 0x80010000 ...
## Booting kernel from Legacy Image at 80010000 ...
   Image Name:   MIPS OpenWrt Linux-5.10.138
   Image Type:   MIPS Linux Kernel Image (lzma compressed)
   Data Size:    2753060 Bytes = 2.6 MiB
   Load Address: 80001000
   Entry Point:  80001000
   Verifying Checksum ... OK
   Uncompressing Kernel Image ... lzma compressed: uncompress error 1
Must RESET board to recover
```

After:
```
Loading from nand0, offset 0x180000
   Image Name:   MIPS OpenWrt Linux-5.10.138
   Image Type:   MIPS Linux Kernel Image (uncompressed)
   Data Size:    2735532 Bytes = 2.6 MiB
   Load Address: 80001000
   Entry Point:  80001000
Automatic boot of image at addr 0x80010000 ...
## Booting kernel from Legacy Image at 80010000 ...
   Image Name:   MIPS OpenWrt Linux-5.10.138
   Image Type:   MIPS Linux Kernel Image (uncompressed)
   Data Size:    2735532 Bytes = 2.6 MiB
   Load Address: 80001000
   Entry Point:  80001000
   Verifying Checksum ... OK
   Loading Kernel Image ... OK


OpenWrt kernel loader for MIPS based SoC
Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org>
Decompressing kernel... done!
Starting kernel at 80001000...
```

Signed-off-by: Du Cai <caidu@smail.nju.edu.cn>