### PR TITLE
tfa-layerscape: Use trusted-firmware-a.mk

### DIFF
--- a/package/boot/tfa-layerscape/Makefile
+++ b/package/boot/tfa-layerscape/Makefile
@@ -18,6 +18,7 @@ PKG_MIRROR_HASH:=893f2d28a77dcc9d4413a619b4719ca5f1f4dc78dd824a8488e7d543e66bcf9
 PKG_BUILD_DEPENDS:=tfa-layerscape/host
 
 include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/trusted-firmware-a.mk
 include $(INCLUDE_DIR)/package.mk
 
 HOST_CFLAGS += -Wall -Werror -pedantic -std=c99
@@ -38,131 +39,97 @@ define Host/Install
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/tools/nxp/byte_swap $(STAGING_DIR_HOST)/bin/tfa-byte-swap
 endef
 
-define Package/tfa-generic
-  SECTION:=boot
-  CATEGORY:=Boot Loaders
-  DEPENDS:=@TARGET_layerscape_armv8_64b +layerscape-rcw +u-boot-fsl_$(subst tfa-,,$(1))
-  VARIANT:=$(subst tfa-,,$(1))
+define Trusted-Firmware-A/Default
+  BUILD_TARGET:=layerscape
+  BUILD_SUBTARGET:=armv8_64b
+  DEPENDS:=+layerscape-rcw +u-boot-fsl_$(1)
 endef
 
-define Package/tfa-ls1012a-frdm
-  $(Package/tfa-generic)
-  TITLE:=NXP LS1012AFRDM Trusted Firmware
+define Trusted-Firmware-A/ls1012a-frdm
+  NAME:=NXP LS1012AFRDM
   PLAT:=ls1012afrdm
   BOOT_MODE:=qspi
 endef
 
-define Package/tfa-ls1012a-rdb
-  $(Package/tfa-generic)
-  TITLE:=NXP LS1012ARDB Trusted Firmware
+define Trusted-Firmware-A/ls1012a-rdb
+  NAME:=NXP LS1012ARDB
   PLAT:=ls1012ardb
   BOOT_MODE:=qspi
 endef
 
-define Package/tfa-ls1012a-frwy-sdboot
-  $(Package/tfa-generic)
-  TITLE:=NXP LS1012AFRWY Trusted Firmware
+define Trusted-Firmware-A/ls1012a-frwy-sdboot
+  NAME:=NXP LS1012AFRWY
   PLAT:=ls1012afrwy
   BOOT_MODE:=qspi
 endef
 
-define Package/tfa-ls1043a-rdb
-  $(Package/tfa-generic)
-  TITLE:=NXP LS1043ARDB Trusted Firmware
+define Trusted-Firmware-A/ls1043a-rdb
+  NAME:=NXP LS1043ARDB
   PLAT:=ls1043ardb
   BOOT_MODE:=nor
 endef
 
-define Package/tfa-ls1043a-rdb-sdboot
-  $(Package/tfa-generic)
-  TITLE:=NXP LS1043ARDB SD Boot Trusted Firmware
+define Trusted-Firmware-A/ls1043a-rdb-sdboot
+  NAME:=NXP LS1043ARDB SD Boot
   PLAT:=ls1043ardb
   BOOT_MODE:=sd
 endef
 
-define Package/tfa-ls1046a-frwy
-  $(Package/tfa-generic)
-  TITLE:=NXP LS1046AFRWY Trusted Firmware
+define Trusted-Firmware-A/ls1046a-frwy
+  NAME:=NXP LS1046AFRWY
   PLAT:=ls1046afrwy
   BOOT_MODE:=qspi
 endef
 
-define Package/tfa-ls1046a-frwy-sdboot
-  $(Package/tfa-generic)
-  TITLE:=NXP LS1046AFRWY SD Boot Trusted Firmware
+define Trusted-Firmware-A/ls1046a-frwy-sdboot
+  NAME:=NXP LS1046AFRWY SD Boot
   PLAT:=ls1046afrwy
   BOOT_MODE:=sd
 endef
 
