### PR TITLE
 ipq40xx: add e2600ac c1/c2 to DSA 

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -100,6 +100,9 @@ ipq40xx_setup_interfaces()
 	qxwlan,e2600ac-c1)
 		ucidef_set_interfaces_lan_wan "sw-eth1" "sw-eth2"
 		;;
+	qxwlan,e2600ac-c2)
+		ucidef_set_interfaces_lan_wan "sw-eth1 sw-eth2" "sw-eth3"
+		;;
 	zte,mf286d)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "wan"
 		;;

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -97,6 +97,9 @@ ipq40xx_setup_interfaces()
 	plasmacloud,pa2200)
 		ucidef_set_interfaces_lan_wan "ethernet1" "ethernet2"
 		;;
+	qxwlan,e2600ac-c1)
+		ucidef_set_interfaces_lan_wan "sw-eth1" "sw-eth2"
+		;;
 	zte,mf286d)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "wan"
 		;;

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-e2600ac-c1.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-e2600ac-c1.dts
@@ -79,6 +79,14 @@
 				precal_art_5000: precal@5000 {
 					reg = <0x5000 0x2f20>;
 				};
+
+				macaddr_gmac0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_gmac1: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
 			};
 			partition@180000 {
 				compatible = "denx,fit";
@@ -101,4 +109,28 @@
 	nvmem-cell-names = "pre-calibration";
 	nvmem-cells = <&precal_art_5000>;
 	qcom,ath10k-calibration-variant = "Qxwlan-E2600AC-C1";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+	label = "sw-eth1";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0>;
+};
+
+&swport5 {
+	status = "okay";
+
+	label = "sw-eth2";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac1>;
 };

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-e2600ac-c2.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-e2600ac-c2.dts
@@ -79,6 +79,14 @@
 				precal_art_5000: precal@5000 {
 					reg = <0x5000 0x2f20>;
 				};
+
+				macaddr_gmac0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_gmac1: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
 			};
 		};
 	};
@@ -136,4 +144,36 @@
 	nvmem-cell-names = "pre-calibration";
 	nvmem-cells = <&precal_art_5000>;
 	qcom,ath10k-calibration-variant = "Qxwlan-E2600AC-C2";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport2 {
+	status = "okay";
+	label = "sw-eth1";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0>;
+};
+
+&swport4 {
+	status = "okay";
+	label = "sw-eth2";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0>;
+};
+
+&swport5 {
+	status = "okay";
+
+	label = "sw-eth3";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac1>;
 };

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -1046,8 +1046,7 @@ define Device/qxwlan_e2600ac-c2
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += qxwlan_e2600ac-c2
+TARGET_DEVICES += qxwlan_e2600ac-c2
 
 define Device/sony_ncp-hg100-cellular
 	$(call Device/FitImage)

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -1033,8 +1033,7 @@ define Device/qxwlan_e2600ac-c1
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
 	DEFAULT := n
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += qxwlan_e2600ac-c1
+TARGET_DEVICES += qxwlan_e2600ac-c1
 
 define Device/qxwlan_e2600ac-c2
 	$(call Device/FitImage)

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -1028,10 +1028,8 @@ define Device/qxwlan_e2600ac-c1
 	DEVICE_VARIANT := C1
 	BOARD_NAME := e2600ac-c1
 	SOC := qcom-ipq4019
-	KERNEL_SIZE := 4096k
 	IMAGE_SIZE := 31232k
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
-	DEFAULT := n
 endef
 TARGET_DEVICES += qxwlan_e2600ac-c1
 


### PR DESCRIPTION
1.Convert E2600ac c1/c2 to DSA and enable it.
2.Currently, e2600ac-c1 cannot be built as the kernel is larger than the defined KERNEL_SIZE,
however, there is no bootloader limit for the kernel size so remove KERNEL_SIZE completely.

Signed-off-by: 张 鹏 <sd20@qxwlan.com>