### PR TITLE
realtek: Use constants from <linux/mii.h> and <linux/mdio.h>

### DIFF
--- a/target/linux/realtek/files-5.15/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-5.15/drivers/net/phy/rtl83xx-phy.c
@@ -221,9 +221,9 @@ int rtl839x_read_sds_phy(int phy_addr, int phy_reg)
 	 * which would otherwise read as 0.
 	 */
 	if (soc_info.id == 0x8393) {
-		if (phy_reg == 2)
+		if (phy_reg == MII_PHYSID1)
 			return 0x1c;
-		if (phy_reg == 3)
+		if (phy_reg == MII_PHYSID2)
 			return 0x8393;
 	}
 
@@ -495,10 +495,10 @@ static int rtl8226_advertise_aneg(struct phy_device *phydev)
 	if (v < 0)
 		goto out;
 
-	v |= BIT(5); /* HD 10M */
-	v |= BIT(6); /* FD 10M */
-	v |= BIT(7); /* HD 100M */
-	v |= BIT(8); /* FD 100M */
+	v |= ADVERTISE_10HALF;
+	v |= ADVERTISE_10FULL;
+	v |= ADVERTISE_100HALF;
+	v |= ADVERTISE_100FULL;
 
 	ret = phy_write_mmd(phydev, MMD_AN, 16, v);
 
@@ -506,7 +506,7 @@ static int rtl8226_advertise_aneg(struct phy_device *phydev)
 	v = phy_read_mmd(phydev, MMD_VEND2, 0xA412);
 	if (v < 0)
 		goto out;
-	v |= BIT(9); /* FD 1000M */
+	v |= ADVERTISE_1000FULL;
 
 	ret = phy_write_mmd(phydev, MMD_VEND2, 0xA412, v);
 	if (ret < 0)

--- a/target/linux/realtek/files-5.15/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-5.15/drivers/net/phy/rtl83xx-phy.c
@@ -13,6 +13,7 @@
 #include <linux/crc32.h>
 #include <linux/sfp.h>
 #include <linux/mii.h>
+#include <linux/mdio.h>
 
 #include <asm/mach-rtl838x/mach-rtl83xx.h>
 #include "rtl83xx-phy.h"
@@ -443,20 +444,20 @@ static int rtl8226_read_status(struct phy_device *phydev)
 
 	/* Link status must be read twice */
 	for (int i = 0; i < 2; i++)
-		val = phy_read_mmd(phydev, MMD_VEND2, 0xA402);
+		val = phy_read_mmd(phydev, MDIO_MMD_VEND2, 0xA402);
 
 	phydev->link = val & BIT(2) ? 1 : 0;
 	if (!phydev->link)
 		goto out;
 
 	/* Read duplex status */
-	val = phy_read_mmd(phydev, MMD_VEND2, 0xA434);
+	val = phy_read_mmd(phydev, MDIO_MMD_VEND2, 0xA434);
 	if (val < 0)
 		goto out;
 	phydev->duplex = !!(val & BIT(3));
 
 	/* Read speed */
