### PR TITLE
ramips: add support for Mercusys MR70X

### DIFF
--- a/target/linux/ramips/dts/mt7621_mercusys_mr70x.dts
+++ b/target/linux/ramips/dts/mt7621_mercusys_mr70x.dts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "mercusys,mr70x", "mediatek,mt7621-soc";
+	model = "Mercusys MR70X";
+
+	aliases {
+		led-boot = &led_orange;
+		led-failsafe = &led_orange;
+		led-running = &led_orange;
+		led-upgrade = &led_orange;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+		bootargs-override = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_orange: power_orange {
+			label = "orange:power";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		key-restart {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x40000 0xf60000>;
+			};
+
+			factory: partition@fa0000 {
+				label = "factory";
+				reg = <0xfa0000 0x60000>;
+				read-only;
+				
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory_8: macaddr@8 {
+					reg = <0x8 0x6>;
+				};
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x50000>;
+		mediatek,disable-radar-background;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_8>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_factory_8>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <2>;
+};
+
+&mdio {
+	ethphy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart2", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1495,6 +1495,18 @@ define Device/mediatek_mt7621-eval-board
 endef
 TARGET_DEVICES += mediatek_mt7621-eval-board
 
+define Device/mercusys_mr70x
+  $(Device/dsa-migration)
+  $(Device/tplink-safeloader)
+  KERNEL := $(KERNEL_DTB) | uImage lzma
+  IMAGE_SIZE := 15744k
+  DEVICE_VENDOR := Mercusys
+  DEVICE_MODEL := MR70X
+  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  TPLINK_BOARD_ID := MR70X
+endef
+TARGET_DEVICES += mercusys_mr70x
+
 define Device/MikroTik
   $(Device/dsa-migration)
   DEVICE_VENDOR := MikroTik

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -115,6 +115,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		;;
+	mercusys,mr70x)
+		hw_mac_addr="$(mtd_get_mac_binary factory 0x8)"
+		[ "$PHYNBR" = "0" ] && echo -n "$hw_mac_addr" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr -1 > /sys${DEVPATH}/macaddress
+		;;
 	netgear,wax202)
 		hw_mac_addr=$(mtd_get_mac_ascii Config mac)
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
Add support for Mercusys MR70X

Hardware:
- SoC: MediaTek MT7621DAT (880Mhz)
- RAM: DDR3 128MB (SoC)
- Flash: Winbond W25Q128JV (SPI-NOR 16MB)
- WiFi: MediaTek MT7915 DBDC
- Ethernet: SoC (WAN x1, LAN x3, 1Gb)
- UART: [GND, RX, TX, 3.3V] (115200 8N1, J1)

Installation:
1. Flash factory image. This can be done using stock web ui
2. Connect to OpenWrt with an SSH connection to 192.168.1.1
3. Perform sysupgrade with sysupgrade image

Revert to stock firmware:
- Flash stock firmware via OEM Web UI Recovery mode

Web UI Recovery method:
1. Unplug the router
2. Plug in and hold reset button 5~10 secs
3. Set your computer IP address manually to 192.168.1.x / 255.255.255.0
4. Flash image with web browser to 192.168.1.1