### PR TITLE
ath79:enable link state reporting for eth1 on Qxwlan e750a/e600g/e600gac

### DIFF
--- a/target/linux/ath79/dts/ar7240.dtsi
+++ b/target/linux/ath79/dts/ar7240.dtsi
@@ -87,6 +87,7 @@
 	reset-names = "mac";
 
 	phy-mode = "gmii";
+	builtin-switch;
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/dts/ar7241.dtsi
+++ b/target/linux/ath79/dts/ar7241.dtsi
@@ -95,6 +95,7 @@
 	reset-names = "mac";
 
 	phy-mode = "gmii";
+	builtin-switch;
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/dts/ar7242.dtsi
+++ b/target/linux/ath79/dts/ar7242.dtsi
@@ -86,6 +86,7 @@
 	reset-names = "mac";
 
 	phy-mode = "gmii";
+	builtin-switch;
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -222,6 +222,7 @@
 
 	pll-data = <0x00110000 0x00001099 0x00991099>;
 	phy-mode = "gmii";
+	builtin-switch;
 
 	resets = <&rst 13>;
 	reset-names = "mac";

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-16m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-16m.dts
@@ -32,9 +32,12 @@
 &eth1 {
 	status = "okay";
 
+	phy-handle = <&swphy0>;
+
 	nvmem-cells = <&macaddr_pridata_400>;
 	nvmem-cell-names = "mac-address";
 
+	/delete-node/ fixed-link;
 	gmac-config {
 		device = <&gmac>;
 		switch-phy-swap = <0>;

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-8m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-8m.dts
@@ -32,9 +32,12 @@
 &eth1 {
 	status = "okay";
 
+	phy-handle = <&swphy0>;
+
 	nvmem-cells = <&macaddr_pridata_400>;
 	nvmem-cell-names = "mac-address";
 
+	/delete-node/ fixed-link;
 	gmac-config {
 		device = <&gmac>;
 		switch-phy-swap = <0>;

--- a/target/linux/ath79/dts/ar9344_ruckus_zf7372.dts
+++ b/target/linux/ath79/dts/ar9344_ruckus_zf7372.dts
@@ -101,10 +101,12 @@
 
 &eth1 {
 	status = "okay";
+	phy-handle = <&swphy0>;
 
 	nvmem-cells = <&macaddr_board_data_66>;
 	nvmem-cell-names = "mac-address";
 
+	/delete-node/ fixed-link;
 	gmac-config {
 		device = <&gmac>;
 		switch-phy-swap = <0>;

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -287,6 +287,7 @@
 	clocks = <&pll ATH79_CLK_AHB>, <&pll ATH79_CLK_AHB>;
 	clock-names = "eth", "mdio";
 	phy-mode = "gmii";
+	builtin-switch;
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/dts/qca9531_qxwlan_e600g.dtsi
+++ b/target/linux/ath79/dts/qca9531_qxwlan_e600g.dtsi
@@ -101,8 +101,10 @@
 };
 
 &eth1 {
+	phy-handle = <&swphy0>;
 	nvmem-cells = <&macaddr_pridata_400>;
 	nvmem-cell-names = "mac-address";
+	/delete-node/ fixed-link;
 };
 
 &wmac {

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -286,6 +286,7 @@
 	reset-names = "mac";
 
 	phy-mode = "gmii";
+	builtin-switch;
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -326,6 +326,7 @@
 	compatible = "qca,qca9560-eth", "syscon";
 
 	phy-mode = "gmii";
+	builtin-switch;
 
 	resets = <&rst 13>;
 	reset-names = "mac";

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
@@ -160,6 +160,7 @@ struct ag71xx {
 	u16			rx_buf_size;
 	u8			rx_buf_offset;
 	u8			tx_hang_workaround:1;
+	u8			builtin_switch:1;
 
 	struct net_device	*dev;
 	struct platform_device  *pdev;

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -867,6 +867,7 @@ __ag71xx_link_adjust(struct ag71xx *ag, bool update)
 	u32 cfg2;
 	u32 ifctl;
 	u32 fifo5;
+	unsigned int speed;
 
 	if (!ag->link && update) {
 		ag71xx_hw_stop(ag);
@@ -882,7 +883,7 @@ __ag71xx_link_adjust(struct ag71xx *ag, bool update)
 
 	cfg2 = ag71xx_rr(ag, AG71XX_REG_MAC_CFG2);
 	cfg2 &= ~(MAC_CFG2_IF_1000 | MAC_CFG2_IF_10_100 | MAC_CFG2_FDX);
-	cfg2 |= (ag->duplex) ? MAC_CFG2_FDX : 0;
+	cfg2 |= (ag->duplex || ag->builtin_switch) ? MAC_CFG2_FDX : 0;
 
 	ifctl = ag71xx_rr(ag, AG71XX_REG_MAC_IFCTL);
 	ifctl &= ~(MAC_IFCTL_SPEED);
@@ -890,7 +891,11 @@ __ag71xx_link_adjust(struct ag71xx *ag, bool update)
 	fifo5 = ag71xx_rr(ag, AG71XX_REG_FIFO_CFG5);
 	fifo5 &= ~FIFO_CFG5_BM;
 
-	switch (ag->speed) {
+	speed = ag->speed;
+	if (ag->builtin_switch)
+		speed = SPEED_1000;
+
+	switch (speed) {
 	case SPEED_1000:
 		cfg2 |= MAC_CFG2_IF_1000;
 		fifo5 |= FIFO_CFG5_BM;
@@ -1581,6 +1586,10 @@ static int ag71xx_probe(struct platform_device *pdev)
 	if (IS_ERR(ag->pllregmap)) {
 		dev_dbg(&pdev->dev, "failed to read pll-handle property\n");
 		ag->pllregmap = NULL;
+	}
+
+	if (of_property_read_bool(np, "builtin-switch")) {
+		ag->builtin_switch = 1;
 	}
 
 	ag->mac_base = devm_ioremap(&pdev->dev, res->start,


### PR DESCRIPTION
Enable link state reporting or the Fast Ethernet port attached through
the built-in switch, so it can generate netifd and hotplug events as well.

I tested it on several devices with different CPUs and they all worked really
well after adding the code to solve the link state reporting issue.

Test Device:
Qxwlan e750a (soc: ar9344)
Qxwlan e600g/gac (soc :qca9531)
Qxwlan ml181 (soc: qca9561)
ML181 currently exists only in local sdk and will be committed to OpenWRT

My code is based on: https://github.com/openwrt/openwrt/pull/9971

Signed-off-by: 张 鹏 [sd20@qxwlan.com](mailto:sd20@qxwlan.com)