### PR TITLE
image-commands.mk:  fix: check-size should exit if checking faild

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -210,8 +210,8 @@ define Build/check-size
 	@imagesize="$$(stat -c%s $@)"; \
 	limitsize="$$(($(subst k,* 1024,$(subst m, * 1024k,$(if $(1),$(1),$(IMAGE_SIZE))))))"; \
 	[ $$limitsize -ge $$imagesize ] || { \
-		$(call ERROR_MESSAGE,    WARNING: Image file $@ is too big: $$imagesize > $$limitsize); \
-		rm -f $@; \
+		echo "ERROR: Image file $@ is too big: $$imagesize > $$limitsize";\
+		exit 1;\
 	}
 endef
 


### PR DESCRIPTION
The image check-size function should exit if checking faild. 
The original version causes the fatal error in other routine for file not found which is not the real reason.
