### PR TITLE
generic: better support RealTek 2.5G PHYs

### DIFF
--- a/target/linux/generic/pending-5.15/722-net-phy-realtek-support-switching-between-SGMII-and-.patch
+++ b/target/linux/generic/pending-5.15/722-net-phy-realtek-support-switching-between-SGMII-and-.patch
@@ -1,0 +1,61 @@
+From 312753d0aadba0f58841ae513b80fdbabc887523 Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Wed, 8 Feb 2023 16:32:18 +0800
+Subject: [PATCH] net: phy: realtek: support switching between SGMII and
+ 2500BASE-X for RTL822x series
+
+After commit ace6aba ("net: phy: realtek: rtl8221: allow to configure
+SERDES mode"), the rtl8221 phy can work in SGMII and 2500base-x modes
+respectively. So add interface automatic switching for rtl8221 phy to
+match various wire speeds.
+
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+---
+ drivers/net/phy/realtek.c | 26 ++++++++++++++++++++++++--
+ 1 file changed, 24 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/phy/realtek.c
++++ b/drivers/net/phy/realtek.c
+@@ -676,6 +676,25 @@ static int rtl822x_config_aneg(struct ph
+ 	return __genphy_config_aneg(phydev, ret);
+ }
+ 
++static void rtl822x_update_interface(struct phy_device *phydev)
++{
++	/* Automatically switch SERDES interface between
++	 * SGMII and 2500-BaseX according to speed.
++	 */
++	switch (phydev->speed) {
++	case SPEED_2500:
++		phydev->interface = PHY_INTERFACE_MODE_2500BASEX;
++		break;
++	case SPEED_1000:
++	case SPEED_100:
++	case SPEED_10:
++		phydev->interface = PHY_INTERFACE_MODE_SGMII;
++		break;
++	default:
++		break;
++	}
++}
++
+ static int rtl822x_read_status(struct phy_device *phydev)
+ {
+ 	int ret;
+@@ -694,11 +713,14 @@ static int rtl822x_read_status(struct ph
+ 			phydev->lp_advertising, lpadv & RTL_LPADV_2500FULL);
+ 	}
+ 
+-	ret = genphy_read_status(phydev);
++	ret = rtlgen_read_status(phydev);
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	return rtlgen_get_speed(phydev);
++	if (phydev->link)
++		rtl822x_update_interface(phydev);
++
++	return 0;
+ }
+ 
+ static bool rtlgen_supports_2_5gbps(struct phy_device *phydev)

