### PR TITLE
CI: check-kernel-patches: use buildbot user on git diff check

### DIFF
--- a/.github/workflows/check-kernel-patches.yml
+++ b/.github/workflows/check-kernel-patches.yml
@@ -85,10 +85,6 @@ jobs:
         run: |
           chown -R buildbot:buildbot openwrt
 
-      - name: Opt-out from Git stricter repository ownership checks
-        run: |
-          git config --global --add safe.directory '*'
-
       - name: Initialization environment
         run: |
           TARGET=$(echo ${{ inputs.target }} | cut -d "/" -f 1)
@@ -138,6 +134,7 @@ jobs:
         run: make target/linux/refresh V=s
 
       - name: Validate Refreshed Kernel Patches
+        shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
         run: |
           . .github/workflows/scripts/ci_helpers.sh


### PR DESCRIPTION
Use buildbot user on git diff check instead of using git config safe directory.

This should accomplish the same result but should be a better approach following safe practice enforced by git.

Fixes: a7747e8670cb ("ci: fix check kernel patches job")