### PR TITLE
[22.03] ramips: Correct Unielec 01 and 06 dts wan macaddr byte location

### DIFF
--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
@@ -53,7 +53,7 @@
 };
 
 &gmac1 {
-	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
 };
 

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-06-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-06-16m.dts
@@ -58,7 +58,7 @@
 };
 
 &gmac1 {
-	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
 };
 

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-06-64m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-06-64m.dts
@@ -59,7 +59,7 @@
 };
 
 &gmac1 {
-	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
 };
 


### PR DESCRIPTION
Recent backport patch b5cb5f352d3133ac8384275be7d47264ad135e74 had missed changing the wan macaddr_factory address location.

This patch corrects the address location.

Signed-off-by: David Bentham <db260179@gmail.com>
