### PR TITLE
ipq40xx: fit multiple dts inside of a single device image

### DIFF
--- a/scripts/mkits-tlt-rutx-fit.sh
+++ b/scripts/mkits-tlt-rutx-fit.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Licensed under the terms of the GNU GPL License version 2 or later.
+# Author: Samuele Barella <dotsynergy@proton.me>, based on mkits-qsdk-ipq-image.sh and mkits.sh from Teltonika's RUTX SDK.
+
+usage() {
+	printf "Usage: %s -A arch -C comp -a addr -e entry" "$(basename "$0")"
+	printf " -v version -k kernel [-D name -n address -d dtb] -o its_file"
+
+	printf "\n\t-A ==> set architecture to 'arch'"
+	printf "\n\t-C ==> set compression type 'comp'"
+	printf "\n\t-c ==> set config name 'config'"
+	printf "\n\t-a ==> set load address to 'addr' (hex)"
+	printf "\n\t-e ==> set entry point to 'entry' (hex)"
+	printf "\n\t-v ==> set kernel version to 'version'"
+	printf "\n\t-k ==> include kernel image 'kernel'"
+	printf "\n\t-D ==> human friendly Device Tree Blob 'name'"
+	printf "\n\t-n ==> fdt unit-address 'address'"
+	printf "\n\t-d ==> include Device Tree Blob 'dtb'"
+	printf "\n\t-o ==> create output file 'its_file'\n"
+	exit 1
+}
+
+FDTNUM=1
+
+while getopts ":A:a:c:C:D:d:e:k:n:o:v:" OPTION
+do
+	case $OPTION in
+		A ) ARCH=$OPTARG;;
+		a ) LOAD_ADDR=$OPTARG;;
+		c ) CONFIG=$OPTARG;;
+		C ) COMPRESS=$OPTARG;;
+		D ) DEVICE=$OPTARG;;
+		d ) DTB=$OPTARG;;
+		e ) ENTRY_ADDR=$OPTARG;;
+		k ) KERNEL=$OPTARG;;
+		n ) FDTNUM=$OPTARG;;
+		o ) OUTPUT=$OPTARG;;
+		v ) VERSION=$OPTARG;;
+		* ) echo "Invalid option passed to '$0' (options:$*)"
+		usage;;
+	esac
+done
+
+# Make sure user entered all required parameters
+if [ -z "${ARCH}" ] || [ -z "${COMPRESS}" ] || [ -z "${LOAD_ADDR}" ] || \
+	[ -z "${ENTRY_ADDR}" ] || [ -z "${VERSION}" ] || [ -z "${KERNEL}" ] || \
+	[ -z "${OUTPUT}" ] || [ -z "${CONFIG}" ]; then
+	usage
+fi
+
+ARCH_UPPER=$(echo "$ARCH" | tr '[:lower:]' '[:upper:]')
+
+# Conditionally create fdt information
+if [ -n "${DTB}" ]; then
+	FDTNUM=0
+	DEFAULT_CONFIG=$FDTNUM
+
+	DTB_DIR="${DTB%%{*}"
+	DTB="${DTB##*{}"
+	DTB_CSV="${DTB##*{}"
+	DTB_CSV="${DTB%\}*}"
+	IFS=,
+	for f in $DTB_CSV; do
+		FDTNUM=$((FDTNUM+1))
+
+		ff="${DTB_DIR}/${f}"
+		[ -f "${ff}" ] || {
+			echo "ERROR: no DTBs found" >&2
+			rm -f "${OUTPUT}"
+			exit 1
+		}
+
+		FDT_NODE="${FDT_NODE}
+
+			fdt@$FDTNUM {
+				description = \"${f}\";
+				data = /incbin/(\"${ff}\");
+				type = \"flat_dt\";
+				arch = \"${ARCH}\";
+				compression = \"none\";
+				hash@1 {
+					algo = \"crc32\";
+				};
+				hash@2 {
+					algo = \"sha1\";
+				};
+			};
+"
+
+		f="${f#*rutx}"
+		# Remove the file extension
+		f="${f%.dtb}"
+
+		CONFIG_NODE="${CONFIG_NODE}
+
+			conf_mdtb@${FDTNUM} {
+			description = \"${f}\";
+			kernel = \"kernel@1\";
+			fdt = \"fdt@$FDTNUM\";
+		};
+"
+	done
+fi
+
+# Create a default, fully populated DTS file
+DATA="/dts-v1/;
+
+/ {
+	description = \"${ARCH_UPPER} OpenWrt FIT (Flattened Image Tree)\";
+	#address-cells = <1>;
+
+	images {
+		kernel@1 {
+			description = \"${ARCH_UPPER} OpenWrt Linux-${VERSION}\";
+			data = /incbin/(\"${KERNEL}\");
+			type = \"kernel\";
+			arch = \"${ARCH}\";
+			os = \"linux\";
+			compression = \"${COMPRESS}\";
+			load = <${LOAD_ADDR}>;
+			entry = <${ENTRY_ADDR}>;
+			hash@1 {
+				algo = \"crc32\";
+			};
+			hash@2 {
+				algo = \"sha1\";
+			};
+		};
+${FDT_NODE}
+	};
+
+	configurations {
+		default = \"${DEFAULT_CONFIG}\";
+${CONFIG_NODE}
+	};
+};"
+
+# Write .its file to disk
+echo "$DATA" > "${OUTPUT}"

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-rutx-shiftreg.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-rutx-shiftreg.dtsi
@@ -1,0 +1,27 @@
+#include "qcom-ipq4018-rutx.dtsi"
+
+/ {
+	io_expander = "shiftreg_1";
+
+	soc {
+		ext_io {
+			compatible = "spi-gpio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			gpio-sck = <&tlmm 1 GPIO_ACTIVE_HIGH>;  // SRCLK
+			gpio-mosi = <&tlmm 3 GPIO_ACTIVE_HIGH>; // SER
+			cs-gpios = <&tlmm 2 GPIO_ACTIVE_HIGH>;  // RCLK
+			num-chipselects = <1>;
+
+			shift_io: shift_io@0 {
+				compatible = "fairchild,74hc595";
+				reg = <0>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				registers-number = <3>;
+				spi-max-frequency = <10000000>;
+			};
+		};
+	};
+};

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-rutx-stm32.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-rutx-stm32.dtsi
@@ -1,0 +1,55 @@
+#include "qcom-ipq4018-rutx.dtsi"
+
+/ {
+	io_expander = "stm32";
+
+	soc {
+		
+		pinctrl@1000000 {
+			i2c_0_pins: i2c_0_pinmux {
+				mux {
+					pins = "gpio58", "gpio59";
+					function = "blsp_i2c0";
+					bias-disable;
+				};
+			};
+		};
+
+		gpio_export {
+			compatible = "gpio-export";
+			#size-cells = <0>;
+
+			gpio_out {
+				gpio-export,name = "gpio_out";
+				gpio-export,output = <0>;
+				gpio-export,direction_may_change = <0>;
+				gpios = <&stm32_io 23 GPIO_ACTIVE_HIGH>;
+			};
+
+			gpio_in {
+				gpio-export,name = "gpio_in";
+				gpio-export,input = <0>;
+				gpio-export,direction_may_change = <0>;
+				gpios = <&stm32_io 24 GPIO_ACTIVE_LOW>;
+			};
+		};
+	};
+};
+
+&blsp1_i2c3 {
+	status = "okay";
+	pinctrl-0 = <&i2c_0_pins>;
+	pinctrl-names = "default";
+	clock-frequency = <400000>;
+
+	stm32_io: stm32@74 {
+		compatible = "tlt,stm32v1";
+		#gpio-cells = <2>;
+		#interrupt-cells = <2>;
+		gpio-controller;
+		interrupt-controller;
+		interrupt-parent = <&tlmm>;
+		interrupts = <5 2>;
+		reg = <0x74>;
+	};
+};

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-rutx.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-rutx.dtsi
@@ -25,14 +25,6 @@
 					bias-pull-up;
 				};
 			};
