### PR TITLE
tools/patch: apply patch for EACCES on xattr copy

### DIFF
--- a/tools/patch/Makefile
+++ b/tools/patch/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=patch
 PKG_VERSION:=2.7.6
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_CPE_ID:=cpe:/a:gnu:patch
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/tools/patch/patches/070-don-t-fail-hard-on-EACCES-when-copying-xattrs.patch
+++ b/tools/patch/patches/070-don-t-fail-hard-on-EACCES-when-copying-xattrs.patch
@@ -1,0 +1,40 @@
+From f42cbe1a91a3a6f79d1eec594ce7c72aec79179b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Thomas=20Wei=C3=9Fschuh?= <thomas@t-8ch.de>
+Date: Wed, 9 Nov 2022 05:08:22 +0100
+Subject: [PATCH] don't fail hard on EACCES when copying xattrs
+
+On btrfs the xattr "btrfs.compressed" requires privileges to set,
+otherwise EACCES is returned.
+When patch tries to do copy this attribute it receives the error and
+aborts.
+---
+ src/util.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/util.c b/src/util.c
+index c3ff5dd..90d1744 100644
+--- a/src/util.c
++++ b/src/util.c
+@@ -182,7 +182,7 @@ copy_attr_error (struct error_context *ctx, char const *fmt, ...)
+   int err = errno;
+   va_list ap;
+ 
+-  if (err != ENOSYS && err != ENOTSUP && err != EPERM)
++  if (err != ENOSYS && err != ENOTSUP && err != EPERM && err != EACCES)
+     {
+       /* use verror module to print error message */
+       va_start (ap, fmt);
+@@ -284,7 +284,7 @@ set_file_attributes (char const *to, enum file_attributes attr,
+     }
+   if (attr & FA_XATTRS)
+     if (copy_attr (from, to) != 0
+-	&& errno != ENOSYS && errno != ENOTSUP && errno != EPERM)
++	&& errno != ENOSYS && errno != ENOTSUP && errno != EPERM && errno != EACCES)
+       fatal_exit (0);
+   if (attr & FA_MODE)
+     {
+
+base-commit: c835ecc67b7e37c0d0b7dd7e032209fdaa285808
+-- 
+2.38.1
+


### PR DESCRIPTION
When compiling OpenWRT on a compressed btrfs volume the build fails in libtool.
The file `libltdl/config/ltmain.m4sh` from `libtool-2.4.2.tar.xz` is missing write permissions, therefore patch falls back to copying the file and patching that. During this patch tries to preserve all file attribute on the new copy.
However the attribute `btrfs.compression` is privileged and btrfs return EACCES.
While patch ignores multiple other error codes during the copy of xattr copy it is not prepared for EACCES and aborts.

EACCES should be ignored the same way as the other errors.

Build log:
```
...
Applying ./patches/000-relocatable.patch using plaintext:
patching file libltdl/config/general.m4sh
patching file libtoolize.in
patching file libtoolize.m4sh
patching file libltdl/m4/libtool.m4

Applying ./patches/100-libdir-fixes.patch using plaintext:
patching file libltdl/config/ltmain.m4sh
File libltdl/config/ltmain.sh is read-only; trying to patch anyway
patching file libltdl/config/ltmain.sh
patch: setting attribute btrfs.compression for btrfs.compression: Permission denied
Patch failed!  Please fix ./patches/100-libdir-fixes.patch!
```

Link: https://lists.gnu.org/archive/html/bug-patch/2022-11/msg00000.html
Signed-off-by: Thomas Weißschuh <thomas@t-8ch.de>