### PR TITLE
realtek: Improve SMI polling

### DIFF
--- a/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
+++ b/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
@@ -206,7 +206,6 @@
 			compatible = "ethernet-phy-ieee802.3-c22";
 			phy-is-integrated;
 			reg = <27>;
-			rtl9300,smi-address = <4 0>;
 			sds = < 9 >;
 		};
 

--- a/target/linux/realtek/files-5.15/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.15/drivers/net/ethernet/rtl838x_eth.c
@@ -1923,7 +1923,7 @@ static int rtl930x_mdio_reset(struct mii_bus *bus)
 	for (int i = 0; i < RTL930X_CPU_PORT; i++) {
 		int pos;
 
-		if (priv->smi_bus[i] > 3)
+		if (priv->smi_bus[i] >= MAX_SMI_BUSSES)
 			continue;
 		pos = (i % 6) * 5;
 		sw_w32_mask(0x1f << pos, priv->smi_addr[i] << pos,
@@ -1942,7 +1942,7 @@ static int rtl930x_mdio_reset(struct mii_bus *bus)
 	sw_w32_mask(poll_ctrl, 0, RTL930X_SMI_GLB_CTRL);
 
 	/* Configure which SMI busses are polled in c45 based on a c45 PHY being on that bus */
-	for (int i = 0; i < 4; i++)
+	for (int i = 0; i < MAX_SMI_BUSSES; i++)
 		if (priv->smi_bus_isc45[i])
 			c45_mask |= BIT(i + 16);
 

--- a/target/linux/realtek/files-5.15/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.15/drivers/net/ethernet/rtl838x_eth.c
@@ -191,7 +191,7 @@ struct rtl838x_eth_priv {
 	u32 lastEvent;
 	u16 rxrings;
 	u16 rxringlen;
-	u8 smi_bus[MAX_PORTS];
+	u32 smi_bus[MAX_PORTS];
 	u8 smi_addr[MAX_PORTS];
 	u32 sds_id[MAX_PORTS];
 	bool smi_bus_isc45[MAX_SMI_BUSSES];
@@ -2031,6 +2031,8 @@ static int rtl931x_mdio_reset(struct mii_bus *bus)
 	for (int i = 0; i < 56; i++) {
 		u32 pos;
 
+		if (priv->smi_bus[i] >= MAX_SMI_BUSSES)
+			continue;
 		pos = (i % 6) * 5;
 		sw_w32_mask(0x1f << pos, priv->smi_addr[i] << pos, RTL931X_SMI_PORT_ADDR + (i / 6) * 4);
 		pos = (i * 2) % 32;
@@ -2174,13 +2176,17 @@ static int rtl838x_mdio_init(struct rtl838x_eth_priv *priv)
 	for_each_node_by_name(dn, "ethernet-phy") {
 		u32 smi_addr[2];
 
-		if (of_property_read_u32(dn, "reg", &pn))
+		if (of_property_read_u32(dn, "reg", &pn)) {
+			pr_err("%s: missing reg property on port %d\n", __func__, pn);
 			continue;
-
-		if (of_property_read_u32_array(dn, "rtl9300,smi-address", &smi_addr[0], 2)) {
-			smi_addr[0] = 0;
-			smi_addr[1] = pn;
 		}
+
+		if (pn >= MAX_PORTS) {
+			pr_err("%s: illegal port number %d\n", __func__, pn);
+			continue;
+		}
+
+		priv->phy_is_internal[pn] = of_property_read_bool(dn, "phy-is-integrated");
 
 		if (of_property_read_u32(dn, "sds", &priv->sds_id[pn]))
 			priv->sds_id[pn] = U32_MAX;
@@ -2188,19 +2194,27 @@ static int rtl838x_mdio_init(struct rtl838x_eth_priv *priv)
 			pr_info("set sds port %d to %d\n", pn, priv->sds_id[pn]);
 		}
 
-		if (pn < MAX_PORTS) {
+		if (of_property_read_u32_array(dn, "rtl9300,smi-address", &smi_addr[0], 2)) {
+			/* Integrated PHYs associated to a SerDes do not have an smi_bus */
+			if (priv->phy_is_internal[pn] && priv->sds_id[pn] >= 0) {
+				priv->smi_bus[pn] = U32_MAX;
+			/* PHYs whether integrated or not, not associated to an SDS use an smi_bus */
+			} else {
+				/* For RTL83xx, PHY-id is port ID on smi_bus 0 */
+				priv->smi_bus[pn] = 0;
+				priv->smi_addr[pn] = pn;
+			}
+		} else {
 			priv->smi_bus[pn] = smi_addr[0];
 			priv->smi_addr[pn] = smi_addr[1];
-		} else {
-			pr_err("%s: illegal port number %d\n", __func__, pn);
 		}
 
-		if (of_device_is_compatible(dn, "ethernet-phy-ieee802.3-c45"))
-			priv->smi_bus_isc45[smi_addr[0]] = true;
-
-		if (of_property_read_bool(dn, "phy-is-integrated")) {
-			priv->phy_is_internal[pn] = true;
+		if (priv->smi_bus[pn] >= MAX_SMI_BUSSES) {
+			pr_err("%s: illegal SMI bus number %d\n", __func__, priv->smi_bus[pn]);
+			continue;
 		}
+
+		priv->smi_bus_isc45[priv->smi_bus[pn]] = !!of_device_is_compatible(dn, "ethernet-phy-ieee802.3-c45");
 	}
 
 	dn = of_find_compatible_node(NULL, NULL, "realtek,rtl83xx-switch");

--- a/target/linux/realtek/files-5.15/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-5.15/drivers/net/ethernet/rtl838x_eth.c
@@ -13,6 +13,7 @@
 #include <linux/of.h>
 #include <linux/of_net.h>
 #include <linux/of_mdio.h>
+#include <linux/limits.h>
 #include <linux/module.h>
 #include <linux/phylink.h>
 #include <linux/pkt_sched.h>
@@ -2182,7 +2183,7 @@ static int rtl838x_mdio_init(struct rtl838x_eth_priv *priv)
 		}
 
 		if (of_property_read_u32(dn, "sds", &priv->sds_id[pn]))
-			priv->sds_id[pn] = -1;
+			priv->sds_id[pn] = U32_MAX;
 		else {
 			pr_info("set sds port %d to %d\n", pn, priv->sds_id[pn]);
 		}


### PR DESCRIPTION
Currently, we have to put fake SMI bus numbers on SFP links, which use in-band SMI messaging. Lets improve our routine a little bit so we can drop fakes.