### PR TITLE
mediatek: fix 2.5G LED for TP-Link TL-XDR4288/608x

### DIFF
--- a/target/linux/generic/hack-5.15/766-net-phy-realtek-add-led-link-select-for-RTL8221.patch
+++ b/target/linux/generic/hack-5.15/766-net-phy-realtek-add-led-link-select-for-RTL8221.patch
@@ -1,0 +1,69 @@
+From f9e17c264d316611c26b98ad1a3ca01c289c67b4 Mon Sep 17 00:00:00 2001
+From: Yangyu Chen <cyy@cyyself.name>
+Date: Sun, 23 Apr 2023 20:06:41 +0800
+Subject: [PATCH] net: phy: realtek: add led-link-select for RTL8221
+
+RTL8221B PHYs will select the different speeds for 3 LEDs to 10M/100M/1G
+respectively by default. Some devices like TP-LINK XDR-6088/XDR-6086
+have only one LED connects to the PHY chip LED0. If we didn't change the
+default settings, the LED will only blink at 10M speed.
+
+This patch allows configuring LED link select bitmask from DT. And it
+has been tested with TP-Link XDR6088 with different DT configurations.
+
+Signed-off-by: Yangyu Chen <cyy@cyyself.name>
+---
+ drivers/net/phy/realtek.c | 28 +++++++++++++++++++++++++++-
+ 1 file changed, 27 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/phy/realtek.c
++++ b/drivers/net/phy/realtek.c
+@@ -66,6 +66,10 @@
+ #define RTL8221B_PHYCR1_ALDPS_EN		BIT(2)
+ #define RTL8221B_PHYCR1_ALDPS_XTAL_OFF_EN	BIT(12)
+ 
++#define RTL8221B_NR_LEDS				3
++#define RTL8221B_LED_LINK_SELECT		0xd032
++#define RTL8221B_LED_LINK_SELECT_OFFSET	0x2
++
+ #define RTL8366RB_POWER_SAVE			0x15
+ #define RTL8366RB_POWER_SAVE_ON			BIT(12)
+ 
+@@ -885,6 +889,28 @@ static irqreturn_t rtl9000a_handle_inter
+ 	return IRQ_HANDLED;
+ }
+ 
++static int rtl8221b_config_led(struct phy_device *phydev) {
++	struct device *node = &phydev->mdio.dev;
++	u32 link_select[RTL8221B_NR_LEDS];
++	int i, val;
++
++	val = device_property_read_u32_array(node, "realtek,led-link-select", 
++			link_select, RTL8221B_NR_LEDS);
++
++	if (val)
++		return 0;
++
++	for (i = 0; i < RTL8221B_NR_LEDS; i++) {
++		val = phy_write_mmd(phydev, RTL8221B_MMD_PHY_CTRL, 
++			RTL8221B_LED_LINK_SELECT + i * RTL8221B_LED_LINK_SELECT_OFFSET, 
++			link_select[i]);
++		if (val < 0)
++			return val;
++	}
++
++	return 0;
++}
++
+ static int rtl8221b_config_init(struct phy_device *phydev)
+ {
+ 	u16 option_mode;
+@@ -932,7 +958,7 @@ static int rtl8221b_config_init(struct p
+ 	phy_read_mmd_poll_timeout(phydev, RTL8221B_MMD_SERDES_CTRL, 0x7587,
+ 				  val, !(val & BIT(0)), 500, 100000, false);
+ 
+-	return 0;
++	return rtl8221b_config_led(phydev);
+ }
+ 
+ static struct phy_driver realtek_drvs[] = {

--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
@@ -126,6 +126,7 @@
 		reset-deassert-us = <100000>;
 		reset-gpios = <&pio 13 GPIO_ACTIVE_LOW>;
 		realtek,aldps-enable;
+		realtek,led-link-select = <0xa7 0x0 0x0>;
 	};
 
 	phy7: ethernet-phy@7 {
@@ -135,6 +136,7 @@
 		reset-deassert-us = <100000>;
 		reset-gpios = <&pio 17 GPIO_ACTIVE_LOW>;
 		realtek,aldps-enable;
+		realtek,led-link-select = <0xa7 0x0 0x0>;
 	};
 
 	switch: switch@31 {


### PR DESCRIPTION
This patch fixed the LED only blinking at 10Mbps speed from the RTL8221B PHYs for TP-Link TL-XDR4288/608x by adding `realtek,led-link-select` property to the PHY driver and setting all speeds(2.5G/2.5GLite/1G/100M/10M) bitmask on LED0 in the device tree.

Run-tested: TP-Link TL-XDR6088