### PR TITLE
CI: use openwrt official tools container by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,9 @@ on:
         type: boolean
       build_all_boards:
         type: boolean
+      use_openwrt_container:
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -44,6 +47,11 @@ jobs:
         run: |
           OWNER_LC=$(echo "${{ github.repository_owner }}" \
             | tr '[:upper:]' '[:lower:]')
+
+          if [ ${{ inputs.use_openwrt_container }} == "true" ]; then
+            OWNER_LC=openwrt
+          fi
+
           echo "owner_lc=$OWNER_LC" >> $GITHUB_OUTPUT
 
       - name: Generate ccache hash

--- a/.github/workflows/check-kernel-patches.yml
+++ b/.github/workflows/check-kernel-patches.yml
@@ -8,6 +8,9 @@ on:
         type: string
       testing:
         type: boolean
+      use_openwrt_container:
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -26,6 +29,11 @@ jobs:
         run: |
           OWNER_LC=$(echo "${{ github.repository_owner }}" \
             | tr '[:upper:]' '[:lower:]')
+
+          if [ ${{ inputs.use_openwrt_container }} == "true" ]; then
+            OWNER_LC=openwrt
+          fi
+
           echo "owner_lc=$OWNER_LC" >> $GITHUB_OUTPUT
 
       # Per branch tools container tag

--- a/.github/workflows/push-containers.yml
+++ b/.github/workflows/push-containers.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   build-linux-buildbot:
     name: Build tools with buildbot container
+    if: ${{ github.repository_owner  == 'openwrt' }}
     uses: ./.github/workflows/build-tools.yml
     with:
       generate_prebuilt_artifacts: true
@@ -25,6 +26,7 @@ jobs:
   push-tools-container:
     needs: build-linux-buildbot
     name: Push prebuilt tools container
+    if: ${{ github.repository_owner  == 'openwrt' }}
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Use openwrt official tools container by default.
Fork will use openwrt tools container by default.

This can be disabled by setting the option use_openwrt_container to false for the build.yml and check-kernel-patches.yml.

The push-containers workflow is disabled on forks. The workflow can be reenabled by commenting the condition in push-containers.yml.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>