### PR TITLE
ipq40xx: Fix wrong GPIO for internal status LED on ZTE MF289F

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-mf289f.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-mf289f.dts
@@ -43,7 +43,7 @@
 			label = "blue:power";
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_BLUE>;
-			gpios = <&tlmm 10 GPIO_ACTIVE_LOW>;
+			gpios = <&tlmm 35 GPIO_ACTIVE_LOW>;
 		};
 
 		led-1 {


### PR DESCRIPTION
Fixes https://github.com/openwrt/openwrt/pull/10710 wrong GPIO for internal blue led on the DTS for ZTE MF289F

