### PR TITLE
ramips: add support for Amped Wireless B1200EX

### DIFF
--- a/target/linux/ramips/dts/mt7620a_ampedwireless_b1200ex.dts
+++ b/target/linux/ramips/dts/mt7620a_ampedwireless_b1200ex.dts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a_edimax_ew-747x.dtsi"
+
+/ {
+	compatible = "ampedwireless,b1200ex", "ralink,mt7620a-soc";
+	model = "Amped Wireless B1200EX";
+
+	leds {
+		wlan2g {
+			label = "green:wlan2g";
+			gpios = <&gpio2 30 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+
+		wlan5g {
+			label = "green:wlan5g";
+			gpios = <&gpio2 31 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		signal_strength {
+			label = "green:signal_strength";
+			gpios = <&gpio2 29 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7620a_edimax_ew-7476rpc.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_ew-7476rpc.dts
@@ -5,4 +5,39 @@
 / {
 	compatible = "edimax,ew-7476rpc", "ralink,mt7620a-soc";
 	model = "Edimax EW-7476RPC";
+
+	keys {
+		switch_high {
+			label = "switch high";
+			gpios = <&gpio2 22 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		switch_off {
+			label = "switch off";
+			gpios = <&gpio2 23 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+
+	leds {
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio2 30 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio2 31 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		crossband {
+			label = "green:crossband";
+			gpios = <&gpio2 29 GPIO_ACTIVE_LOW>;
+		};
+	};
 };

--- a/target/linux/ramips/dts/mt7620a_edimax_ew-7478ac.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_ew-7478ac.dts
@@ -5,4 +5,39 @@
 / {
 	compatible = "edimax,ew-7478ac", "ralink,mt7620a-soc";
 	model = "Edimax EW-7478AC";
+
+	keys {
+		switch_high {
+			label = "switch high";
+			gpios = <&gpio2 22 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		switch_off {
+			label = "switch off";
+			gpios = <&gpio2 23 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+
+	leds {
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio2 30 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio2 31 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		crossband {
+			label = "green:crossband";
+			gpios = <&gpio2 29 GPIO_ACTIVE_LOW>;
+		};
+	};
 };

--- a/target/linux/ramips/dts/mt7620a_edimax_ew-747x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_edimax_ew-747x.dtsi
@@ -24,20 +24,6 @@
 			gpios = <&gpio2 20 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
-
-		switch_high {
-			label = "switch high";
-			gpios = <&gpio2 22 GPIO_ACTIVE_LOW>;
-			linux,code = <BTN_0>;
-			linux,input-type = <EV_SW>;
-		};
-
-		switch_off {
-			label = "switch off";
-			gpios = <&gpio2 23 GPIO_ACTIVE_LOW>;
-			linux,code = <BTN_1>;
-			linux,input-type = <EV_SW>;
-		};
 	};
 
 	leds {
@@ -53,26 +39,9 @@
 			gpios = <&gpio2 26 GPIO_ACTIVE_LOW>;
 		};
 
-		wlan2g {
-			label = "blue:wlan2g";
-			gpios = <&gpio2 30 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1radio";
-		};
-
-		wlan5g {
-			label = "blue:wlan5g";
-			gpios = <&gpio2 31 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0radio";
-		};
-
 		wps {
 			label = "green:wps";
 			gpios = <&gpio2 28 GPIO_ACTIVE_LOW>;
-		};
-
-		crossband {
-			label = "green:crossband";
-			gpios = <&gpio2 29 GPIO_ACTIVE_LOW>;
 		};
 	};
 };
@@ -206,6 +175,8 @@
 
 &wmac {
 	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
 };
 
 &pcie {
@@ -216,7 +187,10 @@
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
-		mediatek,2ghz = <0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&macaddr_factory_4>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <2>;
 	};
 };
 

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -75,6 +75,19 @@ define Device/amit_jboot
   DEVICE_PACKAGES := jboot-tools kmod-usb2 kmod-usb-ohci
 endef
 
+define Device/ampedwireless_b1200ex
+  SOC := mt7620a
+  DEVICE_VENDOR := Amped Wireless
+  DEVICE_MODEL := B1200EX
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 7744k
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
+	edimax-header -s CSYS -m RN10 -f 0x70000 -S 0x01100000 | pad-rootfs | \
+	check-size | append-metadata
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-phy-realtek
+endef
+TARGET_DEVICES += ampedwireless_b1200ex
+
 define Device/asus_rp-n53
   SOC := mt7620a
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -101,6 +101,7 @@ edimax,br-6478ac-v2|\
 edimax,ew-7478apc)
 	ucidef_set_led_netdev "wifi_led" "wifi" "blue:wlan" "wlan0"
 	;;
+ampedwireless,b1200ex|\
 edimax,ew-7476rpc|\
 edimax,ew-7478ac)
 	ucidef_set_led_switch "lan" "lan" "green:lan"  "switch0" "0x20"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -38,6 +38,7 @@ ramips_setup_interfaces()
 			"3:lan" "4:wan" "6@eth0"
 		;;
 	alfa-network,tube-e4g|\
+	ampedwireless,b1200ex|\
 	buffalo,wmr-300|\
 	dlink,dch-m225|\
 	edimax,ew-7476rpc|\


### PR DESCRIPTION
This device is almost identical to the already supported Edimax EW-7476RP5, the only differences are:
- There is no mode selection slider switch on this device
- The two wireless LEDs are green instead of blue
- Model name in the CSYS header is RN10

Additional changes:
- Moved WiFi LEDs and the slider switch to the individual dt files
- Added ieee80211-freq-limit to the mt7612e radio to properly disable 2.4GHz band on this radio

Device specifications:
SoC:	MediaTek MT7620a @ 580MHz
RAM:	64M (Winbond W9751G6KB-25)
FLASH:	8MB (Macronix)
WiFi:	SoC-integrated: MediaTek MT7620a bgn
WiFi:	MediaTek MT7612EN nac
GbE:	1x (RTL8211E)
BTN:	WPS/RESET
LED:	- WiFi 5G (green)
	- WiFi 2.4G (green)
	- Signal Strength (green)
	- Power (green)
	- WPS (green)
	- LAN (green) UART:	UART is present as Pads with throughholes on the PCB. They are
	located next to the WPS button
	3.3V - RX - GND - TX / 57600-8N1
	3.3V is the square pad

Installation:
Upload the sysupgrade image via the default web interface
