### PR TITLE
netifd: strip mask from IP address in DHCP client params

### DIFF
--- a/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
+++ b/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
@@ -67,7 +67,7 @@ proto_dhcp_setup() {
 		-p /var/run/udhcpc-$iface.pid \
 		-s /lib/netifd/dhcp.script \
 		-f -t 0 -i "$iface" \
-		${ipaddr:+-r $ipaddr} \
+		${ipaddr:+-r ${ipaddr/\/*/}} \
 		${hostname:+-x "hostname:$hostname"} \
 		${vendorid:+-V "$vendorid"} \
 		$clientid $defaultreqopts $broadcast $norelease $dhcpopts


### PR DESCRIPTION
`ipaddr` can be in CIDR notation, but relatively fresh `udhcp` does not like it (likely starting from https://git.busybox.net/busybox/commit/networking/udhcp/dhcpc.c?id=ebe8c14d34d3f6957b4e44967c9089b84e144ddf)