### PR TITLE
kernel: fix KernelPackage when all KCONFIG are versioned

### DIFF
--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -236,7 +236,7 @@ $(call KernelPackage/$(1)/config)
   $(call KernelPackage/depends)
   $(call KernelPackage/hooks)
 
-  ifneq ($(if $(filter-out %=y %=n %=m,$(KCONFIG)),$(filter m y,$(foreach c,$(filter-out %=y %=n %=m,$(KCONFIG)),$($(c)))),.),)
+  ifneq ($(if $(filter-out %=y %=n %=m,$(KCONFIG)),$(filter m y,$(foreach c,$(call version_filter,$(filter-out %=y %=n %=m,$(KCONFIG))),$($(c)))),.),)
     define Package/kmod-$(1)/install
 		  @for mod in $$(call version_filter,$$(FILES)); do \
 			if grep -q "$$$$$$$${mod##$(LINUX_DIR)/}" "$(LINUX_DIR)/modules.builtin"; then \


### PR DESCRIPTION
If a kernel package was defined where all KCONFIG symbols were dynamic, and versioned, no FILES would be installed, as the foreach evaluation was providing the value of the variable defined by the KCONFIG symbol name including the version test

Fix this by calling the version_filter function on the list of KCONFIG variable names run through by foreach

Example, kernel 6.1:
KCONFIG:=CONFIG_OLD@lt6.1 CONFIG_NEW@ge6.1
filter-out any KCONFIG settings forced by package: CONFIG_OLD@lt6.1 CONFIG_NEW@ge6.1
there are dynamic settings, so for each of them,
get the value of the make variable defined by symbol name:
    CONFIG_OLD@lt6.1 is not set
    CONFIG_NEW@ge6.1 is not set
  versus
    CONFIG_OLD is not set
    CONFIG_NEW=m
test if any of these are m, or y
if yes, install files, otherwise, nothing to install

---

This was found in the process of updating kernel to 6.1.36, where a `KCONFIG` symbol had been renamed: https://github.com/openwrt/openwrt/pull/12996#issuecomment-1612814252

I am not especially literate with Makefiles, so would appreciate someone double-checking my logic and fix

Cheers!