### PR TITLE
ramips: Fix root volume for tplink-er605-v2

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
@@ -12,6 +12,9 @@
 
 	chosen {
 		bootargs = "console=ttyS0,115200 noinitrd";
+		// Override bootargs because u-boot passes wrong root parameter.
+		// Instead allow kernel determine root automatically by looking for rootfs volume
+		bootargs-override = "console=ttyS0,115200 noinitrd ubi.mtd=3,2048";
 	};
 
 	aliases {


### PR DESCRIPTION
This device has two sets of volumes: main ones (`kernel`, `rootfs`, etc) and 'backup' (`kernel.b`, `rootfs.b`, etc). Bootloader tries to determine which set of volumes to use by looking at contens of `extra-para` and `extra-para.b` volumes. These volumes contain JSON that looks like this:

```
{
	"dbootFlag": "1",
	"integerFlag": "1",
	"fwFlag": "GOOD",
	"score":1
}
```

It looks like the bootloader looks for `"fwFlag": "GOOD"` (as opposed to `BAD`) then it compares `score` field - whichever 'good' volume has bigger score wins. This determines which set of volumes to use to boot.

So for example if `extra-para` is good and has bigger score then `kernel`, `rootfs`, etc volumes are used. This means bootloader needs to explain to the kernel which volume to use for the rootfs. After looking at bootloader code with disassembler I think it contains a bug. Relevant part of code looks something like this:

```
  if (image_id == 0) {
    rootfs_volume_id = 8;
    rootfs_volume_name = "rootfs";
  }
  else {
    rootfs_volume_id = 0xf;
    rootfs_volume_name = "rootfs.b";
  }
  sprintf(
    &buffer,
    0x800,
    "console=ttyS0,115200 noinitrd ubi.mtd=3,2048 ubi.block=0,%s
    root=/dev/ubiblock0_%d DKMGT_IMAGE_ID=%d DKMGT_IMAGE_TYPE=ubi",
    rootfs_volume_name,
    rootfs_volume_id,
    image_id
    );
```

Where `image_id == 0` if 'normal' (not '*.b' set of volumes is used). However from device dumps we know that from the factory `rootfs.b` has id 8 and `rootfs` has id 15.

So from above we can see that ids and names of rootfs volumes do not match. More over - they are hardcoded in the bootloader.

Both things are problematic for OpwnWRT which completely removes volumes on update meaning that volume ids may actually change.

So instead of relying on bootloader to provide the kernel with root device this patch forces kernel to determine root automatically - and it defaults to `rootfs` volume which is correct for our purposes.

Overall this makes image boot fine from flash after sysupgrade from inirams. assuming `extra-para*` volumes make bootloader use non-'*.b' set of volumes.

Signed-off-by: Nikolay Martynov <mar.kolya@gmail.com>
