### PR TITLE
sdk: fix git initialization

### DIFF
--- a/include/toplevel.mk
+++ b/include/toplevel.mk
@@ -177,6 +177,10 @@ kernel_nconfig: prepare_kernel_conf
 kernel_xconfig: prepare_kernel_conf
 	$(_SINGLE)$(NO_TRACE_MAKE) -C target/linux xconfig
 
+ifeq ($(SDK),1)
+$(STAGING_DIR_HOST)/.prereq-build: include/prepare.mk
+endif
+
 $(STAGING_DIR_HOST)/.prereq-build: include/prereq-build.mk
 	mkdir -p tmp
 	@$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f $(TOPDIR)/include/prereq-build.mk prereq 2>/dev/null || { \

--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -138,14 +138,13 @@ $(BIN_DIR)/$(SDK_NAME).tar.xz: clean
 		$(SDK_BUILD_DIR)/target/linux/*/files* \
 		$(SDK_BUILD_DIR)/target/linux/*/patches*
 	./convert-config.pl $(TOPDIR)/.config > $(SDK_BUILD_DIR)/Config-build.in
-	$(CP) -L \
+	$(CP) \
+		./files/* \
+		$(TOPDIR)/.gitattributes \
+		$(TOPDIR)/.gitignore \
 		$(TOPDIR)/LICENSES \
 		$(TOPDIR)/COPYING \
 		$(TOPDIR)/rules.mk \
-		./files/Config.in \
-		./files/Makefile \
-		./files/include/prepare.mk \
-		./files/README.md \
 		$(SDK_BUILD_DIR)/
 	mkdir -p $(SDK_BUILD_DIR)/package/kernel
 	$(CP) \

--- a/target/sdk/files/include/prepare.mk
+++ b/target/sdk/files/include/prepare.mk
@@ -11,7 +11,14 @@ prepare: .git/config
 	@( \
 		printf "Initializing SDK ... "; \
 		git init -q .; \
-		find . -mindepth 1 -maxdepth 1 -not -name feeds | xargs git add; \
+		find * -prune \
+			'!' -name 'dl' \
+			'!' -name 'feeds' \
+			'!' -name 'tmp' \
+				| xargs git add -f \
+			.gitattributes \
+			.gitignore \
+		; \
 		git commit -q -m "Initial state"; \
 		echo "ok."; \
 	)


### PR DESCRIPTION
split from #11379 due to indecision on the second commit

The extra Makefile prepare.mk
is not being installed in the right place.
We have to use glob instead of listing each file,
otherwise the relative path is not preserved.

Set prepare.mk as a prerequisite
for prereq-build target when the SDK is used.

Use find with POSIX options to pick what is added to git. Also, exclude the download and temp directories from git, but do include git config files.

The git add command must now be forced
because git cross-checks with the .gitignore file
even before the local repository is established.