### PR TITLE
lantiq: switch to Kernel 5.15 by default

### DIFF
--- a/target/linux/lantiq/Makefile
+++ b/target/linux/lantiq/Makefile
@@ -9,8 +9,7 @@ BOARDNAME:=Lantiq
 FEATURES:=squashfs
 SUBTARGETS:=xrx200 xway xway_legacy falcon ase
 
-KERNEL_PATCHVER:=5.10
-KERNEL_TESTING_PATCHVER:=5.15
+KERNEL_PATCHVER:=5.15
 
 define Target/Description
 	Build firmware images for Lantiq SoC


### PR DESCRIPTION
This PR to have an overview of testing.