### PR TITLE
[21.02] treewide: multiple fixup discovered from CI testing

### DIFF
--- a/package/system/procd/patches/0001-uxc-fix-compilation-error-caused-by-unused-variable.patch
+++ b/package/system/procd/patches/0001-uxc-fix-compilation-error-caused-by-unused-variable.patch
@@ -1,0 +1,36 @@
+From 2ddf0005298e08ba1e358d95be6b826c56a7d1fc Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 29 Nov 2022 16:33:23 +0100
+Subject: [PATCH] uxc: fix compilation error caused by unused variable
+
+Fix compilation error caused by unused verbose variable.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ uxc.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/uxc.c b/uxc.c
+index eb40eb2..b22d838 100644
+--- a/uxc.c
++++ b/uxc.c
+@@ -80,6 +80,8 @@ static struct blob_buf conf;
+ static struct blob_buf state;
+ static struct ubus_context *ctx;
+ 
++static bool verbose = false;
++
+ static int usage(void) {
+ 	printf("syntax: uxc <command> [parameters ...]\n");
+ 	printf("commands:\n");
+@@ -724,7 +726,6 @@ int main(int argc, char **argv)
+ 	char *pidfile = NULL;
+ 	bool autostart = false;
+ 	bool force = false;
+-	bool verbose = false;
+ 	int signal = SIGTERM;
+ 	int c;
+ 
+-- 
+2.37.2
+

--- a/target/linux/layerscape/patches-5.4/820-usb-0009-usb-dwc3-Add-workaround-for-host-mode-VBUS-glitch-wh.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0009-usb-dwc3-Add-workaround-for-host-mode-VBUS-glitch-wh.patch
@@ -64,8 +64,12 @@ Reviewed-by: Peter Chen <peter.chen@nxp.com>
  
 --- a/drivers/usb/dwc3/host.c
 +++ b/drivers/usb/dwc3/host.c
-@@ -11,6 +11,44 @@
+@@ -9,8 +9,48 @@
  
+ #include <linux/platform_device.h>
+ 
++#include "../host/xhci.h"
++
  #include "core.h"
  
 +#define XHCI_HCSPARAMS1		0x4
@@ -109,7 +113,7 @@ Reviewed-by: Peter Chen <peter.chen@nxp.com>
  static int dwc3_host_get_irq(struct dwc3 *dwc)
  {
  	struct platform_device	*dwc3_pdev = to_platform_device(dwc->dev);
-@@ -50,6 +88,13 @@ int dwc3_host_init(struct dwc3 *dwc)
+@@ -50,6 +90,13 @@ int dwc3_host_init(struct dwc3 *dwc)
  	struct platform_device	*dwc3_pdev = to_platform_device(dwc->dev);
  	int			prop_idx = 0;
  


### PR DESCRIPTION
While introducing CI support for 21.02 I notice multiple problem with a target and some package. This fix all of them... Actually it's amazing that procd was broken for some reason? Probably related to the specific external toolchain?
