### PR TITLE
mediatek: add support for Netgear WAX206

### DIFF
--- a/target/linux/mediatek/dts/mt7622-netgear-wax206.dts
+++ b/target/linux/mediatek/dts/mt7622-netgear-wax206.dts
@@ -1,0 +1,559 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2022, Marcel Ziswiler <marcel@ziswiler.com> */
+
+/dts-v1/;
+#include "mt7622.dtsi"
+#include "mt6380.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Netgear WAX206";
+	compatible = "netgear,wax206", "mediatek,mt7622";
+
+	aliases {
+		ethernet0 = &gmac0;
+		led-boot = &led_power_r;
+		led-failsafe = &led_power_r;
+		led-running = &led_power_g;
+		led-upgrade = &led_power_g;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8 swiotlb=512";
+	};
+
+	cpus {
+		cpu@0 {
+			proc-supply = <&mt6380_vcpu_reg>;
+			sram-supply = <&mt6380_vm_reg>;
+		};
+
+		cpu@1 {
+			proc-supply = <&mt6380_vcpu_reg>;
+			sram-supply = <&mt6380_vm_reg>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			gpios = <&pio 102 GPIO_ACTIVE_LOW>;
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_power_r: power_red {
+			default-state = "on";
+			gpios = <&pio 3 GPIO_ACTIVE_LOW>;
+			label = "power:red";
+		};
+
+		led_power_g: power_green {
+			default-state = "off";
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+			label = "power:green";
+		};
+
+		inet_green {
+			default-state = "off";
+			gpios = <&pio 20 GPIO_ACTIVE_HIGH>;
+			label = "inet:green";
+		};
+
+		inet_blue {
+			default-state = "off";
+			gpios = <&pio 17 GPIO_ACTIVE_LOW>;
+			label = "inet:blue";
+		};
+
+		wifin_green {
+			default-state = "off";
+			gpios = <&pio 85 GPIO_ACTIVE_LOW>;
+			label = "wifin:green";
+		};
+
+		wifin_blue {
+			default-state = "off";
+			gpios = <&pio 86 GPIO_ACTIVE_LOW>;
+			label = "wifin:blue";
+		};
+
+		wifia_green {
+			default-state = "off";
+			gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
+			label = "wifia:green";
+		};
+
+		wifia_blue {
+			default-state = "off";
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			label = "wifia:blue";
+		};
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x40000000>;
+	};
+};
+
+&bch {
+	status = "okay";
+};
+
+&btif {
+	status = "okay";
+};
+
+&cir {
+	pinctrl-names = "default";
+	pinctrl-0 = <&irrx_pins>;
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_pins>;
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		nvmem-cells = <&macaddr_factory_7fff4>;
+		nvmem-cell-names = "mac-address";
+		phy-mode = "2500base-x";
+		reg = <0>;
+
+		fixed-link {
+			full-duplex;
+			pause;
+			speed = <2500>;
+		};
+	};
+
+	mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		switch@0 {
+			compatible = "mediatek,mt7531";
+			#interrupt-cells = <1>;
+			interrupt-controller;
+			interrupt-parent = <&pio>;
+			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
+			reg = <0>;
+			reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@1 {
+					label = "lan1";
+					reg = <1>;
+				};
+
+				port@2 {
+					label = "lan2";
+					reg = <2>;
+				};
+
+				port@3 {
+					label = "lan3";
+					reg = <3>;
+				};
+
+				port@4 {
+					label = "lan4";
+					reg = <4>;
+				};
+
+				wan: port@5 {
+					label = "wan";
+					nvmem-cells = <&macaddr_factory_7fffa>;
+					nvmem-cell-names = "mac-address";
+					phy-handle = <&rtl8221b_phy>;
+					phy-mode = "sgmii";
+					reg = <5>;
+				};
+
+				port@6 {
+					ethernet = <&gmac0>;
+					label = "cpu";
+					phy-mode = "2500base-x";
+					reg = <6>;
+
+					fixed-link {
+						full-duplex;
+						pause;
+						speed = <2500>;
+					};
+				};
+			};
+		};
+
+		rtl8221b_phy: ethernet-phy@7 {
+			compatible = "ethernet-phy-id001c.c849";
+			reg = <7>;
+			reset-gpios = <&pio 101 GPIO_ACTIVE_LOW>;
+			interrupts = <52 IRQ_TYPE_LEVEL_HIGH>;
+			reset-assert-us = <100000>;
+			reset-deassert-us = <100000>;
+		};
+	};
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+	status = "okay";
+};
+
+&pcie1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_pins>;
+	status = "okay";
+};
+
+&pio {
+	eth_pins: eth-pins {
+		mux {
+			function = "eth";
+			groups = "mdc_mdio", "rgmii_via_gmac2";
+		};
+	};
+
+	irrx_pins: irrx-pins {
+		mux {
+			function = "ir";
+			groups =  "ir_1_rx";
+		};
+	};
+
+	irtx_pins: irtx-pins {
+		mux {
+			function = "ir";
+			groups =  "ir_1_tx";
+		};
+	};
+
+	pcie0_pins: pcie0-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie0_pad_perst",
+				 "pcie0_1_waken",
+				 "pcie0_1_clkreq";
+		};
+	};
+
+	pcie1_pins: pcie1-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie1_pad_perst",
+				 "pcie1_0_waken",
+				 "pcie1_0_clkreq";
+		};
+	};
+
+	pmic_bus_pins: pmic-bus-pins {
+		mux {
+			function = "pmic";
+			groups = "pmic_bus";
+		};
+	};
+
+	pwm7_pins: pwm1-2-pins {
+		mux {
+			function = "pwm";
+			groups = "pwm_ch7_2";
+		};
+	};
+
+	wled_pins: wled-pins {
+		mux {
+			function = "led";
+			groups = "wled";
+		};
+	};
+
+	/* Serial NAND is shared pin with SPI-NOR */
+	serial_nand_pins: serial-nand-pins {
+		mux {
+			function = "flash";
+			groups = "snfi";
+		};
+	};
+
+	spic0_pins: spic0-pins {
+		mux {
+			function = "spi";
+			groups = "spic0_0";
+		};
+	};
+
+	spic1_pins: spic1-pins {
+		mux {
+			function = "spi";
+			groups = "spic1_0";
+		};
+	};
+
+	uart0_pins: uart0-pins {
+		mux {
+			function = "uart";
+			groups = "uart0_0_tx_rx";
+		};
+	};
+
+	uart2_pins: uart2-pins {
+		mux {
+			function = "uart";
+			groups = "uart2_1_tx_rx";
+		};
+	};
+
+	watchdog_pins: watchdog-pins {
+		mux {
+			function = "watchdog";
+			groups = "watchdog";
+		};
+	};
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm7_pins>;
+	status = "okay";
+};
+
+&pwrap {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pmic_bus_pins>;
+	status = "okay";
+};
+
+&rtc {
+	status = "disabled";
+};
+
+&sata {
+	status = "disabled";
+};
+
+&sata_phy {
+	status = "disabled";
+};
+
+&slot0 {
+	wmac1: mt7915@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&snfi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&serial_nand_pins>;
+	status = "okay";
+
+	snand: flash@0 {
+		compatible = "spi-nand";
+		mediatek,bmt-table-size = <0x1000>;
+		mediatek,bmt-v2;
+		nand-ecc-engine = <&snfi>;
+		reg = <0>;
+		spi-rx-bus-width = <4>;
+		spi-tx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Preloader";
+				reg = <0x00000 0x0080000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "ATF";
+				reg = <0x80000 0x0040000>;
+				read-only;
+			};
+
+			partition@c0000 {
+				label = "Bootloader";
+				reg = <0xc0000 0x0080000>;
+				read-only;
+			};
+
+			partition@140000 {
+				label = "Config";
+				reg = <0x140000 0x0080000>;
+			};
+
+			factory: partition@1c0000 {
+				compatible = "nvmem-cells";
+				label = "Factory";
+				reg = <0x1c0000 0x0100000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				read-only;
+
+				macaddr_factory_7fff4: macaddr@7fff4 {
+					reg = <0x7fff4 0x6>;
+				};
+
+				macaddr_factory_7fffa: macaddr@7fffa {
+					reg = <0x7fffa 0x6>;
+				};
+			};
+
+			partition@2c0000 {
+				label = "firmware";
+				reg = <0x2c0000 0x2600000>;
+
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "kernel";
+					reg = <0x0 0x600000>;
+				};
+
+				partition@600000 {
+					label = "ubi";
+					reg = <0x600000 0x2000000>;
+				};
+			};
+
+			partition@28c0000 {
+				label = "firmware_backup";
+				reg = <0x28c0000 0x2600000>;
+				read-only;
+			};
+
+			partition@4ec0000 {
+				label = "CFG";
+				reg = <0x4ec0000 0x800000>;
+				read-only;
+			};
+
+			partition@56c0000 {
+				label = "RAE";
+				reg = <0x56c0000 0x400000>;
+				read-only;
+			};
+
+			partition@5ac0000 {
+				label = "POT";
+				reg = <0x5ac0000 0x100000>;
+				read-only;
+			};
+
+			partition@5bc0000 {
+				label = "Language";
+				reg = <0x5bc0000 0x400000>;
+				read-only;
+			};
+
+			partition@5fc0000 {
+				label = "Traffic";
+				reg = <0x5fc0000 0x200000>;
+				read-only;
+			};
+
+			partition@61c0000 {
+				label = "Cert";
+				reg = <0x61c0000 0x100000>;
+				read-only;
+			};
+
+			partition@62c0000 {
+				label = "NTGRcryptK";
+				reg = <0x62c0000 0x100000>;
+				read-only;
+			};
+
+			partition@63c0000 {
+				label = "NTGRcryptD";
+				reg = <0x63c0000 0x500000>;
+				read-only;
+			};
+
+			partition@68c0000 {
+				label = "LOG";
+				reg = <0x68c0000 0x100000>;
+				read-only;
+			};
+
+			partition@69c0000 {
+				label = "User_data";
+				reg = <0x69c0000 0x640000>;
+				read-only;
+			};
+
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spic0_pins>;
+	status = "okay";
+};
+
+&spi1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spic1_pins>;
+	status = "okay";
+};
+
+&ssusb {
+	status = "disabled";
+};
+
+&u3phy {
+	status = "disabled";
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+	status = "okay";
+};
+
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart2_pins>;
+	status = "okay";
+};
+
+&watchdog {
+	pinctrl-names = "default";
+	pinctrl-0 = <&watchdog_pins>;
+	status = "okay";
+};
+
+&wmac {
+	mediatek,mtd-eeprom = <&factory 0x0000>;
+	status = "okay";
+};
+
+&wmac1 {
+	mediatek,mtd-eeprom = <&factory 0x05000>;
+};

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -228,6 +228,33 @@ define Device/mediatek_mt7622-rfb1-ubi
 endef
 TARGET_DEVICES += mediatek_mt7622-rfb1-ubi
 
