### PR TITLE
[22.03] gdb: Do not link against xxhash

### DIFF
--- a/package/devel/gdb/Makefile
+++ b/package/devel/gdb/Makefile
@@ -66,6 +66,7 @@ CONFIGURE_ARGS+= \
 	--without-mpc \
 	--without-mpfr \
 	--without-isl \
+	--without-xxhash \
 	--with-libgmp-prefix=$(STAGING_DIR)/usr
 
 CONFIGURE_VARS+= \


### PR DESCRIPTION
libxxhash is now available in the OpenWrt package feed and gdb will link against it if gdb finds this library. Explicitly deactivate the usage of xxhash.

This should fix the build of gdb in build bots.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
(cherry picked from commit a442974cfa89c7182c37b3b422b2d49319e2b339)