### PR TITLE
ath79: add suport for COMFAST CF-E380AC v2

### DIFF
--- a/target/linux/ath79/dts/qca9558_comfast_cf-e380ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_comfast_cf-e380ac-v2.dts
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "comfast,cf-e380ac-v2", "qca,qca9558";
+	model = "COMFAST CF-E380AC";
+
+	aliases {
+		serial0 = &uart;
+		label-mac-device = &eth1;
+		led-boot = &led_lan;
+		led-failsafe = &led_lan;
+		led-upgrade = &led_lan;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		led_lan: lan {
+			label = "green:lan";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "red:wlan5g";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		
+		gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		hw_margin_ms = <1200>;
+		always-running;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	mtd-mac-address = <&art 0x0>;
+};
+
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			art: partition@40000 {
+				label = "art";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0x0fa0000>;
+			};
+
+			partition@ff0000 {
+				label = "art-backup";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+
+	pll-data = <0xbe000000 0xb0000101 0xb0001313>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&wdt {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <10>;
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -445,6 +445,7 @@ tplink,cpe510-v3)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:link3" "wlan0" "51" "100" "-50" "13"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:link4" "wlan0" "76" "100" "-75" "13"
 	;;
+comfast,cf-e380ac-v2|\
 tplink,tl-wr902ac-v1)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
 	ucidef_set_led_netdev "internet" "Internet" "green:internet" "eth0"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -27,6 +27,7 @@ ath79_setup_interfaces()
 	avm,fritzdvbc|\
 	comfast,cf-wr752ac-v1|\
 	comfast,cf-e130n-v2|\
+	comfast,cf-e380ac-v2|\
 	devolo,dvl1200i|\
 	devolo,dvl1750c|\
 	devolo,dvl1750i|\
@@ -748,6 +749,7 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_text board_data 0x480)
 		label_mac=$wan_mac
 		;;
+	comfast,cf-e380ac-v2|\	
 	netgear,wndr3700|\
 	netgear,wndr3700-v2|\
 	netgear,wndr3800|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -13,6 +13,7 @@ case "$FIRMWARE" in
 	allnet,all-wap02860ac|\
 	araknis,an-500-ap-i-ac|\
 	araknis,an-700-ap-i-ac|\
+	comfast,cf-e380ac-v2|\
 	engenius,enstationac-v1|\
 	glinet,gl-x750|\
 	watchguard,ap300)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -740,6 +740,17 @@ define Device/comfast_cf-e375ac
 endef
 TARGET_DEVICES += comfast_cf-e375ac
 
+define Device/comfast_cf-e380ac-v2
+  SOC := qca9558
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-E380AC
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 \
+	kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  IMAGE_SIZE := 16000k
+endef
+TARGET_DEVICES += comfast_cf-e380ac-v2
+
 define Device/comfast_cf-e5
   SOC := qca9531
   DEVICE_VENDOR := COMFAST


### PR DESCRIPTION
COMFAST CF-E380AC v2 is a ceiling mount AP with PoE support, based on Qualcomm/Atheros QCA9558+QCA9880+AR8035.

There are two versions of this model, with different RAM and U-Boot MTD partition sizes:
- v1: 128 MB of RAM, 128 KB U-Boot image size
- v2: 256 MB of RAM, 256 KB U-Boot image size

The version number is available only inside the vendor GUI, hardware and markings are the same.

Short specification:

- 720/600/200 MHz (CPU/DDR/AHB)
- 1x 10/100/1000 Mbps Ethernet, with PoE support
- 128 or 256 MB of RAM (DDR2)
- 16 MB of FLASH
- 3T3R 2.4 GHz, with external PA (SE2576L), up to 28 dBm
- 3T3R 5 GHz, with external PA (SE5003L1), up to 30 dBm
- 6x internal antennas
- 1x RGB LED, 1x button
- UART (T11), LEDs/GPIO (J7) and USB (T12) headers on PCB
- external watchdog (Pericon Technology PT7A7514)

COMFAST MAC addresses :
Though the OEM firmware has four addresses in the usual locations, it appears that the assigned addresses are just incremented in a different way:

Interface    address    location
Lan              *:00            0x0
2.4g             *:0A           n/a (0x0 + 10)
5g                *:02           0x6

Unused Addresses found in ART hex dump
address    location
*:01           0x1002
*:03           0x5006

To keep code consistency the MAC address assignments are made based on increments of the one found in 0x0;

Signed-off-by: Joao Henrique Albuquerque <joaohccalbu@gmail.com>
