### PR TITLE
busybox: build additional applets and improve current applet features

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -186,7 +186,7 @@ config BUSYBOX_DEFAULT_FEATURE_USE_BSS_TAIL
 	default n
 config BUSYBOX_DEFAULT_FLOAT_DURATION
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_RTMINMAX
 	bool
 	default n
@@ -258,7 +258,7 @@ config BUSYBOX_DEFAULT_FEATURE_EDITING_SAVE_ON_EXIT
 	default n
 config BUSYBOX_DEFAULT_FEATURE_REVERSE_SEARCH
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_TAB_COMPLETION
 	bool
 	default y
@@ -588,7 +588,7 @@ config BUSYBOX_DEFAULT_DF
 	default y
 config BUSYBOX_DEFAULT_FEATURE_DF_FANCY
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_SKIP_ROOTFS
 	bool
 	default n
@@ -792,7 +792,7 @@ config BUSYBOX_DEFAULT_SORT
 	default y
 config BUSYBOX_DEFAULT_FEATURE_SORT_BIG
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_SORT_OPTIMIZE_MEMORY
 	bool
 	default n
@@ -867,7 +867,7 @@ config BUSYBOX_DEFAULT_TR
 	default y
 config BUSYBOX_DEFAULT_FEATURE_TR_CLASSES
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_TR_EQUIV
 	bool
 	default n
@@ -919,7 +919,7 @@ config BUSYBOX_DEFAULT_WC
 	default y
 config BUSYBOX_DEFAULT_FEATURE_WC_LARGE
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_WHO
 	bool
 	default n
@@ -1138,19 +1138,19 @@ config BUSYBOX_DEFAULT_FEATURE_FIND_MTIME
 	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_ATIME
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_CTIME
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_MMIN
 	bool
 	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_AMIN
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_CMIN
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_PERM
 	bool
 	default y
@@ -1159,7 +1159,7 @@ config BUSYBOX_DEFAULT_FEATURE_FIND_TYPE
 	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_EXECUTABLE
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_XDEV
 	bool
 	default y
@@ -1171,16 +1171,16 @@ config BUSYBOX_DEFAULT_FEATURE_FIND_NEWER
 	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_INUM
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_SAMEFILE
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_EXEC
 	bool
 	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_EXEC_PLUS
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_USER
 	bool
 	default y
@@ -1204,13 +1204,13 @@ config BUSYBOX_DEFAULT_FEATURE_FIND_PRUNE
 	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_QUIT
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_DELETE
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_EMPTY
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_PATH
 	bool
 	default y
@@ -1222,7 +1222,7 @@ config BUSYBOX_DEFAULT_FEATURE_FIND_CONTEXT
 	default n
 config BUSYBOX_DEFAULT_FEATURE_FIND_LINKS
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_GREP
 	bool
 	default y
@@ -1252,13 +1252,13 @@ config BUSYBOX_DEFAULT_FEATURE_XARGS_SUPPORT_ZERO_TERM
 	default y
 config BUSYBOX_DEFAULT_FEATURE_XARGS_SUPPORT_REPL_STR
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_XARGS_SUPPORT_PARALLEL
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_XARGS_SUPPORT_ARGS_FILE
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_BOOTCHARTD
 	bool
 	default n
@@ -1717,7 +1717,7 @@ config BUSYBOX_DEFAULT_FEATURE_MOUNT_FAKE
 	default n
 config BUSYBOX_DEFAULT_FEATURE_MOUNT_VERBOSE
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_MOUNT_HELPERS
 	bool
 	default y
@@ -2011,7 +2011,7 @@ config BUSYBOX_DEFAULT_FEATURE_CROND_CALL_SENDMAIL
 	default n
 config BUSYBOX_DEFAULT_FEATURE_CROND_SPECIAL_TIMES
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_CROND_DIR
 	string
 	default "/etc"
@@ -2113,7 +2113,7 @@ config BUSYBOX_DEFAULT_FEATURE_LESS_MARKS
 	default n
 config BUSYBOX_DEFAULT_FEATURE_LESS_REGEXP
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_LESS_WINCH
 	bool
 	default n
