### PR TITLE
realtek: switch RTL838X to mips24kc

### DIFF
--- a/target/linux/realtek/rtl838x/target.mk
+++ b/target/linux/realtek/rtl838x/target.mk
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 ARCH:=mips
 SUBTARGET:=rtl838x
-CPU_TYPE:=4kec
+CPU_TYPE:=24kc
 BOARD:=realtek
 BOARDNAME:=Realtek MIPS RTL838X
 
@@ -10,6 +10,3 @@ KERNEL_PATCHVER:=5.10
 define Target/Description
 	Build firmware images for Realtek RTL838x based boards.
 endef
-
-FEATURES := $(filter-out mips16,$(FEATURES))
-


### PR DESCRIPTION
Developing device independent drivers requires switching between target architectures very often. This can lead to toolchain rebuilding if packages have been updated. Unify the CPU type for all targets so we only need one toolchain.

Looking at /proc/cpuinfo on a RTL838X we see "ASEs implemented : mips16" Align that feature with other models too.