### PR TITLE
build: config: cleanup impossible dependency logic

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -47,7 +47,6 @@ menu "Target Images"
 				bool "xz"
 
 			config TARGET_INITRAMFS_COMPRESSION_ZSTD
-				depends on !LINUX_5_4 && !LINUX_4_19
 				bool "zstd"
 		endchoice
 

--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -779,7 +779,7 @@ if KERNEL_CGROUPS
 		bool "Memory Resource Controller for Control Groups"
 		default y
 		select KERNEL_FREEZER
-		depends on KERNEL_RESOURCE_COUNTERS || !LINUX_3_18
+		depends on KERNEL_RESOURCE_COUNTERS
 		help
 		  Provides a memory resource controller that manages both anonymous
 		  memory and page cache. (See Documentation/cgroups/memory.txt)


### PR DESCRIPTION
> some config `depends on` lines contained outdated kernel version checks that can no longer happen and had become non-operational; clean them up
> 
> cosmetic change with no functional effect

These came up in a review of some other patches I was working on, so I hunted them all.  I believe the only current valid logic is based on `LINUX_5_10` or `LINUX_5_15`, so this removes any previous references within the config tree.