### PR TITLE
[21.02] kernel: fix handling of xfrm[4|6]_mode_* modules

### DIFF
--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -246,10 +246,11 @@ $(eval $(call KernelPackage,ipsec))
 IPSEC4-m = \
 	ipv4/ah4 \
 	ipv4/esp4 \
-	ipv4/xfrm4_tunnel \
 	ipv4/ipcomp \
-
-IPSEC4-m += $(ifeq ($$(strip $$(call CompareKernelPatchVer,$$(KERNEL_PATCHVER),le,5.2))),ipv4/xfrm4_mode_beet ipv4/xfrm4_mode_transport ipv4/xfrm4_mode_tunnel)
+	ipv4/xfrm4_mode_beet@le5.2 \
+	ipv4/xfrm4_mode_transport@le5.2 \
+	ipv4/xfrm4_mode_tunnel@le5.2 \
+	ipv4/xfrm4_tunnel
 
 define KernelPackage/ipsec4
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
@@ -259,9 +260,9 @@ define KernelPackage/ipsec4
 	CONFIG_INET_AH \
 	CONFIG_INET_ESP \
 	CONFIG_INET_IPCOMP \
-	CONFIG_INET_XFRM_MODE_BEET \
-	CONFIG_INET_XFRM_MODE_TRANSPORT \
-	CONFIG_INET_XFRM_MODE_TUNNEL \
+	CONFIG_INET_XFRM_MODE_BEET@le5.2 \
+	CONFIG_INET_XFRM_MODE_TRANSPORT@le5.2 \
+	CONFIG_INET_XFRM_MODE_TUNNEL@le5.2 \
 	CONFIG_INET_XFRM_TUNNEL \
 	CONFIG_INET_ESP_OFFLOAD=n
   FILES:=$(foreach mod,$(IPSEC4-m),$(LINUX_DIR)/net/$(mod).ko)
@@ -286,10 +287,12 @@ $(eval $(call KernelPackage,ipsec4))
 IPSEC6-m = \
 	ipv6/ah6 \
 	ipv6/esp6 \
-	ipv6/xfrm6_tunnel \
 	ipv6/ipcomp6 \
-
-IPSEC6-m += $(ifeq ($$(strip $$(call CompareKernelPatchVer,$$(KERNEL_PATCHVER),le,5.2))),ipv6/xfrm6_mode_beet ipv6/xfrm6_mode_transport ipv6/xfrm6_mode_tunnel)
+	ipv6/xfrm6_mode_beet@le5.2 \
+	ipv6/xfrm6_mode_ro@le5.2 \
+	ipv6/xfrm6_mode_transport@le5.2 \
+	ipv6/xfrm6_mode_tunnel@le5.2 \
+	ipv6/xfrm6_tunnel
 
 define KernelPackage/ipsec6
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
@@ -299,9 +302,10 @@ define KernelPackage/ipsec6
 	CONFIG_INET6_AH \
 	CONFIG_INET6_ESP \
 	CONFIG_INET6_IPCOMP \
-	CONFIG_INET6_XFRM_MODE_BEET \
-	CONFIG_INET6_XFRM_MODE_TRANSPORT \
-	CONFIG_INET6_XFRM_MODE_TUNNEL \
+	CONFIG_INET6_XFRM_MODE_BEET@le5.2 \
+	CONFIG_INET6_XFRM_MODE_ROUTEOPTIMIZATION@le5.2 \
+	CONFIG_INET6_XFRM_MODE_TRANSPORT@le5.2 \
+	CONFIG_INET6_XFRM_MODE_TUNNEL@le5.2 \
 	CONFIG_INET6_XFRM_TUNNEL \
 	CONFIG_INET6_ESP_OFFLOAD=n
   FILES:=$(foreach mod,$(IPSEC6-m),$(LINUX_DIR)/net/$(mod).ko)
@@ -315,6 +319,7 @@ define KernelPackage/ipsec6/description
  - esp6
  - ipcomp6
  - xfrm6_mode_beet
+ - xfrm6_mode_ro
  - xfrm6_mode_transport
  - xfrm6_mode_tunnel
  - xfrm6_tunnel


### PR DESCRIPTION
For kernel versions before 5.2, the required IPsec modes have to be enabled explicitly (they are built-in for newer kernels).

Commit 1556ed155a9a ("kernel: mode_beet mode_transport mode_tunnel xfram modules") tried to handle this, but it does not really work.

I need this fix, because I'm working on a new target with an external kernel-tree (v4.19) on openwrt-21.02.
