### PR TITLE
wireless-regdb: update to 2023.02.13

### DIFF
--- a/package/firmware/wireless-regdb/Makefile
+++ b/package/firmware/wireless-regdb/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wireless-regdb
-PKG_VERSION:=2022.08.12
+PKG_VERSION:=2023.02.13
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/network/wireless-regdb/
-PKG_HASH:=59c8f7d17966db71b27f90e735ee8f5b42ca3527694a8c5e6e9b56bd379c3b84
+PKG_HASH:=fe81e8a8694dc4753a45087a1c4c7e1b48dee5a59f5f796ce374ea550f0b2e73
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
Changes:
  7f7a9f7 wireless-regdb: update regulatory database based on preceding changes
  660a1ae wireless-regdb: Update regulatory info for Russia (RU) on 5GHz
  fe05cc9 wireless-regdb: Update regulatory rules for Japan (JP) on 6GHz
  d8584dc wireless-regdb: Update regulatory rules for Japan (JP) on 5GHz
  c04fd9b wireless-regdb: update regulatory rules for Switzerland (CH)
  f29772a wireless-regdb: Update regulatory rules for Brazil (BR)

Signed-off-by: CaffeeLake <PascalCoffeeLake@gmail.com>