### PR TITLE
netifd: hide unnecessary error message

### DIFF
--- a/package/network/config/netifd/Makefile
+++ b/package/network/config/netifd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/netifd.git

--- a/package/network/config/netifd/files/usr/libexec/network/packet-steering.sh
+++ b/package/network/config/netifd/files/usr/libexec/network/packet-steering.sh
@@ -56,7 +56,7 @@ for dev in /sys/class/net/*; do
 	irq_cpu_mask="$((1 << $irq_cpu))"
 
 	for q in ${dev}/queues/tx-*; do
-		set_hex_val "$q/xps_cpus" "$PROC_MASK"
+		set_hex_val "$q/xps_cpus" "$PROC_MASK" 2>/dev/null
 	done
 
 	# ignore dsa slave ports for RPS
@@ -65,6 +65,6 @@ for dev in /sys/class/net/*; do
 	[ "$subsys" = "mdio_bus" ] && continue
 
 	for q in ${dev}/queues/rx-*; do
-		set_hex_val "$q/rps_cpus" "$PROC_MASK"
+		set_hex_val "$q/rps_cpus" "$PROC_MASK" 2>/dev/null
 	done
 done


### PR DESCRIPTION
packet steering causes sometimes error messages
to syslog due to write errors.

It's not that files wouldn't exist, they do-
but they just aren't writable somehow.

```
root@openwrt:~# logread | grep steering
Sun Mar 12 17:05:40 2023 daemon.notice procd: /etc/rc.d/S25packet_steering: sh: write error: No such file or directory
root@openwrt:/sys# cd /sys/class/net
root@openwrt:/sys/class/net# ls
br-lan  dummy0  eth0  eth1  eth2  eth3  eth4  eth5  lo  teql0  wlan0
root@openwrt:/sys/class/net# cd wlan0/queues/tx-0
root@openwrt:/sys/class/net/wlan0/queues/tx-0# ls
byte_queue_limits  traffic_class  tx_maxrate  tx_timeout  xps_cpus  xps_rxqs
root@openwrt:/sys/class/net/wlan0/queues/tx-0# echo "ff" > xps_cpus
echo: write error: no such file or directory
root@openwrt:/sys/class/net/wlan0/queues/tx-0#
```
This occurs with other network interfaces as well, my other host has 2 interfaces that this occurred with, so whether this happens or not, depends on used hardware.

This patch doesn't fix any device driver, instead it's more a cosmetic fix provided by redirecting stderr to /dev/null on failure.