### PR TITLE
dnsmasq: set a cachesize default value

### DIFF
--- a/package/network/services/dnsmasq/files/dhcp.conf
+++ b/package/network/services/dnsmasq/files/dhcp.conf
@@ -10,6 +10,7 @@ config dnsmasq
 	option domain	'lan'
 	option expandhosts	1
 	option nonegcache	0
+	option cachesize	1000
 	option authoritative	1
 	option readethers	1
 	option leasefile	'/tmp/dhcp.leases'


### PR DESCRIPTION
Dnsmasq DNS cache size is only 150 items by default. That value gets used if the user does not set any value for the option.

We do not currently show the cachesize option in the dnsmasq uci config file, although the cachesize option has been supported for long.

Set the default value in the uci config file to 1000, so that cache gets used more and unnecessary DNS queries to upstream can be avoided. 

With only 150 cache items, the cache is so small that cache overflows even in a few minutes browsing.
Example:
```
root@router1:~# kill -10 9383
root@router1:~# logread | tail -n 8
Sun Nov 27 22:24:13 2022 daemon.info dnsmasq[1]: time 1669580653
Sun Nov 27 22:24:13 2022 daemon.info dnsmasq[1]: cache size 150, 176/1066 cache insertions re-used unexpired cache entries.
Sun Nov 27 22:24:13 2022 daemon.info dnsmasq[1]: queries forwarded 312, queries answered locally 555
Sun Nov 27 22:24:13 2022 daemon.info dnsmasq[1]: pool memory in use 0, max 0, allocated 0
Sun Nov 27 22:24:13 2022 daemon.info dnsmasq[1]: server 62.241.198.245#53: queries sent 312, retried or failed 0
Sun Nov 27 22:24:13 2022 daemon.info dnsmasq[1]: server 62.241.198.246#53: queries sent 20, retried or failed 0
Sun Nov 27 22:24:13 2022 daemon.info dnsmasq[1]: server 2001:14b8:1000::1#53: queries sent 20, retried or failed 0
Sun Nov 27 22:24:13 2022 daemon.info dnsmasq[1]: server 2001:14b8:1000::2#53: queries sent 20, retried or failed 0
```

With 1000 as the value, the cache is in better use and the recent items do not get overwritten that much.

Example with 1001 as value and a few hours of lazy browsing.
```
Sun Nov 27 22:11:59 2022 daemon.info dnsmasq[1]: time 1669579919
Sun Nov 27 22:11:59 2022 daemon.info dnsmasq[1]: cache size 1001, 0/5190 cache insertions re-used unexpired cache entries.
Sun Nov 27 22:11:59 2022 daemon.info dnsmasq[1]: queries forwarded 2087, queries answered locally 5391
Sun Nov 27 22:11:59 2022 daemon.info dnsmasq[1]: pool memory in use 0, max 0, allocated 0
Sun Nov 27 22:11:59 2022 daemon.info dnsmasq[1]: server 62.241.198.245#53: queries sent 2050, retried or failed 3
Sun Nov 27 22:11:59 2022 daemon.info dnsmasq[1]: server 62.241.198.246#53: queries sent 275, retried or failed 3
Sun Nov 27 22:11:59 2022 daemon.info dnsmasq[1]: server 2001:14b8:1000::1#53: queries sent 238, retried or failed 0
Sun Nov 27 22:11:59 2022 daemon.info dnsmasq[1]: server 2001:14b8:1000::2#53: queries sent 238, retried or failed 0
```

(I have been setting it to 1000 in my own builds for years.)
