### PR TITLE
realtek: Fix patches to match proper style

### DIFF
--- a/target/linux/realtek/patches-5.10/302-clocksource-add-otto-driver.patch
+++ b/target/linux/realtek/patches-5.10/302-clocksource-add-otto-driver.patch
@@ -1,3 +1,56 @@
+From 3cc8011171186d906c547bc6f0c1f8e350edc7cf Mon Sep 17 00:00:00 2001
+From: Markus Stockhausen <markus.stockhausen@gmx.de>
+Date: Mon, 3 Oct 2022 14:45:21 +0200
+Subject: [PATCH] realtek: resurrect timer driver
+
+Now that we provide a clock driver for the Reltek SOCs the CPU frequency might
+change on demand. This has direct visible effects during operation
+
+- the CEVT 4K timer is no longer a stable clocksource
+- after CPU frequencies changes time calculation works wrong
+- sched_clock falls back to kernel default interval (100 Hz)
+- timestamps in dmesg have only 2 digits left
+
+[    0.000000] sched_clock: 32 bits at 100 Hz, resolution 10000000ns, wraps ...
+[    0.060000] pid_max: default: 32768 minimum: 301
+[    0.070000] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
+[    0.070000] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
+[    0.080000] dyndbg: Ignore empty _ddebug table in a CONFIG_DYNAMIC_DEBUG_CORE build
+[    0.090000] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, ...
+
+Looking around where we can start the CEVT timer for RTL930X is a good basis.
+Initially it was developed as a clocksource driver for the broken timer in that
+specific SOC series. Afterwards it was shifted around to the CEVT location,
+got SMP enablement and lost its clocksource feature. So we at least have
+something to copy from. As the timers on these devices are well understood
+the implementation follows this way:
+
+- leave the RTL930X implementation as is
+- provide a new driver for RTL83XX devices only
+- swap RTL930X driver at a later time
+
+Like the clock driver this patch contains a self contained module that is SOC
+independet and already provides full support for the RTL838X, RTL839X and
+RTL930X devices. Some of the new (or reestablished) features are:
+
+- simplified initialization routines
+- SMP setup with CPU hotplug framework
+- derived from LXB clock speed
+- supplied clocksource
+- dedicated register functions for better readability
+- documentation about some caveats
+
+Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
+[remove unused header includes, remove old CONFIG_MIPS dependency, add
+REALTEK_ prefix to driver symbol]
+Signed-off-by: Sander Vanheule <sander@svanheule.net>
+
+---
+ drivers/clocksource/Kconfig                   | 12 +++
+ drivers/clocksource/Makefile                  |  1 +
+ include/linux/cpuhotplug.h                    |  1 +
+ 3 files changed, 14 insertions(+)
+ 
 --- a/drivers/clocksource/Kconfig
 +++ b/drivers/clocksource/Kconfig
 @@ -127,6 +127,17 @@ config RDA_TIMER

--- a/target/linux/realtek/patches-5.15/302-clocksource-add-otto-driver.patch
+++ b/target/linux/realtek/patches-5.15/302-clocksource-add-otto-driver.patch
@@ -1,3 +1,56 @@
+From 3cc8011171186d906c547bc6f0c1f8e350edc7cf Mon Sep 17 00:00:00 2001
+From: Markus Stockhausen <markus.stockhausen@gmx.de>
+Date: Mon, 3 Oct 2022 14:45:21 +0200
+Subject: [PATCH] realtek: resurrect timer driver
+
+Now that we provide a clock driver for the Reltek SOCs the CPU frequency might
+change on demand. This has direct visible effects during operation
+
+- the CEVT 4K timer is no longer a stable clocksource
+- after CPU frequencies changes time calculation works wrong
+- sched_clock falls back to kernel default interval (100 Hz)
+- timestamps in dmesg have only 2 digits left
+
+[    0.000000] sched_clock: 32 bits at 100 Hz, resolution 10000000ns, wraps ...
+[    0.060000] pid_max: default: 32768 minimum: 301
+[    0.070000] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
+[    0.070000] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
+[    0.080000] dyndbg: Ignore empty _ddebug table in a CONFIG_DYNAMIC_DEBUG_CORE build
+[    0.090000] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, ...
+
+Looking around where we can start the CEVT timer for RTL930X is a good basis.
+Initially it was developed as a clocksource driver for the broken timer in that
+specific SOC series. Afterwards it was shifted around to the CEVT location,
+got SMP enablement and lost its clocksource feature. So we at least have
+something to copy from. As the timers on these devices are well understood
+the implementation follows this way:
+
+- leave the RTL930X implementation as is
+- provide a new driver for RTL83XX devices only
+- swap RTL930X driver at a later time
+
+Like the clock driver this patch contains a self contained module that is SOC
+independet and already provides full support for the RTL838X, RTL839X and
+RTL930X devices. Some of the new (or reestablished) features are:
+
+- simplified initialization routines
+- SMP setup with CPU hotplug framework
+- derived from LXB clock speed
+- supplied clocksource
+- dedicated register functions for better readability
+- documentation about some caveats
+
+Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
+[remove unused header includes, remove old CONFIG_MIPS dependency, add
+REALTEK_ prefix to driver symbol]
+Signed-off-by: Sander Vanheule <sander@svanheule.net>
+
+---
+ drivers/clocksource/Kconfig                   | 12 +++
+ drivers/clocksource/Makefile                  |  1 +
+ include/linux/cpuhotplug.h                    |  1 +
+ 3 files changed, 14 insertions(+)
+
 --- a/drivers/clocksource/Kconfig
 +++ b/drivers/clocksource/Kconfig
 @@ -127,6 +127,17 @@ config RDA_TIMER


### PR DESCRIPTION
 See commit f1f97db627b2 ("realtek: Convert incorrect v5.10 patches").

@svanheule label 5.10 and 5.15?