### PR TITLE
ramips: add support for Rostelecom RT-SF-1

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -32,7 +32,8 @@ ampedwireless,ally-r1900k)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000" "4"
 	;;
 beeline,smartbox-giga|\
-beeline,smartbox-turbo)
+beeline,smartbox-turbo|\
+rostelecom,rt-sf-1)
 	ubootenv_add_uci_config "/dev/mtd0" "0x80000" "0x1000" "0x20000"
 	;;
 buffalo,wsr-1166dhp|\

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo.dts
@@ -1,183 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "mt7621.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
+#include "mt7621_sercomm_dxx_nand_256m.dtsi"
 
 / {
 	compatible = "beeline,smartbox-turbo", "mediatek,mt7621-soc";
 	model = "Beeline SmartBox TURBO";
-
-	aliases {
-		label-mac-device = &gmac0;
-
-		led-boot = &led_status_green;
-		led-failsafe = &led_status_red;
-		led-running = &led_status_green;
-		led-upgrade = &led_status_red;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led-1 {
-			label = "blue:wan";
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_WAN;
-			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
-		};
-
-		led_status_green: led-0 {
-			label = "green:status";
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
-		};
-
-		led_status_red: led-2 {
-			label = "red:status";
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		wps {
-			label = "wps";
-			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
-			linux,code = <KEY_WPS_BUTTON>;
-		};
-
-		reset {
-			label = "reset";
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-	};
-
-	ubi-concat {
-		compatible = "mtd-concat";
-		devices = <&ubiconcat0 &ubiconcat1 &ubiconcat2 \
-			&ubiconcat3>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "ubi";
-				reg = <0x0 0xca00000>;
-			};
-		};
-	};
-};
-
-&nand {
-	status = "okay";
-
-	partitions {
-		compatible = "sercomm,sc-partitions", "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		partition@0 {
-			label = "u-boot";
-			reg = <0x0 0x100000>;
-			sercomm,scpart-id = <0>;
-			read-only;
-		};
-
-		partition@100000 {
-			label = "dynamic partition map";
-			reg = <0x100000 0x100000>;
-			sercomm,scpart-id = <1>;
-			read-only;
-		};
-
-		factory: partition@200000 {
-			label = "Factory";
-			reg = <0x200000 0x100000>;
-			sercomm,scpart-id = <2>;
-			read-only;
-
-			compatible = "nvmem-cells";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			macaddr_factory_21000: macaddr@21000 {
-				reg = <0x21000 0x6>;
-			};
-		};
-
-		partition@300000 {
-			label = "Boot Flag";
-			reg = <0x300000 0x100000>;
-			sercomm,scpart-id = <3>;
-		};
-
-		partition@400000 {
-			label = "kernel";
-			reg = <0x400000 0x600000>;
-			sercomm,scpart-id = <4>;
-		};
-
-		partition@a00000 {
-			label = "Kernel 2";
-			reg = <0xa00000 0x600000>;
-			sercomm,scpart-id = <5>;
-			read-only;
-		};
-
-		ubiconcat0: partition@1000000 {
-			label = "File System 1";
-			reg = <0x1000000 0x2000000>;
-			sercomm,scpart-id = <6>;
-		};
-
-		partition@3000000 {
-			label = "File System 2";
-			reg = <0x3000000 0x2000000>;
-			sercomm,scpart-id = <7>;
-			read-only;
-		};
-
-		ubiconcat1: partition@5000000 {
-			label = "Configuration/log";
-			reg = <0x5000000 0x1400000>;
-			sercomm,scpart-id = <8>;
-		};
-
-		ubiconcat2: partition@6400000 {
-			label = "Debug (Ftool)";
-			reg = <0x6400000 0x1a00000>;
-			sercomm,scpart-id = <9>;
-		};
-
-		ubiconcat3: partition@8000000 {
-			label = "container";
-			reg = <0x8000000 0x7c00000>;
-			sercomm,scpart-id = <10>;
-		};
-	};
-};
-
-&pcie {
-	status = "okay";
 };
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
-		ieee80211-freq-limit = <5000000 6000000>;
-
 		nvmem-cells = <&macaddr_factory_21000>;
 		nvmem-cell-names = "mac-address";
 		mac-address-increment = <(5)>;
