### PR TITLE
libpcap: update to 1.10.3

### DIFF
--- a/package/libs/libpcap/Makefile
+++ b/package/libs/libpcap/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpcap
-PKG_VERSION:=1.10.2
+PKG_VERSION:=1.10.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.tcpdump.org/release/
-PKG_HASH:=db6d79d4ad03b8b15fb16c42447d093ad3520c0ec0ae3d331104dcfb1ce77560
+PKG_HASH:=2a8885c403516cf7b0933ed4b14d6caa30e02052489ebd414dc75ac52e7559e6
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=BSD-3-Clause

--- a/package/libs/libpcap/patches/300-Add-support-for-B.A.T.M.A.N.-Advanced.patch
+++ b/package/libs/libpcap/patches/300-Add-support-for-B.A.T.M.A.N.-Advanced.patch
@@ -36,7 +36,7 @@ Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
 
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -134,6 +134,8 @@ PUBHDR = \
+@@ -133,6 +133,8 @@ PUBHDR = \
  HDR = $(PUBHDR) \
  	arcnet.h \
  	atmuni31.h \


### PR DESCRIPTION
Changelog:
https://git.tcpdump.org/libpcap/blob/95691ebe7564afa3faa5c6ba0dbd17e351be455a:/CHANGES

Refresh patch:
- 300-Add-support-for-B.A.T.M.A.N.-Advanced.patch
