### PR TITLE
linux-firmware: ath11k: add symlink for WCN6855 hw2.1

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
 PKG_VERSION:=20221214
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/package/firmware/linux-firmware/qca_ath11k.mk
+++ b/package/firmware/linux-firmware/qca_ath11k.mk
@@ -19,5 +19,6 @@ define Package/ath11k-firmware-wcn6855/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/WCN6855/hw2.0
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/ath11k/WCN6855/hw2.0/* $(1)/lib/firmware/ath11k/WCN6855/hw2.0/
+	$(LN) ./hw2.0 $(1)/lib/firmware/ath11k/WCN6855/hw2.1
 endef
 $(eval $(call BuildPackage,ath11k-firmware-wcn6855))


### PR DESCRIPTION
WCN6855 exists in 2 HW revisions, but both use the same FW so upstream just has a symlink for hw2.1 to hw2.0 that I forgot to make.

Fixes: b4d3694f81f4 ("linux-firmware: package ath11k consumer cards firmware")
Signed-off-by: Robert Marko <robimarko@gmail.com>