### PR TITLE
lantiq: xway: add phy reset pin to AVM Fritz!Box 7320

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7320.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7320.dts
@@ -98,9 +98,20 @@
 
 &gsw {
 	phy-mode = "mii";
+	phy-handle = <&phy0>;
 	nvmem-cells = <&macaddr_ath9k_cal_a91>;
 	nvmem-cell-names = "mac-address";
 	mac-address-increment = <(-2)>;
+
+	mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy0: ethernet-phy@0 {
+			reg = <0>;
+			reset-gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+		};
+	};
 };
 
 &gpio {
@@ -108,6 +119,12 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
+		phy-rst {
+			lantiq,pins = "io36";
+			lantiq,pull = <0>;
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
 		usb0_vbus {
 			lantiq,pins = "io50";
 			lantiq,pull = <0>;


### PR DESCRIPTION
This commit adds the PHY reset gpio for the LAN1 port to the dts. According to the GPL sources, gpios 34 and 36 are used on the AVM FritzBox 7320 and 7330. The second port is unsupported.

The gpio assignment has been verified on the FritzBox 7330.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>