### PR TITLE
ipq40xx: add support for Netgear EX6200v2

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -101,6 +101,10 @@ netgear,ex6150v2)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:router" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:client" "phy1tpt"
 	;;
+netgear,ex6200v2)                                                                                      
+        ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wlan2g" "phy0radio"                               
+        ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wlan5g" "phy1radio"                               
+        ;; 
 qxwlan,e2600ac-c1 |\
 qxwlan,e2600ac-c2)
 	ucidef_set_led_wlan "wlan2g" "WLAN0" "green:wlan0" "phy0tpt"

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -103,6 +103,9 @@ ipq40xx_setup_interfaces()
 	netgear,srs60)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
+	netgear,ex6200v2)                                               
+                ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"      
+                ;; 
 	openmesh,a42|\
 	openmesh,a62)
 		ucidef_set_interfaces_lan_wan "ethernet2" "ethernet1"

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ex6200v2.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ex6200v2.dts
@@ -1,0 +1,430 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2018, David Bauer <mail@david-bauer.net>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "Netgear EX6200v2";
+	compatible = "netgear,ex6200v2";
+
+	soc {
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+
+	};
+
+	aliases {
+		led-boot = &power_amber;
+		led-failsafe = &power_amber;
+		led-running = &power_green;
+		led-upgrade = &power_amber;
+		label-mac-device = &gmac;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	led_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&tlmm 5 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&tlmm 4 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <0>;
+
+		led_gpio: led_gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <1>;
+			spi-max-frequency = <1000000>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_amber: led-power-amber {
+			label = "amber:power";
+			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		power_green: led-power-green {
+			label = "green:power";
+			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g_green {
+			label = "green:wlan2g";
+			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
+
+		};
+
+		wlan2g_red {
+			label = "red:wlan2g";
+			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
+
+		};
+
+		wlan5g_green {
+			label = "green:wlan5g";
+			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g_red {
+			label = "red:wlan5g";
+			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		usb_green {
+			label = "green:usb";
+			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&usb2_port1>, <&usb3_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+};
+
+&tlmm {
+	serial_pins: serial_pinmux {
+		mux {
+			pins = "gpio60", "gpio61";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		pin {
+			function = "blsp_spi0";
+			pins = "gpio55", "gpio56", "gpio57";
+			drive-strength = <12>;
+			bias-disable;
+		};
+		pin_cs {
+			function = "gpio";
+			pins = "gpio54";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+
+	enable-usb-power {
+		gpio-hog;
+		gpios = <3 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "enable USB power";
+	};	
+};
+&blsp1_spi1 {
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <45000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition0@0 {
+				label = "SBL1";
+				reg = <0x00000000 0x00040000>;
+				read-only;
+			};
+
+			partition1@40000 {
+				label = "MIBIB";
+				reg = <0x00040000 0x00020000>;
+				read-only;
+			};
+
+			partition2@60000 {
+				label = "QSEE";
+				reg = <0x00060000 0x00060000>;
+				read-only;
+			};
+
+			partition3@c0000 {
+				label = "CDT";
+				reg = <0x000c0000 0x00010000>;
+				read-only;
+			};
+			partition4@d0000 {
+				label = "DDRPARAMS";
+				reg = <0x000d0000 0x00010000>;
+				read-only;
+			};
+
+			partition5@E0000 {
+				label = "APPSBLENV";
+				reg = <0x000e0000 0x00010000>;
+				read-only;
+			};
+
+			partition6@F0000 {
+				label = "APPSBL";
+				reg = <0x000f0000 0x00080000>;
+				read-only;
+			};
+
+			partition7@170000 {
+				label = "ART";
+				reg = <0x00170000 0x00010000>;
+				compatible = "nvmem-cells";
+				read-only;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				precal_art_1000: precal@1000 {
+					reg = <0x1000 0x2f20>;
+				};
+
+				precal_art_5000: precal@5000 {
+					reg = <0x5000 0x2f20>;
+				};
+			};
+
+			partition8@180000 {
+				label = "config";
+				reg = <0x00180000 0x00010000>;
+				read-only;
+			};
+			 partition9@190000 {
+				label = "pot";
+				reg = <0x00190000 0x00010000>;
+				read-only;
+			};
+
+			partition10@1a0000 {
+				compatible = "nvmem-cells";
+				label = "dnidata";
+				reg = <0x001a0000 0x00010000>;
+				read-only;
+
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_dnidata_0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_dnidata_c: macaddr@c {
+					reg = <0xc 0x6>;
+				};
+			};
+
+			partition11@1b0000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0x001b0000 0x00e10000>;
+			};
+			
+			partition12@fc0000 {
+				label = "rootfs";
+				reg = <0x00fc0000 0x00aa0000>;
+			};
+
+			partition13@1a60000 {
+				label = "rootfs_data";
+				reg = <0x01a60000 0x00070000>;
+			};
+
+			partition14@1ad0000 {
+				label = "language";
+				reg = <0x01ad0000 0x00040000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+
+	usb@6000000 {
+		usb2_port1: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
+	};
+};
+
+&usb3_dwc {
+	usb3_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport1 {
+	status = "okay";
+
+	label = "lan1";
+};
+
+&swport2 {
+	status = "okay";
+
+	label = "lan2";
+};
+
+&swport3 {
+	status = "okay";
+
+	label = "lan3";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "lan4";
+};
+
+&swport5 {
+	status = "okay";
+
+	label = "lan5";
+};
+
+&pcie0 {
+	status = "okay";
+
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+		
+		wifi@1,0 {
+			compatible = "qcom,ath10k";
+			status = "okay";
+			reg = <0x00010000 0 0 0 0>;
+			ieee80211-freq-limit = <5470000 5875000>;
+			qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+		};
+	};
+};
+
+
+&wifi0 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_1000>, <&macaddr_dnidata_0>;
+};
+
+&wifi1 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_5000>, <&macaddr_dnidata_c>;
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -851,6 +851,19 @@ define Device/netgear_ex6150v2
 endef
 TARGET_DEVICES += netgear_ex6150v2
 
+define Device/netgear_ex6200v2
+        $(call Device/DniImage)
+        SOC := qcom-ipq4018
+        DEVICE_VENDOR := NETGEAR
+        DEVICE_MODEL := EX6200
+        DEVICE_VARIANT := v2
+        DEVICE_DTS_CONFIG := config@4
+        NETGEAR_BOARD_ID := EX6200v2series
+        NETGEAR_HW_ID := 29765285+16+0+256+2x2
+        IMAGE_SIZE := 14400k
+endef
+TARGET_DEVICES += netgear_ex6200v2
+
 define Device/netgear_orbi
 	$(call Device/DniImage)
 	SOC := qcom-ipq4019


### PR DESCRIPTION
Specifications:
SOC:	Qualcomm ARM Quad-Core ARMv7 Processor [410fc075] revision 5 (ARMv7), cr=10c5387d 
RAM:	256 MB Winbond W632GU6KB-12
FLASH:	16 MiB Winbond W25Q128
ETH:	Qualcomm QCA8075
WLAN1:  Qualcomm Atheros QCA4018 2.4GHz 802.11b/g/n/ac 2x2 WLAN2:  Qualcomm Atheros QCA4018 5GHz 802.11n/ac
	2x2
INPUT:  Power, WPS, reset button

LED:	5Ghz Radio, 2.4Ghz Radio, Client, USB
SERIAL:	Header accessible through rectangular cutout in plastic shield.
	VCC, TX, RX, GND
        The Serial setting is 115200-8-N-1.

Tested and working:
 - Ethernet
 - 2.4 GHz WiFi (Correct MAC-address)
 - 5 GHz WiFi (Correct MAC-address)
 - Factory installation from WebIF
 - OpenWRT sysupgrade
 - LEDs
 - USB Port

Not Tested:
-	WPS Button

Install via Web-Interface:
Upload the factory image to the device to the Netgear Web-Interface. The device might asks you to confirm the update a second time due to detecting the OpenWRT firmware as older. The device will automatically reboot after the image is written to flash.

Signed-off-by: Isaac Velez <velezis@outlook.com>
