### PR TITLE
ipq40xx: convert Aruba AP-303H to DSA and enable target again

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -69,6 +69,7 @@ ipq40xx_setup_interfaces()
 	mikrotik,wap-r-ac)
 		ucidef_set_interface_lan "sw-eth1 sw-eth2"
 		;;
+	aruba,ap-303h|\
 	netgear,rbr50|\
 	netgear,rbs50|\
 	netgear,srr60|\

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4029-ap-303h.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4029-ap-303h.dts
@@ -420,6 +420,38 @@
 	status = "okay";
 };
 
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport2 {
+	status = "okay";
+
+	label = "lan1";
+};
+
+&swport3 {
+	status = "okay";
+
+	label = "lan2";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "lan3";
+};
+
+&swport5 {
+	status = "okay";
+
+	label = "wan";
+};
+
 &wifi0 {
 	status = "okay";
 	qcom,ath10k-calibration-variant = "Aruba-AP-303";

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -181,8 +181,7 @@ define Device/aruba_ap-303h
 	$(call Device/aruba_glenmorangie)
 	DEVICE_MODEL := AP-303H
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += aruba_ap-303h
+TARGET_DEVICES += aruba_ap-303h
 
 define Device/aruba_ap-365
 	$(call Device/aruba_glenmorangie)


### PR DESCRIPTION
The target was disabled since noone did the DSA conversion. Add the conversion and enable it again.