### PR TITLE
ath79: fix reference clock for RouterBoard 912UAG

### DIFF
--- a/target/linux/ath79/dts/ar9342_mikrotik_routerboard-912uag-2hpnd.dts
+++ b/target/linux/ath79/dts/ar9342_mikrotik_routerboard-912uag-2hpnd.dts
@@ -147,7 +147,7 @@
 };
 
 &ref {
-	clock-frequency = <25000000>;
+	clock-frequency = <40000000>;
 };
 
 &spi {


### PR DESCRIPTION
This fixes reference clock frequency of RB912. 25 MHz frequency leads to system clock running too fast, uptime incrementing too fast and delays (like `sleep 10`) returning too early.

Closes #10949

Signed-off-by: Pavel Kamaev <pavel@kamaev.me>
