### PR TITLE
build: fix incorrect initramfs (bzip2, gzip) compression

### DIFF
--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -178,7 +178,7 @@ else
 endif
 	$(if $(SOURCE_DATE_EPOCH),touch -hcd "@$(SOURCE_DATE_EPOCH)" $(KERNEL_BUILD_DIR)/initrd.cpio)
 	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_BZIP2),$(STAGING_DIR_HOST)/bin/bzip2 -9 -c < $(KERNEL_BUILD_DIR)/initrd.cpio > $(KERNEL_BUILD_DIR)/initrd.cpio.bzip2)
-	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_GZIP),gzip -n -f -S .gzip -9n $(KERNEL_BUILD_DIR)/initrd.cpio)
+	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_GZIP),$(STAGING_DIR_HOST)/bin/libdeflate-gzip -n -f -S .gzip -12 $(KERNEL_BUILD_DIR)/initrd.cpio)
 	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZ4),$(STAGING_DIR_HOST)/bin/lz4c -l -c1 -fz --favor-decSpeed $(KERNEL_BUILD_DIR)/initrd.cpio)
 	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZMA),$(STAGING_DIR_HOST)/bin/lzma e -lc1 -lp2 -pb2 $(KERNEL_BUILD_DIR)/initrd.cpio $(KERNEL_BUILD_DIR)/initrd.cpio.lzma)
 	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZO),$(STAGING_DIR_HOST)/bin/lzop -9 -f $(KERNEL_BUILD_DIR)/initrd.cpio)

--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -177,7 +177,7 @@ else
 	( cd $(TARGET_DIR); find . | LC_ALL=C sort | $(STAGING_DIR_HOST)/bin/cpio --reproducible -o -H newc -R 0:0 > $(KERNEL_BUILD_DIR)/initrd.cpio )
 endif
 	$(if $(SOURCE_DATE_EPOCH),touch -hcd "@$(SOURCE_DATE_EPOCH)" $(KERNEL_BUILD_DIR)/initrd.cpio)
-	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_BZIP2),bzip2 -9 -c < $(KERNEL_BUILD_DIR)/initrd.cpio > $(KERNEL_BUILD_DIR)/initrd.cpio.bzip2)
+	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_BZIP2),$(STAGING_DIR_HOST)/bin/bzip2 -9 -c < $(KERNEL_BUILD_DIR)/initrd.cpio > $(KERNEL_BUILD_DIR)/initrd.cpio.bzip2)
 	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_GZIP),gzip -n -f -S .gzip -9n $(KERNEL_BUILD_DIR)/initrd.cpio)
 	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZ4),$(STAGING_DIR_HOST)/bin/lz4c -l -c1 -fz --favor-decSpeed $(KERNEL_BUILD_DIR)/initrd.cpio)
 	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZMA),$(STAGING_DIR_HOST)/bin/lzma e -lc1 -lp2 -pb2 $(KERNEL_BUILD_DIR)/initrd.cpio $(KERNEL_BUILD_DIR)/initrd.cpio.lzma)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -20,6 +20,9 @@ endif
 ifneq ($(CONFIG_SDK)$(CONFIG_PACKAGE_kmod-b43)$(CONFIG_BRCMSMAC_USE_FW_FROM_WL),)
   BUILD_B43_TOOLS = y
 endif
+ifneq ($(CONFIG_SDK)$(CONFIG_TARGET_INITRAMFS_COMPRESSION_BZIP2),)
+  BUILD_BZIP2_TOOLS = y
+endif
 ifneq ($(CONFIG_SDK)$(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZ4),)
   BUILD_LZ4_TOOLS = y
 endif
@@ -64,8 +67,8 @@ tools-y += sstrip
 tools-y += zip
 tools-y += zlib
 tools-y += zstd
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS),y) += liblzo
 tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(BUILD_B43_TOOLS),y) += b43-tools
+tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(BUILD_BZIP2_TOOLS),y) += bzip2
 tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(BUILD_ISL),y) += isl
 tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(BUILD_LZ4_TOOLS),y) += lz4
 tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(BUILD_LZO_TOOLS),y) += lzop

