### PR TITLE
ramips: Switch default kernel to 5.15

### DIFF
--- a/target/linux/ramips/Makefile
+++ b/target/linux/ramips/Makefile
@@ -10,8 +10,7 @@ BOARDNAME:=MediaTek Ralink MIPS
 SUBTARGETS:=mt7620 mt7621 mt76x8 rt288x rt305x rt3883
 FEATURES:=squashfs gpio
 
-KERNEL_PATCHVER:=5.10
-KERNEL_TESTING_PATCHVER:=5.15
+KERNEL_PATCHVER:=5.15
 
 define Target/Description
 	Build firmware images for Ralink RT288x/RT3xxx based boards.


### PR DESCRIPTION
I tested kernel 5.15 on my device for several times without any problems.

In my tests, 5.15 kernel has performance improvements such MGLRU.

Finally, initial kernel 6.1 support is imminent. All ramips subtargets has 5.15 as testing kernel.

So, it's time to change.

Tested on my Archer C6 v3.2 (mt7621)

Signed-off-by: Rodrigo B. de Sousa Martins <rodrigo.sousa.577@gmail.com>