### PR TITLE
octeon: ubnt-edgerouter-4/6p: rename eth devices

### DIFF
--- a/target/linux/octeon/base-files/etc/board.d/01_network
+++ b/target/linux/octeon/base-files/etc/board.d/01_network
@@ -11,10 +11,10 @@ itus,shield-router)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
 	;;
 ubnt,edgerouter-4)
-	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "lan0"
+	ucidef_set_interfaces_lan_wan "eth1 eth2 eth3" "eth0"
 	;;
 ubnt,edgerouter-6p)
-	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "lan0"
+	ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4 eth5" "eth0"
 	;;
 *)
 	ucidef_set_interfaces_lan_wan "eth0" "eth1"

--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-4.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-4.dts
@@ -10,7 +10,7 @@
 &pip {
 	interface@0 {
 		ethernet@0 {
-			label = "lan3";
+			label = "eth3";
 			status = "okay";
 			phy-mode = "sgmii";
 			phy-handle = <&phy4>;

--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-6p.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-6p.dts
@@ -28,7 +28,7 @@
 &pip {
 	interface@0 {
 		ethernet@0 {
-			label = "lan5";
+			label = "eth5";
 			status = "okay";
 			phy-mode = "sgmii";
 			phy-handle = <&phy4>;
@@ -41,7 +41,7 @@
 		status = "okay";
 
 		ethernet@0 {
-			label = "lan3";
+			label = "eth3";
 			status = "okay";
 			phy-mode = "sgmii";
 			phy-handle = <&phy8>;
@@ -51,7 +51,7 @@
 		};
 
 		ethernet@1 {
-			label = "lan4";
+			label = "eth4";
 			status = "okay";
 			phy-mode = "sgmii";
 			phy-handle = <&phy9>;

--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-e300.dtsi
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-e300.dtsi
@@ -176,7 +176,7 @@
 		status = "okay";
 
 		ethernet@1 {
-			label = "lan0";
+			label = "eth0";
 			status = "okay";
 			phy-mode = "sgmii";
 			phy-handle = <&phy5>;
@@ -186,7 +186,7 @@
 		};
 
 		ethernet@2 {
-			label = "lan1";
+			label = "eth1";
 			status = "okay";
 			phy-mode = "sgmii";
 			phy-handle = <&phy6>;
@@ -196,7 +196,7 @@
 		};
 
 		ethernet@3 {
-			label = "lan2";
+			label = "eth2";
 			status = "okay";
 			phy-mode = "sgmii";
 			phy-handle = <&phy7>;


### PR DESCRIPTION
The eth devices have been named lan0..lanX but on the case the ports are labeled eth0..ethX

Changed ethernet device label in device tree and default config

Signed-off-by: Carsten Spieß <mail@carsten-spiess.de>
