### PR TITLE
ath11k-firmware: update to stable WLAN.HK.2.9.0.1-01862

### DIFF
--- a/package/firmware/ath11k-firmware/Makefile
+++ b/package/firmware/ath11k-firmware/Makefile
@@ -8,9 +8,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ath11k-firmware
-PKG_SOURCE_DATE:=2023-07-06
-PKG_SOURCE_VERSION:=69f6b7346b64784188dba791a9cfb614eefa441f
-PKG_MIRROR_HASH:=0f0203f755cb6713f6a1f41397dcd0f1a24e5cdbe75258af961343b927ebb3e9
+PKG_SOURCE_DATE:=2023-07-28
+PKG_SOURCE_VERSION:=006a4e2a23a6cf9e7a28d8349025a4418e39cb1d
+PKG_MIRROR_HASH:=1043b8c01d28cad2a34e4586e4e6a3949bd1aed9f9afd5b71f527b6b23835e81
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
@@ -60,14 +60,14 @@ $(eval $(call Download,qcn9074-board))
 define Package/ath11k-firmware-ipq8074/install
 	$(INSTALL_DIR) $(1)/lib/firmware/IPQ8074
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/ath11k-firmware/IPQ8074/hw2.0/2.9.0.1/WLAN.HK.2.9.0.1-01837-QCAHKSWPL_SILICONZ-1/* \
+		$(PKG_BUILD_DIR)/ath11k-firmware/IPQ8074/hw2.0/2.9.0.1/WLAN.HK.2.9.0.1-01862-QCAHKSWPL_SILICONZ-1/* \
 		$(1)/lib/firmware/IPQ8074/
 endef
 
 define Package/ath11k-firmware-qcn9074/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/QCN9074/hw1.0
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/ath11k-firmware/QCN9074/hw1.0/2.9.0.1/WLAN.HK.2.9.0.1-01837-QCAHKSWPL_SILICONZ-1/* \
+		$(PKG_BUILD_DIR)/ath11k-firmware/QCN9074/hw1.0/2.9.0.1/WLAN.HK.2.9.0.1-01862-QCAHKSWPL_SILICONZ-1/* \
 		$(1)/lib/firmware/ath11k/QCN9074/hw1.0/
 	$(INSTALL_BIN) \
 		$(DL_DIR)/$(QCN9074_BOARD_FILE) $(1)/lib/firmware/ath11k/QCN9074/hw1.0/board-2.bin


### PR DESCRIPTION
Changelog from quic:

Bug fixes, stability improvements from previous releases are present. There are no backward comatibility issues with this release.



