### PR TITLE
realtek: Fix reset register access

### DIFF
--- a/target/linux/realtek/files-5.15/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.15/drivers/net/ethernet/rtl838x_eth.c
@@ -675,7 +675,7 @@ static void rtl838x_hw_reset(struct rtl838x_eth_priv *priv)
 	else
 		reset_mask = 0xc;
 
-	sw_w32(reset_mask, priv->r->rst_glb_ctrl);
+	sw_w32_mask(0, reset_mask, priv->r->rst_glb_ctrl);
 
 	do { /* Wait for reset of NIC and Queues done */
 		udelay(20);


### PR DESCRIPTION
The reset register on RTL93xx not merely have bits to execute a reset of a hardware component, but also configuration bits for reset procedures. Keep them during executing a reset.

Signed-off-by: Birger Koblitz <git@birger-koblitz.de>
Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>