### PR TITLE
kernel: limit some modules to devices with PCI support 

### DIFF
--- a/package/kernel/linux/modules/i2c.mk
+++ b/package/kernel/linux/modules/i2c.mk
@@ -103,7 +103,7 @@ I2C_DWPCI_MODULES:= \
 define KernelPackage/i2c-designware-pci
   $(call i2c_defaults,$(I2C_DWPCI_MODULES),59)
   TITLE:=Synopsys DesignWare PCI
-  DEPENDS:=+kmod-i2c-designware-core
+  DEPENDS:=@PCI_SUPPORT +kmod-i2c-designware-core
 endef
 
 define KernelPackage/i2c-designware-pci/description

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -901,7 +901,7 @@ define KernelPackage/serial-8250-exar
   KCONFIG:= CONFIG_SERIAL_8250_EXAR
   FILES:=$(LINUX_DIR)/drivers/tty/serial/8250/8250_exar.ko
   AUTOLOAD:=$(call AutoProbe,8250 8250_base 8250_exar)
-  DEPENDS:=+kmod-serial-8250
+  DEPENDS:=@PCI_SUPPORT +kmod-serial-8250
 endef
 
 define KernelPackage/serial-8250-exar/description

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -1352,7 +1352,7 @@ $(eval $(call KernelPackage,mhi-bus))
 define KernelPackage/mhi-pci-generic
   SUBMENU:=$(OTHER_MENU)
   TITLE:=MHI PCI controller driver
-  DEPENDS:=@LINUX_5_15 +kmod-mhi-bus
+  DEPENDS:=@LINUX_5_15 @PCI_SUPPORT +kmod-mhi-bus
   KCONFIG:=CONFIG_MHI_BUS_PCI_GENERIC
   FILES:=$(LINUX_DIR)/drivers/bus/mhi/mhi_pci_generic.ko
   AUTOLOAD:=$(call AutoProbe,mhi_pci_generic)


### PR DESCRIPTION
Kmod-i2c-designware-pci, kmod-serial-8250-exar and limit mhi-pci-generic support various interfaces connected via the PCI bus.  On targets without PCI support, these packages are empty.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>