### PR TITLE
rockchip: fix setup network config for nanopi r2c

### DIFF
--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -7,6 +7,7 @@ rockchip_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
+	friendlyarm,nanopi-r2c|\
 	friendlyarm,nanopi-r2s|\
 	friendlyarm,nanopi-r4s|\
 	xunlong,orangepi-r1-plus|\


### PR DESCRIPTION
Without it the WAN port won't be initialized properly.

Fixes: 8f578c15b314 ("rockchip: add NanoPi R2C support")