### PR TITLE
ath79: fix LED pinout for Comfast CF-E314N v2

### DIFF
--- a/target/linux/ath79/dts/qca9531_comfast_cf-e314n-v2.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e314n-v2.dts
@@ -33,23 +33,23 @@
 		};
 
 		rssilow {
-			label = "red:signal1";
+			label = "red:rssilow";
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 		};
 
 		rssimediumlow {
-			label = "red:signal2";
+			label = "red:rssimediumlow";
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 		};
 
 		rssimediumhigh {
-			label = "green:signal3";
-			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			label = "green:rssimediumhigh";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
 		led_rssihigh: rssihigh {
-			label = "green:signal4";
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			label = "green:rssihigh";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {


### PR DESCRIPTION
This patch standardizes the LED names for Comfast CF-E314N v2, and fixes green:rssimediumhigh and green:rssihigh not working on a physical device.

This matches the pinouts set in #1873, and is supported by a test on real hardware. 

Run-tested: Comfast CF-E314N v2