### PR TITLE
[22.03]layerscape: Fix SPI-NOR issues with vendor patches

### DIFF
--- a/target/linux/layerscape/patches-5.10/303-arm64-dts-ls1012a-frdm-workaround-by-updating-qspi-f.patch
+++ b/target/linux/layerscape/patches-5.10/303-arm64-dts-ls1012a-frdm-workaround-by-updating-qspi-f.patch
@@ -1,0 +1,41 @@
+From 9c5c18dbf8e1845d349ef7020f8af5bc9b56ed1f Mon Sep 17 00:00:00 2001
+From: Pawel Dembicki <paweldembicki@gmail.com>
+Date: Fri, 28 Sep 2022 17:14:32 +0200
+Subject: [PATCH] arm64: dts: ls1012a-frdm/qds: workaround by updating qspi flash to
+ single mode
+
+Update rx and tx bus-width to 1 to use single mode to workaround ubifs
+issue found with double mode. (The same method as RDB board)
+
+Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
+---
+ arch/arm64/boot/dts/freescale/fsl-ls1012a-frdm.dts | 4 ++--
+ arch/arm64/boot/dts/freescale/fsl-ls1012a-qds.dts  | 4 ++--
+ 2 file changed, 4 insertions(+), 4 deletions(-)
+
+--- a/arch/arm64/boot/dts/freescale/fsl-ls1012a-frdm.dts
++++ b/arch/arm64/boot/dts/freescale/fsl-ls1012a-frdm.dts
+@@ -127,8 +127,8 @@
+ 		spi-max-frequency = <50000000>;
+ 		m25p,fast-read;
+ 		reg = <0>;
+-		spi-rx-bus-width = <2>;
+-		spi-tx-bus-width = <2>;
++		spi-rx-bus-width = <1>;
++		spi-tx-bus-width = <1>;
+ 	};
+ };
+ 
+--- a/arch/arm64/boot/dts/freescale/fsl-ls1012a-qds.dts
++++ b/arch/arm64/boot/dts/freescale/fsl-ls1012a-qds.dts
+@@ -181,8 +181,8 @@
+ 		spi-max-frequency = <50000000>;
+ 		m25p,fast-read;
+ 		reg = <0>;
+-		spi-rx-bus-width = <2>;
+-		spi-tx-bus-width = <2>;
++		spi-rx-bus-width = <1>;
++		spi-tx-bus-width = <1>;
+ 	};
+ };
+ 

--- a/target/linux/layerscape/patches-5.10/304-arm64-dts-ls1012a-rdb-workaround-by-updating-qspi-fl.patch
+++ b/target/linux/layerscape/patches-5.10/304-arm64-dts-ls1012a-rdb-workaround-by-updating-qspi-fl.patch
@@ -1,0 +1,29 @@
+From 9c5c18dbf8e1845d349ef7020f8af5bc9b56ed1f Mon Sep 17 00:00:00 2001
+From: Kuldeep Singh <kuldeep.singh@nxp.com>
+Date: Tue, 7 Jan 2020 17:14:32 +0530
+Subject: [PATCH] arm64: dts: ls1012a-rdb: workaround by updating qspi flash to
+ single mode
+
+Update rx and tx bus-width to 1 to use single mode to workaround ubifs
+issue found with double mode.
+
+[ Leo: Local workaround ]
+
+Signed-off-by: Kuldeep Singh <kuldeep.singh@nxp.com>
+---
+ arch/arm64/boot/dts/freescale/fsl-ls1012a-rdb.dts | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/arch/arm64/boot/dts/freescale/fsl-ls1012a-rdb.dts
++++ b/arch/arm64/boot/dts/freescale/fsl-ls1012a-rdb.dts
+@@ -92,8 +92,8 @@
+ 		spi-max-frequency = <50000000>;
+ 		m25p,fast-read;
+ 		reg = <0>;
+-		spi-rx-bus-width = <2>;
+-		spi-tx-bus-width = <2>;
++		spi-rx-bus-width = <1>;
++		spi-tx-bus-width = <1>;
+ 	};
+ };
+ 

