### PR TITLE
tools/7z: Allow building on alpine

### DIFF
--- a/tools/7z/patches/7-zip-flags.patch
+++ b/tools/7z/patches/7-zip-flags.patch
@@ -1,0 +1,27 @@
+--- a/CPP/7zip/7zip_gcc.mak
++++ b/CPP/7zip/7zip_gcc.mak
+@@ -18,13 +18,13 @@ PROGPATH_STATIC = $(O)/$(PROG)s
+ 
+ 
+ ifneq ($(CC), xlc)
+-CFLAGS_WARN_WALL = -Wall -Werror -Wextra
++CFLAGS_WARN_WALL = -Wall -Wextra
+ endif
+ 
+ # for object file
+ CFLAGS_BASE_LIST = -c
+ # CFLAGS_BASE_LIST = -S
+-CFLAGS_BASE = -O2 $(CFLAGS_BASE_LIST) $(CFLAGS_WARN_WALL) $(CFLAGS_WARN) \
++CFLAGS_BASE = $(CFLAGS_BASE_LIST) $(CFLAGS_WARN_WALL) $(CFLAGS_WARN) -D_GNU_SOURCE \
+  -DNDEBUG -D_REENTRANT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE \
+  -fPIC
+ 
+@@ -192,7 +192,7 @@ all: $(O) $(PROGPATH) $(STATIC_TARGET)
+ $(O):
+ 	$(MY_MKDIR) $(O)
+ 
+-LFLAGS_ALL = -s $(MY_ARCH_2) $(LDFLAGS) $(LD_arch) $(OBJS) $(MY_LIBS) $(LIB2)
++LFLAGS_ALL = $(MY_ARCH_2) $(LDFLAGS) $(LD_arch) $(OBJS) $(MY_LIBS) $(LIB2)
+ $(PROGPATH): $(OBJS)
+ 	$(CXX) -o $(PROGPATH) $(LFLAGS_ALL)
+ 

--- a/tools/7z/patches/7-zip-musl.patch
+++ b/tools/7z/patches/7-zip-musl.patch
@@ -1,0 +1,59 @@
+--- a/C/CpuArch.c
++++ b/C/CpuArch.c
+@@ -421,8 +421,6 @@ BoolInt CPU_IsSupported_AES (void) { ret
+ 
+ #ifdef USE_HWCAP
+ 
+-#include <asm/hwcap.h>
+-
+   #define MY_HWCAP_CHECK_FUNC_2(name1, name2) \
+   BoolInt CPU_IsSupported_ ## name1() { return (getauxval(AT_HWCAP)  & (HWCAP_  ## name2)) ? 1 : 0; }
+ 
+--- a/C/Threads.c
++++ b/C/Threads.c
+@@ -257,7 +257,7 @@ WRes Thread_Create_With_CpuSet(CThread *
+       */
+ 
+       // ret2 =
+-      pthread_attr_setaffinity_np(&attr, sizeof(*cpuSet), cpuSet);
++      //pthread_attr_setaffinity_np(&attr, sizeof(*cpuSet), cpuSet);
+       // if (ret2) ret = ret2;
+       #endif
+     }
+@@ -267,14 +267,12 @@ WRes Thread_Create_With_CpuSet(CThread *
+     if (!ret)
+     {
+       p->_created = 1;
+-      /*
+       if (cpuSet)
+       {
+         // ret2 =
+         pthread_setaffinity_np(p->_tid, sizeof(*cpuSet), cpuSet);
+         // if (ret2) ret = ret2;
+       }
+-      */
+     }
+   }
+   // ret2 =
+--- a/C/Threads.h
++++ b/C/Threads.h
+@@ -19,6 +19,7 @@
+ #endif
+ 
+ #include <pthread.h>
++#include <sched.h>
+ 
+ #endif
+ 
+--- a/CPP/Windows/SystemInfo.cpp
++++ b/CPP/Windows/SystemInfo.cpp
+@@ -36,9 +36,6 @@
+ #endif
+ */
+ 
+-#ifdef MY_CPU_ARM_OR_ARM64
+-#include <asm/hwcap.h>
+-#endif
+ #endif
+ 
+ #ifdef __linux__


### PR DESCRIPTION
When using alpine as host, things start to fail. Lets pull in the upstream alpine patches to make things work. This should not affect other hosts.

Note, that Alpine has the '_GNU_SOURCE' define in the APKBUILD file, but here we add this flag to the needed fix flags patch, which does similar things too.