### PR TITLE
realtek: add support for APRESIA ApresiaLightGS120GT-SS

### DIFF
--- a/package/boot/uboot-envtools/files/realtek
+++ b/package/boot/uboot-envtools/files/realtek
@@ -8,6 +8,14 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 case "$board" in
+apresia,aplgs120gtss)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x10000"
+	idx2="$(find_mtd_index u-boot-env2)"
+	[ -n "$idx2" ] && \
+		ubootenv_add_uci_sys_config "/dev/mtd$idx2" "0x0" "0x40000" "0x10000"
+	;;
 d-link,dgs-1210-10mp|\
 d-link,dgs-1210-10p|\
 d-link,dgs-1210-16|\

--- a/target/linux/realtek/dts-5.10/rtl8382_apresia_aplgs120gtss.dts
+++ b/target/linux/realtek/dts-5.10/rtl8382_apresia_aplgs120gtss.dts
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl838x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "apresia,aplgs120gtss", "realtek,rtl8382-soc";
+	model = "APRESIA ApresiaLightGS120GT-SS";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: led-0 {
+			label = "green:pwr";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		led-1 {
+			label = "red:loop";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_FAULT;
+		};
+
+		/* LED chip is soldered, but no hole on the case */
+		led-2 {
+			label = "green:unused";
+			gpios = <&gpio1 36 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 33 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-restart {
+		compatible = "gpio-restart";
+		gpios = <&gpio1 34 GPIO_ACTIVE_LOW>;
+		open-source;
+	};
+
+	gpio1: rtl8231-gpio {
+		compatible = "realtek,rtl8231-gpio";
+		#gpio-cells = <2>;
+		gpio-controller;
+		indirect-access-bus-id = <0>;
+	};
+
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	i2c2: i2c-gpio-2 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 11 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 12 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	i2c3: i2c-gpio-3 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 23 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	/* 4x TX-Disable lines are provided by RTL8214FC */
+	sfp0: sfp-p17 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 8 GPIO_ACTIVE_LOW>;
+	};
+
+	sfp1: sfp-p18 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 3 GPIO_ACTIVE_LOW>;
+	};
+
+	sfp2: sfp-p19 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		los-gpio = <&gpio1 25 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 24 GPIO_ACTIVE_LOW>;
+	};
+
+	sfp3: sfp-p20 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		los-gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 13 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gpio0 {
+	rtl8231_reset {
+		gpio-hog;
+		gpios = <1 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "rtl8231-reset";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "u-boot-env";
+				reg = <0x80000 0x40000>;
+			};
+
+			partition@c0000 {
+				label = "u-boot-env2";
+				reg = <0xc0000 0x40000>;
+			};
+
+			partition@100000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x100000 0xe80000>;
+				openwrt,ih-magic = <0x12345000>;
+			};
+
+			partition@f80000 {
+				label = "firmware2";
+				reg = <0xf80000 0xe80000>;
+			};
+
+			partition@1e00000 {
+				label = "jffs2";
+				reg = <0x1e00000 0x200000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		EXTERNAL_PHY(0)
+		EXTERNAL_PHY(1)
+		EXTERNAL_PHY(2)
+		EXTERNAL_PHY(3)
+		EXTERNAL_PHY(4)
+		EXTERNAL_PHY(5)
+		EXTERNAL_PHY(6)
+		EXTERNAL_PHY(7)
+
+		INTERNAL_PHY(8)
+		INTERNAL_PHY(9)
+		INTERNAL_PHY(10)
+		INTERNAL_PHY(11)
+		INTERNAL_PHY(12)
+		INTERNAL_PHY(13)
+		INTERNAL_PHY(14)
+		INTERNAL_PHY(15)
+
+		EXTERNAL_SFP_PHY_FULL(24, 0)
+		EXTERNAL_SFP_PHY_FULL(25, 1)
+		EXTERNAL_SFP_PHY_FULL(26, 2)
+		EXTERNAL_SFP_PHY_FULL(27, 3)
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, internal)
+		SWITCH_PORT(9, 10, internal)
+		SWITCH_PORT(10, 11, internal)
+		SWITCH_PORT(11, 12, internal)
+		SWITCH_PORT(12, 13, internal)
+		SWITCH_PORT(13, 14, internal)
+		SWITCH_PORT(14, 15, internal)
+		SWITCH_PORT(15, 16, internal)
+
+		SWITCH_PORT(24, 17, qsgmii)
+		SWITCH_PORT(25, 18, qsgmii)
+		SWITCH_PORT(26, 19, qsgmii)
+		SWITCH_PORT(27, 20, qsgmii)
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/dts-5.15/rtl8382_apresia_aplgs120gtss.dts
+++ b/target/linux/realtek/dts-5.15/rtl8382_apresia_aplgs120gtss.dts
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl838x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "apresia,aplgs120gtss", "realtek,rtl8382-soc";
+	model = "APRESIA ApresiaLightGS120GT-SS";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: led-0 {
+			label = "green:pwr";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		led-1 {
+			label = "red:loop";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_FAULT;
+		};
+
+		/* LED chip is soldered, but no hole on the case */
+		led-2 {
+			label = "green:unused";
+			gpios = <&gpio1 36 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 33 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-restart {
+		compatible = "gpio-restart";
+		gpios = <&gpio1 34 GPIO_ACTIVE_LOW>;
+		open-source;
+	};
+
+	gpio1: rtl8231-gpio {
+		compatible = "realtek,rtl8231-gpio";
+		#gpio-cells = <2>;
+		gpio-controller;
+		indirect-access-bus-id = <0>;
+	};
+
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	i2c2: i2c-gpio-2 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 11 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 12 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	i2c3: i2c-gpio-3 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 23 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	/* 4x TX-Disable lines are provided by RTL8214FC */
+	sfp0: sfp-p17 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 8 GPIO_ACTIVE_LOW>;
+	};
+
+	sfp1: sfp-p18 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 3 GPIO_ACTIVE_LOW>;
+	};
+
+	sfp2: sfp-p19 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		los-gpio = <&gpio1 25 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 24 GPIO_ACTIVE_LOW>;
+	};
+
+	sfp3: sfp-p20 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		los-gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 13 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gpio0 {
+	rtl8231_reset {
+		gpio-hog;
+		gpios = <1 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "rtl8231-reset";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "u-boot-env";
+				reg = <0x80000 0x40000>;
+			};
+
+			partition@c0000 {
+				label = "u-boot-env2";
+				reg = <0xc0000 0x40000>;
+			};
+
+			partition@100000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x100000 0xe80000>;
+				openwrt,ih-magic = <0x12345000>;
+			};
+
+			partition@f80000 {
+				label = "firmware2";
+				reg = <0xf80000 0xe80000>;
+			};
+
+			partition@1e00000 {
+				label = "jffs2";
+				reg = <0x1e00000 0x200000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		EXTERNAL_PHY(0)
+		EXTERNAL_PHY(1)
+		EXTERNAL_PHY(2)
+		EXTERNAL_PHY(3)
+		EXTERNAL_PHY(4)
+		EXTERNAL_PHY(5)
+		EXTERNAL_PHY(6)
+		EXTERNAL_PHY(7)
+
+		INTERNAL_PHY(8)
+		INTERNAL_PHY(9)
+		INTERNAL_PHY(10)
+		INTERNAL_PHY(11)
+		INTERNAL_PHY(12)
+		INTERNAL_PHY(13)
+		INTERNAL_PHY(14)
+		INTERNAL_PHY(15)
+
+		EXTERNAL_SFP_PHY_FULL(24, 0)
+		EXTERNAL_SFP_PHY_FULL(25, 1)
+		EXTERNAL_SFP_PHY_FULL(26, 2)
+		EXTERNAL_SFP_PHY_FULL(27, 3)
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, internal)
+		SWITCH_PORT(9, 10, internal)
+		SWITCH_PORT(10, 11, internal)
+		SWITCH_PORT(11, 12, internal)
+		SWITCH_PORT(12, 13, internal)
+		SWITCH_PORT(13, 14, internal)
+		SWITCH_PORT(14, 15, internal)
+		SWITCH_PORT(15, 16, internal)
+
+		SWITCH_PORT(24, 17, qsgmii)
+		SWITCH_PORT(25, 18, qsgmii)
+		SWITCH_PORT(26, 19, qsgmii)
+		SWITCH_PORT(27, 20, qsgmii)
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/Makefile
+++ b/target/linux/realtek/image/Makefile
@@ -6,6 +6,7 @@ include $(INCLUDE_DIR)/image.mk
 KERNEL_LOADADDR = 0x80100000
 
 DEVICE_VARS += \
