### PR TITLE
mediatek: add LED support for Xiaomi Redmi Router AX6000

### DIFF
--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -22,6 +22,20 @@ endef
 
 $(eval $(call KernelPackage,leds-gpio))
 
+define KernelPackage/leds-ws2812b
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=WS2812B RGB LED support
+  KCONFIG:=CONFIG_LEDS_WS2812B
+  FILES:=$(LINUX_DIR)/drivers/leds/leds-ws2812b.ko
+  AUTOLOAD:=$(call AutoLoad,60,leds-ws2812b,1)
+endef
+
+define KernelPackage/leds-ws2812b/description
+ Kernel module for SPI driven WS2812B RGB LED
+endef
+
+$(eval $(call KernelPackage,leds-ws2812b))
+
 LED_TRIGGER_DIR=$(LINUX_DIR)/drivers/leds/trigger
 
 define KernelPackage/ledtrig-activity

--- a/target/linux/generic/pending-5.15/860-leds-add-driver-for-SPI-driven-WorldSemi-WS2812B-RGB-LEDs.patch
+++ b/target/linux/generic/pending-5.15/860-leds-add-driver-for-SPI-driven-WorldSemi-WS2812B-RGB-LEDs.patch
@@ -1,0 +1,266 @@
+--- a/drivers/leds/Makefile
++++ b/drivers/leds/Makefile
+@@ -93,6 +93,7 @@
+ obj-$(CONFIG_LEDS_DAC124S085)		+= leds-dac124s085.o
+ obj-$(CONFIG_LEDS_EL15203000)		+= leds-el15203000.o
+ obj-$(CONFIG_LEDS_SPI_BYTE)		+= leds-spi-byte.o
++obj-$(CONFIG_LEDS_WS2812B)		+= leds-ws2812b.o
+ 
+ # LED Userspace Drivers
+ obj-$(CONFIG_LEDS_USER)			+= uleds.o
+--- a/drivers/leds/Kconfig
++++ b/drivers/leds/Kconfig
+@@ -818,6 +818,17 @@
+ 	  for controlling the brightness. Currently the following controller is
+ 	  supported: Ubiquiti airCube ISP microcontroller based LED controller.
+ 
++config LEDS_WS2812B
++	tristate "SPI driven WS2812B RGB LED support"
++	depends on OF
++	depends on SPI
++	help
++	  This option enables support for driving daisy-chained WS2812B RGB
++	  LED chips using SPI bus. This driver simulates the single-wire
++	  protocol by sending bits over the SPI MOSI pin. For this to work,
++	  the SPI frequency should be 2.105MHz~2.85MHz and the controller
++	  needs to transfer all the bytes continuously.
++
+ config LEDS_TI_LMU_COMMON
+ 	tristate "LED driver for TI LMU"
+ 	depends on LEDS_CLASS
+--- /dev/null
++++ b/drivers/leds/leds-ws2812b.c
+@@ -0,0 +1,233 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * WorldSemi WS2812B individually-addressable LED driver using SPI
++ *
++ * Copyright 2022 Chuanhong Guo <gch981213@gmail.com>
++ *
++ * This driver simulates WS2812B protocol using SPI MOSI pin. A one pulse
++ * is transferred as 3'b110 and a zero pulse is 3'b100. For this driver to
++ * work properly, the SPI frequency should be 2.105MHz~2.85MHz and it needs
++ * to transfer all the bytes continuously.
++ */
++
++#include <linux/led-class-multicolor.h>
++#include <linux/leds.h>
++#include <linux/module.h>
++#include <linux/of_device.h>
++#include <linux/property.h>
++#include <linux/spi/spi.h>
++#include <linux/mutex.h>
++
++#define WS2812B_BYTES_PER_COLOR 3
++#define WS2812B_NUM_COLORS 3
++/* A continuous 0 for 50us+ as the 'reset' signal */
++#define WS2812B_RESET_LEN 18
++
++struct ws2812b_led {
++	struct led_classdev_mc mc_cdev;
++	struct mc_subled subled[WS2812B_NUM_COLORS];
++	int cascade;
++};
++
++struct ws2812b_priv {
++	struct led_classdev ldev;
++	struct spi_device *spi;
++	struct mutex mutex;
++	int num_leds;
++	size_t data_len;
++	u8 *data_buf;
++	struct ws2812b_led leds[];
++};
++
++/**
++ * ws2812b_set_byte - convert a byte of data to 3-byte SPI data for pulses
++ * @priv: pointer to the private data structure
++ * @offset: offset of the target byte in the data stream
++ * @val: 1-byte data to be set
++ *
++ * WS2812B receives a stream of bytes from DI, takes the first 3 byte as LED
++ * brightness and pases the rest to the next LED through the DO pin.
++ * This function assembles a single byte of data to the LED:
++ * A bit is represented with a pulse of specific length. A long pulse is a 1
++ * and a short pulse is a 0.
++ * SPI transfers data continuously, MSB first. We can send 3'b100 to create a
++ * 0 pulse and 3'b110 for a 1 pulse. In this way, a byte of data takes up 3
++ * bytes in a SPI transfer:
++ *  1x0 1x0 1x0 1x0 1x0 1x0 1x0 1x0
++ * Let's rearrange it in 8 bits:
++ *  1x01x01x 01x01x01 x01x01x0
++ * The higher 3 bits, middle 2 bits and lower 3 bits are represented with the
++ * 1st, 2nd and 3rd byte in the SPI transfer respectively.
++ * There are only 8 combinations for 3 bits and 4 for 2 bits, so we can create
++ * a lookup table for the 3 bytes.
++ * e.g. For 0x6b -> 2'b01101011:
++ *  Bit 7-5: 3'b011 -> 10011011 -> 0x9b
++ *  Bit 4-3: 2'b01  -> 01001101 -> 0x4d
++ *  Bit 2-0: 3'b011 -> 00110110 -> 0x36
++ */
++static void ws2812b_set_byte(struct ws2812b_priv *priv, size_t offset, u8 val)
++{
++	/* The lookup table for Bit 7-5 4-3 2-0 */
++	const u8 h3b[] = { 0x92, 0x93, 0x9a, 0x9b, 0xd2, 0xd3, 0xda, 0xdb };
++	const u8 m2b[] = { 0x49, 0x4d, 0x69, 0x6d };
++	const u8 l3b[] = { 0x24, 0x26, 0x34, 0x36, 0xa4, 0xa6, 0xb4, 0xb6 };
++	u8 *p = priv->data_buf + WS2812B_RESET_LEN + (offset * WS2812B_BYTES_PER_COLOR);
++
++	p[0] = h3b[val >> 5]; /* Bit 7-5 */
++	p[1] = m2b[(val >> 3) & 0x3]; /* Bit 4-3 */
++	p[2] = l3b[val & 0x7]; /* Bit 2-0 */
++}
++
++static int ws2812b_set(struct led_classdev *cdev,
++		       enum led_brightness brightness)
++{
++	struct led_classdev_mc *mc_cdev = lcdev_to_mccdev(cdev);
++	struct ws2812b_led *led =
++		container_of(mc_cdev, struct ws2812b_led, mc_cdev);
++	struct ws2812b_priv *priv = dev_get_drvdata(cdev->dev->parent);
++	int ret;
++	int i;
++
++	led_mc_calc_color_components(mc_cdev, brightness);
++
++	mutex_lock(&priv->mutex);
++	for (i = 0; i < WS2812B_NUM_COLORS; i++)
++		ws2812b_set_byte(priv, led->cascade * WS2812B_NUM_COLORS + i,
++				 led->subled[i].brightness);
++	ret = spi_write(priv->spi, priv->data_buf, priv->data_len);
++	mutex_unlock(&priv->mutex);
++
++	return ret;
++}
++
++static int ws2812b_probe(struct spi_device *spi)
++{
++	struct device *dev = &spi->dev;
++	int cur_led = 0;
++	struct ws2812b_priv *priv;
++	struct fwnode_handle *led_node;
++	int num_leds, i, cnt, ret;
++
++	num_leds = device_get_child_node_count(dev);
++
++	priv = devm_kzalloc(dev, struct_size(priv, leds, num_leds), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++	priv->data_len =
++		num_leds * WS2812B_BYTES_PER_COLOR * WS2812B_NUM_COLORS +
++		WS2812B_RESET_LEN;
++	priv->data_buf = kzalloc(priv->data_len, GFP_KERNEL);
++	if (!priv->data_buf)
++		return -ENOMEM;
++
++	for (i = 0; i < num_leds * WS2812B_NUM_COLORS; i++)
++		ws2812b_set_byte(priv, i, 0);
++
++	mutex_init(&priv->mutex);
++	priv->num_leds = num_leds;
++	priv->spi = spi;
++
++	device_for_each_child_node(dev, led_node) {
++		struct led_init_data init_data = {
++			.fwnode = led_node,
++		};
++		/* WS2812B LEDs usually come with GRB color */
++		u32 color_idx[WS2812B_NUM_COLORS] = {
++			LED_COLOR_ID_GREEN,
++			LED_COLOR_ID_RED,
++			LED_COLOR_ID_BLUE,
++		};
++		u32 cascade;
++
++		ret = fwnode_property_read_u32(led_node, "reg", &cascade);
++		if (ret) {
++			dev_err(dev, "failed to obtain numerical LED index for %s",
++				fwnode_get_name(led_node));
++			goto ERR_UNREG_LEDS;
++		}
++		if (cascade >= num_leds) {
++			dev_err(dev, "LED index of %s is larger than the number of LEDs.",
++				fwnode_get_name(led_node));
++			ret = -EINVAL;
++			goto ERR_UNREG_LEDS;
++		}
++
++		cnt = fwnode_property_count_u32(led_node, "color-index");
++		if (cnt > 0 && cnt <= WS2812B_NUM_COLORS)
++			fwnode_property_read_u32_array(led_node, "color-index",
++						       color_idx, (size_t)cnt);
++
++		priv->leds[cur_led].mc_cdev.subled_info =
++			priv->leds[cur_led].subled;
++		priv->leds[cur_led].mc_cdev.num_colors = WS2812B_NUM_COLORS;
++		priv->leds[cur_led].mc_cdev.led_cdev.max_brightness = 255;
++		priv->leds[cur_led].mc_cdev.led_cdev.brightness_set_blocking = ws2812b_set;
++
++		for (i = 0; i < WS2812B_NUM_COLORS; i++) {
++			priv->leds[cur_led].subled[i].color_index = color_idx[i];
++			priv->leds[cur_led].subled[i].intensity = 255;
++		}
++
++		priv->leds[cur_led].cascade = cascade;
++
++		ret = led_classdev_multicolor_register_ext(
++			dev, &priv->leds[cur_led].mc_cdev, &init_data);
++		if (ret) {
++			dev_err(dev, "registration of %s failed.",
++				fwnode_get_name(led_node));
++			goto ERR_UNREG_LEDS;
++		}
++		cur_led++;
++	}
++
++	spi_set_drvdata(spi, priv);
++
++	return 0;
++ERR_UNREG_LEDS:
++	for (; cur_led >= 0; cur_led--)
++		led_classdev_multicolor_unregister(&priv->leds[cur_led].mc_cdev);
++	mutex_destroy(&priv->mutex);
++	kfree(priv->data_buf);
++	return ret;
++}
++
++static int ws2812b_remove(struct spi_device *spi)
++{
++	struct ws2812b_priv *priv = spi_get_drvdata(spi);
++	int cur_led;
++
++	for (cur_led = priv->num_leds - 1; cur_led >= 0; cur_led--)
++		led_classdev_multicolor_unregister(&priv->leds[cur_led].mc_cdev);
++	kfree(priv->data_buf);
++	mutex_destroy(&priv->mutex);
++
++	return 0;
++}
++
++static const struct spi_device_id ws2812b_spi_ids[] = {
++	{ "ws2812b" },
++	{},
++};
++MODULE_DEVICE_TABLE(spi, ws2812b_spi_ids);
++
++static const struct of_device_id ws2812b_dt_ids[] = {
++	{ .compatible = "worldsemi,ws2812b" },
++	{},
++};
++MODULE_DEVICE_TABLE(of, ws2812b_dt_ids);
++
++static struct spi_driver ws2812b_driver = {
++	.probe		= ws2812b_probe,
++	.remove		= ws2812b_remove,
++	.id_table	= ws2812b_spi_ids,
++	.driver = {
++		.name		= KBUILD_MODNAME,
++		.of_match_table	= ws2812b_dt_ids,
++	},
++};
++
++module_spi_driver(ws2812b_driver);
++
++MODULE_AUTHOR("Chuanhong Guo <gch981213@gmail.com>");
++MODULE_DESCRIPTION("WS2812B LED driver using SPI");
++MODULE_LICENSE("GPL");

--- a/target/linux/generic/pending-5.15/860-leds-add-driver-for-SPI-driven-WorldSemi-WS2812B-RGB-LEDs.patch
+++ b/target/linux/generic/pending-5.15/860-leds-add-driver-for-SPI-driven-WorldSemi-WS2812B-RGB-LEDs.patch
@@ -1,6 +1,6 @@
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
-@@ -93,6 +93,7 @@
+@@ -93,6 +93,7 @@ obj-$(CONFIG_LEDS_CR0014114)		+= leds-cr
  obj-$(CONFIG_LEDS_DAC124S085)		+= leds-dac124s085.o
  obj-$(CONFIG_LEDS_EL15203000)		+= leds-el15203000.o
  obj-$(CONFIG_LEDS_SPI_BYTE)		+= leds-spi-byte.o
@@ -10,7 +10,7 @@
  obj-$(CONFIG_LEDS_USER)			+= uleds.o
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
-@@ -818,6 +818,17 @@
+@@ -818,6 +818,17 @@ config LEDS_SPI_BYTE
  	  for controlling the brightness. Currently the following controller is
  	  supported: Ubiquiti airCube ISP microcontroller based LED controller.
  

--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dts
@@ -3,6 +3,7 @@
 /dts-v1/;
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
 
 #include "mt7986a.dtsi"
 
@@ -12,6 +13,10 @@
 
 	aliases {
 		serial0 = &uart0;
+		led-boot = &led_status_rgb;
+		led-failsafe = &led_status_rgb;
+		led-running = &led_status_rgb;
+		led-upgrade = &led_status_rgb;
 	};
 
 	chosen {
@@ -92,6 +97,13 @@
 			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
 			drive-strength = <8>;
 			mediatek,pull-down-adv = <0>; /* bias-disable */
+		};
+	};
+
+	spi_led_pins: spic-pins-29-to-32 {
+		mux {
+			function = "spi";
+			groups = "spi1_2";
 		};
 	};
 
