### PR TITLE
ath25: Fix compile after -WError

### DIFF
--- a/target/linux/ath25/patches-5.15/110-ar2313_ethernet.patch
+++ b/target/linux/ath25/patches-5.15/110-ar2313_ethernet.patch
@@ -33,7 +33,7 @@
 +obj-$(CONFIG_NET_AR231X) += ar231x.o
 --- /dev/null
 +++ b/drivers/net/ethernet/atheros/ar231x/ar231x.c
-@@ -0,0 +1,1119 @@
+@@ -0,0 +1,1117 @@
 +/*
 + * ar231x.c: Linux driver for the Atheros AR231x Ethernet device.
 + *
@@ -155,8 +155,6 @@
 +MODULE_AUTHOR("Sameer Dekate <sdekate@arubanetworks.com>, Imre Kaloz <kaloz@openwrt.org>, Felix Fietkau <nbd@nbd.name>");
 +MODULE_DESCRIPTION("AR231x Ethernet driver");
 +#endif
-+
-+#define virt_to_phys(x) ((u32)(x) & 0x1fffffff)
 +
 +/* prototypes */
 +static void ar231x_halt(struct net_device *dev);

--- a/target/linux/ath25/patches-5.15/120-spiflash.patch
+++ b/target/linux/ath25/patches-5.15/120-spiflash.patch
@@ -350,13 +350,13 @@
 +		switch (read_len) {
 +		case 4:
 +			spi_data |= buf[3] << 24;
-+			/* fall through */
++			fallthrough;
 +		case 3:
 +			spi_data |= buf[2] << 16;
-+			/* fall through */
++			fallthrough;
 +		case 2:
 +			spi_data |= buf[1] << 8;
-+			/* fall through */
++			fallthrough;
 +		case 1:
 +			spi_data |= buf[0] & 0xff;
 +			break;

--- a/target/linux/ath25/patches-5.15/220-enet_micrel_workaround.patch
+++ b/target/linux/ath25/patches-5.15/220-enet_micrel_workaround.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/ethernet/atheros/ar231x/ar231x.c
 +++ b/drivers/net/ethernet/atheros/ar231x/ar231x.c
-@@ -135,6 +135,7 @@ static int ar231x_mdiobus_write(struct m
+@@ -133,6 +133,7 @@ static int ar231x_mdiobus_write(struct m
  static int ar231x_mdiobus_reset(struct mii_bus *bus);
  static int ar231x_mdiobus_probe(struct net_device *dev);
  static void ar231x_adjust_link(struct net_device *dev);
@@ -8,7 +8,7 @@
  
  #ifndef ERR
  #define ERR(fmt, args...) printk("%s: " fmt, __func__, ##args)
-@@ -166,6 +167,32 @@ static const struct net_device_ops ar231
+@@ -164,6 +165,32 @@ static const struct net_device_ops ar231
  #endif
  };
  
@@ -41,7 +41,7 @@
  static int ar231x_probe(struct platform_device *pdev)
  {
  	struct net_device *dev;
-@@ -273,6 +300,24 @@ static int ar231x_probe(struct platform_
+@@ -271,6 +298,24 @@ static int ar231x_probe(struct platform_
  
  	mdiobus_register(sp->mii_bus);
  
@@ -66,7 +66,7 @@
  	if (ar231x_mdiobus_probe(dev) != 0) {
  		printk(KERN_ERR "%s: mdiobus_probe failed\n", dev->name);
  		rx_tasklet_cleanup(dev);
-@@ -326,8 +371,10 @@ static int ar231x_remove(struct platform
+@@ -324,8 +369,10 @@ static int ar231x_remove(struct platform
  	rx_tasklet_cleanup(dev);
  	ar231x_init_cleanup(dev);
  	unregister_netdev(dev);
@@ -79,7 +79,7 @@
  	kfree(dev);
  	return 0;
  }
-@@ -870,7 +917,8 @@ static int ar231x_open(struct net_device
+@@ -868,7 +915,8 @@ static int ar231x_open(struct net_device
  
  	sp->eth_regs->mac_control |= MAC_CONTROL_RE;
  
@@ -89,7 +89,7 @@
  
  	return 0;
  }
-@@ -951,7 +999,8 @@ static int ar231x_close(struct net_devic
+@@ -949,7 +997,8 @@ static int ar231x_close(struct net_devic
  
  #endif
  
@@ -99,7 +99,7 @@
  
  	return 0;
  }
-@@ -995,6 +1044,9 @@ static int ar231x_ioctl(struct net_devic
+@@ -993,6 +1042,9 @@ static int ar231x_ioctl(struct net_devic
  {
  	struct ar231x_private *sp = netdev_priv(dev);
  


### PR DESCRIPTION
This fixes two compile problems after -WError was activated. 