### PR TITLE
ath79: calibrate all ar9344 tl-WDRxxxx with nvmem

### DIFF
--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr3500-v1.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr3500-v1.dts
@@ -50,14 +50,7 @@
 };
 
 &ath9k {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
-	nvmem-cell-names = "mac-address";
 	mac-address-increment = <1>;
-};
-
-&wmac {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
-	nvmem-cell-names = "mac-address";
 };
 
 &eth1 {
@@ -82,14 +75,4 @@
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
 	mac-address-increment = <2>;
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
@@ -75,14 +75,7 @@
 	status = "okay";
 };
 
-&ath9k {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
-	nvmem-cell-names = "mac-address";
-};
-
 &wmac {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
-	nvmem-cell-names = "mac-address";
 	mac-address-increment = <(-1)>;
 };
 
@@ -116,14 +109,4 @@
 
 	phy-mode = "rgmii";
 	phy-handle = <&phy0>;
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
@@ -106,14 +106,39 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,0033";
 		reg = <0x0000 0 0 0 0>;
-		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;
+		nvmem-cells = <&macaddr_uboot_1fc00>, <&cal_art_5000>;
+		nvmem-cell-names = "mac-address", "calibration";
 	};
 };
 
 &wmac {
 	status = "okay";
+	nvmem-cells = <&macaddr_uboot_1fc00>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};
 
-	mtd-cal-data = <&art 0x1000>;
+&uboot {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_uboot_1fc00: macaddr@1fc00 {
+		reg = <0x1fc00 0x6>;
+	};
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	cal_art_1000: cal@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	cal_art_5000: cal@5000 {
+		reg = <0x5000 0x440>;
+	};
 };

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -89,11 +89,6 @@ case "$FIRMWARE" in
 	engenius,ecb600|\
 	mercury,mw4530r-v1|\
 	ocedo,raccoon|\
-	tplink,tl-wdr3500-v1|\
-	tplink,tl-wdr3600-v1|\
-	tplink,tl-wdr4300-v1|\
-	tplink,tl-wdr4300-v1-il|\
-	tplink,tl-wdr4310-v1|\
 	ubnt,unifi-ap-pro|\
 	watchguard,ap100|\
 	watchguard,ap200|\


### PR DESCRIPTION
Driver for both soc (2.4GHz Wifi) and pci (5 GHz) now pull the calibration data from the nvmem subsystem.

This allows us to move the userspace caldata extraction for the pci-e ath9k supported wifi into the device-tree definition of the device.

wmac's nodes are also changed over to use nvmem-cells over OpenWrt's custom mtd-cal-data property.

The wifi mac address remains correct after these changes, because When both "mac-address" and "calibration" are defined, the effective mac address comes from the cell corresponding to "mac-address" and mac-address-increment.

Test passed on my tplink tl-wdr4310.

Signed-off-by: Edward Chow <equu@openmail.cc>