### PR TITLE
ath79: add support for Senao Engenius EWS660AP

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -38,6 +38,7 @@ engenius,ecb600|\
 engenius,enh202-v1|\
 engenius,ens202ext-v1|\
 engenius,enstationac-v1|\
+engenius,ews660ap|\
 etactica,eg200|\
 glinet,gl-ar750s-nor|\
 glinet,gl-ar750s-nor-nand|\

--- a/target/linux/ath79/dts/qca9557_araknis_an-500-ap-i-ac.dts
+++ b/target/linux/ath79/dts/qca9557_araknis_an-500-ap-i-ac.dts
@@ -94,6 +94,10 @@
 	mac-address-increment = <1>;
 };
 
+&pcie0 {
+	status = "okay";
+};
+
 &art {
 	compatible = "nvmem-cells";
 	#address-cells = <1>;

--- a/target/linux/ath79/dts/qca9557_engenius_eap1200h.dts
+++ b/target/linux/ath79/dts/qca9557_engenius_eap1200h.dts
@@ -110,10 +110,14 @@
 	mac-address-increment = <1>;
 };
 
-&ath10k {
+&ath10k_0 {
 	status = "okay";
 
 	nvmem-cells = <&macaddr_art_0>, <&calibration_art_5000>;
 	nvmem-cell-names = "mac-address", "calibration";
 	mac-address-increment = <2>;
+};
+
+&pcie0 {
+	status = "okay";
 };

--- a/target/linux/ath79/dts/qca9557_engenius_enstationac-v1.dts
+++ b/target/linux/ath79/dts/qca9557_engenius_enstationac-v1.dts
@@ -111,6 +111,10 @@
 	qca955x-sgmii-fixup;
 };
 
+&pcie0 {
+	status = "okay";
+};
+
 &art {
 	compatible = "nvmem-cells";
 	#address-cells = <1>;

--- a/target/linux/ath79/dts/qca9558_allnet_all-wap02860ac.dts
+++ b/target/linux/ath79/dts/qca9558_allnet_all-wap02860ac.dts
@@ -95,6 +95,10 @@
 	mac-address-increment = <1>;
 };
 
+&pcie0 {
+	status = "okay";
+};
+
 &art {
 	compatible = "nvmem-cells";
 	#address-cells = <1>;

--- a/target/linux/ath79/dts/qca9558_araknis_an-700-ap-i-ac.dts
+++ b/target/linux/ath79/dts/qca9558_araknis_an-700-ap-i-ac.dts
@@ -93,6 +93,10 @@
 	mac-address-increment = <1>;
 };
 
+&pcie0 {
+	status = "okay";
+};
+
 &art {
 	compatible = "nvmem-cells";
 	#address-cells = <1>;

--- a/target/linux/ath79/dts/qca9558_engenius_eap1750h.dts
+++ b/target/linux/ath79/dts/qca9558_engenius_eap1750h.dts
@@ -110,10 +110,14 @@
 	mac-address-increment = <1>;
 };
 
