### PR TITLE
treewide: replace wpad-basic-wolfssl default

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -17,7 +17,7 @@ DEFAULT_PACKAGES:=\
 	fstools \
 	libc \
 	libgcc \
-	libustream-wolfssl \
+	libustream-mbedtls \
 	logd \
 	mtd \
 	netifd \

--- a/target/linux/apm821xx/image/sata.mk
+++ b/target/linux/apm821xx/image/sata.mk
@@ -8,7 +8,7 @@ define Device/wd_mybooklive
   DEVICE_MODEL := My Book Live
   DEVICE_ALT0_VENDOR := Western Digital
   DEVICE_ALT0_MODEL := My Book Live Duo
-  DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport kmod-usb-storage kmod-fs-vfat wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport kmod-usb-storage kmod-fs-vfat wpad-basic-mbedtls
   SUPPORTED_DEVICES += mbl wd,mybooklive-duo
   BLOCKSIZE := 1k
   DTB_SIZE := 16384

--- a/target/linux/apm821xx/nand/target.mk
+++ b/target/linux/apm821xx/nand/target.mk
@@ -1,7 +1,7 @@
 BOARDNAME:=Devices with NAND flash (Routers)
 FEATURES += nand pcie
 
-DEFAULT_PACKAGES += kmod-ath9k swconfig wpad-basic-wolfssl
+DEFAULT_PACKAGES += kmod-ath9k swconfig wpad-basic-mbedtls
 
 define Target/Description
 	Build firmware images for APM821XX boards with NAND flash.

--- a/target/linux/apm821xx/sata/profiles/00-default.mk
+++ b/target/linux/apm821xx/sata/profiles/00-default.mk
@@ -5,7 +5,7 @@
 define Profile/Default
   NAME:=Default Profile
   PRIORITY:=1
-  PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport kmod-usb-storage kmod-fs-vfat wpad-basic-wolfssl
+  PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport kmod-usb-storage kmod-fs-vfat wpad-basic-mbedtls
 endef
 
 define Profile/Default/Description

--- a/target/linux/archs38/generic/profiles/00-default.mk
+++ b/target/linux/archs38/generic/profiles/00-default.mk
@@ -4,7 +4,7 @@
 
 define Profile/Default
 	NAME:=Default Profile (all drivers)
-	PACKAGES:= kmod-usb2 kmod-ath9k-htc wpad-basic-wolfssl
+	PACKAGES:= kmod-usb2 kmod-ath9k-htc wpad-basic-mbedtls
 endef
 
 define Profile/Default/Description

--- a/target/linux/ath25/Makefile
+++ b/target/linux/ath25/Makefile
@@ -19,6 +19,6 @@ endef
 
 include $(INCLUDE_DIR)/target.mk
 
-DEFAULT_PACKAGES += wpad-basic-wolfssl kmod-ath5k swconfig kmod-gpio-button-hotplug
+DEFAULT_PACKAGES += wpad-basic-mbedtls kmod-ath5k swconfig kmod-gpio-button-hotplug
 
 $(eval $(call BuildTarget))

--- a/target/linux/ath79/generic/target.mk
+++ b/target/linux/ath79/generic/target.mk
@@ -1,6 +1,6 @@
 BOARDNAME:=Generic
 
-DEFAULT_PACKAGES += wpad-basic-wolfssl
+DEFAULT_PACKAGES += wpad-basic-mbedtls
 
 define Target/Description
 	Build firmware images for generic Atheros AR71xx/AR913x/AR934x based boards.

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -168,7 +168,7 @@ endef
 TARGET_DEVICES += ubnt_rocket-5ac-lite
 
 define Device/ubnt_routerstation_common
-  DEVICE_PACKAGES := -kmod-ath9k -wpad-basic-wolfssl -uboot-envtools kmod-usb-ohci \
+  DEVICE_PACKAGES := -kmod-ath9k -wpad-basic-mbedtls -uboot-envtools kmod-usb-ohci \
 	kmod-usb2 fconfig
   DEVICE_VENDOR := Ubiquiti
   SOC := ar7161

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1477,7 +1477,7 @@ define Device/hak5_lan-turtle
   TPLINK_HWID := 0x5348334c
   IMAGES := sysupgrade.bin
   DEVICE_PACKAGES := kmod-usb-chipidea2 -iwinfo -kmod-ath9k -swconfig \
-	-uboot-envtools -wpad-basic-wolfssl
+	-uboot-envtools -wpad-basic-mbedtls
   SUPPORTED_DEVICES += lan-turtle
 endef
 TARGET_DEVICES += hak5_lan-turtle
@@ -1490,7 +1490,7 @@ define Device/hak5_packet-squirrel
   TPLINK_HWID := 0x5351524c
   IMAGES := sysupgrade.bin
   DEVICE_PACKAGES := kmod-usb-chipidea2 -iwinfo -kmod-ath9k -swconfig \
-	-uboot-envtools -wpad-basic-wolfssl
+	-uboot-envtools -wpad-basic-mbedtls
   SUPPORTED_DEVICES += packet-squirrel
 endef
 TARGET_DEVICES += hak5_packet-squirrel
@@ -1525,7 +1525,7 @@ define Device/iodata_etg3-r
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := ETG3-R
   IMAGE_SIZE := 7680k
-  DEVICE_PACKAGES := -iwinfo -kmod-ath9k -wpad-basic-wolfssl
+  DEVICE_PACKAGES := -iwinfo -kmod-ath9k -wpad-basic-mbedtls
 endef
 TARGET_DEVICES += iodata_etg3-r
 
@@ -1585,7 +1585,7 @@ define Device/jjplus_ja76pf2
   SOC := ar7161
   DEVICE_VENDOR := jjPlus
   DEVICE_MODEL := JA76PF2
-  DEVICE_PACKAGES += -kmod-ath9k -swconfig -wpad-basic-wolfssl -uboot-envtools fconfig kmod-hwmon-lm75
+  DEVICE_PACKAGES += -kmod-ath9k -swconfig -wpad-basic-mbedtls -uboot-envtools fconfig kmod-hwmon-lm75
   LOADER_TYPE := bin
   LOADER_FLASH_OFFS := 0x60000
   COMPILE := loader-$(1).bin
@@ -2652,7 +2652,7 @@ define Device/teltonika_rut300
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT300
   SUPPORTED_TELTONIKA_DEVICES := teltonika,rut30x
-  DEVICE_PACKAGES := -kmod-ath9k -uboot-envtools -wpad-basic-wolfssl kmod-usb2
+  DEVICE_PACKAGES := -kmod-ath9k -uboot-envtools -wpad-basic-mbedtls kmod-usb2
   IMAGE_SIZE := 15552k
   IMAGES += factory.bin
   IMAGE/factory.bin = append-kernel | pad-to $$$$(BLOCKSIZE) | \

--- a/target/linux/ath79/mikrotik/target.mk
+++ b/target/linux/ath79/mikrotik/target.mk
@@ -3,7 +3,7 @@ FEATURES += minor nand
 KERNELNAME := vmlinux vmlinuz
 IMAGES_DIR := ../../..
 
-DEFAULT_PACKAGES += wpad-basic-wolfssl
+DEFAULT_PACKAGES += wpad-basic-mbedtls
 
 define Target/Description
 	Build firmware images for MikroTik devices based on Qualcomm Atheros

--- a/target/linux/ath79/nand/target.mk
+++ b/target/linux/ath79/nand/target.mk
@@ -2,7 +2,7 @@ BOARDNAME := Generic devices with NAND flash
 
 FEATURES += nand
 
-DEFAULT_PACKAGES += wpad-basic-wolfssl
+DEFAULT_PACKAGES += wpad-basic-mbedtls
 
 define Target/Description
 	Firmware for boards using Qualcomm Atheros, MIPS-based SoCs

--- a/target/linux/ath79/tiny/target.mk
+++ b/target/linux/ath79/tiny/target.mk
@@ -1,7 +1,7 @@
 BOARDNAME:=Devices with small flash
 FEATURES += low_mem small_flash
 
-DEFAULT_PACKAGES += wpad-basic-wolfssl
+DEFAULT_PACKAGES += wpad-basic-mbedtls
 
 define Target/Description
 	Build firmware images for Atheros AR71xx/AR913x/AR934x based boards with small flash

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -77,7 +77,7 @@ define Device/rpi
   DEVICE_PACKAGES := \
 	cypress-firmware-43430-sdio \
 	brcmfmac-nvram-43430-sdio \
