### PR TITLE
generic: 6.1: backport qca8k patch enabling additional LED trigger modes

### DIFF
--- a/target/linux/generic/backport-6.1/806-v6.5-net-dsa-qca8k-add-support-for-additional-modes-for-n.patch
+++ b/target/linux/generic/backport-6.1/806-v6.5-net-dsa-qca8k-add-support-for-additional-modes-for-n.patch
@@ -1,0 +1,64 @@
+From 2555f35a4f428a9bfdf09aa0459dbfdf59a24a9a Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Wed, 21 Jun 2023 11:54:09 +0200
+Subject: [PATCH] net: dsa: qca8k: add support for additional modes for netdev
+ trigger
+
+The QCA8K switch supports additional modes that can be handled in
+hardware for the LED netdev trigger.
+
+Add these additional modes to further support the Switch LEDs and
+offload more blink modes.
+
+Add additional modes:
+- link_10
+- link_100
+- link_1000
+- half_duplex
+- full_duplex
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Reviewed-by: Florian Fainelli <florian.fainelli@broadcom.com>
+Link: https://lore.kernel.org/r/20230621095409.25859-1-ansuelsmth@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/qca/qca8k-leds.c | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+--- a/drivers/net/dsa/qca/qca8k-leds.c
++++ b/drivers/net/dsa/qca/qca8k-leds.c
+@@ -68,6 +68,16 @@ qca8k_parse_netdev(unsigned long rules,
+ 		*offload_trigger |= QCA8K_LED_TX_BLINK_MASK;
+ 	if (test_bit(TRIGGER_NETDEV_RX, &rules))
+ 		*offload_trigger |= QCA8K_LED_RX_BLINK_MASK;
++	if (test_bit(TRIGGER_NETDEV_LINK_10, &rules))
++		*offload_trigger |= QCA8K_LED_LINK_10M_EN_MASK;
++	if (test_bit(TRIGGER_NETDEV_LINK_100, &rules))
++		*offload_trigger |= QCA8K_LED_LINK_100M_EN_MASK;
++	if (test_bit(TRIGGER_NETDEV_LINK_1000, &rules))
++		*offload_trigger |= QCA8K_LED_LINK_1000M_EN_MASK;
++	if (test_bit(TRIGGER_NETDEV_HALF_DUPLEX, &rules))
++		*offload_trigger |= QCA8K_LED_HALF_DUPLEX_MASK;
++	if (test_bit(TRIGGER_NETDEV_FULL_DUPLEX, &rules))
++		*offload_trigger |= QCA8K_LED_FULL_DUPLEX_MASK;
+ 
+ 	if (rules && !*offload_trigger)
+ 		return -EOPNOTSUPP;
+@@ -322,6 +332,16 @@ qca8k_cled_hw_control_get(struct led_cla
+ 		set_bit(TRIGGER_NETDEV_TX, rules);
+ 	if (val & QCA8K_LED_RX_BLINK_MASK)
+ 		set_bit(TRIGGER_NETDEV_RX, rules);
++	if (val & QCA8K_LED_LINK_10M_EN_MASK)
++		set_bit(TRIGGER_NETDEV_LINK_10, rules);
++	if (val & QCA8K_LED_LINK_100M_EN_MASK)
++		set_bit(TRIGGER_NETDEV_LINK_100, rules);
++	if (val & QCA8K_LED_LINK_1000M_EN_MASK)
++		set_bit(TRIGGER_NETDEV_LINK_1000, rules);
++	if (val & QCA8K_LED_HALF_DUPLEX_MASK)
++		set_bit(TRIGGER_NETDEV_HALF_DUPLEX, rules);
++	if (val & QCA8K_LED_FULL_DUPLEX_MASK)
++		set_bit(TRIGGER_NETDEV_FULL_DUPLEX, rules);
+ 
+ 	return 0;
+ }


### PR DESCRIPTION
Backport qca8k patch enabling additional netdev LED trigger modes.

Additional mode supported for hw control:
- link_10
- link_100
- link_1000
- half_duplex
- full_duplex