### PR TITLE
uboot-mediatek: add support for Xiaomi Redmi Router AX6000

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -39,6 +39,14 @@ xiaomi,redmi-router-ax6000-stock)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x20000"
 	ubootenv_add_uci_sys_config "/dev/mtd2" "0x0" "0x10000" "0x20000"
 	;;
+xiaomi,redmi-router-ax6000-ubootmod)
+	. /lib/upgrade/nand.sh
+	local envubi=$(nand_find_ubi ubi)
+	local envdev=/dev/$(nand_find_volume $envubi ubootenv)
+	local envdev2=/dev/$(nand_find_volume $envubi ubootenv2)
+	ubootenv_add_uci_config "$envdev" "0x0" "0x1f000" "0x20000" "1"
+	ubootenv_add_uci_config "$envdev2" "0x0" "0x1f000" "0x20000" "1"
+	;;
 esac
 
 config_load ubootenv

--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -236,6 +236,18 @@ define U-Boot/mt7986_bananapi_bpi-r3-nor
   FIP_COMPRESS:=1
 endef
 
+define U-Boot/mt7986_xiaomi_redmi-router-ax6000
+  NAME:=Xiaomi Redmi AX6000
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=xiaomi_redmi-router-ax6000-ubootmod
+  UBOOT_CONFIG:=mt7986_xiaomi_redmi-ax6000
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand
+  BL2_SOC:=mt7986
+  BL2_DDRTYPE:=ddr4
+  DEPENDS:=+trusted-firmware-a-mt7986-spim-nand-ddr4
+endef
+
 UBOOT_TARGETS := \
 	mt7620_mt7530_rfb \
 	mt7620_rfb \
@@ -256,6 +268,7 @@ UBOOT_TARGETS := \
 	mt7986_bananapi_bpi-r3-sdmmc \
 	mt7986_bananapi_bpi-r3-snand \
 	mt7986_bananapi_bpi-r3-nor \
+	mt7986_xiaomi_redmi-router-ax6000 \
 	mt7986_rfb
 
 ifdef CONFIG_TARGET_mediatek