-	val = phy_read_mmd(phydev, MMD_VEND2, 0xA434);
+	val = phy_read_mmd(phydev, MDIO_MMD_VEND2, 0xA434);
 	switch (val & 0x0630) {
 	case 0x0000:
 		phydev->speed = SPEED_10;
@@ -491,7 +492,7 @@ static int rtl8226_advertise_aneg(struct phy_device *phydev)
 
 	pr_info("In %s\n", __func__);
 
-	v = phy_read_mmd(phydev, MMD_AN, 16);
+	v = phy_read_mmd(phydev, MDIO_MMD_AN, MDIO_AN_ADVERTISE);
 	if (v < 0)
 		goto out;
 
@@ -500,25 +501,25 @@ static int rtl8226_advertise_aneg(struct phy_device *phydev)
 	v |= ADVERTISE_100HALF;
 	v |= ADVERTISE_100FULL;
 
-	ret = phy_write_mmd(phydev, MMD_AN, 16, v);
+	ret = phy_write_mmd(phydev, MDIO_MMD_AN, MDIO_AN_ADVERTISE, v);
 
 	/* Allow 1GBit */
-	v = phy_read_mmd(phydev, MMD_VEND2, 0xA412);
+	v = phy_read_mmd(phydev, MDIO_MMD_VEND2, 0xA412);
 	if (v < 0)
 		goto out;
 	v |= ADVERTISE_1000FULL;
 
-	ret = phy_write_mmd(phydev, MMD_VEND2, 0xA412, v);
+	ret = phy_write_mmd(phydev, MDIO_MMD_VEND2, 0xA412, v);
 	if (ret < 0)
 		goto out;
 
 	/* Allow 2.5G */
-	v = phy_read_mmd(phydev, MMD_AN, 32);
+	v = phy_read_mmd(phydev, MDIO_MMD_AN, MDIO_AN_10GBT_CTRL);
 	if (v < 0)
 		goto out;
 
-	v |= BIT(7);
-	ret = phy_write_mmd(phydev, MMD_AN, 32, v);
+	v |= MDIO_AN_10GBT_CTRL_ADV2_5G;
+	ret = phy_write_mmd(phydev, MDIO_MMD_AN, MDIO_AN_10GBT_CTRL, v);
 
 out:
 	return ret;
@@ -535,22 +536,22 @@ static int rtl8226_config_aneg(struct phy_device *phydev)
 		if (ret)
 			goto out;
 		/* AutoNegotiationEnable */
-		v = phy_read_mmd(phydev, MMD_AN, 0);
+		v = phy_read_mmd(phydev, MDIO_MMD_AN, MDIO_CTRL1);
 		if (v < 0)
 			goto out;
 
-		v |= BIT(12); /* Enable AN */
-		ret = phy_write_mmd(phydev, MMD_AN, 0, v);
+		v |= MDIO_AN_CTRL1_ENABLE; /* Enable AN */
+		ret = phy_write_mmd(phydev, MDIO_MMD_AN, MDIO_CTRL1, v);
 		if (ret < 0)
 			goto out;
 
 		/* RestartAutoNegotiation */
-		v = phy_read_mmd(phydev, MMD_VEND2, 0xA400);
+		v = phy_read_mmd(phydev, MDIO_MMD_VEND2, 0xA400);
 		if (v < 0)
 			goto out;
-		v |= BIT(9);
+		v |= MDIO_AN_CTRL1_RESTART;
 
-		ret = phy_write_mmd(phydev, MMD_VEND2, 0xA400, v);
+		ret = phy_write_mmd(phydev, MDIO_MMD_VEND2, 0xA400, v);
 	}
 
 /*	TODO: ret = __genphy_config_aneg(phydev, ret); */