-	kmod-brcmfmac wpad-basic-wolfssl
+	kmod-brcmfmac wpad-basic-mbedtls
 endef
 ifeq ($(SUBTARGET),bcm2708)
   TARGET_DEVICES += rpi
@@ -110,7 +110,7 @@ define Device/rpi-2
 	brcmfmac-nvram-43430-sdio \
 	cypress-firmware-43455-sdio \
 	brcmfmac-nvram-43455-sdio \
-	kmod-brcmfmac wpad-basic-wolfssl
+	kmod-brcmfmac wpad-basic-mbedtls
   IMAGE/sysupgrade.img.gz := boot-common | boot-2708 | boot-2711 | sdcard-img | gzip | append-metadata
   IMAGE/factory.img.gz := boot-common | boot-2708 | boot-2711 | sdcard-img | gzip
 endef
@@ -141,7 +141,7 @@ define Device/rpi-3
 	brcmfmac-nvram-43430-sdio \
 	cypress-firmware-43455-sdio \
 	brcmfmac-nvram-43455-sdio \
-	kmod-brcmfmac wpad-basic-wolfssl
+	kmod-brcmfmac wpad-basic-mbedtls
 endef
 ifeq ($(SUBTARGET),bcm2710)
   TARGET_DEVICES += rpi-3
@@ -162,7 +162,7 @@ define Device/rpi-4
   DEVICE_PACKAGES := \
 	cypress-firmware-43455-sdio \
 	brcmfmac-nvram-43455-sdio \
-	kmod-brcmfmac wpad-basic-wolfssl \
+	kmod-brcmfmac wpad-basic-mbedtls \
 	kmod-usb-net-lan78xx \
 	kmod-r8169
   IMAGE/sysupgrade.img.gz := boot-common | boot-2711 | sdcard-img | gzip | append-metadata

--- a/target/linux/bcm47xx/generic/profiles/101-Broadcom-wl.mk
+++ b/target/linux/bcm47xx/generic/profiles/101-Broadcom-wl.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-wl
   NAME:=Broadcom SoC, all Ethernet, BCM43xx WiFi (wl, proprietary)
-  PACKAGES:=-wpad-basic-wolfssl kmod-b44 kmod-tg3 kmod-bgmac kmod-brcm-wl wlc nas
+  PACKAGES:=-wpad-basic-mbedtls kmod-b44 kmod-tg3 kmod-bgmac kmod-brcm-wl wlc nas
 endef
 
 define Profile/Broadcom-wl/Description

--- a/target/linux/bcm47xx/generic/profiles/105-Broadcom-none.mk
+++ b/target/linux/bcm47xx/generic/profiles/105-Broadcom-none.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-none
   NAME:=Broadcom SoC, all Ethernet, No WiFi
-  PACKAGES:=-wpad-basic-wolfssl kmod-b44 kmod-tg3 kmod-bgmac
+  PACKAGES:=-wpad-basic-mbedtls kmod-b44 kmod-tg3 kmod-bgmac
 endef
 
 define Profile/Broadcom-none/Description

--- a/target/linux/bcm47xx/generic/profiles/201-Broadcom-b44-wl.mk
+++ b/target/linux/bcm47xx/generic/profiles/201-Broadcom-b44-wl.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-b44-wl
   NAME:=Broadcom SoC, b44 Ethernet, BCM43xx WiFi (wl, proprietary)
-  PACKAGES:=-wpad-basic-wolfssl kmod-b44 kmod-brcm-wl wlc nas
+  PACKAGES:=-wpad-basic-mbedtls kmod-b44 kmod-brcm-wl wlc nas
 endef
 
 define Profile/Broadcom-b44-wl/Description

--- a/target/linux/bcm47xx/generic/profiles/205-Broadcom-b44-none.mk
+++ b/target/linux/bcm47xx/generic/profiles/205-Broadcom-b44-none.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-b44-none
   NAME:=Broadcom SoC, b44 Ethernet, No WiFi
-  PACKAGES:=-wpad-basic-wolfssl kmod-b44
+  PACKAGES:=-wpad-basic-mbedtls kmod-b44
 endef
 
 define Profile/Broadcom-b44-none/Description

--- a/target/linux/bcm47xx/generic/profiles/211-Broadcom-tg3-wl.mk
+++ b/target/linux/bcm47xx/generic/profiles/211-Broadcom-tg3-wl.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-tg3-wl
   NAME:=Broadcom SoC, tg3 Ethernet, BCM43xx WiFi (wl, proprietary)
-  PACKAGES:=-wpad-basic-wolfssl kmod-brcm-wl wlc nas kmod-tg3
+  PACKAGES:=-wpad-basic-mbedtls kmod-brcm-wl wlc nas kmod-tg3
 endef
 
 define Profile/Broadcom-tg3-wl/Description

--- a/target/linux/bcm47xx/generic/profiles/215-Broadcom-tg3-none.mk
+++ b/target/linux/bcm47xx/generic/profiles/215-Broadcom-tg3-none.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-tg3-none
   NAME:=Broadcom SoC, tg3 Ethernet, no WiFi
-  PACKAGES:=-wpad-basic-wolfssl kmod-tg3
+  PACKAGES:=-wpad-basic-mbedtls kmod-tg3
 endef
 
 define Profile/Broadcom-tg3-none/Description

--- a/target/linux/bcm47xx/generic/profiles/221-Broadcom-bgmac-wl.mk
+++ b/target/linux/bcm47xx/generic/profiles/221-Broadcom-bgmac-wl.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-bgmac-wl
   NAME:=Broadcom SoC, bgmac Ethernet, BCM43xx WiFi (wl, proprietary)
-  PACKAGES:=-wpad-basic-wolfssl kmod-bgmac kmod-brcm-wl wlc nas
+  PACKAGES:=-wpad-basic-mbedtls kmod-bgmac kmod-brcm-wl wlc nas
 endef
 
 define Profile/Broadcom-bgmac-wl/Description

--- a/target/linux/bcm47xx/generic/profiles/225-Broadcom-bgmac-none.mk
+++ b/target/linux/bcm47xx/generic/profiles/225-Broadcom-bgmac-none.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-bgmac-none
   NAME:=Broadcom SoC, bgmac Ethernet, No WiFi
-  PACKAGES:=-wpad-basic-wolfssl kmod-bgmac
+  PACKAGES:=-wpad-basic-mbedtls kmod-bgmac
 endef
 
 define Profile/Broadcom-bgmac-none/Description

--- a/target/linux/bcm47xx/generic/profiles/PS-1208MFG.mk
+++ b/target/linux/bcm47xx/generic/profiles/PS-1208MFG.mk
@@ -4,7 +4,7 @@
 
 define Profile/Ps1208mfg
   NAME:=Edimax PS-1208MFG
-  PACKAGES:=-firewall -dropbear -dnsmasq -mtd -ppp -wpad-basic-wolfssl kmod-b44 block-mount kmod-usb-storage kmod-usb2 kmod-usb-ohci -iptables -swconfig kmod-fs-ext4
+  PACKAGES:=-firewall -dropbear -dnsmasq -mtd -ppp -wpad-basic-mbedtls kmod-b44 block-mount kmod-usb-storage kmod-usb2 kmod-usb-ohci -iptables -swconfig kmod-fs-ext4
 endef
 
 define Profile/Ps1208mfg/Description

--- a/target/linux/bcm47xx/generic/target.mk
+++ b/target/linux/bcm47xx/generic/target.mk
@@ -1,7 +1,7 @@
 BOARDNAME:=Generic
 FEATURES+=pcmcia
 
-DEFAULT_PACKAGES += wpad-basic-wolfssl
+DEFAULT_PACKAGES += wpad-basic-mbedtls
 
 define Target/Description
 	Build generic firmware for all Broadcom BCM47xx and BCM53xx MIPS

--- a/target/linux/bcm47xx/legacy/profiles/101-Broadcom-wl.mk
+++ b/target/linux/bcm47xx/legacy/profiles/101-Broadcom-wl.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-wl
   NAME:=Broadcom SoC, all Ethernet, BCM43xx WiFi (wl, proprietary)
