### PR TITLE
ath79: fix 5GHz on QCA9886 variant of ZTE MF286

### DIFF
--- a/target/linux/ath79/dts/qca9563_zte_mf286.dts
+++ b/target/linux/ath79/dts/qca9563_zte_mf286.dts
@@ -119,8 +119,8 @@
 };
 
 &wifi_ath10k {
-	nvmem-cells = <&macaddr_mac_0>, <&cal_caldata_5000>;
-	nvmem-cell-names = "mac-address", "calibration";
+	nvmem-cells = <&macaddr_mac_0>, <&cal_caldata_5000>, <&cal_caldata_5000>;
+	nvmem-cell-names = "mac-address", "calibration", "pre-calibration";
 	mac-address-increment = <1>;
 };
 

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -401,8 +401,8 @@ TARGET_DEVICES += zte_mf282
 define Device/zte_mf286
   $(Device/zte_mf28x_common)
   DEVICE_MODEL := MF286
-  DEVICE_PACKAGES += ath10k-firmware-qca988x-ct kmod-usb-net-qmi-wwan \
-	kmod-usb-serial-option uqmi
+  DEVICE_PACKAGES += ath10k-firmware-qca988x-ct ath10k-firmware-qca9888-ct \
+	kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
 endef
 TARGET_DEVICES += zte_mf286
 


### PR DESCRIPTION
Recently, a strange variant of ZTE MF286 was discovered, having QCA9886 radio instead of QCA9882 - like MF286A, but having MF286 flash layout and rest of hardware.
To support both variants in one image, bind calibration data at offset 0x5000 both as "calibration" and "pre-calibration" nvmem-cells, so ath10k can load caldata for both at runtime.