### PR TITLE
iucode-tool: fix compile error with musl libc and USE_CPUID_DEVICE

### DIFF
--- a/package/system/iucode-tool/patches/001-iucode_tool-add-missing-limits.h-for-USE_CPUID_DEVIC.patch
+++ b/package/system/iucode-tool/patches/001-iucode_tool-add-missing-limits.h-for-USE_CPUID_DEVIC.patch
@@ -1,0 +1,29 @@
+From e1137cdafc97c0a8b2a0717a771823f3c4320087 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 29 Nov 2022 19:37:03 +0100
+Subject: [PATCH] iucode_tool: add missing limits.h for USE_CPUID_DEVICE
+
+If USE_CPUID_DEVICE is enabled, compilation fails for missing define.
+Add the missing include to fix compilation error with USE_CPUID_DEVICE
+define.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ iucode_tool.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/iucode_tool.c b/iucode_tool.c
+index 4bba5db..0246035 100644
+--- a/iucode_tool.c
++++ b/iucode_tool.c
+@@ -19,6 +19,7 @@
+ #include <stdint.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#include <limits.h>
+ #include <fcntl.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+-- 
+2.37.2
+


### PR DESCRIPTION
Add patch to fix compilation error with USE_CPUID_DEVICE enabled and musl used as libc. Musl doesn't add limits.h header by default and this is required if USE_CPUID_DEVICE is used.

The package currently compile because fortify headers include limits.h by default.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

---

Patch has been proposed upstream with https://gitlab.com/iucode-tool/iucode-tool/-/merge_requests/4