### PR TITLE
bmips: add support for Comtrend VG-8050

### DIFF
--- a/target/linux/bmips/bcm63268/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm63268/base-files/etc/board.d/02_network
@@ -16,6 +16,7 @@ sercomm,h500-s-vfes)
 	ucidef_set_interface "qtn" device "wifi" protocol "static" ipaddr "1.1.1.1" netmask "255.255.255.252"
 	uci add_list firewall.@zone[0].network='qtn'
 	;;
+comtrend,vg-8050 |\
 sercomm,shg2500)
 	ucidef_set_bridge_device switch
 	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"

--- a/target/linux/bmips/bcm63268/base-files/lib/upgrade/platform.sh
+++ b/target/linux/bmips/bcm63268/base-files/lib/upgrade/platform.sh
@@ -9,6 +9,7 @@ platform_check_image() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
+	comtrend,vg-8050 |\
 	comtrend,vr-3032u)
 		CI_JFFS2_CLEAN_MARKERS=1
 		nand_do_upgrade "$1"

--- a/target/linux/bmips/dts/bcm63169-comtrend-vg-8050.dts
+++ b/target/linux/bmips/dts/bcm63169-comtrend-vg-8050.dts
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm63268.dtsi"
+
+/ {
+	model = "Comtrend VG-8050";
+	compatible = "comtrend,vg-8050", "brcm,bcm63169", "brcm,bcm63268";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cferom_6a0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&hsspi {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_hsspi_cs5>;
+
+	switch@5 {
+		compatible = "brcm,bcm53125";
+		reg = <5>;
+		spi-max-frequency = <781000>;
+		spi-cpha;
+		spi-cpol;
+		dsa,member = <1 0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan4";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan3";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan1";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "wan";
+			};
+
+			port@8 {
+				reg = <8>;
+
+				phy-mode = "rgmii";
+				ethernet = <&switch0port6>;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};
+
+&leds {
+	status = "okay";
+
+	brcm,serial-leds;
+	brcm,serial-dat-low;
+	brcm,serial-shift-inv;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_serial_led>;
+
+	led@2 {
+		reg = <2>;
+		active-low;
+		label = "red:internet";
+	};
+
+	led_power_red: led@3 {
+		reg = <3>;
+		active-low;
+		label = "red:power";
+		panic-indicator;
+	};
+
+	led_power_green: led@6 {
+		reg = <6>;
+		active-low;
+		label = "green:power";
+	};
+
+	led@7 {
+		reg = <7>;
+		active-low;
+		label = "green:wps";
+	};
+
+	led@8 {
+		reg = <8>;
+		active-low;
+		label = "green:internet";
+	};
+
+	led@10 {
+		reg = <10>;
+		active-low;
+		label = "green:voip";
+	};
+
+	led@12 {
+		reg = <12>;
+		active-low;
+		label = "red:voip";
+	};
+
+	led@14 {
+		reg = <14>;
+		active-low;
+		label = "red:wps";
+	};
+};
+
+&nflash {
+	status = "okay";
+
+	nandcs@0 {
+		compatible = "brcm,nandcs";
+		reg = <0>;
+		nand-ecc-step-size = <512>;
+		nand-ecc-strength = <15>;
+		nand-on-flash-bbt;
+		brcm,nand-oob-sector-size = <64>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cferom: partition@0 {
+				label = "cferom";
+				reg = <0x0000000 0x0020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "brcm,wfi-split";
+				label = "wfi";
+				reg = <0x0020000 0x7ac0000>;
+			};
+		};
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&switch0 {
+	dsa,member = <0 0>;
+
+	ports {
+		switch0port6: port@6 {
+			reg = <6>;
+			label = "extsw";
+
+			phy-mode = "rgmii";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};
+
+&cferom {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_cferom_6a0: macaddr@6a0 {
+		reg = <0x6a0 0x6>;
+	};
+};

--- a/target/linux/bmips/image/bcm63268.mk
+++ b/target/linux/bmips/image/bcm63268.mk
@@ -1,5 +1,24 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+define Device/comtrend_vg-8050
+  $(Device/bcm63xx-nand)
+  DEVICE_VENDOR := Comtrend
+  DEVICE_MODEL := VG-8050
+  CHIP_ID := 63268
+  SOC := bcm63169
+  CFE_RAM_FILE := comtrend,vg-8050/cferam.000
+  CFE_RAM_JFFS2_NAME := cferam.000
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  SUBPAGESIZE := 512
+  VID_HDR_OFFSET := 2048
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    kmod-leds-bcm6328
+  CFE_WFI_FLASH_TYPE := 3
+  CFE_WFI_VERSION := 0x5732
+endef
+TARGET_DEVICES += comtrend_vg-8050
+
 define Device/comtrend_vr-3032u
   $(Device/bcm63xx-nand)
   DEVICE_VENDOR := Comtrend


### PR DESCRIPTION
The Comtrend VG-8050 is a wifi gigabit ethernet router, 2.4 GHz single band with two external antennas.

Hardware:
 - SoC: Broadcom BCM63169
 - CPU: dual core BMIPS4350 @ 400Mhz
 - RAM: 128 MB DDR
 - Flash: 128 MB NAND
 - LAN switch: Broadcom BCM53125, 5x 1Gbit
 - Wifi 2.4 GHz: SoC (BCM63268) 802.11bgn
 - USB: 2x 2.0 (mod)
 - Buttons: 2x (reset)
 - LEDs: yes
 - UART: yes

Installation via CFE web UI:
  1. Power off the router.
  2. Press reset button near the power switch.
  3. Keep it pressed while powering up during ~20+ seconds.
  4. Browse to http://192.168.1.1 and upload the firmware.
  5. Wait a few minutes for it to finish.

CC @danitool 