### PR TITLE
ramips: add support for Sercomm S1500 devices 

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -45,6 +45,13 @@ etisalat,s3|\
 rostelecom,rt-sf-1)
 	ubootenv_add_uci_config "/dev/mtd0" "0x80000" "0x1000" "0x20000"
 	;;
+beeline,smartbox-pro|\
+tplink,ec330-g5u-v1|\
+wifire,s1500-nbn)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x20000"
+	;;
 buffalo,wsr-1166dhp|\
 buffalo,wsr-600dhp|\
 kroks,kndrt31r16|\
@@ -97,11 +104,6 @@ snr,cpe-w4n-mt)
 	idx="$(find_mtd_index uboot-env)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x1000"
-	;;
-tplink,ec330-g5u-v1)
-	idx="$(find_mtd_index u-boot-env)"
-	[ -n "$idx" ] && \
-		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x20000"
 	;;
 xiaomi,mi-router-3g-v2|\
 xiaomi,mi-router-4a-gigabit|\

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-pro.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-pro.dts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621_sercomm_s1500.dtsi"
+
+/ {
+	compatible = "beeline,smartbox-pro", "mediatek,mt7621-soc";
+	model = "Beeline SmartBox PRO";
+
+	aliases {
+		label-mac-device = &gmac0;
+	};
+
+	keys {
+		switch_bt {
+			label = "ROUT<->REP Switch_bt";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,input-type = <EV_SW>;
+			linux,code = <KEY_RFKILL>;
+			debounce-interval = <60>;
+		};
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1 &ubiconcat2 &ubiconcat3 \
+			&ubiconcat4 &ubiconcat5 &ubiconcat6>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0xd2e0000>;
+			};
+		};
+	};
+};
+
+&led_wps {
+	label = "blue:wps";
+	color = <LED_COLOR_ID_BLUE>;
+};
+
+&partitions {
+	partition@0_all {
+		label = "ALL";
+		reg = <0x0 0xff80000>;
+		read-only;
+	};
+
+	partition@200000 {
+		label = "sys_data";
+		reg = <0x200000 0x1400000>;
+
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		ubiconcat5: partition@0 {
+			label = "sys_data_1";
+			reg = <0x0 0x600000>;
+		};
+
+		/*
+		 * Sercomm U-Boot saves the environment at 0x800000 from
+		 * the start of the NAND, destroying the "sys_data"
+		 * partition. To prevent this, we split "sys_data" into
+		 * two parts with "u-boot-env" partition between them.
+		 */
+		partition@600000 {
+			label = "u-boot-env";
+			reg = <0x600000 0x20000>;
+		};
+
+		ubiconcat6: partition@620000 {
+			label = "sys_data_2";
+			reg = <0x620000 0xde0000>;
+		};
+	};
+
+	ubiconcat0: partition@1f00000 {
+		label = "RootFS_1";
+		reg = <0x1f00000 0x1e00000>;
+	};
+
+	partition@3d00000 {
+		label = "RootFS_2";
+		reg = <0x3d00000 0x1e00000>;
+		read-only;
+	};
+
+	ubiconcat1: partition@5b00000 {
+		label = "JVM/OSGI1";
+		reg = <0x5b00000 0x3200000>;
+	};
+
+	ubiconcat2: partition@8d00000 {
+		label = "JVM/OSGI2";
+		reg = <0x8d00000 0x3200000>;
+	};
+
+	ubiconcat3: partition@bf00000 {
+		label = "OSGI data";
+		reg = <0xbf00000 0x3c00000>;
+	};
+
+	ubiconcat4: partition@fb00000 {
+		label = "Ftool";
+		reg = <0xfb00000 0x100000>;
+	};
+
+	/*
+	 * 4 MiB Reserved for the Bad Blocka
+	 * 0x10000000-0xfc00000=0x400000
+	 */
+};

