### PR TITLE
ramips: mt7621: enable lzma-loader for AFOUNDRY EW1200

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -113,6 +113,7 @@ TARGET_DEVICES += adslr_g7
 
 define Device/afoundry_ew1200
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := AFOUNDRY
   DEVICE_MODEL := EW1200


### PR DESCRIPTION
> ramips: mt7621: enable lzma-loader for AFOUNDRY EW1200
> 
> Fixes boot loader LZMA decompression issues (LZMA ERROR 1)
> As reported in issue #12208 (backport for 22.03)

Same as merged in #12211 this will fix the broken 22.03 release