### PR TITLE
prereq-build: allow symlinks to update

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -175,8 +175,6 @@ $(eval $(call SetupHostCommand,install,Please install GNU 'install', \
 $(eval $(call SetupHostCommand,perl,Please install Perl 5.x, \
 	perl --version | grep "perl.*v5"))
 
-$(eval $(call CleanupPython2))
-
 $(eval $(call SetupHostCommand,python,Please install Python >= 3.6, \
 	python3.11 -V 2>&1 | grep 'Python 3', \
 	python3.10 -V 2>&1 | grep 'Python 3', \

--- a/include/prereq.mk
+++ b/include/prereq.mk
@@ -77,18 +77,6 @@ define RequireCHeader
   $$(eval $$(call Require,$(1),$(2)))
 endef
 
-define CleanupPython2
-  define Require/python2-cleanup
-	if [ -f "$(STAGING_DIR_HOST)/bin/python" ] && \
-		$(STAGING_DIR_HOST)/bin/python -V 2>&1 | \
-		grep -q 'Python 2'; then \
-			rm $(STAGING_DIR_HOST)/bin/python; \
-	fi
-  endef
-
-  $$(eval $$(call Require,python2-cleanup))
-endef
-
 define QuoteHostCommand
 '$(subst ','"'"',$(strip $(1)))'
 endef

--- a/include/prereq.mk
+++ b/include/prereq.mk
@@ -30,6 +30,8 @@ define Require
 		printf "Checking '$(1)'... "
 		if $(NO_TRACE_MAKE) -f $(firstword $(MAKEFILE_LIST)) check-$(1) >/dev/null 2>/dev/null; then \
 			echo 'ok.'; \
+		elif $(NO_TRACE_MAKE) -f $(firstword $(MAKEFILE_LIST)) check-$(1) >/dev/null 2>/dev/null; then \
+			echo 'updated.'; \
 		else \
 			echo 'failed.'; \
 			echo "$(PKG_NAME): $(strip $(2))" >> $(TMP_DIR)/.prereq-error; \
@@ -107,7 +109,7 @@ endef
 # 3+: candidates
 define SetupHostCommand
   define Require/$(1)
-	[ -f "$(STAGING_DIR_HOST)/bin/$(strip $(1))" ] && exit 0; \
+	mkdir -p "$(STAGING_DIR_HOST)/bin"; \
 	for cmd in $(call QuoteHostCommand,$(3)) $(call QuoteHostCommand,$(4)) \
 	           $(call QuoteHostCommand,$(5)) $(call QuoteHostCommand,$(6)) \
 	           $(call QuoteHostCommand,$(7)) $(call QuoteHostCommand,$(8)) \
@@ -117,9 +119,13 @@ define SetupHostCommand
 			bin="$$$$$$$$(PATH="$(subst $(space),:,$(filter-out $(STAGING_DIR_HOST)/%,$(subst :,$(space),$(PATH))))" \
 				command -v "$$$$$$$${cmd%% *}")"; \
 			if [ -x "$$$$$$$$bin" ] && eval "$$$$$$$$cmd" >/dev/null 2>/dev/null; then \
-				mkdir -p "$(STAGING_DIR_HOST)/bin"; \
+				case "$$$$$$$$(ls -dl -- $(STAGING_DIR_HOST)/bin/$(strip $(1)))" in \
+					*" -> $$$$$$$$bin"*) \
+						[ -x "$(STAGING_DIR_HOST)/bin/$(strip $(1))" ] && exit 0 \
+						;; \
+				esac; \
 				ln -sf "$$$$$$$$bin" "$(STAGING_DIR_HOST)/bin/$(strip $(1))"; \
-				exit 0; \
+				exit 1; \
 			fi; \
 		fi; \
 	done; \


### PR DESCRIPTION
Fixes #12610 

to test:
replace a symlink in staging_dir/host/bin with a bad path
`rm -f staging_dir/host/.prereq-build`
`make prereq`
new symlink!