### PR TITLE
ramips: add WAN activity LED for Xiaomi R3Gv2/R4AGv1

### DIFF
--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-3g-v2.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-3g-v2.dtsi
@@ -2,6 +2,8 @@
 
 #include "mt7621_xiaomi_mi-router-4a-common.dtsi"
 
+#include <dt-bindings/leds/common.h>
+
 / {
 	aliases {
 		label-mac-device = &gmac1;
@@ -12,12 +14,23 @@
 
 		led_status_blue: status_blue {
 			label = "blue:status";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
 		};
 
 		led_status_yellow: status_yellow {
 			label = "yellow:status";
+			color = <LED_COLOR_ID_YELLOW>;
+			function = LED_FUNCTION_STATUS;
 			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_blue {
+			label = "blue:wan";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&switch0 12 GPIO_ACTIVE_LOW>;
 		};
 	};
 };
@@ -48,6 +61,9 @@
 };
 
 &switch0 {
+	gpio-controller;
+	#gpio-cells = <2>;
+
 	ports {
 		port@2 {
 			status = "okay";

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -200,6 +200,10 @@ xiaomi,mi-router-cr6608|\
 xiaomi,mi-router-cr6609)
 	ucidef_set_led_netdev "internet" "Internet" "blue:net" "wan"
 	;;
+xiaomi,mi-router-3g-v2|\
+xiaomi,mi-router-4a-gigabit)
+	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
+	;;
 xiaomi,redmi-router-ac2100)
 	ucidef_set_led_netdev "wan" "wan" "white:wan" "wan"
 	;;


### PR DESCRIPTION
The WAN activity LED was connected to MT7530 GPIO. Thanks to upstream change https://github.com/torvalds/linux/commit/429a0edeefd88cbfca5c417dfb8561047bb50769, it is programmable.

Tested on Xiaomi R4AGv1. Should also work for Xiaomi R3Gv2 (identical hardware).