### PR TITLE
ramips: add support for TOZED ZLT S12 PRO

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -208,6 +208,7 @@ generate_network() {
 			}
 		;;
 
+		ncm|\
 		qmi|\
 		mbim)
 			uci -q batch <<-EOF

--- a/package/network/utils/comgt/files/ncm.json
+++ b/package/network/utils/comgt/files/ncm.json
@@ -124,5 +124,17 @@
 		"connect": "AT+ZGACT=1,${context_type}",
 		"finalize": "AT+ZDHCPLEASE=0",
 		"disconnect": "AT+ZGACT=0,1"
+	},
+	"spreadtrum": {
+		"initialize": [
+			"AT+CFUN=1",
+			"AT+CCED=2,8",
+			"AT+SPTTYROUTER=1"
+		],
+		"configure": [
+			"AT+CGDCONT=${profile},\\\"${pdptype}\\\"${apn:+,\\\"$apn\\\"}"
+		],
+		"connect": "AT+SPTZCMD=\\\"Y29ubm1hbmN0bCBuZGlzZGlhbCBBVF5ORElTRFVOPSJ1c2IwIiwxLDE=\\\"",
+		"disconnect": "AT+SPTZCMD=\\\"Y29ubm1hbmN0bCBuZGlzZGlhbCBBVF5ORElTRFVOPSJ1c2IwIiwwLDE=\\\""
 	}
 }

--- a/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
@@ -5,7 +5,7 @@
 
 / {
 	compatible = "d-team,newifi-d2", "mediatek,mt7621-soc";
-	model = "Newifi-D2";
+	model = "D-Team Newifi D2";
 
 	aliases {
 		led-boot = &led_power_blue;

--- a/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
+++ b/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
@@ -5,7 +5,7 @@
 
 / {
 	compatible = "lenovo,newifi-d1", "mediatek,mt7621-soc";
-	model = "Newifi-D1";
+	model = "Lenovo Newifi D1";
 
 	aliases {
 		led-boot = &led_blue;

--- a/target/linux/ramips/dts/mt7621_tozed_zlt-s12-pro.dts
+++ b/target/linux/ramips/dts/mt7621_tozed_zlt-s12-pro.dts
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tozed,zlt-s12-pro", "mediatek,mt7621-soc";
+	model = "TOZED ZLT S12 PRO";
+
+	aliases {
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_yellow;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+		label-mac-device = &wifi1;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-modem-blue {
+			label = "blue:modem";
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+		};
+
+		led-modem-red {
+			label = "red:modem";
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_blue: led-power-blue {
+			label = "blue:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_yellow: led-power-yellow {
+			label = "yellow:power";
+			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
+		};
+
+		led-wifi {
+			label = "blue:wifi";
+			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-signal1 {
+			label = "blue:signal1";
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led-signal2 {
+			label = "blue:signal2";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+		};
+
+		led-signal3 {
+			label = "blue:signal3";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		led-signal4 {
+			label = "blue:signal4";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		led-signal5 {
+			label = "blue:signal5";
+			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
+		};
+
+		led-phone {
+			label = "blue:phone";
+			gpios = <&gpio 31 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		button-rfkill {
+			label = "rfkill";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+		button-wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+
+		lt72_ant0 {
+			gpio-export,name = "lt72_ant0";
+			gpio-export,input = <0>;
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		lt72_ant1 {
+			gpio-export,name = "lt72_ant1";
+			gpio-export,input = <0>;
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		lt72_power {
+			gpio-export,name = "lt72_power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x8000>;
+				read-only;
+			};
+
+			// Stock config partition
+			partition@38000 {
+				label = "tozed-conf";
+				reg = <0x38000 0x8000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi0: mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 {
+	wifi1: mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "rgmii2", "jtag", "uart3";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2135,6 +2135,16 @@ define Device/totolink_x5000r
 endef
 TARGET_DEVICES += totolink_x5000r
 
+define Device/tozed_zlt-s12-pro
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := TOZED
+  DEVICE_MODEL := ZLT S12 PRO
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 comgt-ncm -uboot-envtools
+endef
+TARGET_DEVICES += tozed_zlt-s12-pro
+
 define Device/tplink_archer-ax23-v1
   $(Device/dsa-migration)
   $(Device/tplink-safeloader)

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -774,8 +774,8 @@ define Device/d-team_newifi-d2
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 32448k
-  DEVICE_VENDOR := Newifi
-  DEVICE_MODEL := D2
+  DEVICE_VENDOR := D-Team
+  DEVICE_MODEL := Newifi D2
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
 	kmod-usb-ledtrig-usbport -uboot-envtools
 endef
@@ -1425,8 +1425,8 @@ define Device/lenovo_newifi-d1
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 32448k
-  DEVICE_VENDOR := Newifi
-  DEVICE_MODEL := D1
+  DEVICE_VENDOR := Lenovo
+  DEVICE_MODEL := Newifi D1
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-sdhci-mt7620 \
 	kmod-usb-ledtrig-usbport -uboot-envtools
   SUPPORTED_DEVICES += newifi-d1

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -108,6 +108,10 @@ ramips_setup_interfaces()
 	mikrotik,routerboard-760igs)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan sfp"
 		;;
+	tozed,zlt-s12-pro)
+		ucidef_set_interface "wwan" device "/dev/ttyUSB0" protocol "ncm"
+		uci add_list firewall.@zone[1].network='wwan'
+		;;
 	tplink,deco-m4r-v4)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -12,6 +12,9 @@ mikrotik,routerboard-760igs)
 telco-electronics,x1)
 	ucidef_add_gpio_switch "modem_reset" "Modem Reset" "496"
 	;;
+tozed,zlt-s12-pro)
+	ucidef_add_gpio_switch "lt72_power" "Power LTE modem" "lt72_power" "1"
+	;;
 tplink,eap235-wall-v1|\
 tplink,eap615-wall-v1)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "poe-passthrough"


### PR DESCRIPTION
Hello, this PR adds support for the TOZED LT70-C cellular modem and TOZED ZLT S12 PRO router. I am also adding the vendor name to Lenovo Newifi D1 and D-Team Newifi D2 devices.