### PR TITLE
kernel: modules: add xdp-sockets-diag support

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1107,6 +1107,12 @@ config KERNEL_NET_L3_MASTER_DEV
 	  This module provides glue between core networking code and device
 	  drivers to support L3 master devices like VRF.
 
+config KERNEL_XDP_SOCKETS
+	bool "XDP sockets support"
+	help
+	  XDP sockets allows a channel between XDP programs and
+	  userspace applications.
+
 config KERNEL_WIRELESS_EXT
 	def_bool n
 

--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -1434,6 +1434,22 @@ endef
 $(eval $(call KernelPackage,inet-diag))
 
 
+define KernelPackage/xdp-sockets-diag
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
+  TITLE:=PF_XDP sockets monitoring interface support for ss utility
+  DEPENDS:=@KERNEL_XDP_SOCKETS
+  KCONFIG:=CONFIG_XDP_SOCKETS_DIAG
+  FILES:=$(LINUX_DIR)/net/xdp/xsk_diag.ko
+  AUTOLOAD:=$(call AutoLoad,31,xsk_diag)
+endef
+
+define KernelPackage/xdp-sockets-diag/description
+ Support for PF_XDP sockets monitoring interface used by the ss tool
+endef
+
+$(eval $(call KernelPackage,xdp-sockets-diag))
+
+
 define KernelPackage/wireguard
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=WireGuard secure network tunnel

--- a/target/linux/generic/hack-5.15/901-debloat_sock_diag.patch
+++ b/target/linux/generic/hack-5.15/901-debloat_sock_diag.patch
@@ -160,3 +160,13 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	default n
  	help
  	  Support for UNIX socket monitoring interface used by the ss tool.
+--- a/net/xdp/Kconfig
++++ b/net/xdp/Kconfig
+@@ -10,6 +10,7 @@ config XDP_SOCKETS
+ config XDP_SOCKETS_DIAG
+ 	tristate "XDP sockets: monitoring interface"
+ 	depends on XDP_SOCKETS
++	select SOCK_DIAG
+ 	default n
+ 	help
+ 	  Support for PF_XDP sockets monitoring interface used by the ss tool.

--- a/target/linux/generic/hack-6.1/901-debloat_sock_diag.patch
+++ b/target/linux/generic/hack-6.1/901-debloat_sock_diag.patch
@@ -162,3 +162,13 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	default n
  	help
  	  Support for UNIX socket monitoring interface used by the ss tool.
+--- a/net/xdp/Kconfig
++++ b/net/xdp/Kconfig
+@@ -10,6 +10,7 @@ config XDP_SOCKETS
+ config XDP_SOCKETS_DIAG
+ 	tristate "XDP sockets: monitoring interface"
+ 	depends on XDP_SOCKETS
++	select SOCK_DIAG
+ 	default n
+ 	help
+ 	  Support for PF_XDP sockets monitoring interface used by the ss tool.


### PR DESCRIPTION
Support for PF_XDP sockets monitoring interface used by the ss tool.