### PR TITLE
ipq806x: use new package name for NEC WG2600HP3

### DIFF
--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -245,7 +245,7 @@ define Device/nec_wg2600hp3
 		pad-rootfs | append-metadata
 	DEVICE_PACKAGES := -kmod-ata-ahci -kmod-ata-ahci-platform \
 		-kmod-usb-ohci -kmod-usb2 -kmod-usb-ledtrig-usbport \
-		-kmod-usb-phy-qcom-dwc3 -kmod-usb3 -kmod-usb-dwc3-qcom \
+		-kmod-phy-qcom-ipq806x-usb -kmod-usb3 -kmod-usb-dwc3-qcom \
 		ath10k-firmware-qca9984-ct
 endef
 TARGET_DEVICES += nec_wg2600hp3


### PR DESCRIPTION
commit 0c45ad41e15e2255 changes ipq806x usb kmod name from usb-phy-qcom-dwc3 to phy-qcom-ipq806x-usb, so use new name.
