### PR TITLE
lantiq: Improve gswip, build again

### DIFF
--- a/target/linux/lantiq/patches-5.15/0720-v5.19-net-dsa-lantiq_gswip-Fix-start-index-in-gswip_port_f.patch
+++ b/target/linux/lantiq/patches-5.15/0720-v5.19-net-dsa-lantiq_gswip-Fix-start-index-in-gswip_port_f.patch
@@ -1,0 +1,40 @@
+From 7b4149bdee6a6363cb4eca3599296d41a7b3700d Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Thu, 19 May 2022 00:00:50 +0200
+Subject: net: dsa: lantiq_gswip: Fix start index in gswip_port_fdb()
+
+The first N entries in priv->vlans are reserved for managing ports which
+are not part of a bridge. Use priv->hw_info->max_ports to consistently
+access per-bridge entries at index 7. Starting at
+priv->hw_info->cpu_port (6) is harmless in this case because
+priv->vlan[6].bridge is always NULL so the comparison result is always
+false (which results in this entry being skipped).
+
+Acked-by: Hauke Mehrtens <hauke@hauke-m.de>
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Reviewed-by: Vladimir Oltean <olteanv@gmail.com>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/lantiq_gswip.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -1339,7 +1339,7 @@ static int gswip_port_fdb(struct dsa_swi
+ 	struct gswip_priv *priv = ds->priv;
+ 	struct net_device *bridge = dsa_to_port(ds, port)->bridge_dev;
+ 	struct gswip_pce_table_entry mac_bridge = {0,};
+-	unsigned int cpu_port = priv->hw_info->cpu_port;
++	unsigned int max_ports = priv->hw_info->max_ports;
+ 	int fid = -1;
+ 	int i;
+ 	int err;
+@@ -1347,7 +1347,7 @@ static int gswip_port_fdb(struct dsa_swi
+ 	if (!bridge)
+ 		return -EINVAL;
+ 
+-	for (i = cpu_port; i < ARRAY_SIZE(priv->vlans); i++) {
++	for (i = max_ports; i < ARRAY_SIZE(priv->vlans); i++) {
+ 		if (priv->vlans[i].bridge == bridge) {
+ 			fid = priv->vlans[i].fid;
+ 			break;

--- a/target/linux/lantiq/patches-5.15/0731-dt-bindings-net-dsa-lantiq_gswip-Add-missing-phy-mod.patch
+++ b/target/linux/lantiq/patches-5.15/0731-dt-bindings-net-dsa-lantiq_gswip-Add-missing-phy-mod.patch
@@ -1,0 +1,32 @@
+From 82ea7c7fb4e90620beba8b6436fc12df2379ef8d Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Mon, 10 Oct 2022 16:52:25 +0200
+Subject: [PATCH 731/768] dt-bindings: net: dsa: lantiq_gswip: Add missing
+ phy-mode and fixed-link
+
+The CPU port has to specify a phy-mode and either a phy or a fixed-link.
+Since GSWIP is connected using a SoC internal protocol there's no PHY
+involved. Add phy-mode = "internal" and a fixed-link to describe the
+communication between the PMAC (Ethernet controller) and GSWIP switch.
+
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ Documentation/devicetree/bindings/net/dsa/lantiq-gswip.txt | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/Documentation/devicetree/bindings/net/dsa/lantiq-gswip.txt
++++ b/Documentation/devicetree/bindings/net/dsa/lantiq-gswip.txt
+@@ -97,7 +97,13 @@ switch@e108000 {
+ 		port@6 {
+ 			reg = <0x6>;
+ 			label = "cpu";
++			phy-mode = "internal";
+ 			ethernet = <&eth0>;
++
++			fixed-link {
++				speed = <1000>;
++				full-duplex;
++			};
+ 		};
+ 	};
+ 

--- a/target/linux/lantiq/patches-5.15/0732-net-dsa-lantiq_gswip-Only-allow-phy-mode-internal-on.patch
+++ b/target/linux/lantiq/patches-5.15/0732-net-dsa-lantiq_gswip-Only-allow-phy-mode-internal-on.patch
@@ -1,0 +1,33 @@
+From a55b9d802e11baceb35bd312419ad82086065b08 Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Mon, 10 Oct 2022 16:59:35 +0200
+Subject: [PATCH 732/768] net: dsa: lantiq_gswip: Only allow phy-mode =
+ "internal" on the CPU port
+
+Add the CPU port to gswip_xrx200_phylink_get_caps() and
+gswip_xrx300_phylink_get_caps(). It connects through a SoC-internal bus,
+so the only allowed phy-mode is PHY_INTERFACE_MODE_INTERNAL.
+
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ drivers/net/dsa/lantiq_gswip.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -1513,6 +1513,7 @@ static void gswip_xrx200_phylink_validat
+ 	case 2:
+ 	case 3:
+ 	case 4:
++	case 6:
+ 		if (state->interface != PHY_INTERFACE_MODE_INTERNAL)
+ 			goto unsupported;
+ 		break;
+@@ -1552,6 +1553,7 @@ static void gswip_xrx300_phylink_validat
+ 	case 2:
+ 	case 3:
+ 	case 4:
++	case 6:
+ 		if (state->interface != PHY_INTERFACE_MODE_INTERNAL)
+ 			goto unsupported;
+ 		break;

--- a/target/linux/lantiq/patches-5.15/0733-net-dsa-lantiq_gswip-Use-dev_err_probe-where-appropr.patch
+++ b/target/linux/lantiq/patches-5.15/0733-net-dsa-lantiq_gswip-Use-dev_err_probe-where-appropr.patch
@@ -1,0 +1,145 @@
+From 4d3dd68a1c56674ff666d0622b545992fac31754 Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Sun, 31 Jul 2022 22:54:52 +0200
+Subject: [PATCH 733/768] net: dsa: lantiq_gswip: Use dev_err_probe where
+ appropriate
+
+dev_err_probe() can be used to simplify the existing code. Also it means
+we get rid of the following warning which is seen whenever the PMAC
+(Ethernet controller which connects to GSWIP's CPU port) has not been
+probed yet:
+  gswip 1e108000.switch: dsa switch register failed: -517
+
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ drivers/net/dsa/lantiq_gswip.c | 53 ++++++++++++++++------------------
+ 1 file changed, 25 insertions(+), 28 deletions(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -1939,11 +1939,9 @@ static int gswip_gphy_fw_load(struct gsw
+ 	msleep(200);
+ 
+ 	ret = request_firmware(&fw, gphy_fw->fw_name, dev);
+-	if (ret) {
+-		dev_err(dev, "failed to load firmware: %s, error: %i\n",
+-			gphy_fw->fw_name, ret);
+-		return ret;
+-	}
++	if (ret)
++		return dev_err_probe(dev, ret, "failed to load firmware: %s\n",
++				     gphy_fw->fw_name);
+ 
+ 	/* GPHY cores need the firmware code in a persistent and contiguous
+ 	 * memory area with a 16 kB boundary aligned start address.
+@@ -1956,9 +1954,9 @@ static int gswip_gphy_fw_load(struct gsw
+ 		dev_addr = ALIGN(dma_addr, XRX200_GPHY_FW_ALIGN);
+ 		memcpy(fw_addr, fw->data, fw->size);
+ 	} else {
+-		dev_err(dev, "failed to alloc firmware memory\n");
+ 		release_firmware(fw);
+-		return -ENOMEM;
++		return dev_err_probe(dev, -ENOMEM,
++				     "failed to alloc firmware memory\n");
+ 	}
+ 
+ 	release_firmware(fw);
+@@ -1985,8 +1983,8 @@ static int gswip_gphy_fw_probe(struct gs
+ 
+ 	gphy_fw->clk_gate = devm_clk_get(dev, gphyname);
+ 	if (IS_ERR(gphy_fw->clk_gate)) {
+-		dev_err(dev, "Failed to lookup gate clock\n");
+-		return PTR_ERR(gphy_fw->clk_gate);
++		return dev_err_probe(dev, PTR_ERR(gphy_fw->clk_gate),
++				     "Failed to lookup gate clock\n");
+ 	}
+ 
+ 	ret = of_property_read_u32(gphy_fw_np, "reg", &gphy_fw->fw_addr_offset);
+@@ -2006,8 +2004,8 @@ static int gswip_gphy_fw_probe(struct gs
+ 		gphy_fw->fw_name = priv->gphy_fw_name_cfg->ge_firmware_name;
+ 		break;
+ 	default:
+-		dev_err(dev, "Unknown GPHY mode %d\n", gphy_mode);
+-		return -EINVAL;
++		return dev_err_probe(dev, -EINVAL, "Unknown GPHY mode %d\n",
++				     gphy_mode);
+ 	}
+ 
+ 	gphy_fw->reset = of_reset_control_array_get_exclusive(gphy_fw_np);
+@@ -2060,8 +2058,9 @@ static int gswip_gphy_fw_list(struct gsw
+ 			priv->gphy_fw_name_cfg = &xrx200a2x_gphy_data;
+ 			break;
+ 		default:
+-			dev_err(dev, "unknown GSWIP version: 0x%x", version);
+-			return -ENOENT;
++			return dev_err_probe(dev, -ENOENT,
++					     "unknown GSWIP version: 0x%x",
++					     version);
+ 		}
+ 	}
+ 
+@@ -2069,10 +2068,9 @@ static int gswip_gphy_fw_list(struct gsw
+ 	if (match && match->data)
+ 		priv->gphy_fw_name_cfg = match->data;
+ 
+-	if (!priv->gphy_fw_name_cfg) {
+-		dev_err(dev, "GPHY compatible type not supported");
+-		return -ENOENT;
+-	}
++	if (!priv->gphy_fw_name_cfg)
++		return dev_err_probe(dev, -ENOENT,
++				     "GPHY compatible type not supported");
+ 
+ 	priv->num_gphy_fw = of_get_available_child_count(gphy_fw_list_np);
+ 	if (!priv->num_gphy_fw)
+@@ -2171,8 +2169,8 @@ static int gswip_probe(struct platform_d
+ 			return -EINVAL;
+ 		break;
+ 	default:
+-		dev_err(dev, "unknown GSWIP version: 0x%x", version);
+-		return -ENOENT;
++		return dev_err_probe(dev, -ENOENT,
++				     "unknown GSWIP version: 0x%x", version);
+ 	}
+ 
+ 	/* bring up the mdio bus */
+@@ -2180,10 +2178,9 @@ static int gswip_probe(struct platform_d
+ 	if (gphy_fw_np) {
+ 		err = gswip_gphy_fw_list(priv, gphy_fw_np, version);
+ 		of_node_put(gphy_fw_np);
+-		if (err) {
+-			dev_err(dev, "gphy fw probe failed\n");
+-			return err;
+-		}
++		if (err)
++			return dev_err_probe(dev, err,
++					     "gphy fw probe failed\n");
+ 	}
+ 
+ 	/* bring up the mdio bus */
+@@ -2191,20 +2188,20 @@ static int gswip_probe(struct platform_d
+ 	if (mdio_np) {
+ 		err = gswip_mdio(priv, mdio_np);
+ 		if (err) {
+-			dev_err(dev, "mdio probe failed\n");
++			dev_err_probe(dev, err, "mdio probe failed\n");
+ 			goto put_mdio_node;
+ 		}
+ 	}
+ 
+ 	err = dsa_register_switch(priv->ds);
+ 	if (err) {
+-		dev_err(dev, "dsa switch register failed: %i\n", err);
++		dev_err_probe(dev, err, "dsa switch registration failed\n");
+ 		goto mdio_bus;
+ 	}
+ 	if (!dsa_is_cpu_port(priv->ds, priv->hw_info->cpu_port)) {
+-		dev_err(dev, "wrong CPU port defined, HW only supports port: %i",
+-			priv->hw_info->cpu_port);
+-		err = -EINVAL;
++		err = dev_err_probe(dev, -EINVAL,
++				    "wrong CPU port defined, HW only supports port: %i",
++				    priv->hw_info->cpu_port);
+ 		goto disable_switch;
+ 	}
+ 

--- a/target/linux/lantiq/patches-5.15/0734-net-dsa-lantiq_gswip-Don-t-manually-call-gswip_port_.patch
+++ b/target/linux/lantiq/patches-5.15/0734-net-dsa-lantiq_gswip-Don-t-manually-call-gswip_port_.patch
@@ -1,0 +1,25 @@
+From 8cf0b680abc157adeec3fb93a10354c470694535 Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Thu, 28 Jul 2022 22:37:11 +0200
+Subject: [PATCH 734/768] net: dsa: lantiq_gswip: Don't manually call
+ gswip_port_enable()
+
+We don't need to manually call gswip_port_enable() from within
+gswip_setup() for the CPU port. DSA does this automatically for us.
+
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ drivers/net/dsa/lantiq_gswip.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -874,8 +874,6 @@ static int gswip_setup(struct dsa_switch
+ 
+ 	ds->mtu_enforcement_ingress = true;
+ 
+-	gswip_port_enable(ds, cpu_port, NULL);
+-
+ 	ds->configure_vlan_while_not_filtering = false;
+ 
+ 	return 0;

--- a/target/linux/lantiq/patches-5.15/0735-net-dsa-lantiq_gswip-Simplify-gswip_port_enable.patch
+++ b/target/linux/lantiq/patches-5.15/0735-net-dsa-lantiq_gswip-Simplify-gswip_port_enable.patch
@@ -1,0 +1,59 @@
+From 2fcd57556ffe21b1af92742cd104ebb3ac710ae9 Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Sat, 30 Jul 2022 19:20:09 +0200
+Subject: [PATCH 735/768] net: dsa: lantiq_gswip: Simplify gswip_port_enable()
+
+Instead of checking multiple times whether the port to be enabled is a
+CPU or user port this can be simplified. Only the learning/unicast
+flood/broadcast flood settings can be applied on all ports. Everything
+else cannot be applied to the CPU port.
+
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ drivers/net/dsa/lantiq_gswip.c | 23 +++++++++--------------
+ 1 file changed, 9 insertions(+), 14 deletions(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -669,16 +669,15 @@ static int gswip_port_enable(struct dsa_
+ 			     struct phy_device *phydev)
+ {
+ 	struct gswip_priv *priv = ds->priv;
++	u32 mdio_phy = 0;
+ 	int err;
+ 
+-	if (!dsa_is_user_port(ds, port))
++	if (dsa_is_cpu_port(ds, port))
+ 		return 0;
+ 
+-	if (!dsa_is_cpu_port(ds, port)) {
+-		err = gswip_add_single_port_br(priv, port, true);
+-		if (err)
+-			return err;
+-	}
++	err = gswip_add_single_port_br(priv, port, true);
++	if (err)
++		return err;
+ 
+ 	/* RMON Counter Enable for port */
+ 	gswip_switch_w(priv, GSWIP_BM_PCFG_CNTEN, GSWIP_BM_PCFGp(port));
+@@ -690,15 +689,11 @@ static int gswip_port_enable(struct dsa_
+ 	gswip_switch_mask(priv, 0, GSWIP_SDMA_PCTRL_EN,
+ 			  GSWIP_SDMA_PCTRLp(port));
+ 
+-	if (!dsa_is_cpu_port(ds, port)) {
+-		u32 mdio_phy = 0;
++	if (phydev)
++		mdio_phy = phydev->mdio.addr & GSWIP_MDIO_PHY_ADDR_MASK;
+ 
+-		if (phydev)
+-			mdio_phy = phydev->mdio.addr & GSWIP_MDIO_PHY_ADDR_MASK;
+-
+-		gswip_mdio_mask(priv, GSWIP_MDIO_PHY_ADDR_MASK, mdio_phy,
+-				GSWIP_MDIO_PHYp(port));
+-	}
++	gswip_mdio_mask(priv, GSWIP_MDIO_PHY_ADDR_MASK, mdio_phy,
++			GSWIP_MDIO_PHYp(port));
+ 
+ 	return 0;
+ }

--- a/target/linux/lantiq/patches-5.15/0736-net-dsa-lantiq_gswip-Use-dsa_is_cpu_port-in-gswip_po.patch
+++ b/target/linux/lantiq/patches-5.15/0736-net-dsa-lantiq_gswip-Use-dsa_is_cpu_port-in-gswip_po.patch
@@ -1,0 +1,30 @@
+From 8ab55ac9678ca1f50f786c84484599dd675c5a9f Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Wed, 18 May 2022 23:53:09 +0200
+Subject: [PATCH 736/768] net: dsa: lantiq_gswip: Use dsa_is_cpu_port() in
+ gswip_port_change_mtu()
+
+Make the check for the CPU port in gswip_port_change_mtu() consistent
+with other areas of the driver by using dsa_is_cpu_port().
+
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ drivers/net/dsa/lantiq_gswip.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -1466,12 +1466,11 @@ static int gswip_port_max_mtu(struct dsa
+ static int gswip_port_change_mtu(struct dsa_switch *ds, int port, int new_mtu)
+ {
+ 	struct gswip_priv *priv = ds->priv;
+-	int cpu_port = priv->hw_info->cpu_port;
+ 
+ 	/* CPU port always has maximum mtu of user ports, so use it to set
+ 	 * switch frame size, including 8 byte special header.
+ 	 */
+-	if (port == cpu_port) {
++	if (dsa_is_cpu_port(ds, port)) {
+ 		new_mtu += 8;
+ 		gswip_switch_w(priv, VLAN_ETH_HLEN + new_mtu + ETH_FCS_LEN,
+ 			       GSWIP_MAC_FLEN);

--- a/target/linux/lantiq/patches-5.15/0737-net-dsa-lantiq_gswip-Change-literal-6-to-ETH_ALEN.patch
+++ b/target/linux/lantiq/patches-5.15/0737-net-dsa-lantiq_gswip-Change-literal-6-to-ETH_ALEN.patch
@@ -1,0 +1,24 @@
+From ef98b183d8fc7187a2efcc21c8f54f3cf061d556 Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Tue, 17 May 2022 22:39:58 +0200
+Subject: [PATCH 737/768] net: dsa: lantiq_gswip: Change literal 6 to ETH_ALEN
+
+The addr variable in gswip_port_fdb_dump() stores a mac address. Use
+ETH_ALEN to make this consistent across other drivers.
+
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ drivers/net/dsa/lantiq_gswip.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -1386,7 +1386,7 @@ static int gswip_port_fdb_dump(struct ds
+ {
+ 	struct gswip_priv *priv = ds->priv;
+ 	struct gswip_pce_table_entry mac_bridge = {0,};
+-	unsigned char addr[6];
++	unsigned char addr[ETH_ALEN];
+ 	int i;
+ 	int err;
+ 

--- a/target/linux/lantiq/patches-5.15/0738-net-dsa-lantiq_gswip-Consistently-use-macros-for-the.patch
+++ b/target/linux/lantiq/patches-5.15/0738-net-dsa-lantiq_gswip-Consistently-use-macros-for-the.patch
@@ -1,0 +1,47 @@
+From 61e9b19f6e6174afa7540f0b468a69bc940b91d4 Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Mon, 1 Aug 2022 21:23:49 +0200
+Subject: [PATCH 738/768] net: dsa: lantiq_gswip: Consistently use macros for
+ the mac bridge table
+
+Introduce a new GSWIP_TABLE_MAC_BRIDGE_PORT macro and use it throughout
+the driver. Also update GSWIP_TABLE_MAC_BRIDGE_STATIC to use the BIT()
+macro. This makes the driver code easier to understand.
+
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ drivers/net/dsa/lantiq_gswip.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -236,7 +236,8 @@
+ #define GSWIP_TABLE_ACTIVE_VLAN		0x01
+ #define GSWIP_TABLE_VLAN_MAPPING	0x02
+ #define GSWIP_TABLE_MAC_BRIDGE		0x0b
+-#define  GSWIP_TABLE_MAC_BRIDGE_STATIC	0x01	/* Static not, aging entry */
++#define  GSWIP_TABLE_MAC_BRIDGE_STATIC	BIT(0)		/* Static not, aging entry */
++#define  GSWIP_TABLE_MAC_BRIDGE_PORT	GENMASK(7, 4)	/* Port on learned entries */
+ 
+ #define XRX200_GPHY_FW_ALIGN	(16 * 1024)
+ 
+@@ -1282,7 +1283,8 @@ static void gswip_port_fast_age(struct d
+ 		if (mac_bridge.val[1] & GSWIP_TABLE_MAC_BRIDGE_STATIC)
+ 			continue;
+ 
+-		if (((mac_bridge.val[0] & GENMASK(7, 4)) >> 4) != port)
++		if (port != FIELD_GET(GSWIP_TABLE_MAC_BRIDGE_PORT,
++				      mac_bridge.val[0]))
+ 			continue;
+ 
+ 		mac_bridge.valid = false;
+@@ -1417,7 +1419,8 @@ static int gswip_port_fdb_dump(struct ds
+ 					return err;
+ 			}
+ 		} else {
+-			if (((mac_bridge.val[0] & GENMASK(7, 4)) >> 4) == port) {
++			if (port == FIELD_GET(GSWIP_TABLE_MAC_BRIDGE_PORT,
++					      mac_bridge.val[0])) {
+ 				err = cb(addr, 0, false, data);
+ 				if (err)
+ 					return err;

--- a/target/linux/lantiq/patches-5.15/0739-net-dsa-lantiq_gswip-Forbid-gswip_add_single_port_br.patch
+++ b/target/linux/lantiq/patches-5.15/0739-net-dsa-lantiq_gswip-Forbid-gswip_add_single_port_br.patch
@@ -1,0 +1,26 @@
+From 7a9e185075ababa827d1d3a33b787ad6d718c8ec Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Mon, 1 Aug 2022 22:24:24 +0200
+Subject: [PATCH 739/768] net: dsa: lantiq_gswip: Forbid
+ gswip_add_single_port_br on the CPU port
+
+Calling gswip_add_single_port_br() with the CPU port would be a bug
+because then only the CPU port could talk to itself. Add the CPU port to
+the validation at the beginning of gswip_add_single_port_br().
+
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ drivers/net/dsa/lantiq_gswip.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -633,7 +633,7 @@ static int gswip_add_single_port_br(stru
+ 	unsigned int max_ports = priv->hw_info->max_ports;
+ 	int err;
+ 
+-	if (port >= max_ports) {
++	if (port >= max_ports || dsa_is_cpu_port(priv->ds, port)) {
+ 		dev_err(priv->dev, "single port for %i supported\n", port);
+ 		return -EIO;
+ 	}

--- a/target/linux/lantiq/patches-5.15/0740-net-dsa-lantiq_gswip-Fix-error-message-in-gswip_add_.patch
+++ b/target/linux/lantiq/patches-5.15/0740-net-dsa-lantiq_gswip-Fix-error-message-in-gswip_add_.patch
@@ -1,0 +1,26 @@
+From 28be6bfb735d851e646abb05b8e24eb6764596f5 Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Mon, 1 Aug 2022 22:26:20 +0200
+Subject: [PATCH 740/768] net: dsa: lantiq_gswip: Fix error message in
+ gswip_add_single_port_br()
+
+The error message is printed when the port cannot be used. Update the
+error message to reflect that.
+
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ drivers/net/dsa/lantiq_gswip.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -634,7 +634,8 @@ static int gswip_add_single_port_br(stru
+ 	int err;
+ 
+ 	if (port >= max_ports || dsa_is_cpu_port(priv->ds, port)) {
+-		dev_err(priv->dev, "single port for %i supported\n", port);
++		dev_err(priv->dev, "single port for %i is not supported\n",
++			port);
+ 		return -EIO;
+ 	}
+ 

--- a/target/linux/lantiq/patches-5.15/0741-net-dsa-lantiq_gswip-Fix-comments-in-gswip_port_vlan.patch
+++ b/target/linux/lantiq/patches-5.15/0741-net-dsa-lantiq_gswip-Fix-comments-in-gswip_port_vlan.patch
@@ -1,0 +1,36 @@
+From 45a0371568b1f050d787564875653f41a1f6fb98 Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Fri, 14 Oct 2022 14:06:40 +0200
+Subject: [PATCH 741/768] net: dsa: lantiq_gswip: Fix comments in
+ gswip_port_vlan_filtering()
+
+Update the comments in gswip_port_vlan_filtering() so it's clear that
+there are two separate cases, one for "tag based VLAN" and another one
+for "port based VLAN".
+
+Suggested-by: Martin Schiller <ms@dev.tdt.de>
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ drivers/net/dsa/lantiq_gswip.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -765,7 +765,7 @@ static int gswip_port_vlan_filtering(str
+ 	}
+ 
+ 	if (vlan_filtering) {
+-		/* Use port based VLAN tag */
++		/* Use tag based VLAN */
+ 		gswip_switch_mask(priv,
+ 				  GSWIP_PCE_VCTRL_VSR,
+ 				  GSWIP_PCE_VCTRL_UVR | GSWIP_PCE_VCTRL_VIMR |
+@@ -774,7 +774,7 @@ static int gswip_port_vlan_filtering(str
+ 		gswip_switch_mask(priv, GSWIP_PCE_PCTRL_0_TVM, 0,
+ 				  GSWIP_PCE_PCTRL_0p(port));
+ 	} else {
+-		/* Use port based VLAN tag */
++		/* Use port based VLAN */
+ 		gswip_switch_mask(priv,
+ 				  GSWIP_PCE_VCTRL_UVR | GSWIP_PCE_VCTRL_VIMR |
+ 				  GSWIP_PCE_VCTRL_VEMR,

--- a/target/linux/lantiq/patches-5.15/0742-net-dsa-lantiq_gswip-Add-and-use-a-GSWIP_TABLE_MAC_B.patch
+++ b/target/linux/lantiq/patches-5.15/0742-net-dsa-lantiq_gswip-Add-and-use-a-GSWIP_TABLE_MAC_B.patch
@@ -1,0 +1,33 @@
+From 4775f9543e691d9a2f5dd9aa5d46c66d37928250 Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Fri, 14 Oct 2022 14:19:05 +0200
+Subject: [PATCH 742/768] net: dsa: lantiq_gswip: Add and use a
+ GSWIP_TABLE_MAC_BRIDGE_FID macro
+
+Only bits [5:0] in mac_bridge.key[3] are reserved for the FID. Add a
+macro so this becomes obvious when reading the driver code.
+
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ drivers/net/dsa/lantiq_gswip.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -238,6 +238,7 @@
+ #define GSWIP_TABLE_MAC_BRIDGE		0x0b
+ #define  GSWIP_TABLE_MAC_BRIDGE_STATIC	BIT(0)		/* Static not, aging entry */
+ #define  GSWIP_TABLE_MAC_BRIDGE_PORT	GENMASK(7, 4)	/* Port on learned entries */
++#define  GSWIP_TABLE_MAC_BRIDGE_FID	GENMASK(5, 0)	/* Filtering identifier */
+ 
+ #define XRX200_GPHY_FW_ALIGN	(16 * 1024)
+ 
+@@ -1360,7 +1361,7 @@ static int gswip_port_fdb(struct dsa_swi
+ 	mac_bridge.key[0] = addr[5] | (addr[4] << 8);
+ 	mac_bridge.key[1] = addr[3] | (addr[2] << 8);
+ 	mac_bridge.key[2] = addr[1] | (addr[0] << 8);
+-	mac_bridge.key[3] = fid;
++	mac_bridge.key[3] = FIELD_PREP(GSWIP_TABLE_MAC_BRIDGE_FID, fid);
+ 	mac_bridge.val[0] = add ? BIT(port) : 0; /* port map */
+ 	mac_bridge.val[1] = GSWIP_TABLE_MAC_BRIDGE_STATIC;
+ 	mac_bridge.valid = add;

--- a/target/linux/lantiq/patches-5.15/0743-net-dsa-lantiq_gswip-Improve-error-message-in-gswip_.patch
+++ b/target/linux/lantiq/patches-5.15/0743-net-dsa-lantiq_gswip-Improve-error-message-in-gswip_.patch
@@ -1,0 +1,26 @@
+From 00b5121435ccd4ce54f79179dd9ee3e2610d7dcf Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Fri, 14 Oct 2022 16:31:57 +0200
+Subject: [PATCH 743/768] net: dsa: lantiq_gswip: Improve error message in
+ gswip_port_fdb()
+
+Print the port which is not found to be part of a bridge so it's easier
+to investigate the underlying issue.
+
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ drivers/net/dsa/lantiq_gswip.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -1352,7 +1352,8 @@ static int gswip_port_fdb(struct dsa_swi
+ 	}
+ 
+ 	if (fid == -1) {
+-		dev_err(priv->dev, "Port not part of a bridge\n");
++		dev_err(priv->dev,
++			"Port %d is not known to be part of bridge\n", port);
+ 		return -EINVAL;
+ 	}
+ 

--- a/target/linux/lantiq/patches-5.15/0744-net-dsa-lantiq_gswip-Fix-gswip_add_single_port_br.patch
+++ b/target/linux/lantiq/patches-5.15/0744-net-dsa-lantiq_gswip-Fix-gswip_add_single_port_br.patch
@@ -1,0 +1,45 @@
+From c8c4db06e84159cf91218fe6ba5daabd92b41c74 Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Mon, 1 Aug 2022 22:04:59 +0200
+Subject: [PATCH 744/768] net: dsa: lantiq_gswip: Fix
+ gswip_add_single_port_br()
+
+gswip_add_single_port_br() has to process two steps:
+1. Adding an entry to GSWIP_TABLE_ACTIVE_VLAN
+2. Adding an entry to GSWIP_TABLE_VLAN_MAPPING
+
+Mark the GSWIP_TABLE_VLAN_MAPPING entry as "valid" so it's considered
+by the hardware.
+Also remove the GSWIP_TABLE_ACTIVE_VLAN entry (from the first step) if
+the second step fails.
+
+Fixes: 8206e0ce96b3 ("net: dsa: lantiq: Add VLAN unaware bridge offloading")
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ drivers/net/dsa/lantiq_gswip.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -651,16 +651,18 @@ static int gswip_add_single_port_br(stru
+ 		return err;
+ 	}
+ 
+-	if (!add)
+-		return 0;
+-
+ 	vlan_mapping.index = port + 1;
+ 	vlan_mapping.table = GSWIP_TABLE_VLAN_MAPPING;
+ 	vlan_mapping.val[0] = 0 /* vid */;
+ 	vlan_mapping.val[1] = BIT(port) | BIT(cpu_port);
+ 	vlan_mapping.val[2] = 0;
++	vlan_mapping.valid = add;
+ 	err = gswip_pce_table_entry_write(priv, &vlan_mapping);
+ 	if (err) {
++		/* remove the previously created GSWIP_TABLE_ACTIVE_VLAN */
++		vlan_active.valid = false;
++		gswip_pce_table_entry_write(priv, &vlan_active);
++
+ 		dev_err(priv->dev, "failed to write VLAN mapping: %d\n", err);
+ 		return err;
+ 	}

--- a/target/linux/lantiq/patches-5.15/0745-net-dsa-lantiq_gswip-Manage-the-GSWIP_TABLE_VLAN_MAP.patch
+++ b/target/linux/lantiq/patches-5.15/0745-net-dsa-lantiq_gswip-Manage-the-GSWIP_TABLE_VLAN_MAP.patch
@@ -1,0 +1,71 @@
+From 01e86db83246b36413d3d0c281dc4736cb03e809 Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Sat, 22 Oct 2022 12:25:25 +0200
+Subject: [PATCH 745/768] net: dsa: lantiq_gswip: Manage the
+ GSWIP_TABLE_VLAN_MAPPING valid bit
+
+We manually have to set gswip_pce_table_entry.valid to true for the
+hardware to actually use the entry. Not setting means the default value
+is applied, which results in the entry being ignored.
+
+Update gswip_vlan_add_{un,}aware() to mark the entry as valid as we want
+it to be recognized by the hardware. Also update gswip_vlan_remove() to
+mark the entry as invalid once all user ports have been removed (in this
+case the GSWIP_TABLE_ACTIVE_VLAN entry is also removed later on, meaning
+we want the hardware to forget about any of these entries), otherwise
+mark the entry as valid.
+
+Fixes: 8206e0ce96b3 ("net: dsa: lantiq: Add VLAN unaware bridge offloading")
+Fixes: 9bbb1c053bdc ("net: dsa: lantiq: Add VLAN aware bridge offloading")
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ drivers/net/dsa/lantiq_gswip.c | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -992,6 +992,9 @@ static int gswip_vlan_add_unaware(struct
+ 	/* Update the VLAN mapping entry and write it to the switch */
+ 	vlan_mapping.val[1] |= BIT(cpu_port);
+ 	vlan_mapping.val[1] |= BIT(port);
++
++	vlan_mapping.valid = true;
++
+ 	err = gswip_pce_table_entry_write(priv, &vlan_mapping);
+ 	if (err) {
+ 		dev_err(priv->dev, "failed to write VLAN mapping: %d\n", err);
+@@ -1062,10 +1065,14 @@ static int gswip_vlan_add_aware(struct g
+ 	vlan_mapping.val[1] |= BIT(cpu_port);
+ 	vlan_mapping.val[2] |= BIT(cpu_port);
+ 	vlan_mapping.val[1] |= BIT(port);
++
+ 	if (untagged)
+ 		vlan_mapping.val[2] &= ~BIT(port);
+ 	else
+ 		vlan_mapping.val[2] |= BIT(port);
++
++	vlan_mapping.valid = true;
++
+ 	err = gswip_pce_table_entry_write(priv, &vlan_mapping);
+ 	if (err) {
+ 		dev_err(priv->dev, "failed to write VLAN mapping: %d\n", err);
+@@ -1116,14 +1123,17 @@ static int gswip_vlan_remove(struct gswi
+ 
+ 	vlan_mapping.val[1] &= ~BIT(port);
+ 	vlan_mapping.val[2] &= ~BIT(port);
++
++	/* Remove the VLAN once all user ports have been removed from it. */
++	vlan_mapping.valid = vlan_mapping.val[1] != BIT(cpu_port);
++
+ 	err = gswip_pce_table_entry_write(priv, &vlan_mapping);
+ 	if (err) {
+ 		dev_err(priv->dev, "failed to write VLAN mapping: %d\n", err);
+ 		return err;
+ 	}
+ 
+-	/* In case all ports are removed from the bridge, remove the VLAN */
+-	if ((vlan_mapping.val[1] & ~BIT(cpu_port)) == 0) {
++	if (!vlan_mapping.valid) {
+ 		err = gswip_vlan_active_remove(priv, idx);
+ 		if (err) {
+ 			dev_err(priv->dev, "failed to write active VLAN: %d\n",

--- a/target/linux/lantiq/patches-5.15/0751-net-dsa-lantiq_gswip-allow-adding-fdb-for-individual.patch
+++ b/target/linux/lantiq/patches-5.15/0751-net-dsa-lantiq_gswip-allow-adding-fdb-for-individual.patch
@@ -1,0 +1,40 @@
+From a115138421020267291668e7a0937be96197110a Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Sun, 30 Jul 2023 23:38:25 +0200
+Subject: net: dsa: lantiq_gswip: allow adding fdb for individual ports
+
+This allows adding a MAC address into the forwarding database (fdb) for
+ports which are not part of a bridge. This is happening since kernel
+5.15 and the driver rejected it previously with an error message.
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ drivers/net/dsa/lantiq_gswip.c | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -1353,14 +1353,16 @@ static int gswip_port_fdb(struct dsa_swi
+ 	int i;
+ 	int err;
+ 
+-	if (!bridge)
+-		return -EINVAL;
+-
+-	for (i = max_ports; i < ARRAY_SIZE(priv->vlans); i++) {
+-		if (priv->vlans[i].bridge == bridge) {
+-			fid = priv->vlans[i].fid;
+-			break;
++	if (bridge) {
++		for (i = max_ports; i < ARRAY_SIZE(priv->vlans); i++) {
++			if (priv->vlans[i].bridge == bridge) {
++				fid = priv->vlans[i].fid;
++				break;
++			}
+ 		}
++	} else {
++		/* FID of a standalone port (single port bridge) */
++		fid = port + 1;
+ 	}
+ 
+ 	if (fid == -1) {


### PR DESCRIPTION
This adds multiples patches from this branch: https://github.com/xdarklight/linux/commits/lantiq-gswip-integration-20221022
It also tries to fix the error messages returned in `gswip_port_fdb` when a mac address is added to the CPU port for the fdb.

Here is a longer discussion about this topic: https://lore.kernel.org/netdev/0e66011d-c3bd-5df2-e81d-5b67e4689330@hauke-m.de/T/

Here is some code to make the selftests works: https://github.com/xdarklight/openwrt-packages/commits/heads/refs/wip-kernel-selftests-net-forwarding-20220727

After these changes we can remove the source only flag.

I plan to backport this after some testing to openwrt 23.05 branch too. 

Please test this and report back the results. 