### PR TITLE
ath79: add buzzer node to RB951G-2HnD DTS

### DIFF
--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951g-2hnd.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951g-2hnd.dts
@@ -17,6 +17,12 @@
 			gpio-export,output = <1>;
 			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
 		};
+		
+		buzzer {
+			gpio-export,name = "buzzer";
+			gpio-export,output = <1>;
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
 	};
 };
 


### PR DESCRIPTION
Mikrotik RB951 router has a buzzer on the board (connected to GPIO 17), which makes annoying noises due to the interference caused by PoE input or Wifi transmission when no GPIO pin state is set.
I added buzzer node to device's DTS in order to set default level to high and to provide easier access to it.

Tested on multiple RB951G devices.