### PR TITLE
[22.03] ramips: mt7621: add support for Cudy X6 v2

### DIFF
--- a/target/linux/ramips/dts/mt7621_cudy_x6-v1.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_x6-v1.dts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_cudy_x6.dtsi"
+
+/ {
+	compatible = "cudy,x6-v1", "mediatek,mt7621-soc";
+	model = "CUDY X6 v1";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0x1f80000>;
+	};
+
+	partition@1fd0000 {
+		label = "debug";
+		reg = <0x1fd0000 0x10000>;
+		read-only;
+	};
+
+	partition@1fe0000 {
+		label = "backup";
+		reg = <0x1fe0000 0x10000>;
+		read-only;
+	};
+
+	partition@1ff0000 {
+		label = "bdinfo";
+		reg = <0x1ff0000 0x10000>;
+		read-only;
+
+		compatible = "nvmem-cells";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_bdinfo_de00: macaddr@de00 {
+			reg = <0xde00 0x6>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@4 {
+			nvmem-cells = <&macaddr_bdinfo_de00>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <1>;
+		};
+	};
+};
+
+&wifi {
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/ramips/dts/mt7621_cudy_x6-v2.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_x6-v2.dts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_cudy_x6.dtsi"
+
+/ {
+	compatible = "cudy,x6-v2", "mediatek,mt7621-soc";
+	model = "CUDY X6 v2";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0xf80000>;
+	};
+
+	partition@fd0000 {
+		label = "debug";
+		reg = <0xfd0000 0x10000>;
+		read-only;
+	};
+
+	partition@fe0000 {
+		label = "backup";
+		reg = <0xfe0000 0x10000>;
+		read-only;
+	};
+
+	partition@ff0000 {
+		label = "bdinfo";
+		reg = <0xff0000 0x10000>;
+		read-only;
+
+		compatible = "nvmem-cells";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_bdinfo_de00: macaddr@de00 {
+			reg = <0xde00 0x6>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@4 {
+			nvmem-cells = <&macaddr_bdinfo_de00>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <1>;
+		};
+	};
+};
+
+&wifi {
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/ramips/dts/mt7621_cudy_x6.dtsi
+++ b/target/linux/ramips/dts/mt7621_cudy_x6.dtsi
@@ -6,9 +6,6 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "cudy,x6", "mediatek,mt7621-soc";
-	model = "CUDY X6";
-
 	aliases {
 		led-boot = &led_internet_blue;
 		led-failsafe = &led_internet_red;
@@ -61,7 +58,7 @@
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 
-		partitions {
+		partitions: partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -84,37 +81,7 @@
 				read-only;
 			};
 
-			partition@50000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x50000 0x1f80000>;
-			};
-
-			partition@1fd0000 {
-				label = "debug";
-				reg = <0x1fd0000 0x10000>;
-				read-only;
-			};
-
-			partition@1fe0000 {
-				label = "backup";
-				reg = <0x1fe0000 0x10000>;
-				read-only;
-			};
-
-			partition@1ff0000 {
-				label = "bdinfo";
-				reg = <0x1ff0000 0x10000>;
-				read-only;
-
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				macaddr_bdinfo_de00: macaddr@de00 {
-					reg = <0xde00 0x6>;
-				};
-			};
+			/* additional partitions in DTS */
 		};
 	};
 };
@@ -124,19 +91,11 @@
 };
 
 &pcie1 {
-	wifi@0,0 {
+	wifi:wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
-
-		nvmem-cells = <&macaddr_bdinfo_de00>;
-		nvmem-cell-names = "mac-address";
 	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_bdinfo_de00>;
-	nvmem-cell-names = "mac-address";
 };
 
 &switch0 {
@@ -164,9 +123,6 @@
 		port@4 {
 			status = "okay";
 			label = "wan";
-			nvmem-cells = <&macaddr_bdinfo_de00>;
-			nvmem-cell-names = "mac-address";
-			mac-address-increment = <1>;
 		};
 	};
 };

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -345,16 +345,29 @@ define Device/cudy_wr2100
 endef
 TARGET_DEVICES += cudy_wr2100
 
-define Device/cudy_x6
+define Device/cudy_x6-v1
   $(Device/dsa-migration)
   IMAGE_SIZE := 32256k
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := X6
+  DEVICE_VARIANT := v1
   UIMAGE_NAME := R13
   DEVICE_PACKAGES := kmod-mt7915e
-  SUPPORTED_DEVICES += R13
+  SUPPORTED_DEVICES += cudy,x6 R13
 endef
-TARGET_DEVICES += cudy_x6
+TARGET_DEVICES += cudy_x6-v1
+
+define Device/cudy_x6-v2
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 15872k
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := X6
+  DEVICE_VARIANT := v2
+  UIMAGE_NAME := R30
+  DEVICE_PACKAGES := kmod-mt7915e
+  SUPPORTED_DEVICES += cudy,x6 R30
+endef
+TARGET_DEVICES += cudy_x6-v2
 
 define Device/dlink_dap-x1860-a1
   $(Device/dsa-migration)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -18,7 +18,8 @@ case "$board" in
 		hw_mac_addr=$(macaddr_unsetbit $hw_mac_addr 28)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $hw_mac_addr > /sys${DEVPATH}/macaddress
 		;;
-	cudy,x6)
+	cudy,x6-v1|\
+	cudy,x6-v2)
 		hw_mac_addr="$(mtd_get_mac_binary bdinfo 0xde00)"
 		[ "$PHYNBR" = "1" ] && \
 		macaddr_setbit_la "$(macaddr_add $hw_mac_addr 0x100000)" > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
Rename existing device to v1 and create common .dtsi Difference to v1: 16MB Flash

Specifications:

SoC: MediaTek MT7621
RAM: 256 MB
Flash: 16 MB (SPI NOR, XM25QH128C on my device)
WiFi: MediaTek MT7915E
Switch: 1 WAN, 4 LAN (Gigabit)
Buttons: Reset, WPS
LEDs: Two Power LEDs (blue and red; together they form purple) Power: DC 12V 1A center positive
Serial: 115200 8N1
        C440 - (3V3 - GND - RX - TX) - C41 | v1 and v2
               (P   - G   - R  - T)        | v2 labels them on the board
Installation:

Download and flash the manufacturer's built OpenWrt image available at http://www.cudytech.com/openwrt_software_download
Install the new OpenWrt image via luci (System -> Backup/Flash firmware) Be sure to NOT keep settings.

Recovery:

Loads only signed manufacture firmware due to bootloader RSA verification Serve tftp-recovery image as /recovery.bin on 192.168.1.88/24 Connect to any lan ethernet port
Power on the device while holding the reset button Wait at least 8 seconds before releasing reset button for image to download

MAC addresses as verified by OEM firmware:

use   address             source
LAN   f4:a4:54:86:75:a2   label
WAN   f4:a4:54:86:75:a3   label + 1
2g    f4:a4:54:86:75:a2   label
5g    f6:a4:54:b6:75:a2   label + LA-Bit set + 4th oktet increased

The label MAC address is found in bdinfo 0xde00.

(cherry picked from commit e38de40f8dd350344407fe5a91e81191f6960804)

______________________

This backport was build and run tested successfully on both devices: Cudy X6 v1 and v2