### PR TITLE
dropbear: disable three weak kex/mac algorithms

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -116,6 +116,9 @@ DB_OPT_COMMON = \
 	DROPBEAR_CLI_NETCAT|0 \
 	DROPBEAR_DSS|0 \
 	DO_MOTD|0 \
+	DROPBEAR_RSA_SHA1|0 \
+	DROPBEAR_DH_GROUP14_SHA1|0 \
+	DROPBEAR_SHA1_HMAC|0 \
 
 
 ##############################################################################


### PR DESCRIPTION
`ssh-rsa (2048-bit)`, `hmac-sha1`, and `diffie-hellman-group14-sha1` are weak algorithms.  In the case of `sha-rsa (2048-bit)`, a future deprecation notice has been issued.[1]  It has no place in a potentially internet-facing daemon like dropbear.  Upstream has acknowledged this and offered this solution to disable these three until this is made to be the default in the next release of dropbear next year.[2]

This PR disables these three at build time until then.

1. https://www.openssh.com/txt/release-8.2
2. https://github.com/mkj/dropbear/issues/138

Build system: x86_64
Build-tested: bcm2711/RPi4B
Run-tested: bcm2711/RPi4B

Signed-off-by: John Audia <therealgraysky@proton.me>