### PR TITLE
toolchain/gcc: fix broken gcc version selection

### DIFF
--- a/toolchain/gcc/Config.version
+++ b/toolchain/gcc/Config.version
@@ -4,5 +4,5 @@ config GCC_VERSION_11
 
 config GCC_VERSION
 	string
-	default "12.2.0"
 	default "11.3.0"	if GCC_VERSION_11
+	default "12.2.0"


### PR DESCRIPTION
Config evaluation require default with if to be put before the generic default config with no condition. Putting the default config before any conditional default results in always selecting the non conditional one.

This results in the version be hardcoded to gcc 12 even if gcc 11 is selected in the Advanced build options.

Fix this by putting the gcc 12 default option as last after ANY conditional default config.

Fixes: d9de5252a44e ("toolchain/gcc: switch to version 12 by default")
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>