### PR TITLE
realtek: Prepare for multiple SoC types

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -51,14 +51,17 @@ DEFAULT_PACKAGES.nas:=\
 	fdisk \
 	lsblk \
 	mdadm
-# For router targets
-DEFAULT_PACKAGES.router:=\
+# For switch targets
+DEFAULT_PACKAGES.switch:=\
 	dnsmasq \
 	firewall4 \
-	nftables \
 	kmod-nft-offload \
+	nftables \
 	odhcp6c \
-	odhcpd-ipv6only \
+	odhcpd-ipv6only
+# For router targets
+DEFAULT_PACKAGES.router:=\
+	$(DEFAULT_PACKAGES.switch) \
 	ppp \
 	ppp-mod-pppoe
 

--- a/target/linux/realtek/Makefile
+++ b/target/linux/realtek/Makefile
@@ -5,7 +5,6 @@ include $(TOPDIR)/rules.mk
 ARCH:=mips
 BOARD:=realtek
 BOARDNAME:=Realtek based boards
-DEVICE_TYPE:=basic
 FEATURES:=ramdisk squashfs
 SUBTARGETS:=rtl838x rtl839x rtl930x rtl931x
 
@@ -19,13 +18,9 @@ include $(INCLUDE_DIR)/target.mk
 
 DEFAULT_PACKAGES += \
 	ethtool \
-	firewall4 \
 	ip-bridge \
 	ip-full \
 	kmod-gpio-button-hotplug \
-	kmod-nft-offload \
-	nftables \
-	odhcp6c \
 	tc-bpf \
 	uboot-envtools \
 

--- a/target/linux/realtek/Makefile
+++ b/target/linux/realtek/Makefile
@@ -16,13 +16,6 @@ endef
 
 include $(INCLUDE_DIR)/target.mk
 
-DEFAULT_PACKAGES += \
-	ethtool \
-	ip-bridge \
-	ip-full \
-	kmod-gpio-button-hotplug \
-	tc-bpf \
-	uboot-envtools \
-
+DEFAULT_PACKAGES += ethtool
 
 $(eval $(call BuildTarget))

--- a/target/linux/realtek/Makefile
+++ b/target/linux/realtek/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 ARCH:=mips
 BOARD:=realtek
-BOARDNAME:=Realtek MIPS
+BOARDNAME:=Realtek based boards
 DEVICE_TYPE:=basic
 FEATURES:=ramdisk squashfs
 SUBTARGETS:=rtl838x rtl839x rtl930x rtl931x
@@ -12,7 +12,7 @@ SUBTARGETS:=rtl838x rtl839x rtl930x rtl931x
 KERNEL_PATCHVER:=5.15
 
 define Target/Description
-	Build firmware images for Realtek RTL83xx based boards.
+	Build firmware images for Realtek switch based boards.
 endef
 
 include $(INCLUDE_DIR)/target.mk

--- a/target/linux/realtek/rtl838x/target.mk
+++ b/target/linux/realtek/rtl838x/target.mk
@@ -4,6 +4,7 @@ SUBTARGET:=rtl838x
 CPU_TYPE:=4kec
 BOARD:=realtek
 BOARDNAME:=Realtek MIPS RTL838X
+DEVICE_TYPE:=switch
 
 define Target/Description
 	Build firmware images for Realtek RTL838x based boards.

--- a/target/linux/realtek/rtl838x/target.mk
+++ b/target/linux/realtek/rtl838x/target.mk
@@ -2,12 +2,12 @@
 ARCH:=mips
 SUBTARGET:=rtl838x
 CPU_TYPE:=4kec
-BOARD:=realtek
 BOARDNAME:=Realtek MIPS RTL838X
-DEVICE_TYPE:=switch
 
 define Target/Description
 	Build firmware images for Realtek RTL838x based boards.
 endef
 
 FEATURES := $(filter-out mips16,$(FEATURES))
+
+include $(TOPDIR)/target/linux/realtek/switch.mk

--- a/target/linux/realtek/rtl839x/target.mk
+++ b/target/linux/realtek/rtl839x/target.mk
@@ -4,6 +4,7 @@ SUBTARGET:=rtl839x
 CPU_TYPE:=24kc
 BOARD:=realtek
 BOARDNAME:=Realtek MIPS RTL839X
+DEVICE_TYPE:=switch
 
 define Target/Description
 	Build firmware images for Realtek RTL839x based boards.

--- a/target/linux/realtek/rtl839x/target.mk
+++ b/target/linux/realtek/rtl839x/target.mk
@@ -2,10 +2,10 @@
 ARCH:=mips
 SUBTARGET:=rtl839x
 CPU_TYPE:=24kc
-BOARD:=realtek
 BOARDNAME:=Realtek MIPS RTL839X
-DEVICE_TYPE:=switch
 
 define Target/Description
 	Build firmware images for Realtek RTL839x based boards.
 endef
+
+include $(TOPDIR)/target/linux/realtek/switch.mk

--- a/target/linux/realtek/rtl930x/target.mk
+++ b/target/linux/realtek/rtl930x/target.mk
@@ -4,6 +4,7 @@ SUBTARGET:=rtl930x
 CPU_TYPE:=24kc
 BOARD:=realtek
 BOARDNAME:=Realtek MIPS RTL930X
+DEVICE_TYPE:=switch
 
 define Target/Description
 	Build firmware images for Realtek RTL930x based boards.

--- a/target/linux/realtek/rtl930x/target.mk
+++ b/target/linux/realtek/rtl930x/target.mk
@@ -2,10 +2,10 @@
 ARCH:=mips
 SUBTARGET:=rtl930x
 CPU_TYPE:=24kc
-BOARD:=realtek
 BOARDNAME:=Realtek MIPS RTL930X
-DEVICE_TYPE:=switch
 
 define Target/Description
 	Build firmware images for Realtek RTL930x based boards.
 endef
+
+include $(TOPDIR)/target/linux/realtek/switch.mk

--- a/target/linux/realtek/rtl931x/target.mk
+++ b/target/linux/realtek/rtl931x/target.mk
@@ -2,10 +2,10 @@
 ARCH:=mips
 SUBTARGET:=rtl931x
 CPU_TYPE:=24kc
-BOARD:=realtek
 BOARDNAME:=Realtek MIPS RTL931X
-DEVICE_TYPE:=switch
 
 define Target/Description
 	Build firmware images for Realtek RTL931x based boards.
 endef
+
+include $(TOPDIR)/target/linux/realtek/switch.mk

--- a/target/linux/realtek/rtl931x/target.mk
+++ b/target/linux/realtek/rtl931x/target.mk
@@ -4,6 +4,7 @@ SUBTARGET:=rtl931x
 CPU_TYPE:=24kc
 BOARD:=realtek
 BOARDNAME:=Realtek MIPS RTL931X
+DEVICE_TYPE:=switch
 
 define Target/Description
 	Build firmware images for Realtek RTL931x based boards.

--- a/target/linux/realtek/switch.mk
+++ b/target/linux/realtek/switch.mk
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+DEFAULT_PACKAGES+=ip-bridge
+DEFAULT_PACKAGES+=ip-full
+DEFAULT_PACKAGES+=kmod-gpio-button-hotplug
+DEFAULT_PACKAGES+=tc-bpf
+DEFAULT_PACKAGES+=uboot-envtools
+
+DEVICE_TYPE:=switch


### PR DESCRIPTION
This MR prepares the Makefile for a future where non-switch chips would also be supported.

In doing so, we introduce the 'switch' device type.