### PR TITLE
gettext-full: build with included libxml explicitly

### DIFF
--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -64,6 +64,7 @@ HOST_CONFIGURE_ARGS += \
 	--disable-rpath \
 	--disable-java \
 	--disable-openmp \
+	--with-included-libxml \
 	--without-emacs \
 	--without-libxml2-prefix
 


### PR DESCRIPTION
Avoid picking libxml2 package in hostpkg build.

forum link: https://forum.openwrt.org/t/recent-builds-failing-on-gettext-full/153927