### PR TITLE
generic: 5.10 backport Treat IPv4 segment's lowest address as unicast

### DIFF
--- a/target/linux/generic/backport-5.10/615-v5.14-ip-Treat-IPv4-segment-s-lowest-address-as-unicast.patch
+++ b/target/linux/generic/backport-5.10/615-v5.14-ip-Treat-IPv4-segment-s-lowest-address-as-unicast.patch
@@ -1,0 +1,32 @@
+From 94c821c74bf5fe0c25e09df5334a16f98608db90 Mon Sep 17 00:00:00 2001
+From: Seth David Schoen <schoen@loyalty.org>
+Date: Wed, 12 May 2021 21:37:49 -0700
+Subject: [PATCH] ip: Treat IPv4 segment's lowest address as unicast
+
+Treat only the highest, not the lowest, IPv4 address within a local
+subnet as a broadcast address.
+
+Signed-off-by: Seth David Schoen <schoen@loyalty.org>
+Suggested-by: John Gilmore <gnu@toad.com>
+Acked-by: Dave Taht <dave.taht@gmail.com>
+Reviewed-by: David Ahern <dsahern@kernel.org>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+Link: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=94c821c74bf5
+---
+ net/ipv4/fib_frontend.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+--- a/net/ipv4/fib_frontend.c
++++ b/net/ipv4/fib_frontend.c
+@@ -1129,10 +1129,8 @@ void fib_add_ifaddr(struct in_ifaddr *if
+ 				  prefix, ifa->ifa_prefixlen, prim,
+ 				  ifa->ifa_rt_priority);
+ 
+-		/* Add network specific broadcasts, when it takes a sense */
++		/* Add the network broadcast address, when it makes sense */
+ 		if (ifa->ifa_prefixlen < 31) {
+-			fib_magic(RTM_NEWROUTE, RTN_BROADCAST, prefix, 32,
+-				  prim, 0);
+ 			fib_magic(RTM_NEWROUTE, RTN_BROADCAST, prefix | ~mask,
+ 				  32, prim, 0);
+ 			arp_invalidate(dev, prefix | ~mask, false);


### PR DESCRIPTION
Treat only the highest, not the lowest, IPv4 address within a local subnet as a broadcast address, as subnets do not need two different broadcast addresses and networking documentation consistently prefers the highest address as broadcast.

Backport of patch included in Linux 5.14.  Merged in upstream net-next tree in May 2021 at

https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=94c821c74bf5

This eventually frees up one address per subnet. It matches behavior suggested in our Internet-Draft, and also the default behavior of OpenBSD and FreeBSD.

Signed-off-by: Seth David Schoen <schoen@loyalty.org>