### PR TITLE
generic: 5.15: backport PPC VDSO executable stack fix

### DIFF
--- a/target/linux/generic/backport-5.15/360-v6.1-powerpc-vdso-link-with-z-noexecstack.patch
+++ b/target/linux/generic/backport-5.15/360-v6.1-powerpc-vdso-link-with-z-noexecstack.patch
@@ -1,0 +1,49 @@
+From 78391fb5b1b5318900725c72f1db25b2ae92894f Mon Sep 17 00:00:00 2001
+From: Christophe Leroy <christophe.leroy@csgroup.eu>
+Date: Wed, 7 Jun 2023 09:50:52 +0200
+Subject: [PATCH] powerpc/vdso: link with -z noexecstack
+
+With recent binutils, the following warning appears:
+
+  VDSO32L arch/powerpc/kernel/vdso/vdso32.so.dbg
+/opt/gcc-12.2.0-nolibc/powerpc64-linux/bin/../lib/gcc/powerpc64-linux/12.2.0/../../../../powerpc64-linux/bin/ld: warning: arch/powerpc/kernel/vdso/getcpu-32.o: missing .note.GNU-stack section implies executable stack
+/opt/gcc-12.2.0-nolibc/powerpc64-linux/bin/../lib/gcc/powerpc64-linux/12.2.0/../../../../powerpc64-linux/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
+
+To avoid that, explicitly tell the linker we don't want executable
+stack.
+
+For more explanations, see commit ffcf9c5700e4 ("x86: link vdso
+and boot with -z noexecstack --no-warn-rwx-segments")
+
+Commit was adapted for 5.15 as VDSO32 and VDSO64 were merged later so it
+does not directly apply.
+
+Signed-off-by: Christophe Leroy <christophe.leroy@csgroup.eu>
+Signed-off-by: Michael Ellerman <mpe@ellerman.id.au>
+Link: https://lore.kernel.org/r/b95f2e3216a574837dd61208444e9515c3423da4.1662132312.git.christophe.leroy@csgroup.eu
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+[Adapt to 5.15 as it has VDSO split for 32 and 64bit]
+---
+ arch/powerpc/kernel/vdso32/Makefile | 2 +-
+ arch/powerpc/kernel/vdso64/Makefile | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/arch/powerpc/kernel/vdso32/Makefile
++++ b/arch/powerpc/kernel/vdso32/Makefile
+@@ -66,7 +66,7 @@ include/generated/vdso32-offsets.h: $(ob
+ 
+ # actual build commands
+ quiet_cmd_vdso32ld_and_check = VDSO32L $@
+-      cmd_vdso32ld_and_check = $(VDSOCC) $(c_flags) $(CC32FLAGS) -o $@ -Wl,-T$(filter %.lds,$^) $(filter %.o,$^) ; $(cmd_vdso_check)
++      cmd_vdso32ld_and_check = $(VDSOCC) $(c_flags) $(CC32FLAGS) -o $@ -Wl,-T$(filter %.lds,$^) $(filter %.o,$^) -z noexecstack ; $(cmd_vdso_check)
+ quiet_cmd_vdso32as = VDSO32A $@
+       cmd_vdso32as = $(VDSOCC) $(a_flags) $(CC32FLAGS) -c -o $@ $<
+ quiet_cmd_vdso32cc = VDSO32C $@
+--- a/arch/powerpc/kernel/vdso64/Makefile
++++ b/arch/powerpc/kernel/vdso64/Makefile
+@@ -53,4 +53,4 @@ include/generated/vdso64-offsets.h: $(ob
+ 
+ # actual build commands
+ quiet_cmd_vdso64ld_and_check = VDSO64L $@
+-      cmd_vdso64ld_and_check = $(CC) $(c_flags) -o $@ -Wl,-T$(filter %.lds,$^) $(filter %.o,$^); $(cmd_vdso_check)
++      cmd_vdso64ld_and_check = $(CC) $(c_flags) -o $@ -Wl,-T$(filter %.lds,$^) $(filter %.o,$^) -z noexecstack ; $(cmd_vdso_check)


### PR DESCRIPTION
Recent binutils will warn if there is no .note.GNU-stack section and will interpret that as that stack is executable.

So, lets modify the upstream 6.1 fix as in 5.15 VDSO32 and VDSO64 are still separate but later they were merged to resolve:
`/external-toolchain/openwrt-toolchain-mpc85xx-p1020_gcc-12.3.0_musl.Linux-x86_64/toolchain-powerpc_8548_gcc-12.3.0_musl/bin/../lib/gcc/powerpc-openwrt-linux-musl/12.3.0/../../../../powerpc-openwrt-linux-musl/bin/ld: warning: arch/powerpc/kernel/vdso32/getcpu.o: missing .note.GNU-stack section implies executable stack /external-toolchain/openwrt-toolchain-mpc85xx-p1020_gcc-12.3.0_musl.Linux-x86_64/toolchain-powerpc_8548_gcc-12.3.0_musl/bin/../lib/gcc/powerpc-openwrt-linux-musl/12.3.0/../../../../powerpc-openwrt-linux-musl/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker`
