### PR TITLE
uboot-*: build with newly added generic subtargets

### DIFF
--- a/package/boot/uboot-kirkwood/Makefile
+++ b/package/boot/uboot-kirkwood/Makefile
@@ -17,6 +17,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define U-Boot/Default
   BUILD_TARGET:=kirkwood
+  BUILD_SUBTARGET:=generic
 endef
 
 define U-Boot/dockstar

--- a/package/boot/uboot-mxs/Makefile
+++ b/package/boot/uboot-mxs/Makefile
@@ -19,6 +19,7 @@ include $(INCLUDE_DIR)/host-build.mk
 
 define U-Boot/Default
   BUILD_TARGET:=mxs
+  BUILD_SUBTARGET:=generic
   UBOOT_IMAGE:=u-boot.sb
   DEFAULT:=y
   HIDDEN:=1

--- a/package/boot/uboot-omap/Makefile
+++ b/package/boot/uboot-omap/Makefile
@@ -18,6 +18,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define U-Boot/Default
   BUILD_TARGET:=omap
+  BUILD_SUBTARGET:=generic
   UBOOT_IMAGE:=u-boot.img MLO
 endef
 

--- a/package/boot/uboot-tegra/Makefile
+++ b/package/boot/uboot-tegra/Makefile
@@ -18,6 +18,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define U-Boot/Default
   BUILD_TARGET := tegra
+  BUILD_SUBTARGET := generic
   HIDDEN := y
 endef
 

--- a/package/boot/uboot-zynq/Makefile
+++ b/package/boot/uboot-zynq/Makefile
@@ -18,6 +18,7 @@ include $(INCLUDE_DIR)/host-build.mk
 
 define U-Boot/Default
   BUILD_TARGET:=zynq
+  BUILD_SUBTARGET:=generic
   UBOOT_IMAGE:=spl/boot.bin u-boot.img
   UBOOT_CONFIG:=zynq_$(1)
   UENV:=default


### PR DESCRIPTION
Some U-Boot images are required by firmware image. Without these patches, image build fails.

- zynq/generic
    - https://buildbot.openwrt.org/master/images/#/builders/69/builds/743
- tegra/generic
    - https://buildbot.openwrt.org/master/images/#/builders/62/builds/739
- omap/generic
    - https://buildbot.openwrt.org/master/images/#/builders/32/builds/744

And some succeeds with U-Boot images missing.

- 22.03.2 (U-Boot images exist)
    - https://downloads.openwrt.org/releases/22.03.2/targets/kirkwood/generic/
- snapshot (U-Boot images are currently missing)
    - https://downloads.openwrt.org/snapshots/targets/kirkwood/generic/

Specify generic subtarget in according `uboot-*` packages to fix such issues.

Fixes: cada395a ("kirkwood: add generic subtarget")
Fixes: 64ef920b ("mxs: add generic subtarget")
Fixes: 6d7129ef ("zynq: add generic subtarget")
Fixes: c028e1b1 ("tegra: add generic subtarget")
Fixes: b2bfea48 ("omap: add generic subtarget")
Ref: 40e3f660 ("uboot-fritz4040: build with ipq40xx generic subtarget")

CC: @Ansuel