### PR TITLE
ramips: mt7621: enable unused PCIe port to fix potential boot failure issue

### DIFF
--- a/target/linux/ramips/dts/mt7621_h3c_tx180x.dtsi
+++ b/target/linux/ramips/dts/mt7621_h3c_tx180x.dtsi
@@ -138,10 +138,6 @@
 	};
 };
 
-&pcie2 {
-	status = "disabled";
-};
-
 &state_default {
 	gpio {
 		groups = "jtag";

--- a/target/linux/ramips/dts/mt7621_haier-sim_wr1800k.dtsi
+++ b/target/linux/ramips/dts/mt7621_haier-sim_wr1800k.dtsi
@@ -152,10 +152,6 @@
 	};
 };
 
-&pcie2 {
-	status = "disabled";
-};
-
 &state_default {
 	gpio {
 		groups = "i2c", "uart3", "wdt";

--- a/target/linux/ramips/dts/mt7621_netgear_wax202.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_wax202.dts
@@ -217,10 +217,6 @@
 	};
 };
 
-&pcie2 {
-	status = "disabled";
-};
-
 &state_default {
 	gpio {
 		groups = "uart3", "uart2", "jtag", "wdt";

--- a/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts
@@ -148,10 +148,6 @@
 	};
 };
 
-&pcie2 {
-	status = "disabled";
-};
-
 &gmac0 {
 	nvmem-cells = <&macaddr_info_8>;
 	nvmem-cell-names = "mac-address";


### PR DESCRIPTION
One user reported that his SIMAX1800T couldn't boot like the others. After debugging, I found that this was caused by the disabled PCIe port. I cannot reproduce this issue on my SIMAX1800T. But when I disabled pcie2 on the ASUS RT-AC57U, I got the same result.

It seems that disabling these unused PCIe ports on some mt7621 revisions will cause PCIe to fail to initialize. So we'd better to re-enable them on all related mt7621 devices.