--- a/target/linux/generic/pending-5.15/724-net-phy-realtek-use-genphy_soft_reset-for-2.5G-PHYs.patch
+++ b/target/linux/generic/pending-5.15/724-net-phy-realtek-use-genphy_soft_reset-for-2.5G-PHYs.patch
@@ -1,0 +1,65 @@
+From 85cd45580f5e3b26068cccb7d6173f200e754dc0 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sun, 2 Apr 2023 23:56:16 +0100
+Subject: [PATCH 1/2] net: phy: realtek: use genphy_soft_reset for 2.5G PHYs
+
+Some vendor bootloaders do weird things with those PHYs which result in
+link modes being reported wrongly. Start from a clean sheet by resetting
+the PHY.
+
+Reported-by: Yevhen Kolomeiko <jarvis2709@gmail.com>
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ drivers/net/phy/realtek.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/drivers/net/phy/realtek.c
++++ b/drivers/net/phy/realtek.c
+@@ -1013,6 +1013,7 @@ static struct phy_driver realtek_drvs[]
+ 		.write_page	= rtl821x_write_page,
+ 		.read_mmd	= rtl822x_read_mmd,
+ 		.write_mmd	= rtl822x_write_mmd,
++		.soft_reset     = genphy_soft_reset,
+ 	}, {
+ 		PHY_ID_MATCH_EXACT(0x001cc840),
+ 		.name		= "RTL8226B_RTL8221B 2.5Gbps PHY",
+@@ -1025,6 +1026,7 @@ static struct phy_driver realtek_drvs[]
+ 		.write_page	= rtl821x_write_page,
+ 		.read_mmd	= rtl822x_read_mmd,
+ 		.write_mmd	= rtl822x_write_mmd,
++		.soft_reset     = genphy_soft_reset,
+ 	}, {
+ 		PHY_ID_MATCH_EXACT(0x001cc838),
+ 		.name           = "RTL8226-CG 2.5Gbps PHY",
+@@ -1035,6 +1037,7 @@ static struct phy_driver realtek_drvs[]
+ 		.resume         = rtlgen_resume,
+ 		.read_page      = rtl821x_read_page,
+ 		.write_page     = rtl821x_write_page,
++		.soft_reset     = genphy_soft_reset,
+ 	}, {
+ 		PHY_ID_MATCH_EXACT(0x001cc848),
+ 		.name           = "RTL8226B-CG_RTL8221B-CG 2.5Gbps PHY",
+@@ -1045,6 +1048,7 @@ static struct phy_driver realtek_drvs[]
+ 		.resume         = rtlgen_resume,
+ 		.read_page      = rtl821x_read_page,
+ 		.write_page     = rtl821x_write_page,
++		.soft_reset     = genphy_soft_reset,
+ 	}, {
+ 		PHY_ID_MATCH_EXACT(0x001cc849),
+ 		.name           = "RTL8221B-VB-CG 2.5Gbps PHY",
+@@ -1056,6 +1060,7 @@ static struct phy_driver realtek_drvs[]
+ 		.resume         = rtlgen_resume,
+ 		.read_page      = rtl821x_read_page,
+ 		.write_page     = rtl821x_write_page,
++		.soft_reset     = genphy_soft_reset,
+ 	}, {
+ 		PHY_ID_MATCH_EXACT(0x001cc84a),
+ 		.name           = "RTL8221B-VM-CG 2.5Gbps PHY",
+@@ -1067,6 +1072,7 @@ static struct phy_driver realtek_drvs[]
+ 		.resume         = rtlgen_resume,
+ 		.read_page      = rtl821x_read_page,
+ 		.write_page     = rtl821x_write_page,
++		.soft_reset     = genphy_soft_reset,
+ 	}, {
+ 		PHY_ID_MATCH_EXACT(0x001cc961),
+ 		.name		= "RTL8366RB Gigabit Ethernet",

--- a/target/linux/generic/pending-5.15/725-net-phy-realtek-disable-SGMII-in-band-AN-for-2-5G-PHYs.patch
+++ b/target/linux/generic/pending-5.15/725-net-phy-realtek-disable-SGMII-in-band-AN-for-2-5G-PHYs.patch
@@ -1,0 +1,43 @@
+From 2b1b8c4c215af7988136401c902338d091d408a1 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Mon, 3 Apr 2023 01:21:57 +0300
+Subject: [PATCH 2/2] net: phy: realtek: disable SGMII in-band AN for 2.5G PHYs
+
+MAC drivers don't use SGMII in-band autonegotiation unless told to do so
+in device tree using 'managed = "in-band-status"'. When using MDIO to
+access a PHY, in-band-status is unneeded as we have link-status via
+MDIO. Switch off SGMII in-band autonegotiation using magic values.
+
+Reported-by: Chen Minqiang <ptpt52@gmail.com>
+Reported-by: Chukun Pan <amadeus@jmu.edu.cn>
+Reported-by: Yevhen Kolomeiko <jarvis2709@gmail.com>
+Tested-by: Yevhen Kolomeiko <jarvis2709@gmail.com>
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ drivers/net/phy/realtek.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+--- a/drivers/net/phy/realtek.c
++++ b/drivers/net/phy/realtek.c
+@@ -875,6 +875,7 @@ static irqreturn_t rtl9000a_handle_inter
+ static int rtl8221b_config_init(struct phy_device *phydev)
+ {
+ 	u16 option_mode;
++	int val;
+ 
+ 	switch (phydev->interface) {
+ 	case PHY_INTERFACE_MODE_SGMII:
+@@ -906,6 +907,13 @@ static int rtl8221b_config_init(struct p
+                 break;
+ 	}
+ 
++	/* Disable SGMII AN */
++	phy_write_mmd(phydev, RTL8221B_MMD_SERDES_CTRL, 0x7588, 0x2);
++	phy_write_mmd(phydev, RTL8221B_MMD_SERDES_CTRL, 0x7589, 0x71d0);
++	phy_write_mmd(phydev, RTL8221B_MMD_SERDES_CTRL, 0x7587, 0x3);
++	phy_read_mmd_poll_timeout(phydev, RTL8221B_MMD_SERDES_CTRL, 0x7587, val,
++				  !(val & BIT(0)), 500, 100000, false);
++
+ 	return 0;
+ }
+ 


### PR DESCRIPTION
The RealTek RTL8221 and RTL8226 2.5G Ethernet PHYs have various issues with the current phy driver.
1. Instead of using rate-adaptation we should switch the MAC interface mode and follow the link speed of the twisted pair interface.
2. Vendor bootloaders tend to program the PHY to report weird interface modes, as observed on the Netgear WAX206. Reset the PHY using `genphy_soft_reset` to start of a clean sheet.
3. The PHY is expecting Cisco-style SGMII auto-negotiation by default while Linux MAC drivers use out-of-band status unless `managed = "in-band-status";` is specified in device tree. Use magic sequence to switch off in-band auto-negotiation of the PHY so SGMII link comes up and the MAC tracks the PHYs link speed as commonly done in Linux.

https://forum.openwrt.org/t/netgear-wax206-issue-wan-last-snapshot-r22459/156195

https://github.com/openwrt/openwrt/pull/12202#pullrequestreview-1347413996

@ptpt52  @aiamadeus