-  PACKAGES:=-wpad-basic-wolfssl kmod-brcm-wl-mini wlc nas
+  PACKAGES:=-wpad-basic-mbedtls kmod-brcm-wl-mini wlc nas
 endef
 
 define Profile/Broadcom-wl/Description

--- a/target/linux/bcm47xx/legacy/target.mk
+++ b/target/linux/bcm47xx/legacy/target.mk
@@ -1,7 +1,7 @@
 FEATURES += low_mem pcmcia small_flash
 BOARDNAME:=Legacy (BMIPS3300)
 
-DEFAULT_PACKAGES += wpad-basic-wolfssl
+DEFAULT_PACKAGES += wpad-basic-mbedtls
 
 define Target/Description
 	Build firmware for Broadcom BCM47xx and BCM53xx devices with

--- a/target/linux/bcm47xx/mips74k/profiles/102-Broadcom-wl.mk
+++ b/target/linux/bcm47xx/mips74k/profiles/102-Broadcom-wl.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-mips74k-wl
   NAME:=Broadcom SoC, BCM43xx WiFi (proprietary wl)
-  PACKAGES:=-wpad-basic-wolfssl kmod-brcm-wl wlc nas
+  PACKAGES:=-wpad-basic-mbedtls kmod-brcm-wl wlc nas
 endef
 
 define Profile/Broadcom-mips74k-wl/Description

--- a/target/linux/bcm47xx/mips74k/profiles/103-Broadcom-none.mk
+++ b/target/linux/bcm47xx/mips74k/profiles/103-Broadcom-none.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-mips74k-none
   NAME:=Broadcom SoC, No WiFi
-  PACKAGES:=-wpad-basic-wolfssl
+  PACKAGES:=-wpad-basic-mbedtls
 endef
 
 define Profile/Broadcom-mips74k-none/Description

--- a/target/linux/bcm47xx/mips74k/target.mk
+++ b/target/linux/bcm47xx/mips74k/target.mk
@@ -1,7 +1,7 @@
 BOARDNAME:=MIPS 74K
 CPU_TYPE:=74kc
 
-DEFAULT_PACKAGES += wpad-basic-wolfssl
+DEFAULT_PACKAGES += wpad-basic-mbedtls
 
 define Target/Description
 	Build firmware for Broadcom BCM47xx and BCM53xx devices with

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -111,7 +111,7 @@ DEVICE_VARS += SIGNATURE
 DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_REGION TPLINK_BOARD
 DEVICE_VARS += LUXUL_BOARD
 
-IEEE8021X := wpad-basic-wolfssl
+IEEE8021X := wpad-basic-mbedtls
 B43 := $(IEEE8021X) kmod-b43
 BRCMFMAC_43602A1 := $(IEEE8021X) kmod-brcmfmac brcmfmac-firmware-43602a1-pcie
 BRCMFMAC_4366B1 := $(IEEE8021X) kmod-brcmfmac brcmfmac-firmware-4366b1-pcie

--- a/target/linux/bcm63xx/image/Makefile
+++ b/target/linux/bcm63xx/image/Makefile
@@ -305,12 +305,12 @@ define Device/Default
 endef
 DEVICE_VARS += CHIP_ID DEVICE_LOADADDR
 
-ATH5K_PACKAGES := kmod-ath5k wpad-basic-wolfssl
-ATH9K_PACKAGES := kmod-ath9k wpad-basic-wolfssl
-B43_PACKAGES := kmod-b43 wpad-basic-wolfssl
+ATH5K_PACKAGES := kmod-ath5k wpad-basic-mbedtls
+ATH9K_PACKAGES := kmod-ath9k wpad-basic-mbedtls
+B43_PACKAGES := kmod-b43 wpad-basic-mbedtls
 BRCMWL_PACKAGES := kmod-brcm-wl nas wlc
-RT28_PACKAGES := kmod-rt2800-pci wpad-basic-wolfssl
-RT61_PACKAGES := kmod-rt61-pci wpad-basic-wolfssl
+RT28_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls
+RT61_PACKAGES := kmod-rt61-pci wpad-basic-mbedtls
 USB1_PACKAGES := kmod-usb-ohci kmod-usb-ledtrig-usbport
 USB2_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
 

--- a/target/linux/bcm63xx/profiles/default.mk
+++ b/target/linux/bcm63xx/profiles/default.mk
@@ -4,7 +4,7 @@
 
 define Profile/Default
   NAME:=Default Profile
-  PACKAGES:=kmod-b43 wpad-basic-wolfssl
+  PACKAGES:=kmod-b43 wpad-basic-mbedtls
   PRIORITY:=1
 endef
 

--- a/target/linux/bmips/image/Makefile
+++ b/target/linux/bmips/image/Makefile
@@ -249,8 +249,8 @@ define Device/Default
   DEVICE_LOADADDR :=
 endef
 
-ATH9K_PACKAGES := kmod-ath9k wpad-basic-wolfssl
-B43_PACKAGES := kmod-b43 wpad-basic-wolfssl
+ATH9K_PACKAGES := kmod-ath9k wpad-basic-mbedtls
+B43_PACKAGES := kmod-b43 wpad-basic-mbedtls
 USB1_PACKAGES := kmod-usb-ohci kmod-ledtrig-usbdev
 USB2_PACKAGES := $(USB1_PACKAGES) kmod-usb2
 

--- a/target/linux/ipq40xx/Makefile
+++ b/target/linux/ipq40xx/Makefile
@@ -16,7 +16,7 @@ include $(INCLUDE_DIR)/target.mk
 DEFAULT_PACKAGES += \
 	kmod-usb-dwc3-qcom \
 	kmod-leds-gpio kmod-gpio-button-hotplug \
-	kmod-ath10k-ct wpad-basic-wolfssl \
+	kmod-ath10k-ct wpad-basic-mbedtls \
 	kmod-usb3 kmod-usb-dwc3 ath10k-firmware-qca4019-ct \
 	uboot-envtools
 

--- a/target/linux/ipq806x/Makefile
+++ b/target/linux/ipq806x/Makefile
@@ -20,7 +20,7 @@ DEFAULT_PACKAGES += \
 	kmod-ata-ahci kmod-ata-ahci-platform \
 	kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport \
 	kmod-phy-qcom-ipq806x-usb kmod-usb3 kmod-usb-dwc3-qcom \
-	kmod-ath10k-ct wpad-basic-wolfssl \
+	kmod-ath10k-ct wpad-basic-mbedtls \
 	uboot-envtools
 
 $(eval $(call BuildTarget))

--- a/target/linux/ipq807x/Makefile
+++ b/target/linux/ipq807x/Makefile
@@ -14,7 +14,7 @@ include $(INCLUDE_DIR)/target.mk
 DEFAULT_PACKAGES += \
 	kmod-usb3 kmod-usb-dwc3 kmod-usb-dwc3-qcom \
 	kmod-leds-gpio kmod-gpio-button-hotplug \
-	libwolfsslcpu-crypto kmod-qca-nss-dp \
+	kmod-qca-nss-dp \
 	ath11k-firmware-ipq8074 kmod-ath11k-ahb \
 	wpad-basic-mbedtls uboot-envtools
 

--- a/target/linux/ipq807x/Makefile
+++ b/target/linux/ipq807x/Makefile
@@ -16,6 +16,6 @@ DEFAULT_PACKAGES += \
 	kmod-leds-gpio kmod-gpio-button-hotplug \
 	libwolfsslcpu-crypto kmod-qca-nss-dp \
 	ath11k-firmware-ipq8074 kmod-ath11k-ahb \
-	wpad-basic-wolfssl uboot-envtools
+	wpad-basic-mbedtls uboot-envtools
 
 $(eval $(call BuildTarget))

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -93,7 +93,7 @@ define Device/checkpoint_l-50
   DEVICE_VENDOR := Check Point
   DEVICE_MODEL := L-50
   DEVICE_PACKAGES := kmod-ath9k kmod-gpio-button-hotplug kmod-mvsdio \
-	kmod-rtc-s35390a kmod-usb-ledtrig-usbport wpad-basic-wolfssl
+	kmod-rtc-s35390a kmod-usb-ledtrig-usbport wpad-basic-mbedtls
   IMAGES := sysupgrade.bin
 endef
 TARGET_DEVICES += checkpoint_l-50
