### PR TITLE
tools/ccache: update to 4.7.4

### DIFF
--- a/tools/ccache/Makefile
+++ b/tools/ccache/Makefile
@@ -8,11 +8,11 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=ccache
-PKG_VERSION:=4.7.2
+PKG_VERSION:=4.7.4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/ccache/ccache/releases/download/v$(PKG_VERSION)
-PKG_HASH:=17ca75a577d49c1e4f2ac86d53126859de52b789cfe85dd532758518db114eaf
+PKG_HASH:=df0c64d15d3efaf0b4f6837dd6b1467e40eeaaa807db25ce79c3a08a46a84e36
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk

--- a/tools/ccache/patches/100-honour-copts.patch
+++ b/tools/ccache/patches/100-honour-copts.patch
@@ -1,6 +1,6 @@
 --- a/src/ccache.cpp
 +++ b/src/ccache.cpp
-@@ -1762,6 +1762,7 @@ get_manifest_key(Context& ctx, Hash& hash)
+@@ -1779,6 +1779,7 @@ get_manifest_key(Context& ctx, Hash& has
                             "CPLUS_INCLUDE_PATH",
                             "OBJC_INCLUDE_PATH",
                             "OBJCPLUS_INCLUDE_PATH", // clang


### PR DESCRIPTION
Release Notes:
    https://ccache.dev/releasenotes.html#_ccache_4_7_3
    https://ccache.dev/releasenotes.html#_ccache_4_7_4

Build-tested: x86/64 with CONFIG_CCACHE=y

Signed-off-by: Linhui Liu <liulinhui36@gmail.com>
