### PR TITLE
kernel: use struct group to wipe psb6970 volatile priv data

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/psb6970.c
+++ b/target/linux/generic/files/drivers/net/phy/psb6970.c
@@ -60,11 +60,13 @@ struct psb6970_priv {
 	struct mutex reg_mutex;
 
 	/* all fields below are cleared on reset */
-	bool vlan;
-	u16 vlan_id[PSB6970_MAX_VLANS];
-	u8 vlan_table[PSB6970_MAX_VLANS];
-	u8 vlan_tagged;
-	u16 pvid[PSB6970_NUM_PORTS];
+	struct_group(psb6970_priv_volatile,
+		bool vlan;
+		u16 vlan_id[PSB6970_MAX_VLANS];
+		u8 vlan_table[PSB6970_MAX_VLANS];
+		u8 vlan_tagged;
+		u16 pvid[PSB6970_NUM_PORTS];
+	);
 };
 
 #define to_psb6970(_dev) container_of(_dev, struct psb6970_priv, dev)
@@ -272,8 +274,8 @@ static int psb6970_reset_switch(struct switch_dev *dev)
 
 	mutex_lock(&priv->reg_mutex);
 
-	memset(&priv->vlan, 0, sizeof(struct psb6970_priv) -
-	       offsetof(struct psb6970_priv, vlan));
+	memset(&priv->psb6970_priv_volatile, 0,
+		sizeof(priv->psb6970_priv_volatile));
 
 	for (i = 0; i < PSB6970_MAX_VLANS; i++)
 		priv->vlan_id[i] = i;


### PR DESCRIPTION
Instead of reference vlan and do strange subtraction, use the handy struct_group() to create a virtual struct of the same size of the members. This permits to have a more secure memset and fix compilation warning in 6.1 where additional checks are done.

Fix compilation warning:
```
    inlined from 'psb6970_reset_switch' at drivers/net/phy/psb6970.c:275:2:
./include/linux/fortify-string.h:314:25: error: call to '__write_overflow_field' declared with attribute warning: detected write beyond size of field (1st parameter); maybe use struct_group()? [-Werror=attribute-warning]
  314 |                         __write_overflow_field(p_size_field, size);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```
