### PR TITLE
ath79: improve support for Netgear NAND Flash devices

### DIFF
--- a/target/linux/ath79/dts/ar9344_netgear_r6100.dts
+++ b/target/linux/ath79/dts/ar9344_netgear_r6100.dts
@@ -181,8 +181,8 @@
 		compatible = "qcom,ath10k";
 		reg = <0x0000 0 0 0 0>;
 
-		nvmem-cells = <&macaddr_caldata_c>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&cal_ath10k>, <&macaddr_caldata_c>;
+		nvmem-cell-names = "calibration", "mac-address";
 	};
 };
 
@@ -201,13 +201,22 @@
 &wmac {
 	status = "okay";
 
-	mtd-cal-data = <&caldata 0x1000>;
+	nvmem-cells = <&cal_ath9k>;
+	nvmem-cell-names = "calibration";
 };
 
 &caldata {
 	compatible = "nvmem-cells";
 	#address-cells = <1>;
 	#size-cells = <1>;
+
+	cal_ath9k: calibration@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	cal_ath10k: calibration@5000 {
+		reg = <0x5000 0x844>;
+	};
 
 	macaddr_caldata_0: macaddr@0 {
 		reg = <0x0 0x6>;

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -230,7 +230,7 @@ define Device/linksys_ea4500-v3
 endef
 TARGET_DEVICES += linksys_ea4500-v3
 
-# fake rootfs is mandatory, pad-offset 129 equals (2 * uimage_header + 0xff)
+# fake rootfs is mandatory, pad-offset 64 equals (1 * uimage_header)
 define Device/netgear_ath79_nand
   DEVICE_VENDOR := NETGEAR
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
@@ -238,15 +238,12 @@ define Device/netgear_ath79_nand
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   IMAGE_SIZE := 25600k
-  KERNEL := kernel-bin | append-dtb | lzma -d20 | \
-	pad-offset $$(KERNEL_SIZE) 129 | uImage lzma | \
-	append-string -e '\xff' | \
-	append-uImage-fakehdr filesystem $$(UIMAGE_MAGIC)
-  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma -d20 | uImage lzma
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma | \
+	pad-offset $$(BLOCKSIZE) 64 | append-uImage-fakehdr filesystem $$(UIMAGE_MAGIC)
   IMAGES := sysupgrade.bin factory.img
-  IMAGE/factory.img := append-kernel | append-ubi | netgear-dni | \
-	check-size
-  IMAGE/sysupgrade.bin := sysupgrade-tar | check-size | append-metadata
+  IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
+	append-ubi | check-size | netgear-dni
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   UBINIZE_OPTS := -E 5
 endef
 
@@ -262,8 +259,7 @@ define Device/netgear_pgzng1
   IMAGE_SIZE := 83968k
   PAGESIZE := 2048
   BLOCKSIZE := 128k
-  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma
-  IMAGE/sysupgrade.bin := sysupgrade-tar | check-size | append-metadata
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += netgear_pgzng1
 

--- a/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -18,9 +18,6 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) 1)
 		;;
-	netgear,r6100)
-		caldata_extract "caldata" 0x5000 0x844
-		;;
 	zyxel,emg2926-q10a|\
 	zyxel,nbg6716)
 		caldata_extract "art" 0x5000 0x844


### PR DESCRIPTION
ath79: convert Netgear R6100 radio calibration to nvmem-cells
use nvmem-cells implementation to avoid copying art calibration data to rootfs.

ath79: optimize the firmware recipe for Netgear NAND devices
1. Drop useless character '0xff' before fake filesystem header.
2. Reduce useless padding to shrink the size of the sysupgrade image.
3. Do not check the size of sysupgrade image. It does not make sense to check the size of a compressed package.
4. Do not take the size of netgear header into account because it will not be written to Flash.
5. Use the default lzma compression dictionary parameter '-d24' to get better performance.