### PR TITLE
toolchain: remove outdated hacks and workarounds

### DIFF
--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -29,7 +29,6 @@ EXCLUDE_DIRS:= \
 	*/man \
 	*/info \
 	*/root-* \
-	initial \
 	*.install.clean \
 	*.install.flags \
 	*.install \

--- a/toolchain/binutils/Makefile
+++ b/toolchain/binutils/Makefile
@@ -84,7 +84,6 @@ define Host/Prepare
 	$(call Host/Prepare/Default)
 	ln -snf $(notdir $(HOST_BUILD_DIR)) $(BUILD_DIR_TOOLCHAIN)/$(PKG_NAME)
 	$(CP) $(SCRIPT_DIR)/config.{guess,sub} $(HOST_BUILD_DIR)/
-	$(SED) 's, " Linaro.*,,' $(HOST_BUILD_DIR)/bfd/version.h
 endef
 
 define Host/Compile

--- a/toolchain/binutils/Makefile
+++ b/toolchain/binutils/Makefile
@@ -100,7 +100,6 @@ define Host/Install
 		prefix=$(TOOLCHAIN_DIR) \
 		install
 	$(call FixupLibdir,$(TOOLCHAIN_DIR)/initial)
-	$(RM) $(TOOLCHAIN_DIR)/initial/lib/libiberty.a
 	$(CP) $(TOOLCHAIN_DIR)/bin/$(REAL_GNU_TARGET_NAME)-readelf $(HOST_BUILD_PREFIX)/bin/readelf
 endef
 

--- a/toolchain/binutils/Makefile
+++ b/toolchain/binutils/Makefile
@@ -37,6 +37,12 @@ PATCH_DIR:=./patches/$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/toolchain-build.mk
 
+ifdef CONFIG_GCC_USE_GRAPHITE
+  GRAPHITE_CONFIGURE:= --with-isl=$(STAGING_DIR_HOST)
+else
+  GRAPHITE_CONFIGURE:= --without-isl --without-cloog
+endif
+
 HOST_CONFIGURE_ARGS = \
 	--prefix=$(TOOLCHAIN_DIR) \
 	--build=$(GNU_HOST_NAME) \

--- a/toolchain/binutils/Makefile
+++ b/toolchain/binutils/Makefile
@@ -102,12 +102,6 @@ define Host/Install
 	$(call FixupLibdir,$(TOOLCHAIN_DIR)/initial)
 	$(RM) $(TOOLCHAIN_DIR)/initial/lib/libiberty.a
 	$(CP) $(TOOLCHAIN_DIR)/bin/$(REAL_GNU_TARGET_NAME)-readelf $(HOST_BUILD_PREFIX)/bin/readelf
-	# ARC gcc requires extlib.
-	# If extlib is not available in "initial" folder
-	# initial gcc will fail to build libc.
-	if [ -d $(TOOLCHAIN_DIR)/extlib ]; then \
-		$(CP) -r $(TOOLCHAIN_DIR)/extlib $(TOOLCHAIN_DIR)/initial/; \
-	fi
 endef
 
 define Host/Clean

--- a/toolchain/binutils/Makefile
+++ b/toolchain/binutils/Makefile
@@ -91,14 +91,9 @@ define Host/Compile
 endef
 
 define Host/Install
-	mkdir -p $(TOOLCHAIN_DIR)/initial
 	$(MAKE) -C $(HOST_BUILD_DIR) \
-		prefix=$(TOOLCHAIN_DIR)/initial \
 		install
-	$(MAKE) -C $(HOST_BUILD_DIR) \
-		prefix=$(TOOLCHAIN_DIR) \
-		install
-	$(call FixupLibdir,$(TOOLCHAIN_DIR)/initial)
+	$(call FixupLibdir,$(TOOLCHAIN_DIR))
 	$(CP) $(TOOLCHAIN_DIR)/bin/$(REAL_GNU_TARGET_NAME)-readelf $(HOST_BUILD_PREFIX)/bin/readelf
 endef
 

--- a/toolchain/gcc/initial/Makefile
+++ b/toolchain/gcc/initial/Makefile
@@ -23,10 +23,6 @@ define Host/Install
 		install-gcc \
 		install-target-libgcc
 
