### PR TITLE
ath79:enable link state reporting for eth1 on Qxwlan e750a/e600g/e600gac

### DIFF
--- a/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-16m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-16m.dts
@@ -32,8 +32,11 @@
 &eth1 {
 	status = "okay";
 
+	phy-handle = <&swphy0>;
+
 	nvmem-cells = <&macaddr_pridata_400>;
 	nvmem-cell-names = "mac-address";
+	/delete-node/ fixed-link;
 
 	gmac-config {
 		device = <&gmac>;

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-8m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-8m.dts
@@ -32,8 +32,11 @@
 &eth1 {
 	status = "okay";
 
+	phy-handle = <&swphy0>;
+
 	nvmem-cells = <&macaddr_pridata_400>;
 	nvmem-cell-names = "mac-address";
+	/delete-node/ fixed-link;
 
 	gmac-config {
 		device = <&gmac>;

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -287,6 +287,7 @@
 	clocks = <&pll ATH79_CLK_AHB>, <&pll ATH79_CLK_AHB>;
 	clock-names = "eth", "mdio";
 	phy-mode = "gmii";
+	builtin-switch;
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/dts/qca9531_qxwlan_e600g.dtsi
+++ b/target/linux/ath79/dts/qca9531_qxwlan_e600g.dtsi
@@ -101,8 +101,10 @@
 };
 
 &eth1 {
+	phy-handle = <&swphy0>;
 	nvmem-cells = <&macaddr_pridata_400>;
 	nvmem-cell-names = "mac-address";
+	/delete-node/ fixed-link;
 };
 
 &wmac {

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -284,6 +284,7 @@
 	compatible = "qca,qca9530-eth", "syscon";
 	resets = <&rst 13>;
 	reset-names = "mac";
+	builtin-switch;
 
 	phy-mode = "gmii";
 

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -329,6 +329,7 @@
 
 	resets = <&rst 13>;
 	reset-names = "mac";
+	builtin-switch;
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
+++ b/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
@@ -1,0 +1,62 @@
+diff -ruN a/drivers/net/ethernet/atheros/ag71xx/ag71xx.h b/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
+--- a/drivers/net/ethernet/atheros/ag71xx/ag71xx.h	2023-06-07 08:48:07.568151395 +0800
++++ b/drivers/net/ethernet/atheros/ag71xx/ag71xx.h	2023-06-07 08:50:27.396879479 +0800
+@@ -160,6 +160,7 @@
+ 	u16			rx_buf_size;
+ 	u8			rx_buf_offset;
+ 	u8			tx_hang_workaround:1;
++	u8			builtin_switch:1;
+ 
+ 	struct net_device	*dev;
+ 	struct platform_device  *pdev;
+diff -ruN a/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c b/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+--- a/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c	2023-06-07 08:48:20.136216458 +0800
++++ b/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c	2023-06-07 08:53:41.781904202 +0800
+@@ -867,6 +867,8 @@
+ 	u32 cfg2;
+ 	u32 ifctl;
+ 	u32 fifo5;
++	u32 speed;
++	u32 duplex;
+ 
+ 	if (!ag->link && update) {
+ 		ag71xx_hw_stop(ag);
+@@ -880,9 +882,13 @@
+ 	    !of_device_is_compatible(np, "qca,ar7100-eth"))
+ 		ag71xx_fast_reset(ag);
+ 
++	duplex = ag-> duplex;
++	if (ag->builtin_switch)
++		duplex = 1;
++
+ 	cfg2 = ag71xx_rr(ag, AG71XX_REG_MAC_CFG2);
+ 	cfg2 &= ~(MAC_CFG2_IF_1000 | MAC_CFG2_IF_10_100 | MAC_CFG2_FDX);
+-	cfg2 |= (ag->duplex) ? MAC_CFG2_FDX : 0;
++	cfg2 |= (duplex) ? MAC_CFG2_FDX : 0;
+ 
+ 	ifctl = ag71xx_rr(ag, AG71XX_REG_MAC_IFCTL);
+ 	ifctl &= ~(MAC_IFCTL_SPEED);
+@@ -890,7 +896,11 @@
+ 	fifo5 = ag71xx_rr(ag, AG71XX_REG_FIFO_CFG5);
+ 	fifo5 &= ~FIFO_CFG5_BM;
+ 
+-	switch (ag->speed) {
++	speed = ag->speed;
++	if (ag->builtin_switch)
++		speed = SPEED_1000;
++
++	switch (speed) {
+ 	case SPEED_1000:
+ 		cfg2 |= MAC_CFG2_IF_1000;
+ 		fifo5 |= FIFO_CFG5_BM;
+@@ -1583,6 +1593,10 @@
+ 		ag->pllregmap = NULL;
+ 	}
+ 
++	if (of_property_read_bool(np, "builtin-switch")) {
++		ag->builtin_switch = 1;
++	}
++
+ 	ag->mac_base = devm_ioremap(&pdev->dev, res->start,
+ 				    res->end - res->start + 1);
+ 	if (!ag->mac_base)

--- a/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
+++ b/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ath79: enable link state reporting
 Tested on Qxwlan e750a e600g e600gac and ml181(qca9561)
 
 Link: https://github.com/openwrt/openwrt/pull/9971
-Signed-off-by:张 鹏 <sd20@qxwlan.com>
+Signed-off-by: 张 鹏<sd20@qxwlan.com>
 
 --- a/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
 +++ b/drivers/net/ethernet/atheros/ag71xx/ag71xx.h

--- a/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
+++ b/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
@@ -1,6 +1,14 @@
-diff -ruN a/drivers/net/ethernet/atheros/ag71xx/ag71xx.h b/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
---- a/drivers/net/ethernet/atheros/ag71xx/ag71xx.h	2023-06-07 08:48:07.568151395 +0800
-+++ b/drivers/net/ethernet/atheros/ag71xx/ag71xx.h	2023-06-07 08:50:27.396879479 +0800
+From: 张 鹏 <sd20@qxwlan.com>
+Date: Sun, 7 June 2023 09:32:28 -0700
+Subject: [PATCH] ath79: enable link state reporting
+
+Tested on Qxwlan e750a e600g e600gac and ml181(qca9561).
+
+Link: https://github.com/openwrt/openwrt/pull/9971
+Signed-off-by: 张 鹏 <sd20@qxwlan.com>
+
+--- a/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
++++ b/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
 @@ -160,6 +160,7 @@
  	u16			rx_buf_size;
  	u8			rx_buf_offset;
@@ -9,9 +17,8 @@ diff -ruN a/drivers/net/ethernet/atheros/ag71xx/ag71xx.h b/drivers/net/ethernet/
  
  	struct net_device	*dev;
  	struct platform_device  *pdev;
-diff -ruN a/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c b/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
---- a/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c	2023-06-07 08:48:20.136216458 +0800
-+++ b/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c	2023-06-07 08:53:41.781904202 +0800
+--- a/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
++++ b/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
 @@ -867,6 +867,8 @@
  	u32 cfg2;
  	u32 ifctl;

--- a/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
+++ b/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
@@ -1,6 +1,14 @@
-diff -ruN a/drivers/net/ethernet/atheros/ag71xx/ag71xx.h b/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
---- a/drivers/net/ethernet/atheros/ag71xx/ag71xx.h	2023-06-07 08:48:07.568151395 +0800
-+++ b/drivers/net/ethernet/atheros/ag71xx/ag71xx.h	2023-06-07 08:50:27.396879479 +0800
+From: 张 鹏 <sd20@qxwlan.com>
+Date: Sun, 7 June 2023 09:32:28 -0700
+Subject: [PATCH] ath79: enable link state reporting
+
+Tested on Qxwlan e750a e600g e600gac and ml181(qca9561) 
+
+Link: https://github.com/openwrt/openwrt/pull/9971
+Signed-off-by: 张 鹏 <sd20@qxwlan.com>
+
+--- a/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
++++ b/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
 @@ -160,6 +160,7 @@
  	u16			rx_buf_size;
  	u8			rx_buf_offset;
@@ -9,9 +17,8 @@ diff -ruN a/drivers/net/ethernet/atheros/ag71xx/ag71xx.h b/drivers/net/ethernet/
  
  	struct net_device	*dev;
  	struct platform_device  *pdev;
-diff -ruN a/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c b/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
---- a/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c	2023-06-07 08:48:20.136216458 +0800
-+++ b/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c	2023-06-07 08:53:41.781904202 +0800
+--- a/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
++++ b/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
 @@ -867,6 +867,8 @@
  	u32 cfg2;
  	u32 ifctl;

--- a/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
+++ b/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ath79: enable link state reporting
 Tested on Qxwlan e750a e600g e600gac and ml181(qca9561)
 
 Link: https://github.com/openwrt/openwrt/pull/9971
-Signed-off-by: 张 鹏<sd20@qxwlan.com>
+Signed-off-by: 张 鹏 <sd20@qxwlan.com>
 
 --- a/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
 +++ b/drivers/net/ethernet/atheros/ag71xx/ag71xx.h

--- a/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
+++ b/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
@@ -2,7 +2,7 @@ From: 张 鹏 <sd20@qxwlan.com>
 Date: Sun, 7 June 2023 09:32:28 -0700
 Subject: [PATCH] ath79: enable link state reporting
 
-Tested on Qxwlan e750a e600g e600gac and ml181(qca9561) 
+Tested on Qxwlan e750a e600g e600gac and ml181(qca9561)
 
 Link: https://github.com/openwrt/openwrt/pull/9971
 Signed-off-by: 张 鹏 <sd20@qxwlan.com>

--- a/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
+++ b/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ath79: enable link state reporting
 Tested on Qxwlan e750a e600g e600gac and ml181(qca9561)
 
 Link: https://github.com/openwrt/openwrt/pull/9971
-Signed-off-by: 张 鹏 <sd20@qxwlan.com>
+Signed-off-by:张 鹏 <sd20@qxwlan.com>
 
 --- a/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
 +++ b/drivers/net/ethernet/atheros/ag71xx/ag71xx.h

--- a/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
+++ b/target/linux/ath79/patches-5.15/941-ath79-enable-link-state-reporting-for-eth1.patch
@@ -2,7 +2,7 @@ From: 张 鹏 <sd20@qxwlan.com>
 Date: Sun, 7 June 2023 09:32:28 -0700
 Subject: [PATCH] ath79: enable link state reporting
 
-Tested on Qxwlan e750a e600g e600gac and ml181(qca9561)
+Tested on Qxwlan e750a e600g e600gac and ml181(qca9561).
 
 Link: https://github.com/openwrt/openwrt/pull/9971
 Signed-off-by: 张 鹏 <sd20@qxwlan.com>


### PR DESCRIPTION
Enable link state reporting or the Fast Ethernet port attached through 
the built-in switch, so it can generate netifd and hotplug events as well,
for example -
\- to control DHCP client.

I tested it on several devices with different CPUs and they all worked really 
well after adding the code to solve the link state reporting issue.

Test Device:
Qxwlan e750a (soc: ar9344)
Qxwlan e600g/gac (soc :qca9531)
Qxwlan ml181 (soc: qca9561)   
ML181 currently exists only in local sdk and will be committed to OpenWRT

My code is based on:
https://github.com/openwrt/openwrt/pull/9971

Signed-off-by: 张 鹏 <sd20@qxwlan.com>
