### PR TITLE
CI: add concurrency limits for pr test

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -21,6 +21,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   determine_targets:
     name: Set targets

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: Build Packages with external toolchain

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   determine_targets:
     name: Set targets

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-macos-latest:
     name: Build tools with macos latest


### PR DESCRIPTION
Add concurrency limits for pull request test so that on pull request refresh old jobs are cancelled.

The group is created based on the github ref and the workflow is cancelled only it it comes from a pull_request event. Push events are not affected by this limit.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>