### PR TITLE
CI: kernel: test each target with additional changes than target/linux

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -42,25 +42,22 @@ jobs:
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v35
-        with:
-          since_last_remote_commit: true
 
       - name: Set targets
         id: find_targets
         run: |
-          export TARGETS_SUBTARGETS="$(perl ./scripts/dump-target-info.pl targets 2>/dev/null \
-            | sort -u -t '/' -k1 \
-            | awk '{ print $1 }')"
+          ALL_TARGETS="$(perl ./scripts/dump-target-info.pl targets 2>/dev/null)"
+          CHANGED_FILES="$(echo ${{ steps.changed-files.outputs.all_changed_files }} | tr ' ' '\n')"
 
-          export TARGETS="$(perl ./scripts/dump-target-info.pl targets 2>/dev/null \
-            | sort -u -t '/' -k1,1 \
-            | awk '{ print $1 }')"
+          TARGETS_SUBTARGETS="$(echo "$ALL_TARGETS" | sort -u -t '/' -k1 | awk '{ print $1 }')"
+          TARGETS="$(echo "$ALL_TARGETS" | sort -u -t '/' -k1,1 | awk '{ print $1 }')"
 
           JSON_TARGETS_SUBTARGETS='['
           FIRST=1
           for TARGET in $TARGETS_SUBTARGETS; do
-            if echo ${{ steps.changed-files.outputs.all_changed_files }} | grep -q target/linux/generic ||
-              echo ${{ steps.changed-files.outputs.all_changed_files }} | grep -q $(echo $TARGET | cut -d "/" -f 1); then
+            if echo "$CHANGED_FILES" | grep -v -q target/linux ||
+              echo "$CHANGED_FILES" | grep -q target/linux/generic ||
+              echo "$CHANGED_FILES" | grep -q $(echo $TARGET | cut -d "/" -f 1); then
               [[ $FIRST -ne 1 ]] && JSON_TARGETS_SUBTARGETS="$JSON_TARGETS_SUBTARGETS"','
               JSON_TARGETS_SUBTARGETS="$JSON_TARGETS_SUBTARGETS"'"'"${TARGET}"'"'
               FIRST=0
@@ -71,8 +68,9 @@ jobs:
           JSON_TARGETS='['
           FIRST=1
           for TARGET in $TARGETS; do
-            if echo ${{ steps.changed-files.outputs.all_changed_files }} | grep -q target/linux/generic ||
-              echo ${{ steps.changed-files.outputs.all_changed_files }} | grep -q $(echo $TARGET | cut -d "/" -f 1); then
+            if echo "$CHANGED_FILES" | grep -v -q target/linux ||
+              echo "$CHANGED_FILES" | grep -q target/linux/generic ||
+              echo "$CHANGED_FILES" | grep -q $(echo $TARGET | cut -d "/" -f 1); then
               [[ $FIRST -ne 1 ]] && JSON_TARGETS="$JSON_TARGETS"','
               JSON_TARGETS="$JSON_TARGETS"'"'"${TARGET}"'"'
               FIRST=0


### PR DESCRIPTION
Test each target if there are additional changes than target/linux. This is needed to do wide test with changes to kmods, include/kernel and changes to the workflow files.

While at it also cleanup and rework the code to drop duplication.
Also drop since_last_remote_commit to better track changes.

Fixes: 04ada8bc4118 ("CI: kernel: build only changed targets")
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>