### PR TITLE
ipq40xx: D-Link DAP-2610: convert to DSA

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -43,6 +43,7 @@ ipq40xx_setup_interfaces()
 		;;
 	aruba,ap-303|\
 	avm,fritzrepeater-1200|\
+	dlink,dap-2610|\
 	meraki,mr33|\
 	meraki,mr74|\
 	mikrotik,lhgg-60ad|\

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-dap-2610.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-dap-2610.dts
@@ -181,6 +181,20 @@
 	status = "okay";
 };
 
+&gmac {
+       status = "okay";
+};
+
+&switch {
+       status = "okay";
+};
+
+&swport5 {
+       status = "okay";
+
+       label = "lan";
+};
+
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -419,8 +419,7 @@ define Device/dlink_dap-2610
 	IMAGE/factory.bin    := append-kernel | pad-offset 6144k 160 | append-rootfs | wrgg-image | check-size
 	IMAGE/sysupgrade.bin := append-kernel | wrgg-image | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += dlink_dap-2610
+TARGET_DEVICES += dlink_dap-2610
 
 define Device/edgecore_ecw5211
 	$(call Device/FitImage)


### PR DESCRIPTION
Reenable D-Link DAP-2610, convert it to DSA and label port to 'lan', as shown on the case

Signed-off-by: Guillaume Lefebvre <guillaume@zelig.ch>