### PR TITLE
wolfssl: fix build with /dev/crypto

### DIFF
--- a/package/libs/wolfssl/patches/001-Fix-enable-devcrypto-build-error.patch
+++ b/package/libs/wolfssl/patches/001-Fix-enable-devcrypto-build-error.patch
@@ -1,0 +1,33 @@
+From dc9f46a3be00b5e82684a158605189d1278e324c Mon Sep 17 00:00:00 2001
+From: Eric Blankenhorn <eric@wolfssl.com>
+Date: Wed, 12 Oct 2022 16:05:17 -0500
+Subject: [PATCH] Fix --enable-devcrypto build error for sys without u_int8_t
+ type
+
+---
+ wolfcrypt/src/port/devcrypto/README.md      | 2 +-
+ wolfcrypt/src/port/devcrypto/wc_devcrypto.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/wolfcrypt/src/port/devcrypto/README.md
++++ b/wolfcrypt/src/port/devcrypto/README.md
+@@ -22,7 +22,7 @@ modprobe cryptodev
+ For default build with all supported features use:
+ 
+ ```
+-./configure --enable-cryptodev
++./configure --enable-devcrypto
+ ```
+ 
+ Or for more control over features used:
+--- a/wolfcrypt/src/port/devcrypto/wc_devcrypto.c
++++ b/wolfcrypt/src/port/devcrypto/wc_devcrypto.c
+@@ -122,7 +122,7 @@ int wc_DevCryptoCreate(WC_CRYPTODEV* ctx
+         case CRYPTO_SHA2_512_HMAC:
+             ctx->sess.cipher = 0;
+             ctx->sess.mac    = type;
+-            ctx->sess.mackey    = (u_int8_t*)key;
++            ctx->sess.mackey    = (byte*)key;
+             ctx->sess.mackeylen = keySz;
+             break;
+ 


### PR DESCRIPTION
Bakcport upstream patch to fix build error when
/dev/crypto enabled.

https://github.com/wolfSSL/wolfssl/commit/dc9f46a3be00b5e82684a158605189d1278e324c

Fixes: #10944