### PR TITLE
iptables: add mod-ipvs package

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -522,6 +522,22 @@ define Package/ip6tables-mod-nat/description
 iptables extensions for IPv6-NAT targets.
 endef
 
+define Package/iptables-mod-ipvs
+$(call Package/iptables/Module, +kmod-nf-ipvs)
+  TITLE:=IPVS extension
+endef
+
+define Package/iptables-mod-ipvs/description
+iptables extension for matching an IPVS connection
+
+ Matches:
+  - ipvs
+
+ If you select it, it enables kmod-nf-ipvs.
+
+ see `iptables -m ipvs --help` for more information.
+endef
+
 define Package/libip4tc
 $(call Package/iptables/Default)
   SECTION:=libs
@@ -729,6 +745,11 @@ define Package/libxtables/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libxtables.so.* $(1)/usr/lib/
 endef
 
+define Package/iptables-mod-ipvs/install
+	$(INSTALL_DIR) $(1)/usr/lib/iptables
+	$(CP) $(PKG_BUILD_DIR)/extensions/libxt_ipvs.so $(1)/usr/lib/iptables/
+endef
+
 define BuildPlugin
   define Package/$(1)/install
 	$(INSTALL_DIR) $$(1)/usr/lib/iptables
@@ -777,6 +798,7 @@ $(eval $(call BuildPlugin,iptables-mod-nflog,$(IPT_NFLOG-m)))
 $(eval $(call BuildPlugin,iptables-mod-trace,$(IPT_DEBUG-m)))
 $(eval $(call BuildPlugin,iptables-mod-nfqueue,$(IPT_NFQUEUE-m)))
 $(eval $(call BuildPlugin,iptables-mod-checksum,$(IPT_CHECKSUM-m)))
+$(eval $(call BuildPackage,iptables-mod-ipvs))
 $(eval $(call BuildPackage,ip6tables-nft))
 $(eval $(call BuildPackage,ip6tables-zz-legacy))
 $(eval $(call BuildPlugin,ip6tables-extra,$(IPT_IPV6_EXTRA-m)))


### PR DESCRIPTION
Docker swarm requires the iptables ipvs and state extensions. IPVS, in particular, is required for swarm's overlay network. This patch adds the ipvs iptables extension as a separate package.

The ipvs extension is provided by `libxt_ipvs.so`.

This partially fixes #12028.

A separate `docker-mod-swarm` package could be introduced in the future that installs all docker swarm dependencies and disables swarm on the base docker package. This is a separate issue, however. Docker swarm might still have further issues and all its dependencies would have to be determined.