### PR TITLE
e2fsprogs: do not symlink tune2fs to findfs

### DIFF
--- a/package/utils/e2fsprogs/Makefile
+++ b/package/utils/e2fsprogs/Makefile
@@ -267,7 +267,6 @@ endef
 define Package/tune2fs/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/tune2fs $(1)/usr/sbin/
-	$(LN) tune2fs $(1)/usr/sbin/findfs
 endef
 
 define Package/resize2fs/install


### PR DESCRIPTION
commit c0611b45a998 ("e2fsprogs: symlink e2fsck to fsck.ext{2, 3, 4}, and tune2fs to findfs") introduced a symlink from tune2fs to findfs.

This only works when the included private libblkid library is used, but commit 5b1660a5387b ("utils/e2fsprogs: Update to 1.43.6") disabled the usage of this private lib and enabled the shared lib support.

Removing this symlink makes it possible to install tune2fs and findfs package.
