### PR TITLE
ipq40xx: Fix Linksys upgrade, restore config step

### DIFF
--- a/target/linux/ipq40xx/base-files/lib/upgrade/linksys.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/linksys.sh
@@ -100,7 +100,12 @@ platform_do_upgrade_linksys() {
 		fi
 
 		# complete std upgrade
-		nand_upgrade_tar "$1"
+		if nand_upgrade_tar "$1" ; then
+			nand_do_upgrade_success
+		else
+			nand_do_upgrade_failure
+		fi
+
 	}
 
 	[ "$magic_long" = "27051956" ] && {


### PR DESCRIPTION
It appears that the refactor of the upgrade process for NAND devices resulted in the nand_do_upgrade_success step not being called for devices using the linksys.sh script. As a result, configuration was not preserved over sysupgrade steps.

This was restored for some devices in commit 84ff6c9. This commit restores preservation of config for ipq40xx devices using the linksys.sh script. Other devices and targets have not been examined.

Closes: #11677
Fixes: e25e6d8e54 ("base-files: fix and clean up nand sysupgrade code") Tested-on: EA8300

Signed-off-by: Jeff Kletsky <git-commits@allycomm.com>
