### PR TITLE
build: clone git sources into dl folder

### DIFF
--- a/config/Config-devel.in
+++ b/config/Config-devel.in
@@ -162,3 +162,10 @@ menuconfig DEVEL
 		default "-fno-caller-saves"
 		help
 		  Extra target-independent optimizations to use when building for the target.
+
+	config ENABLE_GIT_SOURCES
+		bool "Enable downloading sources as git repos" if DEVEL
+		default n
+		help
+		  If enabled, openwrt download and prepare steps will clone git sources into DL_DIR, no archiving action is preformed 
+		  then hard link them from DL_DIR into build_dir before hitting the compile step.

--- a/include/unpack.mk
+++ b/include/unpack.mk
@@ -5,7 +5,6 @@
 HOST_TAR:=$(TAR)
 TAR_CMD=$(HOST_TAR) -C $(1)/.. $(TAR_OPTIONS)
 UNZIP_CMD=unzip -q -d $(1)/.. $(DL_DIR)/$(PKG_SOURCE)
-
 ifeq ($(PKG_SOURCE),)
   PKG_UNPACK ?= true
 else
@@ -58,6 +57,9 @@ ifeq ($(strip $(UNPACK_CMD)),)
     ifeq ($(PKG_CAT),zcat)
       UNPACK_CMD=$(STAGING_DIR_HOST)/bin/libdeflate-gzip -dc $(DL_DIR)/$(PKG_SOURCE) | $(TAR_CMD)
     endif
+  endif
+  ifeq ($(strip $(PKG_SOURCE_PROTO)$(CONFIG_ENABLE_GIT_SOURCES)),gity)
+    UNPACK_CMD=cp -rHldp $(DL_DIR)/$(PKG_NAME)-$(PKG_VERSION)/* $(1)/
   endif
 endif
 


### PR DESCRIPTION
this feature will use the git clone command to download sources from all packages that use PKG_SOURCE_PROTO:=git value directly into ./dl folder;

then hard link them into the build_dir folder, this is useful if you want to work and commit in a clean source folder without the need to worry about accidentally saving a generated file during the "configure" and "compile" stage, or losing changes or branches when cleaning "clean" the package, and since the sources are hard linked into build_dir any change performed in the package source in dl folder will also appear in the corresponding folder in build_dir and thus the same dev branches are kept even if you call make package/clean unless you change the package's version or branch to something else.

to test it, set the following configs to yes:
**CONFIG_DEVEL=y**
 **CONFIG_ENABLE_GIT_SOURCES=y**
 
results example : 
./dl/firewall4-2022-11-29-700a925f/
./dl/fstools-2022-11-10-3affe9ea/
./dl/hostapd-2022-07-29-b704dc72/

