### PR TITLE
ramips: fix PCIe NIC initialization issues on ZBT-WE1326

### DIFF
--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-we1326.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-we1326.dts
@@ -121,7 +121,7 @@
 	status = "okay";
 };
 
-&pcie0 {
+&pcie1 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
@@ -135,7 +135,7 @@
 	};
 };
 
-&pcie1 {
+&pcie2 {
 	wifi1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2611,6 +2611,8 @@ define Device/zbtlink_zbt-we1326
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WE1326
+  DEVICE_ALT0_VENDOR := Wiflyer
+  DEVICE_ALT0_MODEL := WF3526-P
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-sdhci-mt7620
   SUPPORTED_DEVICES += zbt-we1326
 endef


### PR DESCRIPTION
Some users report that their Wi-Fi interface is lost after reboot, which may be caused by allocating the wrong pcie port. This commit fixes these wrong ports.

For Netgear R6220, WAC104 and WNDR3700 v5, according to bootlog, MT7612E (5GHz) is connected to pcie0, and MT7603E (2GHz) is connected to pcie2:
```
[2.758986] mt7621-pci 1e140000.pcie: pcie1 no card, disable it (RST & CLK)
[2.772862] mt7621-pci 1e140000.pcie: PCIE0 enabled
[2.782579] mt7621-pci 1e140000.pcie: PCIE2 enabled
...
[3.009151] pci 0000:01:00.0: [14c3:7662] type 00 class 0x028000
[3.125715] pci 0000:02:00.0: [14c3:7603] type 00 class 0x028000
```
For Zbtlink ZBT-WE1326, according to bootlog, MT7612E (5GHz) is connected to pcie1, and MT7603E (2GHz) is connected to pcie2:
```
[4.197658] mt7621-pci 1e140000.pcie: pcie0 no card, disable it (RST & CLK)
[4.204609] mt7621-pci 1e140000.pcie: PCIE1 enabled
[4.209476] mt7621-pci 1e140000.pcie: PCIE2 enabled
...
[4.307988] pci 0000:01:00.0: [14c3:7662] type 00 class 0x028000
[4.367206] pci 0000:02:00.0: [14c3:7603] type 00 class 0x028000
```
OpenWrt Forum Link:
[Missing 2.4GHz interface on WAC104 & difficulty setting up forwarding](https://forum.openwrt.org/t/missing-2-4ghz-interface-on-wac104-difficulty-setting-up-forwarding/119855)
[R6220 ” Could not find PHY for device ‘radio0’” mt76x2 .. issue continues](https://forum.openwrt.org/t/r6220-could-not-find-phy-for-device-radio0-mt76x2-issue-continues/116665)
[ZBT-1326 OpenWRT stable 21.02 results in no Wifi](https://forum.openwrt.org/t/zbt-1326-openwrt-stable-21-02-results-in-no-wifi/108116)

GitHub issues:
https://github.com/openwrt/mt76/issues/199
https://github.com/openwrt/mt76/issues/601
https://github.com/openwrt/openwrt/issues/9374

**I have no relevant device to test, but this should be the correct fix.**