### PR TITLE
mediatek: filogic: rework 02_network setup

### DIFF
--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -12,15 +12,14 @@ mediatek_setup_interfaces()
 		CI_UBIPART="UBI_DEV"
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth1"
 		;;
+	bananapi,bpi-r3)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp2" "eth1 wan"
+		;;
 	mediatek,mt7986a-rfb)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan6" "eth1 wan"
 		;;
 	mediatek,mt7986b-rfb)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3" eth1
-		;;
-	bananapi,bpi-r3)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp2" "eth1 wan"
-		ucidef_set_interface_macaddr "wan" "$(macaddr_add $(cat /sys/class/net/eth0/address) 1)"
 		;;
 	xiaomi,redmi-router-ax6000-stock|\
 	xiaomi,redmi-router-ax6000-ubootmod)
@@ -45,6 +44,9 @@ mediatek_setup_macs()
 		addr=$(mtd_get_mac_binary_ubi "Factory" 0x4)
 		wan_mac="${addr}"
 		lan_mac="${addr}"
+		;;
+	bananapi,bpi-r3)
+		wan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)
 		;;
 	xiaomi,redmi-router-ax6000-stock|\
 	xiaomi,redmi-router-ax6000-ubootmod)

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -12,7 +12,9 @@ mediatek_setup_interfaces()
 		CI_UBIPART="UBI_DEV"
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth1"
 		;;
-	mediatek,mt7986a-rfb|\
+	mediatek,mt7986a-rfb)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan6" "eth1 wan"
+		;;
 	mediatek,mt7986b-rfb)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3" eth1
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -9,8 +9,7 @@ mediatek_setup_interfaces()
 
 	case $board in
 	asus,tuf-ax4200)
-		CI_UBIPART="UBI_DEV"
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth1"
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
 		;;
 	bananapi,bpi-r3)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp2" "eth1 wan"


### PR DESCRIPTION
- Remove redundant code for tuf-ax4200
- Fix network config for mt7986a/b-rfb
- Move the mac address setting together