### PR TITLE
Revert "feeds: use git-src-full to allow Git versioning"

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,8 +1,8 @@
-src-git-full packages https://git.openwrt.org/feed/packages.git
-src-git-full luci https://git.openwrt.org/project/luci.git
-src-git-full routing https://git.openwrt.org/feed/routing.git
-src-git-full telephony https://git.openwrt.org/feed/telephony.git
-#src-git-full video https://github.com/openwrt/video.git
-#src-git-full targets https://github.com/openwrt/targets.git
-#src-git-full oldpackages http://git.openwrt.org/packages.git
+src-git packages https://git.openwrt.org/feed/packages.git
+src-git luci https://git.openwrt.org/project/luci.git
+src-git routing https://git.openwrt.org/feed/routing.git
+src-git telephony https://git.openwrt.org/feed/telephony.git
+#src-git video https://github.com/openwrt/video.git
+#src-git targets https://github.com/openwrt/targets.git
+#src-git oldpackages http://git.openwrt.org/packages.git
 #src-link custom /usr/src/openwrt/custom-feed


### PR DESCRIPTION
This reverts commit 7fae1e5677e9bb4979c8d4ac99be4de6955b13d0 as it should be no longer necessary to do a full clone since commit 48ed07bc0b94 ("treewide: replace AUTORELEASE with real PKG_RELEASE").

Suggested-by: Thibaut VARÈNE <hacks@slashdirt.org>
Cc: @aparcar 