### PR TITLE
[23.05] Revert, only for ZTE MF289F: "ipq-wifi: drop upstreamed board-2.bin" ( fixes #12886 )

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -28,19 +28,40 @@ endef
 # <https://wireless.wiki.kernel.org/en/users/drivers/ath10k/boardfiles>
 
 ALLWIFIBOARDS:= \
+	8dev_habanero \
+	8dev_jalapeno \
+	aruba_ap-365 \
 	buffalo_wxr-5950ax12 \
 	compex_wpq873 \
+	devolo_magic-2-wifi-next \
 	dynalink_dl-wrx36 \
 	edgecore_eap102 \
+	edgecore_ecw5410 \
+	edgecore_oap100 \
 	edimax_cax1800 \
+	extreme-networks_ws-ap3915i \
+	glinet_gl-a1300 \
+	glinet_gl-ap1300 \
+	glinet_gl-s1300 \
+	linksys_ea8300 \
+	linksys_whw03v2 \
 	netgear_wax218 \
 	prpl_haze \
+	nokia_ac400i \
+	p2w_r619ac \
+	pakedge_wr-1 \
 	qnap_301w \
+	qxwlan_e2600ac-c1 \
+	qxwlan_e2600ac-c2 \
 	redmi_ax6 \
+	sony_ncp-hg100-cellular \
+	teltonika_rutx \
 	wallys_dr40x9 \
 	xiaomi_ax3600 \
 	xiaomi_ax9000 \
 	zte_mf287plus \
+	zte_mf18a \
+	zte_mf289f \
 	zyxel_nbg7815
 
 ALLWIFIPACKAGES:=$(foreach BOARD,$(ALLWIFIBOARDS),ipq-wifi-$(BOARD))
@@ -115,19 +136,40 @@ endef
 # Place files in this directory as board-<devicename>.<qca4019|qca9888|qca9889|qca9984|qca99x0|ipq8074>
 # Add $(eval $(call generate-ipq-wifi-package,<devicename>,<display name>))
 
+$(eval $(call generate-ipq-wifi-package,8dev_habanero,8devices Habanero))
+$(eval $(call generate-ipq-wifi-package,8dev_jalapeno,8devices Jalapeno))
+$(eval $(call generate-ipq-wifi-package,aruba_ap-365,Aruba AP-365))
 $(eval $(call generate-ipq-wifi-package,buffalo_wxr-5950ax12,Buffalo WXR-5950AX12))
 $(eval $(call generate-ipq-wifi-package,compex_wpq873,Compex WPQ-873))
+$(eval $(call generate-ipq-wifi-package,devolo_magic-2-wifi-next,devolo Magic 2 WiFi next))
 $(eval $(call generate-ipq-wifi-package,dynalink_dl-wrx36,Dynalink DL-WRX36))
 $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
+$(eval $(call generate-ipq-wifi-package,edgecore_ecw5410,Edgecore ECW5410))
+$(eval $(call generate-ipq-wifi-package,edgecore_oap100,Edgecore OAP100))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))
+$(eval $(call generate-ipq-wifi-package,extreme-networks_ws-ap3915i,Edgecore OAP100))
+$(eval $(call generate-ipq-wifi-package,glinet_gl-a1300,GL.iNet GL-A1300))
+$(eval $(call generate-ipq-wifi-package,glinet_gl-ap1300,GL.iNet GL-AP1300))
+$(eval $(call generate-ipq-wifi-package,glinet_gl-s1300,GL.iNet GL-S1300))
+$(eval $(call generate-ipq-wifi-package,linksys_ea8300,Linksys EA8300))
+$(eval $(call generate-ipq-wifi-package,linksys_whw03v2,Linksys WHW03 V2))
 $(eval $(call generate-ipq-wifi-package,netgear_wax218,Netgear WAX218))
+$(eval $(call generate-ipq-wifi-package,nokia_ac400i,Nokia AC400i))
+$(eval $(call generate-ipq-wifi-package,p2w_r619ac,P&W R619AC))
+$(eval $(call generate-ipq-wifi-package,pakedge_wr-1,Pakedge WR-1))
 $(eval $(call generate-ipq-wifi-package,qnap_301w,QNAP 301w))
 $(eval $(call generate-ipq-wifi-package,prpl_haze,prpl Haze))
