### PR TITLE
ramips: add basic support for TP-Link EC330-G5u v1

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -85,6 +85,11 @@ snr,cpe-w4n-mt)
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x1000"
 	;;
+tplink,ec330-g5u-v1)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x20000"
+	;;
 xiaomi,mi-router-3g-v2|\
 xiaomi,mi-router-4a-gigabit|\
 xiaomi,miwifi-3c)

--- a/target/linux/ramips/dts/mt7621_tplink_ec330-g5u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_ec330-g5u-v1.dts
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tplink,ec330-g5u-v1", "mediatek,mt7621-soc";
+	model = "TP-Link EC330-G5u v1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_USB;
+			function-enumerator = <0>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		led-1 {
+			label = "blue:wps";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WPS;
+			function-enumerator = <0>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			label = "blue:ethernet";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <0>;
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			label = "amber:internet";
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WAN;
+			function-enumerator = <0>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			label = "blue:internet";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
+			function-enumerator = <1>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			label = "blue:wireless_5g";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <0>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+
+		led-6 {
+			label = "blue:wireless_2g";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <1>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		led_power: led-7 {
+			label = "blue:power";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			function-enumerator = <0>;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		led {
+			label = "led";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_LIGHTS_TOGGLE>;
+		};
+
+		wifi {
+			label = "wifi on/off";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		led-light {
+			gpio-export,name = "led-light";
+			gpio-export,output = <0>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x3c00000>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x400000>;
+			read-only;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot-first";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "u-boot-main";
+				reg = <0x20000 0x40000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "u-boot-main-reserve";
+				reg = <0x60000 0x40000>;
+				read-only;
+			};
+		};
+
+		partition@400000 {
+			label = "os0";
+			reg = <0x400000 0x3000000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			ubiconcat0: partition@400000 {
+				label = "ubi-os0";
+				reg = <0x400000 0x2c00000>;
+			};
+		};
+
+		partition@3400000 {
+			label = "os1";
+			reg = <0x3400000 0x3000000>;
+			read-only;
+		};
+
+		ubiconcat1: partition@6400000 {
+			label = "userfs";
+			reg = <0x6400000 0x1000000>;
+		};
+
+		partition@7400000 {
+			label = "u-boot-env";
+			reg = <0x7400000 0x400000>;
+		};
+
+		factory: partition@7800000 {
+			label = "factory";
+			reg = <0x7800000 0x400000>;
+			read-only;
+		};
+
+		partition@0_wholeflash {
+			label = "wholeflash";
+			reg = <0x0 0x7f80000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x14000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+};
+
+&mdio {
+	ethphy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/common-tp-link.mk
+++ b/target/linux/ramips/image/common-tp-link.mk
@@ -1,6 +1,19 @@
 DEVICE_VARS += TPLINK_FLASHLAYOUT TPLINK_HWID TPLINK_HWREV TPLINK_HWREVADD
 DEVICE_VARS += TPLINK_HVERSION TPLINK_BOARD_ID TPLINK_HEADER_VERSION
 
+define Build/uImage-tplink-c9
+	mkimage \
+		-A $(LINUX_KARCH) \
+		-O linux \
+		-T $(word 1,$(1)) \
+		-C none \
+		-a $(KERNEL_LOADADDR) \
+		-e $(KERNEL_LOADADDR) \
+		-n $(wordlist 2,$(words $(1)),$(1)) \
+		-d $@ $@.new
+	mv $@.new $@
+endef
+
 define Device/tplink-v1
   DEVICE_VENDOR := TP-Link
   TPLINK_FLASHLAYOUT :=

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2005,6 +2005,31 @@ define Device/tplink_eap615-wall-v1
 endef
 TARGET_DEVICES += tplink_eap615-wall-v1
 
+define Device/tplink_ec330-g5u-v1
+  $(Device/dsa-migration)
+  LOADER := bin
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := EC330-G5u
+  DEVICE_ALT0_VENDOR := TP-Link
+  DEVICE_ALT0_MODEL := Archer C9ERT
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport \
+	kmod-usb3 uboot-envtools
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | \
+	uImage-tplink-c9 standalone '$(call toupper,$(LINUX_KARCH)) \
+		$(VERSION_DIST) Linux-$(LINUX_VERSION)' | \
+	uImage-tplink-c9 firmware 'OS IMAGE ($(VERSION_DIST))'
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | \
+	uImage none
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata | check-size
+endef
+TARGET_DEVICES += tplink_ec330-g5u-v1
+
 define Device/tplink_er605-v2
   $(Device/dsa-migration)
   DEVICE_VENDOR := TP-Link

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -153,6 +153,11 @@ tplink,archer-c6u-v1)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "br-lan"
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
 	;;
+tplink,ec330-g5u-v1)
+	ucidef_set_led_netdev "lan" "Ethernet" "blue:ethernet" "br-lan" "link tx rx"
+	ucidef_set_led_netdev "wan" "Internet" "blue:internet" "wan" "link tx rx"
+	ucidef_set_led_netdev "wan-off" "Internet-off" "amber:internet" "wan" "link"
+	;;
 tplink,re350-v1)
 	ucidef_set_led_netdev "wifi2g" "Wifi 2.4G" "blue:wifi2G" "wlan0"
 	ucidef_set_led_netdev "wifi5g" "Wifi 5G" "blue:wifi5G" "wlan1"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -231,6 +231,11 @@ ramips_setup_macs()
 		label_mac=$(cat "/sys/firmware/mikrotik/hard_config/mac_base")
 		lan_mac=$label_mac
 		;;
+	tplink,ec330-g5u-v1)
+		label_mac="$(mtd_get_mac_text factory 0x165)"
+		lan_mac=$label_mac
+		wan_mac=$(macaddr_add $label_mac 1)
+		;;
 	tplink,er605-v2)
 		CI_UBIPART="firmware"
 		label_mac=$(mtd_get_mac_uci_config_ubi "tddp")

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -131,6 +131,11 @@ case "$board" in
 		hw_mac_addr="$(mtd_get_mac_binary product-info 0x8)"
 		macaddr_add "$hw_mac_addr" "$PHYNBR" > "/sys${DEVPATH}/macaddress"
 		;;
