### PR TITLE
dnsmasq: DNS upstream override for NTP

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -981,6 +981,14 @@ dnsmasq_start()
 	append_parm "$cfg" "local" "--local"
 	config_list_foreach "$cfg" "listen_address" append_listenaddress
 	config_list_foreach "$cfg" "server" append_server
+
+	local ntp_dnsupstream
+	config_get ntp_dnsupstream "$cfg" ntp_dnsupstream
+	[ -n "$ntp_dnsupstream" ] && {
+		local ntp_servers="$(uci_get system ntp server | tr ' ' '/')"
+		[ -n "$ntp_servers" ] && xappend "--server=/$ntp_servers/$ntp_dnsupstream"
+	}
+
 	config_list_foreach "$cfg" "rev_server" append_rev_server
 	config_list_foreach "$cfg" "address" append_address
 


### PR DESCRIPTION
This introduce a new option ntp_dnsupstream, that is to be configured with a DNS upstream server. e.g.: uci set dhcp.@dnsmasq[0].ntp_dnsupstream='9.9.9.9'

This will make a dnsmasq config line to override the used DNS upstream for the list of domains at system.ntp.server. e.g.: server=/0.openwrt.pool.ntp.org/1.openwrt.pool.ntp.org/9.9.9.9

This is useful when dnsmasq is used in conjunction with stubby, so that there is not race between sysntpd/ntpd and stubby.

Signed-off-by: Azureit azurite@mailfence.com