### PR TITLE
timestamp.pl: rework and more use cases

### DIFF
--- a/include/depends.mk
+++ b/include/depends.mk
@@ -11,7 +11,8 @@
 
 DEP_FINDPARAMS := -x "*/.svn*" -x ".*" -x "*:*" -x "*\!*" -x "* *" -x "*\\\#*" -x "*/.*_check" -x "*/.*.swp" -x "*/.pkgdir*"
 
-find_md5=find $(wildcard $(1)) -type f $(patsubst -x,-and -not -path,$(DEP_FINDPARAMS) $(2)) -printf "%p%T@\n" | sort | $(MKHASH) md5
+find_md5=$(TOPDIR)/scripts/timestamp.pl -P -a "-type f" $(DEP_FINDPARAMS) $(2) -- $(wildcard $(1)) | \
+	 sort | $(MKHASH) md5
 find_md5_reproducible=find $(wildcard $(1)) -type f $(patsubst -x,-and -not -path,$(DEP_FINDPARAMS) $(2)) -print0 | xargs -0 $(MKHASH) md5 | sort | $(MKHASH) md5
 
 define rdep
@@ -29,7 +30,7 @@ ifneq ($(wildcard $(2)),)
 	) \
 	{ \
 		[ -f "$(2)_check.1" ] && mv "$(2)_check.1" "$(2)_check"; \
-	    $(TOPDIR)/scripts/timestamp.pl $(DEP_FINDPARAMS) $(4) -n $(2) $(1) && { \
+		$(foreach depfile,$(1) $(2),$(TOPDIR)/scripts/timestamp.pl $(DEP_FINDPARAMS) $(4) -n $(depfile) &&) { \
 			$(call debug_eval,$(SUBDIR),r,echo "No need to rebuild $(2)";) \
 			touch -r "$(2)" "$(2)_check"; \
 		} \

--- a/include/subdir.mk
+++ b/include/subdir.mk
@@ -89,8 +89,17 @@ ifndef DUMP_TARGET_DB
 define stampfile
   $(1)/stamp-$(3):=$(if $(6),$(6),$(STAGING_DIR))/stamp/.$(2)_$(3)$(5)
   $$($(1)/stamp-$(3)): $(TMP_DIR)/.build $(4)
-	@+$(SCRIPT_DIR)/timestamp.pl -n $$($(1)/stamp-$(3)) $(1) $(4) || \
-		$(MAKE) $(if $(QUIET),--no-print-directory) $$($(1)/flags-$(3)) $(1)/$(3)
+	@+ \
+		{ \
+			$(foreach depfile,$(4),$(SCRIPT_DIR)/timestamp.pl -n $(depfile) &&) \
+			$(SCRIPT_DIR)/timestamp.pl -n $$($(1)/stamp-$(3)) \
+			; \
+		} || \
+		{ \
+			$(SCRIPT_DIR)/timestamp.pl -n $(1) && \
+			$(MAKE) --no-print-directory $$($(1)/flags-$(3)) $(1)/$(3) \
+			; \
+		}
 	@mkdir -p $$$$(dirname $$($(1)/stamp-$(3)))
 	@touch $$($(1)/stamp-$(3))
 

--- a/scripts/timestamp.pl
+++ b/scripts/timestamp.pl
@@ -7,14 +7,14 @@
 #
 
 use strict;
+use POSIX;
 
 sub get_ts($$) {
 	my $path = shift;
 	my $options = shift;
 	my $ts = 0;
 	my $fn = "";
-	$path .= "/" if( -d $path);
-	open FIND, "find $path -type f -and -not -path \\*/.svn\\* -and -not -path \\*CVS\\* $options 2>/dev/null |";
+	open FIND, "find $path $options 2>/dev/null |";
 	while (<FIND>) {
 		chomp;
 		my $file = $_;
@@ -23,47 +23,128 @@ sub get_ts($$) {
 		if ($mt > $ts) {
 			$ts = $mt;
 			$fn = $file;
+			last;
 		}
 	}
 	close FIND;
 	return ($ts, $fn);
 }
 
+sub get_fnames($$) {
+	my $path = shift;
+	my $options = shift;
+	my $ts = 0;
+	my @fns = ();
+	open FIND, "find $path $options 2>/dev/null |";
+	while (<FIND>) {
+		chomp;
+		my $file = $_;
+		next if -l $file;
+		push(@fns, $file);
+	}
+	close FIND;
+	return @fns;
+}
+
 (@ARGV > 0) or push @ARGV, ".";
-my $ts = 0;
 my $n = ".";
+my $t = "0";
+my $ts = 0;
+my $cs = 0;
+my $namef = "%s\t";
+my $timef = "%u\n";
+my @fnames;
 my %options;
+my $path;
 while (@ARGV > 0) {
-	my $path = shift @ARGV;
+	$path = shift @ARGV;
 	if ($path =~ /^-x/) {
-		my $str = shift @ARGV;
-		$options{"findopts"} .= " -and -not -path '".$str."'"
-	} elsif ($path =~ /^-f/) {
-		$options{"findopts"} .= " -follow";
+		my $arg = shift @ARGV;
+		$options{-findopts} .= " '!' -path '" . $arg . "'"
+	} elsif ($path =~ /^-a/) {
+		my $arg = shift @ARGV;
+		$options{-findopts} .= " " . $arg;
 	} elsif ($path =~ /^-n/) {
 		my $arg = $ARGV[0];
 		$options{$path} = $arg;
-	} elsif ($path =~ /^-/) {
+	} elsif ($path =~ /^-cold.*/) {
+		my $path = shift @ARGV;
+		$cs = (stat $path)[9];
+		$options{-c} = -1;
+	} elsif ($path =~ /^-ceq.*/) {
+		my $path = shift @ARGV;
+		$cs = (stat $path)[9];
+		$options{-c} = 0;
+	} elsif ($path =~ /^-cnew.*/) {
+		my $path = shift @ARGV;
+		$cs = (stat $path)[9];
+		$options{-c} = 1;
+	} elsif ($path =~ /^-p/) {
+		$namef = "%s\n";
+		$timef = "";
+	} elsif ($path =~ /^-t/) {
+		$namef = "";
+		$timef = "%s\n";
+	} elsif ($path =~ /^-P/) {
 		$options{$path} = 1;
-	} else {
-		my ($tmp, $fname) = get_ts($path, $options{"findopts"});
-		if ($tmp > $ts) {
-			if ($options{'-F'}) {
-				$n = $fname;
-			} else {
-				$n = $path;
-			}
-			$ts = $tmp;
+	} elsif ($path =~ /^-T/) {
+		$options{$path} = 1;
+		$timef = "%s\n";
+	} elsif ($path =~ /^-r/) {
+		$options{$path} = 1;
+	} elsif ($path =~ /^--/) {
+		$options{-r} = 1;
+		my $path = shift @ARGV;
+		foreach my $paths(@ARGV) {
+			$path .= " $paths";
 		}
+		@ARGV = ($path);
+	} elsif ($path =~ /^-/) {
+		my $path = <STDIN>;
+		chomp($path);
+		@ARGV = ($path);
 	}
 }
 
-if ($options{"-n"}) {
-	exit ($n eq $options{"-n"} ? 0 : 1);
-} elsif ($options{"-p"}) {
-	print "$n\n";
-} elsif ($options{"-t"}) {
-	print "$ts\n";
+if ($options{-r}) {
+	@fnames = get_fnames($path, $options{-findopts});
 } else {
-	print "$n\t$ts\n";
+	my ($tmp, $fname) = get_ts($path, $options{-findopts});
+	if ($tmp > $ts) {
+		$n = $fname;
+		($t, $ts) = ($tmp, $tmp);
+	}
+}
+
+sub print_cs {
+	$n =~ s{^.*/}{} if ($options{-P});
+	$n .= "/" if (-d $n);
+	$t = strftime("%Y-%m-%d %H:%M:%S %z", localtime($ts)) if ($options{-T});
+	($ts <=> $cs) == $options{-c} and (printf $namef, $n and printf $timef, $t);
+}
+
+sub print_ts {
+	$n =~ s{^.*/}{} if ($options{-P});
+	$n .= "/" if (-d $n);
+	$t = strftime("%Y-%m-%d %H:%M:%S %z", localtime($ts)) if ($options{-T});
+	printf $namef, $n and printf $timef, $t;
+}
+
+if ($options{-n}) {
+	exit ($n eq $options{-n} ? 0 : 1);
+} elsif ($options{-r}) {
+	foreach my $fname(@fnames) {
+		$n = $fname;
+		$ts = (stat $fname)[9];
+		$t = $ts;
+		if ($cs) {
+			print_cs;
+		} else {
+			print_ts;
+		}
+	}
+} elsif ($cs) {
+	($ts <=> $cs) == $options{-c} and print_cs or exit(1);
+} else {
+	print_ts;
 }

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -149,7 +149,7 @@ package_reload:
 	if [ -d "$(PACKAGE_DIR)" ] && ( \
 			[ ! -f "$(PACKAGE_DIR)/Packages" ] || \
 			[ ! -f "$(PACKAGE_DIR)/Packages.gz" ] || \
-			[ "`find $(PACKAGE_DIR) -cnewer $(PACKAGE_DIR)/Packages.gz`" ] ); then \
+			[ "$$($(SCRIPT_DIR)/timestamp.pl -a "-type f" -cnewer $(PACKAGE_DIR)/Packages.gz -- $(PACKAGE_DIR))" ] ); then \
 		echo "Package list missing or not up-to-date, generating it." >&2 ;\
 		$(MAKE) package_index; \
 	else \

--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -106,8 +106,9 @@ $(BIN_DIR)/$(SDK_NAME).tar.xz: clean
 	$(CP) -L $(INCLUDE_DIR) $(SCRIPT_DIR) $(SDK_BUILD_DIR)/
 	$(TAR) -cf - -C $(TOPDIR) \
 		`cd $(TOPDIR); find $(KDIR_BASE)/ -name \*.ko` \
-		`cd $(TOPDIR); find $(KDIR_BASE)/firmware/ -newer $(KDIR_BASE)/firmware/Makefile \
-			-type f -name '*.bin' -or -name '*.cis' -or -name '*.csp' -or -name '*.dsp' -or -name '*.fw'` \
+		$$(cd $(TOPDIR); $(SCRIPT_DIR)/timestamp.pl -p -cnewer $(KDIR_BASE)/firmware/Makefile \
+			-a "-type f -name '*.bin' -o -name '*.cis' -o -name '*.csp' -o -name '*.dsp' -o -name '*.fw'" \
+			-- $(KDIR_BASE)/firmware) \
 		$(foreach exclude,$(EXCLUDE_DIRS),--exclude="$(exclude)") \
 		$(SDK_DIRS) $(KERNEL_FILES) | \
 		$(TAR) -xf - -C $(SDK_BUILD_DIR)


### PR DESCRIPTION
usage of the perl script timestamp.pl to handle some non-POSIX usage of find, and in the future possibly more use cases

eventually, `find_md5_reproducible` can be removed (by making this reproducible with some makefile restructuring), this is the first step for that goal