### PR TITLE
ath79: add LTE packages for GL-XE300

### DIFF
--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -199,7 +199,8 @@ define Device/glinet_gl-xe300
   SOC := qca9531
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-XE300
-  DEVICE_PACKAGES := kmod-usb2 block-mount kmod-usb-serial-ch341
+  DEVICE_PACKAGES := kmod-usb2 block-mount kmod-usb-serial-ch341 \
+	kmod-usb-net-qmi-wwan uqmi
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 131072k
   PAGESIZE := 2048


### PR DESCRIPTION
Add LTE packages required for operating the LTE modems shipped with the GL-XE300.

Would be great if this could also be backported to openwrt-22.03 if it's merged.

Signed-off-by: Tom Herbers <mail@tomherbers.de>