### PR TITLE
ipq807x: workaround sysupgrade failing due to ath11k

### DIFF
--- a/target/linux/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq807x/base-files/lib/upgrade/platform.sh
@@ -28,6 +28,13 @@ xiaomi_initramfs_prepare() {
 }
 
 platform_check_image() {
+	# ath11k has a TX queue flush issue, so until that is resolved
+	# lets workaround the issue by calling wpad stop before sysupgrade
+	# attempts to first SIGTERM and then SIGKILL hostapd which will fail
+	# as ath11k TX flush has not yet timed out.
+	# This in turn would cause sysupgrade to fail and leave old version on
+	# the boards.
+	service wpad stop
 	return 0;
 }
 


### PR DESCRIPTION
Currently, ipq807x has an issue with sysupgrade sometimes failing on SIGTERM and then SIGKILL on hostapd.
Luckily it is happening before sysupgrade actually does anything so users are just left with the old code and sysupgrading for the second time or stopping wpad before would work.

However, its not hostapd-s fault but its a bug in TX queue flush in ath11k that will sometimes fail flushing the packets, and then hostapd could not terminate as ath11k has a quite long timeout for the flush, much longer than the loop for SIGTERM and SIGKILL in sysupgrade.

So, until this bug is finally sorted out in ath11k lets workaround the issue by stopping wpad (and thus hostapd) before sysupgrade tries to do so and just wait until it terminates itself before upgrading. Easiest place to do so is in platform_check_image(), especially since its target specific.
Only downside is that sysupgrade may take longer, but we are talking seconds here.
