### PR TITLE
CI: add support to tag pr targeting stable branch

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,3 +17,17 @@ jobs:
       - uses: actions/labeler@v4
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Check Branch
+        id: check-branch
+        run: |
+          if echo "${{ github.base_ref }}" | grep -q -E 'openwrt-[0-9][0-9]\.[0-9][0-9]'; then
+              echo "apply-tag=yes" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: buildsville/add-remove-label@v2.0.0
+        if: ${{ steps.check-branch.outputs.apply-tag }}
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          labels: ${{ github.base_ref }}
+          type: add


### PR DESCRIPTION
Add support to tag pr targeting stable branch matching the simple regex of openwrt-[0-9][0-9].[0-9][0-9]. The tag that will be added will match the pr target branch.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>