### PR TITLE
scripts/feeds: use partial clone for src-git-full

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -164,9 +164,9 @@ my %update_method = (
 		'controldir'	=> ".git",
 		'revision'	=> "git rev-parse --short HEAD | tr -d '\n'"},
 	'src-git-full' => {
-		'init'          => "git clone '%s' '%s'",
-		'init_branch'   => "git clone --branch '%s' '%s' '%s'",
-		'init_commit'   => "git clone '%s' '%s' && cd '%s' && git checkout -b '%s' '%s' && cd -",
+		'init'          => "git clone --filter=blob:none '%s' '%s'",
+		'init_branch'   => "git clone --filter=blob:none --branch '%s' '%s' '%s'",
+		'init_commit'   => "git clone --filter=blob:none '%s' '%s' && cd '%s' && git checkout -b '%s' '%s' && cd -",
 		'update'	=> "git pull --ff-only",
 		'update_force'	=> "git pull --ff-only || (git reset --hard HEAD; git pull --ff-only; exit 1)",
 		'post_update'	=> "git submodule update --init --recursive",


### PR DESCRIPTION
Partial clone is much faster without clipping history
