### PR TITLE
lantiq: add patches headers

### DIFF
--- a/target/linux/lantiq/patches-5.15/0101-find_active_root.patch
+++ b/target/linux/lantiq/patches-5.15/0101-find_active_root.patch
@@ -1,3 +1,13 @@
+From 2c82524000cca691c89c9fda251b55ef04eabcb6 Mon Sep 17 00:00:00 2001
+From: Mathias Kresin <openwrt@kresin.me>
+Date: Mon, 2 May 2016 18:50:00 +0000
+Subject: [PATCH] find active root
+
+Signed-off-by: Mathias Kresin <openwrt@kresin.me>
+---
+ drivers/mtd/parsers/ofpart_core.c | 49 ++++++++++++++++++++++++++++++-
+ 1 file changed, 48 insertions(+), 1 deletion(-)
+
 --- a/drivers/mtd/parsers/ofpart_core.c
 +++ b/drivers/mtd/parsers/ofpart_core.c
 @@ -38,6 +38,38 @@ static bool node_has_compatible(struct d

--- a/target/linux/lantiq/patches-5.15/0151-lantiq-ifxmips_pcie-use-of.patch
+++ b/target/linux/lantiq/patches-5.15/0151-lantiq-ifxmips_pcie-use-of.patch
@@ -1,3 +1,26 @@
+From 1d1885f4a7abd7272f47b835b03d8662fb981d19 Mon Sep 17 00:00:00 2001
+From: Eddi De Pieri <eddi@depieri.net>
+Date: Tue, 14 Oct 2014 11:04:00 +0000
+Subject: [PATCH] MIPS: lantiq: ifxmips_pcie: use of
+
+Signed-off-by: Eddi De Pieri <eddi@depieri.net>
+---
+ arch/mips/pci/Makefile           |   2 +-
+ arch/mips/pci/ifxmips_pcie.c     | 151 +++++++++++++++++++++++++++----
+ arch/mips/pci/ifxmips_pcie_vr9.h | 105 ---------------------
+ 3 files changed, 133 insertions(+), 125 deletions(-)
+
+--- a/arch/mips/pci/Makefile
++++ b/arch/mips/pci/Makefile
+@@ -43,7 +43,7 @@ obj-$(CONFIG_PCI_LANTIQ)	+= pci-lantiq.o
+ obj-$(CONFIG_SOC_MT7620)	+= pci-mt7620.o
+ obj-$(CONFIG_SOC_RT288X)	+= pci-rt2880.o
+ obj-$(CONFIG_SOC_RT3883)	+= pci-rt3883.o
+-obj-$(CONFIG_PCIE_LANTIQ)	+= ifxmips_pcie_phy.o ifxmips_pcie.o fixup-lantiq-pcie.o
++obj-$(CONFIG_PCIE_LANTIQ)	+= ifxmips_pcie.o fixup-lantiq-pcie.o
+ obj-$(CONFIG_PCIE_LANTIQ_MSI)	+= pcie-lantiq-msi.o
+ obj-$(CONFIG_TANBAC_TB0219)	+= fixup-tb0219.o
+ obj-$(CONFIG_TANBAC_TB0226)	+= fixup-tb0226.o
 --- a/arch/mips/pci/ifxmips_pcie.c
 +++ b/arch/mips/pci/ifxmips_pcie.c
 @@ -16,8 +16,15 @@
@@ -374,14 +397,3 @@
  static inline void pcie_core_pmu_setup(int pcie_port)
  {
  	struct clk *clk;
---- a/arch/mips/pci/Makefile
-+++ b/arch/mips/pci/Makefile
-@@ -43,7 +43,7 @@ obj-$(CONFIG_PCI_LANTIQ)	+= pci-lantiq.o
- obj-$(CONFIG_SOC_MT7620)	+= pci-mt7620.o
- obj-$(CONFIG_SOC_RT288X)	+= pci-rt2880.o
- obj-$(CONFIG_SOC_RT3883)	+= pci-rt3883.o
--obj-$(CONFIG_PCIE_LANTIQ)	+= ifxmips_pcie_phy.o ifxmips_pcie.o fixup-lantiq-pcie.o
-+obj-$(CONFIG_PCIE_LANTIQ)	+= ifxmips_pcie.o fixup-lantiq-pcie.o
- obj-$(CONFIG_PCIE_LANTIQ_MSI)	+= pcie-lantiq-msi.o
- obj-$(CONFIG_TANBAC_TB0219)	+= fixup-tb0219.o
- obj-$(CONFIG_TANBAC_TB0226)	+= fixup-tb0226.o

--- a/target/linux/lantiq/patches-5.15/0152-lantiq-VPE.patch
+++ b/target/linux/lantiq/patches-5.15/0152-lantiq-VPE.patch
@@ -1,3 +1,18 @@
+From 4d48a3d1ef6f8d036bd926e3c1f70b56fcc679b2 Mon Sep 17 00:00:00 2001
+From: Stefan Koch <stefan.koch10@gmail.com>
+Date: Thu, 20 Oct 2016 21:32:00 +0200
+Subject: [PATCH] lantiq: vpe
+
+Signed-off-by: Stefan Koch <stefan.koch10@gmail.com>
+---
+ arch/mips/Kconfig                  |  6 ++++
+ arch/mips/include/asm/mipsmtregs.h |  5 ++++
+ arch/mips/include/asm/vpe.h        |  9 ++++++
+ arch/mips/kernel/vpe-mt.c          | 47 ++++++++++++++++++++++++++++++
+ arch/mips/kernel/vpe.c             | 35 ++++++++++++++++++++++
+ arch/mips/lantiq/prom.c            |  4 +++
+ 6 files changed, 106 insertions(+)
+
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
 @@ -2429,6 +2429,12 @@ config MIPS_VPE_LOADER
@@ -13,6 +28,27 @@
  config MIPS_VPE_LOADER_CMP
  	bool
  	default "y"
+--- a/arch/mips/include/asm/mipsmtregs.h
++++ b/arch/mips/include/asm/mipsmtregs.h
+@@ -32,6 +32,9 @@
+ #define read_c0_vpeconf1()		__read_32bit_c0_register($1, 3)
+ #define write_c0_vpeconf1(val)		__write_32bit_c0_register($1, 3, val)
+ 
++#define read_c0_vpeopt()		__read_32bit_c0_register($1, 7)
++#define write_c0_vpeopt(val)		__write_32bit_c0_register($1, 7, val)
++
+ #define read_c0_tcstatus()		__read_32bit_c0_register($2, 1)
+ #define write_c0_tcstatus(val)		__write_32bit_c0_register($2, 1, val)
+ 
+@@ -378,6 +381,8 @@ do {									\
+ #define write_vpe_c0_vpeconf0(val)	mttc0(1, 2, val)
+ #define read_vpe_c0_vpeconf1()		mftc0(1, 3)
+ #define write_vpe_c0_vpeconf1(val)	mttc0(1, 3, val)
++#define read_vpe_c0_vpeopt()		mftc0(1, 7)
++#define write_vpe_c0_vpeopt(val)	mttc0(1, 7, val)
+ #define read_vpe_c0_count()		mftc0(9, 0)
+ #define write_vpe_c0_count(val)		mttc0(9, 0, val)
+ #define read_vpe_c0_status()		mftc0(12, 0)
 --- a/arch/mips/include/asm/vpe.h
 +++ b/arch/mips/include/asm/vpe.h
 @@ -124,4 +124,13 @@ void cleanup_tc(struct tc *tc);
@@ -157,24 +193,3 @@
  
  int ltq_soc_type(void)
  {
---- a/arch/mips/include/asm/mipsmtregs.h
-+++ b/arch/mips/include/asm/mipsmtregs.h
-@@ -32,6 +32,9 @@
- #define read_c0_vpeconf1()		__read_32bit_c0_register($1, 3)
- #define write_c0_vpeconf1(val)		__write_32bit_c0_register($1, 3, val)
- 
-+#define read_c0_vpeopt()		__read_32bit_c0_register($1, 7)
-+#define write_c0_vpeopt(val)		__write_32bit_c0_register($1, 7, val)
-+
- #define read_c0_tcstatus()		__read_32bit_c0_register($2, 1)
- #define write_c0_tcstatus(val)		__write_32bit_c0_register($2, 1, val)
- 
-@@ -378,6 +381,8 @@ do {									\
- #define write_vpe_c0_vpeconf0(val)	mttc0(1, 2, val)
- #define read_vpe_c0_vpeconf1()		mftc0(1, 3)
- #define write_vpe_c0_vpeconf1(val)	mttc0(1, 3, val)
-+#define read_vpe_c0_vpeopt()		mftc0(1, 7)
-+#define write_vpe_c0_vpeopt(val)	mttc0(1, 7, val)
- #define read_vpe_c0_count()		mftc0(9, 0)
- #define write_vpe_c0_count(val)		mttc0(9, 0, val)
- #define read_vpe_c0_status()		mftc0(12, 0)

--- a/target/linux/lantiq/patches-5.15/0154-lantiq-pci-bar11mask-fix.patch
+++ b/target/linux/lantiq/patches-5.15/0154-lantiq-pci-bar11mask-fix.patch
@@ -1,3 +1,13 @@
+From 3c92a781de062064e36b867c0ab22f9aba48f3d3 Mon Sep 17 00:00:00 2001
+From: Eddi De Pieri <eddi@depieri.net>
+Date: Tue, 8 Nov 2016 17:38:00 +0100
+Subject: [PATCH] lantiq: pci: bar11mask fix
+
+Signed-off-by: Eddi De Pieri <eddi@depieri.net>
+---
+ arch/mips/pci/pci-lantiq.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
 --- a/arch/mips/pci/pci-lantiq.c
 +++ b/arch/mips/pci/pci-lantiq.c
 @@ -59,6 +59,8 @@

--- a/target/linux/lantiq/patches-5.15/0155-lantiq-VPE-nosmp.patch
+++ b/target/linux/lantiq/patches-5.15/0155-lantiq-VPE-nosmp.patch
@@ -1,3 +1,13 @@
+From 07ce9e9bc4dcd5ac4728e587901112eef95bbe7b Mon Sep 17 00:00:00 2001
+From: Stefan Koch <stefan.koch10@gmail.com>
+Date: Mon, 13 Mar 2017 23:42:00 +0100
+Subject: [PATCH] lantiq: vpe nosmp
+
+Signed-off-by: Stefan Koch <stefan.koch10@gmail.com>
+---
+ arch/mips/kernel/vpe-mt.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
 --- a/arch/mips/kernel/vpe-mt.c
 +++ b/arch/mips/kernel/vpe-mt.c
 @@ -132,7 +132,10 @@ int vpe_run(struct vpe *v)

--- a/target/linux/lantiq/patches-5.15/0160-owrt-lantiq-multiple-flash.patch
+++ b/target/linux/lantiq/patches-5.15/0160-owrt-lantiq-multiple-flash.patch
@@ -1,3 +1,13 @@
+From ebaae1cd68cd79c7eee67c9c5c0fa45809e84525 Mon Sep 17 00:00:00 2001
+From: Maikel Bloemendal <openwrt@maikelenyvonne.nl>
+Date: Fri, 14 Nov 2014 17:06:00 +0000
+Subject: [PATCH] owrt: lantiq: multiple flash
+
+Signed-off-by: Maikel Bloemendal <openwrt@maikelenyvonne.nl>
+---
+ drivers/mtd/maps/lantiq-flash.c | 168 +++++++++++++++++++++-----------
+ 1 file changed, 109 insertions(+), 59 deletions(-)
+
 --- a/drivers/mtd/maps/lantiq-flash.c
 +++ b/drivers/mtd/maps/lantiq-flash.c
 @@ -17,6 +17,7 @@

--- a/target/linux/lantiq/patches-5.15/0300-MTD-cfi-cmdset-0001-disable-buffered-writes.patch
+++ b/target/linux/lantiq/patches-5.15/0300-MTD-cfi-cmdset-0001-disable-buffered-writes.patch
@@ -1,3 +1,13 @@
+From 5e93c85ac3e5626d1aa7e7f9c0a008b2a4224f04 Mon Sep 17 00:00:00 2001
+From: Matti Laakso <malaakso@elisanet.fi>
+Date: Sat, 14 Feb 2015 20:48:00 +0000
+Subject: [PATCH] MTD: cfi_cmdset_0001: disable buffered writes
+
+Signed-off-by: Matti Laakso <malaakso@elisanet.fi>
+---
+ drivers/mtd/chips/cfi_cmdset_0001.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 --- a/drivers/mtd/chips/cfi_cmdset_0001.c
 +++ b/drivers/mtd/chips/cfi_cmdset_0001.c
 @@ -39,7 +39,7 @@

--- a/target/linux/lantiq/patches-5.15/0301-xrx200-add-gphy-clk-src-device-tree-binding.patch
+++ b/target/linux/lantiq/patches-5.15/0301-xrx200-add-gphy-clk-src-device-tree-binding.patch
@@ -1,3 +1,13 @@
+From 5502ef9d40ab20b2ac683660d1565a7c4968bcc8 Mon Sep 17 00:00:00 2001
+From: Mathias Kresin <openwrt@kresin.me>
+Date: Mon, 2 May 2016 18:50:00 +0000
+Subject: [PATCH] xrx200: add gphy clk src device tree binding
+
+Signed-off-by: Mathias Kresin <openwrt@kresin.me>
+---
+ arch/mips/lantiq/xway/sysctrl.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
 --- a/arch/mips/lantiq/xway/sysctrl.c
 +++ b/arch/mips/lantiq/xway/sysctrl.c
 @@ -440,6 +440,20 @@ static void clkdev_add_clkout(void)

--- a/target/linux/lantiq/patches-5.15/0701-NET-lantiq-etop-of-mido.patch
+++ b/target/linux/lantiq/patches-5.15/0701-NET-lantiq-etop-of-mido.patch
@@ -1,3 +1,13 @@
+From 870ed9cae083ff8a60a739ef7e74c5a1800533be Mon Sep 17 00:00:00 2001
+From: Johann Neuhauser <johann@it-neuhauser.de>
+Date: Thu, 17 May 2018 19:12:35 +0200
+Subject: [PATCH] net: lantiq_etop: of mdio
+
+Signed-off-by: Johann Neuhauser <johann@it-neuhauser.de>
+---
+ drivers/net/ethernet/lantiq_etop.c |  555 +++++++++++++++++++++++++-----------
+ 1 file changed, 389 insertions(+), 166 deletions(-)
+
 --- a/drivers/net/ethernet/lantiq_etop.c
 +++ b/drivers/net/ethernet/lantiq_etop.c
 @@ -30,6 +30,7 @@


### PR DESCRIPTION
This commit adds headers to the patches, so they can be applied with the git am command.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
