### PR TITLE
linux-firmware: ibt-firmware: install sfi/ddc files for AX210 card

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
 PKG_VERSION:=20230515
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/package/firmware/linux-firmware/intel.mk
+++ b/package/firmware/linux-firmware/intel.mk
@@ -3,6 +3,8 @@ define Package/ibt-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/intel
 	$(CP) \
 		$(PKG_BUILD_DIR)/intel/*.bseq \
+		$(PKG_BUILD_DIR)/intel/ibt*.sfi \
+		$(PKG_BUILD_DIR)/intel/ibt*.ddc \
 		$(1)/lib/firmware/intel
 endef
 $(eval $(call BuildPackage,ibt-firmware))


### PR DESCRIPTION
When using an Intel AX210 card, the Bluetooth hci interface failed to start due to a missing `ibt-0041-0041.sfi` file.

`Bluetooth: hci0: Failed to load Intel firmware file intel/ibt-0041-0041.sfi (-2)`

A device specific configuration file (DDC) is also required: 
```
Bluetooth: hci0: Found device firmware: intel/ibt-0041-0041.sfi
Bluetooth: hci0: Waiting for firmware download to complete
...
Bluetooth: hci0: Found Intel DDC parameters: intel/ibt-0041-0041.ddc
Bluetooth: hci0: Applying Intel DDC parameters completed
Bluetooth: hci0: Firmware timestamp 2023.13 buildtype 1 build 62562
```

Fixes: https://github.com/openwrt/openwrt/issues/8558
