### PR TITLE
prereq-build: clean up python check and narrow down its version whitelist

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -185,7 +185,8 @@ $(eval $(call SetupHostCommand,python3,Please install Python >= 3.7, \
 
 $(eval $(call TestHostCommand,python3-distutils, \
 	Please install the Python3 distutils module, \
-	$(STAGING_DIR_HOST)/bin/python3 -c 'from distutils import util'))
+	echo 'from sys import version_info\nif version_info < (3, 12):\n\tfrom distutils import util' | \
+		$(STAGING_DIR_HOST)/bin/python3 -))
 
 $(eval $(call TestHostCommand,python3-stdlib, \
 	Please install the Python3 stdlib module, \

--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -175,14 +175,6 @@ $(eval $(call SetupHostCommand,install,Please install GNU 'install', \
 $(eval $(call SetupHostCommand,perl,Please install Perl 5.x, \
 	perl --version | grep "perl.*v5"))
 
-$(eval $(call SetupHostCommand,python,Please install Python >= 3.7, \
-	python3.11 -V 2>&1 | grep 'Python 3', \
-	python3.10 -V 2>&1 | grep 'Python 3', \
-	python3.9 -V 2>&1 | grep 'Python 3', \
-	python3.8 -V 2>&1 | grep 'Python 3', \
-	python3.7 -V 2>&1 | grep 'Python 3', \
-	python3 -V 2>&1 | grep -E 'Python 3\.([7-9]|[0-9][0-9])\.?'))
-
 $(eval $(call SetupHostCommand,python3,Please install Python >= 3.7, \
 	python3.11 -V 2>&1 | grep 'Python 3', \
 	python3.10 -V 2>&1 | grep 'Python 3', \
@@ -228,7 +220,10 @@ $(STAGING_DIR_HOST)/bin/mkhash: $(SCRIPT_DIR)/mkhash.c
 $(STAGING_DIR_HOST)/bin/xxd: $(SCRIPT_DIR)/xxdi.pl
 	$(LN) $< $@
 
-prereq: $(STAGING_DIR_HOST)/bin/mkhash $(STAGING_DIR_HOST)/bin/xxd
+$(STAGING_DIR_HOST)/bin/python:
+	$(LN) python3 $@
+
+prereq: $(STAGING_DIR_HOST)/bin/mkhash $(STAGING_DIR_HOST)/bin/xxd $(STAGING_DIR_HOST)/bin/python
 
 # Install ldconfig stub
 $(eval $(call TestHostCommand,ldconfig-stub,Failed to install stub, \

--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -181,7 +181,7 @@ $(eval $(call SetupHostCommand,python3,Please install Python >= 3.7, \
 	python3.9 -V 2>&1 | grep 'Python 3', \
 	python3.8 -V 2>&1 | grep 'Python 3', \
 	python3.7 -V 2>&1 | grep 'Python 3', \
-	python3 -V 2>&1 | grep -E 'Python 3\.([7-9]|[0-9][0-9])\.?'))
+	python3 -V 2>&1 | grep -E 'Python 3\.([7-9]|1[0-1])\.?'))
 
 $(eval $(call TestHostCommand,python3-distutils, \
 	Please install the Python3 distutils module, \


### PR DESCRIPTION
Just a couple of minor improvements.

The second patch effectively reverts #10398, so cc @tymscar.
I'm not sure what the reason was to whitelist v3.* instead of a single new version, but as the upcoming v3.12 shows there can be breaking changes - see the 3rd patch.

For a new version we need to add the pythonX.Y interpreter name anyway, bumping a single digit on top doesn't seem too unreasonable.

This doesn't whitelist v3.12 yet as that's still in alpha stage and distros probably not shipping it yet (?).
Someone already on v3.12 needs to check most/all packages for compatibility, based on past issues it's known that quite some packages and/or buildsystems utilize the distutils module.