### PR TITLE
realtek: Fix rtl930x speed status accessor

### DIFF
--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
@@ -348,7 +348,7 @@ inline u32 rtl839x_get_mac_link_spd_sts(int port)
 
 inline u32 rtl930x_get_mac_link_spd_sts(int port)
 {
-	int r = RTL930X_MAC_LINK_SPD_STS + ((port / 10) << 2);
+	int r = RTL930X_MAC_LINK_SPD_STS + ((port >> 3) << 2);
 	u32 speed = sw_r32(r);
 
 	speed >>= (port % 10) * 3;


### PR DESCRIPTION
The rtl930x speed status registers require 4 bits to indicate the speed status. As such, we want to divide by 8. To make things consistent with the rest of this code, use a bitshift however.

This bug probably won't affect many users yet, as there aren't many rtl930x switches in the wild yet with more then 10 ports, and thus a low-impact bugfix.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>