### PR TITLE
realtek: d-link: add support for dgs-1210-28mp-f

### DIFF
--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-28.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-28.dts
@@ -3,98 +3,9 @@
 #include "rtl838x.dtsi"
 #include "rtl83xx_d-link_dgs-1210_common.dtsi"
 #include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
+#include "rtl8382_d-link_dgs-1210-28_common.dtsi"
 
 / {
 	compatible = "d-link,dgs-1210-28", "realtek,rtl838x-soc";
 	model = "D-Link DGS-1210-28";
-};
-
-&ethernet0 {
-	mdio: mdio-bus {
-		compatible = "realtek,rtl838x-mdio";
-		regmap = <&ethernet0>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		EXTERNAL_PHY(0)
-		EXTERNAL_PHY(1)
-		EXTERNAL_PHY(2)
-		EXTERNAL_PHY(3)
-		EXTERNAL_PHY(4)
-		EXTERNAL_PHY(5)
-		EXTERNAL_PHY(6)
-		EXTERNAL_PHY(7)
-
-		INTERNAL_PHY(8)
-		INTERNAL_PHY(9)
-		INTERNAL_PHY(10)
-		INTERNAL_PHY(11)
-		INTERNAL_PHY(12)
-		INTERNAL_PHY(13)
-		INTERNAL_PHY(14)
-		INTERNAL_PHY(15)
-
-		EXTERNAL_PHY(16)
-		EXTERNAL_PHY(17)
-		EXTERNAL_PHY(18)
-		EXTERNAL_PHY(19)
-		EXTERNAL_PHY(20)
-		EXTERNAL_PHY(21)
-		EXTERNAL_PHY(22)
-		EXTERNAL_PHY(23)
-
-		EXTERNAL_SFP_PHY(24)
-		EXTERNAL_SFP_PHY(25)
-		EXTERNAL_SFP_PHY(26)
-		EXTERNAL_SFP_PHY(27)
-	};
-};
-
-&switch0 {
-	ports {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		SWITCH_PORT(0, 1, qsgmii)
-		SWITCH_PORT(1, 2, qsgmii)
-		SWITCH_PORT(2, 3, qsgmii)
-		SWITCH_PORT(3, 4, qsgmii)
-		SWITCH_PORT(4, 5, qsgmii)
-		SWITCH_PORT(5, 6, qsgmii)
-		SWITCH_PORT(6, 7, qsgmii)
-		SWITCH_PORT(7, 8, qsgmii)
-
-		SWITCH_PORT(8, 9, internal)
-		SWITCH_PORT(9, 10, internal)
-		SWITCH_PORT(10, 11, internal)
-		SWITCH_PORT(11, 12, internal)
-		SWITCH_PORT(12, 13, internal)
-		SWITCH_PORT(13, 14, internal)
-		SWITCH_PORT(14, 15, internal)
-		SWITCH_PORT(15, 16, internal)
-
-		SWITCH_PORT(16, 17, qsgmii)
-		SWITCH_PORT(17, 18, qsgmii)
-		SWITCH_PORT(18, 19, qsgmii)
-		SWITCH_PORT(19, 20, qsgmii)
-		SWITCH_PORT(20, 21, qsgmii)
-		SWITCH_PORT(21, 22, qsgmii)
-		SWITCH_PORT(22, 23, qsgmii)
-		SWITCH_PORT(23, 24, qsgmii)
-
-		SWITCH_PORT(24, 25, qsgmii)
-		SWITCH_PORT(25, 26, qsgmii)
-		SWITCH_PORT(26, 27, qsgmii)
-		SWITCH_PORT(27, 28, qsgmii)
-
-		port@28 {
-			ethernet = <&ethernet0>;
-			reg = <28>;
-			phy-mode = "internal";
-			fixed-link {
-				speed = <1000>;
-				full-duplex;
-			};
-		};
-	};
 };

