### PR TITLE
ipq4019: fix support for AVM FRITZ!Repeater 3000

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-fritzrepeater-3000.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-fritzrepeater-3000.dts
@@ -121,6 +121,9 @@
 	status = "okay";
 
 	nand@0 {
+		/delete-property/ nand-ecc-strength;
+		/delete-property/ nand-ecc-step-size;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;


### PR DESCRIPTION
Same as #13101 but for 23.05 branch