### PR TITLE
kernel: Rtl8761 USB bluetooth support

### DIFF
--- a/package/firmware/linux-firmware/realtek.mk
+++ b/package/firmware/linux-firmware/realtek.mk
@@ -86,6 +86,29 @@ define Package/rtl8723bu-firmware/install
 endef
 $(eval $(call BuildPackage,rtl8723bu-firmware))
 
+Package/rtl8761a-firmware = $(call Package/firmware-default,RealTek RTL8761A firmware)
+define Package/rtl8761a-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/rtl_bt
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtl_bt/rtl8761a_fw.bin $(1)/lib/firmware/rtl_bt
+endef
+$(eval $(call BuildPackage,rtl8761a-firmware))
+
+Package/rtl8761b-firmware = $(call Package/firmware-default,RealTek RTL8761B firmware)
+define Package/rtl8761b-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/rtl_bt
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtl_bt/rtl8761b_config.bin $(1)/lib/firmware/rtl_bt
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtl_bt/rtl8761b_fw.bin $(1)/lib/firmware/rtl_bt
+endef
+$(eval $(call BuildPackage,rtl8761b-firmware))
+
+Package/rtl8761bu-firmware = $(call Package/firmware-default,RealTek RTL8761BU firmware)
+define Package/rtl8761bu-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/rtl_bt
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtl_bt/rtl8761bu_config.bin $(1)/lib/firmware/rtl_bt
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtl_bt/rtl8761bu_fw.bin $(1)/lib/firmware/rtl_bt
+endef
+$(eval $(call BuildPackage,rtl8761bu-firmware))
+
 Package/rtl8821ae-firmware = $(call Package/firmware-default,RealTek RTL8821AE firmware)
 define Package/rtl8821ae-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -41,7 +41,7 @@ define KernelPackage/bluetooth
 	CONFIG_BT_HCIBTUSB \
 	CONFIG_BT_HCIBTUSB_BCM=n \
 	CONFIG_BT_HCIBTUSB_MTK=y \
-	CONFIG_BT_HCIBTUSB_RTL=n \
+	CONFIG_BT_HCIBTUSB_RTL=y \
 	CONFIG_BT_HCIUART \
 	CONFIG_BT_HCIUART_BCM=n \
 	CONFIG_BT_HCIUART_INTEL=n \
@@ -56,7 +56,8 @@ define KernelPackage/bluetooth
 	$(LINUX_DIR)/net/bluetooth/hidp/hidp.ko \
 	$(LINUX_DIR)/drivers/bluetooth/hci_uart.ko \
 	$(LINUX_DIR)/drivers/bluetooth/btusb.ko \
-	$(LINUX_DIR)/drivers/bluetooth/btintel.ko
+	$(LINUX_DIR)/drivers/bluetooth/btintel.ko \
+	$(LINUX_DIR)/drivers/bluetooth/btrtl.ko
   AUTOLOAD:=$(call AutoProbe,bluetooth rfcomm bnep hidp hci_uart btusb)
 endef
 

