### PR TITLE
[21.02] cmake: update to version 3.19.8

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -7,14 +7,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
-PKG_VERSION:=3.19.1
+PKG_VERSION:=3.19.8
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:kitware:cmake
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Kitware/CMake/releases/download/v$(PKG_VERSION)/ \
 		https://cmake.org/files/v3.19/
-PKG_HASH:=1d266ea3a76ef650cdcf16c782a317cb4a7aa461617ee941e389cb48738a3aba
+PKG_HASH:=09b4fa4837aae55c75fb170f6a6e2b44818deba48335d1969deddfbb34e30369
 
 HOST_BUILD_PARALLEL:=1
 HOST_CONFIGURE_PARALLEL:=1


### PR DESCRIPTION
Hello,
please consider merging this pull request as it addresses a bad cmake release breaking ccache. This issue was also mentioned here: https://github.com/openwrt/openwrt/issues/8555

I also encountered this problem so I've decided to fix it by upgrading the package to the latest patched version available. I've tested it and the problem seems to be gone.

Thanks and have a nice day.