### PR TITLE
[23.05] ipq4019: add support for ZTE MF287 Pro aka DreiNeo Pro

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -108,7 +108,8 @@ ipq40xx_setup_interfaces()
 	zte,mf286d)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "wan"
 		;;
-	zte,mf287plus)
+	zte,mf287plus|\
+	zte,mf287pro)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
 		;;

--- a/target/linux/ipq40xx/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ipq40xx/base-files/etc/board.d/03_gpio_switches
@@ -36,6 +36,7 @@ wallys,dr40x9)
 	ucidef_add_gpio_switch "sim_card_select" "SIM card select" "423" "0"
 	;;
 zte,mf286d|\
+zte,mf287pro|\
 zte,mf289f)
 	ucidef_add_gpio_switch "power_btn_block" "Power button blocker" "421" "0"
 	;;

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -28,6 +28,7 @@ EOF
 	zte,mf18a |\
 	zte,mf286d |\
 	zte,mf287plus |\
+	zte,mf287pro |\
 	zte,mf289f)
 		CI_UBIPART="rootfs"
 		local mtdnum="$( find_mtd_index $CI_UBIPART )"
@@ -211,6 +212,7 @@ platform_do_upgrade() {
 	zte,mf18a |\
 	zte,mf286d |\
 	zte,mf287plus |\
+	zte,mf287pro |\
 	zte,mf289f)
 		CI_UBIPART="rootfs"
 		nand_do_upgrade "$1"

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287.dtsi
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// Copyright (c) 2022, Pawel Dembicki <paweldembicki@gmail.com>.
+// Copyright (c) 2022, Giammarco Marzano <stich86@gmail.com>.
+// Copyright (c) 2023, Andreas Böhler <dev@aboehler.at>
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/soc/qcom,tcsr.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	chosen {
+		/*
+		 * bootargs forced by u-boot bootipq command:
+		 * 'ubi.mtd=rootfs root=mtd:ubi_rootfs rootfstype=squashfs rootwait'
+		 */
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: led-0 {
+			label = "blue:power";
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		key_reset: key-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+		};
+
+		key_wps: key-wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	soc {
+		rng@22000 {
+			status = "okay";
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			/* select hostmode */
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+			status = "okay";
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_mac_0>;
+	mac-address-increment = <2>;
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport2 {
+	status = "okay";
+
+	label = "lan1";
+};
+
+&swport3 {
+	status = "okay";
+
+	label = "lan2";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "lan3";
+};
+
+&swport5 {
+	status = "okay";
+
+	label = "lan4";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&wifi0 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_1000>, <&macaddr_mac_0>;
+	qcom,ath10k-calibration-variant = "zte,mf287plus";
+};
+
+&wifi1 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_5000>, <&macaddr_mac_0>;
+	mac-address-increment = <1>;
+	qcom,ath10k-calibration-variant = "zte,mf287plus";
+};

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287pro.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287pro.dts
@@ -6,38 +6,57 @@
 #include "qcom-ipq4018-mf287.dtsi"
 
 / {
-	model = "ZTE MF287Plus";
-	compatible = "zte,mf287plus";
+	model = "ZTE MF287Pro";
+	compatible = "zte,mf287pro";
 
-	/*
-	 * This node is used to restart modem module to avoid anomalous
-	 * behaviours on initial communication.
-	 */
-	gpio-restart {
-		compatible = "gpio-restart";
-		gpios = <&tlmm 5 GPIO_ACTIVE_HIGH>;
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		modem {
+			gpio-export,name = "modem-reset";
+			gpio-export,output = <0>;
+			gpios = <&tlmm 8 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	regulator-usb-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "USB_VBUS";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+		regulator-boot-on;
+		gpio = <&tlmm 25 GPIO_ACTIVE_LOW>;
 	};
 };
 
 &key_reset {
-	gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
+	gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
 };
 
 &key_wps {
-	gpios = <&tlmm 2 GPIO_ACTIVE_LOW>;
+	gpios = <&tlmm 68 GPIO_ACTIVE_LOW>;
 };
 
 &led_status {
-	gpios = <&tlmm 0 GPIO_ACTIVE_LOW>;
+	gpios = <&tlmm 35 GPIO_ACTIVE_LOW>;
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <2000>;
 };
 
 &blsp1_spi1 {
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>,
-		   <&tlmm 59 GPIO_ACTIVE_HIGH>,
-		   <&tlmm 1 GPIO_ACTIVE_HIGH>;
+	cs-gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>,
+				<&tlmm 54 GPIO_ACTIVE_HIGH>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
@@ -113,13 +132,13 @@
 
 			partition@0 {
 				label = "fota-flag";
-				reg = <0x0 0x140000>;
+				reg = <0x0 0xa0000>;
 				read-only;
 			};
 
-			partition@140000 {
+			partition@a0000 {
 				label = "ART";
-				reg = <0x140000 0x140000>;
+				reg = <0xa0000 0x80000>;
 				read-only;
 				compatible = "nvmem-cells";
 				#address-cells = <1>;
@@ -134,9 +153,9 @@
 				};
 			};
 
-			partition@280000 {
+			partition@120000 {
 				label = "mac";
-				reg = <0x280000 0x140000>;
+				reg = <0x120000 0x80000>;
 				read-only;
 				compatible = "nvmem-cells";
 				#address-cells = <1>;
@@ -147,25 +166,40 @@
 				};
 			};
 
-			partition@3c0000 {
+			partition@1a0000 {
+				label = "reserved2";
+				reg = <0x1a0000 0xc0000>;
+			};
+
+			partition@260000 {
 				label = "cfg-param";
-				reg = <0x3c0000 0x600000>;
+				reg = <0x260000 0x400000>;
 				read-only;
 			};
 
-			partition@9c0000 {
+			partition@660000 {
+				label = "log";
+				reg = <0x660000 0x400000>;
+			};
+
+			partition@a60000 {
 				label = "oops";
-				reg = <0x9c0000 0x140000>;
+				reg = <0xa60000 0xa0000>;
 			};
 
 			partition@b00000 {
-				label = "web";
-				reg = <0xb00000 0x800000>;
+				label = "reserved3";
+				reg = <0xb00000 0x500000>;
 			};
 
-			partition@1300000 {
+			partition@1000000 {
+				label = "web";
+				reg = <0x1000000 0x800000>;
+			};
+
+			partition@1800000 {
 				label = "rootfs";
-				reg = <0x1300000 0x2200000>;
+				reg = <0x1800000 0x1d00000>;
 			};
 
 			partition@3500000 {
@@ -179,21 +213,34 @@
 			};
 		};
 	};
-
-	zigbee@2 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		compatible = "silabs,em3581";
-		reg = <2>;
-		spi-max-frequency = <12000000>;
-	};
 };
 
 &tlmm {
+	i2c_0_pins: i2c_0_pinmux {
+		mux {
+			pins = "gpio20", "gpio21";
+			function = "blsp_i2c0";
+			bias-disable;
+		};
+	};
+
+	mdio_pins: mdio_pinmux {
+		mux_1 {
+			pins = "gpio6";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mux_2 {
+			pins = "gpio7";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
 	serial_pins: serial_pinmux {
 		mux {
-			pins = "gpio60", "gpio61";
+			pins = "gpio16", "gpio17";
 			function = "blsp_uart0";
 			bias-disable;
 		};
@@ -202,14 +249,14 @@
 	spi_0_pins: spi_0_pinmux {
 		pinmux {
 			function = "blsp_spi0";
-			pins = "gpio55", "gpio56", "gpio57";
+			pins = "gpio12", "gpio13", "gpio14", "gpio15";
 			drive-strength = <12>;
 			bias-disable;
 		};
 
 		pinmux_cs {
 			function = "gpio";
-			pins = "gpio54", "gpio59", "gpio1";
+			pins = "gpio12", "gpio54";
 			drive-strength = <2>;
 			bias-disable;
 			output-high;

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -1162,12 +1162,8 @@ define Device/zte_mf286d
 endef
 TARGET_DEVICES += zte_mf286d
 
-define Device/zte_mf287plus
+define Device/zte_mf287_common
 	$(call Device/zte_mf28x_common)
-	DEVICE_DTS_CONFIG := config@ap.dk01.1-c2
-	DEVICE_MODEL := MF287Plus
-	DEVICE_ALT0_VENDOR := ZTE
-	DEVICE_ALT0_MODEL := MF287
 	DEVICE_PACKAGES += ipq-wifi-zte_mf287plus
 	SOC := qcom-ipq4018
 #	The recovery image is used to return back to stock (an initramfs-based image
@@ -1178,7 +1174,22 @@ define Device/zte_mf287plus
 	IMAGE/factory.bin  := append-ubi
 	IMAGE/recovery.bin := append-squashfs4-fakeroot | sysupgrade-tar kernel=$$$$(BIN_DIR)/openwrt-$$(BOARD)$$(if $$(SUBTARGET),-$$(SUBTARGET))-$$(DEVICE_NAME)-initramfs-zImage.itb rootfs=$$$$@ | append-metadata
 endef
+
+define Device/zte_mf287plus
+	$(call Device/zte_mf287_common)
+	DEVICE_DTS_CONFIG := config@ap.dk01.1-c2
+	DEVICE_MODEL := MF287Plus
+	DEVICE_ALT0_VENDOR := ZTE
+	DEVICE_ALT0_MODEL := MF287
+endef
 TARGET_DEVICES += zte_mf287plus
+
+define Device/zte_mf287pro
+	$(call Device/zte_mf287_common)
+	DEVICE_DTS_CONFIG := config@ap.dk04.1-c1
+	DEVICE_MODEL := MF287Pro
+endef
+TARGET_DEVICES += zte_mf287pro
 
 define Device/zte_mf289f
 	$(call Device/zte_mf28x_common)


### PR DESCRIPTION
Backport support for ZTE MF287 Pro to the 23.05 branch
cherry-picked from https://github.com/openwrt/openwrt/commit/edfe91372adfdaf5ee4e294fb0f5860a16adc551

The ZTE MF287 Pro is a LTE router used (exclusively?) by the network operator "3". It is very similar to the MF287+, but the hardware layout and partition layout have changed quite a bit.

Specifications
==============

SoC: IPQ4018
RAM: 256MiB
Flash: 8MiB SPI-NOR + 128MiB SPI-NAND
LAN: 4x GBit LAN
LTE: ZTE Cat12
WiFi: 802.11a/b/g/n/ac SoC-integrated
USB: 1x 2.0

MAC addresses
=============

LAN: from config + 2
WiFi 1: from config
WiFi 2: from config + 1

Installation
============

Option 1 - TFTP
---------------

TFTP installation using UART is preferred. Disassemble the device and connect serial. Put the initramfs image as openwrt.bin to your TFTP server and configure a static IP of 192.168.1.100. Load the initramfs image by typing:

  setenv serverip 192.168.1.100
  setenv ipaddr 192.168.1.1
  tftpboot 0x82000000 openwrt.bin
  bootm 0x82000000

From this intiramfs boot you can take a backup of the currently installed partitions as no vendor firmware is available for download:

  ubiattach -m17
  cat /dev/ubi0_0 > /tmp/ubi0_0
  cat /dev/ubi0_1 > /tmp/ubi0_1

Copy the files /tmp/ubi0_0 and /tmp/ubi0_1 somewhere save.

Once booted, transfer the sysupgrade image and run sysupgrade. You might have to delete the stock volumes first:

  ubirmvol /dev/ubi0 -N ubi_rootfs
  ubirmvol /dev/ubi0 -N kernel

Option 2 - From stock firmware
------------------------------

The installation from stock requires an exploit first. The exploit consists of a backup file that forces the firmware to download telnetd via TFTP from 192.168.0.22 and run it. Once exploited, you can connect via telnet and login as admin:admin.

The exploit will be available at the device wiki page.

Once inside the stock firmware, you can transfer the -factory.bin file to /tmp by using "scp" from the stock frmware or "tftp".

ZTE has blocked writing to the NAND. Fortunately, it's easy to allow write access - you need to read from one file in /proc. Once done, you need to erase the UBI partition and flash OpenWrt. Before performing the operation, make sure that mtd13 is the partition labelled "rootfs" by calling "cat /proc/mtd".

Complete commands:

  cd /tmp
  tftp -g -r factory.bin 192.168.0.22
  cat /proc/driver/sensor_id
  flash_erase /dev/mtd17 0 0
  dd if=/tmp/factory.bin of=/dev/mtdblock17 bs=131072

Afterwards, reboot your device and you should have a working OpenWrt installation.

Restore Stock
=============

Option 1 - via UART
-------------------

Boot an OpenWrt initramfs image via TFTP as for the initial installation. Transfer the two backed-up files to your box to /tmp.

Then, run the following commands - replace $kernel_length and $rootfs_size by the size of ubi0_0 and ubi0_1 in bytes.

  ubiattach -m 17
  ubirmvol /dev/ubi0 -N kernel
  ubirmvol /dev/ubi0 -N rootfs
  ubirmvol /dev/ubi0 -N rootfs_data
  ubimkvol /dev/ubi0 -N kernel -s $kernel_length
  ubimkvol /dev/ubi0 -N ubi_rootfs -s $rootfs_size
  ubiupdatevol /dev/ubi0_0 /tmp/ubi0_0
  ubiupdatevol /dev/ubi0_1 /tmp/ubi0_1

Option 2 - from within OpenWrt
------------------------------

This option requires to flash an initramfs version first so that access to the flash is possible. This can be achieved by sysupgrading to the recovery.bin version and rebooting. Once rebooted, you are again in a default OpenWrt installation, but no partition is mounted.

Follow the commands from Option 1 to flash back to stock.

LTE Modem
=========

The LTE modem is similar to other ZTE devices and controls some more LEDs and battery management.

Configuring the connection using uqmi works properly, the modem provides three serial ports and a QMI CDC ethernet interface.

Other Notes
===========

Contrary to the stock firmware, the USB port on the back can be used.

There is one GPIO Switch "Power button blocker" which, if enabled, does not trigger a reset of the SoC if the modem reboots. If disabled, the SoC is rebooted along with the modem. The modem can be rebooted via the exported GPIO "modem-reset" in /sys/class/gpio.