--- a/target/linux/generic/backport-5.10/883-v5.11-Bluetooth-btrtl-Refine-the-ic_id_table-for-clearer-a.patch
+++ b/target/linux/generic/backport-5.10/883-v5.11-Bluetooth-btrtl-Refine-the-ic_id_table-for-clearer-a.patch
@@ -1,0 +1,183 @@
+From 6f9ff24645f55ffae12ef717b4f221c3e7dfe115 Mon Sep 17 00:00:00 2001
+From: Max Chou <max.chou@realtek.com>
+Date: Wed, 4 Nov 2020 20:04:14 +0800
+Subject: [PATCH] Bluetooth: btrtl: Refine the ic_id_table for clearer and more
+ regular
+
+Enhance the ic_id_table that it's able to maintain regularly.
+To judge which chip should be initialized by LMP subversion, HCI revision,
+ HCI version and HCI bus which were given in the ic_id_table.
+Also, refine the incorrect LMP subversion of ROM for RTL8723D and
+RTL8723A.
+
+Suggested-by: Alex Lu <alex_lu@realsil.com.cn>
+Signed-off-by: Max Chou <max.chou@realtek.com>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+---
+ drivers/bluetooth/btrtl.c | 65 ++++++++++++---------------------------
+ 1 file changed, 19 insertions(+), 46 deletions(-)
+
+--- a/drivers/bluetooth/btrtl.c
++++ b/drivers/bluetooth/btrtl.c
+@@ -18,10 +18,8 @@
+ #define VERSION "0.1"
+ 
+ #define RTL_EPATCH_SIGNATURE	"Realtech"
+-#define RTL_ROM_LMP_3499	0x3499
+ #define RTL_ROM_LMP_8723A	0x1200
+ #define RTL_ROM_LMP_8723B	0x8723
+-#define RTL_ROM_LMP_8723D	0x8873
+ #define RTL_ROM_LMP_8821A	0x8821
+ #define RTL_ROM_LMP_8761A	0x8761
+ #define RTL_ROM_LMP_8822B	0x8822
+@@ -31,10 +29,13 @@
+ #define IC_MATCH_FL_HCIREV	(1 << 1)
+ #define IC_MATCH_FL_HCIVER	(1 << 2)
+ #define IC_MATCH_FL_HCIBUS	(1 << 3)
+-#define IC_INFO(lmps, hcir) \
+-	.match_flags = IC_MATCH_FL_LMPSUBV | IC_MATCH_FL_HCIREV, \
++#define IC_INFO(lmps, hcir, hciv, bus) \
++	.match_flags = IC_MATCH_FL_LMPSUBV | IC_MATCH_FL_HCIREV | \
++		       IC_MATCH_FL_HCIVER | IC_MATCH_FL_HCIBUS, \
+ 	.lmp_subver = (lmps), \
+-	.hci_rev = (hcir)
++	.hci_rev = (hcir), \
++	.hci_ver = (hciv), \
++	.hci_bus = (bus)
+ 
+ struct id_table {
+ 	__u16 match_flags;
+@@ -58,112 +59,85 @@ struct btrtl_device_info {
+ };
+ 
+ static const struct id_table ic_id_table[] = {
+-	{ IC_MATCH_FL_LMPSUBV, RTL_ROM_LMP_8723A, 0x0,
+-	  .config_needed = false,
+-	  .has_rom_version = false,
+-	  .fw_name = "rtl_bt/rtl8723a_fw.bin",
+-	  .cfg_name = NULL },
+-
+-	{ IC_MATCH_FL_LMPSUBV, RTL_ROM_LMP_3499, 0x0,
++	/* 8723A */
++	{ IC_INFO(RTL_ROM_LMP_8723A, 0xb, 0x6, HCI_USB),
+ 	  .config_needed = false,
+ 	  .has_rom_version = false,
+ 	  .fw_name = "rtl_bt/rtl8723a_fw.bin",
+ 	  .cfg_name = NULL },
+ 
+ 	/* 8723BS */
+-	{ .match_flags = IC_MATCH_FL_LMPSUBV | IC_MATCH_FL_HCIREV |
+-			 IC_MATCH_FL_HCIVER | IC_MATCH_FL_HCIBUS,
+-	  .lmp_subver = RTL_ROM_LMP_8723B,
+-	  .hci_rev = 0xb,
+-	  .hci_ver = 6,
+-	  .hci_bus = HCI_UART,
++	{ IC_INFO(RTL_ROM_LMP_8723B, 0xb, 0x6, HCI_UART),
+ 	  .config_needed = true,
+ 	  .has_rom_version = true,
+ 	  .fw_name  = "rtl_bt/rtl8723bs_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8723bs_config" },
+ 
+ 	/* 8723B */
+-	{ IC_INFO(RTL_ROM_LMP_8723B, 0xb),
++	{ IC_INFO(RTL_ROM_LMP_8723B, 0xb, 0x6, HCI_USB),
+ 	  .config_needed = false,
+ 	  .has_rom_version = true,
+ 	  .fw_name  = "rtl_bt/rtl8723b_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8723b_config" },
+ 
+ 	/* 8723D */
+-	{ IC_INFO(RTL_ROM_LMP_8723B, 0xd),
++	{ IC_INFO(RTL_ROM_LMP_8723B, 0xd, 0x8, HCI_USB),
+ 	  .config_needed = true,
+ 	  .has_rom_version = true,
+ 	  .fw_name  = "rtl_bt/rtl8723d_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8723d_config" },
+ 
+ 	/* 8723DS */
+-	{ .match_flags = IC_MATCH_FL_LMPSUBV | IC_MATCH_FL_HCIREV |
+-			 IC_MATCH_FL_HCIVER | IC_MATCH_FL_HCIBUS,
+-	  .lmp_subver = RTL_ROM_LMP_8723B,
+-	  .hci_rev = 0xd,
+-	  .hci_ver = 8,
+-	  .hci_bus = HCI_UART,
++	{ IC_INFO(RTL_ROM_LMP_8723B, 0xd, 0x8, HCI_UART),
+ 	  .config_needed = true,
+ 	  .has_rom_version = true,
+ 	  .fw_name  = "rtl_bt/rtl8723ds_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8723ds_config" },
+ 
+-	/* 8723DU */
+-	{ IC_INFO(RTL_ROM_LMP_8723D, 0x826C),
+-	  .config_needed = true,
+-	  .has_rom_version = true,
+-	  .fw_name  = "rtl_bt/rtl8723d_fw.bin",
+-	  .cfg_name = "rtl_bt/rtl8723d_config" },
+-
+ 	/* 8821A */
+-	{ IC_INFO(RTL_ROM_LMP_8821A, 0xa),
++	{ IC_INFO(RTL_ROM_LMP_8821A, 0xa, 0x6, HCI_USB),
+ 	  .config_needed = false,
+ 	  .has_rom_version = true,
+ 	  .fw_name  = "rtl_bt/rtl8821a_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8821a_config" },
+ 
+ 	/* 8821C */
+-	{ IC_INFO(RTL_ROM_LMP_8821A, 0xc),
++	{ IC_INFO(RTL_ROM_LMP_8821A, 0xc, 0x8, HCI_USB),
+ 	  .config_needed = false,
+ 	  .has_rom_version = true,
+ 	  .fw_name  = "rtl_bt/rtl8821c_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8821c_config" },
+ 
+ 	/* 8761A */
+-	{ IC_INFO(RTL_ROM_LMP_8761A, 0xa),
++	{ IC_INFO(RTL_ROM_LMP_8761A, 0xa, 0x6, HCI_USB),
+ 	  .config_needed = false,
+ 	  .has_rom_version = true,
+ 	  .fw_name  = "rtl_bt/rtl8761a_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8761a_config" },
+ 
+ 	/* 8761B */
+-	{ IC_INFO(RTL_ROM_LMP_8761A, 0xb),
++	{ IC_INFO(RTL_ROM_LMP_8761A, 0xb, 0xa, HCI_USB),
+ 	  .config_needed = false,
+ 	  .has_rom_version = true,
+ 	  .fw_name  = "rtl_bt/rtl8761b_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8761b_config" },
+ 
+ 	/* 8822C with UART interface */
+-	{ .match_flags = IC_MATCH_FL_LMPSUBV | IC_MATCH_FL_HCIREV |
+-			 IC_MATCH_FL_HCIBUS,
+-	  .lmp_subver = RTL_ROM_LMP_8822B,
+-	  .hci_rev = 0x000c,
+-	  .hci_ver = 0x0a,
+-	  .hci_bus = HCI_UART,
++	{ IC_INFO(RTL_ROM_LMP_8822B, 0xc, 0xa, HCI_UART),
+ 	  .config_needed = true,
+ 	  .has_rom_version = true,
+ 	  .fw_name  = "rtl_bt/rtl8822cs_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8822cs_config" },
+ 
+ 	/* 8822C with USB interface */
+-	{ IC_INFO(RTL_ROM_LMP_8822B, 0xc),
++	{ IC_INFO(RTL_ROM_LMP_8822B, 0xc, 0xa, HCI_USB),
+ 	  .config_needed = false,
+ 	  .has_rom_version = true,
+ 	  .fw_name  = "rtl_bt/rtl8822cu_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8822cu_config" },
+ 
+ 	/* 8822B */
+-	{ IC_INFO(RTL_ROM_LMP_8822B, 0xb),
++	{ IC_INFO(RTL_ROM_LMP_8822B, 0xb, 0x7, HCI_USB),
+ 	  .config_needed = true,
+ 	  .has_rom_version = true,
+ 	  .fw_name  = "rtl_bt/rtl8822b_fw.bin",
+@@ -654,7 +628,6 @@ int btrtl_download_firmware(struct hci_d
+ 
+ 	switch (btrtl_dev->ic_info->lmp_subver) {
+ 	case RTL_ROM_LMP_8723A:
+-	case RTL_ROM_LMP_3499:
+ 		return btrtl_setup_rtl8723a(hdev, btrtl_dev);
+ 	case RTL_ROM_LMP_8723B:
+ 	case RTL_ROM_LMP_8821A:

--- a/target/linux/generic/backport-5.10/884-v5.14-Bluetooth-btrtl-rename-USB-fw-for-RTL8761.patch
+++ b/target/linux/generic/backport-5.10/884-v5.14-Bluetooth-btrtl-rename-USB-fw-for-RTL8761.patch
@@ -1,0 +1,39 @@
+From 9fd2e2949b43dea869f7fce0f8f51df44f635d59 Mon Sep 17 00:00:00 2001
+From: Joakim Tjernlund <Joakim.Tjernlund@infinera.com>
+Date: Fri, 28 May 2021 17:26:44 +0200
+Subject: [PATCH] Bluetooth: btrtl: rename USB fw for RTL8761
+
+According Realteks own BT drivers firmware RTL8761B is for UART
+and RTL8761BU is for USB.
+
+Change existing 8761B to UART and add an 8761BU entry for USB
+
+Signed-off-by: Joakim Tjernlund <Joakim.Tjernlund@infinera.com>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+---
+ drivers/bluetooth/btrtl.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+--- a/drivers/bluetooth/btrtl.c
++++ b/drivers/bluetooth/btrtl.c
+@@ -116,12 +116,19 @@ static const struct id_table ic_id_table
+ 	  .cfg_name = "rtl_bt/rtl8761a_config" },
+ 
+ 	/* 8761B */
+-	{ IC_INFO(RTL_ROM_LMP_8761A, 0xb, 0xa, HCI_USB),
++	{ IC_INFO(RTL_ROM_LMP_8761A, 0xb, 0xa, HCI_UART),
+ 	  .config_needed = false,
+ 	  .has_rom_version = true,
+ 	  .fw_name  = "rtl_bt/rtl8761b_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8761b_config" },
+ 
++	/* 8761BU */
++	{ IC_INFO(RTL_ROM_LMP_8761A, 0xb, 0xa, HCI_USB),
++	  .config_needed = false,
++	  .has_rom_version = true,
++	  .fw_name  = "rtl_bt/rtl8761bu_fw.bin",
++	  .cfg_name = "rtl_bt/rtl8761bu_config" },
++
+ 	/* 8822C with UART interface */
+ 	{ IC_INFO(RTL_ROM_LMP_8822B, 0xc, 0xa, HCI_UART),
+ 	  .config_needed = true,

--- a/target/linux/generic/backport-5.10/885-v5.14-Bluetooth-btusb-Add-0x0b05-0x190e-Realtek-8761BU-ASU.patch
+++ b/target/linux/generic/backport-5.10/885-v5.14-Bluetooth-btusb-Add-0x0b05-0x190e-Realtek-8761BU-ASU.patch
@@ -1,0 +1,54 @@
+From 33404381c5e875cbd57eec6d9bbacd3b13b404c9 Mon Sep 17 00:00:00 2001
+From: Joakim Tjernlund <Joakim.Tjernlund@infinera.com>
+Date: Fri, 28 May 2021 17:26:45 +0200
+Subject: [PATCH] Bluetooth: btusb: Add 0x0b05:0x190e Realtek 8761BU (ASUS
+ BT500) device.
+
+T:  Bus=01 Lev=01 Prnt=01 Port=08 Cnt=04 Dev#= 18 Spd=12   MxCh= 0
+D:  Ver= 1.10 Cls=e0(wlcon) Sub=01 Prot=01 MxPS=64 #Cfgs=  1
+P:  Vendor=0b05 ProdID=190e Rev= 2.00
+S:  Manufacturer=Realtek
+S:  Product=ASUS USB-BT500
+S:  SerialNumber=xxxxxxxx
+C:* #Ifs= 2 Cfg#= 1 Atr=e0 MxPwr=500mA
+I:* If#= 0 Alt= 0 #EPs= 3 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=81(I) Atr=03(Int.) MxPS=  16 Ivl=1ms
+E:  Ad=02(O) Atr=02(Bulk) MxPS=  64 Ivl=0ms
+E:  Ad=82(I) Atr=02(Bulk) MxPS=  64 Ivl=0ms
+I:* If#= 1 Alt= 0 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=   0 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=   0 Ivl=1ms
+I:  If#= 1 Alt= 1 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=   9 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=   9 Ivl=1ms
+I:  If#= 1 Alt= 2 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=  17 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=  17 Ivl=1ms
+I:  If#= 1 Alt= 3 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=  25 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=  25 Ivl=1ms
+I:  If#= 1 Alt= 4 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=  33 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=  33 Ivl=1ms
+I:  If#= 1 Alt= 5 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=  49 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=  49 Ivl=1ms
+Signed-off-by: Joakim Tjernlund <Joakim.Tjernlund@infinera.com>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+---
+ drivers/bluetooth/btusb.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/drivers/bluetooth/btusb.c
++++ b/drivers/bluetooth/btusb.c
+@@ -451,6 +451,10 @@ static const struct usb_device_id blackl
+ 	{ USB_DEVICE(0x0bda, 0xb009), .driver_info = BTUSB_REALTEK },
+ 	{ USB_DEVICE(0x2ff8, 0xb011), .driver_info = BTUSB_REALTEK },
+ 
++	/* Additional Realtek 8761BU Bluetooth devices */
++	{ USB_DEVICE(0x0b05, 0x190e), .driver_info = BTUSB_REALTEK |
++	  					     BTUSB_WIDEBAND_SPEECH },
++
+ 	/* Additional Realtek 8821AE Bluetooth devices */
+ 	{ USB_DEVICE(0x0b05, 0x17dc), .driver_info = BTUSB_REALTEK },
+ 	{ USB_DEVICE(0x13d3, 0x3414), .driver_info = BTUSB_REALTEK },

--- a/target/linux/generic/backport-5.10/886-v5.16-Bluetooth-btusb-Add-support-for-TP-Link-UB500-Adapte.patch
+++ b/target/linux/generic/backport-5.10/886-v5.16-Bluetooth-btusb-Add-support-for-TP-Link-UB500-Adapte.patch
@@ -1,0 +1,57 @@
+From 4fd6d490796171bf786090fee782e252186632e4 Mon Sep 17 00:00:00 2001
+From: Nicholas Flintham <nick@flinny.org>
+Date: Thu, 30 Sep 2021 09:22:39 +0100
+Subject: [PATCH] Bluetooth: btusb: Add support for TP-Link UB500 Adapter
+
+Add support for TP-Link UB500 Adapter (RTL8761B)
+
+* /sys/kernel/debug/usb/devices
+T:  Bus=01 Lev=02 Prnt=05 Port=01 Cnt=01 Dev#= 78 Spd=12   MxCh= 0
+D:  Ver= 1.10 Cls=e0(wlcon) Sub=01 Prot=01 MxPS=64 #Cfgs=  1
+P:  Vendor=2357 ProdID=0604 Rev= 2.00
+S:  Manufacturer=
+S:  Product=TP-Link UB500 Adapter
+S:  SerialNumber=E848B8C82000
+C:* #Ifs= 2 Cfg#= 1 Atr=e0 MxPwr=500mA
+I:* If#= 0 Alt= 0 #EPs= 3 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=81(I) Atr=03(Int.) MxPS=  16 Ivl=1ms
+E:  Ad=02(O) Atr=02(Bulk) MxPS=  64 Ivl=0ms
+E:  Ad=82(I) Atr=02(Bulk) MxPS=  64 Ivl=0ms
+I:* If#= 1 Alt= 0 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=   0 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=   0 Ivl=1ms
+I:  If#= 1 Alt= 1 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=   9 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=   9 Ivl=1ms
+I:  If#= 1 Alt= 2 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=  17 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=  17 Ivl=1ms
+I:  If#= 1 Alt= 3 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=  25 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=  25 Ivl=1ms
+I:  If#= 1 Alt= 4 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=  33 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=  33 Ivl=1ms
+I:  If#= 1 Alt= 5 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=  49 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=  49 Ivl=1ms
+
+Signed-off-by: Nicholas Flintham <nick@flinny.org>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+---
+ drivers/bluetooth/btusb.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/drivers/bluetooth/btusb.c
++++ b/drivers/bluetooth/btusb.c
+@@ -451,6 +451,10 @@ static const struct usb_device_id blackl
+ 	{ USB_DEVICE(0x0bda, 0xb009), .driver_info = BTUSB_REALTEK },
+ 	{ USB_DEVICE(0x2ff8, 0xb011), .driver_info = BTUSB_REALTEK },
+ 
++	/* Additional Realtek 8761B Bluetooth devices */
++	{ USB_DEVICE(0x2357, 0x0604), .driver_info = BTUSB_REALTEK |
++						     BTUSB_WIDEBAND_SPEECH },
++
+ 	/* Additional Realtek 8761BU Bluetooth devices */
+ 	{ USB_DEVICE(0x0b05, 0x190e), .driver_info = BTUSB_REALTEK |
+ 	  					     BTUSB_WIDEBAND_SPEECH },

--- a/target/linux/generic/backport-5.10/887-v5.18-Bluetooth-btusb-Add-another-Realtek-8761BU.patch
+++ b/target/linux/generic/backport-5.10/887-v5.18-Bluetooth-btusb-Add-another-Realtek-8761BU.patch
@@ -1,0 +1,55 @@
+From 6dfbe29f45fb0bde29213dbd754a79e8bfc6ecef Mon Sep 17 00:00:00 2001
+From: Helmut Grohne <helmut@subdivi.de>
+Date: Sat, 26 Feb 2022 16:22:56 +0100
+Subject: [PATCH] Bluetooth: btusb: Add another Realtek 8761BU
+
+This device is sometimes wrapped with a label "EDUP".
+
+T:  Bus=01 Lev=02 Prnt=02 Port=02 Cnt=03 Dev#=107 Spd=12   MxCh= 0
+D:  Ver= 1.10 Cls=e0(wlcon) Sub=01 Prot=01 MxPS=64 #Cfgs=  1
+P:  Vendor=2550 ProdID=8761 Rev= 2.00
+S:  Manufacturer=Realtek
+S:  Product=Bluetooth Radio
+S:  SerialNumber=00E04C239987
+C:* #Ifs= 2 Cfg#= 1 Atr=e0 MxPwr=500mA
+I:* If#= 0 Alt= 0 #EPs= 3 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=81(I) Atr=03(Int.) MxPS=  16 Ivl=1ms
+E:  Ad=02(O) Atr=02(Bulk) MxPS=  64 Ivl=0ms
+E:  Ad=82(I) Atr=02(Bulk) MxPS=  64 Ivl=0ms
+I:* If#= 1 Alt= 0 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=   0 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=   0 Ivl=1ms
+I:  If#= 1 Alt= 1 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=   9 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=   9 Ivl=1ms
+I:  If#= 1 Alt= 2 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=  17 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=  17 Ivl=1ms
+I:  If#= 1 Alt= 3 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=  25 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=  25 Ivl=1ms
+I:  If#= 1 Alt= 4 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=  33 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=  33 Ivl=1ms
+I:  If#= 1 Alt= 5 #EPs= 2 Cls=e0(wlcon) Sub=01 Prot=01 Driver=btusb
+E:  Ad=03(O) Atr=01(Isoc) MxPS=  49 Ivl=1ms
+E:  Ad=83(I) Atr=01(Isoc) MxPS=  49 Ivl=1ms
+
+Signed-off-by: Helmut Grohne <helmut@subdivi.de>
+Link: https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1955351
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+---
+ drivers/bluetooth/btusb.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/bluetooth/btusb.c
++++ b/drivers/bluetooth/btusb.c
+@@ -458,6 +458,8 @@ static const struct usb_device_id blackl
+ 	/* Additional Realtek 8761BU Bluetooth devices */
+ 	{ USB_DEVICE(0x0b05, 0x190e), .driver_info = BTUSB_REALTEK |
+ 	  					     BTUSB_WIDEBAND_SPEECH },
++	{ USB_DEVICE(0x2550, 0x8761), .driver_info = BTUSB_REALTEK |
++						     BTUSB_WIDEBAND_SPEECH },
+ 
+ 	/* Additional Realtek 8821AE Bluetooth devices */
+ 	{ USB_DEVICE(0x0b05, 0x17dc), .driver_info = BTUSB_REALTEK },


### PR DESCRIPTION
Add support for RTL8761B USB bluetooth devices.  These are cheap and easy to find. Tested on a WNDR3700v4 with rtl8761bu firmware. Would love to have this backported to 22.03 if possible after it hits master.

Note without the correct firmware `hciconfig hci0 up` gives `Can't init device hci0: Out of memory (12)`.
