### PR TITLE
ramips: add support for read/write uboot env to Asus RX-AX53U

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -49,6 +49,7 @@ zbtlink,zbt-wg2626|\
 zte,mf283plus)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
 	;;
+asus,rt-ax53u|\
 belkin,rt1800|\
 h3c,tx1800-plus|\
 h3c,tx1801-plus|\

--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -60,12 +60,21 @@
 
 		partition@0 {
 			label = "u-boot";
-			reg = <0x0 0xe0000>;
+			reg = <0x0 0x80000>;
 			read-only;
 		};
 
-		partition@e0000 {
+		/*
+		 * u-boot gets split here while keeping u-boot read-only,
+		 * which allows safe usage of fw_setenv
+		 */
+		partition@80000 {
 			label = "u-boot-env";
+			reg = <0x80000 0x60000>;
+		};
+
+		partition@e0000 {
+			label = "nvram";
 			reg = <0xe0000 0x100000>;
 			read-only;
 		};


### PR DESCRIPTION
Add support for read/writing uboot env by renaming the second partition
to its stock label "nvram" and remove the deemed unnecessary
"read-only". Split the first partition "u-boot" in two, in order
to allow `fw_setenv` safe write-access to the uboot environment
variables.

This implements hauke's request from [1].
Based on the patch provided by Shiji Yang.

[1] https://github.com/openwrt/openwrt/pull/10400#discussion_r945153224

Co-Authored-By: Shiji Yang <yangshiji66@qq.com>
Signed-off-by: Felix Baumann <felix.bau@gmx.de>
