### PR TITLE
qualcommax: ipq807x: include BDF for Compex WPQ873

### DIFF
--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -46,6 +46,7 @@ define Device/compex_wpq873
        PAGESIZE := 2048
        DEVICE_DTS_CONFIG := config@hk09.wpq873
        SOC := ipq8072
+       DEVICE_PACKAGES := ipq-wifi-compex_wpq873
        IMAGE/factory.ubi := append-ubi | qsdk-ipq-factory-nand
 endef
 TARGET_DEVICES += compex_wpq873


### PR DESCRIPTION
Currently, Compex WPQ873 images are not including the ath11k BDF-s at all and this means that there is no WLAN support, so let's include the BDF as it's already packaged.

Fixes: 07c45c085908 ("ipq807x: add support for Compex WPQ873")
