### PR TITLE
include: use libdeflate's gzip to decompress

### DIFF
--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -21,7 +21,7 @@ Kernel/Patch:=$(Kernel/Patch/Default)
 ifneq (,$(findstring .xz,$(LINUX_SOURCE)))
   LINUX_CAT:=xzcat
 else
-  LINUX_CAT:=gzip -dc
+  LINUX_CAT:=$(STAGING_DIR_HOST)/bin/libdeflate-gzip -dc
 endif
 
 ifeq ($(strip $(CONFIG_EXTERNAL_KERNEL_TREE)),"")

--- a/include/unpack.mk
+++ b/include/unpack.mk
@@ -18,7 +18,7 @@ ifeq ($(strip $(UNPACK_CMD)),)
 
     ifeq ($(filter gz tgz,$(EXT)),$(EXT))
       EXT:=$(call ext,$(PKG_SOURCE:.$(EXT)=))
-      DECOMPRESS_CMD:=gzip -dc $(DL_DIR)/$(PKG_SOURCE) |
+      DECOMPRESS_CMD:=$(STAGING_DIR_HOST)/bin/libdeflate-gzip -dc $(DL_DIR)/$(PKG_SOURCE) |
     endif
     ifeq ($(filter bzip2 bz2 bz tbz2 tbz,$(EXT)),$(EXT))
       EXT:=$(call ext,$(PKG_SOURCE:.$(EXT)=))
@@ -56,7 +56,7 @@ ifeq ($(strip $(UNPACK_CMD)),)
     endif
     # replace zcat with $(ZCAT), because some system don't support it properly
     ifeq ($(PKG_CAT),zcat)
-      UNPACK_CMD=gzip -dc $(DL_DIR)/$(PKG_SOURCE) | $(TAR_CMD)
+      UNPACK_CMD=$(STAGING_DIR_HOST)/bin/libdeflate-gzip -dc $(DL_DIR)/$(PKG_SOURCE) | $(TAR_CMD)
     endif
   endif
 endif


### PR DESCRIPTION
libdeflate decompresses much faster than gzip.

Example:

~/d/openwrt> time gzip -dc dl/cmake-3.25.1.tar.gz > /dev/null

________________________________________________________
Executed in    1.01 secs      fish           external
   usr time  912.61 millis    1.67 millis  910.94 millis
   sys time   32.21 millis    0.25 millis   31.96 millis

~/d/openwrt> time libdeflate-gzip -dc dl/cmake-3.25.1.tar.gz > /dev/null

________________________________________________________
Executed in  523.04 millis    fish           external
   usr time  415.48 millis    1.07 millis  414.41 millis
   sys time  107.74 millis    0.15 millis  107.59 millis

Signed-off-by: Rosen Penev <rosenp@gmail.com>