### PR TITLE
bmips: add support for Actiontec R1000H

### DIFF
--- a/target/linux/bmips/bcm6368/base-files/etc/board.d/01_leds
+++ b/target/linux/bmips/bcm6368/base-files/etc/board.d/01_leds
@@ -6,6 +6,10 @@
 board_config_update
 
 case "$(board_name)" in
+actiontec,r1000h)
+	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1" "usb2-port1"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
+	;;
 comtrend,wap-5813n)
 	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1" "usb2-port1"
 	;;

--- a/target/linux/bmips/bcm6368/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6368/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ comtrend,vr-3025un)
 	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 iptv"
 	;;
+actiontec,r1000h |\
 comtrend,wap-5813n |\
 netgear,dgnd3700-v1 |\
 netgear,dgnd3800b |\

--- a/target/linux/bmips/bcm6368/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/bmips/bcm6368/base-files/etc/uci-defaults/09_fix_crc
@@ -3,6 +3,7 @@
 . /lib/functions.sh
 
 case "$(board_name)" in
+actiontec,r1000h |\
 comtrend,vr-3025u |\
 comtrend,vr-3025un |\
 comtrend,wap-5813n |\

--- a/target/linux/bmips/dts/bcm6368-actiontec-r1000h.dts
+++ b/target/linux/bmips/dts/bcm6368-actiontec-r1000h.dts
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6368.dtsi"
+
+/ {
+	model = "Actiontec R1000H";
+	compatible = "actiontec,r1000h", "brcm,bcm6368";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led@5 {
+			label = "green:wan";
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		led@21 {
+			label = "green:usb";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: led@22 {
+			label = "green:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		led@23 {
+			label = "green:wps";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_red: led@24 {
+			label = "red:power";
+			gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		led@30 {
+			label = "red:wps";
+			gpios = <&gpio 30 GPIO_ACTIVE_LOW>;
+		};
+
+		led@31 {
+			label = "red:wan";
+			gpios = <&gpio 31 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cfe_6a0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio_ext {
+	switch@1e {
+		compatible = "brcm,bcm53115";
+		reg = <30>;
+
+		dsa,member = <1 0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan1";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan2";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan4";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "wan";
+			};
+
+			port@5 {
+				/* HPNA coaxial port */
+				reg = <5>;
+				label = "coax";
+
+				phy-mode = "mii";
+
+				fixed-link {
+					speed = <100>;
+					full-duplex;
+				};
+			};
+
+			port@8 {
+				reg = <8>;
+
+				phy-mode = "rgmii";
+				ethernet = <&switch0port5>;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};
+
+&switch0 {
+	dsa,member = <0 0>;
+
+	ports {
+		switch0port5: port@5 {
+			reg = <5>;
+			label = "extsw";
+
+			phy-mode = "rgmii";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&pflash {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		cfe: partition@0 {
+			label = "CFE";
+			reg = <0x000000 0x020000>;
+			read-only;
+		};
+
+		partition@20000 {
+			label = "firmware";
+			reg = <0x020000 0x1fc0000>;
+			compatible = "brcm,bcm963xx-imagetag";
+		};
+
+		partition@fe0000 {
+			label = "nvram";
+			reg = <0x1fe0000 0x020000>;
+		};
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pci {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};
+
+&cfe {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_cfe_6a0: macaddr@6a0 {
+		reg = <0x6a0 0x6>;
+	};
+};

--- a/target/linux/bmips/image/bcm6368.mk
+++ b/target/linux/bmips/image/bcm6368.mk
@@ -1,5 +1,20 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+define Device/actiontec_r1000h
+  $(Device/bcm63xx-cfe)
+  DEVICE_VENDOR := Actiontec
+  DEVICE_MODEL := R1000H
+  CHIP_ID := 6368
+  CFE_BOARD_ID := 96368VVW
+  BLOCKSIZE := 0x20000
+  FLASH_MB := 32
+  CFE_EXTRAS += --signature "$$(DEVICE_VENDOR)"
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    $(B43_PACKAGES) \
+    kmod-leds-gpio
+endef
+TARGET_DEVICES += actiontec_r1000h
+
 define Device/comtrend_vr-3025u
   $(Device/bcm63xx-cfe)
   DEVICE_VENDOR := Comtrend


### PR DESCRIPTION
The  Actiontec R1000H is a gigabit wifi router, 2.4 GHz single band with two external antennas. It comes with a coaxial HomePNA port.

Hardware:
 - SoC: Broadcom BCM6368
 - CPU: dual core BMIPS4350 V3.1 @400Mhz
 - RAM: 64 MB DDR
 - Flash: 32 MB parallel NOR
 - LAN switch: Broadcom BCM53115, 5x 1Gbit
 - LAN coaxial : 1x HPNA 3.1, CG3211 + CG3213
 - Wifi 2.4 GHz: Broadcom BCM4322 802.11bgn
 - USB: 1x 2.0
 - Buttons: 2x, 1 reset
 - LEDs: 7x
 - UART: yes

The HPNA hardware probably needs a firmware to make the coaxial port work. In the OEM firmware is apparently sent with an utility (inhpna) through the ethernet port.

Installation via CFE web UI:
  1. Connect the UART serial port.
  2. Power on the router and press enter at the console prompt to stop the bootloader.
  4. Browse to http://192.168.1.1 and upload the OpenWrt CFE firmware
  5. Wait a few minutes for it to finish

In bcm63xx this router didn't have support for the external gigabit switch. In bmpis it will be configurable allowing to route traffic on the wan port.

CC: @Noltari 
CC: @protectivedad 