### PR TITLE
Update mt7621_youku_yk-l2.dts

### DIFF
--- a/target/linux/ramips/dts/mt7621_youku_yk-l2.dts
+++ b/target/linux/ramips/dts/mt7621_youku_yk-l2.dts
@@ -164,16 +164,6 @@
 			status = "okay";
 			label = "lan2";
 		};
-
-		port@2 {
-			status = "okay";
-			label = "lan3";
-		};
-
-		port@3 {
-			status = "okay";
-			label = "lan4";
-		};
 	};
 };
 


### PR DESCRIPTION
The switch LAN has only two interfaces

Signed-off-by: Cnbbx <admin@cnbbx.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
