### PR TITLE
bmips: enable the data Read Ahead Cache for BMIPS4350

### DIFF
--- a/target/linux/bmips/patches-5.15/203-mips-bmips-dma-fix-CBR-address.patch
+++ b/target/linux/bmips/patches-5.15/203-mips-bmips-dma-fix-CBR-address.patch
@@ -1,0 +1,84 @@
+From 3e4c3863e0cfb8c2abdff6bb494ca69d3d2aed9c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
+Date: Sat, 10 Jun 2023 17:01:40 +0200
+Subject: [PATCH] mips: bmips: dma: fix CBR address
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Some BCM63xx SoCs may return CBR address as 0.
+
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+---
+ arch/mips/bmips/dma.c   | 12 ++++--------
+ arch/mips/bmips/setup.c | 11 ++++-------
+ 2 files changed, 8 insertions(+), 15 deletions(-)
+
+--- a/arch/mips/bmips/dma.c
++++ b/arch/mips/bmips/dma.c
+@@ -64,11 +64,10 @@ phys_addr_t dma_to_phys(struct device *d
+ 	return dma_addr;
+ }
+ 
+-bool bmips_rac_flush_disable;
++void __iomem *bmips_cbr_addr;
+ 
+ void arch_sync_dma_for_cpu_all(void)
+ {
+-	void __iomem *cbr = BMIPS_GET_CBR();
+ 	u32 cfg;
+ 
+ 	if (boot_cpu_type() != CPU_BMIPS3300 &&
+@@ -76,13 +75,10 @@ void arch_sync_dma_for_cpu_all(void)
+ 	    boot_cpu_type() != CPU_BMIPS4380)
+ 		return;
+ 
+-	if (unlikely(bmips_rac_flush_disable))
+-		return;
+-
+ 	/* Flush stale data out of the readahead cache */
+-	cfg = __raw_readl(cbr + BMIPS_RAC_CONFIG);
+-	__raw_writel(cfg | 0x100, cbr + BMIPS_RAC_CONFIG);
+-	__raw_readl(cbr + BMIPS_RAC_CONFIG);
++	cfg = __raw_readl(bmips_cbr_addr + BMIPS_RAC_CONFIG);
++	__raw_writel(cfg | 0x100, bmips_cbr_addr + BMIPS_RAC_CONFIG);
++	__raw_readl(bmips_cbr_addr + BMIPS_RAC_CONFIG);
+ }
+ 
+ static int __init bmips_init_dma_ranges(void)
+--- a/arch/mips/bmips/setup.c
++++ b/arch/mips/bmips/setup.c
+@@ -89,7 +89,7 @@
+ 
+ #define DDR_CSEND_REG		0x8
+ 
+-extern bool bmips_rac_flush_disable;
++extern void __iomem *bmips_cbr_addr;
+ 
+ static const unsigned long kbase = VMLINUX_LOAD_ADDRESS & 0xfff00000;
+ 
+@@ -170,12 +170,6 @@ static void bcm6358_quirks(void)
+ 	 * disable SMP for now
+ 	 */
+ 	bmips_smp_enabled = 0;
+-
+-	/*
+-	 * RAC flush causes kernel panics on BCM6358 when booting from TP1
+-	 * because the bootloader is not initializing it properly.
+-	 */
+-	bmips_rac_flush_disable = !!(read_c0_brcm_cmt_local() & (1 << 31));
+ }
+ 
+ static void bcm6368_quirks(void)
+@@ -198,6 +192,11 @@ static const struct bmips_quirk bmips_qu
+ 
+ void __init prom_init(void)
+ {
++	if (!(read_c0_brcm_cbr() >> 18))
++		bmips_cbr_addr = (void __iomem *)0xff400000;
++	else
++		bmips_cbr_addr = BMIPS_GET_CBR();
++
+ 	bmips_cpu_setup();
+ 	register_bmips_smp_ops();
+ }

