### PR TITLE
kernel: add mt7916_eeprom.bin to mt7916-firmware

### DIFF
--- a/package/kernel/mt76/Makefile
+++ b/package/kernel/mt76/Makefile
@@ -477,6 +477,7 @@ define KernelPackage/mt7916-firmware/install
 		$(PKG_BUILD_DIR)/firmware/mt7916_wa.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7916_wm.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7916_rom_patch.bin \
+		$(PKG_BUILD_DIR)/firmware/mt7916_eeprom.bin \
 		$(1)/lib/firmware/mediatek
 endef
 


### PR DESCRIPTION
This was required to bring up the interface on a board without valid flash eeprom data.

Signed-off-by: Tim Chick <tim_chick@hotmail.com>

