### PR TITLE
libsepol: update to 3.5

### DIFF
--- a/package/libs/libsepol/Makefile
+++ b/package/libs/libsepol/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsepol
-PKG_VERSION:=3.3
+PKG_VERSION:=3.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/SELinuxProject/selinux/releases/download/$(PKG_VERSION)
-PKG_HASH:=2d97df3eb8466169b389c3660acbb90c54200ac96e452eca9f41a9639f4f238b
+PKG_HASH:=78fdaf69924db780bac78546e43d9c44074bad798c2c415d0b9bb96d065ee8a2
 
 PKG_MAINTAINER:=Thomas Petazzoni <thomas.petazzoni@bootlin.com>
 PKG_CPE_ID:=cpe:/a:selinuxproject:libsepol


### PR DESCRIPTION
Release Notes:
https://github.com/SELinuxProject/selinux/releases/download/3.4/RELEASE-3.4.txt https://github.com/SELinuxProject/selinux/releases/download/3.5/RELEASE-3.5.txt