### PR TITLE
bcm27xx: bcm2711: add kmod-r8169 + dependencies

### DIFF
--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -163,7 +163,11 @@ define Device/rpi-4
 	cypress-firmware-43455-sdio \
 	brcmfmac-nvram-43455-sdio \
 	kmod-brcmfmac wpad-basic-wolfssl \
-	kmod-usb-net-lan78xx
+	kmod-usb-net-lan78xx \
+	kmod-mdio-devres \
+	kmod-phy-realtek \
+	kmod-r8169 \
+	r8169-firmware
   IMAGE/sysupgrade.img.gz := boot-common | boot-2711 | sdcard-img | gzip | append-metadata
   IMAGE/factory.img.gz := boot-common | boot-2711 | sdcard-img | gzip
 endef


### PR DESCRIPTION
Some carrier boards [1][2] for the Raspberry Pi CM4 that are specifically designed to be used as routers come with secondary NICs using a Realtek RTL8111 Gigabit Ethernet chip.

When using such a board as a router with OpenWrt, it is very helpful when both NICs are working by default. Since the Raspberry Pi 4 and the CM4 have plenty of disk space, it should cause no harm to include the kmod-r8169 and its dependencies in the image.

[1] https://wiki.dfrobot.com/Compute_Module_4_IoT_Router_Board_Mini_SKU_DFR0767

[2] https://www.waveshare.com/wiki/CM4-DUAL-ETH-MINI

Signed-off-by: Johannes Heimansberg <git@jhe.dedyn.io>
