### PR TITLE
lantiq: replace random_ether_addr with eth_random_addr

### DIFF
--- a/target/linux/lantiq/patches-5.15/0035-owrt-lantiq-wifi-and-ethernet-eeprom-handling.patch
+++ b/target/linux/lantiq/patches-5.15/0035-owrt-lantiq-wifi-and-ethernet-eeprom-handling.patch
@@ -127,7 +127,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +
 +	if (!is_valid_ether_addr(athxk_eeprom_mac)) {
 +		dev_warn(&pdev->dev, "using random mac\n");
-+		random_ether_addr(athxk_eeprom_mac);
++		eth_random_addr(athxk_eeprom_mac);
 +	}
 +
 +	if (!of_property_read_u32(np, "ath,mac-increment", &mac_inc))


### PR DESCRIPTION
Random_ether_addr() is a helper function which was kept for backward compatibility. It is available in the kernel from version 3.6 to 5.16. In newer kernel versions, it has been completely replaced by eth_random_addr().

There should be no functional changes.

Ref: https://github.com/torvalds/linux/commit/ba530fea8ca1b57ee71d4e62f287a5d7ed92f789
