### PR TITLE
ipq40xx: convert AVM FRITZ!Repeater 3000 to DSA

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -61,6 +61,7 @@ ipq40xx_setup_interfaces()
 	avm,fritzbox-7530)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
+	avm,fritzrepeater-3000|\
 	cellc,rtl30vw)
 		ucidef_set_interface_lan "lan1 lan2"
 		;;

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-fritzrepeater-3000.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-fritzrepeater-3000.dts
@@ -247,3 +247,23 @@
 		};
 	};
 };
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "lan1";
+};
+
+&swport5 {
+	status = "okay";
+
+	label = "lan2";
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -295,8 +295,7 @@ define Device/avm_fritzrepeater-3000
 	SOC := qcom-ipq4019
 	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct fritz-caldata fritz-tffs-nand
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += avm_fritzrepeater-3000
+TARGET_DEVICES += avm_fritzrepeater-3000
 
 define Device/buffalo_wtr-m2133hp
 	$(call Device/FitImage)


### PR DESCRIPTION
Convert the repeater to DSA.
