### PR TITLE
build: rockchip: increase default kernel size

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -292,6 +292,7 @@ menu "Target Images"
 		depends on USES_BOOT_PART
 		default 8 if TARGET_apm821xx_sata
 		default 64 if TARGET_bcm27xx
+		default 24 if TARGET_rockchip
 		default 16
 
 	config TARGET_ROOTFS_PARTSIZE


### PR DESCRIPTION
Kernel size on rockchip has increased not allowing save setting on system upgrade. This patch set the default kernel size on rockchip target from 16MB to 24MB
Actual kernel size 16MB:

```
# df /dev/mmcblk0p1
Filesystem           1K-blocks      Used Available Use% Mounted on
/dev/mmcblk0p1           16084     15756         4 100% /tmp/kernel
```

Kernel size 24MB:
```
# df /dev/mmcblk0p1
Filesystem           1K-blocks      Used Available Use% Mounted on
/dev/mmcblk0p1           24148     15224      8436  64% /tmp/kernel
```

Build/Run-tested: Nano Pi R2S

Fixes:https://github.com/openwrt/openwrt/issues/11197
