### PR TITLE
ramips: improve support of TP-Link EC330-G5u v1

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_ec330-g5u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_ec330-g5u-v1.dts
@@ -11,6 +11,8 @@
 	model = "TP-Link EC330-G5u v1";
 
 	aliases {
+		label-mac-device = &gmac0;
+
 		led-boot = &led_power;
 		led-failsafe = &led_power;
 		led-running = &led_power;
@@ -226,6 +228,14 @@
 			label = "factory";
 			reg = <0x7800000 0x400000>;
 			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_factory_165: macaddr@165 {
+				reg = <0x165 0x11>;
+			};
 		};
 
 		partition@0_wholeflash {
@@ -246,6 +256,9 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <2400000 2500000>;
+
+		nvmem-cells = <&macaddr_factory_165>;
+		nvmem-cell-names = "mac-address-ascii";
 	};
 };
 
@@ -255,13 +268,26 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x14000>;
 		ieee80211-freq-limit = <5000000 6000000>;
+
+		nvmem-cells = <&macaddr_factory_165>;
+		nvmem-cell-names = "mac-address-ascii";
+		mac-address-increment = <(2)>;
 	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_165>;
+	nvmem-cell-names = "mac-address-ascii";
 };
 
 &gmac1 {
 	status = "okay";
 	label = "wan";
 	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_factory_165>;
+	nvmem-cell-names = "mac-address-ascii";
+	mac-address-increment = <(1)>;
 };
 
 &mdio {

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2214,6 +2214,9 @@ define Device/tplink_ec330-g5u-v1
 	uImage-tplink-c9 firmware 'OS IMAGE ($(VERSION_DIST))'
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | \
 	uImage none
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata | check-size
 endef
 TARGET_DEVICES += tplink_ec330-g5u-v1

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -245,11 +245,6 @@ ramips_setup_macs()
 		label_mac=$(cat "/sys/firmware/mikrotik/hard_config/mac_base")
 		lan_mac=$label_mac
 		;;
-	tplink,ec330-g5u-v1)
-		label_mac="$(mtd_get_mac_text factory 0x165)"
-		lan_mac=$label_mac
-		wan_mac=$(macaddr_add $label_mac 1)
-		;;
 	tplink,er605-v2)
 		CI_UBIPART="firmware"
 		label_mac=$(mtd_get_mac_uci_config_ubi "tddp")

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -161,11 +161,6 @@ case "$board" in
 		hw_mac_addr="$(mtd_get_mac_binary product-info 0x8)"
 		macaddr_add "$hw_mac_addr" "$PHYNBR" > "/sys${DEVPATH}/macaddress"
 		;;
-	tplink,ec330-g5u-v1)
-		hw_mac_addr="$(mtd_get_mac_text factory 0x165)"
-		[ "$PHYNBR" = "0" ] && echo -n $hw_mac_addr > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
-		;;
 	yuncore,ax820)
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary Factory 0xe000)" > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
This PR contains a few improvements for TP-Link EC330-G5u v1:
- Add factory image. This allows to install OpenWrt without connecting a serial cable (UART)
- Switch to "mac-address-ascii" in dts. This allows us drop workarounds in OpenWrt network scripts.

All changes were tested on a real device.