### PR TITLE
ramips: add support for Unielec U7621-06 32M build target

### DIFF
--- a/target/linux/ramips/dts/mt7621_unielec_u7621-06-32m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-06-32m.dts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ *  Copyright(c) 2017 Kristian Evensen <kristian.evensen@gmail.com>.
+ *  Copyright(c) 2017 Piotr Dymacz <pepe2k@gmail.com>.
+ *  Copyright(c) 2018 Nishant Sharma <codemarauder@gmail.com>.
+ *  All rights reserved.
+ */
+
+#include "mt7621_unielec_u7621-06.dtsi"
+
+/ {
+	compatible = "unielec,u7621-06-32m", "unielec,u7621-06", "mediatek,mt7621-soc";
+	model = "UniElec U7621-06 (32M flash)";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			firmware: partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2147,6 +2147,18 @@ define Device/unielec_u7621-06-16m
 endef
 TARGET_DEVICES += unielec_u7621-06-16m
 
+define Device/unielec_u7621-06-32m
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 32448k
+  DEVICE_VENDOR := UniElec
+  DEVICE_MODEL := U7621-06
+  DEVICE_VARIANT := 32M
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 -wpad-basic-wolfssl
+  SUPPORTED_DEVICES += unielec,u7621-06-32m
+endef
+TARGET_DEVICES += unielec_u7621-06-32m
+
 define Device/unielec_u7621-06-64m
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)


### PR DESCRIPTION
Unielec offers 32MB variant of U7621-06, see Specifications "NOR Flash"
at the bottom of the page.
http://www.unielecinc.com/q/news/cn/p/product/detail.html?qd_guid=pyrEjfTmYf
Based on target\linux\ramips\dts\mt7621_unielec_u7621-06-64m.dts