### PR TITLE
mdadm: fix compilation with musl 1.2.4

### DIFF
--- a/package/utils/mdadm/Makefile
+++ b/package/utils/mdadm/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mdadm
 PKG_VERSION:=4.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/raid/mdadm
@@ -49,7 +49,8 @@ TARGET_CFLAGS += \
 	-DMAP_DIR='\"/var/run/mdadm\"' \
 	-DMDMON_DIR='\"/var/run/mdadm\"' \
 	-DFAILED_SLOTS_DIR='\"/var/run/mdadm/failed-slots\"' \
-	-DNO_LIBUDEV
+	-DNO_LIBUDEV \
+	-D_LARGEFILE64_SOURCE
 
 TARGET_CXFLAGS = -DNO_LIBUDEV
 


### PR DESCRIPTION
_LARGEFILE64_SOURCE has to be defined in the source, or CFLAGS can be used to pass -D_LARGEFILE64_SOURCE to allow to keep using LFS64 definitions.

Fixes error in the form of:
```
restripe.c: In function 'restore_stripes':
restripe.c:758:43: error: 'off64_t' undeclared (first use in this function); did you mean 'off_t'?
  758 |                                          (off64_t)read_offset) {
      |                                           ^~~~~~~
      |                                           off_t
restripe.c:758:43: note: each undeclared identifier is reported only once for each function it appears in
restripe.c:758:51: error: expected ')' before 'read_offset'
  758 |                                          (off64_t)read_offset) {
      |                                                   ^~~~~~~~~~~
      |                                                   )
restripe.c:757:36: note: to match this '('
  757 |                                 if (lseek64(source, read_offset, 0) !=
      |                                    ^
make[3]: *** [Makefile:193: restripe.o] Error 1
```

Fixes: fff878c5bcda ("toolchain/musl: update to 1.2.4")
