### PR TITLE
tools/xz: update to 5.4.4

### DIFF
--- a/tools/xz/Makefile
+++ b/tools/xz/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xz
-PKG_VERSION:=5.4.3
+PKG_VERSION:=5.4.4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/lzmautils \
 		http://tukaani.org/xz
-PKG_HASH:=9243a04598d7a70c1f567a0143a255581ac5c64b140fd55fd5cbc1e00b0e6f90
+PKG_HASH:=0b6fcde1ac38e90433a2556f500c065950b9bcd2d602006efc334782bdfe6296
 PKG_CPE_ID:=cpe:/a:tukaani:xz
 
 HOST_BUILD_PARALLEL:=1


### PR DESCRIPTION
* liblzma and xzdec can now build against WASI SDK when threading support is disabled. xz and tests don't build yet.

* CMake:

    - Fixed a bug preventing other projects from including liblzma
      multiple times using find_package().

    - Don't create broken symlinks in Cygwin and MSYS2 unless
      supported by the environment. This prevented building for the
      default MSYS2 environment. The problem was introduced in
      xz 5.4.0.

* Documentation:

    - Small improvements to man pages.

    - Small improvements and typo fixes for liblzma API
      documentation.

* Tests:

    - Added a new section to INSTALL to describe basic test usage
      and address recent questions about building the tests when
      cross compiling.

    - Small fixes and improvements to the tests.

* Translations:

    - Fixed a mistake that caused one of the error messages to not
      be translated. This only affected versions 5.4.2 and 5.4.3.

    - Updated the Chinese (simplified), Croatian, Esperanto, German,
      Korean, Polish, Romanian, Spanish, Swedish, Ukrainian, and
      Vietnamese translations.

    - Updated the German, Korean, Romanian, and Ukrainian man page
      translations.
