### PR TITLE
ramips: tplink,mr600v2: fix image generation for sysupgrade image

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2193,6 +2193,9 @@ define Device/tplink_mr600-v2-eu
   TPLINK_FLASHLAYOUT := 16Mltq
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
 		kmod-usb-net-qmi-wwan uqmi kmod-usb3 -uboot-envtools
+  IMAGE/factory.bin := tplink-v2-image -e -a 0x10000
+  IMAGE/sysupgrade.bin := tplink-v2-image -s -e -a 0x10000 | check-size | \
+	append-metadata
   KERNEL := $(KERNEL_DTB) | uImage lzma
   KERNEL_INITRAMFS := $$(KERNEL) | tplink-v2-header
   TPLINK_BOARD_ID := MR600-V2-EU


### PR DESCRIPTION
The MR600v2 does not find its rootfs if it is neither directly after the kernel or aligned to an erase block boundary (64k).

This aligns the rootfs to 0x10000 allowing the device to boot again. Based on investigation by forum user relghuar.

Relevant forum thread: https://forum.openwrt.org/t/tp-link-archer-mr600-exploration/65489/50