@@ -2843,7 +2843,7 @@ config BUSYBOX_DEFAULT_FEATURE_PS_WIDE
 	default y
 config BUSYBOX_DEFAULT_FEATURE_PS_LONG
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_PS_TIME
 	bool
 	default n
@@ -2879,7 +2879,7 @@ config BUSYBOX_DEFAULT_FEATURE_TOP_CPU_GLOBAL_PERCENTS
 	default y
 config BUSYBOX_DEFAULT_FEATURE_TOP_SMP_CPU
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_TOP_DECIMALS
 	bool
 	default n
@@ -3176,7 +3176,7 @@ config BUSYBOX_DEFAULT_FEATURE_SH_MATH_64
 	default y
 config BUSYBOX_DEFAULT_FEATURE_SH_MATH_BASE
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_SH_EXTRA_QUIET
 	bool
 	default n
@@ -3188,7 +3188,7 @@ config BUSYBOX_DEFAULT_FEATURE_SH_NOFORK
 	default y
 config BUSYBOX_DEFAULT_FEATURE_SH_READ_FRAC
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_SH_HISTFILESIZE
 	bool
 	default n

--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -1051,13 +1051,13 @@ config BUSYBOX_DEFAULT_CMP
 	default y
 config BUSYBOX_DEFAULT_DIFF
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_DIFF_LONG_OPTIONS
 	bool
 	default n
 config BUSYBOX_DEFAULT_FEATURE_DIFF_DIR
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_ED
 	bool
 	default n
@@ -1513,7 +1513,7 @@ config BUSYBOX_DEFAULT_FEATURE_ACPID_COMPAT
 	default n
 config BUSYBOX_DEFAULT_BLKDISCARD
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_BLKID
 	bool
 	default n
@@ -1630,7 +1630,7 @@ config BUSYBOX_DEFAULT_FEATURE_HWCLOCK_ADJTIME_FHS
 	default n
 config BUSYBOX_DEFAULT_IONICE
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_IPCRM
 	bool
 	default n
@@ -1741,7 +1741,7 @@ config BUSYBOX_DEFAULT_FEATURE_MOUNT_OTHERTAB
 	default n
 config BUSYBOX_DEFAULT_MOUNTPOINT
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_NOLOGIN
 	bool
 	default n
@@ -1750,7 +1750,7 @@ config BUSYBOX_DEFAULT_NOLOGIN_DEPENDENCIES
 	default n
 config BUSYBOX_DEFAULT_NSENTER
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_PIVOT_ROOT
 	bool
 	default y
@@ -1789,16 +1789,16 @@ config BUSYBOX_DEFAULT_LINUX64
 	default n
 config BUSYBOX_DEFAULT_SETPRIV
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_SETPRIV_DUMP
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_SETPRIV_CAPABILITIES
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_SETPRIV_CAPABILITY_NAMES
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_SETSID
 	bool
 	default n
@@ -1840,7 +1840,7 @@ config BUSYBOX_DEFAULT_FEATURE_UMOUNT_ALL
 	default y
 config BUSYBOX_DEFAULT_UNSHARE
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_WALL
 	bool
 	default n

--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -2900,7 +2900,7 @@ config BUSYBOX_DEFAULT_WATCH
 	default y
 config BUSYBOX_DEFAULT_CHPST
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_SETUIDGID
 	bool
 	default n

--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -540,7 +540,7 @@ config BUSYBOX_DEFAULT_CRC32
 	default n
 config BUSYBOX_DEFAULT_COMM
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_CP
 	bool
 	default y
@@ -636,7 +636,7 @@ config BUSYBOX_DEFAULT_FALSE
 	default y
 config BUSYBOX_DEFAULT_FOLD
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_HEAD
 	bool
 	default y
@@ -735,7 +735,7 @@ config BUSYBOX_DEFAULT_NICE
 	default y
 config BUSYBOX_DEFAULT_NL
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_NOHUP
 	bool
 	default n
