### PR TITLE
ath79: fix Ethernet Port settings for embedded wireless DORIN platform

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -319,7 +319,7 @@ ath79_setup_interfaces()
 		;;
 	embeddedwireless,dorin)
 		ucidef_add_switch "switch0" \
-			"0@eth0" "1:wan" "2:lan:3" "3:lan:2"
+			"0@eth0" "1:lan" "2:lan" "3:wan"
 		;;
 	engenius,eap300-v2)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
Port settings are different at ath79 compared to legacy ar71xx. This leads to problems for a few applications.

