### PR TITLE
treewide: Disable building devices with 8M, 16M and 32M RAM

### DIFF
--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -707,6 +707,7 @@ define Device/tplink_tl-wr1043nd-v1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-switch-rtl8366rb
   TPLINK_HWID := 0x10430001
   SUPPORTED_DEVICES += tl-wr1043nd
+  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_tl-wr1043nd-v1
 
@@ -789,6 +790,7 @@ define Device/tplink_tl-wr710n-v1
   DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x07100001
   SUPPORTED_DEVICES += tl-wr710n
+  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_tl-wr710n-v1
 
@@ -801,6 +803,7 @@ define Device/tplink_tl-wr710n-v2.1
   TPLINK_HWID := 0x07100002
   TPLINK_HWREV := 0x2
   SUPPORTED_DEVICES += tl-wr710n
+  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_tl-wr710n-v2.1
 
@@ -822,6 +825,7 @@ define Device/tplink_tl-wr810n-v2
   DEVICE_VARIANT := v2
   TPLINK_HWID := 0x8100002
   SUPPORTED_DEVICES += tl-wr810n-v2
+  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_tl-wr810n-v2
 
@@ -851,6 +855,7 @@ define Device/tplink_tl-wr842n-v1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x8420001
   SUPPORTED_DEVICES += tl-mr3420
+  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_tl-wr842n-v1
 
@@ -862,6 +867,7 @@ define Device/tplink_tl-wr842n-v2
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x8420002
   SUPPORTED_DEVICES += tl-wr842n-v2
+  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_tl-wr842n-v2
 

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2924,6 +2924,7 @@ define Device/wd_mynet-wifi-rangeextender
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | cybertan-trx | \
 	addpattern | append-metadata
   SUPPORTED_DEVICES += mynet-rext
+  DEFAULT := n
 endef
 TARGET_DEVICES += wd_mynet-wifi-rangeextender
 
@@ -3014,6 +3015,7 @@ define Device/ziking_cpe46b
   DEVICE_MODEL := CPE46B
   IMAGE_SIZE := 8000k
   DEVICE_PACKAGES := kmod-i2c-gpio
+  DEFAULT := n
 endef
 TARGET_DEVICES += ziking_cpe46b
 

--- a/target/linux/ath79/image/tiny-ubnt.mk
+++ b/target/linux/ath79/image/tiny-ubnt.mk
@@ -5,6 +5,7 @@ define Device/ubnt_airrouter
   SOC := ar7241
   DEVICE_MODEL := AirRouter
   SUPPORTED_DEVICES += airrouter
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_airrouter
 
@@ -14,6 +15,7 @@ define Device/ubnt_nanobridge-m
   DEVICE_MODEL := NanoBridge M
   DEVICE_PACKAGES += rssileds
   SUPPORTED_DEVICES += bullet-m
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_nanobridge-m
 
@@ -24,6 +26,7 @@ define Device/ubnt_bullet-m-ar7240
   DEVICE_VARIANT := XM (AR7240)
   DEVICE_PACKAGES += rssileds
   SUPPORTED_DEVICES += bullet-m
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_bullet-m-ar7240
 
@@ -34,6 +37,7 @@ define Device/ubnt_bullet-m-ar7241
   DEVICE_VARIANT := XM (AR7241)
   DEVICE_PACKAGES += rssileds
   SUPPORTED_DEVICES += bullet-m ubnt,bullet-m
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_bullet-m-ar7241
 
@@ -43,6 +47,7 @@ define Device/ubnt_picostation-m
   DEVICE_MODEL := Picostation M
   DEVICE_PACKAGES += rssileds
   SUPPORTED_DEVICES += bullet-m
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_picostation-m
 
@@ -52,6 +57,7 @@ define Device/ubnt_nanostation-m
   DEVICE_MODEL := Nanostation M
   DEVICE_PACKAGES += rssileds
   SUPPORTED_DEVICES += nanostation-m
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_nanostation-m
 
@@ -61,6 +67,7 @@ define Device/ubnt_nanostation-loco-m
   DEVICE_MODEL := Nanostation Loco M
   DEVICE_PACKAGES += rssileds
   SUPPORTED_DEVICES += bullet-m
+  DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_nanostation-loco-m
 

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -76,5 +76,6 @@ define Device/pqi_air-pen
   DEVICE_PACKAGES := kmod-usb-chipidea2
   IMAGE_SIZE := 7680k
   SUPPORTED_DEVICES += pqi-air-pen
+  DEFAULT := n
 endef
 TARGET_DEVICES += pqi_air-pen

--- a/target/linux/bcm47xx/image/generic.mk
+++ b/target/linux/bcm47xx/image/generic.mk
@@ -10,6 +10,7 @@ define Device/linksys_wrt300n-v1.1
   $(Device/linksys)
   DEVICE_ID := EWC2
   VERSION := 1.51.2
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt300n-v1.1
 
@@ -20,6 +21,7 @@ define Device/linksys_wrt310n-v1
   $(Device/linksys)
   DEVICE_ID := 310N
   VERSION := 1.0.10
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt310n-v1
 
@@ -30,6 +32,7 @@ define Device/linksys_wrt350n-v1
   $(Device/linksys)
   DEVICE_ID := EWCG
   VERSION := 1.04.1
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt350n-v1
 

--- a/target/linux/bcm47xx/image/legacy.mk
+++ b/target/linux/bcm47xx/image/legacy.mk
@@ -315,6 +315,7 @@ define Device/usrobotics_usr5461
   DEVICE_PACKAGES := kmod-b43 $(USB1_PACKAGES)
   IMAGES := bin
   IMAGE/bin := append-rootfs | trx-with-loader | usrobotics-bin
+  DEFAULT := n
 endef
 TARGET_DEVICES += usrobotics_usr5461
 

