### PR TITLE
busybox: Activate resize tool by default

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -982,7 +982,7 @@ config BUSYBOX_DEFAULT_RESET
 	default y
 config BUSYBOX_DEFAULT_RESIZE
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_RESIZE_PRINT
 	bool
 	default n


### PR DESCRIPTION
The resize tool will resize the prompt to match the current terminal size. This is helpful when connecting to the system using UART to make the vi or top output match the current terminal size.

This increases the busybox binary size by 136 bytes and the ipkg size by 335 bytes on aarch64.