### PR TITLE
ci: fix check kernel patches job

### DIFF
--- a/.github/workflows/check-kernel-patches.yml
+++ b/.github/workflows/check-kernel-patches.yml
@@ -85,6 +85,10 @@ jobs:
         run: |
           chown -R buildbot:buildbot openwrt
 
+      - name: Opt-out from Git stricter repository ownership checks
+        run: |
+          git config --global --add safe.directory '*'
+
       - name: Initialization environment
         run: |
           TARGET=$(echo ${{ inputs.target }} | cut -d "/" -f 1)

--- a/target/linux/ath79/patches-5.15/0003-leds-add-reset-controller-based-driver.patch
+++ b/target/linux/ath79/patches-5.15/0003-leds-add-reset-controller-based-driver.patch
@@ -3,6 +3,8 @@ From: John Crispin <john@phrozen.org>
 Date: Tue, 6 Mar 2018 10:03:03 +0100
 Subject: [PATCH 03/27] leds: add reset-controller based driver
 
+Hello there! :-)
+
 Signed-off-by: John Crispin <john@phrozen.org>
 ---
  drivers/leds/Kconfig      |  11 ++++


### PR DESCRIPTION
Currently the check fails due [to the following error](https://github.com/openwrt/openwrt/actions/runs/5006262947/jobs/8972363594?pr=12638#step:11:20):

```shell
 warning: Not a git repository. Use --no-index to compare two paths outside a working tree
 usage: git diff --no-index [<options>] <path> <path>
```

Thats likely caused by commit 1cb8cdbf0723 ("ci: use new buildbot worker images with Debian 11") which contains a patched Git version with CVE security fixes introduced in DLA-3239-2:

  Multiple issues were found in Git, a distributed revision control
  system. An attacker may cause other local users into executing arbitrary
  commands, leak information from the local filesystem, and bypass
  restricted shell.

  Note: Due to new security checks, access to repositories owned and
  accessed by different local users may now be rejected by Git; in case
  changing ownership is not practical, git displays a way to bypass these
  checks using the new "safe.directory" configuration entry.

So lets opt-out of this new behavior by setting `safe.directory=*` and thus force Git to consider all Git repositories as safe regardless of their owner, since we need to trust those sources anyway and it should be likely more robust solution, then fiddling with filesystem permissions.

Fixes: 1cb8cdbf0723 ("ci: use new buildbot worker images with Debian 11")
References: https://www.debian.org/lts/security/2022/dla-3239-2