### PR TITLE
kernel: fix wrong detection of Linux-Testing-Version in makefile DUMP

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -13,6 +13,15 @@ endif
 
 include $(KERNEL_DETAILS_FILE)
 
+ifdef KERNEL_TESTING_PATCHVER
+  KERNEL_TESTING_DETAILS_FILE=$(INCLUDE_DIR)/kernel-$(KERNEL_TESTING_PATCHVER)
+  ifeq ($(wildcard $(KERNEL_TESTING_DETAILS_FILE)),)
+    $(error Missing kernel version/hash file for $(KERNEL_TESTING_PATCHVER). Please create $(KERNEL_TESTING_DETAILS_FILE))
+  endif
+
+  include $(KERNEL_TESTING_DETAILS_FILE)
+endif
+
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))
 


### PR DESCRIPTION
When the split was done, the case for testing kernel version wasn't handled and only the to-be-compiled kernel version details files was included. This cause the kernel Linux-Testing-Version output from makefile target DUMP to report only the kernel version without the minor version (example 6.1 instead of 6.1.29).

This value is expected with the full kernel version and this cause the dump-target-info.pl script to not correctly identify if a target have a testing kernel for the kernels calls.

Fix this regression by correctly including the kernel details files if the target declare support for a testing kernel version.

Fixes: 0765466a42f4 ("kernel: split kernel version to dedicated files")