### PR TITLE
ipq806x: fix Linksys EAX500 family devices dead Ethernet

### DIFF
--- a/target/linux/ipq806x/files-5.10/arch/arm/boot/dts/qcom-ipq8064-eax500.dtsi
+++ b/target/linux/ipq806x/files-5.10/arch/arm/boot/dts/qcom-ipq8064-eax500.dtsi
@@ -12,6 +12,18 @@
 	};
 };
 
+&qcom_pinmux {
+	/* eax500 routers reuse the pcie2 reset pin for switch reset pin */
+	switch_reset: switch_reset_pins {
+		mux {
+			pins = "gpio63";
+			function = "gpio";
+			drive-strength = <12>;
+			bias-pull-up;
+		};
+	};
+};
+
 &usb3_0 {
 	status = "okay";
 };
@@ -27,10 +39,6 @@
 };
 
 &pcie1 {
-	status = "okay";
-};
-
-&pcie2 {
 	status = "okay";
 };
 
@@ -159,6 +167,10 @@
 
 	pinctrl-0 = <&mdio0_pins>;
 	pinctrl-names = "default";
+
+	/* Switch from documentation require at least 10ms for reset */
+	reset-gpios = <&qcom_pinmux 63 GPIO_ACTIVE_HIGH>;
+	reset-post-delay-us = <12000>;
 
 	phy0: ethernet-phy@0 {
 		reg = <0>;

--- a/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8064-eax500.dtsi
+++ b/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8064-eax500.dtsi
@@ -12,6 +12,18 @@
 	};
 };
 
+&qcom_pinmux {
+	/* eax500 routers reuse the pcie2 reset pin for switch reset pin */
+	switch_reset: switch_reset_pins {
+		mux {
+			pins = "gpio63";
+			function = "gpio";
+			drive-strength = <12>;
+			bias-pull-up;
+		};
+	};
+};
+
 &hs_phy_0 {
 	status = "okay";
 };
@@ -43,10 +55,6 @@
 };
 
 &pcie1 {
-	status = "okay";
-};
-
-&pcie2 {
 	status = "okay";
 };
 
@@ -172,6 +180,10 @@
 
 	pinctrl-0 = <&mdio0_pins>;
 	pinctrl-names = "default";
