### PR TITLE
wireless-regdb: update to 2023.05.03

### DIFF
--- a/package/firmware/wireless-regdb/Makefile
+++ b/package/firmware/wireless-regdb/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wireless-regdb
-PKG_VERSION:=2023.02.13
+PKG_VERSION:=2023.05.03
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/network/wireless-regdb/
-PKG_HASH:=fe81e8a8694dc4753a45087a1c4c7e1b48dee5a59f5f796ce374ea550f0b2e73
+PKG_HASH:=f254d08ab3765aeae2b856222e11a95d44aef519a6663877c71ef68fae4c8c12
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
Changes:
  43f81b4 wireless-regdb: update regulatory database based on preceding changes
  66f245d wireless-regdb: Update regulatory rules for Hong Kong (HK)
  e78c450 wireless-regdb: update regulatory rules for India (IN)
  1647bb6 wireless-regdb: Update regulatory rules for Russia (RU). Remove DFS requirement.
  c076f21 Update regulatory info for Russia (RU) on 6GHz

Signed-off-by: CaffeeLake <PascalCoffeeLake@gmail.com>