### PR TITLE
mediatek: filogic: add 360-t7-108M support

### DIFF
--- a/target/linux/mediatek/dts/mt7981-360-t7-108M.dts
+++ b/target/linux/mediatek/dts/mt7981-360-t7-108M.dts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "360 T7";
+	compatible = "360,t7", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x10000000>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: red {
+			label = "red:status";
+			gpios = <&pio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: green {
+			label = "green:status";
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+};
+
+&mdio_bus {
+	switch: switch@0 {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		compatible = "spi-nand";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bl2";
+				reg = <0x0000000 0x0100000>;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x0180000 0x0200000>;
+			};
+
+			partition@380000 {
+				label = "fip";
+				reg = <0x0380000 0x0200000>;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x0580000 0x6c00000>;
+			};
+
+			partition@7180000 {
+				label = "config";
+				reg = <0x7180000 0x0100000>;
+			};
+
+			partition@7280000 {
+				label = "factory";
+				reg = <0x7280000 0x0080000>;
+			};
+
+			partition@7300000 {
+				label = "log";
+				reg = <0x7300000 0x0400000>;
+			};
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan3";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan1";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "wan";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -39,6 +39,7 @@ mediatek_setup_interfaces()
 	mercusys,mr90x-v1)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2" eth1
 		;;
+	360,t7|\
 	qihoo,360t7)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
 		;;
@@ -92,6 +93,7 @@ mediatek_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii u-boot-env mac)
 		label_mac=$lan_mac
 		;;
+	360,t7|\
 	qihoo,360t7)
 		lan_mac=$(mtd_get_mac_ascii factory lanMac)
 		wan_mac=$(macaddr_add "$lan_mac" 1)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -47,6 +47,7 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 3 > /sys${DEVPATH}/macaddress
 		;;
+	360,t7|\
 	qihoo,360t7)
 		addr=$(mtd_get_mac_ascii factory lanMac)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -83,6 +83,7 @@ platform_do_upgrade() {
 		nand_do_upgrade "$1"
 		;;
 	h3c,magic-nx30-pro|\
+	360,t7|\
 	qihoo,360t7|\
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -83,7 +83,6 @@ platform_do_upgrade() {
 		nand_do_upgrade "$1"
 		;;
 	h3c,magic-nx30-pro|\
-	360,t7|\
 	qihoo,360t7|\
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -297,6 +297,27 @@ define Device/mercusys_mr90x-v1
 endef
 TARGET_DEVICES += mercusys_mr90x-v1
 
+define Device/360_t7
+  DEVICE_VENDOR := MediaTek
+  DEVICE_MODEL := 360 T7 (with 108M ubi)
+  DEVICE_DTS := mt7981-360-t7-108M
+  DEVICE_DTS_DIR := ../dts
+  SUPPORTED_DEVICES := 360,t7
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 110592k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+    KERNEL = kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS = kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+endef
+TARGET_DEVICES += 360_t7
+
 define Device/qihoo_360t7
   DEVICE_VENDOR := Qihoo
   DEVICE_MODEL := 360T7


### PR DESCRIPTION
 mediatek: filogic: add 360-t7-108M support

Hardware specification:
  SoC: MediaTek MT7981B 2x A53
  Flash: ESMT F50L1G41LB 128MB
  RAM: MT5CC128M16JR-EK 256MB
  Ethernet: 4x 10/100/1000 Mbps
  Switch: MediaTek MT7531AE
  WiFi: MediaTek MT7976C
  Button: Reset, WPS
  Power: DC 12V 1A

刷机方法来源
感谢hanwckf's blog
https://cmi.hanwckf.top/p/360t7-firmware/

步骤简介：
1.拆机后找到UART串口。线序由上到下为RXD，TXD，GND，波特率115200
2.打开串口助手，上电，等待机器启动后，不断按下 f和回车键 ，直到出现下面的提示后，即可进入failsafe模式
------------------------------------------------
*********
[   10.205973] wed_get_slot_map(): assign slot_id:0 for entry: 0!
[   10.211812] wed_get_slot_map(): assign slot_id:1 for entry: 1!
[   10.218061] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[   10.235722] init: - preinit -
[   10.539480] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[   10.547859] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
------------------------------------------------


出现‘Press the [f] key and hit [enter] to enter failsafe mode’
输入如下命令
-------------------------------
f
 
fw_setenv bootmenu_delay 3
mount_root
sed -i 's/.*local debug=.*/\tlocal debug=1/' /etc/init.d/telnet
reboot
 
-------------------------------

重启后显示如下
------------------------------
welcome to the boot loader!

  *** U-Boot Boot Menu ***

     1. Startup system (Default)
     2. Upgrade firmware
     3. Upgrade ATF BL2
     4. Upgrade ATF FIP
     5. Upgrade single image
     6. Load image
     0. U-Boot console


  Press UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit
-------------------------------

按下‘4’ 进入人Upgrade ATF FIP
------------------------------
*** Upgrading ATF FIP ***

Available load methods:
    0 - TFTP client (Default)
    1 - Xmodem
    2 - Ymodem
    3 - Kermit
    4 - S-Record
    5 - RAM

Select (enter for default):

Input U-Boot's IP address: 192.168.1.1        #回车
Input TFTP server's IP address: 192.168.1.2   #回车（电脑设置固定ip地址192.168.1.2 运行tftp64 选包含360t7-fip-fixed-parts.bin文件夹）
Input IP netmask: 255.255.255.0               #回车
Input file name: 360t7-fip-fixed-parts.bin    #输入文件名360t7-fip-fixed-parts.bin

TFTP from server 192.168.1.2; our IP address is 192.168.1.1   #以下为执行日志
Filename '360t7-fip-fixed-parts.bin'.
Load address: 0x46000000
Loading: ################################################
         133.8 KiB/s
done
Bytes transferred = 694097 (a9751 hex)
Saving Environment to MTD... Erasing on MTD device 'nmbm0'... OK
Writing to MTD device 'nmbm0'... OK
OK

*** Loaded 694097 (0xa9751) bytes at 0x46000000 ***

Erasing from 0x0 to 0xbffff, size 0xc0000 ... OK
Writing from 0x46000000 to 0x0, size 0xa9751 ... OK
Verifying from 0x0 to 0xa9750, size 0xa9751 ... OK

*** ATF FIP upgrade completed! ***

Erasing environment from 0x100000 to 0x11ffff, size 0x20000 ... OK       #显示这个ok uboot已经刷入
MT7981>
------------------------------------------------------------------------------


路由器断电下按下“reset”不松开  插入电源。8秒后松开。指示灯变绿色
浏览器打开192.168.1.1,进web界面的固件恢复，上传编译的固件openwrt-mediatek-filogic-360_t7-squashfs-factory.bin



Signed-off-by: Chukun Pan <zhc9709@qq.com>