+define Device/netgear_wax206
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := NETGEAR
+  DEVICE_MODEL := WAX206
+  DEVICE_DTS := mt7622-netgear-wax206
+  DEVICE_DTS_DIR := ../dts
+  NETGEAR_ENC_MODEL := WAX206
+  NETGEAR_ENC_REGION := US
+  DEVICE_PACKAGES := kmod-mt7915-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 6144k
+  IMAGE_SIZE := 32768k
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
+	append-squashfs4-fakeroot
+# recovery can also be used with stock firmware web-ui, hence the padding...
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 128k
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  IMAGES += factory.img
+  IMAGE/factory.img := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size | netgear-encrypted-factory
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += netgear_wax206
+
 define Device/ruijie_rg-ew3200gx-pro
   DEVICE_VENDOR := Ruijie
   DEVICE_MODEL := RG-EW3200GX PRO

--- a/target/linux/mediatek/mt7622/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/mt7622/base-files/etc/board.d/01_leds
@@ -7,7 +7,8 @@ board_config_update
 
 case $board in
 linksys,e8450|\
-linksys,e8450-ubi)
+linksys,e8450-ubi|\
+netgear,wax206)
 	ucidef_set_led_netdev "wan" "WAN" "inet:blue" "wan"
 	;;
 xiaomi,redmi-router-ax6s)

