### PR TITLE
mac80211: ath11k: sync with ath-next

### DIFF
--- a/package/firmware/ath11k-firmware/Makefile
+++ b/package/firmware/ath11k-firmware/Makefile
@@ -8,9 +8,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ath11k-firmware
-PKG_SOURCE_DATE:=2023-03-31
-PKG_SOURCE_VERSION:=a039049a9349722fa5c74185452ab04644a0d351
-PKG_MIRROR_HASH:=ed401e3f6e91d70565b3396139193f7e815f410db93700697205ac8ed1b828c5
+PKG_SOURCE_DATE:=2023-06-02
+PKG_SOURCE_VERSION:=210d1a7242c6eaeec180e8bb87e805653bb6d35a
+PKG_MIRROR_HASH:=888da6f5425d90379da2e07d7bfeda288c07f0d14ed165ceb7af94d98e7790c5
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
@@ -60,14 +60,14 @@ $(eval $(call Download,qcn9074-board))
 define Package/ath11k-firmware-ipq8074/install
 	$(INSTALL_DIR) $(1)/lib/firmware/IPQ8074
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/ath11k-firmware/IPQ8074/hw2.0/testing/2.9.0.1/WLAN.HK.2.9.0.1-01385-QCAHKSWPL_SILICONZ-1/* \
+		$(PKG_BUILD_DIR)/ath11k-firmware/IPQ8074/hw2.0/testing/2.9.0.1/WLAN.HK.2.9.0.1-01713-QCAHKSWPL_SILICONZ-1/* \
 		$(1)/lib/firmware/IPQ8074/
 endef
 
 define Package/ath11k-firmware-qcn9074/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/QCN9074/hw1.0
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/ath11k-firmware/QCN9074/hw1.0/testing/2.9.0.1/WLAN.HK.2.9.0.1-01385-QCAHKSWPL_SILICONZ-1/* \
+		$(PKG_BUILD_DIR)/ath11k-firmware/QCN9074/hw1.0/testing/2.9.0.1/WLAN.HK.2.9.0.1-01713-QCAHKSWPL_SILICONZ-1/* \
 		$(1)/lib/firmware/ath11k/QCN9074/hw1.0/
 	$(INSTALL_BIN) \
 		$(DL_DIR)/$(QCN9074_BOARD_FILE) $(1)/lib/firmware/ath11k/QCN9074/hw1.0/board-2.bin

--- a/package/kernel/mac80211/patches/ath11k/0070-wifi-ath-work-around-false-positive-stringop-overrea.patch
+++ b/package/kernel/mac80211/patches/ath11k/0070-wifi-ath-work-around-false-positive-stringop-overrea.patch
@@ -1,0 +1,84 @@
+From 695df2f417d25202bdac9cde3c82d2acb6492b4d Mon Sep 17 00:00:00 2001
+From: Arnd Bergmann <arnd@arndb.de>
+Date: Fri, 5 May 2023 16:11:25 +0300
+Subject: [PATCH] wifi: ath: work around false-positive stringop-overread
+ warning
+
+In a rare arm64 randconfig build, I got multiple warnings for ath11k
+and ath12k:
+
+In function 'ath11k_peer_assoc_h_ht',
+    inlined from 'ath11k_peer_assoc_prepare' at drivers/net/wireless/ath/ath11k/mac.c:2665:2:
+drivers/net/wireless/ath/ath11k/mac.c:1709:13: error: 'ath11k_peer_assoc_h_ht_masked' reading 10 bytes from a region of size 0 [-Werror=stringop-overread]
+ 1709 |         if (ath11k_peer_assoc_h_ht_masked(ht_mcs_mask))
+      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This happens whenever gcc-13 fails to inline one of the functions
+that take a fixed-length array argument but gets passed a pointer.
+
+Change these functions to all take a regular pointer argument
+instead.
+
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230417205447.1800912-1-arnd@kernel.org
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -433,7 +433,7 @@ u8 ath11k_mac_bitrate_to_idx(const struc
+ }
+ 
+ static u32
+-ath11k_mac_max_ht_nss(const u8 ht_mcs_mask[IEEE80211_HT_MCS_MASK_LEN])
++ath11k_mac_max_ht_nss(const u8 *ht_mcs_mask)
+ {
+ 	int nss;
+ 
+@@ -445,7 +445,7 @@ ath11k_mac_max_ht_nss(const u8 ht_mcs_ma
+ }
+ 
+ static u32
+-ath11k_mac_max_vht_nss(const u16 vht_mcs_mask[NL80211_VHT_NSS_MAX])
++ath11k_mac_max_vht_nss(const u16 *vht_mcs_mask)
+ {
+ 	int nss;
+ 
+@@ -457,7 +457,7 @@ ath11k_mac_max_vht_nss(const u16 vht_mcs
+ }
+ 
+ static u32
+-ath11k_mac_max_he_nss(const u16 he_mcs_mask[NL80211_HE_NSS_MAX])
++ath11k_mac_max_he_nss(const u16 *he_mcs_mask)
+ {
+ 	int nss;
+ 
+@@ -1658,7 +1658,7 @@ static void ath11k_peer_assoc_h_rates(st
+ }
+ 
+ static bool
+-ath11k_peer_assoc_h_ht_masked(const u8 ht_mcs_mask[IEEE80211_HT_MCS_MASK_LEN])
++ath11k_peer_assoc_h_ht_masked(const u8 *ht_mcs_mask)
+ {
+ 	int nss;
+ 
+@@ -1670,7 +1670,7 @@ ath11k_peer_assoc_h_ht_masked(const u8 h
+ }
+ 
+ static bool
+-ath11k_peer_assoc_h_vht_masked(const u16 vht_mcs_mask[])
++ath11k_peer_assoc_h_vht_masked(const u16 *vht_mcs_mask)
+ {
+ 	int nss;
+ 
+@@ -2065,7 +2065,7 @@ static u16 ath11k_peer_assoc_h_he_limit(
+ }
+ 
+ static bool
+-ath11k_peer_assoc_h_he_masked(const u16 he_mcs_mask[NL80211_HE_NSS_MAX])
++ath11k_peer_assoc_h_he_masked(const u16 *he_mcs_mask)
+ {
+ 	int nss;
+ 

--- a/package/kernel/mac80211/patches/ath11k/0071-wifi-ath11k-driver-settings-for-MBSSID-and-EMA.patch
+++ b/package/kernel/mac80211/patches/ath11k/0071-wifi-ath11k-driver-settings-for-MBSSID-and-EMA.patch
@@ -1,0 +1,133 @@
+From a08dbb04d7365a04d52882143cf196005bfc88c3 Mon Sep 17 00:00:00 2001
+From: Aloka Dixit <quic_alokad@quicinc.com>
+Date: Fri, 5 May 2023 16:11:27 +0300
+Subject: [PATCH 71/77] wifi: ath11k: driver settings for MBSSID and EMA
+
+Advertise the driver support for multiple BSSID (MBSSID) and
+enhanced multi-BSSID advertisements (EMA) by setting extended
+capabilities.
+
+Configure mbssid_max_interfaces and ema_max_profile_periodicity
+fields in structure wiphy which are used to advertise maximum number
+of interfaces and profile periodicity supported by the driver.
+
+Add new WMI fields to configure maximum vdev count supported for
+MBSSID and profile periodicity in case of EMA.
+Setting WMI_RSRC_CFG_FLAG2_CALC_NEXT_DTIM_COUNT_SET flag
+indicates that the firmware should track and update the DTIM counts
+for each non-transmitted profile.
+
+Tested-on: IPQ8074 hw2.0 AHB WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Aloka Dixit <quic_alokad@quicinc.com>
+Co-developed-by: John Crispin <john@phrozen.org>
+Signed-off-by: John Crispin <john@phrozen.org>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230405221648.17950-2-quic_alokad@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/hw.c  | 3 +++
+ drivers/net/wireless/ath/ath11k/hw.h  | 1 +
+ drivers/net/wireless/ath/ath11k/mac.c | 7 +++++++
+ drivers/net/wireless/ath/ath11k/wmi.c | 3 +++
+ drivers/net/wireless/ath/ath11k/wmi.h | 6 ++++++
+ 5 files changed, 20 insertions(+)
+
+--- a/drivers/net/wireless/ath/ath11k/hw.c
++++ b/drivers/net/wireless/ath/ath11k/hw.c
+@@ -202,6 +202,9 @@ static void ath11k_init_wmi_config_ipq80
+ 	config->twt_ap_sta_count = 1000;
+ 	config->flag1 |= WMI_RSRC_CFG_FLAG1_BSS_CHANNEL_INFO_64;
+ 	config->flag1 |= WMI_RSRC_CFG_FLAG1_ACK_RSSI;
++	config->ema_max_vap_cnt = ab->num_radios;
++	config->ema_max_profile_period = TARGET_EMA_MAX_PROFILE_PERIOD;
++	config->beacon_tx_offload_max_vdev += config->ema_max_vap_cnt;
+ }
+ 
+ static int ath11k_hw_mac_id_to_pdev_id_ipq8074(struct ath11k_hw_params *hw,
+--- a/drivers/net/wireless/ath/ath11k/hw.h
++++ b/drivers/net/wireless/ath/ath11k/hw.h
+@@ -64,6 +64,7 @@
+ #define TARGET_NUM_WDS_ENTRIES		32
+ #define TARGET_DMA_BURST_SIZE		1
+ #define TARGET_RX_BATCHMODE		1
++#define TARGET_EMA_MAX_PROFILE_PERIOD	8
+ 
+ #define ATH11K_HW_MAX_QUEUES		4
+ #define ATH11K_QUEUE_LEN		4096
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -9001,19 +9001,23 @@ static int ath11k_mac_setup_iface_combin
+ 
+ static const u8 ath11k_if_types_ext_capa[] = {
+ 	[0] = WLAN_EXT_CAPA1_EXT_CHANNEL_SWITCHING,
++	[2] = WLAN_EXT_CAPA3_MULTI_BSSID_SUPPORT,
+ 	[7] = WLAN_EXT_CAPA8_OPMODE_NOTIF,
+ };
+ 
+ static const u8 ath11k_if_types_ext_capa_sta[] = {
+ 	[0] = WLAN_EXT_CAPA1_EXT_CHANNEL_SWITCHING,
++	[2] = WLAN_EXT_CAPA3_MULTI_BSSID_SUPPORT,
+ 	[7] = WLAN_EXT_CAPA8_OPMODE_NOTIF,
+ 	[9] = WLAN_EXT_CAPA10_TWT_REQUESTER_SUPPORT,
+ };
+ 
+ static const u8 ath11k_if_types_ext_capa_ap[] = {
+ 	[0] = WLAN_EXT_CAPA1_EXT_CHANNEL_SWITCHING,
++	[2] = WLAN_EXT_CAPA3_MULTI_BSSID_SUPPORT,
+ 	[7] = WLAN_EXT_CAPA8_OPMODE_NOTIF,
+ 	[9] = WLAN_EXT_CAPA10_TWT_RESPONDER_SUPPORT,
++	[10] = WLAN_EXT_CAPA11_EMA_SUPPORT,
+ };
+ 
+ static const struct wiphy_iftype_ext_capab ath11k_iftypes_ext_capa[] = {
+@@ -9251,6 +9255,9 @@ static int __ath11k_mac_register(struct
+ 		wiphy_ext_feature_set(ar->hw->wiphy,
+ 				      NL80211_EXT_FEATURE_ENABLE_FTM_RESPONDER);
+ 
++	ar->hw->wiphy->mbssid_max_interfaces = TARGET_NUM_VDEVS(ab);
++	ar->hw->wiphy->ema_max_profile_periodicity = TARGET_EMA_MAX_PROFILE_PERIOD;
++
+ 	ath11k_reg_init(ar);
+ 
+ 	if (!test_bit(ATH11K_FLAG_RAW_MODE, &ab->dev_flags)) {
+--- a/drivers/net/wireless/ath/ath11k/wmi.c
++++ b/drivers/net/wireless/ath/ath11k/wmi.c
+@@ -3987,6 +3987,9 @@ ath11k_wmi_copy_resource_config(struct w
+ 		~(1 << WMI_CFG_HOST_SERVICE_FLAG_REG_CC_EXT);
+ 	wmi_cfg->host_service_flags |= (tg_cfg->is_reg_cc_ext_event_supported <<
+ 					WMI_CFG_HOST_SERVICE_FLAG_REG_CC_EXT);
++	wmi_cfg->flags2 = WMI_RSRC_CFG_FLAG2_CALC_NEXT_DTIM_COUNT_SET;
++	wmi_cfg->ema_max_vap_cnt = tg_cfg->ema_max_vap_cnt;
++	wmi_cfg->ema_max_profile_period = tg_cfg->ema_max_profile_period;
+ }
+ 
+ static int ath11k_init_cmd_send(struct ath11k_pdev_wmi *wmi,
+--- a/drivers/net/wireless/ath/ath11k/wmi.h
++++ b/drivers/net/wireless/ath/ath11k/wmi.h
+@@ -2317,6 +2317,7 @@ struct wmi_init_cmd {
+ } __packed;
+ 
+ #define WMI_RSRC_CFG_FLAG1_BSS_CHANNEL_INFO_64 BIT(5)
++#define WMI_RSRC_CFG_FLAG2_CALC_NEXT_DTIM_COUNT_SET BIT(9)
+ #define WMI_RSRC_CFG_FLAG1_ACK_RSSI BIT(18)
+ 
+ #define WMI_CFG_HOST_SERVICE_FLAG_REG_CC_EXT 4
+@@ -2389,6 +2390,9 @@ struct wmi_resource_config {
+ 	u32 msdu_flow_override_config1;
+ 	u32 flags2;
+ 	u32 host_service_flags;
++	u32 max_rnr_neighbours;
++	u32 ema_max_vap_cnt;
++	u32 ema_max_profile_period;
+ } __packed;
+ 
+ struct wmi_service_ready_event {
+@@ -5646,6 +5650,8 @@ struct target_resource_config {
+ 	u32 twt_ap_pdev_count;
+ 	u32 twt_ap_sta_count;
+ 	u8 is_reg_cc_ext_event_supported;
++	u32 ema_max_vap_cnt;
++	u32 ema_max_profile_period;
+ };
+ 
+ enum wmi_debug_log_param {

--- a/package/kernel/mac80211/patches/ath11k/0072-wifi-ath11k-MBSSID-configuration-during-vdev-create-.patch
+++ b/package/kernel/mac80211/patches/ath11k/0072-wifi-ath11k-MBSSID-configuration-during-vdev-create-.patch
@@ -1,0 +1,215 @@
+From 5a81610acf66c4ad6e1a1fbd09f3f555fca863b1 Mon Sep 17 00:00:00 2001
+From: Aloka Dixit <quic_alokad@quicinc.com>
+Date: Fri, 5 May 2023 16:11:27 +0300
+Subject: [PATCH 72/77] wifi: ath11k: MBSSID configuration during vdev
+ create/start
+
+Configure multiple BSSID flags and index of the transmitting interface
+in vdev create/start commands depending on the service bit
+WMI_TLV_SERVICE_MBSS_PARAM_IN_VDEV_START_SUPPORT.
+
+Tested-on: IPQ8074 hw2.0 AHB WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Aloka Dixit <quic_alokad@quicinc.com>
+Co-developed-by: John Crispin <john@phrozen.org>
+Signed-off-by: John Crispin <john@phrozen.org>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230405221648.17950-3-quic_alokad@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 70 +++++++++++++++++++++++++--
+ drivers/net/wireless/ath/ath11k/wmi.c |  5 ++
+ drivers/net/wireless/ath/ath11k/wmi.h | 19 ++++++++
+ 3 files changed, 90 insertions(+), 4 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -6181,17 +6181,62 @@ static void ath11k_mac_op_stop(struct ie
+ 	atomic_set(&ar->num_pending_mgmt_tx, 0);
+ }
+ 
+-static void
+-ath11k_mac_setup_vdev_create_params(struct ath11k_vif *arvif,
+-				    struct vdev_create_params *params)
++static int ath11k_mac_setup_vdev_params_mbssid(struct ath11k_vif *arvif,
++					       u32 *flags, u32 *tx_vdev_id)
++{
++	struct ath11k *ar = arvif->ar;
++	struct ath11k_vif *tx_arvif;
++	struct ieee80211_vif *tx_vif;
++
++	*tx_vdev_id = 0;
++	tx_vif = arvif->vif->mbssid_tx_vif;
++	if (!tx_vif) {
++		*flags = WMI_HOST_VDEV_FLAGS_NON_MBSSID_AP;
++		return 0;
++	}
++
++	tx_arvif = (void *)tx_vif->drv_priv;
++
++	if (arvif->vif->bss_conf.nontransmitted) {
++		if (ar->hw->wiphy != ieee80211_vif_to_wdev(tx_vif)->wiphy)
++			return -EINVAL;
++
++		*flags = WMI_HOST_VDEV_FLAGS_NON_TRANSMIT_AP;
++		*tx_vdev_id = ath11k_vif_to_arvif(tx_vif)->vdev_id;
++	} else if (tx_arvif == arvif) {
++		*flags = WMI_HOST_VDEV_FLAGS_TRANSMIT_AP;
++	} else {
++		return -EINVAL;
++	}
++
++	if (arvif->vif->bss_conf.ema_ap)
++		*flags |= WMI_HOST_VDEV_FLAGS_EMA_MODE;
++
++	return 0;
++}
++
++static int ath11k_mac_setup_vdev_create_params(struct ath11k_vif *arvif,
++					       struct vdev_create_params *params)
+ {
+ 	struct ath11k *ar = arvif->ar;
+ 	struct ath11k_pdev *pdev = ar->pdev;
++	int ret;
+ 
+ 	params->if_id = arvif->vdev_id;
+ 	params->type = arvif->vdev_type;
+ 	params->subtype = arvif->vdev_subtype;
+ 	params->pdev_id = pdev->pdev_id;
++	params->mbssid_flags = 0;
++	params->mbssid_tx_vdev_id = 0;
++
++	if (!test_bit(WMI_TLV_SERVICE_MBSS_PARAM_IN_VDEV_START_SUPPORT,
++		      ar->ab->wmi_ab.svc_map)) {
++		ret = ath11k_mac_setup_vdev_params_mbssid(arvif,
++							  &params->mbssid_flags,
++							  &params->mbssid_tx_vdev_id);
++		if (ret)
++			return ret;
++	}
+ 
+ 	if (pdev->cap.supported_bands & WMI_HOST_WLAN_2G_CAP) {
+ 		params->chains[NL80211_BAND_2GHZ].tx = ar->num_tx_chains;
+@@ -6206,6 +6251,7 @@ ath11k_mac_setup_vdev_create_params(stru
+ 		params->chains[NL80211_BAND_6GHZ].tx = ar->num_tx_chains;
+ 		params->chains[NL80211_BAND_6GHZ].rx = ar->num_rx_chains;
+ 	}
++	return 0;
+ }
+ 
+ static void ath11k_mac_op_update_vif_offload(struct ieee80211_hw *hw,
+@@ -6500,7 +6546,12 @@ static int ath11k_mac_op_add_interface(s
+ 	for (i = 0; i < ARRAY_SIZE(vif->hw_queue); i++)
+ 		vif->hw_queue[i] = i % (ATH11K_HW_MAX_QUEUES - 1);
+ 
+-	ath11k_mac_setup_vdev_create_params(arvif, &vdev_param);
++	ret = ath11k_mac_setup_vdev_create_params(arvif, &vdev_param);
++	if (ret) {
++		ath11k_warn(ab, "failed to create vdev parameters %d: %d\n",
++			    arvif->vdev_id, ret);
++		goto err;
++	}
+ 
+ 	ret = ath11k_wmi_vdev_create(ar, vif->addr, &vdev_param);
+ 	if (ret) {
+@@ -6905,6 +6956,17 @@ ath11k_mac_vdev_start_restart(struct ath
+ 	arg.pref_tx_streams = ar->num_tx_chains;
+ 	arg.pref_rx_streams = ar->num_rx_chains;
+ 
++	arg.mbssid_flags = 0;
++	arg.mbssid_tx_vdev_id = 0;
++	if (test_bit(WMI_TLV_SERVICE_MBSS_PARAM_IN_VDEV_START_SUPPORT,
++		     ar->ab->wmi_ab.svc_map)) {
++		ret = ath11k_mac_setup_vdev_params_mbssid(arvif,
++							  &arg.mbssid_flags,
++							  &arg.mbssid_tx_vdev_id);
++		if (ret)
++			return ret;
++	}
++
+ 	if (arvif->vdev_type == WMI_VDEV_TYPE_AP) {
+ 		arg.ssid = arvif->u.ap.ssid;
+ 		arg.ssid_len = arvif->u.ap.ssid_len;
+--- a/drivers/net/wireless/ath/ath11k/wmi.c
++++ b/drivers/net/wireless/ath/ath11k/wmi.c
+@@ -724,6 +724,9 @@ int ath11k_wmi_vdev_create(struct ath11k
+ 	cmd->vdev_subtype = param->subtype;
+ 	cmd->num_cfg_txrx_streams = WMI_NUM_SUPPORTED_BAND_MAX;
+ 	cmd->pdev_id = param->pdev_id;
++	cmd->mbssid_flags = param->mbssid_flags;
++	cmd->mbssid_tx_vdev_id = param->mbssid_tx_vdev_id;
++
+ 	ether_addr_copy(cmd->vdev_macaddr.addr, macaddr);
+ 
+ 	ptr = skb->data + sizeof(*cmd);
+@@ -941,6 +944,8 @@ int ath11k_wmi_vdev_start(struct ath11k
+ 	cmd->cac_duration_ms = arg->cac_duration_ms;
+ 	cmd->regdomain = arg->regdomain;
+ 	cmd->he_ops = arg->he_ops;
++	cmd->mbssid_flags = arg->mbssid_flags;
++	cmd->mbssid_tx_vdev_id = arg->mbssid_tx_vdev_id;
+ 
+ 	if (!restart) {
+ 		if (arg->ssid) {
+--- a/drivers/net/wireless/ath/ath11k/wmi.h
++++ b/drivers/net/wireless/ath/ath11k/wmi.h
+@@ -137,6 +137,14 @@ enum {
+ 	WMI_AUTORATE_3200NS_GI = BIT(11),
+ };
+ 
++enum {
++	WMI_HOST_VDEV_FLAGS_NON_MBSSID_AP       = 0x00000001,
++	WMI_HOST_VDEV_FLAGS_TRANSMIT_AP         = 0x00000002,
++	WMI_HOST_VDEV_FLAGS_NON_TRANSMIT_AP     = 0x00000004,
++	WMI_HOST_VDEV_FLAGS_EMA_MODE            = 0x00000008,
++	WMI_HOST_VDEV_FLAGS_SCAN_MODE_VAP       = 0x00000010,
++};
++
+ /*
+  * wmi command groups.
+  */
+@@ -2096,6 +2104,7 @@ enum wmi_tlv_service {
+ 	WMI_TLV_SERVICE_EXT2_MSG = 220,
+ 	WMI_TLV_SERVICE_PEER_POWER_SAVE_DURATION_SUPPORT = 246,
+ 	WMI_TLV_SERVICE_SRG_SRP_SPATIAL_REUSE_SUPPORT = 249,
++	WMI_TLV_SERVICE_MBSS_PARAM_IN_VDEV_START_SUPPORT = 253,
+ 	WMI_TLV_SERVICE_PASSIVE_SCAN_START_TIME_ENHANCE = 263,
+ 
+ 	/* The second 128 bits */
+@@ -2583,6 +2592,8 @@ struct vdev_create_params {
+ 		u8 rx;
+ 	} chains[NUM_NL80211_BANDS];
+ 	u32 pdev_id;
++	u32 mbssid_flags;
++	u32 mbssid_tx_vdev_id;
+ };
+ 
+ struct wmi_vdev_create_cmd {
+@@ -2593,6 +2604,8 @@ struct wmi_vdev_create_cmd {
+ 	struct wmi_mac_addr vdev_macaddr;
+ 	u32 num_cfg_txrx_streams;
+ 	u32 pdev_id;
++	u32 mbssid_flags;
++	u32 mbssid_tx_vdev_id;
+ } __packed;
+ 
+ struct wmi_vdev_txrx_streams {
+@@ -2656,6 +2669,9 @@ struct wmi_vdev_start_request_cmd {
+ 	u32 he_ops;
+ 	u32 cac_duration_ms;
+ 	u32 regdomain;
++	u32 min_data_rate;
++	u32 mbssid_flags;
++	u32 mbssid_tx_vdev_id;
+ } __packed;
+ 
+ #define MGMT_TX_DL_FRM_LEN		     64
+@@ -2825,6 +2841,9 @@ struct wmi_vdev_start_req_arg {
+ 	u32 pref_rx_streams;
+ 	u32 pref_tx_streams;
+ 	u32 num_noa_descriptors;
++	u32 min_data_rate;
++	u32 mbssid_flags;
++	u32 mbssid_tx_vdev_id;
+ };
+ 
+ struct peer_create_params {

--- a/package/kernel/mac80211/patches/ath11k/0073-wifi-ath11k-rename-MBSSID-fields-in-wmi_vdev_up_cmd.patch
+++ b/package/kernel/mac80211/patches/ath11k/0073-wifi-ath11k-rename-MBSSID-fields-in-wmi_vdev_up_cmd.patch
@@ -1,0 +1,52 @@
+From cf604e72bc6e6db68c7fcaa8779b03ec14b8d2fa Mon Sep 17 00:00:00 2001
+From: Aloka Dixit <quic_alokad@quicinc.com>
+Date: Fri, 5 May 2023 16:11:27 +0300
+Subject: [PATCH 73/77] wifi: ath11k: rename MBSSID fields in wmi_vdev_up_cmd
+
+Rename trans_bssid to tx_vdev_bssid to make it similar to vdev_bssid.
+
+Rename profile_num to nontx_profile_cnt, and profile_idx to
+nontx_profile_idx which makes it clear that these store configurations
+related to MBSSID non-transmitting profiles.
+
+Tested-on: IPQ8074 hw2.0 AHB WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Aloka Dixit <quic_alokad@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230405221648.17950-4-quic_alokad@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/wmi.c | 6 +++---
+ drivers/net/wireless/ath/ath11k/wmi.h | 6 +++---
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/wmi.c
++++ b/drivers/net/wireless/ath/ath11k/wmi.c
+@@ -1029,10 +1029,10 @@ int ath11k_wmi_vdev_up(struct ath11k *ar
+ 		bss_conf = &arvif->vif->bss_conf;
+ 
+ 		if (bss_conf->nontransmitted) {
+-			ether_addr_copy(cmd->trans_bssid.addr,
++			ether_addr_copy(cmd->tx_vdev_bssid.addr,
+ 					bss_conf->transmitter_bssid);
+-			cmd->profile_idx = bss_conf->bssid_index;
+-			cmd->profile_num = bss_conf->bssid_indicator;
++			cmd->nontx_profile_idx = bss_conf->bssid_index;
++			cmd->nontx_profile_cnt = bss_conf->bssid_indicator;
+ 		}
+ 	}
+ 
+--- a/drivers/net/wireless/ath/ath11k/wmi.h
++++ b/drivers/net/wireless/ath/ath11k/wmi.h
+@@ -2625,9 +2625,9 @@ struct wmi_vdev_up_cmd {
+ 	u32 vdev_id;
+ 	u32 vdev_assoc_id;
+ 	struct wmi_mac_addr vdev_bssid;
+-	struct wmi_mac_addr trans_bssid;
+-	u32 profile_idx;
+-	u32 profile_num;
++	struct wmi_mac_addr tx_vdev_bssid;
++	u32 nontx_profile_idx;
++	u32 nontx_profile_cnt;
+ } __packed;
+ 
+ struct wmi_vdev_stop_cmd {

--- a/package/kernel/mac80211/patches/ath11k/0074-wifi-ath11k-MBSSID-parameter-configuration-in-AP-mod.patch
+++ b/package/kernel/mac80211/patches/ath11k/0074-wifi-ath11k-MBSSID-parameter-configuration-in-AP-mod.patch
@@ -1,0 +1,138 @@
+From c82dc33f252fd8883be66f2d0230af0fd734c683 Mon Sep 17 00:00:00 2001
+From: Aloka Dixit <quic_alokad@quicinc.com>
+Date: Fri, 5 May 2023 16:11:27 +0300
+Subject: [PATCH 74/77] wifi: ath11k: MBSSID parameter configuration in AP mode
+
+Include MBSSID parameters in WMI vdev up operation.
+
+Tested-on: IPQ8074 hw2.0 AHB WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Aloka Dixit <quic_alokad@quicinc.com>
+Co-developed-by: John Crispin <john@phrozen.org>
+Signed-off-by: John Crispin <john@phrozen.org>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230405221648.17950-5-quic_alokad@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 29 +++++++++++++++++++++------
+ drivers/net/wireless/ath/ath11k/wmi.c |  8 +++++++-
+ drivers/net/wireless/ath/ath11k/wmi.h |  3 ++-
+ 3 files changed, 32 insertions(+), 8 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -964,7 +964,7 @@ static int ath11k_mac_monitor_vdev_start
+ 		return ret;
+ 	}
+ 
+-	ret = ath11k_wmi_vdev_up(ar, vdev_id, 0, ar->mac_addr);
++	ret = ath11k_wmi_vdev_up(ar, vdev_id, 0, ar->mac_addr, NULL, 0, 0);
+ 	if (ret) {
+ 		ath11k_warn(ar->ab, "failed to put up monitor vdev %i: %d\n",
+ 			    vdev_id, ret);
+@@ -1423,6 +1423,7 @@ static void ath11k_control_beaconing(str
+ 				     struct ieee80211_bss_conf *info)
+ {
+ 	struct ath11k *ar = arvif->ar;
++	struct ath11k_vif *tx_arvif = NULL;
+ 	int ret = 0;
+ 
+ 	lockdep_assert_held(&arvif->ar->conf_mutex);
+@@ -1451,8 +1452,14 @@ static void ath11k_control_beaconing(str
+ 
+ 	ether_addr_copy(arvif->bssid, info->bssid);
+ 
++	if (arvif->vif->mbssid_tx_vif)
++		tx_arvif = (struct ath11k_vif *)arvif->vif->mbssid_tx_vif->drv_priv;
++
+ 	ret = ath11k_wmi_vdev_up(arvif->ar, arvif->vdev_id, arvif->aid,
+-				 arvif->bssid);
++				 arvif->bssid,
++				 tx_arvif ? tx_arvif->bssid : NULL,
++				 info->bssid_index,
++				 1 << info->bssid_indicator);
+ 	if (ret) {
+ 		ath11k_warn(ar->ab, "failed to bring up vdev %d: %i\n",
+ 			    arvif->vdev_id, ret);
+@@ -2879,7 +2886,8 @@ static void ath11k_bss_assoc(struct ieee
+ 	arvif->aid = vif->cfg.aid;
+ 	ether_addr_copy(arvif->bssid, bss_conf->bssid);
+ 
+-	ret = ath11k_wmi_vdev_up(ar, arvif->vdev_id, arvif->aid, arvif->bssid);
++	ret = ath11k_wmi_vdev_up(ar, arvif->vdev_id, arvif->aid, arvif->bssid,
++				 NULL, 0, 0);
+ 	if (ret) {
+ 		ath11k_warn(ar->ab, "failed to set vdev %d up: %d\n",
+ 			    arvif->vdev_id, ret);
+@@ -7133,7 +7141,8 @@ ath11k_mac_update_vif_chan(struct ath11k
+ 			   int n_vifs)
+ {
+ 	struct ath11k_base *ab = ar->ab;
+-	struct ath11k_vif *arvif;
++	struct ath11k_vif *arvif, *tx_arvif = NULL;
++	struct ieee80211_vif *mbssid_tx_vif;
+ 	int ret;
+ 	int i;
+ 	bool monitor_vif = false;
+@@ -7187,8 +7196,15 @@ ath11k_mac_update_vif_chan(struct ath11k
+ 			ath11k_warn(ab, "failed to update bcn tmpl during csa: %d\n",
+ 				    ret);
+ 
++		mbssid_tx_vif = arvif->vif->mbssid_tx_vif;
++		if (mbssid_tx_vif)
++			tx_arvif = (struct ath11k_vif *)mbssid_tx_vif->drv_priv;
++
+ 		ret = ath11k_wmi_vdev_up(arvif->ar, arvif->vdev_id, arvif->aid,
+-					 arvif->bssid);
++					 arvif->bssid,
++					 tx_arvif ? tx_arvif->bssid : NULL,
++					 arvif->vif->bss_conf.bssid_index,
++					 1 << arvif->vif->bss_conf.bssid_indicator);
+ 		if (ret) {
+ 			ath11k_warn(ab, "failed to bring vdev up %d: %d\n",
+ 				    arvif->vdev_id, ret);
+@@ -7306,7 +7322,8 @@ static int ath11k_start_vdev_delay(struc
+ 	}
+ 
+ 	if (arvif->vdev_type == WMI_VDEV_TYPE_MONITOR) {
+-		ret = ath11k_wmi_vdev_up(ar, arvif->vdev_id, 0, ar->mac_addr);
++		ret = ath11k_wmi_vdev_up(ar, arvif->vdev_id, 0, ar->mac_addr,
++					 NULL, 0, 0);
+ 		if (ret) {
+ 			ath11k_warn(ab, "failed put monitor up: %d\n", ret);
+ 			return ret;
+--- a/drivers/net/wireless/ath/ath11k/wmi.c
++++ b/drivers/net/wireless/ath/ath11k/wmi.c
+@@ -1001,7 +1001,8 @@ int ath11k_wmi_vdev_start(struct ath11k
+ 	return ret;
+ }
+ 
+-int ath11k_wmi_vdev_up(struct ath11k *ar, u32 vdev_id, u32 aid, const u8 *bssid)
++int ath11k_wmi_vdev_up(struct ath11k *ar, u32 vdev_id, u32 aid, const u8 *bssid,
++		       u8 *tx_bssid, u32 nontx_profile_idx, u32 nontx_profile_cnt)
+ {
+ 	struct ath11k_pdev_wmi *wmi = ar->wmi;
+ 	struct wmi_vdev_up_cmd *cmd;
+@@ -1025,6 +1026,11 @@ int ath11k_wmi_vdev_up(struct ath11k *ar
+ 
+ 	ether_addr_copy(cmd->vdev_bssid.addr, bssid);
+ 
++	cmd->nontx_profile_idx = nontx_profile_idx;
++	cmd->nontx_profile_cnt = nontx_profile_cnt;
++	if (tx_bssid)
++		ether_addr_copy(cmd->tx_vdev_bssid.addr, tx_bssid);
++
+ 	if (arvif && arvif->vif->type == NL80211_IFTYPE_STATION) {
+ 		bss_conf = &arvif->vif->bss_conf;
+ 
+--- a/drivers/net/wireless/ath/ath11k/wmi.h
++++ b/drivers/net/wireless/ath/ath11k/wmi.h
+@@ -6301,7 +6301,8 @@ int ath11k_wmi_bcn_tmpl(struct ath11k *a
+ 			struct sk_buff *bcn);
+ int ath11k_wmi_vdev_down(struct ath11k *ar, u8 vdev_id);
+ int ath11k_wmi_vdev_up(struct ath11k *ar, u32 vdev_id, u32 aid,
+-		       const u8 *bssid);
++		       const u8 *bssid, u8 *tx_bssid, u32 nontx_profile_idx,
++		       u32 nontx_profile_cnt);
+ int ath11k_wmi_vdev_stop(struct ath11k *ar, u8 vdev_id);
+ int ath11k_wmi_vdev_start(struct ath11k *ar, struct wmi_vdev_start_req_arg *arg,
+ 			  bool restart);

--- a/package/kernel/mac80211/patches/ath11k/0075-wifi-ath11k-refactor-vif-parameter-configurations.patch
+++ b/package/kernel/mac80211/patches/ath11k/0075-wifi-ath11k-refactor-vif-parameter-configurations.patch
@@ -1,0 +1,86 @@
+From cb9bea773c85e372931cd7a177db4165adf29d95 Mon Sep 17 00:00:00 2001
+From: Aloka Dixit <quic_alokad@quicinc.com>
+Date: Fri, 5 May 2023 16:11:28 +0300
+Subject: [PATCH 75/77] wifi: ath11k: refactor vif parameter configurations
+
+Security parameters for each non-transmitting profile can be
+different when MBSSID is enabled and this information is included
+in the MBSSID element in the Beacon frame. Current implementation
+to set rsnie_present and wpaie_present does not parse this element
+hence it applies only to the transmitting interface.
+
+Move the code to a separate function to make additions for
+non-transmitting interfaces cleaner.
+
+Tested-on: IPQ8074 hw2.0 AHB WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Aloka Dixit <quic_alokad@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230405221648.17950-6-quic_alokad@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 41 ++++++++++++++++-----------
+ 1 file changed, 24 insertions(+), 17 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -1351,28 +1351,14 @@ err_mon_del:
+ 	return ret;
+ }
+ 
+-static int ath11k_mac_setup_bcn_tmpl(struct ath11k_vif *arvif)
++static void ath11k_mac_set_vif_params(struct ath11k_vif *arvif,
++				      struct sk_buff *bcn)
+ {
+-	struct ath11k *ar = arvif->ar;
+-	struct ath11k_base *ab = ar->ab;
+-	struct ieee80211_hw *hw = ar->hw;
+-	struct ieee80211_vif *vif = arvif->vif;
+-	struct ieee80211_mutable_offsets offs = {};
+-	struct sk_buff *bcn;
+ 	struct ieee80211_mgmt *mgmt;
+ 	u8 *ies;
+-	int ret;
+-
+-	if (arvif->vdev_type != WMI_VDEV_TYPE_AP)
+-		return 0;
+-
+-	bcn = ieee80211_beacon_get_template(hw, vif, &offs, 0);
+-	if (!bcn) {
+-		ath11k_warn(ab, "failed to get beacon template from mac80211\n");
+-		return -EPERM;
+-	}
+ 
+ 	ies = bcn->data + ieee80211_get_hdrlen_from_skb(bcn);
++	mgmt = (struct ieee80211_mgmt *)bcn->data;
+ 	ies += sizeof(mgmt->u.beacon);
+ 
+ 	if (cfg80211_find_ie(WLAN_EID_RSN, ies, (skb_tail_pointer(bcn) - ies)))
+@@ -1386,7 +1372,28 @@ static int ath11k_mac_setup_bcn_tmpl(str
+ 		arvif->wpaie_present = true;
+ 	else
+ 		arvif->wpaie_present = false;
++}
++
++static int ath11k_mac_setup_bcn_tmpl(struct ath11k_vif *arvif)
++{
++	struct ath11k *ar = arvif->ar;
++	struct ath11k_base *ab = ar->ab;
++	struct ieee80211_hw *hw = ar->hw;
++	struct ieee80211_vif *vif = arvif->vif;
++	struct ieee80211_mutable_offsets offs = {};
++	struct sk_buff *bcn;
++	int ret;
++
++	if (arvif->vdev_type != WMI_VDEV_TYPE_AP)
++		return 0;
++
++	bcn = ieee80211_beacon_get_template(hw, vif, &offs, 0);
++	if (!bcn) {
++		ath11k_warn(ab, "failed to get beacon template from mac80211\n");
++		return -EPERM;
++	}
+ 
++	ath11k_mac_set_vif_params(arvif, bcn);
+ 	ret = ath11k_wmi_bcn_tmpl(ar, arvif->vdev_id, &offs, bcn);
+ 
+ 	kfree_skb(bcn);

--- a/package/kernel/mac80211/patches/ath11k/0076-wifi-ath11k-MBSSID-beacon-support.patch
+++ b/package/kernel/mac80211/patches/ath11k/0076-wifi-ath11k-MBSSID-beacon-support.patch
@@ -1,0 +1,190 @@
+From 335a92765d308dfe22826f5562cd4b4389b45e71 Mon Sep 17 00:00:00 2001
+From: Aloka Dixit <quic_alokad@quicinc.com>
+Date: Fri, 5 May 2023 16:11:28 +0300
+Subject: [PATCH 76/77] wifi: ath11k: MBSSID beacon support
+
+- Split ath11k_mac_setup_bcn_tmpl() to move the beacon retrieval and
+  WMI command to a new function, ath11k_mac_setup_bcn_tmpl_legacy().
+  In the original function add checks to use the transmitting interface
+  when MBSSID is enabled.
+- Set rsnie_present and wpaie_present fields for the non-transmitting
+  interfaces when MBSSID is enabled.
+
+Tested-on: IPQ8074 hw2.0 AHB WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Aloka Dixit <quic_alokad@quicinc.com>
+Co-developed-by: John Crispin <john@phrozen.org>
+Signed-off-by: John Crispin <john@phrozen.org>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230405221648.17950-7-quic_alokad@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 116 ++++++++++++++++++++++++--
+ drivers/net/wireless/ath/ath11k/wmi.c |   1 +
+ 2 files changed, 112 insertions(+), 5 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -1351,6 +1351,84 @@ err_mon_del:
+ 	return ret;
+ }
+ 
++static void ath11k_mac_setup_nontx_vif_rsnie(struct ath11k_vif *arvif,
++					     bool tx_arvif_rsnie_present,
++					     const u8 *profile, u8 profile_len)
++{
++	if (cfg80211_find_ie(WLAN_EID_RSN, profile, profile_len)) {
++		arvif->rsnie_present = true;
++	} else if (tx_arvif_rsnie_present) {
++		int i;
++		u8 nie_len;
++		const u8 *nie = cfg80211_find_ext_ie(WLAN_EID_EXT_NON_INHERITANCE,
++						     profile, profile_len);
++		if (!nie)
++			return;
++
++		nie_len = nie[1];
++		nie += 2;
++		for (i = 0; i < nie_len; i++) {
++			if (nie[i] == WLAN_EID_RSN) {
++				arvif->rsnie_present = false;
++				break;
++			}
++		}
++	}
++}
++
++static bool ath11k_mac_set_nontx_vif_params(struct ath11k_vif *tx_arvif,
++					    struct ath11k_vif *arvif,
++					    struct sk_buff *bcn)
++{
++	struct ieee80211_mgmt *mgmt;
++	const u8 *ies, *profile, *next_profile;
++	int ies_len;
++
++	ies = bcn->data + ieee80211_get_hdrlen_from_skb(bcn);
++	mgmt = (struct ieee80211_mgmt *)bcn->data;
++	ies += sizeof(mgmt->u.beacon);
++	ies_len = skb_tail_pointer(bcn) - ies;
++
++	ies = cfg80211_find_ie(WLAN_EID_MULTIPLE_BSSID, ies, ies_len);
++	arvif->rsnie_present = tx_arvif->rsnie_present;
++
++	while (ies) {
++		u8 mbssid_len;
++
++		ies_len -= (2 + ies[1]);
++		mbssid_len = ies[1] - 1;
++		profile = &ies[3];
++
++		while (mbssid_len) {
++			u8 profile_len;
++
++			profile_len = profile[1];
++			next_profile = profile + (2 + profile_len);
++			mbssid_len -= (2 + profile_len);
++
++			profile += 2;
++			profile_len -= (2 + profile[1]);
++			profile += (2 + profile[1]); /* nontx capabilities */
++			profile_len -= (2 + profile[1]);
++			profile += (2 + profile[1]); /* SSID */
++			if (profile[2] == arvif->vif->bss_conf.bssid_index) {
++				profile_len -= 5;
++				profile = profile + 5;
++				ath11k_mac_setup_nontx_vif_rsnie(arvif,
++								 tx_arvif->rsnie_present,
++								 profile,
++								 profile_len);
++				return true;
++			}
++			profile = next_profile;
++		}
++		ies = cfg80211_find_ie(WLAN_EID_MULTIPLE_BSSID, profile,
++				       ies_len);
++	}
++
++	return false;
++}
++
+ static void ath11k_mac_set_vif_params(struct ath11k_vif *arvif,
+ 				      struct sk_buff *bcn)
+ {
+@@ -1374,18 +1452,26 @@ static void ath11k_mac_set_vif_params(st
+ 		arvif->wpaie_present = false;
+ }
+ 
+-static int ath11k_mac_setup_bcn_tmpl(struct ath11k_vif *arvif)
++static int ath11k_mac_setup_bcn_tmpl_mbssid(struct ath11k_vif *arvif)
+ {
+ 	struct ath11k *ar = arvif->ar;
+ 	struct ath11k_base *ab = ar->ab;
++	struct ath11k_vif *tx_arvif = arvif;
+ 	struct ieee80211_hw *hw = ar->hw;
+ 	struct ieee80211_vif *vif = arvif->vif;
+ 	struct ieee80211_mutable_offsets offs = {};
+ 	struct sk_buff *bcn;
+ 	int ret;
+ 
+-	if (arvif->vdev_type != WMI_VDEV_TYPE_AP)
+-		return 0;
++	if (arvif->vif->mbssid_tx_vif) {
++		tx_arvif = (void *)arvif->vif->mbssid_tx_vif->drv_priv;
++		if (tx_arvif != arvif) {
++			ar = tx_arvif->ar;
++			ab = ar->ab;
++			hw = ar->hw;
++			vif = tx_arvif->vif;
++		}
++	}
+ 
+ 	bcn = ieee80211_beacon_get_template(hw, vif, &offs, 0);
+ 	if (!bcn) {
+@@ -1393,9 +1479,12 @@ static int ath11k_mac_setup_bcn_tmpl(str
+ 		return -EPERM;
+ 	}
+ 
+-	ath11k_mac_set_vif_params(arvif, bcn);
+-	ret = ath11k_wmi_bcn_tmpl(ar, arvif->vdev_id, &offs, bcn);
++	if (tx_arvif == arvif)
++		ath11k_mac_set_vif_params(tx_arvif, bcn);
++	else if (!ath11k_mac_set_nontx_vif_params(tx_arvif, arvif, bcn))
++		return -EINVAL;
+ 
++	ret = ath11k_wmi_bcn_tmpl(ar, arvif->vdev_id, &offs, bcn);
+ 	kfree_skb(bcn);
+ 
+ 	if (ret)
+@@ -1405,6 +1494,23 @@ static int ath11k_mac_setup_bcn_tmpl(str
+ 	return ret;
+ }
+ 
++static int ath11k_mac_setup_bcn_tmpl(struct ath11k_vif *arvif)
++{
++	struct ieee80211_vif *vif = arvif->vif;
++
++	if (arvif->vdev_type != WMI_VDEV_TYPE_AP)
++		return 0;
++
++	/* Target does not expect beacon templates for the already up
++	 * non-transmitting interfaces, and results in a crash if sent.
++	 */
++	if (vif->mbssid_tx_vif &&
++	    arvif != (void *)vif->mbssid_tx_vif->drv_priv && arvif->is_up)
++		return 0;
++
++	return ath11k_mac_setup_bcn_tmpl_mbssid(arvif);
++}
++
+ void ath11k_mac_bcn_tx_event(struct ath11k_vif *arvif)
+ {
+ 	struct ieee80211_vif *vif = arvif->vif;
+--- a/drivers/net/wireless/ath/ath11k/wmi.c
++++ b/drivers/net/wireless/ath/ath11k/wmi.c
+@@ -1737,6 +1737,7 @@ int ath11k_wmi_bcn_tmpl(struct ath11k *a
+ 	}
+ 
+ 	cmd->buf_len = bcn->len;
++	cmd->mbssid_ie_offset = offs->mbssid_off;
+ 
+ 	ptr = skb->data + sizeof(*cmd);
+ 

--- a/package/kernel/mac80211/patches/ath11k/0077-wifi-ath11k-EMA-beacon-support.patch
+++ b/package/kernel/mac80211/patches/ath11k/0077-wifi-ath11k-EMA-beacon-support.patch
@@ -1,0 +1,156 @@
+From 87bd401138161008fdb82fbca6e213af117bfeb9 Mon Sep 17 00:00:00 2001
+From: Aloka Dixit <quic_alokad@quicinc.com>
+Date: Fri, 5 May 2023 16:11:28 +0300
+Subject: [PATCH 77/77] wifi: ath11k: EMA beacon support
+
+Add new function ath11k_mac_setup_bcn_tmpl_ema() which invokes the new
+API provided by MAC80211 to retrieve EMA beacons.
+
+Tested-on: IPQ8074 hw2.0 AHB WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Aloka Dixit <quic_alokad@quicinc.com>
+Co-developed-by: John Crispin <john@phrozen.org>
+Signed-off-by: John Crispin <john@phrozen.org>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230405221648.17950-8-quic_alokad@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 59 ++++++++++++++++++++++++++-
+ drivers/net/wireless/ath/ath11k/wmi.c |  3 +-
+ drivers/net/wireless/ath/ath11k/wmi.h | 11 ++++-
+ 3 files changed, 70 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -1452,6 +1452,60 @@ static void ath11k_mac_set_vif_params(st
+ 		arvif->wpaie_present = false;
+ }
+ 
++static int ath11k_mac_setup_bcn_tmpl_ema(struct ath11k_vif *arvif)
++{
++	struct ath11k_vif *tx_arvif;
++	struct ieee80211_ema_beacons *beacons;
++	int ret = 0;
++	bool nontx_vif_params_set = false;
++	u32 params = 0;
++	u8 i = 0;
++
++	tx_arvif = (void *)arvif->vif->mbssid_tx_vif->drv_priv;
++
++	beacons = ieee80211_beacon_get_template_ema_list(tx_arvif->ar->hw,
++							 tx_arvif->vif, 0);
++	if (!beacons || !beacons->cnt) {
++		ath11k_warn(arvif->ar->ab,
++			    "failed to get ema beacon templates from mac80211\n");
++		return -EPERM;
++	}
++
++	if (tx_arvif == arvif)
++		ath11k_mac_set_vif_params(tx_arvif, beacons->bcn[0].skb);
++	else
++		arvif->wpaie_present = tx_arvif->wpaie_present;
++
++	for (i = 0; i < beacons->cnt; i++) {
++		if (tx_arvif != arvif && !nontx_vif_params_set)
++			nontx_vif_params_set =
++				ath11k_mac_set_nontx_vif_params(tx_arvif, arvif,
++								beacons->bcn[i].skb);
++
++		params = beacons->cnt;
++		params |= (i << WMI_EMA_TMPL_IDX_SHIFT);
++		params |= ((!i ? 1 : 0) << WMI_EMA_FIRST_TMPL_SHIFT);
++		params |= ((i + 1 == beacons->cnt ? 1 : 0) << WMI_EMA_LAST_TMPL_SHIFT);
++
++		ret = ath11k_wmi_bcn_tmpl(tx_arvif->ar, tx_arvif->vdev_id,
++					  &beacons->bcn[i].offs,
++					  beacons->bcn[i].skb, params);
++		if (ret) {
++			ath11k_warn(tx_arvif->ar->ab,
++				    "failed to set ema beacon template id %i error %d\n",
++				    i, ret);
++			break;
++		}
++	}
++
++	ieee80211_beacon_free_ema_list(beacons);
++
++	if (tx_arvif != arvif && !nontx_vif_params_set)
++		return -EINVAL; /* Profile not found in the beacons */
++
++	return ret;
++}
++
+ static int ath11k_mac_setup_bcn_tmpl_mbssid(struct ath11k_vif *arvif)
+ {
+ 	struct ath11k *ar = arvif->ar;
+@@ -1484,7 +1538,7 @@ static int ath11k_mac_setup_bcn_tmpl_mbs
+ 	else if (!ath11k_mac_set_nontx_vif_params(tx_arvif, arvif, bcn))
+ 		return -EINVAL;
+ 
+-	ret = ath11k_wmi_bcn_tmpl(ar, arvif->vdev_id, &offs, bcn);
++	ret = ath11k_wmi_bcn_tmpl(ar, arvif->vdev_id, &offs, bcn, 0);
+ 	kfree_skb(bcn);
+ 
+ 	if (ret)
+@@ -1508,6 +1562,9 @@ static int ath11k_mac_setup_bcn_tmpl(str
+ 	    arvif != (void *)vif->mbssid_tx_vif->drv_priv && arvif->is_up)
+ 		return 0;
+ 
++	if (vif->bss_conf.ema_ap && vif->mbssid_tx_vif)
++		return ath11k_mac_setup_bcn_tmpl_ema(arvif);
++
+ 	return ath11k_mac_setup_bcn_tmpl_mbssid(arvif);
+ }
+ 
+--- a/drivers/net/wireless/ath/ath11k/wmi.c
++++ b/drivers/net/wireless/ath/ath11k/wmi.c
+@@ -1699,7 +1699,7 @@ int ath11k_wmi_send_bcn_offload_control_
+ 
+ int ath11k_wmi_bcn_tmpl(struct ath11k *ar, u32 vdev_id,
+ 			struct ieee80211_mutable_offsets *offs,
+-			struct sk_buff *bcn)
++			struct sk_buff *bcn, u32 ema_params)
+ {
+ 	struct ath11k_pdev_wmi *wmi = ar->wmi;
+ 	struct wmi_bcn_tmpl_cmd *cmd;
+@@ -1738,6 +1738,7 @@ int ath11k_wmi_bcn_tmpl(struct ath11k *a
+ 
+ 	cmd->buf_len = bcn->len;
+ 	cmd->mbssid_ie_offset = offs->mbssid_off;
++	cmd->ema_params = ema_params;
+ 
+ 	ptr = skb->data + sizeof(*cmd);
+ 
+--- a/drivers/net/wireless/ath/ath11k/wmi.h
++++ b/drivers/net/wireless/ath/ath11k/wmi.h
+@@ -3566,6 +3566,10 @@ struct wmi_get_pdev_temperature_cmd {
+ 
+ #define WMI_BEACON_TX_BUFFER_SIZE	512
+ 
++#define WMI_EMA_TMPL_IDX_SHIFT            8
++#define WMI_EMA_FIRST_TMPL_SHIFT          16
++#define WMI_EMA_LAST_TMPL_SHIFT           24
++
+ struct wmi_bcn_tmpl_cmd {
+ 	u32 tlv_header;
+ 	u32 vdev_id;
+@@ -3576,6 +3580,11 @@ struct wmi_bcn_tmpl_cmd {
+ 	u32 csa_event_bitmap;
+ 	u32 mbssid_ie_offset;
+ 	u32 esp_ie_offset;
++	u32 csc_switch_count_offset;
++	u32 csc_event_bitmap;
++	u32 mu_edca_ie_offset;
++	u32 feature_enable_bitmap;
++	u32 ema_params;
+ } __packed;
+ 
+ struct wmi_key_seq_counter {
+@@ -6298,7 +6307,7 @@ int ath11k_wmi_mgmt_send(struct ath11k *
+ 			 struct sk_buff *frame);
+ int ath11k_wmi_bcn_tmpl(struct ath11k *ar, u32 vdev_id,
+ 			struct ieee80211_mutable_offsets *offs,
+-			struct sk_buff *bcn);
++			struct sk_buff *bcn, u32 ema_param);
+ int ath11k_wmi_vdev_down(struct ath11k *ar, u8 vdev_id);
+ int ath11k_wmi_vdev_up(struct ath11k *ar, u32 vdev_id, u32 aid,
+ 		       const u8 *bssid, u8 *tx_bssid, u32 nontx_profile_idx,

--- a/package/kernel/mac80211/patches/ath11k/0078-wifi-ath11k-Relocate-the-func-ath11k_mac_bitrate_mas.patch
+++ b/package/kernel/mac80211/patches/ath11k/0078-wifi-ath11k-Relocate-the-func-ath11k_mac_bitrate_mas.patch
@@ -1,0 +1,75 @@
+From 570eec3d40505c30babbe3b8f85a38496c975ab2 Mon Sep 17 00:00:00 2001
+From: Maharaja Kennadyrajan <quic_mkenna@quicinc.com>
+Date: Tue, 9 May 2023 20:07:23 +0300
+Subject: [PATCH] wifi: ath11k: Relocate the func
+ ath11k_mac_bitrate_mask_num_ht_rates() and change hweight16 to hweight8
+
+Relocate the function ath11k_mac_bitrate_mask_num_ht_rates() definition
+to call this function from other functions which helps to avoid the
+compilation error (function not defined).
+
+ht_mcs[] is 1 byte array and it is enough to use hweight8() instead
+of hweight16(). Hence, fixed the same.
+
+Tested on: Compile tested only.
+
+Signed-off-by: Maharaja Kennadyrajan <quic_mkenna@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230504092033.3542456-2-quic_mkenna@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 30 +++++++++++++--------------
+ 1 file changed, 15 insertions(+), 15 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: BSD-3-Clause-Clear
+ /*
+  * Copyright (c) 2018-2019 The Linux Foundation. All rights reserved.
+- * Copyright (c) 2021-2022 Qualcomm Innovation Center, Inc. All rights reserved.
++ * Copyright (c) 2021-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ #include <net/mac80211.h>
+@@ -4338,6 +4338,20 @@ exit:
+ }
+ 
+ static int
++ath11k_mac_bitrate_mask_num_ht_rates(struct ath11k *ar,
++				     enum nl80211_band band,
++				     const struct cfg80211_bitrate_mask *mask)
++{
++	int num_rates = 0;
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(mask->control[band].ht_mcs); i++)
++		num_rates += hweight8(mask->control[band].ht_mcs[i]);
++
++	return num_rates;
++}
++
++static int
+ ath11k_mac_bitrate_mask_num_vht_rates(struct ath11k *ar,
+ 				      enum nl80211_band band,
+ 				      const struct cfg80211_bitrate_mask *mask)
+@@ -7791,20 +7805,6 @@ static void ath11k_mac_op_flush(struct i
+ 	ath11k_mac_flush_tx_complete(ar);
+ }
+ 
+-static int
+-ath11k_mac_bitrate_mask_num_ht_rates(struct ath11k *ar,
+-				     enum nl80211_band band,
+-				     const struct cfg80211_bitrate_mask *mask)
+-{
+-	int num_rates = 0;
+-	int i;
+-
+-	for (i = 0; i < ARRAY_SIZE(mask->control[band].ht_mcs); i++)
+-		num_rates += hweight16(mask->control[band].ht_mcs[i]);
+-
+-	return num_rates;
+-}
+-
+ static bool
+ ath11k_mac_has_single_legacy_rate(struct ath11k *ar,
+ 				  enum nl80211_band band,

--- a/package/kernel/mac80211/patches/ath11k/0079-wifi-ath11k-Send-HT-fixed-rate-in-WMI-peer-fixed-par.patch
+++ b/package/kernel/mac80211/patches/ath11k/0079-wifi-ath11k-Send-HT-fixed-rate-in-WMI-peer-fixed-par.patch
@@ -1,0 +1,141 @@
+From df8e3729ffc0aa645839693f74ee7b6d999cdf64 Mon Sep 17 00:00:00 2001
+From: Maharaja Kennadyrajan <quic_mkenna@quicinc.com>
+Date: Tue, 9 May 2023 20:07:24 +0300
+Subject: [PATCH] wifi: ath11k: Send HT fixed rate in WMI peer fixed param
+
+Due to the firmware behavior with HT fixed rate setting,
+HT fixed rate MCS with NSS > 1 are treated as NSS = 1
+HT rates in the firmware and enables the HT fixed rate of
+NSS = 1.
+
+This leads to HT fixed rate is always configured for NSS = 1
+even though the user sets NSS = 2 or > 1 HT fixed MCS in the
+set bitrate command.
+
+Currently HT fixed MCS is sent via WMI peer assoc command.
+Fix this issue, by sending the HT fixed rate MCS in WMI peer
+fixed param instead of sending in peer assoc command.
+
+Tested-on: QCN9074 hw1.0 PCI WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Maharaja Kennadyrajan <quic_mkenna@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230504092033.3542456-3-quic_mkenna@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 63 ++++++++++++++++++++++++++-
+ 1 file changed, 61 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -4480,6 +4480,54 @@ ath11k_mac_set_peer_he_fixed_rate(struct
+ 	return ret;
+ }
+ 
++static int
++ath11k_mac_set_peer_ht_fixed_rate(struct ath11k_vif *arvif,
++				  struct ieee80211_sta *sta,
++				  const struct cfg80211_bitrate_mask *mask,
++				  enum nl80211_band band)
++{
++	struct ath11k *ar = arvif->ar;
++	u8 ht_rate, nss = 0;
++	u32 rate_code;
++	int ret, i;
++
++	lockdep_assert_held(&ar->conf_mutex);
++
++	for (i = 0; i < ARRAY_SIZE(mask->control[band].ht_mcs); i++) {
++		if (hweight8(mask->control[band].ht_mcs[i]) == 1) {
++			nss = i + 1;
++			ht_rate = ffs(mask->control[band].ht_mcs[i]) - 1;
++		}
++	}
++
++	if (!nss) {
++		ath11k_warn(ar->ab, "No single HT Fixed rate found to set for %pM",
++			    sta->addr);
++		return -EINVAL;
++	}
++
++	/* Avoid updating invalid nss as fixed rate*/
++	if (nss > sta->deflink.rx_nss)
++		return -EINVAL;
++
++	ath11k_dbg(ar->ab, ATH11K_DBG_MAC,
++		   "Setting Fixed HT Rate for peer %pM. Device will not switch to any other selected rates",
++		   sta->addr);
++
++	rate_code = ATH11K_HW_RATE_CODE(ht_rate, nss - 1,
++					WMI_RATE_PREAMBLE_HT);
++	ret = ath11k_wmi_set_peer_param(ar, sta->addr,
++					arvif->vdev_id,
++					WMI_PEER_PARAM_FIXED_RATE,
++					rate_code);
++	if (ret)
++		ath11k_warn(ar->ab,
++			    "failed to update STA %pM HT Fixed Rate %d: %d\n",
++			    sta->addr, rate_code, ret);
++
++	return ret;
++}
++
+ static int ath11k_station_assoc(struct ath11k *ar,
+ 				struct ieee80211_vif *vif,
+ 				struct ieee80211_sta *sta,
+@@ -4491,7 +4539,7 @@ static int ath11k_station_assoc(struct a
+ 	struct cfg80211_chan_def def;
+ 	enum nl80211_band band;
+ 	struct cfg80211_bitrate_mask *mask;
+-	u8 num_vht_rates, num_he_rates;
++	u8 num_ht_rates, num_vht_rates, num_he_rates;
+ 
+ 	lockdep_assert_held(&ar->conf_mutex);
+ 
+@@ -4519,6 +4567,7 @@ static int ath11k_station_assoc(struct a
+ 
+ 	num_vht_rates = ath11k_mac_bitrate_mask_num_vht_rates(ar, band, mask);
+ 	num_he_rates = ath11k_mac_bitrate_mask_num_he_rates(ar, band, mask);
++	num_ht_rates = ath11k_mac_bitrate_mask_num_ht_rates(ar, band, mask);
+ 
+ 	/* If single VHT/HE rate is configured (by set_bitrate_mask()),
+ 	 * peer_assoc will disable VHT/HE. This is now enabled by a peer specific
+@@ -4535,6 +4584,11 @@ static int ath11k_station_assoc(struct a
+ 							band);
+ 		if (ret)
+ 			return ret;
++	} else if (sta->deflink.ht_cap.ht_supported && num_ht_rates == 1) {
++		ret = ath11k_mac_set_peer_ht_fixed_rate(arvif, sta, mask,
++							band);
++		if (ret)
++			return ret;
+ 	}
+ 
+ 	/* Re-assoc is run only to update supported rates for given station. It
+@@ -4608,7 +4662,7 @@ static void ath11k_sta_rc_update_wk(stru
+ 	const u16 *vht_mcs_mask;
+ 	const u16 *he_mcs_mask;
+ 	u32 changed, bw, nss, smps, bw_prev;
+-	int err, num_vht_rates, num_he_rates;
++	int err, num_ht_rates, num_vht_rates, num_he_rates;
+ 	const struct cfg80211_bitrate_mask *mask;
+ 	struct peer_assoc_params peer_arg;
+ 	enum wmi_phy_mode peer_phymode;
+@@ -4724,6 +4778,8 @@ static void ath11k_sta_rc_update_wk(stru
+ 
+ 	if (changed & IEEE80211_RC_SUPP_RATES_CHANGED) {
+ 		mask = &arvif->bitrate_mask;
++		num_ht_rates = ath11k_mac_bitrate_mask_num_ht_rates(ar, band,
++								    mask);
+ 		num_vht_rates = ath11k_mac_bitrate_mask_num_vht_rates(ar, band,
+ 								      mask);
+ 		num_he_rates = ath11k_mac_bitrate_mask_num_he_rates(ar, band,
+@@ -4746,6 +4802,9 @@ static void ath11k_sta_rc_update_wk(stru
+ 		} else if (sta->deflink.he_cap.has_he && num_he_rates == 1) {
+ 			ath11k_mac_set_peer_he_fixed_rate(arvif, sta, mask,
+ 							  band);
++		} else if (sta->deflink.ht_cap.ht_supported && num_ht_rates == 1) {
++			ath11k_mac_set_peer_ht_fixed_rate(arvif, sta, mask,
++							  band);
+ 		} else {
+ 			/* If the peer is non-VHT/HE or no fixed VHT/HE rate
+ 			 * is provided in the new bitrate mask we set the

--- a/package/kernel/mac80211/patches/ath11k/0080-wifi-ath11k-add-support-default-regdb-while-searchin.patch
+++ b/package/kernel/mac80211/patches/ath11k/0080-wifi-ath11k-add-support-default-regdb-while-searchin.patch
@@ -1,0 +1,127 @@
+From 88ca89202f8e8afb5225eb5244d79cd67c15d744 Mon Sep 17 00:00:00 2001
+From: Wen Gong <quic_wgong@quicinc.com>
+Date: Fri, 26 May 2023 12:41:06 +0300
+Subject: [PATCH] wifi: ath11k: add support default regdb while searching
+ board-2.bin for WCN6855
+
+Sometimes board-2.bin does not have the regdb data which matched the
+parameters such as vendor, device, subsystem-vendor, subsystem-device
+and etc. Add default regdb data with 'bus=%s' into board-2.bin for
+WCN6855, then ath11k use 'bus=pci' to search regdb data in board-2.bin
+for WCN6855.
+
+kernel: [  122.515808] ath11k_pci 0000:03:00.0: boot using board name 'bus=pci,vendor=17cb,device=1103,subsystem-vendor=17cb,subsystem-device=3374,qmi-chip-id=2,qmi-board-id=262'
+kernel: [  122.517240] ath11k_pci 0000:03:00.0: boot firmware request ath11k/WCN6855/hw2.0/board-2.bin size 6179564
+kernel: [  122.517280] ath11k_pci 0000:03:00.0: failed to fetch regdb data for bus=pci,vendor=17cb,device=1103,subsystem-vendor=17cb,subsystem-device=3374,qmi-chip-id=2,qmi-board-id=262 from ath11k/WCN6855/hw2.0/board-2.bin
+kernel: [  122.517464] ath11k_pci 0000:03:00.0: boot using board name 'bus=pci'
+kernel: [  122.518901] ath11k_pci 0000:03:00.0: boot firmware request ath11k/WCN6855/hw2.0/board-2.bin size 6179564
+kernel: [  122.518915] ath11k_pci 0000:03:00.0: board name
+kernel: [  122.518917] ath11k_pci 0000:03:00.0: 00000000: 62 75 73 3d 70 63 69                             bus=pci
+kernel: [  122.518918] ath11k_pci 0000:03:00.0: boot found match regdb data for name 'bus=pci'
+kernel: [  122.518920] ath11k_pci 0000:03:00.0: boot found regdb data for 'bus=pci'
+kernel: [  122.518921] ath11k_pci 0000:03:00.0: fetched regdb
+
+Tested-on: WCN6855 hw2.0 PCI WLAN.HSP.1.1-03125-QCAHSPSWPL_V1_V2_SILICONZ_LITE-3
+
+Signed-off-by: Wen Gong <quic_wgong@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230517133959.8224-1-quic_wgong@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/core.c | 53 +++++++++++++++++++-------
+ 1 file changed, 40 insertions(+), 13 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/core.c
++++ b/drivers/net/wireless/ath/ath11k/core.c
+@@ -961,7 +961,8 @@ int ath11k_core_check_dt(struct ath11k_b
+ }
+ 
+ static int __ath11k_core_create_board_name(struct ath11k_base *ab, char *name,
+-					   size_t name_len, bool with_variant)
++					   size_t name_len, bool with_variant,
++					   bool bus_type_mode)
+ {
+ 	/* strlen(',variant=') + strlen(ab->qmi.target.bdf_ext) */
+ 	char variant[9 + ATH11K_QMI_BDF_EXT_STR_LENGTH] = { 0 };
+@@ -972,15 +973,20 @@ static int __ath11k_core_create_board_na
+ 
+ 	switch (ab->id.bdf_search) {
+ 	case ATH11K_BDF_SEARCH_BUS_AND_BOARD:
+-		scnprintf(name, name_len,
+-			  "bus=%s,vendor=%04x,device=%04x,subsystem-vendor=%04x,subsystem-device=%04x,qmi-chip-id=%d,qmi-board-id=%d%s",
+-			  ath11k_bus_str(ab->hif.bus),
+-			  ab->id.vendor, ab->id.device,
+-			  ab->id.subsystem_vendor,
+-			  ab->id.subsystem_device,
+-			  ab->qmi.target.chip_id,
+-			  ab->qmi.target.board_id,
+-			  variant);
++		if (bus_type_mode)
++			scnprintf(name, name_len,
++				  "bus=%s",
++				  ath11k_bus_str(ab->hif.bus));
++		else
++			scnprintf(name, name_len,
++				  "bus=%s,vendor=%04x,device=%04x,subsystem-vendor=%04x,subsystem-device=%04x,qmi-chip-id=%d,qmi-board-id=%d%s",
++				  ath11k_bus_str(ab->hif.bus),
++				  ab->id.vendor, ab->id.device,
++				  ab->id.subsystem_vendor,
++				  ab->id.subsystem_device,
++				  ab->qmi.target.chip_id,
++				  ab->qmi.target.board_id,
++				  variant);
+ 		break;
+ 	default:
+ 		scnprintf(name, name_len,
+@@ -999,13 +1005,19 @@ static int __ath11k_core_create_board_na
+ static int ath11k_core_create_board_name(struct ath11k_base *ab, char *name,
+ 					 size_t name_len)
+ {
+-	return __ath11k_core_create_board_name(ab, name, name_len, true);
++	return __ath11k_core_create_board_name(ab, name, name_len, true, false);
+ }
+ 
+ static int ath11k_core_create_fallback_board_name(struct ath11k_base *ab, char *name,
+ 						  size_t name_len)
+ {
+-	return __ath11k_core_create_board_name(ab, name, name_len, false);
++	return __ath11k_core_create_board_name(ab, name, name_len, false, false);
++}
++
++static int ath11k_core_create_bus_type_board_name(struct ath11k_base *ab, char *name,
++						  size_t name_len)
++{
++	return __ath11k_core_create_board_name(ab, name, name_len, false, true);
+ }
+ 
+ const struct firmware *ath11k_core_firmware_request(struct ath11k_base *ab,
+@@ -1309,7 +1321,7 @@ success:
+ 
+ int ath11k_core_fetch_regdb(struct ath11k_base *ab, struct ath11k_board_data *bd)
+ {
+-	char boardname[BOARD_NAME_SIZE];
++	char boardname[BOARD_NAME_SIZE], default_boardname[BOARD_NAME_SIZE];
+ 	int ret;
+ 
+ 	ret = ath11k_core_create_board_name(ab, boardname, BOARD_NAME_SIZE);
+@@ -1323,6 +1335,21 @@ int ath11k_core_fetch_regdb(struct ath11
+ 						 ATH11K_BD_IE_REGDB,
+ 						 ATH11K_BD_IE_REGDB_NAME,
+ 						 ATH11K_BD_IE_REGDB_DATA);
++	if (!ret)
++		goto exit;
++
++	ret = ath11k_core_create_bus_type_board_name(ab, default_boardname,
++						     BOARD_NAME_SIZE);
++	if (ret) {
++		ath11k_dbg(ab, ATH11K_DBG_BOOT,
++			   "failed to create default board name for regdb: %d", ret);
++		goto exit;
++	}
++
++	ret = ath11k_core_fetch_board_data_api_n(ab, bd, default_boardname,
++						 ATH11K_BD_IE_REGDB,
++						 ATH11K_BD_IE_REGDB_NAME,
++						 ATH11K_BD_IE_REGDB_DATA);
+ 	if (!ret)
+ 		goto exit;
+ 

--- a/package/kernel/mac80211/patches/ath11k/0081-wifi-ath11k-remove-unused-function-ath11k_tm_event_w.patch
+++ b/package/kernel/mac80211/patches/ath11k/0081-wifi-ath11k-remove-unused-function-ath11k_tm_event_w.patch
@@ -1,0 +1,128 @@
+From 86f85575a3f6a20cef1c8bb98e78585fe3a53ccc Mon Sep 17 00:00:00 2001
+From: Govindaraj Saminathan <quic_gsaminat@quicinc.com>
+Date: Fri, 26 May 2023 12:41:06 +0300
+Subject: [PATCH 82/84] wifi: ath11k: remove unused function
+ ath11k_tm_event_wmi()
+
+The function ath11k_tm_event_wmi() is only defined and it is not used
+anywhere. Hence remove the unused.
+
+Tested-on: IPQ8074 hw2.0 AHB WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Govindaraj Saminathan <quic_gsaminat@quicinc.com>
+Signed-off-by: Raj Kumar Bhagat <quic_rajkbhag@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230517135934.16408-2-quic_rajkbhag@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/testmode.c | 64 +---------------------
+ drivers/net/wireless/ath/ath11k/testmode.h |  8 +--
+ 2 files changed, 2 insertions(+), 70 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/testmode.c
++++ b/drivers/net/wireless/ath/ath11k/testmode.c
+@@ -1,6 +1,7 @@
+ // SPDX-License-Identifier: BSD-3-Clause-Clear
+ /*
+  * Copyright (c) 2018-2019 The Linux Foundation. All rights reserved.
++ * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ #include "testmode.h"
+@@ -20,69 +21,6 @@ static const struct nla_policy ath11k_tm
+ 	[ATH11K_TM_ATTR_VERSION_MINOR]	= { .type = NLA_U32 },
+ };
+ 
+-/* Returns true if callee consumes the skb and the skb should be discarded.
+- * Returns false if skb is not used. Does not sleep.
+- */
+-bool ath11k_tm_event_wmi(struct ath11k *ar, u32 cmd_id, struct sk_buff *skb)
+-{
+-	struct sk_buff *nl_skb;
+-	bool consumed;
+-	int ret;
+-
+-	ath11k_dbg(ar->ab, ATH11K_DBG_TESTMODE,
+-		   "testmode event wmi cmd_id %d skb %pK skb->len %d\n",
+-		   cmd_id, skb, skb->len);
+-
+-	ath11k_dbg_dump(ar->ab, ATH11K_DBG_TESTMODE, NULL, "", skb->data, skb->len);
+-
+-	spin_lock_bh(&ar->data_lock);
+-
+-	consumed = true;
+-
+-	nl_skb = cfg80211_testmode_alloc_event_skb(ar->hw->wiphy,
+-						   2 * sizeof(u32) + skb->len,
+-						   GFP_ATOMIC);
+-	if (!nl_skb) {
+-		ath11k_warn(ar->ab,
+-			    "failed to allocate skb for testmode wmi event\n");
+-		goto out;
+-	}
+-
+-	ret = nla_put_u32(nl_skb, ATH11K_TM_ATTR_CMD, ATH11K_TM_CMD_WMI);
+-	if (ret) {
+-		ath11k_warn(ar->ab,
+-			    "failed to put testmode wmi event cmd attribute: %d\n",
+-			    ret);
+-		kfree_skb(nl_skb);
+-		goto out;
+-	}
+-
+-	ret = nla_put_u32(nl_skb, ATH11K_TM_ATTR_WMI_CMDID, cmd_id);
+-	if (ret) {
+-		ath11k_warn(ar->ab,
+-			    "failed to put testmode wmi even cmd_id: %d\n",
+-			    ret);
+-		kfree_skb(nl_skb);
+-		goto out;
+-	}
+-
+-	ret = nla_put(nl_skb, ATH11K_TM_ATTR_DATA, skb->len, skb->data);
+-	if (ret) {
+-		ath11k_warn(ar->ab,
+-			    "failed to copy skb to testmode wmi event: %d\n",
+-			    ret);
+-		kfree_skb(nl_skb);
+-		goto out;
+-	}
+-
+-	cfg80211_testmode_event(nl_skb, GFP_ATOMIC);
+-
+-out:
+-	spin_unlock_bh(&ar->data_lock);
+-
+-	return consumed;
+-}
+-
+ static int ath11k_tm_cmd_get_version(struct ath11k *ar, struct nlattr *tb[])
+ {
+ 	struct sk_buff *skb;
+--- a/drivers/net/wireless/ath/ath11k/testmode.h
++++ b/drivers/net/wireless/ath/ath11k/testmode.h
+@@ -1,24 +1,18 @@
+ /* SPDX-License-Identifier: BSD-3-Clause-Clear */
+ /*
+  * Copyright (c) 2018-2019 The Linux Foundation. All rights reserved.
++ * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ #include "core.h"
+ 
+ #ifdef CPTCFG_NL80211_TESTMODE
+ 
+-bool ath11k_tm_event_wmi(struct ath11k *ar, u32 cmd_id, struct sk_buff *skb);
+ int ath11k_tm_cmd(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+ 		  void *data, int len);
+ 
+ #else
+ 
+-static inline bool ath11k_tm_event_wmi(struct ath11k *ar, u32 cmd_id,
+-				       struct sk_buff *skb)
+-{
+-	return false;
+-}
+-
+ static inline int ath11k_tm_cmd(struct ieee80211_hw *hw,
+ 				struct ieee80211_vif *vif,
+ 				void *data, int len)

--- a/package/kernel/mac80211/patches/ath11k/0082-wifi-ath11k-factory-test-mode-support.patch
+++ b/package/kernel/mac80211/patches/ath11k/0082-wifi-ath11k-factory-test-mode-support.patch
@@ -1,0 +1,850 @@
+From b43310e44edc823a7f02af1e1e2b4e8a9abc7d91 Mon Sep 17 00:00:00 2001
+From: Govindaraj Saminathan <quic_gsaminat@quicinc.com>
+Date: Fri, 26 May 2023 12:41:07 +0300
+Subject: [PATCH 83/84] wifi: ath11k: factory test mode support
+
+Add support to process factory test mode commands (FTM) for calibration.
+By default firmware start with NORMAL mode and to process the FTM commands
+firmware needs to be restarted in FTM mode using module parameter ftm_mode.
+The pre-request is all the radios should be down before starting the test.
+
+When start command ATH11K_TM_CMD_TESTMODE_START is received, ar->state
+is set to Test Mode. If the FTM command or event length is greater
+than 256 bytes, it will be broken down into multiple segments and
+encoded with TLV header if it is segmented commands, else it is sent
+to firmware as it is.
+
+On receiving UTF event from firmware, if it is segmented event, the driver
+will wait until it receives all the segments and notify the complete
+data to user application. In case the segmented sequence are missed or
+lost from the firmware, driver will skip the already received partial data.
+
+In case of unsegmented UTF event from firmware, driver notifies the
+data to the user application as it comes. Applications handles
+the data further.
+
+Command to boot in ftm mode:
+
+insmod ath11k ftm_mode=1
+
+Tested-on: IPQ8074 hw2.0 AHB WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Govindaraj Saminathan <quic_gsaminat@quicinc.com>
+Co-developed-by: Sowmiya Sree Elavalagan <quic_ssreeela@quicinc.com>
+Signed-off-by: Sowmiya Sree Elavalagan <quic_ssreeela@quicinc.com>
+Signed-off-by: Raj Kumar Bhagat <quic_rajkbhag@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230517135934.16408-4-quic_rajkbhag@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/ahb.c        |   3 +-
+ drivers/net/wireless/ath/ath11k/core.c       |  21 +-
+ drivers/net/wireless/ath/ath11k/core.h       |  16 +-
+ drivers/net/wireless/ath/ath11k/debug.h      |   1 +
+ drivers/net/wireless/ath/ath11k/mac.c        |  11 +-
+ drivers/net/wireless/ath/ath11k/pci.c        |   3 +-
+ drivers/net/wireless/ath/ath11k/testmode.c   | 350 ++++++++++++++++++-
+ drivers/net/wireless/ath/ath11k/testmode.h   |   6 +
+ drivers/net/wireless/ath/ath11k/testmode_i.h |  18 +-
+ drivers/net/wireless/ath/ath11k/wmi.c        |  11 +-
+ drivers/net/wireless/ath/ath11k/wmi.h        |  22 ++
+ drivers/net/wireless/ath/ath11k/wow.c        |   3 +-
+ 12 files changed, 444 insertions(+), 21 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/ahb.c
++++ b/drivers/net/wireless/ath/ath11k/ahb.c
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: BSD-3-Clause-Clear
+ /*
+  * Copyright (c) 2018-2019 The Linux Foundation. All rights reserved.
+- * Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
++ * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ #include <linux/module.h>
+@@ -1155,6 +1155,7 @@ static int ath11k_ahb_probe(struct platf
+ 	ab->hif.ops = hif_ops;
+ 	ab->pdev = pdev;
+ 	ab->hw_rev = hw_rev;
++	ab->fw_mode = ATH11K_FIRMWARE_MODE_NORMAL;
+ 	platform_set_drvdata(pdev, ab);
+ 
+ 	ret = ath11k_pcic_register_pci_ops(ab, pci_ops);
+--- a/drivers/net/wireless/ath/ath11k/core.c
++++ b/drivers/net/wireless/ath/ath11k/core.c
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: BSD-3-Clause-Clear
+ /*
+  * Copyright (c) 2018-2019 The Linux Foundation. All rights reserved.
+- * Copyright (c) 2021-2022 Qualcomm Innovation Center, Inc. All rights reserved.
++ * Copyright (c) 2021-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ #include <linux/module.h>
+@@ -32,6 +32,10 @@ module_param_named(frame_mode, ath11k_fr
+ MODULE_PARM_DESC(frame_mode,
+ 		 "Datapath frame mode (0: raw, 1: native wifi (default), 2: ethernet)");
+ 
++bool ath11k_ftm_mode;
++module_param_named(ftm_mode, ath11k_ftm_mode, bool, 0444);
++MODULE_PARM_DESC(ftm_mode, "Boots up in factory test mode");
++
+ static const struct ath11k_hw_params ath11k_hw_params[] = {
+ 	{
+ 		.hw_rev = ATH11K_HW_IPQ8074,
+@@ -1381,6 +1385,11 @@ static int ath11k_core_soc_create(struct
+ {
+ 	int ret;
+ 
++	if (ath11k_ftm_mode) {
++		ab->fw_mode = ATH11K_FIRMWARE_MODE_FTM;
++		ath11k_info(ab, "Booting in factory test mode\n");
++	}
++
+ 	ret = ath11k_qmi_init_service(ab);
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to initialize qmi :%d\n", ret);
+@@ -1607,7 +1616,7 @@ int ath11k_core_qmi_firmware_ready(struc
+ {
+ 	int ret;
+ 
+-	ret = ath11k_core_start_firmware(ab, ATH11K_FIRMWARE_MODE_NORMAL);
++	ret = ath11k_core_start_firmware(ab, ab->fw_mode);
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to start firmware: %d\n", ret);
+ 		return ret;
+@@ -1772,7 +1781,8 @@ void ath11k_core_pre_reconfigure_recover
+ 	for (i = 0; i < ab->num_radios; i++) {
+ 		pdev = &ab->pdevs[i];
+ 		ar = pdev->ar;
+-		if (!ar || ar->state == ATH11K_STATE_OFF)
++		if (!ar || ar->state == ATH11K_STATE_OFF ||
++		    ar->state == ATH11K_STATE_FTM)
+ 			continue;
+ 
+ 		ieee80211_stop_queues(ar->hw);
+@@ -1841,7 +1851,12 @@ static void ath11k_core_post_reconfigure
+ 			ath11k_warn(ab,
+ 				    "device is wedged, will not restart radio %d\n", i);
+ 			break;
++		case ATH11K_STATE_FTM:
++			ath11k_dbg(ab, ATH11K_DBG_TESTMODE,
++				   "fw mode reset done radio %d\n", i);
++			break;
+ 		}
++
+ 		mutex_unlock(&ar->conf_mutex);
+ 	}
+ 	complete(&ab->driver_recovery);
+--- a/drivers/net/wireless/ath/ath11k/core.h
++++ b/drivers/net/wireless/ath/ath11k/core.h
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: BSD-3-Clause-Clear */
+ /*
+  * Copyright (c) 2018-2019 The Linux Foundation. All rights reserved.
+- * Copyright (c) 2021-2022 Qualcomm Innovation Center, Inc. All rights reserved.
++ * Copyright (c) 2021-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ #ifndef ATH11K_CORE_H
+@@ -52,6 +52,7 @@
+ #define ATH11K_SMBIOS_BDF_EXT_MAGIC "BDF_"
+ 
+ extern unsigned int ath11k_frame_mode;
++extern bool ath11k_ftm_mode;
+ 
+ #define ATH11K_SCAN_TIMEOUT_HZ (20 * HZ)
+ 
+@@ -277,6 +278,7 @@ enum ath11k_dev_flags {
+ 	ATH11K_FLAG_FIXED_MEM_RGN,
+ 	ATH11K_FLAG_DEVICE_INIT_DONE,
+ 	ATH11K_FLAG_MULTI_MSI_VECTORS,
++	ATH11K_FLAG_FTM_SEGMENTED,
+ };
+ 
+ enum ath11k_monitor_flags {
+@@ -530,6 +532,7 @@ enum ath11k_state {
+ 	ATH11K_STATE_RESTARTING,
+ 	ATH11K_STATE_RESTARTED,
+ 	ATH11K_STATE_WEDGED,
++	ATH11K_STATE_FTM,
+ 	/* Add other states as required */
+ };
+ 
+@@ -709,6 +712,8 @@ struct ath11k {
+ 	u32 last_ppdu_id;
+ 	u32 cached_ppdu_id;
+ 	int monitor_vdev_id;
++	struct completion fw_mode_reset;
++	u8 ftm_msgref;
+ #ifdef CPTCFG_ATH11K_DEBUGFS
+ 	struct ath11k_debug debug;
+ #endif
+@@ -838,6 +843,7 @@ struct ath11k_msi_config {
+ /* Master structure to hold the hw data which may be used in core module */
+ struct ath11k_base {
+ 	enum ath11k_hw_rev hw_rev;
++	enum ath11k_firmware_mode fw_mode;
+ 	struct platform_device *pdev;
+ 	struct device *dev;
+ 	struct ath11k_qmi qmi;
+@@ -978,6 +984,14 @@ struct ath11k_base {
+ 		const struct ath11k_pci_ops *ops;
+ 	} pci;
+ 
++#ifdef CPTCFG_NL80211_TESTMODE
++	struct {
++		u32 data_pos;
++		u32 expected_seq;
++		u8 *eventdata;
++	} testmode;
++#endif
++
+ 	/* must be last */
+ 	u8 drv_priv[] __aligned(sizeof(void *));
+ };
+--- a/drivers/net/wireless/ath/ath11k/debug.h
++++ b/drivers/net/wireless/ath/ath11k/debug.h
+@@ -1,6 +1,7 @@
+ /* SPDX-License-Identifier: BSD-3-Clause-Clear */
+ /*
+  * Copyright (c) 2018-2019 The Linux Foundation. All rights reserved.
++ * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ #ifndef _ATH11K_DEBUG_H_
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -643,7 +643,10 @@ struct ath11k *ath11k_mac_get_ar_by_pdev
+ 		return NULL;
+ 
+ 	for (i = 0; i < ab->num_radios; i++) {
+-		pdev = rcu_dereference(ab->pdevs_active[i]);
++		if (ab->fw_mode == ATH11K_FIRMWARE_MODE_FTM)
++			pdev = &ab->pdevs[i];
++		else
++			pdev = rcu_dereference(ab->pdevs_active[i]);
+ 
+ 		if (pdev && pdev->pdev_id == pdev_id)
+ 			return (pdev->ar ? pdev->ar : NULL);
+@@ -6271,6 +6274,11 @@ static int ath11k_mac_op_start(struct ie
+ 	struct ath11k_pdev *pdev = ar->pdev;
+ 	int ret;
+ 
++	if (ath11k_ftm_mode) {
++		ath11k_warn(ab, "mac operations not supported in factory test mode\n");
++		return -EOPNOTSUPP;
++	}
++
+ 	ath11k_mac_drain_tx(ar);
+ 	mutex_lock(&ar->conf_mutex);
+ 
+@@ -6285,6 +6293,7 @@ static int ath11k_mac_op_start(struct ie
+ 	case ATH11K_STATE_RESTARTED:
+ 	case ATH11K_STATE_WEDGED:
+ 	case ATH11K_STATE_ON:
++	case ATH11K_STATE_FTM:
+ 		WARN_ON(1);
+ 		ret = -EINVAL;
+ 		goto err;
+--- a/drivers/net/wireless/ath/ath11k/pci.c
++++ b/drivers/net/wireless/ath/ath11k/pci.c
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: BSD-3-Clause-Clear
+ /*
+  * Copyright (c) 2019-2020 The Linux Foundation. All rights reserved.
+- * Copyright (c) 2021-2022, Qualcomm Innovation Center, Inc. All rights reserved.
++ * Copyright (c) 2021-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ #include <linux/module.h>
+@@ -745,6 +745,7 @@ static int ath11k_pci_probe(struct pci_d
+ 	ab_pci->ab = ab;
+ 	ab_pci->pdev = pdev;
+ 	ab->hif.ops = &ath11k_pci_hif_ops;
++	ab->fw_mode = ATH11K_FIRMWARE_MODE_NORMAL;
+ 	pci_set_drvdata(pdev, ab);
+ 	spin_lock_init(&ab_pci->window_lock);
+ 
+--- a/drivers/net/wireless/ath/ath11k/testmode.c
++++ b/drivers/net/wireless/ath/ath11k/testmode.c
+@@ -12,6 +12,9 @@
+ #include "core.h"
+ #include "testmode_i.h"
+ 
++#define ATH11K_FTM_SEGHDR_CURRENT_SEQ		GENMASK(3, 0)
++#define ATH11K_FTM_SEGHDR_TOTAL_SEGMENTS	GENMASK(7, 4)
++
+ static const struct nla_policy ath11k_tm_policy[ATH11K_TM_ATTR_MAX + 1] = {
+ 	[ATH11K_TM_ATTR_CMD]		= { .type = NLA_U32 },
+ 	[ATH11K_TM_ATTR_DATA]		= { .type = NLA_BINARY,
+@@ -21,13 +24,217 @@ static const struct nla_policy ath11k_tm
+ 	[ATH11K_TM_ATTR_VERSION_MINOR]	= { .type = NLA_U32 },
+ };
+ 
++static struct ath11k *ath11k_tm_get_ar(struct ath11k_base *ab)
++{
++	struct ath11k_pdev *pdev;
++	struct ath11k *ar = NULL;
++	int i;
++
++	for (i = 0; i < ab->num_radios; i++) {
++		pdev = &ab->pdevs[i];
++		ar = pdev->ar;
++
++		if (ar && ar->state == ATH11K_STATE_FTM)
++			break;
++	}
++
++	return ar;
++}
++
++/* This function handles unsegmented events. Data in various events are aggregated
++ * in application layer, this event is unsegmented from host perspective.
++ */
++static void ath11k_tm_wmi_event_unsegmented(struct ath11k_base *ab, u32 cmd_id,
++					    struct sk_buff *skb)
++{
++	struct sk_buff *nl_skb;
++	struct ath11k *ar;
++
++	ath11k_dbg(ab, ATH11K_DBG_TESTMODE,
++		   "event wmi cmd_id %d skb length %d\n",
++		   cmd_id, skb->len);
++	ath11k_dbg_dump(ab, ATH11K_DBG_TESTMODE, NULL, "", skb->data, skb->len);
++
++	ar = ath11k_tm_get_ar(ab);
++	if (!ar) {
++		ath11k_warn(ab, "testmode event not handled due to invalid pdev\n");
++		return;
++	}
++
++	spin_lock_bh(&ar->data_lock);
++
++	nl_skb = cfg80211_testmode_alloc_event_skb(ar->hw->wiphy,
++						   2 * nla_total_size(sizeof(u32)) +
++						   nla_total_size(skb->len),
++						   GFP_ATOMIC);
++	if (!nl_skb) {
++		ath11k_warn(ab,
++			    "failed to allocate skb for unsegmented testmode wmi event\n");
++		goto out;
++	}
++
++	if (nla_put_u32(nl_skb, ATH11K_TM_ATTR_CMD, ATH11K_TM_CMD_WMI) ||
++	    nla_put_u32(nl_skb, ATH11K_TM_ATTR_WMI_CMDID, cmd_id) ||
++	    nla_put(nl_skb, ATH11K_TM_ATTR_DATA, skb->len, skb->data)) {
++		ath11k_warn(ab, "failed to populate testmode unsegmented event\n");
++		kfree_skb(nl_skb);
++		goto out;
++	}
++
++	cfg80211_testmode_event(nl_skb, GFP_ATOMIC);
++	spin_unlock_bh(&ar->data_lock);
++	return;
++
++out:
++	spin_unlock_bh(&ar->data_lock);
++	ath11k_warn(ab, "Failed to send testmode event to higher layers\n");
++}
++
++/* This function handles segmented events. Data of various events received
++ * from firmware is aggregated and sent to application layer
++ */
++static int ath11k_tm_process_event(struct ath11k_base *ab, u32 cmd_id,
++				   const struct wmi_ftm_event_msg *ftm_msg,
++				   u16 length)
++{
++	struct sk_buff *nl_skb;
++	int ret = 0;
++	struct ath11k *ar;
++	u8 const *buf_pos;
++	u16 datalen;
++	u8 total_segments, current_seq;
++	u32 data_pos;
++	u32 pdev_id;
++
++	ath11k_dbg(ab, ATH11K_DBG_TESTMODE,
++		   "event wmi cmd_id %d ftm event msg %pK datalen %d\n",
++		   cmd_id, ftm_msg, length);
++	ath11k_dbg_dump(ab, ATH11K_DBG_TESTMODE, NULL, "", ftm_msg, length);
++	pdev_id = DP_HW2SW_MACID(ftm_msg->seg_hdr.pdev_id);
++
++	if (pdev_id >= ab->num_radios) {
++		ath11k_warn(ab, "testmode event not handled due to invalid pdev id: %d\n",
++			    pdev_id);
++		return -EINVAL;
++	}
++
++	ar = ab->pdevs[pdev_id].ar;
++	if (!ar) {
++		ath11k_warn(ab, "testmode event not handled due to absence of pdev\n");
++		return -ENODEV;
++	}
++
++	current_seq = FIELD_GET(ATH11K_FTM_SEGHDR_CURRENT_SEQ,
++				ftm_msg->seg_hdr.segmentinfo);
++	total_segments = FIELD_GET(ATH11K_FTM_SEGHDR_TOTAL_SEGMENTS,
++				   ftm_msg->seg_hdr.segmentinfo);
++	datalen = length - (sizeof(struct wmi_ftm_seg_hdr));
++	buf_pos = ftm_msg->data;
++
++	spin_lock_bh(&ar->data_lock);
++
++	if (current_seq == 0) {
++		ab->testmode.expected_seq = 0;
++		ab->testmode.data_pos = 0;
++	}
++
++	data_pos = ab->testmode.data_pos;
++
++	if ((data_pos + datalen) > ATH11K_FTM_EVENT_MAX_BUF_LENGTH) {
++		ath11k_warn(ab, "Invalid ftm event length at %d: %d\n",
++			    data_pos, datalen);
++		ret = -EINVAL;
++		goto out;
++	}
++
++	memcpy(&ab->testmode.eventdata[data_pos], buf_pos, datalen);
++	data_pos += datalen;
++
++	if (++ab->testmode.expected_seq != total_segments) {
++		ab->testmode.data_pos = data_pos;
++		ath11k_dbg(ab, ATH11K_DBG_TESTMODE,
++			   "partial data received current_seq %d total_seg %d\n",
++			    current_seq, total_segments);
++		goto out;
++	}
++
++	ath11k_dbg(ab, ATH11K_DBG_TESTMODE,
++		   "total data length pos %d len %d\n",
++		    data_pos, ftm_msg->seg_hdr.len);
++	nl_skb = cfg80211_testmode_alloc_event_skb(ar->hw->wiphy,
++						   2 * nla_total_size(sizeof(u32)) +
++						   nla_total_size(data_pos),
++						   GFP_ATOMIC);
++	if (!nl_skb) {
++		ath11k_warn(ab,
++			    "failed to allocate skb for segmented testmode wmi event\n");
++		ret = -ENOMEM;
++		goto out;
++	}
++
++	if (nla_put_u32(nl_skb, ATH11K_TM_ATTR_CMD,
++			ATH11K_TM_CMD_WMI_FTM) ||
++	    nla_put_u32(nl_skb, ATH11K_TM_ATTR_WMI_CMDID, cmd_id) ||
++	    nla_put(nl_skb, ATH11K_TM_ATTR_DATA, data_pos,
++		    &ab->testmode.eventdata[0])) {
++		ath11k_warn(ab, "failed to populate segmented testmode event");
++		kfree_skb(nl_skb);
++		ret = -ENOBUFS;
++		goto out;
++	}
++
++	cfg80211_testmode_event(nl_skb, GFP_ATOMIC);
++
++out:
++	spin_unlock_bh(&ar->data_lock);
++	return ret;
++}
++
++static void ath11k_tm_wmi_event_segmented(struct ath11k_base *ab, u32 cmd_id,
++					  struct sk_buff *skb)
++{
++	const void **tb;
++	const struct wmi_ftm_event_msg *ev;
++	u16 length;
++	int ret;
++
++	tb = ath11k_wmi_tlv_parse_alloc(ab, skb->data, skb->len, GFP_ATOMIC);
++	if (IS_ERR(tb)) {
++		ret = PTR_ERR(tb);
++		ath11k_warn(ab, "failed to parse ftm event tlv: %d\n", ret);
++		return;
++	}
++
++	ev = tb[WMI_TAG_ARRAY_BYTE];
++	if (!ev) {
++		ath11k_warn(ab, "failed to fetch ftm msg\n");
++		kfree(tb);
++		return;
++	}
++
++	length = skb->len - TLV_HDR_SIZE;
++	ret = ath11k_tm_process_event(ab, cmd_id, ev, length);
++	if (ret)
++		ath11k_warn(ab, "Failed to process ftm event\n");
++
++	kfree(tb);
++}
++
++void ath11k_tm_wmi_event(struct ath11k_base *ab, u32 cmd_id, struct sk_buff *skb)
++{
++	if (test_bit(ATH11K_FLAG_FTM_SEGMENTED, &ab->dev_flags))
++		ath11k_tm_wmi_event_segmented(ab, cmd_id, skb);
++	else
++		ath11k_tm_wmi_event_unsegmented(ab, cmd_id, skb);
++}
++
+ static int ath11k_tm_cmd_get_version(struct ath11k *ar, struct nlattr *tb[])
+ {
+ 	struct sk_buff *skb;
+ 	int ret;
+ 
+ 	ath11k_dbg(ar->ab, ATH11K_DBG_TESTMODE,
+-		   "testmode cmd get version_major %d version_minor %d\n",
++		   "cmd get version_major %d version_minor %d\n",
+ 		   ATH11K_TESTMODE_VERSION_MAJOR,
+ 		   ATH11K_TESTMODE_VERSION_MINOR);
+ 
+@@ -53,6 +260,43 @@ static int ath11k_tm_cmd_get_version(str
+ 	return cfg80211_testmode_reply(skb);
+ }
+ 
++static int ath11k_tm_cmd_testmode_start(struct ath11k *ar, struct nlattr *tb[])
++{
++	int ret;
++
++	mutex_lock(&ar->conf_mutex);
++
++	if (ar->state == ATH11K_STATE_FTM) {
++		ret = -EALREADY;
++		goto err;
++	}
++
++	/* start utf only when the driver is not in use  */
++	if (ar->state != ATH11K_STATE_OFF) {
++		ret = -EBUSY;
++		goto err;
++	}
++
++	ar->ab->testmode.eventdata = kzalloc(ATH11K_FTM_EVENT_MAX_BUF_LENGTH,
++					     GFP_KERNEL);
++	if (!ar->ab->testmode.eventdata) {
++		ret = -ENOMEM;
++		goto err;
++	}
++
++	ar->state = ATH11K_STATE_FTM;
++	ar->ftm_msgref = 0;
++
++	mutex_unlock(&ar->conf_mutex);
++
++	ath11k_dbg(ar->ab, ATH11K_DBG_TESTMODE, "cmd start\n");
++	return 0;
++
++err:
++	mutex_unlock(&ar->conf_mutex);
++	return ret;
++}
++
+ static int ath11k_tm_cmd_wmi(struct ath11k *ar, struct nlattr *tb[])
+ {
+ 	struct ath11k_pdev_wmi *wmi = ar->wmi;
+@@ -63,11 +307,6 @@ static int ath11k_tm_cmd_wmi(struct ath1
+ 
+ 	mutex_lock(&ar->conf_mutex);
+ 
+-	if (ar->state != ATH11K_STATE_ON) {
+-		ret = -ENETDOWN;
+-		goto out;
+-	}
+-
+ 	if (!tb[ATH11K_TM_ATTR_DATA]) {
+ 		ret = -EINVAL;
+ 		goto out;
+@@ -80,11 +319,17 @@ static int ath11k_tm_cmd_wmi(struct ath1
+ 
+ 	buf = nla_data(tb[ATH11K_TM_ATTR_DATA]);
+ 	buf_len = nla_len(tb[ATH11K_TM_ATTR_DATA]);
++	if (!buf_len) {
++		ath11k_warn(ar->ab, "No data present in testmode wmi command\n");
++		ret = -EINVAL;
++		goto out;
++	}
++
+ 	cmd_id = nla_get_u32(tb[ATH11K_TM_ATTR_WMI_CMDID]);
+ 
+ 	ath11k_dbg(ar->ab, ATH11K_DBG_TESTMODE,
+-		   "testmode cmd wmi cmd_id %d buf %pK buf_len %d\n",
+-		   cmd_id, buf, buf_len);
++		   "cmd wmi cmd_id %d buf length %d\n",
++		   cmd_id, buf_len);
+ 
+ 	ath11k_dbg_dump(ar->ab, ATH11K_DBG_TESTMODE, NULL, "", buf, buf_len);
+ 
+@@ -111,6 +356,91 @@ out:
+ 	return ret;
+ }
+ 
++static int ath11k_tm_cmd_wmi_ftm(struct ath11k *ar, struct nlattr *tb[])
++{
++	struct ath11k_pdev_wmi *wmi = ar->wmi;
++	struct ath11k_base *ab = ar->ab;
++	struct sk_buff *skb;
++	u32 cmd_id, buf_len, hdr_info;
++	int ret;
++	void *buf;
++	u8 segnumber = 0, seginfo;
++	u16 chunk_len, total_bytes, num_segments;
++	u8 *bufpos;
++	struct wmi_ftm_cmd *ftm_cmd;
++
++	set_bit(ATH11K_FLAG_FTM_SEGMENTED, &ab->dev_flags);
++
++	mutex_lock(&ar->conf_mutex);
++
++	if (ar->state != ATH11K_STATE_FTM) {
++		ret = -ENETDOWN;
++		goto out;
++	}
++
++	if (!tb[ATH11K_TM_ATTR_DATA]) {
++		ret = -EINVAL;
++		goto out;
++	}
++
++	buf = nla_data(tb[ATH11K_TM_ATTR_DATA]);
++	buf_len = nla_len(tb[ATH11K_TM_ATTR_DATA]);
++	cmd_id = WMI_PDEV_UTF_CMDID;
++
++	ath11k_dbg(ar->ab, ATH11K_DBG_TESTMODE,
++		   "cmd wmi ftm cmd_id %d buffer length %d\n",
++		   cmd_id, buf_len);
++	ath11k_dbg_dump(ar->ab, ATH11K_DBG_TESTMODE, NULL, "", buf, buf_len);
++
++	bufpos = buf;
++	total_bytes = buf_len;
++	num_segments = total_bytes / MAX_WMI_UTF_LEN;
++
++	if (buf_len - (num_segments * MAX_WMI_UTF_LEN))
++		num_segments++;
++
++	while (buf_len) {
++		chunk_len = min_t(u16, buf_len, MAX_WMI_UTF_LEN);
++
++		skb = ath11k_wmi_alloc_skb(wmi->wmi_ab, (chunk_len +
++					   sizeof(struct wmi_ftm_cmd)));
++		if (!skb) {
++			ret = -ENOMEM;
++			goto out;
++		}
++
++		ftm_cmd = (struct wmi_ftm_cmd *)skb->data;
++		hdr_info = FIELD_PREP(WMI_TLV_TAG, WMI_TAG_ARRAY_BYTE) |
++			   FIELD_PREP(WMI_TLV_LEN, (chunk_len +
++				      sizeof(struct wmi_ftm_seg_hdr)));
++		ftm_cmd->tlv_header = hdr_info;
++		ftm_cmd->seg_hdr.len = total_bytes;
++		ftm_cmd->seg_hdr.msgref = ar->ftm_msgref;
++		seginfo = FIELD_PREP(ATH11K_FTM_SEGHDR_TOTAL_SEGMENTS, num_segments) |
++			  FIELD_PREP(ATH11K_FTM_SEGHDR_CURRENT_SEQ, segnumber);
++		ftm_cmd->seg_hdr.segmentinfo = seginfo;
++		segnumber++;
++
++		memcpy(&ftm_cmd->data, bufpos, chunk_len);
++
++		ret = ath11k_wmi_cmd_send(wmi, skb, cmd_id);
++		if (ret) {
++			ath11k_warn(ar->ab, "failed to send wmi ftm command: %d\n", ret);
++			goto out;
++		}
++
++		buf_len -= chunk_len;
++		bufpos += chunk_len;
++	}
++
++	ar->ftm_msgref++;
++	ret = 0;
++
++out:
++	mutex_unlock(&ar->conf_mutex);
++	return ret;
++}
++
+ int ath11k_tm_cmd(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+ 		  void *data, int len)
+ {
+@@ -131,6 +461,10 @@ int ath11k_tm_cmd(struct ieee80211_hw *h
+ 		return ath11k_tm_cmd_get_version(ar, tb);
+ 	case ATH11K_TM_CMD_WMI:
+ 		return ath11k_tm_cmd_wmi(ar, tb);
++	case ATH11K_TM_CMD_TESTMODE_START:
++		return ath11k_tm_cmd_testmode_start(ar, tb);
++	case ATH11K_TM_CMD_WMI_FTM:
++		return ath11k_tm_cmd_wmi_ftm(ar, tb);
+ 	default:
+ 		return -EOPNOTSUPP;
+ 	}
+--- a/drivers/net/wireless/ath/ath11k/testmode.h
++++ b/drivers/net/wireless/ath/ath11k/testmode.h
+@@ -8,11 +8,17 @@
+ 
+ #ifdef CPTCFG_NL80211_TESTMODE
+ 
++void ath11k_tm_wmi_event(struct ath11k_base *ab, u32 cmd_id, struct sk_buff *skb);
+ int ath11k_tm_cmd(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+ 		  void *data, int len);
+ 
+ #else
+ 
++static inline void ath11k_tm_wmi_event(struct ath11k_base *ab, u32 cmd_id,
++				       struct sk_buff *skb)
++{
++}
++
+ static inline int ath11k_tm_cmd(struct ieee80211_hw *hw,
+ 				struct ieee80211_vif *vif,
+ 				void *data, int len)
+--- a/drivers/net/wireless/ath/ath11k/testmode_i.h
++++ b/drivers/net/wireless/ath/ath11k/testmode_i.h
+@@ -1,6 +1,7 @@
+ /* SPDX-License-Identifier: BSD-3-Clause-Clear */
+ /*
+  * Copyright (c) 2018-2019 The Linux Foundation. All rights reserved.
++ * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ /* "API" level of the ath11k testmode interface. Bump it after every
+@@ -11,9 +12,10 @@
+ /* Bump this after every _compatible_ interface change, for example
+  * addition of a new command or an attribute.
+  */
+-#define ATH11K_TESTMODE_VERSION_MINOR 0
++#define ATH11K_TESTMODE_VERSION_MINOR 1
+ 
+ #define ATH11K_TM_DATA_MAX_LEN		5000
++#define ATH11K_FTM_EVENT_MAX_BUF_LENGTH 2048
+ 
+ enum ath11k_tm_attr {
+ 	__ATH11K_TM_ATTR_INVALID		= 0,
+@@ -47,4 +49,18 @@ enum ath11k_tm_cmd {
+ 	 * ATH11K_TM_ATTR_DATA.
+ 	 */
+ 	ATH11K_TM_CMD_WMI = 1,
++
++	/* Boots the UTF firmware, the netdev interface must be down at the
++	 * time.
++	 */
++	ATH11K_TM_CMD_TESTMODE_START = 2,
++
++	/* The command used to transmit a FTM WMI command to the firmware
++	 * and the event to receive WMI events from the firmware. The data
++	 * received only contain the payload, need to add the tlv header
++	 * and send the cmd to firmware with command id WMI_PDEV_UTF_CMDID.
++	 * The data payload size could be large and the driver needs to
++	 * send segmented data to firmware.
++	 */
++	ATH11K_TM_CMD_WMI_FTM = 3,
+ };
+--- a/drivers/net/wireless/ath/ath11k/wmi.c
++++ b/drivers/net/wireless/ath/ath11k/wmi.c
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: BSD-3-Clause-Clear
+ /*
+  * Copyright (c) 2018-2019 The Linux Foundation. All rights reserved.
+- * Copyright (c) 2021, Qualcomm Innovation Center, Inc. All rights reserved.
++ * Copyright (c) 2021, 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ #include <linux/skbuff.h>
+ #include <linux/ctype.h>
+@@ -19,6 +19,7 @@
+ #include "mac.h"
+ #include "hw.h"
+ #include "peer.h"
++#include "testmode.h"
+ 
+ struct wmi_tlv_policy {
+ 	size_t min_len;
+@@ -237,9 +238,8 @@ static int ath11k_wmi_tlv_parse(struct a
+ 				   (void *)tb);
+ }
+ 
+-static const void **
+-ath11k_wmi_tlv_parse_alloc(struct ath11k_base *ab, const void *ptr,
+-			   size_t len, gfp_t gfp)
++const void **ath11k_wmi_tlv_parse_alloc(struct ath11k_base *ab, const void *ptr,
++					size_t len, gfp_t gfp)
+ {
+ 	const void **tb;
+ 	int ret;
+@@ -8628,6 +8628,9 @@ static void ath11k_wmi_tlv_op_rx(struct
+ 	case WMI_PDEV_CSA_SWITCH_COUNT_STATUS_EVENTID:
+ 		ath11k_wmi_pdev_csa_switch_count_status_event(ab, skb);
+ 		break;
++	case WMI_PDEV_UTF_EVENTID:
++		ath11k_tm_wmi_event(ab, id, skb);
++		break;
+ 	case WMI_PDEV_TEMPERATURE_EVENTID:
+ 		ath11k_wmi_pdev_temperature_event(ab, skb);
+ 		break;
+--- a/drivers/net/wireless/ath/ath11k/wmi.h
++++ b/drivers/net/wireless/ath/ath11k/wmi.h
+@@ -1,6 +1,7 @@
+ /* SPDX-License-Identifier: BSD-3-Clause-Clear */
+ /*
+  * Copyright (c) 2018-2019 The Linux Foundation. All rights reserved.
++ * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ #ifndef ATH11K_WMI_H
+@@ -68,6 +69,7 @@ struct wmi_tlv {
+ 
+ #define WMI_APPEND_TO_EXISTING_CHAN_LIST_FLAG 1
+ 
++#define MAX_WMI_UTF_LEN 252
+ #define WMI_BA_MODE_BUFFER_SIZE_256  3
+ /*
+  * HW mode config type replicated from FW header
+@@ -3564,6 +3566,24 @@ struct wmi_get_pdev_temperature_cmd {
+ 	u32 pdev_id;
+ } __packed;
+ 
++struct wmi_ftm_seg_hdr {
++	u32 len;
++	u32 msgref;
++	u32 segmentinfo;
++	u32 pdev_id;
++} __packed;
++
++struct wmi_ftm_cmd {
++	u32 tlv_header;
++	struct wmi_ftm_seg_hdr seg_hdr;
++	u8 data[];
++} __packed;
++
++struct wmi_ftm_event_msg {
++	struct wmi_ftm_seg_hdr seg_hdr;
++	u8 data[];
++} __packed;
++
+ #define WMI_BEACON_TX_BUFFER_SIZE	512
+ 
+ #define WMI_EMA_TMPL_IDX_SHIFT            8
+@@ -6300,6 +6320,8 @@ enum wmi_sta_keepalive_method {
+ #define WMI_STA_KEEPALIVE_INTERVAL_DEFAULT	30
+ #define WMI_STA_KEEPALIVE_INTERVAL_DISABLE	0
+ 
++const void **ath11k_wmi_tlv_parse_alloc(struct ath11k_base *ab, const void *ptr,
++					size_t len, gfp_t gfp);
+ int ath11k_wmi_cmd_send(struct ath11k_pdev_wmi *wmi, struct sk_buff *skb,
+ 			u32 cmd_id);
+ struct sk_buff *ath11k_wmi_alloc_skb(struct ath11k_wmi_base *wmi_sc, u32 len);
+--- a/drivers/net/wireless/ath/ath11k/wow.c
++++ b/drivers/net/wireless/ath/ath11k/wow.c
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: BSD-3-Clause-Clear
+ /*
+  * Copyright (c) 2020 The Linux Foundation. All rights reserved.
+- * Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
++ * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ #include <linux/delay.h>
+@@ -838,6 +838,7 @@ exit:
+ 		case ATH11K_STATE_RESTARTING:
+ 		case ATH11K_STATE_RESTARTED:
+ 		case ATH11K_STATE_WEDGED:
++		case ATH11K_STATE_FTM:
+ 			ath11k_warn(ar->ab, "encountered unexpected device state %d on resume, cannot recover\n",
+ 				    ar->state);
+ 			ret = -EIO;

--- a/package/kernel/mac80211/patches/ath11k/0083-wifi-ath11k-Allow-ath11k-to-boot-without-caldata-in-.patch
+++ b/package/kernel/mac80211/patches/ath11k/0083-wifi-ath11k-Allow-ath11k-to-boot-without-caldata-in-.patch
@@ -1,0 +1,47 @@
+From 8aeba427296bff6a6051686f1d139c89a0b00e4c Mon Sep 17 00:00:00 2001
+From: Sowmiya Sree Elavalagan <quic_ssreeela@quicinc.com>
+Date: Fri, 26 May 2023 12:41:07 +0300
+Subject: [PATCH 84/84] wifi: ath11k: Allow ath11k to boot without caldata in
+ ftm mode
+
+Currently, if ath11k is unable to load the calibration data file it will
+always exit. However the calibration data may not be present in factory
+test mode, so update the logic to allow the driver to execute in FTM mode
+even if downloading the calibration data fails.
+
+Tested-on : IPQ8074 hw2.0 AHB WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Sowmiya Sree Elavalagan <quic_ssreeela@quicinc.com>
+Signed-off-by: Raj Kumar Bhagat <quic_rajkbhag@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230517135934.16408-5-quic_rajkbhag@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/qmi.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/wireless/ath/ath11k/qmi.c
++++ b/drivers/net/wireless/ath/ath11k/qmi.c
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: BSD-3-Clause-Clear
+ /*
+  * Copyright (c) 2018-2019 The Linux Foundation. All rights reserved.
+- * Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
++ * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+  */
+ 
+ #include <linux/elf.h>
+@@ -2460,6 +2460,14 @@ static int ath11k_qmi_load_bdf_qmi(struc
+ 
+ 		fw_entry = ath11k_core_firmware_request(ab, ATH11K_DEFAULT_CAL_FILE);
+ 		if (IS_ERR(fw_entry)) {
++			/* Caldata may not be present during first time calibration in
++			 * factory hence allow to boot without loading caldata in ftm mode
++			 */
++			if (ath11k_ftm_mode) {
++				ath11k_info(ab,
++					    "Booting without cal data file in factory test mode\n");
++				return 0;
++			}
+ 			ret = PTR_ERR(fw_entry);
+ 			ath11k_warn(ab,
+ 				    "qmi failed to load CAL data file:%s\n",

--- a/package/kernel/mac80211/patches/ath11k/0084-wifi-ath11k-Add-HTT-stats-for-PHY-reset-case.patch
+++ b/package/kernel/mac80211/patches/ath11k/0084-wifi-ath11k-Add-HTT-stats-for-PHY-reset-case.patch
@@ -1,0 +1,261 @@
+From 2d4f9093e2d8531ad0a2bb98fe5b36dc8addf2a2 Mon Sep 17 00:00:00 2001
+From: Nidhi Jain <quic_nidhjain@quicinc.com>
+Date: Fri, 26 May 2023 12:41:07 +0300
+Subject: [PATCH] wifi: ath11k: Add HTT stats for PHY reset case
+
+New HTT stats are added with stats type 37 to
+provide PHY reset stats and PHY reset counter stats.
+
+PHY reset stats are used to display the current
+PHY-related operation information such as band, CCA
+threshold, current operating channel etc.,
+
+PHY reset counter stats are used to display the
+PHY reset counter values like calibration counts,
+temperature based recalibration counts etc.,
+
+Usage:
+echo 37 > /sys/kernel/debug/ieee80211/phyX/ath11k/htt_stats_type
+cat /sys/kernel/debug/ieee80211/phyx/ath11k/htt_stats
+
+Output:
+
+HTT_PHY_RESET_STATS_TLV:
+pdev_id = 0
+chan_mhz = 5180
+chan_band_center_freq1 = 5210
+chan_band_center_freq2 = 0
+chan_phy_mode = 18
+chan_flags = 0x8
+chan_num = 36
+reset_cause = 0x50000
+prev_reset_cause = 0x50000
+phy_warm_reset_src = 0x0
+rx_gain_tbl_mode = 0
+xbar_val = 0xfac688
+force_calibration = 0
+phyrf_mode = 0
+phy_homechan = 0
+phy_tx_ch_mask = 0x3
+phy_rx_ch_mask = 0x3
+phybb_ini_mask = 0x5
+phyrf_ini_mask = 0x0
+phy_dfs_en_mask = 0x0
+phy_sscan_en_mask = 0x0
+phy_synth_sel_mask = 0x0
+phy_adfs_freq = 0
+cck_fir_settings = 0x0
+phy_dyn_pri_chan = 6
+cca_thresh = 0x26232020
+dyn_cca_status = 0
+rxdesense_thresh_hw = 0xcfe0afe
+rxdesense_thresh_sw = 0xcfe0afe
+
+HTT_PHY_RESET_COUNTERS_TLV:
+pdev_id = 0
+cf_active_low_fail_cnt = 0
+cf_active_low_pass_cnt = 0
+phy_off_through_vreg_cnt = 0
+force_calibration_cnt = 0
+rf_mode_switch_phy_off_cnt = 0
+
+Tested-on: IPQ8074 hw2.0 AHB WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Nidhi Jain <quic_nidhjain@quicinc.com>
+Signed-off-by: Maharaja Kennadyrajan <quic_mkenna@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230517141242.2754293-1-quic_mkenna@quicinc.com
+---
+ .../wireless/ath/ath11k/debugfs_htt_stats.c   | 114 ++++++++++++++++++
+ .../wireless/ath/ath11k/debugfs_htt_stats.h   |  43 +++++++
+ 2 files changed, 157 insertions(+)
+
+--- a/drivers/net/wireless/ath/ath11k/debugfs_htt_stats.c
++++ b/drivers/net/wireless/ath/ath11k/debugfs_htt_stats.c
+@@ -4011,6 +4011,114 @@ void htt_print_phy_stats_tlv(const void
+ 	stats_req->buf_len = len;
+ }
+ 
++static inline void
++htt_print_phy_reset_counters_tlv(const void *tag_buf,
++				 u16 tag_len,
++				 struct debug_htt_stats_req *stats_req)
++{
++	const struct htt_phy_reset_counters_tlv *htt_stats_buf = tag_buf;
++	u8 *buf = stats_req->buf;
++	u32 len = stats_req->buf_len;
++	u32 buf_len = ATH11K_HTT_STATS_BUF_SIZE;
++
++	if (tag_len < sizeof(*htt_stats_buf))
++		return;
++
++	len += scnprintf(buf + len, buf_len - len, "HTT_PHY_RESET_COUNTERS_TLV:\n");
++
++	len += scnprintf(buf + len, buf_len - len, "pdev_id = %u\n",
++			 htt_stats_buf->pdev_id);
++	len += scnprintf(buf + len, buf_len - len, "cf_active_low_fail_cnt = %u\n",
++			 htt_stats_buf->cf_active_low_fail_cnt);
++	len += scnprintf(buf + len, buf_len - len, "cf_active_low_pass_cnt = %u\n",
++			 htt_stats_buf->cf_active_low_pass_cnt);
++	len += scnprintf(buf + len, buf_len - len, "phy_off_through_vreg_cnt = %u\n",
++			 htt_stats_buf->phy_off_through_vreg_cnt);
++	len += scnprintf(buf + len, buf_len - len, "force_calibration_cnt = %u\n",
++			 htt_stats_buf->force_calibration_cnt);
++	len += scnprintf(buf + len, buf_len - len, "rf_mode_switch_phy_off_cnt = %u\n",
++			 htt_stats_buf->rf_mode_switch_phy_off_cnt);
++
++	stats_req->buf_len = len;
++}
++
++static inline void
++htt_print_phy_reset_stats_tlv(const void *tag_buf,
++			      u16 tag_len,
++			      struct debug_htt_stats_req *stats_req)
++{
++	const struct htt_phy_reset_stats_tlv *htt_stats_buf = tag_buf;
++	u8 *buf = stats_req->buf;
++	u32 len = stats_req->buf_len;
++	u32 buf_len = ATH11K_HTT_STATS_BUF_SIZE;
++
++	if (tag_len < sizeof(*htt_stats_buf))
++		return;
++
++	len += scnprintf(buf + len, buf_len - len, "HTT_PHY_RESET_STATS_TLV:\n");
++
++	len += scnprintf(buf + len, buf_len - len, "pdev_id = %u\n",
++			 htt_stats_buf->pdev_id);
++	len += scnprintf(buf + len, buf_len - len, "chan_mhz = %u\n",
++			 htt_stats_buf->chan_mhz);
++	len += scnprintf(buf + len, buf_len - len, "chan_band_center_freq1 = %u\n",
++			 htt_stats_buf->chan_band_center_freq1);
++	len += scnprintf(buf + len, buf_len - len, "chan_band_center_freq2 = %u\n",
++			 htt_stats_buf->chan_band_center_freq2);
++	len += scnprintf(buf + len, buf_len - len, "chan_phy_mode = %u\n",
++			 htt_stats_buf->chan_phy_mode);
++	len += scnprintf(buf + len, buf_len - len, "chan_flags = 0x%0x\n",
++			 htt_stats_buf->chan_flags);
++	len += scnprintf(buf + len, buf_len - len, "chan_num = %u\n",
++			 htt_stats_buf->chan_num);
++	len += scnprintf(buf + len, buf_len - len, "reset_cause = 0x%0x\n",
++			 htt_stats_buf->reset_cause);
++	len += scnprintf(buf + len, buf_len - len, "prev_reset_cause = 0x%0x\n",
++			 htt_stats_buf->prev_reset_cause);
++	len += scnprintf(buf + len, buf_len - len, "phy_warm_reset_src = 0x%0x\n",
++			 htt_stats_buf->phy_warm_reset_src);
++	len += scnprintf(buf + len, buf_len - len, "rx_gain_tbl_mode = %d\n",
++			 htt_stats_buf->rx_gain_tbl_mode);
++	len += scnprintf(buf + len, buf_len - len, "xbar_val = 0x%0x\n",
++			 htt_stats_buf->xbar_val);
++	len += scnprintf(buf + len, buf_len - len, "force_calibration = %u\n",
++			 htt_stats_buf->force_calibration);
++	len += scnprintf(buf + len, buf_len - len, "phyrf_mode = %u\n",
++			 htt_stats_buf->phyrf_mode);
++	len += scnprintf(buf + len, buf_len - len, "phy_homechan = %u\n",
++			 htt_stats_buf->phy_homechan);
++	len += scnprintf(buf + len, buf_len - len, "phy_tx_ch_mask = 0x%0x\n",
++			 htt_stats_buf->phy_tx_ch_mask);
++	len += scnprintf(buf + len, buf_len - len, "phy_rx_ch_mask = 0x%0x\n",
++			 htt_stats_buf->phy_rx_ch_mask);
++	len += scnprintf(buf + len, buf_len - len, "phybb_ini_mask = 0x%0x\n",
++			 htt_stats_buf->phybb_ini_mask);
++	len += scnprintf(buf + len, buf_len - len, "phyrf_ini_mask = 0x%0x\n",
++			 htt_stats_buf->phyrf_ini_mask);
++	len += scnprintf(buf + len, buf_len - len, "phy_dfs_en_mask = 0x%0x\n",
++			 htt_stats_buf->phy_dfs_en_mask);
++	len += scnprintf(buf + len, buf_len - len, "phy_sscan_en_mask = 0x%0x\n",
++			 htt_stats_buf->phy_sscan_en_mask);
++	len += scnprintf(buf + len, buf_len - len, "phy_synth_sel_mask = 0x%0x\n",
++			 htt_stats_buf->phy_synth_sel_mask);
++	len += scnprintf(buf + len, buf_len - len, "phy_adfs_freq = %u\n",
++			 htt_stats_buf->phy_adfs_freq);
++	len += scnprintf(buf + len, buf_len - len, "cck_fir_settings = 0x%0x\n",
++			 htt_stats_buf->cck_fir_settings);
++	len += scnprintf(buf + len, buf_len - len, "phy_dyn_pri_chan = %u\n",
++			 htt_stats_buf->phy_dyn_pri_chan);
++	len += scnprintf(buf + len, buf_len - len, "cca_thresh = 0x%0x\n",
++			 htt_stats_buf->cca_thresh);
++	len += scnprintf(buf + len, buf_len - len, "dyn_cca_status = %u\n",
++			 htt_stats_buf->dyn_cca_status);
++	len += scnprintf(buf + len, buf_len - len, "rxdesense_thresh_hw = 0x%x\n",
++			 htt_stats_buf->rxdesense_thresh_hw);
++	len += scnprintf(buf + len, buf_len - len, "rxdesense_thresh_sw = 0x%x\n",
++			 htt_stats_buf->rxdesense_thresh_sw);
++
++	stats_req->buf_len = len;
++}
++
+ static inline
+ void htt_print_peer_ctrl_path_txrx_stats_tlv(const void *tag_buf,
+ 					     struct debug_htt_stats_req *stats_req)
+@@ -4425,6 +4533,12 @@ static int ath11k_dbg_htt_ext_stats_pars
+ 	case HTT_STATS_PHY_STATS_TAG:
+ 		htt_print_phy_stats_tlv(tag_buf, stats_req);
+ 		break;
++	case HTT_STATS_PHY_RESET_COUNTERS_TAG:
++		htt_print_phy_reset_counters_tlv(tag_buf, len, stats_req);
++		break;
++	case HTT_STATS_PHY_RESET_STATS_TAG:
++		htt_print_phy_reset_stats_tlv(tag_buf, len, stats_req);
++		break;
+ 	case HTT_STATS_PEER_CTRL_PATH_TXRX_STATS_TAG:
+ 		htt_print_peer_ctrl_path_txrx_stats_tlv(tag_buf, stats_req);
+ 		break;
+--- a/drivers/net/wireless/ath/ath11k/debugfs_htt_stats.h
++++ b/drivers/net/wireless/ath/ath11k/debugfs_htt_stats.h
+@@ -111,6 +111,8 @@ enum htt_tlv_tag_t {
+ 	HTT_STATS_TXBF_OFDMA_STEER_STATS_TAG		    = 116,
+ 	HTT_STATS_PHY_COUNTERS_TAG			    = 121,
+ 	HTT_STATS_PHY_STATS_TAG				    = 122,
++	HTT_STATS_PHY_RESET_COUNTERS_TAG		    = 123,
++	HTT_STATS_PHY_RESET_STATS_TAG			    = 124,
+ 
+ 	HTT_STATS_MAX_TAG,
+ };
+@@ -1964,6 +1966,47 @@ struct htt_phy_stats_tlv {
+ 	u32 fw_run_time;
+ };
+ 
++struct htt_phy_reset_counters_tlv {
++	u32 pdev_id;
++	u32 cf_active_low_fail_cnt;
++	u32 cf_active_low_pass_cnt;
++	u32 phy_off_through_vreg_cnt;
++	u32 force_calibration_cnt;
++	u32 rf_mode_switch_phy_off_cnt;
++};
++
++struct htt_phy_reset_stats_tlv {
++	u32 pdev_id;
++	u32 chan_mhz;
++	u32 chan_band_center_freq1;
++	u32 chan_band_center_freq2;
++	u32 chan_phy_mode;
++	u32 chan_flags;
++	u32 chan_num;
++	u32 reset_cause;
++	u32 prev_reset_cause;
++	u32 phy_warm_reset_src;
++	u32 rx_gain_tbl_mode;
++	u32 xbar_val;
++	u32 force_calibration;
++	u32 phyrf_mode;
++	u32 phy_homechan;
++	u32 phy_tx_ch_mask;
++	u32 phy_rx_ch_mask;
++	u32 phybb_ini_mask;
++	u32 phyrf_ini_mask;
++	u32 phy_dfs_en_mask;
++	u32 phy_sscan_en_mask;
++	u32 phy_synth_sel_mask;
++	u32 phy_adfs_freq;
++	u32 cck_fir_settings;
++	u32 phy_dyn_pri_chan;
++	u32 cca_thresh;
++	u32 dyn_cca_status;
++	u32 rxdesense_thresh_hw;
++	u32 rxdesense_thresh_sw;
++};
++
+ struct htt_peer_ctrl_path_txrx_stats_tlv {
+ 	/* peer mac address */
+ 	u8 peer_mac_addr[ETH_ALEN];

--- a/package/kernel/mac80211/patches/ath11k/902-ath11k-Disable-coldboot-calibration-for-IPQ8074.patch
+++ b/package/kernel/mac80211/patches/ath11k/902-ath11k-Disable-coldboot-calibration-for-IPQ8074.patch
@@ -13,7 +13,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 
 --- a/drivers/net/wireless/ath/ath11k/core.c
 +++ b/drivers/net/wireless/ath/ath11k/core.c
-@@ -82,7 +82,7 @@ static const struct ath11k_hw_params ath
+@@ -86,7 +86,7 @@ static const struct ath11k_hw_params ath
  		.supports_shadow_regs = false,
  		.idle_ps = false,
  		.supports_sta_ps = false,

--- a/package/kernel/mac80211/patches/ath11k/903-ath11k-support-setting-FW-memory-mode-via-DT.patch
+++ b/package/kernel/mac80211/patches/ath11k/903-ath11k-support-setting-FW-memory-mode-via-DT.patch
@@ -22,16 +22,16 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 
 --- a/drivers/net/wireless/ath/ath11k/core.c
 +++ b/drivers/net/wireless/ath/ath11k/core.c
-@@ -32,7 +32,7 @@ module_param_named(frame_mode, ath11k_fr
- MODULE_PARM_DESC(frame_mode,
- 		 "Datapath frame mode (0: raw, 1: native wifi (default), 2: ethernet)");
+@@ -36,7 +36,7 @@ bool ath11k_ftm_mode;
+ module_param_named(ftm_mode, ath11k_ftm_mode, bool, 0444);
+ MODULE_PARM_DESC(ftm_mode, "Boots up in factory test mode");
  
 -static const struct ath11k_hw_params ath11k_hw_params[] = {
 +static struct ath11k_hw_params ath11k_hw_params[] = {
  	{
  		.hw_rev = ATH11K_HW_IPQ8074,
  		.name = "ipq8074 hw2.0",
-@@ -1911,7 +1911,8 @@ static void ath11k_core_reset(struct wor
+@@ -1953,7 +1953,8 @@ static void ath11k_core_reset(struct wor
  static int ath11k_init_hw_params(struct ath11k_base *ab)
  {
  	const struct ath11k_hw_params *hw_params = NULL;
@@ -41,7 +41,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  
  	for (i = 0; i < ARRAY_SIZE(ath11k_hw_params); i++) {
  		hw_params = &ath11k_hw_params[i];
-@@ -1927,7 +1928,30 @@ static int ath11k_init_hw_params(struct
+@@ -1969,7 +1970,30 @@ static int ath11k_init_hw_params(struct
  
  	ab->hw_params = *hw_params;
  

--- a/package/kernel/mac80211/patches/ath11k/905-ath11k-remove-intersection-support-for-regulatory-ru.patch
+++ b/package/kernel/mac80211/patches/ath11k/905-ath11k-remove-intersection-support-for-regulatory-ru.patch
@@ -271,7 +271,7 @@ Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
  #endif
 --- a/drivers/net/wireless/ath/ath11k/wmi.c
 +++ b/drivers/net/wireless/ath/ath11k/wmi.c
-@@ -6980,24 +6980,12 @@ static void ath11k_wmi_htc_tx_complete(s
+@@ -6996,24 +6996,12 @@ static void ath11k_wmi_htc_tx_complete(s
  		wake_up(&wmi->tx_ce_desc_wq);
  }
  
@@ -296,7 +296,7 @@ Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
  	int ret = 0, pdev_idx, i, j;
  	struct ath11k *ar;
  
-@@ -7059,17 +7047,7 @@ static int ath11k_reg_chan_list_event(st
+@@ -7075,17 +7063,7 @@ static int ath11k_reg_chan_list_event(st
  		    (char *)reg_info->alpha2, 2))
  		goto mem_free;
  

--- a/package/kernel/mac80211/patches/subsys/336-v6.4-wifi-mac80211-generate-EMA-beacons-in-AP-mode.patch
+++ b/package/kernel/mac80211/patches/subsys/336-v6.4-wifi-mac80211-generate-EMA-beacons-in-AP-mode.patch
@@ -1,0 +1,372 @@
+From bd54f3c29077f23dad92ef82a78061b40be30c65 Mon Sep 17 00:00:00 2001
+From: Aloka Dixit <quic_alokad@quicinc.com>
+Date: Mon, 5 Dec 2022 16:50:37 -0800
+Subject: [PATCH] wifi: mac80211: generate EMA beacons in AP mode
+
+Add APIs to generate an array of beacons for an EMA AP (enhanced
+multiple BSSID advertisements), each including a single MBSSID element.
+EMA profile periodicity equals the count of elements.
+
+- ieee80211_beacon_get_template_ema_list() - Generate and return all
+EMA beacon templates. Drivers must call ieee80211_beacon_free_ema_list()
+to free the memory. No change in the prototype for the existing API,
+ieee80211_beacon_get_template(), which should be used for non-EMA AP.
+
+- ieee80211_beacon_get_template_ema_index() - Generate a beacon which
+includes the multiple BSSID element at the given index. Drivers can use
+this function in a loop until NULL is returned which indicates end of
+available MBSSID elements.
+
+- ieee80211_beacon_free_ema_list() - free the memory allocated for the
+list of EMA beacon templates.
+
+Modify existing functions ieee80211_beacon_get_ap(),
+ieee80211_get_mbssid_beacon_len() and ieee80211_beacon_add_mbssid()
+to accept a new parameter for EMA index.
+
+Signed-off-by: Aloka Dixit <quic_alokad@quicinc.com>
+Co-developed-by: John Crispin <john@phrozen.org>
+Signed-off-by: John Crispin <john@phrozen.org>
+Link: https://lore.kernel.org/r/20221206005040.3177-2-quic_alokad@quicinc.com
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+ include/net/mac80211.h     |  68 +++++++++++++++++++
+ net/mac80211/cfg.c         |  11 +--
+ net/mac80211/ieee80211_i.h |  10 ++-
+ net/mac80211/tx.c          | 134 ++++++++++++++++++++++++++++++++++---
+ 4 files changed, 205 insertions(+), 18 deletions(-)
+
+--- a/include/net/mac80211.h
++++ b/include/net/mac80211.h
+@@ -5252,6 +5252,74 @@ ieee80211_beacon_get_template(struct iee
+ 			      unsigned int link_id);
+ 
+ /**
++ * ieee80211_beacon_get_template_ema_index - EMA beacon template generation
++ * @hw: pointer obtained from ieee80211_alloc_hw().
++ * @vif: &struct ieee80211_vif pointer from the add_interface callback.
++ * @offs: &struct ieee80211_mutable_offsets pointer to struct that will
++ *	receive the offsets that may be updated by the driver.
++ * @link_id: the link id to which the beacon belongs (or 0 for a non-MLD AP).
++ * @ema_index: index of the beacon in the EMA set.
++ *
++ * This function follows the same rules as ieee80211_beacon_get_template()
++ * but returns a beacon template which includes multiple BSSID element at the
++ * requested index.
++ *
++ * Return: The beacon template. %NULL indicates the end of EMA templates.
++ */
++struct sk_buff *
++ieee80211_beacon_get_template_ema_index(struct ieee80211_hw *hw,
++					struct ieee80211_vif *vif,
++					struct ieee80211_mutable_offsets *offs,
++					unsigned int link_id, u8 ema_index);
++
++/**
++ * struct ieee80211_ema_beacons - List of EMA beacons
++ * @cnt: count of EMA beacons.
++ *
++ * @bcn: array of EMA beacons.
++ * @bcn.skb: the skb containing this specific beacon
++ * @bcn.offs: &struct ieee80211_mutable_offsets pointer to struct that will
++ *	receive the offsets that may be updated by the driver.
++ */
++struct ieee80211_ema_beacons {
++	u8 cnt;
++	struct {
++		struct sk_buff *skb;
++		struct ieee80211_mutable_offsets offs;
++	} bcn[];
++};
++
++/**
++ * ieee80211_beacon_get_template_ema_list - EMA beacon template generation
++ * @hw: pointer obtained from ieee80211_alloc_hw().
++ * @vif: &struct ieee80211_vif pointer from the add_interface callback.
++ * @link_id: the link id to which the beacon belongs (or 0 for a non-MLD AP)
++ *
++ * This function follows the same rules as ieee80211_beacon_get_template()
++ * but allocates and returns a pointer to list of all beacon templates required
++ * to cover all profiles in the multiple BSSID set. Each template includes only
++ * one multiple BSSID element.
++ *
++ * Driver must call ieee80211_beacon_free_ema_list() to free the memory.
++ *
++ * Return: EMA beacon templates of type struct ieee80211_ema_beacons *.
++ *	%NULL on error.
++ */
++struct ieee80211_ema_beacons *
++ieee80211_beacon_get_template_ema_list(struct ieee80211_hw *hw,
++				       struct ieee80211_vif *vif,
++				       unsigned int link_id);
++
++/**
++ * ieee80211_beacon_free_ema_list - free an EMA beacon template list
++ * @ema_beacons: list of EMA beacons of type &struct ieee80211_ema_beacons pointers.
++ *
++ * This function will free a list previously acquired by calling
++ * ieee80211_beacon_get_template_ema_list()
++ */
++void ieee80211_beacon_free_ema_list(struct ieee80211_ema_beacons *ema_beacons);
++
++/**
+  * ieee80211_beacon_get_tim - beacon generation function
+  * @hw: pointer obtained from ieee80211_alloc_hw().
+  * @vif: &struct ieee80211_vif pointer from the add_interface callback.
+--- a/net/mac80211/cfg.c
++++ b/net/mac80211/cfg.c
+@@ -1122,11 +1122,11 @@ static int ieee80211_assign_beacon(struc
+ 	if (params->mbssid_ies) {
+ 		mbssid = params->mbssid_ies;
+ 		size += struct_size(new->mbssid_ies, elem, mbssid->cnt);
+-		size += ieee80211_get_mbssid_beacon_len(mbssid);
++		size += ieee80211_get_mbssid_beacon_len(mbssid, mbssid->cnt);
+ 	} else if (old && old->mbssid_ies) {
+ 		mbssid = old->mbssid_ies;
+ 		size += struct_size(new->mbssid_ies, elem, mbssid->cnt);
+-		size += ieee80211_get_mbssid_beacon_len(mbssid);
++		size += ieee80211_get_mbssid_beacon_len(mbssid, mbssid->cnt);
+ 	}
+ 
+ 	new = kzalloc(size, GFP_KERNEL);
+@@ -3384,8 +3384,11 @@ cfg80211_beacon_dup(struct cfg80211_beac
+ 
+ 	len = beacon->head_len + beacon->tail_len + beacon->beacon_ies_len +
+ 	      beacon->proberesp_ies_len + beacon->assocresp_ies_len +
+-	      beacon->probe_resp_len + beacon->lci_len + beacon->civicloc_len +
+-	      ieee80211_get_mbssid_beacon_len(beacon->mbssid_ies);
++	      beacon->probe_resp_len + beacon->lci_len + beacon->civicloc_len;
++
++	if (beacon->mbssid_ies)
++		len += ieee80211_get_mbssid_beacon_len(beacon->mbssid_ies,
++						       beacon->mbssid_ies->cnt);
+ 
+ 	new_beacon = kzalloc(sizeof(*new_beacon) + len, GFP_KERNEL);
+ 	if (!new_beacon)
+--- a/net/mac80211/ieee80211_i.h
++++ b/net/mac80211/ieee80211_i.h
+@@ -1182,13 +1182,17 @@ ieee80211_vif_get_shift(struct ieee80211
+ }
+ 
+ static inline int
+-ieee80211_get_mbssid_beacon_len(struct cfg80211_mbssid_elems *elems)
++ieee80211_get_mbssid_beacon_len(struct cfg80211_mbssid_elems *elems, u8 i)
+ {
+-	int i, len = 0;
++	int len = 0;
+ 
+-	if (!elems)
++	if (!elems || !elems->cnt || i > elems->cnt)
+ 		return 0;
+ 
++	if (i < elems->cnt)
++		return elems->elem[i].len;
++
++	/* i == elems->cnt, calculate total length of all MBSSID elements */
+ 	for (i = 0; i < elems->cnt; i++)
+ 		len += elems->elem[i].len;
+ 
+--- a/net/mac80211/tx.c
++++ b/net/mac80211/tx.c
+@@ -5205,13 +5205,20 @@ ieee80211_beacon_get_finish(struct ieee8
+ }
+ 
+ static void
+-ieee80211_beacon_add_mbssid(struct sk_buff *skb, struct beacon_data *beacon)
++ieee80211_beacon_add_mbssid(struct sk_buff *skb, struct beacon_data *beacon,
++			    u8 i)
+ {
+-	int i;
++	if (!beacon->mbssid_ies || !beacon->mbssid_ies->cnt ||
++	    i > beacon->mbssid_ies->cnt)
++		return;
+ 
+-	if (!beacon->mbssid_ies)
++	if (i < beacon->mbssid_ies->cnt) {
++		skb_put_data(skb, beacon->mbssid_ies->elem[i].data,
++			     beacon->mbssid_ies->elem[i].len);
+ 		return;
++	}
+ 
++	/* i == beacon->mbssid_ies->cnt, include all MBSSID elements */
+ 	for (i = 0; i < beacon->mbssid_ies->cnt; i++)
+ 		skb_put_data(skb, beacon->mbssid_ies->elem[i].data,
+ 			     beacon->mbssid_ies->elem[i].len);
+@@ -5224,7 +5231,8 @@ ieee80211_beacon_get_ap(struct ieee80211
+ 			struct ieee80211_mutable_offsets *offs,
+ 			bool is_template,
+ 			struct beacon_data *beacon,
+-			struct ieee80211_chanctx_conf *chanctx_conf)
++			struct ieee80211_chanctx_conf *chanctx_conf,
++			u8 ema_index)
+ {
+ 	struct ieee80211_local *local = hw_to_local(hw);
+ 	struct ieee80211_sub_if_data *sdata = vif_to_sdata(vif);
+@@ -5243,7 +5251,9 @@ ieee80211_beacon_get_ap(struct ieee80211
+ 	/* headroom, head length,
+ 	 * tail length, maximum TIM length and multiple BSSID length
+ 	 */
+-	mbssid_len = ieee80211_get_mbssid_beacon_len(beacon->mbssid_ies);
++	mbssid_len = ieee80211_get_mbssid_beacon_len(beacon->mbssid_ies,
++						     ema_index);
++
+ 	skb = dev_alloc_skb(local->tx_headroom + beacon->head_len +
+ 			    beacon->tail_len + 256 +
+ 			    local->hw.extra_beacon_tailroom + mbssid_len);
+@@ -5261,7 +5271,7 @@ ieee80211_beacon_get_ap(struct ieee80211
+ 		offs->cntdwn_counter_offs[0] = beacon->cntdwn_counter_offsets[0];
+ 
+ 		if (mbssid_len) {
+-			ieee80211_beacon_add_mbssid(skb, beacon);
++			ieee80211_beacon_add_mbssid(skb, beacon, ema_index);
+ 			offs->mbssid_off = skb->len - mbssid_len;
+ 		}
+ 
+@@ -5280,12 +5290,51 @@ ieee80211_beacon_get_ap(struct ieee80211
+ 	return skb;
+ }
+ 
++static struct ieee80211_ema_beacons *
++ieee80211_beacon_get_ap_ema_list(struct ieee80211_hw *hw,
++				 struct ieee80211_vif *vif,
++				 struct ieee80211_link_data *link,
++				 struct ieee80211_mutable_offsets *offs,
++				 bool is_template, struct beacon_data *beacon,
++				 struct ieee80211_chanctx_conf *chanctx_conf)
++{
++	struct ieee80211_ema_beacons *ema = NULL;
++
++	if (!beacon->mbssid_ies || !beacon->mbssid_ies->cnt)
++		return NULL;
++
++	ema = kzalloc(struct_size(ema, bcn, beacon->mbssid_ies->cnt),
++		      GFP_ATOMIC);
++	if (!ema)
++		return NULL;
++
++	for (ema->cnt = 0; ema->cnt < beacon->mbssid_ies->cnt; ema->cnt++) {
++		ema->bcn[ema->cnt].skb =
++			ieee80211_beacon_get_ap(hw, vif, link,
++						&ema->bcn[ema->cnt].offs,
++						is_template, beacon,
++						chanctx_conf, ema->cnt);
++		if (!ema->bcn[ema->cnt].skb)
++			break;
++	}
++
++	if (ema->cnt == beacon->mbssid_ies->cnt)
++		return ema;
++
++	ieee80211_beacon_free_ema_list(ema);
++	return NULL;
++}
++
++#define IEEE80211_INCLUDE_ALL_MBSSID_ELEMS -1
++
+ static struct sk_buff *
+ __ieee80211_beacon_get(struct ieee80211_hw *hw,
+ 		       struct ieee80211_vif *vif,
+ 		       struct ieee80211_mutable_offsets *offs,
+ 		       bool is_template,
+-		       unsigned int link_id)
++		       unsigned int link_id,
++		       int ema_index,
++		       struct ieee80211_ema_beacons **ema_beacons)
+ {
+ 	struct ieee80211_local *local = hw_to_local(hw);
+ 	struct beacon_data *beacon = NULL;
+@@ -5314,8 +5363,29 @@ __ieee80211_beacon_get(struct ieee80211_
+ 		if (!beacon)
+ 			goto out;
+ 
+-		skb = ieee80211_beacon_get_ap(hw, vif, link, offs, is_template,
+-					      beacon, chanctx_conf);
++		if (ema_beacons) {
++			*ema_beacons =
++				ieee80211_beacon_get_ap_ema_list(hw, vif, link,
++								 offs,
++								 is_template,
++								 beacon,
++								 chanctx_conf);
++		} else {
++			if (beacon->mbssid_ies && beacon->mbssid_ies->cnt) {
++				if (ema_index >= beacon->mbssid_ies->cnt)
++					goto out; /* End of MBSSID elements */
++
++				if (ema_index <= IEEE80211_INCLUDE_ALL_MBSSID_ELEMS)
++					ema_index = beacon->mbssid_ies->cnt;
++			} else {
++				ema_index = 0;
++			}
++
++			skb = ieee80211_beacon_get_ap(hw, vif, link, offs,
++						      is_template, beacon,
++						      chanctx_conf,
++						      ema_index);
++		}
+ 	} else if (sdata->vif.type == NL80211_IFTYPE_ADHOC) {
+ 		struct ieee80211_if_ibss *ifibss = &sdata->u.ibss;
+ 		struct ieee80211_hdr *hdr;
+@@ -5403,10 +5473,50 @@ ieee80211_beacon_get_template(struct iee
+ 			      struct ieee80211_mutable_offsets *offs,
+ 			      unsigned int link_id)
+ {
+-	return __ieee80211_beacon_get(hw, vif, offs, true, link_id);
++	return __ieee80211_beacon_get(hw, vif, offs, true, link_id,
++				      IEEE80211_INCLUDE_ALL_MBSSID_ELEMS, NULL);
+ }
+ EXPORT_SYMBOL(ieee80211_beacon_get_template);
+ 
++struct sk_buff *
++ieee80211_beacon_get_template_ema_index(struct ieee80211_hw *hw,
++					struct ieee80211_vif *vif,
++					struct ieee80211_mutable_offsets *offs,
++					unsigned int link_id, u8 ema_index)
++{
++	return __ieee80211_beacon_get(hw, vif, offs, true, link_id, ema_index,
++				      NULL);
++}
++EXPORT_SYMBOL(ieee80211_beacon_get_template_ema_index);
++
++void ieee80211_beacon_free_ema_list(struct ieee80211_ema_beacons *ema_beacons)
++{
++	u8 i;
++
++	if (!ema_beacons)
++		return;
++
++	for (i = 0; i < ema_beacons->cnt; i++)
++		kfree_skb(ema_beacons->bcn[i].skb);
++
++	kfree(ema_beacons);
++}
++EXPORT_SYMBOL(ieee80211_beacon_free_ema_list);
++
++struct ieee80211_ema_beacons *
++ieee80211_beacon_get_template_ema_list(struct ieee80211_hw *hw,
++				       struct ieee80211_vif *vif,
++				       unsigned int link_id)
++{
++	struct ieee80211_ema_beacons *ema_beacons = NULL;
++
++	WARN_ON(__ieee80211_beacon_get(hw, vif, NULL, false, link_id, 0,
++				       &ema_beacons));
++
++	return ema_beacons;
++}
++EXPORT_SYMBOL(ieee80211_beacon_get_template_ema_list);
++
+ struct sk_buff *ieee80211_beacon_get_tim(struct ieee80211_hw *hw,
+ 					 struct ieee80211_vif *vif,
+ 					 u16 *tim_offset, u16 *tim_length,
+@@ -5414,7 +5524,9 @@ struct sk_buff *ieee80211_beacon_get_tim
+ {
+ 	struct ieee80211_mutable_offsets offs = {};
+ 	struct sk_buff *bcn = __ieee80211_beacon_get(hw, vif, &offs, false,
+-						     link_id);
++						     link_id,
++						     IEEE80211_INCLUDE_ALL_MBSSID_ELEMS,
++						     NULL);
+ 	struct sk_buff *copy;
+ 	int shift;
+ 

--- a/package/kernel/mac80211/patches/subsys/500-mac80211_configure_antenna_gain.patch
+++ b/package/kernel/mac80211/patches/subsys/500-mac80211_configure_antenna_gain.patch
@@ -77,7 +77,7 @@
  static void ieee80211_rfkill_poll(struct wiphy *wiphy)
  {
  	struct ieee80211_local *local = wiphy_priv(wiphy);
-@@ -4953,6 +4966,7 @@ const struct cfg80211_ops mac80211_confi
+@@ -4956,6 +4969,7 @@ const struct cfg80211_ops mac80211_confi
  	.set_wiphy_params = ieee80211_set_wiphy_params,
  	.set_tx_power = ieee80211_set_tx_power,
  	.get_tx_power = ieee80211_get_tx_power,
@@ -87,7 +87,7 @@
  	CFG80211_TESTMODE_DUMP(ieee80211_testmode_dump)
 --- a/net/mac80211/ieee80211_i.h
 +++ b/net/mac80211/ieee80211_i.h
-@@ -1538,6 +1538,7 @@ struct ieee80211_local {
+@@ -1542,6 +1542,7 @@ struct ieee80211_local {
  	int dynamic_ps_forced_timeout;
  
  	int user_power_level; /* in dBm, for all interfaces */


### PR DESCRIPTION
Synchronize the ath11k backports with the current ath-next tree.

This introduces support for MBSSID and EMA, adds factory test mode and
some new HTT stats.
Generic mac80211 EMA beacon support was backported as well.

While we are here, bump the minor 2.9.0.1 FW version as well.

Runtime tested on Dynalink DL-WRX36/ipq807x
