### PR TITLE
ath79: add support for KuWFi C910

### DIFF
--- a/target/linux/ath79/dts/qca9533_kuwfi_c910.dts
+++ b/target/linux/ath79/dts/qca9533_kuwfi_c910.dts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	compatible = "kuwfi,c910", "qca,qca9533";
+	model = "KuWFi C910";
+
+	aliases {
+		label-mac-device = &eth1;
+		led-boot = &internet_red;
+		led-failsafe = &internet_red;
+		led-upgrade = &internet_red;
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x0>;
+				label = "firmware";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+			};
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		internet_blue {
+			label = "blue:internet";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "white:wifi";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		internet_green {
+			label = "green:internet";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "white:wan";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "white:lan2";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		// gpio 12 enables or disables LTE (Quectel EC200T)
+
+		internet_red: internet_red {
+			label = "red:internet";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "white:lan1";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "winbond,w25q128", "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "u-boot-env";
+				reg = <0x020000 0x010000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x030000 0x020000>;
+				read-only;
+			};
+
+			fwconcat0: partition@50000 {
+				label = "fwconcat0";
+				reg = <0x050000 0xe30000>;
+			};
+
+			partition@e80000 {
+				label = "loader";
+				reg = <0xe80000 0x10000>;
+			};
+
+			fwconcat1: partition@e90000 {
+				label = "fwconcat1";
+				reg = <0xe90000 0x160000>;
+			};
+
+			partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				calibration_art_1000: macaddr@1000 {
+					reg = <0x1000 0x440>;
+				};
+
+				macaddr_art_1002: macaddr@1002 {
+					reg = <0x1002 0x6>;
+				};
+			};
+		};
+	};
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+
+	nvmem-cells = <&macaddr_art_1002>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&eth1 {
+	phy-handle = <&swphy4>;
+
+	nvmem-cells = <&macaddr_art_1002>;
+	nvmem-cell-names = "mac-address";
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&calibration_art_1000>;
+	nvmem-cell-names = "calibration";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -268,6 +268,11 @@ hiwifi,hc6361)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
 	ucidef_set_led_wlan "wlan" "WLAN" "blue:wlan" "phy0tpt"
 	;;
+kuwfi,c910)
+	ucidef_set_led_netdev "wan" "WAN" "white:wan" "eth1"
+	ucidef_set_led_switch "lan1" "LAN1" "white:lan1" "switch0" "0x10"
+	ucidef_set_led_switch "lan2" "LAN2" "white:lan2" "switch0" "0x02"
+	;;
 meraki,mr12|\
 tplink,cpe210-v2|\
 tplink,cpe210-v3)

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -347,6 +347,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:3" "3:lan:2" "4:lan:1"
 		;;
+	kuwfi,c910)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:2" "4:lan:1"
+		;;
 	letv,lba-047-ch)
 		ucidef_set_interface_wan "eth0"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1583,6 +1583,22 @@ define Device/joyit_jt-or750i
 endef
 TARGET_DEVICES += joyit_jt-or750i
 
+define Device/kuwfi_c910
+  $(Device/loader-okli-uimage)
+  SOC := qca9533
+  DEVICE_VENDOR := KuWFi
+  DEVICE_MODEL := C910
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-net-cdc-ether comgt-ncm
+  LOADER_FLASH_OFFS := 0x50000
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x4f4b4c49
+  IMAGE_SIZE := 15936k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | pad-to 14528k | \
+	append-loader-okli-uimage $(1) | pad-to 64k
+endef
+TARGET_DEVICES += kuwfi_c910
+
 define Device/letv_lba-047-ch
   $(Device/loader-okli-uimage)
   SOC := qca9531


### PR DESCRIPTION
KuWFi C910 is an 802.11n (300N) indoor router with LTE support.

I can't find anywhere the OEM firmware. So if you want to restore the original firmware you must do a dump before the OpenWrt flash.

According to the U-Boot, the board name is Iyunlink MINI_V2.

Hardware
--------
SoC:   Qualcomm QCA9533 650/400/200/25/25 MHz (CPU/RAM/AHB/SPI/REF)
RAM:   128 MB DDR2 16-bit CL3-4-4-10 (Nanya NT5TU64M16HG-AC)
FLASH: 16 MB Winbond W25Q128
ETH:
  - 2x 100M LAN (QCA9533 internal AR8229 switch, eth0)
  - 1x 100M WAN (QCA9533 internal PHY, eth1)
