### PR TITLE
kernel/modules: fix drbg for >= 5.13.0

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -827,7 +827,9 @@ $(eval $(call KernelPackage,crypto-rmd160))
 
 define KernelPackage/crypto-rng
   TITLE:=CryptoAPI random number generation
-  DEPENDS:=+kmod-crypto-hash +kmod-crypto-hmac +kmod-crypto-sha256
+  DEPENDS:=+kmod-crypto-hash +kmod-crypto-hmac \
+		+LINUX_5_10:kmod-crypto-sha256 \
+		+LINUX_5_15:kmod-crypto-sha512
   KCONFIG:= \
 	CONFIG_CRYPTO_DRBG \
 	CONFIG_CRYPTO_DRBG_HMAC=y \


### PR DESCRIPTION
drbg swtiched to use HMAC(SHA-512) since 5.13.0
