### PR TITLE
linux-firmware: update to 20221109

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
-PKG_VERSION:=20221012
+PKG_VERSION:=20221109
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=e9d174af729511c8cccb60ec4e0b223b3c44b67d813b42d1ab9813acfa667fa5
+PKG_HASH:=c0ddffbbcf30f2e015bddd5c6d3ce1f13976b906aceabda4a57e3c41a3190701
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
Changes:
712460c linux-firmware: Update firmware file for Intel Bluetooth 9462 90d5f7e linux-firmware: Update firmware file for Intel Bluetooth 9462 48954ba linux-firmware: Update firmware file for Intel Bluetooth 9560 0e205fd linux-firmware: Update firmware file for Intel Bluetooth 9560 06b941e linux-firmware: Update firmware file for Intel Bluetooth AX201 ba958ff linux-firmware: Update firmware file for Intel Bluetooth AX201 02bdea2 linux-firmware: Update firmware file for Intel Bluetooth AX211 7044d46 linux-firmware: Update firmware file for Intel Bluetooth AX211 1b99bcd linux-firmware: Update firmware file for Intel Bluetooth AX210 4668ae9 linux-firmware: Update firmware file for Intel Bluetooth AX200 5bdfdba linux-firmware: Update firmware file for Intel Bluetooth AX201 b0f995c amdgpu: update DMCUB firmware for DCN 3.1.6 d991031 rtl_bt: Update RTL8822C BT UART firmware to 0xFFB8_ABD6 fd62f01 rtl_bt: Update RTL8822C BT USB firmware to 0xFFB8_ABD3 b15fc21 WHENCE: mrvl: prestera: Add WHENCE entries for newly updated 4.1 FW images bf5a337 mrvl: prestera: Update Marvell Prestera Switchdev FW to v4.1 4a733c2 iwlwifi: add new FWs from core74_pv-60 release 7d2bb50 qcom: drop split a530_zap firmware file
7d56713 qcom/vpu-1.0: drop split firmware in favour of the mbn file 1431496 qcom/venus-4.2: drop split firmware in favour of the mbn file cf95783 qcom/venus-4.2: replace split firmware with the mbn file 1fe6f49 qcom/venus-1.8: replace split firmware with the mbn file abc0302 linux-firmware: Add firmware for Cirrus CS35L41 on new ASUS Laptop 20d9516 iwlwifi: add new PNVM binaries from core74-44 release 06dbfbc iwlwifi: add new FWs from core69-81 release 05df8e6 qcom: update venus firmware files for VPU-2.0 cd6fcdb qcom: remove split SC7280 venus firmware images 1612706 qcom: update venus firmware file for v5.4
ad9fdba qcom: replace split SC7180 venus firmware images with symlink dae5d46 rtw89: 8852b: update fw to v0.27.32.1
a8e86ec rtlwifi: update firmware for rtl8192eu to v35.7 9aa8db1 rtlwifi: Add firmware v4.0 for RTL8188FU
8f86b5a i915: Add HuC 7.10.3 for DG2
48407ff cnm: update chips&media wave521c firmware. bd31846 brcm: add symlink for Pi Zero 2 W NVRAM file 771968c linux-firmware: Add firmware for Cirrus CS35L41 on ASUS Laptops 6f9620e linux-firmware: Add firmware for Cirrus CS35L41 on Lenovo Laptops 1d18cb9 linux-firmware: Add firmware for Cirrus CS35L41 on HP Laptops e497757 rtw89: 8852b: add initial fw v0.27.32.0
98b5577 iwlwifi: add new FWs from core72-129 release 604026c iwlwifi: update 9000-family firmwares to core72-129
