### PR TITLE
tools/meson: update to 1.1.1

### DIFF
--- a/tools/meson/Makefile
+++ b/tools/meson/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=meson
-PKG_VERSION:=1.1.0
+PKG_VERSION:=1.1.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/mesonbuild/meson/releases/download/$(PKG_VERSION)
-PKG_HASH:=d9616c44cd6c53689ff8f05fc6958a693f2e17c3472a8daf83cee55dabff829f
+PKG_HASH:=d04b541f97ca439fb82fab7d0d480988be4bd4e62563a5ca35fadb5400727b1c
 
 PKG_MAINTAINER:=Andre Heider <a.heider@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
026644099 Bump versions for 1.1.1 release
72f26cd0a azure pipelines: fix branch patterns to support 1.x release branches
e619b96ad ci: Don't error out CI if codecov upload fails
cf2887d57 ci: Move to the codecov github action
f7b0596bd docs: Fix some typos in feature option examples
0d9e46c84 qt: Allow specifying separate tools for qt4/5/6
be89526e7 rust compiler: use better sanity check logging comparable to the clike one
c953363a7 meson_exe: print suitable debug information for DLL not found errors
6a7cd1350 llvm: Bump broken micro version for CI
3dbeac046 ci: Don't search for llvm modules with LLVM 16.0.x
e17d243aa rust: Also disallow `.` in Rust library target names
630a29f4d rust: Don't allow spaces/dashes in Rust library names
b4c669f6e rust: Don't use prefer-dynamic in case of proc-macro Rust dependencies
225719770 mbuild: .pdb files are created only when debug symbols are enabled
e6cc0f2d8 minstall: Fix install_subdir() excludes with path separators on Win
4269a2401 rust: Use `isinstance(d, build.StaticLibrary)` instead of comparing the type name string
cc481c0da rust: Link staticlib/cdylib link targets like link targets from any other language
0d2c62529 rust: Don't prefer dynamic linking of Rust libraries for cdylibs
1a10b8f77 rust: Use the corresponding rustc version when clippy-driver is chosen as Rust compiler
6dce28185 rust: Don't pass dependency compile arguments to the compiler
b781d1261 Fix paths of Fortran order dependencies Fixes https://github.com/openwrt/openwrt/pull/11047
5886499f8 Fix building python extensions on win-arm64
8014827d0 Python module: emit warning for debug buildtypes with MSVC and no debug Python
a53dcd6f6 Fix unit test that hardcoded `/` and hence broke on Windows
795e39b3a Fix `ERROR: no toolchain found` when run from unittests
35d1def39 Add Cython to Windows CI jobs on Azure
a5ef21302 Use release buildtype in Cython tests, and skip unless ninja backend
8bbf6a5df fix regression in precomputing CMAKE_SIZEOF_VOID_P
26b73afba wrap: Always pass posix paths to patch
6696a754a Don't use dyndep scanner when preprocessing
22163998b Specify c++ 11 flag as code uses c++ 11 features
7c5dc1a79 Fix html coverage report generation when using clang on linux
46e0303c3 yasm: Fix usage of incompatible optimization flags
093ae573b fix python.version() not working in some cases
9bfdae8d7 Add c++23 to the list of C++ standards.
4c72b6da5 select the correct python_command for pyinstaller builds, even on not-Windows
9678aa05f fix data collection with pyinstaller
e5928e63d minstall: work around broken environments with missing UIDs
452d1c567 minstall: do not drop privileges if msetup also ran under sudo
960ae14c4 rust: Convert dashes in crate names to underscores
cb75ce50d backend/vs: Fix OpenMPSupport
11fe12d09 zsh: fix help / descriptions
307cb2573 ci: properly check `test cases/windows` files
1f1f05b8b ci: rename workflow
08e684499 syntax-highlighting: vim: fix mesonSpaceError
de8c4839e packaging: fix options hostArchitectures attribute
560ece485 fix various spelling issues