### PR TITLE
ramips: enable LED button for TP-Link EC330-G5u v1

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/rc.button/lights_toggle
+++ b/target/linux/ramips/mt7621/base-files/etc/rc.button/lights_toggle
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+[ "${ACTION}" = "released" ] || exit 0
+
+. /lib/functions.sh
+
+case $(board_name) in
+	tplink,ec330-g5u-v1)
+		led_light="/sys/class/gpio/led-light/value"
+		echo $(($(cat $led_light) ^ 1)) > $led_light
+		;;
+	*)
+		;;
+esac
+
+return 0


### PR DESCRIPTION
The device already has LED push button (`KEY_LIGHTS_TOGGLE`) and exported GPIO control `led-light`. This commit adds button handler script for switching on/off all device LEDs.
