### PR TITLE
ath79: change default config for dumb APs

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/50_dumb-ap
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/50_dumb-ap
@@ -1,0 +1,47 @@
+. /lib/functions.sh
+
+board=$(board_name)
+
+board_get_serial() {
+    case "$board" in
+    fortinet,fap-221-b|\
+    fortinet,fap-221-c)
+        echo $(dd if=$(find_mtd_part "u-boot") bs=1 skip=$((0x3ff90)) count=16)
+        ;;
+    *)
+        ;;
+    esac
+}
+
+board_preconfigure() {
+
+    # Load the relevant configuration files
+    config_load system
+    config_load dumbap
+
+
+    # Check if we've already completed this configuration once.
+    DUMBAP_PRECONFIG=$(uci -q get dumbap.preconfig)
+
+    # If we don't find the identifier, preconfigure the device as a dumb AP.
+    if [ "$DUMBAP_PRECONFIG" != "1" ]
+    then
+        # Set hostname to serial number, to avoid potential DNS conflicts if main
+        # router is already called openwrt.
+        serial=$(board_get_serial)
+        if [ "" != $serial ]
+        then
+            uci set system.@system[0].hostname=$serial
+            uci commit system
+        fi
+
+        # Configure an identifier so we don't repeat on upgrade.
+        uci import dumbap < /dev/null
+        uci set dumbap.preconfig='1'
+        uci commit dumbap
+    fi
+}
+
+board_preconfigure
+
+exit 0


### PR DESCRIPTION
Implements a uci-defaults script that, for boards which are dumb APs by
nature, changes the default network configuration as follows:

- Hostname is set to the serial number of the board, where possible.

This is primarily to avoid a DNS conflict on a network where the default
gateway already has the hostname "openwrt". A secondary bonus is that the
device would be easier to identify when looking at DHCP leases.

- Sets the LAN protocol to DHCP.

This is to stop the device taking the IP address 192.168.1.1 by default.
On many home networks this is the IP of the default gateway and, as such,
booting the device with this configuration while connected to the network
would cause an IP conflict.

- Removes references to WAN from default network config.

The boards targeted by this change have single ethernet ports, intended
for LAN. As such, a WAN interface is not expected to be used nor required.

Signed-off-by: Dominic Houghton <technpizza@gmail.com>

