### PR TITLE
realtek: Fixes for upcomming 6.1

### DIFF
--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/common.c
@@ -6,6 +6,8 @@
 #include <net/nexthop.h>
 #include <net/neighbour.h>
 #include <net/netevent.h>
+#include <linux/etherdevice.h>
+#include <linux/if_vlan.h>
 #include <linux/inetdevice.h>
 #include <linux/rhashtable.h>
 #include <linux/of_net.h>

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <net/dsa.h>
+#include <linux/etherdevice.h>
 #include <linux/if_bridge.h>
 #include <asm/mach-rtl838x/mach-rtl83xx.h>
 

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <asm/mach-rtl838x/mach-rtl83xx.h>
+#include <linux/etherdevice.h>
 #include <linux/iopoll.h>
 #include <net/nexthop.h>
 

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <asm/mach-rtl838x/mach-rtl83xx.h>
+#include <linux/etherdevice.h>
 
 #include "rtl83xx.h"
 

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <asm/mach-rtl838x/mach-rtl83xx.h>
+#include <linux/etherdevice.h>
 #include <linux/inetdevice.h>
 
 #include "rtl83xx.h"

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <asm/mach-rtl838x/mach-rtl83xx.h>
+#include <linux/etherdevice.h>
 
 #include "rtl83xx.h"
 

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/tc.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/tc.c
@@ -2,6 +2,7 @@
 
 #include <net/dsa.h>
 #include <linux/delay.h>
+#include <linux/etherdevice.h>
 #include <linux/netdevice.h>
 #include <net/flow_offload.h>
 #include <linux/rhashtable.h>


### PR DESCRIPTION
To prepare for the comming 6.1 migration, here's a few fixes that'll break 6.1. Best to get them in now, so we get them for 5.15 as well before the 6.1 'copy'.