### PR TITLE
base-files: fix nand_do_platform_check fail

### DIFF
--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -453,7 +453,11 @@ nand_do_platform_check() {
 
 	local gz="$(identify_if_gzip "$file")"
 	local file_type="$(identify "$file" "" "$gz")"
-	local control_length=$( (tar xO${gz}f "$file" "sysupgrade-$board_name/CONTROL" | wc -c) 2> /dev/null)
+	local control_length=$( (tar xO${gz}f "$file" "sysupgrade-${board_name//,/_}/CONTROL" | wc -c) 2> /dev/null)
+
+	if [ "$control_length" = 0 ]; then
+		control_length=$( (tar xO${gz}f "$file" "sysupgrade-${board_name//_/,}/CONTROL" | wc -c) 2> /dev/null)
+	fi
 
 	if [ "$control_length" != 0 ]; then
 		nand_verify_tar_file "$file" "$gz" || return 1

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -95,7 +95,7 @@ platform_check_image() {
 		;;
 	*)
 		nand_do_platform_check "$board" "$1"
-		return 0
+		return $?
 		;;
 	esac
 

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
@@ -74,6 +74,7 @@ platform_check_image() {
 	totolink,a8000ru|\
 	xiaomi,redmi-router-ax6s)
 		nand_do_platform_check "$board" "$1"
+		return $?
 		;;
 	*)
 		[ "$magic" != "d00dfeed" ] && {


### PR DESCRIPTION
This change ensures compatibility with both types of sysupgrade-tar files.

1. For some boards like xiaomi,redmi-router-ax6s, sysupgrade-tar is pack in directory `vendor,name/`
2. For some boards like xiaomi,mi-router-3g, sysupgrade-tar is pack in directory `vendor_name/`

And ensure that the platform_check_image() function returns an error code.

