### PR TITLE
treewide: strip useless `default n` Kconfig lines

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -5,7 +5,6 @@
 
 config EXPERIMENTAL
 	bool "Enable experimental features by default"
-	default n
 	help
 	  Set this option to build with latest bleeding edge features
 	  which may or may not work as expected.
@@ -42,7 +41,6 @@ menu "Global build settings"
 
 	config BUILDBOT
 		bool "Set build defaults for automatic builds (e.g. via buildbot)"
-		default n
 		help
 		  This option changes several defaults to be more suitable for
 		  automatic builds. This includes the following changes:
@@ -75,10 +73,8 @@ menu "Global build settings"
 
 	config DISPLAY_SUPPORT
 		bool "Show packages that require graphics support (local or remote)"
-		default n
 
 	config BUILD_PATENTED
-		default n
 		bool "Compile with support for patented functionality"
 		help
 		  When this option is disabled, software which provides patented functionality
@@ -86,7 +82,6 @@ menu "Global build settings"
 		  functionality, this optional support will get disabled for this package.
 
 	config BUILD_NLS
-		default n
 		bool "Compile with full language support"
 		help
 		  When this option is enabled, packages are built with the full versions of
@@ -100,7 +95,6 @@ menu "Global build settings"
 	config CLEAN_IPKG
 		bool
 		prompt "Remove ipkg/opkg status data files in final images"
-		default n
 		help
 		  This removes all ipkg/opkg status data files from the target directory
 		  before building the root filesystem.
@@ -108,14 +102,12 @@ menu "Global build settings"
 	config IPK_FILES_CHECKSUMS
 		bool
 		prompt "Record files checksums in package metadata"
-		default n
 		help
 		  This makes file checksums part of package metadata. It increases size
 		  but provides you with pkg_check command to check for flash corruptions.
 
 	config INCLUDE_CONFIG
 		bool "Include build configuration in firmware" if DEVEL
-		default n
 		help
 		  If enabled, buildinfo files will be stored in /etc/build.* of firmware.
 
@@ -149,7 +141,6 @@ menu "Global build settings"
 	config DEBUG
 		bool
 		prompt "Compile packages with debugging info"
-		default n
 		help
 		  Adds -g3 to the CFLAGS.
 

--- a/config/Config-devel.in
+++ b/config/Config-devel.in
@@ -4,11 +4,9 @@
 
 menuconfig DEVEL
 	bool "Advanced configuration options (for developers)"
-	default n
 
 	config BROKEN
 		bool "Show broken platforms / packages / devices" if DEVEL
-		default n
 
 	config BINARY_FOLDER
 		string "Binary folder" if DEVEL
@@ -53,7 +51,6 @@ menuconfig DEVEL
 
 	config AUTOREMOVE
 		bool "Automatic removal of build directories" if DEVEL
-		default n
 		help
 		  Automatically delete build directories after make target completed.
 		  This allows you to symlink build_dir into a scratch location, e.g. a ramdisk,
@@ -61,7 +58,6 @@ menuconfig DEVEL
 
 	config BUILD_ALL_HOST_TOOLS
 		bool "Compile all host tools" if DEVEL
-		default n
 		help
 		  Compile all host host tools even if not needed. This is needed to prepare a
 		  universal precompiled host tools archive to use in another buildroot.
@@ -84,7 +80,6 @@ menuconfig DEVEL
 
 	config CCACHE
 		bool "Use ccache" if DEVEL
-		default n
 		help
 		  Compiler cache; see https://ccache.samba.org/
 

--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -59,7 +59,6 @@ menu "Target Images"
 		config TARGET_INITRAMFS_FORCE
 			bool "Force"
 			depends on TARGET_ROOTFS_INITRAMFS
-			default n
 			help
 			  Ignore the initramfs passed by the bootloader.
 
@@ -128,7 +127,6 @@ menu "Target Images"
 		config TARGET_EXT4_JOURNAL
 			bool "Create a journaling filesystem"
 			depends on TARGET_ROOTFS_EXT4FS
-			default n
 			help
 			  Create an ext4 filesystem with a journal.
 
@@ -233,7 +231,6 @@ menu "Target Images"
 	config GRUB_FLOWCONTROL
 		bool "Use RTE/CTS on serial console"
 		depends on GRUB_SERIAL != ""
-		default n
 
 	config GRUB_BOOTOPTS
 		string "Extra kernel boot options"
@@ -312,7 +309,6 @@ menu "Target Images"
 
 	config TARGET_ROOTFS_PERSIST_VAR
 		bool "Make /var persistent"
