### PR TITLE
ipq40xx: add DSL support for 6.1 kernel

### DIFF
--- a/package/kernel/lantiq/ltq-ifxos/patches/100-compat.patch
+++ b/package/kernel/lantiq/ltq-ifxos/patches/100-compat.patch
@@ -90,3 +90,17 @@
     return ret;
  }
  
+--- a/src/linux/ifxos_linux_thread_drv.c
++++ b/src/linux/ifxos_linux_thread_drv.c
+@@ -154,7 +154,11 @@ IFXOS_STATIC int IFXOS_KernelThreadStart
+    retVal = pThrCntrl->pThrFct(&pThrCntrl->thrParams);
+    pThrCntrl->thrParams.bRunning = IFX_FALSE;
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0))
++   kthread_complete_and_exit(&pThrCntrl->thrCompletion, (long)retVal);
++#else
+    complete_and_exit(&pThrCntrl->thrCompletion, (long)retVal);
++#endif
+ 
+    IFXOS_PRN_USR_DBG_NL( IFXOS, IFXOS_PRN_LEVEL_NORMAL,
+       ("EXIT - Kernel Thread Startup <%s>" IFXOS_CRLF,

--- a/package/kernel/lantiq/ltq-vdsl-vr11-mei/patches/100-compat.patch
+++ b/package/kernel/lantiq/ltq-vdsl-vr11-mei/patches/100-compat.patch
@@ -8,3 +8,16 @@
  MODULE_LICENSE ("GPL");
  #endif /* #ifdef MODULE*/
  
+--- a/src/drv_mei_cpe_linux.h
++++ b/src/drv_mei_cpe_linux.h
+@@ -110,6 +110,10 @@ typedef irqreturn_t (*usedIsrHandler_t)(
+ #  endif
+ #endif
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0))
++#define PDE_DATA pde_data
++#endif
++
+ /**
+    Function typedef for the Linux request_threaded_irq()
+ */

--- a/package/kernel/lantiq/ltq-vdsl-vr11-mei/patches/122-cp_linux-fix-compilation-warning.patch
+++ b/package/kernel/lantiq/ltq-vdsl-vr11-mei/patches/122-cp_linux-fix-compilation-warning.patch
@@ -1,6 +1,6 @@
---- a/src/drv_mei_cpe_linux.c	
+--- a/src/drv_mei_cpe_linux.c
 +++ b/src/drv_mei_cpe_linux.c
-@@ -1267,7 +1267,9 @@ static long MEI_Ioctl( struct file *filp,
+@@ -1267,7 +1267,9 @@ static long MEI_Ioctl( struct file *filp
  MEI_IOCTL_RETURN:
  
     local_args.drv_ioctl.retCode = ret;

--- a/package/kernel/lantiq/vrx518_ep/patches/100-compat.patch
+++ b/package/kernel/lantiq/vrx518_ep/patches/100-compat.patch
@@ -42,6 +42,25 @@
  		dev_err(&pdev->dev,
  			"%s: Failed to enable MSI interrupts error code: %d\n",
  			__func__, err);
+@@ -589,15 +589,15 @@ static int dc_ep_probe(struct pci_dev *p
+ 	/* Target structures have a limit of 32 bit DMA pointers.
+ 	 * DMA pointers can be wider than 32 bits by default on some systems.
+ 	 */
+-	ret = pci_set_dma_mask(pdev, DMA_BIT_MASK(32));
++	ret = dma_set_mask(&pdev->dev, DMA_BIT_MASK(32));
+ 	if (ret) {
+ 		dev_err(&pdev->dev, "32-bit DMA not available: %d\n", ret);
+ 		goto err_region;
+ 	}
+ 
+-	ret = pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
++	ret = dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
+ 	if (ret) {
+-		dev_err(&pdev->dev, "cannot enable 32-bit consistent DMA\n");
++		dev_err(&pdev->dev, "cannot enable 32-bit coherent DMA\n");
+ 		goto err_region;
+ 	}
+ 
 @@ -654,7 +654,7 @@ static int dc_ep_probe(struct pci_dev *p
  		goto err_iomap;
  

--- a/package/kernel/lantiq/vrx518_tc/patches/100-compat.patch
+++ b/package/kernel/lantiq/vrx518_tc/patches/100-compat.patch
@@ -243,7 +243,33 @@
  
  #include "inc/tc_main.h"
  #include "inc/reg_addr.h"
-@@ -182,8 +182,8 @@ static int ptm_get_qid(struct net_device
+@@ -62,6 +62,9 @@
+ #include "inc/fw/vrx518_addr_def.h"
+ #include "inc/fw/vrx518_ppe_fw.h"
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0))
++#define PDE_DATA pde_data
++#endif
+ 
+ static struct ptm_priv *g_ptm_priv;
+ static struct ptm_ep_priv g_ep_priv[BOND_MAX];
+@@ -84,6 +87,7 @@ static int ptm_erb_addr_get(const unsign
+ 	unsigned int *data_addr, unsigned int *desc_addr);
+ 
+ 
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,16,0))
+ static inline void tc_ether_addr_copy(u8 *dst, const u8 *src)
+ {
+ #if defined(CONFIG_HAVE_EFFICIENT_UNALIGNED_ACCESS)
+@@ -98,6 +102,7 @@ static inline void tc_ether_addr_copy(u8
+ 	a[2] = b[2];
+ #endif
+ }
++#endif
+ 
+ static inline int is_ptm_sl(struct ptm_ep_priv *priv)
+ {
+@@ -182,8 +187,8 @@ static int ptm_get_qid(struct net_device
  	return qid;
  }
  
@@ -254,7 +280,7 @@
  {
  	struct ptm_priv *ptm_tc = netdev_priv(dev);
  
-@@ -191,8 +191,6 @@ static struct rtnl_link_stats64 *ptm_get
+@@ -191,8 +196,6 @@ static struct rtnl_link_stats64 *ptm_get
  		memcpy(storage, &ptm_tc->stats64, sizeof(ptm_tc->stats64));
  	else
  		storage->tx_errors += ptm_tc->stats64.tx_errors;
@@ -263,7 +289,16 @@
  }
  
  static int ptm_set_mac_address(struct net_device *dev, void *p)
-@@ -209,7 +207,7 @@ static int ptm_set_mac_address(struct ne
+@@ -204,12 +207,16 @@ static int ptm_set_mac_address(struct ne
+ 		return -EBUSY;
+ 
+ 	tc_info(ptm_tc->tc_priv, MSG_EVENT, "ptm mac address update!\n");
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0))
++	eth_hw_addr_set(dev, addr->sa_data);
++#else
+ 	tc_ether_addr_copy(dev->dev_addr, addr->sa_data);
++#endif
+ 
  	return 0;
  }
  
@@ -272,7 +307,7 @@
  {
  	struct ptm_priv *ptm_tc = netdev_priv(dev);
  
-@@ -503,7 +501,7 @@ static int ptm_xmit(struct sk_buff *skb,
+@@ -503,7 +510,7 @@ static int ptm_xmit(struct sk_buff *skb,
  	if (!showtime_stat(ptm_tc->tc_priv))
  		goto PTM_XMIT_DROP;
  
@@ -281,7 +316,7 @@
  		goto PTM_XMIT_DROP;
  
  	dump_skb_info(ptm_tc->tc_priv, skb, (MSG_TX | MSG_TXDATA));
-@@ -632,11 +630,8 @@ static int ptm_dev_init(struct tc_priv *
+@@ -632,11 +639,8 @@ static int ptm_dev_init(struct tc_priv *
  	struct ptm_priv *ptm_tc;
  	const char macaddr[ETH_ALEN]
  		= {0xAC, 0x9A, 0x96, 0x11, 0x22, 0x33};
@@ -295,7 +330,19 @@
  	if (!dev) {
  		tc_dbg(tc_priv, MSG_INIT, "Cannot alloc net device\n");
  		return -ENOMEM;
-@@ -2103,7 +2098,6 @@ static int ptm_showtime_exit(const unsig
+@@ -644,7 +648,11 @@ static int ptm_dev_init(struct tc_priv *
+ 	ptm_tc = netdev_priv(dev);
+ 	ptm_tc->dev = dev;
+ 	ptm_tc->tc_priv = tc_priv;
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,16,0))
++	eth_hw_addr_set(dev, macaddr);
++#else
+ 	tc_ether_addr_copy(dev->dev_addr, macaddr);
++#endif
+ 	spin_lock_init(&ptm_tc->ptm_lock);
+ 	memcpy(ptm_tc->outq_map, def_outq_map, sizeof(def_outq_map));
+ 	SET_NETDEV_DEV(ptm_tc->dev, tc_priv->ep_dev[id].dev);
+@@ -2103,7 +2111,6 @@ static int ptm_showtime_exit(const unsig
  	struct ptm_ep_priv *priv = tc_ep_priv(idx);
  	u32 stop = ACA_TXIN_EN;
  	struct dc_ep_dev *ep;
@@ -398,7 +445,18 @@
  #include <net/genetlink.h>
  #include <linux/time.h>
  #include "inc/tc_main.h"
-@@ -353,7 +355,7 @@ static ssize_t mem_proc_write(struct fil
+@@ -35,6 +37,10 @@
+ #include "inc/platform.h"
+ #include "inc/dsl_tc.h"
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0))
++#define PDE_DATA pde_data
++#endif
++
+ #define ATM_HEADER_SIZE (ATM_CELL_SIZE - ATM_CELL_PAYLOAD)
+ static char *dbg_flag_str[] = {
+ 	"rx",
+@@ -353,7 +359,7 @@ static ssize_t mem_proc_write(struct fil
  	}
  	addr = set_val = repeat_cnt = 0;
  
@@ -407,7 +465,7 @@
  		return -EFAULT;
  
  	len = count < sizeof(str) ? count : sizeof(str) - 1;
-@@ -450,13 +452,12 @@ static int proc_read_mem_seq_open(struct
+@@ -450,13 +456,12 @@ static int proc_read_mem_seq_open(struct
  	return single_open(file, proc_read_mem, NULL);
  }
  
@@ -427,7 +485,7 @@
  };
  
  static ssize_t pp32_proc_write(struct file *file, const char __user *buf,
-@@ -748,13 +749,12 @@ static int proc_read_pp32_seq_open(struc
+@@ -748,13 +753,12 @@ static int proc_read_pp32_seq_open(struc
  	return single_open(file, proc_read_pp32, PDE_DATA(inode));
  }
  
@@ -447,7 +505,7 @@
  };
  
  static int proc_read_tc_cfg(struct seq_file *seq, void *v)
-@@ -865,13 +865,12 @@ static int proc_read_tc_cfg_seq_open(str
+@@ -865,13 +869,12 @@ static int proc_read_tc_cfg_seq_open(str
  	return single_open(file, proc_read_tc_cfg, PDE_DATA(inode));
  }
  
@@ -467,7 +525,7 @@
  };
  
  static ssize_t proc_write_dbg(struct file *file, const char __user *buf,
-@@ -951,13 +950,12 @@ static int proc_read_dbg_seq_open(struct
+@@ -951,13 +954,12 @@ static int proc_read_dbg_seq_open(struct
  	return single_open(file, proc_read_dbg, PDE_DATA(inode));
  }
  
@@ -487,7 +545,7 @@
  };
  
  static ssize_t proc_write_tc_switch(struct file *file, const char __user *buf,
-@@ -1018,11 +1016,11 @@ proc_tc_switch_help:
+@@ -1018,11 +1020,11 @@ proc_tc_switch_help:
  	return count;
  }
  
@@ -503,7 +561,7 @@
  static ssize_t proc_write_show_time(struct file *file, const char __user *buf,
  			size_t count, loff_t *data)
  {
-@@ -1077,10 +1075,9 @@ proc_show_time_help:
+@@ -1077,10 +1079,9 @@ proc_show_time_help:
  	return count;
  }
  
@@ -517,7 +575,7 @@
  };
  
  static int proc_read_ver(struct seq_file *seq, void *v)
-@@ -1128,12 +1125,11 @@ static int proc_read_ver_seq_open(struct
+@@ -1128,12 +1129,11 @@ static int proc_read_ver_seq_open(struct
  	return single_open(file, proc_read_ver, PDE_DATA(inode));
  }
  
@@ -535,7 +593,7 @@
  };
  
  static int proc_read_soc(struct seq_file *seq, void *v)
-@@ -1142,20 +1138,18 @@ static int proc_read_soc(struct seq_file
+@@ -1142,20 +1142,18 @@ static int proc_read_soc(struct seq_file
  
  	tcpriv = (struct tc_priv *)seq->private;
  
@@ -564,7 +622,7 @@
  
  	return 0;
  }
-@@ -1165,15 +1159,13 @@ static int proc_read_soc_seq_open(struct
+@@ -1165,15 +1163,13 @@ static int proc_read_soc_seq_open(struct
  	return single_open(file, proc_read_soc, PDE_DATA(inode));
  }
  
@@ -585,7 +643,7 @@
  static struct tc_proc_list tc_procs[] = {
  	{TC_PROC_DIR,	0,	NULL,			1},
  	{"cfg",		0644, &tc_cfg_proc_fops,	0},
-@@ -1241,13 +1233,12 @@ static int proc_read_ptm_wanmib_seq_open
+@@ -1241,13 +1237,12 @@ static int proc_read_ptm_wanmib_seq_open
  	return single_open(file, proc_read_ptm_wanmib, PDE_DATA(inode));
  }
  
@@ -605,7 +663,7 @@
  };
  
  static int proc_ptm_read_cfg(struct seq_file *seq, void *v)
-@@ -1300,7 +1291,7 @@ static ssize_t ptm_cfg_proc_write(struct
+@@ -1300,7 +1295,7 @@ static ssize_t ptm_cfg_proc_write(struct
  		return -EINVAL;
  	}
  
@@ -614,7 +672,7 @@
  		return -EFAULT;
  
  	len = count < sizeof(str) ? count : sizeof(str) - 1;
-@@ -1343,13 +1334,12 @@ proc_ptm_cfg_help:
+@@ -1343,13 +1338,12 @@ proc_ptm_cfg_help:
  }
  
  
@@ -634,7 +692,7 @@
  };
  
  static ssize_t proc_ptm_write_prio(struct file *file, const char __user *buf,
-@@ -1455,13 +1445,12 @@ static int proc_ptm_read_prio_seq_open(s
+@@ -1455,13 +1449,12 @@ static int proc_ptm_read_prio_seq_open(s
  	return single_open(file, proc_ptm_read_prio, PDE_DATA(inode));
  }
  
@@ -654,7 +712,7 @@
  };
  
  static int proc_ptm_read_bond_seq_open(struct inode *inode, struct file *file)
-@@ -1469,12 +1458,11 @@ static int proc_ptm_read_bond_seq_open(s
+@@ -1469,12 +1462,11 @@ static int proc_ptm_read_bond_seq_open(s
  	return single_open(file, proc_ptm_read_bond, PDE_DATA(inode));
  }
  
@@ -672,7 +730,7 @@
  };
  
  static int proc_ptm_read_bondmib_seq_open(struct inode *inode,
-@@ -1483,13 +1471,12 @@ static int proc_ptm_read_bondmib_seq_ope
+@@ -1483,13 +1475,12 @@ static int proc_ptm_read_bondmib_seq_ope
  	return single_open(file, proc_ptm_read_bondmib, PDE_DATA(inode));
  }
  
@@ -692,7 +750,7 @@
  };
  
  struct fwdbg_t {
-@@ -1910,14 +1897,14 @@ static int proc_read_fwdbg_seq_open(stru
+@@ -1910,14 +1901,14 @@ static int proc_read_fwdbg_seq_open(stru
  {
  	return single_open(file, proc_read_fwdbg, NULL);
  }
@@ -714,7 +772,7 @@
  static struct tc_proc_list ptm_sl_procs[] = {
  	{TC_PROC_PTM_DIR, 0,	NULL,			1},
  	{"mem",		0644,	&mem_proc_fops,		0},
-@@ -2077,7 +2064,7 @@ static ssize_t atm_cfg_proc_write(struct
+@@ -2077,7 +2068,7 @@ static ssize_t atm_cfg_proc_write(struct
  
  	priv = (struct atm_priv *)PDE_DATA(file_inode(file));
  
@@ -723,7 +781,7 @@
  		return -EFAULT;
  
  	len = count < sizeof(str) ? count : sizeof(str) - 1;
-@@ -2119,13 +2106,12 @@ proc_atm_cfg_help:
+@@ -2119,13 +2110,12 @@ proc_atm_cfg_help:
  	return count;
  }
  
@@ -743,7 +801,7 @@
  };
  
  static ssize_t proc_write_atm_wanmib(struct file *file, const char __user *buf,
-@@ -2173,13 +2159,12 @@ static int proc_read_atm_wanmib_seq_open
+@@ -2173,13 +2163,12 @@ static int proc_read_atm_wanmib_seq_open
  
  
  
@@ -763,7 +821,7 @@
  };
  
  static int proc_read_htu_seq_open(struct inode *inode, struct file *file)
-@@ -2187,12 +2172,11 @@ static int proc_read_htu_seq_open(struct
+@@ -2187,12 +2176,11 @@ static int proc_read_htu_seq_open(struct
  	return single_open(file, proc_read_htu, PDE_DATA(inode));
  }
  
@@ -781,7 +839,7 @@
  };
  
  static int proc_read_queue_seq_open(struct inode *inode, struct file *file)
-@@ -2200,12 +2184,11 @@ static int proc_read_queue_seq_open(stru
+@@ -2200,12 +2188,11 @@ static int proc_read_queue_seq_open(stru
  	return single_open(file, proc_read_queue, PDE_DATA(inode));
  }
  
@@ -799,7 +857,7 @@
  };
  
  static void set_q_prio(struct atm_priv *priv,
-@@ -2428,13 +2411,12 @@ static const struct seq_operations pvc_m
+@@ -2428,13 +2415,12 @@ static const struct seq_operations pvc_m
  	.show = pvc_mib_seq_show,
  };
  
@@ -819,7 +877,7 @@
  };
  
  static int proc_read_pvc_mib_seq_open(struct inode *inode, struct file *file)
-@@ -2447,12 +2429,11 @@ static int proc_read_pvc_mib_seq_open(st
+@@ -2447,12 +2433,11 @@ static int proc_read_pvc_mib_seq_open(st
  	return ret;
  }
  
@@ -837,7 +895,7 @@
  };
  
  static ssize_t proc_write_cell(struct file *file,
-@@ -2592,13 +2573,12 @@ static int proc_read_cell_seq_open(struc
+@@ -2592,13 +2577,12 @@ static int proc_read_cell_seq_open(struc
  	return single_open(file, proc_read_cell, NULL);
  }
  

--- a/package/kernel/lantiq/vrx518_tc/patches/200-swplat.patch
+++ b/package/kernel/lantiq/vrx518_tc/patches/200-swplat.patch
@@ -79,7 +79,7 @@ This replaces it by a basic working implementation.
  		tc_dbg(priv->tc_priv, MSG_TX, "ATM: TX fail\n");
 --- a/dcdp/ptm_tc.c
 +++ b/dcdp/ptm_tc.c
-@@ -497,6 +497,7 @@ static int ptm_xmit(struct sk_buff *skb,
+@@ -506,6 +506,7 @@ static int ptm_xmit(struct sk_buff *skb,
  	struct ptm_priv *ptm_tc = netdev_priv(dev);
  	int qid;
  	enum tc_pkt_type type;
@@ -87,7 +87,7 @@ This replaces it by a basic working implementation.
  
  	if (!showtime_stat(ptm_tc->tc_priv))
  		goto PTM_XMIT_DROP;
-@@ -510,11 +511,13 @@ static int ptm_xmit(struct sk_buff *skb,
+@@ -519,11 +520,13 @@ static int ptm_xmit(struct sk_buff *skb,
  	type = ptm_tc->tc_priv->tc_mode == TC_PTM_BND_MODE
  		? PTM_BOND_PKT : PTM_SL_PKT;
  
@@ -102,7 +102,7 @@ This replaces it by a basic working implementation.
  	}
  
  	return 0;
-@@ -631,7 +634,7 @@ static int ptm_dev_init(struct tc_priv *
+@@ -640,7 +643,7 @@ static int ptm_dev_init(struct tc_priv *
  	const char macaddr[ETH_ALEN]
  		= {0xAC, 0x9A, 0x96, 0x11, 0x22, 0x33};
  
@@ -111,7 +111,7 @@ This replaces it by a basic working implementation.
  	if (!dev) {
  		tc_dbg(tc_priv, MSG_INIT, "Cannot alloc net device\n");
  		return -ENOMEM;
-@@ -2324,7 +2327,11 @@ static void ptm_aca_init(struct ptm_ep_p
+@@ -2337,7 +2340,11 @@ static void ptm_aca_init(struct ptm_ep_p
  	cfg = &priv->tc_priv->cfg;
  
  	txin = &param.aca_txin;
@@ -123,7 +123,7 @@ This replaces it by a basic working implementation.
  	txin->hd_size_in_dw = cfg->txin.soc_desc_dwsz;
  	txin->pd_desc_base = SB_XBAR_ADDR(__ACA_TX_IN_PD_LIST_BASE);
  	txin->pd_desc_num = __ACA_TX_IN_PD_LIST_NUM;
-@@ -2347,7 +2354,11 @@ static void ptm_aca_init(struct ptm_ep_p
+@@ -2360,7 +2367,11 @@ static void ptm_aca_init(struct ptm_ep_p
  		txin->soc_cmlt_cnt_addr);
  
  	txout = &param.aca_txout;
@@ -135,7 +135,7 @@ This replaces it by a basic working implementation.
  	txout->hd_size_in_dw = cfg->txout.soc_desc_dwsz;
  	if (priv->tc_priv->param.cdma_desc_loc == LOC_IN_FPI)
  		txout->pd_desc_base = sb_r32(__TX_OUT_SHADOW_PTR) - phybase;
-@@ -2373,7 +2384,11 @@ static void ptm_aca_init(struct ptm_ep_p
+@@ -2386,7 +2397,11 @@ static void ptm_aca_init(struct ptm_ep_p
  		txout->soc_cmlt_cnt_addr);
  
  	rxout = &param.aca_rxout;
@@ -147,7 +147,7 @@ This replaces it by a basic working implementation.
  	rxout->hd_size_in_dw = cfg->rxout.soc_desc_dwsz;
  	if (priv->tc_priv->param.cdma_desc_loc == LOC_IN_FPI)
  		rxout->pd_desc_base = sb_r32(__RX_OUT_SHADOW_PTR) - phybase;
-@@ -2399,7 +2414,11 @@ static void ptm_aca_init(struct ptm_ep_p
+@@ -2412,7 +2427,11 @@ static void ptm_aca_init(struct ptm_ep_p
  		rxout->soc_cmlt_cnt_addr);
  
  	rxin = &param.aca_rxin;

--- a/package/kernel/lantiq/vrx518_tc/patches/201-desc-length.patch
+++ b/package/kernel/lantiq/vrx518_tc/patches/201-desc-length.patch
@@ -54,7 +54,7 @@ significantly lower latencies when the line is saturated.
  struct cdma {
 --- a/dcdp/ptm_tc.c
 +++ b/dcdp/ptm_tc.c
-@@ -75,7 +75,11 @@ static const u32 tx_kvec[] = {
+@@ -78,7 +78,11 @@ static const u32 tx_kvec[] = {
  	0x30B1B233, 0xB43536B7, 0xB8393ABB, 0x3CBDBE3F,
  	0xC04142C3, 0x44C5C647, 0x48C9CA4B, 0xCC4D4ECF
  };
@@ -66,7 +66,7 @@ significantly lower latencies when the line is saturated.
  static const char ptm_drv_name[] = "PTM SL";
  static const char ptm_bond_name[][IFNAMSIZ] = {"PTM US BOND", "PTM DS BOND"};
  
-@@ -1005,6 +1009,10 @@ static void us_fp_desq_cfg_ctxt_init(str
+@@ -1018,6 +1022,10 @@ static void us_fp_desq_cfg_ctxt_init(str
  	int i;
  	u32 desc_addr;
  	rx_descriptor_t desc;
@@ -77,7 +77,7 @@ significantly lower latencies when the line is saturated.
  
  	memset(&desq_cfg, 0, sizeof(desq_cfg));
  	/* Initialize US Fast-Path Descriptor Queue Config/Context */
-@@ -1012,7 +1020,11 @@ static void us_fp_desq_cfg_ctxt_init(str
+@@ -1025,7 +1033,11 @@ static void us_fp_desq_cfg_ctxt_init(str
  	desq_cfg.fast_path	= 1;
  	desq_cfg.mbox_int_en	= 0;
  	desq_cfg.des_sync_needed = 0;
@@ -89,7 +89,7 @@ significantly lower latencies when the line is saturated.
  	desq_cfg.des_base_addr	= __US_FAST_PATH_DES_LIST_BASE;
  
  	tc_mem_write(priv, fpi_addr(__US_FP_INQ_DES_CFG_CTXT),
-@@ -1036,12 +1048,20 @@ static void us_qos_desq_cfg_ctxt_init(st
+@@ -1049,12 +1061,20 @@ static void us_qos_desq_cfg_ctxt_init(st
  	int offset, i;
  	rx_descriptor_t desc;
  	u32 phy_addr;
@@ -110,7 +110,7 @@ significantly lower latencies when the line is saturated.
  
  	offset = 0;
  	for (i = 0; i < QOSQ_NUM; i++) {
-@@ -1080,6 +1100,10 @@ static void us_outq_desq_cfg_ctxt_init(s
+@@ -1093,6 +1113,10 @@ static void us_outq_desq_cfg_ctxt_init(s
  	u32 phy_addr;
  	int i;
  	u32 offset;
@@ -121,7 +121,7 @@ significantly lower latencies when the line is saturated.
  
  	/* Setup OUTQ_QoS_CFG_CTXT */
  	/* NOTE: By default, Shaping & WFQ both are DISABLED!! */
-@@ -1108,7 +1132,11 @@ static void us_outq_desq_cfg_ctxt_init(s
+@@ -1121,7 +1145,11 @@ static void us_outq_desq_cfg_ctxt_init(s
  	desq_cfg.des_in_own_val	= US_OUTQ_DES_OWN;
  	desq_cfg.mbox_int_en	= 0;
  	desq_cfg.des_sync_needed = 0;
@@ -134,7 +134,7 @@ significantly lower latencies when the line is saturated.
  	/**
  	* Only BC0 is used in VRX518
  	*/
-@@ -1174,7 +1202,11 @@ static void us_qos_cfg_init(struct ptm_e
+@@ -1187,7 +1215,11 @@ static void us_qos_cfg_init(struct ptm_e
  	/* Set QoS NO DROP */
  	sb_w32(1, __QOSQ_NO_DROP);
  	/* Enable Preemption function/Disable QoS by default */
@@ -146,7 +146,7 @@ significantly lower latencies when the line is saturated.
  	/* By default, all qid mappint to non-preemption queue */
  	sb_w32(0x0, _QID2PREEMP_MAP);
  
-@@ -1376,6 +1408,11 @@ static void ptm_local_desq_cfg_ctxt_init
+@@ -1389,6 +1421,11 @@ static void ptm_local_desq_cfg_ctxt_init
  	u32 dcnt, addr, pdbram_base;
  	unsigned int us_des_alloc[] = {
  		__US_TC_LOCAL_Q0_DES_LIST_NUM, __US_TC_LOCAL_Q1_DES_LIST_NUM};
@@ -158,7 +158,7 @@ significantly lower latencies when the line is saturated.
  
  	/* Setup the Local DESQ Configuration/Context for UpStream Queues */
  	memset(&desq_cfg, 0, sizeof(desq_cfg));
-@@ -2321,6 +2358,10 @@ static void ptm_aca_init(struct ptm_ep_p
+@@ -2334,6 +2371,10 @@ static void ptm_aca_init(struct ptm_ep_p
  	u32 phybase = priv->ep->phy_membase;
  	u32 start;
  	u32 type;
@@ -169,7 +169,7 @@ significantly lower latencies when the line is saturated.
  
  	priv->tc_priv->tc_ops.soc_cfg_get(&priv->tc_priv->cfg, ptm_id(priv));
  	memset(&param, 0, sizeof(param));
-@@ -2334,7 +2375,11 @@ static void ptm_aca_init(struct ptm_ep_p
+@@ -2347,7 +2388,11 @@ static void ptm_aca_init(struct ptm_ep_p
  #endif
  	txin->hd_size_in_dw = cfg->txin.soc_desc_dwsz;
  	txin->pd_desc_base = SB_XBAR_ADDR(__ACA_TX_IN_PD_LIST_BASE);
@@ -198,7 +198,7 @@ significantly lower latencies when the line is saturated.
  
 --- a/dcdp/tc_proc.c
 +++ b/dcdp/tc_proc.c
-@@ -1114,6 +1114,9 @@ static int proc_read_ver(struct seq_file
+@@ -1118,6 +1118,9 @@ static int proc_read_ver(struct seq_file
  		(date >> 16) & 0xff,
  		(date & 0xffff));
  
@@ -208,7 +208,7 @@ significantly lower latencies when the line is saturated.
  #ifdef FEATURE_POWER_DOWN
  	seq_puts(seq, " + Support Power Down enhancement feature\n");
  #endif
-@@ -1166,6 +1169,113 @@ static const struct proc_ops tc_soc_proc
+@@ -1170,6 +1173,113 @@ static const struct proc_ops tc_soc_proc
  	.proc_release	= single_release,
  };
  
@@ -322,7 +322,7 @@ significantly lower latencies when the line is saturated.
  static struct tc_proc_list tc_procs[] = {
  	{TC_PROC_DIR,	0,	NULL,			1},
  	{"cfg",		0644, &tc_cfg_proc_fops,	0},
-@@ -1174,6 +1284,9 @@ static struct tc_proc_list tc_procs[] =
+@@ -1178,6 +1288,9 @@ static struct tc_proc_list tc_procs[] =
  	{"showtime",	0200, &tc_show_time_proc_fops,	0},
  	{"ver",		0644, &tc_ver_proc_fops,	0},
  	{"soc",		0644, &tc_soc_proc_fops,	0},
@@ -332,7 +332,7 @@ significantly lower latencies when the line is saturated.
  };
  
  int tc_proc_init(struct tc_priv *priv)
-@@ -1333,7 +1446,6 @@ proc_ptm_cfg_help:
+@@ -1337,7 +1450,6 @@ proc_ptm_cfg_help:
  	return count;
  }
  

--- a/package/kernel/lantiq/vrx518_tc/patches/202-napi.patch
+++ b/package/kernel/lantiq/vrx518_tc/patches/202-napi.patch
@@ -334,7 +334,7 @@
  	int (*umt_init)(u32 umt_id, u32 umt_period, u32 umt_dst);
 --- a/dcdp/ptm_tc.c
 +++ b/dcdp/ptm_tc.c
-@@ -141,7 +141,11 @@ static int ptm_open(struct net_device *d
+@@ -146,7 +146,11 @@ static int ptm_open(struct net_device *d
  	struct ptm_priv *ptm_tc = netdev_priv(dev);
  
  	tc_info(ptm_tc->tc_priv, MSG_EVENT, "ptm open\n");
@@ -346,7 +346,7 @@
  #ifdef CONFIG_SOC_TYPE_XWAY
  	xet_phy_wan_port(7, NULL, 1, 1);
  	if (ppa_hook_ppa_phys_port_add_fn)
-@@ -158,7 +162,11 @@ static int ptm_stop(struct net_device *d
+@@ -163,7 +167,11 @@ static int ptm_stop(struct net_device *d
  	struct ptm_priv *ptm_tc = netdev_priv(dev);
  
  	tc_info(ptm_tc->tc_priv, MSG_EVENT, "ptm stop\n");
@@ -358,7 +358,7 @@
  #ifdef CONFIG_SOC_TYPE_XWAY
      if (ppa_drv_datapath_mac_entry_setting)
          ppa_drv_datapath_mac_entry_setting(dev->dev_addr, 0, 6, 10, 1, 2);
-@@ -555,7 +563,7 @@ static void ptm_rx(struct net_device *de
+@@ -564,7 +572,7 @@ static void ptm_rx(struct net_device *de
  	ptm_tc->stats64.rx_packets++;
  	ptm_tc->stats64.rx_bytes += skb->len;
  
@@ -367,17 +367,22 @@
  		ptm_tc->stats64.rx_dropped++;
  
  	return;
-@@ -651,6 +659,9 @@ static int ptm_dev_init(struct tc_priv *
+@@ -664,6 +672,14 @@ static int ptm_dev_init(struct tc_priv *
  	memcpy(ptm_tc->outq_map, def_outq_map, sizeof(def_outq_map));
  	SET_NETDEV_DEV(ptm_tc->dev, tc_priv->ep_dev[id].dev);
  
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0))
++	netif_napi_add(ptm_tc->dev, &ptm_tc->napi_rx, tc_priv->tc_ops.napi_rx);
++	netif_napi_add_tx(ptm_tc->dev, &ptm_tc->napi_tx, tc_priv->tc_ops.napi_tx);
++#else
 +	netif_napi_add(ptm_tc->dev, &ptm_tc->napi_rx, tc_priv->tc_ops.napi_rx, NAPI_POLL_WEIGHT);
 +	netif_tx_napi_add(ptm_tc->dev, &ptm_tc->napi_tx, tc_priv->tc_ops.napi_tx, NAPI_POLL_WEIGHT);
 +
++#endif
  	err = register_netdev(ptm_tc->dev);
  	if (err)
  		goto err1;
-@@ -2605,7 +2616,9 @@ static int ptm_ring_init(struct ptm_ep_p
+@@ -2618,7 +2634,9 @@ static int ptm_ring_init(struct ptm_ep_p
  {
  	ptm_aca_ring_config_init(priv, id, bonding);
  	return priv->tc_priv->tc_ops.dev_reg(priv->ptm_tc->dev,
@@ -388,7 +393,7 @@
  }
  
  /**
-@@ -2960,7 +2973,9 @@ void ptm_tc_unload(enum dsl_tc_mode tc_m
+@@ -2973,7 +2991,9 @@ void ptm_tc_unload(enum dsl_tc_mode tc_m
  	/* unregister device */
  	if (ptm_tc->tc_priv->tc_ops.dev_unreg != NULL)
  		ptm_tc->tc_priv->tc_ops.dev_unreg(ptm_tc->dev,
@@ -399,7 +404,7 @@
  
  	/* remove PTM callback function */
  	ptm_cb_setup(ptm_tc, 0);
-@@ -2978,6 +2993,10 @@ void ptm_exit(void)
+@@ -2991,6 +3011,10 @@ void ptm_exit(void)
  
  	if (!priv)
  		return;

--- a/package/kernel/lantiq/vrx518_tc/patches/205-dcdp-ptm_tc-dynamically-alloc-mib.patch
+++ b/package/kernel/lantiq/vrx518_tc/patches/205-dcdp-ptm_tc-dynamically-alloc-mib.patch
@@ -1,6 +1,6 @@
 --- a/dcdp/ptm_tc.c
 +++ b/dcdp/ptm_tc.c
-@@ -298,15 +298,19 @@ static int ptm_tc_get_stats(struct ptm_e
+@@ -307,15 +307,19 @@ static int ptm_tc_get_stats(struct ptm_e
  )
  {
  	struct rtnl_link_stats64 *stat;
@@ -21,7 +21,7 @@
  	if (bonding)
  		stats->tc_info = TC_PTM_BND_MODE;
  	else
-@@ -340,11 +344,11 @@ static int ptm_tc_get_stats(struct ptm_e
+@@ -349,11 +353,11 @@ static int ptm_tc_get_stats(struct ptm_e
  		? cur_cnt - last_cnt
  		: cur_cnt + ((unsigned int)(-1) - last_cnt);
  
@@ -36,7 +36,7 @@
  
  	cur_cnt = tc_r32(GIF0_RX_CRC_ERR_CNT);
  	last_cnt = priv->ptm_mib.rx_crc_err_pdu[0];
-@@ -358,7 +362,7 @@ static int ptm_tc_get_stats(struct ptm_e
+@@ -367,7 +371,7 @@ static int ptm_tc_get_stats(struct ptm_e
  		? cur_cnt - last_cnt
  		: cur_cnt + ((unsigned int)(-1) - last_cnt);
  
@@ -45,7 +45,7 @@
  	cur_cnt = sb_r32(__US_TC_LOCAL_Q_CFG_CTXT_BASE +
  		offsetof(desq_cfg_ctxt_t, deq_pkt_cnt) / 4);
  	last_cnt = priv->ptm_mib.tx_total_pdu[0];
-@@ -376,90 +380,108 @@ static int ptm_tc_get_stats(struct ptm_e
+@@ -385,90 +389,108 @@ static int ptm_tc_get_stats(struct ptm_e
  	/* For bonding information */
  	if (bonding) {
  		int i;


### PR DESCRIPTION
This was only compile time tested in combination with #13294

I'm not sure if I get around to actually runtime test that soonish, does anyone have a spare fritzbox 75x0 to see if the DSL line is working on 6.1?