### PR TITLE
CI: label-kernel: support compile testing kernel version and all target

### DIFF
--- a/.github/workflows/label-kernel.yml
+++ b/.github/workflows/label-kernel.yml
@@ -12,17 +12,84 @@ jobs:
     name: Set target
     runs-on: ubuntu-latest
     outputs:
-      target: ${{ steps.set_target.outputs.target }}
-      subtarget: ${{ steps.set_target.outputs.subtarget }}
+      targets_subtargets: ${{ steps.set_target.outputs.targets_subtargets }}
+      targets: ${{ steps.set_target.outputs.targets }}
 
     steps:
-      - name: Set target
-        id: set_target
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Parse label
+        id: parse_label
         env:
           CI_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          echo "$CI_EVENT_LABEL_NAME" | sed -n 's/.*:\(.*\):\(.*\)$/target=\1/p' | tee --append $GITHUB_OUTPUT
-          echo "$CI_EVENT_LABEL_NAME" | sed -n 's/.*:\(.*\):\(.*\)$/subtarget=\2/p' | tee --append $GITHUB_OUTPUT
+          echo "$CI_EVENT_LABEL_NAME" | sed -n 's/ci:kernel:\([^:]*\):\([^:]*\):*\([^:]*\)$/target=\1/p' | tee --append $GITHUB_OUTPUT
+          echo "$CI_EVENT_LABEL_NAME" | sed -n 's/ci:kernel:\([^:]*\):\([^:]*\):*\([^:]*\)$/subtarget=\2/p' | tee --append $GITHUB_OUTPUT
+          echo "$CI_EVENT_LABEL_NAME" | sed -n 's/ci:kernel:\([^:]*\):\([^:]*\):*\([^:]*\)$/testing=\3/p' | tee --append $GITHUB_OUTPUT
+
+      - name: Set targets
+        id: set_target
+        run: |
+          ALL_TARGETS="$(perl ./scripts/dump-target-info.pl kernels 2>/dev/null)"
+
+          TARGETS_SUBTARGETS="$(echo "$ALL_TARGETS" | sort -u -t '/' -k1)"
+          TARGETS="$(echo "$ALL_TARGETS" | sort -u -t '/' -k1,1)"
+
+          [ "${{ steps.parse_label.outputs.subtarget }}" = "first" ] && TARGETS_SUBTARGETS=$TARGETS
+
+          JSON_TARGETS_SUBTARGETS='['
+          FIRST=1
+          while IFS= read -r line; do
+            TARGET_SUBTARGET=$(echo $line | cut -d " " -f 1)
+            TARGET=$(echo $TARGET_SUBTARGET | cut -d "/" -f 1)
+            SUBTARGET=$(echo $TARGET_SUBTARGET | cut -d "/" -f 2)
+
+            [ "${{ steps.parse_label.outputs.target }}" != "all" ] && [ "${{ steps.parse_label.outputs.target }}" != "$TARGET" ] && continue
+            [ "${{ steps.parse_label.outputs.subtarget }}" != "all" ] && [ "${{ steps.parse_label.outputs.subtarget }}" != "first" ] &&
+              [ "${{ steps.parse_label.outputs.subtarget }}" != $SUBTARGET ] && continue
+            if [ "${{ steps.parse_label.outputs.testing }}" = "testing" ]; then
+              TESTING_KERNEL_VER=$(echo $line | cut -d " " -f 3)
+              [ -z "$TESTING_KERNEL_VER" ] && continue
+            fi
+
+            TUPLE='{"target":"'"$TARGET"'","subtarget":"'"$SUBTARGET"'","testing":"'"$TESTING_KERNEL_VER"'"}'
+            [[ $FIRST -ne 1 ]] && JSON_TARGETS_SUBTARGETS="$JSON_TARGETS_SUBTARGETS"','
+            JSON_TARGETS_SUBTARGETS="$JSON_TARGETS_SUBTARGETS""$TUPLE"
+            FIRST=0
+          done <<< "$TARGETS_SUBTARGETS"
+          JSON_TARGETS_SUBTARGETS="$JSON_TARGETS_SUBTARGETS"']'
+
+          JSON_TARGETS='['
+          FIRST=1
+          while IFS= read -r line; do
+            TARGET_SUBTARGET=$(echo $line | cut -d " " -f 1)
+            TARGET=$(echo $TARGET_SUBTARGET | cut -d "/" -f 1)
+            SUBTARGET=$(echo $TARGET_SUBTARGET | cut -d "/" -f 2)
+
+            [ "${{ steps.parse_label.outputs.target }}" != "all" ] && [ "${{ steps.parse_label.outputs.target }}" != $TARGET ] && continue
+            if [ "${{ steps.parse_label.outputs.testing }}" = "testing" ]; then
+              TESTING_KERNEL_VER=$(echo $line | cut -d " " -f 3)
+              [ -z "$TESTING_KERNEL_VER" ] && continue
+            fi
+
+            TUPLE='{"target":"'"$TARGET"'","subtarget":"'"$SUBTARGET"'","testing":"'"$TESTING_KERNEL_VER"'"}'
+            [[ $FIRST -ne 1 ]] && JSON_TARGETS="$JSON_TARGETS"','
+            JSON_TARGETS="$JSON_TARGETS""$TUPLE"
+            FIRST=0
+          done <<< "$TARGETS"
+          JSON_TARGETS="$JSON_TARGETS"']'
+
+          echo -e "\n---- targets to build ----\n"
+          echo "$JSON_TARGETS_SUBTARGETS"
+          echo -e "\n---- targets to build ----\n"
+
+          echo -e "\n---- targets to check patch ----\n"
+          echo "$JSON_TARGETS"
+          echo -e "\n---- targets to check patch ----\n"
+
+          echo "targets_subtargets=$JSON_TARGETS_SUBTARGETS" >> $GITHUB_OUTPUT
+          echo "targets=$JSON_TARGETS" >> $GITHUB_OUTPUT
 
   build_kernel:
     name: Build Kernel with external toolchain