--- a/tools/bzip2/Makefile
+++ b/tools/bzip2/Makefile
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2022 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bzip2
+PKG_VERSION:=1.0.8
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://sourceware.org/pub/bzip2
+PKG_HASH:=ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269
+
+PKG_LICENSE:=bzip2-1.0.8
+PKG_LICENSE_FILES:=LICENSE
+PKG_CPE_ID:=cpe:/a:bzip:bzip2
+
+HOST_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/host-build.mk
+
+HOSTCC := $(HOSTCC_NOCACHE)
+HOST_CFLAGS += $(HOST_FPIC)
+
+HOST_MAKE_FLAGS+= \
+	CFLAGS="$(HOST_CFLAGS)" \
+	LDFLAGS="$(HOST_LDFLAGS)" \
+	ENABLE_BIN_SHARED=1 \
+	ENABLE_BIN_STATIC=0 \
+	ENABLE_LIB_SHARED=1 \
+	ENABLE_LIB_STATIC=1 \
+	ENABLE_DEV=1 \
+	ENABLE_DOCS=1 \
+	ENABLE_TESTS=0 \
+	PREFIX="$(HOST_BUILD_PREFIX)"
+
+define Host/Configure
+endef
+
+define Host/Uninstall
+	$(call Host/Compile/Default,uninstall)
+	$(call Host/Compile/Default,clean)
+endef
+
+define Host/Clean
+endef
+
+$(eval $(call HostBuild))

