### PR TITLE
build: introduce a dependency check for swig

### DIFF
--- a/include/u-boot.mk
+++ b/include/u-boot.mk
@@ -8,6 +8,10 @@ PKG_SOURCE_URL = \
 	ftp://ftp.denx.de/pub/u-boot
 endif
 
+ifdef UBOOT_FORCE_INTREE_DTC
+	$(eval $(call SetupHostCommand,swig,Please install 'swig', swig -help))
+endif
+
 PKG_BUILD_DIR = $(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_TARGETS := bin
@@ -88,7 +92,9 @@ define Build/Configure/U-Boot
 		+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) $(UBOOT_CONFIGURE_VARS) oldconfig)
 endef
 
-DTC=$(wildcard $(LINUX_DIR)/scripts/dtc/dtc)
+ifndef UBOOT_FORCE_INTREE_DTC
+	DTC=$(wildcard $(LINUX_DIR)/scripts/dtc/dtc)
+endif
 
 define Build/Compile/U-Boot
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -12,6 +12,7 @@ PKG_HASH:=312b7eeae44581d1362c3a3f02c28d806647756c82ba8c72241c7cdbe68ba77e
 
 PKG_MAINTAINER:=Tobias Maedel <openwrt@tbspace.de>
 
+UBOOT_FORCE_INTREE_DTC:=1
 include $(INCLUDE_DIR)/u-boot.mk
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
`swig` is required by `pylibfdt`, which is needed to build modern versions of u-boot. There is no reliable way to check for Python support, and running grep on the help text feels pretty fragile, so only the existence of `swig` is being checked.

Should we make this per-target or put it in `u-boot.mk` somehow, so this is only checked if u-boot is being built? Suggestions are welcome.
