### PR TITLE
ramips: add missing LEDs to Asus RT-AX53U

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -26,10 +26,20 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_power: led-0 {
+		led_power: power {
+			label = "blue:power";
 			color = <LED_COLOR_ID_BLUE>;
-                        function = LED_FUNCTION_POWER;
+			function = LED_FUNCTION_POWER;
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_usb {
+			label = "blue:usb";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_USB;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ehci_port2>;
+			linux,default-trigger = "usbport";
 		};
 	};
 

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -307,7 +307,8 @@ define Device/asus_rt-ax53u
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
-  DEVICE_PACKAGES := kmod-mt7915e kmod-usb3 uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915e kmod-usb3 uboot-envtools \
+	kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += asus_rt-ax53u
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -19,6 +19,11 @@ asus,rp-ac87)
 	ucidef_set_led_rssi "rssimed-wlan1" "RSSIMED" "green:rssimed-wlan1" "wlan1" "40" "100"
 	ucidef_set_led_rssi "rssihigh-wlan1" "RSSIHIGH" "green:rssihigh-wlan1" "wlan1" "70" "100"
 	;;
+asus,rt-ax53u)
+	ucidef_set_led_usbport "usb" "USB" "blue:usb" "usb1-port2"
+	ucidef_set_led_wlan "wlan2g" "WiFi 2.4GHz" "mt76-phy0" "phy0tpt"
+	ucidef_set_led_wlan "wlan5g" "WiFi 5GHz" "mt76-phy1" "phy1tpt"
+	;;
 asus,rt-n56u-b1)
 	ucidef_set_led_netdev "lan" "LAN link" "blue:lan" "br-lan"
 	ucidef_set_led_netdev "wan" "WAN link" "blue:wan" "wan"


### PR DESCRIPTION
This patch adds the missing LEDs to Asus RT-AX53U.
Based on PR https://github.com/openwrt/openwrt/pull/10400 and patch provided in https://github.com/openwrt/openwrt/issues/11068
 - enable the two LEDs controlled by mt7915e for wireless (depends on https://github.com/openwrt/mt76/pull/725);
 - add label to power LED so it works properly and fix formatting;
 - add the USB LED;
 - switch LEDs are best left to be controlled by hardware for now.

Fixes: https://github.com/openwrt/openwrt/issues/11068

Co-Authored-By: Ivan Rozhuk <rozhuk.im@gmail.com>
Co-Authored-By: Shiji Yang <yangshiji66@qq.com>
Co-Authored-By: Hartmut Birr <e9hack@gmail.com>
Tested-by: Felix Baumann <felix.bau@gmx.de>
Tested-by: Marian Sarcinschi <znevna@gmail.com>
Signed-off-by: Marian Sarcinschi <znevna@gmail.com>