### PR TITLE
WIP: ramips: add support for Asus RT-N65U

### DIFF
--- a/target/linux/ramips/dts/rt3883_asus_rt-n65u.dts
+++ b/target/linux/ramips/dts/rt3883_asus_rt-n65u.dts
@@ -1,0 +1,178 @@
+#include "rt3883.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "asus,rt-n65u", "ralink,rt3883-soc";
+	model = "Asus RT-N65U";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	rtl8367rb {
+		compatible = "realtek,rtl8367b";
+		cpu_port = <6>;
+		realtek,extif1 = <1 0 1 1 1 1 1 1 2>;
+		mii-bus = <&mdio0>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "blue:power";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "blue:lan";
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "blue:wan";
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "blue:usb";
+			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "uartf";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+
+	port@0 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+		phy-handle = <&phy0>;
+	};
+
+	mdio0:mdio-bus {
+		status = "okay";
+
+		phy0: ethernet-phy@0 {
+			reg = <0>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&pci {
+	status = "okay";
+};
+
+&pci1 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci1814,3352";
+		reg = <0x10000 0 0 0 0>;
+		ralink,mtd-eeprom = <&factory 0x8000>;
+	};
+};
+
+&wmac {
+	status = "okay";
+	ralink,2ghz = <0>;
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 {
+		reg = <0x4 0x6>;
+	};
+};

--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -17,6 +17,19 @@ define Device/asus_rt-n56u
 endef
 TARGET_DEVICES += asus_rt-n56u
 
+define Device/asus_rt-n65u
+  $(Device/uimage-lzma-loader)
+  SOC := rt3883
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := 16384k
+  DEVICE_VENDOR := ASUS
+  DEVICE_MODEL := RT-N65U
+  DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb3 \
+	kmod-usb-ledtrig-usbport kmod-switch-rtl8366-smi kmod-switch-rtl8367b
+  SUPPORTED_DEVICES += rt-n65u
+endef
+TARGET_DEVICES += asus_rt-n65u
+
 define Device/belkin_f9k1109v1
   $(Device/uimage-lzma-loader)
   SOC := rt3883

--- a/target/linux/ramips/rt3883/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/rt3883/base-files/etc/board.d/02_network
@@ -16,7 +16,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "5@eth0"
 		;;
-	dlink,dir-645)
+	dlink,dir-645|\
+	asus,rt-n65u)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
 		;;
@@ -50,7 +51,8 @@ ramips_setup_macs()
 	local label_mac=""
 
 	case $board in
-	asus,rt-n56u)
+	asus,rt-n56u|\
+	asus,rt-n65u)
 		lan_mac=$(macaddr_setbit_la "$(cat /sys/class/net/eth0/address)")
 		wan_mac=$(mtd_get_mac_binary factory 0x8004)
 		;;

--- a/target/linux/ramips/rt3883/base-files/lib/preinit/04_handle_checksumming
+++ b/target/linux/ramips/rt3883/base-files/lib/preinit/04_handle_checksumming
@@ -10,7 +10,7 @@ do_checksumming_disable() {
 
 	case "$board" in
 	asus,rt-n56u)
-		echo "Board is ASUS RT-N56U, replacing uImage header..."
+		echo "Board is ASUS $board, replacing uImage header..."
 		local firmware_mtd=$(find_mtd_part firmware)
 		local rootfs_mtd=$(find_mtd_part rootfs)
 		local rootfs_data_mtd=$(find_mtd_part rootfs_data)


### PR DESCRIPTION
ASUS RT-N65U is a 2.4/5 Ghz band 11ac (Wi-Fi 5) router, based on RT3883F.

Specification:
- CPU1: Ralink RT3883 @500MHz, WiSoC 5GHz
- CPU2: Ralink RT3352 @400MHz, WiSoC 2.4GHz
- RAM1: 128MB
- RAM2: 16MB
- Flash: Macronix MX25L12805D (16MB)
- WLAN: Ralink RT3883 (5GHz 3T3R), Ralink RT3352 (2.4GHz 2T2R)
- 4x 10/100/1000 Mbps Ethernet
- 1x 10/100/1000 Mbps WAN
- USB: ASMedia ASM1042 USB 3.0 Controller
- PMU: UTC UZ1086L-ADJ
- 4x LED, 2x button

Notes:
- Lot of stuff have been copies from `rt-n56u`

TODO:
- [x] verify if it boots on the real device
- [ ] try to figure-out what's wrong and fix it
  - [ ] LZMA compression
  - [x] SPI flash mounting
  - [ ] switch problem
  - [ ] overall check