### PR TITLE
px5g-mbedtls: Check return of read() function

### DIFF
--- a/package/utils/px5g-mbedtls/px5g-mbedtls.c
+++ b/package/utils/px5g-mbedtls/px5g-mbedtls.c
@@ -20,6 +20,7 @@
  */
 
 #include <sys/types.h>
+#include <sys/random.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -31,6 +32,7 @@
 #include <stdbool.h>
 
 #include <mbedtls/bignum.h>
+#include <mbedtls/entropy.h>
 #include <mbedtls/x509_crt.h>
 #include <mbedtls/ecp.h>
 #include <mbedtls/rsa.h>
@@ -40,12 +42,16 @@
 #define PX5G_COPY "Copyright (c) 2009 Steven Barth <steven@midlink.org>"
 #define PX5G_LICENSE "Licensed under the GNU Lesser General Public License v2.1"
 
-static int urandom_fd;
 static char buf[16384];
 
 static int _urandom(void *ctx, unsigned char *out, size_t len)
 {
-	read(urandom_fd, out, len);
+	ssize_t ret;
+
+	ret = getrandom(out, len, 0);
+	if (ret < 0 || (size_t)ret != len)
+		return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
+
 	return 0;
 }
 
@@ -306,8 +312,6 @@ int selfsigned(char **arg)
 
 int main(int argc, char *argv[])
 {
-	urandom_fd = open("/dev/urandom", O_RDONLY);
-
 	if (!argv[1]) {
 		//Usage
 	} else if (!strcmp(argv[1], "eckey")) {


### PR DESCRIPTION
This fixes a compile error against glibc.

````
px5g-mbedtls.c: In function '_urandom':
px5g-mbedtls.c:48:9: error: ignoring return value of 'read' declared with attribute 'warn_unused_result' [-Werror=unused-result]
   48 |         read(urandom_fd, out, len);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
````

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>