### PR TITLE
grub2: opt-out of gc-sections usage

### DIFF
--- a/package/boot/grub2/Makefile
+++ b/package/boot/grub2/Makefile
@@ -7,7 +7,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=grub
 PKG_VERSION:=2.06
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/grub
@@ -25,7 +25,7 @@ ifneq ($(BUILD_VARIANT),none)
 endif
 
 PKG_FLAGS:=nonshared
-PKG_BUILD_FLAGS:=no-lto no-mold
+PKG_BUILD_FLAGS:=no-gc-sections no-lto no-mold
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Compile tested: master x86-64
Run tested: master x86-64

Description:
Fix building with `USE_GC_SECTIONS` enabled.

```
/mnt/caches/openwrt/openwrt-master-x64/staging_dir/toolchain-x86_64_gcc-12.3.0_musl/bin/../lib/gcc/x86_64-openwrt-linux-musl/12.3.0/../../../../x86_64-openwrt-linux-musl/bin/ld.bfd: --gc-sections requires a defined symbol root specified by -e or -u
collect2: error: ld returned 1 exit status
make[4]: *** [Makefile:27665: disk.module] Error 1
make[4]: Leaving directory '/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/linux-x86_64/grub-efi/grub-2.06/grub-core'
make[3]: *** [Makefile:26916: all] Error 2
make[3]: Leaving directory '/mnt/caches/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/linux-x86_64/grub-efi/grub-2.06/grub-core'
make[2]: *** [Makefile:205: /home/jmarcet/src/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/linux-x86_64/grub-efi/grub-2.06/.built] Error 2
make[2]: Leaving directory '/home/jmarcet/src/openwrt/openwrt-master-x64/package/boot/grub2'
time: package/boot/grub2/efi/compile#3.21#1.34#4.28
    ERROR: package/boot/grub2 failed to build (build variant: efi).
make[1]: *** [package/Makefile:120: package/boot/grub2/compile] Error 1
make[1]: Leaving directory '/home/jmarcet/src/openwrt/openwrt-master-x64'
make: *** [/home/jmarcet/src/openwrt/openwrt-master-x64/include/toplevel.mk:232: package/boot/grub2/compile] Error 2
```
