### PR TITLE
[22.03] ramips: mt7621: backport commits for Asus RT-AX53U

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -47,6 +47,7 @@ ravpower,rp-wd03)
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x4000" "0x1000" "0x1000"
 	;;
+asus,rt-ax53u|\
 jcg,q20|\
 netgear,wax202)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"

--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -63,6 +63,11 @@
 &nand {
 	status = "okay";
 
+	mediatek,nmbm;
+	mediatek,bmt-remap-range =
+		<0x000000 0x7e0000>,
+		<0x35e0000 0x7800000>;
+
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -110,13 +115,22 @@
 		};
 
 		partition@3e0000 {
-			label = "kernel";
-			reg = <0x3e0000 0x400000>;
-		};
+			label = "firmware";
+			reg = <0x3e0000 0x3200000>;
 
-		partition@7e0000 {
-			label = "ubi";
-			reg = <0x7e0000 0x2e00000>;
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x2e00000>;
+			};
 		};
 
 		partition@35e0000 {
@@ -124,7 +138,12 @@
 			reg = <0x35e0000 0x3200000>;
 		};
 
-		/* Last 8M possibly store the bad block table */
+		partition@67e0000 {
+			label = "jffs2";
+			reg = <0x67e0000 0x1020000>;
+		};
+
+		/* Last 8M are reserved for NMBM management (bad blocks) */
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -60,12 +60,21 @@
 
 		partition@0 {
 			label = "u-boot";
-			reg = <0x0 0xe0000>;
+			reg = <0x0 0x80000>;
 			read-only;
 		};
 
-		partition@e0000 {
+		/*
+		 * u-boot gets split here while keeping u-boot read-only,
+		 * which allows safe usage of fw_setenv
+		 */
+		partition@80000 {
 			label = "u-boot-env";
+			reg = <0x80000 0x60000>;
+		};
+
+		partition@e0000 {
+			label = "nvram";
 			reg = <0xe0000 0x100000>;
 			read-only;
 		};

--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -26,10 +26,20 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_power: led-0 {
+		led_power: power {
+			label = "blue:power";
 			color = <LED_COLOR_ID_BLUE>;
-                        function = LED_FUNCTION_POWER;
+			function = LED_FUNCTION_POWER;
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_usb {
+			label = "blue:usb";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_USB;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ehci_port2>;
+			linux,default-trigger = "usbport";
 		};
 	};
 

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -241,6 +241,8 @@ define Device/asus_rt-ax53u
   $(Device/dsa-migration)
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-AX53U
+  DEVICE_ALT0_VENDOR := ASUS
+  DEVICE_ALT0_MODEL := RT-AX1800U
   IMAGE_SIZE := 51200k
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -250,7 +250,8 @@ define Device/asus_rt-ax53u
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
-  DEVICE_PACKAGES := kmod-mt7915e kmod-usb3 uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915e kmod-usb3 uboot-envtools \
+	kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += asus_rt-ax53u
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -7,6 +7,11 @@ board=$(board_name)
 board_config_update
 
 case $board in
+asus,rt-ax53u)
+	ucidef_set_led_usbport "usb" "USB" "blue:usb" "usb1-port2"
+	ucidef_set_led_wlan "wlan2g" "WiFi 2.4GHz" "mt76-phy0" "phy0tpt"
+	ucidef_set_led_wlan "wlan5g" "WiFi 5GHz" "mt76-phy1" "phy1tpt"
+	;;
 asus,rt-n56u-b1)
 	ucidef_set_led_netdev "lan" "LAN link" "blue:lan" "br-lan"
 	ucidef_set_led_netdev "wan" "WAN link" "blue:wan" "wan"


### PR DESCRIPTION
This backports the last fixes concerning the Asus RT-AX53U to the 22 branch.
WiFi LEDs won't work, yet. They require the WiFi driver MT76 to be updated to include https://github.com/openwrt/mt76/commit/679254c50f279fe4f1e3ae1fb943f0d1ecdac4ab