### PR TITLE
ramips: add support for SNR-CPE-ME1

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -87,6 +87,7 @@ linksys,ea8100-v2|\
 mts,wg430223)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
 	;;
+snr,snr-cpe-me1|\
 snr,snr-cpe-me2-sfp|\
 snr,cpe-w4n-mt)
 	idx="$(find_mtd_index uboot-env)"

--- a/target/linux/ramips/dts/mt7621_snr-cpe-me1.dts
+++ b/target/linux/ramips/dts/mt7621_snr-cpe-me1.dts
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "snr,snr-cpe-me1", "mediatek,mt7621-soc";
+	model = "SNR-CPE-ME1";
+
+	aliases {
+		label-mac-device = &gmac1;
+
+		led-boot = &led_usb;
+		led-failsafe = &led_vpn;
+		led-running = &led_green;
+		led-upgrade = &led_sys;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_usb: led-0 { // USB Activity
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>; // [JTAG] JTDO
+		};
+
+		led_vpn: led-1 { // VPN Activity
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>; // [JTAG] JTCLK
+		};
+
+		led_sys: led-2 { // System config
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>; // [I2C] I2C_SD
+			panic-indicator;
+		};
+
+		led_green: led-3 { // ? LED
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_HEARTBEAT;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>; // [JTAG] JTMS
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset Button";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>; // [JTAG] JTDI
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	reg_usb_vbus: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 { // MT7603EN
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 { // MT7610EN
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 { // GD25Q128CSIG
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <44000000>; // 44 MHz
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "Factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
+			};
+
+			partition@50000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+
+			partition@30001 {
+				label = "uboot-env";
+				reg = <0x30000 0x1000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&xhci {
+	vbus-supply = <&reg_usb_vbus>;
+	vusb33-supply = <&reg_3p3v>;
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2031,6 +2031,18 @@ define Device/sim_simax1800t
 endef
 TARGET_DEVICES += sim_simax1800t
 
+define Device/snr_snr-cpe-me1
+	$(Device/dsa-migration)
+	$(Device/uimage-lzma-loader)
+	IMAGE_SIZE := 15040k
+	DEVICE_VENDOR := SNR
+	DEVICE_MODEL := SNR-CPE-ME1
+	UIMAGE_NAME := SNR-CPE-ME1-5GHZ-MT
+	DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x0e kmod-usb3 \
+		kmod-usb-ledtrig-usbport uboot-envtools
+endef
+TARGET_DEVICES += snr_snr-cpe-me1
+
 define Device/snr_snr-cpe-me2-lite
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -163,6 +163,9 @@ oraybox,x3a)
 	ucidef_set_led_netdev "wan" "wan link" "red:status" "wan"
 	ucidef_set_led_netdev "lan" "lan link" "green:status" "br-lan"
 	;;
+snr,snr-cpe-me1)
+	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1" "usb2-port1"
+	;;
 tplink,archer-a6-v3|\
 tplink,archer-ax23-v1|\
 tplink,archer-c6-v3|\


### PR DESCRIPTION
SNR-CPE-ME1 is a wireless WiFi 5 router manufactured by SNR/NAG company.
```
Specification:
    - SoC           : MediaTek MT7621A
    - RAM           : DDR3 256 MiB
    - Flash         : SPI-NOR 16 MiB
    - WLAN          : 2.4 GHz (MediaTek MT7603EN)
                      5 GHz (MediaTek MT7610EN)
    - Ethernet      : 10/100/1000 Mbps x5
      - Switch      : MediaTek MT7530 (in SoC)
    - UART          : through-hole on PCB
      - [J4] 3.3V, TX, RX, GND (57600n8)
    - Power         : 12 VDC, 1.5 A
```
- [x] GPIO LED
- [x] GPIO Button
- [x] Correct order of Ethernet interfaces
- [x] Work mt7603en
- [x] Work mt7610en
- [x] Work USB
- [x] U-boot Env
- [x] MACs interfaces