### PR TITLE
mac80211: complete "210-ap_scan.patch"

### DIFF
--- a/package/kernel/mac80211/patches/ath/402-ath_regd_optional.patch
+++ b/package/kernel/mac80211/patches/ath/402-ath_regd_optional.patch
@@ -82,7 +82,7 @@
  	help
 --- a/local-symbols
 +++ b/local-symbols
-@@ -110,6 +110,7 @@ ADM8211=
+@@ -102,6 +102,7 @@ ADM8211=
  ATH_COMMON=
  WLAN_VENDOR_ATH=
  ATH_DEBUG=

--- a/package/kernel/mac80211/patches/ath10k/080-ath10k_thermal_config.patch
+++ b/package/kernel/mac80211/patches/ath10k/080-ath10k_thermal_config.patch
@@ -37,7 +37,7 @@
  void ath10k_thermal_event_temperature(struct ath10k *ar, int temperature);
 --- a/local-symbols
 +++ b/local-symbols
-@@ -169,6 +169,7 @@ ATH10K_SNOC=
+@@ -161,6 +161,7 @@ ATH10K_SNOC=
  ATH10K_DEBUG=
  ATH10K_DEBUGFS=
  ATH10K_SPECTRAL=

--- a/package/kernel/mac80211/patches/ath10k/974-ath10k_add-LED-and-GPIO-controlling-support-for-various-chipsets.patch
+++ b/package/kernel/mac80211/patches/ath10k/974-ath10k_add-LED-and-GPIO-controlling-support-for-various-chipsets.patch
@@ -114,7 +114,7 @@ v13:
  ath10k_core-$(CONFIG_DEV_COREDUMP) += coredump.o
 --- a/local-symbols
 +++ b/local-symbols
-@@ -170,6 +170,7 @@ ATH10K_DEBUG=
+@@ -162,6 +162,7 @@ ATH10K_DEBUG=
  ATH10K_DEBUGFS=
  ATH10K_SPECTRAL=
  ATH10K_THERMAL=

--- a/package/kernel/mac80211/patches/ath9k/551-ath9k_ubnt_uap_plus_hsr.patch
+++ b/package/kernel/mac80211/patches/ath9k/551-ath9k_ubnt_uap_plus_hsr.patch
@@ -371,7 +371,7 @@
  
 --- a/local-symbols
 +++ b/local-symbols
-@@ -137,6 +137,7 @@ ATH9K_WOW=
+@@ -129,6 +129,7 @@ ATH9K_WOW=
  ATH9K_RFKILL=
  ATH9K_CHANNEL_CONTEXT=
  ATH9K_PCOEM=

--- a/package/kernel/mac80211/patches/rt2x00/602-rt2x00-introduce-rt2x00eeprom.patch
+++ b/package/kernel/mac80211/patches/rt2x00/602-rt2x00-introduce-rt2x00eeprom.patch
@@ -1,6 +1,6 @@
 --- a/local-symbols
 +++ b/local-symbols
-@@ -354,6 +354,7 @@ RT2X00_LIB_FIRMWARE=
+@@ -347,6 +347,7 @@ RT2X00_LIB_FIRMWARE=
  RT2X00_LIB_CRYPTO=
  RT2X00_LIB_LEDS=
  RT2X00_LIB_DEBUGFS=

--- a/package/kernel/mac80211/patches/subsys/210-ap_scan.patch
+++ b/package/kernel/mac80211/patches/subsys/210-ap_scan.patch
@@ -1,6 +1,9 @@
 From: Felix Fietkau <nbd@nbd.name>
 Date: Wed, 3 Oct 2012 00:00:00 +0200
-Subject: [PATCH] mac80211: allow scans in access point mode (for site survey)
+Subject: [PATCH] mac80211: force scans in access point mode by default
+
+Allow scans by default by making them forced scans by default.
+This is achieved by removing the test for NL80211_SCAN_FLAG_AP.
 
 ---
  net/mac80211/cfg.c | 2 +-
