### PR TITLE
added missing CPE IDs to four package Makefiles

### DIFF
--- a/package/boot/arm-trusted-firmware-sunxi/Makefile
+++ b/package/boot/arm-trusted-firmware-sunxi/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=arm-trusted-firmware-sunxi
+PKG_CPE_ID:=cpe:/o:arm:arm_trusted_firmware
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git

--- a/package/libs/libnftnl/Makefile
+++ b/package/libs/libnftnl/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnftnl
+PKG_CPE_ID:=cpe:/a:netfilter:libnftnl
 PKG_VERSION:=1.2.3
 PKG_RELEASE:=$(AUTORELEASE)
 

--- a/package/libs/ncurses/Makefile
+++ b/package/libs/ncurses/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ncurses
+PKG_CPE_ID:=cpe:/a:gnu:ncurses
 PKG_VERSION:=6.3
 PKG_RELEASE:=$(AUTORELEASE)
 

--- a/package/network/utils/wireless-tools/Makefile
+++ b/package/network/utils/wireless-tools/Makefile
@@ -8,6 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wireless-tools
+PKG_CPE_ID:=cpe:/a:wireless_tools_project:wireless_tools
 PKG_VERSION:=29
 PKG_MINOR:=
 PKG_RELEASE:=6


### PR DESCRIPTION
We've compared all packages in the main tree against the current NIST dictionary and found only these four with a known CPE ID which was still missing.
