### PR TITLE
armvirt: add U-Boot support via new uboot-armvirt package

### DIFF
--- a/include/u-boot.mk
+++ b/include/u-boot.mk
@@ -83,6 +83,9 @@ endef
 
 define Build/Configure/U-Boot
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) $(UBOOT_CONFIGURE_VARS) $(UBOOT_CONFIG)_config
+	$(if $(strip $(UBOOT_CUSTOMIZE_CONFIG)),
+		$(PKG_BUILD_DIR)/scripts/config --file $(PKG_BUILD_DIR)/.config $(UBOOT_CUSTOMIZE_CONFIG)
+		+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) $(UBOOT_CONFIGURE_VARS) oldconfig)
 endef
 
 DTC=$(wildcard $(LINUX_DIR)/scripts/dtc/dtc)

--- a/package/boot/uboot-armvirt/Makefile
+++ b/package/boot/uboot-armvirt/Makefile
@@ -1,0 +1,36 @@
+include $(TOPDIR)/rules.mk
+
+PKG_VERSION:=2023.04
+PKG_RELEASE:=1
+
+PKG_HASH:=e31cac91545ff41b71cec5d8c22afd695645cd6e2a442ccdacacd60534069341
+
+include $(INCLUDE_DIR)/u-boot.mk
+include $(INCLUDE_DIR)/package.mk
+
+define U-Boot/Default
+  BUILD_TARGET:=armvirt
+endef
+
+define U-Boot/armvirt
+  NAME:=QEMU ARM Virtual Machine 32-bit
+  BUILD_SUBTARGET:=32
+  BUILD_DEVICES:=generic
+  UBOOT_CONFIG:=qemu_arm
+endef
+
+define U-Boot/armvirt64
+  NAME:=QEMU ARM Virtual Machine 64-bit
+  BUILD_SUBTARGET:=64
+  BUILD_DEVICES:=generic
+  UBOOT_CONFIG:=qemu_arm64
+endef
+
+UBOOT_TARGETS := \
+	armvirt \
+	armvirt64
+
+UBOOT_CUSTOMIZE_CONFIG := \
+	--enable CMD_EFIDEBUG
+
+$(eval $(call BuildPackage/U-Boot))

