### PR TITLE
mac80211: subsys: complete patch files for use with git am

### DIFF
--- a/package/kernel/mac80211/patches/subsys/110-mac80211_keep_keys_on_stop_ap.patch
+++ b/package/kernel/mac80211/patches/subsys/110-mac80211_keep_keys_on_stop_ap.patch
@@ -1,4 +1,11 @@
-Used for AP+STA support in OpenWrt - preserve AP mode keys across STA reconnects
+From: Felix Fietkau <nbd@nbd.name>
+Date: Mon, 27 Oct 2014 00:00:00 +0100
+Subject: [PATCH] mac80211: preseve AP mode keys across STA reconnect
+
+Used for AP+STA support in OpenWrt - preserve AP mode keys across STA reconnect
+---
+ net/mac80211/cfg.c | 1 -
+ 1 file changed, 1 deletion(-)
 
 --- a/net/mac80211/cfg.c
 +++ b/net/mac80211/cfg.c

--- a/package/kernel/mac80211/patches/subsys/120-cfg80211_allow_perm_addr_change.patch
+++ b/package/kernel/mac80211/patches/subsys/120-cfg80211_allow_perm_addr_change.patch
@@ -1,3 +1,12 @@
+From: Felix Fietkau <nbd@nbd.name>
+Date: Thu, 11 Dec 2014 00:00:00 +0100
+Subject: [PATCH] cfg80211: add support for changing the device mac address via
+ sysfs
+
+---
+ net/wireless/sysfs.c | 27 ++++++++++++++++++++++-----
+ 1 file changed, 22 insertions(+), 5 deletions(-)
+
 --- a/net/wireless/sysfs.c
 +++ b/net/wireless/sysfs.c
 @@ -24,18 +24,35 @@ static inline struct cfg80211_registered

--- a/package/kernel/mac80211/patches/subsys/150-disable_addr_notifier.patch
+++ b/package/kernel/mac80211/patches/subsys/150-disable_addr_notifier.patch
@@ -1,3 +1,11 @@
+From: Felix Fietkau <nbd@nbd.name>
+Date: Sun, 24 Feb 2013 00:00:00 +0100
+Subject: [PATCH] mac80211: disable ipv4/ipv6 address notifiers
+
+---
+ net/mac80211/main.c | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
 --- a/net/mac80211/main.c
 +++ b/net/mac80211/main.c
 @@ -337,7 +337,7 @@ void ieee80211_restart_hw(struct ieee802

--- a/package/kernel/mac80211/patches/subsys/210-ap_scan.patch
+++ b/package/kernel/mac80211/patches/subsys/210-ap_scan.patch
@@ -1,3 +1,11 @@
+From: Felix Fietkau <nbd@nbd.name>
+Date: Wed, 3 Oct 2012 00:00:00 +0200
+Subject: [PATCH] mac80211: allow scans in access point mode (for site survey)
+
+---
+ net/mac80211/cfg.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 --- a/net/mac80211/cfg.c
 +++ b/net/mac80211/cfg.c
 @@ -2497,7 +2497,7 @@ static int ieee80211_scan(struct wiphy *

--- a/package/kernel/mac80211/patches/subsys/400-allow-ibss-mixed.patch
+++ b/package/kernel/mac80211/patches/subsys/400-allow-ibss-mixed.patch
@@ -1,7 +1,18 @@
-ath10k-ct starting with version 5.2 allows the combination of 
-NL80211_IFTYPE_ADHOC and beacon_int_min_gcd in ath10k_10x_ct_if_comb 
-which triggers this warning. Ben told me that this is not a big problem 
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Mon, 24 Feb 2020 00:00:00 +0100
+Subject: [PATCH] mac80211: Allow IBSS mode and different beacon intervals
+
+ath10k-ct supports the combination to select IBSS (ADHOC) mode and
+different beacon intervals together. mac80211 does not like this
+combination, but Ben says this is ok, so remove this check.
+
+ath10k-ct starting with version 5.2 allows the combination of
+NL80211_IFTYPE_ADHOC and beacon_int_min_gcd in ath10k_10x_ct_if_comb
+which triggers this warning. Ben told me that this is not a big problem
 and we should ignore this.
+---
+ net/wireless/core.c | 15 ---------------
+ 1 file changed, 15 deletions(-)
 
 --- a/net/wireless/core.c
 +++ b/net/wireless/core.c


### PR DESCRIPTION
Adding proper fields to patch files allowsing for `git am` to properly function.
