### PR TITLE
ramips: Asus RT-AX53U partition layout change

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -65,8 +65,7 @@
 
 	mediatek,nmbm;
 	mediatek,bmt-remap-range =
-		<0x000000 0x7e0000>,
-		<0x35e0000 0x7800000>;
+		<0x000000 0x7e0000>;
 
 	partitions {
 		compatible = "fixed-partitions";
@@ -116,7 +115,7 @@
 
 		partition@3e0000 {
 			label = "firmware";
-			reg = <0x3e0000 0x3200000>;
+			reg = <0x3e0000 0x7420000>;
 
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
@@ -129,18 +128,8 @@
 
 			partition@400000 {
 				label = "ubi";
-				reg = <0x400000 0x2e00000>;
+				reg = <0x400000 0x7020000>;
 			};
-		};
-
-		partition@35e0000 {
-			label = "firmware2";
-			reg = <0x35e0000 0x3200000>;
-		};
-
-		partition@67e0000 {
-			label = "jffs2";
-			reg = <0x67e0000 0x1020000>;
 		};
 
 		/* Last 8M are reserved for NMBM management (bad blocks) */

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -342,7 +342,10 @@ define Device/asus_rt-ax53u
   DEVICE_MODEL := RT-AX53U
   DEVICE_ALT0_VENDOR := ASUS
   DEVICE_ALT0_MODEL := RT-AX1800U
-  IMAGE_SIZE := 51200k
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := Sysupgrade is not possible due to partition \
+	layout change, proceed by installing factory image
+  IMAGE_SIZE := 118912k
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
@@ -8,6 +8,9 @@
 board_config_update
 
 case "$(board_name)" in
+	asus,rt-ax53u)
+		ucidef_set_compat_version "2.0"
+		;;
 	*)
 		ucidef_set_compat_version "1.1"
 		;;


### PR DESCRIPTION
Change Asus RT-AX53U partition layout to maximize available space.

Increase DEVICE_COMPAT_VERSION and add DEVICE_COMPAT_MESSAGE to prevent unintentional damage.