### PR TITLE
lantiq: ar9/vr9: add fritz-tffs package

### DIFF
--- a/target/linux/lantiq/image/ar9.mk
+++ b/target/linux/lantiq/image/ar9.mk
@@ -8,7 +8,7 @@ define Device/avm_fritz7312
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ltq-deu-ar9 -swconfig
+	kmod-ltq-deu-ar9 fritz-tffs -swconfig
 endef
 TARGET_DEVICES += avm_fritz7312
 
@@ -24,7 +24,7 @@ define Device/avm_fritz7320
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ltq-deu-ar9 kmod-usb-dwc2 -swconfig
+	kmod-ltq-deu-ar9 kmod-usb-dwc2 fritz-tffs -swconfig
   SUPPORTED_DEVICES += FRITZ7320
 endef
 TARGET_DEVICES += avm_fritz7320

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -152,7 +152,8 @@ define Device/avm_fritz7360sl
   $(Device/AVM)
   DEVICE_MODEL := FRITZ!Box 7360 SL
   IMAGE_SIZE := 15744k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls kmod-usb-dwc2
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+	kmod-usb-dwc2 fritz-tffs
   SUPPORTED_DEVICES += FRITZ7360SL
 endef
 TARGET_DEVICES += avm_fritz7360sl
@@ -163,7 +164,8 @@ define Device/avm_fritz7360-v2
   DEVICE_MODEL := FRITZ!Box 7360
   DEVICE_VARIANT := v2
   IMAGE_SIZE := 32128k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls kmod-usb-dwc2
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+	kmod-usb-dwc2 fritz-tffs
 endef
 TARGET_DEVICES += avm_fritz7360-v2
 
@@ -174,7 +176,8 @@ define Device/avm_fritz7362sl
   DEVICE_MODEL := FRITZ!Box 7362 SL
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls kmod-usb-dwc2 fritz-tffs
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+	kmod-usb-dwc2 fritz-tffs
 endef
 TARGET_DEVICES += avm_fritz7362sl
 
@@ -186,7 +189,8 @@ define Device/avm_fritz7412
   BOARD_NAME := FRITZ7412
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls fritz-tffs-nand fritz-caldata
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+	fritz-tffs-nand fritz-caldata
 endef
 TARGET_DEVICES += avm_fritz7412
 
@@ -197,8 +201,8 @@ define Device/avm_fritz7430
   DEVICE_MODEL := FRITZ!Box 7430
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader kmod-usb-dwc2 wpad-basic-mbedtls \
-	fritz-tffs-nand fritz-caldata
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+	kmod-usb-dwc2 fritz-tffs-nand fritz-caldata
 endef
 TARGET_DEVICES += avm_fritz7430
 


### PR DESCRIPTION
Add fritz-tffs package to AVM devices
Reorder some device's packages for consistency

Signed-off-by: Felix Baumann <felix.bau@gmx.de>

Notes:
I checked all AVM devices whether they have a NOR-Partition called `tffs (1)` and added _fritz-tffs_ when it was missing.
All AVM devices that are NAND-only (`nand-tffs` partition) already have the _fritz-tffs-nand_ package (including the ones in the IPQ40xx target).
It's useful to have this package preinstalled on all AVM devices for checking Bootloader environment variables without having to rely on opkg. (HWRevision, linux_fs_start and several mac address variables are defined here)