### PR TITLE
ipq40xx: fix wlan mac address for Aruba AP-303H

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4029-ap-303h.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4029-ap-303h.dts
@@ -359,6 +359,10 @@
 				macaddr_mfginfo_1d: macaddr@1d {
 					reg = <0x1d 0x6>;
 				};
+
+				macaddr_mfginfo_45: macaddr@45 {
+					reg = <0x45 0x6>;
+				};
 			};
 
 			partition@3a0000 {
@@ -454,17 +458,15 @@
 
 &wifi0 {
 	status = "okay";
-	qcom,ath10k-calibration-variant = "Aruba-AP-303";
 	nvmem-cell-names = "pre-calibration", "mac-address";
-	nvmem-cells = <&precal_art_1000>, <&macaddr_mfginfo_1d>;
+	nvmem-cells = <&precal_art_1000>, <&macaddr_mfginfo_45>;
 	qcom,ath10k-calibration-variant = "Aruba-AP-303";
 };
 
 &wifi1 {
 	status = "okay";
-	qcom,ath10k-calibration-variant = "Aruba-AP-303";
 	nvmem-cell-names = "pre-calibration", "mac-address";
-	nvmem-cells = <&precal_art_5000>, <&macaddr_mfginfo_1d>;
+	nvmem-cells = <&precal_art_5000>, <&macaddr_mfginfo_45>;
 	mac-address-increment = <1>;
 	qcom,ath10k-calibration-variant = "Aruba-AP-303";
 };


### PR DESCRIPTION
Assigns the correct mac address from nvmen to the wlan interfaces. This mac address corresponds to the label "Wireless MAC" on the device and the stock firmware.
