### PR TITLE
ath79: move reference clock node to SOC dtsi

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -7,6 +7,7 @@ on:
       - 'include/kernel*'
       - 'package/kernel/**'
       - 'target/linux/generic/**'
+      - 'target/linux/ath79/**'
   push:
     paths:
       - '.github/workflows/kernel.yml'
@@ -59,6 +60,7 @@ jobs:
             FIRST=0
           done
           JSON="$JSON"']'
+          JSON='["ath79/generic","ath79/nand","ath79/tiny","ath79/mikrotik"]'
 
            echo -e "\n---- targets ----\n"
            echo "$JSON"
@@ -172,10 +174,12 @@ jobs:
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
         run: |
-          echo CONFIG_ALL_KMODS=y >> .config
           echo CONFIG_DEVEL=y >> .config
           echo CONFIG_AUTOREMOVE=y >> .config
           echo CONFIG_CCACHE=y >> .config
+          echo CONFIG_TARGET_MULTI_PROFILE=y >> .config
+          echo CONFIG_TARGET_ALL_PROFILES=y >> .config
+          echo CONFIG_TARGET_PER_DEVICE_ROOTFS=y >> .config
 
           ./scripts/ext-toolchain.sh \
             --toolchain ${{ env.TOOLCHAIN_FILE }}/toolchain-* \
@@ -202,10 +206,10 @@ jobs:
         working-directory: openwrt
         run: make target/compile -j$(nproc) BUILD_LOG=1 || ret=$? .github/workflows/scripts/show_build_failures.sh
 
-      - name: Build Kernel Kmods
+      - name: Build images to test dts syntax
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
-        run: make package/linux/compile -j$(nproc) BUILD_LOG=1 || ret=$? .github/workflows/scripts/show_build_failures.sh
+        run: make -j$(nproc) BUILD_LOG=1 || ret=$? .github/workflows/scripts/show_build_failures.sh
 
       - name: Upload logs
         if: failure()

--- a/target/linux/ath79/dts/ar7100.dtsi
+++ b/target/linux/ath79/dts/ar7100.dtsi
@@ -21,6 +21,13 @@
 		};
 	};
 
