### PR TITLE
 ipq40xx: Convert openmesh,a42 + openmesh,a62 to DSA + nvmem-cells

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -159,7 +159,6 @@ ipq40xx_setup_macs()
 	pakedge,wr-1)
 		wan_mac=$(macaddr_add $(get_mac_label) 1)
 		;;
-	openmesh,a42|\
 	openmesh,a62)
 		label_mac="$(mtd_get_mac_binary "0:ART" 0x0)"
 		;;

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -159,9 +159,6 @@ ipq40xx_setup_macs()
 	pakedge,wr-1)
 		wan_mac=$(macaddr_add $(get_mac_label) 1)
 		;;
-	openmesh,a62)
-		label_mac="$(mtd_get_mac_binary "0:ART" 0x0)"
-		;;
 	esac
 
 	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -70,7 +70,8 @@ ipq40xx_setup_interfaces()
 	netgear,srs60)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
-	openmesh,a42)
+	openmesh,a42|\
+	openmesh,a62)
 		ucidef_set_interfaces_lan_wan "ethernet2" "ethernet1"
 		;;
 	zte,mf286d)
@@ -158,7 +159,8 @@ ipq40xx_setup_macs()
 	pakedge,wr-1)
 		wan_mac=$(macaddr_add $(get_mac_label) 1)
 		;;
-	openmesh,a42)
+	openmesh,a42|\
+	openmesh,a62)
 		label_mac="$(mtd_get_mac_binary "0:ART" 0x0)"
 		;;
 	esac

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -70,6 +70,9 @@ ipq40xx_setup_interfaces()
 	netgear,srs60)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
+	openmesh,a42)
+		ucidef_set_interfaces_lan_wan "ethernet2" "ethernet1"
+		;;
 	zte,mf286d)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "wan"
 		;;
@@ -154,6 +157,9 @@ ipq40xx_setup_macs()
 	netgear,srs60|\
 	pakedge,wr-1)
 		wan_mac=$(macaddr_add $(get_mac_label) 1)
+		;;
+	openmesh,a42)
+		label_mac="$(mtd_get_mac_binary "0:ART" 0x0)"
 		;;
 	esac
 

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -77,7 +77,6 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3D000 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
 	cellc,rtl30vw |\
-	openmesh,a42 |\
 	openmesh,a62 |\
 	plasmacloud,pa1200 |\
 	plasmacloud,pa2200)
@@ -173,7 +172,6 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C000 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
 	cellc,rtl30vw |\
-	openmesh,a42 |\
 	openmesh,a62 |\
 	plasmacloud,pa1200 |\
 	plasmacloud,pa2200)

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -34,7 +34,6 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C800 -e 0x212 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1") || \
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C000 -e 0x212 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
-	openmesh,a62 |\
 	plasmacloud,pa2200)
 		caldata_extract "0:ART" 0x9000 0x2f20
 		;;
@@ -77,7 +76,6 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3D000 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
 	cellc,rtl30vw |\
-	openmesh,a62 |\
 	plasmacloud,pa1200 |\
 	plasmacloud,pa2200)
 		caldata_extract "0:ART" 0x1000 0x2f20
@@ -172,7 +170,6 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C000 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
 	cellc,rtl30vw |\
-	openmesh,a62 |\
 	plasmacloud,pa1200 |\
 	plasmacloud,pa2200)
 		caldata_extract "0:ART" 0x5000 0x2f20

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -29,6 +29,10 @@ preinit_set_mac_address() {
 		ip link set dev lan1 address $(macaddr_add "$base_mac" 1)
 		ip link set dev eth0 address $(macaddr_setbit "$base_mac" 7)
 		;;
+	openmesh,a42)
+		ip link set dev ethernet1 address $(mtd_get_mac_binary "0:ART" 0x0)
+		ip link set dev ethernet2 address $(mtd_get_mac_binary "0:ART" 0x6)
+		;;
 	mikrotik,wap-ac)
 		base_mac=$(cat /sys/firmware/mikrotik/hard_config/mac_base)
 		ip link set dev sw-eth1 address "$base_mac"

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -29,7 +29,6 @@ preinit_set_mac_address() {
 		ip link set dev lan1 address $(macaddr_add "$base_mac" 1)
 		ip link set dev eth0 address $(macaddr_setbit "$base_mac" 7)
 		;;
-	openmesh,a42|\
 	openmesh,a62)
 		ip link set dev ethernet1 address $(mtd_get_mac_binary "0:ART" 0x0)
 		ip link set dev ethernet2 address $(mtd_get_mac_binary "0:ART" 0x6)

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -29,10 +29,6 @@ preinit_set_mac_address() {
 		ip link set dev lan1 address $(macaddr_add "$base_mac" 1)
 		ip link set dev eth0 address $(macaddr_setbit "$base_mac" 7)
 		;;
-	openmesh,a62)
-		ip link set dev ethernet1 address $(mtd_get_mac_binary "0:ART" 0x0)
-		ip link set dev ethernet2 address $(mtd_get_mac_binary "0:ART" 0x6)
-		;;
 	mikrotik,wap-ac)
 		base_mac=$(cat /sys/firmware/mikrotik/hard_config/mac_base)
 		ip link set dev sw-eth1 address "$base_mac"

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -29,7 +29,8 @@ preinit_set_mac_address() {
 		ip link set dev lan1 address $(macaddr_add "$base_mac" 1)
 		ip link set dev eth0 address $(macaddr_setbit "$base_mac" 7)
 		;;
-	openmesh,a42)
+	openmesh,a42|\
+	openmesh,a62)
 		ip link set dev ethernet1 address $(mtd_get_mac_binary "0:ART" 0x0)
 		ip link set dev ethernet2 address $(mtd_get_mac_binary "0:ART" 0x6)
 		;;

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-a42.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-a42.dts
@@ -17,10 +17,6 @@
 			status = "okay";
 		};
 
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@194b000 {
 			/* select hostmode */
 			compatible = "qcom,tcsr";
@@ -164,6 +160,28 @@
 
 &usb2_hs_phy {
 	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+	label = "ethernet2";
+};
+
+&swport5 {
+	status = "okay";
+	label = "ethernet1";
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-a42.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-a42.dts
@@ -71,6 +71,7 @@
 		led-failsafe = &led_status_green;
 		led-running = &led_status_green;
 		led-upgrade = &led_status_green;
+		label-mac-device = &swport5;
 	};
 
 	leds {
@@ -144,7 +145,32 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <24000000>;
+
 		/* partitions are passed via bootloader */
+		partitions {
+			partition-art {
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				label = "0:ART";
+
+				precal_art_1000: precal@1000 {
+					reg = <0x1000 0x2f20>;
+				};
+
+				precal_art_5000: precal@5000 {
+					reg = <0x5000 0x2f20>;
+				};
+
+				macaddr_gmac0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_gmac1: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
+			};
+		};
 	};
 };
 
