### PR TITLE
CI: build: skip sdk adapt to external toolchain on cache hit 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,7 +267,7 @@ jobs:
             --config ${{ env.TARGET }}/${{ env.SUBTARGET }}
 
       - name: Adapt external sdk to external toolchain format
-        if: inputs.build_toolchain == false && steps.parse-toolchain.outputs.toolchain-type == 'external_sdk'
+        if: inputs.build_toolchain == false && steps.parse-toolchain.outputs.toolchain-type == 'external_sdk' && steps.cache-external-toolchain.outputs.cache-hit != 'true'
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
         run: |

--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -68,7 +68,6 @@ jobs:
     with:
       target: ${{ matrix.target }}
       build_all_kmods: true
-      include_feeds: true
 
   check-kernel-patches:
     name: Check Kernel patches


### PR DESCRIPTION
On cache hit, skip sdk adapt to external toolchain. This is needed because we
cache the already extracted sdk and that is already adapted to be used
as external toolchain.

Rerunning the adap step will result in the test to fail for missing file
as the file are already got wrapped to the external toolchain format.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

---

Also include a small fixup to speedup kernel tests