+$(eval $(call generate-ipq-wifi-package,qxwlan_e2600ac-c1,Qxwlan E2600AC C1))
+$(eval $(call generate-ipq-wifi-package,qxwlan_e2600ac-c2,Qxwlan E2600AC C2))
 $(eval $(call generate-ipq-wifi-package,redmi_ax6,Redmi AX6))
+$(eval $(call generate-ipq-wifi-package,sony_ncp-hg100-cellular,Sony NCP-HG100/Cellular))
+$(eval $(call generate-ipq-wifi-package,teltonika_rutx,Teltonika RUTX))
 $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax3600,Xiaomi AX3600))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax9000,Xiaomi AX9000))
 $(eval $(call generate-ipq-wifi-package,zte_mf287plus,ZTE MF287Plus))
+$(eval $(call generate-ipq-wifi-package,zte_mf18a,ZTE MF18A))
+$(eval $(call generate-ipq-wifi-package,zte_mf289f,ZTE MF289F))
 $(eval $(call generate-ipq-wifi-package,zyxel_nbg7815,Zyxel NBG7815))
 
 $(foreach PACKAGE,$(ALLWIFIPACKAGES),$(eval $(call BuildPackage,$(PACKAGE))))

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -28,39 +28,19 @@ endef
 # <https://wireless.wiki.kernel.org/en/users/drivers/ath10k/boardfiles>
 
 ALLWIFIBOARDS:= \
-	8dev_habanero \
-	8dev_jalapeno \
-	aruba_ap-365 \
 	buffalo_wxr-5950ax12 \
 	compex_wpq873 \
-	devolo_magic-2-wifi-next \
 	dynalink_dl-wrx36 \
 	edgecore_eap102 \
-	edgecore_ecw5410 \
-	edgecore_oap100 \
 	edimax_cax1800 \
-	extreme-networks_ws-ap3915i \
-	glinet_gl-a1300 \
-	glinet_gl-ap1300 \
-	glinet_gl-s1300 \
-	linksys_ea8300 \
-	linksys_whw03v2 \
 	netgear_wax218 \
 	prpl_haze \
-	nokia_ac400i \
-	p2w_r619ac \
-	pakedge_wr-1 \
 	qnap_301w \
-	qxwlan_e2600ac-c1 \
-	qxwlan_e2600ac-c2 \
 	redmi_ax6 \
-	sony_ncp-hg100-cellular \
-	teltonika_rutx \
 	wallys_dr40x9 \
 	xiaomi_ax3600 \
 	xiaomi_ax9000 \
 	zte_mf287plus \
-	zte_mf18a \
 	zte_mf289f \
 	zyxel_nbg7815
 
@@ -136,39 +116,19 @@ endef
 # Place files in this directory as board-<devicename>.<qca4019|qca9888|qca9889|qca9984|qca99x0|ipq8074>
 # Add $(eval $(call generate-ipq-wifi-package,<devicename>,<display name>))
 
-$(eval $(call generate-ipq-wifi-package,8dev_habanero,8devices Habanero))
-$(eval $(call generate-ipq-wifi-package,8dev_jalapeno,8devices Jalapeno))
-$(eval $(call generate-ipq-wifi-package,aruba_ap-365,Aruba AP-365))
 $(eval $(call generate-ipq-wifi-package,buffalo_wxr-5950ax12,Buffalo WXR-5950AX12))
 $(eval $(call generate-ipq-wifi-package,compex_wpq873,Compex WPQ-873))
-$(eval $(call generate-ipq-wifi-package,devolo_magic-2-wifi-next,devolo Magic 2 WiFi next))
 $(eval $(call generate-ipq-wifi-package,dynalink_dl-wrx36,Dynalink DL-WRX36))
 $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
-$(eval $(call generate-ipq-wifi-package,edgecore_ecw5410,Edgecore ECW5410))
-$(eval $(call generate-ipq-wifi-package,edgecore_oap100,Edgecore OAP100))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))
-$(eval $(call generate-ipq-wifi-package,extreme-networks_ws-ap3915i,Edgecore OAP100))
-$(eval $(call generate-ipq-wifi-package,glinet_gl-a1300,GL.iNet GL-A1300))
-$(eval $(call generate-ipq-wifi-package,glinet_gl-ap1300,GL.iNet GL-AP1300))
-$(eval $(call generate-ipq-wifi-package,glinet_gl-s1300,GL.iNet GL-S1300))
-$(eval $(call generate-ipq-wifi-package,linksys_ea8300,Linksys EA8300))
-$(eval $(call generate-ipq-wifi-package,linksys_whw03v2,Linksys WHW03 V2))
 $(eval $(call generate-ipq-wifi-package,netgear_wax218,Netgear WAX218))
