### PR TITLE
ramips: add support for Etisalat S3

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -33,6 +33,7 @@ ampedwireless,ally-r1900k)
 	;;
 beeline,smartbox-giga|\
 beeline,smartbox-turbo|\
+etisalat,s3|\
 rostelecom,rt-sf-1)
 	ubootenv_add_uci_config "/dev/mtd0" "0x80000" "0x1000" "0x20000"
 	;;

--- a/target/linux/ramips/dts/mt7621_etisalat_s3.dts
+++ b/target/linux/ramips/dts/mt7621_etisalat_s3.dts
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "etisalat,s3", "mediatek,mt7621-soc";
+	model = "Etisalat S3";
+
+	aliases {
+		label-mac-device = &gmac0;
+
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			label = "blue:wan";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_green: led-1 {
+			label = "green:status";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: led-2 {
+			label = "red:status";
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1 &ubiconcat2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x4f80000>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "sercomm,sc-partitions", "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x100000>;
+			sercomm,scpart-id = <0>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "dynamic partition map";
+			reg = <0x100000 0x100000>;
+			sercomm,scpart-id = <1>;
+			read-only;
+		};
+
+		factory: partition@200000 {
+			label = "Factory";
+			reg = <0x200000 0x100000>;
+			sercomm,scpart-id = <2>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_factory_21000: macaddr@21000 {
+				reg = <0x21000 0x6>;
+			};
+		};
+
+		partition@300000 {
+			label = "Boot Flag";
+			reg = <0x300000 0x100000>;
+			sercomm,scpart-id = <3>;
+		};
+
+		partition@400000 {
+			label = "kernel";
+			reg = <0x400000 0x600000>;
+			sercomm,scpart-id = <4>;
+		};
+
+		partition@a00000 {
+			label = "Kernel 2";
+			reg = <0xa00000 0x600000>;
+			sercomm,scpart-id = <5>;
+			read-only;
+		};
+
+		ubiconcat0: partition@1000000 {
+			label = "File System 1";
+			reg = <0x1000000 0x2000000>;
+			sercomm,scpart-id = <6>;
+		};
+
+		partition@3000000 {
+			label = "File System 2";
+			reg = <0x3000000 0x2000000>;
+			sercomm,scpart-id = <7>;
+			read-only;
+		};
+
+		ubiconcat1: partition@5000000 {
+			label = "Configuration/log";
+			reg = <0x5000000 0x1400000>;
+			sercomm,scpart-id = <8>;
+		};
+
+		ubiconcat2: partition@6400000 {
+			label = "application tmp buffer (Ftool)";
+			reg = <0x6400000 0x1b80000>;
+			sercomm,scpart-id = <9>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		nvmem-cells = <&macaddr_factory_21000>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <(3)>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		nvmem-cells = <&macaddr_factory_21000>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <(2)>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_21000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_factory_21000>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <(11)>;
+};
+
+&mdio {
+	ethphy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&uartlite3 {
+	status = "okay";
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/common-sercomm.mk
+++ b/target/linux/ramips/image/common-sercomm.mk
@@ -79,9 +79,9 @@ define Device/sercomm_dxx
 	lzma -a0 | uImage lzma
   IMAGES += factory.img
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGE/factory.img := append-ubi | sercomm-part-tag rootfs | \
-	sercomm-prepend-tagged-kernel kernel | gzip | sercomm-payload | \
-	sercomm-crypto
+  IMAGE/factory.img := append-ubi | check-size | \
+	sercomm-part-tag rootfs | sercomm-prepend-tagged-kernel kernel | \
+	gzip | sercomm-payload | sercomm-crypto
   SERCOMM_KERNEL_OFFSET := 0x400100
   SERCOMM_ROOTFS_OFFSET := 0x1000000
 endef

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -798,6 +798,19 @@ define Device/elecom_wrc-2533gst2
 endef
 TARGET_DEVICES += elecom_wrc-2533gst2
 
+define Device/etisalat_s3
+  $(Device/sercomm_dxx)
+  IMAGE_SIZE := 32768k
+  SERCOMM_HWID := DDK
+  SERCOMM_HWVER := 10000
+  SERCOMM_SWVER := 4009
+  DEVICE_VENDOR := Etisalat
+  DEVICE_MODEL := S3
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7615-firmware \
+	kmod-usb3 uboot-envtools
+endef
+TARGET_DEVICES += etisalat_s3
+
 define Device/firefly_firewrt
   $(Device/dsa-migration)
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -26,6 +26,7 @@ asus,rt-n56u-b1)
 beeline,smartbox-flash|\
 beeline,smartbox-giga|\
 beeline,smartbox-turbo|\
+etisalat,s3|\
 rostelecom,rt-sf-1)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
 	;;

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -64,6 +64,7 @@ platform_do_upgrade() {
 	dlink,dir-2660-a1|\
 	dlink,dir-3060-a1|\
 	dlink,dir-853-a3|\
+	etisalat,s3|\
 	h3c,tx1800-plus|\
 	h3c,tx1801-plus|\
 	h3c,tx1806|\


### PR DESCRIPTION
Etisalat S3 is a wireless WiFi 5 router manufactured by Sercomm company.

Device specification
--------------------
SoC Type: MediaTek MT7621AT
RAM: 256 MiB
Flash: 128 MiB
Wireless 2.4 GHz (MT7603EN): b/g/n, 2x2
Wireless 5 GHz (MT7615E): a/n/ac, 4x4
Ethernet: 5x GbE (WAN, LAN1, LAN2, LAN3, LAN4)
USB ports: 1x USB3.0
Button: 2 buttons (Reset & WPS)
LEDs:
   - 1x Status (RGB)
   - 1x 2.4G (blue, hardware, mt76-phy0)
   - 1x 5G (blue, hardware, mt76-phy1) Power: 12 VDC, 1.5 A
Connector type: barrel
Bootloader: U-Boot

Installation
-----------------
1.  Login to the router web interface under admin account
2.  Navigate to Settings -> Configuration -> Save to Computer
3.  Decode the configuration. For example, using cfgtool.py tool (see related section):
`cfgtool.py decode configurationBackup.cfg`
4.  Open configurationBackup.xml and find the following line: 
`<PARAMETER name="Password" type="string" value="<your router serial is here>" writable="1" encryption="1" password="1"/>`
5.  Insert the following line after and save: 
`<PARAMETER name="Enable" type="boolean" value="1" writable="1" encryption="0"/>`
6.  Encode the configuration. For example, using cfgtool.py tool: 
`cfgtool.py encode configurationBackup.xml`
7.  Upload the changed configuration (configurationBackup_changed.cfg) to the router
8.  Login to the router web interface (SuperUser:ETxxxxxxxxxx, where ETxxxxxxxxxx is the serial number from the backplate label)
9.  Navigate to Settings -> WAN -> Add static IP interface (e.g. 10.0.0.1/255.255.255.0)
10. Navigate to Settings -> Remote cotrol -> Add SSH, port 22, 10.0.0.0/255.255.255.0 and interface created before
11. Change IP of your client to 10.0.0.2/255.255.255.0 and connect the ethernet cable to the WAN port of the router
12. Connect to the router using SSH shell under SuperUser account
13. Run in SSH shell:
`sh`
14. Make a mtd backup (optional, see related section)
15. Change bootflag to Sercomm1 and reboot:
```
printf 1 | dd bs=1 seek=7 count=1 of=/dev/mtdblock3
reboot
```
16. Login to the router web interface under admin account
17. Remove dots from the OpenWrt factory image filename
18. Update firmware via web using OpenWrt factory image

Revert to stock
---------------
Change bootflag to Sercomm1 in OpenWrt CLI and then reboot:
`printf 1 | dd bs=1 seek=7 count=1 of=/dev/mtdblock3`

mtd backup
----------
1. Set up a tftp server (e.g. tftpd64 for windows)
2. Connect to a router using SSH shell and run the following commands: 
```
cd /tmp
for i in 0 1 2 3 4 5 6 7 8 9 10; do nanddump -f mtd$i /dev/mtd$i; tftp -l mtd$i -p 10.0.0.2; md5sum mtd$i >> mtd.md5; rm mtd$i; done 
tftp -l mtd.md5 -p 10.0.0.2
```

Recovery
--------
Use sercomm-recovery tool.
Link: https://github.com/danitool/sercomm-recovery

MAC Addresses
-------------
```
+-----+------------+---------+
| use | address    | example |
+-----+------------+---------+
| LAN | label      | *:50    |
| WAN | label + 11 | *:5b    |
| 2g  | label + 2  | *:52    |
| 5g  | label + 3  | *:53    |
+-----+------------+---------+
```
The label MAC address was found in Factory 0x21000

cfgtool.py
----------
A tool for decoding and encoding Sercomm configs.
Link: https://github.com/r3d5ky/sercomm_cfg_unpacker
