### PR TITLE
mac80211: add support for VHT 2.4G

### DIFF
--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -140,7 +140,7 @@ mac80211_hostapd_setup_base() {
 	[ -n "$acs_exclude_dfs" ] && [ "$acs_exclude_dfs" -gt 0 ] &&
 		append base_cfg "acs_exclude_dfs=1" "$N"
 
-	json_get_vars noscan ht_coex min_tx_power:0 tx_burst
+	json_get_vars noscan ht_coex vendor_vht min_tx_power:0 tx_burst
 	json_get_values ht_capab_list ht_capab
 	json_get_values channel_list channels
 
@@ -293,7 +293,7 @@ mac80211_hostapd_setup_base() {
 	}
 	[ "$hwmode" = "a" ] || enable_ac=0
 
-	if [ "$enable_ac" != "0" ]; then
+	if [ "$enable_ac" != "0" -o "$vendor_vht" = "1" ]; then
 		json_get_vars \
 			rxldpc:1 \
 			short_gi_80:1 \

--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -140,7 +140,7 @@ mac80211_hostapd_setup_base() {
 	[ -n "$acs_exclude_dfs" ] && [ "$acs_exclude_dfs" -gt 0 ] &&
 		append base_cfg "acs_exclude_dfs=1" "$N"
 
-	json_get_vars noscan ht_coex vendor_vht min_tx_power:0 tx_burst
+	json_get_vars noscan ht_coex min_tx_power:0 tx_burst
 	json_get_values ht_capab_list ht_capab
 	json_get_values channel_list channels
 
@@ -278,20 +278,38 @@ mac80211_hostapd_setup_base() {
 			vht_center_seg0=$idx
 		;;
 	esac
-	[ "$band" = "5g" ] && {
-		json_get_vars background_radar:0
+	if [ "$band" = "2g" ]; then
+		enable_ac=0
 
-		[ "$background_radar" -eq 1 ] && append base_cfg "enable_background_radar=1" "$N"
-	}
-	[ "$band" = "6g" ] && {
-		op_class=
 		case "$htmode" in
-			HE20) op_class=131;;
-			HE*) op_class=$((132 + $vht_oper_chwidth))
+			VHT20|VHT40)
+				vendor_vht=1
+			;;
+			HT20|HT40)
+				vendor_vht=0
+			;;
+			*)
+				htmode="HT20"
+				vendor_vht=0
+			;;
 		esac
-		[ -n "$op_class" ] && append base_cfg "op_class=$op_class" "$N"
-	}
-	[ "$hwmode" = "a" ] || enable_ac=0
+	else
+		[ "$band" = "5g" ] && {
+			json_get_vars background_radar:0
+
+			[ "$background_radar" -eq 1 ] && append base_cfg "enable_background_radar=1" "$N"
+		}
+		[ "$band" = "6g" ] && {
+			op_class=
+			case "$htmode" in
+				HE20) op_class=131;;
+				HE*) op_class=$((132 + $vht_oper_chwidth))
+			esac
+			[ -n "$op_class" ] && append base_cfg "op_class=$op_class" "$N"
+		}
+
+		vendor_vht=0
+	fi
 
 	if [ "$enable_ac" != "0" -o "$vendor_vht" = "1" ]; then
 		json_get_vars \

--- a/package/kernel/mac80211/patches/subsys/999-mac80211-allow-vht-on-2g.patch
+++ b/package/kernel/mac80211/patches/subsys/999-mac80211-allow-vht-on-2g.patch
@@ -1,0 +1,36 @@
+--- a/net/mac80211/vht.c
++++ b/net/mac80211/vht.c
+@@ -135,7 +135,8 @@ ieee80211_vht_cap_ie_to_sta_vht_cap(stru
+ 	have_80mhz = false;
+ 	for (i = 0; i < sband->n_channels; i++) {
+ 		if (sband->channels[i].flags & (IEEE80211_CHAN_DISABLED |
+-						IEEE80211_CHAN_NO_80MHZ))
++						IEEE80211_CHAN_NO_80MHZ) &&
++						(sband->band != NL80211_BAND_2GHZ))
+ 			continue;
+ 
+ 		have_80mhz = true;
+--- a/net/mac80211/util.c
++++ b/net/mac80211/util.c
+@@ -1925,7 +1925,8 @@ static int ieee80211_build_preq_ies_band
+ 	/* Check if any channel in this sband supports at least 80 MHz */
+ 	for (i = 0; i < sband->n_channels; i++) {
+ 		if (sband->channels[i].flags & (IEEE80211_CHAN_DISABLED |
+-						IEEE80211_CHAN_NO_80MHZ))
++						IEEE80211_CHAN_NO_80MHZ) &&
++						(sband->band != NL80211_BAND_2GHZ))
+ 			continue;
+ 
+ 		have_80mhz = true;
+--- a/net/mac80211/mlme.c
++++ b/net/mac80211/mlme.c
+@@ -5122,7 +5122,8 @@ static int ieee80211_prep_channel(struct
+ 	have_80mhz = false;
+ 	for (i = 0; i < sband->n_channels; i++) {
+ 		if (sband->channels[i].flags & (IEEE80211_CHAN_DISABLED |
+-						IEEE80211_CHAN_NO_80MHZ))
++						IEEE80211_CHAN_NO_80MHZ) &&
++						(sband->band != NL80211_BAND_2GHZ))
+ 			continue;
+ 
+ 		have_80mhz = true;


### PR DESCRIPTION
Continuation of #2522.

This no longer needs a patched hostapd nor a new config option. Instead it simply activates when `htmode` is either `VHT20` or `VHT40` on a 2.4 GHz radio.

Tested in combination with https://github.com/openwrt/mt76/pull/333