### PR TITLE
ath79: add support for Senao Engenius EAP1750H

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -27,6 +27,7 @@ arduino,yun|\
 buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\
 engenius,eap1200h|\
+engenius,eap1750h|\
 engenius,eap300-v2|\
 engenius,eap350-v1|\
 engenius,eap600|\

--- a/target/linux/ath79/dts/qca9557_engenius_eap1200h.dts
+++ b/target/linux/ath79/dts/qca9557_engenius_eap1200h.dts
@@ -89,18 +89,31 @@
 &wmac {
 	status = "okay";
 
-	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_art_0>, <&calibration_ath9k>;
+	nvmem-cell-names = "mac-address", "calibration";
 	mac-address-increment = <1>;
+};
+
+&ath10k {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>, <&calibration_ath10k>;
+	nvmem-cell-names = "mac-address", "calibration";
+	mac-address-increment = <2>;
 };
 
 &art {
 	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
 
 	macaddr_art_0: macaddr@0 {
 		reg = <0x0 0x6>;
+	};
+
+	calibration_ath9k: calibration@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	calibration_ath10k: calibration@5000 {
+		reg = <0x5000 0x844>;
 	};
 };

--- a/target/linux/ath79/dts/qca9558_engenius_eap1750h.dts
+++ b/target/linux/ath79/dts/qca9558_engenius_eap1750h.dts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x_senao_loader.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "engenius,eap1750h", "qca,qca9558";
+	model = "EnGenius EAP1750H";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "amber:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wifi2g {
+			label = "blue:wifi2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi5g {
+			label = "green:wifi5g";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wps {
+			label = "blue:wps";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&partitions {
+	art: partition@ff0000 {
+		label = "art";
+		reg = <0xff0000 0x010000>;
+		read-only;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy5: ethernet-phy@5 {
+		reg = <5>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-handle = <&phy5>;
+	phy-mode = "rgmii-id";
+
+	pll-data = <0x82000000 0x80000101 0x80001313>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>, <&calibration_ath9k>;
+	nvmem-cell-names = "mac-address", "calibration";
+	mac-address-increment = <1>;
+};
+
+&ath10k {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>, <&calibration_ath10k>;
+	nvmem-cell-names = "mac-address", "calibration";
+	mac-address-increment = <2>;
+};
+
+&art {
+	compatible = "nvmem-cells";
+
+	macaddr_art_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+
+	calibration_ath9k: calibration@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	calibration_ath10k: calibration@5000 {
+		reg = <0x5000 0x844>;
+	};
+};

--- a/target/linux/ath79/dts/qca955x_senao_loader.dtsi
+++ b/target/linux/ath79/dts/qca955x_senao_loader.dtsi
@@ -28,7 +28,7 @@
 &pcie0 {
 	status = "okay";
 
-	wifi@0,0,0 {
+	ath10k: wifi@0,0,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x0 0 0 0 0>;
 	};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -38,6 +38,7 @@ ath79_setup_interfaces()
 	dlink,dap-3320-a1|\
 	dlink,dir-505|\
 	engenius,eap1200h|\
+	engenius,eap1750h|\
 	engenius,eap600|\
 	engenius,ecb1200|\
 	engenius,ecb1750|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -13,7 +13,6 @@ case "$FIRMWARE" in
 	allnet,all-wap02860ac|\
 	araknis,an-500-ap-i-ac|\
 	araknis,an-700-ap-i-ac|\
-	engenius,eap1200h|\
 	engenius,enstationac-v1|\
 	glinet,gl-x750|\
 	watchguard,ap300)

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -36,6 +36,7 @@ platform_do_upgrade() {
 	araknis,an-500-ap-i-ac|\
 	araknis,an-700-ap-i-ac|\
 	engenius,eap1200h|\
+	engenius,eap1750h|\
 	engenius,eap300-v2|\
 	engenius,eap600|\
 	engenius,ecb600|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1152,6 +1152,18 @@ define Device/engenius_eap1200h
 endef
 TARGET_DEVICES += engenius_eap1200h
 
+define Device/engenius_eap1750h
+  $(Device/senao_loader_okli)
+  SOC := qca9558
+  DEVICE_VENDOR := EnGenius
+  DEVICE_MODEL := EAP1750H
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct
+  IMAGE_SIZE := 11584k
+  LOADER_FLASH_OFFS := 0x220000
+  SENAO_IMGNAME := ar71xx-generic-eap1750h
+endef
+TARGET_DEVICES += engenius_eap1750h
+
 define Device/engenius_eap300-v2
   $(Device/senao_loader_okli)
   SOC := ar9341


### PR DESCRIPTION
this board is equivalent hardware to Engenius EAP1200H

first, change EAP1200H wifi calibration from script to nvmem-cells

rebased right before commit a01d23e755ba46f41e667d558d82d4871d7f5450
because of issue #11319 