### PR TITLE
[22.03] ipq40xx: ZTE MF286D: fix DEVICE_PACKAGES

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -1008,7 +1008,7 @@ endef
 define Device/zte_mf286d
 	$(call Device/zte_mf28x_common)
 	DEVICE_MODEL := MF286D
-	DEVICE_PACKAGES := ipq-wifi-zte_mf286d
+	DEVICE_PACKAGES += ipq-wifi-zte_mf286d
 endef
 TARGET_DEVICES += zte_mf286d
 


### PR DESCRIPTION
Backporting ZTE MF289F introduced an override of DEVICE_PACKAGES for MF286D, which removed packages needed for built-in modem support. Fix assignment type to restore those.

Fixes: 3e15a54bb0ef ("ipq40xx: Add ZTE MF289F")
Reported-by: Cezary Jackiewicz <cezary@eko.one.pl>
Signed-off-by: Lech Perczak <lech.perczak@gmail.com>