### PR TITLE
apm821xx: fix autoloading of kmod-hw-crypto4xx

### DIFF
--- a/target/linux/apm821xx/modules.mk
+++ b/target/linux/apm821xx/modules.mk
@@ -23,7 +23,7 @@ define KernelPackage/hw-crypto-4xx
 	   +kmod-crypto-ccm +kmod-crypto-gcm \
 	   +kmod-crypto-sha1 +kmod-crypto-sha256 +kmod-crypto-sha512
   FILES:=$(LINUX_DIR)/drivers/crypto/amcc/crypto4xx.ko
-  AUTOLOAD:=$(call AutoLoad,09,sata_dwc_460ex,1)
+  AUTOLOAD:=$(call AutoLoad,09,crypto4xx,1)
   $(call AddDepends/crypto)
 endef
 


### PR DESCRIPTION
Fixes: 55fbcad20a2d (apm821xx: make crypto4xx as a standalone module)

Contents of `/etc/modules.d/09_kmod-hw-crypto4xx` and `/etc/modules-boot.d/09_kmod-hw-crypto4xx` was wrong.