### PR TITLE
[23.05] ramips: mt7621: add support for Zbtlink ZBT-WG1608 (32M)

### DIFF
--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1608-32m.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1608-32m.dts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_zbtlink_zbt-wg1608.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-wg1608-32m", "mediatek,mt7621-soc";
+	model = "Zbtlink ZBT-WG1608 (32M)";
+};
+
+&flash0 {
+	broken-flash-reset;
+};
+
+&firmware {
+	reg = <0x50000 0x1fb0000>;
+};

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1608.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1608.dtsi
@@ -61,7 +61,7 @@
 &spi0 {
 	status = "okay";
 
-	flash@0 {
+	flash0: flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <50000000>;

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2706,6 +2706,18 @@ define Device/zbtlink_zbt-wg1608-16m
 endef
 TARGET_DEVICES += zbtlink_zbt-wg1608-16m
 
+define Device/zbtlink_zbt-wg1608-32m
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 32448k
+  DEVICE_VENDOR := Zbtlink
+  DEVICE_MODEL := ZBT-WG1608
+  DEVICE_VARIANT := 32M
+  DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt7603 kmod-mt7615e \
+	kmod-mt7663-firmware-ap kmod-usb3 kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += zbtlink_zbt-wg1608-32m
+
 define Device/zbtlink_zbt-wg2626
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)


### PR DESCRIPTION
This is a backport from #10434.

There will be no problem because it is a variant with only a difference in flash capacity(16M -> 32M) from the already included ZBT-WG1608 model.