### PR TITLE
[22.03] build: fix lzma-loader build corruption

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -525,6 +525,7 @@ define Device/Build/compile
   $$(_COMPILE_TARGET): $(KDIR)/$(1)
   $(eval $(call Device/Export,$(KDIR)/$(1)))
   $(KDIR)/$(1): FORCE
+	rm -f $(KDIR)/$(1)
 	$$(call concat_cmd,$(COMPILE/$(1)))
 
 endef

--- a/target/linux/ath79/image/Makefile
+++ b/target/linux/ath79/image/Makefile
@@ -83,7 +83,7 @@ define Device/loader-okli-uimage
   LOADER_TYPE := bin
   COMPILE := loader-$(1).bin loader-$(1).uImage
   COMPILE/loader-$(1).bin := loader-okli-compile
-  COMPILE/loader-$(1).uImage := append-loader-okli $(1) | pad-to 64k | \
+  COMPILE/loader-$(1).uImage := loader-okli-compile | pad-to 64k | \
 	lzma | uImage lzma
 endef
 


### PR DESCRIPTION
Closes #11319 
Closes #11265 

Fix the problem with building the lzma-loader that is present in both master and 22.03.2, where basically, the whole uImage is inside the lzma compressed data of the uImage on subsequent builds after an initial build, even after `make clean`.

~~Any 1 of the 2 commits fixes the immediate problem, but to be more complete and prevent something similar from happening in the future, it would be nice to have both of the commits, which handles the issue on both sides, both through the behavior of the makefiles' targets and rules regarding `COMPILE`, and through the definitions that are fed into them in ath79 specifically.~~

^ above will apply to a future PR
