### PR TITLE
qualcommax: ipq807x: add support for Netgear RAX120v2 (replaces #11830)

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq807x
@@ -9,6 +9,7 @@ board=$(board_name)
 
 case "$board" in
 dynalink,dl-wrx36|\
+netgear,rax120v2|\
 netgear,wax218)
 	idx="$(find_mtd_index 0:appsblenv)"
 	[ -n "$idx" ] && \

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -33,6 +33,7 @@ ALLWIFIBOARDS:= \
 	dynalink_dl-wrx36 \
 	edgecore_eap102 \
 	edimax_cax1800 \
+	netgear_rax120v2 \
 	netgear_wax218 \
 	prpl_haze \
 	qnap_301w \
@@ -121,6 +122,7 @@ $(eval $(call generate-ipq-wifi-package,compex_wpq873,Compex WPQ-873))
 $(eval $(call generate-ipq-wifi-package,dynalink_dl-wrx36,Dynalink DL-WRX36))
 $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))
+$(eval $(call generate-ipq-wifi-package,netgear_rax120v2,Netgear RAX120v2))
 $(eval $(call generate-ipq-wifi-package,netgear_wax218,Netgear WAX218))
 $(eval $(call generate-ipq-wifi-package,qnap_301w,QNAP 301w))
 $(eval $(call generate-ipq-wifi-package,prpl_haze,prpl Haze))

