### PR TITLE
sdk: do not exclude all doc directories

### DIFF
--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -32,7 +32,6 @@ EXCLUDE_DIRS:= \
 	*.install.clean \
 	*.install.flags \
 	*.install \
-	*/doc \
 	*/share/locale
 
 SDK_DIRS = \
@@ -158,6 +157,8 @@ $(BIN_DIR)/$(SDK_NAME).tar.xz: clean
 		$(SDK_BUILD_DIR)/package/kernel/
 
 	-rm -rf $(SDK_BUILD_DIR)/$(STAGING_SUBDIR_HOST)/.prereq-build
+	-rm -rf $(SDK_BUILD_DIR)/$(STAGING_SUBDIR_HOST)/doc
+	-rm -rf $(SDK_BUILD_DIR)/$(STAGING_SUBDIR_HOST)/share/doc
 
 	-rm -f $(SDK_BUILD_DIR)/feeds.conf.default
 	$(if $(BASE_FEED),echo "$(BASE_FEED)" > $(SDK_BUILD_DIR)/feeds.conf.default)


### PR DESCRIPTION
this is untested but very simple fix...

bulldbot errors in building gettext using the sdk...

```
/builder/shared-workdir/build/sdk/staging_dir/host/share/gnulib/gnulib-tool: *** file /builder/shared-workdir/build/sdk/staging_dir/host/share/gnulib/doc/relocatable.texi not found
/builder/shared-workdir/build/sdk/staging_dir/host/share/gnulib/gnulib-tool: *** Stop.
```

Some packages which are using local gnulib source
are expecting files to exist in the directory:

staging_dir/host/share/gnulib/doc

so delete the other doc directories directly
instead of excluding all of them.

Fixes: d167adbc4 ("gettext-full: bootstrap to local gnulib source")
