### PR TITLE
RFT: realtek: Fix CRC offloading for rtl83xx

### DIFF
--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -2247,7 +2247,7 @@ static int rtl83xx_set_features(struct net_device *dev, netdev_features_t featur
 		if (!(features & NETIF_F_RXCSUM))
 			sw_w32_mask(BIT(3), 0, priv->r->mac_port_ctrl(priv->cpu_port));
 		else
-			sw_w32_mask(0, BIT(4), priv->r->mac_port_ctrl(priv->cpu_port));
+			sw_w32_mask(0, BIT(3), priv->r->mac_port_ctrl(priv->cpu_port));
 	}
 
 	return 0;


### PR DESCRIPTION
In rtl83xx_set_features we set bit 3 to enable, and bit 4 to disable checksuming. Looking at rtl93xx_set_features we however see that for both enable and disable the same bit is used (bit 4). This can't be right, especially as bit 4 for rtl83xx seems to be Collision threshold occupying 2 bits. Change this to make this more logical.

Fixes: 9e8d62e42117 ("realtek: enable CRC offloading")
Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>

@svanheule I haven't tested this as I do not have the hardware, however should be testable using netif controls it seems? Logically, this seems to be broken, but not sure if this is a copy/paste error from the SDK, or from the rtl93xx set feature code ...

And yes, magic bit values, but that is already pushed to a different MR :) and I wanted to keep this fix short and simple.