### PR TITLE
realtek: Fix reset register access

### DIFF
--- a/target/linux/realtek/files-5.10/arch/mips/include/asm/mach-rtl838x/mach-rtl83xx.h
+++ b/target/linux/realtek/files-5.10/arch/mips/include/asm/mach-rtl838x/mach-rtl83xx.h
@@ -281,9 +281,13 @@
 #define	RGCR				(0x1E70)
 #define RTL838X_RST_GLB_CTRL_0		(0x003c)
 #define RTL838X_RST_GLB_CTRL_1		(0x0040)
+#define RTL83XX_RST_GLB_CTRL_SW_NIC_RST         BIT(3)
+#define RTL83XX_RST_GLB_CTRL_SW_Q_RST           BIT(2)
 #define RTL839X_RST_GLB_CTRL		(0x0014)
 #define RTL930X_RST_GLB_CTRL_0		(0x000c)
 #define RTL931X_RST_GLB_CTRL		(0x0400)
+#define RTL93XX_RST_GLB_CTRL_SW_NIC_RST         BIT(2)
+#define RTL93XX_RST_GLB_CTRL_SW_Q_RST           BIT(1)
 
 /* LED control by switch */
 #define RTL838X_LED_MODE_SEL		(0x1004)

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -676,13 +676,12 @@ static void rtl838x_hw_reset(struct rtl838x_eth_priv *priv)
 		sw_w32(0xffffffff, priv->r->dma_if_intr_sts);
 	}
 
-	/* Reset NIC (SW_NIC_RST) and queues (SW_Q_RST) */
 	if (priv->family_id == RTL9300_FAMILY_ID || priv->family_id == RTL9310_FAMILY_ID)
-		reset_mask = 0x6;
+		reset_mask = RTL93XX_RST_GLB_CTRL_SW_NIC_RST | RTL93XX_RST_GLB_CTRL_SW_Q_RST;
 	else
-		reset_mask = 0xc;
+		reset_mask = RTL83XX_RST_GLB_CTRL_SW_NIC_RST | RTL83XX_RST_GLB_CTRL_SW_Q_RST;
 
-	sw_w32(reset_mask, priv->r->rst_glb_ctrl);
+	sw_w32_mask(0, reset_mask, priv->r->rst_glb_ctrl);
 
 	do { /* Wait for reset of NIC and Queues done */
 		udelay(20);


### PR DESCRIPTION
The reset register on RTL93xx not merely have bits to execute a reset of a hardware component, but also configuration bits for reset procedures. Keep them during executing a reset.

Signed-off-by: Birger Koblitz <git@birger-koblitz.de>
Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>