### PR TITLE
ipq40xx: re-enable EA6350v3, EA8300, MR8300, WHW01 builds

### DIFF
--- a/package/base-files/files/lib/upgrade/stage2
+++ b/package/base-files/files/lib/upgrade/stage2
@@ -41,7 +41,7 @@ switch_to_ramfs() {
 		pivot_root mount_root reboot sync kill sleep		\
 		md5sum hexdump cat zcat dd tar gzip			\
 		ls basename find cp mv rm mkdir rmdir mknod touch chmod \
-		'[' printf wc grep awk sed cut sort			\
+		'[' printf wc grep awk sed cut sort tail		\
 		mtd partx losetup mkfs.ext4 nandwrite flash_erase	\
 		ubiupdatevol ubiattach ubiblock ubiformat		\
 		ubidetach ubirsvol ubirmvol ubimkvol			\

--- a/package/boot/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-envtools/files/ipq40xx
@@ -63,7 +63,7 @@ linksys,ea8300|\
 linksys,mr8300)
 	ubootenv_add_uci_config "/dev/mtd7" "0x0" "0x40000" "0x20000"
 	;;
-linksys,whw01-v1)
+linksys,whw01)
 	ubootenv_add_uci_config "/dev/mtd6" "0x0" "0x40000" "0x10000"
 	;;
 zyxel,nbg6617)

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -59,6 +59,9 @@ ipq40xx_setup_interfaces()
 	compex,wpj428)
 		ucidef_set_interface_lan "lan1 lan2"
 		;;
+	linksys,whw01)
+		ucidef_set_interface_lan "eth1 eth2"
+		;;
 	glinet,gl-a1300|\
 	glinet,gl-b1300|\
 	mobipromo,cm520-79f)

--- a/target/linux/ipq40xx/base-files/etc/init.d/bootcount
+++ b/target/linux/ipq40xx/base-files/etc/init.d/bootcount
@@ -11,7 +11,7 @@ boot() {
 	linksys,ea6350v3|\
 	linksys,ea8300|\
 	linksys,mr8300|\
-	linksys,whw01-v1)
+	linksys,whw01)
 		mtd resetbc s_env || true
 		;;
 	netgear,wac510)

--- a/target/linux/ipq40xx/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/ipq40xx/base-files/etc/uci-defaults/05_fix-compat-version
@@ -1,6 +1,9 @@
 . /lib/functions.sh
 
 case "$(board_name)" in
+linksys,ea6350v3|\
+linksys,ea8300|\
+linksys,mr8300|\
 ezviz,cs-w3-wd1200g-eup)
 	uci set system.@system[0].compat_version="2.0"
 	uci commit system

--- a/target/linux/ipq40xx/base-files/lib/upgrade/linksys.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/linksys.sh
@@ -47,6 +47,14 @@ linksys_get_target_firmware() {
 	esac
 }
 
+linksys_is_factory_image() {
+	local board=$(board_name)
+	board=${board##*,}
+
+	# check matching footer signature
+	tail -c 256 $1 | grep -q -i "\.LINKSYS\.........${board}"
+}
+
 platform_do_upgrade_linksys() {
 	local magic_long="$(get_magic_long "$1")"
 
@@ -98,5 +106,15 @@ platform_do_upgrade_linksys() {
 	[ "$magic_long" = "27051956" ] && {
 		echo "writing \"$1\" image to \"$part_label\""
 		get_image "$1" | mtd write - "$part_label"
+	}
+
+	[ "$magic_long" = "d00dfeed" ] && {
+		if ! linksys_is_factory_image "$1"; then
+			echo "factory image doesn't match device"
+			return 1
+		fi
+
+		echo "writing \"$1\" factory image to \"$part_label\""
+		get_image "$1" | mtd -e "$part_label" write - "$part_label"
 	}
 }

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -164,7 +164,7 @@ platform_do_upgrade() {
 	linksys,ea6350v3 |\
 	linksys,ea8300 |\
 	linksys,mr8300 |\
-	linksys,whw01-v1)
+	linksys,whw01)
 		platform_do_upgrade_linksys "$1"
 		;;
 	meraki,mr33 |\

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-ea6350v3.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-ea6350v3.dts
@@ -269,17 +269,17 @@
 				label = "kernel";
 				reg = <0x00000000 0x02800000>;
 			};
