### PR TITLE
tools/llvm: update to 15.0.6

### DIFF
--- a/tools/llvm-bpf/Makefile
+++ b/tools/llvm-bpf/Makefile
@@ -7,16 +7,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=llvm-project
-PKG_VERSION:=14.0.6
+PKG_VERSION:=15.0.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).src.tar.xz
 PKG_SOURCE_URL:=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(PKG_VERSION)
-PKG_HASH:=8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a
+PKG_HASH:=9d53ad04dc60cb7b30e810faf64c5ab8157dadef46c8766f67f286238256ff92
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)-$(PKG_VERSION).src
-
-HOST_BUILD_PARALLEL:=1
 
 CMAKE_BINARY_SUBDIR := build
 CMAKE_SOURCE_SUBDIR := llvm


### PR DESCRIPTION
Release Notes:
	https://discourse.llvm.org/t/llvm-15-0-0-release/65099
	https://discourse.llvm.org/t/llvm-15-0-1-released/65380
	https://discourse.llvm.org/t/llvm-15-0-2-released/65695
	https://discourse.llvm.org/t/llvm-15-0-3-released/66036
	https://discourse.llvm.org/t/llvm-15-0-4-released/66337
	https://discourse.llvm.org/t/llvm-15-0-5-release/66616
	https://discourse.llvm.org/t/llvm-15-0-6-released/66899

Remove HOST_BUILD_PARALLEL as it's default now.

Signed-off-by: Linhui Liu <liulinhui36@gmail.com>