### PR TITLE
tools/libressl: bump to 3.7.1

### DIFF
--- a/tools/libressl/Makefile
+++ b/tools/libressl/Makefile
@@ -8,9 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libressl
-PKG_VERSION:=3.7.0
-PKG_HASH:=3fc1290f4007ec75f6e9acecbb25512630d1b9ab8c53ba79844e395868c3e006
-PKG_RELEASE:=1
+PKG_VERSION:=3.7.1
+PKG_HASH:=98086961a2b8b657ed0fea3056fb2db14294b6bfa193c15a5236a0a35c843ded
 
 PKG_CPE_ID:=cpe:/a:openbsd:libressl
 


### PR DESCRIPTION
Release Notes:
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.7.1-relnotes.txt