### PR TITLE
ath79: add support for ESR900 / ESR1200 / ESR1750

### DIFF
--- a/target/linux/ath79/dts/qca9557_engenius_esr1200.dts
+++ b/target/linux/ath79/dts/qca9557_engenius_esr1200.dts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x_senao_router-dual.dtsi"
+
+/ {
+	compatible = "engenius,esr1200", "qca,qca9557";
+	model = "EnGenius ESR1200";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "amber:power";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wps_amber {
+			label = "amber:wps";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		wps_blue {
+			label = "blue:wps";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&phy0 {
+	qca,mib-poll-interval = <500>;
+
+	qca,ar8327-initvals = <
+		0x04 0x87680000 /* PORT0 PAD MODE CTRL */
+		0x10 0x40000000 /* POWER_ON_STRAP */
+		0x50 0xcf35cf35 /* LED_CTRL0 */
+		0x54 0xcf35cf35 /* LED_CTRL1 */
+		0x58 0xcf35cf35 /* LED_CTRL2 */
+		0x5c 0x03ffff00 /* LED_CTRL3 */
+		0x7c 0x0000007e /* PORT0_STATUS */
+	>;
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};
+
+&wmac {
+	nvmem-cells = <&calibration_art_1000>;
+	nvmem-cell-names = "calibration";
+};
+
+&ath10k_0 {
+	nvmem-cells = <&calibration_art_5000>;
+	nvmem-cell-names = "calibration";
+};

--- a/target/linux/ath79/dts/qca9558_engenius_epg5000.dts
+++ b/target/linux/ath79/dts/qca9558_engenius_epg5000.dts
@@ -62,5 +62,11 @@
 };
 
 &wmac {
-	qca,no-eeprom;
+	nvmem-cells = <&calibration_art_1000>;
+	nvmem-cell-names = "calibration";
+};
+
+&ath10k_0 {
+	nvmem-cells = <&calibration_art_5000>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/dts/qca9558_engenius_epg5000.dts
+++ b/target/linux/ath79/dts/qca9558_engenius_epg5000.dts
@@ -47,8 +47,15 @@
 };
 
 &phy0 {
+	qca,mib-poll-interval = <500>;
+
 	qca,ar8327-initvals = <
-		0x04 0x87600000 /* PORT0 PAD MODE CTRL */
+		0x04 0x87680000 /* PORT0 PAD MODE CTRL */
+		0x10 0x40000000 /* POWER_ON_STRAP */
+		0x50 0xcf35cf35 /* LED_CTRL0 */
+		0x54 0xcf35cf35 /* LED_CTRL1 */
+		0x58 0xcf35cf35 /* LED_CTRL2 */
+		0x5c 0x03ffff00 /* LED_CTRL3 */
 		0x7c 0x0000007e /* PORT0_STATUS */
 	>;
 };

--- a/target/linux/ath79/dts/qca9558_engenius_epg5000.dts
+++ b/target/linux/ath79/dts/qca9558_engenius_epg5000.dts
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "qca955x.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "qca955x_senao_router-dual.dtsi"
 
 / {
 	model = "EnGenius EPG5000";
@@ -47,110 +44,13 @@
 			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		wps {
-			label = "wps";
-			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-	};
 };
 
-&eth0 {
-	status = "okay";
-
-	phy-handle = <&phy0>;
-	pll-data = <0xa6000000 0x00000101 0x00001616>;
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy0: ethernet-phy@0 {
-		reg = <0>;
-
-		qca,ar8327-initvals = <
-			0x04 0x87600000 /* PORT0 PAD MODE CTRL */
-			0x7c 0x0000007e /* PORT0_STATUS */
-			>;
-	};
-};
-
-&pcie0 {
-	status = "okay";
-
-	wifi@0,0 {
-		compatible = "pci168c,003c";
-		reg = <0x0000 0 0 0 0>;
-	};
-};
-
-&spi {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x000000 0x030000>;
-				read-only;
-			};
-
-			partition@30000 {
-				label = "u-boot-env";
-				reg = <0x030000 0x010000>;
-			};
-
-			partition@40000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x040000 0xe50000>;
-			};
-
-			partition@790000 {
-				label = "manufacture";
-				reg = <0xe90000 0x100000>;
-				read-only;
-			};
-
-			partition@ed0000 {
-				label = "backup";
-				reg = <0xf90000 0x010000>;
-				read-only;
-			};
-
-			partition@fe0000 {
-				label = "storage";
-				reg = <0xfa0000 0x050000>;
-				read-only;
-			};
-
-			partition@ff0000 {
-				label = "art";
-				reg = <0xff0000 0x010000>;
-				read-only;
-			};
-		};
-	};
+&phy0 {
+	qca,ar8327-initvals = <
+		0x04 0x87600000 /* PORT0 PAD MODE CTRL */
+		0x7c 0x0000007e /* PORT0_STATUS */
+	>;
 };
 
 &usb_phy1 {
@@ -162,7 +62,5 @@
 };
 
 &wmac {
-	status = "okay";
-
 	qca,no-eeprom;
 };