--- a/target/linux/bcm47xx/image/legacy.mk
+++ b/target/linux/bcm47xx/image/legacy.mk
@@ -63,6 +63,7 @@ define Device/asus_wl-500w
   DEVICE_PACKAGES := kmod-b43 kmod-usb-uhci kmod-usb2-pci
   $(Device/asus)
   PRODUCTID := "WL500W      "
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_wl-500w
 
@@ -119,6 +120,7 @@ define Device/huawei_e970
   KERNEL_NAME = vmlinux.gz
   IMAGES := bin
   IMAGE/bin := append-rootfs | trx-without-loader | huawei-bin
+  DEFAULT := n
 endef
 TARGET_DEVICES += huawei_e970
 
@@ -220,6 +222,7 @@ define Device/linksys_wrt160n-v1
   $(Device/linksys)
   DEVICE_ID := N150
   VERSION := 1.50.1
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt160n-v1
 
@@ -231,6 +234,7 @@ define Device/linksys_wrt300n-v1
   IMAGES := bin trx
   DEVICE_ID := EWCB
   VERSION := 1.03.6
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt300n-v1
 

--- a/target/linux/bcm47xx/image/legacy.mk
+++ b/target/linux/bcm47xx/image/legacy.mk
@@ -7,6 +7,7 @@ define Device/asus_wl-300g
   DEVICE_PACKAGES := kmod-b43
   $(Device/asus)
   PRODUCTID := "WL300g      "
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_wl-300g
 
@@ -15,6 +16,7 @@ define Device/asus_wl-320gp
   DEVICE_PACKAGES := kmod-b43
   $(Device/asus)
   PRODUCTID := "WL320gP     "
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_wl-320gp
 
@@ -23,6 +25,7 @@ define Device/asus_wl-330ge
   DEVICE_PACKAGES := kmod-b43
   $(Device/asus)
   PRODUCTID := "WL-330gE    "
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_wl-330ge
 
@@ -31,6 +34,7 @@ define Device/asus_wl-500gd
   DEVICE_PACKAGES := kmod-b43 $(USB2_PACKAGES)
   $(Device/asus)
   PRODUCTID := "WL500gx     "
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_wl-500gd
 
@@ -40,6 +44,7 @@ define Device/asus_wl-500gp-v1
   DEVICE_PACKAGES := kmod-b43 $(USB2_PACKAGES)
   $(Device/asus)
   PRODUCTID := "WL500gp     "
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_wl-500gp-v1
 
@@ -49,6 +54,7 @@ define Device/asus_wl-500gp-v2
   DEVICE_PACKAGES := kmod-b43 $(USB2_PACKAGES)
   $(Device/asus)
   PRODUCTID := "WL500gpv2   "
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_wl-500gp-v2
 
@@ -65,6 +71,7 @@ define Device/asus_wl-520gu
   DEVICE_PACKAGES := kmod-b43 $(USB2_PACKAGES)
   $(Device/asus)
   PRODUCTID := "WL520gu     "
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_wl-520gu
 
@@ -73,6 +80,7 @@ define Device/asus_wl-550ge
   DEVICE_PACKAGES := kmod-b43
   $(Device/asus)
   PRODUCTID := "WL550gE     "
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_wl-550ge
 
@@ -81,6 +89,7 @@ define Device/asus_wl-hdd25
   DEVICE_PACKAGES := kmod-b43 $(USB1_PACKAGES)
   $(Device/asus)
   PRODUCTID := "WLHDD       "
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_wl-hdd25
 
@@ -99,6 +108,7 @@ define Device/edimax_ps1208-mfg
   DEVICE_PACKAGES := kmod-b43 $(USB2_PACKAGES)
   IMAGES := bin
   IMAGE/bin := append-rootfs | trx-with-loader | edimax-bin
+  DEFAULT := n
 endef
 TARGET_DEVICES += edimax_ps1208-mfg
 
@@ -118,6 +128,7 @@ define Device/linksys_wrt54g3g
   $(Device/linksys)
   DEVICE_ID := W54F
   VERSION := 2.20.1
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt54g3g
 
@@ -126,6 +137,7 @@ define Device/linksys_wrt54g3g-em
   $(Device/linksys)
   DEVICE_ID := W3GN
   VERSION := 2.20.1
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt54g3g-em
 
@@ -140,6 +152,7 @@ define Device/linksys_wrt54g3gv2-vf
   DEVICE_ID := 3G2V
   VERSION := 3.00.24
   SERIAL := 6
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt54g3gv2-vf
 
@@ -149,6 +162,7 @@ define Device/linksys_wrt54g
   $(Device/linksys)
   DEVICE_ID := W54G
   VERSION := 4.71.1
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt54g
 
@@ -163,6 +177,7 @@ define Device/linksys_wrt54gs
   FILESYSTEMS := $(FS_128K)
   DEVICE_ID := W54S
   VERSION := 4.80.1
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt54gs
 
@@ -173,6 +188,7 @@ define Device/linksys_wrt54gs-v4
   $(Device/linksys)
   DEVICE_ID := W54s
   VERSION := 1.09.1
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt54gs-v4
 
@@ -183,6 +199,7 @@ define Device/linksys_wrtsl54gs
   FILESYSTEMS := $(FS_128K)
   DEVICE_ID := W54U
   VERSION := 2.08.1
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrtsl54gs
 
@@ -192,6 +209,7 @@ define Device/linksys_wrt150n
   $(Device/linksys)
   DEVICE_ID := N150
   VERSION := 1.51.3
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt150n
 
@@ -221,6 +239,7 @@ define Device/motorola_wa840g
   DEVICE_PACKAGES := kmod-b43
   $(Device/motorola)
   MOTOROLA_DEVICE := 2
+  DEFAULT := n
 endef
 TARGET_DEVICES += motorola_wa840g
 
