### PR TITLE
base-files: fix Linksys upgrade, restore config step

### DIFF
--- a/target/linux/ipq40xx/base-files/lib/upgrade/linksys.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/linksys.sh
@@ -103,7 +103,7 @@ platform_do_upgrade_linksys() {
 		if nand_upgrade_tar "$1" ; then
 			nand_do_upgrade_success
 		else
-			nand_do_upgrade_failure
+			nand_do_upgrade_failed
 		fi
 
 	}

--- a/target/linux/ipq806x/base-files/lib/upgrade/linksys.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/linksys.sh
@@ -97,7 +97,7 @@ platform_do_upgrade_linksys() {
 		if nand_upgrade_tar "$1" ; then
 			nand_do_upgrade_success
 		else
-			nand_do_upgrade_failure
+			nand_do_upgrade_failed
 		fi
 
 	}

--- a/target/linux/kirkwood/base-files/lib/upgrade/linksys.sh
+++ b/target/linux/kirkwood/base-files/lib/upgrade/linksys.sh
@@ -68,7 +68,12 @@ platform_do_upgrade_linksys() {
 			CI_UBIPART="rootfs2"
 		fi
 
-		nand_upgrade_tar "$1"
+		if nand_upgrade_tar "$1" ; then
+			nand_do_upgrade_success
+		else
+			nand_do_upgrade_failed
+		fi
+
 	}
 	[ "$magic_long" = "27051956" ] && {
 		get_image "$1" | mtd write - $part_label

--- a/target/linux/mvebu/cortexa9/base-files/lib/upgrade/linksys.sh
+++ b/target/linux/mvebu/cortexa9/base-files/lib/upgrade/linksys.sh
@@ -68,7 +68,12 @@ platform_do_upgrade_linksys() {
 			CI_UBIPART="rootfs2"
 		fi
 
-		nand_upgrade_tar "$1"
+		if nand_upgrade_tar "$1" ; then
+			nand_do_upgrade_success
+		else
+			nand_do_upgrade_failed
+		fi
+
 	}
 	[ "$magic_long" = "27051956" -o "$magic_long" = "0000a0e1" ] && {
 		get_image "$1" | mtd write - $part_label


### PR DESCRIPTION
It appears that the refactor of the upgrade process for NAND devices resulted in the nand_do_upgrade_success step not being called for devices using the linksys.sh script. As a result, configuration was not preserved over sysupgrade steps.

This restores the preservation of configs for kirkwood, and mvebu/cortexa9 devices and fixes an error in ipq40xx and ipq806x, using the linksys.sh script.

Fixes: e25e6d8
Fixes: #12298
Fixes: 8634c1080d5033e8cf0069ee7447821726232b95
Fixes: 2715aff5df836c1d3eb8cbf5afdb0c197902ee4b

Signed-off-by: Michael Trinidad <trinidude4@hotmail.com>