### PR TITLE
ramips: mt7621: mikrotik 760igs (hEX S) fix SFP

### DIFF
--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-760igs.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-760igs.dts
@@ -49,6 +49,7 @@
 	status = "okay";
 
 	label = "sfp";
+	phy-mode = "rgmii-rxid";
 	phy-handle = <&ephy7>;
 };
 


### PR DESCRIPTION
SFP was working on 22.03, but not on master
narrowed down to `rgmii-rxid`


This device uses an AR8031/AR8033 chip to convert SoC gmac1 RGMII to 1000base-x or sgmii for the SFP fibre cage. The SFP cage requires phy-mode rgmii-rxid, and without it will not recieve any packets: ethtool -S sfp rx_fcs_errors will increase when packets should be being received, but no other _rx counters will change.

Fixes: c77858aa792 ("ramips: mt7621-dts: change phy-mode of gmac1 to rgmii")
Signed-off-by: John Thomson <git@johnthomson.fastmail.com.au>