-$(eval $(call generate-ipq-wifi-package,nokia_ac400i,Nokia AC400i))
-$(eval $(call generate-ipq-wifi-package,p2w_r619ac,P&W R619AC))
-$(eval $(call generate-ipq-wifi-package,pakedge_wr-1,Pakedge WR-1))
 $(eval $(call generate-ipq-wifi-package,qnap_301w,QNAP 301w))
 $(eval $(call generate-ipq-wifi-package,prpl_haze,prpl Haze))
-$(eval $(call generate-ipq-wifi-package,qxwlan_e2600ac-c1,Qxwlan E2600AC C1))
-$(eval $(call generate-ipq-wifi-package,qxwlan_e2600ac-c2,Qxwlan E2600AC C2))
 $(eval $(call generate-ipq-wifi-package,redmi_ax6,Redmi AX6))
-$(eval $(call generate-ipq-wifi-package,sony_ncp-hg100-cellular,Sony NCP-HG100/Cellular))
-$(eval $(call generate-ipq-wifi-package,teltonika_rutx,Teltonika RUTX))
 $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax3600,Xiaomi AX3600))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax9000,Xiaomi AX9000))
 $(eval $(call generate-ipq-wifi-package,zte_mf287plus,ZTE MF287Plus))
-$(eval $(call generate-ipq-wifi-package,zte_mf18a,ZTE MF18A))
 $(eval $(call generate-ipq-wifi-package,zte_mf289f,ZTE MF289F))
 $(eval $(call generate-ipq-wifi-package,zyxel_nbg7815,Zyxel NBG7815))
 

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -132,6 +132,7 @@ define Device/8dev_habanero-dvk
 	IMAGE_SIZE := 30976k
 	SOC := qcom-ipq4019
 	IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-rootfs | pad-rootfs | check-size | append-metadata
+	DEVICE_PACKAGES := ipq-wifi-8dev_habanero
 endef
 TARGET_DEVICES += 8dev_habanero-dvk
 
@@ -141,6 +142,7 @@ define Device/8dev_jalapeno-common
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	SOC := qcom-ipq4018
+	DEVICE_PACKAGES := ipq-wifi-8dev_jalapeno
 endef
 
 define Device/8dev_jalapeno
@@ -186,7 +188,7 @@ TARGET_DEVICES += aruba_ap-303h
 define Device/aruba_ap-365
 	$(call Device/aruba_glenmorangie)
 	DEVICE_MODEL := AP-365
-	DEVICE_PACKAGES := kmod-hwmon-ad7418
+	DEVICE_PACKAGES := kmod-hwmon-ad7418 ipq-wifi-aruba_ap-365
 endef
 TARGET_DEVICES += aruba_ap-365
 
@@ -385,6 +387,7 @@ define Device/devolo_magic-2-wifi-next
 	IMAGE_SIZE := 26624k
 	IMAGES := sysupgrade.bin
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
+	DEVICE_PACKAGES := ipq-wifi-devolo_magic-2-wifi-next
 	DEFAULT := n
 endef
 # Missing DSA Setup
@@ -439,7 +442,7 @@ define Device/edgecore_oap100
 	PAGESIZE := 2048
 	IMAGES := sysupgrade.bin
 	DEVICE_DTS_CONFIG := config@ap.dk07.1-c1
-	DEVICE_PACKAGES := kmod-usb-acm kmod-usb-net kmod-usb-net-cdc-qmi uqmi
+	DEVICE_PACKAGES := ipq-wifi-edgecore_oap100 kmod-usb-acm kmod-usb-net kmod-usb-net-cdc-qmi uqmi
 endef
 # Missing DSA Setup
 #TARGET_DEVICES += edgecore_oap100
@@ -536,6 +539,7 @@ define Device/extreme-networks_ws-ap3915i
 	SOC := qcom-ipq4029
 	BLOCKSIZE := 128k
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | check-size | append-metadata
+	DEVICE_PACKAGES := ipq-wifi-extreme-networks_ws-ap3915i
 endef
 TARGET_DEVICES += extreme-networks_ws-ap3915i
 
