### PR TITLE
bpf: ignore missing LLVM bins on package for non compile steps

### DIFF
--- a/include/bpf.mk
+++ b/include/bpf.mk
@@ -64,7 +64,7 @@ BPF_CFLAGS := \
 	-O2 -emit-llvm -Xclang -disable-llvm-passes
 
 ifneq ($(CONFIG_HAS_BPF_TOOLCHAIN),)
-ifeq ($(DUMP),)
+ifeq ($(DUMP)$(filter download refresh,$(MAKECMDGOALS)),)
   CLANG_VER:=$(shell $(CLANG) -dM -E - < /dev/null | grep __clang_major__ | cut -d' ' -f3)
   CLANG_VER_VALID:=$(shell [ "$(CLANG_VER)" -ge "$(CLANG_MIN_VER)" ] && echo 1 )
   ifeq ($(CLANG_VER_VALID),)


### PR DESCRIPTION
To download a package the LLVM bins are not strictly needed. Currently with an example run of make package/bridger/download V=s, the build fail with

make[2]: Entering directory '/home/ansuel/openwrt-ansuel/openwrt/package/network/services/bridger' bash: line 1: /home/ansuel/openwrt-ansuel/openwrt/staging_dir/host/llvm-bpf/bin/clang: No such file or directory bash: line 1: [: : integer expression expected
/home/ansuel/openwrt-ansuel/openwrt/include/bpf.mk:71: *** ERROR: LLVM/clang version too old. Minimum required: 12, found: .  Stop. make[2]: Leaving directory '/home/ansuel/openwrt-ansuel/openwrt/package/network/services/bridger' time: package/network/services/bridger/download#0.04#0.00#0.06
    ERROR: package/network/services/bridger failed to build.

This is wrong since it may be needed to download the required packages first and then compile them later.

Fix this by ignoring the LLVM bin check on non compile steps.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

---

@neheb @hauke @nbd168 this was catched by the reproducible tests that first download the packet and then compile them... this result in the build failing with the missing LLVM error.