### PR TITLE
ath79: fix 5GHz Wi-Fi on Zyxel NBG6716

### DIFF
--- a/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -21,6 +21,7 @@ case "$FIRMWARE" in
 	zyxel,emg2926-q10a|\
 	zyxel,nbg6716)
 		caldata_extract "art" 0x5000 0x844
+		caldata_validate "4408" || rm /lib/firmware/$FIRMWARE
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) 1)
 		;;
 	esac


### PR DESCRIPTION
Reimplement the fix present in ar71xx[1]

Some NBG6716 do not have ath10k calibration data in flash, only in chip OTP. To determine if flash has a valid calibration data, the first two bytes telling the length of the calibration data are checked against the requested length. If the lengths match, calibration data is valid and read from flash.

[1] 2ea98fc39b21392c1556d6768604f54a578278d4

Closes #10784
____________

This patch requires testing still.

Question for reviewers: Is it ok to simply delete the extracted caldata? This will probably be run on every(!) reboot then (causing nand wear).
Currently other devices use calidata_validate() only in order to check several locations on the same partition. (or in order to use two different caldata_extract functions (ubi and regular) for the same cal location)

Possible solutions, I can think of:
- I could modify caldata_extract() instead so it always validates before extracting.
- I could also modify caldata_validate() so it can extract data itself instead of reading from /lib/firmware.
- Or I can modify caldata_extract() so it extracts into RAM or /tmp/ first before the file is moved to /lib/firmware/
- Maybe I can achieve writing to /tmp/ by placing a symbolic link in /lib/firmware/$FIRMWARE that points to /tmp/$FIRMWARE (instead of modifying caldata.sh)

What is your oppinion?

____
Also: Would it make sense to reintroduce an error message like in the old code?
> ath10kcal_die "no calibration data found in $part"