### PR TITLE
libtraceevent: update to 1.7.2

### DIFF
--- a/package/libs/libtraceevent/Makefile
+++ b/package/libs/libtraceevent/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtraceevent
-PKG_VERSION:=1.7.1
+PKG_VERSION:=1.7.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/snapshot/
-PKG_HASH:=17b7131c106793c3b45477445bd32d295170c4245ed8348e03c17296e53009e1
+PKG_HASH:=a8b4bf8f05c06d1d6405f6d0038467a87e7ab218f0d8b0608d08bca5d1fc112a
 
 PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
 


### PR DESCRIPTION
Changes:
1c6f0f3 libtraceevent: version 1.7.2
73f6a8a libtraceevent: Fix some missing commas in big endian blocks da2ea6b libtraceevent: Rename "ok" to "token_has_paren" in process_sizeof() e6f7cfa libtraceevent: No need for testing ok in else if (!ok) in process_sizeof() a4b1ba5 libtraceevent: Fix double free in parsing sizeof()
