### PR TITLE
perf: opt-out of lto usage

### DIFF
--- a/package/devel/perf/Makefile
+++ b/package/devel/perf/Makefile
@@ -10,9 +10,9 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=perf
 PKG_VERSION:=$(LINUX_VERSION)
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
-PKG_BUILD_FLAGS:=no-mips16
+PKG_BUILD_FLAGS:=no-mips16 no-lto
 PKG_BUILD_PARALLEL:=1
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_FLAGS:=nonshared


### PR DESCRIPTION
Maintainer: Felix Fietkau <nbd@nbd.name>
Compile tested: master x86-64
Run tested: master x86-64

Description:
Fix building with `USE_LTO` enabled:

```
mold: error: undefined symbol: __memset
>>> referenced by <artificial>
>>>               /home/jmarcet/src/openwrt/openwrt-master-x64/tmp/ccsgR7G6.ltrans10.ltrans.o
mold: error: undefined symbol: memset_orig
>>> referenced by <artificial>
>>>               /home/jmarcet/src/openwrt/openwrt-master-x64/tmp/ccsgR7G6.ltrans10.ltrans.o
mold: error: undefined symbol: perf_regs_load
>>> referenced by <artificial>
>>>               /home/jmarcet/src/openwrt/openwrt-master-x64/tmp/ccsgR7G6.ltrans15.ltrans.o:(test_dwarf_unwind__thread)
mold: error: undefined symbol: memset_erms
>>> referenced by <artificial>
>>>               /home/jmarcet/src/openwrt/openwrt-master-x64/tmp/ccsgR7G6.ltrans10.ltrans.o
mold: error: undefined symbol: memcpy_orig
>>> referenced by <artificial>
>>>               /home/jmarcet/src/openwrt/openwrt-master-x64/tmp/ccsgR7G6.ltrans10.ltrans.o
mold: error: undefined symbol: memcpy_erms
>>> referenced by <artificial>
>>>               /home/jmarcet/src/openwrt/openwrt-master-x64/tmp/ccsgR7G6.ltrans10.ltrans.o
mold: error: undefined symbol: __memcpy
>>> referenced by <artificial>
>>>               /home/jmarcet/src/openwrt/openwrt-master-x64/tmp/ccsgR7G6.ltrans10.ltrans.o
collect2: error: ld returned 1 exit status
make[5]: *** [Makefile.perf:670: /home/jmarcet/src/openwrt/linux/tools/perf-target-x86_64_musl/perf] Error 1
make[4]: *** [Makefile.perf:238: sub-make] Error 2
make[3]: *** [Makefile:70: all] Error 2
make[2]: *** [Makefile:84: /home/jmarcet/src/openwrt/openwrt-master-x64/build_dir/target-x86_64_musl/linux-x86_64/linux-5.15.120/tools/perf-target-x86_64_musl/.built] Error 2
make[2]: Leaving directory '/home/jmarcet/src/openwrt/openwrt-master-x64/package/devel/perf'
time: package/devel/perf/compile#55.88#6.78#12.89
    ERROR: package/devel/perf failed to build.
make[1]: *** [package/Makefile:120: package/devel/perf/compile] Error 1
make[1]: Leaving directory '/home/jmarcet/src/openwrt/openwrt-master-x64'
make: *** [/home/jmarcet/src/openwrt/openwrt-master-x64/include/toplevel.mk:232: package/devel/perf/compile] Error 2
```

