### PR TITLE
kernel: enable CONFIG_BTRFS_FS_POSIX_ACL

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -70,6 +70,7 @@ define KernelPackage/fs-btrfs
   DEPENDS:=+kmod-lib-crc32c +kmod-lib-lzo +kmod-lib-zlib-inflate +kmod-lib-zlib-deflate +kmod-lib-raid6 +kmod-lib-xor +kmod-lib-zstd
   KCONFIG:=\
 	CONFIG_BTRFS_FS \
+	CONFIG_BTRFS_FS_POSIX_ACL=y \
 	CONFIG_BTRFS_FS_CHECK_INTEGRITY=n
   FILES:=\
 	$(LINUX_DIR)/fs/btrfs/btrfs.ko


### PR DESCRIPTION
This change permits openwrt to receive btrfs streams containing ACLs.

When disabled, devices cannot receive btrfs streams containing ACLs.
This severely limits the usefulness of openwrt as a NAS/backup target.

Receiving files that contain ACLs currently results in stream errors:
- system.posix_acl_default= failed: Not supported


Signed-off-by: Bryan Roessler <38270216+cryobry@users.noreply.github.com>

