### PR TITLE
CI: tools: reogranize and split workflow

### DIFF
--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -1,0 +1,72 @@
+name: Build host tools
+
+on:
+  workflow_call:
+    inputs:
+      generate_prebuilt_artifacts:
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build tools
+    runs-on: ubuntu-latest
+    container: registry.gitlab.com/openwrt/buildbot/buildworker-3.4.1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: openwrt
+
+      - name: Fix permission
+        run: chown -R buildbot:buildbot openwrt
+
+      - name: Set configs for tools container
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: |
+          touch .config
+          echo CONFIG_DEVEL=y >> .config
+          echo CONFIG_AUTOREMOVE=y >> .config
+          echo CONFIG_CCACHE=y >> .config
+
+      - name: Make prereq
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: make defconfig
+
+      - name: Build tools
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: make tools/install -j$(nproc) BUILD_LOG=1 || ret=$? .github/workflows/scripts/show_build_failures.sh
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-buildbot-logs
+          path: openwrt/logs
+
+      - name: Upload config
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-buildbot-config
+          path: openwrt/.config
+
+      - name: Archive prebuilt tools
+        if: inputs.generate_prebuilt_artifacts == true
+        shell: su buildbot -c "sh -e {0}"
+        working-directory: openwrt
+        run: tar --mtime=now -cf tools.tar staging_dir/host build_dir/host dl
+
+      - name: Upload prebuilt tools
+        if: inputs.generate_prebuilt_artifacts == true
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-buildbot-prebuilt-tools
+          path: openwrt/tools.tar
+          retention-days: 1

--- a/.github/workflows/push-containers.yml
+++ b/.github/workflows/push-containers.yml
@@ -1,0 +1,86 @@
+name: Build and Push prebuilt tools container
+
+on:
+  push:
+    paths:
+      - 'tools/**'
+      - '.github/workflows/build-tools.yml'
+      - '.github/workflows/push-containers.yml'
+      - '.github/workflows/Dockerfile.tools'
+
+permissions:
+  contents: read
+
+jobs:
+  build-linux-buildbot:
+    name: Build tools with buildbot container
+    uses: ./.github/workflows/build-tools.yml
+    with:
+      generate_prebuilt_artifacts: true
+
+  push-tools-container:
+    needs: build-linux-buildbot
+    name: Push prebuilt tools container
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set lower case owner name
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >> "$GITHUB_ENV"
+
+      # Per branch tools container tag
+      # By default stick to latest
+      # For official test targetting openwrt stable branch
+      # Get the branch or parse the tag and push dedicated tools containers
+      # Any branch that will match this pattern openwrt-[0-9][0-9].[0-9][0-9]
+      # will refresh the tools container with the matching tag.
+      # (example branch openwrt-22.03 -> tools:openwrt-22.03)
+      # (example branch openwrt-22.03-test -> tools:openwrt-22.03)
+      - name: Determine tools container tag
+        run: |
+          CONTAINER_TAG=latest
+
+          if [ ${{ github.ref_type }} == "branch" ]; then
+            if echo "${{ github.ref_name }}" | grep -q -E 'openwrt-[0-9][0-9]\.[0-9][0-9]'; then
+              CONTAINER_TAG="$(echo ${{ github.ref_name }} | sed 's/^\(openwrt-[0-9][0-9]\.[0-9][0-9]\).*/\1/')"
+            fi
+          elif [ ${{ github.ref_type }} == "tag" ]; then
+            if echo "${{ github.ref_name }}" | grep -q -E 'v[0-9][0-9]\.[0-9][0-9]\..+'; then
+              CONTAINER_TAG=openwrt-"$(echo ${{ github.ref_name }} | sed 's/v\([0-9][0-9]\.[0-9][0-9]\)\..\+/\1/')"
+            fi
+          fi
+
+          echo "Tools container to push tools:$CONTAINER_TAG"
+          echo "CONTAINER_TAG=$CONTAINER_TAG" >> "$GITHUB_ENV"
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: 'openwrt'
+
+      - name: Download prebuilt tools from build job
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-buildbot-prebuilt-tools
+          path: openwrt
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: openwrt
+          push: true
+          tags: ghcr.io/${{ env.OWNER_LC }}/tools:${{ env.CONTAINER_TAG }}
+          file: openwrt/.github/workflows/Dockerfile.tools

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
       - 'tools/**'
+      - '.github/workflows/build-tools.yml'
       - '.github/workflows/tools.yml'
   push:
     paths:
       - 'tools/**'
+      - '.github/workflows/build-tools.yml'
       - '.github/workflows/tools.yml'
 
 permissions:
