### PR TITLE
base-files: preserve user-added sysctl.d files

### DIFF
--- a/package/base-files/files/etc/sysctl.conf
+++ b/package/base-files/files/etc/sysctl.conf
@@ -1,1 +1,5 @@
-# Defaults are configured in /etc/sysctl.d/* and can be customized in this file
+# Per-package and local customizations can be made in /etc/sysctl.d/*,
+# and are sourced in lexical order, so keep that in mind when trying to
+# override a package's defaults.
+#
+# This file is sourced last.

--- a/package/base-files/files/lib/upgrade/keep.d/base-files-essential
+++ b/package/base-files/files/lib/upgrade/keep.d/base-files-essential
@@ -8,4 +8,5 @@
 /etc/shells
 /etc/shinit
 /etc/sysctl.conf
+/etc/sysctl.d/
 /etc/rc.local


### PR DESCRIPTION
It's inconsistent that we do a `sysupgrade` backup of `/etc/sysctl.conf` but not `/etc/sysctl.d/`.

Indeed, most people would probably prefer to add a `local.conf` file to that directory, rather than modify one if the system distribution files.