### PR TITLE
tools/liblzo: add `liblzo` library

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -56,6 +56,7 @@ $(curdir)/genext2fs/compile := $(curdir)/libtool/compile
 $(curdir)/gengetopt/compile := $(curdir)/libtool/compile
 $(curdir)/gmp/compile := $(curdir)/libtool/compile
 $(curdir)/isl/compile := $(curdir)/gmp/compile
+$(curdir)/liblzo/compile := $(curdir)/cmake/compile
 $(curdir)/libressl/compile := $(curdir)/pkgconf/compile
 $(curdir)/libtool/compile := $(curdir)/automake/compile $(curdir)/missing-macros/compile
 $(curdir)/lzma-old/compile := $(curdir)/zlib/compile

--- a/tools/liblzo/Makefile
+++ b/tools/liblzo/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2022 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=lzo
+PKG_VERSION:=2.10
+PKG_RELEASE:=4
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://www.oberhumer.com/opensource/lzo/download/
+PKG_HASH:=c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072
+
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
+
+CMAKE_BINARY_SUBDIR:=openwrt-build
+
+include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+CMAKE_HOST_OPTIONS += \
+	-DENABLE_SHARED=ON \
+	-DENABLE_TESTS=OFF \
+	-DENABLE_EXAMPLES=OFF \
+	-DENABLE_DOC=OFF \
+	-DBUILD_TESTING=OFF
+
+define Host/Uninstall
+	rm -rf $(STAGING_DIR_HOST)/include/lzo
+	rm -f  $(STAGING_DIR_HOST)/lib/liblzo2.a
+	rm -f  $(STAGING_DIR_HOST)/lib/liblzo2.so.2.0.0
+	rm -f  $(STAGING_DIR_HOST)/lib/liblzo2.so.2
+	rm -f  $(STAGING_DIR_HOST)/lib/liblzo2.so
+	rm -f  $(STAGING_DIR_HOST)/lib/pkgconfig/lzo2.pc
+endef
+
+$(eval $(call HostBuild))

--- a/tools/liblzo/patches/001-add-cmake-ENABLE-configurables.patch
+++ b/tools/liblzo/patches/001-add-cmake-ENABLE-configurables.patch
@@ -1,0 +1,68 @@
+--- a/CMakeLists.txt	2022-11-28 06:34:39.171209779 -0800
++++ b/CMakeLists.txt	2022-11-28 06:33:13.368239757 -0800
+@@ -51,8 +51,11 @@
+ project(lzo VERSION 2.10 LANGUAGES C)
+ 
+ # configuration options
+-option(ENABLE_STATIC "Build static LZO library." ON)
+-option(ENABLE_SHARED "Build shared LZO library." OFF)
++option(ENABLE_STATIC   "Build static LZO library." ON)
++option(ENABLE_SHARED   "Build shared LZO library." OFF)
++option(ENABLE_TESTS    "Build tests."              ON)
++option(ENABLE_EXAMPLES "Build examples."           ON)
++option(ENABLE_DOCS     "Install documentation."    ON)
+ if(NOT ENABLE_STATIC AND NOT ENABLE_SHARED)
+     set(ENABLE_STATIC ON)
+ endif()
+@@ -127,14 +130,20 @@
+     endif()
+ endmacro()
+ # main test driver
++if(ENABLE_TESTS OR ENABLE_EXAMPLES)
+ lzo_add_executable(lzotest  lzotest/lzotest.c)
++endif()
+ # examples
++if(ENABLE_EXAMPLES)
+ lzo_add_executable(dict     examples/dict.c)
+ lzo_add_executable(lzopack  examples/lzopack.c)
+ lzo_add_executable(overlap  examples/overlap.c)
+ lzo_add_executable(precomp  examples/precomp.c)
+ lzo_add_executable(precomp2 examples/precomp2.c)
++endif()
++if(ENABLE_TESTS OR ENABLE_EXAMPLES)
+ lzo_add_executable(simple   examples/simple.c)
++endif()
+ # some boring internal test programs
+ if(0)
+     lzo_add_executable(align    tests/align.c)
+@@ -144,7 +153,7 @@
+ endif()
+ 
+ # miniLZO
+-if(1)
++if(ENABLE_TESTS)
+     add_executable(testmini minilzo/testmini.c minilzo/minilzo.c)
+     target_include_directories(testmini PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include/lzo") # needed for "lzoconf.h"
+ endif()
+@@ -263,8 +272,10 @@
+ 
+ if(DEFINED CMAKE_INSTALL_FULL_LIBDIR)
+ 
+-set(f AUTHORS COPYING NEWS THANKS doc/LZO.FAQ doc/LZO.TXT doc/LZOAPI.TXT)
+-install(FILES ${f} DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}")
++if(ENABLE_DOCS)
++    set(f AUTHORS COPYING NEWS THANKS doc/LZO.FAQ doc/LZO.TXT doc/LZOAPI.TXT)
++    install(FILES ${f} DESTINATION "${CMAKE_INSTALL_FULL_DOCDIR}")
++endif()
+ 
+ set(f include/lzo/lzo1.h include/lzo/lzo1a.h include/lzo/lzo1b.h
+     include/lzo/lzo1c.h include/lzo/lzo1f.h include/lzo/lzo1x.h
+@@ -285,7 +296,7 @@
+     )
+ endif()
+ 
+-if(1)
++if(ENABLE_EXAMPLES)
+     set(f lzopack lzotest simple testmini) # examples
+     install(TARGETS ${f} DESTINATION "${CMAKE_INSTALL_FULL_LIBEXECDIR}/lzo/examples")
+ endif()


### PR DESCRIPTION
> prerequisite of upcoming `tools/lzop` addition, and subsequent initramfs and squashfs cleanups
> 
> same as `packages/lzo` modified to be a HOST/tools type build, and should always be the same version and sources when either one is bumped
> 
> because this (and `packages/lzo`) only provide liblzo and no executables, use the clearer name `tools/liblzo`

Unused until upcoming changes to `tools/squashfskit4` and adding `tools/lzop` for initramfs feature fixes.  Tested build, install, clean.

Probably later, I might backport the improved build definition to `packages/lzo` as it is much nicer relying on the package itself to do installations (given the provided patch).  There is no `uninstall` target so the Uninstall still removes a fixed list of files.