### PR TITLE
scripts/feeds: do not warn if override is already installed

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -32,6 +32,7 @@ $valid_mk or die "Unsupported version of make found: $mk\n";
 my @feeds;
 my %build_packages;
 my %installed;
+my %installed_over;
 my %installed_pkg;
 my %installed_targets;
 my %feed_cache;
@@ -285,6 +286,7 @@ sub get_installed() {
 	parse_package_metadata("./tmp/.packageinfo");
 	%installed_pkg = %vpackage;
 	%installed = %srcpackage;
+	%installed_over = %overrides;
 	%installed_targets = get_targets("./tmp/.targetinfo");
 }
 
@@ -574,7 +576,7 @@ sub install_src {
 	my $override = 0;
 	if (is_core_src($name)) {
 		if (!$force) {
-			if ($name ne "toolchain" && $name ne "linux") {
+			if ($name ne "toolchain" && $name ne "linux" && !$installed_over{$name}) {
 				warn "WARNING: Not overriding core package '$name'; use -f to force\n";
 			}
 			return 0;
@@ -596,6 +598,7 @@ sub install_src {
 	}
 
 	if ($override) {
+		$installed_over{$name} = 1;
 		warn "Overriding core package '$name' with version from $select_feed->[1]\n";
 	} else {
 		warn "Installing package '$name' from $select_feed->[1]\n";


### PR DESCRIPTION
When attempting to install a package that is already present in core and `-f` is not used, suppress the warning about not overriding in case override has already been installed. This avoids spurious warnings caused by dependencies being installed, which is always done without force, or by running `scripts/feeds install -f -p <feed> -a` followed by `scripts/feeds install -a` for example.
