### PR TITLE
realtek: use irq_force_affinity on otto timer instead

### DIFF
--- a/target/linux/realtek/files-5.10/drivers/clocksource/timer-rtl-otto.c
+++ b/target/linux/realtek/files-5.10/drivers/clocksource/timer-rtl-otto.c
@@ -244,7 +244,7 @@ static int rttm_cpu_starting(unsigned int cpu)
 
 	RTTM_DEBUG(to->of_base.base);
 	to->clkevt.cpumask = cpumask_of(cpu);
-	irq_set_affinity(to->of_irq.irq, to->clkevt.cpumask);
+	irq_force_affinity(to->of_irq.irq, to->clkevt.cpumask);
 	clockevents_config_and_register(&to->clkevt, RTTM_TICKS_PER_SEC,
 					RTTM_MIN_DELTA, RTTM_MAX_DELTA);
 	rttm_enable_irq(to->of_base.base);

--- a/target/linux/realtek/files-5.15/drivers/clocksource/timer-rtl-otto.c
+++ b/target/linux/realtek/files-5.15/drivers/clocksource/timer-rtl-otto.c
@@ -244,7 +244,7 @@ static int rttm_cpu_starting(unsigned int cpu)
 
 	RTTM_DEBUG(to->of_base.base);
 	to->clkevt.cpumask = cpumask_of(cpu);
-	irq_set_affinity(to->of_irq.irq, to->clkevt.cpumask);
+	irq_force_affinity(to->of_irq.irq, to->clkevt.cpumask);
 	clockevents_config_and_register(&to->clkevt, RTTM_TICKS_PER_SEC,
 					RTTM_MIN_DELTA, RTTM_MAX_DELTA);
 	rttm_enable_irq(to->of_base.base);


### PR DESCRIPTION
After commit e0d2c59ee9954187737110594220a53007ad0d74 ("genirq: Always limit the affinity to online CPUs", 5.10) on Linux, the cpumask passed to irq_set_affinity of irqchip driver is limited to online CPUs. When irq_do_set_affinity called from otto timer driver with only one secondary CPU, that CPU is not marked as online yet, filtered out by cpu_online_mask and fall to error path. Then, fail to set affinity for that CPU and it leads to instability of timer on secondary CPU(s).

At least, RTL839x system will be affected.

