### PR TITLE
Fix mbedTLS missing TLS v1.3 support with OpenSSL

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -130,6 +130,26 @@ menu "Global build settings"
 		  Useful for release builds, so that kernel issues can be debugged offline
 		  later.
 
+	choice
+		prompt "TLS provider"
+		default TLS_PROVIDER_MBEDTLS if !GRAND_FLASH
+		default TLS_PROVIDER_OPENSSL if GRAND_FLASH
+		help
+                  This allows to select TLS provider.
+
+	config TLS_PROVIDER_MBEDTLS
+		bool "mbedTLS"
+		select PACKAGE_libustream-mbedtls
+
+	config TLS_PROVIDER_OPENSSL
+		bool "OpenSSL"
+		select PACKAGE_libustream-openssl
+
+	config TLS_PROVIDER_WOLFSSL
+		bool "wolfSSL"
+		select PACKAGE_libustream-wolfssl
+	endchoice
+
 	menu "Kernel build options"
 
 	source "config/Config-kernel.in"

--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -138,8 +138,6 @@ menu "Target Images"
 
 	config TARGET_ROOTFS_JFFS2_NAND
 		bool "jffs2 for NAND"
-		default y if USES_JFFS2_NAND
-		depends on USES_JFFS2_NAND
 		help
 		  Build a JFFS2 root filesystem for NAND flash.
 

