### PR TITLE
ath79: calibrate dlink dir-825 c1 and dir-835 a1 with nvmem

### DIFF
--- a/target/linux/ath79/dts/ar9344_dlink_dir-8x5.dtsi
+++ b/target/linux/ath79/dts/ar9344_dlink_dir-8x5.dtsi
@@ -29,6 +29,9 @@
 	/* default for ar934x, except for 1000M */
 	pll-data = <0x06000000 0x00000101 0x00001616>;
 
+	nvmem-cells = <&macaddr_lan>;
+	nvmem-cell-names = "mac-address-ascii";
+
 	phy-mode = "rgmii";
 	phy-handle = <&phy0>;
 };
@@ -55,7 +58,13 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
-		qca,no-eeprom;
+		/* "mac-address-ascii" currently does not work for
+		   ath9k pci devices. these below are retained for future
+		   improvements. */
+		/* nvmem-cells = <&macaddr_wan>, <&cal_art_5000>;
+		   nvmem-cell-names = "mac-address-ascii", "calibration";
+		   mac-address-increment = <1>; */
+		qca,no-eeprom; /* remove this when "mac-address-ascii" works  */
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
@@ -102,16 +111,40 @@
 				read-only;
 			};
 
-			partition@fe0000 {
+			mac: partition@fe0000 {
 				label = "mac";
 				reg = <0xfe0000 0x010000>;
 				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_lan: macaddr@4 {
+					reg = <0x4 0x11>;
+				};
+
+				macaddr_wan: macaddr@18 {
+					reg = <0x18 0x11>;
+				};
 			};
 
-			partition@ff0000 {
+			art: partition@ff0000 {
 				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				cal_art_1000: cal@1000 {
+					reg = <0x1000 0x440>;
+				};
+
+				cal_art_5000: cal@5000 {
+					reg = <0x5000 0x440>;
+				};
 			};
 		};
 	};
@@ -127,5 +160,6 @@
 
 &wmac {
 	status = "okay";
-	qca,no-eeprom;
+	nvmem-cells = <&macaddr_lan>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address-ascii", "calibration";
 };

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -639,7 +639,6 @@ ath79_setup_macs()
 		;;
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1)
-		lan_mac=$(mtd_get_mac_text "mac" 0x4)
 		wan_mac=$(mtd_get_mac_text "mac" 0x18)
 		;;
 	dlink,dir-842-c1|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -23,9 +23,7 @@ case "$FIRMWARE" in
 	avm,fritzdvbc)
 		caldata_extract_reverse "urlader" 0x1541 0x440
 		;;
-	dlink,dir-505|\
-	dlink,dir-825-c1|\
-	dlink,dir-835-a1)
+	dlink,dir-505)
 		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_text "mac" 0x4)
 		;;


### PR DESCRIPTION
Driver for both soc (2.4GHz Wifi) and pci (5 GHz) now pull the calibration data from the nvmem subsystem.

This allows us to move the userspace caldata extraction for the pci-e ath9k supported wifi into the device-tree definition of the device.

Currently, only ethernet and wmac devices uses the mac address of "mac-address-ascii" cells, while PCI ath9k devices uses the mac address within calibration data.

Signed-off-by: Edward Chow <equu@openmail.cc>