### PR TITLE
ramips: add linux 5.15 and 5.10 support for Zbits ZB25VQ128 SPI-NOR on Totolink X5000R

### DIFF
--- a/target/linux/ramips/patches-5.10/412-mtd-spi-nor-add-support-for-zbit-zb25vq128.patch
+++ b/target/linux/ramips/patches-5.10/412-mtd-spi-nor-add-support-for-zbit-zb25vq128.patch
@@ -1,0 +1,75 @@
+* [PATCH] mtd: spi-nor: Add support for ZB25VQ128
+@ 2021-09-18  7:22 Daniel Palmer
+  2021-09-20 11:26 ` Pratyush Yadav
+  0 siblings, 1 reply; 5+ messages in thread
+From: Daniel Palmer @ 2021-09-18  7:22 UTC (permalink / raw)
+  To: linux-mtd, tudor.ambarus; +Cc: michael, p.yadav, linux-kernel, Daniel Palmer
+
+Add support for the ZBIT ZB25VQ128 128MBit SPI NOR
+flash.
+
+Link: http://www.cipatelje.eu/pdf/ZB25VQ128.pdf
+Signed-off-by: Daniel Palmer <daniel@0x0f.com>
+---
+ drivers/mtd/spi-nor/Makefile |  1 +
+ drivers/mtd/spi-nor/core.c   |  1 +
+ drivers/mtd/spi-nor/core.h   |  1 +
+ drivers/mtd/spi-nor/zbit.c   | 21 +++++++++++++++++++++
+ 4 files changed, 24 insertions(+)
+ create mode 100644 drivers/mtd/spi-nor/zbit.c
+
+--- a/drivers/mtd/spi-nor/Makefile
++++ b/drivers/mtd/spi-nor/Makefile
+@@ -19,6 +19,7 @@
+ spi-nor-objs			+= xilinx.o
+ spi-nor-objs			+= xmc.o
+ spi-nor-objs			+= xtx.o
++spi-nor-objs			+= zbit.o
+ obj-$(CONFIG_MTD_SPI_NOR)	+= spi-nor.o
+ 
+ obj-$(CONFIG_MTD_SPI_NOR)	+= controllers/
+--- a/drivers/mtd/spi-nor/core.c
++++ b/drivers/mtd/spi-nor/core.c
+@@ -2038,6 +2038,7 @@ static const struct spi_nor_manufacturer *manufacturers[] = {
+ 	&spi_nor_xilinx,
+ 	&spi_nor_xmc,
+	&spi_nor_xtx,
++	&spi_nor_zbit,
+ };
+ 
+ static const struct flash_info *
+--- a/drivers/mtd/spi-nor/core.h
++++ b/drivers/mtd/spi-nor/core.h
+@@ -399,6 +399,7 @@ struct spi_nor_manufacturer {
+ extern const struct spi_nor_manufacturer spi_nor_xilinx;
+ extern const struct spi_nor_manufacturer spi_nor_xmc;
+ extern const struct spi_nor_manufacturer spi_nor_xtx;
++extern const struct spi_nor_manufacturer spi_nor_zbit;
+
+ int spi_nor_write_enable(struct spi_nor *nor);
+ int spi_nor_write_disable(struct spi_nor *nor);
+--- /dev/null
++++ b/drivers/mtd/spi-nor/zbit.c
+@@ -0,0 +1,21 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (C) 2021, Daniel Palmer<daniel@thingy.jp>
++ */
++
++#include <linux/mtd/spi-nor.h>
++
++#include "core.h"
++
++static const struct flash_info zbit_parts[] = {
++	/* zbit */
++	{ "zb25vq128", INFO(0x5e4018, 0, 64 * 1024, 256,
++			    SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
++			    SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB) },
++};
++
++const struct spi_nor_manufacturer spi_nor_zbit = {
++	.name = "zbit",
++	.parts = zbit_parts,
++	.nparts = ARRAY_SIZE(zbit_parts),
++};
+-- 

--- a/target/linux/ramips/patches-5.15/412-mtd-spi-nor-add-support-for-zbit-zb25vq128.patch
+++ b/target/linux/ramips/patches-5.15/412-mtd-spi-nor-add-support-for-zbit-zb25vq128.patch
@@ -1,0 +1,75 @@
+* [PATCH] mtd: spi-nor: Add support for ZB25VQ128
+@ 2021-09-18  7:22 Daniel Palmer
+  2021-09-20 11:26 ` Pratyush Yadav
+  0 siblings, 1 reply; 5+ messages in thread
+From: Daniel Palmer @ 2021-09-18  7:22 UTC (permalink / raw)
+  To: linux-mtd, tudor.ambarus; +Cc: michael, p.yadav, linux-kernel, Daniel Palmer
+
+Add support for the ZBIT ZB25VQ128 128MBit SPI NOR
+flash.
+
+Link: http://www.cipatelje.eu/pdf/ZB25VQ128.pdf
+Signed-off-by: Daniel Palmer <daniel@0x0f.com>
+---
+ drivers/mtd/spi-nor/Makefile |  1 +
+ drivers/mtd/spi-nor/core.c   |  1 +
+ drivers/mtd/spi-nor/core.h   |  1 +
+ drivers/mtd/spi-nor/zbit.c   | 21 +++++++++++++++++++++
+ 4 files changed, 24 insertions(+)
+ create mode 100644 drivers/mtd/spi-nor/zbit.c
+
+--- a/drivers/mtd/spi-nor/Makefile
++++ b/drivers/mtd/spi-nor/Makefile
+@@ -19,6 +19,7 @@
+ spi-nor-objs			+= xilinx.o
+ spi-nor-objs			+= xmc.o
+ spi-nor-objs			+= xtx.o
++spi-nor-objs			+= zbit.o
+ obj-$(CONFIG_MTD_SPI_NOR)	+= spi-nor.o
+ 
+ obj-$(CONFIG_MTD_SPI_NOR)	+= controllers/
+--- a/drivers/mtd/spi-nor/core.c
++++ b/drivers/mtd/spi-nor/core.c
+@@ -1861,6 +1861,7 @@ static const struct spi_nor_manufacturer *manufacturers[] = {
+ 	&spi_nor_xilinx,
+ 	&spi_nor_xmc,
+	&spi_nor_xtx,
++	&spi_nor_zbit,
+ };
+ 
+ static const struct flash_info *
+--- a/drivers/mtd/spi-nor/core.h
++++ b/drivers/mtd/spi-nor/core.h
+@@ -491,6 +491,7 @@ struct sfdp {
+ extern const struct spi_nor_manufacturer spi_nor_xilinx;
+ extern const struct spi_nor_manufacturer spi_nor_xmc;
+ extern const struct spi_nor_manufacturer spi_nor_xtx;
++extern const struct spi_nor_manufacturer spi_nor_zbit;
+
+ extern const struct attribute_group *spi_nor_sysfs_groups[];
+
+--- /dev/null
++++ b/drivers/mtd/spi-nor/zbit.c
+@@ -0,0 +1,21 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (C) 2021, Daniel Palmer<daniel@thingy.jp>
++ */
++
++#include <linux/mtd/spi-nor.h>
++
++#include "core.h"
++
++static const struct flash_info zbit_parts[] = {
++	/* zbit */
++	{ "zb25vq128", INFO(0x5e4018, 0, 64 * 1024, 256,
++			    SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
++			    SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB) },
++};
++
++const struct spi_nor_manufacturer spi_nor_zbit = {
++	.name = "zbit",
++	.parts = zbit_parts,
++	.nparts = ARRAY_SIZE(zbit_parts),
++};
+-- 


### PR DESCRIPTION
Adds support for Zbits ZB25VQ128 SPI-NOR for Totolink X5000R manufactured in 2022 and beyond. Current firmware and snapshot builds will cause any new X5000R devices to bootloop upon flashing using the instruction provided in the wiki. These two patches will add in the support for the new SPI-NOR chip used in current X5000R production and will not cause a bootloop upon flashing with the implementation of the patch files in Linux 5.10 and 5.15 kernel OpenWRT builds.