### PR TITLE
kernel: 5.15: disable kmod-ptp for broken targets

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -1079,6 +1079,7 @@ define KernelPackage/ptp
   SUBMENU:=$(OTHER_MENU)
   TITLE:=PTP clock support
   DEPENDS:=+kmod-pps
+  DEPENDS+=@!(LINUX_5_15&&(TARGET_kirkwood||TARGET_mvebu||TARGET_qoriq))
   KCONFIG:= \
 	CONFIG_PTP_1588_CLOCK \
 	CONFIG_NET_PTP_CLASSIFY=y


### PR DESCRIPTION
Currently in linux 5.15, mv88e6xxx dsa driver cannot be built-in as described in commit 97c77fff28cf001399f33c7bc1ec6687ba18450b

This disables kmod-ptp, which is dragging the driver to become a kmod, for the following affected targets in linux 5.15:
- kirkwood
- mvebu
- qoriq