### PR TITLE
ramips: rt5350: enable lzma-loader for ALLNET ALL5003

### DIFF
--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -120,6 +120,7 @@ endef
 TARGET_DEVICES += allnet_all5002
 
 define Device/allnet_all5003
+  $(Device/uimage-lzma-loader)
   SOC := rt5350
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := Allnet


### PR DESCRIPTION
Fixes the boot loader LZMA decompression issue:
LZMA ERROR 1 - must RESET board to recover