### PR TITLE
dnsmasq: add support for filter-AAAA/A

### DIFF
--- a/package/network/services/dnsmasq/files/dhcp.conf
+++ b/package/network/services/dnsmasq/files/dhcp.conf
@@ -21,6 +21,8 @@ config dnsmasq
 	#list bogusnxdomain     '64.94.110.11'
 	option localservice	1  # disable to allow DNS requests from non-local subnets
 	option ednspacket_max	1232
+	option filter_aaaa	0
+	option filter_a		0
 
 config dhcp lan
 	option interface	lan

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -960,6 +960,9 @@ dnsmasq_start()
 	append_bool "$cfg" rapidcommit "--dhcp-rapid-commit"
 	append_bool "$cfg" scriptarp "--script-arp"
 
+	append_bool "$cfg" filter_aaaa "--filter-AAAA"
+	append_bool "$cfg" filter_a "--filter-A"
+
 	append_parm "$cfg" logfacility "--log-facility"
 	config_get logfacility "$cfg" "logfacility"
 	append_parm "$cfg" cachesize "--cache-size"


### PR DESCRIPTION
This add --filter-A and --filter-AAAA options, to remove IPv4 or IPv6 addresses from DNS answers. these options is supported since version 2.87.