### PR TITLE
tools/cmake: update to 3.26.3

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
-PKG_VERSION:=3.26.0
+PKG_VERSION:=3.26.3
 PKG_VERSION_MAJOR:=$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:kitware:cmake
@@ -15,7 +15,7 @@ PKG_CPE_ID:=cpe:/a:kitware:cmake
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Kitware/CMake/releases/download/v$(PKG_VERSION)/ \
 		https://cmake.org/files/v$(PKG_VERSION_MAJOR)/
-PKG_HASH:=4256613188857e95700621f7cdaaeb954f3546a9249e942bc2f9b3c26e381365
+PKG_HASH:=bbd8d39217509d163cb544a40d6428ac666ddc83e22905d3e52c925781f0f659
 
 HOST_BUILD_PARALLEL:=1
 HOST_CONFIGURE_PARALLEL:=1


### PR DESCRIPTION
Release Notes:
- https://www.kitware.com/cmake-3-26-1-available-for-download/
- https://www.kitware.com/cmake-3-26-2-available-for-download/
- https://www.kitware.com/cmake-3-26-3-available-for-download/
