### PR TITLE
realtek: dsa: support active-high LEDs

### DIFF
--- a/target/linux/realtek/dts-5.10/rtl9302_zyxel_xgs1250-12.dts
+++ b/target/linux/realtek/dts-5.10/rtl9302_zyxel_xgs1250-12.dts
@@ -64,6 +64,7 @@
 
 	led_set: led_set@0 {
 		compatible = "realtek,rtl9300-leds";
+		active-low;
 		led_set0 = <0x0000 0xffff 0x0a20 0x0b80>; // LED set 0: 1000Mbps,  10/100Mbps
 		led_set1 = <0x0a0b 0x0a28 0x0a82 0x0a0b>; // LED set 1: (10G, 5G, 2.5G) (2.5G, 1G)
 							  // (5G, 10/100) (10G, 5G, 2.5G)

--- a/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
+++ b/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
@@ -68,6 +68,7 @@
 		led_set1 = <0x0a0b 0x0a28 0x0a82 0x0a0b>; // LED set 1: (10G, 5G, 2.5G) (2.5G, 1G)
 							  // (5G, 10/100) (10G, 5G, 2.5G)
 		led_set2 = <0x0000 0xffff 0x0a20 0x0a01>; // LED set 2: 1000MBit, 10GBit
+		active-low;
 	};
 };
 

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -21,6 +21,8 @@
 #define RTL930X_VLAN_PORT_TAG_STS_CTRL_IGR_P_OTAG_KEEP_MASK	GENMASK(1,1)
 #define RTL930X_VLAN_PORT_TAG_STS_CTRL_IGR_P_ITAG_KEEP_MASK	GENMASK(0,0)
 
+#define RTL930X_LED_GLB_ACTIVE_LOW  BIT(22)
+
 extern struct mutex smi_lock;
 extern struct rtl83xx_soc_info soc_info;
 
@@ -2430,6 +2432,13 @@ static void rtl930x_led_init(struct rtl838x_switch_priv *priv)
 
 	/* Set LED mode to serial (0x1) */
 	sw_w32_mask(0x3, 0x1, RTL930X_LED_GLB_CTRL);
+
+	// Set LED active state
+	if (of_property_read_bool(node, "active-low")) {
+		sw_w32_mask(RTL930X_LED_GLB_ACTIVE_LOW, 0, RTL930X_LED_GLB_CTRL);
+	} else {
+		sw_w32_mask(0, RTL930X_LED_GLB_ACTIVE_LOW, RTL930X_LED_GLB_CTRL);
+	}
 
 	/* Set port type masks */
 	sw_w32(pm, RTL930X_LED_PORT_COPR_MASK_CTRL);


### PR DESCRIPTION
The TP-LINK TL-ST1008F has active-high LEDs, so we need a device tree property  to express this.

Signed-off-by: Lorenz Brun <lorenz@brun.one>
