### PR TITLE
xdp-tools: update to version 1.2.9

### DIFF
--- a/package/network/utils/xdp-tools/Makefile
+++ b/package/network/utils/xdp-tools/Makefile
@@ -2,8 +2,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xdp-tools
 PKG_RELEASE:=$(AUTORELEASE)
-PKG_VERSION:=1.2.8
-PKG_HASH:=2c575e5242e60055b0e7fc720f5b6ea87d74911f967dde3d50046d751f35bff0
+PKG_VERSION:=1.2.9
+PKG_HASH:=159ed8d3c8195d812ec3cde83bd736245a72743af372998320d39c2ba69ab142
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/xdp-project/xdp-tools/tar.gz/v$(PKG_VERSION)?

--- a/package/network/utils/xdp-tools/patches/010-configure-respect-LDFLAGS.patch
+++ b/package/network/utils/xdp-tools/patches/010-configure-respect-LDFLAGS.patch
@@ -1,6 +1,6 @@
 --- a/configure
 +++ b/configure
-@@ -138,7 +138,7 @@ int main(int argc, char **argv) {
+@@ -174,7 +174,7 @@ int main(int argc, char **argv) {
      return 0;
  }
  EOF
@@ -9,7 +9,7 @@
      if [ "$?" -eq "0" ]; then
          echo "HAVE_PCAP:=y" >>$CONFIG
          [ -n "$LIBPCAP_CFLAGS" ] && echo 'CFLAGS += ' $LIBPCAP_CFLAGS >> $CONFIG
-@@ -186,7 +186,7 @@ int main(int argc, char **argv) {
+@@ -222,7 +222,7 @@ int main(int argc, char **argv) {
      return 0;
  }
  EOF
@@ -18,7 +18,7 @@
      if [ "$?" -eq "0" ]; then
          echo "HAVE_FEATURES+=${config_var}" >>"$CONFIG"
          echo "yes"
-@@ -253,7 +253,7 @@ int main(int argc, char **argv) {
+@@ -289,7 +289,7 @@ int main(int argc, char **argv) {
  }
  EOF
  


### PR DESCRIPTION
Changes since v1.2.8:
 xdp-project/xdp-tools@32aaf32 libxdp: Fix incorrect rx_ring_setup_done
 xdp-project/xdp-tools@6049671 headers: add bpf_endian.h for parsing_helpers.h
 xdp-project/xdp-tools@2682c1c export-man: Ignore errors when executing git shell command
 xdp-project/xdp-tools@8afda7a xdp-loader/README: Mention lack of support for HW mode in most cards
 xdp-project/xdp-tools@dc69919 libxdp: fix prog_fd checks for fd >= 0
 xdp-project/xdp-tools@3d7c22a libxdp: Allow falling back to single-program attachment for loaded programs
 xdp-project/xdp-tools@af00429 libxdp: Fix check in xdp_program__attach_single()
 xdp-project/xdp-tools@41703d2 libxdp: Make sure to set the the program autoload when loading a program
 xdp-project/xdp-tools@b1fd2e5 test-xdpdump: Only run tshark attribute test on newer versions of tshark
 xdp-project/xdp-tools@5dfe342 libxdp: Convert xdp-dispatcher to use strict section names
 xdp-project/xdp-tools@929a22e configure: Try to auto-detect versioned clang binaries
 xdp-project/xdp-tools@074fcfb libxdp: Check program name when determining if a program is a dispatcher
 xdp-project/xdp-tools@e13a191 Bump TOOLS_VERSION to 1.2.9

Signed-off-by: Daniel Golle <daniel@makrotopia.org>