### PR TITLE
ramips: use ARTIFACTS for initramfs-factory of I-O DATA WN-AX1167GR

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -49,23 +49,6 @@ define Build/haier-sim_wr1800k-factory
   $(CP) $(1) $(BIN_DIR)/
 endef
 
-define Build/iodata-factory
-	$(eval fw_size=$(word 1,$(1)))
-	$(eval fw_type=$(word 2,$(1)))
-	$(eval product=$(word 3,$(1)))
-	$(eval factory_bin=$(word 4,$(1)))
-	if [ -e $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) -a "$$(stat -c%s $@)" -lt "$(fw_size)" ]; then \
-		$(CP) $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) $(factory_bin); \
-		$(STAGING_DIR_HOST)/bin/mksenaofw \
-			-r 0x30a -p $(product) -t $(fw_type) \
-			-e $(factory_bin) -o $(factory_bin).new; \
-		mv $(factory_bin).new $(factory_bin); \
-		$(CP) $(factory_bin) $(BIN_DIR)/; \
-	else \
-		echo "WARNING: initramfs kernel image too big, cannot generate factory image (actual $$(stat -c%s $@); max $(fw_size))" >&2; \
-	fi
-endef
-
 define Build/iodata-mstc-header
 	( \
 		data_size_crc="$$(dd if=$@ ibs=64 skip=1 2>/dev/null | gzip -c | \
@@ -955,10 +938,13 @@ define Device/iodata_wn-ax1167gr
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 15552k
-  KERNEL_INITRAMFS := $$(KERNEL) | \
-	iodata-factory 7864320 4 0x1055 $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.bin
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := WN-AX1167GR
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  ARTIFACTS := initramfs-factory.bin
+  ARTIFACT/initramfs-factory.bin := append-image initramfs-kernel.bin | \
+	check-size 7680k | senao-header -r 0x30a -p 0x1055 -t 4
+endif
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2
 endef
 TARGET_DEVICES += iodata_wn-ax1167gr


### PR DESCRIPTION
Use ARTIFACTS to generate initramfs-based factory image of I-O DATA WN-AX1167GR instead of redundant recipe which generate on KERNEL_INITRAMFS.

Note:

WN-AX1167GR has 2x OS images on stock firmware.

stock log:
```
flash manufacture id: c2, device id 20 18
MX25L12805D(c2 2018c220) (16384 Kbytes)
mtd .name = raspi, .size = 0x01000000 (16M) .erasesize = 0x00010000 (64K) .numeraseregions = 0 Creating 10 MTD partitions on "raspi":
0x000000000000-0x000001000000 : "ALL"
0x000000000000-0x000000030000 : "Bootloader"
0x000000030000-0x000000040000 : "Config "
0x000000040000-0x000000050000 : "Factory"
0x000000050000-0x000000060000 : "iNIC_rf"
0x000000060000-0x0000007e0000 : "Kernel"
0x000000800000-0x000000f80000 : "app"
0x000000f90000-0x000000fa0000 : "Key"
0x000000fa0000-0x000000fb0000 : "backup"
0x000000fb0000-0x000001000000 : "storage"
```
1st image is "Kernel" and 2nd is "app" when booted from 1st image. In OpenWrt, those 2x partitions are combined to "firmware" with undefined (empty) areas (0x7e0000-0x7fffff, 0xf80000-0xf8ffff).

The size of an OS image partition is 0x780000 (7680 KiB = 7.5 MiB), so check-size for initramfs-factory image needs to be called with the size.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>