### PR TITLE
[22.03] tools/mkimage: build uboot with NO_SDL=1

### DIFF
--- a/tools/mkimage/Makefile
+++ b/tools/mkimage/Makefile
@@ -26,6 +26,7 @@ define Host/Compile
 		HOSTLDFLAGS="$(HOST_LDFLAGS)" \
 		PKG_CONFIG_EXTRAARGS="--static" \
 		V=$(if $(findstring c,$(OPENWRT_VERBOSE)),1) \
+		NO_SDL=1 \
 		tools-only_config \
 		tools-only
 endef


### PR DESCRIPTION
From uboot Documentation for uboot-2022.01 for tools-only we can build with NO_SDL=1 to skip installing the sdl2 package.

Follow this to fix compilation error on macos

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>