### PR TITLE
[ramips] Add support for D-Link Dir 853 A1

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-853-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-853-a1.dts
@@ -109,7 +109,13 @@
 
 			factory: partition@40000 {
 				label = "factory";
-				reg = <0x40000 0x20000>;
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "config2_stock";
+				reg = <0x50000 0x10000>;
 				read-only;
 			};
 
@@ -121,7 +127,7 @@
 			};
 
 			partition@fb0000 {
-				label = "private";
+				label = "private_stock";
 				reg = <0xfb0000 0x50000>;
 				read-only;
 			};
@@ -149,6 +155,21 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
 &switch0 {
 	ports {
 		port@0 {
@@ -169,13 +190,6 @@
 		port@3 {
 			status = "okay";
 			label = "lan1";
-		};
-
-		wan: port@4 {
-			status = "okay";
-			label = "wan";
-			nvmem-cells = <&macaddr_factory_e006>;
-			nvmem-cell-names = "mac-address";
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-853-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-853-a1.dts
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dir-853-a1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-853 A1";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_blue;
+		led-running = &led_power_blue;
+		led-upgrade = &led_net_orange;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: power_orange {
+			label = "orange:power";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_net_orange: net_orange {
+			label = "orange:net";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		net_blue {
+			label = "blue:net";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		usb_blue {
+			label = "blue:usb";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x20000>;
+				read-only;
+			};
+
+			partition@60000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,padding = <96>;
+				label = "firmware";
+				reg = <0x60000 0xf50000>;
+			};
+
+			partition@fb0000 {
+				label = "private";
+				reg = <0xfb0000 0x50000>;
+				read-only;
+			};
+		};
+	};
+};
+
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+
+		/* The correct Mac addresses are set in 10_fix_wifi_mac. */
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		wan: port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e006>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart2", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -409,6 +409,14 @@ define Device/dlink_dir-2660-a1
 endef
 TARGET_DEVICES += dlink_dir-2660-a1
 
+define Device/dlink_dir-853-a1
+  $(Device/dlink_dir-8xx-a1)
+  DEVICE_MODEL := DIR-853
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES += kmod-usb3 kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += dlink_dir-853-a1
+
 define Device/dlink_dir-853-a3
   $(Device/dlink_dir-xx60-a1)
   DEVICE_MODEL := DIR-853

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -37,6 +37,7 @@ dlink,dir-2640-a1|\
 dlink,dir-2660-a1)
 	ucidef_set_led_netdev "wan" "wan" "white:net" "wan"
 	;;
+dlink,dir-853-a1|\
 dlink,dir-853-a3)
 	ucidef_set_led_netdev "wan" "wan" "blue:net" "wan"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -22,6 +22,16 @@ case "$board" in
 		hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"
 		macaddr_add $hw_mac_addr "$PHYNBR" > /sys${DEVPATH}/macaddress
 		;;
+	dlink,dir-853-a1)
+		if [ "$PHYNBR" = "0" ]; then
+			base_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0xe000)" 1)
+			macaddr_setbit_la "$base_mac" > /sys${DEVPATH}/macaddress
+		fi
+		if [ "$PHYNBR" = "1" ]; then
+			base_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0xe000)" 2)
+			macaddr_setbit_la "$base_mac" > /sys${DEVPATH}/macaddress
+		fi
+		;;
 	dlink,dir-853-a3)
 		[ "$PHYNBR" = "0" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary factory 0xe000)" \


### PR DESCRIPTION
Specifications:
* SoC: MT7621AT
* RAM: 256MB (NT5CC64M16GP-DI)
* Flash: 16MB NOR SPI flash (GD25Q127CSIG, using GD25Q128C driver)
* WiFi: MT7615DN (2.4GHz+5Ghz) with DBDC
* Ethernet: 4x1000M LAN, 1x 1000M WAN
* LEDs: Power Blue+Orange,Wan Blue+Orange,WPS Blue,"2.4G"Blue, "5G" Blue,
  USB Blue
* Buttons: Reset,WPS, Wifi
* Serial interface: on board but not populated, pinout is "3.3V Input Output Gnd". Settings are 57600 8N1.

Stock flash layout:
```
GD25Q128C(c8 40180000) (16384 Kbytes)
mtd .name = raspi, .size = 0x01000000 (16M) .erasesize = 0x00010000 (64K) .numeraseregions = 0
Creating 7 MTD partitions on "raspi":
0x000000000000-0x000001000000 : "ALL"
0x000000000000-0x000000030000 : "Bootloader"
0x000000030000-0x000000040000 : "Config"
0x000000040000-0x000000050000 : "Factory"
0x000000050000-0x000000060000 : "Config2"
0x000000060000-0x000000fb0000 : "Kernel"
0x000000fb0000-0x000001000000 : "Private"
```
The kernel partition will be replaced with the OpenWrt image, the other partitions are left untouched.

"Config2" seems to be the config storage used by the stock firmware. 

"Private" is a 320kB empty JFFS2 partition that comes with the stock firmware. One can get a larger space for OpenWrt by merging it with "Kernel".

OpenWrt flash layout:
```
0x000000000000-0x000000030000 : "u-boot"
0x000000030000-0x000000040000 : "u-boot-env"
0x000000040000-0x000000050000 : "factory"
0x000000050000-0x000000060000 : "config2_stock"
0x000000060000-0x000000fb0000 : "firmware"
0x000000fb0000-0x000001000000 : "private_stock"
```

The OpenWrt image must have 96 bytes of padding in the header.

MAC addresses on OEM firmware:
|      		| location on the flash 	| notes    	|
|------		|-----------------------	|----------	|
| lan (eth2) 	| factory + 0xe000      	| on label 	|
| wan (eth3) 	| factory + 0xe006      	|          	|
| 2.4g (rax0) 	| not on flash          	| lan + 1  	|
| 5g (ra0) 	| not on flash          	| lan + 2  	|

Mac addresses of the 2.4g and 5g interface are stored as ASCII strings in the u-boot-env partition.

Flash and test instructions:
1. Open the case, and solder the 4-pin header near the WAN port.
2. Connect it to a USB-UART TTL adapter, no need to connect VCC.
3. Open a terminal emulator on your PC using 57600 baud, 8 data bits, no parity bit, one stop bit, and no flow control.
4. Setup a TFTP server on your PC that can serve `xxx-ramips-mt7621-dlink_dir-853-a1-initramfs-kernel.bin`.
5. Connect any LAN port to your PC and configure a static IPv4 address: 192.168.0.101 (netmask 255.255.255.0) for your interface.
6. Power on the device and keeps pressing 1 until you see the prompt.
7. Use default IP addresses and enter the file name accordingly, then hit enter.
8. Wait until it boots to OpenWrt, the default IP address is 192.168.1.1, you need to change your PC network adapter to use DHCP in order to access LUCI.
9. So far, the OpenWrt runs in RAM and the flash contents are not touched. To write OpenWrt to the device permantly, click on "System -> Backup/Flash Firmware" in Luci and flash `xxx-ramips-mt7621-dlink_dir-853-a1-squashfs-sysupgrade.bin`

Known problems:
* WLAN0 defaults to 5G after a fresh installation to enable 2.4G network, you need to config it manually in LUCI.
* Not sure if update via the stock web interface works or not

Credits to Kar200 and Lucky1 who gave me plenty of help.

Prebuild firmwares:
[dir-853-a1.zip](https://github.com/openwrt/openwrt/files/10805078/dir-853-a1.zip)