### PR TITLE
linux-firmware: add backports

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
 PKG_VERSION:=20230625
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/package/firmware/linux-firmware/patches/200-partially-revert-amdgpu-dmcub-updates.patch
+++ b/package/firmware/linux-firmware/patches/200-partially-revert-amdgpu-dmcub-updates.patch
@@ -1,0 +1,25 @@
+From d3f66064cf43bd7338a79174bd0ff60c4ecbdf6d Mon Sep 17 00:00:00 2001
+From: Hamza Mahfooz <hamza.mahfooz@amd.com>
+Date: Wed, 5 Jul 2023 16:56:35 -0400
+Subject: Partially revert "amdgpu: DMCUB updates for DCN 3.1.4 and 3.1.5"
+
+This partially reverts commit ade163aaaeae0c1ad20cb3dd8ce878bf61c91b3a.
+
+The DCN315 DMCUB firmware update provided by the aforementioned commit
+wasn't thoroughly tested before being sent for public consumption and as
+such there are a number of issues with it. So, revert to the previous
+version until it can be fixed properly.
+
+Link: https://gitlab.freedesktop.org/drm/amd/-/issues/2666
+Signed-off-by: Hamza Mahfooz <hamza.mahfooz@amd.com>
+Signed-off-by: Josh Boyer <jwboyer@kernel.org>
+---
+ amdgpu/dcn_3_1_5_dmcub.bin | Bin 301344 -> 177296 bytes
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+diff --git a/amdgpu/dcn_3_1_5_dmcub.bin b/amdgpu/dcn_3_1_5_dmcub.bin
+index 18209407..a6686d44 100644
+Binary files a/amdgpu/dcn_3_1_5_dmcub.bin and b/amdgpu/dcn_3_1_5_dmcub.bin differ
+-- 
+cgit 
+

