### PR TITLE
scp: add -y option

### DIFF
--- a/package/network/services/dropbear/patches/902-scp-y.patch
+++ b/package/network/services/dropbear/patches/902-scp-y.patch
@@ -1,0 +1,30 @@
+--- a/scp.c
++++ b/scp.c
+@@ -326,7 +326,7 @@
+ 	addargs(&args, "%s", ssh_program);
+ 
+ 	fflag = tflag = 0;
+-	while ((ch = getopt(argc, argv, "dfl:prtvBCc:i:P:q1246S:o:F:")) != -1)
++	while ((ch = getopt(argc, argv, "dfl:prtvBCc:i:P:q1246S:o:F:y")) != -1)
+ 		switch (ch) {
+ 		/* User-visible flags. */
+ 		case '1':
+@@ -373,6 +373,9 @@
+ 			showprogress = 0;
+ #endif
+ 			break;
++		case 'y':
++			addargs(&args, "-y");
++			break;
+ 
+ 		/* Server options. */
+ 		case 'd':
+@@ -1144,7 +1147,7 @@
+ usage(void)
+ {
+ 	(void) fprintf(stderr,
+-	    "usage: scp [-1246BCpqrv] [-c cipher] [-F ssh_config] [-i identity_file]\n"
++	    "usage: scp [-1246BCpqrvy] [-c cipher] [-F ssh_config] [-i identity_file]\n"
+ 	    "           [-l limit] [-P port] [-S program]\n"
+ 	    "           [[user@]host1:]file1 [...] [[user@]host2:]file2\n");
+ 	exit(1);


### PR DESCRIPTION
This allows to skip the host check, similarly as in the ssh client.

Signed-off-by: Matteo Croce <teknoraver@meta.com>