### PR TITLE
build: add gzip to prereq-build.mk

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -149,6 +149,9 @@ $(eval $(call SetupHostCommand,stat,Cannot find a file stat utility, \
 	gstat -c%s $(TOPDIR)/Makefile, \
 	stat -c%s $(TOPDIR)/Makefile))
 
+$(eval $(call SetupHostCommand,gzip,Please install 'gzip', \
+	gzip --version </dev/null))
+
 $(eval $(call SetupHostCommand,unzip,Please install 'unzip', \
 	unzip 2>&1 | grep zipfile, \
 	unzip))


### PR DESCRIPTION
> gzip has never been checked for, a system without it would be rare, fix it anyway
> 
> ~~also repair incorrect message about egrep~~

Fairly self-explanatory...

~~Yes, `egrep` usually comes with `grep` but then it would exist after the `grep` check right?  So tell the user what's actually missing, then they can dig into why their OS doesn't have `egrep` but does have `grep`...~~