### PR TITLE
sunxi: improve support for MarsBoard A10

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -116,8 +116,8 @@ endef
 
 define U-Boot/Marsboard_A10
   BUILD_SUBTARGET:=cortexa8
-  NAME:=Marsboard
-  BUILD_DEVICES:=marsboard_a10-marsboard
+  NAME:=HAOYU Marsboard A10
+  BUILD_DEVICES:=haoyu_a10-marsboard
 endef
 
 define U-Boot/Mele_M9

--- a/target/linux/sunxi/image/cortexa8.mk
+++ b/target/linux/sunxi/image/cortexa8.mk
@@ -22,8 +22,8 @@ TARGET_DEVICES += linksprite_a10-pcduino
 define Device/marsboard_a10-marsboard
   DEVICE_VENDOR := HAOYU Electronics
   DEVICE_MODEL := MarsBoard A10
-  DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi \
-	sound-soc-sunxi
+  DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac \
+	kmod-rtc-sunxi kmod-sound-core kmod-sound-soc-sunxi
   SOC := sun4i
 endef
 TARGET_DEVICES += marsboard_a10-marsboard

--- a/target/linux/sunxi/image/cortexa8.mk
+++ b/target/linux/sunxi/image/cortexa8.mk
@@ -11,6 +11,16 @@ define Device/cubietech_a10-cubieboard
 endef
 TARGET_DEVICES += cubietech_a10-cubieboard
 
+define Device/haoyu_a10-marsboard
+  DEVICE_VENDOR := HAOYU Electronics
+  DEVICE_MODEL := MarsBoard A10
+  DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac \
+	kmod-rtc-sunxi kmod-sound-core kmod-sound-soc-sunxi
+  SUPPORTED_DEVICES += marsboard,a10-marsboard
+  SOC := sun4i
+endef
+TARGET_DEVICES += haoyu_a10-marsboard
+
 define Device/linksprite_a10-pcduino
   DEVICE_VENDOR := LinkSprite
   DEVICE_MODEL := pcDuino
@@ -18,15 +28,6 @@ define Device/linksprite_a10-pcduino
   SOC := sun4i
 endef
 TARGET_DEVICES += linksprite_a10-pcduino
-
-define Device/marsboard_a10-marsboard
-  DEVICE_VENDOR := HAOYU Electronics
-  DEVICE_MODEL := MarsBoard A10
-  DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac \
-	kmod-rtc-sunxi kmod-sound-core kmod-sound-soc-sunxi
-  SOC := sun4i
-endef
-TARGET_DEVICES += marsboard_a10-marsboard
 
 define Device/olimex_a10-olinuxino-lime
   DEVICE_VENDOR := Olimex


### PR DESCRIPTION
- sunxi: fix typo in device packages for MarsBoard A10
The kmod prefix for sound-soc-sunxi is missing, fix it.
Also add kmod-sound-core as dependence.
- sunxi: fix board_name for MarsBoard A10
The compatible in the device tree is "haoyu,a10-marsboard",
modify the board_name to keep it consistent.