log:
```
[   23.954654] RESETTING 8390, CPU_PORT 52
[   24.205463] rtl838x-eth 1b00a300.ethernet eth0: configuring for fixed/internal link mode
[   24.312120] In rtl838x_mac_config, mode 1
[   24.366869] rtl83xx-switch switch@1b000000 lan1: configuring for phy/qsgmii link mode
[   24.470229] rtl838x-eth 1b00a300.ethernet eth0: Link is Up - 1Gbps/Full - flow control off
[   37.560020] rcu: INFO: rcu_sched detected stalls on CPUs/tasks:
[   37.638025] rcu:     1-...!: (0 ticks this GP) idle=6ac/0/0x0 softirq=0/0 fqs=1  (false positive?)
[   37.752683]  (detected by 0, t=6002 jiffies, g=-1179, q=26293)
[   37.829510] Sending NMI from CPU 0 to CPUs 1:
[   37.886857] NMI backtrace for cpu 1 skipped: idling at r4k_wait_irqoff+0x1c/0x24
[   37.984801] rcu: rcu_sched kthread timer wakeup didn't happen for 5999 jiffies! g-1179 f0x0 RCU_GP_WAIT_FQS(5) ->state=0x402
[   38.132743] rcu:     Possible timer handling issue on cpu=1 timer-softirq=0
[   38.221033] rcu: rcu_sched kthread starved for 6000 jiffies! g-1179 f0x0 RCU_GP_WAIT_FQS(5) ->state=0x402 ->cpu=1
[   38.356336] rcu:     Unless rcu_sched kthread gets sufficient CPU time, OOM is now expected behavior.
[   38.474440] rcu: RCU grace-period kthread stack dump:
[   38.540946] task:rcu_sched       state:I stack:    0 pid:   13 ppid:     2 flags:0x00100000
[   38.651024] Stack : 807d0000 800a31d4 00000000 00000000 8206be30 807d0000 80842a80 82044680
[   38.761100]         807d0000 00000001 807d0000 80842bb0 00000000 806635b8 80842bb0 00000000
[   38.871178]         80840000 80098734 ffff8c07 80667a40 807d0000 807d0000 80840000 00000000
[   38.981255]         00000000 814384fc ffff8c07 800a2548 10400001 82044680 80842a80 80842a80
[   39.091332]         00000000 8009abd4 8142fd20 8009b2d0 00000000 812e0000 80090000 8070ac0c
[   39.201409]         ...
[   39.233518] Call Trace:
[   39.265622] [<806631e0>] __schedule+0x2a8/0x618
[   39.325252] [<806635b8>] schedule+0x68/0xe4
[   39.380288] [<80667a40>] schedule_timeout+0x68/0xe0
[   39.444500] [<8009abd4>] rcu_gp_fqs_loop+0x304/0x39c
[   39.509860] [<8009d754>] rcu_gp_kthread+0x140/0x16c
[   39.574071] [<800506d0>] kthread+0x134/0x13c
[   39.630255] [<80001cd8>] ret_from_kernel_thread+0x14/0x1c
[   39.701348]
[   39.720838] rcu: Stack dump where RCU GP kthread last ran:
[   39.793077] Sending NMI from CPU 0 to CPUs 1:
[   39.850420] NMI backtrace for cpu 1 skipped: idling at r4k_wait_irqoff+0x1c/0x24
[   89.942392] random: crng init done
[   89.990040] rcu: INFO: rcu_sched detected stalls on CPUs/tasks:
[   90.068034] rcu:     1-...!: (0 ticks this GP) idle=6c8/0/0x0 softirq=0/0 fqs=0  (false positive?)
[   90.182693]  (detected by 0, t=10007 jiffies, g=-1175, q=25135)
[   90.260667] Sending NMI from CPU 0 to CPUs 1:
[   90.318014] NMI backtrace for cpu 1 skipped: idling at r4k_wait_irqoff+0x1c/0x24
[   90.415957] rcu: rcu_sched kthread timer wakeup didn't happen for 10006 jiffies! g-1175 f0x0 RCU_GP_WAIT_FQS(5) ->state=0x402
[   90.565045] rcu:     Possible timer handling issue on cpu=1 timer-softirq=0
[   90.653337] rcu: rcu_sched kthread starved for 10007 jiffies! g-1175 f0x0 RCU_GP_WAIT_FQS(5) ->state=0x402 ->cpu=1
[   90.789786] rcu:     Unless rcu_sched kthread gets sufficient CPU time, OOM is now expected behavior.
[   90.907890] rcu: RCU grace-period kthread stack dump:
[   90.974396] task:rcu_sched       state:I stack:    0 pid:   13 ppid:     2 flags:0x00100000
[   91.084474] Stack : 807d0000 800a31d4 00000000 00000000 8206be30 8143ad20 80842a80 82044680
[   91.194550]         807d0000 00000001 807d0000 80842bb0 00000001 806635b8 80842bb0 00000001
[   91.304628]         80840000 80098734 ffffa466 80667a40 807d61fc 80099e74 fffffb68 00000000
[   91.414705]         00000000 81438744 ffffa466 800a2548 34c00001 82044680 80842a80 80842a80
[   91.524782]         00000000 8009abd4 8143ad20 8009b2d0 00000000 812e0000 80090000 8070ac0c
[   91.634859]         ...
[   91.666967] Call Trace:
[   91.699072] [<806631e0>] __schedule+0x2a8/0x618
[   91.758702] [<806635b8>] schedule+0x68/0xe4
[   91.813738] [<80667a40>] schedule_timeout+0x68/0xe0
[   91.877949] [<8009abd4>] rcu_gp_fqs_loop+0x304/0x39c
[   91.943309] [<8009d754>] rcu_gp_kthread+0x140/0x16c
[   92.007521] [<800506d0>] kthread+0x134/0x13c
[   92.063705] [<80001cd8>] ret_from_kernel_thread+0x14/0x1c
[   92.134798]
[   92.154288] rcu: Stack dump where RCU GP kthread last ran:
[   92.226526] Sending NMI from CPU 0 to CPUs 1:
[   92.283870] NMI backtrace for cpu 1 skipped: idling at r4k_wait_irqoff+0x1c/0x24
...
```
Replace to irq_force_affinity from irq_set_affinity and ignore cpu_online_mask to fix the issue.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>

cc: @svanheule 