### PR TITLE
odhcp6c: add skpriority option

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -34,6 +34,7 @@ proto_dhcpv6_init_config() {
 	proto_config_add_string "vendorclass"
 	proto_config_add_array "sendopts:list(string)"
 	proto_config_add_boolean delegate
+	proto_config_add_int skpriority
 	proto_config_add_int "soltimeout"
 	proto_config_add_boolean fakeroutes
 	proto_config_add_boolean sourcefilter
@@ -54,8 +55,8 @@ proto_dhcpv6_setup() {
 	local config="$1"
 	local iface="$2"
 
-	local reqaddress reqprefix clientid reqopts defaultreqopts noslaaconly forceprefix extendprefix norelease noserverunicast noclientfqdn noacceptreconfig ip6prefix ip6prefixes iface_dslite iface_map iface_464xlat ifaceid userclass vendorclass sendopts delegate zone_dslite zone_map zone_464xlat zone encaplimit_dslite encaplimit_map soltimeout fakeroutes sourcefilter keep_ra_dnslifetime ra_holdoff verbose
-	json_get_vars reqaddress reqprefix clientid reqopts defaultreqopts noslaaconly forceprefix extendprefix norelease noserverunicast noclientfqdn noacceptreconfig iface_dslite iface_map iface_464xlat ifaceid userclass vendorclass delegate zone_dslite zone_map zone_464xlat zone encaplimit_dslite encaplimit_map soltimeout fakeroutes sourcefilter keep_ra_dnslifetime ra_holdoff verbose
+	local reqaddress reqprefix clientid reqopts defaultreqopts noslaaconly forceprefix extendprefix norelease noserverunicast noclientfqdn noacceptreconfig ip6prefix ip6prefixes iface_dslite iface_map iface_464xlat ifaceid userclass vendorclass sendopts delegate zone_dslite zone_map zone_464xlat zone encaplimit_dslite encaplimit_map skpriority soltimeout fakeroutes sourcefilter keep_ra_dnslifetime ra_holdoff verbose
+	json_get_vars reqaddress reqprefix clientid reqopts defaultreqopts noslaaconly forceprefix extendprefix norelease noserverunicast noclientfqdn noacceptreconfig iface_dslite iface_map iface_464xlat ifaceid userclass vendorclass delegate zone_dslite zone_map zone_464xlat zone encaplimit_dslite encaplimit_map skpriority soltimeout fakeroutes sourcefilter keep_ra_dnslifetime ra_holdoff verbose
 	json_for_each_item proto_dhcpv6_add_prefix ip6prefix ip6prefixes
 
 	# Configure
@@ -88,6 +89,8 @@ proto_dhcpv6_setup() {
 	[ -n "$userclass" ] && append opts "-u$userclass"
 
 	[ "$keep_ra_dnslifetime" = "1" ] && append opts "-L"
+
+	[ -n "$skpriority" ] && append opts "-K$skpriority"
 
 	[ -n "$ra_holdoff" ] && append opts "-m$ra_holdoff"
 


### PR DESCRIPTION
Allowing the (kernel) packet priority to be set through UCI.

This makes it straightforward to set some VLAN priority for DHCP requests through a simple egress qos map. (Avoiding the need for firewall matching and marking through iptables, which prevents using flow offloading).

(Such priority tag is a hard requirement for some ISPs, such as Orange in France).

Depends on: https://github.com/openwrt/odhcp6c/pull/74

CC: @dedeckeh 