### PR TITLE
ath79: POC for DT-based expansion-friendly fw

### DIFF
--- a/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
+++ b/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 #include "ar7242.dtsi"
+#include "tplink_classic_flash_layout.dtsi"
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
@@ -95,54 +96,36 @@
 &spi {
 	status = "okay";
 
-	flash@0 {
+	flash: flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 		m25p,fast-read;
+	};
+};
 
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
+&uboot {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-			uboot: partition@0 {
-				label = "u-boot";
-				reg = <0x000000 0x020000>;
-				read-only;
+		macaddr_uboot_1fc00: macaddr@1fc00 {
+			compatible = "mac-base";
+			reg = <0x1fc00 0x6>;
+			#nvmem-cell-cells = <1>;
+		};
+	};
+};
 
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
+&art {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-					macaddr_uboot_1fc00: macaddr@1fc00 {
-						reg = <0x1fc00 0x6>;
-					};
-				};
-			};
-
-			partition@20000 {
-				compatible = "tplink,firmware";
-				label = "firmware";
-				reg = <0x020000 0x7d0000>;
-			};
-
-			partition@7f0000 {
-				label = "art";
-				reg = <0x7f0000 0x010000>;
-				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					cal_art_1000: cal@1000 {
-						reg = <0x1000 0x440>;
-					};
-				};
-			};
+		cal_art_1000: cal@1000 {
+			reg = <0x1000 0x440>;
 		};
 	};
 };

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 #include "ar9344.dtsi"
+#include "tplink_classic_flash_layout.dtsi"
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
@@ -69,59 +70,39 @@
 &spi {
 	status = "okay";
 
-	flash@0 {
+	flash: flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <33000000>;
+	};
+};
 
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
+&uboot {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-			uboot: partition@0 {
-				label = "u-boot";
-				reg = <0x000000 0x020000>;
-				read-only;
+		macaddr_uboot_1fc00: macaddr@1fc00 {
+			compatible = "mac-base";
+			reg = <0x1fc00 0x6>;
+			#nvmem-cell-cells = <1>;
+		};
+	};
+};
 
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
+&art {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-					macaddr_uboot_1fc00: macaddr@1fc00 {
-						compatible = "mac-base";
-						reg = <0x1fc00 0x6>;
-						#nvmem-cell-cells = <1>;
-					};
-				};
-			};
+		cal_art_1000: cal@1000 {
+			reg = <0x1000 0x440>;
+		};
 
-			partition@20000 {
-				compatible = "tplink,firmware";
-				label = "firmware";
-				reg = <0x020000 0x7d0000>;
-			};
-
-			partition@7f0000 {
-				label = "art";
-				reg = <0x7f0000 0x010000>;
-				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					cal_art_1000: cal@1000 {
-						reg = <0x1000 0x440>;
-					};
-
-					cal_art_5000: cal@5000 {
-						reg = <0x5000 0x440>;
-					};
-				};
-			};
+		cal_art_5000: cal@5000 {
+			reg = <0x5000 0x440>;
 		};
 	};
 };

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c.dtsi
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 #include "qca955x.dtsi"
+#include "tplink_classic_flash_layout.dtsi"
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
@@ -100,16 +101,10 @@
 &spi {
 	status = "okay";
 
-	flash@0 {
+	flash: flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;
-
-		mtdparts: partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-		};
 	};
 };
 

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c5-v1.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c5-v1.dts
@@ -28,48 +28,32 @@
 	};
 };
 
