### PR TITLE
libjson-c: import patch to fix compilation on macos

### DIFF
--- a/package/libs/libjson-c/Makefile
+++ b/package/libs/libjson-c/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=json-c
 PKG_VERSION:=0.16
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-nodoc.tar.gz
 PKG_SOURCE_URL:=https://s3.amazonaws.com/json-c_releases/releases/

--- a/package/libs/libjson-c/patches/010-fix-build-with-clang-15.patch
+++ b/package/libs/libjson-c/patches/010-fix-build-with-clang-15.patch
@@ -1,0 +1,184 @@
+From 6eca65617aacd19f4928acd5766b8dd20eda0b34 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 13 Aug 2022 20:37:03 -0700
+Subject: [PATCH] Fix build with clang-15+
+
+Fixes
+json_util.c:63:35: error: a function declaration without a prototype is deprecated in all versions of C [-We
+rror,-Wstrict-prototypes]
+const char *json_util_get_last_err()
+                                  ^
+                                   void
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ json_util.c            | 2 +-
+ tests/test1.c          | 6 +++---
+ tests/test4.c          | 2 +-
+ tests/test_cast.c      | 2 +-
+ tests/test_charcase.c  | 2 +-
+ tests/test_parse.c     | 8 ++++----
+ tests/test_printbuf.c  | 4 ++--
+ tests/test_util_file.c | 6 +++---
+ 8 files changed, 16 insertions(+), 16 deletions(-)
+
+--- a/json_util.c
++++ b/json_util.c
+@@ -60,7 +60,7 @@ static int _json_object_to_fd(int fd, st
+ 
+ static char _last_err[256] = "";
+ 
+-const char *json_util_get_last_err()
++const char *json_util_get_last_err(void)
+ {
+ 	if (_last_err[0] == '\0')
+ 		return NULL;
+--- a/tests/test1.c
++++ b/tests/test1.c
+@@ -58,7 +58,7 @@ static const char *to_json_string(json_o
+ #endif
+ 
+ json_object *make_array(void);
+-json_object *make_array()
++json_object *make_array(void)
+ {
+ 	json_object *my_array;
+ 
+@@ -74,7 +74,7 @@ json_object *make_array()
+ }
+ 
+ void test_array_del_idx(void);
+-void test_array_del_idx()
++void test_array_del_idx(void)
+ {
+ 	int rc;
+ 	size_t ii;
+@@ -140,7 +140,7 @@ void test_array_del_idx()
+ }
+ 
+ void test_array_list_expand_internal(void);
+-void test_array_list_expand_internal()
++void test_array_list_expand_internal(void)
+ {
+ 	int rc;
+ 	size_t ii;
+--- a/tests/test4.c
++++ b/tests/test4.c
+@@ -28,7 +28,7 @@ void print_hex(const char *s)
+ }
+ 
+ static void test_lot_of_adds(void);
+-static void test_lot_of_adds()
++static void test_lot_of_adds(void)
+ {
+ 	int ii;
+ 	char key[50];
+--- a/tests/test_cast.c
++++ b/tests/test_cast.c
+@@ -94,7 +94,7 @@ static void getit(struct json_object *ne
+ 	printf("new_obj.%s json_object_get_double()=%f\n", field, json_object_get_double(o));
+ }
+ 
+-static void checktype_header()
++static void checktype_header(void)
+ {
+ 	printf("json_object_is_type: %s,%s,%s,%s,%s,%s,%s\n", json_type_to_name(json_type_null),
+ 	       json_type_to_name(json_type_boolean), json_type_to_name(json_type_double),
+--- a/tests/test_charcase.c
++++ b/tests/test_charcase.c
+@@ -19,7 +19,7 @@ int main(int argc, char **argv)
+ }
+ 
+ /* make sure only lowercase forms are parsed in strict mode */
+-static void test_case_parse()
++static void test_case_parse(void)
+ {
+ 	struct json_tokener *tok;
+ 	json_object *new_obj;
+--- a/tests/test_parse.c
++++ b/tests/test_parse.c
+@@ -92,7 +92,7 @@ static void single_basic_parse(const cha
+ 	if (getenv("TEST_PARSE_CHUNKSIZE") != NULL)
+ 		single_incremental_parse(test_string, clear_serializer);
+ }
+-static void test_basic_parse()
++static void test_basic_parse(void)
+ {
+ 	single_basic_parse("\"\003\"", 0);
+ 	single_basic_parse("/* hello */\"foo\"", 0);
+@@ -195,7 +195,7 @@ static void test_basic_parse()
+ 	single_basic_parse("[18446744073709551616]", 1);
+ }
+ 
+-static void test_utf8_parse()
++static void test_utf8_parse(void)
+ {
+ 	// json_tokener_parse doesn't support checking for byte order marks.
+ 	// It's the responsibility of the caller to detect and skip a BOM.
+@@ -222,7 +222,7 @@ static int clear_serializer(json_object
+ 	return JSON_C_VISIT_RETURN_CONTINUE;
+ }
+ 
+-static void test_verbose_parse()
++static void test_verbose_parse(void)
+ {
+ 	json_object *new_obj;
+ 	enum json_tokener_error error = json_tokener_success;
+@@ -562,7 +562,7 @@ struct incremental_step
+     {NULL, -1, -1, json_tokener_success, 0},
+ };
+ 
+-static void test_incremental_parse()
++static void test_incremental_parse(void)
+ {
+ 	json_object *new_obj;
+ 	enum json_tokener_error jerr;
+--- a/tests/test_printbuf.c
++++ b/tests/test_printbuf.c
+@@ -16,7 +16,7 @@ static void test_printbuf_memset_length(
+ #define __func__ __FUNCTION__
+ #endif
+ 
+-static void test_basic_printbuf_memset()
++static void test_basic_printbuf_memset(void)
+ {
+ 	struct printbuf *pb;
+ 
+@@ -29,7 +29,7 @@ static void test_basic_printbuf_memset()
+ 	printf("%s: end test\n", __func__);
+ }
+ 
+-static void test_printbuf_memset_length()
++static void test_printbuf_memset_length(void)
+ {
+ 	struct printbuf *pb;
+ 
+--- a/tests/test_util_file.c
++++ b/tests/test_util_file.c
+@@ -35,7 +35,7 @@ static void test_read_fd_equal(const cha
+ #define PATH_MAX 256
+ #endif
+ 
+-static void test_write_to_file()
++static void test_write_to_file(void)
+ {
+ 	json_object *jso;
+ 
+@@ -231,7 +231,7 @@ static void test_read_valid_nested_with_
+ 	close(d);
+ }
+ 
+-static void test_read_nonexistant()
++static void test_read_nonexistant(void)
+ {
+ 	const char *filename = "./not_present.json";
+ 
+@@ -249,7 +249,7 @@ static void test_read_nonexistant()
+ 	}
+ }
+ 
+-static void test_read_closed()
++static void test_read_closed(void)
+ {
+ 	// Test reading from a closed fd
+ 	int d = open("/dev/null", O_RDONLY, 0);


### PR DESCRIPTION
Fixes errors in the form of:
```
  /Users/user/src/openwrt/openwrt/build_dir/hostpkg/json-c-0.16/json_util.c:63:35: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
  const char *json_util_get_last_err()
                                    ^
                                     void
  1 error generated.
  ninja: build stopped: subcommand failed.
```

Reported-by: Paul Spooren <mail@aparcar.org>
Suggested-by: Paul Spooren <mail@aparcar.org>
