### PR TITLE
omap: mark source only

### DIFF
--- a/target/linux/omap/Makefile
+++ b/target/linux/omap/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=omap
 BOARDNAME:=TI OMAP3/4/AM33xx
-FEATURES:=usb usbgadget ext4 targz fpu audio display nand rootfs-part squashfs
+FEATURES:=usb usbgadget ext4 targz fpu audio display nand rootfs-part squashfs source-only
 CPU_TYPE:=cortex-a8
 CPU_SUBTYPE:=vfpv3
 SUBTARGETS:=generic


### PR DESCRIPTION
The target is currently broken with Kernel 5.15 and no one in sight to fix it. Instead of stalling the next release indefinitely, make it source only and see if someone steps up to fix it.