+        CAMEO_BOARD_MODEL \
         CAMEO_BOARD_VERSION \
         CAMEO_CUSTOMER_SIGNATURE \
         CAMEO_KERNEL_PART \
@@ -36,12 +37,12 @@ define Build/cameo-headers
         dd if=$@ bs=$(CAMEO_KERNEL_PART_SIZE) count=1 of=$@.kernel_part; \
         dd if=$@ bs=$(CAMEO_KERNEL_PART_SIZE) skip=1 of=$@.rootfs_part; \
         $(SCRIPT_DIR)/cameo-imghdr.py $@.kernel_part $@.kernel_part.hex \
-                "$(DEVICE_MODEL)" os $(CAMEO_KERNEL_PART) \
+                "$(CAMEO_BOARD_MODEL)" os $(CAMEO_KERNEL_PART) \
                 $(CAMEO_CUSTOMER_SIGNATURE) \
                 $(CAMEO_BOARD_VERSION) \
                 $(KERNEL_LOADADDR); \
         $(SCRIPT_DIR)/cameo-imghdr.py $@.rootfs_part $@.rootfs_part.hex \
-                "$(DEVICE_MODEL)" squashfs $(CAMEO_ROOTFS_PART) \
+                "$(CAMEO_BOARD_MODEL)" squashfs $(CAMEO_ROOTFS_PART) \
                 $(CAMEO_CUSTOMER_SIGNATURE) \
                 $(CAMEO_BOARD_VERSION); \
         cat $@.kernel_part.hex $@.rootfs_part.hex > $@