-		default n
 		help
 		  Do not symlink /var to /tmp, so that its content will persist
 		  across reboots. When enabled, /var/run will still be linked

--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -47,12 +47,10 @@ config KERNEL_MIPS_FP_SUPPORT
 
 config KERNEL_ARM_PMU
 	bool
-	default n
 	depends on (arm || aarch64)
 
 config KERNEL_X86_VSYSCALL_EMULATION
 	bool "Enable vsyscall emulation"
-	default n
 	depends on x86_64
 	help
 	  This enables emulation of the legacy vsyscall page.  Disabling
@@ -70,12 +68,10 @@ config KERNEL_X86_VSYSCALL_EMULATION
 
 config KERNEL_PERF_EVENTS
 	bool "Compile the kernel with performance events and counters"
-	default n
 	select KERNEL_ARM_PMU if (arm || aarch64)
 
 config KERNEL_PROFILING
 	bool "Compile the kernel with profiling enabled"
-	default n
 	select KERNEL_PERF_EVENTS
 	help
 	  Enable the extended profiling support mechanisms used by profilers such
@@ -255,7 +251,6 @@ config KERNEL_KCOV_INSTRUMENT_ALL
 
 config KERNEL_TASKSTATS
 	bool "Compile the kernel with task resource/io statistics and accounting"
-	default n
 	help
 	  Enable the collection and publishing of task/io statistics and
 	  accounting.  Enable this option to enable i/o monitoring in system
@@ -283,37 +278,30 @@ config KERNEL_KALLSYMS
 config KERNEL_FTRACE
 	bool "Compile the kernel with tracing support"
 	depends on !TARGET_uml
-	default n
 
 config KERNEL_FTRACE_SYSCALLS
 	bool "Trace system calls"
 	depends on KERNEL_FTRACE
-	default n
 
 config KERNEL_ENABLE_DEFAULT_TRACERS
 	bool "Trace process context switches and events"
 	depends on KERNEL_FTRACE
-	default n
 
 config KERNEL_FUNCTION_TRACER
 	bool "Function tracer"
 	depends on KERNEL_FTRACE
-	default n
 
 config KERNEL_FUNCTION_GRAPH_TRACER
 	bool "Function graph tracer"
 	depends on KERNEL_FUNCTION_TRACER
-	default n
 
 config KERNEL_DYNAMIC_FTRACE
 	bool "Enable/disable function tracing dynamically"
 	depends on KERNEL_FUNCTION_TRACER
-	default n
 
 config KERNEL_FUNCTION_PROFILER
 	bool "Function profiler"
 	depends on KERNEL_FUNCTION_TRACER
-	default n
 
 config KERNEL_IRQSOFF_TRACER
 	bool "Interrupts-off Latency Tracer"
@@ -364,7 +352,6 @@ config KERNEL_HIST_TRIGGERS
 
 config KERNEL_DEBUG_KERNEL
 	bool
-	default n
 
 config KERNEL_DEBUG_INFO
 	bool "Compile the kernel with debug information"
@@ -376,7 +363,6 @@ config KERNEL_DEBUG_INFO
 config KERNEL_DEBUG_INFO_BTF
 
 	bool "Enable additional BTF type information"
-	default n
 	depends on !HOST_OS_MACOS
 	depends on KERNEL_DEBUG_INFO && !KERNEL_DEBUG_INFO_REDUCED
 	select DWARVES
@@ -403,12 +389,10 @@ config KERNEL_DEBUG_INFO_REDUCED
 
 config KERNEL_DEBUG_LL_UART_NONE
 	bool
-	default n
 	depends on arm
 
 config KERNEL_DEBUG_LL
 	bool
-	default n
 	depends on arm
 	select KERNEL_DEBUG_LL_UART_NONE
 	help
@@ -417,7 +401,6 @@ config KERNEL_DEBUG_LL
 config KERNEL_DEBUG_VIRTUAL
 	bool "Compile the kernel with VM translations debugging"
 	select KERNEL_DEBUG_KERNEL
-	default n
 	help
 	  Enable checks sanity checks to catch invalid uses of
 	  virt_to_phys()/phys_to_virt() against the non-linear address space.
@@ -425,7 +408,6 @@ config KERNEL_DEBUG_VIRTUAL
 config KERNEL_DYNAMIC_DEBUG
 	bool "Compile the kernel with dynamic printk"
 	select KERNEL_DEBUG_FS
-	default n
 	help
 	  Compiles debug level messages into the kernel, which would not
 	  otherwise be available at runtime. These messages can then be
@@ -437,7 +419,6 @@ config KERNEL_DYNAMIC_DEBUG
 config KERNEL_EARLY_PRINTK
 	bool "Compile the kernel with early printk"
 	default y if TARGET_bcm53xx
