### PR TITLE
ramips: improve support for H3C TX180x series and SIM SIMAX1800T

### DIFF
--- a/target/linux/ramips/dts/mt7621_h3c_tx180x.dtsi
+++ b/target/linux/ramips/dts/mt7621_h3c_tx180x.dtsi
@@ -16,6 +16,7 @@
 
 	chosen {
 		bootargs = "console=ttyS0,115200";
+		bootargs-override = "console=ttyS0,115200";
 	};
 
 	keys {
@@ -139,6 +140,13 @@
 
 &pcie2 {
 	status = "disabled";
+};
+
+&state_default {
+	gpio {
+		groups = "jtag";
+		function = "gpio";
+	};
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_haier-sim_wr1800k.dtsi
+++ b/target/linux/ramips/dts/mt7621_haier-sim_wr1800k.dtsi
@@ -16,6 +16,7 @@
 	};
 
 	chosen {
+		bootargs = "console=ttyS0,115200";
 		bootargs-override = "console=ttyS0,115200";
 	};
 


### PR DESCRIPTION
This PR include these tiny improvements:

For H3C TX180x series devices
1. Explicitly declare gpio pin groups to ensure that gpio works properly.
2. Override bootargs in device tree to avoid modifying u-boot envs during initial installation.

For SIM SIMAX1800T & Haier HAR-20S2U1
1. Use `ARTIFACTS` to build factory image. This change allows users to generate initramfs factory image using OpenWrt ImageBuilder.
2. Override the default bootargs property defined in "mt7621.dtsi". Although we use the "bootargs-override" property to set bootargs, the default "bootargs" property will still be written into the device tree, so it is better to override it.