### PR TITLE
ipq807x: Add bluetooth driver to zyxel nbg7815

### DIFF
--- a/target/linux/ipq807x/image/generic.mk
+++ b/target/linux/ipq807x/image/generic.mk
@@ -141,6 +141,6 @@ define Device/zyxel_nbg7815
 	IMAGES += factory.bin sysupgrade.bin
 	IMAGE/factory.bin := append-rootfs | pad-rootfs | pad-to 64k
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-to 64k | sysupgrade-tar rootfs=$$$$@ | append-metadata
-	DEVICE_PACKAGES := ipq-wifi-zyxel_nbg7815 kmod-ath11k-pci e2fsprogs kmod-fs-ext4 losetup kmod-hwmon-tmp103
+	DEVICE_PACKAGES := ipq-wifi-zyxel_nbg7815 kmod-ath11k-pci e2fsprogs kmod-fs-ext4 losetup kmod-hwmon-tmp103 kmod-bluetooth
 endef
 TARGET_DEVICES += zyxel_nbg7815


### PR DESCRIPTION
Zyxel NBG7815 supports bluetooth with blsp1_uart3.
Configuration are already added to dts file, device needs only module to working bluetooth properly. 
Tested at below posts:
https://forum.openwrt.org/t/openwrt-support-for-armor-g5-nbg7815/98598/259?u=itork
