### PR TITLE
ipq807x: add support for Netgear WAX620

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq807x
@@ -10,7 +10,8 @@ board=$(board_name)
 case "$board" in
 dynalink,dl-wrx36|\
 netgear,rax120v2|\
-netgear,wax218)
+netgear,wax218|\
+netgear,wax620)
 	idx="$(find_mtd_index 0:appsblenv)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000" "2"

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -35,6 +35,7 @@ ALLWIFIBOARDS:= \
 	edimax_cax1800 \
 	netgear_rax120v2 \
 	netgear_wax218 \
+	netgear_wax620 \
 	prpl_haze \
 	qnap_301w \
 	redmi_ax6 \
@@ -126,6 +127,7 @@ $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))
 $(eval $(call generate-ipq-wifi-package,netgear_rax120v2,Netgear RAX120v2))
 $(eval $(call generate-ipq-wifi-package,netgear_wax218,Netgear WAX218))
+$(eval $(call generate-ipq-wifi-package,netgear_wax620,Netgear WAX620))
 $(eval $(call generate-ipq-wifi-package,qnap_301w,QNAP 301w))
 $(eval $(call generate-ipq-wifi-package,prpl_haze,prpl Haze))
 $(eval $(call generate-ipq-wifi-package,redmi_ax6,Redmi AX6))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax620.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax620.dts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	model = "Netgear WAX620";
+	compatible = "netgear,wax620", "qcom,ipq8074";
+
+	aliases {
+		serial0 = &blsp1_uart5;
+		ethernet0 = &dp6;
+		led-boot = &led_system_blue;
+		led-failsafe = &led_system_red;
+		led-running = &led_system_green;
+		led-upgrade = &led_system_blue;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		/*
+		 * Netgear's U-Boot adds "ubi.mtd=rootfs root=mtd:ubi_rootfs"
+		 * That fails to create a UBI block device, so add it here.
+		*/
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 52 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	led_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&tlmm 18 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&tlmm 19 GPIO_ACTIVE_HIGH>;
+
+		led_gpio: led_gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <1>;
+			enable-gpios = <&tlmm 20 GPIO_ACTIVE_HIGH>;
+			spi-max-frequency = <1000000>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system_red: system-red {
+			label = "system:red";
+			gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_system_green: system-green {
+			label = "system:green";
+			gpios = <&tlmm 55 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_system_blue: system-blue {
+			label = "system:blue";
+			gpios = <&tlmm 56 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_lan_g {
+			label = "lan:green";
+			gpios = <&led_gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_lan_o {
+			label = "lan:orange";
+			gpios = <&led_gpio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_2g_b {
+			label = "wlan2g:blue";
+			gpios = <&led_gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_2g_g {
+			label = "wlan2g:green";
+			gpios = <&led_gpio 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_5g_b {
+			label = "wlan5g:blue";
+			gpios = <&led_gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_5g_g {
+			label = "wlan5g:green";
+			gpios = <&led_gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+
+	switch_cpu_bmp = <0x01>;	
+	switch_lan_bmp = <0x3e>;
+	switch_wan_bmp = <0x40>;
+	switch_mac_mode = <0x00>;
+	switch_mac_mode1 = <0xff>;
+	switch_mac_mode2 = <0x0f>;
+	bm_tick_mode = <0x00>;
+	tm_tick_mode = <0x00>;
+
+	qcom,port_phyinfo {
+		port@5 {
+			port_id = <6>;
+			phy_address = <28>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+
+	qca8081_28: ethernet-phy@28 {
+		reg = <28>;
+	};
+};
+
+&dp6 {
+	status = "okay";
+	phy-handle = <&qca8081_28>;
+	label = "lan";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+		};
+	};
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Netgear-WAX620";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -115,6 +115,20 @@ define Device/netgear_rax120v2
 endef
 TARGET_DEVICES += netgear_rax120v2
 
+define Device/netgear_wax620
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Netgear
+	DEVICE_MODEL := WAX620
+	DEVICE_DTS_CONFIG := config@hk07
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	SOC := ipq8072
+	DEVICE_PACKAGES += kmod-spi-gpio kmod-gpio-nxp-74hc164 \
+		ipq-wifi-netgear_wax620
+endef
+TARGET_DEVICES += netgear_wax620
+
 define Device/netgear_wax218
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
@@ -12,6 +12,9 @@ edgecore,eap102)
 netgear,rax120v2)
 	ucidef_set_led_netdev "aqr" "AQR" "white:aqr" "lan5"
 	;;
+netgear,wax620)
+	ucidef_set_led_netdev "lan" "LAN" "lan:green" "lan"
+	;;
 netgear,wax218)
 	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "lan"
 	ucidef_set_led_wlan "wlan5g" "WIFI 5GHz" "blue:wlan5g" "phy0radio"

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -25,7 +25,8 @@ ipq807x_setup_interfaces()
 	netgear,rax120v2)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "wan"
 		;;
-	netgear,wax218)
+	netgear,wax218|\
+	netgear,wax620)
 		ucidef_set_interface_lan "lan" "dhcp"
 		;;
 	prpl,haze)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -16,6 +16,7 @@ case "$FIRMWARE" in
 	dynalink,dl-wrx36|\
 	netgear,rax120v2|\
 	netgear,wax218|\
+	netgear,wax620|\
 	qnap,301w|\
 	redmi,ax6|\
 	xiaomi,ax3600|\

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -69,7 +69,8 @@ platform_do_upgrade() {
 	compex,wpq873|\
 	edimax,cax1800|\
 	netgear,rax120v2|\
-	netgear,wax218)
+	netgear,wax218|\
+	netgear,wax620)
 		nand_do_upgrade "$1"
 		;;
 	prpl,haze|\


### PR DESCRIPTION
Netgear WAX620 AX3600 Wireless Access Point, is wall or ceiling mountable. It can be powered via PoE, or a 12 V adapter.
The majority of the code is based on [Netgear WAX218 PR](https://github.com/openwrt/openwrt/pull/11959).

```
Specifications:
* CPU: Qualcomm IPQ8072A, SoC Version: 2.0, Quad core Cortex-A53 1.6896 GHz
* RAM: 1 GiB of DDR4 600 MHz
* Flash: NAND 2x256 MiB (Macronix MX30UF2G18AC)
* 4 RGB LEDs: Power, LAN, 2.4GHz and 5GHz
* UART: Two 4-pin unpopulated headers under the LEDs.
  Use the header closest to LED 4 and 5.
  They are marked with a white stroke.
  TX RX GND, beginning from "4". 115200n8.

Lan:
* One 100/1000/2.5GBASE-T Gigabit Ethernet (QCA8081)

Wlan:
* 4x4 in 2.4GHz: 802.11b/g/n/ax
* 4x4 in 5.0GHz: 802.11a/n/ac/ax
* OFDM and OFDMA
* Bidir and MU-MIMO
* Internal antenna 3.1/4.3 dBi (2.4GHz/5GHz)

Power:
* PoE+ 802.3at/af 25.5W
* DC 12V 2.5A
```

## Installation: serial connection
```
Note: The OpenWrt image is setup with DHCP and not a static IP.
1.  Download the OpenWrt initramfs image. Copy the image to a TFTP server
2.  Connect to console on the AP, and connect the LAN port to your LAN
3.  Stop auto boot to get to U-boot shell, interrupt the autoboot process by pressing '0' when prompted
4.  Set active_fw in env
    # setenv active_fw 1
5.  Transfer the initramfs image with TFTP
    # setenv serverip 192.168.1.10 (IP of TFTP server host)
    # setenv ipaddr 192.168.1.1 (IP used by the router for getting the image, must be in the same subnet as the TFTP host)
    # tftpboot openwrt-qualcommax-ipq807x-netgear_wax620-initramfs-uImage.itb
6.  Reboot and load the image
    # bootm
7.  SCP factory image to the AP
    # scp openwrt-qualcommax-ipq807x-netgear_wax620-squashfs-factory.ubi root@192.168.1.1:/tmp/
8.  Connect to device using SSH (use the LAN port)
9.  Flash squashfs-factory.ubi from within the initramfs instance of OpenWRT
    Before you flash, please check your mtd partitions where mtdX is the right mtd rootfs partition.
    # cat /proc/mtd (To check MTD partitions)
    # ubiformat /dev/mtd19 -y -f /tmp/openwrt-qualcommax-ipq807x-netgear_wax620-squashfs-factory.ubi
10. Set active_fw to 0
    # /usr/sbin/fw_setenv active_fw 0
11. Reboot the AP and your done
    # reboot
```
Signed-off-by: Kristian Skramstad <kristian+github@83.no>