### PR TITLE
kernel: crypto: fix architecture specific modules

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -52,6 +52,7 @@ $(eval $(call KernelPackage,crypto-aead))
 
 define KernelPackage/crypto-arc4
   TITLE:=ARC4 cipher CryptoAPI module
+  DEPENDS:=+kmod-crypto-user
   KCONFIG:= \
 	  CONFIG_CRYPTO_ARC4 \
 	  CONFIG_CRYPTO_USER_API_ENABLE_OBSOLETE=y
@@ -678,7 +679,7 @@ $(eval $(call KernelPackage,crypto-michael-mic))
 
 define KernelPackage/crypto-misc
   TITLE:=Other CryptoAPI modules
-  DEPENDS:=+kmod-crypto-xts
+  DEPENDS:=+kmod-crypto-xts +kmod-crypto-user
   KCONFIG:= \
 	CONFIG_CRYPTO_USER_API_ENABLE_OBSOLETE=y \
 	CONFIG_CRYPTO_CAMELLIA_X86_64 \

--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -541,7 +541,7 @@ define KernelPackage/crypto-lib-curve25519/config
   imply PACKAGE_kmod-crypto-kpp
 endef
 
-define KernelPackage/crypto-lib-curve25519/x86/64
+define KernelPackage/crypto-lib-curve25519/x86_64
   KCONFIG+=CONFIG_CRYPTO_CURVE25519_X86
   FILES+=$(LINUX_DIR)/arch/x86/crypto/curve25519-x86_64.ko
 endef
@@ -554,6 +554,11 @@ endef
 ifeq ($(ARCH)-$(CONFIG_KERNEL_MODE_NEON),arm-y)
   KernelPackage/crypto-lib-curve25519/$(CRYPTO_TARGET)=\
 	  $(KernelPackage/crypto-lib-curve25519/arm-neon)
+endif
+
+ifdef KernelPackage/crypto-lib-curve25519/$(ARCH)
+  KernelPackage/crypto-lib-curve25519/$(CRYPTO_TARGET)=\
+	  $(KernelPackage/crypto-lib-curve25519/$(ARCH))
 endif
 
 $(eval $(call KernelPackage,crypto-lib-curve25519))
@@ -646,10 +651,15 @@ define KernelPackage/crypto-md5/octeon
   AUTOLOAD+=$(call AutoLoad,09,octeon-md5)
 endef
 
-define KernelPackage/crypto-md5/mpc85xx
+define KernelPackage/crypto-md5/powerpc
   FILES+=$(LINUX_DIR)/arch/powerpc/crypto/md5-ppc.ko
   AUTOLOAD+=$(call AutoLoad,09,md5-ppc)
 endef
+
+ifdef KernelPackage/crypto-md5/$(ARCH)
+  KernelPackage/crypto-md5/$(CRYPTO_TARGET)=\
+	  $(KernelPackage/crypto-md5/$(ARCH))
+endif
 
 $(eval $(call KernelPackage,crypto-md5))
 
@@ -735,7 +745,7 @@ ifndef CONFIG_TARGET_x86_64
   endef
 endif
 
-define KernelPackage/crypto-misc/x86/64
+define KernelPackage/crypto-misc/x86_64
   FILES+= \
 	$(LINUX_DIR)/arch/x86/crypto/camellia-x86_64.ko \
 	$(LINUX_DIR)/arch/x86/crypto/blowfish-x86_64.ko \
@@ -754,6 +764,11 @@ define KernelPackage/crypto-misc/x86/64
 	cast6-avx-x86_64 twofish-x86_64 twofish-x86_64-3way \
 	twofish-avx-x86_64 blowfish-x86_64 serpent-avx-x86_64 serpent-avx2)
 endef
+
+ifdef KernelPackage/crypto-misc/$(ARCH)
+  KernelPackage/crypto-misc/$(CRYPTO_TARGET)=\
+	  $(KernelPackage/crypto-misc/$(ARCH))
+endif
 
 $(eval $(call KernelPackage,crypto-misc))
 
@@ -884,10 +899,15 @@ define KernelPackage/crypto-sha1/mpc85xx
   AUTOLOAD+=$(call AutoLoad,09,sha1-ppc-spe)
 endef
 
-define KernelPackage/crypto-sha1/x86/64
+define KernelPackage/crypto-sha1/x86_64
   FILES+=$(LINUX_DIR)/arch/x86/crypto/sha1-ssse3.ko
   AUTOLOAD+=$(call AutoLoad,09,sha1-ssse3)
 endef
+
+ifdef KernelPackage/crypto-sha1/$(ARCH)
+  KernelPackage/crypto-sha1/$(CRYPTO_TARGET)=\
+	  $(KernelPackage/crypto-sha1/$(ARCH))
+endif
 
 $(eval $(call KernelPackage,crypto-sha1))
 
@@ -917,10 +937,15 @@ define KernelPackage/crypto-sha256/mpc85xx
   AUTOLOAD+=$(call AutoLoad,09,sha256-ppc-spe)
 endef
 
-define KernelPackage/crypto-sha256/x86/64
+define KernelPackage/crypto-sha256/x86_64
   FILES+=$(LINUX_DIR)/arch/x86/crypto/sha256-ssse3.ko
   AUTOLOAD+=$(call AutoLoad,09,sha256-ssse3)
 endef
+
+ifdef KernelPackage/crypto-sha256/$(ARCH)
+  KernelPackage/crypto-sha256/$(CRYPTO_TARGET)=\
+	  $(KernelPackage/crypto-sha256/$(ARCH))
+endif
 
 $(eval $(call KernelPackage,crypto-sha256))
 
@@ -954,10 +979,15 @@ endef
 
 KernelPackage/crypto-sha512/tegra=$(KernelPackage/crypto-sha512/arm)
 
-define KernelPackage/crypto-sha512/x86/64
+define KernelPackage/crypto-sha512/x86_64
   FILES+=$(LINUX_DIR)/arch/x86/crypto/sha512-ssse3.ko
   AUTOLOAD+=$(call AutoLoad,09,sha512-ssse3)
 endef
+
+ifdef KernelPackage/crypto-sha512/$(ARCH)
+  KernelPackage/crypto-sha512/$(CRYPTO_TARGET)=\
+	  $(KernelPackage/crypto-sha512/$(ARCH))
+endif
 
 $(eval $(call KernelPackage,crypto-sha512))
 


### PR DESCRIPTION
While tracking one bug report related to wrong package dependencies I've noticed, that a bunch of the crypto modules are actually not architecture specific, but either board/subtarget (x86/64) or board (mpc85xx) specific.

So lets fix it, by making relevant modules architecture specific:

 * `x86/64`  -> `x86_64`
 * `mpc85xx` -> `powerpc`