### PR TITLE
arm-trusted-firmware-rockchip: add m0 gcc toolchain

### DIFF
--- a/package/boot/arm-trusted-firmware-rockchip/Makefile
+++ b/package/boot/arm-trusted-firmware-rockchip/Makefile
@@ -37,6 +37,33 @@ TFA_TARGETS:= \
 	rk3328 \
 	rk3399
 
+ifeq ($(BUILD_VARIANT),rk3399)
+  M0_GCC_NAME:=gcc-arm
+  M0_GCC_RELEASE:=11.2-2022.02
+  M0_GCC_VERSION:=$(HOST_ARCH)-arm-none-eabi
+  M0_GCC_SOURCE:=$(M0_GCC_NAME)-$(M0_GCC_RELEASE)-$(M0_GCC_VERSION).tar.xz
+
+  define Download/m0-gcc
+    FILE:=$(M0_GCC_SOURCE)
+    URL:=https://developer.arm.com/-/media/Files/downloads/gnu/$(M0_GCC_RELEASE)/binrel
+  ifeq ($(HOST_ARCH),aarch64)
+    HASH:=ef1d82e5894e3908cb7ed49c5485b5b95deefa32872f79c2b5f6f5447cabf55f
+  else
+    HASH:=8c5acd5ae567c0100245b0556941c237369f210bceb196edfe5a2e7532c60326
+  endif
+  endef
+
+  define Build/Prepare
+	$(eval $(call Download,m0-gcc))
+	$(call Build/Prepare/Default)
+
+	xzcat $(DL_DIR)/$(M0_GCC_SOURCE) | $(HOST_TAR) -C $(PKG_BUILD_DIR)/ $(TAR_OPTIONS)
+  endef
+
+  TFA_MAKE_FLAGS+= \
+    M0_CROSS_COMPILE=$(PKG_BUILD_DIR)/$(M0_GCC_NAME)-$(M0_GCC_RELEASE)-$(M0_GCC_VERSION)/bin/arm-none-eabi-
+endif
+
 define Package/trusted-firmware-a/install
 	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/build/$(PLAT)/release/bl31/bl31.elf $(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)_bl31.elf


### PR DESCRIPTION
rk3399 ATF requires arm toolchain to build the m0 pmu driver.
As OpenWrt doesn't ship this toolchain so download the prebuilt one
just like what we did in arm-trusted-firmware-mvebu.

Fixes: 5d1cb52da062 ("arm-trusted-firmware-rockchip: Update to 2.9")
