### PR TITLE
mediatek: add support for reyee AX3200-E5

### DIFF
--- a/target/linux/mediatek/dts/mt7622-reyee-ax3200-e5.dts
+++ b/target/linux/mediatek/dts/mt7622-reyee-ax3200-e5.dts
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#include "mt7622.dtsi"
+#include "mt6380.dtsi"
+
+/ {
+	model = "reyee AX3200 E5";
+	compatible = "reyee,ax3200-e5", "mediatek,mt7622";
+
+	aliases {
+		ethernet0 = &gmac0;
+		label-mac-device = &gmac0;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n1";
+		bootargs = "console=ttyS0,115200n1 swiotlb=512";
+	};
+
+	cpus {
+		cpu@0 {
+			proc-supply = <&mt6380_vcpu_reg>;
+			sram-supply = <&mt6380_vm_reg>;
+		};
+
+		cpu@1 {
+			proc-supply = <&mt6380_vcpu_reg>;
+			sram-supply = <&mt6380_vm_reg>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 102 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		mesh_green {
+			label = "green:mesh";
+			gpios = <&pio 79 GPIO_ACTIVE_LOW>;
+		};
+
+		mesh_red {
+			label = "red:mesh";
+			gpios = <&pio 82 GPIO_ACTIVE_LOW>;
+		};
+
+		led_system: system_blue {
+			label = "blue:system";
+			gpios = <&pio 81 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x40000000>;
+	};
+};
+
+&eth {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_pins>;
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-connection-type = "2500base-x";
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		switch@0 {
+			compatible = "mediatek,mt7531";
+			reg = <0>;
+			reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
+			
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			interrupt-parent = <&pio>;
+			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					label = "lan1";
+				};
+
+				port@1 {
+					reg = <1>;
+					label = "lan2";
+				};
+
+				port@2 {
+					reg = <2>;
+					label = "lan3";
+				};
+
+				port@3 {
+					reg = <3>;
+					label = "lan4";
+				};
+
+				wan: port@4 {
+					reg = <4>;
+					label = "wan";
+				};
+
+				port@6 {
+					reg = <6>;
+					label = "cpu";
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+};
+
+&slot0 {
+	mt7915@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x5000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pio {
+	epa_elna_pins: epa-elna-pins {
+		mux {
+			function = "antsel";
+			groups = "antsel0", "antsel1", "antsel2", "antsel3",
+				"antsel4", "antsel5", "antsel6", "antsel7",
+				"antsel8", "antsel9", "antsel12", "antsel13",
+				"antsel14", "antsel15", "antsel16", "antsel17";
+		};
+	};
+
+	eth_pins: eth-pins {
+		mux {
+			function = "eth";
+			groups = "mdc_mdio", "rgmii_via_gmac2";
+		};
+	};
+
+	pcie0_pins: pcie0-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie0_pad_perst",
+				 "pcie0_0_waken",
+				 "pcie0_0_clkreq";
+		};
+	};
+
+	pmic_bus_pins: pmic-bus-pins {
+		mux {
+			function = "pmic";
+			groups = "pmic_bus";
+		};
+	};
+
+	spi_nor_pins: spi-nor-pins {
+		mux {
+			function = "flash";
+			groups = "spi_nor";
+		};
+	};
+
+	uart0_pins: uart0-pins {
+		mux {
+			function = "uart";
+			groups = "uart0_0_tx_rx";
+		};
+	};
+
+	watchdog_pins: watchdog-pins {
+		mux {
+			function = "watchdog";
+			groups = "watchdog";
+		};
+	};
+};
+
+&pwrap {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pmic_bus_pins>;
+};
+
+&nor_flash {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_nor_pins>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Preloader";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "ATF";
+				reg = <0x20000 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot";
+				reg = <0x30000 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "u-boot-env";
+				reg = <0x80000 0x90000>;
+			};
+
+			factory: partition@90000 {
+				label = "Factory";
+				reg = <0x90000 0xd0000>;
+				read-only;
+			};
+
+			partition@d0000 {
+				label = "product_info";
+				reg = <0xd0000 0xe0000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "kdump";
+				reg = <0xe0000 0xf0000>;
+				read-only;
+			};
+
+			partition@f0000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0xf0000 0x1000000>;
+			};
+		};
+	};
+};
+
+&rtc {
+	status = "disabled";
+};
+
+&uart0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+};
+
+&watchdog {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&watchdog_pins>;
+};
+
+&wmac {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&epa_elna_pins>;
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -217,6 +217,15 @@ define Device/ruijie_rg-ew3200gx-pro
 endef
 TARGET_DEVICES += ruijie_rg-ew3200gx-pro
 
+define Device/reyee_ax3200-e5
+  DEVICE_VENDOR := reyee
+  DEVICE_MODEL := AX3200 E5
+  DEVICE_DTS := mt7622-reyee-ax3200-e5
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e
+endef
+TARGET_DEVICES += reyee_ax3200-e5
+
 define Device/totolink_a8000ru
   DEVICE_VENDOR := TOTOLINK
   DEVICE_MODEL := A8000RU

--- a/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
@@ -13,7 +13,8 @@ mediatek_setup_interfaces()
 	linksys,e8450-ubi|\
 	mediatek,mt7622-rfb1|\
 	mediatek,mt7622-rfb1-ubi|\
-	ruijie,rg-ew3200gx-pro)
+	ruijie,rg-ew3200gx-pro|\
+	reyee,ax3200-e5)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" wan
 		;;
 	buffalo,wsr-2533dhp2)
@@ -42,6 +43,9 @@ mediatek_setup_macs()
 
 	case $board in
 	ruijie,rg-ew3200gx-pro)
+		lan_mac=$(macaddr_add $(get_mac_label) 1)
+		;;
+	reyee,ax3200-e5)
 		lan_mac=$(macaddr_add $(get_mac_label) 1)
 		;;
 	xiaomi,redmi-router-ax6s)

--- a/target/linux/mediatek/mt7622/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/mt7622/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -14,4 +14,8 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label) 3 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $(get_mac_label) 2 > /sys${DEVPATH}/macaddress
 		;;
+	reyee,ax3200-e5)
+		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label) 3 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $(get_mac_label) 2 > /sys${DEVPATH}/macaddress
+		;;
 esac


### PR DESCRIPTION
mediatek: add support for reyee AX3200-E5
This is yet another model of the Ruijie RG-EW3200GX PRO with a slightly different flash layout, install process is the same.

Specifications:
- SoC: MT7622B
- RAM: 256MB
- Flash: XMC XM25QH128C or Winbond WQ25Q128JVSQ 16MB SPI NOR
- Ethernet: 5x1GbE
- Switch: MT7531BE
- WiFi: 2.4G: MT7622 5G: MT7915AN+MT7975AN
- 3LEDs: System LED(blue) + Mesh LED(green) + Mesh LED(red)
- 2Keys: Mesh button + Reset button
- UART: Marked J19 on board. 3.3v, 115200n1
- Power: 12V 2.5A

Flash instruction:
1. Serve the initramfs.img using a TFTP server with address 10.10.10.3.
2. Interrupt the uboot startup process via UART.
3. Select "System Load Linux to SDRAM via TFTP" item.
4. (important) Back up firmware(mtd7) partitions with:
        dd if=/dev/mtd7 of=/tmp/firmware.bin
   and then download the firmware.bin image via SCP.
5. Flash the OpenWrt sysupgrade firmware.

Recovery stock firmware:
1. Transfer the firmware.bin image to the device.
2. Flash the image with:
        mtd write firmware.bin firmware