### PR TITLE
kernel: Fix perf build with binutils 2.40

### DIFF
--- a/target/linux/generic/backport-5.15/060-v6.0-01-tools-build-Add-feature-test-for-init_disassemble_in.patch
+++ b/target/linux/generic/backport-5.15/060-v6.0-01-tools-build-Add-feature-test-for-init_disassemble_in.patch
@@ -1,0 +1,95 @@
+From 598ada195606eb0e577db0487dd59a2536f206ce Mon Sep 17 00:00:00 2001
+From: Andres Freund <andres@anarazel.de>
+Date: Sun, 31 Jul 2022 18:38:27 -0700
+Subject: [PATCH 1/5] tools build: Add feature test for init_disassemble_info
+ API changes
+
+binutils changed the signature of init_disassemble_info(), which now causes
+compilation failures for tools/{perf,bpf}, e.g. on debian unstable.
+
+Relevant binutils commit:
+
+  https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=60a3da00bd5407f07
+
+This commit adds a feature test to detect the new signature.  Subsequent
+commits will use it to fix the build failures.
+
+Signed-off-by: Andres Freund <andres@anarazel.de>
+Acked-by: Quentin Monnet <quentin@isovalent.com>
+Cc: Alexei Starovoitov <ast@kernel.org>
+Cc: Ben Hutchings <benh@debian.org>
+Cc: Jiri Olsa <jolsa@kernel.org>
+Cc: Quentin Monnet <quentin@isovalent.com>
+Cc: Sedat Dilek <sedat.dilek@gmail.com>
+Cc: bpf@vger.kernel.org
+Link: http://lore.kernel.org/lkml/20220622181918.ykrs5rsnmx3og4sv@alap3.anarazel.de
+Link: https://lore.kernel.org/r/20220801013834.156015-2-andres@anarazel.de
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+(cherry picked from commit cfd59ca91467056bb2c36907b2fa67b8e1af9952)
+---
+ tools/build/Makefile.feature                        |  1 +
+ tools/build/feature/Makefile                        |  4 ++++
+ tools/build/feature/test-all.c                      |  4 ++++
+ tools/build/feature/test-disassembler-init-styled.c | 13 +++++++++++++
+ 4 files changed, 22 insertions(+)
+ create mode 100644 tools/build/feature/test-disassembler-init-styled.c
+
+--- a/tools/build/Makefile.feature
++++ b/tools/build/Makefile.feature
+@@ -69,6 +69,7 @@ FEATURE_TESTS_BASIC :=
+         libaio				\
+         libzstd				\
+         disassembler-four-args		\
++        disassembler-init-styled	\
+         file-handle
+ 
+ # FEATURE_TESTS_BASIC + FEATURE_TESTS_EXTRA is the complete list
+--- a/tools/build/feature/Makefile
++++ b/tools/build/feature/Makefile
+@@ -18,6 +18,7 @@ FILES=
+          test-libbfd.bin                        \
+          test-libbfd-buildid.bin		\
+          test-disassembler-four-args.bin        \
++         test-disassembler-init-styled.bin	\
+          test-reallocarray.bin			\
+          test-libbfd-liberty.bin                \
+          test-libbfd-liberty-z.bin              \
+@@ -239,6 +240,9 @@ $(OUTPUT)test-libbfd-buildid.bin:
+ $(OUTPUT)test-disassembler-four-args.bin:
+ 	$(BUILD) -DPACKAGE='"perf"' -lbfd -lopcodes
+ 
++$(OUTPUT)test-disassembler-init-styled.bin:
++	$(BUILD) -DPACKAGE='"perf"' -lbfd -lopcodes
++
+ $(OUTPUT)test-reallocarray.bin:
+ 	$(BUILD)
+ 
+--- a/tools/build/feature/test-all.c
++++ b/tools/build/feature/test-all.c
+@@ -166,6 +166,10 @@
+ # include "test-disassembler-four-args.c"
+ #undef main
+ 
++#define main main_test_disassembler_init_styled
++# include "test-disassembler-init-styled.c"
++#undef main
++
+ #define main main_test_libzstd
+ # include "test-libzstd.c"
+ #undef main
+--- /dev/null
++++ b/tools/build/feature/test-disassembler-init-styled.c
+@@ -0,0 +1,13 @@
++// SPDX-License-Identifier: GPL-2.0
++#include <stdio.h>
++#include <dis-asm.h>
++
++int main(void)
++{
++	struct disassemble_info info;
++
++	init_disassemble_info(&info, stdout,
++			      NULL, NULL);
++
++	return 0;
++}

