### PR TITLE
kernel: kmod-fs-ntfs3: fix typo

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -535,7 +535,7 @@ define KernelPackage/fs-ntfs3
   AUTOLOAD:=$(call AutoLoad,80,ntfs3)
 endef
 
-define KernelPackage/fuse/description
+define KernelPackage/fs-ntfs3/description
  Kernel module for fully functional NTFS filesystem support. It allows
  reading as well as writing.
 


### PR DESCRIPTION
Fix typo that mistaken the description of ntfs3 for fuse.

Signed-off-by: Xu Yiming <xuyiming.open@outlook.com>