### PR TITLE
openssl: opt-out of lto usage

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,8 +9,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_VERSION:=3.0.9
-PKG_RELEASE:=2
-PKG_BUILD_FLAGS:=no-mips16 gc-sections
+PKG_RELEASE:=3
+PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_BUILD_PARALLEL:=1
 


### PR DESCRIPTION
This fixes building with USE_LTO enabled:

```
aarch64-openwrt-linux-musl-gcc -fPIC -pthread -Wa,--noexecstack -Wall -O3 -Os -pipe -mcpu=cortex-a53 -fno-caller-saves -fno-plt -fhonour-copts -fmacro-prefix-map=/build_dir/target-aarch64_cortex-a53_musl/openssl-3.0.9=openssl-3.0.9 -ffunction-sections -fdata-sections -flto=auto -fno-fat-lto-objects -Wformat -Werror=format-security -DPIC -fPIC -fstack-protector-strong -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -DPIC -fPIC -Os -pipe -mcpu=cortex-a53 -fno-caller-saves -fno-plt -fhonour-copts -fmacro-prefix-map=/build_dir/target-aarch64_cortex-a53_musl/openssl-3.0.9=openssl-3.0.9 -ffunction-sections -fdata-sections -flto=auto -fno-fat-lto-objects -Wformat -Werror=format-security -fPIC -fstack-protector-strong -fPIC -fuse-ld=bfd -flto=auto -fuse-linker-plugin -fPIC -specs=/include/hardened-ld-pie.specs -znow -zrelro -L. -Wl,-z,defs -Wl,-znodelete -shared -Wl,-Bsymbolic  -Wl,-z,now -Wl,-z,relro -L/staging_dir/toolchain-aarch64_cortex-a53_gcc-13.1.0_musl/usr/lib -L/staging_dir/toolchain-aarch64_cortex-a53_gcc-13.1.0_musl/lib -Wl,--gc-sections \
	-o providers/legacy.so -Wl,--version-script=providers/legacy.ld \
	providers/legacy-dso-legacyprov.o \
	providers/liblegacy.a providers/libcommon.a -lcrypto -ldl -pthread 
ld.bfd: /tmp/ccdWw6Lo.ltrans0.ltrans.o: in function `legacy_get_params':
<artificial>:(.text.legacy_get_params+0xd4): undefined reference to `ossl_prov_is_running'
ld.bfd: <artificial>:(.text.legacy_get_params+0xd8): undefined reference to `ossl_prov_is_running'
ld.bfd: /tmp/ccdWw6Lo.ltrans0.ltrans.o: in function `legacy_teardown':
<artificial>:(.text.legacy_teardown+0x4): undefined reference to `ossl_prov_ctx_get0_libctx'
ld.bfd: <artificial>:(.text.legacy_teardown+0x8): undefined reference to `ossl_prov_ctx_get0_libctx'
ld.bfd: <artificial>:(.text.legacy_teardown+0x34): undefined reference to `ossl_prov_ctx_free'
ld.bfd: <artificial>:(.text.legacy_teardown+0x38): undefined reference to `ossl_prov_ctx_free'
ld.bfd: /tmp/ccdWw6Lo.ltrans0.ltrans.o: in function `OSSL_provider_init':
<artificial>:(.text.OSSL_provider_init+0x14): undefined reference to `ossl_prov_ctx_new'
ld.bfd: <artificial>:(.text.OSSL_provider_init+0x18): undefined reference to `ossl_prov_ctx_new'
ld.bfd: <artificial>:(.text.OSSL_provider_init+0x84): undefined reference to `ossl_prov_ctx_set0_libctx'
ld.bfd: <artificial>:(.text.OSSL_provider_init+0x88): undefined reference to `ossl_prov_ctx_set0_libctx'
ld.bfd: <artificial>:(.text.OSSL_provider_init+0x98): undefined reference to `ossl_prov_ctx_set0_handle'
ld.bfd: <artificial>:(.text.OSSL_provider_init+0x9c): undefined reference to `ossl_prov_ctx_set0_handle'
ld.bfd: /tmp/ccdWw6Lo.ltrans0.ltrans.o:(.data.rel.ro.legacy_kdfs+0x10): undefined reference to `ossl_kdf_pbkdf1_functions'
ld.bfd: /tmp/ccdWw6Lo.ltrans0.ltrans.o:(.data.rel.ro.legacy_ciphers+0x10): undefined reference to `ossl_cast5128ecb_functions'
ld.bfd: /tmp/ccdWw6Lo.ltrans0.ltrans.o:(.data.rel.ro.legacy_ciphers+0x30): undefined reference to `ossl_cast5128cbc_functions'
[...]
ld.bfd: /tmp/ccdWw6Lo.ltrans0.ltrans.o:(.data.rel.ro.legacy_digests+0x10): undefined reference to `ossl_md4_functions'
ld.bfd: /tmp/ccdWw6Lo.ltrans0.ltrans.o:(.data.rel.ro.legacy_digests+0x30): undefined reference to `ossl_ripemd160_functions'
collect2: error: ld returned 1 exit status
```
