### PR TITLE
[21.02] mpc85xx: Drop pci aliases to avoid domain changes

### DIFF
--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/hiveap-330.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/hiveap-330.dts
@@ -234,3 +234,16 @@
 	};
 };
 /include/ "fsl/p1020si-post.dtsi"
+
+/*
+ * For the OpenWrt 22.03 release, since Linux 5.10.138 now uses
+ * aliases to determine PCI domain numbers, drop aliases so as not to
+ * change the sysfs path of our wireless netdevs.
+ */
+
+/ {
+	aliases {
+		/delete-property/ pci0;
+		/delete-property/ pci1;
+	};
+};

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/panda.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/panda.dts
@@ -262,3 +262,17 @@
 	};
 };
 /include/ "fsl/p1020si-post.dtsi"
+
+/*
+ * For the OpenWrt 22.03 release, since Linux 5.10.138 now uses
+ * aliases to determine PCI domain numbers, drop aliases so as not to
+ * change the sysfs path of our wireless netdevs.
+ */
+
+/ {
+	aliases {
+		/delete-property/ pci0;
+		/delete-property/ pci1;
+	};
+};
+

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/red-15w-rev1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/red-15w-rev1.dts
@@ -212,3 +212,17 @@
 };
 
 /include/ "fsl/p1010si-post.dtsi"
+
+/*
+ * For the OpenWrt 22.03 release, since Linux 5.10.138 now uses
+ * aliases to determine PCI domain numbers, drop aliases so as not to
+ * change the sysfs path of our wireless netdevs.
+ */
+
+/ {
+	aliases {
+		/delete-property/ pci0;
+		/delete-property/ pci1;
+	};
+};
+

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
@@ -290,3 +290,16 @@
 		/delete-node/ crypto@30000; /* Pulled in by p1010si-post */
 	};
 };
+
+/*
+ * For the OpenWrt 22.03 release, since Linux 5.10.138 now uses
+ * aliases to determine PCI domain numbers, drop aliases so as not to
+ * change the sysfs path of our wireless netdevs.
+ */
+
+/ {
+	aliases {
+		/delete-property/ pci0;
+		/delete-property/ pci1;
+	};
+};

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/ws-ap3710i.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/ws-ap3710i.dts
@@ -170,3 +170,16 @@
 
 };
 /include/ "fsl/p1020si-post.dtsi"
+
+/*
+ * For the OpenWrt 22.03 release, since Linux 5.10.138 now uses
+ * aliases to determine PCI domain numbers, drop aliases so as not to
+ * change the sysfs path of our wireless netdevs.
+ */
+
+/ {
+	aliases {
+		/delete-property/ pci0;
+		/delete-property/ pci1;
+	};
+};


### PR DESCRIPTION
Backport 7f4b4c29f3489697dca7495216460d0ed5023e02 to openwrt-21.02 to fix firstboot WiFi configuration on mpc85xx.

Fixes: #11002
Closes: #11005 [suppressed by this backport]