### PR TITLE
ath79: add support for GL.iNet GL-X1200

### DIFF
--- a/target/linux/ath79/dts/qca9563_glinet_gl-x1200-nor-nand.dts
+++ b/target/linux/ath79/dts/qca9563_glinet_gl-x1200-nor-nand.dts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9563_glinet_gl-x1200.dtsi"
+
+/ {
+	compatible = "glinet,gl-x1200-nor-nand", "qca,qca9563";
+	model = "GL.iNet GL-X1200 (NOR/NAND)";
+};
+
+&nor_partitions {
+	partition@60000 {
+		label = "kernel";
+		reg = <0x060000 0x400000>;
+
+		/*
+		 * U-Boot bootcmd is "bootm 0x9f060000".
+		 * So this might be possible to resize in the future.
+		 */
+	};
+
+	partition@460000 {
+		label = "nor_reserved";
+		reg = <0x460000 0xba0000>;
+	};
+};
+
+&nand_ubi {
+	label = "ubi";
+};

--- a/target/linux/ath79/dts/qca9563_glinet_gl-x1200-nor.dts
+++ b/target/linux/ath79/dts/qca9563_glinet_gl-x1200-nor.dts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9563_glinet_gl-x1200.dtsi"
+
+/ {
+	compatible = "glinet,gl-x1200-nor", "qca,qca9563";
+	model = "GL.iNet GL-X1200 (NOR)";
+};
+
+&nor_partitions {
+	partition@60000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x060000 0xfa0000>;
+	};
+};

--- a/target/linux/ath79/dts/qca9563_glinet_gl-x1200.dtsi
+++ b/target/linux/ath79/dts/qca9563_glinet_gl-x1200.dtsi
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "red:system";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		wlan2g {
+			label = "green:wlan2g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "green:wlan5g";
+			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_modem1_power {
+			gpio-export,name = "gl-x1200:4g1:power";
+			gpio-export,output = <0>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		gpio_modem2_power {
+			gpio-export,name = "gl-x1200:4g2:power";
+			gpio-export,output = <0>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		nor_partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "art";
+				reg = <0x050000 0x010000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				calibration_ath9k: calibration@1000 {
+					reg = <0x1000 0x440>;
+				};
+
+				calibration_ath10k: calibration@5000 {
+					reg = <0x5000 0x2f20>;
+				};
+
+				macaddr_art_0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_art_1002: macaddr@1002 {
+					reg = <0x1002 0x6>;
+				};
+
+				macaddr_art_5006: macaddr@5006 {
+					reg = <0x5006 0x6>;
+				};
+			};
+
+			/* Firmware / Kernel flash type specific */
+		};
+	};
+
+	flash@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			nand_ubi: partition@0 {
+				label = "nand_ubi";
+				reg = <0x000000 0x8000000>;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy0>;
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gpio {
+	usb_vbus {
+		gpio-hog;
+		gpios = <7 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "usb-vbus";
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0 0 0 0 0>;
+
+		nvmem-cells = <&macaddr_art_5006>, <&calibration_ath10k>;
+		nvmem-cell-names = "mac-address", "pre-calibration";
+	};
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_1002>, <&calibration_ath9k>;
+	nvmem-cell-names = "mac-address", "calibration";
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -212,6 +212,35 @@ define Device/glinet_gl-xe300
 endef
 TARGET_DEVICES += glinet_gl-xe300
 
+define Device/glinet_gl-x1200-common
+  SOC := qca9563
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := GL-X1200
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct-htt kmod-usb2 \
+	kmod-usb-storage block-mount kmod-usb-net-qmi-wwan uqmi
+  IMAGE_SIZE := 16000k
+endef
+
+define Device/glinet_gl-x1200-nor-nand
+  $(Device/glinet_gl-x1200-common)
+  DEVICE_VARIANT := NOR/NAND
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 131072k
+  PAGESIZE := 2048
+  VID_HDR_OFFSET := 2048
+  BLOCKSIZE := 128k
+  IMAGES += factory.img
+  IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += glinet_gl-x1200-nor-nand
+
+define Device/glinet_gl-x1200-nor
+  $(Device/glinet_gl-x1200-common)
+  DEVICE_VARIANT := NOR
+endef
+TARGET_DEVICES += glinet_gl-x1200-nor
+
 define Device/linksys_ea4500-v3
   SOC := qca9558
   DEVICE_VENDOR := Linksys

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -30,6 +30,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "4:lan"
 		;;
+	glinet,gl-x1200-nor|\
+	glinet,gl-x1200-nor-nand)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan"
+		;;
 	linksys,ea4500-v3)
 		ucidef_add_switch "switch0" \
 			"6@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0@eth0"