@@ -145,7 +145,7 @@ define Device/endian_4i-edge-200
   DEVICE_MODEL := 4i Edge 200
   DEVICE_ALT0_VENDOR := Endian
   DEVICE_ALT0_MODEL := UTM Mini Firewall
-  DEVICE_PACKAGES := kmod-ath9k kmod-mvsdio wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-ath9k kmod-mvsdio wpad-basic-mbedtls
   KERNEL_SIZE := 4096k
   IMAGES := sysupgrade.bin
 endef
@@ -201,7 +201,7 @@ TARGET_DEVICES += iptime_nas1
 
 define Device/linksys
   DEVICE_VENDOR := Linksys
-  DEVICE_PACKAGES := kmod-mwl8k wpad-basic-wolfssl kmod-gpio-button-hotplug
+  DEVICE_PACKAGES := kmod-mwl8k wpad-basic-mbedtls kmod-gpio-button-hotplug
   KERNEL_IN_UBI :=
   UBINIZE_OPTS := -E 5
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi

--- a/target/linux/lantiq/image/ar9.mk
+++ b/target/linux/lantiq/image/ar9.mk
@@ -4,7 +4,7 @@ define Device/avm_fritz7312
   SOC := ar9
   IMAGE_SIZE := 15744k
   LOADER_FLASH_OFFS := 0x31000
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-wolfssl \
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
@@ -20,7 +20,7 @@ define Device/avm_fritz7320
   SOC := ar9
   IMAGE_SIZE := 15744k
   LOADER_FLASH_OFFS := 0x31000
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-wolfssl \
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
@@ -42,7 +42,7 @@ define Device/bt_homehub-v3a
 	kmod-ltq-adsl-ar9-fw-a kmod-ltq-atm-ar9 \
 	kmod-ltq-deu-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath9k kmod-owl-loader wpad-basic-wolfssl \
+	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
 	uboot-envtools
   SUPPORTED_DEVICES += BTHOMEHUBV3A
   DEFAULT := n
@@ -60,7 +60,7 @@ define Device/buffalo_wbmr-hp-g300h-a
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-a kmod-ltq-atm-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath9k kmod-owl-loader wpad-basic-wolfssl
+	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls
   SUPPORTED_DEVICES := WBMR buffalo,wbmr-hp-g300h
 endef
 TARGET_DEVICES += buffalo_wbmr-hp-g300h-a
@@ -76,7 +76,7 @@ define Device/buffalo_wbmr-hp-g300h-b
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath9k kmod-owl-loader wpad-basic-wolfssl
+	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls
   SUPPORTED_DEVICES := WBMR buffalo,wbmr-hp-g300h
 endef
 TARGET_DEVICES += buffalo_wbmr-hp-g300h-b
@@ -106,7 +106,7 @@ define Device/netgear_dgn3500
 	dgn3500-sercom-footer $(DGN3500_KERNEL_OFFSET_HEX) "WW" | pad-rootfs | \
 	check-size 16320k | pad-to 16384k
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport \
-	kmod-ath9k kmod-owl-loader wpad-basic-wolfssl \
+	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-a kmod-ltq-atm-ar9 \
 	kmod-ltq-deu-ar9 ltq-adsl-app ppp-mod-pppoa
@@ -128,7 +128,7 @@ define Device/netgear_dgn3500b
 	dgn3500-sercom-footer $(DGN3500_KERNEL_OFFSET_HEX) "DE" | pad-rootfs | \
 	check-size 16320k | pad-to 16384k
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport \
-	kmod-ath9k kmod-owl-loader wpad-basic-wolfssl \
+	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	kmod-ltq-deu-ar9 ltq-adsl-app ppp-mod-pppoa
@@ -141,7 +141,7 @@ define Device/zte_h201l
   DEVICE_MODEL := H201L
   IMAGE_SIZE := 7808k
   SOC := ar9
-  DEVICE_PACKAGES := kmod-ath9k-htc wpad-basic-wolfssl \
+  DEVICE_PACKAGES := kmod-ath9k-htc wpad-basic-mbedtls \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	kmod-ltq-deu-ar9 ltq-adsl-app ppp-mod-pppoe \
@@ -157,7 +157,7 @@ define Device/zyxel_p-2601hn
   DEVICE_VARIANT := F1/F3
   IMAGE_SIZE := 15616k
   SOC := ar9
-  DEVICE_PACKAGES := kmod-rt2800-usb wpad-basic-wolfssl \
+  DEVICE_PACKAGES := kmod-rt2800-usb wpad-basic-mbedtls \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	kmod-ltq-deu-ar9 ltq-adsl-app ppp-mod-pppoe \

--- a/target/linux/lantiq/image/danube.mk
+++ b/target/linux/lantiq/image/danube.mk
@@ -10,7 +10,7 @@ define Device/arcadyan_arv4510pw
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
 	kmod-ltq-tapi kmod-ltq-vmmc \
-	kmod-rt2800-pci kmod-ath5k wpad-basic-wolfssl
+	kmod-rt2800-pci kmod-ath5k wpad-basic-mbedtls
   SUPPORTED_DEVICES += ARV4510PW
 endef
 TARGET_DEVICES += arcadyan_arv4510pw
@@ -43,7 +43,7 @@ define Device/arcadyan_arv7506pw11
   DEVICE_PACKAGES := kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-rt2800-pci wpad-basic-wolfssl
+	kmod-rt2800-pci wpad-basic-mbedtls
   SUPPORTED_DEVICES += ARV7506PW11
 endef
 TARGET_DEVICES += arcadyan_arv7506pw11
@@ -60,7 +60,7 @@ define Device/arcadyan_arv7510pw22
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
 	kmod-ltq-tapi kmod-ltq-vmmc \
-	kmod-rt2800-pci wpad-basic-wolfssl \
+	kmod-rt2800-pci wpad-basic-mbedtls \
 	kmod-usb-uhci kmod-usb2 kmod-usb2-pci
   SUPPORTED_DEVICES += ARV7510PW22
 endef
@@ -77,7 +77,7 @@ define Device/arcadyan_arv7518pw
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath9k kmod-owl-loader wpad-basic-wolfssl
+	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls
   SUPPORTED_DEVICES += ARV7518PW
 endef
 TARGET_DEVICES += arcadyan_arv7518pw
@@ -93,7 +93,7 @@ define Device/arcadyan_arv7519pw
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-rt2800-pci wpad-basic-wolfssl
+	kmod-rt2800-pci wpad-basic-mbedtls
   SUPPORTED_DEVICES += ARV7519PW
 endef
 TARGET_DEVICES += arcadyan_arv7519pw
@@ -106,7 +106,7 @@ define Device/arcadyan_arv7525pw
   DEVICE_ALT0_VARIANT := Typ A
   IMAGE_SIZE := 3776k
   SOC := danube
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-wolfssl \
+  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls \
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa -swconfig
@@ -127,7 +127,7 @@ define Device/arcadyan_arv752dpw
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
 	kmod-ltq-tapi kmod-ltq-vmmc \
-	kmod-rt2800-pci wpad-basic-wolfssl
+	kmod-rt2800-pci wpad-basic-mbedtls
   SUPPORTED_DEVICES += ARV752DPW
 endef
 TARGET_DEVICES += arcadyan_arv752dpw
@@ -144,7 +144,7 @@ define Device/arcadyan_arv752dpw22
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
 	kmod-ltq-tapi kmod-ltq-vmmc \
-	kmod-rt2800-pci wpad-basic-wolfssl
+	kmod-rt2800-pci wpad-basic-mbedtls
   SUPPORTED_DEVICES += ARV752DPW22
 endef
 TARGET_DEVICES += arcadyan_arv752dpw22
@@ -160,7 +160,7 @@ define Device/arcadyan_arv8539pw22
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath9k kmod-owl-loader wpad-basic-wolfssl
+	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls
   SUPPORTED_DEVICES += ARV8539PW22
 endef
 TARGET_DEVICES += arcadyan_arv8539pw22
@@ -176,7 +176,7 @@ define Device/audiocodes_mp-252
 	kmod-usb-ledtrig-usbport kmod-usb-dwc2 \
 	kmod-rt2800-pci \
 	ltq-adsl-app ppp-mod-pppoa \
