### PR TITLE
base-files: add the possibility to set sysctl via the uci

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -49,6 +49,7 @@ define Package/base-files/conffiles
 /etc/config/
 /etc/config/network
 /etc/config/system
+/etc/config/sysctl
 /etc/dropbear/
 /etc/ethers
 /etc/group

--- a/package/base-files/files/etc/init.d/sysctl
+++ b/package/base-files/files/etc/init.d/sysctl
@@ -2,6 +2,7 @@
 # Copyright (C) 2006 OpenWrt.org
 
 START=11
+USE_PROCD=1
 
 apply_defaults() {
 	local mem="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)"
@@ -68,11 +69,19 @@ apply_uci() {
 	config_foreach handle_sysctl sysctl "/tmp/run/sysctl.d/01-uci.conf"
 }
 
-start() {
-	apply_defaults
-	[ -f /tmp/sysctl-default.conf ] || sysctl -a 1>/tmp/sysctl-default.conf 2>/dev/null
+reload_service() {
 	apply_uci
 	for CONF in /etc/sysctl.d/*.conf /etc/sysctl.conf /tmp/run/sysctl.d/*.conf; do
 		[ -f "$CONF" ] && sysctl -e -p "$CONF" >&-
 	done
+}
+
+service_triggers() {
+	procd_add_reload_trigger "sysctl"
+}
+
+start_service() {
+	apply_defaults
+	[ -f /tmp/sysctl-default.conf ] || sysctl -a 1>/tmp/sysctl-default.conf 2>/dev/null
+	reload_service
 }

--- a/package/base-files/files/etc/init.d/sysctl
+++ b/package/base-files/files/etc/init.d/sysctl
@@ -39,7 +39,7 @@ apply_defaults() {
 start() {
 	apply_defaults
 	[ -f /tmp/sysctl-default.conf ] || sysctl -a 1>/tmp/sysctl-default.conf 2>/dev/null
-	for CONF in /etc/sysctl.d/*.conf /etc/sysctl.conf; do
+	for CONF in /etc/sysctl.d/*.conf /etc/sysctl.conf /tmp/run/sysctl.d/*.conf; do
 		[ -f "$CONF" ] && sysctl -e -p "$CONF" >&-
 	done
 }

--- a/package/base-files/files/etc/init.d/sysctl
+++ b/package/base-files/files/etc/init.d/sysctl
@@ -38,6 +38,7 @@ apply_defaults() {
 
 start() {
 	apply_defaults
+	[ -f /tmp/sysctl-default.conf ] || sysctl -a 1>/tmp/sysctl-default.conf 2>/dev/null
 	for CONF in /etc/sysctl.d/*.conf /etc/sysctl.conf; do
 		[ -f "$CONF" ] && sysctl -e -p "$CONF" >&-
 	done

--- a/package/base-files/files/etc/init.d/sysctl
+++ b/package/base-files/files/etc/init.d/sysctl
@@ -36,9 +36,42 @@ apply_defaults() {
 	fi
 }
 
+handle_sysctl() {
+	local cfg="$1"
+	local sysctl="$2"
+
+	local enable section value
+
+	config_get section "$cfg" section
+	[ -z "$section" ] && return
+
+	# check if section should be set and if not reset to default value
+	config_get_bool enable "$cfg" enable '0'
+	if [ "$enable" = '0' ]; then
+		value="$(grep "$section =" /tmp/sysctl-default.conf)"
+		value="${value##*= }"
+	else
+		config_get value "$cfg" value
+	fi
+
+	[ -z "$value" ] && return
+
+	echo "${section}=${value}" >> "$sysctl"
+}
+
+apply_uci() {
+	mkdir -p /tmp/run/sysctl.d
+
+	rm -f /tmp/run/sysctl.d/01-uci.conf
+
+	config_load sysctl
+	config_foreach handle_sysctl sysctl "/tmp/run/sysctl.d/01-uci.conf"
+}
+
 start() {
 	apply_defaults
 	[ -f /tmp/sysctl-default.conf ] || sysctl -a 1>/tmp/sysctl-default.conf 2>/dev/null
+	apply_uci
 	for CONF in /etc/sysctl.d/*.conf /etc/sysctl.conf /tmp/run/sysctl.d/*.conf; do
 		[ -f "$CONF" ] && sysctl -e -p "$CONF" >&-
 	done

--- a/package/base-files/files/etc/init.d/sysctl
+++ b/package/base-files/files/etc/init.d/sysctl
@@ -80,6 +80,10 @@ service_triggers() {
 	procd_add_reload_trigger "sysctl"
 }
 
+stop_service() {
+	[ -f /tmp/sysctl-default.conf ] && sysctl -e -p /tmp/sysctl-default.conf 1>/dev/null 2>&1
+}
+
 start_service() {
 	apply_defaults
 	[ -f /tmp/sysctl-default.conf ] || sysctl -a 1>/tmp/sysctl-default.conf 2>/dev/null


### PR DESCRIPTION
Sometimes it is necessary that certain settings in the sysctl can be easily changed via uci. In my case it is about the `/proc/sys/net/ipv4/fib_multipath_hash_policy`. I would like to make this change via the LuCI. With the current interface via `/etc/sysctl.d/`, this is not so easy possible. If the settings are mapped as uci, it is much easier via LuCI to change this sysctl settings.
The service has been changed to procd so that the uci changes are executed during a `/sbin/reload_config`. So that the default value can be set by the kernel again when the sysctl section is disabled, the sysctl settings are read out once during bootup and stored in the `tmp` directory.

Unamed uci section in `/etc/config/sysctl`:
https://www.kernel.org/doc/html/latest/networking/ip-sysctl.html
```
config sysctl
            option enable '1'
            option section 'net.ipv4.fib_multipath_hash_policy'
            option value '2'
```