### PR TITLE
ramips: add support for D-Link DAP-1620 B1

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -126,6 +126,13 @@ define Build/append-string
 	echo -n $(1) >> $@
 endef
 
+define Build/append-md5sum-ascii-salted
+	cp $@ $@.salted
+	echo -ne $(1) >> $@.salted
+	$(STAGING_DIR_HOST)/bin/mkhash md5 $@.salted | head -c32 >> $@
+	rm $@.salted
+endef
+
 define Build/append-ubi
 	sh $(TOPDIR)/scripts/ubinize-image.sh \
 		$(if $(UBOOTENV_IN_UBI),--uboot-env) \

--- a/target/linux/ramips/dts/mt7621_dlink_dap-1620-b1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dap-1620-b1.dts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dap-1620-b1", "mediatek,mt7621-soc";
+	model = "D-Link DAP-1620 B1";
+
+	aliases {
+		label-mac-device = &gmac0;
+
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_low_red {
+			label = "red:rssilow";
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_low_green {
+			label = "green:rssilow";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_med_green {
+			label = "green:rssimed";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_high_green {
+			label = "green:rssihigh";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		/* The correct MAC addresses are set in 10_fix_wifi_mac. */
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -7,7 +7,7 @@ include ./common-tp-link.mk
 
 DEFAULT_SOC := mt7621
 
-DEVICE_VARS += ELECOM_HWNAME LINKSYS_HWNAME
+DEVICE_VARS += ELECOM_HWNAME LINKSYS_HWNAME DLINK_HWID
 
 ifdef CONFIG_LINUX_5_10
   DTS_CPPFLAGS += -DDTS_LEGACY
@@ -553,6 +553,22 @@ define Device/cudy_x6
   SUPPORTED_DEVICES += R13
 endef
 TARGET_DEVICES += cudy_x6
+
+define Device/dlink_dap-1620-b1
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DAP-1620
+  DEVICE_VARIANT := B1
+  DEVICE_PACKAGES := kmod-mt7615-firmware rssileds
+  DLINK_HWID := MT76XMT7621-RP-PR2475-NA
+  IMAGE_SIZE := 16064k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | \
+    check-size 11009992 | pad-to 11009992 | \
+    append-md5sum-ascii-salted ffff | \
+    append-string $$(DLINK_HWID) | \
+    check-size
+endef
+TARGET_DEVICES += dlink_dap-1620-b1
 
 define Device/dlink_dap-x1860-a1
   $(Device/dsa-migration)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -60,6 +60,13 @@ jcg,y2|\
 xzwifi,creativebox-v1)
 	ucidef_set_led_netdev "internet" "internet" "blue:internet" "wan"
 	;;
+dlink,dap-1620-b1)
+	ucidef_set_rssimon "wlan1" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "red:rssilow" "wlan1" "1" "40"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "green:rssilow" "wlan1" "21" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimed" "wlan1" "61" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan1" "81" "100"
+	;;
 dlink,dap-x1860-a1)
 	ucidef_set_rssimon "wlan1" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "orange:rssilow" "wlan1" "1" "25"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ ramips_setup_interfaces()
 	ampedwireless,ally-00x19k|\
 	asus,rp-ac56|\
 	asus,rp-ac87|\
+	dlink,dap-1620-b1|\
 	dlink,dap-x1860-a1|\
 	edimax,re23s|\
 	mikrotik,ltap-2hnd|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -32,19 +32,20 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 		macaddr_setbit_la "$(macaddr_add $hw_mac_addr 0x100000)" > /sys${DEVPATH}/macaddress
 		;;
-	dlink,dap-x1860-a1)
-		hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"
-		[ "$PHYNBR" = "0" ] && \
-			macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && \
-			macaddr_add $hw_mac_addr 4 > /sys${DEVPATH}/macaddress
-		;;
+	dlink,dap-1620-b1|\
 	dlink,dir-853-a1)
 		lan_mac_addr="$(mtd_get_mac_binary factory 0xe000)"
 		[ "$PHYNBR" = "0" ] && \
 			macaddr_add $lan_mac_addr 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_add $lan_mac_addr 2 > /sys${DEVPATH}/macaddress
+		;;
+	dlink,dap-x1860-a1)
+		hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"
+		[ "$PHYNBR" = "0" ] && \
+			macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && \
+			macaddr_add $hw_mac_addr 4 > /sys${DEVPATH}/macaddress
 		;;
 	dlink,dir-853-a3)
 		[ "$PHYNBR" = "0" ] && \


### PR DESCRIPTION
The DAP-1620 rev B is a wall-plug AC1300 repeater.

Specifications:
- MT7621AT, 128 MiB RAM, 16 MiB SPI NOR
- MT7615DN 2x2 802.11n + 2x2 802.11ac (DBDC)
- Ethernet: 1 port 10/100/1000
- Status LEDs (1x red+green)
- LED RSSI bargraph (2x green, 1x red+green)

Installation:
- Keep reset button pressed during plug-in
- Web Recovery Updater is at 192.168.0.50
- Upload factory.bin, confirm flashing
  (seems to work best with Chromium-based browsers)

Revert to OEM firmware:
- decrypt OEM firmware via
  ```
  tail -c+117 DAP1620B1_FW212B03.bin | \
   openssl aes-256-cbc -d -md md5 -out decrypted.bin \
   -k 905503a4e0c3cd3c1ce062246de427a68962347e
  ```
- flash `decrypted.bin` via D-Link Web Recovery

Comments:
1) Used be71421656a4642512 for `factory.bin` generation.
2) The device code in `mt7621.mk` could be easily adapted to include also 
  D-Link DRA-1360, which has identical hardware but a different HW ID.
3) The OEM firmware decryption key is derived from model name and HW ID:
  ```echo -n DAP-1620 | openssl dgst -sha1 -hmac MT76XMT7621-RP-PR2475-NA```
4) DBDC is not enabled by default in the mt7615dn eeprom, so either override, i.e.,
   ```echo 1 > /sys/kernel/debug/ieee80211/phy0/mt76/dbdc```
  or patch byte 0x3e of the `factory` partition to 0x30 (instead of 0).
5) When DBDC is enabled (manually or after eeprom patch), `phy0` registers as 
  a dual-band device (2.4+5), which is wrong, and causes a bad autogenerated
  `/etc/config/wireless`. 53d2675a09 is an `mt76` patch that fixes it.
6) For further information see IRC discussions with @paulfertser today and yesterday.