### PR TITLE
ath79: fix user LED glow on Mikrotik 911 Lite boards

### DIFF
--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-911-lite.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-911-lite.dts
@@ -25,7 +25,7 @@
 
 	led_user: user {
 		label = "green:user";
-		gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		gpios = <&gpio 3 (GPIO_ACTIVE_LOW|GPIO_OPEN_DRAIN)>;
 	};
 };
 


### PR DESCRIPTION
GPIO3, to which the user LED is connected on RB911-Lite boards seems to still sink current, even when driven high. Enabling open drain for this pin fixes this behaviour and gets rid of the glow when LED is set to off, so enable it.