### PR TITLE
realtek: refactor ethernet driver

### DIFF
--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -1304,7 +1304,8 @@ static int rtl838x_hw_receive(struct net_device *dev, int r, int budget)
 			skb_data = skb_put(skb, len);
 			/* Make sure data is visible */
 			mb();
-			memcpy(skb->data, (u8 *)KSEG1ADDR(data), len);
+			dma_sync_single_for_device(&priv->pdev->dev, CPHYSADDR(data), len, DMA_FROM_DEVICE);
+			memcpy(skb->data, (u8 *)KSEG0ADDR(data), len);
 			/* Overwrite CRC with cpu_tag */
 			if (dsa) {
 				priv->r->decode_tag(h, &tag);

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -159,7 +159,7 @@ extern int rtl931x_write_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 val);
  * driver in /drivers/net/mdio. For the time being keep them here.
  */
 
-static int rtl838x_mdio_read_paged(struct mii_bus *bus, int mii_id, u16 page, int regnum)
+static int rtmd_838x_read_paged(struct mii_bus *bus, int mii_id, u16 page, int regnum)
 {
 	u32 val;
 	int err;
@@ -184,12 +184,12 @@ static int rtl838x_mdio_read_paged(struct mii_bus *bus, int mii_id, u16 page, in
 	return val;
 }
 
-static int rtl838x_mdio_read(struct mii_bus *bus, int mii_id, int regnum)
+static int rtmd_838x_read(struct mii_bus *bus, int mii_id, int regnum)
 {
-	return rtl838x_mdio_read_paged(bus, mii_id, 0, regnum);
+	return rtmd_838x_read_paged(bus, mii_id, 0, regnum);
 }
 
-static int rtl839x_mdio_read_paged(struct mii_bus *bus, int mii_id, u16 page, int regnum)
+static int rtmd_839x_read_paged(struct mii_bus *bus, int mii_id, u16 page, int regnum)
 {
 	u32 val;
 	int err;
@@ -214,12 +214,12 @@ static int rtl839x_mdio_read_paged(struct mii_bus *bus, int mii_id, u16 page, in
 	return val;
 }
 
-static int rtl839x_mdio_read(struct mii_bus *bus, int mii_id, int regnum)
+static int rtmd_839x_read(struct mii_bus *bus, int mii_id, int regnum)
 {
-	return rtl839x_mdio_read_paged(bus, mii_id, 0, regnum);
+	return rtmd_839x_read_paged(bus, mii_id, 0, regnum);
 }
 
-static int rtl930x_mdio_read_paged(struct mii_bus *bus, int mii_id, u16 page, int regnum)
+static int rtmd_930x_read_paged(struct mii_bus *bus, int mii_id, u16 page, int regnum)
 {
 	u32 val;
 	int err;
@@ -244,12 +244,12 @@ static int rtl930x_mdio_read_paged(struct mii_bus *bus, int mii_id, u16 page, in
 	return val;
 }
 
-static int rtl930x_mdio_read(struct mii_bus *bus, int mii_id, int regnum)
+static int rtmd_930x_read(struct mii_bus *bus, int mii_id, int regnum)
 {
-	return rtl930x_mdio_read_paged(bus, mii_id, 0, regnum);
+	return rtmd_930x_read_paged(bus, mii_id, 0, regnum);
 }
 
-static int rtl931x_mdio_read_paged(struct mii_bus *bus, int mii_id, u16 page, int regnum)
+static int rtmd_931x_read_paged(struct mii_bus *bus, int mii_id, u16 page, int regnum)
 {
 	u32 val;
 	int err, v;
@@ -283,12 +283,12 @@ static int rtl931x_mdio_read_paged(struct mii_bus *bus, int mii_id, u16 page, in
 	return val;
 }
 
-static int rtl931x_mdio_read(struct mii_bus *bus, int mii_id, int regnum)
+static int rtmd_931x_read(struct mii_bus *bus, int mii_id, int regnum)
 {
-	return rtl931x_mdio_read_paged(bus, mii_id, 0, regnum);
+	return rtmd_931x_read_paged(bus, mii_id, 0, regnum);
 }
 
-static int rtl838x_mdio_write_paged(struct mii_bus *bus, int mii_id, u16 page,
+static int rtmd_838x_write_paged(struct mii_bus *bus, int mii_id, u16 page,
 				    int regnum, u16 value)
 {
 	u32 offset = 0;
@@ -316,13 +316,13 @@ static int rtl838x_mdio_write_paged(struct mii_bus *bus, int mii_id, u16 page,
 	return err;
 }
 
-static int rtl838x_mdio_write(struct mii_bus *bus, int mii_id,
+static int rtmd_838x_write(struct mii_bus *bus, int mii_id,
 			      int regnum, u16 value)
 {
-	return rtl838x_mdio_write_paged(bus, mii_id, 0, regnum, value);
+	return rtmd_838x_write_paged(bus, mii_id, 0, regnum, value);
 }
 
-static int rtl839x_mdio_write_paged(struct mii_bus *bus, int mii_id, u16 page,
+static int rtmd_839x_write_paged(struct mii_bus *bus, int mii_id, u16 page,
 				    int regnum, u16 value)
 {
 	struct rtnc_priv *priv = bus->priv;
@@ -346,13 +346,13 @@ static int rtl839x_mdio_write_paged(struct mii_bus *bus, int mii_id, u16 page,
 	return err;
 }
 
-static int rtl839x_mdio_write(struct mii_bus *bus, int mii_id,
+static int rtmd_839x_write(struct mii_bus *bus, int mii_id,
 			      int regnum, u16 value)
 {
-	return rtl839x_mdio_write_paged(bus, mii_id, 0, regnum, value);
+	return rtmd_839x_write_paged(bus, mii_id, 0, regnum, value);
 }
 
-static int rtl930x_mdio_write_paged(struct mii_bus *bus, int mii_id, u16 page,
+static int rtmd_930x_write_paged(struct mii_bus *bus, int mii_id, u16 page,
 				    int regnum, u16 value)
 {
 	struct rtnc_priv *priv = bus->priv;
@@ -370,13 +370,13 @@ static int rtl930x_mdio_write_paged(struct mii_bus *bus, int mii_id, u16 page,
 	return err;
 }
 
-static int rtl930x_mdio_write(struct mii_bus *bus, int mii_id,
+static int rtmd_930x_write(struct mii_bus *bus, int mii_id,
 			      int regnum, u16 value)
 {
-	return rtl930x_mdio_write_paged(bus, mii_id, 0, regnum, value);
+	return rtmd_930x_write_paged(bus, mii_id, 0, regnum, value);
 }
 
-static int rtl931x_mdio_write_paged(struct mii_bus *bus, int mii_id, u16 page,
+static int rtmd_931x_write_paged(struct mii_bus *bus, int mii_id, u16 page,
 				    int regnum, u16 value)
 {
 	struct rtnc_priv *priv = bus->priv;
@@ -400,13 +400,13 @@ static int rtl931x_mdio_write_paged(struct mii_bus *bus, int mii_id, u16 page,
 	return err;
 }
 
-static int rtl931x_mdio_write(struct mii_bus *bus, int mii_id,
+static int rtmd_931x_write(struct mii_bus *bus, int mii_id,
 			      int regnum, u16 value)
 {
-	return rtl931x_mdio_write_paged(bus, mii_id, 0, regnum, value);
+	return rtmd_931x_write_paged(bus, mii_id, 0, regnum, value);
 }
 
-static int rtl838x_mdio_reset(struct mii_bus *bus)
+static int rtmd_838x_reset(struct mii_bus *bus)
 {
 	pr_debug("%s called\n", __func__);
 	/* Disable MAC polling the PHY so that we can start configuration */
@@ -419,7 +419,7 @@ static int rtl838x_mdio_reset(struct mii_bus *bus)
 	return 0;
 }
 
-static int rtl839x_mdio_reset(struct mii_bus *bus)
+static int rtmd_839x_reset(struct mii_bus *bus)
 {
 	return 0;
 
@@ -438,7 +438,7 @@ static int rtl839x_mdio_reset(struct mii_bus *bus)
 u8 mac_type_bit[RTL930X_CPU_PORT] = {0, 0, 0, 0, 2, 2, 2, 2, 4, 4, 4, 4, 6, 6, 6, 6,
 				     8, 8, 8, 8, 10, 10, 10, 10, 12, 15, 18, 21};
 
-static int rtl930x_mdio_reset(struct mii_bus *bus)
+static int rtmd_930x_reset(struct mii_bus *bus)
 {
 	int i;
 	int pos;
@@ -543,7 +543,7 @@ static int rtl930x_mdio_reset(struct mii_bus *bus)
 	return 0;
 }
 
-static int rtl931x_mdio_reset(struct mii_bus *bus)
+static int rtmd_931x_reset(struct mii_bus *bus)
 {
 	int i;
 	int pos;
@@ -638,7 +638,7 @@ static int rtnc_931x_chip_init(struct rtnc_priv *priv)
 	return 0;
 }
 
-static int rtl838x_mdio_init(struct rtnc_priv *priv)
+static int rtmd_init(struct rtnc_priv *priv)
 {
 	struct device_node *mii_np, *dn;
 	u32 pn;
@@ -666,36 +666,36 @@ static int rtl838x_mdio_init(struct rtnc_priv *priv)
 	switch(priv->family_id) {
 	case RTL8380_FAMILY_ID:
 		priv->mii_bus->name = "rtl838x-eth-mdio";
-		priv->mii_bus->read = rtl838x_mdio_read;
-		priv->mii_bus->read_paged = rtl838x_mdio_read_paged;
-		priv->mii_bus->write = rtl838x_mdio_write;
-		priv->mii_bus->write_paged = rtl838x_mdio_write_paged;
-		priv->mii_bus->reset = rtl838x_mdio_reset;
+		priv->mii_bus->read = rtmd_838x_read;
+		priv->mii_bus->read_paged = rtmd_838x_read_paged;
+		priv->mii_bus->write = rtmd_838x_write;
+		priv->mii_bus->write_paged = rtmd_838x_write_paged;
+		priv->mii_bus->reset = rtmd_838x_reset;
 		break;
 	case RTL8390_FAMILY_ID:
 		priv->mii_bus->name = "rtl839x-eth-mdio";
-		priv->mii_bus->read = rtl839x_mdio_read;
-		priv->mii_bus->read_paged = rtl839x_mdio_read_paged;
-		priv->mii_bus->write = rtl839x_mdio_write;
-		priv->mii_bus->write_paged = rtl839x_mdio_write_paged;
-		priv->mii_bus->reset = rtl839x_mdio_reset;
+		priv->mii_bus->read = rtmd_839x_read;
+		priv->mii_bus->read_paged = rtmd_839x_read_paged;
+		priv->mii_bus->write = rtmd_839x_write;
+		priv->mii_bus->write_paged = rtmd_839x_write_paged;
+		priv->mii_bus->reset = rtmd_839x_reset;
 		break;
 	case RTL9300_FAMILY_ID:
 		priv->mii_bus->name = "rtl930x-eth-mdio";
-		priv->mii_bus->read = rtl930x_mdio_read;
-		priv->mii_bus->read_paged = rtl930x_mdio_read_paged;
-		priv->mii_bus->write = rtl930x_mdio_write;
-		priv->mii_bus->write_paged = rtl930x_mdio_write_paged;
-		priv->mii_bus->reset = rtl930x_mdio_reset;
+		priv->mii_bus->read = rtmd_930x_read;
+		priv->mii_bus->read_paged = rtmd_930x_read_paged;
+		priv->mii_bus->write = rtmd_930x_write;
+		priv->mii_bus->write_paged = rtmd_930x_write_paged;
+		priv->mii_bus->reset = rtmd_930x_reset;
 		priv->mii_bus->probe_capabilities = MDIOBUS_C22_C45;
 		break;
 	case RTL9310_FAMILY_ID:
 		priv->mii_bus->name = "rtl931x-eth-mdio";
-		priv->mii_bus->read = rtl931x_mdio_read;
-		priv->mii_bus->read_paged = rtl931x_mdio_read_paged;
-		priv->mii_bus->write = rtl931x_mdio_write;
-		priv->mii_bus->write_paged = rtl931x_mdio_write_paged;
-		priv->mii_bus->reset = rtl931x_mdio_reset;
+		priv->mii_bus->read = rtmd_931x_read;
+		priv->mii_bus->read_paged = rtmd_931x_read_paged;
+		priv->mii_bus->write = rtmd_931x_write;
+		priv->mii_bus->write_paged = rtmd_931x_write_paged;
+		priv->mii_bus->reset = rtmd_931x_reset;
 		priv->mii_bus->probe_capabilities = MDIOBUS_C22_C45;
 		break;
 	}
@@ -760,7 +760,7 @@ err_put_node:
 	return ret;
 }
 
-static int rtl838x_mdio_remove(struct rtnc_priv *priv)
+static int rtmd_remove(struct rtnc_priv *priv)
 {
 	pr_debug("%s called\n", __func__);
 	if (!priv->mii_bus)
@@ -2529,7 +2529,7 @@ static int __init rtnc_probe(struct platform_device *pdev)
 	priv->pdev = pdev;
 	priv->netdev = dev;
 
-	err = rtl838x_mdio_init(priv);
+	err = rtmd_init(priv);
 	if (err)
 		goto err_free;
 
@@ -2580,7 +2580,7 @@ static int rtnc_remove(struct platform_device *pdev)
 
 	if (dev) {
 		pr_info("Removing platform driver for rtl838x-eth\n");
-		rtl838x_mdio_remove(priv);
+		rtmd_remove(priv);
 		rtnc_hw_stop(priv);
 
 		netif_tx_stop_all_queues(dev);

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -1398,10 +1398,10 @@ static void rtnc_93xx_hw_en_rxtx(struct rtnc_priv *priv)
 
 	rtnc_setup_counters(priv);
 
-	/* Enable Notify, RX done, RX overflow and TX done interrupts */
+	/* Enable RX done and RX overflow interrupts */
 	sw_w32(0xffffffff, priv->r->dma_if_intr_rx_runout_msk);
 	sw_w32(0xffffffff, priv->r->dma_if_intr_rx_done_msk);
-	sw_w32(0x0000000f, priv->r->dma_if_intr_tx_done_msk);
+	sw_w32(0x00000000, priv->r->dma_if_intr_tx_done_msk);
 
 	/* Enable DMA */
 	sw_w32_mask(0, RTNC_RX_EN_93XX | RTNC_TX_EN_93XX, priv->r->dma_if_ctrl);

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -736,8 +736,8 @@ static void rtl838x_hw_en_rxtx(struct rtl838x_eth_priv *priv)
 	/* Truncate RX buffer to 0x640 (1600) bytes, pad TX */
 	sw_w32(0x06400020, priv->r->dma_if_ctrl);
 
-	/* Enable RX done, RX overflow and TX done interrupts */
-	sw_w32(0xfffff, priv->r->dma_if_intr_msk);
+	/* Enable RX done and RX overflow interrupts */
+	sw_w32(0xffff, priv->r->dma_if_intr_msk);
 
 	/* Enable DMA, engine expects empty FCS field */
 	sw_w32_mask(0, RX_EN | TX_EN, priv->r->dma_if_ctrl);
@@ -760,8 +760,8 @@ static void rtl839x_hw_en_rxtx(struct rtl838x_eth_priv *priv)
 	/* Setup CPU-Port: RX Buffer */
 	sw_w32(0x0000c808, priv->r->dma_if_ctrl);
 
-	/* Enable Notify, RX done, RX overflow and TX done interrupts */
-	sw_w32(0x007fffff, priv->r->dma_if_intr_msk); // Notify IRQ!
+	/* Enable Notify, RX done and RX overflow interrupts */
+	sw_w32(0x0070ffff, priv->r->dma_if_intr_msk); // Notify IRQ!
 
 	/* Enable DMA */
 	sw_w32_mask(0, RX_EN | TX_EN, priv->r->dma_if_ctrl);
@@ -1380,7 +1380,7 @@ static int rtl838x_poll_rx(struct napi_struct *napi, int budget)
 		if (priv->family_id == RTL9300_FAMILY_ID || priv->family_id == RTL9310_FAMILY_ID)
 			sw_w32(0xffffffff, priv->r->dma_if_intr_rx_done_msk);
 		else
-			sw_w32_mask(0, 0xf00ff | BIT(r + 8), priv->r->dma_if_intr_msk);
+			sw_w32_mask(0, 0x000ff | BIT(r + 8), priv->r->dma_if_intr_msk);
 	}
 	return work_done;
 }

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -43,7 +43,9 @@
 #define TX_EN_93XX	0x20
 #define RX_EN_93XX	0x10
 #define TX_DO		0x2
-#define WRAP		0x2
+#define R_OWN_CPU	0x0
+#define R_OWN_ETH	0x1
+#define R_WRAP		0x2
 #define MAX_PORTS	57
 #define MAX_SMI_BUSSES	4
 
@@ -354,8 +356,8 @@ static void rtl838x_rb_cleanup(struct rtl838x_eth_priv *priv, int status)
 			/* make sure the header is visible to the ASIC */
 			mb();
 
-			ring->rx_r[r][idx] = KSEG1ADDR(h) | 0x1
-				| (idx == (priv->rxringlen - 1) ? WRAP : 0x1);
+			ring->rx_r[r][idx] = KSEG1ADDR(h) |
+				(idx == (priv->rxringlen - 1) ? R_OWN_ETH | R_WRAP : R_OWN_ETH);
 			idx = (idx + 1) % priv->rxringlen;
 		} while (&ring->rx_r[r][idx] != last);
 		ring->c_rx[r] = idx;
@@ -420,7 +422,7 @@ static void rtl839x_l2_notification_handler(struct rtl838x_eth_priv *priv)
 		}
 
 		/* Hand the ring entry back to the switch */
-		nb->ring[e] = nb->ring[e] | 1;
+		nb->ring[e] = nb->ring[e] | R_OWN_ETH;
 		e = (e + 1) % NOTIFY_BLOCKS;
 
 		w->macs[i] = 0ULL;
@@ -832,9 +834,9 @@ static void rtl838x_setup_ring_buffer(struct rtl838x_eth_priv *priv, struct ring
 					+ j * RING_BUFFER);
 			h->size = RING_BUFFER;
 			/* All rings owned by switch, last one wraps */
-			ring->rx_r[i][j] = KSEG1ADDR(h) | 1 
-					   | (j == (priv->rxringlen - 1) ? WRAP : 0);
+			ring->rx_r[i][j] = KSEG1ADDR(h) | R_OWN_ETH;
 		}
+		ring->rx_r[i][j-1] |= R_WRAP;
 		ring->c_rx[i] = 0;
 	}
 
@@ -846,10 +848,10 @@ static void rtl838x_setup_ring_buffer(struct rtl838x_eth_priv *priv, struct ring
 					+ i * TXRINGLEN * RING_BUFFER
 					+ j * RING_BUFFER);
 			h->size = RING_BUFFER;
-			ring->tx_r[i][j] = KSEG1ADDR(&ring->tx_header[i][j]);
+			ring->tx_r[i][j] = KSEG1ADDR(h) | R_OWN_CPU;
 		}
 		/* Last header is wrapping around */
-		ring->tx_r[i][j-1] |= WRAP;
+		ring->tx_r[i][j-1] |= R_WRAP;
 		ring->c_tx[i] = 0;
 	}
 }
@@ -860,7 +862,7 @@ static void rtl839x_setup_notify_ring_buffer(struct rtl838x_eth_priv *priv)
 	struct notify_b *b = priv->membase + sizeof(struct ring_b);
 
 	for (i = 0; i < NOTIFY_BLOCKS; i++)
-		b->ring[i] = KSEG1ADDR(&b->blocks[i]) | 1 | (i == (NOTIFY_BLOCKS - 1) ? WRAP : 0);
+		b->ring[i] = KSEG1ADDR(&b->blocks[i]) | 1 | (i == (NOTIFY_BLOCKS - 1) ? R_WRAP : 0);
 
 	sw_w32((u32) b->ring, RTL839X_DMA_IF_NBUF_BASE_DESC_ADDR_CTRL);
 	sw_w32_mask(0x3ff << 2, 100 << 2, RTL839X_L2_NOTIFICATION_CTRL);
@@ -1164,7 +1166,7 @@ static int rtl838x_eth_tx(struct sk_buff *skb, struct net_device *dev)
 	}
 
 	/* We can send this packet if CPU owns the descriptor */
-	if (!(ring->tx_r[q][ring->c_tx[q]] & 0x1)) {
+	if (!(ring->tx_r[q][ring->c_tx[q]] & R_OWN_ETH)) {
 
 		/* Set descriptor for tx */
 		h = &ring->tx_header[q][ring->c_tx[q]];
@@ -1185,7 +1187,7 @@ static int rtl838x_eth_tx(struct sk_buff *skb, struct net_device *dev)
 		wmb();
 
 		/* Hand over to switch */
-		ring->tx_r[q][ring->c_tx[q]] |= 1;
+		ring->tx_r[q][ring->c_tx[q]] |= R_OWN_ETH;
 
 		// Before starting TX, prevent a Lextra bus bug on RTL8380 SoCs
 		if (priv->family_id == RTL8380_FAMILY_ID) {
@@ -1266,7 +1268,7 @@ static int rtl838x_hw_receive(struct net_device *dev, int r, int budget)
 	idx = ring->c_rx[r];
 
 	do {
-		if ((ring->rx_r[r][idx] & 0x1)) {
+		if ((ring->rx_r[r][idx] & R_OWN_ETH)) {
 			if (&ring->rx_r[r][idx] != last) {
 				netdev_warn(dev, "Ring contention: r: %x, last %x, cur %x\n",
 				    r, (uint32_t)last, (u32) &ring->rx_r[r][idx]);
@@ -1339,8 +1341,8 @@ static int rtl838x_hw_receive(struct net_device *dev, int r, int budget)
 		h->buf = data;
 		h->size = RING_BUFFER;
 
-		ring->rx_r[r][idx] = KSEG1ADDR(h) | 0x1
-			| (idx == (priv->rxringlen - 1) ? WRAP : 0x1);
+		ring->rx_r[r][idx] = KSEG1ADDR(h) |
+			(idx == (priv->rxringlen - 1) ? R_OWN_ETH | R_WRAP : R_OWN_ETH);
 		idx = (idx + 1) % priv->rxringlen;
 		last = (u32 *)KSEG1ADDR(sw_r32(priv->r->dma_if_rx_cur + r * 4));
 	} while (&ring->rx_r[r][idx] != last && work_done < budget);

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -21,7 +21,6 @@
 #include <net/switchdev.h>
 #include <asm/cacheflush.h>
 
-#include <asm/mach-rtl838x/mach-rtl83xx.h>
 #include "rtl838x_eth.h"
 
 extern struct rtl83xx_soc_info soc_info;

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -1922,8 +1922,11 @@ static int rtnc_poll_rx(struct napi_struct *napi, int budget)
 		/* Enable RX interrupt */
 		if (priv->family_id == RTL9300_FAMILY_ID || priv->family_id == RTL9310_FAMILY_ID)
 			sw_w32(0xffffffff, priv->r->dma_if_intr_rx_done_msk);
-		else
+		else {
 			sw_w32_mask(0, 0x000ff | BIT(r + 8), priv->r->dma_if_intr_msk);
+			/* Avoid stalls during high load */
+			priv->r->update_cntr(r, 0);
+		}
 	}
 	return work_done;
 }

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -602,42 +602,6 @@ static int rtmd_931x_reset(struct mii_bus *bus)
 	return 0;
 }
 
-static int rtnc_931x_chip_init(struct rtnc_priv *priv)
-{
-	pr_info("In %s\n", __func__);
-
-	// Initialize Encapsulation memory and wait until finished
-	sw_w32(0x1, RTL931X_MEM_ENCAP_INIT);
-	do { } while (sw_r32(RTL931X_MEM_ENCAP_INIT) & 1);
-	pr_info("%s: init ENCAP done\n", __func__);
-
-	// Initialize Managemen Information Base memory and wait until finished
-	sw_w32(0x1, RTL931X_MEM_MIB_INIT);
-	do { } while (sw_r32(RTL931X_MEM_MIB_INIT) & 1);
-	pr_info("%s: init MIB done\n", __func__);
-
-	// Initialize ACL (PIE) memory and wait until finished
-	sw_w32(0x1, RTL931X_MEM_ACL_INIT);
-	do { } while (sw_r32(RTL931X_MEM_ACL_INIT) & 1);
-	pr_info("%s: init ACL done\n", __func__);
-
-	// Initialize ALE memory and wait until finished
-	sw_w32(0xFFFFFFFF, RTL931X_MEM_ALE_INIT_0);
-	do { } while (sw_r32(RTL931X_MEM_ALE_INIT_0));
-	sw_w32(0x7F, RTL931X_MEM_ALE_INIT_1);
-	sw_w32(0x7ff, RTL931X_MEM_ALE_INIT_2);
-	do { } while (sw_r32(RTL931X_MEM_ALE_INIT_2) & 0x7ff);
-	pr_info("%s: init ALE done\n", __func__);
-
-	// Enable ESD auto recovery
-	sw_w32(0x1, RTL931X_MDX_CTRL_RSVD);
-
-	// Init SPI, is this for thermal control or what?
-	sw_w32_mask(0x7 << 11, 0x2 << 11, RTL931X_SPI_CTRL0);
-
-	return 0;
-}
-
 static int rtmd_init(struct rtnc_priv *priv)
 {
 	struct device_node *mii_np, *dn;
@@ -2365,6 +2329,42 @@ static void rtnc_soc_info(int *soc_id, int *soc_family)
 
 	*soc_id = 0;
 	*soc_family = 1;
+}
+
+static int rtnc_931x_chip_init(struct rtnc_priv *priv)
+{
+	pr_info("In %s\n", __func__);
+
+	// Initialize Encapsulation memory and wait until finished
+	sw_w32(0x1, RTL931X_MEM_ENCAP_INIT);
+	do { } while (sw_r32(RTL931X_MEM_ENCAP_INIT) & 1);
+	pr_info("%s: init ENCAP done\n", __func__);
+
+	// Initialize Managemen Information Base memory and wait until finished
+	sw_w32(0x1, RTL931X_MEM_MIB_INIT);
+	do { } while (sw_r32(RTL931X_MEM_MIB_INIT) & 1);
+	pr_info("%s: init MIB done\n", __func__);
+
+	// Initialize ACL (PIE) memory and wait until finished
+	sw_w32(0x1, RTL931X_MEM_ACL_INIT);
+	do { } while (sw_r32(RTL931X_MEM_ACL_INIT) & 1);
+	pr_info("%s: init ACL done\n", __func__);
+
+	// Initialize ALE memory and wait until finished
+	sw_w32(0xFFFFFFFF, RTL931X_MEM_ALE_INIT_0);
+	do { } while (sw_r32(RTL931X_MEM_ALE_INIT_0));
+	sw_w32(0x7F, RTL931X_MEM_ALE_INIT_1);
+	sw_w32(0x7ff, RTL931X_MEM_ALE_INIT_2);
+	do { } while (sw_r32(RTL931X_MEM_ALE_INIT_2) & 0x7ff);
+	pr_info("%s: init ALE done\n", __func__);
+
+	// Enable ESD auto recovery
+	sw_w32(0x1, RTL931X_MDX_CTRL_RSVD);
+
+	// Init SPI, is this for thermal control or what?
+	sw_w32_mask(0x7 << 11, 0x2 << 11, RTL931X_SPI_CTRL0);
+
+	return 0;
 }
 
 static int __init rtnc_probe(struct platform_device *pdev)

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -1228,7 +1228,7 @@ static void rtnc_hw_reset(struct rtnc_priv *priv)
 	
 	pr_info("RESETTING %x, CPU_PORT %d\n", priv->family_id, priv->cpu_port);
 	sw_w32_mask(0x3, 0, priv->r->mac_port_ctrl(priv->cpu_port));
-	mdelay(100);
+	msleep(100);
 
 	/* Disable and clear interrupts */
 	if (priv->family_id == RTL9300_FAMILY_ID || priv->family_id == RTL9310_FAMILY_ID) {
@@ -1267,7 +1267,7 @@ static void rtnc_hw_reset(struct rtnc_priv *priv)
 	do { /* Wait for reset of NIC and Queues done */
 		udelay(20);
 	} while (sw_r32(priv->r->rst_glb_ctrl) & reset_mask);
-	mdelay(100);
+	msleep(100);
 
 	/* Re-enable link change interrupt */
 	if (priv->family_id == RTL8390_FAMILY_ID) {
@@ -1559,7 +1559,7 @@ static void rtnc_hw_stop(struct rtnc_priv *priv)
 		sw_w32_mask(RTNC_RX_EN_93XX | RTNC_TX_EN_93XX, 0, priv->r->dma_if_ctrl);
 	else
 		sw_w32_mask(RTNC_RX_EN_83XX | RTNC_TX_EN_83XX, 0, priv->r->dma_if_ctrl);
-	mdelay(200); /* Test, whether this is needed */
+	msleep(200); /* Test, whether this is needed */
 
 	/* Block all ports */
 	if (priv->family_id == RTL8380_FAMILY_ID) {
@@ -1589,7 +1589,7 @@ static void rtnc_hw_stop(struct rtnc_priv *priv)
 		sw_w32_mask(0x3, 0, priv->r->mac_force_mode_ctrl + priv->cpu_port *4);
 	else if (priv->family_id == RTL9310_FAMILY_ID)
 		sw_w32_mask(BIT(0) | BIT(9), 0, priv->r->mac_force_mode_ctrl + priv->cpu_port *4);
-	mdelay(100);
+	msleep(100);
 
 	/* Disable all TX/RX interrupts */
 	if (priv->family_id == RTL9300_FAMILY_ID || priv->family_id == RTL9310_FAMILY_ID) {
@@ -1606,7 +1606,7 @@ static void rtnc_hw_stop(struct rtnc_priv *priv)
 
 	/* Disable TX/RX DMA */
 	sw_w32(0x00000000, priv->r->dma_if_ctrl);
-	mdelay(200);
+	msleep(200);
 }
 
 static int rtnc_ndo_stop(struct net_device *ndev)
@@ -2028,7 +2028,7 @@ static void rtnc_mac_an_restart(struct phylink_config *config)
 	pr_debug("In %s\n", __func__);
 	/* Restart by disabling and re-enabling link */
 	sw_w32(0x6192D, priv->r->mac_force_mode_ctrl + priv->cpu_port * 4);
-	mdelay(20);
+	msleep(20);
 	sw_w32(0x6192F, priv->r->mac_force_mode_ctrl + priv->cpu_port * 4);
 }
 

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -823,22 +823,17 @@ static void rtnc_93xx_header_vlan_set(struct rtnc_hdr *h, int vlan)
 	h->cpu_tag[3] |= (vlan & 0xff) << 8;
 }
 
+void rtnc_83xx_update_cntr(int r, int released)
+{
+	/* This feature is not available on RTL838x/RTL839x SoCs */
+}
+
 /*
  * On the RTL93XX, the RTL93XX_DMA_IF_RX_RING_CNTR track the fill level of 
  * the rings. Writing x into these registers substracts x from its content.
  * When the content reaches the ring size, the ASIC no longer adds
  * packets to this receive queue.
  */
-void rtnc_838x_update_cntr(int r, int released)
-{
-	/* This feature is not available on RTL838x SoCs */
-}
-
-void rtnc_839x_update_cntr(int r, int released)
-{
-	/* This feature is not available on RTL839x SoCs */
-}
-
 void rtnc_930x_update_cntr(int r, int released)
 {
 	int pos = (r % 3) * 10;
@@ -1131,7 +1126,7 @@ static const struct rtnc_reg rtnc_838x_reg = {
 	.get_mac_tx_pause_sts = rtnc_838x_get_mac_tx_pause_sts,
 	.mac = RTL838X_MAC,
 	.l2_tbl_flush_ctrl = RTL838X_L2_TBL_FLUSH_CTRL,
-	.update_cntr = rtnc_838x_update_cntr,
+	.update_cntr = rtnc_83xx_update_cntr,
 	.create_tx_header = rtnc_838x_create_tx_header,
 	.decode_tag = rtnc_838x_decode_tag,
 };
@@ -1156,7 +1151,7 @@ static const struct rtnc_reg rtnc_839x_reg = {
 	.get_mac_tx_pause_sts = rtnc_839x_get_mac_tx_pause_sts,
 	.mac = RTL839X_MAC,
 	.l2_tbl_flush_ctrl = RTL839X_L2_TBL_FLUSH_CTRL,
-	.update_cntr = rtnc_839x_update_cntr,
+	.update_cntr = rtnc_83xx_update_cntr,
 	.create_tx_header = rtnc_839x_create_tx_header,
 	.decode_tag = rtnc_839x_decode_tag,
 };

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -160,7 +160,7 @@ static void rtnc_931x_create_tx_header(struct rtnc_hdr *h, unsigned int dest_por
 		h->cpu_tag[2] = (BIT(5) | (prio & 0x1f)) << 8;
 }
 
-static void rtl93xx_header_vlan_set(struct rtnc_hdr *h, int vlan)
+static void rtnc_93xx_header_vlan_set(struct rtnc_hdr *h, int vlan)
 {
 	h->cpu_tag[2] |= BIT(4); // Enable VLAN forwarding offload
 	h->cpu_tag[2] |= (vlan >> 8) & 0xf;
@@ -223,17 +223,17 @@ extern int rtl931x_write_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 val);
  * When the content reaches the ring size, the ASIC no longer adds
  * packets to this receive queue.
  */
-void rtl838x_update_cntr(int r, int released)
+void rtnc_838x_update_cntr(int r, int released)
 {
 	// This feature is not available on RTL838x SoCs
 }
 
-void rtl839x_update_cntr(int r, int released)
+void rtnc_839x_update_cntr(int r, int released)
 {
 	// This feature is not available on RTL839x SoCs
 }
 
-void rtl930x_update_cntr(int r, int released)
+void rtnc_930x_update_cntr(int r, int released)
 {
 	int pos = (r % 3) * 10;
 	u32 reg = RTL930X_DMA_IF_RX_RING_CNTR + ((r / 3) << 2);
@@ -245,7 +245,7 @@ void rtl930x_update_cntr(int r, int released)
 	sw_w32(v, reg);
 }
 
-void rtl931x_update_cntr(int r, int released)
+void rtnc_931x_update_cntr(int r, int released)
 {
 	int pos = (r % 3) * 10;
 	u32 reg = RTL931X_DMA_IF_RX_RING_CNTR + ((r / 3) << 2);
@@ -540,7 +540,7 @@ static const struct rtl838x_eth_reg rtl838x_reg = {
 	.get_mac_tx_pause_sts = rtl838x_get_mac_tx_pause_sts,
 	.mac = RTL838X_MAC,
 	.l2_tbl_flush_ctrl = RTL838X_L2_TBL_FLUSH_CTRL,
-	.update_cntr = rtl838x_update_cntr,
+	.update_cntr = rtnc_838x_update_cntr,
 	.create_tx_header = rtnc_838x_create_tx_header,
 	.decode_tag = rtl838x_decode_tag,
 };
@@ -565,7 +565,7 @@ static const struct rtl838x_eth_reg rtl839x_reg = {
 	.get_mac_tx_pause_sts = rtl839x_get_mac_tx_pause_sts,
 	.mac = RTL839X_MAC,
 	.l2_tbl_flush_ctrl = RTL839X_L2_TBL_FLUSH_CTRL,
-	.update_cntr = rtl839x_update_cntr,
+	.update_cntr = rtnc_839x_update_cntr,
 	.create_tx_header = rtnc_839x_create_tx_header,
 	.decode_tag = rtl839x_decode_tag,
 };
@@ -596,7 +596,7 @@ static const struct rtl838x_eth_reg rtl930x_reg = {
 	.get_mac_tx_pause_sts = rtl930x_get_mac_tx_pause_sts,
 	.mac = RTL930X_MAC_L2_ADDR_CTRL,
 	.l2_tbl_flush_ctrl = RTL930X_L2_TBL_FLUSH_CTRL,
-	.update_cntr = rtl930x_update_cntr,
+	.update_cntr = rtnc_930x_update_cntr,
 	.create_tx_header = rtnc_930x_create_tx_header,
 	.decode_tag = rtl930x_decode_tag,
 };
@@ -627,7 +627,7 @@ static const struct rtl838x_eth_reg rtl931x_reg = {
 	.get_mac_tx_pause_sts = rtl931x_get_mac_tx_pause_sts,
 	.mac = RTL931X_MAC_L2_ADDR_CTRL,
 	.l2_tbl_flush_ctrl = RTL931X_L2_TBL_FLUSH_CTRL,
-	.update_cntr = rtl931x_update_cntr,
+	.update_cntr = rtnc_931x_update_cntr,
 	.create_tx_header = rtnc_931x_create_tx_header,
 	.decode_tag = rtl931x_decode_tag,
 };
@@ -1215,8 +1215,8 @@ txdone:
  * Return queue number for TX. On the RTL83XX, these queues have equal priority
  * so we do round-robin
  */
-u16 rtl83xx_pick_tx_queue(struct net_device *dev, struct sk_buff *skb,
-			  struct net_device *sb_dev)
+u16 rtnc_83xx_ndo_select_queue(struct net_device *dev, struct sk_buff *skb,
+			       struct net_device *sb_dev)
 {
 	static u8 last = 0;
 
@@ -1227,8 +1227,8 @@ u16 rtl83xx_pick_tx_queue(struct net_device *dev, struct sk_buff *skb,
 /*
  * Return queue number for TX. On the RTL93XX, queue 1 is the high priority queue
  */
-u16 rtl93xx_pick_tx_queue(struct net_device *dev, struct sk_buff *skb,
-			  struct net_device *sb_dev)
+u16 rtnc_93xx_ndo_select_queue(struct net_device *dev, struct sk_buff *skb,
+			       struct net_device *sb_dev)
 {
 	if (skb->priority >= TC_PRIO_CONTROL)
 		return 1;
@@ -1521,7 +1521,7 @@ static void rtl838x_set_mac_hw(struct net_device *dev, u8 *mac)
 	spin_unlock_irqrestore(&priv->lock, flags);
 }
 
-static int rtl838x_set_mac_address(struct net_device *dev, void *p)
+static int rtnc_set_mac_address(struct net_device *dev, void *p)
 {
 	struct rtnc_priv *priv = netdev_priv(dev);
 	const struct sockaddr *addr = p;
@@ -2240,8 +2240,8 @@ static const struct net_device_ops rtl838x_eth_netdev_ops = {
 	.ndo_open = rtnc_ndo_open,
 	.ndo_stop = rtnc_ndo_stop,
 	.ndo_start_xmit = rtnc_ndo_start_xmit,
-	.ndo_select_queue = rtl83xx_pick_tx_queue,
-	.ndo_set_mac_address = rtl838x_set_mac_address,
+	.ndo_select_queue = rtnc_83xx_ndo_select_queue,
+	.ndo_set_mac_address = rtnc_set_mac_address,
 	.ndo_validate_addr = eth_validate_addr,
 	.ndo_set_rx_mode = rtl838x_eth_set_multicast_list,
 	.ndo_tx_timeout = rtnc_ndo_tx_timeout,
@@ -2254,8 +2254,8 @@ static const struct net_device_ops rtl839x_eth_netdev_ops = {
 	.ndo_open = rtnc_ndo_open,
 	.ndo_stop = rtnc_ndo_stop,
 	.ndo_start_xmit = rtnc_ndo_start_xmit,
-	.ndo_select_queue = rtl83xx_pick_tx_queue,
-	.ndo_set_mac_address = rtl838x_set_mac_address,
+	.ndo_select_queue = rtnc_83xx_ndo_select_queue,
+	.ndo_set_mac_address = rtnc_set_mac_address,
 	.ndo_validate_addr = eth_validate_addr,
 	.ndo_set_rx_mode = rtl839x_eth_set_multicast_list,
 	.ndo_tx_timeout = rtnc_ndo_tx_timeout,
@@ -2268,8 +2268,8 @@ static const struct net_device_ops rtl930x_eth_netdev_ops = {
 	.ndo_open = rtnc_ndo_open,
 	.ndo_stop = rtnc_ndo_stop,
 	.ndo_start_xmit = rtnc_ndo_start_xmit,
-	.ndo_select_queue = rtl93xx_pick_tx_queue,
-	.ndo_set_mac_address = rtl838x_set_mac_address,
+	.ndo_select_queue = rtnc_93xx_ndo_select_queue,
+	.ndo_set_mac_address = rtnc_set_mac_address,
 	.ndo_validate_addr = eth_validate_addr,
 	.ndo_set_rx_mode = rtl930x_eth_set_multicast_list,
 	.ndo_tx_timeout = rtnc_ndo_tx_timeout,
@@ -2282,8 +2282,8 @@ static const struct net_device_ops rtl931x_eth_netdev_ops = {
 	.ndo_open = rtnc_ndo_open,
 	.ndo_stop = rtnc_ndo_stop,
 	.ndo_start_xmit = rtnc_ndo_start_xmit,
-	.ndo_select_queue = rtl93xx_pick_tx_queue,
-	.ndo_set_mac_address = rtl838x_set_mac_address,
+	.ndo_select_queue = rtnc_93xx_ndo_select_queue,
+	.ndo_set_mac_address = rtnc_set_mac_address,
 	.ndo_validate_addr = eth_validate_addr,
 	.ndo_set_rx_mode = rtl931x_eth_set_multicast_list,
 	.ndo_tx_timeout = rtnc_ndo_tx_timeout,
@@ -2305,7 +2305,7 @@ static const struct ethtool_ops rtl838x_ethtool_ops = {
 	.set_link_ksettings     = rtl838x_set_link_ksettings,
 };
 
-static void get_soc_info(int *soc_id, int *soc_family)
+static void rtnc_soc_info(int *soc_id, int *soc_family)
 {
 	int id;
 
@@ -2377,7 +2377,7 @@ static int __init rtnc_probe(struct platform_device *pdev)
 		return -EINVAL;
 	}
 
-	get_soc_info(&soc_id, &soc_family);
+	rtnc_soc_info(&soc_id, &soc_family);
 	if (soc_id) {
 		pr_info("Realtek SoC ethernet ID %4x, family %4x\n",
 			soc_id, soc_family);
@@ -2511,7 +2511,7 @@ static int __init rtnc_probe(struct platform_device *pdev)
 		netdev_warn(dev, "Invalid MAC address, using random\n");
 		eth_hw_addr_random(dev);
 		memcpy(sa.sa_data, dev->dev_addr, ETH_ALEN);
-		if (rtl838x_set_mac_address(dev, &sa))
+		if (rtnc_set_mac_address(dev, &sa))
 			netdev_warn(dev, "Failed to set MAC address.\n");
 	}
 	pr_info("Using MAC %08x%08x\n", sw_r32(priv->r->mac),

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -265,7 +265,7 @@ struct rtnc_dsa_tag {
 	bool	crc_error;
 };
 
-bool rtl838x_decode_tag(struct rtnc_hdr *h, struct rtnc_dsa_tag *t)
+bool rtnc_838x_decode_tag(struct rtnc_hdr *h, struct rtnc_dsa_tag *t)
 {
 	/* cpu_tag[0] is reserved. Fields are off-by-one */
 	t->reason = h->cpu_tag[4] & 0xf;
@@ -282,7 +282,7 @@ bool rtl838x_decode_tag(struct rtnc_hdr *h, struct rtnc_dsa_tag *t)
 	return t->l2_offloaded;
 }
 
-bool rtl839x_decode_tag(struct rtnc_hdr *h, struct rtnc_dsa_tag *t)
+bool rtnc_839x_decode_tag(struct rtnc_hdr *h, struct rtnc_dsa_tag *t)
 {
 	/* cpu_tag[0] is reserved. Fields are off-by-one */
 	t->reason = h->cpu_tag[5] & 0x1f;
@@ -300,7 +300,7 @@ bool rtl839x_decode_tag(struct rtnc_hdr *h, struct rtnc_dsa_tag *t)
 	return t->l2_offloaded;
 }
 
-bool rtl930x_decode_tag(struct rtnc_hdr *h, struct rtnc_dsa_tag *t)
+bool rtnc_930x_decode_tag(struct rtnc_hdr *h, struct rtnc_dsa_tag *t)
 {
 	t->reason = h->cpu_tag[7] & 0x3f;
 	t->queue =  (h->cpu_tag[2] >> 11) & 0x1f;
@@ -316,7 +316,7 @@ bool rtl930x_decode_tag(struct rtnc_hdr *h, struct rtnc_dsa_tag *t)
 	return t->l2_offloaded;
 }
 
-bool rtl931x_decode_tag(struct rtnc_hdr *h, struct rtnc_dsa_tag *t)
+bool rtnc_931x_decode_tag(struct rtnc_hdr *h, struct rtnc_dsa_tag *t)
 {
 	t->reason = h->cpu_tag[7] & 0x3f;
 	t->queue =  (h->cpu_tag[2] >> 11) & 0x1f;
@@ -533,16 +533,16 @@ static const struct rtnc_reg rtnc_838x_reg = {
 	.dma_if_rx_ring_cntr = rtnc_838x_dma_if_rx_ring_cntr,
 	.dma_if_rx_cur = RTL838X_DMA_IF_RX_CUR,
 	.rst_glb_ctrl = RTL838X_RST_GLB_CTRL_0,
-	.get_mac_link_sts = rtl838x_get_mac_link_sts,
-	.get_mac_link_dup_sts = rtl838x_get_mac_link_dup_sts,
-	.get_mac_link_spd_sts = rtl838x_get_mac_link_spd_sts,
-	.get_mac_rx_pause_sts = rtl838x_get_mac_rx_pause_sts,
-	.get_mac_tx_pause_sts = rtl838x_get_mac_tx_pause_sts,
+	.get_mac_link_sts = rtnc_838x_get_mac_link_sts,
+	.get_mac_link_dup_sts = rtnc_838x_get_mac_link_dup_sts,
+	.get_mac_link_spd_sts = rtnc_838x_get_mac_link_spd_sts,
+	.get_mac_rx_pause_sts = rtnc_838x_get_mac_rx_pause_sts,
+	.get_mac_tx_pause_sts = rtnc_838x_get_mac_tx_pause_sts,
 	.mac = RTL838X_MAC,
 	.l2_tbl_flush_ctrl = RTL838X_L2_TBL_FLUSH_CTRL,
 	.update_cntr = rtnc_838x_update_cntr,
 	.create_tx_header = rtnc_838x_create_tx_header,
-	.decode_tag = rtl838x_decode_tag,
+	.decode_tag = rtnc_838x_decode_tag,
 };
 
 static const struct rtnc_reg rtnc_839x_reg = {
@@ -558,16 +558,16 @@ static const struct rtnc_reg rtnc_839x_reg = {
 	.dma_if_rx_ring_cntr = rtnc_839x_dma_if_rx_ring_cntr,
 	.dma_if_rx_cur = RTL839X_DMA_IF_RX_CUR,
 	.rst_glb_ctrl = RTL839X_RST_GLB_CTRL,
-	.get_mac_link_sts = rtl839x_get_mac_link_sts,
-	.get_mac_link_dup_sts = rtl839x_get_mac_link_dup_sts,
-	.get_mac_link_spd_sts = rtl839x_get_mac_link_spd_sts,
-	.get_mac_rx_pause_sts = rtl839x_get_mac_rx_pause_sts,
-	.get_mac_tx_pause_sts = rtl839x_get_mac_tx_pause_sts,
+	.get_mac_link_sts = rtnc_839x_get_mac_link_sts,
+	.get_mac_link_dup_sts = rtnc_839x_get_mac_link_dup_sts,
+	.get_mac_link_spd_sts = rtnc_839x_get_mac_link_spd_sts,
+	.get_mac_rx_pause_sts = rtnc_839x_get_mac_rx_pause_sts,
+	.get_mac_tx_pause_sts = rtnc_839x_get_mac_tx_pause_sts,
 	.mac = RTL839X_MAC,
 	.l2_tbl_flush_ctrl = RTL839X_L2_TBL_FLUSH_CTRL,
 	.update_cntr = rtnc_839x_update_cntr,
 	.create_tx_header = rtnc_839x_create_tx_header,
-	.decode_tag = rtl839x_decode_tag,
+	.decode_tag = rtnc_839x_decode_tag,
 };
 
 static const struct rtnc_reg rtnc_930x_reg = {
@@ -589,16 +589,16 @@ static const struct rtnc_reg rtnc_930x_reg = {
 	.dma_if_rx_ring_cntr = rtnc_930x_dma_if_rx_ring_cntr,
 	.dma_if_rx_cur = RTL930X_DMA_IF_RX_CUR,
 	.rst_glb_ctrl = RTL930X_RST_GLB_CTRL_0,
-	.get_mac_link_sts = rtl930x_get_mac_link_sts,
-	.get_mac_link_dup_sts = rtl930x_get_mac_link_dup_sts,
-	.get_mac_link_spd_sts = rtl930x_get_mac_link_spd_sts,
-	.get_mac_rx_pause_sts = rtl930x_get_mac_rx_pause_sts,
-	.get_mac_tx_pause_sts = rtl930x_get_mac_tx_pause_sts,
+	.get_mac_link_sts = rtnc_930x_get_mac_link_sts,
+	.get_mac_link_dup_sts = rtnc_930x_get_mac_link_dup_sts,
+	.get_mac_link_spd_sts = rtnc_930x_get_mac_link_spd_sts,
+	.get_mac_rx_pause_sts = rtnc_930x_get_mac_rx_pause_sts,
+	.get_mac_tx_pause_sts = rtnc_930x_get_mac_tx_pause_sts,
 	.mac = RTL930X_MAC_L2_ADDR_CTRL,
 	.l2_tbl_flush_ctrl = RTL930X_L2_TBL_FLUSH_CTRL,
 	.update_cntr = rtnc_930x_update_cntr,
 	.create_tx_header = rtnc_930x_create_tx_header,
-	.decode_tag = rtl930x_decode_tag,
+	.decode_tag = rtnc_930x_decode_tag,
 };
 
 static const struct rtnc_reg rtnc_931x_reg = {
@@ -620,16 +620,16 @@ static const struct rtnc_reg rtnc_931x_reg = {
 	.dma_if_rx_ring_cntr = rtnc_931x_dma_if_rx_ring_cntr,
 	.dma_if_rx_cur = RTL931X_DMA_IF_RX_CUR,
 	.rst_glb_ctrl = RTL931X_RST_GLB_CTRL,
-	.get_mac_link_sts = rtl931x_get_mac_link_sts,
-	.get_mac_link_dup_sts = rtl931x_get_mac_link_dup_sts,
-	.get_mac_link_spd_sts = rtl931x_get_mac_link_spd_sts,
-	.get_mac_rx_pause_sts = rtl931x_get_mac_rx_pause_sts,
-	.get_mac_tx_pause_sts = rtl931x_get_mac_tx_pause_sts,
+	.get_mac_link_sts = rtnc_931x_get_mac_link_sts,
+	.get_mac_link_dup_sts = rtnc_931x_get_mac_link_dup_sts,
+	.get_mac_link_spd_sts = rtnc_931x_get_mac_link_spd_sts,
+	.get_mac_rx_pause_sts = rtnc_931x_get_mac_rx_pause_sts,
+	.get_mac_tx_pause_sts = rtnc_931x_get_mac_tx_pause_sts,
 	.mac = RTL931X_MAC_L2_ADDR_CTRL,
 	.l2_tbl_flush_ctrl = RTL931X_L2_TBL_FLUSH_CTRL,
 	.update_cntr = rtnc_931x_update_cntr,
 	.create_tx_header = rtnc_931x_create_tx_header,
-	.decode_tag = rtl931x_decode_tag,
+	.decode_tag = rtnc_931x_decode_tag,
 };
 
 static void rtnc_hw_reset(struct rtnc_priv *priv)
@@ -720,7 +720,7 @@ static void rtnc_hw_ring_setup(struct rtnc_priv *priv)
 		sw_w32(KSEG1ADDR(&ring->tx_r[i]), priv->r->dma_tx_base + i * 4);
 }
 
-static void rtl838x_hw_en_rxtx(struct rtnc_priv *priv)
+static void rtnc_838x_hw_en_rxtx(struct rtnc_priv *priv)
 {
 	/* Disable Head of Line features for all RX rings */
 	sw_w32(0xffffffff, priv->r->dma_if_rx_ring_size(0));
@@ -747,7 +747,7 @@ static void rtl838x_hw_en_rxtx(struct rtnc_priv *priv)
 	sw_w32_mask(0, BIT(3), priv->r->mac_port_ctrl(priv->cpu_port));
 }
 
-static void rtl839x_hw_en_rxtx(struct rtnc_priv *priv)
+static void rtnc_839x_hw_en_rxtx(struct rtnc_priv *priv)
 {
 	/* Setup CPU-Port: RX Buffer */
 	sw_w32(0x0000c808, priv->r->dma_if_ctrl);
@@ -771,7 +771,7 @@ static void rtl839x_hw_en_rxtx(struct rtnc_priv *priv)
 	sw_w32_mask(0, 3, priv->r->mac_force_mode_ctrl + priv->cpu_port * 4);
 }
 
-static void rtl93xx_hw_en_rxtx(struct rtnc_priv *priv)
+static void rtnc_93xx_hw_en_rxtx(struct rtnc_priv *priv)
 {
 	int i, pos;
 	u32 v;
@@ -891,7 +891,7 @@ static int rtnc_ndo_open(struct net_device *ndev)
 
 	switch (priv->family_id) {
 	case RTL8380_FAMILY_ID:
-		rtl838x_hw_en_rxtx(priv);
+		rtnc_838x_hw_en_rxtx(priv);
 		/* Trap IGMP/MLD traffic to CPU-Port */
 		sw_w32(0x3, RTL838X_SPCL_TRAP_IGMP_CTRL);
 		/* Flush learned FDB entries on link down of a port */
@@ -899,7 +899,7 @@ static int rtnc_ndo_open(struct net_device *ndev)
 		break;
 
 	case RTL8390_FAMILY_ID:
-		rtl839x_hw_en_rxtx(priv);
+		rtnc_839x_hw_en_rxtx(priv);
 		// Trap MLD and IGMP messages to CPU_PORT
 		sw_w32(0x3, RTL839X_SPCL_TRAP_IGMP_CTRL);
 		/* Flush learned FDB entries on link down of a port */
@@ -907,7 +907,7 @@ static int rtnc_ndo_open(struct net_device *ndev)
 		break;
 
 	case RTL9300_FAMILY_ID:
-		rtl93xx_hw_en_rxtx(priv);
+		rtnc_93xx_hw_en_rxtx(priv);
 		/* Flush learned FDB entries on link down of a port */
 		sw_w32_mask(0, BIT(7), RTL930X_L2_CTRL);
 		// Trap MLD and IGMP messages to CPU_PORT
@@ -915,7 +915,7 @@ static int rtnc_ndo_open(struct net_device *ndev)
 		break;
 
 	case RTL9310_FAMILY_ID:
-		rtl93xx_hw_en_rxtx(priv);
+		rtnc_93xx_hw_en_rxtx(priv);
 
 		// Trap MLD and IGMP messages to CPU_PORT
 		sw_w32((0x2 << 3) | 0x2,  RTL931X_VLAN_APP_PKT_CTRL);
@@ -1018,7 +1018,7 @@ static int rtnc_ndo_stop(struct net_device *ndev)
 	return 0;
 }
 
-static void rtl838x_eth_set_multicast_list(struct net_device *ndev)
+static void rtnc_838x_ndo_set_rx_mode(struct net_device *ndev)
 {
 	/*
 	 * Flood all classes of RMA addresses (01-80-C2-00-00-{01..2F})
@@ -1036,7 +1036,7 @@ static void rtl838x_eth_set_multicast_list(struct net_device *ndev)
 	}
 }
 
-static void rtl839x_eth_set_multicast_list(struct net_device *ndev)
+static void rtnc_839x_ndo_set_rx_mode(struct net_device *ndev)
 {
 	/*
 	 * Flood all classes of RMA addresses (01-80-C2-00-00-{01..2F})
@@ -1063,7 +1063,7 @@ static void rtl839x_eth_set_multicast_list(struct net_device *ndev)
 	}
 }
 
-static void rtl930x_eth_set_multicast_list(struct net_device *ndev)
+static void rtnc_930x_ndo_set_rx_mode(struct net_device *ndev)
 {
 	/*
 	 * Flood all classes of RMA addresses (01-80-C2-00-00-{01..2F})
@@ -1082,7 +1082,7 @@ static void rtl930x_eth_set_multicast_list(struct net_device *ndev)
 	}
 }
 
-static void rtl931x_eth_set_multicast_list(struct net_device *ndev)
+static void rtnc_931x_ndo_set_rx_mode(struct net_device *ndev)
 {
 	/*
 	 * Flood all classes of RMA addresses (01-80-C2-00-00-{01..2F})
@@ -1110,7 +1110,7 @@ static void rtnc_ndo_tx_timeout(struct net_device *ndev, unsigned int txqueue)
 	spin_lock_irqsave(&priv->lock, flags);
 	rtnc_hw_stop(priv);
 	rtnc_hw_ring_setup(priv);
-	rtl838x_hw_en_rxtx(priv);
+	rtnc_838x_hw_en_rxtx(priv);
 	netif_trans_update(ndev);
 	netif_start_queue(ndev);
 	spin_unlock_irqrestore(&priv->lock, flags);
@@ -1411,7 +1411,7 @@ static void rtl838x_mac_config(struct phylink_config *config,
 	pr_info("In %s, mode %x\n", __func__, mode);
 }
 
-static void rtl838x_mac_an_restart(struct phylink_config *config)
+static void rtnc_mac_an_restart(struct phylink_config *config)
 {
 	struct net_device *dev = container_of(config->dev, struct net_device, dev);
 	struct rtnc_priv *priv = netdev_priv(dev);
@@ -1427,7 +1427,7 @@ static void rtl838x_mac_an_restart(struct phylink_config *config)
 	sw_w32(0x6192F, priv->r->mac_force_mode_ctrl + priv->cpu_port * 4);
 }
 
-static void rtl838x_mac_pcs_get_state(struct phylink_config *config,
+static void rtnc_mac_pcs_get_state(struct phylink_config *config,
 				  struct phylink_link_state *state)
 {
 	u32 speed;
@@ -1473,7 +1473,7 @@ static void rtl838x_mac_pcs_get_state(struct phylink_config *config,
 		state->pause |= MLO_PAUSE_TX;
 }
 
-static void rtl838x_mac_link_down(struct phylink_config *config,
+static void rtnc_mac_link_down(struct phylink_config *config,
 				  unsigned int mode,
 				  phy_interface_t interface)
 {
@@ -1485,7 +1485,7 @@ static void rtl838x_mac_link_down(struct phylink_config *config,
 	sw_w32_mask(0x03, 0, priv->r->mac_port_ctrl(priv->cpu_port));
 }
 
-static void rtl838x_mac_link_up(struct phylink_config *config,
+static void rtnc_mac_link_up(struct phylink_config *config,
 			    struct phy_device *phy, unsigned int mode,
 			    phy_interface_t interface, int speed, int duplex,
 			    bool tx_pause, bool rx_pause)
@@ -2243,7 +2243,7 @@ static const struct net_device_ops rtl838x_eth_netdev_ops = {
 	.ndo_select_queue = rtnc_83xx_ndo_select_queue,
 	.ndo_set_mac_address = rtnc_set_mac_address,
 	.ndo_validate_addr = eth_validate_addr,
-	.ndo_set_rx_mode = rtl838x_eth_set_multicast_list,
+	.ndo_set_rx_mode = rtnc_838x_ndo_set_rx_mode,
 	.ndo_tx_timeout = rtnc_ndo_tx_timeout,
 	.ndo_set_features = rtl83xx_set_features,
 	.ndo_fix_features = rtl838x_fix_features,
@@ -2257,7 +2257,7 @@ static const struct net_device_ops rtl839x_eth_netdev_ops = {
 	.ndo_select_queue = rtnc_83xx_ndo_select_queue,
 	.ndo_set_mac_address = rtnc_set_mac_address,
 	.ndo_validate_addr = eth_validate_addr,
-	.ndo_set_rx_mode = rtl839x_eth_set_multicast_list,
+	.ndo_set_rx_mode = rtnc_839x_ndo_set_rx_mode,
 	.ndo_tx_timeout = rtnc_ndo_tx_timeout,
 	.ndo_set_features = rtl83xx_set_features,
 	.ndo_fix_features = rtl838x_fix_features,
@@ -2271,7 +2271,7 @@ static const struct net_device_ops rtl930x_eth_netdev_ops = {
 	.ndo_select_queue = rtnc_93xx_ndo_select_queue,
 	.ndo_set_mac_address = rtnc_set_mac_address,
 	.ndo_validate_addr = eth_validate_addr,
-	.ndo_set_rx_mode = rtl930x_eth_set_multicast_list,
+	.ndo_set_rx_mode = rtnc_930x_ndo_set_rx_mode,
 	.ndo_tx_timeout = rtnc_ndo_tx_timeout,
 	.ndo_set_features = rtl93xx_set_features,
 	.ndo_fix_features = rtl838x_fix_features,
@@ -2285,7 +2285,7 @@ static const struct net_device_ops rtl931x_eth_netdev_ops = {
 	.ndo_select_queue = rtnc_93xx_ndo_select_queue,
 	.ndo_set_mac_address = rtnc_set_mac_address,
 	.ndo_validate_addr = eth_validate_addr,
-	.ndo_set_rx_mode = rtl931x_eth_set_multicast_list,
+	.ndo_set_rx_mode = rtnc_931x_ndo_set_rx_mode,
 	.ndo_tx_timeout = rtnc_ndo_tx_timeout,
 	.ndo_set_features = rtl93xx_set_features,
 	.ndo_fix_features = rtl838x_fix_features,
@@ -2293,11 +2293,11 @@ static const struct net_device_ops rtl931x_eth_netdev_ops = {
 
 static const struct phylink_mac_ops rtl838x_phylink_ops = {
 	.validate = rtnc_validate,
-	.mac_pcs_get_state = rtl838x_mac_pcs_get_state,
-	.mac_an_restart = rtl838x_mac_an_restart,
+	.mac_pcs_get_state = rtnc_mac_pcs_get_state,
+	.mac_an_restart = rtnc_mac_an_restart,
 	.mac_config = rtl838x_mac_config,
-	.mac_link_down = rtl838x_mac_link_down,
-	.mac_link_up = rtl838x_mac_link_up,
+	.mac_link_down = rtnc_mac_link_down,
+	.mac_link_up = rtnc_mac_link_up,
 };
 
 static const struct ethtool_ops rtl838x_ethtool_ops = {

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -2508,7 +2508,7 @@ static int __init rtl838x_eth_probe(struct platform_device *pdev)
 	for (i = 0; i < priv->rxrings; i++) {
 		priv->rx_qs[i].id = i;
 		priv->rx_qs[i].priv = priv;
-		netif_napi_add(dev, &priv->rx_qs[i].napi, rtl838x_poll_rx, 64);
+		netif_napi_add(dev, &priv->rx_qs[i].napi, rtl838x_poll_rx, NAPI_POLL_WEIGHT);
 	}
 
 	platform_set_drvdata(pdev, dev);

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -1282,10 +1282,9 @@ static int rtl838x_hw_receive(struct net_device *dev, int r, int budget)
 			break;
 		work_done++;
 
-		len -= 4; /* strip the CRC */
-		/* Add 4 bytes for cpu_tag */
-		if (dsa)
-			len += 4;
+		/* Reuse CRC for DSA tag or strip it otherwise */
+		if (!dsa)
+			len -= 4;
 
 		skb = netdev_alloc_skb(dev, len + 4);
 		skb_reserve(skb, NET_IP_ALIGN);

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -1255,7 +1255,7 @@ static int rtl838x_hw_receive(struct net_device *dev, int r, int budget)
 	LIST_HEAD(rx_list);
 	unsigned long flags;
 	int i, len, work_done = 0;
-	u8 *data, *skb_data;
+	u8 *data;
 	unsigned int val;
 	u32	*last;
 	struct p_hdr *h;
@@ -1301,11 +1301,10 @@ static int rtl838x_hw_receive(struct net_device *dev, int r, int budget)
 				}
 			}
 
-			skb_data = skb_put(skb, len);
-			/* Make sure data is visible */
+			/* Make new data visible for CPU */
 			mb();
 			dma_sync_single_for_device(&priv->pdev->dev, CPHYSADDR(data), len, DMA_FROM_DEVICE);
-			memcpy(skb->data, (u8 *)KSEG0ADDR(data), len);
+			skb_put_data(skb, (u8 *)KSEG0ADDR(data), len);
 			/* Overwrite CRC with cpu_tag */
 			if (dsa) {
 				priv->r->decode_tag(h, &tag);

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -134,7 +134,7 @@ struct rtnc_dsa_tag {
 	bool			crc_error;
 };
 
-struct fdb_update_work {
+struct rtnc_fdb_update {
 	struct work_struct	work;
 	struct net_device	*ndev;
 	u64			macs[RTNC_NOTIFY_EVENTS + 1];
@@ -962,8 +962,8 @@ static void rtnc_rb_cleanup(struct rtnc_priv *priv, int status)
 
 void rtnc_fdb_sync(struct work_struct *work)
 {
-	const struct fdb_update_work *uw =
-		container_of(work, struct fdb_update_work, work);
+	const struct rtnc_fdb_update *uw =
+		container_of(work, struct rtnc_fdb_update, work);
 	struct switchdev_notifier_fdb_info info;
 	u8 addr[ETH_ALEN];
 	int i = 0;
@@ -990,7 +990,7 @@ static void rtnc_839x_l2_notification_handler(struct rtnc_priv *priv)
 	struct n_event *event;
 	int i;
 	u64 mac;
-	struct fdb_update_work *w;
+	struct rtnc_fdb_update *w;
 
 	while (!(nb->ring[e] & 1)) {
 		w = kzalloc(sizeof(*w), GFP_ATOMIC);

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -456,11 +456,8 @@ static irqreturn_t rtl83xx_net_irq(int irq, void *dev_id)
 		}
 	}
 
-	/* RX buffer overrun */
+	/* RX buffer overrun interrupts are ignored for now */
 	if (status & 0x0000ff) {
-		pr_err("RX buffer overrun: status %x, mask: %x\n",
-			 status, sw_r32(priv->r->dma_if_intr_msk));
-		rtl838x_rb_cleanup(priv, status & 0xff);
 	}
 
 	/* Notification interrupts */
@@ -1259,7 +1256,7 @@ static int rtl838x_hw_receive(struct net_device *dev, int r, int budget)
 	do {
 		if ((ring->rx_r[r][idx] & R_OWN_ETH)) {
 			if (&ring->rx_r[r][idx] != last) {
-				netdev_warn(dev, "Ring contention: r: %x, last %x, cur %x\n",
+				netdev_dbg(dev, "Ring contention: r: %x, last %x, cur %x\n",
 				    r, (uint32_t)last, (u32) &ring->rx_r[r][idx]);
 			}
 			break;

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -191,7 +191,7 @@ struct rtnc_priv {
 	struct phylink_config phylink_config;
 	u16 id;
 	u16 family_id;
-	const struct rtl838x_eth_reg *r;
+	const struct rtnc_reg *r;
 	u8 cpu_port;
 	u32 lastEvent;
 	u16 rxrings;
@@ -520,7 +520,7 @@ static irqreturn_t rtnc_93xx_net_irq(int irq, void *dev_id)
 	return IRQ_HANDLED;
 }
 
-static const struct rtl838x_eth_reg rtl838x_reg = {
+static const struct rtnc_reg rtnc_838x_reg = {
 	.net_irq = rtnc_83xx_net_irq,
 	.mac_port_ctrl = rtnc_838x_mac_port_ctrl,
 	.dma_if_intr_sts = RTL838X_DMA_IF_INTR_STS,
@@ -529,8 +529,8 @@ static const struct rtl838x_eth_reg rtl838x_reg = {
 	.mac_force_mode_ctrl = RTL838X_MAC_FORCE_MODE_CTRL,
 	.dma_rx_base = RTL838X_DMA_RX_BASE,
 	.dma_tx_base = RTL838X_DMA_TX_BASE,
-	.dma_if_rx_ring_size = rtl838x_dma_if_rx_ring_size,
-	.dma_if_rx_ring_cntr = rtl838x_dma_if_rx_ring_cntr,
+	.dma_if_rx_ring_size = rtnc_838x_dma_if_rx_ring_size,
+	.dma_if_rx_ring_cntr = rtnc_838x_dma_if_rx_ring_cntr,
 	.dma_if_rx_cur = RTL838X_DMA_IF_RX_CUR,
 	.rst_glb_ctrl = RTL838X_RST_GLB_CTRL_0,
 	.get_mac_link_sts = rtl838x_get_mac_link_sts,
@@ -545,7 +545,7 @@ static const struct rtl838x_eth_reg rtl838x_reg = {
 	.decode_tag = rtl838x_decode_tag,
 };
 
-static const struct rtl838x_eth_reg rtl839x_reg = {
+static const struct rtnc_reg rtnc_839x_reg = {
 	.net_irq = rtnc_83xx_net_irq,
 	.mac_port_ctrl = rtnc_839x_mac_port_ctrl,
 	.dma_if_intr_sts = RTL839X_DMA_IF_INTR_STS,
@@ -554,8 +554,8 @@ static const struct rtl838x_eth_reg rtl839x_reg = {
 	.mac_force_mode_ctrl = RTL839X_MAC_FORCE_MODE_CTRL,
 	.dma_rx_base = RTL839X_DMA_RX_BASE,
 	.dma_tx_base = RTL839X_DMA_TX_BASE,
-	.dma_if_rx_ring_size = rtl839x_dma_if_rx_ring_size,
-	.dma_if_rx_ring_cntr = rtl839x_dma_if_rx_ring_cntr,
+	.dma_if_rx_ring_size = rtnc_839x_dma_if_rx_ring_size,
+	.dma_if_rx_ring_cntr = rtnc_839x_dma_if_rx_ring_cntr,
 	.dma_if_rx_cur = RTL839X_DMA_IF_RX_CUR,
 	.rst_glb_ctrl = RTL839X_RST_GLB_CTRL,
 	.get_mac_link_sts = rtl839x_get_mac_link_sts,
@@ -570,7 +570,7 @@ static const struct rtl838x_eth_reg rtl839x_reg = {
 	.decode_tag = rtl839x_decode_tag,
 };
 
-static const struct rtl838x_eth_reg rtl930x_reg = {
+static const struct rtnc_reg rtnc_930x_reg = {
 	.net_irq = rtnc_93xx_net_irq,
 	.mac_port_ctrl = rtnc_930x_mac_port_ctrl,
 	.dma_if_intr_rx_runout_sts = RTL930X_DMA_IF_INTR_RX_RUNOUT_STS,
@@ -585,8 +585,8 @@ static const struct rtl838x_eth_reg rtl930x_reg = {
 	.mac_force_mode_ctrl = RTL930X_MAC_FORCE_MODE_CTRL,
 	.dma_rx_base = RTL930X_DMA_RX_BASE,
 	.dma_tx_base = RTL930X_DMA_TX_BASE,
-	.dma_if_rx_ring_size = rtl930x_dma_if_rx_ring_size,
-	.dma_if_rx_ring_cntr = rtl930x_dma_if_rx_ring_cntr,
+	.dma_if_rx_ring_size = rtnc_930x_dma_if_rx_ring_size,
+	.dma_if_rx_ring_cntr = rtnc_930x_dma_if_rx_ring_cntr,
 	.dma_if_rx_cur = RTL930X_DMA_IF_RX_CUR,
 	.rst_glb_ctrl = RTL930X_RST_GLB_CTRL_0,
 	.get_mac_link_sts = rtl930x_get_mac_link_sts,
@@ -601,7 +601,7 @@ static const struct rtl838x_eth_reg rtl930x_reg = {
 	.decode_tag = rtl930x_decode_tag,
 };
 
-static const struct rtl838x_eth_reg rtl931x_reg = {
+static const struct rtnc_reg rtnc_931x_reg = {
 	.net_irq = rtnc_93xx_net_irq,
 	.mac_port_ctrl = rtnc_931x_mac_port_ctrl,
 	.dma_if_intr_rx_runout_sts = RTL931X_DMA_IF_INTR_RX_RUNOUT_STS,
@@ -616,8 +616,8 @@ static const struct rtl838x_eth_reg rtl931x_reg = {
 	.mac_force_mode_ctrl = RTL931X_MAC_FORCE_MODE_CTRL,
 	.dma_rx_base = RTL931X_DMA_RX_BASE,
 	.dma_tx_base = RTL931X_DMA_TX_BASE,
-	.dma_if_rx_ring_size = rtl931x_dma_if_rx_ring_size,
-	.dma_if_rx_ring_cntr = rtl931x_dma_if_rx_ring_cntr,
+	.dma_if_rx_ring_size = rtnc_931x_dma_if_rx_ring_size,
+	.dma_if_rx_ring_cntr = rtnc_931x_dma_if_rx_ring_cntr,
 	.dma_if_rx_cur = RTL931X_DMA_IF_RX_CUR,
 	.rst_glb_ctrl = RTL931X_RST_GLB_CTRL,
 	.get_mac_link_sts = rtl931x_get_mac_link_sts,
@@ -1235,7 +1235,7 @@ u16 rtnc_93xx_ndo_select_queue(struct net_device *dev, struct sk_buff *skb,
 	return 0;
 }
 
-static int rtl838x_hw_receive(struct net_device *dev, int r, int budget)
+static int rtnc_hw_receive(struct net_device *dev, int r, int budget)
 {
 	struct rtnc_priv *priv = netdev_priv(dev);
 	struct ring_b *ring = priv->ring;
@@ -1335,7 +1335,7 @@ static int rtnc_poll_rx(struct napi_struct *napi, int budget)
 	int work;
 
 	while (work_done < budget) {
-		work = rtl838x_hw_receive(priv->netdev, r, budget - work_done);
+		work = rtnc_hw_receive(priv->netdev, r, budget - work_done);
 		if (!work)
 			break;
 		work_done += work;
@@ -1352,7 +1352,7 @@ static int rtnc_poll_rx(struct napi_struct *napi, int budget)
 }
 
 
-static void rtl838x_validate(struct phylink_config *config,
+static void rtnc_validate(struct phylink_config *config,
 			 unsigned long *supported,
 			 struct phylink_link_state *state)
 {
@@ -1498,7 +1498,7 @@ static void rtl838x_mac_link_up(struct phylink_config *config,
 	sw_w32_mask(0, 0x03, priv->r->mac_port_ctrl(priv->cpu_port));
 }
 
-static void rtl838x_set_mac_hw(struct net_device *dev, u8 *mac)
+static void rtnc_set_mac_hw(struct net_device *dev, u8 *mac)
 {
 	struct rtnc_priv *priv = netdev_priv(dev);
 	unsigned long flags;
@@ -1531,24 +1531,24 @@ static int rtnc_set_mac_address(struct net_device *dev, void *p)
 		return -EADDRNOTAVAIL;
 
 	memcpy(dev->dev_addr, addr->sa_data, ETH_ALEN);
-	rtl838x_set_mac_hw(dev, mac);
+	rtnc_set_mac_hw(dev, mac);
 
 	pr_info("Using MAC %08x%08x\n", sw_r32(priv->r->mac), sw_r32(priv->r->mac + 4));
 	return 0;
 }
 
-static int rtl8390_init_mac(struct rtnc_priv *priv)
+static int rtnc_839x_init_mac(struct rtnc_priv *priv)
 {
 	// We will need to set-up EEE and the egress-rate limitation
 	return 0;
 }
 
-static int rtl8380_init_mac(struct rtnc_priv *priv)
+static int rtnc_838x_init_mac(struct rtnc_priv *priv)
 {
 	int i;
 
 	if (priv->family_id == RTL8390_FAMILY_ID)
-		return rtl8390_init_mac(priv);
+		return rtnc_839x_init_mac(priv);
 
     // At present we do not know how to set up EEE on any other SoC than RTL8380
 	if (priv->family_id != RTL8380_FAMILY_ID)
@@ -2292,7 +2292,7 @@ static const struct net_device_ops rtl931x_eth_netdev_ops = {
 };
 
 static const struct phylink_mac_ops rtl838x_phylink_ops = {
-	.validate = rtl838x_validate,
+	.validate = rtnc_validate,
 	.mac_pcs_get_state = rtl838x_mac_pcs_get_state,
 	.mac_an_restart = rtl838x_mac_an_restart,
 	.mac_config = rtl838x_mac_config,
@@ -2446,22 +2446,22 @@ static int __init rtnc_probe(struct platform_device *pdev)
 	switch (priv->family_id) {
 	case RTL8380_FAMILY_ID:
 		priv->cpu_port = RTL838X_CPU_PORT;
-		priv->r = &rtl838x_reg;
+		priv->r = &rtnc_838x_reg;
 		dev->netdev_ops = &rtl838x_eth_netdev_ops;
 		break;
 	case RTL8390_FAMILY_ID:
 		priv->cpu_port = RTL839X_CPU_PORT;
-		priv->r = &rtl839x_reg;
+		priv->r = &rtnc_839x_reg;
 		dev->netdev_ops = &rtl839x_eth_netdev_ops;
 		break;
 	case RTL9300_FAMILY_ID:
 		priv->cpu_port = RTL930X_CPU_PORT;
-		priv->r = &rtl930x_reg;
+		priv->r = &rtnc_930x_reg;
 		dev->netdev_ops = &rtl930x_eth_netdev_ops;
 		break;
 	case RTL9310_FAMILY_ID:
 		priv->cpu_port = RTL931X_CPU_PORT;
-		priv->r = &rtl931x_reg;
+		priv->r = &rtnc_931x_reg;
 		dev->netdev_ops = &rtl931x_eth_netdev_ops;
 		rtl931x_chip_init(priv);
 		break;
@@ -2487,7 +2487,7 @@ static int __init rtnc_probe(struct platform_device *pdev)
 		goto err_free;
 	}
 
-	rtl8380_init_mac(priv);
+	rtnc_838x_init_mac(priv);
 
 	/* try to get mac address in the following order:
 	 * 1) from device tree data
@@ -2495,7 +2495,7 @@ static int __init rtnc_probe(struct platform_device *pdev)
 	 */
 	of_get_mac_address(pdev->dev.of_node, dev->dev_addr);
 	if (is_valid_ether_addr(dev->dev_addr)) {
-		rtl838x_set_mac_hw(dev, (u8 *)dev->dev_addr);
+		rtnc_set_mac_hw(dev, (u8 *)dev->dev_addr);
 	} else {
 		dev->dev_addr[0] = (sw_r32(priv->r->mac) >> 8) & 0xff;
 		dev->dev_addr[1] = sw_r32(priv->r->mac) & 0xff;

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -460,7 +460,7 @@ static irqreturn_t rtl83xx_net_irq(int irq, void *dev_id)
 
 	/* RX buffer overrun */
 	if (status & 0x000ff) {
-		pr_debug("RX buffer overrun: status %x, mask: %x\n",
+		pr_err("RX buffer overrun: status %x, mask: %x\n",
 			 status, sw_r32(priv->r->dma_if_intr_msk));
 		sw_w32(status, priv->r->dma_if_intr_sts);
 		rtl838x_rb_cleanup(priv, status & 0xff);

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -953,8 +953,7 @@ static void rtnc_rb_cleanup(struct rtnc_priv *priv, int status)
 			/* make sure the header is visible to the ASIC */
 			mb();
 
-			ring->rx_r[r][idx] = KSEG1ADDR(h) |
-				(idx == (priv->rxringlen - 1) ? RTNC_OWN_ETH | RTNC_WRAP : RTNC_OWN_ETH);
+			ring->rx_r[r][idx] |= RTNC_OWN_ETH;
 			idx = (idx + 1) % priv->rxringlen;
 		} while (&ring->rx_r[r][idx] != last);
 		ring->c_rx[r] = idx;
@@ -1899,8 +1898,7 @@ static int rtnc_hw_receive(struct net_device *dev, int r, int budget)
 			dev->stats.rx_dropped++;
 		}
 
-		ring->rx_r[r][idx] = KSEG1ADDR(h) |
-			(idx == (priv->rxringlen - 1) ? RTNC_OWN_ETH | RTNC_WRAP : RTNC_OWN_ETH);
+		ring->rx_r[r][idx] |= RTNC_OWN_ETH;
 		idx = (idx + 1) % priv->rxringlen;
 	};
 

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -813,36 +813,32 @@ static void rtl93xx_hw_en_rxtx(struct rtl838x_eth_priv *priv)
 static void rtl838x_setup_ring_buffer(struct rtl838x_eth_priv *priv, struct ring_b *ring)
 {
 	int i, j;
-
+	char *buf;
 	struct p_hdr *h;
 
+	buf = (u8 *)KSEG1ADDR(priv->rxspace);
 	for (i = 0; i < priv->rxrings; i++) {
-		for (j = 0; j < priv->rxringlen; j++) {
+		for (j = 0; j < priv->rxringlen; j++, buf += RING_BUFFER) {
 			h = &ring->rx_header[i][j];
 			memset(h, 0, sizeof(struct p_hdr));
-			h->buf = (u8 *)KSEG1ADDR(priv->rxspace
-					+ i * priv->rxringlen * RING_BUFFER
-					+ j * RING_BUFFER);
+			h->buf = buf;
 			h->size = RING_BUFFER;
-			/* All rings owned by switch, last one wraps */
 			ring->rx_r[i][j] = KSEG1ADDR(h) | R_OWN_ETH;
 		}
-		ring->rx_r[i][j-1] |= R_WRAP;
+		ring->rx_r[i][j - 1] |= R_WRAP;
 		ring->c_rx[i] = 0;
 	}
 
+	buf = (u8 *)KSEG1ADDR(priv->txspace);
 	for (i = 0; i < TXRINGS; i++) {
-		for (j = 0; j < TXRINGLEN; j++) {
+		for (j = 0; j < TXRINGLEN; j++, buf += RING_BUFFER) {
 			h = &ring->tx_header[i][j];
 			memset(h, 0, sizeof(struct p_hdr));
-			h->buf = (u8 *)KSEG1ADDR(priv->txspace
-					+ i * TXRINGLEN * RING_BUFFER
-					+ j * RING_BUFFER);
+			h->buf = buf;
 			h->size = RING_BUFFER;
 			ring->tx_r[i][j] = KSEG1ADDR(h) | R_OWN_CPU;
 		}
-		/* Last header is wrapping around */
-		ring->tx_r[i][j-1] |= R_WRAP;
+		ring->tx_r[i][j - 1] |= R_WRAP;
 		ring->c_tx[i] = 0;
 	}
 }

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -415,7 +415,7 @@ static int rtmd_838x_reset(struct mii_bus *bus)
 	/* Enable PHY control via SoC */
 	sw_w32_mask(0, 1 << 15, RTL838X_SMI_GLB_CTRL);
 
-	// Probably should reset all PHYs here...
+	/* Probably should reset all PHYs here... */
 	return 0;
 }
 
@@ -431,7 +431,7 @@ static int rtmd_839x_reset(struct mii_bus *bus)
 	/* Disable PHY polling via SoC */
 	sw_w32_mask(1 << 7, 0, RTL839X_SMI_GLB_CTRL);
 
-	// Probably should reset all PHYs here...
+	/* Probably should reset all PHYs here... */
 	return 0;
 }
 
@@ -448,10 +448,10 @@ static int rtmd_930x_reset(struct mii_bus *bus)
 	u32 poll_ctrl = 0;
 	u32 private_poll_mask = 0;
 	u32 v;
-	bool uses_usxgmii = false; // For the Aquantia PHYs
-	bool uses_hisgmii = false; // For the RTL8221/8226
+	bool uses_usxgmii = false; /* For the Aquantia PHYs */
+	bool uses_hisgmii = false; /* For the RTL8221/8226 */
 
-	// Mapping of port to phy-addresses on an SMI bus
+	/* Mapping of port to phy-addresses on an SMI bus */
 	poll_sel[0] = poll_sel[1] = 0;
 	for (i = 0; i < RTL930X_CPU_PORT; i++) {
 		if (priv->smi_bus[i] > 3)
@@ -465,14 +465,14 @@ static int rtmd_930x_reset(struct mii_bus *bus)
 		poll_ctrl |= BIT(20 + priv->smi_bus[i]);
 	}
 
-	// Configure which SMI bus is behind which port number
+	/* Configure which SMI bus is behind which port number */
 	sw_w32(poll_sel[0], RTL930X_SMI_PORT0_15_POLLING_SEL);
 	sw_w32(poll_sel[1], RTL930X_SMI_PORT16_27_POLLING_SEL);
 
-	// Disable POLL_SEL for any SMI bus with a normal PHY (not RTL8295R for SFP+)
+	/* Disable POLL_SEL for any SMI bus with a normal PHY (not RTL8295R for SFP+) */
 	sw_w32_mask(poll_ctrl, 0, RTL930X_SMI_GLB_CTRL);
 
-	// Configure which SMI busses are polled in c45 based on a c45 PHY being on that bus
+	/* Configure which SMI busses are polled in c45 based on a c45 PHY being on that bus */
 	for (i = 0; i < 4; i++)
 		if (priv->smi_bus_isc45[i])
 			c45_mask |= BIT(i + 16);
@@ -480,13 +480,15 @@ static int rtmd_930x_reset(struct mii_bus *bus)
 	pr_info("c45_mask: %08x\n", c45_mask);
 	sw_w32_mask(0, c45_mask, RTL930X_SMI_GLB_CTRL);
 
-	// Set the MAC type of each port according to the PHY-interface
-	// Values are FE: 2, GE: 3, XGE/2.5G: 0(SERDES) or 1(otherwise), SXGE: 0
+	/*
+	 * Set the MAC type of each port according to the PHY-interface
+	 * Values are FE: 2, GE: 3, XGE/2.5G: 0(SERDES) or 1(otherwise), SXGE: 0
+	 */
 	v = 0;
 	for (i = 0; i < RTL930X_CPU_PORT; i++) {
 		switch (priv->interfaces[i]) {
 		case PHY_INTERFACE_MODE_10GBASER:
-			break;			// Serdes: Value = 0
+			break; /* Serdes: Value = 0 */
 
 		case PHY_INTERFACE_MODE_HSGMII:
 			private_poll_mask |= BIT(i);
@@ -507,12 +509,14 @@ static int rtmd_930x_reset(struct mii_bus *bus)
 	}
 	sw_w32(v, RTL930X_SMI_MAC_TYPE_CTRL);
 
-	// Set the private polling mask for all Realtek PHYs (i.e. not the 10GBit Aquantia ones)
+	/* Set the private polling mask for all Realtek PHYs (i.e. not the 10GBit Aquantia ones) */
 	sw_w32(private_poll_mask, RTL930X_SMI_PRVTE_POLLING_CTRL);
 
-	/* The following magic values are found in the port configuration, they seem to
+	/*
+	 * The following magic values are found in the port configuration, they seem to
 	 * define different ways of polling a PHY. The below is for the Aquantia PHYs of
-	 * the XGS1250 and the RTL8226 of the XGS1210 */
+	 * the XGS1250 and the RTL8226 of the XGS1210
+	 */
 	if (uses_usxgmii) {
 		sw_w32(0x01010000, RTL930X_SMI_10GPHY_POLLING_REG0_CFG);
 		sw_w32(0x01E7C400, RTL930X_SMI_10GPHY_POLLING_REG9_CFG);
@@ -554,13 +558,13 @@ static int rtmd_931x_reset(struct mii_bus *bus)
 	bool mdc_on[4];
 
 	pr_info("%s called\n", __func__);
-	// Disable port polling for configuration purposes
+	/* Disable port polling for configuration purposes */
 	sw_w32(0, RTL931X_SMI_PORT_POLLING_CTRL);
 	sw_w32(0, RTL931X_SMI_PORT_POLLING_CTRL + 4);
 	msleep(100);
 
 	mdc_on[0] = mdc_on[1] = mdc_on[2] = mdc_on[3] = false;
-	// Mapping of port to phy-addresses on an SMI bus
+	/* Mapping of port to phy-addresses on an SMI bus */
 	poll_sel[0] = poll_sel[1] = poll_sel[2] = poll_sel[3] = 0;
 	for (i = 0; i < 56; i++) {
 		pos = (i % 6) * 5;
@@ -571,20 +575,20 @@ static int rtmd_931x_reset(struct mii_bus *bus)
 		mdc_on[priv->smi_bus[i]] = true;
 	}
 
-	// Configure which SMI bus is behind which port number
+	/* Configure which SMI bus is behind which port number */
 	for (i = 0; i < 4; i++) {
 		pr_info("poll sel %d, %08x\n", i, poll_sel[i]);
 		sw_w32(poll_sel[i], RTL931X_SMI_PORT_POLLING_SEL + (i * 4));
 	}
 
-	// Configure which SMI busses
+	/* Configure which SMI busses */
 	pr_info("%s: WAS RTL931X_MAC_L2_GLOBAL_CTRL2 %08x\n", __func__, sw_r32(RTL931X_MAC_L2_GLOBAL_CTRL2));
 	pr_info("c45_mask: %08x, RTL931X_SMI_GLB_CTRL0 was %X", c45_mask, sw_r32(RTL931X_SMI_GLB_CTRL0));
 	for (i = 0; i < 4; i++) {
-		// bus is polled in c45
+		/* bus is polled in c45 */
 		if (priv->smi_bus_isc45[i])
-			c45_mask |= 0x2 << (i * 2);  // Std. C45, non-standard is 0x3
-		// Enable bus access via MDC
+			c45_mask |= 0x2 << (i * 2);  /* Std. C45, non-standard is 0x3 */
+		/* Enable bus access via MDC */
 		if (mdc_on[i])
 			sw_w32_mask(0, BIT(9 + i), RTL931X_MAC_L2_GLOBAL_CTRL2);
 	}
@@ -592,11 +596,12 @@ static int rtmd_931x_reset(struct mii_bus *bus)
 	pr_info("%s: RTL931X_MAC_L2_GLOBAL_CTRL2 %08x\n", __func__, sw_r32(RTL931X_MAC_L2_GLOBAL_CTRL2));
 	pr_info("c45_mask: %08x, RTL931X_SMI_GLB_CTRL0 was %X", c45_mask, sw_r32(RTL931X_SMI_GLB_CTRL0));
 
-	/* We have a 10G PHY enable polling
-	sw_w32(0x01010000, RTL931X_SMI_10GPHY_POLLING_SEL2);
-	sw_w32(0x01E7C400, RTL931X_SMI_10GPHY_POLLING_SEL3);
-	sw_w32(0x01E7E820, RTL931X_SMI_10GPHY_POLLING_SEL4);
-*/
+	/*
+	 * We have a 10G PHY enable polling
+	 * sw_w32(0x01010000, RTL931X_SMI_10GPHY_POLLING_SEL2);
+	 * sw_w32(0x01E7C400, RTL931X_SMI_10GPHY_POLLING_SEL3);
+	 * sw_w32(0x01E7E820, RTL931X_SMI_10GPHY_POLLING_SEL4);
+	 */
 	sw_w32_mask(0xff, c45_mask, RTL931X_SMI_GLB_CTRL1);
 
 	return 0;
@@ -743,9 +748,9 @@ static int rtmd_remove(struct rtnc_priv *priv)
 
 static void rtnc_838x_create_tx_header(struct rtnc_hdr *h, unsigned int dest_port, int prio)
 {
-	// cpu_tag[0] is reserved on the RTL83XX SoCs
-	h->cpu_tag[1] = 0x0401;  // BIT 10: RTL8380_CPU_TAG, BIT0: L2LEARNING on
-	h->cpu_tag[2] = 0x0200;  // Set only AS_DPM, to enable DPM settings below
+	/* cpu_tag[0] is reserved on the RTL83XX SoCs */
+	h->cpu_tag[1] = 0x0401;  /* BIT 10: RTL8380_CPU_TAG, BIT0: L2LEARNING on */
+	h->cpu_tag[2] = 0x0200;  /* Set only AS_DPM, to enable DPM settings below */
 	h->cpu_tag[3] = 0x0000;
 	h->cpu_tag[4] = BIT(dest_port) >> 16;
 	h->cpu_tag[5] = BIT(dest_port) & 0xffff;
@@ -757,11 +762,11 @@ static void rtnc_838x_create_tx_header(struct rtnc_hdr *h, unsigned int dest_por
 
 static void rtnc_839x_create_tx_header(struct rtnc_hdr *h, unsigned int dest_port, int prio)
 {
-	// cpu_tag[0] is reserved on the RTL83XX SoCs
-	h->cpu_tag[1] = 0x0100; // RTL8390_CPU_TAG marker
+	/* cpu_tag[0] is reserved on the RTL83XX SoCs */
+	h->cpu_tag[1] = 0x0100; /* RTL8390_CPU_TAG marker */
 	h->cpu_tag[2] = BIT(4) | BIT(7); /* AS_DPM (4) and L2LEARNING (7) flags */
 	h->cpu_tag[3] = h->cpu_tag[4] = h->cpu_tag[5] = 0;
-	// h->cpu_tag[1] |= BIT(1) | BIT(0); // Bypass filter 1/2
+	/* h->cpu_tag[1] |= BIT(1) | BIT(0); Bypass filter 1/2 */
 	if (dest_port >= 32) {
 		dest_port -= 32;
 		h->cpu_tag[2] |= (BIT(dest_port) >> 16) & 0xf;
@@ -778,7 +783,7 @@ static void rtnc_839x_create_tx_header(struct rtnc_hdr *h, unsigned int dest_por
 
 static void rtnc_930x_create_tx_header(struct rtnc_hdr *h, unsigned int dest_port, int prio)
 {
-	h->cpu_tag[0] = 0x8000;  // CPU tag marker
+	h->cpu_tag[0] = 0x8000;  /* CPU tag marker */
 	h->cpu_tag[1] = h->cpu_tag[2] = 0;
 	h->cpu_tag[3] = 0;
 	h->cpu_tag[4] = 0;
@@ -793,7 +798,7 @@ static void rtnc_930x_create_tx_header(struct rtnc_hdr *h, unsigned int dest_por
 
 static void rtnc_931x_create_tx_header(struct rtnc_hdr *h, unsigned int dest_port, int prio)
 {
-	h->cpu_tag[0] = 0x8000;  // CPU tag marker
+	h->cpu_tag[0] = 0x8000;  /* CPU tag marker */
 	h->cpu_tag[1] = h->cpu_tag[2] = 0;
 	h->cpu_tag[3] = 0;
 	h->cpu_tag[4] = h->cpu_tag[5] = h->cpu_tag[6] = h->cpu_tag[7] = 0;
@@ -813,7 +818,7 @@ static void rtnc_931x_create_tx_header(struct rtnc_hdr *h, unsigned int dest_por
 
 static void rtnc_93xx_header_vlan_set(struct rtnc_hdr *h, int vlan)
 {
-	h->cpu_tag[2] |= BIT(4); // Enable VLAN forwarding offload
+	h->cpu_tag[2] |= BIT(4); /* Enable VLAN forwarding offload */
 	h->cpu_tag[2] |= (vlan >> 8) & 0xf;
 	h->cpu_tag[3] |= (vlan & 0xff) << 8;
 }
@@ -826,12 +831,12 @@ static void rtnc_93xx_header_vlan_set(struct rtnc_hdr *h, int vlan)
  */
 void rtnc_838x_update_cntr(int r, int released)
 {
-	// This feature is not available on RTL838x SoCs
+	/* This feature is not available on RTL838x SoCs */
 }
 
 void rtnc_839x_update_cntr(int r, int released)
 {
-	// This feature is not available on RTL839x SoCs
+	/* This feature is not available on RTL839x SoCs */
 }
 
 void rtnc_930x_update_cntr(int r, int released)
@@ -866,7 +871,7 @@ bool rtnc_838x_decode_tag(struct rtnc_hdr *h, struct rtnc_dsa_tag *t)
 	t->crc_error = t->reason == 13;
 
 	pr_debug("Reason: %d\n", t->reason);
-	if (t->reason != 6) // NIC_RX_REASON_SPECIAL_TRAP
+	if (t->reason != 6) /* NIC_RX_REASON_SPECIAL_TRAP */
 		t->l2_offloaded = 1;
 	else
 		t->l2_offloaded = 0;
@@ -883,8 +888,8 @@ bool rtnc_839x_decode_tag(struct rtnc_hdr *h, struct rtnc_dsa_tag *t)
 	t->crc_error = h->cpu_tag[4] & BIT(6);
 
 	pr_debug("Reason: %d\n", t->reason);
-	if ((t->reason >= 7 && t->reason <= 13) || // NIC_RX_REASON_RMA
-	    (t->reason >= 23 && t->reason <= 25))  // NIC_RX_REASON_SPECIAL_TRAP
+	if ((t->reason >= 7 && t->reason <= 13) || /* NIC_RX_REASON_RMA */
+	    (t->reason >= 23 && t->reason <= 25))  /* NIC_RX_REASON_SPECIAL_TRAP */
 		t->l2_offloaded = 0;
 	else
 		t->l2_offloaded = 1;
@@ -917,7 +922,7 @@ bool rtnc_931x_decode_tag(struct rtnc_hdr *h, struct rtnc_dsa_tag *t)
 
 	if (t->reason != 63)
 		pr_info("%s: Reason %d, port %d, queue %d\n", __func__, t->reason, t->port, t->queue);
-	if (t->reason >= 19 && t->reason <= 27)	// NIC_RX_REASON_RMA
+	if (t->reason >= 19 && t->reason <= 27)	/* NIC_RX_REASON_RMA */
 		t->l2_offloaded = 0;
 	else
 		t->l2_offloaded = 1;
@@ -1269,7 +1274,7 @@ static void rtnc_hw_reset(struct rtnc_priv *priv)
 
 	/* Setup Head of Line */
 	if (priv->family_id == RTL8380_FAMILY_ID)
-		sw_w32(0, RTL838X_DMA_IF_RX_RING_SIZE);  // Disabled on RTL8380
+		sw_w32(0, RTL838X_DMA_IF_RX_RING_SIZE);  /* Disabled on RTL8380 */
 	if (priv->family_id == RTL8390_FAMILY_ID)
 		sw_w32(0xffffffff, RTL839X_DMA_IF_RX_RING_CNTR);
 	if (priv->family_id == RTL9300_FAMILY_ID || priv->family_id == RTL9310_FAMILY_ID) {
@@ -1322,7 +1327,8 @@ static void rtnc_838x_hw_en_rxtx(struct rtnc_priv *priv)
 
 	/* Restart TX/RX to CPU port */
 	sw_w32_mask(0x0, 0x3, priv->r->mac_port_ctrl(priv->cpu_port));
-	/* Set Speed, duplex, flow control
+	/*
+	 * Set Speed, duplex, flow control
 	 * FORCE_EN | LINK_EN | NWAY_EN | DUP_SEL
 	 * | SPD_SEL = 0b10 | FORCE_FC_EN | PHY_MASTER_SLV_MANUAL_EN
 	 * | MEDIA_SEL
@@ -1339,7 +1345,7 @@ static void rtnc_839x_hw_en_rxtx(struct rtnc_priv *priv)
 	sw_w32(0x0000c808, priv->r->dma_if_ctrl);
 
 	/* Enable Notify, RX done and RX overflow interrupts */
-	sw_w32(0x0070ffff, priv->r->dma_if_intr_msk); // Notify IRQ!
+	sw_w32(0x0070ffff, priv->r->dma_if_intr_msk); /* Notify IRQ! */
 
 	/* Enable DMA */
 	sw_w32_mask(0, RTNC_RX_EN_83XX | RTNC_TX_EN_83XX, priv->r->dma_if_ctrl);
@@ -1348,7 +1354,7 @@ static void rtnc_839x_hw_en_rxtx(struct rtnc_priv *priv)
 	sw_w32_mask(0x0, 0x3 | BIT(3), priv->r->mac_port_ctrl(priv->cpu_port));
 
 	/* CPU port joins Lookup Miss Flooding Portmask */
-	// TODO: The code below should also work for the RTL838x
+	/* TODO: The code below should also work for the RTL838x */
 	sw_w32(0x28000, RTL839X_TBL_ACCESS_L2_CTRL);
 	sw_w32_mask(0, 0x80000000, RTL839X_TBL_ACCESS_L2_DATA(0));
 	sw_w32(0x38000, RTL839X_TBL_ACCESS_L2_CTRL);
@@ -1369,7 +1375,7 @@ static void rtnc_93xx_hw_en_rxtx(struct rtnc_priv *priv)
 		pos = (i % 3) * 10;
 		sw_w32_mask(0x3ff << pos, priv->rxringlen << pos, priv->r->dma_if_rx_ring_size(i));
 
-		// Some SoCs have issues with missing underflow protection
+		/* Some SoCs have issues with missing underflow protection */
 		v = (sw_r32(priv->r->dma_if_rx_ring_cntr(i)) >> pos) & 0x3ff;
 		sw_w32_mask(0x3ff << pos, v, priv->r->dma_if_rx_ring_cntr(i));
 	}
@@ -1442,8 +1448,8 @@ static void rtnc_839x_setup_notify_ring_buffer(struct rtnc_priv *priv)
 	sw_w32_mask(0x3ff << 2, 100 << 2, RTL839X_L2_NOTIFICATION_CTRL);
 
 	/* Setup notification events */
-	sw_w32_mask(0, 1 << 14, RTL839X_L2_CTRL_0); // RTL8390_L2_CTRL_0_FLUSH_NOTIFY_EN
-	sw_w32_mask(0, 1 << 12, RTL839X_L2_NOTIFICATION_CTRL); // SUSPEND_NOTIFICATION_EN
+	sw_w32_mask(0, 1 << 14, RTL839X_L2_CTRL_0); /* RTL8390_L2_CTRL_0_FLUSH_NOTIFY_EN */
+	sw_w32_mask(0, 1 << 12, RTL839X_L2_NOTIFICATION_CTRL); /* SUSPEND_NOTIFICATION_EN */
 
 	/* Enable Notification */
 	sw_w32_mask(0, 1 << 0, RTL839X_L2_NOTIFICATION_CTRL);
@@ -1486,7 +1492,7 @@ static int rtnc_ndo_open(struct net_device *ndev)
 
 	case RTL8390_FAMILY_ID:
 		rtnc_839x_hw_en_rxtx(priv);
-		// Trap MLD and IGMP messages to CPU_PORT
+		/* Trap MLD and IGMP messages to CPU_PORT */
 		sw_w32(0x3, RTL839X_SPCL_TRAP_IGMP_CTRL);
 		/* Flush learned FDB entries on link down of a port */
 		sw_w32_mask(0, BIT(7), RTL839X_L2_CTRL_0);
@@ -1496,20 +1502,20 @@ static int rtnc_ndo_open(struct net_device *ndev)
 		rtnc_93xx_hw_en_rxtx(priv);
 		/* Flush learned FDB entries on link down of a port */
 		sw_w32_mask(0, BIT(7), RTL930X_L2_CTRL);
-		// Trap MLD and IGMP messages to CPU_PORT
+		/* Trap MLD and IGMP messages to CPU_PORT */
 		sw_w32((0x2 << 3) | 0x2,  RTL930X_VLAN_APP_PKT_CTRL);
 		break;
 
 	case RTL9310_FAMILY_ID:
 		rtnc_93xx_hw_en_rxtx(priv);
 
-		// Trap MLD and IGMP messages to CPU_PORT
+		/* Trap MLD and IGMP messages to CPU_PORT */
 		sw_w32((0x2 << 3) | 0x2,  RTL931X_VLAN_APP_PKT_CTRL);
 
-		// Disable External CPU access to switch, clear EXT_CPU_EN
+		/* Disable External CPU access to switch, clear EXT_CPU_EN */
 		sw_w32_mask(BIT(2), 0, RTL931X_MAC_L2_GLOBAL_CTRL2);
 
-		// Set PCIE_PWR_DOWN
+		/* Set PCIE_PWR_DOWN */
 		sw_w32_mask(0, BIT(1), RTL931X_PS_SOC_CTRL);
 		break;
 	}
@@ -1527,7 +1533,7 @@ static void rtnc_hw_stop(struct rtnc_priv *priv)
 	u32 clear_irq = priv->family_id == RTL8380_FAMILY_ID ? 0x000fffff : 0x007fffff;
 	int i;
 
-	// Disable RX/TX from/to CPU-port
+	/* Disable RX/TX from/to CPU-port */
 	sw_w32_mask(0x3, 0, priv->r->mac_port_ctrl(priv->cpu_port));
 
 	/* Disable traffic */
@@ -1535,7 +1541,7 @@ static void rtnc_hw_stop(struct rtnc_priv *priv)
 		sw_w32_mask(RTNC_RX_EN_93XX | RTNC_TX_EN_93XX, 0, priv->r->dma_if_ctrl);
 	else
 		sw_w32_mask(RTNC_RX_EN_83XX | RTNC_TX_EN_83XX, 0, priv->r->dma_if_ctrl);
-	mdelay(200); // Test, whether this is needed
+	mdelay(200); /* Test, whether this is needed */
 
 	/* Block all ports */
 	if (priv->family_id == RTL8380_FAMILY_ID) {
@@ -1556,7 +1562,7 @@ static void rtnc_hw_stop(struct rtnc_priv *priv)
 			do { } while (sw_r32(priv->r->l2_tbl_flush_ctrl) & (1 << 28));
 		}
 	}
-	// TODO: L2 flush register is 64 bit on RTL931X and 930X
+	/* TODO: L2 flush register is 64 bit on RTL931X and 930X */
 
 	/* CPU-Port: Link down */
 	if (priv->family_id == RTL8380_FAMILY_ID || priv->family_id == RTL8390_FAMILY_ID)
@@ -1714,7 +1720,7 @@ static int rtnc_ndo_start_xmit(struct sk_buff *skb, struct net_device *dev)
 	int dest_port = -1;
 	int q = skb_get_queue_mapping(skb) % RTNC_TXRINGS;
 
-	if (q) // Check for high prio queue
+	if (q) /* Check for high prio queue */
 		pr_debug("SKB priority: %d\n", skb->priority);
 
 	spin_lock_irqsave(&priv->lock, flags);
@@ -1731,7 +1737,7 @@ static int rtnc_ndo_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		len -= 4;
 	}
 
-	len += 4; // Add space for CRC
+	len += 4; /* Add space for CRC */
 
 	if (skb_padto(skb, len)) {
 		ret = NETDEV_TX_OK;
@@ -1745,7 +1751,7 @@ static int rtnc_ndo_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		h = &ring->tx_header[q][ring->c_tx[q]];
 		h->size = len;
 		h->len = len;
-		// On RTL8380 SoCs, small packet lengths being sent need adjustments
+		/* On RTL8380 SoCs, small packet lengths being sent need adjustments */
 		if (priv->family_id == RTL8380_FAMILY_ID) {
 			if (len < ETH_ZLEN - 4)
 				h->len -= 4;
@@ -1762,7 +1768,7 @@ static int rtnc_ndo_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		/* Hand over to switch */
 		ring->tx_r[q][ring->c_tx[q]] |= RTNC_OWN_ETH;
 
-		// Before starting TX, prevent a Lextra bus bug on RTL8380 SoCs
+		/* Before starting TX, prevent a Lextra bus bug on RTL8380 SoCs */
 		if (priv->family_id == RTL8380_FAMILY_ID) {
 			for (i = 0; i < 10; i++) {
 				val = sw_r32(priv->r->dma_if_ctrl);
@@ -1774,7 +1780,7 @@ static int rtnc_ndo_start_xmit(struct sk_buff *skb, struct net_device *dev)
 		/* Tell switch to send data */
 		if (priv->family_id == RTL9310_FAMILY_ID
 			|| priv->family_id == RTL9300_FAMILY_ID) {
-			// Ring ID q == 0: Low priority, Ring ID = 1: High prio queue
+			/* Ring ID q == 0: Low priority, Ring ID = 1: High prio queue */
 			if (!q)
 				sw_w32_mask(0, BIT(2), priv->r->dma_if_ctrl);
 			else
@@ -1903,7 +1909,7 @@ static int rtnc_hw_receive(struct net_device *dev, int r, int budget)
 		idx = (idx + 1) % priv->rxringlen;
 	};
 
-	// Update counters
+	/* Update counters */
 	priv->r->update_cntr(r, 0);
 	ring->c_rx[r] = idx;
 
@@ -2125,7 +2131,7 @@ static int rtnc_set_mac_address(struct net_device *dev, void *p)
 
 static int rtnc_839x_init_mac(struct rtnc_priv *priv)
 {
-	// We will need to set-up EEE and the egress-rate limitation
+	/* We will need to set-up EEE and the egress-rate limitation */
 	return 0;
 }
 
@@ -2136,7 +2142,7 @@ static int rtnc_838x_init_mac(struct rtnc_priv *priv)
 	if (priv->family_id == RTL8390_FAMILY_ID)
 		return rtnc_839x_init_mac(priv);
 
-    // At present we do not know how to set up EEE on any other SoC than RTL8380
+	/* At present we do not know how to set up EEE on any other SoC than RTL8380 */
 	if (priv->family_id != RTL8380_FAMILY_ID)
 		return 0;
 
@@ -2335,22 +2341,22 @@ static int rtnc_931x_chip_init(struct rtnc_priv *priv)
 {
 	pr_info("In %s\n", __func__);
 
-	// Initialize Encapsulation memory and wait until finished
+	/* Initialize Encapsulation memory and wait until finished */
 	sw_w32(0x1, RTL931X_MEM_ENCAP_INIT);
 	do { } while (sw_r32(RTL931X_MEM_ENCAP_INIT) & 1);
 	pr_info("%s: init ENCAP done\n", __func__);
 
-	// Initialize Managemen Information Base memory and wait until finished
+	/* Initialize Management Information Base memory and wait until finished */
 	sw_w32(0x1, RTL931X_MEM_MIB_INIT);
 	do { } while (sw_r32(RTL931X_MEM_MIB_INIT) & 1);
 	pr_info("%s: init MIB done\n", __func__);
 
-	// Initialize ACL (PIE) memory and wait until finished
+	/* Initialize ACL (PIE) memory and wait until finished */
 	sw_w32(0x1, RTL931X_MEM_ACL_INIT);
 	do { } while (sw_r32(RTL931X_MEM_ACL_INIT) & 1);
 	pr_info("%s: init ACL done\n", __func__);
 
-	// Initialize ALE memory and wait until finished
+	/* Initialize ALE memory and wait until finished */
 	sw_w32(0xFFFFFFFF, RTL931X_MEM_ALE_INIT_0);
 	do { } while (sw_r32(RTL931X_MEM_ALE_INIT_0));
 	sw_w32(0x7F, RTL931X_MEM_ALE_INIT_1);
@@ -2358,10 +2364,10 @@ static int rtnc_931x_chip_init(struct rtnc_priv *priv)
 	do { } while (sw_r32(RTL931X_MEM_ALE_INIT_2) & 0x7ff);
 	pr_info("%s: init ALE done\n", __func__);
 
-	// Enable ESD auto recovery
+	/* Enable ESD auto recovery */
 	sw_w32(0x1, RTL931X_MDX_CTRL_RSVD);
 
-	// Init SPI, is this for thermal control or what?
+	/* Init SPI, is this for thermal control or what? */
 	sw_w32_mask(0x7 << 11, 0x2 << 11, RTL931X_SPI_CTRL0);
 
 	return 0;

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -1283,7 +1283,7 @@ static int rtl838x_hw_receive(struct net_device *dev, int r, int budget)
 		if (!dsa)
 			len -= 4;
 
-		skb = netdev_alloc_skb_ip_align(dev, len);
+		skb = napi_alloc_skb(&priv->rx_qs[r].napi, len);
 
 		if (likely(skb)) {
 			/* BUG: Prevent bug on RTL838x SoCs*/
@@ -1367,9 +1367,7 @@ static int rtl838x_poll_rx(struct napi_struct *napi, int budget)
 		work_done += work;
 	}
 
-	if (work_done < budget) {
-		napi_complete_done(napi, work_done);
-
+	if (work_done < budget && napi_complete_done(napi, work_done)) {
 		/* Enable RX interrupt */
 		if (priv->family_id == RTL9300_FAMILY_ID || priv->family_id == RTL9310_FAMILY_ID)
 			sw_w32(0xffffffff, priv->r->dma_if_intr_rx_done_msk);

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -398,7 +398,7 @@ void rtnc_fdb_sync(struct work_struct *work)
 	kfree(work);
 }
 
-static void rtl839x_l2_notification_handler(struct rtnc_priv *priv)
+static void rtnc_839x_l2_notification_handler(struct rtnc_priv *priv)
 {
 	struct notify_b *nb = priv->notify;
 	u32 e = priv->lastEvent;
@@ -468,7 +468,7 @@ static irqreturn_t rtnc_83xx_net_irq(int irq, void *dev_id)
 	/* Notification interrupts */
 	if (status & 0x700000) {
 		if (priv->family_id == RTL8390_FAMILY_ID)
-			rtl839x_l2_notification_handler(priv);
+			rtnc_839x_l2_notification_handler(priv);
 	}
 
 	/* Acknowledge interrupts */
@@ -844,7 +844,7 @@ static void rtnc_setup_ring_buffer(struct rtnc_priv *priv)
 	}
 }
 
-static void rtl839x_setup_notify_ring_buffer(struct rtnc_priv *priv)
+static void rtnc_839x_setup_notify_ring_buffer(struct rtnc_priv *priv)
 {
 	int i;
 	struct notify_b *b = priv->notify;
@@ -877,7 +877,7 @@ static int rtnc_ndo_open(struct net_device *ndev)
 	rtnc_hw_reset(priv);
 	rtnc_setup_ring_buffer(priv);
 	if (priv->family_id == RTL8390_FAMILY_ID) {
-		rtl839x_setup_notify_ring_buffer(priv);
+		rtnc_839x_setup_notify_ring_buffer(priv);
 		/* Make sure the ring structure is visible to the ASIC */
 		mb();
 		flush_cache_all();
@@ -1400,7 +1400,7 @@ static void rtnc_validate(struct phylink_config *config,
 }
 
 
-static void rtl838x_mac_config(struct phylink_config *config,
+static void rtnc_mac_config(struct phylink_config *config,
 			       unsigned int mode,
 			       const struct phylink_link_state *state)
 {
@@ -1571,7 +1571,7 @@ static int rtnc_838x_init_mac(struct rtnc_priv *priv)
 	return 0;
 }
 
-static int rtl838x_get_link_ksettings(struct net_device *ndev,
+static int rtnc_get_link_ksettings(struct net_device *ndev,
 				      struct ethtool_link_ksettings *cmd)
 {
 	struct rtnc_priv *priv = netdev_priv(ndev);
@@ -1580,7 +1580,7 @@ static int rtl838x_get_link_ksettings(struct net_device *ndev,
 	return phylink_ethtool_ksettings_get(priv->phylink, cmd);
 }
 
-static int rtl838x_set_link_ksettings(struct net_device *ndev,
+static int rtnc_set_link_ksettings(struct net_device *ndev,
 				      const struct ethtool_link_ksettings *cmd)
 {
 	struct rtnc_priv *priv = netdev_priv(ndev);
@@ -2032,7 +2032,7 @@ static int rtl931x_mdio_reset(struct mii_bus *bus)
 	return 0;
 }
 
-static int rtl931x_chip_init(struct rtnc_priv *priv)
+static int rtnc_931x_chip_init(struct rtnc_priv *priv)
 {
 	pr_info("In %s\n", __func__);
 
@@ -2202,13 +2202,13 @@ static int rtl838x_mdio_remove(struct rtnc_priv *priv)
 	return 0;
 }
 
-static netdev_features_t rtl838x_fix_features(struct net_device *dev,
+static netdev_features_t rtnc_ndo_fix_features(struct net_device *dev,
 					  netdev_features_t features)
 {
 	return features;
 }
 
-static int rtl83xx_set_features(struct net_device *dev, netdev_features_t features)
+static int rtnc_83xx_ndo_set_features(struct net_device *dev, netdev_features_t features)
 {
 	struct rtnc_priv *priv = netdev_priv(dev);
 
@@ -2222,7 +2222,7 @@ static int rtl83xx_set_features(struct net_device *dev, netdev_features_t featur
 	return 0;
 }
 
-static int rtl93xx_set_features(struct net_device *dev, netdev_features_t features)
+static int rtnc_93xx_ndo_set_features(struct net_device *dev, netdev_features_t features)
 {
 	struct rtnc_priv *priv = netdev_priv(dev);
 
@@ -2236,7 +2236,7 @@ static int rtl93xx_set_features(struct net_device *dev, netdev_features_t featur
 	return 0;
 }
 
-static const struct net_device_ops rtl838x_eth_netdev_ops = {
+static const struct net_device_ops rtnc_838x_net_device_ops = {
 	.ndo_open = rtnc_ndo_open,
 	.ndo_stop = rtnc_ndo_stop,
 	.ndo_start_xmit = rtnc_ndo_start_xmit,
@@ -2245,12 +2245,12 @@ static const struct net_device_ops rtl838x_eth_netdev_ops = {
 	.ndo_validate_addr = eth_validate_addr,
 	.ndo_set_rx_mode = rtnc_838x_ndo_set_rx_mode,
 	.ndo_tx_timeout = rtnc_ndo_tx_timeout,
-	.ndo_set_features = rtl83xx_set_features,
-	.ndo_fix_features = rtl838x_fix_features,
+	.ndo_set_features = rtnc_83xx_ndo_set_features,
+	.ndo_fix_features = rtnc_ndo_fix_features,
 	.ndo_setup_tc = rtl83xx_setup_tc,
 };
 
-static const struct net_device_ops rtl839x_eth_netdev_ops = {
+static const struct net_device_ops rtnc_839x_net_device_ops = {
 	.ndo_open = rtnc_ndo_open,
 	.ndo_stop = rtnc_ndo_stop,
 	.ndo_start_xmit = rtnc_ndo_start_xmit,
@@ -2259,12 +2259,12 @@ static const struct net_device_ops rtl839x_eth_netdev_ops = {
 	.ndo_validate_addr = eth_validate_addr,
 	.ndo_set_rx_mode = rtnc_839x_ndo_set_rx_mode,
 	.ndo_tx_timeout = rtnc_ndo_tx_timeout,
-	.ndo_set_features = rtl83xx_set_features,
-	.ndo_fix_features = rtl838x_fix_features,
+	.ndo_set_features = rtnc_83xx_ndo_set_features,
+	.ndo_fix_features = rtnc_ndo_fix_features,
 	.ndo_setup_tc = rtl83xx_setup_tc,
 };
 
-static const struct net_device_ops rtl930x_eth_netdev_ops = {
+static const struct net_device_ops rtnc_930x_net_device_ops = {
 	.ndo_open = rtnc_ndo_open,
 	.ndo_stop = rtnc_ndo_stop,
 	.ndo_start_xmit = rtnc_ndo_start_xmit,
@@ -2273,12 +2273,12 @@ static const struct net_device_ops rtl930x_eth_netdev_ops = {
 	.ndo_validate_addr = eth_validate_addr,
 	.ndo_set_rx_mode = rtnc_930x_ndo_set_rx_mode,
 	.ndo_tx_timeout = rtnc_ndo_tx_timeout,
-	.ndo_set_features = rtl93xx_set_features,
-	.ndo_fix_features = rtl838x_fix_features,
+	.ndo_set_features = rtnc_93xx_ndo_set_features,
+	.ndo_fix_features = rtnc_ndo_fix_features,
 	.ndo_setup_tc = rtl83xx_setup_tc,
 };
 
-static const struct net_device_ops rtl931x_eth_netdev_ops = {
+static const struct net_device_ops rtnc_931x_net_device_ops = {
 	.ndo_open = rtnc_ndo_open,
 	.ndo_stop = rtnc_ndo_stop,
 	.ndo_start_xmit = rtnc_ndo_start_xmit,
@@ -2287,22 +2287,22 @@ static const struct net_device_ops rtl931x_eth_netdev_ops = {
 	.ndo_validate_addr = eth_validate_addr,
 	.ndo_set_rx_mode = rtnc_931x_ndo_set_rx_mode,
 	.ndo_tx_timeout = rtnc_ndo_tx_timeout,
-	.ndo_set_features = rtl93xx_set_features,
-	.ndo_fix_features = rtl838x_fix_features,
+	.ndo_set_features = rtnc_93xx_ndo_set_features,
+	.ndo_fix_features = rtnc_ndo_fix_features,
 };
 
-static const struct phylink_mac_ops rtl838x_phylink_ops = {
+static const struct phylink_mac_ops rtnc_phylink_mac_ops = {
 	.validate = rtnc_validate,
 	.mac_pcs_get_state = rtnc_mac_pcs_get_state,
 	.mac_an_restart = rtnc_mac_an_restart,
-	.mac_config = rtl838x_mac_config,
+	.mac_config = rtnc_mac_config,
 	.mac_link_down = rtnc_mac_link_down,
 	.mac_link_up = rtnc_mac_link_up,
 };
 
-static const struct ethtool_ops rtl838x_ethtool_ops = {
-	.get_link_ksettings     = rtl838x_get_link_ksettings,
-	.set_link_ksettings     = rtl838x_set_link_ksettings,
+static const struct ethtool_ops rtnc_ethtool_ops = {
+	.get_link_ksettings = rtnc_get_link_ksettings,
+	.set_link_ksettings = rtnc_set_link_ksettings,
 };
 
 static void rtnc_soc_info(int *soc_id, int *soc_family)
@@ -2434,7 +2434,7 @@ static int __init rtnc_probe(struct platform_device *pdev)
 
 	spin_lock_init(&priv->lock);
 
-	dev->ethtool_ops = &rtl838x_ethtool_ops;
+	dev->ethtool_ops = &rtnc_ethtool_ops;
 	dev->min_mtu = ETH_ZLEN;
 	dev->max_mtu = 1536;
 	dev->features = NETIF_F_RXCSUM | NETIF_F_HW_CSUM;
@@ -2447,23 +2447,23 @@ static int __init rtnc_probe(struct platform_device *pdev)
 	case RTL8380_FAMILY_ID:
 		priv->cpu_port = RTL838X_CPU_PORT;
 		priv->r = &rtnc_838x_reg;
-		dev->netdev_ops = &rtl838x_eth_netdev_ops;
+		dev->netdev_ops = &rtnc_838x_net_device_ops;
 		break;
 	case RTL8390_FAMILY_ID:
 		priv->cpu_port = RTL839X_CPU_PORT;
 		priv->r = &rtnc_839x_reg;
-		dev->netdev_ops = &rtl839x_eth_netdev_ops;
+		dev->netdev_ops = &rtnc_839x_net_device_ops;
 		break;
 	case RTL9300_FAMILY_ID:
 		priv->cpu_port = RTL930X_CPU_PORT;
 		priv->r = &rtnc_930x_reg;
-		dev->netdev_ops = &rtl930x_eth_netdev_ops;
+		dev->netdev_ops = &rtnc_930x_net_device_ops;
 		break;
 	case RTL9310_FAMILY_ID:
 		priv->cpu_port = RTL931X_CPU_PORT;
 		priv->r = &rtnc_931x_reg;
-		dev->netdev_ops = &rtl931x_eth_netdev_ops;
-		rtl931x_chip_init(priv);
+		dev->netdev_ops = &rtnc_931x_net_device_ops;
+		rtnc_931x_chip_init(priv);
 		break;
 	default:
 		pr_err("Unknown SoC family\n");
@@ -2547,7 +2547,7 @@ static int __init rtnc_probe(struct platform_device *pdev)
 	priv->phylink_config.type = PHYLINK_NETDEV;
 
 	phylink = phylink_create(&priv->phylink_config, pdev->dev.fwnode,
-				 phy_mode, &rtl838x_phylink_ops);
+				 phy_mode, &rtnc_phylink_mac_ops);
 
 	if (IS_ERR(phylink)) {
 		err = PTR_ERR(phylink);

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -1260,7 +1260,7 @@ static void rtnc_hw_reset(struct rtnc_priv *priv)
 	else
 		reset_mask = 0xc;
 
-	sw_w32(reset_mask, priv->r->rst_glb_ctrl);
+	sw_w32_mask(0, reset_mask, priv->r->rst_glb_ctrl);
 
 	do { /* Wait for reset of NIC and Queues done */
 		udelay(20);

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.c
@@ -1287,8 +1287,7 @@ static int rtl838x_hw_receive(struct net_device *dev, int r, int budget)
 		if (!dsa)
 			len -= 4;
 
-		skb = netdev_alloc_skb(dev, len + 4);
-		skb_reserve(skb, NET_IP_ALIGN);
+		skb = netdev_alloc_skb_ip_align(dev, len);
 
 		if (likely(skb)) {
 			/* BUG: Prevent bug on RTL838x SoCs*/

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
@@ -483,7 +483,7 @@ inline u32 rtl931x_get_mac_tx_pause_sts(int p)
 }
 
 struct p_hdr;
-struct dsa_tag;
+struct rtnc_dsa_tag;
 
 struct rtl838x_eth_reg {
 	irqreturn_t (*net_irq)(int irq, void *dev_id);
@@ -515,7 +515,7 @@ struct rtl838x_eth_reg {
 	int l2_tbl_flush_ctrl;
 	void (*update_cntr)(int r, int work_done);
 	void (*create_tx_header)(struct p_hdr *h, unsigned int dest_port, int prio);
-	bool (*decode_tag)(struct p_hdr *h, struct dsa_tag *tag);
+	bool (*decode_tag)(struct p_hdr *h, struct rtnc_dsa_tag *tag);
 };
 
 int rtl838x_write_phy(u32 port, u32 page, u32 reg, u32 val);

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
@@ -3,6 +3,76 @@
 #ifndef _RTL838X_ETH_H
 #define _RTL838X_ETH_H
 
+struct rtl83xx_soc_info {
+	unsigned char *name;
+	unsigned int id;
+	unsigned int family;
+	unsigned char *compatible;
+	volatile void *sw_base;
+	volatile void *icu_base;
+	int cpu_port;
+};
+
+#define RTL838X_SW_BASE		((volatile void *) 0xBB000000)
+
+#define sw_r32(reg)		readl(RTL838X_SW_BASE + reg)
+#define sw_w32(val, reg)	writel(val, RTL838X_SW_BASE + reg)
+#define sw_w32_mask(clear, set, reg)	\
+				sw_w32((sw_r32(reg) & ~(clear)) | (set), reg)
+
+/* Definition of family IDs */
+#define RTL8389_FAMILY_ID			(0x8389)
+#define RTL8328_FAMILY_ID			(0x8328)
+#define RTL8390_FAMILY_ID			(0x8390)
+#define RTL8350_FAMILY_ID			(0x8350)
+#define RTL8380_FAMILY_ID			(0x8380)
+#define RTL8330_FAMILY_ID			(0x8330)
+#define RTL9300_FAMILY_ID			(0x9300)
+#define RTL9310_FAMILY_ID			(0x9310)
+
+/* CPU Ports */
+#define RTL838X_CPU_PORT			28
+#define RTL839X_CPU_PORT			52
+#define RTL930X_CPU_PORT			28
+#define RTL931X_CPU_PORT			56
+
+/* Reset */
+#define RTL838X_RST_GLB_CTRL_0			(0x003c)
+#define RTL838X_RST_GLB_CTRL_1			(0x0040)
+#define RTL839X_RST_GLB_CTRL			(0x0014)
+#define RTL930X_RST_GLB_CTRL_0			(0x000c)
+#define RTL931X_RST_GLB_CTRL			(0x0400)
+
+#define RTL838X_ISR_PORT_LINK_STS_CHG		(0x114C)
+#define RTL838X_IMR_PORT_LINK_STS_CHG		(0x1104)
+
+#define RTL839X_ISR_PORT_LINK_STS_CHG		(0x00a0)
+#define RTL839X_IMR_PORT_LINK_STS_CHG		(0x0068)
+
+#define RTL930X_ISR_PORT_LINK_STS_CHG		(0xC660)
+#define RTL930X_IMR_PORT_LINK_STS_CHG		(0xC62C)
+
+#define RTL931X_ISR_PORT_LINK_STS_CHG		(0x12B8)
+#define RTL931X_IMR_PORT_LINK_STS_CHG		(0x126C)
+#define RTL931X_MAC_L2_GLOBAL_CTRL2		(0x1358)
+
+#define RTL838X_SMI_GLB_CTRL			(0xa100)
+#define RTL838X_SMI_POLL_CTRL			(0xa17c)
+
+#define RTL839X_SMI_GLB_CTRL			(0x03f8)
+#define RTL839X_SMI_PORT_POLLING_CTRL		(0x03fc)
+
+#define RTL930X_SMI_GLB_CTRL			(0xCA00)
+#define RTL930X_SMI_POLL_CTRL			(0xca90)
+#define RTL930X_SMI_PORT0_5_ADDR		(0xCB80)
+
+#define RTL931X_SMI_GLB_CTRL0			(0x0CC0)
+#define RTL931X_SMI_GLB_CTRL1			(0x0CBC)
+#define RTL931X_SMI_PORT_POLLING_CTRL		(0x0CCC)
+#define RTL931X_SMI_PORT_POLLING_SEL		(0x0C9C)
+#define RTL931X_SMI_PORT_ADDR			(0x0C74)
+#define RTL931X_SPI_CTRL0			(0x103C)
+
 /*
  * Register definition
  */

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
@@ -3,22 +3,30 @@
 #ifndef _RTL838X_ETH_H
 #define _RTL838X_ETH_H
 
-struct rtl83xx_soc_info {
-	unsigned char *name;
-	unsigned int id;
-	unsigned int family;
-	unsigned char *compatible;
-	volatile void *sw_base;
-	volatile void *icu_base;
-	int cpu_port;
-};
-
 #define RTL838X_SW_BASE		((volatile void *) 0xBB000000)
 
 #define sw_r32(reg)		readl(RTL838X_SW_BASE + reg)
 #define sw_w32(val, reg)	writel(val, RTL838X_SW_BASE + reg)
 #define sw_w32_mask(clear, set, reg)	\
 				sw_w32((sw_r32(reg) & ~(clear)) | (set), reg)
+
+#define RTL838X_MODEL_NAME_INFO			(0x00D4)
+#define RTL839X_MODEL_NAME_INFO			(0x0FF0)
+#define RTL93XX_MODEL_NAME_INFO			(0x0004)
+
+/* Definition of SOC IDs */
+#define RTL8328_SOC_ID				(0x8328)
+#define RTL8332_SOC_ID				(0x8332)
+#define RTL8380_SOC_ID				(0x8380)
+#define RTL8382_SOC_ID				(0x8382)
+#define RTL8390_SOC_ID				(0x8390)
+#define RTL8391_SOC_ID				(0x8391)
+#define RTL8392_SOC_ID				(0x8392)
+#define RTL8393_SOC_ID				(0x8393)
+#define RTL9301_SOC_ID				(0x9301)
+#define RTL9302_SOC_ID				(0x9302)
+#define RTL9303_SOC_ID				(0x9303)
+#define RTL9313_SOC_ID				(0x9313)
 
 /* Definition of family IDs */
 #define RTL8389_FAMILY_ID			(0x8389)

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
@@ -296,12 +296,12 @@
 /* Registers of the internal Serdes of the 8380 */
 #define RTL838X_SDS4_FIB_REG0			(0xF800)
 
-inline int rtl838x_mac_port_ctrl(int p)
+inline int rtnc_838x_mac_port_ctrl(int p)
 {
 	return RTL838X_MAC_PORT_CTRL + (p << 7);
 }
 
-inline int rtl839x_mac_port_ctrl(int p)
+inline int rtnc_839x_mac_port_ctrl(int p)
 {
 	return RTL839X_MAC_PORT_CTRL + (p << 7);
 }
@@ -311,12 +311,12 @@ inline int rtl839x_mac_port_ctrl(int p)
  * by the Ethernet driver is in the same bits now in RTL931X_MAC_L2_PORT_CTRL
  */
 
-inline int rtl930x_mac_port_ctrl(int p)
+inline int rtnc_930x_mac_port_ctrl(int p)
 {
 	return RTL930X_MAC_L2_PORT_CTRL + (p << 6);
 }
 
-inline int rtl931x_mac_port_ctrl(int p)
+inline int rtnc_931x_mac_port_ctrl(int p)
 {
 	return RTL931X_MAC_L2_PORT_CTRL + (p << 7);
 }
@@ -482,7 +482,7 @@ inline u32 rtl931x_get_mac_tx_pause_sts(int p)
 	return (sw_r32(RTL931X_MAC_TX_PAUSE_STS + ((p >> 5) << 2)) & BIT(p % 32));
 }
 
-struct p_hdr;
+struct rtnc_hdr;
 struct rtnc_dsa_tag;
 
 struct rtl838x_eth_reg {
@@ -514,8 +514,8 @@ struct rtl838x_eth_reg {
 	int mac;
 	int l2_tbl_flush_ctrl;
 	void (*update_cntr)(int r, int work_done);
-	void (*create_tx_header)(struct p_hdr *h, unsigned int dest_port, int prio);
-	bool (*decode_tag)(struct p_hdr *h, struct rtnc_dsa_tag *tag);
+	void (*create_tx_header)(struct rtnc_hdr *h, unsigned int dest_port, int prio);
+	bool (*decode_tag)(struct rtnc_hdr *h, struct rtnc_dsa_tag *tag);
 };
 
 int rtl838x_write_phy(u32 port, u32 page, u32 reg, u32 val);

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
@@ -361,17 +361,17 @@ inline int rtnc_931x_dma_if_rx_ring_cntr(int i)
 	return RTL931X_DMA_IF_RX_RING_CNTR + ((i / 3) << 2);
 }
 
-inline u32 rtl838x_get_mac_link_sts(int port)
+inline u32 rtnc_838x_get_mac_link_sts(int port)
 {
 	return (sw_r32(RTL838X_MAC_LINK_STS) & BIT(port));
 }
 
-inline u32 rtl839x_get_mac_link_sts(int p)
+inline u32 rtnc_839x_get_mac_link_sts(int p)
 {
 	return (sw_r32(RTL839X_MAC_LINK_STS + ((p >> 5) << 2)) & BIT(p % 32));
 }
 
-inline u32 rtl930x_get_mac_link_sts(int port)
+inline u32 rtnc_930x_get_mac_link_sts(int port)
 {
 	u32 link = sw_r32(RTL930X_MAC_LINK_STS);
 
@@ -380,32 +380,32 @@ inline u32 rtl930x_get_mac_link_sts(int port)
 	return link & BIT(port);
 }
 
-inline u32 rtl931x_get_mac_link_sts(int p)
+inline u32 rtnc_931x_get_mac_link_sts(int p)
 {
 	return (sw_r32(RTL931X_MAC_LINK_STS + ((p >> 5) << 2)) & BIT(p % 32));
 }
 
-inline u32 rtl838x_get_mac_link_dup_sts(int port)
+inline u32 rtnc_838x_get_mac_link_dup_sts(int port)
 {
 	return (sw_r32(RTL838X_MAC_LINK_DUP_STS) & BIT(port));
 }
 
-inline u32 rtl839x_get_mac_link_dup_sts(int p)
+inline u32 rtnc_839x_get_mac_link_dup_sts(int p)
 {
 	return (sw_r32(RTL839X_MAC_LINK_DUP_STS + ((p >> 5) << 2)) & BIT(p % 32));
 }
 
-inline u32 rtl930x_get_mac_link_dup_sts(int port)
+inline u32 rtnc_930x_get_mac_link_dup_sts(int port)
 {
 	return (sw_r32(RTL930X_MAC_LINK_DUP_STS) & BIT(port));
 }
 
-inline u32 rtl931x_get_mac_link_dup_sts(int p)
+inline u32 rtnc_931x_get_mac_link_dup_sts(int p)
 {
 	return (sw_r32(RTL931X_MAC_LINK_DUP_STS + ((p >> 5) << 2)) & BIT(p % 32));
 }
 
-inline u32 rtl838x_get_mac_link_spd_sts(int port)
+inline u32 rtnc_838x_get_mac_link_spd_sts(int port)
 {
 	int r = RTL838X_MAC_LINK_SPD_STS + ((port >> 4) << 2);
 	u32 speed = sw_r32(r);
@@ -414,7 +414,7 @@ inline u32 rtl838x_get_mac_link_spd_sts(int port)
 	return (speed & 0x3);
 }
 
-inline u32 rtl839x_get_mac_link_spd_sts(int port)
+inline u32 rtnc_839x_get_mac_link_spd_sts(int port)
 {
 	int r = RTL839X_MAC_LINK_SPD_STS + ((port >> 4) << 2);
 	u32 speed = sw_r32(r);
@@ -424,7 +424,7 @@ inline u32 rtl839x_get_mac_link_spd_sts(int port)
 }
 
 
-inline u32 rtl930x_get_mac_link_spd_sts(int port)
+inline u32 rtnc_930x_get_mac_link_spd_sts(int port)
 {
 	int r = RTL930X_MAC_LINK_SPD_STS + ((port / 10) << 2);
 	u32 speed = sw_r32(r);
@@ -433,7 +433,7 @@ inline u32 rtl930x_get_mac_link_spd_sts(int port)
 	return (speed & 0x7);
 }
 
-inline u32 rtl931x_get_mac_link_spd_sts(int port)
+inline u32 rtnc_931x_get_mac_link_spd_sts(int port)
 {
 	int r = RTL931X_MAC_LINK_SPD_STS + ((port >> 3) << 2);
 	u32 speed = sw_r32(r);
@@ -442,42 +442,42 @@ inline u32 rtl931x_get_mac_link_spd_sts(int port)
 	return (speed & 0xf);
 }
 
-inline u32 rtl838x_get_mac_rx_pause_sts(int port)
+inline u32 rtnc_838x_get_mac_rx_pause_sts(int port)
 {
 	return (sw_r32(RTL838X_MAC_RX_PAUSE_STS) & (1 << port));
 }
 
-inline u32 rtl839x_get_mac_rx_pause_sts(int p)
+inline u32 rtnc_839x_get_mac_rx_pause_sts(int p)
 {
 	return (sw_r32(RTL839X_MAC_RX_PAUSE_STS + ((p >> 5) << 2)) & BIT(p % 32));
 }
 
-inline u32 rtl930x_get_mac_rx_pause_sts(int port)
+inline u32 rtnc_930x_get_mac_rx_pause_sts(int port)
 {
 	return (sw_r32(RTL930X_MAC_RX_PAUSE_STS) & (1 << port));
 }
 
-inline u32 rtl931x_get_mac_rx_pause_sts(int p)
+inline u32 rtnc_931x_get_mac_rx_pause_sts(int p)
 {
 	return (sw_r32(RTL931X_MAC_RX_PAUSE_STS + ((p >> 5) << 2)) & BIT(p % 32));
 }
 
-inline u32 rtl838x_get_mac_tx_pause_sts(int port)
+inline u32 rtnc_838x_get_mac_tx_pause_sts(int port)
 {
 	return (sw_r32(RTL838X_MAC_TX_PAUSE_STS) & (1 << port));
 }
 
-inline u32 rtl839x_get_mac_tx_pause_sts(int p)
+inline u32 rtnc_839x_get_mac_tx_pause_sts(int p)
 {
 	return (sw_r32(RTL839X_MAC_TX_PAUSE_STS + ((p >> 5) << 2)) & BIT(p % 32));
 }
 
-inline u32 rtl930x_get_mac_tx_pause_sts(int port)
+inline u32 rtnc_930x_get_mac_tx_pause_sts(int port)
 {
 	return (sw_r32(RTL930X_MAC_TX_PAUSE_STS) & (1 << port));
 }
 
-inline u32 rtl931x_get_mac_tx_pause_sts(int p)
+inline u32 rtnc_931x_get_mac_tx_pause_sts(int p)
 {
 	return (sw_r32(RTL931X_MAC_TX_PAUSE_STS + ((p >> 5) << 2)) & BIT(p % 32));
 }

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
@@ -44,6 +44,10 @@
 #define RTL930X_CPU_PORT			28
 #define RTL931X_CPU_PORT			56
 
+/* Hardware ring sizes */
+#define RTL83XX_HW_RINGSIZE			15
+#define RTL93XX_HW_RINGSIZE			1023
+
 /* Reset */
 #define RTL838X_RST_GLB_CTRL_0			(0x003c)
 #define RTL838X_RST_GLB_CTRL_1			(0x0040)

--- a/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-5.10/drivers/net/ethernet/rtl838x_eth.h
@@ -321,42 +321,42 @@ inline int rtnc_931x_mac_port_ctrl(int p)
 	return RTL931X_MAC_L2_PORT_CTRL + (p << 7);
 }
 
-inline int rtl838x_dma_if_rx_ring_size(int i)
+inline int rtnc_838x_dma_if_rx_ring_size(int i)
 {
 	return RTL838X_DMA_IF_RX_RING_SIZE + ((i >> 3) << 2);
 }
 
-inline int rtl839x_dma_if_rx_ring_size(int i)
+inline int rtnc_839x_dma_if_rx_ring_size(int i)
 {
 	return RTL839X_DMA_IF_RX_RING_SIZE + ((i >> 3) << 2);
 }
 
-inline int rtl930x_dma_if_rx_ring_size(int i)
+inline int rtnc_930x_dma_if_rx_ring_size(int i)
 {
 	return RTL930X_DMA_IF_RX_RING_SIZE + ((i / 3) << 2);
 }
 
-inline int rtl931x_dma_if_rx_ring_size(int i)
+inline int rtnc_931x_dma_if_rx_ring_size(int i)
 {
 	return RTL931X_DMA_IF_RX_RING_SIZE + ((i / 3) << 2);
 }
 
-inline int rtl838x_dma_if_rx_ring_cntr(int i)
+inline int rtnc_838x_dma_if_rx_ring_cntr(int i)
 {
 	return RTL838X_DMA_IF_RX_RING_CNTR + ((i >> 3) << 2);
 }
 
-inline int rtl839x_dma_if_rx_ring_cntr(int i)
+inline int rtnc_839x_dma_if_rx_ring_cntr(int i)
 {
 	return RTL839X_DMA_IF_RX_RING_CNTR + ((i >> 3) << 2);
 }
 
-inline int rtl930x_dma_if_rx_ring_cntr(int i)
+inline int rtnc_930x_dma_if_rx_ring_cntr(int i)
 {
 	return RTL930X_DMA_IF_RX_RING_CNTR + ((i / 3) << 2);
 }
 
-inline int rtl931x_dma_if_rx_ring_cntr(int i)
+inline int rtnc_931x_dma_if_rx_ring_cntr(int i)
 {
 	return RTL931X_DMA_IF_RX_RING_CNTR + ((i / 3) << 2);
 }
@@ -485,7 +485,7 @@ inline u32 rtl931x_get_mac_tx_pause_sts(int p)
 struct rtnc_hdr;
 struct rtnc_dsa_tag;
 
-struct rtl838x_eth_reg {
+struct rtnc_reg {
 	irqreturn_t (*net_irq)(int irq, void *dev_id);
 	int (*mac_port_ctrl)(int port);
 	int dma_if_intr_sts;


### PR DESCRIPTION
Several patches to optimize and cleanup the ethernet driver. 

It makes the RTL930x ethernet interface available from the outside world. Measured speeds with iperf3 send/receive on a RTL839X:

```
                 without patch     with patch
Client->Switch:   200 MBit/sec   320 MBit/sec
Switch->Client:   125 MBit/sec   150 MBit/sec
```