--- a/target/linux/bmips/patches-5.15/204-mips-bmips-enable-RAC-on-BMIPS4350.patch
+++ b/target/linux/bmips/patches-5.15/204-mips-bmips-enable-RAC-on-BMIPS4350.patch
@@ -1,0 +1,42 @@
+From 7f862eaedac56b67972393f0a9affcd2fe53479b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20Gonz=C3=A1lez=20Cabanelas?= <dgcbueu@gmail.com>
+Date: Sun, 18 Jun 2023 19:59:25 +0200
+Subject: [PATCH] mips: bmips: enable RAC on BMIPS4350
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The data RAC is left disabled by the bootloader in some SoCs, at least in
+the core it boots from.
+Enabling this feature increases the performance up to +30% depending on the
+task.
+
+Signed-off-by: Daniel González Cabanelas <dgcbueu@gmail.com>
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+---
+ arch/mips/kernel/smp-bmips.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+--- a/arch/mips/kernel/smp-bmips.c
++++ b/arch/mips/kernel/smp-bmips.c
+@@ -614,6 +614,20 @@ void bmips_cpu_setup(void)
+ 		__raw_readl(cbr + BMIPS_RAC_ADDRESS_RANGE);
+ 		break;
+ 
++	case CPU_BMIPS4350:
++		/* Enable data RAC */
++		if (!(read_c0_brcm_cmt_local() & (1 << 31))) {
++			cfg = __raw_readl(cbr + BMIPS_RAC_CONFIG);
++			__raw_writel(cfg | 0xa, cbr + BMIPS_RAC_CONFIG);
++			__raw_readl(cbr + BMIPS_RAC_CONFIG);
++		} else {
++			cbr = (void __iomem *)0xff400000;
++			cfg = __raw_readl(cbr + BMIPS_RAC_CONFIG_1);
++			__raw_writel(cfg | 0xa, cbr + BMIPS_RAC_CONFIG_1);
++			__raw_readl(cbr + BMIPS_RAC_CONFIG_1);
++		}
++		break;
++
+ 	case CPU_BMIPS4380:
+ 		/* CBG workaround for early BMIPS4380 CPUs */
+ 		switch (read_c0_prid()) {

--- a/target/linux/bmips/patches-6.1/203-mips-bmips-dma-fix-CBR-address.patch
+++ b/target/linux/bmips/patches-6.1/203-mips-bmips-dma-fix-CBR-address.patch
@@ -1,0 +1,82 @@
+From 3e4c3863e0cfb8c2abdff6bb494ca69d3d2aed9c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
+Date: Sat, 10 Jun 2023 17:01:40 +0200
+Subject: [PATCH] mips: bmips: dma: fix CBR address
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Some BCM63xx SoCs may return CBR address as 0.
+
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+---
+ arch/mips/bmips/dma.c   | 12 ++++--------
+ arch/mips/bmips/setup.c | 11 ++++-------
+ 2 files changed, 8 insertions(+), 15 deletions(-)
+
+--- a/arch/mips/bmips/dma.c
++++ b/arch/mips/bmips/dma.c
+@@ -5,11 +5,10 @@
+ #include <asm/bmips.h>
+ #include <asm/io.h>
+ 
+-bool bmips_rac_flush_disable;
++void __iomem *bmips_cbr_addr;
+ 
+ void arch_sync_dma_for_cpu_all(void)
+ {
+-	void __iomem *cbr = BMIPS_GET_CBR();
+ 	u32 cfg;
+ 
+ 	if (boot_cpu_type() != CPU_BMIPS3300 &&
+@@ -17,11 +16,8 @@ void arch_sync_dma_for_cpu_all(void)
+ 	    boot_cpu_type() != CPU_BMIPS4380)
+ 		return;
+ 
+-	if (unlikely(bmips_rac_flush_disable))
+-		return;
+-
+ 	/* Flush stale data out of the readahead cache */
+-	cfg = __raw_readl(cbr + BMIPS_RAC_CONFIG);
+-	__raw_writel(cfg | 0x100, cbr + BMIPS_RAC_CONFIG);
+-	__raw_readl(cbr + BMIPS_RAC_CONFIG);
++	cfg = __raw_readl(bmips_cbr_addr + BMIPS_RAC_CONFIG);
++	__raw_writel(cfg | 0x100, bmips_cbr_addr + BMIPS_RAC_CONFIG);
++	__raw_readl(bmips_cbr_addr + BMIPS_RAC_CONFIG);
+ }
+--- a/arch/mips/bmips/setup.c
++++ b/arch/mips/bmips/setup.c
+@@ -90,7 +90,7 @@
+ 
+ #define DDR_CSEND_REG		0x8
+ 
+-extern bool bmips_rac_flush_disable;
++extern void __iomem *bmips_cbr_addr;
+ 
+ static const unsigned long kbase = VMLINUX_LOAD_ADDRESS & 0xfff00000;
+ 
+@@ -171,12 +171,6 @@ static void bcm6358_quirks(void)
+ 	 * disable SMP for now
+ 	 */
+ 	bmips_smp_enabled = 0;
+-
+-	/*
+-	 * RAC flush causes kernel panics on BCM6358 when booting from TP1
+-	 * because the bootloader is not initializing it properly.
+-	 */
+-	bmips_rac_flush_disable = !!(read_c0_brcm_cmt_local() & (1 << 31));
+ }
+ 
+ static void bcm6368_quirks(void)
+@@ -209,6 +203,11 @@ static void __init bmips_init_cfe(void)
+ 
+ void __init prom_init(void)
+ {
++	if (!(read_c0_brcm_cbr() >> 18))
++		bmips_cbr_addr = (void __iomem *) 0xff400000;
++	else
++		bmips_cbr_addr = BMIPS_GET_CBR();
++
+ 	bmips_init_cfe();
+ 	bmips_cpu_setup();
+ 	register_bmips_smp_ops();

--- a/target/linux/bmips/patches-6.1/204-mips-bmips-enable-RAC-on-BMIPS4350.patch
+++ b/target/linux/bmips/patches-6.1/204-mips-bmips-enable-RAC-on-BMIPS4350.patch
@@ -1,0 +1,42 @@
+From 7f862eaedac56b67972393f0a9affcd2fe53479b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20Gonz=C3=A1lez=20Cabanelas?= <dgcbueu@gmail.com>
+Date: Sun, 18 Jun 2023 19:59:25 +0200
+Subject: [PATCH] mips: bmips: enable RAC on BMIPS4350
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The data RAC is left disabled by the bootloader in some SoCs, at least in
+the core it boots from.
+Enabling this feature increases the performance up to +30% depending on the
+task.
+
+Signed-off-by: Daniel González Cabanelas <dgcbueu@gmail.com>
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+---
+ arch/mips/kernel/smp-bmips.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+--- a/arch/mips/kernel/smp-bmips.c
++++ b/arch/mips/kernel/smp-bmips.c
+@@ -615,6 +615,20 @@ void bmips_cpu_setup(void)
+ 		__raw_readl(cbr + BMIPS_RAC_ADDRESS_RANGE);
+ 		break;
+ 
++	case CPU_BMIPS4350:
++		/* Enable data RAC */
++		if (!(read_c0_brcm_cmt_local() & (1 << 31))) {
++			cfg = __raw_readl(cbr + BMIPS_RAC_CONFIG);
++			__raw_writel(cfg | 0xa, cbr + BMIPS_RAC_CONFIG);
++			__raw_readl(cbr + BMIPS_RAC_CONFIG);
++		} else {
++			cbr = (void __iomem *)0xff400000;
++			cfg = __raw_readl(cbr + BMIPS_RAC_CONFIG_1);
++			__raw_writel(cfg | 0xa, cbr + BMIPS_RAC_CONFIG_1);
++			__raw_readl(cbr + BMIPS_RAC_CONFIG_1);
++		}
++		break;
++
+ 	case CPU_BMIPS4380:
+ 		/* CBG workaround for early BMIPS4380 CPUs */
+ 		switch (read_c0_prid()) {


### PR DESCRIPTION
The data RAC is left disabled by the bootloader in some SoCs, at least in the core it boots from. Enabling this feature increases the performance up to +30% depending on the task.

The kernel enables the whole RAC unconditionally on BMIPS3300 CPUs. Enable the data RAC in a similar way also for BMIPS4350.

Tested on DGND3700 v1 (BCM6368) and HG556a (BCM6358).

CC: @Noltari 