### PR TITLE
ramips: add support for COMFAST CF-EW72 V2

### DIFF
--- a/target/linux/ramips/dts/mt7621_comfast_cf-ew72-v2.dts
+++ b/target/linux/ramips/dts/mt7621_comfast_cf-ew72-v2.dts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "comfast,cf-ew72-v2", "mediatek,mt7621-soc";
+	model = "COMFAST CF-EW72 V2";
+	
+	// There are at least two HW variants of cf-ew72-v2: 
+	// With external RAM chip and with integrated RAM (RAM chip not soldered).
+	// Both act same.
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		// The only both visible and controllable indicator is wifi LED.
+		// CF-EW72 have 8 LEDs: 
+		//  "wlan" is the only LED is controllable with GPIO and have proper hole in shell.
+		//  "power", "wan" and "lan" LEDs have proper holes in shell, but can not be controlled with GPIO
+		//  "hidden_led_2" and "hidden_led_4" can be controlled with GPIO, but have no proper holes in shell
+		//     "hidden_led_2" is between POWER and WAN LEDs
+		//     "hidden_led_4" is between WAN and LAN LEDs
+		//  "noconn_led_6" and "noconn_led_8" exist, but have no proper holes in shell and not controlled:
+		//     "noconn_led_6" is between LAN and WLAN LEDs
+		//     "noconn_led_8" is after WLAN LED
+		
+		// LED "hidden_led_2" between POWER and WAN LEDs is controllable with GPIO, but it has no proper hole in shell;
+		// LED "hidden_led_4" between WAN and LAN LEDs is controllable with GPIO, but it has no proper hole in shell;
+
+		// TABLE of LEDs. All leds are blue.
+		//
+		// Place (WAN->ANT) | Num | GPIO | LED name (LuCI)   | Note
+		// -----------------|-----|-----------------------------------------------------------------------------------------         
+		//            power | 1   |      |                   | POWER LED. Not controlled with GPIO.
+		//     hidden_led_2 | 2   | 13   | blue:hidden_led_2 | This LED does not have proper hole in shell.
+		//              wan | 3   |      |                   | WAN LED. Not controlled with GPIO.
+		//     hidden_led_4 | 4   | 16   | blue:hidden_led_4 | This LED does not have proper hole in shell.
+		//              lan | 5   |      |                   | LAN LED. Not controlled with GPIO.
+		//     noconn_led_6 | 6   |      |                   | Not controlled with GPIO, possibly not connected
+		//             wlan | 7   | 15   | blue:wlan         | WLAN LED. Wireless indicator.
+		//     noconn_led_8 | 8   |      |                   | Not controlled with GPIO, possibly not connected
+
+		hidden_led_2_blue {
+			label = "blue:hidden_led_2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		hidden_led_4_blue {
+			label = "blue:hidden_led_4";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan_blue {
+			label = "blue:wlan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	aliases {
+		label-mac-device = &wan;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "w25q128";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,fast-read;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+			
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+			
+			factory: partition@40000  {
+				label = "factory";
+				compatible = "nvmem-cells";
+				reg = <0x40000 0x10000>;
+				read-only;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+					macaddr_factory_e000: macaddr@e000 {
+						compatible = "mac-base";
+						reg = <0xe000 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					// Serial number can be found in "factory" at 0xE100. 
+					//   it starts and ends with double quotes `"` and is ASCII string
+				};
+			};
+			
+			partition@50000  {
+				label = "firmware";
+				compatible = "denx,uimage";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&gpio {
+	groups = "i2c", "uart2", "uart3", "sdhci", "jtag";
+	function = "gpio";
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi_2_4_ghz: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		// Wi-Fi device reads it's MAC address from EEPROM (&factory + 4)
+		// adding anything related to mac-address here will cause use random MAC
+	};
+};
+
+&pcie1 {
+	wifi_5_0_ghz: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		// Wi-Fi device reads it's MAC address from EEPROM, (&factory + 0x8000 + 4)
+		// adding anything related to mac-address here will cause use random MAC.
+	};
+};
+
+&pcie2 {
+	status = "disabled";
+};
+
+&switch0 {
+	mediatek,mcm;
+	ports {
+		wan: port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e000 1>;
+			nvmem-cell-names = "mac-address";
+		};
+		
+		lan: port@1 {
+			status = "okay";
+			label = "lan";
+			nvmem-cells = <&macaddr_factory_e000 0>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -558,6 +558,21 @@ define Device/comfast_cf-e390ax
 endef
 TARGET_DEVICES += comfast_cf-e390ax
 
+define Device/comfast_cf-ew72-v2
+    $(Device/dsa-migration)
+    $(Device/uimage-lzma-loader)
+    IMAGE_SIZE := 15808k
+    DEVICE_VENDOR := ComFast
+    DEVICE_MODEL := CF-EW72 V2
+    DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
+        -uboot-envtools
+    IMAGES += factory.bin
+    IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
+        check-size | append-metadata
+    IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | check-size
+endef
+TARGET_DEVICES += comfast_cf-ew72-v2
+
 define Device/cudy_m1800
   $(Device/dsa-migration)
   DEVICE_VENDOR := Cudy

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -152,7 +152,8 @@ ramips_setup_interfaces()
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		ucidef_set_interface "qtn" ifname "eth1" protocol "static" ipaddr "1.1.1.1" netmask "255.255.255.0"
 		;;
-	comfast,cf-e390ax)
+	comfast,cf-e390ax|\
+	comfast,cf-ew72-v2)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
 	*)


