### PR TITLE
[23.05] openssl: passing cflags to configure

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_VERSION:=3.0.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_BUILD_FLAGS:=no-mips16 gc-sections
 
 PKG_BUILD_PARALLEL:=1
@@ -366,6 +366,7 @@ define Build/Configure
 			--libdir=lib \
 			--openssldir=/etc/ssl \
 			--cross-compile-prefix="$(TARGET_CROSS)" \
+			$(TARGET_CFLAGS) \
 			$(TARGET_CPPFLAGS) \
 			$(TARGET_LDFLAGS) \
 			$(OPENSSL_OPTIONS) && \


### PR DESCRIPTION
openssl sets additional cflags in its configuration script. We need to make it aware of our custom cflags to avoid adding conflicting cflags.

Fixes: #12866
Signed-off-by: Jitao Lu <dianlujitao@gmail.com>
(cherry picked from commit 51f57e7c2dd2799e34036ec74b3436bf490fade0)