### PR TITLE
libustream-ssl: add PROVIDES and fix CONFLICTS

### DIFF
--- a/package/libs/ustream-ssl/Makefile
+++ b/package/libs/ustream-ssl/Makefile
@@ -23,6 +23,7 @@ define Package/libustream/default
   CATEGORY:=Libraries
   TITLE:=ustream SSL Library
   DEPENDS:=+libubox
+  PROVIDES:=libustream-ssl
   ABI_VERSION:=20201210
 endef
 

--- a/package/libs/ustream-ssl/Makefile
+++ b/package/libs/ustream-ssl/Makefile
@@ -31,6 +31,7 @@ define Package/libustream-openssl
   $(Package/libustream/default)
   TITLE += (openssl)
   DEPENDS += +PACKAGE_libustream-openssl:libopenssl
+  CONFLICTS := libustream-mbedtls libustream-wolfssl
   VARIANT:=openssl
 endef
 
@@ -38,7 +39,7 @@ define Package/libustream-wolfssl
   $(Package/libustream/default)
   TITLE += (wolfssl)
   DEPENDS += +PACKAGE_libustream-wolfssl:libwolfssl
-  CONFLICTS := libustream-openssl
+  CONFLICTS := libustream-mbedtls libustream-openssl
   VARIANT:=wolfssl
 endef
 
@@ -46,8 +47,8 @@ define Package/libustream-mbedtls
   $(Package/libustream/default)
   TITLE += (mbedtls)
   DEPENDS += +PACKAGE_libustream-mbedtls:libmbedtls
-  CONFLICTS := libustream-openssl libustream-wolfssl
   VARIANT:=mbedtls
+  CONFLICTS := libustream-openssl libustream-wolfssl
   DEFAULT_VARIANT:=1
 endef
 


### PR DESCRIPTION
    libustream-ssl: fix CONFLICTS definitions
    
    The definitions where incomplete so packages could be selected in
    parallel, causing build time issues.
    
    libustream-ssl: add PROVIDES definition
    
    The package now provides `libustream-ssl` so other packages can depend
    on that generically instead of requiring the specific version. This is
    mostly important for the `luci-ssl` packages which would profit of this.
  