### PR TITLE
Fix NETGEAR DGND3700v2 bootloop

### DIFF
--- a/target/linux/bcm63xx/dts/bcm6362-netgear-dgnd3700-v2.dts
+++ b/target/linux/bcm63xx/dts/bcm6362-netgear-dgnd3700-v2.dts
@@ -167,6 +167,7 @@
 				compatible = "brcm,wfi";
 				label = "wfi";
 				reg = <0x0004000 0x1c7c000>;
+				brcm,cferam = "cfe";
 			};
 
 			partition@1c80000 {

--- a/target/linux/bmips/dts/bcm6362-netgear-dgnd3700-v2.dts
+++ b/target/linux/bmips/dts/bcm6362-netgear-dgnd3700-v2.dts
@@ -222,6 +222,7 @@
 				compatible = "brcm,wfi";
 				label = "wfi";
 				reg = <0x0004000 0x1c7c000>;
+				brcm,cferam = "cfe";
 			};
 
 			partition@1c80000 {


### PR DESCRIPTION
The DGND3700v2 renames the cferam bootloader from cferam to cfeXXX, where XXX
is the number of firmware upgrades performed by the bootloader. Other bcm63xx
devices rename cferam.000 to cferam.XXX, but this device is special because
the cferam name isn't changed on the first firmware flashing but it's changed
on the subsequent ones.
Therefore, we need to look for "cfe" instead of "cferam" to properly detect
the cferam partition and fix the bootlop.

Fixes: https://github.com/openwrt/openwrt/issues/8691

CC @danitool @infrastation