### PR TITLE
ipq40xx: Linksys MR8300: fix the USB port power

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-xx8300.dtsi
@@ -112,6 +112,16 @@
 			status = "okay";
 		};
 	};
+
+	regulator-usb-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "USB_VBUS";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+		regulator-boot-on;
+		gpio = <&tlmm 68 GPIO_ACTIVE_LOW>;
+	};
 };
 
 
@@ -280,7 +290,7 @@
 			pins =  "gpio55", "gpio56", "gpio57",
 				"gpio60", "gpio62", "gpio63",
 				"gpio64", "gpio65", "gpio66",
-				"gpio67", "gpio68", "gpio69";
+				"gpio67", "gpio69";
 			function = "qpic";
 			bias-pull-down;
 		};


### PR DESCRIPTION
The USB port on the MR8300 randomly fails to feed bus-powered devices.

This is caused by a misconfigured pinmux. The GPIO68 should be used to enable the USB power (active low), but it's inside the NAND pinmux.

This GPIO pin was found in the original firmware at a startup script in both MR8300 and EA8300. Therefore apply the fix for both boards.


Reviewed-by: Robert Marko <robimarko@gmail.com>
(cherry picked from commit ed64c3323590e3c9fa8b423bf37689023a7a101f)
Signed-off-by: Steffen Scheib <steffen@scheib.me>