-	wpad-basic-wolfssl
+	wpad-basic-mbedtls
   SUPPORTED_DEVICES += ACMP252
 endef
 TARGET_DEVICES += audiocodes_mp-252
@@ -193,7 +193,7 @@ define Device/bt_homehub-v2b
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
 	kmod-ltq-deu-danube ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath9k kmod-owl-loader wpad-basic-wolfssl
+	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls
   SUPPORTED_DEVICES += BTHOMEHUBV2B
   DEFAULT := n
 endef
@@ -217,7 +217,7 @@ define Device/siemens_gigaset-sx76x
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoe \
-	kmod-ath5k wpad-basic-wolfssl
+	kmod-ath5k wpad-basic-mbedtls
   SUPPORTED_DEVICES += GIGASX76X
 endef
 TARGET_DEVICES += siemens_gigaset-sx76x

--- a/target/linux/lantiq/image/tp-link.mk
+++ b/target/linux/lantiq/image/tp-link.mk
@@ -26,7 +26,7 @@ define Device/tplink_tdw8970
   TPLINK_HWID := 0x89700001
   TPLINK_HWREV := 1
   IMAGE_SIZE := 7680k
-  DEVICE_PACKAGES:= kmod-ath9k wpad-basic-wolfssl kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES:= kmod-ath9k wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += TDW8970
 endef
 TARGET_DEVICES += tplink_tdw8970
@@ -40,7 +40,7 @@ define Device/tplink_tdw8980
   TPLINK_HWID := 0x89800001
   TPLINK_HWREV := 14
   IMAGE_SIZE := 7680k
-  DEVICE_PACKAGES:= kmod-ath9k kmod-owl-loader wpad-basic-wolfssl kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES:= kmod-ath9k kmod-owl-loader wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += TDW8980
 endef
 TARGET_DEVICES += tplink_tdw8980
@@ -54,7 +54,7 @@ define Device/tplink_vr200
   TPLINK_HWID := 0x63e64801
   TPLINK_HWREV := 0x53
   IMAGE_SIZE := 15808k
-  DEVICE_PACKAGES:= kmod-mt76x0e wpad-basic-wolfssl kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES:= kmod-mt76x0e wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += VR200
 endef
 TARGET_DEVICES += tplink_vr200
@@ -68,7 +68,7 @@ define Device/tplink_vr200v
   TPLINK_HWID := 0x73b70801
   TPLINK_HWREV := 0x2f
   IMAGE_SIZE := 15808k
-  DEVICE_PACKAGES:= kmod-mt76x0e wpad-basic-wolfssl kmod-usb-dwc2 kmod-usb-ledtrig-usbport kmod-ltq-tapi kmod-ltq-vmmc
+  DEVICE_PACKAGES:= kmod-mt76x0e wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport kmod-ltq-tapi kmod-ltq-vmmc
   SUPPORTED_DEVICES += VR200v
 endef
 TARGET_DEVICES += tplink_vr200v

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -54,7 +54,7 @@ define Device/arcadyan_vgv7510kw22-brn
   SIGNATURE := BRNDA6431
   MAGIC := 0x12345678
   CRC32_POLY := 0x04c11db7
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-wolfssl kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
+  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
   SUPPORTED_DEVICES += VGV7510KW22BRN
 endef
 TARGET_DEVICES += arcadyan_vgv7510kw22-brn
@@ -68,7 +68,7 @@ define Device/arcadyan_vgv7510kw22-nor
   DEVICE_ALT0_MODEL := Box 6431
   DEVICE_ALT0_VARIANT := NOR
   IMAGE_SIZE := 15232k
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-wolfssl kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
+  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
   SUPPORTED_DEVICES += VGV7510KW22NOR
 endef
 TARGET_DEVICES += arcadyan_vgv7510kw22-nor
@@ -86,7 +86,7 @@ define Device/arcadyan_vgv7519-brn
   SIGNATURE := 5D00008000
   MAGIC := 0x12345678
   CRC32_POLY := 0x2083b8ed
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-wolfssl kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
+  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
   SUPPORTED_DEVICES += VGV7519BRN
 endef
 TARGET_DEVICES += arcadyan_vgv7519-brn
@@ -100,7 +100,7 @@ define Device/arcadyan_vgv7519-nor
   DEVICE_ALT0_MODEL := Experiabox 8
   DEVICE_ALT0_VARIANT := NOR
   IMAGE_SIZE := 15360k
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-wolfssl kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
+  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
   SUPPORTED_DEVICES += VGV7519NOR
 endef
 TARGET_DEVICES += arcadyan_vgv7519-nor
@@ -116,7 +116,7 @@ define Device/avm_fritz3370
   IMAGES += eva-kernel.bin eva-filesystem.bin
   IMAGE/eva-kernel.bin := append-kernel
   IMAGE/eva-filesystem.bin := append-ubi
-  DEVICE_PACKAGES := kmod-ath9k wpad-basic-wolfssl kmod-usb-dwc2 fritz-tffs
+  DEVICE_PACKAGES := kmod-ath9k wpad-basic-mbedtls kmod-usb-dwc2 fritz-tffs
 endef
 
 define Device/avm_fritz3370-rev2-hynix
@@ -142,7 +142,7 @@ define Device/avm_fritz3390
   DEVICE_MODEL := FRITZ!Box 3390
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-wolfssl \
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
 	kmod-usb-dwc2 fritz-tffs
 endef
 TARGET_DEVICES += avm_fritz3390
@@ -152,7 +152,7 @@ define Device/avm_fritz7360sl
   $(Device/AVM)
   DEVICE_MODEL := FRITZ!Box 7360 SL
   IMAGE_SIZE := 15744k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-wolfssl kmod-usb-dwc2
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls kmod-usb-dwc2
   SUPPORTED_DEVICES += FRITZ7360SL
 endef
 TARGET_DEVICES += avm_fritz7360sl
@@ -163,7 +163,7 @@ define Device/avm_fritz7360-v2
   DEVICE_MODEL := FRITZ!Box 7360
   DEVICE_VARIANT := v2
   IMAGE_SIZE := 32128k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-wolfssl kmod-usb-dwc2
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls kmod-usb-dwc2
 endef
 TARGET_DEVICES += avm_fritz7360-v2
 
@@ -174,7 +174,7 @@ define Device/avm_fritz7362sl
   DEVICE_MODEL := FRITZ!Box 7362 SL
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-wolfssl kmod-usb-dwc2 fritz-tffs
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls kmod-usb-dwc2 fritz-tffs
 endef
 TARGET_DEVICES += avm_fritz7362sl
 
@@ -186,7 +186,7 @@ define Device/avm_fritz7412
   BOARD_NAME := FRITZ7412
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-wolfssl fritz-tffs-nand fritz-caldata
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls fritz-tffs-nand fritz-caldata
 endef
 TARGET_DEVICES += avm_fritz7412
 
@@ -197,7 +197,7 @@ define Device/avm_fritz7430
   DEVICE_MODEL := FRITZ!Box 7430
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader kmod-usb-dwc2 wpad-basic-wolfssl \
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader kmod-usb-dwc2 wpad-basic-mbedtls \
 	fritz-tffs-nand fritz-caldata
 endef
 TARGET_DEVICES += avm_fritz7430
@@ -210,7 +210,7 @@ define Device/bt_homehub-v5a
   DEVICE_VARIANT := Type A
   BOARD_NAME := BTHOMEHUBV5A
   DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader \
-	kmod-ath10k-ct ath10k-firmware-qca988x-ct wpad-basic-wolfssl kmod-usb-dwc2
+	kmod-ath10k-ct ath10k-firmware-qca988x-ct wpad-basic-mbedtls kmod-usb-dwc2
   SUPPORTED_DEVICES += BTHOMEHUBV5A
 endef
 TARGET_DEVICES += bt_homehub-v5a
@@ -220,7 +220,7 @@ define Device/buffalo_wbmr-300hpd
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WBMR-300HPD
   IMAGE_SIZE := 15616k
-  DEVICE_PACKAGES := kmod-mt7603 wpad-basic-wolfssl kmod-usb-dwc2
+  DEVICE_PACKAGES := kmod-mt7603 wpad-basic-mbedtls kmod-usb-dwc2
   SUPPORTED_DEVICES += WBMR300
 endef
 TARGET_DEVICES += buffalo_wbmr-300hpd
