### PR TITLE
generic: Convert incorrect generic/5.15 patches again

### DIFF
--- a/target/linux/generic/backport-5.15/733-v6.3-18-net-ethernet-mtk_eth_soc-add-support-for-MT7981.patch
+++ b/target/linux/generic/backport-5.15/733-v6.3-18-net-ethernet-mtk_eth_soc-add-support-for-MT7981.patch
@@ -1,3 +1,20 @@
+From f5d43ddd334b7c32fcaed9ba46afbd85cb467f1f Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sun, 19 Mar 2023 12:56:28 +0000
+Subject: [PATCH] net: ethernet: mtk_eth_soc: add support for MT7981 SoC
+
+The MediaTek MT7981 SoC comes with two 1G/2.5G SGMII ports, just like
+MT7986.
+
+In addition MT7981 is equipped with a built-in 1000Base-T PHY which can
+be used with GMAC1.
+
+As many MT7981 boards make use of inverting SGMII signal polarity, add
+new device-tree attribute 'mediatek,pn_swap' to support them.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+
 --- a/drivers/net/ethernet/mediatek/mtk_eth_path.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_path.c
 @@ -96,12 +96,20 @@ static int set_mux_gmac2_gmac0_to_gephy(

--- a/target/linux/generic/hack-5.15/750-net-pcs-mtk-lynxi-workaround-2500BaseX-no-an.patch
+++ b/target/linux/generic/hack-5.15/750-net-pcs-mtk-lynxi-workaround-2500BaseX-no-an.patch
@@ -1,3 +1,16 @@
+From 880d1311335120f64447ca9d11933872d734e19a Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Mon, 27 Mar 2023 18:41:54 +0100
+Subject: [PATCH] generic: pcs-mtk-lynxi: add hack to use 2500Base-X without AN
+
+Using 2500Base-T SFP modules e.g. on the BananaPi R3 requires manually
+disabling auto-negotiation, e.g. using ethtool. While a proper fix
+using SFP quirks is being discussed upstream, bring a work-around to
+restore user experience to what it was before the switch to the
+dedicated SGMII PCS driver.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+
 --- a/drivers/net/pcs/pcs-mtk-lynxi.c
 +++ b/drivers/net/pcs/pcs-mtk-lynxi.c
 @@ -92,14 +92,23 @@ static void mtk_pcs_lynxi_get_state(stru

--- a/target/linux/generic/hack-5.15/795-backport-phylink_pcs-helpers.patch
+++ b/target/linux/generic/hack-5.15/795-backport-phylink_pcs-helpers.patch
@@ -1,3 +1,20 @@
+From 027586ae8ecacff49757ed854c020f35d24a599c Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sat, 11 Mar 2023 03:44:41 +0000
+Subject: [PATCH] generic: backport some phylink helper functions
+
+It isn't feasible to literally backport all upstream phylink_pcs changes
+down to Linux 5.15: It's just too many patches, and many downstream
+drivers and hacks are likely to break. We are too close to branching off
+to risk this, and it's also just too much work.
+Instead just add helper functions used by modern PCS drivers while keeping
+the original functions instact as well. While this may add a kilobyte or
+two of extra kernel size, it has the advantage that we get the best of both
+worlds: None of the existing codepaths are touched, but yet we have the
+option to backport singular improvements to Ethernet drivers where needed.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+
 --- a/include/linux/phylink.h
 +++ b/include/linux/phylink.h
 @@ -584,10 +584,37 @@ int phylink_speed_up(struct phylink *pl)


### PR DESCRIPTION
OpenWRT's developer guide prefers having actual patches so they an be sent upstream more easily.

However, in this case, Adding proper fields also allows for `git am` to properly function. Some of these patches are quite old, and lack much traceable history.

This commit tries to rectify that, by digging in the history to find where and how it was first added.

It is by no means perfect and also shows some patches that should have been long gone.