@@ -8,12 +11,21 @@ Subject: [PATCH] mac80211: allow scans in access point mode (for site survey)
 
 --- a/net/mac80211/cfg.c
 +++ b/net/mac80211/cfg.c
-@@ -2720,6 +2720,8 @@ static int ieee80211_scan(struct wiphy *
- 		 */
+@@ -2721,15 +2721,13 @@ static int ieee80211_scan(struct wiphy *
  		fallthrough;
  	case NL80211_IFTYPE_AP:
-+		/* skip check */
-+		break;
  		/*
- 		 * If the scan has been forced (and the driver supports
- 		 * forcing), don't care about being beaconing already.
+-		 * If the scan has been forced (and the driver supports
+-		 * forcing), don't care about being beaconing already.
++		 * Don't care about being already beaconing.
+ 		 * This will create problems to the attached stations (e.g. all
+ 		 * the  frames sent while scanning on other channel will be
+ 		 * lost)
+ 		 */
+ 		if (sdata->deflink.u.ap.beacon &&
+-		    (!(wiphy->features & NL80211_FEATURE_AP_SCAN) ||
+-		     !(req->flags & NL80211_SCAN_FLAG_AP)))
++		    !(wiphy->features & NL80211_FEATURE_AP_SCAN))
+ 			return -EOPNOTSUPP;
+ 		break;
+ 	case NL80211_IFTYPE_NAN:

--- a/package/kernel/mac80211/patches/subsys/306-03-wifi-mac80211-Drop-support-for-TX-push-path.patch
+++ b/package/kernel/mac80211/patches/subsys/306-03-wifi-mac80211-Drop-support-for-TX-push-path.patch
@@ -11,7 +11,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
 
 --- a/net/mac80211/cfg.c
 +++ b/net/mac80211/cfg.c
-@@ -4339,9 +4339,6 @@ static int ieee80211_get_txq_stats(struc
+@@ -4335,9 +4335,6 @@ static int ieee80211_get_txq_stats(struc
  	struct ieee80211_sub_if_data *sdata;
  	int ret = 0;
  

--- a/package/kernel/mac80211/patches/subsys/500-mac80211_configure_antenna_gain.patch
+++ b/package/kernel/mac80211/patches/subsys/500-mac80211_configure_antenna_gain.patch
@@ -57,7 +57,7 @@
  	__NL80211_ATTR_AFTER_LAST,
 --- a/net/mac80211/cfg.c
 +++ b/net/mac80211/cfg.c
-@@ -2998,6 +2998,19 @@ static int ieee80211_get_tx_power(struct
+@@ -2994,6 +2994,19 @@ static int ieee80211_get_tx_power(struct
  	return 0;
  }
  
@@ -77,7 +77,7 @@
  static void ieee80211_rfkill_poll(struct wiphy *wiphy)
  {
  	struct ieee80211_local *local = wiphy_priv(wiphy);
-@@ -4881,6 +4894,7 @@ const struct cfg80211_ops mac80211_confi
+@@ -4877,6 +4890,7 @@ const struct cfg80211_ops mac80211_confi
  	.set_wiphy_params = ieee80211_set_wiphy_params,
  	.set_tx_power = ieee80211_set_tx_power,
  	.get_tx_power = ieee80211_get_tx_power,


### PR DESCRIPTION
Don't skip all checks. Maybe an interface does not support scanning. Change the patch, that scans are now forced by default. The equivalent iw call is:
  iw dev wlan0 scan ap-force

This patch should be replaced in future by changing iwinfo behavior.

Refresh patches:
- ath/402-ath_regd_optional.patch
- ath10k/080-ath10k_thermal_config.patch
- ath10k/974-ath10k_add-LED-and-GPIO-controlling-support-for-various-chipsets.patch
- ath9k/551-ath9k_ubnt_uap_plus_hsr.patch
- rt2x00/602-rt2x00-introduce-rt2x00eeprom.patch
- subsys/306-03-wifi-mac80211-Drop-support-for-TX-push-path.patch
- subsys/500-mac80211_configure_antenna_gain.patch
