### PR TITLE
kernel: kmod-usb-serial-mos7720: support parallel port in MCS7715

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -750,8 +750,9 @@ $(eval $(call KernelPackage,usb-serial-mct))
 
 define KernelPackage/usb-serial-mos7720
   TITLE:=Support for Moschip MOS7720 devices
-  KCONFIG:=CONFIG_USB_SERIAL_MOS7720
+  KCONFIG:=CONFIG_USB_SERIAL_MOS7720 CONFIG_USB_SERIAL_MOS7715_PARPORT=y
   FILES:=$(LINUX_DIR)/drivers/usb/serial/mos7720.ko
+  DEPENDS:=+kmod-ppdev
   AUTOLOAD:=$(call AutoProbe,mos7720)
   $(call AddDepends/usb-serial)
 endef


### PR DESCRIPTION
In-kernel driver for MCS7715 USB-serial bridge has a bool option,
enabling support for parallel port on that chip - which is tied to the
same kernel module. Expose this option in OpenWrt's Kconfig as well, and
make its default follow ALL_KMODS, so it can be left out in case of more
minimal builds, while supporting the parallel port by default in official
builds.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>