### PR TITLE
CI: bump actions version to v3 and fixup for labeler v4

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Upload logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.TARGET }}-${{ env.SUBTARGET }}-logs
           path: "openwrt/logs"

--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set lower case owner name
         id: lower_owner
@@ -83,30 +83,30 @@ jobs:
 
     steps:
       - name: Checkout master directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: openwrt
 
       - name: Checkout packages feed
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: openwrt/packages
           path: openwrt/feeds/packages
 
       - name: Checkout luci feed
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: openwrt/luci
           path: openwrt/feeds/luci
 
       - name: Checkout routing feed
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: openwrt/routing
           path: openwrt/feeds/routing
 
       - name: Checkout telephony feed
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: openwrt/telephony
           path: openwrt/feeds/telephony

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,6 +14,6 @@ jobs:
     name: Pull Request Labeler
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4.0.1
+      - uses: actions/labeler@v4
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -84,14 +84,14 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: macos-latest-logs
           path: ${{ env.WORKPATH }}/openwrt/logs
 
       - name: Upload config
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: macos-latest-config
           path: ${{ env.WORKPATH }}/openwrt/.config
@@ -132,14 +132,14 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: linux-buildbot-logs
           path: openwrt/logs
 
       - name: Upload config
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: linux-buildbot-config
           path: openwrt/.config
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload prebuilt tools
         if: github.event_name == 'push'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: linux-buildbot-prebuilt-tools
           path: openwrt/tools.tar
@@ -180,7 +180,7 @@ jobs:
           path: 'openwrt'
 
       - name: Download prebuilt tools from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: linux-buildbot-prebuilt-tools
           path: openwrt

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: openwrt
 
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'openwrt'
 
@@ -175,7 +175,7 @@ jobs:
           echo "OWNER_LC=${OWNER,,}" >> "$GITHUB_ENV"
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'openwrt'
 


### PR DESCRIPTION
Bump actions version to v3 to mute deprecation warning and move labeler to major v4 version.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>