### PR TITLE
ath79: create APBoot-compatible image for Aruba AP-175

### DIFF
--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -407,6 +407,12 @@ define Device/aruba_ap-175
   DEVICE_MODEL := AP-175
   IMAGE_SIZE := 16000k
   DEVICE_PACKAGES := kmod-gpio-pca953x kmod-hwmon-lm75 kmod-i2c-gpio kmod-rtc-ds1374
+  LOADER_TYPE := bin
+  LOADER_FLASH_OFFS := 0x42000
+  COMPILE := loader-$(1).bin
+  COMPILE/loader-$(1).bin := loader-okli-compile
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x4f4b4c49 | loader-okli $(1) 8128 | uImage none
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
 endef
 TARGET_DEVICES += aruba_ap-175
 


### PR DESCRIPTION
As was done in commit e11d00d44c66 ("ath79: create Aruba AP-105 APBoot compatible image"), alter the Aruba AP-175 image generation process so OpenWrt can be loaded with the vendor Aruba APBoot. Since the remainder of the explanation and installation process is identical, continuing the quote from that commit:

> This works by prepending the OpenWrt LZMA loader to the uImage and
> jumping directly to the loader. Aruba does not offer bootm on these
> boards.

> This approach keeps compatibility to devices which had their U-Boot
> replaced. Both bootloaders can boot the same image.

> With this patch, new installations do not require replacing the
> bootloader and can be performed from the serial console without
> opening the case.

> Installation
> ------------

> 1. Attach to the serial console of the AP-175.
>    Interrupt autoboot and change the U-Boot env.

>    $ setenv apb_rb_openwrt "setenv ipaddr 192.168.1.1;
>      setenv serverip 192.168.1.66;
>      netget 0x84000000 ap175.bin; go 0x84000040"
>    $ setenv apb_fb_openwrt "cp.b 0xbf040000 0x84000000 0x10000;
>      go 0x84000040"
>    $ setenv bootcmd "run apb_fb_openwrt"
>    $ saveenv

> 2. Load the OpenWrt initramfs image on the device using TFTP.
>    Place the initramfs image as "ap175.bin" in the TFTP server
>    root directory, connect it to the AP and make the server reachable
>    at 192.168.1.66/24.

>    $ run apb_rb_openwrt

> 3. Once OpenWrt booted, transfer the sysupgrade image to the device
>    using scp and use sysupgrade to install the firmware.

Signed-off-by: Martin Kennedy <hurricos@gmail.com>