### PR TITLE
procd: allow jail parameters to be set from initscripts

### DIFF
--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -239,6 +239,17 @@ _procd_add_jail_mount_rw() {
 	json_select ..
 }
 
+_procd_set_jail_param() {
+	local type="$1"; shift
+
+	local _json_no_warning=1
+
+	json_select "jail"
+	[ $? = 0 ] || return
+	json_add_string "$type" "$1"
+	json_select ..
+}
+
 _procd_set_param() {
 	local type="$1"; shift
 
@@ -647,6 +658,7 @@ _procd_wrapper \
 	procd_add_jail \
 	procd_add_jail_mount \
 	procd_add_jail_mount_rw \
+	procd_set_jail_param \
 	procd_set_param \
 	procd_append_param \
 	procd_add_validation \


### PR DESCRIPTION
This is needed to set parameters like 'pidfile' (for the PID of the jailed/namespace process) and 'hostname'.

For example, set a pidfile which can be used by another script to enter into the namespace context

In init script:
```
    procd_set_param command /bin/pause.sh
    procd_add_jail jailed_process procfs
...
    procd_set_jail_param pidfile "/var/run/jailedproc.pid"
    procd_close_instance
```
In script to enter the jail namespace:

```
JAIL_PID=$(cat /var/run/jailedproc.pid)
nsenter -t "${JAIL_PID}" -m -u -i -p -S 1123 -- sh
```
