### PR TITLE
ipq40xx: ea8300, mr8300: DSA: Adjust MAC addresses

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -152,6 +152,7 @@ ipq40xx_setup_macs()
 	linksys,mr8300)
 		wan_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
+		label_mac=$wan_mac
 		;;
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2|\

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -26,8 +26,13 @@ preinit_set_mac_address() {
 	linksys,ea8300|\
 	linksys,mr8300)
 		base_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
+		base_mac_la=$(macaddr_setbit "$base_mac" 7)
+		ip link set dev wan address "$base_mac"
 		ip link set dev lan1 address $(macaddr_add "$base_mac" 1)
-		ip link set dev eth0 address $(macaddr_setbit "$base_mac" 7)
+		ip link set dev lan2 address $(macaddr_add "$base_mac_la" 2)
+		ip link set dev lan3 address $(macaddr_add "$base_mac_la" 3)
+		ip link set dev lan4 address $(macaddr_add "$base_mac_la" 4)
+		ip link set dev eth0 address $(macaddr_add "$base_mac_la" 5)
 		;;
 	mikrotik,wap-ac|\
 	mikrotik,wap-ac-lte|\


### PR DESCRIPTION
At present, all four Ethernet phys associated with the lan0-3 ports are assigned the same MAC address. This causes MAC collisions that become problematic with more complex network configurations.

This patch assigns the "label MAC" to "wan" and the next sequential to "lan1". The MAC assigned to lan1 was used by the OEM firmware. lan2-4 are assigned locally administered MAC addresses, sequential from lan1 with its LA bit set. "eth0" is assigned the next in sequence, pushing the generated MACs above the range already in use.

label_mac is also defined and now available in board.json

NB: If MAC assignments are already present in /etc/config/network
    they take precedence. These assignments may already be present
    from an eariler boot sequence that generated the local config.

Tested-on: ea8300

Signed-off-by: Jeff Kletsky <git-commits@allycomm.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
