### PR TITLE
ramips: fix WAN mac address allocation for Unielec 01 and 06 models

### DIFF
--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
@@ -53,9 +53,8 @@
 };
 
 &gmac1 {
-	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &factory {
@@ -65,5 +64,9 @@
 
 	macaddr_factory_e000: macaddr@e000 {
 		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-06-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-06-16m.dts
@@ -58,9 +58,8 @@
 };
 
 &gmac1 {
-	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &factory {
@@ -70,5 +69,9 @@
 
 	macaddr_factory_e000: macaddr@e000 {
 		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-06-64m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-06-64m.dts
@@ -59,9 +59,8 @@
 };
 
 &gmac1 {
-	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &factory {
@@ -71,5 +70,9 @@
 
 	macaddr_factory_e000: macaddr@e000 {
 		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
 	};
 };


### PR DESCRIPTION
Manufacturer has predetermined mac address values for lan and wan ports.

This change keeps inline with other mt7621 devices mac address allocation from factory mtd partition.

Example from hexdump output:

```
0xe000 0x6 (lan) -           0xe006 0x6 (wan)

0000e000  70 b3 d5 10 02 96 70 b3  d5 10 02 95 ff ff ff ff
```

Previous change had created an overlapping mac address situation as it would increment by one based on the lan mac address location found in the factory partition, which would sometimes increment to the same as the mt7603 wifi chip.

Tested on Unielec u7621-01 model

Signed-off-by: David Bentham <db260179@gmail.com>