### PR TITLE
ramips: mt7621: ASUS RT-AX53U add NMBM, nest firmware 

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -63,6 +63,11 @@
 &nand {
 	status = "okay";
 
+	mediatek,nmbm;
+	mediatek,bmt-remap-range =
+		<0x000000 0x7e0000>,
+		<0x35e0000 0x7800000>;
+
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -110,13 +115,22 @@
 		};
 
 		partition@3e0000 {
-			label = "kernel";
-			reg = <0x3e0000 0x400000>;
-		};
+			label = "firmware";
+			reg = <0x3e0000 0x3200000>;
 
-		partition@7e0000 {
-			label = "ubi";
-			reg = <0x7e0000 0x2e00000>;
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x2e00000>;
+			};
 		};
 
 		partition@35e0000 {
@@ -124,7 +138,12 @@
 			reg = <0x35e0000 0x3200000>;
 		};
 
-		/* Last 8M possibly store the bad block table */
+		partition@67e0000 {
+			label = "jffs2";
+			reg = <0x67e0000 0x1020000>;
+		};
+
+		/* Last 8M are reserved for NMBM management (bad blocks) */
 	};
 };
 


### PR DESCRIPTION
Nests kernel and ubi into firmware partition in-order to be compatible
with OEM firmware. This allows restoring oem firmware from a backup of
firmware2. Add jffs2 partition which is present in the oem firmware.
Add support for mediatek NMBM (wear leveling on newer mediatek devices).
Exclude UBI partition from NMBM management.
Continues PR https://github.com/openwrt/openwrt/pull/10685.

Tested-by: Felix Baumann <felix.bau@gmx.de>
Signed-off-by: Felix Baumann <felix.bau@gmx.de>

____________

This was tested as a sysupgrade from 22 as well as a flash from stock rom (mtd-write via ssh and also via the asus recovery tool with the initramfs image)

Log with the changes to partitions and to showcase NMBM
```
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.474615] nand: device found, Manufacturer ID: 0x01, Chip ID: 0xf1
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.481052] nand: AMD/Spansion S34ML01G2
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.484963] nand: 128 MiB, SLC, erase size: 128 KiB, page size: 2048, OOB size: 64
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.492533] mt7621-nand 1e003000.nand: ECC strength adjusted to 4 bits
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.501718] Signature found at block 1023 [0x07fe0000]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.506841] NMBM management region starts at block 960 [0x07800000]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.517696] First info table with writecount 0 found in block 960
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.537315] Second info table with writecount 0 found in block 963
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.543593] NMBM has been successfully attached
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.548289] 8 fixed-partitions partitions found on MTD device mt7621-nand
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.555870] Creating 8 MTD partitions on "mt7621-nand":
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.561216] 0x000000000000-0x000000080000 : "u-boot"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.574879] 0x000000080000-0x0000000e0000 : "u-boot-env"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.586840] 0x0000000e0000-0x0000001e0000 : "nvram"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.608358] 0x0000001e0000-0x0000002e0000 : "factory"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.629813] 0x0000002e0000-0x0000003e0000 : "factory2"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.651345] 0x0000003e0000-0x0000035e0000 : "firmware"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    2.424755] 2 fixed-partitions partitions found on MTD device firmware
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    2.431381] Creating 2 MTD partitions on "firmware":
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    2.436336] 0x000000000000-0x000000400000 : "kernel"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    2.503558] 0x000000400000-0x000003200000 : "ubi"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    3.214273] 0x0000035e0000-0x0000067e0000 : "firmware2"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    3.986504] 0x0000067e0000-0x000007800000 : "jffs2"
```

