### PR TITLE
realtek: use generic earlycon setup on 5.15

### DIFF
--- a/target/linux/realtek/dts-5.15/rtl8382_iodata_bsh-g24mb.dts
+++ b/target/linux/realtek/dts-5.15/rtl8382_iodata_bsh-g24mb.dts
@@ -16,10 +16,6 @@
 		led-upgrade = &led_sys_loop;
 	};
 
-	chosen {
-		bootargs = "console=ttyS0,115200";
-	};
-
 	memory@0 {
 		device_type = "memory";
 		reg = <0x0 0x8000000>;

--- a/target/linux/realtek/dts-5.15/rtl838x.dtsi
+++ b/target/linux/realtek/dts-5.15/rtl838x.dtsi
@@ -117,8 +117,14 @@
 		};
 	};
 
+	aliases {
+		serial0 = &uart0;
+		serial1 = &uart1;
+	};
+
 	chosen {
-		bootargs = "console=ttyS0,115200";
+		bootargs = "earlycon";
+		stdout-path = "serial0:115200n8";
 	};
 
 	cpuintc: cpuintc {

--- a/target/linux/realtek/dts-5.15/rtl838x_hpe_1920.dtsi
+++ b/target/linux/realtek/dts-5.15/rtl838x_hpe_1920.dtsi
@@ -5,7 +5,7 @@
 
 / {
 	chosen {
-		bootargs = "console=ttyS0,38400";
+		stdout-path = "serial0:38400n8";
 	};
 
 	memory@0 {

--- a/target/linux/realtek/dts-5.15/rtl8393_tplink_sg2452p-v4.dts
+++ b/target/linux/realtek/dts-5.15/rtl8393_tplink_sg2452p-v4.dts
@@ -24,7 +24,7 @@
 	};
 
 	chosen {
-		bootargs = "console=ttyS0,38400";
+		stdout-path = "serial0:38400n8";
 	};
 
 	keys {

--- a/target/linux/realtek/dts-5.15/rtl839x.dtsi
+++ b/target/linux/realtek/dts-5.15/rtl839x.dtsi
@@ -142,8 +142,14 @@
 		};
 	};
 
+	aliases {
+		serial0 = &uart0;
+		serial1 = &uart1;
+	};
+
 	chosen {
-		bootargs = "console=ttyS0,115200";
+		bootargs = "earlycon";
+		stdout-path = "serial0:115200n8";
 	};
 
 	cpuintc: cpuintc {

--- a/target/linux/realtek/dts-5.15/rtl83xx_panasonic_mxxeg-pn28xx0k.dtsi
+++ b/target/linux/realtek/dts-5.15/rtl83xx_panasonic_mxxeg-pn28xx0k.dtsi
@@ -6,7 +6,7 @@
 
 / {
 	chosen {
-		bootargs = "console=ttyS0,9600";
+		stdout-path = "serial0:9600n8";
 	};
 
 	memory@0 {

--- a/target/linux/realtek/dts-5.15/rtl930x.dtsi
+++ b/target/linux/realtek/dts-5.15/rtl930x.dtsi
@@ -24,8 +24,14 @@
 		reg = <0x0 0x8000000>;
 	};
 
+	aliases {
+		serial0 = &uart0;
+		serial1 = &uart1;
+	};
+
 	chosen {
-		bootargs = "console=ttyS0,115200";
+		bootargs = "earlycon";
+		stdout-path = "serial0:115200n8";
 	};
 
 	cpuintc: cpuintc {

--- a/target/linux/realtek/dts-5.15/rtl931x.dtsi
+++ b/target/linux/realtek/dts-5.15/rtl931x.dtsi
@@ -28,9 +28,15 @@
 		device_type = "memory";
 		reg = <0x0 0x10000000>;
 	};
-	
+
+	aliases {
+		serial0 = &uart0;
+		serial1 = &uart1;
+	};
+
 	chosen {
-		bootargs = "console=ttyS0,115200";
+		bootargs = "earlycon";
+		stdout-path = "serial0:115200n8";
 	};
 
 	lx_clk: lx_clk {

--- a/target/linux/realtek/files-5.15/arch/mips/rtl838x/prom.c
+++ b/target/linux/realtek/files-5.15/arch/mips/rtl838x/prom.c
@@ -117,9 +117,6 @@ void __init prom_init(void)
 {
 	uint32_t model;
 
-	/* uart0 */
-	setup_8250_early_printk_port(0xb8002000, 2, 0);
-
 	model = sw_r32(RTL838X_MODEL_NAME_INFO);
 	pr_info("RTL838X model is %x\n", model);
 	model = model >> 16 & 0xFFFF;


### PR DESCRIPTION
Use generic earlycon on Linux Kernel instead of initialization in platform setup.
And also, drop bootargs with console= parameter from I-O DATA BSH-G24MB. It uses 115200bps as baud-rate, the same as default in rtl838x.dtsi.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>