-&mtdparts {
-	partition@0 {
-		label = "u-boot";
-		reg = <0x000000 0x020000>;
-		read-only;
+&uboot {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-		nvmem-layout {
-			compatible = "fixed-layout";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			macaddr_uboot_1fc00: macaddr@1fc00 {
-				compatible = "mac-base";
-				reg = <0x1fc00 0x6>;
-				#nvmem-cell-cells = <1>;
-			};
+		macaddr_uboot_1fc00: macaddr@1fc00 {
+			compatible = "mac-base";
+			reg = <0x1fc00 0x6>;
+			#nvmem-cell-cells = <1>;
 		};
 	};
+};
 
-	partition@20000 {
-		label = "firmware";
-		reg = <0x020000 0xfd0000>;
-		compatible = "tplink,firmware";
-	};
+&art {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	partition@ff0000 {
-		label = "art";
-		reg = <0xff0000 0x010000>;
-		read-only;
+		cal_art_1000: calibration@1000 {
+			reg = <0x1000 0x440>;
+		};
 
-		nvmem-layout {
-			compatible = "fixed-layout";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			cal_art_1000: calibration@1000 {
-				reg = <0x1000 0x440>;
-			};
-
-			cal_art_5000: calibration@5000 {
-				reg = <0x5000 0x844>;
-			};
+		cal_art_5000: calibration@5000 {
+			reg = <0x5000 0x844>;
 		};
 	};
 };

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c7-v1.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c7-v1.dts
@@ -28,44 +28,28 @@
 	};
 };
 
-&mtdparts {
-	uboot: partition@0 {
-		label = "u-boot";
-		reg = <0x000000 0x020000>;
-		read-only;
+&uboot {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-		nvmem-layout {
-			compatible = "fixed-layout";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			macaddr_uboot_1fc00: macaddr@1fc00 {
-				compatible = "mac-base";
-				reg = <0x1fc00 0x6>;
-				#nvmem-cell-cells = <1>;
-			};
+		macaddr_uboot_1fc00: macaddr@1fc00 {
+			compatible = "mac-base";
+			reg = <0x1fc00 0x6>;
+			#nvmem-cell-cells = <1>;
 		};
 	};
+};
 
-	partition@20000 {
-		label = "firmware";
-		compatible = "tplink,firmware";
-		reg = <0x020000 0x7d0000>;
-	};
+&art {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	partition@7f0000 {
-		label = "art";
-		reg = <0x7f0000 0x010000>;
-		read-only;
-
-		nvmem-layout {
-			compatible = "fixed-layout";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			calibration_art_1000: calibration@1000 {
-				reg = <0x1000 0x440>;
-			};
+		calibration_art_1000: calibration@1000 {
+			reg = <0x1000 0x440>;
 		};
 	};
 };

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c7-v2.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c7-v2.dts
@@ -29,48 +29,32 @@
 	};
 };
 
-&mtdparts {
-	uboot: partition@0 {
-		label = "u-boot";
-		reg = <0x000000 0x020000>;
-		read-only;
+&uboot {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-		nvmem-layout {
-			compatible = "fixed-layout";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			macaddr_uboot_1fc00: macaddr@1fc00 {
-				compatible = "mac-base";
-				reg = <0x1fc00 0x6>;
-				#nvmem-cell-cells = <1>;
-			};
+		macaddr_uboot_1fc00: macaddr@1fc00 {
+			compatible = "mac-base";
+			reg = <0x1fc00 0x6>;
+			#nvmem-cell-cells = <1>;
 		};
 	};
+};
 
-	partition@20000 {
-		label = "firmware";
-		reg = <0x020000 0xfd0000>;
-		compatible = "tplink,firmware";
-	};
+&art {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	partition@ff0000 {
-		label = "art";
-		reg = <0xff0000 0x010000>;
-		read-only;
+		calibration_art_1000: calibration@1000 {
+			reg = <0x1000 0x440>;
+		};
 
-		nvmem-layout {
-			compatible = "fixed-layout";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			calibration_art_1000: calibration@1000 {
-				reg = <0x1000 0x440>;
-			};
-
-			calibration_art_5000: calibration@5000 {
-				reg = <0x5000 0x844>;
-			};
+		calibration_art_5000: calibration@5000 {
+			reg = <0x5000 0x844>;
 		};
 	};
 };

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 #include "qca955x.dtsi"
+#include "tplink_classic_flash_layout.dtsi"
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
@@ -122,59 +123,39 @@
 &spi {
 	status = "okay";
 
-	flash@0 {
+	flash: flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;
+	};
+};
 
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
+&uboot {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-			uboot: partition@0 {
-				label = "u-boot";
-				reg = <0x000000 0x020000>;
-				read-only;
+		macaddr_uboot_1fc00: macaddr@1fc00 {
+			compatible = "mac-base";
+			reg = <0x1fc00 0x6>;
+			#nvmem-cell-cells = <1>;
+		};
+	};
+};
 
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
+&art {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-					macaddr_uboot_1fc00: macaddr@1fc00 {
-						compatible = "mac-base";
-						reg = <0x1fc00 0x6>;
-						#nvmem-cell-cells = <1>;
-					};
-				};
-			};
+		cal_ath9k_soc: cal_ath9k@1000 {
+			reg = <0x1000 0x440>;
+		};
 
-			partition@20000 {
-				compatible = "tplink,firmware";
-				label = "firmware";
-				reg = <0x020000 0x7d0000>;
-			};
-
-			partition@7f0000 {
-				label = "art";
-				reg = <0x7f0000 0x010000>;
-				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					cal_ath9k_soc: cal_ath9k@1000 {
-						reg = <0x1000 0x440>;
-					};
-
-					cal_ath9k_pci: cal_ath9k@5000 {
-						reg = <0x5000 0x440>;
-					};
-				};
-			};
+		cal_ath9k_pci: cal_ath9k@5000 {
+			reg = <0x5000 0x440>;
 		};
 	};
 };

--- a/target/linux/ath79/dts/tplink_classic_flash_layout.dtsi
+++ b/target/linux/ath79/dts/tplink_classic_flash_layout.dtsi
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/mtd/partitions/constants.h>
+
+&spi {
+	flash: flash@0 {
+		mtdparts: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <2>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0 0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@1 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				// retain 0x10000
+				reg = <MTDPART_OFS_SPECIAL MTDPART_OFS_RETAIN 0x010000>;
+			};
+
+			art: partition@2 {
+				label = "art";
+				reg = <MTDPART_OFS_SPECIAL MTDPART_OFS_APPEND 0x010000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/generic/files/include/dt-bindings/mtd/partitions/constants.h
+++ b/target/linux/generic/files/include/dt-bindings/mtd/partitions/constants.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ *    *** IMPORTANT ***
+ * This file is not only included from C-code but also from devicetree source
+ * files. As such this file MUST only contain comments and defines.
+ *
+ * Device Tree constants identical to those in include/linux/mtd/partitions.h
+ */
+
+#ifndef _DT_BINDINGS_MTD_PARTITIONS_CONSTANTS_H
+#define _DT_BINDINGS_MTD_PARTITIONS_CONSTANTS_H
+
+#define MTDPART_OFS_SPECIAL	(-1)
+#define MTDPART_OFS_RETAIN	(-3)
+#define MTDPART_OFS_NXTBLK	(-2)
+#define MTDPART_OFS_APPEND	(-1)
+#define MTDPART_SIZ_FULL	(0)
+
+#endif


### PR DESCRIPTION
On former ar71xx, official firmwares could be directly flashed into a
device with expanded flash, provided that partitions like "art" have been
relocated to the end of the expanded flash, but it does not work well on
the current ath79, because the offset of all partitions is set in the
device tree. If partitions like "art" are kept in their original offset,
flashing an official firmware to an expanded device can work, but extra
space beyond the original end will not be usable.

However, there are special "offset" and "size" values documented in
include/linux/mtd/partitions.h of Linux:

 // consume as much as possible, leaving size after the end of partition.
 #define MTDPART_OFS_RETAIN	(uint64_t)(-3)

 // the partition will start at the next erase block.
 #define MTDPART_OFS_NXTBLK	(uint64_t)(-2)

 // the partition will start where the previous one ended.
 #define MTDPART_OFS_APPEND	(uint64_t)(-1)

 // the partition will extend to the end of the master MTD device.
 #define MTDPART_SIZ_FULL	(0)

When these special values are used, the actual offset and size of a
partition will be determined at runtime.

As a result, MTDPART_OFS_RETAIN could be used to define the "offset" of the
original writable partition. Its "size" is used to retain spaces for
read-only partitions after it. (e.g. art) All partitions after it could use
MTDPART_OFS_APPEND for its "offset". However, since these special values
have uint64_t type, the #address-cells should be 2 and format
<high32 low32> should be used, e.g. <(-1) (-3)> for MTDPART_OFS_RETAIN.

If official firmwares are built in this way, they will be flashed to a
well-expanded device again, and can claim all extra space. Partitions like
art could still be relocated to the end of the expanded flash, as many
bootloaders expect.

Tested on my tplink tl-wdr4310 (unexpanded), and tl-wdr4900v2 (expanded to
16MiB).

Signed-off-by: Edward Chow <equu@openmail.cc>