### PR TITLE
bmips: add support for Comtrend VR-3025un

### DIFF
--- a/target/linux/bmips/bcm6368/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6368/base-files/etc/board.d/02_network
@@ -10,6 +10,10 @@ observa,vh4032n)
 	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 	;;
+comtrend,vr-3025un)
+	ucidef_set_bridge_device switch
+	ucidef_set_interface_lan "lan1 lan2 lan3 iptv"
+	;;
 netgear,dgnd3700-v1 |\
 netgear,dgnd3800b |\
 netgear,evg2000)

--- a/target/linux/bmips/bcm6368/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/bmips/bcm6368/base-files/etc/uci-defaults/09_fix_crc
@@ -4,6 +4,7 @@
 
 case "$(board_name)" in
 comtrend,vr-3025u |\
+comtrend,vr-3025un |\
 netgear,evg2000 |\
 observa,vh4032n)
 	mtd fixtrx firmware

--- a/target/linux/bmips/dts/bcm6368-comtrend-vr-3025un.dts
+++ b/target/linux/bmips/dts/bcm6368-comtrend-vr-3025un.dts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6368.dtsi"
+
+/ {
+	model = "Comtrend VR-3025un";
+	compatible = "comtrend,vr-3025un", "brcm,bcm6368";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led@2 {
+			label = "green:dsl";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led@5 {
+			label = "green:internet";
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_green: led@22 {
+			label = "green:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_red: led@24 {
+			label = "red:power";
+			gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		led@31 {
+			label = "red:internet";
+			gpios = <&gpio 31 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	bcm43222-sprom {
+		compatible = "brcm,ssb-sprom";
+
+		pci-bus = <0>;
+		pci-dev = <1>;
+
+		nvmem-cells = <&macaddr_cfe_6a0>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <1>;
+
+		brcm,sprom = "brcm/bcm43222-sprom.bin";
+		brcm,sprom-fixups = <97 0xfeb3>,
+				    <98 0x1618>,
+				    <99 0xfab0>,
+				    <113 0xfed1>,
+				    <114 0x1609>,
+				    <115 0xfad9>;
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cfe_6a0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pci {
+	status = "okay";
+};
+
+&pflash {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		cfe: partition@0 {
+			label = "CFE";
+			reg = <0x000000 0x010000>;
+			read-only;
+		};
+
+		partition@20000 {
+			compatible = "brcm,bcm963xx-imagetag";
+			label = "firmware";
+			reg = <0x010000 0x7e0000>;
+		};
+
+		partition@1fe0000 {
+			label = "nvram";
+			reg = <0x7f0000 0x010000>;
+		};
+	};
+};
+
+&pinctrl {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_ephy0_led &pinctrl_ephy1_led
+		     &pinctrl_ephy2_led &pinctrl_ephy3_led>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+
+			phy-handle = <&phy1>;
+			phy-mode = "mii";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+
+			phy-handle = <&phy2>;
+			phy-mode = "mii";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+
+			phy-handle = <&phy3>;
+			phy-mode = "mii";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "iptv";
+
+			phy-handle = <&phy4>;
+			phy-mode = "mii";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};
+
+&cfe {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_cfe_6a0: macaddr@6a0 {
+		reg = <0x6a0 0x6>;
+	};
+};

--- a/target/linux/bmips/image/bcm6368.mk
+++ b/target/linux/bmips/image/bcm6368.mk
@@ -14,6 +14,19 @@ define Device/comtrend_vr-3025u
 endef
 TARGET_DEVICES += comtrend_vr-3025u
 
+define Device/comtrend_vr-3025un
+  $(Device/bcm63xx-cfe)
+  DEVICE_VENDOR := Comtrend
+  DEVICE_MODEL := VR-3025un
+  CHIP_ID := 6368
+  CFE_BOARD_ID := 96368M-1341N
+  FLASH_MB := 8
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    $(B43_PACKAGES) broadcom-43222-sprom \
+    kmod-leds-gpio
+endef
+TARGET_DEVICES += comtrend_vr-3025un
+
 define Device/netgear_dgnd3700-v1
   $(Device/bcm63xx-netgear)
   DEVICE_VENDOR := NETGEAR


### PR DESCRIPTION
The Comtrend VR-3025un is a wifi gigabit router, 2.4 GHz single band with two external antennas.
This device is very similar to the VR-3025u except for the smaller flash.

Hardware:
 - SoC: Broadcom BCM6368
 - CPU: dual core BMIPS4350 @ 400Mhz
 - RAM: 64 MB DDR
 - Flash: 8 MB parallel NOR
 - Ethernet LAN: 4x 100Mbit
 - Wifi 2.4 GHz: miniPCI Broadcom BCM43222 802.11bgn
 - USB: 1x 2.0
 - Buttons: 1x (reset)
 - LEDs: yes
 - UART: yes

Installation via CFE web UI:
  1. Power off the router.
  2. Press reset button near the antenna.
  3. Keep it pressed while powering up during ~20+ seconds.
  4. Browse to http://192.168.1.1 and upload the firmware.
  5. Wait a few minutes for it to finish.

CC @danitool 