### PR TITLE
realtek: Use hex for "soc" identifier in debugfs

### DIFF
--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/debugfs.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/debugfs.c
@@ -605,7 +605,7 @@ void rtl838x_dbgfs_init(struct rtl838x_switch_priv *priv)
 
 	priv->dbgfs_dir = rtl838x_dir;
 
-	debugfs_create_u32("soc", 0444, rtl838x_dir,
+	debugfs_create_x32("soc", 0444, rtl838x_dir,
 			   (u32 *)(RTL838X_SW_BASE + RTL838X_MODEL_NAME_INFO));
 
 	/* Create one directory per port */


### PR DESCRIPTION
The upper 16 bits of the 32 bit value encode the SoC model in BCD notation (for example 0x83806800 on a Netgear GS108Tv3 with an RTL8380M), so it makes more sense to output the value in hex notation rather than in decimal notation.

Signed-off-by: Pascal Ernster <git@hardfalcon.net>