### PR TITLE
treewide: improve use of STAGING_DIR_HOST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ $(if $(findstring $(space),$(TOPDIR)),$(error ERROR: The path to the OpenWrt dir
 world:
 
 DISTRO_PKG_CONFIG:=$(shell $(TOPDIR)/scripts/command_all.sh pkg-config | grep '/usr' -m 1)
-export PATH:=$(TOPDIR)/staging_dir/host/bin:$(PATH)
+export PATH:=$(if $(STAGING_DIR),$(abspath $(STAGING_DIR)/../host/bin),$(TOPDIR)/staging_dir/host/bin):$(PATH)
 
 ifneq ($(OPENWRT_BUILD),1)
   _SINGLE=export MAKEFLAGS=$(space);

--- a/include/scan.mk
+++ b/include/scan.mk
@@ -11,7 +11,7 @@ TARGET_STAMP:=$(TMP_DIR)/info/.files-$(SCAN_TARGET).stamp
 FILELIST:=$(TMP_DIR)/info/.files-$(SCAN_TARGET)-$(SCAN_COOKIE)
 OVERRIDELIST:=$(TMP_DIR)/info/.overrides-$(SCAN_TARGET)-$(SCAN_COOKIE)
 
-export PATH:=$(TOPDIR)/staging_dir/host/bin:$(PATH)
+export PATH:=$(STAGING_DIR_HOST)/bin:$(PATH)
 
 define feedname
 $(if $(patsubst feeds/%,,$(1)),,$(word 2,$(subst /, ,$(1))))

--- a/include/toplevel.mk
+++ b/include/toplevel.mk
@@ -51,22 +51,22 @@ path:=$(subst :,$(space),$(PATH))
 path:=$(filter-out .%,$(path))
 path:=$(subst $(space),:,$(path))
 export PATH:=$(path)
+export STAGING_DIR_HOST:=$(if $(STAGING_DIR),$(abspath $(STAGING_DIR)/../host),$(TOPDIR)/staging_dir/host)
 
 unexport TAR_OPTIONS
 
 ifeq ($(FORCE),)
-  .config scripts/config/conf scripts/config/mconf: staging_dir/host/.prereq-build
+  .config scripts/config/conf scripts/config/mconf: $(STAGING_DIR_HOST)/.prereq-build
 endif
 
 SCAN_COOKIE?=$(shell echo $$$$)
 export SCAN_COOKIE
-export STAGING_DIR_HOST=$(TOPDIR)/staging_dir/host
 
 SUBMAKE:=umask 022; $(SUBMAKE)
 
 ULIMIT_FIX=_limit=`ulimit -n`; [ "$$_limit" = "unlimited" -o "$$_limit" -ge 1024 ] || ulimit -n 1024;
 
-prepare-mk: staging_dir/host/.prereq-build FORCE ;
+prepare-mk: $(STAGING_DIR_HOST)/.prereq-build FORCE ;
 
 ifdef SDK
   IGNORE_PACKAGES = linux
@@ -75,7 +75,7 @@ endif
 _ignore = $(foreach p,$(IGNORE_PACKAGES),--ignore $(p))
 
 prepare-tmpinfo: FORCE
-	@+$(MAKE) -r -s staging_dir/host/.prereq-build $(PREP_MK)
+	@+$(MAKE) -r -s $(STAGING_DIR_HOST)/.prereq-build $(PREP_MK)
 	mkdir -p tmp/info
 	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="packageinfo" SCAN_DIR="package" SCAN_NAME="package" SCAN_DEPTH=5 SCAN_EXTRA=""
 	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="targetinfo" SCAN_DIR="target/linux" SCAN_NAME="target" SCAN_DEPTH=3 SCAN_EXTRA="" SCAN_MAKEOPTS="TARGET_BUILD=1"
@@ -152,7 +152,7 @@ xconfig: scripts/config/qconf prepare-tmpinfo FORCE
 
 prepare_kernel_conf: .config toolchain/install FORCE
 
-ifeq ($(wildcard staging_dir/host/bin/quilt),)
+ifeq ($(wildcard $(STAGING_DIR_HOST)/bin/quilt),)
   prepare_kernel_conf:
 	@+$(SUBMAKE) -r tools/quilt/compile
 else
@@ -176,7 +176,7 @@ kernel_nconfig: prepare_kernel_conf
 kernel_xconfig: prepare_kernel_conf
 	$(_SINGLE)$(NO_TRACE_MAKE) -C target/linux xconfig
 
-staging_dir/host/.prereq-build: include/prereq-build.mk
+$(STAGING_DIR_HOST)/.prereq-build: include/prereq-build.mk
 	mkdir -p tmp
 	@$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f $(TOPDIR)/include/prereq-build.mk prereq 2>/dev/null || { \
 		echo "Prerequisite check failed. Use FORCE=1 to override."; \
@@ -199,7 +199,7 @@ else
   DOWNLOAD_DIRS = package/download
 endif
 
-download: .config FORCE $(if $(wildcard $(TOPDIR)/staging_dir/host/bin/flock),,tools/flock/compile)
+download: .config FORCE $(if $(wildcard $(STAGING_DIR_HOST)/bin/flock),,tools/flock/compile)
 	@+$(foreach dir,$(DOWNLOAD_DIRS),$(SUBMAKE) $(dir);)
 
 clean dirclean: .config
@@ -263,7 +263,7 @@ distclean:
 	@$(_SINGLE)$(SUBMAKE) -C scripts/config clean
 
 ifeq ($(findstring v,$(DEBUG)),)
-  .SILENT: symlinkclean clean dirclean distclean config-clean download help tmpinfo-clean .config scripts/config/mconf scripts/config/conf menuconfig staging_dir/host/.prereq-build tmp/.prereq-package prepare-tmpinfo
+  .SILENT: symlinkclean clean dirclean distclean config-clean download help tmpinfo-clean .config scripts/config/mconf scripts/config/conf menuconfig $(STAGING_DIR_HOST)/.prereq-build tmp/.prereq-package prepare-tmpinfo
 endif
 .PHONY: help FORCE
 .NOTPARALLEL:

--- a/rules.mk
+++ b/rules.mk
@@ -156,8 +156,8 @@ BUILD_LOG_DIR:=$(if $(call qstrip,$(CONFIG_BUILD_LOG_DIR)),$(call qstrip,$(CONFI
 PKG_INFO_DIR := $(STAGING_DIR)/pkginfo
 
 BUILD_DIR_HOST:=$(if $(IS_PACKAGE_BUILD),$(BUILD_DIR_BASE)/hostpkg,$(BUILD_DIR_BASE)/host)
-STAGING_DIR_HOST:=$(TOPDIR)/staging_dir/host
-STAGING_DIR_HOSTPKG:=$(TOPDIR)/staging_dir/hostpkg
+STAGING_DIR_HOST:=$(abspath $(STAGING_DIR)/../host)
+STAGING_DIR_HOSTPKG:=$(abspath $(STAGING_DIR)/../hostpkg)
 
 TARGET_PATH:=$(subst $(space),:,$(filter-out .,$(filter-out ./,$(subst :,$(space),$(PATH)))))
 TARGET_INIT_PATH:=$(call qstrip,$(CONFIG_TARGET_INIT_PATH))

--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -72,7 +72,7 @@ ifdef CONFIG_INSTALL_GCCGO
 endif
 
 ifdef CONFIG_GCC_USE_GRAPHITE
-  GRAPHITE_CONFIGURE:= --with-isl=$(TOPDIR)/staging_dir/host
+  GRAPHITE_CONFIGURE:= --with-isl=$(STAGING_DIR_HOST)
 else
   GRAPHITE_CONFIGURE:= --without-isl --without-cloog
 endif
@@ -106,9 +106,9 @@ GCC_CONFIGURE:= \
 			--with-abi=$(call qstrip,$(CONFIG_MIPS64_ABI))) \
 		$(if $(CONFIG_arc),--with-cpu=$(CONFIG_CPU_TYPE)) \
 		$(if $(CONFIG_powerpc64), $(if $(CONFIG_USE_MUSL),--with-abi=elfv2)) \
-		--with-gmp=$(TOPDIR)/staging_dir/host \
-		--with-mpfr=$(TOPDIR)/staging_dir/host \
-		--with-mpc=$(TOPDIR)/staging_dir/host \
+		--with-gmp=$(STAGING_DIR_HOST) \
+		--with-mpfr=$(STAGING_DIR_HOST) \
+		--with-mpc=$(STAGING_DIR_HOST) \
 		--disable-decimal-float \
 		--with-diagnostics-color=auto-if-env \
 		--enable-__cxa_atexit \

--- a/toolchain/gcc/final/Makefile
+++ b/toolchain/gcc/final/Makefile
@@ -9,7 +9,7 @@ GCC_CONFIGURE += \
 	--enable-threads \
 	--with-slibdir=$(TOOLCHAIN_DIR)/lib \
 	--enable-lto \
-	--with-libelf=$(TOPDIR)/staging_dir/host
+	--with-libelf=$(STAGING_DIR_HOST)
 
 ifndef CONFIG_USE_GLIBC
   GCC_CONFIGURE += --disable-libsanitizer

--- a/toolchain/gdb/Makefile
+++ b/toolchain/gdb/Makefile
@@ -30,10 +30,10 @@ HOST_CONFIGURE_ARGS = \
 	--build=$(GNU_HOST_NAME) \
 	--host=$(GNU_HOST_NAME) \
 	--target=$(REAL_GNU_TARGET_NAME) \
-	--with-gmp=$(TOPDIR)/staging_dir/host \
-	--with-mpfr=$(TOPDIR)/staging_dir/host \
-	--with-mpc=$(TOPDIR)/staging_dir/host \
-	--with-expat=$(TOPDIR)/staging_dir/host \
+	--with-gmp=$(STAGING_DIR_HOST) \
+	--with-mpfr=$(STAGING_DIR_HOST) \
+	--with-mpc=$(STAGING_DIR_HOST) \
+	--with-expat=$(STAGING_DIR_HOST) \
 	--disable-werror \
 	--without-uiout \
 	--enable-tui --disable-gdbtk --without-x \

--- a/tools/autoconf/patches/000-relocatable.patch
+++ b/tools/autoconf/patches/000-relocatable.patch
@@ -6,7 +6,7 @@
  {
 -  my $pkgdatadir = $ENV{'autom4te_perllibdir'} || '@pkgdatadir@';
 +  my $pkgdatadir = $ENV{'autom4te_perllibdir'} ||
-+	($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/share/autoconf' : '@pkgdatadir@');
++	($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/autoconf' : '@pkgdatadir@');
    unshift @INC, "$pkgdatadir";
  
    # Override SHELL.  On DJGPP SHELL may not be set to a shell
@@ -15,7 +15,7 @@
  
  # Lib files.
 -my $autom4te = $ENV{'AUTOM4TE'} || '@bindir@/@autom4te-name@';
-+my $autom4te = $ENV{'AUTOM4TE'} || ($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/bin/@autom4te-name@' : '@bindir@/@autom4te-name@');
++my $autom4te = $ENV{'AUTOM4TE'} || ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/bin/@autom4te-name@' : '@bindir@/@autom4te-name@');
  local $config_h;
  my $config_h_in;
  my @prepend_include;
@@ -41,7 +41,7 @@
  {
 -  my $pkgdatadir = $ENV{'autom4te_perllibdir'} || '@pkgdatadir@';
 +  my $pkgdatadir = $ENV{'autom4te_perllibdir'} ||
-+	($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/share/autoconf' : '@pkgdatadir@');
++	($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/autoconf' : '@pkgdatadir@');
    unshift @INC, $pkgdatadir;
  
    # Override SHELL.  On DJGPP SHELL may not be set to a shell
@@ -51,7 +51,7 @@
  # Data directory.
 -my $pkgdatadir = $ENV{'AC_MACRODIR'} || '@pkgdatadir@';
 +my $pkgdatadir = $ENV{'AC_MACRODIR'} ||
-+	($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/share/autoconf' : '@pkgdatadir@');
++	($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/autoconf' : '@pkgdatadir@');
  
  # $LANGUAGE{LANGUAGE} -- Automatic options for LANGUAGE.
  my %language;
@@ -60,7 +60,7 @@
  
  # $M4.
 -my $m4 = $ENV{"M4"} || '@M4@';
-+my $m4 = $ENV{"M4"} || ($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/bin/m4' : '@M4@');
++my $m4 = $ENV{"M4"} || ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/bin/m4' : '@M4@');
  # Some non-GNU m4's don't reject the --help option, so give them /dev/null.
  fatal "need GNU m4 1.4 or later: $m4"
    if system "$m4 --help </dev/null 2>&1 | grep reload-state >/dev/null";
@@ -69,9 +69,9 @@
        my @words = shellwords ($_);
        my $type = shift @words;
 +
-+      if ($ENV{'STAGING_DIR'})
++      if ($ENV{'STAGING_DIR_HOST'})
 +      {
-+        @words = map { s!^@pkgdatadir@!$ENV{'STAGING_DIR'}/../host/share/autoconf!; $_ } @words;
++        @words = map { s!^@pkgdatadir@!$ENV{'STAGING_DIR_HOST'}/share/autoconf!; $_ } @words;
 +      }
 +
        if ($type eq 'begin-language:')
@@ -99,7 +99,7 @@
  {
 -  my $pkgdatadir = $ENV{'autom4te_perllibdir'} || '@pkgdatadir@';
 +  my $pkgdatadir = $ENV{'autom4te_perllibdir'} ||
-+	($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/share/autoconf' : '@pkgdatadir@');
++	($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/autoconf' : '@pkgdatadir@');
    unshift @INC, $pkgdatadir;
  
    # Override SHELL.  On DJGPP SHELL may not be set to a shell
@@ -110,9 +110,9 @@
 -my $autoconf   = $ENV{'AUTOCONF'}   || '@bindir@/@autoconf-name@';
 -my $autoheader = $ENV{'AUTOHEADER'} || '@bindir@/@autoheader-name@';
 -my $autom4te   = $ENV{'AUTOM4TE'}   || '@bindir@/@autom4te-name@';
-+my $autoconf   = $ENV{'AUTOCONF'}   || ($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/bin/@autoconf-name@' : '@bindir@/@autoconf-name@');
-+my $autoheader = $ENV{'AUTOHEADER'} || ($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/bin/@autoheader-name@' : '@bindir@/@autoheader-name@');
-+my $autom4te   = $ENV{'AUTOM4TE'}   || ($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/bin/@autom4te-name@' : '@bindir@/@autom4te-name@');
++my $autoconf   = $ENV{'AUTOCONF'}   || ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/bin/@autoconf-name@' : '@bindir@/@autoconf-name@');
++my $autoheader = $ENV{'AUTOHEADER'} || ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/bin/@autoheader-name@' : '@bindir@/@autoheader-name@');
++my $autom4te   = $ENV{'AUTOM4TE'}   || ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/bin/@autom4te-name@' : '@bindir@/@autom4te-name@');
  my $automake   = $ENV{'AUTOMAKE'}   || 'automake';
  my $aclocal    = $ENV{'ACLOCAL'}    || 'aclocal';
  my $libtoolize = $ENV{'LIBTOOLIZE'} || 'libtoolize';
@@ -134,7 +134,7 @@
  {
 -  my $pkgdatadir = $ENV{'autom4te_perllibdir'} || '@pkgdatadir@';
 +  my $pkgdatadir = $ENV{'autom4te_perllibdir'} ||
-+	($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/share/autoconf' : '@pkgdatadir@');
++	($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/autoconf' : '@pkgdatadir@');
    unshift @INC, $pkgdatadir;
  
    # Override SHELL.  On DJGPP SHELL may not be set to a shell
@@ -143,11 +143,11 @@
  
  # Autoconf and lib files.
 -my $autom4te = $ENV{'AUTOM4TE'} || '@bindir@/@autom4te-name@';
-+my $autom4te = $ENV{'AUTOM4TE'} || ($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/bin/@autom4te-name@' : '@bindir@/@autom4te-name@');
++my $autom4te = $ENV{'AUTOM4TE'} || ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/bin/@autom4te-name@' : '@bindir@/@autom4te-name@');
  my $autoconf = "$autom4te --language=autoconf";
  my @prepend_include;
 -my @include = ('@pkgdatadir@');
-+my @include = ($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/share/autoconf' : '@pkgdatadir@');
++my @include = ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/autoconf' : '@pkgdatadir@');
  
  # $help
  # -----
@@ -169,7 +169,7 @@
  {
 -  my $pkgdatadir = $ENV{'autom4te_perllibdir'} || '@pkgdatadir@';
 +  my $pkgdatadir = $ENV{'autom4te_perllibdir'} ||
-+	($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/share/autoconf' : '@pkgdatadir@');
++	($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/autoconf' : '@pkgdatadir@');
    unshift @INC, $pkgdatadir;
  
    # Override SHELL.  On DJGPP SHELL may not be set to a shell
@@ -178,11 +178,11 @@
  # We need to find m4sugar.
  my @prepend_include;
 -my @include = ('@pkgdatadir@');
-+my @include = ($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/share/autoconf' : '@pkgdatadir@');
++my @include = ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/autoconf' : '@pkgdatadir@');
  my $force = 0;
  # m4.
 -my $m4 = $ENV{"M4"} || '@M4@';
-+my $m4 = $ENV{"M4"} || ($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/bin/m4' : '@M4@');
++my $m4 = $ENV{"M4"} || ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/bin/m4' : '@M4@');
  
  
  # $HELP
@@ -208,7 +208,7 @@
  {
 -  my $pkgdatadir = $ENV{'autom4te_perllibdir'} || '@pkgdatadir@';
 +  my $pkgdatadir = $ENV{'autom4te_perllibdir'} ||
-+	($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/share/autoconf' : '@pkgdatadir@');
++	($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/autoconf' : '@pkgdatadir@');
    unshift @INC, $pkgdatadir;
  
    # Override SHELL.  On DJGPP SHELL may not be set to a shell
@@ -219,8 +219,8 @@
  
  # Variables.
 -: ${AUTOM4TE='@bindir@/@autom4te-name@'}
-+if test -n "$STAGING_DIR"; then
-+	: ${AUTOM4TE="$STAGING_DIR/../host/bin/@autom4te-name@"}
++if test -n "$STAGING_DIR_HOST"; then
++	: ${AUTOM4TE="$STAGING_DIR_HOST/bin/@autom4te-name@"}
 +else
 +	: ${AUTOM4TE='@bindir@/@autom4te-name@'}
 +fi

--- a/tools/automake/Makefile
+++ b/tools/automake/Makefile
@@ -25,7 +25,7 @@ HOST_CONFIGURE_VARS += \
 	am_cv_prog_PERL_ithreads=no
 
 define Host/Configure
-	(cd $(HOST_BUILD_DIR); $(AM_TOOL_PATHS) STAGING_DIR="" ./bootstrap)
+	(cd $(HOST_BUILD_DIR); $(AM_TOOL_PATHS) STAGING_DIR_HOST="" ./bootstrap)
 	$(call Host/Configure/Default)
 endef
 

--- a/tools/automake/patches/000-relocatable.patch
+++ b/tools/automake/patches/000-relocatable.patch
@@ -5,7 +5,7 @@
  our $VERSION = '@VERSION@';
  our $RELEASE_YEAR = '@RELEASE_YEAR@';
 -our $libdir = '@datadir@/@PACKAGE@-@APIVERSION@';
-+our $libdir = $ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/share/@PACKAGE@-@APIVERSION@' : '@datadir@/@PACKAGE@-@APIVERSION@';
++our $libdir = $ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/@PACKAGE@-@APIVERSION@' : '@datadir@/@PACKAGE@-@APIVERSION@';
  
  our $perl_threads = 0;
  # We need at least this version for CLONE support.
@@ -30,7 +30,7 @@
  BEGIN
  {
 -  @Aclocal::perl_libdirs = ('@datadir@/@PACKAGE@-@APIVERSION@')
-+  @Aclocal::perl_libdirs = ($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/share/@PACKAGE@-@APIVERSION@' : '@datadir@/@PACKAGE@-@APIVERSION@')
++  @Aclocal::perl_libdirs = ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/@PACKAGE@-@APIVERSION@' : '@datadir@/@PACKAGE@-@APIVERSION@')
      unless @Aclocal::perl_libdirs;
    unshift @INC, @Aclocal::perl_libdirs;
  }
@@ -40,8 +40,8 @@
  my @user_includes = ();
 -my @automake_includes = ("@datadir@/aclocal-$APIVERSION");
 -my @system_includes = ('@datadir@/aclocal');
-+my @automake_includes = ($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . "/../host/share/aclocal-$APIVERSION" : "@datadir@/aclocal-$APIVERSION");
-+my @system_includes = ($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/share/aclocal' : '@datadir@/aclocal');
++my @automake_includes = ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . "/share/aclocal-$APIVERSION" : "@datadir@/aclocal-$APIVERSION");
++my @system_includes = ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/aclocal' : '@datadir@/aclocal');
  
  # Whether we should copy M4 file in $user_includes[0].
  my $install = 0;
@@ -66,7 +66,7 @@
  BEGIN
  {
 -  @Automake::perl_libdirs = ('@datadir@/@PACKAGE@-@APIVERSION@')
-+  @Automake::perl_libdirs = ($ENV{'STAGING_DIR'} ? $ENV{'STAGING_DIR'} . '/../host/share/@PACKAGE@-@APIVERSION@' : '@datadir@/@PACKAGE@-@APIVERSION@')
++  @Automake::perl_libdirs = ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/@PACKAGE@-@APIVERSION@' : '@datadir@/@PACKAGE@-@APIVERSION@')
      unless @Automake::perl_libdirs;
    unshift @INC, @Automake::perl_libdirs;
  

--- a/tools/libtool/patches/000-relocatable.patch
+++ b/tools/libtool/patches/000-relocatable.patch
@@ -13,11 +13,11 @@
  : ${MV="mv -f"}
  : ${RM="rm -f"}
 -: ${SED="@SED@"}
-+if test -n "$STAGING_DIR"; then
-+	: ${EGREP="$STAGING_DIR/../host/bin/grep -E"}
-+	: ${FGREP="$STAGING_DIR/../host/bin/grep -F"}
-+	: ${GREP="$STAGING_DIR/../host/bin/grep"}
-+	: ${SED="$STAGING_DIR/../host/bin/sed"}
++if test -n "$STAGING_DIR_HOST"; then
++	: ${EGREP="$STAGING_DIR_HOST/bin/grep -E"}
++	: ${FGREP="$STAGING_DIR_HOST/bin/grep -F"}
++	: ${GREP="$STAGING_DIR_HOST/bin/grep"}
++	: ${SED="$STAGING_DIR_HOST/bin/sed"}
 +else
 +	: ${EGREP="@EGREP@"}
 +	: ${FGREP="@FGREP@"}
@@ -42,11 +42,11 @@
  : ${MV="mv -f"}
  : ${RM="rm -f"}
 -: ${SED="@SED@"}
-+if test -n "$STAGING_DIR"; then
-+	: ${EGREP="$STAGING_DIR/../host/bin/grep -E"}
-+	: ${FGREP="$STAGING_DIR/../host/bin/grep -F"}
-+	: ${GREP="$STAGING_DIR/../host/bin/grep"}
-+	: ${SED="$STAGING_DIR/../host/bin/sed"}
++if test -n "$STAGING_DIR_HOST"; then
++	: ${EGREP="$STAGING_DIR_HOST/bin/grep -E"}
++	: ${FGREP="$STAGING_DIR_HOST/bin/grep -F"}
++	: ${GREP="$STAGING_DIR_HOST/bin/grep"}
++	: ${SED="$STAGING_DIR_HOST/bin/sed"}
 +else
 +	: ${EGREP="@EGREP@"}
 +	: ${FGREP="@FGREP@"}
@@ -64,11 +64,11 @@
 -  pkgdatadir=@pkgdatadir@
 -  pkgltdldir=@pkgdatadir@
 -  aclocaldir=@aclocaldir@
-+  if test -n "$STAGING_DIR"; then
-+    datadir="$STAGING_DIR/../host/share"
-+    pkgdatadir="$STAGING_DIR/../host/share/libtool"
-+    pkgltdldir="$STAGING_DIR/../host/share/libtool"
-+    aclocaldir="$STAGING_DIR/../host/share/aclocal"
++  if test -n "$STAGING_DIR_HOST"; then
++    datadir="$STAGING_DIR_HOST/share"
++    pkgdatadir="$STAGING_DIR_HOST/share/libtool"
++    pkgltdldir="$STAGING_DIR_HOST/share/libtool"
++    aclocaldir="$STAGING_DIR_HOST/share/aclocal"
 +  else
 +    datadir=@datadir@
 +    pkgdatadir=@pkgdatadir@
@@ -88,11 +88,11 @@
 -  pkgdatadir=@pkgdatadir@
 -  pkgltdldir=@pkgdatadir@
 -  aclocaldir=@aclocaldir@
-+  if test -n "$STAGING_DIR"; then
-+    datadir="$STAGING_DIR/../host/share"
-+    pkgdatadir="$STAGING_DIR/../host/share/libtool"
-+    pkgltdldir="$STAGING_DIR/../host/share/libtool"
-+    aclocaldir="$STAGING_DIR/../host/share/aclocal"
++  if test -n "$STAGING_DIR_HOST"; then
++    datadir="$STAGING_DIR_HOST/share"
++    pkgdatadir="$STAGING_DIR_HOST/share/libtool"
++    pkgltdldir="$STAGING_DIR_HOST/share/libtool"
++    aclocaldir="$STAGING_DIR_HOST/share/aclocal"
 +  else
 +    datadir=@datadir@
 +    pkgdatadir=@pkgdatadir@
@@ -111,7 +111,7 @@
 -
  _LT_DECL([LTCC], [CC], [1], [A C compiler])dnl
 -_LT_DECL([LTCFLAGS], [CFLAGS], [1], [LTCC compiler flags])dnl
-+_LT_DECL([LTCFLAGS], [CFLAGS], ["-O2 -I\${STAGING_DIR:-$STAGING_DIR}/../host/include"], [LTCC compiler flags])dnl
++_LT_DECL([LTCFLAGS], [CFLAGS], ["-O2 -I\${STAGING_DIR_HOST:-$STAGING_DIR_HOST}/include"], [LTCC compiler flags])dnl
  _LT_TAGDECL([CC], [compiler], [1], [A language specific compiler])dnl
  _LT_TAGDECL([with_gcc], [GCC], [0], [Is the compiler the GNU compiler?])dnl
  
@@ -122,9 +122,9 @@
 -_LT_DECL([], [GREP], [1], [A grep program that handles long lines])
 -_LT_DECL([], [EGREP], [1], [An ERE matcher])
 -_LT_DECL([], [FGREP], [1], [A literal string matcher])
-+_LT_DECL([], [GREP], ["\${STAGING_DIR:-$STAGING_DIR}/../host/bin/grep"], [A grep program that handles long lines])
-+_LT_DECL([], [EGREP], ["\${STAGING_DIR:-$STAGING_DIR}/../host/bin/grep -E"], [An ERE matcher])
-+_LT_DECL([], [FGREP], ["\${STAGING_DIR:-$STAGING_DIR}/../host/bin/grep -F"], [A literal string matcher])
++_LT_DECL([], [GREP], ["\${STAGING_DIR_HOST:-$STAGING_DIR_HOST}/bin/grep"], [A grep program that handles long lines])
++_LT_DECL([], [EGREP], ["\${STAGING_DIR_HOST:-$STAGING_DIR_HOST}/bin/grep -E"], [An ERE matcher])
++_LT_DECL([], [FGREP], ["\${STAGING_DIR_HOST:-$STAGING_DIR_HOST}/bin/grep -F"], [A literal string matcher])
  dnl Non-bleeding-edge autoconf doesn't subst GREP, so do it here too
  AC_SUBST([GREP])
  ])
@@ -135,7 +135,7 @@
 -test -z "$SED" && SED=sed
  Xsed="$SED -e 1s/^X//"
 -_LT_DECL([], [SED], [1], [A sed program that does not truncate output])
-+_LT_DECL([], [SED], ["\${STAGING_DIR:-$STAGING_DIR}/../host/bin/sed"], [A sed program that does not truncate output])
++_LT_DECL([], [SED], ["\${STAGING_DIR_HOST:-$STAGING_DIR_HOST}/bin/sed"], [A sed program that does not truncate output])
  _LT_DECL([], [Xsed], ["\$SED -e 1s/^X//"],
      [Sed that helps us avoid accidentally triggering echo(1) options like -n])
  ])# _LT_DECL_SED

--- a/tools/mpc/Makefile
+++ b/tools/mpc/Makefile
@@ -22,8 +22,8 @@ unexport CFLAGS
 HOST_CONFIGURE_ARGS += \
 	--enable-static \
 	--disable-shared \
-	--with-mpfr=$(TOPDIR)/staging_dir/host \
-	--with-gmp=$(TOPDIR)/staging_dir/host
+	--with-mpfr=$(STAGING_DIR_HOST) \
+	--with-gmp=$(STAGING_DIR_HOST)
 
 define Host/Uninstall
 	-$(call Host/Compile/Default,uninstall)


### PR DESCRIPTION
This evolved in a much bigger project.

It was notice an inconsistency between what .mk define and some relocatable patch.
Relocatable patch derive the path from STAGING_DIR
.mk hardcode everything to staging_dir/host
other use STAGING_DIR_HOST that is always hardcoded to staging_dir/host

The intention of this big pr is to change everything to use STAGING_DIR_HOST and to change how STAGING_DIR_HOST is defined.

With this pr STAGING_DIR_HOST is now derived from STAGING_DIR.

This is needed as some downstream project provide STAGING_DIR with the make to use a different staging_dir than the default one. The original implementation is saved while fixing the inconsistency between very .mk and tools patches.

---

~~Instead of using STAGING_DIR and then go up one dir with '../' use
directly STAGING_DIR_HOST env variable. This should produce cleaner
symbolic links.~~

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
