### PR TITLE
dropbear: add BlankPasswordLogin uci option

### DIFF
--- a/package/network/services/dropbear/files/dropbear.init
+++ b/package/network/services/dropbear/files/dropbear.init
@@ -119,6 +119,7 @@ validate_section_dropbear()
 		'enable:bool:1' \
 		'Interface:string' \
 		'GatewayPorts:bool:0' \
+		'BlankPasswordLogin:bool:0' \
 		'RootPasswordAuth:bool:1' \
 		'RootLogin:bool:1' \
 		'rsakeyfile:file' \
@@ -158,6 +159,7 @@ dropbear_instance()
 	procd_set_param command "$PROG" -F -P "$pid_file"
 	[ "${PasswordAuth}" -eq 0 ] && procd_append_param command -s
 	[ "${GatewayPorts}" -eq 1 ] && procd_append_param command -a
+	[ "${BlankPasswordLogin}" -eq 1 ] && procd_append_param command -B
 	[ "${RootPasswordAuth}" -eq 0 ] && procd_append_param command -g
 	[ "${RootLogin}" -eq 0 ] && procd_append_param command -w
 	if [ -n "${rsakeyfile}" ]; then


### PR DESCRIPTION
This commit adds "BlankPasswordLogin" option, which let non-root users login with a blank password and the default behavior is off.