### PR TITLE
mediatek: define NMBM remapping range for GL-MT3000

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt3000.dts
@@ -156,6 +156,7 @@
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;
 		mediatek,bmt-max-reserved-blocks = <64>;
+		mediatek,bmt-remap-range = <0x0 0x5c0000>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
This limits remapping by the NMBM translation layer to non-UBI areas.

This is necessary for UBI to map physical blocks in order to perform wear levelling as well as bad-block management.

I've validated that the Device still boots with this change.