### PR TITLE
sunxi: fix wifi connection for Banana Pi M2 Berry (as a cherry pick)

### DIFF
--- a/target/linux/sunxi/image/cortexa7.mk
+++ b/target/linux/sunxi/image/cortexa7.mk
@@ -81,7 +81,7 @@ define Device/sinovoip_bananapi-m2-berry
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Berry
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi kmod-brcmfmac \
-	brcmfmac-firmware-43430-sdio wpad-basic-wolfssl
+	cypress-firmware-43430-sdio wpad-basic-wolfssl
   SUPPORTED_DEVICES:=lemaker,bananapi-m2-berry
   SOC := sun8i-v40
 endef


### PR DESCRIPTION
This is the same change as in pull request #11984 with the cherry-pick commit ff2bb16730f629d54bde8ba85c75d8614741e3fd which only includes changing the [target/linux/sunxi/image/cortexa7.mk](https://github.com/openwrt/openwrt/blob/ff2bb16730f629d54bde8ba85c75d8614741e3fd/target/linux/sunxi/image/cortexa7.mk) file to fix the wifi issue mentioned in #11984