### PR TITLE
mediatek: fix array-bounds error in rtl8367c

### DIFF
--- a/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367c/rtl8367c_asicdrv_svlan.c
+++ b/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367c/rtl8367c_asicdrv_svlan.c
@@ -775,8 +775,8 @@ ret_t rtl8367c_setAsicSvlanSP2CConf(rtk_uint32 index, rtl8367c_svlan_s2c_t* pSvl
         if(retVal != RT_ERR_OK)
             return retVal;
 
-        accessPtr ++;
         regData = *accessPtr;
+        accessPtr ++;
     }
 
     return retVal;


### PR DESCRIPTION
Fixes errors in the form of:
```
  drivers/net/phy/rtk/rtl8367c/rtl8367c_asicdrv_svlan.c: In function
    'rtl8367c_setAsicSvlanSP2CConf':
  drivers/net/phy/rtk/rtl8367c/rtl8367c_asicdrv_svlan.c:779:19: error:
    array subscript 2 is outside array bounds of 'rtk_uint16[2]'
    {aka 'short unsigned int[2]'} [-Werror=array-bounds]
    779 |         regData = *accessPtr;
        |                   ^~~~~~~~~~
  drivers/net/phy/rtk/rtl8367c/rtl8367c_asicdrv_svlan.c:761:16:
    note: while referencing 'smiSvlanSP2C'
    761 |     rtk_uint16 smiSvlanSP2C[RTL8367C_SVLAN_SP2C_LEN];
        |                ^~~~~~~~~~~~
  cc1: all warnings being treated as errors
  make[9]: *** [scripts/Makefile.build:250:
    drivers/net/phy/rtk/rtl8367c/rtl8367c_asicdrv_svlan.o] Error 1
```
