### PR TITLE
uhttpd: use procd to reload on acem renew

### DIFF
--- a/package/network/services/uhttpd/Makefile
+++ b/package/network/services/uhttpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uhttpd
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uhttpd.git
@@ -113,8 +113,6 @@ define Package/uhttpd/install
 	$(VERSION_SED_SCRIPT) $(1)/etc/config/uhttpd
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/uhttpd $(1)/usr/sbin/uhttpd
-	$(INSTALL_DIR) $(1)/etc/hotplug.d/acme
-	$(INSTALL_DATA) ./files/acme.hotplug $(1)/etc/hotplug.d/acme/00-uhttpd
 endef
 
 define Package/uhttpd-mod-lua/install

--- a/package/network/services/uhttpd/files/acme.hotplug
+++ b/package/network/services/uhttpd/files/acme.hotplug
@@ -1,3 +1,0 @@
-if [ "$ACTION" = renewed ]; then
-	/etc/init.d/uhttpd reload
-fi

--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -222,6 +222,7 @@ start_instance()
 service_triggers()
 {
 	procd_add_reload_trigger "uhttpd"
+	procd_add_raw_trigger acme.renew 5000 /etc/init.d/uhttpd reload
 }
 
 start_service() {


### PR DESCRIPTION
Calling /etc/init.d/uhttpd reload directly in the acme hotplug script can inadvertently start a stopped instance.

Signed-off-by: Glen Huang <i@glenhuang.com>

cc @tohojo