### PR TITLE
kernel: remove obsolete kernel version switches

### DIFF
--- a/target/linux/ath25/files/drivers/net/phy/mvswitch.c
+++ b/target/linux/ath25/files/drivers/net/phy/mvswitch.c
@@ -312,11 +312,7 @@ mvswitch_config_init(struct phy_device *pdev)
 	priv->orig_features = dev->features;
 
 #ifdef HEADER_MODE
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0)
 	dev->extra_priv_flags |= IFF_NO_IP_ALIGN;
-#else
-	dev->priv_flags |= IFF_NO_IP_ALIGN;
-#endif
 	dev->features |= NETIF_F_HW_VLAN_CTAG_RX | NETIF_F_HW_VLAN_CTAG_TX;
 #else
 	dev->features |= NETIF_F_HW_VLAN_CTAG_RX;
@@ -376,11 +372,7 @@ mvswitch_detach(struct phy_device *pdev)
 	dev->eth_mangle_rx = NULL;
 	dev->eth_mangle_tx = NULL;
 	dev->features = priv->orig_features;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0)
 	dev->extra_priv_flags &= ~IFF_NO_IP_ALIGN;
-#else
-	dev->priv_flags &= ~IFF_NO_IP_ALIGN;
-#endif
 }
 
 static void

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -1352,11 +1352,7 @@ static int ag71xx_rx_packets(struct ag71xx *ag, int limit)
 		dev->stats.rx_packets++;
 		dev->stats.rx_bytes += pktlen;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
-		skb = build_skb(ring->buf[i].rx_buf, ag71xx_buffer_size(ag));
-#else
 		skb = napi_build_skb(ring->buf[i].rx_buf, ag71xx_buffer_size(ag));
-#endif
 		if (!skb) {
 			skb_free_frag(ring->buf[i].rx_buf);
 			goto next;

--- a/target/linux/generic/files/block/partitions/fit.c
+++ b/target/linux/generic/files/block/partitions/fit.c
@@ -73,11 +73,7 @@
 
 int parse_fit_partitions(struct parsed_partitions *state, u64 fit_start_sector, u64 sectors, int *slot, int add_remain)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
 	struct block_device *bdev = state->disk->part0;
-#else
-	struct block_device *bdev = state->bdev;
-#endif
 	struct address_space *mapping = bdev->bd_inode->i_mapping;
 	struct page *page;
 	void *fit, *init_fit;

--- a/target/linux/generic/files/drivers/net/phy/ar8216.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8216.c
@@ -891,11 +891,7 @@ ar8216_phy_write(struct ar8xxx_priv *priv, int addr, int regnum, u16 val)
 static int
 ar8229_hw_init(struct ar8xxx_priv *priv)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0)
 	phy_interface_t phy_if_mode;
-#else
-	int phy_if_mode;
-#endif
 
 	if (priv->initialized)
 		return 0;
@@ -903,11 +899,7 @@ ar8229_hw_init(struct ar8xxx_priv *priv)
 	ar8xxx_write(priv, AR8216_REG_CTRL, AR8216_CTRL_RESET);
 	ar8xxx_reg_wait(priv, AR8216_REG_CTRL, AR8216_CTRL_RESET, 0, 1000);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0)
 	of_get_phy_mode(priv->pdev->of_node, &phy_if_mode);
-#else
-	phy_if_mode = of_get_phy_mode(priv->pdev->of_node);
-#endif
 
 	if (phy_if_mode == PHY_INTERFACE_MODE_GMII) {
 		ar8xxx_write(priv, AR8229_REG_OPER_MODE0,
@@ -2467,11 +2459,7 @@ ar8xxx_phy_config_init(struct phy_device *phydev)
 	/* VID fixup only needed on ar8216 */
 	if (chip_is_ar8216(priv)) {
 		dev->phy_ptr = priv;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0)
 		dev->extra_priv_flags |= IFF_NO_IP_ALIGN;
-#else
-		dev->priv_flags |= IFF_NO_IP_ALIGN;
-#endif
 		dev->eth_mangle_rx = ar8216_mangle_rx;
 		dev->eth_mangle_tx = ar8216_mangle_tx;
 	}
@@ -2706,11 +2694,7 @@ ar8xxx_phy_detach(struct phy_device *phydev)
 
 #ifdef CONFIG_ETHERNET_PACKET_MANGLE
 	dev->phy_ptr = NULL;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0)
 	dev->extra_priv_flags &= ~IFF_NO_IP_ALIGN;
