### PR TITLE
fortify-headers: _REDIR_TIME64 isn't defined for x86_64 in MUSL

### DIFF
--- a/toolchain/fortify-headers/patches/001-__ppoll_time64.patch
+++ b/toolchain/fortify-headers/patches/001-__ppoll_time64.patch
@@ -5,7 +5,7 @@
  }
  
 -#ifdef _GNU_SOURCE
-+#if defined(_GNU_SOURCE) && !_REDIR_TIME64
++#if defined(_GNU_SOURCE) && !(defined(_REDIR_TIME64) && _REDIR_TIME64)
  #undef ppoll
  _FORTIFY_FN(ppoll) int ppoll(struct pollfd *__f, nfds_t __n, const struct timespec *__s,
                               const sigset_t *__m)


### PR DESCRIPTION
If you're compiling on x86_64 which is a 64-bit platform, then `_REDIR_TIME64` isn't set and compilation will fail with:

```
In file included from pathtrace.c:12:
/home/pprindeville/work/openwrt/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/include/fortify/poll.h:42:30: error: "_REDIR_TIME64" is not defined, evaluates to 0 [-Werror=undef]
   42 | #if defined(_GNU_SOURCE) && !_REDIR_TIME64
      |                              ^~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[6]: *** [Makefile:6503: libstrace_a-pathtrace.o] Error 1
```
