### PR TITLE
lldpd: Implement more setting options

### DIFF
--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lldpd
 PKG_VERSION:=1.0.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lldpd/lldpd/releases/download/$(PKG_VERSION)/

--- a/package/network/services/lldpd/files/lldpd.config
+++ b/package/network/services/lldpd/files/lldpd.config
@@ -7,11 +7,12 @@ config lldpd config
 	option agentxsocket /var/run/agentx.sock
 
 	option lldp_class 4
-	option lldp_location "2:FR:6:Commercial Rd:3:Roseville:19:4"
 
 	# if empty, the distribution description is sent
 	#option lldp_description "OpenWrt System"
 	#option lldp_hostname "Modified Hostname"
+
+	option lldp_location "address country EU"
 
 	#option lldp_mgmt_ip "!192.168.1.1"
 

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -31,6 +31,12 @@ write_lldpd_conf()
 	local lldp_hostname
 	config_get lldp_hostname 'config' 'lldp_hostname' "$(cat /proc/sys/kernel/hostname)"
 
+	local lldp_platform
+	config_get lldp_platform 'config' 'lldp_platform' "$lldp_description"
+
+	local lldp_fast_start
+	config_get_bool ifaces 'config' 'lldp_fast_start' 0
+
 	local ifaces
 	config_get ifaces 'config' 'interface'
 
@@ -53,8 +59,11 @@ write_lldpd_conf()
 	[ -n "$ifnames" ] && echo "configure system interface pattern" "$ifnames" >> "$LLDPD_CONF"
 	[ -n "$lldp_description" ] && echo "configure system description" "\"$lldp_description\"" >> "$LLDPD_CONF"
 	[ -n "$lldp_hostname" ] && echo "configure system hostname" "\"$lldp_hostname\"" >> "$LLDPD_CONF"
+	[ -n "$lldp_platform" ] && echo "configure system platform" "\"$lldp_platform\"" >> "$LLDPD_CONF"
 	[ -n "$lldp_mgmt_ip" ] && echo "configure system ip management pattern" "\"$lldp_mgmt_ip\"" >> "$LLDPD_CONF"
+
 	[ -n "$lldp_syscapabilities" ] && echo "configure system capabilities enabled" "\"$lldp_syscapabilities\"" >> "$LLDPD_CONF"
+	[ $lldp_fast_start -gt 0 ] echo "configure med fast-start" "enable" >> "$LLDPD_CONF"
 
 	# Since lldpd's sysconfdir is /tmp, we'll symlink /etc/lldpd.d to /tmp/$LLDPD_CONFS_DIR
 	[ -e $LLDPD_CONFS_DIR ] || ln -s /etc/lldpd.d $LLDPD_CONFS_DIR
