### PR TITLE
[21.02] scripts/dl_github_archieve.py: fix generating unreproducible tar

### DIFF
--- a/scripts/dl_github_archive.py
+++ b/scripts/dl_github_archive.py
@@ -133,7 +133,7 @@ class Path(object):
     def tar(path, subdir, into=None, ts=None):
         """Pack ``path`` into tarball ``into``."""
         # --sort=name requires a recent build of GNU tar
-        args = ['tar', '--numeric-owner', '--owner=0', '--group=0', '--sort=name']
+        args = ['tar', '--numeric-owner', '--owner=0', '--group=0', '--sort=name', '--mode=a-s']
         args += ['-C', path, '-cf', into, subdir]
         envs = os.environ.copy()
         if ts is not None:


### PR DESCRIPTION
Allign dl_github_archieve.py to 8252511dc0b5a71e9e64b96f233a27ad73e28b7f change. On supported system the sigid bit is applied to files and tar archieve that on tar creation. This cause unreproducible tar for these system and these bit should be dropped to produce reproducible tar.

Add the missing option following the command options used in other scripts.

Fixes: 75ab064d2b38 ("build: download code from github using archive API")
Suggested-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
Tested-by: Robert Marko <robimarko@gmail.com>
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
(cherry picked from commit 5f1758ef14575df4e86896526b1c2035c231899e)