### PR TITLE
zbt-wd323: add GPIO WDT support

### DIFF
--- a/target/linux/ath79/dts/ar9344_zbtlink_zbt-wd323.dts
+++ b/target/linux/ath79/dts/ar9344_zbtlink_zbt-wd323.dts
@@ -59,6 +59,14 @@
 			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
 		};
 	};
+	
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <30000>;
+		always-running;
+	};
 };
 
 &wdt {


### PR DESCRIPTION
Watchdog has not been properly configured for this router - the PCB has a
hardware watchdog connected to one of the GPIO pin 21 [1]
This commit provides this fix [2]

Without this fix, the ZBT-WD323 is unusable in OpenWRT because it power
cycles every 30 seconds due to the watchdog tripping

[1] https://forum.openwrt.org/t/zbt-wd323-router-power-cycles-every-30-seconds/77535/7
[2] https://forum.openwrt.org/t/zbt-wd323-images-unusable-proposed-workaround/162145/5
