### PR TITLE
CI: ignore master branch for push events

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -17,6 +17,8 @@ on:
       - 'include/kernel*'
       - 'package/kernel/**'
       - 'target/linux/**'
+    branches-ignore:
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -19,6 +19,8 @@ on:
       - 'package/**'
       - 'target/linux/generic/**'
       - 'toolchain/**'
+    branches-ignore:
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/push-containers.yml
+++ b/.github/workflows/push-containers.yml
@@ -12,6 +12,8 @@ on:
       - '.github/workflows/build.yml'
       - '.github/workflows/toolchain.yml'
       - '.github/workflows/Dockerfile.toolchain'
+    branches-ignore:
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -11,6 +11,8 @@ on:
       - '.github/workflows/build.yml'
       - '.github/workflows/toolchain.yml'
       - 'toolchain/**'
+    branches-ignore:
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -13,6 +13,8 @@ on:
       - 'tools/**'
       - '.github/workflows/build-tools.yml'
       - '.github/workflows/tools.yml'
+    branches-ignore:
+      - master
 
 permissions:
   contents: read


### PR DESCRIPTION
Due to problem with migrating from master to main as the default branch and downstream project still requiring the master branch to be present, we currently have for push events double CI runs, one for main and one for master. To solve this ignore any push event to the master branch for every workflow that react on push events.