--- a/package/firmware/linux-firmware/patches/201-linux-firmware-update-amd-cpu-ucode.patch
+++ b/package/firmware/linux-firmware/patches/201-linux-firmware-update-amd-cpu-ucode.patch
@@ -1,0 +1,77 @@
+From b250b32ab1d044953af2dc5e790819a7703b7ee6 Mon Sep 17 00:00:00 2001
+From: John Allen <john.allen@amd.com>
+Date: Tue, 18 Jul 2023 23:19:59 +0000
+Subject: linux-firmware: Update AMD cpu microcode
+
+* Update AMD cpu microcode for processor family 19h
+
+Key Name        = AMD Microcode Signing Key (for signing microcode container files only)
+Key ID          = F328AE73
+Key Fingerprint = FC7C 6C50 5DAF CC14 7183 57CA E4BE 5339 F328 AE73
+
+Signed-off-by: John Allen <john.allen@amd.com>
+Signed-off-by: Josh Boyer <jwboyer@kernel.org>
+---
+ WHENCE                                 |   2 +-
+ amd-ucode/README                       |   6 +++---
+ amd-ucode/microcode_amd_fam19h.bin     | Bin 16804 -> 16804 bytes
+ amd-ucode/microcode_amd_fam19h.bin.asc |  16 ++++++++--------
+ 4 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/WHENCE b/WHENCE
+index de23a75e..b92e5299 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -3912,7 +3912,7 @@ Raw: amd-ucode/microcode_amd_fam17h.bin
+ Version: 2023-04-13
+ File: amd-ucode/microcode_amd_fam19h.bin
+ Raw: amd-ucode/microcode_amd_fam19h.bin
+-Version: 2023-01-31
++Version: 2023-07-18
+ File: amd-ucode/README
+ 
+ License: Redistributable. See LICENSE.amd-ucode for details
+diff --git a/amd-ucode/README b/amd-ucode/README
+index 0d97f910..4308fe2d 100644
+--- a/amd-ucode/README
++++ b/amd-ucode/README
+@@ -36,6 +36,6 @@ Microcode patches in microcode_amd_fam17h.bin:
+   Family=0x17 Model=0x31 Stepping=0x00: Patch=0x08301072 Length=3200 bytes
+ 
+ Microcode patches in microcode_amd_fam19h.bin:
+-  Family=0x19 Model=0x01 Stepping=0x00: Patch=0x0a001078 Length=5568 bytes
+-  Family=0x19 Model=0x01 Stepping=0x01: Patch=0x0a0011ce Length=5568 bytes
+-  Family=0x19 Model=0x01 Stepping=0x02: Patch=0x0a001231 Length=5568 bytes
++  Family=0x19 Model=0x01 Stepping=0x01: Patch=0x0a0011d1 Length=5568 bytes
++  Family=0x19 Model=0x01 Stepping=0x00: Patch=0x0a001079 Length=5568 bytes
++  Family=0x19 Model=0x01 Stepping=0x02: Patch=0x0a001234 Length=5568 bytes
+diff --git a/amd-ucode/microcode_amd_fam19h.bin b/amd-ucode/microcode_amd_fam19h.bin
+index 4bd623e1..50470c3f 100644
+Binary files a/amd-ucode/microcode_amd_fam19h.bin and b/amd-ucode/microcode_amd_fam19h.bin differ
+diff --git a/amd-ucode/microcode_amd_fam19h.bin.asc b/amd-ucode/microcode_amd_fam19h.bin.asc
+index 7c5193cf..a32b4d61 100644
+--- a/amd-ucode/microcode_amd_fam19h.bin.asc
++++ b/amd-ucode/microcode_amd_fam19h.bin.asc
+@@ -1,11 +1,11 @@
+ -----BEGIN PGP SIGNATURE-----
+ 
+-iQEzBAABCgAdFiEE/HxsUF2vzBRxg1fK5L5TOfMornMFAmPS0gkACgkQ5L5TOfMo
+-rnMWewf/SNlPcRuJ/RPEKThbPJyToBi98e7QLqlGkuIQ7sZBjZ/zZIycQDkQgjVV
+-MpO8E2yxn0Pp/2T6IzGBLPWpMVgvCabIn2gRe3qvRbJ5dYnxU3I5hfCITGHG0z2K
+-OgH3Z51aKZGX0fCRHKdrtVf9RMdcYcVHD9NU48q8x8gArdRg+IZSCPzqD3dNw7nT
+-TS2WHNiMzyqXkkqqkroofljUSZcuMIqDDEsfIB9LDQjFCMYEththlC0m0wz1QIRv
+-HJCJZ8p/E8xMPLEp0JvhA1zxBePlyKmKtHLxhslyvEePJif5fHECEx95Q2xYRS+F
+-rMXPlWVgxXzeM1NUxEBDM8vI6gaXtQ==
+-=+Rqf
++iQEzBAABCgAdFiEE/HxsUF2vzBRxg1fK5L5TOfMornMFAmS3F00ACgkQ5L5TOfMo
++rnNEhQgAizSV8IFpvaYNytaJKLA4uevrZneGPV4czjCXnnj1yHpfQmCTyZQnoLnx
++7gyzf7K5271zO51FBQ5z2Nm48a3XPUhMbQLNP4BZdekLiA3bRpMtSyHct6zD0ULm
++xaFaOQ7MR1tGADhlon1bDvtnOuixUhwrZhEIlR9MzQAzERKDMOAVTbxn9ZhMfYiT
++LhA791Blyyi+6Z9uh7BpaA8l8uvoxt+uuvlBTjQMR3ER/TEjgcsoy+XhhK4QKS0V
++wJCtcDle/3pF+N6SAFWiXbNZ+P8p19afhcYddDl97xtpzA6/8b20a2eHkrqnu/Ds
++jTozF9kmhiifYMYpXtXgSOwI3GRZbQ==
++=t+j1
+ -----END PGP SIGNATURE-----
+-- 
+cgit 
+

