### PR TITLE
ramips: mt7621 Fix issue with pci not init after reboot 

### DIFF
--- a/target/linux/ramips/patches-5.10/901-staging-mt7621-pci-delay-for-properly-detect.patch
+++ b/target/linux/ramips/patches-5.10/901-staging-mt7621-pci-delay-for-properly-detect.patch
@@ -1,0 +1,22 @@
+--- a/drivers/staging/mt7621-pci/pci-mt7621.c
++++ b/drivers/staging/mt7621-pci/pci-mt7621.c
+@@ -502,8 +502,9 @@
+ 	int err;
+ 
+ 	rt_sysc_m32(PERST_MODE_MASK, PERST_MODE_GPIO, MT7621_GPIO_MODE);
+-
++	mdelay(250);
+ 	mt7621_pcie_reset_assert(pcie);
++	mdelay(250);
+ 	mt7621_pcie_reset_rc_deassert(pcie);
+ 
+ 	list_for_each_entry_safe(port, tmp, &pcie->ports, list) {
+@@ -520,7 +521,7 @@
+ 			list_del(&port->list);
+ 		}
+ 	}
+-
++	mdelay(250);
+ 	mt7621_pcie_reset_ep_deassert(pcie);
+ 
+ 	tmp = NULL;


### PR DESCRIPTION
As the issue was resolved in
https://github.com/openwrt/openwrt/issues/9374
Merge request based on patch found by: @wifiseguro in  https://github.com/openwrt/openwrt/issues/9374#issuecomment-1244150080

Before the patch the router for example Netgear R6220 had problems to detect and start 2.4Ghz Radio without turning it off for couple of minutes to hardreset all electronics. Patch adds delay between pci initialization which is fixing issue with one of card

Signed-off-by: Bartixxx32 <mcbplay1@gmail.com> 
