### PR TITLE
mac80211: ath11k: fix monitor bringup

### DIFF
--- a/package/kernel/mac80211/patches/ath11k/0019-wifi-ath11k-Fix-scan-request-param-frame-size-warnin.patch
+++ b/package/kernel/mac80211/patches/ath11k/0019-wifi-ath11k-Fix-scan-request-param-frame-size-warnin.patch
@@ -1,0 +1,161 @@
+From d45daa6d1a8da080f1b516c570a8428a7b9225e4 Mon Sep 17 00:00:00 2001
+From: Karthikeyan Kathirvel <quic_kathirve@quicinc.com>
+Date: Tue, 6 Dec 2022 00:51:25 +0530
+Subject: [PATCH] wifi: ath11k: Fix scan request param frame size warning
+
+Following warning was observed
+
+drivers/net/wireless/ath/ath11k/mac.c:2351:1: warning: the frame
+size of 1184 bytes is larger than 1024 bytes [-Wframe-larger-than=]
+
+A local variable is declared with a size larger than 1024 bytes
+this causing a compilation warning. Change the local variable to
+heap memory to fix the warning.
+
+Tested-on: IPQ8074 AHB WLAN.HK.2.7.0.1-01701-QCAHKSWPL_SILICONZ-1 v2
+
+Signed-off-by: Karthikeyan Kathirvel <quic_kathirve@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20221205192125.13533-1-quic_kathirve@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 83 +++++++++++++++------------
+ 1 file changed, 45 insertions(+), 38 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -3612,7 +3612,7 @@ static int ath11k_mac_op_hw_scan(struct
+ 	struct ath11k *ar = hw->priv;
+ 	struct ath11k_vif *arvif = ath11k_vif_to_arvif(vif);
+ 	struct cfg80211_scan_request *req = &hw_req->req;
+-	struct scan_req_params arg;
++	struct scan_req_params *arg = NULL;
+ 	int ret = 0;
+ 	int i;
+ 	u32 scan_timeout;
+@@ -3640,72 +3640,78 @@ static int ath11k_mac_op_hw_scan(struct
+ 	if (ret)
+ 		goto exit;
+ 
+-	memset(&arg, 0, sizeof(arg));
+-	ath11k_wmi_start_scan_init(ar, &arg);
+-	arg.vdev_id = arvif->vdev_id;
+-	arg.scan_id = ATH11K_SCAN_ID;
++	arg = kzalloc(sizeof(*arg), GFP_KERNEL);
++
++	if (!arg) {
++		ret = -ENOMEM;
++		goto exit;
++	}
++
++	ath11k_wmi_start_scan_init(ar, arg);
++	arg->vdev_id = arvif->vdev_id;
++	arg->scan_id = ATH11K_SCAN_ID;
+ 
+ 	if (req->ie_len) {
+-		arg.extraie.ptr = kmemdup(req->ie, req->ie_len, GFP_KERNEL);
+-		if (!arg.extraie.ptr) {
++		arg->extraie.ptr = kmemdup(req->ie, req->ie_len, GFP_KERNEL);
++		if (!arg->extraie.ptr) {
+ 			ret = -ENOMEM;
+ 			goto exit;
+ 		}
+-		arg.extraie.len = req->ie_len;
++		arg->extraie.len = req->ie_len;
+ 	}
+ 
+ 	if (req->n_ssids) {
+-		arg.num_ssids = req->n_ssids;
+-		for (i = 0; i < arg.num_ssids; i++) {
+-			arg.ssid[i].length  = req->ssids[i].ssid_len;
+-			memcpy(&arg.ssid[i].ssid, req->ssids[i].ssid,
++		arg->num_ssids = req->n_ssids;
++		for (i = 0; i < arg->num_ssids; i++) {
++			arg->ssid[i].length  = req->ssids[i].ssid_len;
++			memcpy(&arg->ssid[i].ssid, req->ssids[i].ssid,
+ 			       req->ssids[i].ssid_len);
+ 		}
+ 	} else {
+-		arg.scan_flags |= WMI_SCAN_FLAG_PASSIVE;
++		arg->scan_flags |= WMI_SCAN_FLAG_PASSIVE;
+ 	}
+ 
+ 	if (req->n_channels) {
+-		arg.num_chan = req->n_channels;
+-		arg.chan_list = kcalloc(arg.num_chan, sizeof(*arg.chan_list),
+-					GFP_KERNEL);
++		arg->num_chan = req->n_channels;
++		arg->chan_list = kcalloc(arg->num_chan, sizeof(*arg->chan_list),
++					 GFP_KERNEL);
+ 
+-		if (!arg.chan_list) {
++		if (!arg->chan_list) {
+ 			ret = -ENOMEM;
+ 			goto exit;
+ 		}
+ 
+-		for (i = 0; i < arg.num_chan; i++)
+-			arg.chan_list[i] = req->channels[i]->center_freq;
++		for (i = 0; i < arg->num_chan; i++)
++			arg->chan_list[i] = req->channels[i]->center_freq;
+ 	}
+ 
+ 	if (req->flags & NL80211_SCAN_FLAG_RANDOM_ADDR) {
+-		arg.scan_f_add_spoofed_mac_in_probe = 1;
+-		ether_addr_copy(arg.mac_addr.addr, req->mac_addr);
+-		ether_addr_copy(arg.mac_mask.addr, req->mac_addr_mask);
++		arg->scan_f_add_spoofed_mac_in_probe = 1;
++		ether_addr_copy(arg->mac_addr.addr, req->mac_addr);
++		ether_addr_copy(arg->mac_mask.addr, req->mac_addr_mask);
+ 	}
+ 
+ 	/* if duration is set, default dwell times will be overwritten */
+ 	if (req->duration) {
+-		arg.dwell_time_active = req->duration;
+-		arg.dwell_time_active_2g = req->duration;
+-		arg.dwell_time_active_6g = req->duration;
+-		arg.dwell_time_passive = req->duration;
+-		arg.dwell_time_passive_6g = req->duration;
+-		arg.burst_duration = req->duration;
++		arg->dwell_time_active = req->duration;
++		arg->dwell_time_active_2g = req->duration;
++		arg->dwell_time_active_6g = req->duration;
++		arg->dwell_time_passive = req->duration;
++		arg->dwell_time_passive_6g = req->duration;
++		arg->burst_duration = req->duration;
+ 
+-		scan_timeout = min_t(u32, arg.max_rest_time *
+-				(arg.num_chan - 1) + (req->duration +
++		scan_timeout = min_t(u32, arg->max_rest_time *
++				(arg->num_chan - 1) + (req->duration +
+ 				ATH11K_SCAN_CHANNEL_SWITCH_WMI_EVT_OVERHEAD) *
+-				arg.num_chan, arg.max_scan_time);
++				arg->num_chan, arg->max_scan_time);
+ 	} else {
+-		scan_timeout = arg.max_scan_time;
++		scan_timeout = arg->max_scan_time;
+ 	}
+ 
+ 	/* Add a margin to account for event/command processing */
+ 	scan_timeout += ATH11K_MAC_SCAN_CMD_EVT_OVERHEAD;
+ 
+-	ret = ath11k_start_scan(ar, &arg);
++	ret = ath11k_start_scan(ar, arg);
+ 	if (ret) {
+ 		ath11k_warn(ar->ab, "failed to start hw scan: %d\n", ret);
+ 		spin_lock_bh(&ar->data_lock);
+@@ -3717,10 +3723,11 @@ static int ath11k_mac_op_hw_scan(struct
+ 				     msecs_to_jiffies(scan_timeout));
+ 
+ exit:
+-	kfree(arg.chan_list);
+-
+-	if (req->ie_len)
+-		kfree(arg.extraie.ptr);
++	if (arg) {
++		kfree(arg->chan_list);
++		kfree(arg->extraie.ptr);
++		kfree(arg);
++	}
+ 
+ 	mutex_unlock(&ar->conf_mutex);
+ 

--- a/package/kernel/mac80211/patches/ath11k/0020-wifi-ath11k-fix-monitor-mode-bringup-crash.patch
+++ b/package/kernel/mac80211/patches/ath11k/0020-wifi-ath11k-fix-monitor-mode-bringup-crash.patch
@@ -1,0 +1,79 @@
+From 950b43f8bd8a4d476d2da6d2a083a89bcd3c90d7 Mon Sep 17 00:00:00 2001
+From: Nagarajan Maran <quic_nmaran@quicinc.com>
+Date: Tue, 29 Nov 2022 19:55:32 +0530
+Subject: [PATCH] wifi: ath11k: fix monitor mode bringup crash
+
+When the interface is brought up in monitor mode, it leads
+to NULL pointer dereference crash. This crash happens when
+the packet type is extracted for a SKB. This extraction
+which is present in the received msdu delivery path,is
+not needed for the monitor ring packets since they are
+all RAW packets. Hence appending the flags with
+"RX_FLAG_ONLY_MONITOR" to skip that extraction.
+
+Observed calltrace:
+
+Unable to handle kernel NULL pointer dereference at virtual address
+0000000000000064
+Mem abort info:
+  ESR = 0x0000000096000004
+  EC = 0x25: DABT (current EL), IL = 32 bits
+  SET = 0, FnV = 0
+  EA = 0, S1PTW = 0
+  FSC = 0x04: level 0 translation fault
+Data abort info:
+  ISV = 0, ISS = 0x00000004
+  CM = 0, WnR = 0
+user pgtable: 4k pages, 48-bit VAs, pgdp=0000000048517000
+[0000000000000064] pgd=0000000000000000, p4d=0000000000000000
+Internal error: Oops: 0000000096000004 [#1] PREEMPT SMP
+Modules linked in: ath11k_pci ath11k qmi_helpers
+CPU: 2 PID: 1781 Comm: napi/-271 Not tainted
+6.1.0-rc5-wt-ath-656295-gef907406320c-dirty #6
+Hardware name: Qualcomm Technologies, Inc. IPQ8074/AP-HK10-C2 (DT)
+pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+pc : ath11k_hw_qcn9074_rx_desc_get_decap_type+0x34/0x60 [ath11k]
+lr : ath11k_hw_qcn9074_rx_desc_get_decap_type+0x5c/0x60 [ath11k]
+sp : ffff80000ef5bb10
+x29: ffff80000ef5bb10 x28: 0000000000000000 x27: ffff000007baafa0
+x26: ffff000014a91ed0 x25: 0000000000000000 x24: 0000000000000000
+x23: ffff800002b77378 x22: ffff000014a91ec0 x21: ffff000006c8d600
+x20: 0000000000000000 x19: ffff800002b77740 x18: 0000000000000006
+x17: 736564203634343a x16: 656e694c20657079 x15: 0000000000000143
+x14: 00000000ffffffea x13: ffff80000ef5b8b8 x12: ffff80000ef5b8c8
+x11: ffff80000a591d30 x10: ffff80000a579d40 x9 : c0000000ffffefff
+x8 : 0000000000000003 x7 : 0000000000017fe8 x6 : ffff80000a579ce8
+x5 : 0000000000000000 x4 : 0000000000000000 x3 : 0000000000000000
+x2 : 3a35ec12ed7f8900 x1 : 0000000000000000 x0 : 0000000000000052
+Call trace:
+ ath11k_hw_qcn9074_rx_desc_get_decap_type+0x34/0x60 [ath11k]
+ ath11k_dp_rx_deliver_msdu.isra.42+0xa4/0x3d0 [ath11k]
+ ath11k_dp_rx_mon_deliver.isra.43+0x2f8/0x458 [ath11k]
+ ath11k_dp_rx_process_mon_rings+0x310/0x4c0 [ath11k]
+ ath11k_dp_service_srng+0x234/0x338 [ath11k]
+ ath11k_pcic_ext_grp_napi_poll+0x30/0xb8 [ath11k]
+ __napi_poll+0x5c/0x190
+ napi_threaded_poll+0xf0/0x118
+ kthread+0xf4/0x110
+ ret_from_fork+0x10/0x20
+
+Tested-on: QCN9074 hw1.0 PCI WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+Reported-by: Florian Schmidt <florian@fls.name>
+Link: https://bugzilla.kernel.org/show_bug.cgi?id=216573
+Signed-off-by: Nagarajan Maran <quic_nmaran@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20221129142532.23421-1-quic_nmaran@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/dp_rx.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/net/wireless/ath/ath11k/dp_rx.c
++++ b/drivers/net/wireless/ath/ath11k/dp_rx.c
+@@ -5022,6 +5022,7 @@ static int ath11k_dp_rx_mon_deliver(stru
+ 		} else {
+ 			rxs->flag |= RX_FLAG_ALLOW_SAME_PN;
+ 		}
++		rxs->flag |= RX_FLAG_ONLY_MONITOR;
+ 		ath11k_update_radiotap(ar, ppduinfo, mon_skb, rxs);
+ 
+ 		ath11k_dp_rx_deliver_msdu(ar, napi, mon_skb, rxs);


### PR DESCRIPTION
Currently, ath11k will crash the crash if we try to bringup the monitor mode interface.
Luckily, it has already been fixed upstream, so backport the patches fixing it.

Fixes: 93ae4353cdf6 ("mac80211: add ath11k PCI support")
Signed-off-by: Robert Marko <robimarko@gmail.com>
