### PR TITLE
CI: build all host tools

### DIFF
--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -32,6 +32,7 @@ jobs:
           echo CONFIG_DEVEL=y >> .config
           echo CONFIG_AUTOREMOVE=y >> .config
           echo CONFIG_CCACHE=y >> .config
+          echo CONFIG_BUILD_ALL_HOST_TOOLS=y >> .config
 
       - name: Make prereq
         shell: su buildbot -c "sh -e {0}"


### PR DESCRIPTION
Now that we build also core packages, we need more host tools. Compile
all of them to reduce compile time on other actions.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
