### PR TITLE
ramips: use default lzma dictionary size for better performance

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -7,7 +7,6 @@ include ./common-tp-link.mk
 
 DEFAULT_SOC := mt7621
 
-KERNEL_DTB += -d21
 DEVICE_VARS += ELECOM_HWNAME LINKSYS_HWNAME
 
 ifdef CONFIG_LINUX_5_10


### PR DESCRIPTION
limit dictionary size patch was introduced to solve the well known "LZMA ERROR 1 - must RESET board to recover" error.
https://github.com/openwrt/openwrt/commit/09b6755946409d8fd8e95fab003f037ae026f04b "ramips: limit dictionary size for lzma compression"

It seems that it has failed recently and we can use lzma loader to fix this error by adding "$(Device/uimage-lzma-loader)". So just remove it to use the default parameter -d24 for a higher compression ratio.

Now 69+(196 in total) devices in mt7621 target use lzma loader.
**Need some feedback.**