@@ -780,7 +780,7 @@ config BUSYBOX_DEFAULT_SHRED
 	default n
 config BUSYBOX_DEFAULT_SHUF
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_SLEEP
 	bool
 	default y
@@ -798,16 +798,16 @@ config BUSYBOX_DEFAULT_FEATURE_SORT_OPTIMIZE_MEMORY
 	default n
 config BUSYBOX_DEFAULT_SPLIT
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_SPLIT_FANCY
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_STAT
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_STAT_FORMAT
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_STAT_FILESYSTEM
 	bool
 	default n
@@ -828,7 +828,7 @@ config BUSYBOX_DEFAULT_FSYNC
 	default y
 config BUSYBOX_DEFAULT_TAC
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_TAIL
 	bool
 	default y
@@ -855,7 +855,7 @@ config BUSYBOX_DEFAULT_FEATURE_TEST_64
 	default y
 config BUSYBOX_DEFAULT_TIMEOUT
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_TOUCH
 	bool
 	default y

--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -2092,7 +2092,7 @@ config BUSYBOX_DEFAULT_I2CTRANSFER
 	default n
 config BUSYBOX_DEFAULT_INOTIFYD
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_LESS
 	bool
 	default y
@@ -2200,10 +2200,10 @@ config BUSYBOX_DEFAULT_TIME
 	default y
 config BUSYBOX_DEFAULT_TREE
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_TS
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_TTYSIZE
 	bool
 	default n
@@ -2233,7 +2233,7 @@ config BUSYBOX_DEFAULT_VOLNAME
 	default n
 config BUSYBOX_DEFAULT_WATCHDOG
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_WATCHDOG_OPEN_TWICE
 	bool
 	default n

--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -2267,7 +2267,7 @@ config BUSYBOX_DEFAULT_ARP
 	default n
 config BUSYBOX_DEFAULT_ARPING
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_BRCTL
 	bool
 	default y
@@ -2555,7 +2555,7 @@ config BUSYBOX_DEFAULT_FEATURE_FANCY_PING
 	default y
 config BUSYBOX_DEFAULT_PSCAN
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_ROUTE
 	bool
 	default y

--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -2789,7 +2789,7 @@ config BUSYBOX_DEFAULT_FREE
 	default y
 config BUSYBOX_DEFAULT_FUSER
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_IOSTAT
 	bool
 	default n
@@ -2810,13 +2810,13 @@ config BUSYBOX_DEFAULT_MPSTAT
 	default n
 config BUSYBOX_DEFAULT_NMETER
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_PGREP
 	bool
 	default y
 config BUSYBOX_DEFAULT_PKILL
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_PIDOF
 	bool
 	default y
@@ -2897,7 +2897,7 @@ config BUSYBOX_DEFAULT_FEATURE_UPTIME_UTMP_SUPPORT
 	default n
 config BUSYBOX_DEFAULT_WATCH
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_CHPST
 	bool
 	default n

--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -24,7 +24,7 @@ config BUSYBOX_DEFAULT_FEATURE_VERBOSE_USAGE
 	default y
 config BUSYBOX_DEFAULT_FEATURE_COMPRESS_USAGE
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_LFS
 	bool
 	default y


### PR DESCRIPTION
As [discussed on the OpenWrt forums](https://forum.openwrt.org/t/busybox-applets-included-in-openwrt-images-and-builds/165676/1) and briefly talked about with @hauke on IRC, I propose the following changes to the busybox default configuration for OpenWrt to provide more features for both interactive shell sessions and for scripting at the cost of a little binary size increase.

I hope the individual patches make it easy enough to cherry-pick what is deemed useful.

The busybox applets gained by merging this PR are the following:

-   comm
-   fold
-   nl
-   shuf
-   split
-   stat
-   tac
-   timeout
-   blkdiscard
-   ionice
-   mountpoint
-   nsenter
-   setpriv
-   unshare
-   inotifyd
-   tree
-   ts
-   watchdog
-   arping
-   pscan
-   fuser
-   nmeter
-   pkill
-   watch
-   chpst

Thank you for your consideration, and also for making OpenWrt happen! :sunglasses: