### PR TITLE
ath79: add support for TP-Link CPE605-v1

### DIFF
--- a/target/linux/ath79/dts/ar9344_tplink_cpe605-v1.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe605-v1.dts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_tplink_cpe.dtsi"
+
+/ {
+	model = "TP-Link CPE605 v1";
+	compatible = "tplink,cpe605-v1", "qca,ar9344";
+
+	aliases {
+		led-boot = &led_lan;
+		led-failsafe = &led_lan;
+		led-upgrade = &led_lan;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_lan: lan {
+			label = "green:lan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "green:wlan5g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -18,6 +18,7 @@ glinet,6416|\
 glinet,gl-ar300m-lite|\
 glinet,gl-ar300m16|\
 pcs,cap324|\
+tplink,cpe605-v1|\
 tplink,cpe610-v1|\
 tplink,cpe610-v2|\
 tplink,tl-wa1201-v2)

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -77,6 +77,7 @@ ath79_setup_interfaces()
 	tplink,cpe210-v3|\
 	tplink,cpe510-v2|\
 	tplink,cpe510-v3|\
+	tplink,cpe605-v1|\
 	tplink,cpe610-v1|\
 	tplink,cpe610-v2|\
 	tplink,cpe710-v1|\

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -350,6 +350,16 @@ define Device/tplink_cpe510-v3
 endef
 TARGET_DEVICES += tplink_cpe510-v3
 
+define Device/tplink_cpe605-v1
+  $(Device/tplink-safeloader-okli)
+  SOC := ar9344
+  IMAGE_SIZE := 7680k
+  DEVICE_MODEL := CPE605
+  DEVICE_VARIANT := v1
+  TPLINK_BOARD_ID := CPE605V1
+endef
+TARGET_DEVICES += tplink_cpe605-v1
+
 define Device/tplink_cpe610-v1
   $(Device/tplink-safeloader-okli)
   SOC := ar9344


### PR DESCRIPTION
TP-Link CPE605-v1 is an outdoor wireless CPE for 5 GHz with one Ethernet port based on Atheros AR9344

Specifications:
 - 560/450/225 MHz (CPU/DDR/AHB)
 - 1x 10/100 Mbps Ethernet
 - 64 MB of DDR2 RAM
 - 8 MB of SPI-NOR Flash
 - 23dBi high-gain directional antenna and a dedicated metal reflector
 - Power, LAN, WLAN5G green LEDs
 - 3x green RSSI LEDs

Flashing instructions:
 Flash factory image through stock firmware WEB UI or through TFTP
 To get to TFTP recovery just hold reset button while powering on for
 around 4-5 seconds and release.
 Rename factory image to recovery.bin
 Stock TFTP server IP:192.168.0.100
 Stock device TFTP adress:192.168.0.254

Signed-off-by: Andrew Cameron <apcameron@softhome.net>

This PR is dependent on (https://patchwork.ozlabs.org/project/openwrt/patch/!&!AAAAAAAAAAAYAAAAAAAAAAJNiGDLubtLrZ8GtG8UGkrCgAAAEAAAAPXecoGKnBlChBXJCSaZESUBAAAAAA==@gmail.com/) being accepted first to update the tplinksafeloader code.
