### PR TITLE
toolchain/gcc: switch to version 12 by default

### DIFF
--- a/package/kernel/rtl8812au-ct/Makefile
+++ b/package/kernel/rtl8812au-ct/Makefile
@@ -39,7 +39,9 @@ NOSTDINC_FLAGS := \
 	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \
 	-I$(STAGING_DIR)/usr/include/mac80211 \
 	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
-	-include backport/backport.h
+	-include backport/backport.h \
+	-Wno-error=address \
+	-Wno-error=stringop-overread
 
 NOSTDINC_FLAGS+=-DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT -DBUILD_OPENWRT
 

--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -81,7 +81,7 @@ HOST_CONFIGURE_VARS += \
 CONFIGURE_VARS += \
 	ac_cv_search__obstack_free=yes
 
-TARGET_CFLAGS += -D_GNU_SOURCE -Wno-unused-result -Wno-format-nonliteral
+TARGET_CFLAGS += -D_GNU_SOURCE -Wno-unused-result -Wno-format-nonliteral -Wno-error=use-after-free
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include

--- a/package/network/utils/uqmi/Makefile
+++ b/package/network/utils/uqmi/Makefile
@@ -32,7 +32,11 @@ define Package/uqmi/description
 endef
 
 TARGET_CFLAGS += \
-	-I$(STAGING_DIR)/usr/include -ffunction-sections -fdata-sections
+	-I$(STAGING_DIR)/usr/include \
+	-ffunction-sections \
+	-fdata-sections \
+	-Wno-error=dangling-pointer \
+	-Wno-error=maybe-uninitialized
 
 TARGET_LDFLAGS += -Wl,--gc-sections
 

--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -2,7 +2,7 @@
 
 choice
 	prompt "GCC compiler Version" if TOOLCHAINOPTS
-	default GCC_USE_VERSION_11
+	default GCC_USE_VERSION_12
 	help
 	  Select the version of gcc you wish to use.
 

--- a/toolchain/gcc/Config.version
+++ b/toolchain/gcc/Config.version
@@ -1,8 +1,8 @@
-config GCC_VERSION_12
-	default y if GCC_USE_VERSION_12
+config GCC_VERSION_11
+	default y if GCC_USE_VERSION_11
 	bool
 
 config GCC_VERSION
 	string
-	default "12.2.0"	if GCC_VERSION_12
-	default "11.3.0"
+	default "12.2.0"
+	default "11.3.0"	if GCC_VERSION_11

--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -178,7 +178,7 @@ define Host/SetToolchainInfo
 endef
 
 
-ifdef CONFIG_GCC_USE_VERSION_12
+ifeq ($(GCC_MAJOR_VERSION),12)
 	GCC_VERSION_FILE:=gcc/genversion.cc
 else
 	GCC_VERSION_FILE:=gcc/version.c


### PR DESCRIPTION
This was build tested with all core packages on all targets
successfully.

This was run tested on the following systems:
* lantiq/xrx200 musl
* armvirt/64 musl

The size of the images stays more or less the same for mips BE and aarch64.

With GCC 11 I got these sizes for lantiq/xrx200:
````
-rw-r--r-- 1 hauke hauke 7219848 Jan  1 22:01 openwrt-lantiq-xrx200-tplink_tdw8970-initramfs-kernel.bin
-rw-r--r-- 1 hauke hauke 7472208 Jan  1 22:01 openwrt-lantiq-xrx200-tplink_tdw8970-squashfs-sysupgrade.bin
````

With GCC 12 I got these sizes for lantiq/xrx200:
````
-rw-r--r-- 1 hauke hauke 7217355 Jan  1 22:35 openwrt-lantiq-xrx200-tplink_tdw8970-initramfs-kernel.bin
-rw-r--r-- 1 hauke hauke 7406674 Jan  1 22:35 openwrt-lantiq-xrx200-tplink_tdw8970-squashfs-sysupgrade.bin
````

The sysupgrade image is probably padded. The initramfs image is 0.03% smaller.
Some packages are getting bigger:

GCC 11:
````
-rw-r--r-- 1 hauke hauke 347538 Jan  1 22:00 kmod-mac80211_5.10.161+6.1-rc8-2_mips_24kc.ipk
-rw-r--r-- 1 hauke hauke 335388 Jan  1 21:58 libc_1.2.3-4_mips_24kc.ipk
-rw-r--r-- 1 hauke hauke 113211 Jan  1 21:58 dropbear_2022.82-2_mips_24kc.ipk
-rw-r--r-- 1 hauke hauke 134879 Jan  1 21:58 dnsmasq_2.88-1_mips_24kc.ipk
-rw-r--r-- 1 hauke hauke 211657 Jan  1 21:58 busybox_1.35.0-5_mips_24kc.ipk
````

GCC 12:
````
-rw-r--r-- 1 hauke hauke 348493 Jan  1 22:34 kmod-mac80211_5.10.161+6.1-rc8-2_mips_24kc.ipk
-rw-r--r-- 1 hauke hauke 337815 Jan  1 22:29 libc_1.2.3-4_mips_24kc.ipk
-rw-r--r-- 1 hauke hauke 114041 Jan  1 22:30 dropbear_2022.82-2_mips_24kc.ipk
-rw-r--r-- 1 hauke hauke 135145 Jan  1 22:31 dnsmasq_2.88-1_mips_24kc.ipk
-rw-r--r-- 1 hauke hauke 213072 Jan  1 22:33 busybox_1.35.0-5_mips_24kc.ipk
````

With GCC 11 I got these sizes for armvirt/64:
````
-rw-r--r-- 1 hauke hauke  4143943 Jan  1 21:54 openwrt-armvirt-64-default-rootfs.tar.gz
-rwxr-xr-x 1 hauke hauke 10887176 Jan  1 21:54 openwrt-armvirt-64-Image
-rwxr-xr-x 1 hauke hauke 24911880 Jan  1 21:54 openwrt-armvirt-64-Image-initramfs
-rw-r--r-- 1 hauke hauke  4141572 Jan  1 21:54 openwrt-armvirt-64-rootfs.cpio.gz
-rw-r--r-- 1 hauke hauke  4255854 Jan  1 21:54 openwrt-armvirt-64-rootfs-ext4.img.gz
-rw-r--r-- 1 hauke hauke  3391178 Jan  1 21:54 openwrt-armvirt-64-rootfs-squashfs.img.gz
````

With GCC 12 I got these sizes for armvirt/64:
````
-rw-r--r-- 1 hauke hauke  4142778 Jan  2 00:20 openwrt-armvirt-64-default-rootfs.tar.gz
-rwxr-xr-x 1 hauke hauke 10887176 Jan  2 00:20 openwrt-armvirt-64-Image
-rwxr-xr-x 1 hauke hauke 24911880 Jan  2 00:20 openwrt-armvirt-64-Image-initramfs
-rw-r--r-- 1 hauke hauke  4138105 Jan  2 00:20 openwrt-armvirt-64-rootfs.cpio.gz
-rw-r--r-- 1 hauke hauke  4255463 Jan  2 00:20 openwrt-armvirt-64-rootfs-ext4.img.gz
-rw-r--r-- 1 hauke hauke  3390390 Jan  2 00:20 openwrt-armvirt-64-rootfs-squashfs.img.gz
````

When compiling with gcc 12 I ran into some compile errors, I deactivated them in the packages. Most of them are false positives. I am open for better patches.

I started now a build on all targets in github CI. 
https://github.com/hauke/openwrt/actions?query=branch%3Aupdate-gcc-test

If anyone is aware of problem with GCC 12 please post it here. 