### PR TITLE
ath79: fix model name of Extreme Networks WS-AP3805i

### DIFF
--- a/target/linux/ath79/dts/qca9557_extreme-networks_ws-ap3805i.dts
+++ b/target/linux/ath79/dts/qca9557_extreme-networks_ws-ap3805i.dts
@@ -7,7 +7,7 @@
 
 / {
 	compatible = "extreme-networks,ws-ap3805i", "qca,qca9557";
-	model = "Extreme Networks AP3805i";
+	model = "Extreme Networks WS-AP3805i";
 
 	aliases {
 		led-boot = &led_power_green;


### PR DESCRIPTION
Everywhere else the device is referred to as WS-AP3805i, only the model name wrongly only said AP3805i.

Signed-off-by: Tom Herbers <mail@tomherbers.de>

The PR where the device was introduced is #3762.