### PR TITLE
fortify-headers: fix build error when _REDIR_TIME64 is not defined

### DIFF
--- a/toolchain/fortify-headers/Makefile
+++ b/toolchain/fortify-headers/Makefile
@@ -9,7 +9,7 @@ include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=fortify-headers
 PKG_VERSION:=1.1
-PKG_RELEASE=2
+PKG_RELEASE=3
 
 PKG_SOURCE_URL:=https://dl.2f30.org/releases
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/toolchain/fortify-headers/patches/001-__ppoll_time64.patch
+++ b/toolchain/fortify-headers/patches/001-__ppoll_time64.patch
@@ -5,7 +5,7 @@
  }
  
 -#ifdef _GNU_SOURCE
-+#if defined(_GNU_SOURCE) && !_REDIR_TIME64
++#if defined(_GNU_SOURCE) && !(defined(_REDIR_TIME64) && _REDIR_TIME64)
  #undef ppoll
  _FORTIFY_FN(ppoll) int ppoll(struct pollfd *__f, nfds_t __n, const struct timespec *__s,
                               const sigset_t *__m)


### PR DESCRIPTION
some targets do not define the `_REDIR_TIME64` macro resulting in a build error regression since ddfe5678a448ac8875e94f2fb4ddca67416fa14a
fix by checking if the macro is defined

[1] https://github.com/openwrt/openwrt/issues/12587
[2] https://github.com/openwrt/openwrt/pull/12575

@Ansuel @hauke @neheb @nbd168 @mpratt14 @1715173329 @jow- @ldir-EDB0 @graysky2 @john-tho 