### PR TITLE
openssl: Fix powerpc dependency to libatomic

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -95,7 +95,7 @@ $(call Package/openssl/Default)
 	   +OPENSSL_ENGINE_BUILTIN_AFALG:kmod-crypto-user \
 	   +OPENSSL_ENGINE_BUILTIN_DEVCRYPTO:kmod-cryptodev \
 	   +OPENSSL_ENGINE_BUILTIN_PADLOCK:kmod-crypto-hw-padlock \
-	   +(arm||armeb||mips||mipsel||ppc):libatomic
+	   +(arm||armeb||mips||mipsel||powerpc):libatomic
   TITLE+= (libraries)
   ABI_VERSION:=$(firstword $(subst .,$(space),$(PKG_VERSION)))
   MENU:=1


### PR DESCRIPTION
The powerpc CPU type is named CONFIG_powerpc and not CONFIG_ppc in OpenWrt, fix the dependency.

This fixes the openssl build in the mpc85xx target.

Fixes: 7e7e76afca78 ("openssl: bump to 3.0.8")