### PR TITLE
ipq40xx: fix usb driver not loaded for GL-A1300

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-gl-a1300.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-gl-a1300.dts
@@ -267,6 +267,14 @@
         pinctrl-names = "default";
 };
 
+&usb2 {
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
 &usb2_hs_phy {
 	status = "okay";
 };


### PR DESCRIPTION
This patch enables USB support for the GL.iNet GL-A1300 
Repair the usb driver startup phase is not loaded

Signed-off-by: Weiping Yang <weiping.yang@gl-inet.com>