### PR TITLE
ath79: disable build 32 MiB RAM devices by default

### DIFF
--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -707,6 +707,7 @@ define Device/tplink_tl-wr1043nd-v1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-switch-rtl8366rb
   TPLINK_HWID := 0x10430001
   SUPPORTED_DEVICES += tl-wr1043nd
+  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_tl-wr1043nd-v1
 
@@ -789,6 +790,7 @@ define Device/tplink_tl-wr710n-v1
   DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x07100001
   SUPPORTED_DEVICES += tl-wr710n
+  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_tl-wr710n-v1
 
@@ -801,6 +803,7 @@ define Device/tplink_tl-wr710n-v2.1
   TPLINK_HWID := 0x07100002
   TPLINK_HWREV := 0x2
   SUPPORTED_DEVICES += tl-wr710n
+  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_tl-wr710n-v2.1
 
@@ -822,6 +825,7 @@ define Device/tplink_tl-wr810n-v2
   DEVICE_VARIANT := v2
   TPLINK_HWID := 0x8100002
   SUPPORTED_DEVICES += tl-wr810n-v2
+  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_tl-wr810n-v2
 
@@ -851,6 +855,7 @@ define Device/tplink_tl-wr842n-v1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x8420001
   SUPPORTED_DEVICES += tl-mr3420
+  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_tl-wr842n-v1
 
@@ -862,6 +867,7 @@ define Device/tplink_tl-wr842n-v2
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x8420002
   SUPPORTED_DEVICES += tl-wr842n-v2
+  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_tl-wr842n-v2
 

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2847,6 +2847,7 @@ define Device/wd_mynet-wifi-rangeextender
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | cybertan-trx | \
 	addpattern | append-metadata
   SUPPORTED_DEVICES += mynet-rext
+  DEFAULT := n
 endef
 TARGET_DEVICES += wd_mynet-wifi-rangeextender
 
@@ -2937,6 +2938,7 @@ define Device/ziking_cpe46b
   DEVICE_MODEL := CPE46B
   IMAGE_SIZE := 8000k
   DEVICE_PACKAGES := kmod-i2c-gpio
+  DEFAULT := n
 endef
 TARGET_DEVICES += ziking_cpe46b
 

--- a/target/linux/ath79/image/tiny-ubnt.mk
+++ b/target/linux/ath79/image/tiny-ubnt.mk
@@ -5,6 +5,7 @@ define Device/ubnt_airrouter
   SOC := ar7241
   DEVICE_MODEL := AirRouter
   SUPPORTED_DEVICES += airrouter
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_airrouter
 
@@ -14,6 +15,7 @@ define Device/ubnt_nanobridge-m
   DEVICE_MODEL := NanoBridge M
   DEVICE_PACKAGES += rssileds
   SUPPORTED_DEVICES += bullet-m
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_nanobridge-m
 
@@ -24,6 +26,7 @@ define Device/ubnt_bullet-m-ar7240
   DEVICE_VARIANT := XM (AR7240)
   DEVICE_PACKAGES += rssileds
   SUPPORTED_DEVICES += bullet-m
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_bullet-m-ar7240
 
@@ -34,6 +37,7 @@ define Device/ubnt_bullet-m-ar7241
   DEVICE_VARIANT := XM (AR7241)
   DEVICE_PACKAGES += rssileds
   SUPPORTED_DEVICES += bullet-m ubnt,bullet-m
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_bullet-m-ar7241
 
@@ -43,6 +47,7 @@ define Device/ubnt_picostation-m
   DEVICE_MODEL := Picostation M
   DEVICE_PACKAGES += rssileds
   SUPPORTED_DEVICES += bullet-m
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_picostation-m
 
@@ -52,6 +57,7 @@ define Device/ubnt_nanostation-m
   DEVICE_MODEL := Nanostation M
   DEVICE_PACKAGES += rssileds
   SUPPORTED_DEVICES += nanostation-m
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_nanostation-m
 
@@ -61,6 +67,7 @@ define Device/ubnt_nanostation-loco-m
   DEVICE_MODEL := Nanostation Loco M
   DEVICE_PACKAGES += rssileds
   SUPPORTED_DEVICES += bullet-m
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_nanostation-loco-m
 

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -40,6 +40,7 @@ define Device/engenius_eap350-v1
   IMAGE_SIZE := 4928k
   LOADER_FLASH_OFFS := 0x1a0000
   SENAO_IMGNAME := senao-eap350
+  DEFAULT := n
 endef
 TARGET_DEVICES += engenius_eap350-v1
 
@@ -53,6 +54,7 @@ define Device/engenius_ecb350-v1
   IMAGE_SIZE := 4928k
   LOADER_FLASH_OFFS := 0x1a0000
   SENAO_IMGNAME := senao-ecb350
+  DEFAULT := n
 endef
 TARGET_DEVICES += engenius_ecb350-v1
 
@@ -66,6 +68,7 @@ define Device/engenius_enh202-v1
   IMAGE_SIZE := 4928k
   LOADER_FLASH_OFFS := 0x1a0000
   SENAO_IMGNAME := senao-enh202
+  DEFAULT := n
 endef
 TARGET_DEVICES += engenius_enh202-v1
 
@@ -76,5 +79,6 @@ define Device/pqi_air-pen
   DEVICE_PACKAGES := kmod-usb-chipidea2
   IMAGE_SIZE := 7680k
   SUPPORTED_DEVICES += pqi-air-pen
+  DEFAULT := n
 endef
 TARGET_DEVICES += pqi_air-pen


### PR DESCRIPTION
Those devices are queried from the [OpenWrt ToH](https://openwrt.org/toh/views/toh_standard_all)