### PR TITLE
meta: add issue template for bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,6 +11,8 @@ assignees: ''
 
 Version: release/commit hash
 Device: target/subtarget/profile
+- [ ] Downloaded image
+- [ ] Self built image
 
 > A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+
+Version: release/commit hash
+Device: target/subtarget/profile
+
+> A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+> Steps to reproduce the behavior
+
+**Expected behavior**
+
+> A clear and concise description of what you expected to happen.
+
+**Additional context**
+
+> Add any other context about the problem here.


### PR DESCRIPTION
This tempalte automatically adds the `bug` label and gives the reporter some ideas what to include in the error message.

Signed-off-by: Paul Spooren <mail@aparcar.org>