### PR TITLE
uhttpd: fix 413 when content length is a multiple of 4096

### DIFF
--- a/package/network/services/uhttpd/Makefile
+++ b/package/network/services/uhttpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uhttpd
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uhttpd.git

--- a/package/network/services/uhttpd/patches/001-fix-413.patch
+++ b/package/network/services/uhttpd/patches/001-fix-413.patch
@@ -1,0 +1,10 @@
+--- a/client.c
++++ b/client.c
+@@ -532,6 +532,7 @@ void uh_client_read_cb(struct client *cl
+ 
+ 		if (!read_cbs[cl->state](cl, str, len)) {
+ 			if (len == us->r.buffer_len &&
++			    cl->state != CLIENT_STATE_DONE &&
+ 			    cl->state != CLIENT_STATE_DATA)
+ 				uh_header_error(cl, 413, "Request Entity Too Large");
+ 			break;


### PR DESCRIPTION
fix https://github.com/openwrt/luci/issues/2051

Signed-off-by: Liangbin Lian <jjm2473@gmail.com>