### PR TITLE
kernel: add kmod-lib-842

### DIFF
--- a/package/kernel/linux/modules/lib.mk
+++ b/package/kernel/linux/modules/lib.mk
@@ -170,6 +170,28 @@ endef
 $(eval $(call KernelPackage,lib-lz4))
 
 
+define KernelPackage/lib-842
+  SUBMENU:=$(LIB_MENU)
+  TITLE:=842 support
+  DEPENDS:=+kmod-crypto-acompress +kmod-crypto-crc32
+  KCONFIG:= \
+	CONFIG_CRYPTO_842 \
+	CONFIG_842_COMPRESS \
+	CONFIG_842_DECOMPRESS
+  FILES:= \
+	$(LINUX_DIR)/crypto/842.ko \
+	$(LINUX_DIR)/lib/842/842_compress.ko \
+	$(LINUX_DIR)/lib/842/842_decompress.ko
+  AUTOLOAD:=$(call AutoProbe,842 842_compress 842_decompress)
+endef
+
+define KernelPackage/lib-842/description
+ Kernel module for 842 compression/decompression support
+endef
+
+$(eval $(call KernelPackage,lib-842))
+
+
 define KernelPackage/lib-raid6
   SUBMENU:=$(LIB_MENU)
   TITLE:=RAID6 algorithm support

--- a/target/linux/generic/config-5.15
+++ b/target/linux/generic/config-5.15
@@ -7562,6 +7562,7 @@ CONFIG_ZONE_DMA=y
 # CONFIG_ZPA2326 is not set
 # CONFIG_ZPOOL is not set
 # CONFIG_ZRAM is not set
+# CONFIG_ZRAM_DEF_COMP_842 is not set
 # CONFIG_ZRAM_DEF_COMP_LZ4 is not set
 # CONFIG_ZRAM_DEF_COMP_LZ4HC is not set
 # CONFIG_ZRAM_DEF_COMP_LZO is not set


### PR DESCRIPTION
> ~~"842" is a compression option~~

> "842" is a compression scheme and this is the software implementation
> which is too slow to really use beyond a proof of concept.  It can be
> selected in ZRAM, ZSWAP, or `fs/pstore`, and is here for completeness.
> In general you need a Power8 or better with 842-in-hardware for it to
> be fast, but other 842-accelerators are emerging.

Tested, the modules build and load, but nothing uses them yet.  ZRAM has an option for it in 5.15, so add that config item.  Not sure if anything uses it in 5.10 at all, but the kmod exists.