### PR TITLE
linux-firmware: Add support for Intel Wireless AX211

### DIFF
--- a/package/firmware/linux-firmware/intel.mk
+++ b/package/firmware/linux-firmware/intel.mk
@@ -183,6 +183,14 @@ define Package/iwlwifi-firmware-ax210/install
 endef
 $(eval $(call BuildPackage,iwlwifi-firmware-ax210))
 
+Package/iwlwifi-firmware-ax211 = $(call Package/firmware-default,Intel AX211 firmware)
+define Package/iwlwifi-firmware-ax211/install
+	$(INSTALL_DIR) $(1)/lib/firmware
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-so-a0-gf-a0-72.ucode $(1)/lib/firmware
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-so-a0-gf-a0.pnvm $(1)/lib/firmware
+endef
+$(eval $(call BuildPackage,iwlwifi-firmware-ax211))
+
 Package/e100-firmware = $(call Package/firmware-default,Intel e100)
 define Package/e100-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/e100


### PR DESCRIPTION
**Description** :
 Add Intel AX211 firmware option  as  a choice in menuconfig .it's  significant to  passthrough technique in x86 hyper-v or hypervisor to implement a soft router. In previous OpenWRT version it was not supported but currently AX211 is a popular
choice for customers

**Build & Testing**:
```
型号 Microsoft Corporation Virtual Machine
架构 13th Gen Intel(R) Core(TM) i7-13700K
目标平台 x86/64
固件版本 OpenWrt SNAPSHOT r23400-3556455f04 / LuCI Master git-23.166.63902-4d631c3
内核版本 5.15.117
本地时间 2023-06-20 07:18:09
运行时间 2d 10h 58m 59s
```