### PR TITLE
uboot-envtools: ath79: add support for Ubiquiti XM devices

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -66,7 +66,15 @@ openmesh,om5p-an|\
 openmesh,om5p-ac-v1|\
 openmesh,om5p-ac-v2|\
 samsung,wam250|\
+ubnt,airrouter|\
+ubnt,bullet-m-ar7240|\
+ubnt,bullet-m-ar7241|\
+ubnt,nanobridge-m|\
+ubnt,nanostation-loco-m|\
 ubnt,nanostation-m|\
+ubnt,picostation-m|\
+ubnt,powerbridge-m|\
+ubnt,rocket-m|\
 watchguard,ap100|\
 watchguard,ap200|\
 watchguard,ap300|\


### PR DESCRIPTION
Inspired by commit 9565c5726a34da7c9c953d2293b70fdbfef0e0be, and by facts that all Ubiquiti XM devices share flash layout, and images are mostly compatible between all of them - enable uboot-envtools support for whole XM line.

Build tested on: Ubiquiti Airrouter, Bullet-M (7240,7241), Nanobridge-M, Nanostation-M (+ Loco), Picostation-M, Powerbridge-M, Rocket-M. Runtime tested on: Ubiquiti Nanobridge M5 (XM).

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>