@@ -566,6 +570,7 @@ define Device/glinet_gl-a1300
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	IMAGE_SIZE := 131072k
+	DEVICE_PACKAGE := ipq-wifi-glinet_gl-a1300
 endef
 TARGET_DEVICES += glinet_gl-a1300
 
@@ -580,7 +585,7 @@ define Device/glinet_gl-ap1300
 	PAGESIZE := 2048
 	IMAGE_SIZE := 131072k
 	KERNEL_INSTALL := 1
-	DEVICE_PACKAGES := kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+	DEVICE_PACKAGES := ipq-wifi-glinet_gl-ap1300 kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
 endef
 TARGET_DEVICES += glinet_gl-ap1300
 
@@ -623,7 +628,7 @@ define Device/glinet_gl-s1300
 	IMAGE_SIZE := 26624k
 	IMAGES := sysupgrade.bin
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
-	DEVICE_PACKAGES := kmod-fs-ext4 kmod-mmc kmod-spi-dev
+	DEVICE_PACKAGES := ipq-wifi-glinet_gl-s1300 kmod-fs-ext4 kmod-mmc kmod-spi-dev
 endef
 # Missing DSA Setup
 #TARGET_DEVICES += glinet_gl-s1300
@@ -690,7 +695,7 @@ define Device/linksys_ea8300
 	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
 	IMAGES += factory.bin
 	IMAGE/factory.bin  := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=EA8300
-	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct kmod-usb-ledtrig-usbport
+	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct ipq-wifi-linksys_ea8300 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += linksys_ea8300
 
@@ -724,7 +729,7 @@ define Device/linksys_whw03v2
 	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
 	IMAGES += factory.bin
 	IMAGE/factory.bin  := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=WHW03v2
-	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct kmod-leds-pca963x kmod-spi-dev kmod-bluetooth
+	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct ipq-wifi-linksys_whw03v2 kmod-leds-pca963x kmod-spi-dev kmod-bluetooth
 endef
 TARGET_DEVICES += linksys_whw03v2
 
@@ -930,6 +935,7 @@ define Device/p2w_r619ac
 	DEVICE_DTS_CONFIG := config@10
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
+	DEVICE_PACKAGES := ipq-wifi-p2w_r619ac
 endef
 
 define Device/p2w_r619ac-64m
@@ -951,6 +957,7 @@ define Device/pakedge_wr-1
 	DEVICE_VENDOR := Pakedge
 	DEVICE_MODEL := WR-1
 	DEVICE_DTS_CONFIG := config@ap.dk01.1-c1
+	DEVICE_PACKAGES := ipq-wifi-pakedge_wr-1
 	SOC := qcom-ipq4018
 	BLOCKSIZE := 64k
 	IMAGE_SIZE := 31232k
@@ -1031,6 +1038,7 @@ define Device/qxwlan_e2600ac-c1
 	SOC := qcom-ipq4019
 	IMAGE_SIZE := 31232k
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
+	DEVICE_PACKAGES := ipq-wifi-qxwlan_e2600ac-c1
 endef
 TARGET_DEVICES += qxwlan_e2600ac-c1
 
@@ -1044,6 +1052,7 @@ define Device/qxwlan_e2600ac-c2
 	KERNEL_INSTALL := 1
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
+	DEVICE_PACKAGES := ipq-wifi-qxwlan_e2600ac-c2
 endef
 TARGET_DEVICES += qxwlan_e2600ac-c2
 
@@ -1055,7 +1064,8 @@ define Device/sony_ncp-hg100-cellular
 	SOC := qcom-ipq4019
 	KERNEL_SIZE := 8192k
 	IMAGE_SIZE := 128m
-	DEVICE_PACKAGES := e2fsprogs kmod-fs-ext4 uqmi
+	DEVICE_PACKAGES := e2fsprogs ipq-wifi-sony_ncp-hg100-cellular \
+		kmod-fs-ext4 uqmi
 endef
 TARGET_DEVICES += sony_ncp-hg100-cellular
 
@@ -1071,7 +1081,7 @@ define Device/teltonika_rutx10
 	PAGESIZE := 2048
 	FILESYSTEMS := squashfs
 	IMAGE/factory.ubi := append-ubi | qsdk-ipq-factory-nand | append-rutx-metadata
-	DEVICE_PACKAGES := kmod-bluetooth
+	DEVICE_PACKAGES := ipq-wifi-teltonika_rutx kmod-bluetooth
 endef
 # Missing DSA Setup
 #TARGET_DEVICES += teltonika_rutx10
