### PR TITLE
ath79: move common usb led trigger node to SOC dtsi

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -7,6 +7,7 @@ on:
       - 'include/kernel*'
       - 'package/kernel/**'
       - 'target/linux/generic/**'
+      - 'target/linux/ath79/**'
   push:
     paths:
       - '.github/workflows/kernel.yml'
@@ -59,6 +60,7 @@ jobs:
             FIRST=0
           done
           JSON="$JSON"']'
+          JSON='["ath79/generic","ath79/nand","ath79/tiny","ath79/mikrotik"]'
 
            echo -e "\n---- targets ----\n"
            echo "$JSON"
@@ -172,10 +174,12 @@ jobs:
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
         run: |
-          echo CONFIG_ALL_KMODS=y >> .config
           echo CONFIG_DEVEL=y >> .config
           echo CONFIG_AUTOREMOVE=y >> .config
           echo CONFIG_CCACHE=y >> .config
+          echo CONFIG_TARGET_MULTI_PROFILE=y >> .config
+          echo CONFIG_TARGET_ALL_PROFILES=y >> .config
+          echo CONFIG_TARGET_PER_DEVICE_ROOTFS=y >> .config
 
           ./scripts/ext-toolchain.sh \
             --toolchain ${{ env.TOOLCHAIN_FILE }}/toolchain-* \
@@ -202,10 +206,10 @@ jobs:
         working-directory: openwrt
         run: make target/compile -j$(nproc) BUILD_LOG=1 || ret=$? .github/workflows/scripts/show_build_failures.sh
 
-      - name: Build Kernel Kmods
+      - name: Build images to test dts syntax
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
-        run: make package/linux/compile -j$(nproc) BUILD_LOG=1 || ret=$? .github/workflows/scripts/show_build_failures.sh
+        run: make -j$(nproc) BUILD_LOG=1 || ret=$? .github/workflows/scripts/show_build_failures.sh
 
       - name: Upload logs
         if: failure()

--- a/target/linux/ath79/dts/ar7100.dtsi
+++ b/target/linux/ath79/dts/ar7100.dtsi
@@ -156,6 +156,11 @@
 
 		#address-cells = <1>;
 		#size-cells = <0>;
+
+		usb_ehci_port: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
 	};
 
 	usb1: usb@1c000000 {
@@ -172,6 +177,11 @@
 
 		#address-cells = <1>;
 		#size-cells = <0>;
+
+		usb_ohci_port: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
 	};
 
 	spi: spi@1f000000 {

--- a/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
+++ b/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
@@ -170,25 +170,11 @@
 };
 
 &usb1 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	usb_ohci_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb2 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	usb_ehci_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &pcie0 {

--- a/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
+++ b/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
@@ -122,25 +122,11 @@
 };
 
 &usb1 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	usb_ohci_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb2 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	usb_ehci_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar7161_netgear_wndr.dtsi
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr.dtsi
@@ -116,25 +116,11 @@
 };
 
 &usb1 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	usb_ohci_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb2 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	usb_ehci_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &pcie0 {

--- a/target/linux/ath79/dts/ar7161_ubnt_routerstation.dtsi
+++ b/target/linux/ath79/dts/ar7161_ubnt_routerstation.dtsi
@@ -99,22 +99,8 @@
 
 &usb1 {
 	status = "okay";
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	usb_ohci_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb2 {
 	status = "okay";
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	usb_ehci_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };

--- a/target/linux/ath79/dts/ar7240.dtsi
+++ b/target/linux/ath79/dts/ar7240.dtsi
@@ -32,6 +32,11 @@
 
 		#address-cells = <1>;
 		#size-cells = <0>;
+
+		hub_port: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
 	};
 };
 

--- a/target/linux/ath79/dts/ar7241.dtsi
+++ b/target/linux/ath79/dts/ar7241.dtsi
@@ -39,6 +39,11 @@
 
 		#address-cells = <1>;
 		#size-cells = <0>;
+
+		hub_port: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
 	};
 };
 

--- a/target/linux/ath79/dts/ar7241_netgear_wnr2200.dtsi
+++ b/target/linux/ath79/dts/ar7241_netgear_wnr2200.dtsi
@@ -183,12 +183,5 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };

