### PR TITLE
busybox: turn on BUSYBOX_DEFAULT_ASH_RANDOM_SUPPORT in order to have $RANDOM

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -3023,7 +3023,7 @@ config BUSYBOX_DEFAULT_ASH_ALIAS
 	default y
 config BUSYBOX_DEFAULT_ASH_RANDOM_SUPPORT
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_ASH_EXPAND_PRMT
 	bool
 	default y


### PR DESCRIPTION
Replaces https://github.com/openwrt/openwrt/pull/12291/ and https://github.com/openwrt/packages/pull/20728

From the proposal in this comment: https://github.com/openwrt/openwrt/pull/12291#issuecomment-1519018979

As estimated here, https://github.com/openwrt/openwrt/pull/12291#issuecomment-1490639789, this change is expected to increase the image size by few hundreds bytes.

Allows the users to use the $RANDOM variable, which is a very convenient way to get a random number between 0 and 32767.
