### PR TITLE
ramips: add support for Linksys RE7000

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -19,6 +19,7 @@ alfa-network,r36m-e4g|\
 alfa-network,tube-e4g|\
 engenius,epg600|\
 engenius,esr600h|\
+linksys,re7000|\
 sitecom,wlr-4100-v1-002|\
 zyxel,keenetic-lite-iii-a)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x1000"

--- a/target/linux/ramips/dts/mt7621_linksys_re7000.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_re7000.dts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "linksys,re7000", "mediatek,mt7621-soc";
+	model = "Linksys RE7000";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wifi {
+			label = "orange:wifi";
+			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wps {
+			label = "orange:wps";
+			gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x1000>;
+			};
+
+			partition@32000 {
+				label = "config";
+				reg = <0x32000 0xe000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart2", "rgmii2";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_2e>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_2e: macaddr@2e {
+		reg = <0x2e 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1541,6 +1541,15 @@ define Device/linksys_re6500
 endef
 TARGET_DEVICES += linksys_re6500
 
+define Device/linksys_re7000
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Linksys
+  DEVICE_MODEL := RE7000
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware
+endef
+TARGET_DEVICES += linksys_re7000
+
 define Device/mediatek_ap-mt7621a-v60
   $(Device/dsa-migration)
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -17,6 +17,7 @@ ramips_setup_interfaces()
 	dlink,dap-1620-b1|\
 	dlink,dap-x1860-a1|\
 	edimax,re23s|\
+	linksys,re7000|\
 	mikrotik,ltap-2hnd|\
 	mikrotik,routerboard-m11g|\
 	netgear,ex6150|\


### PR DESCRIPTION
Hardware specification:

- SoC: MediaTek MT7621AT (880 MHz)
- Flash: 16 MB (Macronix MX25L12835FM2I-10G)
- RAM: 128 MB (Nanya NT5CC64M16GP-DI)
- WLAN 2.4 GHz: 2x2 MediaTek MT7603EN
- WLAN 5 GHz: 2x2 MediaTek MT7615N
- Ethernet: 1x 10/100/1000 Mbps
- LED: Power, Wifi, WPS
- Button: Reset, WPS
- UART: 1:VCC, 2:GND, 3:TX, 4:RX (from LAN port)
- Serial console @ 57600,8n1

Flash instructions:

Connect to serial console and start up the device. As the bootloader got locked you need to type in a password to unlock U-Boot access. When you see the following output on the console:

relocate_code Pointer at: 87f1c000

type in the super secure password:

1234567890

Then select TFTP boot from RAM by selecting option 1 in the boot menu. As Linksys decided to leave out a basic TFTP configuration you need to set server- & client ip as well as the image filename the device will search for. You need to use the initramfs openwrt image for the TFTP boot process.

Once openwrt has booted up, upload the sysupgrade image via scp and run sysupgrade as normal.