-	( cd $(TOOLCHAIN_DIR)/initial/lib/gcc/$(REAL_GNU_TARGET_NAME)/$(PKG_VERSION) ; \
-		cp libgcc.a libgcc_initial.a; \
-	)
-
 	$(call FixupLibdir,$(TOOLCHAIN_DIR)/initial)
 	$$(call file_copy,$(TOOLCHAIN_DIR)/initial/.,$(TOOLCHAIN_DIR)/)
 endef

--- a/toolchain/gcc/initial/Makefile
+++ b/toolchain/gcc/initial/Makefile
@@ -23,9 +23,7 @@ define Host/Install
 		install-gcc \
 		install-target-libgcc
 
-	# XXX: glibc insists on linking against libgcc_eh
 	( cd $(TOOLCHAIN_DIR)/initial/lib/gcc/$(REAL_GNU_TARGET_NAME)/$(PKG_VERSION) ; \
-		[ -e libgcc_eh.a ] || ln -sf libgcc.a libgcc_eh.a ; \
 		cp libgcc.a libgcc_initial.a; \
 	)
 

--- a/toolchain/gcc/initial/Makefile
+++ b/toolchain/gcc/initial/Makefile
@@ -19,12 +19,10 @@ endef
 
 define Host/Install
 	+$(GCC_MAKE) $(HOST_JOBS) -C $(GCC_BUILD_DIR) \
-		prefix="$(TOOLCHAIN_DIR)/initial" \
 		install-gcc \
 		install-target-libgcc
 
-	$(call FixupLibdir,$(TOOLCHAIN_DIR)/initial)
-	$$(call file_copy,$(TOOLCHAIN_DIR)/initial/.,$(TOOLCHAIN_DIR)/)
+	$(call FixupLibdir,$(TOOLCHAIN_DIR))
 endef
 
 $(eval $(call HostBuild))

--- a/toolchain/glibc/Makefile
+++ b/toolchain/glibc/Makefile
@@ -20,7 +20,7 @@ define Host/Install
 		install
 	( cd $(TOOLCHAIN_DIR) ; \
 		for d in lib usr/lib ; do \
-		  for f in libc.so libpthread.so libgcc_s.so ; do \
+		  for f in libc.so libm.so libpthread.so libgcc_s.so ; do \
 		    if [ -f $$$$d/$$$$f -a ! -L $$$$d/$$$$f ] ; then \
 		      $(SED) 's,/usr/lib/,,g;s,/lib/,,g' $$$$d/$$$$f ; \
 		    fi \

--- a/toolchain/musl/Makefile
+++ b/toolchain/musl/Makefile
@@ -9,7 +9,7 @@ HOST_BUILD_PARALLEL:=1
 
 MUSL_MAKEOPTS = -C $(HOST_BUILD_DIR) \
 	DESTDIR="$(TOOLCHAIN_DIR)/" \
-	LIBCC="$(subst libgcc.a,libgcc_initial.a,$(shell $(TARGET_CC) -print-libgcc-file-name))"
+	LIBCC="$(shell $(TARGET_CC) -print-libgcc-file-name)"
 
 define Host/SetToolchainInfo
 	$(SED) 's,^\(LIBC_TYPE\)=.*,\1=$(PKG_NAME),' $(TOOLCHAIN_DIR)/info.mk


### PR DESCRIPTION
While combing through toolchain/ to hunt down problems uncovered in #10862 and #11970 I noticed some irregularities and spots to clean up.

Some are obvious, some less so.
I'm not sure if the last patch with the "initial" dir removal breaks anyone's workflow, let me know if that's the case.

I had to dig rather far into the git history to find the origins of some spots.

Testing on various target/libc combinations look okay so far.

@nbd168 you're active in that corner, how does that look to you?

before:
2.9G	build_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl
436M	staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl

after:
2.9G	build_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl
280M	staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl

With #11970 on top:
2.9G	build_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl
291M	staging_dir/toolchain-aarch64_cortex-a53_gcc-12.2.0_musl