### PR TITLE
ramips: fix MAC address assignment for rt1800, e7350

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -219,6 +219,7 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii Config lan_hwaddr)
 		wan_mac=$(mtd_get_mac_ascii Config wan_hwaddr)
 		label_mac=$lan_mac
+		;;
 	mikrotik,ltap-2hnd)
 		label_mac=$(cat "/sys/firmware/mikrotik/hard_config/mac_base")
 		lan_mac=$label_mac


### PR DESCRIPTION
previous commit ffa4b5283b introduced a bug which broke the MAC address assignment for belkin,rt1800 and linksys,e7350.

Signed-off-by: Arne Zachlod <arne@nerdkeller.org>