### PR TITLE
[21.02] mac80211: Update to version 5.10.168-1

### DIFF
--- a/package/kernel/mac80211/Makefile
+++ b/package/kernel/mac80211/Makefile
@@ -10,10 +10,10 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=mac80211
 
-PKG_VERSION:=5.10.157-1
+PKG_VERSION:=5.10.168-1
 PKG_RELEASE:=1
-PKG_SOURCE_URL:=@KERNEL/linux/kernel/projects/backports/stable/v5.10.157/
-PKG_HASH:=1ce937c49f2b39be00768fba83e214aad6612d469c92ccd06dc17b14e6cf3a64
+PKG_SOURCE_URL:=@KERNEL/linux/kernel/projects/backports/stable/v5.10.168/
+PKG_HASH:=ba43215e99b367febaad507c94423b156c7af9a415d978fbc630e9e8d6641d73
 
 PKG_SOURCE:=backports-$(PKG_VERSION).tar.xz
 PKG_BUILD_DIR:=$(KERNEL_BUILD_DIR)/backports-$(PKG_VERSION)

--- a/package/kernel/mac80211/patches/brcm/861-brcmfmac-workaround-bug-with-some-inconsistent-BSSes.patch
+++ b/package/kernel/mac80211/patches/brcm/861-brcmfmac-workaround-bug-with-some-inconsistent-BSSes.patch
@@ -10,7 +10,7 @@ Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c
-@@ -715,8 +715,36 @@ static struct wireless_dev *brcmf_cfg802
+@@ -718,8 +718,36 @@ static struct wireless_dev *brcmf_cfg802
  	struct brcmf_cfg80211_info *cfg = wiphy_to_cfg(wiphy);
  	struct brcmf_pub *drvr = cfg->pub;
  	struct wireless_dev *wdev;

--- a/package/kernel/mac80211/patches/brcm/862-brcmfmac-Disable-power-management.patch
+++ b/package/kernel/mac80211/patches/brcm/862-brcmfmac-Disable-power-management.patch
@@ -14,7 +14,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.org>
 
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c
-@@ -2961,6 +2961,10 @@ brcmf_cfg80211_set_power_mgmt(struct wip
+@@ -2964,6 +2964,10 @@ brcmf_cfg80211_set_power_mgmt(struct wip
  	 * preference in cfg struct to apply this to
  	 * FW later while initializing the dongle
  	 */

--- a/package/kernel/mac80211/patches/brcm/998-survey.patch
+++ b/package/kernel/mac80211/patches/brcm/998-survey.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/cfg80211.c
-@@ -2913,6 +2913,63 @@ done:
+@@ -2916,6 +2916,63 @@ done:
  }
  
  static int
@@ -64,7 +64,7 @@
  brcmf_cfg80211_dump_station(struct wiphy *wiphy, struct net_device *ndev,
  			    int idx, u8 *mac, struct station_info *sinfo)
  {
-@@ -3008,6 +3065,7 @@ static s32 brcmf_inform_single_bss(struc
+@@ -3011,6 +3068,7 @@ static s32 brcmf_inform_single_bss(struc
  	struct brcmu_chan ch;
  	u16 channel;
  	u32 freq;
@@ -72,7 +72,7 @@
  	u16 notify_capability;
  	u16 notify_interval;
  	u8 *notify_ie;
-@@ -3032,6 +3090,17 @@ static s32 brcmf_inform_single_bss(struc
+@@ -3035,6 +3093,17 @@ static s32 brcmf_inform_single_bss(struc
  		band = NL80211_BAND_5GHZ;
  
  	freq = ieee80211_channel_to_frequency(channel, band);
@@ -90,7 +90,7 @@
  	bss_data.chan = ieee80211_get_channel(wiphy, freq);
  	bss_data.scan_width = NL80211_BSS_CHAN_WIDTH_20;
  	bss_data.boottime_ns = ktime_to_ns(ktime_get_boottime());
-@@ -5518,6 +5587,7 @@ static struct cfg80211_ops brcmf_cfg8021
+@@ -5521,6 +5590,7 @@ static struct cfg80211_ops brcmf_cfg8021
  	.leave_ibss = brcmf_cfg80211_leave_ibss,
  	.get_station = brcmf_cfg80211_get_station,
  	.dump_station = brcmf_cfg80211_dump_station,

--- a/package/kernel/mac80211/patches/subsys/397-disable-mbssid.patch
+++ b/package/kernel/mac80211/patches/subsys/397-disable-mbssid.patch
@@ -10,7 +10,7 @@
  			continue;
 --- a/net/wireless/scan.c
 +++ b/net/wireless/scan.c
-@@ -2012,6 +2012,7 @@ static const struct element
+@@ -2013,6 +2013,7 @@ static const struct element
  	const struct element *next_mbssid;
  	const struct element *next_sub;
  
@@ -18,7 +18,7 @@
  	next_mbssid = cfg80211_find_elem(WLAN_EID_MULTIPLE_BSSID,
  					 mbssid_end,
  					 ielen - (mbssid_end - ie));
-@@ -2093,6 +2094,7 @@ static void cfg80211_parse_mbssid_data(s
+@@ -2094,6 +2095,7 @@ static void cfg80211_parse_mbssid_data(s
  	u16 capability;
  	struct cfg80211_bss *bss;
  
@@ -26,7 +26,7 @@
  	if (!non_tx_data)
  		return;
  	if (!cfg80211_find_ie(WLAN_EID_MULTIPLE_BSSID, ie, ielen))
-@@ -2253,6 +2255,7 @@ cfg80211_update_notlisted_nontrans(struc
+@@ -2254,6 +2256,7 @@ cfg80211_update_notlisted_nontrans(struc
  	const struct cfg80211_bss_ies *old;
  	size_t cpy_len;
  
@@ -34,11 +34,11 @@
  	lockdep_assert_held(&wiphy_to_rdev(wiphy)->bss_lock);
  
  	ie = mgmt->u.probe_resp.variable;
-@@ -2470,6 +2473,7 @@ cfg80211_inform_bss_frame_data(struct wi
- 
+@@ -2472,6 +2475,7 @@ cfg80211_inform_bss_frame_data(struct wi
  	res = cfg80211_inform_single_bss_frame_data(wiphy, data, mgmt,
  						    len, gfp);
+ 
 +	return res;
- 	if (!res || !wiphy->support_mbssid ||
- 	    !cfg80211_find_ie(WLAN_EID_MULTIPLE_BSSID, ie, ielen))
+ 	/* don't do any further MBSSID handling for S1G */
+ 	if (ieee80211_is_s1g_beacon(mgmt->frame_control))
  		return res;


### PR DESCRIPTION
This update mac80211 to version 5.10.165-test2. This includes multiple bugfixes. Some of these bugfixes are fixing security relevant bugs.

I will update this commit to a final backports release before merging.