### PR TITLE
ath79: move ubnt-xm 64M RAM boards back to generic

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -497,7 +497,9 @@ ubnt,bullet-m-xw|\
 ubnt,nanostation-loco-m-xw|\
 ubnt,nanostation-m-xw|\
 ubnt,powerbeam-m2-xw|\
-ubnt,powerbeam-m5-xw)
+ubnt,powerbeam-m5-xw|\
+ubnt,powerbridge-m|\
+ubnt,rocket-m)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "red:link1" "wlan0" "1" "100"
 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "orange:link2" "wlan0" "26" "100"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -111,7 +111,9 @@ ath79_setup_interfaces()
 	ubnt,powerbeam-5ac-gen2|\
 	ubnt,powerbeam-m2-xw|\
 	ubnt,powerbeam-m5-xw|\
+	ubnt,powerbridge-m|\
 	ubnt,rocket-5ac-lite|\
+	ubnt,rocket-m|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-lr|\
 	ubnt,unifiac-mesh|\
@@ -794,6 +796,8 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_text mac 0x18)
 		label_mac=$wan_mac
 		;;
+	ubnt,powerbridge-m|\
+	ubnt,rocket-m|\
 	ubnt,unifi)
 		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -113,6 +113,10 @@ case "$FIRMWARE" in
 	tplink,tl-wr842n-v1)
 		caldata_extract "art" 0x1000 0x3e0
 		;;
+	ubnt,powerbridge-m|\
+	ubnt,rocket-m)
+		caldata_extract "art" 0x1000 0x1000
+		;;
 	wd,mynet-n600|\
 	wd,mynet-n750)
 		caldata_extract "art" 0x5000 0x440

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -158,6 +158,15 @@ define Device/ubnt_powerbeam-m5-xw
 endef
 TARGET_DEVICES += ubnt_powerbeam-m5-xw
 
+define Device/ubnt_powerbridge-m
+  $(Device/ubnt-xm)
+  SOC := ar7241
+  DEVICE_MODEL := PowerBridge M
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += bullet-m
+endef
+TARGET_DEVICES += ubnt_powerbridge-m
+
 define Device/ubnt_rocket-5ac-lite
   $(Device/ubnt-xc)
   SOC := qca9558
@@ -166,6 +175,15 @@ define Device/ubnt_rocket-5ac-lite
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
 endef
 TARGET_DEVICES += ubnt_rocket-5ac-lite
+
+define Device/ubnt_rocket-m
+  $(Device/ubnt-xm)
+  SOC := ar7241
+  DEVICE_MODEL := Rocket M
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += rocket-m
+endef
+TARGET_DEVICES += ubnt_rocket-m
 
 define Device/ubnt_routerstation_common
   DEVICE_PACKAGES := -kmod-ath9k -wpad-basic-mbedtls -uboot-envtools kmod-usb-ohci \

--- a/target/linux/ath79/image/tiny-ubnt.mk
+++ b/target/linux/ath79/image/tiny-ubnt.mk
@@ -70,21 +70,3 @@ define Device/ubnt_nanostation-loco-m
   DEFAULT := n
 endef
 TARGET_DEVICES += ubnt_nanostation-loco-m
-
-define Device/ubnt_powerbridge-m
-  $(Device/ubnt-xm)
-  SOC := ar7241
-  DEVICE_MODEL := PowerBridge M
-  DEVICE_PACKAGES += rssileds
-  SUPPORTED_DEVICES += bullet-m
-endef
-TARGET_DEVICES += ubnt_powerbridge-m
-
-define Device/ubnt_rocket-m
-  $(Device/ubnt-xm)
-  SOC := ar7241
-  DEVICE_MODEL := Rocket M
-  DEVICE_PACKAGES += rssileds
-  SUPPORTED_DEVICES += rocket-m
-endef
-TARGET_DEVICES += ubnt_rocket-m

--- a/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
@@ -116,9 +116,7 @@ ubnt,bullet-m-ar7241|\
 ubnt,nanobridge-m|\
 ubnt,nanostation-loco-m|\
 ubnt,nanostation-m|\
-ubnt,picostation-m|\
-ubnt,powerbridge-m|\
-ubnt,rocket-m)
+ubnt,picostation-m)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "red:link1" "wlan0" "1" "100"
 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "orange:link2" "wlan0" "26" "100"

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -54,9 +54,7 @@ ath79_setup_interfaces()
 	ubnt,bullet-m-ar7241|\
 	ubnt,nanobridge-m|\
 	ubnt,picostation-m|\
-	ubnt,nanostation-loco-m|\
-	ubnt,powerbridge-m|\
-	ubnt,rocket-m)
+	ubnt,nanostation-loco-m)
 		ucidef_set_interface_lan "eth0"
 		;;
 	engenius,enh202-v1)
@@ -135,9 +133,7 @@ ath79_setup_macs()
 	ubnt,nanobridge-m|\
 	ubnt,nanostation-loco-m|\
 	ubnt,nanostation-m|\
-	ubnt,picostation-m|\
-	ubnt,powerbridge-m|\
-	ubnt,rocket-m)
+	ubnt,picostation-m)
 		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;
 	tplink,tl-wr941-v2|\

--- a/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -43,9 +43,7 @@ case "$FIRMWARE" in
 	ubnt,nanobridge-m|\
 	ubnt,nanostation-loco-m|\
 	ubnt,nanostation-m|\
-	ubnt,picostation-m|\
-	ubnt,powerbridge-m|\
-	ubnt,rocket-m)
+	ubnt,picostation-m)
 		caldata_extract "art" 0x1000 0x1000
 		;;
 	pqi,air-pen)


### PR DESCRIPTION
return ubnt_rocket-m and ubnt_powerbridge-m back to ath79-generic
They have enough RAM-ressources to not be considered as tiny.

This reverts the commit f4415f7635164ec07ddc22f56df93555804b5767 partially

_________________________________

The gluon devs believe the Ubiquiti Rocket M2/M5 and PowerBridge M2/M5 devices where moved to tiny by accident.
They offer enough RAM ressources to still run kernels 5.10 and upwards without any issues.

@PolynomialDivision Please take a look at my PR, if you can spot any issues.
This was mainly a revert and shouldn't introduce any changes whatsoever (compared to OpenWrt 22.03.01
I would appreciate your feedback very much :)

I'd also like to know whether the calibration-data for these two boards appears incorrect.
Now would be a great time to fix those as well. You did so a couple month back for some boards that shared size 0x1000 calibration data before your change.
https://github.com/openwrt/openwrt/commit/a14170b6e9c8bab493c5e0e7689405a8a0675e8a

~~I still have to build-test this.~~ went successfully
I can provide a run-test for new calibration data on the rocket-m5 if required. (the other devices I don't have any access to)
