### PR TITLE
mpc85xx: tl-wdr4900-v1 base-files fix erroneous PCI device rename for config/wireless

### DIFF
--- a/target/linux/mpc85xx/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
+++ b/target/linux/mpc85xx/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
@@ -53,8 +53,8 @@ WIRELESS_CHANGED=false
 
 case "$(board_name)" in
 tplink,tl-wdr4900-v1)
-	migrate_radio 'ffe09000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0' 'ffe09000.pcie/pci9000:00/9000:00:00.0/9000:01:00.0'
-	migrate_radio 'ffe0a000.pcie/pci0001:02/0001:02:00.0/0001:03:00.0' 'ffe0a000.pcie/pcia000:02/a000:02:00.0/a000:03:00.0'
+	migrate_radio 'ffe09000.pcie/pci9000:00/9000:00:00.0/9000:01:00.0' 'ffe09000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0'
+	migrate_radio 'ffe0a000.pcie/pcia000:02/a000:02:00.0/a000:03:00.0' 'ffe0a000.pcie/pci0001:02/0001:02:00.0/0001:03:00.0'
 	;;
 esac
 


### PR DESCRIPTION
TP-Link TL-WDR4900 v1 (mpc85xx/p1010) wifi config broken after upgrade 21.02.3 to 21.02.5

Fixes #11002