### PR TITLE
ipq40xx: convert to DSA and enable Sony NCP-HG100/Cellular

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -95,8 +95,8 @@ qxwlan,e2600ac-c2)
 	ucidef_set_led_wlan "wlan5g" "WLAN1" "green:wlan1" "phy1tpt"
 	;;
 sony,ncp-hg100-cellular)
-	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
-	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "lan"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
 	ucidef_set_led_netdev "wwan" "WWAN" "green:wan-4" "wwan0"
 	;;
 zyxel,nbg6617 |\

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -33,7 +33,8 @@ ipq40xx_setup_interfaces()
 	glinet,gl-b2200|\
 	luma,wrtq-329acn|\
 	mikrotik,cap-ac|\
-	netgear,wac510)
+	netgear,wac510|\
+	sony,ncp-hg100-cellular)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
 	aruba,ap-303|\

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-ncp-hg100-cellular.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-ncp-hg100-cellular.dts
@@ -16,7 +16,7 @@
 		led-failsafe = &led_cloud_red;
 		led-running = &led_cloud_green;
 		led-upgrade = &led_cloud_green;
-		label-mac-device = &gmac0;
+		label-mac-device = &gmac;
 	};
 
 	chosen {
@@ -57,21 +57,7 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		ess-psgmii@98000 {
-			status = "okay";
-		};
-
 		dma@7984000 {
-			status = "okay";
-		};
-
-		ess-switch@c000000 {
-			status = "okay";
-			switch_mac_mode = <0x0>; /* mac mode for RGMII RMII */
-			switch_initvlas = <0x0007c 0x54>; /* PORT0_STATUS */
-		};
-
-		edma@c080000 {
 			status = "okay";
 		};
 	};
@@ -614,6 +600,24 @@
 
 &usb3_ss_phy {
 	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+	label = "lan";
+};
+
+&swport5 {
+	status = "okay";
+	label = "wan";
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -1048,8 +1048,7 @@ define Device/sony_ncp-hg100-cellular
 	DEVICE_PACKAGES := e2fsprogs ipq-wifi-sony_ncp-hg100-cellular \
 		kmod-fs-ext4 uqmi
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += sony_ncp-hg100-cellular
+TARGET_DEVICES += sony_ncp-hg100-cellular
 
 define Device/teltonika_rutx10
 	$(call Device/FitImage)


### PR DESCRIPTION
This patch converts networking on Sony NCP-HG100/Cellular to DSA and re-enables support for the device.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