@@ -186,69 +17,14 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
-		ieee80211-freq-limit = <2400000 2500000>;
-
 		nvmem-cells = <&macaddr_factory_21000>;
 		nvmem-cell-names = "mac-address";
 		mac-address-increment = <(4)>;
 	};
 };
 
-&gmac0 {
-	nvmem-cells = <&macaddr_factory_21000>;
-	nvmem-cell-names = "mac-address";
-};
-
 &gmac1 {
-	status = "okay";
-	label = "wan";
-	phy-handle = <&ethphy0>;
-
 	nvmem-cells = <&macaddr_factory_21000>;
 	nvmem-cell-names = "mac-address";
 	mac-address-increment = <(1)>;
-};
-
-&mdio {
-	ethphy0: ethernet-phy@0 {
-		reg = <0>;
-	};
-};
-
-&switch0 {
-	ports {
-		port@1 {
-			status = "okay";
-			label = "lan1";
-		};
-
-		port@2 {
-			status = "okay";
-			label = "lan2";
-		};
-
-		port@3 {
-			status = "okay";
-			label = "lan3";
-		};
-
-		port@4 {
-			status = "okay";
-			label = "lan4";
-		};
-	};
-};
-
-&uartlite3 {
-	status = "okay";
-};
-
-&state_default {
-	gpio {
-		groups = "jtag", "uart2";
-		function = "gpio";
-	};
 };

--- a/target/linux/ramips/dts/mt7621_rostelecom_rt-sf-1.dts
+++ b/target/linux/ramips/dts/mt7621_rostelecom_rt-sf-1.dts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_sercomm_dxx_nand_256m.dtsi"
+
+/ {
+	compatible = "rostelecom,rt-sf-1", "mediatek,mt7621-soc";
+	model = "Rostelecom RT-SF-1";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		nvmem-cells = <&macaddr_factory_21000>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <(3)>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		nvmem-cells = <&macaddr_factory_21000>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <(2)>;
+	};
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr_factory_21000>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <(11)>;
+};

