### PR TITLE
lldpd: use release tar instead of codeload

### DIFF
--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -12,8 +12,8 @@ PKG_VERSION:=1.0.16
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/lldpd/lldpd/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=9bc6154377b97187d96d5e22aa5c4946c6cbc85f1416149853cc0940639a77e5
+PKG_SOURCE_URL:=https://github.com/lldpd/lldpd/releases/download/$(PKG_VERSION)/
+PKG_HASH:=7753c6e31e938923185f4e10c4ab328929729e22ee4a9687d08881fb82c092ee
 
 PKG_MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
 PKG_LICENSE:=ISC


### PR DESCRIPTION
There is currently a problem with making reproducible version of lldpd. The tool version is generated based on 3 source:
1. .dist-version file in release tar
2. git hash with presence of .git directory
3. current date

Using the codeload tar from github results in getting the repo without the .git directory and since they are not release tar, we don't have .dist-version. This results in having lldpd bin with a version set to the current build time.

Switch to release tar so that we correctly have a .dist-version file and the version is not based on the build time.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
Reviewed-by: Robert Marko <robimarko@gmail.com>

---

@neheb @stintel look what I discovered... 

I notice this while checking the repro link on IRC and notice that for some reason the version was set to a date.
https://tests.reproducible-builds.org/openwrt/dbd/packages/i386_pentium4/base/lldpd_1.0.16-1_i386_pentium4.ipk.html
