### PR TITLE
ci: use new buildbot worker images with Debian 11

### DIFF
--- a/.github/workflows/Dockerfile.tools
+++ b/.github/workflows/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/openwrt/buildbot/buildworker-3.4.1
+FROM ghcr.io/openwrt/buildbot/buildworker-v3.8.0:v2
 
 COPY --chown=buildbot staging_dir/host /prebuilt_tools/staging_dir/host
 COPY --chown=buildbot build_dir/host /prebuilt_tools/build_dir/host

--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: Build tools
     runs-on: ubuntu-latest
-    container: registry.gitlab.com/openwrt/buildbot/buildworker-3.4.1
+    container: ghcr.io/openwrt/buildbot/buildworker-v3.8.0:v2
 
     steps:
       - name: Checkout

--- a/package/Makefile
+++ b/package/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2010 OpenWrt.org
+# Copyright (C) 2006-2030 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.

--- a/target/linux/generic/PATCHES
+++ b/target/linux/generic/PATCHES
@@ -18,3 +18,5 @@ ALL patches must be in a way that they are potentially upstreamable, meaning:
 - they must contain a proper subject
 - they must contain a proper commit message explaining what they change
 - they must contain a valid Signed-off-by line
+
+Hi there!

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2011 OpenWrt.org
+# Copyright (C) 2006-2029 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.


### PR DESCRIPTION
Debian 10 LTS support ends on 6/2024, so it makes no sense to use it as a base for 23.05 release, so lets switch to Debian 11 which should've LTS support till 6/2026.

References: https://github.com/openwrt/buildbot/commit/f2744543fa8027117b254ba2f4fa4366149d5bfb