### PR TITLE
ramips: add support for HiWiFi HC5611

### DIFF
--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5611.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5611.dts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_hiwifi_hc5x61a.dtsi"
+
+/ {
+	compatible = "hiwifi,hc5611", "mediatek,mt7628an-soc";
+	model = "HiWiFi HC5611";
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "green:system";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		internet {
+			label = "red:internet";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "gpio", "spi cs1", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -243,6 +243,14 @@ define Device/hilink_hlk-7688a
 endef
 TARGET_DEVICES += hilink_hlk-7688a
 
+define Device/hiwifi_hc5611
+  IMAGE_SIZE := 15808k
+  DEVICE_VENDOR := HiWiFi
+  DEVICE_MODEL := HC5611
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += hiwifi_hc5611
+
 define Device/hiwifi_hc5661a
   IMAGE_SIZE := 15808k
   DEVICE_VENDOR := HiWiFi

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -46,6 +46,9 @@ skylab,skw92a)
 hilink,hlk-7688a)
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
+hiwifi,hc5611)
+	ucidef_set_led_netdev "internet" "internet" "red:internet" "br-lan" "tx rx"
+	;;
 hiwifi,hc5661a|\
 hiwifi,hc5761a)
 	ucidef_set_led_switch "internet" "internet" "blue:internet" "switch0" "0x10"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ ramips_setup_interfaces()
 	glinet,microuter-n300|\
 	glinet,vixmini|\
 	hak5,wifi-pineapple-mk7|\
+	hiwifi,hc5611|\
 	mediatek,linkit-smart-7688|\
 	minew,g1-c|\
 	onion,omega2p|\
@@ -226,6 +227,7 @@ ramips_setup_macs()
 	zyxel,keenetic-extra-ii)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1)
 		;;
+	hiwifi,hc5611|\
 	hiwifi,hc5661a|\
 	hiwifi,hc5761a|\
 	hiwifi,hc5861b)

--- a/target/linux/ramips/mt76x8/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt76x8/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -10,6 +10,7 @@ PHYNBR=${DEVPATH##*/phy}
 board=$(board_name)
 
 case "$board" in
+	hiwifi,hc5611|\
 	hiwifi,hc5661a|\
 	hiwifi,hc5761a|\
 	hiwifi,hc5861b)


### PR DESCRIPTION
### Hardware:
CPU: MediaTek MT7628AN @ 575 MHz
Flash: 16 MB
RAM: 128 MB
Ethernet: 10/100Mbps x 1
Wlan: 300 Mbps
USB: USB 2.0 x 1
LED: red/green x 1
Button: reset x 1

### Installation

1. Open https://www.hiwifi.wtf/, Get Cloud token and unlock ssh
2. Upload the openwrt firmware to the router via SCP
3. Login the router via SSH
4. Run `mtd -r write path_to_firmware.bin firmware`

### Others
I have tested on my device.
```
- The LED will display RED on power-on, After system start completed, trun GREEN 
- Reset button working now. Long press after 5s will reset factory. Short press less 1s will reboot the device
- USB can working under official u-boot
```