### PR TITLE
rules: fix broken commitcount on alpine system

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -409,7 +409,7 @@ $(shell \
   if git log -1 >/dev/null 2>/dev/null; then \
     if [ -n "$(1)" ]; then \
       last_bump="$$(git log --pretty=format:'%h %s' . | \
-        grep --max-count=1 -e ': [uU]pdate to ' -e ': [bB]ump to ' | \
+        grep -m 1 -e ': [uU]pdate to ' -e ': [bB]ump to ' | \
         cut -f 1 -d ' ')"; \
     fi; \
     if [ -n "$$last_bump" ]; then \


### PR DESCRIPTION
To generate commitcount we use grep --max-count. This is not present on alpine grep and cause wrong generation. Use -m as it's just the short version of --max-count and more portable.

Fixes: #11200
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>