### PR TITLE
ci: bump buildworker container and check integrity of toolchain tarball 

### DIFF
--- a/.github/workflows/Dockerfile.tools
+++ b/.github/workflows/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM ghcr.io/openwrt/buildbot/buildworker-v3.8.0:v2
+FROM ghcr.io/openwrt/buildbot/buildworker-v3.8.0:v6
 
 COPY --chown=buildbot staging_dir/host /prebuilt_tools/staging_dir/host
 COPY --chown=buildbot build_dir/host /prebuilt_tools/build_dir/host

--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: Build tools
     runs-on: ubuntu-latest
-    container: ghcr.io/openwrt/buildbot/buildworker-v3.8.0:v2
+    container: ghcr.io/openwrt/buildbot/buildworker-v3.8.0:v6
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,13 +263,22 @@ jobs:
           restore-keys: |
             ccache-kernel-${{ inputs.target }}/${{ inputs.subtarget }}-
 
+      - name: Import GPG keys
+        shell: su buildbot -c "sh -e {0}"
+        run: gpg --receive-keys 0xCD84BCED626471F1 0x1D53D1877742E911 0xCD54E82DADB3684D
+
       - name: Download external toolchain/sdk
         if: inputs.build_toolchain == false && steps.parse-toolchain.outputs.toolchain-type != 'internal' && steps.parse-toolchain.outputs.toolchain-type != 'external_container'
         shell: su buildbot -c "sh -e {0}"
         working-directory: openwrt
         run: |
-          wget -O - https://downloads.cdn.openwrt.org/${{ env.TOOLCHAIN_PATH }}/targets/${{ inputs.target }}/${{ inputs.subtarget }}/${{ env.TOOLCHAIN_FILE }}.tar.xz \
-            | tar --xz -xf -
+          wget https://downloads.cdn.openwrt.org/${{ env.TOOLCHAIN_PATH }}/targets/${{ inputs.target }}/${{ inputs.subtarget }}/${{ env.TOOLCHAIN_FILE }}.tar.xz
+          wget https://downloads.cdn.openwrt.org/${{ env.TOOLCHAIN_PATH }}/targets/${{ inputs.target }}/${{ inputs.subtarget }}/sha256sums.asc
+          wget https://downloads.cdn.openwrt.org/${{ env.TOOLCHAIN_PATH }}/targets/${{ inputs.target }}/${{ inputs.subtarget }}/sha256sums
+          gpg --with-fingerprint --verify sha256sums.asc
+          sha256sum --check --ignore-missing sha256sums
+          tar --xz -xf ${{ env.TOOLCHAIN_FILE }}.tar.xz
+          rm ${{ env.TOOLCHAIN_FILE }}.tar.xz sha256sums
 
       - name: Configure testing kernel
         if: inputs.testing == true


### PR DESCRIPTION
### ci: build: verify downloaded toolchain tarball
    
    CDNs are known to ship outdated or corrupted files, if it unpacks
    correctly, it necessarily doesn't mean, that we're using the desired
    content. So lets fix it by checking the tarball as well.
    
    I'm adding GPG checking explicitly, its not needed, but just double
    checking, that everything is working as expected on build
    infrastructure.

###    ci: bump buildworker container to version v6
    
    Its being used by buildbot workers, adds g++-multilib to fix node
    cross-compilation from a 64-bit build machine to 32-bit host.
    
References: https://github.com/openwrt/buildbot/pull/7
