### PR TITLE
f2fs-tools: fix compilation with musl 1.2.4

### DIFF
--- a/package/utils/f2fs-tools/Makefile
+++ b/package/utils/f2fs-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=f2fs-tools
 PKG_VERSION:=1.15.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/snapshot/
@@ -110,6 +110,10 @@ endif
 
 CONFIGURE_VARS += \
 	ac_cv_file__git=no
+
+ifneq ($(CONFIG_USE_MUSL),)
+  CONFIGURE_VARS += ac_cv_func_lseek64=yes
+endif
 
 define Package/libf2fs/install
 	$(INSTALL_DIR) $(1)/usr/lib


### PR DESCRIPTION
musl 1.2.4 deprecated legacy "LFS64" ("large file support") interfaces and
autotools failed to check the lseek64 function.

Force enable ac_cv_func_lseek64 to workaround it.