### PR TITLE
bmips: add support for Sercomm SHG2500

### DIFF
--- a/target/linux/bmips/dts/bcm63168-sercomm-shg2500.dts
+++ b/target/linux/bmips/dts/bcm63168-sercomm-shg2500.dts
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm63268.dtsi"
+
+/ {
+	model = "Sercomm SHG2500";
+	compatible = "sercomm,shg2500", "brcm,bcm63168", "brcm,bcm63268";
+
+	i2c {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio 14 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio 9 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cferom_6a0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio_int {
+	phy12: ethernet-phy@c {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <12>;
+	};
+};
+
+&mdio_ext {
+	switch@1e {
+		compatible = "brcm,bcm53125";
+		reg = <30>;
+
+		dsa,member = <1 0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@1 {
+				reg = <1>;
+				label = "lan1";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan3";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "lan4";
+			};
+
+			port@8 {
+				reg = <8>;
+
+				phy-mode = "rgmii";
+				ethernet = <&switch0port4>;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};
+
+&nflash {
+	status = "okay";
+
+	nandcs@0 {
+		compatible = "brcm,nandcs";
+		reg = <0>;
+		nand-ecc-step-size = <512>;
+		nand-ecc-strength = <15>;
+		nand-on-flash-bbt;
+		brcm,nand-oob-sector-size = <64>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cferom: partition@0 {
+				label = "cferom";
+				reg = <0x0000000 0x0020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "part_map";
+				reg = <0x0020000 0x00a0000>;
+				read-only;
+			};
+
+			partition@c0000 {
+				label = "cferam1";
+				reg = <0x00c0000 0x0140000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "cferam2";
+				reg = <0x0200000 0x0140000>;
+				read-only;
+			};
+
+			artition@6920000 {
+				label = "bootflag1";
+				reg = <0x6920000 0x0140000>;
+			};
+
+			partition@6a60000 {
+				label = "bootflag2";
+				reg = <0x6a60000 0x0140000>;
+			};
+
+			partition@520000 {
+				compatible = "sercomm,wfi";
+				label = "wfi";
+				reg = <0x0520000 0x6400000>;
+			};
+
+			partition@6ba0000 {
+				label = "xml_cfg";
+				reg = <0x6ba0000 0x0280000>;
+				read-only;
+			};
+
+			partition@6e20000 {
+				label = "app_data";
+				reg = <0x6e20000 0x0280000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pinctrl {
+	pinctrl_uart1: uart1-pins {
+		pinctrl_uart1_sdin: uart1_sdin {
+			function = "uart1_sdin";
+			pins = "gpio12";
+		};
+
+		pinctrl_uart1_sdout: uart1_sdout {
+			function = "uart1_sdout";
+			pins = "gpio13";
+		};
+	};
+};
+
+&switch0 {
+	dsa,member = <0 0>;
+
+	ports {
+		port@3 {
+			reg = <3>;
+			label = "wan";
+
+			phy-handle = <&phy12>;
+			phy-mode = "gmii";
+		};
+
+		switch0port4: port@4 {
+			reg = <4>;
+			label = "extsw";
+
+			phy-mode = "rgmii";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart1>;
+};
+
+&usbh {
+	status = "okay";
+};
+
+&cferom {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_cferom_6a0: macaddr@6a0 {
+		reg = <0x6a0 0x6>;
+	};
+};

--- a/target/linux/bmips/image/bcm63xx_nand.mk
+++ b/target/linux/bmips/image/bcm63xx_nand.mk
@@ -154,3 +154,29 @@ define Device/sercomm_h500-s-vfes
   SERCOMM_VERSION := 1001
 endef
 TARGET_DEVICES += sercomm_h500-s-vfes
+
+define Device/sercomm_shg2500
+  $(Device/sercomm-nand)
+  DEVICE_VENDOR := Sercomm
+  DEVICE_MODEL := SHG2500
+  DEVICE_LOADADDR := $(KERNEL_LOADADDR)
+  KERNEL := kernel-bin | append-dtb | lzma | cfe-jffs2-kernel
+  CHIP_ID := 63268
+  SOC := bcm63168
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  SUBPAGESIZE := 512
+  VID_HDR_OFFSET := 2048
+  DEVICE_PACKAGES += $(USB2_PACKAGES) kmod-i2c-gpio
+  SERCOMM_PID := \
+    30 30 30 30 30 30 30 31 34 32 34 65 34 61 30 30 \
+    30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 \
+    30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 \
+    30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 \
+    30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 \
+    30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 \
+    30 30 30 30 33 32 30 37 30 30 30 30 30 30 30 30 \
+    0D 0A 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  SERCOMM_VERSION := 1001
+endef
+TARGET_DEVICES += sercomm_shg2500

--- a/target/linux/bmips/nand/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/nand/base-files/etc/board.d/02_network
@@ -10,7 +10,8 @@ comtrend,vr-3032u)
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 	;;
 huawei,hg253s-v2 |\
-netgear,dgnd3700-v2)
+netgear,dgnd3700-v2 |\
+sercomm,shg2500)
 	ucidef_set_bridge_device switch
 	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 	;;


### PR DESCRIPTION
Sercomm SHG2500 is a BCM63168 with 128M of RAM, 256M of NAND, an external BCM53124S switch for the LAN ports and internal/external Broadcom wifi.