### PR TITLE
mediatek: add support for Buffalo WSR-6000AX8 and AX8P

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -81,6 +81,15 @@ jdcloud,re-cp-03)
 		;;
 	esac
 	;;
+buffalo,wsr-6000ax8|\
+mercusys,mr80x-v3|\
+mercusys,mr90x-v1|\
+routerich,ax3000|\
+routerich,ax3000-v1|\
+tenbay,wr3000k|\
+tplink,re6000xd)
+	ubootenv_add_mtd "u-boot-env" "0x0" "0x20000" "0x20000" "1"
+	;;
 comfast,cf-e393ax|\
 iptime,ax3000m)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x80000"
@@ -102,14 +111,6 @@ gatonetworks,gdsp)
 	;;
 glinet,gl-mt3000)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x20000"
-	;;
-mercusys,mr80x-v3|\
-mercusys,mr90x-v1|\
-routerich,ax3000|\
-routerich,ax3000-v1|\
-tenbay,wr3000k|\
-tplink,re6000xd)
-	ubootenv_add_mtd "u-boot-env" "0x0" "0x20000" "0x20000" "1"
 	;;
 openembed,som7981)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x80000"

--- a/target/linux/mediatek/dts/mt7986b-buffalo-wsr-6000ax8.dts
+++ b/target/linux/mediatek/dts/mt7986b-buffalo-wsr-6000ax8.dts
@@ -1,0 +1,415 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7986b.dtsi"
+
+/ {
+	model = "Buffalo WSR-6000AX8";
+	compatible = "buffalo,wsr-6000ax8", "mediatek,mt7986b";
+
+	aliases {
+		serial0 = &uart0;
+
+		label-mac-device = &gmac0;
+		led-boot = &power_green;
+		led-failsafe = &power_amber;
+		led-running = &power_green;
+		led-upgrade = &power_green;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-override = "ubi.mtd=ubi";
+	};
+
+	memory@40000000  {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_green: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		power_amber: led-1 {
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_WLAN;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_WLAN;
+		};
+
+		led-4 {
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 17 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_WAN;
+		};
+
+		led-5 {
+			label = "green:internet";
+			gpios = <&pio 30 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_INDICATOR;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		key-reset {
+			label = "reset";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		key-wps {
+			label = "wps";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		/* GPIO 18 and 19 are a tri-state switch button with
+		 * ROUTER / AP / WB.
+		 */
+		key-router {
+			label = "router";
+			gpios = <&pio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		key-bridge {
+			label = "wb";
+			gpios = <&pio 19 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
+		};
+
+		/* GPIO 20 is a switch button with AUTO / MANUAL. */
+		key-manual {
+			label = "manual";
+			gpios = <&pio 20 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_2>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cells = <&macaddr_board_data_4 0>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy6>;
+
+		nvmem-cells = <&macaddr_board_data_4 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		reset-delay-us = <1500000>;
+		reset-post-delay-us = <2000000>;
+
+		/* WAN 2.5Gbps phy: MaxLinear GPY211C */
+		phy6: phy@6 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <6>;
+		};
+
+		switch: switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-parent = <&pio>;
+			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable; /* bias-disable */
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable; /* bias-disable */
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			       "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			       "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			       "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			       "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			       "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			       "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+
+	wf_dbdc_pins: wf_dbdc-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_dbdc";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			       "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			       "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			       "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			       "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			       "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			       "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+		mediatek,bmt-remap-range = <0x0 0x580000>,
+					   <0x3980000 0x7480000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					precal_factory_1010: precal@1010 {
+						reg = <0x1010 0x58810>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x1a00000>;
+			};
+
+			partition@1f80000 {
+				label = "Kernel2";
+				reg = <0x1f80000 0x1a00000>;
+			};
+
+			partition@3980000 {
+				label = "glbcfg";
+				reg = <0x3980000 0x200000>;
+				read-only;
+			};
+
+			partition@3b80000 {
+				label = "seccfg";
+				reg = <0x3b80000 0x200000>;
+				read-only;
+			};
+
+			partition@3d80000 {
+				label = "board_data";
+				reg = <0x3d80000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_board_data_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x11>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@3f80000 {
+				label = "debug_log";
+				reg = <0x3f80000 0x900000>;
+				read-only;
+			};
+
+			partition@4880000 {
+				label = "WTB";
+				reg = <0x4880000 0x2c00000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	pinctrl-names = "default", "dbdc";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+	pinctrl-1 = <&wf_dbdc_pins>;
+
+	nvmem-cells = <&eeprom_factory_0>, <&precal_factory_1010>;
+	nvmem-cell-names = "eeprom", "precal";
+	status = "okay";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_board_data_4 2>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_board_data_4 9>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -9,6 +9,7 @@ mediatek_setup_interfaces()
 
 	case $board in
 	abt,asr3000|\
+	buffalo,wsr-6000ax8|\
 	cmcc,rax3000m|\
 	h3c,magic-nx30-pro|\
 	netis,nx31|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -12,6 +12,18 @@ asus_initial_setup()
 	ubimkvol /dev/ubi0 -N jffs2 -s 0x3e000
 }
 
+buffalo_initial_setup()
+{
+	local mtdnum="$( find_mtd_index ubi )"
+	if [ ! "$mtdnum" ]; then
+		echo "unable to find mtd partition ubi"
+		return 1
+	fi
+
+	ubidetach -m "$mtdnum"
+	ubiformat /dev/mtd$mtdnum -y
+}
+
 xiaomi_initial_setup()
 {
 	# initialize UBI and setup uboot-env if it's running on initramfs
@@ -131,6 +143,7 @@ platform_do_upgrade() {
 		CI_KERNPART="linux"
 		nand_do_upgrade "$1"
 		;;
+	buffalo,wsr-6000ax8|\
 	cudy,wr3000h-v1|\
 	cudy,wr3000p-v1)
 		CI_UBIPART="ubi"
@@ -332,6 +345,9 @@ platform_pre_upgrade() {
 	asus,tuf-ax6000|\
 	asus,zenwifi-bt8)
 		asus_initial_setup
+		;;
+	buffalo,wsr-6000ax8)
+		buffalo_initial_setup
 		;;
 	xiaomi,mi-router-ax3000t|\
 	xiaomi,mi-router-wr30u-stock|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -601,6 +601,19 @@ endif
 endef
 TARGET_DEVICES += bananapi_bpi-r4-poe
 
+define Device/buffalo_wsr-6000ax8
+  DEVICE_MODEL := WSR-6000AX8
+  DEVICE_VENDOR := Buffalo
+  DEVICE_ALT0_MODEL := WSR-6000AX8P
+  DEVICE_ALT0_VENDOR := Buffalo
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS := mt7986b-buffalo-wsr-6000ax8
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  IMAGE_SIZE := 26624k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += buffalo_wsr-6000ax8
+
 define Device/cetron_ct3003
   DEVICE_VENDOR := Cetron
   DEVICE_MODEL := CT3003


### PR DESCRIPTION
This commit adds support for Buffalo WSR-6000AX8 and AX8P models.

Hardware
--------
SOC:       MediaTek MT7986B
RAM:       512MB
FLASH:     128MB SPI-NAND (Winbond)
WIFI 2.4G: (Embedded in SOC) b/g/n/ax, MIMO 4x4
WIFI 5G:   (Embedded in SOC) a/n/ac/ax, MIMO 4x4
ETHERNET:  2.5GbE MaxLinear GPY211C (eth1: WAN)
ETHERNET:  MediaTek MT7531AE 3xGbE (eth0: LAN1, LAN2, LAN3)
UART:      3.3V 115200 8N1

Serial(UART) Pin Layout
-----------------------

&nbsp;&nbsp;&nbsp;+---+----+-----+------+
J4 |  RX   |  TX   |  GND  |(3.3V) |
&nbsp;&nbsp;&nbsp;+---+----+-----+------+
           (Bottom Side)

MAC Address Table
-----------------
eth0/LAN:  board_data 0x4(text)
eth1/WAN:  board_data 0x4(text)
WIFI 2.4G: eth0 + 2
WIFI 5G:   eth0 + 9

Installation
------------

1. Set up a TFTP server with the IP address "192.168.11.2".
2. Rename the OpenWrt initramfs image to "linux.ubi-recovery" and place it in the TFTP server's root directory.
3. While holding down the AOSS button, power on the WSR-6000AX8 (or AX8P).
4. The device will automatically download the initramfs image from the TFTP server and boot into it.
5. Once booted, run "sysupgrade -n" using the OpenWrt sysupgrade image to complete the installation.

Recovery
--------

1. Decrypt the official firmware image using "buffalo-enc".
   example:   $ buffalo-enc -d -i wsr_6000ax8_jp_100 -o wsr_6000ax8_jp_100.dec \ -l -O 0xc8
2. Run "sysupgrade -F -n" with the decrypted image.