+	tplink,ec330-g5u-v1)
+		hw_mac_addr="$(mtd_get_mac_text factory 0x165)"
+		[ "$PHYNBR" = "0" ] && echo -n $hw_mac_addr > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
+		;;
 	yuncore,ax820)
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary Factory 0xe000)" > /sys${DEVPATH}/macaddress

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -102,6 +102,7 @@ platform_do_upgrade() {
 	sercomm,na502|\
 	sercomm,na502s|\
 	sim,simax1800t|\
+	tplink,ec330-g5u-v1|\
 	xiaomi,mi-router-3g|\
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-4|\


### PR DESCRIPTION
This adds basic support for TP-Link EC330-G5u Ver:1.0 router (also known as TP-Link Archer C9ERT).

Device specification
--------------------
SoC Type: MediaTek MT7621AT
RAM: 128 MiB, Nanya NT5CC64M16GP-DI
Flash: 128 MiB NAND, ESMT F59L1G81MA-25T
Wireless 2.4 GHz (MediaTek MT7615N): b/g/n, 4x4
Wireless 5 GHz (MediaTek MT7615N): a/n/ac, 4x4
Ethernet: 5xGbE (WAN, LAN1, LAN2, LAN3, LAN4)
USB ports: 1xUSB3.0
Button: 4 (Led, WiFi On/Off, Reset, WPS)
LEDs: 7 blue LEDs, 1 orange(amber) LED, 1 white(non-gpio) LED 
Power: 12 VDC, 2 A
Connector type: Barrel
Bootloader: First U-Boot (1.1.3), Main U-Boot (1.1.3). Additionally, original TP-Link firmware contains Image U-Boot (1.1.3).

Serial console (UART)
---------------------
```
                            V
+-------+-------+-------+-------+
| +3.3V |  GND  |  TX   |  RX   |
+---+---+-------+-------+-------+
    |              J2
    |
    +--- Don't connect
```

Installation
------------
1. Rename OpenWrt initramfs image to test.bin and place it on tftp server with IP 192.168.0.5
2. Attach UART, switch on the router and interrupt the boot process by pressing 't'
3. Load and run OpenWrt initramfs image: 
```
tftpboot
bootm
```
5. Once inside OpenWrt, switch to the first boot image:
```
fw_setenv BootImage 0
```
7. Run 'sysupgrade -n' with the sysupgrade OpenWrt image

Back to Stock
-------------
Run in the OpenWrt shell:
```
fw_setenv BootImage 1
reboot
```

Recovery
--------
1. Press Reset button and power on the router
3. Navigate to U-Boot recovery web server (http://192.168.0.1/) and upload the OEM firmware

MAC addresses
-------------
```
+---------+-------------------+-------------------+-------------+
|         | MAC example 1     | MAC example 2     | Algorithm   |
+---------+-------------------+-------------------+-------------+
| label   | 68:ff:7b:xx:xx:f4 | 50:d4:f7:xx:xx:da | label       |
| LAN     | 68:ff:7b:xx:xx:f4 | 50:d4:f7:xx:xx:da | label       |
| WAN     | 72:ff:7b:xx:xx:f5 | 54:d4:f7:xx:xx:db | label+1 [1] |
| WLAN 2g | 68:ff:7b:xx:xx:f4 | 50:d4:f7:xx:xx:da | label       |
| WLAN 5g | 68:ff:7b:xx:xx:f6 | 50:d4:f7:xx:xx:dc | label+2     |
+---------+-------------------+-------------------+-------------+
```
label MAC address was found in factory at 0x165 (text format xx:xx:xx:xx:xx:xx).

Notes
-----
[1] WAN MAC address:
a. First octet of WAN MAC is differ than others and OUI is not related to TP-Link company. This probably should be fixed.
b. Flipping bits in first octet and hex delta are different for the different MAC examples:
```
      +-----------------+----------------+----------------+
      |                 | Example 1      | Example 2      |
      +-----------------+----------------+----------------+
      | LAN             | 68 = 0110 1000 | 50 = 0101 0000 |
      | MAC (1st octet) |         ^ ^ ^  |                |
      +-----------------+----------------+----------------+
      | WAN             | 72 = 0111 0010 | 54 = 0101 0100 |
      | MAC (1st octet) |         ^ ^ ^  |            ^   |
      +-----------------+----------------+----------------+
      | HEX delta       | 0xa            | 0x4            |
      +-----------------+----------------+----------------+
      | DEC delta       | 4              | 4              |
      +-----------------+----------------+----------------+
```
c. DEC delta is a constant (4). This looks like a mistake in OEM firmware and probably should be fixed.
Based on the above, I decided to keep correct OUI and make WAN MAC = label + 1.

[2] Bootloaders
   The device contains 3 bootloaders:
   - First U-Boot: U-Boot 1.1.3 (Mar 18 2019 - 12:50:24). The First U-Boot located on NAND Flash to load next full-feature Uboot.
   - Main U-Boot + its backup: U-Boot 1.1.3 (Mar 18 2019 - 12:50:29). This bootloader includes recovery webserver. Requires special uImages to continue the boot process: 
```
   - 0x00 (os0, os1) - firmware uImage 
   - 0x40 (os0, os1) - standalone uImage (OpenWrt kernel is here)
```
   - Additionally, both slots of the original TP-Link firmware contains Image U-Boot: U-Boot 1.1.3 (Oct 16 2019 - 08:14:45). It checks image magics and CRCs. We don't use this U-Boot with OpenWrt.