@@ -198,6 +210,34 @@
 			};
 
 			/* last 12 MiB is reserved for NMBM bad block table */
+		};
+	};
+};
+
+&spi1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_led_pins>;
+	status = "okay";
+
+	ws2812b@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "worldsemi,ws2812b";
+		reg = <0>;
+		spi-max-frequency = <3000000>;
+
+		led_status_rgb: led@0 {
+			reg = <0>;
+			label = "rgb:status";
+			color-index = <LED_COLOR_ID_RED LED_COLOR_ID_GREEN LED_COLOR_ID_BLUE>;
+			default-intensity = <255 255 255>;
+		};
+
+		led_network_rgb: led@1 {
+			reg = <1>;
+			label = "rgb:network";
+			color-index = <LED_COLOR_ID_RED LED_COLOR_ID_GREEN LED_COLOR_ID_BLUE>;
+			default-intensity = <255 255 255>;
 		};
 	};
 };

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -1,0 +1,18 @@
+
+. /lib/functions/leds.sh
+. /lib/functions/uci-defaults.sh
+
+board=$(board_name)
+
+board_config_update
+
+case $board in
+xiaomi,redmi-router-ax6000)
+	ucidef_set_led_netdev "wan" "wan" "rgb:network" "wan"
+	ucidef_set_led_heartbeat "status" "status" "rgb:status"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -130,6 +130,7 @@ define Device/xiaomi_redmi-router-ax6000
   DEVICE_MODEL := Redmi Router AX6000
   DEVICE_DTS := mt7986a-xiaomi-redmi-router-ax6000
   DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-leds-ws2812b
   KERNEL_LOADADDR := 0x48000000
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k

