### PR TITLE
CI: tools: directly copy prebuilt tools in container

### DIFF
--- a/.github/workflows/Dockerfile.tools
+++ b/.github/workflows/Dockerfile.tools
@@ -1,3 +1,4 @@
 FROM registry.gitlab.com/openwrt/buildbot/buildworker-3.4.1
 
-COPY --chown=buildbot:buildbot tools.tar /tools.tar
+COPY --chown=buildbot staging_dir/host /prebuilt_tools/staging_dir/host
+COPY --chown=buildbot build_dir/host /prebuilt_tools/build_dir/host

--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -61,7 +61,7 @@ jobs:
         if: inputs.generate_prebuilt_artifacts == true
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
-        run: tar --mtime=now -cf tools.tar staging_dir/host build_dir/host
+        run: tar -cf tools.tar staging_dir/host build_dir/host
 
       - name: Upload prebuilt tools
         if: inputs.generate_prebuilt_artifacts == true

--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -61,7 +61,7 @@ jobs:
         if: inputs.generate_prebuilt_artifacts == true
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
-        run: tar --mtime=now -cf tools.tar staging_dir/host build_dir/host dl
+        run: tar --mtime=now -cf tools.tar staging_dir/host build_dir/host
 
       - name: Upload prebuilt tools
         if: inputs.generate_prebuilt_artifacts == true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,16 @@ jobs:
           echo "TARGET=$TARGET" >> "$GITHUB_ENV"
           echo "SUBTARGET=$SUBTARGET" >> "$GITHUB_ENV"
 
+      - name: Prepare prebuilt tools
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: |
+          mkdir -p staging_dir build_dir
+          ln -s /prebuilt_tools/staging_dir/host staging_dir/host
+          ln -s /prebuilt_tools/build_dir/host build_dir/host
+
+          ./scripts/ext-tools.sh --refresh
+
       - name: Update & Install feeds
         if: inputs.include_feeds == true
         shell: su buildbot -c "sh -e {0}"
@@ -220,11 +230,6 @@ jobs:
         run: |
           wget -O - https://downloads.cdn.openwrt.org/${{ env.TOOLCHAIN_PATH }}/targets/${{ env.TARGET }}/${{ env.SUBTARGET }}/${{ env.TOOLCHAIN_FILE }}.tar.xz \
             | tar --xz -xf -
-
-      - name: Extract prebuilt tools
-        shell: su buildbot -c "sh -e {0}"
-        working-directory: openwrt
-        run: ./scripts/ext-tools.sh --tools /tools.tar
 
       - name: Configure testing kernel
         if: inputs.testing == true

--- a/.github/workflows/check-kernel-patches.yml
+++ b/.github/workflows/check-kernel-patches.yml
@@ -84,10 +84,15 @@ jobs:
           echo "TARGET=$TARGET" >> "$GITHUB_ENV"
           echo "SUBTARGET=$SUBTARGET" >> "$GITHUB_ENV"
 
-      - name: Extract prebuilt tools
+      - name: Prepare prebuilt tools
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
-        run: ./scripts/ext-tools.sh --tools /tools.tar
+        run: |
+          mkdir -p staging_dir build_dir
+          ln -sf /prebuilt_tools/staging_dir/host staging_dir/host
+          ln -sf /prebuilt_tools/build_dir/host build_dir/host
+
+          ./scripts/ext-tools.sh --refresh
 
       - name: Configure testing kernel
         if: inputs.testing == true

--- a/.github/workflows/push-containers.yml
+++ b/.github/workflows/push-containers.yml
@@ -70,6 +70,10 @@ jobs:
           name: linux-buildbot-prebuilt-tools
           path: openwrt
 
+      - name: Extract prebuild tools
+        working-directory: openwrt
+        run: tar -xf tools.tar
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/include/host-build.mk
+++ b/include/host-build.mk
@@ -206,5 +206,9 @@ endif
 
 define HostBuild
   $(HostBuild/Core)
