### PR TITLE
bmips: bcm6328: add Innacomm W3400V6

### DIFF
--- a/target/linux/bmips/bcm6328/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6328/base-files/etc/board.d/02_network
@@ -11,6 +11,7 @@ arcadyan,ar7516)
 	;;
 comtrend,ar-5381u |\
 comtrend,ar-5387un |\
+innacomm,w3400v6 |\
 nucom,r5010unv2)
 	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"

--- a/target/linux/bmips/dts/bcm6328-innacomm-w3400v6.dts
+++ b/target/linux/bmips/dts/bcm6328-innacomm-w3400v6.dts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6328.dtsi"
+
+/ {
+	model = "Innacomm W3400V6";
+	compatible = "innacomm,w3400v6", "brcm,bcm6328";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	bcm4318-sprom {
+		compatible = "brcm,bcma-sprom";
+
+		pci-bus = <1>;
+		pci-dev = <0>;
+
+		nvmem-cells = <&macaddr_cfe_6a0 1>;
+		nvmem-cell-names = "mac-address";
+
+		brcm,sprom = "brcm/bcm4318-sprom.bin";
+	};
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cfe_6a0 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&hsspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <16666667>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x000000 0x010000>;
+				label = "cfe";
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_cfe_6a0: macaddr@6a0 {
+						compatible = "mac-base";
+						reg = <0x6a0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@10000 {
+				compatible = "brcm,bcm963xx-imagetag";
+				reg = <0x010000 0x7e0000>;
+				label = "firmware";
+			};
+
+			partition@7f0000 {
+				reg = <0x7f0000 0x010000>;
+				label = "nvram";
+			};
+		};
+	};
+};
+
+&leds {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_leds>;
+
+	led@1 {
+		reg = <1>;
+		active-low;
+		label = "green:internet";
+	};
+
+	led@2 {
+		reg = <2>;
+		active-low;
+		label = "red:internet";
+	};
+
+	led@3 {
+		reg = <3>;
+		active-low;
+		label = "green:dsl";
+	};
+
+	led_power_green: led@4 {
+		reg = <4>;
+		active-low;
+		label = "green:power";
+		default-state = "on";
+	};
+
+	led_power_red: led@5 {
+		reg = <5>;
+		active-low;
+		label = "red:power";
+		panic-indicator;
+	};
+
+	led@11 {
+		reg = <11>;
+		active-low;
+		label = "green:wps";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pinctrl {
+	pinctrl_leds: leds {
+		function = "led";
+		pins = "gpio1", "gpio2", "gpio3",
+		       "gpio4", "gpio5", "gpio11";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			reg = <0>;
+			label = "lan4";
+
+			phy-handle = <&phy1>;
+			phy-mode = "mii";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan3";
+
+			phy-handle = <&phy2>;
+			phy-mode = "mii";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan2";
+
+			phy-handle = <&phy3>;
+			phy-mode = "mii";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan1";
+
+			phy-handle = <&phy4>;
+			phy-mode = "mii";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/target/linux/bmips/image/bcm6328.mk
+++ b/target/linux/bmips/image/bcm6328.mk
@@ -39,6 +39,18 @@ define Device/comtrend_ar-5387un
 endef
 TARGET_DEVICES += comtrend_ar-5387un
 
+define Device/innacomm_w3400v6
+  $(Device/bcm63xx-cfe)
+  DEVICE_VENDOR := Innacomm
+  DEVICE_MODEL := W3400V6
+  CHIP_ID := 6328
+  CFE_BOARD_ID := 96328ang
+  FLASH_MB := 8
+  DEVICE_PACKAGES += $(B43_PACKAGES) \
+    broadcom-4318-sprom kmod-leds-bcm6328
+endef
+TARGET_DEVICES += innacomm_w3400v6
+
 define Device/nucom_r5010unv2
   $(Device/bcm63xx-cfe)
   DEVICE_VENDOR := NuCom


### PR DESCRIPTION
Innacomm W3400V6 is an xDSL B/G wireless router based on Broadcom BCM6328 SoC.

SoC: Broadcom BCM6328
CPU: BMIPS4350 V8.0, 320 MHz, 1 core
Flash: SPI-NOR 8MB, MX25L6406E
RAM: 64 MB
Ethernet: 4x 10/100 Mbps
Switch: Integrated
Wireless: 802.11b/g, BCM4312
LEDs/Buttons: 9x / 2x

Flash instruction, web UI:
1. Set a static IP on your computer compatible with 192.168.1.1, i.e 192.168.1.100.
2. Connect the ethernet cable from your computer to the router.
3. Make sure the router is powered off.
4. Press the reset button, don't release it yet!
5. While pressing reset, power on the router.
6. Wait 10 seconds or more. Note: The power LED is red at first then turns to solid green when ready.
7. Release the reset button.
8. Browse to 192.168.1.1
9. Select .bin file.
10. Upgrade the image.
11. Wait for it to reboot.

