### PR TITLE
base-files: add 'isup' to the wifi script

### DIFF
--- a/package/base-files/files/sbin/wifi
+++ b/package/base-files/files/sbin/wifi
@@ -17,8 +17,8 @@ ubus_wifi_cmd() {
 	local dev="$2"
 
 	json_init
-	[ -n "$2" ] && json_add_string device "$2"
-	ubus call network.wireless "$1" "$(json_dump)"
+	[ -n "$dev" ] && json_add_string device "$dev"
+	ubus call network.wireless "$cmd" "$(json_dump)"
 }
 
 find_net_config() {(

--- a/package/base-files/files/sbin/wifi
+++ b/package/base-files/files/sbin/wifi
@@ -6,7 +6,7 @@
 
 usage() {
 	cat <<EOF
-Usage: $0 [config|up|down|reconf|reload|status]
+Usage: $0 [config|up|down|reconf|reload|status|isup]
 enables (default), disables or configures devices not yet configured.
 EOF
 	exit 1
@@ -19,6 +19,22 @@ ubus_wifi_cmd() {
 	json_init
 	[ -n "$dev" ] && json_add_string device "$dev"
 	ubus call network.wireless "$cmd" "$(json_dump)"
+}
+
+wifi_isup() {
+	local dev="$1"
+
+	json_load "$(ubus_wifi_cmd "status" "$dev")"
+	json_get_keys devices
+
+	for device in $devices; do
+		json_select "$device"
+			json_get_var up up
+			[ $up -eq 0 ] && return 1
+		json_select ..
+	done
+
+	return 0
 }
 
 find_net_config() {(
@@ -245,6 +261,7 @@ case "$1" in
 	detect) wifi_detect_notice ;;
 	config) wifi_config ;;
 	status) ubus_wifi_cmd "status" "$2";;
+	isup) wifi_isup "$2"; exit $?;;
 	reload) wifi_reload "$2";;
 	reload_legacy) wifi_reload_legacy "$2";;
 	--help|help) usage;;


### PR DESCRIPTION
This is a silent command that allows easy wifi up/down automation for scripts.

It takes one or multiple devices as arguments (or all if none are passed), and the exit code indicates if any of those is not up.

E.g.:
wifi isup && echo "all wifi devices are up"
wifi isup radio0 || echo "this wifi is down"