### PR TITLE
prereq-build: add extra check for elfutils required header

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -204,6 +204,18 @@ $(eval $(call SetupHostCommand,which,Please install 'which', \
 	/bin/which which, \
 	which which))
 
+$(eval $(call RequireCHeader,argp.h, \
+	Missing argp.h Please install the argp-standalone package if musl libc))
+
+$(eval $(call RequireCHeader,fts.h, \
+	Missing fts.h Please install the musl-fts-dev package if musl libc))
+
+$(eval $(call RequireCHeader,obstack.h, \
+	Missing obstack.h Please install the musl-obstack-dev package if musl libc))
+
+$(eval $(call RequireCHeader,libintl.h, \
+	Missing libintl.h Please install the musl-libintl package if musl libc))
+
 $(STAGING_DIR_HOST)/bin/mkhash: $(SCRIPT_DIR)/mkhash.c
 	mkdir -p $(dir $@)
 	$(CC) -O2 -I$(TOPDIR)/tools/include -o $@ $<

--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -49,10 +49,9 @@ $(eval $(call TestHostCommand,working-g++, \
 		g++ -x c++ -o $(TMP_DIR)/a.out - -lstdc++ && \
 		$(TMP_DIR)/a.out))
 
-$(eval $(call TestHostCommand,ncurses, \
+$(eval $(call RequireCHeader,ncurses.h, \
 	Please install ncurses. (Missing libncurses.so or ncurses.h), \
-	echo 'int main(int argc, char **argv) { initscr(); return 0; }' | \
-		gcc -include ncurses.h -x c -o $(TMP_DIR)/a.out - -lncurses))
+	initscr(), -lncurses))
 
 $(eval $(call SetupHostCommand,git,Please install Git (git-core) >= 1.7.12.2, \
 	git --exec-path | xargs -I % -- grep -q -- --recursive %/git-submodule, \

--- a/include/prereq.mk
+++ b/include/prereq.mk
@@ -63,6 +63,18 @@ define RequireHeader
   $$(eval $$(call Require,$(1),$(2)))
 endef
 
+# 1: header to test
+# 2: failure message
+# 3: optional compile time test
+# 4: optional link library test (example -lncurses)
+define RequireCHeader
+  define Require/$(1)
+    echo 'int main(int argc, char **argv) { $(3); return 0; }' | gcc -include $(1) -x c -o $(TMP_DIR)/a.out - $(4)
+  endef
+
+  $$(eval $$(call Require,$(1),$(2)))
+endef
+
 define CleanupPython2
   define Require/python2-cleanup
 	if [ -f "$(STAGING_DIR_HOST)/bin/python" ] && \


### PR DESCRIPTION
While testing tools build on an alpine image it was found that with musl
libc some header are missing for elfutils tool.

Add extra prereq-build check to make sure these header are present in
the system to correctly compile host tools.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
