### PR TITLE
bmips: add support for NuCom R5010UNv2

### DIFF
--- a/target/linux/bmips/bcm6328/base-files/etc/board.d/01_leds
+++ b/target/linux/bmips/bcm6328/base-files/etc/board.d/01_leds
@@ -6,6 +6,7 @@
 board_config_update
 
 case "$(board_name)" in
+nucom,r5010unv2 |\
 sercomm,ad1018)
 	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1" "usb2-port1"
 	;;

--- a/target/linux/bmips/bcm6328/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6328/base-files/etc/board.d/02_network
@@ -6,7 +6,8 @@ board_config_update
 
 case "$(board_name)" in
 comtrend,ar-5381u |\
-comtrend,ar-5387un)
+comtrend,ar-5387un |\
+nucom,r5010unv2)
 	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 	;;

--- a/target/linux/bmips/bcm6328/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/bmips/bcm6328/base-files/etc/uci-defaults/09_fix_crc
@@ -4,7 +4,8 @@
 
 case "$(board_name)" in
 comtrend,ar-5381u |\
-comtrend,ar-5387un)
+comtrend,ar-5387un |\
+nucom,r5010unv2)
 	mtd fixtrx firmware
 	;;
 esac

--- a/target/linux/bmips/dts/bcm6328-nucom-r5010unv2.dts
+++ b/target/linux/bmips/dts/bcm6328-nucom-r5010unv2.dts
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6328.dtsi"
+
+/ {
+	model = "NuCom R5010UNv2";
+	compatible = "nucom,r5010unv2", "brcm,bcm6328";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	bcm43217-sprom {
+		compatible = "brcm,bcma-sprom";
+
+		pci-bus = <1>;
+		pci-dev = <0>;
+
+		nvmem-cells = <&macaddr_cfe_6a0>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <1>;
+
+		brcm,sprom = "brcm/bcm43217-sprom.bin";
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cfe_6a0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&hsspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <16666667>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cfe: partition@0 {
+				label = "cfe";
+				reg = <0x000000 0x010000>;
+				read-only;
+			};
+
+			partition@10000 {
+				compatible = "brcm,bcm963xx-imagetag";
+				label = "firmware";
+				reg = <0x010000 0xfe0000>;
+			};
+
+			partition@ff0000 {
+				label = "nvram";
+				reg = <0xff0000 0x010000>;
+			};
+		};
+	};
+};
+
+&leds {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_ephy0_act_led &pinctrl_ephy1_act_led
+		     &pinctrl_ephy2_act_led &pinctrl_ephy3_act_led
+		     &pinctrl_leds>;
+
+	led@1 {
+		reg = <1>;
+		active-low;
+		label = "green:internet";
+	};
+
+	led@2 {
+		reg = <2>;
+		active-low;
+		label = "red:internet";
+	};
+
+	led@3 {
+		reg = <3>;
+		active-low;
+		label = "green:dsl";
+	};
+
+	led_power_green: led@4 {
+		reg = <4>;
+		active-low;
+		label = "green:power";
+	};
+
+	led_power_red: led@5 {
+		reg = <5>;
+		active-low;
+		label = "red:power";
+		panic-indicator;
+	};
+
+	led@10 {
+		reg = <10>;
+		active-low;
+		label = "green:wps";
+	};
+
+	led@11 {
+		reg = <11>;
+		active-low;
+		label = "green:usb";
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pinctrl {
+	pinctrl_leds: leds {
+		function = "led";
+		pins = "gpio1", "gpio2", "gpio3",
+		       "gpio4", "gpio5", "gpio10",
+		       "gpio11";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+
+			phy-handle = <&phy1>;
+			phy-mode = "mii";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+
+			phy-handle = <&phy2>;
+			phy-mode = "mii";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+
+			phy-handle = <&phy3>;
+			phy-mode = "mii";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan4";
+
+			phy-handle = <&phy4>;
+			phy-mode = "mii";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};
+
+&cfe {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_cfe_6a0: macaddr@6a0 {
+		reg = <0x6a0 0x6>;
+	};
+};

--- a/target/linux/bmips/image/bcm6328.mk
+++ b/target/linux/bmips/image/bcm6328.mk
@@ -26,6 +26,19 @@ define Device/comtrend_ar-5387un
 endef
 TARGET_DEVICES += comtrend_ar-5387un
 
+define Device/nucom_r5010unv2
+  $(Device/bcm63xx-cfe)
+  DEVICE_VENDOR := NuCom
+  DEVICE_MODEL := R5010UNv2
+  CHIP_ID := 6328
+  CFE_BOARD_ID := 96328ang
+  FLASH_MB := 16
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    $(B43_PACKAGES) broadcom-43217-sprom \
+    kmod-leds-bcm6328
+endef
+TARGET_DEVICES += nucom_r5010unv2
+
 define Device/sercomm_ad1018
   $(Device/sercomm-nand)
   DEVICE_VENDOR := Sercomm


### PR DESCRIPTION
The NuCom R5010UNv2 is a wifi fast ethernet router, 2.4 GHz single band with two external antennas.

Hardware:
 - SoC: Broadcom BCM6328
 - CPU: single core BMIPS4350 V7.5 @ 320Mhz
 - RAM: 64 MB DDR2
 - Flash: 16 MB SPI NOR
 - Ethernet LAN: 4x 100Mbit
 - Wifi 2.4 GHz: Broadcom BCM43217 802.11bgn (onboard)
 - USB: 1x 2.0
 - Buttons: 2x
 - ADSL: yes, unsupported
 - LEDs: 7x
 - UART: yes

Installation via CFE web UI:
  1. Power off the router and press the RESET button
  2. Power on the router and wait 12 or more seconds
  3. Release the RESET button
  4. Browse to http://192.168.1.1 and upload the Openwrt cfe firmware
  5. Wait a few minutes for it to finish

CC: @Noltari 