### PR TITLE
ath79: add support for Fortinet FAP-221-C

### DIFF
--- a/target/linux/ath79/dts/qca9558_fortinet_fap-221-c.dts
+++ b/target/linux/ath79/dts/qca9558_fortinet_fap-221-c.dts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "fortinet,fap-221-c", "qca,qca9558";
+	model = "Fortinet FAP-221-C";
+
+	chosen {
+		bootargs = "console=ttyS0,9600";
+	};
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_diag_green;
+		led-running = &led_power;
+		led-upgrade = &led_diag_red;
+		led-failsafe = &led_diag_red;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&enable_gpio_2_3 &jtag_disable_pins>;
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_diag_green: diag_green {
+			label = "green:diag";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+
+		led_diag_red: diag_red {
+			label = "red:diag";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi1_green {
+			label = "green:wifi1";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi1_red {
+			label = "red:wifi1";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2_green {
+			label = "green:wifi2";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi2_red {
+			label = "red:wifi2";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		lan_green {
+			label = "green:lan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x73714f4b>;
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&pinmux {
+	enable_gpio_2_3: pinmux_enable_gpio_2_3 {
+		pinctrl-single,bits = <0x00 0x0  0xffff0000>;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	ath10k: wifi@0,0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0 0 0 0 0>;
+
+		nvmem-cells = <&calibration_art_5000>;
+		nvmem-cell-names = "calibration";
+	};
+};
+
+&pcie1 {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,003c";
+		reg = <0x0000 0 0 0 0>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+
+	nvmem-cells = <&calibration_art_1000>;
+	nvmem-cell-names = "calibration";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			fwconcat0: partition@40000 {
+				label = "fwconcat0";
+				reg = <0x040000 0x1400000>;
+			};
+
+			partition@1440000 {
+				label = "loader";
+				reg = <0x1440000 0x010000>;
+			};
+
+			fwconcat1: partition@1450000 {
+				label = "fwconcat1";
+				reg = <0x1450000 0x03f0000>;
+			};
+
+			partition@1840000 {
+				label = "reserved";
+				reg = <0x1840000 0x7B0000>;
+				read-only;
+			};
+
+			art: partition@1ff0000 {
+				label = "art";
+				reg = <0x1ff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy5: ethernet-phy@5 {
+		reg = <5>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy5>;
+	phy-mode = "rgmii-id";
+
+	pll-data = <0x82000000 0x80000101 0x80001313>;
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	calibration_art_1000: calibration@1000 {
+		reg = <0x1000 0x440>;
+	};
+
+	calibration_art_5000: calibration@5000 {
+		reg = <0x5000 0x844>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -46,6 +46,7 @@ ath79_setup_interfaces()
 	enterasys,ws-ap3705i|\
 	extreme-networks,ws-ap3805i|\
 	fortinet,fap-221-b|\
+	fortinet,fap-221-c|\
 	glinet,gl-ar300m-lite|\
 	glinet,gl-usb150|\
 	hak5,wifi-pineapple-nano|\
@@ -675,7 +676,8 @@ ath79_setup_macs()
 	enterasys,ws-ap3705i)
 		label_mac=$(mtd_get_mac_ascii u-boot-env0 ethaddr)
 		;;
-	fortinet,fap-221-b)
+	fortinet,fap-221-b|\
+	fortinet,fap-221-c)
 		lan_mac=$(mtd_get_mac_text u-boot 0x3ff80 12)
 		label_mac=$lan_mac
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -63,6 +63,9 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii cfg1 RADIOADDR1)
 		;;
+	fortinet,fap-221-c)
+		caldata_extract "art" 0x1000 0x440
+		;;
 	nec,wg800hp)
 		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_text board_data 0x680)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -93,6 +93,9 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(mtd_get_mac_ascii cfg1 RADIOADDR0)
 		;;
+	fortinet,fap-221-c)
+		caldata_extract "art" 0x5000 0x844
+		;;
 	glinet,gl-ar750)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) 1)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -35,7 +35,8 @@ case "$board" in
 		[ "$PHYNBR" -eq 1 ] && \
 			mtd_get_mac_ascii bdcfg "wlanmac" > /sys${DEVPATH}/macaddress
 		;;
-	fortinet,fap-221-b)
+	fortinet,fap-221-b|\
+	fortinet,fap-221-c)
 		macaddr_add "$(mtd_get_mac_text u-boot 0x3ff80 12)" $((PHYNBR*7+1)) > /sys${DEVPATH}/macaddress
 		;;
 	iodata,wn-ac1600dgr)

