### PR TITLE
kernel: match pci devs or drvs against DT nodes

### DIFF
--- a/package/kernel/mac80211/patches/ath10k/991-ath10k-stop-loading-cal-data-from-incompatible-dt-nodes-for-pci-dev.patch
+++ b/package/kernel/mac80211/patches/ath10k/991-ath10k-stop-loading-cal-data-from-incompatible-dt-nodes-for-pci-dev.patch
@@ -1,0 +1,40 @@
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -1896,6 +1896,36 @@ static int ath10k_download_cal_nvmem(struct ath10k *ar, const char *cell_name)
+ 	size_t len;
+ 	int ret;
+ 
++	/* devm_nvmem_cell_get() will get a cell first from the OF
++	 * DT node representing the given device with nvmem-cell-name
++	 * "calibration", and from the global lookup table as a fallback,
++	 * and an ath9k device could be either a pci one or a platform one.
++	 *
++	 * If the OF DT node is not compatible with the real device, the
++	 * calibration data got from the node should not be applied.
++	 *
++	 * dev_is_pci(ar->dev) && ( no OF node || caldata not from node
++	 * || not compatible ) -> do not use caldata .
++	 *
++	 * !dev_is_pci(ar->dev) -> always use caldata .
++	 *
++	 * The judgement for compatibility differs with ath9k for many
++	 * DT using "qcom,ath10k" as compatibility string.
++	 */
++	if (dev_is_pci(ar->dev) &&
++	    (!ar->dev->of_node ||
++	     !of_property_match_string(ar->dev->of_node,
++				       "nvmem-cell-names",
++				       cell_name) ||
++	     !of_device_is_compatible(ar->dev->of_node,
++				      "qcom,ath10k") ||
++	     !of_pci_node_match_device(ar->dev->of_node,
++				       to_pci_dev(sc->dev))))
++		/* follow the "just return 0;" convention as
++		 * noted below.
++		 */
++		return ERR_PTR(-ENOENT);
++
+ 	cell = devm_nvmem_cell_get(ar->dev, cell_name);
+ 	if (IS_ERR(cell)) {
+ 		ret = PTR_ERR(cell);

--- a/package/kernel/mac80211/patches/ath9k/602-ath9k-stop-loading-cal-data-from-incompatible-dt-nodes-for-pci-dev.patch
+++ b/package/kernel/mac80211/patches/ath9k/602-ath9k-stop-loading-cal-data-from-incompatible-dt-nodes-for-pci-dev.patch
@@ -1,0 +1,43 @@
+diff --git a/drivers/net/wireless/ath/ath9k/init.c b/drivers/net/wireless/ath/ath9k/init.c
+--- a/drivers/net/wireless/ath/ath9k/init.c
++++ b/drivers/net/wireless/ath/ath9k/init.c
+@@ -22,6 +22,7 @@
+ #include <linux/module.h>
+ #include <linux/of.h>
+ #include <linux/of_net.h>
++#include <linux/pci.h>
+ #include <linux/nvmem-consumer.h>
+ #include <linux/relay.h>
+ #include <linux/dmi.h>
+@@ -577,6 +578,31 @@ static int ath9k_nvmem_request_eeprom(struct ath_softc *sc)
+ 	size_t len;
+ 	int err;
+ 
++	/* devm_nvmem_cell_get() will get a cell first from the OF
++	 * DT node representing the given device with nvmem-cell-name
++	 * "calibration", and from the global lookup table as a fallback,
++	 * and an ath9k device could be either a pci one or a platform one.
++	 *
++	 * If the OF DT node is not compatible with the real device, the
++	 * calibration data got from the node should not be applied.
++	 *
++	 * dev_is_pci(sc->dev) && ( no OF node || caldata not from node
++	 * || not compatible ) -> do not use caldata .
++	 *
++	 * !dev_is_pci(sc->dev) -> always use caldata .
++	 */
++	if (dev_is_pci(sc->dev) &&
++	    (!sc->dev->of_node ||
++	     !of_property_match_string(sc->dev->of_node,
++				       "nvmem-cell-names",
++				       "calibration") ||
++	     !of_pci_node_match_device(sc->dev->of_node,
++				       to_pci_dev(sc->dev))))
++		/* follow the "just return 0;" convention as
++		 * noted below.
++		 */
++		return 0;
++
+ 	cell = devm_nvmem_cell_get(sc->dev, "calibration");
+ 	if (IS_ERR(cell)) {
+ 		err = PTR_ERR(cell);

--- a/target/linux/generic/pending-5.10/921-pci-Add-functions-to-match-pci-dev-or-driver-against.patch
+++ b/target/linux/generic/pending-5.10/921-pci-Add-functions-to-match-pci-dev-or-driver-against.patch
@@ -1,0 +1,511 @@
+From: Edward Chow <equu@openmail.cc>
+To: lpieralisi@kernel.org
+Cc: linux-pci@vger.kernel.org,
+	Edward Chow <equu@openmail.cc>
+Subject: [PATCH] pci: Add functions to match pci dev or driver against OF DT node
+Date: Sat,  7 Jan 2023 22:53:17 +0800
+Message-Id: <20230107145316.13903-1-equu@openmail.cc>
+X-Mailer: git-send-email 2.39.0
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+
+Currently, there seems no mechanism to check whether a compatibility
+string within an OF DT node for a PCI device (whose spec is at
+https://www.devicetree.org/open-firmware/bindings/pci/ ) matches the
+vendor and device id of either the PCI device installed on the
+corresponding location or the driver suggested by the compatibility
+string, which can cause, for example, that an nvram cell defined
+within an OF DT node for a driver may be erroneously applied to a
+replaced device which should be powered with another driver capable to
+accept an nvram cell with the same name, causing the driver
+malfunctional or even kernel panic.
+
+In order to resolve such issue, this patch introduces a function to
+decode a compatibility string into a struct pci_device_id, which could
+further be matched against PCI devices or drivers, as well as
+functions to match a compatibility string or OF DT node against PCI
+devices or drivers.
+
+PCI drivers can then call these functions to check whether an OF DT
+node matches themselves during driver enumeration, in order to accept
+additional data provided by the node or ignore them when
+incompatible.
+
+Signed-off-by: Edward Chow <equu@openmail.cc>
+---
+ drivers/pci/of.c         | 304 +++++++++++++++++++++++++++++++++++++++
+ drivers/pci/pci-driver.c |   5 -
+ drivers/pci/pci.h        |  56 ++++++++
+ include/linux/of_pci.h   |  25 ++++
+ include/linux/pci.h      |   6 +
+ 5 files changed, 391 insertions(+), 5 deletions(-)
+
+--- a/drivers/pci/of.c
++++ b/drivers/pci/of.c
+@@ -13,6 +13,8 @@
+ #include <linux/of_irq.h>
+ #include <linux/of_address.h>
+ #include <linux/of_pci.h>
++#include <linux/string.h>
++#include <linux/kstrtox.h>
+ #include "pci.h"
+ 
+ #ifdef CONFIG_PCI
+@@ -252,6 +254,308 @@ void of_pci_check_probe_only(void)
+ EXPORT_SYMBOL_GPL(of_pci_check_probe_only);
+ 
+ /**
++ * of_pci_compat_to_device_id() - Decode an OF compatibility string into a
++ * pci_device_id structure.
++ * @compat: the compatibility string to decode, could be NULL
++ * @id: pointer to a struct pci_device_id, to store the result
++ * @rev: pointer to output revision info, PCI_ANY_ID if no revision in @compat
++ * @req_pcie: pointer to output whether @compat mandates PCI-E compatibility
++ *
++ * returns 0 when success, -EINVAL when failed.
++ */
++int of_pci_compat_to_device_id(const char *compat, struct pci_device_id *id,
++			       __u32 *rev, __u32 *req_pcie)
++{
++	union {
++		__u8 u8;
++		__u16 u16;
++		__u32 u32;
++	} res = {0};
++	*req_pcie = 0;
++	*rev = PCI_ANY_ID;
++	if (!compat || strncasecmp(compat, "pci", 3) != 0)
++		goto failed;
++	compat += 3;
++
++	if (strncasecmp(compat, "class,", 6) == 0) {
++		/* pciclass,CCSSPP */
++		compat += 6;
++		if ((strlen(compat) < 4)
++		   || kstrtouint(compat, 16, &id->class))
++			goto failed;
++		if (id->class < 0x10000) {
++			id->class <<= 8;
++			id->class_mask = 0xFFFF00;
++		} else {
++			id->class_mask = PCI_ANY_ID;
++		}
++		id->vendor = PCI_ANY_ID;
++		id->device = PCI_ANY_ID;
++		id->subvendor = PCI_ANY_ID;
++		id->subdevice = PCI_ANY_ID;
++		goto done;
++	}
++
++	if (strncasecmp(compat, "ex", 2) == 0) {
++		/* pciex...  */
++		*req_pcie = 1;
++		compat += 2;
++	}
++	if (kstrtou16(compat, 16, &res.u16))
++		goto failed;
++	id->vendor = res.u16;
++	compat = strchr(compat, ',');
++	if (!compat)
++		goto failed;
++	compat++;
++	if (kstrtou16(compat, 16, &res.u16))
++		goto failed;
++	id->device = res.u16;
++	compat = strchr(compat, '.');
++	if (compat == NULL) {
++		/* pciVVVV,DDDD */
++		id->subvendor = PCI_ANY_ID;
++		id->subdevice = PCI_ANY_ID;
++		goto done;
++	}
++
++	compat++;
++	if (strlen(compat) == 2) {
++		/* pciVVVV,DDDD.RR */
++		if (kstrtou8(compat, 16, &res.u8))
++			goto failed;
++		*rev = res.u8;
++		id->subvendor = PCI_ANY_ID;
++		id->subdevice = PCI_ANY_ID;
++		goto done;
++	}
++
++	if (kstrtou16(compat, 16, &res.u16))
++		goto failed;
++	id->subvendor = res.u16;
++	compat = strchr(compat, '.');
++	if (!compat)
++		goto failed;
++	compat++;
++	if (kstrtou16(compat, 16, &res.u16))
++		goto failed;
++	id->subdevice = res.u16;
++	compat = strchr(compat, '.');
++	if (compat == NULL)
++		/* pciVVVV,DDDD.SSSS.ssss */
++		goto done;
++
++	compat++;
++	if (strlen(compat) == 2) {
++		/* pciVVVV,DDDD.SSSS.ssss.RR */
++		if (kstrtou8(compat, 16, &res.u8))
++			goto failed;
++		*rev = res.u8;
++		goto done;
++	}
++
++ failed:
++	return -EINVAL;
++ done:
++	return 0;
++}
++
++/**
++ * of_pci_compat_match_device() - Tell whether a PCI device structure matches
++ * a given OF compatibility string
++ * @compat: single OF compatibility string to match, could be NULL
++ * @dev the PCI device structure to match against
++ *
++ * Returns whether they match.
++ */
++bool of_pci_compat_match_device(const char *compat, const struct pci_dev *dev)
++{
++	__u32 rev = PCI_ANY_ID;
++	__u32 req_pcie = 0;
++	struct pci_device_id id = {0};
++
++	if (of_pci_compat_to_device_id(compat, &id, &rev, &req_pcie))
++		return false;
++	return pci_match_one_device(&id, dev) &&
++		(rev == PCI_ANY_ID || rev == dev->revision) &&
++		req_pcie ? dev->pcie_cap : true;
++}
++
++/**
++ * of_pci_node_match_device() - Tell whether an OF device tree node
++ * matches the given pci device
++ * @node: single OF device tree node to match, could be NULL
++ * @dev: the PCI device structure to match against, could be NULL
++ *
++ * Returns whether they match.
++ */
++bool of_pci_node_match_device(const struct device_node *node,
++			      const struct pci_dev *dev)
++{
++	struct property *prop;
++	const char *cp;
++
++	if (!node || !dev)
++		return false;
++	prop = of_find_property(node, "compatible", NULL);
++	for (cp = of_prop_next_string(prop, NULL); cp;
++	     cp = of_prop_next_string(prop, cp)) {
++		if (of_pci_compat_match_device(cp, dev))
++			return true;
++	}
++	return false;
++}
++EXPORT_SYMBOL_GPL(of_pci_node_match_device);
++
++/**
++ * of_pci_compat_match_one_id() - Tell whether a PCI device id structure matches
++ * a given OF compatibility string, note that there is no revision nor PCIe
++ * capability info in PCI device id structures
++ *
++ * @compat: single OF compatibility string to match, could be NULL
++ * @id the PCI device id structure to match against, could be NULL
++ *
++ * Returns the matching pci_device_id structure pointed by id
++ * or %NULL if there is no match.
++ */
++const struct pci_device_id *
++of_pci_compat_match_one_id(const char *compat, const struct pci_device_id *id)
++{
++	__u32 rev = PCI_ANY_ID;
++	__u32 req_pcie = 0;
++	struct pci_device_id pr = {0};
++
++	if (!compat || !id ||
++	    of_pci_compat_to_device_id(compat, &pr, &rev, &req_pcie))
++		return NULL;
++	return pci_match_one_id(id, &pr);
++}
++
++/**
++ * of_pci_compat_match_id_table() - Tell whether a given OF compatibility string
++ * matches a given pci_id table
++ *
++ * @compat: single OF compatibility string to match, could be NULL
++ * @table the PCI device id table to match against, could be NULL
++ *
++ * Returns the matching pci_device_id structure or %NULL if there is no match.
++ */
++const struct pci_device_id *
++of_pci_compat_match_id_table(const char *compat, const struct pci_device_id *table)
++{
++	if (compat && table) {
++		while (table->vendor || table->subvendor || table->class_mask) {
++			if (of_pci_compat_match_one_id(compat, table))
++				return table;
++			table++;
++		}
++	}
++	return NULL;
++}
++
++/**
++ * of_pci_node_match_id_table() - Tell whether an OF device tree node
++ * matches the given pci_id table
++ * @node: single OF device tree node to match, could be NULL
++ * @table: the PCI device id table to match against, could be NULL
++ *
++ * Returns the matching pci_device_id structure
++ * or %NULL if there is no match.
++ */
++const struct pci_device_id *
++of_pci_node_match_id_table(const struct device_node *node,
++			   const struct pci_device_id *table)
++{
++	struct property *prop;
++	const char *cp;
++	const struct pci_device_id *id;
++
++	if (!node || !table)
++		return NULL;
++	prop = of_find_property(node, "compatible", NULL);
++	for (cp = of_prop_next_string(prop, NULL); cp;
++	     cp = of_prop_next_string(prop, cp)) {
++		id = of_pci_compat_match_id_table(cp, table);
++		if (id)
++			return id;
++	}
++	return NULL;
++}
++EXPORT_SYMBOL_GPL(of_pci_node_match_id_table);
++
++/**
++ * of_pci_compat_match_driver - See if a given OF compatibility string matches
++ * a driver's list of IDs
++ * @compat: single OF compatibility string to match, could be NULL
++ * @drv: the PCI driver to match against, could be NULL
++ *
++ * Used by a driver to check whether an OF compatibility string matches one of
++ * (dynamically) supported devices, which may have been augmented
++ * via the sysfs "new_id" file.  Returns the matching pci_device_id
++ * structure or %NULL if there is no match.
++ */
++const struct pci_device_id *
++of_pci_compat_match_driver(const char *compat, struct pci_driver *drv)
++{
++	struct pci_dynid *dynid;
++	const struct pci_device_id *found_id = NULL, *ids;
++
++	if (!compat || !drv)
++		return NULL;
++	/* Look at the dynamic ids first, before the static ones */
++	spin_lock(&drv->dynids.lock);
++	list_for_each_entry(dynid, &drv->dynids.list, node) {
++		if (of_pci_compat_match_one_id(compat, &dynid->id)) {
++			found_id = &dynid->id;
++			break;
++		}
++	}
++	spin_unlock(&drv->dynids.lock);
++
++	if (found_id)
++		return found_id;
++
++	for (ids = drv->id_table; (found_id = of_pci_compat_match_one_id(compat, ids));
++	     ids = found_id + 1) {
++		/* exclude ids in id_table with override_only */
++		if (!found_id->override_only)
++			return found_id;
++	}
++
++	return NULL;
++}
++
++/**
++ * of_pci_node_match_driver() - Tell whether an OF device tree node
++ * matches the given pci driver
++ * @node: single OF device tree node to match, could be NULL
++ * @drv: the PCI driver structure to match against, could be NULL
++ *
++ * Returns the matching pci_device_id structure
++ * or %NULL if there is no match.
++ */
++const struct pci_device_id *
++of_pci_node_match_driver(const struct device_node *node,
++			 struct pci_driver *drv)
++{
++	struct property *prop;
++	const char *cp;
++	const struct pci_device_id *id;
++
++	if (!node || !drv)
++		return NULL;
++	prop = of_find_property(node, "compatible", NULL);
++	for (cp = of_prop_next_string(prop, NULL); cp;
++	     cp = of_prop_next_string(prop, cp)) {
++		id = of_pci_compat_match_driver(cp, drv);
++		if (id)
++			return id;
++	}
++	return NULL;
++}
++EXPORT_SYMBOL_GPL(of_pci_node_match_driver);
++
++/**
+  * devm_of_pci_get_host_bridge_resources() - Resource-managed parsing of PCI
+  *                                           host bridge resources from DT
+  * @dev: host bridge device
+--- a/drivers/pci/pci-driver.c
++++ b/drivers/pci/pci-driver.c
+@@ -23,11 +23,6 @@
+ #include "pci.h"
+ #include "pcie/portdrv.h"
+ 
+-struct pci_dynid {
+-	struct list_head node;
+-	struct pci_device_id id;
+-};
+-
+ /**
+  * pci_add_dynid - add a new PCI device ID to this driver and re-probe devices
+  * @drv: target pci driver
+--- a/drivers/pci/pci.h
++++ b/drivers/pci/pci.h
+@@ -241,6 +241,29 @@ pci_match_one_device(const struct pci_de
+ 	return NULL;
+ }
+ 
++/**
++ * pci_match_one_id - Tell if a PCI device id structure matches another
++ *			  PCI device id structure
++ * @id: single PCI device id structure to match, usually in a list or array
++ * @pr: the probing PCI device id structure to match against, usually converted from
++ *      other format
++ *
++ * Returns the matching pci_device_id structure pointed by id
++ * or %NULL if there is no match.
++ */
++static inline const struct pci_device_id *
++pci_match_one_id(const struct pci_device_id *id, const struct pci_device_id *pr)
++{
++	if ((id->vendor == pr->vendor) &&
++	    (id->device == pr->device) &&
++	    (id->subvendor == pr->subvendor) &&
++	    (id->subdevice == pr->subdevice) &&
++	    (id->class == pr->class) &&
++	    (id->class_mask == pr->class_mask))
++		return id;
++	return NULL;
++}
++
+ /* PCI slot sysfs helper code */
+ #define to_pci_slot(s) container_of(s, struct pci_slot, kobj)
+ 
+@@ -672,6 +695,15 @@ void pci_release_bus_of_node(struct pci_
+ 
+ int devm_of_pci_bridge_init(struct device *dev, struct pci_host_bridge *bridge);
+ 
++int of_pci_compat_to_device_id(const char *compat, struct pci_device_id *id,
++			       __u32 *rev, __u32 *req_pcie);
++bool of_pci_compat_match_device(const char *compat, const struct pci_dev *dev);
++const struct pci_device_id *
++of_pci_compat_match_one_id(const char *compat, const struct pci_device_id *id);
++const struct pci_device_id *
++of_pci_compat_match_id_table(const char *compat, const struct pci_device_id *table);
++const struct pci_device_id *
++of_pci_compat_match_driver(const char *compat, struct pci_driver *drv);
+ #else
+ static inline int
+ of_pci_parse_bus_range(struct device_node *node, struct resource *res)
+@@ -701,6 +733,30 @@ static inline int devm_of_pci_bridge_ini
+ 	return 0;
+ }
+ 
++static inline int of_pci_compat_to_device_id(const char *compat, struct pci_device_id *id,
++			       __u32 *rev, __u32 *req_pcie)
++{
++	return -EINVAL;
++}
++static inline bool of_pci_compat_match_device(const char *compat, const struct pci_dev *dev)
++{
++	return false;
++}
++static inline const struct pci_device_id *
++of_pci_compat_match_one_id(const char *compat, const struct pci_device_id *id)
++{
++	return NULL;
++}
++static inline const struct pci_device_id *
++of_pci_compat_match_id_table(const char *compat, const struct pci_device_id *table)
++{
++	return NULL;
++}
++static inline const struct pci_device_id *
++of_pci_compat_match_driver(const char *compat, struct pci_driver *drv)
++{
++	return NULL;
++}
+ #endif /* CONFIG_OF */
+ 
+ #ifdef CONFIG_PCIEAER
+--- a/include/linux/of_pci.h
++++ b/include/linux/of_pci.h
+@@ -13,6 +13,14 @@ struct device_node *of_pci_find_child_de
+ 					     unsigned int devfn);
+ int of_pci_get_devfn(struct device_node *np);
+ void of_pci_check_probe_only(void);
++bool of_pci_node_match_device(const struct device_node *node,
++			      const struct pci_dev *dev);
++const struct pci_device_id *
++of_pci_node_match_id_table(const struct device_node *node,
++			   const struct pci_device_id *table);
++const struct pci_device_id *
++of_pci_node_match_driver(const struct device_node *node,
++			 struct pci_driver *drv);
+ #else
+ static inline struct device_node *of_pci_find_child_device(struct device_node *parent,
+ 					     unsigned int devfn)
+@@ -26,6 +34,23 @@ static inline int of_pci_get_devfn(struc
+ }
+ 
+ static inline void of_pci_check_probe_only(void) { }
++static inline bool of_pci_node_match_device(const struct device_node *node,
++			      const struct pci_dev *dev)
++{
++	return false;
++}
++static inline const struct pci_device_id *
++of_pci_node_match_id_table(const struct device_node *node,
++			   const struct pci_device_id *table)
++{
++	return NULL;
++}
++static inline const struct pci_device_id *
++of_pci_node_match_driver(const struct device_node *node,
++			 struct pci_driver *drv)
++{
++	return NULL;
++}
+ #endif
+ 
+ #if IS_ENABLED(CONFIG_OF_IRQ)
+--- a/include/linux/pci.h
++++ b/include/linux/pci.h
+@@ -1466,6 +1466,12 @@ void pci_unregister_driver(struct pci_dr
+ 	builtin_driver(__pci_driver, pci_register_driver)
+ 
+ struct pci_driver *pci_dev_driver(const struct pci_dev *dev);
++
++struct pci_dynid {
++	struct list_head node;
++	struct pci_device_id id;
++};
++
+ int pci_add_dynid(struct pci_driver *drv,
+ 		  unsigned int vendor, unsigned int device,
+ 		  unsigned int subvendor, unsigned int subdevice,

--- a/target/linux/generic/pending-5.15/921-pci-Add-functions-to-match-pci-dev-or-driver-against.patch
+++ b/target/linux/generic/pending-5.15/921-pci-Add-functions-to-match-pci-dev-or-driver-against.patch
@@ -1,0 +1,511 @@
+From: Edward Chow <equu@openmail.cc>
+To: lpieralisi@kernel.org
+Cc: linux-pci@vger.kernel.org,
+	Edward Chow <equu@openmail.cc>
+Subject: [PATCH] pci: Add functions to match pci dev or driver against OF DT node
+Date: Sat,  7 Jan 2023 22:53:17 +0800
+Message-Id: <20230107145316.13903-1-equu@openmail.cc>
+X-Mailer: git-send-email 2.39.0
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+
+Currently, there seems no mechanism to check whether a compatibility
+string within an OF DT node for a PCI device (whose spec is at
+https://www.devicetree.org/open-firmware/bindings/pci/ ) matches the
+vendor and device id of either the PCI device installed on the
+corresponding location or the driver suggested by the compatibility
+string, which can cause, for example, that an nvram cell defined
+within an OF DT node for a driver may be erroneously applied to a
+replaced device which should be powered with another driver capable to
+accept an nvram cell with the same name, causing the driver
+malfunctional or even kernel panic.
+
+In order to resolve such issue, this patch introduces a function to
+decode a compatibility string into a struct pci_device_id, which could
+further be matched against PCI devices or drivers, as well as
+functions to match a compatibility string or OF DT node against PCI
+devices or drivers.
+
+PCI drivers can then call these functions to check whether an OF DT
+node matches themselves during driver enumeration, in order to accept
+additional data provided by the node or ignore them when
+incompatible.
+
+Signed-off-by: Edward Chow <equu@openmail.cc>
+---
+ drivers/pci/of.c         | 304 +++++++++++++++++++++++++++++++++++++++
+ drivers/pci/pci-driver.c |   5 -
+ drivers/pci/pci.h        |  56 ++++++++
+ include/linux/of_pci.h   |  25 ++++
+ include/linux/pci.h      |   6 +
+ 5 files changed, 391 insertions(+), 5 deletions(-)
+
+--- a/drivers/pci/of.c
++++ b/drivers/pci/of.c
+@@ -13,6 +13,8 @@
+ #include <linux/of_irq.h>
+ #include <linux/of_address.h>
+ #include <linux/of_pci.h>
++#include <linux/string.h>
++#include <linux/kstrtox.h>
+ #include "pci.h"
+ 
+ #ifdef CONFIG_PCI
+@@ -252,6 +254,308 @@ void of_pci_check_probe_only(void)
+ EXPORT_SYMBOL_GPL(of_pci_check_probe_only);
+ 
+ /**
++ * of_pci_compat_to_device_id() - Decode an OF compatibility string into a
++ * pci_device_id structure.
++ * @compat: the compatibility string to decode, could be NULL
++ * @id: pointer to a struct pci_device_id, to store the result
++ * @rev: pointer to output revision info, PCI_ANY_ID if no revision in @compat
++ * @req_pcie: pointer to output whether @compat mandates PCI-E compatibility
++ *
++ * returns 0 when success, -EINVAL when failed.
++ */
++int of_pci_compat_to_device_id(const char *compat, struct pci_device_id *id,
++			       __u32 *rev, __u32 *req_pcie)
++{
++	union {
++		__u8 u8;
++		__u16 u16;
++		__u32 u32;
++	} res = {0};
++	*req_pcie = 0;
++	*rev = PCI_ANY_ID;
++	if (!compat || strncasecmp(compat, "pci", 3) != 0)
++		goto failed;
++	compat += 3;
++
++	if (strncasecmp(compat, "class,", 6) == 0) {
++		/* pciclass,CCSSPP */
++		compat += 6;
++		if ((strlen(compat) < 4)
++		   || kstrtouint(compat, 16, &id->class))
++			goto failed;
++		if (id->class < 0x10000) {
++			id->class <<= 8;
++			id->class_mask = 0xFFFF00;
++		} else {
++			id->class_mask = PCI_ANY_ID;
++		}
++		id->vendor = PCI_ANY_ID;
++		id->device = PCI_ANY_ID;
++		id->subvendor = PCI_ANY_ID;
++		id->subdevice = PCI_ANY_ID;
++		goto done;
++	}
++
++	if (strncasecmp(compat, "ex", 2) == 0) {
++		/* pciex...  */
++		*req_pcie = 1;
++		compat += 2;
++	}
++	if (kstrtou16(compat, 16, &res.u16))
++		goto failed;
++	id->vendor = res.u16;
++	compat = strchr(compat, ',');
++	if (!compat)
++		goto failed;
++	compat++;
++	if (kstrtou16(compat, 16, &res.u16))
++		goto failed;
++	id->device = res.u16;
++	compat = strchr(compat, '.');
++	if (compat == NULL) {
++		/* pciVVVV,DDDD */
++		id->subvendor = PCI_ANY_ID;
++		id->subdevice = PCI_ANY_ID;
++		goto done;
++	}
++
++	compat++;
++	if (strlen(compat) == 2) {
++		/* pciVVVV,DDDD.RR */
++		if (kstrtou8(compat, 16, &res.u8))
++			goto failed;
++		*rev = res.u8;
++		id->subvendor = PCI_ANY_ID;
++		id->subdevice = PCI_ANY_ID;
++		goto done;
++	}
++
++	if (kstrtou16(compat, 16, &res.u16))
++		goto failed;
++	id->subvendor = res.u16;
++	compat = strchr(compat, '.');
++	if (!compat)
++		goto failed;
++	compat++;
++	if (kstrtou16(compat, 16, &res.u16))
++		goto failed;
++	id->subdevice = res.u16;
++	compat = strchr(compat, '.');
++	if (compat == NULL)
++		/* pciVVVV,DDDD.SSSS.ssss */
++		goto done;
++
++	compat++;
++	if (strlen(compat) == 2) {
++		/* pciVVVV,DDDD.SSSS.ssss.RR */
++		if (kstrtou8(compat, 16, &res.u8))
++			goto failed;
++		*rev = res.u8;
++		goto done;
++	}
++
++ failed:
++	return -EINVAL;
++ done:
++	return 0;
++}
++
++/**
++ * of_pci_compat_match_device() - Tell whether a PCI device structure matches
++ * a given OF compatibility string
++ * @compat: single OF compatibility string to match, could be NULL
++ * @dev the PCI device structure to match against
++ *
++ * Returns whether they match.
++ */
++bool of_pci_compat_match_device(const char *compat, const struct pci_dev *dev)
++{
++	__u32 rev = PCI_ANY_ID;
++	__u32 req_pcie = 0;
++	struct pci_device_id id = {0};
++
++	if (of_pci_compat_to_device_id(compat, &id, &rev, &req_pcie))
++		return false;
++	return pci_match_one_device(&id, dev) &&
++		(rev == PCI_ANY_ID || rev == dev->revision) &&
++		req_pcie ? dev->pcie_cap : true;
++}
++
++/**
++ * of_pci_node_match_device() - Tell whether an OF device tree node
++ * matches the given pci device
++ * @node: single OF device tree node to match, could be NULL
++ * @dev: the PCI device structure to match against, could be NULL
++ *
++ * Returns whether they match.
++ */
++bool of_pci_node_match_device(const struct device_node *node,
++			      const struct pci_dev *dev)
++{
++	struct property *prop;
++	const char *cp;
++
++	if (!node || !dev)
++		return false;
++	prop = of_find_property(node, "compatible", NULL);
++	for (cp = of_prop_next_string(prop, NULL); cp;
++	     cp = of_prop_next_string(prop, cp)) {
++		if (of_pci_compat_match_device(cp, dev))
++			return true;
++	}
++	return false;
++}
++EXPORT_SYMBOL_GPL(of_pci_node_match_device);
++
++/**
++ * of_pci_compat_match_one_id() - Tell whether a PCI device id structure matches
++ * a given OF compatibility string, note that there is no revision nor PCIe
++ * capability info in PCI device id structures
++ *
++ * @compat: single OF compatibility string to match, could be NULL
++ * @id the PCI device id structure to match against, could be NULL
++ *
++ * Returns the matching pci_device_id structure pointed by id
++ * or %NULL if there is no match.
++ */
++const struct pci_device_id *
++of_pci_compat_match_one_id(const char *compat, const struct pci_device_id *id)
++{
++	__u32 rev = PCI_ANY_ID;
++	__u32 req_pcie = 0;
++	struct pci_device_id pr = {0};
++
++	if (!compat || !id ||
++	    of_pci_compat_to_device_id(compat, &pr, &rev, &req_pcie))
++		return NULL;
++	return pci_match_one_id(id, &pr);
++}
++
++/**
++ * of_pci_compat_match_id_table() - Tell whether a given OF compatibility string
++ * matches a given pci_id table
++ *
++ * @compat: single OF compatibility string to match, could be NULL
++ * @table the PCI device id table to match against, could be NULL
++ *
++ * Returns the matching pci_device_id structure or %NULL if there is no match.
++ */
++const struct pci_device_id *
++of_pci_compat_match_id_table(const char *compat, const struct pci_device_id *table)
++{
++	if (compat && table) {
++		while (table->vendor || table->subvendor || table->class_mask) {
++			if (of_pci_compat_match_one_id(compat, table))
++				return table;
++			table++;
++		}
++	}
++	return NULL;
++}
++
++/**
++ * of_pci_node_match_id_table() - Tell whether an OF device tree node
++ * matches the given pci_id table
++ * @node: single OF device tree node to match, could be NULL
++ * @table: the PCI device id table to match against, could be NULL
++ *
++ * Returns the matching pci_device_id structure
++ * or %NULL if there is no match.
++ */
++const struct pci_device_id *
++of_pci_node_match_id_table(const struct device_node *node,
++			   const struct pci_device_id *table)
++{
++	struct property *prop;
++	const char *cp;
++	const struct pci_device_id *id;
++
++	if (!node || !table)
++		return NULL;
++	prop = of_find_property(node, "compatible", NULL);
++	for (cp = of_prop_next_string(prop, NULL); cp;
++	     cp = of_prop_next_string(prop, cp)) {
++		id = of_pci_compat_match_id_table(cp, table);
++		if (id)
++			return id;
++	}
++	return NULL;
++}
++EXPORT_SYMBOL_GPL(of_pci_node_match_id_table);
++
++/**
++ * of_pci_compat_match_driver - See if a given OF compatibility string matches
++ * a driver's list of IDs
++ * @compat: single OF compatibility string to match, could be NULL
++ * @drv: the PCI driver to match against, could be NULL
++ *
++ * Used by a driver to check whether an OF compatibility string matches one of
++ * (dynamically) supported devices, which may have been augmented
++ * via the sysfs "new_id" file.  Returns the matching pci_device_id
++ * structure or %NULL if there is no match.
++ */
++const struct pci_device_id *
++of_pci_compat_match_driver(const char *compat, struct pci_driver *drv)
++{
++	struct pci_dynid *dynid;
++	const struct pci_device_id *found_id = NULL, *ids;
++
++	if (!compat || !drv)
++		return NULL;
++	/* Look at the dynamic ids first, before the static ones */
++	spin_lock(&drv->dynids.lock);
++	list_for_each_entry(dynid, &drv->dynids.list, node) {
++		if (of_pci_compat_match_one_id(compat, &dynid->id)) {
++			found_id = &dynid->id;
++			break;
++		}
++	}
++	spin_unlock(&drv->dynids.lock);
++
++	if (found_id)
++		return found_id;
++
++	for (ids = drv->id_table; (found_id = of_pci_compat_match_one_id(compat, ids));
++	     ids = found_id + 1) {
++		/* exclude ids in id_table with override_only */
++		if (!found_id->override_only)
++			return found_id;
++	}
++
++	return NULL;
++}
++
++/**
++ * of_pci_node_match_driver() - Tell whether an OF device tree node
++ * matches the given pci driver
++ * @node: single OF device tree node to match, could be NULL
++ * @drv: the PCI driver structure to match against, could be NULL
++ *
++ * Returns the matching pci_device_id structure
++ * or %NULL if there is no match.
++ */
++const struct pci_device_id *
++of_pci_node_match_driver(const struct device_node *node,
++			 struct pci_driver *drv)
++{
++	struct property *prop;
++	const char *cp;
++	const struct pci_device_id *id;
++
++	if (!node || !drv)
++		return NULL;
++	prop = of_find_property(node, "compatible", NULL);
++	for (cp = of_prop_next_string(prop, NULL); cp;
++	     cp = of_prop_next_string(prop, cp)) {
++		id = of_pci_compat_match_driver(cp, drv);
++		if (id)
++			return id;
++	}
++	return NULL;
++}
++EXPORT_SYMBOL_GPL(of_pci_node_match_driver);
++
++/**
+  * devm_of_pci_get_host_bridge_resources() - Resource-managed parsing of PCI
+  *                                           host bridge resources from DT
+  * @dev: host bridge device
+--- a/drivers/pci/pci-driver.c
++++ b/drivers/pci/pci-driver.c
+@@ -23,11 +23,6 @@
+ #include "pci.h"
+ #include "pcie/portdrv.h"
+ 
+-struct pci_dynid {
+-	struct list_head node;
+-	struct pci_device_id id;
+-};
+-
+ /**
+  * pci_add_dynid - add a new PCI device ID to this driver and re-probe devices
+  * @drv: target pci driver
+--- a/drivers/pci/pci.h
++++ b/drivers/pci/pci.h
+@@ -241,6 +241,29 @@ pci_match_one_device(const struct pci_de
+ 	return NULL;
+ }
+ 
++/**
++ * pci_match_one_id - Tell if a PCI device id structure matches another
++ *			  PCI device id structure
++ * @id: single PCI device id structure to match, usually in a list or array
++ * @pr: the probing PCI device id structure to match against, usually converted from
++ *      other format
++ *
++ * Returns the matching pci_device_id structure pointed by id
++ * or %NULL if there is no match.
++ */
++static inline const struct pci_device_id *
++pci_match_one_id(const struct pci_device_id *id, const struct pci_device_id *pr)
++{
++	if ((id->vendor == pr->vendor) &&
++	    (id->device == pr->device) &&
++	    (id->subvendor == pr->subvendor) &&
++	    (id->subdevice == pr->subdevice) &&
++	    (id->class == pr->class) &&
++	    (id->class_mask == pr->class_mask))
++		return id;
++	return NULL;
++}
++
+ /* PCI slot sysfs helper code */
+ #define to_pci_slot(s) container_of(s, struct pci_slot, kobj)
+ 
+@@ -672,6 +695,15 @@ void pci_release_bus_of_node(struct pci_
+ 
+ int devm_of_pci_bridge_init(struct device *dev, struct pci_host_bridge *bridge);
+ 
++int of_pci_compat_to_device_id(const char *compat, struct pci_device_id *id,
++			       __u32 *rev, __u32 *req_pcie);
++bool of_pci_compat_match_device(const char *compat, const struct pci_dev *dev);
++const struct pci_device_id *
++of_pci_compat_match_one_id(const char *compat, const struct pci_device_id *id);
++const struct pci_device_id *
++of_pci_compat_match_id_table(const char *compat, const struct pci_device_id *table);
++const struct pci_device_id *
++of_pci_compat_match_driver(const char *compat, struct pci_driver *drv);
+ #else
+ static inline int
+ of_pci_parse_bus_range(struct device_node *node, struct resource *res)
+@@ -701,6 +733,30 @@ static inline int devm_of_pci_bridge_ini
+ 	return 0;
+ }
+ 
++static inline int of_pci_compat_to_device_id(const char *compat, struct pci_device_id *id,
++			       __u32 *rev, __u32 *req_pcie)
++{
++	return -EINVAL;
++}
++static inline bool of_pci_compat_match_device(const char *compat, const struct pci_dev *dev)
++{
++	return false;
++}
++static inline const struct pci_device_id *
++of_pci_compat_match_one_id(const char *compat, const struct pci_device_id *id)
++{
++	return NULL;
++}
++static inline const struct pci_device_id *
++of_pci_compat_match_id_table(const char *compat, const struct pci_device_id *table)
++{
++	return NULL;
++}
++static inline const struct pci_device_id *
++of_pci_compat_match_driver(const char *compat, struct pci_driver *drv)
++{
++	return NULL;
++}
+ #endif /* CONFIG_OF */
+ 
+ #ifdef CONFIG_PCIEAER
+--- a/include/linux/of_pci.h
++++ b/include/linux/of_pci.h
+@@ -13,6 +13,14 @@ struct device_node *of_pci_find_child_de
+ 					     unsigned int devfn);
+ int of_pci_get_devfn(struct device_node *np);
+ void of_pci_check_probe_only(void);
++bool of_pci_node_match_device(const struct device_node *node,
++			      const struct pci_dev *dev);
++const struct pci_device_id *
++of_pci_node_match_id_table(const struct device_node *node,
++			   const struct pci_device_id *table);
++const struct pci_device_id *
++of_pci_node_match_driver(const struct device_node *node,
++			 struct pci_driver *drv);
+ #else
+ static inline struct device_node *of_pci_find_child_device(struct device_node *parent,
+ 					     unsigned int devfn)
+@@ -26,6 +34,23 @@ static inline int of_pci_get_devfn(struc
+ }
+ 
+ static inline void of_pci_check_probe_only(void) { }
++static inline bool of_pci_node_match_device(const struct device_node *node,
++			      const struct pci_dev *dev)
++{
++	return false;
++}
++static inline const struct pci_device_id *
++of_pci_node_match_id_table(const struct device_node *node,
++			   const struct pci_device_id *table)
++{
++	return NULL;
++}
++static inline const struct pci_device_id *
++of_pci_node_match_driver(const struct device_node *node,
++			 struct pci_driver *drv)
++{
++	return NULL;
++}
+ #endif
+ 
+ #if IS_ENABLED(CONFIG_OF_IRQ)
+--- a/include/linux/pci.h
++++ b/include/linux/pci.h
+@@ -1466,6 +1466,12 @@ void pci_unregister_driver(struct pci_dr
+ 	builtin_driver(__pci_driver, pci_register_driver)
+ 
+ struct pci_driver *pci_dev_driver(const struct pci_dev *dev);
++
++struct pci_dynid {
++	struct list_head node;
++	struct pci_device_id id;
++};
++
+ int pci_add_dynid(struct pci_driver *drv,
+ 		  unsigned int vendor, unsigned int device,
+ 		  unsigned int subvendor, unsigned int subdevice,


### PR DESCRIPTION
A TP-LINK archer C7 v2 device running OpenWRT v22.03+ will drop into reboot loop after its internal but socketed ath10k mini PCIe wlan card gets replaced with an ath9k one (namely, an ar9580 working well on my laptop). Further observation in OpenWRT's failsafe mode shows that the router reboots right after the ath9k driver is manually loaded, but after a firmware image built with the only change being the node corresponding to the wlan card (the node `wifi@0,0`) removed from the [device tree](https://github.com/openwrt/openwrt/blob/master/target/linux/ath79/dts/qca9558_tplink_archer-c7-v2.dts) is flashed, everything works just fine.

The node `wifi@0,0` should only compatible with "qcom,ath10k", but the reboot seems to be caused by the "calibration" data (targeting ath10k devices) declared in this node being loaded by the ath9k driver for the ath9k card installed on its place, regardless the compatibility string.

In order to resolve such issue, a PCI driver should check whether its
positionally corresponding device tree nodes is compatible before loading
any data from the node.

This commit contains 3 kernel patches:
931 adds routines to match pci devices or drivers against device tree nodes,
602 and 991 add checks to ath9k and ath10k respectively.

Signed-off-by: Edward Chow [equu@openmail.cc](mailto:equu@openmail.cc)
