### PR TITLE
lantiq: fix ath9k-eeprom for AVM Fritz!Box 7430

### DIFF
--- a/target/linux/lantiq/xrx200/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/xrx200/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -23,10 +23,28 @@ case "$FIRMWARE" in
 			avm,fritz7360-v2)
 				caldata_extract "urlader" 0x985 0x1000
 				;;
-			avm,fritz7412|\
-			avm,fritz7430)
+			avm,fritz7412)
 				/usr/bin/fritz_cal_extract -i 1 -s 0x1e000 -e 0x207 -l 5120 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader") || \
 				/usr/bin/fritz_cal_extract -i 1 -s 0x1e800 -e 0x207 -l 5120 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader")
+				;;
+			avm,fritz7430)
+				reversed=$( \
+				/usr/bin/fritz_cal_extract -i 1 -s 0x1e000 -e 0x207 -l 5120 $(find_mtd_chardev "urlader") || \
+				/usr/bin/fritz_cal_extract -i 1 -s 0x1e800 -e 0x207 -l 5120 $(find_mtd_chardev "urlader") | \
+				hexdump -v -e '/1 "%02x "')
+
+				caldata=""
+				i=0
+				count=$((${#reversed} / 3 - 4))
+				for byte in $reversed; do
+					i=$(($i+1))
+					if [ "$i" -gt "$count" ]; then
+						break
+					fi
+					caldata="\x${byte}${caldata}"
+				done
+
+				printf "%b" "$caldata" > /lib/firmware/$FIRMWARE
 				;;
 			bt,homehub-v5a)
 				caldata_extract_ubi "caldata" 0x1000 0x1000


### PR DESCRIPTION
@grische noticed that the extracted wifi calibration data (ath9k-eeprom) is incorrect.
Symptoms included:
- wrong mac address
- radio was detected like dbdc (2.4GHz and 5GHz support at the same time)

This patch fixes this by also reversing the order of bytes and throwing away the last 4 Bytes.
Unlike caldata.sh the fritz_cal_extract.c doesn't support reversing. So this patch combines both methods.

_________________

The new code is based on https://github.com/openwrt/openwrt/blob/master/package/base-files/files/lib/functions/caldata.sh#L64-L80

The issue was noticed here: https://github.com/freifunk-gluon/gluon/pull/2270

<details>
  <summary>iw list (before)</summary>

  ```
Wiphy phy0
        wiphy index: 0
        max # scan SSIDs: 4
        max scan IEs length: 2257 bytes
        max # sched scan SSIDs: 0
        max # match sets: 0
        Retry short limit: 7
        Retry long limit: 4
        Coverage class: 0 (up to 0m)
        Device supports AP-side u-APSD.
        Device supports T-DLS.
        Available Antennas: TX 0x7 RX 0x7
        Configured Antennas: TX 0x7 RX 0x7
        Supported interface modes:
                 * IBSS
                 * managed
                 * AP
                 * AP/VLAN
                 * monitor
                 * mesh point
                 * P2P-client
                 * P2P-GO
                 * outside context of a BSS
        Band 1:
                Capabilities: 0x11ef
                        RX LDPC
                        HT20/HT40
                        SM Power Save disabled
                        RX HT20 SGI
                        RX HT40 SGI
                        TX STBC
                        RX STBC 1-stream
                        Max AMSDU length: 3839 bytes
                        DSSS/CCK HT40
                Maximum RX AMPDU length 65535 bytes (exponent: 0x003)
                Minimum RX AMPDU time spacing: 8 usec (0x06)
                HT TX/RX MCS rate indexes supported: 0-23
                Frequencies:
                        * 2412 MHz [1] (20.0 dBm)
                        * 2417 MHz [2] (20.0 dBm)
                        * 2422 MHz [3] (20.0 dBm)
                        * 2427 MHz [4] (20.0 dBm)
                        * 2432 MHz [5] (20.0 dBm)
                        * 2437 MHz [6] (20.0 dBm)
                        * 2442 MHz [7] (20.0 dBm)
                        * 2447 MHz [8] (20.0 dBm)
                        * 2452 MHz [9] (20.0 dBm)
                        * 2457 MHz [10] (20.0 dBm)
                        * 2462 MHz [11] (20.0 dBm)
                        * 2467 MHz [12] (20.0 dBm)
                        * 2472 MHz [13] (20.0 dBm)
                        * 2484 MHz [14] (disabled)
        Band 2:
                Capabilities: 0x11ef
                        RX LDPC
                        HT20/HT40
                        SM Power Save disabled
                        RX HT20 SGI
                        RX HT40 SGI
                        TX STBC
                        RX STBC 1-stream
                        Max AMSDU length: 3839 bytes
                        DSSS/CCK HT40
                Maximum RX AMPDU length 65535 bytes (exponent: 0x003)
                Minimum RX AMPDU time spacing: 8 usec (0x06)
                HT TX/RX MCS rate indexes supported: 0-23
                Frequencies:
                        * 5180 MHz [36] (15.0 dBm)
                        * 5200 MHz [40] (15.0 dBm)
                        * 5220 MHz [44] (15.0 dBm)
                        * 5240 MHz [48] (15.0 dBm)
                        * 5260 MHz [52] (15.0 dBm) (radar detection)
                        * 5280 MHz [56] (15.0 dBm) (radar detection)
                        * 5300 MHz [60] (15.0 dBm) (radar detection)
                        * 5320 MHz [64] (15.0 dBm) (radar detection)
                        * 5500 MHz [100] (15.0 dBm) (radar detection)
                        * 5520 MHz [104] (15.0 dBm) (radar detection)
                        * 5540 MHz [108] (15.0 dBm) (radar detection)
                        * 5560 MHz [112] (15.0 dBm) (radar detection)
                        * 5580 MHz [116] (15.0 dBm) (radar detection)
                        * 5600 MHz [120] (15.0 dBm) (radar detection)
                        * 5620 MHz [124] (15.0 dBm) (radar detection)
                        * 5640 MHz [128] (15.0 dBm) (radar detection)
                        * 5660 MHz [132] (15.0 dBm) (radar detection)
                        * 5680 MHz [136] (15.0 dBm) (radar detection)
                        * 5700 MHz [140] (15.0 dBm) (radar detection)
                        * 5745 MHz [149] (13.0 dBm)
                        * 5765 MHz [153] (13.0 dBm)
                        * 5785 MHz [157] (13.0 dBm)
                        * 5805 MHz [161] (13.0 dBm)
                        * 5825 MHz [165] (13.0 dBm)
        valid interface combinations:
                 * #{ managed } <= 2048, #{ AP, mesh point } <= 8, #{ P2P-client, P2P-GO } <= 1, #{ IBSS } <= 1,
                   total <= 2048, #channels <= 1, STA/AP BI must match, radar detect widths: { 20 MHz (no HT), 20 MHz, 40 MHz }

        HT Capability overrides:
                 * MCS: ff ff ff ff ff ff ff ff ff ff
                 * maximum A-MSDU length
                 * supported channel width
                 * short GI for 40 MHz
                 * max A-MPDU length exponent
                 * min MPDU start spacing
        max # scan plans: 1
        max scan plan interval: -1
        max scan plan iterations: 0
        Supported extended features:
                * [ RRM ]: RRM
                * [ FILS_STA ]: STA FILS (Fast Initial Link Setup)
                * [ CQM_RSSI_LIST ]: multiple CQM_RSSI_THOLD records
                * [ CONTROL_PORT_OVER_NL80211 ]: control port over nl80211
                * [ TXQS ]: FQ-CoDel-enabled intermediate TXQs
                * [ AIRTIME_FAIRNESS ]: airtime fairness scheduling
                * [ SCAN_RANDOM_SN ]: use random sequence numbers in scans
                * [ SCAN_MIN_PREQ_CONTENT ]: use probe request with only rate IEs in scans
                * [ CAN_REPLACE_PTK0 ]: can safely replace PTK 0 when rekeying
                * [ CONTROL_PORT_NO_PREAUTH ]: disable pre-auth over nl80211 control port support
                * [ DEL_IBSS_STA ]: deletion of IBSS station support
                * [ MULTICAST_REGISTRATIONS ]: mgmt frame registration for multicast
                * [ SCAN_FREQ_KHZ ]: scan on kHz frequency support
                * [ CONTROL_PORT_OVER_NL80211_TX_STATUS ]: tx status for nl80211 control port support
  ```

</details>

<details>
  <summary>iw list (with this patch)</summary>

  ```
Wiphy phy0
        wiphy index: 0
        max # scan SSIDs: 4
        max scan IEs length: 2257 bytes
        max # sched scan SSIDs: 0
        max # match sets: 0
        Retry short limit: 7
        Retry long limit: 4
        Coverage class: 0 (up to 0m)
        Device supports AP-side u-APSD.
        Device supports T-DLS.
        Available Antennas: TX 0x7 RX 0x7
        Configured Antennas: TX 0x7 RX 0x7
        Supported interface modes:
                 * IBSS
                 * managed
                 * AP
                 * AP/VLAN
                 * monitor
                 * mesh point
                 * P2P-client
                 * P2P-GO
                 * outside context of a BSS
        Band 1:
                Capabilities: 0x11ef
                        RX LDPC
                        HT20/HT40
                        SM Power Save disabled
                        RX HT20 SGI
                        RX HT40 SGI
                        TX STBC
                        RX STBC 1-stream
                        Max AMSDU length: 3839 bytes
                        DSSS/CCK HT40
                Maximum RX AMPDU length 65535 bytes (exponent: 0x003)
                Minimum RX AMPDU time spacing: 8 usec (0x06)
                HT TX/RX MCS rate indexes supported: 0-23
                Frequencies:
                        * 2412 MHz [1] (25.0 dBm)
                        * 2417 MHz [2] (25.0 dBm)
                        * 2422 MHz [3] (25.0 dBm)
                        * 2427 MHz [4] (25.0 dBm)
                        * 2432 MHz [5] (25.0 dBm)
                        * 2437 MHz [6] (25.0 dBm)
                        * 2442 MHz [7] (25.0 dBm)
                        * 2447 MHz [8] (25.0 dBm)
                        * 2452 MHz [9] (25.0 dBm)
                        * 2457 MHz [10] (25.0 dBm)
                        * 2462 MHz [11] (25.0 dBm)
                        * 2467 MHz [12] (disabled)
                        * 2472 MHz [13] (disabled)
                        * 2484 MHz [14] (disabled)
        valid interface combinations:
                 * #{ managed } <= 2048, #{ AP, mesh point } <= 8, #{ P2P-client, P2P-GO } <= 1, #{ IBSS } <= 1,
                   total <= 2048, #channels <= 1, STA/AP BI must match, radar detect widths: { 20 MHz (no HT), 20 MHz, 40 MHz }

        HT Capability overrides:
                 * MCS: ff ff ff ff ff ff ff ff ff ff
                 * maximum A-MSDU length
                 * supported channel width
                 * short GI for 40 MHz
                 * max A-MPDU length exponent
                 * min MPDU start spacing
        max # scan plans: 1
        max scan plan interval: -1
        max scan plan iterations: 0
        Supported extended features:
                * [ RRM ]: RRM
                * [ FILS_STA ]: STA FILS (Fast Initial Link Setup)
                * [ CQM_RSSI_LIST ]: multiple CQM_RSSI_THOLD records
                * [ CONTROL_PORT_OVER_NL80211 ]: control port over nl80211
                * [ TXQS ]: FQ-CoDel-enabled intermediate TXQs
                * [ SCAN_RANDOM_SN ]: use random sequence numbers in scans
                * [ SCAN_MIN_PREQ_CONTENT ]: use probe request with only rate IEs in scans
                * [ CAN_REPLACE_PTK0 ]: can safely replace PTK 0 when rekeying
                * [ AIRTIME_FAIRNESS ]: airtime fairness scheduling
                * [ CONTROL_PORT_NO_PREAUTH ]: disable pre-auth over nl80211 control port support
                * [ DEL_IBSS_STA ]: deletion of IBSS station support
                * [ MULTICAST_REGISTRATIONS ]: mgmt frame registration for multicast
                * [ SCAN_FREQ_KHZ ]: scan on kHz frequency support
                * [ CONTROL_PORT_OVER_NL80211_TX_STATUS ]: tx status for nl80211 control port support
  ```

</details>

logread excerpt from booting with this patch
```
Wed Mar 22 15:28:10 2023 kern.warn kernel: [   15.386677] ifx_pcie_bios_map_irq port 0 dev 0000:01:00.0 slot 0 pin 1
Wed Mar 22 15:28:10 2023 kern.warn kernel: [   15.391990] ifx_pcie_bios_map_irq dev 0000:01:00.0 irq 144 assigned
Wed Mar 22 15:28:10 2023 kern.info kernel: [   15.398165] ath9k 0000:01:00.0: enabling device (0000 -> 0002)
Wed Mar 22 15:28:10 2023 kern.warn kernel: [   15.404630] ath9k 0000:01:00.0: Direct firmware load for ath9k-eeprom-pci-0000:01:00.0.bin failed with error -2
Wed Mar 22 15:28:10 2023 kern.warn kernel: [   15.414168] ath9k 0000:01:00.0: Falling back to sysfs fallback for: ath9k-eeprom-pci-0000:01:00.0.bin
Wed Mar 22 15:28:10 2023 kern.debug kernel: [   21.139726] ath: EEPROM regdomain: 0x0
Wed Mar 22 15:28:10 2023 kern.debug kernel: [   21.139753] ath: EEPROM indicates default country code should be used
Wed Mar 22 15:28:10 2023 kern.debug kernel: [   21.139764] ath: doing EEPROM country->regdmn map search
Wed Mar 22 15:28:10 2023 kern.debug kernel: [   21.139800] ath: country maps to regdmn code: 0x3a
Wed Mar 22 15:28:10 2023 kern.debug kernel: [   21.139814] ath: Country alpha2 being used: US
Wed Mar 22 15:28:10 2023 kern.debug kernel: [   21.139827] ath: Regpair used: 0x3a
Wed Mar 22 15:28:10 2023 kern.debug kernel: [   21.153345] ieee80211 phy0: Selected rate control algorithm 'minstrel_ht'
Wed Mar 22 15:28:10 2023 kern.info kernel: [   21.158178] ieee80211 phy0: Atheros AR9300 Rev:3 mem=0xbc000000, irq=144
```