### PR TITLE
airoha: spi-en7523: comment out unused function

### DIFF
--- a/target/linux/airoha/patches-5.15/0005-spi-Add-support-for-the-Airoha-EN7523-SoC-SPI-contro.patch
+++ b/target/linux/airoha/patches-5.15/0005-spi-Add-support-for-the-Airoha-EN7523-SoC-SPI-contro.patch
@@ -166,7 +166,7 @@
 +	}
 +}
 +
-+static void set_spi_clock_speed(int freq_mhz)
++/*static void set_spi_clock_speed(int freq_mhz)
 +{
 +	u32 tmp, val;
 +
@@ -177,7 +177,7 @@
 +	val = (400 / (freq_mhz * 2));
 +	tmp |= (val << 8) | 1;
 +	writel(tmp, ENSPI_CLOCK_DIVIDER);
-+}
++}*/
 +
 +static void init_hw(void)
 +{


### PR DESCRIPTION
Comment out the unused SPI function so that target compiles with WERROR.
