### PR TITLE
selinux-policy: update to 1.2.5

### DIFF
--- a/package/libs/libselinux/Makefile
+++ b/package/libs/libselinux/Makefile
@@ -103,7 +103,7 @@ endef
 $(foreach a,$(LIBSELINUX_UTILS),$(eval $(call GenUtilPkg,libselinux-$(a),$(a))))
 
 # Needed to link libselinux utilities, which link against
-# libselinux.so, which indirectly depends on libpcre.so, installed in
+# libselinux.so, which indirectly depends on libpcre2.so, installed in
 # $(STAGING_DIR_HOSTPKG).
 HOST_LDFLAGS += -Wl,-rpath="$(STAGING_DIR_HOSTPKG)/lib"
 

--- a/package/system/selinux-policy/Makefile
+++ b/package/system/selinux-policy/Makefile
@@ -8,8 +8,8 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=selinux-policy
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.defensec.nl/selinux-policy.git
-PKG_VERSION:=1.2.3
-PKG_MIRROR_HASH:=ff1ddca168a6631aeac34352657f424bc4acf5d50b8aa7ff8dfa8c9663ba8538
+PKG_VERSION:=1.2.5
+PKG_MIRROR_HASH:=81ac6e31d2f1febddbe594f3578a9c40444fc0e349075ab6abd3d3ee014a988e
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=secilc/host policycoreutils/host
 


### PR DESCRIPTION
30d503a uci jsonfilter: pipe and leak
e13cb64 rpcd leds
144781f jsonfilter, luci, ubus
1210762 rpcd and all agents get fd's leaked
ab9227c rpcd
2f99e0e luci rpcd
b43aaf3 rpcd (enable/disable services) luci peeraddr f20f03e rpcd
7bc74f6 rpcd reads all subj state and luci-bwc leaks 9634b17 adds inotify perms to anon_inode
3d3c17c adds bare anon_inode (linux 5.15)
7104b20 dnsmasq and luci
0de2c66 luci,rpcd, ucode, wpad
14f5cf9 luci and ucode
e3ce84c rpcd, ucode and cgiio loose ends
96a2401 misc updates
9fe0490 initscript: remove redundant rules
71bd77e allow all init scripts to log to logd
f697331 sandbox: make ttydev handling more robust
a471877 simplify pty tty console access
f738984 sandbox: also remove TIOSCTI from all ttydevs