@@ -229,6 +248,7 @@ define Device/motorola_we800g
   DEVICE_PACKAGES := kmod-b43
   $(Device/motorola)
   MOTOROLA_DEVICE := 3
+  DEFAULT := n
 endef
 TARGET_DEVICES += motorola_we800g
 
@@ -237,6 +257,7 @@ define Device/motorola_wr850g
   DEVICE_PACKAGES := kmod-b43
   $(Device/motorola)
   MOTOROLA_DEVICE := 1
+  DEFAULT := n
 endef
 TARGET_DEVICES += motorola_wr850g
 
@@ -247,6 +268,7 @@ define Device/netgear_wgr614-v8
   $(Device/netgear)
   NETGEAR_BOARD_ID := U12H072T00_NETGEAR
   NETGEAR_REGION := 2
+  DEFAULT := n
 endef
 TARGET_DEVICES += netgear_wgr614-v8
 
@@ -257,6 +279,7 @@ define Device/netgear_wgt634u
   FILESYSTEMS := $(FS_128K)
   IMAGES := bin
   IMAGE/bin := append-rootfs | trx-with-loader | prepend-with-elf
+  DEFAULT := n
 endef
 TARGET_DEVICES += netgear_wgt634u
 
@@ -267,6 +290,7 @@ define Device/netgear_wndr3300-v1
   $(Device/netgear)
   NETGEAR_BOARD_ID := U12H093T00_NETGEAR
   NETGEAR_REGION := 2
+  DEFAULT := n
 endef
 TARGET_DEVICES += netgear_wndr3300-v1
 
@@ -277,6 +301,7 @@ define Device/netgear_wnr834b-v2
   $(Device/netgear)
   NETGEAR_BOARD_ID := U12H081T00_NETGEAR
   NETGEAR_REGION := 2
+  DEFAULT := n
 endef
 TARGET_DEVICES += netgear_wnr834b-v2
 

--- a/target/linux/bcm47xx/image/mips74k.mk
+++ b/target/linux/bcm47xx/image/mips74k.mk
@@ -34,6 +34,7 @@ define Device/asus_rt-n10p
   DEVICE_PACKAGES := kmod-b43
   $(Device/asus)
   PRODUCTID := RT-N10P
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n10p
 
@@ -42,6 +43,7 @@ define Device/asus_rt-n10p-v2
   DEVICE_VARIANT := v2
   $(Device/asus)
   PRODUCTID := RT-N10PV2
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n10p-v2
 
@@ -51,6 +53,7 @@ define Device/asus_rt-n10u
   DEVICE_PACKAGES := kmod-b43 $(USB2_PACKAGES)
   $(Device/asus)
   PRODUCTID := RT-N10U
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n10u
 
@@ -60,6 +63,7 @@ define Device/asus_rt-n10u-b
   DEVICE_PACKAGES := kmod-b43 $(USB2_PACKAGES)
   $(Device/asus)
   PRODUCTID := RT-N10U
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n10u-b
 
@@ -69,6 +73,7 @@ define Device/asus_rt-n12
   DEVICE_PACKAGES := kmod-b43
   $(Device/asus)
   PRODUCTID := "RT-N12      "
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n12
 
@@ -77,6 +82,7 @@ define Device/asus_rt-n12-b1
   DEVICE_VARIANT := B1
   $(Device/asus)
   PRODUCTID := RT-N12B1
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n12-b1
 
@@ -85,6 +91,7 @@ define Device/asus_rt-n12-c1
   DEVICE_VARIANT := C1
   $(Device/asus)
   PRODUCTID := RT-N12C1
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n12-c1
 
@@ -93,6 +100,7 @@ define Device/asus_rt-n12-d1
   DEVICE_VARIANT := D1
   $(Device/asus)
   PRODUCTID := RT-N12D1
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n12-d1
 
@@ -100,6 +108,7 @@ define Device/asus_rt-n12hp
   DEVICE_MODEL := RT-N12HP
   $(Device/asus)
   PRODUCTID := RT-N12HP
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n12hp
 
@@ -132,6 +141,7 @@ define Device/asus_rt-n53
   DEVICE_PACKAGES := kmod-b43
   $(Device/asus)
   PRODUCTID := RT-N53
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n53
 
@@ -169,6 +179,7 @@ define Device/linksys_wrt310n-v2
   $(Device/linksys)
   DEVICE_ID := 310N
   VERSION := 2.0.1
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt310n-v2
 
@@ -179,6 +190,7 @@ define Device/linksys_wrt320n-v1
   $(Device/linksys)
   DEVICE_ID := 320N
   VERSION := 1.0.5
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt320n-v1
 
@@ -188,6 +200,7 @@ define Device/linksys_e900-v1
   $(Device/linksys)
   DEVICE_ID := E900
   VERSION := 1.0.4
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_e900-v1
 
@@ -198,6 +211,7 @@ define Device/linksys_e1000
   $(Device/linksys)
   DEVICE_ID := E100
   VERSION := 1.1.3
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_e1000
 
@@ -207,6 +221,7 @@ define Device/linksys_e1200-v1
   $(Device/linksys)
   DEVICE_ID := E120
   VERSION := 1.0.3
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_e1200-v1
 
@@ -216,6 +231,7 @@ define Device/linksys_e1200-v2
   $(Device/linksys)
   DEVICE_ID := E122
   VERSION := 1.0.4
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_e1200-v2
 
@@ -225,6 +241,7 @@ define Device/linksys_e1500-v1
   $(Device/linksys)
   DEVICE_ID := E150
   VERSION := 1.0.5
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_e1500-v1
 
@@ -245,6 +262,7 @@ define Device/linksys_e2000-v1
   $(Device/linksys)
   DEVICE_ID := 32XN
   VERSION := 1.0.4
+  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_e2000-v1
 
