### PR TITLE
ath79: Use upstream b53 DSA driver for Ubiquiti EdgeSwitch 8XP

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -538,6 +538,44 @@ endef
 
 $(eval $(call KernelPackage,dsa))
 
+
+define KernelPackage/dsa-b53
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Broadcom BCM53xx managed switch DSA support
+  DEPENDS:=+kmod-dsa
+  KCONFIG:=CONFIG_B53 \
+  CONFIG_NET_DSA_TAG_BRCM \
+  CONFIG_NET_DSA_TAG_BRCM_LEGACY \
+  CONFIG_NET_DSA_TAG_BRCM_PREPEND
+  FILES:= \
+  $(LINUX_DIR)/drivers/net/dsa/b53/b53_common.ko \
+  $(LINUX_DIR)/net/dsa/tag_brcm.ko
+  AUTOLOAD:=$(call AutoProbe,b53_common)
+endef
+
+define KernelPackage/dsa-b53/description
+  Broadcom BCM53xx managed switch support
+endef
+
+$(eval $(call KernelPackage,dsa-b53))
+
+
+define KernelPackage/dsa-b53-mdio
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=B53 MDIO connected switch DSA driver
+  DEPENDS:=+kmod-dsa-b53
+  KCONFIG:=CONFIG_B53_MDIO_DRIVER
+  FILES:=$(LINUX_DIR)/drivers/net/dsa/b53/b53_mdio.ko
+  AUTOLOAD:=$(call AutoProbe,b53_mdio)
+endef
+
+define KernelPackage/dsa-b53-mdio/description
+  B53 MDIO connected switch driver
+endef
+
+$(eval $(call KernelPackage,dsa-b53-mdio))
+
+
 define KernelPackage/dsa-tag-dsa
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Marvell DSA type DSA and EDSA taggers
@@ -607,36 +645,6 @@ define KernelPackage/swconfig/description
 endef
 
 $(eval $(call KernelPackage,swconfig))
-
-define KernelPackage/switch-bcm53xx
-  SUBMENU:=$(NETWORK_DEVICES_MENU)
-  TITLE:=Broadcom bcm53xx switch support
-  DEPENDS:=+kmod-swconfig
-  KCONFIG:=CONFIG_SWCONFIG_B53
-  FILES:=$(LINUX_DIR)/drivers/net/phy/b53/b53_common.ko
-  AUTOLOAD:=$(call AutoLoad,42,b53_common)
-endef
-
-define KernelPackage/switch-bcm53xx/description
-  Broadcom bcm53xx switch support
-endef
-
-$(eval $(call KernelPackage,switch-bcm53xx))
-
-define KernelPackage/switch-bcm53xx-mdio
-  SUBMENU:=$(NETWORK_DEVICES_MENU)
-  TITLE:=Broadcom bcm53xx switch MDIO support
-  DEPENDS:=+kmod-switch-bcm53xx
-  KCONFIG:=CONFIG_SWCONFIG_B53_PHY_DRIVER
-  FILES:=$(LINUX_DIR)/drivers/net/phy/b53/b53_mdio.ko
-  AUTOLOAD:=$(call AutoLoad,42,b53_mdio)
-endef
-
-define KernelPackage/switch-bcm53xx-mdio/description
-  Broadcom bcm53xx switch MDIO support
-endef
-
-$(eval $(call KernelPackage,switch-bcm53xx-mdio))
 
 
 define KernelPackage/switch-ip17xx

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -569,9 +569,7 @@ ath79_setup_interfaces()
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:lan"
 		;;
 	ubnt,edgeswitch-8xp)
-		ucidef_set_interface_wan "eth1"
-		ucidef_add_switch "switch0" \
-			"0:lan:1" "1:lan:2" "2:lan:3" "3:lan:4" "4:lan:5" "5:lan:6" "6:lan:7" "7:lan:8"  "8@eth0"
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5 lan6 lan7 lan8" "eth1"
 		;;
 	ubnt,routerstation-pro)
 		ucidef_set_interface_wan "eth0"

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -58,8 +58,9 @@ TARGET_DEVICES += ubnt_edgeswitch-5xp
 define Device/ubnt_edgeswitch-8xp
   $(Device/ubnt-sw)
   DEVICE_MODEL := EdgeSwitch 8XP
-  DEVICE_PACKAGES += kmod-switch-bcm53xx-mdio
-  DEFAULT := n
+  DEVICE_PACKAGES += kmod-dsa-b53-mdio
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := Config cannot be migrated from swconfig to DSA
 endef
 TARGET_DEVICES += ubnt_edgeswitch-8xp
 


### PR DESCRIPTION
The swconfig-based b53 driver for the BCM53128 switch stopped working after commits b2cfed4 (Revert "swconfig: fix Broadcom b53 support") and e4e4107 (kernel: export switch_generic_set_link() symbol).

This commit enables DSA for the ath79/generic target/subtarget, adds the upstream b53 MDIO switch driver to the kernel config, removes the kmod-switch-bcm53xx-mdio package from the image Makefile and updates the 02_network init script with the new interfaces. Finally, it reenables image building for the device.

Fixes #10374.

Tested on a Ubiquiti EdgeSwitch 8XP (network works again, sysupgrade compatibility message is issued).

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>