@@ -15,7 +17,7 @@ permissions:
 
 jobs:
   build-macos-latest:
-    if: github.event_name != 'push'
+    name: Build tools with macos latest
     runs-on: macos-latest
 
     steps:
@@ -97,130 +99,5 @@ jobs:
           path: ${{ env.WORKPATH }}/openwrt/.config
 
   build-linux-buildbot:
-    runs-on: ubuntu-latest
-    container: registry.gitlab.com/openwrt/buildbot/buildworker-3.4.1
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          path: 'openwrt'
-
-      - name: Fix permission
-        run: |
-          chown -R buildbot:buildbot openwrt
-
-      - name: Set configs for tools container
-        if: github.event_name == 'push'
-        shell: su buildbot -c "sh -e {0}"
-        working-directory: openwrt
-        run: |
-          touch .config
-          echo CONFIG_DEVEL=y >> .config
-          echo CONFIG_AUTOREMOVE=y >> .config
-          echo CONFIG_CCACHE=y >> .config
-
-      - name: Make prereq
-        shell: su buildbot -c "sh -e {0}"
-        working-directory: openwrt
-        run: make defconfig
-
-      - name: Build tools BuildBot Container
-        shell: su buildbot -c "sh -e {0}"
-        working-directory: openwrt
-        run: make tools/install -j$(nproc) BUILD_LOG=1 || ret=$? .github/workflows/scripts/show_build_failures.sh
-
-      - name: Upload logs
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: linux-buildbot-logs
-          path: openwrt/logs
-
-      - name: Upload config
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: linux-buildbot-config
-          path: openwrt/.config
-
-      - name: Archive prebuilt tools
-        if: github.event_name == 'push'
-        shell: su buildbot -c "sh -e {0}"
-        working-directory: openwrt
-        run: tar --mtime=now -cf tools.tar staging_dir/host build_dir/host dl
-
-      - name: Upload prebuilt tools
-        if: github.event_name == 'push'
-        uses: actions/upload-artifact@v3
-        with:
-          name: linux-buildbot-prebuilt-tools
-          path: openwrt/tools.tar
-          retention-days: 1
-
-  push-tools-container:
-    needs: build-linux-buildbot
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Set lower case owner name
-        env:
-          OWNER: ${{ github.repository_owner }}
-        run: |
-          echo "OWNER_LC=${OWNER,,}" >> "$GITHUB_ENV"
-
-      # Per branch tools container tag
-      # By default stick to latest
-      # For official test targetting openwrt stable branch
-      # Get the branch or parse the tag and push dedicated tools containers
-      # Any branch that will match this pattern openwrt-[0-9][0-9].[0-9][0-9]
-      # will refresh the tools container with the matching tag.
-      # (example branch openwrt-22.03 -> tools:openwrt-22.03)
-      # (example branch openwrt-22.03-test -> tools:openwrt-22.03)
-      - name: Determine tools container tag
-        run: |
-          CONTAINER_TAG=latest
-
-          if [ ${{ github.ref_type }} == "branch" ]; then
-            if echo "${{ github.ref_name }}" | grep -q -E 'openwrt-[0-9][0-9]\.[0-9][0-9]'; then
-              CONTAINER_TAG="$(echo ${{ github.ref_name }} | sed 's/^\(openwrt-[0-9][0-9]\.[0-9][0-9]\).*/\1/')"
-            fi
-          elif [ ${{ github.ref_type }} == "tag" ]; then
-            if echo "${{ github.ref_name }}" | grep -q -E 'v[0-9][0-9]\.[0-9][0-9]\..+'; then
-              CONTAINER_TAG=openwrt-"$(echo ${{ github.ref_name }} | sed 's/v\([0-9][0-9]\.[0-9][0-9]\)\..\+/\1/')"
-            fi
-          fi
-
-          echo "Tools container to push tools:$CONTAINER_TAG"
-          echo "CONTAINER_TAG=$CONTAINER_TAG" >> "$GITHUB_ENV"
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          path: 'openwrt'
-
-      - name: Download prebuilt tools from build job
-        uses: actions/download-artifact@v3
-        with:
-          name: linux-buildbot-prebuilt-tools
-          path: openwrt
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: openwrt
-          push: true
-          tags: ghcr.io/${{ env.OWNER_LC }}/tools:${{ env.CONTAINER_TAG }}
-          file: openwrt/.github/workflows/Dockerfile.tools
+    name: Build tools with buildbot container
+    uses: ./.github/workflows/build-tools.yml


### PR DESCRIPTION
Generilize tools workflow for future usage in shared workflow for tools build.

Split tools workflow to tools and push-containers:
- tools just execute build test
- push-containers build and push prebuilt containers

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>