### PR TITLE
ipq807x: add support for Netgear WAX218

### DIFF
--- a/package/boot/uboot-envtools/files/ipq807x
+++ b/package/boot/uboot-envtools/files/ipq807x
@@ -8,7 +8,8 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 case "$board" in
-dynalink,dl-wrx36)
+dynalink,dl-wrx36|\
+netgear,wax218)
 	idx="$(find_mtd_index 0:appsblenv)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000" "2"

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -44,6 +44,7 @@ ALLWIFIBOARDS:= \
 	glinet_gl-s1300 \
 	linksys_ea8300 \
 	linksys_whw03v2 \
+	netgear_wax218 \
 	nokia_ac400i \
 	p2w_r619ac \
 	pakedge_wr-1 \
@@ -147,6 +148,7 @@ $(eval $(call generate-ipq-wifi-package,glinet_gl-ap1300,GL.iNet GL-AP1300))
 $(eval $(call generate-ipq-wifi-package,glinet_gl-s1300,GL.iNet GL-S1300))
 $(eval $(call generate-ipq-wifi-package,linksys_ea8300,Linksys EA8300))
 $(eval $(call generate-ipq-wifi-package,linksys_whw03v2,Linksys WHW03 V2))
+$(eval $(call generate-ipq-wifi-package,netgear_wax218,Netgear WAX218))
 $(eval $(call generate-ipq-wifi-package,nokia_ac400i,Nokia AC400i))
 $(eval $(call generate-ipq-wifi-package,p2w_r619ac,P&W R619AC))
 $(eval $(call generate-ipq-wifi-package,pakedge_wr-1,Pakedge WR-1))

--- a/target/linux/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq807x/base-files/etc/board.d/01_leds
@@ -9,6 +9,11 @@ case "$board" in
 edgecore,eap102)
 	ucidef_set_led_netdev "wan" "WAN" "green:wanpoe" "wan"
 	;;
+netgear,wax218)
+	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "lan"
+	ucidef_set_led_wlan "wlan5g" "WIFI 5GHz" "blue:wlan5g" "phy0radio"
+	ucidef_set_led_wlan "wlan2g" "WIFI 2.4GHz" "blue:wlan2g" "phy1radio"
+	;;
 redmi,ax6|\
 xiaomi,ax3600)
 	ucidef_set_led_netdev "wan" "WAN" "blue:network" "wan"

--- a/target/linux/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq807x/base-files/etc/board.d/02_network
@@ -22,6 +22,9 @@ ipq807x_setup_interfaces()
 	edimax,cax1800)
 		ucidef_set_interfaces_lan_wan "lan"
 		;;
+	netgear,wax218)
+		ucidef_set_interface_lan "lan" "dhcp"
+		;;
 	qnap,301w)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 10g-2" "10g-1"
 		;;

--- a/target/linux/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -13,6 +13,7 @@ case "$FIRMWARE" in
 	edgecore,eap102|\
 	edimax,cax1800|\
 	dynalink,dl-wrx36|\
+	netgear,wax218|\
 	qnap,301w|\
 	redmi,ax6|\
 	xiaomi,ax3600|\

--- a/target/linux/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq807x/base-files/lib/upgrade/platform.sh
@@ -66,7 +66,8 @@ platform_do_upgrade() {
 		fw_setenv upgrade_available 1
 		nand_do_upgrade "$1"
 		;;
-	edimax,cax1800)
+	edimax,cax1800|\
+	netgear,wax218)
 		nand_do_upgrade "$1"
 		;;
 	qnap,301w)

