### PR TITLE
ramips: Add Xiaomi Mi Router 4A (100M International V2)

### DIFF
--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m-intl-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m-intl-v2.dts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_xiaomi_mi-router-4.dtsi"
+
+/ {
+	compatible = "xiaomi,mi-router-4a-100m-intl-v2", "mediatek,mt7628an-soc";
+	model = "Xiaomi Mi Router 4A (100M International Edition V2)";
+
+	aliases {
+		led-boot = &led_power_yellow;
+		led-failsafe = &led_power_yellow;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_yellow;
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_yellow: power_yellow {
+			label = "yellow:power";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "blue:wan";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+};
+
+&partitions {
+	partition@20000 {
+		label = "reserved";
+		reg = <0x20000 0x10000>;
+		read-only;
+	};
+
+	partition@60000 {
+		label = "overlay";
+		reg = <0x60000 0x100000>;
+		read-only;
+	};
+
+	partition@160000 {
+		label = "firmware";
+		reg = <0x160000 0xdc0000>;
+		compatible = "denx,uimage";
+	};
+
+	partition@ff0000 {
+		label = "config";
+		reg = <0xff0000 0x10000>;
+		read-only;
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <(-1)>;
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+	mediatek,portdisable = <0x2a>;
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 {
+		reg = <0x4 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -995,6 +995,16 @@ define Device/xiaomi_mi-router-4a-100m-intl
 endef
 TARGET_DEVICES += xiaomi_mi-router-4a-100m-intl
 
+define Device/xiaomi_mi-router-4a-100m-intl-v2
+  IMAGE_SIZE := 14976k
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := Mi Router 4A
+  DEVICE_VARIANT := 100M International Edition V2
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap
+  SUPPORTED_DEVICES += xiaomi,mir4a-100m-intl-v2
+endef
+TARGET_DEVICES += xiaomi_mi-router-4a-100m-intl-v2
+
 define Device/xiaomi_mi-router-4c
   IMAGE_SIZE := 14976k
   DEVICE_VENDOR := Xiaomi

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -154,7 +154,8 @@ wavlink,wl-wn578a2)
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
 xiaomi,mi-router-4a-100m|\
-xiaomi,mi-router-4a-100m-intl)
+xiaomi,mi-router-4a-100m-intl|\
+xiaomi,mi-router-4a-100m-intl-v2)
 	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x01"
 	;;
 xiaomi,mi-router-4c)

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -171,7 +171,8 @@ ramips_setup_interfaces()
 			"0:wan" "3:lan" "4:lan" "6@eth0"
 		;;
 	xiaomi,mi-router-4a-100m|\
-	xiaomi,mi-router-4a-100m-intl)
+	xiaomi,mi-router-4a-100m-intl|\
+	xiaomi,mi-router-4a-100m-intl-v2)
 		ucidef_add_switch "switch0" \
 			"4:lan:1" "2:lan:2" "0:wan" "6@eth0"
 		;;


### PR DESCRIPTION
The new V2 - version has a modified partition layout compared 
to the V1 and also has swapped the 5GHz chipset to the MT7613BE. 
This commit adds support for this new version of this router.

Signed-off-by: Nita Vesa <nita.vesa@elektrik.link>