### PR TITLE
fortify-headers: suppress stdio.h format warnings

### DIFF
--- a/toolchain/fortify-headers/Makefile
+++ b/toolchain/fortify-headers/Makefile
@@ -9,7 +9,7 @@ include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=fortify-headers
 PKG_VERSION:=1.1
-PKG_RELEASE=3
+PKG_RELEASE=4
 
 PKG_SOURCE_URL:=https://dl.2f30.org/releases
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/toolchain/fortify-headers/patches/002-ignore-format-warnings.patch
+++ b/toolchain/fortify-headers/patches/002-ignore-format-warnings.patch
@@ -1,0 +1,23 @@
+diff --git a/include/stdio.h b/include/stdio.h
+index a965184..57526b8 100644
+--- a/include/stdio.h
++++ b/include/stdio.h
+@@ -24,6 +24,9 @@ __extension__
+ #if defined(_FORTIFY_SOURCE) && _FORTIFY_SOURCE > 0 && defined(__OPTIMIZE__) && __OPTIMIZE__ > 0
+ #include "fortify-headers.h"
+ 
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wformat-nonliteral"
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+@@ -120,6 +123,8 @@ _FORTIFY_FN(sprintf) int sprintf(char *__s, const char *__f, ...)
+ }
+ #endif
+ 
++#pragma GCC diagnostic pop
++
+ #endif
+ 
+ #endif


### PR DESCRIPTION
Prevent build failures when compiling packages with FORTIFY_SOURCE and -Werror=format-nonliteral by suppressing this warning within the fortified stdio.h. These are warnings (treated as errors) like
```
..._musl/include/fortify/stdio.h: In function 'snprintf':
..._musl/include/fortify/stdio.h:101:9: error: format not a string literal,
  argument types not checked [-Werror=format-nonliteral]
```
Some packages (e.g. glib2) currently work around this by disabling fortify-source entirely, which is not ideal (see e.g. https://github.com/openwrt/packages/issues/18884).
