### PR TITLE
mediatek: filogic: add ZyXEL EX5700 (Telenor) support

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -71,6 +71,9 @@ zyxel,ex5601-t0)
 	local envdev=/dev/mtd$(find_mtd_index "u-boot-env")
 	ubootenv_add_uci_config "$envdev" "0x0" "0x20000" "0x40000" "2"
 	;;
+zyxel,ex5700-telenor)
+	ubootenv_add_uci_config "/dev/ubootenv" "0x0" "0x4000" "0x4000" "1"
+	;;
 esac
 
 config_load ubootenv

--- a/package/kernel/ubootenv-nvram/Makefile
+++ b/package/kernel/ubootenv-nvram/Makefile
@@ -1,0 +1,30 @@
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=ubootenv-nvram
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/ubootenv-nvram
+  SUBMENU:=Other modules
+  TITLE:=NVRAM environment for uboot-envtools
+  FILES:=$(PKG_BUILD_DIR)/ubootenv-nvram.ko
+  AUTOLOAD:=$(call AutoLoad,30,ubootenv-nvram,1)
+  KCONFIG:=
+endef
+
+define KernelPackage/ubootenv-nvram/description
+  Support vendor modified U-Boot storing the environment
+  in RAM.  This driver exports the environment memory
+  region as a misc device named "ubootenv", pretending
+  it is a NOR mtd device to let existing userspace tools
+  work without modifications.
+endef
+
+define Build/Compile
+	$(KERNEL_MAKE) M="$(PKG_BUILD_DIR)" modules
+endef
+
+$(eval $(call KernelPackage,ubootenv-nvram))

--- a/package/kernel/ubootenv-nvram/src/Makefile
+++ b/package/kernel/ubootenv-nvram/src/Makefile
@@ -1,0 +1,1 @@
+obj-m += ubootenv-nvram.o

