### PR TITLE
ath79: add support for Adtran Bluesocket BSAP-192x board

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -12,6 +12,8 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 case "$board" in
+adtran,bsap1920|\
+adtran,bsap1925|\
 alcatel,hh40v|\
 alfa-network,ap121f|\
 alfa-network,ap121fe|\

--- a/target/linux/ath79/dts/ar9344_adtran_bsap1920.dts
+++ b/target/linux/ath79/dts/ar9344_adtran_bsap1920.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+
+#include "ar9344_adtran_bsap192x.dtsi"
+
+/ {
+	model = "Adtran Bluesocket BSAP-1920";
+	compatible = "adtran,bsap1920", "qca,ar9344";
+};

--- a/target/linux/ath79/dts/ar9344_adtran_bsap1925.dts
+++ b/target/linux/ath79/dts/ar9344_adtran_bsap1925.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+
+#include "ar9344_adtran_bsap192x.dtsi"
+
+/ {
+	model = "Adtran Bluesocket BSAP-1925";
+	compatible = "adtran,bsap1925", "qca,ar9344";
+};

--- a/target/linux/ath79/dts/ar9344_adtran_bsap192x.dtsi
+++ b/target/linux/ath79/dts/ar9344_adtran_bsap192x.dtsi
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_power_amber;
+		led-failsafe = &led_power_amber;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_amber;
+	};
+
+	chosen {
+		/delete-property/ bootargs;
+		bootargs-append = "root=";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_amber: power_amber {
+			label = "amber:power";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan_amber {
+			label = "amber:wlan";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan_green {
+			label = "green:wlan";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan_amber {
+			label = "amber:lan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		lan_green {
+			label = "green:lan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <25000000>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x0040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x0040000 0x0010000>;
+			};
+
+			partition@50000 {
+				label = "Cert";
+				reg = <0x0050000 0x0040000>;
+				read-only;
+			};
+
+			partition@90000 {
+				label = "Kdump";
+				reg = <0x0090000 0x0170000>;
+				read-only;
+			};
+
+			partition@300000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x0300000 0x1ce0000>;
+			};
+
+			senao: partition@1fe0000 {
+				label = "SENAO";
+				reg = <0x1fe0000 0x0010000>;
+				read-only;
+			};
+
+			art: partition@1ff0000 {
+				label = "art";
+				reg = <0x1ff0000 0x0010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,0030";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&macaddr_senao_0>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <(1)>;
+		mtd-cal-data = <&art 0x5000>;
+		qca,no-eeprom;
+		ieee80211-freq-limit = <2402000 2482000>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	ieee80211-freq-limit = <4900000 5990000>;
+	mtd-cal-data = <&art 0x1000>;
+	nvmem-cells = <&macaddr_senao_0>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <9>;
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M */
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	nvmem-cells = <&macaddr_senao_0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&senao {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_senao_0: macaddr@0 {
+		reg = <0x18 0x6>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -16,6 +16,8 @@ alcatel,hh40v)
 	ucidef_set_led_netdev "wan_data" "WAN Data" "green:wan" "eth0" "tx rx"
 	ucidef_set_led_netdev "wan_link" "WAN Link" "orange:wan" "eth0" "link"
 	;;
+adtran,bsap1920|\
+adtran,bsap1925|\
 alfa-network,ap121f|\
 alfa-network,ap121fe|\
 avm,fritz450e|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -10,6 +10,8 @@ ath79_setup_interfaces()
 	case "$board" in
 	adtran,bsap1800-v2|\
 	adtran,bsap1840|\
+	adtran,bsap1920|\
+	adtran,bsap1925|\
 	allnet,all-wap02860ac|\
 	alfa-network,ap121f|\
 	alfa-network,pi-wifi4|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -86,6 +86,10 @@ case "$FIRMWARE" in
 	;;
 "ath9k-eeprom-pci-0000:00:00.0.bin")
 	case $board in
+	adtran,bsap1920|\
+	adtran,bsap1925)
+		caldata_extract "art" 0x1000 0x440
+		;;	
 	aruba,ap-115)
 		caldata_extract "oemdata" 0x5000 0x440
 		;;

--- a/target/linux/ath79/generic/base-files/etc/init.d/bootcount
+++ b/target/linux/ath79/generic/base-files/etc/init.d/bootcount
@@ -8,6 +8,10 @@ boot() {
 	adtran,bsap1840)
 		fconfig -s -w -d $(find_mtd_part "RedBoot config") -n boot_cntb -x 0
 		;;
+	adtran,bsap1920|\
+	adtran,bsap1925)
+		fw_setenv bootcnt 0
+		;;
 	moxa,awk-1137c)
 		fw_setenv fwr_verify 0
 		;;

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
@@ -32,6 +32,8 @@ openmesh,mr1750-v1|\
 openmesh,mr1750-v2)
 	migrate_leds ":wlan24=:wifi2g" ":wlan58=:wifi5g" ":wan=:lan"
 	;;
