### PR TITLE
mediatek: Add support for Cudy WR3000

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000.dts
@@ -1,0 +1,217 @@
+/dts-v1/;
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "CUDY WR3000";
+	compatible = "cudy,wr3000", "mediatek,mt7981";
+
+	aliases {
+		ethernet0 = &gmac0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: led@0 {
+			label = "blue:power";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led@1 {
+			label = "blue:internet";
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+		
+		led@2 {
+			label = "blue:wifi";
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led@3 {
+			label = "blue:wifi5";
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+		
+		led@4 {
+			label = "blue:wan";
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+		};
+		
+		led@5 {
+			label = "blue:lan";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cells = <&macaddr_de00>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+};
+
+&mdio {
+	switch: switch@0 {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&spi2 {
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+		partition@00000 {
+			label = "BL2";
+			reg = <0x000000 0x040000>;
+			read-only;
+		};
+		partition@40000 {
+			label = "u-boot-env";
+			reg = <0x040000 0x010000>;
+		};
+		factory: partition@50000 {
+			label = "Factory";
+			reg = <0x050000 0x010000>;
+			read-only;
+
+		};
+		partition@60000 {
+			label = "bdinfo";
+			reg = <0x060000 0x010000>;
+			read-only;
+			
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_de00: macaddr@de00 {
+				reg = <0xDE00 0x6>;
+			};
+		};
+		partition@70000 {
+			label = "FIP";
+			reg = <0x070000 0x080000>;
+			read-only;
+		};
+		partition@f0000 {
+			compatible = "denx,fit";
+			label = "firmware";
+			reg = <0x0f0000 0xF10000>;
+			};
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@1 {
+			reg = <0>;
+			label = "wan";
+			nvmem-cells = <&macaddr_de00>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <(1)>;
+		};
+
+		port@2 {
+			reg = <1>;
+			label = "lan1";
+		};
+
+		port@3 {
+			reg = <2>;
+			label = "lan2";
+		};
+
+		port@4 {
+			reg = <3>;
+			label = "lan3";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -6,6 +6,9 @@ board=$(board_name)
 board_config_update
 
 case $board in
+cudy,wr3000)
+	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
+	;;
 xiaomi,redmi-router-ax6000-stock|\
 xiaomi,redmi-router-ax6000-ubootmod)
 	ucidef_set_led_netdev "wan" "wan" "rgb:network" "wan"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -14,6 +14,9 @@ mediatek_setup_interfaces()
 	bananapi,bpi-r3)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp2" "eth1 wan"
 		;;
+	cudy,wr3000)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
+		;;
 	mediatek,mt7986a-rfb)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan6" "eth1 wan"
 		;;
@@ -53,6 +56,10 @@ mediatek_setup_macs()
 		;;
 	bananapi,bpi-r3)
 		wan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)
+		;;
+	cudy,wr3000)
+		lan_mac=$(mtd_get_mac_binary "bdinfo" 0xde00)
+		label_mac="$lan_mac"
 		;;
 	xiaomi,redmi-router-ax6000-stock|\
 	xiaomi,redmi-router-ax6000-ubootmod)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -24,6 +24,10 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_unsetbit $addr 6 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_setbit $addr 6 > /sys${DEVPATH}/macaddress
 		;;
+	cudy,wr3000)
+		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label) > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $(get_mac_label) 65536 > /sys${DEVPATH}/macaddress
+		;;
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088)

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -67,6 +67,9 @@ platform_do_upgrade() {
 			;;
 		esac
 		;;
+	cudy,wr3000)
+		default_do_upgrade "$1"
+		;;
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -100,6 +100,18 @@ define Device/bananapi_bpi-r3
 endef
 TARGET_DEVICES += bananapi_bpi-r3
 
+define Device/cudy_wr3000
+  DEVICE_VENDOR := CUDY
+  DEVICE_MODEL := WR3000
+  BOARD_NAME := R31
+  SUPPORTED_DEVICES += R31
+  DEVICE_DTS := mt7981b-cudy-wr3000
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7981-firmware
+  IMAGE_SIZE := 15424k
+endef
+TARGET_DEVICES += cudy_wr3000
+
 define Device/mediatek_mt7986a-rfb-nand
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7986 rfba AP (NAND)


### PR DESCRIPTION
MT7981B /256MB /16MB SPI (XM25QH128C)
2x2 AX 2.4Ghz
2x2 AX 5Ghz 160Mhz wide
1Gbit WAN
3x 1Gbit LAN
OEM:
LAN F4:XX:XX:8E:XX:94 (label)
WAN F4:XX:XX:8E:XX:95
5Ghz F6:XX:XX:BE:XX:94
2.4Ghz F4:XX:XX:8E:XX:94

OpenWrt
LAN1-3 F4:XX:XX:8E:XX:94 (label)
WAN F4:XX:XX:8E:XX:95
5Ghz F4:XX:XX:8F:XX:94
2.4Ghz F4:XX:XX:8E:XX:94

Installation via u-boot:
* Connect TTL converter ( bottom of the board in the middle "□○○○") Pinout: 1: TX, 2: RX, 3: GND, 4: VCC, with pin 1 Actual connector is on top side under radiator
* Set speed 115200 8 N 1
* Interrupt boot process by holding  down-arrow key during boot

```
  *** U-Boot Boot Menu ***

      1. Startup system (Default)
      2. Upgrade firmware
      3. Upgrade ATF BL2
      4. Upgrade ATF FIP
      5. Upgrade single image
 ->>> 6. Load image
      0. U-Boot console
```

* Boot the OpenWrt openwrt-mediatek-filogic-cudy_wr3000-initramfs-kernel.bin
* use GUI or sysupgrade to install openwrt-mediatek-filogic-cudy_wr3000-squashfs-sysupgrade.bin

Reverse to OEM firmware
* cut file till 2nd "D00DFEED" using dd dd if=/tmp/WR3000-R31-1.15.5-20230222-084907-sysupgrade.bin of=/tmp/oem.bin bs=512 skip=1028
* flash it back to firmware partition mtd -r write /tmp/oem.bin firmware

Tested And
Signed-off-by: Robert Senderek <robert.senderek@10g.pl>
