### PR TITLE
ca-certificates: Update to version 20230311

### DIFF
--- a/package/system/ca-certificates/Makefile
+++ b/package/system/ca-certificates/Makefile
@@ -7,16 +7,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ca-certificates
-PKG_VERSION:=20211016
+PKG_VERSION:=20230311
 PKG_RELEASE:=1
 PKG_MAINTAINER:=
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@DEBIAN/pool/main/c/ca-certificates
-PKG_HASH:=2ae9b6dc5f40c25d6d7fe55e07b54f12a8967d1955d3b7b2f42ee46266eeef88
+PKG_HASH:=83de934afa186e279d1ed08ea0d73f5cf43a6fbfb5f00874b6db3711c64576f3
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
+
+TAR_OPTIONS+= --strip-components 1
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
 define Package/ca-certificates
   SECTION:=base
@@ -33,13 +36,6 @@ define Package/ca-bundle
   PKGARCH:=all
   PROVIDES:=ca-certs
 endef
-
-define Build/Prepare
-	$(DECOMPRESS_CMD) $(HOST_TAR) -C $(PKG_BUILD_DIR) $(TAR_OPTIONS)
-	$(Build/Patch)
-endef
-
-MAKE_PATH := work
 
 define Build/Install
 	mkdir -p \

--- a/package/system/ca-certificates/patches/0001-ca-certificates-fix-python3-cryptography-woes-in-cer.patch
+++ b/package/system/ca-certificates/patches/0001-ca-certificates-fix-python3-cryptography-woes-in-cer.patch
@@ -18,8 +18,8 @@ Reported-by: Chen Minqiang <ptpt52@gmail.com>
 Reported-by: Shane Synan <digitalcircuit36939@gmail.com>
 Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
 ---
---- a/work/mozilla/certdata2pem.py
-+++ b/work/mozilla/certdata2pem.py
+--- a/mozilla/certdata2pem.py
++++ b/mozilla/certdata2pem.py
 @@ -21,16 +21,12 @@
  # USA.
  
@@ -42,8 +42,8 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
          if not obj['CKA_LABEL'] in trust or not trust[obj['CKA_LABEL']]:
              continue
 -
--        cert = x509.load_der_x509_certificate(obj['CKA_VALUE'])
--        if cert.not_valid_after < datetime.datetime.now():
+-        cert = x509.load_der_x509_certificate(bytes(obj['CKA_VALUE']))
+-        if cert.not_valid_after < datetime.datetime.utcnow():
 -            print('!'*74)
 -            print('Trusted but expired certificate found: %s' % obj['CKA_LABEL'])
 -            print('!'*74)


### PR DESCRIPTION
Update the ca-certificates and ca-bundle package from version 20211016 to version 20230311.

```
Debian change-log entry [1]:
|[...]
|[ Đoàn Trần Công Danh ]
|* ca-certificates: compat with non-GNU mktemp (closes: #1000847) |
|[ Ilya Lipnitskiy ]
|* certdata2pem.py: use UTC time when checking cert validity |
|[ Julien Cristau ]
|* Update Mozilla certificate authority bundle to version 2.60
|   The following certificate authorities were added (+):
|   + "Autoridad de Certificacion Firmaprofesional CIF A62634068"
|   + "Certainly Root E1"
|   + "Certainly Root R1"
|   + "D-TRUST BR Root CA 1 2020"
|   + "D-TRUST EV Root CA 1 2020"
|   + "DigiCert TLS ECC P384 Root G5"
|   + "DigiCert TLS RSA4096 Root G5"
|   + "E-Tugra Global Root CA ECC v3"
|   + "E-Tugra Global Root CA RSA v3"
|   + "HARICA TLS ECC Root CA 2021"
|   + "HARICA TLS RSA Root CA 2021"
|   + "HiPKI Root CA - G1"
|   + "ISRG Root X2"
|   + "Security Communication ECC RootCA1"
|   + "Security Communication RootCA3"
|   + "Telia Root CA v2"
|   + "TunTrust Root CA"
|   + "vTrus ECC Root CA"
|   + "vTrus Root CA"
|  The following certificate authorities were removed (-):
|  - "Cybertrust Global Root" (expired)
|  - "EC-ACC"
|  - "GlobalSign Root CA - R2" (expired)
|  - "Hellenic Academic and Research Institutions RootCA 2011"
|  - "Network Solutions Certificate Authority"
|  - "Staat der Nederlanden EV Root CA" (expired)
|* Drop trailing space from debconf template causing misformatting
|  (closes: #980821)
|
|[ Wataru Ashihara ]
|* Make certdata2pem.py compatible with cryptography >= 35 (closes: #1008244)
|[...]

[1]: https://metadata.ftp-master.debian.org/changelogs/main/c/ca-certificates/ca-certificates_20230311_changelog
```