### PR TITLE
ipq806x: add support to netgear_xr450

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -37,6 +37,7 @@ netgear,d7800 |\
 netgear,r7500 |\
 netgear,r7500v2 |\
 netgear,r7800 |\
+netgear,xr450 |\
 netgear,xr500)
 	ucidef_set_led_usbport "usb1" "USB 1" "white:usb1" "usb1-port1" "usb2-port1"
 	ucidef_set_led_usbport "usb2" "USB 2" "white:usb2" "usb3-port1" "usb4-port1"

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -59,6 +59,7 @@ nec,wg2600hp3)
 		"2:lan" "3:lan" "4:lan" "5:lan" "0@eth1" "1:wan" "6@eth0"
 	;;
 netgear,r7800 |\
+netgear,xr450 |\
 netgear,xr500 |\
 tplink,c2600 |\
 tplink,vr2600v)

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -17,6 +17,7 @@ platform_do_upgrade() {
 	netgear,r7500 |\
 	netgear,r7500v2 |\
 	netgear,r7800 |\
+	netgear,xr450 |\
 	netgear,xr500 |\
 	nokia,ac400i |\
 	qcom,ipq8064-ap148 |\

--- a/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8065-xr450.dts
+++ b/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8065-xr450.dts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq8065-nighthawk.dtsi"
+
+/ {
+	model = "Netgear Nighthawk XR450";
+	compatible = "netgear,xr450", "qcom,ipq8065", "qcom,ipq8064";
+
+};
+
+&leds {
+	usb1 {
+		label = "white:usb1";
+		gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
+	};
+
+	usb2 {
+		label = "white:usb2";
+		gpios = <&qcom_pinmux 26 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&partitions {
+	partition@1880000 {
+		label = "ubi";
+		reg = <0x1880000 0xce00000>;
+	};
+
+	partition@e680000 {
+		label = "reserve";
+		reg = <0xe680000 0x0780000>;
+		read-only;
+	};
+};
+
+&wifi0 {
+	nvmem-cells = <&macaddr_art_c>, <&precal_art_1000>;
+	nvmem-cell-names = "mac-address", "pre-calibration";
+};
+
+&wifi1 {
+	nvmem-cells = <&macaddr_art_0>, <&precal_art_5000>;
+	nvmem-cell-names = "mac-address", "pre-calibration";
+};
+
+&art {
+	macaddr_art_c: macaddr@c {
+		reg = <0xc 0x6>;
+	};
+};

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -320,6 +320,20 @@ define Device/netgear_r7800
 endef
 TARGET_DEVICES += netgear_r7800
 
+define Device/netgear_xr450
+	$(call Device/DniImage)
+	DEVICE_VENDOR := NETGEAR
+	DEVICE_MODEL := Nighthawk XR450
+	SOC := qcom-ipq8065
+	KERNEL_SIZE := 4096k
+	NETGEAR_BOARD_ID := XR450
+	NETGEAR_HW_ID := 29764958+0+256+512+4x4+4x4+cascade
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct kmod-ramoops
+endef
+TARGET_DEVICES += netgear_xr450
+
 define Device/netgear_xr500
 	$(call Device/DniImage)
 	DEVICE_VENDOR := NETGEAR


### PR DESCRIPTION
Add support for NETGEAR Nighthawk XR450. Hardware is virtually the same as XR500. 
Factory image requires XR450 in file header, platform name updated.
