### PR TITLE
[22.03] ramips: correct page read return value of the mt7621 nand driver

### DIFF
--- a/target/linux/ramips/files/drivers/mtd/nand/raw/mt7621_nand.c
+++ b/target/linux/ramips/files/drivers/mtd/nand/raw/mt7621_nand.c
@@ -1006,7 +1006,7 @@ static int mt7621_nfc_read_page_hwecc(struct nand_chip *nand, uint8_t *buf,
 {
 	struct mt7621_nfc *nfc = nand_get_controller_data(nand);
 	struct mtd_info *mtd = nand_to_mtd(nand);
-	int bitflips = 0;
+	int bitflips = 0, ret = 0;
 	int rc, i;
 
 	nand_read_page_op(nand, page, 0, NULL, 0);
@@ -1031,7 +1031,7 @@ static int mt7621_nfc_read_page_hwecc(struct nand_chip *nand, uint8_t *buf,
 		mt7621_nfc_read_sector_fdm(nfc, i);
 
 		if (rc < 0) {
-			bitflips = -EIO;
+			ret = -EIO;
 			continue;
 		}
 
@@ -1043,10 +1043,11 @@ static int mt7621_nfc_read_page_hwecc(struct nand_chip *nand, uint8_t *buf,
 			dev_dbg(nfc->dev,
 				 "Uncorrectable ECC error at page %d.%d\n",
 				 page, i);
-			bitflips = -EBADMSG;
+			bitflips = nand->ecc.strength + 1;
 			mtd->ecc_stats.failed++;
-		} else if (bitflips >= 0) {
-			bitflips += rc;
+		} else {
+			if (rc > bitflips)
+				bitflips = rc;
 			mtd->ecc_stats.corrected += rc;
 		}
 	}
@@ -1054,6 +1055,9 @@ static int mt7621_nfc_read_page_hwecc(struct nand_chip *nand, uint8_t *buf,
 	mt7621_ecc_decoder_op(nfc, false);
 
 	nfi_write16(nfc, NFI_CON, 0);
+
+	if (ret < 0)
+		return ret;
 
 	return bitflips;
 }


### PR DESCRIPTION
read_page() need to return maximum number of bitflips instead of the accumulated number. Change takes from upstream mt7621 u-boot [1].

 * @read_page:  function to read a page according to the ECC generator
 *              requirements; returns maximum number of bitflips
 *              corrected in any single ECC step, -EIO hw error

[1] https://lore.kernel.org/all/cover.1653015383.git.weijie.gao@mediatek.com/

Signed-off-by: Shiji Yang <yangshiji66@qq.com>
(cherry picked from commit 2fbb91d73ffecc7d033e5bb0b550d664ef9e0f91)

__________

We need this to prevent devices in the 22 release from running into bootloops when badblocks occur in the ubi partition.
Affected are atleast Asus RT-AX53U and RT-AX54.

~~This remains a draft, until I or @Znevna find the time for testing :)~~

EDIT:
I run-tested the patch successfully on my RT-AX53U.
~~But since my device doesn't have any bad blocks, I want to wait for Piotr's feedback :)~~
This was confirmed to be fixing the described issue by Piotr. This is ready to be reviewed and merged now