### PR TITLE
lantiq: mark only xrx200 subtarget as source-only

### DIFF
--- a/target/linux/lantiq/Makefile
+++ b/target/linux/lantiq/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 BOARD:=lantiq
 BOARDNAME:=Lantiq
-FEATURES:=squashfs source-only
+FEATURES:=squashfs
 SUBTARGETS:=xrx200 xway xway_legacy falcon ase
 
 KERNEL_PATCHVER:=5.10

--- a/target/linux/lantiq/xrx200/target.mk
+++ b/target/linux/lantiq/xrx200/target.mk
@@ -1,7 +1,7 @@
 ARCH:=mips
 SUBTARGET:=xrx200
 BOARDNAME:=XRX200
-FEATURES+=atm nand ramdisk
+FEATURES+=atm nand ramdisk source-only
 CPU_TYPE:=24kc
 
 DEFAULT_PACKAGES+=kmod-leds-gpio \


### PR DESCRIPTION
The current problems blocking the switch to the kernel 5.15 are related to the GSWIP driver. This driver is only used by the xrx200 subtarget. The other subtargets are unaffected by this problem.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>