### PR TITLE
ramips: Alternative name Asus RT-AC750L for Asus RT-AC1200V2

### DIFF
--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -55,6 +55,8 @@ define Device/asus_rt-ac1200-v2
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-AC1200
   DEVICE_VARIANT := V2
+  DEVICE_ALT0_VENDOR := ASUS
+  DEVICE_ALT0_MODEL := RT-AC750L
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs


### PR DESCRIPTION
The Asus RT-AC750L is identical to the already supported Asus RT-AC1200V2. Use the ALT0 buildroot tags to show both devices.

Reference : https://forum.openwrt.org/t/asus-rt-ac750l-is-the-same-as-rt-ac1200-v2/151783

Signed-off-by: Karl Chan exkc@exkc.moe