-
-			i2c_0_pins: i2c_0_pinmux {
-				mux {
-					pins = "gpio58", "gpio59";
-					function = "blsp_i2c0";
-					bias-disable;
-				};
-			};
 		};
 
 		keys {

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-rutx10_STM32.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-rutx10_STM32.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "qcom-ipq4018-rutx-shiftreg.dtsi"
+#include "qcom-ipq4018-rutx-stm32.dtsi"
 
 / {
 	model = "Teltonika RUTX10";
@@ -12,13 +12,13 @@
 
 			wifi2g {
 				label = "green:wifi2g";
-				gpios = <&shift_io 5 GPIO_ACTIVE_HIGH>;
+				gpios = <&stm32_io 19 GPIO_ACTIVE_HIGH>;
 				linux,default-trigger = "phy0tpt";
 			};
 
 			wifi5g {
 				label = "green:wifi5g";
-				gpios = <&shift_io 6 GPIO_ACTIVE_HIGH>;
+				gpios = <&stm32_io 18 GPIO_ACTIVE_HIGH>;
 				linux,default-trigger = "phy1tpt";
 			};
 		};
@@ -31,14 +31,14 @@
 				gpio-export,name = "gpio_out";
 				gpio-export,output = <0>;
 				gpio-export,direction_may_change = <0>;
-				gpios = <&shift_io 0 GPIO_ACTIVE_HIGH>;
+				gpios = <&stm32_io 23 GPIO_ACTIVE_HIGH>;
 			};
 
 			gpio_in {
 				gpio-export,name = "gpio_in";
 				gpio-export,input = <0>;
 				gpio-export,direction_may_change = <0>;
-				gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
+				gpios = <&stm32_io 24 GPIO_ACTIVE_LOW>;
 			};
 		};
 	};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -3,9 +3,27 @@ DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID
 DEVICE_VARS += RAS_BOARD RAS_ROOTFS_SIZE RAS_VERSION
 DEVICE_VARS += WRGG_DEVNAME WRGG_SIGNATURE
 
