### PR TITLE
fortify-headers: fix inconsistent time_t version of ppoll

### DIFF
--- a/toolchain/fortify-headers/Makefile
+++ b/toolchain/fortify-headers/Makefile
@@ -9,7 +9,7 @@ include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=fortify-headers
 PKG_VERSION:=1.1
-PKG_RELEASE=1
+PKG_RELEASE=2
 
 PKG_SOURCE_URL:=https://dl.2f30.org/releases
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/toolchain/fortify-headers/patches/001-__ppoll_time64.patch
+++ b/toolchain/fortify-headers/patches/001-__ppoll_time64.patch
@@ -1,0 +1,11 @@
+--- a/include/poll.h
++++ b/include/poll.h
+@@ -39,7 +39,7 @@ _FORTIFY_FN(poll) int poll(struct pollfd
+ 	return __orig_poll(__f, __n, __s);
+ }
+ 
+-#ifdef _GNU_SOURCE
++#if defined(_GNU_SOURCE) && !_REDIR_TIME64
+ #undef ppoll
+ _FORTIFY_FN(ppoll) int ppoll(struct pollfd *__f, nfds_t __n, const struct timespec *__s,
+                              const sigset_t *__m)


### PR DESCRIPTION
Bug:
`fortify/poll.h` includes `poll.h`, which redirects the `ppoll` sys call to `__ppoll_time64`,
if the `_REDIR_TIME64` macro is 1. Then `fortify/poll.h` will `#undef ppoll` and use the 32 bit version, which is inconsistent.

Fix: we should not do this when `_REDIR_TIME64` is 1.

[1] https://forum.openwrt.org/t/idle-cpu-usage-of-usbmuxd/140331/15
[2] https://github.com/openwrt/openwrt/issues/12574

Host tested: macOS 12.6.5
Targets tested: TP-Link TL-WR1043ND v4, WRT3200ACM

@Ansuel @hauke @nbd168 @mpratt14 @1715173329 @jow- @ldir-EDB0 