### PR TITLE
ath79: fix wifi leds for D-Link DIR-825 B1

### DIFF
--- a/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
+++ b/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
@@ -59,13 +59,13 @@
 		wlan2g {
 			label = "blue:wlan2g";
 			gpios = <&ath9k0 5 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wlan5g {
 			label = "blue:wlan5g";
 			gpios = <&ath9k1 5 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 


### PR DESCRIPTION
phy0 is the 5g radio and phy1 is the 2g radio

---

I don't know if this is correct and would like someone's comments on this one.

For me, on my DIR-825 B1 router, running 22.03.3, the wifi leds are mixed up. The 2g led flashes when 5g radio transmits/recieves and the opposite for the 5g led.

I don't know how the phy devices are assigned. Are they assigned the same for all devices or is it a bit random and I was unlucky to get them assigned "wrong"?

I have only tested 22.03.3, ie not master.