### PR TITLE
kernel: package jc42, max6697, and i2c-mux-reg

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -369,6 +369,21 @@ endef
 $(eval $(call KernelPackage,hwmon-max6642))
 
 
+define KernelPackage/hwmon-max6697
+  TITLE:=MAX6697 monitoring support
+  KCONFIG:=CONFIG_SENSORS_MAX6697
+  FILES:=$(LINUX_DIR)/drivers/hwmon/max6697.ko
+  AUTOLOAD:=$(call AutoProbe,max6697)
+  $(call AddDepends/hwmon,+kmod-i2c-core)
+endef
+
+define KernelPackage/hwmon-max6697/description
+ Kernel module for Maxim MAX6697 temperature monitor
+endef
+
+$(eval $(call KernelPackage,hwmon-max6697))
+
+
 define KernelPackage/hwmon-mcp3021
   TITLE:=MCP3021/3221 monitoring support
   KCONFIG:=CONFIG_SENSORS_MCP3021

--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -217,6 +217,21 @@ endef
 $(eval $(call KernelPackage,hwmon-it87))
 
 
+define KernelPackage/hwmon-jc42
+  TITLE:=Jedec JC42.4 compliant temperature sensors support
+  KCONFIG:=CONFIG_SENSORS_JC42
+  FILES:=$(LINUX_DIR)/drivers/hwmon/jc42.ko
+  AUTOLOAD:=$(call AutoProbe,jc42)
+  $(call AddDepends/hwmon,+kmod-i2c-core +kmod-regmap-i2c)
+endef
+
+define KernelPackage/hwmon-jc42/description
+ Kernel module for Jedec JC42.4 compliant temperature sensors
+endef
+
+$(eval $(call KernelPackage,hwmon-jc42))
+
+
 define KernelPackage/hwmon-lm63
   TITLE:=LM63/64 monitoring support
   KCONFIG:=CONFIG_SENSORS_LM63

--- a/package/kernel/linux/modules/i2c.mk
+++ b/package/kernel/linux/modules/i2c.mk
@@ -200,6 +200,22 @@ endef
 $(eval $(call KernelPackage,i2c-mux-gpio))
 
 
+I2C_MUX_REG_MODULES:= \
+  CONFIG_I2C_MUX_REG:drivers/i2c/muxes/i2c-mux-reg
+
+define KernelPackage/i2c-mux-reg
+  $(call i2c_defaults,$(I2C_MUX_REG_MODULES),51)
+  TITLE:=Register-based I2C mux/switches
+  DEPENDS:=+kmod-i2c-mux
+endef
+
+define KernelPackage/i2c-mux-reg/description
+ Kernel modules for register-based I2C bus mux/switching devices
+endef
+
+$(eval $(call KernelPackage,i2c-mux-reg))
+
+
 I2C_MUX_PCA9541_MODULES:= \
   CONFIG_I2C_MUX_PCA9541:drivers/i2c/muxes/i2c-mux-pca9541
 


### PR DESCRIPTION
These packages are needed for our work on [Cisco vEdge 1000](https://openwrt.org/inbox/toh/cisco/vedge_1000).