### PR TITLE
base-files: add config_foreach_break

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -149,13 +149,20 @@ config_foreach() {
 	[ "$#" -ge 1 ] && shift
 	local ___type="$1"
 	[ "$#" -ge 1 ] && shift
+	local ___break_loop=0
 	local section cfgtype
+
+	# shellcheck disable=SC2317
+	config_foreach_break() {
+		___break_loop=1
+	}
 
 	[ -z "$CONFIG_SECTIONS" ] && return 0
 	for section in ${CONFIG_SECTIONS}; do
 		config_get cfgtype "$section" TYPE
 		[ -n "$___type" ] && [ "x$cfgtype" != "x$___type" ] && continue
 		eval "$___function \"\$section\" \"\$@\""
+		[ "$___break_loop" = 1 ] && break
 	done
 }
 


### PR DESCRIPTION
config_foreach currently lacks the mechanism to break out of the loop,
config_foreach_break addresses this.
