### PR TITLE
CI: labeler: Add target label to target packages

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,54 +9,77 @@
   - "target/linux/armvirt/**"
 "target/at91":
   - "target/linux/at91/**"
+  - "package/boot/at91bootstrap/**"
+  - "package/boot/uboot-at91/**"
 "target/ath25":
   - "target/linux/ath25/**"
 "target/ath79":
   - "target/linux/ath79/**"
 "target/bcm27xx":
   - "target/linux/bcm27xx/**"
+  - "package/kernel/bcm27xx-gpu-fw/**"
 "target/bcm47xx":
   - "target/linux/bcm47xx/**"
 "target/bcm4908":
   - "target/linux/bcm4908/**"
+  - "package/boot/uboot-bcm4908/**"
 "target/bcm53xx":
   - "target/linux/bcm53xx/**"
 "target/bcm63xx":
   - "target/linux/bcm63xx/**"
+  - "package/kernel/bcm63xx-cfe/**"
+  - "package/boot/arm-trusted-firmware-bcm63xx/**"
 "target/bmips":
   - "target/linux/bmips/**"
 "target/gemini":
   - "target/linux/gemini/**"
 "target/imx":
   - "target/linux/imx/**"
+  - "package/boot/imx-bootlets/**"
+  - "package/boot/uboot-imx/**"
 "target/ipq40xx":
   - "target/linux/ipq40xx/**"
 "target/ipq806x":
   - "target/linux/ipq806x/**"
 "target/kirkwood":
   - "target/linux/kirkwood/**"
+  - "package/boot/uboot-kirkwood/**"
 "target/lantiq":
   - "target/linux/lantiq/**"
+  - "package/kernel/lantiq/**"
+  - "package/firmware/lantiq/**"
+  - "package/boot/uboot-lantiq/**"
 "target/layerscape":
   - "target/linux/layerscape/**"
+  - "package/firmware/layerscape/**"
+  - "package/boot/tfa-layerscape/**"
+  - "package/boot/uboot-layerscape/**"
+  - "package/network/utils/layerscape/**"
 "target/malta":
   - "target/linux/malta/**"
 "target/mediatek":
   - "target/linux/mediatek/**"
+  - "package/boot/arm-trusted-firmware-mediatek/**"
+  - "package/boot/uboot-mediatek/**"
 "target/mpc85xx":
   - "target/linux/mpc85xx/**"
 "target/mvebu":
   - "target/linux/mvebu/**"
+  - "package/boot/arm-trusted-firmware-mvebu/**"
+  - "package/boot/uboot-mvebu/**"
 "target/mxs":
   - "target/linux/mxs/**"
+  - "package/boot/uboot-mxs/**"
 "target/octeon":
   - "target/linux/octeon/**"
 "target/octeontx":
   - "target/linux/octeontx/**"
 "target/omap":
   - "target/linux/omap/**"
+  - "package/boot/uboot-omap/**"
 "target/oxnas":
   - "target/linux/oxnas/**"
+  - "package/boot/uboot-oxnas/**"
 "target/pistachio":
   - "target/linux/pistachio/**"
 "target/qoriq":
@@ -67,16 +90,22 @@
   - "target/linux/realtek/**"
 "target/rockchip":
   - "target/linux/rockchip/**"
+  - "package/boot/arm-trusted-firmware-rockchip/**"
+  - "package/boot/uboot-rockchip/**"
 "target/sunxi":
   - "target/linux/sunxi/**"
+  - "package/boot/arm-trusted-firmware-sunxi/**"
+  - "package/boot/uboot-sunxi/**"
 "target/tegra":
   - "target/linux/tegra/**"
+  - "package/boot/uboot-tegra/**"
 "target/uml":
   - "target/linux/uml/**"
 "target/x86":
   - "target/linux/x86/**"
 "target/zynq":
   - "target/linux/zynq/**"
+  - "package/boot/uboot-zynq/**"
 # target/imagebuilder
 "target/imagebuilder":
   - "target/imagebuilder/**"


### PR DESCRIPTION
This adds the target label also to changes in packages which are target specific like the boot loader of a target or some drivers which are only use on one target.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>