### PR TITLE
kernel: introduce KERNEL_WERROR config option

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1343,3 +1343,19 @@ config KERNEL_UBIFS_FS_SECURITY
 
 config KERNEL_JFFS2_FS_SECURITY
 	bool "JFFS2 Security Labels"
+
+config KERNEL_WERROR
+	bool "Compile the kernel with warnings as errors"
+	default BUILDBOT
+	default y if GCC_USE_VERSION_12
+	help
+	  A kernel build should not cause any compiler warnings, and this
+	  enables the '-Werror' (for C) and '-Dwarnings' (for Rust) flags
+	  to enforce that rule by default. Certain warnings from other tools
+	  such as the linker may be upgraded to errors with this option as
+	  well.
+
+	  However, if you have a new (or very old) compiler or linker with odd
+	  and unusual warnings, or you have some architecture with problems,
+	  you may need to disable this config option in order to
+	  successfully build the kernel.

--- a/target/linux/generic/config-5.15
+++ b/target/linux/generic/config-5.15
@@ -7472,7 +7472,7 @@ CONFIG_WATCHDOG_OPEN_TIMEOUT=0
 # CONFIG_WD80x3 is not set
 # CONFIG_WDAT_WDT is not set
 # CONFIG_WDTPCI is not set
-CONFIG_WERROR=y
+# CONFIG_WERROR is not set
 # CONFIG_WEXT_CORE is not set
 # CONFIG_WEXT_PRIV is not set
 # CONFIG_WEXT_PROC is not set

--- a/target/linux/generic/config-6.1
+++ b/target/linux/generic/config-6.1
@@ -7731,7 +7731,7 @@ CONFIG_WATCHDOG_OPEN_TIMEOUT=0
 # CONFIG_WD80x3 is not set
 # CONFIG_WDAT_WDT is not set
 # CONFIG_WDTPCI is not set
-CONFIG_WERROR=y
+# CONFIG_WERROR is not set
 # CONFIG_WEXT_CORE is not set
 # CONFIG_WEXT_PRIV is not set
 # CONFIG_WEXT_PROC is not set


### PR DESCRIPTION
In commit b2d1eb717b65 ("generic: 5.15: enable Werror by default for kernel compile") CONFIG_WERROR=y was enabled and all warnings/errors reported with GCC 12 were fixed.

Keeping this in sync with past/future GCC versions is going to be uphill battle, so lets introduce new KERNEL_WERROR config option, enable it by default only for tested/known working combinations and on buildbots.

References: #12687 #12622 #12734