### PR TITLE
coreutils: Disable sparse copy on macOS

### DIFF
--- a/tools/coreutils/patches/002-cp-mv-install-Disable-sparse-copy-on-macOS.patch
+++ b/tools/coreutils/patches/002-cp-mv-install-Disable-sparse-copy-on-macOS.patch
@@ -1,0 +1,11 @@
+--- a/src/copy.c
++++ b/src/copy.c
+@@ -1047,7 +1047,7 @@ infer_scantype (int fd, struct stat cons
+          && ST_NBLOCKS (*sb) < sb->st_size / ST_NBLOCKSIZE))
+     return PLAIN_SCANTYPE;
+ 
+-#ifdef SEEK_HOLE
++#if defined(SEEK_HOLE) && !defined(__APPLE__)
+   scan_inference->ext_start = lseek (fd, 0, SEEK_DATA);
+   if (0 <= scan_inference->ext_start || errno == ENXIO)
+     return LSEEK_SCANTYPE;


### PR DESCRIPTION
@hauke @graysky2 @neheb @Ansuel @nbd168 
Fix build errors in `toolchain/musl` and `toolchain/kernel-headers` introduced in https://github.com/openwrt/openwrt/commit/c5608227ef8b705c18fb5323409bc69bd9ca192e tools/coreutils: update to 9.1

Due to a bug in macOS, sparse copies are corrupted on virtual disks formatted with APFS. HFS is not affected.
Affected are coreutils `install`, and `gcp` when compiled with `SEEK_HOLE`, as well as macOS Finder.
When the compiler is installed, a corrupted copy is created, which cannot be executed, so the build fails.

While reading the entire file returns valid data, scanning for allocated segments may return holes where valid data is present. In this case a sparse copy does not contain these segments and return zeroes instead. Once the virtual disk is dismounted and then mounted again, a sparse copy produces correct results.

I tried contacting Apple and the coreutils team in 2021 to no avail. What would be the best way to make them aware?

Tested on macOS 12.6.3 x64, targets WRT3200ACM, x64

Steps to reproduce, config and build log: https://httpstorm.com/share/.openwrt/test/2023-02-06_coreutils-9.1/
- open Disk Utility
- press Command-N to create a new virtual disk
- Image Format: sparse disk image
- save as: ~/vhd/test
- Name: test
- Size: 50 GB
- Format: APFS (Case-sensitive)
- Encryption: none
- Partitions: Single partition - GUID Partition Map
- Save
- clone and build OpenWRT

Build log
```
make[3] -C toolchain/musl compile
    ERROR: toolchain/musl failed to build.
    ERROR: toolchain/kernel-headers failed to build.

make toolchain/kernel-headers/{clean,compile} V=sc
...
gcc -L/Volumes/test/b/openwrt/staging_dir/host/lib -o scripts/kconfig/conf scripts/kconfig/conf.o scripts/kconfig/confdata.o scripts/kconfig/expr.o scripts/kconfig/lexer.lex.o scripts/kconfig/menu.o scripts/kconfig/parser.tab.o scripts/kconfig/preprocess.o scripts/kconfig/symbol.o scripts/kconfig/util.o   
scripts/kconfig/conf  --oldconfig Kconfig
arm-openwrt-linux-muslgnueabi-gcc: unknown compiler
scripts/Kconfig.include:44: Sorry, this compiler is not supported.
make[4]: *** [scripts/kconfig/Makefile:77: oldconfig] Error 1
make[3]: *** [Makefile:621: oldconfig] Error 2
make[3]: Leaving directory '/Volumes/test/b/openwrt/build_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-12.2.0_musl_eabi/linux-5.15.91'
yes: stdout: Broken pipe
make[2]: *** [Makefile:114: /Volumes/test/b/openwrt/build_dir/toolchain-arm_cortex-a9+vfpv3-d16_gcc-12.2.0_musl_eabi/linux-5.15.91/.configured] Error 2
make[2]: Leaving directory '/Volumes/test/b/openwrt/toolchain/kernel-headers'
time: toolchain/kernel-headers/compile#11.74#14.76#24.36
    ERROR: toolchain/kernel-headers failed to build.
make[1]: *** [toolchain/Makefile:97: toolchain/kernel-headers/compile] Error 1
make[1]: Leaving directory '/Volumes/test/b/openwrt'
make: *** [/Volumes/test/b/openwrt/include/toplevel.mk:231: toolchain/kernel-headers/compile] Error 2
```