-	default n
 	depends on arm
 	select KERNEL_DEBUG_KERNEL
 	select KERNEL_DEBUG_LL if arm
@@ -448,7 +429,6 @@ config KERNEL_EARLY_PRINTK
 
 config KERNEL_KPROBES
 	bool "Compile the kernel with kprobes support"
-	default n
 	select KERNEL_FTRACE
 	select KERNEL_PERF_EVENTS
 	help
@@ -465,7 +445,6 @@ config KERNEL_KPROBE_EVENTS
 
 config KERNEL_BPF_EVENTS
 	bool "Compile the kernel with BPF event support"
-	default n
 	select KERNEL_KPROBES
 	help
 	  Allows to attach BPF programs to kprobe, uprobe and tracepoint events.
@@ -475,7 +454,6 @@ config KERNEL_BPF_EVENTS
 
 config KERNEL_BPF_KPROBE_OVERRIDE
 	bool
-	default n
 	depends on KERNEL_KPROBES
 
 config KERNEL_AIO
@@ -496,7 +474,6 @@ config KERNEL_FANOTIFY
 
 config KERNEL_BLK_DEV_BSG
 	bool "Compile the kernel with SCSI generic v4 support for any block device"
-	default n
 
 config KERNEL_TRANSPARENT_HUGEPAGE
 	bool
@@ -520,7 +497,6 @@ config KERNEL_HUGETLB_PAGE
 	bool "Compile the kernel with HugeTLB support"
 	select KERNEL_TRANSPARENT_HUGEPAGE
 	select KERNEL_HUGETLBFS
-	default n
 
 config KERNEL_MAGIC_SYSRQ
 	bool "Compile the kernel with SysRq support"
@@ -545,7 +521,6 @@ config KERNEL_ELF_CORE
 config KERNEL_PROVE_LOCKING
 	bool "Enable kernel lock checking"
 	select KERNEL_DEBUG_KERNEL
-	default n
 
 config KERNEL_SOFTLOCKUP_DETECTOR
 	bool "Compile the kernel with detect Soft Lockups"
@@ -647,11 +622,9 @@ config USE_RFKILL
 
 config USE_SPARSE
 	bool "Enable sparse check during kernel build"
-	default n
 
 config KERNEL_DEVTMPFS
 	bool "Compile the kernel with device tmpfs enabled"
-	default n
 	help
 	  devtmpfs is a simple, kernel-managed /dev filesystem. The kernel creates
 	  devices nodes for all registered devices to simplify boot, but leaves more
@@ -661,7 +634,6 @@ if KERNEL_DEVTMPFS
 
 	config KERNEL_DEVTMPFS_MOUNT
 		bool "Automatically mount devtmpfs after root filesystem is mounted"
-		default n
 
 endif
 
@@ -672,17 +644,14 @@ config KERNEL_KEYS
 config KERNEL_PERSISTENT_KEYRINGS
 	bool "Enable kernel persistent keyrings"
 	depends on KERNEL_KEYS
-	default n
 
 config KERNEL_KEYS_REQUEST_CACHE
 	bool "Enable temporary caching of the last request_key() result"
 	depends on KERNEL_KEYS
-	default n
 
 config KERNEL_BIG_KEYS
 	bool "Enable large payload keys on kernel keyrings"
 	depends on KERNEL_KEYS
-	default n
 
 #
 # CGROUP support symbols
@@ -696,7 +665,6 @@ if KERNEL_CGROUPS
 
 	config KERNEL_CGROUP_DEBUG
 		bool "Example debug cgroup subsystem"
-		default n
 		help
 		  This option enables a simple cgroup subsystem that
 		  exports useful debugging information about the cgroups
@@ -707,7 +675,6 @@ if KERNEL_CGROUPS
 
 	config KERNEL_CGROUP_FREEZER
 		bool "legacy Freezer cgroup subsystem"
-		default n
 		select KERNEL_FREEZER
 		help
 		  Provides a way to freeze and unfreeze all tasks in a
@@ -717,7 +684,6 @@ if KERNEL_CGROUPS
 
 	config KERNEL_CGROUP_DEVICE
 		bool "legacy Device controller for cgroups"
-		default n
 		help
 		  Provides a cgroup implementing whitelists for devices which
 		  a process in the cgroup can mknod or open.
@@ -725,7 +691,6 @@ if KERNEL_CGROUPS
 
 	config KERNEL_CGROUP_HUGETLB
 		bool "HugeTLB controller"
-		default n
 		select KERNEL_HUGETLB_PAGE
 
 	config KERNEL_CGROUP_PIDS
