### PR TITLE
CI: remove various tools from macOS CI

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -41,26 +41,16 @@ jobs:
         working-directory: ${{ env.WORKPATH }}/openwrt
         run: |
           brew install \
-            autoconf \
             automake \
             coreutils \
             diffutils \
             findutils \
             gawk \
-            gettext \
             git-extras \
-            gmp \
-            gnu-getopt \
             gnu-sed \
-            gnu-tar \
             grep \
-            m4 \
             make \
-            mpfr \
-            ncurses \
-            pcre \
-            pkg-config \
-            wget
+            pcre
 
             echo "/bin" >> "$GITHUB_PATH"
             echo "/sbin/Library/Apple/usr/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -49,8 +49,7 @@ jobs:
             git-extras \
             gnu-sed \
             grep \
-            make \
-            pcre
+            make
 
             echo "/bin" >> "$GITHUB_PATH"
             echo "/sbin/Library/Apple/usr/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -54,19 +54,13 @@ jobs:
             gnu-sed \
             gnu-tar \
             grep \
-            libidn2 \
-            libunistring \
             m4 \
             make \
             mpfr \
             ncurses \
-            openssl@1.1 \
             pcre \
             pkg-config \
-            quilt \
-            readline \
-            wget \
-            zstd
+            wget
 
             echo "/bin" >> "$GITHUB_PATH"
             echo "/sbin/Library/Apple/usr/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
This was needed when tools/zstd was not in the tree. Now that it is, remove it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @aparcar @Ansuel 