### PR TITLE
ustream-ssl: fix variants conflicts

### DIFF
--- a/package/libs/ustream-ssl/Makefile
+++ b/package/libs/ustream-ssl/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ustream-ssl
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/ustream-ssl.git
@@ -31,13 +31,14 @@ define Package/libustream-openssl
   TITLE += (openssl)
   DEPENDS += +PACKAGE_libustream-openssl:libopenssl
   VARIANT:=openssl
+  CONFLICTS := libustream-wolfssl libustream-mbedtls
 endef
 
 define Package/libustream-wolfssl
   $(Package/libustream/default)
   TITLE += (wolfssl)
   DEPENDS += +PACKAGE_libustream-wolfssl:libwolfssl
-  CONFLICTS := libustream-openssl
+  CONFLICTS := libustream-openssl libustream-mbedtls
   VARIANT:=wolfssl
 endef
 


### PR DESCRIPTION
The conflicts added in 219e17a35088 are incomplete, fix it.

Fixes: 219e17a35088 ("ustream-ssl: variants conflict with each other")
Signed-off-by: Michael Heimpold <mhei@heimpold.de>
