### PR TITLE
bmips: add support for Comtrend AR-5381u

### DIFF
--- a/target/linux/bmips/bcm6328/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6328/base-files/etc/board.d/02_network
@@ -5,6 +5,7 @@
 board_config_update
 
 case "$(board_name)" in
+comtrend,ar-5381u |\
 comtrend,ar-5387un)
 	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"

--- a/target/linux/bmips/bcm6328/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/bmips/bcm6328/base-files/etc/uci-defaults/09_fix_crc
@@ -3,6 +3,7 @@
 . /lib/functions.sh
 
 case "$(board_name)" in
+comtrend,ar-5381u |\
 comtrend,ar-5387un)
 	mtd fixtrx firmware
 	;;

--- a/target/linux/bmips/dts/bcm6328-comtrend-ar-5381u.dts
+++ b/target/linux/bmips/dts/bcm6328-comtrend-ar-5381u.dts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6328.dtsi"
+
+/ {
+	model = "Comtrend AR-5381u";
+	compatible = "comtrend,ar-5381u", "brcm,bcm6328";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_alarm_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	bcm43225-sprom {
+		compatible = "brcm,bcma-sprom";
+
+		pci-bus = <1>;
+		pci-dev = <0>;
+
+		nvmem-cells = <&macaddr_cfe_6a0>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <1>;
+
+		brcm,sprom = "brcm/bcm43225-sprom.bin";
+		brcm,sprom-fixups = <97 0xfee5>,
+				    <98 0x157c>,
+				    <99 0xfae7>,
+				    <113 0xfefa>,
+				    <114 0x15d6>,
+				    <115 0xfaf8>;
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cfe_6a0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&hsspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <16666667>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cfe: partition@0 {
+				reg = <0x000000 0x010000>;
+				label = "cfe";
+				read-only;
+			};
+
+			partition@10000 {
+				compatible = "brcm,bcm963xx-imagetag";
+				reg = <0x010000 0xfe0000>;
+				label = "firmware";
+			};
+
+			partition@ff0000 {
+				reg = <0xff0000 0x010000>;
+				label = "nvram";
+			};
+		};
+	};
+};
+
+&leds {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_leds>;
+
+	led_alarm_red: led@2 {
+		reg = <2>;
+		active-low;
+		label = "red:alarm";
+		panic-indicator;
+	};
+
+	led@3 {
+		reg = <3>;
+		active-low;
+		label = "green:internet";
+	};
+
+	led_power_green: led@4 {
+		reg = <4>;
+		active-low;
+		label = "green:power";
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pinctrl {
+	pinctrl_leds: leds {
+		function = "led";
+		pins = "gpio2", "gpio3", "gpio4";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+
+			phy-handle = <&phy1>;
+			phy-mode = "mii";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+
+			phy-handle = <&phy2>;
+			phy-mode = "mii";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+
+			phy-handle = <&phy3>;
+			phy-mode = "mii";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan4";
+
+			phy-handle = <&phy4>;
+			phy-mode = "mii";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};
+
+&cfe {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_cfe_6a0: macaddr@6a0 {
+		reg = <0x6a0 0x6>;
+	};
+};

--- a/target/linux/bmips/image/bcm6328.mk
+++ b/target/linux/bmips/image/bcm6328.mk
@@ -1,5 +1,18 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+define Device/comtrend_ar-5381u
+  $(Device/bcm63xx-cfe)
+  DEVICE_VENDOR := Comtrend
+  DEVICE_MODEL := AR-5381u
+  CHIP_ID := 6328
+  CFE_BOARD_ID := 96328A-1241N
+  FLASH_MB := 16
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    $(B43_PACKAGES) broadcom-43225-sprom \
+    kmod-leds-bcm6328
+endef
+TARGET_DEVICES += comtrend_ar-5381u
+
 define Device/comtrend_ar-5387un
   $(Device/bcm63xx-cfe)
   DEVICE_VENDOR := Comtrend


### PR DESCRIPTION
The Comtrend AR-5381u is a wifi fast ethernet router, 2.4 GHz single band with two internal antennas.

Hardware:
 - SoC: Broadcom BCM6328
 - CPU: single core BMIPS4350 @ 320Mhz
 - RAM: 64 MB DDR
 - Flash: 16 MB SPI NOR
 - Ethernet LAN: 4x 100Mbit
 - Wifi 2.4 GHz: miniPCI Broadcom BCM43225 802.11bgn
 - USB: 1x 2.0
 - Buttons: 1x (reset)
 - LEDs: yes
 - UART: yes

Installation via CFE web UI:
  1. Power off the router.
  2. Press reset button near the power switch.
  3. Keep it pressed while powering up during ~20+ seconds.
  4. Browse to http://192.168.1.1 and upload the firmware.
  5. Wait a few minutes for it to finish.
 
CC @danitool