### PR TITLE
[bpftool][binutils] update to recent version

### DIFF
--- a/package/devel/binutils/Makefile
+++ b/package/devel/binutils/Makefile
@@ -8,16 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=binutils
-PKG_VERSION:=2.38
+PKG_VERSION:=2.40
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@GNU/binutils
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_VERSION:=$(PKG_VERSION)
-PKG_HASH:=e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024
+PKG_HASH:=0f8a4c272d7f17f369ded10a4aca28b8e304828e95526da482b0ccc4dfc9d8e1
 
 PKG_FIXUP:=patch-libtool
-PKG_LIBTOOL_PATHS:=. gas bfd opcodes gprof binutils ld libiberty gold intl
+PKG_LIBTOOL_PATHS:=. gas bfd opcodes gprof gprofng binutils ld libiberty gold intl libctf libsframe
 PKG_REMOVE_FILES:=libtool.m4
 PKG_INSTALL:=1
 
@@ -87,7 +87,10 @@ CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-install-libiberty \
 	--enable-install-libbfd \
-	--enable-install-libctf
+	--enable-install-libctf \
+	--with-system-zlib \
+	--without-zstd \
+	--disable-gprofng
 
 define Build/Install
 	$(call Build/Install/Default)
@@ -105,6 +108,7 @@ endef
 define Package/libbfd/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libbfd*.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libsframe*.so* $(1)/usr/lib/
 endef
 
 define Package/libctf/install

