### PR TITLE
RFT: rockchip: use LZMA FIT for kernel image

### DIFF
--- a/target/linux/rockchip/image/Makefile
+++ b/target/linux/rockchip/image/Makefile
@@ -16,7 +16,6 @@ define Build/boot-common
 	rm -fR $@.boot
 	mkdir -p $@.boot
 
-	$(CP) $(DTS_DIR)/$(DEVICE_DTS).dtb $@.boot/rockchip.dtb
 	$(CP) $(IMAGE_KERNEL) $@.boot/kernel.img
 endef
 
@@ -48,7 +47,7 @@ endef
 ### Devices ###
 define Device/Default
   PROFILES := Default
-  KERNEL := kernel-bin
+  KERNEL = kernel-bin | lzma | fit lzma $$(DTS_DIR)/$$(DEVICE_DTS).dtb
   IMAGES := sysupgrade.img.gz
   DEVICE_DTS = rockchip/$$(SOC)-$(lastword $(subst _, ,$(1)))
 endef

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -2,6 +2,9 @@
 #
 # Copyright (C) 2020 Tobias Maedel
 
+# FIT will be loaded at 0x02080000. Leave 16M for that, align it to 2M and load the kernel after it.
+KERNEL_LOADADDR := 0x03200000
+
 define Device/friendlyarm_nanopi-r2s
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R2S

--- a/target/linux/rockchip/image/mmc.bootscript
+++ b/target/linux/rockchip/image/mmc.bootscript
@@ -2,7 +2,6 @@ part uuid mmc ${devnum}:2 uuid
 
 setenv bootargs "console=ttyS2,1500000 console=tty1 earlycon=uart8250,mmio32,0xff1a0000 root=PARTUUID=${uuid} rw rootwait"
 
-load mmc ${devnum}:1 ${fdt_addr_r} rockchip.dtb
 load mmc ${devnum}:1 ${kernel_addr_r} kernel.img
 
-booti ${kernel_addr_r} - ${fdt_addr_r}
+bootm ${kernel_addr_r}

--- a/target/linux/rockchip/image/nanopi-r2s.bootscript
+++ b/target/linux/rockchip/image/nanopi-r2s.bootscript
@@ -2,7 +2,6 @@ part uuid mmc ${devnum}:2 uuid
 
 setenv bootargs "console=ttyS2,1500000 earlycon=uart8250,mmio32,0xff130000 root=PARTUUID=${uuid} rw rootwait"
 
-load mmc ${devnum}:1 ${fdt_addr_r} rockchip.dtb
 load mmc ${devnum}:1 ${kernel_addr_r} kernel.img
 
-booti ${kernel_addr_r} - ${fdt_addr_r}
+bootm ${kernel_addr_r}

--- a/target/linux/rockchip/image/nanopi-r4s.bootscript
+++ b/target/linux/rockchip/image/nanopi-r4s.bootscript
@@ -2,7 +2,6 @@ part uuid mmc ${devnum}:2 uuid
 
 setenv bootargs "console=ttyS2,1500000 earlycon=uart8250,mmio32,0xff1a0000 root=PARTUUID=${uuid} rw rootwait"
 
-load mmc ${devnum}:1 ${fdt_addr_r} rockchip.dtb
 load mmc ${devnum}:1 ${kernel_addr_r} kernel.img
 
-booti ${kernel_addr_r} - ${fdt_addr_r}
+bootm ${kernel_addr_r}


### PR DESCRIPTION
Use LZMA compressed kernel to save some space in boot partition.

Fixes: #11197
RFT:
I tried booting the NanoPi R2S image on NanoPi Neo3 and NanoPi R4S image on NanoPi M4v2. Both boot fine but I ended up with random kernel crash in the system. I'm not sure if it's because the ram mismatch or the changed kernel load address.
It would be great if someone with supported rockchip devices can test this for me :)