### PR TITLE
prereq: make existing binary check work for sdk as well

### DIFF
--- a/include/prereq.mk
+++ b/include/prereq.mk
@@ -111,7 +111,6 @@ define SetupHostCommand
 						[ -x "$(STAGING_DIR_HOST)/bin/$(strip $(1))" ] && exit 0 \
 						;; \
 					"-"*) \
-						find "$(STAGING_DIR_HOST)/stamp" | grep $(strip $(1)) && \
 						[ -x "$(STAGING_DIR_HOST)/bin/$(strip $(1))" ] && exit 0 \
 						;; \
 					*" -> /"*) \

--- a/include/prereq.mk
+++ b/include/prereq.mk
@@ -107,15 +107,9 @@ define SetupHostCommand
 			bin="$$$$$$$$(command -v "$$$$$$$${cmd%% *}")"; \
 			if [ -x "$$$$$$$$bin" ] && eval "$$$$$$$$cmd" >/dev/null 2>/dev/null; then \
 				case "$$$$$$$$(ls -dl -- $(STAGING_DIR_HOST)/bin/$(strip $(1)))" in \
-					*" -> $$$$$$$$bin"*) \
-						[ -x "$(STAGING_DIR_HOST)/bin/$(strip $(1))" ] && exit 0 \
-						;; \
-					"-"*) \
-						[ -x "$(STAGING_DIR_HOST)/bin/$(strip $(1))" ] && exit 0 \
-						;; \
-					*" -> /"*) \
-						;; \
-					*" -> "*) \
+					"-"* | \
+					*" -> $$$$$$$$bin"* | \
+					*" -> "[!/]*) \
 						[ -x "$(STAGING_DIR_HOST)/bin/$(strip $(1))" ] && exit 0 \
 						;; \
 				esac; \


### PR DESCRIPTION
To avoid replacing host built binaries with symlinks again, a check for an appropriate stamp was added in 729909c07f ("prereq-build: do not replace binaries with symlinks"). Unfortunately the stamp directory does not exist in the packages SDK, so the fix was ineffective there.

This caused the packages builders to e.g. use the host tar again, which in turn made the tarballs created different since it may lack reproducibility fixes, or implement these differently, causing spurious hash failures on source repository based packages.

Fix this by dropping the stamp dir check, and just check that the file is usable.

Now that most cases do the same thing in SetupHostCommand, we can merge them
together into one. To allow moving the generic symlink check, invert the
check and let it check for relative links by matching on link targets
that do not start with a slash.

This then allows us to also drop the absolute link case, shortening the
case statement further.

This reorders the check to

* if it is not a symlink, do not change it
* if it is a symlink and it points to the found command, do not change it
* if it is a symlink with a relative path, do not change it
* else, update/replace it

Fixes: 729909c07f ("prereq-build: do not replace binaries with symlinks")