### PR TITLE
ipq40xx: Linksys MR8300: fix the USB port power: backport to OpenWrt 21.02

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-xx8300.dtsi
@@ -112,6 +112,16 @@
 			status = "okay";
 		};
 	};
+
+	gpio_export {
+		compatible = "gpio-export";
+
+		usb {
+			gpio-export,name = "usb_power";
+			gpio-export,output = <0>;
+			gpios = <&tlmm 68 GPIO_ACTIVE_HIGH>;
+		};
+	};
 };
 
 
@@ -280,7 +290,7 @@
 			pins =  "gpio55", "gpio56", "gpio57",
 				"gpio60", "gpio62", "gpio63",
 				"gpio64", "gpio65", "gpio66",
-				"gpio67", "gpio68", "gpio69";
+				"gpio67", "gpio69";
 			function = "qpic";
 			bias-pull-down;
 		};


### PR DESCRIPTION
This is a backport of PR #12024 to OpenWrt 21.02 and fixes #11187
I tested it on my MR8300 and it is working without any issue.

Original commit message by @danitool:
The USB port on the MR8300 randomly fails to feed bus-powered devices.

This is caused by a misconfigured pinmux. The GPIO68 is used to enable the USB power (active low), but it's inside the NAND pinmux.

This GPIO pin was found in the original firmware at a startup script in both MR8300 and EA8300. Therefore apply the fix for both boards.

Signed-off-by: Steffen Scheib <steffen@scheib.me>
