### PR TITLE
xdp-tools: fix compilation wrongly using host header

### DIFF
--- a/package/kernel/bpf-headers/patches/101-linux-netlink-drop-NL_SET_ERR_MSG-for-kernel-modules.patch
+++ b/package/kernel/bpf-headers/patches/101-linux-netlink-drop-NL_SET_ERR_MSG-for-kernel-modules.patch
@@ -1,0 +1,30 @@
+From 7ed95633bff19950069c348b94c9c13164a57a2a Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Wed, 18 Jan 2023 20:20:39 +0100
+Subject: [PATCH] linux/netlink: drop NL_SET_ERR_MSG for kernel modules
+
+We don't need NL_SET_ERR_MSG_MOD for bpf modules and we can drop it to
+solve missing KBUILD_MODNAME define.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ include/linux/netlink.h | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/include/linux/netlink.h b/include/linux/netlink.h
+index 61b1c7f..93561fb 100644
+--- a/include/linux/netlink.h
++++ b/include/linux/netlink.h
+@@ -98,9 +98,6 @@ struct netlink_ext_ack {
+ 		__extack->_msg = __msg;			\
+ } while (0)
+ 
+-#define NL_SET_ERR_MSG_MOD(extack, msg)			\
+-	NL_SET_ERR_MSG((extack), KBUILD_MODNAME ": " msg)
+-
+ #define NL_SET_BAD_ATTR_POLICY(extack, attr, pol) do {	\
+ 	if ((extack)) {					\
+ 		(extack)->bad_attr = (attr);		\
+-- 
+2.38.1
+

--- a/package/kernel/bpf-headers/patches/102-net-flow_offload-use-NL_SET_ERR_MSG-instead-of-NL_SE.patch
+++ b/package/kernel/bpf-headers/patches/102-net-flow_offload-use-NL_SET_ERR_MSG-instead-of-NL_SE.patch
@@ -1,0 +1,44 @@
+From 6e7cd9c0abffea55e39a4160949bc6fba972d161 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Thu, 19 Jan 2023 13:37:46 +0100
+Subject: [PATCH] net/flow_offload: use NL_SET_ERR_MSG instead of
+ NL_SET_ERR_MSG_MOD
+
+Use NL_SET_ERR_MSG instead of NL_SET_ERR_MSG_MOD for bpf modules as
+kernel modules are not supported.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ include/net/flow_offload.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/net/flow_offload.h b/include/net/flow_offload.h
+index 7a2b022..f17c485 100644
+--- a/include/net/flow_offload.h
++++ b/include/net/flow_offload.h
+@@ -321,7 +321,7 @@ flow_action_mixed_hw_stats_check(const struct flow_action *action,
+ 
+ 	flow_action_for_each(i, action_entry, action) {
+ 		if (i && action_entry->hw_stats != last_hw_stats) {
+-			NL_SET_ERR_MSG_MOD(extack, "Mixing HW stats types for actions is not supported");
++			NL_SET_ERR_MSG(extack, "Mixing HW stats types for actions is not supported");
+ 			return false;
+ 		}
+ 		last_hw_stats = action_entry->hw_stats;
+@@ -356,11 +356,11 @@ __flow_action_hw_stats_check(const struct flow_action *action,
+ 
+ 	if (!check_allow_bit &&
+ 	    ~action_entry->hw_stats & FLOW_ACTION_HW_STATS_ANY) {
+-		NL_SET_ERR_MSG_MOD(extack, "Driver supports only default HW stats type \"any\"");
++		NL_SET_ERR_MSG(extack, "Driver supports only default HW stats type \"any\"");
+ 		return false;
+ 	} else if (check_allow_bit &&
+ 		   !(action_entry->hw_stats & BIT(allow_bit))) {
+-		NL_SET_ERR_MSG_MOD(extack, "Driver does not support selected HW stats type");
++		NL_SET_ERR_MSG(extack, "Driver does not support selected HW stats type");
+ 		return false;
+ 	}
+ 	return true;
+-- 
+2.38.1
+

--- a/package/network/utils/xdp-tools/Makefile
+++ b/package/network/utils/xdp-tools/Makefile
@@ -85,8 +85,13 @@ CONFIGURE_VARS += \
 	CFLAGS="$(TARGET_CFLAGS)" \
 	LDFLAGS="$(TARGET_LDFLAGS)" \
 	CLANG="$(CLANG)" \
-	BPF_TARGET="$(BPF_TARGET)" \
-	LLC="$(LLVM_LLC)"
+	BPF_TARGET="$(BPF_ARCH)-linux-gnu" \
+	LLC="$(LLVM_LLC)" \
+	BPF_LDFLAGS="-march=$(BPF_TARGET) -mcpu=v3"
+
+ifneq ($(findstring c,$(OPENWRT_VERBOSE)),)
+	MAKE_FLAGS+=V=1
+endif
 
 MAKE_VARS += \
 	PREFIX=/usr \
@@ -94,7 +99,7 @@ MAKE_VARS += \
 
 define Build/Configure
 	$(call Build/Configure/Default)
-	echo "BPF_CFLAGS += -I$(BPF_HEADERS_DIR)/tools/lib -fno-stack-protector" >> $(PKG_BUILD_DIR)/config.mk
+	echo "BPF_CFLAGS += $(BPF_CFLAGS) -Wno-error -fno-stack-protector" >> $(PKG_BUILD_DIR)/config.mk
 endef
 
 define Build/InstallDev

--- a/package/network/utils/xdp-tools/patches/010-configure-respect-LDFLAGS.patch
+++ b/package/network/utils/xdp-tools/patches/010-configure-respect-LDFLAGS.patch
@@ -1,6 +1,6 @@
 --- a/configure
 +++ b/configure
-@@ -174,7 +174,7 @@ int main(int argc, char **argv) {
+@@ -176,7 +176,7 @@ int main(int argc, char **argv) {
      return 0;
  }
  EOF
@@ -9,7 +9,7 @@
      if [ "$?" -eq "0" ]; then
          echo "HAVE_PCAP:=y" >>$CONFIG
          [ -n "$LIBPCAP_CFLAGS" ] && echo 'CFLAGS += ' $LIBPCAP_CFLAGS >> $CONFIG
-@@ -222,7 +222,7 @@ int main(int argc, char **argv) {
+@@ -224,7 +224,7 @@ int main(int argc, char **argv) {
      return 0;
  }
  EOF
@@ -18,7 +18,7 @@
      if [ "$?" -eq "0" ]; then
          echo "HAVE_FEATURES+=${config_var}" >>"$CONFIG"
          echo "yes"
-@@ -289,7 +289,7 @@ int main(int argc, char **argv) {
+@@ -291,7 +291,7 @@ int main(int argc, char **argv) {
  }
  EOF
  

--- a/package/network/utils/xdp-tools/patches/020-libxdp-Use-__noinline__-reserved-attribute-for-XDP-d.patch
+++ b/package/network/utils/xdp-tools/patches/020-libxdp-Use-__noinline__-reserved-attribute-for-XDP-d.patch
@@ -1,0 +1,49 @@
+From 1f160c287c14b4300c4248752e20da5981c9763e Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Wed, 18 Jan 2023 19:00:54 +0100
+Subject: [PATCH] libxdp: Use __noinline__ reserved attribute for XDP
+ dispatcher
+
+The use of noinline is wrong as noline is not a reserved attribute and
+with gcc12 this became an error. Use the reserved __noinline__ attribute
+to fix compilation error.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+[a.heider: adapt lib/libxdp/protocol.org too]
+Signed-off-by: Andre Heider <a.heider@gmail.com>
+---
+ lib/libxdp/protocol.org        | 2 +-
+ lib/libxdp/xdp-dispatcher.c.in | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+--- a/lib/libxdp/protocol.org
++++ b/lib/libxdp/protocol.org
+@@ -54,7 +54,7 @@ static volatile const struct xdp_dispatc
+ /* The volatile return value prevents the compiler from assuming it knows the
+  * return value and optimising based on that.
+  */
+-__attribute__ ((noinline))
++__attribute__ ((__noinline__))
+ int prog0(struct xdp_md *ctx) {
+         volatile int ret = XDP_DISPATCHER_RETVAL;
+ 
+--- a/lib/libxdp/xdp-dispatcher.c.in
++++ b/lib/libxdp/xdp-dispatcher.c.in
+@@ -30,7 +30,7 @@ static volatile const struct xdp_dispatc
+  * return value and optimising based on that.
+  */
+ forloop(`i', `0', NUM_PROGS,
+-`__attribute__ ((noinline))
++`__attribute__ ((__noinline__))
+ int format(`prog%d', i)(struct xdp_md *ctx) {
+         volatile int ret = XDP_DISPATCHER_RETVAL;
+ 
+@@ -40,7 +40,7 @@ int format(`prog%d', i)(struct xdp_md *c
+ }
+ ')
+ 
+-__attribute__ ((noinline))
++__attribute__ ((__noinline__))
+ int compat_test(struct xdp_md *ctx) {
+         volatile int ret = XDP_DISPATCHER_RETVAL;
+ 

--- a/package/network/utils/xdp-tools/patches/021-headers-xdp-drop-vlan_hdr-as-already-defined.patch
+++ b/package/network/utils/xdp-tools/patches/021-headers-xdp-drop-vlan_hdr-as-already-defined.patch
@@ -1,0 +1,31 @@
+From bc2a11227b5bed29d33926d5ff7e707228db9e87 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Wed, 18 Jan 2023 20:07:58 +0100
+Subject: [PATCH] headers: xdp: drop vlan_hdr as already defined
+
+Drop vlan_hdr as already defined by bpf headers.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ headers/xdp/parsing_helpers.h | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+--- a/headers/xdp/parsing_helpers.h
++++ b/headers/xdp/parsing_helpers.h
+@@ -33,16 +33,6 @@ struct hdr_cursor {
+ };
+ 
+ /*
+- *	struct vlan_hdr - vlan header
+- *	@h_vlan_TCI: priority and VLAN ID
+- *	@h_vlan_encapsulated_proto: packet type ID or len
+- */
+-struct vlan_hdr {
+-	__be16	h_vlan_TCI;
+-	__be16	h_vlan_encapsulated_proto;
+-};
+-
+-/*
+  * Struct icmphdr_common represents the common part of the icmphdr and icmp6hdr
+  * structures.
+  */

--- a/package/network/utils/xdp-tools/patches/022-xdp-dump-add-missing-perf_event-include-for-bpf-and-.patch
+++ b/package/network/utils/xdp-tools/patches/022-xdp-dump-add-missing-perf_event-include-for-bpf-and-.patch
@@ -1,0 +1,34 @@
+From 0388d7447de027e0d2369d6b8a9c58ea0f8f027c Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Wed, 18 Jan 2023 20:37:12 +0100
+Subject: [PATCH] xdp-dump: add missing perf_event include for bpf and xdp
+
+Add missing perf_event include needed for struct perf_event_header for
+bpf and xdp.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ xdp-dump/xdpdump_bpf.c | 1 +
+ xdp-dump/xdpdump_xdp.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+--- a/xdp-dump/xdpdump_bpf.c
++++ b/xdp-dump/xdpdump_bpf.c
+@@ -4,6 +4,7 @@
+  * Include files
+  *****************************************************************************/
+ #include <stdbool.h>
++#include <linux/perf_event.h>
+ #include <linux/bpf.h>
+ #include <bpf/bpf_helpers.h>
+ #include <bpf/bpf_trace_helpers.h>
+--- a/xdp-dump/xdpdump_xdp.c
++++ b/xdp-dump/xdpdump_xdp.c
+@@ -4,6 +4,7 @@
+  * Include files
+  *****************************************************************************/
+ #include <stdbool.h>
++#include <linux/perf_event.h>
+ #include <linux/bpf.h>
+ #include <bpf/bpf_helpers.h>
+ #include <bpf/bpf_trace_helpers.h>

--- a/package/network/utils/xdp-tools/patches/023-libxdp-fix-compilation-on-multiarch-systems.patch
+++ b/package/network/utils/xdp-tools/patches/023-libxdp-fix-compilation-on-multiarch-systems.patch
@@ -1,0 +1,30 @@
+From cb1ef3322671a67e2050a3eee18b49cdb4ed4bed Mon Sep 17 00:00:00 2001
+From: Andre Heider <a.heider@gmail.com>
+Date: Wed, 18 Jan 2023 20:54:41 +0100
+Subject: [PATCH] libxdp: fix compilation on multiarch systems
+
+Multiarch systems require an additional include path, which is covered
+by ARCH_INCLUDES here. Just as lib/util, add it to BPF_CFLAGS.
+
+Fixes compilation on debian:
+
+In file included from xdp-dispatcher.c:3:
+In file included from ../../headers/linux/bpf.h:11:
+/usr/include/linux/types.h:5:10: fatal error: 'asm/types.h' file not found
+
+Signed-off-by: Andre Heider <a.heider@gmail.com>
+---
+ lib/libxdp/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/lib/libxdp/Makefile
++++ b/lib/libxdp/Makefile
+@@ -30,7 +30,7 @@ PC_FILE := $(OBJDIR)/libxdp.pc
+ TEMPLATED_SOURCES := xdp-dispatcher.c
+ 
+ CFLAGS += -I$(HEADER_DIR)
+-BPF_CFLAGS += -I$(HEADER_DIR)
++BPF_CFLAGS += -I$(HEADER_DIR) $(ARCH_INCLUDES)
+ 
+ 
+ ifndef BUILD_STATIC_ONLY

--- a/package/network/utils/xdp-tools/patches/024-lib-allow-overwriting-W-flags-via-BPF_CFLAGS.patch
+++ b/package/network/utils/xdp-tools/patches/024-lib-allow-overwriting-W-flags-via-BPF_CFLAGS.patch
@@ -1,0 +1,49 @@
+From e2d8eae9477f6ba41ab75ad77202f235e34c04f7 Mon Sep 17 00:00:00 2001
+From: Andre Heider <a.heider@gmail.com>
+Date: Wed, 18 Jan 2023 22:30:23 +0100
+Subject: [PATCH] lib: allow overwriting -W* flags via BPF_CFLAGS
+
+The bpf header file situation is a mess, and the default warning
+compiler flags may not be suitable everywhere, especially with -Werror
+in the mix.
+
+Move BPF_CFLAGS further down, so these can be overwritten by builders.
+
+Signed-off-by: Andre Heider <a.heider@gmail.com>
+---
+ lib/common.mk       | 2 +-
+ lib/libxdp/Makefile | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/lib/common.mk
++++ b/lib/common.mk
+@@ -108,12 +108,12 @@ $(XDP_OBJ): %.o: %.c $(KERN_USER_H) $(EX
+ 	$(QUIET_CLANG)$(CLANG) -S \
+ 	    -target $(BPF_TARGET) \
+ 	    -D __BPF_TRACING__ \
+-	    $(BPF_CFLAGS) \
+ 	    -Wall \
+ 	    -Wno-unused-value \
+ 	    -Wno-pointer-sign \
+ 	    -Wno-compare-distinct-pointer-types \
+ 	    -Werror \
++	    $(BPF_CFLAGS) \
+ 	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
+ 	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
+ 
+--- a/lib/libxdp/Makefile
++++ b/lib/libxdp/Makefile
+@@ -139,12 +139,12 @@ $(XDP_OBJS): %.o: %.c $(BPF_HEADERS) $(L
+ 	$(QUIET_CLANG)$(CLANG) -S \
+ 	    -target $(BPF_TARGET) \
+ 	    -D __BPF_TRACING__ \
+-	    $(BPF_CFLAGS) \
+ 	    -Wall \
+ 	    -Wno-unused-value \
+ 	    -Wno-pointer-sign \
+ 	    -Wno-compare-distinct-pointer-types \
+ 	    -Werror \
++	    $(BPF_CFLAGS) \
+ 	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
+ 	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
+ 

--- a/package/network/utils/xdp-tools/patches/025-Add-BPF_LDFLAGS-to-allow-overwriting-llc-s-march-arg.patch
+++ b/package/network/utils/xdp-tools/patches/025-Add-BPF_LDFLAGS-to-allow-overwriting-llc-s-march-arg.patch
@@ -1,0 +1,55 @@
+From 7b00d4a90af1d7bff50833ffe1216cf59592353a Mon Sep 17 00:00:00 2001
+From: Andre Heider <a.heider@gmail.com>
+Date: Wed, 18 Jan 2023 22:42:28 +0100
+Subject: [PATCH] Add BPF_LDFLAGS to allow overwriting llc's -march argument
+
+The argument to clang's -target isn't necessarily the same as to
+llc's -march.
+
+Analogue to BPF_CFLAGS, introduce BPF_LDFLAGS to allow e.g.:
+BPF_TARGET="mipsel-linux-gnu" BPF_LDFLAGS="-march=bpfel -mcpu=v3"
+
+Signed-off-by: Andre Heider <a.heider@gmail.com>
+---
+ configure           | 2 ++
+ lib/common.mk       | 2 +-
+ lib/libxdp/Makefile | 2 +-
+ 3 files changed, 4 insertions(+), 2 deletions(-)
+
+--- a/configure
++++ b/configure
+@@ -17,10 +17,12 @@ check_opts()
+     : ${DYNAMIC_LIBXDP:=0}
+     : ${MAX_DISPATCHER_ACTIONS:=10}
+     : ${BPF_TARGET:=bpf}
++    : ${BPF_LDFLAGS:=-march=$(BPF_TARGET)}
+     echo "PRODUCTION:=${PRODUCTION}" >>$CONFIG
+     echo "DYNAMIC_LIBXDP:=${DYNAMIC_LIBXDP}" >>$CONFIG
+     echo "MAX_DISPATCHER_ACTIONS:=${MAX_DISPATCHER_ACTIONS}" >>$CONFIG
+     echo "BPF_TARGET:=${BPF_TARGET}" >>$CONFIG
++    echo "BPF_LDFLAGS:=${BPF_LDFLAGS}" >>$CONFIG
+ }
+ 
+ find_tool()
+--- a/lib/common.mk
++++ b/lib/common.mk
+@@ -115,7 +115,7 @@ $(XDP_OBJ): %.o: %.c $(KERN_USER_H) $(EX
+ 	    -Werror \
+ 	    $(BPF_CFLAGS) \
+ 	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
+-	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
++	$(QUIET_LLC)$(LLC) $(BPF_LDFLAGS) -filetype=obj -o $@ ${@:.o=.ll}
+ 
+ .PHONY: man
+ ifeq ($(EMACS),)
+--- a/lib/libxdp/Makefile
++++ b/lib/libxdp/Makefile
+@@ -146,7 +146,7 @@ $(XDP_OBJS): %.o: %.c $(BPF_HEADERS) $(L
+ 	    -Werror \
+ 	    $(BPF_CFLAGS) \
+ 	    -O2 -emit-llvm -c -g -o ${@:.o=.ll} $<
+-	$(QUIET_LLC)$(LLC) -march=$(BPF_TARGET) -filetype=obj -o $@ ${@:.o=.ll}
++	$(QUIET_LLC)$(LLC) $(BPF_LDFLAGS) -filetype=obj -o $@ ${@:.o=.ll}
+ 
+ .PHONY: man
+ ifeq ($(EMACS),)


### PR DESCRIPTION
Currently it's needed to have gcc-multilib on the host to correctly
compile xdp-tools. This is wrong and means that we are using host header
to compile a tool.

By some searching in how the makefile works it was discovered that
BPF_CFLAGS were not used and required to be appended to config.mk

Only one single header was added but we should include each BPF_CFLAGS
from bpf.mk. To make this some patching to bpf-header were required and
some patches to xdp-tools were required.
Also it's needed to pass the correct target to BPF_CFLAGS.

With the following changes xdp-tools can correctly compile with each
header from bpf-headers and should not use any host header.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