-define Package/tfa-ls1046a-rdb
-  $(Package/tfa-generic)
-  TITLE:=NXP LS1046ARDB Trusted Firmware
+define Trusted-Firmware-A/ls1046a-rdb
+  NAME:=NXP LS1046ARDB
   PLAT:=ls1046ardb
   BOOT_MODE:=qspi
 endef
 
-define Package/tfa-ls1046a-rdb-sdboot
-  $(Package/tfa-generic)
-  TITLE:=NXP LS1046ARDB SD Boot Trusted Firmware
+define Trusted-Firmware-A/ls1046a-rdb-sdboot
+  NAME:=NXP LS1046ARDB SD Boot
   PLAT:=ls1046ardb
   BOOT_MODE:=sd
 endef
 
-define Package/tfa-ls1088a-rdb
-  $(Package/tfa-generic)
-  TITLE:=NXP LS1088ARDB Trusted Firmware
+define Trusted-Firmware-A/ls1088a-rdb
+  NAME:=NXP LS1088ARDB
   PLAT:=ls1088ardb
   BOOT_MODE:=qspi
 endef
 
-define Package/tfa-ls1088a-rdb-sdboot
-  $(Package/tfa-generic)
-  TITLE:=NXP LS1088ARDB SD Boot Trusted Firmware
+define Trusted-Firmware-A/ls1088a-rdb-sdboot
+  NAME:=NXP LS1088ARDB SD Boot
   PLAT:=ls1088ardb
   BOOT_MODE:=sd
 endef
 
-define Package/tfa-ls2088a-rdb
-  $(Package/tfa-generic)
-  TITLE:=NXP LS2088ARDB Trusted Firmware
+define Trusted-Firmware-A/ls2088a-rdb
+  NAME:=NXP LS2088ARDB
   PLAT:=ls2088ardb
   BOOT_MODE:=nor
 endef
 
-define Package/tfa-lx2160a-rdb
-  $(Package/tfa-generic)
-  TITLE:=NXP LX2160ARDB Trusted Firmware
+define Trusted-Firmware-A/lx2160a-rdb
+  NAME:=NXP LX2160ARDB
   PLAT:=lx2160ardb
   BOOT_MODE:=flexspi_nor
 endef
 
-define Package/tfa-lx2160a-rdb-sdboot
-  $(Package/tfa-generic)
-  TITLE:=NXP LX2160ARDB SD Boot Trusted Firmware
+define Trusted-Firmware-A/lx2160a-rdb-sdboot
+  NAME:=NXP LX2160ARDB SD Boot
   PLAT:=lx2160ardb
   BOOT_MODE:=sd
 endef
 
-define Build/InstallDev
-	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
-	$(CP) $(PKG_BUILD_DIR)/build/$(PLAT)/release/bl2_$(BOOT_MODE).pbl \
-		$(STAGING_DIR_IMAGE)/fsl_$(BUILD_VARIANT)-bl2.pbl
-	$(CP) $(PKG_BUILD_DIR)/build/$(PLAT)/release/fip.bin \
-		$(STAGING_DIR_IMAGE)/fsl_$(BUILD_VARIANT)-fip.bin
-endef
-
-define Build/Compile
-	$(eval $(Package/tfa-$(BUILD_VARIANT))) \
-	$(MAKE) -C $(PKG_BUILD_DIR) CROSS_COMPILE=$(TARGET_CROSS) \
-		fip pbl PLAT=$(PLAT) BOOT_MODE=$(BOOT_MODE) \
-		RCW=$(STAGING_DIR_IMAGE)/fsl_$(BUILD_VARIANT)-rcw.bin \
-		BL33=$(STAGING_DIR_IMAGE)/fsl_$(BUILD_VARIANT)-uboot.bin \
-		FIPTOOL=$(STAGING_DIR_HOST)/bin/fiptool-layerscape \
-		CREATE_PBL=$(STAGING_DIR_HOST)/bin/tfa-create-pbl \
-		BYTE_SWAP=$(STAGING_DIR_HOST)/bin/tfa-byte-swap
-endef
-
-TFAS := \
+TFA_TARGETS := \
   ls1012a-frdm \
   ls1012a-rdb \
   ls1012a-frwy-sdboot \
