### PR TITLE
ipq40xx: convert to DSA and enable mobipromo,cm520-79f

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -80,9 +80,9 @@ mikrotik,sxtsq-5-ac)
 	ucidef_set_led_rssi "rssihigh" "rssihigh" "green:rssihigh" "wlan0" "81" "100"
 	;;
 mobipromo,cm520-79f)
-	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
-	ucidef_set_led_switch "lan1" "LAN1" "blue:lan1" "switch0" "0x10"
-	ucidef_set_led_switch "lan2" "LAN2" "blue:lan2" "switch0" "0x08"
+	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "wan"
+	ucidef_set_led_netdev "lan1" "LAN1" "blue:lan1" "lan1"
+	ucidef_set_led_netdev "lan2" "LAN2" "blue:lan2" "lan2"
 	;;
 netgear,ex6100v2 |\
 netgear,ex6150v2)

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -55,7 +55,8 @@ ipq40xx_setup_interfaces()
 	compex,wpj428)
 		ucidef_set_interface_lan "lan1 lan2"
 		;;
-	glinet,gl-b1300)
+	glinet,gl-b1300|\
+	mobipromo,cm520-79f)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
 	mikrotik,wap-ac)

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-cm520-79f.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-cm520-79f.dts
@@ -342,6 +342,36 @@
 	status = "okay";
 };
 
+&gmac {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_1006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport3 {
+	status = "okay";
+
+	label = "lan2";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "lan1";
+};
+
+&swport5 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_5006>;
+	nvmem-cell-names = "mac-address";
+};
+
 &wifi0 {
 	status = "okay";
 	nvmem-cell-names = "pre-calibration";

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -762,8 +762,7 @@ define Device/mobipromo_cm520-79f
 	PAGESIZE := 2048
 	DEVICE_PACKAGES := kmod-usb-ledtrig-usbport
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += mobipromo_cm520-79f
+TARGET_DEVICES += mobipromo_cm520-79f
 
 define Device/netgear_ex61x0v2
 	$(call Device/DniImage)


### PR DESCRIPTION
Convert to DSA and enable the MobiPromo CM520-79F device again.

Signed-off-by: Jack Chen <redchenjs@live.com>
