### PR TITLE
lantiq-xrx200: fix wan LED on o2 box 6431/arcadyan-vgv7510kw22

### DIFF
--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
@@ -28,7 +28,10 @@ arcadyan,arv7519rw22)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0.1"
 	;;
 arcadyan,vgv7510kw22-nor|\
-arcadyan,vgv7510kw22-brn|\
+arcadyan,vgv7510kw22-brn)
+	ucidef_set_led_netdev "internet" "internet" "$led_internet" "wan"
+	ucidef_set_led_wlan "wifi" "wifi" "green:wlan" "phy0radio"
+	;;
 zyxel,p-2812hnu-f1|\
 zyxel,p-2812hnu-f3)
 	ucidef_set_led_wlan "wifi" "wifi" "green:wlan" "phy0radio"


### PR DESCRIPTION
The WIFI LED already worked for me with the latest openwrt 22.03 version. Wifi LED did not with an older 22.x version (in gluon - there phy0radio did nothing but phy0tpt did show activity

the WAN interface has the name "wan" and not "pppoe-wan" on this device

fixes #7757 (and FS#2987)

Signed-off-by: Florian Maurer <f.maurer@outlook.de>