### PR TITLE
ramips: correct the PCIe port number for some mt7621 devices

### DIFF
--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_ayx.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_ayx.dtsi
@@ -96,7 +96,7 @@
 	};
 };
 
-&pcie1 {
+&pcie2 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;

--- a/target/linux/ramips/dts/mt7621_netgear_wac104.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_wac104.dts
@@ -122,7 +122,7 @@
 	};
 };
 
-&pcie1 {
+&pcie2 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;


### PR DESCRIPTION
MT7621 uses a new PCIe driver in the 5.15+ kernel. Allocating wrong PCIe port will cause the PCIe NIC to not work properly. This commit fixes the wrong port numbers on Netgear R6220, WAC104 and WNDR3700 v5.

According to bootlog, MT7612E (5GHz) is connected to pcie0, and MT7603E (2GHz) is connected to pcie2:
[2.758986] mt7621-pci 1e140000.pcie: pcie1 no card, disable it (RST & CLK) [2.772862] mt7621-pci 1e140000.pcie: PCIE0 enabled [2.782579] mt7621-pci 1e140000.pcie: PCIE2 enabled ...
[3.009151] pci 0000:01:00.0: [14c3:7662] type 00 class 0x028000 [3.125715] pci 0000:02:00.0: [14c3:7603] type 00 class 0x028000

Tested-by: Maximilian Baumgartner <aufhaxer@googlemail.com>

[felix.bau@gmx.de: adjust commit message for Netgear devices]

---
This is a continuation of: https://github.com/openwrt/openwrt/pull/11220
The second half of @DragonBluep's patch was tested successfully by @mbaumga on Netgear devices:
https://github.com/freifunk-gluon/gluon/issues/2789#issuecomment-1437454970

I have one remaining question:
> Mon Feb 20 06:36:12 2023 kern.err kernel: [    1.046719] mt7621-pci 1e140000.pcie: pcie1 no card, disable it (RST & CLK)

Is it correct that the device is still displaying this as an error? (Is it still expecting something to be plugged into pcie1 because of the mt7621.dtsi?)