--- a/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -19,7 +19,8 @@ preinit_set_mac_address() {
 	siemens,ws-ap3610)
 		ip link set dev eth0 address $(mtd_get_mac_ascii cfg1 ethaddr)
 		;;
-	fortinet,fap-221-b)
+	fortinet,fap-221-b|\
+	fortinet,fap-221-c)
 		ip link set dev eth0 address $(mtd_get_mac_text u-boot 0x3ff80 12)
 		;;
 	tplink,deco-s4-v2)

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -54,7 +54,8 @@ platform_do_upgrade() {
 		ROOTFS_FILE="root.squashfs"
 		platform_do_upgrade_failsafe_datachk "$1"
 		;;
-	fortinet,fap-221-b)
+	fortinet,fap-221-b|\
+	fortinet,fap-221-c)
 		SKIP_HASH="1"
 		ENV_SCRIPT="/dev/null"
 		IMAGE_LIST="tar tzf $1"

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1340,6 +1340,23 @@ define Device/fortinet_fap-221-b
 endef
 TARGET_DEVICES += fortinet_fap-221-b
 
+define Device/fortinet_fap-221-c
+  $(Device/senao_loader_okli)
+  SOC := qca9558
+  DEVICE_VENDOR := Fortinet
+  DEVICE_MODEL := FAP-221-C
+  FACTORY_IMG_NAME := FP221C-9.99-AP-build999-999999-patch99
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct
+  IMAGE_SIZE := 20480k
+  LOADER_FLASH_OFFS := 0x0040000
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	  append-rootfs | pad-rootfs | \
+	  check-size | pad-to $$$$(IMAGE_SIZE) | \
+	  append-loader-okli-uimage $(1) | pad-to 10944k | \
+	  gzip-filename $$$$(FACTORY_IMG_NAME)
+endef
+TARGET_DEVICES += fortinet_fap-221-c
+
 define Device/glinet_6408
   $(Device/tplink-8mlzma)
   SOC := ar9331


### PR DESCRIPTION
Fortinet FAP-221-C is an indoor access point with 1Gb ethernet port,
dual-band wireless, internal antenna plates, and PoE.

Hardware and board design from Senao, although this variant uses a 32MB
flash chip whereas the base design appears to use a 16MB chip.

# Specifications
    SoC:        Qualcomm Atheros QCA9558
    WiFi 1:     Qualcomm Atheros QCA9558
    WiFi 2:     Qualcomm Atheros QCA9882
    Ethernet:   Qualcomm Atheros QCA9558 (1x GbE, 802.3af PoE)
    RAM:        256MB
    Flash:      32MB
	Buttons:    Single reset button (GPIO)
    LEDs:       WiFi 2 (r/g), WiFi 1 (r/g), LAN (r/g)*, Diag (r/g),
                Power (g)
                * LAN LED behaves odd. Red seems to be hardwired to
                  ethernet status somehow. Green can be controlled
                  via GPIO as expected.

# UART

```
Unmarked, but populated 4-pin header

[o o o o]
 | | | ^- VCC, pin 1
 | |  `-- GND
 |  `---- TX
  `------ RX
```

The UART runs at 9600-8-N-1.

# Installation

## OEM firmware

Upload squashfs-factory.bin to a TFTP server. Connect to the device via
SSH, with the default username "admin" and no password. Run the following
command:

`restore <filename> <TFTP IP>`

The same can also be achieved by logging into the console via UART.

## u-boot

Connect to the UART console, and power on the device. Interrupt the boot
sequence when indicated. Press [G] to upload a new firmware. Enter the
details of your TFTP server, assign an available IP to the device, and
enter the name of the firmware file on the TFTP server. The file will be
transferred to the device, then press [D] to save the image to flash.

# Backup OEM firmware

Fortinet do not provide binaries for these devices to the public. So if
you ever want to go back to OEM firmware, follow these steps to dump and
generate a flashable image.

Power up the device, and identify its IP address on the network. Run the
following commands on your local machine, assuming a Linux environment.

```
# These commands dump the individual firmware partitions
ssh admin@<deviceip> "cat /dev/mtdblock1" > mtdblock1
ssh admin@<deviceip> "cat /dev/mtdblock2" > mtdblock2
ssh admin@<deviceip> "cat /dev/mtdblock3" > mtdblock3

# These commands assemble the firmware image, image.out
cat mtdblock1 mtdblock2 mtdblock3 > FP221C
gzip FP221C
mv FP221C image.out
```

The resulting file "image.out" can be flashed by u-boot. Note that due
to containing the additional "reserved" partition, the `restore` command
will not allow flashing this image back. Omit mtdblock3 to generate an
image that can be flashed with `restore`.

Signed-off-by: Dominic Houghton <technpizza@gmail.com>