### PR TITLE
busybox: Select missing package for BUSYBOX_CONFIG_FEATURE_WGET_OPENSSL

### DIFF
--- a/package/utils/busybox/config/networking/Config.in
+++ b/package/utils/busybox/config/networking/Config.in
@@ -1209,6 +1209,7 @@ config BUSYBOX_CONFIG_FEATURE_WGET_OPENSSL
 	bool "Try to connect to HTTPS using openssl"
 	default BUSYBOX_DEFAULT_FEATURE_WGET_OPENSSL
 	depends on BUSYBOX_CONFIG_WGET
+	select PACKAGE_openssl-util
 	help
 	Try to use openssl to handle HTTPS.
 


### PR DESCRIPTION
Adding the feature "wget with openssl" should select the required openssl automatically.

Signed-off-by: Stefan Weil <sw@weilnetz.de>