@@ -178,7 +145,25 @@ TFAS := \
   lx2160a-rdb \
   lx2160a-rdb-sdboot
 
+TFA_MAKE_FLAGS += \
+	fip pbl \
+	BOOT_MODE=$(BOOT_MODE) \
+	RCW=$(STAGING_DIR_IMAGE)/fsl_$(BUILD_VARIANT)-rcw.bin \
+	BL33=$(STAGING_DIR_IMAGE)/fsl_$(BUILD_VARIANT)-uboot.bin \
+	FIPTOOL=$(STAGING_DIR_HOST)/bin/fiptool-layerscape \
+	CREATE_PBL=$(STAGING_DIR_HOST)/bin/tfa-create-pbl \
+	BYTE_SWAP=$(STAGING_DIR_HOST)/bin/tfa-byte-swap
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
+	$(CP) $(PKG_BUILD_DIR)/build/$(PLAT)/release/bl2_$(BOOT_MODE).pbl \
+		$(STAGING_DIR_IMAGE)/fsl_$(BUILD_VARIANT)-bl2.pbl
+	$(CP) $(PKG_BUILD_DIR)/build/$(PLAT)/release/fip.bin \
+		$(STAGING_DIR_IMAGE)/fsl_$(BUILD_VARIANT)-fip.bin
+endef
+
+define Package/trusted-firmware-a/install/default
+endef
+
 $(eval $(call HostBuild))
-$(foreach tfa,$(TFAS), \
-  $(eval $(call BuildPackage,tfa-$(tfa))) \
-)
+$(eval $(call BuildPackage/Trusted-Firmware-A))

--- a/target/linux/layerscape/image/armv8_64b.mk
+++ b/target/linux/layerscape/image/armv8_64b.mk
@@ -29,7 +29,7 @@ define Device/fsl_ls1012a-frdm
   DEVICE_MODEL := FRDM-LS1012A
   DEVICE_PACKAGES += \
     layerscape-ppfe \
-    tfa-ls1012a-frdm \
+    trusted-firmware-a-ls1012a-frdm \
     kmod-ppfe
   BLOCKSIZE := 256KiB
   IMAGE/firmware.bin := \
@@ -55,7 +55,7 @@ define Device/fsl_ls1012a-rdb
   DEVICE_MODEL := LS1012A-RDB
   DEVICE_PACKAGES += \
     layerscape-ppfe \
-    tfa-ls1012a-rdb \
+    trusted-firmware-a-ls1012a-rdb \
     kmod-hwmon-ina2xx \
     kmod-iio-fxas21002c-i2c \
     kmod-iio-fxos8700-i2c \
@@ -79,7 +79,7 @@ define Device/fsl_ls1012a-frwy-sdboot
   DEVICE_MODEL := FRWY-LS1012A
   DEVICE_PACKAGES += \
     layerscape-ppfe \
-    tfa-ls1012a-frwy-sdboot \
+    trusted-firmware-a-ls1012a-frwy-sdboot \
     kmod-ppfe
   DEVICE_DTS := freescale/fsl-ls1012a-frwy
   IMAGES += firmware.bin
@@ -105,7 +105,7 @@ define Device/fsl_ls1043a-rdb
   DEVICE_VARIANT := Default
   DEVICE_PACKAGES += \
     layerscape-fman \
-    tfa-ls1043a-rdb \
+    trusted-firmware-a-ls1043a-rdb \
     fmc fmc-eth-config \
     kmod-ahci-qoriq \
     kmod-hwmon-ina2xx \
@@ -131,7 +131,7 @@ define Device/fsl_ls1043a-rdb-sdboot
   DEVICE_VARIANT := SD Card Boot
   DEVICE_PACKAGES += \
     layerscape-fman \
