### PR TITLE
bmips: add support for external switches

### DIFF
--- a/target/linux/bmips/dts/bcm6362-netgear-dgnd3700-v2.dts
+++ b/target/linux/bmips/dts/bcm6362-netgear-dgnd3700-v2.dts
@@ -148,6 +148,58 @@
 	};
 };
 
+&mdio_ext {
+	switch@1e {
+		compatible = "brcm,bcm53125";
+		reg = <30>;
+
+		dsa,member = <1 0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan1";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan2";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan4";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "wan";
+			};
+
+			switch1port8: port@8 {
+				reg = <8>;
+				label = "cpu";
+
+				phy-mode = "rgmii";
+				ethernet = <&switch0port4>;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};
+
 &nflash {
 	status = "okay";
 
@@ -224,8 +276,10 @@
 };
 
 &switch0 {
+	dsa,member = <0 0>;
+
 	ports {
-		port@4 {
+		switch0port4: port@4 {
 			reg = <4>;
 			label = "extsw";
 

--- a/target/linux/bmips/nand/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/nand/base-files/etc/board.d/02_network
@@ -11,7 +11,7 @@ comtrend,vr-3032u)
 	;;
 netgear,dgnd3700-v2)
 	ucidef_set_bridge_device switch
-	ucidef_set_interface_lan "extsw"
+	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 	;;
 esac
 

--- a/target/linux/bmips/patches-5.15/520-net-bcm6368_mdiomux-late-init.patch
+++ b/target/linux/bmips/patches-5.15/520-net-bcm6368_mdiomux-late-init.patch
@@ -1,0 +1,19 @@
+--- a/drivers/net/mdio/mdio-mux-bcm6368.c
++++ b/drivers/net/mdio/mdio-mux-bcm6368.c
+@@ -177,7 +177,15 @@ static struct platform_driver bcm6368_md
+ 	.probe	= bcm6368_mdiomux_probe,
+ 	.remove	= bcm6368_mdiomux_remove,
+ };
+-module_platform_driver(bcm6368_mdiomux_driver);
++
++int __init bcm6368_mdiomux_init(void)
++{
++	int ret = platform_driver_register(&bcm6368_mdiomux_driver);
++	if (ret)
++		pr_err("bcm6368_mdiomux: Error registering platform driver!\n");
++	return ret;
++}
++late_initcall(bcm6368_mdiomux_init);
+ 
+ MODULE_AUTHOR("Álvaro Fernández Rojas <noltari@gmail.com>");
+ MODULE_DESCRIPTION("BCM6368 mdiomux bus controller driver");


### PR DESCRIPTION
This PR adds support for external switches on bmips target.

- Register MDIO mux bus from b53_mmap instead of using separate driver.
- Strip VLAN tag added after the Broadcom Legacy tag by the internal BCM63xx switch.

More info: https://github.com/openwrt/openwrt/issues/10313