### PR TITLE
realtek: add support for TP-Link T1600G-28TS v3

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -41,7 +41,8 @@ hpe,1920-24g)
 	;;
 tplink,sg2008p-v1|\
 tplink,sg2210p-v3|\
-tplink,sg2452p-v4)
+tplink,sg2452p-v4|\
+tplink,t1600g-28ts-v3)
 	label_mac=$(get_mac_label)
 	lan_mac="$label_mac"
 	;;

--- a/target/linux/realtek/dts-5.15/rtl8382_tplink_t1600g-28ts-v3.dts
+++ b/target/linux/realtek/dts-5.15/rtl8382_tplink_t1600g-28ts-v3.dts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl838x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tplink,t1600g-28ts-v3", "realtek,rtl838x-soc";
+	model = "TP-Link T1600G-28TS v3";
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+		label-mac-device = &ethernet0;
+	};
+
+	chosen {
+		stdout-path = "serial0:38400n8";
+	};
+
+	leds {
+		pinctrl-names = "default";
+		compatible = "gpio-leds";
+
+		led_sys: led-0 {
+			label = "green:sys";
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0xe0000>;
+				read-only;
+			};
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0xe0000 0x20000>;
+			};
+			partition@100000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x100000 0x1a00000>;
+			};
+			partition@1b00000 {
+				label = "usrappfs";
+				reg = <0x1b00000 0x400000>;
+			};
+			partition@1f00000 {
+				compatible = "nvmem-cells";
+				label = "para";
+				reg = <0x1f00000 0x100000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				read-only;
+
+				factory_macaddr: macaddr@fdff4 {
+					reg = <0xfdff4 0x6>;
+				};
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&factory_macaddr>;
+	nvmem-cell-names = "mac-address";
+
+	mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		EXTERNAL_PHY(0)
+		EXTERNAL_PHY(1)
+		EXTERNAL_PHY(2)
+		EXTERNAL_PHY(3)
+		EXTERNAL_PHY(4)
+		EXTERNAL_PHY(5)
+		EXTERNAL_PHY(6)
+		EXTERNAL_PHY(7)
+
+		INTERNAL_PHY(8)
+		INTERNAL_PHY(9)
+		INTERNAL_PHY(10)
+		INTERNAL_PHY(11)
+		INTERNAL_PHY(12)
+		INTERNAL_PHY(13)
+		INTERNAL_PHY(14)
+		INTERNAL_PHY(15)
+
+		EXTERNAL_PHY(16)
+		EXTERNAL_PHY(17)
+		EXTERNAL_PHY(18)
+		EXTERNAL_PHY(19)
+		EXTERNAL_PHY(20)
+		EXTERNAL_PHY(21)
+		EXTERNAL_PHY(22)
+		EXTERNAL_PHY(23)
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, internal)
+		SWITCH_PORT(9, 10, internal)
+		SWITCH_PORT(10, 11, internal)
+		SWITCH_PORT(11, 12, internal)
+		SWITCH_PORT(12, 13, internal)
+		SWITCH_PORT(13, 14, internal)
+		SWITCH_PORT(14, 15, internal)
+		SWITCH_PORT(15, 16, internal)
+
+		SWITCH_PORT(16, 17, qsgmii)
+		SWITCH_PORT(17, 18, qsgmii)
+		SWITCH_PORT(18, 19, qsgmii)
+		SWITCH_PORT(19, 20, qsgmii)
+		SWITCH_PORT(20, 21, qsgmii)
+		SWITCH_PORT(21, 22, qsgmii)
+		SWITCH_PORT(22, 23, qsgmii)
+		SWITCH_PORT(23, 24, qsgmii)
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -234,6 +234,16 @@ define Device/tplink_sg2210p-v3
 endef
 TARGET_DEVICES += tplink_sg2210p-v3
 
+define Device/tplink_t1600g-28ts-v3
+  SOC := rtl8382
+  KERNEL_SIZE := 6m
+  IMAGE_SIZE := 26m
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := T1600G-28TS
+  DEVICE_VARIANT := v3
+endef
+TARGET_DEVICES += tplink_t1600g-28ts-v3
+
 define Device/zyxel_gs1900-10hp
   $(Device/zyxel_gs1900)
   SOC := rtl8380


### PR DESCRIPTION
This is an RTL8382-based switch with 24 copper ports + 4 SFP ports

Specifications:
---------------
 * SoC:       Realtek RTL8382M
 * Flash:     32 MiB SPI flash
 * RAM:       256 MiB
 * Ethernet:  24x 10/100/1000 Mbps
 * Buttons:   1x "Reset" button
 * UART:      1x serial header, unpopulated
 * SFP:       4 SFP ports

Works:
------
  - (24) RJ-45 ethernet ports
  - Switch functions
  - Buttons
  - Sys LED on front panel (no port LEDs)

Not yet enabled:
----------------
  - Port LEDs (no driver for RTL8231 in this mode)
  - SFP cages (no driver for PHY)

Install via web interface:
-------------------------

Not supported at this time.

Install via serial console/tftp:
--------------------------------

The U-Boot firmware drops to a TP-Link specific "BOOTUTIL" shell at 38400 baud. There is no known way to exit out of this shell, and no way to do anything useful.

Ideally, one would trick the bootloader into flashing the sysupgrade image first. However, if the image exceeds 6MiB in size, it will not work. To install OpenWRT:

Prepare a tftp server with:
 1. server address: 192.168.0.146
 2. the image as: "uImage.img"

Power on device, and stop boot by pressing any key. Once the shell is active:
 1. Ground out the CLK (pin 16) of the ROM (U6)
 2. Select option "3. Start"
 3. Bootloader notes that "The kernel has been damaged!"
 4. Release CLK as soon as bootloader thinks image is corrupted.
 5. Bootloader enters automatic recovery -- details printed on console
 6. Watch as the bootloader flashes and boots OpenWRT.

Blind install via tftp:
-----------------------

This method works when it's not feasible to install a serial header.

Prepare a tftp server with:
 1. server address: 192.168.0.146
 2. the image as: "uImage.img"
 3. Watch network traffic (tcpdump or wireshark works)
 4. Power on the device.
 5. Wait 1-2 seconds then ground out the CLK (pin 16) of the ROM (U6)
 6. When 192.168.0.30 makes tftp requests, release pin 16
 7. Wait 2-3 minutes for device to auto-flash and boot OpenWRT