### PR TITLE
build: images: squashfs: add help, fix description

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -150,7 +150,7 @@ menu "Target Images"
 		bool "squashfs"
 		default y if USES_SQUASHFS
 		help
-		  Build a squashfs-lzma root filesystem.
+		  Build a squashfs root filesystem.
 
 		config TARGET_SQUASHFS_BLOCK_SIZE
 			int "Block size (in KiB)"
@@ -158,6 +158,9 @@ menu "Target Images"
 			default 64 if LOW_MEMORY_FOOTPRINT
 			default 1024 if (SMALL_FLASH && !LOW_MEMORY_FOOTPRINT)
 			default 256
+			help
+			  Select squashfs block size, must be one of:
+			    4, 8, 16, 32, 64, 128, 256, 512, 1024
 
 	menuconfig TARGET_ROOTFS_UBIFS
 		bool "ubifs"


### PR DESCRIPTION
> add help text for `TARGET_SQUASHFS_BLOCK_SIZE` to match the only valid settings accepted by `mksquashfs4` ("block size not power of two or not between 4096 and 1Mbyte") thus for this setting in "KB", the set:
>   `4, 8, 16, 32, 64, 128, 256, 512, 1024`
> 
> replace `squashfs-lzma` with `squashfs` in the description for `TARGET_ROOTFS_SQUASHFS` because it has various compressions, and not just lzma as it did in the past
> 
> cosmetic change with no functional effect

Found this opportunity for minor improvement while working on some other changes, and when I chose an invalid blocksize once and noted there was nothing about valid settings in help.