### PR TITLE
tools/sed: Fix handling of symlinks of 128 chars

### DIFF
--- a/tools/sed/patches/001-sed-fix-handling-of-symlinks-pointing-to-path-with-1.patch
+++ b/tools/sed/patches/001-sed-fix-handling-of-symlinks-pointing-to-path-with-1.patch
@@ -1,0 +1,47 @@
+From 8f600f2df293d539e9e9137f6f82faa1633b97c1 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Sat, 17 Dec 2022 20:56:29 -0800
+Subject: [PATCH] sed: fix symlink bufsize readlink check
+
+Problem reported by Hauke Mehrtens.
+* sed/utils.c (follow_symlink): Fix typo when checking size of
+second and later symlink, when that symlink is so large that it
+does not fit into the buffer.  Although the bug is not a buffer
+overflow, it does cause sed to mishandle the symlink.
+* testsuite/follow-symlinks.sh: Test for the bug.
+---
+ sed/utils.c                  |  2 +-
+ testsuite/follow-symlinks.sh | 13 +++++++++++++
+ 3 files changed, 18 insertions(+), 1 deletion(-)
+
+--- a/sed/utils.c
++++ b/sed/utils.c
+@@ -345,7 +345,7 @@ follow_symlink (const char *fname)
+       while ((linklen = (buf_used < buf_size
+                          ? readlink (fn, buf + buf_used, buf_size - buf_used)
+                          : 0))
+-             == buf_size)
++             == buf_size - buf_used)
+         {
+           buf = xpalloc (buf, &buf_size, 1, SSIZE_IDX_MAX, 1);
+           if (num_links)
+--- a/testsuite/follow-symlinks.sh
++++ b/testsuite/follow-symlinks.sh
+@@ -73,4 +73,17 @@ compare_ exp-la-abs out-la-abs || fail=1
+ ln -s la-loop la-loop || framework_failure_
+ sed --follow-symlinks -i s/a/b/ la-loop && fail=1
+ 
++# symlink of length 128
++long=d/
++for i in 2 3 4 5 6 7; do
++  long=$long$long
++done
++dir=${long%/d/}
++file=$dir/xx
++mkdir -p $dir &&
++echo x >$file &&
++ln -s $file yy &&
++ln -s yy xx || framework_failure_
++sed -i --follow-symlinks s/x/y/ xx || fail=1
++
+ Exit $fail


### PR DESCRIPTION
If the absolute path a symlink is pointing to is 128 bytes long sed failed with an error message like this: "<path>/sedstbU8O: Not a directory"

This fixes a problem building python seen in the build bot.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>