--- a/target/linux/ath79/dts/ar7241_tplink_tl-mr3x20.dtsi
+++ b/target/linux/ath79/dts/ar7241_tplink_tl-mr3x20.dtsi
@@ -25,14 +25,7 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
+++ b/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
@@ -78,14 +78,7 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar7242.dtsi
+++ b/target/linux/ath79/dts/ar7242.dtsi
@@ -39,6 +39,11 @@
 
 		#address-cells = <1>;
 		#size-cells = <0>;
+
+		hub_port: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
 	};
 };
 

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
@@ -135,12 +135,5 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g302h-a1a0.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g302h-a1a0.dts
@@ -210,14 +210,7 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &art {

--- a/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
+++ b/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
@@ -125,14 +125,7 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar7242_ubnt_sw.dtsi
+++ b/target/linux/ath79/dts/ar7242_ubnt_sw.dtsi
@@ -114,14 +114,7 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &pcie {

--- a/target/linux/ath79/dts/ar9132.dtsi
+++ b/target/linux/ath79/dts/ar9132.dtsi
@@ -152,6 +152,14 @@
 			phys = <&usb_phy>;
 
 			status = "disabled";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			hub_port: port@1 {
+				reg = <1>;
+				#trigger-source-cells = <0>;
+			};
 		};
 
 		spi: spi@1f000000 {

--- a/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh.dtsi
+++ b/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh.dtsi
@@ -246,14 +246,6 @@
 
 &usb {
 	status = "okay";
-
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
@@ -74,14 +74,7 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -129,6 +129,11 @@
 
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			hub_port: port@1 {
+				reg = <1>;
+				#trigger-source-cells = <0>;
+			};
 		};
 
 		spi: spi@1f000000 {

--- a/target/linux/ath79/dts/ar9331_arduino_yun.dts
+++ b/target/linux/ath79/dts/ar9331_arduino_yun.dts
@@ -57,7 +57,7 @@
 		usb {
 			label = "white:usb";
 			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
-			trigger-sources = <&hub_port1>;
+			trigger-sources = <&hub_port>;
 			linux,default-trigger = "usbport";
 		};
 	};
@@ -125,22 +125,8 @@
 &usb {
 	status = "okay";
 
-	#address-cells = <1>;
-	#size-cells = <0>;
 	dr_mode = "host";
 	vbus-supply = <&reg_usb_vbus>;
-
-	port@1 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <1>;
-		#trigger-source-cells = <0>;
-
-		hub_port1: port@1 {
-			reg = <1>;
-			#trigger-source-cells = <0>;
-		};
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr3020-v1.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr3020-v1.dts
@@ -86,16 +86,9 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	dr_mode = "host";
 	vbus-supply = <&reg_usb_vbus>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
@@ -82,16 +82,9 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	dr_mode = "host";
 	vbus-supply = <&reg_usb_vbus>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar9341_tplink_tl-mr3420-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-mr3420-v2.dts
@@ -82,14 +82,7 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
@@ -83,14 +83,7 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar9344_atheros_db120.dts
+++ b/target/linux/ath79/dts/ar9344_atheros_db120.dts
@@ -41,7 +41,7 @@
 		usb {
 			label = "green:usb";
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
-			trigger-sources = <&hub_port1>;
+			trigger-sources = <&hub_port>;
 			linux,default-trigger = "usbport";
 		};
 	};
@@ -219,14 +219,6 @@
 
 &usb {
 	status = "okay";
-
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	hub_port1: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar9344_dlink_dir-825-c1.dts
+++ b/target/linux/ath79/dts/ar9344_dlink_dir-825-c1.dts
@@ -28,7 +28,7 @@
 			label = "blue:usb";
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "usbport";
-			trigger-sources = <&hub_port1>;
+			trigger-sources = <&hub_port>;
 		};
 
 		wan_blue {

--- a/target/linux/ath79/dts/ar9344_dlink_dir-8x5.dtsi
+++ b/target/linux/ath79/dts/ar9344_dlink_dir-8x5.dtsi
@@ -119,13 +119,6 @@
 
 &usb {
 	status = "okay";
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	hub_port1: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar9344_netgear_r6100.dts
+++ b/target/linux/ath79/dts/ar9344_netgear_r6100.dts
@@ -192,14 +192,6 @@
 
 &usb {
 	status = "okay";
-
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar9344_netgear_wndr_usb.dtsi
+++ b/target/linux/ath79/dts/ar9344_netgear_wndr_usb.dtsi
@@ -24,11 +24,4 @@
 
 &usb {
 	status = "okay";
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };

--- a/target/linux/ath79/dts/ar9344_pcs_cr5000.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cr5000.dts
@@ -106,13 +106,6 @@
 
 &usb {
 	status = "okay";
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	hub_port1: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar9344_teltonika_rut9xx.dtsi
+++ b/target/linux/ath79/dts/ar9344_teltonika_rut9xx.dtsi
@@ -113,29 +113,26 @@
 };
 
 &usb {
+	status = "okay";
+};
+
+&hub_port {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	status = "okay";
 
 	port@1 {
-		#address-cells = <1>;
-		#size-cells = <0>;
+		compatible = "usb-a-connector";
 		reg = <1>;
+	};
 
-		port@1 {
-			compatible = "usb-a-connector";
-			reg = <1>;
-		};
+	port@3 {
+		label = "RS-232 serial adapter";
+		reg = <3>;
+	};
 
-		port@3 {
-			label = "RS-232 serial adapter";
-			reg = <3>;
-		};
-
-		port@4 {
-			label = "internal wwan modem";
-			reg = <4>;
-		};
+	port@4 {
+		label = "internal wwan modem";
+		reg = <4>;
 	};
 };
 

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr3500-v1.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr3500-v1.dts
@@ -42,14 +42,7 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
@@ -53,25 +53,21 @@
 };
 
 &usb {
+	status = "okay";
+};
+
+&hub_port {
 	#address-cells = <1>;
 	#size-cells = <0>;
-	status = "okay";
 
-	port@1 {
-		#address-cells = <1>;
-		#size-cells = <0>;
+	hub_port1: port@1 {
 		reg = <1>;
 		#trigger-source-cells = <0>;
+	};
 
-		hub_port1: port@1 {
-			reg = <1>;
-			#trigger-source-cells = <0>;
-		};
-
-		hub_port2: port@2 {
-			reg = <2>;
-			#trigger-source-cells = <0>;
-		};
+	hub_port2: port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
 	};
 };
 

--- a/target/linux/ath79/dts/ar9344_wd_mynet-n750.dts
+++ b/target/linux/ath79/dts/ar9344_wd_mynet-n750.dts
@@ -69,26 +69,7 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	port@1 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <1>;
-		#trigger-source-cells = <0>;
-
-		hub_port1: port@1 {
-			reg = <1>;
-			#trigger-source-cells = <0>;
-		};
-
-		hub_port2: port@2 {
-			reg = <2>;
-			#trigger-source-cells = <0>;
-		};
-	};
 };
 
 &mdio0 {

--- a/target/linux/ath79/dts/ar9344_winchannel_wb2000.dts
+++ b/target/linux/ath79/dts/ar9344_winchannel_wb2000.dts
@@ -46,7 +46,7 @@
 		usb {
 			label = "green:usb";
 			gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
-			trigger-sources = <&hub_port1>, <&hub_port2>;
+			trigger-sources = <&hub_port>;
 			linux,default-trigger = "usbport";
 		};
 
@@ -150,26 +150,7 @@
 };
 
 &usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	port@1 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <1>;
-		#trigger-source-cells = <0>;
-
-		hub_port1: port@1 {
-			reg = <1>;
-			#trigger-source-cells = <0>;
-		};
-
-		hub_port2: port@2 {
-			reg = <2>;
-			#trigger-source-cells = <0>;
-		};
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -178,6 +178,11 @@
 
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			hub_port: port@1 {
+				reg = <1>;
+				#trigger-source-cells = <0>;
+			};
 		};
 
 		nand: nand@1b000200 {

--- a/target/linux/ath79/dts/qca9531_alfa-network_r36a.dtsi
+++ b/target/linux/ath79/dts/qca9531_alfa-network_r36a.dtsi
@@ -111,14 +111,6 @@
 
 &usb0 {
 	status = "okay";
-
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/qca9531_comfast_cf-e5.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e5.dts
@@ -62,14 +62,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/qca9531_comfast_cf-e560ac.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e560ac.dts
@@ -135,14 +135,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &eth0 {

--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar300m.dtsi
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar300m.dtsi
@@ -142,8 +142,6 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	vbus-supply = <&reg_usb_vbus>;
 	status = "okay";
 };

--- a/target/linux/ath79/dts/qca9531_glinet_gl-x750.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-x750.dts
@@ -60,14 +60,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/qca9531_teltonika_rut300.dts
+++ b/target/linux/ath79/dts/qca9531_teltonika_rut300.dts
@@ -107,14 +107,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/qca9531_tplink_archer-d50-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_archer-d50-v1.dts
@@ -178,14 +178,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &romfile {

--- a/target/linux/ath79/dts/qca9531_tplink_tl-mr3420-v3.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-mr3420-v3.dts
@@ -102,7 +102,7 @@
 		usb {
 			label = "green:usb";
 			gpios = <&led_gpio 7 GPIO_ACTIVE_LOW>;
-			trigger-sources = <&hub_port>;
+			trigger-sources = <&hub_port0>;
 			linux,default-trigger = "usbport";
 		};
 
@@ -190,14 +190,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/qca9531_tplink_tl-mr6400-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-mr6400-v1.dts
@@ -148,14 +148,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/qca9531_tplink_tl-wr902ac-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-wr902ac-v1.dts
@@ -178,14 +178,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &info {

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr842n-v3.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr842n-v3.dts
@@ -71,7 +71,7 @@
 			label = "green:usb";
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "usbport";
-			trigger-sources = <&hub_port>;
+			trigger-sources = <&hub_port0>;
 		};
 	};
 
@@ -95,14 +95,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -206,6 +206,11 @@
 
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			hub_port0: port@1 {
+				reg = <1>;
+				#trigger-source-cells = <0>;
+			};
 		};
 
 		spi: spi@1f000000 {

--- a/target/linux/ath79/dts/qca9557_8dev_rambutan.dts
+++ b/target/linux/ath79/dts/qca9557_8dev_rambutan.dts
@@ -110,9 +110,6 @@
 
 &usb0 {
 	status = "okay";
-
-	#address-cells = <1>;
-	#size-cells = <0>;
 };
 
 &usb_phy1 {
@@ -121,9 +118,6 @@
 
 &usb1 {
 	status = "okay";
-
-	#address-cells = <1>;
-	#size-cells = <0>;
 };
 
 &art {

--- a/target/linux/ath79/dts/qca9558_belkin_f9x-v2.dtsi
+++ b/target/linux/ath79/dts/qca9558_belkin_f9x-v2.dtsi
@@ -104,14 +104,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &spi {

--- a/target/linux/ath79/dts/qca9558_domywifi_dw33d.dts
+++ b/target/linux/ath79/dts/qca9558_domywifi_dw33d.dts
@@ -76,14 +76,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy1 {
@@ -91,14 +84,7 @@
 };
 
 &usb1 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port1: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &spi {

--- a/target/linux/ath79/dts/qca9558_librerouter_librerouter-v1.dts
+++ b/target/linux/ath79/dts/qca9558_librerouter_librerouter-v1.dts
@@ -84,8 +84,6 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
 };
 
@@ -94,8 +92,6 @@
 };
 
 &usb1 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
 };
 

--- a/target/linux/ath79/dts/qca9558_sitecom_wlr-8100.dts
+++ b/target/linux/ath79/dts/qca9558_sitecom_wlr-8100.dts
@@ -136,8 +136,6 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
 };
 

--- a/target/linux/ath79/dts/qca9558_sophos_ap.dtsi
+++ b/target/linux/ath79/dts/qca9558_sophos_ap.dtsi
@@ -169,9 +169,4 @@
 
 &usb0 {
 	vbus-supply = <&reg_usb_vbus>;
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c.dtsi
@@ -85,14 +85,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy1 {
@@ -100,14 +93,7 @@
 };
 
 &usb1 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port1: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &spi {

--- a/target/linux/ath79/dts/qca9558_tplink_archer-d7.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-d7.dtsi
@@ -141,16 +141,9 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	dr_mode = "host";
 	vbus-supply = <&reg_usb0_vbus>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy1 {
@@ -158,14 +151,7 @@
 };
 
 &usb1 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	dr_mode = "host";
 	vbus-supply = <&reg_usb1_vbus>;
 	status = "okay";
-
-	hub_port1: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
@@ -109,14 +109,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy1 {
@@ -124,14 +117,7 @@
 };
 
 &usb1 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port1: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &spi {

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
@@ -77,14 +77,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &spi {

--- a/target/linux/ath79/dts/qca9558_trendnet_tew-823dru.dts
+++ b/target/linux/ath79/dts/qca9558_trendnet_tew-823dru.dts
@@ -72,14 +72,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy1 {
@@ -87,14 +80,7 @@
 };
 
 &usb1 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port1: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &spi {

--- a/target/linux/ath79/dts/qca955x.dtsi
+++ b/target/linux/ath79/dts/qca955x.dtsi
@@ -268,6 +268,11 @@
 
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			hub_port0: port@1 {
+				reg = <1>;
+				#trigger-source-cells = <0>;
+			};
 		};
 
 		usb1: usb@1b400000 {
@@ -289,6 +294,11 @@
 
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			hub_port1: port@1 {
+				reg = <1>;
+				#trigger-source-cells = <0>;
+			};
 		};
 
 		nand: nand@1b800200 {

--- a/target/linux/ath79/dts/qca955x_zyxel_nbg6x16.dtsi
+++ b/target/linux/ath79/dts/qca955x_zyxel_nbg6x16.dtsi
@@ -116,19 +116,8 @@
 
 &usb0 {
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
-
 };
 
 &usb1 {
 	status = "okay";
-
-	hub_port1: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c59-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c59-v1.dts
@@ -16,19 +16,12 @@
 		label = "green:usb";
 		gpios = <&led_gpio 7 GPIO_ACTIVE_LOW>;
 		linux,default-trigger = "usbport";
-		trigger-sources = <&hub_port>;
+		trigger-sources = <&hub_port0>;
 	};
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy0 {

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c59-v2.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c59-v2.dts
@@ -16,19 +16,12 @@
 		label =	"green:usb";
 		gpios =	<&led_gpio 7 GPIO_ACTIVE_LOW>;
 		linux,default-trigger =	"usbport";
-		trigger-sources	= <&hub_port>;
+		trigger-sources	= <&hub_port0>;
 	};
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy0 {

--- a/target/linux/ath79/dts/qca9563_netgear_wndr.dtsi
+++ b/target/linux/ath79/dts/qca9563_netgear_wndr.dtsi
@@ -235,14 +235,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &caldata {

--- a/target/linux/ath79/dts/qca9563_netgear_wndr4500-v3.dts
+++ b/target/linux/ath79/dts/qca9563_netgear_wndr4500-v3.dts
@@ -28,12 +28,5 @@
 };
 
 &usb1 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port1: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };

--- a/target/linux/ath79/dts/qca9563_qxwlan_e1700ac.dtsi
+++ b/target/linux/ath79/dts/qca9563_qxwlan_e1700ac.dtsi
@@ -125,14 +125,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy1 {

--- a/target/linux/ath79/dts/qca9563_rosinson_wr818.dts
+++ b/target/linux/ath79/dts/qca9563_rosinson_wr818.dts
@@ -123,14 +123,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy1 {
@@ -138,14 +131,7 @@
 };
 
 &usb1 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	port@2 {
-		reg = <2>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &info {

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c7-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c7-v4.dts
@@ -152,14 +152,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &usb_phy1 {
@@ -167,14 +160,7 @@
 };
 
 &usb1 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port1: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &spi {

--- a/target/linux/ath79/dts/qca9563_tplink_archer-x7-v5.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-x7-v5.dtsi
@@ -108,14 +108,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &spi {

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043nd-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043nd-v4.dts
@@ -94,14 +94,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &eth0 {

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -204,6 +204,11 @@
 
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			hub_port0: port@1 {
+				reg = <1>;
+				#trigger-source-cells = <0>;
+			};
 		};
 
 		usb1: usb@1b400000 {
@@ -226,6 +231,11 @@
 
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			hub_port1: port@1 {
+				reg = <1>;
+				#trigger-source-cells = <0>;
+			};
 		};
 
 		spi: spi@1f000000 {

--- a/target/linux/ath79/dts/qcn5502_tplink_archer-a9-v6.dts
+++ b/target/linux/ath79/dts/qcn5502_tplink_archer-a9-v6.dts
@@ -227,14 +227,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &wmac {


### PR DESCRIPTION
These frequently used usb led triggers are universal, so it's better to move them to SOC dtsi. Just like the ramips target.