### PR TITLE
octeon: ubnt-edgerouter-6p: isl28022 power monitor added to device tree

### DIFF
--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-6p.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-6p.dts
@@ -62,3 +62,15 @@
 	};
 };
 
+&twsi1 {
+	status = "okay";
+
+	pmon@40 {
+		compatible = "isl,isl28022";
+		reg = <0x40>;
+		shunt-resistor-micro-ohms = <8000>;
+		shunt-gain = <1>;
+		average = <128>;
+	};
+};
+


### PR DESCRIPTION
TBD: check if also used on ubnt-edgerouter-4

Thanks for your contribution to OpenWrt!

Signed-off-by: Carsten Spieß <mail@carsten-spiess.de>