--- a/target/linux/ramips/dts/mt7621_sercomm_dxx_nand_256m.dtsi
+++ b/target/linux/ramips/dts/mt7621_sercomm_dxx_nand_256m.dtsi
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		label-mac-device = &gmac0;
+
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-1 {
+			label = "blue:wan";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_green: led-0 {
+			label = "green:status";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: led-2 {
+			label = "red:status";
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1 &ubiconcat2 \
+			&ubiconcat3>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0xca00000>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "sercomm,sc-partitions", "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x100000>;
+			sercomm,scpart-id = <0>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "dynamic partition map";
+			reg = <0x100000 0x100000>;
+			sercomm,scpart-id = <1>;
+			read-only;
+		};
+
+		factory: partition@200000 {
+			label = "Factory";
+			reg = <0x200000 0x100000>;
+			sercomm,scpart-id = <2>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_factory_21000: macaddr@21000 {
+				reg = <0x21000 0x6>;
+			};
+		};
+
+		partition@300000 {
+			label = "Boot Flag";
+			reg = <0x300000 0x100000>;
+			sercomm,scpart-id = <3>;
+		};
+
+		partition@400000 {
+			label = "kernel";
+			reg = <0x400000 0x600000>;
+			sercomm,scpart-id = <4>;
+		};
+
+		partition@a00000 {
+			label = "Kernel 2";
+			reg = <0xa00000 0x600000>;
+			sercomm,scpart-id = <5>;
+			read-only;
+		};
+
+		ubiconcat0: partition@1000000 {
+			label = "File System 1";
+			reg = <0x1000000 0x2000000>;
+			sercomm,scpart-id = <6>;
+		};
+
+		partition@3000000 {
+			label = "File System 2";
+			reg = <0x3000000 0x2000000>;
+			sercomm,scpart-id = <7>;
+			read-only;
+		};
+
+		ubiconcat1: partition@5000000 {
+			label = "Configuration/log";
+			reg = <0x5000000 0x1400000>;
+			sercomm,scpart-id = <8>;
+		};
+
+		ubiconcat2: partition@6400000 {
+			label = "Debug (Ftool)";
+			reg = <0x6400000 0x1a00000>;
+			sercomm,scpart-id = <9>;
+		};
+
+		ubiconcat3: partition@8000000 {
+			label = "Container";
+			reg = <0x8000000 0x7c00000>;
+			sercomm,scpart-id = <10>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_21000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+};
+
+&mdio {
+	ethphy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&uartlite3 {
+	status = "okay";
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart2";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1688,6 +1688,19 @@ define Device/renkforce_ws-wn530hp3-a
 endef
 TARGET_DEVICES += renkforce_ws-wn530hp3-a
 
+define Device/rostelecom_rt-sf-1
+  $(Device/sercomm_dxx)
+  IMAGE_SIZE := 32768k
+  SERCOMM_HWID := DKG
+  SERCOMM_HWVER := 10110
+  SERCOMM_SWVER := 1026
+  DEVICE_VENDOR := Rostelecom
+  DEVICE_MODEL := RT-SF-1
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7615-firmware \
+	kmod-usb3 uboot-envtools
+endef
+TARGET_DEVICES += rostelecom_rt-sf-1
+
 define Device/samknows_whitebox-v8
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -25,7 +25,8 @@ asus,rt-n56u-b1)
 	;;
 beeline,smartbox-flash|\
 beeline,smartbox-giga|\
-beeline,smartbox-turbo)
+beeline,smartbox-turbo|\
+rostelecom,rt-sf-1)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
 	;;
 belkin,rt1800)

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -8,7 +8,8 @@ boot() {
 		[ -n "$(fw_printenv bootcount bootchanged 2>/dev/null)" ] &&\
 			echo -e "bootcount\nbootchanged\n" | /usr/sbin/fw_setenv -s -
 		;;
-	beeline,smartbox-turbo)
+	beeline,smartbox-turbo|\
+	rostelecom,rt-sf-1)
 		[[ $(hexdump -n 1 -e '/1 "%1d"' -s $((0x20001)) /dev/mtd3) == \
 			$((0xff)) ]] || printf '\xff' | dd of=/dev/mtdblock3 \
 			count=1 bs=1 seek=$((0x20001))

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -93,6 +93,7 @@ platform_do_upgrade() {
 	netgear,wax202|\
 	netis,wf2881|\
 	raisecom,msg1500-x-00|\
+	rostelecom,rt-sf-1|\
 	sercomm,na502|\
 	sercomm,na502s|\
 	xiaomi,mi-router-3g|\


### PR DESCRIPTION
[Device page on OpenWrt Wiki](https://openwrt.org/toh/rostelecom/rt-sf-1)
---------------------------------

Rostelecom RT-SF-1 is a wireless WiFi 5 router manufactured by Sercomm company.

Device specification
--------------------
SoC Type: MediaTek MT7621AT
RAM: 256 MiB
Flash: 256 MiB, Micron MT29F2G08ABAGA3W
Wireless 2.4 GHz (MT7603EN): b/g/n, 2x2
Wireless 5 GHz (MT7615E): a/n/ac, 4x4
Ethernet: 5xGbE (WAN, LAN1, LAN2, LAN3, LAN4)
USB ports: 1xUSB3.0
ZigBee: 3.0, EFR32 MG1B232GG
Button: 2 buttons (Reset & WPS)
LEDs:
   - 1x Status (RGB)
   - 1x 2.4G (blue, hardware, mt76-phy0)
   - 1x 5G (blue, hardware, mt76-phy1)

Power: 12 VDC, 1.5 A
Connector type: barrel
Bootloader: U-Boot

Installation
-----------------
1. Remove dots from the OpenWrt factory image filename
2. Login to the router web interface
3. Update firmware using web interface with the OpenWrt factory image
4. If OpenWrt is booted, then no further steps are required. Enjoy! Otherwise (Stock firmware has booted again) proceed to the next step.
5. Update firmware using web interface with any version of the Stock firmware
6. Update firmware using web interface with the OpenWrt factory image

Revert to stock
---------------
Change bootflag to Sercomm1 in OpenWrt CLI and then reboot:
`printf 1 | dd bs=1 seek=7 count=1 of=/dev/mtdblock3`

Recovery
--------
Use sercomm-recovery tool.
Link: https://github.com/danitool/sercomm-recovery

MAC Addresses
-------------
```
+-----+------------+------------+
| use | address    | example    |
+-----+------------+------------+
| LAN | label      | *:72, *:d2 |
| WAN | label + 11 | *:7d, *:dd |
| 2g  | label + 2  | *:74, *:d4 |
| 5g  | label + 3  | *:75, *:d5 |
+-----+------------+------------+
```
The label MAC address was found in Factory 0x21000
