### PR TITLE
ramips: enable BBT on NAND in I-O DATA devices

### DIFF
--- a/target/linux/ramips/dts/mt7621_iodata_wn-dx1200gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-dx1200gr.dts
@@ -58,6 +58,11 @@
 &nand {
 	status = "okay";
 
+	mediatek,bbt;
+	mediatek,bmt-remap-range =
+		<0x0000000 0x0800000>,
+		<0x3600000 0x4980000>;
+
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/target/linux/ramips/dts/mt7621_iodata_wn-xx-xr.dtsi
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-xx-xr.dtsi
@@ -55,6 +55,11 @@
 &nand {
 	status = "okay";
 
+	mediatek,bbt;
+	mediatek,bmt-remap-range =
+		<0x0000000 0x0800000>,
+		<0x3600000 0x4980000>;
+
 	partitions: partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;


### PR DESCRIPTION
This patch enables MediaTek NAND BBT on I-O DATA devices manufactured by MSTC (MitraStar Technology Corp.).

[WN-AX2033GR]
Tested-by: Yanase Yuki <dev@zpc.sakura.ne.jp>
[WN-AX1167GR2, WN-DX1167R, WN-DX1200GR, WN-DX2033GR]
Tested-by: INAGAKI Hiroshi <musashino.open@gmail.com>
Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