+adtran,bsap1920|\
+adtran,bsap1925|\
 pcs,cap324)
 	migrate_leds "lan:amber=amber:lan" "lan:green=green:lan"
 	;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -247,6 +247,25 @@ define Device/adtran_bsap1840
 endef
 TARGET_DEVICES += adtran_bsap1840
 
+define Device/adtran_bsap192x
+  SOC := ar9344
+  DEVICE_VENDOR := Adtran
+  DEVICE_PACKAGES := uboot-envtools
+  IMAGE_SIZE := 13312k
+endef
+
+define Device/adtran_bsap1920
+  $(Device/adtran_bsap192x)
+  DEVICE_MODEL := Bluesocket BSAP-1920
+endef
+TARGET_DEVICES += adtran_bsap1920
+
+define Device/adtran_bsap1925
+  $(Device/adtran_bsap192x)
+  DEVICE_MODEL := Bluesocket BSAP-1925
+endef
+TARGET_DEVICES += adtran_bsap1925
+
 define Device/alcatel_hh40v
   SOC := qca9531
   DEVICE_VENDOR := Alcatel


### PR DESCRIPTION
This board is an Atheros AR9344 based dual band enterprise access point known as Adtran models BSAP-1920 and BSAP-1925. The BSAP-192x series are the same hardware, BSAP-1925 antennae are external and detachable RP-SMA, while the BSAP-1920 are internal. They have an internal 3V TTL serial port header that is populated with pins, connection info is 115200, 8N1.
Board is similar to PowerCloud Systems CAP324 except larger flash size.

Specification:

    System-On-Chip: Atheros AR9344
    CPU/Speed: 560 MHz
    Flash-Chip: Spansion FL256SAIFRO
    Flash size: 32 MiB
    RAM: 128 MiB
    phy0: Atheros AR9340 5GHz 802.11an
    phy1: Atheros AR9300 2.4GHz 802.11bgn
    PHY: Atheros AR8035-A
    Power: PoE 802.3af and 12V DC at 2A

Installation:

    Connect to the serial console using a TTL 3V adapter only
    115200 bps, 8 data bits, no parity, 1 stop bit
    Pin 1 (VCC) is marked with an arrow. Use RX TX GND
    Pin 4 3 2 1
    Signal RX TX GND VCC
    Due to a u-boot quirk you may have to connect serial cables after the AP boots
    or you will be sitting at a screen that never changes.

    Interrupt the bootloader using its password, which is: b100:

    at bootloader 192x > prompt enter the following commands

    setenv serverip <your_tftp_server_ip>

    setenv ipaddr <valid_ip_range_>

    setenv mfg_state

    saveenv

    tftpboot 0x3000000 openwrt-ath79-generic-adtran_bsap1925-initramfs-kernel.bin

    bootm 0x3000000

    Wait for the status LED to go solid green

    perform a sysupgrade using openwrt-ath79-generic-adtran_bsap1925-squashfs-sysupgrade.bin

Signed-off-by: Brian Gonyer <bgonyer@gmail.com>