--- a/target/linux/generic/hack-5.15/726-net-phy-aquantia-enable-AQR111-and-AQR111B0.patch
+++ b/target/linux/generic/hack-5.15/726-net-phy-aquantia-enable-AQR111-and-AQR111B0.patch
@@ -1,0 +1,109 @@
+Author: Thomas Kupper <thomas.kupper@gmail.com>
+Date:   Wed May 24 21:14:17 2023 +0200
+
+kernel: phy: add Aquantia PHY AQR111 & AQR111B0
+
+Add the IDs for Aquantia PHY AQR111 and AQR111B0 as found in the GPL sources
+of the Netgear RAX120v2 firmware v1.2.8.40.
+
+This is a 5GbE chip but it reports support for 10G. Implement config_init()
+to set max speed to 5G.
+
+Signed-off-by: Thomas Kupper <thomas.kupper@gmail.com>
+--- a/drivers/net/phy/aquantia_main.c
++++ b/drivers/net/phy/aquantia_main.c
+@@ -20,6 +20,8 @@
+ #define PHY_ID_AQR105	0x03a1b4a2
+ #define PHY_ID_AQR106	0x03a1b4d0
+ #define PHY_ID_AQR107	0x03a1b4e0
++#define PHY_ID_AQR111	0x03a1b610
++#define PHY_ID_AQR111B0	0x03a1b612
+ #define PHY_ID_AQR112	0x03a1b662
+ #define PHY_ID_AQR112C	0x03a1b790
+ #define PHY_ID_AQR112R	0x31c31d12
+@@ -686,6 +688,33 @@ static int aqcs109_config_init(struct ph
+ 	return aqr107_set_downshift(phydev, MDIO_AN_VEND_PROV_DOWNSHIFT_DFLT);
+ }
+ 
++static int aqr111_config_init(struct phy_device *phydev)
++{
++	int ret;
++
++	/* Check that the PHY interface type is compatible */
++	if (phydev->interface != PHY_INTERFACE_MODE_SGMII &&
++	    phydev->interface != PHY_INTERFACE_MODE_2500BASEX &&
++	    phydev->interface != PHY_INTERFACE_MODE_XGMII &&
++	    phydev->interface != PHY_INTERFACE_MODE_USXGMII &&
++	    phydev->interface != PHY_INTERFACE_MODE_10GKR &&
++	    phydev->interface != PHY_INTERFACE_MODE_10GBASER)
++		return -ENODEV;
++
++	WARN(phydev->interface == PHY_INTERFACE_MODE_XGMII,
++	     "Your devicetree is out of date, please update it. The AQR107 family doesn't support XGMII, maybe you mean USXGMII.\n");
++
++	ret = aqr107_wait_reset_complete(phydev);
++	if (!ret)
++		aqr107_chip_info(phydev);
++
++	/* AQR111 reports supporting speed up to 10G, however only speeds up to 5G are supported. */
++	ret = phy_set_max_speed(phydev, SPEED_5000);
++	if (ret)
++		return ret;
++
++	return aqr107_set_downshift(phydev, MDIO_AN_VEND_PROV_DOWNSHIFT_DFLT);
++}
+ static void aqr107_link_change_notify(struct phy_device *phydev)
+ {
+ 	u8 fw_major, fw_minor;
+@@ -905,6 +934,42 @@ static struct phy_driver aqr_driver[] =
+ 	.link_change_notify = aqr107_link_change_notify,
+ },
+ {
++	PHY_ID_MATCH_MODEL(PHY_ID_AQR111),
++	.name		= "Aquantia AQR111",
++	.probe		= aqr107_probe,
++	.config_init	= aqr111_config_init,
++	.config_aneg    = aqr_config_aneg,
++	.config_intr	= aqr_config_intr,
++	.handle_interrupt = aqr_handle_interrupt,
++	.read_status	= aqr107_read_status,
++	.get_tunable    = aqr107_get_tunable,
++	.set_tunable    = aqr107_set_tunable,
++	.suspend	= aqr107_suspend,
++	.resume		= aqr107_resume,
++	.get_sset_count	= aqr107_get_sset_count,
++	.get_strings	= aqr107_get_strings,
++	.get_stats	= aqr107_get_stats,
++	.link_change_notify = aqr107_link_change_notify,
++},
++{
++	PHY_ID_MATCH_MODEL(PHY_ID_AQR111B0),
++	.name		= "Aquantia AQR111B0",
++	.probe		= aqr107_probe,
++	.config_init	= aqr111_config_init,
++	.config_aneg    = aqr_config_aneg,
++	.config_intr	= aqr_config_intr,
++	.handle_interrupt = aqr_handle_interrupt,
++	.read_status	= aqr107_read_status,
++	.get_tunable    = aqr107_get_tunable,
++	.set_tunable    = aqr107_set_tunable,
++	.suspend	= aqr107_suspend,
++	.resume		= aqr107_resume,
++	.get_sset_count	= aqr107_get_sset_count,
++	.get_strings	= aqr107_get_strings,
++	.get_stats	= aqr107_get_stats,
++	.link_change_notify = aqr107_link_change_notify,
++},
++{
+ 	PHY_ID_MATCH_MODEL(PHY_ID_AQR112),
+ 	.name		= "Aquantia AQR112",
+ 	.probe		= aqr107_probe,
+@@ -970,6 +1035,8 @@ static struct mdio_device_id __maybe_unu
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR105) },
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR106) },
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR107) },
++	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR111) },
++	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR111B0) },
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR112) },
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR112C) },
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR112R) },