+define Build/tlt-rutx-fit
+	$(TOPDIR)/scripts/mkits-tlt-rutx-fit.sh \
+		-D $(DEVICE_NAME) -o $@.its -k $@ \
+		$(if $(word 2,$(1)),-d $(word 2,$(1))) -C $(word 1,$(1)) \
+		-a $(KERNEL_LOADADDR) -e $(if $(KERNEL_ENTRY),$(KERNEL_ENTRY),$(KERNEL_LOADADDR)) \
+		$(if $(DEVICE_FDT_NUM),-n $(DEVICE_FDT_NUM)) \
+		-c $(if $(DEVICE_DTS_CONFIG),$(DEVICE_DTS_CONFIG),"config@1") \
+		-A $(LINUX_KARCH) -v $(LINUX_VERSION)
+	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
+	@mv $@.new $@
+endef
+
 define Device/FitImage
 	KERNEL_SUFFIX := -uImage.itb
 	KERNEL = kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
+	KERNEL_NAME := Image
+endef
+
+define Device/TLTFitImage
+	KERNEL_SUFFIX := -fit-uImage.itb
+	KERNEL = kernel-bin | gzip | tlt-rutx-fit gzip "$$(KDIR)/{$$(subst $$(space),$$(comma),$$(addprefix image-,$$(addsuffix .dtb,$$(DEVICE_DTS))))}"
 	KERNEL_NAME := Image
 endef
 
@@ -1060,7 +1078,7 @@ endef
 TARGET_DEVICES += sony_ncp-hg100-cellular
 
 define Device/teltonika_rutx10
