### PR TITLE
base-files: add support for retrieving IPv6 assignments

### DIFF
--- a/package/base-files/files/lib/functions/network.sh
+++ b/package/base-files/files/lib/functions/network.sh
@@ -90,6 +90,13 @@ network_get_prefix6() {
 	__network_ifstatus "$1" "$2" "['ipv6-prefix'][0]['address','mask']" "/"
 }
 
+# determine first IPv6 prefix assignment of given logical interface
+# 1: destination variable
+# 2: interface
+network_get_prefix_assignment6() {
+	__network_ifstatus "$1" "$2" "['ipv6-prefix-assignment'][0]['address','mask']" "/"
+}
+
 # determine all IPv4 addresses of given logical interface
 # 1: destination variable
 # 2: interface
@@ -185,6 +192,13 @@ network_get_subnets6() {
 # 2: interface
 network_get_prefixes6() {
 	__network_ifstatus "$1" "$2" "['ipv6-prefix'][*]['address','mask']" "/ "
+}
+
+# determine all IPv6 prefix assignments of given logical interface
+# 1: destination variable
+# 2: interface
+network_get_prefix_assignments6() {
+	__network_ifstatus "$1" "$2" "['ipv6-prefix-assignment'][*]['address','mask']" "/ "
 }
 
 # determine IPv4 gateway of given logical interface


### PR DESCRIPTION
In DHCPv6-PD enabled environments, addresses are assigned to interfaces. These new functions retrieve the IPv6 assigned prefix(es).

Signed-off-by: Mark Baker mark@vpost.net