### PR TITLE
[22.03][draft] ramips: TPLink RE305 v3: Lower spi-max-frequency 

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_re305-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re305-v3.dts
@@ -13,7 +13,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <50000000>;
+		spi-max-frequency = <10000000>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
Fix flash I/O instability observed in newer devices with cFeon QH64A-104HIP (detected as en25qh64).

This instability was no longer observed for this device on /master after 540377010532d9840ebe0778c2af991bd4b67052 "mediatek: add support for SPI calibration", so we don't need to adjust the speed there, just on 22.03.

---

Ref:
https://forum.openwrt.org/t/support-for-tp-link-re305-v3/75893/91