### PR TITLE
ath79: add mobile gateway variant of embedded wireless DORIN platform

### DIFF
--- a/target/linux/ath79/dts/ar9331_embeddedwireless_dorin-mobile-gw.dts
+++ b/target/linux/ath79/dts/ar9331_embeddedwireless_dorin-mobile-gw.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+ #include "ar9331_embeddedwireless_dorin.dts"
+
+ / {
+ 	model = "Embedded Wireless Mobile Gateway";
+ 	compatible = "embeddedwireless,dorin-mobile-gw", "qca,ar9331";
+ };
+
+ &wmac {
+ 	status = "disabled";
+ };
+ 

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -331,6 +331,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:wan" "2:lan:3" "3:lan:2"
 		;;
+	embeddedwireless,dorin-mobile-gw)
+ 		ucidef_add_switch "switch0" \
+ 			"0@eth0" "1:lan"
+ 		;;
 	engenius,eap300-v2)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan"

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1316,6 +1316,15 @@ define Device/embeddedwireless_dorin
 endef
 TARGET_DEVICES += embeddedwireless_dorin
 
+ define Device/embeddedwireless_dorin-mobile-gw
+   SOC := ar9331
+   DEVICE_VENDOR := Embedded Wireless
+   DEVICE_MODEL := Dorin Mobile GW
+   DEVICE_PACKAGES := kmod-usb-chipidea2
+   IMAGE_SIZE := 16000k
+ endef
+ TARGET_DEVICES += embeddedwireless_dorin-mobile-gw
+
 define Device/engenius_eap1200h
   $(Device/senao_loader_okli)
   SOC := qca9557


### PR DESCRIPTION
    main difference one LAN port only

    Signed-off-by: Reiner Rusnak <rr@embeddedwireless.de>
