### PR TITLE
octeon: ubnt-edgerouter-e300: fix missing MTD partition

### DIFF
--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-e300.dtsi
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-e300.dtsi
@@ -99,22 +99,28 @@
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 
-		partition@0 {
-			label = "boot0";
-			read-only;
-			reg = <0x000000 0x300000>;
-		};
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-		partition@300000 {
-			label = "dummy";
-			read-only;
-			reg = <0x300000 0x100000>;
-		};
+			partition@0 {
+				label = "boot0";
+				read-only;
+				reg = <0x000000 0x300000>;
+			};
 
-		eeprom: partition@400000 {
-			label = "eeprom";
-			read-only;
-			reg = <0x400000 0x10000>;
+			partition@300000 {
+				label = "dummy";
+				read-only;
+				reg = <0x300000 0x100000>;
+			};
+
+			eeprom: partition@400000 {
+				label = "eeprom";
+				read-only;
+				reg = <0x400000 0x10000>;
+			};
 		};
 	};
 };


### PR DESCRIPTION
The MAC addresses should be read from 3rd MTD partition, but only two MTD partitions are populated.

To fix it, a partitions node has to surround the partion nodes in device tree.

Tested with Edgerouter 6P

Signed-off-by: Carsten Spieß <mail@carsten-spiess.de>
