### PR TITLE
[22.03] generic: add support for EON EN25QX128A spi nor flash

### DIFF
--- a/target/linux/generic/pending-5.10/477-mtd-spi-nor-add-eon-en25qx128a.patch
+++ b/target/linux/generic/pending-5.10/477-mtd-spi-nor-add-eon-en25qx128a.patch
@@ -1,0 +1,21 @@
+From: Christian Marangi <ansuelsmth@gmail.com>
+Subject: kernel/mtd: add support for EON EN25QX128A
+
+Add support for EON EN25QX128A with no flags as it does
+support SFDP parsing.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/mtd/spi-nor/spi-nor.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/mtd/spi-nor/eon.c
++++ b/drivers/mtd/spi-nor/eon.c
+@@ -16,6 +16,7 @@ static const struct flash_info eon_parts
+ 	{ "en25p64",    INFO(0x1c2017, 0, 64 * 1024,  128, 0) },
+ 	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },
+ 	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256, SECT_4K) },
++	{ "en25qx128a", INFO(0x1c7118, 0, 64 * 1024, 256, 0) },
+ 	{ "en25q80a",   INFO(0x1c3014, 0, 64 * 1024,   16,
+ 			     SECT_4K | SPI_NOR_DUAL_READ) },
+ 	{ "en25qh16",   INFO(0x1c7015, 0, 64 * 1024,   32,

--- a/target/linux/generic/pending-5.15/477-mtd-spi-nor-add-eon-en25qx128a.patch
+++ b/target/linux/generic/pending-5.15/477-mtd-spi-nor-add-eon-en25qx128a.patch
@@ -1,0 +1,21 @@
+From: Christian Marangi <ansuelsmth@gmail.com>
+Subject: kernel/mtd: add support for EON EN25QX128A
+
+Add support for EON EN25QX128A with no flags as it does
+support SFDP parsing.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/mtd/spi-nor/spi-nor.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/mtd/spi-nor/eon.c
++++ b/drivers/mtd/spi-nor/eon.c
+@@ -16,6 +16,7 @@ static const struct flash_info eon_parts
+ 	{ "en25p64",    INFO(0x1c2017, 0, 64 * 1024,  128, 0) },
+ 	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },
+ 	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256, SECT_4K) },
++	{ "en25qx128a", INFO(0x1c7118, 0, 64 * 1024, 256, 0) },
+ 	{ "en25q80a",   INFO(0x1c3014, 0, 64 * 1024,   16,
+ 			     SECT_4K | SPI_NOR_DUAL_READ) },
+ 	{ "en25qh16",   INFO(0x1c7015, 0, 64 * 1024,   32,


### PR DESCRIPTION
Add support for EON EN25QX128A spi nor flash with no flags as it does support SFDP parsing.

Fixes: #9442
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
Tested-by: Szabolcs Hubai <szab.hu@gmail.com> [ramips/mt7621: xiaomi_mi-router-4a-gigabit] 
(cherry picked from commit d7876daf6552a9f39bd5e0bf50b554e9406ec275)