### PR TITLE
kernel: set default values for ARM low level debugging symbols

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -387,12 +387,18 @@ config KERNEL_DEBUG_INFO_REDUCED
 	  DEBUG_INFO build and compile times are reduced too.
 	  Only works with newer gcc versions.
 
+# KERNEL_DEBUG_LL symbols must have the default value set as otherwise
+# KConfig wont evaluate them unless KERNEL_EARLY_PRINTK is selected
+# which means that buildroot wont override the DEBUG_LL symbols in target
+# kernel configurations and lead to devices that dont have working console
 config KERNEL_DEBUG_LL_UART_NONE
 	bool
+	default n
 	depends on arm
 
 config KERNEL_DEBUG_LL
 	bool
+	default n
 	depends on arm
 	select KERNEL_DEBUG_LL_UART_NONE
 	help


### PR DESCRIPTION
Set default values for KERNEL_DEBUG_LL and KERNEL_DEBUG_LL_UART_NONE again as both of these symbols are non visible if KERNEL_EARLY_PRINTK is not selected and KConfig wont write their value to .config.

This usually is the intended behaviour, but in OpenWrt we are relying on the KConfig to set these and disable the debug console settings that multiple targets like mvebu have set in their kernel config. This was the behaviour before removing all of the "default n" settings as KConfig by default considers symbols disabled but they are not visible anymore and thus their value is not set in .config and build system then later does not override the values from target kernel config.

So, to restore the behaviour to the previous one lets a default value for KERNEL_DEBUG_LL and KERNEL_DEBUG_LL_UART_NONE.

Fixes: 8bc72ea7be39 ("treewide: strip useless default n Kconfig lines")
Tested-by: Georgi Valkov <gvalkov@gmail.com>
Signed-off-by: Robert Marko <robimarko@gmail.com>