### PR TITLE
ath79: convert ath9k-eeprom-pci from 0x5000 to nvmem-cells

### DIFF
--- a/target/linux/ath79/dts/ar9344_araknis_an-300-ap-i-n.dts
+++ b/target/linux/ath79/dts/ar9344_araknis_an-300-ap-i-n.dts
@@ -87,11 +87,10 @@
 	ath9k: wifi@0,0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_art_0>, <&calibration_ath9k_5000>;
+		nvmem-cell-names = "mac-address", "calibration";
 		mac-address-increment = <1>;
 		qca,disable-5ghz;
-		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -102,10 +101,8 @@
 
 	qca,disable-2ghz;
 
-	mtd-cal-data = <&art 0x1000>;
-
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_art_0>, <&calibration_ath9k_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
 	mac-address-increment = <2>;
 };
 
@@ -113,6 +110,14 @@
 	compatible = "nvmem-cells";
 	#address-cells = <1>;
 	#size-cells = <1>;
+
+	calibration_ath9k_1000: calibration@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	calibration_ath9k_5000: calibration@5000 {
+		reg = <0x5000 0x440>;
+	};
 
 	macaddr_art_0: macaddr@0 {
 		reg = <0x0 0x6>;

--- a/target/linux/ath79/dts/ar9344_atheros_db120.dts
+++ b/target/linux/ath79/dts/ar9344_atheros_db120.dts
@@ -204,7 +204,8 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
-		qca,no-eeprom;
+		nvmem-cells = <&calibration_ath9k_5000>;
+		nvmem-cell-names = "calibration";
 		ieee80211-freq-limit = <4900000 5990000>;
 		#gpio-cells = <2>;
 		gpio-controller;
@@ -214,7 +215,8 @@
 &wmac {
 	status = "okay";
 
-	mtd-cal-data = <&art 0x1000>;
+	nvmem-cells = <&calibration_ath9k_1000>;
+	nvmem-cell-names = "calibration";
 };
 
 &usb {
@@ -229,6 +231,14 @@
 	compatible = "nvmem-cells";
 	#address-cells = <1>;
 	#size-cells = <1>;
+
+	calibration_ath9k_1000: calibration@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	calibration_ath9k_5000: calibration@5000 {
+		reg = <0x5000 0x440>;
+	};
 
 	macaddr_art_0: macaddr@0 {
 		reg = <0x0 0x6>;

--- a/target/linux/ath79/dts/ar9344_engenius_eap600.dts
+++ b/target/linux/ath79/dts/ar9344_engenius_eap600.dts
@@ -36,14 +36,14 @@
 
 &pcie {
 	wifi@0,0,0 {
-		nvmem-cells = <&macaddr_art_0>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_art_0>, <&calibration_ath9k_5000>;
+		nvmem-cell-names = "mac-address", "calibration";
 	};
 };
 
 &wmac {
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_art_0>, <&calibration_ath9k_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
 	mac-address-increment = <(-1)>;
 };
 
@@ -51,6 +51,14 @@
 	compatible = "nvmem-cells";
 	#address-cells = <1>;
 	#size-cells = <1>;
+
+	calibration_ath9k_1000: calibration@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	calibration_ath9k_5000: calibration@5000 {
+		reg = <0x5000 0x440>;
+	};
 
 	macaddr_art_0: macaddr@0 {
 		reg = <0x0 0x6>;

--- a/target/linux/ath79/dts/ar9344_engenius_ecb600.dts
+++ b/target/linux/ath79/dts/ar9344_engenius_ecb600.dts
@@ -30,15 +30,15 @@
 
 &pcie {
 	wifi@0,0,0 {
-		nvmem-cells = <&macaddr_art_0>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_art_0>, <&calibration_ath9k_5000>;
+		nvmem-cell-names = "mac-address", "calibration";
 		mac-address-increment = <(-2)>;
 	};
 };
 
 &wmac {
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_art_0>, <&calibration_ath9k_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
 	mac-address-increment = <(-1)>;
 };
 
@@ -46,6 +46,14 @@
 	compatible = "nvmem-cells";
 	#address-cells = <1>;
 	#size-cells = <1>;
+
+	calibration_ath9k_1000: calibration@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	calibration_ath9k_5000: calibration@5000 {
+		reg = <0x5000 0x440>;
+	};
 
 	macaddr_art_0: macaddr@0 {
 		reg = <0x0 0x6>;

--- a/target/linux/ath79/dts/ar9344_ocedo_raccoon.dts
+++ b/target/linux/ath79/dts/ar9344_ocedo_raccoon.dts
@@ -129,9 +129,8 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_c>;
-		nvmem-cell-names = "mac-address";
-		qca,no-eeprom;
+		nvmem-cells = <&macaddr_art_c>, <&calibration_ath9k_5000>;
+		nvmem-cell-names = "mac-address", "calibration";
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -140,9 +139,8 @@
 &wmac {
 	status = "okay";
 
-	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_art_6>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_art_6>, <&calibration_ath9k_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
 };
 
 &mdio0 {
@@ -180,6 +178,14 @@
 	compatible = "nvmem-cells";
 	#address-cells = <1>;
 	#size-cells = <1>;
+
+	calibration_ath9k_1000: calibration@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	calibration_ath9k_5000: calibration@5000 {
+		reg = <0x5000 0x440>;
+	};
 
 	macaddr_art_0: macaddr@0 {
 		reg = <0x0 0x6>;

--- a/target/linux/ath79/dts/ar9344_senao_ap-dual.dtsi
+++ b/target/linux/ath79/dts/ar9344_senao_ap-dual.dtsi
@@ -63,7 +63,6 @@
 		compatible = "pci168c,0030";
 		reg = <0x0 0 0 0 0>;
 		ieee80211-freq-limit = <2402000 2482000>;
-		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -73,6 +72,4 @@
 	status = "okay";
 
 	ieee80211-freq-limit = <4900000 5990000>;
-
-	mtd-cal-data = <&art 0x1000>;
 };

--- a/target/linux/ath79/dts/ar9344_ubnt_unifi-ap-pro.dts
+++ b/target/linux/ath79/dts/ar9344_ubnt_unifi-ap-pro.dts
@@ -115,14 +115,16 @@
 	wifi@0,0 {
 		compatible = "pci168c,0033";
 		reg = <0 0 0 0 0>;
-		qca,no-eeprom;
+		nvmem-cells = <&calibration_ath9k_5000>;
+		nvmem-cell-names = "calibration";
 	};
 };
 
 &wmac {
 	status = "okay";
 
-	mtd-cal-data = <&art 0x1000>;
+	nvmem-cells = <&calibration_ath9k_1000>;
+	nvmem-cell-names = "calibration";
 };
 
 &mdio0 {
@@ -155,6 +157,14 @@
 	compatible = "nvmem-cells";
 	#address-cells = <1>;
 	#size-cells = <1>;
+
+	calibration_ath9k_1000: calibration@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	calibration_ath9k_5000: calibration@5000 {
+		reg = <0x5000 0x440>;
+	};
 
 	macaddr_art_0: macaddr@0 {
 		reg = <0x0 0x6>;

--- a/target/linux/ath79/dts/ar9344_watchguard_ap100.dts
+++ b/target/linux/ath79/dts/ar9344_watchguard_ap100.dts
@@ -63,13 +63,18 @@
 
 &pcie {
 	status = "disabled";
+
+	wifi@0,0,0 {
+		nvmem-cells = <&calibration_ath9k_5000>;
+		nvmem-cell-names = "calibration";
+	};
 };
 
 &wmac {
 	/delete-property/ qca,disable-2ghz;
 
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_art_0>, <&calibration_ath9k_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
 	mac-address-increment = <(-2)>;
 };
 
@@ -77,6 +82,14 @@
 	compatible = "nvmem-cells";
 	#address-cells = <1>;
 	#size-cells = <1>;
+
+	calibration_ath9k_1000: calibration@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	calibration_ath9k_5000: calibration@5000 {
+		reg = <0x5000 0x440>;
+	};
 
 	macaddr_art_0: macaddr@0 {
 		reg = <0x0 0x6>;

--- a/target/linux/ath79/dts/ar9344_watchguard_ap200.dts
+++ b/target/linux/ath79/dts/ar9344_watchguard_ap200.dts
@@ -63,15 +63,15 @@
 
 &pcie {
 	wifi@0,0,0 {
-		nvmem-cells = <&macaddr_art_0>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_art_0>, <&calibration_ath9k_5000>;
+		nvmem-cell-names = "mac-address", "calibration";
 		mac-address-increment = <(-1)>;
 	};
 };
 
 &wmac {
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_art_0>, <&calibration_ath9k_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
 	mac-address-increment = <(-2)>;
 };
 
@@ -79,6 +79,14 @@
 	compatible = "nvmem-cells";
 	#address-cells = <1>;
 	#size-cells = <1>;
+
+	calibration_ath9k_1000: calibration@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	calibration_ath9k_5000: calibration@5000 {
+		reg = <0x5000 0x440>;
+	};
 
 	macaddr_art_0: macaddr@0 {
 		reg = <0x0 0x6>;

--- a/target/linux/ath79/dts/ar9344_winchannel_wb2000.dts
+++ b/target/linux/ath79/dts/ar9344_winchannel_wb2000.dts
@@ -140,9 +140,8 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
-		qca,no-eeprom;
-		nvmem-cells = <&macaddr_addr_0>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_addr_0>, <&calibration_ath9k_5000>;
+		nvmem-cell-names = "mac-address", "calibration";
 		mac-address-increment = <0x10>;
 		#gpio-cells = <2>;
 		gpio-controller;
@@ -161,8 +160,8 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_addr_0>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_addr_0>, <&calibration_ath9k_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
 };
 
 &mdio0 {
@@ -200,5 +199,19 @@
 
 	macaddr_addr_0: macaddr@0 {
 		reg = <0x0 0x6>;
+	};
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	calibration_ath9k_1000: calibration@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	calibration_ath9k_5000: calibration@5000 {
+		reg = <0x5000 0x440>;
 	};
 };

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -83,7 +83,6 @@ case "$FIRMWARE" in
 	;;
 "ath9k-eeprom-pci-0000:00:00.0.bin")
 	case $board in
-	ubnt,unifi-ap-pro|\
 	winchannel,wb2000)
 		caldata_extract "art" 0x5000 0x440
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -83,9 +83,6 @@ case "$FIRMWARE" in
 	;;
 "ath9k-eeprom-pci-0000:00:00.0.bin")
 	case $board in
-	winchannel,wb2000)
-		caldata_extract "art" 0x5000 0x440
-		;;
 	avm,fritz300e)
 		caldata_extract_reverse "urloader" 0x1541 0x440
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -83,7 +83,6 @@ case "$FIRMWARE" in
 	;;
 "ath9k-eeprom-pci-0000:00:00.0.bin")
 	case $board in
-	atheros,db120|\
 	engenius,eap600|\
 	engenius,ecb600|\
 	mercury,mw4530r-v1|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -83,7 +83,6 @@ case "$FIRMWARE" in
 	;;
 "ath9k-eeprom-pci-0000:00:00.0.bin")
 	case $board in
-	mercury,mw4530r-v1|\
 	ocedo,raccoon|\
 	ubnt,unifi-ap-pro|\
 	winchannel,wb2000)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -83,7 +83,6 @@ case "$FIRMWARE" in
 	;;
 "ath9k-eeprom-pci-0000:00:00.0.bin")
 	case $board in
-	araknis,an-300-ap-i-n|\
 	atheros,db120|\
 	engenius,eap600|\
 	engenius,ecb600|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -83,7 +83,6 @@ case "$FIRMWARE" in
 	;;
 "ath9k-eeprom-pci-0000:00:00.0.bin")
 	case $board in
-	ocedo,raccoon|\
 	ubnt,unifi-ap-pro|\
 	winchannel,wb2000)
 		caldata_extract "art" 0x5000 0x440

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -83,13 +83,9 @@ case "$FIRMWARE" in
 	;;
 "ath9k-eeprom-pci-0000:00:00.0.bin")
 	case $board in
-	engenius,eap600|\
-	engenius,ecb600|\
 	mercury,mw4530r-v1|\
 	ocedo,raccoon|\
 	ubnt,unifi-ap-pro|\
-	watchguard,ap100|\
-	watchguard,ap200|\
 	winchannel,wb2000)
 		caldata_extract "art" 0x5000 0x440
 		;;


### PR DESCRIPTION
Convert first block of ath79 ath9k boards to nvmem-cells.

Pull the calibration data from the nvmem subsystem. This allows us to move userspace caldata extraction into the device-tree definition.