### PR TITLE
ramips: add Xiaomi RA75 red signal led

### DIFF
--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-ra75.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-ra75.dts
@@ -32,6 +32,10 @@
 			label = "amber:signal";
 			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
 		};
+		led_signal_red: signal_red {
+			label = "red:signal";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+		};
 	};
 
 	keys {
@@ -49,6 +53,13 @@
 		};
 	};
 
+};
+
+&state_default {
+	gpio {
+		groups = "gpio", "refclk", "wdt", "wled_an", "uart1";
+		function = "gpio";
+	};
 };
 
 &partitions {


### PR DESCRIPTION
RA75 has 5 physical LEDs under 2 indicators, mixed with light pipes:
Indicator "System":
  GPIO0: blue
  GPIO2: amber
Indicator "Signal":
  GPIO44: blue
  GPIO37: amber
  GPIO46: red

All except GPIO46 were already added by Jo Deisenhofer. GPIO46 is used for UART1 by default, so it needs additional pin control change in devicetree to be operational. 
Verified on my RA75.

Note: The pin control change overrides the similar block in mt7628an_xiaomi_mi-router-4.dtsi. I'm 95% sure that uart1 can be disabled without copying of state_default block, directly in the dtsi for all Xiaomi routers that include the dtsi. I doubt those routers really use uart1. But I don't have that hardware for testing, and potentially such a change can break those HW variants. I'm open to the suggestions whether to move the uart1 disabling change to the dtsi (Mi Router 4a and Mi router 4c are affected) or leave it as is.