### PR TITLE
bmips: add support for Observa VH4032N

### DIFF
--- a/target/linux/bmips/bcm6368/base-files/etc/board.d/01_leds
+++ b/target/linux/bmips/bcm6368/base-files/etc/board.d/01_leds
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+. /lib/functions/leds.sh
 . /lib/functions/uci-defaults.sh
 
 board_config_update
 
 case "$(board_name)" in
-comtrend,vr-3025u |\
 observa,vh4032n)
-	ucidef_set_bridge_device switch
-	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
+	ucidef_set_led_usbport "usb1" "USB1" "blue:hspa" "usb1-port1" "usb2-port1"
+	ucidef_set_led_usbport "usb2" "USB2" "red:hspa" "1-2-port1" "1-2-port2"
 	;;
 esac
 

--- a/target/linux/bmips/bcm6368/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/bmips/bcm6368/base-files/etc/uci-defaults/09_fix_crc
@@ -3,7 +3,8 @@
 . /lib/functions.sh
 
 case "$(board_name)" in
-comtrend,vr-3025u)
+comtrend,vr-3025u |\
+observa,vh4032n)
 	mtd fixtrx firmware
 	;;
 esac

--- a/target/linux/bmips/dts/bcm6368-observa-vh4032n.dts
+++ b/target/linux/bmips/dts/bcm6368-observa-vh4032n.dts
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6368.dtsi"
+
+/ {
+	model = "Observa VH4032N";
+	compatible = "observa,vh4032n", "brcm,bcm6368";
+
+	aliases {
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led@2 {
+			label = "blue:dsl";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led@5 {
+			label = "red:dsl";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led@11 {
+			label = "blue:hspa";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led@12 {
+			label = "red:hspa";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_blue: led@22 {
+			label = "blue:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led_power_red: led@24 {
+			label = "red:power";
+			gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
+		};
+
+		led@25 {
+			label = "blue:voice";
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led@26 {
+			label = "red:voice";
+			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	bcm43222-sprom {
+		compatible = "brcm,ssb-sprom";
+
+		pci-bus = <0>;
+		pci-dev = <1>;
+
+		nvmem-cells = <&macaddr_cfe_6a0>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <1>;
+
+		brcm,sprom = "brcm/bcm43222-sprom.bin";
+		brcm,sprom-fixups = <2   0x04d2>, <4   0x4350>,
+				    <65  0x1300>, <68  0x0402>,
+				    <70  0x0090>, <71  0x4c19>,
+				    <72  0x2345>, <87  0x0315>,
+				    <88  0x0315>, <96  0x2048>,
+				    <97  0xfed7>, <98  0x15a6>,
+				    <99  0xfaee>, <100 0x3e3a>,
+				    <101 0x3a36>, <102 0xff7f>,
+				    <103 0x11b9>, <104 0xfc53>,
+				    <105 0xffe6>, <106 0xfdd2>,
+				    <107 0xfe49>, <108 0xff6a>,
+				    <109 0x136e>, <110 0xfbed>,
+				    <111 0x0000>, <112 0x2048>,
+				    <113 0xfee2>, <114 0x15e5>,
+				    <115 0xfaed>, <116 0x3e3a>,
+				    <117 0x3a36>, <118 0xffc8>,
+				    <119 0x12b8>, <120 0xfca1>,
+				    <121 0xff9b>, <122 0x122a>,
+				    <123 0xfcc8>, <124 0xff95>,
+				    <125 0x146b>, <126 0xfbba>,
+				    <127 0x0000>, <161 0x0000>,
+				    <162 0x0000>, <169 0x0000>,
+				    <170 0x0000>, <171 0x0000>,
+				    <172 0x0000>, <173 0x0000>,
+				    <174 0x0000>, <175 0x0000>,
+				    <176 0x0000>, <219 0x1108>;
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cfe_6a0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gpio {
+	usb_hub_reset {
+		gpio-hog;
+		gpios = <27 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "usb-hub-reset-gpio";
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pci {
+	status = "okay";
+};
+
+&pflash {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		cfe: partition@0 {
+			label = "CFE";
+			reg = <0x0000000 0x0020000>;
+			read-only;
+		};
+
+		partition@20000 {
+			compatible = "brcm,bcm963xx-imagetag";
+			label = "firmware";
+			reg = <0x0020000 0x1fc0000>;
+		};
+
+		partition@1fe0000 {
+			label = "nvram";
+			reg = <0x1fe0000 0x020000>;
+		};
+	};
+};
+
+&pinctrl {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_ephy0_led &pinctrl_ephy1_led
+		     &pinctrl_ephy2_led &pinctrl_ephy3_led>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			reg = <0>;
+			label = "lan4";
+
+			phy-handle = <&phy1>;
+			phy-mode = "mii";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan3";
+
+			phy-handle = <&phy2>;
+			phy-mode = "mii";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan2";
+
+			phy-handle = <&phy3>;
+			phy-mode = "mii";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan1";
+
+			phy-handle = <&phy4>;
+			phy-mode = "mii";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};
+
+&cfe {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_cfe_6a0: macaddr@6a0 {
+		reg = <0x6a0 0x6>;
+	};
+};

--- a/target/linux/bmips/image/bcm6368.mk
+++ b/target/linux/bmips/image/bcm6368.mk
@@ -13,3 +13,18 @@ define Device/comtrend_vr-3025u
     kmod-leds-gpio
 endef
 TARGET_DEVICES += comtrend_vr-3025u
+
+define Device/observa_vh4032n
+  $(Device/bcm63xx-cfe)
+  DEVICE_VENDOR := Observa
+  DEVICE_MODEL := VH4032N
+  IMAGES += sysupgrade.bin
+  CFE_BOARD_ID := 96368VVW
+  CHIP_ID := 6368
+  BLOCKSIZE := 0x20000
+  FLASH_MB := 32
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    $(B43_PACKAGES) broadcom-43222-sprom \
+    kmod-leds-gpio
+endef
+TARGET_DEVICES += observa_vh4032n


### PR DESCRIPTION
The Observa Telecom is an xDSL wifi router with a vertical white casing and two internal antennas connected via UFL.

Hardware:
 - SoC: Broadcom BCM6368
 - CPU: dual core BMIPS4350 V3.1 @400MHz
 - RAM: 128 MB DDR
 - Flash: 32 MB parallel NOR
 - Ethernet LAN: 4x 100Mbit
 - Wifi 2.4/5 GHz: onboard Broadcom BCM43222 802.11abgn
 - USB: 3x 2.0
 - Buttons: 2x, 1 reset
 - LEDs: 8x, blue and red
 - UART: 1x

Installation via OEM web UI:
  1. Use the admin credentials to login via web UI
  2. Go to Managament->Update firmware and select the OpenWrt CFE firmware
  3. Press "Update Firmware" button and wait some minutes until it finish

CC: @Noltari 