### PR TITLE
image-commands.mk: Be consistent in command invocation

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -307,7 +307,7 @@ define Build/fit
 endef
 
 define Build/gzip
-	gzip -f -9n -c $@ $(1) > $@.new
+	$(STAGING_DIR_HOST)/bin/gzip -f -9n -c $@ $(1) > $@.new
 	@mv $@.new $@
 endef
 


### PR DESCRIPTION
Most/all other tools use the staging dir prefix, gzip should as well.

See #11506 for details.