### PR TITLE
Escape whitespaces in VERSION_DIST for Netgear images

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -400,7 +400,7 @@ endef
 
 define Build/netgear-dni
 	$(STAGING_DIR_HOST)/bin/mkdniimg \
-		-B $(NETGEAR_BOARD_ID) -v $(VERSION_DIST).$(firstword $(subst -, ,$(REVISION))) \
+		-B $(NETGEAR_BOARD_ID) -v $(shell cat $(VERSION_DIST)| sed -e 's/[[:space:]]/-/g').$(firstword $(subst -, ,$(REVISION))) \
 		$(if $(NETGEAR_HW_ID),-H $(NETGEAR_HW_ID)) \
 		-r "$(1)" \
 		-i $@ -o $@.new
@@ -413,7 +413,7 @@ define Build/netgear-encrypted-factory
 		--output-file $@ \
 		--model $(NETGEAR_ENC_MODEL) \
 		--region $(NETGEAR_ENC_REGION) \
-		--version V1.0.0.0.$(VERSION_DIST).$(firstword $(subst -, ,$(REVISION))) \
+		--version V1.0.0.0.$(shell cat $(VERSION_DIST)| sed -e 's/[[:space:]]/-/g').$(firstword $(subst -, ,$(REVISION))) \
 		--encryption-block-size 0x20000 \
 		--openssl-bin "$(STAGING_DIR_HOST)/bin/openssl" \
 		--key 6865392d342b4d212964363d6d7e7765312c7132613364316e26322a5a5e2538 \


### PR DESCRIPTION
I got a build-error on traget "linux" the following error:

~~~
netgear-encrypted-factory.py --input-file <squashfs-factory.img> --output-file <squashfs-factory.img> --model WAX202 --region US --version V1.0.0.0.ColVisTec AG.r20134 --encryption-block-size 0x20000 --openssl-bin "openwrt/staging_dir/host/bin/openssl" --key <key> --iv <iv>
usage: netgear-encrypted-factory.py [-h] --input-file INPUT_FILE --output-file OUTPUT_FILE --model MODEL --region REGION --version VERSION --encryption-block-size ENCRYPTION_BLOCK_SIZE
                                    --openssl-bin OPENSSL_BIN --key KEY --iv IV
netgear-encrypted-factory.py: error: unrecognized arguments: AG.r20134
~~~

The whitespace in the "--version" option breaks parsing. Instead of quoting it, I replace by whitespace by dash, to prevent problems further down, when having whitespace inside firmware.


Runtime tested on ramips/mt7621 with v22.03.5