--- a/target/linux/ath79/dts/qca9558_engenius_esr1750.dts
+++ b/target/linux/ath79/dts/qca9558_engenius_esr1750.dts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x_senao_router-dual.dtsi"
+
+/ {
+	compatible = "engenius,esr1750", "qca,qca9558";
+	model = "EnGenius ESR1750";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "amber:power";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wps_amber {
+			label = "amber:wps";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		wps_blue {
+			label = "blue:wps";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&phy0 {
+	qca,mib-poll-interval = <500>;
+
+	qca,ar8327-initvals = <
+		0x04 0x87680000 /* PORT0 PAD MODE CTRL */
+		0x10 0x40000000 /* POWER_ON_STRAP */
+		0x50 0xcf35cf35 /* LED_CTRL0 */
+		0x54 0xcf35cf35 /* LED_CTRL1 */
+		0x58 0xcf35cf35 /* LED_CTRL2 */
+		0x5c 0x03ffff00 /* LED_CTRL3 */
+		0x7c 0x0000007e /* PORT0_STATUS */
+	>;
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};
+
+&wmac {
+	nvmem-cells = <&calibration_art_1000>;
+	nvmem-cell-names = "calibration";
+};
+
+&ath10k_0 {
+	nvmem-cells = <&calibration_art_5000>;
+	nvmem-cell-names = "calibration";
+};

--- a/target/linux/ath79/dts/qca9558_engenius_esr900.dts
+++ b/target/linux/ath79/dts/qca9558_engenius_esr900.dts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x_senao_router-dual.dtsi"
+
+/ {
+	compatible = "engenius,esr900", "qca,qca9558";
+	model = "EnGenius ESR900";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "amber:power";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wps_amber {
+			label = "amber:wps";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		wps_blue {
+			label = "blue:wps";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&phy0 {
+	qca,mib-poll-interval = <500>;
+
+	qca,ar8327-initvals = <
+		0x04 0x07680000 /* PORT0 PAD MODE CTRL */
+		0x10 0x40000000 /* POWER_ON_STRAP */
+		0x50 0xcf35cf35 /* LED_CTRL0 */
+		0x54 0xcf35cf35 /* LED_CTRL1 */
+		0x58 0xcf35cf35 /* LED_CTRL2 */
+		0x5c 0x03ffff00 /* LED_CTRL3 */
+		0x7c 0x0000007e /* PORT0_STATUS */
+	>;
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};
+
+&wmac {
+	nvmem-cells = <&calibration_art_1000>;
+	nvmem-cell-names = "calibration";
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0,0 {
+		compatible = "pci168c,0033";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&calibration_art_5000>;
+		nvmem-cell-names = "calibration";
+	};
+};

--- a/target/linux/ath79/dts/qca955x_senao_router-dual.dtsi
+++ b/target/linux/ath79/dts/qca955x_senao_router-dual.dtsi
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy0>;
+	pll-data = <0xa6000000 0x00000101 0x00001616>;
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	ath10k_0: wifi@0,0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0000 0 0 0 0>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x030000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x030000 0x010000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x040000 0xe50000>;
+			};
+
+			partition@e90000 {
+				label = "manufacture";
+				reg = <0xe90000 0x100000>;
+				read-only;
+			};
+
+			partition@f90000 {
+				label = "backup";
+				reg = <0xf90000 0x010000>;
+				read-only;
+			};
+
+			partition@fa0000 {
+				label = "storage";
+				reg = <0xfa0000 0x050000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+
+				calibration_art_1000: calibration@1000 {
+					reg = <0x1000 0x440>;
+				};
+
+				calibration_art_5000: calibration@5000 {
+					reg = <0x5000 0x844>;
+				};
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/qca955x_senao_router-dual.dtsi
+++ b/target/linux/ath79/dts/qca955x_senao_router-dual.dtsi
@@ -55,7 +55,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <25000000>;
+		spi-max-frequency = <40000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -287,6 +287,7 @@ ath79_setup_interfaces()
 	dlink,dir-842-c3|\
 	dlink,dir-859-a1|\
 	engenius,epg5000|\
+	engenius,esr900|\
 	sitecom,wlr-7100|\
 	tplink,archer-c2-v3|\
 	tplink,tl-wr1043nd-v4|\
@@ -665,7 +666,8 @@ ath79_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		label_mac=$lan_mac
 		;;
-	engenius,epg5000)
+	engenius,epg5000|\
+	engenius,esr900)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -287,6 +287,7 @@ ath79_setup_interfaces()
 	dlink,dir-842-c3|\
 	dlink,dir-859-a1|\
 	engenius,epg5000|\
+	engenius,esr1200|\
 	engenius,esr1750|\
 	engenius,esr900|\
 	sitecom,wlr-7100|\
@@ -668,6 +669,7 @@ ath79_setup_macs()
 		label_mac=$lan_mac
 		;;
 	engenius,epg5000|\
+	engenius,esr1200|\
 	engenius,esr1750|\
 	engenius,esr900)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -287,6 +287,7 @@ ath79_setup_interfaces()
 	dlink,dir-842-c3|\
 	dlink,dir-859-a1|\
 	engenius,epg5000|\
+	engenius,esr1750|\
 	engenius,esr900|\
 	sitecom,wlr-7100|\
 	tplink,archer-c2-v3|\
@@ -667,6 +668,7 @@ ath79_setup_macs()
 		label_mac=$lan_mac
 		;;
 	engenius,epg5000|\
+	engenius,esr1750|\
 	engenius,esr900)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -43,7 +43,14 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env athaddr) 1)
 		;;
-	engenius,epg5000|\
+	enterasys,ws-ap3705i)
+		caldata_extract "calibrate" 0x1000 0x440
+		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env0 RADIOADDR1)
+		;;
+	extreme-networks,ws-ap3805i)
+		caldata_extract "art" 0x1000 0x440
+		ath9k_patch_mac $(mtd_get_mac_ascii cfg1 RADIOADDR1)
+		;;
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr|\
 	iodata,wn-ac1600dgr2|\
@@ -52,14 +59,6 @@ case "$FIRMWARE" in
 	sitecom,wlr-8100)
 		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env ethaddr)
-		;;
-	enterasys,ws-ap3705i)
-		caldata_extract "calibrate" 0x1000 0x440
-		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env0 RADIOADDR1)
-		;;
-	extreme-networks,ws-ap3805i)
-		caldata_extract "art" 0x1000 0x440
-		ath9k_patch_mac $(mtd_get_mac_ascii cfg1 RADIOADDR1)
 		;;
 	nec,wg800hp)
 		caldata_extract "art" 0x1000 0x440

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -77,14 +77,6 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(mtd_get_mac_ascii u-boot-env athaddr)
 		;;
-	engenius,epg5000|\
-	iodata,wn-ac1167dgr|\
-	iodata,wn-ac1600dgr2|\
-	sitecom,wlr-7100|\
-	zyxel,nbg6616)
-		caldata_extract "art" 0x5000 0x844
-		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) 1)
-		;;
 	engenius,ews511ap)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) 1)
@@ -96,6 +88,13 @@ case "$FIRMWARE" in
 	glinet,gl-ar750)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) 1)
+		;;
+	iodata,wn-ac1167dgr|\
+	iodata,wn-ac1600dgr2|\
+	sitecom,wlr-7100|\
+	zyxel,nbg6616)
+		caldata_extract "art" 0x5000 0x844
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) 1)
 		;;
 	nec,wg800hp)
 		caldata_extract "art" 0x5000 0x844

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -35,6 +35,7 @@ case "$board" in
 		[ "$PHYNBR" -eq 1 ] && \
 			mtd_get_mac_ascii bdcfg "wlanmac" > /sys${DEVPATH}/macaddress
 		;;
+	engenius,epg5000|\
 	engenius,esr1200|\
 	engenius,esr1750|\
 	engenius,esr900)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -35,6 +35,9 @@ case "$board" in
 		[ "$PHYNBR" -eq 1 ] && \
 			mtd_get_mac_ascii bdcfg "wlanmac" > /sys${DEVPATH}/macaddress
 		;;
+	engenius,esr900)
+		macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" "$PHYNBR" > /sys${DEVPATH}/macaddress
+		;;
 	fortinet,fap-221-b)
 		macaddr_add "$(mtd_get_mac_text u-boot 0x3ff80 12)" $((PHYNBR*7+1)) > /sys${DEVPATH}/macaddress
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -35,6 +35,7 @@ case "$board" in
 		[ "$PHYNBR" -eq 1 ] && \
 			mtd_get_mac_ascii bdcfg "wlanmac" > /sys${DEVPATH}/macaddress
 		;;
+	engenius,esr1200|\
 	engenius,esr1750|\
 	engenius,esr900)
 		macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" "$PHYNBR" > /sys${DEVPATH}/macaddress

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -35,6 +35,7 @@ case "$board" in
 		[ "$PHYNBR" -eq 1 ] && \
 			mtd_get_mac_ascii bdcfg "wlanmac" > /sys${DEVPATH}/macaddress
 		;;
