### PR TITLE
Added random_numgen to functions.sh

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -433,4 +433,9 @@ cmdline_get_var() {
 	done
 }
 
+# generate a random number between 0 and 32767, alternative to $RANDOM
+random_numgen() {
+	echo $(( $(hexdump -n 2 -e '"%u"' /dev/urandom) >> 1 ))
+}
+
 [ -z "$IPKG_INSTROOT" ] && [ -f /lib/config/uci.sh ] && . /lib/config/uci.sh


### PR DESCRIPTION
The same function has been proposed as a standalone package in https://github.com/openwrt/packages/pull/20728 and, following @1715173329's suggestion on https://github.com/openwrt/packages/pull/20728#issuecomment-1489085725 it has been proposed here as a function inside `package/base-files/files/lib/functions.sh`.

The reason for having this is for avoiding to use $RANDOM in LibreMesh.
If we use $RANDOM, we have to select `BUSYBOX_CONFIG_ASH_RANDOM_SUPPORT` which is not selected by default, and we cannot use the unmodified OpenWrt's ImageBuilder.

See the original discussion on https://github.com/libremesh/lime-packages/issues/800.