<details>
  <summary>full logread</summary>

  ```
root@OpenWrt:~# logread
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    0.000000] Linux version 5.15.102 (ffac@community-build) (mipsel-openwrt-linux-musl-gcc (OpenWrt GCC 12.2.0 r22396-7dd2c1ce37) 12.2.0, GNU ld (GNU Binutils) 2.40.0) #0 SMP Fri Mar 31 02:34:43 2023
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] SoC Type: MediaTek MT7621 ver:1 eco:3
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] printk: bootconsole [early0] enabled
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] CPU0 revision is: 0001992f (MIPS 1004Kc)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] MIPS: machine is ASUS RT-AX53U
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] Initrd not found or empty - disabling initrd
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] VPE topology {2,2} total 4
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
Fri Mar 31 02:41:30 2023 kern.warn kernel: [    0.000000] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] Zone ranges:
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000]   Normal   [mem 0x0000000000000000-0x000000000fffffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000]   HighMem  empty
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] Movable zone start for each node
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] Early memory node ranges
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000]   node   0: [mem 0x0000000000000000-0x000000000fffffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000000fffffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] percpu: Embedded 11 pages/cpu s15632 r8192 d21232 u45056
Fri Mar 31 02:41:30 2023 kern.debug kernel: [    0.000000] pcpu-alloc: s15632 r8192 d21232 u45056 alloc=11*4096
Fri Mar 31 02:41:30 2023 kern.debug kernel: [    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 64960
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    0.000000] Kernel command line: console=ttyS0,115200
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] Dentry cache hash table entries: 32768 (order: 5, 131072 bytes, linear)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] Inode-cache hash table entries: 16384 (order: 4, 65536 bytes, linear)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] Writing ErrCtl register=00058547
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] Readback ErrCtl register=00058547
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] Memory: 248648K/262144K available (7134K kernel code, 625K rwdata, 1452K rodata, 1272K init, 242K bss, 13496K reserved, 0K cma-reserved, 0K highmem)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] rcu: Hierarchical RCU implementation.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000]       Tracing variant of Tasks RCU enabled.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] NR_IRQS: 256
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000000] clocksource: GIC: mask: 0xffffffffffffffff max_cycles: 0xcaf478abb4, max_idle_ns: 440795247997 ns
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.000004] sched_clock: 64 bits at 880MHz, resolution 1ns, wraps every 4398046511103ns
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.008065] Calibrating delay loop... 586.13 BogoMIPS (lpj=2930688)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.066210] pid_max: default: 32768 minimum: 301
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.071027] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.078236] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.089061] rcu: Hierarchical SRCU implementation.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.094098] dyndbg: Ignore empty _ddebug table in a CONFIG_DYNAMIC_DEBUG_CORE build
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.102205] smp: Bringing up secondary CPUs ...
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.107473] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.107500] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
Fri Mar 31 02:41:30 2023 kern.warn kernel: [    0.107515] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.107559] CPU1 revision is: 0001992f (MIPS 1004Kc)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.161972] Synchronize counters for CPU 1: done.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.194013] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.194034] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
Fri Mar 31 02:41:30 2023 kern.warn kernel: [    0.194045] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.194074] CPU2 revision is: 0001992f (MIPS 1004Kc)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.253200] Synchronize counters for CPU 2: done.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.283799] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.283820] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
Fri Mar 31 02:41:30 2023 kern.warn kernel: [    0.283830] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.283862] CPU3 revision is: 0001992f (MIPS 1004Kc)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.338395] Synchronize counters for CPU 3: done.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.368255] smp: Brought up 1 node, 4 CPUs
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.376246] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.386047] futex hash table entries: 1024 (order: 3, 32768 bytes, linear)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.393050] pinctrl core: initialized pinctrl subsystem
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.399536] NET: Registered PF_NETLINK/PF_ROUTE protocol family
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.405957] thermal_sys: Registered thermal governor 'step_wise'
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.406517] cpuidle: using governor teo
Fri Mar 31 02:41:30 2023 kern.debug kernel: [    0.426777] FPU Affinity set after 11720 emulations
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.438254] clocksource: Switched to clocksource GIC
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.444010] NET: Registered PF_INET protocol family
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.449000] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.456836] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 6144 bytes, linear)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.465180] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.472851] TCP established hash table entries: 2048 (order: 1, 8192 bytes, linear)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.480485] TCP bind hash table entries: 2048 (order: 2, 16384 bytes, linear)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.487554] TCP: Hash tables configured (established 2048 bind 2048)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.493990] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.500483] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.507657] NET: Registered PF_UNIX/PF_LOCAL protocol family
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.513284] PCI: CLS 0 bytes, default 32
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.520104] workingset: timestamp_bits=14 max_order=16 bucket_order=2
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.530756] squashfs: version 4.0 (2009/01/31) Phillip Lougher
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.536512] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.550718] mt7621_gpio 1e000600.gpio: registering 32 gpios
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.556593] mt7621_gpio 1e000600.gpio: registering 32 gpios
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.562465] mt7621_gpio 1e000600.gpio: registering 32 gpios
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.568608] mt7621-pci 1e140000.pcie: host bridge /pcie@1e140000 ranges:
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.575287] mt7621-pci 1e140000.pcie:   No bus range found for /pcie@1e140000, using [bus 00-ff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.584047] mt7621-pci 1e140000.pcie:      MEM 0x0060000000..0x006fffffff -> 0x0060000000
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.592161] mt7621-pci 1e140000.pcie:       IO 0x001e160000..0x001e16ffff -> 0x0000000000
Fri Mar 31 02:41:30 2023 kern.err kernel: [    0.958260] mt7621-pci 1e140000.pcie: pcie2 no card, disable it (RST & CLK)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.965153] mt7621-pci 1e140000.pcie: PCIE0 enabled
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.970004] mt7621-pci 1e140000.pcie: PCIE1 enabled
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.974846] PCI coherence region base: 0x60000000, mask/settings: 0xf0000002
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.981995] mt7621-pci 1e140000.pcie: PCI host bridge to bus 0000:00
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.988290] pci_bus 0000:00: root bus resource [bus 00-ff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    0.993706] pci_bus 0000:00: root bus resource [mem 0x60000000-0x6fffffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.000546] pci_bus 0000:00: root bus resource [io  0x0000-0xffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.006718] pci 0000:00:00.0: [0e8d:0801] type 01 class 0x060400
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.012657] pci 0000:00:00.0: reg 0x10: [mem 0x00000000-0x7fffffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.018869] pci 0000:00:00.0: reg 0x14: [mem 0x00000000-0x0000ffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.025133] pci 0000:00:00.0: supports D1
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.029062] pci 0000:00:00.0: PME# supported from D0 D1 D3hot
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.035510] pci 0000:00:01.0: [0e8d:0801] type 01 class 0x060400
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.041503] pci 0000:00:01.0: reg 0x10: [mem 0x00000000-0x7fffffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.047682] pci 0000:00:01.0: reg 0x14: [mem 0x00000000-0x0000ffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.053985] pci 0000:00:01.0: supports D1
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.057903] pci 0000:00:01.0: PME# supported from D0 D1 D3hot
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.065434] pci 0000:00:00.0: bridge configuration invalid ([bus 00-00]), reconfiguring
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.073392] pci 0000:00:01.0: bridge configuration invalid ([bus 00-00]), reconfiguring
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.081614] pci 0000:01:00.0: [14c3:7916] type 00 class 0x000280
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.087577] pci 0000:01:00.0: reg 0x10: [mem 0x00000000-0x000fffff 64bit pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.094744] pci 0000:01:00.0: reg 0x18: [mem 0x00000000-0x00003fff 64bit pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.101906] pci 0000:01:00.0: reg 0x20: [mem 0x00000000-0x00000fff 64bit pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.109190] pci 0000:01:00.0: supports D1 D2
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.113367] pci 0000:01:00.0: PME# supported from D0 D1 D2 D3hot D3cold
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.119987] pci 0000:01:00.0: 2.000 Gb/s available PCIe bandwidth, limited by 2.5 GT/s PCIe x1 link at 0000:00:00.0 (capable of 4.000 Gb/s with 5.0 GT/s PCIe x1 link)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.136049] pci 0000:00:00.0: PCI bridge to [bus 01-ff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.141235] pci 0000:00:00.0:   bridge window [io  0x0000-0x0fff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.147251] pci 0000:00:00.0:   bridge window [mem 0x00000000-0x000fffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.154007] pci 0000:00:00.0:   bridge window [mem 0x00000000-0x000fffff pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.161177] pci_bus 0000:01: busn_res: [bus 01-ff] end is updated to 01
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.167981] pci 0000:02:00.0: [14c3:7915] type 00 class 0x000280
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.173966] pci 0000:02:00.0: reg 0x10: [mem 0x00000000-0x000fffff 64bit pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.181134] pci 0000:02:00.0: reg 0x18: [mem 0x00000000-0x00003fff 64bit pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.188311] pci 0000:02:00.0: reg 0x20: [mem 0x00000000-0x00000fff 64bit pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.195572] pci 0000:02:00.0: supports D1 D2
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.199771] pci 0000:02:00.0: PME# supported from D0 D1 D2 D3hot D3cold
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.206350] pci 0000:02:00.0: 2.000 Gb/s available PCIe bandwidth, limited by 2.5 GT/s PCIe x1 link at 0000:00:01.0 (capable of 4.000 Gb/s with 5.0 GT/s PCIe x1 link)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.222422] pci 0000:00:01.0: PCI bridge to [bus 02-ff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.227579] pci 0000:00:01.0:   bridge window [io  0x0000-0x0fff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.233648] pci 0000:00:01.0:   bridge window [mem 0x00000000-0x000fffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.240383] pci 0000:00:01.0:   bridge window [mem 0x00000000-0x000fffff pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.247536] pci_bus 0000:02: busn_res: [bus 02-ff] end is updated to 02
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.254167] pci 0000:00:00.0: BAR 0: no space for [mem size 0x80000000]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.260706] pci 0000:00:00.0: BAR 0: failed to assign [mem size 0x80000000]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.267597] pci 0000:00:01.0: BAR 0: no space for [mem size 0x80000000]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.274178] pci 0000:00:01.0: BAR 0: failed to assign [mem size 0x80000000]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.281090] pci 0000:00:00.0: BAR 8: assigned [mem 0x60000000-0x600fffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.287813] pci 0000:00:00.0: BAR 9: assigned [mem 0x60100000-0x602fffff pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.295003] pci 0000:00:01.0: BAR 8: assigned [mem 0x60300000-0x603fffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.301739] pci 0000:00:01.0: BAR 9: assigned [mem 0x60400000-0x605fffff pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.308917] pci 0000:00:00.0: BAR 1: assigned [mem 0x60600000-0x6060ffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.315639] pci 0000:00:01.0: BAR 1: assigned [mem 0x60610000-0x6061ffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.322398] pci 0000:00:00.0: BAR 7: assigned [io  0x0000-0x0fff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.328441] pci 0000:00:01.0: BAR 7: assigned [io  0x1000-0x1fff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.334483] pci 0000:01:00.0: BAR 0: assigned [mem 0x60100000-0x601fffff 64bit pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.342188] pci 0000:01:00.0: BAR 2: assigned [mem 0x60200000-0x60203fff 64bit pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.349879] pci 0000:01:00.0: BAR 4: assigned [mem 0x60204000-0x60204fff 64bit pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.357548] pci 0000:00:00.0: PCI bridge to [bus 01]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.362477] pci 0000:00:00.0:   bridge window [io  0x0000-0x0fff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.368531] pci 0000:00:00.0:   bridge window [mem 0x60000000-0x600fffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.375250] pci 0000:00:00.0:   bridge window [mem 0x60100000-0x602fffff pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.382450] pci 0000:02:00.0: BAR 0: assigned [mem 0x60400000-0x604fffff 64bit pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.390142] pci 0000:02:00.0: BAR 2: assigned [mem 0x60500000-0x60503fff 64bit pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.397810] pci 0000:02:00.0: BAR 4: assigned [mem 0x60504000-0x60504fff 64bit pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.405516] pci 0000:00:01.0: PCI bridge to [bus 02]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.410432] pci 0000:00:01.0:   bridge window [io  0x1000-0x1fff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.416462] pci 0000:00:01.0:   bridge window [mem 0x60300000-0x603fffff]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.423216] pci 0000:00:01.0:   bridge window [mem 0x60400000-0x605fffff pref]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.432840] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.440756] printk: console [ttyS0] disabled
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.445052] 1e000c00.uartlite: ttyS0 at MMIO 0x1e000c00 (irq = 19, base_baud = 3125000) is a 16550A
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.454056] printk: console [ttyS0] enabled
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.462321] printk: bootconsole [early0] disabled
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.474615] nand: device found, Manufacturer ID: 0x01, Chip ID: 0xf1
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.481052] nand: AMD/Spansion S34ML01G2
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.484963] nand: 128 MiB, SLC, erase size: 128 KiB, page size: 2048, OOB size: 64
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.492533] mt7621-nand 1e003000.nand: ECC strength adjusted to 4 bits
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.501718] Signature found at block 1023 [0x07fe0000]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.506841] NMBM management region starts at block 960 [0x07800000]
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.517696] First info table with writecount 0 found in block 960
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.537315] Second info table with writecount 0 found in block 963
Fri Mar 31 02:41:30 2023 kern.info kernel: [    1.543593] NMBM has been successfully attached
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.548289] 8 fixed-partitions partitions found on MTD device mt7621-nand
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.555870] Creating 8 MTD partitions on "mt7621-nand":
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.561216] 0x000000000000-0x000000080000 : "u-boot"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.574879] 0x000000080000-0x0000000e0000 : "u-boot-env"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.586840] 0x0000000e0000-0x0000001e0000 : "nvram"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.608358] 0x0000001e0000-0x0000002e0000 : "factory"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.629813] 0x0000002e0000-0x0000003e0000 : "factory2"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    1.651345] 0x0000003e0000-0x0000035e0000 : "firmware"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    2.424755] 2 fixed-partitions partitions found on MTD device firmware
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    2.431381] Creating 2 MTD partitions on "firmware":
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    2.436336] 0x000000000000-0x000000400000 : "kernel"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    2.503558] 0x000000400000-0x000003200000 : "ubi"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    3.214273] 0x0000035e0000-0x0000067e0000 : "firmware2"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    3.986504] 0x0000067e0000-0x000007800000 : "jffs2"
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.389730] mt7530 mdio-bus:1f: MT7530 adapts as multi-chip module
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.402989] mtk_soc_eth 1e100000.ethernet eth0: mediatek frame engine at 0xbe100000, irq 21
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.414769] mtk_soc_eth 1e100000.ethernet wan: mediatek frame engine at 0xbe100000, irq 21
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.424974] i2c_dev: i2c /dev entries driver
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.432322] NET: Registered PF_INET6 protocol family
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.439756] Segment Routing with IPv6
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.443496] In-situ OAM (IOAM) with IPv6
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.447502] NET: Registered PF_PACKET protocol family
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.452933] 8021q: 802.1Q VLAN Support v1.8
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.462905] mt7530 mdio-bus:1f: MT7530 adapts as multi-chip module
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.492549] mt7530 mdio-bus:1f: configuring for fixed/rgmii link mode
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.502922] mt7530 mdio-bus:1f: Link is Up - 1Gbps/Full - flow control rx/tx
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.509529] mt7530 mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7530 PHY] (irq=23)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.522462] mt7530 mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7530 PHY] (irq=24)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.534725] mt7530 mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7530 PHY] (irq=25)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    4.547109] DSA: tree 0 setup
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    4.553776] UBI: auto-attach mtd7
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    4.557126] ubi0: attaching mtd7
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    5.737819] ubi0: scanning is finished
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    5.758335] ubi0: attached mtd7 (name "ubi", size 46 MiB)
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    5.763767] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    5.770626] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    5.777388] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    5.784335] ubi0: good PEBs: 368, bad PEBs: 0, corrupted PEBs: 0
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    5.790332] ubi0: user volume: 2, internal volumes: 1, max. volumes count: 128
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    5.797524] ubi0: max/mean erase counter: 1/0, WL threshold: 4096, image sequence number: 532688723
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    5.806542] ubi0: available PEBs: 0, total reserved PEBs: 368, PEBs reserved for bad PEB handling: 19
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    5.815773] ubi0: background thread "ubi_bgt0d" started, PID 310
Fri Mar 31 02:41:30 2023 kern.info kernel: [    5.818056] block ubiblock0_0: created from ubi0:0(rootfs)
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    5.827312] ubiblock: device ubiblock0_0 (rootfs) set to be root filesystem
Fri Mar 31 02:41:30 2023 kern.info kernel: [    5.841490] VFS: Mounted root (squashfs filesystem) readonly on device 254:0.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    5.852830] Freeing unused kernel image (initmem) memory: 1272K
Fri Mar 31 02:41:30 2023 kern.warn kernel: [    5.858791] This architecture does not have kernel memory protection.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    5.865221] Run /sbin/init as init process
Fri Mar 31 02:41:30 2023 kern.debug kernel: [    5.869311]   with arguments:
Fri Mar 31 02:41:30 2023 kern.debug kernel: [    5.869319]     /sbin/init
Fri Mar 31 02:41:30 2023 kern.debug kernel: [    5.869325]   with environment:
Fri Mar 31 02:41:30 2023 kern.debug kernel: [    5.869330]     HOME=/
Fri Mar 31 02:41:30 2023 kern.debug kernel: [    5.869335]     TERM=linux
Fri Mar 31 02:41:30 2023 user.info kernel: [    6.330478] init: Console is alive
Fri Mar 31 02:41:30 2023 user.info kernel: [    6.334208] init: - watchdog -
Fri Mar 31 02:41:30 2023 user.info kernel: [    7.142864] kmodloader: loading kernel modules from /etc/modules-boot.d/*
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.201519] usbcore: registered new interface driver usbfs
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.207164] usbcore: registered new interface driver hub
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.212676] usbcore: registered new device driver usb
Fri Mar 31 02:41:30 2023 kern.warn kernel: [    7.229028] xhci-mtk 1e1c0000.xhci: supply vbus not found, using dummy regulator
Fri Mar 31 02:41:30 2023 kern.warn kernel: [    7.236665] xhci-mtk 1e1c0000.xhci: supply vusb33 not found, using dummy regulator
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.244467] xhci-mtk 1e1c0000.xhci: xHCI Host Controller
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.249841] xhci-mtk 1e1c0000.xhci: new USB bus registered, assigned bus number 1
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.268450] xhci-mtk 1e1c0000.xhci: hcc params 0x01401198 hci version 0x96 quirks 0x0000000000290010
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.277632] xhci-mtk 1e1c0000.xhci: irq 20, io mem 0x1e1c0000
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.283599] xhci-mtk 1e1c0000.xhci: xHCI Host Controller
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.288949] xhci-mtk 1e1c0000.xhci: new USB bus registered, assigned bus number 2
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.296425] xhci-mtk 1e1c0000.xhci: Host supports USB 3.0 SuperSpeed
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.303834] hub 1-0:1.0: USB hub found
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.307732] hub 1-0:1.0: 2 ports detected
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.312656] usb usb2: We don't know the algorithms for LPM for this host, disabling LPM.
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.321724] hub 2-0:1.0: USB hub found
Fri Mar 31 02:41:30 2023 kern.info kernel: [    7.325609] hub 2-0:1.0: 1 port detected
Fri Mar 31 02:41:30 2023 user.info kernel: [    7.336985] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
Fri Mar 31 02:41:30 2023 user.info kernel: [    7.348682] init: - preinit -
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    8.119229] random: jshn: uninitialized urandom read (4 bytes read)
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    8.238733] random: jshn: uninitialized urandom read (4 bytes read)
Fri Mar 31 02:41:30 2023 kern.notice kernel: [    8.289588] random: jshn: uninitialized urandom read (4 bytes read)
Fri Mar 31 02:41:30 2023 kern.info kernel: [    8.639773] mtk_soc_eth 1e100000.ethernet eth0: configuring for fixed/rgmii link mode
Fri Mar 31 02:41:30 2023 kern.info kernel: [    8.652261] mtk_soc_eth 1e100000.ethernet eth0: Link is Up - 1Gbps/Full - flow control rx/tx
Fri Mar 31 02:41:30 2023 kern.info kernel: [    8.658855] mt7530 mdio-bus:1f lan1: configuring for phy/gmii link mode
Fri Mar 31 02:41:30 2023 kern.info kernel: [    8.667699] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
Fri Mar 31 02:41:30 2023 kern.notice kernel: [   10.860866] UBIFS (ubi0:1): Mounting in unauthenticated mode
Fri Mar 31 02:41:30 2023 kern.notice kernel: [   10.866864] UBIFS (ubi0:1): background thread "ubifs_bgt0_1" started, PID 454
Fri Mar 31 02:41:30 2023 kern.notice kernel: [   10.949690] UBIFS (ubi0:1): recovery needed
Fri Mar 31 02:41:30 2023 kern.notice kernel: [   11.138295] UBIFS (ubi0:1): recovery completed
Fri Mar 31 02:41:30 2023 kern.notice kernel: [   11.142905] UBIFS (ubi0:1): UBIFS: mounted UBI device 0, volume 1, name "rootfs_data"
Fri Mar 31 02:41:30 2023 kern.notice kernel: [   11.150722] UBIFS (ubi0:1): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
Fri Mar 31 02:41:30 2023 kern.notice kernel: [   11.160613] UBIFS (ubi0:1): FS size: 38346752 bytes (36 MiB, 302 LEBs), max 312 LEBs, journal size 1904640 bytes (1 MiB, 15 LEBs)
Fri Mar 31 02:41:30 2023 kern.notice kernel: [   11.172252] UBIFS (ubi0:1): reserved for root: 1811211 bytes (1768 KiB)
Fri Mar 31 02:41:30 2023 kern.notice kernel: [   11.178880] UBIFS (ubi0:1): media format: w5/r0 (latest is w5/r0), UUID 8D0D3A4C-46C4-413A-BD25-C1423E569222, small LPT model
Fri Mar 31 02:41:30 2023 user.info kernel: [   11.194485] mount_root: switching to ubifs overlay
Fri Mar 31 02:41:30 2023 user.warn kernel: [   11.215817] urandom-seed: Seeding with /etc/urandom.seed
Fri Mar 31 02:41:30 2023 user.info kernel: [   11.332982] procd: - early -
Fri Mar 31 02:41:30 2023 user.info kernel: [   11.336104] procd: - watchdog -
Fri Mar 31 02:41:30 2023 user.info kernel: [   11.948455] procd: - watchdog -
Fri Mar 31 02:41:30 2023 user.info kernel: [   11.952510] procd: - ubus -
Fri Mar 31 02:41:30 2023 kern.notice kernel: [   12.044862] random: ubusd: uninitialized urandom read (4 bytes read)
Fri Mar 31 02:41:30 2023 kern.notice kernel: [   12.053603] random: ubusd: uninitialized urandom read (4 bytes read)
Fri Mar 31 02:41:30 2023 kern.notice kernel: [   12.060554] random: ubusd: uninitialized urandom read (4 bytes read)
Fri Mar 31 02:41:30 2023 user.info kernel: [   12.076027] procd: - init -
Fri Mar 31 02:41:30 2023 user.info kernel: [   12.707704] kmodloader: loading kernel modules from /etc/modules.d/*
Fri Mar 31 02:41:30 2023 user.info kernel: [   12.861761] urngd: v1.0.2 started.
Fri Mar 31 02:41:30 2023 kern.info kernel: [   12.907581] Loading modules backported from Linux version v6.1-rc8-0-g76dcd734eca2
Fri Mar 31 02:41:30 2023 kern.info kernel: [   12.915272] Backport generated by backports.git v5.15.81-1-41-g02e352527db5
Fri Mar 31 02:41:30 2023 kern.notice kernel: [   13.049211] random: crng init done
Fri Mar 31 02:41:30 2023 kern.notice kernel: [   13.052647] random: 31 urandom warning(s) missed due to ratelimiting
Fri Mar 31 02:41:30 2023 kern.info kernel: [   13.104735] pci 0000:00:00.0: enabling device (0000 -> 0003)
Fri Mar 31 02:41:30 2023 kern.info kernel: [   13.110459] mt7915e_hif 0000:01:00.0: enabling device (0000 -> 0002)
Fri Mar 31 02:41:30 2023 kern.info kernel: [   13.117280] pci 0000:00:01.0: enabling device (0000 -> 0003)
Fri Mar 31 02:41:30 2023 kern.info kernel: [   13.122994] mt7915e 0000:02:00.0: enabling device (0000 -> 0002)
Fri Mar 31 02:41:30 2023 kern.info kernel: [   13.397339] mt7915e 0000:02:00.0: HW/SW Version: 0x8a108a10, Build Time: 20220929104113a
Fri Mar 31 02:41:30 2023 kern.info kernel: [   13.397339]
Fri Mar 31 02:41:30 2023 kern.info kernel: [   13.727139] mt7915e 0000:02:00.0: WM Firmware Version: ____000000, Build Time: 20220929104145
Fri Mar 31 02:41:30 2023 kern.info kernel: [   13.760826] mt7915e 0000:02:00.0: WA Firmware Version: DEV_000000, Build Time: 20220929104205
Fri Mar 31 02:41:30 2023 kern.info kernel: [   13.940159] PPP generic driver version 2.4.2
Fri Mar 31 02:41:30 2023 kern.info kernel: [   13.946426] NET: Registered PF_PPPOX protocol family
Fri Mar 31 02:41:30 2023 user.info kernel: [   13.960318] kmodloader: done loading kernel modules from /etc/modules.d/*
Fri Mar 31 02:41:31 2023 user.notice dnsmasq: DNS rebinding protection is active, will discard upstream RFC1918 responses!
Fri Mar 31 02:41:32 2023 user.notice dnsmasq: Allowing 127.0.0.0/8 responses
Fri Mar 31 02:41:32 2023 daemon.info dnsmasq[1]: started, version 2.89 cachesize 1000
Fri Mar 31 02:41:32 2023 daemon.info dnsmasq[1]: DNS service limited to local subnets
Fri Mar 31 02:41:32 2023 daemon.info dnsmasq[1]: compile time options: IPv6 GNU-getopt no-DBus UBus no-i18n no-IDN DHCP no-DHCPv6 no-Lua TFTP no-conntrack no-ipset no-nftset no-auth no-cryptohash no-DNSSEC no-ID loop-detect inotify dumpfile
Fri Mar 31 02:41:32 2023 daemon.info dnsmasq[1]: UBus support enabled: connected to system bus
Fri Mar 31 02:41:32 2023 daemon.info dnsmasq[1]: using only locally-known addresses for test
Fri Mar 31 02:41:32 2023 daemon.info dnsmasq[1]: using only locally-known addresses for onion
Fri Mar 31 02:41:32 2023 daemon.info dnsmasq[1]: using only locally-known addresses for localhost
Fri Mar 31 02:41:32 2023 daemon.info dnsmasq[1]: using only locally-known addresses for local
Fri Mar 31 02:41:32 2023 daemon.info dnsmasq[1]: using only locally-known addresses for invalid
Fri Mar 31 02:41:32 2023 daemon.info dnsmasq[1]: using only locally-known addresses for bind
Fri Mar 31 02:41:32 2023 daemon.info dnsmasq[1]: using only locally-known addresses for lan
Fri Mar 31 02:41:32 2023 daemon.warn dnsmasq[1]: no servers found in /tmp/resolv.conf.d/resolv.conf.auto, will retry
Fri Mar 31 02:41:32 2023 daemon.info dnsmasq[1]: read /etc/hosts - 12 names
Fri Mar 31 02:41:32 2023 daemon.info dnsmasq[1]: read /tmp/hosts/dhcp.cfg01411c - 0 names
Fri Mar 31 02:41:32 2023 authpriv.info dropbear[1163]: Not backgrounding
Fri Mar 31 02:41:34 2023 daemon.notice wpa_supplicant[1271]: Successfully initialized wpa_supplicant
Fri Mar 31 02:41:34 2023 user.notice : Added device handler type: bonding
Fri Mar 31 02:41:34 2023 user.notice : Added device handler type: 8021ad
Fri Mar 31 02:41:34 2023 user.notice : Added device handler type: 8021q
Fri Mar 31 02:41:34 2023 user.notice : Added device handler type: macvlan
Fri Mar 31 02:41:34 2023 user.notice : Added device handler type: veth
Fri Mar 31 02:41:34 2023 user.notice : Added device handler type: bridge
Fri Mar 31 02:41:34 2023 user.notice : Added device handler type: Network device
Fri Mar 31 02:41:34 2023 user.notice : Added device handler type: tunnel
Fri Mar 31 02:41:35 2023 daemon.notice procd: /etc/rc.d/S25packet_steering: sh: write error: No such file or directory
Fri Mar 31 02:41:35 2023 daemon.notice procd: /etc/rc.d/S25packet_steering: sh: write error: No such file or directory
Fri Mar 31 02:41:35 2023 daemon.notice procd: /etc/rc.d/S50uhttpd: 4+0 records in
Fri Mar 31 02:41:35 2023 daemon.notice procd: /etc/rc.d/S50uhttpd: 4+0 records out
Fri Mar 31 02:41:36 2023 user.notice ucitrack: Setting up /etc/config/dhcp reload dependency on /etc/config/network
Fri Mar 31 02:41:36 2023 user.notice ucitrack: Setting up /etc/config/network reload dependency on /etc/config/wireless
Fri Mar 31 02:41:36 2023 user.notice ucitrack: Setting up /etc/config/luci-splash reload dependency on /etc/config/firewall
Fri Mar 31 02:41:36 2023 user.notice ucitrack: Setting up /etc/config/qos reload dependency on /etc/config/firewall
Fri Mar 31 02:41:36 2023 user.notice ucitrack: Setting up /etc/config/miniupnpd reload dependency on /etc/config/firewall
Fri Mar 31 02:41:36 2023 user.notice ucitrack: Setting up /etc/config/odhcpd reload dependency on /etc/config/dhcp
Fri Mar 31 02:41:36 2023 user.notice ucitrack: Setting up non-init /etc/config/fstab reload handler: /sbin/block mount
Fri Mar 31 02:41:36 2023 user.notice ucitrack: Setting up /etc/config/system reload trigger for non-procd /etc/init.d/led
Fri Mar 31 02:41:37 2023 user.notice ucitrack: Setting up /etc/config/luci_statistics reload dependency on /etc/config/system
Fri Mar 31 02:41:37 2023 user.notice ucitrack: Setting up /etc/config/dhcp reload dependency on /etc/config/system
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.783330] mtk_soc_eth 1e100000.ethernet eth0: Link is Down
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.812913] mtk_soc_eth 1e100000.ethernet eth0: configuring for fixed/rgmii link mode
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.821258] mtk_soc_eth 1e100000.ethernet eth0: Link is Up - 1Gbps/Full - flow control rx/tx
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.830748] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.842686] mt7530 mdio-bus:1f lan1: configuring for phy/gmii link mode
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.851659] br-lan: port 1(lan1) entered blocking state
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.856949] br-lan: port 1(lan1) entered disabled state
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.865993] device lan1 entered promiscuous mode
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.870772] device eth0 entered promiscuous mode
Fri Mar 31 02:41:37 2023 daemon.notice netifd: Interface 'lan' is enabled
Fri Mar 31 02:41:37 2023 daemon.notice netifd: Interface 'lan' is setting up now
Fri Mar 31 02:41:37 2023 daemon.notice netifd: Interface 'lan' is now up
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.913535] mt7530 mdio-bus:1f lan2: configuring for phy/gmii link mode
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.922593] br-lan: port 2(lan2) entered blocking state
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.927892] br-lan: port 2(lan2) entered disabled state
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.937321] device lan2 entered promiscuous mode
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.953478] mt7530 mdio-bus:1f lan3: configuring for phy/gmii link mode
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.961846] br-lan: port 3(lan3) entered blocking state
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.967116] br-lan: port 3(lan3) entered disabled state
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.974877] device lan3 entered promiscuous mode
Fri Mar 31 02:41:37 2023 daemon.notice netifd: Interface 'loopback' is enabled
Fri Mar 31 02:41:37 2023 daemon.notice netifd: Interface 'loopback' is setting up now
Fri Mar 31 02:41:37 2023 daemon.notice netifd: Interface 'loopback' is now up
Fri Mar 31 02:41:37 2023 kern.info kernel: [   21.995455] mtk_soc_eth 1e100000.ethernet wan: PHY [mdio-bus:00] driver [MediaTek MT7530 PHY] (irq=POLL)
Fri Mar 31 02:41:37 2023 kern.info kernel: [   22.005094] mtk_soc_eth 1e100000.ethernet wan: configuring for phy/rgmii link mode
Fri Mar 31 02:41:37 2023 daemon.notice netifd: Interface 'wan' is enabled
Fri Mar 31 02:41:37 2023 daemon.notice netifd: Interface 'wan6' is enabled
Fri Mar 31 02:41:37 2023 daemon.notice netifd: Network device 'eth0' link is up
Fri Mar 31 02:41:37 2023 daemon.notice netifd: Network device 'lo' link is up
Fri Mar 31 02:41:37 2023 daemon.notice netifd: Interface 'loopback' has link connectivity
Fri Mar 31 02:41:37 2023 daemon.notice procd: /etc/rc.d/S96led: setting up led USB
Fri Mar 31 02:41:37 2023 daemon.notice procd: /etc/rc.d/S96led: setting up led WiFi 2.4GHz
Fri Mar 31 02:41:37 2023 daemon.notice procd: /etc/rc.d/S96led: setting up led WiFi 5GHz
Fri Mar 31 02:41:38 2023 user.notice firewall: Reloading firewall due to ifup of lan (br-lan)
Fri Mar 31 02:41:38 2023 daemon.info procd: - init complete -
Fri Mar 31 02:41:40 2023 kern.info kernel: [   25.253199] mt7530 mdio-bus:1f lan2: Link is Up - 1Gbps/Full - flow control off
Fri Mar 31 02:41:40 2023 kern.info kernel: [   25.260608] br-lan: port 2(lan2) entered blocking state
Fri Mar 31 02:41:40 2023 kern.info kernel: [   25.265823] br-lan: port 2(lan2) entered forwarding state
Fri Mar 31 02:41:40 2023 kern.info kernel: [   25.271973] IPv6: ADDRCONF(NETDEV_CHANGE): br-lan: link becomes ready
Fri Mar 31 02:41:40 2023 daemon.notice netifd: Network device 'lan2' link is up
Fri Mar 31 02:41:40 2023 daemon.notice netifd: bridge 'br-lan' link is up
Fri Mar 31 02:41:40 2023 daemon.notice netifd: Interface 'lan' has link connectivity
Fri Mar 31 02:41:41 2023 daemon.err odhcpd[1539]: Failed to send to fe80::9e5c:8eff:fec0:8491%lan@br-lan (Address not available)
Fri Mar 31 02:41:41 2023 daemon.info dnsmasq[1]: read /etc/hosts - 12 names
Fri Mar 31 02:41:41 2023 daemon.info dnsmasq[1]: read /tmp/hosts/dhcp.cfg01411c - 0 names
Fri Mar 31 02:41:41 2023 daemon.info dnsmasq[1]: read /tmp/hosts/dhcp.cfg01411c.2155 - 0 names
Fri Mar 31 02:41:41 2023 daemon.info dnsmasq[1]: read /tmp/hosts/odhcpd - 0 names
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: exiting on receipt of SIGTERM
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: started, version 2.89 cachesize 1000
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: DNS service limited to local subnets
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: compile time options: IPv6 GNU-getopt no-DBus UBus no-i18n no-IDN DHCP no-DHCPv6 no-Lua TFTP no-conntrack no-ipset no-nftset no-auth no-cryptohash no-DNSSEC no-ID loop-detect inotify dumpfile
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: UBus support enabled: connected to system bus
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq-dhcp[1]: DHCP, IP range 192.168.1.100 -- 192.168.1.249, lease time 12h
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: using only locally-known addresses for test
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: using only locally-known addresses for onion
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: using only locally-known addresses for localhost
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: using only locally-known addresses for local
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: using only locally-known addresses for invalid
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: using only locally-known addresses for bind
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: using only locally-known addresses for lan
Fri Mar 31 02:41:42 2023 daemon.warn dnsmasq[1]: no servers found in /tmp/resolv.conf.d/resolv.conf.auto, will retry
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: read /etc/hosts - 12 names
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: read /tmp/hosts/dhcp.cfg01411c - 2 names
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: read /tmp/hosts/odhcpd - 0 names
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq-dhcp[1]: read /etc/ethers - 0 addresses
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq-dhcp[1]: DHCPREQUEST(br-lan) 192.168.51.21 9c:5c:8e:c0:84:91
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq-dhcp[1]: DHCPNAK(br-lan) 192.168.51.21 9c:5c:8e:c0:84:91 wrong network
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: read /etc/hosts - 12 names
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: read /tmp/hosts/dhcp.cfg01411c - 2 names
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq[1]: read /tmp/hosts/odhcpd - 2 names
Fri Mar 31 02:41:42 2023 daemon.info dnsmasq-dhcp[1]: read /etc/ethers - 0 addresses
Fri Mar 31 02:41:45 2023 daemon.warn odhcpd[1539]: No default route present, overriding ra_lifetime!
Fri Mar 31 02:41:46 2023 daemon.info dnsmasq-dhcp[1]: DHCPDISCOVER(br-lan) 9c:5c:8e:c0:84:91
Fri Mar 31 02:41:46 2023 daemon.info dnsmasq-dhcp[1]: DHCPOFFER(br-lan) 192.168.1.211 9c:5c:8e:c0:84:91
Fri Mar 31 02:41:46 2023 daemon.info dnsmasq[1]: read /etc/hosts - 12 names
Fri Mar 31 02:41:46 2023 daemon.info dnsmasq[1]: read /tmp/hosts/dhcp.cfg01411c - 2 names
Fri Mar 31 02:41:46 2023 daemon.info dnsmasq[1]: read /tmp/hosts/odhcpd - 2 names
Fri Mar 31 02:41:46 2023 daemon.info dnsmasq-dhcp[1]: read /etc/ethers - 0 addresses
Fri Mar 31 02:41:46 2023 daemon.info dnsmasq-dhcp[1]: DHCPREQUEST(br-lan) 192.168.1.211 9c:5c:8e:c0:84:91
Fri Mar 31 02:41:46 2023 daemon.info dnsmasq-dhcp[1]: DHCPACK(br-lan) 192.168.1.211 9c:5c:8e:c0:84:91 Felix-Desktop
Fri Mar 31 02:41:49 2023 daemon.warn odhcpd[1539]: No default route present, overriding ra_lifetime!
Fri Mar 31 02:41:57 2023 daemon.warn odhcpd[1539]: No default route present, overriding ra_lifetime!
Fri Mar 31 02:50:12 2023 daemon.warn odhcpd[1539]: No default route present, overriding ra_lifetime!
Fri Mar 31 02:54:57 2023 authpriv.info dropbear[2982]: Child connection from 192.168.1.211:1074
Fri Mar 31 02:55:00 2023 authpriv.notice dropbear[2982]: Auth succeeded with blank password for 'root' from 192.168.1.211:1074
  ```
</details>