### PR TITLE
bcm63xx: fix the Home Hub 2a power LED

### DIFF
--- a/target/linux/bcm63xx/dts/bcm6358-bt-home-hub-2-a.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-bt-home-hub-2-a.dts
@@ -60,7 +60,7 @@
 	};
 
 	led_power_green: led@1 {
-		reg = <0>;
+		reg = <1>;
 		active-low;
 		label = "green:power";
 		default-state = "on";


### PR DESCRIPTION
Power LED register is wrong at dts. Fix it.
(fixes 9ceeaf4c6cac6e5ff5a52 brcm63xx: switch to hardware led controllers)

CC: @Noltari 