### PR TITLE
ath79: add support for ZTE MF282

### DIFF
--- a/target/linux/ath79/dts/qca9563_zte_mf281.dts
+++ b/target/linux/ath79/dts/qca9563_zte_mf281.dts
@@ -3,246 +3,157 @@
 // Copyright (c) 2021, 2022 Lech Perczak
 // Copyright (c) 2022 David Bauer <mail@david-bauer.net>
 
-#include "qca956x.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
+#include "qca9563_zte_mf28x.dtsi"
 
 / {
 	model = "ZTE MF281";
 	compatible = "zte,mf281", "qca,qca9563";
 
-	aliases {
-		led-boot = &led_debug;
-		led-failsafe = &led_debug;
-		led-running = &led_debug;
-		led-upgrade = &led_debug;
-		label-mac-device = &eth0;
-	};
-
 	leds {
-		compatible = "gpio-leds";
 		pinctrl-names = "default";
 		pinctrl-0 = <&enable_wlan_led_gpio>;
-
-		/* Hidden SMD LED below signal strength LEDs.
-		 * Visible through slits underside of the case.
-		 */
-		led_debug: debug {
-			label = "green:debug";
-			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
-			default-state = "on";
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		wps {
-			label = "wps";
-			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-	};
-
-	/* This GPIO is used to reset whole board _including_ the modem */
-	gpio-restart {
-		compatible = "gpio-restart";
-		gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
-		active-delay = <3000>;
-		inactive-delay = <1000>;
 	};
 };
 
-&spi {
-	status = "okay";
+&led_debug {
+	label = "green:debug";
+	color = <LED_COLOR_ID_GREEN>;
+};
 
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
+&boot_flash {
+	partitions {
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0xa0000>;
+			read-only;
+		};
 
-		partitions {
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0xa0000 0x20000>;
+			read-only;
+		};
+	};
+};
+
+&system_flash {
+	partitions {
+		partition@0 {
+			label = "fota-flag";
+			reg = <0x000000 0xa0000>;
+			read-only;
+		};
+
+		partition@a0000 {
+			label = "art";
+			reg = <0xa0000 0x80000>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cal_caldata_1000: cal@1000 {
+				reg = <0x1000 0x440>;
+			};
+
+			cal_caldata_5000: cal@5000 {
+				reg = <0x5000 0x2f20>;
+			};
+		};
+
+		partition@120000 {
+			label = "mac";
+			reg = <0x120000 0x80000>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_mac_0: macaddr@0 {
+				reg = <0x0 0x6>;
+			};
+		};
+
+		partition@1a0000 {
+			label = "reserved2";
+			reg = <0x1a0000 0xc0000>;
+			read-only;
+		};
+
+		partition@260000 {
+			label = "cfg-param";
+			reg = <0x260000 0x400000>;
+			read-only;
+		};
+
+		partition@660000 {
+			label = "log";
+			reg = <0x660000 0x400000>;
+			read-only;
+		};
+
+		partition@a60000 {
+			label = "oops";
+			reg = <0xa60000 0xa0000>;
+			read-only;
+		};
+
+		partition@b00000 {
+			label = "reserved3";
+			reg = <0xb00000 0x500000>;
+			read-only;
+		};
+
+		partition@1000000 {
+			label = "web";
+			reg = <0x1000000 0x800000>;
+			read-only;
+		};
+
+		partition@1800000 {
+			label = "firmware";
+			reg = <0x1800000 0x1d00000>;
+
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
 
 			partition@0 {
-				label = "u-boot";
-				reg = <0x0 0xa0000>;
-				read-only;
+				label = "kernel";
+				reg = <0x0 0x600000>;
 			};
 
-			partition@80000 {
-				label = "u-boot-env";
-				reg = <0xa0000 0x20000>;
-				read-only;
+			partition@600000 {
+				label = "ubi";
+				reg = <0x600000 0x1700000>;
 			};
 		};
-	};
 
-	flash@1 {
-		compatible = "spi-nand";
-		reg = <1>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "fota-flag";
-				reg = <0x000000 0xa0000>;
-				read-only;
-			};
-
-			partition@a0000 {
-				label = "art";
-				reg = <0xa0000 0x80000>;
-				read-only;
-
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				cal_caldata_1000: cal@1000 {
-					reg = <0x1000 0x440>;
-				};
-
-				cal_caldata_5000: cal@5000 {
-					reg = <0x5000 0x2f20>;
-				};
-			};
-
-			partition@120000 {
-				label = "mac";
-				reg = <0x120000 0x80000>;
-				read-only;
-
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				macaddr_mac_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
-			};
-
-			partition@1a0000 {
-				label = "reserved2";
-				reg = <0x1a0000 0xc0000>;
-				read-only;
-			};
-
-			partition@260000 {
-				label = "cfg-param";
-				reg = <0x260000 0x400000>;
-				read-only;
-			};
-
-			partition@660000 {
-				label = "log";
-				reg = <0x660000 0x400000>;
-				read-only;
-			};
-
-			partition@a60000 {
-				label = "oops";
-				reg = <0xa60000 0xa0000>;
-				read-only;
-			};
-
-			partition@b00000 {
-				label = "reserved3";
-				reg = <0xb00000 0x500000>;
-				read-only;
-			};
-
-			partition@1000000 {
-				label = "web";
-				reg = <0x1000000 0x800000>;
-				read-only;
-			};
-
-			partition@1800000 {
-				label = "firmware";
-				reg = <0x1800000 0x1d00000>;
-
-				compatible = "fixed-partitions";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				partition@0 {
-					label = "kernel";
-					reg = <0x0 0x600000>;
-				};
-
-				partition@600000 {
-					label = "ubi";
-					reg = <0x600000 0x1700000>;
-				};
-			};
-
-			partition@3500000 {
-				label = "data";
-				reg = <0x3500000 0x1900000>;
-				read-only;
-			};
-
-			partition@4e00000 {
-				label = "fota";
-				reg = <0x4e00000 0x3200000>;
-				read-only;
-			};
+		partition@3500000 {
+			label = "data";
+			reg = <0x3500000 0x1900000>;
+			read-only;
 		};
-	};
-};
 
-&mdio0 {
-	status = "okay";
-
-	phy0: ethernet-phy@0 {
-		reg = <0>;
-		phy-mode = "sgmii";
-
-		qca,ar8327-initvals = <
-			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
-			0x7c 0x0000007e /* PORT0_STATUS */
-		>;
+		partition@4e00000 {
+			label = "fota";
+			reg = <0x4e00000 0x3200000>;
+			read-only;
+		};
 	};
 };
 
 &eth0 {
-	status = "okay";
-
-	phy-mode = "sgmii";
-	phy-handle = <&phy0>;
-
 	nvmem-cells = <&macaddr_mac_0>;
 	nvmem-cell-names = "mac-address";
 };
 
-&pcie {
-	status = "okay";
-
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x0 0 0 0 0>;
-
-		nvmem-cells = <&macaddr_mac_0>, <&cal_caldata_5000>;
-		nvmem-cell-names = "mac-address", "pre-calibration";
-		mac-address-increment = <1>;
-	};
+&wifi_ath10k {
+	nvmem-cells = <&macaddr_mac_0>, <&cal_caldata_5000>;
+	nvmem-cell-names = "mac-address", "pre-calibration";
+	mac-address-increment = <1>;
 };
 
 &pinmux {
@@ -252,24 +163,6 @@
 };
 
 &wmac {
-	status = "okay";
-
 	nvmem-cells = <&macaddr_mac_0>, <&cal_caldata_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
-};
-
-&usb_phy0 {
-	status = "okay";
-};
-
-&usb0 {
-	status = "okay";
-};
-
-&usb_phy1 {
-	status = "okay";
-};
-
-&usb1 {
-	status = "okay";
 };

--- a/target/linux/ath79/dts/qca9563_zte_mf282.dts
+++ b/target/linux/ath79/dts/qca9563_zte_mf282.dts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// Copyright (c) 2021 Cezary Jackiewicz
+// Copyright (c) 2021, 2022 Lech Perczak
+// Copyright (c) 2022 David Bauer <mail@david-bauer.net>
+// Copyright (c) 2023 Andreas Böhler <dev@aboehler.at>
+
+#include "qca9563_zte_mf28x.dtsi"
+
+/ {
+	model = "ZTE MF282";
+	compatible = "zte,mf282", "qca,qca9563";
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x7440000>;
+				label = "ubi";
+			};
+		};
+	};
+};
+
+&led_debug {
+	label = "blue:debug";
+	color = <LED_COLOR_ID_BLUE>;
+};
+
+&boot_flash {
+	partitions {
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x80000 0x20000>;
+			read-only;
+		};
+	};
+};
+
+&system_flash {
+	partitions {
+		partition@0 {
+			label = "fota-flag";
+			reg = <0x000000 0x140000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "caldata";
+			reg = <0x140000 0x140000>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cal_caldata_1000: cal@1000 {
+				reg = <0x1000 0x440>;
+			};
+
+			cal_caldata_5000: cal@5000 {
+				reg = <0x5000 0x844>;
+			};
+		};
+
+		partition@280000 {
+			label = "mac";
+			reg = <0x280000 0x140000>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_mac_0: macaddr@0 {
+				reg = <0x0 0x6>;
+			};
+		};
+
+		/* This encompasses stock cfg-param, oops, web partitions,
+		 * which can be overwritten safely
+		 */
+		ubiconcat0: partition@3c0000 {
+			label = "ubiconcat0";
+			reg = <0x3c0000 0xf40000>;
+		};
+
+		/* Kernel MTD size is increased to 8MB from stock 3MB */
+		partition@1300000 {
+			label = "kernel";
+			reg = <0x1300000 0x800000>;
+		};
+
+		/* This encompasses stock rootfs, data, fota partitions,
+		 * which can be overwritten safely
+		 */
+		ubiconcat1: partition@1b00000 {
+			label = "ubiconcat1";
+			reg = <0x1b00000 0x6500000>;
+		};
+	};
+};
+
+&eth0 {
+	nvmem-cells = <&macaddr_mac_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wifi_ath10k {
+	nvmem-cells = <&macaddr_mac_0>, <&cal_caldata_5000>;
+	nvmem-cell-names = "mac-address", "calibration";
+	mac-address-increment = <1>;
+};
+
+&wmac {
+	nvmem-cells = <&macaddr_mac_0>, <&cal_caldata_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};

--- a/target/linux/ath79/dts/qca9563_zte_mf286.dtsi
+++ b/target/linux/ath79/dts/qca9563_zte_mf286.dtsi
@@ -1,35 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 // Copyright (c) 2021 Cezary Jackiewicz
 // Copyright (c) 2021, 2022 Lech Perczak
-#include "qca956x.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
+#include "qca9563_zte_mf28x.dtsi"
 
 / {
-	aliases {
-		led-boot = &led_debug;
-		led-failsafe = &led_debug;
-		led-running = &led_debug;
-		led-upgrade = &led_debug;
-		label-mac-device = &eth0;
-	};
-
 	leds {
-		compatible = "gpio-leds";
 		pinctrl-names = "default";
 		pinctrl-0 = <&enable_wlan_led_gpio>;
-
-		/* Hidden SMD LED below signal strength LEDs.
-		 * Visible through slits underside of the case,
-		 * and slightly through the case below signal state LEDs
-		 */
-		led_debug: led-0 {
-			function = LED_FUNCTION_DEBUG;
-			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
-			default-state = "on";
-		};
 
 		led-1 {
 			function = LED_FUNCTION_WLAN;
@@ -40,22 +17,6 @@
 	};
 
 	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		wps {
-			label = "wps";
-			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
 		wifi {
 			label = "wifi";
 			linux,code = <KEY_RFKILL>;
@@ -63,96 +24,10 @@
 			debounce-interval = <60>;
 		};
 	};
-
-	/* This GPIO is used to reset whole board _including_ the modem */
-	gpio-restart {
-		compatible = "gpio-restart";
-		gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
-		active-delay = <3000>;
-		inactive-delay = <1000>;
-	};
-};
-
-&spi {
-	status = "okay";
-
-	boot_flash: flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-		};
-	};
-
-	system_flash: flash@1 {
-		compatible = "spi-nand";
-		reg = <1>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-		};
-	};
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy0: ethernet-phy@0 {
-		reg = <0>;
-		phy-mode = "sgmii";
-
-		qca,ar8327-initvals = <
-			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
-			0x7c 0x0000007e /* PORT0_STATUS */
-		>;
-	};
-};
-
-&eth0 {
-	status = "okay";
-
-	phy-mode = "sgmii";
-	phy-handle = <&phy0>;
-};
-
-&pcie {
-	status = "okay";
-
-	wifi_ath10k: wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x0 0 0 0 0>;
-	};
 };
 
 &pinmux {
 	enable_wlan_led_gpio: pinmux_wlan_led_gpio {
 		pinctrl-single,bits = <0x10 0x0 0xff000000>;
 	};
-};
-
-&wmac {
-	status = "okay";
-};
-
-&usb_phy0 {
-	status = "okay";
-};
-
-&usb0 {
-	status = "okay";
-};
-
-&usb_phy1 {
-	status = "okay";
-};
-
-&usb1 {
-	status = "okay";
 };

