### PR TITLE
ath79: disable image building for Ubiquiti EdgeSwitch 8XP

### DIFF
--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -43,6 +43,7 @@ define Device/ubnt_edgeswitch-8xp
   $(Device/ubnt-sw)
   DEVICE_MODEL := EdgeSwitch 8XP
   DEVICE_PACKAGES += kmod-switch-bcm53xx-mdio
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_edgeswitch-8xp
 


### PR DESCRIPTION
The downstream OpenWrt driver for the BCM53128 switch ceased to work, rendering the 8 LAN ports of the device unusable. This commit disables image building in future 22.03 releases until the problem is solved.

See issue #10374 for more details.