### PR TITLE
[23.05] base-files: enable BPF JIT kallsyms by default

### DIFF
--- a/package/base-files/files/etc/sysctl.d/10-default.conf
+++ b/package/base-files/files/etc/sysctl.d/10-default.conf
@@ -9,6 +9,7 @@ fs.protected_hardlinks=1
 fs.protected_symlinks=1
 
 net.core.bpf_jit_enable=1
+net.core.bpf_jit_kallsyms=1
 
 net.ipv4.conf.default.arp_ignore=1
 net.ipv4.conf.all.arp_ignore=1


### PR DESCRIPTION
Set net.core.bpf_jit_kallsyms=1 in /etc/sysctl.d/10-default.conf.

For privileged users, this exports addresses of JIT-compiled programs to appear in /proc/kallsyms when present, allowing their use for debugging and in traces.

For further details see the upstream commit [74451e66d5](https://github.com/torvalds/linux/commit/74451e66d516c55e309e8d89a4a1e7596e46aacd) ("bpf: make jited programs visible in traces").

(cherry picked from commit b3aaede2a7b14f2be850db8ae0c826e2782a60e8)
Build and run-tested on `malta/be` and `armvirt/64` under kernel 5.15.

Kindly requesting either @hauke or @dangowrt for review and backport. 
