### PR TITLE
toolchain: enable zstd

### DIFF
--- a/toolchain/binutils/Makefile
+++ b/toolchain/binutils/Makefile
@@ -50,7 +50,7 @@ HOST_CONFIGURE_ARGS = \
 	--target=$(REAL_GNU_TARGET_NAME) \
 	--with-sysroot=$(TOOLCHAIN_DIR) \
 	--with-system-zlib \
-	--without-zstd \
+	--with-zstd \
 	--enable-deterministic-archives \
 	--enable-plugins \
 	--enable-lto \

--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -66,6 +66,9 @@ TAR_OPTIONS += \
 	--exclude-from='$(CURDIR)/../exclude-testsuite' --exclude=gcc/ada/*.ad* \
 	--exclude=libjava
 
+# this needs to be without -L/-lzstd flags or other parts fail to build
+# use an absolute path to ensure it really picks up our version
+export ac_cv_search_ZSTD_compress=$(STAGING_DIR_HOST)/lib/libzstd.a -pthread
 export libgcc_cv_fixed_point=no
 ifdef CONFIG_INSTALL_GCCGO
   export libgo_cv_c_split_stack_supported=no
@@ -103,7 +106,7 @@ GCC_CONFIGURE:= \
 		$(if $(CONFIG_arc),--with-cpu=$(CONFIG_CPU_TYPE)) \
 		$(if $(CONFIG_powerpc64), $(if $(CONFIG_USE_MUSL),--with-abi=elfv2)) \
 		--with-system-zlib=$(STAGING_DIR_HOST) \
-		--without-zstd \
+		--with-zstd=$(STAGING_DIR_HOST) \
 		--with-gmp=$(STAGING_DIR_HOST) \
 		--with-mpfr=$(STAGING_DIR_HOST) \
 		--with-mpc=$(STAGING_DIR_HOST) \


### PR DESCRIPTION
The binutils change is noop until 2.40 (2.39 is default)

The GCC change works only on lightweight systems. On some, there's some problem where it causes issues during LTO.

ping @dhewg @anomeome 