### PR TITLE
ramips: add support for SNR-CPE-ME2-SFP

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -85,6 +85,7 @@ linksys,ea8100-v2|\
 mts,wg430223)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
 	;;
+snr,snr-cpe-me2-sfp|\
 snr,cpe-w4n-mt)
 	idx="$(find_mtd_index uboot-env)"
 	[ -n "$idx" ] && \

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-sfp.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-sfp.dts
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "snr,snr-cpe-me2-sfp", "mediatek,mt7621-soc";
+	model = "SNR-CPE-ME2-SFP";
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: sys {
+			label = "green:sys";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		vpn {
+			label = "green:vpn";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "green:usb";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	sfp_wan: sfp0 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c>;
+		los-gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1000>;
+	};
+
+	reg_usb_vbus: regulator-usb {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3", "jtag";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 { // GD25Q127CSIG
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <44000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+
+			partition@30001 {
+				label = "uboot-env";
+				reg = <0x30000 0x1000>;
+			};
+		};
+	};
+};
+
+&gpio {
+	// driver issue, bypass
+	enable_sfp {
+		gpio-hog;
+		gpios = <9 GPIO_ACTIVE_LOW>;
+		output-low;
+	};
+};
+
+&mdio {
+	phy_sfp: ethernet-phy@0 {
+		reg = <0>;
+		sfp = <&sfp_wan>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-mode = "rgmii-rxid";
+	phy-handle = <&phy_sfp>;
+
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&xhci {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_usb_vbus>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1963,6 +1963,18 @@ define Device/snr_snr-cpe-me2-lite
 endef
 TARGET_DEVICES += snr_snr-cpe-me2-lite
 
+define Device/snr_snr-cpe-me2-sfp
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := SNR
+  DEVICE_MODEL := SNR-CPE-ME2-SFP
+  UIMAGE_NAME := $$(DEVICE_MODEL)
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 \
+	    kmod-sfp kmod-usb-ledtrig-usbport uboot-envtools
+endef
+TARGET_DEVICES += snr_snr-cpe-me2-sfp
+
 define Device/storylink_sap-g3200u3
   $(Device/dsa-migration)
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -139,6 +139,10 @@ case "$board" in
 			macaddr_setbit_la "$(mtd_get_mac_ascii Config protest_lan_mac)" \
 				> /sys${DEVPATH}/macaddress
 		;;
+	snr,snr-cpe-me2-sfp)
+		hw_mac_addr="$(mtd_get_mac_binary factory 0x8004)"
+		[ "$PHYNBR" = "1" ] &&  echo -n "$hw_mac_addr" > /sys${DEVPATH}/macaddress
+		;;
 	tenbay,t-mb5eu-v01)
 		hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"
 		[ "$PHYNBR" = "1" ] &&  macaddr_add $hw_mac_addr "0x100000" > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
SNR-CPE-ME2-SFP is a wireless WiFi 5 router manufactured by SNR/NAG company.

```Specification:
- SoC: MediaTek MT7621A
- CPU: 880MHz
- Flash: 16 MB (GD25Q127CSIG)
- RAM:  256 MB
- WLAN: 2.4 GHz, 5 GHz (MediaTek MT7615DN)
- Ethernet: 4x 10/100/1000 Mbps
- SFP cage (using RTL8211FS-CG)
- USB 3.0 port
- Power: 12 VDC, 2 A
```

- [x] Update using sysupgrade
- [x] GPIO LED and BUTTON
- [x] Wi-Fi
- [x] SFP
- [x] Ethernet
- [x] USB
- [x] Stability
- [x] Correct MAC
- [x] U-boot env

Builds link: https://disk.yandex.ru/d/2Q_AgZliMr3e-Q