### PR TITLE
ath79: add support for TP-Link TL-WDR6500 v2

### DIFF
--- a/target/linux/ath79/dts/qca9561_tplink_tl-wdr6500-v2.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_tl-wdr6500-v2.dts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,tl-wdr6500-v2", "qca,qca9561";
+	model = "TP-Link TL-WDR6500 v2";
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &eth1;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan4 {
+			label = "green:lan4";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "green:lan3";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "green:lan2";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "green:lan1";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		led_system: system {
+			label = "white:system";
+			gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x010000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_uboot_0fc00: macaddr@0fc00 {
+					reg = <0x0fc00 0x6>;
+				};
+			};
+
+			partition@10000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x010000 0x7e0000>;
+			};
+
+			partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				calibration_ath9k: calibration@1000 {
+					reg = <0x1000 0x440>;
+				};
+
+				calibration_ath10k: calibration@5000 {
+					reg = <0x5000 0x844>;
+				};
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0 0 0 0 0>;
+
+		nvmem-cells = <&macaddr_uboot_0fc00>, <&calibration_ath10k>;
+		nvmem-cell-names = "mac-address", "calibration";
+		mac-address-increment = <(-2)>;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	nvmem-cells = <&macaddr_uboot_0fc00>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_uboot_0fc00>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_uboot_0fc00>, <&calibration_ath9k>;
+	nvmem-cell-names = "mac-address", "calibration";
+	mac-address-increment = <(-1)>;
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -30,6 +30,13 @@ tplink,cpe610-v2|\
 tplink,tl-wa1201-v2)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
 	;;
+tplink,tl-wdr6500-v2)
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
+	ucidef_set_led_switch "lan1" "LAN1" "green:lan1" "switch0" "0x02"
+	ucidef_set_led_switch "lan2" "LAN2" "green:lan2" "switch0" "0x04"
+	ucidef_set_led_switch "lan3" "LAN3" "green:lan3" "switch0" "0x08"
+	ucidef_set_led_switch "lan4" "LAN4" "green:lan4" "switch0" "0x10"
+	;;
 alfa-network,n2q)
 	ucidef_set_led_netdev "lan2" "LAN2" "orange:lan2" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "orange:lan1" "switch0" "0x10"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -247,7 +247,8 @@ ath79_setup_interfaces()
 	comfast,cf-e560ac|\
 	qca,ap143-8m|\
 	qca,ap143-16m|\
-	tplink,tl-wr841hp-v3)
+	tplink,tl-wr841hp-v3|\
+	tplink,tl-wdr6500-v2)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -676,6 +676,22 @@ define Device/tplink_tl-wdr4900-v2
 endef
 TARGET_DEVICES += tplink_tl-wdr4900-v2
 
+define Device/tplink_tl-wdr6500-v2
+  $(Device/tplink-8mlzma)
+  SOC := qca9561
+  DEVICE_MODEL := TL-WDR6500
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-ledtrig-usbdev \
+	kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  IMAGE_SIZE := 8000k
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | uImage lzma
+  TPLINK_HWID := 0x65000002
+  TPLINK_HEADER_VERSION := 1
+  SUPPORTED_DEVICES += tl-wdr6500-v2
+endef
+TARGET_DEVICES += tplink_tl-wdr6500-v2
+
 define Device/tplink_tl-wdr7500-v3
   $(Device/tplink-8mlzma)
   SOC := qca9558


### PR DESCRIPTION
    This ports the TP-Link TL-WDR6500 v2 from ar71xx to ath79.

    Specifications:

      SoC: QCA9561
      CPU: 750 MHz
      Flash: 8 MiB (Winbond W25Q64FVSIG)
      RAM: 128 MiB
      WiFi 2.4 GHz: QCA956X 3x3 MIMO 802.11b/g/n
      WiFi 5 GHz: QCA9882-BR4A 2x2 MIMO 802.11a/n/ac
      Ethernet: 4x LAN and 1x WAN (all 100M)
      USB: 1x Header

    Flashing instructions:

      As it appears, the device does not support flashing via GUI or
      TFTP, only serial is possible.

    Boot dmesg log:
[tl-wdr6500v2.log](https://github.com/openwrt/openwrt/files/11654686/tl-wdr6500v2.log)