-&ath10k {
+&ath10k_0 {
 	status = "okay";
 
 	nvmem-cells = <&macaddr_art_0>, <&calibration_art_5000>;
 	nvmem-cell-names = "mac-address", "calibration";
 	mac-address-increment = <2>;
+};
+
+&pcie0 {
+	status = "okay";
 };

--- a/target/linux/ath79/dts/qca9558_engenius_ews660ap.dts
+++ b/target/linux/ath79/dts/qca9558_engenius_ews660ap.dts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x_senao_loader.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "engenius,ews660ap", "qca,qca9558";
+	model = "EnGenius EWS660AP";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_wifi5g;
+		led-failsafe = &led_wifi5g;
+		led-upgrade = &led_wifi5g;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wifi2g {
+			label = "green:wifi2g";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led_wifi5g: wifi5g {
+			label = "green:wifi5g";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&partitions {
+	partition@ff0000 {
+		label = "art";
+		reg = <0xff0000 0x010000>;
+		read-only;
+
+		compatible = "nvmem-cells";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_art_0: macaddr@0 {
+			reg = <0x0 0x6>;
+		};
+
+		calibration_art_1000: calibration@1000 {
+			reg = <0x1000 0x440>;
+		};
+
+		calibration_art_5000: calibration@5000 {
+			reg = <0x5000 0x844>;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+
+	phy2: ethernet-phy@2 {
+		reg = <2>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+		at803x-override-sgmii-link-check;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-handle = <&phy1>;
+	phy-mode = "rgmii-id";
+
+	pll-data = <0x82000000 0x80000101 0x80001313>;
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+
+	phy-handle = <&phy2>;
+
+	pll-data = <0x03000000 0x00000101 0x00001313>;
+
+	qca955x-sgmii-fixup;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>, <&calibration_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
+	mac-address-increment = <2>;
+};
+
+&ath10k_1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>, <&calibration_art_5000>;
+	nvmem-cell-names = "mac-address", "calibration";
+	mac-address-increment = <3>;
+};
+
+&pcie1 {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/qca9558_watchguard_ap300.dts
+++ b/target/linux/ath79/dts/qca9558_watchguard_ap300.dts
@@ -121,6 +121,10 @@
 	mac-address-increment = <1>;
 };
 
+&pcie0 {
+	status = "okay";
+};
+
 &art {
 	compatible = "nvmem-cells";
 	#address-cells = <1>;

--- a/target/linux/ath79/dts/qca955x_senao_loader.dtsi
+++ b/target/linux/ath79/dts/qca955x_senao_loader.dtsi
@@ -26,11 +26,16 @@
 };
 
 &pcie0 {
-	status = "okay";
-
-	ath10k: wifi@0,0,0 {
+	ath10k_0: wifi@0,0,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x0 0 0 0 0>;
+	};
+};
+
+&pcie1 {
+	ath10k_1: wifi@0,1,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0 1 0 0 0>;
 	};
 };
 

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -136,6 +136,7 @@ ath79_setup_interfaces()
 	devolo,dvl1750e|\
 	engenius,enstationac-v1|\
 	engenius,ews511ap|\
+	engenius,ews660ap|\
 	ocedo,ursus|\
 	ruckus,zf7372|\
 	ubnt,unifi-ap-outdoor-plus)

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -42,6 +42,7 @@ platform_do_upgrade() {
 	engenius,ecb600|\
 	engenius,ens202ext-v1|\
 	engenius,enstationac-v1|\
+	engenius,ews660ap|\
 	watchguard,ap100|\
 	watchguard,ap200|\
 	watchguard,ap300)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1308,6 +1308,18 @@ define Device/engenius_ews511ap
 endef
 TARGET_DEVICES += engenius_ews511ap
 
+define Device/engenius_ews660ap
+  $(Device/senao_loader_okli)
+  SOC := qca9558
+  DEVICE_VENDOR := EnGenius
+  DEVICE_MODEL := EWS660AP
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct
+  IMAGE_SIZE := 11584k
+  LOADER_FLASH_OFFS := 0x220000
+  SENAO_IMGNAME := ar71xx-generic-ews660ap
+endef
+TARGET_DEVICES += engenius_ews660ap
+
 define Device/enterasys_ws-ap3705i
   SOC := ar9344
   DEVICE_VENDOR := Enterasys


### PR DESCRIPTION
FCC ID: A8J-EWS660AP

Engenius EWS660AP is an outdoor wireless access point with 2 gigabit ethernet ports, dual-band wireless,
internal antenna plates, and 802.3at PoE+

**Specification:**

  - QCA9558 SOC		2.4 GHz, 3x3
  - QCA9880 WLAN	mini PCIe card, 5 GHz, 3x3, 26dBm
  - AR8035-A PHY	RGMII GbE with PoE+ IN
  - AR8033 PHY		SGMII GbE with PoE+ OUT
  - 40 MHz clock
  - 16 MB FLASH		MX25L12845EMI-10G
  - 2x 64 MB RAM
  - UART at J1		populated, RX grounded
  - 6 internal antenna plates (5 dbi, omni-directional)
  - 5 LEDs, 1 button (power, eth0, eth1, 2G, 5G) (reset)

**MAC addresses:**

  Base MAC addressed labeled as "MAC"
  Only one Vendor MAC address in flash

  eth0 *:d4 MAC art 0x0
  eth1 *:d5 --- art 0x0 +1
  phy1 *:d6 --- art 0x0 +2
  phy0 *:d7 --- art 0x0 +3

**Serial Access:**

  the RX line on the board for UART is shorted to ground by resistor R176
  therefore it must be removed to use the console
  but it is not necessary to remove to view boot log

  optionally, R175 can be replaced with a solder bridge short

  the resistors R175 and R176 are next to the UART RX pin

**Installation:**

  2 ways to flash factory.bin from OEM:

  Method 1: Firmware upgrade page:

    OEM webpage at 192.168.1.1 username and password "admin" Navigate to "Firmware Upgrade" page from left pane Click Browse and select the factory.bin image Upload and verify checksum Click Continue to confirm and wait 3 minutes

  Method 2: Serial to load Failsafe webpage:

    After connecting to serial console and rebooting... Interrupt uboot with any key pressed rapidly execute `run failsafe_boot` OR `bootm 0x9fd70000` wait a minute connect to ethernet and navigate to "192.168.1.1/index.htm" Select the factory.bin image and upload wait about 3 minutes

**Return to OEM:**

  If you have a serial cable, see Serial Failsafe instructions
  otherwise, uboot-env can be used to make uboot load the failsafe image

  ssh into openwrt and run
  `fw_setenv rootfs_checksum 0`
  reboot, wait 3 minutes
  connect to ethernet and navigate to 192.168.1.1/index.htm
  select OEM firmware image from Engenius and click upgrade

**TFTP recovery:**

  Requires serial console, reset button does nothing

  rename initramfs.bin to '0101A8C0.img'
  make available on TFTP server at 192.168.1.101
  power board, interrupt boot
  execute tftpboot and bootm 0x81000000

**Format of OEM firmware image:**

  The OEM software of EWS660AP is a heavily modified version
  of Openwrt Kamikaze. One of the many modifications
  is to the sysupgrade program. Image verification is performed
  simply by the successful ungzip and untar of the supplied file
  and name check and header verification of the resulting contents.
  To form a factory.bin that is accepted by OEM Openwrt build,
  the kernel and rootfs must have specific names...

    openwrt-ar71xx-generic-ews660ap-uImage-lzma.bin openwrt-ar71xx-generic-ews660ap-root.squashfs

  and begin with the respective headers (uImage, squashfs).
  Then the files must be tarballed and gzipped.
  The resulting binary is actually a tar.gz file in disguise.
  This can be verified by using binwalk on the OEM firmware images,
  ungzipping then untaring.

  Newer EnGenius software requires more checks but their script
  includes a way to skip them, otherwise the tar must include
  a text file with the version and md5sums in a deprecated format.

  The OEM upgrade script is at /etc/fwupgrade.sh.

  OKLI kernel loader is required because the OEM software
  expects the kernel to be no greater than 1536k
  and the factory.bin upgrade procedure would otherwise
  overwrite part of the kernel when writing rootfs.

Note on PLL-data cells:

  The default PLL register values will not work
  because of the external AR8035 switch between
  the SOC and the ethernet port.

  For QCA955x series, the PLL registers for eth0 and eth1
  can be see in the DTSI as 0x28 and 0x48 respectively.
  Therefore the PLL registers can be read from uboot
  for each link speed after attempting tftpboot
  or another network action using that link speed
  with `md 0x18050028 1` and `md 0x18050048 1`.

  The clock delay required for RGMII can be applied
  at the PHY side, using the at803x driver `phy-mode`.
  Therefore the PLL registers for GMAC0
  do not need the bits for delay on the MAC side.
  This is possible due to fixes in at803x driver
  since Linux 5.1 and 5.3

Tested-by: Niklas Arnitz <openwrt@arnitz.email>
Signed-off-by: Michael Pratt <mcpratt@pm.me>
