### PR TITLE
ath79: add support for D-Link DIR-629 A1

### DIFF
--- a/target/linux/ath79/dts/qca9558_dlink_dir-629-a1.dts
+++ b/target/linux/ath79/dts/qca9558_dlink_dir-629-a1.dts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "dlink,dir-629-a1", "qca,qca9558";
+	model = "D-Link DIR-629 A1";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		serial0 = &uart;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_power: led-1 {
+			label = "green:power";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "mii";
+
+	nvmem-cells = <&macaddr_mfcdata_35>;
+	nvmem-cell-names = "mac-address-ascii";
+
+	fixed-link {
+		speed = <100>;
+		full-duplex;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	switch0@1f {
+		compatible = "qca,ar8236";
+		reg = <0x1f>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <30000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x008000>;
+				read-only;
+			};
+
+			partition@48000 {
+				label = "mfcdata";
+				reg = <0x048000 0x008000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_mfcdata_35: macaddr@35 {
+					reg = <0x35 0x11>;
+				};
+
+				macaddr_mfcdata_51: macaddr@51 {
+					reg = <0x51 0x11>;
+				};
+			};
+
+			partition@50000 {
+				label = "devconf";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "langpack";
+				reg = <0x060000 0x020000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "art";
+				reg = <0x080000 0x010000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				cal_art_1000: calibration@1000 {
+					reg = <0x1000 0x440>;
+				};
+			};
+
+			partition@90000 {
+				compatible = "seama";
+				label = "firmware";
+				reg = <0x090000 0x770000>;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&cal_art_1000>, <&macaddr_mfcdata_51>;
+	nvmem-cell-names = "calibration", "mac-address-ascii";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -278,6 +278,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:2" "2:lan:1"
 		;;
+	dlink,dir-629-a1|\
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1|\
 	dlink,dir-842-c1|\
@@ -622,6 +623,9 @@ ath79_setup_macs()
 	dlink,dap-2695-a1|\
 	dlink,dap-3662-a1)
 		label_mac=$(mtd_get_mac_ascii bdcfg "wlanmac")
+		;;
+	dlink,dir-629-a1)
+		wan_mac=$(mtd_get_mac_text "mfcdata" 0x6a)
 		;;
 	dlink,dir-825-b1|\
 	trendnet,tew-673gru)

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/09_fix-checksum
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/09_fix-checksum
@@ -21,6 +21,7 @@ dlink,dap-3320-a1|\
 dlink,dap-3662-a1)
 	fixwrgg
 	;;
+dlink,dir-629-a1|\
 qihoo,c301)
 	fix_seama_header
 	;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1010,6 +1010,19 @@ define Device/dlink_dir-505
 endef
 TARGET_DEVICES += dlink_dir-505
 
+define Device/dlink_dir-629-a1
+  $(Device/seama)
+  SOC := qca9558
+  IMAGE_SIZE := 7616k
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DIR-629
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES := -uboot-envtools
+  SEAMA_MTDBLOCK := 6
+  SEAMA_SIGNATURE := wrgn83_dlob.hans_dir629
+endef
+TARGET_DEVICES += dlink_dir-629-a1
+
 define Device/dlink_dir-825-b1
   SOC := ar7161
   DEVICE_VENDOR := D-Link


### PR DESCRIPTION
```
Specifications:
  SOC:      QCA9588 720 MHz
  Switch:   AR8236
  RAM:      64 MiB DDR2
  Flash:    8 MiB
  WLAN:     Wi-Fi4 2.4 GHz 3*3
  LAN:      LAN ports *4
  WAN:      WAN port *1
  Buttons:  reset *1 + wps *1
  LEDs: ethernet *5, power, wlan, wps

MAC Address:
  use      address               source
  label    70:62:b8:xx:xx:96     lan && wlan
  lan      70:62:b8:xx:xx:96     mfcdata.0x35
  wan      70:62:b8:xx:xx:97     mfcdata.0x6a
  wlan     70:62:b8:xx:xx:96     mfcdata.0x51

Install via Web UI:
  Apply factory image in the stock firmware's Web UI.

Install via Emergency Room Mode:
  DIR-629 A1 will enter recovery mode when the system fails to boot or
  press reset button for about 10 seconds.

  First, set IP address to 192.168.0.1 and server IP to 192.168.0.10.
  Then we can open http://192.168.0.1 in the web browser to upload
  OpenWrt factory image or stock firmware. Some modern browsers may
  need to turn on compatibility mode.
```