### PR TITLE
ath79: calibrate dlink dir-825 b1 with nvmem

### DIFF
--- a/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
+++ b/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
@@ -139,7 +139,8 @@
 	ath9k0: wifi@0,11 {
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
-		qca,no-eeprom;
+		nvmem-cells = <&macaddr_lan>, <&cal_art_1000>;
+		nvmem-cell-names = "mac-address-ascii", "calibration";
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -147,7 +148,9 @@
 	ath9k1: wifi@0,12 {
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
-		qca,no-eeprom;
+		nvmem-cells = <&macaddr_wan>, <&cal_art_5000>;
+		nvmem-cell-names = "mac-address-ascii", "calibration";
+		mac-address-increment = <1>;
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -183,7 +186,7 @@
 				reg = <0x050000 0x610000>;
 			};
 
-			partition@660000 {
+			caldata: partition@660000 {
 				label = "caldata";
 				reg = <0x660000 0x010000>;
 				read-only;
@@ -202,6 +205,9 @@
 
 	pll-data = <0x11110000 0x00001099 0x00991099>;
 
+	nvmem-cells = <&macaddr_lan>;
+	nvmem-cell-names = "mac-address-ascii";
+
 	fixed-link {
 		speed = <1000>;
 		full-duplex;
@@ -213,5 +219,30 @@
 
 	pll-data = <0x11110000 0x00001099 0x00991099>;
 
+	nvmem-cells = <&macaddr_wan>;
+	nvmem-cell-names = "mac-address-ascii";
+
 	phy-handle = <&phy4>;
+};
+
+&caldata {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	cal_art_1000: cal@1000 {
+		reg = <0x1000 0xeb8>;
+	};
+
+	cal_art_5000: cal@5000 {
+		reg = <0x5000 0xeb8>;
+	};
+
+	macaddr_lan: macaddr@ffa0 {
+		reg = <0xffa0 0x11>;
+	};
+
+	macaddr_wan: macaddr@ffb4 {
+		reg = <0xffb4 0x11>;
+	};
 };

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -203,7 +203,6 @@ ath79_setup_interfaces()
 		;;
 	buffalo,wzr-hp-g300nh-rb|\
 	buffalo,wzr-hp-g300nh-s|\
-	dlink,dir-825-b1|\
 	trendnet,tew-673gru)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
@@ -624,7 +623,6 @@ ath79_setup_macs()
 	dlink,dap-3662-a1)
 		label_mac=$(mtd_get_mac_ascii bdcfg "wlanmac")
 		;;
-	dlink,dir-825-b1|\
 	trendnet,tew-673gru)
 		lan_mac=$(mtd_get_mac_text "caldata" 0xffa0)
 		wan_mac=$(mtd_get_mac_text "caldata" 0xffb4)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -127,7 +127,6 @@ case "$FIRMWARE" in
 	buffalo,wzr-hp-ag300h)
 		caldata_extract "art" 0x1000 0xeb8
 		;;
-	dlink,dir-825-b1|\
 	trendnet,tew-673gru)
 		caldata_extract "caldata" 0x1000 0xeb8
 		ath9k_patch_mac_crc $(mtd_get_mac_text "caldata" 0xffa0) 0x20c
@@ -146,7 +145,6 @@ case "$FIRMWARE" in
 	buffalo,wzr-hp-ag300h)
 		caldata_extract "art" 0x5000 0xeb8
 		;;
-	dlink,dir-825-b1|\
 	trendnet,tew-673gru)
 		caldata_extract "caldata" 0x5000 0xeb8
 		ath9k_patch_mac_crc $(macaddr_add $(mtd_get_mac_text "caldata" 0xffb4) 1) 0x20c


### PR DESCRIPTION
Driver for both soc (2.4GHz Wifi) and pci (5 GHz) now pull the calibration data from the nvmem subsystem.

This allows us to move the userspace caldata extraction for the pci-e ath9k supported wifi into the device-tree definition of the device.

Currently, only ethernet devices uses the mac address of "mac-address-ascii" cells, while PCI ath9k devices uses the mac address within calibration data.

Signed-off-by: Edward Chow <equu@openmail.cc>