### PR TITLE
mediatek: MT7981 fixes

### DIFF
--- a/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7981.dtsi
+++ b/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7981.dtsi
@@ -555,14 +555,15 @@
 					"mediatek,mt7981-mmc";
 		reg = <0 0x11230000 0 0x1000>, <0 0x11c20000 0 0x1000>;
 		interrupts = <GIC_SPI 143 IRQ_TYPE_LEVEL_HIGH>;
-		clocks = <&topckgen CLK_TOP_EMMC_208M>,
-				<&topckgen CLK_TOP_EMMC_400M>,
-				<&infracfg CLK_INFRA_MSDC_CK>;
+		clocks = <&infracfg CLK_INFRA_MSDC_CK>,
+			 <&infracfg CLK_INFRA_MSDC_HCK_CK>,
+			 <&infracfg CLK_INFRA_MSDC_66M_CK>,
+			 <&infracfg CLK_INFRA_MSDC_133M_CK>;
 		assigned-clocks = <&topckgen CLK_TOP_EMMC_208M_SEL>,
 				  <&topckgen CLK_TOP_EMMC_400M_SEL>;
 		assigned-clock-parents = <&topckgen CLK_TOP_CB_M_D2>,
 					 <&topckgen CLK_TOP_CB_NET2_D2>;
-		clock-names = "source", "hclk", "source_cg";
+		clock-names = "source", "hclk", "axi_cg", "ahb_cg";
 		status = "disabled";
 	};
 

--- a/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7981.dtsi
+++ b/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7981.dtsi
@@ -640,7 +640,6 @@
 		phys = <&u2port0 PHY_TYPE_USB2>,
 		       <&u3port0 PHY_TYPE_USB3>;
 		vusb33-supply = <&reg_3p3v>;
-		mediatek,u3p-dis-msk = <0x01>;
 		status = "disabled";
 	};
 


### PR DESCRIPTION
 * [x] setup all clocks for eMMC
 * [x] no need to disable USB 3
 * [ ] setup all clocks for I2C (tbd)
 

