### PR TITLE
[WIP,RFT,RFC] mac80211: add support for QAM-256 in 2.4GHz 802.11n

### DIFF
--- a/files/www/luci-static/resources/view/network/wireless.js
+++ b/files/www/luci-static/resources/view/network/wireless.js
@@ -1,0 +1,2431 @@
+'use strict';
+'require view';
+'require dom';
+'require poll';
+'require fs';
+'require ui';
+'require rpc';
+'require uci';
+'require form';
+'require network';
+'require firewall';
+'require tools.widgets as widgets';
+
+var isReadonlyView = !L.hasViewPermission();
+
+function count_changes(section_id) {
+	var changes = ui.changes.changes, n = 0;
+
+	if (!L.isObject(changes))
+		return n;
+
+	if (Array.isArray(changes.wireless))
+		for (var i = 0; i < changes.wireless.length; i++)
+			n += (changes.wireless[i][1] == section_id);
+
+	return n;
+}
+
+function render_radio_badge(radioDev) {
+	return E('span', { 'class': 'ifacebadge' }, [
+		E('img', { 'src': L.resource('icons/wifi%s.png').format(radioDev.isUp() ? '' : '_disabled') }),
+		' ',
+		radioDev.getName()
+	]);
+}
+
+function render_signal_badge(signalPercent, signalValue, noiseValue, wrap, mode) {
+	var icon, title, value;
+
+	if (signalPercent < 0)
+		icon = L.resource('icons/signal-none.png');
+	else if (signalPercent == 0)
+		icon = L.resource('icons/signal-0.png');
+	else if (signalPercent < 25)
+		icon = L.resource('icons/signal-0-25.png');
+	else if (signalPercent < 50)
+		icon = L.resource('icons/signal-25-50.png');
+	else if (signalPercent < 75)
+		icon = L.resource('icons/signal-50-75.png');
+	else
+		icon = L.resource('icons/signal-75-100.png');
+
+	if (signalValue != null && signalValue != 0) {
+		if (noiseValue != null && noiseValue != 0) {
+			value = '%d/%d\xa0%s'.format(signalValue, noiseValue, _('dBm'));
+			title = '%s: %d %s / %s: %d %s / %s %d'.format(
+				_('Signal'), signalValue, _('dBm'),
+				_('Noise'), noiseValue, _('dBm'),
+				_('SNR'), signalValue - noiseValue);
+		}
+		else {
+			value = '%d\xa0%s'.format(signalValue, _('dBm'));
+			title = '%s: %d %s'.format(_('Signal'), signalValue, _('dBm'));
+		}
+	}
+	else if (signalPercent > -1) {
+		switch (mode) {
+			case 'ap':
+				title = _('No client associated');
+				break;
+
+			case 'sta':
+			case 'adhoc':
+			case 'mesh':
+				title = _('Not associated');
+				break;
+
+			default:
+				title = _('No RX signal');
+		}
+
+		if (noiseValue != null && noiseValue != 0) {
+			value = '---/%d\xa0%s'.format(noiseValue, _('dBm'));
+			title = '%s / %s: %d %s'.format(title, _('Noise'), noiseValue, _('dBm'));
+		}
+		else {
+			value = '---\xa0%s'.format(_('dBm'));
+		}
+	}
+	else {
+		value = E('em', {}, E('small', {}, [ _('disabled') ]));
+		title = _('Interface is disabled');
+	}
+
+	return E('div', {
+		'class': wrap ? 'center' : 'ifacebadge',
+		'title': title,
+		'data-signal': signalValue,
+		'data-noise': noiseValue
+	}, [
+		E('img', { 'src': icon }),
+		E('span', {}, [
+			wrap ? E('br') : ' ',
+			value
+		])
+	]);
+}
+
+function render_network_badge(radioNet) {
+	return render_signal_badge(
+		radioNet.isUp() ? radioNet.getSignalPercent() : -1,
+		radioNet.getSignal(), radioNet.getNoise(), false, radioNet.getMode());
+}
+
+function render_radio_status(radioDev, wifiNets) {
+	var name = radioDev.getI18n().replace(/ Wireless Controller .+$/, ''),
+	    node = E('div', [ E('big', {}, E('strong', {}, name)), E('div') ]),
+	    channel, frequency, bitrate;
+
+	for (var i = 0; i < wifiNets.length; i++) {
+		channel   = channel   || wifiNets[i].getChannel();
+		frequency = frequency || wifiNets[i].getFrequency();
+		bitrate   = bitrate   || wifiNets[i].getBitRate();
+	}
+
+	if (radioDev.isUp())
+		L.itemlist(node.lastElementChild, [
+			_('Channel'), '%s (%s %s)'.format(channel || '?', frequency || '?', _('GHz')),
+			_('Bitrate'), '%s %s'.format(bitrate || '?', _('Mbit/s'))
+		], ' | ');
+	else
+		node.lastElementChild.appendChild(E('em', _('Device is not active')));
+
+	return node;
+}
+
+function render_network_status(radioNet) {
+	var mode = radioNet.getActiveMode(),
+	    bssid = radioNet.getActiveBSSID(),
+	    channel = radioNet.getChannel(),
+	    disabled = (radioNet.get('disabled') == '1' || uci.get('wireless', radioNet.getWifiDeviceName(), 'disabled') == '1'),
+	    is_assoc = (bssid && bssid != '00:00:00:00:00:00' && channel && mode != 'Unknown' && !disabled),
+	    is_mesh = (radioNet.getMode() == 'mesh'),
+	    changecount = count_changes(radioNet.getName()),
+	    status_text = null;
+
+	if (changecount)
+		status_text = E('a', {
+			href: '#',
+			click: L.bind(ui.changes.displayChanges, ui.changes)
+		}, _('Interface has %d pending changes').format(changecount));
+	else if (!is_assoc)
+		status_text = E('em', disabled ? _('Wireless is disabled') : _('Wireless is not associated'));
+
+	return L.itemlist(E('div'), [
+		is_mesh ? _('Mesh ID') : _('SSID'), (is_mesh ? radioNet.getMeshID() : radioNet.getSSID()) || '?',
+		_('Mode'),       mode,
+		_('BSSID'),      (!changecount && is_assoc) ? bssid : null,
+		_('Encryption'), (!changecount && is_assoc) ? radioNet.getActiveEncryption() || _('None') : null,
+		null,            status_text
+	], [ ' | ', E('br') ]);
+}
+
+function render_modal_status(node, radioNet) {
+	var mode = radioNet.getActiveMode(),
+	    noise = radioNet.getNoise(),
+	    bssid = radioNet.getActiveBSSID(),
+	    channel = radioNet.getChannel(),
+	    disabled = (radioNet.get('disabled') == '1'),
+	    is_assoc = (bssid && bssid != '00:00:00:00:00:00' && channel && mode != 'Unknown' && !disabled);
+
+	if (node == null)
+		node = E('span', { 'class': 'ifacebadge large', 'data-network': radioNet.getName() }, [ E('small'), E('span') ]);
+
+	dom.content(node.firstElementChild, render_signal_badge(
+		disabled ? -1 : radioNet.getSignalPercent(),
+		radioNet.getSignal(), noise, true, radioNet.getMode()));
+
+	L.itemlist(node.lastElementChild, [
+		_('Mode'),       mode,
+		_('SSID'),       radioNet.getSSID() || '?',
+		_('BSSID'),      is_assoc ? bssid : null,
+		_('Encryption'), is_assoc ? radioNet.getActiveEncryption() || _('None') : null,
+		_('Channel'),    is_assoc ? '%d (%.3f %s)'.format(radioNet.getChannel(), radioNet.getFrequency() || 0, _('GHz')) : null,
+		_('Tx-Power'),   is_assoc ? '%d %s'.format(radioNet.getTXPower(), _('dBm')) : null,
+		_('Signal'),     is_assoc ? '%d %s'.format(radioNet.getSignal(), _('dBm')) : null,
+		_('Noise'),      (is_assoc && noise != null) ? '%d %s'.format(noise, _('dBm')) : null,
+		_('Bitrate'),    is_assoc ? '%.1f %s'.format(radioNet.getBitRate() || 0, _('Mbit/s')) : null,
+		_('Country'),    is_assoc ? radioNet.getCountryCode() : null
+	], [ ' | ', E('br'), E('br'), E('br'), E('br'), E('br'), ' | ', E('br'), ' | ' ]);
+
+	if (!is_assoc)
+		dom.append(node.lastElementChild, E('em', disabled ? _('Wireless is disabled') : _('Wireless is not associated')));
+
+	return node;
+}
+
+function format_wifirate(rate) {
+	var s = '%.1f\xa0%s, %d\xa0%s'.format(rate.rate / 1000, _('Mbit/s'), rate.mhz, _('MHz')),
+	    ht = rate.ht, vht = rate.vht,
+	    mhz = rate.mhz, nss = rate.nss,
+	    mcs = rate.mcs, sgi = rate.short_gi,
+	    he = rate.he, he_gi = rate.he_gi,
+	    he_dcm = rate.he_dcm,
+	    eht = rate?.eht ?? false, eht_gi = rate?.eht_gi ?? 0,
+	    eht_dcm = rate?.eht_dcm ?? 0;
+
+	if (ht || vht) {
+		if (vht) s += ', VHT-MCS\xa0%d'.format(mcs);
+		if (nss) s += ', VHT-NSS\xa0%d'.format(nss);
+		if (ht)  s += ', MCS\xa0%s'.format(mcs);
+		if (sgi) s += ', ' + _('Short GI').replace(/ /g, '\xa0');
+	}
+
+	if (he) {
+		s += ', HE-MCS\xa0%d'.format(mcs);
+		if (nss) s += ', HE-NSS\xa0%d'.format(nss);
+		if (he_gi) s += ', HE-GI\xa0%d'.format(he_gi);
+		if (he_dcm) s += ', HE-DCM\xa0%d'.format(he_dcm);
+	}
+
+	if (eht) {
+		s += ', EHT-MCS\xa0%d'.format(mcs);
+		if (nss) s += ', EHT-NSS\xa0%d'.format(nss);
+		if (eht_gi) s += ', EHT-GI\xa0%d'.format(eht_gi);
+		if (eht_dcm) s += ', EHT-DCM\xa0%d'.format(eht_dcm);
+	}
+
+	return s;
+}
+
+function radio_restart(id, ev) {
+	var row = document.querySelector('.cbi-section-table-row[data-sid="%s"]'.format(id)),
+	    dsc = row.querySelector('[data-name="_stat"] > div'),
+	    btn = row.querySelector('.cbi-section-actions button');
+
+	btn.blur();
+	btn.classList.add('spinning');
+	btn.disabled = true;
+
+	dsc.setAttribute('restart', '');
+	dom.content(dsc, E('em', _('Device is restarting…')));
+}
+
+function network_updown(id, map, ev) {
+	var radio = uci.get('wireless', id, 'device'),
+	    disabled = (uci.get('wireless', id, 'disabled') == '1') ||
+	               (uci.get('wireless', radio, 'disabled') == '1');
+
+	if (disabled) {
+		uci.unset('wireless', id, 'disabled');
+		uci.unset('wireless', radio, 'disabled');
+	}
+	else {
+		uci.set('wireless', id, 'disabled', '1');
+
+		var all_networks_disabled = true,
+		    wifi_ifaces = uci.sections('wireless', 'wifi-iface');
+
+		for (var i = 0; i < wifi_ifaces.length; i++) {
+			if (wifi_ifaces[i].device == radio && wifi_ifaces[i].disabled != '1') {
+				all_networks_disabled = false;
+				break;
+			}
+		}
+
+		if (all_networks_disabled)
+			uci.set('wireless', radio, 'disabled', '1');
+	}
+
+	return map.save().then(function() {
+		ui.changes.apply()
+	});
+}
+
+function next_free_sid(offset) {
+	var sid = 'wifinet' + offset;
+
+	while (uci.get('wireless', sid))
+		sid = 'wifinet' + (++offset);
+
+	return sid;
+}
+
+function add_dependency_permutations(o, deps) {
+	var res = null;
+
+	for (var key in deps) {
+		if (!deps.hasOwnProperty(key) || !Array.isArray(deps[key]))
+			continue;
+
+		var list = deps[key],
+		    tmp = [];
+
+		for (var j = 0; j < list.length; j++) {
+			for (var k = 0; k < (res ? res.length : 1); k++) {
+				var item = (res ? Object.assign({}, res[k]) : {});
+				item[key] = list[j];
+				tmp.push(item);
+			}
+		}
+
+		res = tmp;
+	}
+
+	for (var i = 0; i < (res ? res.length : 0); i++)
+		o.depends(res[i]);
+}
+
+// Define a class CBIWifiFrequencyValue that extends form.Value
+var CBIWifiFrequencyValue = form.Value.extend({
+	// Declare an RPC method to get the frequency list for a given device
+	callFrequencyList: rpc.declare({
+		object: 'iwinfo',
+		method: 'freqlist',
+		params: [ 'device' ],
+		expect: { results: [] }
+	}),
+
+	// Load method to fetch WiFi device details and frequency list
+	load: function(section_id) {
+		return Promise.all([
+			network.getWifiDevice(section_id),
+			this.callFrequencyList(section_id)
+		]).then(L.bind(function(data) {
+			this.channels = {
+				'2g': L.hasSystemFeature('hostapd', 'acs') ? [ 'auto', 'auto', { available: true } ] : [],
+				'5g': L.hasSystemFeature('hostapd', 'acs') ? [ 'auto', 'auto', { available: true } ] : [],
+				'6g': L.hasSystemFeature('hostapd', 'acs') ? [ 'auto', 'auto', { available: true } ] : [],
+				'60g': []
+			};
+
+			for (var i = 0; i < data[1].length; i++) {
+				if (!data[1][i].band)
+					continue;
+
+				var band = '%dg'.format(data[1][i].band),
+				    available = true;
+
+
+				if (data[1][i].restricted && data[1][i].no_ir)
+					available = false;
+
+				this.channels[band].push(
+					data[1][i].channel,
+					'%d (%d Mhz)'.format(data[1][i].channel, data[1][i].mhz),
+					{
+						available: available,
+						no_outdoor: data[1][i].no_outdoor
+					}
+					
+				);
+			}
+
+			var hwmodelist = L.toArray(data[0] ? data[0].getHWModes() : null)
+				.reduce(function(o, v) { o[v] = true; return o }, {});
+
+			// Define supported modes
+			this.modes = [
+				'', 'Legacy', { available: hwmodelist.a || hwmodelist.b || hwmodelist.g },
+				'n', 'N', { available: hwmodelist.n },
+				'ac', 'AC', { available: L.hasSystemFeature('hostapd', '11ac') && hwmodelist.ac },
+				'ax', 'AX', { available: L.hasSystemFeature('hostapd', '11ax') && hwmodelist.ax },
+				'be', 'BE', { available: L.hasSystemFeature('hostapd', '11be') && hwmodelist.be }
+			];
+
+			// Create a list of HT modes based on device capabilities
+			var htmodelist = L.toArray(data[0] ? data[0].getHTModes() : null)
+				.reduce(function(o, v) { o[v] = true; return o }, {});
+
+			this.htmodes = {
+				'': [ '', '-', { available: true } ],
+				'n': [
+					'HT20', '20 MHz', { available: htmodelist.HT20 },
+					'HT40', '40 MHz', { available: htmodelist.HT40 },
+					'VHT20', '20 MHz QAM-256', { available: htmodelist.VHT20 },
+					'VHT40', '40 MHz QAM-256', { available: htmodelist.VHT40 }
+				],
+				'ac': [
+					'VHT20', '20 MHz', { available: htmodelist.VHT20 },
+					'VHT40', '40 MHz', { available: htmodelist.VHT40 },
+					'VHT80', '80 MHz', { available: htmodelist.VHT80 },
+					'VHT160', '160 MHz', { available: htmodelist.VHT160 }
+				],
+				'ax': [
+					'HE20', '20 MHz', { available: htmodelist.HE20 },
+					'HE40', '40 MHz', { available: htmodelist.HE40 },
+					'HE80', '80 MHz', { available: htmodelist.HE80 },
+					'HE160', '160 MHz', { available: htmodelist.HE160 }
+				],
+				'be': [
+					'EHT20', '20 MHz', { available: htmodelist.EHT20 },
+					'EHT40', '40 MHz', { available: htmodelist.EHT40 },
+					'EHT80', '80 MHz', { available: htmodelist.EHT80 },
+					'EHT160', '160 MHz', { available: htmodelist.EHT160 },
+					'EHT320', '320 MHz', { available: htmodelist.EHT320 }
+				]
+			};
+
+			// Define available bands for widget selection based on channel availability
+			// AX and BE are available on 2/5/6G bands
+			this.bands = {
+				'': [
+					'2g', '2.4 GHz', { available: this.channels['2g'].length > 3 },
+					'5g', '5 GHz', { available: this.channels['5g'].length > 3 },
+					'60g', '60 GHz', { available: this.channels['60g'].length > 0 }
+				],
+				'n': [
+					'2g', '2.4 GHz', { available: this.channels['2g'].length > 3 },
+					'5g', '5 GHz', { available: this.channels['5g'].length > 3 }
+				],
+				'ac': [
+					'5g', '5 GHz', { available: true }
+				],
+				'ax': [
+					'2g', '2.4 GHz', { available: this.channels['2g'].length > 3 },
+					'5g', '5 GHz', { available: this.channels['5g'].length > 3 },
+					'6g', '6 GHz', { available: this.channels['6g'].length > 3 }
+				],
+				'be': [
+					'2g', '2.4 GHz', { available: this.channels['2g'].length > 3 },
+					'5g', '5 GHz', { available: this.channels['5g'].length > 3 },
+					'6g', '6 GHz', { available: this.channels['6g'].length > 3 }
+				]
+			};
+		}, this));
+	},
+
+	// Set values in the select element
+	setValues: function(sel, vals) {
+		if (sel.vals)
+			sel.vals.selected = sel.selectedIndex;
+
+		while (sel.options[0])
+			sel.remove(0);
+
+		for (var i = 0; vals && i < vals.length; i += 3)
+			if (vals[i+2] && vals[i+2].available)
+				sel.add(E('option', { value: vals[i+0] }, [ vals[i+1] ]));
+
+		if (vals && !isNaN(vals.selected))
+			sel.selectedIndex = vals.selected;
+
+		sel.parentNode.style.display = (sel.options.length <= 1) ? 'none' : '';
+		sel.vals = vals;
+	},
+
+	toggleWifiMode: function(elem) {
+		this.toggleWifiHTMode(elem);
+		this.toggleWifiBand(elem);
+	},
+
+	toggleWifiHTMode: function(elem) {
+		var mode = elem.querySelector('.mode');
+		var bwdt = elem.querySelector('.htmode');
+
+		this.setValues(bwdt, this.htmodes[mode.value]);
+	},
+
+	toggleWifiBand: function(elem) {
+		var mode = elem.querySelector('.mode');
+		var band = elem.querySelector('.band');
+
+		this.setValues(band, this.bands[mode.value]);
+		this.toggleWifiChannel(elem);
+
+		this.map.checkDepends();
+	},
+
+	checkWifiChannelRestriction: function(elem) {
+		var band = elem.querySelector('.band'),
+		     chan = elem.querySelector('.channel'),
+		     restricted_chan = elem.querySelector('.restricted_channel'),
+		     channels = this.channels[band.value],
+		     no_outdoor;
+
+		if (chan.selectedIndex < 0)
+			return;
+
+		no_outdoor = channels[(chan.selectedIndex*3)+2].no_outdoor;
+		if (no_outdoor)
+			restricted_chan.style.display = '';
+		else
+			restricted_chan.style.display = 'none';
+	},
+
+	toggleWifiChannel: function(elem) {
+		var band = elem.querySelector('.band');
+		var chan = elem.querySelector('.channel');
+
+		this.setValues(chan, this.channels[band.value]);
+
+		this.map.checkDepends();
+		this.checkWifiChannelRestriction(elem);
+	},
+
+	setInitialValues: function(section_id, elem) {
+		var mode = elem.querySelector('.mode'),
+		    band = elem.querySelector('.band'),
+		    chan = elem.querySelector('.channel'),
+		    bwdt = elem.querySelector('.htmode'),
+		    htval = uci.get('wireless', section_id, 'htmode'),
+		    hwval = uci.get('wireless', section_id, 'hwmode'),
+		    chval = uci.get('wireless', section_id, 'channel'),
+		    bandval = uci.get('wireless', section_id, 'band');
+
+		this.setValues(mode, this.modes);
+
+		if (hwval != null) {
+			this.useBandOption = false;
+
+			if (/be/.test(mode.value))
+				band.value = '6g';
+			else if (/ax/.test(mode.value))
+				band.value = '5g';
+			else
+				band.value = '2g';
+		}
+		else {
+			this.useBandOption = true;
+
+			band.value = bandval;
+		}
+
+		this.toggleWifiBand(elem);
+
+		// Determine mode based on htmode value
+		if (/EHT20|EHT40|EHT80|EHT160|EHT320/.test(htval))
+			mode.value = 'be';		
+		else if (/HE20|HE40|HE80|HE160/.test(htval))
+			mode.value = 'ax';
+		else if (/VHT20|VHT40/.test(htval) && band.value == '2g')
+			mode.value = 'n';
+		else if (/VHT20|VHT40|VHT80|VHT160/.test(htval))
+			mode.value = 'ac';
+		else if (/HT20|HT40/.test(htval))
+			mode.value = 'n';
+		else
+			mode.value = '';
+
+		this.toggleWifiMode(elem);
+
+		bwdt.value = htval;
+		chan.value = chval || (chan.options[0] ? chan.options[0].value : 'auto');
+
+		this.checkWifiChannelRestriction(elem);
+
+		return elem;
+	},
+
+	renderWidget: function(section_id, option_index, cfgvalue) {
+		var elem = E('div');
+
+		dom.content(elem, [
+			E('div', { 'class' : 'restricted_channel', 'style': 'display:none'}, [
+				E('div', {'class': 'cbi-button alert-message warning disabled'}, _('Indoor Only Channel Selected'))
+			]),
+			E('label', { 'style': 'float:left; margin-right:3px' }, [
+				_('Mode'), E('br'),
+				E('select', {
+					'class': 'mode',
+					'style': 'width:auto',
+					'change': L.bind(this.toggleWifiMode, this, elem),
+					'disabled': (this.disabled != null) ? this.disabled : this.map.readonly
+				})
+			]),
+			E('label', { 'style': 'float:left; margin-right:3px' }, [
+				_('Band'), E('br'),
+				E('select', {
+					'class': 'band',
+					'style': 'width:auto',
+					'change': L.bind(this.toggleWifiBand, this, elem),
+					'disabled': (this.disabled != null) ? this.disabled : this.map.readonly
+				})
+			]),
+			E('label', { 'style': 'float:left; margin-right:3px' }, [
+				_('Channel'), E('br'),
+				E('select', {
+					'class': 'channel',
+					'style': 'width:auto',
+					'change': L.bind(this.toggleWifiChannel, this, elem),
+					'disabled': (this.disabled != null) ? this.disabled : this.map.readonly
+				})
+			]),
+			E('label', { 'style': 'float:left; margin-right:3px' }, [
+				_('Width'), E('br'),
+				E('select', {
+					'class': 'htmode',
+					'style': 'width:auto',
+					'change': L.bind(this.map.checkDepends, this.map),
+					'disabled': (this.disabled != null) ? this.disabled : this.map.readonly
+				})
+			]),
+			E('br', { 'style': 'clear:left' })
+		]);
+
+		return this.setInitialValues(section_id, elem);
+	},
+
+	cfgvalue: function(section_id) {
+		return [
+		    uci.get('wireless', section_id, 'htmode'),
+		    uci.get('wireless', section_id, 'hwmode') || uci.get('wireless', section_id, 'band'),
+		    uci.get('wireless', section_id, 'channel')
+		];
+	},
+
+	formvalue: function(section_id) {
+		var node = this.map.findElement('data-field', this.cbid(section_id));
+
+		return [
+		    node.querySelector('.htmode').value,
+		    node.querySelector('.band').value,
+ 			node.querySelector('.channel').value
+		];
+	},
+
+	write: function(section_id, value) {
+		uci.set('wireless', section_id, 'htmode', value[0] || null);
+
+		if (this.useBandOption)
+			uci.set('wireless', section_id, 'band', value[1]);
+		else
+			uci.set('wireless', section_id, 'hwmode', (value[1] == '2g') ? '11g' : '11a');
+
+		uci.set('wireless', section_id, 'channel', value[2]);
+	}
+});
+
+var CBIWifiTxPowerValue = form.ListValue.extend({
+	callTxPowerList: rpc.declare({
+		object: 'iwinfo',
+		method: 'txpowerlist',
+		params: [ 'device' ],
+		expect: { results: [] }
+	}),
+
+	load: function(section_id) {
+		return this.callTxPowerList(section_id).then(L.bind(function(pwrlist) {
+			this.powerval = this.wifiNetwork ? this.wifiNetwork.getTXPower() : null;
+			this.poweroff = this.wifiNetwork ? this.wifiNetwork.getTXPowerOffset() : null;
+
+			this.value('', _('driver default'));
+
+			for (var i = 0; i < pwrlist.length; i++)
+				this.value(pwrlist[i].dbm, '%d dBm (%d mW)'.format(pwrlist[i].dbm, pwrlist[i].mw));
+
+			return form.ListValue.prototype.load.apply(this, [section_id]);
+		}, this));
+	},
+
+	renderWidget: function(section_id, option_index, cfgvalue) {
+		var widget = form.ListValue.prototype.renderWidget.apply(this, [section_id, option_index, cfgvalue]);
+		    widget.firstElementChild.style.width = 'auto';
+
+		dom.append(widget, E('span', [
+			' - ', _('Current power'), ': ',
+			E('span', [ this.powerval != null ? '%d dBm'.format(this.powerval) : E('em', _('unknown')) ]),
+			this.poweroff ? ' + %d dB offset = %s dBm'.format(this.poweroff, this.powerval != null ? this.powerval + this.poweroff : '?') : ''
+		]));
+
+		return widget;
+	}
+});
+
+var CBIWifiCountryValue = form.Value.extend({
+	callCountryList: rpc.declare({
+		object: 'iwinfo',
+		method: 'countrylist',
+		params: [ 'device' ],
+		expect: { results: [] }
+	}),
+
+	load: function(section_id) {
+		return this.callCountryList(section_id).then(L.bind(function(countrylist) {
+			if (Array.isArray(countrylist) && countrylist.length > 0) {
+				this.value('', _('driver default'));
+
+				for (var i = 0; i < countrylist.length; i++)
+					this.value(countrylist[i].iso3166, '%s - %s'.format(countrylist[i].iso3166, countrylist[i].country));
+			}
+
+			return form.Value.prototype.load.apply(this, [section_id]);
+		}, this));
+	},
+
+	validate: function(section_id, formvalue) {
+		if (formvalue != null && formvalue != '' && !/^[A-Z0-9][A-Z0-9]$/.test(formvalue))
+			return _('Use ISO/IEC 3166 alpha2 country codes.');
+
+		return true;
+	},
+
+	renderWidget: function(section_id, option_index, cfgvalue) {
+		var typeClass = (this.keylist && this.keylist.length) ? form.ListValue : form.Value;
+		return typeClass.prototype.renderWidget.apply(this, [section_id, option_index, cfgvalue]);
+	}
+});
+
+return view.extend({
+	poll_status: function(map, data) {
+		var rows = map.querySelectorAll('.cbi-section-table-row[data-sid]');
+
+		for (var i = 0; i < rows.length; i++) {
+			var section_id = rows[i].getAttribute('data-sid'),
+			    radioDev = data[1].filter(function(d) { return d.getName() == section_id })[0],
+			    radioNet = data[2].filter(function(n) { return n.getName() == section_id })[0],
+			    badge = rows[i].querySelector('[data-name="_badge"] > div'),
+			    stat = rows[i].querySelector('[data-name="_stat"]'),
+			    btns = rows[i].querySelectorAll('.cbi-section-actions button'),
+			    busy = btns[0].classList.contains('spinning') || btns[1].classList.contains('spinning') || btns[2].classList.contains('spinning');
+
+			if (radioDev) {
+				dom.content(badge, render_radio_badge(radioDev));
+				dom.content(stat, render_radio_status(radioDev, data[2].filter(function(n) { return n.getWifiDeviceName() == radioDev.getName() })));
+			}
+			else {
+				dom.content(badge, render_network_badge(radioNet));
+				dom.content(stat, render_network_status(radioNet));
+			}
+
+			if (stat.hasAttribute('restart'))
+				dom.content(stat, E('em', _('Device is restarting…')));
+
+			btns[0].disabled = isReadonlyView || busy;
+			btns[1].disabled = (isReadonlyView && radioDev) || busy;
+			btns[2].disabled = isReadonlyView || busy;
+		}
+
+		var table = document.querySelector('#wifi_assoclist_table'),
+		    hosts = data[0],
+		    trows = [];
+
+		for (var i = 0; i < data[3].length; i++) {
+			var bss = data[3][i],
+			    name = hosts.getHostnameByMACAddr(bss.mac),
+			    ipv4 = hosts.getIPAddrByMACAddr(bss.mac),
+			    ipv6 = hosts.getIP6AddrByMACAddr(bss.mac);
+
+			var hint;
+
+			if (name && ipv4 && ipv6)
+				hint = '%s <span class="hide-xs">(%s, %s)</span>'.format(name, ipv4, ipv6);
+			else if (name && (ipv4 || ipv6))
+				hint = '%s <span class="hide-xs">(%s)</span>'.format(name, ipv4 || ipv6);
+			else
+				hint = name || ipv4 || ipv6 || '?';
+
+			var row = [
+				E('span', {
+					'class': 'ifacebadge',
+					'data-ifname': bss.network.getIfname(),
+					'data-ssid': bss.network.getSSID()
+				}, [
+					E('img', {
+						'src': L.resource('icons/wifi%s.png').format(bss.network.isUp() ? '' : '_disabled'),
+						'title': bss.radio.getI18n()
+					}),
+					E('span', [
+						' %s '.format(bss.network.getShortName()),
+						E('small', '(%s)'.format(bss.network.getIfname()))
+					])
+				]),
+				bss.mac,
+				hint,
+				render_signal_badge(Math.min((bss.signal + 110) / 70 * 100, 100), bss.signal, bss.noise),
+				E('span', {}, [
+					E('span', format_wifirate(bss.rx)),
+					E('br'),
+					E('span', format_wifirate(bss.tx))
+				])
+			];
+
+			if (bss.network.isClientDisconnectSupported()) {
+				if (table.firstElementChild.childNodes.length < 6)
+					table.firstElementChild.appendChild(E('th', { 'class': 'th cbi-section-actions'}));
+
+				row.push(E('button', {
+					'class': 'cbi-button cbi-button-remove',
+					'click': L.bind(function(net, mac, ev) {
+						dom.parent(ev.currentTarget, '.tr').style.opacity = 0.5;
+						ev.currentTarget.classList.add('spinning');
+						ev.currentTarget.disabled = true;
+						ev.currentTarget.blur();
+
+						net.disconnectClient(mac, true, 5, 60000);
+					}, this, bss.network, bss.mac),
+					'disabled': isReadonlyView || null
+				}, [ _('Disconnect') ]));
+			}
+			else {
+				row.push('-');
+			}
+
+			trows.push(row);
+		}
+
+		cbi_update_table(table, trows, E('em', _('No information available')));
+
+		var stat = document.querySelector('.cbi-modal [data-name="_wifistat_modal"] .ifacebadge.large');
+
+		if (stat)
+			render_modal_status(stat, data[2].filter(function(n) { return n.getName() == stat.getAttribute('data-network') })[0]);
+
+		return network.flushCache();
+	},
+
+	load: function() {
+		return Promise.all([
+			uci.changes(),
+			uci.load('wireless'),
+			uci.load('system')
+		]);
+	},
+
+	checkAnonymousSections: function() {
+		var wifiIfaces = uci.sections('wireless', 'wifi-iface');
+
+		for (var i = 0; i < wifiIfaces.length; i++)
+			if (wifiIfaces[i]['.anonymous'])
+				return true;
+
+		return false;
+	},
+
+	callUciRename: rpc.declare({
+		object: 'uci',
+		method: 'rename',
+		params: [ 'config', 'section', 'name' ]
+	}),
+
+	render: function() {
+		if (this.checkAnonymousSections())
+			return this.renderMigration();
+		else
+			return this.renderOverview();
+	},
+
+	handleMigration: function(ev) {
+		var wifiIfaces = uci.sections('wireless', 'wifi-iface'),
+		    id_offset = 0,
+		    tasks = [];
+
+		for (var i = 0; i < wifiIfaces.length; i++) {
+			if (!wifiIfaces[i]['.anonymous'])
+				continue;
+
+			var new_name = next_free_sid(id_offset);
+
+			tasks.push(this.callUciRename('wireless', wifiIfaces[i]['.name'], new_name));
+			id_offset = +new_name.substring(7) + 1;
+		}
+
+		return Promise.all(tasks)
+			.then(L.bind(ui.changes.init, ui.changes))
+			.then(L.bind(ui.changes.apply, ui.changes));
+	},
+
+	renderMigration: function() {
+		ui.showModal(_('Wireless configuration migration'), [
+			E('p', _('The existing wireless configuration needs to be changed for LuCI to function properly.')),
+			E('p', _('Upon pressing "Continue", anonymous "wifi-iface" sections will be assigned with a name in the form <em>wifinet#</em> and the network will be restarted to apply the updated configuration.')),
+			E('div', { 'class': 'right' },
+				E('button', {
+					'class': 'btn cbi-button-action important',
+					'click': ui.createHandlerFn(this, 'handleMigration')
+				}, _('Continue')))
+		]);
+	},
+
+	renderOverview: function() {
+		var m, s, o;
+
+		m = new form.Map('wireless');
+		m.chain('network');
+		m.chain('firewall');
+
+		s = m.section(form.GridSection, 'wifi-device', _('Wireless Overview'));
+		s.anonymous = true;
+		s.addremove = false;
+
+		s.load = function() {
+			return network.getWifiDevices().then(L.bind(function(radios) {
+				this.radios = radios.sort(function(a, b) {
+					return a.getName() > b.getName();
+				});
+
+				var tasks = [];
+
+				for (var i = 0; i < radios.length; i++)
+					tasks.push(radios[i].getWifiNetworks());
+
+				return Promise.all(tasks);
+			}, this)).then(L.bind(function(data) {
+				this.wifis = [];
+
+				for (var i = 0; i < data.length; i++)
+					this.wifis.push.apply(this.wifis, data[i]);
+			}, this));
+		};
+
+		s.cfgsections = function() {
+			var rv = [];
+
+			for (var i = 0; i < this.radios.length; i++) {
+				rv.push(this.radios[i].getName());
+
+				for (var j = 0; j < this.wifis.length; j++)
+					if (this.wifis[j].getWifiDeviceName() == this.radios[i].getName())
+						rv.push(this.wifis[j].getName());
+			}
+
+			return rv;
+		};
+
+		s.modaltitle = function(section_id) {
+			var radioNet = this.wifis.filter(function(w) { return w.getName() == section_id})[0];
+			return radioNet ? radioNet.getI18n() : _('Edit wireless network');
+		};
+
+		s.lookupRadioOrNetwork = function(section_id) {
+			var radioDev = this.radios.filter(function(r) { return r.getName() == section_id })[0];
+			if (radioDev)
+				return radioDev;
+
+			var radioNet = this.wifis.filter(function(w) { return w.getName() == section_id })[0];
+			if (radioNet)
+				return radioNet;
+
+			return null;
+		};
+
+		s.renderRowActions = function(section_id) {
+			var inst = this.lookupRadioOrNetwork(section_id), btns;
+
+			if (inst.getWifiNetworks) {
+				btns = [
+					E('button', {
+						'class': 'cbi-button cbi-button-neutral',
+						'title': _('Restart radio interface'),
+						'click': ui.createHandlerFn(this, radio_restart, section_id)
+					}, _('Restart')),
+					E('button', {
+						'class': 'cbi-button cbi-button-action important',
+						'title': _('Find and join network'),
+						'click': ui.createHandlerFn(this, 'handleScan', inst)
+					}, _('Scan')),
+					E('button', {
+						'class': 'cbi-button cbi-button-add',
+						'title': _('Provide new network'),
+						'click': ui.createHandlerFn(this, 'handleAdd', inst)
+					}, _('Add'))
+				];
+			}
+			else {
+				var isDisabled = (inst.get('disabled') == '1' ||
+					uci.get('wireless', inst.getWifiDeviceName(), 'disabled') == '1');
+
+				btns = [
+					E('button', {
+						'class': 'cbi-button cbi-button-neutral enable-disable',
+						'title': isDisabled ? _('Enable this network') : _('Disable this network'),
+						'click': ui.createHandlerFn(this, network_updown, section_id, this.map)
+					}, isDisabled ? _('Enable') : _('Disable')),
+					E('button', {
+						'class': 'cbi-button cbi-button-action important',
+						'title': _('Edit this network'),
+						'click': ui.createHandlerFn(this, 'renderMoreOptionsModal', section_id)
+					}, _('Edit')),
+					E('button', {
+						'class': 'cbi-button cbi-button-negative remove',
+						'title': _('Delete this network'),
+						'click': ui.createHandlerFn(this, 'handleRemove', section_id)
+					}, _('Remove'))
+				];
+			}
+
+			return E('td', { 'class': 'td middle cbi-section-actions' }, E('div', btns));
+		};
+
+		s.addModalOptions = function(s) {
+			return network.getWifiNetwork(s.section).then(function(radioNet) {
+				var hwtype = uci.get('wireless', radioNet.getWifiDeviceName(), 'type');
+				var o, ss;
+
+				o = s.option(form.SectionValue, '_device', form.NamedSection, radioNet.getWifiDeviceName(), 'wifi-device', _('Device Configuration'));
+				o.modalonly = true;
+
+				ss = o.subsection;
+				ss.tab('general', _('General Setup'));
+				ss.tab('advanced', _('Advanced Settings'));
+
+				var isDisabled = (radioNet.get('disabled') == '1' ||
+					uci.get('wireless', radioNet.getWifiDeviceName(), 'disabled') == 1);
+
+				o = ss.taboption('general', form.DummyValue, '_wifistat_modal', _('Status'));
+				o.cfgvalue = L.bind(function(radioNet) {
+					return render_modal_status(null, radioNet);
+				}, this, radioNet);
+				o.write = function() {};
+
+				o = ss.taboption('general', form.Button, '_toggle', isDisabled ? _('Wireless network is disabled') : _('Wireless network is enabled'));
+				o.inputstyle = isDisabled ? 'apply' : 'reset';
+				o.inputtitle = isDisabled ? _('Enable') : _('Disable');
+				o.onclick = ui.createHandlerFn(s, network_updown, s.section, s.map);
+
+				o = ss.taboption('general', CBIWifiFrequencyValue, '_freq', '<br />' + _('Operating frequency'), _('Some channels may be restricted to Indoor Only use by your Regulatory Domain. Make sure to follow this advice if a channel is reported as such.'));
+				o.ucisection = s.section;
+
+				if (hwtype == 'mac80211') {
+					o = ss.taboption('general', form.Flag, 'legacy_rates', _('Allow legacy 802.11b rates'), _('Legacy or badly behaving devices may require legacy 802.11b rates to interoperate. Airtime efficiency may be significantly reduced where these are used. It is recommended to not allow 802.11b rates where possible.'));
+					o.depends({'_freq': '2g', '!contains': true});
+
+					o = ss.taboption('general', CBIWifiTxPowerValue, 'txpower', _('Maximum transmit power'), _('Specifies the maximum transmit power the wireless radio may use. Depending on regulatory requirements and wireless usage, the actual transmit power may be reduced by the driver.'));
+					o.wifiNetwork = radioNet;
+
+					o = ss.taboption('advanced', CBIWifiCountryValue, 'country', _('Country Code'));
+					o.wifiNetwork = radioNet;
+
+					o = ss.taboption('advanced', form.ListValue, 'cell_density', _('Coverage cell density'), _('Configures data rates based on the coverage cell density. Normal configures basic rates to 6, 12, 24 Mbps if legacy 802.11b rates are not used else to 5.5, 11 Mbps. High configures basic rates to 12, 24 Mbps if legacy 802.11b rates are not used else to the 11 Mbps rate. Very High configures 24 Mbps as the basic rate. Supported rates lower than the minimum basic rate are not offered.'));
+					o.value('0', _('Disabled'));
+					o.value('1', _('Normal'));
+					o.value('2', _('High'));
+					o.value('3', _('Very High'));
+
+					o = ss.taboption('advanced', form.Value, 'distance', _('Distance Optimization'), _('Distance to farthest network member in meters. Set only for distances above one kilometer; otherwise it is harmful.'));
+					o.datatype = 'or(range(0,114750),"auto")';
+					o.placeholder = 'auto';
+
+					o = ss.taboption('advanced', form.Value, 'frag', _('Fragmentation Threshold'));
+					o.datatype = 'min(256)';
+					o.placeholder = _('off');
+
+					o = ss.taboption('advanced', form.Value, 'rts', _('RTS/CTS Threshold'));
+					o.datatype = 'uinteger';
+					o.placeholder = _('off');
+
+					o = ss.taboption('advanced', form.Flag, 'noscan', _('Force 40MHz mode'), _('Always use 40MHz channels even if the secondary channel overlaps. Using this option does not comply with IEEE 802.11n-2009!'));
+					o.rmempty = true;
+
+					o = ss.taboption('advanced', form.Value, 'beacon_int', _('Beacon Interval'));
+					o.datatype = 'range(15,65535)';
+					o.placeholder = 100;
+					o.rmempty = true;
+				}
+
+
+				o = s.option(form.SectionValue, '_device', form.NamedSection, radioNet.getName(), 'wifi-iface', _('Interface Configuration'));
+				o.modalonly = true;
+
+				ss = o.subsection;
+				ss.tab('general', _('General Setup'));
+				ss.tab('encryption', _('Wireless Security'));
+				ss.tab('macfilter', _('MAC-Filter'));
+				ss.tab('advanced', _('Advanced Settings'));
+				ss.tab('roaming', _('WLAN roaming'), _('Settings for assisting wireless clients in roaming between multiple APs: 802.11r, 802.11k and 802.11v'));
+
+				o = ss.taboption('general', form.ListValue, 'mode', _('Mode'));
+				o.value('ap', _('Access Point'));
+				o.value('sta', _('Client'));
+				o.value('adhoc', _('Ad-Hoc'));
+
+				o = ss.taboption('general', form.Value, 'mesh_id', _('Mesh Id'));
+				o.depends('mode', 'mesh');
+
+				o = ss.taboption('advanced', form.Flag, 'mesh_fwding', _('Forward mesh peer traffic'));
+				o.rmempty = false;
+				o.default = '1';
+				o.depends('mode', 'mesh');
+
+				o = ss.taboption('advanced', form.Value, 'mesh_rssi_threshold', _('RSSI threshold for joining'), _('0 = not using RSSI threshold, 1 = do not change driver default'));
+				o.rmempty = false;
+				o.default = '0';
+				o.datatype = 'range(-255,1)';
+				o.depends('mode', 'mesh');
+
+				o = ss.taboption('general', form.Value, 'ssid', _('<abbr title="Extended Service Set Identifier">ESSID</abbr>'));
+				o.datatype = 'maxlength(32)';
+				o.depends('mode', 'ap');
+				o.depends('mode', 'sta');
+				o.depends('mode', 'adhoc');
+				o.depends('mode', 'ahdemo');
+				o.depends('mode', 'monitor');
+				o.depends('mode', 'ap-wds');
+				o.depends('mode', 'sta-wds');
+				o.depends('mode', 'wds');
+
+				o = ss.taboption('general', form.Value, 'bssid', _('<abbr title="Basic Service Set Identifier">BSSID</abbr>'));
+				o.datatype = 'macaddr';
+
+				o = ss.taboption('general', widgets.NetworkSelect, 'network', _('Network'), _('Choose the network(s) you want to attach to this wireless interface or fill out the <em>custom</em> field to define a new network.'));
+				o.rmempty = true;
+				o.multiple = true;
+				o.novirtual = true;
+				o.write = function(section_id, value) {
+					return network.getDevice(section_id).then(L.bind(function(dev) {
+						var old_networks = dev.getNetworks().reduce(function(o, v) { o[v.getName()] = v; return o }, {}),
+						    new_networks = {},
+						    values = L.toArray(value),
+						    tasks = [];
+
+						for (var i = 0; i < values.length; i++) {
+							new_networks[values[i]] = true;
+
+							if (old_networks[values[i]])
+								continue;
+
+							tasks.push(network.getNetwork(values[i]).then(L.bind(function(name, net) {
+								return net || network.addNetwork(name, { proto: 'none' });
+							}, this, values[i])).then(L.bind(function(dev, net) {
+								if (net) {
+									if (!net.isEmpty()) {
+										var target_dev = net.getDevice();
+
+										/* Resolve parent interface of vlan */
+										while (target_dev && target_dev.getType() == 'vlan')
+											target_dev = target_dev.getParent();
+
+										if (!target_dev || target_dev.getType() != 'bridge')
+											net.set('type', 'bridge');
+									}
+
+									net.addDevice(dev);
+								}
+							}, this, dev)));
+						}
+
+						for (var name in old_networks)
+							if (!new_networks[name])
+								tasks.push(network.getNetwork(name).then(L.bind(function(dev, net) {
+									if (net)
+										net.deleteDevice(dev);
+								}, this, dev)));
+
+						return Promise.all(tasks);
+					}, this));
+				};
+
+				if (hwtype == 'mac80211') {
+					var mode = ss.children[0],
+					    bssid = ss.children[5],
+					    encr;
+
+					mode.value('mesh', '802.11s');
+					mode.value('ahdemo', _('Pseudo Ad-Hoc (ahdemo)'));
+					mode.value('monitor', _('Monitor'));
+
+					bssid.depends('mode', 'adhoc');
+					bssid.depends('mode', 'sta');
+					bssid.depends('mode', 'sta-wds');
+
+					o = ss.taboption('macfilter', form.ListValue, 'macfilter', _('MAC Address Filter'));
+					o.depends('mode', 'ap');
+					o.depends('mode', 'ap-wds');
+					o.value('', _('disable'));
+					o.value('allow', _('Allow listed only'));
+					o.value('deny', _('Allow all except listed'));
+
+					o = ss.taboption('macfilter', form.DynamicList, 'maclist', _('MAC-List'));
+					o.datatype = 'macaddr';
+					o.retain = true;
+					o.depends('macfilter', 'allow');
+					o.depends('macfilter', 'deny');
+					o.load = function(section_id) {
+						return network.getHostHints().then(L.bind(function(hints) {
+							hints.getMACHints().map(L.bind(function(hint) {
+								this.value(hint[0], hint[1] ? '%s (%s)'.format(hint[0], hint[1]) : hint[0]);
+							}, this));
+
+							return form.DynamicList.prototype.load.apply(this, [section_id]);
+						}, this));
+					};
+
+					mode.value('ap-wds', '%s (%s)'.format(_('Access Point'), _('WDS')));
+					mode.value('sta-wds', '%s (%s)'.format(_('Client'), _('WDS')));
+
+					mode.write = function(section_id, value) {
+						switch (value) {
+						case 'ap-wds':
+							uci.set('wireless', section_id, 'mode', 'ap');
+							uci.set('wireless', section_id, 'wds', '1');
+							break;
+
+						case 'sta-wds':
+							uci.set('wireless', section_id, 'mode', 'sta');
+							uci.set('wireless', section_id, 'wds', '1');
+							break;
+
+						default:
+							uci.set('wireless', section_id, 'mode', value);
+							uci.unset('wireless', section_id, 'wds');
+							break;
+						}
+					};
+
+					mode.cfgvalue = function(section_id) {
+						var mode = uci.get('wireless', section_id, 'mode'),
+						    wds = uci.get('wireless', section_id, 'wds');
+
+						if (mode == 'ap' && wds)
+							return 'ap-wds';
+						else if (mode == 'sta' && wds)
+							return 'sta-wds';
+
+						return mode;
+					};
+
+					o = ss.taboption('general', form.Flag, 'hidden', _('Hide <abbr title="Extended Service Set Identifier">ESSID</abbr>'), _('Where the ESSID is hidden, clients may fail to roam and airtime efficiency may be significantly reduced.'));
+					o.depends('mode', 'ap');
+					o.depends('mode', 'ap-wds');
+
+					o = ss.taboption('general', form.Flag, 'wmm', _('WMM Mode'), _('Where Wi-Fi Multimedia (WMM) Mode QoS is disabled, clients may be limited to 802.11a/802.11g rates.'));
+					o.depends('mode', 'ap');
+					o.depends('mode', 'ap-wds');
+					o.default = o.enabled;
+
+					/* https://w1.fi/cgit/hostap/commit/?id=34f7c699a6bcb5c45f82ceb6743354ad79296078  */
+					/* multicast_to_unicast https://github.com/openwrt/openwrt/commit/7babb978ad9d7fc29acb1ff86afb1eb343af303a */
+					o = ss.taboption('advanced', form.Flag, 'multicast_to_unicast_all', _('Multi To Unicast'), _('ARP, IPv4 and IPv6 (even 802.1Q) with multicast destination MACs are unicast to the STA MAC address. Note: This is not Directed Multicast Service (DMS) in 802.11v. Note: might break receiver STA multicast expectations.'));
+					o.rmempty = true;
+
+					o = ss.taboption('advanced', form.Flag, 'isolate', _('Isolate Clients'), _('Prevents client-to-client communication'));
+					o.depends('mode', 'ap');
+					o.depends('mode', 'ap-wds');
+
+					o = ss.taboption('advanced', form.Value, 'ifname', _('Interface name'), _('Override default interface name'));
+					o.optional = true;
+					o.datatype = 'netdevname';
+					o.placeholder = radioNet.getIfname();
+					if (/^radio\d+\.network/.test(o.placeholder))
+						o.placeholder = '';
+
+					var macaddr = uci.get('wireless', radioNet.getName(), 'macaddr');
+					o = ss.taboption('advanced', form.Value, 'macaddr', _('MAC address'), _('Override default MAC address - the range of usable addresses might be limited by the driver'));
+					o.value('', _('driver default (%s)').format(!macaddr ? radioNet.getActiveBSSID() : _('no override')));
+					o.value('random', _('randomly generated'));
+					o.datatype = "or('random',macaddr)";
+
+					o = ss.taboption('advanced', form.Flag, 'short_preamble', _('Short Preamble'));
+					o.default = o.enabled;
+
+					o = ss.taboption('advanced', form.Value, 'dtim_period', _('DTIM Interval'), _('Delivery Traffic Indication Message Interval'));
+					o.optional = true;
+					o.placeholder = 2;
+					o.datatype = 'range(1,255)';
+
+					o = ss.taboption('advanced', form.Value, 'wpa_group_rekey', _('Time interval for rekeying GTK'), _('sec'));
+					o.optional    = true;
+					o.placeholder = 600;
+					o.datatype    = 'uinteger';
+
+					o = ss.taboption('advanced', form.Flag , 'skip_inactivity_poll', _('Disable Inactivity Polling'));
+					o.optional    = true;
+					o.datatype    = 'uinteger';
+
+					o = ss.taboption('advanced', form.Value, 'max_inactivity', _('Station inactivity limit'), _('802.11v: BSS Max Idle. Units: seconds.'));
+					o.optional    = true;
+					o.placeholder = 300;
+					o.datatype    = 'uinteger';
+
+					o = ss.taboption('advanced', form.Value, 'max_listen_interval', _('Maximum allowed Listen Interval'));
+					o.optional    = true;
+					o.placeholder = 65535;
+					o.datatype    = 'uinteger';
+
+					o = ss.taboption('advanced', form.Flag, 'disassoc_low_ack', _('Disassociate On Low Acknowledgement'), _('Allow AP mode to disconnect STAs based on low ACK condition'));
+					o.default = o.enabled;
+				}
+
+
+				encr = o = ss.taboption('encryption', form.ListValue, 'encryption', _('Encryption'));
+				o.depends('mode', 'ap');
+				o.depends('mode', 'sta');
+				o.depends('mode', 'adhoc');
+				o.depends('mode', 'ahdemo');
+				o.depends('mode', 'ap-wds');
+				o.depends('mode', 'sta-wds');
+				o.depends('mode', 'mesh');
+
+				o.cfgvalue = function(section_id) {
+					var v = String(uci.get('wireless', section_id, 'encryption'));
+					if (v == 'wep')
+						return 'wep-open';
+					else if (v.match(/\+/))
+						return v.replace(/\+.+$/, '');
+					return v;
+				};
+
+				o.write = function(section_id, value) {
+					var e = this.section.children.filter(function(o) { return o.option == 'encryption' })[0].formvalue(section_id),
+					    co = this.section.children.filter(function(o) { return o.option == 'cipher' })[0], c = co.formvalue(section_id);
+
+					if (value == 'wpa' || value == 'wpa2' || value == 'wpa3' || value == 'wpa3-mixed' || value == 'wpa3-192')
+						uci.unset('wireless', section_id, 'key');
+
+					if (co.isActive(section_id) && e && (c == 'tkip' || c == 'ccmp' || c == 'ccmp256' || c == 'gcmp' || c == 'gcmp256' || c == 'tkip+ccmp'))
+						e += '+' + c;
+
+					uci.set('wireless', section_id, 'encryption', e);
+				};
+
+				o = ss.taboption('encryption', form.ListValue, 'cipher', _('Cipher'));
+				o.depends('encryption', 'wpa');
+				o.depends('encryption', 'wpa2');
+				o.depends('encryption', 'wpa3');
+				o.depends('encryption', 'wpa3-mixed');
+				o.depends('encryption', 'wpa3-192');
+				o.depends('encryption', 'psk');
+				o.depends('encryption', 'psk2');
+				o.depends('encryption', 'wpa-mixed');
+				o.depends('encryption', 'psk-mixed');
+				o.value('auto', _('auto'));
+				o.value('ccmp', _('Force CCMP (AES)'));
+				o.value('ccmp256', _('Force CCMP-256 (AES)'));
+				o.value('gcmp', _('Force GCMP (AES)'));
+				o.value('gcmp256', _('Force GCMP-256 (AES)'));
+				o.value('tkip', _('Force TKIP'));
+				o.value('tkip+ccmp', _('Force TKIP and CCMP (AES)'));
+				o.write = ss.children.filter(function(o) { return o.option == 'encryption' })[0].write;
+
+				o.cfgvalue = function(section_id) {
+					var v = String(uci.get('wireless', section_id, 'encryption'));
+					if (v.match(/\+/)) {
+						v = v.replace(/^[^+]+\+/, '');
+						if (v == 'aes')
+							v = 'ccmp';
+						else if (v == 'tkip+aes' || v == 'aes+tkip' || v == 'ccmp+tkip')
+							v = 'tkip+ccmp';
+					}
+					return v;
+				};
+
+
+				var crypto_modes = [];
+
+				if (hwtype == 'mac80211') {
+					var has_supplicant = L.hasSystemFeature('wpasupplicant'),
+					    has_hostapd = L.hasSystemFeature('hostapd');
+
+					// Probe EAP support
+					var has_ap_eap = L.hasSystemFeature('hostapd', 'eap'),
+					    has_sta_eap = L.hasSystemFeature('wpasupplicant', 'eap');
+
+					// Probe SAE support
+					var has_ap_sae = L.hasSystemFeature('hostapd', 'sae'),
+					    has_sta_sae = L.hasSystemFeature('wpasupplicant', 'sae');
+
+					// Probe OWE support
+					var has_ap_owe = L.hasSystemFeature('hostapd', 'owe'),
+					    has_sta_owe = L.hasSystemFeature('wpasupplicant', 'owe');
+
+					// Probe Suite-B support
+					var has_ap_eap192 = L.hasSystemFeature('hostapd', 'suiteb192'),
+					    has_sta_eap192 = L.hasSystemFeature('wpasupplicant', 'suiteb192');
+
+					// Probe WEP support
+					var has_ap_wep = L.hasSystemFeature('hostapd', 'wep'),
+					    has_sta_wep = L.hasSystemFeature('wpasupplicant', 'wep');
+
+					if (has_hostapd || has_supplicant) {
+						crypto_modes.push(['psk2',      'WPA2-PSK',                    35]);
+						crypto_modes.push(['psk-mixed', 'WPA-PSK/WPA2-PSK Mixed Mode', 22]);
+						crypto_modes.push(['psk',       'WPA-PSK',                     12]);
+					}
+					else {
+						encr.description = _('WPA-Encryption requires wpa_supplicant (for client mode) or hostapd (for AP and ad-hoc mode) to be installed.');
+					}
+
+					if (has_ap_sae || has_sta_sae) {
+						crypto_modes.push(['sae',       'WPA3-SAE',                     31]);
+						crypto_modes.push(['sae-mixed', 'WPA2-PSK/WPA3-SAE Mixed Mode', 30]);
+					}
+
+					if (has_ap_wep || has_sta_wep) {
+						crypto_modes.push(['wep-open',   _('WEP Open System'), 11]);
+						crypto_modes.push(['wep-shared', _('WEP Shared Key'),  10]);
+					}
+
+					if (has_ap_eap || has_sta_eap) {
+						if (has_ap_eap192 || has_sta_eap192) {
+							crypto_modes.push(['wpa3', 'WPA3-EAP', 33]);
+							crypto_modes.push(['wpa3-mixed', 'WPA2-EAP/WPA3-EAP Mixed Mode', 32]);
+							crypto_modes.push(['wpa3-192', 'WPA3-EAP 192-bit Mode', 36]);
+						}
+
+						crypto_modes.push(['wpa2', 'WPA2-EAP', 34]);
+						crypto_modes.push(['wpa',  'WPA-EAP',  20]);
+					}
+
+					if (has_ap_owe || has_sta_owe) {
+						crypto_modes.push(['owe', 'OWE', 1]);
+					}
+
+					encr.crypto_support = {
+						'ap': {
+							'wep-open': has_ap_wep || _('Requires hostapd with WEP support'),
+							'wep-shared': has_ap_wep || _('Requires hostapd with WEP support'),
+							'psk': has_hostapd || _('Requires hostapd'),
+							'psk2': has_hostapd || _('Requires hostapd'),
+							'psk-mixed': has_hostapd || _('Requires hostapd'),
+							'sae': has_ap_sae || _('Requires hostapd with SAE support'),
+							'sae-mixed': has_ap_sae || _('Requires hostapd with SAE support'),
+							'wpa': has_ap_eap || _('Requires hostapd with EAP support'),
+							'wpa2': has_ap_eap || _('Requires hostapd with EAP support'),
+							'wpa3': has_ap_eap192 || _('Requires hostapd with EAP Suite-B support'),
+							'wpa3-mixed': has_ap_eap192 || _('Requires hostapd with EAP Suite-B support'),
+							'wpa3-192': has_ap_eap192 || _('Requires hostapd with EAP Suite-B support'),
+							'owe': has_ap_owe || _('Requires hostapd with OWE support')
+						},
+						'sta': {
+							'wep-open': has_sta_wep || _('Requires wpa-supplicant with WEP support'),
+							'wep-shared': has_sta_wep || _('Requires wpa-supplicant with WEP support'),
+							'psk': has_supplicant || _('Requires wpa-supplicant'),
+							'psk2': has_supplicant || _('Requires wpa-supplicant'),
+							'psk-mixed': has_supplicant || _('Requires wpa-supplicant'),
+							'sae': has_sta_sae || _('Requires wpa-supplicant with SAE support'),
+							'sae-mixed': has_sta_sae || _('Requires wpa-supplicant with SAE support'),
+							'wpa': has_sta_eap || _('Requires wpa-supplicant with EAP support'),
+							'wpa2': has_sta_eap || _('Requires wpa-supplicant with EAP support'),
+							'wpa3': has_sta_eap192 || _('Requires wpa-supplicant with EAP Suite-B support'),
+							'wpa3-mixed': has_sta_eap192 || _('Requires wpa-supplicant with EAP Suite-B support'),
+							'wpa3-192': has_sta_eap192 || _('Requires wpa-supplicant with EAP Suite-B support'),
+							'owe': has_sta_owe || _('Requires wpa-supplicant with OWE support')
+						},
+						'adhoc': {
+							'wep-open': true,
+							'wep-shared': true,
+							'psk': has_supplicant || _('Requires wpa-supplicant'),
+							'psk2': has_supplicant || _('Requires wpa-supplicant'),
+							'psk-mixed': has_supplicant || _('Requires wpa-supplicant'),
+						},
+						'mesh': {
+							'sae': has_sta_sae || _('Requires wpa-supplicant with SAE support')
+						},
+						'ahdemo': {
+							'wep-open': true,
+							'wep-shared': true
+						},
+						'wds': {
+							'wep-open': true,
+							'wep-shared': true
+						}
+					};
+
+					encr.crypto_support['ap-wds'] = encr.crypto_support['ap'];
+					encr.crypto_support['sta-wds'] = encr.crypto_support['sta'];
+
+					encr.validate = function(section_id, value) {
+						var modeopt = this.section.children.filter(function(o) { return o.option == 'mode' })[0],
+						    modeval = modeopt.formvalue(section_id),
+						    modetitle = modeopt.vallist[modeopt.keylist.indexOf(modeval)],
+						    enctitle = this.vallist[this.keylist.indexOf(value)];
+
+						if (value == 'none')
+							return true;
+
+						if (!L.isObject(this.crypto_support[modeval]) || !this.crypto_support[modeval].hasOwnProperty(value))
+							return _('The selected %s mode is incompatible with %s encryption').format(modetitle, enctitle);
+
+						return this.crypto_support[modeval][value];
+					};
+				}
+				else if (hwtype == 'broadcom') {
+					crypto_modes.push(['psk2',     'WPA2-PSK',                    33]);
+					crypto_modes.push(['psk+psk2', 'WPA-PSK/WPA2-PSK Mixed Mode', 22]);
+					crypto_modes.push(['psk',      'WPA-PSK',                     12]);
+					crypto_modes.push(['wep-open',   _('WEP Open System'),        11]);
+					crypto_modes.push(['wep-shared', _('WEP Shared Key'),         10]);
+				}
+
+				crypto_modes.push(['none',       _('No Encryption'),   0]);
+
+				crypto_modes.sort(function(a, b) { return b[2] - a[2] });
+
+				for (var i = 0; i < crypto_modes.length; i++) {
+					var security_level = (crypto_modes[i][2] >= 30) ? _('strong security')
+						: (crypto_modes[i][2] >= 20) ? _('medium security')
+							: (crypto_modes[i][2] >= 10) ? _('weak security') : _('open network');
+
+					encr.value(crypto_modes[i][0], '%s (%s)'.format(crypto_modes[i][1], security_level));
+				}
+
+
+				o = ss.taboption('encryption', form.Flag, 'ppsk', _('Enable Private PSK (PPSK)'), _('Private Pre-Shared Key (PPSK) allows the use of different Pre-Shared Key for each STA MAC address. Private MAC PSKs are stored on the RADIUS server.'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk', 'psk2', 'psk+psk2', 'psk-mixed'] });
+
+				o = ss.taboption('encryption', form.Value, 'auth_server', _('RADIUS Authentication Server'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk', 'psk2', 'psk+psk2', 'psk-mixed'], ppsk: ['1'] });
+				o.rmempty = true;
+				o.datatype = 'host(0)';
+
+				o = ss.taboption('encryption', form.Value, 'auth_port', _('RADIUS Authentication Port'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk', 'psk2', 'psk+psk2', 'psk-mixed'], ppsk: ['1'] });
+				o.rmempty = true;
+				o.datatype = 'port';
+				o.placeholder = '1812';
+
+				o = ss.taboption('encryption', form.Value, 'auth_secret', _('RADIUS Authentication Secret'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk', 'psk2', 'psk+psk2', 'psk-mixed'], ppsk: ['1'] });
+				o.rmempty = true;
+				o.password = true;
+
+				o = ss.taboption('encryption', form.Value, 'acct_server', _('RADIUS Accounting Server'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				o.rmempty = true;
+				o.datatype = 'host(0)';
+
+				o = ss.taboption('encryption', form.Value, 'acct_port', _('RADIUS Accounting Port'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				o.rmempty = true;
+				o.datatype = 'port';
+				o.placeholder = '1813';
+
+				o = ss.taboption('encryption', form.Value, 'acct_secret', _('RADIUS Accounting Secret'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				o.rmempty = true;
+				o.password = true;
+
+				/* extra RADIUS settings start */
+				var attr_validate = function(section_id, value) {
+					if (!value)
+						return true;
+
+					if (!/^[0-9]+(:s:.+|:d:[0-9]+|:x:([0-9a-zA-Z]{2})+)?$/.test(value) )
+						return _('Must be in %s format.').format('<attr_id>[:<syntax:value>]');
+
+					return true;
+				};
+
+				var req_attr_syntax = _('Format:') + '<code>&lt;attr_id&gt;[:&lt;syntax:value&gt;]</code>' + '<br />' +
+					'<code>syntax: s = %s; '.format(_('string (UTF-8)')) + 'd = %s; '.format(_('integer')) + 'x = %s</code>'.format(_('octet string'))
+
+				/* https://w1.fi/cgit/hostap/commit/?id=af35e7af7f8bb1ca9f0905b4074fb56a264aa12b */
+				o = ss.taboption('encryption', form.DynamicList, 'radius_auth_req_attr', _('RADIUS Access-Request attributes'),
+					_('Attributes to add/replace in each request.') + '<br />' + req_attr_syntax );
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				o.rmempty = true;
+				o.validate = attr_validate;
+				o.placeholder = '126:s:Operator';
+
+				o = ss.taboption('encryption', form.DynamicList, 'radius_acct_req_attr', _('RADIUS Accounting-Request attributes'),
+					_('Attributes to add/replace in each request.') + '<br />' + req_attr_syntax );
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				o.rmempty = true;
+				o.validate = attr_validate;
+				o.placeholder = '77:x:74657374696e67';
+
+				o = ss.taboption('encryption', form.ListValue, 'dynamic_vlan', _('RADIUS Dynamic VLAN Assignment'), _('Required: Rejects auth if RADIUS server does not provide appropriate VLAN attributes.'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk', 'psk2', 'psk+psk2', 'psk-mixed'], ppsk: ['1'] });
+				o.value('0', _('Disabled'));
+				o.value('1', _('Optional'));
+				o.value('2', _('Required'));
+				o.write = function (section_id, value) {
+					return this.super('write', [section_id, (value == 0) ? null: value]);
+				}
+
+				o = ss.taboption('encryption', form.Flag, 'per_sta_vif', _('RADIUS Per STA VLAN'), _('Each STA is assigned its own AP_VLAN interface.'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk', 'psk2', 'psk+psk2', 'psk-mixed'], ppsk: ['1'] });
+
+				//hostapd internally defaults to vlan_naming=1 even with dynamic VLAN off
+				o = ss.taboption('encryption', form.Flag, 'vlan_naming', _('RADIUS VLAN Naming'), _('Off: <code>vlanXXX</code>, e.g., <code>vlan1</code>. On: <code>vlan_tagged_interface.XXX</code>, e.g. <code>eth0.1</code>.'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk', 'psk2', 'psk+psk2', 'psk-mixed'], ppsk: ['1'] });
+
+				o = ss.taboption('encryption', widgets.DeviceSelect, 'vlan_tagged_interface', _('RADIUS VLAN Tagged Interface'), _('E.g. eth0, eth1'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk', 'psk2', 'psk+psk2', 'psk-mixed'], ppsk: ['1'] });
+				o.size = 1;
+				o.rmempty = true;
+				o.multiple = false;
+				o.noaliases = true;
+				o.nocreate = true;
+				o.noinactive = true;
+
+				o = ss.taboption('encryption', form.Value, 'vlan_bridge', _('RADIUS VLAN Bridge Naming Scheme'), _('E.g. <code>br-vlan</code> or <code>brvlan</code>.'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk', 'psk2', 'psk+psk2', 'psk-mixed'], ppsk: ['1'] });
+				o.rmempty = true;
+
+				/* extra RADIUS settings end */
+
+				o = ss.taboption('encryption', form.Value, 'dae_client', _('DAE-Client'), _('Dynamic Authorization Extension client.'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				o.rmempty = true;
+				o.datatype = 'host(0)';
+
+				o = ss.taboption('encryption', form.Value, 'dae_port', _('DAE-Port'), _('Dynamic Authorization Extension port.'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				o.rmempty = true;
+				o.datatype = 'port';
+				o.placeholder = '3799';
+
+				o = ss.taboption('encryption', form.Value, 'dae_secret', _('DAE-Secret'), _('Dynamic Authorization Extension secret.'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+				o.rmempty = true;
+				o.password = true;
+
+				//WPA(1) has only WPA IE. Only >= WPA2 has RSN IE Preauth frames.
+				o = ss.taboption('encryption', form.Flag, 'rsn_preauth', _('RSN Preauth'), _('Robust Security Network (RSN): Allow roaming preauth for WPA2-EAP networks (and advertise it in WLAN beacons). Only works if the specified network interface is a bridge. Shortens the time-critical reassociation process.'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa2', 'wpa3', 'wpa3-mixed'] });
+
+
+				o = ss.taboption('encryption', form.Value, '_wpa_key', _('Key'));
+				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk', 'psk2', 'psk+psk2', 'psk-mixed'], ppsk: ['0'] });
+				add_dependency_permutations(o, { mode: ['sta', 'adhoc', 'mesh', 'sta-wds'], encryption: ['psk', 'psk2', 'psk+psk2', 'psk-mixed'] });
+				o.depends('encryption', 'sae');
+				o.depends('encryption', 'sae-mixed');
+				o.datatype = 'wpakey';
+				o.rmempty = true;
+				o.password = true;
+
+				o.cfgvalue = function(section_id) {
+					var key = uci.get('wireless', section_id, 'key');
+					return /^[1234]$/.test(key) ? null : key;
+				};
+
+				o.write = function(section_id, value) {
+					uci.set('wireless', section_id, 'key', value);
+					uci.unset('wireless', section_id, 'key1');
+					uci.unset('wireless', section_id, 'key2');
+					uci.unset('wireless', section_id, 'key3');
+					uci.unset('wireless', section_id, 'key4');
+				};
+
+
+				o = ss.taboption('encryption', form.ListValue, '_wep_key', _('Used Key Slot'));
+				o.depends('encryption', 'wep-open');
+				o.depends('encryption', 'wep-shared');
+				o.value('1', _('Key #%d').format(1));
+				o.value('2', _('Key #%d').format(2));
+				o.value('3', _('Key #%d').format(3));
+				o.value('4', _('Key #%d').format(4));
+
+				o.cfgvalue = function(section_id) {
+					var slot = +uci.get('wireless', section_id, 'key');
+					return (slot >= 1 && slot <= 4) ? String(slot) : '';
+				};
+
+				o.write = function(section_id, value) {
+					uci.set('wireless', section_id, 'key', value);
+				};
+
+				for (var slot = 1; slot <= 4; slot++) {
+					o = ss.taboption('encryption', form.Value, 'key%d'.format(slot), _('Key #%d').format(slot));
+					o.depends('encryption', 'wep-open');
+					o.depends('encryption', 'wep-shared');
+					o.datatype = 'wepkey';
+					o.rmempty = true;
+					o.password = true;
+
+					o.write = function(section_id, value) {
+						if (value != null && (value.length == 5 || value.length == 13))
+							value = 's:%s'.format(value);
+						uci.set('wireless', section_id, this.option, value);
+					};
+				}
+
+
+				if (hwtype == 'mac80211') {
+					// Probe 802.11r support (and EAP support as a proxy for Openwrt)
+					var has_80211r = L.hasSystemFeature('hostapd', '11r') || L.hasSystemFeature('hostapd', 'eap');
+
+					o = ss.taboption('roaming', form.Flag, 'ieee80211r', _('802.11r Fast Transition'), _('Enables fast roaming among access points that belong to the same Mobility Domain'));
+					add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa2', 'wpa3', 'wpa3-mixed', , 'wpa3-192'] });
+					if (has_80211r)
+						add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk2', 'psk-mixed', 'sae', 'sae-mixed'] });
+					o.rmempty = true;
+
+					o = ss.taboption('roaming', form.Value, 'nasid', _('NAS ID'), _('Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not needed with normal WPA(2)-PSK.'));
+					add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+					o.depends({ ieee80211r: '1' });
+					o.rmempty = true;
+
+					o = ss.taboption('roaming', form.Value, 'mobility_domain', _('Mobility Domain'), _('4-character hexadecimal ID'));
+					o.depends({ ieee80211r: '1' });
+					o.placeholder = '4f57';
+					o.datatype = 'and(hexstring,length(4))';
+					o.rmempty = true;
+
+					o = ss.taboption('roaming', form.Value, 'reassociation_deadline', _('Reassociation Deadline'), _('time units (TUs / 1.024 ms) [1000-65535]'));
+					o.depends({ ieee80211r: '1' });
+					o.placeholder = '1000';
+					o.datatype = 'range(1000,65535)';
+					o.rmempty = true;
+
+					o = ss.taboption('roaming', form.ListValue, 'ft_over_ds', _('FT protocol'));
+					o.depends({ ieee80211r: '1' });
+					o.value('0', _('FT over the Air'));
+					o.value('1', _('FT over DS'));
+					o.rmempty = true;
+
+					o = ss.taboption('roaming', form.Flag, 'ft_psk_generate_local', _('Generate PMK locally'), _('When using a PSK, the PMK can be automatically generated. When enabled, the R0/R1 key options below are not applied. Disable this to use the R0 and R1 key options.'));
+					add_dependency_permutations(o, { ieee80211r: ['1'], mode: ['ap', 'ap-wds'], encryption: ['psk2', 'psk-mixed'] });
+					o.default = o.enabled;
+					o.rmempty = false;
+
+					o = ss.taboption('roaming', form.Value, 'r0_key_lifetime', _('R0 Key Lifetime'), _('minutes'));
+					o.depends({ ieee80211r: '1' });
+					o.placeholder = '10000';
+					o.datatype = 'uinteger';
+					o.rmempty = true;
+
+					o = ss.taboption('roaming', form.Value, 'r1_key_holder', _('R1 Key Holder'), _('6-octet identifier as a hex string - no colons'));
+					o.depends({ ieee80211r: '1' });
+					o.placeholder = '00004f577274';
+					o.datatype = 'and(hexstring,length(12))';
+					o.rmempty = true;
+
+					o = ss.taboption('roaming', form.Flag, 'pmk_r1_push', _('PMK R1 Push'));
+					o.depends({ ieee80211r: '1' });
+					o.placeholder = '0';
+					o.rmempty = true;
+
+					o = ss.taboption('roaming', form.DynamicList, 'r0kh', _('External R0 Key Holder List'), _('List of R0KHs in the same Mobility Domain. <br />Format: MAC-address,NAS-Identifier,256-bit key as hex string. <br />This list is used to map R0KH-ID (NAS Identifier) to a destination MAC address when requesting PMK-R1 key from the R0KH that the STA used during the Initial Mobility Domain Association.'));
+					o.depends({ ieee80211r: '1' });
+					o.rmempty = true;
+
+					o = ss.taboption('roaming', form.DynamicList, 'r1kh', _('External R1 Key Holder List'), _ ('List of R1KHs in the same Mobility Domain. <br />Format: MAC-address,R1KH-ID as 6 octets with colons,256-bit key as hex string. <br />This list is used to map R1KH-ID to a destination MAC address when sending PMK-R1 key from the R0KH. This is also the list of authorized R1KHs in the MD that can request PMK-R1 keys.'));
+					o.depends({ ieee80211r: '1' });
+					o.rmempty = true;
+					// End of 802.11r options
+
+					// Probe 802.11k and 802.11v support via EAP support (full hostapd has EAP)
+					if (L.hasSystemFeature('hostapd', 'eap')) {
+						/* 802.11k settings start */
+						o = ss.taboption('roaming', form.Flag, 'ieee80211k', _('802.11k RRM'), _('Radio Resource Measurement - Sends beacons to assist roaming. Not all clients support this.'));
+						// add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk', 'psk2', 'psk-mixed', 'sae', 'sae-mixed'] });
+						o.depends('mode', 'ap');
+						o.depends('mode', 'ap-wds');
+
+						o = ss.taboption('roaming', form.Flag, 'rrm_neighbor_report', _('Neighbour Report'), _('802.11k: Enable neighbor report via radio measurements.'));
+						o.depends({ ieee80211k: '1' });
+						o.default = o.enabled;
+
+						o = ss.taboption('roaming', form.Flag, 'rrm_beacon_report', _('Beacon Report'), _('802.11k: Enable beacon report via radio measurements.'));
+						o.depends({ ieee80211k: '1' });
+						o.default = o.enabled;
+						/* 802.11k settings end */
+
+						/* 802.11v settings start */
+						o = ss.taboption('roaming', form.ListValue, 'time_advertisement', _('Time advertisement'), _('802.11v: Time Advertisement in management frames.'));
+						o.value('0', _('Disabled'));
+						o.value('2', _('Enabled'));
+						o.write = function (section_id, value) {
+							return this.super('write', [section_id, (value == 2) ? value: null]);
+						}
+
+						//Pull current System TZ setting
+						var tz = uci.get('system', '@system[0]', 'timezone');
+						o = ss.taboption('roaming', form.Value, 'time_zone', _('Time zone'), _('802.11v: Local Time Zone Advertisement in management frames.'));
+						o.value(tz);
+						o.rmempty = true;
+
+						o = ss.taboption('roaming', form.Flag, 'wnm_sleep_mode', _('WNM Sleep Mode'), _('802.11v: Wireless Network Management (WNM) Sleep Mode (extended sleep mode for stations).'));
+						o.rmempty = true;
+
+						/* wnm_sleep_mode_no_keys: https://git.openwrt.org/?p=openwrt/openwrt.git;a=commitdiff;h=bf98faaac8ed24cf7d3d93dd4fcd7304d109363b */
+						o = ss.taboption('roaming', form.Flag, 'wnm_sleep_mode_no_keys', _('WNM Sleep Mode Fixes'), _('802.11v: Wireless Network Management (WNM) Sleep Mode Fixes: Prevents reinstallation attacks.'));
+						o.rmempty = true;
+
+						o = ss.taboption('roaming', form.Flag, 'bss_transition', _('BSS Transition'), _('802.11v: Basic Service Set (BSS) transition management.'));
+						o.rmempty = true;
+
+						/* in master, but not 21.02.1: proxy_arp */
+						o = ss.taboption('roaming', form.Flag, 'proxy_arp', _('ProxyARP'), _('802.11v: Proxy ARP enables non-AP STA to remain in power-save for longer.'));
+						o.rmempty = true;
+
+						/* TODO: na_mcast_to_ucast is missing: needs adding to hostapd.sh - nice to have */
+					}
+					/* 802.11v settings end */
+				}
+
+				if (hwtype == 'mac80211') {
+					o = ss.taboption('encryption', form.ListValue, 'eap_type', _('EAP-Method'));
+					o.value('tls',  'TLS');
+					o.value('ttls', 'TTLS');
+					o.value('peap', 'PEAP');
+					o.value('fast', 'FAST');
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+
+					o = ss.taboption('encryption', form.Flag, 'ca_cert_usesystem', _('Use system certificates'), _("Validate server certificate using built-in system CA bundle,<br />requires the \"ca-bundle\" package"));
+					o.enabled = '1';
+					o.disabled = '0';
+					o.default = o.disabled;
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+					o.validate = function(section_id, value) {
+						if (value == '1' && !L.hasSystemFeature('cabundle')) {
+							return _("This option cannot be used because the ca-bundle package is not installed.");
+						}
+						return true;
+					};
+
+					o = ss.taboption('encryption', form.FileUpload, 'ca_cert', _('Path to CA-Certificate'));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], ca_cert_usesystem: ['0'] });
+
+					o = ss.taboption('encryption', form.Value, 'subject_match', _('Certificate constraint (Subject)'), _("Certificate constraint substring - e.g. /CN=wifi.mycompany.com<br />See `logread -f` during handshake for actual values"));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+
+					o = ss.taboption('encryption', form.DynamicList, 'altsubject_match', _('Certificate constraint (SAN)'), _("Certificate constraint(s) via Subject Alternate Name values<br />(supported attributes: EMAIL, DNS, URI) - e.g. DNS:wifi.mycompany.com"));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+
+					o = ss.taboption('encryption', form.DynamicList, 'domain_match', _('Certificate constraint (Domain)'), _("Certificate constraint(s) against DNS SAN values (if available)<br />or Subject CN (exact match)"));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+
+					o = ss.taboption('encryption', form.DynamicList, 'domain_suffix_match', _('Certificate constraint (Wildcard)'), _("Certificate constraint(s) against DNS SAN values (if available)<br />or Subject CN (suffix match)"));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'] });
+
+					o = ss.taboption('encryption', form.FileUpload, 'client_cert', _('Path to Client-Certificate'));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], eap_type: ['tls'] });
+
+					o = ss.taboption('encryption', form.FileUpload, 'priv_key', _('Path to Private Key'));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], eap_type: ['tls'] });
+
+					o = ss.taboption('encryption', form.Value, 'priv_key_pwd', _('Password of Private Key'));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], eap_type: ['tls'] });
+					o.password = true;
+
+					o = ss.taboption('encryption', form.ListValue, 'auth', _('Authentication'));
+					o.value('PAP', 'PAP');
+					o.value('CHAP', 'CHAP');
+					o.value('MSCHAP', 'MSCHAP');
+					o.value('MSCHAPV2', 'MSCHAPv2');
+					o.value('EAP-GTC', 'EAP-GTC');
+					o.value('EAP-MD5', 'EAP-MD5');
+					o.value('EAP-MSCHAPV2', 'EAP-MSCHAPv2');
+					o.value('EAP-TLS', 'EAP-TLS');
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], eap_type: ['fast', 'peap', 'ttls'] });
+
+					o.validate = function(section_id, value) {
+						var eo = this.section.children.filter(function(o) { return o.option == 'eap_type' })[0],
+						    ev = eo.formvalue(section_id);
+
+						if (ev != 'ttls' && (value == 'PAP' || value == 'CHAP' || value == 'MSCHAP' || value == 'MSCHAPV2'))
+							return _('This authentication type is not applicable to the selected EAP method.');
+
+						return true;
+					};
+
+					o = ss.taboption('encryption', form.Flag, 'ca_cert2_usesystem', _('Use system certificates for inner-tunnel'), _("Validate server certificate using built-in system CA bundle,<br />requires the \"ca-bundle\" package"));
+					o.enabled = '1';
+					o.disabled = '0';
+					o.default = o.disabled;
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], auth: ['EAP-TLS'] });
+					o.validate = function(section_id, value) {
+						if (value == '1' && !L.hasSystemFeature('cabundle')) {
+							return _("This option cannot be used because the ca-bundle package is not installed.");
+						}
+						return true;
+					};
+
+					o = ss.taboption('encryption', form.FileUpload, 'ca_cert2', _('Path to inner CA-Certificate'));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], auth: ['EAP-TLS'], ca_cert2_usesystem: ['0'] });
+
+					o = ss.taboption('encryption', form.Value, 'subject_match2', _('Inner certificate constraint (Subject)'), _("Certificate constraint substring - e.g. /CN=wifi.mycompany.com<br />See `logread -f` during handshake for actual values"));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], auth: ['EAP-TLS'] });
+
+					o = ss.taboption('encryption', form.DynamicList, 'altsubject_match2', _('Inner certificate constraint (SAN)'), _("Certificate constraint(s) via Subject Alternate Name values<br />(supported attributes: EMAIL, DNS, URI) - e.g. DNS:wifi.mycompany.com"));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], auth: ['EAP-TLS'] });
+
+					o = ss.taboption('encryption', form.DynamicList, 'domain_match2', _('Inner certificate constraint (Domain)'), _("Certificate constraint(s) against DNS SAN values (if available)<br />or Subject CN (exact match)"));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], auth: ['EAP-TLS'] });
+
+					o = ss.taboption('encryption', form.DynamicList, 'domain_suffix_match2', _('Inner certificate constraint (Wildcard)'), _("Certificate constraint(s) against DNS SAN values (if available)<br />or Subject CN (suffix match)"));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], auth: ['EAP-TLS'] });
+
+					o = ss.taboption('encryption', form.FileUpload, 'client_cert2', _('Path to inner Client-Certificate'));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], auth: ['EAP-TLS'] });
+
+					o = ss.taboption('encryption', form.FileUpload, 'priv_key2', _('Path to inner Private Key'));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], auth: ['EAP-TLS'] });
+
+					o = ss.taboption('encryption', form.Value, 'priv_key2_pwd', _('Password of inner Private Key'));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], auth: ['EAP-TLS'] });
+					o.password = true;
+
+					o = ss.taboption('encryption', form.Value, 'identity', _('Identity'));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], eap_type: ['fast', 'peap', 'tls', 'ttls'] });
+
+					o = ss.taboption('encryption', form.Value, 'anonymous_identity', _('Anonymous Identity'));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], eap_type: ['fast', 'peap', 'tls', 'ttls'] });
+
+					o = ss.taboption('encryption', form.Value, 'password', _('Password'));
+					add_dependency_permutations(o, { mode: ['sta', 'sta-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed', 'wpa3-192'], eap_type: ['fast', 'peap', 'ttls'] });
+					o.password = true;
+
+
+					if (hwtype == 'mac80211') {
+						// ieee802.11w options
+						o = ss.taboption('encryption', form.ListValue, 'ieee80211w', _('802.11w Management Frame Protection'), _("Note: Some wireless drivers do not fully support 802.11w. E.g. mwlwifi may have problems"));
+						o.value('0', _('Disabled'));
+						o.value('1', _('Optional'));
+						o.value('2', _('Required'));
+						add_dependency_permutations(o, { mode: ['ap', 'ap-wds', 'sta', 'sta-wds'], encryption: ['owe', 'psk2', 'psk-mixed', 'sae', 'sae-mixed', 'wpa2', 'wpa3', 'wpa3-mixed'] });
+
+						o.defaults = {
+							'2': [{ encryption: 'sae' }, { encryption: 'owe' }, { encryption: 'wpa3' }, { encryption: 'wpa3-mixed' }],
+							'1': [{ encryption: 'sae-mixed'}],
+							'0': []
+						};
+
+						o.write = function(section_id, value) {
+							if (value != this.default)
+								return form.ListValue.prototype.write.call(this, section_id, value);
+							else
+								return form.ListValue.prototype.remove.call(this, section_id);
+						};
+
+						o = ss.taboption('encryption', form.Value, 'ieee80211w_max_timeout', _('802.11w maximum timeout'), _('802.11w Association SA Query maximum timeout'));
+						o.depends('ieee80211w', '1');
+						o.depends('ieee80211w', '2');
+						o.datatype = 'uinteger';
+						o.placeholder = '1000';
+						o.rmempty = true;
+
+						o = ss.taboption('encryption', form.Value, 'ieee80211w_retry_timeout', _('802.11w retry timeout'), _('802.11w Association SA Query retry timeout'));
+						o.depends('ieee80211w', '1');
+						o.depends('ieee80211w', '2');
+						o.datatype = 'uinteger';
+						o.placeholder = '201';
+						o.rmempty = true;
+
+						if (L.hasSystemFeature('hostapd', 'ocv') || L.hasSystemFeature('wpasupplicant', 'ocv')) {
+							o = ss.taboption('encryption', form.ListValue, 'ocv', _('Operating Channel Validation'), _("Note: Workaround mode allows a STA that claims OCV capability to connect even if the STA doesn't send OCI or negotiate PMF."));
+							o.value('0', _('Disabled'));
+							o.value('1', _('Enabled'));
+							o.value('2', _('Enabled (workaround mode)'));
+							o.default = '0';
+							o.depends('ieee80211w', '1');
+							o.depends('ieee80211w', '2');
+
+							o.validate = function(section_id, value) {
+								var modeopt = this.section.children.filter(function(o) { return o.option == 'mode' })[0],
+								modeval = modeopt.formvalue(section_id);
+
+								if ((value == '2') && ((modeval == 'sta') || (modeval == 'sta-wds'))) {
+									return _('Workaround mode can only be used when acting as an access point.');
+								}
+
+								return true;
+							}
+						}
+
+						o = ss.taboption('encryption', form.Flag, 'wpa_disable_eapol_key_retries', _('Enable key reinstallation (KRACK) countermeasures'), _('Complicates key reinstallation attacks on the client side by disabling retransmission of EAPOL-Key frames that are used to install keys. This workaround might cause interoperability issues and reduced robustness of key negotiation especially in environments with heavy traffic load.'));
+						add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['psk2', 'psk-mixed', 'sae', 'sae-mixed', 'wpa2', 'wpa3', 'wpa3-mixed'] });
+
+						if (L.hasSystemFeature('hostapd', 'wps') && L.hasSystemFeature('wpasupplicant')) {
+							o = ss.taboption('encryption', form.Flag, 'wps_pushbutton', _('Enable WPS pushbutton, requires WPA(2)-PSK/WPA3-SAE'))
+							o.enabled = '1';
+							o.disabled = '0';
+							o.default = o.disabled;
+							o.depends('encryption', 'psk');
+							o.depends('encryption', 'psk2');
+							o.depends('encryption', 'psk-mixed');
+							o.depends('encryption', 'sae');
+							o.depends('encryption', 'sae-mixed');
+						}
+					}
+				}
+			});
+		};
+
+		s.handleRemove = function(section_id, ev) {
+			document.querySelector('.cbi-section-table-row[data-sid="%s"]'.format(section_id)).style.opacity = 0.5;
+			return form.TypedSection.prototype.handleRemove.apply(this, [section_id, ev]);
+		};
+
+		s.handleScan = function(radioDev, ev) {
+			var table = E('table', { 'class': 'table' }, [
+				E('tr', { 'class': 'tr table-titles' }, [
+					E('th', { 'class': 'th col-2 middle center' }, _('Signal')),
+					E('th', { 'class': 'th col-4 middle left' }, _('SSID')),
+					E('th', { 'class': 'th col-2 middle center hide-xs' }, _('Channel')),
+					E('th', { 'class': 'th col-2 middle left hide-xs' }, _('Mode')),
+					E('th', { 'class': 'th col-3 middle left hide-xs' }, _('BSSID')),
+					E('th', { 'class': 'th col-3 middle left' }, _('Encryption')),
+					E('th', { 'class': 'th cbi-section-actions right' }, ' '),
+				])
+			]);
+
+			var stop = E('button', {
+				'class': 'btn',
+				'click': L.bind(this.handleScanStartStop, this),
+				'style': 'display:none',
+				'data-state': 'stop'
+			}, _('Stop refresh'));
+
+			cbi_update_table(table, [], E('em', { class: 'spinning' }, _('Starting wireless scan...')));
+
+			var md = ui.showModal(_('Join Network: Wireless Scan'), [
+				table,
+				E('div', { 'class': 'right' }, [
+					stop,
+					' ',
+					E('button', {
+						'class': 'btn',
+						'click': L.bind(this.handleScanAbort, this)
+					}, _('Dismiss'))
+				])
+			]);
+
+			md.style.maxWidth = '90%';
+			md.style.maxHeight = 'none';
+
+			this.pollFn = L.bind(this.handleScanRefresh, this, radioDev, {}, table, stop);
+
+			poll.add(this.pollFn);
+			poll.start();
+		};
+
+		s.handleScanRefresh = function(radioDev, scanCache, table, stop) {
+			return radioDev.getScanList().then(L.bind(function(results) {
+				var rows = [];
+
+				for (var i = 0; i < results.length; i++)
+					scanCache[results[i].bssid] = results[i];
+
+				for (var k in scanCache)
+					if (scanCache[k].stale)
+						results.push(scanCache[k]);
+
+				results.sort(function(a, b) {
+					var diff = (b.quality - a.quality) || (a.channel - b.channel);
+
+					if (diff)
+						return diff;
+
+					if (a.ssid < b.ssid)
+						return -1;
+					else if (a.ssid > b.ssid)
+						return 1;
+
+					if (a.bssid < b.bssid)
+						return -1;
+					else if (a.bssid > b.bssid)
+						return 1;
+				});
+
+				for (var i = 0; i < results.length; i++) {
+					var res = results[i],
+					    qv = res.quality || 0,
+					    qm = res.quality_max || 0,
+					    q = (qv > 0 && qm > 0) ? Math.floor((100 / qm) * qv) : 0,
+					    s = res.stale ? 'opacity:0.5' : '';
+
+					rows.push([
+						E('span', { 'style': s }, render_signal_badge(q, res.signal, res.noise)),
+						E('span', { 'style': s }, (res.ssid != null) ? '%h'.format(res.ssid) : E('em', _('hidden'))),
+						E('span', { 'style': s }, '%d'.format(res.channel)),
+						E('span', { 'style': s }, '%h'.format(res.mode)),
+						E('span', { 'style': s }, '%h'.format(res.bssid)),
+						E('span', { 'style': s }, '%h'.format(network.formatWifiEncryption(res.encryption))),
+						E('div', { 'class': 'right' }, E('button', {
+							'class': 'cbi-button cbi-button-action important',
+							'click': ui.createHandlerFn(this, 'handleJoin', radioDev, res)
+						}, _('Join Network')))
+					]);
+
+					res.stale = true;
+				}
+
+				cbi_update_table(table, rows);
+
+				stop.disabled = false;
+				stop.style.display = '';
+				stop.classList.remove('spinning');
+			}, this));
+		};
+
+		s.handleScanStartStop = function(ev) {
+			var btn = ev.currentTarget;
+
+			if (btn.getAttribute('data-state') == 'stop') {
+				poll.remove(this.pollFn);
+				btn.firstChild.data = _('Start refresh');
+				btn.setAttribute('data-state', 'start');
+			}
+			else {
+				poll.add(this.pollFn);
+				btn.firstChild.data = _('Stop refresh');
+				btn.setAttribute('data-state', 'stop');
+				btn.classList.add('spinning');
+				btn.disabled = true;
+			}
+		};
+
+		s.handleScanAbort = function(ev) {
+			var md = dom.parent(ev.target, 'div[aria-modal="true"]');
+			if (md) {
+				md.style.maxWidth = '';
+				md.style.maxHeight = '';
+			}
+
+			ui.hideModal();
+			poll.remove(this.pollFn);
+
+			this.pollFn = null;
+		};
+
+		s.handleJoinConfirm = function(radioDev, bss, form, ev) {
+			var nameopt = L.toArray(form.lookupOption('name', '_new_'))[0],
+			    passopt = L.toArray(form.lookupOption('password', '_new_'))[0],
+			    ssidopt = L.toArray(form.lookupOption('ssid', '_new_'))[0],
+			    bssidopt = L.toArray(form.lookupOption('bssid', '_new_'))[0],
+			    zoneopt = L.toArray(form.lookupOption('zone', '_new_'))[0],
+			    replopt = L.toArray(form.lookupOption('replace', '_new_'))[0],
+			    nameval = (nameopt && nameopt.isValid('_new_')) ? nameopt.formvalue('_new_') : null,
+			    passval = (passopt && passopt.isValid('_new_')) ? passopt.formvalue('_new_') : null,
+			    ssidval = (ssidopt && ssidopt.isValid('_new_')) ? ssidopt.formvalue('_new_') : null,
+			    bssidval = (bssidopt && bssidopt.isValid('_new_')) ? bssidopt.formvalue('_new_') : null,
+			    zoneval = zoneopt ? zoneopt.formvalue('_new_') : null,
+			    enc = L.isObject(bss.encryption) ? bss.encryption : null,
+			    is_wep = (enc && Array.isArray(enc.wep)),
+			    is_psk = (enc && Array.isArray(enc.wpa) && L.toArray(enc.authentication).filter(function(a) { return a == 'psk' }).length > 0),
+			    is_sae = (enc && Array.isArray(enc.wpa) && L.toArray(enc.authentication).filter(function(a) { return a == 'sae' }).length > 0);
+
+			if (nameval == null || (passopt && passval == null))
+				return;
+
+			var section_id = null;
+
+			return this.map.save(function() {
+				var wifi_sections = uci.sections('wireless', 'wifi-iface');
+
+				if (replopt.formvalue('_new_') == '1') {
+					for (var i = 0; i < wifi_sections.length; i++)
+						if (wifi_sections[i].device == radioDev.getName())
+							uci.remove('wireless', wifi_sections[i]['.name']);
+				}
+
+				if (uci.get('wireless', radioDev.getName(), 'disabled') == '1') {
+					for (var i = 0; i < wifi_sections.length; i++)
+						if (wifi_sections[i].device == radioDev.getName())
+							uci.set('wireless', wifi_sections[i]['.name'], 'disabled', '1');
+
+					uci.unset('wireless', radioDev.getName(), 'disabled');
+				}
+
+				var htmodes = radioDev.getHTModes();
+
+				if (bss.vht_operation && htmodes && htmodes.indexOf('VHT20') !== -1) {
+					for (var w = bss.vht_operation.channel_width; w >= 20; w /= 2) {
+						if (htmodes.indexOf('VHT'+w) !== -1) {
+							uci.set('wireless', radioDev.getName(), 'htmode', 'VHT'+w);
+							break;
+						}
+					}
+				}
+				else if (bss.ht_operation && htmodes && htmodes.indexOf('HT20') !== -1) {
+					var w = (bss.ht_operation.secondary_channel_offset == 'no secondary') ? 20 : 40;
+					uci.set('wireless', radioDev.getName(), 'htmode', 'HT'+w);
+				}
+				else {
+					uci.remove('wireless', radioDev.getName(), 'htmode');
+				}
+
+				uci.set('wireless', radioDev.getName(), 'channel', bss.channel);
+
+				section_id = next_free_sid(wifi_sections.length);
+
+				uci.add('wireless', 'wifi-iface', section_id);
+				uci.set('wireless', section_id, 'device', radioDev.getName());
+				uci.set('wireless', section_id, 'mode', (bss.mode == 'Ad-Hoc') ? 'adhoc' : 'sta');
+				uci.set('wireless', section_id, 'network', nameval);
+
+				if (bss.ssid != null) {
+					uci.set('wireless', section_id, 'ssid', bss.ssid);
+
+					if (bssidval == '1')
+						uci.set('wireless', section_id, 'bssid', bss.bssid);
+				}
+				else if (bss.bssid != null) {
+					uci.set('wireless', section_id, 'bssid', bss.bssid);
+				}
+
+				if (ssidval != null)
+					uci.set('wireless', section_id, 'ssid', ssidval);
+
+				if (is_sae) {
+					uci.set('wireless', section_id, 'encryption', 'sae');
+					uci.set('wireless', section_id, 'key', passval);
+				}
+				else if (is_psk) {
+					for (var i = enc.wpa.length - 1; i >= 0; i--) {
+						if (enc.wpa[i] == 2) {
+							uci.set('wireless', section_id, 'encryption', 'psk2');
+							break;
+						}
+						else if (enc.wpa[i] == 1) {
+							uci.set('wireless', section_id, 'encryption', 'psk');
+							break;
+						}
+					}
+
+					uci.set('wireless', section_id, 'key', passval);
+				}
+				else if (is_wep) {
+					uci.set('wireless', section_id, 'encryption', 'wep-open');
+					uci.set('wireless', section_id, 'key', '1');
+					uci.set('wireless', section_id, 'key1', passval);
+				}
+				else {
+					uci.set('wireless', section_id, 'encryption', 'none');
+				}
+
+				return network.addNetwork(nameval, { proto: 'dhcp' }).then(function(net) {
+					firewall.deleteNetwork(net.getName());
+
+					var zonePromise = zoneval
+						? firewall.getZone(zoneval).then(function(zone) { return zone || firewall.addZone(zoneval) })
+						: Promise.resolve();
+
+					return zonePromise.then(function(zone) {
+						if (zone)
+							zone.addNetwork(net.getName());
+					});
+				});
+			}).then(L.bind(function() {
+				ui.showModal(null, E('p', { 'class': 'spinning' }, [ _('Loading data…') ]));
+
+				return this.renderMoreOptionsModal(section_id);
+			}, this));
+		};
+
+		s.handleJoin = function(radioDev, bss, ev) {
+			poll.remove(this.pollFn);
+
+			var m2 = new form.Map('wireless'),
+			    s2 = m2.section(form.NamedSection, '_new_'),
+			    enc = L.isObject(bss.encryption) ? bss.encryption : null,
+			    is_wep = (enc && Array.isArray(enc.wep)),
+			    is_psk = (enc && Array.isArray(enc.wpa) && L.toArray(enc.authentication).filter(function(a) { return a == 'psk' || a == 'sae' })),
+			    replace, passphrase, name, bssid, zone;
+
+			var nameUsed = function(name) {
+				var s = uci.get('network', name);
+				if (s != null && s['.type'] != 'interface')
+					return true;
+
+				var net = (s != null) ? network.instantiateNetwork(name) : null;
+				return (net != null && !net.isEmpty());
+			};
+
+			s2.render = function() {
+				return Promise.all([
+					{},
+					this.renderUCISection('_new_')
+				]).then(this.renderContents.bind(this));
+			};
+
+			if (bss.ssid == null) {
+				name = s2.option(form.Value, 'ssid', _('Network SSID'), _('The correct SSID must be manually specified when joining a hidden wireless network'));
+				name.rmempty = false;
+			};
+
+			replace = s2.option(form.Flag, 'replace', _('Replace wireless configuration'), _('Check this option to delete the existing networks from this radio.'));
+
+			name = s2.option(form.Value, 'name', _('Name of the new network'),
+				_('Name for OpenWrt network configuration. (No relation to wireless network name/SSID)') + '<br />' +
+				_('The allowed characters are: <code>A-Z</code>, <code>a-z</code>, <code>0-9</code> and <code>_</code>'));
+			name.datatype = 'uciname';
+			name.default = 'wwan';
+			name.rmempty = false;
+			name.validate = function(section_id, value) {
+				if (nameUsed(value))
+					return _('The network name is already used');
+
+				return true;
+			};
+
+			for (var i = 2; nameUsed(name.default); i++)
+				name.default = 'wwan%d'.format(i);
+
+			if (is_wep || is_psk) {
+				passphrase = s2.option(form.Value, 'password', is_wep ? _('WEP passphrase') : _('WPA passphrase'), _('Specify the secret encryption key here.'));
+				passphrase.datatype = is_wep ? 'wepkey' : 'wpakey';
+				passphrase.password = true;
+				passphrase.rmempty = false;
+			}
+
+			if (bss.ssid != null) {
+				bssid = s2.option(form.Flag, 'bssid', _('Lock to BSSID'), _('Instead of joining any network with a matching SSID, only connect to the BSSID <code>%h</code>.').format(bss.bssid));
+				bssid.default = '0';
+			}
+
+			zone = s2.option(widgets.ZoneSelect, 'zone', _('Create / Assign firewall-zone'), _('Choose the firewall zone you want to assign to this interface. Select <em>unspecified</em> to remove the interface from the associated zone or fill out the <em>custom</em> field to define a new zone and attach the interface to it.'));
+			zone.default = 'wan';
+
+			return m2.render().then(L.bind(function(nodes) {
+				ui.showModal(_('Joining Network: %q').replace(/%q/, '"%h"'.format(bss.ssid)), [
+					nodes,
+					E('div', { 'class': 'right' }, [
+						E('button', {
+							'class': 'btn',
+							'click': ui.hideModal
+						}, _('Cancel')), ' ',
+						E('button', {
+							'class': 'cbi-button cbi-button-positive important',
+							'click': ui.createHandlerFn(this, 'handleJoinConfirm', radioDev, bss, m2)
+						}, _('Submit'))
+					])
+				], 'cbi-modal').querySelector('[id="%s"] input[class][type]'.format((passphrase || name).cbid('_new_'))).focus();
+			}, this));
+		};
+
+		s.handleAdd = function(radioDev, ev) {
+			var section_id = next_free_sid(uci.sections('wireless', 'wifi-iface').length);
+
+			uci.unset('wireless', radioDev.getName(), 'disabled');
+
+			uci.add('wireless', 'wifi-iface', section_id);
+			uci.set('wireless', section_id, 'device', radioDev.getName());
+			uci.set('wireless', section_id, 'mode', 'ap');
+			uci.set('wireless', section_id, 'ssid', 'OpenWrt');
+			uci.set('wireless', section_id, 'encryption', 'none');
+
+			this.addedSection = section_id;
+			return this.renderMoreOptionsModal(section_id);
+		};
+
+		o = s.option(form.DummyValue, '_badge');
+		o.modalonly = false;
+		o.textvalue = function(section_id) {
+			var inst = this.section.lookupRadioOrNetwork(section_id),
+			    node = E('div', { 'class': 'center' });
+
+			if (inst.getWifiNetworks)
+				node.appendChild(render_radio_badge(inst));
+			else
+				node.appendChild(render_network_badge(inst));
+
+			return node;
+		};
+
+		o = s.option(form.DummyValue, '_stat');
+		o.modalonly = false;
+		o.textvalue = function(section_id) {
+			var inst = this.section.lookupRadioOrNetwork(section_id);
+
+			if (inst.getWifiNetworks)
+				return render_radio_status(inst, this.section.wifis.filter(function(e) {
+					return (e.getWifiDeviceName() == inst.getName());
+				}));
+			else
+				return render_network_status(inst);
+		};
+
+		return m.render().then(L.bind(function(m, nodes) {
+			poll.add(L.bind(function() {
+				var section_ids = m.children[0].cfgsections(),
+				    tasks = [ network.getHostHints(), network.getWifiDevices() ];
+
+				for (var i = 0; i < section_ids.length; i++) {
+					var row = nodes.querySelector('.cbi-section-table-row[data-sid="%s"]'.format(section_ids[i])),
+					    dsc = row.querySelector('[data-name="_stat"] > div'),
+					    btns = row.querySelectorAll('.cbi-section-actions button');
+
+					if (dsc.getAttribute('restart') == '') {
+						dsc.setAttribute('restart', '1');
+						tasks.push(fs.exec('/sbin/wifi', ['up', section_ids[i]]).catch(function(e) {
+							ui.addNotification(null, E('p', e.message));
+						}));
+					}
+					else if (dsc.getAttribute('restart') == '1') {
+						dsc.removeAttribute('restart');
+						btns[0].classList.remove('spinning');
+						btns[0].disabled = false;
+					}
+				}
+
+				return Promise.all(tasks)
+					.then(L.bind(function(hosts_radios) {
+						var tasks = [];
+
+						for (var i = 0; i < hosts_radios[1].length; i++)
+							tasks.push(hosts_radios[1][i].getWifiNetworks());
+
+						return Promise.all(tasks).then(function(data) {
+							hosts_radios[2] = [];
+
+							for (var i = 0; i < data.length; i++)
+								hosts_radios[2].push.apply(hosts_radios[2], data[i]);
+
+							return hosts_radios;
+						});
+					}, network))
+					.then(L.bind(function(hosts_radios_wifis) {
+						var tasks = [];
+
+						for (var i = 0; i < hosts_radios_wifis[2].length; i++)
+							tasks.push(hosts_radios_wifis[2][i].getAssocList());
+
+						return Promise.all(tasks).then(function(data) {
+							hosts_radios_wifis[3] = [];
+
+							for (var i = 0; i < data.length; i++) {
+								var wifiNetwork = hosts_radios_wifis[2][i],
+								    radioDev = hosts_radios_wifis[1].filter(function(d) { return d.getName() == wifiNetwork.getWifiDeviceName() })[0];
+
+								for (var j = 0; j < data[i].length; j++)
+									hosts_radios_wifis[3].push(Object.assign({ radio: radioDev, network: wifiNetwork }, data[i][j]));
+							}
+
+							return hosts_radios_wifis;
+						});
+					}, network))
+					.then(L.bind(this.poll_status, this, nodes));
+			}, this), 5);
+
+			var table = E('table', { 'class': 'table assoclist', 'id': 'wifi_assoclist_table' }, [
+				E('tr', { 'class': 'tr table-titles' }, [
+					E('th', { 'class': 'th nowrap' }, _('Network')),
+					E('th', { 'class': 'th hide-xs' }, _('MAC address')),
+					E('th', { 'class': 'th' }, _('Host')),
+					E('th', { 'class': 'th' }, _('Signal / Noise')),
+					E('th', { 'class': 'th' }, _('RX Rate / TX Rate'))
+				])
+			]);
+
+			cbi_update_table(table, [], E('em', { 'class': 'spinning' }, _('Collecting data...')))
+
+			return E([ nodes, E('h3', _('Associated Stations')), table ]);
+		}, this, m));
+	},
+
+	handleReset: null
+});

