### PR TITLE
download: reuse git repo

### DIFF
--- a/include/download.mk
+++ b/include/download.mk
@@ -214,14 +214,15 @@ endef
 
 # Only intends to be called as a submethod from other DownloadMethod
 define DownloadMethod/rawgit
-	echo "Checking out files from the git repository..."; \
+	gitdir="$(DL_DIR)/git/`basename $(URL)`"; \
+	echo "Checking out files to $$$$gitdir ..."; \
 	mkdir -p $(TMP_DIR)/dl && \
 	cd $(TMP_DIR)/dl && \
 	rm -rf $(SUBDIR) && \
 	[ \! -d $(SUBDIR) ] && \
-	git clone $(OPTS) $(URL) $(SUBDIR) && \
-	(cd $(SUBDIR) && git checkout $(VERSION) && \
-	git submodule update --init --recursive) && \
+	mkdir -p "$(SUBDIR)" && \
+	mkdir -p $(DL_DIR)/git && \
+	"$(SCRIPT_DIR)"/git-cached-checkout.sh "$$$$gitdir" "$(URL)" "$(VERSION)" "$(TMP_DIR)/dl/$(SUBDIR)" && \
 	echo "Packing checkout..." && \
 	export TAR_TIMESTAMP=`cd $(SUBDIR) && git log -1 --format='@%ct'` && \
 	rm -rf $(SUBDIR)/.git && \

--- a/scripts/git-cached-checkout.sh
+++ b/scripts/git-cached-checkout.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+gitdir="$1"
+giturl="$2"
+gitversion="$3"
+checkoutdir="$4"
+if [ ! -d "$gitdir" ]; then
+	mkdir "$gitdir" || exit $?
+	cd "$gitdir" || exit $?
+	git init --bare || exit $?
+	git config --unset core.bare
+	git remote add origin "dummy"
+	git config --unset core.worktree
+	git config --unset-all remote.origin.fetch
+	git config --add remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+	git config --add remote.origin.fetch "+refs/tags/*:refs/tags/*"
+fi
+
+set -e
+cd "$gitdir"
+git remote set-url origin "$giturl"
+git rev-parse origin/$gitversion \
+	|| git show $gitversion >/dev/null \
+	|| git fetch --progress origin $gitversion \
+	|| git fetch --tags --progress origin
+
+cd "$checkoutdir"
+echo "gitdir: $gitdir" > .git
+git reset --hard origin/$gitversion || git reset --hard $gitversion
+
+echo git submodule
+git submodule update --init --recursive


### PR DESCRIPTION
for pacakge with git repo as download source
speed up git fetch on package version upgrade
by keeping git repo in dl/.git/$reponame locally
