### PR TITLE
mwlwifi: fix 6.1 Kernel support

### DIFF
--- a/package/kernel/mwlwifi/Makefile
+++ b/package/kernel/mwlwifi/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwlwifi
-PKG_RELEASE=1
+PKG_RELEASE=2
 
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=

--- a/package/kernel/mwlwifi/patches/006-remove-uaccess-and-get_fs-calls-from-PCIe-for-Kenel-.patch
+++ b/package/kernel/mwlwifi/patches/006-remove-uaccess-and-get_fs-calls-from-PCIe-for-Kenel-.patch
@@ -1,0 +1,53 @@
+From ad911365cac3723d1c00d048905a5e22ff4a10f3 Mon Sep 17 00:00:00 2001
+From: Stefan Kalscheuer <stefan@stklcode.de>
+Date: Sun, 18 Jun 2023 17:53:27 +0200
+Subject: [PATCH 1/2] remove uaccess and get_fs calls from PCIe for Kenel >=
+ 5.18
+
+Remove the calls to deprecated get_fs and force_uaccess_* API for modern
+kernels.
+
+The get_fs functionality and the transitional force_uaccess_* calls have
+been removed Kernel 5.18 [1] while read and write operations have been
+refactored, so the code can work on kernel- and userspace data without
+the need to shifting the boundary using set_fs().
+
+[1] https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=967747bbc084b93b54e66f9047d342232314cd25
+
+Signed-off-by: Stefan Kalscheuer <stefan@stklcode.de>
+---
+ hif/pcie/pcie.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/hif/pcie/pcie.c b/hif/pcie/pcie.c
+index 24453b6..bee1cc5 100644
+--- a/hif/pcie/pcie.c
++++ b/hif/pcie/pcie.c
+@@ -1294,7 +1294,9 @@ static void pcie_bf_mimo_ctrl_decode(struct mwl_priv *priv,
+ 	const char filename[] = "/tmp/BF_MIMO_Ctrl_Field_Output.txt";
+ 	char str_buf[256];
+ 	char *buf = &str_buf[0];
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
+ 	mm_segment_t oldfs;
++#endif
+ 
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
+ 	oldfs = get_fs();
+@@ -1302,7 +1304,7 @@ static void pcie_bf_mimo_ctrl_decode(struct mwl_priv *priv,
+ #elif LINUX_VERSION_CODE < KERNEL_VERSION(5,10,0)
+ 	oldfs = get_fs();
+ 	set_fs(KERNEL_DS);
+-#else
++#elif LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
+ 	oldfs = force_uaccess_begin();
+ #endif
+ 
+@@ -1326,7 +1328,7 @@ static void pcie_bf_mimo_ctrl_decode(struct mwl_priv *priv,
+ 
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(5,10,0)
+ 	set_fs(oldfs);
+-#else
++#elif LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
+ 	force_uaccess_end(oldfs);
+ #endif
+ }

--- a/package/kernel/mwlwifi/patches/007-replace-usage-of-the-deprecated-pci-dma-compat.h-API.patch
+++ b/package/kernel/mwlwifi/patches/007-replace-usage-of-the-deprecated-pci-dma-compat.h-API.patch
@@ -1,0 +1,275 @@
+From 61c75dce424c180b633c64613a1948df5a41cf1e Mon Sep 17 00:00:00 2001
+From: Stefan Kalscheuer <stefan@stklcode.de>
+Date: Sun, 18 Jun 2023 17:59:07 +0200
+Subject: [PATCH 2/2] replace usage of the deprecated "pci-dma-compat.h" API
+
+The pci-dma-compat API has been legacy for quite a while and was removed
+with 5.18 [1]. Migrate all calls, so the module can be compiled against
+modern kernel versions.
+
+Replace some compat calls:
+* pci_set_dma_mask with dma_set_mask
+* pci_(un)map_single with dma_(un)map_single
+* pci_dma_mapping_error with dma_mapping_error
+* PCI_DMA_{FROM,TO}DEVICE with DMA_{FOM,TO}_DEVICE
+
+[1] https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=7968778914e53788a01c2dee2692cab157de9ac0
+
+Signed-off-by: Stefan Kalscheuer <stefan@stklcode.de>
+---
+ hif/pcie/pcie.c   |  2 +-
+ hif/pcie/rx.c     | 20 ++++++++++----------
+ hif/pcie/rx_ndp.c | 20 ++++++++++----------
+ hif/pcie/tx.c     | 22 +++++++++++-----------
+ hif/pcie/tx_ndp.c | 14 +++++++-------
+ 5 files changed, 39 insertions(+), 39 deletions(-)
+
+diff --git a/hif/pcie/pcie.c b/hif/pcie/pcie.c
+index bee1cc5..d85c29e 100644
+--- a/hif/pcie/pcie.c
++++ b/hif/pcie/pcie.c
+@@ -1556,7 +1556,7 @@ static int pcie_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+ 		return rc;
+ 	}
+ 
+-	rc = pci_set_dma_mask(pdev, DMA_BIT_MASK(32));
++	rc = dma_set_mask(&pdev->dev, DMA_BIT_MASK(32));
+ 	if (rc) {
+ 		pr_err("%s: 32-bit PCI DMA not supported\n",
+ 		       PCIE_DRV_NAME);
+diff --git a/hif/pcie/rx.c b/hif/pcie/rx.c
+index 91eb984..2857c0f 100644
+--- a/hif/pcie/rx.c
++++ b/hif/pcie/rx.c
+@@ -107,11 +107,11 @@ static int pcie_rx_ring_init(struct mwl_priv *priv)
+ 			desc->prx_ring[i].rssi = 0x00;
+ 			desc->prx_ring[i].pkt_len =
+ 				cpu_to_le16(SYSADPT_MAX_AGGR_SIZE);
+-			dma = pci_map_single(pcie_priv->pdev,
++			dma = dma_map_single(&(pcie_priv->pdev)->dev,
+ 					     rx_hndl->psk_buff->data,
+ 					     desc->rx_buf_size,
+-					     PCI_DMA_FROMDEVICE);
+-			if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
++					     DMA_FROM_DEVICE);
++			if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
+ 				wiphy_err(priv->hw->wiphy,
+ 					  "failed to map pci memory!\n");
+ 				return -ENOMEM;
+@@ -153,11 +153,11 @@ static void pcie_rx_ring_cleanup(struct mwl_priv *priv)
+ 			if (!rx_hndl->psk_buff)
+ 				continue;
+ 
+-			pci_unmap_single(pcie_priv->pdev,
++			dma_unmap_single(&(pcie_priv->pdev)->dev,
+ 					 le32_to_cpu
+ 					 (rx_hndl->pdesc->pphys_buff_data),
+ 					 desc->rx_buf_size,
+-					 PCI_DMA_FROMDEVICE);
++					 DMA_FROM_DEVICE);
+ 
+ 			dev_kfree_skb_any(rx_hndl->psk_buff);
+ 
+@@ -335,11 +335,11 @@ static inline int pcie_rx_refill(struct mwl_priv *priv,
+ 	rx_hndl->pdesc->rssi = 0x00;
+ 	rx_hndl->pdesc->pkt_len = cpu_to_le16(desc->rx_buf_size);
+ 
+-	dma = pci_map_single(pcie_priv->pdev,
++	dma = dma_map_single(&(pcie_priv->pdev)->dev,
+ 			     rx_hndl->psk_buff->data,
+ 			     desc->rx_buf_size,
+-			     PCI_DMA_FROMDEVICE);
+-	if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
++			     DMA_FROM_DEVICE);
++	if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
+ 		dev_kfree_skb_any(rx_hndl->psk_buff);
+ 		wiphy_err(priv->hw->wiphy,
+ 			  "failed to map pci memory!\n");
+@@ -413,10 +413,10 @@ void pcie_rx_recv(unsigned long data)
+ 		prx_skb = curr_hndl->psk_buff;
+ 		if (!prx_skb)
+ 			goto out;
+-		pci_unmap_single(pcie_priv->pdev,
++		dma_unmap_single(&(pcie_priv->pdev)->dev,
+ 				 le32_to_cpu(curr_hndl->pdesc->pphys_buff_data),
+ 				 desc->rx_buf_size,
+-				 PCI_DMA_FROMDEVICE);
++				 DMA_FROM_DEVICE);
+ 		pkt_len = le16_to_cpu(curr_hndl->pdesc->pkt_len);
+ 
+ 		if (skb_tailroom(prx_skb) < pkt_len) {
+diff --git a/hif/pcie/rx_ndp.c b/hif/pcie/rx_ndp.c
+index 228075d..106d559 100644
+--- a/hif/pcie/rx_ndp.c
++++ b/hif/pcie/rx_ndp.c
+@@ -86,11 +86,11 @@ static int pcie_rx_ring_init_ndp(struct mwl_priv *priv)
+ 			}
+ 			skb_reserve(psk_buff, MIN_BYTES_RX_HEADROOM);
+ 
+-			dma = pci_map_single(pcie_priv->pdev,
++			dma = dma_map_single(&(pcie_priv->pdev)->dev,
+ 					     psk_buff->data,
+ 					     desc->rx_buf_size,
+-					     PCI_DMA_FROMDEVICE);
+-			if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
++					     DMA_FROM_DEVICE);
++			if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
+ 				wiphy_err(priv->hw->wiphy,
+ 					  "failed to map pci memory!\n");
+ 				return -ENOMEM;
+@@ -120,11 +120,11 @@ static void pcie_rx_ring_cleanup_ndp(struct mwl_priv *priv)
+ 	if (desc->prx_ring) {
+ 		for (i = 0; i < MAX_NUM_RX_DESC; i++) {
+ 			if (desc->rx_vbuflist[i]) {
+-				pci_unmap_single(pcie_priv->pdev,
++				dma_unmap_single(&(pcie_priv->pdev)->dev,
+ 						 le32_to_cpu(
+ 						 desc->prx_ring[i].data),
+ 						 desc->rx_buf_size,
+-						 PCI_DMA_FROMDEVICE);
++						 DMA_FROM_DEVICE);
+ 				desc->rx_vbuflist[i] = NULL;
+ 			}
+ 		}
+@@ -400,11 +400,11 @@ static inline int pcie_rx_refill_ndp(struct mwl_priv *priv, u32 buf_idx)
+ 		return -ENOMEM;
+ 	skb_reserve(psk_buff, MIN_BYTES_RX_HEADROOM);
+ 
+-	dma = pci_map_single(pcie_priv->pdev,
++	dma = dma_map_single(&(pcie_priv->pdev)->dev,
+ 			     psk_buff->data,
+ 			     desc->rx_buf_size,
+-			     PCI_DMA_FROMDEVICE);
+-	if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
++			     DMA_FROM_DEVICE);
++	if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
+ 		wiphy_err(priv->hw->wiphy,
+ 			  "refill: failed to map pci memory!\n");
+ 		return -ENOMEM;
+@@ -509,10 +509,10 @@ recheck:
+ 			break;
+ 		}
+ 
+-		pci_unmap_single(pcie_priv->pdev,
++		dma_unmap_single(&(pcie_priv->pdev)->dev,
+ 				 le32_to_cpu(prx_desc->data),
+ 				 desc->rx_buf_size,
+-				 PCI_DMA_FROMDEVICE);
++				 DMA_FROM_DEVICE);
+ 
+ 		bad_mic = false;
+ 		ctrl = le32_to_cpu(prx_ring_done->ctrl);
+diff --git a/hif/pcie/tx.c b/hif/pcie/tx.c
+index 62a34a8..8f3c828 100644
+--- a/hif/pcie/tx.c
++++ b/hif/pcie/tx.c
+@@ -243,11 +243,11 @@ static void pcie_tx_ring_cleanup(struct mwl_priv *priv)
+ 					    desc->tx_hndl[i].psk_buff->data,
+ 					    le32_to_cpu(
+ 					    desc->ptx_ring[i].pkt_ptr));
+-				pci_unmap_single(pcie_priv->pdev,
++				dma_unmap_single(&(pcie_priv->pdev)->dev,
+ 						 le32_to_cpu(
+ 						 desc->ptx_ring[i].pkt_ptr),
+ 						 desc->tx_hndl[i].psk_buff->len,
+-						 PCI_DMA_TODEVICE);
++						 DMA_TO_DEVICE);
+ 				dev_kfree_skb_any(desc->tx_hndl[i].psk_buff);
+ 				desc->ptx_ring[i].status =
+ 					cpu_to_le32(EAGLE_TXD_STATUS_IDLE);
+@@ -305,10 +305,10 @@ static void pcie_txbd_ring_delete(struct mwl_priv *priv)
+ 			skb = pcie_priv->tx_buf_list[num];
+ 			tx_desc = (struct pcie_tx_desc *)skb->data;
+ 
+-			pci_unmap_single(pcie_priv->pdev,
++			dma_unmap_single(&(pcie_priv->pdev)->dev,
+ 					 le32_to_cpu(tx_desc->pkt_ptr),
+ 					 skb->len,
+-					 PCI_DMA_TODEVICE);
++					 DMA_TO_DEVICE);
+ 			dev_kfree_skb_any(skb);
+ 		}
+ 		pcie_priv->tx_buf_list[num] = NULL;
+@@ -453,9 +453,9 @@ static inline void pcie_tx_skb(struct mwl_priv *priv, int desc_num,
+ 	tx_desc->type = tx_ctrl->type;
+ 	tx_desc->xmit_control = tx_ctrl->xmit_control;
+ 	tx_desc->sap_pkt_info = 0;
+-	dma = pci_map_single(pcie_priv->pdev, tx_skb->data,
+-			     tx_skb->len, PCI_DMA_TODEVICE);
+-	if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
++	dma = dma_map_single(&(pcie_priv->pdev)->dev, tx_skb->data,
++			     tx_skb->len, DMA_TO_DEVICE);
++	if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
+ 		dev_kfree_skb_any(tx_skb);
+ 		wiphy_err(priv->hw->wiphy,
+ 			  "failed to map pci memory!\n");
+@@ -676,10 +676,10 @@ static void pcie_pfu_tx_done(struct mwl_priv *priv)
+ 			pfu_dma = (struct pcie_pfu_dma_data *)done_skb->data;
+ 			tx_desc = &pfu_dma->tx_desc;
+ 			dma_data = &pfu_dma->dma_data;
+-			pci_unmap_single(pcie_priv->pdev,
++			dma_unmap_single(&(pcie_priv->pdev)->dev,
+ 					 le32_to_cpu(data_buf->paddr),
+ 					 le16_to_cpu(data_buf->len),
+-					 PCI_DMA_TODEVICE);
++					 DMA_TO_DEVICE);
+ 			tx_desc->pkt_ptr = 0;
+ 			tx_desc->pkt_len = 0;
+ 			tx_desc->status = cpu_to_le32(EAGLE_TXD_STATUS_IDLE);
+@@ -768,10 +768,10 @@ static void pcie_non_pfu_tx_done(struct mwl_priv *priv)
+ 		       (tx_desc->status & cpu_to_le32(EAGLE_TXD_STATUS_OK)) &&
+ 		       (!(tx_desc->status &
+ 		       cpu_to_le32(EAGLE_TXD_STATUS_FW_OWNED)))) {
+-			pci_unmap_single(pcie_priv->pdev,
++			dma_unmap_single(&(pcie_priv->pdev)->dev,
+ 					 le32_to_cpu(tx_desc->pkt_ptr),
+ 					 le16_to_cpu(tx_desc->pkt_len),
+-					 PCI_DMA_TODEVICE);
++					 DMA_TO_DEVICE);
+ 			done_skb = tx_hndl->psk_buff;
+ 			rate = le32_to_cpu(tx_desc->rate_info);
+ 			tx_desc->pkt_ptr = 0;
+diff --git a/hif/pcie/tx_ndp.c b/hif/pcie/tx_ndp.c
+index 6758cde..f4256c2 100644
+--- a/hif/pcie/tx_ndp.c
++++ b/hif/pcie/tx_ndp.c
+@@ -131,10 +131,10 @@ static void pcie_tx_ring_cleanup_ndp(struct mwl_priv *priv)
+ 	for (i = 0; i < MAX_TX_RING_SEND_SIZE; i++) {
+ 		tx_skb = desc->tx_vbuflist[i];
+ 		if (tx_skb) {
+-			pci_unmap_single(pcie_priv->pdev,
++			dma_unmap_single(&(pcie_priv->pdev)->dev,
+ 					 desc->pphys_tx_buflist[i],
+ 					 tx_skb->len,
+-					 PCI_DMA_TODEVICE);
++					 DMA_TO_DEVICE);
+ 			dev_kfree_skb_any(tx_skb);
+ 			desc->pphys_tx_buflist[i] = 0;
+ 			desc->tx_vbuflist[i] = NULL;
+@@ -266,9 +266,9 @@ static inline int pcie_tx_skb_ndp(struct mwl_priv *priv,
+ 			(TXRING_CTRL_TAG_MGMT << TXRING_CTRL_TAG_SHIFT));
+ 	}
+ 
+-	dma = pci_map_single(pcie_priv->pdev, tx_skb->data,
+-			     tx_skb->len, PCI_DMA_TODEVICE);
+-	if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
++	dma = dma_map_single(&(pcie_priv->pdev)->dev, tx_skb->data,
++			     tx_skb->len, DMA_TO_DEVICE);
++	if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
+ 		dev_kfree_skb_any(tx_skb);
+ 		wiphy_err(priv->hw->wiphy,
+ 			  "failed to map pci memory!\n");
+@@ -450,10 +450,10 @@ void pcie_tx_done_ndp(struct ieee80211_hw *hw)
+ 				  "buffer is NULL for tx done ring\n");
+ 			break;
+ 		}
+-		pci_unmap_single(pcie_priv->pdev,
++		dma_unmap_single(&(pcie_priv->pdev)->dev,
+ 				 desc->pphys_tx_buflist[index],
+ 				 skb->len,
+-				 PCI_DMA_TODEVICE);
++				 DMA_TO_DEVICE);
+ 		desc->pphys_tx_buflist[index] = 0;
+ 		desc->tx_vbuflist[index] = NULL;
+ 
+


### PR DESCRIPTION
Remove `force_uaccess_*` API usage and replace calls from _pci-dma-compat.h_ for Kernel >= 5.18, so that the module compiles against Kernel 6.1

Build and run tested on a Linksys WRT1900ACS with two 88W8864 chips.

The patches are not really pretty, maybe I can figure out a more elegant solution, but there are already some switches by kernel version, so I just added another one.