### PR TITLE
mpc85xx: set correct CPU_TYPE

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -235,6 +235,7 @@ ifeq ($(DUMP),1)
   ifeq ($(ARCH),powerpc)
     CPU_CFLAGS_603e:=-mcpu=603e
     CPU_CFLAGS_8540:=-mcpu=8540
+    CPU_CFLAGS_8548:=-mcpu=8548
     CPU_CFLAGS_405:=-mcpu=405
     CPU_CFLAGS_440:=-mcpu=440
     CPU_CFLAGS_464fp:=-mcpu=464fp

--- a/target/linux/mpc85xx/Makefile
+++ b/target/linux/mpc85xx/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=powerpc
 BOARD:=mpc85xx
 BOARDNAME:=Freescale MPC85xx
-CPU_TYPE:=8540
+CPU_TYPE:=8548
 FEATURES:=squashfs ramdisk nand
 SUBTARGETS:=p1010 p1020 p2020
 


### PR DESCRIPTION
This PR contains two PR:

1. It changes CPU_TYPE from 8540 to 8548
2. Adds support for 8548