### PR TITLE
ramips: add support for YunCore FAP640

### DIFF
--- a/target/linux/ramips/dts/mt7621_yuncore_fap640.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_fap640.dts
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "yuncore,fap640", "mediatek,mt7621-soc";
+	model = "YunCore FAP640";
+
+	aliases {
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: status_blue {
+			label = "blue:status";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&switch0 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "mt7530-0:04:link";
+		};
+
+		lan1 {
+			label = "green:lan1";
+			gpios = <&switch0 9 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:03:link";
+		};
+
+		lan2 {
+			label = "green:lan2";
+			gpios = <&switch0 6 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "mt7530-0:02:link";
+		};
+
+		lan3 {
+			label = "green:lan3";
+			gpios = <&switch0 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "mt7530-0:01:link";
+		};
+
+		lan4 {
+			label = "green:lan4";
+			gpios = <&switch0 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "mt7530-0:00:link";
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		hw_margin_ms = <200>;
+		always-running;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			/* range 0x40000 to 0x50000 is empty in vendor
+			 * firmware, so we do not use it either
+			 */
+
+			factory: partition@50000 {
+				label = "Factory";
+				reg = <0x50000 0x40000>;
+				read-only;
+			};
+
+			partition@90000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x90000 0xf70000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		mediatek,disable-radar-background;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_0004>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	gpio-controller;
+	#gpio-cells = <2>;
+
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_0004>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_0004: macaddr@0004 {
+		reg = <0x0004 0x6>;
+	};
+};
+

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2260,6 +2260,16 @@ define Device/yuncore_ax820
 endef
 TARGET_DEVICES += yuncore_ax820
 
+define Device/yuncore_fap640
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 15808k
+  DEVICE_VENDOR := YunCore
+  DEVICE_MODEL := FAP640
+  DEVICE_PACKAGES := kmod-mt7915e
+endef
+TARGET_DEVICES += yuncore_fap640
+
 define Device/zbtlink_zbt-we1326
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -126,6 +126,11 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary Factory 0xe000)" > /sys${DEVPATH}/macaddress
 		;;
+	yuncore,fap640)
+		hw_mac_addr="$(mtd_get_mac_binary Factory 0x4)"
+		[ "$PHYNBR" = "0" ] && macaddr_setbit_la "$hw_mac_addr" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && echo -n "$hw_mac_addr" > /sys${DEVPATH}/macaddress
+		;;
 	zyxel,nwa50ax|\
 	zyxel,nwa55axe)
 		hw_mac_addr="$(mtd_get_mac_binary mrd 0x1fff8)"


### PR DESCRIPTION
It is an 802.11ax (Wi-Fi 6) router, based on MediaTek MT7621A.

Specifications:
- SoC: MT7621AT (880MHz, 2 Cores)
- RAM: 128 MB
- Flash: 16 MB SPI
- Wi-Fi: - MT7915DN + MT7905DAN: 2.4/5 GHz
- Ethernet: 5x1GiE via MT7530, 1xWAN with POE and 4xLAN
- UART: J4 (115200 baud) - Pinout: [3V3] (TXD) (RXD) (GND)
- Power: 802.11af/at PoE;

- Bootloader: U-Boot
- Buttons: - Reset
- LEDs: - Status - RGB controlled by - GPIO 14 LOW - green color - GPIO 15 LOW- red color - GPIO 16 LOW - blue color - WAN - gren color, controlled by switch GPIO 12 LOW - LAN1 - gren color, controlled by switch GPIO 9 HIGH - LAN2 - gren color, controlled by switch GPIO 6 LOW - LAN3 - gren color, controlled by switch GPIO 3 LOW - LAN4 - gren color, controlled by switch GPIO 0 LOW

Installation:
OEM firmware is based on LEDE with custom UI and support standard sysupgrade variant of firmware. However it requires "*.ubin" extension for sysupgrade file. Always select "Factory reset" switch on upgrade to OpenWRT, otherwise router will not boot.

MAC addresses with OEM firmware:
vendor   source
lan      factory 0x4 (label)
5g       factory 0x4 (label)
2g       label with flipped bits bit in 1-st byte and bits 5, 6, 7 in
  4-th byte

Example
label:  44:xx:xx:b7:xx:xx
lan:    44:xx:xx:b7:xx:xx
2g      46:xx:xx:c7:xx:xx
5g      44:xx:xx:b7:xx:xx