+	engenius,esr1750|\
 	engenius,esr900)
 		macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" "$PHYNBR" > /sys${DEVPATH}/macaddress
 		;;

--- a/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -12,6 +12,7 @@ preinit_set_mac_address() {
 		ip link set dev eth0 address $(mtd_get_mac_ascii bdcfg "lanmac")
 		ip link set dev eth1 address $(mtd_get_mac_ascii bdcfg "wanmac")
 		;;
+	engenius,esr1750|\
 	engenius,esr900)
 		ip link set dev eth0 address $(mtd_get_mac_ascii u-boot-env ethaddr)
 		;;

--- a/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -12,6 +12,7 @@ preinit_set_mac_address() {
 		ip link set dev eth0 address $(mtd_get_mac_ascii bdcfg "lanmac")
 		ip link set dev eth1 address $(mtd_get_mac_ascii bdcfg "wanmac")
 		;;
+	engenius,esr1200|\
 	engenius,esr1750|\
 	engenius,esr900)
 		ip link set dev eth0 address $(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -12,6 +12,9 @@ preinit_set_mac_address() {
 		ip link set dev eth0 address $(mtd_get_mac_ascii bdcfg "lanmac")
 		ip link set dev eth1 address $(mtd_get_mac_ascii bdcfg "wanmac")
 		;;
+	engenius,esr900)
+		ip link set dev eth0 address $(mtd_get_mac_ascii u-boot-env ethaddr)
+		;;
 	enterasys,ws-ap3705i)
 		ip link set dev eth0 address $(mtd_get_mac_ascii u-boot-env0 ethaddr)
 		;;

--- a/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -12,6 +12,7 @@ preinit_set_mac_address() {
 		ip link set dev eth0 address $(mtd_get_mac_ascii bdcfg "lanmac")
 		ip link set dev eth1 address $(mtd_get_mac_ascii bdcfg "wanmac")
 		;;
+	engenius,epg5000|\
 	engenius,esr1200|\
 	engenius,esr1750|\
 	engenius,esr900)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1299,6 +1299,20 @@ define Device/engenius_epg5000
 endef
 TARGET_DEVICES += engenius_epg5000
 
+define Device/engenius_esr900
+  SOC := qca9558
+  DEVICE_VENDOR := EnGenius
+  DEVICE_MODEL := ESR900
+  DEVICE_PACKAGES := kmod-usb2
+  IMAGE_SIZE := 14656k
+  IMAGES += factory.dlf
+  IMAGE/factory.dlf := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | \
+	senao-header -r 0x101 -p 0x4e -t 2
+  SUPPORTED_DEVICES += esr900
+endef
+TARGET_DEVICES += engenius_esr900
+
 define Device/engenius_ews511ap
   SOC := qca9531
   DEVICE_VENDOR := EnGenius

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1299,6 +1299,20 @@ define Device/engenius_epg5000
 endef
 TARGET_DEVICES += engenius_epg5000
 
+define Device/engenius_esr1200
+  SOC := qca9557
+  DEVICE_VENDOR := EnGenius
+  DEVICE_MODEL := ESR1200
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct kmod-usb2
+  IMAGE_SIZE := 14656k
+  IMAGES += factory.dlf
+  IMAGE/factory.dlf := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | \
+	senao-header -r 0x101 -p 0x61 -t 2
+  SUPPORTED_DEVICES += esr1200 esr1750 engenius,esr1750
+endef
+TARGET_DEVICES += engenius_esr1200
+
 define Device/engenius_esr1750
   SOC := qca9558
   DEVICE_VENDOR := EnGenius

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1299,6 +1299,20 @@ define Device/engenius_epg5000
 endef
 TARGET_DEVICES += engenius_epg5000
 
+define Device/engenius_esr1750
+  SOC := qca9558
+  DEVICE_VENDOR := EnGenius
+  DEVICE_MODEL := ESR1750
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct kmod-usb2
+  IMAGE_SIZE := 14656k
+  IMAGES += factory.dlf
+  IMAGE/factory.dlf := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | \
+	senao-header -r 0x101 -p 0x62 -t 2
+  SUPPORTED_DEVICES += esr1750 esr1200 engenius,esr1200
+endef
+TARGET_DEVICES += engenius_esr1750
+
 define Device/engenius_esr900
   SOC := qca9558
   DEVICE_VENDOR := EnGenius


### PR DESCRIPTION
These were supported in ar71xx in 18.06

The hardware for all are nearly identical to EPG5000, currently supported.
Also reworking EPG5000 DTS and using nvmem-cells for the radio calibration.