### PR TITLE
[22.03] ramips: add support for D-Link DIR-806A B1 router

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -22,6 +22,10 @@ sitecom,wlr-4100-v1-002|\
 zyxel,keenetic-lite-iii-a)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x1000"
 	;;
+arcadyan,we420223-99|\
+dlink,dir-806a-b1)
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x1000" "0x1000"
+	;;
 allnet,all0256n-4m|\
 allnet,all0256n-8m|\
 allnet,all5002|\

--- a/target/linux/ramips/dts/mt7620a_dlink_dir-806a-b1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dir-806a-b1.dts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "dlink,dir-806a-b1", "ralink,mt7620a-soc";
+	model = "D-Link DIR-806A B1";
+
+	aliases {
+		led-boot = &wps_led;
+		led-failsafe = &wps_led;
+		led-running = &wps_led;
+		led-upgrade = &wps_led;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;	// #12
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wifi_led: 2.4g {
+			label = "green:wlan";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;	// #72
+		};
+
+		wps_led: wps {
+			label = "green:wps";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;	// #39
+		};
+
+	};
+
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <48000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ALL";
+				reg = <0x0 0x800000>;
+				read-only;
+			};
+
+			partition@0_1 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "Factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uartf", "ephy";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <(-2)>;
+};
+
+&wmac {
+	pinctrl-names = "default", "pa_gpio";
+	pinctrl-0 = <&pa_pins>;
+	pinctrl-1 = <&pa_gpio_pins>;
+
+	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <(-1)>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		nvmem-cells = <&macaddr_factory_8004>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <(-3)>;
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 {
+		reg = <0x4 0x6>;
+	};
+
+	macaddr_factory_8004: macaddr@8004 {
+		reg = <0x8004 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -210,6 +210,19 @@ define Device/dlink_dir-510l
 endef
 TARGET_DEVICES += dlink_dir-510l
 
+define Device/dlink_dir-806a-b1
+  SOC := mt7620a
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DIR-806A
+  DEVICE_VARIANT := B1
+  DEVICE_PACKAGES += kmod-mt76x0e
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | check-size | \
+	sign-dlink-ru cef285a2e29e40b2baab31277d44298b
+endef
+TARGET_DEVICES += dlink_dir-806a-b1
+
 define Device/dlink_dir-810l
   SOC := mt7620a
   DEVICE_PACKAGES := kmod-mt76x0e

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -44,6 +44,9 @@ comfast,cf-wr800n)
 	ucidef_set_led_netdev "lan" "lan" "white:ethernet" eth0.1
 	ucidef_set_led_netdev "wifi_led" "wifi" "white:wifi" "wlan0"
 	;;
+dlink,dir-806a-b1)
+	ucidef_set_led_netdev "wifi_led" "2.4g" "green:wlan" "wlan1"
+	;;
 dlink,dir-810l|\
 trendnet,tew-810dr)
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -78,6 +78,7 @@ ramips_setup_interfaces()
 	asus,rt-ac54u|\
 	asus,rt-n14u|\
 	bdcom,wap2100-sk|\
+	dlink,dir-806a-b1|\
 	domywifi,dm202|\
 	domywifi,dm203|\
 	domywifi,dw22d|\


### PR DESCRIPTION
That is a backport https://github.com/openwrt/openwrt/pull/12779

General specification:
SoC Type: MediaTek MT7620A (580MHz)
ROM: 8 MB SPI-NOR (MX25L6406E)
RAM: 64 MB DDR (W9751G6KB-25)
Switch: MediaTek MT7530
Ethernet: 5 ports - 5×100MbE (WAN, LAN1-4)
Wireless: 2.4 GHz (MediaTek RT5390): b/g/n
Wireless: 5 GHz (MediaTek MT7610EN): ac/n
Buttons: 2 button (POWER, WPS/RESET)
Bootloader: U-Boot 1.1.3
Power: 12 VDC, 0.5 A

MACs:
| LAN	| [Factory + 0x04] - 2		|
| WLAN 2.4g	| [Factory + 0x04] - 1		|
| WLAN 5g	| [Factory + 0x8004] - 3	|
| WAN	| [Factory + 0x04] - 2		|

OEM easy installation:

1. Use a PC to browse to http://192.168.0.1.
2. Go to the System section and open the Firmware Update section.
3. Under the Local Update at the right, click on the CHOOSE FILE...
4. When a modal window appears, choose the firmware file and click on the Open.
5. Next click on the UPDATE FIRMWARE button and upload the firmware image. Wait for the router to flash and reboot.

OEM installation using the TFTP method (need level converter):

1. Download the latest firmware image.
2. Set up a Tftp server on a PC (e.g. Tftpd32) and place the firmware image to the root directory of the server.
3. Power off the router and use a twisted pair cable to connect the PC to any of the router's LAN ports.
4. Configure the network adapter of the PC to use IP address 192.168.0.180 and subnet mask 255.255.255.0.
5. Connect serial port (57600 8N1) and turn on the router.
6. Then interrupt "U-Boot Boot Menu" by hitting 2 key (select "2: Load system code then write to Flash via TFTP.").
7. Press Y key when show "Warning!! Erase Linux in Flash then burn new one. Are you sure? (Y/N)" Input device IP (192.168.0.1) ==:192.168.0.1
Input server IP (192.168.0.180) ==:192.168.0.180
Input Linux Kernel filename () ==:firmware_name
The router should download the firmware via TFTP and complete flashing in
 a few minutes.
After flashing is complete, use the PC to browse to http://192.168.1.1 or
 ssh to proceed with the configuration.


(cherry picked from commit ce998cb6e161db9c9e868fd570da9189f05fde3e) [Replace phy1-ap0 with wlan1]

Device topic at forum.openwrt.org [here](https://forum.openwrt.org/t/add-support-for-d-link-dir-806a-rev-b1/158797)