### PR TITLE
ramips: rt3883: enable lzma-loader for Belkin F9K1109v1

### DIFF
--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -18,6 +18,7 @@ endef
 TARGET_DEVICES += asus_rt-n56u
 
 define Device/belkin_f9k1109v1
+  $(Device/uimage-lzma-loader)
   SOC := rt3883
   BLOCKSIZE := 64k
   DEVICE_VENDOR := Belkin
@@ -25,7 +26,6 @@ define Device/belkin_f9k1109v1
   DEVICE_VARIANT := Version 1.0
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport
   IMAGE_SIZE := 7808k
-  KERNEL := kernel-bin | append-dtb | lzma -d16 | uImage lzma
   # Stock firmware checks for this uImage image name during upload.
   UIMAGE_NAME := N750F9K1103VB
 endef


### PR DESCRIPTION
This fix booting problem from wiki https://openwrt.org/toh/belkin/f9k1109_v1 (WARNING: The stock u-boot will fail to load a kernel after the kernel reaches a certain size. The snapshot builds are commonly that size.)
Also fix issue https://github.com/openwrt/openwrt/issues/10968
thx to @xabolcs for pointing me my mistakes 

Bootlog from master installed via uboot recovery 
```
initializing CHIP_RTL8367R_VB 1010

3: System Boot system code via Flash.
## Booting image at bc050000 ...
.   Image Name:   N750F9K1103VB
   Created:      2022-10-17  13:42:50 UTC
   Image Type:   MIPS Linux Kernel Image (uncompressed)
   Data Size:    1600666 Bytes =  1.5 MB
   Load Address: 80000000
   Entry Point:  80000000
.........................   Verifying Checksum ... OK
OK
No initrd
## Transferring control to Linux (at address 80000000) ...
## Giving linux memsize in MB, 64

Starting kernel ...



OpenWrt kernel loader for MIPS based SoC
Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org>
Decompressing kernel... done!
Starting kernel at 80000000...

[    0.000000] Linux version 5.10.147 (user@chuwi14) (mipsel-openwrt-linux-musl-gcc (OpenWrt GCC 11.3.0 r20705-1722e23ffc) 11.3.0, GNU ld (GNU Binutils) 2.37) #0 Mon Oct 17 13:42:50 2022
[    0.000000] SoC Type: Ralink RT3883 ver:1 eco:5
[    0.000000] printk: bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 0001974c (MIPS 74Kc)
[    0.000000] MIPS: machine is Belkin F9K1109 Version 1.0
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] Primary instruction cache 64kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, VIPT, cache aliases, linesize 32 bytes
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x0000000003ffffff]
[    0.000000] Movable zone start for each node

```