### PR TITLE
[22.03] ramips: rt3883: enable lzma-loader for Belkin F9K1109v1

### DIFF
--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -18,6 +18,7 @@ endef
 TARGET_DEVICES += asus_rt-n56u
 
 define Device/belkin_f9k1109v1
+  $(Device/uimage-lzma-loader)
   SOC := rt3883
   BLOCKSIZE := 64k
   DEVICE_VENDOR := Belkin
@@ -25,7 +26,6 @@ define Device/belkin_f9k1109v1
   DEVICE_VARIANT := Version 1.0
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport
   IMAGE_SIZE := 7808k
-  KERNEL := kernel-bin | append-dtb | lzma -d16 | uImage lzma
   # Stock firmware checks for this uImage image name during upload.
   UIMAGE_NAME := N750F9K1103VB
 endef


### PR DESCRIPTION
User **lobotron** [reported on the forums](https://forum.openwrt.org/t/rt3883-based-belkin-f9k1109-gets-lzma-error-1-v22-03-and-v21-02-release/140155) that the last usable OpenWrt release is the 19.07 for the device in subject.
Backport commit ac296f621058119501ccd54e7cb2a243af5dc5a0 to previous OpenWrt releases.

This PR is for **openwrt-22.03**.
Original issue: #10968