--- a/target/linux/generic/hack-6.1/726-net-phy-aquantia-enable-AQR111-and-AQR111B0.patch
+++ b/target/linux/generic/hack-6.1/726-net-phy-aquantia-enable-AQR111-and-AQR111B0.patch
@@ -1,0 +1,110 @@
+Author: Thomas Kupper <thomas.kupper@gmail.com>
+Date:   Wed May 24 21:14:17 2023 +0200
+
+kernel: phy: add Aquantia PHY AQR111 & AQR111B0
+
+Add the IDs for Aquantia PHY AQR111 and AQR111B0 as found in the GPL sources
+of the Netgear RAX120v2 firmware v1.2.8.40.
+
+This is a 5GbE chip but it reports support for 10G. Implement config_init()
+to set max speed to 5G.
+
+Signed-off-by: Thomas Kupper <thomas.kupper@gmail.com>
+--- a/drivers/net/phy/aquantia_main.c
++++ b/drivers/net/phy/aquantia_main.c
+@@ -24,6 +24,8 @@
+ #define PHY_ID_AQR405	0x03a1b4b0
+ #define PHY_ID_AQR113C	0x31c31c12
+ #define PHY_ID_AQR813	0x31c31cb2
++#define PHY_ID_AQR111	0x03a1b610
++#define PHY_ID_AQR111B0	0x03a1b612
+ #define PHY_ID_AQR112	0x03a1b662
+ #define PHY_ID_AQR412	0x03a1b712
+ #define PHY_ID_AQR113	0x31c31c40
+@@ -729,6 +731,34 @@ static int aqcs109_config_init(struct ph
+ 	return aqr107_set_downshift(phydev, MDIO_AN_VEND_PROV_DOWNSHIFT_DFLT);
+ }
+ 
++static int aqr111_config_init(struct phy_device *phydev)
++{
++	int ret;
++
++	/* Check that the PHY interface type is compatible */
++	if (phydev->interface != PHY_INTERFACE_MODE_SGMII &&
++	    phydev->interface != PHY_INTERFACE_MODE_1000BASEKX &&
++	    phydev->interface != PHY_INTERFACE_MODE_2500BASEX &&
++	    phydev->interface != PHY_INTERFACE_MODE_XGMII &&
++	    phydev->interface != PHY_INTERFACE_MODE_USXGMII &&
++	    phydev->interface != PHY_INTERFACE_MODE_10GKR &&
++	    phydev->interface != PHY_INTERFACE_MODE_10GBASER &&
++	    phydev->interface != PHY_INTERFACE_MODE_XAUI &&
++	    phydev->interface != PHY_INTERFACE_MODE_RXAUI)
++		return -ENODEV;
++
++	WARN(phydev->interface == PHY_INTERFACE_MODE_XGMII,
++	     "Your devicetree is out of date, please update it. The AQR107 family doesn't support XGMII, maybe you mean USXGMII.\n");
++
++	ret = aqr107_wait_reset_complete(phydev);
++	if (!ret)
++		aqr107_chip_info(phydev);
++
++	/* AQR111 reports supporting speed up to 10G, however only speeds up to 5G are supported. */
++	phy_set_max_speed(phydev, SPEED_5000);
++
++	return aqr107_set_downshift(phydev, MDIO_AN_VEND_PROV_DOWNSHIFT_DFLT);
++}
+ static void aqr107_link_change_notify(struct phy_device *phydev)
+ {
+ 	u8 fw_major, fw_minor;
+@@ -961,6 +991,42 @@ static struct phy_driver aqr_driver[] =
+ 	.link_change_notify = aqr107_link_change_notify,
+ },
+ {
++	PHY_ID_MATCH_MODEL(PHY_ID_AQR111),
++	.name		= "Aquantia AQR111",
++	.probe		= aqr107_probe,
++	.config_init	= aqr111_config_init,
++	.config_aneg    = aqr_config_aneg,
++	.config_intr	= aqr_config_intr,
++	.handle_interrupt = aqr_handle_interrupt,
++	.read_status	= aqr107_read_status,
++	.get_tunable    = aqr107_get_tunable,
++	.set_tunable    = aqr107_set_tunable,
++	.suspend	= aqr107_suspend,
++	.resume		= aqr107_resume,
++	.get_sset_count	= aqr107_get_sset_count,
++	.get_strings	= aqr107_get_strings,
++	.get_stats	= aqr107_get_stats,
++	.link_change_notify = aqr107_link_change_notify,
++},
++{
++	PHY_ID_MATCH_MODEL(PHY_ID_AQR111B0),
++	.name		= "Aquantia AQR111B0",
++	.probe		= aqr107_probe,
++	.config_init	= aqr111_config_init,
++	.config_aneg    = aqr_config_aneg,
++	.config_intr	= aqr_config_intr,
++	.handle_interrupt = aqr_handle_interrupt,
++	.read_status	= aqr107_read_status,
++	.get_tunable    = aqr107_get_tunable,
++	.set_tunable    = aqr107_set_tunable,
++	.suspend	= aqr107_suspend,
++	.resume		= aqr107_resume,
++	.get_sset_count	= aqr107_get_sset_count,
++	.get_strings	= aqr107_get_strings,
++	.get_stats	= aqr107_get_stats,
++	.link_change_notify = aqr107_link_change_notify,
++},
++{
+ 	PHY_ID_MATCH_MODEL(PHY_ID_AQR112),
+ 	.name		= "Aquantia AQR112",
+ 	.probe		= aqr107_probe,
+@@ -1030,6 +1096,8 @@ static struct mdio_device_id __maybe_unu
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR405) },
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR113C) },
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR813) },
++	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR111) },
++	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR111B0) },
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR112) },
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR412) },
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR113) },

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-rax120v2.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-rax120v2.dts
@@ -1,0 +1,553 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-ess.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Netgear RAX120v2";
+	compatible = "netgear,rax120v2", "qcom,ipq8074";
+
+	aliases {
+		serial0 = &blsp1_uart5;
+
+		led-running = &led_system_white;
+		led-upgrade = &led_system_white;
+		led-internet = &led_wan_white;
+		label-mac-device = &dp1;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " ubi.mtd=rootfs root=/dev/ubiblock0_0";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&tlmm 57 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	led_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&tlmm 18 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&tlmm 19 GPIO_ACTIVE_HIGH>;
+
+		led_gpio: led_gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <2>;
+			enable-gpios = <&tlmm 20 GPIO_ACTIVE_HIGH>;
+			spi-max-frequency = <1000000>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system_white: system-white {
+			label = "white:system";
+			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_WHITE>;
+		};
+
+		led_24g_white {
+			label = "white:24g";
+			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_WHITE>;
+			linux,default-trigger = "phy1radio";
+		};
+
+		led_5g_white {
+			label = "white:5g";
+			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_WHITE>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		led_usb1_white {
+			label = "white:usb1";
+			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_WHITE>;
+		};
+
+		led_usb2_white {
+			label = "white:usb2";
+			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_WHITE>;
+		};
+
+		led_wan_white: wan-white {
+			label = "white:wan";
+			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_WHITE>;
+		};
+
+		led_aqr_green {
+			label = "green:aqr";
+			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+
+		led_aqr_red {
+			label = "red:aqr";
+			gpios = <&led_gpio 10 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+		};
+
+		led_aqr_white {
+			label = "white:aqr";
+			gpios = <&led_gpio 11 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_WHITE>;
+		};
+
+		led_wps_white {
+			label = "white:wps";
+			gpios = <&tlmm 40 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_WHITE>;
+		};
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+
+	qca8075_0: ethernet-phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0>;
+	};
+
+	qca8075_1: ethernet-phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <1>;
+	};
+
+	qca8075_2: ethernet-phy@2 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <2>;
+	};
+
+	qca8075_3: ethernet-phy@3 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <3>;
+	};
+
+	qca8075_4: ethernet-phy@4 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <4>;
+	};
+
+	aqr111b0: ethernet-phy@7 {
+		compatible ="ethernet-phy-ieee802.3-c45";
+		reg = <7>;
+		reset-gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_lan_bmp = <0x3e>; /* lan port bitmap */
+	switch_wan_bmp = <0x40>; /* wan port bitmap */
+	switch_mac_mode = <0x0>; /* mac mode for uniphy instance0*/
+	switch_mac_mode1 = <0xff>; /* mac mode for uniphy instance1*/
+	switch_mac_mode2 = <0xd>; /* mac mode for uniphy instance2*/
+	bm_tick_mode = <0>; /* bm tick mode */
+	tm_tick_mode = <0>; /* tm tick mode */
+
+	qcom,port_phyinfo {
+		port@1 {
+			port_id = <1>;
+			phy_address = <0>;
+		};
+		port@2 {
+			port_id = <2>;
+			phy_address = <1>;
+		};
+		port@3 {
+			port_id = <3>;
+			phy_address = <2>;
+		};
+		port@4 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+		port@5 {
+			port_id = <5>;
+			phy_address = <4>;
+		};
+		port@6 {
+			port_id = <6>;
+			phy_address = <7>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			ethernet-phy-ieee802.3-c45;
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp1 {
+	status = "okay";
+	phy-handle = <&qca8075_0>;
+	label = "lan4";
+	nvmem-cells = <&macaddr_dp1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&dp2 {
+	status = "okay";
+	phy-handle = <&qca8075_1>;
+	label = "lan3";
+	nvmem-cells = <&macaddr_dp2>;
+	nvmem-cell-names = "mac-address";
+};
+
+&dp3 {
+	status = "okay";
+	phy-handle = <&qca8075_2>;
+	label = "lan2";
+	nvmem-cells = <&macaddr_dp3>;
+	nvmem-cell-names = "mac-address";
+};
+
+&dp4 {
+	status = "okay";
+	phy-handle = <&qca8075_3>;
+	label = "lan1";
+	nvmem-cells = <&macaddr_dp4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&dp5 {
+	status = "okay";
+	phy-handle = <&qca8075_4>;
+	label = "wan";
+	nvmem-cells = <&macaddr_dp5>;
+	nvmem-cell-names = "mac-address";
+};
+
+&dp6_syn {
+	status = "okay";
+	phy-handle = <&aqr111b0>;
+	label = "lan5";
+	nvmem-cells = <&macaddr_dp6_syn>;
+	nvmem-cell-names = "mac-address";
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&blsp1_i2c2 {
+	status = "okay";
+
+	g761@3e {
+		compatible = "gmt,g763";
+		reg = <0x3e>;
+		clocks =<&sleep_clk>;
+		fan_gear_mode = <0>;
+		fan_start = <1>;
+		pwm_polarity = <0>;
+	};
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:sbl1";
+				reg = <0x00 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "0:mibib";
+				reg = <0x100000 0x100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "0:bootconfig";
+				reg = <0x200000 0x80000>;
+				read-only;
+			};
+
+			partition@280000 {
+				label = "0:bootconfig_1";
+				reg = <0x280000 0x80000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "0:qsee";
+				reg = <0x300000 0x300000>;
+				read-only;
+			};
+
+			partition@600000 {
+				label = "0:qsee_1";
+				reg = <0x600000 0x300000>;
+				read-only;
+			};
+
+			partition@900000 {
+				label = "0:devcfg";
+				reg = <0x900000 0x80000>;
+				read-only;
+			};
+
+			partition@980000 {
+				label = "0:devcfg_1";
+				reg = <0x980000 0x80000>;
+				read-only;
+			};
+
+			partition@a00000 {
+				label = "0:apdp";
+				reg = <0xa00000 0x80000>;
+				read-only;
+			};
+
+			partition@a80000 {
+				label = "0:apdp_1";
+				reg = <0xa80000 0x80000>;
+				read-only;
+			};
+
+			partition@b00000 {
+				label = "0:rpm";
+				reg = <0xb00000 0x80000>;
+				read-only;
+			};
+
+			partition@b80000 {
+				label = "0:rpm_1";
+				reg = <0xb80000 0x80000>;
+				read-only;
+			};
+
+			partition@c00000 {
+				label = "0:cdt";
+				reg = <0xc00000 0x80000>;
+				read-only;
+			};
+
+			partition@c80000 {
+				label = "0:cdt_1";
+				reg = <0xc80000 0x80000>;
+				read-only;
+			};
+
+			partition@d00000 {
+				label = "0:appsblenv";
+				reg = <0xd00000 0x80000>;
+			};
+
+			partition@d80000 {
+				label = "0:appsbl";
+				reg = <0xd80000 0x100000>;
+				read-only;
+			};
+
+			partition@e80000 {
+				label = "0:appsbl_1";
+				reg = <0xe80000 0x100000>;
+				read-only;
+			};
+
+			partition@f80000 {
+				label = "0:art";
+				reg = <0xf80000 0x80000>;
+				read-only;
+			};
+
+			partition@1000000 {
+				label = "0:art.bak";
+				reg = <0x1000000 0x0080000>;
+				read-only;
+			};
+
+			partition@1080000 {
+				label = "config";
+				reg = <0x1080000 0x0100000>;
+				read-only;
+			};
+
+			partition@1180000 {
+				label = "boarddata1";
+				reg = <0x1180000 0x0100000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_dp1: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_dp2: macaddr@1 {
+					reg = <0x6 0x6>;
+				};
+
+				macaddr_dp3: macaddr@2 {
+					reg = <0xc 0x6>;
+				};
+
+				macaddr_dp4: macaddr@3 {
+					reg = <0x12 0x6>;
+				};
+
+				macaddr_dp5: macaddr@4 {
+					reg = <0x18 0x6>;
+				};
+
+				macaddr_dp6_syn: macaddr@5 {
+					reg = <0x1e 0x6>;
+				};
+
+			};
+
+			partition@1280000 {
+				label = "boarddata2";
+				reg = <0x1280000 0x0100000>;
+				read-only;
+			};
+
+			partition@1380000 {
+				label = "pot";
+				reg = <0x1380000 0x0100000>;
+				read-only;
+			};
+
+			partition@1480000 {
+				label = "dnidata";
+				reg = <0x1480000 0x0500000>;
+				read-only;
+			};
+
+			partition@1980000 {
+				label = "kernel";
+				reg = <0x1980000 0x1d00000>;
+			};
+
+			partition@7e00000 {
+				label = "ethphyfw";
+				reg = <0x7e00000 0x80000>;
+			};
+
+			partition@e8800000 {
+				label = "rootfs";
+				reg = <0xe880000 0x11780000>;
+			};
+		};
+	};
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&qusb_phy_1 {
+	status = "okay";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&ssphy_1 {
+	status = "okay";
+};
+
+&usb_0 {
+	status = "okay";
+};
+
+&usb_1 {
+	status = "okay";
+};
+
+&wifi{
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Netgear-RAX120v2";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -91,6 +91,30 @@ define Device/edimax_cax1800
 endef
 TARGET_DEVICES += edimax_cax1800
 
+define Device/netgear_rax120v2
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Netgear
+	DEVICE_MODEL := RAX120v2
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_DTS_CONFIG := config@hk01
+	SOC := ipq8074
+	KERNEL_SIZE := 29696k
+	NETGEAR_BOARD_ID := RAX120
+	NETGEAR_HW_ID := 29765589+0+512+1024+4x4+8x8
+	DEVICE_PACKAGES := ipq-wifi-netgear_rax120v2 kmod-spi-gpio \
+		kmod-spi-bitbang kmod-gpio-nxp-74hc164 kmod-hwmon-g761
+	IMAGES = web-ui-factory.img sysupgrade.bin
+	IMAGE/web-ui-factory.img := append-image initramfs-uImage.itb | \
+		pad-offset $$$$(BLOCKSIZE) 64 | append-uImage-fakehdr filesystem | \
+		netgear-dni
+	IMAGE/sysupgrade.bin := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | \
+		append-uImage-fakehdr filesystem | sysupgrade-tar kernel=$$$$@ | \
+		append-metadata
+endef
+TARGET_DEVICES += netgear_rax120v2
+
 define Device/netgear_wax218
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
@@ -9,6 +9,9 @@ case "$board" in
 edgecore,eap102)
 	ucidef_set_led_netdev "wan" "WAN" "green:wanpoe" "wan"
 	;;
+netgear,rax120v2)
+	ucidef_set_led_netdev "aqr" "AQR" "white:aqr" "lan5"
+	;;
 netgear,wax218)
 	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "lan"
 	ucidef_set_led_wlan "wlan5g" "WIFI 5GHz" "blue:wlan5g" "phy0radio"

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -22,6 +22,9 @@ ipq807x_setup_interfaces()
 	edimax,cax1800)
 		ucidef_set_interfaces_lan_wan "lan"
 		;;
+	netgear,rax120v2)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "wan"
+		;;
 	netgear,wax218)
 		ucidef_set_interface_lan "lan" "dhcp"
 		;;

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -14,6 +14,7 @@ case "$FIRMWARE" in
 	edgecore,eap102|\
 	edimax,cax1800|\
 	dynalink,dl-wrx36|\
