### PR TITLE
ath79: improve LED situation of the GL-XE300

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_gl-xe300.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-xe300.dts
@@ -10,6 +10,9 @@
 	model = "GL.iNet GL-XE300";
 
 	aliases {
+		led-boot = &led_wlan;
+		led-failsafe = &led_wlan;
+		led-upgrade = &led_wlan;
 		label-mac-device = &eth0;
 	};
 
@@ -55,7 +58,7 @@
 			label = "green:wan";
 		};
 
-		wlan {
+		led_wlan: wlan {
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 			label = "green:wlan";
 			linux,default-trigger = "phy0tpt";

--- a/target/linux/ath79/nand/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/nand/base-files/etc/board.d/01_leds
@@ -17,6 +17,7 @@ glinet,gl-ar300m-nor)
 glinet,gl-xe300)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x10"
+	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	ucidef_set_led_netdev "3gnet" "LTE" "green:lte" "wwan0"
 	;;
 netgear,pgzng1)


### PR DESCRIPTION
## ath79: add led aliases for GL-XE300
This adds aliases that are needed to define which LED should be used
to display the current state of the router.

Since there doesn't seems to be a way to use the PWR LED on this device
another LED must be used. I have selected the WLAN LED for this purpose.

Hijacking other LEDs for debugging purposes isn't something new:

- d40956a74c34000fb7ab83fa7deeaa6535ef4e5d (ubnt-xm - link4)
- 3930aab2cb067d04f5c9ebbf1af57744e19355eb (tplink_cpe210-v1 - led_link4)
- 27eae6597e5f1570f2f0a8584907b077e724a0e1 (pqi-air-pen - wlan)
- 59d065c9f81c4d1a89464d071134a50529449f34 (zte_mf283plus - led_wwan_green/led_wwan_red)

Signed-off-by: Tom Herbers <mail@tomherbers.de>

## ath79: add WLAN led for GL-XE300
This commit adds the WLAN led of the GL-XE300 to the default leds config.

Signed-off-by: Tom Herbers <mail@tomherbers.de>