### PR TITLE
dnsmasq: add UCI support for DNS TXT resource records

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -743,6 +743,21 @@ dhcp_mx_add() {
 	xappend "--mx-host=$service"
 }
 
+dhcp_txt_add() {
+	local cfg="$1"
+	local strs=
+	config_get name "$cfg" name
+	[ -n "$name" ] || return 0
+
+	append_strings () {
+	    strs="$strs,\"$1\""
+	}
+	config_list_foreach "$cfg" text append_strings
+	[ -n "$strs" ] || return 0
+
+	xappend "--txt-record=$name$strs"
+}
+
 dhcp_cname_add() {
 	local cfg="$1"
 	local cname target
@@ -1144,6 +1159,7 @@ dnsmasq_start()
 	echo >> $CONFIGFILE_TMP
 	config_foreach filter_dnsmasq srvhost dhcp_srv_add "$cfg"
 	config_foreach filter_dnsmasq mxhost dhcp_mx_add "$cfg"
+	config_foreach filter_dnsmasq txtrecord dhcp_txt_add "$cfg"
 	echo >> $CONFIGFILE_TMP
 
 	config_get_bool boguspriv "$cfg" boguspriv 1


### PR DESCRIPTION
dnsmasq has support for TXT DNS reource records via the --txt-record option but this is previously unsupported on OpenWRT via UCI. TXT records are important for DKIM, SPF etc.

UCI entries are like:

    config txtrecord
	    option name 'dk._domainkey.<DOMAINNAME>'
	    list text 'k=rsa; p=<KEY>'

The "text" is a list because the dnsmasq --txt-record option takes a list.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
