### PR TITLE
bmips: add support for Netgear DGND3700 v1, DGND3800B

### DIFF
--- a/target/linux/bmips/bcm6368/base-files/etc/board.d/01_leds
+++ b/target/linux/bmips/bcm6368/base-files/etc/board.d/01_leds
@@ -6,6 +6,15 @@
 board_config_update
 
 case "$(board_name)" in
+netgear,dgnd3700-v1 |\
+netgear,dgnd3800b)
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "switch.1"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
+	ucidef_set_led_netdev "wlan0" "WIFI2G" "green:wifi2g" "phy0-ap0"
+	ucidef_set_led_netdev "wlan1" "WIFI5G" "blue:wifi5g" "phy1-ap0"
+	ucidef_set_led_usbport "usb1" "USB1" "green:usb1" "usb1-port1" "usb2-port1"
+	ucidef_set_led_usbport "usb2" "USB2" "green:usb2" "usb1-port2" "usb2-port2"
+	;;
 observa,vh4032n)
 	ucidef_set_led_usbport "usb1" "USB1" "blue:hspa" "usb1-port1" "usb2-port1"
 	ucidef_set_led_usbport "usb2" "USB2" "red:hspa" "1-2-port1" "1-2-port2"

--- a/target/linux/bmips/bcm6368/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6368/base-files/etc/board.d/02_network
@@ -10,6 +10,11 @@ observa,vh4032n)
 	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 	;;
+netgear,dgnd3700-v1 |\
+netgear,dgnd3800b)
+	ucidef_set_bridge_device switch
+	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/bmips/dts/bcm6368-netgear-dgnd3700-v1.dts
+++ b/target/linux/bmips/dts/bcm6368-netgear-dgnd3700-v1.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6368-netgear-dgnd3700.dtsi"
+
+/ {
+	model = "Netgear DGND3700 v1";
+	compatible = "netgear,dgnd3700-v1", "brcm,bcm6368";
+};