--- a/target/linux/generic/backport-5.15/060-v6.0-02-tools-include-add-dis-asm-compat.h-to-handle-version.patch
+++ b/target/linux/generic/backport-5.15/060-v6.0-02-tools-include-add-dis-asm-compat.h-to-handle-version.patch
@@ -1,0 +1,96 @@
+From 08ec5766e5cf7b24fdebefb83b6f760bceeddf40 Mon Sep 17 00:00:00 2001
+From: Andres Freund <andres@anarazel.de>
+Date: Sun, 31 Jul 2022 18:38:29 -0700
+Subject: [PATCH 2/5] tools include: add dis-asm-compat.h to handle version
+ differences
+
+binutils changed the signature of init_disassemble_info(), which now causes
+compilation failures for tools/{perf,bpf}, e.g. on debian unstable.
+
+Relevant binutils commit:
+
+  https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=60a3da00bd5407f07
+
+This commit introduces a wrapper for init_disassemble_info(), to avoid
+spreading #ifdef DISASM_INIT_STYLED to a bunch of places. Subsequent
+commits will use it to fix the build failures.
+
+It likely is worth adding a wrapper for disassember(), to avoid the already
+existing DISASM_FOUR_ARGS_SIGNATURE ifdefery.
+
+Signed-off-by: Andres Freund <andres@anarazel.de>
+Signed-off-by: Ben Hutchings <benh@debian.org>
+Acked-by: Quentin Monnet <quentin@isovalent.com>
+Cc: Alexei Starovoitov <ast@kernel.org>
+Cc: Ben Hutchings <benh@debian.org>
+Cc: Jiri Olsa <jolsa@kernel.org>
+Cc: Quentin Monnet <quentin@isovalent.com>
+Cc: Sedat Dilek <sedat.dilek@gmail.com>
+Cc: bpf@vger.kernel.org
+Link: http://lore.kernel.org/lkml/20220622181918.ykrs5rsnmx3og4sv@alap3.anarazel.de
+Link: https://lore.kernel.org/r/20220801013834.156015-4-andres@anarazel.de
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+(cherry picked from commit a45b3d6926231c3d024ea0de4f7bd967f83709ee)
+---
+ tools/include/tools/dis-asm-compat.h | 55 ++++++++++++++++++++++++++++
+ 1 file changed, 55 insertions(+)
+ create mode 100644 tools/include/tools/dis-asm-compat.h
+
+--- /dev/null
++++ b/tools/include/tools/dis-asm-compat.h
+@@ -0,0 +1,55 @@
++/* SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause */
++#ifndef _TOOLS_DIS_ASM_COMPAT_H
++#define _TOOLS_DIS_ASM_COMPAT_H
++
++#include <stdio.h>
++#include <dis-asm.h>
++
++/* define types for older binutils version, to centralize ifdef'ery a bit */
++#ifndef DISASM_INIT_STYLED
++enum disassembler_style {DISASSEMBLER_STYLE_NOT_EMPTY};
++typedef int (*fprintf_styled_ftype) (void *, enum disassembler_style, const char*, ...);
++#endif
++
++/*
++ * Trivial fprintf wrapper to be used as the fprintf_styled_func argument to
++ * init_disassemble_info_compat() when normal fprintf suffices.
++ */
++static inline int fprintf_styled(void *out,
++				 enum disassembler_style style,
++				 const char *fmt, ...)
++{
++	va_list args;
++	int r;
++
++	(void)style;
++
++	va_start(args, fmt);
++	r = vfprintf(out, fmt, args);
++	va_end(args);
++
++	return r;
++}
++
++/*
++ * Wrapper for init_disassemble_info() that hides version
++ * differences. Depending on binutils version and architecture either
++ * fprintf_func or fprintf_styled_func will be called.
++ */
++static inline void init_disassemble_info_compat(struct disassemble_info *info,
++						void *stream,
++						fprintf_ftype unstyled_func,
++						fprintf_styled_ftype styled_func)
++{
++#ifdef DISASM_INIT_STYLED
++	init_disassemble_info(info, stream,
++			      unstyled_func,
++			      styled_func);
++#else
++	(void)styled_func;
++	init_disassemble_info(info, stream,
++			      unstyled_func);
++#endif
++}
++
++#endif /* _TOOLS_DIS_ASM_COMPAT_H */

