### PR TITLE
ath79: Fix glinet ar300m usb not working

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar300m-lite.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar300m-lite.dts
@@ -7,7 +7,6 @@
 	model = "GL.iNet GL-AR300M-Lite";
 };
 
-/delete-node/ &reg_usb_vbus;
 
 /delete-node/ &nand_flash;
 
@@ -30,6 +29,3 @@
 	label = "green:wlan";
 };
 
-&usb0 {
-	/delete-property/ vbus-supply;
-};

--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar300m.dtsi
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar300m.dtsi
@@ -37,14 +37,14 @@
 		};
 	};
 
-	reg_usb_vbus: reg_usb_vbus {
-		compatible = "regulator-fixed";
+	gpio-export {
+		compatible = "gpio-export";
 
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 2 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
+		gpio_usb_power {
+			gpio-export,name = "usb_power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
 	};
 
 	leds {
@@ -142,7 +142,6 @@
 };
 
 &usb0 {
-	vbus-supply = <&reg_usb_vbus>;
 	status = "okay";
 };
 


### PR DESCRIPTION
glinet forum users reported the problem at
https://forum.gl-inet.com/t/gl-ar300m16-openwrt-22-03-0-rc5-usb-port-power-off-by-default/23199

The current code uses the regulator framework to control the USB power supply. Although usb0 described in DTS refers to the regulator by vbus-supply, but there is no code related to regulator implemented in the USB driver of QCA953X, so the USB of the device cannot work.

Under the regulator framework, adding the regulator-always-on attribute fixes this problem, but it means that USB power will not be able to be turned off. Since we need to control the USB power supply in user space, I didn't find any other better way under the regulator framework of Linux, so I directly export gpio.

Signed-off-by: Luo Chongjun <luochongjun@gl-inet.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
