### PR TITLE
kmod-rtl88x2bu: Add support for rtl88x2bu driver

### DIFF
--- a/package/kernel/rtl88x2bu/Makefile
+++ b/package/kernel/rtl88x2bu/Makefile
@@ -1,0 +1,53 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rtl88x2bu
+PKG_RELEASE=1
+
+PKG_LICENSE:=GPLv2
+PKG_LICENSE_FILES:=
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/morrownr/88x2bu-20210702.git
+PKG_MIRROR_HASH:=d8bc277348cf97a1b645e2c1c07c9a0dcb9ce5796b7fd5bdce87d19b5f3e17bb
+PKG_SOURCE_DATE:=2022-10-19
+PKG_SOURCE_VERSION:=73a681a0db4a9ad132f85d567e225374c1e6a12b
+
+PKG_BUILD_PARALLEL:=1
+
+STAMP_CONFIGURED_DEPENDS := $(STAGING_DIR)/usr/include/mac80211-backport/backport/autoconf.h
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/rtl88x2bu
+  SUBMENU:=Wireless Drivers
+  TITLE:=Driver for Realtek 88x2bu devices
+  DEPENDS:=+kmod-cfg80211 +kmod-usb-core +@DRIVER_11N_SUPPORT +@DRIVER_11AC_SUPPORT
+  FILES:=\
+	$(PKG_BUILD_DIR)/88x2bu.ko
+  AUTOLOAD:=$(call AutoProbe,88x2bu)
+  PROVIDES:=kmod-rtl88x2bu
+endef
+
+NOSTDINC_FLAGS := \
+	$(KERNEL_NOSTDINC_FLAGS) \
+	-I$(PKG_BUILD_DIR) \
+	-I$(PKG_BUILD_DIR)/include \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \
+	-I$(STAGING_DIR)/usr/include/mac80211 \
+	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
+	-include backport/backport.h
+
+NOSTDINC_FLAGS+=-DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT -DBUILD_OPENWRT
+
+define Build/Compile
+	+$(MAKE) $(PKG_JOBS) -C "$(LINUX_DIR)" \
+		$(KERNEL_MAKE_FLAGS) \
+		M="$(PKG_BUILD_DIR)" \
+		NOSTDINC_FLAGS="$(NOSTDINC_FLAGS)" \
+		CONFIG_RTL8822BU=m \
+		modules
+endef
+
+$(eval $(call KernelPackage,rtl88x2bu))

--- a/package/kernel/rtl88x2bu/patches/001-use-kernel-byteorder.patch
+++ b/package/kernel/rtl88x2bu/patches/001-use-kernel-byteorder.patch
@@ -1,0 +1,15 @@
+Fix compile problem when rtw_byteorder.h and asm/byteorder.h gets 
+included in addition for example indirectly, do not use realtek own copy 
+of the byteorder headers.
+
+--- a/include/drv_types.h
++++ b/include/drv_types.h
+@@ -30,7 +30,7 @@
+ #include <drv_conf.h>
+ #include <basic_types.h>
+ #include <osdep_service.h>
+-#include <rtw_byteorder.h>
++#include <asm/byteorder.h>
+ #include <wlan_bssdef.h>
+ #include <wifi.h>
+ #include <ieee80211.h>

--- a/package/kernel/rtl88x2bu/patches/002-use-kernel-wireless-header.patch
+++ b/package/kernel/rtl88x2bu/patches/002-use-kernel-wireless-header.patch
@@ -1,0 +1,31 @@
+Fix wireless.h to use linux kernel header files
+including uapi version of wireless.h
+
+--- a/include/linux/wireless.h
++++ b/include/linux/wireless.h
+@@ -18,16 +18,17 @@
+ 
+ /***************************** INCLUDES *****************************/
+ 
+-#if 0
++#if 1
+ 	#include <linux/types.h>		/* for __u* and __s* typedefs */
+ 	#include <linux/socket.h>		/* for "struct sockaddr" et al	*/
+ 	#include <linux/if.h>			/* for IFNAMSIZ and co... */
++	#include <linux/wireless.h>
++	#include <uapi/linux/wireless.h>
+ #else
+ 	#define __user
+ 	/* typedef uint16_t	__u16; */
+ 	#include <sys/socket.h>			/* for "struct sockaddr" et al	*/
+ 	#include <net/if.h>			/* for IFNAMSIZ and co... */
+-#endif
+ 
+ /****************************** TYPES ******************************/
+ #ifdef CONFIG_COMPAT
+@@ -84,4 +85,5 @@ struct	iwreq {
+ 	union	iwreq_data	u;
+ };
+ 
++#endif
+ #endif	/* _LINUX_WIRELESS_H */

--- a/package/kernel/rtl88x2bu/temp.txt
+++ b/package/kernel/rtl88x2bu/temp.txt
@@ -1,0 +1,8 @@
+\\
+	-I$(PKG_BUILD_DIR) \
+	-I$(PKG_BUILD_DIR)/include 
+	-I$(STAGING_DIR)/usr/include/mac80211-backport \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \
+	-I$(STAGING_DIR)/usr/include/mac80211 \
+	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
+	-include backport/backport.h


### PR DESCRIPTION
This package add support for morrownr's rtl88x2bu driver. The 88x2bu driver adds support for various Realtek-based chips. See morrownr's repo https://github.com/morrownr/88x2bu-20210702 for a list of supported devices. This, for example, includes TP-Link's T3U Plus.

Signed-off-by: Alexander Lochmann <alexander.lochmann@tu-dortmund.de>