### PR TITLE
mac80211: fix bcm53xx wireless not working

### DIFF
--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -729,28 +729,13 @@ mac80211_iw_interface_add() {
 	return $rc
 }
 
-mac80211_set_ifname() {
-	local phy="$1"
-	local prefix="$2"
-	eval "ifname=\"$phy-$prefix\${idx_$prefix:-0}\"; idx_$prefix=\$((\${idx_$prefix:-0 } + 1))"
-}
-
 mac80211_prepare_vif() {
 	json_select config
 
 	json_get_vars ifname mode ssid wds powersave macaddr enable wpa_psk_file vlan_file
 
-	[ -n "$ifname" ] || {
-		local prefix;
-
-		case "$mode" in
-		ap|sta|mesh) prefix=$mode;;
-		adhoc) prefix=ibss;;
-		monitor) prefix=mon;;
-		esac
-
-		mac80211_set_ifname "$phy" "$prefix"
-	}
+	[ -n "$ifname" ] || ifname="wlan${phy#phy}${if_idx:+-$if_idx}"
+	if_idx=$((${if_idx:-0} + 1))
 
 	set_default wds 0
 	set_default powersave 0


### PR DESCRIPTION
On bcm53xx devices, wireless interface name must be "wlan0" or "wlan1"

Fixes: #11466
Fixes: 6603748e0ca6 ("mac80211: change default ifname to <phy>-<type><index>")
Signed-off-by: Ning Nao <ningnao@foxmail.com>