### PR TITLE
policycoreutils: update to 3.5

### DIFF
--- a/package/utils/policycoreutils/Makefile
+++ b/package/utils/policycoreutils/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=policycoreutils
-PKG_VERSION:=3.3
+PKG_VERSION:=3.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/SELinuxProject/selinux/releases/download/$(PKG_VERSION)
-PKG_HASH:=4199040ced8a81f2ddd0522b4faf2aba62fc821473f4051dc8474fb1c4a01078
+PKG_HASH:=78453e1529fbbf800e88860094d555e781ce1fba11a7ef77b5aabb43e1173276
 PKG_INSTALL:=1
 HOST_BUILD_DEPENDS:=libsemanage/host gettext-full/host
 PKG_BUILD_DEPENDS:=BUSYBOX_CONFIG_PAM:libpam gettext-full/host


### PR DESCRIPTION
Release Notes:
https://github.com/SELinuxProject/selinux/releases/download/3.4/RELEASE-3.4.txt https://github.com/SELinuxProject/selinux/releases/download/3.5/RELEASE-3.5.txt