### PR TITLE
openssl: update to 3.0.10

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.0.9
-PKG_RELEASE:=3
+PKG_VERSION:=3.0.10
+PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_BUILD_PARALLEL:=1
@@ -24,7 +24,7 @@ PKG_SOURCE_URL:= \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/old/$(PKG_BASE)/
 
-PKG_HASH:=eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90
+PKG_HASH:=1761d4f5b13a1028b9b6f3d4b8e17feb0cedc9370f6afe61d7193d2cdce83323
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE

--- a/package/libs/openssl/patches/100-Configure-afalg-support.patch
+++ b/package/libs/openssl/patches/100-Configure-afalg-support.patch
@@ -10,7 +10,7 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
 --- a/Configure
 +++ b/Configure
-@@ -1677,7 +1677,9 @@ $config{CFLAGS} = [ map { $_ eq '--ossl-
+@@ -1674,7 +1674,9 @@ $config{CFLAGS} = [ map { $_ eq '--ossl-
  
  unless ($disabled{afalgeng}) {
      $config{afalgeng}="";


### PR DESCRIPTION
This update contains bugfixes and security fixes

Changes between 3.0.9 and 3.0.10 [1 Aug 2023]
 * Fix excessive time spent checking DH q parameter value ([CVE-2023-3817])
 * Fix DH_check() excessive time with over sized modulus ([CVE-2023-3446])
 * Do not ignore empty associated data entries with AES-SIV ([CVE-2023-2975])

compile && run tested on ramips/mt7621 devices: beeline smartbox turbo-plus, wifire s1500, xiaomi mi router 3 pro

