### PR TITLE
ipq806x: kernel ramoops storage for C2600/AD7200

### DIFF
--- a/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8064-ad7200-c2600.dtsi
+++ b/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8064-ad7200-c2600.dtsi
@@ -10,6 +10,15 @@
 		device_type = "memory";
 	};
 
+	ramoops@42100000 {
+		compatible = "ramoops";
+		reg = <0x42100000 0x40000>;
+		record-size = <0x4000>;
+		console-size = <0x4000>;
+		ftrace-size = <0x4000>;
+		pmsg-size = <0x4000>;
+	};
+
 	aliases {
 		mdio-gpio0 = &mdio0;
 		label-mac-device = &gmac2;

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -409,7 +409,7 @@ define Device/tplink_ad7200
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	TPLINK_BOARD_ID := AD7200
-	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct kmod-wil6210
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct kmod-ramoops kmod-wil6210
 endef
 TARGET_DEVICES += tplink_ad7200
 
@@ -424,7 +424,7 @@ define Device/tplink_c2600
 	BOARD_NAME := c2600
 	SUPPORTED_DEVICES += c2600
 	TPLINK_BOARD_ID := C2600
-	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct kmod-ramoops
 endef
 TARGET_DEVICES += tplink_c2600
 


### PR DESCRIPTION
Define the kernel crash log storage ramoops/pstore feature for C2600/AD7200 and add kmod-ramoops to default.

Tested with a C2600 only so far.

For anyone willing to test with an AD7200 there should be this message in the dmesg/kernel log
```
[    9.686278] pstore: Using crash dump compression: deflate
[    9.686309] pstore: Registered ramoops as persistent store backend
[    9.690737] ramoops: using 0x40000@0x42100000, ecc: 0
```
using SSH, force a crash/reboot with `echo c > /proc/sysrq-trigger` there should be a file in `/sys/fs/pstore`