### PR TITLE
ath79: convert UBNT Aircube AC WiFis to nvmem-cells

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_aircube-ac.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_aircube-ac.dts
@@ -58,10 +58,26 @@
 				read-only;
 			};
 
-			art: partition@ff0000 {
+			partition@ff0000 {
 				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_art_0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				calibration_art_1000: calibration@1000 {
+					reg = <0x1000 0x440>;
+				};
+
+				calibration_art_5000: calibration@5000 {
+					reg = <0x5000 0x844>;
+				};
 			};
 		};
 	};
@@ -73,6 +89,13 @@
 
 &pcie {
 	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0 0 0 0 0>;
+		nvmem-cells = <&calibration_art_5000>;
+		nvmem-cell-names = "calibration";
+	};
 };
 
 &mdio0 {
@@ -109,15 +132,6 @@
 &wmac {
 	status = "okay";
 
-	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
+	nvmem-cells = <&calibration_art_1000>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -35,7 +35,6 @@ case "$FIRMWARE" in
 	sophos,ap55c|\
 	sophos,ap100|\
 	sophos,ap100c|\
-	ubnt,aircube-ac|\
 	ubnt,bullet-ac|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-lr|\


### PR DESCRIPTION
Pull the calibration data from the nvmem subsystem. This allows us to move userspace caldata extraction into the device-tree definition.

Merge art into partition node.


Run-Tested on an Aircube AC device by myself.

I can offer to convert similar AR9342 targets like the 8 UBNT WA based, too, though I don't own any of them for testing.