+
+	/* Switch from documentation require at least 10ms for reset */
+	reset-gpios = <&qcom_pinmux 63 GPIO_ACTIVE_HIGH>;
+	reset-post-delay-us = <12000>;
 
 	phy0: ethernet-phy@0 {
 		reg = <0>;

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -185,7 +185,6 @@ define Device/linksys_ea8500
 	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
 		append-ubi
 	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct
-	DEFAULT := n
 endef
 TARGET_DEVICES += linksys_ea8500
 

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -163,7 +163,6 @@ define Device/linksys_ea7500-v1
 	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
 		append-ubi | pad-to $$$$(PAGESIZE)
 	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct
-	DEFAULT := n
 endef
 TARGET_DEVICES += linksys_ea7500-v1
 

--- a/target/linux/ipq806x/patches-5.10/082-ipq8064-dtsi-tweaks.patch
+++ b/target/linux/ipq806x/patches-5.10/082-ipq8064-dtsi-tweaks.patch
@@ -35,14 +35,6 @@
  			#interrupt-cells = <2>;
  			interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL_HIGH>;
  
-@@ -155,6 +156,7 @@
- 					function = "pcie3_rst";
- 					drive-strength = <12>;
- 					bias-disable;
-+					output-low;
- 				};
- 			};
- 
 @@ -190,6 +192,7 @@
  		intc: interrupt-controller@2000000 {
  			compatible = "qcom,msm-qgic2";

--- a/target/linux/ipq806x/patches-5.10/082-ipq8064-dtsi-tweaks.patch
+++ b/target/linux/ipq806x/patches-5.10/082-ipq8064-dtsi-tweaks.patch
@@ -35,7 +35,7 @@
  			#interrupt-cells = <2>;
  			interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL_HIGH>;
  
-@@ -190,6 +192,7 @@
+@@ -190,6 +191,7 @@
  		intc: interrupt-controller@2000000 {
  			compatible = "qcom,msm-qgic2";
  			interrupt-controller;
@@ -43,7 +43,7 @@
  			#interrupt-cells = <3>;
  			reg = <0x02000000 0x1000>,
  			      <0x02002000 0x1000>;
-@@ -219,21 +222,23 @@
+@@ -219,21 +221,23 @@
  		acc0: clock-controller@2088000 {
  			compatible = "qcom,kpss-acc-v1";
  			reg = <0x02088000 0x1000>, <0x02008000 0x1000>;
@@ -69,7 +69,7 @@
  			reg = <0x02099000 0x1000>, <0x02009000 0x1000>;
  			regulator;
  		};
-@@ -251,7 +256,7 @@
+@@ -251,7 +255,7 @@
  
  			syscon-tcsr = <&tcsr>;
  
@@ -78,7 +78,7 @@
  				compatible = "qcom,msm-uartdm-v1.3", "qcom,msm-uartdm";
  				reg = <0x12490000 0x1000>,
  				      <0x12480000 0x1000>;
-@@ -261,7 +266,7 @@
+@@ -261,7 +265,7 @@
  				status = "disabled";
  			};
  
@@ -87,7 +87,7 @@
  				compatible = "qcom,i2c-qup-v1.1.1";
  				reg = <0x124a0000 0x1000>;
  				interrupts = <GIC_SPI 196 IRQ_TYPE_LEVEL_HIGH>;
-@@ -326,7 +331,7 @@
+@@ -326,7 +330,7 @@
  
  			syscon-tcsr = <&tcsr>;
  
@@ -96,7 +96,7 @@
  				compatible = "qcom,msm-uartdm-v1.3", "qcom,msm-uartdm";
  				reg = <0x1a240000 0x1000>,
  				      <0x1a200000 0x1000>;
-@@ -397,7 +402,7 @@
+@@ -397,7 +401,7 @@
  			status = "disabled";
  		};
  
@@ -105,7 +105,7 @@
  			compatible = "qcom,ipq806x-ahci", "generic-ahci";
  			reg = <0x29000000 0x180>;
  
-@@ -430,13 +435,35 @@
+@@ -430,13 +434,35 @@
  			reg = <0x00700000 0x1000>;
  			#address-cells = <1>;
  			#size-cells = <1>;
