### PR TITLE
kernel: net: phy: realtek: fix rtl822x_probe on unsupported devices

### DIFF
--- a/target/linux/generic/pending-5.15/729-net-phy-realtek-introduce-rtl822x_probe.patch
+++ b/target/linux/generic/pending-5.15/729-net-phy-realtek-introduce-rtl822x_probe.patch
@@ -50,23 +50,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static int rtlgen_resume(struct phy_device *phydev)
  {
  	int ret = genphy_resume(phydev);
-@@ -1013,6 +1036,7 @@ static struct phy_driver realtek_drvs[]
- 		.match_phy_device = rtl8226_match_phy_device,
- 		.get_features	= rtl822x_get_features,
- 		.config_aneg	= rtl822x_config_aneg,
-+		.probe          = rtl822x_probe,
- 		.read_status	= rtl822x_read_status,
- 		.suspend	= genphy_suspend,
- 		.resume		= rtlgen_resume,
-@@ -1026,6 +1050,7 @@ static struct phy_driver realtek_drvs[]
- 		.name		= "RTL8226B_RTL8221B 2.5Gbps PHY",
- 		.get_features	= rtl822x_get_features,
- 		.config_aneg	= rtl822x_config_aneg,
-+		.probe          = rtl822x_probe,
- 		.read_status	= rtl822x_read_status,
- 		.suspend	= genphy_suspend,
- 		.resume		= rtlgen_resume,
-@@ -1039,6 +1064,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1039,6 +1062,7 @@ static struct phy_driver realtek_drvs[]
  		.name           = "RTL8226-CG 2.5Gbps PHY",
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
@@ -74,7 +58,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.read_status    = rtl822x_read_status,
  		.suspend        = genphy_suspend,
  		.resume         = rtlgen_resume,
-@@ -1050,6 +1076,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1050,6 +1074,7 @@ static struct phy_driver realtek_drvs[]
  		.name           = "RTL8226B-CG_RTL8221B-CG 2.5Gbps PHY",
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
@@ -82,7 +66,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.read_status    = rtl822x_read_status,
  		.suspend        = genphy_suspend,
  		.resume         = rtlgen_resume,
-@@ -1062,6 +1089,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1062,6 +1087,7 @@ static struct phy_driver realtek_drvs[]
  		.get_features   = rtl822x_get_features,
  		.config_init    = rtl8221b_config_init,
  		.config_aneg    = rtl822x_config_aneg,
@@ -90,7 +74,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.read_status    = rtl822x_read_status,
  		.suspend        = genphy_suspend,
  		.resume         = rtlgen_resume,
-@@ -1074,6 +1102,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1074,6 +1100,7 @@ static struct phy_driver realtek_drvs[]
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
  		.config_init    = rtl8221b_config_init,

--- a/target/linux/generic/pending-5.15/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-5.15/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -52,7 +52,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static int rtl822x_probe(struct phy_device *phydev)
  {
  	struct device *dev = &phydev->mdio.dev;
-@@ -1084,7 +1116,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1082,7 +1114,7 @@ static struct phy_driver realtek_drvs[]
  		.write_page     = rtl821x_write_page,
  		.soft_reset     = genphy_soft_reset,
  	}, {

--- a/target/linux/generic/pending-6.1/729-net-phy-realtek-introduce-rtl822x_probe.patch
+++ b/target/linux/generic/pending-6.1/729-net-phy-realtek-introduce-rtl822x_probe.patch
@@ -50,23 +50,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static int rtlgen_resume(struct phy_device *phydev)
  {
  	int ret = genphy_resume(phydev);
-@@ -1033,6 +1056,7 @@ static struct phy_driver realtek_drvs[]
- 		.match_phy_device = rtl8226_match_phy_device,
- 		.get_features	= rtl822x_get_features,
- 		.config_aneg	= rtl822x_config_aneg,
-+		.probe          = rtl822x_probe,
- 		.read_status	= rtl822x_read_status,
- 		.suspend	= genphy_suspend,
- 		.resume		= rtlgen_resume,
-@@ -1046,6 +1070,7 @@ static struct phy_driver realtek_drvs[]
- 		.name		= "RTL8226B_RTL8221B 2.5Gbps PHY",
- 		.get_features	= rtl822x_get_features,
- 		.config_aneg	= rtl822x_config_aneg,
-+		.probe          = rtl822x_probe,
- 		.read_status	= rtl822x_read_status,
- 		.suspend	= genphy_suspend,
- 		.resume		= rtlgen_resume,
-@@ -1059,6 +1084,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1059,6 +1082,7 @@ static struct phy_driver realtek_drvs[]
  		.name           = "RTL8226-CG 2.5Gbps PHY",
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
@@ -74,7 +58,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.read_status    = rtl822x_read_status,
  		.suspend        = genphy_suspend,
  		.resume         = rtlgen_resume,
-@@ -1070,6 +1096,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1070,6 +1094,7 @@ static struct phy_driver realtek_drvs[]
  		.name           = "RTL8226B-CG_RTL8221B-CG 2.5Gbps PHY",
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
@@ -82,7 +66,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.read_status    = rtl822x_read_status,
  		.suspend        = genphy_suspend,
  		.resume         = rtlgen_resume,
-@@ -1082,6 +1109,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1082,6 +1107,7 @@ static struct phy_driver realtek_drvs[]
  		.get_features   = rtl822x_get_features,
  		.config_init    = rtl8221b_config_init,
  		.config_aneg    = rtl822x_config_aneg,
@@ -90,7 +74,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.read_status    = rtl822x_read_status,
  		.suspend        = genphy_suspend,
  		.resume         = rtlgen_resume,
-@@ -1094,6 +1122,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1094,6 +1120,7 @@ static struct phy_driver realtek_drvs[]
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
  		.config_init    = rtl8221b_config_init,

--- a/target/linux/generic/pending-6.1/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.1/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -52,7 +52,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static int rtl822x_probe(struct phy_device *phydev)
  {
  	struct device *dev = &phydev->mdio.dev;
-@@ -1104,7 +1136,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1102,7 +1134,7 @@ static struct phy_driver realtek_drvs[]
  		.write_page     = rtl821x_write_page,
  		.soft_reset     = genphy_soft_reset,
  	}, {


### PR DESCRIPTION
@dangowrt 

Calling rtl822x_probe() on phy devices which uses the rtl822x_read_mmd() and rtl822x_write_mmd() functions makes no sense and the probe ends with an EOPNOTSUPP error.