--- a/target/linux/realtek/image/Makefile
+++ b/target/linux/realtek/image/Makefile
@@ -9,8 +9,8 @@ DEVICE_VARS += \
         CAMEO_BOARD_VERSION \
         CAMEO_CUSTOMER_SIGNATURE \
         CAMEO_KERNEL_PART \
+        CAMEO_KERNEL_PART_SIZE \
         CAMEO_ROOTFS_PART \
-        DLINK_KERNEL_PART_SIZE \
         H3C_DEVICE_ID \
         H3C_PRODUCT_ID \
         ZYXEL_VERS
@@ -23,18 +23,18 @@ define Build/zyxel-vers
        done ) >> $@
 endef
 
-define Build/dlink-cameo
-	$(SCRIPT_DIR)/cameo-tag.py $@ $(DLINK_KERNEL_PART_SIZE)
+define Build/cameo-tag
+	$(SCRIPT_DIR)/cameo-tag.py $@ $(CAMEO_KERNEL_PART_SIZE)
 endef
 
-define Build/dlink-version
+define Build/cameo-version
 	echo -n "OpenWrt" >> $@
 	dd if=/dev/zero bs=25 count=1 >> $@
 endef
 
-define Build/dlink-headers
-        dd if=$@ bs=$(DLINK_KERNEL_PART_SIZE) count=1 of=$@.kernel_part; \
-        dd if=$@ bs=$(DLINK_KERNEL_PART_SIZE) skip=1 of=$@.rootfs_part; \
+define Build/cameo-headers
+        dd if=$@ bs=$(CAMEO_KERNEL_PART_SIZE) count=1 of=$@.kernel_part; \
+        dd if=$@ bs=$(CAMEO_KERNEL_PART_SIZE) skip=1 of=$@.rootfs_part; \
         $(SCRIPT_DIR)/cameo-imghdr.py $@.kernel_part $@.kernel_part.hex \
                 "$(DEVICE_MODEL)" os $(CAMEO_KERNEL_PART) \
                 $(CAMEO_CUSTOMER_SIGNATURE) \

