### PR TITLE
libsemanage: update to 3.5

### DIFF
--- a/package/libs/libsemanage/Makefile
+++ b/package/libs/libsemanage/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsemanage
-PKG_VERSION:=3.3
+PKG_VERSION:=3.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/SELinuxProject/selinux/releases/download/$(PKG_VERSION)
-PKG_HASH:=84d0ec5afa34bbbb471f602d8c1bf317d12443d07852a34b60741d428d597ce8
+PKG_HASH:=f53534e50247538280ed0d76c6ce81d8fb3939bd64cadb89da10dba42e40dd9c
 PKG_MAINTAINER:=Thomas Petazzoni <thomas.petazzoni@bootlin.com>
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Release Notes:
https://github.com/SELinuxProject/selinux/releases/download/3.4/RELEASE-3.4.txt https://github.com/SELinuxProject/selinux/releases/download/3.5/RELEASE-3.5.txt