-			rootfs@300000 {
+			rootfs@500000 {
 				label = "rootfs";
-				reg = <0x00300000 0x02500000>;
+				reg = <0x00500000 0x02300000>;
 			};
 			alt_kernel@2800000 {
 				label = "alt_kernel";
 				reg = <0x02800000 0x02800000>;
 			};
-			alt_rootfs@2b00000 {
+			alt_rootfs@2d00000 {
 				label = "alt_rootfs";
-				reg = <0x02b00000 0x02500000>;
+				reg = <0x02d00000 0x02300000>;
 			};
 			sysdiag@5000000 {
 				label = "sysdiag";

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-whw01.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-whw01.dts
@@ -316,3 +316,21 @@
 	nvmem-cell-names = "pre-calibration";
 	nvmem-cells = <&precal_art_5000>;
 };
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+	label = "eth1";
+};
+
+&swport5 {
+	status = "okay";
+	label = "eth2";
+};

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-whw01.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-whw01.dts
@@ -6,8 +6,8 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	model = "Linksys WHW01 v1";
-	compatible = "linksys,whw01-v1";
+	model = "Linksys WHW01";
+	compatible = "linksys,whw01";
 
 	aliases {
 		serial0 = &blsp1_uart1;

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-xx8300.dtsi
@@ -195,9 +195,9 @@
 				reg = <0x780000 0x5800000>;
 			};
 
-			partition@a80000 {
+			partition@c80000 {
 				label = "rootfs";
-				reg = <0xa80000 0x5500000>;
+				reg = <0xc80000 0x5300000>;
 			};
 
 			partition@5f80000 {
@@ -205,9 +205,9 @@
 				reg = <0x5f80000 0x5800000>;
 			};
 
-			partition@6280000 {
+			partition@6480000 {
 				label = "alt_rootfs";
-				reg = <0x6280000 0x5500000>;
+				reg = <0x6480000 0x5300000>;
 			};
 
 			partition@b780000 {

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -637,74 +637,86 @@ endef
 # Missing DSA Setup
 #TARGET_DEVICES += glinet_gl-s1300
 
+define Device/kernel-size-6350-8300
+	DEVICE_COMPAT_VERSION := 2.0
+	DEVICE_COMPAT_MESSAGE := Kernel partition size must be increased for \
+	this OpenWrt version. Before continuing, you MUST issue either the \
+	command "fw_setenv kernsize 500000" from the OpenWrt command line, \
+	or "setenv kernsize 500000 ; saveenv" from the U-Boot serial console. \
+	Instead of the sysupgrade image, you must then install the OpenWrt \
+	factory image, setting the force flag and wiping the configuration. \
+	(e.g. "sysupgrade -n -F openwrt-squashfs-factory.bin" on command line)
+endef
+
 define Device/linksys_ea6350v3
 	# The Linksys EA6350v3 has a uboot bootloader that does not
 	# support either booting lzma kernel images nor booting UBI
 	# partitions. This uboot, however, supports raw kernel images and
 	# gzipped images.
 	#
-	# As for the time of writing this, the device will boot the kernel
-	# from a fixed address with a fixed length of 3MiB. Also, the
-	# device has a hard-coded kernel command line that requieres the
+	# As configured by the OEM factory, the device will boot the kernel
+	# from a fixed address with a fixed length of 3 MiB. Also, the
+	# device has a hard-coded kernel command line that requires the
 	# rootfs and alt_rootfs to be in mtd11 and mtd13 respectively.
 	# Oh... and the kernel partition overlaps with the rootfs
 	# partition (the same for alt_kernel and alt_rootfs).
 	#
 	# If you are planing re-partitioning the device, you may want to
-	# keep those details in mind:
-	# 1. The kernel adresses you should honor are 0x00000000 and
+	# keep these details in mind:
+	# 1. The kernel addresses you should honor are 0x00000000 and
 	#    0x02800000 respectively.
-	# 2. The kernel size (plus the dtb) cannot exceed 3.00MiB in size.
+	# 2. The kernel size (plus the dtb) cannot exceed 3 MiB in size
+	#    unless the uboot environment variable "kernsize" is increased.
 	# 3. You can use 'zImage', but not a raw 'Image' packed with lzma.
 	# 4. The kernel command line from uboot is harcoded to boot with
 	#    rootfs either in mtd11 or mtd13.
 	$(call Device/FitzImage)
+	$(call Device/kernel-size-6350-8300)
 	DEVICE_VENDOR := Linksys
 	DEVICE_MODEL := EA6350
 	DEVICE_VARIANT := v3
 	SOC := qcom-ipq4018
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
-	KERNEL_SIZE := 3072k
-	IMAGE_SIZE := 37888k
+	KERNEL_SIZE := 5120k
+	IMAGE_SIZE := 35840k
 	UBINIZE_OPTS := -E 5
 	IMAGES += factory.bin
 	IMAGE/factory.bin := append-kernel | append-uImage-fakehdr filesystem | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=EA6350v3
-	DEFAULT := n
 endef
 TARGET_DEVICES += linksys_ea6350v3
 
 define Device/linksys_ea8300
 	$(call Device/FitzImage)
+	$(call Device/kernel-size-6350-8300)
 	DEVICE_VENDOR := Linksys
 	DEVICE_MODEL := EA8300
 	SOC := qcom-ipq4019
-	KERNEL_SIZE := 3072k
-	IMAGE_SIZE := 87040k
+	KERNEL_SIZE := 5120k
+	IMAGE_SIZE := 84992k
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
 	IMAGES += factory.bin
 	IMAGE/factory.bin  := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=EA8300
 	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct ipq-wifi-linksys_ea8300 kmod-usb-ledtrig-usbport
-	DEFAULT := n
 endef
 TARGET_DEVICES += linksys_ea8300
 
 define Device/linksys_mr8300
 	$(call Device/FitzImage)
+	$(call Device/kernel-size-6350-8300)
 	DEVICE_VENDOR := Linksys
 	DEVICE_MODEL := MR8300
 	SOC := qcom-ipq4019
-	KERNEL_SIZE := 3072k
-	IMAGE_SIZE := 87040k
+	KERNEL_SIZE := 5120k
+	IMAGE_SIZE := 84992k
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
 	IMAGES += factory.bin
 	IMAGE/factory.bin  := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=MR8300
 	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct kmod-usb-ledtrig-usbport
-	DEFAULT := n
 endef
 TARGET_DEVICES += linksys_mr8300
 

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -720,25 +720,22 @@ define Device/linksys_mr8300
 endef
 TARGET_DEVICES += linksys_mr8300
 
-define Device/linksys_whw01-v1
+define Device/linksys_whw01
 	$(call Device/FitzImage)
 	DEVICE_VENDOR := Linksys
 	DEVICE_MODEL := WHW01
-	DEVICE_VARIANT := v1
 	KERNEL_SIZE := 6144k
-	IMAGE_SIZE := 28704512  # 28032k minus linksys signature (256-bytes).
+	IMAGE_SIZE := 75776K
 	SOC := qcom-ipq4018
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
 	IMAGES += factory.bin
-	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
-		append-ubi | linksys-image type=WHW01 | pad-to $$$$(PAGESIZE) | \
-		check-size
+	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=WHW01
 	DEVICE_PACKAGES := uboot-envtools kmod-leds-pca963x
 endef
 # Missing DSA Setup
-#TARGET_DEVICES += linksys_whw01-v1
+#TARGET_DEVICES += linksys_whw01
 
 define Device/luma_wrtq-329acn
 	$(call Device/FitImage)

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -734,8 +734,7 @@ define Device/linksys_whw01
 	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=WHW01
 	DEVICE_PACKAGES := uboot-envtools kmod-leds-pca963x
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += linksys_whw01
+TARGET_DEVICES += linksys_whw01
 
 define Device/luma_wrtq-329acn
 	$(call Device/FitImage)


### PR DESCRIPTION
### Description
This series re-enables builds for the Linksys family including EA6350v3, EA8300, MR8300 and WHW01.

The EA6350v3, EA8300, and MR8300 were disabled because their kernel size exceeded the OEM default kernel partition size. Enabling their builds and simplifying the flashing process involved:
1. Re-partition to increase kernel size from 3 MB to 5MB.
2. Add compatibility checks to force factory image installation when upgrading from older OpenWrt versions.
3. Extend sysupgrade to support flashing factory images (OpenWrt or OEM), so no need for TFTP or OEM GUI.

I've tested these changes on EA6350v3 by upgrading from 22.03.02 to a snapshot with the new DSA and larger 5 MB kernel partition.

The WHW01 was disabled only for lack of DSA support and already includes a 6 MB kernel partition. Changes in the course of enabling builds included:
1. Migrate network configuration to DSA, labeling 2 generic ethernet ports as "eth1" and "eth2".
2. Updating the DTS-defined board name to match online documentation and factory firmware.

These changes have been tested so far with the help of @Nyshan @maxdad.

I would appreciate any further review from ipq40xx experts and help from testers owning any of these devices.

Thanks!

### Testing Summary
Guidance for testing is provided below in https://github.com/openwrt/openwrt/pull/11405#issuecomment-1336614898. Successful installation, testing, and review has been carried out on the devices and by the people listed below.

- [x] EA6350v3: @guidosarducci (me)
- [x] EA8300: @guidosarducci @cybrnook  Untested but identical to MR8300 only with less RAM and different LED config
- [x] MR8300: @badulesia
- [x] WHW01: @Nyshan @maxdad

<br/><br/>
CC: @robimarko @jeffsf @cybrnook  @chunkeey @diizzyy @Ansuel @Nyshan @maxdad