-	$(call Device/FitImage)
+	$(call Device/TLTFitImage)
 	$(call Device/UbiFit)
 	DEVICE_VENDOR := Teltonika
 	DEVICE_MODEL := RUTX10
@@ -1072,9 +1090,10 @@ define Device/teltonika_rutx10
 	FILESYSTEMS := squashfs
 	IMAGE/factory.ubi := append-ubi | qsdk-ipq-factory-nand | append-rutx-metadata
 	DEVICE_PACKAGES := kmod-bluetooth
+	DEVICE_DTS := \
+		qcom-ipq4018-rutx10_STM32 qcom-ipq4018-rutx10
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += teltonika_rutx10
+TARGET_DEVICES += teltonika_rutx10
 
 define Device/teltonika_rutx50
 	$(call Device/FitImage)


### PR DESCRIPTION
Since the manufacturer discontinued STM32 versions of the base board for RUTX10 and other models in the RUTX line, new devices will not work and the support is broken. 

This aims to fix it, by implementing a script tailored to RUTX devices that fits multiple DTSes in a single device image, allowing boot for both the STM32 and Shiftreg versions (currently only for RUTX10, affected). This paves the way for RUTX11, RUTX12, RUTX14 support, all of which suffer from this board revision differences, to be supported in future PRs.

Uboot on RUTX devices parses the FIT description, and looks in the configuration entries `conf_mdtb@X` for a the Description field. It must match either `NN` or `NN_STM32`, with NN the two model digits. If it finds a match for the device (e.g. RUTX10 STM32 -> 10_STM32) it selects the corresponding DTS from the `fdt@X` entries.

Output from custom `mkits.sh` script:
```
FIT description: ARM OpenWrt FIT (Flattened Image Tree)
Created:         Wed Jul 26 11:17:24 2023
 Image 0 (kernel@1)
  Description:  ARM OpenWrt Linux-5.15.120
  Created:      Wed Jul 26 11:17:24 2023
  Type:         Kernel Image
  Compression:  gzip compressed
  Data Size:    8963035 Bytes = 8752.96 KiB = 8.55 MiB
  Architecture: ARM
  OS:           Linux
  Load Address: 0x80208000
  Entry Point:  0x80208000
  Hash algo:    crc32
  Hash value:   ff9421a8
  Hash algo:    sha1
  Hash value:   844ad650543eee71f64a85d6c4c3907b9112ccdf
 Image 1 (fdt@1)
  Description:  image-qcom-ipq4018-rutx10_STM32.dtb
  Created:      Wed Jul 26 11:17:24 2023
  Type:         Flat Device Tree
  Compression:  uncompressed
  Data Size:    18631 Bytes = 18.19 KiB = 0.02 MiB
  Architecture: ARM
  Hash algo:    crc32
  Hash value:   18f6acab
  Hash algo:    sha1
  Hash value:   cd514e1aff5a867642c55d7d126c38d33b34a951
 Image 2 (fdt@2)
  Description:  image-qcom-ipq4018-rutx10.dtb
  Created:      Wed Jul 26 11:17:24 2023
  Type:         Flat Device Tree
  Compression:  uncompressed
  Data Size:    18659 Bytes = 18.22 KiB = 0.02 MiB
  Architecture: ARM
  Hash algo:    crc32
  Hash value:   d6d841c8
  Hash algo:    sha1
  Hash value:   fd91aa7f86435fe10f5a98798778e908b09a6e69
 Default Configuration: '0'
 Configuration 0 (conf_mdtb@1)
  Description:  10_STM32
  Kernel:       kernel@1
  FDT:          fdt@1
 Configuration 1 (conf_mdtb@2)
  Description:  10
  Kernel:       kernel@1
  FDT:          fdt@2
```

Related thread on the forum: https://forum.openwrt.org/t/teltonika-rutx-dealing-with-uboot-selected-multiple-device-trees/165423