### PR TITLE
toolchain/gcc: backport patch fixing use-after-free wrong warn for gcc12

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -69,6 +69,7 @@ jobs:
       target: ${{ matrix.target }}
       build_kernel: true
       build_all_kmods: true
+      build_toolchain: true
 
   check-kernel-patches:
     name: Check Kernel patches

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -42,4 +42,5 @@ jobs:
       build_all_kmods: true
       build_all_modules: true
       build_full: true
+      build_toolchain: true
 

--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -81,7 +81,7 @@ HOST_CONFIGURE_VARS += \
 CONFIGURE_VARS += \
 	ac_cv_search__obstack_free=yes
 
-TARGET_CFLAGS += -D_GNU_SOURCE -Wno-unused-result -Wno-format-nonliteral -Wno-error=use-after-free
+TARGET_CFLAGS += -D_GNU_SOURCE -Wno-unused-result -Wno-format-nonliteral
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include

--- a/toolchain/gcc/patches-12.x/011-Handle-failure-to-determine-pointer-provenance-conse.patch
+++ b/toolchain/gcc/patches-12.x/011-Handle-failure-to-determine-pointer-provenance-conse.patch
@@ -1,0 +1,88 @@
+From 2f714642e574c64e1c0e093cad3de6f8accb6ec7 Mon Sep 17 00:00:00 2001
+From: Martin Sebor <msebor@redhat.com>
+Date: Tue, 18 Jan 2022 17:52:01 -0700
+Subject: [PATCH] Handle failure to determine pointer provenance conservatively
+ [PR104069].
+
+Partly resolves:
+PR middle-end/104069 - -Werror=use-after-free false positive on elfutils-0.186
+
+gcc/ChangeLog:
+	PR middle-end/104069
+	* gimple-ssa-warn-access.cc (pointers_related_p): Return false for
+	an unknown result as documented.
+
+gcc/testsuite/ChangeLog:
+	PR middle-end/104069
+	* gcc.dg/Wuse-after-free.c: New test.
+---
+ gcc/gimple-ssa-warn-access.cc          |  4 ++-
+ gcc/testsuite/gcc.dg/Wuse-after-free.c | 41 ++++++++++++++++++++++++++
+ 2 files changed, 44 insertions(+), 1 deletion(-)
+ create mode 100644 gcc/testsuite/gcc.dg/Wuse-after-free.c
+
+diff --git a/gcc/gimple-ssa-warn-access.cc b/gcc/gimple-ssa-warn-access.cc
+index f639807a78a..f9508a1d211 100644
+--- a/gcc/gimple-ssa-warn-access.cc
++++ b/gcc/gimple-ssa-warn-access.cc
+@@ -4082,7 +4082,9 @@ pointers_related_p (gimple *stmt, tree p, tree q, pointer_query &qry)
+   access_ref pref, qref;
+   if (!qry.get_ref (p, stmt, &pref, 0)
+       || !qry.get_ref (q, stmt, &qref, 0))
+-    return true;
++    /* GET_REF() only rarely fails.  When it does, it's likely because
++       it involves a self-referential PHI.  Return a conservative result.  */
++    return false;
+ 
+   return pref.ref == qref.ref;
+ }
+diff --git a/gcc/testsuite/gcc.dg/Wuse-after-free.c b/gcc/testsuite/gcc.dg/Wuse-after-free.c
+new file mode 100644
+index 00000000000..9862de5c0a9
+--- /dev/null
++++ b/gcc/testsuite/gcc.dg/Wuse-after-free.c
+@@ -0,0 +1,41 @@
++/* PR middle-end/104069 - -Werror=use-after-free false positive on
++   elfutils-0.186
++   { dg-do compile }
++   { dg-options "-Wall" } */
++
++typedef __SIZE_TYPE__ size_t;
++
++extern void* realloc (void *, size_t);
++
++void* __libdw_unzstd (size_t todo)
++{
++  void *sb = 0;
++
++  for ( ; ; )
++    {
++      // Ran only once.
++      if (!sb)
++	{
++	  char *b = realloc (sb, todo);
++	  if (!b)
++	    break;
++
++	  sb = b;
++	}
++
++      todo -= 1;
++      if (todo == 0)
++	break;
++    }
++
++  // Shrink buffer: leave only one byte for simplicity.
++  char *b = realloc (sb, 1);
++  if (b)
++    sb = b;
++  else
++    {
++      // Realloc failed mysteriously, leave 'sb' untouched.
++    }
++
++  return sb;        // { dg-bogus "-Wuse-after-free" }
++}
+-- 
+2.37.2
+


### PR DESCRIPTION
Gcc 12 suffer from a problem with use-after-free false positive warn with
realloc usage. Backport the patch that should fix elfutils compilation
error.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