@@ -232,7 +232,7 @@ define Device/lantiq_easy80920-nand
   DEVICE_MODEL := VR9 EASY80920
   DEVICE_VARIANT := NAND
   IMAGE_SIZE := 64512k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-wolfssl kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += lantiq_easy80920-nand
 
@@ -242,7 +242,7 @@ define Device/lantiq_easy80920-nor
   DEVICE_MODEL := VR9 EASY80920
   DEVICE_VARIANT := NOR
   IMAGE_SIZE := 7936k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-wolfssl kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += lantiq_easy80920-nor
 
@@ -269,7 +269,7 @@ define Device/zyxel_p-2812hnu-f1
   DEVICE_MODEL := P-2812HNU
   DEVICE_VARIANT := F1
   BOARD_NAME := P2812HNUF1
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-wolfssl kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport
   KERNEL_SIZE := 3072k
   SUPPORTED_DEVICES += P2812HNUF1
 endef
@@ -282,7 +282,7 @@ define Device/zyxel_p-2812hnu-f3
   DEVICE_MODEL := P-2812HNU
   DEVICE_VARIANT := F3
   BOARD_NAME := P2812HNUF3
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-wolfssl kmod-usb-dwc2
+  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2
   KERNEL_SIZE := 2048k
   SUPPORTED_DEVICES += P2812HNUF3
   DEFAULT := n

--- a/target/linux/lantiq/image/xway_legacy.mk
+++ b/target/linux/lantiq/image/xway_legacy.mk
@@ -6,7 +6,7 @@ define Device/arcadyan_arv4518pwr01
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath5k wpad-basic-wolfssl
+	kmod-ath5k wpad-basic-mbedtls
   SUPPORTED_DEVICES += ARV4518PWR01
   DEFAULT := n
 endef
@@ -20,7 +20,7 @@ define Device/arcadyan_arv4518pwr01a
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath5k wpad-basic-wolfssl
+	kmod-ath5k wpad-basic-mbedtls
   SUPPORTED_DEVICES += ARV4518PWR01A
   DEFAULT := n
 endef
@@ -38,7 +38,7 @@ define Device/arcadyan_arv4520pw
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-rt61-pci wpad-basic-wolfssl
+	kmod-rt61-pci wpad-basic-mbedtls
   SUPPORTED_DEVICES += ARV4520PW
   DEFAULT := n
 endef
@@ -51,7 +51,7 @@ define Device/arcadyan_arv4525pw
   DEVICE_ALT0_MODEL := Speedport W502V
   DEVICE_ALT0_VARIANT := Typ A
   IMAGE_SIZE := 3776k
-  DEVICE_PACKAGES := kmod-ath5k wpad-basic-wolfssl \
+  DEVICE_PACKAGES := kmod-ath5k wpad-basic-mbedtls \
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa -swconfig
@@ -67,7 +67,7 @@ define Device/arcadyan_arv452cqw
   DEVICE_ALT0_MODEL := Easybox 801
   IMAGE_SIZE := 3776k
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport \
-	kmod-ath5k wpad-basic-wolfssl \
+	kmod-ath5k wpad-basic-mbedtls \
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa

--- a/target/linux/malta/Makefile
+++ b/target/linux/malta/Makefile
@@ -14,6 +14,6 @@ KERNEL_PATCHVER:=5.15
 
 include $(INCLUDE_DIR)/target.mk
 
-DEFAULT_PACKAGES += wpad-basic-wolfssl kmod-mac80211-hwsim kmod-pcnet32 mkf2fs e2fsprogs
+DEFAULT_PACKAGES += wpad-basic-mbedtls kmod-mac80211-hwsim kmod-pcnet32 mkf2fs e2fsprogs
 
 $(eval $(call BuildTarget))

--- a/target/linux/mediatek/filogic/target.mk
+++ b/target/linux/mediatek/filogic/target.mk
@@ -2,7 +2,7 @@ ARCH:=aarch64
 SUBTARGET:=filogic
 BOARDNAME:=Filogic 830 (MT7986)
 CPU_TYPE:=cortex-a53
-DEFAULT_PACKAGES += kmod-crypto-hw-safexcel kmod-mt7915e kmod-mt7986-firmware wpad-basic-wolfssl uboot-envtools
+DEFAULT_PACKAGES += kmod-crypto-hw-safexcel kmod-mt7915e kmod-mt7986-firmware wpad-basic-mbedtls uboot-envtools
 KERNELNAME:=Image dtbs
 
 define Target/Description

--- a/target/linux/mediatek/mt7622/target.mk
+++ b/target/linux/mediatek/mt7622/target.mk
@@ -2,7 +2,7 @@ ARCH:=aarch64
 SUBTARGET:=mt7622
 BOARDNAME:=MT7622
 CPU_TYPE:=cortex-a53
-DEFAULT_PACKAGES += kmod-mt7622-firmware wpad-basic-wolfssl uboot-envtools
+DEFAULT_PACKAGES += kmod-mt7622-firmware wpad-basic-mbedtls uboot-envtools
 KERNELNAME:=Image dtbs
 
 define Target/Description

--- a/target/linux/mpc85xx/Makefile
+++ b/target/linux/mpc85xx/Makefile
@@ -20,7 +20,7 @@ include $(INCLUDE_DIR)/target.mk
 
 DEFAULT_PACKAGES += \
 	kmod-input-core kmod-input-gpio-keys kmod-button-hotplug \
-	kmod-leds-gpio swconfig kmod-ath9k wpad-basic-wolfssl kmod-usb2 \
+	kmod-leds-gpio swconfig kmod-ath9k wpad-basic-mbedtls kmod-usb2 \
 	uboot-envtools
 
 $(eval $(call BuildTarget))

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -58,7 +58,7 @@ define Device/cznic_turris-omnia
   KERNEL_INITRAMFS := kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
   DEVICE_PACKAGES :=  \
     mkf2fs e2fsprogs kmod-fs-vfat kmod-nls-cp437 kmod-nls-iso8859-1 \
-    wpad-basic-wolfssl kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct \
+    wpad-basic-mbedtls kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct \
     partx-utils kmod-i2c-mux-pca954x kmod-leds-turris-omnia
   IMAGES := $$(DEVICE_IMG_PREFIX)-sysupgrade.img.gz omnia-medkit-$$(DEVICE_IMG_PREFIX)-initramfs.tar.gz
   IMAGE/$$(DEVICE_IMG_PREFIX)-sysupgrade.img.gz := boot-scr | boot-img | sdcard-img | gzip | append-metadata
@@ -109,7 +109,7 @@ TARGET_DEVICES += kobol_helios4
 define Device/linksys
   $(Device/NAND-128K)
   DEVICE_VENDOR := Linksys
-  DEVICE_PACKAGES := kmod-mwlwifi wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-mwlwifi wpad-basic-mbedtls
   IMAGES += factory.img
   IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
 	append-ubi | pad-to $$$$(PAGESIZE)

--- a/target/linux/omap/profiles/00-default.mk
+++ b/target/linux/omap/profiles/00-default.mk
@@ -8,7 +8,7 @@ define Profile/Default
 	kmod-usb-net-asix kmod-usb-net-asix-ax88179 kmod-usb-net-hso \
 	kmod-usb-net-kaweth kmod-usb-net-pegasus kmod-usb-net-mcs7830 \
 	kmod-usb-net-smsc95xx kmod-usb-net-dm9601-ether \
-	wpad-basic-wolfssl
+	wpad-basic-mbedtls
   PRIORITY := 1
 endef
 

--- a/target/linux/oxnas/image/ox820.mk
+++ b/target/linux/oxnas/image/ox820.mk
@@ -50,7 +50,7 @@ define Device/cloudengines_pogoplugpro
   DEVICE_MODEL := PogoPlug Pro (with mPCIe)
   SUPPORTED_DEVICES += pogoplug-pro
   DEVICE_PACKAGES := kmod-usb2-oxnas kmod-usb-ledtrig-usbport \
