### PR TITLE
musl: Fix symbol loading in gdb

### DIFF
--- a/toolchain/musl/patches/800-mips_pie_debug.patch
+++ b/toolchain/musl/patches/800-mips_pie_debug.patch
@@ -1,0 +1,61 @@
+Fix DT_DEBUG handling on MIPS in musl libc.
+With this change gdb will load the symbol files for shared libraries on MIPS too.
+
+This patch was taken from this thread: https://www.openwall.com/lists/musl/2022/01/09/4
+
+--- a/arch/mips/reloc.h
++++ b/arch/mips/reloc.h
+@@ -29,6 +29,7 @@
+ 
+ #define NEED_MIPS_GOT_RELOCS 1
+ #define DT_DEBUG_INDIRECT DT_MIPS_RLD_MAP
++#define DT_DEBUG_INDIRECT_REL DT_MIPS_RLD_MAP_REL
+ #define ARCH_SYM_REJECT_UND(s) (!((s)->st_other & STO_MIPS_PLT))
+ 
+ #define CRTJMP(pc,sp) __asm__ __volatile__( \
+--- a/arch/mips64/reloc.h
++++ b/arch/mips64/reloc.h
+@@ -38,6 +38,7 @@
+ 
+ #define NEED_MIPS_GOT_RELOCS 1
+ #define DT_DEBUG_INDIRECT DT_MIPS_RLD_MAP
++#define DT_DEBUG_INDIRECT_REL DT_MIPS_RLD_MAP_REL
+ #define ARCH_SYM_REJECT_UND(s) (!((s)->st_other & STO_MIPS_PLT))
+ 
+ #define CRTJMP(pc,sp) __asm__ __volatile__( \
+--- a/arch/mipsn32/reloc.h
++++ b/arch/mipsn32/reloc.h
+@@ -29,6 +29,7 @@
+ 
+ #define NEED_MIPS_GOT_RELOCS 1
+ #define DT_DEBUG_INDIRECT DT_MIPS_RLD_MAP
++#define DT_DEBUG_INDIRECT_REL DT_MIPS_RLD_MAP_REL
+ #define ARCH_SYM_REJECT_UND(s) (!((s)->st_other & STO_MIPS_PLT))
+ 
+ #define CRTJMP(pc,sp) __asm__ __volatile__( \
+--- a/ldso/dynlink.c
++++ b/ldso/dynlink.c
+@@ -1923,6 +1923,10 @@ void __dls3(size_t *sp, size_t *auxv)
+ 			size_t *ptr = (size_t *) app.dynv[i+1];
+ 			*ptr = (size_t)&debug;
+ 		}
++		if (app.dynv[i]==DT_DEBUG_INDIRECT_REL) {
++			size_t *ptr = (size_t *)((size_t)&app.dynv[i] + app.dynv[i+1]);
++			*ptr = (size_t)&debug;
++		}
+ 	}
+ 
+ 	/* This must be done before final relocations, since it calls
+--- a/src/internal/dynlink.h
++++ b/src/internal/dynlink.h
+@@ -92,6 +92,10 @@ struct fdpic_dummy_loadmap {
+ #define DT_DEBUG_INDIRECT 0
+ #endif
+ 
++#ifndef DT_DEBUG_INDIRECT_REL
++#define DT_DEBUG_INDIRECT_REL 0
++#endif
++
+ #define AUX_CNT 32
+ #define DYN_CNT 32
+ 


### PR DESCRIPTION
Fix DT_DEBUG handling on MIPS in musl libc.
With this change gdb will load the symbol files for shared libraries on MIPS too.

This patch was taken from this thread: https://www.openwall.com/lists/musl/2022/01/09/4

Signed-off-by: Hauke Mehrtens <hmehrtens@maxlinear.com>