### PR TITLE
scripts: remove redundant '0x0a' in Linksys image signature

### DIFF
--- a/scripts/linksys-image.sh
+++ b/scripts/linksys-image.sh
@@ -17,7 +17,6 @@
 #  <padding>	    Padding ('0' + 0x20 *7) (8 bytes)
 #  <signature>	    Signature of signer. Not checked so use arbitrary value (16 bytes)
 #  <padding>        Padding (0x00) (192 bytes)
-#  0x0A		    (1 byte)
 
 ## version history
 # * version 1: initial commit
@@ -61,7 +60,5 @@ CRC=$(printf "%08X" $(dd if="${IMG_IN}" bs=$(stat -c%s "${IMG_IN}") count=1|cksu
 printf ".LINKSYS.01000409%-15s%-8s%-8s%-16s" "${TYPE}" "${CRC}" "0" "K0000000F0246434" >> "${IMG_TMP_OUT}"
 
 dd if=/dev/zero bs=1 count=192 conv=notrunc >> "${IMG_TMP_OUT}"
-
-printf '\12' >> "${IMG_TMP_OUT}"
 
 cp "${IMG_TMP_OUT}" "${IMG_OUT}"


### PR DESCRIPTION
In PR https://github.com/openwrt/openwrt/pull/11106 I made a mistake by accident. I forgot to remove the unused character '0x0a' at the end.

The redundant '0x0a' after the 192 bytes '0x00' padding broke the factory image. We need to remove it to make things work again.

Fixes: e6769d11f3 scripts: fix missing character '0' issue in linksys image

