### PR TITLE
zynq: switch default kernel to 5.15

### DIFF
--- a/target/linux/zynq/Makefile
+++ b/target/linux/zynq/Makefile
@@ -18,8 +18,7 @@ define Target/Description
 	Build firmware image for Zynq 7000 SoC devices.
 endef
 
-KERNEL_PATCHVER:=5.10
-KERNEL_TESTING_PATCHVER:=5.15
+KERNEL_PATCHVER:=5.15
 
 include $(INCLUDE_DIR)/target.mk
 


### PR DESCRIPTION
The default kernel should be switched to 5.15 in order to enable testing by a broader audience.