+	netgear,rax120v2|\
 	netgear,wax218|\
 	qnap,301w|\
 	redmi,ax6|\

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -68,6 +68,7 @@ platform_do_upgrade() {
 		;;
 	compex,wpq873|\
 	edimax,cax1800|\
+	netgear,rax120v2|\
 	netgear,wax218)
 		nand_do_upgrade "$1"
 		;;


### PR DESCRIPTION
ipq807x: add support for Netgear RAX120v2

Netgear Nighthawk RAX120v2 AX WIFI router with 5 1G and 1 5G ports.

The majority of the code is based on @jewwest's PR #11830.

Specifications:
    * CPU: Qualcomm IPQ8074 Quad core Cortex-A53 2.2GHz
    * RAM: 1024MB of DDR3 (Nanya NT5CC256M16EP-EK × 2)
    * Flash: SPI-NAND 512 MiB (Winbond W29N04GZBIBA)
    * Ethernet: 4x 10/100/1000 Mbps LAN,
                1x 10/100/1000 Mbps WAN (Qualcomm QCA8075),
                1x 10/100/1000/2500/5000 Mbps LAN/WAN (Aquantia AQR111B0 PHY)
    * Wi-Fi:
        * 2.4 GHz: Qualcomm QCN5024 4x4
        * 2x 5 GHz: Qualcomm QCN5054 4x4
    * USB: 2x USB 3.0
    * LEDs: Power, 2.4GHz & 5GHz Radio, WPS, WAN, USB1 & USB2, 5G LAN
    * Keys: LEDs On/Off, Power, Reset, RFKILL, WPS
    * UART: Marked J9003 VCC TX RX GND, beginning from "1". 3.3v, 115200n8
    * Power: 19 VDC, 3.1 A

