### PR TITLE
ramips: add support for D-Link DIR-3040 A1

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-3040-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-3040-a1.dts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_dlink_dir-xx60-a1.dtsi"
+
+/ {
+	compatible = "dlink,dir-3040-a1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-3040 A1";
+};
+
+&wps {
+	gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+};
+
+&leds {
+	usb2_white {
+		function = LED_FUNCTION_USB;
+		color = <LED_COLOR_ID_WHITE>;
+		function-enumerator = <0>;
+		gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		trigger-sources = <&ehci_port2>;
+		linux,default-trigger = "usbport";
+	};
+
+	usb3_white {
+		function = LED_FUNCTION_USB;
+		color = <LED_COLOR_ID_WHITE>;
+		function-enumerator = <1>;
+		gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		trigger-sources = <&xhci_ehci_port1>;
+		linux,default-trigger = "usbport";
+	};
+
+	wlan2g {
+		function = LED_FUNCTION_WLAN_2GHZ;
+		color = <LED_COLOR_ID_WHITE>;
+		gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		linux,default-trigger = "phy0radio";
+	};
+
+	wlan5glb {
+		function = LED_FUNCTION_WLAN_5GHZ;
+		color = <LED_COLOR_ID_WHITE>;
+		function-enumerator = <0>;
+		gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		linux,default-trigger = "phy1radio";
+	};
+
+	wlan5ghb {
+		function = LED_FUNCTION_WLAN_5GHZ;
+		color = <LED_COLOR_ID_WHITE>;
+		function-enumerator = <1>;
+		gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		linux,default-trigger = "phy2radio";
+	};
+};
+
+&wifi0 {
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_e000 1>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	ieee80211-freq-limit;
+	/delete-property/ ieee80211-freq-limit;
+};
+
+&wifi1 {
+	nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_e000 3>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-xx60-a1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-xx60-a1.dtsi
@@ -24,7 +24,7 @@
 			linux,code = <KEY_RESTART>;
 		};
 
-		wps {
+		wps: wps {
 			label = "wps";
 			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -783,6 +783,13 @@ define Device/dlink_dir-2660-a1
 endef
 TARGET_DEVICES += dlink_dir-2660-a1
 
+define Device/dlink_dir-3040-a1
+  $(Device/dlink_dir-xx60-a1)
+  DEVICE_MODEL := DIR-3040
+  DEVICE_VARIANT := A1
+endef
+TARGET_DEVICES += dlink_dir-3040-a1
+
 define Device/dlink_dir-3060-a1
   $(Device/dlink_dir-xx60-a1)
   DEVICE_MODEL := DIR-3060

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -96,6 +96,7 @@ dlink,dir-2640-a1|\
 dlink,dir-2660-a1)
 	ucidef_set_led_netdev "wan" "wan" "white:net" "wan"
 	;;
+dlink,dir-3040-a1|\
 dlink,dir-3060-a1)
 	ucidef_set_led_netdev "net_white" "WAN Link" "white:net" "wan" "link"
 	ucidef_set_led_netdev "net_orange" "WAN Activity" "orange:net" "wan" "tx rx"

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -60,6 +60,11 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_add $hw_mac_addr 4 > /sys${DEVPATH}/macaddress
 		;;
+	dlink,dir-3040-a1)
+		lan_mac_addr="$(mtd_get_mac_binary factory 0xe000)"
+		[ "$PHYNBR" = "0" ] && \
+			macaddr_add $lan_mac_addr 2 > /sys${DEVPATH}/macaddress
+		;;
 	dlink,dir-853-a3)
 		[ "$PHYNBR" = "0" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary factory 0xe000)" \

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -73,6 +73,7 @@ platform_do_upgrade() {
 	dlink,dir-1960-a1|\
 	dlink,dir-2640-a1|\
 	dlink,dir-2660-a1|\
+	dlink,dir-3040-a1|\
 	dlink,dir-3060-a1|\
 	dlink,dir-853-a3|\
 	etisalat,s3|\


### PR DESCRIPTION
This adds support for the A1 hardware revision of the DIR-3040.
It is an exact copy of the [DIR-3060](https://wikidevi.wi-cat.ru/D-Link_DIR-3060_rev_A1) save for some cosmetic changes to the housing. Even going so far as having the same FCC ID. 

### Hardware specification:
SoC: MediaTek MT7621AT
Flash: Winbond W29N01HVSINA 128MB
RAM: Micron MT41K128M16JT-125 256MB
Ethernet: 5x 10/100/1000 Mbps
WiFi1: MT7615DN 2.4GHz N 2x2:2
WiFi2: MT7615DN 5GHz AC 2x2:2
WiFi3: MT7615N 5GHz AC 4x4:4
Button: WPS, Reset

### Flash instructions:
OpenWrt can be installed via [D-Link Recovery GUI](https://openwrt.org/docs/guide-user/installation/installation_methods/d-link_recovery_gui):
NOTE: Seems to only work in Firefox on Windows. Tried with Chrome on Windows, Firefox in Linux, and Chromium in Linux. None of these other browsers worked.

1. Push and hold reset button (on the bottom of the device) until power led starts flashing (about 10 secs or so) while plugging in the power cable.
2. Give it ~30 seconds, to boot the recovery mode GUI
3. Connect your client computer to LAN1 of the device
4. Set your client IP address manually to 192.168.0.2 / 255.255.255.0.
5. Call the recovery page for the device at http://192.168.0.1/
6. Use the provided emergency web GUI to upload and flash a new firmware to the device

Thanks to @Lucky1openwrt  and @iivailo for creating the DIR-3060 DTS file and related changes, so it was possible for me to adapt them to the DIR-3040, build images, test and fix minor issues.

### MAC Addresses:

| use | address | example |
| --- | --- | --- |
| LAN | label | f4:*:61 |
| WAN | label + 4 | f4:*:65 |
| WI1/2g | label + 2 | f4:*:62 |
| WI1/5g | label + 1 | f4:*:62 |
| WI2/5g | label + 3 | f4:*:64 |

The label MAC address was found in Factory, 0xe000

### Checklist:

- [x] nand
- [x] ethernet
- [x] button
- [x] Wifi2g
- [x] wifi5g
- [x] wifi5g
- [x] mac
- [x] led