### PR TITLE
[22.03] umbim: Allow roaming and partner connections

### DIFF
--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -14,6 +14,8 @@ proto_mbim_init_config() {
 	proto_config_add_string apn
 	proto_config_add_string pincode
 	proto_config_add_string delay
+	proto_config_add_boolean allow_roaming
+	proto_config_add_boolean allow_partner
 	proto_config_add_string auth
 	proto_config_add_string username
 	proto_config_add_string password
@@ -25,8 +27,8 @@ _proto_mbim_setup() {
 	local tid=2
 	local ret
 
-	local device apn pincode delay $PROTO_DEFAULT_OPTIONS
-	json_get_vars device apn pincode delay auth username password $PROTO_DEFAULT_OPTIONS
+	local device apn pincode delay allow_roaming allow_partner $PROTO_DEFAULT_OPTIONS
+	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner $PROTO_DEFAULT_OPTIONS
 
 	[ -n "$ctl_device" ] && device=$ctl_device
 
@@ -108,14 +110,31 @@ _proto_mbim_setup() {
 	tid=$((tid + 1))
 
 	echo "mbim[$$]" "Register with network"
-	umbim $DBG -n -t $tid -d $device registration || {
-		echo "mbim[$$]" "Subscriber registration failed"
+	connected=0
+	umbim $DBG -n -t $tid -d $device registration
+	reg_status=$?
+	case $reg_status in
+		0)	echo "mbim[$$]" "Registered in home mode"
+			tid=$((tid + 1))
+			connected=1;;
+		4)	if [ "$allow_roaming" = "1" ]; then
+				echo "mbim[$$]" "Registered in roaming mode"
+				tid=$((tid + 1))
+				connected=1
+			fi;;
+		5) 	if [ "$allow_partner" = "1" ]; then
+				echo "mbim[$$]" "Registered in partner mode"
+				tid=$((tid + 1))
+				connected=1
+			fi;;
+	esac
+	if [ $connected -ne 1 ]; then
+		echo "mbim[$$]" "Subscriber registration failed (code $reg_status)"
 		tid=$((tid + 1))
 		umbim $DBG -t $tid -d "$device" disconnect
 		proto_notify_error "$interface" NO_REGISTRATION
 		return 1
-	}
-	tid=$((tid + 1))
+	fi
 
 	echo "mbim[$$]" "Attach to network"
 	umbim $DBG -n -t $tid -d $device attach || {


### PR DESCRIPTION
Allow registration if the SIM is roaming or partner mode, by adding two new options to the protocol.

Until now, such registration failed because umbim returns exit codes 4 and 5 for such situations.

Signed-off-by: Julio Gonzalez Gil <git@juliogonzalez.es>

Port of #10456, fixes #8369 for 22.03