### PR TITLE
ath79: fix broken 02_network script

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -749,7 +749,7 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_text board_data 0x480)
 		label_mac=$wan_mac
 		;;
-	comfast,cf-e380ac-v2|\	
+	comfast,cf-e380ac-v2|\
 	netgear,wndr3700|\
 	netgear,wndr3700-v2|\
 	netgear,wndr3800|\


### PR DESCRIPTION
Script was broken by an extraneous space. 935a63c59d634ee384635003391b65399097f683

@joaohcca @hauke For the COMFAST CF-E380AC v2, it will probably be good to check that the script behaves as intended because it probably was not running at all before.