### PR TITLE
[22.03] mvebu: disable also wrt32x due to broken switch

### DIFF
--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -196,7 +196,6 @@ define Device/linksys_wrt32x
   KERNEL_SIZE := 6144k
   KERNEL := kernel-bin | append-dtb
   SUPPORTED_DEVICES += armada-385-linksys-venom linksys,venom
-  DEFAULT := y
 endef
 TARGET_DEVICES += linksys_wrt32x
 


### PR DESCRIPTION
cc @ynezz 

WRT32x has identical hardware as WRT3200ACM, so handle the devices identically.

Reference to:
* FCC approval: WRT32x is a new name for WRT3200ACM hardware 
   https://fccid.io/Q87-WRT3200ACM#Grant-TCB-5 
   FCC IDENTIFIER: | Q87-WRT3200ACM C2PC: - Adding a new model name: WRT32X;

* Linux switch definition: 
  https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-5.15.y&id=2716777b4f21649fb907b4a4fb96e1c8d0a5ec16 
  MV88E6176 is mostly compatible to MV88E6352 and is documented in the same functional specification. Add support for it.

Fixes: a0bae2fef8 "mvebu: cortexa9: disable devices using broken mv88e6176 switch"

Reference to discussion at a0bae2fef8bdd

