### PR TITLE
ramips: mt7621: enable lzma-loader for AFOUNDRY EW1200

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -140,6 +140,7 @@ TARGET_DEVICES += adslr_g7
 
 define Device/afoundry_ew1200
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := AFOUNDRY
   DEVICE_MODEL := EW1200


### PR DESCRIPTION
> Fixes boot loader LZMA decompression issues (LZMA ERROR 1)
> As reported in issue #12208

~~Pending test on actual device,~~ see the originating issue, above.

~~After success~~, this will need backported as the 23.x release images for this device will brick it, and possibly 22.x (~~pending test~~).

Summary: 21.x was the last known good build.  Suspect the uboot allocates insufficient RAM region for the expanded kernel, and the kernel got bigger than whatever that amount is (maybe 8MB) somewhere between 21.x and 23.x.  lzma-loader should bypass that limit until the compressed kernel exceeds the size (probably unlikely for "quite a while"?)