### PR TITLE
Introduce `findrev` from `luci.mk`

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -13,7 +13,6 @@ include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
 PKG_FLAGS:=nonshared
-PKG_RELEASE:=$(COMMITCOUNT)
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/
 PKG_BUILD_DEPENDS:=usign/host ucert/host
@@ -42,7 +41,7 @@ define Package/base-files
   DEPENDS:=+netifd +libc +jsonfilter +SIGNED_PACKAGES:usign +SIGNED_PACKAGES:openwrt-keyring +NAND_SUPPORT:ubi-utils +fstools +fwtool
   TITLE:=Base filesystem for OpenWrt
   URL:=http://openwrt.org/
-  VERSION:=$(PKG_RELEASE)-$(REVISION)
+  VERSION:=$(call findrev,$(TOPDIR))
 endef
 
 define Package/base-files/conffiles

--- a/rules.mk
+++ b/rules.mk
@@ -435,6 +435,30 @@ $(shell \
 )
 endef
 
+define findrev
+  $(shell \
+    if git log -1 >/dev/null 2>/dev/null; then \
+      set -- $$(git log -1 --format="%ct %h" --abbrev=7 -- $(if $(1),$(1),.)); \
+      if [ -n "$$1" ]; then
+        secs="$$(($$1 % 86400))"; \
+        yday="$$(date --utc --date="@$$1" "+%y.%j")"; \
+        printf 'git-%s.%05d-%s' "$$yday" "$$secs" "$$2"; \
+      else \
+        echo "unknown"; \
+      fi; \
+    else \
+      ts=$$(find $(if $(1),$(1),.) -type f -printf '%T@\n' 2>/dev/null | sort -rn | head -n1 | cut -d. -f1); \
+      if [ -n "$$ts" ]; then \
+        secs="$$(($$ts % 86400))"; \
+        date="$$(date --utc --date="@$$ts" "+%y%m%d")"; \
+        printf '%s.%05d' "$$date" "$$secs"; \
+      else \
+        echo "unknown"; \
+      fi; \
+    fi \
+  )
+endef
+
 abi_version_str = $(subst -,,$(subst _,,$(subst .,,$(1))))
 
 COMMITCOUNT = $(if $(DUMP),0,$(call commitcount))


### PR DESCRIPTION
To avoid manual increasing of PKG_RELEASE for every change the
$(AUTORELEASE) and $(COMMITCOUNT) functions were previously added. While
those perfectly automated the previous release schema, they required a
full Git history to work. With ever increasing popularity of OpenWrt,
this brings server infrastructure to stall and wastes bandwidth.

An alternative is the automatic revision finding used in luci.git, where
the function `findrev` automatically generates a PKG_RELEASE based on
the last commit.

A modified `findrev` version is added to the rules.mk file to represent
custom needs. Most prominently the `base-files` package requires the
revision of openwrt.git and not of the package specific sub-folder.

The function `findrev` works also without using a Git repository by
falling back to the last file modification time.