--- a/include/image.mk
+++ b/include/image.mk
@@ -40,8 +40,10 @@ IMG_PREFIX_VERCODE:=$(if $(CONFIG_VERSION_CODE_FILENAMES),$(call sanitize,$(VERS
 IMG_PREFIX:=$(VERSION_DIST_SANITIZED)-$(IMG_PREFIX_VERNUM)$(IMG_PREFIX_VERCODE)$(IMG_PREFIX_EXTRA)$(BOARD)$(if $(SUBTARGET),-$(SUBTARGET))
 IMG_ROOTFS:=$(IMG_PREFIX)-rootfs
 IMG_COMBINED:=$(IMG_PREFIX)-combined
+ifeq ($(DUMP),)
 IMG_PART_SIGNATURE:=$(shell echo $(SOURCE_DATE_EPOCH)$(LINUX_VERMAGIC) | $(MKHASH) md5 | cut -b1-8)
 IMG_PART_DISKGUID:=$(shell echo $(SOURCE_DATE_EPOCH)$(LINUX_VERMAGIC) | $(MKHASH) md5 | sed -E 's/(.{8})(.{4})(.{4})(.{4})(.{10})../\1-\2-\3-\4-\500/')
+endif
 
 MKFS_DEVTABLE_OPT := -D $(INCLUDE_DIR)/device_table.txt
 
@@ -167,7 +169,9 @@ define Image/pad-to
 	mv $(1).new $(1)
 endef
 
+ifeq ($(DUMP),)
 ROOTFS_PARTSIZE=$(shell echo $$(($(CONFIG_TARGET_ROOTFS_PARTSIZE)*1024*1024)))
+endif
 
 define Image/pad-root-squashfs
 	$(call Image/pad-to,$(KDIR)/root.squashfs,$(if $(1),$(1),$(ROOTFS_PARTSIZE)))

--- a/include/scan.mk
+++ b/include/scan.mk
@@ -50,7 +50,8 @@ define PackageDir
 		$$(call progress,Collecting $(SCAN_NAME) info: $(SCAN_DIR)/$(2)) \
 		echo Source-Makefile: $(SCAN_DIR)/$(2)/Makefile; \
 		$(if $(3),echo Override: $(3),true); \
-		$(NO_TRACE_MAKE) --no-print-dir -r DUMP=1 FEED="$(call feedname,$(2))" -C $(SCAN_DIR)/$(2) $(SCAN_MAKEOPTS) 2>/dev/null || { \
+		$(if $(findstring c,$(OPENWRT_VERBOSE)),$(MAKE),$(NO_TRACE_MAKE) --no-print-dir) -r DUMP=1 FEED="$(call feedname,$(2))" -C $(SCAN_DIR)/$(2) $(SCAN_MAKEOPTS) \
+			$(if $(findstring c,$(OPENWRT_VERBOSE)),,2>/dev/null) || { \
 			mkdir -p "$(TOPDIR)/logs/$(SCAN_DIR)/$(2)"; \
 			$(NO_TRACE_MAKE) --no-print-dir -r DUMP=1 FEED="$(call feedname,$(2))" -C $(SCAN_DIR)/$(2) $(SCAN_MAKEOPTS) > $(TOPDIR)/logs/$(SCAN_DIR)/$(2)/dump.txt 2>&1; \
 			$$(call progress,ERROR: please fix $(SCAN_DIR)/$(2)/Makefile - see logs/$(SCAN_DIR)/$(2)/dump.txt for details\n) \

--- a/include/target.mk
+++ b/include/target.mk
@@ -17,7 +17,6 @@ DEFAULT_PACKAGES:=\
 	fstools \
 	libc \
 	libgcc \
-	libustream-mbedtls \
 	logd \
 	mtd \
 	netifd \
@@ -36,6 +35,13 @@ endif
 # include ujail on systems with enough storage
 ifeq ($(CONFIG_SMALL_FLASH),)
 DEFAULT_PACKAGES+=procd-ujail
+endif
+
+# mbedTLS wireless features handling
+DEFAULT_PACKAGES+=libustream-mbedtls
+PACKAGE_NO_WIRELESS:=-wpad-basic-mbedtls
+ifneq($(CONFIG_WIRELESS_SUPPORT),)
+DEFAULT_PACKAGES+=wpad-basic-mbedtls
 endif
 
 # include seccomp ld-preload hooks if kernel supports it

--- a/include/target.mk
+++ b/include/target.mk
@@ -37,11 +37,31 @@ ifeq ($(CONFIG_SMALL_FLASH),)
 DEFAULT_PACKAGES+=procd-ujail
 endif
 
-# mbedTLS wireless features handling
-DEFAULT_PACKAGES+=libustream-mbedtls
-PACKAGE_NO_WIRELESS:=-wpad-basic-mbedtls
-ifneq($(CONFIG_WIRELESS_SUPPORT),)
-DEFAULT_PACKAGES+=wpad-basic-mbedtls
+# mbedTLS and wireless features handling
+ifeq ($(CONFIG_TLS_PROVIDER_MBEDTLS),y)
+  DEFAULT_PACKAGES+=libustream-mbedtls
+  PACKAGE_NO_WIRELESS:=-wpad-basic-mbedtls
+  ifneq ($(CONFIG_WIRELESS_SUPPORT),)
+    DEFAULT_PACKAGES+=wpad-basic-mbedtls
+  endif
+endif
+
+# OpenSSL and wireless features handling
+ifeq ($(CONFIG_TLS_PROVIDER_OPENSSL),y)
+  DEFAULT_PACKAGES+=libustream-openssl
+  PACKAGE_NO_WIRELESS:=-wpad-basic-openssl
+  ifneq ($(CONFIG_WIRELESS_SUPPORT),)
+    DEFAULT_PACKAGES+=wpad-basic-openssl
+  endif
+endif
+
+# wolfSSL and wireless features handling
+ifeq ($(CONFIG_TLS_PROVIDER_WOLFSSL),y)
+  DEFAULT_PACKAGES+=libustream-wolfssl
+  PACKAGE_NO_WIRELESS:=-wpad-basic-wolfssl
+  ifneq ($(CONFIG_WIRELESS_SUPPORT),)
+    DEFAULT_PACKAGES+=wpad-basic-wolfssl
+  endif
 endif
 
 # include seccomp ld-preload hooks if kernel supports it

--- a/rules.mk
+++ b/rules.mk
@@ -90,9 +90,6 @@ endif
 ifneq ($(filter -march=armv%,$(TARGET_OPTIMIZATION)),)
   GCC_ARCH:=$(patsubst -march=%,%,$(filter -march=armv%,$(TARGET_OPTIMIZATION)))
 endif
-ifdef CONFIG_HAS_SPE_FPU
-  TARGET_SUFFIX:=$(TARGET_SUFFIX)spe
-endif
 ifdef CONFIG_MIPS64_ABI
   ifneq ($(CONFIG_MIPS64_ABI_O32),y)
      ARCH_SUFFIX:=$(ARCH_SUFFIX)_$(call qstrip,$(CONFIG_MIPS64_ABI))

--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -21,6 +21,7 @@ sub target_config_features(@) {
 		/^ext4$/ and $ret .= "\tselect USES_EXT4\n";
 		/^fpu$/ and $ret .= "\tselect HAS_FPU\n";
 		/^gpio$/ and $ret .= "\tselect GPIO_SUPPORT\n";
+		/^grand-flash$/ and $ret .= "\tselect GRAND_FLASH\n";
 		/^jffs2$/ and $ret .= "\tselect USES_JFFS2\n";
 		/^jffs2_nand$/ and $ret .= "\tselect USES_JFFS2_NAND\n";
 		/^legacy-sdcard$/ and $ret .= "\tselect LEGACY_SDCARD_SUPPORT\n";

--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -40,7 +40,6 @@ sub target_config_features(@) {
 		/^rtc$/ and $ret .= "\tselect RTC_SUPPORT\n";
 		/^separate-ramdisk$/ and $ret .= "\tselect USES_INITRAMFS\n\tselect USES_SEPARATE_INITRAMFS\n";
 		/^small-flash$/ and $ret .= "\tselect SMALL_FLASH\n";
-		/^spe_fpu$/ and $ret .= "\tselect HAS_SPE_FPU\n";
 		/^squashfs$/ and $ret .= "\tselect USES_SQUASHFS\n";
 		/^targz$/ and $ret .= "\tselect USES_TARGZ\n";
 		/^testing-kernel$/ and $ret .= "\tselect HAS_TESTING_KERNEL\n";

--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -39,7 +39,7 @@ sub target_config_features(@) {
 		/^rootfs-part$/ and $ret .= "\tselect USES_ROOTFS_PART\n";
 		/^rtc$/ and $ret .= "\tselect RTC_SUPPORT\n";
 		/^separate-ramdisk$/ and $ret .= "\tselect USES_INITRAMFS\n\tselect USES_SEPARATE_INITRAMFS\n";
-		/^small_flash$/ and $ret .= "\tselect SMALL_FLASH\n";
+		/^small-flash$/ and $ret .= "\tselect SMALL_FLASH\n";
 		/^spe_fpu$/ and $ret .= "\tselect HAS_SPE_FPU\n";
 		/^squashfs$/ and $ret .= "\tselect USES_SQUASHFS\n";
 		/^targz$/ and $ret .= "\tselect USES_TARGZ\n";

--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -23,7 +23,6 @@ sub target_config_features(@) {
 		/^gpio$/ and $ret .= "\tselect GPIO_SUPPORT\n";
 		/^grand-flash$/ and $ret .= "\tselect GRAND_FLASH\n";
 		/^jffs2$/ and $ret .= "\tselect USES_JFFS2\n";
-		/^jffs2_nand$/ and $ret .= "\tselect USES_JFFS2_NAND\n";
 		/^legacy-sdcard$/ and $ret .= "\tselect LEGACY_SDCARD_SUPPORT\n";
 		/^low_mem$/ and $ret .= "\tselect LOW_MEMORY_FOOTPRINT\n";
 		/^minor$/ and $ret .= "\tselect USES_MINOR\n";

--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -24,7 +24,7 @@ sub target_config_features(@) {
 		/^grand-flash$/ and $ret .= "\tselect GRAND_FLASH\n";
 		/^jffs2$/ and $ret .= "\tselect USES_JFFS2\n";
 		/^legacy-sdcard$/ and $ret .= "\tselect LEGACY_SDCARD_SUPPORT\n";
-		/^low_mem$/ and $ret .= "\tselect LOW_MEMORY_FOOTPRINT\n";
+		/^low-mem$/ and $ret .= "\tselect LOW_MEMORY_FOOTPRINT\n";
 		/^minor$/ and $ret .= "\tselect USES_MINOR\n";
 		/^mips16$/ and $ret .= "\tselect HAS_MIPS16\n";
 		/^nand$/ and $ret .= "\tselect NAND_SUPPORT\n";

--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -49,6 +49,7 @@ sub target_config_features(@) {
 		/^usb$/ and $ret .= "\tselect USB_SUPPORT\n";
 		/^usbgadget$/ and $ret .= "\tselect USB_GADGET_SUPPORT\n";
 		/^virtio$/ and $ret .= "\tselect VIRTIO_SUPPORT\n";
+		/^wireless$/ and $ret .= "\tselect WIRELESS_SUPPORT\n";
 	}
 	return $ret;
 }

--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -38,7 +38,7 @@ sub target_config_features(@) {
 		/^rfkill$/ and $ret .= "\tselect RFKILL_SUPPORT\n";
 		/^rootfs-part$/ and $ret .= "\tselect USES_ROOTFS_PART\n";
 		/^rtc$/ and $ret .= "\tselect RTC_SUPPORT\n";
-		/^separate_ramdisk$/ and $ret .= "\tselect USES_INITRAMFS\n\tselect USES_SEPARATE_INITRAMFS\n";
+		/^separate-ramdisk$/ and $ret .= "\tselect USES_INITRAMFS\n\tselect USES_SEPARATE_INITRAMFS\n";
 		/^small_flash$/ and $ret .= "\tselect SMALL_FLASH\n";
 		/^spe_fpu$/ and $ret .= "\tselect HAS_SPE_FPU\n";
 		/^squashfs$/ and $ret .= "\tselect USES_SQUASHFS\n";

--- a/target/Config.in
+++ b/target/Config.in
@@ -63,9 +63,6 @@ config USES_SQUASHFS
 config USES_JFFS2
 	bool
 
-config USES_JFFS2_NAND
-	bool
-
 config USES_EXT4
 	bool
 

--- a/target/Config.in
+++ b/target/Config.in
@@ -88,6 +88,9 @@ config LOW_MEMORY_FOOTPRINT
 config SMALL_FLASH
 	bool
 
+config GRAND_FLASH
+	bool
+
 config NOMMU
 	bool
 

--- a/target/Config.in
+++ b/target/Config.in
@@ -5,11 +5,6 @@ source "tmp/.config-target.in"
 config HAS_TESTING_KERNEL
 	bool
 
-config HAS_SPE_FPU
-	depends on powerpc
-	select HAS_FPU
-	bool
-
 config HAS_FPU
 	bool
 

--- a/target/Config.in
+++ b/target/Config.in
@@ -124,6 +124,9 @@ config USES_BOOT_PART
 
 config WIRELESS_SUPPORT
 	bool
+	imply PACKAGE_wpad-basic-mbedtls if TLS_PROVIDER_MBEDTLS
+	imply PACKAGE_wpad-basic-openssl if TLS_PROVIDER_OPENSSL
+	imply PACKAGE_wpad-basic-wolfssl if TLS_PROVIDER_WOLFSSL
 
 # Architecture selection
 

--- a/target/Config.in
+++ b/target/Config.in
@@ -122,6 +122,9 @@ config USES_ROOTFS_PART
 config USES_BOOT_PART
 	bool
 
+config WIRELESS_SUPPORT
+	bool
+
 # Architecture selection
 
 config aarch64

--- a/target/linux/airoha/Makefile
+++ b/target/linux/airoha/Makefile
@@ -4,7 +4,7 @@ ARCH:=arm
 BOARD:=airoha
 BOARDNAME:=Airoha ARM
 CPU_TYPE:=cortex-a7
-FEATURES:=dt squashfs nand ramdisk gpio source-only
+FEATURES:=dt squashfs nand ramdisk gpio source-only grand-flash
 
 KERNEL_PATCHVER:=5.15
 

--- a/target/linux/apm821xx/Makefile
+++ b/target/linux/apm821xx/Makefile
@@ -6,7 +6,7 @@ ARCH:=powerpc
 BOARD:=apm821xx
 BOARDNAME:=AppliedMicro APM821xx
 CPU_TYPE:=464fp
-FEATURES:=fpu dt gpio ramdisk squashfs usb
+FEATURES:=fpu dt gpio ramdisk squashfs usb wireless
 SUBTARGETS:=nand sata
 
 KERNEL_PATCHVER:=5.15

--- a/target/linux/apm821xx/image/sata.mk
+++ b/target/linux/apm821xx/image/sata.mk
@@ -9,7 +9,7 @@ define Device/wd_mybooklive
   DEVICE_ALT0_VENDOR := Western Digital
   DEVICE_ALT0_MODEL := My Book Live Duo
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-ata-dwc kmod-usb-ledtrig-usbport \
-	kmod-usb-storage kmod-fs-vfat
+	kmod-usb-storage kmod-fs-vfat $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += mbl wd,mybooklive-duo
   BLOCKSIZE := 1k
   DEVICE_DTC_FLAGS := --pad 4096

--- a/target/linux/apm821xx/image/sata.mk
+++ b/target/linux/apm821xx/image/sata.mk
@@ -9,7 +9,7 @@ define Device/wd_mybooklive
   DEVICE_ALT0_VENDOR := Western Digital
   DEVICE_ALT0_MODEL := My Book Live Duo
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-ata-dwc kmod-usb-ledtrig-usbport \
-	kmod-usb-storage kmod-fs-vfat wpad-basic-mbedtls
+	kmod-usb-storage kmod-fs-vfat
   SUPPORTED_DEVICES += mbl wd,mybooklive-duo
   BLOCKSIZE := 1k
   DEVICE_DTC_FLAGS := --pad 4096

--- a/target/linux/apm821xx/nand/target.mk
+++ b/target/linux/apm821xx/nand/target.mk
@@ -1,7 +1,7 @@
 BOARDNAME:=Devices with NAND flash (Routers)
 FEATURES += nand pcie
 
-DEFAULT_PACKAGES += kmod-ath9k swconfig wpad-basic-mbedtls
+DEFAULT_PACKAGES += kmod-ath9k swconfig
 
 define Target/Description
 	Build firmware images for APM821XX boards with NAND flash.

--- a/target/linux/apm821xx/sata/profiles/00-default.mk
+++ b/target/linux/apm821xx/sata/profiles/00-default.mk
@@ -5,7 +5,7 @@
 define Profile/Default
   NAME:=Default Profile
   PRIORITY:=1
-  PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport kmod-usb-storage kmod-fs-vfat wpad-basic-mbedtls
+  PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport kmod-usb-storage kmod-fs-vfat
 endef
 
 define Profile/Default/Description

--- a/target/linux/archs38/generic/profiles/00-default.mk
+++ b/target/linux/archs38/generic/profiles/00-default.mk
@@ -4,7 +4,7 @@
 
 define Profile/Default
 	NAME:=Default Profile (all drivers)
-	PACKAGES:= kmod-usb2 kmod-ath9k-htc wpad-basic-mbedtls
+	PACKAGES:= kmod-usb2 kmod-ath9k-htc
 endef
 
 define Profile/Default/Description

--- a/target/linux/archs38/generic/target.mk
+++ b/target/linux/archs38/generic/target.mk
@@ -1,5 +1,5 @@
 BOARDNAME:=Generic
-FEATURES += ext4 usb ramdisk
+FEATURES += ext4 usb ramdisk wireless
 
 define Target/Description
 	Build firmware images for ARC HS38 based boards.

--- a/target/linux/armsr/Makefile
+++ b/target/linux/armsr/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 BOARD:=armsr
 BOARDNAME:=Arm SystemReady (EFI) compliant
 FEATURES:=fpu pci pcie rtc usb boot-part rootfs-part
-FEATURES+=cpiogz ext4 ramdisk squashfs targz vmdk
+FEATURES+=cpiogz ext4 ramdisk squashfs targz vmdk grand-flash
 
 KERNEL_PATCHVER:=6.1
 

--- a/target/linux/ath25/Makefile
+++ b/target/linux/ath25/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=mips
 BOARD:=ath25
 BOARDNAME:=Atheros AR231x/AR5312
-FEATURES:=squashfs low_mem small_flash source-only
+FEATURES:=squashfs low_mem small_flash source-only wireless
 SUBTARGETS:=generic
 
 KERNEL_PATCHVER:=5.15
@@ -18,6 +18,6 @@ endef
 
 include $(INCLUDE_DIR)/target.mk
 
-DEFAULT_PACKAGES += wpad-basic-mbedtls kmod-ath5k swconfig kmod-gpio-button-hotplug
+DEFAULT_PACKAGES += kmod-ath5k swconfig kmod-gpio-button-hotplug
 
 $(eval $(call BuildTarget))

--- a/target/linux/ath25/Makefile
+++ b/target/linux/ath25/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=mips
 BOARD:=ath25
 BOARDNAME:=Atheros AR231x/AR5312
-FEATURES:=squashfs low_mem small_flash source-only wireless
+FEATURES:=squashfs low-mem small_flash source-only wireless
 SUBTARGETS:=generic
 
 KERNEL_PATCHVER:=5.15

--- a/target/linux/ath25/Makefile
+++ b/target/linux/ath25/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=mips
 BOARD:=ath25
 BOARDNAME:=Atheros AR231x/AR5312
-FEATURES:=squashfs low-mem small_flash source-only wireless
+FEATURES:=squashfs low-mem small-flash source-only wireless
 SUBTARGETS:=generic
 
 KERNEL_PATCHVER:=5.15

--- a/target/linux/ath79/Makefile
+++ b/target/linux/ath79/Makefile
@@ -6,7 +6,7 @@ BOARDNAME:=Atheros ATH79
 CPU_TYPE:=24kc
 SUBTARGETS:=generic mikrotik nand tiny
 
-FEATURES:=ramdisk squashfs usbgadget
+FEATURES:=ramdisk squashfs usbgadget wireless
 
 KERNEL_PATCHVER:=5.15
 KERNEL_TESTING_PATCHVER:=6.1

--- a/target/linux/ath79/generic/target.mk
+++ b/target/linux/ath79/generic/target.mk
@@ -1,7 +1,5 @@
 BOARDNAME:=Generic
 
-DEFAULT_PACKAGES += wpad-basic-mbedtls
-
 define Target/Description
 	Build firmware images for generic Atheros AR71xx/AR913x/AR934x based boards.
 endef

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -186,7 +186,7 @@ endef
 TARGET_DEVICES += ubnt_rocket-m
 
 define Device/ubnt_routerstation_common
-  DEVICE_PACKAGES := -kmod-ath9k -wpad-basic-mbedtls -uboot-envtools kmod-usb-ohci \
+  DEVICE_PACKAGES := -kmod-ath9k $(PACKAGE_NO_WIRELESS) -uboot-envtools kmod-usb-ohci \
 	kmod-usb2 fconfig
   DEVICE_VENDOR := Ubiquiti
   SOC := ar7161

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1660,7 +1660,7 @@ define Device/hak5_lan-turtle
   TPLINK_HWID := 0x5348334c
   IMAGES := sysupgrade.bin
   DEVICE_PACKAGES := kmod-usb-chipidea2 -iwinfo -kmod-ath9k -swconfig \
-	-uboot-envtools -wpad-basic-mbedtls
+	-uboot-envtools $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += lan-turtle
 endef
 TARGET_DEVICES += hak5_lan-turtle
@@ -1673,7 +1673,7 @@ define Device/hak5_packet-squirrel
   TPLINK_HWID := 0x5351524c
   IMAGES := sysupgrade.bin
   DEVICE_PACKAGES := kmod-usb-chipidea2 -iwinfo -kmod-ath9k -swconfig \
-	-uboot-envtools -wpad-basic-mbedtls
+	-uboot-envtools $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += packet-squirrel
 endef
 TARGET_DEVICES += hak5_packet-squirrel
@@ -1708,7 +1708,7 @@ define Device/iodata_etg3-r
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := ETG3-R
   IMAGE_SIZE := 7680k
-  DEVICE_PACKAGES := -iwinfo -kmod-ath9k -wpad-basic-mbedtls
+  DEVICE_PACKAGES := -iwinfo -kmod-ath9k $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += iodata_etg3-r
 
@@ -1768,7 +1768,7 @@ define Device/jjplus_ja76pf2
   SOC := ar7161
   DEVICE_VENDOR := jjPlus
   DEVICE_MODEL := JA76PF2
-  DEVICE_PACKAGES += -kmod-ath9k -swconfig -wpad-basic-mbedtls -uboot-envtools fconfig kmod-hwmon-lm75
+  DEVICE_PACKAGES += -kmod-ath9k -swconfig $(PACKAGE_NO_WIRELESS) -uboot-envtools fconfig kmod-hwmon-lm75
   LOADER_TYPE := bin
   LOADER_FLASH_OFFS := 0x60000
   COMPILE := loader-$(1).bin
@@ -2878,7 +2878,7 @@ define Device/teltonika_rut300
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT300
   SUPPORTED_TELTONIKA_DEVICES := teltonika,rut30x
-  DEVICE_PACKAGES := -kmod-ath9k -uboot-envtools -wpad-basic-mbedtls kmod-usb2
+  DEVICE_PACKAGES := -kmod-ath9k -uboot-envtools $(PACKAGE_NO_WIRELESS) kmod-usb2
   IMAGE_SIZE := 15552k
   IMAGES += factory.bin
   IMAGE/factory.bin = append-kernel | pad-to $$$$(BLOCKSIZE) | \

--- a/target/linux/ath79/mikrotik/target.mk
+++ b/target/linux/ath79/mikrotik/target.mk
@@ -3,7 +3,7 @@ FEATURES += minor nand
 KERNELNAME := vmlinux vmlinuz
 IMAGES_DIR := ../../..
 
-DEFAULT_PACKAGES += wpad-basic-mbedtls yafut
+DEFAULT_PACKAGES += yafut
 
 define Target/Description
 	Build firmware images for MikroTik devices based on Qualcomm Atheros

--- a/target/linux/ath79/nand/target.mk
+++ b/target/linux/ath79/nand/target.mk
@@ -2,8 +2,6 @@ BOARDNAME := Generic devices with NAND flash
 
 FEATURES += nand
 
-DEFAULT_PACKAGES += wpad-basic-mbedtls
-
 define Target/Description
 	Firmware for boards using Qualcomm Atheros, MIPS-based SoCs
 	in the ar72xx and subsequent series, with support for NAND flash

--- a/target/linux/ath79/tiny/target.mk
+++ b/target/linux/ath79/tiny/target.mk
@@ -1,8 +1,6 @@
 BOARDNAME:=Devices with small flash
 FEATURES += low_mem small_flash
 
-DEFAULT_PACKAGES += wpad-basic-mbedtls
-
 define Target/Description
 	Build firmware images for Atheros AR71xx/AR913x/AR934x based boards with small flash
 endef

--- a/target/linux/ath79/tiny/target.mk
+++ b/target/linux/ath79/tiny/target.mk
@@ -1,5 +1,5 @@
 BOARDNAME:=Devices with small flash
-FEATURES += low_mem small_flash
+FEATURES += low-mem small_flash
 
 define Target/Description
 	Build firmware images for Atheros AR71xx/AR913x/AR934x based boards with small flash

--- a/target/linux/ath79/tiny/target.mk
+++ b/target/linux/ath79/tiny/target.mk
@@ -1,5 +1,5 @@
 BOARDNAME:=Devices with small flash
-FEATURES += low-mem small_flash
+FEATURES += low-mem small-flash
 
 define Target/Description
 	Build firmware images for Atheros AR71xx/AR913x/AR934x based boards with small flash

--- a/target/linux/bcm27xx/Makefile
+++ b/target/linux/bcm27xx/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=bcm27xx
 BOARDNAME:=Broadcom BCM27xx
-FEATURES:=audio boot-part display ext4 fpu gpio rootfs-part rtc squashfs usb usbgadget
+FEATURES:=audio boot-part display ext4 fpu gpio rootfs-part rtc squashfs usb usbgadget wireless
 SUBTARGETS:=bcm2708 bcm2709 bcm2710 bcm2711
 
 KERNEL_PATCHVER:=6.1

--- a/target/linux/bcm27xx/Makefile
+++ b/target/linux/bcm27xx/Makefile
@@ -8,7 +8,8 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=bcm27xx
 BOARDNAME:=Broadcom BCM27xx
-FEATURES:=audio boot-part display ext4 fpu gpio rootfs-part rtc squashfs usb usbgadget wireless
+FEATURES:=audio boot-part display ext4 fpu gpio
+FEATURES+=rootfs-part rtc squashfs usb usbgadget wireless grand-flash
 SUBTARGETS:=bcm2708 bcm2709 bcm2710 bcm2711
 
 KERNEL_PATCHVER:=6.1

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -77,7 +77,7 @@ define Device/rpi
   DEVICE_PACKAGES := \
 	cypress-firmware-43430-sdio \
 	brcmfmac-nvram-43430-sdio \
-	kmod-brcmfmac wpad-basic-mbedtls
+	kmod-brcmfmac
 endef
 ifeq ($(SUBTARGET),bcm2708)
   TARGET_DEVICES += rpi
@@ -110,7 +110,7 @@ define Device/rpi-2
 	brcmfmac-nvram-43430-sdio \
 	cypress-firmware-43455-sdio \
 	brcmfmac-nvram-43455-sdio \
-	kmod-brcmfmac wpad-basic-mbedtls
+	kmod-brcmfmac
   IMAGE/sysupgrade.img.gz := boot-common | boot-2708 | boot-2711 | sdcard-img | gzip | append-metadata
   IMAGE/factory.img.gz := boot-common | boot-2708 | boot-2711 | sdcard-img | gzip
 endef
@@ -141,7 +141,7 @@ define Device/rpi-3
 	brcmfmac-nvram-43430-sdio \
 	cypress-firmware-43455-sdio \
 	brcmfmac-nvram-43455-sdio \
-	kmod-brcmfmac wpad-basic-mbedtls
+	kmod-brcmfmac
 endef
 ifeq ($(SUBTARGET),bcm2710)
   TARGET_DEVICES += rpi-3
@@ -162,7 +162,7 @@ define Device/rpi-4
   DEVICE_PACKAGES := \
 	cypress-firmware-43455-sdio \
 	brcmfmac-nvram-43455-sdio \
-	kmod-brcmfmac wpad-basic-mbedtls \
+	kmod-brcmfmac \
 	kmod-usb-net-lan78xx \
 	kmod-r8169
   IMAGE/sysupgrade.img.gz := boot-common | boot-2711 | sdcard-img | gzip | append-metadata

--- a/target/linux/bcm47xx/generic/profiles/101-Broadcom-wl.mk
+++ b/target/linux/bcm47xx/generic/profiles/101-Broadcom-wl.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-wl
   NAME:=Broadcom SoC, all Ethernet, BCM43xx WiFi (wl, proprietary)
-  PACKAGES:=-wpad-basic-mbedtls kmod-b44 kmod-tg3 kmod-bgmac kmod-brcm-wl wlc nas
+  PACKAGES:=$(PACKAGE_NO_WIRELESS) kmod-b44 kmod-tg3 kmod-bgmac kmod-brcm-wl wlc nas
 endef
 
 define Profile/Broadcom-wl/Description

--- a/target/linux/bcm47xx/generic/profiles/105-Broadcom-none.mk
+++ b/target/linux/bcm47xx/generic/profiles/105-Broadcom-none.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-none
   NAME:=Broadcom SoC, all Ethernet, No WiFi
-  PACKAGES:=-wpad-basic-mbedtls kmod-b44 kmod-tg3 kmod-bgmac
+  PACKAGES:=$(PACKAGE_NO_WIRELESS) kmod-b44 kmod-tg3 kmod-bgmac
 endef
 
 define Profile/Broadcom-none/Description

--- a/target/linux/bcm47xx/generic/profiles/201-Broadcom-b44-wl.mk
+++ b/target/linux/bcm47xx/generic/profiles/201-Broadcom-b44-wl.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-b44-wl
   NAME:=Broadcom SoC, b44 Ethernet, BCM43xx WiFi (wl, proprietary)
-  PACKAGES:=-wpad-basic-mbedtls kmod-b44 kmod-brcm-wl wlc nas
+  PACKAGES:=$(PACKAGE_NO_WIRELESS) kmod-b44 kmod-brcm-wl wlc nas
 endef
 
 define Profile/Broadcom-b44-wl/Description

--- a/target/linux/bcm47xx/generic/profiles/205-Broadcom-b44-none.mk
+++ b/target/linux/bcm47xx/generic/profiles/205-Broadcom-b44-none.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-b44-none
   NAME:=Broadcom SoC, b44 Ethernet, No WiFi
-  PACKAGES:=-wpad-basic-mbedtls kmod-b44
+  PACKAGES:=$(PACKAGE_NO_WIRELESS) kmod-b44
 endef
 
 define Profile/Broadcom-b44-none/Description

--- a/target/linux/bcm47xx/generic/profiles/211-Broadcom-tg3-wl.mk
+++ b/target/linux/bcm47xx/generic/profiles/211-Broadcom-tg3-wl.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-tg3-wl
   NAME:=Broadcom SoC, tg3 Ethernet, BCM43xx WiFi (wl, proprietary)
-  PACKAGES:=-wpad-basic-mbedtls kmod-brcm-wl wlc nas kmod-tg3
+  PACKAGES:=$(PACKAGE_NO_WIRELESS) kmod-brcm-wl wlc nas kmod-tg3
 endef
 
 define Profile/Broadcom-tg3-wl/Description

--- a/target/linux/bcm47xx/generic/profiles/215-Broadcom-tg3-none.mk
+++ b/target/linux/bcm47xx/generic/profiles/215-Broadcom-tg3-none.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-tg3-none
   NAME:=Broadcom SoC, tg3 Ethernet, no WiFi
-  PACKAGES:=-wpad-basic-mbedtls kmod-tg3
+  PACKAGES:=$(PACKAGE_NO_WIRELESS) kmod-tg3
 endef
 
 define Profile/Broadcom-tg3-none/Description

--- a/target/linux/bcm47xx/generic/profiles/221-Broadcom-bgmac-wl.mk
+++ b/target/linux/bcm47xx/generic/profiles/221-Broadcom-bgmac-wl.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-bgmac-wl
   NAME:=Broadcom SoC, bgmac Ethernet, BCM43xx WiFi (wl, proprietary)
-  PACKAGES:=-wpad-basic-mbedtls kmod-bgmac kmod-brcm-wl wlc nas
+  PACKAGES:=$(PACKAGE_NO_WIRELESS) kmod-bgmac kmod-brcm-wl wlc nas
 endef
 
 define Profile/Broadcom-bgmac-wl/Description

--- a/target/linux/bcm47xx/generic/profiles/225-Broadcom-bgmac-none.mk
+++ b/target/linux/bcm47xx/generic/profiles/225-Broadcom-bgmac-none.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-bgmac-none
   NAME:=Broadcom SoC, bgmac Ethernet, No WiFi
-  PACKAGES:=-wpad-basic-mbedtls kmod-bgmac
+  PACKAGES:=$(PACKAGE_NO_WIRELESS) kmod-bgmac
 endef
 
 define Profile/Broadcom-bgmac-none/Description

--- a/target/linux/bcm47xx/generic/profiles/PS-1208MFG.mk
+++ b/target/linux/bcm47xx/generic/profiles/PS-1208MFG.mk
@@ -4,7 +4,7 @@
 
 define Profile/Ps1208mfg
   NAME:=Edimax PS-1208MFG
-  PACKAGES:=-firewall -dropbear -dnsmasq -mtd -ppp -wpad-basic-mbedtls kmod-b44 block-mount kmod-usb-storage kmod-usb2 kmod-usb-ohci -iptables -swconfig kmod-fs-ext4
+  PACKAGES:=-firewall -dropbear -dnsmasq -mtd -ppp $(PACKAGE_NO_WIRELESS) kmod-b44 block-mount kmod-usb-storage kmod-usb2 kmod-usb-ohci -iptables -swconfig kmod-fs-ext4
 endef
 
 define Profile/Ps1208mfg/Description

--- a/target/linux/bcm47xx/generic/target.mk
+++ b/target/linux/bcm47xx/generic/target.mk
@@ -1,7 +1,5 @@
 BOARDNAME:=Generic
-FEATURES+=pcmcia
-
-DEFAULT_PACKAGES += wpad-basic-mbedtls
+FEATURES+=pcmcia wireless
 
 define Target/Description
 	Build generic firmware for all Broadcom BCM47xx and BCM53xx MIPS

--- a/target/linux/bcm47xx/legacy/profiles/101-Broadcom-wl.mk
+++ b/target/linux/bcm47xx/legacy/profiles/101-Broadcom-wl.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-wl
   NAME:=Broadcom SoC, all Ethernet, BCM43xx WiFi (wl, proprietary)
-  PACKAGES:=-wpad-basic-mbedtls kmod-brcm-wl-mini wlc nas
+  PACKAGES:=$(PACKAGE_NO_WIRELESS) kmod-brcm-wl-mini wlc nas
 endef
 
 define Profile/Broadcom-wl/Description

--- a/target/linux/bcm47xx/legacy/target.mk
+++ b/target/linux/bcm47xx/legacy/target.mk
@@ -1,4 +1,4 @@
-FEATURES += low_mem pcmcia small_flash wireless
+FEATURES += low-mem pcmcia small_flash wireless
 BOARDNAME:=Legacy (BMIPS3300)
 
 define Target/Description

--- a/target/linux/bcm47xx/legacy/target.mk
+++ b/target/linux/bcm47xx/legacy/target.mk
@@ -1,7 +1,5 @@
-FEATURES += low_mem pcmcia small_flash
+FEATURES += low_mem pcmcia small_flash wireless
 BOARDNAME:=Legacy (BMIPS3300)
-
-DEFAULT_PACKAGES += wpad-basic-mbedtls
 
 define Target/Description
 	Build firmware for Broadcom BCM47xx and BCM53xx devices with

--- a/target/linux/bcm47xx/legacy/target.mk
+++ b/target/linux/bcm47xx/legacy/target.mk
@@ -1,4 +1,4 @@
-FEATURES += low-mem pcmcia small_flash wireless
+FEATURES += low-mem pcmcia small-flash wireless
 BOARDNAME:=Legacy (BMIPS3300)
 
 define Target/Description

--- a/target/linux/bcm47xx/mips74k/profiles/102-Broadcom-wl.mk
+++ b/target/linux/bcm47xx/mips74k/profiles/102-Broadcom-wl.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-mips74k-wl
   NAME:=Broadcom SoC, BCM43xx WiFi (proprietary wl)
-  PACKAGES:=-wpad-basic-mbedtls kmod-brcm-wl wlc nas
+  PACKAGES:=$(PACKAGE_NO_WIRELESS) kmod-brcm-wl wlc nas
 endef
 
 define Profile/Broadcom-mips74k-wl/Description

--- a/target/linux/bcm47xx/mips74k/profiles/103-Broadcom-none.mk
+++ b/target/linux/bcm47xx/mips74k/profiles/103-Broadcom-none.mk
@@ -4,7 +4,7 @@
 
 define Profile/Broadcom-mips74k-none
   NAME:=Broadcom SoC, No WiFi
-  PACKAGES:=-wpad-basic-mbedtls
+  PACKAGES:=$(PACKAGE_NO_WIRELESS)
 endef
 
 define Profile/Broadcom-mips74k-none/Description

--- a/target/linux/bcm47xx/mips74k/target.mk
+++ b/target/linux/bcm47xx/mips74k/target.mk
@@ -1,7 +1,6 @@
 BOARDNAME:=MIPS 74K
 CPU_TYPE:=74kc
-
-DEFAULT_PACKAGES += wpad-basic-mbedtls
+FEATURES += wireless
 
 define Target/Description
 	Build firmware for Broadcom BCM47xx and BCM53xx devices with

--- a/target/linux/bcm4908/Makefile
+++ b/target/linux/bcm4908/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=aarch64
 BOARD:=bcm4908
 BOARDNAME:=Broadcom BCM4908 (ARMv8A CPUs Brahma-B53)
-FEATURES:=squashfs nand usb gpio
+FEATURES:=squashfs nand usb gpio grand-flash
 CPU_TYPE:=cortex-a53
 SUBTARGETS:=generic
 

--- a/target/linux/bcm53xx/generic/target.mk
+++ b/target/linux/bcm53xx/generic/target.mk
@@ -1,1 +1,2 @@
 BOARDNAME:=Generic
+FEATURES += wireless

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -133,11 +133,10 @@ DEVICE_VARS += SIGNATURE
 DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_REGION TPLINK_BOARD
 DEVICE_VARS += LUXUL_BOARD
 
-IEEE8021X := wpad-basic-mbedtls
-B43 := $(IEEE8021X) kmod-b43
-BRCMFMAC_43602A1 := $(IEEE8021X) kmod-brcmfmac brcmfmac-firmware-43602a1-pcie
-BRCMFMAC_4366B1 := $(IEEE8021X) kmod-brcmfmac brcmfmac-firmware-4366b1-pcie
-BRCMFMAC_4366C0 := $(IEEE8021X) kmod-brcmfmac brcmfmac-firmware-4366c0-pcie
+B43 := kmod-b43
+BRCMFMAC_43602A1 := kmod-brcmfmac brcmfmac-firmware-43602a1-pcie
+BRCMFMAC_4366B1 := kmod-brcmfmac brcmfmac-firmware-4366b1-pcie
+BRCMFMAC_4366C0 := kmod-brcmfmac brcmfmac-firmware-4366c0-pcie
 USB2_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-phy-bcm-ns-usb2
 USB2_PACKAGES += kmod-usb-ledtrig-usbport
 USB3_PACKAGES := $(USB2_PACKAGES) kmod-usb3 kmod-phy-bcm-ns-usb3

--- a/target/linux/bcm63xx/Makefile
+++ b/target/linux/bcm63xx/Makefile
@@ -9,7 +9,7 @@ ARCH:=mips
 BOARD:=bcm63xx
 BOARDNAME:=Broadcom BCM63xx
 SUBTARGETS:=generic smp
-FEATURES:=squashfs usb atm pci pcmcia usbgadget source-only
+FEATURES:=squashfs usb atm pci pcmcia usbgadget source-only wireless
 
 KERNEL_PATCHVER:=5.15
 

--- a/target/linux/bcm63xx/image/Makefile
+++ b/target/linux/bcm63xx/image/Makefile
@@ -303,12 +303,12 @@ define Device/Default
 endef
 DEVICE_VARS += CHIP_ID DEVICE_LOADADDR
 
-ATH5K_PACKAGES := kmod-ath5k wpad-basic-mbedtls
-ATH9K_PACKAGES := kmod-ath9k wpad-basic-mbedtls
-B43_PACKAGES := kmod-b43 wpad-basic-mbedtls
+ATH5K_PACKAGES := kmod-ath5k
+ATH9K_PACKAGES := kmod-ath9k
+B43_PACKAGES := kmod-b43
 BRCMWL_PACKAGES := kmod-brcm-wl nas wlc
-RT28_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls
-RT61_PACKAGES := kmod-rt61-pci wpad-basic-mbedtls
+RT28_PACKAGES := kmod-rt2800-pci
+RT61_PACKAGES := kmod-rt61-pci
 USB1_PACKAGES := kmod-usb-ohci kmod-usb-ledtrig-usbport
 USB2_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
 

--- a/target/linux/bcm63xx/profiles/default.mk
+++ b/target/linux/bcm63xx/profiles/default.mk
@@ -4,7 +4,7 @@
 
 define Profile/Default
   NAME:=Default Profile
-  PACKAGES:=kmod-b43 wpad-basic-mbedtls
+  PACKAGES:=kmod-b43
   PRIORITY:=1
 endef
 

--- a/target/linux/bmips/Makefile
+++ b/target/linux/bmips/Makefile
@@ -7,7 +7,7 @@ CPU_TYPE:=mips32
 BOARD:=bmips
 BOARDNAME:=Broadcom BMIPS
 SUBTARGETS:=bcm6318 bcm6328 bcm6358 bcm6362 bcm6368 bcm63268
-FEATURES:=gpio squashfs usb
+FEATURES:=gpio squashfs usb wireless
 
 KERNEL_PATCHVER:=5.15
 KERNEL_TESTING_PATCHVER:=6.1

--- a/target/linux/bmips/bcm6358/target.mk
+++ b/target/linux/bmips/bcm6358/target.mk
@@ -2,7 +2,7 @@
 
 SUBTARGET:=bcm6358
 BOARDNAME:=BCM6358 based boards
-FEATURES+=low_mem
+FEATURES+=low-mem
 
 define Target/Description
   Build firmware images for Broadcom BCM6358 based boards.

--- a/target/linux/bmips/image/Makefile
+++ b/target/linux/bmips/image/Makefile
@@ -333,8 +333,8 @@ define Device/sercomm-nand
 endef
 
 ### Package helpers ###
-ATH9K_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls
-B43_PACKAGES := kmod-b43 wpad-basic-mbedtls
+ATH9K_PACKAGES := kmod-ath9k kmod-owl-loader
+B43_PACKAGES := kmod-b43
 USB1_PACKAGES := kmod-usb-ohci kmod-usb-ledtrig-usbport
 USB2_PACKAGES := $(USB1_PACKAGES) kmod-usb2
 

--- a/target/linux/bmips/image/bcm63268.mk
+++ b/target/linux/bmips/image/bcm63268.mk
@@ -32,7 +32,7 @@ define Device/comtrend_vr-3032u
   SUBPAGESIZE := 512
   VID_HDR_OFFSET := 2048
   DEVICE_PACKAGES += $(USB2_PACKAGES) \
-    kmod-leds-bcm6328
+    kmod-leds-bcm6328 $(PACKAGE_NO_WIRELESS)
   CFE_WFI_FLASH_TYPE := 3
   CFE_WFI_VERSION := 0x5732
 endef
@@ -52,7 +52,7 @@ define Device/sercomm_h500-s-lowi
   SUBPAGESIZE := 512
   VID_HDR_OFFSET := 2048
   DEVICE_PACKAGES += $(USB2_PACKAGES) \
-    kmod-leds-bcm6328
+    kmod-leds-bcm6328 $(PACKAGE_NO_WIRELESS)
   SERCOMM_FSVER := 1001
   SERCOMM_HWVER := 1434b31
   SERCOMM_SWVER := 3305
@@ -73,7 +73,7 @@ define Device/sercomm_h500-s-vfes
   SUBPAGESIZE := 512
   VID_HDR_OFFSET := 2048
   DEVICE_PACKAGES += $(USB2_PACKAGES) \
-    kmod-leds-bcm6328
+    kmod-leds-bcm6328 $(PACKAGE_NO_WIRELESS)
   SERCOMM_FSVER := 1001
   SERCOMM_HWVER := 142584b
   SERCOMM_SWVER := 3417
@@ -93,7 +93,7 @@ define Device/sercomm_shg2500
   SUBPAGESIZE := 512
   VID_HDR_OFFSET := 2048
   DEVICE_PACKAGES += $(USB2_PACKAGES) \
-    broadcom-4360-sprom \
+    broadcom-4360-sprom $(PACKAGE_NO_WIRELESS) \
     kmod-i2c-gpio kmod-leds-sercomm-msp430
   SERCOMM_FSVER := 1001
   SERCOMM_HWVER := 1424e4a

--- a/target/linux/bmips/image/bcm6362.mk
+++ b/target/linux/bmips/image/bcm6362.mk
@@ -17,7 +17,7 @@ define Device/huawei_hg253s-v2
   SUBPAGESIZE := 512
   VID_HDR_OFFSET := 2048
   DEVICE_PACKAGES += $(USB2_PACKAGES) \
-    kmod-leds-bcm6328 kmod-leds-gpio
+    kmod-leds-bcm6328 kmod-leds-gpio $(PACKAGE_NO_WIRELESS)
   CFE_WFI_FLASH_TYPE := 3
 endef
 TARGET_DEVICES += huawei_hg253s-v2

--- a/target/linux/gemini/Makefile
+++ b/target/linux/gemini/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=gemini
 BOARDNAME:=Cortina Systems CS351x
-FEATURES:=squashfs pci rtc usb dt gpio display ext4 rootfs-part boot-part
+FEATURES:=squashfs pci rtc usb dt gpio display ext4 rootfs-part boot-part grand-flash
 CPU_TYPE:=fa526
 SUBTARGETS:=generic
 

--- a/target/linux/imx/Makefile
+++ b/target/linux/imx/Makefile
@@ -7,7 +7,8 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=imx
 BOARDNAME:=NXP i.MX
-FEATURES:=audio display fpu gpio pcie rtc usb usbgadget squashfs targz nand ubifs boot-part rootfs-part
+FEATURES:=audio display fpu gpio pcie rtc usb usbgadget squashfs
+FEATURES+=targz nand ubifs boot-part rootfs-part grand-flash
 SUBTARGETS:=cortexa7 cortexa9
 
 KERNEL_PATCHVER:=5.15

--- a/target/linux/ipq40xx/Makefile
+++ b/target/linux/ipq40xx/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=ipq40xx
 BOARDNAME:=Qualcomm Atheros IPQ40XX
-FEATURES:=squashfs fpu ramdisk nand
+FEATURES:=squashfs fpu ramdisk nand wireless
 CPU_TYPE:=cortex-a7
 CPU_SUBTYPE:=neon-vfpv4
 SUBTARGETS:=generic chromium mikrotik
@@ -16,7 +16,7 @@ include $(INCLUDE_DIR)/target.mk
 DEFAULT_PACKAGES += \
 	kmod-usb-dwc3-qcom \
 	kmod-leds-gpio kmod-gpio-button-hotplug \
-	kmod-ath10k-ct wpad-basic-mbedtls \
+	kmod-ath10k-ct \
 	kmod-usb3 kmod-usb-dwc3 ath10k-firmware-qca4019-ct \
 	uboot-envtools
 

--- a/target/linux/ipq806x/Makefile
+++ b/target/linux/ipq806x/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=ipq806x
 BOARDNAME:=Qualcomm Atheros IPQ806X
-FEATURES:=squashfs fpu ramdisk
+FEATURES:=squashfs fpu ramdisk wireless
 CPU_TYPE:=cortex-a15
 CPU_SUBTYPE:=neon-vfpv4
 SUBTARGETS:=generic chromium
@@ -20,7 +20,7 @@ DEFAULT_PACKAGES += \
 	kmod-ata-ahci kmod-ata-ahci-platform \
 	kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport \
 	kmod-phy-qcom-ipq806x-usb kmod-usb3 kmod-usb-dwc3-qcom \
-	kmod-ath10k-ct wpad-basic-mbedtls \
+	kmod-ath10k-ct \
 	uboot-envtools
 
 $(eval $(call BuildTarget))

--- a/target/linux/ipq806x/Makefile
+++ b/target/linux/ipq806x/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=ipq806x
 BOARDNAME:=Qualcomm Atheros IPQ806X
-FEATURES:=squashfs fpu ramdisk wireless
+FEATURES:=squashfs fpu ramdisk wireless grand-flash
 CPU_TYPE:=cortex-a15
 CPU_SUBTYPE:=neon-vfpv4
 SUBTARGETS:=generic chromium

--- a/target/linux/kirkwood/Makefile
+++ b/target/linux/kirkwood/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=kirkwood
 BOARDNAME:=Marvell Kirkwood
-FEATURES:=usb nand squashfs ramdisk
+FEATURES:=usb nand squashfs ramdisk wireless
 CPU_TYPE:=xscale
 SUBTARGETS:=generic
 

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -93,7 +93,7 @@ define Device/checkpoint_l-50
   DEVICE_VENDOR := Check Point
   DEVICE_MODEL := L-50
   DEVICE_PACKAGES := kmod-ath9k kmod-gpio-button-hotplug kmod-mvsdio \
-	kmod-rtc-s35390a kmod-usb-ledtrig-usbport wpad-basic-mbedtls
+	kmod-rtc-s35390a kmod-usb-ledtrig-usbport
   IMAGES := sysupgrade.bin
 endef
 TARGET_DEVICES += checkpoint_l-50
@@ -105,7 +105,7 @@ define Device/cisco_on100
   KERNEL_IN_UBI :=
   UBINIZE_OPTS := -E 5
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
-  DEVICE_PACKAGES := kmod-mvsdio
+  DEVICE_PACKAGES := kmod-mvsdio $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += on100
 endef
 TARGET_DEVICES += cisco_on100
@@ -115,6 +115,7 @@ define Device/cloudengines_pogoe02
   DEVICE_MODEL := Pogoplug E02
   DEVICE_DTS := kirkwood-pogo_e02
   SUPPORTED_DEVICES += pogo_e02
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += cloudengines_pogoe02
 
@@ -123,7 +124,7 @@ define Device/cloudengines_pogoplugv4
   DEVICE_MODEL := Pogoplug V4
   DEVICE_DTS := kirkwood-pogoplug-series-4
   DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 kmod-mvsdio kmod-usb3 \
-	kmod-gpio-button-hotplug
+	kmod-gpio-button-hotplug $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += cloudengines_pogoplugv4
 
@@ -132,7 +133,8 @@ define Device/ctera_c200-v1
   DEVICE_MODEL := C200
   DEVICE_VARIANT := V1
   DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-gpio-button-hotplug \
-	kmod-hwmon-lm63 kmod-rtc-s35390a kmod-usb-ledtrig-usbport
+	kmod-hwmon-lm63 kmod-rtc-s35390a kmod-usb-ledtrig-usbport \
+        $(PACKAGE_NO_WIRELESS)
   KERNEL := kernel-bin | append-dtb | uImage none | ctera-firmware
   KERNEL_IN_UBI :=
   KERNEL_SUFFIX := -factory.firm
@@ -145,7 +147,7 @@ define Device/endian_4i-edge-200
   DEVICE_MODEL := 4i Edge 200
   DEVICE_ALT0_VENDOR := Endian
   DEVICE_ALT0_MODEL := UTM Mini Firewall
-  DEVICE_PACKAGES := kmod-ath9k kmod-mvsdio wpad-basic-mbedtls
+  DEVICE_PACKAGES := kmod-ath9k kmod-mvsdio
   KERNEL_SIZE := 4096k
   IMAGES := sysupgrade.bin
 endef
@@ -154,7 +156,7 @@ TARGET_DEVICES += endian_4i-edge-200
 define Device/globalscale_sheevaplug
   DEVICE_VENDOR := Globalscale
   DEVICE_MODEL := Sheevaplug
-  DEVICE_PACKAGES := kmod-mvsdio
+  DEVICE_PACKAGES := kmod-mvsdio $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += globalscale_sheevaplug
 
@@ -163,6 +165,7 @@ define Device/iom_iconnect-1.1
   DEVICE_MODEL := Iconnect
   DEVICE_DTS := kirkwood-iconnect
   SUPPORTED_DEVICES += iconnect
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += iom_iconnect-1.1
 
@@ -171,7 +174,8 @@ define Device/iom_ix2-200
   DEVICE_MODEL := StorCenter ix2-200
   DEVICE_DTS := kirkwood-iomega_ix2_200
   DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 \
-	kmod-gpio-button-hotplug kmod-hwmon-lm63
+	kmod-gpio-button-hotplug kmod-hwmon-lm63 \
+	$(PACKAGE_NO_WIRELESS)
   PAGESIZE := 512
   SUBPAGESIZE := 256
   BLOCKSIZE := 16k
@@ -189,7 +193,8 @@ define Device/iom_ix4-200d
   DEVICE_MODEL := StorCenter ix4-200d
   DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 \
 	kmod-gpio-button-hotplug kmod-gpio-nxp-74hc164 \
-	kmod-hwmon-adt7475 kmod-mvsdio kmod-spi-gpio
+	kmod-hwmon-adt7475 kmod-mvsdio kmod-spi-gpio \
+	$(PACKAGE_NO_WIRELESS)
   PAGESIZE := 512
   SUBPAGESIZE := 256
   BLOCKSIZE := 16k
@@ -207,7 +212,8 @@ define Device/iptime_nas1
   DEVICE_MODEL := NAS1
   DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 \
 	kmod-gpio-button-hotplug kmod-gpio-pca953x kmod-hwmon-drivetemp \
-	kmod-hwmon-gpiofan kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-hwmon-gpiofan kmod-usb-ledtrig-usbport -uboot-envtools \
+	$(PACKAGE_NO_WIRELESS)
   KERNEL := $$(KERNEL) | iptime-naspkg nas1
   BLOCKSIZE := 256k
   IMAGE_SIZE := 15872k
@@ -219,7 +225,7 @@ TARGET_DEVICES += iptime_nas1
 
 define Device/linksys
   DEVICE_VENDOR := Linksys
-  DEVICE_PACKAGES := kmod-mwl8k wpad-basic-mbedtls kmod-gpio-button-hotplug
+  DEVICE_PACKAGES := kmod-mwl8k kmod-gpio-button-hotplug
   KERNEL_IN_UBI :=
   UBINIZE_OPTS := -E 5
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
@@ -264,7 +270,8 @@ define Device/netgear_readynas-duo-v2
   KERNEL_IN_UBI :=
   IMAGES := sysupgrade.bin
   DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 \
-	kmod-gpio-button-hotplug kmod-hwmon-g762 kmod-rtc-rs5c372a kmod-usb3
+	kmod-gpio-button-hotplug kmod-hwmon-g762 kmod-rtc-rs5c372a kmod-usb3 \
+	$(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += netgear_readynas-duo-v2
 
@@ -272,7 +279,7 @@ define Device/raidsonic_ib-nas62x0
   DEVICE_VENDOR := RaidSonic
   DEVICE_MODEL := ICY BOX IB-NAS62x0
   DEVICE_DTS := kirkwood-ib62x0
-  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4
+  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += ib62x0
 endef
 TARGET_DEVICES += raidsonic_ib-nas62x0
@@ -281,7 +288,7 @@ define Device/seagate_blackarmor-nas220
   DEVICE_VENDOR := Seagate
   DEVICE_MODEL := Blackarmor NAS220
   DEVICE_PACKAGES := kmod-hwmon-adt7475 kmod-fs-ext4 kmod-ata-marvell-sata \
-	mdadm kmod-gpio-button-hotplug
+	mdadm kmod-gpio-button-hotplug $(PACKAGE_NO_WIRELESS)
   PAGESIZE := 512
   SUBPAGESIZE := 256
   BLOCKSIZE := 16k
@@ -293,13 +300,15 @@ define Device/seagate_dockstar
   DEVICE_VENDOR := Seagate
   DEVICE_MODEL := FreeAgent Dockstar
   SUPPORTED_DEVICES += dockstar
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += seagate_dockstar
 
 define Device/seagate_goflexnet
   DEVICE_VENDOR := Seagate
   DEVICE_MODEL := GoFlexNet
-  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4
+  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 \
+	$(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += goflexnet
 endef
 TARGET_DEVICES += seagate_goflexnet
@@ -307,7 +316,8 @@ TARGET_DEVICES += seagate_goflexnet
 define Device/seagate_goflexhome
   DEVICE_VENDOR := Seagate
   DEVICE_MODEL := GoFlexHome
-  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4
+  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 \
+	$(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += goflexhome
 endef
 TARGET_DEVICES += seagate_goflexhome
@@ -316,7 +326,8 @@ define Device/zyxel_nsa310b
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := NSA310b
   DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-r8169 kmod-fs-ext4 \
-	kmod-gpio-button-hotplug kmod-hwmon-lm85
+	kmod-gpio-button-hotplug kmod-hwmon-lm85 \
+	$(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += nsa310b
 endef
 TARGET_DEVICES += zyxel_nsa310b
@@ -324,7 +335,8 @@ TARGET_DEVICES += zyxel_nsa310b
 define Device/zyxel_nsa310s
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := NSA310S
-  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 kmod-gpio-button-hotplug
+  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 kmod-gpio-button-hotplug \
+	$(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += zyxel_nsa310s
 
@@ -333,7 +345,8 @@ define Device/zyxel_nsa325
   DEVICE_MODEL := NSA325
   DEVICE_VARIANT := v1/v2
   DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 \
-	kmod-gpio-button-hotplug kmod-rtc-pcf8563 kmod-usb3
+	kmod-gpio-button-hotplug kmod-rtc-pcf8563 kmod-usb3 \
+	$(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += nsa325
 endef
 TARGET_DEVICES += zyxel_nsa325

--- a/target/linux/lantiq/Makefile
+++ b/target/linux/lantiq/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 BOARD:=lantiq
 BOARDNAME:=Lantiq
-FEATURES:=squashfs
+FEATURES:=squashfs wireless
 SUBTARGETS:=xrx200 xway xway_legacy falcon ase
 
 KERNEL_PATCHVER:=5.15

--- a/target/linux/lantiq/ase/target.mk
+++ b/target/linux/lantiq/ase/target.mk
@@ -5,7 +5,7 @@
 ARCH:=mips
 SUBTARGET:=ase
 BOARDNAME:=Amazon-SE
-FEATURES+=atm mips16 small_flash
+FEATURES+=atm mips16 small-flash
 CPU_TYPE:=mips32
 
 DEFAULT_PACKAGES+=kmod-leds-gpio kmod-gpio-button-hotplug \

--- a/target/linux/lantiq/image/amazonse.mk
+++ b/target/linux/lantiq/image/amazonse.mk
@@ -4,7 +4,8 @@ define Device/allnet_all0333cj
   IMAGE_SIZE := 3700k
   DEVICE_PACKAGES := kmod-ltq-adsl-ase kmod-ltq-adsl-ase-mei \
 	kmod-ltq-adsl-ase-fw-b kmod-ltq-atm-ase \
-	ltq-adsl-app ppp-mod-pppoe
+	ltq-adsl-app ppp-mod-pppoe \
+	$(PACKAGE_NO_WIRELESS)
   DEFAULT := n
 endef
 TARGET_DEVICES += allnet_all0333cj
@@ -15,7 +16,8 @@ define Device/netgear_dgn1000b
   IMAGE_SIZE := 3712k
   DEVICE_PACKAGES := kmod-ltq-adsl-ase kmod-ltq-adsl-ase-mei \
 	kmod-ltq-adsl-ase-fw-b kmod-ltq-atm-ase \
-	ltq-adsl-app ppp-mod-pppoe
+	ltq-adsl-app ppp-mod-pppoe \
+	$(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += DGN1000B
   DEFAULT := n
 endef

--- a/target/linux/lantiq/image/ar9.mk
+++ b/target/linux/lantiq/image/ar9.mk
@@ -4,7 +4,7 @@ define Device/avm_fritz7312
   SOC := ar9
   IMAGE_SIZE := 15744k
   LOADER_FLASH_OFFS := 0x31000
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
@@ -22,7 +22,7 @@ define Device/avm_fritz7320
   SOC := ar9
   IMAGE_SIZE := 15744k
   LOADER_FLASH_OFFS := 0x31000
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
@@ -44,7 +44,7 @@ define Device/bt_homehub-v3a
 	kmod-ltq-adsl-ar9-fw-a kmod-ltq-atm-ar9 \
 	kmod-ltq-deu-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+	kmod-ath9k kmod-owl-loader \
 	uboot-envtools
   SUPPORTED_DEVICES += BTHOMEHUBV3A
   DEFAULT := n
@@ -62,7 +62,7 @@ define Device/buffalo_wbmr-hp-g300h-a
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-a kmod-ltq-atm-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls
+	kmod-ath9k kmod-owl-loader
   SUPPORTED_DEVICES := WBMR buffalo,wbmr-hp-g300h
 endef
 TARGET_DEVICES += buffalo_wbmr-hp-g300h-a
@@ -78,7 +78,7 @@ define Device/buffalo_wbmr-hp-g300h-b
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls
+	kmod-ath9k kmod-owl-loader
   SUPPORTED_DEVICES := WBMR buffalo,wbmr-hp-g300h
 endef
 TARGET_DEVICES += buffalo_wbmr-hp-g300h-b
@@ -110,7 +110,7 @@ define Device/netgear_dgn3500
 	dgn3500-sercom-footer $(DGN3500_KERNEL_OFFSET_HEX) "WW" | pad-rootfs | \
 	check-size 16320k | pad-to 16384k
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport \
-	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+	kmod-ath9k kmod-owl-loader \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-a kmod-ltq-atm-ar9 \
 	kmod-ltq-deu-ar9 ltq-adsl-app ppp-mod-pppoa
@@ -134,7 +134,7 @@ define Device/netgear_dgn3500b
 	dgn3500-sercom-footer $(DGN3500_KERNEL_OFFSET_HEX) "DE" | pad-rootfs | \
 	check-size 16320k | pad-to 16384k
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport \
-	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+	kmod-ath9k kmod-owl-loader \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	kmod-ltq-deu-ar9 ltq-adsl-app ppp-mod-pppoa
@@ -147,7 +147,7 @@ define Device/zte_h201l
   DEVICE_MODEL := H201L
   IMAGE_SIZE := 7808k
   SOC := ar9
-  DEVICE_PACKAGES := kmod-ath9k-htc wpad-basic-mbedtls \
+  DEVICE_PACKAGES := kmod-ath9k-htc \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	kmod-ltq-deu-ar9 ltq-adsl-app ppp-mod-pppoe \
@@ -164,7 +164,7 @@ define Device/zyxel_p-2601hn
   DEVICE_VARIANT := F1/F3
   IMAGE_SIZE := 15616k
   SOC := ar9
-  DEVICE_PACKAGES := kmod-rt2800-usb wpad-basic-mbedtls \
+  DEVICE_PACKAGES := kmod-rt2800-usb \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	kmod-ltq-deu-ar9 ltq-adsl-app ppp-mod-pppoe \

--- a/target/linux/lantiq/image/danube.mk
+++ b/target/linux/lantiq/image/danube.mk
@@ -10,7 +10,7 @@ define Device/arcadyan_arv4510pw
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
 	kmod-ltq-tapi kmod-ltq-vmmc \
-	kmod-rt2800-pci kmod-ath5k wpad-basic-mbedtls
+	kmod-rt2800-pci kmod-ath5k
   SUPPORTED_DEVICES += ARV4510PW
   DEFAULT := n
 endef
@@ -28,7 +28,8 @@ define Device/arcadyan_arv4519pw
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport \
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
-	ltq-adsl-app ppp-mod-pppoa
+	ltq-adsl-app ppp-mod-pppoa \
+	$(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += ARV4519PW
   DEFAULT := n
 endef
@@ -44,7 +45,7 @@ define Device/arcadyan_arv7506pw11
   DEVICE_PACKAGES := kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-rt2800-pci wpad-basic-mbedtls
+	kmod-rt2800-pci
   SUPPORTED_DEVICES += ARV7506PW11
 endef
 TARGET_DEVICES += arcadyan_arv7506pw11
@@ -61,7 +62,7 @@ define Device/arcadyan_arv7510pw22
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
 	kmod-ltq-tapi kmod-ltq-vmmc \
-	kmod-rt2800-pci wpad-basic-mbedtls \
+	kmod-rt2800-pci \
 	kmod-usb-uhci kmod-usb2 kmod-usb2-pci
   SUPPORTED_DEVICES += ARV7510PW22
 endef
@@ -78,7 +79,7 @@ define Device/arcadyan_arv7518pw
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls
+	kmod-ath9k kmod-owl-loader
   SUPPORTED_DEVICES += ARV7518PW
 endef
 TARGET_DEVICES += arcadyan_arv7518pw
@@ -94,7 +95,7 @@ define Device/arcadyan_arv7519pw
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-rt2800-pci wpad-basic-mbedtls
+	kmod-rt2800-pci
   SUPPORTED_DEVICES += ARV7519PW
 endef
 TARGET_DEVICES += arcadyan_arv7519pw
@@ -107,7 +108,7 @@ define Device/arcadyan_arv7525pw
   DEVICE_ALT0_VARIANT := Typ A
   IMAGE_SIZE := 3776k
   SOC := danube
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls \
+  DEVICE_PACKAGES := kmod-rt2800-pci \
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa -swconfig
@@ -128,7 +129,7 @@ define Device/arcadyan_arv752dpw
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
 	kmod-ltq-tapi kmod-ltq-vmmc \
-	kmod-rt2800-pci wpad-basic-mbedtls
+	kmod-rt2800-pci
   SUPPORTED_DEVICES += ARV752DPW
 endef
 TARGET_DEVICES += arcadyan_arv752dpw
@@ -145,7 +146,7 @@ define Device/arcadyan_arv752dpw22
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
 	kmod-ltq-tapi kmod-ltq-vmmc \
-	kmod-rt2800-pci wpad-basic-mbedtls
+	kmod-rt2800-pci
   SUPPORTED_DEVICES += ARV752DPW22
 endef
 TARGET_DEVICES += arcadyan_arv752dpw22
@@ -161,7 +162,7 @@ define Device/arcadyan_arv8539pw22
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls
+	kmod-ath9k kmod-owl-loader
   SUPPORTED_DEVICES += ARV8539PW22
 endef
 TARGET_DEVICES += arcadyan_arv8539pw22
@@ -176,8 +177,7 @@ define Device/audiocodes_mp-252
 	kmod-ltq-tapi kmod-ltq-vmmc \
 	kmod-usb-ledtrig-usbport kmod-usb-dwc2 \
 	kmod-rt2800-pci \
-	ltq-adsl-app ppp-mod-pppoa \
-	wpad-basic-mbedtls
+	ltq-adsl-app ppp-mod-pppoa
   SUPPORTED_DEVICES += ACMP252
 endef
 TARGET_DEVICES += audiocodes_mp-252
@@ -194,7 +194,7 @@ define Device/bt_homehub-v2b
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
 	kmod-ltq-deu-danube ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls
+	kmod-ath9k kmod-owl-loader
   SUPPORTED_DEVICES += BTHOMEHUBV2B
   DEFAULT := n
 endef
@@ -206,6 +206,7 @@ define Device/lantiq_easy50712
   SOC := danube
   IMAGE_SIZE := 3776k
   DEFAULT := n
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += lantiq_easy50712
 
@@ -218,7 +219,7 @@ define Device/siemens_gigaset-sx76x
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoe \
-	kmod-ath5k wpad-basic-mbedtls
+	kmod-ath5k
   SUPPORTED_DEVICES += GIGASX76X
   DEFAULT := n
 endef

--- a/target/linux/lantiq/image/falcon.mk
+++ b/target/linux/lantiq/image/falcon.mk
@@ -1,6 +1,7 @@
 define Device/lantiq_easy88388
   DEVICE_VENDOR := Lantiq
   DEVICE_MODEL := EASY88388 Falcon FTTDP8 Reference Board
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGE_SIZE := 7424k
 endef
 TARGET_DEVICES += lantiq_easy88388
@@ -8,6 +9,7 @@ TARGET_DEVICES += lantiq_easy88388
 define Device/lantiq_easy88444
   DEVICE_VENDOR := Lantiq
   DEVICE_MODEL := EASY88444 Falcon FTTdp G.FAST Reference Board
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGE_SIZE := 7424k
 endef
 TARGET_DEVICES += lantiq_easy88444
@@ -16,6 +18,7 @@ define Device/lantiq_easy98020
   DEVICE_VENDOR := Lantiq
   DEVICE_MODEL := Falcon SFU Reference Board (EASY98020)
   DEVICE_VARIANT := v1.0-v1.7
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGE_SIZE := 7424k
 endef
 TARGET_DEVICES += lantiq_easy98020
@@ -24,6 +27,7 @@ define Device/lantiq_easy98020-v18
   DEVICE_VENDOR := Lantiq
   DEVICE_MODEL := Falcon SFU Reference Board (EASY98020)
   DEVICE_VARIANT := v1.8
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGE_SIZE := 7424k
 endef
 TARGET_DEVICES += lantiq_easy98020-v18
@@ -31,6 +35,7 @@ TARGET_DEVICES += lantiq_easy98020-v18
 define Device/lantiq_easy98021
   DEVICE_VENDOR := Lantiq
   DEVICE_MODEL := Falcon HGU Reference Board (EASY98021)
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGE_SIZE := 7424k
 endef
 TARGET_DEVICES += lantiq_easy98021
@@ -39,6 +44,7 @@ define Device/lantiq_easy98035synce
   DEVICE_VENDOR := Lantiq
   DEVICE_MODEL := Falcon SFP Stick (EASY98035SYNCE)
   DEVICE_VARIANT := with Synchronous Ethernet
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGE_SIZE := 7424k
 endef
 TARGET_DEVICES += lantiq_easy98035synce
@@ -47,6 +53,7 @@ define Device/lantiq_easy98035synce1588
   DEVICE_VENDOR := Lantiq
   DEVICE_MODEL := Falcon SFP Stick (EASY98035SYNCE1588)
   DEVICE_VARIANT := with SyncE and IEEE1588
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGE_SIZE := 7424k
 endef
 TARGET_DEVICES += lantiq_easy98035synce1588
@@ -56,7 +63,8 @@ define Device/lantiq_easy98000-nand
   DEVICE_MODEL := EASY98000 Falcon Eval Board
   DEVICE_VARIANT := NAND
   IMAGE_SIZE := 3904k
-  DEVICE_PACKAGES := kmod-dm9000 kmod-i2c-lantiq kmod-eeprom-at24
+  DEVICE_PACKAGES := kmod-dm9000 kmod-i2c-lantiq kmod-eeprom-at24 \
+	$(PACKAGE_NO_WIRELESS)
   DEFAULT := n
 endef
 TARGET_DEVICES += lantiq_easy98000-nand
@@ -66,7 +74,8 @@ define Device/lantiq_easy98000-nor
   DEVICE_MODEL := EASY98000 Falcon Eval Board
   DEVICE_VARIANT := NOR
   IMAGE_SIZE := 3904k
-  DEVICE_PACKAGES := kmod-dm9000 kmod-i2c-lantiq kmod-eeprom-at24
+  DEVICE_PACKAGES := kmod-dm9000 kmod-i2c-lantiq kmod-eeprom-at24 \
+	$(PACKAGE_NO_WIRELESS)
   DEFAULT := n
 endef
 TARGET_DEVICES += lantiq_easy98000-nor
@@ -76,13 +85,15 @@ define Device/lantiq_easy98000-sflash
   DEVICE_MODEL := EASY98000 Falcon Eval Board
   DEVICE_VARIANT := SFLASH
   IMAGE_SIZE := 7424k
-  DEVICE_PACKAGES := kmod-dm9000 kmod-i2c-lantiq kmod-eeprom-at24
+  DEVICE_PACKAGES := kmod-dm9000 kmod-i2c-lantiq kmod-eeprom-at24 \
+	$(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += lantiq_easy98000-sflash
 
 define Device/lantiq_falcon-mdu
   DEVICE_VENDOR := Lantiq
   DEVICE_MODEL := Falcon / VINAXdp MDU Board
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGE_SIZE := 7424k
 endef
 TARGET_DEVICES += lantiq_falcon-mdu
@@ -90,6 +101,7 @@ TARGET_DEVICES += lantiq_falcon-mdu
 define Device/lantiq_falcon-sfp
   DEVICE_VENDOR := Lantiq
   DEVICE_MODEL := Falcon SFP Stick
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGE_SIZE := 7424k
 endef
 TARGET_DEVICES += lantiq_falcon-sfp

--- a/target/linux/lantiq/image/tp-link.mk
+++ b/target/linux/lantiq/image/tp-link.mk
@@ -26,7 +26,7 @@ define Device/tplink_tdw8970
   TPLINK_HWID := 0x89700001
   TPLINK_HWREV := 1
   IMAGE_SIZE := 7680k
-  DEVICE_PACKAGES:= kmod-ath9k wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES:= kmod-ath9k kmod-usb-dwc2 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += TDW8970
 endef
 TARGET_DEVICES += tplink_tdw8970
@@ -40,7 +40,7 @@ define Device/tplink_tdw8980
   TPLINK_HWID := 0x89800001
   TPLINK_HWREV := 14
   IMAGE_SIZE := 7680k
-  DEVICE_PACKAGES:= kmod-ath9k kmod-owl-loader wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES:= kmod-ath9k kmod-owl-loader kmod-usb-dwc2 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += TDW8980
 endef
 TARGET_DEVICES += tplink_tdw8980
@@ -54,7 +54,7 @@ define Device/tplink_vr200
   TPLINK_HWID := 0x63e64801
   TPLINK_HWREV := 0x53
   IMAGE_SIZE := 15808k
-  DEVICE_PACKAGES:= kmod-mt76x0e wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES:= kmod-mt76x0e kmod-usb-dwc2 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += VR200
 endef
 TARGET_DEVICES += tplink_vr200
@@ -68,7 +68,7 @@ define Device/tplink_vr200v
   TPLINK_HWID := 0x73b70801
   TPLINK_HWREV := 0x2f
   IMAGE_SIZE := 15808k
-  DEVICE_PACKAGES:= kmod-mt76x0e wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport kmod-ltq-tapi kmod-ltq-vmmc
+  DEVICE_PACKAGES:= kmod-mt76x0e kmod-usb-dwc2 kmod-usb-ledtrig-usbport kmod-ltq-tapi kmod-ltq-vmmc
   SUPPORTED_DEVICES += VR200v
 endef
 TARGET_DEVICES += tplink_vr200v

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -11,6 +11,7 @@ define Device/alphanetworks_asl56026
   DEVICE_MODEL := ASL56026
   DEVICE_ALT0_VENDOR := BT Openreach
   DEVICE_ALT0_MODEL := ECI VDSL Modem V-2FUb/I
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGE_SIZE := 7488k
   DEFAULT := n
 endef
@@ -27,7 +28,7 @@ define Device/arcadyan_arv7519rw22
   DEVICE_ALT1_MODEL := ARV7519RW22
   KERNEL_SIZE := 2048k
   IMAGE_SIZE := 31232k
-  DEVICE_PACKAGES := kmod-usb-dwc2
+  DEVICE_PACKAGES := kmod-usb-dwc2 $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += ARV7519RW22
   DEFAULT := n
 endef
@@ -37,6 +38,7 @@ define Device/arcadyan_vg3503j
   $(Device/dsa-migration)
   DEVICE_VENDOR := BT Openreach
   DEVICE_MODEL := ECI VDSL Modem V-2FUb/R
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGE_SIZE := 8000k
   SUPPORTED_DEVICES += VG3503J
   DEFAULT := n
@@ -56,7 +58,7 @@ define Device/arcadyan_vgv7510kw22-brn
   SIGNATURE := BRNDA6431
   MAGIC := 0x12345678
   CRC32_POLY := 0x04c11db7
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
+  DEVICE_PACKAGES := kmod-rt2800-pci kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
   SUPPORTED_DEVICES += VGV7510KW22BRN
 endef
 TARGET_DEVICES += arcadyan_vgv7510kw22-brn
@@ -70,7 +72,7 @@ define Device/arcadyan_vgv7510kw22-nor
   DEVICE_ALT0_MODEL := Box 6431
   DEVICE_ALT0_VARIANT := NOR
   IMAGE_SIZE := 15232k
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
+  DEVICE_PACKAGES := kmod-rt2800-pci kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
   SUPPORTED_DEVICES += VGV7510KW22NOR
 endef
 TARGET_DEVICES += arcadyan_vgv7510kw22-nor
@@ -88,7 +90,7 @@ define Device/arcadyan_vgv7519-brn
   SIGNATURE := 5D00008000
   MAGIC := 0x12345678
   CRC32_POLY := 0x2083b8ed
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
+  DEVICE_PACKAGES := kmod-rt2800-pci kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
   SUPPORTED_DEVICES += VGV7519BRN
 endef
 TARGET_DEVICES += arcadyan_vgv7519-brn
@@ -102,7 +104,7 @@ define Device/arcadyan_vgv7519-nor
   DEVICE_ALT0_MODEL := Experiabox 8
   DEVICE_ALT0_VARIANT := NOR
   IMAGE_SIZE := 15360k
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
+  DEVICE_PACKAGES := kmod-rt2800-pci kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
   SUPPORTED_DEVICES += VGV7519NOR
 endef
 TARGET_DEVICES += arcadyan_vgv7519-nor
@@ -118,7 +120,7 @@ define Device/avm_fritz3370
   IMAGES += eva-kernel.bin eva-filesystem.bin
   IMAGE/eva-kernel.bin := append-kernel
   IMAGE/eva-filesystem.bin := append-ubi
-  DEVICE_PACKAGES := kmod-ath9k wpad-basic-mbedtls kmod-usb-dwc2 fritz-tffs
+  DEVICE_PACKAGES := kmod-ath9k kmod-usb-dwc2 fritz-tffs
 endef
 
 define Device/avm_fritz3370-rev2-hynix
@@ -144,7 +146,7 @@ define Device/avm_fritz3390
   DEVICE_MODEL := FRITZ!Box 3390
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader \
 	kmod-usb-dwc2 fritz-tffs
 endef
 TARGET_DEVICES += avm_fritz3390
@@ -154,7 +156,7 @@ define Device/avm_fritz7360sl
   $(Device/AVM)
   DEVICE_MODEL := FRITZ!Box 7360 SL
   IMAGE_SIZE := 15744k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader \
 	kmod-usb-dwc2 fritz-tffs
   SUPPORTED_DEVICES += FRITZ7360SL
 endef
@@ -166,7 +168,7 @@ define Device/avm_fritz7360-v2
   DEVICE_MODEL := FRITZ!Box 7360
   DEVICE_VARIANT := v2
   IMAGE_SIZE := 32128k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader \
 	kmod-usb-dwc2 fritz-tffs
 endef
 TARGET_DEVICES += avm_fritz7360-v2
@@ -178,7 +180,7 @@ define Device/avm_fritz7362sl
   DEVICE_MODEL := FRITZ!Box 7362 SL
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader \
 	kmod-usb-dwc2 fritz-tffs
 endef
 TARGET_DEVICES += avm_fritz7362sl
@@ -191,7 +193,7 @@ define Device/avm_fritz7412
   BOARD_NAME := FRITZ7412
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader \
 	fritz-tffs-nand fritz-caldata
 endef
 TARGET_DEVICES += avm_fritz7412
@@ -203,7 +205,7 @@ define Device/avm_fritz7430
   DEVICE_MODEL := FRITZ!Box 7430
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls \
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader \
 	kmod-usb-dwc2 fritz-tffs-nand fritz-caldata
 endef
 TARGET_DEVICES += avm_fritz7430
@@ -216,7 +218,7 @@ define Device/bt_homehub-v5a
   DEVICE_VARIANT := Type A
   BOARD_NAME := BTHOMEHUBV5A
   DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader \
-	kmod-ath10k-ct ath10k-firmware-qca988x-ct wpad-basic-mbedtls kmod-usb-dwc2
+	kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-usb-dwc2
   SUPPORTED_DEVICES += BTHOMEHUBV5A
 endef
 TARGET_DEVICES += bt_homehub-v5a
@@ -226,7 +228,7 @@ define Device/buffalo_wbmr-300hpd
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WBMR-300HPD
   IMAGE_SIZE := 15616k
-  DEVICE_PACKAGES := kmod-mt7603 wpad-basic-mbedtls kmod-usb-dwc2
+  DEVICE_PACKAGES := kmod-mt7603 kmod-usb-dwc2
   SUPPORTED_DEVICES += WBMR300
 endef
 TARGET_DEVICES += buffalo_wbmr-300hpd
@@ -238,7 +240,7 @@ define Device/lantiq_easy80920-nand
   DEVICE_MODEL := VR9 EASY80920
   DEVICE_VARIANT := NAND
   IMAGE_SIZE := 64512k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader kmod-usb-dwc2 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += lantiq_easy80920-nand
 
@@ -248,7 +250,7 @@ define Device/lantiq_easy80920-nor
   DEVICE_MODEL := VR9 EASY80920
   DEVICE_VARIANT := NOR
   IMAGE_SIZE := 7936k
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader kmod-usb-dwc2 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += lantiq_easy80920-nor
 
@@ -256,6 +258,7 @@ define Device/netgear_dm200
   $(Device/dsa-migration)
   DEVICE_VENDOR := NETGEAR
   DEVICE_MODEL := DM200
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGES := sysupgrade.bin factory.img
   IMAGE/sysupgrade.bin := append-kernel | \
 	pad-offset 64k 64 | append-uImage-fakehdr filesystem | \
@@ -275,7 +278,7 @@ define Device/zyxel_p-2812hnu-f1
   DEVICE_MODEL := P-2812HNU
   DEVICE_VARIANT := F1
   BOARD_NAME := P2812HNUF1
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-rt2800-pci kmod-usb-dwc2 kmod-usb-ledtrig-usbport
   KERNEL_SIZE := 3072k
   SUPPORTED_DEVICES += P2812HNUF1
 endef
@@ -288,7 +291,7 @@ define Device/zyxel_p-2812hnu-f3
   DEVICE_MODEL := P-2812HNU
   DEVICE_VARIANT := F3
   BOARD_NAME := P2812HNUF3
-  DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2
+  DEVICE_PACKAGES := kmod-rt2800-pci kmod-usb-dwc2
   KERNEL_SIZE := 2048k
   SUPPORTED_DEVICES += P2812HNUF3
   DEFAULT := n

--- a/target/linux/lantiq/image/xway_legacy.mk
+++ b/target/linux/lantiq/image/xway_legacy.mk
@@ -6,7 +6,7 @@ define Device/arcadyan_arv4518pwr01
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath5k wpad-basic-mbedtls
+	kmod-ath5k
   SUPPORTED_DEVICES += ARV4518PWR01
   DEFAULT := n
 endef
@@ -20,7 +20,7 @@ define Device/arcadyan_arv4518pwr01a
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-a kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-ath5k wpad-basic-mbedtls
+	kmod-ath5k
   SUPPORTED_DEVICES += ARV4518PWR01A
   DEFAULT := n
 endef
@@ -38,7 +38,7 @@ define Device/arcadyan_arv4520pw
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa \
-	kmod-rt61-pci wpad-basic-mbedtls
+	kmod-rt61-pci
   SUPPORTED_DEVICES += ARV4520PW
   DEFAULT := n
 endef
@@ -51,7 +51,7 @@ define Device/arcadyan_arv4525pw
   DEVICE_ALT0_MODEL := Speedport W502V
   DEVICE_ALT0_VARIANT := Typ A
   IMAGE_SIZE := 3776k
-  DEVICE_PACKAGES := kmod-ath5k wpad-basic-mbedtls \
+  DEVICE_PACKAGES := kmod-ath5k \
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa -swconfig
@@ -67,7 +67,7 @@ define Device/arcadyan_arv452cqw
   DEVICE_ALT0_MODEL := Easybox 801
   IMAGE_SIZE := 3776k
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport \
-	kmod-ath5k wpad-basic-mbedtls \
+	kmod-ath5k \
 	kmod-ltq-adsl-danube-mei kmod-ltq-adsl-danube \
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa

--- a/target/linux/lantiq/xway_legacy/target.mk
+++ b/target/linux/lantiq/xway_legacy/target.mk
@@ -1,7 +1,7 @@
 ARCH:=mips
 SUBTARGET:=xway_legacy
 BOARDNAME:=XWAY Legacy
-FEATURES+=atm ramdisk small_flash
+FEATURES+=atm ramdisk small-flash
 CPU_TYPE:=24kc
 
 DEFAULT_PACKAGES+=kmod-leds-gpio kmod-gpio-button-hotplug swconfig

--- a/target/linux/layerscape/Makefile
+++ b/target/linux/layerscape/Makefile
@@ -9,7 +9,7 @@ BOARDNAME:=NXP Layerscape
 
 KERNEL_PATCHVER:=5.15
 
-FEATURES:=squashfs nand usb pcie gpio fpu ubifs ext4 rootfs-part boot-part
+FEATURES:=squashfs nand usb pcie gpio fpu ubifs ext4 rootfs-part boot-part grand-flash
 SUBTARGETS:=armv8_64b armv7
 
 define Target/Description

--- a/target/linux/layerscape/image/Makefile
+++ b/target/linux/layerscape/image/Makefile
@@ -8,8 +8,11 @@ include $(INCLUDE_DIR)/image.mk
 LS_SD_KERNELPART_SIZE = 40
 LS_SD_KERNELPART_OFFSET = 16
 LS_SD_ROOTFSPART_OFFSET = 64
+
+ifeq ($(DUMP),)
 LS_SD_IMAGE_SIZE = $(shell echo $$((($(LS_SD_ROOTFSPART_OFFSET) + \
 	$(CONFIG_TARGET_ROOTFS_PARTSIZE)))))
+endif
 
 # The limitation of flash sysupgrade.bin is 1MB dtb + 16MB kernel + 32MB rootfs
 LS_SYSUPGRADE_IMAGE_SIZE = 49m

--- a/target/linux/malta/Makefile
+++ b/target/linux/malta/Makefile
@@ -8,7 +8,7 @@ BOARD:=malta
 BOARDNAME:=MIPS Malta CoreLV board (qemu)
 SUBTARGETS:=le be le64 be64
 INITRAMFS_EXTRA_FILES:=
-FEATURES:=cpiogz ext4 ramdisk squashfs targz wireless
+FEATURES:=cpiogz ext4 ramdisk squashfs targz wireless grand-flash
 
 KERNEL_PATCHVER:=5.15
 KERNEL_TESTING_PATCHVER:=6.1

--- a/target/linux/malta/Makefile
+++ b/target/linux/malta/Makefile
@@ -8,13 +8,13 @@ BOARD:=malta
 BOARDNAME:=MIPS Malta CoreLV board (qemu)
 SUBTARGETS:=le be le64 be64
 INITRAMFS_EXTRA_FILES:=
-FEATURES:=cpiogz ext4 ramdisk squashfs targz
+FEATURES:=cpiogz ext4 ramdisk squashfs targz wireless
 
 KERNEL_PATCHVER:=5.15
 KERNEL_TESTING_PATCHVER:=6.1
 
 include $(INCLUDE_DIR)/target.mk
 
-DEFAULT_PACKAGES += wpad-basic-mbedtls kmod-mac80211-hwsim kmod-pcnet32 mkf2fs e2fsprogs
+DEFAULT_PACKAGES += kmod-mac80211-hwsim kmod-pcnet32 mkf2fs e2fsprogs
 
 $(eval $(call BuildTarget))

--- a/target/linux/mediatek/Makefile
+++ b/target/linux/mediatek/Makefile
@@ -6,7 +6,7 @@ ARCH:=arm
 BOARD:=mediatek
 BOARDNAME:=MediaTek Ralink ARM
 SUBTARGETS:=mt7622 mt7623 mt7629 filogic
-FEATURES:=dt-overlay emmc fpu gpio nand pci pcie rootfs-part separate_ramdisk squashfs usb
+FEATURES:=dt-overlay emmc fpu gpio nand pci pcie rootfs-part separate_ramdisk squashfs usb wireless
 
 KERNEL_PATCHVER:=5.15
 KERNEL_TESTING_PATCHVER:=6.1

--- a/target/linux/mediatek/Makefile
+++ b/target/linux/mediatek/Makefile
@@ -7,7 +7,7 @@ BOARD:=mediatek
 BOARDNAME:=MediaTek Ralink ARM
 SUBTARGETS:=mt7622 mt7623 mt7629 filogic
 FEATURES:=dt-overlay emmc fpu gpio nand pci pcie rootfs-part
-FEATURES+=separate_ramdisk squashfs usb wireless grand-flash
+FEATURES+=separate-ramdisk squashfs usb wireless grand-flash
 
 KERNEL_PATCHVER:=5.15
 KERNEL_TESTING_PATCHVER:=6.1

--- a/target/linux/mediatek/Makefile
+++ b/target/linux/mediatek/Makefile
@@ -6,7 +6,8 @@ ARCH:=arm
 BOARD:=mediatek
 BOARDNAME:=MediaTek Ralink ARM
 SUBTARGETS:=mt7622 mt7623 mt7629 filogic
-FEATURES:=dt-overlay emmc fpu gpio nand pci pcie rootfs-part separate_ramdisk squashfs usb wireless
+FEATURES:=dt-overlay emmc fpu gpio nand pci pcie rootfs-part
+FEATURES+=separate_ramdisk squashfs usb wireless grand-flash
 
 KERNEL_PATCHVER:=5.15
 KERNEL_TESTING_PATCHVER:=6.1

--- a/target/linux/mediatek/filogic/target.mk
+++ b/target/linux/mediatek/filogic/target.mk
@@ -2,7 +2,7 @@ ARCH:=aarch64
 SUBTARGET:=filogic
 BOARDNAME:=Filogic 8x0 (MT798x)
 CPU_TYPE:=cortex-a53
-DEFAULT_PACKAGES += kmod-crypto-hw-safexcel kmod-mt7915e wpad-basic-mbedtls uboot-envtools
+DEFAULT_PACKAGES += kmod-crypto-hw-safexcel kmod-mt7915e uboot-envtools
 KERNELNAME:=Image dtbs
 
 define Target/Description

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -176,7 +176,9 @@ define Device/bananapi_bpi-r3
 				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
 				) \
 				  gzip
+ifeq ($(DUMP),)
   IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
+endif
   KERNEL			:= kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -88,7 +88,9 @@ define Device/bananapi_bpi-r64
 				   pad-to 46080k | append-image squashfs-sysupgrade.itb | check-size |\
 				) \
 				  gzip
+ifeq ($(DUMP),)
   IMAGE_SIZE := $$(shell expr 45 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
+endif
   KERNEL			:= kernel-bin | gzip
   KERNEL_INITRAMFS		:= kernel-bin | lzma | fit lzma $$(DTS_DIR)/$$(DEVICE_DTS).dtb with-initrd | pad-to 128k
   IMAGE/sysupgrade.itb		:= append-kernel | fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb external-static-with-rootfs | append-metadata

--- a/target/linux/mediatek/image/mt7623.mk
+++ b/target/linux/mediatek/image/mt7623.mk
@@ -96,7 +96,9 @@ define Device/bananapi_bpi-r2
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   KERNEL_INITRAMFS := kernel-bin | gzip | fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb with-initrd
+ifeq ($(DUMP),)
   IMAGE_SIZE := $$(shell expr 48 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
+endif
   IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb external-static-with-rootfs | append-metadata
   ARTIFACT/preloader.bin := mt7623-mbr emmc |\
 			    pad-to 2k | append-preloader $$(UBOOT_TARGET)
@@ -130,7 +132,9 @@ define Device/unielec_u7623-02
   UBOOT_TARGET := mt7623a_unielec_u7623
   UBOOT_IMAGE := u-boot-mtk.bin
   UBOOT_PATH := $(STAGING_DIR_IMAGE)/$$(UBOOT_TARGET)-$$(UBOOT_IMAGE)
+ifeq ($(DUMP),)
   IMAGE_SIZE := $$(shell expr 48 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
+endif
   IMAGES := sysupgrade.itb
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb

--- a/target/linux/mediatek/mt7622/target.mk
+++ b/target/linux/mediatek/mt7622/target.mk
@@ -2,7 +2,7 @@ ARCH:=aarch64
 SUBTARGET:=mt7622
 BOARDNAME:=MT7622
 CPU_TYPE:=cortex-a53
-DEFAULT_PACKAGES += kmod-mt7622-firmware wpad-basic-mbedtls uboot-envtools
+DEFAULT_PACKAGES += kmod-mt7622-firmware uboot-envtools
 KERNELNAME:=Image dtbs
 
 define Target/Description

--- a/target/linux/mpc85xx/Makefile
+++ b/target/linux/mpc85xx/Makefile
@@ -8,7 +8,7 @@ ARCH:=powerpc
 BOARD:=mpc85xx
 BOARDNAME:=Freescale MPC85xx
 CPU_TYPE:=8548
-FEATURES:=squashfs ramdisk nand
+FEATURES:=squashfs ramdisk nand wireless
 SUBTARGETS:=p1010 p1020 p2020
 
 KERNEL_PATCHVER:=5.15
@@ -19,7 +19,7 @@ include $(INCLUDE_DIR)/target.mk
 
 DEFAULT_PACKAGES += \
 	kmod-input-core kmod-input-gpio-keys kmod-button-hotplug \
-	kmod-leds-gpio swconfig kmod-ath9k wpad-basic-mbedtls kmod-usb2 \
+	kmod-leds-gpio swconfig kmod-ath9k kmod-usb2 \
 	uboot-envtools
 
 $(eval $(call BuildTarget))

--- a/target/linux/mvebu/Makefile
+++ b/target/linux/mvebu/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 BOARD:=mvebu
 BOARDNAME:=Marvell EBU Armada
-FEATURES:=fpu usb pci pcie gpio nand squashfs ramdisk boot-part rootfs-part legacy-sdcard targz
+FEATURES:=fpu usb pci pcie gpio nand squashfs ramdisk boot-part rootfs-part legacy-sdcard targz wireless
 SUBTARGETS:=cortexa9 cortexa53 cortexa72
 
 KERNEL_PATCHVER:=5.15

--- a/target/linux/mvebu/image/cortexa53.mk
+++ b/target/linux/mvebu/image/cortexa53.mk
@@ -2,6 +2,7 @@ define Device/glinet_gl-mv1000
   $(call Device/Default-arm64)
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-MV1000
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SOC := armada-3720
 endef
 TARGET_DEVICES += glinet_gl-mv1000
@@ -14,6 +15,7 @@ define Device/globalscale_espressobin
   DEVICE_ALT0_VENDOR := Marvell
   DEVICE_ALT0_MODEL := Armada 3700 Community Board
   DEVICE_ALT0_VARIANT := Non-eMMC
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SOC := armada-3720
   BOOT_SCRIPT := espressobin
 endef
@@ -27,6 +29,7 @@ define Device/globalscale_espressobin-emmc
   DEVICE_ALT0_VENDOR := Marvell
   DEVICE_ALT0_MODEL := Armada 3700 Community Board
   DEVICE_ALT0_VARIANT := eMMC
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SOC := armada-3720
   BOOT_SCRIPT := espressobin
 endef
@@ -37,7 +40,7 @@ define Device/globalscale_espressobin-ultra
   DEVICE_VENDOR := Marvell
   DEVICE_MODEL := ESPRESSObin
   DEVICE_VARIANT := Ultra
-  DEVICE_PACKAGES += kmod-i2c-pxa kmod-rtc-pcf8563
+  DEVICE_PACKAGES += kmod-i2c-pxa kmod-rtc-pcf8563 $(PACKAGE_NO_WIRELESS)
   SOC := armada-3720
   BOOT_SCRIPT := espressobin
 endef
@@ -51,6 +54,7 @@ define Device/globalscale_espressobin-v7
   DEVICE_ALT0_VENDOR := Marvell
   DEVICE_ALT0_MODEL := Armada 3700 Community Board
   DEVICE_ALT0_VARIANT := V7 Non-eMMC
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SOC := armada-3720
   BOOT_SCRIPT := espressobin
 endef
@@ -64,6 +68,7 @@ define Device/globalscale_espressobin-v7-emmc
   DEVICE_ALT0_VENDOR := Marvell
   DEVICE_ALT0_MODEL := Armada 3700 Community Board
   DEVICE_ALT0_VARIANT := V7 eMMC
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SOC := armada-3720
   BOOT_SCRIPT := espressobin
 endef
@@ -74,6 +79,7 @@ define Device/marvell_armada-3720-db
   DEVICE_VENDOR := Marvell
   DEVICE_MODEL := Armada 3720 Development Board (DB-88F3720-DDR3)
   DEVICE_DTS := armada-3720-db
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += marvell_armada-3720-db
 
@@ -85,7 +91,7 @@ define Device/methode_udpu
   KERNEL_LOADADDR := 0x00800000
   KERNEL_INITRAMFS := kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
   KERNEL_INITRAMFS_SUFFIX := .itb
-  DEVICE_PACKAGES += f2fs-tools fdisk kmod-i2c-pxa kmod-hwmon-lm75
+  DEVICE_PACKAGES += f2fs-tools fdisk kmod-i2c-pxa kmod-hwmon-lm75 $(PACKAGE_NO_WIRELESS)
   DEVICE_IMG_NAME = $$(DEVICE_IMG_PREFIX)-$$(2)
   IMAGES := firmware.tgz
   IMAGE/firmware.tgz := boot-scr | boot-img-ext4 | uDPU-firmware | append-metadata

--- a/target/linux/mvebu/image/cortexa72.mk
+++ b/target/linux/mvebu/image/cortexa72.mk
@@ -2,6 +2,7 @@ define Device/globalscale_mochabin
   $(call Device/Default-arm64)
   DEVICE_VENDOR := Globalscale
   DEVICE_MODEL := MOCHAbin
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SOC := armada-7040
 endef
 TARGET_DEVICES += globalscale_mochabin
@@ -11,6 +12,7 @@ define Device/marvell_armada7040-db
   DEVICE_VENDOR := Marvell
   DEVICE_MODEL := Armada 7040 Development Board
   DEVICE_DTS := armada-7040-db
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGE/sdcard.img.gz := boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
 endef
 TARGET_DEVICES += marvell_armada7040-db
@@ -20,6 +22,7 @@ define Device/marvell_armada8040-db
   DEVICE_VENDOR := Marvell
   DEVICE_MODEL := Armada 8040 Development Board
   DEVICE_DTS := armada-8040-db
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGE/sdcard.img.gz := boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
 endef
 TARGET_DEVICES += marvell_armada8040-db
@@ -32,7 +35,7 @@ define Device/marvell_macchiatobin-doubleshot
   DEVICE_ALT0_VENDOR := SolidRun
   DEVICE_ALT0_MODEL := Armada 8040 Community Board
   DEVICE_ALT0_VARIANT := Double Shot
-  DEVICE_PACKAGES += kmod-i2c-mux-pca954x
+  DEVICE_PACKAGES += kmod-i2c-mux-pca954x $(PACKAGE_NO_WIRELESS)
   DEVICE_DTS := armada-8040-mcbin
   SUPPORTED_DEVICES := marvell,armada8040-mcbin-doubleshot marvell,armada8040-mcbin
 endef
@@ -46,7 +49,7 @@ define Device/marvell_macchiatobin-singleshot
   DEVICE_ALT0_VENDOR := SolidRun
   DEVICE_ALT0_MODEL := Armada 8040 Community Board
   DEVICE_ALT0_VARIANT := Single Shot
-  DEVICE_PACKAGES += kmod-i2c-mux-pca954x
+  DEVICE_PACKAGES += kmod-i2c-mux-pca954x $(PACKAGE_NO_WIRELESS)
   DEVICE_DTS := armada-8040-mcbin-singleshot
   SUPPORTED_DEVICES := marvell,armada8040-mcbin-singleshot
 endef
@@ -57,7 +60,8 @@ define Device/marvell_clearfog-gt-8k
   DEVICE_VENDOR := SolidRun
   DEVICE_MODEL := Clearfog
   DEVICE_VARIANT := GT-8K
-  DEVICE_PACKAGES += kmod-i2c-mux-pca954x kmod-crypto-hw-safexcel
+  DEVICE_PACKAGES += kmod-i2c-mux-pca954x kmod-crypto-hw-safexcel \
+	$(PACKAGE_NO_WIRELESS)
   DEVICE_DTS := armada-8040-clearfog-gt-8k
   SUPPORTED_DEVICES := marvell,armada8040-clearfog-gt-8k
 endef
@@ -67,6 +71,7 @@ define Device/iei_puzzle-m901
   $(call Device/Default-arm64)
   DEVICE_VENDOR := iEi
   DEVICE_MODEL := Puzzle-M901
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SOC := cn9131
 endef
 TARGET_DEVICES += iei_puzzle-m901
@@ -75,6 +80,7 @@ define Device/iei_puzzle-m902
   $(call Device/Default-arm64)
   DEVICE_VENDOR := iEi
   DEVICE_MODEL := Puzzle-M902
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SOC := cn9132
 endef
 TARGET_DEVICES += iei_puzzle-m902

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -55,7 +55,7 @@ define Device/buffalo_ls421de
   DEVICE_PACKAGES :=  \
     kmod-rtc-rs5c372a kmod-hwmon-gpiofan kmod-hwmon-drivetemp kmod-usb3 \
     kmod-linkstation-poweroff kmod-md-raid0 kmod-md-raid1 kmod-md-mod \
-    kmod-fs-xfs mkf2fs e2fsprogs partx-utils
+    kmod-fs-xfs mkf2fs e2fsprogs partx-utils $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += buffalo_ls421de
 
@@ -72,7 +72,8 @@ define Device/ctera_c200-v2
   KERNEL_SUFFIX := -factory.firm
   DEVICE_PACKAGES :=  \
     kmod-gpio-button-hotplug kmod-hwmon-drivetemp kmod-hwmon-nct7802 \
-    kmod-rtc-s35390a kmod-usb3 kmod-usb-ledtrig-usbport
+    kmod-rtc-s35390a kmod-usb3 kmod-usb-ledtrig-usbport \
+    $(PACKAGE_NO_WIRELESS)
   IMAGES := sysupgrade.bin
 endef
 TARGET_DEVICES += ctera_c200-v2
@@ -86,7 +87,7 @@ define Device/cznic_turris-omnia
   KERNEL_INITRAMFS := kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
   DEVICE_PACKAGES :=  \
     mkf2fs e2fsprogs kmod-fs-vfat kmod-nls-cp437 kmod-nls-iso8859-1 \
-    wpad-basic-mbedtls kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct \
+    kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct \
     partx-utils kmod-i2c-mux-pca954x kmod-leds-turris-omnia
   IMAGES := sysupgrade.img.gz
   IMAGE/sysupgrade.img.gz := boot-scr | boot-img | sdcard-img | gzip | append-metadata
@@ -106,7 +107,7 @@ define Device/fortinet_fg-50e
   DEVICE_DTS := armada-385-fortinet-fg-50e
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | \
     sysupgrade-tar rootfs=$$$$@ | append-metadata
-  DEVICE_PACKAGES := kmod-hwmon-nct7802
+  DEVICE_PACKAGES := kmod-hwmon-nct7802 $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += fortinet_fg-50e
 
@@ -114,6 +115,7 @@ define Device/globalscale_mirabox
   $(Device/NAND-512K)
   DEVICE_VENDOR := Globalscale
   DEVICE_MODEL := Mirabox
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SOC := armada-370
   SUPPORTED_DEVICES += mirabox
 endef
@@ -122,7 +124,8 @@ TARGET_DEVICES += globalscale_mirabox
 define Device/iptime_nas1dual
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := NAS1dual
-  DEVICE_PACKAGES := kmod-hwmon-drivetemp kmod-hwmon-gpiofan kmod-usb3
+  DEVICE_PACKAGES := kmod-hwmon-drivetemp kmod-hwmon-gpiofan kmod-usb3 \
+	$(PACKAGE_NO_WIRELESS)
   SOC := armada-385
   KERNEL := kernel-bin | append-dtb | iptime-naspkg nas1dual
   KERNEL_SIZE := 6144k
@@ -138,7 +141,7 @@ define Device/kobol_helios4
   DEVICE_MODEL := Helios4
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin
-  DEVICE_PACKAGES := mkf2fs e2fsprogs partx-utils
+  DEVICE_PACKAGES := mkf2fs e2fsprogs partx-utils $(PACKAGE_NO_WIRELESS)
   IMAGES := sdcard.img.gz
   IMAGE/sdcard.img.gz := boot-scr | boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
   SOC := armada-388
@@ -150,7 +153,7 @@ TARGET_DEVICES += kobol_helios4
 define Device/linksys
   $(Device/NAND-128K)
   DEVICE_VENDOR := Linksys
-  DEVICE_PACKAGES := kmod-mwlwifi wpad-basic-mbedtls
+  DEVICE_PACKAGES := kmod-mwlwifi
   IMAGES += factory.img
   IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
 	append-ubi | pad-to $$$$(PAGESIZE)
@@ -243,6 +246,7 @@ define Device/marvell_a370-db
   DEVICE_VENDOR := Marvell
   DEVICE_MODEL := Armada 370 Development Board (DB-88F6710-BP-DDR3)
   DEVICE_DTS := armada-370-db
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += armada-370-db
 endef
 TARGET_DEVICES += marvell_a370-db
@@ -252,6 +256,7 @@ define Device/marvell_a370-rd
   DEVICE_VENDOR := Marvell
   DEVICE_MODEL := Armada 370 RD (RD-88F6710-A1)
   DEVICE_DTS := armada-370-rd
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += armada-370-rd
 endef
 TARGET_DEVICES += marvell_a370-rd
@@ -261,6 +266,7 @@ define Device/marvell_a385-db-ap
   DEVICE_VENDOR := Marvell
   DEVICE_MODEL := Armada 385 Development Board AP (DB-88F6820-AP)
   DEVICE_DTS := armada-385-db-ap
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGES += factory.img
   IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
 	append-ubi | pad-to $$$$(PAGESIZE)
@@ -273,6 +279,7 @@ define Device/marvell_a388-rd
   DEVICE_VENDOR := Marvell
   DEVICE_MODEL := Armada 388 RD (RD-88F6820-AP)
   DEVICE_DTS := armada-388-rd
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   IMAGES := firmware.bin
   IMAGE/firmware.bin := append-kernel | pad-to 256k | append-rootfs | pad-rootfs
   SUPPORTED_DEVICES := armada-388-rd marvell,a385-rd
@@ -284,6 +291,7 @@ define Device/marvell_axp-db
   DEVICE_VENDOR := Marvell
   DEVICE_MODEL := Armada XP Development Board (DB-78460-BP)
   DEVICE_DTS := armada-xp-db
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += armada-xp-db
 endef
 TARGET_DEVICES += marvell_axp-db
@@ -293,6 +301,7 @@ define Device/marvell_axp-gp
   DEVICE_VENDOR := Marvell
   DEVICE_MODEL := Armada Armada XP GP (DB-MV784MP-GP)
   DEVICE_DTS := armada-xp-gp
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += armada-xp-gp
 endef
 TARGET_DEVICES += marvell_axp-gp
@@ -301,6 +310,7 @@ define Device/plathome_openblocks-ax3-4
   DEVICE_VENDOR := Plat'Home
   DEVICE_MODEL := OpenBlocks AX3
   DEVICE_VARIANT := 4 ports
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SOC := armada-xp
   SUPPORTED_DEVICES += openblocks-ax3-4
   BLOCKSIZE := 128k
@@ -315,7 +325,7 @@ define Device/solidrun_clearfog-base-a1
   DEVICE_MODEL := ClearFog Base
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin
-  DEVICE_PACKAGES := mkf2fs e2fsprogs partx-utils
+  DEVICE_PACKAGES := mkf2fs e2fsprogs partx-utils $(PACKAGE_NO_WIRELESS)
   IMAGES := sdcard.img.gz
   IMAGE/sdcard.img.gz := boot-scr | boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
   DEVICE_DTS := armada-388-clearfog-base armada-388-clearfog-pro
@@ -333,7 +343,7 @@ define Device/solidrun_clearfog-pro-a1
   DEVICE_MODEL := ClearFog Pro
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin
-  DEVICE_PACKAGES := mkf2fs e2fsprogs partx-utils
+  DEVICE_PACKAGES := mkf2fs e2fsprogs partx-utils $(PACKAGE_NO_WIRELESS)
   IMAGES := sdcard.img.gz
   IMAGE/sdcard.img.gz := boot-scr | boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
   DEVICE_DTS := armada-388-clearfog-pro armada-388-clearfog-base

--- a/target/linux/omap/Makefile
+++ b/target/linux/omap/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=omap
 BOARDNAME:=TI OMAP3/4/AM33xx
-FEATURES:=usb usbgadget ext4 targz fpu audio display nand rootfs-part squashfs source-only
+FEATURES:=usb usbgadget ext4 targz fpu audio display nand rootfs-part squashfs source-only wireless
 CPU_TYPE:=cortex-a8
 CPU_SUBTYPE:=vfpv3
 SUBTARGETS:=generic

--- a/target/linux/omap/profiles/00-default.mk
+++ b/target/linux/omap/profiles/00-default.mk
@@ -7,8 +7,7 @@ define Profile/Default
   PACKAGES:= \
 	kmod-usb-net-asix kmod-usb-net-asix-ax88179 kmod-usb-net-hso \
 	kmod-usb-net-kaweth kmod-usb-net-pegasus kmod-usb-net-mcs7830 \
-	kmod-usb-net-smsc95xx kmod-usb-net-dm9601-ether \
-	wpad-basic-mbedtls
+	kmod-usb-net-smsc95xx kmod-usb-net-dm9601-ether
   PRIORITY := 1
 endef
 

--- a/target/linux/oxnas/Makefile
+++ b/target/linux/oxnas/Makefile
@@ -4,7 +4,7 @@ ARCH:=arm
 BOARD:=oxnas
 BOARDNAME:=PLXTECH/Oxford NAS782x/OX8xx
 SUBTARGETS:=ox810se ox820
-FEATURES:=gpio ramdisk rtc squashfs
+FEATURES:=gpio ramdisk rtc squashfs wireless
 DEVICE_TYPE:=nas
 
 KERNEL_PATCHVER:=5.15

--- a/target/linux/oxnas/image/ox810se.mk
+++ b/target/linux/oxnas/image/ox810se.mk
@@ -15,6 +15,7 @@ define Device/wd_mbwe
   DEVICE_VENDOR := Western Digital
   DEVICE_MODEL := My Book
   DEVICE_VARIANT := World Edition
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   KERNEL := kernel-bin | append-dtb | uImage none
 endef
 TARGET_DEVICES += wd_mbwe

--- a/target/linux/oxnas/image/ox820.mk
+++ b/target/linux/oxnas/image/ox820.mk
@@ -41,7 +41,7 @@ define Device/akitio_mycloud
   DEVICE_MODEL := MyCloud Mini
   SUPPORTED_DEVICES += akitio
   DEVICE_PACKAGES := kmod-ata-oxnas-sata kmod-i2c-gpio kmod-rtc-ds1307 \
-	kmod-usb2-oxnas kmod-usb-ledtrig-usbport
+	kmod-usb2-oxnas kmod-usb-ledtrig-usbport $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += akitio_mycloud
 
@@ -50,7 +50,7 @@ define Device/cloudengines_pogoplugpro
   DEVICE_MODEL := PogoPlug Pro (with mPCIe)
   SUPPORTED_DEVICES += pogoplug-pro
   DEVICE_PACKAGES := kmod-usb2-oxnas kmod-usb-ledtrig-usbport \
-	kmod-ata-oxnas-sata kmod-rt2800-pci wpad-basic-mbedtls
+	kmod-ata-oxnas-sata kmod-rt2800-pci
 endef
 TARGET_DEVICES += cloudengines_pogoplugpro
 
@@ -59,7 +59,7 @@ define Device/cloudengines_pogoplug-series-3
   DEVICE_MODEL := PogoPlug Series V3 (without mPCIe)
   SUPPORTED_DEVICES += cloudengines,pogoplugv3 pogoplug-v3
   DEVICE_PACKAGES := kmod-usb2-oxnas kmod-usb-ledtrig-usbport \
-	kmod-ata-oxnas-sata
+	kmod-ata-oxnas-sata $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += cloudengines_pogoplug-series-3
 
@@ -70,7 +70,7 @@ define Device/shuttle_kd20
   DEVICE_PACKAGES := kmod-usb2-oxnas kmod-usb3 kmod-usb-ledtrig-usbport \
 	kmod-i2c-gpio kmod-rtc-pcf8563 kmod-gpio-beeper kmod-hwmon-drivetemp \
 	kmod-hwmon-gpiofan kmod-ata-oxnas-sata kmod-md-mod kmod-md-raid0 \
-	kmod-md-raid1 kmod-fs-ext4 kmod-fs-xfs
+	kmod-md-raid1 kmod-fs-ext4 kmod-fs-xfs $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += shuttle_kd20
 
@@ -79,6 +79,6 @@ define Device/mitrastar_stg-212
   DEVICE_MODEL := STG-212
   SUPPORTED_DEVICES += stg212
   DEVICE_PACKAGES := kmod-ata-oxnas-sata kmod-fs-ext4 kmod-fs-xfs \
-	kmod-usb2-oxnas kmod-usb-ledtrig-usbport
+	kmod-usb2-oxnas kmod-usb-ledtrig-usbport $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += mitrastar_stg-212

--- a/target/linux/qoriq/Makefile
+++ b/target/linux/qoriq/Makefile
@@ -8,7 +8,8 @@ ARCH:=powerpc64
 BOARD:=qoriq
 BOARDNAME:=NXP QorIQ (PowerPC)
 CPU_TYPE:=e5500
-FEATURES:=boot-part ext4 fpu legacy-sdcard powerpc64 ramdisk rootfs-part rtc source-only
+FEATURES:=boot-part ext4 fpu legacy-sdcard powerpc64 ramdisk
+FEATURES+=rootfs-part rtc source-only grand-flash
 SUBTARGETS:=generic
 
 KERNEL_PATCHVER:=5.15

--- a/target/linux/qualcommax/Makefile
+++ b/target/linux/qualcommax/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=aarch64
 BOARD:=qualcommax
 BOARDNAME:=Qualcomm Atheros 802.11ax WiSoC-s
-FEATURES:=squashfs ramdisk fpu nand rtc emmc
+FEATURES:=squashfs ramdisk fpu nand rtc emmc wireless
 KERNELNAME:=Image dtbs
 CPU_TYPE:=cortex-a53
 SUBTARGETS:=ipq807x
@@ -14,8 +14,9 @@ include $(INCLUDE_DIR)/target.mk
 DEFAULT_PACKAGES += \
 	kmod-usb3 kmod-usb-dwc3 kmod-usb-dwc3-qcom \
 	kmod-leds-gpio kmod-gpio-button-hotplug \
-	kmod-qca-nss-dp kmod-ath11k-ahb \
-	wpad-basic-mbedtls uboot-envtools \
+	kmod-phy-aquantia kmod-qca-nss-dp \
+	ath11k-firmware-ipq8074 kmod-ath11k-ahb \
+	uboot-envtools \
 	e2fsprogs kmod-fs-ext4 losetup
 
 $(eval $(call BuildTarget))

--- a/target/linux/qualcommax/Makefile
+++ b/target/linux/qualcommax/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=aarch64
 BOARD:=qualcommax
 BOARDNAME:=Qualcomm Atheros 802.11ax WiSoC-s
-FEATURES:=squashfs ramdisk fpu nand rtc emmc wireless
+FEATURES:=squashfs ramdisk fpu nand rtc emmc wireless grand-flash
 KERNELNAME:=Image dtbs
 CPU_TYPE:=cortex-a53
 SUBTARGETS:=ipq807x

--- a/target/linux/ramips/Makefile
+++ b/target/linux/ramips/Makefile
@@ -8,7 +8,7 @@ ARCH:=mipsel
 BOARD:=ramips
 BOARDNAME:=MediaTek Ralink MIPS
 SUBTARGETS:=mt7620 mt7621 mt76x8 rt288x rt305x rt3883
-FEATURES:=squashfs gpio
+FEATURES:=squashfs gpio wireless
 
 KERNEL_PATCHVER:=5.15
 

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -54,7 +54,7 @@ define Device/alfa-network_tube-e4g
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := Tube-E4G
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci uboot-envtools uqmi -iwinfo \
-	-kmod-rt2800-soc -wpad-basic-mbedtls
+	-kmod-rt2800-soc $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += tube-e4g
 endef
 TARGET_DEVICES += alfa-network_tube-e4g

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -227,7 +227,7 @@ define Device/alfa-network_quad-e4g
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := Quad-E4G
   DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 \
-	-wpad-basic-mbedtls
+	$(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += quad-e4g
 endef
 TARGET_DEVICES += alfa-network_quad-e4g
@@ -285,7 +285,7 @@ define Device/asiarf_ap7621-001
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AP7621-001
   DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt76x2 kmod-usb3 \
-	-wpad-basic-mbedtls -uboot-envtools
+	$(PACKAGE_NO_WIRELESS) -uboot-envtools
 endef
 TARGET_DEVICES += asiarf_ap7621-001
 
@@ -296,7 +296,7 @@ define Device/asiarf_ap7621-nv1
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AP7621-NV1
   DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt76x2 kmod-usb3 \
-	-wpad-basic-mbedtls -uboot-envtools
+	$(PACKAGE_NO_WIRELESS) -uboot-envtools
 endef
 TARGET_DEVICES += asiarf_ap7621-nv1
 
@@ -845,7 +845,7 @@ define Device/dual-q_h721
   DEVICE_VENDOR := Dual-Q
   DEVICE_MODEL := H721
   DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 \
-	-wpad-basic-mbedtls -uboot-envtools
+	$(PACKAGE_NO_WIRELESS) -uboot-envtools
 endef
 TARGET_DEVICES += dual-q_h721
 
@@ -1089,7 +1089,7 @@ define Device/gnubee_gb-pc1
   DEVICE_VENDOR := GnuBee
   DEVICE_MODEL := GB-PC1
   DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 kmod-sdhci-mt7620 \
-	-wpad-basic-mbedtls -uboot-envtools
+	$(PACKAGE_NO_WIRELESS) -uboot-envtools
   IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += gnubee_gb-pc1
@@ -1100,7 +1100,7 @@ define Device/gnubee_gb-pc2
   DEVICE_VENDOR := GnuBee
   DEVICE_MODEL := GB-PC2
   DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 kmod-sdhci-mt7620 \
-	-wpad-basic-mbedtls -uboot-envtools
+	$(PACKAGE_NO_WIRELESS) -uboot-envtools
   IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += gnubee_gb-pc2
@@ -1424,7 +1424,7 @@ define Device/iptime_t5004
   UIMAGE_NAME := t5004
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := T5004
-  DEVICE_PACKAGES := -wpad-basic-mbedtls -uboot-envtools
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS) -uboot-envtools
 endef
 TARGET_DEVICES += iptime_t5004
 
@@ -1602,7 +1602,7 @@ define Device/mediatek_ap-mt7621a-v60
   DEVICE_VENDOR := Mediatek
   DEVICE_MODEL := AP-MT7621A-V60 EVB
   DEVICE_PACKAGES := kmod-usb3 kmod-sdhci-mt7620 kmod-sound-mt7620 \
-	-wpad-basic-mbedtls -uboot-envtools
+	$(PACKAGE_NO_WIRELESS) -uboot-envtools
 endef
 TARGET_DEVICES += mediatek_ap-mt7621a-v60
 
@@ -1611,7 +1611,7 @@ define Device/mediatek_mt7621-eval-board
   IMAGE_SIZE := 15104k
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7621 EVB
-  DEVICE_PACKAGES := -wpad-basic-mbedtls -uboot-envtools
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS) -uboot-envtools
   SUPPORTED_DEVICES += mt7621
 endef
 TARGET_DEVICES += mediatek_mt7621-eval-board
@@ -1651,7 +1651,7 @@ TARGET_DEVICES += mikrotik_ltap-2hnd
 define Device/mikrotik_routerboard-750gr3
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD 750Gr3
-  DEVICE_PACKAGES += -wpad-basic-mbedtls
+  DEVICE_PACKAGES += $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += mikrotik,rb750gr3
 endef
 TARGET_DEVICES += mikrotik_routerboard-750gr3
@@ -1659,14 +1659,14 @@ TARGET_DEVICES += mikrotik_routerboard-750gr3
 define Device/mikrotik_routerboard-760igs
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD 760iGS
-  DEVICE_PACKAGES += kmod-sfp -wpad-basic-mbedtls
+  DEVICE_PACKAGES += kmod-sfp $(PACKAGE_NO_WIRELESS)
 endef
 TARGET_DEVICES += mikrotik_routerboard-760igs
 
 define Device/mikrotik_routerboard-m11g
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD M11G
-  DEVICE_PACKAGES := -wpad-basic-mbedtls
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += mikrotik,rbm11g
 endef
 TARGET_DEVICES += mikrotik_routerboard-m11g
@@ -1674,7 +1674,7 @@ TARGET_DEVICES += mikrotik_routerboard-m11g
 define Device/mikrotik_routerboard-m33g
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD M33G
-  DEVICE_PACKAGES := -wpad-basic-mbedtls
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += mikrotik,rbm33g
 endef
 TARGET_DEVICES += mikrotik_routerboard-m33g
@@ -1996,7 +1996,7 @@ define Device/planex_vr500
   IMAGE_SIZE := 65216k
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := VR500
-  DEVICE_PACKAGES := kmod-usb3 -wpad-basic-mbedtls -uboot-envtools
+  DEVICE_PACKAGES := kmod-usb3 $(PACKAGE_NO_WIRELESS) -uboot-envtools
   SUPPORTED_DEVICES += vr500
 endef
 TARGET_DEVICES += planex_vr500
@@ -2150,7 +2150,7 @@ define Device/thunder_timecloud
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Thunder
   DEVICE_MODEL := Timecloud
-  DEVICE_PACKAGES := kmod-usb3 -wpad-basic-mbedtls -uboot-envtools
+  DEVICE_PACKAGES := kmod-usb3 $(PACKAGE_NO_WIRELESS) -uboot-envtools
   SUPPORTED_DEVICES += timecloud
 endef
 TARGET_DEVICES += thunder_timecloud
@@ -2316,7 +2316,7 @@ define Device/tplink_er605-v2
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := ER605
   DEVICE_VARIANT := v2
-  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS) kmod-usb3 -uboot-envtools
   KERNEL_IN_UBI := 1
   KERNEL_LOADADDR := 0x82000000
   KERNEL := kernel-bin | relocate-kernel 0x80001000 | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
@@ -2410,7 +2410,7 @@ define Device/ubnt_edgerouter_common
   KERNEL_INITRAMFS := $$(KERNEL) | \
 	ubnt-erx-factory-image $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.tar
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES += -wpad-basic-mbedtls -uboot-envtools
+  DEVICE_PACKAGES += $(PACKAGE_NO_WIRELESS) -uboot-envtools
 endef
 
 define Device/ubnt_edgerouter-x
@@ -2495,7 +2495,7 @@ define Device/unielec_u7621-06-16m
   DEVICE_MODEL := U7621-06
   DEVICE_VARIANT := 16M
   DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 \
-	-wpad-basic-mbedtls -uboot-envtools
+	$(PACKAGE_NO_WIRELESS) -uboot-envtools
   SUPPORTED_DEVICES += u7621-06-256M-16M unielec,u7621-06-256m-16m
 endef
 TARGET_DEVICES += unielec_u7621-06-16m
@@ -2508,7 +2508,7 @@ define Device/unielec_u7621-06-32m
   DEVICE_MODEL := U7621-06
   DEVICE_VARIANT := 32M
   DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 \
-	-wpad-basic-mbedtls -uboot-envtools
+	$(PACKAGE_NO_WIRELESS) -uboot-envtools
   SUPPORTED_DEVICES += unielec,u7621-06-32m
 endef
 TARGET_DEVICES += unielec_u7621-06-32m
@@ -2521,7 +2521,7 @@ define Device/unielec_u7621-06-64m
   DEVICE_MODEL := U7621-06
   DEVICE_VARIANT := 64M
   DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 \
-	-wpad-basic-mbedtls -uboot-envtools
+	$(PACKAGE_NO_WIRELESS) -uboot-envtools
   SUPPORTED_DEVICES += unielec,u7621-06-512m-64m
 endef
 TARGET_DEVICES += unielec_u7621-06-64m
@@ -2759,7 +2759,7 @@ define Device/xiaoyu_xy-c5
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := XiaoYu
   DEVICE_MODEL := XY-C5
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 -wpad-basic-mbedtls \
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 $(PACKAGE_NO_WIRELESS) \
 	-uboot-envtools
 endef
 TARGET_DEVICES += xiaoyu_xy-c5
@@ -2770,7 +2770,7 @@ define Device/xzwifi_creativebox-v1
   DEVICE_VENDOR := CreativeBox
   DEVICE_MODEL := v1
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mt7603 kmod-mt76x2 kmod-sdhci-mt7620 \
-	kmod-usb3 -wpad-basic-mbedtls -uboot-envtools
+	kmod-usb3 $(PACKAGE_NO_WIRELESS) -uboot-envtools
 endef
 TARGET_DEVICES += xzwifi_creativebox-v1
 

--- a/target/linux/ramips/mt7620/target.mk
+++ b/target/linux/ramips/mt7620/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=MT7620 based boards
 FEATURES+=usb ramdisk
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-rt2800-soc wpad-basic-mbedtls swconfig
+DEFAULT_PACKAGES += kmod-rt2800-soc swconfig
 
 define Target/Description
 	Build firmware images for Ralink MT7620 based boards.

--- a/target/linux/ramips/mt7621/target.mk
+++ b/target/linux/ramips/mt7621/target.mk
@@ -10,7 +10,7 @@ KERNELNAME:=vmlinux vmlinuz
 # make Kernel/CopyImage use $LINUX_DIR/vmlinuz
 IMAGES_DIR:=../../..
 
-DEFAULT_PACKAGES += wpad-basic-mbedtls uboot-envtools kmod-crypto-hw-eip93
+DEFAULT_PACKAGES += uboot-envtools kmod-crypto-hw-eip93
 
 define Target/Description
 	Build firmware images for Ralink MT7621 based boards.

--- a/target/linux/ramips/mt76x8/target.mk
+++ b/target/linux/ramips/mt76x8/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=MT76x8 based boards
 FEATURES+=usb ramdisk
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-mt7603 wpad-basic-mbedtls swconfig
+DEFAULT_PACKAGES += kmod-mt7603 swconfig
 
 define Target/Description
 	Build firmware images for Ralink MT76x8 based boards.

--- a/target/linux/ramips/rt288x/target.mk
+++ b/target/linux/ramips/rt288x/target.mk
@@ -4,7 +4,7 @@
 
 SUBTARGET:=rt288x
 BOARDNAME:=RT288x based boards
-FEATURES+=small_flash
+FEATURES+=small-flash
 CPU_TYPE:=24kc
 
 DEFAULT_PACKAGES += kmod-rt2800-soc swconfig

--- a/target/linux/ramips/rt288x/target.mk
+++ b/target/linux/ramips/rt288x/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=RT288x based boards
 FEATURES+=small_flash
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-rt2800-soc wpad-basic-mbedtls swconfig
+DEFAULT_PACKAGES += kmod-rt2800-soc swconfig
 
 define Target/Description
 	Build firmware images for Ralink RT288x based boards.

--- a/target/linux/ramips/rt305x/target.mk
+++ b/target/linux/ramips/rt305x/target.mk
@@ -4,7 +4,7 @@
 
 SUBTARGET:=rt305x
 BOARDNAME:=RT3x5x/RT5350 based boards
-FEATURES+=usb ramdisk small_flash
+FEATURES+=usb ramdisk small-flash
 CPU_TYPE:=24kc
 
 DEFAULT_PACKAGES += kmod-rt2800-soc swconfig

--- a/target/linux/ramips/rt305x/target.mk
+++ b/target/linux/ramips/rt305x/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=RT3x5x/RT5350 based boards
 FEATURES+=usb ramdisk small_flash
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-rt2800-soc wpad-basic-mbedtls swconfig
+DEFAULT_PACKAGES += kmod-rt2800-soc swconfig
 
 define Target/Description
 	Build firmware images for Ralink RT3x5x/RT5350 based boards.

--- a/target/linux/ramips/rt3883/target.mk
+++ b/target/linux/ramips/rt3883/target.mk
@@ -4,7 +4,7 @@
 
 SUBTARGET:=rt3883
 BOARDNAME:=RT3662/RT3883 based boards
-FEATURES+=usb pci small_flash
+FEATURES+=usb pci small-flash
 CPU_TYPE:=74kc
 
 DEFAULT_PACKAGES += kmod-rt2800-pci kmod-rt2800-soc swconfig

--- a/target/linux/ramips/rt3883/target.mk
+++ b/target/linux/ramips/rt3883/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=RT3662/RT3883 based boards
 FEATURES+=usb pci small_flash
 CPU_TYPE:=74kc
 
-DEFAULT_PACKAGES += kmod-rt2800-pci kmod-rt2800-soc wpad-basic-mbedtls swconfig
+DEFAULT_PACKAGES += kmod-rt2800-pci kmod-rt2800-soc swconfig
 
 define Target/Description
 	Build firmware images for Ralink RT3662/RT3883 based boards.

--- a/target/linux/rockchip/Makefile
+++ b/target/linux/rockchip/Makefile
@@ -4,7 +4,8 @@ include $(TOPDIR)/rules.mk
 
 BOARD:=rockchip
 BOARDNAME:=Rockchip
-FEATURES:=ext4 audio usb usbgadget display gpio fpu pci pcie rootfs-part boot-part squashfs
+FEATURES:=ext4 audio usb usbgadget display gpio fpu pci pcie
+FEATURES+=rootfs-part boot-part squashfs grand-flash
 SUBTARGETS:=armv8
 
 KERNEL_PATCHVER:=5.15

--- a/target/linux/sifiveu/Makefile
+++ b/target/linux/sifiveu/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=riscv64
 BOARD:=sifiveu
 BOARDNAME:=SiFive U-based RISC-V boards
-FEATURES:=ext4
+FEATURES:=ext4 grand-flash
 KERNELNAME:=Image dtbs
 SUBTARGETS:=generic
 

--- a/target/linux/sunxi/Makefile
+++ b/target/linux/sunxi/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=sunxi
 BOARDNAME:=Allwinner ARM SoCs
-FEATURES:=fpu usb ext4 display rootfs-part rtc squashfs wireless
+FEATURES:=fpu usb ext4 display rootfs-part rtc squashfs wireless grand-flash
 SUBTARGETS:=cortexa8 cortexa7 cortexa53
 
 KERNEL_PATCHVER:=6.1

--- a/target/linux/sunxi/Makefile
+++ b/target/linux/sunxi/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=sunxi
 BOARDNAME:=Allwinner ARM SoCs
-FEATURES:=fpu usb ext4 display rootfs-part rtc squashfs
+FEATURES:=fpu usb ext4 display rootfs-part rtc squashfs wireless
 SUBTARGETS:=cortexa8 cortexa7 cortexa53
 
 KERNEL_PATCHVER:=6.1

--- a/target/linux/sunxi/image/cortexa53.mk
+++ b/target/linux/sunxi/image/cortexa53.mk
@@ -33,6 +33,7 @@ define Device/friendlyarm_nanopi-neo-plus2
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO Plus2
   SUPPORTED_DEVICES:=nanopi-neo-plus2
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   $(Device/sun50i-h5)
 endef
 TARGET_DEVICES += friendlyarm_nanopi-neo-plus2
@@ -41,6 +42,7 @@ define Device/friendlyarm_nanopi-neo2
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO2
   SUPPORTED_DEVICES:=nanopi-neo2
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   $(Device/sun50i-h5)
 endef
 TARGET_DEVICES += friendlyarm_nanopi-neo2
@@ -48,7 +50,7 @@ TARGET_DEVICES += friendlyarm_nanopi-neo2
 define Device/friendlyarm_nanopi-r1s-h5
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := Nanopi R1S H5
-  DEVICE_PACKAGES := kmod-gpio-button-hotplug kmod-usb-net-rtl8152
+  DEVICE_PACKAGES := kmod-gpio-button-hotplug kmod-usb-net-rtl8152 $(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES:=nanopi-r1s-h5
   $(Device/sun50i-h5)
 endef
@@ -58,6 +60,7 @@ define Device/libretech_all-h3-cc-h5
   DEVICE_VENDOR := Libre Computer
   DEVICE_MODEL := ALL-H3-CC
   DEVICE_VARIANT := H5
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   $(Device/sun50i-h5)
   SUNXI_DTS := $$(SUNXI_DTS_DIR)$$(SOC)-libretech-all-h3-cc
 endef
@@ -102,6 +105,7 @@ define Device/xunlong_orangepi-one-plus
   $(Device/sun50i-h6)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi One Plus
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SUNXI_DTS_DIR := allwinner/
 endef
 TARGET_DEVICES += xunlong_orangepi-one-plus
@@ -109,6 +113,7 @@ TARGET_DEVICES += xunlong_orangepi-one-plus
 define Device/xunlong_orangepi-pc2
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC 2
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   $(Device/sun50i-h5)
 endef
 TARGET_DEVICES += xunlong_orangepi-pc2
@@ -123,6 +128,7 @@ TARGET_DEVICES += xunlong_orangepi-zero2
 define Device/xunlong_orangepi-zero-plus
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi Zero Plus
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   $(Device/sun50i-h5)
 endef
 TARGET_DEVICES += xunlong_orangepi-zero-plus

--- a/target/linux/sunxi/image/cortexa7.mk
+++ b/target/linux/sunxi/image/cortexa7.mk
@@ -6,6 +6,7 @@
 define Device/cubietech_cubieboard2
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubieboard2
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
   SOC := sun7i-a20
 endef
@@ -14,6 +15,7 @@ TARGET_DEVICES += cubietech_cubieboard2
 define Device/cubietech_cubietruck
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubietruck
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtc-sunxi kmod-brcmfmac
   SOC := sun7i-a20
 endef
@@ -23,7 +25,7 @@ define Device/friendlyarm_nanopi-m1-plus
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi M1 Plus
   DEVICE_PACKAGES:=kmod-leds-gpio kmod-brcmfmac \
-	cypress-firmware-43430-sdio wpad-basic-mbedtls
+	cypress-firmware-43430-sdio
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += friendlyarm_nanopi-m1-plus
@@ -31,6 +33,7 @@ TARGET_DEVICES += friendlyarm_nanopi-m1-plus
 define Device/friendlyarm_nanopi-neo
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO
+  DEVICE_PACKAGES := $(PACKAGE_NO_WIRELESS)
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += friendlyarm_nanopi-neo
@@ -39,7 +42,7 @@ define Device/friendlyarm_nanopi-neo-air
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO Air
   DEVICE_PACKAGES := kmod-leds-gpio kmod-brcmfmac \
-	brcmfmac-firmware-43430a0-sdio wpad-basic-mbedtls
+	brcmfmac-firmware-43430a0-sdio
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += friendlyarm_nanopi-neo-air
@@ -48,7 +51,7 @@ define Device/friendlyarm_nanopi-r1
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R1
   DEVICE_PACKAGES := kmod-usb-net-rtl8152 kmod-leds-gpio \
-	kmod-brcmfmac cypress-firmware-43430-sdio wpad-basic-mbedtls
+	kmod-brcmfmac cypress-firmware-43430-sdio
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r1
@@ -56,7 +59,7 @@ TARGET_DEVICES += friendlyarm_nanopi-r1
 define Device/friendlyarm_zeropi
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := ZeroPi
-  DEVICE_PACKAGES := kmod-rtc-sunxi
+  DEVICE_PACKAGES := kmod-rtc-sunxi $(PACKAGE_NO_WIRELESS)
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += friendlyarm_zeropi
@@ -66,7 +69,7 @@ define Device/lamobo_lamobo-r1
   DEVICE_MODEL := Lamobo R1
   DEVICE_ALT0_VENDOR := Bananapi
   DEVICE_ALT0_MODEL := BPi-R1
-  DEVICE_PACKAGES := kmod-ata-sunxi kmod-rtl8192cu wpad-basic-mbedtls
+  DEVICE_PACKAGES := kmod-ata-sunxi kmod-rtl8192cu
   DEVICE_COMPAT_VERSION := 1.1
   DEVICE_COMPAT_MESSAGE := Config cannot be migrated from swconfig to DSA
   SOC := sun7i-a20
@@ -76,7 +79,7 @@ TARGET_DEVICES += lamobo_lamobo-r1
 define Device/lemaker_bananapi
   DEVICE_VENDOR := LeMaker
   DEVICE_MODEL := Banana Pi
-  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi
+  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi $(PACKAGE_NO_WIRELESS)
   SOC := sun7i-a20
 endef
 TARGET_DEVICES += lemaker_bananapi
@@ -85,7 +88,7 @@ define Device/sinovoip_bananapi-m2-berry
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Berry
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-brcmfmac \
-	cypress-firmware-43430-sdio wpad-basic-mbedtls
+	cypress-firmware-43430-sdio
   SUPPORTED_DEVICES:=lemaker,bananapi-m2-berry
   SOC := sun8i-v40
 endef
@@ -95,7 +98,7 @@ define Device/sinovoip_bananapi-m2-ultra
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Ultra
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-brcmfmac \
-	brcmfmac-firmware-43430a0-sdio wpad-basic-mbedtls
+	brcmfmac-firmware-43430a0-sdio
   SUPPORTED_DEVICES:=lemaker,bananapi-m2-ultra
   SOC := sun8i-r40
 endef
@@ -105,7 +108,7 @@ define Device/lemaker_bananapro
   DEVICE_VENDOR := LeMaker
   DEVICE_MODEL := Banana Pro
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi kmod-brcmfmac \
-	cypress-firmware-43362-sdio wpad-basic-mbedtls
+	cypress-firmware-43362-sdio wpad-basic-mbedtls $(PACKAGE_NO_WIRELESS)
   SOC := sun7i-a20
 endef
 TARGET_DEVICES += lemaker_bananapro
@@ -122,7 +125,7 @@ TARGET_DEVICES += linksprite_pcduino3
 define Device/linksprite_pcduino3-nano
   DEVICE_VENDOR := LinkSprite
   DEVICE_MODEL := pcDuino3 Nano
-  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi
+  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi $(PACKAGE_NO_WIRELESS)
   SOC := sun7i-a20
 endef
 TARGET_DEVICES += linksprite_pcduino3-nano
@@ -138,7 +141,7 @@ TARGET_DEVICES += mele_m9
 define Device/olimex_a20-olinuxino-lime
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-LIME
-  DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtc-sunxi
+  DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtc-sunxi $(PACKAGE_NO_WIRELESS)
   SOC := sun7i
 endef
 TARGET_DEVICES += olimex_a20-olinuxino-lime
@@ -146,7 +149,7 @@ TARGET_DEVICES += olimex_a20-olinuxino-lime
 define Device/olimex_a20-olinuxino-lime2
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-LIME2
-  DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtc-sunxi kmod-usb-hid
+  DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtc-sunxi kmod-usb-hid $(PACKAGE_NO_WIRELESS)
   SOC := sun7i
 endef
 TARGET_DEVICES += olimex_a20-olinuxino-lime2
@@ -155,7 +158,7 @@ define Device/olimex_a20-olinuxino-lime2-emmc
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-LIME2
   DEVICE_VARIANT := eMMC
-  DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtc-sunxi kmod-usb-hid
+  DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtc-sunxi kmod-usb-hid $(PACKAGE_NO_WIRELESS)
   SOC := sun7i
 endef
 TARGET_DEVICES += olimex_a20-olinuxino-lime2-emmc
@@ -163,7 +166,7 @@ TARGET_DEVICES += olimex_a20-olinuxino-lime2-emmc
 define Device/olimex_a20-olinuxino-micro
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-MICRO
-  DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
+  DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi $(PACKAGE_NO_WIRELESS)
   SOC := sun7i
 endef
 TARGET_DEVICES += olimex_a20-olinuxino-micro
@@ -172,7 +175,7 @@ define Device/sinovoip_bananapi-m2-plus
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2+
   DEVICE_PACKAGES:=kmod-leds-gpio kmod-brcmfmac \
-	brcmfmac-firmware-43430a0-sdio wpad-basic-mbedtls
+	brcmfmac-firmware-43430a0-sdio
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += sinovoip_bananapi-m2-plus
@@ -198,7 +201,7 @@ TARGET_DEVICES += sinovoip_bananapi-p2-zero
 define Device/xunlong_orangepi-one
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi One
-  DEVICE_PACKAGES:=kmod-rtc-sunxi
+  DEVICE_PACKAGES:=kmod-rtc-sunxi $(PACKAGE_NO_WIRELESS)
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += xunlong_orangepi-one
@@ -206,7 +209,7 @@ TARGET_DEVICES += xunlong_orangepi-one
 define Device/xunlong_orangepi-pc
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC
-  DEVICE_PACKAGES:=kmod-gpio-button-hotplug
+  DEVICE_PACKAGES:=kmod-gpio-button-hotplug $(PACKAGE_NO_WIRELESS)
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += xunlong_orangepi-pc
@@ -214,7 +217,7 @@ TARGET_DEVICES += xunlong_orangepi-pc
 define Device/xunlong_orangepi-pc-plus
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC Plus
-  DEVICE_PACKAGES:=kmod-gpio-button-hotplug
+  DEVICE_PACKAGES:=kmod-gpio-button-hotplug $(PACKAGE_NO_WIRELESS)
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += xunlong_orangepi-pc-plus
@@ -222,7 +225,7 @@ TARGET_DEVICES += xunlong_orangepi-pc-plus
 define Device/xunlong_orangepi-plus
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi Plus
-  DEVICE_PACKAGES:=kmod-rtc-sunxi
+  DEVICE_PACKAGES:=kmod-rtc-sunxi $(PACKAGE_NO_WIRELESS)
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += xunlong_orangepi-plus
@@ -238,7 +241,7 @@ TARGET_DEVICES += xunlong_orangepi-r1
 define Device/xunlong_orangepi-zero
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi Zero
-  DEVICE_PACKAGES:=kmod-rtc-sunxi
+  DEVICE_PACKAGES:=kmod-rtc-sunxi $(PACKAGE_NO_WIRELESS)
   SOC := sun8i-h2-plus
 endef
 TARGET_DEVICES += xunlong_orangepi-zero
@@ -246,7 +249,7 @@ TARGET_DEVICES += xunlong_orangepi-zero
 define Device/xunlong_orangepi-2
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi 2
-  DEVICE_PACKAGES:=kmod-rtc-sunxi
+  DEVICE_PACKAGES:=kmod-rtc-sunxi $(PACKAGE_NO_WIRELESS)
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += xunlong_orangepi-2

--- a/target/linux/sunxi/image/cortexa8.mk
+++ b/target/linux/sunxi/image/cortexa8.mk
@@ -6,7 +6,7 @@
 define Device/cubietech_a10-cubieboard
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubieboard
-  DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
+  DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi $(PACKAGE_NO_WIRELESS)
   SOC := sun4i
 endef
 TARGET_DEVICES += cubietech_a10-cubieboard
@@ -15,7 +15,8 @@ define Device/haoyu_a10-marsboard
   DEVICE_VENDOR := HAOYU Electronics
   DEVICE_MODEL := MarsBoard A10
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac \
-	kmod-rtc-sunxi kmod-sound-core kmod-sound-soc-sunxi
+	kmod-rtc-sunxi kmod-sound-core kmod-sound-soc-sunxi \
+	$(PACKAGE_NO_WIRELESS)
   SUPPORTED_DEVICES += marsboard,a10-marsboard
   SOC := sun4i
 endef
@@ -32,7 +33,7 @@ TARGET_DEVICES += linksprite_a10-pcduino
 define Device/olimex_a10-olinuxino-lime
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A10-OLinuXino-LIME
-  DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
+  DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi $(PACKAGE_NO_WIRELESS)
   SOC := sun4i
 endef
 TARGET_DEVICES += olimex_a10-olinuxino-lime

--- a/target/linux/sunxi/profiles/00-default.mk
+++ b/target/linux/sunxi/profiles/00-default.mk
@@ -12,8 +12,7 @@ define Profile/Default
 	kmod-rtl8xxxu \
 	kmod-sun4i-emac \
 	rtl8188eu-firmware \
-	swconfig \
-	wpad-basic-mbedtls
+	swconfig
   PRIORITY := 1
 endef
 

--- a/target/linux/tegra/Makefile
+++ b/target/linux/tegra/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH := arm
 BOARD := tegra
 BOARDNAME := NVIDIA Tegra
-FEATURES := audio boot-part display ext4 fpu gpio pci pcie rootfs-part rtc squashfs usb
+FEATURES := audio boot-part display ext4 fpu gpio pci pcie rootfs-part rtc squashfs usb wireless
 CPU_TYPE := cortex-a9
 CPU_SUBTYPE := vfpv3-d16
 SUBTARGETS := generic

--- a/target/linux/tegra/Makefile
+++ b/target/linux/tegra/Makefile
@@ -7,7 +7,8 @@ include $(TOPDIR)/rules.mk
 ARCH := arm
 BOARD := tegra
 BOARDNAME := NVIDIA Tegra
-FEATURES := audio boot-part display ext4 fpu gpio pci pcie rootfs-part rtc squashfs usb wireless
+FEATURES := audio boot-part display ext4 fpu gpio pci pcie
+FEATURES += rootfs-part rtc squashfs usb wireless grand-flash
 CPU_TYPE := cortex-a9
 CPU_SUBTYPE := vfpv3-d16
 SUBTARGETS := generic

--- a/target/linux/tegra/image/Makefile
+++ b/target/linux/tegra/image/Makefile
@@ -43,7 +43,7 @@ define Device/compulab_trimslice
   DEVICE_MODEL := TrimSlice
   DEVICE_DTS := tegra20-trimslice
   DEVICE_PACKAGES := kmod-r8169 kmod-rt2800-usb kmod-rtc-em3027 \
-	kmod-usb-storage wpad-basic-mbedtls
+	kmod-usb-storage
   UBOOT := trimslice-mmc
 endef
 TARGET_DEVICES += compulab_trimslice

--- a/target/linux/uml/Makefile
+++ b/target/linux/uml/Makefile
@@ -11,14 +11,14 @@ ifeq ($(HOST_OS),Linux)
 ARCH:=x86_64
 BOARD:=uml
 BOARDNAME:=User Mode Linux
-FEATURES:=audio ext4 rootfs-part squashfs
+FEATURES:=audio ext4 rootfs-part squashfs wireless
 
 KERNEL_PATCHVER:=5.15
 KERNEL_TESTING_PATCHVER:=6.1
 
 include $(INCLUDE_DIR)/target.mk
 
-DEFAULT_PACKAGES += wpad-basic-mbedtls kmod-mac80211-hwsim mkf2fs e2fsprogs
+DEFAULT_PACKAGES += kmod-mac80211-hwsim mkf2fs e2fsprogs
 
   endif
 endif

--- a/target/linux/uml/Makefile
+++ b/target/linux/uml/Makefile
@@ -11,7 +11,7 @@ ifeq ($(HOST_OS),Linux)
 ARCH:=x86_64
 BOARD:=uml
 BOARDNAME:=User Mode Linux
-FEATURES:=audio ext4 rootfs-part squashfs wireless
+FEATURES:=audio ext4 rootfs-part squashfs wireless grand-flash
 
 KERNEL_PATCHVER:=5.15
 KERNEL_TESTING_PATCHVER:=6.1

--- a/target/linux/x86/Makefile
+++ b/target/linux/x86/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=i386
 BOARD:=x86
 BOARDNAME:=x86
-FEATURES:=squashfs ext4 vdi vmdk vhdx pcmcia targz fpu boot-part rootfs-part
+FEATURES:=squashfs ext4 vdi vmdk vhdx pcmcia targz fpu boot-part rootfs-part grand-flash
 SUBTARGETS:=generic legacy geode 64
 
 KERNEL_PATCHVER:=5.15

--- a/target/linux/zynq/Makefile
+++ b/target/linux/zynq/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=zynq
 BOARDNAME:=Xilinx Zynq 7000 SoCs
-FEATURES:=fpu gpio rtc usb usbgadget boot-part rootfs-part squashfs
+FEATURES:=fpu gpio rtc usb usbgadget boot-part rootfs-part squashfs grand-flash
 CPU_TYPE:=cortex-a9
 CPU_SUBTYPE:=neon
 SUBTARGETS:=generic


### PR DESCRIPTION
Current default official images on all devices are using mbedTLS 2.y which
doesn't support TLS v1.3 (#12874), so lets fix it by using OpenSSL on devices
which should have enough storage space to accomodate additional ~1.5MB
(rough estimate didn't measured it).

This is just my first quick attempt to implement one of the possible
solutions, since I think, that using mbedTLS 3.y is not an option for backport
into 23.05.

While at it, make the dash/underscore naming pattern in `FEATURES` consistent
and use dash, cleanup apparently unused features as well.