@@ -142,7 +142,7 @@
  		};
  
  		tcsr: syscon@1a400000 {
-@@ -622,7 +649,7 @@
+@@ -622,7 +648,7 @@
  
  		gmac0: ethernet@37000000 {
  			device_type = "network";
@@ -151,7 +151,7 @@
  			reg = <0x37000000 0x200000>;
  			interrupts = <GIC_SPI 220 IRQ_TYPE_LEVEL_HIGH>;
  			interrupt-names = "macirq";
-@@ -645,7 +672,7 @@
+@@ -645,7 +671,7 @@
  
  		gmac1: ethernet@37200000 {
  			device_type = "network";
@@ -160,7 +160,7 @@
  			reg = <0x37200000 0x200000>;
  			interrupts = <GIC_SPI 223 IRQ_TYPE_LEVEL_HIGH>;
  			interrupt-names = "macirq";
-@@ -668,7 +695,7 @@
+@@ -668,7 +694,7 @@
  
  		gmac2: ethernet@37400000 {
  			device_type = "network";
@@ -169,7 +169,7 @@
  			reg = <0x37400000 0x200000>;
  			interrupts = <GIC_SPI 226 IRQ_TYPE_LEVEL_HIGH>;
  			interrupt-names = "macirq";
-@@ -691,7 +718,7 @@
+@@ -691,7 +717,7 @@
  
  		gmac3: ethernet@37600000 {
  			device_type = "network";
@@ -178,7 +178,7 @@
  			reg = <0x37600000 0x200000>;
  			interrupts = <GIC_SPI 229 IRQ_TYPE_LEVEL_HIGH>;
  			interrupt-names = "macirq";
-@@ -740,13 +767,13 @@
+@@ -740,13 +766,13 @@
  			qcom,ee = <0>;
  		};
  
@@ -195,7 +195,7 @@
  				status          = "disabled";
  				compatible      = "arm,pl18x", "arm,primecell";
  				arm,primecell-periphid = <0x00051180>;
-@@ -760,13 +787,12 @@
+@@ -760,13 +786,12 @@
  				non-removable;
  				cap-sd-highspeed;
  				cap-mmc-highspeed;

--- a/target/linux/ipq806x/patches-5.10/083-ipq8064-dtsi-additions.patch
+++ b/target/linux/ipq806x/patches-5.10/083-ipq8064-dtsi-additions.patch
@@ -475,7 +475,7 @@
  		qcom_pinmux: pinmux@800000 {
  			compatible = "qcom,ipq8064-pinctrl";
  			reg = <0x800000 0x4000>;
-@@ -160,6 +589,15 @@
+@@ -159,6 +588,15 @@
  				};
  			};
  
@@ -491,7 +491,7 @@
  			spi_pins: spi_pins {
  				mux {
  					pins = "gpio18", "gpio19", "gpio21";
-@@ -169,6 +607,53 @@
+@@ -168,6 +606,53 @@
  				};
  			};
  
@@ -545,7 +545,7 @@
  			leds_pins: leds_pins {
  				mux {
  					pins = "gpio7", "gpio8", "gpio9",
-@@ -231,6 +716,17 @@
+@@ -230,6 +715,17 @@
  			clock-output-names = "acpu1_aux";
  		};
  
@@ -563,7 +563,7 @@
  		saw0: regulator@2089000 {
  			compatible = "qcom,saw2", "qcom,apq8064-saw2-v1.1-cpu", "syscon";
  			reg = <0x02089000 0x1000>, <0x02009000 0x1000>;
-@@ -243,6 +739,52 @@
+@@ -242,6 +738,52 @@
  			regulator;
  		};
  
@@ -616,7 +616,7 @@
  		gsbi2: gsbi@12480000 {
  			compatible = "qcom,gsbi-v1.0.0";
  			cell-index = <2>;
-@@ -368,6 +910,33 @@
+@@ -367,6 +909,33 @@
  			};
  		};
  
@@ -650,7 +650,7 @@
  		gsbi7: gsbi@16600000 {
  			status = "disabled";
  			compatible = "qcom,gsbi-v1.0.0";
-@@ -389,6 +958,19 @@
+@@ -388,6 +957,19 @@
  				clock-names = "core", "iface";
  				status = "disabled";
  			};
@@ -670,7 +670,7 @@
  		};
  
  		sata_phy: sata-phy@1b400000 {
-@@ -478,6 +1060,95 @@
+@@ -477,6 +1059,95 @@
  			#reset-cells = <1>;
  		};
  
@@ -766,7 +766,7 @@
  		pcie0: pci@1b500000 {
  			compatible = "qcom,pcie-ipq8064";
  			reg = <0x1b500000 0x1000
-@@ -739,6 +1410,59 @@
+@@ -738,6 +1409,59 @@
  			status = "disabled";
  		};
  
@@ -826,7 +826,7 @@
  		vsdcc_fixed: vsdcc-regulator {
  			compatible = "regulator-fixed";
  			regulator-name = "SDCC Power";
-@@ -814,4 +1538,17 @@
+@@ -813,4 +1537,17 @@
  			};
  		};
  	};

--- a/target/linux/ipq806x/patches-5.10/103-ARM-dts-qcom-reduce-pci-IO-size-to-64K.patch
+++ b/target/linux/ipq806x/patches-5.10/103-ARM-dts-qcom-reduce-pci-IO-size-to-64K.patch
@@ -17,7 +17,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 
 --- a/arch/arm/boot/dts/qcom-ipq8064.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq8064.dtsi
-@@ -1163,7 +1163,7 @@
+@@ -1162,7 +1162,7 @@
  			#address-cells = <3>;
  			#size-cells = <2>;
  
@@ -26,7 +26,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  				  0x82000000 0 0x08000000 0x08000000 0 0x07e00000>; /* non-prefetchable memory */
  
  			interrupts = <GIC_SPI 35 IRQ_TYPE_LEVEL_HIGH>;