+	extosc: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-output-names = "ref";
+		clock-frequency = <40000000>;
+	};
+
 	ahb {
 		apb {
 			ddr_ctrl: memory-controller@18000000 {
@@ -73,8 +80,8 @@
 				compatible = "qca,ar7100-pll", "syscon";
 				reg = <0x18050000 0x20>;
 
+				clocks = <&extosc>;
 				clock-names = "ref";
-				/* The board must provides the ref clock */
 
 				#clock-cells = <1>;
 				clock-output-names = "cpu", "ddr", "ahb";

--- a/target/linux/ath79/dts/ar7161_aruba_ap-105.dts
+++ b/target/linux/ath79/dts/ar7161_aruba_ap-105.dts
@@ -21,13 +21,6 @@
 		label-mac-device = &eth0;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <40000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
+++ b/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
@@ -12,13 +12,6 @@
 		led-upgrade = &led_diag;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <40000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 
@@ -216,10 +209,6 @@
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &spi {

--- a/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
+++ b/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
@@ -16,13 +16,6 @@
 		led-upgrade = &led_power_orange;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <40000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 
@@ -172,10 +165,6 @@
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &spi {

--- a/target/linux/ath79/dts/ar7161_jjplus_ja76pf2.dts
+++ b/target/linux/ath79/dts/ar7161_jjplus_ja76pf2.dts
@@ -26,13 +26,6 @@
 		led-upgrade = &led_d2;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <40000000>;
-	};
-
 	i2c {
 		compatible = "i2c-gpio";
 		sda-gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;

--- a/target/linux/ath79/dts/ar7161_meraki_mr16.dts
+++ b/target/linux/ath79/dts/ar7161_meraki_mr16.dts
@@ -16,13 +16,6 @@
 		led-upgrade = &led_power_orange;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <40000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 
@@ -98,10 +91,6 @@
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &mdio0 {

--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -16,13 +16,6 @@
 		led-upgrade = &led_power_orange;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <40000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/ar7161_netgear_wndr.dtsi
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr.dtsi
@@ -14,13 +14,6 @@
 		led-upgrade = &led_power_orange;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <40000000>;
-	};
-
 	reset-leds {
 		compatible = "reset-leds";
 

--- a/target/linux/ath79/dts/ar7161_siemens_ws-ap3610.dts
+++ b/target/linux/ath79/dts/ar7161_siemens_ws-ap3610.dts
@@ -17,13 +17,6 @@
 		label-mac-device = &eth0;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <40000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/ar7161_trendnet_tew-673gru.dts
+++ b/target/linux/ath79/dts/ar7161_trendnet_tew-673gru.dts
@@ -16,13 +16,6 @@
 		led-upgrade = &led_wps;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <40000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 
@@ -110,10 +103,6 @@
 		reg = <0x9000 0 0 0 0>;
 		qca,no-eeprom;
 	};
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &spi {

--- a/target/linux/ath79/dts/ar7161_ubnt_routerstation.dtsi
+++ b/target/linux/ath79/dts/ar7161_ubnt_routerstation.dtsi
@@ -14,13 +14,6 @@
 		led-upgrade = &led_rf;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <40000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi.dtsi
@@ -10,12 +10,6 @@
 		label-mac-device = &eth0;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <40000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys";
 
@@ -25,10 +19,6 @@
 			debounce-interval = <60>;
 		};
 	};
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &pcie {

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
@@ -12,12 +12,6 @@
 		led-upgrade = &led_diag;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <40000000>;
-	};
-
 	keys: keys {
 		compatible = "gpio-keys";
 
@@ -134,10 +128,6 @@
 
 	phy-mode = "rgmii";
 	phy-handle = <&phy0>;
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g302h-a1a0.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g302h-a1a0.dts
@@ -15,12 +15,6 @@
 		led-upgrade = &led_diag;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <40000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys";
 
@@ -209,10 +203,6 @@
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar7242_meraki_mr12.dts
+++ b/target/linux/ath79/dts/ar7242_meraki_mr12.dts
@@ -16,13 +16,6 @@
 		led-upgrade = &led_power_orange;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <40000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 
@@ -85,10 +78,6 @@
 		nvmem-cell-names = "mac-address";
 		mac-address-increment = <1>;
 	};
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &mdio0 {

--- a/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
+++ b/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
@@ -21,12 +21,6 @@
 		bootargs = "console=ttyS0,115200n8";
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <40000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys";
 
@@ -93,10 +87,6 @@
 			};
 		};
 	};
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &spi {

--- a/target/linux/ath79/dts/ar724x.dtsi
+++ b/target/linux/ath79/dts/ar724x.dtsi
@@ -24,6 +24,13 @@
 		};
 	};
 
+	extosc: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-output-names = "ref";
+		clock-frequency = <40000000>;
+	};
+
 	ahb: ahb {
 		apb {
 			ddr_ctrl: memory-controller@18000000 {
@@ -89,8 +96,8 @@
 				compatible = "qca,ar7240-pll", "syscon";
 				reg = <0x18050000 0x3c>;
 
+				clocks = <&extosc>;
 				clock-names = "ref";
-				/* The board must provides the ref clock */
 
 				#clock-cells = <1>;
 				clock-output-names = "cpu", "ddr", "ahb";

--- a/target/linux/ath79/dts/ar9132.dtsi
+++ b/target/linux/ath79/dts/ar9132.dtsi
@@ -24,6 +24,13 @@
 		};
 	};
 
+	extosc: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-output-names = "ref";
+		clock-frequency = <40000000>;
+	};
+
 	cpuintc: interrupt-controller {
 		compatible = "qca,ar9132-cpu-intc", "qca,ar7100-cpu-intc";
 
@@ -94,8 +101,8 @@
 						"qca,ar9130-pll", "syscon";
 				reg = <0x18050000 0x20>;
 
+				clocks = <&extosc>;
 				clock-names = "ref";
-				/* The board must provides the ref clock */
 
 				#clock-cells = <1>;
 				clock-output-names = "cpu", "ddr", "ahb";

--- a/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh.dtsi
+++ b/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh.dtsi
@@ -11,12 +11,6 @@
 		led-upgrade = &led_diag;
 	};
 
-	clock40mhz: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <40000000>;
-	};
-
 	/* There is a GPIO driven NXP 74HC153 dual 4-way multiplexer on board
 	 * used for buttons that are on top of the the device.
          */
