### PR TITLE
ath79: fix MAC address assigment for TP-Link TL-WR740N/TL-WR741ND v4

### DIFF
--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr741nd-v4.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr741nd-v4.dtsi
@@ -118,7 +118,7 @@
 	};
 };
 
-&eth0 {
+&eth0 {		/* WAN interface, initialized last as eth1 */
 	status = "okay";
 
 	nvmem-cells = <&macaddr_uboot_1fc00>;
@@ -133,12 +133,11 @@
 	};
 };
 
-&eth1 {
+&eth1 {		/* LAN interface, initialized first as eth0 */
 	status = "okay";
 
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-1)>;
 };
 
 &wmac {


### PR DESCRIPTION
On TP-Link TL-WR740N/TL-WR741ND v4 LAN MAC address (eth1 in DTS) is main device MAC address, so do not increment it. WAN MAC is LAN MAC + 1.