@@ -754,7 +719,6 @@ if KERNEL_CGROUPS
 
 	config KERNEL_PROC_PID_CPUSET
 		bool "Include legacy /proc/<pid>/cpuset file"
-		default n
 		depends on KERNEL_CPUSETS
 
 	config KERNEL_CGROUP_CPUACCT
@@ -820,7 +784,6 @@ if KERNEL_CGROUPS
 
 	config KERNEL_MEMCG_SWAP_ENABLED
 		bool "Memory Resource Controller Swap Extension enabled by default"
-		default n
 		depends on KERNEL_MEMCG_SWAP
 		help
 		  Memory Resource Controller Swap Extension comes with its price in
@@ -849,7 +812,6 @@ if KERNEL_CGROUPS
 	config KERNEL_CGROUP_PERF
 		bool "Enable perf_event per-cpu per-container group (cgroup) monitoring"
 		select KERNEL_PERF_EVENTS
-		default n
 		help
 		  This option extends the per-cpu mode to restrict monitoring to
 		  threads which belong to the cgroup specified and run on the
@@ -926,7 +888,6 @@ if KERNEL_CGROUPS
 
 	config KERNEL_DEBUG_BLK_CGROUP
 		bool "Enable Block IO controller debugging"
-		default n
 		depends on KERNEL_BLK_CGROUP
 		help
 		  Enable some debugging help. Currently it exports additional stat
@@ -934,15 +895,12 @@ if KERNEL_CGROUPS
 
 	config KERNEL_NET_CLS_CGROUP
 		bool "legacy Control Group Classifier"
-		default n
 
 	config KERNEL_CGROUP_NET_CLASSID
 		bool "legacy Network classid cgroup"
-		default n
 
 	config KERNEL_CGROUP_NET_PRIO
 		bool "legacy Network priority cgroup"
-		default n
 
 endif
 
@@ -1168,7 +1126,6 @@ endif
 menu "Filesystem ACL and attr support options"
 	config USE_FS_ACL_ATTR
 		bool "Use filesystem ACL and attr support by default"
-		default n
 		help
 		  Make using ACLs (e.g. POSIX ACL, NFSv4 ACL) the default
 		  for kernel and packages, except tmpfs, flash filesystems,
@@ -1193,17 +1150,14 @@ menu "Filesystem ACL and attr support options"
 	config KERNEL_F2FS_FS_POSIX_ACL
 		bool "Enable POSIX ACL for F2FS Filesystems"
 		select KERNEL_FS_POSIX_ACL
-		default n
 
 	config KERNEL_JFFS2_FS_POSIX_ACL
 		bool "Enable POSIX ACL for JFFS2 Filesystems"
 		select KERNEL_FS_POSIX_ACL
-		default n
 
 	config KERNEL_TMPFS_POSIX_ACL
 		bool "Enable POSIX ACL for TMPFS Filesystems"
 		select KERNEL_FS_POSIX_ACL
-		default n
 
 	config KERNEL_CIFS_ACL
 		bool "Enable CIFS ACLs"
@@ -1226,15 +1180,12 @@ menu "Filesystem ACL and attr support options"
 
 	config KERNEL_NFS_V3_ACL_SUPPORT
 		bool "Enable ACLs for NFSv3"
-		default n
 
 	config KERNEL_NFSD_V2_ACL_SUPPORT
 		bool "Enable ACLs for NFSDv2"
-		default n
 
 	config KERNEL_NFSD_V3_ACL_SUPPORT
 		bool "Enable ACLs for NFSDv3"
-		default n
 
 	config KERNEL_REISER_FS_POSIX_ACL
 		bool "Enable POSIX ACLs for ReiserFS"

--- a/target/linux/at91/image/Config.in
+++ b/target/linux/at91/image/Config.in
@@ -1,10 +1,8 @@
 config AT91_DFBOOT
 	bool "Build dataflashboot loader"
 	depends on TARGET_at91
-	default n
 
 config FLEXIBITY_ROOT
 	bool "Build Flexibity RootFS (with embedded kernel)"
 	depends on TARGET_at91_flexibity
-	default n
 

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/Kconfig
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/Kconfig
@@ -10,14 +10,12 @@ if AG71XX
 
 config AG71XX_DEBUG
 	bool "Atheros AR71xx built-in ethernet driver debugging"
-	default n
 	help
 	  Atheros AR71xx built-in ethernet driver debugging messages.
 
 config AG71XX_DEBUG_FS
 	bool "Atheros AR71xx built-in ethernet driver debugfs support"
 	depends on DEBUG_FS
