### PR TITLE
uboot-bcm4908: fix build error on GCC >= 10

### DIFF
--- a/package/boot/uboot-bcm4908/patches/101-fix-gcc-10-build-error.patch
+++ b/package/boot/uboot-bcm4908/patches/101-fix-gcc-10-build-error.patch
@@ -1,0 +1,12 @@
+Index: u-boot-2022-03-15-0625aad7/scripts/dtc/dtc-lexer.l
+===================================================================
+--- u-boot-2022-03-15-0625aad7.orig/scripts/dtc/dtc-lexer.l	2022-03-15 14:24:21.000000000 +0100
++++ u-boot-2022-03-15-0625aad7/scripts/dtc/dtc-lexer.l	2022-12-07 18:18:18.469149911 +0100
+@@ -38,7 +38,6 @@
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */


### PR DESCRIPTION
GCC versions 10 and up default to `-fno-common`, causing the build to fail with the following error:

```
/usr/bin/ld: scripts/dtc/dtc-parser.tab.o:(.bss+0x10): multiple definition of `yylloc'; scripts/dtc/dtc-lexer.lex.o:(.bss+0x0): first defined here
```

This patch mirrors the one in uboot-zync (8b870418).

Signed-off-by: Joseph C. Lehner <joseph.c.lehner@gmail.com>