### PR TITLE
mvebu:puzzle-m902: add network interface name reorder function

### DIFF
--- a/target/linux/mvebu/base-files/lib/preinit/06_puzzle-M902_reorder_eth
+++ b/target/linux/mvebu/base-files/lib/preinit/06_puzzle-M902_reorder_eth
@@ -1,0 +1,27 @@
+reorder_puzzlem902_interfaces() {
+	if [ ! -f /tmp/sysinfo/board_name ]; then
+		echo "No board name found, not doing reorder_puzzlem902_interfaces"
+		return 0
+	fi
+
+	board=$(cat /tmp/sysinfo/board_name)
+	case "$board" in
+	iei,puzzle-m902)
+
+		# Reorder ethernet interfaces to match the physical order
+		ip link set eth0 name eth10
+		ip link set eth2 name eth0
+		ip link set eth3 name eth11
+		ip link set eth4 name eth3
+		ip link set eth5 name eth2
+		ip link set eth6 name eth12
+		ip link set eth7 name eth5
+		ip link set eth8 name eth4
+		;;
+	default)
+		echo "board $board"
+		;;
+	esac
+}
+
+boot_hook_add preinit_main reorder_puzzlem902_interfaces

--- a/target/linux/mvebu/cortexa72/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/cortexa72/base-files/etc/board.d/02_network
@@ -17,7 +17,7 @@ iei,puzzle-m901)
 	ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4 eth5" "eth0"
 	;;
 iei,puzzle-m902)
-	ucidef_set_interfaces_lan_wan "eth0 eth1 eth3 eth4 eth5 eth6 eth7 eth8" "eth2"
+	ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4 eth5 eth10 eth11 eth12" "eth0"
 	;;
 marvell,armada8040-mcbin-doubleshot|\
 marvell,armada8040-mcbin-singleshot)


### PR DESCRIPTION
mvebu: puzzle-m902: add network interface name reorder function

In order for the name of the network port to match the name of the device printed text Original: eth2 eth1 eth5 eth4 eth8 eth7 eth0 eth3 eth6 Reorder : eth0 eth1 eth2 eth3 eth4 eth5 eth10 eth11 eth12


