### PR TITLE
sunxi: dts: fix ethernet node of FriendlyELEC ZeroPi

### DIFF
--- a/package/boot/uboot-sunxi/patches/250-sun8i-h3-zeropi-add-device-tree.patch
+++ b/package/boot/uboot-sunxi/patches/250-sun8i-h3-zeropi-add-device-tree.patch
@@ -65,7 +65,7 @@
 +	pinctrl-0 = <&emac_rgmii_pins>;
 +	phy-supply = <&reg_gmac_3v3>;
 +	phy-handle = <&ext_rgmii_phy>;
-+	phy-mode = "rgmii";
++	phy-mode = "rgmii-id";
 +
 +	allwinner,leds-active-low;
 +	status = "okay";


### PR DESCRIPTION
Since commit torvalds/linux@bbc4d71 ("net: phy: realtek: fix rtl8211e rx/tx delay config") network is broken on the FirendlyELEC(ARM) ZeroPi.

This patch changes the `phy-mode` to use internal delays both for RX and TX as has been done for other boards affected by the same commit.