### PR TITLE
[22.03] uboot-mvebu: update to version 2023.07.02

### DIFF
--- a/package/boot/uboot-mvebu/Makefile
+++ b/package/boot/uboot-mvebu/Makefile
@@ -8,10 +8,10 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
-PKG_VERSION:=2022.07
+PKG_VERSION:=2023.07.02
 PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_HASH:=92b08eb49c24da14c1adbf70a71ae8f37cc53eeb4230e859ad8b6733d13dcf5e
+PKG_HASH:=6b6a48581c14abb0f95bd87c1af4d740922406d7b801002a9f94727fdde021d5
 
 include $(INCLUDE_DIR)/u-boot.mk
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Since 2021.07 multiple bugs were introduced that made it impossible to create a bootable target for mvebu. Those issues should be now fixed since 2023.07-rc1.

Fixes: #11661
Signed-off-by: Oli Ze <olze@trustserv.de>

I am not sure about this PKG_RELEASE=1 vs PKG_RELEASE:=$(AUTORELEASE) - please let me know if this is fine to use or if i should take the old AUTORELEASE version