### PR TITLE
wolfssl: update to 5.6.3

### DIFF
--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wolfssl
-PKG_VERSION:=5.5.4-stable
-PKG_RELEASE:=4
+PKG_VERSION:=5.6.3-stable
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/wolfSSL/wolfssl/archive/v$(PKG_VERSION)
-PKG_HASH:=b7ee150e49def77c765bc02aac92ddeb0bebefd4cb12aa263d8f95e405221fb8
+PKG_HASH:=2e74a397fa797c2902d7467d500de904907666afb4ff80f6464f6efd5afb114a
 
 PKG_FIXUP:=libtool libtool-abiver
 PKG_INSTALL:=1

--- a/package/libs/wolfssl/patches/001-fix-detection-of-cut-tool-in-configure.ac.patch
+++ b/package/libs/wolfssl/patches/001-fix-detection-of-cut-tool-in-configure.ac.patch
@@ -1,0 +1,25 @@
+From 41d248461bd9ad44193a4806ecb5361513e8944e Mon Sep 17 00:00:00 2001
+From: jordan <jordan@wolfssl.com>
+Date: Tue, 27 Jun 2023 13:18:25 -0500
+Subject: [PATCH] fix detection of cut tool in configure.ac
+
+---
+ configure.ac | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -8723,10 +8723,11 @@ echo "extern \"C\" {" >> $OPTION_FILE
+ echo "#endif" >> $OPTION_FILE
+ echo "" >> $OPTION_FILE
+ 
+-# check for supported command to trim option with
++# Check for supported command to trim option with.
++# note: cut requires an argument to exit with success.
+ if colrm >/dev/null 2>&1 </dev/null; then
+     TRIM="colrm 3"
+-elif cut >/dev/null 2>&1 </dev/null; then
++elif cut --version >/dev/null 2>&1 </dev/null; then
+     TRIM="cut -c1-2"
+ else
+     AC_MSG_ERROR([Could not find colrm or cut to make options file])

--- a/package/libs/wolfssl/patches/100-disable-hardening-check.patch
+++ b/package/libs/wolfssl/patches/100-disable-hardening-check.patch
@@ -1,10 +1,10 @@
 --- a/wolfssl/wolfcrypt/settings.h
 +++ b/wolfssl/wolfcrypt/settings.h
-@@ -2496,7 +2496,7 @@ extern void uITRON4_free(void *p) ;
- #endif
+@@ -2630,7 +2630,7 @@ extern void uITRON4_free(void *p) ;
  
  /* warning for not using harden build options (default with ./configure) */
--#ifndef WC_NO_HARDEN
+ /* do not warn if big integer support is disabled */
+-#if !defined(WC_NO_HARDEN) && !defined(NO_BIG_INT)
 +#if 0
      #if (defined(USE_FAST_MATH) && !defined(TFM_TIMING_RESISTANT)) || \
          (defined(HAVE_ECC) && !defined(ECC_TIMING_RESISTANT)) || \


### PR DESCRIPTION
Release Notes:
https://github.com/wolfSSL/wolfssl/releases/tag/v5.6.0-stable

Refresh patch:
- 100-disable-hardening-check.patch
