### PR TITLE
uboot-envtools: fix parallel building

### DIFF
--- a/package/boot/uboot-envtools/Makefile
+++ b/package/boot/uboot-envtools/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=uboot-envtools
 PKG_DISTNAME:=u-boot
 PKG_VERSION:=2023.07.02
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_DISTNAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \
@@ -45,18 +45,19 @@ define Package/uboot-envtools/description
 endef
 
 define Build/Configure
-	touch $(PKG_BUILD_DIR)/include/config.h
-	mkdir -p $(PKG_BUILD_DIR)/include/config
-	touch $(PKG_BUILD_DIR)/include/config/auto.conf
-	mkdir -p $(PKG_BUILD_DIR)/include/generated
-	touch $(PKG_BUILD_DIR)/include/generated/autoconf.h
+	$(call Build/Compile/Default,tools-only_defconfig)
 endef
 
+define Build/Compile
+	$(call Build/Compile/Default,envtools)
+endef
+
+# We need to override the ARCH passed by buildsystem as otherwise the defconfig
+# for tools-only wont match and the includes for sandbox will be dropped
 MAKE_FLAGS += \
+	ARCH="sandbox" \
 	TARGET_CFLAGS="$(TARGET_CFLAGS)" \
 	TARGET_LDFLAGS="$(TARGET_LDFLAGS)" \
-	no-dot-config-targets=envtools \
-	envtools
 
 define Package/uboot-envtools/conffiles
 /etc/config/ubootenv


### PR DESCRIPTION
Recent envtools update to 2023.07.02 has introduced a breakage when trying to parallel build with the following error:
`/bin/sh: line 1: scripts/basic/fixdep: No such file or directory`
Luckily it can easily be reproduced locally via a simple script so it was not hard to bisect it down to upstream commit [1].

However, its not that commits fault, it just uncovered an issue with the way we have been building envtools for a long time, maybe even from the package introduction.

The issue is that we are trying to build envtools as one of the U-Boot no-dot-config-targets but envtools was newer a valid target for it but since we were creating the config headers that were not actually used it was actually building all this time.

Since the blamed commit [1] a tool called printinitialenv is built and now a proper config is actually required in order for prerequisites to get built properly.

So, in order to properly fix this (Hopefully for good) lets stop pretending that envtools are a valid no-dot-config-targets target and use the tools-only defconfig which is meant exactly for just building the tools. This will make a minimal config for the U-Boot sandbox target and then envtools will build just fine in parallel mode (I tested with 32 threads). We do hovewer need to override the ARCH passed by OpenWrt and set it to sandbox as otherwise U-Boot will not find the required headers because the ARCH is being overriden to an incorrect one.

[1] https://source.denx.de/u-boot/u-boot/-/commit/40b77f2a3ac13a7547c1b7c9c51a4090869de8f4

Fixes: 9db033005210 ("uboot-envtools: update to 2023.07.02")
