### PR TITLE
ramips: cudy wr1300v1 reduce SPI freq to 10000000

### DIFF
--- a/target/linux/ramips/dts/mt7621_cudy_wr1300-v1.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr1300-v1.dts
@@ -65,8 +65,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
-		m25p,fast-read;
+		spi-max-frequency = <10000000>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
Reducing SPI flash frequency allows the build to boot on both old variants with W25Q128 chip and new variants with XM25QH128C chip.

The old 80000000 value only boots on devices with the W25Q128 flash.

This is also the change Cudy themselves made in their openwrt builds and their .dts file.

Signed-off-by: Filip Milivojevic <zekica@gmail.com>