### PR TITLE
mediatek: mt7622: Disable mediatek bmt for Xiaomi AX6S

### DIFF
--- a/target/linux/mediatek/dts/mt7622-xiaomi-redmi-router-ax6s.dts
+++ b/target/linux/mediatek/dts/mt7622-xiaomi-redmi-router-ax6s.dts
@@ -227,10 +227,6 @@
 		spi-rx-bus-width = <4>;
 		nand-ecc-engine = <&snfi>;
 
-		mediatek,bmt-v2;
-		mediatek,bmt-table-size = <0x1000>;
-		mediatek,bmt-remap-range = <0x0 0x6c0000>;
-
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;


### PR DESCRIPTION
Bad block management driver silently shifts mtd offsets when it marks block as bad. But neither stock uboot, nor "fixed-partitions" respect this shifting. This leads to various problems:
 - soft-bricking device after sysupgrade because kernel is written at the wrong offset (from uboot's point of view)
 - inability to load configuration and radio calibration data from "factory" partition because partition offset is shifted

To fix the problem, disable bad block management driver until proper support for BBT management is implemented.

Signed-off-by: Eugene Konev <uejikov@gmail.com>
