### PR TITLE
kernel: do not inline MEMREAD/MEMWRITE ioctls

### DIFF
--- a/target/linux/generic/pending-5.15/450-mtdchar-mark-bits-of-ioctl-handler-noinline.patch
+++ b/target/linux/generic/pending-5.15/450-mtdchar-mark-bits-of-ioctl-handler-noinline.patch
@@ -1,0 +1,47 @@
+From 31e7ce9a06e3624dddaaebec68ab0f1494620834 Mon Sep 17 00:00:00 2001
+From: Arnd Bergmann <arnd@arndb.de>
+Date: Mon, 17 Apr 2023 22:56:50 +0200
+Subject: [PATCH] mtdchar: mark bits of ioctl handler noinline
+
+The addition of the mtdchar_read_ioctl() function caused the stack usage
+of mtdchar_ioctl() to grow beyond the warning limit on 32-bit architectures
+with gcc-13:
+
+drivers/mtd/mtdchar.c: In function 'mtdchar_ioctl':
+drivers/mtd/mtdchar.c:1229:1: error: the frame size of 1488 bytes is larger than 1024 bytes [-Werror=frame-larger-than=]
+
+Mark both the read and write portions as noinline_for_stack to ensure
+they don't get inlined and use separate stack slots to reduce the
+maximum usage, both in the mtdchar_ioctl() and combined with any
+of its callees.
+
+Fixes: 095bb6e44eb1 ("mtdchar: add MEMREAD ioctl")
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+---
+ drivers/mtd/mtdchar.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+--- a/drivers/mtd/mtdchar.c
++++ b/drivers/mtd/mtdchar.c
+@@ -573,8 +573,8 @@ static int mtdchar_blkpg_ioctl(struct mt
+ 	}
+ }
+ 
+-static int mtdchar_write_ioctl(struct mtd_info *mtd,
+-		struct mtd_write_req __user *argp)
++static noinline_for_stack int
++mtdchar_write_ioctl(struct mtd_info *mtd, struct mtd_write_req __user *argp)
+ {
+ 	struct mtd_info *master = mtd_get_master(mtd);
+ 	struct mtd_write_req req;
+@@ -621,8 +621,8 @@ static int mtdchar_write_ioctl(struct mt
+ 	return ret;
+ }
+ 
+-static int mtdchar_read_ioctl(struct mtd_info *mtd,
+-		struct mtd_read_req __user *argp)
++static noinline_for_stack int
++mtdchar_read_ioctl(struct mtd_info *mtd, struct mtd_read_req __user *argp)
+ {
+ 	struct mtd_info *master = mtd_get_master(mtd);
+ 	struct mtd_read_req req;


### PR DESCRIPTION
A Linksys E8450 (mt7622) device running current master has recently started crashing [1]:

    [    0.562900] mtk-ecc 1100e000.ecc: probed
    [    0.570254] spi-nand spi2.0: Fidelix SPI NAND was found.
    [    0.575576] spi-nand spi2.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
    [    0.583780] mtk-snand 1100d000.spi: ECC strength: 4 bits per 512 bytes
    [    0.682930] Insufficient stack space to handle exception!
    [    0.682939] ESR: 0x0000000096000047 -- DABT (current EL)
    [    0.682946] FAR: 0xffffffc008c47fe0
    [    0.682948] Task stack:     [0xffffffc008c48000..0xffffffc008c4c000]
    [    0.682951] IRQ stack:      [0xffffffc008008000..0xffffffc00800c000]
    [    0.682954] Overflow stack: [0xffffff801feb00a0..0xffffff801feb10a0]
    [    0.682959] CPU: 1 PID: 1 Comm: swapper/0 Tainted: G S                5.15.107 #0
    [    0.682966] Hardware name: Linksys E8450 (DT)
    [    0.682969] pstate: 800000c5 (Nzcv daIF -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
    [    0.682975] pc : dequeue_entity+0x0/0x250
    [    0.682988] lr : dequeue_task_fair+0x98/0x290
    [    0.682992] sp : ffffffc008c48030
    [    0.682994] x29: ffffffc008c48030 x28: 0000000000000001 x27: ffffff801feb6380
    [    0.683004] x26: 0000000000000001 x25: ffffff801feb6300 x24: ffffff8000068000
    [    0.683011] x23: 0000000000000001 x22: 0000000000000009 x21: 0000000000000000
    [    0.683017] x20: ffffff801feb6380 x19: ffffff8000068080 x18: 0000000017a740a6
    [    0.683024] x17: ffffffc008bae748 x16: ffffffc008bae6d8 x15: ffffffffffffffff
    [    0.683031] x14: ffffffffffffffff x13: 0000000000000000 x12: 0000000f00000101
    [    0.683038] x11: 0000000000000449 x10: 0000000000000127 x9 : 0000000000000000
    [    0.683044] x8 : 0000000000000125 x7 : 0000000000116da1 x6 : 0000000000116da1
    [    0.683051] x5 : 00000000001165a1 x4 : ffffff801feb6e00 x3 : 0000000000000000
    [    0.683058] x2 : 0000000000000009 x1 : ffffff8000068080 x0 : ffffff801feb6380
    [    0.683066] Kernel panic - not syncing: kernel stack overflow
    [    0.683069] SMP: stopping secondary CPUs
    [    1.648361] SMP: failed to stop secondary CPUs 0-1
    [    1.648366] Kernel Offset: disabled
    [    1.648368] CPU features: 0x00003000,00000802
    [    1.648372] Memory Limit: none

The last working revision was reportedly commit e11d00d44c ("ath79: create Aruba AP-105 APBoot compatible image") while the first tested revision that failed with the above message was commit 1416b9bbe9 ("tools/dwarves: update to 1.25").

The exact reason for why these kernel panics started happening has not been thoroughly investigated.  However, since the crash happens right after snand driver initialization, commit fa4dc86e98 ("kernel: backport MEMREAD ioctl") is the most likely culprit.

The panic message quoted above includes mentions of a stack overflow.  A pending upstream kernel patch [2] exists that prevents inlining mtdchar_read_ioctl() and mtdchar_write_ioctl() into mtdchar_ioctl() as the addition of the former triggered compiler warnings related to stack size on some platforms.  Add a backport of that patch in hope of fixing the crashes described above.

[1] https://lists.openwrt.org/pipermail/openwrt-devel/2023-April/040872.html
[2] https://lists.infradead.org/pipermail/linux-mtd/2023-April/097912.html

See also #12225 