### PR TITLE
openssl: fix low-severity CVE-2023-1255

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_VERSION:=3.0.8
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 PKG_BUILD_FLAGS:=no-mips16 gc-sections
 
 PKG_BUILD_PARALLEL:=1

--- a/package/libs/openssl/patches/220-aesv8-armx.pl-Avoid-buffer-overrread-in-AES-XTS-decr.patch
+++ b/package/libs/openssl/patches/220-aesv8-armx.pl-Avoid-buffer-overrread-in-AES-XTS-decr.patch
@@ -1,0 +1,39 @@
+From 02ac9c9420275868472f33b01def01218742b8bb Mon Sep 17 00:00:00 2001
+From: Tomas Mraz <tomas@openssl.org>
+Date: Mon, 17 Apr 2023 16:51:20 +0200
+Subject: [PATCH] aesv8-armx.pl: Avoid buffer overrread in AES-XTS decryption
+
+Original author: Nevine Ebeid (Amazon)
+Fixes: CVE-2023-1255
+
+The buffer overread happens on decrypts of 4 mod 5 sizes.
+Unless the memory just after the buffer is unmapped this is harmless.
+
+Reviewed-by: Paul Dale <pauli@openssl.org>
+Reviewed-by: Tom Cosgrove <tom.cosgrove@arm.com>
+(Merged from https://github.com/openssl/openssl/pull/20759)
+
+(cherry picked from commit 72dfe46550ee1f1bbfacd49f071419365bc23304)
+
+diff --git a/crypto/aes/asm/aesv8-armx.pl b/crypto/aes/asm/aesv8-armx.pl
+index 6a7bf05d1b..bd583e2c89 100755
+--- a/crypto/aes/asm/aesv8-armx.pl
++++ b/crypto/aes/asm/aesv8-armx.pl
+@@ -3353,7 +3353,7 @@ $code.=<<___	if ($flavour =~ /64/);
+ .align	4
+ .Lxts_dec_tail4x:
+ 	add	$inp,$inp,#16
+-	vld1.32	{$dat0},[$inp],#16
++	tst	$tailcnt,#0xf
+ 	veor	$tmp1,$dat1,$tmp0
+ 	vst1.8	{$tmp1},[$out],#16
+ 	veor	$tmp2,$dat2,$tmp2
+@@ -3362,6 +3362,8 @@ $code.=<<___	if ($flavour =~ /64/);
+ 	veor	$tmp4,$dat4,$tmp4
+ 	vst1.8	{$tmp3-$tmp4},[$out],#32
+ 
++	b.eq	.Lxts_dec_abort
++	vld1.32	{$dat0},[$inp],#16
+ 	b	.Lxts_done
+ .align	4
+ .Lxts_outer_dec_tail:


### PR DESCRIPTION
This applies commit 02ac9c94 to fix this OpenSSL Security Advisory issued on 20th April 2023[1]:

Input buffer over-read in AES-XTS implementation on 64 bit ARM (CVE-2023-1255)
==============================================================

Severity: Low

Issue summary: The AES-XTS cipher decryption implementation for 64 bit ARM platform contains a bug that could cause it to read past the input buffer, leading to a crash.

Impact summary: Applications that use the AES-XTS algorithm on the 64 bit ARM platform can crash in rare circumstances. The AES-XTS algorithm is usually used for disk encryption.

The AES-XTS cipher decryption implementation for 64 bit ARM platform will read past the end of the ciphertext buffer if the ciphertext size is 4 mod 5 in 16 byte blocks, e.g. 144 bytes or 1024 bytes. If the memory after the ciphertext buffer is unmapped, this will trigger a crash which results in a denial of service.

If an attacker can control the size and location of the ciphertext buffer being decrypted by an application using AES-XTS on 64 bit ARM, the application is affected. This is fairly unlikely making this issue a Low severity one.

1. https://www.openssl.org/news/secadv/20230420.txt

