### PR TITLE
generic: backport PPC boot wrapper VDSO executable stack fix

### DIFF
--- a/target/linux/generic/backport-5.15/202-v6.1-kallsyms-support-big-kernel-symbols.patch
+++ b/target/linux/generic/backport-5.15/202-v6.1-kallsyms-support-big-kernel-symbols.patch
@@ -1,0 +1,128 @@
+From 73bbb94466fd3f8b313eeb0b0467314a262dddb3 Mon Sep 17 00:00:00 2001
+From: Miguel Ojeda <ojeda@kernel.org>
+Date: Mon, 5 Apr 2021 04:58:39 +0200
+Subject: [PATCH] kallsyms: support "big" kernel symbols
+
+Rust symbols can become quite long due to namespacing introduced
+by modules, types, traits, generics, etc.
+
+Increasing to 255 is not enough in some cases, therefore
+introduce longer lengths to the symbol table.
+
+In order to avoid increasing all lengths to 2 bytes (since most
+of them are small, including many Rust ones), use ULEB128 to
+keep smaller symbols in 1 byte, with the rest in 2 bytes.
+
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Reviewed-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Co-developed-by: Alex Gaynor <alex.gaynor@gmail.com>
+Signed-off-by: Alex Gaynor <alex.gaynor@gmail.com>
+Co-developed-by: Wedson Almeida Filho <wedsonaf@google.com>
+Signed-off-by: Wedson Almeida Filho <wedsonaf@google.com>
+Co-developed-by: Gary Guo <gary@garyguo.net>
+Signed-off-by: Gary Guo <gary@garyguo.net>
+Co-developed-by: Boqun Feng <boqun.feng@gmail.com>
+Signed-off-by: Boqun Feng <boqun.feng@gmail.com>
+Co-developed-by: Matthew Wilcox <willy@infradead.org>
+Signed-off-by: Matthew Wilcox <willy@infradead.org>
+Signed-off-by: Miguel Ojeda <ojeda@kernel.org>
+---
+ kernel/kallsyms.c  | 26 ++++++++++++++++++++++----
+ scripts/kallsyms.c | 29 ++++++++++++++++++++++++++---
+ 2 files changed, 48 insertions(+), 7 deletions(-)
+
+--- a/kernel/kallsyms.c
++++ b/kernel/kallsyms.c
+@@ -69,12 +69,20 @@ static unsigned int kallsyms_expand_symb
+ 	data = &kallsyms_names[off];
+ 	len = *data;
+ 	data++;
++	off++;
++
++	/* If MSB is 1, it is a "big" symbol, so needs an additional byte. */
++	if ((len & 0x80) != 0) {
++		len = (len & 0x7F) | (*data << 7);
++		data++;
++		off++;
++	}
+ 
+ 	/*
+ 	 * Update the offset to return the offset for the next symbol on
+ 	 * the compressed stream.
+ 	 */
+-	off += len + 1;
++	off += len;
+ 
+ 	/*
+ 	 * For every byte on the compressed symbol data, copy the table
+@@ -127,7 +135,7 @@ static char kallsyms_get_symbol_type(uns
+ static unsigned int get_symbol_offset(unsigned long pos)
+ {
+ 	const u8 *name;
+-	int i;
++	int i, len;
+ 
+ 	/*
+ 	 * Use the closest marker we have. We have markers every 256 positions,
+@@ -141,8 +149,18 @@ static unsigned int get_symbol_offset(un
+ 	 * so we just need to add the len to the current pointer for every
+ 	 * symbol we wish to skip.
+ 	 */
+-	for (i = 0; i < (pos & 0xFF); i++)
+-		name = name + (*name) + 1;
++	for (i = 0; i < (pos & 0xFF); i++) {
++		len = *name;
++
++		/*
++		 * If MSB is 1, it is a "big" symbol, so we need to look into
++		 * the next byte (and skip it, too).
++		 */
++		if ((len & 0x80) != 0)
++			len = ((len & 0x7F) | (name[1] << 7)) + 1;
++
++		name = name + len + 1;
++	}
+ 
+ 	return name - kallsyms_names;
+ }
+--- a/scripts/kallsyms.c
++++ b/scripts/kallsyms.c
+@@ -470,12 +470,35 @@ static void write_src(void)
+ 		if ((i & 0xFF) == 0)
+ 			markers[i >> 8] = off;
+ 
+-		printf("\t.byte 0x%02x", table[i]->len);
++		/* There cannot be any symbol of length zero. */
++		if (table[i]->len == 0) {
++			fprintf(stderr, "kallsyms failure: "
++				"unexpected zero symbol length\n");
++			exit(EXIT_FAILURE);
++		}
++
++		/* Only lengths that fit in up-to-two-byte ULEB128 are supported. */
++		if (table[i]->len > 0x3FFF) {
++			fprintf(stderr, "kallsyms failure: "
++				"unexpected huge symbol length\n");
++			exit(EXIT_FAILURE);
++		}
++
++		/* Encode length with ULEB128. */
++		if (table[i]->len <= 0x7F) {
++			/* Most symbols use a single byte for the length. */
++			printf("\t.byte 0x%02x", table[i]->len);
++			off += table[i]->len + 1;
++		} else {
++			/* "Big" symbols use two bytes. */
++			printf("\t.byte 0x%02x, 0x%02x",
++				(table[i]->len & 0x7F) | 0x80,
++				(table[i]->len >> 7) & 0x7F);
++			off += table[i]->len + 2;
++		}
+ 		for (k = 0; k < table[i]->len; k++)
+ 			printf(", 0x%02x", table[i]->sym[k]);
+ 		printf("\n");
+-
+-		off += table[i]->len + 1;
+ 	}
+ 	printf("\n");
+ 

