### PR TITLE
mac80211: backport merged version of A-MSDU mesh patch

### DIFF
--- a/package/kernel/mac80211/Makefile
+++ b/package/kernel/mac80211/Makefile
@@ -11,7 +11,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=mac80211
 
 PKG_VERSION:=6.1.24
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 # PKG_SOURCE_URL:=@KERNEL/linux/kernel/projects/backports/stable/v5.15.58/
 PKG_SOURCE_URL:=http://mirror2.openwrt.org/sources/
 PKG_HASH:=5d39aca7e34c33cb9b3e366117b2e86841b7bdd37933679d6b1e61be6b150648

--- a/package/kernel/mac80211/patches/subsys/315-v6.3-wifi-mac80211-fix-receiving-A-MSDU-frames-on-mesh-in.patch
+++ b/package/kernel/mac80211/patches/subsys/315-v6.3-wifi-mac80211-fix-receiving-A-MSDU-frames-on-mesh-in.patch
@@ -1,5 +1,6 @@
+From 986e43b19ae9176093da35e0a844e65c8bf9ede7 Mon Sep 17 00:00:00 2001
 From: Felix Fietkau <nbd@nbd.name>
-Date: Tue, 6 Dec 2022 11:15:02 +0100
+Date: Mon, 13 Feb 2023 11:08:54 +0100
 Subject: [PATCH] wifi: mac80211: fix receiving A-MSDU frames on mesh
  interfaces
 
@@ -33,7 +34,15 @@ For locally received packets, the Mesh Control header is stripped away.
 For forwarded packets, a new 802.11 header gets added.
 
 Signed-off-by: Felix Fietkau <nbd@nbd.name>
+Link: https://lore.kernel.org/r/20230213100855.34315-4-nbd@nbd.name
+[fix fortify build error]
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
 ---
+ .../wireless/marvell/mwifiex/11n_rxreorder.c  |   2 +-
+ include/net/cfg80211.h                        |  27 +-
+ net/mac80211/rx.c                             | 350 ++++++++++--------
+ net/wireless/util.c                           | 120 +++---
+ 4 files changed, 297 insertions(+), 202 deletions(-)
 
 --- a/drivers/net/wireless/marvell/mwifiex/11n_rxreorder.c
 +++ b/drivers/net/wireless/marvell/mwifiex/11n_rxreorder.c
@@ -557,7 +566,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +		memcpy(&payload.eth.h_source, mesh_addr, ETH_ALEN);
 +		break;
 +	case MESH_FLAGS_AE_A5_A6:
-+		memcpy(&payload.eth.h_dest, mesh_addr, 2 * ETH_ALEN);
++		memcpy(&payload.eth, mesh_addr, 2 * ETH_ALEN);
 +		break;
 +	default:
 +		break;


### PR DESCRIPTION
Kernel 6.1 now has fortify_memcpy_chk() and it is causing the following warning while trying to compile backports:
```
  CC [M]  /home/robimarko/Building/AX3600/ipq807x-5.15/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/backports-6.1.24/net/wireless/util.o
In file included from ./include/linux/string.h:253,
                 from /home/robimarko/Building/AX3600/ipq807x-5.15/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/backports-6.1.24/backport-include/linux/string.h:3,
                 from ./include/linux/bitmap.h:11,
                 from ./include/linux/cpumask.h:12,
                 from ./include/linux/smp.h:13,
                 from ./arch/arm64/include/asm/arch_timer.h:18,
                 from ./arch/arm64/include/asm/timex.h:8,
                 from ./include/linux/timex.h:67,
                 from ./include/linux/time32.h:13,
                 from ./include/linux/time.h:60,
                 from /home/robimarko/Building/AX3600/ipq807x-5.15/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/backports-6.1.24/backport-include/linux/time.h:3,
                 from ./include/linux/skbuff.h:15,
                 from /home/robimarko/Building/AX3600/ipq807x-5.15/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/backports-6.1.24/backport-include/linux/skbuff.h:3,
                 from ./include/linux/if_ether.h:19,
                 from /home/robimarko/Building/AX3600/ipq807x-5.15/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/backports-6.1.24/backport-include/linux/if_ether.h:3,
                 from ./include/linux/etherdevice.h:20,
                 from /home/robimarko/Building/AX3600/ipq807x-5.15/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/backports-6.1.24/backport-include/linux/etherdevice.h:3,
                 from /home/robimarko/Building/AX3600/ipq807x-5.15/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/backports-6.1.24/net/wireless/util.c:12:
In function 'fortify_memcpy_chk',
    inlined from 'ieee80211_strip_8023_mesh_hdr' at /home/robimarko/Building/AX3600/ipq807x-5.15/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/backports-6.1.24/net/wireless/util.c:590:3:
./include/linux/fortify-string.h:404:25: error: call to '__write_overflow_field' declared with attribute warning: detected write beyond size of field (1st parameter); maybe use struct_group()? [-Werror=attribute-warning]
  404 |                         __write_overflow_field(p_size_field, size);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

This issue was fixed in the final version of
("wifi: mac80211: fix receiving A-MSDU frames on mesh interfaces") that was merged upstream but we have a older version that is using: 
`memcpy(&payload.eth.h_dest, mesh_addr, 2 * ETH_ALEN); `
instead of:
`memcpy(&payload.eth, mesh_addr, 2 * ETH_ALEN);`

So, lets just backport the merged version of patch to fix the issue.
