### PR TITLE
mediatek: fix asus_tuf-ax4200

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -44,7 +44,7 @@ define Device/asus_tuf-ax4200
   DEVICE_DTS := mt7986a-asus-tuf-ax4200
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTS_LOADADDR := 0x47000000
-  DEVICE_PACKAGES := kmod-usb3
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7986-firmware mt7986-wo-firmware
   IMAGES := sysupgrade.bin
   KERNEL_LOADADDR := 0x48000000
   KERNEL = kernel-bin | lzma | \


### PR DESCRIPTION
This fixes commit https://github.com/openwrt/openwrt/commit/d98c4fb8bfabe86d4cfdb8bb5497ec6791d1e36d

That commit modified the filogic target but forgot to include the modifications for this new device.
