### PR TITLE
ramips: fix lan leds for Wavlink WL-WN535K1

### DIFF
--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn535k1.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn535k1.dts
@@ -48,12 +48,12 @@
 
 		lan1 {
 			label = "green:lan1";
-			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
 		};
 
 		lan2 {
 			label = "green:lan2";
-			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -219,8 +219,8 @@ tplink,re200-v1)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	;;
 wavlink,wl-wn535k1)
-	ucidef_set_led_switch "lan1" "lan2" "green:lan1" "switch0" "0x04"
-	ucidef_set_led_switch "lan2" "lan2" "green:lan2" "switch0" "0x20"
+	ucidef_set_led_switch "lan1" "lan1" "green:lan1" "switch0" "0x20"
+	ucidef_set_led_switch "lan2" "lan2" "green:lan2" "switch0" "0x04"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
 wavlink,wl-wn579x3)

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -235,7 +235,7 @@ ramips_setup_interfaces()
 		;;
 	wavlink,wl-wn535k1)
 		ucidef_add_switch "switch0" \
-			"2:lan" "5:lan" "4:wan" "6@eth0"
+			"2:lan:2" "5:lan:1" "4:wan" "6@eth0"
 		;;
 	wavlink,wl-wn579x3)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
Previously both lan1 and lan2 leds were wrongly labelled as lan2. Moreover they were connected to the wrong lan port. Fixes 8fde82095ba0 ("ramips: add support for Wavlink WL-WN535K1")

Reported-by: Nicolò Maria Semprini <nicosemp@gmail.com>
