### PR TITLE
rockchip: add FriendlyARM NanoPC T4 support

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -74,6 +74,13 @@ define U-Boot/rk3399/Default
   ATF:=rk3399_bl31.elf
 endef
 
+define U-Boot/nanopc-t4-rk3399
+  $(U-Boot/rk3399/Default)
+  NAME:=NanoPC T4
+  BUILD_DEVICES:= \
+    friendlyarm_nanopc-t4
+endef
+
 define U-Boot/nanopi-r4s-rk3399
   $(U-Boot/rk3399/Default)
   NAME:=NanoPi R4S
@@ -96,6 +103,7 @@ define U-Boot/rockpro64-rk3399
 endef
 
 UBOOT_TARGETS := \
+  nanopc-t4-rk3399 \
   nanopi-r4s-rk3399 \
   rock-pi-4-rk3399 \
   rockpro64-rk3399 \

--- a/target/linux/rockchip/Makefile
+++ b/target/linux/rockchip/Makefile
@@ -16,7 +16,7 @@ endef
 
 include $(INCLUDE_DIR)/target.mk
 
-DEFAULT_PACKAGES += uboot-envtools partx-utils e2fsprogs mkf2fs kmod-gpio-button-hotplug
+DEFAULT_PACKAGES += uboot-envtools partx-utils e2fsprogs mkf2fs
 
 KERNELNAME:=Image dtbs
 

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -12,15 +12,24 @@ define Device/firefly_roc-rk3328-cc
   DEVICE_DTS := rockchip/rk3328-roc-cc
   UBOOT_DEVICE_NAME := roc-cc-rk3328
   IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
+  DEVICE_PACKAGES := kmod-gpio-button-hotplug
 endef
 TARGET_DEVICES += firefly_roc-rk3328-cc
+
+define Device/friendlyarm_nanopc-t4
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPC T4
+  SOC := rk3399
+  IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
+endef
+TARGET_DEVICES += friendlyarm_nanopc-t4
 
 define Device/friendlyarm_nanopi-r2c
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R2C
   SOC := rk3328
   IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
-  DEVICE_PACKAGES := kmod-usb-net-rtl8152
+  DEVICE_PACKAGES := kmod-usb-net-rtl8152 kmod-gpio-button-hotplug
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r2c
 
@@ -29,7 +38,7 @@ define Device/friendlyarm_nanopi-r2s
   DEVICE_MODEL := NanoPi R2S
   SOC := rk3328
   IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
-  DEVICE_PACKAGES := kmod-usb-net-rtl8152
+  DEVICE_PACKAGES := kmod-usb-net-rtl8152 kmod-gpio-button-hotplug
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r2s
 
@@ -39,7 +48,7 @@ define Device/friendlyarm_nanopi-r4s
   DEVICE_VARIANT := 4GB LPDDR4
   SOC := rk3399
   IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
-  DEVICE_PACKAGES := kmod-r8169
+  DEVICE_PACKAGES := kmod-r8169 kmod-gpio-button-hotplug
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r4s
 
@@ -48,6 +57,7 @@ define Device/pine64_rockpro64
   DEVICE_MODEL := RockPro64
   SOC := rk3399
   IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
+  DEVICE_PACKAGES := kmod-gpio-button-hotplug
 endef
 TARGET_DEVICES += pine64_rockpro64
 
@@ -58,6 +68,7 @@ define Device/radxa_rock-pi-4a
   SUPPORTED_DEVICES := radxa,rockpi4a radxa,rockpi4
   UBOOT_DEVICE_NAME := rock-pi-4-rk3399
   IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
+  DEVICE_PACKAGES := kmod-gpio-button-hotplug
 endef
 TARGET_DEVICES += radxa_rock-pi-4a
 
@@ -66,7 +77,7 @@ define Device/xunlong_orangepi-r1-plus
   DEVICE_MODEL := Orange Pi R1 Plus
   SOC := rk3328
   IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
-  DEVICE_PACKAGES := kmod-usb-net-rtl8152
+  DEVICE_PACKAGES := kmod-usb-net-rtl8152 kmod-gpio-button-hotplug
 endef
 TARGET_DEVICES += xunlong_orangepi-r1-plus
 
@@ -75,6 +86,6 @@ define Device/xunlong_orangepi-r1-plus-lts
   DEVICE_MODEL := Orange Pi R1 Plus LTS
   SOC := rk3328
   IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
-  DEVICE_PACKAGES := kmod-usb-net-rtl8152
+  DEVICE_PACKAGES := kmod-usb-net-rtl8152 kmod-gpio-button-hotplug
 endef
 TARGET_DEVICES += xunlong_orangepi-r1-plus-lts


### PR DESCRIPTION
Hardware
--------
RockChip RK3399 ARM64 (6 cores)
4GB LPDDR3 RAM
1x 1000 Base-T
1 GPIO LED (status)
HDMI 2.0
3.5mm TRRS AV jack
Micro-SD slot
16GB eMMC
1x USB 3.0 Port
2x USB 2.0 Port
1x USB Type-C Port
1x M.2 PCI-E Port
AP6356S (BCM4356) SDIO WiFi & Bluetooth adapter
--------
Note: AP6356S is not supported yet due to the lack of firmware and NVRAM

Tested on NanoPC-T4 by me.
NanoPC-T4 only have a adc-button, kmod-gpio-button-hotplug will cause a kernel panic, so remove it.