### PR TITLE
kernel: backport ksmbd security fix ZDI-22-1690

### DIFF
--- a/package/kernel/ksmbd/patches/02-fix_zdi_22_1690.patch
+++ b/package/kernel/ksmbd/patches/02-fix_zdi_22_1690.patch
@@ -1,0 +1,53 @@
+From 1f9d85a340b0d8ff14cf47573417fe84efef9731 Mon Sep 17 00:00:00 2001
+From: Namjae Jeon <linkinjeon@kernel.org>
+Date: Wed, 27 Jul 2022 23:11:47 +0900
+Subject: [PATCH] ksmbd: fix use-after-free bug in smb2_tree_disconect
+
+smb2_tree_disconnect() freed the struct ksmbd_tree_connect,
+but it left the dangling pointer. It can be accessed
+again under compound requests.
+
+This bug can lead an oops looking something link:
+
+[ 1685.468014 ] BUG: KASAN: use-after-free in ksmbd_tree_conn_disconnect+0x131/0x160 [ksmbd]
+[ 1685.468068 ] Read of size 4 at addr ffff888102172180 by task kworker/1:2/4807
+...
+[ 1685.468130 ] Call Trace:
+[ 1685.468132 ]  <TASK>
+[ 1685.468135 ]  dump_stack_lvl+0x49/0x5f
+[ 1685.468141 ]  print_report.cold+0x5e/0x5cf
+[ 1685.468145 ]  ? ksmbd_tree_conn_disconnect+0x131/0x160 [ksmbd]
+[ 1685.468157 ]  kasan_report+0xaa/0x120
+[ 1685.468194 ]  ? ksmbd_tree_conn_disconnect+0x131/0x160 [ksmbd]
+[ 1685.468206 ]  __asan_report_load4_noabort+0x14/0x20
+[ 1685.468210 ]  ksmbd_tree_conn_disconnect+0x131/0x160 [ksmbd]
+[ 1685.468222 ]  smb2_tree_disconnect+0x175/0x250 [ksmbd]
+[ 1685.468235 ]  handle_ksmbd_work+0x30e/0x1020 [ksmbd]
+[ 1685.468247 ]  process_one_work+0x778/0x11c0
+[ 1685.468251 ]  ? _raw_spin_lock_irq+0x8e/0xe0
+[ 1685.468289 ]  worker_thread+0x544/0x1180
+[ 1685.468293 ]  ? __cpuidle_text_end+0x4/0x4
+[ 1685.468297 ]  kthread+0x282/0x320
+[ 1685.468301 ]  ? process_one_work+0x11c0/0x11c0
+[ 1685.468305 ]  ? kthread_complete_and_exit+0x30/0x30
+[ 1685.468309 ]  ret_from_fork+0x1f/0x30
+
+Reported-by: zdi-disclosures@trendmicro.com # ZDI-CAN-17816
+Reviewed-by: Hyunchul Lee <hyc.lee@gmail.com>
+Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>
+---
+ smb2pdu.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/smb2pdu.c b/smb2pdu.c
+index 15bded43..1396ec49 100644
+--- a/smb2pdu.c
++++ b/smb2pdu.c
+@@ -2059,6 +2059,7 @@ int smb2_tree_disconnect(struct ksmbd_work *work)
+ 
+ 	ksmbd_close_tree_conn_fds(work);
+ 	ksmbd_tree_conn_disconnect(sess, tcon);
++	work->tcon = NULL;
+ 	return 0;
+ }
+ 


### PR DESCRIPTION
 Fix zero day vulnerability reported as [ZDI-22-1690](https://www.zerodayinitiative.com/advisories/ZDI-22-1690/), no CVE assigned yet.
 Picked from https://github.com/cifsd-team/ksmbd/commit/1f9d85a340
