### PR TITLE
ncurses: add alacritty terminfo

### DIFF
--- a/package/libs/ncurses/Makefile
+++ b/package/libs/ncurses/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ncurses
 PKG_CPE_ID:=cpe:/a:gnu:ncurses
 PKG_VERSION:=6.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -123,6 +123,7 @@ ifneq ($(HOST_OS),FreeBSD)
 	)
 	for file in \
 		a/ansi \
+		a/alacritty \
 		d/dumb \
 		l/linux \
 		r/rxvt \


### PR DESCRIPTION
Add terminfo file for the terminal emulator alacritty. 

https://github.com/alacritty/alacritty

Compile tested: x86-64 (APU2), ramips (ASUS RT-AX53U)
Run tested: ramips (ASUS RT-AX53U)
Size impact: 845 bytes

Related: https://github.com/openwrt/openwrt/issues/8902#issuecomment-1050997027

Signed-off-by: Tobias Hilbig <web.tobias@hilbig-ffb.de>