### PR TITLE
odhcp6c: respect 'delegate' option for 464XLAT sub-interface

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -105,6 +105,7 @@ proto_dhcpv6_setup() {
 	[ -n "$iface_464xlat" ] && proto_export "IFACE_464XLAT=$iface_464xlat"
 	[ "$delegate" = "0" ] && proto_export "IFACE_DSLITE_DELEGATE=0"
 	[ "$delegate" = "0" ] && proto_export "IFACE_MAP_DELEGATE=0"
+	[ "$delegate" = "0" ] && proto_export "IFACE_464XLAT_DELEGATE=0"
 	[ -n "$zone_dslite" ] && proto_export "ZONE_DSLITE=$zone_dslite"
 	[ -n "$zone_map" ] && proto_export "ZONE_MAP=$zone_map"
 	[ -n "$zone_464xlat" ] && proto_export "ZONE_464XLAT=$zone_464xlat"


### PR DESCRIPTION
dhcpv6.script contained support for disabling prefix delegation of 464XLAT sub-interface, but netifd protocol handler was missing the required export to disable this. Add missing export, akin to DS-Lite and MAP.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>