### PR TITLE
ath79: calibrate TL-WDR4900 v2 with nvmem-cells

### DIFF
--- a/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
@@ -96,10 +96,9 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,0033";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_uboot_1fc00>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_uboot_1fc00>, <&cal_ath9k_pci>;
+		nvmem-cell-names = "mac-address", "calibration";
 		mac-address-increment = <(-2)>;
-		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -152,6 +151,14 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_uboot_1fc00: macaddr@1fc00 {
+					reg = <0x1fc00 0x6>;
+				};
 			};
 
 			partition@20000 {
@@ -164,6 +171,18 @@
 				label = "art";
 				reg = <0x7f0000 0x010000>;
 				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				cal_ath9k_soc: cal_ath9k@1000 {
+					reg = <0x1000 0x440>;
+				};
+
+				cal_ath9k_pci: cal_ath9k@5000 {
+					reg = <0x5000 0x440>;
+				};
 			};
 		};
 	};
@@ -219,18 +238,7 @@
 &wmac {
 	status = "okay";
 
-	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_uboot_1fc00>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_uboot_1fc00>, <&cal_ath9k_soc>;
+	nvmem-cell-names = "mac-address", "calibration";
 	mac-address-increment = <(-1)>;
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -94,7 +94,6 @@ case "$FIRMWARE" in
 	tplink,tl-wdr4300-v1|\
 	tplink,tl-wdr4300-v1-il|\
 	tplink,tl-wdr4310-v1|\
-	tplink,tl-wdr4900-v2|\
 	ubnt,unifi-ap-pro|\
 	watchguard,ap100|\
 	watchguard,ap200|\


### PR DESCRIPTION
Driver for both soc (2.4GHz Wifi) and pci (5 GHz) now pull the calibration data from the nvmem subsystem.

This allows us to move the userspace caldata extraction for the pci-e ath9k supported wifi into the device-tree definition of the device.

wmac's nodes are also changed over to use nvmem-cells over OpenWrt's custom mtd-cal-data property.

Signed-off-by: Edward Chow <equu@openmail.cc>