### PR TITLE
scripts: support CONFIG_BINARY_FOLDER and size_compare: print a grand total

### DIFF
--- a/scripts/qemustart
+++ b/scripts/qemustart
@@ -158,7 +158,8 @@ parse_args() {
 		return 1
 	}
 	[ -n "$o_subtarget" ] || o_subtarget="generic"
-	o_bindir="bin/targets/$o_target/$o_subtarget"
+	eval "$(grep ^CONFIG_BINARY_FOLDER= .config 2>/dev/null)"
+	o_bindir="${CONFIG_BINARY_FOLDER:-bin}/targets/$o_target/$o_subtarget"
 }
 
 start_qemu_armvirt() {

--- a/scripts/size_compare.sh
+++ b/scripts/size_compare.sh
@@ -75,6 +75,7 @@ package_size () {
 }
 
 compare_sizes () {
+	TOTAL_DIFF="0"
 	for PACKAGE in $PACKAGES; do
 		if [ "$PACKAGE" = "libc" ]; then
 			continue
@@ -92,7 +93,8 @@ compare_sizes () {
 			SIZE_LOCAL=$(tar tzvf "$PACKAGE_FILE" ./data.tar.gz | awk '{ print $3 }')
 		fi
 		SIZE_UPSTREAM=$(package_size "$TMP_INDEX" "$PACKAGE")
-		SIZE_DIFF="$((SIZE_LOCAL-SIZE_UPSTREAM))"
+		SIZE_DIFF="$((SIZE_LOCAL - SIZE_UPSTREAM))"
+		TOTAL_DIFF="$((TOTAL_DIFF + SIZE_DIFF))"
 		if [ "$SIZE_DIFF" -gt 0 ]; then
 			SIZE_DIFF="+$SIZE_DIFF"
 		fi
@@ -102,6 +104,7 @@ compare_sizes () {
 			echo "$PACKAGE is missing upstream"
 		fi
 	done
+	echo "~~~~~~~	total change	${TOTAL_DIFF}"
 }
 
 if [ "$1" = "-h" ]; then

--- a/scripts/size_compare.sh
+++ b/scripts/size_compare.sh
@@ -21,17 +21,20 @@
 ###   -p --package-size 	Check IPK package size and not installed size
 ###   -h --help 		This message
 
-CONFIG_TARGET=$(sed -n 's/^CONFIG_TARGET_BOARD="\(.*\)"$/\1/p' .config)
-CONFIG_SUBTARGET=$(sed -n 's/^CONFIG_TARGET_SUBTARGET="\(.*\)"$/\1/p' .config)
-CONFIG_ARCH=$(sed -n 's/^CONFIG_TARGET_ARCH_PACKAGES="\(.*\)"$/\1/p' .config)
+eval "$(grep \
+	-e ^CONFIG_TARGET_BOARD= \
+	-e ^CONFIG_TARGET_SUBTARGET= \
+	-e ^CONFIG_TARGET_ARCH_PACKAGES= \
+	-e ^CONFIG_BINARY_FOLDER= \
+	.config 2>/dev/null \
+)"
 CONFIG_PACKAGES=$(sed -n 's/^CONFIG_PACKAGE_\(.*\)=y$/\1/p' .config | tr '\n' ' ')
-CONFIG_BIN_DIR=$(sed -n 's/^CONFIG_BINARY_DIR="\(.*\)"$/\1/p' .config)
 
-TARGET=${TARGET:-$CONFIG_TARGET}
-SUBTARGET=${SUBTARGET:-$CONFIG_SUBTARGET}
-ARCH=${ARCH:-$CONFIG_ARCH}
+TARGET=${TARGET:-$CONFIG_TARGET_BOARD}
+SUBTARGET=${SUBTARGET:-$CONFIG_TARGET_SUBTARGET}
+ARCH=${ARCH:-$CONFIG_TARGET_ARCH_PACKAGES}
 PACKAGES=${PACKAGES:-$CONFIG_PACKAGES}
-BIN_DIR=${CONFIG_BIN_DIR:-./bin}
+BIN_DIR=${CONFIG_BINARY_FOLDER:-./bin}
 BASE_URL="${BASE_URL:-https://downloads.openwrt.org/snapshots}"
 CHECK_INSTALLED="${CHECK_INSTALLED:-y}"
 


### PR DESCRIPTION
This solves some minor issues.

For the "print a grand total" patch I took a shortcut:
There's this line: `compare_sizes | sort -g -r` and that breaks setting a global var in compare_sizes(). So the function itself itself prints the total, intentionally with a `~` prefix so it's at the and after sorting...

Whatever, it's just a helper script, good enough :)