### PR TITLE
boot/uboot-mediatek: Fix ramips/mt76x8 buildbot

### DIFF
--- a/package/boot/uboot-mediatek/patches/420-add-support-for-RAVPower-RP-WD009.patch
+++ b/package/boot/uboot-mediatek/patches/420-add-support-for-RAVPower-RP-WD009.patch
@@ -125,7 +125,7 @@ Subject: [PATCH] add support for RAVPower RP-WD009
 +}
 --- /dev/null
 +++ b/configs/ravpower-rp-wd009-ram_defconfig
-@@ -0,0 +1,61 @@
+@@ -0,0 +1,64 @@
 +CONFIG_MIPS=y
 +CONFIG_SYS_LOAD_ADDR=0x80010000
 +CONFIG_NR_DRAM_BANKS=1
@@ -140,6 +140,7 @@ Subject: [PATCH] add support for RAVPower RP-WD009
 +CONFIG_SYS_CONSOLE_INFO_QUIET=y
 +CONFIG_VERSION_VARIABLE=y
 +CONFIG_BOARD_RAVPOWER_RP_WD009=y
++CONFIG_SYS_MIPS_TIMER_FREQ=290000000
 +CONFIG_HUSH_PARSER=y
 +CONFIG_CMD_LICENSE=y
 +# CONFIG_CMD_ELF is not set
@@ -187,9 +188,11 @@ Subject: [PATCH] add support for RAVPower RP-WD009
 +CONFIG_WDT_MT7621=y
 +CONFIG_LZMA=y
 +CONFIG_BAUDRATE=57600
++CONFIG_SYS_MAXARGS=64
++CONFIG_SYS_CBSIZE=512
 --- /dev/null
 +++ b/include/configs/ravpower-rp-wd009.h
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,40 @@
 +/* SPDX-License-Identifier: GPL-2.0+ */
 +/*
 + * Copyright (C) 2018 Stefan Roese <sr@denx.de>
@@ -219,9 +222,7 @@ Subject: [PATCH] add support for RAVPower RP-WD009
 +#define CONFIG_SYS_MEMTEST_END		0x80400000
 +
 +/* Memory usage */
-+#define CONFIG_SYS_MAXARGS		64
 +#define CONFIG_SYS_BOOTPARAMS_LEN	(128 * 1024)
-+#define CONFIG_SYS_CBSIZE		512
 +
 +/* Environment settings */
 +


### PR DESCRIPTION
The build hangs in make syncconfig for u-boot-ravpower_rp-wd009 
Because CONFIG_SYS_MIPS_TIMER_FREQ is not in the .config, the build hangs in a console prompt for the value. 
Move defines from header to defconfig

Signed-off-by: Jo Deisenhofer <jo.deisenhofer@gmail.com>