### PR TITLE
Xiaomi mi-mini router improvements

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -105,6 +105,10 @@ snr,cpe-w4n-mt)
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x1000"
 	;;
+xiaomi,miwifi-mini)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
+	ubootenv_add_uci_sys_config "/dev/mtd9" "0x0" "0x4000" "0x10000"
+	;;
 xiaomi,mi-router-3g-v2|\
 xiaomi,mi-router-4a-gigabit|\
 xiaomi,miwifi-3c)

--- a/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
+++ b/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
@@ -8,8 +8,8 @@
 	model = "Xiaomi MiWiFi Mini";
 
 	aliases {
-		led-boot = &led_blue;
-		led-failsafe = &led_blue;
+		led-boot = &led_yellow;
+		led-failsafe = &led_red;
 		led-running = &led_blue;
 		led-upgrade = &led_blue;
 		label-mac-device = &ethernet;
@@ -25,15 +25,14 @@
 		led_blue: blue {
 			label = "blue:status";
 			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
-			default-state = "on";
 		};
 
-		yellow {
+		led_yellow: yellow {
 			label = "yellow:status";
 			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
 		};
 
-		red {
+		led_red: red {
 			label = "red:status";
 			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
 		};


### PR DESCRIPTION
This two commits make improvements on Xiaomi mi-mini router:

- change led indications color scheme as other Xiaomi routers
- add u-boot env config for reading and writing u-boot env parameters

Tested on two boards, works fine.
