### PR TITLE
kernel: ca8210: Fix crash by zero initializing data

### DIFF
--- a/target/linux/generic/pending-5.10/870-ca8210-Fix-crash-by-zero-initializing-data.patch
+++ b/target/linux/generic/pending-5.10/870-ca8210-Fix-crash-by-zero-initializing-data.patch
@@ -1,0 +1,30 @@
+From 1e24c54da257ab93cff5826be8a793b014a5dc9c Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Mon, 21 Nov 2022 01:22:01 +0100
+Subject: ca8210: Fix crash by zero initializing data
+
+The struct cas_control embeds multiple generic SPI structures and we
+have to make sure these structures are initialized to default values.
+This driver does not set all attributes. When using kmalloc before some
+attributes were not initialized and contained random data which caused
+random crashes at bootup.
+
+Fixes: ded845a781a5 ("ieee802154: Add CA8210 IEEE 802.15.4 device driver")
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+Link: https://lore.kernel.org/r/20221121002201.1339636-1-hauke@hauke-m.de
+Signed-off-by: Stefan Schmidt <stefan@datenfreihafen.org>
+---
+ drivers/net/ieee802154/ca8210.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/ieee802154/ca8210.c
++++ b/drivers/net/ieee802154/ca8210.c
+@@ -926,7 +926,7 @@ static int ca8210_spi_transfer(
+ 
+ 	dev_dbg(&spi->dev, "%s called\n", __func__);
+ 
+-	cas_ctl = kmalloc(sizeof(*cas_ctl), GFP_ATOMIC);
++	cas_ctl = kzalloc(sizeof(*cas_ctl), GFP_ATOMIC);
+ 	if (!cas_ctl)
+ 		return -ENOMEM;
+ 

--- a/target/linux/generic/pending-5.15/870-ca8210-Fix-crash-by-zero-initializing-data.patch
+++ b/target/linux/generic/pending-5.15/870-ca8210-Fix-crash-by-zero-initializing-data.patch
@@ -1,0 +1,30 @@
+From 1e24c54da257ab93cff5826be8a793b014a5dc9c Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Mon, 21 Nov 2022 01:22:01 +0100
+Subject: ca8210: Fix crash by zero initializing data
+
+The struct cas_control embeds multiple generic SPI structures and we
+have to make sure these structures are initialized to default values.
+This driver does not set all attributes. When using kmalloc before some
+attributes were not initialized and contained random data which caused
+random crashes at bootup.
+
+Fixes: ded845a781a5 ("ieee802154: Add CA8210 IEEE 802.15.4 device driver")
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+Link: https://lore.kernel.org/r/20221121002201.1339636-1-hauke@hauke-m.de
+Signed-off-by: Stefan Schmidt <stefan@datenfreihafen.org>
+---
+ drivers/net/ieee802154/ca8210.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/ieee802154/ca8210.c
++++ b/drivers/net/ieee802154/ca8210.c
+@@ -927,7 +927,7 @@ static int ca8210_spi_transfer(
+ 
+ 	dev_dbg(&spi->dev, "%s called\n", __func__);
+ 
+-	cas_ctl = kmalloc(sizeof(*cas_ctl), GFP_ATOMIC);
++	cas_ctl = kzalloc(sizeof(*cas_ctl), GFP_ATOMIC);
+ 	if (!cas_ctl)
+ 		return -ENOMEM;
+ 


### PR DESCRIPTION
This fixes crashes at bootup on pistachio.

The patch was send upstream and is o its way into Linus tree. 

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
