### PR TITLE
[22.03] kernel: netconsole: add network console logging support

### DIFF
--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -1469,3 +1469,19 @@ define KernelPackage/wireguard/description
 endef
 
 $(eval $(call KernelPackage,wireguard))
+
+
+define KernelPackage/netconsole
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
+  TITLE:=Network console logging support
+  KCONFIG:=CONFIG_NETCONSOLE \
+	  CONFIG_NETCONSOLE_DYNAMIC=n
+  FILES:=$(LINUX_DIR)/drivers/net/netconsole.ko
+  AUTOLOAD:=$(call AutoProbe,netconsole)
+endef
+
+define KernelPackage/netconsole/description
+  Network console logging support.
+endef
+
+$(eval $(call KernelPackage,netconsole))


### PR DESCRIPTION
Request to backport this feature to OpenWrt 22.03 as it might be sometimes handy.

Cherry-picked from the commit: https://github.com/openwrt/openwrt/commit/488b25f5ac5028923f67e3beade92dab0c2591f1

Quoted from the commit message:
```
Accessing the console on many devices is difficult. netconsole eases debugging on devices that crash
after the network is up.

Reference to the netconsole documentation in upstream Linux: <https://www.kernel.org/doc/html/latest/networking/netconsole.html> |
|netconsole=[+][src-port]@[src-ip]/[<dev>],[tgt-port]@<tgt-ip>/[tgt-macaddr] |
| where
|  +            if present, enable extended console support
|  src-port     source for UDP packets (defaults to 6665)
|  src-ip       source IP to use (interface address)
|  dev          network interface (eth0)
|  tgt-port     port for logging agent (6666)
|  tgt-ip       IP address for logging agent
|  tgt-macaddr  ethernet MAC address for logging agent (broadcast)

OpenWrt specific notes:

OpenWrt's device userspace scripts are attaching the network interface (i.e. eth0) to a (virtual) bridge (br-lan) device. This will cause netconsole to report:
|network logging stopped on interface eth0 as it is joining a master device (and unfortunately the traffic/logs to stop at this point)

As a workaround, the netconsole module can be manually loaded again after the bridge has been setup with:

 insmod netconsole netconsole=@/br-lan,@192.168.1.x/MA:C...

One way of catching errors before the handoff, try to append the /etc/modules.conf file with the following extra line:
 options netconsole netconsole=@/eth0,@192.168.1.x/MA:C...

and install the kmod-netconsole (=y) into the base image.
```