### PR TITLE
uboot-envtools: update to 2023.07.02

### DIFF
--- a/package/boot/uboot-envtools/Makefile
+++ b/package/boot/uboot-envtools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uboot-envtools
 PKG_DISTNAME:=u-boot
-PKG_VERSION:=2023.04
+PKG_VERSION:=2023.07.02
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_DISTNAME)-$(PKG_VERSION).tar.bz2
@@ -17,7 +17,7 @@ PKG_SOURCE_URL:= \
     https://ftp.denx.de/pub/u-boot \
     https://mirror.cyberbits.eu/u-boot \
     ftp://ftp.denx.de/pub/u-boot
-PKG_HASH:=e31cac91545ff41b71cec5d8c22afd695645cd6e2a442ccdacacd60534069341
+PKG_HASH:=6b6a48581c14abb0f95bd87c1af4d740922406d7b801002a9f94727fdde021d5
 PKG_SOURCE_SUBDIR:=$(PKG_DISTNAME)-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_DISTNAME)-$(PKG_VERSION)
 

--- a/package/boot/uboot-envtools/patches/002-Revert-tools-env-use-run-to-store-lockfile.patch
+++ b/package/boot/uboot-envtools/patches/002-Revert-tools-env-use-run-to-store-lockfile.patch
@@ -1,0 +1,44 @@
+Revert "tools: env: use /run to store lockfile"
+
+In OpenWRT we still use /var/lock as default location for lock files and
+/run might not even exist. Revert the upstream change and restore the
+previous default path.
+
+This reverts upstream commit
+ https://source.denx.de/u-boot/u-boot/-/commit/aeb40f1166e072856f865d26d42a4bea1ec3a514
+---
+ tools/env/fw_env_main.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tools/env/fw_env_main.c b/tools/env/fw_env_main.c
+index 0b201b9e62..1d193bd437 100644
+--- a/tools/env/fw_env_main.c
++++ b/tools/env/fw_env_main.c
+@@ -73,7 +73,7 @@ void usage_printenv(void)
+ 		" -c, --config         configuration file, default:" CONFIG_FILE "\n"
+ #endif
+ 		" -n, --noheader       do not repeat variable name in output\n"
+-		" -l, --lock           lock node, default:/run\n"
++		" -l, --lock           lock node, default:/var/lock\n"
+ 		"\n");
+ }
+ 
+@@ -88,7 +88,7 @@ void usage_env_set(void)
+ #ifdef CONFIG_FILE
+ 		" -c, --config         configuration file, default:" CONFIG_FILE "\n"
+ #endif
+-		" -l, --lock           lock node, default:/run\n"
++		" -l, --lock           lock node, default:/var/lock\n"
+ 		" -s, --script         batch mode to minimize writes\n"
+ 		"\n"
+ 		"Examples:\n"
+@@ -206,7 +206,7 @@ int parse_setenv_args(int argc, char *argv[])
+ 
+ int main(int argc, char *argv[])
+ {
+-	char *lockname = "/run/" CMD_PRINTENV ".lock";
++	char *lockname = "/var/lock/" CMD_PRINTENV ".lock";
+ 	int lockfd = -1;
+ 	int retval = EXIT_SUCCESS;
+ 	char *_cmdname;
+


### PR DESCRIPTION
Update to the latest stable version.

This update changes the default lockfile directory from /var/lock to /run [1]. In OpenWRT we still use the "legacy" /var/lock and /run might not even exist, so we add a patch to revert this particular change.

[1] https://source.denx.de/u-boot/u-boot/-/commit/aeb40f1166e072856f865d26d42a4bea1ec3a514


Build and run tested on a Turris Omnia (mvebu/cortexa9) with U-Boot 2023.07.02
