### PR TITLE
ramips: Fix Wireless Frequencies for HYC-G920

### DIFF
--- a/target/linux/ramips/dts/mt7621_hanyang_hyc-g920.dts
+++ b/target/linux/ramips/dts/mt7621_hanyang_hyc-g920.dts
@@ -116,6 +116,7 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {
 			led-sources = <2>;
@@ -129,6 +130,7 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {
 			led-sources = <2>;


### PR DESCRIPTION
Fix wireless frequencies to show correct wireless interfaces.