### PR TITLE
lantiq: vr9: include usb driver for fritz 7430

### DIFF
--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -197,7 +197,8 @@ define Device/avm_fritz7430
   DEVICE_MODEL := FRITZ!Box 7430
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-wolfssl fritz-tffs-nand fritz-caldata
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader kmod-usb-dwc2 wpad-basic-wolfssl \
+	fritz-tffs-nand fritz-caldata
 endef
 TARGET_DEVICES += avm_fritz7430
 


### PR DESCRIPTION
> Reported by user: missing driver for USB; add to image definition https://github.com/openwrt/openwrt/issues/11326
> 
> Resolves: #11326

See linked issue for more information.