### PR TITLE
ipq806x: add missing enclosing reserved-memory block on C2600/AD7200

### DIFF
--- a/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8064-ad7200-c2600.dtsi
+++ b/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8064-ad7200-c2600.dtsi
@@ -10,14 +10,16 @@
 		device_type = "memory";
 	};
 
-	ramoops@42100000 {
-		compatible = "ramoops";
-		reg = <0x42100000 0x40000>;
-		record-size = <0x4000>;
-		console-size = <0x4000>;
-		ftrace-size = <0x4000>;
-		pmsg-size = <0x4000>;
-	};
+	reserved-memory {
+                ramoops@42100000 {
+                        compatible = "ramoops";
+                        reg = <0x42100000 0x40000>;
+                        record-size = <0x4000>;
+                        console-size = <0x4000>;
+                        ftrace-size = <0x4000>;
+                        pmsg-size = <0x4000>;
+                };
+        };
 
 	aliases {
 		mdio-gpio0 = &mdio0;


### PR DESCRIPTION
Most of the time when booting kernel prints a warning from mm/page_alloc.c when pstore/ramoops is being initialized and ramoops is not functional.

Fix this by moving ramopps node into reserved-memory block as described in kernel documentation.

Fixes: 2964e5024c ("ipq806x: kernel ramoops storage for C2600/AD7200")
Signed-off-by: Filip Matijević <filip.matijevic.pz@gmail.com>
