### PR TITLE
kernel: enable acls in kmod-fs-btrfs

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -70,6 +70,7 @@ define KernelPackage/fs-btrfs
   DEPENDS:=+kmod-lib-crc32c +kmod-lib-lzo +kmod-lib-zlib-inflate +kmod-lib-zlib-deflate +kmod-lib-raid6 +kmod-lib-xor +kmod-lib-zstd
   KCONFIG:=\
 	CONFIG_BTRFS_FS \
+	CONFIG_BTRFS_FS_POSIX_ACL=y \
 	CONFIG_BTRFS_FS_CHECK_INTEGRITY=n
   FILES:=\
 	$(LINUX_DIR)/fs/btrfs/btrfs.ko


### PR DESCRIPTION
Sets CONFIG_BTRFS_FS_POSIX_ACL=y for kmod-fs-btrfs. 

Currently, `btrfs receive` fails when send stream contains ACLs, 
with lsetxattr and "system.posix_acl_default= failed: Not supported"
errors

"acl" is a default btrfs default mount option and expected for core
functionality: https://btrfs.readthedocs.io/en/latest/Administration.html

This change restores `btrfs receive` support to btrfs.

Signed-off-by: Bryan Roessler <bryanroessler@gmail.com>
