### PR TITLE
realtek: dgs-1210-10mp: sfp phy-handle patch

### DIFF
--- a/target/linux/realtek/dts-5.10/rtl8380_d-link_dgs-1210-10mp-f.dts
+++ b/target/linux/realtek/dts-5.10/rtl8380_d-link_dgs-1210-10mp-f.dts
@@ -112,7 +112,7 @@
 		port@24 {
 			reg = <24>;
 			label = "lan9";
-			phy-handle = <14>;
+			phy-handle = <&phy24>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp0>;
@@ -121,7 +121,7 @@
 		port@26 {
 			reg = <26>;
 			label = "lan10";
-			phy-handle = <15>;
+			phy-handle = <&phy26>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp1>;

--- a/target/linux/realtek/dts-5.15/rtl8380_d-link_dgs-1210-10mp-f.dts
+++ b/target/linux/realtek/dts-5.15/rtl8380_d-link_dgs-1210-10mp-f.dts
@@ -112,7 +112,7 @@
 		port@24 {
 			reg = <24>;
 			label = "lan9";
-			phy-handle = <14>;
+			phy-handle = <&phy24>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp0>;
@@ -121,7 +121,7 @@
 		port@26 {
 			reg = <26>;
 			label = "lan10";
-			phy-handle = <15>;
+			phy-handle = <&phy26>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp1>;


### PR DESCRIPTION
Patch for adjusting the wrong phy-handle definitions for the sfp ports included in commit: 89eb8b50d18d29dc0360d94b2daaf2bd4f0faa02.

Added the patch to both kernel 5.10 and 5.15 dts files.