### PR TITLE
octeon: ubnt-edgerouter-4/6p: devicetree cleanup

### DIFF
--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-4.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-4.dts
@@ -19,13 +19,3 @@
 		};
 	};
 };
-
-&eeprom {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_eeprom_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-};

--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-6p.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-6p.dts
@@ -62,12 +62,3 @@
 	};
 };
 
-&eeprom {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_eeprom_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-};


### PR DESCRIPTION
removed redundant eeprom partition nodes from
cn7130_ubnt_edgerouter-4.dts and cn7130_ubnt_edgerouter-6p.dts as they are identically defined in cn7130_ubnt_edgerouter-e300.dtsi

Signed-off-by: Carsten Spieß <mail@carsten-spiess.de>