### PR TITLE
armsr: change image names to 'combined-efi'

### DIFF
--- a/target/linux/armsr/README
+++ b/target/linux/armsr/README
@@ -49,7 +49,7 @@ With a EDKII or U-Boot binary for the QEMU ARM virtual machines, you can use the
 images in EFI mode:
 
 32-bit:
-gunzip -c bin/targets/armsr/armv7/openwrt-armsr-armv7-generic-ext4-combined.img.gz > openwrt-arm-32.img
+gunzip -c bin/targets/armsr/armv7/openwrt-armsr-armv7-generic-ext4-combined-efi.img.gz > openwrt-arm-32.img
 qemu-system-arm -nographic \
     -cpu cortex-a15 -machine virt \
     -bios bin/targets/armsr/armv7/u-boot-qemu_armv7/u-boot.bin \
@@ -60,7 +60,7 @@ qemu-system-arm -nographic \
     -netdev user,id=testwan -net nic,netdev=testwan
 
 64-bit:
-gunzip -c bin/targets/armsr/armv8/openwrt-armsr-armv8-generic-ext4-combined.img.gz > openwrt-arm-64.img
+gunzip -c bin/targets/armsr/armv8/openwrt-armsr-armv8-generic-ext4-combined-efi.img.gz > openwrt-arm-64.img
 qemu-system-aarch64 -nographic \
     -cpu cortex-a53 -machine virt \
     -bios bin/targets/armsr/armv8/u-boot-qemu_armv8/u-boot.bin \

--- a/target/linux/armsr/image/Makefile
+++ b/target/linux/armsr/image/Makefile
@@ -74,18 +74,18 @@ DEVICE_VARS += GRUB2_VARIANT UBOOT
 define Device/efi-default
   IMAGE/rootfs.img := append-rootfs | pad-to $(ROOTFS_PARTSIZE)
   IMAGE/rootfs.img.gz := append-rootfs | pad-to $(ROOTFS_PARTSIZE) | gzip
-  IMAGE/combined.img := grub-config efi | combined efi | grub-install efi | append-metadata
-  IMAGE/combined.img.gz := grub-config efi | combined efi | grub-install efi | gzip | append-metadata
-  IMAGE/combined.vmdk := grub-config efi | combined efi | grub-install efi | qemu-image vmdk
+  IMAGE/combined-efi.img := grub-config efi | combined efi | grub-install efi | append-metadata
+  IMAGE/combined-efi.img.gz := grub-config efi | combined efi | grub-install efi | gzip | append-metadata
+  IMAGE/combined-efi.vmdk := grub-config efi | combined efi | grub-install efi | qemu-image vmdk
  ifeq ($(CONFIG_TARGET_IMAGES_GZIP),y)
     IMAGES-y := rootfs.img.gz
-    IMAGES-y += combined.img.gz
+    IMAGES-y += combined-efi.img.gz
   else
     IMAGES-y := rootfs.img
-    IMAGES-y += combined.img
+    IMAGES-y += combined-efi.img
   endif
   ifeq ($(CONFIG_VMDK_IMAGES),y)
-    IMAGES-y += combined.vmdk
+    IMAGES-y += combined-efi.vmdk
   endif
   KERNEL := kernel-bin
   KERNEL_INSTALL := 1


### PR DESCRIPTION
This came out of https://github.com/openwrt/luci/pull/6430 . If this is merged, that PR will be redundant.

`luci-app-attendedsysupgrade` expects images to be named 'combined-efi' when the system is using EFI images.

This came about as x86 has 'combined' images for legacy (BIOS) boot and 'combined-efi' for EFI systems.
armsr images were originally named 'combined' only as there was no 'legacy' image type.

To avoid special handling in the attendedsysupgrade code, name EFI images consistent with other targets.
(if other archs adopt EFI, e.g RISC-V, then they should also name images `combined-efi`)

This change also needs to be applied to 23.05.

Ping @aparcar 
