### PR TITLE
layerscape: armv8_64b: remove (rare/not widely distributed) Traverse LS1043 boards

### DIFF
--- a/target/linux/layerscape/base-files/lib/upgrade/platform.sh
+++ b/target/linux/layerscape/base-files/lib/upgrade/platform.sh
@@ -3,8 +3,8 @@
 # Copyright 2020 NXP
 #
 
-RAMFS_COPY_BIN="/usr/sbin/fw_printenv /usr/sbin/fw_setenv /usr/sbin/ubinfo /bin/echo"
-RAMFS_COPY_DATA="/etc/fw_env.config /var/lock/fw_printenv.lock"
+RAMFS_COPY_BIN=""
+RAMFS_COPY_DATA=""
 
 REQUIRE_IMAGE_METADATA=1
 


### PR DESCRIPTION
This pull request removes support for building images for the Traverse LS1043 family (LS1043V and LS1043S).

These boards were not widely distributed. The only version in production (for "OEM" customers) is different from the ones described in OpenWrt. The public release of the LS1043A family (then called Five64) was cancelled in favour of our LS1088A design (Ten64). Additionally, supporting code for these boards (U-Boot, device tree etc.) was never sent upstream.

I do not think it is worth consuming OpenWrt project resources (such as buildbot) and contributor time (handling the non-upstream DTS etc.) to support them.

Additionally, I have cleaned up some redundant file copies in sysupgrade in 288d864b3da770101894dcc4739b7b2423b3e390 . Regression tested on Ten64 (NAND).