### PR TITLE
mvebu: switch default kernel to 5.15

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3 
 
       - name: Set lower case owner name
         id: lower_owner

--- a/target/linux/mvebu/Makefile
+++ b/target/linux/mvebu/Makefile
@@ -9,8 +9,7 @@ BOARDNAME:=Marvell EBU Armada
 FEATURES:=fpu usb pci pcie gpio nand squashfs ramdisk boot-part rootfs-part legacy-sdcard targz
 SUBTARGETS:=cortexa9 cortexa53 cortexa72
 
-KERNEL_PATCHVER:=5.10
-KERNEL_TESTING_PATCHVER:=5.15
+KERNEL_PATCHVER:=5.15
 
 include $(INCLUDE_DIR)/target.mk
 


### PR DESCRIPTION
In light of https://github.com/openwrt/openwrt/issues/11077, switch mvebu to 5.15 which has been the testing kernel on this target since April - over half a year.

Run-tested on the following subtargets:
* cortexa9 (Turris Omnia - 03f41b1eb2f15ab06d5800274be6a67c64e2a629)
* cortexa72 (MikroTik RB5009UG+S+IN)

Signed-off-by: Stijn Segers <foss@volatilesystems.org>