-	kmod-ata-oxnas-sata kmod-rt2800-pci wpad-basic-wolfssl
+	kmod-ata-oxnas-sata kmod-rt2800-pci wpad-basic-mbedtls
 endef
 TARGET_DEVICES += cloudengines_pogoplugpro
 

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -54,7 +54,7 @@ define Device/alfa-network_tube-e4g
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := Tube-E4G
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci uboot-envtools uqmi -iwinfo \
-	-kmod-rt2800-soc -wpad-basic-wolfssl
+	-kmod-rt2800-soc -wpad-basic-mbedtls
   SUPPORTED_DEVICES += tube-e4g
 endef
 TARGET_DEVICES += alfa-network_tube-e4g

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -155,7 +155,7 @@ define Device/alfa-network_quad-e4g
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := Quad-E4G
   DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 uboot-envtools \
-	-wpad-basic-wolfssl
+	-wpad-basic-mbedtls
   SUPPORTED_DEVICES += quad-e4g
 endef
 TARGET_DEVICES += alfa-network_quad-e4g
@@ -217,7 +217,7 @@ define Device/asiarf_ap7621-001
   IMAGE_SIZE := 16000k
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AP7621-001
-  DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt76x2 kmod-usb3 -wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt76x2 kmod-usb3 -wpad-basic-mbedtls
 endef
 TARGET_DEVICES += asiarf_ap7621-001
 
@@ -226,7 +226,7 @@ define Device/asiarf_ap7621-nv1
   IMAGE_SIZE := 16000k
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AP7621-NV1
-  DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt76x2 kmod-usb3 -wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt76x2 kmod-usb3 -wpad-basic-mbedtls
 endef
 TARGET_DEVICES += asiarf_ap7621-nv1
 
@@ -680,7 +680,7 @@ define Device/dual-q_h721
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Dual-Q
   DEVICE_MODEL := H721
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 -wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 -wpad-basic-mbedtls
 endef
 TARGET_DEVICES += dual-q_h721
 
@@ -923,7 +923,7 @@ define Device/gnubee_gb-pc1
   $(Device/uimage-lzma-loader)
   DEVICE_VENDOR := GnuBee
   DEVICE_MODEL := Personal Cloud One
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 kmod-sdhci-mt7620 -wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 kmod-sdhci-mt7620 -wpad-basic-mbedtls
   IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += gnubee_gb-pc1
@@ -933,7 +933,7 @@ define Device/gnubee_gb-pc2
   $(Device/uimage-lzma-loader)
   DEVICE_VENDOR := GnuBee
   DEVICE_MODEL := Personal Cloud Two
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 kmod-sdhci-mt7620 -wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 kmod-sdhci-mt7620 -wpad-basic-mbedtls
   IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += gnubee_gb-pc2
@@ -1246,7 +1246,7 @@ define Device/iptime_t5004
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := T5004
-  DEVICE_PACKAGES := -wpad-basic-wolfssl
+  DEVICE_PACKAGES := -wpad-basic-mbedtls
 endef
 TARGET_DEVICES += iptime_t5004
 
@@ -1431,7 +1431,7 @@ define Device/mediatek_ap-mt7621a-v60
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Mediatek
   DEVICE_MODEL := AP-MT7621A-V60 EVB
-  DEVICE_PACKAGES := kmod-usb3 kmod-sdhci-mt7620 kmod-sound-mt7620 -wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-usb3 kmod-sdhci-mt7620 kmod-sound-mt7620 -wpad-basic-mbedtls
 endef
 TARGET_DEVICES += mediatek_ap-mt7621a-v60
 
@@ -1441,7 +1441,7 @@ define Device/mediatek_mt7621-eval-board
   IMAGE_SIZE := 15104k
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7621 EVB
-  DEVICE_PACKAGES := -wpad-basic-wolfssl
+  DEVICE_PACKAGES := -wpad-basic-mbedtls
   SUPPORTED_DEVICES += mt7621
 endef
 TARGET_DEVICES += mediatek_mt7621-eval-board
@@ -1469,7 +1469,7 @@ TARGET_DEVICES += mikrotik_ltap-2hnd
 define Device/mikrotik_routerboard-750gr3
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD 750Gr3
-  DEVICE_PACKAGES += -wpad-basic-wolfssl
+  DEVICE_PACKAGES += -wpad-basic-mbedtls
   SUPPORTED_DEVICES += mikrotik,rb750gr3
 endef
 TARGET_DEVICES += mikrotik_routerboard-750gr3
@@ -1477,14 +1477,14 @@ TARGET_DEVICES += mikrotik_routerboard-750gr3
 define Device/mikrotik_routerboard-760igs
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD 760iGS
-  DEVICE_PACKAGES += kmod-sfp -wpad-basic-wolfssl
+  DEVICE_PACKAGES += kmod-sfp -wpad-basic-mbedtls
 endef
 TARGET_DEVICES += mikrotik_routerboard-760igs
 
 define Device/mikrotik_routerboard-m11g
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD M11G
-  DEVICE_PACKAGES := -wpad-basic-wolfssl
+  DEVICE_PACKAGES := -wpad-basic-mbedtls
   SUPPORTED_DEVICES += mikrotik,rbm11g
 endef
 TARGET_DEVICES += mikrotik_routerboard-m11g
@@ -1492,7 +1492,7 @@ TARGET_DEVICES += mikrotik_routerboard-m11g
 define Device/mikrotik_routerboard-m33g
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD M33G
-  DEVICE_PACKAGES := -wpad-basic-wolfssl
+  DEVICE_PACKAGES := -wpad-basic-mbedtls
   SUPPORTED_DEVICES += mikrotik,rbm33g
 endef
 TARGET_DEVICES += mikrotik_routerboard-m33g
@@ -1805,7 +1805,7 @@ define Device/planex_vr500
   IMAGE_SIZE := 65216k
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := VR500
-  DEVICE_PACKAGES := kmod-usb3 -wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-usb3 -wpad-basic-mbedtls
   SUPPORTED_DEVICES += vr500
 endef
 TARGET_DEVICES += planex_vr500
@@ -1949,7 +1949,7 @@ define Device/thunder_timecloud
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Thunder
   DEVICE_MODEL := Timecloud
-  DEVICE_PACKAGES := kmod-usb3 -wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-usb3 -wpad-basic-mbedtls
   SUPPORTED_DEVICES += timecloud
 endef
 TARGET_DEVICES += thunder_timecloud
@@ -2082,7 +2082,7 @@ define Device/tplink_er605-v2
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := ER605
   DEVICE_VARIANT := v2
-  DEVICE_PACKAGES := -wpad-basic-wolfssl kmod-usb3
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   KERNEL_SIZE := 4096k
@@ -2176,7 +2176,7 @@ define Device/ubnt_edgerouter_common
   KERNEL_INITRAMFS := $$(KERNEL) | \
 	ubnt-erx-factory-image $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.tar
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES += -wpad-basic-wolfssl
+  DEVICE_PACKAGES += -wpad-basic-mbedtls
 endef
 
 define Device/ubnt_edgerouter-x
@@ -2258,7 +2258,7 @@ define Device/unielec_u7621-06-16m
   DEVICE_VENDOR := UniElec
   DEVICE_MODEL := U7621-06
   DEVICE_VARIANT := 16M
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 -wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 -wpad-basic-mbedtls
   SUPPORTED_DEVICES += u7621-06-256M-16M unielec,u7621-06-256m-16m
 endef
 TARGET_DEVICES += unielec_u7621-06-16m
@@ -2270,7 +2270,7 @@ define Device/unielec_u7621-06-32m
   DEVICE_VENDOR := UniElec
   DEVICE_MODEL := U7621-06
   DEVICE_VARIANT := 32M
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 -wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 -wpad-basic-mbedtls
   SUPPORTED_DEVICES += unielec,u7621-06-32m
 endef
 TARGET_DEVICES += unielec_u7621-06-32m
@@ -2282,7 +2282,7 @@ define Device/unielec_u7621-06-64m
   DEVICE_VENDOR := UniElec
   DEVICE_MODEL := U7621-06
   DEVICE_VARIANT := 64M
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 -wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 -wpad-basic-mbedtls
   SUPPORTED_DEVICES += unielec,u7621-06-512m-64m
 endef
 TARGET_DEVICES += unielec_u7621-06-64m
@@ -2505,7 +2505,7 @@ define Device/xiaoyu_xy-c5
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := XiaoYu
   DEVICE_MODEL := XY-C5
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 -wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 -wpad-basic-mbedtls
 endef
 TARGET_DEVICES += xiaoyu_xy-c5
 
