### PR TITLE
ramips: Add support for CJ-Hello HYC-G920

### DIFF
--- a/target/linux/ramips/dts/mt7621_hanyang_hyc-g920.dts
+++ b/target/linux/ramips/dts/mt7621_hanyang_hyc-g920.dts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "hanyang,hyc-g920", "mediatek,mt7621-soc";
+	model = "CJ-Hello HYC-G920";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+		bootargs-override = "console=ttyS0,115200";
+	};
+	
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "red:power";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "green:usb";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "mac";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+
+			partition@fb0000 {
+				label = "config ";
+				reg = <0xfb0000 0x20000>;
+				read-only;
+			};
+
+			partition@fd0000 {
+				label = "config_bak ";
+				reg = <0xfd0000 0x20000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "mac_bak ";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_4>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <1>;
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "sdhci";
+		function = "gpio";
+	};
+};
+	
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 {
+		reg = <0x4 0x6>;
+	};
+
+	macaddr_factory_8004: macaddr@8004 {
+		reg = <0x8004 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -974,6 +974,16 @@ define Device/gnubee_gb-pc2
 endef
 TARGET_DEVICES += gnubee_gb-pc2
 
+define Device/hanyang_hyc-g920
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  DEVICE_VENDOR := Hanyang
+  DEVICE_MODEL := CJ-Hello HYC-G920
+  IMAGE_SIZE := 15744k
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt76x2 kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += hanyang_hyc-g920
+
 define Device/h3c_tx180x
   $(Device/dsa-migration)
   BLOCKSIZE := 128k


### PR DESCRIPTION
Hanyang Digitech Co., Ltd.
MSIP-CMM-HYD-HYC-G920
CJ-Hello HYC-G920

SoC		: MediaTek MT7621AT
RAM		: 256M (SK hynix H5TQ2G63FFR)
FLASH	: 16MB (Winbond W25Q128BV)
WiFi	: MediaTek MT7602EN bgn 2SS
WiFi	: MediaTek MT7612EN nac 2SS
BTN		: Reset
LED		: - Power RED
		  - WAN Green
		  - LAN {1-4}
		  - WiFi 2.4 GHz Blue
		  - WiFi 5 GHz Blue
		  - USB Green
		  
**For MT7621 stage1 DDR Test**

UART	: J4 GND - 3V3 - TX - RX - GND / 57600-8N1

```
                MT7621   stage1 code 10:33:55 (ASIC)
                CPU=500000000 HZ BUS=166666666 HZ
```


**For u boot environment** 

UART	: J4 GND - 3V3 - TX - RX - GND / 115200-8N1


**UART Menu**

```
	Please choose the operation:
		1: Load system code to SDRAM via TFTP.
		2: Load system code then write to Flash via TFTP.
		3: Boot system code via Flash (default).
		4: Entr boot command line interface.
		7: Load Boot Loader code then write to Flash via Serial.
		9: Load Boot Loader code then write to Flash via TFTP.
```

**Steps**

Press 4: Entr boot command line interface.

On the pormpt enter.
`setenv firmware_size 0xf60000`
Then enter.
`saveenv`
Then enter.
`reset`

**Device will reboot** 

Set your IP 192.168.100.100/24
Connect your lan cable to wan port.


**On the UART Menu**

Press 2: Load system code then write to Flash via TFTP.

 Warning!! Erase Linux in Flash then burn new one. Are you sure?(Y/N) **enter** `Y`
 Please Input new ones /or Ctrl-C to discard
        Input device IP (192.168.100.55) ==:`192.168.100.55`
        Input server IP (192.168.100.100) ==:`192.168.100.100`
        Input Linux Kernel filename () ==:`openwrt-22.03.0-ramips-mt7621-hanyang_hyc-g920-squashfs-sysupgrade.bin`

After uploading firmware image, device will boot Openwrt.

Signed-off-by: Muhammad AL-Qadhy <m.ismael@gmail.com>