--- a/package/kernel/ubootenv-nvram/src/ubootenv-nvram.c
+++ b/package/kernel/ubootenv-nvram/src/ubootenv-nvram.c
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ *   Copyright (C) 2022  Bjørn Mork <bjorn@mork.no>
+ */
+
+#include <linux/fs.h>
+#include <linux/init.h>
+#include <linux/io.h>
+#include <linux/miscdevice.h>
+#include <linux/mm.h>
+#include <linux/module.h>
+#include <linux/mtd/mtd.h>
+#include <linux/of.h>
+#include <linux/of_reserved_mem.h>
+#include <linux/platform_device.h>
+
+#define NAME "ubootenv"
+
+struct ubootenv_drvdata {
+	void *env;
+	struct reserved_mem *rmem;
+	struct miscdevice misc;
+};
+
+static inline struct ubootenv_drvdata *to_ubootenv_drvdata(struct file *file)
+{
+	return container_of(file->private_data, struct ubootenv_drvdata, misc);
+}
+
+static ssize_t ubootenv_write(struct file *file, const char __user *buffer, size_t count,
+			      loff_t *ppos)
+{
+	struct ubootenv_drvdata *data = to_ubootenv_drvdata(file);
+
+	if (!data->env)
+		return -EIO;
+	return simple_write_to_buffer(data->env, data->rmem->size, ppos, buffer, count);
+}
+
+static ssize_t ubootenv_read(struct file *file, char __user *buffer, size_t count, loff_t *ppos)
+{
+	struct ubootenv_drvdata *data = to_ubootenv_drvdata(file);
+
+	if (!data->env)
+		return 0;
+	return simple_read_from_buffer(buffer, count, ppos, data->env, data->rmem->size);
+}
+
+static loff_t ubootenv_llseek(struct file *file, loff_t off, int whence)
+{
+	struct ubootenv_drvdata *data = to_ubootenv_drvdata(file);
+
+	return fixed_size_llseek(file, off, whence, data->rmem->size);
+}
+
+/* Faking the minimal mtd ioctl subset required by the fw_env.c */
+static long ubootenv_ioctl(struct file *file, u_int cmd, u_long arg)
+{
+	struct ubootenv_drvdata *data = to_ubootenv_drvdata(file);
+	void __user *argp = (void __user *)arg;
+	struct mtd_info_user info = {
+		.type = MTD_NORFLASH,
+		.size = data->rmem->size,
+	};
+
+	switch (cmd) {
+	case MEMISLOCKED:
+	case MEMERASE:
+		break;
+	case MEMGETINFO:
+		if (copy_to_user(argp, &info, sizeof(struct mtd_info_user)))
+			return -EFAULT;
+		break;
+	default:
+		return -ENOTTY;
+	}
+	return 0;
+}
+
+static const struct file_operations ubootenv_fops = {
+	.owner          = THIS_MODULE,
+	.read           = ubootenv_read,
+	.write          = ubootenv_write,
+	.llseek         = ubootenv_llseek,
+	.unlocked_ioctl = ubootenv_ioctl,
+};
+
+/* We can only map a single reserved-memory range */
+static struct ubootenv_drvdata drvdata = {
+	.misc = {
+		.fops  = &ubootenv_fops,
+		.minor = MISC_DYNAMIC_MINOR,
+		.name  = NAME,
+	},
+};
+
+const struct of_device_id of_ubootenv_match[] = {
+	{ .compatible = "ubootenv" },
+	{},
+};
+MODULE_DEVICE_TABLE(of, of_ubootenv_match);
+
+static int ubootenv_probe(struct platform_device *pdev)
+{
+	struct ubootenv_drvdata *data = &drvdata;
+	struct device *dev = &pdev->dev;
+	struct device_node *np;
+
+	/* enforce single instance */
+	if (data->env)
+		return -EINVAL;
+
+	np = of_parse_phandle(dev->of_node, "memory-region", 0);
+	if (!np)
+		return -ENODEV;
+
+	data->rmem = of_reserved_mem_lookup(np);
+	of_node_put(np);
+	if (!data->rmem)
+		return -ENODEV;
+
+	if (!data->rmem->size || (data->rmem->size > ULONG_MAX))
+		return -EINVAL;
+
+	if (!PAGE_ALIGNED(data->rmem->base) || !PAGE_ALIGNED(data->rmem->size))
+		return -EINVAL;
+
+	data->env = devm_memremap(&pdev->dev, data->rmem->base, data->rmem->size, MEMREMAP_WB);
+	platform_set_drvdata(pdev, data);
+
+	data->misc.parent = &pdev->dev;
+	return misc_register(&data->misc);
+}
+
+static int ubootenv_remove(struct platform_device *pdev)
+{
+	struct ubootenv_drvdata *data = platform_get_drvdata(pdev);
+
+	data->env = NULL;
+	misc_deregister(&data->misc);
+	return 0;
+}
+
+static struct platform_driver ubootenv_driver = {
+	.probe = ubootenv_probe,
+	.remove = ubootenv_remove,
+	.driver = {
+		.name           = NAME,
+		.owner          = THIS_MODULE,
+		.of_match_table = of_ubootenv_match,
+	},
+};
+
+module_platform_driver(ubootenv_driver);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Bjørn Mork <bjorn@mork.no>");
+MODULE_DESCRIPTION("Access u-boot environment in RAM");

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5700-telenor.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5700-telenor.dts
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	model = "ZyXEL EX5700 (Telenor)";
+	compatible = "zyxel,ex5700-telenor", "mediatek,mt7986a";
+
+	aliases {
+		serial0 = &uart0;
+		ethernet0 = &gmac0;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_amber;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+
+		// Stock U-Boot crashes unless /chosen/bootargs exists
+		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8";
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x40000000>;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+
+	keys {
+		compatible = "gpio-keys";
+		poll-interval = <20>;
+
+		reset-button {
+			label = "reset";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps-button {
+			label = "wps";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		red1 {
+			label = "red:net";
+			gpios = <&pio 23 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		green1 {
+			label = "green:net";
+			gpios = <&pio 25 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		amber1 {
+			label = "amber:net";
+			gpios = <&pio 29 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		white2 {
+			label = "white:status";
+			gpios = <&pio 16 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		red2 {
+			label = "red:status";
+			gpios = <&pio 17 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		led_status_green: green2 {
+			label = "green:status";
+			gpios = <&pio 31 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		led_status_amber: amber2 {
+			label = "amber:status";
+			gpios = <&pio 18 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+	};
+
+};
+
+&eth {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_pins>;
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		label = "wan";
+		phy-mode = "2500base-x";
+		phy-handle = <&phy6>;
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+};
+
+&mdio {
+	reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <50000>;
+	reset-post-delay-us = <20000>;
+
+	phy5: phy@5 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <5>;
+	};
+
+	phy6: phy@6 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <6>;
+	};
+
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan3";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan1";
+		};
+
+		port@5 {
+			reg = <5>;
+			label = "lan4";
+			phy-mode = "2500base-x";
+			phy-handle = <&phy5>;
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&pcie {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie_pins>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			mediatek,mtd-eeprom = <&factory 0xa0000>;
+		};
+	};
+};
+
+&pcie_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_5g_pins>;
+
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};
+
+&pio {
+	eth_pins: eth-pins {
+		mux {
+			function = "eth";
+			groups = "switch_int", "mdc_mdio";
+		};
+	};
+
+	pcie_pins: pcie-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie_pereset"; // "pcie_clk" and "pcie_wake" is unused?
+		};
+	};
+
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <8>;
+			mediatek,pull-down-adv = <0>; /* bias-disable */
+		};
+	};
+
+	wf_5g_pins: wf_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_5g";
+		};
+		conf {
+			pins = "WF1_HB1", "WF1_HB2", "WF1_HB3", "WF1_HB4",
+			       "WF1_HB0", "WF1_HB5", "WF1_HB6", "WF1_HB7",
+			       "WF1_HB8", "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <4>;
+		};
+	};
+
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	cs-gpios = <0>, <0>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+	};
+
+	flash@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		spi-max-frequency = <20000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x000000 0x100000>;
+				read-only;
+			};
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+			};
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x1da80000>;
+			};
+		};
+	};
+};
+
+&ssusb {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_5v>;
+	status = "okay";
+};
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/init.d/bootcount
+++ b/target/linux/mediatek/filogic/base-files/etc/init.d/bootcount
@@ -1,0 +1,12 @@
+#!/bin/sh /etc/rc.common
+# SPDX-License-Identifier: GPL-2.0-only
+
+START=99
+
+boot() {
+	case $(board_name) in
+	zyxel,ex5700-telenor)
+		fw_setenv uboot_bootcount 0
+		;;
+	esac
+}

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/04_set_netdev_label
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/04_set_netdev_label
@@ -1,0 +1,15 @@
+set_netdev_labels() {
+	local dir
+	local label
+	local netdev
+
+	for dir in /sys/class/net/*; do
+		[ -r "$dir/of_node/label" ] || continue
+		label="$(cat "$dir/of_node/label")"
+		netdev="$(basename $dir)"
+		[ "$netdev" = "$label" ] && continue
+		ip link set "$netdev" name "$label"
+	done
+}
+
+boot_hook_add preinit_main set_netdev_labels

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -509,6 +509,20 @@ define Device/zyxel_ex5601-t0-stock
 endef
 TARGET_DEVICES += zyxel_ex5601-t0-stock
 
+define Device/zyxel_ex5700-telenor
+  DEVICE_VENDOR := ZyXEL
+  DEVICE_MODEL := EX5700 (Telenor)
+  DEVICE_DTS := mt7986a-zyxel-ex5700-telenor
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7916-firmware kmod-ubootenv-nvram kmod-usb3 kmod-mt7986-firmware mt7986-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += zyxel_ex5700-telenor
+
 define Device/zyxel_nwa50ax-pro
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := NWA50AX Pro


### PR DESCRIPTION
Add support for the Telenor branded version of the ZyXEL EX5700. This comes with a modified U-Boot requiring device specific workarounds.