--- a/package/boot/uboot-mediatek/patches/439-add-xiaomi_redmi-ax6000.patch
+++ b/package/boot/uboot-mediatek/patches/439-add-xiaomi_redmi-ax6000.patch
@@ -1,0 +1,391 @@
+--- /dev/null
++++ b/configs/mt7986_xiaomi_redmi-ax6000_defconfig
+@@ -0,0 +1,175 @@
++CONFIG_ARM=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TARGET_MT7986=y
++CONFIG_SYS_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7986a-xiaomi_redmi-ax6000"
++CONFIG_DEFAULT_ENV_FILE="xiaomi_redmi-ax6000_env"
++CONFIG_DEFAULT_FDT_FILE="mediatek/mt7986a-xiaomi_redmi-ax6000.dtb"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_SMBIOS_PRODUCT_NAME=""
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_BOOTDELAY=30
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_CFB_CONSOLE_ANSI=y
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_GPIO_HOG=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_FIT=y
++CONFIG_FIT_ENABLE_SHA256_SUPPORT=y
++# CONFIG_LED is not set
++# CONFIG_LED_BLINK is not set
++# CONFIG_LED_GPIO is not set
++CONFIG_LOGLEVEL=7
++CONFIG_LOG=y
++CONFIG_SYS_PROMPT="MT7986> "
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_BOOTP=y
++CONFIG_CMD_BUTTON=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_CPU=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_ECHO=y
++CONFIG_CMD_ENV_READMEM=y
++CONFIG_CMD_ERASEENV=y
++# CONFIG_CMD_EXT4 is not set
++# CONFIG_CMD_FAT is not set
++CONFIG_CMD_FDT=y
++# CONFIG_CMD_FS_GENERIC is not set
++# CONFIG_CMD_FS_UUID is not set
++CONFIG_CMD_GPIO=y
++# CONFIG_CMD_GPT is not set
++CONFIG_CMD_HASH=y
++CONFIG_CMD_ITEST=y
++# CONFIG_CMD_LED is not set
++CONFIG_CMD_LICENSE=y
++CONFIG_CMD_LINK_LOCAL=y
++# CONFIG_CMD_MBR is not set
++CONFIG_CMD_MTD=y
++# CONFIG_CMD_PCI is not set
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_SF_TEST=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_PXE=y
++# CONFIG_CMD_PWM is not set
++CONFIG_CMD_SMC=y
++CONFIG_CMD_TFTPBOOT=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_CMD_UBIFS=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_PART=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_SETEXPR=y
++CONFIG_CMD_SLEEP=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_SOURCE=y
++CONFIG_CMD_STRINGS=y
++# CONFIG_CMD_USB is not set
++# CONFIG_CMD_FLASH is not set
++CONFIG_CMD_UUID=y
++CONFIG_DISPLAY_CPUINFO=y
++CONFIG_DM_MTD=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++# CONFIG_DM_USB is not set
++# CONFIG_DM_PWM is not set
++# CONFIG_PWM_MTK is not set
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_PARTITION_UUIDS=y
++CONFIG_NETCONSOLE=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_CLK=y
++CONFIG_DM_GPIO=y
++# CONFIG_DM_SCSI is not set
++# CONFIG_AHCI is not set
++CONFIG_PHY=y
++# CONFIG_PHY_MTK_TPHY is not set
++CONFIG_PHY_FIXED=y
++CONFIG_DM_ETH=y
++CONFIG_MEDIATEK_ETH=y
++# CONFIG_PCI is not set
++# CONFIG_MMC is not set
++# CONFIG_DM_MMC is not set
++CONFIG_MTD=y
++CONFIG_MTD_UBI_FASTMAP=y
++# CONFIG_DM_PCI is not set
++# CONFIG_PCIE_MEDIATEK is not set
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++# CONFIG_PINCTRL_MT7622 is not set
++CONFIG_POWER_DOMAIN=y
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_PRE_CON_BUF_ADDR=0x4007EF00
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_RAM=y
++CONFIG_DM_SERIAL=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++# CONFIG_I2C is not set
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPI_NAND=y
++CONFIG_MTK_SPI_NAND_MTD=y
++CONFIG_SYSRESET_WATCHDOG=y
++CONFIG_WDT_MTK=y
++CONFIG_LZO=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
++CONFIG_RANDOM_UUID=y
++CONFIG_REGEX=y
++# CONFIG_USB is not set
++# CONFIG_USB_HOST is not set
++# CONFIG_USB_XHCI_HCD is not set
++# CONFIG_USB_XHCI_MTK is not set
++# CONFIG_USB_STORAGE is not set
++CONFIG_OF_EMBED=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_SIZE=0x1f000
++CONFIG_ENV_SIZE_REDUND=0x1f000
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_CLK=y
++CONFIG_PHY_FIXED=y
++CONFIG_DM_ETH=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7986=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_SERIAL=y
++CONFIG_MTK_SERIAL=y
++CONFIG_HEXDUMP=y
++CONFIG_USE_DEFAULT_ENV_FILE=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTK_SPIM=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_NAND=y
++CONFIG_CMD_NAND_TRIMFFS=y
++CONFIG_LMB_MAX_REGIONS=64
+--- /dev/null
++++ b/arch/arm/dts/mt7986a-xiaomi_redmi-ax6000.dts
+@@ -0,0 +1,152 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (c) 2021 MediaTek Inc.
++ * Author: Sam Shih <sam.shih@mediatek.com>
++ */
++
++/dts-v1/;
++#include "mt7986.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++
++/ {
++	#address-cells = <1>;
++	#size-cells = <1>;
++	model = "Xiaomi Redmi AX6000";
++	compatible = "mediatek,mt7986", "mediatek,mt7986-sd-rfb";
++
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	keys {
++		compatible = "gpio-keys";
++		factory {
++			label = "reset";
++			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
++		};
++		mesh {
++			label = "mesh";
++			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&uart0 {
++	status = "okay";
++};
++
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_pins>;
++	status = "disabled";
++};
++
++&eth {
++	status = "okay";
++	mediatek,gmac-id = <0>;
++	phy-mode = "sgmii";
++	mediatek,switch = "mt7531";
++	reset-gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
++
++	fixed-link {
++		speed = <1000>;
++		full-duplex;
++	};
++};
++
++&pinctrl {
++	spic_pins: spi1-pins-func-1 {
++		mux {
++			function = "spi";
++			groups = "spi1_2";
++		};
++	};
++
++	uart1_pins: spi1-pins-func-3 {
++		mux {
++			function = "uart";
++			groups = "uart1_2";
++		};
++	};
++
++	spi_flash_pins: spi0-pins-func-1 {
++		mux {
++			function = "flash";
++			groups = "spi0", "spi0_wp_hold";
++		};
++
++		conf-pu {
++			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_00>;
++		};
++
++		conf-pd {
++			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_00>;
++		};
++	};
++};
++
++&spi0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi_flash_pins>;
++	status = "okay";
++	must_tx;
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <1>;
++	sample_sel = <0>;
++
++	spi_nand@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "bl2";
++				reg = <0x0 0x80000>;
++			};
++
++			partition@100000 {
++				label = "nvram";
++				reg = <0x100000 0x40000>;
++			};
++
++			partition@140000 {
++				label = "bdata";
++				reg = <0x140000 0x40000>;
++			};
++
++			partition@180000 {
++				label = "factory";
++				reg = <0x180000 0x200000>;
++			};
++
++			partition@380000 {
++				label = "fip";
++				reg = <0x380000 0x200000>;
++			};
++
++			partition@600000 {
++				label = "ubi";
++				reg = <0x580000 0x7a80000>;
++			};
++		};
++	};
++};
++
++&watchdog {
++	status = "disabled";
++};
+--- /dev/null
++++ b/xiaomi_redmi-ax6000_env
+@@ -0,0 +1,55 @@
++ethaddr_factory=mtd read factory 0x40080000 0x0 0x20000 && env readmem -b ethaddr 0x40080004 0x6 ; setenv ethaddr_factory
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x46000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootargs=console=ttyS0,115200n8 console_msg_format=syslog
++bootcmd=if pstore check ; then run boot_recovery ; else run boot_ubi ; fi
++bootconf=config-1
++bootdelay=0
++bootfile=openwrt-mediatek-filogic-xiaomi_redmi-router-ax6000-ubootmod-initramfs-recovery.itb
++bootfile_bl2=openwrt-mediatek-filogic-xiaomi_redmi-router-ax6000-ubootmod-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-xiaomi_redmi-router-ax6000-ubootmod-bl31-uboot.fip
++bootfile_upg=openwrt-mediatek-filogic-xiaomi_redmi-router-ax6000-ubootmod-squashfs-sysupgrade.itb
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=0
++bootmenu_title=      [0;34m( ( ( [1;39mOpenWrt[0;34m ) ) )
++bootmenu_0=Initialize environment.=run _firstboot
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=Boot system via TFTP.=run boot_tftp ; run bootmenu_confirm_return
++bootmenu_2=Boot production system from NAND.=run boot_production ; run bootmenu_confirm_return
++bootmenu_3=Boot recovery system from NAND.=run boot_recovery ; run bootmenu_confirm_return
++bootmenu_4=Load production system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_production ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_5=Load recovery system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_recovery ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_6=[31mLoad BL31+U-Boot FIP via TFTP then write to NAND.[0m=run boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_7=[31mLoad BL2 preloader via TFTP then write to NAND.[0m=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_8=Reboot.=reset
++bootmenu_9=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_first=if button reset ; then run boot_tftp_recovery ; setenv flag_recover 1 ; run boot_default ; fi ; bootmenu
++boot_default=if env exists flag_recover ; then else run bootcmd ; fi ; run boot_recovery ; setenv replacevol 1 ; run boot_tftp_forever
++boot_production=run ubi_read_production && bootm $loadaddr#$bootconf
++boot_recovery=run ubi_read_recovery && bootm $loadaddr#$bootconf
++boot_ubi=run boot_production ; run boot_recovery ; run boot_tftp_forever
++boot_tftp_forever=while true ; do run boot_tftp_recovery ; sleep 1 ; done
++boot_tftp_recovery=tftpboot $loadaddr $bootfile && env exists replacevol && iminfo $loadaddr && run ubi_write_recovery ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp_production=tftpboot $loadaddr $bootfile_upg && env exists replacevol && iminfo $loadaddr && run ubi_write_production ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp=tftpboot $loadaddr $bootfile && bootm $loadaddr#$bootconf
++boot_tftp_write_fip=tftpboot $loadaddr $bootfile_fip && run mtd_write_fip && run reset_factory
++boot_tftp_write_bl2=tftpboot $loadaddr $bootfile_bl2 && run mtd_write_bl2
++part_fit=fit
++reset_factory=ubi part ubi ; mw $loadaddr 0x0 0x800 ; ubi write $loadaddr ubootenv 0x800 ; ubi write $loadaddr ubootenv2 0x800
++mtd_write_fip=mtd erase fip && mtd write fip $loadaddr
++mtd_write_bl2=mtd erase bl2 && mtd write bl2 $loadaddr
++ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x100000 dynamic 0 ; ubi check ubootenv2 || ubi create ubootenv2 0x100000 dynamic 1
++ubi_format=ubi detach ; mtd erase ubi && ubi part ubi ; reset
++ubi_prepare_rootfs=if ubi check rootfs_data ; then else if env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi ; fi
++ubi_read_production=ubi read $loadaddr $part_fit && iminfo $loadaddr && run ubi_prepare_rootfs
++ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery
++ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++ubi_write_production=ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic && ubi write $loadaddr fit $filesize
++ubi_write_recovery=ubi check recovery && ubi remove recovery ; run ubi_remove_rootfs ; ubi create recovery $filesize dynamic && ubi write $loadaddr recovery $filesize
++_init_env=setenv _init_env ; run ubi_create_env ; saveenv ; saveenv
++_firstboot=setenv _firstboot ; run ethaddr_factory ; run _switch_to_menu ; run _init_env ; run boot_first
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"

--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000-stock.dts
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000-stock.dts
@@ -8,7 +8,25 @@
 	compatible = "xiaomi,redmi-router-ax6000-stock", "mediatek,mt7986a";
 };
 
+&spi_nand_flash {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};
+
 &partitions {
+	partition@580000 {
+		label = "crash";
+		reg = <0x580000 0x40000>;
+		read-only;
+	};
+
+	partition@5c0000 {
+		label = "crash_log";
+		reg = <0x5c0000 0x40000>;
+		read-only;
+	};
+
 	partition@600000 {
 		label = "ubi_kernel";
 		reg = <0x600000 0x1e00000>;

--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000-ubootmod.dts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7986a-xiaomi-redmi-router-ax6000.dtsi"
+
+/ {
+	model = "Xiaomi Redmi Router AX6000 (OpenWrt U-Boot layout)";
+	compatible = "xiaomi,redmi-router-ax6000-ubootmod", "mediatek,mt7986a";
+};
+
+&partitions {
+	partition@580000 {
+		label = "ubi";
+		reg = <0x580000 0x7a80000>;
+	};
+};

--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dts
@@ -8,7 +8,25 @@
 	compatible = "xiaomi,redmi-router-ax6000", "mediatek,mt7986a";
 };
 
+&spi_nand_flash {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};
+
 &partitions {
+	partition@580000 {
+		label = "crash";
+		reg = <0x580000 0x40000>;
+		read-only;
+	};
+
+	partition@5c0000 {
+		label = "crash_log";
+		reg = <0x5c0000 0x40000>;
+		read-only;
+	};
+
 	/* ubi partition is the result of squashing
 	 * consecutive stock partitions:
 	 * - ubi

--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
@@ -127,15 +127,11 @@
 	pinctrl-0 = <&spi_flash_pins>;
 	status = "okay";
 
-	flash@0 {
+	spi_nand_flash: flash@0 {
 		compatible = "spi-nand";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		reg = <0>;
-
-		mediatek,nmbm;
-		mediatek,bmt-max-ratio = <1>;
-		mediatek,bmt-max-reserved-blocks = <64>;
 
 		spi-max-frequency = <20000000>;
 		spi-tx-buswidth = <4>;
@@ -179,18 +175,6 @@
 			partition@380000 {
 				label = "FIP";
 				reg = <0x380000 0x200000>;
-				read-only;
-			};
-
-			partition@580000 {
-				label = "crash";
-				reg = <0x580000 0x40000>;
-				read-only;
-			};
-
-			partition@5c0000 {
-				label = "crash_log";
-				reg = <0x5c0000 0x40000>;
 				read-only;
 			};
 		};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -7,7 +7,8 @@ board_config_update
 
 case $board in
 xiaomi,redmi-router-ax6000|\
-xiaomi,redmi-router-ax6000-stock)
+xiaomi,redmi-router-ax6000-stock|\
+xiaomi,redmi-router-ax6000-ubootmod)
 	ucidef_set_led_netdev "wan" "wan" "rgb:network" "wan"
 	;;
 esac

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -17,7 +17,8 @@ mediatek_setup_interfaces()
 		ucidef_set_interface_macaddr "wan" "$(macaddr_add $(cat /sys/class/net/eth0/address) 1)"
 		;;
 	xiaomi,redmi-router-ax6000|\
-	xiaomi,redmi-router-ax6000-stock)
+	xiaomi,redmi-router-ax6000-stock|\
+	xiaomi,redmi-router-ax6000-ubootmod)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" wan
 		;;
 	*)
@@ -35,7 +36,8 @@ mediatek_setup_macs()
 
 	case $board in
 	xiaomi,redmi-router-ax6000|\
-	xiaomi,redmi-router-ax6000-stock)
+	xiaomi,redmi-router-ax6000-stock|\
+	xiaomi,redmi-router-ax6000-ubootmod)
 		wan_mac=$(mtd_get_mac_ascii Bdata ethaddr_wan)
 		label_mac=$wan_mac
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -64,6 +64,10 @@ platform_do_upgrade() {
 		CI_ROOT_UBIPART=ubi
 		nand_do_upgrade "$1"
 		;;
+	xiaomi,redmi-router-ax6000-ubootmod)
+		CI_KERNPART="fit"
+		nand_do_upgrade "$1"
+		;;
 	*)
 		nand_do_upgrade "$1"
 		;;

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -157,3 +157,32 @@ endif
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += xiaomi_redmi-router-ax6000-stock
+
+define Device/xiaomi_redmi-router-ax6000-ubootmod
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := Redmi Router AX6000 (OpenWrt U-Boot layout)
+  DEVICE_DTS := mt7986a-xiaomi-redmi-router-ax6000-ubootmod
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-leds-ws2812b
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  IMAGES := sysupgrade.itb
+  KERNEL_LOADADDR := 0x48000000
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+        fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+  ARTIFACTS := preloader.bin bl31-uboot.fip
+  ARTIFACT/preloader.bin := bl2 spim-nand-ddr4
+  ARTIFACT/bl31-uboot.fip := bl31-uboot xiaomi_redmi-router-ax6000
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  ARTIFACTS += initramfs-factory.ubi
+  ARTIFACT/initramfs-factory.ubi := append-image-stage initramfs-recovery.itb | ubinize-kernel
+endif
+endef
+TARGET_DEVICES += xiaomi_redmi-router-ax6000-ubootmod


### PR DESCRIPTION
uboot-mediatek: add support for Xiaomi Redmi Router AX6000

U-Boot flash instructions:

0. OpenWrt U-Boot does not support stock layout, it comes with recovery
boot support, automatic tftp recovery and never blocks UART.

A new flash layout is introduced, we call it OpenWrt U-Boot layout,
stock flash layout and the old OpenWrt layout are not supported.

During the whole flash procedure, please do not reboot or power off
unless requested explicitly, or you will break your device.

1. Your device should already running OpenWrt.
If not, follow the instructions to flash OpenWrt:
https://github.com/openwrt/openwrt/pull/11115

2. Backup BL2 Nvram Bdata Factory and FIP in case you break something or
in case you want to go back to stock firmware one day.

cat /dev/mtdblock0 > /tmp/BL2.bin
cat /dev/mtdblock1 > /tmp/Nvram.bin
cat /dev/mtdblock2 > /tmp/Bdata.bin
cat /dev/mtdblock3 > /tmp/Factory.bin
cat /dev/mtdblock4 > /tmp/FIP.bin

And save all whose bin files to somewhere safe.

Then backup your configurations, since ubiformat for entire mtd device is
required to create new ubootenv volume for OpenWrt U-Boot.

3. Run the following cmd to boot into an initramfs with the new OpenWrt
U-Boot layout that expand ubi partion to the end of flash:

ubiformat /dev/mtd7 -y -f /tmp/ax6000-ubootmod-initramfs-factory.ubi

4. After boot into initramfs, check mtd partion info.
The ubi partion should be mtd5

root@OpenWrt:~# cat /proc/mtd
dev:    size   erasesize  name
mtd0: 00100000 00020000 BL2
mtd1: 00040000 00020000 Nvram
mtd2: 00040000 00020000 Bdata
mtd3: 00200000 00020000 Factory
mtd4: 00200000 00020000 FIP
mtd5: 07a80000 00020000 ubi

5. Load kmod-mtd-rw to temporarily make the bootloader partions writable.
The kmod-mtd-rw is from the feeds, it is not packed in initramfs-kernel
by default.

To install kmod-mtd-rw via opkg

opkg update && opkg install kmod-mtd-rw

Or, download kmod-mtd-rw.ipk from OpenWrt server and install it manually
e.g:
https://downloads.openwrt.org/snapshots/targets/mediatek/filogic/kmods/
Select your OpenWrt release version and kernel version accordingly.

Load kmod-mtd-rw:
insmod /lib/modules/$(uname -r)/mtd-rw.ko i_want_a_brick=1

6. Run the following cmd to clean all pending crash dumps in pstore,
or OpenWrt U-Boot may boot into NAND recovery or tftp recovery.

rm -f /sys/fs/pstore/*

7. Format ubi and create new ubootenv volume:

ubidetach -p /dev/mtd5; ubiformat /dev/mtd5 -y; ubiattach -p /dev/mtd5
ubimkvol /dev/ubi0 -n 0 -N ubootenv -s 128KiB
ubimkvol /dev/ubi0 -n 1 -N ubootenv2 -s 128KiB

8. This is optional. Skip this if you do not want to have NAND recovery
boot feature offered by OpenWrt U-Boot. Don't worry, you always have
automatic tftp recovery feature enabled.

ubimkvol /dev/ubi0 -n 2 -N recovery -s 10MiB
ubiupdatevol /dev/ubi0_2 /tmp/ax6000-ubootmod-initramfs-recovery.itb

9. Now, flash new U-Boot. Bye-bye ugly stock U-Boot.

mtd write /tmp/ax6000-ubootmod-preloader.bin BL2
mtd write /tmp/ax6000-ubootmod-bl31-uboot.fip FIP

10. Flash the squashfs-sysupgrade.bin as usual

sysupgrade -n /tmp/ax6000-ubootmod-squashfs-sysupgrade.itb

Enjoy!