@@ -353,6 +371,7 @@ define Device/netgear_wn3000rp
   $(Device/netgear)
   NETGEAR_BOARD_ID := U12H163T01_NETGEAR
   NETGEAR_REGION := 1
+  DEFAULT := n
 endef
 TARGET_DEVICES += netgear_wn3000rp
 
@@ -434,6 +453,7 @@ define Device/netgear_wnr2000v2
   $(Device/netgear)
   NETGEAR_BOARD_ID := U12H114T00_NETGEAR
   NETGEAR_REGION := 2
+  DEFAULT := n
 endef
 TARGET_DEVICES += netgear_wnr2000v2
 
@@ -486,6 +506,7 @@ define Device/netgear_wnr3500-v2
   $(Device/netgear)
   NETGEAR_BOARD_ID := U12H127T00_NETGEAR
   NETGEAR_REGION := 2
+  DEFAULT := n
 endef
 TARGET_DEVICES += netgear_wnr3500-v2
 

--- a/target/linux/bcm47xx/image/mips74k.mk
+++ b/target/linux/bcm47xx/image/mips74k.mk
@@ -24,6 +24,7 @@ define Device/asus_rt-n10
   DEVICE_PACKAGES := kmod-b43
   $(Device/asus)
   PRODUCTID := "RT-N10      "
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n10
 
@@ -323,6 +324,7 @@ define Device/netgear_wgr614-v10-na
   $(Device/netgear)
   NETGEAR_BOARD_ID := U12H139T01_NETGEAR
   NETGEAR_REGION := 2
+  DEFAULT := n
 endef
 TARGET_DEVICES += netgear_wgr614-v10-na
 
@@ -332,6 +334,7 @@ define Device/netgear_wgr614-v10
   $(Device/netgear)
   NETGEAR_BOARD_ID := U12H139T01_NETGEAR
   NETGEAR_REGION := 1
+  DEFAULT := n
 endef
 TARGET_DEVICES += netgear_wgr614-v10
 
@@ -420,6 +423,7 @@ define Device/netgear_wnr1000-v3
   $(Device/netgear)
   NETGEAR_BOARD_ID := U12H139T00_NETGEAR
   NETGEAR_REGION := 2
+  DEFAULT := n
 endef
 TARGET_DEVICES += netgear_wnr1000-v3
 

