### PR TITLE
ipq807x: add Compex WPQ873

### DIFF
--- a/package/boot/uboot-envtools/files/ipq807x
+++ b/package/boot/uboot-envtools/files/ipq807x
@@ -14,6 +14,7 @@ netgear,wax218)
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000" "2"
 	;;
+compex,wpq873|\
 edgecore,eap102|\
 zyxel,nbg7815)
 	idx="$(find_mtd_index 0:appsblenv)"

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -6,9 +6,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firmware/qca-wireless.git
-PKG_SOURCE_DATE:=2023-04-12
-PKG_SOURCE_VERSION:=b22487d729362feaff7d06354353d005a3a9d6b7
-PKG_MIRROR_HASH:=94eea9db636b2cbf6782ec17d8b8fe36770c61ff283702ec418df1a1b09f54ef
+PKG_SOURCE_DATE:=2023-05-22
+PKG_SOURCE_VERSION:=0f73d32e641c4f17e64597da0e6c40ed3cbebe69
+PKG_MIRROR_HASH:=70bd8ecda004528ec74de078d00df792f92322c58c4ec4b0630d1da097a8bc89
 
 PKG_FLAGS:=nonshared
 
@@ -29,6 +29,7 @@ endef
 
 ALLWIFIBOARDS:= \
 	buffalo_wxr-5950ax12 \
+	compex_wpq873 \
 	dynalink_dl-wrx36 \
 	edgecore_eap102 \
 	edimax_cax1800 \
@@ -113,6 +114,7 @@ endef
 # Add $(eval $(call generate-ipq-wifi-package,<devicename>,<display name>))
 
 $(eval $(call generate-ipq-wifi-package,buffalo_wxr-5950ax12,Buffalo WXR-5950AX12))
+$(eval $(call generate-ipq-wifi-package,compex_wpq873,Compex WPQ-873))
 $(eval $(call generate-ipq-wifi-package,dynalink_dl-wrx36,Dynalink DL-WRX36))
 $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))

--- a/target/linux/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq807x/base-files/etc/board.d/02_network
@@ -28,6 +28,7 @@ ipq807x_setup_interfaces()
 	qnap,301w)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 10g-2" "10g-1"
 		;;
+	compex,wpq873|\
 	redmi,ax6|\
 	xiaomi,ax3600)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"

--- a/target/linux/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -10,6 +10,7 @@ case "$FIRMWARE" in
 "ath11k/IPQ8074/hw2.0/cal-ahb-c000000.wifi.bin")
 	case "$board" in
 	buffalo,wxr-5950ax12|\
+	compex,wpq873|\
 	edgecore,eap102|\
 	edimax,cax1800|\
 	dynalink,dl-wrx36|\

--- a/target/linux/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq807x/base-files/lib/upgrade/platform.sh
@@ -66,6 +66,7 @@ platform_do_upgrade() {
 		fw_setenv upgrade_available 1
 		nand_do_upgrade "$1"
 		;;
+	compex,wpq873|\
 	edimax,cax1800|\
 	netgear,wax218)
 		nand_do_upgrade "$1"

