### PR TITLE
add support for the mold linker

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -182,7 +182,6 @@ menu "Global build settings"
 			help
 			  This will install binaries stripped using strip from binutils.
 
-
 		config USE_SSTRIP
 			bool "sstrip"
 			depends on !USE_GLIBC
@@ -199,13 +198,12 @@ menu "Global build settings"
 		help
 		  Specifies arguments passed to the strip command when stripping binaries.
 
-	config SSTRIP_ARGS
-		string
-		prompt "Sstrip arguments"
+	config SSTRIP_DISCARD_TRAILING_ZEROES
+		bool "Strip trailing zero bytes"
 		depends on USE_SSTRIP
-		default "-z"
+		default y
 		help
-		  Specifies arguments passed to the sstrip command when stripping binaries.
+		  Use sstrip's -z option to discard trailing zero bytes
 
 	config STRIP_KERNEL_EXPORTS
 		bool "Strip unnecessary exports from the kernel image"

--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -159,6 +159,19 @@ menu "Global build settings"
 		  Adds LTO flags to the CFLAGS and LDFLAGS.
 		  Packages can choose to opt-out via setting PKG_BUILD_FLAGS:=no-lto
 
+	config MOLD
+		depends on (aarch64 || arm || i386 || i686 || m68k || powerpc || powerpc64 || sh4 || x86_64)
+		depends on !GCC_USE_VERSION_11
+		def_bool $(shell, ./config/check-hostcxx.sh 10 2 12)
+
+	config USE_MOLD
+		bool
+		prompt "Use the mold linker for all packages"
+		depends on MOLD
+		help
+		  Link packages with mold, a modern linker
+		  Packages can opt-out via setting PKG_BUILD_FLAGS:=no-mold
+
 	config IPV6
 		def_bool y
 
@@ -200,7 +213,7 @@ menu "Global build settings"
 
 	config SSTRIP_DISCARD_TRAILING_ZEROES
 		bool "Strip trailing zero bytes"
-		depends on USE_SSTRIP
+		depends on USE_SSTRIP && !USE_MOLD
 		default y
 		help
 		  Use sstrip's -z option to discard trailing zero bytes

--- a/config/check-hostcxx.sh
+++ b/config/check-hostcxx.sh
@@ -1,0 +1,12 @@
+cat << EOF | "$STAGING_DIR_HOST/bin/g++" -c -x c++ -o /dev/null - >/dev/null 2>&1
+#if __clang__
+  #if __clang_major__ < $3
+    #error "clang too old"
+  #endif
+#else
+  #if __GNUC__ < $1 || (__GNUC__ == $1 && (__GNUC_MINOR__ < $2))
+    #error "gcc too old"
+  #endif
+#endif
+EOF
+[ $? -eq 0 ] && echo y || echo n

--- a/include/meson.mk
+++ b/include/meson.mk
@@ -78,6 +78,7 @@ define Meson/CreateCrossFile
 	$(STAGING_DIR_HOST)/bin/sed \
 		-e "s|@CC@|$(foreach BIN,$(TARGET_CC),'$(BIN)',)|" \
 		-e "s|@CXX@|$(foreach BIN,$(TARGET_CXX),'$(BIN)',)|" \
+		-e "s|@LD@|$(foreach FLAG,$(TARGET_LINKER),'$(FLAG)',)|" \
 		-e "s|@AR@|$(TARGET_AR)|" \
 		-e "s|@STRIP@|$(TARGET_CROSS)strip|" \
 		-e "s|@NM@|$(TARGET_NM)|" \

--- a/include/package.mk
+++ b/include/package.mk
@@ -55,6 +55,11 @@ ifeq ($(call pkg_build_flag,lto,$(if $(CONFIG_USE_LTO),1,0)),1)
   TARGET_CXXFLAGS+= -flto=auto -fno-fat-lto-objects
   TARGET_LDFLAGS+= -flto=auto -fuse-linker-plugin
 endif
+ifdef CONFIG_USE_MOLD
+  ifeq ($(call pkg_build_flag,mold,1),1)
+    TARGET_LINKER:=mold
+  endif
+endif
 
 include $(INCLUDE_DIR)/hardening.mk
 include $(INCLUDE_DIR)/prereq.mk

--- a/include/package.mk
+++ b/include/package.mk
@@ -24,7 +24,7 @@ PKG_JOBS?=$(if $(PKG_BUILD_PARALLEL),$(MAKE_J),-j1)
 endif
 
 PKG_BUILD_FLAGS?=