@@ -87,6 +92,11 @@ ath79_setup_macs()
 	dongwon,dw02-412h-128m)
 		wan_mac=$(mtd_get_mac_binary art 0x0)
 		label_mac=$wan_mac
+		;;
+	glinet,gl-x1200-nor|\
+	glinet,gl-x1200-nor-nand)
+		wan_mac=$(mtd_get_mac_binary art 0x0)
+		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;
 	netgear,wndr3700-v4|\
 	netgear,wndr4300|\

--- a/target/linux/ath79/nand/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/nand/base-files/lib/upgrade/platform.sh
@@ -19,7 +19,9 @@ platform_do_upgrade() {
 		glinet_nand_nor_do_upgrade "$1"
 		;;
 	glinet,gl-ar750s-nor|\
-	glinet,gl-ar750s-nor-nand)
+	glinet,gl-ar750s-nor-nand|\
+	glinet,gl-x1200-nor|\
+	glinet,gl-x1200-nor-nand)
 		nand_nor_do_upgrade "$1"
 		;;
 	*)


### PR DESCRIPTION
This patch adds supports for GL-X1200.

Specification:
	- SOC: QCA9563 (775MHz)
	- Flash: 16 MiB
	- RAM: 128 MiB DDR2
	- Ethernet: 4x 1Gbps LAN + 1x 1Gbps WAN
	- Wireless: QCA9563(2.4GHz) and QCA9886(5GHz)
	- SIM: 2x SIM card slots
	- MicroSD: 1x microSD slot
	- Antenna: 2x external 5dBi antennas
	- USB: 1x USB 2.0 port
	- Button: 1x reset button
	- LED: 16x LEDs (3x GPIO controllable)
	- UART: 1x UART on PCB (JP1: 3.3V, RX, TX, GND)
	- OEM U-Boot supplies HTTP/GUI access

Implementation Notes
====================

Both the NOR and NAND variants boot off a NOR-based kernel,
consistent with the OEM's firmware.

The mode LEDs are
    * Boot, Running   system
    * Failsafe        2G
    * Upgrade         5G

Installation
============

Using sysupgrade
----------------

sysupgrade may be used to install a NAND image on a device running
a NAND image or a NOR image on a device running a NOR image. It is
recommended to *not* preserve config when upgrading from OEM firmware
or previous versions of OpenWrt. No supported sysupgrade path should
require "force". Transitioning from NOR to NAND can be accomplished

Using U-Boot
------------

The OEM U-Boot can be put into a graphical, firmware-upload mode by
holding down the button on the side of the router while applying power
and for a bit more than five seconds following with the current OEM
U-Boot. The power LED will come on, then the 5G LED will flash five
times, about once a second.  When the 5G LED stops flashing and the
2G LED lights solid, the router's U-Boot will provide an upload page
at http://192.168.1.1/ Either a browser may be used to upload an image,
or a utility such as curl may be used:

curl -X POST -F gl_firmware=\@*-nand-squashfs-factory.img \
         http://192.168.1.1/index.html
or
    curl -X POST -F gl_firmware=\@*-nor-squashfs-sysupgrade.bin \
         http://192.168.1.1/index.html

Note that NOR vs. NAND is based on the file name extension.

Signed-off-by: Xinfa Deng <xinfa.deng@gl-inet.com>