### PR TITLE
tools/ccache: bump to 4.8 and always disable documentation compilation 

### DIFF
--- a/tools/ccache/Makefile
+++ b/tools/ccache/Makefile
@@ -5,7 +5,6 @@
 # See /LICENSE for more information.
 #
 include $(TOPDIR)/rules.mk
-include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=ccache
 PKG_VERSION:=4.7.4
@@ -22,10 +21,7 @@ CMAKE_HOST_OPTIONS += \
 	-DCMAKE_CXX_COMPILER_LAUNCHER="" \
 	-DCMAKE_SKIP_RPATH=FALSE \
 	-DCMAKE_INSTALL_RPATH="${STAGING_DIR_HOST}/lib" \
+	-DENABLE_DOCUMENTATION=OFF
 	-DREDIS_STORAGE_BACKEND=OFF
-
-ifneq (docs-$(CONFIG_BUILD_DOCUMENTATION),docs-y)
-CMAKE_HOST_OPTIONS += -DENABLE_DOCUMENTATION=OFF
-endif
 
 $(eval $(call HostBuild))

--- a/tools/ccache/Makefile
+++ b/tools/ccache/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ccache
-PKG_VERSION:=4.7.4
+PKG_VERSION:=4.8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/ccache/ccache/releases/download/v$(PKG_VERSION)
-PKG_HASH:=df0c64d15d3efaf0b4f6837dd6b1467e40eeaaa807db25ce79c3a08a46a84e36
+PKG_HASH:=b963ee3bf88d7266b8a0565e4ba685d5666357f0a7e364ed98adb0dc1191fcbb
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk

--- a/tools/ccache/patches/100-honour-copts.patch
+++ b/tools/ccache/patches/100-honour-copts.patch
@@ -1,6 +1,6 @@
 --- a/src/ccache.cpp
 +++ b/src/ccache.cpp
-@@ -1779,6 +1779,7 @@ get_manifest_key(Context& ctx, Hash& has
+@@ -1813,6 +1813,7 @@ get_manifest_key(Context& ctx, Hash& has
                             "CPLUS_INCLUDE_PATH",
                             "OBJC_INCLUDE_PATH",
                             "OBJCPLUS_INCLUDE_PATH", // clang


### PR DESCRIPTION
Release Notes:
https://ccache.dev/releasenotes.html#_ccache_4_8

Remove useless include target.mk (https://github.com/openwrt/openwrt/commit/b492e69bd2d09aaa2c3c76b52203cbb3527eb2f7)