### PR TITLE
imagebuilder: update help texts and add missing commands 

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -35,6 +35,7 @@ Available Commands:
 	info:	Show a list of available target profiles
 	clean:	Remove images and temporary build files
 	image:	Build an image (see below for more information).
+	manifest: Show all package that will be installed into the image
 	package_depends: Show installation dependency of the package
 
 image:
@@ -50,7 +51,7 @@ image:
 	make image DISABLED_SERVICES="<svc1> [<svc2> [<svc3> ..]]" # Which services in /etc/init.d/ should be disabled
 	make image ADD_LOCAL_KEY=1 # store locally generated signing key in built images
 
-Print manifest:
+manifest:
 	List "all" packages which get installed into the image.
 	You can use the following parameters:
 

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -36,6 +36,7 @@ Available Commands:
 	clean:	Remove images and temporary build files
 	image:	Build an image (see below for more information).
 	manifest: Show all package that will be installed into the image
+	package_whatdepends: Show which packages have a dependency on this
 	package_depends: Show installation dependency of the package
 
 image:
@@ -58,6 +59,13 @@ manifest:
 	make manifest PROFILE="<profilename>" # override the default target profile
 	make manifest PACKAGES="<pkg1> [<pkg2> [<pkg3> ...]]" # include extra packages
 	make manifest STRIP_ABI=1 # remove ABI version from printed package names
+
+
+package_whatdepends:
+	List "all" packages that have a dependency on this package
+	You can use the following parameters:
+
+	make package_whatdepends PACKAGE="<pkg>"
 
 package_depends:
 	List "all" packages dependency of the package
@@ -263,7 +271,7 @@ manifest: FORCE
 		$(if $(PROFILE),USER_PROFILE="$(PROFILE_FILTER)") \
 		$(if $(PACKAGES),USER_PACKAGES="$(PACKAGES)"))
 
-whatdepends: FORCE
+package_whatdepends: FORCE
 ifeq ($(PACKAGE),)
 	@echo 'Variable `PACKAGE` is not set but required by `whatdepends`'
 	@exit 1
@@ -280,4 +288,4 @@ endif
 	@$(OPKG) depends -A $(PACKAGE)
 
 
-.SILENT: help info image manifest whatdepends package_depends
+.SILENT: help info image manifest package_whatdepends package_depends

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -35,6 +35,7 @@ Available Commands:
 	info:	Show a list of available target profiles
 	clean:	Remove images and temporary build files
 	image:	Build an image (see below for more information).
+	package_depends: Show installation dependency of the package
 
 Building images:
 	By default 'make image' will create an image with the default
@@ -56,6 +57,12 @@ Print manifest:
 	make manifest PROFILE="<profilename>" # override the default target profile
 	make manifest PACKAGES="<pkg1> [<pkg2> [<pkg3> ...]]" # include extra packages
 	make manifest STRIP_ABI=1 # remove ABI version from printed package names
+
+package_depends:
+	List "all" packages dependency of the package
+	You can use the following parameters:
+
+	make package_depends PACKAGE="<pkg>"
 
 endef
 $(eval $(call shexport,Helptext))
@@ -263,4 +270,13 @@ endif
 	@$(MAKE) -s package_reload
 	@$(OPKG) whatdepends -A $(PACKAGE)
 
-.SILENT: help info image manifest whatdepends
+package_depends: FORCE
+ifeq ($(PACKAGE),)
+	@echo 'Variable `PACKAGE` is not set but required by `package_depends`'
+	@exit 1
+endif
+	@$(MAKE) -s package_reload
+	@$(OPKG) depends -A $(PACKAGE)
+
+
+.SILENT: help info image manifest whatdepends package_depends

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -37,7 +37,7 @@ Available Commands:
 	image:	Build an image (see below for more information).
 	package_depends: Show installation dependency of the package
 
-Building images:
+image:
 	By default 'make image' will create an image with the default
 	target profile and package set. You can use the following parameters
 	to change that:


### PR DESCRIPTION
* Unify and update help texts
* Add `package_whatdepends` command
* Add `package_depends` command
