### PR TITLE
 ath79: fix broken switch/networking for WZR-HP-G300NH devices

### DIFF
--- a/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh.dtsi
+++ b/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh.dtsi
@@ -178,7 +178,6 @@
 
 		gpio-sda = <&gpio 19 GPIO_ACTIVE_HIGH>;
 		gpio-sck = <&gpio 20 GPIO_ACTIVE_HIGH>;
-		mii-bus = <&mdio0>;
 
 		mdio-bus {
 			status = "okay";

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -611,13 +611,14 @@ endef
 define Device/buffalo_wzr-hp-g300nh-rb
   $(Device/buffalo_wzr-hp-g300nh)
   DEVICE_MODEL := WZR-HP-G300NH (RTL8366RB switch)
+  DEVICE_PACKAGES += kmod-switch-rtl8366rb
 endef
 TARGET_DEVICES += buffalo_wzr-hp-g300nh-rb
 
 define Device/buffalo_wzr-hp-g300nh-s
   $(Device/buffalo_wzr-hp-g300nh)
   DEVICE_MODEL := WZR-HP-G300NH (RTL8366S switch)
-  DEVICE_PACKAGES += kmod-switch-rtl8366rb
+  DEVICE_PACKAGES += kmod-switch-rtl8366s
 endef
 TARGET_DEVICES += buffalo_wzr-hp-g300nh-s
 


### PR DESCRIPTION
Switch drivers for RTL8366S/RB were packaged as modules but not properly added to device definitions for WZR-HP-G300NH router variants (https://github.com/openwrt/openwrt/commit/6e0f0eae5b48bddead035d9dd89b710c10c50337 and https://github.com/openwrt/openwrt/commit/575ec7a4b1a085f243961ef13dd23f228a60e67e), breaking network access on installation or upgrade. 

Additionally, the change from built-in to loadable modules affects the driver probing process, which now tries to manage the switch via SMI, fails, but doesn't fall back to using GPIOs. This again breaks switch initialization and network access.

To fix these problems:

- Assign the correct switch driver package to each router.
- Force GPIO usage (the original behaviour) by dropping the "mii-bus" DTS definition.

Copying relevant contributors for this device: @msandber and @luizluca .

Based on past ath79 activity, could you also please take a look at this: @robimarko , @hauke , @chunkeey ?

Thanks everyone.