### PR TITLE
openssl: fix VIA Padlock AES-192 and 256 encryption

### DIFF
--- a/package/libs/openssl/patches/010-padlock.patch
+++ b/package/libs/openssl/patches/010-padlock.patch
@@ -1,0 +1,52 @@
+From 2bcf8e69bd92e33d84c48e7d108d3d46b22f8a6d Mon Sep 17 00:00:00 2001
+From: ValdikSS <iam@valdikss.org.ru>
+Date: Wed, 18 Jan 2023 20:14:48 +0300
+Subject: [PATCH] Padlock: fix byte swapping assembly for AES-192 and 256
+
+Byte swapping code incorrectly uses the number of AES rounds to swap expanded
+AES key, while swapping only a single dword in a loop, resulting in swapped
+key and partially swapped expanded keys, breaking AES encryption and
+decryption on VIA Padlock hardware.
+
+This commit correctly sets the number of swapping loops to be done.
+
+Fixes #20073
+
+CLA: trivial
+
+Reviewed-by: Hugo Landau <hlandau@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/20077)
+
+(cherry picked from commit 7331e7ef79fe4499d81cc92249e9c97e9ff9291a)
+---
+ engines/asm/e_padlock-x86.pl    | 2 ++
+ engines/asm/e_padlock-x86_64.pl | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/engines/asm/e_padlock-x86.pl b/engines/asm/e_padlock-x86.pl
+index 5b097ce3ef9b..07f7000fd38a 100644
+--- a/engines/asm/e_padlock-x86.pl
++++ b/engines/asm/e_padlock-x86.pl
+@@ -116,6 +116,8 @@
+ &function_begin_B("padlock_key_bswap");
+ 	&mov	("edx",&wparam(0));
+ 	&mov	("ecx",&DWP(240,"edx"));
++	&inc	("ecx");
++	&shl	("ecx",2);
+ &set_label("bswap_loop");
+ 	&mov	("eax",&DWP(0,"edx"));
+ 	&bswap	("eax");
+diff --git a/engines/asm/e_padlock-x86_64.pl b/engines/asm/e_padlock-x86_64.pl
+index 09b0aaa48dfe..dfd2ae656375 100644
+--- a/engines/asm/e_padlock-x86_64.pl
++++ b/engines/asm/e_padlock-x86_64.pl
+@@ -92,6 +92,8 @@
+ .align	16
+ padlock_key_bswap:
+ 	mov	240($arg1),%edx
++	inc	%edx
++	shl	\$2,%edx
+ .Lbswap_loop:
+ 	mov	($arg1),%eax
+ 	bswap	%eax


### PR DESCRIPTION
Byte swapping code incorrectly uses the number of AES rounds to swap expanded AES key, while swapping only a single dword in a loop, resulting in swapped key and partially swapped expanded keys, breaking AES encryption and decryption on VIA Padlock hardware.

This commit correctly sets the number of swapping loops to be done.

Upstream: https://github.com/openssl/openssl/commit/2bcf8e69bd92e33d84c48e7d108d3d46b22f8a6d

Signed-off-by: ValdikSS ValdikSS <iam@valdikss.org.ru>
