### PR TITLE
ramips: Alternative name Asus RT-AX1800U for Asus RT-AX53U

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -297,6 +297,8 @@ define Device/asus_rt-ax53u
   $(Device/dsa-migration)
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-AX53U
+  DEVICE_ALT0_VENDOR := ASUS
+  DEVICE_ALT0_MODEL := RT-AX1800U
   IMAGE_SIZE := 51200k
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k


### PR DESCRIPTION
The Asus RT-AX1800U is identical to the already supported Asus RT-AX53U. Use the ALT0 buildroot tags to show both devices.

Tested-by: Marian Sarcinschi <znevna@gmail.com>
Signed-off-by: Felix Baumann <felix.bau@gmx.de>