--- a/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8072-wax218.dts
+++ b/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8072-wax218.dts
@@ -1,0 +1,191 @@
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	model = "Netgear WAX218";
+	compatible = "netgear,wax218", "qcom,ipq8074";
+
+	aliases {
+		serial0 = &blsp1_uart5;
+		led-boot = &led_power_amber;
+		led-failsafe = &led_power_amber;
+		led-running = &led_power_amber;
+		led-upgrade = &led_power_amber;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		/*
+		 * Netgear's U-Boot adds "ubi.mtd=rootfs root=mtd:ubi_rootfs"
+		 * That fails to create a UBI block device, so add it here.
+		*/
+		bootargs-append = " ubi.block=0,rootfs root=/dev/ubiblock0_1";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 52 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	led_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&tlmm 18 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&tlmm 19 GPIO_ACTIVE_HIGH>;
+
+		led_gpio: led_gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <1>;
+			enable-gpios = <&tlmm 20 GPIO_ACTIVE_HIGH>;
+			spi-max-frequency = <1000000>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_amber: led_power {
+			label = "amber:power";
+			gpios = <&led_gpio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_lan {
+			label = "blue:lan";
+			gpios = <&led_gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_wlan_2g {
+			label = "blue:wlan2g";
+			gpios = <&led_gpio 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_wlan_5g {
+			label = "blue:wlan5g";
+			gpios = <&led_gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+
+	switch_cpu_bmp = <0x1>;
+	switch_lan_bmp = <0x3e>;
+	switch_wan_bmp = <0x40>;
+	switch_mac_mode = <0x00>;
+	switch_mac_mode1 = <0xff>;
+	switch_mac_mode2 = <0x0f>;
+	bm_tick_mode = <0>;
+	tm_tick_mode = <0>;
+
+	qcom,port_phyinfo {
+		port@5 {
+			port_id = <6>;
+			phy_address = <28>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+
+	qca8081_28: ethernet-phy@28 {
+		reg = <28>;
+	};
+};
+
+&dp6_syn {
+	status = "okay";
+	phy-handle = <&qca8081_28>;
+	label = "lan";
+	nvmem-cells = <&macaddr_ubootenv_ethaddr>;
+	nvmem-cell-names = "mac-address-ascii";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+
+			partition-0-appsblenv {
+				compatible = "fixed-partitions";
+				label = "0:appsblenv";
+				read-only;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					compatible = "u-boot,env";
+					label = "env-data";
+					reg = <0x0 0x40000>;
+
+					macaddr_ubootenv_ethaddr: ethaddr {};
+				};
+			};
+		};
+	};
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Netgear-WAX218";
+};

--- a/target/linux/ipq807x/image/generic.mk
+++ b/target/linux/ipq807x/image/generic.mk
@@ -71,6 +71,23 @@ define Device/edimax_cax1800
 endef
 TARGET_DEVICES += edimax_cax1800
 
+define Device/netgear_wax218
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	ARTIFACTS := web-ui-factory.fit
+	DEVICE_VENDOR := Netgear
+	DEVICE_MODEL := WAX218
+	DEVICE_DTS_CONFIG := config@hk07
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	SOC := ipq8072
+	ARTIFACT/web-ui-factory.fit := append-image initramfs-uImage.itb | \
+		ubinize-kernel | qsdk-ipq-factory-nand
+	DEVICE_PACKAGES := kmod-spi-gpio kmod-spi-bitbang kmod-gpio-nxp-74hc164 \
+		ipq-wifi-netgear_wax218
+endef
+TARGET_DEVICES += netgear_wax218
+
 define Device/qnap_301w
 	$(call Device/FitImage)
 	DEVICE_VENDOR := QNAP


### PR DESCRIPTION

 ipq807x: add support for Netgear WAX218

Netgear WAX218 is a 802.11ax AP claiming AX3600 support. It is wall
or ceiling mountable. It can be powered via PoE, or a 12 V adapter.

The board has footprints for 2.54mm UART headers. They're difficult to
solder because the GND is connected to a large copper plane. Only try
soldering if you are very skilled. Otherwise, use pogo pins.

Specifications:
---------------
    * CPU: Qualcomm IPQ8072A Quad core Cortex-A53 2.2GHz
    * RAM: 366 MB of RAM available to OS, not sure of total amount
    * Storage: Macronix MX30UF2G18AC 256MB NAND
    * Ethernet:
            * 2.5G RJ45 port (QCA8081) with PoE input
    * WLAN:
            * 2.4GHz/5GHz with 8 antennas
    * LEDs:
            * Power (Amber)
            * LAN (Blue)
            * 2G WLAN (Blue)
            * 5G WLAN (Blue)
    * Buttons:
            * 1x Factory reset
    * Power: 12V DC Jack
    * UART: Two 4-pin unpopulated headers near the LEDs
            * "J2 UART" is the CPU UART, 3.3 V level

Installation:
=============

Web UI method
-------------

Flashing OpenWRT using the vendor's Web UI is problematic on this
device. The u-boot mechanism for communicating the active rootfs is
antiquated and unreliable. Instead of setting the kernel commandline,
it relies on patching the DTS partitions of the nand node. The way
partitions are patched is incompatible with newer kernels.

Newer kernels use the SMEM partition table, which puts "rootfs" on
mtd12. The vendor's Web UI will flash to either mtd12 or mtd14. One
reliable way to boot from mtd14 and avoid boot loops is to use an
initramfs image.

 1. In the factory web UI, navigate to System Manager -> Firmware.
 2. In the "Local Firmware Upgrade" section, click Browse
 3. Navigate and select the 'web-ui-factory.fit' image
 4. Click "Upload"
 5. On the following page, click on "Proceed"

The flash proceeds at this point and the system will reboot
automatically to OpenWRT.

 6. Flash the 'nand-sysupgrade.bin' using Luci or the commandline

SSH method
----------

Enable SSH using the CLI or Web UI. The root account is locked out to
ssh, and the admin account defaults to Netgear's CLI application.
So we need to get creative:

First, make sure the device boots from the second firmware partition:

    ssh -okexalgorithms=diffie-hellman-group14-sha1 admin@<ipaddr> \
        /usr/sbin/fw_setenv active_fw 1

Then reboot the device, and run the update:

    scp -O -o kexalgorithms=diffie-hellman-group14-sha1 \
        -o hostkeyalgorithms=ssh-rsa \
        netgear_wax218-squashfs-nand-factory.ubi \
        admin@<ipaddr>:/tmp/openwrt.ubi

    ssh -okexalgorithms=diffie-hellman-group14-sha1 admin@<ipaddr> \
        /usr/sbin/ubiformat /dev/mtd12 -f /tmp/openwrt.ubi

    ssh -okexalgorithms=diffie-hellman-group14-sha1 admin@<ipaddr> \
        /usr/sbin/fw_setenv active_fw 0

Now reboot the device, and it should boot into a ready-to-use OpenWRT.

Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>