### PR TITLE
ipq40xx: fix rebooting after 5.15.111

### DIFF
--- a/target/linux/ipq40xx/patches-5.15/910-Revert-firmware-qcom_scm-Clear-download-bit-during-r.patch
+++ b/target/linux/ipq40xx/patches-5.15/910-Revert-firmware-qcom_scm-Clear-download-bit-during-r.patch
@@ -1,0 +1,27 @@
+From c87df89a82c17411cd6b98e5afaa1203ee9508dc Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Thu, 18 May 2023 12:16:02 +0200
+Subject: [PATCH] Revert "firmware: qcom_scm: Clear download bit during reboot"
+
+This reverts commit a3ea89b5978dbcd0fa55f675c5a1e04611093709.
+
+It is breaking reboot on IPQ4019 boards, so revert until a proper fix
+is found.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+---
+ drivers/firmware/qcom_scm.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/drivers/firmware/qcom_scm.c
++++ b/drivers/firmware/qcom_scm.c
+@@ -1352,7 +1352,8 @@ static int qcom_scm_probe(struct platfor
+ static void qcom_scm_shutdown(struct platform_device *pdev)
+ {
+ 	/* Clean shutdown, disable download mode to allow normal restart */
+-	qcom_scm_set_download_mode(false);
++	if (download_mode)
++		qcom_scm_set_download_mode(false);
+ }
+ 
+ static const struct of_device_id qcom_scm_dt_match[] = {


### PR DESCRIPTION
Kernel 5.15.111 includes backport of commit
("firmware: qcom_scm: Clear download bit during reboot") which is causing reboot on ipq40xx to stop working, more precisely the board will hang after reboot is called with:
```
root@OpenWrt:/# reboot
root@OpenWrt:/# [   76.473541] device lan1 left promiscuous mode
[   76.474204] br-lan: port 1(lan1) entered disabled state
[   76.527975] device lan2 left promiscuous mode
[   76.530301] br-lan: port 2(lan2) entered disabled state
[   76.579376] device lan3 left promiscuous mode
[   76.581698] br-lan: port 3(lan3) entered disabled state
[   76.638434] device lan4 left promiscuous mode
[   76.638777] br-lan: port 4(lan4) entered disabled state
[   76.978489] qca8k-ipq4019 c000000.switch wan: Link is Down
[   76.978883] device eth0 left promiscuous mode
[   76.987077] ipqess-edma c080000.ethernet eth0: Link is Down
[
Format: Log Type - Time(microsec) - Message - Optional Info
Log Type: B - Since Boot(Power On Reset),  D - Delta,  S - Statistic
S - QC_IMAGE_VERSION_STRING=BOOT.BF.3.1.1-00123
S - IMAGE_VARIANT_STRING=DAABANAZA
S - OEM_IMAGE_VERSION_STRING=CRM
S - Boot Config, 0x00000021
S - Reset status Config, 0x00000010
S - Core 0 Frequency, 0 MHz
B -       261 - PBL, Start
B -      1339 - bootable_media_detect_entry, Start
B -      1679 - bootable_media_detect_success, Start
B -      1693 - elf_loader_entry, Start
B -      5076 - auth_hash_seg_entry, Start
B -      7223 - auth_hash_seg_exit, Start
B -    578349 - elf_segs_hash_verify_entry, Start
B -    696356 - PBL, End
B -    696380 - SBL1, Start
B -    787236 - pm_device_init, Start
D -         7 - pm_device_init, Delta
B -    788701 - boot_flash_init, Start
D -     52782 - boot_flash_init, Delta
B -    845625 - boot_config_data_table_init, Start
D -      3836 - boot_config_data_table_init, Delta - (419 Bytes)
B -    852841 - clock_init, Start
D -      7566 - clock_init, Delta
B -    864883 - CDT version:2,Platform ID:9,Major ID:0,Minor ID:0,Subtype:64
B -    868413 - sbl1_ddr_set_params, Start
B -    873402 - cpr_init, Start
D -         2 - cpr_init, Delta
B -    877842 - Pre_DDR_clock_init, Start
D -         4 - Pre_DDR_clock_init, Delta
D -     13234 - sbl1_ddr_set_params, Delta
B -    891155 - pm_driver_init, Start
D -         2 - pm_driver_init, Delta
B -    909105 - Image Load, Start
B -   1030210 - Boot error ocuured!. Error code: 303d
```

QCA-s fix is also to revert the culprit commit.

Fixes: 228e0e10398b ("kernel: bump 5.15 to 5.15.111")
Issue: #12646 
