### PR TITLE
openssl: openssl: fix powerpc & arc libatomic dependencies ❤️ 

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_VERSION:=3.0.8
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_USE_MIPS16:=0
 
 PKG_BUILD_PARALLEL:=1
@@ -95,7 +95,7 @@ $(call Package/openssl/Default)
 	   +OPENSSL_ENGINE_BUILTIN_AFALG:kmod-crypto-user \
 	   +OPENSSL_ENGINE_BUILTIN_DEVCRYPTO:kmod-cryptodev \
 	   +OPENSSL_ENGINE_BUILTIN_PADLOCK:kmod-crypto-hw-padlock \
-	   +(arm||armeb||mips||mipsel||ppc):libatomic
+	   +(arm||armeb||mips||mipsel||powerpc||arc):libatomic
   TITLE+= (libraries)
   ABI_VERSION:=$(firstword $(subst .,$(space),$(PKG_VERSION)))
   MENU:=1

--- a/package/libs/openssl/patches/110-openwrt_targets.patch
+++ b/package/libs/openssl/patches/110-openwrt_targets.patch
@@ -23,7 +23,7 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 +        inherit_from    => [ "linux-aarch64", "openwrt" ],
 +    },
 +    "linux-arc-openwrt" => {
-+        inherit_from    => [ "linux-generic32", "openwrt" ],
++        inherit_from    => [ "linux-latomic", "openwrt" ],
 +    },
 +    "linux-arm-openwrt" => {
 +        inherit_from    => [ "linux-armv4", "openwrt" ],


### PR DESCRIPTION
PowerPC had ppc instead of powerpc, when selecting libatomic. Arc needs to be built with libatomic as well.

Fixes #12048 

This was compile-tested for arc_archs and powerpc_464fp

Ping @Ansuel 