### PR TITLE
patchelf: Revert "tools/patchelf: update to 0.18.0"

### DIFF
--- a/tools/patchelf/Makefile
+++ b/tools/patchelf/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=patchelf
-PKG_VERSION:=0.18.0
+PKG_VERSION:=0.17.2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/NixOS/patchelf/releases/download/$(PKG_VERSION)
-PKG_HASH:=1952b2a782ba576279c211ee942e341748fdb44997f704dd53def46cd055470b
+PKG_HASH:=bae2ea376072e422c196218dd9bdef0548ccc08da4de9f36b4672df84ea2d8e2
 
 HOST_BUILD_PARALLEL:=1
 HOST_FIXUP:=autoreconf


### PR DESCRIPTION
This reverts commit ec6bcda8e49815efeee845da50defc85ae068b79.

patchelf 0.18.0 requires GCC 8, it does not compile using GCC 7 any more. Downgrade to patchelf 0.17.2 which still supports GCC 7.

Downgrade patchelf to 0.17.2 only in the OpenWrt 23.05 branch and require GCC 8 in the master branch.

Ubuntu 18.04 uses GCC 7 by default.

Fixed: #13102 

We should require GCC 8 in master, see #12188
