### PR TITLE
rockchip: add FriendlyARM NanoPC T4 support

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -74,6 +74,13 @@ define U-Boot/rk3399/Default
   ATF:=rk3399_bl31.elf
 endef
 
+define U-Boot/nanopc-t4-rk3399
+  $(U-Boot/rk3399/Default)
+  NAME:=NanoPC T4
+  BUILD_DEVICES:= \
+    friendlyarm_nanopc-t4
+endef
+
 define U-Boot/nanopi-r4s-rk3399
   $(U-Boot/rk3399/Default)
   NAME:=NanoPi R4S
@@ -96,6 +103,7 @@ define U-Boot/rockpro64-rk3399
 endef
 
 UBOOT_TARGETS := \
+  nanopc-t4-rk3399 \
   nanopi-r4s-rk3399 \
   rock-pi-4-rk3399 \
   rockpro64-rk3399 \

--- a/package/boot/uboot-rockchip/patches/105-nanopc-t4-fix-memory-unstability.patch
+++ b/package/boot/uboot-rockchip/patches/105-nanopc-t4-fix-memory-unstability.patch
@@ -1,0 +1,24 @@
+From 445502bc21ecf1b5120faee785cea578b810c759 Mon Sep 17 00:00:00 2001
+From: Lu jicong <jiconglu58@gmail.com>
+Date: Wed, 5 Jul 2023 17:13:55 +0800
+Subject: [PATCH] rockchip: rk3399: nanopc-t4: use 1600MHz sdram config
+
+Current 1866MHz sdram config is too high for NanoPC-T4.
+On this frequency, its lpddr3 sdram becomes unstable,
+causing memtest failures and random kernel crashes.
+
+Signed-off-by: Lu jicong <jiconglu58@gmail.com>
+---
+ arch/arm/dts/rk3399-nanopc-t4-u-boot.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/dts/rk3399-nanopc-t4-u-boot.dtsi b/arch/arm/dts/rk3399-nanopc-t4-u-boot.dtsi
+index 17201bcf41..8b6c9059ab 100644
+--- a/arch/arm/dts/rk3399-nanopc-t4-u-boot.dtsi
++++ b/arch/arm/dts/rk3399-nanopc-t4-u-boot.dtsi
+@@ -4,4 +4,4 @@
+  */
+ 
+ #include "rk3399-nanopi4-u-boot.dtsi"
+-#include "rk3399-sdram-lpddr3-samsung-4GB-1866.dtsi"
++#include "rk3399-sdram-lpddr3-4GB-1600.dtsi"

--- a/package/firmware/linux-firmware/broadcom.mk
+++ b/package/firmware/linux-firmware/broadcom.mk
@@ -149,6 +149,18 @@ define Package/brcmfmac-nvram-43455-sdio/install
 endef
 $(eval $(call BuildPackage,brcmfmac-nvram-43455-sdio))
 
+Package/brcmfmac-nvram-4356-sdio = $(call Package/firmware-default,Broadcom BCM4356 SDIO NVRAM)
+define Package/brcmfmac-nvram-4356-sdio/install
+	$(INSTALL_DIR) $(1)/lib/firmware/brcm
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/brcm/brcmfmac4356-sdio.AP6356S.txt \
+		$(1)/lib/firmware/brcm/
+	$(LN) \
+		brcmfmac4356-sdio.AP6356S.txt \
+		$(1)/lib/firmware/brcm/brcmfmac4356-sdio.friendlyarm,nanopc-t4.txt
+endef
+$(eval $(call BuildPackage,brcmfmac-nvram-4356-sdio))
+
 Package/brcmfmac-firmware-usb = $(call Package/firmware-default,Broadcom BCM43xx fullmac USB firmware)
 define Package/brcmfmac-firmware-usb/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm

--- a/package/kernel/mac80211/broadcom.mk
+++ b/package/kernel/mac80211/broadcom.mk
@@ -431,6 +431,7 @@ define KernelPackage/brcmfmac/config
 		bool "Enable SDIO bus interface support"
 		default y if TARGET_bcm27xx
 		default y if TARGET_imx_cortexa7
+		default y if TARGET_rockchip
 		default y if TARGET_sunxi
 		default n
 		help

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -20,6 +20,7 @@ define Device/friendlyarm_nanopc-t4
   DEVICE_MODEL := NanoPC T4
   SOC := rk3399
   IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
+  DEVICE_PACKAGES := kmod-brcmfmac brcmfmac-nvram-4356-sdio cypress-firmware-4356-sdio
 endef
 TARGET_DEVICES += friendlyarm_nanopc-t4
 

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -15,6 +15,14 @@ define Device/firefly_roc-rk3328-cc
 endef
 TARGET_DEVICES += firefly_roc-rk3328-cc
 
+define Device/friendlyarm_nanopc-t4
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPC T4
+  SOC := rk3399
+  IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
+endef
+TARGET_DEVICES += friendlyarm_nanopc-t4
+
 define Device/friendlyarm_nanopi-r2c
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R2C

--- a/target/linux/rockchip/patches-5.15/109-nanopc-t4-add-led-aliases.patch
+++ b/target/linux/rockchip/patches-5.15/109-nanopc-t4-add-led-aliases.patch
@@ -1,0 +1,16 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts
+@@ -15,6 +15,13 @@
+ 	model = "FriendlyElec NanoPC-T4";
+ 	compatible = "friendlyarm,nanopc-t4", "rockchip,rk3399";
+ 
++	aliases {
++		led-boot = &status_led;
++		led-failsafe = &status_led;
++		led-running = &status_led;
++		led-upgrade = &status_led;
++	};
++
+ 	vcc12v0_sys: vcc12v0-sys {
+ 		compatible = "regulator-fixed";
+ 		regulator-always-on;

--- a/target/linux/rockchip/patches-6.1/109-nanopc-t4-add-led-aliases.patch
+++ b/target/linux/rockchip/patches-6.1/109-nanopc-t4-add-led-aliases.patch
@@ -1,0 +1,16 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts
+@@ -15,6 +15,13 @@
+ 	model = "FriendlyElec NanoPC-T4";
+ 	compatible = "friendlyarm,nanopc-t4", "rockchip,rk3399";
+ 
++	aliases {
++		led-boot = &status_led;
++		led-failsafe = &status_led;
++		led-running = &status_led;
++		led-upgrade = &status_led;
++	};
++
+ 	vcc12v0_sys: vcc12v0-sys {
+ 		compatible = "regulator-fixed";
+ 		regulator-always-on;


### PR DESCRIPTION
Hardware
--------
RockChip RK3399 ARM64 (6 cores)
4GB LPDDR3 RAM
1x 1000 Base-T
1 GPIO LED (status)
HDMI 2.0
3.5mm TRRS AV jack
Micro-SD slot
16GB eMMC
1x USB 3.0 Port
2x USB 2.0 Port
1x USB Type-C Port
1x M.2 PCI-E Port
AP6356S (BCM4356) SDIO WiFi & Bluetooth adapter