### PR TITLE
linux-atm: use target specific kernel headers

### DIFF
--- a/package/network/utils/linux-atm/Makefile
+++ b/package/network/utils/linux-atm/Makefile
@@ -21,6 +21,7 @@ PKG_BUILD_PARALLEL:=1
 PKG_LICENSE:=GPL-2.0+
 PKG_CPE_ID:=cpe:/a:linux-atm:linux-atm
 PKG_FIXUP:=autoreconf
+PKG_FLAGS:=nonshared
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -97,6 +98,8 @@ define GenAtmPlugin
 endef
 
 $(foreach t,$(ATM_DEBUG_TOOLS),$(eval $(call GenAtmPlugin,atm-$(t),$(t))))
+
+TARGET_CFLAGS += -I$(LINUX_DIR)/user_headers/include
 
 define Build/Configure
 	$(call Build/Configure/Default)


### PR DESCRIPTION
@nbd168 As discussed on the mailing-list, here is a patch to convert the linux-atm package to use the `$(LINUX_DIR)/user_headers`.

There are a few targets that mess with the atm kernel headers. To avoid incompatibility between kernel and user space during compilation, the correct headers should be used.

Consequently, the package must also be marked as nonshared.
