### PR TITLE
[22.03] toolchain: gcc: import patch fixing asm machine directive for powerpc

### DIFF
--- a/toolchain/gcc/patches/11.2.0/020-powerpc-Fix-asm-machine-directive-for-some-CPUs.patch
+++ b/toolchain/gcc/patches/11.2.0/020-powerpc-Fix-asm-machine-directive-for-some-CPUs.patch
@@ -1,0 +1,54 @@
+From 3cb53c10831be59d967d9dce8e7980fee4703500 Mon Sep 17 00:00:00 2001
+From: Sebastian Huber <sebastian.huber@embedded-brains.de>
+Date: Tue, 18 Jan 2022 12:44:53 +0100
+Subject: [PATCH] powerpc: Fix asm machine directive for some CPUs
+
+For some CPUs, the assembler machine directive cannot be determined by ISA
+flags.
+
+gcc/
+
+	PR target/104090
+	* config/rs6000/rs6000.c (rs6000_machine_from_flags): Use also
+	rs6000_cpu.
+---
+ gcc/config/rs6000/rs6000.c | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+--- a/gcc/config/rs6000/rs6000.c
++++ b/gcc/config/rs6000/rs6000.c
+@@ -5780,6 +5780,34 @@ const char *rs6000_machine;
+ const char *
+ rs6000_machine_from_flags (void)
+ {
++  /* For some CPUs, the machine cannot be determined by ISA flags.  We have to
++     check them first.  */
++  switch (rs6000_cpu)
++    {
++    case PROCESSOR_PPC8540:
++    case PROCESSOR_PPC8548:
++      return "e500";
++
++    case PROCESSOR_PPCE300C2:
++    case PROCESSOR_PPCE300C3:
++      return "e300";
++
++    case PROCESSOR_PPCE500MC:
++      return "e500mc";
++
++    case PROCESSOR_PPCE500MC64:
++      return "e500mc64";
++
++    case PROCESSOR_PPCE5500:
++      return "e5500";
++
++    case PROCESSOR_PPCE6500:
++      return "e6500";
++
++    default:
++      break;
++    }
++
+   HOST_WIDE_INT flags = rs6000_isa_flags;
+ 
+   /* Disable the flags that should never influence the .machine selection.  */


### PR DESCRIPTION
Applications with libmbedtls, e.g. curl, fail on mpc85xx with:
  curl[7227]: illegal instruction (4) at b7c94288 nip b7c94288 lr b7c6b528 code 1 in libmbedcrypto.so.2.28.1[b7c3e000+7e000]
  curl[7227]: code: 3d7e0000 809e8004 91490000 816b814c 7d6903a6 4e800421 80010024 83c10018
  curl[7227]: code: 38210020 7c0803a6 4e800020 9421fff0 <7d4d42e6> 7c6c42e6 7d2d42e6 7c0a4840

This is due to a bug in gcc-11.2.0. It is fixed with gcc-11.3.0. Import the patch that is fixing the issue.
