### PR TITLE
generic: import patch fixing workqueue compilation with gcc-13

### DIFF
--- a/target/linux/generic/pending-5.15/160-workqueue-fix-enum-type-for-gcc-13.patch
+++ b/target/linux/generic/pending-5.15/160-workqueue-fix-enum-type-for-gcc-13.patch
@@ -1,0 +1,44 @@
+From 525ff9c2965770762b81d679820552a208070d59 Mon Sep 17 00:00:00 2001
+From: Arnd Bergmann <arnd@arndb.de>
+Date: Tue, 17 Jan 2023 17:40:35 +0100
+Subject: workqueue: fix enum type for gcc-13
+
+In gcc-13, the WORK_STRUCT_WQ_DATA_MASK constant is a signed 64-bit
+type on 32-bit architectures because the enum definition has both
+negative numbers and numbers above LONG_MAX in it:
+
+kernel/workqueue.c: In function 'get_work_pwq':
+kernel/workqueue.c:709:24: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
+  709 |                 return (void *)(data & WORK_STRUCT_WQ_DATA_MASK);
+      |                        ^
+kernel/workqueue.c: In function 'get_work_pool':
+kernel/workqueue.c:737:25: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
+  737 |                 return ((struct pool_workqueue *)
+      |                         ^
+kernel/workqueue.c: In function 'get_work_pool_id':
+kernel/workqueue.c:759:25: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
+  759 |                 return ((struct pool_workqueue *)
+      |                         ^
+
+Change the enum definition to ensure all values can fit into
+the range of 'unsigned long' on all architectures.
+
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+Tested-by: Thierry Reding <treding@nvidia.com>
+Tested-by: Lai Jiangshan<jiangshanlai@gmail.com>
+Signed-off-by: Tejun Heo <tj@kernel.org>
+---
+ include/linux/workqueue.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/include/linux/workqueue.h
++++ b/include/linux/workqueue.h
+@@ -83,7 +83,7 @@ enum {
+ 
+ 	/* convenience constants */
+ 	WORK_STRUCT_FLAG_MASK	= (1UL << WORK_STRUCT_FLAG_BITS) - 1,
+-	WORK_STRUCT_WQ_DATA_MASK = ~WORK_STRUCT_FLAG_MASK,
++	WORK_STRUCT_WQ_DATA_MASK = (unsigned long)~WORK_STRUCT_FLAG_MASK,
+ 	WORK_STRUCT_NO_POOL	= (unsigned long)WORK_OFFQ_POOL_NONE << WORK_OFFQ_POOL_SHIFT,
+ 
+ 	/* bit mask for work_busy() return values */

--- a/target/linux/generic/pending-6.1/160-workqueue-fix-enum-type-for-gcc-13.patch
+++ b/target/linux/generic/pending-6.1/160-workqueue-fix-enum-type-for-gcc-13.patch
@@ -1,0 +1,44 @@
+From 525ff9c2965770762b81d679820552a208070d59 Mon Sep 17 00:00:00 2001
+From: Arnd Bergmann <arnd@arndb.de>
+Date: Tue, 17 Jan 2023 17:40:35 +0100
+Subject: workqueue: fix enum type for gcc-13
+
+In gcc-13, the WORK_STRUCT_WQ_DATA_MASK constant is a signed 64-bit
+type on 32-bit architectures because the enum definition has both
+negative numbers and numbers above LONG_MAX in it:
+
+kernel/workqueue.c: In function 'get_work_pwq':
+kernel/workqueue.c:709:24: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
+  709 |                 return (void *)(data & WORK_STRUCT_WQ_DATA_MASK);
+      |                        ^
+kernel/workqueue.c: In function 'get_work_pool':
+kernel/workqueue.c:737:25: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
+  737 |                 return ((struct pool_workqueue *)
+      |                         ^
+kernel/workqueue.c: In function 'get_work_pool_id':
+kernel/workqueue.c:759:25: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
+  759 |                 return ((struct pool_workqueue *)
+      |                         ^
+
+Change the enum definition to ensure all values can fit into
+the range of 'unsigned long' on all architectures.
+
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+Tested-by: Thierry Reding <treding@nvidia.com>
+Tested-by: Lai Jiangshan<jiangshanlai@gmail.com>
+Signed-off-by: Tejun Heo <tj@kernel.org>
+---
+ include/linux/workqueue.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/include/linux/workqueue.h
++++ b/include/linux/workqueue.h
+@@ -83,7 +83,7 @@ enum {
+ 
+ 	/* convenience constants */
+ 	WORK_STRUCT_FLAG_MASK	= (1UL << WORK_STRUCT_FLAG_BITS) - 1,
+-	WORK_STRUCT_WQ_DATA_MASK = ~WORK_STRUCT_FLAG_MASK,
++	WORK_STRUCT_WQ_DATA_MASK = (unsigned long)~WORK_STRUCT_FLAG_MASK,
+ 	WORK_STRUCT_NO_POOL	= (unsigned long)WORK_OFFQ_POOL_NONE << WORK_OFFQ_POOL_SHIFT,
+ 
+ 	/* bit mask for work_busy() return values */


### PR DESCRIPTION
Already applied in wq/for-6.5 [0].

Fixes errors in the form of:
```
  kernel/workqueue.c: In function 'get_work_pwq':
  kernel/workqueue.c:705:24: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
    705 |                 return (void *)(data & WORK_STRUCT_WQ_DATA_MASK);
        |                        ^
  kernel/workqueue.c: In function 'get_work_pool':
  kernel/workqueue.c:733:25: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
    733 |                 return ((struct pool_workqueue *)
        |                         ^
  kernel/workqueue.c: In function 'get_work_pool_id':
  kernel/workqueue.c:755:25: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
    755 |                 return ((struct pool_workqueue *)
        |                         ^
  cc1: all warnings being treated as errors
```
[0] - https://lore.kernel.org/all/ZGmEmkcrfh7QdkIz@slm.duckdns.org/
Please remove this message before posting the pull request.