--- a/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ mediatek_setup_interfaces()
 	linksys,e8450-ubi|\
 	mediatek,mt7622-rfb1|\
 	mediatek,mt7622-rfb1-ubi|\
+	netgear,wax206|\
 	reyee,ax3200-e5|\
 	ruijie,rg-ew3200gx-pro)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" wan

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
@@ -35,6 +35,7 @@ platform_do_upgrade() {
 		;;
 	elecom,wrc-x3200gst3|\
 	mediatek,mt7622-rfb1-ubi|\
+	netgear,wax206|\
 	totolink,a8000ru|\
 	xiaomi,redmi-router-ax6s)
 		nand_do_upgrade "$1"
@@ -71,6 +72,7 @@ platform_check_image() {
 		;;
 	elecom,wrc-x3200gst3|\
 	mediatek,mt7622-rfb1-ubi|\
+	netgear,wax206|\
 	totolink,a8000ru|\
 	xiaomi,redmi-router-ax6s)
 		nand_do_platform_check "$board" "$1"


### PR DESCRIPTION
Specifications:
* SoC: MediaTek MT7622BV
* RAM: DDR3 512 MiB (Nanya NT5CC256M16ER-EK)
* Flash: SPI-NAND 256 MiB (Toshiba TC58CVG1S3HRAIJ)
* Wi-Fi 2.4/5 GHz 4T4R:
  * 2.4 GHz: MediaTek MT7622BV
  * 5 GHz: MediaTek MT7915AN/MT7975AN
