### PR TITLE
kirkwood: add support for Iomega Storcenter ix4-200d

### DIFF
--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -37,6 +37,9 @@ kirkwood_setup_interfaces()
 	endian,4i-edge-200)
 		ucidef_set_interface_lan "port1 port2 port3 port4 eth1"
 		;;
+	iom,ix4-200d)
+		ucidef_set_interface_lan "eth0 eth1" "dhcp"
+		;;
 	linksys,e4200-v2|\
 	linksys,ea3500|\
 	linksys,ea4500)

--- a/target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-ix4-200d.dts
+++ b/target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-ix4-200d.dts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "kirkwood.dtsi"
+#include "kirkwood-6281.dtsi"
+
+/ {
+	model = "Iomega ix4-200d";
+	compatible = "iom,ix4-200d", "marvell,kirkwood-88f6281", "marvell,kirkwood";
+
+	aliases {
+		led-boot = &led_status_white;
+		led-failsafe = &led_status_red;
+		led-running = &led_power_white;
+		led-upgrade = &led_status_red;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8 earlyprintk";
+		stdout-path = &uart0;
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x00000000 0x20000000>;
+	};
+
+	ocp@f1000000 {
+		i2c@11000 {
+			status = "okay";
+
+			adt7473@2e {
+				compatible = "adi,adt7473";
+				reg = <0x2e>;
+			};
+		};
+
+		pinctrl: pin-controller@10000 {
+			pmx_spi: pmx-spi {
+				marvell,pins = "mpp12", "mpp13", "mpp14";
+				marvell,function = "gpio";
+			};
+
+			pmx_keys: pmx-keys {
+				marvell,pins = "mpp16", "mpp29", "mpp47", "mpp49";
+				marvell,function = "gpio";
+			};
+		};
+
+		sata@80000 {
+			status = "okay";
+			nr-ports = <2>;
+		};
+
+		serial@12000 {
+			status = "okay";
+		};
+
+		spi3 {
+			compatible = "spi-gpio";
+			#address-cells = <0x1>;
+			ranges;
+			status = "okay";
+			sck-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			mosi-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			cs-gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			num-chipselects = <1>;
+			#size-cells = <0>;
+
+			gpio_spi: gpio_spi@0 {
+				compatible = "fairchild,74hc595";
+				reg = <0>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				registers-number = <1>;
+				spi-max-frequency = <100000>;
+			};
+		};
+
+		gpio-keys {
+			compatible = "gpio-keys";
+			pinctrl-0 = <&pmx_keys>;
+			pinctrl-names = "default";
+
+			next-button {
+				label = "Next Button";
+				linux,code = <BTN_0>;
+				gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+			};
+
+			reset-button {
+				label = "Reset Button";
+				linux,code = <KEY_RESTART>;
+				gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+			};
+
+			cancel-button {
+				label = "Cancel Button";
+				linux,code = <BTN_1>;
+				gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+			};
+
+			power-button {
+				label = "Power Button";
+				linux,code = <KEY_POWER2>;
+				gpios = <&gpio1 17 GPIO_ACTIVE_LOW>;
+			};
+		};
+
+		gpio-leds {
+			compatible = "gpio-leds";
+
+			led_status_white: led-status-white {
+				label = "status:white";
+				gpios = <&gpio_spi 4 GPIO_ACTIVE_LOW>;
+			};
+
+			led_status_red: led-status-red {
+				label = "status:red";
+				gpios = <&gpio_spi 5 GPIO_ACTIVE_LOW>;
+			};
+
+			led_power_white: led-power-white {
+				label = "power:white";
+				gpios = <&gpio_spi 7 GPIO_ACTIVE_HIGH>;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+	ethernet0-port@0 {
+		phy-handle = <&ethphy0>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+	ethernet1-port@0 {
+		phy-handle = <&ethphy1>;
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	ethphy0: ethernet-phy@8 {
+		reg = <8>;
+	};
+
+	ethphy1: ethernet-phy@9 {
+		reg = <9>;
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+	
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0000000 0x100000>;
+			read-only;
+		};
+
+		partition@a0000 {
+			label = "u-boot environment";
+			reg = <0xa0000 0x20000>;
+			read-only;
+		};
+ 
+		partition@100000 {
+			label = "kernel";
+			reg = <0x100000 0x300000>;
+		};
+ 
+		partition@400000 {
+			label = "ubi";
+			reg = <0x400000 0x1C00000>;
+		};
+	};
+};
+
+&pciec {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+};

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -184,6 +184,24 @@ define Device/iom_ix2-200
 endef
 TARGET_DEVICES += iom_ix2-200
 
+define Device/iom_ix4-200d
+  DEVICE_VENDOR := Iomega
+  DEVICE_MODEL := StorCenter ix4-200d
+  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 \
+	kmod-gpio-button-hotplug kmod-gpio-nxp-74hc164 \
+	kmod-hwmon-adt7475 kmod-mvsdio kmod-spi-gpio
+  PAGESIZE := 512
+  SUBPAGESIZE := 256
+  BLOCKSIZE := 16k
+  KERNEL_SIZE := 3072k
+  KERNEL_IN_UBI :=
+  UBINIZE_OPTS := -E 5
+  IMAGE_SIZE := 31744k
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
+	check-size
+endef
+TARGET_DEVICES += iom_ix4-200d
+
 define Device/iptime_nas1
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := NAS1


### PR DESCRIPTION
Iomega Storcenter ix4-200d is a four-bay SATA NAS powered by a Marvell
 Kirkwood SoC clocked at 1.2GHz. It has 512MB of RAM and 32MB of
 flash memory, 3x USB 2.0 and 2x 1Gbit/s NIC

Specification:
- SoC: Marvell Kirkwood 88F6281
- CPU/Speed: 1200Mhz
- Flash size: 32 MiB
- RAM: 512MB
- LAN: 2x 1Gbit/s
- 3x USB 2.0

Notes:
- The blue drive LED is triggered by HDD activity, it can not be controlled via GPIO.
- The LCD screen requires proprietary code and does not function at this time.
- Due to a kernel-related issue with the Marvell 88SE6121 SATA controller, currently only trays numbered 3 and 4 work, 1 and 2 do not. [1]

Serial pinout:

    CN4
    --------------
    | 10 8 6 4 2 |
    |  9 7 5 3 1 |
    -------------- PIN 1 Mark (fat line)

     1 = RXD
     4 = TXD
     6 = GND
     9 = 3.3V (not necessary to connect)

Installation instructions:
```
1. download initramfs-uImage and copy into tftp server
2. connect the tftp server to network port #1
3. access uboot environment with serial cable and run 
    ```
    setenv mainlineLinux yes
    setenv arcNumber 1682
    setenv console 'console=ttyS0,115200n8'
    setenv mtdparts 'mtdparts=orion_nand:0x100000@0x000000(u-boot)ro,0x20000@0xA0000(u-boot environment)ro,0x300000@0x100000(kernel),0x1C00000@0x400000(ubi)'
    setenv bootargs_root 'root='
    setenv bootcmd 'setenv bootargs ${console} ${mtdparts} ${bootargs_root}; nand read.e 0x800000 0x100000 0x300000; bootm 0x00800000'
    saveenv
    setenv serverip 192.168.1.1
    setenv ipaddr 192.168.1.2
    tftpboot 0x00800000 [initramfs-uImage filename]
    bootm 0x00800000
    ```
4. connect to LAN on network port #2, log into openwrt and sysupgrade to install into flash
```

[1] https://bugzilla.kernel.org/show_bug.cgi?id=216094
