### PR TITLE
include: autotools: Add dummy GTKDOCIZE

### DIFF
--- a/include/autotools.mk
+++ b/include/autotools.mk
@@ -23,7 +23,8 @@ AM_TOOL_PATHS:= \
 	LIBTOOLIZE=$(STAGING_DIR_HOST)/bin/libtoolize \
 	LIBTOOL=$(STAGING_DIR_HOST)/bin/libtool \
 	M4=$(STAGING_DIR_HOST)/bin/m4 \
-	AUTOPOINT=true
+	AUTOPOINT=true \
+	GTKDOCIZE=true
 
 # 1: build dir
 # 2: remove files


### PR DESCRIPTION
autoreconf wants to use the gtkdocize tool now if a configure.ac file defines GTK_DOC_CHECk(). OpenWrt does not ship the gtkdocize tool, just use true instead. This fixes the build of some applications like guntls.

Fixes: 030447b8f4c7 ("tools/autoconf: bump to 2.71")