### PR TITLE
wolfssl: fix Config.in typo

### DIFF
--- a/package/libs/wolfssl/Config.in
+++ b/package/libs/wolfssl/Config.in
@@ -81,7 +81,7 @@ if PACKAGE_libwolfssl
 			bool "AF_ALG"
 
 		config WOLFSSL_HAS_DEVCRYPTO_CBC
-			bool "/dev/crytpo - AES-CBC-only"
+			bool "/dev/crypto - AES-CBC-only"
 			select WOLFSSL_HAS_DEVCRYPTO
 
 		config WOLFSSL_HAS_DEVCRYPTO_AES


### PR DESCRIPTION
Found a typo in an item description, simple repair, no effect other than cosmetic.
