### PR TITLE
[23.05] filogic: add support for Netgear WAX220

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -37,6 +37,9 @@ bananapi,bpi-r3)
 		;;
 	esac
 	;;
+netgear,wax220)
+	ubootenv_add_uci_config "/dev/mtd5" "0x0" "0x20000" "0x20000"
+	;;
 xiaomi,redmi-router-ax6000-stock)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x20000"
 	ubootenv_add_uci_sys_config "/dev/mtd2" "0x0" "0x10000" "0x20000"

--- a/target/linux/mediatek/dts/mt7986b-netgear-wax220.dts
+++ b/target/linux/mediatek/dts/mt7986b-netgear-wax220.dts
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7986b.dtsi"
+
+/ {
+	#address-cells = <0x2>;
+	#size-cells = <0x2>;
+	model = "Netgear WAX220";
+	compatible = "netgear,wax220", "mediatek,mt7986b-spim-snand-rfb";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_amber;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_amber;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			label = "reset";
+		};
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan5g_green {
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+			label = "green:wlan5g";
+		};
+
+		led_power_amber: power_amber {
+			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
+			label = "amber:power";
+		};
+
+		wlan2g_green {
+			gpios = <&pio 19 GPIO_ACTIVE_HIGH>;
+			label = "green:wlan2g";
+		};
+
+		led_power_blue: power_blue {
+			gpios = <&pio 7 GPIO_ACTIVE_HIGH>;
+			label = "blue:power";
+		};
+
+		led_power_green: power_green {
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			label = "green:power";
+		};
+
+		wlan2g_blue {
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			label = "blue:wlan2g";
+		};
+
+		lan_green {
+			gpios = <&pio 22 GPIO_ACTIVE_HIGH>;
+			label = "green:lan";
+		};
+
+		lan_amber {
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+			label = "amber:lan";
+		};
+
+		wlan5g_blue {
+			gpios = <&pio 2 GPIO_ACTIVE_LOW>;
+			label = "blue:wlan5g";
+		};
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-handle = <&phy6>;
+		phy-mode = "2500base-x";
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+};
+
+&mdio {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	phy6: ethernet-phy@6 {
+		reg = <6>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <100000>;
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <46 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <8>;
+			mediatek,pull-down-adv = <0>; /* bias-disable */
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins =  "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+				"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+				"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+				"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+				"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+				"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+				"WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <4>;
+		};
+	};
+
+	wf_dbdc_pins: wf-dbdc-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_dbdc";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			 "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			 "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			 "WF0_TOP_CLK", "WF0_TOP_DATA";
+			drive-strength = <4>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+
+	spi_nand_flash: flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <20000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		partitions: partitions {
+			#address-cells = <0x1>;
+			#size-cells = <0x1>;
+			compatible = "fixed-partitions";
+
+			partition@5fc0000 {
+				label = "Traffic";
+				reg = <0x5fc0000 0x200000>;
+			};
+
+			partition@63c0000 {
+				label = "NTGRcryptD";
+				reg = <0x63c0000 0x500000>;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x5140000>;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+			};
+
+			partition@69c0000 {
+				label = "User_data";
+				reg = <0x69c0000 0x640000>;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@68c0000 {
+				label = "LOG";
+				reg = <0x68c0000 0x100000>;
+			};
+
+			partition@5ac0000 {
+				label = "POT";
+				reg = <0x5ac0000 0x100000>;
+			};
+
+			partition@0 {
+				label = "BL2";
+				read-only;
+				reg = <0x0 0x100000>;
+			};
+
+			partition@5bc0000 {
+				label = "Language";
+				reg = <0x5bc0000 0x400000>;
+			};
+
+			partition@61c0000 {
+				label = "Cert";
+				reg = <0x61c0000 0x100000>;
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+			};
+
+			partition@56c0000 {
+				label = "RAE";
+				reg = <0x56c0000 0x400000>;
+			};
+
+			partition@62c0000 {
+				label = "NTGRcryptK";
+				reg = <0x62c0000 0x100000>;
+			};
+		};
+	};
+
+};
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	pinctrl-names = "default", "dbdc";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+	pinctrl-1 = <&wf_dbdc_pins>;
+
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -9,6 +9,11 @@ case $board in
 cudy,wr3000-v1)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
 	;;
+netgear,wax220)
+	ucidef_set_led_netdev "eth0" "LAN" "green:lan" "eth0"
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan2g" "phy0-ap0"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan5g" "phy1-ap0"
+	;;
 xiaomi,redmi-router-ax6000-stock|\
 xiaomi,redmi-router-ax6000-ubootmod)
 	ucidef_set_led_netdev "wan" "wan" "rgb:network" "wan"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -11,6 +11,9 @@ mediatek_setup_interfaces()
 	asus,tuf-ax4200)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
 		;;
+	netgear,wax220)
+		ucidef_set_interface_lan "eth0"
+		;;
 	bananapi,bpi-r3)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp2" "eth1 wan"
 		;;
@@ -65,6 +68,10 @@ mediatek_setup_macs()
 		;;
 	bananapi,bpi-r3)
 		wan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)
+		;;
+	netgear,wax220)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env mac)
+		label_mac=$lan_mac
 		;;
 	qihoo,360t7)
 		lan_mac=$(mtd_get_mac_ascii factory lanMac)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -32,6 +32,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $addr 1) > /sys${DEVPATH}/macaddress
 		;;
+	netgear,wax220)
+		hw_mac_addr=$(mtd_get_mac_ascii u-boot-env mac)
+		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 3 > /sys${DEVPATH}/macaddress
+		;;
 	qihoo,360t7)
 		addr=$(mtd_get_mac_ascii factory lanMac)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -176,6 +176,22 @@ define Device/glinet_gl-mt3000
 endef
 TARGET_DEVICES += glinet_gl-mt3000
 
+define Device/netgear_wax220
+  DEVICE_VENDOR := Netgear
+  DEVICE_MODEL := WAX220
+  DEVICE_DTS := mt7986b-netgear-wax220
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7986-firmware mt7986-wo-firmware
+  IMAGES := sysupgrade.bin
+  KERNEL_IN_UBI := 1
+  KERNEL := kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += netgear_wax220
+
 define Device/mediatek_mt7986a-rfb-nand
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7986 rfba AP (NAND)


### PR DESCRIPTION
Backport of 984786a2f7ec622c99e8c9cdada65d0ea0cf4e0b

Build and run tested on hardware.

Hardware
--------
SOC:   MediaTek MT7986
RAM:   1024MB DDR3
FLASH: 128MB SPI-NAND (Winbond)
WIFI:  Mediatek MT7986 DBDC 802.11ax 2.4/5 GHz
ETH:   Realtek RTL8221B-VB-CG 2.5 N-Base-T PHY with PoE
UART:  3V3 115200 8N1 (Pinout silkscreened / Do not connect VCC)

Installation
------------

1. Download the OpenWrt initramfs image. Copy the image to a TFTP server
2. Connect the TFTP server to the WAX220. Conect to the serial console, interrupt the autoboot process by pressing '0' when prompted.
3. Download & Boot the OpenWrt initramfs image.

   $ setenv ipaddr 192.168.2.1 $ setenv serverip 192.168.2.2 $ tftpboot openwrt.bin $ bootm

4. Wait for OpenWrt to boot. Transfer the sysupgrade image to the device using scp and install using sysupgrade.

   $ sysupgrade -n <path-to-sysupgrade.bin>