-@@ -1214,7 +1214,7 @@
+@@ -1213,7 +1213,7 @@
  			#address-cells = <3>;
  			#size-cells = <2>;
  
@@ -35,7 +35,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  				  0x82000000 0 0x2e000000 0x2e000000 0 0x03e00000>; /* non-prefetchable memory */
  
  			interrupts = <GIC_SPI 57 IRQ_TYPE_LEVEL_HIGH>;
-@@ -1265,7 +1265,7 @@
+@@ -1264,7 +1264,7 @@
  			#address-cells = <3>;
  			#size-cells = <2>;
  

--- a/target/linux/ipq806x/patches-5.10/109-v5.15-arm-dts-qcom-add-ahb-reset-to-ipq806x-gmac.patch
+++ b/target/linux/ipq806x/patches-5.10/109-v5.15-arm-dts-qcom-add-ahb-reset-to-ipq806x-gmac.patch
@@ -14,7 +14,7 @@ Signed-off-by: Bjorn Andersson <bjorn.andersson@linaro.org>
 
 --- a/arch/arm/boot/dts/qcom-ipq8064.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq8064.dtsi
-@@ -1335,8 +1335,9 @@
+@@ -1334,8 +1334,9 @@
  			clocks = <&gcc GMAC_CORE1_CLK>;
  			clock-names = "stmmaceth";
  
@@ -26,7 +26,7 @@ Signed-off-by: Bjorn Andersson <bjorn.andersson@linaro.org>
  
  			status = "disabled";
  		};
-@@ -1358,8 +1359,9 @@
+@@ -1357,8 +1358,9 @@
  			clocks = <&gcc GMAC_CORE2_CLK>;
  			clock-names = "stmmaceth";
  
@@ -38,7 +38,7 @@ Signed-off-by: Bjorn Andersson <bjorn.andersson@linaro.org>
  
  			status = "disabled";
  		};
-@@ -1381,8 +1383,9 @@
+@@ -1380,8 +1382,9 @@
  			clocks = <&gcc GMAC_CORE3_CLK>;
  			clock-names = "stmmaceth";
  
@@ -50,7 +50,7 @@ Signed-off-by: Bjorn Andersson <bjorn.andersson@linaro.org>
  
  			status = "disabled";
  		};
-@@ -1404,8 +1407,9 @@
+@@ -1403,8 +1406,9 @@
  			clocks = <&gcc GMAC_CORE4_CLK>;
  			clock-names = "stmmaceth";
  


### PR DESCRIPTION
With 5.15 kernel version Linksys EAX500 family devices suffered from a
big regression where the Ethernet switch became silent and started to
malfunction.

It was discovered later that the cause was not really the kernel upgrade
itself but a hackish implementation of the hw implementation of these
special routers.

In the original Linksys source code, GPIO 63 was handled in a special way
and was reset on reboot.

Normally GPIO 63 is used for pcie2 reset but in every device we support,
pcie2 is actually never used as nothing is attached to it.

Linksys rerouted GPIO 63 to the switch reset pin and deviates from
common hw implementation.

Till now it was used an hack to handle this case... It was set pcie3 as
working (while actually nothing was connected), set it to output low
(for assert-deassert from the pcie init code) and be done with it.
The result was that the GPIO was reset for enough time in early boot and
everything worked correctly.
This hack implementation was born to fail from the very start and in
kernel 5.15 finally problem arised.

In 5.15 pcie code changed and now the GPIO reset pin is not asserted as
probe won't fail if nothing is connected to the line (the old behaviour)
This result in the switch hold the reset pin and the Ethernet switch
dead.

On top of that with 5.15 code got optimized and simply attaching the
GPIO reset to the mdio wasn't enough as the switch require at least 10ms
to be correctly reset.

So implement finally a correct solution where:
- pcie2 is correctly disabled (nothing attached, unused)
- drop the wrong output-low for pcie2 reset pin
- define GPIO 63 as switch reset
- Add the reset-gpios to the mdio0 node
- Set the reset-post-delay-us to 12ms to correctly give time the switch
  to reset

Fixes: https://github.com/openwrt/openwrt/issues/10983
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