WIFI:
  - 2.4GHz: 1x QCA9533 2T2R (b/g/n)
  - 2 external non detachable antennas (near the power barrel side)
LTE:
  - Quectel EC200T-EU (or -CN or -AU depending on markets)
  - 2 external non detachable antennas (near the sim slot side)
BTN:
  - 1x Reset button
LEDS:
  - 5x White leds (Power, Wifi, Wan, Lan1, Lan2)
  - 1x RGB led (Internet)
UART: 115200-8-N-1 (Starting from lan ports in order: GND, RX, TX, VCC)

Everything works correctly.

MAC Addresses
-------------
```
LAN XX:XX:XX:XX:XX:48 (art@0x1002)
WAN XX:XX:XX:XX:XX:49 (art@0x1002 + 1)
WIFI XX:XX:XX:XX:XX:48

LABEL XX:XX:XX:XX:XX:48
```

Installation
------------
Turn the router on while pressing the reset button for 4 seconds. You can simply count the flashes of the first lan led. (See notes) If done correctly you should see the first lan led glowing slowly and you should be able to enter the U-Boot web interface.

Click on the second tab ("固件") and select the -factory.bin firmware then click "Update firmware".

A screen "Update in progress" should appear.

After few minutes the flash should be completed.

This procedure can be used also to recover the router in case of soft brick.

Backup the original firmware
----------------------------
The following steps are intended for a linux pc. However using the right software this guide should also work for Windows and MacOS.

1) Install a tftp server on your pc. For example tftpd-hpa.

2) Create two empty files in your tftp folder called:
	kuwfi_c910_all_nor.bin
	kuwfi_c910_firmware_only.bin

3) Give global write permissions to these files:
	`chmod 666 kuwfi_c910_all_nor.bin`
	`chmod 666 kuwfi_c910_firmware_only.bin`

4) Start a netcat session on your pc with this command:
	`nc -u -p 6666 192.168.1.1 6666`

5) Set the static address on your pc: 192.168.1.2. Connect the router
	to your pc.

6) Turn the router on while pressing the reset button for 8-9 seconds.
	You can simply count the flashes of the first lan led. If you
	press the reset button for too many seconds it will continue
	the normal boot, so you have to restart the router. (See notes)

7) If done correctly you should see the U-Boot network console and you
	should see the following lines on the netcat session:
```
Version and build date:
  U-Boot 1.1.4-55f1bca8-dirty, 2020-05-07

Modification by:
  Piotr Dymacz <piotr@dymacz.pl>
  https://github.com/pepe2k/u-boot_mod

u-boot>
```

8) Start the transfer of the whole NOR:
	`tftpput 0x9f000000 0x1000000 kuwfi_c910_all_nor.bin`

9) The router should start the transfer and it should end with a
	message like this (pay attention to the bytes transferred):
```
TFTP transfer complete!

Bytes transferred: 16777216 (0x1000000)
```

10) Repeat the same transfer for the firmware:
	`tftpput 0x9f050000 0xfa0000 kuwfi_c910_firmware_only.bin`

11) The router should start the transfer and it should end with a
	message like this (pay attention to the bytes transferred):
```
TFTP transfer complete!

Bytes transferred: 16384000 (0xfa0000)
```

12) Now you have the backup for the whole nor and for the firmware
	partition. If you want to restore the OEM firmware from OpenWrt
	you have to flash the kuwfi_c910_firmware_only.bin from the
	U-Boot web interface.

	WARNING: Don't use the kuwfi_c910_all_nor.bin file. This file
	is only useful if you manage to	hard brick the router or you
	damage the art partition (ask on the forum)

Notes
-----
This router (or at least my unit) has the pepe2k's U-Boot. It's a modded U-Boot version with a lot of cool features. You can read more here: https://github.com/pepe2k/u-boot_mod

With this version of U-Boot, pushing the reset button while turning on the router starts different tools:
 - 3-5 seconds: U-Boot web interface that can be used to replace the firmware, the art or the U-Boot itself
 - 5-7 seconds: U-Boot uart console
 - 7-10 seconds: U-Boot network console
 - 11+ seconds: Normal boot

The LTE modem can be used in cdc_ether (ECM) or RNDIS mode. The default mode is ECM and in this commit only the ECM software is included. In order to set RNDIS mode you must use this AT command:
	AT+QCFG="usbnet",3
In order to use again the ECM mode you must use this AT command:
	AT+QCFG="usbnet",1

Look for "Quectel_EC200T_Linux_USB_Driver_User_Guide_V1.0.pdf" for other AT commands