--- a/tools/bzip2/patches/020-no-utime.patch
+++ b/tools/bzip2/patches/020-no-utime.patch
@@ -1,0 +1,27 @@
+--- a/bzip2.c
++++ b/bzip2.c
+@@ -69,7 +69,6 @@
+ #if BZ_UNIX
+ #   include <fcntl.h>
+ #   include <sys/types.h>
+-#   include <utime.h>
+ #   include <unistd.h>
+ #   include <sys/stat.h>
+ #   include <sys/times.h>
+@@ -1051,12 +1050,12 @@ void applySavedTimeInfoToOutputFile ( Ch
+ {
+ #  if BZ_UNIX
+    IntNative      retVal;
+-   struct utimbuf uTimBuf;
++   struct timespec uTimBuf[2] = {};
+ 
+-   uTimBuf.actime = fileMetaInfo.st_atime;
+-   uTimBuf.modtime = fileMetaInfo.st_mtime;
++   uTimBuf[0].tv_sec = fileMetaInfo.st_atime;
++   uTimBuf[1].tv_sec = fileMetaInfo.st_mtime;
+ 
+-   retVal = utime ( dstName, &uTimBuf );
++   retVal = utimensat ( AT_FDCWD, dstName, uTimBuf , 0 );
+    ERROR_IF_NOT_ZERO ( retVal );
+ #  endif
+ }

--- a/tools/bzip2/patches/021-merge-and-improve-makefiles.patch
+++ b/tools/bzip2/patches/021-merge-and-improve-makefiles.patch
@@ -1,0 +1,401 @@
+--- a/bzip2.c
++++ b/bzip2.c
+@@ -54,7 +54,7 @@
+ #include <math.h>
+ #include <errno.h>
+ #include <ctype.h>
+-#include "bzlib.h"
++#include <bzlib.h>
+ 
+ #define ERROR_IF_EOF(i)       { if ((i) == EOF)  ioError(); }
+ #define ERROR_IF_NOT_ZERO(i)  { if ((i) != 0)    ioError(); }
+--- a/bzlib_private.h
++++ b/bzlib_private.h
+@@ -30,7 +30,7 @@
+ #include <string.h>
+ #endif
+ 
+-#include "bzlib.h"
++#include <bzlib.h>
+ 
+ 
+ 
+--- a/Makefile
++++ b/Makefile
+@@ -21,11 +21,38 @@
+ LDFLAGS=
+ 
+ BIGFILES=-D_FILE_OFFSET_BITS=64
+-CFLAGS=-Wall -Winline -O2 -g $(BIGFILES)
++CFLAGS_COMMON=-Wall -Winline -O2 -g $(BIGFILES) -I.
++CFLAGS_NOPIC=$(filter-out -O%,$(CFLAGS)) $(CFLAGS_COMMON)
++CFLAGS_PIC=$(filter-out -O%,$(CFLAGS)) -fpic -fPIC $(CFLAGS_COMMON)
+ 
+ # Where you want it installed when you do 'make install'
+-PREFIX=/usr/local
+-
++PREFIX?=/usr/local
++ENABLE_BIN_STATIC?=1
++ENABLE_BIN_SHARED?=1
++ENABLE_LIB_STATIC?=1
++ENABLE_LIB_SHARED?=1
++ENABLE_DEV?=1
++ENABLE_DOCS?=1
++ENABLE_TESTS?=1
++
++ifeq ($(ENABLE_BIN_STATIC),1)
++  ENABLE_BIN=1
++  ifneq ($(ENABLE_LIB_STATIC),1)
++    ENABLE_LIB_STATIC=1
++  endif
++endif
++ifeq ($(ENABLE_BIN_SHARED),1)
++  ENABLE_BIN=1
++  ifneq ($(ENABLE_LIB_SHARED),1)
++    ENABLE_LIB_STATIC=1
++  endif
++endif
++ifeq ($(ENABLE_LIB_STATIC),1)
++  ENABLE_LIB=1
++endif
++ifeq ($(ENABLE_LIB_SHARED),1)
++  ENABLE_LIB=1
++endif
+ 
+ OBJS= blocksort.o  \
+       huffman.o    \
+@@ -35,15 +62,38 @@
+       decompress.o \
+       bzlib.o
+ 
+-all: libbz2.a bzip2 bzip2recover test
+-
+-bzip2: libbz2.a bzip2.o
+-	$(CC) $(CFLAGS) $(LDFLAGS) -o bzip2 bzip2.o -L. -lbz2
++TGTS_all:=
++TGTS_bzip2:=bzip2.o
++TGTS_check:=
++TGTS_install:=
++ifeq ($(ENABLE_LIB),1)
++  TGTS_all+=libbz2
++  TGTS_bzip2+=libbz2
++endif
++ifeq ($(ENABLE_BIN),1)
++  TGTS_all+=bzip2 bzip2recover
++  TGTS_install+=bzip2 bzip2recover
++endif
++ifeq ($(ENABLE_TESTS),1)
++  TGTS_all+=test
++  TGTS_check+=test
++endif
++ 
++all: $(TGTS_all)
++
++bzip2: $(TGTS_bzip2)
++ifeq ($(ENABLE_BIN_STATIC),1)
++	$(CC) $(CFLAGS_NOPIC) $(LDFLAGS) -o bzip2 bzip2.o -L. -lbz2
++endif
++ifeq ($(ENABLE_BIN_SHARED),1)
++	$(CC) $(CFLAGS_PIC) -o bzip2-shared bzip2.o libbz2.so.1.0
++endif
+ 
+ bzip2recover: bzip2recover.o
+-	$(CC) $(CFLAGS) $(LDFLAGS) -o bzip2recover bzip2recover.o
++	$(CC) $(CFLAGS_NOPIC) $(LDFLAGS) -o bzip2recover bzip2recover.o
+ 
+-libbz2.a: $(OBJS)
++libbz2: $(OBJS)
++ifeq ($(ENABLE_LIB_STATIC),1)
+ 	rm -f libbz2.a
+ 	$(AR) cq libbz2.a $(OBJS)
+ 	@if ( test -f $(RANLIB) -o -f /usr/bin/ranlib -o \
+@@ -51,8 +101,18 @@
+ 		echo $(RANLIB) libbz2.a ; \
+ 		$(RANLIB) libbz2.a ; \
+ 	fi
++endif
++ifeq ($(ENABLE_LIB_SHARED),1)
++	$(CC) -shared -Wl,-soname -Wl,libbz2.so.1.0 $(LDFLAGS) -o libbz2.so.1.0.8 $(OBJS)
++	rm -f libbz2.so.1.0
++	rm -f libbz2.so.1
++	rm -f libbz2.so
++	ln -s libbz2.so.1.0.8 libbz2.so.1.0
++	ln -s libbz2.so.1.0 libbz2.so.1
++	ln -s libbz2.so.1 libbz2.so
++endif
+ 
+-check: test
++check: $(TGTS_check)
+ test: bzip2
+ 	@cat words1
+ 	./bzip2 -1  < sample1.ref > sample1.rb2
+@@ -69,69 +129,153 @@
+ 	cmp sample3.tst sample3.ref
+ 	@cat words3
+ 
+-install: bzip2 bzip2recover
++install: $(TGTS_install)
++ifeq ($(ENABLE_BIN),1)
+ 	if ( test ! -d $(PREFIX)/bin ) ; then mkdir -p $(PREFIX)/bin ; fi
++endif
++ifeq ($(ENABLE_LIB),1)
+ 	if ( test ! -d $(PREFIX)/lib ) ; then mkdir -p $(PREFIX)/lib ; fi
++endif
++ifeq ($(ENABLE_DEV),1)
++	if ( test ! -d $(PREFIX)/include ) ; then mkdir -p $(PREFIX)/include ; fi
++endif
++ifeq ($(ENABLE_DOCS),1)
+ 	if ( test ! -d $(PREFIX)/man ) ; then mkdir -p $(PREFIX)/man ; fi
+ 	if ( test ! -d $(PREFIX)/man/man1 ) ; then mkdir -p $(PREFIX)/man/man1 ; fi
+-	if ( test ! -d $(PREFIX)/include ) ; then mkdir -p $(PREFIX)/include ; fi
++endif
++ifeq ($(ENABLE_BIN),1)
++  ifeq ($(ENABLE_BIN_STATIC),1)
+ 	cp -f bzip2 $(PREFIX)/bin/bzip2
+-	cp -f bzip2 $(PREFIX)/bin/bunzip2
+-	cp -f bzip2 $(PREFIX)/bin/bzcat
++	chmod a+rx $(PREFIX)/bin/bzip2
++  endif
++  ifeq ($(ENABLE_BIN_SHARED),1)
++    ifeq ($(ENABLE_BIN_STATIC),1)
++	cp -f bzip2-shared $(PREFIX)/bin/bzip2-shared
++	chmod a+rx $(PREFIX)/bin/bzip2-shared
++    else
++	cp -f bzip2-shared $(PREFIX)/bin/bzip2
++    endif
++  endif
++	rm -f $(PREFIX)/bin/bunzip2
++	rm -f $(PREFIX)/bin/bzcat
++	( cd $(PREFIX)/bin && ln -s bzip2 bunzip2 )
++	( cd $(PREFIX)/bin && ln -s bzip2 bzcat )
++	rm -f $(PREFIX)/bin/bunzip2-shared
++	rm -f $(PREFIX)/bin/bzcat-shared
++  ifeq ($(ENABLE_BIN_SHARED),1)
++    ifeq ($(ENABLE_BIN_STATIC),1)
++	( cd $(PREFIX)/bin && ln -s bzip2-shared bunzip2-shared )
++	( cd $(PREFIX)/bin && ln -s bzip2-shared bzcat-shared )
++    endif
++  endif
+ 	cp -f bzip2recover $(PREFIX)/bin/bzip2recover
+-	chmod a+x $(PREFIX)/bin/bzip2
+-	chmod a+x $(PREFIX)/bin/bunzip2
+-	chmod a+x $(PREFIX)/bin/bzcat
+-	chmod a+x $(PREFIX)/bin/bzip2recover
+-	cp -f bzip2.1 $(PREFIX)/man/man1
+-	chmod a+r $(PREFIX)/man/man1/bzip2.1
+-	cp -f bzlib.h $(PREFIX)/include
+-	chmod a+r $(PREFIX)/include/bzlib.h
+-	cp -f libbz2.a $(PREFIX)/lib
+-	chmod a+r $(PREFIX)/lib/libbz2.a
++	chmod a+rx $(PREFIX)/bin/bzip2recover
+ 	cp -f bzgrep $(PREFIX)/bin/bzgrep
+-	ln -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzegrep
+-	ln -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzfgrep
+-	chmod a+x $(PREFIX)/bin/bzgrep
++	chmod a+rx $(PREFIX)/bin/bzgrep
++	rm -f $(PREFIX)/bin/bzegrep
++	rm -f $(PREFIX)/bin/bzfgrep
++	( cd $(PREFIX)/bin && ln -s bzgrep bzegrep )
++	( cd $(PREFIX)/bin && ln -s bzgrep bzfgrep )
+ 	cp -f bzmore $(PREFIX)/bin/bzmore
+-	ln -s -f $(PREFIX)/bin/bzmore $(PREFIX)/bin/bzless
+-	chmod a+x $(PREFIX)/bin/bzmore
++	chmod a+rx $(PREFIX)/bin/bzmore
++	rm -f $(PREFIX)/bin/bzless
++	( cd $(PREFIX)/bin && ln -s bzmore bzless )
++	rm -f $(PREFIX)/bin/bzcmp
+ 	cp -f bzdiff $(PREFIX)/bin/bzdiff
+-	ln -s -f $(PREFIX)/bin/bzdiff $(PREFIX)/bin/bzcmp
+-	chmod a+x $(PREFIX)/bin/bzdiff
+-	cp -f bzgrep.1 bzmore.1 bzdiff.1 $(PREFIX)/man/man1
+-	chmod a+r $(PREFIX)/man/man1/bzgrep.1
+-	chmod a+r $(PREFIX)/man/man1/bzmore.1
+-	chmod a+r $(PREFIX)/man/man1/bzdiff.1
++	chmod a+rx $(PREFIX)/bin/bzdiff
++	( cd $(PREFIX)/bin && ln -s bzdiff bzcmp )
++endif
++ifeq ($(ENABLE_DEV),1)
++	cp -f bzlib.h $(PREFIX)/include
++	chmod a+r $(PREFIX)/include/bzlib.h
++endif
++ifeq ($(ENABLE_DOCS),1)
++	cp -f bzip2.1 bzgrep.1 bzmore.1 bzdiff.1 $(PREFIX)/man/man1
+ 	echo ".so man1/bzgrep.1" > $(PREFIX)/man/man1/bzegrep.1
+ 	echo ".so man1/bzgrep.1" > $(PREFIX)/man/man1/bzfgrep.1
+ 	echo ".so man1/bzmore.1" > $(PREFIX)/man/man1/bzless.1
+ 	echo ".so man1/bzdiff.1" > $(PREFIX)/man/man1/bzcmp.1
++	chmod a+r $(PREFIX)/man/man1/bzip2.1
++	chmod a+r $(PREFIX)/man/man1/bzgrep.1
++	chmod a+r $(PREFIX)/man/man1/bzmore.1
++	chmod a+r $(PREFIX)/man/man1/bzdiff.1
++	chmod a+r $(PREFIX)/man/man1/bzegrep.1
++	chmod a+r $(PREFIX)/man/man1/bzfgrep.1
++	chmod a+r $(PREFIX)/man/man1/bzless.1
++	chmod a+r $(PREFIX)/man/man1/bzcmp.1
++endif
++ifeq ($(ENABLE_LIB_SHARED),1)
++	cp -f libbz2.so.1.0.8 $(PREFIX)/lib
++	chmod a+r $(PREFIX)/lib/libbz2.so.1.0.8
++	rm -f $(PREFIX)/lib/libbz2.so.1.0
++	rm -f $(PREFIX)/lib/libbz2.so.1
++	rm -f $(PREFIX)/lib/libbz2.so
++	( cd $(PREFIX)/lib && ln -s libbz2.so.1.0.8 libbz2.so.1.0 )
++	( cd $(PREFIX)/lib && ln -s libbz2.so.1.0 libbz2.so.1 )
++	( cd $(PREFIX)/lib && ln -s libbz2.so.1 libbz2.so )
++endif
++ifeq ($(ENABLE_LIB_STATIC),1)
++	cp -f libbz2.a $(PREFIX)/lib
++	chmod a+r $(PREFIX)/lib/libbz2.a
++endif
++
++uninstall:
++	rm -f $(PREFIX)/bin/bzip2
++	rm -f $(PREFIX)/bin/bzip2-shared
++	rm -f $(PREFIX)/bin/bunzip2
++	rm -f $(PREFIX)/bin/bzcat
++	rm -f $(PREFIX)/bin/bunzip2-shared
++	rm -f $(PREFIX)/bin/bzcat-shared
++	rm -f $(PREFIX)/bin/bzip2recover
++	rm -f $(PREFIX)/bin/bzgrep
++	rm -f $(PREFIX)/bin/bzegrep
++	rm -f $(PREFIX)/bin/bzfgrep
++	rm -f $(PREFIX)/bin/bzmore
++	rm -f $(PREFIX)/bin/bzless
++	rm -f $(PREFIX)/bin/bzdiff
++	rm -f $(PREFIX)/bin/bzcmp
++	rm -f $(PREFIX)/include/bzlib.h
++	rm -f $(PREFIX)/lib/libbz2.so.1.0.8
++	rm -f $(PREFIX)/lib/libbz2.so.1.0
++	rm -f $(PREFIX)/lib/libbz2.so.1
++	rm -f $(PREFIX)/lib/libbz2.so
++	rm -f $(PREFIX)/lib/libbz2.a
++	rm -f $(PREFIX)/man/man1/bzip2.1
++	rm -f $(PREFIX)/man/man1/bzgrep.1
++	rm -f $(PREFIX)/man/man1/bzmore.1
++	rm -f $(PREFIX)/man/man1/bzdiff.1
++	rm -f $(PREFIX)/man/man1/bzegrep.1
++	rm -f $(PREFIX)/man/man1/bzfgrep.1
++	rm -f $(PREFIX)/man/man1/bzless.1
++	rm -f $(PREFIX)/man/man1/bzcmp.1
++	(rmdir $(PREFIX)/bin $(PREFIX)/include $(PREFIX)/lib $(PREFIX)/man/man1 $(PREFIX)/man || true ) 2> /dev/null
+ 
+ clean: 
+-	rm -f *.o libbz2.a bzip2 bzip2recover \
++	rm -f $(OBJS) bzip2.o \
++	libbz2.so.1.0.8 libbz2.so.1.0 libbz2.so.1 libbz2.so \
++	libbz2.a bzip2 bzip2-shared bzip2recover \
+ 	sample1.rb2 sample2.rb2 sample3.rb2 \
+ 	sample1.tst sample2.tst sample3.tst
+ 
+ blocksort.o: blocksort.c
+ 	@cat words0
+-	$(CC) $(CFLAGS) -c blocksort.c
++	$(CC) $(CFLAGS_NOPIC) -c blocksort.c
+ huffman.o: huffman.c
+-	$(CC) $(CFLAGS) -c huffman.c
++	$(CC) $(CFLAGS_NOPIC) -c huffman.c
+ crctable.o: crctable.c
+-	$(CC) $(CFLAGS) -c crctable.c
++	$(CC) $(CFLAGS_NOPIC) -c crctable.c
+ randtable.o: randtable.c
+-	$(CC) $(CFLAGS) -c randtable.c
++	$(CC) $(CFLAGS_NOPIC) -c randtable.c
+ compress.o: compress.c
+-	$(CC) $(CFLAGS) -c compress.c
++	$(CC) $(CFLAGS_NOPIC) -c compress.c
+ decompress.o: decompress.c
+-	$(CC) $(CFLAGS) -c decompress.c
++	$(CC) $(CFLAGS_NOPIC) -c decompress.c
+ bzlib.o: bzlib.c
+-	$(CC) $(CFLAGS) -c bzlib.c
++	$(CC) $(CFLAGS_NOPIC) -c bzlib.c
+ bzip2.o: bzip2.c
+-	$(CC) $(CFLAGS) -c bzip2.c
++	$(CC) $(CFLAGS_NOPIC) -c bzip2.c
+ bzip2recover.o: bzip2recover.c
+-	$(CC) $(CFLAGS) -c bzip2recover.c
++	$(CC) $(CFLAGS_NOPIC) -c bzip2recover.c
+ 
+ 
+ distclean: clean
+@@ -189,7 +333,6 @@
+ 	   $(DISTNAME)/bzmore.1 \
+ 	   $(DISTNAME)/bzgrep \
+ 	   $(DISTNAME)/bzgrep.1 \
+-	   $(DISTNAME)/Makefile-libbz2_so \
+ 	   $(DISTNAME)/bz-common.xsl \
+ 	   $(DISTNAME)/bz-fo.xsl \
+ 	   $(DISTNAME)/bz-html.xsl \
+--- a/Makefile-libbz2_so
++++ b/Makefile-libbz2_so
+@@ -1,59 +0,0 @@
+-
+-# This Makefile builds a shared version of the library, 
+-# libbz2.so.1.0.8, with soname libbz2.so.1.0,
+-# at least on x86-Linux (RedHat 7.2), 
+-# with gcc-2.96 20000731 (Red Hat Linux 7.1 2.96-98).  
+-# Please see the README file for some important info 
+-# about building the library like this.
+-
+-# ------------------------------------------------------------------
+-# This file is part of bzip2/libbzip2, a program and library for
+-# lossless, block-sorting data compression.
+-#
+-# bzip2/libbzip2 version 1.0.8 of 13 July 2019
+-# Copyright (C) 1996-2019 Julian Seward <jseward@acm.org>
+-#
+-# Please read the WARNING, DISCLAIMER and PATENTS sections in the 
+-# README file.
+-#
+-# This program is released under the terms of the license contained
+-# in the file LICENSE.
+-# ------------------------------------------------------------------
+-
+-
+-SHELL=/bin/sh
+-CC=gcc
+-BIGFILES=-D_FILE_OFFSET_BITS=64
+-CFLAGS=-fpic -fPIC -Wall -Winline -O2 -g $(BIGFILES)
+-
+-OBJS= blocksort.o  \
+-      huffman.o    \
+-      crctable.o   \
+-      randtable.o  \
+-      compress.o   \
+-      decompress.o \
+-      bzlib.o
+-
+-all: $(OBJS)
+-	$(CC) -shared -Wl,-soname -Wl,libbz2.so.1.0 -o libbz2.so.1.0.8 $(OBJS)
+-	$(CC) $(CFLAGS) -o bzip2-shared bzip2.c libbz2.so.1.0.8
+-	rm -f libbz2.so.1.0
+-	ln -s libbz2.so.1.0.8 libbz2.so.1.0
+-
+-clean: 
+-	rm -f $(OBJS) bzip2.o libbz2.so.1.0.8 libbz2.so.1.0 bzip2-shared
+-
+-blocksort.o: blocksort.c
+-	$(CC) $(CFLAGS) -c blocksort.c
+-huffman.o: huffman.c
+-	$(CC) $(CFLAGS) -c huffman.c
+-crctable.o: crctable.c
+-	$(CC) $(CFLAGS) -c crctable.c
+-randtable.o: randtable.c
+-	$(CC) $(CFLAGS) -c randtable.c
+-compress.o: compress.c
+-	$(CC) $(CFLAGS) -c compress.c
+-decompress.o: decompress.c
+-	$(CC) $(CFLAGS) -c decompress.c
+-bzlib.o: bzlib.c
+-	$(CC) $(CFLAGS) -c bzlib.c
+--- a/unzcrash.c
++++ b/unzcrash.c
+@@ -30,7 +30,7 @@
+ 
+ #include <stdio.h>
+ #include <assert.h>
+-#include "bzlib.h"
++#include <bzlib.h>
+ 
+ #define M_BLOCK 1000000
+ 


### PR DESCRIPTION
> build: fix incorrect initramfs (bzip2, gzip) compression
> 
> Requires: tools/bzip2, tools/libdeflate
> 
> fix consistency of executables so all of them explicitly use
> `$(STAGING_DIR_HOST)/bin`, and not system-installed ones from the usual
> environment `PATH`; this affects these options:
> * `CONFIG_KERNEL_INITRAMFS_COMPRESSION_BZIP2`
> * `CONFIG_KERNEL_INITRAMFS_COMPRESSION_GZIP`
> 
> those may have worked in the past but only via side effect of having the
> binaries on the host system (and whatever unpredictable version or
> patchset those might be)
>
> use newer libdeflate-gzip for the GZIP support
>
> Fixes: 330bd380e8b6 ("image: allow building FIT and uImage with ramdisk")

This is split from [another initramfs PR](https://github.com/openwrt/openwrt/pull/11381) because this part fixes a past commit.

Also includes a small new fix for missing and incorrect prereq checks, related to gzip but unrelated to initramfs.