--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-28_common.dtsi
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-28_common.dtsi
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		EXTERNAL_PHY(0)
+		EXTERNAL_PHY(1)
+		EXTERNAL_PHY(2)
+		EXTERNAL_PHY(3)
+		EXTERNAL_PHY(4)
+		EXTERNAL_PHY(5)
+		EXTERNAL_PHY(6)
+		EXTERNAL_PHY(7)
+
+		INTERNAL_PHY(8)
+		INTERNAL_PHY(9)
+		INTERNAL_PHY(10)
+		INTERNAL_PHY(11)
+		INTERNAL_PHY(12)
+		INTERNAL_PHY(13)
+		INTERNAL_PHY(14)
+		INTERNAL_PHY(15)
+
+		EXTERNAL_PHY(16)
+		EXTERNAL_PHY(17)
+		EXTERNAL_PHY(18)
+		EXTERNAL_PHY(19)
+		EXTERNAL_PHY(20)
+		EXTERNAL_PHY(21)
+		EXTERNAL_PHY(22)
+		EXTERNAL_PHY(23)
+
+		EXTERNAL_SFP_PHY(24)
+		EXTERNAL_SFP_PHY(25)
+		EXTERNAL_SFP_PHY(26)
+		EXTERNAL_SFP_PHY(27)
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, internal)
+		SWITCH_PORT(9, 10, internal)
+		SWITCH_PORT(10, 11, internal)
+		SWITCH_PORT(11, 12, internal)
+		SWITCH_PORT(12, 13, internal)
+		SWITCH_PORT(13, 14, internal)
+		SWITCH_PORT(14, 15, internal)
+		SWITCH_PORT(15, 16, internal)
+
+		SWITCH_PORT(16, 17, qsgmii)
+		SWITCH_PORT(17, 18, qsgmii)
+		SWITCH_PORT(18, 19, qsgmii)
+		SWITCH_PORT(19, 20, qsgmii)
+		SWITCH_PORT(20, 21, qsgmii)
+		SWITCH_PORT(21, 22, qsgmii)
+		SWITCH_PORT(22, 23, qsgmii)
+		SWITCH_PORT(23, 24, qsgmii)
+
+		SWITCH_PORT(24, 25, qsgmii)
+		SWITCH_PORT(25, 26, qsgmii)
+		SWITCH_PORT(26, 27, qsgmii)
+		SWITCH_PORT(27, 28, qsgmii)
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-28mp-f.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_d-link_dgs-1210-28mp-f.dts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl838x.dtsi"
+#include "rtl83xx_d-link_dgs-1210_common.dtsi"
+#include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
+#include "rtl8382_d-link_dgs-1210-28_common.dtsi"
+
+/ {
+	compatible = "d-link,dgs-1210-28mp-f", "realtek,rtl8382-soc", "realtek,rtl838x-soc";
+	model = "D-Link DGS-1210-28MP F";
+};
+
+&leds {
+	link_act {
+		label = "green:link_act";
+		gpios = <&gpio1 28 GPIO_ACTIVE_LOW>;
+	};
+
+	poe {
+		label = "green:poe";
+		gpios = <&gpio1 29 GPIO_ACTIVE_LOW>;
+	};
+
+	poe_max {
+		label = "yellow:poe_max";
+		gpios = <&gpio1 27 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&keys {
+	mode {
+		label = "mode";
+		gpios = <&gpio1 30 GPIO_ACTIVE_LOW>;
+		linux,code = <BTN_0>;
+	};
+};
+
+&uart1 {
+	status = "okay";
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -50,6 +50,15 @@ define Device/d-link_dgs-1210-28
 endef
 TARGET_DEVICES += d-link_dgs-1210-28
 
+define Device/d-link_dgs-1210-28mp-f
+  $(Device/d-link_dgs-1210)
+  SOC := rtl8382
+  DEVICE_MODEL := DGS-1210-28MP
+  DEVICE_VARIANT := F
+  DEVICE_PACKAGES += realtek-poe
+endef
+TARGET_DEVICES += d-link_dgs-1210-28mp-f
+
 # The "IMG-" uImage name allows flashing the iniramfs from the vendor Web UI.
 # Avoided for sysupgrade, as the vendor FW would do an incomplete flash.
 define Device/engenius_ews2910p


### PR DESCRIPTION
General hardware info:
----------------------

D-Link DGS-1210-28MP rev. F1 is a switch with 24 ethernet ports and 4 combo ports, all ports Gbit capable. It is based on a RTL8382 SoC @ 500MHz, DRAM 128MB and 32MB flash. 24 ethernet ports are 802.3af/at PoE capable with a total PoE power budget of 370W.

Power over Ethernet:
--------------------

In order to enable PoE, the realtek-poe package is required. It is installed by default, but currently it requires the manual editing of /etc/config/poe. Keep in mind that the port number assignment does not match on this switch - port 1 in the config file is physical port 7 on the switch.

Serial connection:
------------------
The UART for the SoC (115200 8N1) is available via unpopulated standard 0.1" pin header marked J6. Pin1 is marked with arrow and square.

Pin 1: Vcc 3,3V
Pin 2: Tx
Pin 3: Rx
Pin 4: Gnd

OEM installation from Web Interface:
------------------------------------

  1. Make sure you are booting using OEM in image 2 slot. If not, switch to image2 using the menus System > Firmware Information > Boot from image2 Tools > reboot
  2. Upload image in vendor firmware via Tools > Backup / Upgrade Firmware > image1
  3. Toogle startup image via System > Firmware Information > Boot from image1
  4. Tools > reboot

Other installation methods not tested, but since the device shares the board with the DGS-1210-28, the following should work:

Boot initramfs image from U-Boot:
---------------------------------

  1. Press Escape key during `Hit Esc key to stop autoboot` prompt
  2. Press CTRL+C keys to get into real U-Boot prompt
  3. Init network with `rtk network on` command
  4. Load image with `tftpboot 0x8f000000 openwrt-rtl838x-generic-d-link_dgs-1210-28mp-f-initramfs-kernel.bin` command
  5. Boot the image with `bootm` command

Signed-off-by: Andreas Böhler <dev@aboehler.at>