### PR TITLE
ramips: mt7621: add Cudy X6 v2

### DIFF
--- a/target/linux/ramips/dts/mt7621_cudy_x6-v1.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_x6-v1.dts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_cudy_x6.dtsi"
+
+/ {
+	compatible = "cudy,x6-v1", "mediatek,mt7621-soc";
+	model = "CUDY X6 v1";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0x1f80000>;
+	};
+
+	partition@1fd0000 {
+		label = "debug";
+		reg = <0x1fd0000 0x10000>;
+		read-only;
+	};
+
+	partition@1fe0000 {
+		label = "backup";
+		reg = <0x1fe0000 0x10000>;
+		read-only;
+	};
+
+	partition@1ff0000 {
+		label = "bdinfo";
+		reg = <0x1ff0000 0x10000>;
+		read-only;
+
+		compatible = "nvmem-cells";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_bdinfo_de00: macaddr@de00 {
+			reg = <0xde00 0x6>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&wifi {
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/ramips/dts/mt7621_cudy_x6-v2.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_x6-v2.dts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_cudy_x6.dtsi"
+
+/ {
+	compatible = "cudy,x6-v2", "mediatek,mt7621-soc";
+	model = "CUDY X6 v2";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0xf80000>;
+	};
+
+	partition@fd0000 {
+		label = "debug";
+		reg = <0xfd0000 0x10000>;
+		read-only;
+	};
+
+	partition@fe0000 {
+		label = "backup";
+		reg = <0xfe0000 0x10000>;
+		read-only;
+	};
+
+	partition@ff0000 {
+		label = "bdinfo";
+		reg = <0xff0000 0x10000>;
+		read-only;
+
+		compatible = "nvmem-cells";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_bdinfo_de00: macaddr@de00 {
+			reg = <0xde00 0x6>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&wifi {
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/ramips/dts/mt7621_cudy_x6.dtsi
+++ b/target/linux/ramips/dts/mt7621_cudy_x6.dtsi
@@ -6,9 +6,6 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "cudy,x6", "mediatek,mt7621-soc";
-	model = "CUDY X6";
-
 	aliases {
 		led-boot = &led_internet_blue;
 		led-failsafe = &led_internet_red;
@@ -61,7 +58,7 @@
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 
-		partitions {
+		partitions: partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -84,37 +81,7 @@
 				read-only;
 			};
 
-			partition@50000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x50000 0x1f80000>;
-			};
-
-			partition@1fd0000 {
-				label = "debug";
-				reg = <0x1fd0000 0x10000>;
-				read-only;
-			};
-
-			partition@1fe0000 {
-				label = "backup";
-				reg = <0x1fe0000 0x10000>;
-				read-only;
-			};
-
-			partition@1ff0000 {
-				label = "bdinfo";
-				reg = <0x1ff0000 0x10000>;
-				read-only;
-
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				macaddr_bdinfo_de00: macaddr@de00 {
-					reg = <0xde00 0x6>;
-				};
-			};
+			/* additional partitions in DTS */
 		};
 	};
 };
@@ -124,30 +91,18 @@
 };
 
 &pcie1 {
-	wifi@0,0 {
+	wifi:wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		mediatek,disable-radar-background;
-
-		nvmem-cells = <&macaddr_bdinfo_de00>;
-		nvmem-cell-names = "mac-address";
 	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_bdinfo_de00>;
-	nvmem-cell-names = "mac-address";
 };
 
 &gmac1 {
 	status = "okay";
 	label = "wan";
 	phy-handle = <&ethphy4>;
-
-	nvmem-cells = <&macaddr_bdinfo_de00>;
-	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &mdio {

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -520,16 +520,29 @@ define Device/cudy_wr2100
 endef
 TARGET_DEVICES += cudy_wr2100
 
-define Device/cudy_x6
+define Device/cudy_x6-v1
   $(Device/dsa-migration)
   IMAGE_SIZE := 32256k
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := X6
+  DEVICE_VARIANT := v1
   UIMAGE_NAME := R13
   DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
-  SUPPORTED_DEVICES += R13
+  SUPPORTED_DEVICES += cudy,x6 R13
 endef
-TARGET_DEVICES += cudy_x6
+TARGET_DEVICES += cudy_x6-v1
+
+define Device/cudy_x6-v2
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 15872k
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := X6
+  DEVICE_VARIANT := v2
+  UIMAGE_NAME := R30
+  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  SUPPORTED_DEVICES += cudy,x6 R30
+endef
+TARGET_DEVICES += cudy_x6-v2
 
 define Device/dlink_dap-x1860-a1
   $(Device/dsa-migration)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -27,7 +27,8 @@ case "$board" in
 		hw_mac_addr=$(macaddr_unsetbit $hw_mac_addr 28)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $hw_mac_addr > /sys${DEVPATH}/macaddress
 		;;
-	cudy,x6)
+	cudy,x6-v1|\
+	cudy,x6-v2)
 		hw_mac_addr="$(mtd_get_mac_binary bdinfo 0xde00)"
 		[ "$PHYNBR" = "1" ] && \
 		macaddr_setbit_la "$(macaddr_add $hw_mac_addr 0x100000)" > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
This PR adds support for the Cudy X6 v2 and at the same time improves support for v1:
- Corrects the WiFi MAC addresses to match oem/stock behavior.
- Also makes use of the red led: default for failsafe and upgrade (instead of the blue led)

This adds a common .dtsi file for both devices. The .dts files themselves only differ due to the smaller flash size of v2 which causes the partitions to be at different offsets.
______________

About the WiFi Mac correction:
v1 and v2 assign the MAC for 5GHz WiFi slightly differently.
Both set the LA bit, but v1 then adds 0x100000 while v2 adds 0x300000. (at least this is the case for the two devices I own)
OpenWrt now adds 0x100000 in all cases, which is fine I think (the LA bit is set after all).
The previously used mac addresses from the factory partition were completely wrong and belong to Ralink instead of Cudy.

EDIT:
`ramips: Cudy X6 fixes / improvements`
was already merged in 45cf200b2e22c34f2ae043b87e24230de526fefc

The only remaining part is merging the support for X6 v2