### PR TITLE
generic: b53: rename exported symbols to avoid upstream conflict

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/b53/b53_common.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_common.c
@@ -1611,8 +1611,8 @@ static int b53_switch_init(struct b53_device *dev)
 	return b53_switch_reset(dev);
 }
 
-struct b53_device *b53_switch_alloc(struct device *base, struct b53_io_ops *ops,
-				    void *priv)
+struct b53_device *b53_swconfig_switch_alloc(struct device *base, struct b53_io_ops *ops,
+					     void *priv)
 {
 	struct b53_device *dev;
 
@@ -1627,9 +1627,9 @@ struct b53_device *b53_switch_alloc(struct device *base, struct b53_io_ops *ops,
 
 	return dev;
 }
-EXPORT_SYMBOL(b53_switch_alloc);
+EXPORT_SYMBOL(b53_swconfig_switch_alloc);
 
-int b53_switch_detect(struct b53_device *dev)
+int b53_swconfig_switch_detect(struct b53_device *dev)
 {
 	u32 id32;
 	u16 tmp;
@@ -1694,9 +1694,9 @@ int b53_switch_detect(struct b53_device *dev)
 		return b53_read8(dev, B53_MGMT_PAGE, B53_REV_ID,
 				 &dev->core_rev);
 }
-EXPORT_SYMBOL(b53_switch_detect);
+EXPORT_SYMBOL(b53_swconfig_switch_detect);
 
-int b53_switch_register(struct b53_device *dev)
+int b53_swconfig_switch_register(struct b53_device *dev)
 {
 	int ret;
 
@@ -1706,7 +1706,7 @@ int b53_switch_register(struct b53_device *dev)
 		dev->sw_dev.alias = dev->pdata->alias;
 	}
 
-	if (!dev->chip_id && b53_switch_detect(dev))
+	if (!dev->chip_id && b53_swconfig_switch_detect(dev))
 		return -EINVAL;
 
 	ret = b53_switch_init(dev);
@@ -1717,7 +1717,7 @@ int b53_switch_register(struct b53_device *dev)
 
 	return register_switch(&dev->sw_dev, NULL);
 }
-EXPORT_SYMBOL(b53_switch_register);
+EXPORT_SYMBOL(b53_swconfig_switch_register);
 
 MODULE_AUTHOR("Jonas Gorski <jogo@openwrt.org>");
 MODULE_DESCRIPTION("B53 switch library");

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_mdio.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_mdio.c
@@ -280,7 +280,7 @@ static int b53_phy_probe(struct phy_device *phydev)
 	if (phydev->mdio.addr != B53_PSEUDO_PHY && phydev->mdio.addr != 0)
 		return -ENODEV;
 
-	dev = b53_switch_alloc(&phydev->mdio.dev, &b53_mdio_ops, phydev->mdio.bus);
+	dev = b53_swconfig_switch_alloc(&phydev->mdio.dev, &b53_mdio_ops, phydev->mdio.bus);
 	if (!dev)
 		return -ENOMEM;
 
@@ -290,7 +290,7 @@ static int b53_phy_probe(struct phy_device *phydev)
 	dev->pdata = NULL;
 	mutex_init(&dev->reg_mutex);
 
-	ret = b53_switch_detect(dev);
+	ret = b53_swconfig_switch_detect(dev);
 	if (ret)
 		return ret;
 
@@ -302,7 +302,7 @@ static int b53_phy_probe(struct phy_device *phydev)
 
 	linkmode_copy(phydev->advertising, phydev->supported);
 
-	ret = b53_switch_register(dev);
+	ret = b53_swconfig_switch_register(dev);
 	if (ret) {
 		dev_err(dev->dev, "failed to register switch: %i\n", ret);
 		return ret;

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_mmap.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_mmap.c
@@ -205,7 +205,7 @@ static int b53_mmap_probe(struct platform_device *pdev)
 	if (!pdata)
 		return -EINVAL;
 
-	dev = b53_switch_alloc(&pdev->dev, &b53_mmap_ops, pdata->regs);
+	dev = b53_swconfig_switch_alloc(&pdev->dev, &b53_mmap_ops, pdata->regs);
 	if (!dev)
 		return -ENOMEM;
 
@@ -214,7 +214,7 @@ static int b53_mmap_probe(struct platform_device *pdev)
 
 	platform_set_drvdata(pdev, dev);
 
-	return b53_switch_register(dev);
+	return b53_swconfig_switch_register(dev);
 }
 
 static int b53_mmap_remove(struct platform_device *pdev)

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_priv.h
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_priv.h
@@ -183,12 +183,12 @@ static inline struct b53_device *sw_to_b53(struct switch_dev *sw)
 	return container_of(sw, struct b53_device, sw_dev);
 }
 
-struct b53_device *b53_switch_alloc(struct device *base, struct b53_io_ops *ops,
-				    void *priv);
+struct b53_device *b53_swconfig_switch_alloc(struct device *base, struct b53_io_ops *ops,
+					     void *priv);
 
-int b53_switch_detect(struct b53_device *dev);
+int b53_swconfig_switch_detect(struct b53_device *dev);
 
-int b53_switch_register(struct b53_device *dev);
+int b53_swconfig_switch_register(struct b53_device *dev);
 
 static inline void b53_switch_remove(struct b53_device *dev)
 {

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_spi.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_spi.c
@@ -288,14 +288,14 @@ static int b53_spi_probe(struct spi_device *spi)
 	struct b53_device *dev;
 	int ret;
 
-	dev = b53_switch_alloc(&spi->dev, &b53_spi_ops, spi);
+	dev = b53_swconfig_switch_alloc(&spi->dev, &b53_spi_ops, spi);
 	if (!dev)
 		return -ENOMEM;
 
 	if (spi->dev.platform_data)
 		dev->pdata = spi->dev.platform_data;
 
-	ret = b53_switch_register(dev);
+	ret = b53_swconfig_switch_register(dev);
 	if (ret)
 		return ret;
 

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_srab.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_srab.c
@@ -342,7 +342,7 @@ static int b53_srab_probe(struct platform_device *pdev)
 	if (!pdata)
 		return -EINVAL;
 
-	dev = b53_switch_alloc(&pdev->dev, &b53_srab_ops, pdata->regs);
+	dev = b53_swconfig_switch_alloc(&pdev->dev, &b53_srab_ops, pdata->regs);
 	if (!dev)
 		return -ENOMEM;
 
@@ -351,7 +351,7 @@ static int b53_srab_probe(struct platform_device *pdev)
 
 	platform_set_drvdata(pdev, dev);
 
-	return b53_switch_register(dev);
+	return b53_swconfig_switch_register(dev);
 }
 
 static int b53_srab_remove(struct platform_device *pdev)


### PR DESCRIPTION
Upstream DSA driver is exporting symbols with the same name as our downstream swconfig driver, so lets rename the downstream symbols to make them unique and avoid the conflict on 6.1 kernel.

Without this change, building 6.1 with kmod-switch-bcm53xx would conflict with the B53 DSA driver and CI would fail.
