### PR TITLE
github: hide text in pull request template

### DIFF
--- a/.github/pull_request_template
+++ b/.github/pull_request_template
@@ -1,8 +1,8 @@
+<!--
 Thanks for your contribution to OpenWrt!
 
 To help keep the codebase consistent and readable,
 and to help people review your contribution,
 we ask you to follow the rules you find in the wiki at this link
 https://openwrt.org/submitting-patches
-
-Please remove this message before posting the pull request.
+-->


### PR DESCRIPTION
GitHub supports using HTML comments, so we can let people see the reminder, but they don't have to remove it and it won't be visible when the PR is created.

This PR contains the reminder right under this message, but it's not visible.
<!--
Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
-->