### PR TITLE
base-files: keep directory permissions in sysupgrade backup

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -140,7 +140,7 @@ list_static_conffiles() {
 
 	find $(sed -ne '/^[[:space:]]*$/d; /^#/d; p' \
 		/etc/sysupgrade.conf /lib/upgrade/keep.d/* 2>/dev/null) \
-		\( -type f -o -type l \) $filter 2>/dev/null
+		\( -type f -o -type l -o -type d \) $filter 2>/dev/null
 }
 
 add_conffiles() {


### PR DESCRIPTION
tar, when supplied only a list of files, does not save directory permissions/owner where these files are located, and restore the directories with root owner and standard 755 permission, which may cause issues for daemons not running as root.

This also allows preserving empty directories upon restore.

Signed-off-by: ValdikSS ValdikSS <iam@valdikss.org.ru>