### PR TITLE
[21.02] build: handle directory with whitespace in AUTOREMOVE clean

### DIFF
--- a/include/host-build.mk
+++ b/include/host-build.mk
@@ -197,8 +197,8 @@ ifndef DUMP
 
     ifneq ($(CONFIG_AUTOREMOVE),)
       host-compile:
-		$(FIND) $(HOST_BUILD_DIR) -mindepth 1 -maxdepth 1 -not '(' -type f -and -name '.*' -and -size 0 ')' | \
-			$(XARGS) rm -rf
+		$(FIND) $(HOST_BUILD_DIR) -mindepth 1 -maxdepth 1 -not '(' -type f -and -name '.*' -and -size 0 ')' -print0 | \
+			$(XARGS) -0 rm -rf
     endif
   endef
 endif

--- a/include/package.mk
+++ b/include/package.mk
@@ -258,8 +258,8 @@ define Build/CoreTargets
   ifneq ($(CONFIG_AUTOREMOVE),)
     compile:
 		-touch -r $(PKG_BUILD_DIR)/.built $(PKG_BUILD_DIR)/.autoremove 2>/dev/null >/dev/null
-		$(FIND) $(PKG_BUILD_DIR) -mindepth 1 -maxdepth 1 -not '(' -type f -and -name '.*' -and -size 0 ')' -and -not -name '.pkgdir' | \
-			$(XARGS) rm -rf
+		$(FIND) $(PKG_BUILD_DIR) -mindepth 1 -maxdepth 1 -not '(' -type f -and -name '.*' -and -size 0 ')' -and -not -name '.pkgdir'  -print0 | \
+			$(XARGS) -0 rm -rf
   endif
 endef
 


### PR DESCRIPTION
Package with whitespace in their build directory are not correctly removed when CONFIG_AUTOREMOVE is enabled. This is caused by xargs that use whitespace as delimiters. To handle this use \0 as the delimiter and set find to use \0 as the delimiter.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
(cherry picked from commit dccee21792b89031bcd801030de403f195d80278)