-__unknown_flags=$(filter-out no-iremap no-mips16 gc-sections no-gc-sections lto no-lto,$(PKG_BUILD_FLAGS))
+__unknown_flags=$(filter-out no-iremap no-mips16 gc-sections no-gc-sections lto no-lto no-mold,$(PKG_BUILD_FLAGS))
 ifneq ($(__unknown_flags),)
   $(error unknown PKG_BUILD_FLAGS: $(__unknown_flags))
 endif

--- a/package/boot/grub2/Makefile
+++ b/package/boot/grub2/Makefile
@@ -25,7 +25,7 @@ ifneq ($(BUILD_VARIANT),none)
 endif
 
 PKG_FLAGS:=nonshared
-PKG_BUILD_FLAGS:=no-lto
+PKG_BUILD_FLAGS:=no-lto no-mold
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk

--- a/package/kernel/lantiq/ltq-ifxos/Makefile
+++ b/package/kernel/lantiq/ltq-ifxos/Makefile
@@ -23,6 +23,7 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_EXTMOD_SUBDIRS:=src
 
 PKG_FIXUP:=autoreconf
+PKG_BUILD_FLAGS:=no-mold
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/package/kernel/lantiq/ltq-vdsl-vr11-mei/Makefile
+++ b/package/kernel/lantiq/ltq-vdsl-vr11-mei/Makefile
@@ -25,6 +25,7 @@ PKG_EXTMOD_SUBDIRS:=src
 
 PKG_FIXUP:=autoreconf
 PKG_FLAGS:=nonshared
+PKG_BUILD_FLAGS:=no-mold
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/package/kernel/lantiq/ltq-vdsl-vr11/Makefile
+++ b/package/kernel/lantiq/ltq-vdsl-vr11/Makefile
@@ -23,6 +23,7 @@ PKG_LICENSE:=GPL-2.0 BSD-2-Clause
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_FIXUP:=autoreconf
+PKG_BUILD_FLAGS:=no-mold
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/rules.mk
+++ b/rules.mk
@@ -330,7 +330,7 @@ else
     STRIP:=$(TARGET_CROSS)strip $(call qstrip,$(CONFIG_STRIP_ARGS))
   else
     ifneq ($(CONFIG_USE_SSTRIP),)
-      STRIP:=$(STAGING_DIR_HOST)/bin/sstrip $(call qstrip,$(CONFIG_SSTRIP_ARGS))
+      STRIP:=$(STAGING_DIR_HOST)/bin/sstrip $(if $(CONFIG_SSTRIP_DISCARD_TRAILING_ZEROES),-z)
     endif
   endif
   RSTRIP= \

--- a/rules.mk
+++ b/rules.mk
@@ -211,6 +211,10 @@ ifndef DUMP
     endif
   endif
 endif
+
+TARGET_LINKER?=bfd
+TARGET_LDFLAGS+= -fuse-ld=$(TARGET_LINKER)
+
 TARGET_PATH_PKG:=$(STAGING_DIR)/host/bin:$(STAGING_DIR_HOSTPKG)/bin:$(TARGET_PATH)
 
 ifeq ($(CONFIG_SOFT_FLOAT),y)
@@ -252,6 +256,7 @@ TARGET_RANLIB:=$(TARGET_CROSS)gcc-ranlib
 TARGET_NM:=$(TARGET_CROSS)gcc-nm
 TARGET_CC:=$(TARGET_CROSS)gcc
 TARGET_CXX:=$(TARGET_CROSS)g++
+TARGET_LD:=$(TARGET_CROSS)ld.$(TARGET_LINKER)
 KPATCH:=$(SCRIPT_DIR)/patch-kernel.sh
 FILECMD:=$(STAGING_DIR_HOST)/bin/file
 SED:=$(STAGING_DIR_HOST)/bin/sed -i -e
@@ -305,7 +310,7 @@ endif
 TARGET_CONFIGURE_OPTS = \
   AR="$(TARGET_AR)" \
   AS="$(TARGET_CC) -c $(TARGET_ASFLAGS)" \
-  LD=$(TARGET_CROSS)ld \
+  LD="$(TARGET_LD)" \
   NM="$(TARGET_NM)" \
   CC="$(TARGET_CC)" \
   GCC="$(TARGET_CC)" \

--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -27,7 +27,7 @@
 curdir:=toolchain
 
 # subdirectories to descend into
