### PR TITLE
bmips: add support for Comtrend WAP-5813n

### DIFF
--- a/target/linux/bmips/bcm6368/base-files/etc/board.d/01_leds
+++ b/target/linux/bmips/bcm6368/base-files/etc/board.d/01_leds
@@ -6,6 +6,9 @@
 board_config_update
 
 case "$(board_name)" in
+comtrend,wap-5813n)
+	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1" "usb2-port1"
+	;;
 netgear,dgnd3700-v1 |\
 netgear,dgnd3800b)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "switch.1"

--- a/target/linux/bmips/bcm6368/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6368/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ comtrend,vr-3025un)
 	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 iptv"
 	;;
+comtrend,wap-5813n |\
 netgear,dgnd3700-v1 |\
 netgear,dgnd3800b |\
 netgear,evg2000)

--- a/target/linux/bmips/bcm6368/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/bmips/bcm6368/base-files/etc/uci-defaults/09_fix_crc
@@ -5,6 +5,7 @@
 case "$(board_name)" in
 comtrend,vr-3025u |\
 comtrend,vr-3025un |\
+comtrend,wap-5813n |\
 netgear,evg2000 |\
 observa,vh4032n)
 	mtd fixtrx firmware

--- a/target/linux/bmips/dts/bcm6369-comtrend-wap-5813n.dts
+++ b/target/linux/bmips/dts/bcm6369-comtrend-wap-5813n.dts
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6368.dtsi"
+
+/ {
+	model = "Comtrend WAP-5813n";
+	compatible = "comtrend,wap-5813n", "brcm,bcm6369", "brcm,bcm6368";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		wlan {
+			label = "wlan";
+			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WLAN>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led@5 {
+			label = "green:internet";
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		led@14 {
+			label = "green:usb";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: led@22 {
+			label = "green:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		led@23 {
+			label = "green:wps";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_red: led@24 {
+			label = "red:power";
+			gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		led@31 {
+			label = "red:internet";
+			gpios = <&gpio 31 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	bcm4322-sprom {
+		compatible = "brcm,ssb-sprom";
+
+		pci-bus = <0>;
+		pci-dev = <1>;
+
+		nvmem-cells = <&macaddr_cfe_6a0>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <1>;
+
+		brcm,sprom = "brcm/bcm4322-sprom.bin";
+		brcm,sprom-fixups = <97 0xfeed>,
+				    <98 0x15d1>,
+				    <99 0xfb0d>,
+				    <113 0xfef7>,
+				    <114 0x15f7>,
+				    <115 0xfb1a>;
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cfe_6a0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&lsspi {
+	status = "okay";
+
+	switch@0 {
+		compatible = "brcm,bcm53115";
+		reg = <0>;
+		spi-max-frequency = <781000>;
+		dsa,member = <1 0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan4";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan3";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan1";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "wan";
+			};
+
+			port@5 {
+				reg = <5>;
+
+				phy-mode = "rgmii";
+				ethernet = <&switch0port4>;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};
+
+&pflash {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		cfe: partition@0 {
+			label = "CFE";
+			reg = <0x000000 0x010000>;
+			read-only;
+		};
+
+		partition@20000 {
+			label = "firmware";
+			reg = <0x010000 0x7e0000>;
+			compatible = "brcm,bcm963xx-imagetag";
+		};
+
+		partition@fe0000 {
+			label = "nvram";
+			reg = <0x7f0000 0x010000>;
+		};
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pci {
+	status = "okay";
+};
+
+&switch0 {
+	dsa,member = <0 0>;
+
+	ports {
+		switch0port4: port@4 {
+			reg = <4>;
+			label = "extsw";
+
+			phy-mode = "rgmii";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};
+
+&cfe {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_cfe_6a0: macaddr@6a0 {
+		reg = <0x6a0 0x6>;
+	};
+};

--- a/target/linux/bmips/image/bcm6368.mk
+++ b/target/linux/bmips/image/bcm6368.mk
@@ -27,6 +27,20 @@ define Device/comtrend_vr-3025un
 endef
 TARGET_DEVICES += comtrend_vr-3025un
 
+define Device/comtrend_wap-5813n
+  $(Device/bcm63xx-cfe)
+  DEVICE_VENDOR := Comtrend
+  DEVICE_MODEL := WAP-5813n
+  CHIP_ID := 6368
+  SOC := bcm6369
+  CFE_BOARD_ID := 96369R-1231N
+  FLASH_MB := 8
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    $(B43_PACKAGES) broadcom-4322-sprom \
+    kmod-leds-gpio
+endef
+TARGET_DEVICES += comtrend_wap-5813n
+
 define Device/netgear_dgnd3700-v1
   $(Device/bcm63xx-netgear)
   DEVICE_VENDOR := NETGEAR


### PR DESCRIPTION
The Comtrend WAP-5813n is a wifi gigabit router, 2.4 GHz single band with two external antennas.

Hardware:
 - SoC: Broadcom BCM6369
 - CPU: dual core BMIPS4350 @ 400Mhz
 - RAM: 64 MB DDR
 - Flash: 8 MB parallel NOR
 - LAN switch: Broadcom BCM53115, 5x 1Gbit
 - Wifi 2.4 GHz: miniPCI Broadcom BCM4322 802.11bgn
 - USB: 1x 2.0 (optional)
 - Buttons: 3x (reset)
 - LEDs: yes
 - UART: yes

Installation via CFE web UI:
  1. Power off the router.
  2. Press reset button near the power switch.
  3. Keep it pressed while powering up during ~20+ seconds.
  4. Browse to http://192.168.1.1 and upload the firmware.
  5. Wait a few minutes for it to finish.

CC @danitool