### PR TITLE
ipq40xx: fix assignment of lan port numbers for Cell C RTL30VW

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rtl30vw.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rtl30vw.dts
@@ -383,11 +383,11 @@
 &swport3 {
 	status = "okay";
 
-	label = "lan2";
+	label = "lan1";
 };
 
 &swport4 {
 	status = "okay";
 
-	label = "lan1";
+	label = "lan2";
 };


### PR DESCRIPTION
After switching to DSA, the LAN ports in Cell C RTL30VW have swapped numbers. Assigning the right numbers.

Signed-off-by: Cezary Jackiewicz <cezary@eko.one.pl>
