### PR TITLE
rampis: fix Reference to non-existent node for GB-PC2

### DIFF
--- a/target/linux/ramips/dts/mt7621_gnubee_gb-pc2.dts
+++ b/target/linux/ramips/dts/mt7621_gnubee_gb-pc2.dts
@@ -119,8 +119,7 @@
 	label = "ethyellow";
 	phy-handle = <&ethphy5>;
 
-	nvmem-cells = <&macaddr_factory_e000>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&factory 0xe000>;
 };
 
 &mdio {


### PR DESCRIPTION
Fix cannot build: Reference to non-existent node or label
"macaddr_factory_e000" dtb compilation error.

The cherry-pick had to be reworked to use the old mtd-mac-address way as
openwrt-21.02 still wasn't migrated to nvmem implementation.

Fixes: https://github.com/Ansuel/openwrt/commit/d604032c2a50fc6228bcaae78baee1048ff9af16 ("ramips: fix GB-PC1 and GB-PC2 device support")
Fixes: https://github.com/openwrt/openwrt/issues/11654
Fixes: https://github.com/openwrt/openwrt/issues/11385
Signed-off-by: Arınç ÜNAL <arinc.unal@arinc9.com>
[ rework commit message, add more fixes tag ]
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>