### PR TITLE
[22.03][draft] kernel: add support for XMC XM25QH64C

### DIFF
--- a/target/linux/generic/pending-5.10/488-mtd-spi-nor-add-xmc-xm25qh64c.patch
+++ b/target/linux/generic/pending-5.10/488-mtd-spi-nor-add-xmc-xm25qh64c.patch
@@ -1,0 +1,22 @@
+From: Joe Mullally <jwmullally@gmail.com>
+Subject: mtd/spi-nor/xmc: add support for XMC XM25QH64C
+
+The XMC XM25QH64C is a 8MB SPI NOR chip. The patch is verified on TL-WPA8631P v3.
+Datasheet available at https://www.xmcwh.com/uploads/442/XM25QH64C.pdf
+
+Signed-off-by: Joe Mullally <jwmullally@gmail.com>
+---
+ drivers/mtd/spi-nor/xmc.c                             | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/mtd/spi-nor/xmc.c
++++ b/drivers/mtd/spi-nor/xmc.c
+@@ -12,6 +12,8 @@ static const struct flash_info xmc_parts
+ 	/* XMC (Wuhan Xinxin Semiconductor Manufacturing Corp.) */
+ 	{ "XM25QH64A", INFO(0x207017, 0, 64 * 1024, 128,
+ 			    SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++	{ "XM25QH64C", INFO(0x204017, 0, 64 * 1024, 128,
++			    SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ "XM25QH128A", INFO(0x207018, 0, 64 * 1024, 256,
+ 			     SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ "XM25QH128C", INFO(0x204018, 0, 64 * 1024, 256,


### PR DESCRIPTION
The XMC XM25QH64C is a 8MB SPI NOR chip. The patch is verified on TL-WPA8631P v3. Datasheet available at https://www.xmcwh.com/uploads/442/XM25QH64C.pdf

---

22.03 backport of pending PR https://github.com/openwrt/openwrt/pull/12207