### PR TITLE
ipq807x: add critical thermal trips to all thermal zones

### DIFF
--- a/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8074-ac-cpu.dtsi
+++ b/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8074-ac-cpu.dtsi
@@ -29,12 +29,6 @@
 			hysteresis = <2000>;
 			type = "passive";
 		};
-
-		cpu0_crit: cpu_crit {
-			temperature = <110000>;
-			hysteresis = <1000>;
-			type = "critical";
-		};
 	};
 
 	cooling-maps {
@@ -54,12 +48,6 @@
 			temperature = <95000>;
 			hysteresis = <2000>;
 			type = "passive";
-		};
-
-		cpu1_crit: cpu_crit {
-			temperature = <110000>;
-			hysteresis = <1000>;
-			type = "critical";
 		};
 	};
 
@@ -81,12 +69,6 @@
 			hysteresis = <2000>;
 			type = "passive";
 		};
-
-		cpu2_crit: cpu_crit {
-			temperature = <110000>;
-			hysteresis = <1000>;
-			type = "critical";
-		};
 	};
 
 	cooling-maps {
@@ -107,12 +89,6 @@
 			hysteresis = <2000>;
 			type = "passive";
 		};
-
-		cpu3_crit: cpu_crit {
-			temperature = <110000>;
-			hysteresis = <1000>;
-			type = "critical";
-		};
 	};
 
 	cooling-maps {
@@ -132,12 +108,6 @@
 			temperature = <95000>;
 			hysteresis = <2000>;
 			type = "passive";
-		};
-
-		cluster_crit: cluster_crit {
-			temperature = <110000>;
-			hysteresis = <1000>;
-			type = "critical";
 		};
 	};
 

--- a/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8074-hk-cpu.dtsi
+++ b/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8074-hk-cpu.dtsi
@@ -35,12 +35,6 @@
 			hysteresis = <2000>;
 			type = "passive";
 		};
-
-		cpu0_crit: cpu_crit {
-			temperature = <110000>;
-			hysteresis = <1000>;
-			type = "critical";
-		};
 	};
 
 	cooling-maps {
@@ -73,12 +67,6 @@
 			temperature = <100000>;
 			hysteresis = <2000>;
 			type = "passive";
-		};
-
-		cpu1_crit: cpu_crit {
-			temperature = <110000>;
-			hysteresis = <1000>;
-			type = "critical";
 		};
 	};
 
@@ -113,12 +101,6 @@
 			hysteresis = <2000>;
 			type = "passive";
 		};
-
-		cpu2_crit: cpu_crit {
-			temperature = <110000>;
-			hysteresis = <1000>;
-			type = "critical";
-		};
 	};
 
 	cooling-maps {
@@ -152,12 +134,6 @@
 			hysteresis = <2000>;
 			type = "passive";
 		};
-
-		cpu3_crit: cpu_crit {
-			temperature = <110000>;
-			hysteresis = <1000>;
-			type = "critical";
-		};
 	};
 
 	cooling-maps {
@@ -190,12 +166,6 @@
 			temperature = <100000>;
 			hysteresis = <2000>;
 			type = "passive";
-		};
-
-		cluster_crit: cluster_crit {
-			temperature = <110000>;
-			hysteresis = <1000>;
-			type = "critical";
 		};
 	};
 

