### PR TITLE
prereq-build: limit argp/fts/obstack/libintl.h to Linux OS

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -204,17 +204,19 @@ $(eval $(call SetupHostCommand,which,Please install 'which', \
 	/bin/which which, \
 	which which))
 
-$(eval $(call RequireCHeader,argp.h, \
+ifeq ($(HOST_OS),Linux)
+  $(eval $(call RequireCHeader,argp.h, \
 	Missing argp.h Please install the argp-standalone package if musl libc))
 
-$(eval $(call RequireCHeader,fts.h, \
+  $(eval $(call RequireCHeader,fts.h, \
 	Missing fts.h Please install the musl-fts-dev package if musl libc))
 
-$(eval $(call RequireCHeader,obstack.h, \
+  $(eval $(call RequireCHeader,obstack.h, \
 	Missing obstack.h Please install the musl-obstack-dev package if musl libc))
 
-$(eval $(call RequireCHeader,libintl.h, \
+  $(eval $(call RequireCHeader,libintl.h, \
 	Missing libintl.h Please install the musl-libintl package if musl libc))
+endif
 
 $(STAGING_DIR_HOST)/bin/mkhash: $(SCRIPT_DIR)/mkhash.c
 	mkdir -p $(dir $@)


### PR DESCRIPTION
BSD based OS have different fixup and doesn't require these header. Limit these Header to Linux based OS.

Fixes: 36bc306ae611 ("prereq-build: add extra check for elfutils required header")
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>