### PR TITLE
sunxi: fix wifi connection for Banana Pi M2 Berry

### DIFF
--- a/target/linux/sunxi/image/cortexa7.mk
+++ b/target/linux/sunxi/image/cortexa7.mk
@@ -81,7 +81,7 @@ define Device/sinovoip_bananapi-m2-berry
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Berry
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi kmod-brcmfmac \
-	brcmfmac-firmware-43430-sdio wpad-basic-wolfssl
+	cypress-firmware-43430-sdio wpad-basic-wolfssl
   SUPPORTED_DEVICES:=lemaker,bananapi-m2-berry
   SOC := sun8i-v40
 endef


### PR DESCRIPTION
sunxi: fix for wifi connection not working for Banana Pi M2 Berry

- fixes the problem that the banana pi m2 berry cannot connect to wifi and cannot be used as an access point