### PR TITLE
ipq40xx: Convert plasmacloud,pa1200 + plasmacloud,pa2200 to DSA + nvmem-cells

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -77,7 +77,8 @@ ipq40xx_setup_interfaces()
 	openmesh,a62)
 		ucidef_set_interfaces_lan_wan "ethernet2" "ethernet1"
 		;;
-	plasmacloud,pa1200)
+	plasmacloud,pa1200|\
+	plasmacloud,pa2200)
 		ucidef_set_interfaces_lan_wan "ethernet1" "ethernet2"
 		;;
 	zte,mf286d)

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -77,6 +77,9 @@ ipq40xx_setup_interfaces()
 	openmesh,a62)
 		ucidef_set_interfaces_lan_wan "ethernet2" "ethernet1"
 		;;
+	plasmacloud,pa1200)
+		ucidef_set_interfaces_lan_wan "ethernet1" "ethernet2"
+		;;
 	zte,mf286d)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "wan"
 		;;

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -76,7 +76,6 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3D000 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
 	cellc,rtl30vw |\
-	plasmacloud,pa1200 |\
 	plasmacloud,pa2200)
 		caldata_extract "0:ART" 0x1000 0x2f20
 		;;
@@ -171,7 +170,6 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C000 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
 	cellc,rtl30vw |\
-	plasmacloud,pa1200 |\
 	plasmacloud,pa2200)
 		caldata_extract "0:ART" 0x5000 0x2f20
 		;;

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -34,9 +34,6 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C800 -e 0x212 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1") || \
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C000 -e 0x212 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
-	plasmacloud,pa2200)
-		caldata_extract "0:ART" 0x9000 0x2f20
-		;;
 	linksys,ea8300 |\
 	linksys,mr8300)
 		caldata_extract "ART" 0x9000 0x2f20
@@ -75,8 +72,7 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C800 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1") || \
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3D000 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
-	cellc,rtl30vw |\
-	plasmacloud,pa2200)
+	cellc,rtl30vw)
 		caldata_extract "0:ART" 0x1000 0x2f20
 		;;
 	devolo,magic-2-wifi-next)
@@ -169,8 +165,7 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3D000 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1") || \
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C000 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
-	cellc,rtl30vw |\
-	plasmacloud,pa2200)
+	cellc,rtl30vw)
 		caldata_extract "0:ART" 0x5000 0x2f20
 		;;
 	devolo,magic-2-wifi-next)

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-pa1200.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-pa1200.dts
@@ -140,7 +140,32 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <24000000>;
+
 		/* partitions are passed via bootloader */
+		partitions {
+			partition-art {
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				label = "0:ART";
+
+				precal_art_1000: precal@1000 {
+					reg = <0x1000 0x2f20>;
+				};
+
+				precal_art_5000: precal@5000 {
+					reg = <0x5000 0x2f20>;
+				};
+
+				macaddr_gmac0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_gmac1: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
+			};
+		};
 	};
 };
 
@@ -161,9 +186,15 @@
 &wifi0 {
 	status = "okay";
 	qcom,ath10k-calibration-variant = "PlasmaCloud-PA1200";
+
+	nvmem-cell-names = "pre-calibration";
+	nvmem-cells = <&precal_art_1000>;
 };
 
 &wifi1 {
 	status = "okay";
 	qcom,ath10k-calibration-variant = "PlasmaCloud-PA1200";
+
+	nvmem-cell-names = "pre-calibration";
+	nvmem-cells = <&precal_art_5000>;
 };

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-pa1200.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-pa1200.dts
@@ -17,10 +17,6 @@
 			status = "okay";
 		};
 
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@194b000 {
 			/* select hostmode */
 			compatible = "qcom,tcsr";
@@ -75,6 +71,7 @@
 		led-failsafe = &led_status_yellow;
 		led-running = &led_status_cyan;
 		led-upgrade = &led_status_yellow;
+		label-mac-device = &swport5;
 	};
 
 	leds {
@@ -181,6 +178,34 @@
 
 &usb2_hs_phy {
 	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+	label = "ethernet2";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac1>;
+};
+
+&swport5 {
+	status = "okay";
+	label = "ethernet1";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-pa2200.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-pa2200.dts
@@ -17,10 +17,6 @@
 			status = "okay";
 		};
 
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -63,6 +59,7 @@
 		led-failsafe = &led_status_blue;
 		led-running = &led_power_orange;
 		led-upgrade = &led_status_blue;
+		label-mac-device = &swport4;
 	};
 
 	leds {
@@ -205,6 +202,34 @@
 			nvmem-cells = <&precal_art_9000>;
 		};
 	};
+};
+
+&mdio {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+	label = "ethernet1";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0>;
+};
+
+&swport5 {
+	status = "okay";
+	label = "ethernet2";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac1>;
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-pa2200.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-pa2200.dts
@@ -140,7 +140,36 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <24000000>;
+
 		/* partitions are passed via bootloader */
+		partitions {
+			partition-art {
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				label = "0:ART";
+
+				precal_art_1000: precal@1000 {
+					reg = <0x1000 0x2f20>;
+				};
+
+				precal_art_5000: precal@5000 {
+					reg = <0x5000 0x2f20>;
+				};
+
+				precal_art_9000: precal@9000 {
+					reg = <0x9000 0x2f20>;
+				};
+
+				macaddr_gmac0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_gmac1: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
+			};
+		};
 	};
 };
 
@@ -171,6 +200,9 @@
 			reg = <0x00010000 0 0 0 0>;
 			qcom,ath10k-calibration-variant = "PlasmaCloud-PA2200";
 			ieee80211-freq-limit = <5170000 5350000>;
+
+			nvmem-cell-names = "pre-calibration";
+			nvmem-cells = <&precal_art_9000>;
 		};
 	};
 };
@@ -178,10 +210,16 @@
 &wifi0 {
 	status = "okay";
 	qcom,ath10k-calibration-variant = "PlasmaCloud-PA2200";
+
+	nvmem-cell-names = "pre-calibration";
+	nvmem-cells = <&precal_art_1000>;
 };
 
 &wifi1 {
 	status = "okay";
 	qcom,ath10k-calibration-variant = "PlasmaCloud-PA2200";
 	ieee80211-freq-limit = <5470000 5875000>;
+
+	nvmem-cell-names = "pre-calibration";
+	nvmem-cells = <&precal_art_5000>;
 };

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -974,8 +974,7 @@ define Device/plasmacloud_pa2200
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
 	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += plasmacloud_pa2200
+TARGET_DEVICES += plasmacloud_pa2200
 
 define Device/qcom_ap-dk01.1-c1
 	DEVICE_VENDOR := Qualcomm Atheros

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -958,8 +958,7 @@ define Device/plasmacloud_pa1200
 	IMAGE/factory.bin := append-rootfs | pad-rootfs | openmesh-image ce_type=PA1200
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += plasmacloud_pa1200
+TARGET_DEVICES += plasmacloud_pa1200
 
 define Device/plasmacloud_pa2200
 	$(call Device/FitImageLzma)


### PR DESCRIPTION
Based on #11078 to avoid some minor conflicts. But can also create a separate branch with only the plasmacloud patches when this is preferred.

* ethernet1:
  - physical port label "Ethernet 1"
  - its mac address is printed on the device label
* ethernet2:
  - physical port label "Ethernet 2"
  - can be used to power the device

Both ports are not marked by there role (because the vendor firmware automatically detects roles) but the "Ethernet 2" port was used in the past for "WAN" functionality in OpenWrt.

As requested by @robimarko, it is also using nvmem to access the precal data + mac addresses.