### PR TITLE
bcm63xx: mark as source-only

### DIFF
--- a/target/linux/bcm63xx/Makefile
+++ b/target/linux/bcm63xx/Makefile
@@ -9,7 +9,7 @@ ARCH:=mips
 BOARD:=bcm63xx
 BOARDNAME:=Broadcom BCM63xx
 SUBTARGETS:=generic smp
-FEATURES:=squashfs usb atm pci pcmcia usbgadget
+FEATURES:=squashfs usb atm pci pcmcia usbgadget source-only
 
 KERNEL_PATCHVER:=5.15
 


### PR DESCRIPTION
Maintaining bcm63xx is a nightmare due to the amount of devices and patches required, since every board requires an individual patch due to the lack of full device tree compatibility.
Moreover, there are a lot of devices supported on this target which won't work due to not having enough resources (16M-32M of RAM and/or 4M of flash).
Therefore, any development efforts should be focused on bmips and support for those devices with enough resources should be added on bmips target.

CC @danitool 