### PR TITLE
fortify-headers: add __extension__ mark to strings.h

### DIFF
--- a/toolchain/fortify-headers/patches/002-strings.h-add-__extension__-mark.patch
+++ b/toolchain/fortify-headers/patches/002-strings.h-add-__extension__-mark.patch
@@ -1,0 +1,29 @@
+From 9ee4b9bd8df55ebbd5f6426fda4a36e1958b64c5 Mon Sep 17 00:00:00 2001
+From: Matthias Van Parys <matthias.vanparys@softathome.com>
+Date: Mon, 10 Jul 2023 14:31:05 +0200
+Subject: [PATCH] strings.h: Add __extension__ mark to include_next to silence
+ -pedantic
+
+Add __extension__ before #include-next in strings.h as was done for all other header files in commits
+7fd984fcb532be01f68cddc194c09a7ca10c1ea6 and a9ffac8596b094da8563aa5dd5d81c946670afe
+---
+ include/strings.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/include/strings.h b/include/strings.h
+index a16e1ad..d1902db 100644
+--- a/include/strings.h
++++ b/include/strings.h
+@@ -16,6 +16,9 @@
+ #ifndef _FORTIFY_STRINGS_H
+ #define _FORTIFY_STRINGS_H
+ 
++#ifndef __cplusplus
++__extension__
++#endif
+ #include_next <strings.h>
+ 
+ #if defined(_FORTIFY_SOURCE) && _FORTIFY_SOURCE > 0 && defined(__OPTIMIZE__) && __OPTIMIZE__ > 0
+-- 
+2.34.1
+


### PR DESCRIPTION
Add the \_\_extension__ mark before #include_next in strings.h to avoid a compilation error when -pedantic is enabled. This has been done for all other headers in the past.



