### PR TITLE
openssl: fix CVE-2023-464 and CVE-2023-465

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_VERSION:=3.0.8
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 PKG_BUILD_FLAGS:=no-mips16 gc-sections
 
 PKG_BUILD_PARALLEL:=1

--- a/package/libs/openssl/patches/200-x509-excessive-resource-use-verifying-policy-constra.patch
+++ b/package/libs/openssl/patches/200-x509-excessive-resource-use-verifying-policy-constra.patch
@@ -1,0 +1,207 @@
+From 959c59c7a0164117e7f8366466a32bb1f8d77ff1 Mon Sep 17 00:00:00 2001
+From: Pauli <pauli@openssl.org>
+Date: Wed, 8 Mar 2023 15:28:20 +1100
+Subject: [PATCH] x509: excessive resource use verifying policy constraints
+
+A security vulnerability has been identified in all supported versions
+of OpenSSL related to the verification of X.509 certificate chains
+that include policy constraints.  Attackers may be able to exploit this
+vulnerability by creating a malicious certificate chain that triggers
+exponential use of computational resources, leading to a denial-of-service
+(DoS) attack on affected systems.
+
+Fixes CVE-2023-0464
+
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+Reviewed-by: Shane Lontis <shane.lontis@oracle.com>
+(Merged from https://github.com/openssl/openssl/pull/20568)
+
+--- a/crypto/x509/pcy_local.h
++++ b/crypto/x509/pcy_local.h
+@@ -111,6 +111,11 @@ struct X509_POLICY_LEVEL_st {
+ };
+ 
+ struct X509_POLICY_TREE_st {
++    /* The number of nodes in the tree */
++    size_t node_count;
++    /* The maximum number of nodes in the tree */
++    size_t node_maximum;
++
+     /* This is the tree 'level' data */
+     X509_POLICY_LEVEL *levels;
+     int nlevel;
+@@ -157,7 +162,8 @@ X509_POLICY_NODE *ossl_policy_tree_find_
+ X509_POLICY_NODE *ossl_policy_level_add_node(X509_POLICY_LEVEL *level,
+                                              X509_POLICY_DATA *data,
+                                              X509_POLICY_NODE *parent,
+-                                             X509_POLICY_TREE *tree);
++                                             X509_POLICY_TREE *tree,
++                                             int extra_data);
+ void ossl_policy_node_free(X509_POLICY_NODE *node);
+ int ossl_policy_node_match(const X509_POLICY_LEVEL *lvl,
+                            const X509_POLICY_NODE *node, const ASN1_OBJECT *oid);
+--- a/crypto/x509/pcy_node.c
++++ b/crypto/x509/pcy_node.c
+@@ -59,10 +59,15 @@ X509_POLICY_NODE *ossl_policy_level_find
+ X509_POLICY_NODE *ossl_policy_level_add_node(X509_POLICY_LEVEL *level,
+                                              X509_POLICY_DATA *data,
+                                              X509_POLICY_NODE *parent,
+-                                             X509_POLICY_TREE *tree)
++                                             X509_POLICY_TREE *tree,
++                                             int extra_data)
+ {
+     X509_POLICY_NODE *node;
+ 
++    /* Verify that the tree isn't too large.  This mitigates CVE-2023-0464 */
++    if (tree->node_maximum > 0 && tree->node_count >= tree->node_maximum)
++        return NULL;
++
+     node = OPENSSL_zalloc(sizeof(*node));
+     if (node == NULL) {
+         ERR_raise(ERR_LIB_X509V3, ERR_R_MALLOC_FAILURE);
+@@ -70,7 +75,7 @@ X509_POLICY_NODE *ossl_policy_level_add_
+     }
+     node->data = data;
+     node->parent = parent;
+-    if (level) {
++    if (level != NULL) {
+         if (OBJ_obj2nid(data->valid_policy) == NID_any_policy) {
+             if (level->anyPolicy)
+                 goto node_error;
+@@ -90,7 +95,7 @@ X509_POLICY_NODE *ossl_policy_level_add_
+         }
+     }
+ 
+-    if (tree) {
++    if (extra_data) {
+         if (tree->extra_data == NULL)
+             tree->extra_data = sk_X509_POLICY_DATA_new_null();
+         if (tree->extra_data == NULL){
+@@ -103,6 +108,7 @@ X509_POLICY_NODE *ossl_policy_level_add_
+         }
+     }
+ 
++    tree->node_count++;
+     if (parent)
+         parent->nchild++;
+ 
+--- a/crypto/x509/pcy_tree.c
++++ b/crypto/x509/pcy_tree.c
+@@ -14,6 +14,17 @@
+ 
+ #include "pcy_local.h"
+ 
++/*
++ * If the maximum number of nodes in the policy tree isn't defined, set it to
++ * a generous default of 1000 nodes.
++ *
++ * Defining this to be zero means unlimited policy tree growth which opens the
++ * door on CVE-2023-0464.
++ */
++#ifndef OPENSSL_POLICY_TREE_NODES_MAX
++# define OPENSSL_POLICY_TREE_NODES_MAX 1000
++#endif
++
+ static void expected_print(BIO *channel,
+                            X509_POLICY_LEVEL *lev, X509_POLICY_NODE *node,
+                            int indent)
+@@ -163,6 +174,9 @@ static int tree_init(X509_POLICY_TREE **
+         return X509_PCY_TREE_INTERNAL;
+     }
+ 
++    /* Limit the growth of the tree to mitigate CVE-2023-0464 */
++    tree->node_maximum = OPENSSL_POLICY_TREE_NODES_MAX;
++
+     /*
+      * http://tools.ietf.org/html/rfc5280#section-6.1.2, figure 3.
+      *
+@@ -180,7 +194,7 @@ static int tree_init(X509_POLICY_TREE **
+     if ((data = ossl_policy_data_new(NULL,
+                                      OBJ_nid2obj(NID_any_policy), 0)) == NULL)
+         goto bad_tree;
+-    if (ossl_policy_level_add_node(level, data, NULL, tree) == NULL) {
++    if (ossl_policy_level_add_node(level, data, NULL, tree, 1) == NULL) {
+         ossl_policy_data_free(data);
+         goto bad_tree;
+     }
+@@ -239,7 +253,8 @@ static int tree_init(X509_POLICY_TREE **
+  * Return value: 1 on success, 0 otherwise
+  */
+ static int tree_link_matching_nodes(X509_POLICY_LEVEL *curr,
+-                                    X509_POLICY_DATA *data)
++                                    X509_POLICY_DATA *data,
++                                    X509_POLICY_TREE *tree)
+ {
+     X509_POLICY_LEVEL *last = curr - 1;
+     int i, matched = 0;
+@@ -249,13 +264,13 @@ static int tree_link_matching_nodes(X509
+         X509_POLICY_NODE *node = sk_X509_POLICY_NODE_value(last->nodes, i);
+ 
+         if (ossl_policy_node_match(last, node, data->valid_policy)) {
+-            if (ossl_policy_level_add_node(curr, data, node, NULL) == NULL)
++            if (ossl_policy_level_add_node(curr, data, node, tree, 0) == NULL)
+                 return 0;
+             matched = 1;
+         }
+     }
+     if (!matched && last->anyPolicy) {
+-        if (ossl_policy_level_add_node(curr, data, last->anyPolicy, NULL) == NULL)
++        if (ossl_policy_level_add_node(curr, data, last->anyPolicy, tree, 0) == NULL)
+             return 0;
+     }
+     return 1;
+@@ -268,7 +283,8 @@ static int tree_link_matching_nodes(X509
+  * Return value: 1 on success, 0 otherwise.
+  */
+ static int tree_link_nodes(X509_POLICY_LEVEL *curr,
+-                           const X509_POLICY_CACHE *cache)
++                           const X509_POLICY_CACHE *cache,
++                           X509_POLICY_TREE *tree)
+ {
+     int i;
+ 
+@@ -276,7 +292,7 @@ static int tree_link_nodes(X509_POLICY_L
+         X509_POLICY_DATA *data = sk_X509_POLICY_DATA_value(cache->data, i);
+ 
+         /* Look for matching nodes in previous level */
+-        if (!tree_link_matching_nodes(curr, data))
++        if (!tree_link_matching_nodes(curr, data, tree))
+             return 0;
+     }
+     return 1;
+@@ -307,7 +323,7 @@ static int tree_add_unmatched(X509_POLIC
+     /* Curr may not have anyPolicy */
+     data->qualifier_set = cache->anyPolicy->qualifier_set;
+     data->flags |= POLICY_DATA_FLAG_SHARED_QUALIFIERS;
+-    if (ossl_policy_level_add_node(curr, data, node, tree) == NULL) {
++    if (ossl_policy_level_add_node(curr, data, node, tree, 1) == NULL) {
+         ossl_policy_data_free(data);
+         return 0;
+     }
+@@ -370,7 +386,7 @@ static int tree_link_any(X509_POLICY_LEV
+     /* Finally add link to anyPolicy */
+     if (last->anyPolicy &&
+             ossl_policy_level_add_node(curr, cache->anyPolicy,
+-                                       last->anyPolicy, NULL) == NULL)
++                                       last->anyPolicy, tree, 0) == NULL)
+         return 0;
+     return 1;
+ }
+@@ -553,7 +569,7 @@ static int tree_calculate_user_set(X509_
+             extra->flags = POLICY_DATA_FLAG_SHARED_QUALIFIERS
+                 | POLICY_DATA_FLAG_EXTRA_NODE;
+             node = ossl_policy_level_add_node(NULL, extra, anyPolicy->parent,
+-                                              tree);
++                                              tree, 1);
+         }
+         if (!tree->user_policies) {
+             tree->user_policies = sk_X509_POLICY_NODE_new_null();
+@@ -580,7 +596,7 @@ static int tree_evaluate(X509_POLICY_TRE
+ 
+     for (i = 1; i < tree->nlevel; i++, curr++) {
+         cache = ossl_policy_cache_set(curr->cert);
+-        if (!tree_link_nodes(curr, cache))
++        if (!tree_link_nodes(curr, cache, tree))
+             return X509_PCY_TREE_INTERNAL;
+ 
+         if (!(curr->flags & X509_V_FLAG_INHIBIT_ANY)

--- a/package/libs/openssl/patches/210-Ensure-that-EXFLAG_INVALID_POLICY-is-checked-even-in.patch
+++ b/package/libs/openssl/patches/210-Ensure-that-EXFLAG_INVALID_POLICY-is-checked-even-in.patch
@@ -1,0 +1,44 @@
+From 1dd43e0709fece299b15208f36cc7c76209ba0bb Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.org>
+Date: Tue, 7 Mar 2023 16:52:55 +0000
+Subject: [PATCH] Ensure that EXFLAG_INVALID_POLICY is checked even in leaf
+ certs
+
+Even though we check the leaf cert to confirm it is valid, we
+later ignored the invalid flag and did not notice that the leaf
+cert was bad.
+
+Fixes: CVE-2023-0465
+
+Reviewed-by: Hugo Landau <hlandau@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/20587)
+
+--- a/crypto/x509/x509_vfy.c
++++ b/crypto/x509/x509_vfy.c
+@@ -1654,15 +1654,23 @@ static int check_policy(X509_STORE_CTX *
+         goto memerr;
+     /* Invalid or inconsistent extensions */
+     if (ret == X509_PCY_TREE_INVALID) {
+-        int i;
++        int i, cbcalled = 0;
+ 
+         /* Locate certificates with bad extensions and notify callback. */
+-        for (i = 1; i < sk_X509_num(ctx->chain); i++) {
++        for (i = 0; i < sk_X509_num(ctx->chain); i++) {
+             X509 *x = sk_X509_value(ctx->chain, i);
+ 
++            if ((x->ex_flags & EXFLAG_INVALID_POLICY) != 0)
++                cbcalled = 1;
+             CB_FAIL_IF((x->ex_flags & EXFLAG_INVALID_POLICY) != 0,
+                        ctx, x, i, X509_V_ERR_INVALID_POLICY_EXTENSION);
+         }
++        if (!cbcalled) {
++            /* Should not be able to get here */
++            ERR_raise(ERR_LIB_X509, ERR_R_INTERNAL_ERROR);
++            return 0;
++        }
++        /* The callback ignored the error so we return success */
+         return 1;
+     }
+     if (ret == X509_PCY_TREE_FAILURE) {


### PR DESCRIPTION
Apply two patches fixing low-severity vulnerabilities related to certificate policies validation:

- Excessive Resource Usage Verifying X.509 Policy Constraints (CVE-2023-0464) Severity: Low A security vulnerability has been identified in all supported versions of OpenSSL related to the verification of X.509 certificate chains that include policy constraints.  Attackers may be able to exploit this vulnerability by creating a malicious certificate chain that triggers exponential use of computational resources, leading to a denial-of-service (DoS) attack on affected systems. Policy processing is disabled by default but can be enabled by passing the `-policy' argument to the command line utilities or by calling the `X509_VERIFY_PARAM_set1_policies()' function.

- Invalid certificate policies in leaf certificates are silently ignored (CVE-2023-0465) Severity: Low Applications that use a non-default option when verifying certificates may be vulnerable to an attack from a malicious CA to circumvent certain checks. Invalid certificate policies in leaf certificates are silently ignored by OpenSSL and other certificate policy checks are skipped for that certificate.  A malicious CA could use this to deliberately assert invalid certificate policies in order to circumvent policy checking on the certificate altogether. Policy processing is disabled by default but can be enabled by passing the `-policy' argument to the command line utilities or by calling the `X509_VERIFY_PARAM_set1_policies()' function.

Note: OpenSSL also released a fix for low-severity security advisory CVE-2023-466.  It is not included here because the fix only changes the documentation, which is not built nor included in any OpenWrt package.

Due to the low-severity of these issues, there will be not be an immediate new release of OpenSSL.

