### PR TITLE
CI: build: fix external toolchain use with release tag tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
           fi
 
           if [ -n "$major_ver" ]; then
-            git fetch --tags
+            git fetch --tags -f
             latest_tag="$(git tag --sort=-creatordate -l $major_ver* | head -n1)"
             if [ -n "$latest_tag" ]; then
               TOOLCHAIN_PATH=releases/$(echo $latest_tag | sed 's/^v//')


### PR DESCRIPTION
When a new tag for a release is created, the just checkout repo from github actions will already have such tag locally created.

This will result in git fetch --tags failing with error rejecting the remote tag with (would clobber existing tag).

Add -f option to overwrite any local tags and always fetch them from remote.

Fixes: e24a1e6f6d7f ("CI: build: add support for external toolchains from stable branch")
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>