### PR TITLE
[21.02] kernel: add kmod-nvme package

### DIFF
--- a/package/kernel/linux/modules/block.mk
+++ b/package/kernel/linux/modules/block.mk
@@ -508,6 +508,29 @@ endef
 $(eval $(call KernelPackage,nbd))
 
 
+define KernelPackage/nvme
+  SUBMENU:=$(BLOCK_MENU)
+  TITLE:=NVM Express block device
+  DEPENDS:=@PCI_SUPPORT
+  KCONFIG:= \
+	CONFIG_NVME_CORE \
+	CONFIG_BLK_DEV_NVME \
+	CONFIG_NVME_MULTIPATH=n \
+	CONFIG_NVME_HWMON=n
+  FILES:= \
+	$(LINUX_DIR)/drivers/nvme/host/nvme-core.ko \
+	$(LINUX_DIR)/drivers/nvme/host/nvme.ko
+  AUTOLOAD:=$(call AutoLoad,30,nvme-core nvme)
+endef
+
+define KernelPackage/nvme/description
+ Kernel module for NVM Express solid state drives directly
+ connected to the PCI or PCI Express bus.
+endef
+
+$(eval $(call KernelPackage,nvme))
+
+
 define KernelPackage/scsi-core
   SUBMENU:=$(BLOCK_MENU)
   TITLE:=SCSI device support


### PR DESCRIPTION
Quoted commit message:

```
Add driver for NVM Express block devices, ie. PCIe connected SSDs.

Targets which allow booting from NVMe (x86, maybe some mvebu boards come to mind) should have it built-in, so rootfs can be mounted from there. For targets without NVMe support in bootloader or BIOS/firmware it's sufficient to provide the kernel module package.

On targets having the NVMe driver built-in the resulting kmod package is an empty dummy. In any case, depending on or installing kmod-nvme results in driver support being available (either because it was already built-in or because the relevant kernel modules are added and loaded).
```