### PR TITLE
[21.02] generic: add support for EON EN25QX128A spi nor flash

### DIFF
--- a/target/linux/generic/hack-5.4/400-unlock_mx25l6406e_with_4bit_block_protect.patch
+++ b/target/linux/generic/hack-5.4/400-unlock_mx25l6406e_with_4bit_block_protect.patch
@@ -30,7 +30,7 @@
  	ret = read_sr(nor);
  	if (ret < 0) {
  		dev_err(nor->dev, "error while reading status register\n");
-@@ -2337,7 +2344,7 @@ static const struct flash_info spi_nor_i
+@@ -2338,7 +2345,7 @@ static const struct flash_info spi_nor_i
  	{ "mx25l1606e",  INFO(0xc22015, 0, 64 * 1024,  32, SECT_4K) },
  	{ "mx25l3205d",  INFO(0xc22016, 0, 64 * 1024,  64, SECT_4K) },
  	{ "mx25l3255e",  INFO(0xc29e16, 0, 64 * 1024,  64, SECT_4K) },
@@ -39,7 +39,7 @@
  	{ "mx25u2033e",  INFO(0xc22532, 0, 64 * 1024,   4, SECT_4K) },
  	{ "mx25u3235f",	 INFO(0xc22536, 0, 64 * 1024,  64,
  			 SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
-@@ -5025,6 +5032,9 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -5026,6 +5033,9 @@ int spi_nor_scan(struct spi_nor *nor, co
  	if (info->flags & USE_CLSR)
  		nor->flags |= SNOR_F_USE_CLSR;
  

--- a/target/linux/generic/pending-5.4/477-mtd-spi-nor-add-eon-en25qx128a.patch
+++ b/target/linux/generic/pending-5.4/477-mtd-spi-nor-add-eon-en25qx128a.patch
@@ -1,0 +1,21 @@
+From: Christian Marangi <ansuelsmth@gmail.com>
+Subject: kernel/mtd: add support for EON EN25QX128A
+
+Add support for EON EN25QX128A with no flags as it does
+support SFDP parsing.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/mtd/spi-nor/spi-nor.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -2180,6 +2180,7 @@ static const struct flash_info spi_nor_i
+ 	{ "en25p64",    INFO(0x1c2017, 0, 64 * 1024,  128, 0) },
+ 	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },
+ 	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256, SECT_4K) },
++	{ "en25qx128a", INFO(0x1c7118, 0, 64 * 1024, 256, 0) },
+ 	{ "en25q80a",   INFO(0x1c3014, 0, 64 * 1024,   16,
+ 			SECT_4K | SPI_NOR_DUAL_READ) },
+ 	{ "en25qh32",   INFO(0x1c7016, 0, 64 * 1024,   64, 0) },

--- a/target/linux/generic/pending-5.4/479-mtd-spi-nor-add-xtx-xt25f128b.patch
+++ b/target/linux/generic/pending-5.4/479-mtd-spi-nor-add-xtx-xt25f128b.patch
@@ -30,7 +30,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2506,6 +2506,9 @@ static const struct flash_info spi_nor_i
+@@ -2507,6 +2507,9 @@ static const struct flash_info spi_nor_i
  	/* XMC (Wuhan Xinxin Semiconductor Manufacturing Corp.) */
  	{ "XM25QH64A", INFO(0x207017, 0, 64 * 1024, 128, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
  	{ "XM25QH128A", INFO(0x207018, 0, 64 * 1024, 256, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },

--- a/target/linux/generic/pending-5.4/481-mtd-spi-nor-rework-broken-flash-reset-support.patch
+++ b/target/linux/generic/pending-5.4/481-mtd-spi-nor-rework-broken-flash-reset-support.patch
@@ -91,7 +91,7 @@ Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
  
  	spi_nor_unlock_and_unprep(nor, SPI_NOR_OPS_LOCK);
  	return ret;
-@@ -2559,6 +2586,10 @@ static int spi_nor_read(struct mtd_info
+@@ -2560,6 +2587,10 @@ static int spi_nor_read(struct mtd_info
  	if (ret)
  		return ret;
  
@@ -102,7 +102,7 @@ Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
  	while (len) {
  		loff_t addr = from;
  
-@@ -2582,6 +2613,7 @@ static int spi_nor_read(struct mtd_info
+@@ -2583,6 +2614,7 @@ static int spi_nor_read(struct mtd_info
  	ret = 0;
  
  read_err:
@@ -110,7 +110,7 @@ Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
  	spi_nor_unlock_and_unprep(nor, SPI_NOR_OPS_READ);
  	return ret;
  }
-@@ -2599,6 +2631,10 @@ static int sst_write(struct mtd_info *mt
+@@ -2600,6 +2632,10 @@ static int sst_write(struct mtd_info *mt
  	if (ret)
  		return ret;
  
@@ -121,7 +121,7 @@ Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
  	write_enable(nor);
  
  	nor->sst_write_second = false;
-@@ -2661,6 +2697,7 @@ static int sst_write(struct mtd_info *mt
+@@ -2662,6 +2698,7 @@ static int sst_write(struct mtd_info *mt
  	}
  sst_write_err:
  	*retlen += actual;
@@ -129,7 +129,7 @@ Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
  	spi_nor_unlock_and_unprep(nor, SPI_NOR_OPS_WRITE);
  	return ret;
  }
-@@ -2683,6 +2720,10 @@ static int spi_nor_write(struct mtd_info
+@@ -2684,6 +2721,10 @@ static int spi_nor_write(struct mtd_info
  	if (ret)
  		return ret;
  
@@ -140,7 +140,7 @@ Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
  	for (i = 0; i < len; ) {
  		ssize_t written;
  		loff_t addr = to + i;
-@@ -2722,6 +2763,7 @@ static int spi_nor_write(struct mtd_info
+@@ -2723,6 +2764,7 @@ static int spi_nor_write(struct mtd_info
  	}
  
  write_err:
@@ -148,7 +148,7 @@ Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
  	spi_nor_unlock_and_unprep(nor, SPI_NOR_OPS_WRITE);
  	return ret;
  }
-@@ -4726,9 +4768,13 @@ static int spi_nor_init(struct spi_nor *
+@@ -4727,9 +4769,13 @@ static int spi_nor_init(struct spi_nor *
  		 * reboots (e.g., crashes). Warn the user (or hopefully, system
  		 * designer) that this is bad.
  		 */

--- a/target/linux/generic/pending-5.4/482-mtd-spi-nor-add-support-for-Gigadevice-GD25D05.patch
+++ b/target/linux/generic/pending-5.4/482-mtd-spi-nor-add-support-for-Gigadevice-GD25D05.patch
@@ -10,7 +10,7 @@ Signed-off-by: Koen Vandeputte <koen.vandeputte@ncentric.com>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2232,6 +2232,11 @@ static const struct flash_info spi_nor_i
+@@ -2233,6 +2233,11 @@ static const struct flash_info spi_nor_i
  
  	/* GigaDevice */
  	{

--- a/target/linux/generic/pending-5.4/482-mtd-spi-nor-fix-4-byte-opcode-support-for-w25q256.patch
+++ b/target/linux/generic/pending-5.4/482-mtd-spi-nor-fix-4-byte-opcode-support-for-w25q256.patch
@@ -48,7 +48,7 @@ Signed-off-by: Mantas Pucka <mantas@8devices.com>
  /* NOTE: double check command sets and memory organization when you add
   * more nor chips.  This current list focusses on newer chips, which
   * have been converging on command sets which including JEDEC ID.
-@@ -2515,7 +2541,8 @@ static const struct flash_info spi_nor_i
+@@ -2516,7 +2542,8 @@ static const struct flash_info spi_nor_i
  	{ "w25q80", INFO(0xef5014, 0, 64 * 1024,  16, SECT_4K) },
  	{ "w25q80bl", INFO(0xef4014, 0, 64 * 1024,  16, SECT_4K) },
  	{ "w25q128", INFO(0xef4018, 0, 64 * 1024, 256, SECT_4K) },

--- a/target/linux/ipq40xx/patches-5.4/0019-v5.6-mtd-spi-nor-Add-support-for-mx25r3235f.patch
+++ b/target/linux/ipq40xx/patches-5.4/0019-v5.6-mtd-spi-nor-Add-support-for-mx25r3235f.patch
@@ -18,7 +18,7 @@ Signed-off-by: Tudor Ambarus <tudor.ambarus@microchip.com>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2353,6 +2353,8 @@ static const struct flash_info spi_nor_i
+@@ -2354,6 +2354,8 @@ static const struct flash_info spi_nor_i
  	{ "mx25u6435f",  INFO(0xc22537, 0, 64 * 1024, 128, SECT_4K) },
  	{ "mx25l12805d", INFO(0xc22018, 0, 64 * 1024, 256, 0) },
  	{ "mx25l12855e", INFO(0xc22618, 0, 64 * 1024, 256, 0) },

--- a/target/linux/layerscape/patches-5.4/817-spi-0006-LF-20-2-mtd-spi-nor-Use-1-bit-mode-of-spansion-s25fs.patch
+++ b/target/linux/layerscape/patches-5.4/817-spi-0006-LF-20-2-mtd-spi-nor-Use-1-bit-mode-of-spansion-s25fs.patch
@@ -11,7 +11,7 @@ Signed-off-by: Kuldeep Singh <kuldeep.singh@nxp.com>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2419,7 +2419,7 @@ static const struct flash_info spi_nor_i
+@@ -2420,7 +2420,7 @@ static const struct flash_info spi_nor_i
  	{ "s25fl512s",  INFO6(0x010220, 0x4d0080, 256 * 1024, 256,
  			SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
  			SPI_NOR_HAS_LOCK | USE_CLSR) },

--- a/target/linux/mediatek/patches-5.4/1020-spi-nor-w25q512jv.patch
+++ b/target/linux/mediatek/patches-5.4/1020-spi-nor-w25q512jv.patch
@@ -13,7 +13,7 @@ Ref: https://patchwork.ozlabs.org/project/linux-mtd/patch/20210213151047.11700-1
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2552,6 +2552,9 @@ static const struct flash_info spi_nor_i
+@@ -2553,6 +2553,9 @@ static const struct flash_info spi_nor_i
  			  .fixups = &w25q256_fixups },
  	{ "w25q256jvm", INFO(0xef7019, 0, 64 * 1024, 512,
  			     SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },

--- a/target/linux/pistachio/patches-5.4/401-mtd-nor-support-mtd-name-from-device-tree.patch
+++ b/target/linux/pistachio/patches-5.4/401-mtd-nor-support-mtd-name-from-device-tree.patch
@@ -10,7 +10,7 @@ Signed-off-by: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -4938,6 +4938,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -4939,6 +4939,7 @@ int spi_nor_scan(struct spi_nor *nor, co
  	struct mtd_info *mtd = &nor->mtd;
  	struct device_node *np = spi_nor_get_flash_node(nor);
  	struct spi_nor_flash_parameter *params = &nor->params;
@@ -18,7 +18,7 @@ Signed-off-by: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
  	int ret;
  	int i;
  
-@@ -5000,7 +5001,12 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -5001,7 +5002,12 @@ int spi_nor_scan(struct spi_nor *nor, co
  	/* Init flash parameters based on flash_info struct and SFDP */
  	spi_nor_init_params(nor);
  

--- a/target/linux/ramips/patches-5.4/302-spi-nor-add-gd25q512.patch
+++ b/target/linux/ramips/patches-5.4/302-spi-nor-add-gd25q512.patch
@@ -1,6 +1,6 @@
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2305,6 +2305,11 @@ static const struct flash_info spi_nor_i
+@@ -2306,6 +2306,11 @@ static const struct flash_info spi_nor_i
  			SPI_NOR_4B_OPCODES | SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
  			.fixups = &gd25q256_fixups,
  	},


### PR DESCRIPTION
Add support for EON EN25QX128A spi nor flash with no flags as it does support SFDP parsing.

Fixes: #9442
Tested-by: Szabolcs Hubai <szab.hu@gmail.com> [ramips/mt7621: xiaomi_mi-router-4a-gigabit] 
(cherry picked from commit d7876daf6552a9f39bd5e0bf50b554e9406ec275)
[ apply the same patch to 5.4 kernel ]
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>