### PR TITLE
ipq40xx: meraki-mr33, meraki-mr74: disable image generation

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -764,6 +764,7 @@ define Device/meraki_mr33
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	DEVICE_PACKAGES := -swconfig ath10k-firmware-qca9887-ct
+	DEFAULT := n
 endef
 TARGET_DEVICES += meraki_mr33
 
@@ -776,6 +777,7 @@ define Device/meraki_mr74
 	PAGESIZE := 2048
 	DEVICE_PACKAGES := -swconfig ath10k-firmware-qca9887-ct
 	DEVICE_DTS_CONFIG := config@3
+	DEFAULT := n
 endef
 TARGET_DEVICES += meraki_mr74
 


### PR DESCRIPTION
After migrating to kernel 5.15, upgrading causes the units to become soft-bricked, hanging forever at the kernel startup. Kernel size limitation of 4000000 bytes is suspected here, but this is not fully confirmed.

Disable the images to protect users from inadvertent bricking of units, because recovery of those is painful with Cisco's U-boot, until the root cause is found and fixed.