--- a/target/linux/bcm63xx/image/bcm63xx.mk
+++ b/target/linux/bcm63xx/image/bcm63xx.mk
@@ -210,6 +210,7 @@ define Device/adb_a4001n
   CHIP_ID := 6328
   FLASH_MB := 8
   DEVICE_PACKAGES := $(USB2_PACKAGES) $(B43_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += adb_a4001n
 
@@ -222,6 +223,7 @@ define Device/adb_a4001n1
   CHIP_ID := 6328
   FLASH_MB := 16
   DEVICE_PACKAGES := $(USB2_PACKAGES) $(B43_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += adb_a4001n1
 
@@ -234,6 +236,7 @@ define Device/adb_pdg-a4001n-a-000-1a1-ax
   CHIP_ID := 6328
   FLASH_MB := 16
   DEVICE_PACKAGES := $(USB2_PACKAGES) $(B43_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += adb_pdg-a4001n-a-000-1a1-ax
 
@@ -269,6 +272,7 @@ define Device/alcatel_rg100a
   CHIP_ID := 6358
   BLOCK_SIZE := 0x20000
   DEVICE_PACKAGES := $(USB2_PACKAGES) $(B43_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += alcatel_rg100a
 
@@ -448,6 +452,7 @@ define Device/comtrend_ct-6373
   CFE_BOARD_ID := CT6373-1
   CHIP_ID := 6358
   DEVICE_PACKAGES := $(B43_PACKAGES) $(USB2_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += comtrend_ct-6373
 
@@ -532,6 +537,7 @@ define Device/d-link_dsl-2650u
   CFE_BOARD_ID := 96358VW2
   CHIP_ID := 6358
   DEVICE_PACKAGES := $(B43_PACKAGES) $(USB2_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += d-link_dsl-2650u
 
@@ -593,6 +599,7 @@ define Device/d-link_dsl-2750u-c1
   CHIP_ID := 6328
   FLASH_MB := 8
   DEVICE_PACKAGES := $(USB2_PACKAGES) $(B43_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += d-link_dsl-2750u-c1
 
@@ -618,6 +625,7 @@ define Device/d-link_dva-g3810bn-tl
   CFE_BOARD_ID := 96358VW
   CHIP_ID := 6358
   DEVICE_PACKAGES := $(B43_PACKAGES) $(USB2_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += d-link_dva-g3810bn-tl
 
@@ -765,6 +773,7 @@ define Device/huawei_echolife-hg622
   BLOCK_SIZE := 0x20000
   FLASH_MB := 16
   DEVICE_PACKAGES := $(RT28_PACKAGES) $(USB2_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += huawei_echolife-hg622
 
@@ -825,6 +834,7 @@ define Device/netgear_cvg834g
   HCS_MAGIC_BYTES := 0xa020
   HCS_REV_MIN := 0001
   HCS_REV_MAJ := 0022
+  DEFAULT := n
 endef
 TARGET_DEVICES += netgear_cvg834g
 
@@ -930,6 +940,7 @@ define Device/pirelli_a226g
   CHIP_ID := 6358
   CFE_EXTRAS += --signature2 IMAGE --tag-version 8
   DEVICE_PACKAGES := $(B43_PACKAGES) $(USB2_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += pirelli_a226g
 
@@ -941,6 +952,7 @@ define Device/pirelli_a226m
   CHIP_ID := 6358
   CFE_EXTRAS += --signature2 IMAGE --tag-version 8
   DEVICE_PACKAGES := $(USB2_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += pirelli_a226m
 
@@ -965,6 +977,7 @@ define Device/pirelli_agpf-s0
   CFE_EXTRAS += --signature2 IMAGE --tag-version 8
   BLOCK_SIZE := 0x20000
   DEVICE_PACKAGES := $(B43_PACKAGES) $(USB2_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += pirelli_agpf-s0
 
@@ -1009,6 +1022,7 @@ define Device/sagem_fast-2704n
   CHIP_ID := 6318
   FLASH_MB := 8
   DEVICE_PACKAGES := $(B43_PACKAGES) $(USB2_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += sagem_fast-2704n
 
@@ -1046,6 +1060,7 @@ define Device/sfr_neufbox-4-sercomm-r0
   CHIP_ID := 6358
   CFE_EXTRAS += --rsa-signature "$(VERSION_DIST)-$(firstword $(subst -,$(space),$(REVISION)))"
   DEVICE_PACKAGES := $(B43_PACKAGES) $(USB2_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += sfr_neufbox-4-sercomm-r0
 
@@ -1058,6 +1073,7 @@ define Device/sfr_neufbox-4-foxconn-r1
   CHIP_ID := 6358
   CFE_EXTRAS += --rsa-signature "$(VERSION_DIST)-$(firstword $(subst -,$(space),$(REVISION)))"
   DEVICE_PACKAGES := $(B43_PACKAGES) $(USB2_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += sfr_neufbox-4-foxconn-r1
 
@@ -1096,6 +1112,7 @@ define Device/t-com_speedport-w-303v
   CFE_BOARD_ID := 96358-502V
   CHIP_ID := 6358
   DEVICE_PACKAGES := $(B43_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += t-com_speedport-w-303v
 
@@ -1182,6 +1199,7 @@ define Device/telsey_cpva642
   CFE_EXTRAS += --signature "Telsey Tlc" --signature2 "99.99.999" --second-image-flag "0"
   FLASH_MB := 8
   DEVICE_PACKAGES := $(RT63_PACKAGES) $(USB2_PACKAGES)
+  DEFAULT := n
 endef
 TARGET_DEVICES += telsey_cpva642
 

--- a/target/linux/lantiq/image/ar9.mk
+++ b/target/linux/lantiq/image/ar9.mk
@@ -154,6 +154,7 @@ define Device/zte_h201l
 	kmod-usb-dwc2 kmod-usb-ledtrig-usbport \
 	kmod-ltq-tapi kmod-ltq-vmmc
   SUPPORTED_DEVICES += H201L
+  DEFAULT := n
 endef
 TARGET_DEVICES += zte_h201l
 

--- a/target/linux/lantiq/image/danube.mk
+++ b/target/linux/lantiq/image/danube.mk
@@ -12,6 +12,7 @@ define Device/arcadyan_arv4510pw
 	kmod-ltq-tapi kmod-ltq-vmmc \
 	kmod-rt2800-pci kmod-ath5k wpad-basic-mbedtls
   SUPPORTED_DEVICES += ARV4510PW
+  DEFAULT := n
 endef
 TARGET_DEVICES += arcadyan_arv4510pw
 
@@ -219,5 +220,6 @@ define Device/siemens_gigaset-sx76x
 	ltq-adsl-app ppp-mod-pppoe \
 	kmod-ath5k wpad-basic-mbedtls
   SUPPORTED_DEVICES += GIGASX76X
+  DEFAULT := n
 endef
 TARGET_DEVICES += siemens_gigaset-sx76x

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -12,6 +12,7 @@ define Device/alphanetworks_asl56026
   DEVICE_ALT0_VENDOR := BT Openreach
   DEVICE_ALT0_MODEL := ECI VDSL Modem V-2FUb/I
   IMAGE_SIZE := 7488k
+  DEFAULT := n
 endef
 TARGET_DEVICES += alphanetworks_asl56026
 
@@ -38,6 +39,7 @@ define Device/arcadyan_vg3503j
   DEVICE_MODEL := ECI VDSL Modem V-2FUb/R
   IMAGE_SIZE := 8000k
   SUPPORTED_DEVICES += VG3503J
+  DEFAULT := n
 endef
 TARGET_DEVICES += arcadyan_vg3503j
 

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -124,6 +124,7 @@ define Device/asus_rt-n12p
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-N11P/RT-N12+/RT-N12Eb1
   SUPPORTED_DEVICES += rt-n12p
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n12p
 
@@ -191,6 +192,7 @@ define Device/comfast_cf-wr800n
   DEVICE_VENDOR := Comfast
   DEVICE_MODEL := CF-WR800N
   SUPPORTED_DEVICES += cf-wr800n
+  DEFAULT := n
 endef
 TARGET_DEVICES += comfast_cf-wr800n
 
@@ -241,6 +243,7 @@ define Device/dlink_dwr-116-a1
   DLINK_ROM_ID := DLK6E3803001
   DLINK_FAMILY_MEMBER := 0x6E38
   DLINK_FIRMWARE_SIZE := 0x7E0000
+  DEFAULT := n
 endef
 TARGET_DEVICES += dlink_dwr-116-a1
 
@@ -853,6 +856,7 @@ define Device/netgear_wn3000rp-v3
   DEVICE_MODEL := WN3000RP
   DEVICE_VARIANT := v3
   SUPPORTED_DEVICES += wn3000rpv3
+  DEFAULT := n
 endef
 TARGET_DEVICES += netgear_wn3000rp-v3
 
@@ -1438,6 +1442,7 @@ define Device/zbtlink_zbt-wr8305rt
   DEVICE_MODEL := ZBT-WR8305RT
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
   SUPPORTED_DEVICES += zbt-wr8305rt
+  DEFAULT := n
 endef
 TARGET_DEVICES += zbtlink_zbt-wr8305rt
 

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -68,6 +68,7 @@ define Device/asus_rt-n10p-v3
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-N10P
   DEVICE_VARIANT := V3
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n10p-v3
 
@@ -82,6 +83,7 @@ define Device/asus_rt-n11p-b1
   DEVICE_ALT1_VENDOR := ASUS
   DEVICE_ALT1_MODEL := RT-N300
   DEVICE_ALT1_VARIANT := B1
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n11p-b1
 

--- a/target/linux/ramips/image/rt288x.mk
+++ b/target/linux/ramips/image/rt288x.mk
@@ -54,6 +54,7 @@ define Device/belkin_f5d8235-v1
   DEVICE_PACKAGES := kmod-switch-rtl8366s kmod-usb-ohci kmod-usb-ohci-pci \
 	kmod-usb2 kmod-usb2-pci kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += f5d8235-v1
+  DEFAULT := n
 endef
 TARGET_DEVICES += belkin_f5d8235-v1
 

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -43,6 +43,7 @@ define Device/7links_px-4885-8m
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb2 kmod-usb-ohci \
 	kmod-usb-ledtrig-usbport kmod-leds-gpio
   SUPPORTED_DEVICES += px-4885-8M
+  DEFAULT := n
 endef
 TARGET_DEVICES += 7links_px-4885-8m
 
@@ -53,6 +54,7 @@ define Device/8devices_carambola
   DEVICE_MODEL := Carambola
   DEVICE_PACKAGES :=
   SUPPORTED_DEVICES += carambola
+  DEFAULT := n
 endef
 TARGET_DEVICES += 8devices_carambola
 
@@ -62,6 +64,7 @@ define Device/accton_wr6202
   DEVICE_VENDOR := Accton
   DEVICE_MODEL := WR6202
   SUPPORTED_DEVICES += wr6202
+  DEFAULT := n
 endef
 TARGET_DEVICES += accton_wr6202
 
@@ -81,6 +84,7 @@ define Device/alfa-network_w502u
   DEVICE_VENDOR := ALFA
   DEVICE_MODEL := Networks W502U
   SUPPORTED_DEVICES += w502u
+  DEFAULT := n
 endef
 TARGET_DEVICES += alfa-network_w502u
 
@@ -104,6 +108,7 @@ define Device/allnet_all0256n-8m
   DEVICE_VARIANT := 8M
   DEVICE_PACKAGES := rssileds
   SUPPORTED_DEVICES += all0256n-8M
+  DEFAULT := n
 endef
 TARGET_DEVICES += allnet_all0256n-8m
 
@@ -127,6 +132,7 @@ define Device/allnet_all5003
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport \
 	kmod-i2c-gpio kmod-hwmon-lm92 kmod-gpio-pcf857x
   SUPPORTED_DEVICES += all5003
+  DEFAULT := n
 endef
 TARGET_DEVICES += allnet_all5003
 
@@ -138,6 +144,7 @@ define Device/alphanetworks_asl26555-16m
   DEVICE_VARIANT := 16M
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += asl26555 asl26555-16M
+  DEFAULT := n
 endef
 TARGET_DEVICES += alphanetworks_asl26555-16m
 
@@ -148,6 +155,7 @@ define Device/alphanetworks_asl26555-8m
   DEVICE_MODEL := ASL26555
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += asl26555 asl26555-8M
+  DEFAULT := n
 endef
 TARGET_DEVICES += alphanetworks_asl26555-8m
 
@@ -159,6 +167,7 @@ define Device/arcwireless_freestation5
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-rt2500-usb kmod-rt2800-usb \
 	kmod-rt2x00-usb
   SUPPORTED_DEVICES += freestation5
+  DEFAULT := n
 endef
 TARGET_DEVICES += arcwireless_freestation5
 
@@ -201,6 +210,7 @@ define Device/asiarf_awm002-evb-8m
   DEVICE_VARIANT := 8M
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-i2c-gpio
   SUPPORTED_DEVICES += awm002-evb-8M
+  DEFAULT := n
 endef
 TARGET_DEVICES += asiarf_awm002-evb-8m
 
@@ -232,6 +242,7 @@ define Device/asus_rt-n13u
   DEVICE_MODEL := RT-N13U
   DEVICE_PACKAGES := kmod-leds-gpio kmod-rt2800-pci kmod-usb-dwc2
   SUPPORTED_DEVICES += rt-n13u
+  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n13u
 
@@ -262,6 +273,7 @@ define Device/aximcom_mr-102n
   DEVICE_VENDOR := AXIMCom
   DEVICE_MODEL := MR-102N
   SUPPORTED_DEVICES += mr-102n
+  DEFAULT := n
 endef
 TARGET_DEVICES += aximcom_mr-102n
 
@@ -274,6 +286,7 @@ define Device/aztech_hw550-3g
   DEVICE_ALT0_MODEL := ALL0239-3G
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += hw550-3g
+  DEFAULT := n
 endef
 TARGET_DEVICES += aztech_hw550-3g
 
@@ -285,6 +298,7 @@ define Device/belkin_f5d8235-v2
   DEVICE_VARIANT := v2
   DEVICE_PACKAGES := kmod-switch-rtl8366rb
   SUPPORTED_DEVICES += f5d8235-v2
+  DEFAULT := n
 endef
 TARGET_DEVICES += belkin_f5d8235-v2
 
@@ -294,6 +308,7 @@ define Device/belkin_f7c027
   DEVICE_VENDOR := Belkin
   DEVICE_MODEL := F7C027
   SUPPORTED_DEVICES += f7c027
+  DEFAULT := n
 endef
 TARGET_DEVICES += belkin_f7c027
 
@@ -320,6 +335,7 @@ define Device/dlink_dap-1350
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DAP-1350
   SUPPORTED_DEVICES += dap-1350
+  DEFAULT := n
 endef
 TARGET_DEVICES += dlink_dap-1350
 
@@ -369,6 +385,7 @@ define Device/dlink_dir-300-b7
   DEVICE_MODEL := DIR-300
   DEVICE_VARIANT := B7
   SUPPORTED_DEVICES += dir-300-b7
+  DEFAULT := n
 endef
 TARGET_DEVICES += dlink_dir-300-b7
 
@@ -379,6 +396,7 @@ define Device/dlink_dir-320-b1
   DEVICE_MODEL := DIR-320
   DEVICE_VARIANT := B1
   SUPPORTED_DEVICES += dir-320-b1
+  DEFAULT := n
 endef
 TARGET_DEVICES += dlink_dir-320-b1
 
@@ -445,6 +463,7 @@ define Device/dlink_dir-620-a1
   DEVICE_MODEL := DIR-620
   DEVICE_VARIANT := A1
   SUPPORTED_DEVICES += dir-620-a1
+  DEFAULT := n
 endef
 TARGET_DEVICES += dlink_dir-620-a1
 
@@ -455,6 +474,7 @@ define Device/dlink_dir-620-d1
   DEVICE_MODEL := DIR-620
   DEVICE_VARIANT := D1
   SUPPORTED_DEVICES += dir-620-d1
+  DEFAULT := n
 endef
 TARGET_DEVICES += dlink_dir-620-d1
 
@@ -474,6 +494,7 @@ define Device/dlink_dwr-512-b
   IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
   IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
   SUPPORTED_DEVICES += dwr-512-b
+  DEFAULT := n
 endef
 TARGET_DEVICES += dlink_dwr-512-b
 
@@ -484,6 +505,7 @@ define Device/easyacc_wizard-8800
   DEVICE_VENDOR := EasyAcc
   DEVICE_MODEL := WIZARD 8800
   SUPPORTED_DEVICES += wizard8800
+  DEFAULT := n
 endef
 TARGET_DEVICES += easyacc_wizard-8800
 
@@ -558,6 +580,7 @@ define Device/hame_mpr-a2
   DEVICE_VARIANT := A2
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2
   SUPPORTED_DEVICES += mpr-a2
+  DEFAULT := n
 endef
 TARGET_DEVICES += hame_mpr-a2
 
@@ -611,6 +634,7 @@ define Device/huawei_hg255d
   DEVICE_VENDOR := HuaWei
   DEVICE_MODEL := HG255D
   SUPPORTED_DEVICES += hg255d
+  DEFAULT := n
 endef
 TARGET_DEVICES += huawei_hg255d
 
@@ -623,6 +647,7 @@ define Device/intenso_memory2move
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-storage kmod-scsi-core kmod-fs-ext4 \
 	kmod-fs-vfat block-mount
   SUPPORTED_DEVICES += m2m
+  DEFAULT := n
 endef
 TARGET_DEVICES += intenso_memory2move
 
@@ -668,6 +693,7 @@ define Device/mofinetwork_mofi3500-3gn
   DEVICE_VENDOR := MoFi Network
   DEVICE_MODEL := MOFI3500-3GN
   SUPPORTED_DEVICES += mofi3500-3gn
+  DEFAULT := n
 endef
 TARGET_DEVICES += mofinetwork_mofi3500-3gn
 
@@ -730,6 +756,7 @@ define Device/nexx_wt1520-8m
   DEVICE_MODEL := WT1520
   DEVICE_VARIANT := 8M
   SUPPORTED_DEVICES += wt1520-8M
+  DEFAULT := n
 endef
 TARGET_DEVICES += nexx_wt1520-8m
 
@@ -741,6 +768,7 @@ define Device/nixcore_x1-16m
   DEVICE_VARIANT := 16M
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-i2c-ralink kmod-spi-dev
   SUPPORTED_DEVICES += nixcore-x1 nixcore-x1-16M
+  DEFAULT := n
 endef
 TARGET_DEVICES += nixcore_x1-16m
 
@@ -752,6 +780,7 @@ define Device/nixcore_x1-8m
   DEVICE_VARIANT := 8M
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-i2c-ralink kmod-spi-dev
   SUPPORTED_DEVICES += nixcore-x1 nixcore-x1-8M
+  DEFAULT := n
 endef
 TARGET_DEVICES += nixcore_x1-8m
 
@@ -763,6 +792,7 @@ define Device/olimex_rt5350f-olinuxino
   DEVICE_MODEL := RT5350F-OLinuXino
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-i2c-ralink kmod-spi-dev
   SUPPORTED_DEVICES += rt5350f-olinuxino
+  DEFAULT := n
 endef
 TARGET_DEVICES += olimex_rt5350f-olinuxino
 
@@ -774,6 +804,7 @@ define Device/olimex_rt5350f-olinuxino-evb
   DEVICE_MODEL := RT5350F-OLinuXino-EVB
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-i2c-ralink kmod-spi-dev
   SUPPORTED_DEVICES += rt5350f-olinuxino-evb
+  DEFAULT := n
 endef
 TARGET_DEVICES += olimex_rt5350f-olinuxino-evb
 
@@ -792,6 +823,7 @@ define Device/omnima_miniembwifi
   DEVICE_VENDOR := Omnima
   DEVICE_MODEL := MiniEMBWiFi
   SUPPORTED_DEVICES += miniembwifi
+  DEFAULT := n
 endef
 TARGET_DEVICES += omnima_miniembwifi
 
@@ -835,6 +867,7 @@ define Device/planex_mzk-wdpr
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := MZK-WDPR
   SUPPORTED_DEVICES += mzk-wdpr
+  DEFAULT := n
 endef
 TARGET_DEVICES += planex_mzk-wdpr
 
@@ -887,6 +920,7 @@ define Device/poray_m4-8m
   DEVICE_VARIANT := 8M
   DEVICE_PACKAGES := kmod-usb2
   SUPPORTED_DEVICES += m4-8M
+  DEFAULT := n
 endef
 TARGET_DEVICES += poray_m4-8m
 
@@ -900,6 +934,7 @@ define Device/poray_x5
   DEVICE_MODEL := X5/X6
   DEVICE_PACKAGES := kmod-usb2
   SUPPORTED_DEVICES += x5
+  DEFAULT := n
 endef
 TARGET_DEVICES += poray_x5
 
@@ -913,6 +948,7 @@ define Device/poray_x8
   DEVICE_MODEL := X8
   DEVICE_PACKAGES := kmod-usb2
   SUPPORTED_DEVICES += x8
+  DEFAULT := n
 endef
 TARGET_DEVICES += poray_x8
 
@@ -923,6 +959,7 @@ define Device/prolink_pwh2004
   DEVICE_MODEL := PWH2004
   DEVICE_PACKAGES :=
   SUPPORTED_DEVICES += pwh2004
+  DEFAULT := n
 endef
 TARGET_DEVICES += prolink_pwh2004
 
@@ -973,6 +1010,7 @@ define Device/teltonika_rut5xx
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT5XX
   SUPPORTED_DEVICES += rut5xx
+  DEFAULT := n
 endef
 TARGET_DEVICES += teltonika_rut5xx
 
@@ -1042,6 +1080,7 @@ define Device/trendnet_tew-714tru
   DEVICE_VENDOR := TRENDnet
   DEVICE_MODEL := TEW-714TRU
   SUPPORTED_DEVICES += tew-714tru
+  DEFAULT := n
 endef
 TARGET_DEVICES += trendnet_tew-714tru
 
@@ -1077,6 +1116,7 @@ define Device/unbranded_wr512-3gn-8m
   DEVICE_MODEL := WR512-3GN
   DEVICE_VARIANT := 8M
   SUPPORTED_DEVICES += wr512-3gn-8M
+  DEFAULT := n
 endef
 TARGET_DEVICES += unbranded_wr512-3gn-8m
 
@@ -1108,6 +1148,7 @@ define Device/upvel_ur-336un
   DEVICE_MODEL := UR-336UN
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += ur-336un
+  DEFAULT := n
 endef
 TARGET_DEVICES += upvel_ur-336un
 
@@ -1119,6 +1160,7 @@ define Device/vocore_vocore-16m
   DEVICE_VARIANT := 16M
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-i2c-ralink kmod-spi-dev
   SUPPORTED_DEVICES += vocore vocore-16M
+  DEFAULT := n
 endef
 TARGET_DEVICES += vocore_vocore-16m
 
@@ -1130,6 +1172,7 @@ define Device/vocore_vocore-8m
   DEVICE_VARIANT := 8M
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-i2c-ralink kmod-spi-dev
   SUPPORTED_DEVICES += vocore vocore-8M
+  DEFAULT := n
 endef
 TARGET_DEVICES += vocore_vocore-8m
 
@@ -1149,6 +1192,7 @@ define Device/wiznet_wizfi630a
   DEVICE_VENDOR := WIZnet
   DEVICE_MODEL := WizFi630A
   SUPPORTED_DEVICES += wizfi630a
+  DEFAULT := n
 endef
 TARGET_DEVICES += wiznet_wizfi630a
 
@@ -1158,6 +1202,7 @@ define Device/zorlik_zl5900v2
   DEVICE_VENDOR := Zorlik
   DEVICE_MODEL := ZL5900V2
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2
+  DEFAULT := n
 endef
 TARGET_DEVICES += zorlik_zl5900v2
 
@@ -1180,6 +1225,7 @@ define Device/zyxel_keenetic
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ehci kmod-usb-ledtrig-usbport \
 	kmod-usb-dwc2
   SUPPORTED_DEVICES += kn
+  DEFAULT := n
 endef
 TARGET_DEVICES += zyxel_keenetic
 
@@ -1190,6 +1236,7 @@ define Device/zyxel_keenetic-4g-b
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := Keenetic 4G
   DEVICE_VARIANT := B
+  DEFAULT := n
 endef
 TARGET_DEVICES += zyxel_keenetic-4g-b
 
@@ -1200,6 +1247,7 @@ define Device/zyxel_keenetic-lite-b
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := Keenetic Lite
   DEVICE_VARIANT := B
+  DEFAULT := n
 endef
 TARGET_DEVICES += zyxel_keenetic-lite-b
 

--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -72,6 +72,7 @@ define Device/loewe_wmdr-143n
   DEVICE_VENDOR := Loewe
   DEVICE_MODEL := WMDR-143N
   SUPPORTED_DEVICES += wmdr-143n
+  DEFAULT := n
 endef
 TARGET_DEVICES += loewe_wmdr-143n
 


### PR DESCRIPTION
I suggest disabling the build of devices with too little amount of ram before the new release.
People who still need current openwrt versions for these devices probably have to build them themselves in order for them to run with this little amount of ram. (or stay on older releases instead)
Feedback is welcome.

This change hopefully prevents issues like this one from being reported:
https://github.com/openwrt/openwrt/issues/12554
Let's save people from themselves and free (some) buildbot ressources at the same time.

I used the ToH as my primary source but I also looked up lots of devices for some of the targets, when they weren't present in the ToH.
I most certainly missed a few 32M devices (due to missing ToH entries) but these should be most of them.
I was surprised to find 8M and 16M RAM devices that are still being built on a daily basis.

I couldn't find any ram specs on the following devices:
D-Link DWL-3150: amount of ram unknown, likely only 16M like the others (last remaining device in subtarget bcm47xx/legacy)
Argus ATP-52B, Omnima MiniEMBWiFi, Hauppauge Broadway, NexAira Business Class II : amount of ram unknown (subtarget ramips/rt3050x)
