### PR TITLE
dnsmasq: add dhcphostsfile to ujail sandbox

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1212,6 +1212,7 @@ dnsmasq_start()
 		[ ! -e "$logfacility" ] && touch "$logfacility"
 		procd_add_jail_mount_rw "$logfacility"
 	esac
+	[ -e "$hostsfile" ] && procd_add_jail_mount $hostsfile
 
 	procd_close_instance
 }


### PR DESCRIPTION
The dhcphostsfile must be mounted into the (ujail) sandbox. 
The file can not be accessed without this mount.
