### PR TITLE
dropbear: add ed25519 for failsafe key

### DIFF
--- a/package/network/services/dropbear/files/dropbear.failsafe
+++ b/package/network/services/dropbear/files/dropbear.failsafe
@@ -1,8 +1,9 @@
 #!/bin/sh
 
 failsafe_dropbear () {
-	dropbearkey -t rsa -s 1024 -f /tmp/dropbear_failsafe_host_key
-	dropbear -r /tmp/dropbear_failsafe_host_key <> /dev/null 2>&1
+	dropbearkey -t rsa -s 1024 -f /tmp/dropbear_rsa_failsafe_host_key
+	dropbearkey -t ed25519 -f /tmp/dropbear_ed25519_failsafe_host_key
+	dropbear -r /tmp/dropbear_rsa_failsafe_host_key -r /tmp/dropbear_ed25519_failsafe_host_key <> /dev/null 2>&1
 }
 
 boot_hook_add failsafe failsafe_dropbear


### PR DESCRIPTION
At least Fedora and RHEL 9 set RSAMinSize=2048, so when trying to use
failsafe, we get 'Bad server host key: Invalid key length'
To workaround the issue, we can use: ssh -o RSAMinSize=1024 ...

Generating 2048 bits RSA is extremely slow, so add ed25519.
We keep RSA 1024 to be as compatible as possible.