### PR TITLE
WWAN: add Medion Webstick S4222

### DIFF
--- a/package/network/utils/wwan/files/data/0e8d-00a5
+++ b/package/network/utils/wwan/files/data/0e8d-00a5
@@ -1,0 +1,5 @@
+{
+        "desc": "Medion S4222",
+        "control": 2,
+        "data": 0
+}


### PR DESCRIPTION
adding support for medion webstick s4222 (MD99079) which works after adding this file.