### PR TITLE
lantiq: build fixes for kernel 5.15

### DIFF
--- a/package/kernel/lantiq/ltq-ifxos/patches/002-fix-compile.patch
+++ b/package/kernel/lantiq/ltq-ifxos/patches/002-fix-compile.patch
@@ -20,3 +20,14 @@
  
  #include "ifx_types.h"
  #include "ifxos_rt_if_check.h"
+--- a/src/include/linux/ifxos_linux_interrupt.h
++++ b/src/include/linux/ifxos_linux_interrupt.h
+@@ -31,7 +31,7 @@
+    IFX Linux adaptation - Includes
+    ========================================================================= */
+ #include "ifx_types.h"
+-#include <asm/irq.h>
++#include <linux/interrupt.h>
+ 
+ /* ============================================================================
+    IFX Linux adaptation - supported features

--- a/package/kernel/lantiq/ltq-tapi/patches/510-linux-515.patch
+++ b/package/kernel/lantiq/ltq-tapi/patches/510-linux-515.patch
@@ -1,0 +1,14 @@
+--- a/src/drv_tapi_linux.c
++++ b/src/drv_tapi_linux.c
+@@ -3779,8 +3779,10 @@ IFX_void_t TAPI_OS_ThreadKill(IFXOS_Thre
+          mb();
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,28)
+          kill_proc(pThrCntrl->tid, SIGKILL, 1);
+-#else
++#elif LINUX_VERSION_CODE < KERNEL_VERSION(3,8,0)
+          kill_pid(find_vpid(pThrCntrl->tid), SIGKILL, 1);
++#else
++         kill_pid(get_task_pid(pThrCntrl->tid, PIDTYPE_PID), SIGKILL, 1);
+ #endif
+          /* release the big kernel lock */
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)


### PR DESCRIPTION
This contains two build fixes for ltq-ifxos and ltq-tapi when using kernel 5.15.#

```
ltq-ifxos: Fix compile with ltq-tapi
    
Do not include asm/irq.h directly, but include irq.h instead. This fixes
the build of ltq-tapi with lantiq/xway.
```


```
ltq-tapi: Fix compile with kernel 5.15
    
Do not use find_vpid(), but get_task_pid() to get the pid from
pThrCntrl->tid. This is now a ponter to struct task_struct instead of
an integer.
    
This fixes the build of ltq-tapi with lantiq/xway.
```