### PR TITLE
linux-firmware: disable stripping

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
 PKG_VERSION:=20221214
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -20,6 +20,9 @@ PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 SCAN_DEPS = *.mk
 
 include $(INCLUDE_DIR)/package.mk
+
+RSTRIP:=:
+STRIP:=:
 
 define Package/firmware-default
   SECTION:=firmware


### PR DESCRIPTION
It has been brought to my attention that recently added WCN6855 firmware is broken as it is getting stripped during building due to being 2 ELF binaries.
I am sure WCN6750 and any other ELF binaries are having the same issue, so since stripping firmware binaries is clearly unwanted disable it.

Fixes: b4d3694f81f4 ("linux-firmware: package ath11k consumer cards firmware")
Signed-off-by: Robert Marko <robimarko@gmail.com>