### PR TITLE
tools/patchelf: update to 0.17.2

### DIFF
--- a/tools/patchelf/Makefile
+++ b/tools/patchelf/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=patchelf
-PKG_VERSION:=0.17.0
+PKG_VERSION:=0.17.2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/NixOS/patchelf/releases/download/$(PKG_VERSION)
-PKG_HASH:=45d76f4a31688a523718ec512f31650b1f35d1affec3eafeb3feeb5448d341e1
+PKG_HASH:=bae2ea376072e422c196218dd9bdef0548ccc08da4de9f36b4672df84ea2d8e2
 
 HOST_BUILD_PARALLEL:=1
 HOST_FIXUP:=autoreconf


### PR DESCRIPTION
Changes from version 0.17.1 to version 0.17.2:
- fix incorrect version in 0.17.1

Changes from version 0.17.0 to version 0.17.1:
- Also pass STRIP to the tests
- Fix Out-of-bounds read in the function modifySoname
- Split segment size fix

Signed-off-by: Linhui Liu <liulinhui36@gmail.com>