### PR TITLE
tools/pkgconf: update to 1.9.4 and add PKG_CPE_ID

### DIFF
--- a/tools/pkgconf/Makefile
+++ b/tools/pkgconf/Makefile
@@ -13,6 +13,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://distfiles.dereferenced.org/pkgconf
 PKG_HASH:=daccf1bbe5a30d149b556c7d2ffffeafd76d7b514e249271abdd501533c1d8ae
 
+PKG_CPE_ID:=cpe:/a:pkgconf:pkgconf
+
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/meson.mk
 

--- a/tools/pkgconf/Makefile
+++ b/tools/pkgconf/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pkgconf
-PKG_VERSION:=1.9.3
+PKG_VERSION:=1.9.4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://distfiles.dereferenced.org/pkgconf
-PKG_HASH:=5fb355b487d54fb6d341e4f18d4e2f7e813a6622cf03a9e87affa6a40565699d
+PKG_HASH:=daccf1bbe5a30d149b556c7d2ffffeafd76d7b514e249271abdd501533c1d8ae
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/meson.mk
@@ -22,7 +22,7 @@ HOSTCC := $(HOSTCC_NOCACHE)
 
 MESON_HOST_ARGS += \
 	-Ddefault_library=static \
-	-Dtests=false
+	-Dtests=disabled
 
 define Host/Install
 	$(call Host/Install/Meson)


### PR DESCRIPTION
Release information:
https://github.com/pkgconf/pkgconf/blob/master/NEWS

Fixes CVE-2023-24056.

Further, this commit corrects the "-Dtests" flag and changes it from "false" to "disabled".
