### PR TITLE
mvebu: Ctera C200-V2: tune the dts pcie config

### DIFF
--- a/target/linux/mvebu/files/arch/arm/boot/dts/armada-370-c200-v2.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/armada-370-c200-v2.dts
@@ -337,8 +337,9 @@
 				/* Renesas uPD720202 */
 				compatible = "pci1912,0015";
 				reg = <0x1000 0 0 0 0>;
-				#address-cells = <3>;
-				#size-cells = <2>;
+
+				#address-cells = <1>;
+				#size-cells = <0>;
 
 				usb1_port: port@1 {
 					reg = <1>;
@@ -383,7 +384,7 @@
 
 	pmx_pcie: pmx-pcie {
 		marvell,pins = "mpp59";
-		marvell,function = "gpio";
+		marvell,function = "gpo";
 	};
 
 	/* this gpio is connected to the pin of buzzer


### PR DESCRIPTION
The pinmux used for reset in the pcie express node is wrong. The mpp59 pin cannot be pinmuxed to gpio but gpo. There are also subnodes defined with wrong address/size cells.

Change the pcie reset pinmux to gpo and fix addressing for subnodes.

@CHKDSK88 can you check this?