### PR TITLE
lantiq: add rgmii delays on BT Home Hub 5A

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_bt_homehub-v5a.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_bt_homehub-v5a.dts
@@ -174,13 +174,17 @@
 	port@0 {
 		reg = <0>;
 		label = "lan3";
-		phy-mode = "rgmii";
+		phy-mode = "rgmii-id";
+		tx-internal-delay-ps = <1500>;
+		rx-internal-delay-ps = <1500>;
 		phy-handle = <&phy0>;
 	};
 	port@1 {
 		reg = <1>;
 		label = "lan4";
-		phy-mode = "rgmii";
+		phy-mode = "rgmii-id";
+		tx-internal-delay-ps = <1500>;
+		rx-internal-delay-ps = <1500>;
 		phy-handle = <&phy1>;
 	};
 	port@2 {
@@ -198,7 +202,9 @@
 	port@5 {
 		reg = <5>;
 		label = "wan";
-		phy-mode = "rgmii";
+		phy-mode = "rgmii-id";
+		tx-internal-delay-ps = <1500>;
+		rx-internal-delay-ps = <1500>;
 		phy-handle = <&phy5>;
 	};
 };


### PR DESCRIPTION
This comit fixes warnings that occur on kernel 5.15:
```
...
[    2.269736] Intel XWAY PHY11G (PEF 7071/PEF 7072) v1.5 / v1.6 1e108000.switch-mii:00:
               PHY has delays (e.g. via pin strapping), but phy-mode = 'rgmii'
[    2.269736] Should be 'rgmii-id' to use internal delays txskew:1500 ps rxskew:1500 ps
...
```

Ref: https://github.com/torvalds/linux/commit/be393dd685d215d44a43f5c5dcb8f7e57668d00e
Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>