### PR TITLE
tools/pkgconf: update to 2.0.1

### DIFF
--- a/tools/pkgconf/Makefile
+++ b/tools/pkgconf/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pkgconf
-PKG_VERSION:=1.9.5
+PKG_VERSION:=2.0.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://distfiles.dereferenced.org/pkgconf
-PKG_HASH:=1ac1656debb27497563036f7bffc281490f83f9b8457c0d60bcfb638fb6b6171
+PKG_HASH:=3238af7473740844e5159dd8fb6540603e3fbcebf60beb3c8a426cdca2e29c51
 
 PKG_CPE_ID:=cpe:/a:pkgconf:pkgconf
 


### PR DESCRIPTION
Changes from 2.0.0 to 2.0.1:
----------------------------

* The behavior of --modversion was largely reverted back to the traditional pkg-config behavior, but still operates on a solved dependency graph.

  The order of --modversion output is based on the dependency resolution queue which is passed to the solver, which itself generally maps to the order of the constrants provided on the command line.

* A new flag, --verbose, has been added.  When used with `--modversion`, it is possible to disambiguate which version belongs to which module:

    % pkgconf --modversion --verbose foo bar
    foo: 1.2.3
    bar: 1.3

Changes from 1.9.5 to 2.0.0:
----------------------------

* When flattening the dependency graph, retain the latest seen edges rather than the earliest.

* Fix a long-standing bug where the dependency resolution queue was evaluated in reverse.  This bug masked the aforementioned dependency flattening bug in many cases.

* Fix handling of --with-path, which was appending paths to the search list rather than prepending them as intended.

* Error when --modversion is requested with more than one package, as the output is ambiguous.