### PR TITLE
[22.03] Remove packages: kmod-rtc-pt7c4338 and kmod-w1-slave-ds2760

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -647,22 +647,6 @@ endef
 
 $(eval $(call KernelPackage,rtc-pcf2127))
 
-define KernelPackage/rtc-pt7c4338
-  SUBMENU:=$(OTHER_MENU)
-  TITLE:=Pericom PT7C4338 RTC support
-  DEFAULT:=m if ALL_KMODS && RTC_SUPPORT
-  DEPENDS:=+kmod-i2c-core
-  KCONFIG:=CONFIG_RTC_DRV_PT7C4338 \
-	CONFIG_RTC_CLASS=y
-  FILES:=$(LINUX_DIR)/drivers/rtc/rtc-pt7c4338.ko
-  AUTOLOAD:=$(call AutoProbe,rtc-pt7c4338)
-endef
-
-define KernelPackage/rtc-pt7c4338/description
- Kernel module for Pericom PT7C4338 i2c RTC chip
-endef
-
-$(eval $(call KernelPackage,rtc-pt7c4338))
 
 define KernelPackage/rtc-rs5c372a
   SUBMENU:=$(OTHER_MENU)

--- a/package/kernel/linux/modules/w1.mk
+++ b/package/kernel/linux/modules/w1.mk
@@ -160,23 +160,6 @@ endef
 $(eval $(call KernelPackage,w1-slave-ds2433))
 
 
-define KernelPackage/w1-slave-ds2760
-  TITLE:=Dallas 2760 battery monitor chip (HP iPAQ & others)
-  KCONFIG:= \
-	CONFIG_W1_SLAVE_DS2760 \
-	CONFIG_W1_SLAVE_DS2433_CRC=n
-  FILES:=$(W1_SLAVES_DIR)/w1_ds2760.ko
-  AUTOLOAD:=$(call AutoProbe,w1_ds2760)
-  $(call AddDepends/w1)
-endef
-
-define KernelPackage/w1-slave-ds2760/description
- Kernel module for 1-wire DS2760 battery monitor chip support
-endef
-
-$(eval $(call KernelPackage,w1-slave-ds2760))
-
-
 define KernelPackage/w1-slave-ds2413
   TITLE:=DS2413 2 Ch. Addressable Switch
   KCONFIG:= \


### PR DESCRIPTION
Backported from the master branch:

[kmod-w1-slave-ds2760: Remove package](https://github.com/openwrt/openwrt/commit/bb78cef49cd2db248fa432775ed3b74e32837768):

> The w1_ds2760.ko driver was merged into the ds2760_battery.ko driver.
The driver was removed and this package was never build any more.
This happened with kernel 4.19.

[kernel: kmod-rtc-pt7c4338: Remove package](https://github.com/openwrt/openwrt/commit/151802ecac628db33a11052abc12a1e062acc146):

> The rtc-pt7c4338.ko was never upstream under this name, the driver was
removed from OpenWrt some years ago, remove the kmod-rtc-pt7c4338
package too.