--- a/target/linux/generic/backport-5.15/060-v6.0-03-tools-perf-Fix-compilation-error-with-new-binutils.patch
+++ b/target/linux/generic/backport-5.15/060-v6.0-03-tools-perf-Fix-compilation-error-with-new-binutils.patch
@@ -1,0 +1,111 @@
+From 3bc373152a3a00742750dbbe974d541af78231e6 Mon Sep 17 00:00:00 2001
+From: Andres Freund <andres@anarazel.de>
+Date: Sun, 31 Jul 2022 18:38:30 -0700
+Subject: [PATCH 3/5] tools perf: Fix compilation error with new binutils
+
+binutils changed the signature of init_disassemble_info(), which now causes
+compilation failures for tools/perf/util/annotate.c, e.g. on debian
+unstable.
+
+Relevant binutils commit:
+
+  https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=60a3da00bd5407f07
+
+Wire up the feature test and switch to init_disassemble_info_compat(),
+which were introduced in prior commits, fixing the compilation failure.
+
+I verified that perf can still disassemble bpf programs by using bpftrace
+under load, recording a perf trace, and then annotating the bpf "function"
+with and without the changes. With old binutils there's no change in output
+before/after this patch. When comparing the output from old binutils (2.35)
+to new bintuils with the patch (upstream snapshot) there are a few output
+differences, but they are unrelated to this patch. An example hunk is:
+
+       1.15 :   55:mov    %rbp,%rdx
+       0.00 :   58:add    $0xfffffffffffffff8,%rdx
+       0.00 :   5c:xor    %ecx,%ecx
+  -    1.03 :   5e:callq  0xffffffffe12aca3c
+  +    1.03 :   5e:call   0xffffffffe12aca3c
+       0.00 :   63:xor    %eax,%eax
+  -    2.18 :   65:leaveq
+  -    2.82 :   66:retq
+  +    2.18 :   65:leave
+  +    2.82 :   66:ret
+
+Signed-off-by: Andres Freund <andres@anarazel.de>
+Acked-by: Quentin Monnet <quentin@isovalent.com>
+Cc: Alexei Starovoitov <ast@kernel.org>
+Cc: Ben Hutchings <benh@debian.org>
+Cc: Jiri Olsa <jolsa@kernel.org>
+Cc: Sedat Dilek <sedat.dilek@gmail.com>
+Cc: bpf@vger.kernel.org
+Link: http://lore.kernel.org/lkml/20220622181918.ykrs5rsnmx3og4sv@alap3.anarazel.de
+Link: https://lore.kernel.org/r/20220801013834.156015-5-andres@anarazel.de
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+(cherry picked from commit 83aa0120487e8bc3f231e72c460add783f71f17c)
+---
+ tools/perf/Makefile.config | 8 ++++++++
+ tools/perf/util/annotate.c | 7 ++++---
+ 2 files changed, 12 insertions(+), 3 deletions(-)
+
+--- a/tools/perf/Makefile.config
++++ b/tools/perf/Makefile.config
+@@ -296,6 +296,7 @@ FEATURE_CHECK_LDFLAGS-libpython := $(PYT
+ FEATURE_CHECK_LDFLAGS-libaio = -lrt
+ 
+ FEATURE_CHECK_LDFLAGS-disassembler-four-args = -lbfd -lopcodes -ldl
++FEATURE_CHECK_LDFLAGS-disassembler-init-styled = -lbfd -lopcodes -ldl
+ 
+ CORE_CFLAGS += -fno-omit-frame-pointer
+ CORE_CFLAGS += -ggdb3
+@@ -872,13 +873,16 @@ ifndef NO_LIBBFD
+     ifeq ($(feature-libbfd-liberty), 1)
+       EXTLIBS += -lbfd -lopcodes -liberty
+       FEATURE_CHECK_LDFLAGS-disassembler-four-args += -liberty -ldl
++      FEATURE_CHECK_LDFLAGS-disassembler-init-styled += -liberty -ldl
+     else
+       ifeq ($(feature-libbfd-liberty-z), 1)
+         EXTLIBS += -lbfd -lopcodes -liberty -lz
+         FEATURE_CHECK_LDFLAGS-disassembler-four-args += -liberty -lz -ldl
++        FEATURE_CHECK_LDFLAGS-disassembler-init-styled += -liberty -lz -ldl
+       endif
+     endif
+     $(call feature_check,disassembler-four-args)
++    $(call feature_check,disassembler-init-styled)
+   endif
+ 
+   ifeq ($(feature-libbfd-buildid), 1)
+@@ -992,6 +996,10 @@ ifeq ($(feature-disassembler-four-args),
+     CFLAGS += -DDISASM_FOUR_ARGS_SIGNATURE
+ endif
+ 
++ifeq ($(feature-disassembler-init-styled), 1)
++    CFLAGS += -DDISASM_INIT_STYLED
++endif
++
+ ifeq (${IS_64_BIT}, 1)
+   ifndef NO_PERF_READ_VDSO32
+     $(call feature_check,compile-32)
+--- a/tools/perf/util/annotate.c
++++ b/tools/perf/util/annotate.c
+@@ -1694,6 +1694,7 @@ fallback:
+ #include <bpf/btf.h>
+ #include <bpf/libbpf.h>
+ #include <linux/btf.h>
++#include <tools/dis-asm-compat.h>
+ 
+ static int symbol__disassemble_bpf(struct symbol *sym,
+ 				   struct annotate_args *args)
+@@ -1736,9 +1737,9 @@ static int symbol__disassemble_bpf(struc
+ 		ret = errno;
+ 		goto out;
+ 	}
+-	init_disassemble_info(&info, s,
+-			      (fprintf_ftype) fprintf);
+-
++	init_disassemble_info_compat(&info, s,
++				     (fprintf_ftype) fprintf,
++				     fprintf_styled);
+ 	info.arch = bfd_get_arch(bfdf);
+ 	info.mach = bfd_get_mach(bfdf);
+ 

--- a/target/linux/generic/backport-5.15/060-v6.0-04-tools-bpf_jit_disasm-Fix-compilation-error-with-new-.patch
+++ b/target/linux/generic/backport-5.15/060-v6.0-04-tools-bpf_jit_disasm-Fix-compilation-error-with-new-.patch
@@ -1,0 +1,102 @@
+From 042e7f11769adac0736d77d76262912b90724d7d Mon Sep 17 00:00:00 2001
+From: Andres Freund <andres@anarazel.de>
+Date: Sun, 31 Jul 2022 18:38:31 -0700
+Subject: [PATCH 4/5] tools bpf_jit_disasm: Fix compilation error with new
+ binutils
+
+binutils changed the signature of init_disassemble_info(), which now causes
+compilation to fail for tools/bpf/bpf_jit_disasm.c, e.g. on debian
+unstable.
+
+Relevant binutils commit:
+
+  https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=60a3da00bd5407f07
+
+Wire up the feature test and switch to init_disassemble_info_compat(),
+which were introduced in prior commits, fixing the compilation failure.
+
+I verified that bpf_jit_disasm can still disassemble bpf programs, both
+with the old and new dis-asm.h API. With old binutils there's no change in
+output before/after this patch. When comparing the output from old
+binutils (2.35) to new bintuils with the patch (upstream snapshot) there
+are a few output differences, but they are unrelated to this patch. An
+example hunk is:
+
+     f4:	mov    %r14,%rsi
+     f7:	mov    %r15,%rdx
+     fa:	mov    $0x2a,%ecx
+  -  ff:	callq  0xffffffffea8c4988
+  +  ff:	call   0xffffffffea8c4988
+    104:	test   %rax,%rax
+    107:	jge    0x0000000000000110
+    109:	xor    %eax,%eax
+  - 10b:	jmpq   0x0000000000000073
+  + 10b:	jmp    0x0000000000000073
+    110:	cmp    $0x16,%rax
+
+However, I had to use an older kernel to generate the bpf_jit_enabled =
+2 output, as that has been broken since 5.18 / 1022a5498f6f745c ("bpf,
+x86_64: Use bpf_jit_binary_pack_alloc").
+
+  https://lore.kernel.org/20220703030210.pmjft7qc2eajzi6c@alap3.anarazel.de
+
+Signed-off-by: Andres Freund <andres@anarazel.de>
+Acked-by: Quentin Monnet <quentin@isovalent.com>
+Cc: Alexei Starovoitov <ast@kernel.org>
+Cc: Ben Hutchings <benh@debian.org>
+Cc: Daniel Borkmann <daniel@iogearbox.net>
+Cc: Jiri Olsa <jolsa@kernel.org>
+Cc: Quentin Monnet <quentin@isovalent.com>
+Cc: Sedat Dilek <sedat.dilek@gmail.com>
+Cc: bpf@vger.kernel.org
+Link: http://lore.kernel.org/lkml/20220622181918.ykrs5rsnmx3og4sv@alap3.anarazel.de
+Link: https://lore.kernel.org/r/20220801013834.156015-6-andres@anarazel.de
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+(cherry picked from commit 96ed066054abf11c7d3e106e3011a51f3f1227a3)
+---
+ tools/bpf/Makefile         | 5 ++++-
+ tools/bpf/bpf_jit_disasm.c | 5 ++++-
+ 2 files changed, 8 insertions(+), 2 deletions(-)
+
+--- a/tools/bpf/Makefile
++++ b/tools/bpf/Makefile
+@@ -34,7 +34,7 @@ else
+ endif
+ 
+ FEATURE_USER = .bpf
+-FEATURE_TESTS = libbfd disassembler-four-args
++FEATURE_TESTS = libbfd disassembler-four-args disassembler-init-styled
+ FEATURE_DISPLAY = libbfd disassembler-four-args
+ 
+ check_feat := 1
+@@ -56,6 +56,9 @@ endif
+ ifeq ($(feature-disassembler-four-args), 1)
+ CFLAGS += -DDISASM_FOUR_ARGS_SIGNATURE
+ endif
++ifeq ($(feature-disassembler-init-styled), 1)
++CFLAGS += -DDISASM_INIT_STYLED
++endif
+ 
+ $(OUTPUT)%.yacc.c: $(srctree)/tools/bpf/%.y
+ 	$(QUIET_BISON)$(YACC) -o $@ -d $<
+--- a/tools/bpf/bpf_jit_disasm.c
++++ b/tools/bpf/bpf_jit_disasm.c
+@@ -28,6 +28,7 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <limits.h>
++#include <tools/dis-asm-compat.h>
+ 
+ #define CMD_ACTION_SIZE_BUFFER		10
+ #define CMD_ACTION_READ_ALL		3
+@@ -64,7 +65,9 @@ static void get_asm_insns(uint8_t *image
+ 	assert(bfdf);
+ 	assert(bfd_check_format(bfdf, bfd_object));
+ 
+-	init_disassemble_info(&info, stdout, (fprintf_ftype) fprintf);
++	init_disassemble_info_compat(&info, stdout,
++				     (fprintf_ftype) fprintf,
++				     fprintf_styled);
+ 	info.arch = bfd_get_arch(bfdf);
+ 	info.mach = bfd_get_mach(bfdf);
+ 	info.buffer = image;

--- a/target/linux/generic/backport-5.15/060-v6.0-05-tools-bpftool-Fix-compilation-error-with-new-binutil.patch
+++ b/target/linux/generic/backport-5.15/060-v6.0-05-tools-bpftool-Fix-compilation-error-with-new-binutil.patch
@@ -1,0 +1,146 @@
+From a82db18ab34ba7f9d38319e8cc01ffe382e3e55e Mon Sep 17 00:00:00 2001
+From: Andres Freund <andres@anarazel.de>
+Date: Sun, 31 Jul 2022 18:38:33 -0700
+Subject: [PATCH 5/5] tools bpftool: Fix compilation error with new binutils
+
+binutils changed the signature of init_disassemble_info(), which now causes
+compilation to fail for tools/bpf/bpftool/jit_disasm.c, e.g. on debian
+unstable.
+
+Relevant binutils commit:
+
+  https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=60a3da00bd5407f07
+
+Wire up the feature test and switch to init_disassemble_info_compat(),
+which were introduced in prior commits, fixing the compilation failure.
+
+I verified that bpftool can still disassemble bpf programs, both with an
+old and new dis-asm.h API. There are no output changes for plain and json
+formats. When comparing the output from old binutils (2.35)
+to new bintuils with the patch (upstream snapshot) there are a few output
+differences, but they are unrelated to this patch. An example hunk is:
+
+     2f:	pop    %r14
+     31:	pop    %r13
+     33:	pop    %rbx
+  -  34:	leaveq
+  -  35:	retq
+  +  34:	leave
+  +  35:	ret
+
+Signed-off-by: Andres Freund <andres@anarazel.de>
+Acked-by: Quentin Monnet <quentin@isovalent.com>
+Cc: Alexei Starovoitov <ast@kernel.org>
+Cc: Ben Hutchings <benh@debian.org>
+Cc: Jiri Olsa <jolsa@kernel.org>
+Cc: Quentin Monnet <quentin@isovalent.com>
+Cc: Sedat Dilek <sedat.dilek@gmail.com>
+Cc: bpf@vger.kernel.org
+Link: http://lore.kernel.org/lkml/20220622181918.ykrs5rsnmx3og4sv@alap3.anarazel.de
+Link: https://lore.kernel.org/r/20220801013834.156015-8-andres@anarazel.de
+Signed-off-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+(cherry picked from commit 600b7b26c07a070d0153daa76b3806c1e52c9e00)
+---
+ tools/bpf/bpftool/Makefile     |  5 +++-
+ tools/bpf/bpftool/jit_disasm.c | 42 +++++++++++++++++++++++++++-------
+ 2 files changed, 38 insertions(+), 9 deletions(-)
+
+--- a/tools/bpf/bpftool/Makefile
++++ b/tools/bpf/bpftool/Makefile
+@@ -76,7 +76,7 @@ INSTALL ?= install
+ RM ?= rm -f
+ 
+ FEATURE_USER = .bpftool
+-FEATURE_TESTS = libbfd disassembler-four-args reallocarray zlib libcap \
++FEATURE_TESTS = libbfd disassembler-four-args disassembler-init-styled reallocarray zlib libcap \
+ 	clang-bpf-co-re
+ FEATURE_DISPLAY = libbfd disassembler-four-args zlib libcap \
+ 	clang-bpf-co-re
+@@ -100,6 +100,9 @@ endif
+ ifeq ($(feature-disassembler-four-args), 1)
+ CFLAGS += -DDISASM_FOUR_ARGS_SIGNATURE
+ endif
++ifeq ($(feature-disassembler-init-styled), 1)
++    CFLAGS += -DDISASM_INIT_STYLED
++endif
+ 
+ ifeq ($(feature-reallocarray), 0)
+ CFLAGS += -DCOMPAT_NEED_REALLOCARRAY
+--- a/tools/bpf/bpftool/jit_disasm.c
++++ b/tools/bpf/bpftool/jit_disasm.c
+@@ -24,6 +24,7 @@
+ #include <sys/stat.h>
+ #include <limits.h>
+ #include <bpf/libbpf.h>
++#include <tools/dis-asm-compat.h>
+ 
+ #include "json_writer.h"
+ #include "main.h"
+@@ -39,15 +40,12 @@ static void get_exec_path(char *tpath, s
+ }
+ 
+ static int oper_count;
+-static int fprintf_json(void *out, const char *fmt, ...)
++static int printf_json(void *out, const char *fmt, va_list ap)
+ {
+-	va_list ap;
+ 	char *s;
+ 	int err;
+ 
+-	va_start(ap, fmt);
+ 	err = vasprintf(&s, fmt, ap);
+-	va_end(ap);
+ 	if (err < 0)
+ 		return -1;
+ 
+@@ -73,6 +71,32 @@ static int fprintf_json(void *out, const
+ 	return 0;
+ }
+ 
++static int fprintf_json(void *out, const char *fmt, ...)
++{
++	va_list ap;
++	int r;
++
++	va_start(ap, fmt);
++	r = printf_json(out, fmt, ap);
++	va_end(ap);
++
++	return r;
++}
++
++static int fprintf_json_styled(void *out,
++			       enum disassembler_style style __maybe_unused,
++			       const char *fmt, ...)
++{
++	va_list ap;
++	int r;
++
++	va_start(ap, fmt);
++	r = printf_json(out, fmt, ap);
++	va_end(ap);
++
++	return r;
++}
++
+ void disasm_print_insn(unsigned char *image, ssize_t len, int opcodes,
+ 		       const char *arch, const char *disassembler_options,
+ 		       const struct btf *btf,
+@@ -99,11 +123,13 @@ void disasm_print_insn(unsigned char *im
+ 	assert(bfd_check_format(bfdf, bfd_object));
+ 
+ 	if (json_output)
+-		init_disassemble_info(&info, stdout,
+-				      (fprintf_ftype) fprintf_json);
++		init_disassemble_info_compat(&info, stdout,
++					     (fprintf_ftype) fprintf_json,
++					     fprintf_json_styled);
+ 	else
+-		init_disassemble_info(&info, stdout,
+-				      (fprintf_ftype) fprintf);
++		init_disassemble_info_compat(&info, stdout,
++					     (fprintf_ftype) fprintf,
++					     fprintf_styled);
+ 
+ 	/* Update architecture info for offload. */
+ 	if (arch) {


### PR DESCRIPTION
Backport patches from kernel 6.0 which are fixing building of perf with binutils 2.40.

Kernel 5.10 is also not building but the backporting is more complicated and only a few targets are still using kernel 5.10.