### PR TITLE
ipq806x: 5.15: multiple fixup related to smem and others

### DIFF
--- a/target/linux/generic/backport-5.15/301-v5.16-soc-qcom-smem-Support-reserved-memory-description.patch
+++ b/target/linux/generic/backport-5.15/301-v5.16-soc-qcom-smem-Support-reserved-memory-description.patch
@@ -1,0 +1,166 @@
+From b5af64fceb04dc298c5e69c517b4d83893ff060b Mon Sep 17 00:00:00 2001
+From: Bjorn Andersson <bjorn.andersson@linaro.org>
+Date: Thu, 30 Sep 2021 11:21:10 -0700
+Subject: [PATCH 1/1] soc: qcom: smem: Support reserved-memory description
+
+Practically all modern Qualcomm platforms has a single reserved-memory
+region for SMEM. So rather than having to describe SMEM in the form of a
+node with a reference to a reserved-memory node, allow the SMEM device
+to be instantiated directly from the reserved-memory node.
+
+The current means of falling back to dereferencing the "memory-region"
+is kept as a fallback, if it's determined that the SMEM node is a
+reserved-memory node.
+
+The "qcom,smem" compatible is added to the reserved_mem_matches list, to
+allow the reserved-memory device to be probed.
+
+In order to retain the readability of the code, the resolution of
+resources is split from the actual ioremapping.
+
+Signed-off-by: Bjorn Andersson <bjorn.andersson@linaro.org>
+Acked-by: Rob Herring <robh@kernel.org>
+Reviewed-by: Vladimir Zapolskiy <vladimir.zapolskiy@linaro.org>
+Link: https://lore.kernel.org/r/20210930182111.57353-4-bjorn.andersson@linaro.org
+---
+ drivers/of/platform.c   |  1 +
+ drivers/soc/qcom/smem.c | 57 ++++++++++++++++++++++++++++-------------
+ 2 files changed, 40 insertions(+), 18 deletions(-)
+
+--- a/drivers/of/platform.c
++++ b/drivers/of/platform.c
+@@ -509,6 +509,7 @@ EXPORT_SYMBOL_GPL(of_platform_default_po
+ static const struct of_device_id reserved_mem_matches[] = {
+ 	{ .compatible = "qcom,rmtfs-mem" },
+ 	{ .compatible = "qcom,cmd-db" },
++	{ .compatible = "qcom,smem" },
+ 	{ .compatible = "ramoops" },
+ 	{ .compatible = "nvmem-rmem" },
+ 	{}
+--- a/drivers/soc/qcom/smem.c
++++ b/drivers/soc/qcom/smem.c
+@@ -9,6 +9,7 @@
+ #include <linux/module.h>
+ #include <linux/of.h>
+ #include <linux/of_address.h>
++#include <linux/of_reserved_mem.h>
+ #include <linux/platform_device.h>
+ #include <linux/sizes.h>
+ #include <linux/slab.h>
+@@ -240,7 +241,7 @@ static const u8 SMEM_INFO_MAGIC[] = { 0x
+  * @size:	size of the memory region
+  */
+ struct smem_region {
+-	u32 aux_base;
++	phys_addr_t aux_base;
+ 	void __iomem *virt_base;
+ 	size_t size;
+ };
+@@ -499,7 +500,7 @@ static void *qcom_smem_get_global(struct
+ 	for (i = 0; i < smem->num_regions; i++) {
+ 		region = &smem->regions[i];
+ 
+-		if (region->aux_base == aux_base || !aux_base) {
++		if ((u32)region->aux_base == aux_base || !aux_base) {
+ 			if (size != NULL)
+ 				*size = le32_to_cpu(entry->size);
+ 			return region->virt_base + le32_to_cpu(entry->offset);
+@@ -664,7 +665,7 @@ phys_addr_t qcom_smem_virt_to_phys(void
+ 		if (p < region->virt_base + region->size) {
+ 			u64 offset = p - region->virt_base;
+ 
+-			return (phys_addr_t)region->aux_base + offset;
++			return region->aux_base + offset;
+ 		}
+ 	}
+ 
+@@ -863,12 +864,12 @@ qcom_smem_enumerate_partitions(struct qc
+ 	return 0;
+ }
+ 
+-static int qcom_smem_map_memory(struct qcom_smem *smem, struct device *dev,
+-				const char *name, int i)
++static int qcom_smem_resolve_mem(struct qcom_smem *smem, const char *name,
++				 struct smem_region *region)
+ {
++	struct device *dev = smem->dev;
+ 	struct device_node *np;
+ 	struct resource r;
+-	resource_size_t size;
+ 	int ret;
+ 
+ 	np = of_parse_phandle(dev->of_node, name, 0);
+@@ -881,13 +882,9 @@ static int qcom_smem_map_memory(struct q
+ 	of_node_put(np);
+ 	if (ret)
+ 		return ret;
+-	size = resource_size(&r);
+ 
+-	smem->regions[i].virt_base = devm_ioremap_wc(dev, r.start, size);
+-	if (!smem->regions[i].virt_base)
+-		return -ENOMEM;
+-	smem->regions[i].aux_base = (u32)r.start;
+-	smem->regions[i].size = size;
++	region->aux_base = r.start;
++	region->size = resource_size(&r);
+ 
+ 	return 0;
+ }
+@@ -895,12 +892,14 @@ static int qcom_smem_map_memory(struct q
+ static int qcom_smem_probe(struct platform_device *pdev)
+ {
+ 	struct smem_header *header;
++	struct reserved_mem *rmem;
+ 	struct qcom_smem *smem;
+ 	size_t array_size;
+ 	int num_regions;
+ 	int hwlock_id;
+ 	u32 version;
+ 	int ret;
++	int i;
+ 
+ 	num_regions = 1;
+ 	if (of_find_property(pdev->dev.of_node, "qcom,rpm-msg-ram", NULL))
+@@ -914,13 +913,35 @@ static int qcom_smem_probe(struct platfo
+ 	smem->dev = &pdev->dev;
+ 	smem->num_regions = num_regions;
+ 
+-	ret = qcom_smem_map_memory(smem, &pdev->dev, "memory-region", 0);
+-	if (ret)
+-		return ret;
+-
+-	if (num_regions > 1 && (ret = qcom_smem_map_memory(smem, &pdev->dev,
+-					"qcom,rpm-msg-ram", 1)))
+-		return ret;
++	rmem = of_reserved_mem_lookup(pdev->dev.of_node);
++	if (rmem) {
++		smem->regions[0].aux_base = rmem->base;
++		smem->regions[0].size = rmem->size;
++	} else {
++		/*
++		 * Fall back to the memory-region reference, if we're not a
++		 * reserved-memory node.
++		 */
++		ret = qcom_smem_resolve_mem(smem, "memory-region", &smem->regions[0]);
++		if (ret)
++			return ret;
++	}
++
++	if (num_regions > 1) {
++		ret = qcom_smem_resolve_mem(smem, "qcom,rpm-msg-ram", &smem->regions[1]);
++		if (ret)
++			return ret;
++	}
++
++	for (i = 0; i < num_regions; i++) {
++		smem->regions[i].virt_base = devm_ioremap_wc(&pdev->dev,
++							     smem->regions[i].aux_base,
++							     smem->regions[i].size);
++		if (!smem->regions[i].virt_base) {
++			dev_err(&pdev->dev, "failed to remap %pa\n", &smem->regions[i].aux_base);
++			return -ENOMEM;
++		}
++	}
+ 
+ 	header = smem->regions[0].virt_base;
+ 	if (le32_to_cpu(header->initialized) != 1 ||

--- a/target/linux/generic/backport-5.15/407-v5.17-mtd-parsers-qcom-Don-t-print-error-message-on-EPROBE.patch
+++ b/target/linux/generic/backport-5.15/407-v5.17-mtd-parsers-qcom-Don-t-print-error-message-on-EPROBE.patch
@@ -1,0 +1,32 @@
+From 26bccc9671ba5e01f7153addbe94e7dc3f677375 Mon Sep 17 00:00:00 2001
+From: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+Date: Mon, 3 Jan 2022 03:03:16 +0000
+Subject: [PATCH 13/14] mtd: parsers: qcom: Don't print error message on
+ -EPROBE_DEFER
+
+Its possible for the main smem driver to not be loaded by the time we come
+along to parse the smem partition description but, this is a perfectly
+normal thing.
+
+No need to print out an error message in this case.
+
+Signed-off-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+Reviewed-by: Manivannan Sadhasivam <mani@kernel.org>
+Signed-off-by: Miquel Raynal <miquel.raynal@bootlin.com>
+Link: https://lore.kernel.org/linux-mtd/20220103030316.58301-3-bryan.odonoghue@linaro.org
+---
+ drivers/mtd/parsers/qcomsmempart.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/drivers/mtd/parsers/qcomsmempart.c
++++ b/drivers/mtd/parsers/qcomsmempart.c
+@@ -75,7 +75,8 @@ static int parse_qcomsmem_part(struct mt
+ 	pr_debug("Parsing partition table info from SMEM\n");
+ 	ptable = qcom_smem_get(SMEM_APPS, SMEM_AARM_PARTITION_TABLE, &len);
+ 	if (IS_ERR(ptable)) {
+-		pr_err("Error reading partition table header\n");
++		if (PTR_ERR(ptable) != -EPROBE_DEFER)
++			pr_err("Error reading partition table header\n");
+ 		return PTR_ERR(ptable);
+ 	}
+ 

--- a/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8064-g10.dts
+++ b/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8064-g10.dts
@@ -158,71 +158,17 @@
 	pinctrl-0 = <&mdio0_pins>;
 	pinctrl-names = "default";
 
-	switch@10 {
-		compatible = "qca,qca8337";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <0x10>;
-
-		qca8k,rgmii56_1_8v;
-
-		ports {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			port@0 {
-				reg = <0>;
-				label = "cpu";
-				ethernet = <&gmac1>;
-				phy-mode = "rgmii-id";
-
-				fixed-link {
-					speed = <1000>;
-					full-duplex;
-				};
-			};
-
-			port@1 {
-				reg = <1>;
-				label = "lan1";
-			};
-
-			port@2 {
-				reg = <2>;
-				label = "lan2";
-			};
-
-			port@3 {
-				reg = <3>;
-				label = "lan3";
-			};
-
-			port@4 {
-				reg = <4>;
-				label = "lan4";
-			};
-
-			port@5 {
-				reg = <5>;
-				label = "wan";
-			};
-
-			/*
-			port@6 {
-					reg = <0>;
-					label = "cpu";
-					ethernet = <&gmac2>;
-					phy-mode = "rgmii";
-
-					fixed-link {
-							speed = <1000>;
-							full-duplex;
-							pause;
-							asym-pause;
-					};
-			};
-			*/
-		};
+	ethernet-phy@0 {
+		reg = <0>;
+		qca,ar8327-initvals = <
+			0x00004 0x7600000   /* PAD0_MODE */
+			0x00008 0x1000000   /* PAD5_MODE */
+			0x0000c 0x80        /* PAD6_MODE */
+			0x000e4 0x6a545     /* MAC_POWER_SEL */
+			0x000e0 0xc74164de  /* SGMII_CTRL */
+			0x0007c 0x4e        /* PORT0_STATUS */
+			0x00094 0x4e        /* PORT6_STATUS */
+			>;
 	};
 };
 

--- a/target/linux/ipq806x/patches-5.15/130-mtd-nand-raw-qcom_nandc-handle-ret-from-parse-with-c.patch
+++ b/target/linux/ipq806x/patches-5.15/130-mtd-nand-raw-qcom_nandc-handle-ret-from-parse-with-c.patch
@@ -1,0 +1,54 @@
+From 99d897e04c0856188e371e60b00e13106cd44a24 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Fri, 21 Oct 2022 18:38:21 +0200
+Subject: [PATCH] mtd: nand: raw: qcom_nandc: handle ret from parse with
+ codeword_fixup
+
+With use_codeword_fixup enabled, any return from
+mtd_device_parse_register gets overwritten. Aside from the clear bug, this
+is also problematic as a parser can EPROBE_DEFER and because this is not
+correctly handled, the nand is never rescanned later in the bootup
+process.
+
+An example of this problem is when smem requires additional time to be
+probed and nandc use qcomsmempart as parser. Parser will return
+EPROBE_DEFER but in the current code this ret gets overwritten by
+qcom_nand_host_parse_boot_partitions and qcom_nand_host_init_and_register
+return 0.
+
+Correctly handle the return code from mtd_device_parse_register so that
+any error from this function is not ignored.
+
+Fixes: 862bdedd7f4b ("mtd: nand: raw: qcom_nandc: add support for unprotected spare data pages")
+Cc: stable@vger.kernel.org # v6.0+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/mtd/nand/raw/qcom_nandc.c | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+--- a/drivers/mtd/nand/raw/qcom_nandc.c
++++ b/drivers/mtd/nand/raw/qcom_nandc.c
+@@ -3157,16 +3157,18 @@ static int qcom_nand_host_init_and_regis
+ 
+ 	ret = mtd_device_parse_register(mtd, probes, NULL, NULL, 0);
+ 	if (ret)
+-		nand_cleanup(chip);
++		goto err;
+ 
+ 	if (nandc->props->use_codeword_fixup) {
+ 		ret = qcom_nand_host_parse_boot_partitions(nandc, host, dn);
+-		if (ret) {
+-			nand_cleanup(chip);
+-			return ret;
+-		}
++		if (ret)
++			goto err;
+ 	}
+ 
++	return 0;
++
++err:
++	nand_cleanup(chip);
+ 	return ret;
+ }
+ 

--- a/target/linux/ipq806x/patches-5.15/131-ARM-dts-qcom-ipq8064-disable-mmc-ddr-1_8v-for-sdcc1.patch
+++ b/target/linux/ipq806x/patches-5.15/131-ARM-dts-qcom-ipq8064-disable-mmc-ddr-1_8v-for-sdcc1.patch
@@ -1,0 +1,26 @@
+From f7b300f770683cd063f922e43fa4ad818761c1fb Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Sat, 22 Oct 2022 16:55:21 +0200
+Subject: [PATCH] ARM: dts: qcom: ipq8064: disable mmc-ddr-1_8v for sdcc1
+
+It was reported non working mmc with this option enabled.
+Both mmc for ipq8064 are supplied by a fixed 3.3v regulator so mmc can't
+be run at 1.8v.
+Disable it to restore correct functionality of this SoC feature.
+
+Tested-by: Hendrik Koerner <koerhen@web.de>
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ arch/arm/boot/dts/qcom-ipq8064.dtsi | 1 -
+ 1 file changed, 1 deletion(-)
+
+--- a/arch/arm/boot/dts/qcom-ipq8064.dtsi
++++ b/arch/arm/boot/dts/qcom-ipq8064.dtsi
+@@ -1529,7 +1529,6 @@
+ 				non-removable;
+ 				cap-sd-highspeed;
+ 				cap-mmc-highspeed;
+-				mmc-ddr-1_8v;
+ 				vmmc-supply = <&vsdcc_fixed>;
+ 				dmas = <&sdcc1bam 2>, <&sdcc1bam 1>;
+ 				dma-names = "tx", "rx";

--- a/target/linux/ipq806x/patches-5.15/900-arm-add-cmdline-override.patch
+++ b/target/linux/ipq806x/patches-5.15/900-arm-add-cmdline-override.patch
@@ -1,0 +1,37 @@
+--- a/arch/arm/Kconfig
++++ b/arch/arm/Kconfig
+@@ -1740,6 +1740,14 @@ config ARM_ATAG_DTB_COMPAT_CMDLINE_MANGL
+ 
+ endchoice
+ 
++config CMDLINE_OVERRIDE
++	bool "Use alternative cmdline from device tree"
++	help
++	  Some bootloaders may have uneditable bootargs. While CMDLINE_FORCE can
++	  be used, this is not a good option for kernels that are shared across
++	  devices. This setting enables using "chosen/cmdline-override" as the
++	  cmdline if it exists in the device tree.
++
+ config CMDLINE
+ 	string "Default kernel command string"
+ 	default ""
+--- a/drivers/of/fdt.c
++++ b/drivers/of/fdt.c
+@@ -1162,6 +1162,17 @@ int __init early_init_dt_scan_chosen(uns
+ 	if (p != NULL && l > 0)
+ 		strlcat(data, p, min_t(int, strlen(data) + (int)l, COMMAND_LINE_SIZE));
+ 
++    /* CONFIG_CMDLINE_OVERRIDE is used to fallback to a different
++     * device tree option of chosen/bootargs-override. This is
++     * helpful on boards where u-boot sets bootargs, and is unable
++     * to be modified.
++     */
++#ifdef CONFIG_CMDLINE_OVERRIDE
++	p = of_get_flat_dt_prop(node, "bootargs-override", &l);
++	if (p != NULL && l > 0)
++		strlcpy(data, p, min((int)l, COMMAND_LINE_SIZE));
++#endif
++
+ 	/*
+ 	 * CONFIG_CMDLINE is meant to be a default in case nothing else
+ 	 * managed to set the command line, unless CONFIG_CMDLINE_FORCE


### PR DESCRIPTION
When 5.15 kernel was refreshed, a new implementation for smem was used, but I didn't notice that this was supported only with kernel 5.16. A backport patch should fix that.

Also backport one mtd parser patch that mute a confusing warning and revert unwanted DSA conversion for asrock G10.

Fixes: #11000

---

I would love some testing from the smem based device if this fix the bootloop... I tested this on my r7800 using smem and partition gots correctly detected with this.