### PR TITLE
base-files: Increase failsafe trigger wait time from 2 to 4 sec

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -77,7 +77,7 @@ endef
 define ImageConfigOptions
 	mkdir -p $(1)/lib/preinit
 	echo 'pi_suppress_stderr="$(CONFIG_TARGET_PREINIT_SUPPRESS_STDERR)"' >$(1)/lib/preinit/00_preinit.conf
-	echo 'fs_failsafe_wait_timeout=$(if $(CONFIG_TARGET_PREINIT_TIMEOUT),$(CONFIG_TARGET_PREINIT_TIMEOUT),2)' >>$(1)/lib/preinit/00_preinit.conf
+	echo 'fs_failsafe_wait_timeout=$(if $(CONFIG_TARGET_PREINIT_TIMEOUT),$(CONFIG_TARGET_PREINIT_TIMEOUT),4)' >>$(1)/lib/preinit/00_preinit.conf
 	echo 'pi_init_path="$(TARGET_INIT_PATH)"' >>$(1)/lib/preinit/00_preinit.conf
 	echo 'pi_init_env=$(if $(CONFIG_TARGET_INIT_ENV),$(CONFIG_TARGET_INIT_ENV),"")' >>$(1)/lib/preinit/00_preinit.conf
 	echo 'pi_init_cmd=$(if $(CONFIG_TARGET_INIT_CMD),$(CONFIG_TARGET_INIT_CMD),"/sbin/init")' >>$(1)/lib/preinit/00_preinit.conf

--- a/package/base-files/image-config.in
+++ b/package/base-files/image-config.in
@@ -44,7 +44,7 @@ config TARGET_PREINIT_DISABLE_FAILSAFE
 config TARGET_PREINIT_TIMEOUT
 	int
 	prompt "Failsafe/Debug wait timeout" if PREINITOPT
-	default 2
+	default 4
 	help
 		How long to wait for failsafe mode to be entered or for
 		a debug option to be pressed before continuing with a


### PR DESCRIPTION
Increase the failsafe waiting timeout period from 2 seconds to 4 seconds.

Since commit 29207748b in 2015 we have had a rapid LED blinking indication for the failsafe triggering period. But the really short timeout of 2 seconds requires snappy reaction time from the user to notice the rapid LED blinking and to push button inside the short window.

Relax the timeout to 4 seconds, which more easily allows to notice the change in LED blinking and push a button.

Note, this will increase the booting time by two seconds, but that should not be noticeable by most users (when compared to the total length of the boot process).

I have carried this in my own build for years, but thought to "upstream" it now.
