### PR TITLE
lantiq: mark source only

### DIFF
--- a/target/linux/lantiq/Makefile
+++ b/target/linux/lantiq/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 BOARD:=lantiq
 BOARDNAME:=Lantiq
-FEATURES:=squashfs
+FEATURES:=squashfs source-only
 SUBTARGETS:=xrx200 xway xway_legacy falcon ase
 
 KERNEL_PATCHVER:=5.10


### PR DESCRIPTION
The target is currently broken with Kernel 5.15 and no one in sight to fix it. Instead of stalling the next release indefinitely, make it source only and see if someone steps up to fix it.