### PR TITLE
util-linux: Fix taskset conflict with busybox

### DIFF
--- a/package/utils/util-linux/Makefile
+++ b/package/utils/util-linux/Makefile
@@ -485,6 +485,7 @@ endef
 define Package/taskset
 $(call Package/util-linux/Default)
   TITLE:=set or retrieve a process's CPU affinity
+  ALTERNATIVES:=200:/usr/bin/taskset:/usr/bin/util-linux-taskset
 endef
 
 define Package/taskset/description
@@ -851,7 +852,7 @@ endef
 
 define Package/taskset/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/taskset $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/taskset $(1)/usr/bin/util-linux-taskset
 endef
 
 define Package/unshare/install


### PR DESCRIPTION
This fixes the following error:
 * check_data_file_clashes: Package taskset wants to install file build_dir/target-powerpc_8548_musl/root-mpc85xx/usr/bin/taskset But that file is already provided by package  * busybox
 * opkg_install_cmd: Cannot install package taskset.

Fixes: 3c3d797c4dad ("busybox: enable taskset by default")
