### PR TITLE
uboot-envtools: Add u-boot env config for GL-MT3000

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -37,6 +37,9 @@ bananapi,bpi-r3)
 		;;
 	esac
 	;;
+glinet,gl-mt3000)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x20000"
+	;;
 xiaomi,redmi-router-ax6000-stock)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x20000"
 	ubootenv_add_uci_sys_config "/dev/mtd2" "0x0" "0x10000" "0x20000"


### PR DESCRIPTION
This commit add u-boot env config for GL-MT3000, so that we can use fw_printenv to print u-boot env and use fw_setenv to set u-boot env in GL-MT3000.
