### PR TITLE
mac80211: ath11k: restore 160MHz support

### DIFF
--- a/package/kernel/mac80211/patches/ath11k/904-wifi-ath11k-restore-160MHz-support.patch
+++ b/package/kernel/mac80211/patches/ath11k/904-wifi-ath11k-restore-160MHz-support.patch
@@ -1,0 +1,29 @@
+From e0edb3ac33694ab6a2705f7b053948a926520d81 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Tue, 28 Mar 2023 13:30:30 +0200
+Subject: [PATCH] wifi: ath11k: restore 160MHz support
+
+The blamed commit started clearing 80+80 and 160MHz support flags for 5G.
+This is preventing those modes from being advertised and thus used causing
+a regression, so until this is properly sorted out lets remove the flag
+clearing to restore 160MHz support.
+
+Fixes: 38dfe775d0ab ("wifi: ath11k: push MU-MIMO params from hostapd to hardware")
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -5552,10 +5552,6 @@ static int ath11k_mac_copy_he_cap(struct
+ 
+ 		he_cap_elem->mac_cap_info[1] &=
+ 			IEEE80211_HE_MAC_CAP1_TF_MAC_PAD_DUR_MASK;
+-		he_cap_elem->phy_cap_info[0] &=
+-			~IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_160MHZ_IN_5G;
+-		he_cap_elem->phy_cap_info[0] &=
+-			~IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_80PLUS80_MHZ_IN_5G;
+ 
+ 		he_cap_elem->phy_cap_info[5] &=
+ 			~IEEE80211_HE_PHY_CAP5_BEAMFORMEE_NUM_SND_DIM_UNDER_80MHZ_MASK;


### PR DESCRIPTION
Recent ath11k sync introduced a regression causing 80+80 and 160MHz to stop being advertised and thus not selectable due to the respective feature flags being cleared.

So, until we get answers upstream to what was the reasoning behind this and it gets fixed, lets just remove the flag clearing to reanable 160MHz.

Fixes: 789a0bac3535 ("mac80211: ath11k: sync with ath-next")
