### PR TITLE
ramips: add support for D-Link DIR-1935 A1

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-1935-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-1935-a1.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_dlink_dir-8xx.dtsi"
+#include "mt7621_dlink_flash-16m-a1.dtsi"
+
+/ {
+	compatible = "dlink,dir-1935-a1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-1935 A1";
+
+	aliases {
+		label-mac-device = &gmac0;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -540,6 +540,14 @@ define Device/dlink_dir-xx60-a1
 	check-size
 endef
 
+define Device/dlink_dir-1935-a1
+  $(Device/dlink_dir-8xx-a1)
+  DEVICE_MODEL := DIR-1935
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES += kmod-usb3
+endef
+TARGET_DEVICES += dlink_dir-1935-a1
+
 define Device/dlink_dir-1960-a1
   $(Device/dlink_dir-xx60-a1)
   DEVICE_MODEL := DIR-1960

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -78,6 +78,7 @@ dlink,dir-853-a3)
 dlink,dir-853-r1)
 	ucidef_set_led_netdev "internet" "internet" "blue:net" "wan"
 	;;
+dlink,dir-1935-a1|\
 dlink,dir-860l-b1|\
 dlink,dir-867-a1|\
 dlink,dir-878-a1|\


### PR DESCRIPTION
Add support for D-Link DIR-1935 A1 based on similarities to DIR-882 A1, DIR-867 A1 and other DIR-8xx A1 models. Existing DIR-882 A1 openwrt "factory" firmware installs without modificaitons via the D-Link Recovery GUI and has no known incompatibilities with the DIR-1935 A1.

Changes to be committed:
       new file:   target/linux/ramips/dts/mt7621_dlink_dir-1935-a1.dts
       modified:   target/linux/ramips/image/mt7621.mk
       modified:   target/linux/ramips/mt7621/base-files/etc/board.d/01_leds

Specifications:
* Board: Not known
* SoC: MediaTek MT7621 Family
* RAM: 128 MB (DDR3)
* Flash: 16 MB (SPI NOR)
* WiFi: MediaTek MT7615 Family (x2)
* Switch: 1 WAN, 4 LAN (Gigabit)
* Ports: 1 USB 3.0
* Buttons: Reset, WiFi Toggle, WPS
* LEDs: Power (green/orange), Internet (green/orange), WiFi 2.4G (green), WiFi 5G (green)

Notes:
* 160MHz 5GHz is available in LuCi but does not appear to work (i.e. no SSID is visible in wifi scanning apps on other devices) with either official DIR-882 A1 firmware or a test build for the DIR-1935 A1 based on the 22.03.2 branch. 80 MHz 5GHz works.

Serial port:
* Untested (potential user damage/error)
* Expected to be identical to other DIR-8xx A1 models:
	* Parameters: 57600, 8N1
	* Location: J1 header (close to the Reset, WiFi and WPS buttons)
	* Pinout: 1 - VCC 2 - RXD 3 - TXD 4 - GND

Installation:
* D-Link Recovery GUI: power down the router, press and hold the reset button, then re-plug it. Keep the reset button pressed until the power LED starts flashing orange, manually assign a static IP address under the 192.168.0.xxx subnet (e.g. 192.168.0.2) and go to http://192.168.0.1

* Some modern browsers may have problems flashing via the Recovery GUI, if that occurs consider uploading the firmware through cURL:

    curl -v -i -F "firmware=@file.bin" 192.168.0.1

Signed-off-by: Keith Harrison <keithh@protonmail.com>