@@ -2515,7 +2515,7 @@ define Device/xzwifi_creativebox-v1
   DEVICE_VENDOR := CreativeBox
   DEVICE_MODEL := v1
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mt7603 kmod-mt76x2 kmod-sdhci-mt7620 \
-	kmod-usb3 -wpad-basic-wolfssl
+	kmod-usb3 -wpad-basic-mbedtls
 endef
 TARGET_DEVICES += xzwifi_creativebox-v1
 

--- a/target/linux/ramips/mt7620/target.mk
+++ b/target/linux/ramips/mt7620/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=MT7620 based boards
 FEATURES+=usb ramdisk
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-rt2800-soc wpad-basic-wolfssl swconfig
+DEFAULT_PACKAGES += kmod-rt2800-soc wpad-basic-mbedtls swconfig
 
 define Target/Description
 	Build firmware images for Ralink MT7620 based boards.

--- a/target/linux/ramips/mt7621/target.mk
+++ b/target/linux/ramips/mt7621/target.mk
@@ -10,7 +10,7 @@ KERNELNAME:=vmlinux vmlinuz
 # make Kernel/CopyImage use $LINUX_DIR/vmlinuz
 IMAGES_DIR:=../../..
 
-DEFAULT_PACKAGES += wpad-basic-wolfssl
+DEFAULT_PACKAGES += wpad-basic-mbedtls
 
 define Target/Description
 	Build firmware images for Ralink MT7621 based boards.

--- a/target/linux/ramips/mt76x8/target.mk
+++ b/target/linux/ramips/mt76x8/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=MT76x8 based boards
 FEATURES+=usb ramdisk
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-mt7603 wpad-basic-wolfssl swconfig
+DEFAULT_PACKAGES += kmod-mt7603 wpad-basic-mbedtls swconfig
 
 define Target/Description
 	Build firmware images for Ralink MT76x8 based boards.

--- a/target/linux/ramips/rt288x/target.mk
+++ b/target/linux/ramips/rt288x/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=RT288x based boards
 FEATURES+=small_flash
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-rt2800-soc wpad-basic-wolfssl swconfig
+DEFAULT_PACKAGES += kmod-rt2800-soc wpad-basic-mbedtls swconfig
 
 define Target/Description
 	Build firmware images for Ralink RT288x based boards.

--- a/target/linux/ramips/rt305x/target.mk
+++ b/target/linux/ramips/rt305x/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=RT3x5x/RT5350 based boards
 FEATURES+=usb ramdisk small_flash
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-rt2800-soc wpad-basic-wolfssl swconfig
+DEFAULT_PACKAGES += kmod-rt2800-soc wpad-basic-mbedtls swconfig
 
 define Target/Description
 	Build firmware images for Ralink RT3x5x/RT5350 based boards.

--- a/target/linux/ramips/rt3883/target.mk
+++ b/target/linux/ramips/rt3883/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=RT3662/RT3883 based boards
 FEATURES+=usb pci small_flash
 CPU_TYPE:=74kc
 
-DEFAULT_PACKAGES += kmod-rt2800-pci kmod-rt2800-soc wpad-basic-wolfssl swconfig
+DEFAULT_PACKAGES += kmod-rt2800-pci kmod-rt2800-soc wpad-basic-mbedtls swconfig
 
 define Target/Description
 	Build firmware images for Ralink RT3662/RT3883 based boards.

--- a/target/linux/sunxi/image/cortexa7.mk
+++ b/target/linux/sunxi/image/cortexa7.mk
@@ -23,7 +23,7 @@ define Device/friendlyarm_nanopi-m1-plus
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi M1 Plus
   DEVICE_PACKAGES:=kmod-leds-gpio kmod-brcmfmac \
-	cypress-firmware-43430-sdio wpad-basic-wolfssl
+	cypress-firmware-43430-sdio wpad-basic-mbedtls
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += friendlyarm_nanopi-m1-plus
@@ -39,7 +39,7 @@ define Device/friendlyarm_nanopi-neo-air
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO Air
   DEVICE_PACKAGES := kmod-leds-gpio kmod-brcmfmac \
-	brcmfmac-firmware-43430a0-sdio wpad-basic-wolfssl
+	brcmfmac-firmware-43430a0-sdio wpad-basic-mbedtls
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += friendlyarm_nanopi-neo-air
@@ -48,7 +48,7 @@ define Device/friendlyarm_nanopi-r1
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R1
   DEVICE_PACKAGES := kmod-usb-net-rtl8152 kmod-leds-gpio \
-	kmod-brcmfmac cypress-firmware-43430-sdio wpad-basic-wolfssl
+	kmod-brcmfmac cypress-firmware-43430-sdio wpad-basic-mbedtls
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r1
@@ -66,7 +66,7 @@ define Device/lamobo_lamobo-r1
   DEVICE_MODEL := Lamobo R1
   DEVICE_ALT0_VENDOR := Bananapi
   DEVICE_ALT0_MODEL := BPi-R1
-  DEVICE_PACKAGES := kmod-ata-sunxi kmod-rtl8192cu wpad-basic-wolfssl
+  DEVICE_PACKAGES := kmod-ata-sunxi kmod-rtl8192cu wpad-basic-mbedtls
   DEVICE_COMPAT_VERSION := 1.1
   DEVICE_COMPAT_MESSAGE := Config cannot be migrated from swconfig to DSA
   SOC := sun7i-a20
@@ -85,7 +85,7 @@ define Device/sinovoip_bananapi-m2-berry
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Berry
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-brcmfmac \
-	cypress-firmware-43430-sdio wpad-basic-wolfssl
+	cypress-firmware-43430-sdio wpad-basic-mbedtls
   SUPPORTED_DEVICES:=lemaker,bananapi-m2-berry
   SOC := sun8i-v40
 endef
@@ -95,7 +95,7 @@ define Device/sinovoip_bananapi-m2-ultra
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Ultra
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-brcmfmac \
-	brcmfmac-firmware-43430a0-sdio wpad-basic-wolfssl
+	brcmfmac-firmware-43430a0-sdio wpad-basic-mbedtls
   SUPPORTED_DEVICES:=lemaker,bananapi-m2-ultra
   SOC := sun8i-r40
 endef
@@ -171,7 +171,7 @@ define Device/sinovoip_bananapi-m2-plus
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2+
   DEVICE_PACKAGES:=kmod-leds-gpio kmod-brcmfmac \
-	brcmfmac-firmware-43430a0-sdio wpad-basic-wolfssl
+	brcmfmac-firmware-43430a0-sdio wpad-basic-mbedtls
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += sinovoip_bananapi-m2-plus

--- a/target/linux/sunxi/profiles/00-default.mk
+++ b/target/linux/sunxi/profiles/00-default.mk
@@ -13,7 +13,7 @@ define Profile/Default
 	kmod-sun4i-emac \
 	rtl8188eu-firmware \
 	swconfig \
-	wpad-basic-wolfssl
+	wpad-basic-mbedtls
   PRIORITY := 1
 endef
 

--- a/target/linux/tegra/image/Makefile
+++ b/target/linux/tegra/image/Makefile
@@ -43,7 +43,7 @@ define Device/compulab_trimslice
   DEVICE_MODEL := TrimSlice
   DEVICE_DTS := tegra20-trimslice
   DEVICE_PACKAGES := kmod-r8169 kmod-rt2800-usb kmod-rtc-em3027 \
-	kmod-usb-storage wpad-basic-wolfssl
+	kmod-usb-storage wpad-basic-mbedtls
   UBOOT := trimslice-mmc
 endef
 TARGET_DEVICES += compulab_trimslice

--- a/target/linux/uml/Makefile
+++ b/target/linux/uml/Makefile
@@ -17,7 +17,7 @@ KERNEL_PATCHVER:=5.15
 
 include $(INCLUDE_DIR)/target.mk
 
-DEFAULT_PACKAGES += wpad-basic-wolfssl kmod-mac80211-hwsim mkf2fs e2fsprogs
+DEFAULT_PACKAGES += wpad-basic-mbedtls kmod-mac80211-hwsim mkf2fs e2fsprogs
 
   endif
 endif


### PR DESCRIPTION
The newly merged mbedtls backend is smaller and has fewer ABI related issues than the wolfSSL one.

Signed-off-by: Rosen Penev <rosenp@gmail.com>