### PR TITLE
ath79: calibrate TP-LINK TL-WR2543ND with nvmem

### DIFF
--- a/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
+++ b/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
@@ -115,7 +115,7 @@
 				reg = <0x020000 0x7d0000>;
 			};
 
-			partition@7f0000 {
+			art: partition@7f0000 {
 				label = "art";
 				reg = <0x7f0000 0x010000>;
 				read-only;
@@ -139,9 +139,8 @@
 		reg = <0x0000 0 0 0 0>;
 		#gpio-cells = <2>;
 		gpio-controller;
-		qca,no-eeprom;
-		nvmem-cells = <&macaddr_uboot_1fc00>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_uboot_1fc00>, <&cal_art_1000>;
+		nvmem-cell-names = "mac-address", "calibration";
 	};
 };
 
@@ -166,5 +165,15 @@
 
 	macaddr_uboot_1fc00: macaddr@1fc00 {
 		reg = <0x1fc00 0x6>;
+	};
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	cal_art_1000: cal@1000 {
+		reg = <0x1000 0x440>;
 	};
 };

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -121,7 +121,6 @@ case "$FIRMWARE" in
 	netgear,wnr2200-8m|\
 	netgear,wnr2200-16m|\
 	pcs,cap324|\
-	tplink,tl-wr2543-v1|\
 	tplink,tl-wr842n-v1)
 		caldata_extract "art" 0x1000 0x1000
 		;;


### PR DESCRIPTION
Driver for and pci wlan card now pull the calibration data from the nvmem subsystem.

This allows us to move the userspace caldata extraction for the pci-e ath9k supported wifi into the device-tree definition of the device.

The wifi mac address remains correct after these changes, because When both "mac-address" and "calibration" are defined, the effective mac address comes from the cell corresponding to "mac-address" and mac-address-increment.

Test passed on my tplink tl-wr2543nd.

Signed-off-by: Edward Chow <equu@openmail.cc>