### PR TITLE
bpf-headers: fix package category

### DIFF
--- a/package/kernel/bpf-headers/Makefile
+++ b/package/kernel/bpf-headers/Makefile
@@ -39,7 +39,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define Package/bpf-headers
   SECTION:=kernel
-  CATEGORY:=Kernel
+  CATEGORY:=Kernel modules
   TITLE:=eBPF kernel headers
   BUILDONLY:=1
   HIDDEN:=1


### PR DESCRIPTION
This removes the non-selectable 'Kernel' item when make menuconfig.