### PR TITLE
ramips: add support for Youku X2 and improve support for Youku YK-L2 and YK-L1 series

### DIFF
--- a/target/linux/ramips/dts/mt7620a_youku_x2.dts
+++ b/target/linux/ramips/dts/mt7620a_youku_x2.dts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a_youku_yk-l1.dtsi"
+
+/ {
+	compatible = "youku,x2", "ralink,mt7620a-soc";
+	model = "Youku X2";
+};
+
+&ethernet {
+	mediatek,portmap = "wllll";
+};
+
+&firmware {
+	reg = <0x50000 0xfb0000>;
+};
+
+&led_wlan {
+	linux,default-trigger = "phy1tpt";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
@@ -86,8 +86,9 @@
 			};
 
 			firmware: partition@50000 {
-				compatible = "denx,uimage";
+				compatible = "openwrt,uimage", "denx,uimage";
 				label = "firmware";
+				openwrt,ih-magic = <0x12291000>;
 				/* reg property is set based on flash size in DTS files */
 			};
 		};

--- a/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
@@ -15,7 +15,7 @@
 	leds {
 		compatible = "gpio-leds";
 
-		wlan {
+		led_wlan: wlan {
 			label = "blue:wlan";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";

--- a/target/linux/ramips/dts/mt7621_youku_yk-l2.dts
+++ b/target/linux/ramips/dts/mt7621_youku_yk-l2.dts
@@ -95,8 +95,9 @@
 			};
 
 			partition@50000 {
-				compatible = "denx,uimage";
+				compatible = "openwrt,uimage", "denx,uimage";
 				label = "firmware";
+				openwrt,ih-magic = <0x12291000>;
 				reg = <0x50000 0xfb0000>;
 			};
 		};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1281,6 +1281,8 @@ define Device/youku_yk-l1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 \
 	kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += youku-yk1 youku,yk1
+  UIMAGE_MAGIC := 0x12291000
+  UIMAGE_NAME := 400000000000000000000000
 endef
 TARGET_DEVICES += youku_yk-l1
 
@@ -1291,6 +1293,8 @@ define Device/youku_yk-l1c
   DEVICE_MODEL := YK-L1c
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 \
 	kmod-usb-ledtrig-usbport
+  UIMAGE_MAGIC := 0x12291000
+  UIMAGE_NAME := 400000000000000000000000
 endef
 TARGET_DEVICES += youku_yk-l1c
 

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1273,6 +1273,18 @@ define Device/xiaomi_miwifi-mini
 endef
 TARGET_DEVICES += xiaomi_miwifi-mini
 
+define Device/youku_x2
+  SOC := mt7620a
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Youku
+  DEVICE_MODEL := X2
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci \
+	kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
+  UIMAGE_MAGIC := 0x12291000
+  UIMAGE_NAME := 400000000000000000001000
+endef
+TARGET_DEVICES += youku_x2
+
 define Device/youku_yk-l1
   SOC := mt7620a
   IMAGE_SIZE := 32448k

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2251,6 +2251,8 @@ define Device/youku_yk-l2
   DEVICE_MODEL := YK-L2
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
 	kmod-usb-ledtrig-usbport
+  UIMAGE_MAGIC := 0x12291000
+  UIMAGE_NAME := 400000000000000000003000
 endef
 TARGET_DEVICES += youku_yk-l2
 

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -237,6 +237,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"5:lan" "4:wan" "6@eth0"
 		;;
+	youku,x2)
+		ucidef_add_switch "switch0" \
+			"1:lan:2" "4:lan:1" "0:wan" "6@eth0"
+		;;
 	youku,yk-l1|\
 	youku,yk-l1c)
 		ucidef_add_switch "switch0" \
@@ -368,6 +372,7 @@ ramips_setup_macs()
 	ohyeah,oy-0001|\
 	wavlink,wl-wn530hg4|\
 	wevo,air-duo|\
+	youku,x2|\
 	youku,yk-l1|\
 	youku,yk-l1c)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)


### PR DESCRIPTION
Youku X2 Specifications:
-SOC:      MT7620AN + MT7612EN
-RAM:      128 MiB DDR2
-Flash:    16 MiB (Winbond W25Q28FVFG)
-WLAN:     2.4G + 5G
-LAN:      LAN ports *2
-WAN:      WAN port *1
-USB:      USB2.0 *1
-SD Card:  MicroSD *1
-Buttons:  Reset *1
-LEDs: ethernet *3, system, usb, wlan2g, wlan5g

Add UIMAGE_NAME and UIMAGE_MAGIC for YK-L2 and YK-L1 series to allows users to directly apply sysupgrade.bin in the stock firmware Web UI. At the same time, this change makes it possible to boot OpenWrt with the official u-boot.