### PR TITLE
CI: kernel: fix deprecation of set-output

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -35,14 +35,14 @@ jobs:
         run: |
           OWNER_LC=$(echo "${{ github.repository_owner }}" \
             | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=owner_lc::$OWNER_LC"
+          echo "owner_lc=$OWNER_LC" >> $GITHUB_OUTPUT
 
       - name: Generate ccache hash
         id: ccache_hash
         run: |
           CCACHE_HASH=$(md5sum include/kernel-* | awk '{ print $1 }' \
            | md5sum | awk '{ print $1 }')
-          echo "::set-output name=ccache_hash::$CCACHE_HASH"
+          echo "ccache_hash=$CCACHE_HASH" >> $GITHUB_OUTPUT
 
       - name: Set targets
         id: find_targets
@@ -64,7 +64,7 @@ jobs:
            echo "$JSON"
            echo -e "\n---- targets ----\n"
 
-           echo "::set-output name=target::$JSON"
+           echo "target=$JSON" >> $GITHUB_OUTPUT
 
   build:
     name: Build Kernel with external toolchain


### PR DESCRIPTION
From [0], github deprecated set-output with a better approach of appending variables to $GITHUB_OUTPUT

[0] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>