### PR TITLE
package: uboot: adjust LS1012A-IOT config and env

### DIFF
--- a/package/boot/uboot-layerscape/files/fsl_ls1021a-iot-sdboot-uEnv.txt
+++ b/package/boot/uboot-layerscape/files/fsl_ls1021a-iot-sdboot-uEnv.txt
@@ -2,7 +2,7 @@ fdtaddr=0x8f000000
 loadaddr=0x81000000
 fdt_high=0x8fffffff
 initrd_high=0xffffffff
-sd_boot=ext4load mmc 0:1 $loadaddr fitImage;bootm $loadaddr
+sd_boot=ext4load mmc 0:1 ${loadaddr} fitImage;bootm ${loadaddr}
 bootargs=root=/dev/mmcblk0p2 rw rootwait rootfstype=squashfs,f2fs noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200
 bootcmd=echo starting openwrt ...;run sd_boot
 bootdelay=3

--- a/package/boot/uboot-layerscape/patches/0900-layerscape-adjust-LS1021A-IOT-config-for-OpenWrt.patch
+++ b/package/boot/uboot-layerscape/patches/0900-layerscape-adjust-LS1021A-IOT-config-for-OpenWrt.patch
@@ -1,0 +1,52 @@
+From b382eeafe01df21da3518b2f1dd7d22ee114efb0 Mon Sep 17 00:00:00 2001
+From: Pawel Dembicki <paweldembicki@gmail.com>
+Date: Mon, 24 Oct 2022 14:19:38 +0200
+Subject: [PATCH] layerscape: adjust LS1021A-IOT config for OpenWrt
+
+Two configs are required:
+  - FIT
+  - Ext4load
+
+Let's enable it. U-boot is now bigger than 512K. Let's enlarge it to
+768K. Envs start at 1M, so it will fit.
+
+Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
+---
+ configs/ls1021aiot_sdcard_defconfig | 3 +++
+ include/configs/ls1021aiot.h        | 4 ++--
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/configs/ls1021aiot_sdcard_defconfig b/configs/ls1021aiot_sdcard_defconfig
+index e541c9c69bfc..2d9789debfa4 100644
+--- a/configs/ls1021aiot_sdcard_defconfig
++++ b/configs/ls1021aiot_sdcard_defconfig
+@@ -27,8 +27,11 @@ CONFIG_CMD_MII=y
+ # CONFIG_CMD_MDIO is not set
+ CONFIG_CMD_PING=y
+ CONFIG_CMD_EXT2=y
++CONFIG_CMD_EXT4=y
+ CONFIG_CMD_FAT=y
+ # CONFIG_SPL_EFI_PARTITION is not set
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
+ CONFIG_OF_CONTROL=y
+ CONFIG_ENV_OVERWRITE=y
+ CONFIG_ENV_IS_IN_MMC=y
+diff --git a/include/configs/ls1021aiot.h b/include/configs/ls1021aiot.h
+index e2ae6e46c071..1dbfe6db5af2 100644
+--- a/include/configs/ls1021aiot.h
++++ b/include/configs/ls1021aiot.h
+@@ -78,8 +78,8 @@
+ 		CONFIG_SYS_MONITOR_LEN)
+ #define CONFIG_SYS_SPL_MALLOC_SIZE	0x100000
+ #define CONFIG_SPL_BSS_START_ADDR	0x80100000
+-#define CONFIG_SPL_BSS_MAX_SIZE		0x80000
+-#define CONFIG_SYS_MONITOR_LEN		0x80000
++#define CONFIG_SPL_BSS_MAX_SIZE		0xc0000
++#define CONFIG_SYS_MONITOR_LEN		0xc0000
+ #endif
+ 
+ #define CONFIG_SYS_DDR_SDRAM_BASE	0x80000000UL
+-- 
+2.25.1
+


### PR DESCRIPTION
In a254279a6c30 LS1012A-IOT kernel image was switched to FIT.

But u-boot config is lack of FIT and ext4 support.

This patch enables it.

It also fix envs, because for some reason this board need to use "loadaddr" variable in brackets.

Fixes: #9894
Fixes: a254279a6c30 ("layerscape: Change to combined rootfs on sd images")

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>