### PR TITLE
firmware-utils: add missing build dependencies

### DIFF
--- a/package/utils/firmware-utils/Makefile
+++ b/package/utils/firmware-utils/Makefile
@@ -3,13 +3,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=firmware-utils
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firmware-utils.git
 PKG_SOURCE_DATE:=2023-05-18
 PKG_SOURCE_VERSION:=02cdbc6a4d61605c008efef09162f772f553fcde
 PKG_MIRROR_HASH:=f5188fc38bb03ddbcc34763ff049597e2d8af98c0854910dc87f10e5927096e2
+
+PKG_BUILD_DEPENDS:=openssl zlib
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
Fixes the following build error:

```
CMake Error at CMakeLists.txt:9 (MESSAGE):
  Unable to find zlib library.
CMake Error at CMakeLists.txt:13 (MESSAGE):
  Unable to find OpenSSL librry.
```

Fixes: 24d6abe2d7cd8b ("firmware-utils: new package replacing otrx")
