### PR TITLE
github: add command for device

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -32,7 +32,9 @@ body:
     id: device
     attributes:
       label: Device
-      description: The device exhibiting this bug.
+      description: |
+        The device exhibiting this bug (if unsure, use command below).
+        ```cat /tmp/sysinfo/model```
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
This adds a command to the issue template to simplify the "device" name.: