### PR TITLE
ccache: explicitly use depend mode only

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -290,6 +290,7 @@ ifneq ($(CONFIG_CCACHE),)
   export CCACHE_BASEDIR:=$(TOPDIR)
   export CCACHE_DIR:=$(if $(call qstrip,$(CONFIG_CCACHE_DIR)),$(call qstrip,$(CONFIG_CCACHE_DIR)),$(TOPDIR)/.ccache)
   export CCACHE_COMPILERCHECK:=%compiler% -dumpmachine; %compiler% -dumpversion
+  export CCACHE_DEPEND CCACHE_NODIRECT
 endif
 
 TARGET_CONFIGURE_OPTS = \


### PR DESCRIPTION
Depend mode in ccache is more strict,
making the event of a cache miss and recompilation to be more likely after a very small change
like the configuration options in part of the toolchain.

In addition, the overhead of a cache miss is smaller due to ccache not attempting to use the preprocessor in a second attempt to make a cache hit.