### PR TITLE
 mbedtls: Update to version 2.28.4 

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=2.28.3
+PKG_VERSION:=2.28.4
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ARMmbed/mbedtls/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=bdf7c5bbdc338da3edad89b2885d4f8668f9a6fffeba6ec17a60333e36dade6f
+PKG_HASH:=578c4dcd15bbff3f5cd56aa07cd4f850fc733634e3d5947be4f7157d5bfd81ac
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=gpl-2.0.txt

--- a/package/libs/mbedtls/patches/100-x509-crt-verify-SAN-iPAddress.patch
+++ b/package/libs/mbedtls/patches/100-x509-crt-verify-SAN-iPAddress.patch
@@ -33,7 +33,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
  #include <windows.h>
  #else
  #include <time.h>
-@@ -2995,6 +2999,61 @@ find_parent:
+@@ -3001,6 +3005,61 @@ find_parent:
      }
  }
  
@@ -95,7 +95,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
  /*
   * Check for CN match
   */
-@@ -3015,24 +3074,51 @@ static int x509_crt_check_cn(const mbedt
+@@ -3021,24 +3080,51 @@ static int x509_crt_check_cn(const mbedt
      return -1;
  }
  
@@ -158,7 +158,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
  }
  
  /*
-@@ -3043,31 +3129,23 @@ static void x509_crt_verify_name(const m
+@@ -3049,31 +3135,23 @@ static void x509_crt_verify_name(const m
                                   uint32_t *flags)
  {
      const mbedtls_x509_name *name;


### PR DESCRIPTION
This only fixes minor problems.
    Changelog: https://github.com/Mbed-TLS/mbedtls/releases/tag/v2.28.4
