### PR TITLE
airoha: spi-en7523: Fix compile warning

### DIFF
--- a/target/linux/airoha/patches-5.15/0005-spi-Add-support-for-the-Airoha-EN7523-SoC-SPI-contro.patch
+++ b/target/linux/airoha/patches-5.15/0005-spi-Add-support-for-the-Airoha-EN7523-SoC-SPI-contro.patch
@@ -25,7 +25,7 @@
  obj-$(CONFIG_SPI_FSL_CPM)		+= spi-fsl-cpm.o
 --- /dev/null
 +++ b/drivers/spi/spi-en7523.c
-@@ -0,0 +1,311 @@
+@@ -0,0 +1,313 @@
 +// SPDX-License-Identifier: GPL-2.0
 +
 +#include <linux/module.h>
@@ -166,6 +166,7 @@
 +	}
 +}
 +
++#if 0
 +static void set_spi_clock_speed(int freq_mhz)
 +{
 +	u32 tmp, val;
@@ -178,6 +179,7 @@
 +	tmp |= (val << 8) | 1;
 +	writel(tmp, ENSPI_CLOCK_DIVIDER);
 +}
++#endif
 +
 +static void init_hw(void)
 +{


### PR DESCRIPTION
The set_spi_clock_speed() function is not used, this causes a compile warning which results in a build error with -WError.

This is very similar to #12642.