@@ -248,10 +242,6 @@
 
 &uart {
 	status = "okay";
-};
-
-&pll {
-	clocks = <&clock40mhz>;
 };
 
 &usb {

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wa901nd-v2.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wa901nd-v2.dts
@@ -17,12 +17,6 @@
 		label-mac-device = &eth0;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <40000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys";
 
@@ -60,10 +54,6 @@
 			linux,default-trigger = "phy0tpt";
 		};
 	};
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &spi {

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
@@ -17,12 +17,6 @@
 		label-mac-device = &eth0;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <40000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys";
 
@@ -77,10 +71,6 @@
 		resets = <&rst 8>;
 		reset-names = "switch";
 	};
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &usb {

--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -28,6 +28,12 @@
 		bootargs = "console=ttyATH0,115200";
 	};
 
+	ref: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-output-names = "ref";
+	};
+
 	ahb {
 		apb {
 			ddr_ctrl: memory-controller@18000000 {
@@ -83,7 +89,11 @@
 				compatible = "qca,ar9330-pll";
 				reg = <0x18050000 0x100>;
 
+				clocks = <&ref>;
+				clock-names = "ref";
+
 				#clock-cells = <1>;
+				clock-output-names = "cpu", "ddr", "ahb";
 			};
 
 			wdt: wdt@18060008 {

--- a/target/linux/ath79/dts/ar9331.dtsi
+++ b/target/linux/ath79/dts/ar9331.dtsi
@@ -4,9 +4,4 @@
 
 / {
 	compatible = "qca,ar9331";
-
-	ref: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-	};
 };

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -104,7 +104,9 @@
 
 				#clock-cells = <1>;
 				clock-output-names = "cpu", "ddr", "ahb";
+
 				clocks = <&extosc>;
+				clock-names = "ref";
 			};
 
 			wdt: wdt@18060008 {

--- a/target/linux/ath79/dts/qca9558_netgear_ex7300.dtsi
+++ b/target/linux/ath79/dts/qca9558_netgear_ex7300.dtsi
@@ -120,10 +120,6 @@
 	status = "okay";
 };
 
-&pll {
-	clocks = <&extosc>;
-};
-
 &spi {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9558_ocedo_koala.dts
+++ b/target/linux/ath79/dts/qca9558_ocedo_koala.dts
@@ -59,10 +59,6 @@
 	status = "okay";
 };
 
-&pll {
-	clocks = <&extosc>;
-};
-
 &spi {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9558_ocedo_ursus.dts
+++ b/target/linux/ath79/dts/qca9558_ocedo_ursus.dts
@@ -30,10 +30,6 @@
 	status = "okay";
 };
 
-&pll {
-	clocks = <&extosc>;
-};
-
 &spi {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca955x.dtsi
+++ b/target/linux/ath79/dts/qca955x.dtsi
@@ -119,6 +119,7 @@
 				clock-output-names = "cpu", "ddr", "ahb";
 
 				clocks = <&extosc>;
+				clock-names = "ref";
 			};
 
 			wdt: wdt@18060008 {

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -95,6 +95,7 @@
 				clock-output-names = "cpu", "ddr", "ahb";
 
 				clocks = <&extosc>;
+				clock-names = "ref";
 			};
 
 			wdt: wdt@18060008 {

--- a/target/linux/ath79/dts/qcn5502_netgear_ex7300-v2.dts
+++ b/target/linux/ath79/dts/qcn5502_netgear_ex7300-v2.dts
@@ -124,10 +124,6 @@
 	};
 };
 
-&pll {
-	clocks = <&extosc>;
-};
-
 &spi {
 	status = "okay";
 


### PR DESCRIPTION
AR7100, AR724x, AR9132 and QCA95xx only support fixed frequency external crystal oscillator, so move reference clock node to SOC dtsi files. [datasheet collections](https://github.com/Deoptim/atheros)

From kernel driver code: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/arch/mips/ath79/clock.c?h=linux-5.10.y This commit does not change any default behavior, just a cleanup. It should be safe for ath79 target because we have already done the same thing in QCA95xx.

memo: PR in list that need to apply this change
#9401
#10794
#9593