### PR TITLE
lantiq-xrx200: fix wifi LED on o2 box 6431

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
@@ -80,6 +80,7 @@
 		wifi: wifi {
 			label = "green:wlan";
 			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		power_red: power2 {

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
@@ -30,7 +30,6 @@ arcadyan,arv7519rw22)
 arcadyan,vgv7510kw22-nor|\
 arcadyan,vgv7510kw22-brn)
 	ucidef_set_led_netdev "internet" "internet" "$led_internet" "wan"
-	ucidef_set_led_wlan "wifi" "wifi" "green:wlan" "phy0radio"
 	;;
 zyxel,p-2812hnu-f1|\
 zyxel,p-2812hnu-f3)


### PR DESCRIPTION
wifi LED did not work using phy0radio, which somehow slipped through in the previous testing

Signed-off-by: Florian Maurer <f.maurer@outlook.de>
