### PR TITLE
ramips: mt7621: enable lzma-loader for Asus RT-N56U-B1

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -291,6 +291,7 @@ TARGET_DEVICES += asus_rt-ac85p
 
 define Device/asus_rt-n56u-b1
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-N56U
   DEVICE_VARIANT := B1


### PR DESCRIPTION
Fixes boot loader LZMA decompression issues

Signed-off-by: Alex Khodin <mxktz1@gmail.com>
