### PR TITLE
Fix Netgear WAX206 WAN port

### DIFF
--- a/target/linux/generic/pending-5.15/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-5.15/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -1,0 +1,63 @@
+From 0de82310d2b32e78ff79d42c08b1122a6ede3778 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sun, 30 Apr 2023 00:15:41 +0100
+Subject: [PATCH] net: phy: realtek: detect early version of RTL8221B
+
+Early versions (?) of the RTL8221B PHY cannot be identified in a regular
+Clause-45 bus scan as the PHY doesn't report the implemented MMDs
+correctly but returns 0 instead.
+Implement custom identify function using the PKGID instead of iterating
+over the implemented MMDs.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+
+--- a/drivers/net/phy/realtek.c
++++ b/drivers/net/phy/realtek.c
+@@ -744,6 +744,38 @@ static int rtl8226_match_phy_device(stru
+ 	       rtlgen_supports_2_5gbps(phydev);
+ }
+ 
++static int rtl8221b_vb_cg_match_phy_device(struct phy_device *phydev)
++{
++	int val;
++	u32 id;
++
++	if (phydev->mdio.bus->probe_capabilities >= MDIOBUS_C45) {
++		val = phy_read_mmd(phydev, MDIO_MMD_PMAPMD, MDIO_PKGID1);
++		if (val < 0)
++			return 0;
++
++		id = val << 16;
++		val = phy_read_mmd(phydev, MDIO_MMD_PMAPMD, MDIO_PKGID2);
++		if (val < 0)
++			return 0;
++
++		id |= val;
++	} else {
++		val = phy_read(phydev, MII_PHYSID1);
++		if (val < 0)
++			return 0;
++
++		id = val << 16;
++		val = phy_read(phydev, MII_PHYSID2);
++		if (val < 0)
++			return 0;
++
++		id |= val;
++	}
++
++	return (id == 0x001cc849);
++}
++
+ static int rtl822x_probe(struct phy_device *phydev)
+ {
+ 	struct device *dev = &phydev->mdio.dev;
+@@ -1084,7 +1116,7 @@ static struct phy_driver realtek_drvs[]
+ 		.write_page     = rtl821x_write_page,
+ 		.soft_reset     = genphy_soft_reset,
+ 	}, {
+-		PHY_ID_MATCH_EXACT(0x001cc849),
++		.match_phy_device = rtl8221b_vb_cg_match_phy_device,
+ 		.name           = "RTL8221B-VB-CG 2.5Gbps PHY",
+ 		.get_features   = rtl822x_get_features,
+ 		.config_init    = rtl8221b_config_init,

--- a/target/linux/mediatek/dts/mt7622-netgear-wax206.dts
+++ b/target/linux/mediatek/dts/mt7622-netgear-wax206.dts
@@ -185,7 +185,7 @@
 					nvmem-cells = <&macaddr_factory_7fffa>;
 					nvmem-cell-names = "mac-address";
 					phy-handle = <&rtl8221b_phy>;
-					phy-mode = "sgmii";
+					phy-mode = "2500base-x";
 					reg = <5>;
 				};
 
@@ -204,7 +204,7 @@
 		};
 
 		rtl8221b_phy: ethernet-phy@7 {
-			compatible = "ethernet-phy-id001c.c849";
+			compatible = "ethernet-phy-ieee802.3-c45";
 			reg = <7>;
 			reset-gpios = <&pio 101 GPIO_ACTIVE_LOW>;
 			interrupts = <52 IRQ_TYPE_LEVEL_HIGH>;


### PR DESCRIPTION
Commit 998b973 broke 2.5G on the Netgear WAX206 as the device previously relied on a hard-coded PHY id in device tree which prevents the the PHY to be used via Clause-45 MDIO. Add patch to fix Clause-45 identification of the PHY and drop hard-coded PHY id from Netgear WAX206 device tree.