### PR TITLE
mac80211: do not enforce start_disabled=1 when staidx>0

### DIFF
--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -509,13 +509,14 @@ mac80211_hostapd_setup_bss() {
 	json_get_vars wds wds_bridge dtim_period max_listen_int start_disabled
 
 	set_default wds 0
-	set_default start_disabled 0
-
 	[ "$wds" -gt 0 ] && {
 		append hostapd_cfg "wds_sta=1" "$N"
 		[ -n "$wds_bridge" ] && append hostapd_cfg "wds_bridge=$wds_bridge" "$N"
 	}
-	[ "$staidx" -gt 0 -o "$start_disabled" -eq 1 ] && append hostapd_cfg "start_disabled=1" "$N"
+
+	[ "$staidx" -gt 0 ] && set_default start_disabled 1
+	set_default start_disabled 0
+	[ "$start_disabled" -eq 1 ] && append hostapd_cfg "start_disabled=1" "$N"
 
 	cat >> /var/run/hostapd-$phy.conf <<EOF
 $hostapd_cfg


### PR DESCRIPTION
I do not really understand the purpose of not letting the AP interface start automatically when there are wireless client (station mode) interfaces present on the same wireless radio.
Maybe there are issues in some drivers that do not let this work properly? Or is it because client connection can disrupt the access point interface connectivity? I don't know.

With this patch, I provide an option for the user to override this default behaviour by explicitly setting `start_disabled` to `0`. The existence of station interfaces will only control the default value of `start_disabled` but the user's preference will always be used if it is explicitly defined.