--- a/target/linux/mediatek/patches-5.15/930-spi-mediatek-fix-spi1-clock-dependency-for-mt7986.patch
+++ b/target/linux/mediatek/patches-5.15/930-spi-mediatek-fix-spi1-clock-dependency-for-mt7986.patch
@@ -1,0 +1,29 @@
+--- a/drivers/spi/spi-mt65xx.c
++++ b/drivers/spi/spi-mt65xx.c
+@@ -1223,10 +1223,16 @@ static int mtk_spi_probe(struct platform
+ 		goto err_disable_spi_hclk;
+ 	}
+ 
++	ret = clk_prepare_enable(mdata->sel_clk);
++	if (ret < 0) {
++		dev_err(&pdev->dev, "failed to enable sel_clk (%d)\n", ret);
++		goto err_disable_spi_clk;
++	}
++
+ 	ret = clk_set_parent(mdata->sel_clk, mdata->parent_clk);
+ 	if (ret < 0) {
+ 		dev_err(&pdev->dev, "failed to clk_set_parent (%d)\n", ret);
+-		goto err_disable_spi_clk;
++		goto err_disable_spi_sel_clk;
+ 	}
+ 
+ 	mdata->spi_clk_hz = clk_get_rate(mdata->spi_clk);
+@@ -1277,6 +1283,8 @@ static int mtk_spi_probe(struct platform
+ 
+ err_disable_runtime_pm:
+ 	pm_runtime_disable(&pdev->dev);
++err_disable_spi_sel_clk:
++	clk_disable_unprepare(mdata->sel_clk);
+ err_disable_spi_clk:
+ 	clk_disable_unprepare(mdata->spi_clk);
+ err_disable_spi_hclk:


### PR DESCRIPTION
V1:
1. The LED panel is on SPI1 bus, while SPI1 has a clock issue.
clk_disable_unused() function during the boot process will disable the sel_clk of SPI1 by mistake.
When driver trying to read registers of SPI1, CPU will hang.
So we enable the sel_clk explicitly to make SPI1 full functional.

2. LED panel has 2 physical RGB LEDs, which are controlled by a single wire proprietary protocal.
This device uses MOSI of SPI1 to output the single wire data to both LEDs.
With some kind of reverse-engineering method, I can set RGB colors for each of them finally.
And a new driver, leds-spi-single-wire, was written to light up the LED panel.

V2:
switch to multicolor led driver by @981213 