### PR TITLE
github: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Create a bug report to help us improve
+labels:
+  - bug
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: OpenWrt version
+      description: |
+        The OpenWrt release or commit hash where this bug occurs (use command below).
+        ```. /etc/openwrt_release && echo $DISTRIB_REVISION```
+    validations:
+      required: true
+  - type: input
+    id: target
+    attributes:
+      label: OpenWrt target/subtarget
+      description: |
+        The OpenWrt target and subtarget where this bug is observed (use command below).
+        ```. /etc/openwrt_release && echo $DISTRIB_TARGET```
+    validations:
+      required: true
+  - type: input
+    id: device
+    attributes:
+      label: Device
+      description: The device exhibiting this bug.
+    validations:
+      required: true
+  - type: dropdown
+    id: image_kind
+    attributes:
+      label: Image kind
+      options:
+        - Official downloaded image
+        - Self-built image
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the reported behaviour.
+  - type: textarea
+    id: behaviour
+    attributes:
+      label: Actual behaviour
+      description: A clear and concise description of what actually happens.
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: A clear and concise description of what you expected to happen.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional info
+      description: Add any additional info you think might be helfpul.
+  - type: textarea
+    id: diffconfig
+    attributes:
+      label: Diffconfig
+      description: |
+        In case of a self-built image, please attach diffconfig.
+        ```./scripts/diffconfig.sh```
+      render: text
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Terms
+      description: By submitting this issue, you agree to the terms below.
+      options:
+        - label: I am reporting an issue for OpenWrt, not an unsupported fork.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+---
+blank_issues_enabled: false
+contact_links:
+  - name: Feature request
+    url: https://forum.openwrt.org
+    about: The OpenWrt project relies on volunteers. While we appreciate feature requests, we might lack the manpower to handle them. Ideally, you get familiar with the codebase and attempt to contribute the feature yourself. We recommend to post in the forum, as this is the most likely place to receive feedback on feature requests.
+  - name: OpenWrt community
+    url: https://openwrt.org/contact
+    about: Consider reaching out to our community to get help. OpenWrt is a complex software project with many pitfalls; there is a good chance someone can help you solve your issue in no time.
+  - name: OpenWrt documentation
+    url: https://openwrt.org/docs/start
+    about: The OpenWrt documentation contains a lot of valuable information.


### PR DESCRIPTION
Add an issue template with required fields, instructions how to easily get some of that required data from the device. Aside from that, also add some links to the OpenWrt contact page, and for feature requests, link to the forum.

TODO: we still need to create a dedicated forum category for feature requests and link to that directly.
And we might want to reconsider some wording. I tried to be friendly, but not being a native English speaker ... Maybe we need a review by @ldir-EDB0 or @dwmw2?

@jow requested to remove the "If this doesn't look right, choose a different type" part, but this is added by Github and I have not found a way to remove this.

Also ping @aparcar @Ansuel

Previews:
* https://github.com/stintel/openwrt-issue-template/issues/new/choose
* https://github.com/stintel/openwrt-issue-template/issues/1