### PR TITLE
mvebu: mochabin: enlarge PCI memory window

### DIFF
--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/armada-7040-mochabin.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/armada-7040-mochabin.dts
@@ -445,4 +445,5 @@
 	phys = <&cp0_comphy5 2>;
 	phy-names = "cp0-pcie2-x1-phy";
 	reset-gpio = <&cp0_gpio1 9 GPIO_ACTIVE_LOW>;
+	ranges = <0x82000000 0x0 0xc0000000 0x0 0xc0000000 0x0 0x8000000>;
 };


### PR DESCRIPTION
Armada 7040 uses a rather small 15MB memory window for every PCI adapter, however, this is not sufficient for Qualcomm QCA6390 802.11ax cards that are shipped along with the OpenWrt WLAN model of MOCHAbin as ath11k requires at least 16MB of memory.

So, similar to what MACCHIATOBin has been doing for years, let's move to using the second PCIe 2 memory window and expand it to 128MB to make it future-proof.

This has been already sent upstream [1].
[1] https://lore.kernel.org/linux-arm-kernel/20230219121418.1395401-1-robert.marko@sartura.hr/