--- a/target/linux/realtek/image/common.mk
+++ b/target/linux/realtek/image/common.mk
@@ -1,19 +1,13 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
-define Device/d-link_dgs-1210
-  IMAGE_SIZE := 13824k
-  DEVICE_VENDOR := D-Link
-  DLINK_KERNEL_PART_SIZE := 1572864
+define Device/cameo-fw
+  CAMEO_BOARD_MODEL = $$(DEVICE_MODEL)
   KERNEL := \
 	kernel-bin | \
 	append-dtb | \
 	libdeflate-gzip | \
 	uImage gzip | \
 	cameo-tag
-  CAMEO_KERNEL_PART := 2
-  CAMEO_ROOTFS_PART := 3
-  CAMEO_CUSTOMER_SIGNATURE := 2
-  CAMEO_BOARD_VERSION := 32
   IMAGES += factory_image1.bin
   IMAGE/factory_image1.bin := \
 	append-kernel | \
@@ -24,6 +18,17 @@ define Device/d-link_dgs-1210
 	check-size | \
 	cameo-version | \
 	cameo-headers
+endef
+
+define Device/d-link_dgs-1210
+  $(Device/cameo-fw)
+  IMAGE_SIZE := 13824k
+  DEVICE_VENDOR := D-Link
+  CAMEO_KERNEL_PART_SIZE := 1572864
+  CAMEO_KERNEL_PART := 2
+  CAMEO_ROOTFS_PART := 3
+  CAMEO_CUSTOMER_SIGNATURE := 2
+  CAMEO_BOARD_VERSION := 32
 endef
 
 define Device/hpe_1920

--- a/target/linux/realtek/image/common.mk
+++ b/target/linux/realtek/image/common.mk
@@ -9,7 +9,7 @@ define Device/d-link_dgs-1210
 	append-dtb | \
 	libdeflate-gzip | \
 	uImage gzip | \
-	dlink-cameo
+	cameo-tag
   CAMEO_KERNEL_PART := 2
   CAMEO_ROOTFS_PART := 3
   CAMEO_CUSTOMER_SIGNATURE := 2
@@ -22,8 +22,8 @@ define Device/d-link_dgs-1210
 	pad-rootfs | \
 	pad-to 16 | \
 	check-size | \
-	dlink-version | \
-	dlink-headers
+	cameo-version | \
+	cameo-headers
 endef
 
 define Device/hpe_1920

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -12,6 +12,22 @@ define Device/allnet_all-sg8208m
 endef
 TARGET_DEVICES += allnet_all-sg8208m
 
+define Device/apresia_aplgs120gtss
+  $(Device/cameo-fw)
+  SOC := rtl8382
+  IMAGE_SIZE := 14848k
+  DEVICE_VENDOR := APRESIA
+  DEVICE_MODEL := ApresiaLightGS120GT-SS
+  UIMAGE_MAGIC := 0x12345000
+  CAMEO_KERNEL_PART_SIZE := 1572864
+  CAMEO_KERNEL_PART := 3
+  CAMEO_ROOTFS_PART := 4
+  CAMEO_CUSTOMER_SIGNATURE := 2
+  CAMEO_BOARD_MODEL := APLGS120GTSS
+  CAMEO_BOARD_VERSION := 4
+endef
+TARGET_DEVICES += apresia_aplgs120gtss
+
 define Device/d-link_dgs-1210-10mp-f
   $(Device/d-link_dgs-1210)
   SOC := rtl8380


### PR DESCRIPTION
This patch series adds support for APRESIA ApresiaLightGS120GT-SS.
This depends on mtdsplit changes (https://github.com/openwrt/openwrt/pull/11553).

bootlog: https://gist.github.com/musashino205/fca2f5f5db9d3028470d93251e0bb813