### PR TITLE
ath79: add support for MikroTik RB951G-2HnD

### DIFF
--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951g-2hnd.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951g-2hnd.dts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_mikrotik_routerboard-951x-2hnd.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-951g-2hnd", "qca,ar9344";
+	model = "Mikrotik RouterBOARD 951G-2HnD";
+
+	/delete-node/ aliases;
+	/delete-node/ leds;
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_usb_power {
+			gpio-export,name = "rb951g-2hnd:power:usb";
+			gpio-export,output = <1>;
+			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <25000000>;
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+                qca,ar8327-initvals = <
+			0x04 0x07600000 /* PAD0_MODE */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x6f000000 0x00000101 0x00001616>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-gmac0 = <1>;
+		rxd-delay = <1>;
+		switch-only-mode = <1>;
+	};
+};
+
+&eth1 {
+	status = "disabled";
+};

--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951ui-2hnd.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951ui-2hnd.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "ar9344_mikrotik_routerboard.dtsi"
+#include "ar9344_mikrotik_routerboard-951x-2hnd.dtsi"
 
 / {
 	compatible = "mikrotik,routerboard-951ui-2hnd", "qca,ar9344";
@@ -59,77 +59,6 @@
 	};
 };
 
-&gpio {
-	nand_power {
-		gpio-hog;
-		gpios = <14 GPIO_ACTIVE_LOW>;
-		output-high;
-	};
-};
-
-&nand {
-	status = "okay";
-
-	nand-ecc-mode = "soft";
-	qca,nand-swap-dma;
-
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		partition@0 {
-			label = "booter";
-			reg = <0x0000000 0x0040000>;
-			read-only;
-		};
-
-		partition@40000 {
-			label = "kernel";
-			reg = <0x0040000 0x03c0000>;
-		};
-
-		partition@400000 {
-			label = "ubi";
-			reg = <0x0400000 0x7c00000>;
-		};
-	};
-};
-
-&spi {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "mikrotik,routerboot-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "routerboot";
-				reg = <0x0 0x0>;
-				read-only;
-			};
-
-			hard_config: hard_config {
-				read-only;
-			};
-
-			bios {
-				size = <0x1000>;
-				read-only;
-			};
-
-			soft_config {
-			};
-		};
-	};
-};
-
 &eth0 {
 	phy-handle = <&swphy4>;
 
@@ -142,12 +71,4 @@
 
 &wmac {
 	qca,led-pin = /bits/ 8 <11>;
-};
-
-&usb {
-	status = "okay";
-};
-
-&usb_phy {
-	status = "okay";
 };

--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951x-2hnd.dtsi
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951x-2hnd.dtsi
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_mikrotik_routerboard.dtsi"
+
+&gpio {
+	nand_power {
+		gpio-hog;
+		gpios = <14 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+};
+
+&nand {
+	status = "okay";
+
+	nand-ecc-mode = "soft";
+	qca,nand-swap-dma;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "booter";
+			reg = <0x0000000 0x0040000>;
+			read-only;
+		};
+
+		partition@40000 {
+			label = "kernel";
+			reg = <0x0040000 0x03c0000>;
+		};
+
+		partition@400000 {
+			label = "ubi";
+			reg = <0x0400000 0x7c00000>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "mikrotik,routerboot-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "routerboot";
+				reg = <0x0 0x0>;
+				read-only;
+			};
+
+			hard_config: hard_config {
+				read-only;
+			};
+
+			bios {
+				size = <0x1000>;
+				read-only;
+			};
+
+			soft_config {
+			};
+		};
+	};
+};
+
+&usb {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -48,6 +48,15 @@ define Device/mikrotik_routerboard-922uags-5hpacd
 endef
 TARGET_DEVICES += mikrotik_routerboard-922uags-5hpacd
 
+define Device/mikrotik_routerboard-951g-2hnd
+  $(Device/mikrotik_nand)
+  SOC := ar9344
+  DEVICE_MODEL := RouterBOARD 951G-2HnD
+  DEVICE_PACKAGES += kmod-usb-ohci kmod-usb2
+  SUPPORTED_DEVICES += rb-951g-2hnd
+endef
+TARGET_DEVICES += mikrotik_routerboard-951g-2hnd
+
 define Device/mikrotik_routerboard-951ui-2hnd
   $(Device/mikrotik_nand)
   SOC := ar9344

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -35,6 +35,7 @@ ath79_setup_interfaces()
 	mikrotik,routerboard-map-2nd)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;
+	mikrotik,routerboard-951g-2hnd|\
 	mikrotik,routerboard-962uigs-5hact2hnt)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:lan" "4:lan" "5:lan" "1:wan"

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -46,6 +46,7 @@ case "$FIRMWARE" in
 	mikrotik,routerboard-962uigs-5hact2hnt)
 		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" 7)
 		;;
+	mikrotik,routerboard-951g-2hnd|\
 	mikrotik,routerboard-951ui-2hnd)
 		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" +11)
 		;;

--- a/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
@@ -33,6 +33,7 @@ platform_do_upgrade() {
 	mikrotik,routerboard-912uag-2hpnd|\
 	mikrotik,routerboard-921gs-5hpacd-15s|\
 	mikrotik,routerboard-922uags-5hpacd|\
+	mikrotik,routerboard-951g-2hnd|\
 	mikrotik,routerboard-951ui-2hnd|\
 	mikrotik,routerboard-sxt-5nd-r2)
 		platform_do_upgrade_mikrotik_nand "$1"


### PR DESCRIPTION
MikroTik RB951G-2HnD is a wireless SOHO router that was previously supported by the ar71xx target, see commit 7a709573d7 ("ar71xx: add kernel support for the Mikrotik RB951G board").

Specifications
--------------

  - SoC: Atheros AR9344 (600 MHz)
  - RAM: 128 MB (2x 64 MB)
  - Storage: 128 MB NAND flash (various manufacturers)
  - Ethernet: Atheros AR8327 switch, 5x 10/100/1000 Mbit/s
      - 1x PoE in (port 1, 8-30 V input)
  - Wireless: Atheros AR9340 (802.11b/g/n)
  - USB: 2.0 (1A)
  - 8x LED:
      - 1x power (green, not configurable)
      - 1x user (green, not configurable)
      - 5x GE ports (green, not configurable)
      - 1x wireless (green, not configurable)
  - 1x button (restart)

Unlike on the RB951Ui-2HnD, none of the LEDs on this device seem to be GPIO-controllable, which was also the case for older OpenWRT versions that supported this board via a mach file.  The Ethernet port LEDs are controlled by the switch chip.

See https://mikrotik.com/product/RB951G-2HnD for more details.

Flashing
--------

TFTP boot initramfs image and then perform sysupgrade.  Follow common MikroTik procedures at https://openwrt.org/toh/mikrotik/common.