--- a/target/linux/ipq807x/patches-6.1/0134-arm64-dts-qcom-ipq8074-add-critical-thermal-trips.patch
+++ b/target/linux/ipq807x/patches-6.1/0134-arm64-dts-qcom-ipq8074-add-critical-thermal-trips.patch
@@ -1,0 +1,197 @@
+From 145bbf2b88990ef3ff00ee541bb7662008683c16 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Wed, 7 Jun 2023 20:26:26 +0200
+Subject: [PATCH] arm64: dts: qcom: ipq8074: add critical thermal trips
+
+According to bindings, thermal zones must have associated trips as well.
+Since we currently dont have CPUFreq support and thus no passive cooling
+lets start by defining critical trips to protect the devices against
+severe overheating.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+---
+ arch/arm64/boot/dts/qcom/ipq8074.dtsi | 96 +++++++++++++++++++++++++++
+ 1 file changed, 96 insertions(+)
+
+--- a/arch/arm64/boot/dts/qcom/ipq8074.dtsi
++++ b/arch/arm64/boot/dts/qcom/ipq8074.dtsi
+@@ -1293,6 +1293,14 @@
+ 			polling-delay = <1000>;
+ 
+ 			thermal-sensors = <&tsens 4>;
++
++			trips {
++				nss-top-crit {
++					temperature = <110000>;
++					hysteresis = <1000>;
++					type = "critical";
++				};
++			};
+ 		};
+ 
+ 		nss0-thermal {
+@@ -1300,6 +1308,14 @@
+ 			polling-delay = <1000>;
+ 
+ 			thermal-sensors = <&tsens 5>;
++
++			trips {
++				nss-0-crit {
++					temperature = <110000>;
++					hysteresis = <1000>;
++					type = "critical";
++				};
++			};
+ 		};
+ 
+ 		nss1-thermal {
+@@ -1307,6 +1323,14 @@
+ 			polling-delay = <1000>;
+ 
+ 			thermal-sensors = <&tsens 6>;
++
++			trips {
++				nss-1-crit {
++					temperature = <110000>;
++					hysteresis = <1000>;
++					type = "critical";
++				};
++			};
+ 		};
+ 
+ 		wcss-phya0-thermal {
+@@ -1314,6 +1338,14 @@
+ 			polling-delay = <1000>;
+ 
+ 			thermal-sensors = <&tsens 7>;
++
++			trips {
++				wcss-phya0-crit {
++					temperature = <110000>;
++					hysteresis = <1000>;
++					type = "critical";
++				};
++			};
+ 		};
+ 
+ 		wcss-phya1-thermal {
+@@ -1321,6 +1353,14 @@
+ 			polling-delay = <1000>;
+ 
+ 			thermal-sensors = <&tsens 8>;
++
++			trips {
++				wcss-phya1-crit {
++					temperature = <110000>;
++					hysteresis = <1000>;
++					type = "critical";
++				};
++			};
+ 		};
+ 
+ 		cpu0_thermal: cpu0-thermal {
+@@ -1328,6 +1368,14 @@
+ 			polling-delay = <1000>;
+ 
+ 			thermal-sensors = <&tsens 9>;
++
++			trips {
++				cpu0-crit {
++					temperature = <110000>;
++					hysteresis = <1000>;
++					type = "critical";
++				};
++			};
+ 		};
+ 
+ 		cpu1_thermal: cpu1-thermal {
+@@ -1335,6 +1383,14 @@
+ 			polling-delay = <1000>;
+ 
+ 			thermal-sensors = <&tsens 10>;
++
++			trips {
++				cpu1-crit {
++					temperature = <110000>;
++					hysteresis = <1000>;
++					type = "critical";
++				};
++			};
+ 		};
+ 
+ 		cpu2_thermal: cpu2-thermal {
+@@ -1342,6 +1398,14 @@
+ 			polling-delay = <1000>;
+ 
+ 			thermal-sensors = <&tsens 11>;
++
++			trips {
++				cpu2-crit {
++					temperature = <110000>;
++					hysteresis = <1000>;
++					type = "critical";
++				};
++			};
+ 		};
+ 
+ 		cpu3_thermal: cpu3-thermal {
+@@ -1349,6 +1413,14 @@
+ 			polling-delay = <1000>;
+ 
+ 			thermal-sensors = <&tsens 12>;
++
++			trips {
++				cpu3-crit {
++					temperature = <110000>;
++					hysteresis = <1000>;
++					type = "critical";
++				};
++			};
+ 		};
+ 
+ 		cluster_thermal: cluster-thermal {
+@@ -1356,6 +1428,14 @@
+ 			polling-delay = <1000>;
+ 
+ 			thermal-sensors = <&tsens 13>;
++
++			trips {
++				cluster-crit {
++					temperature = <110000>;
++					hysteresis = <1000>;
++					type = "critical";
++				};
++			};
+ 		};
+ 
+ 		wcss-phyb0-thermal {
+@@ -1363,6 +1443,14 @@
+ 			polling-delay = <1000>;
+ 
+ 			thermal-sensors = <&tsens 14>;
++
++			trips {
++				wcss-phyb0-crit {
++					temperature = <110000>;
++					hysteresis = <1000>;
++					type = "critical";
++				};
++			};
+ 		};
+ 
+ 		wcss-phyb1-thermal {
+@@ -1370,6 +1458,14 @@
+ 			polling-delay = <1000>;
+ 
+ 			thermal-sensors = <&tsens 15>;
++
++			trips {
++				wcss-phyb1-crit {
++					temperature = <110000>;
++					hysteresis = <1000>;
++					type = "critical";
++				};
++			};
+ 		};
+ 	};
+ };


### PR DESCRIPTION
Kernel 6.1 has started actually enforcing the bindings requirment that
thermal zones must have associated trips described as well, otherwise they
will fail during probing with:
```
[    0.865494] thermal_sys: Failed to find 'trips' node
[    0.867254] thermal_sys: Failed to find trip points for thermal-sensor id=4
[    0.872271] thermal_sys: Failed to find 'trips' node
[    0.878898] thermal_sys: Failed to find trip points for thermal-sensor id=5
[    0.884222] thermal_sys: Failed to find 'trips' node
[    0.890775] thermal_sys: Failed to find trip points for thermal-sensor id=6
[    0.896073] thermal_sys: Failed to find 'trips' node
[    0.902668] thermal_sys: Failed to find trip points for thermal-sensor id=7
[    0.907964] thermal_sys: Failed to find 'trips' node
[    0.914569] thermal_sys: Failed to find trip points for thermal-sensor id=8
[    0.921203] thermal_sys: Failed to find 'trips' node
[    0.926469] thermal_sys: Failed to find trip points for thermal-sensor id=14
[    0.931759] thermal_sys: Failed to find 'trips' node
[    0.938703] thermal_sys: Failed to find trip points for thermal-sensor id=15
```

So, since CPUFreq support isnt yet upstream we can start by adding critical
trips to all of the thermal zones to protect the devices against severely
overheating.
Qualcomm has set the overheat trip at 120 C but lets be conservative and
set it at 110 C.

This patch has been sent upstream as well.

Duplicate critical entries from the AC and HK DTSI have been removed.