--- a/target/linux/ramips/dts/mt7621_sercomm_s1500.dtsi
+++ b/target/linux/ramips/dts/mt7621_sercomm_s1500.dtsi
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_wps;
+		led-failsafe = &led_wps;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			label = "amber:lan4";
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <0>;
+			linux,default-trigger = "mt7530-0:00:1Gbps";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			label = "green:lan4";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			label = "amber:lan3";
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			linux,default-trigger = "mt7530-0:01:1Gbps";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			label = "green:lan3";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			label = "amber:lan2";
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			linux,default-trigger = "mt7530-0:02:1Gbps";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			label = "amber:lan1";
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <5>;
+			linux,default-trigger = "mt7530-0:03:1Gbps";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		led-6 {
+			label = "green:lan1";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <6>;
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		led-7 {
+			label = "amber:wan";
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WAN;
+			function-enumerator = <0>;
+			linux,default-trigger = "mt7530-0:04:1Gbps";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+		};
+
+		led-8 {
+			label = "green:wan";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			function-enumerator = <1>;
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led-9 {
+			label = "green:lan2";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <7>;
+			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
+		};
+
+		led-10 {
+			label = "white:wlan2g";
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <0>;
+			linux,default-trigger = "phy1radio";
+			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wps: led-11 {
+			function = LED_FUNCTION_WPS;
+			function-enumerator = <0>;
+			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+
+		led_status: led-12 {
+			label = "white:status";
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_STATUS;
+			function-enumerator = <0>;
+			gpios = <&gpio 30 GPIO_ACTIVE_LOW>;
+		};
+
+		led-13 {
+			label = "white:wlan5g";
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <1>;
+			linux,default-trigger = "phy0radio";
+			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_1000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&nand {
+	status = "okay";
+
+	partitions: partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x100000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "Factory";
+			reg = <0x100000 0x100000>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_factory_1000: macaddr@1000 {
+				reg = <0x1000 0x6>;
+			};
+		};
+
+		partition@1600000 {
+			label = "boot_flag";
+			reg = <0x1600000 0x100000>;
+		};
+
+		partition@1700000 {
+			label = "kernel";
+			reg = <0x1700000 0x400000>;
+		};
+
+		partition@1b00000 {
+			label = "Kernel_2";
+			reg = <0x1b00000 0x400000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	reset-gpios = <&gpio 8 GPIO_ACTIVE_LOW>,
+		<&gpio 19 GPIO_ACTIVE_LOW>;
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+
+		nvmem-cells = <&macaddr_factory_1000>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <2>;
+	};
+};
+
+&pcie1 {
+	wlan_2g: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+
+		nvmem-cells = <&macaddr_factory_1000>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "uart3", "jtag", "uart2", "i2c", "rgmii2";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		wan: port@4 {
+			status = "okay";
+			label = "wan";
+
+			nvmem-cells = <&macaddr_factory_1000>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <1>;
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_wifire_s1500-nbn.dts
+++ b/target/linux/ramips/dts/mt7621_wifire_s1500-nbn.dts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621_sercomm_s1500.dtsi"
+
+/ {
+	compatible = "wifire,s1500-nbn", "mediatek,mt7621-soc";
+	model = "WiFire S1500.NBN";
+
+	aliases {
+		label-mac-device = &wan;
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1 &ubiconcat2 &ubiconcat3>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x4680000>;
+			};
+		};
+	};
+};
+
+&led_wps {
+	label = "white:wps";
+	color = <LED_COLOR_ID_WHITE>;
+};
+
+&partitions {
+	partition@0_all {
+		label = "ALL";
+		reg = <0x0 0x7f80000>;
+		read-only;
+	};
+
+	partition@80000 {
+		label = "u-boot-env";
+		reg = <0x80000 0x20000>;
+	};
+
+	ubiconcat1: partition@200000 {
+		label = "sys_data";
+		reg = <0x200000 0x1400000>;
+	};
+
+	ubiconcat0: partition@1f00000 {
+		label = "RootFS_1";
+		reg = <0x1f00000 0x2e00000>;
+	};
+
+	partition@4d00000 {
+		label = "RootFS_2";
+		reg = <0x4d00000 0x2e00000>;
+		read-only;
+	};
+
+	ubiconcat2: partition@7b00000 {
+		label = "Ftool";
+		reg = <0x7b00000 0x100000>;
+	};
+
+	ubiconcat3: partition@7c00000 {
+		label = "BCT";
+		reg = <0x7c00000 0x380000>;
+	};
+
+	/*
+	 * 512 KiB reserved for the Bad Blocks
+	 * 0x8000000-0x7f80000=0x80000
+	 */
+};
+
+&wlan_2g {
+	mac-address-increment = <1>;
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -398,6 +398,23 @@ define Device/beeline_smartbox-giga
 endef
 TARGET_DEVICES += beeline_smartbox-giga
 
+define Device/beeline_smartbox-pro
+  $(Device/sercomm_s1500)
+  DEVICE_VENDOR := Beeline
+  DEVICE_MODEL := SmartBox PRO
+  DEVICE_ALT0_VENDOR := Sercomm
+  DEVICE_ALT0_MODEL := S1500 AWI
+  IMAGE_SIZE := 34816k
+  IMAGE/factory.img := append-kernel | sercomm-kernel-factory | \
+	sercomm-reset-slot1-chksum | append-ubi | check-size | \
+	sercomm-factory-cqr | sercomm-append-tail | sercomm-mkhash
+  SERCOMM_HWID := AWI
+  SERCOMM_HWVER := 10000
+  SERCOMM_ROOTFS2_OFFSET := 0x3d00000
+  SERCOMM_SWVER := 2020
+endef
+TARGET_DEVICES += beeline_smartbox-pro
+
 define Device/beeline_smartbox-turbo
   $(Device/sercomm_dxx)
   IMAGE_SIZE := 32768k
@@ -2452,6 +2469,24 @@ define Device/wevo_w2914ns-v2
   SUPPORTED_DEVICES += w2914nsv2
 endef
 TARGET_DEVICES += wevo_w2914ns-v2
+
+define Device/wifire_s1500-nbn
+  $(Device/sercomm_s1500)
+  DEVICE_VENDOR := WiFire
+  DEVICE_MODEL := S1500.NBN
+  DEVICE_ALT0_VENDOR := Sercomm
+  DEVICE_ALT0_MODEL := S1500 BUC
+  IMAGE_SIZE := 51200k
+  IMAGE/factory.img := append-kernel | sercomm-kernel-factory | \
+	sercomm-reset-slot1-chksum | append-ubi | check-size | \
+	sercomm-factory-cqr | sercomm-fix-buc-pid | sercomm-mkhash | \
+	sercomm-crypto
+  SERCOMM_HWID := BUC
+  SERCOMM_HWVER := 10000
+  SERCOMM_ROOTFS2_OFFSET := 0x4d00000
+  SERCOMM_SWVER := 2015
+endef
+TARGET_DEVICES += wifire_s1500-nbn
 
 define Device/winstars_ws-wn583a6
   $(Device/dsa-migration)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -40,6 +40,14 @@ etisalat,s3|\
 rostelecom,rt-sf-1)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
 	;;
+beeline,smartbox-pro|\
+wifire,s1500-nbn)
+	ucidef_set_led_netdev "lan1" "lan1" "green:lan1" "lan1" "link tx rx"
+	ucidef_set_led_netdev "lan2" "lan2" "green:lan2" "lan2" "link tx rx"
+	ucidef_set_led_netdev "lan3" "lan3" "green:lan3" "lan3" "link tx rx"
+	ucidef_set_led_netdev "lan4" "lan4" "green:lan4" "lan4" "link tx rx"
+	ucidef_set_led_netdev "wan"  "wan"  "green:wan"  "wan"  "link tx rx"
+	;;
 belkin,rt1800)
 	ucidef_set_led_netdev "wan" "wan" "white:wan" "wan"
 	;;

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -59,6 +59,7 @@ platform_do_upgrade() {
 	asus,rt-ax54|\
 	beeline,smartbox-flash|\
 	beeline,smartbox-giga|\
+	beeline,smartbox-pro|\
 	beeline,smartbox-turbo|\
 	beeline,smartbox-turbo-plus|\
 	belkin,rt1800|\
@@ -107,6 +108,7 @@ platform_do_upgrade() {
 	sercomm,na502s|\
 	sim,simax1800t|\
 	tplink,ec330-g5u-v1|\
+	wifire,s1500-nbn|\
 	xiaomi,mi-router-3g|\
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-4|\


### PR DESCRIPTION
[OpenWrt Wiki - Beeline SmartBox PRO](https://openwrt.org/inbox/toh/beeline/smartbox_pro)
[OpenWrt Wiki - WiFire S1500.NBN](https://openwrt.org/toh/wifire/s1500_nbn)
--------------------------------------------------------------------

This commit adds support for following wireless routers:
 - Beeline SmartBox PRO (Serсomm S1500 AWI)
 - WiFire S1500.NBN (Serсomm S1500 BUC)

This commit is based on this PR:
Link: https://github.com/openwrt/openwrt/pull/4770
Author: Maximilian Weinmann <x1@disroot.org>
The opening of this PR was agreed with author.

My changes:
- Sorting, minor changes and some movings between dts and dtsi
- Move leds to dts when possible
- Recipes for the factory image
- Update of the installation/recovery/return to stock guides

Common specification
--------------------
```
SoC: MediaTek MT7621AT (880 MHz, 2 cores)
Switch: MediaTek MT7530 (via SoC MT7621AT)
Wireless 2.4 GHz (MT7602EN): b/g/n, 2x2
Wireless 5 GHz (MT7612EN): a/n/ac, 2x2
Ethernet: 5 ports - 5×GbE (WAN, LAN1-4)
Mini PCIe (via J2 on PCB, Not soldered on the board)
UART: J4 -> GND[], TX, VCC(3.3V), RX
BootLoader: U-Boot SerComm/Mediatek
```

Beeline SmartBox PRO specification
----------------------------------
```
RAM (Nanya NT5CB128M16FP): 256 MiB
NAND-Flash (ESMT F59L2G81A): 256 MiB
USB ports: 2xUSB2.0
LEDs: Status (white), WPS (blue), 2g (white), 5g (white) + 10 LED Ethernet
Buttons: 2 button (reset, wps), 1 switch button (ROUT<->REP)
Power: 12 VDC, 1.5 A
PCB Sticker: 970AWI0QW00N256SMT Ver. 1.0
CSN: SG15********
MAC LAN: 94:4A:0C:**:**:**
Manufacturer's code: 0AWI0500QW1
```

WiFire S1500.NBN specification
------------------------------
```
RAM (Nanya NT5CC64M16GP): 128 MiB
NAND-Flash (ESMT F59L1G81MA): 128 MiB
USB ports: 1xUSB2.0
LEDs: Status (white), WPS (white), 2g (white), 5g (white) + 10 LED Ethernet
Buttons: 2 button (RESET, WPS)
Power: 12 VDC, 1.0 A
PCB Sticker: 970BUC0RW00N128SMT Ver. 1.0
CSN: MH16********
MAC WAN: E0:60:66:**:**:**
Manufacturer's code: 0BUC0500RW1
```

MAC address table (PRO)
-----------------------
```
use   address   source
LAN   *:23      factory 0x1000 (label)
WAN   *:24      factory $label +1
2g    *:23      factory $label
5g    *:25      factory $label +2
```

MAC addresses (NBN)
-------------------
```
use   address   source
LAN   *:0e      factory 0x1000
WAN   *:0f      LAN +1 (label)
2g    *:0f      LAN +1
5g    *:10      LAN +2
```

OEM easy Installation
---------------------
  1. Remove all dots from the factory image filename (except the dot before file extension)
  2. Upload and update the firmware via the original web interface
  3. Two options are possible after the reboot:
     a. OpenWrt - that's OK, the mission accomplished
     b. Stock firmware - install Stock firmware (to switch booflag from Sercomm0 to Sercomm1) and then OpenWrt factory image.

Return to Stock
---------------
1. Change the bootflag to Sercomm1 in OpenWrt CLI and then reboot:
```
   printf 1 | dd bs=1 seek=7 count=1 of=/dev/mtdblock2
   reboot
```
2. Install stock firmware via the web OEM firmware interface

Recovery
--------
Use sercomm-recovery tool.
Link: https://github.com/danitool/sercomm-recovery

Test build 
-----------
https://mega.nz/folder/5gAijYQL#fbQvX9cZNzDPhJU7y1pr_w 

Tested-By: 
-----------
Tested-by: Pavel Ivanov <pi635v@gmail.com>
Tested-by: Denis Myshaev <denis.myshaev@gmail.com>
Tested-by: Oleg Galeev <olegingaleev@gmail.com>
Tested-By: Ivan Pavlov <AuthorReflex@gmail.com>
Tested-By: @SopaDeMacaco-UmaDelicia
Tested-By: @Maker39

CC: @MaxS0niX