### PR TITLE
ath79: calibrate nand netgear wndrxxxx with nvmem

### DIFF
--- a/target/linux/ath79/dts/ar9344_netgear_wndr.dtsi
+++ b/target/linux/ath79/dts/ar9344_netgear_wndr.dtsi
@@ -243,9 +243,8 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_caldata_0>;
-	nvmem-cell-names = "mac-address";
-	qca,no-eeprom;
+	nvmem-cells = <&macaddr_caldata_0>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
 };
 
 &pcie {
@@ -254,9 +253,8 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,0033";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_caldata_c>;
-		nvmem-cell-names = "mac-address";
-		qca,no-eeprom;
+		nvmem-cells = <&macaddr_caldata_c>, <&cal_art_5000>;
+		nvmem-cell-names = "mac-address", "calibration";
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -273,5 +271,13 @@
 
 	macaddr_caldata_c: macaddr@c {
 		reg = <0xc 0x6>;
+	};
+
+	cal_art_1000: cal@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	cal_art_5000: cal@5000 {
+		reg = <0x5000 0x440>;
 	};
 };

--- a/target/linux/ath79/dts/qca9563_netgear_wndr.dtsi
+++ b/target/linux/ath79/dts/qca9563_netgear_wndr.dtsi
@@ -209,9 +209,8 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_caldata_0>;
-	nvmem-cell-names = "mac-address";
-	qca,no-eeprom;
+	nvmem-cells = <&macaddr_caldata_0>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
 };
 
 &pcie {
@@ -221,9 +220,8 @@
 		/* chip is AR9580, override bogus PCI ID 168c:abcd */
 		compatible = "pci168c,0033";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_caldata_c>;
-		nvmem-cell-names = "mac-address";
-		qca,no-eeprom;
+		nvmem-cells = <&macaddr_caldata_c>, <&cal_art_5000>;
+		nvmem-cell-names = "mac-address", "calibration";
 		qca,gpio-mask=<0xf6ff>;	/* unmask pin 9 for RFKILL button */
 		#gpio-cells = <2>;
 		gpio-controller;
@@ -249,5 +247,13 @@
 
 	macaddr_caldata_c: macaddr@c {
 		reg = <0xc 0x6>;
+	};
+
+	cal_art_1000: cal@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	cal_art_5000: cal@5000 {
+		reg = <0x5000 0x440>;
 	};
 };

--- a/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -12,29 +12,6 @@ case "$FIRMWARE" in
 	8dev,rambutan)
 		caldata_extract "caldata" 0x1000 0x800
 		;;
-	netgear,wndr3700-v4|\
-	netgear,wndr4300|\
-	netgear,wndr4300sw|\
-	netgear,wndr4300tn|\
-	netgear,wndr4300-v2|\
-	netgear,wndr4500-v3)
-		caldata_extract "caldata" 0x1000 0x440
-		;;
-	*)
-		caldata_die "board $board is not supported yet"
-		;;
-	esac
-	;;
-"ath9k-eeprom-pci-0000:00:00.0.bin")
-	case $board in
-	netgear,wndr3700-v4|\
-	netgear,wndr4300|\
-	netgear,wndr4300sw|\
-	netgear,wndr4300tn|\
-	netgear,wndr4300-v2|\
-	netgear,wndr4500-v3)
-		caldata_extract "caldata" 0x5000 0x440
-		;;
 	*)
 		caldata_die "board $board is not supported yet"
 		;;


### PR DESCRIPTION
Driver for both soc (2.4GHz Wifi) and pci (5 GHz) now pull the calibration data from the nvmem subsystem.

This allows us to move the userspace caldata extraction for the pci-e ath9k supported wifi into the device-tree definition of the device.

wmac's nodes are also changed over to use nvmem-cells over OpenWrt's custom mtd-cal-data property.

The wifi mac address remains correct after these changes, because When both "mac-address" and "calibration" are defined, the effective mac address comes from the cell corresponding to "mac-address" and mac-address-increment.

Test passed on my wndr3700v4 and wndr4500v3.
Signed-off-by: Edward Chow <equu@openmail.cc>