### PR TITLE
[22.03] ramips: add support for Keenetic Lite III rev. A

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -18,7 +18,8 @@ alfa-network,quad-e4g|\
 alfa-network,r36m-e4g|\
 alfa-network,tube-e4g|\
 engenius,esr600h|\
-sitecom,wlr-4100-v1-002)
+sitecom,wlr-4100-v1-002|\
+zyxel,keenetic-lite-iii-a)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x1000"
 	;;
 allnet,all0256n-4m|\

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-lite-iii-a.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-lite-iii-a.dts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "zyxel,keenetic-lite-iii-a", "ralink,mt7620n-soc";
+	model = "ZyXEL Keenetic Lite III (rev. A)";
+
+	aliases {
+		led-boot = &led_wan;
+		led-failsafe = &led_wan;
+		led-running = &led_wan;
+		led-upgrade = &led_wan;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+ 
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>; // #GPIO1
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>; // #GPIO2
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		sw0 {
+			label = "sw0";
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>; // #GPIO17
+			linux,code = <BTN_0>;
+		};
+
+		sw1 {
+			label = "sw1";
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>; // #GPIO20
+			linux,code = <BTN_1>;
+		};
+
+		sw2 {
+			label = "sw2";
+			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>; // #GPIO21
+			linux,code = <BTN_2>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wan: wan {
+			label = "green:wan";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>; // #GPIO38
+		};
+
+		wifi {
+			label = "green:wifi";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&gpio3 0 GPIO_ACTIVE_HIGH>; // #GPIO72
+		};
+	};
+
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <48000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "U-Boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "U-Config";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "RF-EEPROM";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7a0000>;
+			};
+
+			partition@7f0000 {
+				label = "Config";
+				reg = <0x7f0000 0x10000>;
+			};
+
+			partition@0_1 {
+				label = "Full";
+				reg = <0x0 0x800000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c";
+		function = "gpio";
+	};
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1395,6 +1395,18 @@ define Device/zte_q7
 endef
 TARGET_DEVICES += zte_q7
 
+define Device/zyxel_keenetic-lite-iii-a
+  SOC := mt7620n
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := ZyXEL
+  DEVICE_MODEL := Keenetic Lite III
+  DEVICE_VARIANT := A
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to 64k | check-size | \
+		zyimage -d 2102018 -v "ZyXEL Keenetic Lite III"
+endef
+TARGET_DEVICES += zyxel_keenetic-lite-iii-a
+
 define Device/zyxel_keenetic-omni
   SOC := mt7620n
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -55,6 +55,7 @@ planex,mzk-ex300np|\
 zbtlink,zbt-we826-16m|\
 zbtlink,zbt-we826-32m|\
 zbtlink,zbt-wr8305rt|\
+zyxel,keenetic-lite-iii-a|\
 zyxel,keenetic-omni|\
 zyxel,keenetic-omni-ii|\
 zyxel,keenetic-viva)

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -28,6 +28,7 @@ ramips_setup_interfaces()
 	zbtlink,zbt-we826-32m|\
 	zbtlink,zbt-we826-e|\
 	zbtlink,zbt-wr8305rt|\
+	zyxel,keenetic-lite-iii-a|\
 	zyxel,keenetic-omni)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
@@ -386,6 +387,11 @@ ramips_setup_macs()
 		;;
 	zbtlink,zbt-we1026-5g-16m)
 		label_mac=$(mtd_get_mac_binary factory 0x4)
+		;;
+	zyxel,keenetic-lite-iii-a)
+		lan_mac=$(mtd_get_mac_binary RF-EEPROM 0x4)		
+		wan_mac=$(mtd_get_mac_binary RF-EEPROM 0x28)
+		label_mac=$wan_mac
 		;;
 	zyxel,keenetic-omni|\
 	zyxel,keenetic-omni-ii|\


### PR DESCRIPTION
General specification:
SoC Type: MediaTek MT7620N (580MHz)
ROM: 8 MB SPI-NOR (W25Q64FV)
RAM: 64 MB DDR (EM6AB160TSD-5G)
Switch: MediaTek MT7530
Ethernet: 5 ports - 5×100MbE (WAN, LAN1-4)
Wireless: 2.4 GHz (MediaTek RT5390): b/g/n
Buttons: 3 button (POWER, RESET, WPS)
Slide switch: 4 position (BASE, ADAPTER, BOOSTER, ACCESS POINT) Bootloader: U-Boot 1.1.3
Power: 9 VDC, 0.6 A

MAC in stock:

| LAN 	| RF-EEPROM + 0x04	|
| WLAN	| RF-EEPROM + 0x04	|
| WAN 	| RF-EEPROM + 0x28	|

OEM easy installation
1. Use a PC to browse to http://my.keenetic.net.
2. Go to the System section and open the Files tab.
3. Under the Files tab, there will be a list of system files. Click on the Firmware file.
4. When a modal window appears, click on the Choose File button and upload the firmware image.
5. Wait for the router to flash and reboot.

OEM installation using the TFTP method
1. Download the latest firmware image and rename it to klite3_recovery.bin.
2. Set up a Tftp server on a PC (e.g. Tftpd32) and place the firmware image to the root directory of the server.
3. Power off the router and use a twisted pair cable to connect the PC to any of the router's LAN ports.
4. Configure the network adapter of the PC to use IP address 192.168.1.2 and subnet mask 255.255.255.0.
5. Power up the router while holding the reset button pressed.
6. Wait approximately for 5 seconds and then release the reset button.
7. The router should download the firmware via TFTP and complete flashing in a few minutes.
After flashing is complete, use the PC to browse to http://192.168.1.1 or ssh to proceed with the configuration.

Device topic at forum.openwrt.org [here](https://forum.openwrt.org/t/add-support-for-zyxel-keenetic-lite-iii-rev-a/153187)
