### PR TITLE
binutils: Deactivate msgpack

### DIFF
--- a/package/devel/binutils/Makefile
+++ b/package/devel/binutils/Makefile
@@ -90,6 +90,7 @@ CONFIGURE_ARGS += \
 	--enable-install-libctf \
 	--with-system-zlib \
 	--without-zstd \
+	--without-msgpack \
 	--disable-gprofng
 
 define Build/Install


### PR DESCRIPTION
Deactivate the msgpack option. The binutils build might detect the libmsgpackc.so.2 library and will try to link against it, if it is not explicitly deactivated.

This prevents the following build errors seen in the build bots. Package binutils is missing dependencies for the following libraries: libmsgpackc.so.2