### PR TITLE
bmips: add support for Netgear EVG2000

### DIFF
--- a/target/linux/bmips/bcm6368/base-files/etc/board.d/01_leds
+++ b/target/linux/bmips/bcm6368/base-files/etc/board.d/01_leds
@@ -15,6 +15,11 @@ netgear,dgnd3800b)
 	ucidef_set_led_usbport "usb1" "USB1" "green:usb1" "usb1-port1" "usb2-port1"
 	ucidef_set_led_usbport "usb2" "USB2" "green:usb2" "usb1-port2" "usb2-port2"
 	;;
+netgear,evg2000)
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "switch.1"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
+	ucidef_set_led_usbdev "usb" "USB" "green:usb" "usb1-port1" "usb2-port1" "usb1-port2" "usb2-port2"
+	;;
 observa,vh4032n)
 	ucidef_set_led_usbport "usb1" "USB1" "blue:hspa" "usb1-port1" "usb2-port1"
 	ucidef_set_led_usbport "usb2" "USB2" "red:hspa" "1-2-port1" "1-2-port2"

--- a/target/linux/bmips/bcm6368/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6368/base-files/etc/board.d/02_network
@@ -11,7 +11,8 @@ observa,vh4032n)
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 	;;
 netgear,dgnd3700-v1 |\
-netgear,dgnd3800b)
+netgear,dgnd3800b |\
+netgear,evg2000)
 	ucidef_set_bridge_device switch
 	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 	;;

--- a/target/linux/bmips/bcm6368/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/bmips/bcm6368/base-files/etc/uci-defaults/09_fix_crc
@@ -4,6 +4,7 @@
 
 case "$(board_name)" in
 comtrend,vr-3025u |\
+netgear,evg2000 |\
 observa,vh4032n)
 	mtd fixtrx firmware
 	;;

--- a/target/linux/bmips/dts/bcm6369-netgear-evg2000.dts
+++ b/target/linux/bmips/dts/bcm6369-netgear-evg2000.dts
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6368.dtsi"
+
+/ {
+	model = "Netgear EVG2000";
+	compatible = "netgear,evg2000", "brcm,bcm6369", "brcm,bcm6368";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led@2 {
+			label = "green:voip2";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led@4 {
+			label = "red:internet";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led@5 {
+			label = "green:internet";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led@14 {
+			label = "green:voip1";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led@15 {
+			label = "green:usb";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: led@22 {
+			label = "green:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_power_red: led@23 {
+			label = "red:power";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		led@24 {
+			label = "green:lan";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+		};
+
+		led@27 {
+			label = "green:wan";
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	bcm4322-sprom {
+		compatible = "brcm,ssb-sprom";
+
+		pci-bus = <0>;
+		pci-dev = <1>;
+
+		nvmem-cells = <&macaddr_cfe_6a0>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <1>;
+
+		brcm,sprom = "brcm/bcm4322-sprom.bin";
+		brcm,sprom-fixups = <219 0xec08>;
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cfe_6a0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio_ext {
+	switch@1e {
+		compatible = "brcm,bcm53115";
+		reg = <30>;
+
+		dsa,member = <1 0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "wan";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan1";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan3";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "lan4";
+			};
+
+			port@8 {
+				reg = <8>;
+
+				phy-mode = "rgmii";
+				ethernet = <&switch0port5>;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};
+
+&switch0 {
+	dsa,member = <0 0>;
+
+	ports {
+		switch0port5: port@5 {
+			reg = <5>;
+			label = "extsw";
+
+			phy-mode = "rgmii";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&pflash {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		cfe: partition@0 {
+			label = "CFE";
+			reg = <0x000000 0x020000>;
+			read-only;
+		};
+
+		partition@20000 {
+			label = "firmware";
+			reg = <0x020000 0xf40000>;
+			compatible = "brcm,bcm963xx-imagetag";
+		};
+
+		partition@f60000 {
+			label = "board_data";
+			reg = <0xf60000 0x080000>;
+			read-only;
+		};
+
+		partition@fe0000 {
+			label = "nvram";
+			reg = <0xfe0000 0x020000>;
+		};
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pci {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};
+
+&cfe {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_cfe_6a0: macaddr@6a0 {
+		reg = <0x6a0 0x6>;
+	};
+};

--- a/target/linux/bmips/image/bcm6368.mk
+++ b/target/linux/bmips/image/bcm6368.mk
@@ -43,6 +43,21 @@ define Device/netgear_dgnd3800b
 endef
 TARGET_DEVICES += netgear_dgnd3800b
 
+define Device/netgear_evg2000
+  $(Device/bcm63xx_netgear)
+  DEVICE_MODEL := EVG2000
+  CFE_BOARD_ID := 96369PVG
+  CHIP_ID := 6368
+  SOC := bcm6369
+  BLOCKSIZE := 0x20000
+  NETGEAR_BOARD_ID := U12H154T90_NETGEAR
+  NETGEAR_REGION := 1
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    $(B43_PACKAGES) broadcom-4322-sprom \
+    kmod-leds-gpio
+endef
+TARGET_DEVICES += netgear_evg2000
+
 define Device/observa_vh4032n
   $(Device/bcm63xx-cfe)
   DEVICE_VENDOR := Observa


### PR DESCRIPTION
The Netgear EVG2000 is a wifi gigabit router, 2.4 GHz single band with two internal antennas integrated in the main PCB. 

Hardware:
 - SoC: Broadcom BCM6369
 - CPU: dual core BMIPS4350 V3.1 @400Mhz
 - RAM: 64 MB DDR
 - Flash: 16 MB parallel NOR
 - LAN switch: Broadcom BCM53115, 5x 1Gbit
 - Wifi 2.4 GHz: Broadcom BCM4322 802.11bgn
 - USB: 2x 2.0
 - Buttons: 2x, 1 reset
 - LEDs: 10x
 - FXS: 2x
 - UART: yes

Installation via CFE web UI:
  1. Power off the router and make a temporal TX-RX shortcircuit on the serial pins.
  2. Power on the router and wait 3 or more seconds
  3. Remove the TX-RX shortcircuit
  4. Browse to http://192.168.1.1 or http://192.168.0.1 and upload the firmware
  5. Wait a few minutes for it to finish

The BCM53115 switch is managed via MDIO and wasn't supported in bcm63xx target. It always worked as a dumb switch. Now in bmips, with the new DSA Broadcom drivers, it will be supported with the WAN port working

CC: @Noltari 
CC: @Xotic750 