-$(curdir)/builddirs := $(if $(CONFIG_GDB),gdb) $(if $(CONFIG_EXTERNAL_TOOLCHAIN),wrapper,kernel-headers binutils gcc/initial gcc/final $(LIBC) fortify-headers) $(if $(CONFIG_NASM),nasm)
+$(curdir)/builddirs := $(if $(CONFIG_GDB),gdb) $(if $(CONFIG_EXTERNAL_TOOLCHAIN),wrapper,kernel-headers binutils gcc/initial gcc/final $(LIBC) fortify-headers) $(if $(CONFIG_NASM),nasm) $(if $(CONFIG_USE_MOLD),mold)
 
 # builddir dependencies
 ifeq ($(CONFIG_EXTERNAL_TOOLCHAIN),)

--- a/toolchain/mold/Makefile
+++ b/toolchain/mold/Makefile
@@ -1,0 +1,22 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/toolchain-build.mk
+
+define Host/Configure
+endef
+
+define Host/Compile
+endef
+
+define Host/Install
+	$(INSTALL_DIR) $(TOOLCHAIN_DIR)/bin
+	$(INSTALL_BIN) $(STAGING_DIR_HOST)/bin/mold $(TOOLCHAIN_DIR)/bin/$(REAL_GNU_TARGET_NAME)-ld.mold
+endef
+
+define Host/Clean
+endef
+
+$(eval $(call HostBuild))

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -83,6 +83,7 @@ tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_TARGET_tegra),y) += cbootimage
 tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USES_MINOR),y) += kernel2minor
 tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USE_SPARSE),y) += sparse
 tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USE_LLVM_BUILD),y) += llvm-bpf
+tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USE_MOLD),y) += mold
 
 # builddir dependencies
 $(curdir)/autoconf/compile := $(curdir)/m4/compile
@@ -114,6 +115,7 @@ $(curdir)/meson/compile := $(curdir)/ninja/compile
 $(curdir)/missing-macros/compile := $(curdir)/autoconf/compile
 $(curdir)/mkimage/compile += $(curdir)/bison/compile $(curdir)/libressl/compile
 $(curdir)/mklibs/compile := $(curdir)/libtool/compile
+$(curdir)/mold/compile := $(curdir)/cmake/compile $(curdir)/zlib/compile $(curdir)/zstd/compile
 $(curdir)/mpc/compile := $(curdir)/mpfr/compile $(curdir)/gmp/compile
 $(curdir)/mpfr/compile := $(curdir)/gmp/compile
 $(curdir)/mtd-utils/compile := $(curdir)/libtool/compile $(curdir)/e2fsprogs/compile $(curdir)/zlib/compile

--- a/tools/meson/Makefile
+++ b/tools/meson/Makefile
@@ -2,6 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=meson
 PKG_VERSION:=1.1.1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/mesonbuild/meson/releases/download/$(PKG_VERSION)

--- a/tools/meson/files/openwrt-cross.txt.in
+++ b/tools/meson/files/openwrt-cross.txt.in
@@ -1,6 +1,8 @@
 [binaries]
 c = [@CC@]
+c_ld = [@LD@]
 cpp = [@CXX@]
+cpp_ld = [@LD@]
 ar = '@AR@'
 strip = '@STRIP@'
 nm = '@NM@'

--- a/tools/mold/Makefile
+++ b/tools/mold/Makefile
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mold
+PKG_VERSION:=1.11.0
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL_FILE:=v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/rui314/mold/archive/refs/tags
+PKG_HASH:=99318eced81b09a77e4c657011076cc8ec3d4b6867bd324b8677974545bc4d6f
+
+include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+CMAKE_HOST_OPTIONS += \
+	-DMOLD_LTO=ON \
+	-DMOLD_MOSTLY_STATIC=ON \
+	-DMOLD_USE_SYSTEM_MIMALLOC=OFF \
+	-DMOLD_USE_SYSTEM_TBB=OFF
+
+$(eval $(call HostBuild))


