### PR TITLE
mediatek: filogic: wax220: support factory image

### DIFF
--- a/target/linux/mediatek/filogic/base-files/lib/preinit/75_rootfs_prepare
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/75_rootfs_prepare
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-2.0-or-later OR BSD-2-Clause
+
+rootfs_create() {
+	local blocks
+
+	blocks=$(cat /sys/class/ubi/ubi0/avail_eraseblocks)
+	[ -z "$blocks" ] && {
+		echo "Failed to read amount of available erase blocks" >&2
+		return
+	}
+
+	# Delete after getting available blocks: Make sure enough space is
+	# left to recreate these volumes.
+	ubirmvol /dev/ubi0 -N kernel_backup
+	ubirmvol /dev/ubi0 -N rootfs_backup
+
+	# Use 90% of remaining flash size for "rootfs_data"
+	ubimkvol /dev/ubi0 -n 20 -N rootfs_data --lebs $((blocks / 100 * 90))
+	mknod -m 0600 /dev/ubi0_20 c 250 21
+}
+
+rootfs_prepare() {
+	case $(board_name) in
+	netgear,wax220)
+		if ! ubinfo /dev/ubi0 -N rootfs_data &>/dev/null; then
+			echo "Creating \"rootfs_data\" UBI volume"
+			rootfs_create
+		fi
+		;;
+	*)
+		;;
+	esac
+}
+
+boot_hook_add preinit_main rootfs_prepare

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -202,18 +202,20 @@ endef
 TARGET_DEVICES += h3c_magic-nx30-pro
 
 define Device/netgear_wax220
-  DEVICE_VENDOR := Netgear
+  DEVICE_VENDOR := NETGEAR
   DEVICE_MODEL := WAX220
   DEVICE_DTS := mt7986b-netgear-wax220
   DEVICE_DTS_DIR := ../dts
+  NETGEAR_ENC_MODEL := WAX220
+  NETGEAR_ENC_REGION := US
   DEVICE_PACKAGES := kmod-mt7986-firmware mt7986-wo-firmware
-  IMAGES := sysupgrade.bin
-  KERNEL_IN_UBI := 1
-  KERNEL := kernel-bin | lzma | \
-        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  IMAGE_SIZE := 32768k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGES += factory.img
+  # Padding to 10M seems to be required by OEM web interface
+  IMAGE/factory.img := sysupgrade-tar | \
+	  pad-to 10M | check-size | netgear-encrypted-factory
 endef
 TARGET_DEVICES += netgear_wax220
 


### PR DESCRIPTION
Enable building a factory image which can be flashed through the OEM
firmware's web interface. It seems that the web interface requires a
minimum file size of 10MiB, otherwise it will not accept the image.

The update image is a regular sysupgrade tarball packed in a Netgear
encrypted image. The Netgear encrypted image is the same as used in
WAX202 or WAX206, including the encryption keys and IV.