--- a/package/firmware/linux-firmware/patches/202-update-amd-cpu-microcode-for-17h.patch
+++ b/package/firmware/linux-firmware/patches/202-update-amd-cpu-microcode-for-17h.patch
@@ -1,0 +1,78 @@
+From 0bc3126c9cfa0b8c761483215c25382f831a7c6f Mon Sep 17 00:00:00 2001
+From: John Allen <john.allen@amd.com>
+Date: Wed, 19 Jul 2023 19:17:57 +0000
+Subject: linux-firmware: Update AMD fam17h cpu microcode
+
+* Update AMD cpu microcode for processor family 17h
+
+Key Name        = AMD Microcode Signing Key (for signing microcode container files only)
+Key ID          = F328AE73
+Key Fingerprint = FC7C 6C50 5DAF CC14 7183 57CA E4BE 5339 F328 AE73
+
+Signed-off-by: John Allen <john.allen@amd.com>
+Signed-off-by: Josh Boyer <jwboyer@kernel.org>
+---
+ WHENCE                                 |   2 +-
+ amd-ucode/README                       |   3 ++-
+ amd-ucode/microcode_amd_fam17h.bin     | Bin 9700 -> 12924 bytes
+ amd-ucode/microcode_amd_fam17h.bin.asc |  16 ++++++++--------
+ 4 files changed, 11 insertions(+), 10 deletions(-)
+
+diff --git a/WHENCE b/WHENCE
+index b92e5299..dcb86fab 100644
+--- a/WHENCE
++++ b/WHENCE
+@@ -3909,7 +3909,7 @@ Raw: amd-ucode/microcode_amd_fam16h.bin
+ Version: 2014-10-28
+ File: amd-ucode/microcode_amd_fam17h.bin
+ Raw: amd-ucode/microcode_amd_fam17h.bin
+-Version: 2023-04-13
++Version: 2023-07-19
+ File: amd-ucode/microcode_amd_fam19h.bin
+ Raw: amd-ucode/microcode_amd_fam19h.bin
+ Version: 2023-07-18
+diff --git a/amd-ucode/README b/amd-ucode/README
+index 4308fe2d..1d39da3b 100644
+--- a/amd-ucode/README
++++ b/amd-ucode/README
+@@ -32,8 +32,9 @@ Microcode patches in microcode_amd_fam16h.bin:
+ 
+ Microcode patches in microcode_amd_fam17h.bin:
+   Family=0x17 Model=0x08 Stepping=0x02: Patch=0x0800820d Length=3200 bytes
++  Family=0x17 Model=0x31 Stepping=0x00: Patch=0x0830107a Length=3200 bytes
++  Family=0x17 Model=0xa0 Stepping=0x00: Patch=0x08a00008 Length=3200 bytes
+   Family=0x17 Model=0x01 Stepping=0x02: Patch=0x0800126e Length=3200 bytes
+-  Family=0x17 Model=0x31 Stepping=0x00: Patch=0x08301072 Length=3200 bytes
+ 
+ Microcode patches in microcode_amd_fam19h.bin:
+   Family=0x19 Model=0x01 Stepping=0x01: Patch=0x0a0011d1 Length=5568 bytes
+diff --git a/amd-ucode/microcode_amd_fam17h.bin b/amd-ucode/microcode_amd_fam17h.bin
+index 37d899cd..f9841b65 100644
+Binary files a/amd-ucode/microcode_amd_fam17h.bin and b/amd-ucode/microcode_amd_fam17h.bin differ
+diff --git a/amd-ucode/microcode_amd_fam17h.bin.asc b/amd-ucode/microcode_amd_fam17h.bin.asc
+index 27da52c8..34a40245 100644
+--- a/amd-ucode/microcode_amd_fam17h.bin.asc
++++ b/amd-ucode/microcode_amd_fam17h.bin.asc
+@@ -1,11 +1,11 @@
+ -----BEGIN PGP SIGNATURE-----
+ 
+-iQEzBAABCgAdFiEE/HxsUF2vzBRxg1fK5L5TOfMornMFAmQeEvgACgkQ5L5TOfMo
+-rnPOpAf/dYhPqq/ktg1muI/khV4EhDiguX6OXib3fmfSZdvPIAI0cRI77M3Lvf0b
+-nlV8D67e5HOQ5foJbix5tunz0sZjqr2QU8U9dNk/ut0KC7UiCRc8VH40aSi/OQBG
+-Y8c7tb6IJ+N+jyJ6Ii6koUuRO2Lk2MckcrWLRuLRV4bB+osyJrGjc/X54Z6UJ/Ma
+-VDg13Yxy5WvC7sMmlmnY42JLeLBKDVUvg0zDvJ4aOLLxRE2l3eiAKE+TV122LmxN
+-ca5WA/ESYQ9BjxHYIrpTd9nQaWa/TIZ+rOmJGLMtnQ1gGlW97zQuJR7zh+8vdLzC
+-iwVlS1cu7kcV7KYDytTkWJ+2gwb3uQ==
+-=lP2S
++iQEzBAABCgAdFiEE/HxsUF2vzBRxg1fK5L5TOfMornMFAmS4Mm4ACgkQ5L5TOfMo
++rnN35wgAkllCunxE6J5hQyLMx5o4WTHZkbNvXmu6nV1Y3vjiL1oeaK+pmx8BlkPt
++fGZJCe/068kqmp3N4EtOZLxXn55t3jNBYectPr0RmFqpjMsEJEcfXfuXROA4N9Ti
++Zd/o6X21eHEsm0kK0q4YfppfgTd5Ze7k1jTkUuuU6/yh6uRk1MiFreEzkPO3Aayh
++iEWlYx33vq3HccTPgdY3D64Zr8gmgKG+8mdEvqb1jK4SVZ1/9vy4OKIIpUZB/eqx
++46h9Ejwn9pktnYkHi/A/zCREEcIQ10HXFF5bjxJTFQkM5S46/QEO7uuvnpMb+6Yy
++4V1/QIWMG6ixqCRx9GqbBK7GHdYODw==
++=+IsI
+ -----END PGP SIGNATURE-----
+-- 
+cgit 
+


### PR DESCRIPTION
* Revert DMCUB firmware
* Update AMD ucode for 17th and 19th family to mitigate CVE-2023-20593 (aka Zenbleed)
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-20593
https://lock.cmpxchg8b.com/zenbleed.html

Build system: x86/64
Build-tested: x86/64/Ryzen 7
Run-tested: x86/64/Ryzen 7

Thanks for your contribution to OpenWrt!