### PR TITLE
sdk: trim initial dot at the start of bundeled libraries

### DIFF
--- a/scripts/bundle-libraries.sh
+++ b/scripts/bundle-libraries.sh
@@ -197,14 +197,14 @@ for BIN in "$@"; do
 		RUN="${LDSO#ld-}"; RUN="run-${RUN%%.so*}.sh"
 		REL="$(_relpath "$DIR/lib" "$BIN")"
 
-		_mv "$BIN" "$RUNDIR/.${BIN##*/}.bin"
+		_mv "$BIN" "$RUNDIR/${BIN##*/}.bin"
 
 		cat <<-EOF > "$BIN"
 			#!/usr/bin/env bash
 			dir="\$(dirname "\$0")"
 			export RUNAS_ARG0="\$0"
 			export LD_PRELOAD="\${LD_PRELOAD:+\$LD_PRELOAD:}\$dir/${REL:+$REL/}runas.so"
-			exec "\$dir/${REL:+$REL/}$LDSO" --library-path "\$dir/${REL:+$REL/}" "\$dir/.${BIN##*/}.bin" "\$@"
+			exec "\$dir/${REL:+$REL/}$LDSO" --library-path "\$dir/${REL:+$REL/}" "\$dir/${BIN##*/}.bin" "\$@"
 		EOF
 
 		chmod ${VERBOSE:+-v} 0755 "$BIN"


### PR DESCRIPTION
There is currently an inconsistency between how the sdk and the external toolchain treat bundled libraries.

One append .bin to the tool, the other append . at the start of the file and .bin at the end.

Fix this inconsistency and remove the dot at the start of the bundled library. This is also needed as some CI caching procedure use zip as the archive program and doesn't accept having . at the start of the file.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

---

Some background about this... Currently openwrt-21.02 use sdk as external toolchain. This works if the sdk is not cached on github server but if the cache match, then the already extracted directory is downloaded from cache.

It was found that github trim the starting dot for compatibility reason and this mess our procedure to ""covert"" the sdk to an external toolchain format (done for consistency in how everything is treated...)

So something like this happen when the cache is generated...
.arc-openwrt-linux-gnu-strings.bin --> arc-openwrt-linux-gnu-strings.bin


As said in the commit description there is currently an inconsistency between sdk and external toolchain and I just notice this problem...
Considering they are just bundled bin and they are always called by our wrapper script we should not cause any problem in downstream project (they should never user the bundled bin directly as that will result in misconfiguration and package compiled with the wrong configs). Is this change acceptable? 

Seems a quick and easy way to handle the stupid github renaming file and having consistency with the naming used by the external toolchain that just append .bin to the related tool.

@jow- tagging you hoping you will get positive idea about this.