@@ -70,6 +79,8 @@ start_service() {
 	local enable_fdp
 	local enable_sonmp
 	local enable_edp
+	local disable_lldp_med
+	local disable_advertising_software
 	local lldp_class
 	local lldp_location
 	local readonly_mode
@@ -80,6 +91,8 @@ start_service() {
 	config_get_bool enable_fdp 'config' 'enable_fdp' 0
 	config_get_bool enable_sonmp 'config' 'enable_sonmp' 0
 	config_get_bool enable_edp 'config' 'enable_edp' 0
+	config_get_bool disable_lldp_med 'config' 'disable_lldp_med' 0
+	config_get_bool disable_advertising_software 'config' 'disable_advertising_software' 0
 	config_get lldp_class 'config' 'lldp_class'
 	config_get lldp_location 'config' 'lldp_location'
 	config_get_bool readonly_mode 'config' 'readonly_mode' 0
@@ -94,10 +107,12 @@ start_service() {
 	procd_open_instance
 	procd_set_param command /usr/sbin/lldpd -d
 
-	[ $enable_cdp -gt 0 ] && procd_append_param command '-c'
-	[ $enable_fdp -gt 0 ] && procd_append_param command '-f'
-	[ $enable_sonmp -gt 0 ] && procd_append_param command '-s'
-	[ $enable_edp -gt 0 ] && procd_append_param command '-e'
+	[ $enable_cdp -gt 0 ] && procd_append_param command "-$(printf 'c%.0s' $(seq 1 $enable_cdp))"
+	[ $enable_fdp -gt 0 ] && procd_append_param command "-$(printf 'f%.0s' $(seq 1 $enable_fdp))"
+	[ $enable_sonmp -gt 0 ] && procd_append_param command "-$(printf 's%.0s' $(seq 1 $enable_sonmp))"
+	[ $enable_edp -gt 0 ] && procd_append_param command "-$(printf 'e%.0s' $(seq 1 $enable_edp))"
+	[ $disable_lldp_med -gt 0 ] && procd_append_param command '-i'
+	[ $disable_advertising_software -gt 0 ] && procd_append_param command '-k'
 	[ $readonly_mode -gt 0 ] && procd_append_param command '-r'
 	[ -n "$lldp_class" ] && procd_append_param command -M "$lldp_class"
 	[ -n "$agentxsocket" ] && procd_append_param command -x -X "$agentxsocket"

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -39,6 +39,7 @@ get_config_restart_hash() {
 	config_get      v 'config' 'filter'; append _string "$v" ","
 	config_get_bool v 'config' 'readonly_mode'; append _string "$v" ","
 	config_get_bool v 'config' 'lldpmed_no_inventory'; append _string "$v" ","
+	config_get_bool v 'config' 'lldp_no_version'; append _string "$v" ","
 
 	config_get_bool v 'config' 'enable_lldp' 1; append _string "$v" ","
 	config_get_bool v 'config' 'force_lldp'; append _string "$v" ","
@@ -100,6 +101,8 @@ write_lldpd_conf()
 	config_get lldp_portidsubtype 'config' 'lldp_portidsubtype' 'macaddress'
 	config_get lldp_mgmt_ip 'config' 'lldp_mgmt_ip'
 	config_get lldp_syscapabilities 'config' 'lldp_syscapabilities'
+	config_get_bool lldpmed_fast_start 'config' 'lldpmed_fast_start' 0
+	config_get lldpmed_fast_start_tx_interval 'config' 'lldpmed_fast_start_tx_interval' 0
 
 	local ifaces
 	config_get ifaces 'config' 'interface'
@@ -125,6 +128,13 @@ write_lldpd_conf()
 	[ $lldp_fast_start -gt 0 ] echo "configure med fast-start" "enable" >> "$LLDPD_CONF"
 	[ -n "$lldp_agenttype" ] && echo "configure lldp agent-type" "\"$lldp_agenttype\"" >> "$LLDPD_CONF"
 	[ -n "$lldp_portidsubtype" ] && echo "configure lldp portidsubtype" "\"$lldp_portidsubtype\"" >> "$LLDPD_CONF"
+	if [ $lldpmed_fast_start -gt 0 ]; then
+		if [ $lldpmed_fast_start_tx_interval -gt 0 ]; then
+		    echo "configure med fast-start tx-interval" "\"$lldpmed_fast_start_tx_interval\"" >> "$LLDPD_CONF"
+		else
+		    echo "configure med fast-start" "enable" >> "$LLDPD_CONF"
+		fi
+    fi
 
 	# Since lldpd's sysconfdir is /tmp, we'll symlink /etc/lldpd.d to /tmp/$LLDPD_CONFS_DIR
 	[ -e $LLDPD_CONFS_DIR ] || ln -s /etc/lldpd.d $LLDPD_CONFS_DIR
@@ -139,6 +149,7 @@ start_service() {
 	local lldp_class
 	local lldp_location
 	local lldpmed_no_inventory
+	local lldp_no_version
 	local readonly_mode
 	local agentxsocket
 	local filter
@@ -160,6 +171,7 @@ start_service() {
 	config_get lldp_class 'config' 'lldp_class'
 	config_get lldp_location 'config' 'lldp_location'
 	config_get_bool lldpmed_no_inventory 'config' 'lldpmed_no_inventory' 0
+	config_get_bool lldp_no_version 'config' 'lldp_no_version' 0
 	config_get_bool readonly_mode 'config' 'readonly_mode' 0
 	config_get agentxsocket 'config' 'agentxsocket'
 	config_get filter 'config' 'filter' 15
@@ -246,6 +258,7 @@ start_service() {
 
 	[ $readonly_mode -gt 0 ] && procd_append_param command '-r'
 	[ $lldpmed_no_inventory -gt 0 ] && procd_append_param command '-i'
+	[ $lldp_no_version -gt 0 ] && procd_append_param command '-k'
 	[ -n "$lldp_class" ] && procd_append_param command -M "$lldp_class"
 	[ -n "$agentxsocket" ] && procd_append_param command -x -X "$agentxsocket"
 	[ -n "$filter" ] && procd_append_param command -H "$filter"
@@ -311,6 +324,7 @@ reload_service() {
 		unconfigure system hostname
 		unconfigure system platform
 		unconfigure system ip management pattern
+		unconfigure med fast-start
 	EOF
 	# Rewrite lldpd.conf
 	# If something changed it should be included by the lldpcli call

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -16,7 +16,6 @@ LLDPD_RUN=/var/run/lldpd
 LLDPD_RESTART_HASH=${LLDPD_RUN}/lldpd.restart_hash
 
 . "$IPKG_INSTROOT/lib/functions/network.sh"
-. "$IPKG_INSTROOT/usr/share/libubox/jshn.sh"
 
 find_release_info()
 {
@@ -284,22 +283,6 @@ service_triggers() {
 	procd_add_config_trigger "config.change" "lldpd" /etc/init.d/lldpd reload
 }
 
-lldpcli_running_config_read() {
-	json_init
-	json_load "`$LLDPCLI -f json show configuration`"
-}
-
-lldpcli_running_config_get_value() {
-	local param=$1
-	local value=""
-	json_select "configuration"
-		json_select "config"
-			json_get_var value "$param"
-		json_select ..
-	json_select ..
-	echo $value
-}
-
 reload_service() {
 	running || return 1
 
@@ -339,6 +322,6 @@ reload_service() {
 }
 
 stop_service() {
-	rm -rf ${LLDPD_RUN} 2>/dev/null
+	rm -rf ${LLDPD_RUN} $LLDPSOCKET
 }
 

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -88,6 +88,7 @@ write_lldpd_conf()
 	local lldp_portidsubtype
 	local lldp_mgmt_ip
 	local lldp_syscapabilities
+	local lldp_location
 
 	config_load 'lldpd'
 	config_get lldp_description 'config' 'lldp_description' "$(find_release_info)"
@@ -102,6 +103,8 @@ write_lldpd_conf()
 	config_get lldp_syscapabilities 'config' 'lldp_syscapabilities'
 	config_get_bool lldpmed_fast_start 'config' 'lldpmed_fast_start' 0
 	config_get lldpmed_fast_start_tx_interval 'config' 'lldpmed_fast_start_tx_interval' 0
+	config_get lldp_syscapabilities 'config' 'lldp_syscapabilities'
+	config_get lldp_location 'config' 'lldp_location'
 
 	local ifaces
 	config_get ifaces 'config' 'interface'
@@ -135,6 +138,9 @@ write_lldpd_conf()
 		fi
     fi
 
+	[ -n "$lldp_syscapabilities" ] && echo "configure system capabilities enabled" "\"$lldp_syscapabilities\"" >> "$LLDPD_CONF"
+	[ -n "$lldp_location" ] && echo "configure med location" "\"$lldp_location\"" >> "$LLDPD_CONF"
+
 	# Since lldpd's sysconfdir is /tmp, we'll symlink /etc/lldpd.d to /tmp/$LLDPD_CONFS_DIR
 	[ -e $LLDPD_CONFS_DIR ] || ln -s /etc/lldpd.d $LLDPD_CONFS_DIR
 }
@@ -146,7 +152,6 @@ start_service() {
 	local enable_sonmp
 	local enable_edp
 	local lldp_class
-	local lldp_location
 	local lldpmed_no_inventory
 	local lldp_no_version
 	local readonly_mode
@@ -168,7 +173,6 @@ start_service() {
 	config_get_bool enable_sonmp 'config' 'enable_sonmp' 0
 	config_get_bool enable_edp 'config' 'enable_edp' 0
 	config_get lldp_class 'config' 'lldp_class'
-	config_get lldp_location 'config' 'lldp_location'
 	config_get_bool lldpmed_no_inventory 'config' 'lldpmed_no_inventory' 0
 	config_get_bool lldp_no_version 'config' 'lldp_no_version' 0
 	config_get_bool readonly_mode 'config' 'readonly_mode' 0

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -1,14 +1,22 @@
 #!/bin/sh /etc/rc.common
+# Copyright (C) 2018 Anton Kikin <a.kikin@tano-systems.com>
 # Copyright (C) 2008-2015 OpenWrt.org
 
 START=90
 STOP=01
 
 USE_PROCD=1
+LLDPDBIN=/usr/sbin/lldpd
 LLDPCLI=/usr/sbin/lldpcli
 LLDPSOCKET=/var/run/lldpd.socket
 LLDPD_CONF=/tmp/lldpd.conf
 LLDPD_CONFS_DIR=/tmp/lldpd.d
+
+LLDPD_RUN=/var/run/lldpd
+LLDPD_RESTART_HASH=${LLDPD_RUN}/lldpd.restart_hash
+
+. "$IPKG_INSTROOT/lib/functions/network.sh"
+. "$IPKG_INSTROOT/usr/share/libubox/jshn.sh"
 
 find_release_info()
 {
@@ -19,23 +27,79 @@ find_release_info()
 	echo "${PRETTY_NAME:-Unknown OpenWrt release} @ $(cat /proc/sys/kernel/hostname)"
 }
 
+get_config_restart_hash() {
+	local var="$1"
+	local _string _hash v
+
+	config_load 'lldpd'
+
+	config_get      v 'config' 'lldp_class'; append _string "$v" ","
+	config_get      v 'config' 'agentxsocket'; append _string "$v" ","
+	config_get      v 'config' 'cid_interface'; append _string "$v" ","
+	config_get      v 'config' 'filter'; append _string "$v" ","
+	config_get_bool v 'config' 'readonly_mode'; append _string "$v" ","
+	config_get_bool v 'config' 'lldpmed_no_inventory'; append _string "$v" ","
+
+	config_get_bool v 'config' 'enable_lldp' 1; append _string "$v" ","
+	config_get_bool v 'config' 'force_lldp'; append _string "$v" ","
+
+	config_get_bool v 'config' 'enable_cdp'; append _string "$v" ","
+	config_get      v 'config' 'cdp_version'; append _string "$v" ","
+	config_get_bool v 'config' 'force_cdp'; append _string "$v" ","
+	config_get_bool v 'config' 'force_cdpv2'; append _string "$v" ","
+
+	config_get_bool v 'config' 'enable_edp'; append _string "$v" ","
+	config_get_bool v 'config' 'force_edp'; append _string "$v" ","
+
+	config_get_bool v 'config' 'enable_fdp'; append _string "$v" ","
+	config_get_bool v 'config' 'force_fdp'; append _string "$v" ","
+
+	config_get_bool v 'config' 'enable_sonmp'; append _string "$v" ","
+	config_get_bool v 'config' 'force_sonmp'; append _string "$v" ","
+
+	_hash=`echo -n "${_string}" | md5sum | awk '{ print \$1 }'`
+	export -n "$var=$_hash"
+}
+
+get_config_cid_ifaces() {
+	local _ifaces
+	config_get _ifaces 'config' 'cid_interface'
+
+	local _iface _ifnames=""
+	for _iface in $_ifaces; do
+		local _ifname=""
+		if network_get_device _ifname "$_iface" || [ -e "/sys/class/net/$_iface" ]; then
+			append _ifnames "${_ifname:-$_iface}" ","
+		fi
+	done
+
+	export -n "${1}=$_ifnames"
+}
+
 write_lldpd_conf()
 {
-	. /lib/functions/network.sh
-
 	local lldp_description
+	local lldp_hostname
+	local lldp_platform
+	local lldp_tx_interval
+	local lldp_tx_hold
+	local lldp_mgmt_ip
+	local lldp_agetntype
+	local lldp_portidsubtype
+	local lldp_mgmt_ip
+	local lldp_syscapabilities
 
 	config_load 'lldpd'
 	config_get lldp_description 'config' 'lldp_description' "$(find_release_info)"
-
-	local lldp_hostname
 	config_get lldp_hostname 'config' 'lldp_hostname' "$(cat /proc/sys/kernel/hostname)"
-
-	local lldp_platform
-	config_get lldp_platform 'config' 'lldp_platform' "$lldp_description"
-
-	local lldp_fast_start
-	config_get_bool ifaces 'config' 'lldp_fast_start' 0
+	config_get lldp_platform 'config' 'lldp_platform' ""
+	config_get lldp_tx_interval 'config' 'lldp_tx_interval' 0
+	config_get lldp_tx_hold 'config' 'lldp_tx_hold' 0
+	config_get lldp_mgmt_ip 'config' 'lldp_mgmt_ip' ''
+	config_get lldp_agenttype 'config' 'lldp_agenttype' 'nearest-bridge'
+	config_get lldp_portidsubtype 'config' 'lldp_portidsubtype' 'macaddress'
+	config_get lldp_mgmt_ip 'config' 'lldp_mgmt_ip'
+	config_get lldp_syscapabilities 'config' 'lldp_syscapabilities'
 
 	local ifaces
 	config_get ifaces 'config' 'interface'
@@ -48,88 +112,204 @@ write_lldpd_conf()
 		fi
 	done
 
-	local lldp_mgmt_ip
-	config_get lldp_mgmt_ip 'config' 'lldp_mgmt_ip'
-
-	local lldp_syscapabilities
-	config_get lldp_syscapabilities 'config' 'lldp_syscapabilities'
-
 	# Clear out the config file first
 	echo -n > "$LLDPD_CONF"
 	[ -n "$ifnames" ] && echo "configure system interface pattern" "$ifnames" >> "$LLDPD_CONF"
+	[ $lldp_tx_interval -gt 0 ] && echo "configure lldp tx-interval" "$lldp_tx_interval" >> "$LLDPD_CONF"
+	[ $lldp_tx_hold -gt 0 ] && echo "configure lldp tx-hold" "$lldp_tx_hold" >> "$LLDPD_CONF"
 	[ -n "$lldp_description" ] && echo "configure system description" "\"$lldp_description\"" >> "$LLDPD_CONF"
 	[ -n "$lldp_hostname" ] && echo "configure system hostname" "\"$lldp_hostname\"" >> "$LLDPD_CONF"
 	[ -n "$lldp_platform" ] && echo "configure system platform" "\"$lldp_platform\"" >> "$LLDPD_CONF"
 	[ -n "$lldp_mgmt_ip" ] && echo "configure system ip management pattern" "\"$lldp_mgmt_ip\"" >> "$LLDPD_CONF"
-
 	[ -n "$lldp_syscapabilities" ] && echo "configure system capabilities enabled" "\"$lldp_syscapabilities\"" >> "$LLDPD_CONF"
 	[ $lldp_fast_start -gt 0 ] echo "configure med fast-start" "enable" >> "$LLDPD_CONF"
+	[ -n "$lldp_agenttype" ] && echo "configure lldp agent-type" "\"$lldp_agenttype\"" >> "$LLDPD_CONF"
+	[ -n "$lldp_portidsubtype" ] && echo "configure lldp portidsubtype" "\"$lldp_portidsubtype\"" >> "$LLDPD_CONF"
 
 	# Since lldpd's sysconfdir is /tmp, we'll symlink /etc/lldpd.d to /tmp/$LLDPD_CONFS_DIR
 	[ -e $LLDPD_CONFS_DIR ] || ln -s /etc/lldpd.d $LLDPD_CONFS_DIR
 }
 
-service_triggers() {
-	procd_add_reload_trigger "lldpd"
-}
 
 start_service() {
-
 	local enable_cdp
 	local enable_fdp
 	local enable_sonmp
 	local enable_edp
-	local disable_lldp_med
-	local disable_advertising_software
 	local lldp_class
 	local lldp_location
+	local lldpmed_no_inventory
 	local readonly_mode
 	local agentxsocket
+	local filter
+
+	local enable_lldp
+	local force_lldp
+	local cdp_version
+	local force_cdp
+	local force_cdpv2
+	local force_edp
+	local force_fdp
+	local force_sonmp
 
 	config_load 'lldpd'
 	config_get_bool enable_cdp 'config' 'enable_cdp' 0
 	config_get_bool enable_fdp 'config' 'enable_fdp' 0
 	config_get_bool enable_sonmp 'config' 'enable_sonmp' 0
 	config_get_bool enable_edp 'config' 'enable_edp' 0
-	config_get_bool disable_lldp_med 'config' 'disable_lldp_med' 0
-	config_get_bool disable_advertising_software 'config' 'disable_advertising_software' 0
 	config_get lldp_class 'config' 'lldp_class'
 	config_get lldp_location 'config' 'lldp_location'
+	config_get_bool lldpmed_no_inventory 'config' 'lldpmed_no_inventory' 0
 	config_get_bool readonly_mode 'config' 'readonly_mode' 0
 	config_get agentxsocket 'config' 'agentxsocket'
+	config_get filter 'config' 'filter' 15
 
-	mkdir -p /var/run/lldp
-	chown lldp:lldp /var/run/lldp
+	config_get_bool enable_lldp 'config' 'enable_lldp' 1
+	config_get_bool force_lldp 'config' 'force_lldp' 0
+	config_get cdp_version 'config' 'cdp_version' 'cdpv1v2'
+	config_get_bool force_cdp 'config' 'force_cdp' 0
+	config_get_bool force_cdpv2 'config' 'force_cdpv2' 0
+	config_get_bool force_edp 'config' 'force_edp' 0
+	config_get_bool force_fdp 'config' 'force_fdp' 0
+	config_get_bool force_sonmp 'config' 'force_sonmp' 0
+
+	local readonly_mode
+	config_get_bool readonly_mode 'config' 'readonly_mode' 0
+
+	mkdir -p ${LLDPD_RUN}
+	chown lldp:lldp ${LLDPD_RUN}
 
 	# When lldpd starts, it also loads up what we write in this config file
 	write_lldpd_conf
 
 	procd_open_instance
-	procd_set_param command /usr/sbin/lldpd -d
+	procd_set_param command ${LLDPDBIN}
+	procd_append_param command -d # don't daemonize, procd will handle that for us
 
-	[ $enable_cdp -gt 0 ] && procd_append_param command "-$(printf 'c%.0s' $(seq 1 $enable_cdp))"
-	[ $enable_fdp -gt 0 ] && procd_append_param command "-$(printf 'f%.0s' $(seq 1 $enable_fdp))"
-	[ $enable_sonmp -gt 0 ] && procd_append_param command "-$(printf 's%.0s' $(seq 1 $enable_sonmp))"
-	[ $enable_edp -gt 0 ] && procd_append_param command "-$(printf 'e%.0s' $(seq 1 $enable_edp))"
-	[ $disable_lldp_med -gt 0 ] && procd_append_param command '-i'
-	[ $disable_advertising_software -gt 0 ] && procd_append_param command '-k'
+	if [ $enable_lldp -gt 0 ]; then
+		if [ $force_lldp -gt 0 ]; then
+			procd_append_param command '-l'
+		fi
+	else
+		# Disable LLDP
+		procd_append_param command '-ll'
+	fi
+
+	if [ $enable_cdp -gt 0 ]; then
+		if [ $cdp_version == "cdpv1v2" ]; then
+			if [ $force_cdp -gt 0 ]; then
+				if [ $force_cdpv2 -gt 0 ]; then
+					# CDPv1 enabled, CDPv2 forced
+					procd_append_param command '-ccc'
+				else
+					# CDPv1 forced, CDPv2 enabled
+					procd_append_param command '-cc'
+				fi
+			else
+				# CDPv1 and CDPv2 enabled
+				procd_append_param command '-c'
+			fi
+		elif [ $cdp_version == "cdpv2" ]; then
+			if [ $force_cdp -gt 0 ]; then
+				# CDPv1 disabled, CDPv2 forced
+				procd_append_param command '-ccccc'
+			else
+				# CDPv1 disabled, CDPv2 enabled
+				procd_append_param command '-cccc'
+			fi
+		fi
+	fi
+	
+	if [ $enable_fdp -gt 0 ]; then
+		if [ $force_fdp -gt 0 ]; then
+			procd_append_param command '-ff'
+		else
+			procd_append_param command '-f'
+		fi
+	fi
+
+	if [ $enable_edp -gt 0 ]; then
+		if [ $force_edp -gt 0 ]; then
+			procd_append_param command '-ee'
+		else
+			procd_append_param command '-e'
+		fi
+	fi
+
+	if [ $enable_sonmp -gt 0 ]; then
+		if [ $force_sonmp -gt 0 ]; then
+			procd_append_param command '-ss'
+		else
+			procd_append_param command '-s'
+		fi
+	fi
+
 	[ $readonly_mode -gt 0 ] && procd_append_param command '-r'
+	[ $lldpmed_no_inventory -gt 0 ] && procd_append_param command '-i'
 	[ -n "$lldp_class" ] && procd_append_param command -M "$lldp_class"
 	[ -n "$agentxsocket" ] && procd_append_param command -x -X "$agentxsocket"
+	[ -n "$filter" ] && procd_append_param command -H "$filter"
+
+	# ChassisID interfaces
+	local ifnames
+	get_config_cid_ifaces ifnames
+	[ -n "$ifnames" ] && procd_append_param command -C "$ifnames"
+
+	# Overwrite default configuration locations processed by lldpcli at start
+	procd_append_param command -O "$LLDPD_CONF"
+
+	local restart_hash
+	get_config_restart_hash restart_hash
+	echo -n "$restart_hash" > $LLDPD_RESTART_HASH
 
 	# set auto respawn behavior
 	procd_set_param respawn
 	procd_close_instance
 }
 
+service_triggers() {
+	procd_add_config_trigger "config.change" "lldpd" /etc/init.d/lldpd reload
+}
+
+lldpcli_running_config_read() {
+	json_init
+	json_load "`$LLDPCLI -f json show configuration`"
+}
+
+lldpcli_running_config_get_value() {
+	local param=$1
+	local value=""
+	json_select "configuration"
+		json_select "config"
+			json_get_var value "$param"
+		json_select ..
+	json_select ..
+	echo $value
+}
+
 reload_service() {
 	running || return 1
+
+	local running_hash=""
+	local config_hash=""
+
+	get_config_restart_hash config_hash
+	if [ -f ${LLDPD_RESTART_HASH} ]; then running_hash=`cat $LLDPD_RESTART_HASH`; fi
+
+	if [ "x$running_hash" != "x$config_hash" ]; then
+		# Restart LLDPd
+		# Some parameters can't be configured at runtime
+		restart
+		return 0
+	fi
+
 	$LLDPCLI -u $LLDPSOCKET &> /dev/null <<-EOF
 		pause
 		unconfigure lldp custom-tlv
 		unconfigure system interface pattern
 		unconfigure system description
 		unconfigure system hostname
+		unconfigure system platform
 		unconfigure system ip management pattern
 	EOF
 	# Rewrite lldpd.conf
@@ -145,5 +325,6 @@ reload_service() {
 }
 
 stop_service() {
-	rm -rf /var/run/lldp $LLDPSOCKET
+	rm -rf ${LLDPD_RUN} 2>/dev/null
 }
+


### PR DESCRIPTION
The TanoWrt fork of OpenWrt also has an lldpd package, which has a - in my eyes - better configuration file with more options. This PR would include this improved configuration file.
One difference is that in TanoWrt the user is called `lldpd` instead of `lldp` and the option to set the management IP is called differently. I have changed this accordingly - so that it works with the previous package.

Additionally I added the LLDP MED Fast Start option as well as the use of the `-k` flag, which sends less software information. (https://forum.openwrt.org/t/possibility-to-stop-sending-the-revision-in-lldpd/)

If anyone has a better idea for naming the `lldpmed_fast_start_tx_interval` option, I am open.

Thanks to @systemcrash for the help with Git!