### PR TITLE
procd: fix service arguments processing

### DIFF
--- a/package/system/procd/files/service
+++ b/package/system/procd/files/service
@@ -3,16 +3,17 @@
 main() {
 	local service="$1"
 	local cmd="$2"
+	shift 2
 
 	local boot status
 
 	if [ -f "/etc/init.d/${service}" ]; then
-		/etc/init.d/"${service}" "${cmd}"
+		/etc/init.d/"${service}" "${cmd}" "$@"
 		exit "$?"
 	fi
 
 	if [ -n "$service" ]; then
-		echo "Service \"$1\" not found:"
+		echo "Service $service not found."
 		exit 1
 	fi
 


### PR DESCRIPTION
Provide instance management:
```bash
service openvpn start instance_name
```

Properly process subcommands:
```bash
service simple-adblock check example.org
```

Signed-off-by: Vladislav Grigoryev <20725816+vgaetera@users.noreply.github.com>