### PR TITLE
build: tools: create Config.in; move enablement logic out of Makefile

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -23,6 +23,8 @@ config HOST_OS_MACOS
 
 source "target/Config.in"
 
+source "tools/Config.in"
+
 source "config/Config-images.in"
 
 source "config/Config-build.in"

--- a/config/Config-devel.in
+++ b/config/Config-devel.in
@@ -58,6 +58,25 @@ menuconfig DEVEL
 
 	config BUILD_ALL_HOST_TOOLS
 		bool "Compile all host tools" if DEVEL
+		select TOOLS_BUILD_7z
+		select TOOLS_BUILD_b43-tools
+		select TOOLS_BUILD_bzip2
+		select TOOLS_BUILD_cbootimage
+		select TOOLS_BUILD_dwarves
+		select TOOLS_BUILD_elftosb-sdimage
+		select TOOLS_BUILD_genext2fs
+		select TOOLS_BUILD_gmp
+		select TOOLS_BUILD_isl
+		select TOOLS_BUILD_kernel2minor
+		select TOOLS_BUILD_liblzo
+		select TOOLS_BUILD_llvm-bpf
+		select TOOLS_BUILD_lz4
+		select TOOLS_BUILD_lzop
+		select TOOLS_BUILD_mold
+		select TOOLS_BUILD_mpc
+		select TOOLS_BUILD_mpfr
+		select TOOLS_BUILD_sparse
+		select TOOLS_BUILD_squashfs3-lzma
 		help
 		  Compile all host host tools even if not needed. This is needed to prepare a
 		  universal precompiled host tools archive to use in another buildroot.

--- a/tools/Config.in
+++ b/tools/Config.in
@@ -1,0 +1,76 @@
+config TOOLS_BUILD_7z
+	bool
+	default y if TARGET_realtek
+
+config TOOLS_BUILD_b43-tools
+	bool
+	default y if SDK || PACKAGE_kmod-b43 || BRCMSMAC_USE_FW_FROM_WL
+	help
+	  Build tools for kmod-b43 and broadcom firmware
+
+config TOOLS_BUILD_bzip2
+	bool
+	default y if SDK || TARGET_INITRAMFS_COMPRESSION_BZIP2
+
+config TOOLS_BUILD_cbootimage
+	bool
+	default y if TARGET_tegra
+
+config TOOLS_BUILD_dwarves
+	bool
+	default y if DWARVES
+
+config TOOLS_BUILD_elftosb-sdimage
+	bool
+	default y if TARGET_mxs
+
+config TOOLS_BUILD_genext2fs
+	bool
+	default y if TARGET_apm821xx || TARGET_gemini
+
+config TOOLS_BUILD_gmp
+	bool
+	default y if !EXTERNAL_TOOLCHAIN
+
+config TOOLS_BUILD_isl
+	bool
+	default y if !EXTERNAL_TOOLCHAIN && GCC_USE_GRAPHITE
+
+config TOOLS_BUILD_kernel2minor
+	bool
+	default y if USES_MINOR
+
+config TOOLS_BUILD_liblzo
+	bool
+
+config TOOLS_BUILD_llvm-bpf
+	bool
+	default y if USE_LLVM_BUILD
+
+config TOOLS_BUILD_lz4
+	bool
+	default y if SDK || TARGET_INITRAMFS_COMPRESSION_LZ4
+
+config TOOLS_BUILD_lzop
+	bool
+	default y if SDK || TARGET_INITRAMFS_COMPRESSION_LZO
+
+config TOOLS_BUILD_mold
+	bool
+	default y if USE_MOLD
+
+config TOOLS_BUILD_mpc
+	bool
+	default y if !EXTERNAL_TOOLCHAIN
+
+config TOOLS_BUILD_mpfr
+	bool
+	default y if !EXTERNAL_TOOLCHAIN
+
+config TOOLS_BUILD_sparse
+	bool
+	default y if USE_SPARSE
+
+config TOOLS_BUILD_squashfs3-lzma
+	bool
+	default y if TARGET_ath79

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -11,25 +11,6 @@ curdir:=tools
 # subdirectories to descend into
 tools-y :=
 
-ifeq ($(CONFIG_EXTERNAL_TOOLCHAIN),)
-  BUILD_TOOLCHAIN := y
-  ifdef CONFIG_GCC_USE_GRAPHITE
-    BUILD_ISL = y
-  endif
-endif
-ifneq ($(CONFIG_SDK)$(CONFIG_PACKAGE_kmod-b43)$(CONFIG_BRCMSMAC_USE_FW_FROM_WL),)
-  BUILD_B43_TOOLS = y
-endif
-ifneq ($(CONFIG_SDK)$(CONFIG_TARGET_INITRAMFS_COMPRESSION_BZIP2),)
-  BUILD_BZIP2_TOOLS = y
-endif
-ifneq ($(CONFIG_SDK)$(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZ4),)
-  BUILD_LZ4_TOOLS = y
-endif
-ifneq ($(CONFIG_SDK)$(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZO),)
-  BUILD_LZO_TOOLS = y
-endif
-
 tools-y += autoconf
 tools-y += autoconf-archive
 tools-y += automake
