### PR TITLE
ath79: add support for Ruckus ZoneFlex 7351 and 7363 series

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -139,7 +139,8 @@ plasmacloud,pa300e)
 qihoo,c301)
 	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x10000" "0x10000"
 	;;
-ruckus,zf7025)
+ruckus,zf7025|\
+ruckus,zf7351)
 	ubootenv_add_uci_config "/dev/mtd5" "0x0" "0x40000" "0x40000"
 	;;
 ruckus,zf7321|\

--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -140,7 +140,9 @@ qihoo,c301)
 	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x10000" "0x10000"
 	;;
 ruckus,zf7025|\
-ruckus,zf7351)
+ruckus,zf7341|\
+ruckus,zf7351|\
+ruckus,zf7363)
 	ubootenv_add_uci_config "/dev/mtd5" "0x0" "0x40000" "0x40000"
 	;;
 ruckus,zf7321|\

--- a/target/linux/ath79/dts/ar7161_ruckus_gd11.dtsi
+++ b/target/linux/ath79/dts/ar7161_ruckus_gd11.dtsi
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7100.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "ruckus,gd11", "qca,ar7161";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_red;
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		dir-green {
+			label = "green:dir";
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		opt-green {
+			label = "green:opt";
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_green: power-green {
+			label = "green:power";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led_power_red: power-red {
+			label = "red:power";
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		wlan2g-green {
+			label = "green:wlan2g";
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0assoc";
+		};
+
+		wlan2g-yellow {
+			label = "yellow:wlan2g";
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g-green {
+			label = "green:wlan5g";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1assoc";
+		};
+
+		wlan5g-yellow {
+			label = "yellow:wlan5g";
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		ruckus-himem@3ff0000 {
+			/* Ruckus Himem area used to control
+			 * redundant boot image selection
+			 */
+			compatible = "nvmem-rmem";
+			reg = <0x3ff0000 0x10000>;
+			no-map;
+		};
+	};
+
+	beamforming-2g-spi {
+		compatible = "spi-gpio";
+		mosi-gpios = <&ath9k0 5 GPIO_ACTIVE_HIGH>;
+		sck-gpios = <&ath9k0 6 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		beamforming_2g_gpio: beamforming-2g-gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			registers-number = <1>;
+			spi-max-frequency = <24000000>;
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	beamforming-5g-spi {
+		compatible = "spi-gpio";
+		mosi-gpios = <&ath9k1 5 GPIO_ACTIVE_HIGH>;
+		sck-gpios = <&ath9k1 6 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		beamforming_5g_gpio: beamforming-5g-gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			registers-number = <1>;
+			spi-max-frequency = <24000000>;
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	ath9k0: wifi@0,11 { /* 2.4 GHz */
+		compatible = "pci168c,0029";
+		reg = <0x8800 0 0 0 0>;
+		nvmem-cells = <&macaddr_bdata_60>;
+		nvmem-cell-names = "mac-address";
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+
+	ath9k1: wifi@0,12 { /* 5 GHz */
+		compatible = "pci168c,0029";
+		reg = <0x9000 0 0 0 0>;
+		nvmem-cells = <&macaddr_bdata_76>;
+		nvmem-cell-names = "mac-address";
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@1e {
+		reg = <0x1e>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	nvmem-cells = <&macaddr_bdata_66>;
+	nvmem-cell-names = "mac-address";
+
+	pll-data = <0x00110000 0x00001099 0x00991099>;
+	phy-handle = <&phy0>;
+	phy-mode = "rgmii-id";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <104000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x40000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			/* On stock FW this encompasses rcks_wlan.main,
+			 * rcks_wlan.bkup and datafs partitions
+			 */
+			partition@40000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				reg = <0x40000 0xf40000>;
+				label = "firmware";
+			};
+
+			partition@f80000 {
+				compatible = "u-boot,env";
+				reg = <0xf80000 0x40000>;
+				label = "u-boot-env";
+			};
+
+			board_data: partition@fc0000 {
+				reg = <0xfc0000 0x40000>;
+				label = "board-data";
+				read-only;
+			};
+		};
+	};
+};
+
+&usb1 {
+	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&board_data {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_bdata_60: macaddr@60 {
+		reg = <0x60 0x6>;
+	};
+
+	macaddr_bdata_66: macaddr@66 {
+		reg = <0x66 0x6>;
+	};
+
+	macaddr_bdata_76: macaddr@76 {
+		reg = <0x76 0x6>;
+	};
+};

--- a/target/linux/ath79/dts/ar7161_ruckus_gd11.dtsi
+++ b/target/linux/ath79/dts/ar7161_ruckus_gd11.dtsi
@@ -16,7 +16,7 @@
 		label-mac-device = &eth0;
 	};
 
-	keys {
+	keys: keys {
 		compatible = "gpio-keys";
 
 		reset {

--- a/target/linux/ath79/dts/ar7161_ruckus_zf7341.dts
+++ b/target/linux/ath79/dts/ar7161_ruckus_zf7341.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7161_ruckus_zf734x.dtsi"
+
+/ {
+	model = "Ruckus ZoneFlex 7341[-U]";
+	compatible = "ruckus,zf7341", "qca,ar7161";
+};

--- a/target/linux/ath79/dts/ar7161_ruckus_zf734x.dtsi
+++ b/target/linux/ath79/dts/ar7161_ruckus_zf734x.dtsi
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7161_ruckus_gd11.dtsi"
+
+&keys {
+	opt {
+		/* Not used by stock firmware */
+		label = "opt";
+		linux,code = <KEY_WPS_BUTTON>;
+		gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		debounce-interval = <60>;
+	};
+};
+
+&beamforming_2g_gpio {
+	/* Default beamforming switches configuration from stock firmware,
+	 * the AP is started and for broadcast frames - all outputs high */
+	lb0 {
+		line-name = "beamforming:2g:lb0";
+		gpios = <0 GPIO_ACTIVE_LOW>;
+		output-high;
+		gpio-hog;
+	};
+
+	lb1 {
+		line-name = "beamforming:2g:lb1";
+		gpios = <1 GPIO_ACTIVE_LOW>;
+		output-high;
+		gpio-hog;
+	};
+
+	lb2 {
+		line-name = "beamforming:2g:lb2";
+		gpios = <2 GPIO_ACTIVE_LOW>;
+		output-high;
+		gpio-hog;
+	};
+
+	lb3 {
+		line-name = "beamforming:2g:lb3";
+		gpios = <3 GPIO_ACTIVE_LOW>;
+		output-high;
+		gpio-hog;
+	};
+
+	lb4 {
+		line-name = "beamforming:2g:lb4";
+		gpios = <4 GPIO_ACTIVE_LOW>;
+		output-high;
+		gpio-hog;
+	};
+
+	lb5 {
+		line-name = "beamforming:2g:lb5";
+		gpios = <5 GPIO_ACTIVE_LOW>;
+		output-high;
+		gpio-hog;
+	};
+
+	lb6 {
+		line-name = "beamforming:2g:lb6";
+		gpios = <6 GPIO_ACTIVE_LOW>;
+		output-high;
+		gpio-hog;
+	};
+
+	lb7 {
+		line-name = "beamforming:2g:lb7";
+		gpios = <7 GPIO_ACTIVE_LOW>;
+		output-high;
+		gpio-hog;
+	};
+};
+
+&beamforming_5g_gpio {
+	/* Default beamforming switches configuration from stock firmware,
+	 * the AP is started and for broadcast frames - all outputs high */
+	hb0 {
+		line-name = "beamforming:5g:hb0";
+		gpios = <0 GPIO_ACTIVE_LOW>;
+		output-high;
+		gpio-hog;
+	};
+
+	hb1 {
+		line-name = "beamforming:5g:hb1";
+		gpios = <1 GPIO_ACTIVE_LOW>;
+		output-high;
+		gpio-hog;
+	};
+
+	hb2 {
+		line-name = "beamforming:5g:hb2";
+		gpios = <2 GPIO_ACTIVE_LOW>;
+		output-high;
+		gpio-hog;
+	};
+
+	hb3 {
+		line-name = "beamforming:5g:hb3";
+		gpios = <3 GPIO_ACTIVE_LOW>;
+		output-high;
+		gpio-hog;
+	};
+
+	hb4 {
+		line-name = "beamforming:5g:hb4";
+		gpios = <4 GPIO_ACTIVE_LOW>;
+		output-high;
+		gpio-hog;
+	};
+
+	hb5 {
+		line-name = "beamforming:5g:hb5";
+		gpios = <5 GPIO_ACTIVE_LOW>;
+		output-high;
+		gpio-hog;
+	};
+};

--- a/target/linux/ath79/dts/ar7161_ruckus_zf7351.dts
+++ b/target/linux/ath79/dts/ar7161_ruckus_zf7351.dts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7161_ruckus_gd11.dtsi"
+
+/ {
+	model = "Ruckus ZoneFlex 7351[-U]";
+	compatible = "ruckus,zf7351", "qca,ar7161";
+
+};
+
+&beamforming_2g_gpio {
+	/* Default beamforming switches configuration from stock firmware,
+	 * the AP is started and for broadcast frames - all outputs high */
+	lb0 {
+		line-name = "beamforming:2g:lb0";
+		gpios = <0 GPIO_ACTIVE_HIGH>;
+		output-high;
+		gpio-hog;
+	};
+
+	lb1 {
+		line-name = "beamforming:2g:lb1";
+		gpios = <1 GPIO_ACTIVE_HIGH>;
+		output-high;
+		gpio-hog;
+	};
+
+	lb2 {
+		line-name = "beamforming:2g:lb2";
+		gpios = <2 GPIO_ACTIVE_HIGH>;
+		output-high;
+		gpio-hog;
+	};
+
+	lb3 {
+		line-name = "beamforming:2g:lb3";
+		gpios = <4 GPIO_ACTIVE_HIGH>;
+		output-high;
+		gpio-hog;
+	};
+
+	lb4 {
+		line-name = "beamforming:2g:lb4";
+		gpios = <5 GPIO_ACTIVE_HIGH>;
+		output-high;
+		gpio-hog;
+	};
+
+	lb5 {
+		line-name = "beamforming:2g:lb5";
+		gpios = <6 GPIO_ACTIVE_HIGH>;
+		output-high;
+		gpio-hog;
+	};
+};
+
+&beamforming_5g_gpio {
+	/* Default beamforming switches configuration from stock firmware,
+	 * the AP is started and for broadcast frames - all outputs high */
+	hb0 {
+		line-name = "beamforming:5g:hb0";
+		gpios = <0 GPIO_ACTIVE_HIGH>;
+		output-high;
+		gpio-hog;
+	};
+
+	hb1 {
+		line-name = "beamforming:5g:hb1";
+		gpios = <1 GPIO_ACTIVE_HIGH>;
+		output-high;
+		gpio-hog;
+	};
+
+	hb2 {
+		line-name = "beamforming:5g:hb2";
+		gpios = <2 GPIO_ACTIVE_HIGH>;
+		output-high;
+		gpio-hog;
+	};
+
+	hb3 {
+		line-name = "beamforming:5g:hb3";
+		gpios = <3 GPIO_ACTIVE_HIGH>;
+		output-high;
+		gpio-hog;
+	};
+
+	hb4 {
+		line-name = "beamforming:5g:hb4";
+		gpios = <4 GPIO_ACTIVE_HIGH>;
+		output-high;
+		gpio-hog;
+	};
+
+	hb5 {
+		line-name = "beamforming:5g:hb5";
+		gpios = <5 GPIO_ACTIVE_HIGH>;
+		output-high;
+		gpio-hog;
+	};
+
+	hb6 {
+		line-name = "beamforming:5g:hb6";
+		gpios = <6 GPIO_ACTIVE_HIGH>;
+		output-high;
+		gpio-hog;
+	};
+
+	hb7 {
+		line-name = "beamforming:5g:hb7";
+		gpios = <7 GPIO_ACTIVE_HIGH>;
+		output-high;
+		gpio-hog;
+	};
+};

--- a/target/linux/ath79/dts/ar7161_ruckus_zf7363.dts
+++ b/target/linux/ath79/dts/ar7161_ruckus_zf7363.dts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7161_ruckus_zf734x.dtsi"
+
+/ {
+	model = "Ruckus ZoneFlex 7343/7363[-U]";
+	compatible = "ruckus,zf7363", "qca,ar7161";
+};
+
+&mdio0 {
+	ethernet-phy@0 {
+		reg = <0x0>;
+		max-speed = <100>;
+	};
+
+	ethernet-phy@1 {
+		reg = <0x1>;
+		max-speed = <100>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+	pll-data = <0x00110000 0x00001099 0x00991099>;
+	nvmem-cells = <&macaddr_bdata_6c>;
+	nvmem-cell-names = "mac-address";
+	phy-mode = "rgmii-id";
+
+	fixed-link {
+		speed = <100>;
+		full-duplex;
+	};
+};
+
+&board_data {
+	macaddr_bdata_6c: macaddr@6c {
+		reg = <0x6c 0x6>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -67,6 +67,7 @@ ath79_setup_interfaces()
 	pisen,wmb001n|\
 	pisen,wmm003n|\
 	ruckus,zf7321|\
+	ruckus,zf7341|\
 	ruckus,zf7351|\
 	siemens,ws-ap3610|\
 	sophos,ap15|\
@@ -139,6 +140,7 @@ ath79_setup_interfaces()
 	engenius,ews511ap|\
 	engenius,ews660ap|\
 	ocedo,ursus|\
+	ruckus,zf7363|\
 	ruckus,zf7372|\
 	ubnt,unifi-ap-outdoor-plus)
 		ucidef_set_interface_lan "eth0 eth1"
@@ -745,7 +747,9 @@ ath79_setup_macs()
 		;;
 	ruckus,zf7025|\
 	ruckus,zf7321|\
+	ruckus,zf7341|\
 	ruckus,zf7351|\
+	ruckus,zf7363|\
 	ruckus,zf7372)
 		lan_mac=$(mtd_get_mac_binary board-data 0x807E)
 		label_mac=$lan_mac

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -67,6 +67,7 @@ ath79_setup_interfaces()
 	pisen,wmb001n|\
 	pisen,wmm003n|\
 	ruckus,zf7321|\
+	ruckus,zf7351|\
 	siemens,ws-ap3610|\
 	sophos,ap15|\
 	sophos,ap55|\
@@ -744,6 +745,7 @@ ath79_setup_macs()
 		;;
 	ruckus,zf7025|\
 	ruckus,zf7321|\
+	ruckus,zf7351|\
 	ruckus,zf7372)
 		lan_mac=$(mtd_get_mac_binary board-data 0x807E)
 		label_mac=$lan_mac

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2538,12 +2538,27 @@ define Device/ruckus_gd11_common
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-chipidea2
 endef
 
+define Device/ruckus_zf7341
+  $(Device/ruckus_gd11_common)
+  DEVICE_MODEL := ZoneFlex 7341[-U]
+  DEVICE_PACKAGES += -swconfig
+endef
+TARGET_DEVICES += ruckus_zf7341
+
 define Device/ruckus_zf7351
   $(Device/ruckus_gd11_common)
   DEVICE_MODEL := ZoneFlex 7351[-U]
   DEVICE_PACKAGES += -swconfig
 endef
 TARGET_DEVICES += ruckus_zf7351
+
+define Device/ruckus_zf7363
+  $(Device/ruckus_gd11_common)
+  DEVICE_MODEL := ZoneFlex 7363[-U]
+  DEVICE_ALT0_VENDOR := Ruckus
+  DEVICE_ALT0_MODEL := ZoneFlex 7343[-U]
+endef
+TARGET_DEVICES += ruckus_zf7363
 
 define Device/ruckus_zf73xx_common
   $(Device/ruckus_common)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2530,6 +2530,21 @@ define Device/ruckus_zf7025
 endef
 TARGET_DEVICES += ruckus_zf7025
 
+define Device/ruckus_gd11_common
+  $(Device/ruckus_common)
+  SOC := ar7161
+  IMAGE_SIZE := 15616k
+  BLOCKSIZE := 256k
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-chipidea2
+endef
+
+define Device/ruckus_zf7351
+  $(Device/ruckus_gd11_common)
+  DEVICE_MODEL := ZoneFlex 7351[-U]
+  DEVICE_PACKAGES += -swconfig
+endef
+TARGET_DEVICES += ruckus_zf7351
+
 define Device/ruckus_zf73xx_common
   $(Device/ruckus_common)
   DEVICE_PACKAGES := -swconfig kmod-usb2 kmod-usb-chipidea2


### PR DESCRIPTION
Both boards are very similar hardware- and functionality-wise, based on Ruckus GD11 platform running AR7161 plus dual AR9280 combo.

Excerpt of specification from commit messages:
Ruckus ZoneFlex 7351 is a dual-band, dual-radio 802.11n 2x2 MIMO enterprise
access point.

Support is complete, save for additional Fast Ethernet ports on ZF7363, for which the internal RTL8363S switch functions as unmanaged, while the ports themselves are functional.

Hardware highligts:
- CPU: Atheros AR7161 SoC at 680 MHz
- RAM: 64MB DDR
- Flash: 16MB SPI-NOR
- Wi-Fi 2.4GHz: AR9280 PCI 2x2 MIMO radio with external beamforming
- Wi-Fi 5GHz: AR9280 PCI 2x2 MIMO radio with external beamforming
- Ethernet: single Gigabit Ethernet port through Marvell 88E1116R gigabit PHY
- Standalone 12V/1A power input
- USB: optional single USB 2.0 host port on the 7351-U variant.

Ruckus ZoneFlex 7363 is a dual-band, dual-radio 802.11n 2x2 MIMO enterprise
access point. ZoneFlex 7343 is the single band variant of 7363
restricted to 2.4GHz, and ZoneFlex 7341 is 7343 minus two Fast Ethernet
ports.

Hardware highligts:
- CPU: Atheros AR7161 SoC at 680 MHz
- RAM: 64MB DDR
- Flash: 16MB SPI-NOR
- Wi-Fi 2.4GHz: AR9280 PCI 2x2 MIMO radio with external beamforming
- Wi-Fi 5GHz: AR9280 PCI 2x2 MIMO radio with external beamforming
- Ethernet 1: single Gigabit Ethernet port through Marvell 88E1116R gigabit PHY
- Ethernet 2: two Fast Ethernet ports through Realtek RTL8363S switch,
  connected with Fast Ethernet link to CPU.
- PoE: input through Gigabit port
- Standalone 12V/1A power input
- USB: optional single USB 2.0 host port on the -U variants.

Compile and run-tested on ath79 target.