### PR TITLE
mdadm: revised mdadm config & init logic

### DIFF
--- a/tools/pkgconf/Makefile
+++ b/tools/pkgconf/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pkgconf
-PKG_VERSION:=1.9.5
+PKG_VERSION:=2.0.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://distfiles.dereferenced.org/pkgconf
-PKG_HASH:=1ac1656debb27497563036f7bffc281490f83f9b8457c0d60bcfb638fb6b6171
+PKG_HASH:=3238af7473740844e5159dd8fb6540603e3fbcebf60beb3c8a426cdca2e29c51
 
 PKG_CPE_ID:=cpe:/a:pkgconf:pkgconf
 


### PR DESCRIPTION
This is a significant revision of /etc/init.d/mdadm.  It adds new features, support for new configuration options, safer error handling, (configurable) verbose output, and contains multiple bug fixes.

Most notably, mdadm was being started with the --config flag and that prevented it from using its built in Auto Assembly features. Users were required to put a correct uuid in /etc/config/mdadm.

The new default startup mode is now to automatically assemble all RAID arrays attached to the machine using device scans, rather than configuation options.

A new UCI section, config mdadm global, was added with new options that are supported by the accompanying /etc/init.d/mdadm. Documentation for all new (and previous) options was added as well.  See the /etc/config/mdadmin or mdadm.init file itself for more details.

Additionally, a new stateful 'auto' feature was added that functions similarly to the stateless Auto Assembly feature.  The benefits of stateful auto assembly are to support features that mdadm 4.0 will only read from a configuration file, such as setting the MAILFROM value.  The new mdadm_conf_auto() function will also aid users in troubleshooting. When verbose is turned on it provides tips and better visibility for what's actually happening.

Backward compatibility was retained.  Stateful UCI only configurations are supported.  All previously existing configurations will work in this mode. However, these users will now have to explicitly turn it on.

A new reload_service() function was added to prevent reloads from stopping mdadm.  Reloads will now be ignored, though the stage is set for reloads to trigger scans for new devices.  Explicit restarts still work as expected.

The start_service() function was enhanced to query new UCI mdadm.global options: alert_program, config, email, email_from, monitor_frequency, and verbose.  Each option is documented in /etc/mdadm/config (config.init) and some additional code comments were added.

Finally, error handling and verbose output was enhanced.  Users will know what's going on (if verbose is turned on).

Strict reliance on a shell global ($CONF) was removed and replaced with a single global ($TMP_FILE) that's for development convenience.  When/if a config file is not specified in the UCI config, it will fall back to using $TMP_FILE as the configuration file.

Incremented PKG_RELEASE from 1 to 2

Signed-off-by: Joseph Tingiris <joseph.tingiris@gmail.com>
(rebased and ran through shellcheck)
Signed-off-by: Rosen Penev <rosenp@gmail.com>