--- a/target/linux/bmips/dts/bcm6368-netgear-dgnd3700.dtsi
+++ b/target/linux/bmips/dts/bcm6368-netgear-dgnd3700.dtsi
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6368.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led@2 {
+			label = "green:dsl";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led@4 {
+			label = "red:wan";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led@5 {
+			label = "green:wan";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led@11 {
+			label = "green:wps";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		/* usb front */
+		led@13 {
+			label = "green:usb2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		/* usb back */
+		led@14 {
+			label = "green:usb1";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_red: led@22 {
+			label = "red:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+
+		led@23 {
+			label = "green:lan";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: led@24 {
+			label = "green:power";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led@26 {
+			label = "green:wifi2g";
+			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
+		};
+
+		led@27 {
+			label = "blue:wifi5g";
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cfe_6a0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&lsspi {
+	status = "okay";
+
+	switch@1 {
+		compatible = "brcm,bcm53115";
+		reg = <1>;
+		spi-max-frequency = <781000>;
+		dsa,member = <1 0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			wan@0 {
+				reg = <0>;
+				label = "wan";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan4";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan2";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "lan1";
+			};
+
+			port@8 {
+				reg = <8>;
+
+				phy-mode = "rgmii";
+				ethernet = <&switch0port5>;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};
+
+&nflash {
+	status = "okay";
+
+	nandcs@0 {
+		compatible = "brcm,nandcs";
+		reg = <0>;
+		nand-ecc-step-size = <512>;
+		nand-ecc-strength = <15>;
+		nand-on-flash-bbt;
+		brcm,nand-oob-sector-size = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "storage";
+				reg = <0 0>; /* autodetected size */
+			};
+		};
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pci {
+	status = "okay";
+};
+
+&pflash {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		cfe: partition@0 {
+			label = "CFE";
+			reg = <0x0000000 0x0020000>;
+			read-only;
+		};
+
+		partition@20000 {
+			compatible = "brcm,bcm963xx-imagetag";
+			label = "firmware";
+			reg = <0x0020000 0x1e20000>;
+		};
+
+		partition@1e40000 {
+			label = "board_data";
+			reg = <0x1e40000 0x1a0000>;
+			read-only;
+		};
+
+		partition@1fe0000 {
+			label = "nvram";
+			reg = <0x1fe0000 0x020000>;
+		};
+	};
+};
+
+&switch0 {
+	dsa,member = <0 0>;
+
+	ports {
+		switch0port5: port@5 {
+			reg = <5>;
+			label = "extsw";
+
+			phy-mode = "rgmii";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};
+
+&cfe {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_cfe_6a0: macaddr@6a0 {
+		reg = <0x6a0 0x6>;
+	};
+};

--- a/target/linux/bmips/dts/bcm6368-netgear-dgnd3800b.dts
+++ b/target/linux/bmips/dts/bcm6368-netgear-dgnd3800b.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6368-netgear-dgnd3700.dtsi"
+
+/ {
+	model = "Netgear DGND3800B";
+	compatible = "netgear,dgnd3800b", "brcm,bcm6368";
+};

--- a/target/linux/bmips/image/Makefile
+++ b/target/linux/bmips/image/Makefile
@@ -313,6 +313,15 @@ define Device/bcm63xx-nand
   DEVICE_PACKAGES += nand-utils
 endef
 
+define Device/bcm63xx_netgear
+  $(Device/bcm63xx-cfe)
+  DEVICE_VENDOR := NETGEAR
+  IMAGES := factory.chk sysupgrade.bin
+  IMAGE/factory.chk := cfe-bin | netgear-chk
+  NETGEAR_BOARD_ID :=
+  NETGEAR_REGION :=
+endef
+
 define Device/sercomm-nand
   $(Device/bcm63xx-nand)
   IMAGES := factory.img sysupgrade.bin

--- a/target/linux/bmips/image/bcm6368.mk
+++ b/target/linux/bmips/image/bcm6368.mk
@@ -14,6 +14,35 @@ define Device/comtrend_vr-3025u
 endef
 TARGET_DEVICES += comtrend_vr-3025u
 
+define Device/netgear_dgnd3700-v1
+  $(Device/bcm63xx_netgear)
+  DEVICE_VENDOR := NETGEAR
+  DEVICE_MODEL := DGND3700
+  DEVICE_VARIANT := v1
+  CFE_BOARD_ID := 96368MVWG
+  CHIP_ID := 6368
+  BLOCKSIZE := 0x20000
+  NETGEAR_BOARD_ID := U12L144T01_NETGEAR_NEWLED
+  NETGEAR_REGION := 1
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    $(B43_PACKAGES)
+endef
+TARGET_DEVICES += netgear_dgnd3700-v1
+
+define Device/netgear_dgnd3800b
+  $(Device/bcm63xx_netgear)
+  DEVICE_VENDOR := NETGEAR
+  DEVICE_MODEL := DGND3800B
+  CFE_BOARD_ID := 96368MVWG
+  CHIP_ID := 6368
+  BLOCKSIZE := 0x20000
+  NETGEAR_BOARD_ID := U12L144T11_NETGEAR_NEWLED
+  NETGEAR_REGION := 1
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    $(B43_PACKAGES)
+endef
+TARGET_DEVICES += netgear_dgnd3800b
+
 define Device/observa_vh4032n
   $(Device/bcm63xx-cfe)
   DEVICE_VENDOR := Observa


### PR DESCRIPTION
The Netgear DGND3700 v1 and DGND3800B are the same device but with different factory firmwares. It's an xDSL wifi router with a slim black shiny casing and 4 PCB internal antennas connected via UFL to a miniPCI detachable card.

Hardware:
 - SoC: Broadcom BCM6368
 - CPU: dual core BMIPS4350 V3.1 @400Mhz
 - RAM: 128 MB DDR
 - NOR Flash: 32 MB parallel (CFE and OS)
 - NAND flash: 128 MB (empty)
 - Ethernet LAN: 5x 1Gbit
 - Wifi 2.4 GHz: Broadcom BCM43222 802.11bgn
 - Wifi 5 GHz: Broadcom BCM43222 802.11abgn
 - USB: 2x 2.0
 - Buttons: 3x, 1 reset
 - LEDs: 11x
 - UART: yes

Installation via OEM web UI:
  1. Open the Netgear administration web interface, by default: http://192.168.0.1 user: admin password: password
  2. Look forâ"upgrade firmware" and proceed
  3. Wait some minutes until it finish

CC: @Noltari 