### PR TITLE
zbt-wd323: fix watchdog resets

### DIFF
--- a/target/linux/ath79/dts/ar9344_zbtlink_zbt-wd323.dts
+++ b/target/linux/ath79/dts/ar9344_zbtlink_zbt-wd323.dts
@@ -61,6 +61,14 @@
 	};
 };
 
+watchdog {
+	compatible = "linux,wdt-gpio";
+	gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+	hw_algo = "toggle";
+	hw_margin_ms = <30000>;
+	always-running;
+};
+
 &wdt {
 	status = "okay";
 


### PR DESCRIPTION
Watchdog has not been properly configured for this router, e.g. https://forum.openwrt.org/t/zbt-wd323-router-power-cycles-every-30-seconds/77535/7

The zbt-wd323 target is unusable in its current state because the router restarts every 30s

This commit provides the fix mentioned here
https://forum.openwrt.org/t/zbt-wd323-images-unusable-proposed-workaround/162145/5
