### PR TITLE
comgt: support Mikrotik R11e-LTE6 modem

### DIFF
--- a/package/network/utils/comgt/Makefile
+++ b/package/network/utils/comgt/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=comgt
 PKG_VERSION:=0.32
-PKG_RELEASE:=34
+PKG_RELEASE:=35
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=@SF/comgt
@@ -79,6 +79,7 @@ define Package/comgt/install
 	$(INSTALL_DATA) ./files/getcarrier.gcom $(1)/etc/gcom/getcarrier.gcom
 	$(INSTALL_DATA) ./files/getcnum.gcom $(1)/etc/gcom/getcnum.gcom
 	$(INSTALL_DATA) ./files/getimsi.gcom $(1)/etc/gcom/getimsi.gcom
+	$(INSTALL_DATA) ./files/runcommand.gcom $(1)/etc/gcom/runcommand.gcom
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/tty
 	$(INSTALL_CONF) ./files/3g.usb $(1)/etc/hotplug.d/tty/30-3g
 	$(INSTALL_DIR) $(1)/lib/netifd/proto
@@ -96,7 +97,6 @@ endef
 define Package/comgt-ncm/install
 	$(INSTALL_DIR) $(1)/etc/gcom
 	$(INSTALL_DATA) ./files/ncm.json $(1)/etc/gcom/ncm.json
-	$(INSTALL_DATA) ./files/runcommand.gcom $(1)/etc/gcom/runcommand.gcom
 	$(INSTALL_DIR) $(1)/lib/netifd/proto
 	$(INSTALL_BIN) ./files/ncm.sh $(1)/lib/netifd/proto/ncm.sh
 endef

--- a/package/network/utils/comgt/files/3g.sh
+++ b/package/network/utils/comgt/files/3g.sh
@@ -72,6 +72,8 @@ proto_3g_setup() {
 					*) CODE="2,2";;
 				esac
 				export MODE="AT^SYSCFG=${CODE},3FFFFFFF,2,4"
+			elif echo "$cardinfo" | grep -q "MikroTik"; then
+				COMMAND="AT+CFUN=1" gcom -d "$device" -s /etc/gcom/runcommand.gcom || return 1
 			fi
 
 			if [ -n "$pincode" ]; then

--- a/package/network/utils/comgt/files/ncm.json
+++ b/package/network/utils/comgt/files/ncm.json
@@ -112,5 +112,17 @@
 		],
 		"connect": "AT+ZGACT=1,${profile}",
 		"disconnect": "AT+ZGACT=0,${profile}"
+	},
+	"\"mikrotik\"": {
+		"configure": [
+			"AT+CFUN=4",
+			"AT+ZGDCONT=${profile},\\\"${pdptype}\\\",\\\"${apn}\\\",0",
+			"AT+ZDHCPLEASE=10",
+			"AT+CFUN=1"
+		],
+		"waitforconnect": "\\\"+ZCONSTAT: 1,${context_type}\\\",\\\"+ZGIPDNS: ${context_type}\\\"",
+		"connect": "AT+ZGACT=1,${context_type}",
+		"finalize": "AT+ZDHCPLEASE=0",
+		"disconnect": "AT+ZGACT=0,1"
 	}
 }


### PR DESCRIPTION
In this pull request I publish my composition of all the information I collected about Mikrotik R11e-LTE6 modem:
* [Adding support for MikroTik hAP ac3 LTE6 kit (D53GR_5HacD2HnD)](https://forum.openwrt.org/t/adding-support-for-mikrotik-hap-ac3-lte6-kit-d53gr-5hacd2hnd/137555/)
* [OpenWrt X86_64 + Mikrotik R11e-LTE6](https://forum.openwrt.org/t/openwrt-x86-64-mikrotik-r11e-lte6/151743/44)

This modem has two quirks:
* it writes a few message at startup which confuses the manufacturer detection algorithm
  * the `delay` option is a workaround
* it boots into flight mode, so the first step should be to disable flight mode

----

Notes: I developed this PR with my hands on the modem borrowed from forum member **yodee13** (owner of the second thread). Now I sent the modem back.