### PR TITLE
bmips: fix RAC flush kernel panic in dma

### DIFF
--- a/target/linux/bmips/patches-5.15/300-bmips-fix-RAC-flush-kernel-panic.patch
+++ b/target/linux/bmips/patches-5.15/300-bmips-fix-RAC-flush-kernel-panic.patch
@@ -1,0 +1,40 @@
+--- a/arch/mips/bmips/dma.c
++++ b/arch/mips/bmips/dma.c
+@@ -3,15 +3,17 @@
+ #include <linux/types.h>
+ #include <linux/dma-map-ops.h>
+ #include <asm/bmips.h>
+ #include <asm/io.h>
+ 
++#define MIPS_BASE	0xff400000
++
+ bool bmips_rac_flush_disable;
+ 
+ void arch_sync_dma_for_cpu_all(void)
+ {
+-	void __iomem *cbr = BMIPS_GET_CBR();
++	void __iomem *cbr = (void *)MIPS_BASE;
+ 	u32 cfg;
+ 
+ 	if (boot_cpu_type() != CPU_BMIPS3300 &&
+ 	    boot_cpu_type() != CPU_BMIPS4350 &&
+ 	    boot_cpu_type() != CPU_BMIPS4380)
+--- a/arch/mips/bmips/setup.c
++++ b/arch/mips/bmips/setup.c
+@@ -169,16 +169,10 @@
+ 	/*
+ 	 * BCM3368/BCM6358 need special handling for their shared TLB, so
+ 	 * disable SMP for now
+ 	 */
+ 	bmips_smp_enabled = 0;
+-
+-	/*
+-	 * RAC flush causes kernel panics on BCM6358 when booting from TP1
+-	 * because the bootloader is not initializing it properly.
+-	 */
+-	bmips_rac_flush_disable = !!(read_c0_brcm_cmt_local() & (1 << 31));
+ }
+ 
+ static void bcm6368_quirks(void)
+ {
+ 	bcm63xx_fixup_cpu1();

--- a/target/linux/bmips/patches-6.1/300-bmips-fix-RAC-flush-kernel-panic.patch
+++ b/target/linux/bmips/patches-6.1/300-bmips-fix-RAC-flush-kernel-panic.patch
@@ -1,0 +1,40 @@
+--- a/arch/mips/bmips/dma.c
++++ b/arch/mips/bmips/dma.c
+@@ -3,15 +3,17 @@
+ #include <linux/types.h>
+ #include <linux/dma-map-ops.h>
+ #include <asm/bmips.h>
+ #include <asm/io.h>
+ 
++#define MIPS_BASE	0xff400000
++
+ bool bmips_rac_flush_disable;
+ 
+ void arch_sync_dma_for_cpu_all(void)
+ {
+-	void __iomem *cbr = BMIPS_GET_CBR();
++	void __iomem *cbr = (void *)MIPS_BASE;
+ 	u32 cfg;
+ 
+ 	if (boot_cpu_type() != CPU_BMIPS3300 &&
+ 	    boot_cpu_type() != CPU_BMIPS4350 &&
+ 	    boot_cpu_type() != CPU_BMIPS4380)
+--- a/arch/mips/bmips/setup.c
++++ b/arch/mips/bmips/setup.c
+@@ -169,16 +169,10 @@
+ 	/*
+ 	 * BCM3368/BCM6358 need special handling for their shared TLB, so
+ 	 * disable SMP for now
+ 	 */
+ 	bmips_smp_enabled = 0;
+-
+-	/*
+-	 * RAC flush causes kernel panics on BCM6358 when booting from TP1
+-	 * because the bootloader is not initializing it properly.
+-	 */
+-	bmips_rac_flush_disable = !!(read_c0_brcm_cmt_local() & (1 << 31));
+ }
+ 
+ static void bcm6368_quirks(void)
+ {
+ 	bcm63xx_fixup_cpu1();


### PR DESCRIPTION
When using the second core in BCM6358 and BCM6368 a kernel panic occurs:
```
[   57.638012] Reserved instruction in kernel code[#1]:
[   57.643104] CPU: 0 PID: 2210 Comm: fw4 Not tainted 6.1.31 #0
[   57.648920] $ 0   : 00000000 10008f00 00000000 00000084
[   57.654294] $ 4   : 00000000 10008f01 00000000 81ee3100
[   57.659669] $ 8   : 00000010 8071a60c 00000000 00000002
[   57.665045] $12   : fffffffd 00000026 8201fbe0 8201fce4
[   57.670422] $16   : 000009bc 7f9b8444 00000000 00000000
[   57.675797] $20   : 00000000 00000001 77ea3820 00490000
[   57.681173] $24   : 00000000 808aea7c
[   57.686549] $28   : 829f4000 829f5ed0 00000004 8002017c
```
This is caused by an access to the wrong address when flushing the readahead cache. read_c0_brcm_cbr() returns 0 if executed from TP1. As a result of this BMIPS_GET_CBR() also gets a wrong address. If executed from TP0 we get the right address.

All bmips SoC models supported in OpenWrt use the same RAC register address: 0xff400000.

Fix it by hardcoding this address instead of reading cbr from CP0.

CC: @Noltari 