--- a/package/devel/binutils/patches/001-replace-attribute_const.patch
+++ b/package/devel/binutils/patches/001-replace-attribute_const.patch
@@ -1,0 +1,88 @@
+Fix this compile error:
+----------------------
+./../common/cpuid.c:27:1: error: expected '=', ',', ';', 'asm' or '__attribute__' before '__get_cpuid'
+   27 | __get_cpuid (unsigned int op ATTRIBUTE_UNUSED, unsigned int *eax,
+      | ^~~~~~~~~~~
+----------------------
+
+and this error:
+----------------------
+unwind.c: In function '__collector_ext_return_address':
+unwind.c:236:34: error: '__u64' undeclared (first use in this function)
+  236 |       context->uc_mcontext.sp = (__u64) __builtin_frame_address(0); \
+      |                                  ^~~~~
+unwind.c:490:3: note: in expansion of macro 'FILL_CONTEXT'
+  490 |   FILL_CONTEXT ((&context));
+
+----------------------
+--- a/gprofng/common/cpuid.c
++++ b/gprofng/common/cpuid.c
+@@ -23,7 +23,7 @@
+ #elif defined(__aarch64__)
+ #define ATTRIBUTE_UNUSED __attribute__((unused))
+ 
+-static inline uint_t __attribute_const__
++static inline uint_t __attribute__((__const__))
+ __get_cpuid (unsigned int op ATTRIBUTE_UNUSED, unsigned int *eax,
+ 	     unsigned int *ebx ATTRIBUTE_UNUSED,
+ 	     unsigned int *ecx ATTRIBUTE_UNUSED, unsigned int *edx ATTRIBUTE_UNUSED)
+--- a/gprofng/libcollector/unwind.c
++++ b/gprofng/libcollector/unwind.c
+@@ -233,7 +233,7 @@ memory_error_func (int status ATTRIBUTE_
+ #elif ARCH(Aarch64)
+ #define FILL_CONTEXT(context) \
+     { CALL_UTIL (getcontext) (context);  \
+-      context->uc_mcontext.sp = (__u64) __builtin_frame_address(0); \
++      context->uc_mcontext.sp = (uint64_t) __builtin_frame_address(0); \
+     }
+ 
+ #endif /* ARCH() */
+@@ -4579,11 +4579,11 @@ stack_unwind (char *buf, int size, void
+   if (buf && bptr && eptr && context && size + mode > 0)
+     getByteInstruction ((unsigned char *) eptr);
+   int ind = 0;
+-  __u64 *lbuf = (void *) buf;
+-  int lsize = size / sizeof (__u64);
+-  __u64 pc = context->uc_mcontext.pc;
+-  __u64 sp = context->uc_mcontext.sp;
+-  __u64 stack_base;
++  uint64_t *lbuf = (void *) buf;
++  int lsize = size / sizeof (uint64_t);
++  uint64_t pc = context->uc_mcontext.pc;
++  uint64_t sp = context->uc_mcontext.sp;
++  uint64_t stack_base;
+   unsigned long tbgn = 0;
+   unsigned long tend = 0;
+ 
+@@ -4594,7 +4594,7 @@ stack_unwind (char *buf, int size, void
+     {
+       stack_base = sp + 0x100000;
+       if (stack_base < sp)  // overflow
+-	stack_base = (__u64) -1;
++	stack_base = (uint64_t) -1;
+     }
+   DprintfT (SP_DUMP_UNWIND,
+     "unwind.c:%d stack_unwind %2d pc=0x%llx  sp=0x%llx  stack_base=0x%llx\n",
+@@ -4625,17 +4625,17 @@ stack_unwind (char *buf, int size, void
+ 		      __LINE__, (unsigned long) sp);
+ 	    break;
+ 	  }
+-      pc = ((__u64 *) sp)[1];
+-      __u64 old_sp = sp;
+-      sp = ((__u64 *) sp)[0];
++      pc = ((uint64_t *) sp)[1];
++      uint64_t old_sp = sp;
++      sp = ((uint64_t *) sp)[0];
+       if (sp < old_sp)
+ 	break;
+     }
+   if (ind >= lsize)
+     {
+       ind = lsize - 1;
+-      lbuf[ind++] = (__u64) SP_TRUNC_STACK_MARKER;
++      lbuf[ind++] = (uint64_t) SP_TRUNC_STACK_MARKER;
+     }
+-  return ind * sizeof (__u64);
++  return ind * sizeof (uint64_t);
+ }
+ #endif /* ARCH() */

--- a/package/network/utils/bpftools/Makefile
+++ b/package/network/utils/bpftools/Makefile
@@ -106,7 +106,7 @@ MAKE_FLAGS += \
 	feature-llvm=0 \
 	feature-libcap=0 \
 	feature-disassembler-four-args=1 \
-	feature-disassembler-init-styled=0
+	feature-disassembler-init-styled=1
 
 ifeq ($(BUILD_VARIANT),lib)
   MAKE_PATH = libbpf/src

--- a/package/network/utils/bpftools/Makefile
+++ b/package/network/utils/bpftools/Makefile
@@ -12,9 +12,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://github.com/libbpf/bpftool
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_DATE:=2022-03-08
-PKG_SOURCE_VERSION:=04c465fd1f561f67796dc68bbfe1aa7cfa956c3c
-PKG_MIRROR_HASH:=e22a954cd186f43228a96586bbdc120b11e6c87360ab88ae96ba37afb9c7cb58
+PKG_SOURCE_DATE:=7.1.0
+PKG_SOURCE_VERSION:=b01941c8f7890489f09713348a7d89567538504b
+PKG_MIRROR_HASH:=641fb337342e25ae784a3efe72c71d8c88600a326300d8d5834e26be21547015
 PKG_ABI_VERSION:=$(call abi_version_str,$(PKG_SOURCE_DATE))
 
 PKG_MAINTAINER:=Tony Ambardar <itugrok@yahoo.com>
@@ -82,7 +82,7 @@ endef
 # LTO not compatible with DSO using PIC
 ifneq ($(BUILD_VARIANT),lib)
   TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
-  TARGET_LDFLAGS += -Wl,--gc-sections
+  TARGET_LDFLAGS += -Wl,--gc-sections -flto
 endif
 
 ifeq ($(BUILD_VARIANT),full)
@@ -102,11 +102,11 @@ MAKE_FLAGS += \
 	LIBSUBDIR=lib \
 	check_feat=0 \
 	feature-clang-bpf-co-re=0 \
-	feature-reallocarray=1 \
-	feature-zlib=1 \
 	feature-libbfd=$(full) \
+	feature-llvm=0 \
 	feature-libcap=0 \
-	feature-disassembler-four-args=$(full)
+	feature-disassembler-four-args=1 \
+	feature-disassembler-init-styled=0
 
 ifeq ($(BUILD_VARIANT),lib)
   MAKE_PATH = libbpf/src

--- a/package/network/utils/bpftools/patches/001-cflags.patch
+++ b/package/network/utils/bpftools/patches/001-cflags.patch
@@ -1,10 +1,10 @@
 --- a/libbpf/src/Makefile
 +++ b/libbpf/src/Makefile
-@@ -25,6 +25,7 @@ ALL_CFLAGS := $(INCLUDES)
+@@ -34,6 +34,7 @@ ALL_CFLAGS := $(INCLUDES)
  
  SHARED_CFLAGS += -fPIC -fvisibility=hidden -DSHARED
  
 +CFLAGS = $(EXTRA_CFLAGS)
  CFLAGS ?= -g -O2 -Werror -Wall -std=gnu89
- ALL_CFLAGS += $(CFLAGS) -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
- ALL_LDFLAGS += $(LDFLAGS)
+ ALL_CFLAGS += $(CFLAGS) -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 $(EXTRA_CFLAGS)
+ ALL_LDFLAGS += $(LDFLAGS) $(EXTRA_LDFLAGS)

--- a/package/network/utils/bpftools/patches/002-includes.patch
+++ b/package/network/utils/bpftools/patches/002-includes.patch
@@ -14,7 +14,7 @@
 @@ -73,10 +73,10 @@ CFLAGS += -W -Wall -Wextra -Wno-unused-p
  CFLAGS += $(filter-out -Wswitch-enum -Wnested-externs,$(EXTRA_WARNINGS))
  CFLAGS += -DPACKAGE='"bpftool"' -D__EXPORTED_HEADERS__ \
- 	-I$(if $(OUTPUT),$(OUTPUT),.) \
+ 	-I$(or $(OUTPUT),.) \
 -	-I$(LIBBPF_INCLUDE) \
  	-I$(srctree)/src/kernel/bpf/ \
  	-I$(srctree)/include \


### PR DESCRIPTION
This updates bpftool and binutils. The binutils update depends on the bpdtool update.

### bpftool: Update to version 7.1.0
    
bpftool changelog: https://github.com/libbpf/bpftool/releases
libbpf changelog: https://github.com/libbpf/libbpf/releases
    
This updates the bfptool to version 7.1.0. This also includes an update of the libbpf to version 1.1.
    
This also adds some new feature options and removes some old ones which were also removed form the source code. zlib for example is now mandatory.
    
Add -flto also to LD flags to make it really work.
    
Before this change bpftool was on a git commit between version 6.7 and 6.8 and libbpf was on a commit between version 0.7 and 0.8.


### binutils: Update to version 2.40
    
binutils 2.39: https://lists.gnu.org/archive/html/info-gnu/2022-08/msg00002.html
binutils 2.40: https://lists.gnu.org/archive/html/info-gnu/2023-01/msg00003.html
    
This version includes a new libsframe.so library, pack it into the libbfd package as it is used by this library. Also deactivate some optional configuration options for now.
    
An extra patch to fix compile problem in AARCH64 is added.
gprofng needs a C++ standard library, deactivate it for now.
    
Activate feature-disassembler-init-styled in bpftools too to fix compilation with the updated binutils.
    
An bpftool version 7.0 or later is needed for binutils 2.39 and later.
    
Please report back when you see problems or when this is working for you.