### PR TITLE
realtek: fix off-by-one in I²C mux

### DIFF
--- a/target/linux/realtek/files-5.10/drivers/i2c/muxes/i2c-mux-rtl9300.c
+++ b/target/linux/realtek/files-5.10/drivers/i2c/muxes/i2c-mux-rtl9300.c
@@ -220,7 +220,7 @@ static int rtl9300_i2c_mux_probe(struct platform_device *pdev)
 			goto err_children;
 		}
 
-		if (chan >= NUM_MASTERS * NUM_BUSSES) {
+		if (chan > NUM_MASTERS * NUM_BUSSES) {
 			dev_err(dev, "invalid reg %u\n", chan);
 			ret = -EINVAL;
 			goto err_children;


### PR DESCRIPTION
In the I²C mux for the RTL93xx series there was an off-by-one in the probing routine, causing a probing failure in case all 8 buses of the mux are used.

The 8th I²C bus has been tested on an RTL9303-based switch and is confirmed working with this patch.