### PR TITLE
base-files: fix bcm53xx sysupgrade

### DIFF
--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -270,7 +270,12 @@ nand_upgrade_ubinized() {
 	nand_detach_ubi "$CI_UBIPART" || return 1
 
 	local mtdnum="$( find_mtd_index "$CI_UBIPART" )"
-	${gz}cat "$ubi_file" | ubiformat "/dev/mtd$mtdnum" -y -f - && ubiattach -m "$mtdnum"
+	if [ -n "$gz" ]; then
+		${gz}cat "$ubi_file" | ubiformat "/dev/mtd$mtdnum" -y -f - && ubiattach -m "$mtdnum"
+	else
+		# On some bcm53xx devices, the cat command leads to unintended results
+		ubiformat "/dev/mtd$mtdnum" -y -f "$ubi_file" && ubiattach -m "$mtdnum"
+	fi
 }
 
 # Write the UBIFS image to UBI rootfs volume


### PR DESCRIPTION
On some bcm53xx devices, the cat command leads to unintended results

Fixes: https://github.com/openwrt/openwrt/issues/11473
Fixes: https://github.com/openwrt/openwrt/commit/971071212052d6a38504533f41ad77b58d47376c ("base-files: accept gzipped nand sysupgrade images")
Signed-off-by: Ning Nao <ningnao@foxmail.com>