### PR TITLE
bmips: bcm6362/bcm63268: enable HW RNG

### DIFF
--- a/target/linux/bmips/dts/bcm63268.dtsi
+++ b/target/linux/bmips/dts/bcm63268.dtsi
@@ -443,6 +443,18 @@
 			status = "disabled";
 		};
 
+		random: rng@10002880 {
+			compatible = "brcm,bcm6368-rng";
+			reg = <0x10002880 0x14>;
+
+			clocks = <&periph_clk BCM63268_CLK_IPSEC>;
+			clock-names = "ipsec";
+
+			resets = <&periph_rst BCM63268_RST_IPSEC>;
+
+			power-domains = <&periph_pwr BCM63268_POWER_DOMAIN_IPSEC>;
+		};
+
 		ethernet: ethernet@1000d800 {
 			compatible = "brcm,bcm63268-enetsw";
 			reg = <0x1000d800 0x80>,

--- a/target/linux/bmips/dts/bcm6362.dtsi
+++ b/target/linux/bmips/dts/bcm6362.dtsi
@@ -476,6 +476,18 @@
 			status = "disabled";
 		};
 
+		random: rng@10002880 {
+			compatible = "brcm,bcm6368-rng";
+			reg = <0x10002880 0x14>;
+
+			clocks = <&periph_clk BCM6362_CLK_IPSEC>;
+			clock-names = "ipsec";
+
+			resets = <&periph_rst BCM6362_RST_IPSEC>;
+
+			power-domains = <&periph_pwr BCM6362_POWER_DOMAIN_IPSEC>;
+		};
+
 		ethernet: ethernet@1000d800 {
 			compatible = "brcm,bcm6362-enetsw";
 			reg = <0x1000d800 0x80>,


### PR DESCRIPTION
This enables the HW Random Number Generator on the BCM6362 and BCM63268 SoCs, which is the same one used on BCM6368 SoC.