### PR TITLE
generic: 5.15: allow MV88E6xxx built-in when PTP support disabled

### DIFF
--- a/target/linux/generic/hack-5.15/290-net-dsa-mv88e6xxx-depend-on-PTP-conditionally.patch
+++ b/target/linux/generic/hack-5.15/290-net-dsa-mv88e6xxx-depend-on-PTP-conditionally.patch
@@ -1,0 +1,44 @@
+From e6866ed4219b8c7754dcd3eb1a654f6f524b0e56 Mon Sep 17 00:00:00 2001
+From: "Johnny S. Lee" <foss@jsl.io>
+Date: Thu, 15 Dec 2022 17:49:04 +0800
+Subject: [PATCH] net: dsa: mv88e6xxx: depend on PTP conditionally
+
+PTP hardware timestamping related objects are not linked when PTP
+support for MV88E6xxx (NET_DSA_MV88E6XXX_PTP) is disabled, therefore
+NET_DSA_MV88E6XXX should not depend on PTP_1588_CLOCK_OPTIONAL
+regardless of NET_DSA_MV88E6XXX_PTP.
+
+Instead, condition more strictly on how NET_DSA_MV88E6XXX_PTP's
+dependencies are met, making sure that it cannot be enabled when
+NET_DSA_MV88E6XXX=y and PTP_1588_CLOCK=m.
+
+In other words, this commit allows NET_DSA_MV88E6XXX to be built-in
+while PTP_1588_CLOCK is a module, as long as NET_DSA_MV88E6XXX_PTP is
+prevented from being enabled.
+
+Fixes: e5f31552674e ("ethernet: fix PTP_1588_CLOCK dependencies")
+Signed-off-by: Johnny S. Lee <foss@jsl.io>
+---
+ drivers/net/dsa/mv88e6xxx/Kconfig | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/dsa/mv88e6xxx/Kconfig
++++ b/drivers/net/dsa/mv88e6xxx/Kconfig
+@@ -2,7 +2,6 @@
+ config NET_DSA_MV88E6XXX
+ 	tristate "Marvell 88E6xxx Ethernet switch fabric support"
+ 	depends on NET_DSA
+-	depends on PTP_1588_CLOCK_OPTIONAL
+ 	select IRQ_DOMAIN
+ 	select NET_DSA_TAG_EDSA
+ 	select NET_DSA_TAG_DSA
+@@ -13,7 +12,8 @@ config NET_DSA_MV88E6XXX
+ config NET_DSA_MV88E6XXX_PTP
+ 	bool "PTP support for Marvell 88E6xxx"
+ 	default n
+-	depends on NET_DSA_MV88E6XXX && PTP_1588_CLOCK
++	depends on (NET_DSA_MV88E6XXX = y && PTP_1588_CLOCK = y) || \
++	           (NET_DSA_MV88E6XXX = m && PTP_1588_CLOCK)
+ 	help
+ 	  Say Y to enable PTP hardware timestamping on Marvell 88E6xxx switch
+ 	  chips that support it.


### PR DESCRIPTION
As described in commit 97c77fff28cf001399f33c7bc1ec6687ba18450b MV88E6xxx driver (NET_DSA_MV88E6XXX) cannot be built-in when PTP (PTP_1588_CLOCK) is a module in Linux 5.15. But actually it should be allowed to be built-in when its PTP support (NET_DSA_MV88E6XXX_PTP) is disabled.

This adds a patch to fix that.