### PR TITLE
rockchip: add support for NanoPi R4S 1GB DDR3

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -38,6 +38,19 @@ endef
 
 # RK3399 boards
 
+define U-Boot/nanopi-r4s-1g-rk3399
+  BUILD_SUBTARGET:=armv8
+  NAME:=NanoPi R4S 1G
+  BUILD_DEVICES:= \
+    friendlyarm_nanopi-r4s-1g
+  DEPENDS:=+PACKAGE_u-boot-nanopi-r4s-1g-rk3399:arm-trusted-firmware-rockchip
+  DEVICE_DTS := rk3399-nanopi-r4s
+  PKG_BUILD_DEPENDS:=arm-trusted-firmware-rockchip
+  UBOOT_CONFIG:= nanopi-r4s-rk3399
+  ATF:=rk3399_bl31.elf
+  DDR_1G:=$(1)
+endef
+
 define U-Boot/nanopi-r4s-rk3399
   BUILD_SUBTARGET:=armv8
   NAME:=NanoPi R4S
@@ -69,6 +82,7 @@ define U-Boot/rockpro64-rk3399
 endef
 
 UBOOT_TARGETS := \
+  nanopi-r4s-1g-rk3399 \
   nanopi-r4s-rk3399 \
   rock-pi-4-rk3399 \
   rockpro64-rk3399 \
@@ -78,6 +92,15 @@ UBOOT_CONFIGURE_VARS += USE_PRIVATE_LIBGCC=yes
 
 UBOOT_MAKE_FLAGS += \
   BL31=$(STAGING_DIR_IMAGE)/$(ATF)
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+
+ifneq ($(DDR_1G),)
+	sed -i "16s/"rk3399-sdram-lpddr4-100.dtsi"/"rk3399-sdram-ddr3-1866.dtsi"/" $(PKG_BUILD_DIR)/arch/arm/dts/rk3399-nanopi-r4s-u-boot.dtsi
+	sed -i '/CONFIG_RAM_RK3399_LPDDR4=y/d' $(PKG_BUILD_DIR)/configs/nanopi-r4s-rk3399_defconfig
+endif
+endef
 
 define Build/Configure
 	$(call Build/Configure/U-Boot)

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -15,6 +15,19 @@ define Device/friendlyarm_nanopi-r2s
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r2s
 
+define Device/friendlyarm_nanopi-r4s-1g
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPi R4S 1GB
+  DEVICE_VARIANT := 1GB DDR3
+  DEVICE_DTS := rockchip/rk3399-nanopi-r4s
+  SOC := rk3399
+  SUPPORTED_DEVICES += friendlyarm,nanopi-r4s
+  UBOOT_DEVICE_NAME := nanopi-r4s-1g-rk3399
+  IMAGE/sysupgrade.img.gz := boot-common | boot-script nanopi-r4s | pine64-img | gzip | append-metadata
+  DEVICE_PACKAGES := kmod-r8169
+endef
+TARGET_DEVICES += friendlyarm_nanopi-r4s-1g
+
 define Device/friendlyarm_nanopi-r4s
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R4S


### PR DESCRIPTION
This add support for NanoPi R4S  variant with 1GB DDR3, hardware is the same to the 4 GB.
