### PR TITLE
realtek: Fix CONFIG_MDIO_SMBUS dependency on RTL83xx

### DIFF
--- a/target/linux/realtek/patches-5.10/310-add-i2c-rtl9300-support.patch
+++ b/target/linux/realtek/patches-5.10/310-add-i2c-rtl9300-support.patch
@@ -17,13 +17,14 @@ Submitted-by: Birger Koblitz <git@birger-koblitz.de>
 
 --- a/drivers/i2c/busses/Kconfig
 +++ b/drivers/i2c/busses/Kconfig
-@@ -954,6 +954,16 @@ config I2C_RK3X
+@@ -954,6 +954,17 @@ config I2C_RK3X
  	  This driver can also be built as a module. If so, the module will
  	  be called i2c-rk3x.
  
 +config I2C_RTL9300
 +	tristate "Realtek RTL9300 I2C adapter"
 +	depends on OF
++	select MDIO_SMBUS
 +	help
 +	  Say Y here to include support for the I2C adapter in Realtek RTL9300
 +	  and RTL9310 SoCs.

--- a/target/linux/realtek/patches-5.10/711-net-phy-add-an-MDIO-SMBus-library.patch
+++ b/target/linux/realtek/patches-5.10/711-net-phy-add-an-MDIO-SMBus-library.patch
@@ -108,16 +108,6 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
 +MODULE_AUTHOR("Antoine Tenart");
 +MODULE_DESCRIPTION("MDIO SMBus bridge library");
 +MODULE_LICENSE("GPL");
---- a/drivers/net/phy/Kconfig
-+++ b/drivers/net/phy/Kconfig
-@@ -60,6 +60,7 @@ config SFP
- 	depends on I2C && PHYLINK
- 	depends on HWMON || HWMON=n
- 	select MDIO_I2C
-+	select MDIO_SMBUS
- 
- comment "Switch configuration API + drivers"
- 
 --- a/include/linux/mdio/mdio-i2c.h
 +++ b/include/linux/mdio/mdio-i2c.h
 @@ -12,5 +12,21 @@ struct i2c_adapter;

--- a/target/linux/realtek/patches-5.10/712-net-phy-sfp-add-support-for-SMBus.patch
+++ b/target/linux/realtek/patches-5.10/712-net-phy-sfp-add-support-for-SMBus.patch
@@ -10,10 +10,11 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -413,32 +413,72 @@ static int sfp_i2c_write(struct sfp *sfp
+@@ -413,32 +413,78 @@ static int sfp_i2c_write(struct sfp *sfp
  	return ret == ARRAY_SIZE(msgs) ? len : 0;
  }
  
++#ifdef CONFIG_MDIO_SMBUS
 +static int sfp_smbus_read(struct sfp *sfp, bool a2, u8 dev_addr, void *buf,
 +			  size_t len)
 +{
@@ -42,6 +43,7 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
 +
 +	return sfp->i2c_mii->write(sfp->i2c_mii, bus_addr, dev_addr, val);
 +}
++#endif
 +
  static int sfp_i2c_configure(struct sfp *sfp, struct i2c_adapter *i2c)
  {
@@ -69,6 +71,7 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
 +
 +		mii->name = "SFP I2C Bus";
 +	} else if (i2c_check_functionality(i2c, I2C_FUNC_SMBUS_BYTE_DATA)) {
++#ifdef CONFIG_MDIO_SMBUS
 +		sfp->read = sfp_smbus_read;
 +		sfp->write = sfp_smbus_write;
 +
@@ -79,6 +82,9 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
 -	i2c_mii->name = "SFP I2C Bus";
 -	i2c_mii->phy_mask = ~0;
 +		mii->name = "SFP SMBus";
++#else
++		return -EINVAL;
++#endif
 +	} else {
 +		return -EINVAL;
 +	}


### PR DESCRIPTION
CONFIG_SFP depends on CONFIG_MDIO_SMBUS now and this depends on CONFIG_I2C_SMBUS.
This created the following warnings on the RTL83xx platforms: WARNING: unmet direct dependencies detected for MDIO_SMBUS
  Depends on [n]: NETDEVICES [=y] && MDIO_DEVICE [=y] && MDIO_BUS [=y] && I2C_SMBUS [=n]
  Selected by [y]:
  - SFP [=y] && NETDEVICES [=y] && PHYLIB [=y] && I2C [=y] && PHYLINK [=y] && (HWMON [=y] || HWMON [=y]=n)

We remove the overall dependency to CONFIG_MDIO_SMBUS from CONFIG_SFP and instead add it to CONFIG_I2C_RTL9300 since only the RTL93xx platforms make use of the SMBus capable I2C controller.

Reported-by: Hauke Mehrtens <hauke@hauke-m.de>
Signed-off-by: Birger Koblitz <git@birger-koblitz.de>