### PR TITLE
ath79: tiny: Do not build TPLink WPA8630Pv2 by default

### DIFF
--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -234,6 +234,7 @@ define Device/tplink_tl-wpa8630p-v2
     so the JFFS2 settings partition MUST be reformatted to avoid data corruption. \
     Backup your settings before upgrading, then during sysupgrade, \
     de-select "Keep settings" and select "Force" to continue (equivilant to "sysupgrade -n -F").
+  DEFAULT := n
 endef
 
 define Device/tplink_tl-wpa8630p-v2-int


### PR DESCRIPTION
22.03.1+ and snapshot builds no longer fit the 6M flash space available for these models. (21.02.* and 22.03.0 previously fit OK).

This disables failing buildbot image builds for these devices. Images can still be built manually with ImageBuilder.

Signed-off-by: Joe Mullally <jwmullally@gmail.com>

---

Please merge against both /master and /openwrt-22.03 branches. Thanks!