--- a/target/linux/layerscape/patches-5.10/305-arm64-dts-ls1046a-rdb-Update-qspi-spi-rx-bus-width-t.patch
+++ b/target/linux/layerscape/patches-5.10/305-arm64-dts-ls1046a-rdb-Update-qspi-spi-rx-bus-width-t.patch
@@ -1,0 +1,34 @@
+From 38093ebbf25eb60a1aa863f46118a68a0300c56e Mon Sep 17 00:00:00 2001
+From: Kuldeep Singh <kuldeep.singh@nxp.com>
+Date: Fri, 3 Jan 2020 14:49:07 +0530
+Subject: [PATCH] arm64: dts: ls1046a-rdb: Update qspi spi-rx-bus-width to 1
+
+Update rx width from quad mode to single mode as a workaround.
+
+[Leo: Local workaround ]
+
+Signed-off-by: Kuldeep Singh <kuldeep.singh@nxp.com>
+---
+ arch/arm64/boot/dts/freescale/fsl-ls1046a-rdb.dts | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/arch/arm64/boot/dts/freescale/fsl-ls1046a-rdb.dts
++++ b/arch/arm64/boot/dts/freescale/fsl-ls1046a-rdb.dts
+@@ -101,7 +101,7 @@
+ 		#address-cells = <1>;
+ 		#size-cells = <1>;
+ 		spi-max-frequency = <50000000>;
+-		spi-rx-bus-width = <4>;
++		spi-rx-bus-width = <1>;
+ 		spi-tx-bus-width = <1>;
+ 		reg = <0>;
+ 	};
+@@ -111,7 +111,7 @@
+ 		#address-cells = <1>;
+ 		#size-cells = <1>;
+ 		spi-max-frequency = <50000000>;
+-		spi-rx-bus-width = <4>;
++		spi-rx-bus-width = <1>;
+ 		spi-tx-bus-width = <1>;
+ 		reg = <1>;
+ 	};

--- a/target/linux/layerscape/patches-5.10/400-LF-20-3-mtd-spi-nor-Use-1-bit-mode-of-spansion-s25fs.patch
+++ b/target/linux/layerscape/patches-5.10/400-LF-20-3-mtd-spi-nor-Use-1-bit-mode-of-spansion-s25fs.patch
@@ -1,0 +1,26 @@
+From 2b84e88d36de482da0370290ad4af09a71993f08 Mon Sep 17 00:00:00 2001
+From: Han Xu <han.xu@nxp.com>
+Date: Tue, 14 Apr 2020 11:58:44 -0500
+Subject: [PATCH] LF-20-3 mtd: spi-nor: Use 1 bit mode of spansion(s25fs512s)
+ flash
+
+This is a workaround patch which uses only single bit mode of s25fs512s
+flash
+
+Signed-off-by: Han Xu <han.xu@nxp.com>
+Signed-off-by: Kuldeep Singh <kuldeep.singh@nxp.com>
+---
+ drivers/mtd/spi-nor/spansion.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/mtd/spi-nor/spansion.c
++++ b/drivers/mtd/spi-nor/spansion.c
+@@ -62,7 +62,7 @@ static const struct flash_info spansion_
+ 			      SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
+ 			      USE_CLSR) },
+ 	{ "s25fs512s",  INFO6(0x010220, 0x4d0081, 256 * 1024, 256,
+-			      SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ | USE_CLSR)
++			      SPI_NOR_4B_OPCODES | USE_CLSR)
+ 	  .fixups = &s25fs_s_fixups, },
+ 	{ "s25sl12800", INFO(0x012018, 0x0300, 256 * 1024,  64, 0) },
+ 	{ "s25sl12801", INFO(0x012018, 0x0301,  64 * 1024, 256, 0) },


### PR DESCRIPTION
For some reason LS1012A and LS1046A devboards don't work well with Spansion SPI NOR flash. It cause read and write errors like:

[   27.285887] jffs2: Newly-erased block contained word 0xc20031985 at offset 0x025ae000
[   27.468922] jffs2: Newly-erased block contained word 0x0 at offset 0x02573000
[   27.502615] jffs2: Newly-erased block contained word 0xe723f41e5823f110 at offset 0x02572000
[   27.541550] jffs2: Newly-erased block contained word 0x1a7d266ee6 at offset 0x02571000
[   27.577195] jffs2: Newly-erased block contained word 0x5d000bae8d52fec6 at offset 0x02570000
[   27.611800] jffs2: Newly-erased block contained word 0x63515aee63515a4b at offset 0x0256f000
[   27.651749] jffs2: Newly-erased block contained word 0xc20031985 at offset 0x0256e000
[   27.825593] jffs2: Newly-erased block contained word 0xc20031985 at offset 0x0252e000

NXP have found workarround and applied in their vendor kernel version. They force 1x tx and 1x rx lines in qspi. That method fix issues. This patch ports patches from NXP LSDK tree.

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
(cherry picked from commit 2e4fe289ceb02139e6f1cf8dcae31ad14efba52c)
