### PR TITLE
urng: fix reload implementation

### DIFF
--- a/package/system/urngd/files/urngd.init
+++ b/package/system/urngd/files/urngd.init
@@ -13,5 +13,5 @@ start_service() {
 }
 
 reload_service() {
-	procd_send_signal $PROG
+	restart
 }


### PR DESCRIPTION
Remove the "ubus service signal" command because it is not needed and was incorrectly implemented causing the ubus command to fail. The command should have had the value of the "name" key be "$NAME", not "$PROG". Even if that were corrected, the daemon would be terminated and not restarted, breaking exectations around the reload action. The daemon does not reload on a certain signal. Instead, have reload be equivalent to restart.