### PR TITLE
realtek: dgs-1210-10mp: add full sfp description

### DIFF
--- a/target/linux/realtek/dts-5.10/rtl8380_d-link_dgs-1210-10mp-f.dts
+++ b/target/linux/realtek/dts-5.10/rtl8380_d-link_dgs-1210-10mp-f.dts
@@ -8,6 +8,42 @@
 	compatible = "d-link,dgs-1210-10mp-f", "realtek,rtl8382-soc", "realtek,rtl838x-soc";
 
 	model = "D-Link DGS-1210-10MP F";
+
+	/* i2c for sfp port9 */
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp0: sfp-p9 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* i2c for sfp port10 */
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp-p10 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+	};
 };
 
 &leds {
@@ -72,8 +108,24 @@
 		SWITCH_PORT(13, 6, internal)
 		SWITCH_PORT(14, 7, internal)
 		SWITCH_PORT(15, 8, internal)
-		SWITCH_SFP_PORT(24, 9, rgmii-id)
-		SWITCH_SFP_PORT(26, 10, rgmii-id)
+
+		port@24 {
+			reg = <24>;
+			label = "lan9";
+			phy-handle = <14>;
+			phy-mode = "1000base-x";
+			managed = "in-band-status";
+			sfp = <&sfp0>;
+		};
+
+		port@26 {
+			reg = <26>;
+			label = "lan10";
+			phy-handle = <15>;
+			phy-mode = "1000base-x";
+			managed = "in-band-status";
+			sfp = <&sfp1>;
+		};
 
 		port@28 {
 			ethernet = <&ethernet0>;

--- a/target/linux/realtek/dts-5.15/rtl8380_d-link_dgs-1210-10mp-f.dts
+++ b/target/linux/realtek/dts-5.15/rtl8380_d-link_dgs-1210-10mp-f.dts
@@ -8,6 +8,42 @@
 	compatible = "d-link,dgs-1210-10mp-f", "realtek,rtl8382-soc", "realtek,rtl838x-soc";
 
 	model = "D-Link DGS-1210-10MP F";
+
+	/* i2c for sfp port9 */
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp0: sfp-p9 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* i2c for sfp port10 */
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp-p10 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+	};
 };
 
 &leds {
@@ -72,8 +108,24 @@
 		SWITCH_PORT(13, 6, internal)
 		SWITCH_PORT(14, 7, internal)
 		SWITCH_PORT(15, 8, internal)
-		SWITCH_SFP_PORT(24, 9, rgmii-id)
-		SWITCH_SFP_PORT(26, 10, rgmii-id)
+
+		port@24 {
+			reg = <24>;
+			label = "lan9";
+			phy-handle = <14>;
+			phy-mode = "1000base-x";
+			managed = "in-band-status";
+			sfp = <&sfp0>;
+		};
+
+		port@26 {
+			reg = <26>;
+			label = "lan10";
+			phy-handle = <15>;
+			phy-mode = "1000base-x";
+			managed = "in-band-status";
+			sfp = <&sfp1>;
+		};
 
 		port@28 {
 			ethernet = <&ethernet0>;


### PR DESCRIPTION
Added the hot-plug feature for both sfp ports on d-link dgs-1210-10mp. 
Added the patch to both kernel 5.10 and 5.15 dts files.

This is based on the suggestion I got when adding the device during the summer, but that suggestion didn't work at all. 
I had to first physically verify the connections to the sfp cages and then completely remake the switch part, compared to the original suggestion.

It is mostly tested on kernel 5.10 but I put the project on hold when I found out 5.15 was on its way. Have now tested it on kernel 5.15 also.

Signed-off-by: Daniel Groth <flygarn12@gmail.com>
