### PR TITLE
ath79: 5.15: fix not exported sym ath79_pll_base

### DIFF
--- a/target/linux/ath79/patches-5.15/0041-MIPS-ath79-common-exports.patch
+++ b/target/linux/ath79/patches-5.15/0041-MIPS-ath79-common-exports.patch
@@ -1,0 +1,26 @@
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Subject: [PATCH] ath79: export ath79_pll_base
+
+This symbol is declared as extern but nobody exported it.
+Any module including arch/mips/include/asm/mach-ath79/ath79.h
+will not build. Without this export, ag71xx.ko will not build
+as a module and the build will fail like this:
+
+ERROR: modpost: "ath79_pll_base" [drivers/net/ethernet/atheros/ag71xx/ag71xx.ko] undefined!
+
+The ath79_pll_base symbol is accessed in the ath79_pll_wr() inline function.
+
+---
+ arch/mips/ath79/common.c                      | 1 +
+ 1 file changed, 1 insertions(+)
+
+--- a/arch/mips/ath79/common.c
++++ b/arch/mips/ath79/common.c
+@@ -34,6 +34,7 @@ unsigned int ath79_soc_rev;
+ EXPORT_SYMBOL_GPL(ath79_soc_rev);
+ 
+ void __iomem *ath79_pll_base;
++EXPORT_SYMBOL_GPL(ath79_pll_base);
+ void __iomem *ath79_reset_base;
+ EXPORT_SYMBOL_GPL(ath79_reset_base);
+ void __iomem *ath79_ddr_base;


### PR DESCRIPTION
ath79_pll_base was declared as extern but no code exported it. Anyone including arch/mips/include/asm/mach-ath79/ath79.h and compiled as a module would break with:

ERROR: modpost: "ath79_pll_base" [drivers/net/ethernet/atheros/ag71xx/ag71xx.ko] undefined!