### PR TITLE
[22.03] include/bpf.mk: backport minor fixes

### DIFF
--- a/include/bpf.mk
+++ b/include/bpf.mk
@@ -63,12 +63,14 @@ BPF_CFLAGS := \
 	-Wno-unused-label \
 	-O2 -emit-llvm -Xclang -disable-llvm-passes
 
+ifneq ($(CONFIG_HAS_BPF_TOOLCHAIN),)
 ifeq ($(DUMP),)
   CLANG_VER:=$(shell $(CLANG) -dM -E - < /dev/null | grep __clang_major__ | cut -d' ' -f3)
   CLANG_VER_VALID:=$(shell [ "$(CLANG_VER)" -ge "$(CLANG_MIN_VER)" ] && echo 1 )
   ifeq ($(CLANG_VER_VALID),)
     $(error ERROR: LLVM/clang version too old. Minimum required: $(CLANG_MIN_VER), found: $(CLANG_VER))
   endif
+endif
 endif
 
 define CompileBPF

--- a/include/bpf.mk
+++ b/include/bpf.mk
@@ -64,7 +64,7 @@ BPF_CFLAGS := \
 	-O2 -emit-llvm -Xclang -disable-llvm-passes
 
 ifneq ($(CONFIG_HAS_BPF_TOOLCHAIN),)
-ifeq ($(DUMP),)
+ifeq ($(DUMP)$(filter download refresh,$(MAKECMDGOALS)),)
   CLANG_VER:=$(shell $(CLANG) -dM -E - < /dev/null | grep __clang_major__ | cut -d' ' -f3)
   CLANG_VER_VALID:=$(shell [ "$(CLANG_VER)" -ge "$(CLANG_MIN_VER)" ] && echo 1 )
   ifeq ($(CLANG_VER_VALID),)


### PR DESCRIPTION
These are no-change cherry-picks of c58177b5 and 116c73f.  c58177b5 is not strictly necessary, but avoids any issues if someone tries to add something to packages repo that has optional BPF dependency.  The issue described in 116c73f happens in 22.03 with qosify.