### PR TITLE
libtraceevent/libtracefs/trace-cmd: update to latest releases

### DIFF
--- a/package/devel/trace-cmd/Makefile
+++ b/package/devel/trace-cmd/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=trace-cmd
-PKG_VERSION:=v3.1.5
+PKG_VERSION:=v3.1.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/snapshot/
-PKG_HASH:=9af1ea00e312d03639470e126fa9c786789f03c16df93a57c0bc90eeffbc7d50
+PKG_HASH:=f9198ea306deee9cda3b262342b03b6029e82c1b9c671ba521739a9703e115b9
 
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING

--- a/package/libs/libtraceevent/Makefile
+++ b/package/libs/libtraceevent/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtraceevent
-PKG_VERSION:=1.7.0
+PKG_VERSION:=1.7.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/snapshot/
-PKG_HASH:=3e902184f743c955b183b45f25ea163a3d41c9f287fdcfc95cd9cca748c563c8
+PKG_HASH:=17b7131c106793c3b45477445bd32d295170c4245ed8348e03c17296e53009e1
 
 PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
 

--- a/package/libs/libtracefs/Makefile
+++ b/package/libs/libtracefs/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtracefs
-PKG_VERSION:=1.6.3
+PKG_VERSION:=1.6.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/snapshot/
-PKG_HASH:=de307faaa54ac52cf0ce3ff19b32b51af24897e3440e643068ac82d31e197e92
+PKG_HASH:=52ce793dbb35a3e59bddce31de09a5d92cedd4d0702e64d0916f1ccdb00526c9
 
 PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
 


### PR DESCRIPTION
Update to latest releases.