### PR TITLE
[22.03] tools/ccache: fix build with musl and gcc 12

### DIFF
--- a/tools/ccache/patches/100-honour-copts.patch
+++ b/tools/ccache/patches/100-honour-copts.patch
@@ -1,6 +1,6 @@
 --- a/src/ccache.cpp
 +++ b/src/ccache.cpp
-@@ -1633,6 +1633,7 @@ calculate_result_and_manifest_key(Contex
+@@ -1738,6 +1738,7 @@ calculate_result_and_manifest_key(Contex
                               "CPLUS_INCLUDE_PATH",
                               "OBJC_INCLUDE_PATH",
                               "OBJCPLUS_INCLUDE_PATH", // clang

--- a/tools/ccache/patches/110-musl-gcc12.patch
+++ b/tools/ccache/patches/110-musl-gcc12.patch
@@ -1,0 +1,32 @@
+From a69bdc87d7a4a7b019c4086cb007a0b48a007f4a Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 25 Aug 2022 12:36:18 -0700
+Subject: [PATCH] fix: Fix build with musl when using GCC 12 (#1145)
+
+(cherry picked from commit bb72cc26bc91bc56567dbef608088a9437f836bb)
+---
+ src/Config.hpp          | 2 ++
+ src/core/Statistics.hpp | 1 +
+ 2 files changed, 3 insertions(+)
+
+--- a/src/Config.hpp
++++ b/src/Config.hpp
+@@ -25,6 +25,8 @@
+ 
+ #include "third_party/nonstd/optional.hpp"
+ 
++#include <sys/types.h>
++
+ #include <cstdint>
+ #include <functional>
+ #include <limits>
+--- a/src/core/Statistics.hpp
++++ b/src/core/Statistics.hpp
+@@ -21,6 +21,7 @@
+ #include <core/StatisticsCounters.hpp>
+ 
+ #include <string>
++#include <ctime>
+ #include <unordered_map>
+ #include <vector>
+ 


### PR DESCRIPTION
This fixes the build of ccache when built on a system with musl and gcc 12. As mentioned in the patch, this is not an issue on glibc systems because they include the headers indirectly.
This is not an issue on master because it has a newer version that has this fix and ccache seems to compile fine as is on OpenWrt 21.02 which has an older version of ccache, so this doesn't have to be backported.