### PR TITLE
[22.03] kernel: kmod-net-rtl8192su: Remove package

### DIFF
--- a/package/firmware/linux-firmware/realtek.mk
+++ b/package/firmware/linux-firmware/realtek.mk
@@ -69,13 +69,6 @@ define Package/rtl8192se-firmware/install
 endef
 $(eval $(call BuildPackage,rtl8192se-firmware))
 
-Package/rtl8192su-firmware = $(call Package/firmware-default,RealTek RTL8192SU firmware)
-define Package/rtl8192su-firmware/install
-	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8712u.bin $(1)/lib/firmware/rtlwifi
-endef
-$(eval $(call BuildPackage,rtl8192su-firmware))
-
 Package/rtl8723au-firmware = $(call Package/firmware-default,RealTek RTL8723AU firmware)
 define Package/rtl8723au-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi

--- a/package/kernel/linux/modules/wireless.mk
+++ b/package/kernel/linux/modules/wireless.mk
@@ -22,21 +22,3 @@ define KernelPackage/net-prism54/description
 endef
 
 $(eval $(call KernelPackage,net-prism54))
-
-
-define KernelPackage/net-rtl8192su
-  SUBMENU:=$(WIRELESS_MENU)
-  TITLE:=RTL8192SU support (staging)
-  DEPENDS:=@USB_SUPPORT +@DRIVER_WEXT_SUPPORT +kmod-usb-core +rtl8192su-firmware
-  KCONFIG:=\
-	CONFIG_STAGING=y \
-	CONFIG_R8712U
-  FILES:=$(LINUX_DIR)/drivers/staging/rtl8712/r8712u.ko
-  AUTOLOAD:=$(call AutoProbe,r8712u)
-endef
-
-define KernelPackage/net-rtl8192su/description
- Kernel modules for RealTek RTL8712 and RTL81XXSU fullmac support.
-endef
-
-$(eval $(call KernelPackage,net-rtl8192su))


### PR DESCRIPTION
Quoted commit message:
```
The R8712U driver depends on cfg80211. cfg80211 is provided by mac80211 backports, we can not build any in kernel drivers which depend on cfg80211 which is an out of tree module in OpenWrt.

The cfg80211 dependency was added with kernel 5.9.

We could add rtl8192su to backports and build it from there.
```
Taken from https://github.com/openwrt/openwrt/commit/7ebe1dca476ddb2c08f8a1cbbd0522e69c1edc82

Rebased for OpenWrt 22.03