### PR TITLE
libtracefs: update to 1.6.2

### DIFF
--- a/package/libs/libtracefs/Makefile
+++ b/package/libs/libtracefs/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtracefs
-PKG_VERSION:=1.6.1
+PKG_VERSION:=1.6.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/snapshot/
-PKG_HASH:=215a5182ee7d5a813ff84d290bb8988aa4c04cc16bb837780f61b0f5bf7494ab
+PKG_HASH:=3598ead36660b03cec097bd7e45d900e4c3f7673bba673f5508884477d2d982c
 
 PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
 


### PR DESCRIPTION
378a9dd libtracefs: version 1.6.2
e6daa60 libtracefs: Add unit test to test mounting of tracefs_{tracing,debug}_dir() 32acbbf libtracefs: Have tracefs_{tracing,debug}_dir() mount {tracefs,debugfs} if not mounted
