### PR TITLE
tools/pkgconf: update to 1.9.5

### DIFF
--- a/tools/pkgconf/Makefile
+++ b/tools/pkgconf/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pkgconf
-PKG_VERSION:=1.9.4
+PKG_VERSION:=1.9.5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://distfiles.dereferenced.org/pkgconf
-PKG_HASH:=daccf1bbe5a30d149b556c7d2ffffeafd76d7b514e249271abdd501533c1d8ae
+PKG_HASH:=1ac1656debb27497563036f7bffc281490f83f9b8457c0d60bcfb638fb6b6171
 
 PKG_CPE_ID:=cpe:/a:pkgconf:pkgconf
 


### PR DESCRIPTION
Release Notes:
https://github.com/pkgconf/pkgconf/blob/master/NEWS