### PR TITLE
ramips: add support for D-Link DRA-1360

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dra-1360-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dra-1360-a1.dts
@@ -3,6 +3,6 @@
 #include "mt7621_dlink_dxx-1xx0-x1.dtsi"
 
 / {
-	compatible = "dlink,dap-1620-b1", "mediatek,mt7621-soc";
-	model = "D-Link DAP-1620 B1";
+	compatible = "dlink,dra-1360-a1", "mediatek,mt7621-soc";
+	model = "D-Link DRA-1360 A1";
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dxx-1xx0-x1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dxx-1xx0-x1.dtsi
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		label-mac-device = &gmac0;
+
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_low_red {
+			label = "red:rssilow";
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_low_green {
+			label = "green:rssilow";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_med_green {
+			label = "green:rssimed";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_high_green {
+			label = "green:rssihigh";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		/* The correct MAC addresses are set in 10_fix_wifi_mac. */
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -614,12 +614,9 @@ define Device/cudy_x6-v2
 endef
 TARGET_DEVICES += cudy_x6-v2
 
-define Device/dlink_dap-1620-b1
+define Device/dlink_dxx-1xx0-x1
   DEVICE_VENDOR := D-Link
-  DEVICE_MODEL := DAP-1620
-  DEVICE_VARIANT := B1
   DEVICE_PACKAGES := kmod-mt7615-firmware rssileds
-  DLINK_HWID := MT76XMT7621-RP-PR2475-NA
   IMAGE_SIZE := 16064k
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | \
@@ -627,6 +624,13 @@ define Device/dlink_dap-1620-b1
     append-md5sum-ascii-salted ffff | \
     append-string $$(DLINK_HWID) | \
     check-size
+endef
+
+define Device/dlink_dap-1620-b1
+  $(Device/dlink_dxx-1xx0-x1)
+  DEVICE_MODEL := DAP-1620
+  DEVICE_VARIANT := B1
+  DLINK_HWID := MT76XMT7621-RP-PR2475-NA
 endef
 TARGET_DEVICES += dlink_dap-1620-b1
 
@@ -798,6 +802,14 @@ define Device/dlink_dir-882-r1
 	ab0dff19af8842cdb70a86b4b68d23f7
 endef
 TARGET_DEVICES += dlink_dir-882-r1
+
+define Device/dlink_dra-1360-a1
+  $(Device/dlink_dxx-1xx0-x1)
+  DEVICE_MODEL := DRA-1360
+  DEVICE_VARIANT := A1
+  DLINK_HWID := MT76XMT7621-RP-RA1360-NA
+endef
+TARGET_DEVICES += dlink_dra-1360-a1
 
 define Device/dual-q_h721
   $(Device/dsa-migration)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -69,7 +69,8 @@ jcg,y2|\
 xzwifi,creativebox-v1)
 	ucidef_set_led_netdev "internet" "internet" "blue:internet" "wan"
 	;;
-dlink,dap-1620-b1)
+dlink,dap-1620-b1|\
+dlink,dra-1360-a1)
 	ucidef_set_rssimon "wlan1" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "red:rssilow" "wlan1" "1" "40"
 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "green:rssilow" "wlan1" "21" "100"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -16,6 +16,7 @@ ramips_setup_interfaces()
 	asus,rp-ac87|\
 	dlink,dap-1620-b1|\
 	dlink,dap-x1860-a1|\
+	dlink,dra-1360-a1|\
 	edimax,re23s|\
 	linksys,re7000|\
 	mikrotik,ltap-2hnd|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -38,7 +38,8 @@ case "$board" in
 		macaddr_setbit_la "$(macaddr_add $hw_mac_addr 0x100000)" > /sys${DEVPATH}/macaddress
 		;;
 	dlink,dap-1620-b1|\
-	dlink,dir-853-a1)
+	dlink,dir-853-a1|\
+	dlink,dra-1360-a1)
 		lan_mac_addr="$(mtd_get_mac_binary factory 0xe000)"
 		[ "$PHYNBR" = "0" ] && \
 			macaddr_add $lan_mac_addr 1 > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
Hardware is identical to D-Link DAP-1620 rev B ([same FCC ID](https://fcc.report/FCC-ID/KA2AP1620B1)), but a different model name, revision, and hardware ID are needed.
Thus, the bulk of the DAP-1620-B1 device tree is moved to a common `.dtsi`, which is included by the two `.dts`.

Repeating specs from e4c7703d2a62b8914e4723adae3f67c68a57532c (note that the RAM size mentioned there was incorrect, oops):

The DRA-1360 rev A is a wall-plug AC1300 repeater.

Specifications:
- MT7621AT, 128 MiB RAM, 16 MiB SPI NOR
- MT7615DN 2x2 802.11n +2x2 802.11ac (DBDC)
- Ethernet: 1 port 10/100/1000
- Status LEDs (1x red+green)
- LED RSSI bargraph (2x green, 1x red+green)