-	default n
 	help
 	  Say Y, if you need access to various statistics provided by
 	  the ag71xx driver.

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/Kconfig
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/Kconfig
@@ -12,7 +12,6 @@ config MTD_SPLIT_SQUASHFS_ROOT
 	bool "Squashfs based root partition parser"
 	depends on MTD_SPLIT_SUPPORT
 	select MTD_SPLIT
-	default n
 	help
 	  This provides a parsing function which allows to detect the
 	  offset and size of the unused portion of a rootfs partition

--- a/target/linux/generic/files/drivers/platform/mikrotik/Kconfig
+++ b/target/linux/generic/files/drivers/platform/mikrotik/Kconfig
@@ -1,6 +1,5 @@
 menuconfig MIKROTIK
 	bool "Platform support for MikroTik RouterBoard virtual devices"
-	default n
 	help
 	  Say Y here to get to see options for the MikroTik RouterBoard platform.
 	  This option alone does not add any kernel code.

--- a/target/sdk/files/Config.in
+++ b/target/sdk/files/Config.in
@@ -23,7 +23,6 @@ menu "Global build settings"
 	config DEBUG
 		bool
 		prompt "Compile packages with debugging info"
-		default n
 		help
 		  Adds -g3 to the CFLAGS.
 
@@ -69,7 +68,6 @@ menu "Advanced configuration options (for developers)"
 
 	config BROKEN
 		bool "Show broken packages"
-		default n
 
 	config DOWNLOAD_FOLDER
 		string "Download folder"
@@ -101,19 +99,16 @@ menu "Advanced configuration options (for developers)"
 
 	config CCACHE
 		bool "Use ccache"
-		default n
 		help
 		  Compiler cache; see https://ccache.samba.org/
 
 	config BUILD_LOG
 		bool "Enable log files during build process"
-		default n
 		help
 		  If enabled, log files will be written to the ./log directory.
 
 	config SRC_TREE_OVERRIDE
 		bool "Enable package source tree override"
-		default n
 		help
 		  If enabled, you can force a package to use a git tree as source
 		  code instead of the normal tarball. Create a symlink 'git-src'

--- a/toolchain/Config.in
+++ b/toolchain/Config.in
@@ -197,7 +197,6 @@ menuconfig EXTRA_TARGET_ARCH
 	bool
 	prompt "Enable an extra toolchain target architecture" if TOOLCHAINOPTS
 	depends on !sparc
-	default n
 	help
 	  Some builds may require a 'biarch' toolchain. This option
 	  allows you to specify an additional target arch.
@@ -252,7 +251,6 @@ config DWARVES
 	bool
 	prompt "Build pahole" if TOOLCHAINOPTS
 	depends on !HOST_OS_MACOS
-	default n
 	help
 	  Enable if you want to build pahole and the dwarves tools.
 

--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -27,21 +27,18 @@ config EXTRA_GCC_CONFIG_OPTIONS
 config GCC_DEFAULT_PIE
 	bool
 	prompt "Build executable with PIE enabled by default" if TOOLCHAINOPTS
-	default n
 	help
 	    Use gcc configure option --enable-default-pie to turn on -fPIE and -pie by default.
 
 config GCC_DEFAULT_SSP
 	bool
 	prompt "Build executable with Stack-Smashing Protection enabled by default" if TOOLCHAINOPTS
-	default n
 	help
 	    Use gcc configure option --enable-default-ssp to turn on -fstack-protector-strong by default.
 
 config SJLJ_EXCEPTIONS
 	bool
 	prompt "Use setjump()/longjump() exceptions" if TOOLCHAINOPTS
-	default n
 	help
 	    Use old setjump()/longjump() exceptions instead of the newer
 	    frame unwinding exceptions handling routines.  Warning: increases
@@ -50,7 +47,6 @@ config SJLJ_EXCEPTIONS
 config INSTALL_GFORTRAN
 	bool
 	prompt "Build/install fortran compiler?" if TOOLCHAINOPTS
-	default n
 	help
 	    Build/install GNU fortran compiler ?
 
@@ -58,6 +54,5 @@ config INSTALL_GCCGO
 	bool
 	prompt "Build/install Go compiler?" if TOOLCHAINOPTS
 	depends on USE_GLIBC || BROKEN
-	default n
 	help
 	    Build/install GNU gccgo compiler ?


### PR DESCRIPTION
> Kconfig docs say:
> > The default value deliberately defaults to 'n' in order to avoid
> > bloating the build.
> 
> Apply this rule everywhere, to avoid more cloning of bad examples

Discovered in #11453 

There are some others inside patches, which probably means the kernel itself breaks the Kconfig rules, and some of the injected blocks too.