### PR TITLE
CI: tools: add gnu-getopt to macOS CI 

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -47,6 +47,7 @@ jobs:
             findutils \
             gawk \
             git-extras \
+            gnu-getopt \
             gnu-sed \
             grep \
             make


### PR DESCRIPTION
This used to be implicit. No longer for some reason.

Signed-off-by: Rosen Penev <rosenp@gmail.com>