--- a/package/boot/uboot-armvirt/patches/001-v2023.07-bootstd-Use-blk-uclass-device-numbers-to-set-efi-bootdev.patch
+++ b/package/boot/uboot-armvirt/patches/001-v2023.07-bootstd-Use-blk-uclass-device-numbers-to-set-efi-bootdev.patch
@@ -1,0 +1,62 @@
+From: Simon Glass <sjg@chromium.org>
+To: U-Boot Mailing List <u-boot@lists.denx.de>
+Subject: [PATCH v10 7/9] bootstd: Use blk uclass device numbers to set efi
+ bootdev
+Date: Mon, 24 Apr 2023 13:49:50 +1200
+Message-ID: 
+ <20230424134946.v10.7.Ia5f5e39c882ac22b5f71c4d576941b34e868eeba@changeid>
+
+From: Mathew McBride <matt@traverse.com.au>
+
+When loading a file from a block device, efiload_read_file
+was using the seq_num of the device (e.g "35" of virtio_blk#35)
+instead of the block device id (e.g what you get from running
+the corresponding device scan command, like "virtio 0")
+
+This cause EFI booting from these devices to fail as an
+invalid device number is passed to blk_get_device_part_str:
+
+  Scanning bootdev 'virtio-blk#35.bootdev':
+  distro_efi_read_bootflow_file start (efi,fname=<NULL>)
+  distro_efi_read_bootflow_file start (efi,fname=<NULL>)
+  setting bootdev virtio, 35, efi/boot/bootaa64.efi, 00000000beef9a40, 170800
+  efi_dp_from_name calling blk_get_device_part_str
+  dev=virtio devnr=35 path=efi/boot/bootaa64.efi
+  blk_get_device_part_str (virtio,35)
+  blk_get_device_by_str (virtio, 35)
+  ** Bad device specification virtio 35 **
+  Using default device tree: dtb/qemu-arm.dtb
+  No device tree available
+  0  efi          ready   virtio       1  virtio-blk#35.bootdev.par efi/boot/bootaa64.efi
+  ** Booting bootflow 'virtio-blk#35.bootdev.part_1' with efi
+  blk_get_device_part_str (virtio,0:1)
+  blk_get_device_by_str (virtio, 0)
+  No UEFI binary known at beef9a40 (image buf=00000000beef9a40,addr=0000000000000000)
+  Boot failed (err=-22)
+
+Signed-off-by: Mathew McBride <matt@traverse.com.au>
+Signed-off-by: Simon Glass <sjg@chromium.org>
+Signed-off-by: Petr Štetiar <ynezz@true.cz> [backport to 2023.04]
+---
+
+(no changes since v8)
+
+Changes in v8:
+- Add new patch to use blk uclass device numbers to set efi bootdev
+
+ boot/bootmeth_efi.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/boot/bootmeth_efi.c
++++ b/boot/bootmeth_efi.c
+@@ -117,7 +117,9 @@ static int efiload_read_file(struct blk_
+ 	 * this can go away.
+ 	 */
+ 	media_dev = dev_get_parent(bflow->dev);
+-	snprintf(devnum_str, sizeof(devnum_str), "%x", dev_seq(media_dev));
++	snprintf(devnum_str, sizeof(devnum_str), "%x:%x",
++		 desc ? desc->devnum : dev_seq(media_dev),
++		 bflow->part);
+ 
+ 	strlcpy(dirname, bflow->fname, sizeof(dirname));
+ 	last_slash = strrchr(dirname, '/');

--- a/target/linux/armvirt/README
+++ b/target/linux/armvirt/README
@@ -48,7 +48,7 @@ images in EFI mode:
 gunzip -c bin/targets/armvirt/32/openwrt-armvirt-32-generic-ext4-combined.img.gz > openwrt-arm-32.img
 qemu-system-arm -nographic \
     -cpu cortex-a15 -machine virt \
-    -bios QEMU_EFI_32.fd \
+    -bios bin/targets/armvirt/32/u-boot-armvirt/u-boot.bin \
     -smp 1 -m 1024 \
     -device virtio-rng-pci \
     -drive file=openwrt-arm-32.img,format=raw,index=0,media=disk \
@@ -59,14 +59,13 @@ qemu-system-arm -nographic \
 gunzip -c bin/targets/armvirt/64/openwrt-armvirt-64-generic-ext4-combined.img.gz > openwrt-arm-64.img
 qemu-system-aarch64 -nographic \
     -cpu cortex-a53 -machine virt \
-    -bios QEMU_EFI_64.fd \
+    -bios bin/targets/armvirt/64/u-boot-armvirt64/u-boot.bin \
     -smp 1 -m 1024 \
     -device virtio-rng-pci \
     -drive file=openwrt-arm-64.img,format=raw,index=0,media=disk \
     -netdev user,id=testlan -net nic,netdev=testlan \
     -netdev user,id=testwan -net nic,netdev=testwan
 
-One can find EFI/BIOS binaries from:
-- Compile mainline U-Boot for the QEMU ARM virtual machine (qemu_arm_defconfig/qemu_arm64_defconfig)
-- From distribution packages (such as qemu-efi-arm and qemu-efi-aarch64 in Debian)
+One can obtain other EFI/BIOS binaries from:
+- Distribution packages (such as qemu-efi-arm and qemu-efi-aarch64 in Debian)
 - Community builds, like retrage/edk2-nightly: https://retrage.github.io/edk2-nightly/

--- a/target/linux/armvirt/image/Makefile
+++ b/target/linux/armvirt/image/Makefile
@@ -73,7 +73,7 @@ define Build/grub-install
 	$(INSTALL_DIR) $@.grub2
 endef
 
-DEVICE_VARS += GRUB2_VARIANT
+DEVICE_VARS += GRUB2_VARIANT UBOOT
 define Device/efi-default
   IMAGE/rootfs.img := append-rootfs | pad-to $(ROOTFS_PARTSIZE)
   IMAGE/rootfs.img.gz := append-rootfs | pad-to $(ROOTFS_PARTSIZE) | gzip
@@ -105,6 +105,7 @@ define Device/generic
   DEVICE_TITLE := Generic EFI Boot
   GRUB2_VARIANT := generic
   FILESYSTEMS := ext4 squashfs
+  UBOOT := $(if $(CONFIG_aarch64),armvirt64,armvirt)
   DEVICE_PACKAGES += kmod-amazon-ena kmod-e1000e kmod-vmxnet3 kmod-rtc-rx8025 \
 	kmod-i2c-mux-pca954x kmod-gpio-pca953x partx-utils kmod-wdt-sp805 \
 	kmod-mvneta kmod-mvpp2 kmod-fsl-dpaa1-net kmod-fsl-dpaa2-net \


### PR DESCRIPTION
So we can use self-compiled bootloader provided by internal package.

Cc: @mcbridematt 
