### PR TITLE
ramips: gl-mt1300: downclock SPI to 50MHz

### DIFF
--- a/target/linux/ramips/dts/mt7621_glinet_gl-mt1300.dts
+++ b/target/linux/ramips/dts/mt7621_glinet_gl-mt1300.dts
@@ -67,8 +67,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
-		m25p,fast-read;
+		spi-max-frequency = <50000000>;
 		broken-flash-reset;
 
 		partitions {


### PR DESCRIPTION
The SPI max frequency was set to 80MHz, considerably higher than the vendor clocks it in their firmware (10MHz).  Multiple users reported jffs2 corruption/instability in GitHub issue #10461.

My unit has a W25Q256; datasheet specifies maximum SPI frequency for read command of 50MHz.

Signed-off-by: Michael Lyle <mlyle@lyle.org>

Fixes #10461