### PR TITLE
ramips: mt7621: add migration script for WLAN PCI paths

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+# This must run before 10-wifi-detect
+
+
+[ "${ACTION}" = "add" ] || return
+
+
+. /lib/functions.sh
+
+
+check_radio()
+{
+	local cfg="$1" to="$2"
+
+	config_get path "$cfg" path
+
+	[ "$path" = "$to" ] && PATH_EXISTS=true
+}
+
+do_migrate_radio()
+{
+	local cfg="$1" from="$2" to="$3"
+
+	config_get path "$cfg" path
+
+	[ "$path" = "$from" ] || return
+
+	uci set "wireless.${cfg}.path=${to}"
+	WIRELESS_CHANGED=true
+
+	logger -t wifi-migrate "Updated path of wireless.${cfg} from '${from}' to '${to}'"
+}
+
+migrate_radio()
+{
+	local from="$1" to="$2"
+
+	config_load wireless
+
+	# Check if there is already a section with the target path: In this case, the system
+	# was already upgraded to a version without this migration script before; better bail out,
+	# as we can't be sure we don't break more than we fix.
+	PATH_EXISTS=false
+	config_foreach check_radio wifi-device "$to"
+	$PATH_EXISTS && return
+
+	config_foreach do_migrate_radio wifi-device "$from" "$to"
+}
+
+
+WIRELESS_CHANGED=false
+
+case "$(board_name)" in
+arcadyan,we420223-99|\
+beeline,smartbox-flash|\
+mts,wg430223)
+	migrate_radio '1e140000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0' '1e140000.pcie/pci0000:00/0000:00:01.0/0000:01:00.0'
+	migrate_radio '1e140000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0+1' '1e140000.pcie/pci0000:00/0000:00:01.0/0000:01:00.0+1'
+	;;
+netgear,r6220|\
+netgear,wac104|\
+netgear,wndr3700-v5)
+	migrate_radio '1e140000.pcie/pci0000:00/0000:00:01.0/0000:02:00.0' '1e140000.pcie/pci0000:00/0000:00:02.0/0000:02:00.0'
+	;;
+zbtlink,zbt-we1326)
+	migrate_radio '1e140000.pcie/pci0000:00/0000:00:01.0/0000:02:00.0' '1e140000.pcie/pci0000:00/0000:00:02.0/0000:02:00.0'
+	migrate_radio '1e140000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0' '1e140000.pcie/pci0000:00/0000:00:01.0/0000:01:00.0'
+	;;
+
+esac
+
+$WIRELESS_CHANGED && uci commit wireless
+
+exit 0


### PR DESCRIPTION
PCI paths of the WLAN devices have changed between kernel 5.10 and 5.15; migrate config so existing wifi-iface definitions don't break.

This is implemented as a hotplug handler rather than a uci-defaults script as the migration script must run before the 10-wifi-detect hotplug handler.

based on b452af23a8602ebf7bfb0eb084383ecd595face5

migration was forgotten when device trees were adjusted in
688697889c9ceb9d2d8d413d1abcc5fa7edb402b
c77913be5be5f11a0f20dba1b45b96470099e8a8

fixes #9374

affected devices:
Netgear R6220
Netgear WAC104
Netgear WNDR3700 v5
Zbtlink ZBT-WE1326
Wiflyer WF3526-P
Arcadyan WE420223-99
Beeline Smartbox Flash (Arcadyan WG443223)
MTS WG430223 (Arcadyan WG430223)

___________________

Users of the affected devices noticed in https://github.com/openwrt/openwrt/issues/9374#issuecomment-1457297507 that we need to migrate the wifi paths still. @DragonBluep 

This patch is solely based on https://github.com/openwrt/openwrt/commit/b452af23a8602ebf7bfb0eb084383ecd595face5
I checked the code. If I understand it correctly it should be run once only, even on the Zbtlink/Wiflyer device, as it checks first, whether the migrated new "to" path already exists :)
So even though one path keeps on existing it will migrate the wifi-device successfully to the new paths.

If you want me to add a code comment to the top of the file, then let me know :)
~~This code wasn't tested, yet.~~
I don't own any of the affected hardware.
The PCI address of the zbtlink wifi-devices is partially a guess and based on the Netgear addresses.

EDIT: The code was tested successfully by @mbaumga on one of the affected Netgear devices. 
The first force push added `Tested-by` to the commit message
Now I'm only waiting for a successful test of the affected Zbt device :)

The second force push added Arcadyan devices upon request of @csharper2005 
The third force push addressed the changes @csharper2005 requested and adjusted the pci paths of the Zbt-based devices slightly.
The fourth force push added Tested-by @csharper2005 