### PR TITLE
realtek: Refactor rtl930x leds

### DIFF
--- a/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
+++ b/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
@@ -223,6 +223,10 @@
 			phy-handle = <&phy0>;
 			phy-mode = "xgmii";
 			led-set = <0>;
+			led-num = <(
+				RTL93XX_LED_NUM0 | /* Amber */
+				RTL93XX_LED_NUM1   /* Lime */
+			)>;
 		};
 		port@1 {
 			reg = <1>;
@@ -230,6 +234,10 @@
 			phy-handle = <&phy1>;
 			phy-mode = "xgmii";
 			led-set = <0>;
+			led-num = <(
+				RTL93XX_LED_NUM0 | /* Amber */
+				RTL93XX_LED_NUM1   /* Lime */
+			)>;
 		};
 		port@2 {
 			reg = <2>;
@@ -237,6 +245,10 @@
 			phy-handle = <&phy2>;
 			phy-mode = "xgmii";
 			led-set = <0>;
+			led-num = <(
+				RTL93XX_LED_NUM0 | /* Amber */
+				RTL93XX_LED_NUM1   /* Lime */
+			)>;
 		};
 		port@3 {
 			reg = <3>;
@@ -244,6 +256,10 @@
 			phy-handle = <&phy3>;
 			phy-mode = "xgmii";
 			led-set = <0>;
+			led-num = <(
+				RTL93XX_LED_NUM0 | /* Amber */
+				RTL93XX_LED_NUM1   /* Lime */
+			)>;
 		};
 		port@4 {
 			reg = <4>;
@@ -251,6 +267,10 @@
 			phy-handle = <&phy4>;
 			phy-mode = "xgmii";
 			led-set = <0>;
+			led-num = <(
+				RTL93XX_LED_NUM0 | /* Amber */
+				RTL93XX_LED_NUM1   /* Lime */
+			)>;
 		};
 		port@5 {
 			reg = <5>;
@@ -258,6 +278,10 @@
 			phy-handle = <&phy5>;
 			phy-mode = "xgmii";
 			led-set = <0>;
+			led-num = <(
+				RTL93XX_LED_NUM0 | /* Amber */
+				RTL93XX_LED_NUM1   /* Lime */
+			)>;
 		};
 		port@6 {
 			reg = <6>;
@@ -265,6 +289,10 @@
 			phy-handle = <&phy6>;
 			phy-mode = "xgmii";
 			led-set = <0>;
+			led-num = <(
+				RTL93XX_LED_NUM0 | /* Amber */
+				RTL93XX_LED_NUM1   /* Lime */
+			)>;
 		};
 		port@7 {
 			reg = <7>;
@@ -272,6 +300,10 @@
 			phy-handle = <&phy7>;
 			phy-mode = "xgmii";
 			led-set = <0>;
+			led-num = <(
+				RTL93XX_LED_NUM0 | /* Amber */
+				RTL93XX_LED_NUM1   /* Lime */
+			)>;
 		};
 
 		port@24 {
@@ -280,6 +312,12 @@
 			phy-mode = "usxgmii";
 			phy-handle = <&phy24>;
 			led-set = <1>;
+			led-num = <(
+				RTL93XX_LED_NUM0 | /* Amber/Lime | RGB */
+				RTL93XX_LED_NUM1 | /* Amber      | Red */
+				RTL93XX_LED_NUM2 | /* Lime       | Green */
+				RTL93XX_LED_NUM3   /* off        | Blue */
+			)>;
 		};
 		port@25 {
 			reg = <25>;
@@ -287,6 +325,12 @@
 			phy-mode = "usxgmii";
 			phy-handle = <&phy25>;
 			led-set = <1>;
+			led-num = <(
+				RTL93XX_LED_NUM0 | /* Amber/Lime | RGB */
+				RTL93XX_LED_NUM1 | /* Amber      | Red */
+				RTL93XX_LED_NUM2 | /* Lime       | Green */
+				RTL93XX_LED_NUM3   /* off        | Blue */
+			)>;
 		};
 		port@26 {
 			reg = <26>;
@@ -294,6 +338,12 @@
 			phy-mode = "usxgmii";
 			phy-handle = <&phy26>;
 			led-set = <1>;
+			led-num = <(
+				RTL93XX_LED_NUM0 | /* Amber/Lime | RGB */
+				RTL93XX_LED_NUM1 | /* Amber      | Red */
+				RTL93XX_LED_NUM2 | /* Lime       | Green */
+				RTL93XX_LED_NUM3   /* off        | Blue */
+			)>;
 		};
 
 		port@27 {
@@ -303,6 +353,10 @@
 			phy-handle = <&phy27>;
 			sfp = <&sfp0>;
 			led-set = <2>;
+			led-num = <(
+				RTL93XX_LED_NUM0 | /* Blue */
+				RTL93XX_LED_NUM1   /* Lime */
+			)>;
 
 			fixed-link {
 				speed = <10000>;

--- a/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
+++ b/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
@@ -85,7 +85,7 @@
 			/* LED3 */
 			RTL93XX_LED_SET_NONE
 		>;
-		led_set1 = /bits/ 16 <
+		led_set2 = /bits/ 16 <
 			/* LED0 */
 			(
 				RTL93XX_LED_SET_LINK_ACTIVITY |
@@ -117,7 +117,7 @@
 				RTL93XX_LED_SET_2G5_LINK
 			)
 		>;
-		led_set2 = /bits/ 16 <
+		led_set3 = /bits/ 16 <
 			/* LED0 */
 			(
 				RTL93XX_LED_SET_LINK_ACTIVITY |
@@ -377,7 +377,7 @@
 			label = "lan9";
 			phy-mode = "usxgmii";
 			phy-handle = <&phy24>;
-			led-set = <1>;
+			led-set = <2>;
 			led-num = <(
 				RTL93XX_LED_NUM0 | /* Amber/Lime | RGB */
 				RTL93XX_LED_NUM1 | /* Amber      | Red */
@@ -390,7 +390,7 @@
 			label = "lan10";
 			phy-mode = "usxgmii";
 			phy-handle = <&phy25>;
-			led-set = <1>;
+			led-set = <2>;
 			led-num = <(
 				RTL93XX_LED_NUM0 | /* Amber/Lime | RGB */
 				RTL93XX_LED_NUM1 | /* Amber      | Red */
@@ -403,7 +403,7 @@
 			label = "lan11";
 			phy-mode = "usxgmii";
 			phy-handle = <&phy26>;
-			led-set = <1>;
+			led-set = <2>;
 			led-num = <(
 				RTL93XX_LED_NUM0 | /* Amber/Lime | RGB */
 				RTL93XX_LED_NUM1 | /* Amber      | Red */
@@ -418,7 +418,7 @@
 			phy-mode = "10gbase-r";
 			phy-handle = <&phy27>;
 			sfp = <&sfp0>;
-			led-set = <2>;
+			led-set = <3>;
 			led-num = <(
 				RTL93XX_LED_NUM0 | /* Blue */
 				RTL93XX_LED_NUM1   /* Lime */

--- a/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
+++ b/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
@@ -65,10 +65,10 @@
 	led_set: led_set@0 {
 		compatible = "realtek,rtl9302-leds", "realtek,rtl930x-leds";
 
-		led_set0 = <0x0000 0xffff 0x0a20 0x0b80>; // LED set 0: 1000Mbps,  10/100Mbps
+		led_set0 = <0x0000 0x0000 0x0a20 0x0b80>; // LED set 0: 1000Mbps,  10/100Mbps
 		led_set1 = <0x0a0b 0x0a28 0x0a82 0x0a0b>; // LED set 1: (10G, 5G, 2.5G) (2.5G, 1G)
 							  // (5G, 10/100) (10G, 5G, 2.5G)
-		led_set2 = <0x0000 0xffff 0x0a20 0x0a01>; // LED set 2: 1000MBit, 10GBit
+		led_set2 = <0x0000 0x0000 0x0a20 0x0a01>; // LED set 2: 1000MBit, 10GBit
 	};
 };
 

--- a/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
+++ b/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
@@ -63,7 +63,7 @@
 	};
 
 	led_set: led_set@0 {
-		compatible = "realtek,rtl9300-leds";
+		compatible = "realtek,rtl9302-leds", "realtek,rtl930x-leds";
 
 		led_set0 = <0x0000 0xffff 0x0a20 0x0b80>; // LED set 0: 1000Mbps,  10/100Mbps
 		led_set1 = <0x0a0b 0x0a28 0x0a82 0x0a0b>; // LED set 1: (10G, 5G, 2.5G) (2.5G, 1G)

--- a/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
+++ b/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
@@ -63,7 +63,7 @@
 		tx-disable-gpio = <&gpio0 15 GPIO_ACTIVE_HIGH>;
 	};
 
-	led_set: led_set@0 {
+	led_sets {
 		compatible = "realtek,rtl9302-leds", "realtek,rtl930x-leds";
 
 		led_set0 = /bits/ 16 <

--- a/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
+++ b/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
@@ -6,6 +6,7 @@
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/leds/common.h>
+#include <dt-bindings/leds/leds-realtek.h>
 
 / {
 	compatible = "zyxel,xgs1250-12", "realtek,rtl838x-soc";
@@ -65,10 +66,75 @@
 	led_set: led_set@0 {
 		compatible = "realtek,rtl9302-leds", "realtek,rtl930x-leds";
 
-		led_set0 = <0x0000 0x0000 0x0a20 0x0b80>; // LED set 0: 1000Mbps,  10/100Mbps
-		led_set1 = <0x0a0b 0x0a28 0x0a82 0x0a0b>; // LED set 1: (10G, 5G, 2.5G) (2.5G, 1G)
-							  // (5G, 10/100) (10G, 5G, 2.5G)
-		led_set2 = <0x0000 0x0000 0x0a20 0x0a01>; // LED set 2: 1000MBit, 10GBit
+		led_set0 = /bits/ 16 <
+			/* LED0 */
+			(
+				RTL93XX_LED_SET_LINK_ACTIVITY |
+				RTL93XX_LED_SET_LINK_UP_SOLID |
+				RTL93XX_LED_SET_100M_LINK |
+				RTL93XX_LED_SET_10M_LINK
+			)
+			/* LED1 */
+			(
+				RTL93XX_LED_SET_LINK_ACTIVITY |
+				RTL93XX_LED_SET_LINK_UP_SOLID |
+				RTL93XX_LED_SET_1000M_LINK
+			)
+			/* LED2 */
+			RTL93XX_LED_SET_NONE
+			/* LED3 */
+			RTL93XX_LED_SET_NONE
+		>;
+		led_set1 = /bits/ 16 <
+			/* LED0 */
+			(
+				RTL93XX_LED_SET_LINK_ACTIVITY |
+				RTL93XX_LED_SET_LINK_UP_SOLID |
+				RTL93XX_LED_SET_10G_LINK |
+				RTL93XX_LED_SET_5G_LINK |
+				RTL93XX_LED_SET_2G5_LINK
+			)
+			/* LED1 */
+			(
+				RTL93XX_LED_SET_LINK_ACTIVITY |
+				RTL93XX_LED_SET_LINK_UP_SOLID |
+				RTL93XX_LED_SET_5G_LINK |
+				RTL93XX_LED_SET_100M_LINK
+			)
+			/* LED2 */
+			(
+				RTL93XX_LED_SET_LINK_ACTIVITY |
+				RTL93XX_LED_SET_LINK_UP_SOLID |
+				RTL93XX_LED_SET_2G5_LINK |
+				RTL93XX_LED_SET_1000M_LINK
+			)
+			/* LED3 */
+			(
+				RTL93XX_LED_SET_LINK_ACTIVITY |
+				RTL93XX_LED_SET_LINK_UP_SOLID |
+				RTL93XX_LED_SET_10G_LINK |
+				RTL93XX_LED_SET_5G_LINK |
+				RTL93XX_LED_SET_2G5_LINK
+			)
+		>;
+		led_set2 = /bits/ 16 <
+			/* LED0 */
+			(
+				RTL93XX_LED_SET_LINK_ACTIVITY |
+				RTL93XX_LED_SET_LINK_UP_SOLID |
+				RTL93XX_LED_SET_10G_LINK
+			)
+			/* LED1 */
+			(
+				RTL93XX_LED_SET_LINK_ACTIVITY |
+				RTL93XX_LED_SET_LINK_UP_SOLID |
+				RTL93XX_LED_SET_1000M_LINK
+			)
+			/* LED2 */
+			RTL93XX_LED_SET_NONE
+			/* LED3 */
+			RTL93XX_LED_SET_NONE
+		>;
 	};
 };
 

--- a/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
+++ b/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
@@ -64,7 +64,6 @@
 
 	led_set: led_set@0 {
 		compatible = "realtek,rtl9300-leds";
-		active-low;
 
 		led_set0 = <0x0000 0xffff 0x0a20 0x0b80>; // LED set 0: 1000Mbps,  10/100Mbps
 		led_set1 = <0x0a0b 0x0a28 0x0a82 0x0a0b>; // LED set 1: (10G, 5G, 2.5G) (2.5G, 1G)

--- a/target/linux/realtek/files-5.15/arch/mips/include/asm/mach-rtl838x/mach-rtl83xx.h
+++ b/target/linux/realtek/files-5.15/arch/mips/include/asm/mach-rtl838x/mach-rtl83xx.h
@@ -7,6 +7,7 @@
 #define _MACH_RTL838X_H_
 
 #include <asm/types.h>
+
 /*
  * Register access macros
  */

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/common.c
@@ -353,6 +353,9 @@ static int __init rtl83xx_mdio_probe(struct rtl838x_switch_priv *priv)
 		if (interface == PHY_INTERFACE_MODE_10GBASER)
 			priv->ports[pn].is10G = true;
 
+		if (of_property_read_u32(dn, "led-num", &priv->ports[pn].led_num))
+			priv->ports[pn].led_num = 0;
+
 		if (of_property_read_u32(dn, "led-set", &led_set))
 			led_set = 0;
 		priv->ports[pn].led_set = led_set;

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -3,6 +3,7 @@
 #ifndef _RTL838X_H
 #define _RTL838X_H
 
+#include <linux/types.h>
 #include <net/dsa.h>
 
 /* Register definition */
@@ -622,6 +623,7 @@ struct rtl838x_port {
 	bool is2G5;
 	int sds_num;
 	int led_set;
+	u32 led_num;
 	const struct dsa_port *dp;
 };
 

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -554,23 +554,6 @@ typedef enum {
 #define RTL930X_L3_HW_LU_CTRL			(0xACC0)
 #define RTL930X_L3_IP_ROUTE_CTRL		0xab44
 
-/* Port LED Control */
-#define RTL930X_LED_PORT_NUM_CTRL(p)		(0xCC04 + (((p >> 4) << 2)))
-#define RTL930X_LED_SET0_0_CTRL			(0xCC28)
-#define RTL930X_LED_PORT_COPR_SET_SEL_CTRL(p)	(0xCC2C + (((p >> 4) << 2)))
-#define RTL930X_LED_PORT_FIB_SET_SEL_CTRL(p)	(0xCC34 + (((p >> 4) << 2)))
-#define RTL930X_LED_PORT_COPR_MASK_CTRL		(0xCC3C)
-#define RTL930X_LED_PORT_FIB_MASK_CTRL		(0xCC40)
-#define RTL930X_LED_PORT_COMBO_MASK_CTRL	(0xCC44)
-
-#define RTL931X_LED_PORT_NUM_CTRL(p)		(0x0604 + (((p >> 4) << 2)))
-#define RTL931X_LED_SET0_0_CTRL			(0x0630)
-#define RTL931X_LED_PORT_COPR_SET_SEL_CTRL(p)	(0x0634 + (((p >> 4) << 2)))
-#define RTL931X_LED_PORT_FIB_SET_SEL_CTRL(p)	(0x0644 + (((p >> 4) << 2)))
-#define RTL931X_LED_PORT_COPR_MASK_CTRL		(0x0654)
-#define RTL931X_LED_PORT_FIB_MASK_CTRL		(0x065c)
-#define RTL931X_LED_PORT_COMBO_MASK_CTRL	(0x0664)
-
 #define MAX_VLANS 4096
 #define MAX_LAGS 16
 #define MAX_PRIOS 8

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -3,9 +3,32 @@
 #ifndef _NET_DSA_RTL83XX_H
 #define _NET_DSA_RTL83XX_H
 
+#include <linux/bitops.h>
 #include <net/dsa.h>
 #include "rtl838x.h"
 
+/* The size of a register for the otto platform */
+#define REALTEK_REG_SIZE        BITS_PER_TYPE(u32)
+
+/* Register port offset. e.g. 16 config bits per port -> 2 ports per reg */
+#define REALTEK_REG_PORT_OFFSET(port, bits_per_port, offset) \
+        (((port) / (REALTEK_REG_SIZE / (bits_per_port))) * offset)
+
+/* Register port index. e.g. 3rd port is the first set of bits of the reg */
+#define REALTEK_REG_PORT_INDEX(port, bits_per_port) \
+        (((port) % (REALTEK_REG_SIZE / (bits_per_port))) * (bits_per_port))
+
+/* Size of array to hold all port config bits. E.g. 4 bits per port needs 2 elements (if port num < 32) */
+#define REALTEK_PORT_ARRAY_SIZE(port, bits_per_port) \
+        ((((port) / REALTEK_REG_SIZE) + 1) * bits_per_port)
+
+/* Index to element in array holding config bits. E.g. port 9 with 4 bits per port, yields index 1 */
+#define REALTEK_PORT_ARRAY_INDEX(port, bits_per_port) \
+        (((port) * (bits_per_port)) / REALTEK_REG_SIZE)
+
+/* Get (first) port matching an index. E.g. with 2 bits per port and array index 1 -> port 16 */
+#define REALTEK_INDEX_ARRAY_PORT(index, bits_per_port) \
+        ((index) * (REALTEK_REG_SIZE / (bits_per_port)))
 
 #define RTL8380_VERSION_A 'A'
 #define RTL8390_VERSION_A 'A'

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -5,6 +5,8 @@
 
 #include "rtl83xx.h"
 
+#define RTL930X_LED_GLB_CTRL_LED_ACTIVE                         BIT(22)
+
 #define RTL930X_VLAN_PORT_TAG_STS_INTERNAL			0x0
 #define RTL930X_VLAN_PORT_TAG_STS_UNTAG				0x1
 #define RTL930X_VLAN_PORT_TAG_STS_TAGGED			0x2
@@ -20,8 +22,6 @@
 #define RTL930X_VLAN_PORT_TAG_STS_CTRL_EGR_P_ITAG_KEEP_MASK	GENMASK(2,2)
 #define RTL930X_VLAN_PORT_TAG_STS_CTRL_IGR_P_OTAG_KEEP_MASK	GENMASK(1,1)
 #define RTL930X_VLAN_PORT_TAG_STS_CTRL_IGR_P_ITAG_KEEP_MASK	GENMASK(0,0)
-
-#define RTL930X_LED_GLB_ACTIVE_LOW				BIT(22)
 
 extern struct mutex smi_lock;
 extern struct rtl83xx_soc_info soc_info;
@@ -2431,13 +2431,11 @@ static void rtl930x_led_init(struct rtl838x_switch_priv *priv)
 	}
 
 	/* Set LED mode to serial (0x1) */
-	sw_w32_mask(0x3, 0x1, RTL930X_LED_GLB_CTRL);
-
-	/* Set LED active state */
-	if (of_property_read_bool(node, "active-low"))
-		sw_w32_mask(RTL930X_LED_GLB_ACTIVE_LOW, 0, RTL930X_LED_GLB_CTRL);
-	else
-		sw_w32_mask(0, RTL930X_LED_GLB_ACTIVE_LOW, RTL930X_LED_GLB_CTRL);
+	sw_w32_mask(RTL930X_LED_GLB_CTRL_LED_ACTIVE |
+	            0x3,
+	            (of_property_read_bool(node, "active-high") ? RTL930X_LED_GLB_CTRL_LED_ACTIVE : 0) |
+	            0x1,
+	            RTL930X_LED_GLB_CTRL);
 
 	/* Set port type masks */
 	sw_w32(pm, RTL930X_LED_PORT_COPR_MASK_CTRL);

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -5,7 +5,71 @@
 
 #include "rtl83xx.h"
 
-#define RTL930X_LED_GLB_CTRL_LED_ACTIVE                         BIT(22)
+#define RTL930X_LED_GLB_CTRL_REG                        (0xcc00)
+#define RTL930X_LED_GLB_CTRL_CFG_MDX_DELAY                     GENMASK(31, 28)
+#define RTL930X_LED_GLB_CTRL_LED_STACK_FTG_IGNORE              BIT(27)
+#define RTL930X_LED_GLB_CTRL_LED_STACK                         GENMASK(26, 25)
+#define RTL930X_LED_GLB_CTRL_LED_STACK_DISABLE                         0x0
+#define RTL930X_LED_GLB_CTRL_LED_STACK_TRIGGER_OUTPUT                  0x1
+#define RTL930X_LED_GLB_CTRL_LED_STACK_TRIGGER_INPUT                   0x2
+/* Reserved                                                            0x3 */
+#define RTL930X_LED_GLB_CTRL_LEDIC_PAGE_ACCESS                 BIT(24)
+#define RTL930X_LED_GLB_CTRL_LEDIC_RESTART                     BIT(23)
+#define RTL930X_LED_GLB_CTRL_LED_ACTIVE                        BIT(22)
+#define RTL930X_LED_GLB_CTRL_LED_SIGNAL_INVERT                 BIT(21)
+#define RTL930X_LED_GLB_CTRL_BLINK_TIME_SEL                    GENMASK(20, 18)
+#define RTL930X_LED_GLB_CTRL_LED_CLK_SEL                       GENMASK(17, 16)
+#define RTL930X_LED_GLB_CTRL_LED_LOAD_EN                       BIT(15)
+#define RTL930X_LED_GLB_CTRL_SYS_LED_MODE                      GENMASK(14, 13)
+#define RTL930X_LED_GLB_CTRL_SYS_LED_EN                        BIT(12)
+#define RTL930X_LED_GLB_CTRL_STP2_PWR_ON_LED                   GENMASK(11, 8)
+#define RTL930X_LED_GLB_CTRL_STP1_PWR_ON_LED                   GENMASK(7, 4)
+#define RTL930X_LED_GLB_CTRL_PWR_ON_BLINK_SEL                  GENMASK(3, 2)
+#define RTL930X_LED_GLB_CTRL_LED_MODE                          GENMASK(1, 0)
+#define RTL930X_LED_GLB_CTRL_LED_MODE_DISABLE                          0x0
+#define RTL930X_LED_GLB_CTRL_LED_MODE_SERIAL                           0x1
+#define RTL930X_LED_GLB_CTRL_LED_MODE_SCAN_SINGLECOLOR                 0x2
+#define RTL930X_LED_GLB_CTRL_LED_MODE_SCAN_BICOLOR                     0x3
+
+#define RTL930X_LED_PORT_NUM_CTRL_REG(p)                ((0xcc04) + REALTEK_REG_PORT_OFFSET((p), 2, 0x4))
+#define _RTL930X_LED_PORT_NUM_CTRL_SEL_MASK                     GENMASK(1, 0)
+#define RTL930X_LED_PORT_NUM_CTRL_SEL(p, l) \
+        (((l) & _RTL930X_LED_PORT_NUM_CTRL_SEL_MASK) << REALTEK_REG_PORT_INDEX((p), 2))
+#define RTL930X_LED_PORT_NUM_CTRL_SEL_COUNT                     4
+#define RTL930X_LED_PORT_NUM_CTRL_COUNT                         4
+
+/* Index number counts down (3 - 0), and address runs up (0xcc00 - 0xcc28) */
+#define __LS2P(set, led) \
+        (((set) * RTL930X_LED_PORT_NUM_CTRL_COUNT) + (led))
+#define RTL930X_LED_SET_CTRL_REG(s, l)                  ((0xcc28) - REALTEK_REG_PORT_OFFSET(__LS2P(s, l), 16, 0x4))
+#define _RTL930X_LED_SET_CTRL_LED_MASK                          GENMASK(15, 0)
+#define RTL930X_LED_SET_CTRL_LED(led, sel) \
+        (((sel) & _RTL930X_LED_SET_CTRL_LED_MASK) << REALTEK_REG_PORT_INDEX(led, 16))
+
+#define RTL930X_LED_PORT_COPR_SET_SEL_CTRL_REG(p)       ((0xcc2c) + REALTEK_REG_PORT_OFFSET((p), 2, 0x4))
+#define _RTL930X_LED_PORT_COPR_SET_SEL_CTRL_SET_MASK            GENMASK(1, 0)
+#define RTL930X_LED_PORT_COPR_SET_SEL_CTRL_SET(p, l) \
+        (((l) & _RTL930X_LED_PORT_COPR_SET_SEL_CTRL_SET_MASK) << REALTEK_REG_PORT_INDEX((p), 2))
+
+#define RTL930X_LED_PORT_FIB_SET_SEL_CTRL_REG(p)        ((0xcc34) + REALTEK_REG_PORT_OFFSET((p), 2, 0x4))
+#define _RTL930X_LED_PORT_FIB_SET_SEL_CTRL_SET_MASK             GENMASK(1, 0)
+#define RTL930X_LED_PORT_FIB_SET_SEL_CTRL_SET(p, l) \
+        (((l) & _RTL930X_LED_PORT_FIB_SET_SEL_CTRL_SET_MASK) << REALTEK_REG_PORT_INDEX((p), 2))
+
+#define RTL930X_LED_PORT_COPR_MASK_CTRL_REG(p)          ((0xcc3c) + REALTEK_REG_PORT_OFFSET((p), 1, 0x4))
+#define _RTL930X_LED_PORT_COPR_MASK_CTRL_MASK                   BIT(0)
+#define RTL930X_LED_PORT_COPR_MASK_CTRL_PMASK(p, m) \
+        (((m) & _RTL930X_LED_PORT_COPR_MASK_CTRL_MASK) << REALTEK_REG_PORT_INDEX((p), 1))
+
+#define RTL930X_LED_PORT_FIB_MASK_CTRL_REG(p)           ((0xcc40) + REALTEK_REG_PORT_OFFSET((p), 1, 0x4))
+#define _RTL930X_LED_PORT_FIB_MASK_CTRL_MASK                    BIT(0)
+#define RTL930X_LED_PORT_FIB_MASK_CTRL_PMASK(p, m) \
+        (((m) & _RTL930X_LED_PORT_FIB_MASK_CTRL_MASK) << REALTEK_REG_PORT_INDEX((p), 1))
+
+#define RTL930X_LED_PORT_COMBO_MASK_CTRL_REG(p)         ((0xcc44) + REALTEK_REG_PORT_OFFSET((p), 1, 0x4))
+#define _RTL930X_LED_PORT_COMBO_MASK_CTRL_MASK                  BIT(0)
+#define RTL930X_LED_PORT_COMBO_MASK_CTRL_PMASK(p, m) \
+        (((m) & _RTL930X_LED_PORT_COMBO_MASK_CTRL_MASK) << REALTEK_REG_PORT_INDEX((p), 1))
 
 #define RTL930X_VLAN_PORT_TAG_STS_INTERNAL			0x0
 #define RTL930X_VLAN_PORT_TAG_STS_UNTAG				0x1
@@ -2379,71 +2443,78 @@ void rtl930x_set_distribution_algorithm(int group, int algoidx, u32 algomsk)
 
 static void rtl930x_led_init(struct rtl838x_switch_priv *priv)
 {
+	u32 led_copper_port_set[REALTEK_PORT_ARRAY_SIZE(RTL930X_CPU_PORT, 2)] = { 0x00 };
+	u32 led_fiber_port_set[REALTEK_PORT_ARRAY_SIZE(RTL930X_CPU_PORT, 2)] = { 0x00 };
+	u32 port_mask_copper[REALTEK_PORT_ARRAY_SIZE(RTL930X_CPU_PORT, 1)] = { 0x0 };
+	u32 port_mask_fiber[REALTEK_PORT_ARRAY_SIZE(RTL930X_CPU_PORT, 1)] = { 0x0 };
+	u32 port_mask_combo[REALTEK_PORT_ARRAY_SIZE(RTL930X_CPU_PORT, 1)] = { 0x0 };
+	u32 led_port_num[REALTEK_PORT_ARRAY_SIZE(RTL930X_CPU_PORT, 2)] = { 0x00 };
 	struct device_node *node;
-	u32 pm = 0;
 
 	pr_info("%s called\n", __func__);
-	node = of_find_compatible_node(NULL, NULL, "realtek,rtl9300-leds");
+
+	node = of_find_compatible_node(NULL, NULL, "realtek,rtl930x-leds");
 	if (!node) {
-		pr_info("%s No compatible LED node found\n", __func__);
+		pr_warn("%s No compatible LED node found\n", __func__);
 		return;
 	}
 
-	for (int i = 0; i < priv->cpu_port; i++) {
-		int pos = (i << 1) % 32;
-		u32 set;
-		u32 v;
+	for (int led_set = 0; led_set < RTL930X_LED_PORT_NUM_CTRL_COUNT; led_set++) {
+		u16 led_sel[RTL930X_LED_PORT_NUM_CTRL_SEL_COUNT] = { 0x0000 };
+		char led_set_name[sizeof("led_setN")];
 
-		sw_w32_mask(0x3 << pos, 0, RTL930X_LED_PORT_FIB_SET_SEL_CTRL(i));
-		sw_w32_mask(0x3 << pos, 0, RTL930X_LED_PORT_COPR_SET_SEL_CTRL(i));
-
-		if (!priv->ports[i].phy)
-			continue;
-
-		v = 0x1;
-		if (priv->ports[i].is10G)
-			v = 0x3;
-		if (priv->ports[i].phy_is_integrated)
-			v = 0x1;
-		sw_w32_mask(0x3 << pos, v << pos, RTL930X_LED_PORT_NUM_CTRL(i));
-
-		pm |= BIT(i);
-
-		set = priv->ports[i].led_set;
-		sw_w32_mask(0, set << pos, RTL930X_LED_PORT_COPR_SET_SEL_CTRL(i));
-		sw_w32_mask(0, set << pos, RTL930X_LED_PORT_FIB_SET_SEL_CTRL(i));
+		snprintf(led_set_name, sizeof(led_set_name), "led_set%d", led_set);
+		of_property_read_u16_array(node, led_set_name, led_sel, RTL930X_LED_PORT_NUM_CTRL_SEL_COUNT);
+		for (int led = 0; led < RTL930X_LED_PORT_NUM_CTRL_SEL_COUNT; led += 2)
+			sw_w32(RTL930X_LED_SET_CTRL_LED(led + 0, led_sel[led + 0]) |
+			       RTL930X_LED_SET_CTRL_LED(led + 1, led_sel[led + 1]),
+			       RTL930X_LED_SET_CTRL_REG(led_set, led));
 	}
 
-	for (int i = 0; i < 4; i++) {
-		const __be32 *led_set;
-		char set_name[9];
-		u32 setlen;
-		u32 v;
-
-		sprintf(set_name, "led_set%d", i);
-		led_set = of_get_property(node, set_name, &setlen);
-		if (!led_set || setlen != 16)
-			break;
-		v = be32_to_cpup(led_set) << 16 | be32_to_cpup(led_set + 1);
-		sw_w32(v, RTL930X_LED_SET0_0_CTRL - 4 - i * 8);
-		v = be32_to_cpup(led_set + 2) << 16 | be32_to_cpup(led_set + 3);
-		sw_w32(v, RTL930X_LED_SET0_0_CTRL - i * 8);
-	}
-
-	/* Set LED mode to serial (0x1) */
 	sw_w32_mask(RTL930X_LED_GLB_CTRL_LED_ACTIVE |
-	            0x3,
+	            RTL930X_LED_GLB_CTRL_LED_MODE,
 	            (of_property_read_bool(node, "active-high") ? RTL930X_LED_GLB_CTRL_LED_ACTIVE : 0) |
-	            0x1,
-	            RTL930X_LED_GLB_CTRL);
+	            RTL930X_LED_GLB_CTRL_LED_MODE_SERIAL,
+	            RTL930X_LED_GLB_CTRL_REG);
 
-	/* Set port type masks */
-	sw_w32(pm, RTL930X_LED_PORT_COPR_MASK_CTRL);
-	sw_w32(pm, RTL930X_LED_PORT_FIB_MASK_CTRL);
-	sw_w32(pm, RTL930X_LED_PORT_COMBO_MASK_CTRL);
+	/* TODO can we not setup this from where led_set gets setup? */
+	/* Cache registers first, to avoid huge amounts of read-modify-write's */
+	for (int port = 0; port < priv->cpu_port; port++) {
+		u32 led_num = hweight32(priv->ports[port].led_num);
 
-	for (int i = 0; i < 24; i++)
-		pr_info("%s %08x: %08x\n",__func__, 0xbb00cc00 + i * 4, sw_r32(0xcc00 + i * 4));
+		if (led_num == 0)
+			continue;
+		else
+			led_num--;
+
+		led_port_num[REALTEK_PORT_ARRAY_INDEX(port, 2)] |= RTL930X_LED_PORT_NUM_CTRL_SEL(port, led_num);
+
+		led_copper_port_set[REALTEK_PORT_ARRAY_INDEX(port, 2)] |= RTL930X_LED_PORT_COPR_SET_SEL_CTRL_SET(port, priv->ports[port].led_set);
+		/* TODO probably need 2 properties, no need to have these tied together */
+		led_fiber_port_set[REALTEK_PORT_ARRAY_INDEX(port, 2)] |= RTL930X_LED_PORT_FIB_SET_SEL_CTRL_SET(port, priv->ports[port].led_set);
+
+		/* TODO: Should determine the exact type and exactly set the masks based on phy-mode/type */
+		if (priv->ports[port].phy) {
+			if (priv->ports[port].phy_is_integrated)
+				port_mask_fiber[REALTEK_PORT_ARRAY_INDEX(port, 1)] |= RTL930X_LED_PORT_FIB_MASK_CTRL_PMASK(port, true);
+			else
+				port_mask_copper[REALTEK_PORT_ARRAY_INDEX(port, 1)] |= RTL930X_LED_PORT_COPR_MASK_CTRL_PMASK(port, true);
+			/* TODO need to figure out if leds are either/or */
+			port_mask_combo[REALTEK_PORT_ARRAY_INDEX(port, 1)] |= RTL930X_LED_PORT_COMBO_MASK_CTRL_PMASK(port, true);
+		}
+	}
+
+	for (int i = 0; i < REALTEK_PORT_ARRAY_SIZE(priv->cpu_port, 2); i++) {
+		sw_w32(led_copper_port_set[i], RTL930X_LED_PORT_COPR_SET_SEL_CTRL_REG(REALTEK_INDEX_ARRAY_PORT(i, 2)));
+		sw_w32(led_fiber_port_set[i], RTL930X_LED_PORT_FIB_SET_SEL_CTRL_REG(REALTEK_INDEX_ARRAY_PORT(i, 2)));
+		sw_w32(led_port_num[i], RTL930X_LED_PORT_NUM_CTRL_REG(REALTEK_INDEX_ARRAY_PORT(i, 2)));
+	}
+
+	for (int i = 0; i < REALTEK_PORT_ARRAY_SIZE(priv->cpu_port, 1); i++) {
+		sw_w32(port_mask_copper[i], RTL930X_LED_PORT_COPR_MASK_CTRL_REG(REALTEK_INDEX_ARRAY_PORT(i, 1)));
+		sw_w32(port_mask_fiber[i], RTL930X_LED_PORT_FIB_MASK_CTRL_REG(REALTEK_INDEX_ARRAY_PORT(i, 1)));
+		sw_w32(port_mask_combo[i], RTL930X_LED_PORT_COMBO_MASK_CTRL_REG(REALTEK_INDEX_ARRAY_PORT(i, 1)));
+	}
 }
 
 const struct rtl838x_reg rtl930x_reg = {

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -4,6 +4,63 @@
 
 #include "rtl83xx.h"
 
+#define RTL931X_LED_GLB_CTRL_REG                        (0x0600)
+#define RTL931X_LED_GLB_CTRL_LED_STREAM_XCHG                   BIT(24)
+#define RTL931X_LED_GLB_CTRL_LEDIC_RESTART                     BIT(23)
+#define RTL931X_LED_GLB_CTRL_LEDIC_PAGE_ACCESS                 BIT(21)
+#define RTL931X_LED_GLB_CTRL_LED_ACTIVE                        BIT(21)
+#define RTL931X_LED_GLB_CTRL_LED_SIGNAL_INVERT                 BIT(20)
+#define RTL931X_LED_GLB_CTRL_BLINK_TIME_SEL                    GENMASK(19, 17)
+#define RTL931X_LED_GLB_CTRL_LED_CLK_SEL                       GENMASK(16, 15)
+#define RTL931X_LED_GLB_CTRL_LED_LOAD_EN                       BIT(14)
+#define RTL931X_LED_GLB_CTRL_SYS_LED_MODE                      GENMASK(13, 12)
+#define RTL931X_LED_GLB_CTRL_STP2_PWR_ON_LED                   GENMASK(11, 8)
+#define RTL931X_LED_GLB_CTRL_STP1_PWR_ON_LED                   GENMASK(7, 4)
+#define RTL931X_LED_GLB_CTRL_PWR_ON_BLINK_SEL                  GENMASK(3, 2)
+#define RTL931X_LED_GLB_CTRL_LED_MODE                          GENMASK(1, 0)
+#define RTL931X_LED_GLB_CTRL_LED_MODE_DISABLE                          0x0
+#define RTL931X_LED_GLB_CTRL_LED_MODE_SERIAL                           0x1
+#define RTL931X_LED_GLB_CTRL_LED_MODE_SCAN_SINGLECOLOR                 0x2
+#define RTL931X_LED_GLB_CTRL_LED_MODE_SCAN_BICOLOR                     0x3
+
+#define RTL931X_LED_PORT_NUM_CTRL_REG(p)                ((0x0604) + REALTEK_REG_PORT_OFFSET(p, 2, 0x4))
+#define _RTL931X_LED_PORT_NUM_CTRL_SEL_MASK                     GENMASK(1, 0)
+#define RTL931X_LED_PORT_NUM_CTRL_SEL(p, l) \
+        (((l) & _RTL931X_LED_PORT_NUM_CTRL_SEL_MASK) << REALTEK_REG_PORT_INDEX((p), 2))
+#define RTL931X_LED_PORT_NUM_CTRL_SEL_COUNT                     4
+#define RTL931X_LED_PORT_NUM_CTRL_COUNT                         4
+
+/* Index number counts down (3 - 0), and address runs up (0x0630 - 0x0614) */
+#define RTL931X_LED_SET_CTRL_REG(set, led)              ((0x0630) - REALTEK_REG_PORT_OFFSET(((set) * 4) + (led), 16, 0x4))
+#define _RTL931X_LED_SET_CTRL_LED_MASK                          GENMASK(16, 0)
+#define RTL931X_LED_SET_CTRL_LED(led, sel) \
+        (((sel) & _RTL931X_LED_SET_CTRL_LED_MASK) << REALTEK_REG_PORT_INDEX(led, 16))
+
+#define RTL931X_LED_PORT_COPR_SET_SEL_CTRL_REG(p)       ((0x0634) + REALTEK_REG_PORT_OFFSET((p), 2, 0x4))
+#define _RTL931X_LED_PORT_COPR_SET_SEL_CTRL_SET_MASK            GENMASK(1, 0)
+#define RTL931X_LED_PORT_COPR_SET_SEL_CTRL_SET(l, p) \
+        (((l) & _RTL931X_LED_PORT_COPR_SET_SEL_CTRL_SET_MASK) << REALTEK_REG_PORT_INDEX((p), 2))
+
+#define RTL931X_LED_PORT_FIB_SET_SEL_CTRL_REG(p)        ((0x0644) + REALTEK_REG_PORT_OFFSET((p), 2, 0x4))
+#define _RTL931X_LED_PORT_FIB_SET_SEL_CTRL_SET_MASK             GENMASK(1, 0)
+#define RTL931X_LED_PORT_FIB_SET_SEL_CTRL_SET(l, p) \
+        (((l) & _RTL931X_LED_PORT_FIB_SET_SEL_CTRL_SET_MASK) << REALTEK_REG_PORT_INDEX((p), 2))
+
+#define RTL931X_LED_PORT_COPR_MASK_CTRL_REG(p)          ((0x0654) + (((p) / (REALTEK_REG_SIZE / 1)) * 0x4))
+#define _RTL931X_LED_PORT_COPR_MASK_CTRL_MASK                   BIT(0)
+#define RTL931X_LED_PORT_COPR_MASK_CTRL_PMASK(p, m) \
+        (((m) & _RTL931X_LED_PORT_COPR_MASK_CTRL_MASK) << REALTEK_REG_PORT_INDEX((p), 1))
+
+#define RTL931X_LED_PORT_FIB_MASK_CTRL_REG(p)           ((0x065c) + (((p) / REALTEK_REG_SIZE) * 0x4))
+#define _RTL931X_LED_PORT_FIB_MASK_CTRL_MASK                    BIT(0)
+#define RTL931X_LED_PORT_FIB_MASK_CTRL_PMASK(p, m) \
+        (((m) & _RTL931X_LED_PORT_FIB_MASK_CTRL_MASK) << REALTEK_REG_PORT_INDEX((p), 1))
+
+#define RTL931X_LED_PORT_COMBO_MASK_CTRL_REG(p)         ((0x0664) + REALTEK_REG_PORT_OFFSET((p), 1, 0x4))
+#define _RTL931X_LED_PORT_COMBO_MASK_CTRL_MASK                  BIT(0)
+#define RTL931X_LED_PORT_COMBO_MASK_CTRL_PMASK(p, m) \
+        (((m) & _RTL931X_LED_PORT_COMBO_MASK_CTRL_MASK) << REALTEK_REG_PORT_INDEX((p), 1))
+
 #define RTL931X_VLAN_PORT_TAG_STS_INTERNAL			0x0
 #define RTL931X_VLAN_PORT_TAG_STS_UNTAG				0x1
 #define RTL931X_VLAN_PORT_TAG_STS_TAGGED			0x2
@@ -1559,66 +1616,78 @@ void rtl931x_set_distribution_algorithm(int group, int algoidx, u32 algomsk)
 
 static void rtl931x_led_init(struct rtl838x_switch_priv *priv)
 {
-	u64 pm_copper = 0, pm_fiber = 0;
+	u32 led_copper_port_set[REALTEK_PORT_ARRAY_SIZE(RTL931X_CPU_PORT, 2)] = { 0x00 };
+	u32 led_fiber_port_set[REALTEK_PORT_ARRAY_SIZE(RTL931X_CPU_PORT, 2)] = { 0x00 };
+	u32 port_mask_copper[REALTEK_PORT_ARRAY_SIZE(RTL931X_CPU_PORT, 1)] = { 0x0 };
+	u32 port_mask_fiber[REALTEK_PORT_ARRAY_SIZE(RTL931X_CPU_PORT, 1)] = { 0x0 };
+	u32 port_mask_combo[REALTEK_PORT_ARRAY_SIZE(RTL931X_CPU_PORT, 1)] = { 0x0 };
+	u32 led_port_num[REALTEK_PORT_ARRAY_SIZE(RTL931X_CPU_PORT, 2)] = { 0x00 };
 	struct device_node *node;
 
 	pr_info("%s called\n", __func__);
-	node = of_find_compatible_node(NULL, NULL, "realtek,rtl9300-leds");
+
+	node = of_find_compatible_node(NULL, NULL, "realtek,rtl931x-leds");
 	if (!node) {
 		pr_info("%s No compatible LED node found\n", __func__);
 		return;
 	}
 
-	for (int i = 0; i < priv->cpu_port; i++) {
-		int pos = (i << 1) % 32;
-		u32 set;
-		u32 v;
+	for (int led_set = 0; led_set < RTL931X_LED_PORT_NUM_CTRL_COUNT; led_set++) {
+		u16 led_sel[RTL931X_LED_PORT_NUM_CTRL_SEL_COUNT] = { 0x0000 };
+		char led_set_name[sizeof("led_setN")];
 
-		sw_w32_mask(0x3 << pos, 0, RTL931X_LED_PORT_FIB_SET_SEL_CTRL(i));
-		sw_w32_mask(0x3 << pos, 0, RTL931X_LED_PORT_COPR_SET_SEL_CTRL(i));
+		snprintf(led_set_name, sizeof(led_set_name), "led_set%d", led_set);
+		of_property_read_u16_array(node, led_set_name, led_sel, RTL931X_LED_PORT_NUM_CTRL_SEL_COUNT);
+		for (int led = 0; led < RTL931X_LED_PORT_NUM_CTRL_SEL_COUNT; led += 2)
+			sw_w32(RTL931X_LED_SET_CTRL_LED(led + 0, led_sel[led + 0]) |
+			       RTL931X_LED_SET_CTRL_LED(led + 1, led_sel[led + 1]),
+			       RTL931X_LED_SET_CTRL_REG(led_set, led));
+	}
 
-		if (!priv->ports[i].phy)
-			continue;
+	sw_w32_mask(RTL931X_LED_GLB_CTRL_LED_ACTIVE |
+	            RTL931X_LED_GLB_CTRL_LED_MODE,
+	            (of_property_read_bool(node, "active-high") ? RTL931X_LED_GLB_CTRL_LED_ACTIVE : 0) |
+	            RTL931X_LED_GLB_CTRL_LED_MODE_SERIAL,
+	            RTL931X_LED_GLB_CTRL_REG);
 
-		v = 0x1; /* Found on the EdgeCore, but we do not have any HW description */
-		sw_w32_mask(0x3 << pos, v << pos, RTL931X_LED_PORT_NUM_CTRL(i));
+	/* TODO can we not setup this from where led_set gets setup? */
+	/* Cache registers first, to avoid huge amounts of read-modify-write's */
+	for (int port = 0; port < priv->cpu_port; port++) {
+		u32 led_num = hweight32(priv->ports[port].led_num);
 
-		if (priv->ports[i].phy_is_integrated)
-		pm_fiber |= BIT_ULL(i);
+		if (led_num == 0)
+		/*	continue*/;
+		else
+			led_num--;
+
+		led_port_num[REALTEK_PORT_ARRAY_INDEX(port, 2)] |= RTL931X_LED_PORT_NUM_CTRL_SEL(port, led_num);
+
+		led_copper_port_set[REALTEK_PORT_ARRAY_INDEX(port, 2)] |= RTL931X_LED_PORT_COPR_SET_SEL_CTRL_SET(port, priv->ports[port].led_set);
+		/* TODO probably need 2 properties, no need to have these tied together */
+		led_fiber_port_set[REALTEK_PORT_ARRAY_INDEX(port, 2)] |= RTL931X_LED_PORT_FIB_SET_SEL_CTRL_SET(port, priv->ports[port].led_set);
+
+		/* TODO: Should determine the exact type and exactly set the masks based on phy-mode/type */
+		if (priv->ports[port].phy) {
+			if (priv->ports[port].phy_is_integrated)
+				port_mask_fiber[REALTEK_PORT_ARRAY_INDEX(port, 1)] |= RTL931X_LED_PORT_FIB_MASK_CTRL_PMASK(port, true);
 			else
-		pm_copper |= BIT_ULL(i);
-
-		set = priv->ports[i].led_set;
-		sw_w32_mask(0, set << pos, RTL931X_LED_PORT_COPR_SET_SEL_CTRL(i));
-		sw_w32_mask(0, set << pos, RTL931X_LED_PORT_FIB_SET_SEL_CTRL(i));
+				port_mask_copper[REALTEK_PORT_ARRAY_INDEX(port, 1)] |= RTL931X_LED_PORT_COPR_MASK_CTRL_PMASK(port, true);
+			/* TODO need to figure out if leds are either/or */
+			port_mask_combo[REALTEK_PORT_ARRAY_INDEX(port, 1)] |= RTL931X_LED_PORT_COMBO_MASK_CTRL_PMASK(port, true);
+		}
 	}
 
-	for (int i = 0; i < 4; i++) {
-		const __be32 *led_set;
-		char set_name[9];
-		u32 setlen;
-		u32 v;
-
-		sprintf(set_name, "led_set%d", i);
-		pr_info(">%s<\n", set_name);
-		led_set = of_get_property(node, set_name, &setlen);
-		if (!led_set || setlen != 16)
-			break;
-		v = be32_to_cpup(led_set) << 16 | be32_to_cpup(led_set + 1);
-		sw_w32(v, RTL931X_LED_SET0_0_CTRL - 4 - i * 8);
-		v = be32_to_cpup(led_set + 2) << 16 | be32_to_cpup(led_set + 3);
-		sw_w32(v, RTL931X_LED_SET0_0_CTRL - i * 8);
+	for (int i = 0; i < REALTEK_PORT_ARRAY_SIZE(priv->cpu_port, 2); i++) {
+		sw_w32(led_copper_port_set[i], RTL931X_LED_PORT_COPR_SET_SEL_CTRL_REG(REALTEK_INDEX_ARRAY_PORT(i, 2)));
+		sw_w32(led_fiber_port_set[i], RTL931X_LED_PORT_FIB_SET_SEL_CTRL_REG(REALTEK_INDEX_ARRAY_PORT(i, 2)));
+		sw_w32(led_port_num[i], RTL931X_LED_PORT_NUM_CTRL_REG(REALTEK_INDEX_ARRAY_PORT(i, 2)));
 	}
 
-	/* Set LED mode to serial (0x1) */
-	sw_w32_mask(0x3, 0x1, RTL931X_LED_GLB_CTRL);
-
-	rtl839x_set_port_reg_le(pm_copper, RTL931X_LED_PORT_COPR_MASK_CTRL);
-	rtl839x_set_port_reg_le(pm_fiber, RTL931X_LED_PORT_FIB_MASK_CTRL);
-	rtl839x_set_port_reg_le(pm_copper | pm_fiber, RTL931X_LED_PORT_COMBO_MASK_CTRL);
-
-	for (int i = 0; i < 32; i++)
-		pr_info("%s %08x: %08x\n",__func__, 0xbb000600 + i * 4, sw_r32(0x0600 + i * 4));
+	for (int i = 0; i < REALTEK_PORT_ARRAY_SIZE(priv->cpu_port, 1); i++) {
+		sw_w32(port_mask_copper[i], RTL931X_LED_PORT_COPR_MASK_CTRL_REG(REALTEK_INDEX_ARRAY_PORT(i, 1)));
+		sw_w32(port_mask_fiber[i], RTL931X_LED_PORT_FIB_MASK_CTRL_REG(REALTEK_INDEX_ARRAY_PORT(i, 1)));
+		sw_w32(port_mask_combo[i], RTL931X_LED_PORT_COMBO_MASK_CTRL_REG(REALTEK_INDEX_ARRAY_PORT(i, 1)));
+	}
 }
 
 const struct rtl838x_reg rtl931x_reg = {

--- a/target/linux/realtek/files-5.15/include/dt-bindings/leds/leds-realtek.h
+++ b/target/linux/realtek/files-5.15/include/dt-bindings/leds/leds-realtek.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/*
+ * This header provides constants for the Realtek RTL83xx/RTL93xx led controller
+ */
+
+#ifndef _DT_BINDINGS_LEDS_REALTEK_H
+#define _DT_BINDINGS_LEDS_REALTEK_H __FILE__
+
+/* RTL93XX number of leds configuration bitmap */
+#define RTL93XX_LED_NONE                (0x0)
+#define RTL93XX_LED_NUM0                (1 << 0)
+#define RTL93XX_LED_NUM1                (1 << 1)
+#define RTL93XX_LED_NUM2                (1 << 2)
+#define RTL93XX_LED_NUM3                (1 << 3)
+
+#endif /* _DT_BINDINGS_LEDS_REALTEK_H */

--- a/target/linux/realtek/files-5.15/include/dt-bindings/leds/leds-realtek.h
+++ b/target/linux/realtek/files-5.15/include/dt-bindings/leds/leds-realtek.h
@@ -13,4 +13,23 @@
 #define RTL93XX_LED_NUM2                (1 << 2)
 #define RTL93XX_LED_NUM3                (1 << 3)
 
+/* RTL93XX 16bit LED SET configuration bitmap */
+#define RTL93XX_LED_SET_NONE            (0x0000)
+#define RTL93XX_LED_SET_10G_LINK        (1 << 0)
+#define RTL93XX_LED_SET_5G_LINK         (1 << 1)
+#define RTL93XX_LED_SET_2P_2G5_LINK     (1 << 2)
+#define RTL93XX_LED_SET_2G5_LINK        (1 << 3)
+#define RTL93XX_LED_SET_2P_1G_LINK      (1 << 4)
+#define RTL93XX_LED_SET_1000M_LINK      (1 << 5)
+#define RTL93XX_LED_SET_500M_LINK       (1 << 6)
+#define RTL93XX_LED_SET_100M_LINK       (1 << 7)
+#define RTL93XX_LED_SET_10M_LINK        (1 << 8)
+#define RTL93XX_LED_SET_LINK_UP_SOLID   (1 << 9)
+#define RTL93XX_LED_SET_LINK_UP_BLINK   (1 << 10)
+#define RTL93XX_LED_SET_LINK_ACTIVITY   (1 << 11)
+#define RTL93XX_LED_SET_RX_ACTIVITY     (1 << 12)
+#define RTL93XX_LED_SET_TX_ACTIVITY     (1 << 13)
+#define RTL93XX_LED_SET_COLLISION       (1 << 14)
+#define RTL93XX_LED_SET_FULL_DUPLEX     (1 << 15)
+
 #endif /* _DT_BINDINGS_LEDS_REALTEK_H */


### PR DESCRIPTION
This MR refactors the current led_init functionality of the rtl930x. It is only a small stepping stone for later, but helps us understand the RTL930x behavior better.

Note, that it also fixes LEDS on non XGS1250-12 targets, which would cause leds to be off as it doesn't account for led-counts.