### PR TITLE
kernel: add support for XMC XM25QH64C

### DIFF
--- a/target/linux/generic/pending-5.10/488-mtd-spi-nor-add-xmc-xm25qh64c.patch
+++ b/target/linux/generic/pending-5.10/488-mtd-spi-nor-add-xmc-xm25qh64c.patch
@@ -1,0 +1,22 @@
+From: Joe Mullally <jwmullally@gmail.com>
+Subject: mtd/spi-nor/xmc: add support for XMC XM25QH64C
+
+The XMC XM25QH64C is a 8MB SPI NOR chip. The patch is verified on TL-WPA8631P v3.
+Datasheet available at https://www.xmcwh.com/uploads/442/XM25QH64C.pdf
+
+Signed-off-by: Joe Mullally <jwmullally@gmail.com>
+---
+ drivers/mtd/spi-nor/xmc.c                             | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/mtd/spi-nor/xmc.c
++++ b/drivers/mtd/spi-nor/xmc.c
+@@ -12,6 +12,8 @@ static const struct flash_info xmc_parts
+ 	/* XMC (Wuhan Xinxin Semiconductor Manufacturing Corp.) */
+ 	{ "XM25QH64A", INFO(0x207017, 0, 64 * 1024, 128,
+ 			    SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++	{ "XM25QH64C", INFO(0x204017, 0, 64 * 1024, 128,
++			    SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ "XM25QH128A", INFO(0x207018, 0, 64 * 1024, 256,
+ 			     SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ "XM25QH128C", INFO(0x204018, 0, 64 * 1024, 256,

--- a/target/linux/generic/pending-5.15/488-mtd-spi-nor-add-xmc-xm25qh64c.patch
+++ b/target/linux/generic/pending-5.15/488-mtd-spi-nor-add-xmc-xm25qh64c.patch
@@ -1,0 +1,22 @@
+From: Joe Mullally <jwmullally@gmail.com>
+Subject: mtd/spi-nor/xmc: add support for XMC XM25QH64C
+
+The XMC XM25QH64C is a 8MB SPI NOR chip. The patch is verified on TL-WPA8631P v3.
+Datasheet available at https://www.xmcwh.com/uploads/442/XM25QH64C.pdf
+
+Signed-off-by: Joe Mullally <jwmullally@gmail.com>
+---
+ drivers/mtd/spi-nor/xmc.c                             | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/mtd/spi-nor/xmc.c
++++ b/drivers/mtd/spi-nor/xmc.c
+@@ -12,6 +12,8 @@ static const struct flash_info xmc_parts
+ 	/* XMC (Wuhan Xinxin Semiconductor Manufacturing Corp.) */
+ 	{ "XM25QH64A", INFO(0x207017, 0, 64 * 1024, 128,
+ 			    SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++	{ "XM25QH64C", INFO(0x204017, 0, 64 * 1024, 128,
++			    SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ "XM25QH128A", INFO(0x207018, 0, 64 * 1024, 256,
+ 			     SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ "XM25QH128C", INFO(0x204018, 0, 64 * 1024, 256,


### PR DESCRIPTION
The XMC XM25QH64C is a 8MB SPI NOR chip. The patch is verified on TL-WPA8631P v3. Datasheet available at https://www.xmcwh.com/uploads/442/XM25QH64C.pdf

---

### PR request

A seperate backport PR for 22.03 is open here: https://github.com/openwrt/openwrt/pull/12299

This chip is now showing up in previously supported TP-Link devices (e.g. TL-WPA8631P v3), preventing boot.

Fixes: https://forum.openwrt.org/t/bricked-tp-link-tl-wpa8631p-v3/151594
Confirmation it works: https://forum.openwrt.org/t/bricked-tp-link-tl-wpa8631p-v3/151594/52 , 
[g0-07.wpa8631pv3.XM25QH64C.dmesg.txt](https://github.com/openwrt/openwrt/files/11009388/g0-07.wpa8631pv3.XM25QH64C.dmesg.txt)



### Related discussions and patches:

This chip in uboot: [1](https://elixir.bootlin.com/u-boot/latest/source/drivers/mtd/spi/spi-nor-ids.c#L457)

Previous discussions on merging upstream Linux: [1](https://lkml.kernel.org/lkml/1ba367f93650cb65122acd32fb4a4159@walle.cc/T/), [2](https://lore.kernel.org/linux-mtd/20210727045222.905056-8-tudor.ambarus@microchip.com/)

Similar patch examples for closely related devices in OpenWrt: [1](https://github.com/openwrt/openwrt/commit/ece815508a06ee114f549a7f0970740634fe2e62), [2](https://github.com/openwrt/openwrt/commit/df1383f7964527b2e7178ae744cd167a2c230f9f)