### PR TITLE
mac80211: Backport pre_rcu_remove fix to 22.03.x

### DIFF
--- a/package/kernel/mac80211/patches/subsys/352-wifi-mac80211-fix-invalid-drv_sta_pre_rcu_remove-cal.patch
+++ b/package/kernel/mac80211/patches/subsys/352-wifi-mac80211-fix-invalid-drv_sta_pre_rcu_remove-cal.patch
@@ -1,0 +1,25 @@
+From: Felix Fietkau <nbd@nbd.name>
+Date: Fri, 24 Mar 2023 13:04:17 +0100
+Subject: [PATCH] wifi: mac80211: fix invalid drv_sta_pre_rcu_remove calls for
+ non-uploaded sta
+
+Avoid potential data corruption issues caused by uninitialized driver
+private data structures.
+
+Reported-by: Brian Coverstone <brian@mainsequence.net>
+Fixes: 6a9d1b91f34d ("mac80211: add pre-RCU-sync sta removal driver operation")
+Signed-off-by: Felix Fietkau <nbd@nbd.name>
+---
+
+--- a/net/mac80211/sta_info.c
++++ b/net/mac80211/sta_info.c
+@@ -1041,7 +1041,8 @@ static int __must_check __sta_info_destr
+ 	list_del_rcu(&sta->list);
+ 	sta->removed = true;
+ 
+-	drv_sta_pre_rcu_remove(local, sta->sdata, sta);
++	if (sta->uploaded)
++		drv_sta_pre_rcu_remove(local, sta->sdata, sta);
+ 
+ 	if (sdata->vif.type == NL80211_IFTYPE_AP_VLAN &&
+ 	    rcu_access_pointer(sdata->u.vlan.sta) == sta)


### PR DESCRIPTION
Backport of commit 9779ee0 to fix the invalid drv_sta_pre_rcu_remove call in mac80211.

This patch is simply a copy of the one @nbd168 appled to master moved into the appropriate place and refreshed to correct line numbers when applied against kernel 5.10.x.