### PR TITLE
libdeflate: Update to v1.17

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -42,7 +42,6 @@ tools-y += findutils
 tools-y += firmware-utils
 tools-y += flex
 tools-y += gengetopt
-tools-y += libdeflate
 tools-y += libressl
 tools-y += libtool
 tools-y += lzma
@@ -98,7 +97,6 @@ $(curdir)/genext2fs/compile := $(curdir)/libtool/compile
 $(curdir)/gengetopt/compile := $(curdir)/libtool/compile
 $(curdir)/gmp/compile := $(curdir)/libtool/compile
 $(curdir)/isl/compile := $(curdir)/gmp/compile
-$(curdir)/libdeflate/compile := $(curdir)/cmake/compile
 $(curdir)/liblzo/compile := $(curdir)/cmake/compile
 $(curdir)/libressl/compile := $(curdir)/pkgconf/compile
 $(curdir)/libtool/compile := $(curdir)/automake/compile $(curdir)/missing-macros/compile
@@ -148,6 +146,7 @@ $(foreach tool, $(tools-y), $(if $(wildcard $(curdir)/$(tool)/patches),$(eval $(
 $(foreach tool, $(filter-out xz,$(tools-y)), $(eval $(curdir)/$(tool)/compile += $(curdir)/xz/compile))
 
 # make any tool depend on the following to ensure that archives can be unpacked and patched properly
+tools-core += libdeflate
 tools-core += patch
 tools-core += tar
 tools-core += xz

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -147,8 +147,10 @@ $(foreach tool, $(tools-y), $(if $(wildcard $(curdir)/$(tool)/patches),$(eval $(
 
 $(foreach tool, $(filter-out xz,$(tools-y)), $(eval $(curdir)/$(tool)/compile += $(curdir)/xz/compile))
 
-# make any tool depend on tar, xz and patch to ensure that archives can be unpacked and patched properly
-tools-core := tar xz patch
+# make any tool depend on the following to ensure that archives can be unpacked and patched properly
+tools-core += patch
+tools-core += tar
+tools-core += xz
 
 $(foreach tool, $(tools-y), $(eval $(curdir)/$(tool)/compile += $(patsubst %,$(curdir)/%/compile,$(tools-core))))
 tools-y += $(tools-core)

--- a/tools/libdeflate/Makefile
+++ b/tools/libdeflate/Makefile
@@ -7,13 +7,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdeflate
-PKG_VERSION:=1.15
+PKG_VERSION:=1.17
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://github.com/ebiggers/libdeflate.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
-PKG_MIRROR_HASH:=122feff4543541b547dc89e832adf262c81911ae1acbccdc591f0353a85b600a
+PKG_MIRROR_HASH:=ee5790cf3140aa6a2e0f0c400d4b32539f13cb270e9357135c51927ba3784dc7
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -23,7 +23,7 @@ define Host/Install
 	$(LN) libdeflate-gzip $(STAGING_DIR_HOST)/bin/libdeflate-gunzip
 endef
 
-define Host/Clean
+define Host/Uninstall
 	rm -f $(STAGING_DIR_HOST)/bin/libdeflate-gzip
 	rm -f $(STAGING_DIR_HOST)/bin/libdeflate-gunzip
 endef

--- a/tools/libdeflate/Makefile
+++ b/tools/libdeflate/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdeflate
 PKG_VERSION:=1.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://github.com/ebiggers/libdeflate.git
 PKG_SOURCE_PROTO:=git
@@ -16,16 +16,23 @@ PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_MIRROR_HASH:=ee5790cf3140aa6a2e0f0c400d4b32539f13cb270e9357135c51927ba3784dc7
 
 include $(INCLUDE_DIR)/host-build.mk
-include $(INCLUDE_DIR)/cmake.mk
+
+define Host/Compile
+	$(HOSTCC_NOCACHE) $(HOST_CFLAGS) $(HOST_LDFLAGS) \
+	$(HOST_BUILD_DIR)/lib/*{,/*}.c \
+	$(HOST_BUILD_DIR)/programs/{gzip,prog_util,tgetopt}.c \
+	-o $(HOST_BUILD_DIR)/libdeflate-gzip
+endef
 
 define Host/Install
-	$(INSTALL_BIN) $(HOST_BUILD_DIR)/programs/libdeflate-gzip $(STAGING_DIR_HOST)/bin/
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/libdeflate-gzip $(STAGING_DIR_HOST)/bin/
 	$(LN) libdeflate-gzip $(STAGING_DIR_HOST)/bin/libdeflate-gunzip
 endef
 
 define Host/Uninstall
-	rm -f $(STAGING_DIR_HOST)/bin/libdeflate-gzip
-	rm -f $(STAGING_DIR_HOST)/bin/libdeflate-gunzip
+	$(RM) $(STAGING_DIR_HOST)/bin/libdeflate-gzip
+	$(RM) $(STAGING_DIR_HOST)/bin/libdeflate-gunzip
+	$(call Host/Uninstall/Default)
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
CMake depends on (libdeflate-)gunzip, libdeflate depends on Cmake, so we can't win.

Luckily libdeflate is _very_ easy to build, without any build system, so lets just manually compile it and be done with it.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>