### PR TITLE
ath79: add support for Alcatel HH40V

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -12,6 +12,7 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 case "$board" in
+alcatel,hh40v|\
 alfa-network,ap121f|\
 alfa-network,ap121fe|\
 alfa-network,n2q|\

--- a/target/linux/ath79/dts/qca9531_alcatel_hh40v.dts
+++ b/target/linux/ath79/dts/qca9531_alcatel_hh40v.dts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "alcatel,hh40v", "qca,qca9531";
+	model = "Alcatel HH40V";
+
+	aliases {
+		label-mac-device = &wmac;
+		led-boot = &led_lan_link;
+		led-failsafe = &led_lan_link;
+		led-upgrade = &led_lan_link;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		lan_active {
+			label = "green:lan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan_link: lan_link {
+			label = "orange:lan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_active {
+			label = "green:wan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_link {
+			label = "orange:wan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "blue:wifi";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&usb0 {
+	status = "okay";
+
+	dr_mode = "host";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	/* Winbond W25Q256 SPI flash */
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "oem";
+				reg = <0x050000 0x100000>;
+				read-only;
+			};
+
+			partition@150000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x150000 0xea0000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				cal_art_1000: cal@1000 {
+					reg = <0x1000 0x440>;
+				};
+
+				macaddr_art_0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_art_6: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
+
+				macaddr_art_1002: macaddr@1002 {
+					reg = <0x1002 0x6>;
+				};
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-handle = <&swphy4>;
+};
+
+&eth1 {
+	compatible = "qca,qca9530-eth", "syscon", "simple-mfd";
+
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&cal_art_1000>, <&macaddr_art_1002>;
+	nvmem-cell-names = "calibration", "mac-address";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -10,6 +10,12 @@ case "$board" in
 	ucidef_set_led_netdev "lan" "LAN" "orange:eth0" "eth0"
 	ucidef_set_led_switch "wan" "WAN" "orange:eth1" "switch0" "0x04"
 	;;
+alcatel,hh40v)
+	ucidef_set_led_netdev "lan_data" "LAN Data" "green:lan" "eth1" "tx rx"
+	ucidef_set_led_netdev "lan_link" "LAN Link" "orange:lan" "eth1" "link"
+	ucidef_set_led_netdev "wan_data" "WAN Data" "green:wan" "eth0" "tx rx"
+	ucidef_set_led_netdev "wan_link" "WAN Link" "orange:wan" "eth0" "link"
+	;;
 alfa-network,ap121f|\
 alfa-network,ap121fe|\
 avm,fritz450e|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -217,6 +217,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "3:lan:4" "4:lan:3" "5:lan:2" "2:wan"
 		;;
+	alcatel,hh40v|\
 	comfast,cf-e110n-v2|\
 	comfast,cf-e120a-v3|\
 	comfast,cf-e314n-v2|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -246,6 +246,18 @@ define Device/adtran_bsap1840
 endef
 TARGET_DEVICES += adtran_bsap1840
 
+define Device/alcatel_hh40v
+  SOC := qca9531
+  DEVICE_VENDOR := Alcatel
+  DEVICE_MODEL := HH40V
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-serial-option kmod-usb-net-rndis
+  IMAGE_SIZE := 14976k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs
+endef
+TARGET_DEVICES += alcatel_hh40v
+
 define Device/airtight_c-75
   SOC := qca9550
   DEVICE_VENDOR := AirTight Networks


### PR DESCRIPTION
The Alcatel HH40V is a CAT4 LTE router used by various ISPs.

Specifications
==============

SoC: QCA9531 650MHz
RAM: 128MiB
Flash: 32MiB SPI NOR
LAN: 1x 10/100MBit
WAN: 1x 10/100MBit
LTE: MDM9607 USB 2.0 (rndis configuration)
WiFi: 802.11n (SoC integrated)

Installation (TFTP)
===================

1. Connect serial console
2. Configure static IP to 192.168.1.112
3. Put OpenWrt factory.bin file as firmware-system.bin
4. Press Power + WPS and plug in power
5. Keep buttons pressed until TFTP requests are visible
6. Wait for the system to finish flashing and wait for reboot
7. Bootup will fail as the kernel offset is wrong
8. Run "setenv bootcmd bootm 0x9f150000"
9. Reset board and enjoy OpenWrt

Installation (without UART)
===========================

Installation without UART is a bit tricky and requires several steps too long for the commit message. Basic steps:

1. Create configure backup
2. Patch backup file to enable SSH
3. Login via SSH and configure the new bootcmd
3. Flash OpenWrt factory.bin image manually (sysupgrade doesn't work)

More detailed instructions will be provided on the Wiki page.
