### PR TITLE
secilc: update to 3.5

### DIFF
--- a/package/utils/secilc/Makefile
+++ b/package/utils/secilc/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=secilc
-PKG_VERSION:=3.3
+PKG_VERSION:=3.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/SELinuxProject/selinux/releases/download/$(PKG_VERSION)
-PKG_HASH:=2c5e1a5d417baf1d2aa3eac294e12c3aac7184a5ef6a779dcbe469ed756e8651
+PKG_HASH:=3eebc5a1f97847fa530cf90654b9f3b8f21a13c9ea3d07495325651580cd3373
 HOST_BUILD_DEPENDS:=libsepol/host
 
 PKG_MAINTAINER:=Dominick Grift <dominick.grift@defensec.nl>


### PR DESCRIPTION
Release Notes:
https://github.com/SELinuxProject/selinux/releases/download/3.4/RELEASE-3.4.txt https://github.com/SELinuxProject/selinux/releases/download/3.5/RELEASE-3.5.txt