### PR TITLE
RFT: realtek: Fix duplex on rtl83xx

### DIFF
--- a/target/linux/realtek/files-5.10/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.10/drivers/net/dsa/rtl83xx/dsa.c
@@ -2,6 +2,7 @@
 
 #include <net/dsa.h>
 #include <linux/if_bridge.h>
+#include <uapi/linux/ethtool.h>
 
 #include <asm/mach-rtl838x/mach-rtl83xx.h>
 #include "rtl83xx.h"
@@ -463,9 +464,9 @@ static int rtl83xx_phylink_mac_link_state(struct dsa_switch *ds, int port,
 		state->link = 1;
 	pr_debug("%s: link state port %d: %llx\n", __func__, port, link & BIT_ULL(port));
 
-	state->duplex = 0;
+	state->duplex = DUPLEX_HALF;
 	if (priv->r->get_port_reg_le(priv->r->mac_link_dup_sts) & BIT_ULL(port))
-		state->duplex = 1;
+		state->duplex = DUPLEX_FULL;
 
 	speed = priv->r->get_port_reg_le(priv->r->mac_link_spd_sts(port));
 	speed >>= (port % 16) << 1;
@@ -530,9 +531,9 @@ static int rtl93xx_phylink_mac_link_state(struct dsa_switch *ds, int port,
 	pr_debug("%s: link state port %d: %llx, media %llx\n", __func__, port,
 		 link & BIT_ULL(port), media);
 
-	state->duplex = 0;
+	state->duplex = DUPLEX_HALF;
 	if (priv->r->get_port_reg_le(priv->r->mac_link_dup_sts) & BIT_ULL(port))
-		state->duplex = 1;
+		state->duplex = DUPLEX_FULL;
 
 	speed = priv->r->get_port_reg_le(priv->r->mac_link_spd_sts(port));
 	speed >>= (port % 8) << 2;
@@ -565,7 +566,7 @@ static int rtl93xx_phylink_mac_link_state(struct dsa_switch *ds, int port,
 		&& (port >= 52 || port <= 55)) { /* Internal serdes */
 			state->speed = SPEED_10000;
 			state->link = 1;
-			state->duplex = 1;
+			state->duplex = DUPLEX_FULL;
 	}
 
 	pr_debug("%s: speed is: %d %d\n", __func__, (u32)speed & 0xf, state->speed);

--- a/target/linux/realtek/files-5.10/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.10/drivers/net/dsa/rtl83xx/dsa.c
@@ -691,13 +691,13 @@ static void rtl83xx_phylink_mac_config(struct dsa_switch *ds, int port,
 		reg &= ~(RTL838X_DUPLEX_MODE | RTL838X_FORCE_LINK_EN);
 		if (state->link)
 			reg |= RTL838X_FORCE_LINK_EN;
-		if (state->duplex == RTL838X_DUPLEX_MODE)
+		if (state->duplex == DUPLEX_FULL)
 			reg |= RTL838X_DUPLEX_MODE;
 	} else if (priv->family_id == RTL8390_FAMILY_ID) {
 		reg &= ~(RTL839X_DUPLEX_MODE | RTL839X_FORCE_LINK_EN);
 		if (state->link)
 			reg |= RTL839X_FORCE_LINK_EN;
-		if (state->duplex == RTL839X_DUPLEX_MODE)
+		if (state->duplex == DUPLEX_FULL)
 			reg |= RTL839X_DUPLEX_MODE;
 	}
 

--- a/target/linux/realtek/files-5.10/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-5.10/drivers/net/phy/rtl83xx-phy.c
@@ -460,7 +460,7 @@ static int rtl8226_read_status(struct phy_device *phydev)
 	val = phy_read_mmd(phydev, MMD_VEND2, 0xA434);
 	if (val < 0)
 		goto out;
-	phydev->duplex = !!(val & BIT(3));
+	phydev->duplex = (val & BIT(3)) == BIT(3) ? DUPLEX_FULL : DUPLEX_HALF;
 
 	// Read speed
 	val = phy_read_mmd(phydev, MMD_VEND2, 0xA434);


### PR DESCRIPTION
@svanheule a quick fix on duplexity. Also here, I can't test this. According to the code however, this can't work in its current form, so I'm curious how this is working right now, especially since 1000M doesn't even do half duplex afaik, and we're always executing half-duplex configuration. Could be that the content of that if is reversed however, so forcing half-duplex, works full, and vice versa  ... the register `RTL838X_DUPLEX_MODE` should be 1 in case of full duplex mode however.