### PR DESCRIPTION
An experiment to evaluate if [mold](https://github.com/rui314/mold) is worth adding/using.

mold is a faster drop-in replacement for existing Unix linkers. It produces slightly smaller binaries compared to the currently used bfd. LTO link times are an even bigger winner, so there's a new experimental knob to enable LTO tree-wide - with selected packages opting out of it when failure is to be expected.

mold doesn't support all the archs that OpenWrt does, most notably mips.
Nor does it support linker scripts, so bfd is still used for the kernel and uboot.

With mold enabled I can successfully build my usual ipq4019 .config, which has a couple of additional packages enabled. LTO on top builds fine too, but I didn't run-test that yet.
Standard armvirt32/64 seem to run fine so far.

First impression:
The size gain is present, but smaller than I expected.
LTO so far was rather painless, I expected way more fallout. libxml2 was the only package from feeds where I had to disable LTO. The rest of my used packages build just fine. I expect some more since I don't use that many though (see also [here](https://github.com/gentoo/gentoo/search?q=%22filter-lto%22&type=commits))

My spare devices to actually test drive this on are all mips based, anyone interested in giving this a spin?

~~PS: This currently only works on linux x86_64 hosts, as this just fetches a prebuilt binary for now. Compiling mold requires a host gcc >= 10.2, where prereq-build currently checks for just >=6. But even with that, it won't work on macos, since mach-o support is only available in the commercial version.~~

root fs `du -ck` comparisons, bfd vs mold without lto:
```
--- bfd/du	2023-01-28 23:29:03.634041549 +0100
+++ mold/du	2023-01-28 23:28:57.170041688 +0100
@@ -1,5 +1,5 @@
 4	root-ipq40xx/tmp
-948	root-ipq40xx/sbin
+900	root-ipq40xx/sbin
 4	root-ipq40xx/dev
 8	root-ipq40xx/rom
 52	root-ipq40xx/lib/upgrade/keep.d
@@ -21,7 +21,7 @@
 68	root-ipq40xx/lib/preinit
 4504	root-ipq40xx/lib/modules/5.15.90
 4508	root-ipq40xx/lib/modules
-9420	root-ipq40xx/lib
+9380	root-ipq40xx/lib
 4	root-ipq40xx/overlay
 4	root-ipq40xx/mnt
 684	root-ipq40xx/bin
@@ -116,15 +116,15 @@
 92	root-ipq40xx/usr/share/terminfo
 12	root-ipq40xx/usr/share/libubox
 19752	root-ipq40xx/usr/share
-6072	root-ipq40xx/usr/sbin
+6060	root-ipq40xx/usr/sbin
 8	root-ipq40xx/usr/lib/dnsmasq
 84	root-ipq40xx/usr/lib/ddns
-5584	root-ipq40xx/usr/lib/opkg/info
+5580	root-ipq40xx/usr/lib/opkg/info
 4	root-ipq40xx/usr/lib/opkg/lists
-5668	root-ipq40xx/usr/lib/opkg
-2924	root-ipq40xx/usr/lib/asterisk/modules
-2928	root-ipq40xx/usr/lib/asterisk
-108	root-ipq40xx/usr/lib/rpcd
+5664	root-ipq40xx/usr/lib/opkg
+2752	root-ipq40xx/usr/lib/asterisk/modules
+2756	root-ipq40xx/usr/lib/asterisk
+92	root-ipq40xx/usr/lib/rpcd
 76	root-ipq40xx/usr/lib/lua/prometheus-collectors
 4	root-ipq40xx/usr/lib/lua/mime
 16	root-ipq40xx/usr/lib/lua/luci/cbi
@@ -139,19 +139,19 @@
 176	root-ipq40xx/usr/lib/lua/luci/view
 28	root-ipq40xx/usr/lib/lua/luci/sys/zoneinfo
 36	root-ipq40xx/usr/lib/lua/luci/sys
-620	root-ipq40xx/usr/lib/lua/luci
+612	root-ipq40xx/usr/lib/lua/luci
 16	root-ipq40xx/usr/lib/lua/nixio
 100	root-ipq40xx/usr/lib/lua/socket
-1052	root-ipq40xx/usr/lib/lua
+1032	root-ipq40xx/usr/lib/lua
 28	root-ipq40xx/usr/lib/pppd/2.4.9
 32	root-ipq40xx/usr/lib/pppd
 24	root-ipq40xx/usr/lib/ucode/luci
-236	root-ipq40xx/usr/lib/ucode
-24628	root-ipq40xx/usr/lib
-5936	root-ipq40xx/usr/bin
+220	root-ipq40xx/usr/lib/ucode
+24428	root-ipq40xx/usr/lib
+5928	root-ipq40xx/usr/bin
 16	root-ipq40xx/usr/libexec/rpcd
-1296	root-ipq40xx/usr/libexec
-57688	root-ipq40xx/usr
+1292	root-ipq40xx/usr/libexec
+57464	root-ipq40xx/usr
 4	root-ipq40xx/etc/luci-uploads
 12	root-ipq40xx/etc/sysctl.d
 68	root-ipq40xx/etc/config
@@ -190,5 +190,5 @@
 4	root-ipq40xx/etc/rc.d
 16	root-ipq40xx/etc/iproute2
 1620	root-ipq40xx/etc
-72284	root-ipq40xx
-72284	total
+71972	root-ipq40xx
+71972	total
```

bfd vs mold with lto:
```
--- bfd/du	2023-01-28 23:29:03.634041549 +0100
+++ mold+lto/du	2023-01-28 23:28:52.730041744 +0100
@@ -1,5 +1,5 @@
 4	root-ipq40xx/tmp
-948	root-ipq40xx/sbin
+880	root-ipq40xx/sbin
 4	root-ipq40xx/dev
 8	root-ipq40xx/rom
 52	root-ipq40xx/lib/upgrade/keep.d
@@ -21,7 +21,7 @@
 68	root-ipq40xx/lib/preinit
 4504	root-ipq40xx/lib/modules/5.15.90
 4508	root-ipq40xx/lib/modules
-9420	root-ipq40xx/lib
+9380	root-ipq40xx/lib
 4	root-ipq40xx/overlay
 4	root-ipq40xx/mnt
 684	root-ipq40xx/bin
@@ -116,15 +116,15 @@
 92	root-ipq40xx/usr/share/terminfo
 12	root-ipq40xx/usr/share/libubox
 19752	root-ipq40xx/usr/share
-6072	root-ipq40xx/usr/sbin
+5900	root-ipq40xx/usr/sbin
 8	root-ipq40xx/usr/lib/dnsmasq
 84	root-ipq40xx/usr/lib/ddns
-5584	root-ipq40xx/usr/lib/opkg/info
+5580	root-ipq40xx/usr/lib/opkg/info
 4	root-ipq40xx/usr/lib/opkg/lists
-5668	root-ipq40xx/usr/lib/opkg
-2924	root-ipq40xx/usr/lib/asterisk/modules
-2928	root-ipq40xx/usr/lib/asterisk
-108	root-ipq40xx/usr/lib/rpcd
+5664	root-ipq40xx/usr/lib/opkg
+2736	root-ipq40xx/usr/lib/asterisk/modules
+2740	root-ipq40xx/usr/lib/asterisk
+92	root-ipq40xx/usr/lib/rpcd
 76	root-ipq40xx/usr/lib/lua/prometheus-collectors
 4	root-ipq40xx/usr/lib/lua/mime
 16	root-ipq40xx/usr/lib/lua/luci/cbi
@@ -139,19 +139,19 @@
 176	root-ipq40xx/usr/lib/lua/luci/view
 28	root-ipq40xx/usr/lib/lua/luci/sys/zoneinfo
 36	root-ipq40xx/usr/lib/lua/luci/sys
-620	root-ipq40xx/usr/lib/lua/luci
+612	root-ipq40xx/usr/lib/lua/luci
 16	root-ipq40xx/usr/lib/lua/nixio
-100	root-ipq40xx/usr/lib/lua/socket
-1052	root-ipq40xx/usr/lib/lua
+88	root-ipq40xx/usr/lib/lua/socket
+1016	root-ipq40xx/usr/lib/lua
 28	root-ipq40xx/usr/lib/pppd/2.4.9
 32	root-ipq40xx/usr/lib/pppd
 24	root-ipq40xx/usr/lib/ucode/luci
-236	root-ipq40xx/usr/lib/ucode
-24628	root-ipq40xx/usr/lib
-5936	root-ipq40xx/usr/bin
+220	root-ipq40xx/usr/lib/ucode
+24264	root-ipq40xx/usr/lib
+5844	root-ipq40xx/usr/bin
 16	root-ipq40xx/usr/libexec/rpcd
-1296	root-ipq40xx/usr/libexec
-57688	root-ipq40xx/usr
+1260	root-ipq40xx/usr/libexec
+57024	root-ipq40xx/usr
 4	root-ipq40xx/etc/luci-uploads
 12	root-ipq40xx/etc/sysctl.d
 68	root-ipq40xx/etc/config
@@ -190,5 +190,5 @@
 4	root-ipq40xx/etc/rc.d
 16	root-ipq40xx/etc/iproute2
 1620	root-ipq40xx/etc
-72284	root-ipq40xx
-72284	total
+71512	root-ipq40xx
+71512	total
```