### PR TITLE
CI: use split target and subtarget in label workflow

### DIFF
--- a/.github/workflows/label-kernel.yml
+++ b/.github/workflows/label-kernel.yml
@@ -20,7 +20,8 @@ jobs:
         env:
           CI_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          echo "$CI_EVENT_LABEL_NAME" | sed -n 's/.*:\(.*\):\(.*\)$/target="\1\/\2"/p' | tee --append $GITHUB_OUTPUT
+          echo "$CI_EVENT_LABEL_NAME" | sed -n 's/.*:\(.*\):\(.*\)$/target="\1"/p' | tee --append $GITHUB_OUTPUT
+          echo "$CI_EVENT_LABEL_NAME" | sed -n 's/.*:\(.*\):\(.*\)$/subtarget="\2"/p' | tee --append $GITHUB_OUTPUT
 
   build_kernel:
     name: Build Kernel with external toolchain
@@ -31,6 +32,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       target: ${{ needs.set_target.outputs.target }}
+      subtarget: ${{ needs.set_target.outputs.subtarget }}
       build_kernel: true
       build_all_kmods: true
 
@@ -43,3 +45,4 @@ jobs:
     uses: ./.github/workflows/check-kernel-patches.yml
     with:
       target: ${{ needs.set_target.outputs.target }}
+      subtarget: ${{ needs.set_target.outputs.subtarget }}

--- a/.github/workflows/label-target.yml
+++ b/.github/workflows/label-target.yml
@@ -20,7 +20,8 @@ jobs:
         env:
           CI_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          echo "$CI_EVENT_LABEL_NAME" | sed -n 's/.*:\(.*\):\(.*\)$/target="\1\/\2"/p' | tee --append $GITHUB_OUTPUT
+          echo "$CI_EVENT_LABEL_NAME" | sed -n 's/.*:\(.*\):\(.*\)$/target="\1"/p' | tee --append $GITHUB_OUTPUT
+          echo "$CI_EVENT_LABEL_NAME" | sed -n 's/.*:\(.*\):\(.*\)$/subtarget="\2"/p' | tee --append $GITHUB_OUTPUT
 
   build_target:
     name: Build target
@@ -31,6 +32,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       target: ${{ needs.set_target.outputs.target }}
+      subtarget: ${{ needs.set_target.outputs.subtarget }}
       build_full: true
       build_all_kmods: true
       build_all_boards: true


### PR DESCRIPTION
With eecc6e48117b ("CI: rework build workflow to have split target and subtarget directly") target and subtarget are split in 2 different variables. Label workflow were not aligned to this change and are currently broken.

Fix them and correctly pass split target and subtarget.

Fixes: eecc6e48117b ("CI: rework build workflow to have split target and subtarget directly")