### PR TITLE
bmips: add support for Arcadyan AR7516

### DIFF
--- a/target/linux/bmips/bcm6328/base-files/etc/board.d/01_leds
+++ b/target/linux/bmips/bcm6328/base-files/etc/board.d/01_leds
@@ -6,6 +6,10 @@
 board_config_update
 
 case "$(board_name)" in
+arcadyan,ar7516)
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
+	ucidef_set_led_netdev "wlan0" "WiFi" "green:wifi" "phy0-ap0"
+	;;
 nucom,r5010unv2 |\
 sercomm,ad1018)
 	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1" "usb2-port1"

--- a/target/linux/bmips/bcm6328/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6328/base-files/etc/board.d/02_network
@@ -5,6 +5,10 @@
 board_config_update
 
 case "$(board_name)" in
+arcadyan,ar7516)
+	ucidef_set_bridge_device switch
+	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
+	;;
 comtrend,ar-5381u |\
 comtrend,ar-5387un |\
 nucom,r5010unv2)

--- a/target/linux/bmips/bcm6328/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/bmips/bcm6328/base-files/etc/uci-defaults/09_fix_crc
@@ -3,6 +3,7 @@
 . /lib/functions.sh
 
 case "$(board_name)" in
+arcadyan,ar7516 |\
 comtrend,ar-5381u |\
 comtrend,ar-5387un |\
 nucom,r5010unv2)

--- a/target/linux/bmips/dts/bcm6328-arcadyan-ar7516.dts
+++ b/target/linux/bmips/dts/bcm6328-arcadyan-ar7516.dts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6328.dtsi"
+
+/ {
+	model = "Arcadyan AR7516";
+	compatible = "arcadyan,ar7516", "brcm,bcm6328";
+
+	aliases {
+		led-failsafe = &led_upgrade_green;
+		led-upgrade = &led_upgrade_green;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	bcm43227-sprom {
+		compatible = "brcm,bcma-sprom";
+
+		pci-bus = <1>;
+		pci-dev = <0>;
+
+		nvmem-cells = <&macaddr_cfe_6a0>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <1>;
+
+		brcm,sprom = "brcm/bcm43227-sprom.bin";
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cfe_6a0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&hsspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <16666667>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cfe: partition@0 {
+				label = "cfe";
+				reg = <0x000000 0x010000>;
+				read-only;
+			};
+
+			partition@10000 {
+				compatible = "brcm,bcm963xx-imagetag";
+				label = "firmware";
+				reg = <0x010000 0x7e0000>;
+			};
+
+			partition@7f0000 {
+				label = "nvram";
+				reg = <0x7f0000 0x010000>;
+			};
+		};
+	};
+};
+
+&leds {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_ephy0_act_led &pinctrl_ephy1_act_led
+		     &pinctrl_ephy2_act_led &pinctrl_ephy3_act_led
+		     &pinctrl_leds>;
+
+	led_upgrade_green: led@1 {
+		reg = <1>;
+		label = "green:upgrade";
+	};
+
+	led@6 {
+		reg = <6>;
+		active-low;
+		label = "green:wan";
+	};
+
+	led@7 {
+		reg = <7>;
+		active-low;
+		label = "green:wifi";
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pinctrl {
+	pinctrl_leds: leds {
+		function = "led";
+		pins = "gpio1", "gpio6", "gpio7";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+
+			phy-handle = <&phy1>;
+			phy-mode = "mii";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+
+			phy-handle = <&phy2>;
+			phy-mode = "mii";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+
+			phy-handle = <&phy3>;
+			phy-mode = "mii";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "wan";
+
+			phy-handle = <&phy4>;
+			phy-mode = "mii";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};
+
+&cfe {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_cfe_6a0: macaddr@6a0 {
+		reg = <0x6a0 0x6>;
+	};
+};

--- a/target/linux/bmips/image/bcm6328.mk
+++ b/target/linux/bmips/image/bcm6328.mk
@@ -1,5 +1,18 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+define Device/arcadyan_ar7516
+  $(Device/bcm63xx-cfe)
+  DEVICE_VENDOR := Arcadyan
+  DEVICE_MODEL := AR7516
+  CHIP_ID := 6328
+  CFE_BOARD_ID := AR7516AAW
+  FLASH_MB := 8
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    $(B43_PACKAGES) broadcom-43227-sprom \
+    kmod-leds-bcm6328
+endef
+TARGET_DEVICES += arcadyan_ar7516
+
 define Device/comtrend_ar-5381u
   $(Device/bcm63xx-cfe)
   DEVICE_VENDOR := Comtrend


### PR DESCRIPTION
The Arcadyan AR7516, AKA Orange Bright Box or EE Bright Box 1, is a wifi fast ethernet router, 2.4 GHz single band with two internal antennas. It comes with a horizontal stand black shiny casing.

Newer Bright Box 1 model stands vertically, and comes with a totally different board inside, not compatible with this firmware.

Hardware:
 - SoC: Broadcom BCM6328
 - CPU: single core BMIPS4350 V7.5 @ 320Mhz
 - RAM: 64 MB DDR2
 - Flash: 8 MB SPI NOR
 - Ethernet LAN: 4x 100Mbit
 - Wifi 2.4 GHz: Broadcom BCM43227 802.11bgn (onboard)
 - USB: 1x 2.0
 - ADSL: yes, unsupported
 - Buttons: 2x
 - LEDs: 9x, power LED is hardware controlled
 - UART: yes

Installation in two steps, new CFE bootloader and firmware:

Install new CFE:
  1. Power off the router and press the RESET button
  2. Power on the router and wait some seconds
  3. Release the RESET button
  3. Browse to http://192.168.1.1, this web interface will offer both firmware (“Software”) upgrade and bootloader upgrade; be sure to use the bootloader section of the upload form.
  4. Upload the new CFE (availabe at the wiki page)
  5. Wait about a minute for flashing to finish and reboot into the new bootloader.

Install OpenWrt via new CFE web UI:
  1. After installing the new CFE, visit http://192.168.1.1
  2. Upload the Openwrt cfe firmware
  5. Wait a few minutes for it to finish
 

CC: @Noltari 