### PR TITLE
tools: mold: update to 2.0.0

### DIFF
--- a/tools/mold/Makefile
+++ b/tools/mold/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mold
-PKG_VERSION:=1.11.0
+PKG_VERSION:=2.1.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL_FILE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/rui314/mold/archive/refs/tags
-PKG_HASH:=99318eced81b09a77e4c657011076cc8ec3d4b6867bd324b8677974545bc4d6f
+PKG_HASH:=a32bec1282671b18ea4691855aed925ea2f348dfef89cb7689cd81273ea0c5df
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
- transition from AGPL to MIT
- Previously, mold could not produce an object file with more than 65520 sections using the --relocatable option. Now the bug has been fixed.
- mold now interprets -undefined as a synonym for --undefined instead of -u ndefined. This seems inconsistent, as -ufoo is generally treated as -u foo (which is an alias for --undefined foo), but this is the behavior of the GNU linkers and LLVM lld, so we prioritize compatibility over consistency.
- -nopie is now handled as a synonym for --no-pie.
- [RISC-V] R_RISCV_SET_ULEB128 and R_RISCV_SUB_ULEB128 relocation types are now supported (4bffe26, 1ac5fe7)
- [PPC64] R_PPC64_REL32 relocation type is now supported. (ebd780e)