@@ -32,10 +99,15 @@ jobs:
       packages: read
       actions: write
     uses: ./.github/workflows/build.yml
+    strategy:
+       fail-fast: False
+       matrix:
+         include: ${{fromJson(needs.set_target.outputs.targets_subtargets)}}
     with:
       container_name: toolchain
-      target: ${{ needs.set_target.outputs.target }}
-      subtarget: ${{ needs.set_target.outputs.subtarget }}
+      target: ${{ matrix.target }}
+      subtarget: ${{ matrix.subtarget }}
+      testing: ${{ matrix.testing != '' && true }}
       build_kernel: true
       build_all_kmods: true
 
@@ -46,7 +118,12 @@ jobs:
       contents: read
       packages: read
       actions: write
+    strategy:
+       fail-fast: False
+       matrix:
+         include: ${{fromJson(needs.set_target.outputs.targets)}}
     uses: ./.github/workflows/check-kernel-patches.yml
     with:
-      target: ${{ needs.set_target.outputs.target }}
-      subtarget: ${{ needs.set_target.outputs.subtarget }}
+      target: ${{ matrix.target }}
+      subtarget: ${{ matrix.subtarget }}
+      testing: ${{ matrix.testing != '' && true }}


### PR DESCRIPTION
Add support to label-kernel for compiling testing kernel version and check patches. To trigger this special build appent :testing to the normal label.
Example:

- ci:kernel:ipq806x:generic:testing

Test will fail if the requested target doesn't have a defined kernel testing version.

Also add support for testing all target and subtarget. To trigger this some special pattern are added:
- ci:kernel:all:all Trigger test for all target and subtarget

- ci:kernel:all:first Trigger test for all target and the first subtarget in alphabetical order for the target.

With these special case :testing can also be used and every target and subtarget that supports kernel testing version will be selected:
- ci:kernel:all:all:testing Trigger test for all target and subtarget that have a kernel testing version defined.

- ci:kernel:all:first:testing Trigger test for all target and the first subtarget in alphabetical order for the target that, if they have a kernel testing version defined.