-  $(if $(if $(PKG_HOST_ONLY),,$(if $(and $(filter host-%,$(MAKECMDGOALS)),$(PKG_SKIP_DOWNLOAD)),,$(STAMP_PREPARED))),,$(if $(strip $(PKG_SOURCE_URL)),$(call Download,default)))
+  $(if $(if $(PKG_HOST_ONLY),,$(if $(and $(filter host-%,$(MAKECMDGOALS)),$(PKG_SKIP_DOWNLOAD)),,$(STAMP_PREPARED))),,
+	$(if $(and $(CONFIG_AUTOREMOVE), $(wildcard $(HOST_STAMP_INSTALLED), $(wildcard $(HOST_STAMP_BUILT)))),,
+		$(if $(strip $(PKG_SOURCE_URL)),$(call Download,default))
+	)
+  )
 endef

--- a/scripts/ext-tools.sh
+++ b/scripts/ext-tools.sh
@@ -5,7 +5,7 @@ HOST_BUILD_DIR=$(pwd)/"build_dir/host"
 HOST_STAGING_DIR_STAMP=$(pwd)/"staging_dir/host/stamp"
 
 refresh_timestamps() {
-	find "$1" -not -type l -print0 | xargs -0 touch
+	find -H "$1" -not -type l -print0 | xargs -0 touch
 }
 
 extract_prebuilt_tar() {

--- a/scripts/ext-tools.sh
+++ b/scripts/ext-tools.sh
@@ -12,9 +12,7 @@ extract_prebuilt_tar() {
 	tar -xf "$1"
 }
 
-install_prebuilt_tools() {
-	extract_prebuilt_tar "$TOOLS_TAR"
-
+refresh_prebuilt_tools() {
 	if [ ! -d "$HOST_BUILD_DIR" ]; then
 		echo "Can't find Host Build Dir "$HOST_BUILD_DIR"" >&2
 		exit 1
@@ -29,6 +27,14 @@ install_prebuilt_tools() {
 	fi
 
 	refresh_timestamps "$HOST_STAGING_DIR_STAMP"
+
+	return 0
+}
+
+install_prebuilt_tools() {
+	extract_prebuilt_tar "$TOOLS_TAR"
+
+	refresh_prebuilt_tools
 
 	return 0
 }
@@ -63,6 +69,12 @@ while [ -n "$1" ]; do
 			exit $?
 		;;
 
+		--refresh)
+			refresh_prebuilt_tools
+
+			exit $?
+		;;
+
 		-h|--help)
 			me="$(basename "$0")"
 			echo -e "\nUsage:\n"                                            >&2
@@ -81,8 +93,12 @@ while [ -n "$1" ]; do
 			echo -e "  $me --tools {tar}"                                   >&2
 			echo -e "    Install the prebuilt tools present in the passed"  >&2
 			echo -e "    tar and prepare them."                             >&2
-			echo -e "    To correctly use them it's needed to update the."  >&2
+			echo -e "    To correctly use them it's needed to update the"   >&2
 			echo -e "    timestamp of each tools to skip recompilation.\n"  >&2
+			echo -e "  $me --refresh"                                       >&2
+			echo -e "    Refresh timestamps of already extracted prebuilt"  >&2
+			echo -e "    tools to correctly use them and skip"              >&2
+			echo -e "    recompilation.\n"                                  >&2
 			echo -e "  $me --help"                                          >&2
 			echo -e "    Display this help text and exit.\n\n"              >&2
 			exit 1


### PR DESCRIPTION
Directly copy prebuilt tools in container instead of creating an
archieve and extracting it later in other workflows.

Update build workflow to support this new implementation.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

---

Other changes. With AUTOREMOVE enabled if the tool is already build we skip checking if the package has been downloaded. (skipping recompile in the absence of download package)

---

~~Depends on this https://github.com/openwrt/openwrt/pull/11214~~ actually not