-#else
-	dev->priv_flags &= ~IFF_NO_IP_ALIGN;
-#endif
 	dev->eth_mangle_rx = NULL;
 	dev->eth_mangle_tx = NULL;
 #endif

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_common.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_common.c
@@ -506,15 +506,9 @@ static int b53_configure_ports_of(struct b53_device *dev)
 		if (fixed_link) {
 			u32 spd;
 			u8 po = GMII_PO_LINK;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0)
 			phy_interface_t mode;
-#else
-			int mode = of_get_phy_mode(pn);
-#endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 5, 0)
 			of_get_phy_mode(pn, &mode);
-#endif
 
 			if (!of_property_read_u32(fixed_link, "speed", &spd)) {
 				switch (spd) {

--- a/target/linux/ipq40xx/files/drivers/net/dsa/qca/qca8k-ipq4019.c
+++ b/target/linux/ipq40xx/files/drivers/net/dsa/qca/qca8k-ipq4019.c
@@ -1435,22 +1435,11 @@ qca8k_port_fdb_dump(struct dsa_switch *ds, int port,
 	return 0;
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
-static int
-qca8k_port_vlan_filtering(struct dsa_switch *ds, int port, bool vlan_filtering,
-			  struct switchdev_trans *trans)
-#else
 static int
 qca8k_port_vlan_filtering(struct dsa_switch *ds, int port, bool vlan_filtering,
                           struct netlink_ext_ack *extack)
-#endif
 {
 	struct qca8k_priv *priv = ds->priv;
-
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
-	if (switchdev_trans_ph_prepare(trans))
-		return 0;
-#endif
 
 	if (vlan_filtering) {
 		qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(port),
@@ -1465,70 +1454,32 @@ qca8k_port_vlan_filtering(struct dsa_switch *ds, int port, bool vlan_filtering,
 	return 0;
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
-static int
-qca8k_port_vlan_prepare(struct dsa_switch *ds, int port,
-			const struct switchdev_obj_port_vlan *vlan)
-{
-	return 0;
-}
-#endif
-
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
-static void
-qca8k_port_vlan_add(struct dsa_switch *ds, int port,
-		    const struct switchdev_obj_port_vlan *vlan)
-#else
 static int
 qca8k_port_vlan_add(struct dsa_switch *ds, int port,
 		    const struct switchdev_obj_port_vlan *vlan,
 		    struct netlink_ext_ack *extack)
-#endif
 {
 	bool untagged = vlan->flags & BRIDGE_VLAN_INFO_UNTAGGED;
 	bool pvid = vlan->flags & BRIDGE_VLAN_INFO_PVID;
 	struct qca8k_priv *priv = ds->priv;
 	int ret = 0;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
-	u16 vid;
 
-	for (vid = vlan->vid_begin; vid <= vlan->vid_end && !ret; ++vid)
-		ret = qca8k_vlan_add(priv, port, vid, untagged);
-#else
 	ret = qca8k_vlan_add(priv, port, vlan->vid, untagged);
-#endif
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
-	if (ret)
-		dev_err(priv->dev, "Failed to add VLAN to port %d (%d)", port, ret);
-#else
 	if (ret) {
 		dev_err(priv->dev, "Failed to add VLAN to port %d (%d)", port, ret);
 		return ret;
 	}
-#endif
 
 	if (pvid) {
 		int shift = 16 * (port % 2);
 
 		qca8k_rmw(priv, QCA8K_EGRESS_VLAN(port),
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
-			  0xfff << shift,
-			  vlan->vid_end << shift);
-#else
 			  0xfff << shift, vlan->vid << shift);
-#endif
 		qca8k_write(priv, QCA8K_REG_PORT_VLAN_CTRL0(port),
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
-			    QCA8K_PORT_VLAN_CVID(vlan->vid_end) |
-			    QCA8K_PORT_VLAN_SVID(vlan->vid_end));
-#else
 			    QCA8K_PORT_VLAN_CVID(vlan->vid) |
 			    QCA8K_PORT_VLAN_SVID(vlan->vid));
-#endif
 	}
-#if LINUX_VERSION_CODE > KERNEL_VERSION(5,12,0)
 	return 0;
-#endif
 }
 
 static int
@@ -1537,14 +1488,8 @@ qca8k_port_vlan_del(struct dsa_switch *ds, int port,
 {
 	struct qca8k_priv *priv = ds->priv;
 	int ret = 0;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
-	u16 vid;
 
-	for (vid = vlan->vid_begin; vid <= vlan->vid_end && !ret; ++vid)
-		ret = qca8k_vlan_del(priv, port, vid);
-#else
 	ret = qca8k_vlan_del(priv, port, vlan->vid);
-#endif
 	if (ret)
 		dev_err(priv->dev, "Failed to delete VLAN from port %d (%d)", port, ret);
 
@@ -1577,9 +1522,6 @@ static const struct dsa_switch_ops qca8k_switch_ops = {
 	.port_fdb_del		= qca8k_port_fdb_del,
 	.port_fdb_dump		= qca8k_port_fdb_dump,
 	.port_vlan_filtering	= qca8k_port_vlan_filtering,
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
-	.port_vlan_prepare	= qca8k_port_vlan_prepare,
-#endif
 	.port_vlan_add		= qca8k_port_vlan_add,
 	.port_vlan_del		= qca8k_port_vlan_del,
 	.phylink_validate	= qca8k_phylink_validate,

--- a/target/linux/ipq40xx/files/drivers/net/phy/qca807x.c
+++ b/target/linux/ipq40xx/files/drivers/net/phy/qca807x.c
@@ -576,16 +576,6 @@ static int qca807x_config_intr(struct phy_device *phydev)
 	return ret;
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
-static int qca807x_ack_intr(struct phy_device *phydev)
-{
-	int ret;
-
-	ret = phy_read(phydev, QCA807X_INTR_STATUS);
-
-	return (ret < 0) ? ret : 0;
-}
-#else
 static irqreturn_t qca807x_handle_interrupt(struct phy_device *phydev)
 {
 	int irq_status, int_enabled;
@@ -611,7 +601,6 @@ static irqreturn_t qca807x_handle_interrupt(struct phy_device *phydev)
 
 	return IRQ_HANDLED;
 }
-#endif
 
 static int qca807x_led_config(struct phy_device *phydev)
 {
@@ -802,11 +791,7 @@ static struct phy_driver qca807x_drivers[] = {
 		.config_init	= qca807x_config,
 		.read_status	= qca807x_read_status,
 		.config_intr	= qca807x_config_intr,
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
-		.ack_interrupt	= qca807x_ack_intr,
-#else
 		.handle_interrupt = qca807x_handle_interrupt,
-#endif
 		.soft_reset	= genphy_soft_reset,
 		.get_tunable	= qca807x_get_tunable,
 		.set_tunable	= qca807x_set_tunable,
@@ -824,11 +809,7 @@ static struct phy_driver qca807x_drivers[] = {
 		.config_init	= qca807x_config,
 		.read_status	= qca807x_read_status,
 		.config_intr	= qca807x_config_intr,
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,12,0)
-		.ack_interrupt	= qca807x_ack_intr,
-#else
 		.handle_interrupt = qca807x_handle_interrupt,
-#endif
 		.soft_reset	= genphy_soft_reset,
 		.get_tunable	= qca807x_get_tunable,
 		.set_tunable	= qca807x_set_tunable,

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mdio.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mdio.c
@@ -64,11 +64,7 @@ int fe_connect_phy_node(struct fe_priv *priv, struct device_node *phy_node, int 
 {
 	const __be32 *_phy_addr = NULL;
 	struct phy_device *phydev;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
-	int phy_mode;
-#else
 	phy_interface_t phy_mode = PHY_INTERFACE_MODE_NA;
-#endif
 
 	_phy_addr = of_get_property(phy_node, "reg", NULL);
 
@@ -77,13 +73,8 @@ int fe_connect_phy_node(struct fe_priv *priv, struct device_node *phy_node, int 
 		return -EINVAL;
 	}
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
-	phy_mode = of_get_phy_mode(phy_node);
-	if (phy_mode < 0) {
-#else
 	of_get_phy_mode(phy_node, &phy_mode);
 	if (phy_mode == PHY_INTERFACE_MODE_NA) {
-#endif
 		dev_err(priv->dev, "incorrect phy-mode %d\n", phy_mode);
 		priv->phy->phy_node[port] = NULL;
 		return -EINVAL;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mdio_rt2880.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mdio_rt2880.c
@@ -156,11 +156,7 @@ void rt2880_port_init(struct fe_priv *priv, struct device_node *np)
 	const __be32 *id = of_get_property(np, "reg", NULL);
 	const __be32 *link;
 	int size;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
-	int phy_mode;
-#else
 	phy_interface_t phy_mode = PHY_INTERFACE_MODE_NA;
-#endif
 
 	if (!id || (be32_to_cpu(*id) != 0)) {
 		pr_err("%s: invalid port id\n", np->name);
@@ -176,11 +172,7 @@ void rt2880_port_init(struct fe_priv *priv, struct device_node *np)
 		return;
 	}
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
-	phy_mode = of_get_phy_mode(np);
-#else
 	of_get_phy_mode(np, &phy_mode);
-#endif
 	switch (phy_mode) {
 	case PHY_INTERFACE_MODE_RGMII:
 		break;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -1096,11 +1096,7 @@ poll_again:
 	return rx_done;
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
-static void fe_tx_timeout(struct net_device *dev)
-#else
 static void fe_tx_timeout(struct net_device *dev, unsigned int txqueue)
-#endif
 {
 	struct fe_priv *priv = netdev_priv(dev);
 	struct fe_tx_ring *ring = &priv->tx_ring;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_mt7620.c
@@ -144,11 +144,7 @@ static void mt7620_port_init(struct fe_priv *priv, struct device_node *np)
 	struct mt7620_gsw *gsw = (struct mt7620_gsw *)priv->soc->swpriv;
 	const __be32 *_id = of_get_property(np, "reg", NULL);
 	const __be32 *phy_addr;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
-	int phy_mode;
-#else
 	phy_interface_t phy_mode = PHY_INTERFACE_MODE_NA;
-#endif
 	int size, id;
 	int shift = 12;
 	u32 val, mask = 0;
@@ -178,11 +174,7 @@ static void mt7620_port_init(struct fe_priv *priv, struct device_node *np)
 		priv->phy->phy_fixed[id] = NULL;
 	}
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)
-	phy_mode = of_get_phy_mode(np);
-#else
 	of_get_phy_mode(np, &phy_mode);
-#endif
 	switch (phy_mode) {
 	case PHY_INTERFACE_MODE_RGMII:
 		mask = 0;

--- a/target/linux/ramips/files/drivers/pinctrl/pinctrl-aw9523.c
+++ b/target/linux/ramips/files/drivers/pinctrl/pinctrl-aw9523.c
@@ -386,11 +386,6 @@ static const struct pinconf_ops aw9523_pinconf_ops = {
 	.is_generic = true,
 };
 
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 5, 0)
-#define GPIO_LINE_DIRECTION_IN	1
-#define GPIO_LINE_DIRECTION_OUT	0
-#endif
-
 /*
  * aw9523_get_pin_direction - Get pin direction
  * @regmap: Regmap structure
@@ -436,11 +431,6 @@ static int aw9523_get_port_state(struct regmap *regmap, u8 pin,
 
 	return regmap_read(regmap, reg, state);
 }
-
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(5, 5, 0)
-#undef GPIO_LINE_DIRECTION_IN
-#undef GPIO_LINE_DIRECTION_OUT
-#endif
 
 static int aw9523_gpio_irq_type(struct irq_data *d, unsigned int type)
 {


### PR DESCRIPTION
This removes unneeded kernel version switches from the targets after kernel 5.10 has been dropped.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>