### PR TITLE
toolchain: gcc: switch default to 13

### DIFF
--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -2,7 +2,7 @@
 
 choice
 	prompt "GCC compiler Version" if TOOLCHAINOPTS
-	default GCC_USE_VERSION_12
+	default GCC_USE_VERSION_13
 	help
 	  Select the version of gcc you wish to use.
 

--- a/toolchain/gcc/Config.version
+++ b/toolchain/gcc/Config.version
@@ -2,13 +2,13 @@ config GCC_VERSION_11
 	default y if GCC_USE_VERSION_11
 	bool
 
-config GCC_VERSION_13
-	default y if GCC_USE_VERSION_13
+config GCC_VERSION_12
+	default y if GCC_USE_VERSION_12
 	bool
 
 config GCC_VERSION
 	string
 	default EXTERNAL_GCC_VERSION	if EXTERNAL_TOOLCHAIN && !NATIVE_TOOLCHAIN
 	default "11.3.0"	if GCC_VERSION_11
-	default "13.2.0"	if GCC_VERSION_13
-	default "12.3.0"
+	default "12.3.0"	if GCC_VERSION_12
+	default "13.2.0"


### PR DESCRIPTION
Keep track of what CI says to gcc 13 by default.