### PR TITLE
ath79: add support for MikroTik RB951Ui-2HnD

### DIFF
--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951ui-2hnd.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951ui-2hnd.dts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_mikrotik_routerboard.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-951ui-2hnd", "qca,ar9344";
+	model = "Mikrotik RouterBOARD 951Ui-2HnD";
+
+	/delete-node/ leds;
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_user: user {
+			label = "green:user";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		port1 {
+			label = "green:port1";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		port2 {
+			label = "green:port2";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		port3 {
+			label = "green:port3";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		port4 {
+			label = "green:port4";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+
+		port5 {
+			label = "green:port5";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_poe_power {
+			gpio-export,name = "rb951ui2hnd:power:poe";
+			gpio-export,output = <1>;
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_usb_power {
+			gpio-export,name = "rb951ui2hnd:power:usb";
+			gpio-export,output = <1>;
+			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpio {
+	nand_power {
+		gpio-hog;
+		gpios = <14 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+};
+
+&nand {
+	status = "okay";
+
+	nand-ecc-mode = "soft";
+	qca,nand-swap-dma;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "booter";
+			reg = <0x0000000 0x0040000>;
+			read-only;
+		};
+
+		partition@40000 {
+			label = "kernel";
+			reg = <0x0040000 0x03c0000>;
+		};
+
+		partition@400000 {
+			label = "ubi";
+			reg = <0x0400000 0x7c00000>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "mikrotik,routerboot-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "routerboot";
+				reg = <0x0 0x0>;
+				read-only;
+			};
+
+			hard_config: hard_config {
+				read-only;
+			};
+
+			bios {
+				size = <0x1000>;
+				read-only;
+			};
+
+			soft_config {
+			};
+		};
+	};
+};
+
+&eth0 {
+	phy-handle = <&swphy4>;
+
+	/delete-node/ gmac-config;
+};
+
+&eth1 {
+	compatible = "qca,ar9340-eth", "syscon";
+};
+
+&wmac {
+	qca,led-pin = /bits/ 8 <11>;
+};
+
+&usb {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -48,6 +48,15 @@ define Device/mikrotik_routerboard-922uags-5hpacd
 endef
 TARGET_DEVICES += mikrotik_routerboard-922uags-5hpacd
 
+define Device/mikrotik_routerboard-951ui-2hnd
+  $(Device/mikrotik_nand)
+  SOC := ar9344
+  DEVICE_MODEL := RouterBOARD 951Ui-2HnD
+  DEVICE_PACKAGES += kmod-usb-ohci kmod-usb2
+  SUPPORTED_DEVICES += rb-951ui-2hnd
+endef
+TARGET_DEVICES += mikrotik_routerboard-951ui-2hnd
+
 define Device/mikrotik_routerboard-951ui-2nd
   $(Device/mikrotik_nor)
   SOC := qca9531

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
@@ -16,6 +16,7 @@ mikrotik,routerboard-lhg-5nd)
 	ucidef_set_led_rssi "rssimediumhigh" "rssimediumhigh" "green:rssimediumhigh" "wlan0" "60" "100"
 	ucidef_set_led_rssi "rssihigh" "rssihigh" "green:rssihigh" "wlan0" "80" "100"
 	;;
+mikrotik,routerboard-951ui-2hnd|\
 mikrotik,routerboard-951ui-2nd|\
 mikrotik,routerboard-952ui-5ac2nd)
 	ucidef_set_led_netdev "port1" "port1" "green:port1" "eth1"

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -25,6 +25,7 @@ ath79_setup_interfaces()
 	mikrotik,routerboard-wapr-2nd)
 		ucidef_set_interface_lan "eth0"
 		;;
+	mikrotik,routerboard-951ui-2hnd|\
 	mikrotik,routerboard-951ui-2nd|\
 	mikrotik,routerboard-952ui-5ac2nd)
 		ucidef_set_interface_wan "eth1"

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -46,6 +46,9 @@ case "$FIRMWARE" in
 	mikrotik,routerboard-962uigs-5hact2hnt)
 		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" 7)
 		;;
+	mikrotik,routerboard-951ui-2hnd)
+		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" +11)
+		;;
 	*)
 		caldata_die "board $board is not supported yet"
 		;;

--- a/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
@@ -33,6 +33,7 @@ platform_do_upgrade() {
 	mikrotik,routerboard-912uag-2hpnd|\
 	mikrotik,routerboard-921gs-5hpacd-15s|\
 	mikrotik,routerboard-922uags-5hpacd|\
+	mikrotik,routerboard-951ui-2hnd|\
 	mikrotik,routerboard-sxt-5nd-r2)
 		platform_do_upgrade_mikrotik_nand "$1"
 		;;


### PR DESCRIPTION
Mikrotik RB951Ui-2HnD is a wireless SOHO router that was previously supported by the ar71xx target, see commit d19b868b12 ("ar71xx: Add support for MikroTik RB951Ui-2HnD").

Specifications
--------------

  - SoC: Atheros AR9344 (600 MHz)
  - RAM: 128 MB (2x 64 MB)
  - Storage: 128 MB NAND flash (various manufacturers)
  - Ethernet: Atheros AR8229 switch, 5x 10/100 Mbit/s
      - 1x PoE in (port 1, 8-30 V input)
      - 1x PoE out (port 5, 500 mA output)
  - Wireless: Atheros AR9340 (802.11b/g/n)
  - USB: 2.0 (1A)
  - 9x LED:
      - 1x power (green, not configurable)
      - 1x user (green)
      - 5x FE ports (green)
      - 1x wireless (green)
      - 1x PoE out (red)
  - 1x button (restart)

See https://mikrotik.com/product/RB951Ui-2HnD for more details.

Flashing
--------

TFTP boot initramfs image and then perform sysupgrade.  Follow common MikroTik procedures at https://openwrt.org/toh/mikrotik/common.

~~Notes~~
-----

~~The DTS file does not inherit from `target/linux/ath79/dts/ar9344_mikrotik_routerboard.dtsi` because the LEDs listed in that file use the same GPIO numbers as those in this PR, but have names that would have been confusing - RB951Ui-2HnD does not have any RSSI LEDs, only Ethernet port status LEDs.~~ (Addressed as of 102c16b79e440cd5927750f9de10bdf7456b0dc1.)
