### PR TITLE
lantiq: 5.15: fix compilation warning pciex fixup patch

### DIFF
--- a/target/linux/lantiq/patches-5.15/0001-MIPS-lantiq-add-pcie-driver.patch
+++ b/target/linux/lantiq/patches-5.15/0001-MIPS-lantiq-add-pcie-driver.patch
@@ -178,7 +178,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  int pcibios_map_irq(const struct pci_dev *dev, u8 slot, u8 pin)
  {
 +#ifdef CONFIG_PCIE_LANTIQ
-+	if (pci_find_capability(dev, PCI_CAP_ID_EXP))
++	if (pci_find_capability((struct pci_dev *)dev, PCI_CAP_ID_EXP))
 +		return ifx_pcie_bios_map_irq(dev, slot, pin);
 +#endif
 +


### PR DESCRIPTION
pcibios_map_irq request a const pci_dev while pci_find_capability doesn't. Cast dropping the const to fix compilation warning. Fix compilation warning:
arch/mips/pci/fixup-lantiq.c: In function 'pcibios_map_irq': arch/mips/pci/fixup-lantiq.c:34:33: error: passing argument 1 of 'pci_find_capability' discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
   34 |         if (pci_find_capability(dev, PCI_CAP_ID_EXP))
      |                                 ^~~
In file included from arch/mips/pci/fixup-lantiq.c:9:
./include/linux/pci.h:1129:40: note: expected 'struct pci_dev *' but argument is of type 'const struct pci_dev *'
 1129 | u8 pci_find_capability(struct pci_dev *dev, int cap);
      |                        ~~~~~~~~~~~~~~~~^~~
cc1: all warnings being treated as errors