### PR TITLE
ath79: add support for D-Link COVR-P2500 A1

### DIFF
--- a/target/linux/ath79/dts/qca9563_dlink_covr-p2500-a1.dts
+++ b/target/linux/ath79/dts/qca9563_dlink_covr-p2500-a1.dts
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	compatible = "dlink,covr-p2500-a1", "qca,qca9563";
+	model = "D-Link COVR-P2500 A1";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_red;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan5g {
+			label = "green:wlan5g";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		led_power_red: power_red {
+			label = "red:power";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "green:wlan2g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x68737173>;
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			fwconcat0: partition@50000 {
+				label = "fwconcat0";
+				reg = <0x50000 0xe30000>;
+			};
+
+			partition@e80000 {
+				label = "loader";
+				reg = <0xe80000 0x10000>;
+				read-only;
+			};
+
+			fwconcat1: partition@e90000 {
+				label = "fwconcat1";
+				reg = <0xe90000 0x160000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					calibration_ath9k: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+					precalibration_ath10k: pre-calibration@5000 {
+						reg = <0x5000 0x2f20>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0 0 0 0 0>;
+
+		nvmem-cells = <&precalibration_ath10k>;
+		nvmem-cell-names = "pre-calibration";
+	};
+};
+
+&gpio {
+	phy-reset {
+		gpio-hog;
+		gpios = <11 GPIO_ACTIVE_LOW>;
+		output-low;
+		line-name = "phy-reset";
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		qca,mib-poll-interval = <500>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x10 0x81000080 /* POWER_ON_STRAP */
+			0x50 0xcc35cc35 /* LED_CTRL0 */
+			0x54 0xcb37cb37 /* LED_CTRL1 */
+			0x58 0x00000000 /* LED_CTRL2 */
+			0x5c 0x00f3cf00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001919>;
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&calibration_ath9k>;
+	nvmem-cell-names = "calibration";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -230,6 +230,9 @@ devolo,dlan-pro-1200plus-ac|\
 devolo,magic-2-wifi)
 	ucidef_set_led_netdev "plcw" "dLAN" "white:dlan" "eth0.1" "rx"
 	;;
+dlink,covr-p2500-a1)
+	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x0e" "" "link"
+	;;
 dlink,dap-1330-a1|\
 dlink,dap-1365-a1)
 	ucidef_set_rssimon "wlan0" "200000" "1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -286,6 +286,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:wan" "3:lan" "4:lan"
 		;;
+	dlink,covr-p2500-a1)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan" "2:lan" "3:wan" "4:plc"
+		;;
 	dlink,dap-2695-a1)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:wan" "6@eth1"
@@ -633,6 +637,13 @@ ath79_setup_macs()
 	devolo,dlan-pro-1200plus-ac|\
 	devolo,magic-2-wifi)
 		label_mac=$(macaddr_add "$(mtd_get_mac_binary art 0x1002)" 3)
+		;;
+	dlink,covr-p2500-a1)
+		lan_mac=$(mtd_get_mac_ascii art "protest_lan_mac")
+		wan_mac=$(mtd_get_mac_ascii art "protest_lan_mac")
+		label_mac=$(mtd_get_mac_ascii art "protest_plc_mac")
+		plc_mac=$(mtd_get_mac_ascii art "protest_plc_mac")
+		[ -n "$plc_mac" ] && ucidef_set_interface_macaddr "plc" $plc_mac
 		;;
 	dlink,dap-1330-a1|\
 	dlink,dap-1365-a1|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -17,6 +17,12 @@ case "$board" in
 	adtran,bsap1840)
 		macaddr_add "$(mtd_get_mac_binary 'Board data' 2)" $(($PHYNBR * 8 + 1)) > /sys${DEVPATH}/macaddress
 		;;
+	dlink,covr-p2500-a1)
+		[ "$PHYNBR" -eq 0 ] && \
+			mtd_get_mac_ascii art "protest_ath1_mac" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" -eq 1 ] && \
+			mtd_get_mac_ascii art "protest_ath0_mac" > /sys${DEVPATH}/macaddress
+		;;
 	dlink,dap-1330-a1|\
 	dlink,dap-1365-a1|\
 	dlink,dch-g020-a1)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -33,6 +33,17 @@ define Build/cybertan-trx
 	-rm $@-empty.bin
 endef
 
+define Build/dlink-sge-signature
+	( \
+		crc=$$(gzip -c $@ | tail -c 8 | od -An -tx4 --endian little | cut -d " " -f2); \
+		cat $@; \
+		$(MKHASH) md5 $@ ; \
+		echo $(1); \
+		echo -n $$crc; \
+	) > $@.new
+	mv $@.new $@
+endef
+
 define Build/edimax-headers
 	$(eval edimax_magic=$(word 1,$(1)))
 	$(eval edimax_model=$(word 2,$(1)))
@@ -994,6 +1005,26 @@ define Device/devolo_magic-2-wifi
   IMAGE_SIZE := 15872k
 endef
 TARGET_DEVICES += devolo_magic-2-wifi
+
+define Device/dlink_covr-p2500-a1
+  $(Device/loader-okli-uimage)
+  SOC := qca9563
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := COVR-P2500
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  LOADER_FLASH_OFFS := 0x050000
+  LOADER_KERNEL_MAGIC := 0x68737173
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x68737173
+  IMAGE_SIZE := 14528k
+  IMAGES += factory.bin recovery.bin
+  IMAGE/recovery.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | pad-to 14528k | \
+	append-loader-okli-uimage $(1) | pad-to 15616k
+  IMAGE/factory.bin := $$(IMAGE/recovery.bin) | \
+	dlink-sge-image COVR-P2500 | dlink-sge-signature COVR-P2500
+endef
+TARGET_DEVICES += dlink_covr-p2500-a1
 
 define Device/dlink_dap-13xx
   SOC := qca9533


### PR DESCRIPTION
Specifications:
* QCA9563, 16 MiB flash, 128 MiB RAM, 2T2R 802.11n
* QCA9886 2T2R 801.11ac Wave 2
* QCA7550 Homeplug AV2 1300
* AR8337, 3 Gigabit ports (1, 2: LAN; 3: WAN)

To make use of PLC functionality, firmware needs to be provided via plchost (QCA7550 comes without SPI NOR), patched with the Network Password and MAC.

Flashing via OEM Web Interface
* Flash 'factory.bin' using web-interface
* Wait until firmware succesfully installed and device booted
* Hold down reset button to reset factory defaults (~10 seconds)

Flashing via Recovery Web Interface:
* Hold down reset button during power-on (~10 seconds)
* Recovery Web UI is at 192.168.0.50, no DHCP.
* Flash 'recovery.bin' with scripts/flashing/dlink_recovery_upload.py (Recovery Web UI does not work with modern OSes)

Return to stock
* Hold down reset button during power-on (~10 seconds)
* Recovery Web UI is at 192.168.0.50, no DHCP.
* Flash unencrypted stock firmware with scripts/flashing/dlink_recovery_upload.py (Recovery Web UI does not work with modern OSes)

Co-developed-by: Sebastian Schaper <openwrt@sebastianschaper.net>
Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>
Signed-off-by: Daniel Linjama <daniel@dev.linjama.com>