--- a/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
+++ b/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
@@ -1,0 +1,487 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright 2023 Nokia */
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Compex WPQ873";
+	compatible = "compex,wpq873", "qcom,ipq8074";
+
+	aliases {
+		serial0 = &blsp1_uart5;
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_red;
+		led-running = &led_system_green;
+		led-upgrade = &led_system_blue;
+		/* Aliases as required by u-boot to patch MAC addresses */
+		ethernet0 = &dp6;
+		ethernet1 = &dp2;
+		ethernet2 = &dp3;
+		ethernet3 = &dp4;
+		label-mac-device = &dp6;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 21 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_red: power-red {
+			label = "red:power";
+			gpios = <&tlmm 42 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+		};
+
+		led_power_blue: power-blue {
+			label = "blue:power";
+			gpios = <&tlmm 43 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+		};
+
+		led_system_red: system-red {
+			label = "red:system";
+			gpios = <&tlmm 28 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+		};
+
+		led_system_green: system-green {
+			label = "green:system";
+			gpios = <&tlmm 18 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+
+		led_system_blue: system-blue {
+			label = "blue:system";
+			gpios = <&tlmm 19 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+		};
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	i2c_pins: i2c-pins {
+		pins = "gpio0", "gpio2";
+		function = "blsp5_i2c";
+		drive-strength = <8>;
+		bias-disable;
+	};
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&blsp1_i2c6 {
+	status = "okay";
+
+	pinctrl-0 = <&i2c_pins>;
+	pinctrl-names = "default";
+};
+
+&prng {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&blsp1_spi1 {
+	status = "okay";
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	button_pins: button_pins {
+		reset_button {
+			pins = "gpio66";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&blsp1_spi1 {
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:sbl1";
+				reg = <0x0 0x50000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "0:mibib";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "0:bootconfig";
+				reg = <0x60000 0x20000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "0:bootconfig1";
+				reg = <0x80000 0x20000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				label = "0:qsee";
+				reg = <0xa0000 0x180000>;
+				read-only;
+			};
+
+			partition@220000 {
+				label = "0:qsee_1";
+				reg = <0x220000 0x180000>;
+				read-only;
+			};
+
+			partition@3a0000 {
+				label = "0:devcfg";
+				reg = <0x3a0000 0x10000>;
+				read-only;
+			};
+
+			partition@3b0000 {
+				label = "0:devcfg_1";
+				reg = <0x3b0000 0x10000>;
+				read-only;
+			};
+
+			partition@3c0000 {
+				label = "0:apdp";
+				reg = <0x3c0000 0x10000>;
+				read-only;
+			};
+
+			partition@3d0000 {
+				label = "0:apdp_1";
+				reg = <0x3d0000 0x10000>;
+				read-only;
+			};
+
+			partition@3e0000 {
+				label = "0:rpm";
+				reg = <0x3e0000 0x40000>;
+				read-only;
+			};
+
+			partition@420000 {
+				label = "0:rpm_1";
+				reg = <0x420000 0x40000>;
+				read-only;
+			};
+
+			partition@460000 {
+				label = "0:cdt";
+				reg = <0x460000 0x10000>;
+				read-only;
+			};
+
+			partition@470000 {
+				label = "0:cdt_1";
+				reg = <0x470000 0x10000>;
+				read-only;
+			};
+
+			partition@480000 {
+				label = "0:appsblenv";
+				reg = <0x480000 0x10000>;
+			};
+
+			partition@490000 {
+				label = "0:appsbl";
+				reg = <0x490000 0xa0000>;
+				read-only;
+			};
+
+			partition@550000 {
+				label = "0:appsbl_1";
+				reg = <0x530000 0xa0000>;
+				read-only;
+			};
+
+			partition@610000 {
+				label = "0:art";
+				reg = <0x5d0000 0x40000>;
+				read-only;
+			};
+
+			partition@650000 {
+				label = "0:ethphyfw";
+				reg = <0x610000 0x80000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <8>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "rootfs";
+				reg = <0x0000000 0x3400000>;
+			};
+
+			partition@3400000 {
+				label = "0:wififw";
+				reg = <0x3400000 0x800000>;
+				read-only;
+			};
+
+			partition@3c00000 {
+				label = "rootfs_1";
+				reg = <0x3c00000 0x3400000>;
+			};
+
+			partition@7000000 {
+				label = "0:wififw_1";
+				reg = <0x7000000 0x800000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&qusb_phy_1 {
+	status = "okay";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&ssphy_1 {
+	status = "okay";
+};
+
+&usb_0 {
+	status = "okay";
+};
+
+&usb_1 {
+	status = "okay";
+};
+
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+
+	qca8075_1: ethernet-phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <1>;
+	};
+
+	qca8075_2: ethernet-phy@2 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <2>;
+	};
+
+	qca8075_3: ethernet-phy@3 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <3>;
+	};
+
+	qca8081: ethernet-phy@28 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <28>;
+		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+	};
+
+};
+
+&switch {
+	status = "okay";
+
+	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
+	switch_lan_bmp = <0x3e>; /* lan port bitmap */
+	switch_wan_bmp = <0x40>; /* wan port bitmap */
+	switch_mac_mode = <0x0>; /* mac mode for uniphy instance0*/
+	switch_mac_mode1 = <0x0f>; /* mac mode for uniphy instance1*/
+	switch_mac_mode2 = <0x0f>; /* mac mode for uniphy instance2*/
+	bm_tick_mode = <0>; /* bm tick mode */
+	tm_tick_mode = <0>; /* tm tick mode */
+
+	qcom,port_phyinfo {
+		port@2 {
+			port_id = <2>;
+			phy_address = <1>;
+		};
+		port@3 {
+			port_id = <3>;
+			phy_address = <2>;
+		};
+		port@4 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+		port@5 {
+			port_id = <6>;
+			phy_address = <28>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp2 {
+        status = "okay";
+        phy-handle = <&qca8075_1>;
+        label = "lan1";
+};
+
+&dp3 {
+        status = "okay";
+        phy-handle = <&qca8075_2>;
+        label = "lan2";
+};
+
+&dp4 {
+        status = "okay";
+        phy-handle = <&qca8075_3>;
+        label = "lan3";
+};
+
+&dp6 {
+        status = "okay";
+        phy-handle = <&qca8081>;
+        label = "wan";
+};
+
+&pcie_qmp0 {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+
+	perst-gpio = <&tlmm 58 GPIO_ACTIVE_LOW>;
+
+	bridge@0,0 {
+		reg = <0x00020000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+	};
+};
+
+&pcie_qmp1 {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+
+	perst-gpio = <&tlmm 62 GPIO_ACTIVE_HIGH>;
+
+	bridge@1,0 {
+		reg = <0x00010000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+	};
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Compex-WPQ873";
+};

--- a/target/linux/ipq807x/image/generic.mk
+++ b/target/linux/ipq807x/image/generic.mk
@@ -31,6 +31,19 @@ define Device/buffalo_wxr-5950ax12
 endef
 TARGET_DEVICES += buffalo_wxr-5950ax12
 
+define Device/compex_wpq873
+       $(call Device/FitImage)
+       $(call Device/UbiFit)
+       DEVICE_VENDOR := Compex
+       DEVICE_MODEL := WPQ873
+       BLOCKSIZE := 128k
+       PAGESIZE := 2048
+       DEVICE_DTS_CONFIG := config@hk09.wpq873
+       SOC := ipq8072
+       IMAGE/factory.ubi := append-ubi | qsdk-ipq-factory-nand
+endef
+TARGET_DEVICES += compex_wpq873
+
 define Device/dynalink_dl-wrx36
 	$(call Device/FitImage)
 	$(call Device/UbiFit)


### PR DESCRIPTION
The Compex WPQ873 is a development board with two M.2 B-key slots for cellular modems.

### Device info
 - IPQ8072A SoC
 - 512MiB RAM
 - 256MiB NAND flash
 - 8MiB SPI NOR
 - 3x 1GigE ports
 - 1x 2.5GigE port
 - 2.4GHz/5GHz AX WLAN
 - 1x USB 3.0 port
 - 1x M.2 B-key socket with PCIe 3.0
 - 1x M.2 B-key socket with PCIe 2.0 and USB 3.0
 - 4x SIM card slots

### Installation

#### Prerequisites 
1. TFTP server
2. 3.3V USB to TTL cable for UART console
   2.54mm pitch 4-pin header for UART is readily provided on board, no modifications are necessary to access it
   TTL connector pinout: 2=TX, 3=RX, 4=GND
   Arrow marks pin 1 which is 3.3V
   Serial port settings: 115200 8N1 no flow control

The device will most likely ship with a QSDK-based firmware.

1. Power on device and interrupt u-boot to obtain u-boot CLI
2. set serverip to IP address of the TFTP server, for example:
        `setenv serverip 192.168.1.10`
3. Download image from TFTP server:
        `tftpboot 0x44000000 openwrt-ipq807x-generic-compex_wpq873-squashfs-factory.ubi`
4. Flash ubi image to both partitions and reset:
```
sf probe
imxtract 0x44000000 ubi
nand device 0
nand erase 0x0 0x3400000
nand erase 0x3c00000 0x3400000
nand write $fileaddr 0x0 $filesize
nand write $fileaddr 0x3c00000 $filesize
reset
```

Afterwards, you can use sysupgrade to flash new OpenWRT images.
