### PR TITLE
ramips: add support for SNR-CPE-W4N-MT router

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -72,6 +72,11 @@ linksys,ea8100-v2|\
 mts,wg430223)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
 	;;
+snr,cpe-w4n-mt)
+	idx="$(find_mtd_index uboot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x1000"
+	;;
 xiaomi,mi-router-3g-v2|\
 xiaomi,mi-router-4a-gigabit|\
 xiaomi,miwifi-3c)

--- a/target/linux/ramips/dts/mt7620n_snr_cpe-w4n-mt.dts
+++ b/target/linux/ramips/dts/mt7620n_snr_cpe-w4n-mt.dts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "snr,cpe-w4n-mt", "ralink,mt7620n-soc";
+	model = "SNR-CPE-W4N (rev.M)";
+
+	aliases {
+		led-boot = &led_wps;
+		led-failsafe = &led_sys;
+		led-running = &led_wps;
+		led-upgrade = &led_sys;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: sys {
+			label = "green:sys";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>; // GPIO#38
+			panic-indicator;
+		};
+
+		led_wps: wps {
+			label = "green:wps";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>; // GPIO#39
+		};
+
+		wlan {
+			label = "green:wlan";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>; // GPIO#72
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset Button";
+			gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>; // GPIO#1
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <48000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "Factory";
+				reg = <0x40000 0x100000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+
+			partition@30000_1 {
+				label = "uboot-env";
+				reg = <0x30000 0x1000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "spi refclk";
+		function = "gpio";
+	};
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1091,6 +1091,17 @@ define Device/sitecom_wlr-4100-v1-002
 endef
 TARGET_DEVICES += sitecom_wlr-4100-v1-002
 
+define Device/snr_cpe-w4n-mt
+  $(Device/uimage-lzma-loader)
+  SOC := mt7620n
+  IMAGE_SIZE := 7360k
+  DEVICE_VENDOR := SNR
+  DEVICE_MODEL := CPE-W4N
+  DEVICE_VARIANT := MT
+  UIMAGE_NAME := SNR-CPE-W4N-MT
+endef
+TARGET_DEVICES += snr_cpe-w4n-mt
+
 define Device/tplink_archer-c20i
   $(Device/tplink-v2)
   SOC := mt7620a

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -150,6 +150,11 @@ kingston,mlwg2|\
 sanlinking,d240)
 	ucidef_set_led_netdev "wifi_led" "wifi" "blue:wifi" "wlan0"
 	;;
+snr,cpe-w4n-mt)
+	ucidef_set_led_heartbeat "wps" "WPS" "green:wps"
+	ucidef_set_led_timer "sys" "System" "green:sys" "500" "500"
+	ucidef_set_led_wlan "wlan" "Wi-Fi" "green:wlan" "phy0tpt"
+	;;
 lenovo,newifi-y1)
 	ucidef_set_led_netdev "wifi" "WIFI" "blue:wifi" "wlan1"
 	ucidef_set_led_netdev "wifi5g" "WIFI5G" "blue:wifi5g" "wlan0"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -85,6 +85,7 @@ ramips_setup_interfaces()
 	glinet,gl-mt300n|\
 	glinet,gl-mt750|\
 	hiwifi,hc5661|\
+	snr,cpe-w4n-mt|\
 	wrtnode,wrtnode|\
 	zbtlink,zbt-wa05|\
 	zyxel,keenetic-omni-ii)
@@ -374,6 +375,11 @@ ramips_setup_macs()
 		;;
 	linksys,e1700)
 		wan_mac=$(mtd_get_mac_ascii config WAN_MAC_ADDR)
+		;;
+	snr,cpe-w4n-mt)
+		lan_mac=$(mtd_get_mac_binary Factory 0x28)
+		wan_mac=$(mtd_get_mac_binary Factory 0x2e)
+		label_mac=$wan_mac
 		;;
 	tplink,archer-c2-v1|\
 	tplink,archer-c20-v1|\


### PR DESCRIPTION
General specification:
- SoC Type: MediaTek MT7620N (580MHz)
- ROM: 8 MB SPI-NOR (W25Q64FV)
- RAM: 64 MB DDR (M13S5121632A)
- Switch: MediaTek MT7530
- Ethernet: 5 ports - 5×100MbE (WAN, LAN1-4)
- Wireless 2.4 GHz: b/g/n
- Buttons: 1 button (RESET)
- Bootloader: U-Boot 1.1.3, MediaTek U-Boot: 5.0.0.5
- Power: 12 VDC, 1.0 A

Flash by the native uploader in 2 stages:
1. Use the native uploader to flash an initramfs image. Choose
 openwrt-ramips-mt7620-snr_cpe-w4n-mt-initramfs-kernel.bin file by
 "Administration/Management/Firmware update/Choose File" in vendor's
 web interface (ip: 192.168.1.10, login: Admin, password: Admin).
 Wait ~160 seconds.
2. Flash a sysupgrade image via the initramfs image. Choose
 openwrt-ramips-mt7620-snr_cpe-w4n-mt-squashfs-sysupgrade.bin
 file by "System/Backup/Flash Firmware/Flash image..." in
 LuCI web interface (ip: 192.168.1.1, login: root, no password).
 Wait ~240 seconds.

Flash by U-Boot TFTP method:
1. Configure your PC with IP 192.168.1.131
2. Set up TFTP server and put the
 openwrt-ramips-mt7620-snr_cpe-w4n-mt-squashfs-sysupgrade.bin
 image on your PC
3. Connect serial port (57600 8N1) and turn on the router.
 Then interrupt "U-Boot Boot Menu" by hitting 2 key (select "2:
 Load system code then write to Flash via TFTP.").
Press Y key when show "Warning!! Erase Linux in Flash then burn
 new one. Are you sure? (Y/N)"
Input device IP (192.168.1.1) ==:192.168.1.1
Input server IP (192.168.1.131) ==:192.168.1.131
Input Linux Kernel filename () ==:
openwrt-ramips-mt7620-snr_cpe-w4n-mt-squashfs-sysupgrade.bin
3. Wait ~120 seconds to complete flashing

Signed-off-by: Alexey Bartenev <41exey@proton.me>

Device topic at forum.openwrt.org [here](https://forum.openwrt.org/t/add-support-for-snr-cpe-w4n-mt/139192)