--- a/package/kernel/ath10k-ct/patches/203-wifi-ath10k-add-support-for-QAM-256-in-2.4GHz-802.11.patch
+++ b/package/kernel/ath10k-ct/patches/203-wifi-ath10k-add-support-for-QAM-256-in-2.4GHz-802.11.patch
@@ -1,0 +1,41 @@
+From 7658e786e6de189f218ba7ed5d8db953cc6cf980 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Wed, 14 Jun 2023 09:14:56 +0200
+Subject: [PATCH 3/4] wifi: ath10k: add support for QAM-256 in 2.4GHz 802.11n
+
+Ath10k supports non-standard QAM-256 in 2.4GHz in 802.11n. Permit for
+supported client to benefits from these extra bandwidth by enabling
+support for it.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ ath10k-6.2/mac.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/ath10k-6.2/mac.c b/ath10k-6.2/mac.c
+index 9c4bf2fdbc0f..8d362ba351e6 100644
+--- a/ath10k-6.2/mac.c
++++ b/ath10k-6.2k/mac.c
+@@ -2749,9 +2749,9 @@ static void ath10k_peer_assoc_h_phymode(struct ath10k *ar,
+ 		if (sta->deflink.vht_cap.vht_supported &&
+ 		    !ath10k_peer_assoc_h_vht_masked(vht_mcs_mask)) {
+ 			if (sta->deflink.bandwidth == IEEE80211_STA_RX_BW_40)
+-				phymode = MODE_11AC_VHT40;
++				phymode = MODE_11AC_VHT40_2G;
+ 			else
+-				phymode = MODE_11AC_VHT20;
++				phymode = MODE_11AC_VHT20_2G;
+ 		} else if (sta->deflink.ht_cap.ht_supported &&
+ 			   !ath10k_peer_assoc_h_ht_masked(ht_mcs_mask)) {
+ 			if (sta->deflink.bandwidth == IEEE80211_STA_RX_BW_40)
+@@ -4998,6 +4998,7 @@ static void ath10k_mac_setup_ht_vht_cap(struct ath10k *ar)
+ 
+ 		/* Enable the VHT support at 2.4 GHz */
+ 		band->vht_cap = vht_cap;
++		band->vht_cap.vendor_qam256_supported = true;
+ 	}
+ 	if (ar->phy_capability & WHAL_WLAN_11A_CAPABILITY) {
+ 		band = &ar->mac.sbands[NL80211_BAND_5GHZ];
+-- 
+2.40.1
+

--- a/package/kernel/mac80211/patches/ath10k/200-wifi-ath10k-add-support-for-QAM-256-in-2.4GHz-802.11.patch
+++ b/package/kernel/mac80211/patches/ath10k/200-wifi-ath10k-add-support-for-QAM-256-in-2.4GHz-802.11.patch
@@ -1,0 +1,37 @@
+From 7658e786e6de189f218ba7ed5d8db953cc6cf980 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Wed, 14 Jun 2023 09:14:56 +0200
+Subject: [PATCH 3/4] wifi: ath10k: add support for QAM-256 in 2.4GHz 802.11n
+
+Ath10k supports non-standard QAM-256 in 2.4GHz in 802.11n. Permit for
+supported client to benefits from these extra bandwidth by enabling
+support for it.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/mac.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -2744,9 +2744,9 @@ static void ath10k_peer_assoc_h_phymode(
+ 		if (sta->deflink.vht_cap.vht_supported &&
+ 		    !ath10k_peer_assoc_h_vht_masked(vht_mcs_mask)) {
+ 			if (sta->deflink.bandwidth == IEEE80211_STA_RX_BW_40)
+-				phymode = MODE_11AC_VHT40;
++				phymode = MODE_11AC_VHT40_2G;
+ 			else
+-				phymode = MODE_11AC_VHT20;
++				phymode = MODE_11AC_VHT20_2G;
+ 		} else if (sta->deflink.ht_cap.ht_supported &&
+ 			   !ath10k_peer_assoc_h_ht_masked(ht_mcs_mask)) {
+ 			if (sta->deflink.bandwidth == IEEE80211_STA_RX_BW_40)
+@@ -4996,6 +4996,8 @@ static void ath10k_mac_setup_ht_vht_cap(
+ 	if (ar->phy_capability & WHAL_WLAN_11G_CAPABILITY) {
+ 		band = &ar->mac.sbands[NL80211_BAND_2GHZ];
+ 		band->ht_cap = ht_cap;
++		band->vht_cap = vht_cap;
++		band->vht_cap.vendor_qam256_supported = true;
+ 	}
+ 	if (ar->phy_capability & WHAL_WLAN_11A_CAPABILITY) {
+ 		band = &ar->mac.sbands[NL80211_BAND_5GHZ];

--- a/package/kernel/mac80211/patches/ath10k/930-ath10k_add_tpt_led_trigger.patch
+++ b/package/kernel/mac80211/patches/ath10k/930-ath10k_add_tpt_led_trigger.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/wireless/ath/ath10k/mac.c
 +++ b/drivers/net/wireless/ath/ath10k/mac.c
-@@ -9919,6 +9919,21 @@ static int ath10k_mac_init_rd(struct ath
+@@ -9921,6 +9921,21 @@ static int ath10k_mac_init_rd(struct ath
  	return 0;
  }
  
@@ -22,7 +22,7 @@
  int ath10k_mac_register(struct ath10k *ar)
  {
  	static const u32 cipher_suites[] = {
-@@ -10281,6 +10296,12 @@ int ath10k_mac_register(struct ath10k *a
+@@ -10283,6 +10298,12 @@ int ath10k_mac_register(struct ath10k *a
  
  	ar->hw->weight_multiplier = ATH10K_AIRTIME_WEIGHT_MULTIPLIER;
  

--- a/package/kernel/mac80211/patches/ath10k/975-ath10k-use-tpt-trigger-by-default.patch
+++ b/package/kernel/mac80211/patches/ath10k/975-ath10k-use-tpt-trigger-by-default.patch
@@ -40,7 +40,7 @@ Signed-off-by: Mathias Kresin <dev@kresin.me>
  	if (ret)
 --- a/drivers/net/wireless/ath/ath10k/mac.c
 +++ b/drivers/net/wireless/ath/ath10k/mac.c
-@@ -10297,7 +10297,7 @@ int ath10k_mac_register(struct ath10k *a
+@@ -10299,7 +10299,7 @@ int ath10k_mac_register(struct ath10k *a
  	ar->hw->weight_multiplier = ATH10K_AIRTIME_WEIGHT_MULTIPLIER;
  
  #ifdef CPTCFG_MAC80211_LEDS

--- a/package/kernel/mac80211/patches/ath10k/988-ath10k-always-use-mac80211-loss-detection.patch
+++ b/package/kernel/mac80211/patches/ath10k/988-ath10k-always-use-mac80211-loss-detection.patch
@@ -18,7 +18,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 
 --- a/drivers/net/wireless/ath/ath10k/mac.c
 +++ b/drivers/net/wireless/ath/ath10k/mac.c
-@@ -10089,7 +10089,6 @@ int ath10k_mac_register(struct ath10k *a
+@@ -10091,7 +10091,6 @@ int ath10k_mac_register(struct ath10k *a
  	ieee80211_hw_set(ar->hw, CHANCTX_STA_CSA);
  	ieee80211_hw_set(ar->hw, QUEUE_CONTROL);
  	ieee80211_hw_set(ar->hw, SUPPORTS_TX_FRAG);

--- a/package/kernel/mac80211/patches/ath11k/200-wifi-ath11k-add-support-for-QAM-256-in-2.4GHz-802.11.patch
+++ b/package/kernel/mac80211/patches/ath11k/200-wifi-ath11k-add-support-for-QAM-256-in-2.4GHz-802.11.patch
@@ -1,0 +1,50 @@
+From 462b0e7ce7cadef5c14bb16134e43573b169c9b5 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Wed, 14 Jun 2023 09:44:29 +0200
+Subject: [PATCH 4/4] wifi: ath11k: add support for QAM-256 in 2.4GHz 802.11n
+
+Ath11k supports non-standard QAM-256 in 2.4GHz in 802.11n. Permit for
+supported client to benefits from these extra bandwidth by enabling
+support for it.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 7 +++++--
+ drivers/net/wireless/ath/ath11k/wmi.c | 2 ++
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -2858,9 +2858,9 @@ static void ath11k_peer_assoc_h_phymode(
+ 		} else if (sta->deflink.vht_cap.vht_supported &&
+ 			   !ath11k_peer_assoc_h_vht_masked(vht_mcs_mask)) {
+ 			if (sta->deflink.bandwidth == IEEE80211_STA_RX_BW_40)
+-				phymode = MODE_11AC_VHT40;
++				phymode = MODE_11AC_VHT40_2G;
+ 			else
+-				phymode = MODE_11AC_VHT20;
++				phymode = MODE_11AC_VHT20_2G;
+ 		} else if (sta->deflink.ht_cap.ht_supported &&
+ 			   !ath11k_peer_assoc_h_ht_masked(ht_mcs_mask)) {
+ 			if (sta->deflink.bandwidth == IEEE80211_STA_RX_BW_40)
+@@ -5490,6 +5490,9 @@ static void ath11k_mac_setup_ht_vht_cap(
+ 			*ht_cap_info = ht_cap;
+ 		band->ht_cap = ath11k_create_ht_cap(ar, ht_cap,
+ 						    rate_cap_rx_chainmask);
++		band->vht_cap = ath11k_create_vht_cap(ar, rate_cap_tx_chainmask,
++						      rate_cap_rx_chainmask);
++		band->vht_cap.vendor_qam256_supported = true;
+ 	}
+ 
+ 	if (cap->supported_bands & WMI_HOST_WLAN_5G_CAP &&
+--- a/drivers/net/wireless/ath/ath11k/wmi.c
++++ b/drivers/net/wireless/ath/ath11k/wmi.c
+@@ -411,6 +411,8 @@ ath11k_pull_mac_phy_cap_svc_ready_ext(st
+ 	 * handled.
+ 	 */
+ 	if (mac_phy_caps->supported_bands & WMI_HOST_WLAN_2G_CAP) {
++		pdev_cap->vht_cap = mac_phy_caps->vht_cap_info_2g;
++		pdev_cap->vht_mcs = mac_phy_caps->vht_supp_mcs_2g;
+ 		pdev_cap->tx_chain_mask = mac_phy_caps->tx_chain_mask_2g;
+ 		pdev_cap->rx_chain_mask = mac_phy_caps->rx_chain_mask_2g;
+ 	}

--- a/package/kernel/mac80211/patches/ath12k/001-wifi-ath12k-add-11d-scan-offload-support-and-handle-country-code-for-WCN7850.patch
+++ b/package/kernel/mac80211/patches/ath12k/001-wifi-ath12k-add-11d-scan-offload-support-and-handle-country-code-for-WCN7850.patch
@@ -121,7 +121,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  };
  
  static __le32 ath12k_wmi_tlv_hdr(u32 cmd, u32 len)
-@@ -2363,7 +2365,10 @@ int ath12k_wmi_send_scan_start_cmd(struc
+@@ -2364,7 +2366,10 @@ int ath12k_wmi_send_scan_start_cmd(struc
  	cmd->scan_id = cpu_to_le32(arg->scan_id);
  	cmd->scan_req_id = cpu_to_le32(arg->scan_req_id);
  	cmd->vdev_id = cpu_to_le32(arg->vdev_id);
@@ -133,7 +133,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	cmd->notify_scan_events = cpu_to_le32(arg->notify_scan_events);
  
  	ath12k_wmi_copy_scan_event_cntrl_flags(cmd, arg);
-@@ -3083,6 +3088,110 @@ out:
+@@ -3084,6 +3089,110 @@ out:
  	return ret;
  }
  
@@ -244,7 +244,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  int
  ath12k_wmi_send_twt_enable_cmd(struct ath12k *ar, u32 pdev_id)
  {
-@@ -5668,6 +5777,50 @@ static void ath12k_wmi_op_ep_tx_credits(
+@@ -5669,6 +5778,50 @@ static void ath12k_wmi_op_ep_tx_credits(
  	wake_up(&ab->wmi_ab.tx_credits_wq);
  }
  
@@ -295,7 +295,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  static void ath12k_wmi_htc_tx_complete(struct ath12k_base *ab,
  				       struct sk_buff *skb)
  {
-@@ -7269,6 +7422,9 @@ static void ath12k_wmi_op_rx(struct ath1
+@@ -7270,6 +7423,9 @@ static void ath12k_wmi_op_rx(struct ath1
  	case WMI_GTK_OFFLOAD_STATUS_EVENTID:
  		ath12k_wmi_gtk_offload_status_event(ab, skb);
  		break;
@@ -307,7 +307,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  		ath12k_dbg(ab, ATH12K_DBG_WMI, "Unknown eventid: 0x%x\n", id);
 --- a/drivers/net/wireless/ath/ath12k/wmi.h
 +++ b/drivers/net/wireless/ath/ath12k/wmi.h
-@@ -3859,6 +3859,28 @@ struct wmi_init_country_cmd {
+@@ -3860,6 +3860,28 @@ struct wmi_init_country_cmd {
  	} cc_info;
  } __packed;
  
@@ -336,7 +336,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  struct wmi_delba_send_cmd {
  	__le32 tlv_header;
  	__le32 vdev_id;
-@@ -3944,6 +3966,16 @@ struct ath12k_wmi_eht_rate_set_params {
+@@ -3945,6 +3967,16 @@ struct ath12k_wmi_eht_rate_set_params {
  #define MAX_6G_REG_RULES 5
  #define REG_US_5G_NUM_REG_RULES 4
  
@@ -353,7 +353,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  enum wmi_start_event_param {
  	WMI_VDEV_START_RESP_EVENT = 0,
  	WMI_VDEV_RESTART_RESP_EVENT,
-@@ -5546,11 +5578,17 @@ int ath12k_wmi_send_bcn_offload_control_
+@@ -5547,11 +5579,17 @@ int ath12k_wmi_send_bcn_offload_control_
  					    u32 vdev_id, u32 bcn_ctrl_op);
  int ath12k_wmi_send_init_country_cmd(struct ath12k *ar,
  				     struct ath12k_wmi_init_country_arg *arg);
@@ -485,7 +485,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  		u32 fw_crash_counter;
 --- a/drivers/net/wireless/ath/ath12k/mac.c
 +++ b/drivers/net/wireless/ath/ath12k/mac.c
-@@ -2947,6 +2947,11 @@ static void ath12k_bss_assoc(struct ath1
+@@ -2946,6 +2946,11 @@ static void ath12k_bss_assoc(struct ath1
  	if (ret)
  		ath12k_warn(ar->ab, "failed to set vdev %i OBSS PD parameters: %d\n",
  			    arvif->vdev_id, ret);
@@ -497,7 +497,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  }
  
  static void ath12k_bss_disassoc(struct ath12k *ar,
-@@ -3522,7 +3527,7 @@ void __ath12k_mac_scan_finish(struct ath
+@@ -3521,7 +3526,7 @@ void __ath12k_mac_scan_finish(struct ath
  		ar->scan_channel = NULL;
  		ar->scan.roc_freq = 0;
  		cancel_delayed_work(&ar->scan.timeout);
@@ -506,7 +506,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  		break;
  	}
  }
-@@ -3783,7 +3788,12 @@ scan:
+@@ -3782,7 +3787,12 @@ scan:
  
  	ret = ath12k_start_scan(ar, &arg);
  	if (ret) {
@@ -520,7 +520,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  		spin_lock_bh(&ar->data_lock);
  		ar->scan.state = ATH12K_SCAN_IDLE;
  		spin_unlock_bh(&ar->data_lock);
-@@ -3802,6 +3812,11 @@ exit:
+@@ -3801,6 +3811,11 @@ exit:
  
  	mutex_unlock(&ar->conf_mutex);
  
@@ -532,7 +532,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	return ret;
  }
  
-@@ -5986,7 +6001,7 @@ static int ath12k_mac_start(struct ath12
+@@ -5985,7 +6000,7 @@ static int ath12k_mac_start(struct ath12
  
  	/* TODO: Do we need to enable ANI? */
  
@@ -541,7 +541,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  
  	ar->num_started_vdevs = 0;
  	ar->num_created_vdevs = 0;
-@@ -6166,6 +6181,9 @@ static void ath12k_mac_stop(struct ath12
+@@ -6165,6 +6180,9 @@ static void ath12k_mac_stop(struct ath12
  	cancel_delayed_work_sync(&ar->scan.timeout);
  	cancel_work_sync(&ar->regd_update_work);
  	cancel_work_sync(&ar->ab->rfkill_work);
@@ -551,7 +551,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  
  	spin_lock_bh(&ar->data_lock);
  	list_for_each_entry_safe(ppdu_stats, tmp, &ar->ppdu_stats_info, list) {
-@@ -6412,6 +6430,117 @@ static void ath12k_mac_op_update_vif_off
+@@ -6411,6 +6429,117 @@ static void ath12k_mac_op_update_vif_off
  	ath12k_mac_update_vif_offload(arvif);
  }
  
@@ -669,7 +669,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  static int ath12k_mac_vdev_create(struct ath12k *ar, struct ieee80211_vif *vif)
  {
  	struct ath12k_hw *ah = ar->ah;
-@@ -6526,6 +6655,7 @@ static int ath12k_mac_vdev_create(struct
+@@ -6525,6 +6654,7 @@ static int ath12k_mac_vdev_create(struct
  				    arvif->vdev_id, ret);
  			goto err_peer_del;
  		}
@@ -677,7 +677,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  		break;
  	case WMI_VDEV_TYPE_STA:
  		param_id = WMI_STA_PS_PARAM_RX_WAKE_POLICY;
-@@ -6564,6 +6694,13 @@ static int ath12k_mac_vdev_create(struct
+@@ -6563,6 +6693,13 @@ static int ath12k_mac_vdev_create(struct
  				    arvif->vdev_id, ret);
  			goto err_peer_del;
  		}
@@ -691,7 +691,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  		break;
  	default:
  		break;
-@@ -6904,6 +7041,11 @@ static void ath12k_mac_op_remove_interfa
+@@ -6903,6 +7040,11 @@ static void ath12k_mac_op_remove_interfa
  	ath12k_dbg(ab, ATH12K_DBG_MAC, "mac remove interface (vdev %d)\n",
  		   arvif->vdev_id);
  
@@ -703,7 +703,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	if (arvif->vdev_type == WMI_VDEV_TYPE_AP) {
  		ret = ath12k_peer_delete(ar, arvif->vdev_id, vif->addr);
  		if (ret)
-@@ -7744,6 +7886,14 @@ ath12k_mac_op_unassign_vif_chanctx(struc
+@@ -7743,6 +7885,14 @@ ath12k_mac_op_unassign_vif_chanctx(struc
  	    ar->num_started_vdevs == 1 && ar->monitor_vdev_created)
  		ath12k_mac_monitor_stop(ar);
  
@@ -718,7 +718,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	mutex_unlock(&ar->conf_mutex);
  }
  
-@@ -8282,6 +8432,14 @@ ath12k_mac_op_reconfig_complete(struct i
+@@ -8281,6 +8431,14 @@ ath12k_mac_op_reconfig_complete(struct i
  		ath12k_warn(ar->ab, "pdev %d successfully recovered\n",
  			    ar->pdev->pdev_id);
  
@@ -733,7 +733,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  		if (ab->is_reset) {
  			recovery_count = atomic_inc_return(&ab->recovery_count);
  
-@@ -9331,6 +9489,9 @@ static void ath12k_mac_setup(struct ath1
+@@ -9330,6 +9488,9 @@ static void ath12k_mac_setup(struct ath1
  
  	INIT_WORK(&ar->wmi_mgmt_tx_work, ath12k_mgmt_over_wmi_tx_work);
  	skb_queue_head_init(&ar->wmi_mgmt_tx_queue);

--- a/package/kernel/mac80211/patches/subsys/200-mac80211-introduce-support-for-vendor-QAM-256-in-2.4.patch
+++ b/package/kernel/mac80211/patches/subsys/200-mac80211-introduce-support-for-vendor-QAM-256-in-2.4.patch
@@ -1,0 +1,149 @@
+From 35040d1f349f2346832ca1ebb408924dbefc1cfc Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Wed, 14 Jun 2023 07:15:48 +0200
+Subject: [PATCH 1/4] mac80211: introduce support for vendor QAM-256 in 2.4GHz
+ 802.11n
+
+Some vendor supports non-standard QAM-256 in 2.4GHz 802.11n mode.
+The implementation works by comunicating vht capabilities to the client
+in 2.4GHz 802.11n, the supported client will take this info and
+benefits from the additional rates of it.
+
+Each driver needs to enable support for this by enabling the
+vendor_qam256_supported in the 2G sband struct and add the required
+capabilities for vht_cap.
+
+This feature is supported by various vendor with all kind of marketing
+name, but all of them have in common the use of vht capabilities in
+2.4GHz 802.11n.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ include/net/cfg80211.h |  2 ++
+ net/mac80211/mlme.c    | 14 ++++++++----
+ net/mac80211/util.c    | 10 +++++---
+ net/mac80211/vht.c     | 52 +++++++++++++++++++++++++++---------------
+ 4 files changed, 51 insertions(+), 27 deletions(-)
+
+--- a/include/net/cfg80211.h
++++ b/include/net/cfg80211.h
+@@ -357,11 +357,13 @@ struct ieee80211_sta_ht_cap {
+  * to describe 802.11ac VHT capabilities for an STA.
+  *
+  * @vht_supported: is VHT supported by the STA
++ * @qam256_supported: is QAM256 supported by the STA
+  * @cap: VHT capabilities map as described in 802.11ac spec
+  * @vht_mcs: Supported VHT MCS rates
+  */
+ struct ieee80211_sta_vht_cap {
+ 	bool vht_supported;
++	bool vendor_qam256_supported;
+ 	u32 cap; /* use IEEE80211_VHT_CAP_ */
+ 	struct ieee80211_vht_mcs_info vht_mcs;
+ };
+--- a/net/mac80211/mlme.c
++++ b/net/mac80211/mlme.c
+@@ -5271,6 +5271,8 @@ ieee80211_determine_our_sta_mode(struct
+ 	if (sband->band != NL80211_BAND_2GHZ) {
+ 		conn->mode = IEEE80211_CONN_MODE_VHT;
+ 		conn->bw_limit = IEEE80211_CONN_BW_LIMIT_160;
++	} else if (sband->vht_cap.vendor_qam256_supported) {
++		conn->mode = IEEE80211_CONN_MODE_VHT;
+ 	}
+ 
+ 	if (is_5ghz &&
+--- a/net/mac80211/util.c
++++ b/net/mac80211/util.c
+@@ -1319,7 +1319,9 @@ static int ieee80211_put_preq_ies_band(s
+ 		break;
+ 	}
+ 
+-	if (sband->vht_cap.vht_supported && have_80mhz) {
++	if (sband->vht_cap.vht_supported &&
++	    (have_80mhz ||
++	     sband->vht_cap.vendor_qam256_supported)) {
+ 		u8 *pos;
+ 
+ 		if (skb_tailroom(skb) < 2 + sizeof(struct ieee80211_vht_cap))
+--- a/net/mac80211/vht.c
++++ b/net/mac80211/vht.c
+@@ -122,7 +122,7 @@ ieee80211_vht_cap_ie_to_sta_vht_cap(stru
+ 	struct ieee80211_sta_vht_cap *vht_cap = &link_sta->pub->vht_cap;
+ 	struct ieee80211_sta_vht_cap own_cap;
+ 	u32 cap_info, i;
+-	bool have_80mhz;
++	bool can_vht;
+ 	u32 mpdu_len;
+ 
+ 	memset(vht_cap, 0, sizeof(*vht_cap));
+@@ -134,17 +134,21 @@ ieee80211_vht_cap_ie_to_sta_vht_cap(stru
+ 		return;
+ 
+ 	/* Allow VHT if at least one channel on the sband supports 80 MHz */
+-	have_80mhz = false;
++	can_vht = false;
+ 	for (i = 0; i < sband->n_channels; i++) {
+ 		if (sband->channels[i].flags & (IEEE80211_CHAN_DISABLED |
+ 						IEEE80211_CHAN_NO_80MHZ))
+ 			continue;
+ 
+-		have_80mhz = true;
++		can_vht = true;
+ 		break;
+ 	}
+ 
+-	if (!have_80mhz)
++	/* Some Vendor supports non-standard QAM-256 on 2.4GHz 802.11n */
++	if (sband->vht_cap.vendor_qam256_supported)
++		can_vht = true;
++
++	if (!can_vht)
+ 		return;
+ 
+ 	/*
+@@ -359,23 +363,23 @@ _ieee80211_sta_cap_rx_bw(struct link_sta
+ 	struct ieee80211_sta_vht_cap *vht_cap = &link_sta->pub->vht_cap;
+ 	struct ieee80211_sta_he_cap *he_cap = &link_sta->pub->he_cap;
+ 	struct ieee80211_sta_eht_cap *eht_cap = &link_sta->pub->eht_cap;
++	enum nl80211_band band;
+ 	u32 cap_width;
+ 
++	if (chandef) {
++		band = chandef->chan->band;
++	} else {
++		struct ieee80211_bss_conf *link_conf;
++
++		rcu_read_lock();
++		link_conf = rcu_dereference(sdata->vif.link_conf[link_id]);
++		band = link_conf->chanreq.oper.chan->band;
++		rcu_read_unlock();
++	}
++
+ 	if (he_cap->has_he) {
+-		enum nl80211_band band;
+ 		u8 info;
+ 
+-		if (chandef) {
+-			band = chandef->chan->band;
+-		} else {
+-			struct ieee80211_bss_conf *link_conf;
+-
+-			rcu_read_lock();
+-			link_conf = rcu_dereference(sdata->vif.link_conf[link_id]);
+-			band = link_conf->chanreq.oper.chan->band;
+-			rcu_read_unlock();
+-		}
+-
+ 		if (eht_cap->has_eht && band == NL80211_BAND_6GHZ) {
+ 			info = eht_cap->eht_cap_elem.phy_cap_info[0];
+ 
+@@ -401,7 +405,8 @@ _ieee80211_sta_cap_rx_bw(struct link_sta
+ 		return IEEE80211_STA_RX_BW_20;
+ 	}
+ 
+-	if (!vht_cap->vht_supported)
++	if (!vht_cap->vht_supported || (band == NL80211_BAND_2GHZ &&
++				       vht_cap->vendor_qam256_supported))
+ 		return link_sta->pub->ht_cap.cap & IEEE80211_HT_CAP_SUP_WIDTH_20_40 ?
+ 				IEEE80211_STA_RX_BW_40 :
+ 				IEEE80211_STA_RX_BW_20;

--- a/package/kernel/mac80211/patches/subsys/201-mac80211-add-logic-to-skip-useless-VHT-cap-check-in-.patch
+++ b/package/kernel/mac80211/patches/subsys/201-mac80211-add-logic-to-skip-useless-VHT-cap-check-in-.patch
@@ -1,0 +1,32 @@
+From 793bfa410bd16c273beb390818ab44886c680a22 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Wed, 14 Jun 2023 10:20:31 +0200
+Subject: [PATCH 2/4] mac80211: add logic to skip useless VHT cap check in
+ ieee80211_sta_cap_rx_bw
+
+Add logic to skip useless VHT cap check in ieee80211_sta_cap_rx_bw in
+the case where HT doesn't indicate support for 40MHz.
+
+If the STA doesn't indicate support for 40MHz then it doesn't make sense
+to check additional support for 80MHz, 80+80MHz or 160MHz
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ net/mac80211/vht.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/net/mac80211/vht.c
++++ b/net/mac80211/vht.c
+@@ -442,6 +442,12 @@ ieee80211_sta_cap_chan_bw(struct link_st
+ 				NL80211_CHAN_WIDTH_40 : NL80211_CHAN_WIDTH_20;
+ 	}
+ 
++	/* Skip checking VHT cap and set to 20MHz if HT cap doesn't indicate
++	 * support for 40MHz.
++	 */
++	if (!(link_sta->pub->ht_cap.cap & IEEE80211_HT_CAP_SUP_WIDTH_20_40))
++		return NL80211_CHAN_WIDTH_20;
++
+ 	cap_width = vht_cap->cap & IEEE80211_VHT_CAP_SUPP_CHAN_WIDTH_MASK;
+ 
+ 	if (cap_width == IEEE80211_VHT_CAP_SUPP_CHAN_WIDTH_160MHZ)

--- a/package/kernel/mac80211/patches/subsys/320-mac80211-add-AQL-support-for-broadcast-packets.patch
+++ b/package/kernel/mac80211/patches/subsys/320-mac80211-add-AQL-support-for-broadcast-packets.patch
@@ -12,7 +12,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/include/net/cfg80211.h
 +++ b/include/net/cfg80211.h
-@@ -3423,6 +3423,7 @@ enum wiphy_params_flags {
+@@ -3425,6 +3425,7 @@ enum wiphy_params_flags {
  /* The per TXQ device queue limit in airtime */
  #define IEEE80211_DEFAULT_AQL_TXQ_LIMIT_L	5000
  #define IEEE80211_DEFAULT_AQL_TXQ_LIMIT_H	12000

--- a/package/kernel/mac80211/patches/subsys/333-Revert-wifi-mac80211-move-radar-detect-work-to-sdata.patch
+++ b/package/kernel/mac80211/patches/subsys/333-Revert-wifi-mac80211-move-radar-detect-work-to-sdata.patch
@@ -125,7 +125,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
  				   GFP_KERNEL);
 --- a/net/mac80211/util.c
 +++ b/net/mac80211/util.c
-@@ -3460,7 +3460,7 @@ void ieee80211_dfs_cac_cancel(struct iee
+@@ -3462,7 +3462,7 @@ void ieee80211_dfs_cac_cancel(struct iee
  
  	list_for_each_entry(sdata, &local->interfaces, list) {
  		wiphy_delayed_work_cancel(local->hw.wiphy,

--- a/package/kernel/mac80211/patches/subsys/336-wifi-cfg80211-move-DFS-related-members-to-links-in-w.patch
+++ b/package/kernel/mac80211/patches/subsys/336-wifi-cfg80211-move-DFS-related-members-to-links-in-w.patch
@@ -87,7 +87,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
  		if (!wiphy_ext_feature_isset(wiphy,
 --- a/include/net/cfg80211.h
 +++ b/include/net/cfg80211.h
-@@ -6198,9 +6198,6 @@ enum ieee80211_ap_reg_power {
+@@ -6200,9 +6200,6 @@ enum ieee80211_ap_reg_power {
   * @address: The address for this device, valid only if @netdev is %NULL
   * @is_running: true if this is a non-netdev device that has been started, e.g.
   *	the P2P Device.
@@ -97,7 +97,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
   * @ps: powersave mode is enabled
   * @ps_timeout: dynamic powersave timeout
   * @ap_unexpected_nlportid: (private) netlink port ID of application
-@@ -6224,6 +6221,11 @@ enum ieee80211_ap_reg_power {
+@@ -6226,6 +6223,11 @@ enum ieee80211_ap_reg_power {
   *	unprotected beacon report
   * @links: array of %IEEE80211_MLD_MAX_NUM_LINKS elements containing @addr
   *	@ap and @client for each link
@@ -109,7 +109,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
   * @valid_links: bitmap describing what elements of @links are valid
   */
  struct wireless_dev {
-@@ -6265,11 +6267,6 @@ struct wireless_dev {
+@@ -6267,11 +6269,6 @@ struct wireless_dev {
  	u32 owner_nlportid;
  	bool nl_owner_dead;
  
@@ -121,7 +121,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
  #ifdef CPTCFG_CFG80211_WEXT
  	/* wext data */
  	struct {
-@@ -6336,6 +6333,10 @@ struct wireless_dev {
+@@ -6338,6 +6335,10 @@ struct wireless_dev {
  				struct cfg80211_internal_bss *current_bss;
  			} client;
  		};
@@ -199,7 +199,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
  
 --- a/net/mac80211/util.c
 +++ b/net/mac80211/util.c
-@@ -3462,7 +3462,7 @@ void ieee80211_dfs_cac_cancel(struct iee
+@@ -3464,7 +3464,7 @@ void ieee80211_dfs_cac_cancel(struct iee
  		wiphy_delayed_work_cancel(local->hw.wiphy,
  					  &sdata->deflink.dfs_cac_timer_work);
  

--- a/package/kernel/mac80211/patches/subsys/337-wifi-cfg80211-handle-DFS-per-link.patch
+++ b/package/kernel/mac80211/patches/subsys/337-wifi-cfg80211-handle-DFS-per-link.patch
@@ -102,7 +102,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
  		pr_warn("%s: unhandled radar event %u\n",
 --- a/include/net/cfg80211.h
 +++ b/include/net/cfg80211.h
-@@ -4841,9 +4841,9 @@ struct cfg80211_ops {
+@@ -4843,9 +4843,9 @@ struct cfg80211_ops {
  	int	(*start_radar_detection)(struct wiphy *wiphy,
  					 struct net_device *dev,
  					 struct cfg80211_chan_def *chandef,
@@ -114,7 +114,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
  	int	(*update_ft_ies)(struct wiphy *wiphy, struct net_device *dev,
  				 struct cfg80211_update_ft_ies_params *ftie);
  	int	(*crit_proto_start)(struct wiphy *wiphy,
-@@ -8745,6 +8745,7 @@ void cfg80211_sta_opmode_change_notify(s
+@@ -8747,6 +8747,7 @@ void cfg80211_sta_opmode_change_notify(s
   * @chandef: chandef for the current channel
   * @event: type of event
   * @gfp: context flags
@@ -122,7 +122,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
   *
   * This function is called when a Channel availability check (CAC) is finished
   * or aborted. This must be called to notify the completion of a CAC process,
-@@ -8752,7 +8753,8 @@ void cfg80211_sta_opmode_change_notify(s
+@@ -8754,7 +8755,8 @@ void cfg80211_sta_opmode_change_notify(s
   */
  void cfg80211_cac_event(struct net_device *netdev,
  			const struct cfg80211_chan_def *chandef,
@@ -185,7 +185,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
  
 --- a/net/mac80211/util.c
 +++ b/net/mac80211/util.c
-@@ -3468,7 +3468,7 @@ void ieee80211_dfs_cac_cancel(struct iee
+@@ -3470,7 +3470,7 @@ void ieee80211_dfs_cac_cancel(struct iee
  			cfg80211_cac_event(sdata->dev,
  					   &chandef,
  					   NL80211_RADAR_CAC_ABORTED,

--- a/package/kernel/mac80211/patches/subsys/338-wifi-mac80211-handle-DFS-per-link.patch
+++ b/package/kernel/mac80211/patches/subsys/338-wifi-mac80211-handle-DFS-per-link.patch
@@ -93,7 +93,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
  
 --- a/net/mac80211/util.c
 +++ b/net/mac80211/util.c
-@@ -3455,20 +3455,30 @@ void ieee80211_dfs_cac_cancel(struct iee
+@@ -3457,20 +3457,30 @@ void ieee80211_dfs_cac_cancel(struct iee
  {
  	struct ieee80211_sub_if_data *sdata;
  	struct cfg80211_chan_def chandef;

--- a/package/kernel/mac80211/patches/subsys/340-wifi-mac80211-handle-ieee80211_radar_detected-for-ML.patch
+++ b/package/kernel/mac80211/patches/subsys/340-wifi-mac80211-handle-ieee80211_radar_detected-for-ML.patch
@@ -262,7 +262,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
  
 --- a/net/mac80211/util.c
 +++ b/net/mac80211/util.c
-@@ -3451,11 +3451,16 @@ u64 ieee80211_calculate_rx_timestamp(str
+@@ -3453,11 +3453,16 @@ u64 ieee80211_calculate_rx_timestamp(str
  	return ts;
  }
  
@@ -280,7 +280,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
  	unsigned int link_id;
  
  	lockdep_assert_wiphy(local->hw.wiphy);
-@@ -3468,6 +3473,11 @@ void ieee80211_dfs_cac_cancel(struct iee
+@@ -3470,6 +3475,11 @@ void ieee80211_dfs_cac_cancel(struct iee
  			if (!link)
  				continue;
  
@@ -292,7 +292,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
  			wiphy_delayed_work_cancel(local->hw.wiphy,
  						  &link->dfs_cac_timer_work);
  
-@@ -3488,9 +3498,8 @@ void ieee80211_dfs_radar_detected_work(s
+@@ -3490,9 +3500,8 @@ void ieee80211_dfs_radar_detected_work(s
  {
  	struct ieee80211_local *local =
  		container_of(work, struct ieee80211_local, radar_detected_work);
@@ -303,7 +303,7 @@ Signed-off-by: Johannes Berg <johannes.berg@intel.com>
  
  	lockdep_assert_wiphy(local->hw.wiphy);
  
-@@ -3498,25 +3507,46 @@ void ieee80211_dfs_radar_detected_work(s
+@@ -3500,25 +3509,46 @@ void ieee80211_dfs_radar_detected_work(s
  		if (ctx->replace_state == IEEE80211_CHANCTX_REPLACES_OTHER)
  			continue;
  

--- a/package/kernel/mac80211/patches/subsys/350-wifi-cfg80211-add-option-for-vif-allowed-radios.patch
+++ b/package/kernel/mac80211/patches/subsys/350-wifi-cfg80211-add-option-for-vif-allowed-radios.patch
@@ -23,7 +23,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/include/net/cfg80211.h
 +++ b/include/net/cfg80211.h
-@@ -6227,6 +6227,7 @@ enum ieee80211_ap_reg_power {
+@@ -6229,6 +6229,7 @@ enum ieee80211_ap_reg_power {
   *	entered.
   * @links[].cac_time_ms: CAC time in ms
   * @valid_links: bitmap describing what elements of @links are valid
@@ -31,7 +31,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
   */
  struct wireless_dev {
  	struct wiphy *wiphy;
-@@ -6339,6 +6340,8 @@ struct wireless_dev {
+@@ -6341,6 +6342,8 @@ struct wireless_dev {
  		unsigned int cac_time_ms;
  	} links[IEEE80211_MLD_MAX_NUM_LINKS];
  	u16 valid_links;
@@ -40,7 +40,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  };
  
  static inline const u8 *wdev_address(struct wireless_dev *wdev)
-@@ -6525,6 +6528,17 @@ bool cfg80211_radio_chandef_valid(const
+@@ -6527,6 +6530,17 @@ bool cfg80211_radio_chandef_valid(const
  				  const struct cfg80211_chan_def *chandef);
  
  /**

--- a/package/kernel/mac80211/patches/subsys/354-wifi-cfg80211-pass-net_device-to-.set_monitor_channel.patch
+++ b/package/kernel/mac80211/patches/subsys/354-wifi-cfg80211-pass-net_device-to-.set_monitor_channel.patch
@@ -49,7 +49,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
 --- a/include/net/cfg80211.h
 +++ b/include/net/cfg80211.h
-@@ -4700,6 +4700,7 @@ struct cfg80211_ops {
+@@ -4702,6 +4702,7 @@ struct cfg80211_ops {
  					     struct ieee80211_channel *chan);
  
  	int	(*set_monitor_channel)(struct wiphy *wiphy,

--- a/package/kernel/mac80211/patches/subsys/355-wifi-mac80211-add-flag-to-opt-out-of-virtual-monitor.patch
+++ b/package/kernel/mac80211/patches/subsys/355-wifi-mac80211-add-flag-to-opt-out-of-virtual-monitor.patch
@@ -306,7 +306,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  				continue;
  			break;
  		case NL80211_IFTYPE_AP_VLAN:
-@@ -1857,8 +1858,10 @@ int ieee80211_reconfig(struct ieee80211_
+@@ -1859,8 +1860,10 @@ int ieee80211_reconfig(struct ieee80211_
  	}
  
  	list_for_each_entry(sdata, &local->interfaces, list) {
@@ -318,7 +318,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		    ieee80211_sdata_running(sdata)) {
  			res = drv_add_interface(local, sdata);
  			if (WARN_ON(res))
-@@ -1871,11 +1874,14 @@ int ieee80211_reconfig(struct ieee80211_
+@@ -1873,11 +1876,14 @@ int ieee80211_reconfig(struct ieee80211_
  	 */
  	if (res) {
  		list_for_each_entry_continue_reverse(sdata, &local->interfaces,

--- a/package/kernel/mac80211/patches/subsys/356-wifi-cfg80211-add-monitor-SKIP_TX-flag.patch
+++ b/package/kernel/mac80211/patches/subsys/356-wifi-cfg80211-add-monitor-SKIP_TX-flag.patch
@@ -10,7 +10,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/include/net/cfg80211.h
 +++ b/include/net/cfg80211.h
-@@ -2272,6 +2272,7 @@ static inline int cfg80211_get_station(s
+@@ -2274,6 +2274,7 @@ static inline int cfg80211_get_station(s
   * @MONITOR_FLAG_OTHER_BSS: disable BSSID filtering
   * @MONITOR_FLAG_COOK_FRAMES: report frames after processing
   * @MONITOR_FLAG_ACTIVE: active monitor, ACKs frames on its MAC address
@@ -18,7 +18,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
   */
  enum monitor_flags {
  	MONITOR_FLAG_CHANGED		= BIT(__NL80211_MNTR_FLAG_INVALID),
-@@ -2281,6 +2282,7 @@ enum monitor_flags {
+@@ -2283,6 +2284,7 @@ enum monitor_flags {
  	MONITOR_FLAG_OTHER_BSS		= BIT(NL80211_MNTR_FLAG_OTHER_BSS),
  	MONITOR_FLAG_COOK_FRAMES	= BIT(NL80211_MNTR_FLAG_COOK_FRAMES),
  	MONITOR_FLAG_ACTIVE		= BIT(NL80211_MNTR_FLAG_ACTIVE),

--- a/package/kernel/mac80211/patches/subsys/360-wifi-cfg80211-report-per-wiphy-radio-antenna-mask.patch
+++ b/package/kernel/mac80211/patches/subsys/360-wifi-cfg80211-report-per-wiphy-radio-antenna-mask.patch
@@ -11,7 +11,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/include/net/cfg80211.h
 +++ b/include/net/cfg80211.h
-@@ -5443,6 +5443,8 @@ struct wiphy_radio_freq_range {
+@@ -5445,6 +5445,8 @@ struct wiphy_radio_freq_range {
   * @iface_combinations: Valid interface combinations array, should not
   *	list single interface types.
   * @n_iface_combinations: number of entries in @iface_combinations array.
@@ -20,7 +20,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
   */
  struct wiphy_radio {
  	const struct wiphy_radio_freq_range *freq_range;
-@@ -5450,6 +5452,8 @@ struct wiphy_radio {
+@@ -5452,6 +5454,8 @@ struct wiphy_radio {
  
  	const struct ieee80211_iface_combination *iface_combinations;
  	int n_iface_combinations;

--- a/package/kernel/mt76/patches/200-mt76-allow-VHT-rate-on-2.4GHz.patch
+++ b/package/kernel/mt76/patches/200-mt76-allow-VHT-rate-on-2.4GHz.patch
@@ -1,0 +1,150 @@
+From 309d05fdf260697b1f15b26ebd4f71f0446dd605 Mon Sep 17 00:00:00 2001
+From: DENG Qingfang <dengqf6@mail2.sysu.edu.cn>
+Date: Mon, 23 Nov 2020 10:46:37 +0800
+Subject: [PATCH] mt76: allow VHT rate on 2.4GHz
+
+Allow chips that support 11ac to use 256QAM on 2.4GHz
+
+Signed-off-by: DENG Qingfang <dqfext@gmail.com>
+Signed-off-by: rany <ranygh@riseup.net>
+---
+ mac80211.c    | 12 +++++++-----
+ mt7615/init.c |  3 +++
+ mt7915/init.c | 14 ++++++++++++--
+ mt7921/init.c |  7 +++++++
+ mt7925/init.c |  7 +++++++
+ mt7996/init.c |  5 +++++
+ 6 files changed, 41 insertions(+), 7 deletions(-)
+
+--- a/mac80211.c
++++ b/mac80211.c
+@@ -293,7 +293,7 @@ static void mt76_init_stream_cap(struct
+ void mt76_set_stream_caps(struct mt76_phy *phy, bool vht)
+ {
+ 	if (phy->cap.has_2ghz)
+-		mt76_init_stream_cap(phy, &phy->sband_2g.sband, false);
++		mt76_init_stream_cap(phy, &phy->sband_2g.sband, vht);
+ 	if (phy->cap.has_5ghz)
+ 		mt76_init_stream_cap(phy, &phy->sband_5g.sband, vht);
+ 	if (phy->cap.has_6ghz)
+@@ -360,13 +360,15 @@ mt76_init_sband(struct mt76_phy *phy, st
+ 
+ static int
+ mt76_init_sband_2g(struct mt76_phy *phy, struct ieee80211_rate *rates,
+-		   int n_rates)
++		   int n_rates, bool vht)
+ {
+ 	phy->hw->wiphy->bands[NL80211_BAND_2GHZ] = &phy->sband_2g.sband;
+ 
++	vht = vht && phy->sband_2g.sband.vht_cap.vendor_qam256_supported;
++
+ 	return mt76_init_sband(phy, &phy->sband_2g, mt76_channels_2ghz,
+ 			       ARRAY_SIZE(mt76_channels_2ghz), rates,
+-			       n_rates, true, false);
++			       n_rates, true, vht);
+ }
+ 
+ static int
+@@ -524,7 +526,7 @@ int mt76_register_phy(struct mt76_phy *p
+ 		return ret;
+ 
+ 	if (phy->cap.has_2ghz) {
+-		ret = mt76_init_sband_2g(phy, rates, n_rates);
++		ret = mt76_init_sband_2g(phy, rates, n_rates, vht);
+ 		if (ret)
+ 			return ret;
+ 	}
+@@ -710,7 +712,7 @@ int mt76_register_device(struct mt76_dev
+ 		return ret;
+ 
+ 	if (phy->cap.has_2ghz) {
+-		ret = mt76_init_sband_2g(phy, rates, n_rates);
++		ret = mt76_init_sband_2g(phy, rates, n_rates, vht);
+ 		if (ret)
+ 			return ret;
+ 	}
+--- a/mt7615/init.c
++++ b/mt7615/init.c
+@@ -412,6 +412,9 @@ mt7615_init_wiphy(struct ieee80211_hw *h
+ 		hw->max_tx_fragments = MT_HW_TXP_MAX_BUF_NUM;
+ 
+ 	phy->mt76->sband_2g.sband.ht_cap.cap |= IEEE80211_HT_CAP_LDPC_CODING;
++	phy->mt76->sband_2g.sband.vht_cap.cap |=
++			IEEE80211_VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MASK;
++	phy->mt76->sband_2g.sband.vht_cap.vendor_qam256_supported = true;
+ 	phy->mt76->sband_5g.sband.ht_cap.cap |= IEEE80211_HT_CAP_LDPC_CODING;
+ 	phy->mt76->sband_5g.sband.vht_cap.cap |=
+ 			IEEE80211_VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MASK;
+--- a/mt7915/init.c
++++ b/mt7915/init.c
+@@ -411,12 +411,22 @@ mt7915_init_wiphy(struct mt7915_phy *phy
+ 		phy->mt76->sband_2g.sband.ht_cap.cap |=
+ 			IEEE80211_HT_CAP_LDPC_CODING |
+ 			IEEE80211_HT_CAP_MAX_AMSDU;
+-		if (is_mt7915(&dev->mt76))
++		if (is_mt7915(&dev->mt76)) {
+ 			phy->mt76->sband_2g.sband.ht_cap.ampdu_density =
+ 				IEEE80211_HT_MPDU_DENSITY_4;
+-		else
++
++			phy->mt76->sband_2g.sband.vht_cap.cap |=
++				IEEE80211_VHT_CAP_MAX_MPDU_LENGTH_7991 |
++				IEEE80211_VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MASK;
++		} else {
+ 			phy->mt76->sband_2g.sband.ht_cap.ampdu_density =
+ 				IEEE80211_HT_MPDU_DENSITY_2;
++
++			phy->mt76->sband_2g.sband.vht_cap.cap |=
++				IEEE80211_VHT_CAP_MAX_MPDU_LENGTH_11454 |
++				IEEE80211_VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MASK;
++		}
++		phy->mt76->sband_2g.sband.vht_cap.vendor_qam256_supported = true;
+ 	}
+ 
+ 	if (phy->mt76->cap.has_5ghz) {
+--- a/mt7921/init.c
++++ b/mt7921/init.c
+@@ -319,6 +319,13 @@ int mt7921_register_device(struct mt792x
+ 	dev->mphy.sband_5g.sband.ht_cap.cap |=
+ 			IEEE80211_HT_CAP_LDPC_CODING |
+ 			IEEE80211_HT_CAP_MAX_AMSDU;
++	dev->mphy.sband_2g.sband.vht_cap.cap |=
++			IEEE80211_VHT_CAP_MAX_MPDU_LENGTH_11454 |
++			IEEE80211_VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MASK |
++			IEEE80211_VHT_CAP_SU_BEAMFORMEE_CAPABLE |
++			IEEE80211_VHT_CAP_MU_BEAMFORMEE_CAPABLE |
++			(3 << IEEE80211_VHT_CAP_BEAMFORMEE_STS_SHIFT);
++	dev->mphy.sband_2g.sband.vht_cap.vendor_qam256_supported = true;
+ 	dev->mphy.sband_5g.sband.vht_cap.cap |=
+ 			IEEE80211_VHT_CAP_MAX_MPDU_LENGTH_11454 |
+ 			IEEE80211_VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MASK |
+--- a/mt7925/init.c
++++ b/mt7925/init.c
+@@ -277,6 +277,13 @@ int mt7925_register_device(struct mt792x
+ 			IEEE80211_HT_CAP_MAX_AMSDU;
+ 	dev->mphy.sband_2g.sband.ht_cap.ampdu_density =
+ 			IEEE80211_HT_MPDU_DENSITY_1;
++	dev->mphy.sband_2g.sband.vht_cap.cap |=
++			IEEE80211_VHT_CAP_MAX_MPDU_LENGTH_11454 |
++			IEEE80211_VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MASK |
++			IEEE80211_VHT_CAP_SU_BEAMFORMEE_CAPABLE |
++			IEEE80211_VHT_CAP_MU_BEAMFORMEE_CAPABLE |
++			(3 << IEEE80211_VHT_CAP_BEAMFORMEE_STS_SHIFT);
++	dev->mphy.sband_2g.sband.vht_cap.vendor_qam256_supported = true;
+ 	dev->mphy.sband_5g.sband.vht_cap.cap |=
+ 			IEEE80211_VHT_CAP_MAX_MPDU_LENGTH_11454 |
+ 			IEEE80211_VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MASK |
+--- a/mt7996/init.c
++++ b/mt7996/init.c
+@@ -406,6 +406,11 @@ mt7996_init_wiphy(struct ieee80211_hw *h
+ 		phy->mt76->sband_2g.sband.ht_cap.cap |=
+ 			IEEE80211_HT_CAP_LDPC_CODING |
+ 			IEEE80211_HT_CAP_MAX_AMSDU;
++
++		phy->mt76->sband_2g.sband.vht_cap.cap |=
++			IEEE80211_VHT_CAP_MAX_MPDU_LENGTH_11454 |
++			IEEE80211_VHT_CAP_MAX_A_MPDU_LENGTH_EXPONENT_MASK;
++		phy->mt76->sband_2g.sband.vht_cap.vendor_qam256_supported = true;
+ 		phy->mt76->sband_2g.sband.ht_cap.ampdu_density =
+ 			IEEE80211_HT_MPDU_DENSITY_2;
+ 	}

--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -312,7 +312,6 @@ mac80211_hostapd_setup_base() {
 		esac
 		[ -n "$op_class" ] && append base_cfg "op_class=$op_class" "$N"
 	}
-	[ "$hwmode" = "a" ] || enable_ac=0
 	[ "$band" = "6g" ] && enable_ac=0
 
 	if [ "$enable_ac" != "0" ]; then

--- a/package/network/utils/iwinfo/patches/0001-nl80211-add-support-for-QAM-256-in-2.4GHz-802.11n.patch
+++ b/package/network/utils/iwinfo/patches/0001-nl80211-add-support-for-QAM-256-in-2.4GHz-802.11n.patch
@@ -1,0 +1,69 @@
+From b4fe1f680ba28588c330bcd65156ef7f8423426c Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Thu, 15 Jun 2023 19:44:53 +0200
+Subject: [PATCH] nl80211: add support for QAM-256 in 2.4GHz 802.11n
+
+Add support for QAM-256 in 2.4GHz 802.11n where VHT rates are set in
+2.4GHz 802.11n mode.
+
+To identify if we are using this non-standard mode, we refer to the
+hostapd conf providing vht_capab config.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ iwinfo_nl80211.c | 18 +++++++++++++++---
+ 1 file changed, 15 insertions(+), 3 deletions(-)
+
+--- a/iwinfo_nl80211.c
++++ b/iwinfo_nl80211.c
+@@ -3216,6 +3216,14 @@ static void nl80211_eval_modelist(struct
+ 	{
+ 		m->hw |= IWINFO_80211_B;
+ 		m->hw |= IWINFO_80211_G;
++
++		if (m->nl_vht > 0)
++		{
++			m->ht |= IWINFO_HTMODE_VHT20;
++
++			if (m->nl_ht & (1 << 1))
++				m->ht |= IWINFO_HTMODE_VHT40;
++		}
+ 	}
+ 
+ 	if (m->bands & IWINFO_BAND_5)
+@@ -3366,6 +3374,7 @@ static int nl80211_get_htmode(const char
+ 	struct chan_info chn = { 0 };
+ 	char *res, b[2] = { 0 };
+ 	int err;
++	bool vendor_qam256 = false;
+ 	bool he = false;
+ 	bool eht = false;
+ 
+@@ -3388,13 +3397,17 @@ static int nl80211_get_htmode(const char
+ 		eht = b[0] == '7';
+ 	}
+ 
++	if ((chn.width == NL80211_CHAN_WIDTH_20 || chn.width == NL80211_CHAN_WIDTH_40) &&
++	    nl80211_hostapd_query(res ? res : ifname, "vht_capab", b, sizeof(b)))
++		vendor_qam256 = true;
++
+ 	switch (chn.width) {
+ 	case NL80211_CHAN_WIDTH_20:
+ 		if (eht)
+ 			*buf = IWINFO_HTMODE_EHT20;
+ 		else if (he)
+ 			*buf = IWINFO_HTMODE_HE20;
+-		else if (chn.mode == -1)
++		else if (chn.mode == -1 || vendor_qam256)
+ 			*buf = IWINFO_HTMODE_VHT20;
+ 		else
+ 			*buf = IWINFO_HTMODE_HT20;
+@@ -3404,7 +3417,7 @@ static int nl80211_get_htmode(const char
+ 			*buf = IWINFO_HTMODE_EHT40;
+ 		else if (he)
+ 			*buf = IWINFO_HTMODE_HE40;
+-		else if (chn.mode == -1)
++		else if (chn.mode == -1 || vendor_qam256)
+ 			*buf = IWINFO_HTMODE_VHT40;
+ 		else
+ 			*buf = IWINFO_HTMODE_HT40;


### PR DESCRIPTION
Add support for QAM-256 in 2.4GHz 802.11n. This is non-standard and
comunicate vht capabilities in 2.4GHz 802.11n permittin, for supported
clients, to benefits for additional data rate.

Many driver supports this, for a start enable this for ath10k and
ath11k.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

---

I would ask the community some effort to document all the info we have about this feature, benefits ANY PROBLEM with this.
The intention is to propose this upstream and I need some very good reasoning for this hoping they don't NACK this directly.

Also I would ask if there is any info on a parallel feature like QAM-1024 that should be present in 802.11ac

How to enable
---
Set for 2.4GHz `htmode` to `VHT20` (or `VHT40`) FOR SUPPORTED CARD

Supported card
---
- qca9984 (Netgear r7800)

Supported device from report
---
- Samsung Galaxy S21

Additional Info on the thing
---
In [1] there was an interesting discussion about this. The summarize was that it's obviously non-standard but actually not that non-standard since this just push vht on 2.4GHz, something that was used later for wifi ax.

[1] https://www.cwnp.com/forums/posts?postNum=307375

<sub>Continuation of #12594 and #2522</sub>