### PR TITLE
lantiq: dts: vr9: Add missing properties to the CPU port on the switch

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
@@ -448,7 +448,13 @@
 				port@6 {
 					reg = <0x6>;
 					label = "cpu";
+					phy-mode = "internal";
 					ethernet = <&eth0>;
+
+					fixed-link {
+						speed = <1000>;
+						full-duplex;
+					};
 				};
 			};
 


### PR DESCRIPTION
The CPU port should define the phy-mode and and a PHY phandle or fixed-link to indicate how the CPU port is connected to the SoC's Ethernet controller. On xRX200 this is all internal connection, so use phy-mode = "internal" along with a fixed-link that matches the definition inside &eth0.

No functional changes for now. This is preparation work to get rid of a warning in newer kernel versions (newer than 5.15).

Cc: @sch-m