### PR TITLE
octeon: ubnt-edgerouter-e300: fix LED settings

### DIFF
--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-e300.dtsi
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-e300.dtsi
@@ -33,12 +33,12 @@
 
 		led_power_blue: power_blue {
 			label = "blue:power";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_power_white: power_white {
 			label = "white:power";
-			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
 		};
 	};
 


### PR DESCRIPTION
LEDs on Edgerouter 6P didn't work correctly:
blue /white LED swapped, on/off state inverted

Fixed in device tree:
swap the GPIO ports for power:blue and power:white LEDs change LED activity from LOW to HIGH

Tested on Edgerouter 6P

Signed-off-by: Carsten Spieß <mail@carsten-spiess.de>
