### PR TITLE
ramips: cudy wr1300v2 reduce SPI freq to 40000000

### DIFF
--- a/target/linux/ramips/dts/mt7621_cudy_wr1300-v2.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr1300-v2.dts
@@ -58,8 +58,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
-		m25p,fast-read;
+		spi-max-frequency = <40000000>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
Cases have been reported in which certain devices do not boot correctly or have errors. After various tests by users who have such errors it has been concluded that the SPI frequency should be reduced to 40Mhz, at this speed it appears that all devices work correctly.