### PR TITLE
ramips: fix wrong pcie port number for Arcadyan devices

### DIFF
--- a/target/linux/ramips/dts/mt7621_arcadyan_wg4xx223.dtsi
+++ b/target/linux/ramips/dts/mt7621_arcadyan_wg4xx223.dtsi
@@ -158,7 +158,7 @@
 	status = "okay";
 };
 
-&pcie0 {
+&pcie1 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;


### PR DESCRIPTION
Depends on https://github.com/openwrt/openwrt/pull/11255
--------------------------------------------------------------------
Wrong pcie port number for WLAN causes [missing 5g WLAN interface with 5.15 kernel](https://github.com/openwrt/openwrt/pull/11255#issuecomment-1320832181). This changes port from pcie0 to pcie1 in dtsi.

```
[1.166330] mt7621-pci 1e140000.pcie: pcie0 no card, disable it (RST & CLK)
[1.180073] mt7621-pci 1e140000.pcie: pcie2 no card, disable it (RST & CLK)
[1.193889] mt7621-pci 1e140000.pcie: PCIE1 enabled
```

