### PR TITLE
Fix pcie init error of wlan card in mt7621

### DIFF
--- a/target/linux/ramips/patches-5.10/901-staging-mt7621-pci-delay-for-properly-detect.patch
+++ b/target/linux/ramips/patches-5.10/901-staging-mt7621-pci-delay-for-properly-detect.patch
@@ -1,0 +1,22 @@
+--- a/drivers/staging/mt7621-pci/pci-mt7621.c
++++ b/drivers/staging/mt7621-pci/pci-mt7621.c
+@@ -502,8 +502,9 @@
+ 	int err;
+ 
+ 	rt_sysc_m32(PERST_MODE_MASK, PERST_MODE_GPIO, MT7621_GPIO_MODE);
+-
++	mdelay(250);
+ 	mt7621_pcie_reset_assert(pcie);
++	mdelay(250);
+ 	mt7621_pcie_reset_rc_deassert(pcie);
+ 
+ 	list_for_each_entry_safe(port, tmp, &pcie->ports, list) {
+@@ -520,7 +521,7 @@
+ 			list_del(&port->list);
+ 		}
+ 	}
+-
++	mdelay(250);
+ 	mt7621_pcie_reset_ep_deassert(pcie);
+ 
+ 	tmp = NULL;


### PR DESCRIPTION
As the solution was resolved in issue
https://github.com/openwrt/openwrt/issues/9374


Signed-off-by: Bartixxx32 <mcbplay1@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
