### PR TITLE
ipq40xx: fix booting on Meraki MR33 and MR74

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -762,13 +762,13 @@ define Device/meraki_common
 	SOC := qcom-ipq4029
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
+	DEVICE_DTS_LOADADDR := 0x89000000
 	DEVICE_PACKAGES := ath10k-firmware-qca9887-ct
 endef
 
 define Device/meraki_mr33
 	$(call Device/meraki_common)
 	DEVICE_MODEL := MR33
-	DEFAULT := n
 endef
 TARGET_DEVICES += meraki_mr33
 
@@ -776,7 +776,6 @@ define Device/meraki_mr74
 	$(call Device/meraki_common)
 	DEVICE_MODEL := MR74
 	DEVICE_DTS_CONFIG := config@3
-	DEFAULT := n
 endef
 TARGET_DEVICES += meraki_mr74
 

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -762,7 +762,7 @@ define Device/meraki_common
 	SOC := qcom-ipq4029
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
-	DEVICE_PACKAGES := -swconfig ath10k-firmware-qca9887-ct
+	DEVICE_PACKAGES := ath10k-firmware-qca9887-ct
 endef
 
 define Device/meraki_mr33

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -756,26 +756,25 @@ define Device/luma_wrtq-329acn
 endef
 TARGET_DEVICES += luma_wrtq-329acn
 
-define Device/meraki_mr33
+define Device/meraki_common
 	$(call Device/FitImage)
 	DEVICE_VENDOR := Cisco Meraki
-	DEVICE_MODEL := MR33
 	SOC := qcom-ipq4029
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	DEVICE_PACKAGES := -swconfig ath10k-firmware-qca9887-ct
+endef
+
+define Device/meraki_mr33
+	$(call Device/meraki_common)
+	DEVICE_MODEL := MR33
 	DEFAULT := n
 endef
 TARGET_DEVICES += meraki_mr33
 
 define Device/meraki_mr74
-	$(call Device/FitImage)
-	DEVICE_VENDOR := Cisco Meraki
+	$(call Device/meraki_common)
 	DEVICE_MODEL := MR74
-	SOC := qcom-ipq4029
-	BLOCKSIZE := 128k
-	PAGESIZE := 2048
-	DEVICE_PACKAGES := -swconfig ath10k-firmware-qca9887-ct
 	DEVICE_DTS_CONFIG := config@3
 	DEFAULT := n
 endef


### PR DESCRIPTION
It seems that the Meraki bootloader does not respect the kernel ARM booting
specification[1] that requires that the address where DTB is located needs to
be 64-bit aligned and often places the DTB on a non-64-bit aligned address
and then the kernel fails to find the DTB magic and fails to boot.
Even worse, there are no prints until early printk is enabled and then its
visible that the kernel is trying to find the ATAG-s as DTB was not found or
is invalid.

Unifi 6 devices had the same issue and it can be solved by passing the
load address as part of the FIT image.
It seems that the vendor was aware of the issue and is always relocating
the DTB to 0x89000000, so let's just do the same.

Now that booting is reliable, reenable default images for the Meraki MR33
and MR74 devices.

While doing this, I noticed that image recipes are just duplicates so decided
to fix that up as well as get rid of swconfig removal as its not included by
default anyway.

This should be backported to 23.05 as well.
