### PR TITLE
ramips: add mapping additional uci-defaults from stock firmware

### DIFF
--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -86,6 +86,23 @@ mtd_get_mac_ascii() {
 	get_mac_ascii "$part" "$key"
 }
 
+mtd_get_raw_ascii() {
+	local mtdname="$1"
+	local key="$2"
+	local part
+	local raw_val
+
+	part=$(find_mtd_part "$mtdname")
+	if [ -z "$part" ]; then
+		echo "mtd_get_raw_ascii: partition $mtdname not found!" >&2
+		return
+	fi
+
+	raw_val=$(strings "$part" | sed -n 's/^'"$key"'=//p')
+
+	[ -n "$raw_val" ] && echo "$raw_val"
+}
+
 mtd_get_mac_encrypted_arcadyan() {
 	local iv="00000000000000000000000000000000"
 	local key="2A4B303D7644395C3B2B7053553C5200"

--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -665,6 +665,28 @@ ucidef_set_poe() {
 	json_select ..
 }
 
+ucidef_set_ssid() {
+	local obj="$1"
+	local ssid="$2"
+
+	json_select_object wireless
+		json_select_object "$obj"
+			json_add_string ssid "$ssid"
+		json_select ..
+	json_select ..
+}
+
+ucidef_set_reg_domain() {
+	local obj="$1"
+	local reg_domain="$2"
+
+	json_select_object wireless
+		json_select_object "$obj"
+			json_add_string country "$reg_domain"
+		json_select ..
+	json_select ..
+}
+
 ucidef_add_wlan() {
 	local path="$1"; shift
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/06_factory_extras
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/06_factory_extras
@@ -1,0 +1,30 @@
+
+. /lib/functions.sh
+. /lib/functions/uci-defaults.sh
+. /lib/functions/system.sh
+
+ramips_setup_factory_extras()
+{
+	local board="$1"
+	local reg_domain=""
+	local ssid=""
+
+	case $board in
+	linksys,ea7300-v1)
+		reg_domain=$(mtd_get_raw_ascii devinfo cert_region)
+		ssid=$(mtd_get_raw_ascii devinfo default_ssid)
+		;;
+	esac
+
+	[ -n "$reg_domain" ] && ucidef_set_reg_domain radio0 $reg_domain
+	[ -n "$reg_domain" ] && ucidef_set_reg_domain radio1 $reg_domain
+	[ -n "$ssid" ] && ucidef_set_ssid default_radio0 $ssid
+	[ -n "$ssid" ] && ucidef_set_ssid default_radio1 $ssid
+}
+
+board_config_update
+board=$(board_name)
+ramips_setup_factory_extras $board
+board_config_flush
+
+exit 0


### PR DESCRIPTION
Commit 1: base functions
>    base-files: functions: Add three new functions
>    Add mtd_get_raw_ascii() system function;
>    Add ucidef_set_ssid() and ucidef_set_reg_domain() uci-defaults functions

---

Commit 2: ramips/mt7621 platform specific (using above functions)
>    ramips: add mapping additional uci-defaults from stock firmware
>    initial support for parsing extra information from stock firmware during
>    first boot (`factory_extras`)
>    
>    one board is supported but others can be added if there are useful
>    settings to parse from the stock `devinfo` or similar partition
>    
>    * Linksys EA7300-v1:
>      * wireless: use default_ssid for all wireless (as on label)
>      * wireless: use cert_region for country by default (vs unset)

Signed-off-by: Tony Butler <spudz76@gmail.com>