### PR TITLE
mediatek: introduce KERNEL_LOADADDR to Device/Default template

### DIFF
--- a/target/linux/mediatek/image/Makefile
+++ b/target/linux/mediatek/image/Makefile
@@ -6,6 +6,11 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
+loadaddr-$(CONFIG_TARGET_mediatek_mt7622) := 0x44000000
+loadaddr-$(CONFIG_TARGET_mediatek_mt7623) := 0x80008000
+loadaddr-$(CONFIG_TARGET_mediatek_mt7629) := 0x40008000
+loadaddr-$(CONFIG_TARGET_mediatek_filogic) := 0x48000000
+
 # default all platform image(fit) build
 define Device/Default
   PROFILES = Default $$(DEVICE_NAME)
@@ -14,6 +19,7 @@ define Device/Default
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   KERNEL_INITRAMFS = kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+  KERNEL_LOADADDR = $(loadaddr-y)
   FILESYSTEMS := squashfs
   DEVICE_DTS_DIR := $(DTS_DIR)
   IMAGES := sysupgrade.bin

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1,7 +1,5 @@
 DTS_DIR := $(DTS_DIR)/mediatek
 
-KERNEL_LOADADDR := 0x44000000
-
 define Image/Prepare
 	# For UBI we want only one extra block
 	rm -f $(KDIR)/ubi_mark
@@ -46,7 +44,6 @@ define Device/asus_tuf-ax4200
   DEVICE_DTS_LOADADDR := 0x47000000
   DEVICE_PACKAGES := kmod-usb3 kmod-mt7986-firmware mt7986-wo-firmware
   IMAGES := sysupgrade.bin
-  KERNEL_LOADADDR := 0x48000000
   KERNEL := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   KERNEL_INITRAMFS := kernel-bin | lzma | \
@@ -65,6 +62,7 @@ define Device/bananapi_bpi-r3
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-i2c-gpio kmod-mt7986-firmware kmod-sfp kmod-usb3 e2fsprogs f2fsck mkf2fs mt7986-wo-firmware
   IMAGES := sysupgrade.itb
+  KERNEL_LOADADDR := 0x44000000
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   ARTIFACTS := \
 	       emmc-preloader.bin emmc-bl31-uboot.fip \
@@ -108,7 +106,6 @@ define Device/mediatek_mt7986a-rfb-nand
   DEVICE_DTS := mt7986a-rfb-spim-nand
   DEVICE_DTS_DIR := $(DTS_DIR)/
   DEVICE_PACKAGES := kmod-mt7986-firmware mt7986-wo-firmware
-  KERNEL_LOADADDR := 0x48000000
   SUPPORTED_DEVICES := mediatek,mt7986a-rfb-snand
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
@@ -132,7 +129,6 @@ define Device/mediatek_mt7986b-rfb
   DEVICE_DTS := mt7986b-rfb
   DEVICE_DTS_DIR := $(DTS_DIR)/
   DEVICE_PACKAGES := kmod-mt7986-firmware mt7986-wo-firmware
-  KERNEL_LOADADDR := 0x48000000
   SUPPORTED_DEVICES := mediatek,mt7986b-rfb
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
@@ -151,7 +147,6 @@ define Device/xiaomi_redmi-router-ax6000-stock
   DEVICE_DTS := mt7986a-xiaomi-redmi-router-ax6000-stock
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-leds-ws2812b kmod-mt7986-firmware mt7986-wo-firmware
-  KERNEL_LOADADDR := 0x48000000
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
   PAGESIZE := 2048
@@ -171,7 +166,6 @@ define Device/xiaomi_redmi-router-ax6000-ubootmod
   DEVICE_PACKAGES := kmod-leds-ws2812b kmod-mt7986-firmware mt7986-wo-firmware
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   IMAGES := sysupgrade.itb
-  KERNEL_LOADADDR := 0x48000000
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
   PAGESIZE := 2048

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -1,11 +1,5 @@
 DTS_DIR := $(DTS_DIR)/mediatek
 
-ifdef CONFIG_LINUX_5_4
-  KERNEL_LOADADDR := 0x44080000
-else
-  KERNEL_LOADADDR := 0x44000000
-endif
-
 define Image/Prepare
 	# For UBI we want only one extra block
 	rm -f $(KDIR)/ubi_mark

--- a/target/linux/mediatek/image/mt7623.mk
+++ b/target/linux/mediatek/image/mt7623.mk
@@ -1,4 +1,3 @@
-KERNEL_LOADADDR := 0x80008000
 DEVICE_VARS += UBOOT_TARGET UBOOT_OFFSET UBOOT_IMAGE
 
 # The bootrom of MT7623 expects legacy MediaTek headers present in

--- a/target/linux/mediatek/image/mt7629.mk
+++ b/target/linux/mediatek/image/mt7629.mk
@@ -1,5 +1,3 @@
-KERNEL_LOADADDR := 0x40008000
-
 define Device/mediatek_mt7629-rfb
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7629 rfb AP


### PR DESCRIPTION
We need to reset KERNEL_LOADADDR if we use it on a per-device base. Otherwise the previous value will be kept in case a device doesn't define KERNEL_LOADADDR and relies on the default.

Move initializing KERNEL_LOADADDR to target/linux/mediatek/image/Makefile, similar to how it's done also on the ramips target.

This fixes image size related breakage on devices which rely on the default value of KERNEL_LOADADDR.

While at it use 0x48000000 which is more common than the previous default 0x44000000 for the filogic subtarget.

Fixed: e7c399bee6 ("filogic: add support for ASUS TUF-AX4200")
Signed-off-by: Daniel Golle <<daniel@makrotopia.org>>