### PR TITLE
mac80211: refresh patches

### DIFF
--- a/package/kernel/mac80211/patches/ath/402-ath_regd_optional.patch
+++ b/package/kernel/mac80211/patches/ath/402-ath_regd_optional.patch
@@ -82,7 +82,7 @@
  	help
 --- a/local-symbols
 +++ b/local-symbols
-@@ -110,6 +110,7 @@ ADM8211=
+@@ -102,6 +102,7 @@ ADM8211=
  ATH_COMMON=
  WLAN_VENDOR_ATH=
  ATH_DEBUG=

--- a/package/kernel/mac80211/patches/ath10k/080-ath10k_thermal_config.patch
+++ b/package/kernel/mac80211/patches/ath10k/080-ath10k_thermal_config.patch
@@ -37,7 +37,7 @@
  void ath10k_thermal_event_temperature(struct ath10k *ar, int temperature);
 --- a/local-symbols
 +++ b/local-symbols
-@@ -169,6 +169,7 @@ ATH10K_SNOC=
+@@ -161,6 +161,7 @@ ATH10K_SNOC=
  ATH10K_DEBUG=
  ATH10K_DEBUGFS=
  ATH10K_SPECTRAL=

--- a/package/kernel/mac80211/patches/ath10k/974-ath10k_add-LED-and-GPIO-controlling-support-for-various-chipsets.patch
+++ b/package/kernel/mac80211/patches/ath10k/974-ath10k_add-LED-and-GPIO-controlling-support-for-various-chipsets.patch
@@ -114,7 +114,7 @@ v13:
  ath10k_core-$(CONFIG_DEV_COREDUMP) += coredump.o
 --- a/local-symbols
 +++ b/local-symbols
-@@ -170,6 +170,7 @@ ATH10K_DEBUG=
+@@ -162,6 +162,7 @@ ATH10K_DEBUG=
  ATH10K_DEBUGFS=
  ATH10K_SPECTRAL=
  ATH10K_THERMAL=

--- a/package/kernel/mac80211/patches/ath9k/551-ath9k_ubnt_uap_plus_hsr.patch
+++ b/package/kernel/mac80211/patches/ath9k/551-ath9k_ubnt_uap_plus_hsr.patch
@@ -371,7 +371,7 @@
  
 --- a/local-symbols
 +++ b/local-symbols
-@@ -137,6 +137,7 @@ ATH9K_WOW=
+@@ -129,6 +129,7 @@ ATH9K_WOW=
  ATH9K_RFKILL=
  ATH9K_CHANNEL_CONTEXT=
  ATH9K_PCOEM=

--- a/package/kernel/mac80211/patches/rt2x00/602-rt2x00-introduce-rt2x00eeprom.patch
+++ b/package/kernel/mac80211/patches/rt2x00/602-rt2x00-introduce-rt2x00eeprom.patch
@@ -1,6 +1,6 @@
 --- a/local-symbols
 +++ b/local-symbols
-@@ -354,6 +354,7 @@ RT2X00_LIB_FIRMWARE=
+@@ -347,6 +347,7 @@ RT2X00_LIB_FIRMWARE=
  RT2X00_LIB_CRYPTO=
  RT2X00_LIB_LEDS=
  RT2X00_LIB_DEBUGFS=


### PR DESCRIPTION
The last mac80211 commits did not refresh the patches.

Refresh:
- ath/402-ath_regd_optional.patch
- ath10k/080-ath10k_thermal_config.patch
- ath10k/974-ath10k_add-LED-and-GPIO-controlling-support-for-various-chipsets.patch
- ath9k/551-ath9k_ubnt_uap_plus_hsr.patch
- rt2x00/602-rt2x00-introduce-rt2x00eeprom.patch
