### PR TITLE
[RFC] kernel: add bootindex support via NVMEM to mtdsplit

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit.h
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit.h
@@ -31,6 +31,8 @@ int mtd_get_squashfs_len(struct mtd_info *master,
 			 size_t offset,
 			 size_t *squashfs_len);
 
+int mtd_check_nvmem_bootindex(struct device_node *np);
+
 int mtd_check_rootfs_magic(struct mtd_info *mtd, size_t offset,
 			   enum mtdsplit_part_type *type);
 
@@ -44,6 +46,11 @@ int mtd_find_rootfs_from(struct mtd_info *mtd,
 static inline int mtd_get_squashfs_len(struct mtd_info *master,
 				       size_t offset,
 				       size_t *squashfs_len)
+{
+	return -ENODEV;
+}
+
+int mtd_check_nvmem_bootindex(struct device_node *np)
 {
 	return -ENODEV;
 }

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
@@ -69,6 +69,13 @@ static void uimage_parse_dt(struct mtd_info *master, int *extralen,
 {
 	struct device_node *np = mtd_get_of_node(master);
 
+	/*
+	 * use "partitions" node when the parser is called for
+	 * parsing top-level partitions, instead of mtd's node
+	 */
+	if (np && !mtd_is_partition(master))
+		np = of_get_child_by_name(np, "partitions");
+
 	if (!np || !of_device_is_compatible(np, "openwrt,uimage"))
 		return;
 


### PR DESCRIPTION
This patch series adds getting index for booting and checking active partition, and splitting to mtdsplit.

Tested on:

- APRESIA ApresiaLightGS120GT-SS (ascii)
- I-O DATA WN-DEAX1800GR (hex, with additional changes for mtdsplit_fit)