### PR TITLE
package/system/procd/files/service: pass all arguments to service

### DIFF
--- a/package/system/procd/files/service
+++ b/package/system/procd/files/service
@@ -2,17 +2,17 @@
 
 main() {
 	local service="$1"
-	local cmd="$2"
+	shift
 
 	local boot status
 
 	if [ -f "/etc/init.d/${service}" ]; then
-		/etc/init.d/"${service}" "${cmd}"
+		/etc/init.d/"${service}" "$@"
 		exit "$?"
 	fi
 
 	if [ -n "$service" ]; then
-		echo "Service \"$1\" not found:"
+		echo "Service \"$service\" not found:"
 		exit 1
 	fi
 


### PR DESCRIPTION
After upgrading from 21.02 to 22.03 I noticed that the etherwake service was not behaving as it was before. `service etherwake start home` would not actually wake up `home` while `/etc/init.d/etherwake start home` would work just fine. I tracked down the problem to a change in the `service` command between these two versions. This small change fixes the problem, instead of only passing the second argument to `/etc/init.d/$service` we pass all remaining arguments.

Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>

