### PR TITLE
[22.03] CI: minor fixup for container and toolchain selection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,16 +62,18 @@ jobs:
         run: |
           CONTAINER_TAG=latest
           if [ -n "${{ github.base_ref }}" ]; then
-            if echo "${{ github.base_ref }}" | grep -q -E 'openwrt-[0-9][0-9]\.[0-9][0-9]'; then
+            if echo "${{ github.base_ref }}" | grep -q -E '^openwrt-[0-9][0-9]\.[0-9][0-9]$'; then
               CONTAINER_TAG="${{ github.base_ref }}"
             fi
           elif [ ${{ github.ref_type }} == "branch" ]; then
-            if echo "${{ github.ref_name }}" | grep -q -E 'openwrt-[0-9][0-9]\.[0-9][0-9]-'; then
+            if echo "${{ github.ref_name }}" | grep -q -E '^openwrt-[0-9][0-9]\.[0-9][0-9]$'; then
+              CONTAINER_TAG=${{ github.ref_name }}
+            elif echo "${{ github.ref_name }}" | grep -q -E '^openwrt-[0-9][0-9]\.[0-9][0-9]-'; then
               CONTAINER_TAG="$(echo ${{ github.ref_name }} | sed 's/^\(openwrt-[0-9][0-9]\.[0-9][0-9]\)-.*/\1/')"
             fi
           elif [ ${{ github.ref_type }} == "tag" ]; then
-            if echo "${{ github.ref_name }}" | grep -q -E 'v[0-9][0-9]\.[0-9][0-9]\..+'; then
-              CONTAINER_TAG=openwrt-"$(echo ${{ github.ref_name }} | sed 's/v\([0-9][0-9]\.[0-9][0-9]\)\..\+/\1/')"
+            if echo "${{ github.ref_name }}" | grep -q -E '^v[0-9][0-9]\.[0-9][0-9]\..+'; then
+              CONTAINER_TAG=openwrt-"$(echo ${{ github.ref_name }} | sed 's/^v\([0-9][0-9]\.[0-9][0-9]\)\..\+/\1/')"
             fi
           fi
           echo "Tools container to use tools:$CONTAINER_TAG"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,16 +151,18 @@ jobs:
           TOOLCHAIN_PATH=snapshots
 
           if [ -n "${{ github.base_ref }}" ]; then
-            if echo "${{ github.base_ref }}" | grep -q -E 'openwrt-[0-9][0-9]\.[0-9][0-9]'; then
-              major_ver="$(echo ${{ github.base_ref }} | sed 's/openwrt-/v/')"
+            if echo "${{ github.base_ref }}" | grep -q -E '^openwrt-[0-9][0-9]\.[0-9][0-9]$'; then
+              major_ver="$(echo ${{ github.base_ref }} | sed 's/^openwrt-/v/')"
             fi
           elif [ "${{ github.ref_type }}" = "branch" ]; then
-            if echo "${{ github.ref_name }}" | grep -q -E 'openwrt-[0-9][0-9]\.[0-9][0-9]-'; then
-              major_ver="$(echo ${{ github.ref_name }} | sed 's/openwrt-\([0-9][0-9]\.[0-9][0-9]\)-.*/v\1/')"
+            if echo "${{ github.ref_name }}" | grep -q -E '^openwrt-[0-9][0-9]\.[0-9][0-9]$'; then
+              major_ver="$(echo ${{ github.ref_name }} | sed 's/^openwrt-/v/')"
+            elif echo "${{ github.ref_name }}" | grep -q -E '^openwrt-[0-9][0-9]\.[0-9][0-9]-'; then
+              major_ver="$(echo ${{ github.ref_name }} | sed 's/^openwrt-\([0-9][0-9]\.[0-9][0-9]\)-.*/v\1/')"
             fi
           elif [ "${{ github.ref_type }}" = "tag" ]; then
