### PR TITLE
ramips: mt7621: rename Asus RT-AC57U to v1

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_rt-ac57u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ac57u-v1.dts
@@ -6,8 +6,8 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "asus,rt-ac57u", "mediatek,mt7621-soc";
-	model = "ASUS RT-AC57U";
+	compatible = "asus,rt-ac57u-v1", "mediatek,mt7621-soc";
+	model = "ASUS RT-AC57U v1";
 
 	aliases {
 		led-boot = &led_power;

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -286,17 +286,19 @@ define Device/asus_rp-ac87
 endef
 TARGET_DEVICES += asus_rp-ac87
 
-define Device/asus_rt-ac57u
+define Device/asus_rt-ac57u-v1
   $(Device/dsa-migration)
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-AC57U
+  DEVICE_VARIANT := v1
   DEVICE_ALT0_VENDOR := ASUS
   DEVICE_ALT0_MODEL := RT-AC1200GU
   IMAGE_SIZE := 16064k
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
 	kmod-usb-ledtrig-usbport
+  SUPPORTED_DEVICES += asus,rt-ac57u
 endef
-TARGET_DEVICES += asus_rt-ac57u
+TARGET_DEVICES += asus_rt-ac57u-v1
 
 define Device/asus_rt-ac65p
   $(Device/dsa-migration)


### PR DESCRIPTION
rename RT-AC57U to avoid confusion with unsupported revisions 2 and 3

_________________
This change was only build-tested.
I don't own the device. My intention is to avoid confusion so people don't end up buying an RT-AC57U new.

It's likely RT-AC57U v2 won't receive support for a while since QCN5502 isn't supported by ath9k, yet. #9389
https://wikidevi.wi-cat.ru/ASUS_RT-AC57U_v2
I think v3 also uses QCA, but I don't have a source for that.