### PR TITLE
ramips: TP-Link EAP235/615-Wall: add poe passthrough GPIO definitions

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -12,6 +12,10 @@ mikrotik,routerboard-760igs)
 telco-electronics,x1)
 	ucidef_add_gpio_switch "modem_reset" "Modem Reset" "496"
 	;;
+tplink,eap235-wall-v1|\
+tplink,eap615-wall-v1)
+	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "poe-passthrough"
+	;;
 ubnt,edgerouter-x)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "480"
 	;;


### PR DESCRIPTION
When installing OpwnWRT on both TP-Link EAP-235 and EAP-615-Wall, the default uci system definition for the POE passthrough is missing from the initial board configuration and needs to be [manually added](https://forum.openwrt.org/t/eap615-wall-poe-passthrough-22-03/126735).

The device DTS already exports the relevant GPIO port at `/sys/class/gpio/poe-passthrough`. This PR just updates the `board.json` to reflect that.


DTS GPIO definitions:
https://github.com/openwrt/openwrt/blob/5e48c534f7c6b3a861f4a2dbb81d7bfcd9606f61/target/linux/ramips/dts/mt7621_tplink_eap235-wall-v1.dts#L48-L56
https://github.com/openwrt/openwrt/blob/5e48c534f7c6b3a861f4a2dbb81d7bfcd9606f61/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts#L52-L60