Installation:
    * Flashing OpenWrt is done in two steps:
        a) Flash *-squashfs-web-ui-factory.img from stock UI (thanks to @wangyu-).
            This writes an initramfs based OpenWrt image onto the RAX120v2
        b) From OpenWrt flash the *-squashfs-sysupgrade.bin using LuCI or the commandline

    * U-Boot allows booting an initramfs image via TFTP:
    - Set ip of your PC to 192.168.1.100
        - At the serial console interrupt boot at "Hit any key to stop autoboot:"
        - In u-boot run `tftpsrv`
        - On your PC send the OpenWrt initramfs image:

          tftp 192.168.1.1 -m binary -c put openwrt-ipq807x-generic-netgear_rax120v2-initramfs-uImage.itb

Make 5G Aquantia phy work:
    For the 5G port labeled 'lan5' to work a firmware is needed. This can be loaded in
    u-boot by writing the firmware to the correct mtd partition.

    The firmware file found in the Netgear stock firmware under /lib/firmware/ named
    'AQR-G3_v4.3.C-AQR_DNI_DR-EQ35AX8-R-prov1_ID23888_VER1311.cld' is needed and has to
    be converted to a MBN file.

    The `mkheader.py` script used here can be found in the Netgear V1.2.8.40 GPL source,
    under 'git_home/u-boot.git/tools/mkheader.py'

    Convert the CLD file to MBN using:
    $ python2 mkheader.py 0x44000000 0x13 <*.cld file> aqr_4.3.C.mbn

    This MBN file can then be flashed to the MTD partition to be used by u-boot.

    The necessary files can also be found in
        https://github.com/boretom/openwrt-fork/tree/rax120v2/aquantia-firmware

    * Write MBN file to MTD partition to be loaded automatically by u-boot:

      U-boot automatically tries to load the firmware from nand at address 0x7e00000 which
      corresponds to `/dev/mtd25` in OpenWrt.

        - find ETHPHYFW partition while running OpenWrt (expected: /dev/mtd25)

          $ fgrep -i 'ethphyfw' /proc/mtd
          mtd25: 00080000 00020000 "ethphyfw

        - copy mbn file to /tmp/ folder of the router

          $ scp aqr-v4.3.C.mbn 192.168.1.1:/tmp/

        - write mbn file to ethphyfw partition

          $ mtd write /tmp/aqr_v4.3.C.mbn /dev/mtd25

Revert to stock firmware:
    * Flash the stock firmware to the bootloader using TFTP/NMRP.

References to RAX120v2 GPL source:
    https://www.downloads.netgear.com/files/GPL/RAX120-V1.2.8.40_gpl_src.zip

Signed-off-by: Thomas Kupper <thomas.kupper@gmail.com>