### PR TITLE
kernel: fix mac80211 ubus call hostapd config_add

### DIFF
--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -1251,7 +1251,7 @@ drv_mac80211_setup() {
 		if [ "$no_reload" != "0" ]; then
 			add_ap=1
 			ubus wait_for hostapd
-			local hostapd_res="$(ubus call hostapd config_add "{\"iface\":\"$primary_ap\", \"config\":\"${hostapd_conf_file}\"}")"
+			local hostapd_res="$(ubus call hostapd config_add "{\"iface\":\"$primary_ap\",\"config\":\"${hostapd_conf_file}\"}")"
 			ret="$?"
 			[ "$ret" != 0 -o -z "$hostapd_res" ] && {
 				wireless_setup_failed HOSTAPD_START_FAILED


### PR DESCRIPTION
fix ubus call hostapd config_add error
```
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019): Command failed: ubus call hostapd config_add {"iface":"phy0-ap0", "config":"/var/run/hostapd-phy0.conf"} (Invalid argument)
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019): Usage: ubus [<options>] <command> [arguments...]
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019): Options:
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):  -s <socket>:		Set the unix domain socket to connect to
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):  -t <timeout>:		Set the timeout (in seconds) for a command to complete
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):  -S:			Use simplified output (for scripts)
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):  -v:			More verbose output
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):  -m <type>:		(for monitor): include a specific message type
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019): 			(can be used more than once)
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):  -M <r|t>		(for monitor): only capture received or transmitted traffic
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019): Commands:
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):  - list [<path>]			List objects
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):  - call <path> <method> [<message>]	Call an object method
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):  - subscribe <path> [<path>...]	Subscribe to object(s) notifications
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):  - listen [<path>...]			Listen for events
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):  - send <type> [<message>]		Send an event
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):  - wait_for <object> [<object>...]	Wait for multiple objects to appear on ubus
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):  - monitor				Monitor ubus traffic
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019):
Sat Nov 12 10:30:41 2022 daemon.notice netifd: radio0 (10019): Device setup failed: HOSTAPD_START_FAILED
```