### PR TITLE
[22.03] CI: build: fix use of sdk as toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,6 +266,34 @@ jobs:
             --overwrite-config \
             --config ${{ env.TARGET }}/${{ env.SUBTARGET }}
 
+      - name: Adapt external sdk to external toolchain format
+        if: inputs.build_toolchain == false && steps.parse-toolchain.outputs.toolchain-type == 'external_sdk'
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: |
+          TOOLCHAIN_DIR=${{ env.TOOLCHAIN_FILE }}/staging_dir/$(ls ${{ env.TOOLCHAIN_FILE }}/staging_dir | grep toolchain)
+          TOOLCHAIN_BIN=$TOOLCHAIN_DIR/bin
+          OPENWRT_DIR=$(pwd)
+
+          # Find target name from toolchain info.mk
+          GNU_TARGET_NAME=$(cat $TOOLCHAIN_DIR/info.mk | grep TARGET_CROSS | sed 's/^TARGET_CROSS=\(.*\)-$/\1/')
+
+          cd $TOOLCHAIN_BIN
+
+          # Revert sdk wrapper scripts applied to all the bins
+          for app in $(find . -name "*.bin"); do
+            TARGET_APP=$(echo $app | sed 's/\.\/\.\(.*\)\.bin/\1/')
+            rm $TARGET_APP
+            mv .$TARGET_APP.bin $TARGET_APP
+          done
+
+          # Setup the wrapper script in the sdk toolchain dir simulating an external toolchain build
+          cp $OPENWRT_DIR/target/toolchain/files/wrapper.sh $GNU_TARGET_NAME-wrapper.sh
+          for app in cc gcc g++ c++ cpp ld as ; do
+            [ -f $GNU_TARGET_NAME-$app ] && mv $GNU_TARGET_NAME-$app $GNU_TARGET_NAME-$app.bin
+            ln -sf $GNU_TARGET_NAME-wrapper.sh $GNU_TARGET_NAME-$app
+          done
+
       - name: Configure external toolchain with sdk
         if: inputs.build_toolchain == false && steps.parse-toolchain.outputs.toolchain-type == 'external_sdk'
         shell: su buildbot -c "sh -e {0}"


### PR DESCRIPTION
The toolchain included in a sdk have a different format than an external toolchain tar.

Since sdk is a more integrated setup doesn't use and include wrapper bin that use the external toolchain config and use an alternative and more standard way to include all the toolchain headers.

External toolchain use wrapper.sh to append the configured include header when each tool is called.

Fix the sdk toolchain by reverting their own sdk wrapper scripts and to simulate an external toolchain build copying what is done in the toolchain target makefile.

This handle compilation error and warning caused by not using fortify header on building packages.

Fixes: 006e52545d14 ("CI: build: add support to fallback to sdk for external toolchain")
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
(cherry picked from commit https://github.com/openwrt/openwrt/commit/42f0ab028e2eae0d4e7acf9db7fd68b256f23503)