@@ -1127,7 +1137,7 @@ define Device/zte_mf18a
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	KERNEL_IN_UBI := 1
-	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct ipq-wifi-zte_mf18a
 endef
 TARGET_DEVICES += zte_mf18a
 
@@ -1169,7 +1179,7 @@ TARGET_DEVICES += zte_mf287plus
 define Device/zte_mf289f
 	$(call Device/zte_mf28x_common)
 	DEVICE_MODEL := MF289F
-	DEVICE_PACKAGES += ath10k-firmware-qca9984-ct
+	DEVICE_PACKAGES += ipq-wifi-zte_mf289f ath10k-firmware-qca9984-ct
 endef
 TARGET_DEVICES += zte_mf289f
 

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -132,7 +132,6 @@ define Device/8dev_habanero-dvk
 	IMAGE_SIZE := 30976k
 	SOC := qcom-ipq4019
 	IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-rootfs | pad-rootfs | check-size | append-metadata
-	DEVICE_PACKAGES := ipq-wifi-8dev_habanero
 endef
 TARGET_DEVICES += 8dev_habanero-dvk
 
@@ -142,7 +141,6 @@ define Device/8dev_jalapeno-common
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	SOC := qcom-ipq4018
-	DEVICE_PACKAGES := ipq-wifi-8dev_jalapeno
 endef
 
 define Device/8dev_jalapeno
@@ -188,7 +186,7 @@ TARGET_DEVICES += aruba_ap-303h
 define Device/aruba_ap-365
 	$(call Device/aruba_glenmorangie)
 	DEVICE_MODEL := AP-365
-	DEVICE_PACKAGES := kmod-hwmon-ad7418 ipq-wifi-aruba_ap-365
+	DEVICE_PACKAGES := kmod-hwmon-ad7418
 endef
 TARGET_DEVICES += aruba_ap-365
 
@@ -387,7 +385,6 @@ define Device/devolo_magic-2-wifi-next
 	IMAGE_SIZE := 26624k
 	IMAGES := sysupgrade.bin
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
-	DEVICE_PACKAGES := ipq-wifi-devolo_magic-2-wifi-next
 	DEFAULT := n
 endef
 # Missing DSA Setup
@@ -442,7 +439,7 @@ define Device/edgecore_oap100
 	PAGESIZE := 2048
 	IMAGES := sysupgrade.bin
 	DEVICE_DTS_CONFIG := config@ap.dk07.1-c1
-	DEVICE_PACKAGES := ipq-wifi-edgecore_oap100 kmod-usb-acm kmod-usb-net kmod-usb-net-cdc-qmi uqmi
+	DEVICE_PACKAGES := kmod-usb-acm kmod-usb-net kmod-usb-net-cdc-qmi uqmi
 endef
 # Missing DSA Setup
 #TARGET_DEVICES += edgecore_oap100
@@ -539,7 +536,6 @@ define Device/extreme-networks_ws-ap3915i
 	SOC := qcom-ipq4029
 	BLOCKSIZE := 128k
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | check-size | append-metadata
-	DEVICE_PACKAGES := ipq-wifi-extreme-networks_ws-ap3915i
 endef
 TARGET_DEVICES += extreme-networks_ws-ap3915i
 
@@ -570,7 +566,6 @@ define Device/glinet_gl-a1300
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	IMAGE_SIZE := 131072k
-	DEVICE_PACKAGE := ipq-wifi-glinet_gl-a1300
 endef
 TARGET_DEVICES += glinet_gl-a1300
 
@@ -585,7 +580,7 @@ define Device/glinet_gl-ap1300
 	PAGESIZE := 2048
 	IMAGE_SIZE := 131072k
 	KERNEL_INSTALL := 1
-	DEVICE_PACKAGES := ipq-wifi-glinet_gl-ap1300 kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+	DEVICE_PACKAGES := kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
 endef
 TARGET_DEVICES += glinet_gl-ap1300
 
@@ -628,7 +623,7 @@ define Device/glinet_gl-s1300
 	IMAGE_SIZE := 26624k
 	IMAGES := sysupgrade.bin
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
-	DEVICE_PACKAGES := ipq-wifi-glinet_gl-s1300 kmod-fs-ext4 kmod-mmc kmod-spi-dev
+	DEVICE_PACKAGES := kmod-fs-ext4 kmod-mmc kmod-spi-dev
 endef
 # Missing DSA Setup
 #TARGET_DEVICES += glinet_gl-s1300