* Ethernet: 4x 10/100/1000 Mbps LAN, 1x 10/100/1000/2500 Mbps WAN (Realtek RTL8221B PHY)
* Switch: MediaTek MT7531AE
* LEDs/Keys: 8/1 (Power, Internet, LAN1, LAN2, LAN3, LAN4, Wifin and Wifia dual-colour LEDs + Reset pin)
* UART: Marked J19 on board VCC GND TX RX, beginning from "1". 3.3v, 115200n8
* Power: 12 VDC, 2.5 A

Installation:
* Flash the factory image through the stock web interface, or TFTP to the bootloader. NMRP can be used to TFTP without opening the case.
* U-Boot allows booting an initramfs image via TFTP as follows: 
setenv ipaddr 192.168.1.1 
setenv serverip 192.168.1.100
tftpboot openwrt-mediatek-mt7622-netgear_wax206-initramfs-recovery.itb
bootm

Known Limitations:
* The 2.5G WAN port labeled 'wan' only works for speeds up to 1G at the moment. If connected to a multi-gig port the speed has to be manually set to 1G/full either for the switch port or in OpenWrt. For example add the following to /etc/rc.local to set it after boot: /usr/sbin/ethtool -s wan speed 1000 duplex full

Revert to stock firmware:
* Flash the stock firmware to the bootloader using TFTP/NMRP.

References to WAX206 GPL source:
https://www.downloads.netgear.com/files/GPL/WAX206_V1.0.4.0_Source.rar

* openwrt/target/linux/mediatek/dts/mt7622-netgear-wax206.dts DTS file for this device.
* openwrt/target/linux/mediatek/image/mt7622.mk Image creation code for this device

Signed-off-by: Marcel Ziswiler <marcel@ziswiler.com>
[fix WAN port (1G only), adjust partition layout, adjust image creation]
Signed-off-by: Thomas Kupper <thomas.kupper@gmail.com>