### PR TITLE
realtek: Fix kernel 5.15 bootloop on rtl838x

### DIFF
--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1335,7 +1335,7 @@ static int rtl838x_pie_rule_write(struct rtl838x_switch_priv *priv, int idx, str
 	/* Access IACL table (1) via register 0 */
 	struct table_reg *q = rtl_table_get(RTL8380_TBL_0, 1);
 	u32 r[18];
-	int err = 0;
+	int err;
 	int block = idx / PIE_BLOCK_SIZE;
 	u32 t_select = sw_r32(RTL838X_ACL_BLK_TMPLTE_CTRL(block));
 
@@ -1344,17 +1344,21 @@ static int rtl838x_pie_rule_write(struct rtl838x_switch_priv *priv, int idx, str
 	for (int i = 0; i < 18; i++)
 		r[i] = 0;
 
-	if (!pr->valid)
-		goto err_out;
+	if (!pr->valid) {
+		err = -EINVAL;
+		pr_err("Rule invalid\n");
+		goto errout;
+	}
 
 	rtl838x_write_pie_fixed_fields(r, pr);
 
 	pr_debug("%s: template %d\n", __func__, (t_select >> (pr->tid * 3)) & 0x7);
 	rtl838x_write_pie_templated(r, pr, fixed_templates[(t_select >> (pr->tid * 3)) & 0x7]);
 
-	if (rtl838x_write_pie_action(r, pr)) {
+	err = rtl838x_write_pie_action(r, pr);
+	if (err) {
 		pr_err("Rule actions too complex\n");
-		goto err_out;
+		goto errout;
 	}
 
 /*	rtl838x_pie_rule_dump_raw(r); */
@@ -1362,7 +1366,7 @@ static int rtl838x_pie_rule_write(struct rtl838x_switch_priv *priv, int idx, str
 	for (int i = 0; i < 18; i++)
 		sw_w32(r[i], rtl_table_data(q, i));
 
-err_out:
+errout:
 	rtl_table_write(q, idx);
 	rtl_table_release(q);
 

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1832,7 +1832,7 @@ int rtl838x_read_phy(u32 port, u32 page, u32 reg, u32 *val)
 timeout:
 	mutex_unlock(&smi_lock);
 
-	return -ETIMEDOUT;
+	return err;
 }
 
 /* Write to a register in a page of the PHY */
@@ -1868,7 +1868,7 @@ int rtl838x_write_phy(u32 port, u32 page, u32 reg, u32 val)
 timeout:
 	mutex_unlock(&smi_lock);
 
-	return -ETIMEDOUT;
+	return err;
 }
 
 /* Read an mmd register of a PHY */


### PR DESCRIPTION
Fix the bootloop with kernel 5.15 on rtl838x devices that is caused by a regression introduced with 758c88b969639d0e6b684669d2e54dd1be3102f4.

Tested on a Netgear GS108T v3 and a Netgear GS310TP v1.

Fixes: 758c88b969639d0e6b684669d2e54dd1be3102f4 ("realtek: Whitespace and codestyle cleanup")
Signed-off-by: Pascal Ernster <git@hardfalcon.net>