### PR TITLE
ramips: add support for I-O DATA WN-DEAX1800GR

### DIFF
--- a/target/linux/ramips/dts/mt7621_iodata_wn-deax1800gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-deax1800gr.dts
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "iodata,wn-deax1800gr", "mediatek,mt7621-soc";
+	model = "I-O DATA WN-DEAX1800GR";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-upgrade = &led_status_green;
+		label-mac-device = &gmac1;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: led-0 {
+			label = "green:status";
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_status_red: led-1 {
+			label = "red:status";
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led-2 {
+			label = "green:wps_wifi";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
+		};
+
+		led-3 {
+			label = "green:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			default-state = "on";
+		};
+
+		led-4 {
+			label = "green:router";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+		};
+
+		led-5 {
+			label = "green:internet";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		led_on {
+			label = "led_on";
+			gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	mediatek,nmbm;
+	mediatek,bmt-remap-range =
+		<0x0000000 0x780000>, /*  u-boot - kernel1(6 MiB) */
+		<0x2f80000 0x600000>, /* kernel2 - kernel2(6 MiB) */
+		<0x5d80000 0x780000>; /* storage - working */
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		partition@100000 {
+			compatible = "nvmem-cells";
+			label = "factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom: eeprom@0 {
+					reg = <0x0 0x1aa20>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					compatible = "mac-base";
+					reg = <0x4 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition@180000 {
+			label = "kernel";
+			reg = <0x180000 0x600000>;
+		};
+
+		partition@580000 {
+			label = "ubi";
+			reg = <0x780000 0x2800000>;
+		};
+
+		partition@2f80000 {
+			label = "firmware2";
+			reg = <0x2f80000 0x2e00000>;
+		};
+
+		partition@5d80000 {
+			label = "storage";
+			reg = <0x5d80000 0x600000>;
+			read-only;
+		};
+
+		partition@6380000 {
+			label = "idmkey";
+			reg = <0x6380000 0x100000>;
+			read-only;
+		};
+
+		partition@6480000 {
+			label = "working";
+			reg = <0x6480000 0x80000>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_factory_4 2>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	ethphy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+/*
+ * pcie0: MT7915 HIF (14c3,7916)
+ * pcie1: MT7915     (14c3,7915)
+ */
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+
+		nvmem-cells = <&eeprom>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "uart2", "uart3";
+		function = "gpio";
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -67,6 +67,7 @@ ramips_setup_interfaces()
 	beeline,smartbox-flash|\
 	beeline,smartbox-giga|\
 	glinet,gl-mt1300|\
+	iodata,wn-deax1800gr|\
 	iptime,a3002mesh|\
 	jcg,q20|\
 	lenovo,newifi-d1|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/iodata.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/iodata.sh
@@ -10,55 +10,79 @@ iodata_mstc_prepare_fail() {
 	reboot -f
 }
 
-# I-O DATA devices manufactured by MSTC (MitraStar Technology Corp.)
-# have two important flags:
-# - bootnum: switch between two os images
-#     use 1st image in OpenWrt
-# - debugflag: enable/disable debug
-#     users can interrupt Z-Loader for recovering the device if enabled
+# read/write 1byte in mtd device
 #
 # parameters:
-# - $1: the offset of "debugflag"
-iodata_mstc_upgrade_prepare() {
-	local persist_mtd="$(find_mtd_part persist)"
-	local factory_mtd="$(find_mtd_part factory)"
-	local dflag_offset="$1"
+#   $1: target mtd device ("/dev/mtdblockN")
+#   $2: offset of target value (decimal or hex)
+#   $3: value to set (decimal or hex, don't set when reading)
+iodata_mstc_rw_byte() {
+	local mtd="$1"
+	local offset="$2"
+	local setval="$3"
+	local _val=$(hexdump -s $offset -n 1 -e '"%d"' $mtd)
 
-	if [ -z "$dflag_offset" ]; then
-		echo 'no debugflag offset provided'
+	if [ -z "$setval" ]; then
+		echo $_val
+		return 0
+	fi
+
+	# decimal or hex -> decimal
+	setval=$((setval))
+	[ "$_val" = "$setval" ] && return 0
+	setval="$(printf '%02x' $setval)"
+
+	if ! (printf "\x$setval" | dd bs=1 seek=$((offset)) conv=notrunc of=$mtd 2>/dev/null); then
+		return 1
+	fi
+}
+
+# set flag in mtd device on I-O DATA devices manufactured by MSTC
+# (MitraStar Technology Corp.)
+#
+# parameters:
+#   $1: parameter name
+#   $2: mtd name contains target flag
+#   $3: offset of flag
+#   $4: valid flag values ("n,n,...", ex:"0,1" or "1,2")
+#   $5: value to set to the flag
+iodata_mstc_set_flag() {
+	local name="$1"
+	local mtddev="$(find_mtd_part $2)"
+	local offset="$3"
+	local valid="$4"
+	local setval="$5"
+
+	if [ -z "$offset" ]; then
+		echo "no $name flag offset provided"
 		iodata_mstc_prepare_fail
 	fi
 
-	if [ -z "$persist_mtd" ] || [ -z "$factory_mtd" ]; then
-		echo 'cannot find mtd partition(s), "factory" or "persist"'
+	if [ -z "$mtddev" ]; then
+		echo "cannot find \"$2\" mtd partition"
 		iodata_mstc_prepare_fail
 	fi
 
-	local bootnum=$(hexdump -s 4 -n 1 -e '"%x"' ${persist_mtd})
-	local debugflag=$(hexdump -s $((dflag_offset)) -n 1 -e '"%x"' ${factory_mtd})
+	local flag=$(iodata_mstc_rw_byte "$mtddev" "$offset")
+	local _tmp
+	for i in ${valid//,/ }; do
+		if [ "$flag" = "$((i))" ]; then
+			_tmp=$flag
+			break
+		fi
+	done
 
-	if [ "$bootnum" != "1" ] && [ "$bootnum" != "2" ]; then
-		echo "failed to get bootnum, please check the value at 0x4 in ${persist_mtd}"
+	if [ -z "$_tmp" ]; then
+		echo "failed to get valid $name flag, please check the value at $offset in $mtddev"
 		iodata_mstc_prepare_fail
 	fi
-	if [ "$debugflag" != "0" ] && [ "$debugflag" != "1" ]; then
-		echo "failed to get debugflag, please check the value at ${dflag_offset} in ${factory_mtd}"
-		iodata_mstc_prepare_fail
-	fi
-	echo "current: bootnum => ${bootnum}, debugflag => ${debugflag}"
+	echo "current: $name => $flag"
 
-	if [ "$bootnum" = "2" ]; then
-		if ! (echo -ne "\x01" | dd bs=1 count=1 seek=4 conv=notrunc of=${persist_mtd} 2>/dev/null); then
-			echo "failed to set bootnum"
+	if [ "$flag" != "$((setval))" ]; then
+		if ! iodata_mstc_rw_byte "$mtddev" "$offset" "$setval"; then
+			echo "failed to set \"$name\" flag"
 			iodata_mstc_prepare_fail
 		fi
-		echo "### switch to 1st os-image on next boot ###"
-	fi
-	if [ "$debugflag" = "0" ]; then
-		if ! (echo -ne "\x01" | dd bs=1 count=1 seek=$((dflag_offset)) conv=notrunc of=${factory_mtd} 2>/dev/null); then
-			echo "failed to set debugflag"
-			iodata_mstc_prepare_fail
-		fi
-		echo "### enable debug ###"
+		echo " --> set \"$name\" flag to $setval (valid: $valid)"
 	fi
 }

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -129,6 +129,10 @@ platform_do_upgrade() {
 		iodata_mstc_set_flag "bootnum" "persist" "0x4" "1,2" "1"
 		nand_do_upgrade "$1"
 		;;
+	iodata,wn-deax1800gr)
+		iodata_mstc_set_flag "bootnum" "working" "0x4" "0,1" "0"
+		nand_do_upgrade "$1"
+		;;
 	iodata,wn-dx1200gr)
 		iodata_mstc_set_flag "debugflag" "factory" "0x1fe75" "0,1" "1"
 		iodata_mstc_set_flag "bootnum" "persist" "0x4" "1,2" "1"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -125,11 +125,13 @@ platform_do_upgrade() {
 	iodata,wn-ax2033gr|\
 	iodata,wn-dx1167r|\
 	iodata,wn-dx2033gr)
-		iodata_mstc_upgrade_prepare "0xfe75"
+		iodata_mstc_set_flag "debugflag" "factory" "0xfe75" "0,1" "1"
+		iodata_mstc_set_flag "bootnum" "persist" "0x4" "1,2" "1"
 		nand_do_upgrade "$1"
 		;;
 	iodata,wn-dx1200gr)
-		iodata_mstc_upgrade_prepare "0x1fe75"
+		iodata_mstc_set_flag "debugflag" "factory" "0x1fe75" "0,1" "1"
+		iodata_mstc_set_flag "bootnum" "persist" "0x4" "1,2" "1"
 		nand_do_upgrade "$1"
 		;;
 	tplink,er605-v2)


### PR DESCRIPTION
This PR contains 2x commits:

- improve sysupgrade helper functions for I-O DATA devices
- add support for I-O DATA WN-DEAX1800GR

tested:

- WN-DX1167R
- WN-DEAX1800GR