@@ -695,7 +690,7 @@ define Device/linksys_ea8300
 	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
 	IMAGES += factory.bin
 	IMAGE/factory.bin  := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=EA8300
-	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct ipq-wifi-linksys_ea8300 kmod-usb-ledtrig-usbport
+	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += linksys_ea8300
 
@@ -729,7 +724,7 @@ define Device/linksys_whw03v2
 	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
 	IMAGES += factory.bin
 	IMAGE/factory.bin  := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=WHW03v2
-	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct ipq-wifi-linksys_whw03v2 kmod-leds-pca963x kmod-spi-dev kmod-bluetooth
+	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct kmod-leds-pca963x kmod-spi-dev kmod-bluetooth
 endef
 TARGET_DEVICES += linksys_whw03v2
 
@@ -935,7 +930,6 @@ define Device/p2w_r619ac
 	DEVICE_DTS_CONFIG := config@10
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
-	DEVICE_PACKAGES := ipq-wifi-p2w_r619ac
 endef
 
 define Device/p2w_r619ac-64m
@@ -957,7 +951,6 @@ define Device/pakedge_wr-1
 	DEVICE_VENDOR := Pakedge
 	DEVICE_MODEL := WR-1
 	DEVICE_DTS_CONFIG := config@ap.dk01.1-c1
-	DEVICE_PACKAGES := ipq-wifi-pakedge_wr-1
 	SOC := qcom-ipq4018
 	BLOCKSIZE := 64k
 	IMAGE_SIZE := 31232k
@@ -1038,7 +1031,6 @@ define Device/qxwlan_e2600ac-c1
 	SOC := qcom-ipq4019
 	IMAGE_SIZE := 31232k
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
-	DEVICE_PACKAGES := ipq-wifi-qxwlan_e2600ac-c1
 endef
 TARGET_DEVICES += qxwlan_e2600ac-c1
 
@@ -1052,7 +1044,6 @@ define Device/qxwlan_e2600ac-c2
 	KERNEL_INSTALL := 1
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
-	DEVICE_PACKAGES := ipq-wifi-qxwlan_e2600ac-c2
 endef
 TARGET_DEVICES += qxwlan_e2600ac-c2
 
@@ -1064,8 +1055,7 @@ define Device/sony_ncp-hg100-cellular
 	SOC := qcom-ipq4019
 	KERNEL_SIZE := 8192k
 	IMAGE_SIZE := 128m
-	DEVICE_PACKAGES := e2fsprogs ipq-wifi-sony_ncp-hg100-cellular \
-		kmod-fs-ext4 uqmi
+	DEVICE_PACKAGES := e2fsprogs kmod-fs-ext4 uqmi
 endef
 TARGET_DEVICES += sony_ncp-hg100-cellular
 
@@ -1081,7 +1071,7 @@ define Device/teltonika_rutx10
 	PAGESIZE := 2048
 	FILESYSTEMS := squashfs
 	IMAGE/factory.ubi := append-ubi | qsdk-ipq-factory-nand | append-rutx-metadata
-	DEVICE_PACKAGES := ipq-wifi-teltonika_rutx kmod-bluetooth
+	DEVICE_PACKAGES := kmod-bluetooth
 endef
 # Missing DSA Setup
 #TARGET_DEVICES += teltonika_rutx10
@@ -1137,7 +1127,7 @@ define Device/zte_mf18a
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	KERNEL_IN_UBI := 1
-	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct ipq-wifi-zte_mf18a
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct
 endef
 TARGET_DEVICES += zte_mf18a
 

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -358,7 +358,7 @@ define Device/nokia_ac400i
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	BOARD_NAME := ac400i
-	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct ipq-wifi-nokia-ac400i
+	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct
 endef
 TARGET_DEVICES += nokia_ac400i
 

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -358,7 +358,7 @@ define Device/nokia_ac400i
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	BOARD_NAME := ac400i
-	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct
+	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct ipq-wifi-nokia-ac400i
 endef
 TARGET_DEVICES += nokia_ac400i
 


### PR DESCRIPTION
This pull request fixes #12886.
The original commit 8217f02a1c5e2396f083793575de2e79811842e8 had removed support for ZTE MF289F 2.4GHz wifi and it did not intend to. I reverted and then reapplied it correctly, making the 2.4GHz wifi on the ZTE device usable again.