### PR TITLE
kernel: add MODULE_ALLOW_BTF_MISMATCH option

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -373,6 +373,16 @@ config KERNEL_DEBUG_INFO_BTF
 
 	  Required to run BPF CO-RE applications.
 
+config KERNEL_MODULE_ALLOW_BTF_MISMATCH
+	bool "Allow loading modules with non-matching BTF type info"
+	depends on KERNEL_DEBUG_INFO_BTF
+	help
+	  For modules whose split BTF does not match vmlinux, load without
+	  BTF rather than refusing to load. The default behavior with
+	  module BTF enabled is to reject modules with such mismatches;
+	  this option will still load module BTF where possible but ignore
+	  it when a mismatch is found.
+
 config KERNEL_DEBUG_INFO_REDUCED
 	bool "Reduce debugging information"
 	default y


### PR DESCRIPTION
BTF mismatch can occur for a separately-built module even when the ABI
is otherwise compatible and nothing else would prevent successfully
loading. Add a new config to control how mismatches are handled. By
default, preserve the current behavior of refusing to load the
module. If MODULE_ALLOW_BTF_MISMATCH is enabled, load the module but
ignore its BTF information.