@@ -177,19 +203,31 @@
 &swport4 {
 	status = "okay";
 	label = "ethernet2";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac1>;
 };
 
 &swport5 {
 	status = "okay";
 	label = "ethernet1";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &wifi0 {
 	status = "okay";
 	qcom,ath10k-calibration-variant = "OM-A42";
+
+	nvmem-cell-names = "pre-calibration";
+	nvmem-cells = <&precal_art_1000>;
 };
 
 &wifi1 {
 	status = "okay";
 	qcom,ath10k-calibration-variant = "OM-A42";
+
+	nvmem-cell-names = "pre-calibration";
+	nvmem-cells = <&precal_art_5000>;
 };

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-a62.dts
@@ -17,10 +17,6 @@
 			status = "okay";
 		};
 
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@194b000 {
 			/* select hostmode */
 			compatible = "qcom,tcsr";
@@ -192,6 +188,28 @@
 			ieee80211-freq-limit = <5170000 5350000>;
 		};
 	};
+};
+
+&mdio {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+	label = "ethernet1";
+};
+
+&swport5 {
+	status = "okay";
+	label = "ethernet2";
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-a62.dts
@@ -71,6 +71,7 @@
 		led-failsafe = &led_status_green;
 		led-running = &led_status_green;
 		led-upgrade = &led_status_green;
+		label-mac-device = &swport4;
 	};
 
 	leds {
@@ -151,7 +152,36 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <24000000>;
+
 		/* partitions are passed via bootloader */
+		partitions {
+			partition-art {
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				label = "0:ART";
+
+				precal_art_1000: precal@1000 {
+					reg = <0x1000 0x2f20>;
+				};
+
+				precal_art_5000: precal@5000 {
+					reg = <0x5000 0x2f20>;
+				};
+
+				precal_art_9000: precal@9000 {
+					reg = <0x9000 0x2f20>;
+				};
+
+				macaddr_gmac0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_gmac1: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
+			};
+		};
 	};
 };
 
@@ -186,6 +216,9 @@
 			reg = <0x00010000 0 0 0 0>;
 			qcom,ath10k-calibration-variant = "OM-A62";
 			ieee80211-freq-limit = <5170000 5350000>;
+
+			nvmem-cell-names = "pre-calibration";
+			nvmem-cells = <&precal_art_9000>;
 		};
 	};
 };
@@ -205,20 +238,32 @@
 &swport4 {
 	status = "okay";
 	label = "ethernet1";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &swport5 {
 	status = "okay";
 	label = "ethernet2";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac1>;
 };
 
 &wifi0 {
 	status = "okay";
 	qcom,ath10k-calibration-variant = "OM-A62";
+
+	nvmem-cell-names = "pre-calibration";
+	nvmem-cells = <&precal_art_1000>;
 };
 
 &wifi1 {
 	status = "okay";
 	qcom,ath10k-calibration-variant = "OM-A62";
 	ieee80211-freq-limit = <5470000 5875000>;
+
+	nvmem-cell-names = "pre-calibration";
+	nvmem-cells = <&precal_art_5000>;
 };

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -875,8 +875,7 @@ define Device/openmesh_a42
 	IMAGE/factory.bin := append-rootfs | pad-rootfs | openmesh-image ce_type=A42
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += openmesh_a42
+TARGET_DEVICES += openmesh_a42
 
 define Device/openmesh_a62
 	$(call Device/FitImageLzma)

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -891,8 +891,7 @@ define Device/openmesh_a62
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
 	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += openmesh_a62
+TARGET_DEVICES += openmesh_a62
 
 define Device/p2w_r619ac
 	$(call Device/FitzImage)


### PR DESCRIPTION
* ethernet1:
  - physical port label "Ethernet 1"
  - can be used to power the device
  - its mac address is printed on the device label
* ethernet2:
  - physical port label "Ethernet 2"

Both ports are not marked by there role (because the vendor firmware automatically detects roles) but the "Ethernet 1" port was used in the past for "WAN" functionality in OpenWrt.

As requested by @robimarko, it is also using nvmem to access the precal data + mac addresses.