### PR TITLE
ath79: restore userspace support for LEDs AR8327/AR8337 switches

### DIFF
--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 #include "ar9344_tplink_tl-wdrxxxx.dtsi"
+#include <dt-bindings/leds/common.h>
 
 / {
 	aliases {
@@ -110,6 +111,47 @@
 			0x5c 0x0030c300 /* LED_CTRL3 */
 			0x7c 0x0000007e /* PORT0_STATUS */
 			>;
+
+		leds {
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+				qca,led-mode = <0>;
+			};
+
+			led@3 {
+				reg = <3>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <1>;
+				qca,led-mode = <0>;
+			};
+
+			led@6 {
+				reg = <6>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <2>;
+				qca,led-mode = <0>;
+			};
+
+			led@9 {
+				reg = <9>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <3>;
+				qca,led-mode = <0>;
+			};
+
+			led@12 {
+				reg = <12>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <4>;
+				qca,led-mode = <0>;
+			};
+		};
 	};
 };
 

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
@@ -97,9 +97,9 @@
 &mdio0 {
 	status = "okay";
 
-	phy0: ethernet-phy@0 {
-		reg = <0>;
-		phy-mode = "rgmii";
+	switch@1f {
+		compatible = "qca,ar8327";
+		reg = <0x1f>;
 
 		qca,ar8327-initvals = <
 			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
@@ -123,5 +123,9 @@
 	nvmem-cell-names = "mac-address";
 
 	phy-mode = "rgmii";
-	phy-handle = <&phy0>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
 };

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c.dtsi
@@ -115,8 +115,9 @@
 &mdio0 {
 	status = "okay";
 
-	phy0: ethernet-phy@0 {
-		reg = <0>;
+	switch@1f {
+		compatible = "qca,ar8327";
+		reg = <0x1f>;
 
 		qca,ar8327-initvals = <
 			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
@@ -134,8 +135,12 @@
 &eth0 {
 	status = "okay";
 
-	phy-handle = <&phy0>;
 	pll-data = <0x56000000 0x00000101 0x00001616>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
 
 	gmac-config {
 		device = <&gmac>;

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c.dtsi
@@ -4,6 +4,7 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
 
 / {
 	aliases {
@@ -129,6 +130,47 @@
 			0x7c 0x0000007e /* PORT0_STATUS */
 			0x94 0x0000007e /* PORT6 STATUS */
 			>;
+
+		leds {
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+				qca,led-mode = <0>;
+			};
+
+			led@3 {
+				reg = <3>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <1>;
+				qca,led-mode = <0>;
+			};
+
+			led@6 {
+				reg = <6>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <2>;
+				qca,led-mode = <0>;
+			};
+
+			led@9 {
+				reg = <9>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <3>;
+				qca,led-mode = <0>;
+			};
+
+			led@12 {
+				reg = <12>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <4>;
+				qca,led-mode = <0>;
+			};
+		};
 	};
 };
 

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
@@ -158,6 +158,47 @@
 			0x7c 0x0000007e /* PORT0_STATUS */
 			0x94 0x0000007e /* PORT6 STATUS */
 		>;
+
+		leds {
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <4>;
+				qca,led-mode = <0>;
+			};
+
+			led@3 {
+				reg = <3>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <3>;
+				qca,led-mode = <0>;
+			};
+
+			led@6 {
+				reg = <6>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <2>;
+				qca,led-mode = <0>;
+			};
+
+			led@9 {
+				reg = <9>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <1>;
+				qca,led-mode = <0>;
+			};
+
+			led@12 {
+				reg = <12>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+				qca,led-mode = <0>;
+			};
+		};
 	};
 };
 

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
@@ -143,8 +143,10 @@
 &mdio0 {
 	status = "okay";
 
-	phy0: ethernet-phy@0 {
-		reg = <0>;
+	switch@1f {
+		compatible = "qca,ar8327";
+		reg = <0x1f>;
+
 		qca,ar8327-initvals = <
 			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
 			0x0c 0x07600000 /* PORT6 PAD MODE CTRL */
@@ -166,7 +168,11 @@
 
 	nvmem-cells = <&macaddr_uboot_1fc00 1>;
 	nvmem-cell-names = "mac-address";
-	phy-handle = <&phy0>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
 };
 
 &eth1 {

--- a/target/linux/generic/files/drivers/net/phy/ar8327.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8327.c
@@ -392,8 +392,11 @@ static int
 ar8327_led_register(struct ar8327_led *aled)
 {
 	int ret;
+	struct led_init_data init_data = {
+		.fwnode = aled->fwnode
+	};
 
-	ret = led_classdev_register(NULL, &aled->cdev);
+	ret = led_classdev_register_ext(NULL, &aled->cdev, &init_data);
 	if (ret < 0)
 		return ret;
 
@@ -447,6 +450,7 @@ ar8327_led_create(struct ar8xxx_priv *priv,
 	aled->led_num = led_info->led_num;
 	aled->active_low = led_info->active_low;
 	aled->mode = led_info->mode;
+	aled->fwnode = led_info->fwnode;
 
 	if (aled->mode == AR8327_LED_MODE_HW)
 		aled->enable_hw_mode = true;
@@ -616,6 +620,7 @@ ar8327_hw_config_of(struct ar8xxx_priv *priv, struct device_node *np)
 	const __be32 *paddr;
 	int len;
 	int i;
+	struct device_node *leds, *child;
 
 	paddr = of_get_property(np, "qca,ar8327-initvals", &len);
 	if (!paddr || len < (2 * sizeof(*paddr)))
@@ -643,6 +648,39 @@ ar8327_hw_config_of(struct ar8xxx_priv *priv, struct device_node *np)
 		}
 	}
 
+	leds = of_get_child_by_name(np, "leds");
+	if (!leds)
+		return 0;
+
+	data->leds = kvcalloc(of_get_child_count(leds), sizeof(void *),
+			     GFP_KERNEL);
+	if (!data->leds)
+		return -ENOMEM;
+
+	for_each_available_child_of_node(leds, child) {
+		u32 reg = 0, mode = 0;
+		struct ar8327_led_info info;
+		int ret;
+
+		ret = of_property_read_u32(child, "reg", &reg);
+		if (ret) {
+			pr_err("ar8327: LED %s is missing reg node\n", child->name);
+			continue;
+		}
+
+		of_property_read_u32(child, "qca,led-mode", &mode);
+
+		info = (struct ar8327_led_info) {
+			.name = of_get_property(child, "label", NULL) ? : child->name,
+			.fwnode = of_fwnode_handle(child),
+			.active_low = of_property_read_bool(child, "active-low"),
+			.led_num = (enum ar8327_led_num) reg,
+		        .mode = (enum ar8327_led_mode) mode
+		};
+		ar8327_led_create(priv, &info);
+	}
+
+	of_node_put(leds);
 	return 0;
 }
 #else

--- a/target/linux/generic/files/drivers/net/phy/ar8327.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8327.c
@@ -326,8 +326,7 @@ ar8327_led_set_brightness(struct led_classdev *led_cdev,
 	u8 pattern;
 	bool active;
 
-	active = (brightness != LED_OFF);
-	active ^= aled->active_low;
+	active = (brightness != LED_OFF) != aled->active_low;
 
 	pattern = (active) ? AR8327_LED_PATTERN_ON :
 			     AR8327_LED_PATTERN_OFF;
@@ -501,7 +500,8 @@ ar8327_leds_init(struct ar8xxx_priv *priv)
 		if (aled->enable_hw_mode)
 			aled->pattern = AR8327_LED_PATTERN_RULE;
 		else
-			aled->pattern = AR8327_LED_PATTERN_OFF;
+			aled->pattern = aled->active_low ?
+				AR8327_LED_PATTERN_ON : AR8327_LED_PATTERN_OFF;
 
 		ar8327_set_led_pattern(priv, aled->led_num, aled->pattern);
 	}

--- a/target/linux/generic/files/drivers/net/phy/ar8327.h
+++ b/target/linux/generic/files/drivers/net/phy/ar8327.h
@@ -317,6 +317,7 @@ struct ar8327_led {
 	struct work_struct led_work;
 	bool enable_hw_mode;
 	enum ar8327_led_pattern pattern;
+	struct fwnode_handle *fwnode;
 };
 
 struct ar8327_data {

--- a/target/linux/generic/files/include/linux/ar8216_platform.h
+++ b/target/linux/generic/files/include/linux/ar8216_platform.h
@@ -106,6 +106,7 @@ struct ar8327_led_info {
 	bool active_low;
 	enum ar8327_led_num led_num;
 	enum ar8327_led_mode mode;
+	struct fwnode_handle *fwnode;
 };
 
 #define AR8327_LED_INFO(_led, _mode, _name) {	\


### PR DESCRIPTION
At start, TP-Link WDR4300, WR1043NDv2/3 and Archer C7v[1-3] families are converted, as an example for other devices.
I decided to post this by @DittelHome's request, because qca8k support in ath79 still requires a lot of effort, let alone LED supoort, which isn't agreed upon in upstream.

Compile and run-tested on devices mentioned above.