### PR TITLE
ramips: basic support for tp-link er605-v2

### DIFF
--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -129,6 +129,17 @@ mtd_get_mac_encrypted_deco() {
 	echo $macaddr
 }
 
+mtd_get_mac_uci_config_ubi() {
+	local volumename="$1"
+
+	. /lib/upgrade/nand.sh
+
+	local ubidev=$(nand_attach_ubi $CI_UBIPART)
+	local part=$(nand_find_volume $ubidev $volumename)
+
+	cat "/dev/$part" | sed -n 's/^\s*option macaddr\s*'"'"'\?\([0-9A-F:]\+\)'"'"'\?/\1/Ip'
+}
+
 mtd_get_mac_text() {
 	local mtdname=$1
 	local offset=$(($2))

--- a/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "TP-Link ER605 v2";
+	compatible = "tplink,er605-v2", "mediatek,mt7621-soc";
+
+	chosen {
+		bootargs = "console=ttyS0,115200 noinitrd";
+	};
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &gmac0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_usb: usb {
+			label = "green:usb";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power: power {
+			label = "green:power";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_system: system {
+			label = "green:system";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset button";
+			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	reg_usb_vbus: regulator-usb {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 10 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&gmac0 {
+	label = "dsa";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "eth0";
+	phy-handle = <&ethphy0>;
+};
+
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "disabled";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "eth1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "eth2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "eth3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "eth4";
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "firmware";
+			reg = <0x140000 0x7cc0000>;
+		};
+
+		partition@7e00000 {
+			label = "panic-ops";
+			reg = <0x7e00000 0x200000>;
+		};
+	};
+};
+
+
+&mdio {
+	ethphy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3", "pcie", "jtag";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "disabled";
+};
+
+&xhci {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_usb_vbus>;
+};
+

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1961,6 +1961,24 @@ define Device/tplink_eap615-wall-v1
 endef
 TARGET_DEVICES += tplink_eap615-wall-v1
 
+define Device/tplink_er605-v2
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := ER605
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := -wpad-basic-wolfssl kmod-usb3
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  KERNEL_IN_UBI := 1
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel 0x80001000 | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  IMAGES += sysupgrade.tar
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE_SIZE := 127744k
+endef
+TARGET_DEVICES += tplink_er605-v2
+
 define Device/tplink_mr600-v2-eu
   $(Device/dsa-migration)
   $(Device/tplink-v2)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -99,6 +99,9 @@ ramips_setup_interfaces()
 	tplink,eap615-wall-v1)
 		ucidef_set_interface_lan "lan0 lan1 lan2 lan3"
 		;;
+	tplink,er605-v2)
+		ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4" "eth0"
+		;;
 	tplink,tl-wpa8631p-v3)
 		ucidef_set_interface_lan "lan1 lan2 lan3 plc0"
 		;;
@@ -224,6 +227,12 @@ ramips_setup_macs()
 	mikrotik,ltap-2hnd)
 		label_mac=$(cat "/sys/firmware/mikrotik/hard_config/mac_base")
 		lan_mac=$label_mac
+		;;
+	tplink,er605-v2)
+		CI_UBIPART="firmware"
+		label_mac=$(mtd_get_mac_uci_config_ubi "tddp")
+		lan_mac=$label_mac
+		wan_mac=$(macaddr_add "$label_mac" 1)
 		;;
 	tplink,mr600-v2-eu)
 		label_mac=$(cat "/sys/class/net/eth0/address")

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -124,6 +124,12 @@ platform_do_upgrade() {
 		iodata_mstc_upgrade_prepare "0x1fe75"
 		nand_do_upgrade "$1"
 		;;
+	tplink,er605-v2)
+		echo "Upgrading tplink,er605-v2"
+		CI_UBIPART="firmware"
+		CI_KERNPART="kernel"
+		nand_do_upgrade "$1"
+		;;
 	ubnt,edgerouter-x|\
 	ubnt,edgerouter-x-sfp)
 		platform_upgrade_ubnt_erx "$1"


### PR DESCRIPTION
This is a MT7621-based device with 128MB NAND flash, 256MB RAM, and a USB port. The board has headers to attach console. In order for them to work two solder bridges near those pads need to be made.

The defice has the following partition table:

```
0x000000000000-0x000000080000 : "u-boot"
0x000000080000-0x000000100000 : "u-boot-env"
0x000000100000-0x000000140000 : "factory"
0x000000140000-0x000007e00000 : "firmware"
0x000007e00000-0x000008000000 : "panic-ops"
```

`firmware` partition contains UBI volumes. Unfortunately I accidentally wiped partition and I no longer have access to it.

`firmware` partition contains 'secondary' U-Boot which is run by 'first' u-boot. It also contains various configuration partitions that include device info and MAC address. There also seems to be 'primary' and 'backup' set of 'main' volumes.

U-boot has `mtkupgrade` command that just overrides data on firmware partitions. Firmware file provided by TP-Link cannot be used with that command.

U-boot also has 'recovery' http server. Unfortunately I was not able to make it work with manufacturer's firmware.

Manufacturer's firmware essentially contains multiple UBI volumes along with 'partition table'. Unfortunately I no longer can properly run manufacturer's firmware so I cannot at the moment try to a support for building 'factory' images.

This patch adds support for initramfs image as well as sysupgrade image.

This seems to be pretty standard MT7621 board otherwise.

Things that work:
* network
* leds
* usb
* factory MAC detection

Signed-off-by: Nikolay Martynov <mar.kolya@gmail.com>