### PR DESCRIPTION
Add support for COMFAST CF-EW72 V2

_(different device to CF-EW72 w\o version)_

<hr />

Started wiki page for this device [CF-EW72 V2](https://openwrt.org/inbox/toh/comfast/cf-ew72_v2), detailed infro moved here

<hr /> 
Bootlogs and firmware samples attached.

[openwrt.bootlog.txt](https://github.com/openwrt/openwrt/files/12403046/openwrt.bootlog.txt)
[original.bootlog.txt](https://github.com/openwrt/openwrt/files/12403047/original.bootlog.txt)

**🚫 Avoid using attached firmware files, this is for history only and outdated**

[~~openwrt-ramips-mt7621-comfast_cf-ew72-v2-initramfs-kernel.zip + LuCI~~](https://github.com/openwrt/openwrt/files/12403048/openwrt-ramips-mt7621-comfast_cf-ew72-v2-initramfs-kernel.zip)
[~~openwrt-ramips-mt7621-comfast_cf-ew72-v2-squashfs-factory.zip + LuCI~~](https://github.com/openwrt/openwrt/files/12403050/openwrt-ramips-mt7621-comfast_cf-ew72-v2-squashfs-factory.zip)
[~~openwrt-ramips-mt7621-comfast_cf-ew72-v2-squashfs-sysupgrade.zip + LuCI~~](https://github.com/openwrt/openwrt/files/12403051/openwrt-ramips-mt7621-comfast_cf-ew72-v2-squashfs-sysupgrade.zip)

<hr /> 

### Details (same as in commit message)

## Hardware:

-   SoC: Mediatek MT7621 (MT7621DAT or MT7621AT)
-   Flash: 16 MiB NOR
-   RAM: 128 MiB (for MT7621AT models, comes as separate chip; for MT7621DAT comes integrated into SoC)
-   Ethernet: Built-in, 2 x 1GbE
-   Power: only 802.3af PD on any port, injector supplied in the box
-   PoE passthrough: No
-   Wifi 2.4GHz: Mediatek MT7603BE 802.11b/g/b
-   Wifi 5GHz: Mediatek MT7613BEN 802.11ac/n/a
-   LEDs: 8x (only 1 is both visible and controllable, see below)
-   Buttons: 1x (RESET)

## Installing OpenWrt:
Flashing is done using Mediatek U-Boot System Recovery Mode

-   make wired connection with 2 cables like this:
-   -   `PC (LAN)` <-> `PoE Injector (LAN)`
-   -   `PoE Injector (POE)` <-> `CF-EW72 V2 (LAN)`. Leave unconnected to CF-EW72 V2 yet.
-   configure 192.168.1.(2-254)/24 static ip address on your PC LAN
-   press and keep pressed **RESET** button on device
-   power the device by plugging `PoE Injector (POE)` <-> `CF-EW72 V2 (LAN)` cable
-   wait for about 10 seconds until wifi led stops blinking and release **RESET** button
-   navigate from your PC to http://192.168.1.1 and upload OpenWrt *-factory.bin firmware file
-   proceed until router starts blinking with wifi led again (flashing) and stops (rebooting to OpenWrt)

## MAC addresses as verified by OEM firmware:
```
  vendor OpenWrt  address
  LAN    lan\eth0 label
  WAN    wan     label + 1
  2g     phy0    label + 2
  5g     phy1    label + 3

  The label MAC address was found in 0xe000.
```

## LEDs detailed:
  The only both visible and controllable indicator is blue:wlan LED.
  It is not bound by default to indicate activity of any wireless interfaces.

```
  Place (WAN->ANT) | Num | GPIO | LED name (LuCI)   | Note
  -----------------|-----|-----------------------------------------------------------------------------------------
             power | 1   |      |                   | POWER LED. Not controlled with GPIO.
      hidden_led_2 | 2   | 13   | blue:hidden_led_2 | This LED does not have proper hole in shell.
               wan | 3   |      |                   | WAN LED. Not controlled with GPIO.
      hidden_led_4 | 4   | 16   | blue:hidden_led_4 | This LED does not have proper hole in shell.
               lan | 5   |      |                   | LAN LED. Not controlled with GPIO.
      noconn_led_6 | 6   |      |                   | Not controlled with GPIO, possibly not connected
              wlan | 7   | 15   | blue:wlan         | WLAN LED. Wireless indicator.
      noconn_led_8 | 8   |      |                   | Not controlled with GPIO, possibly not connected
```

  mt76-phy0 and mt76-phy1 leds also exist in OpenWrt, but do not exist on board.