### PR TITLE
ramips: improve support for Zyxel Keenetic Extra II

### DIFF
--- a/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
+++ b/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
@@ -46,7 +46,6 @@
 		led_power: power {
 			label = "green:power";
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
-			default-state = "keep";
 		};
 
 		internet {
@@ -77,6 +76,23 @@
 			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
 		};
 	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &firmware2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x0 0x1d20000>;
+			};
+		};
+	};
 };
 
 &spi0 {
@@ -85,8 +101,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
-		broken-flash-reset;
+		spi-max-frequency = <32000000>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -106,14 +121,13 @@
 			};
 
 			factory: partition@40000 {
-				label = "factory";
+				label = "rf-eeprom";
 				reg = <0x40000 0x10000>;
 				read-only;
 			};
 
-			partition@50000 {
-				compatible = "denx,uimage";
-				label = "firmware";
+			firmware1: partition@50000 {
+				label = "firmware_1";
 				reg = <0x50000 0xe90000>;
 			};
 
@@ -153,10 +167,9 @@
 				read-only;
 			};
 
-			partition@1050000 {
+			firmware2: partition@1050000 {
 				label = "firmware_2";
 				reg = <0x1050000 0xe90000>;
-				read-only;
 			};
 
 			partition@1ee0000 {
@@ -189,6 +202,7 @@
 
 &pcie0 {
 	mt76@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -1029,7 +1029,7 @@ endef
 TARGET_DEVICES += zbtlink_zbt-we1226
 
 define Device/zyxel_keenetic-extra-ii
-  IMAGE_SIZE := 14912k
+  IMAGE_SIZE := 29824k
   BLOCKSIZE := 64k
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := Keenetic Extra II

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -228,8 +228,7 @@ ramips_setup_macs()
 	netgear,r6080|\
 	netgear,r6120|\
 	wrtnode,wrtnode2p|\
-	wrtnode,wrtnode2r|\
-	zyxel,keenetic-extra-ii)
+	wrtnode,wrtnode2r)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1)
 		;;
 	hiwifi,hc5611|\
@@ -253,7 +252,8 @@ ramips_setup_macs()
 	totolink,lr1200)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		;;
-	keenetic,kn-1613)
+	keenetic,kn-1613|\
+	zyxel,keenetic-extra-ii)
 		wan_mac=$(mtd_get_mac_binary rf-eeprom 0x28)
 		;;
 	linksys,e5400)


### PR DESCRIPTION
This PR contains several minor improvements for Zyxel Keenetic Extra II. All changes have been tested.

- drop unneeded default-state for led_power
- concat firmware partitions to extend available free space
- increase spi flash frequency to 32 Mhz (value from stock firmware bootlog)
- drop broken-flash-reset because of onboard flash chip W25Q256FV has reset support
- add compatible for pcie wifi according to kernel documetation
- switch to wan mac address with offset 0x28 in rf-eeprom