-            if echo "${{ github.ref_name }}" | grep -q -E 'v[0-9][0-9]\.[0-9][0-9]\..+'; then
-              major_ver="$(sed 's/\(v[0-9][0-9]\.[0-9][0-9]\)\..\+/\1/')"
+            if echo "${{ github.ref_name }}" | grep -q -E '^v[0-9][0-9]\.[0-9][0-9]\..+'; then
+              major_ver="$(echo ${{ github.ref_name }} | sed 's/^\(v[0-9][0-9]\.[0-9][0-9]\)\..\+/\1/')"
             fi
           fi
 

--- a/.github/workflows/check-kernel-patches.yml
+++ b/.github/workflows/check-kernel-patches.yml
@@ -39,16 +39,18 @@ jobs:
         run: |
           CONTAINER_TAG=latest
           if [ -n "${{ github.base_ref }}" ]; then
-            if echo "${{ github.base_ref }}" | grep -q -E 'openwrt-[0-9][0-9]\.[0-9][0-9]'; then
+            if echo "${{ github.base_ref }}" | grep -q -E '^openwrt-[0-9][0-9]\.[0-9][0-9]$'; then
               CONTAINER_TAG="${{ github.base_ref }}"
             fi
           elif [ ${{ github.ref_type }} == "branch" ]; then
-            if echo "${{ github.ref_name }}" | grep -q -E 'openwrt-[0-9][0-9]\.[0-9][0-9]-'; then
+            if echo "${{ github.ref_name }}" | grep -q -E '^openwrt-[0-9][0-9]\.[0-9][0-9]$'; then
+              CONTAINER_TAG=${{ github.ref_name }}
+            elif echo "${{ github.ref_name }}" | grep -q -E '^openwrt-[0-9][0-9]\.[0-9][0-9]-'; then
               CONTAINER_TAG="$(echo ${{ github.ref_name }} | sed 's/^\(openwrt-[0-9][0-9]\.[0-9][0-9]\)-.*/\1/')"
             fi
           elif [ ${{ github.ref_type }} == "tag" ]; then
-            if echo "${{ github.ref_name }}" | grep -q -E 'v[0-9][0-9]\.[0-9][0-9]\..+'; then
-              CONTAINER_TAG=openwrt-"$(echo ${{ github.ref_name }} | sed 's/v\([0-9][0-9]\.[0-9][0-9]\)\..\+/\1/')"
+            if echo "${{ github.ref_name }}" | grep -q -E '^v[0-9][0-9]\.[0-9][0-9]\..+'; then
+              CONTAINER_TAG=openwrt-"$(echo ${{ github.ref_name }} | sed 's/^v\([0-9][0-9]\.[0-9][0-9]\)\..\+/\1/')"
             fi
           fi
           echo "Tools container to use tools:$CONTAINER_TAG"

--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -3,12 +3,16 @@ name: Build Kernel
 on:
   pull_request:
     paths:
+      - '.github/workflows/check-kernel-patches.yml'
+      - '.github/workflows/build.yml'
       - '.github/workflows/kernel.yml'
       - 'include/kernel*'
       - 'package/kernel/**'
       - 'target/linux/generic/**'
   push:
     paths:
+      - '.github/workflows/check-kernel-patches.yml'
+      - '.github/workflows/build.yml'
       - '.github/workflows/kernel.yml'
       - 'include/kernel*'
       - 'package/kernel/**'

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -3,6 +3,7 @@ name: Build all core packages
 on:
   pull_request:
     paths:
+      - '.github/workflows/build.yml'
       - '.github/workflows/packages.yml'
       - 'config/**'
       - 'include/**'
@@ -11,6 +12,7 @@ on:
       - 'toolchain/**'
   push:
     paths:
+      - '.github/workflows/build.yml'
       - '.github/workflows/packages.yml'
       - 'config/**'
       - 'include/**'


### PR DESCRIPTION
The current match logic doesn't handle test for push events related to
stable release (example openwrt-22.03) but only fork with the related
prefix (example openwrt-22.03-fixup)

Fix wrong matching and while at it also add extra checks to other
matching (check if the branch name actually start with the requested
prefix)