--- a/target/linux/generic/backport-5.15/303-v6.2-powerpc-suppress-some-linker-warnings-in-recent-link.patch
+++ b/target/linux/generic/backport-5.15/303-v6.2-powerpc-suppress-some-linker-warnings-in-recent-link.patch
@@ -1,0 +1,63 @@
+From 579aee9fc594af94c242068c011b0233563d4bbf Mon Sep 17 00:00:00 2001
+From: Stephen Rothwell <sfr@canb.auug.org.au>
+Date: Mon, 10 Oct 2022 16:57:21 +1100
+Subject: [PATCH] powerpc: suppress some linker warnings in recent linker
+ versions
+
+This is a follow on from commit
+
+  0d362be5b142 ("Makefile: link with -z noexecstack --no-warn-rwx-segments")
+
+for arch/powerpc/boot to address wanrings like:
+
+  ld: warning: opal-calls.o: missing .note.GNU-stack section implies executable stack
+  ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
+  ld: warning: arch/powerpc/boot/zImage.epapr has a LOAD segment with RWX permissions
+
+This fixes issue https://github.com/linuxppc/issues/issues/417
+
+Signed-off-by: Stephen Rothwell <sfr@canb.auug.org.au>
+Signed-off-by: Michael Ellerman <mpe@ellerman.id.au>
+Link: https://lore.kernel.org/r/20221010165721.106267e6@canb.auug.org.au
+---
+ arch/powerpc/boot/wrapper | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+--- a/arch/powerpc/boot/wrapper
++++ b/arch/powerpc/boot/wrapper
+@@ -213,6 +213,11 @@ ld_version()
+     }'
+ }
+ 
++ld_is_lld()
++{
++	${CROSS}ld -V 2>&1 | grep -q LLD
++}
++
+ # Do not include PT_INTERP segment when linking pie. Non-pie linking
+ # just ignores this option.
+ LD_VERSION=$(${CROSS}ld --version | ld_version)
+@@ -221,6 +226,14 @@ if [ "$LD_VERSION" -ge "$LD_NO_DL_MIN_VE
+ 	nodl="--no-dynamic-linker"
+ fi
+ 
++# suppress some warnings in recent ld versions
++nowarn="-z noexecstack"
++if ! ld_is_lld; then
++	if [ "$LD_VERSION" -ge "$(echo 2.39 | ld_version)" ]; then
++		nowarn="$nowarn --no-warn-rwx-segments"
++	fi
++fi
++
+ platformo=$object/"$platform".o
+ lds=$object/zImage.lds
+ ext=strip
+@@ -502,7 +515,7 @@ if [ "$platform" != "miboot" ]; then
+         text_start="-Ttext $link_address"
+     fi
+ #link everything
+-    ${CROSS}ld -m $format -T $lds $text_start $pie $nodl $rodynamic $notext -o "$ofile" $map \
++    ${CROSS}ld -m $format -T $lds $text_start $pie $nodl $nowarn $rodynamic $notext -o "$ofile" $map \
+ 	$platformo $tmp $object/wrapper.a
+     rm $tmp
+ fi

--- a/target/linux/generic/backport-6.1/300-v6.2-powerpc-suppress-some-linker-warnings-in-recent-link.patch
+++ b/target/linux/generic/backport-6.1/300-v6.2-powerpc-suppress-some-linker-warnings-in-recent-link.patch
@@ -1,0 +1,63 @@
+From 579aee9fc594af94c242068c011b0233563d4bbf Mon Sep 17 00:00:00 2001
+From: Stephen Rothwell <sfr@canb.auug.org.au>
+Date: Mon, 10 Oct 2022 16:57:21 +1100
+Subject: [PATCH] powerpc: suppress some linker warnings in recent linker
+ versions
+
+This is a follow on from commit
+
+  0d362be5b142 ("Makefile: link with -z noexecstack --no-warn-rwx-segments")
+
+for arch/powerpc/boot to address wanrings like:
+
+  ld: warning: opal-calls.o: missing .note.GNU-stack section implies executable stack
+  ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
+  ld: warning: arch/powerpc/boot/zImage.epapr has a LOAD segment with RWX permissions
+
+This fixes issue https://github.com/linuxppc/issues/issues/417
+
+Signed-off-by: Stephen Rothwell <sfr@canb.auug.org.au>
+Signed-off-by: Michael Ellerman <mpe@ellerman.id.au>
+Link: https://lore.kernel.org/r/20221010165721.106267e6@canb.auug.org.au
+---
+ arch/powerpc/boot/wrapper | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+--- a/arch/powerpc/boot/wrapper
++++ b/arch/powerpc/boot/wrapper
+@@ -215,6 +215,11 @@ ld_version()
+     }'
+ }
+ 
++ld_is_lld()
++{
++	${CROSS}ld -V 2>&1 | grep -q LLD
++}
++
+ # Do not include PT_INTERP segment when linking pie. Non-pie linking
+ # just ignores this option.
+ LD_VERSION=$(${CROSS}ld --version | ld_version)
+@@ -223,6 +228,14 @@ if [ "$LD_VERSION" -ge "$LD_NO_DL_MIN_VE
+ 	nodl="--no-dynamic-linker"
+ fi
+ 
++# suppress some warnings in recent ld versions
++nowarn="-z noexecstack"
++if ! ld_is_lld; then
++	if [ "$LD_VERSION" -ge "$(echo 2.39 | ld_version)" ]; then
++		nowarn="$nowarn --no-warn-rwx-segments"
++	fi
++fi
++
+ platformo=$object/"$platform".o
+ lds=$object/zImage.lds
+ ext=strip
+@@ -504,7 +517,7 @@ if [ "$platform" != "miboot" ]; then
+         text_start="-Ttext $link_address"
+     fi
+ #link everything
+-    ${CROSS}ld -m $format -T $lds $text_start $pie $nodl $rodynamic $notext -o "$ofile" $map \
++    ${CROSS}ld -m $format -T $lds $text_start $pie $nodl $nowarn $rodynamic $notext -o "$ofile" $map \
+ 	$platformo $tmp $object/wrapper.a
+     rm $tmp
+ fi

--- a/target/linux/generic/pending-5.15/203-kallsyms_uncompressed.patch
+++ b/target/linux/generic/pending-5.15/203-kallsyms_uncompressed.patch
@@ -33,7 +33,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
 --- a/kernel/kallsyms.c
 +++ b/kernel/kallsyms.c
-@@ -80,6 +80,11 @@ static unsigned int kallsyms_expand_symb
+@@ -88,6 +88,11 @@ static unsigned int kallsyms_expand_symb
  	 * For every byte on the compressed symbol data, copy the table
  	 * entry for that byte.
  	 */
@@ -45,7 +45,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	while (len) {
  		tptr = &kallsyms_token_table[kallsyms_token_index[*data]];
  		data++;
-@@ -112,6 +117,9 @@ tail:
+@@ -120,6 +125,9 @@ tail:
   */
  static char kallsyms_get_symbol_type(unsigned int off)
  {
@@ -65,7 +65,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static int absolute_percpu;
  static int base_relative;
  
-@@ -486,6 +487,9 @@ static void write_src(void)
+@@ -509,6 +510,9 @@ static void write_src(void)
  
  	free(markers);
  
@@ -75,7 +75,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	output_label("kallsyms_token_table");
  	off = 0;
  	for (i = 0; i < 256; i++) {
-@@ -537,6 +541,9 @@ static unsigned char *find_token(unsigne
+@@ -560,6 +564,9 @@ static unsigned char *find_token(unsigne
  {
  	int i;
  
@@ -85,7 +85,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	for (i = 0; i < len - 1; i++) {
  		if (str[i] == token[0] && str[i+1] == token[1])
  			return &str[i];
-@@ -609,6 +616,9 @@ static void optimize_result(void)
+@@ -632,6 +639,9 @@ static void optimize_result(void)
  {
  	int i, best;
  
@@ -95,7 +95,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	/* using the '\0' symbol last allows compress_symbols to use standard
  	 * fast string functions */
  	for (i = 255; i >= 0; i--) {
-@@ -773,6 +783,8 @@ int main(int argc, char **argv)
+@@ -796,6 +806,8 @@ int main(int argc, char **argv)
  				absolute_percpu = 1;
  			else if (strcmp(argv[i], "--base-relative") == 0)
  				base_relative = 1;

--- a/target/linux/mpc85xx/patches-5.15/100-powerpc-85xx-tl-wdr4900-v1-support.patch
+++ b/target/linux/mpc85xx/patches-5.15/100-powerpc-85xx-tl-wdr4900-v1-support.patch
@@ -38,7 +38,7 @@ Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
  
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -326,6 +326,11 @@ adder875-redboot)
+@@ -339,6 +339,11 @@ adder875-redboot)
      platformo="$object/fixed-head.o $object/redboot-8xx.o"
      binary=y
      ;;

--- a/target/linux/mpc85xx/patches-5.15/107-powerpc-85xx-add-ws-ap3825i-support.patch
+++ b/target/linux/mpc85xx/patches-5.15/107-powerpc-85xx-add-ws-ap3825i-support.patch
@@ -55,7 +55,7 @@ WS-AP3825i AP.
  
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -326,6 +326,7 @@ adder875-redboot)
+@@ -339,6 +339,7 @@ adder875-redboot)
      platformo="$object/fixed-head.o $object/redboot-8xx.o"
      binary=y
      ;;

--- a/target/linux/mpc85xx/patches-5.15/109-powerpc-85xx-add-ws-ap3715i-support.patch
+++ b/target/linux/mpc85xx/patches-5.15/109-powerpc-85xx-add-ws-ap3715i-support.patch
@@ -40,7 +40,7 @@
  image-$(CONFIG_MVME7100)                += dtbImage.mvme7100
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -326,6 +326,7 @@ adder875-redboot)
+@@ -339,6 +339,7 @@ adder875-redboot)
      platformo="$object/fixed-head.o $object/redboot-8xx.o"
      binary=y
      ;;

--- a/target/linux/mpc85xx/patches-5.15/110-powerpc-85xx-br200-wp-support.patch
+++ b/target/linux/mpc85xx/patches-5.15/110-powerpc-85xx-br200-wp-support.patch
@@ -47,7 +47,7 @@
  image-$(CONFIG_WS_AP3825I)		+= simpleImage.ws-ap3825i
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -326,6 +326,7 @@ adder875-redboot)
+@@ -339,6 +339,7 @@ adder875-redboot)
      platformo="$object/fixed-head.o $object/redboot-8xx.o"
      binary=y
      ;;


### PR DESCRIPTION
Backport upstream fix for PowerPC that fix VDSO executable stack warning for the boot wrapper.

Fix the compilation error:
powerpc-openwrt-linux-musl-ld.bin: warning: div64.o: missing .note.GNU-stack section implies executable stack powerpc-openwrt-linux-musl-ld.bin: NOTE: This behaviour is deprecated and will be removed in a future version of the linker powerpc-openwrt-linux-musl-ld.bin: warning: arch/powerpc/boot/simpleImage.ws-ap3825i has a LOAD segment with RWX permissions