@@ -70,22 +51,24 @@ tools-y += util-linux
 tools-y += xz
 tools-y += zip
 tools-y += zlib
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS),y) += liblzo
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(BUILD_B43_TOOLS),y) += b43-tools
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(BUILD_BZIP2_TOOLS),y) += bzip2
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(BUILD_ISL),y) += isl
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(BUILD_LZ4_TOOLS),y) += lz4
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(BUILD_LZO_TOOLS),y) += lzop
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(BUILD_TOOLCHAIN),y) += gmp mpc mpfr
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_TARGET_apm821xx)$(CONFIG_TARGET_gemini),y) += genext2fs
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_TARGET_ath79),y) += lzma-old squashfs3-lzma
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_TARGET_mxs),y) += elftosb sdimage
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_TARGET_realtek),y) += 7z
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_TARGET_tegra),y) += cbootimage cbootimage-configs
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USES_MINOR),y) += kernel2minor
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USE_SPARSE),y) += sparse
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USE_LLVM_BUILD),y) += llvm-bpf
-tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USE_MOLD),y) += mold
+tools-$(if $(CONFIG_TOOLS_BUILD_7z),y) += 7z
+tools-$(if $(CONFIG_TOOLS_BUILD_b43-tools),y) += b43-tools
+tools-$(if $(CONFIG_TOOLS_BUILD_bzip2),y) += bzip2
+tools-$(if $(CONFIG_TOOLS_BUILD_cbootimage),y) += cbootimage cbootimage-configs
+tools-$(if $(CONFIG_TOOLS_BUILD_elftosb-sdimage),y) += elftosb sdimage
+tools-$(if $(CONFIG_TOOLS_BUILD_genext2fs),y) += genext2fs
+tools-$(if $(CONFIG_TOOLS_BUILD_gmp),y) += gmp
+tools-$(if $(CONFIG_TOOLS_BUILD_isl),y) += isl
+tools-$(if $(CONFIG_TOOLS_BUILD_kernel2minor),y) += kernel2minor
+tools-$(if $(CONFIG_TOOLS_BUILD_liblzo),y) += liblzo
+tools-$(if $(CONFIG_TOOLS_BUILD_llvm-bpf),y) += llvm-bpf
+tools-$(if $(CONFIG_TOOLS_BUILD_lz4),y) += lz4
+tools-$(if $(CONFIG_TOOLS_BUILD_lzop),y) += lzop
+tools-$(if $(CONFIG_TOOLS_BUILD_mold),y) += mold
+tools-$(if $(CONFIG_TOOLS_BUILD_mpc),y) += mpc
+tools-$(if $(CONFIG_TOOLS_BUILD_mpfr),y) += mpfr
+tools-$(if $(CONFIG_TOOLS_BUILD_sparse),y) += sparse
+tools-$(if $(CONFIG_TOOLS_BUILD_squashfs3-lzma),y) += lzma-old squashfs3-lzma
 
 # builddir dependencies
 $(curdir)/autoconf/compile := $(curdir)/m4/compile
@@ -140,7 +123,7 @@ ifeq ($(HOST_OS),Darwin)
   tools-y += bash
 else
   $(curdir)/dwarves/compile += $(curdir)/elfutils/compile
-  tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_DWARVES),y) += dwarves
+  tools-$(if $(CONFIG_TOOLS_BUILD_dwarves),y) += dwarves
 endif
 
 ifneq ($(CONFIG_CCACHE)$(CONFIG_SDK),)


### PR DESCRIPTION
> `tools/Makefile` is messy and lines are long checking for multiple conditions to enable various tools; create a `tools/Config.in` and make invisible logic items for each conditional tools-package, and adapt the conditions from the Makefile into Config logic, to acheive the same result with much shorter single-condition lines in Makefile
> 
> also rename `BUILD_ALL_HOST_TOOLS` => `TOOLS_BUILD_ALL` to fit improved namespacing of `CONFIG_TOOLS_*` for any host-tools settings, while moving it from its somewhat out-of-place postion in Config-devel
> 
> minor side effect the "Build all host tools" selection changes postions in the DEVEL menu, from somewhere around the middle to the bottom

This is a different tactic to solve most of the problems in #11359 without massive redesign

Also with my development of more host-tools options in #11328, most of the added Config items there magnify the need for a separate `tools/Config.in`