@@ -567,12 +568,12 @@ static int rtl8226_get_eee(struct phy_device *phydev,
 
 	pr_debug("In %s, port %d, was enabled: %d\n", __func__, addr, e->eee_enabled);
 
-	val = phy_read_mmd(phydev, MMD_AN, 60);
+	val = phy_read_mmd(phydev, MDIO_MMD_AN, MDIO_AN_EEE_ADV);
 	if (e->eee_enabled) {
-		e->eee_enabled = !!(val & BIT(1));
+		e->eee_enabled = !!(val & MDIO_EEE_100TX);
 		if (!e->eee_enabled) {
-			val = phy_read_mmd(phydev, MMD_AN, 62);
-			e->eee_enabled = !!(val & BIT(0));
+			val = phy_read_mmd(phydev, MDIO_MMD_AN, MDIO_AN_EEE_ADV2);
+			e->eee_enabled = !!(val & MDIO_EEE_2_5GT);
 		}
 	}
 	pr_debug("%s: enabled: %d\n", __func__, e->eee_enabled);
@@ -592,29 +593,29 @@ static int rtl8226_set_eee(struct phy_device *phydev, struct ethtool_eee *e)
 	poll_state = disable_polling(port);
 
 	/* Remember aneg state */
-	val = phy_read_mmd(phydev, MMD_AN, 0);
-	an_enabled = !!(val & BIT(12));
+	val = phy_read_mmd(phydev, MDIO_MMD_AN, MDIO_CTRL1);
+	an_enabled = !!(val & MDIO_AN_CTRL1_ENABLE);
 
 	/* Setup 100/1000MBit */
-	val = phy_read_mmd(phydev, MMD_AN, 60);
+	val = phy_read_mmd(phydev, MDIO_MMD_AN, MDIO_AN_EEE_ADV);
 	if (e->eee_enabled)
-		val |= 0x6;
+		val |= (MDIO_EEE_100TX | MDIO_EEE_1000T);
 	else
-		val &= 0x6;
-	phy_write_mmd(phydev, MMD_AN, 60, val);
+		val &= (MDIO_EEE_100TX | MDIO_EEE_1000T);
+	phy_write_mmd(phydev, MDIO_MMD_AN, MDIO_AN_EEE_ADV, val);
 
 	/* Setup 2.5GBit */
-	val = phy_read_mmd(phydev, MMD_AN, 62);
+	val = phy_read_mmd(phydev, MDIO_MMD_AN, MDIO_AN_EEE_ADV2);
 	if (e->eee_enabled)
-		val |= 0x1;
+		val |= MDIO_EEE_2_5GT;
 	else
-		val &= 0x1;
-	phy_write_mmd(phydev, MMD_AN, 62, val);
+		val &= MDIO_EEE_2_5GT;
+	phy_write_mmd(phydev, MDIO_MMD_AN, MDIO_AN_EEE_ADV2, val);
 
 	/* RestartAutoNegotiation */
-	val = phy_read_mmd(phydev, MMD_VEND2, 0xA400);
-	val |= BIT(9);
-	phy_write_mmd(phydev, MMD_VEND2, 0xA400, val);
+	val = phy_read_mmd(phydev, MDIO_MMD_VEND2, 0xA400);
+	val |= MDIO_AN_CTRL1_RESTART;
+	phy_write_mmd(phydev, MDIO_MMD_VEND2, 0xA400, val);
 
 	resume_polling(poll_state);
 
@@ -1058,10 +1059,9 @@ void rtl8218d_eee_set(struct phy_device *phydev, bool enable)
 	val = phy_read(phydev, MII_BMCR);
 	an_enabled = val & BMCR_ANENABLE;
 
-	/* Enable 100M (bit 1) / 1000M (bit 2) EEE */
-	val = phy_read_mmd(phydev, 7, 60);
-	val |= BIT(2) | BIT(1);
-	phy_write_mmd(phydev, 7, 60, enable ? 0x6 : 0);
+	val = phy_read_mmd(phydev, MDIO_MMD_AN, MDIO_AN_EEE_ADV);
+	val |= MDIO_EEE_1000T | MDIO_EEE_100TX;
+	phy_write_mmd(phydev, MDIO_MMD_AN, MDIO_AN_EEE_ADV, enable ? (MDIO_EEE_100TX | MDIO_EEE_1000T) : 0);
 
 	/* 500M EEE ability */
 	val = phy_read_paged(phydev, RTL821X_PAGE_GPHY, 20);
@@ -1093,7 +1093,7 @@ static int rtl8218b_get_eee(struct phy_device *phydev,
 	/* Set GPHY page to copper */
 	phy_write_paged(phydev, RTL821X_PAGE_GPHY, RTL821XINT_MEDIA_PAGE_SELECT, RTL821X_MEDIA_PAGE_COPPER);
 
-	val = phy_read_paged(phydev, 7, 60);
+	val = phy_read_paged(phydev, 7, MDIO_AN_EEE_ADV);
 	if (e->eee_enabled) {
 		/* Verify vs MAC-based EEE */
 		e->eee_enabled = !!(val & BIT(7));
@@ -1121,7 +1121,7 @@ static int rtl8218d_get_eee(struct phy_device *phydev,
 	/* Set GPHY page to copper */
 	phy_write_paged(phydev, RTL821X_PAGE_GPHY, RTL821XEXT_MEDIA_PAGE_SELECT, RTL821X_MEDIA_PAGE_COPPER);
 
-	val = phy_read_paged(phydev, 7, 60);
+	val = phy_read_paged(phydev, 7, MDIO_AN_EEE_ADV);
 	if (e->eee_enabled)
 		e->eee_enabled = !!(val & BIT(7));
 	pr_debug("%s: enabled: %d\n", __func__, e->eee_enabled);
@@ -1162,7 +1162,7 @@ static int rtl8214fc_set_eee(struct phy_device *phydev,
 	phy_write_paged(phydev, RTL821X_PAGE_MAC, 25, val);
 
 	/* Enable 100M (bit 1) / 1000M (bit 2) EEE */
-	phy_write_paged(phydev, 7, 60, e->eee_enabled ? 0x6 : 0);
+	phy_write_paged(phydev, 7, MDIO_AN_EEE_ADV, e->eee_enabled ? (MDIO_EEE_100TX | MDIO_EEE_1000T) : 0);
 
 	/* 500M EEE ability */
 	val = phy_read_paged(phydev, RTL821X_PAGE_GPHY, 20);

--- a/target/linux/realtek/files-5.15/drivers/net/phy/rtl83xx-phy.h
+++ b/target/linux/realtek/files-5.15/drivers/net/phy/rtl83xx-phy.h
@@ -35,10 +35,6 @@ struct __attribute__ ((__packed__)) fw_header {
 #define PHY_ID_RTL8393_I	0x001c8393
 #define PHY_ID_RTL9300_I	0x70d03106
 
-/* PHY MMD devices */
-#define MMD_AN		7
-#define MMD_VEND2	31
-
 /* Registers of the internal Serdes of the 8380 */
 #define RTL838X_SDS_MODE_SEL			(0x0028)
 #define RTL838X_SDS_CFG_REG			(0x0034)


### PR DESCRIPTION
Replace various numerical values, `BIT(x)` and `(1 << x)` constructs in `drivers/net/phy/rtl83xx-phy.c` with constants from `<linux/mii.h>` and `<linux/mdio.h>`.

Suggested-by: DENG Qingfang <dqfext@gmail.com>
Signed-off-by: Pascal Ernster <git@hardfalcon.net>