-    tfa-ls1043a-rdb-sdboot \
+    trusted-firmware-a-ls1043a-rdb-sdboot \
     fmc fmc-eth-config \
     kmod-ahci-qoriq \
     kmod-hwmon-ina2xx \
@@ -155,7 +155,7 @@ define Device/fsl_ls1046a-frwy
   DEVICE_VARIANT := Default
   DEVICE_PACKAGES += \
     layerscape-fman \
-    tfa-ls1046a-frwy
+    trusted-firmware-a-ls1046a-frwy
   DEVICE_DTS := freescale/fsl-ls1046a-frwy
   IMAGE/firmware.bin := \
     ls-clean | \
@@ -176,7 +176,7 @@ define Device/fsl_ls1046a-frwy-sdboot
   DEVICE_VARIANT := SD Card Boot
   DEVICE_PACKAGES += \
     layerscape-fman \
-    tfa-ls1046a-frwy-sdboot
+    trusted-firmware-a-ls1046a-frwy-sdboot
   DEVICE_DTS := freescale/fsl-ls1046a-frwy
   IMAGE/sdcard.img.gz := \
     ls-clean | \
@@ -197,7 +197,7 @@ define Device/fsl_ls1046a-rdb
   DEVICE_VARIANT := Default
   DEVICE_PACKAGES += \
     layerscape-fman \
-    tfa-ls1046a-rdb \
+    trusted-firmware-a-ls1046a-rdb \
     fmc fmc-eth-config \
     kmod-ahci-qoriq \
     kmod-hwmon-ina2xx \
@@ -223,7 +223,7 @@ define Device/fsl_ls1046a-rdb-sdboot
   DEVICE_VARIANT := SD Card Boot
   DEVICE_PACKAGES += \
     layerscape-fman \
-    tfa-ls1046a-rdb-sdboot \
+    trusted-firmware-a-ls1046a-rdb-sdboot \
     fmc fmc-eth-config \
     kmod-ahci-qoriq \
     kmod-hwmon-ina2xx \
@@ -249,7 +249,7 @@ define Device/fsl_ls1088a-rdb
   DEVICE_PACKAGES += \
     layerscape-mc \
     layerscape-dpl \
-    tfa-ls1088a-rdb \
+    trusted-firmware-a-ls1088a-rdb \
     restool \
     kmod-ahci-qoriq \
     kmod-hwmon-ina2xx \
@@ -277,7 +277,7 @@ define Device/fsl_ls1088a-rdb-sdboot
   DEVICE_PACKAGES += \
     layerscape-mc \
     layerscape-dpl \
-    tfa-ls1088a-rdb-sdboot \
+    trusted-firmware-a-ls1088a-rdb-sdboot \
     restool \
     kmod-ahci-qoriq \
     kmod-hwmon-ina2xx \
@@ -304,7 +304,7 @@ define Device/fsl_ls2088a-rdb
   DEVICE_PACKAGES += \
     layerscape-mc \
     layerscape-dpl \
-    tfa-ls2088a-rdb \
+    trusted-firmware-a-ls2088a-rdb \
     restool \
     kmod-ahci-qoriq
   IMAGE/firmware.bin := \
@@ -329,7 +329,7 @@ define Device/fsl_lx2160a-rdb
     layerscape-mc \
     layerscape-dpl \
     layerscape-ddr-phy \
-    tfa-lx2160a-rdb \
+    trusted-firmware-a-lx2160a-rdb \
     restool
   IMAGE/firmware.bin := \
     ls-clean | \
@@ -355,7 +355,7 @@ define Device/fsl_lx2160a-rdb-sdboot
     layerscape-mc \
     layerscape-dpl \
     layerscape-ddr-phy \
-    tfa-lx2160a-rdb-sdboot \
+    trusted-firmware-a-lx2160a-rdb-sdboot \
     restool
   DEVICE_DTS := freescale/fsl-lx2160a-rdb
   IMAGE/sdcard.img.gz := \


### PR DESCRIPTION
This converts the trusted firmware arm build Makefile to make use of the common trusted-firmware-a.mk file. This also fixes the build with binutils 2.39.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
