### PR TITLE
[21.02] ca-certificates: update to 20211016 and add patch

### DIFF
--- a/package/system/ca-certificates/Makefile
+++ b/package/system/ca-certificates/Makefile
@@ -7,13 +7,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ca-certificates
-PKG_VERSION:=20210119
+PKG_VERSION:=20211016
 PKG_RELEASE:=1
 PKG_MAINTAINER:=
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://ftp.debian.org/debian/pool/main/c/ca-certificates
-PKG_HASH:=daa3afae563711c30a0586ddae4336e8e3974c2b627faaca404c4e0141b64665
+PKG_HASH:=2ae9b6dc5f40c25d6d7fe55e07b54f12a8967d1955d3b7b2f42ee46266eeef88
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/system/ca-certificates/patches/0001-ca-certificates-fix-python3-cryptography-woes-in-cer.patch
+++ b/package/system/ca-certificates/patches/0001-ca-certificates-fix-python3-cryptography-woes-in-cer.patch
@@ -1,0 +1,53 @@
+From 3c51cb5ff1d0db41fb3288fb555c7e7055cf3e86 Mon Sep 17 00:00:00 2001
+From: Christian Lamparter <chunkeey@gmail.com>
+Date: Wed, 1 Dec 2021 14:41:31 +0100
+Subject: [PATCH] ca-certificates: fix python3-cryptography woes in
+ certdata2pem.py
+
+reverts the code portion of the Debian's ca-certificate
+commit 033d52259172 ("mozilla/certdata2pem.py: print a warning for expired certificates.")
+
+It broke builds with the popular Ubuntu 20.04 (focal) releases.
+This was due to them shipping with an older python3-cryptography
+version which is not compatible.
+
+More concerns were raised by jow- as well:
+"We don't want the build to depend on the local system time anyway."
+
+Reported-by: Chen Minqiang <ptpt52@gmail.com>
+Reported-by: Shane Synan <digitalcircuit36939@gmail.com>
+Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
+---
+--- a/work/mozilla/certdata2pem.py
++++ b/work/mozilla/certdata2pem.py
+@@ -21,16 +21,12 @@
+ # USA.
+ 
+ import base64
+-import datetime
+ import os.path
+ import re
+ import sys
+ import textwrap
+ import io
+ 
+-from cryptography import x509
+-
+-
+ objects = []
+ 
+ # Dirty file parser.
+@@ -121,13 +117,6 @@ for obj in objects:
+     if obj['CKA_CLASS'] == 'CKO_CERTIFICATE':
+         if not obj['CKA_LABEL'] in trust or not trust[obj['CKA_LABEL']]:
+             continue
+-
+-        cert = x509.load_der_x509_certificate(obj['CKA_VALUE'])
+-        if cert.not_valid_after < datetime.datetime.now():
+-            print('!'*74)
+-            print('Trusted but expired certificate found: %s' % obj['CKA_LABEL'])
+-            print('!'*74)
+-
+         bname = obj['CKA_LABEL'][1:-1].replace('/', '_')\
+                                       .replace(' ', '_')\
+                                       .replace('(', '=')\


### PR DESCRIPTION
Ex-maintainer: @chunkeey 

This updates ca-certificates to the latest version, which is present in OpenWrt 22.03 and OpenWrt master branch

- Compile tested: OpenWrt 21.02.5, Turris 1.1, mpc85xx/powerpc8540
   - Package contents verified
   
  Patch is required otherwise it fails with, but it is included in OpenWrt 22.03 and OpenWrt master branch, too.
```
python3 certdata2pem.py
Traceback (most recent call last):
  File "/home/foo/turris/build/build_dir/target-powerpc_8548_musl/ca-certificates-20211016/work/mozilla/certdata2pem.py", line 31, in <module>
    from cryptography import x509
ModuleNotFoundError: No module named 'cryptography'
make[4]: *** [Makefile:6: all] Error 1
```

Nothing new, just cherry-picked from OpenWrt 22.03 branch.