--- a/target/linux/ath79/dts/qca9563_zte_mf28x.dtsi
+++ b/target/linux/ath79/dts/qca9563_zte_mf28x.dtsi
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// Copyright (c) 2021 Cezary Jackiewicz
+// Copyright (c) 2021, 2022 Lech Perczak
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_debug;
+		led-failsafe = &led_debug;
+		led-running = &led_debug;
+		led-upgrade = &led_debug;
+		label-mac-device = &eth0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		/* Hidden SMD LED below signal strength LEDs.
+		 * Visible through slits underside of the case,
+		 * and slightly through the case below signal state LEDs
+		 */
+		led_debug: led-0 {
+			function = LED_FUNCTION_DEBUG;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	/* This GPIO is used to reset whole board _including_ the modem */
+	gpio-restart {
+		compatible = "gpio-restart";
+		gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		active-delay = <3000>;
+		inactive-delay = <1000>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	boot_flash: flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+	};
+
+	system_flash: flash@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&pcie {
+	status = "okay";
+
+	wifi_ath10k: wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0 0 0 0 0>;
+	};
+};
+
+&wmac {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -390,6 +390,14 @@ define Device/zte_mf281
 endef
 TARGET_DEVICES += zte_mf281
 
+define Device/zte_mf282
+  $(Device/zte_mf28x_common)
+  DEVICE_MODEL := MF282
+  DEVICE_PACKAGES += ath10k-firmware-qca988x-ct kmod-usb-net-qmi-wwan \
+	kmod-usb-serial-option uqmi
+endef
+TARGET_DEVICES += zte_mf282
+
 define Device/zte_mf286
   $(Device/zte_mf28x_common)
   DEVICE_MODEL := MF286

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -66,6 +66,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "5:lan"
 		;;
+	zte,mf282)
+		ucidef_set_interface_lan "eth0"
+		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
+		;;
 	zte,mf286|\
 	zte,mf286a|\
 	zte,mf286r)


### PR DESCRIPTION
The ZTE MF282 is a LTE router used (exclusively?) by the network operator "3".

Specifications
==============

SoC: QCA9563 (775MHz)
RAM: 128MiB
Flash: 8MiB SPI-NOR + 128MiB SPI-NAND
LAN: 1x GBit LAN
LTE: ZTE MF270 (Cat4), detected as P685M
WiFi: QCA9880ac + QCA9560bgn

MAC addresses
=============

LAN: from config
WiFi 1: from config
WiFi 2: +1

Installation
============

TFTP installation using UART is preferred. Disassemble the device and connect serial. Put the initramfs image as openwrt.bin to your TFTP server and configure a static IP of 192.168.1.100. Load the initramfs image by typing:

  setenv serverip 192.168.1.100
  setenv ipaddr 192.168.1.1
  tftpboot 0x82000000 openwrt.bin
  bootm 0x82000000

From this intiramfs boot you can take a backup of the currently installed partitions as no vendor firmware is available for download.

Once booted, transfer the sysupgrade image and run sysupgrade.

LTE Modem
=========

The LTE modem is probably the same as in the MF283+, all instructions apply.

Configuring the connection using modemmanager works properly, the modem provides three serial ports and a QMI CDC ethernet interface.
