### PR TITLE
uboot-envtools: ipq40xx: fix WHW03V2 mtd partition

### DIFF
--- a/package/boot/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-envtools/files/ipq40xx
@@ -60,12 +60,14 @@ linksys,ea6350v3)
 	ubootenv_add_uci_config "/dev/mtd7" "0x0" "0x20000" "0x20000"
 	;;
 linksys,ea8300|\
-linksys,mr8300|\
-linksys,whw03v2)
+linksys,mr8300)
 	ubootenv_add_uci_config "/dev/mtd7" "0x0" "0x40000" "0x20000"
 	;;
 linksys,whw01)
 	ubootenv_add_uci_config "/dev/mtd6" "0x0" "0x40000" "0x10000"
+	;;
+linksys,whw03v2)
+	ubootenv_add_uci_config "/dev/mtd6" "0x0" "0x80000" "0x20000"
 	;;
 zyxel,nbg6617)
 	ubootenv_add_uci_config "/dev/mtd6" "0x0" "0x10000" "0x10000"


### PR DESCRIPTION
The configured u_env partition for the Linksys WHW03 V2 was not correct.
It should have been set to mtd6.

This fix allow to flash the OEM firmware from OpenWRT and to change the
boot partition using fw_setenv.

Signed-off-by: Vincent Tremblay <vincent@vtremblay.dev>