### PR TITLE
mediatek: fix the name of buswidth to bus-width

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
@@ -138,8 +138,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <25000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt3000.dts
@@ -151,8 +151,8 @@
 		spi-cal-addrlen = <5>;
 		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
 
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;
 		mediatek,bmt-max-reserved-blocks = <64>;

--- a/target/linux/mediatek/dts/mt7981b-h3c-magic-nx30-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-h3c-magic-nx30-pro.dts
@@ -104,8 +104,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7981b-qihoo-360t7.dts
+++ b/target/linux/mediatek/dts/mt7981b-qihoo-360t7.dts
@@ -97,8 +97,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-wr30u.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-wr30u.dtsi
@@ -148,8 +148,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions: partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7981b-zyxel-nwa50ax-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-zyxel-nwa50ax-pro.dts
@@ -109,8 +109,8 @@
 		spi-cal-addrlen = <5>;
 		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
 
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;
 		mediatek,bmt-max-reserved-blocks = <64>;

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
@@ -211,8 +211,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <20000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions: partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
@@ -164,8 +164,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <20000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
@@ -138,8 +138,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <20000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions: partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
@@ -445,8 +445,8 @@
 		compatible = "spi-nand";
 		reg = <1>;
 		spi-max-frequency = <10000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5700-telenor.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5700-telenor.dts
@@ -316,8 +316,8 @@
 		mediatek,bmt-max-reserved-blocks = <64>;
 
 		spi-max-frequency = <20000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1.dts
+++ b/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1.dts
@@ -212,8 +212,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <20000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions: partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7986b-netgear-wax220.dts
+++ b/target/linux/mediatek/dts/mt7986b-netgear-wax220.dts
@@ -178,8 +178,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <20000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;

--- a/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3-nand.dtso
+++ b/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3-nand.dtso
@@ -19,8 +19,8 @@
 				compatible = "spi-nand";
 				reg = <0>;
 				spi-max-frequency = <10000000>;
-				spi-tx-buswidth = <4>;
-				spi-rx-buswidth = <4>;
+				spi-tx-bus-width = <4>;
+				spi-rx-bus-width = <4>;
 
 				partitions {
 					compatible = "fixed-partitions";

--- a/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nand.dts
+++ b/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nand.dts
@@ -15,8 +15,8 @@
 		compatible = "spi-nand";
 		reg = <1>;
 		spi-max-frequency = <10000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nor.dts
+++ b/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nor.dts
@@ -15,8 +15,8 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7988a-rfb-snfi-nand.dtso
+++ b/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7988a-rfb-snfi-nand.dtso
@@ -19,8 +19,8 @@
 				compatible = "spi-nand";
 				reg = <0>;
 				spi-max-frequency = <52000000>;
-				spi-tx-buswidth = <4>;
-				spi-rx-buswidth = <4>;
+				spi-tx-bus-width = <4>;
+				spi-rx-bus-width = <4>;
 				mediatek,nmbm;
 				mediatek,bmt-max-ratio = <1>;
 				mediatek,bmt-max-reserved-blocks = <64>;

--- a/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7988a-rfb-spim-nand.dtso
+++ b/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7988a-rfb-spim-nand.dtso
@@ -21,8 +21,8 @@
 				compatible = "spi-nand";
 				reg = <0>;
 				spi-max-frequency = <52000000>;
-				spi-tx-buswidth = <4>;
-				spi-rx-buswidth = <4>;
+				spi-tx-bus-width = <4>;
+				spi-rx-bus-width = <4>;
 				mediatek,nmbm;
 				mediatek,bmt-max-ratio = <1>;
 				mediatek,bmt-max-reserved-blocks = <64>;

--- a/target/linux/mediatek/files-6.1/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nand.dts
+++ b/target/linux/mediatek/files-6.1/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nand.dts
@@ -15,8 +15,8 @@
 		compatible = "spi-nand";
 		reg = <1>;
 		spi-max-frequency = <10000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/files-6.1/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nor.dts
+++ b/target/linux/mediatek/files-6.1/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nor.dts
@@ -15,8 +15,8 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/mediatek/files-6.1/arch/arm64/boot/dts/mediatek/mt7988a-rfb-snfi-nand.dtso
+++ b/target/linux/mediatek/files-6.1/arch/arm64/boot/dts/mediatek/mt7988a-rfb-snfi-nand.dtso
@@ -19,8 +19,8 @@
 				compatible = "spi-nand";
 				reg = <0>;
 				spi-max-frequency = <52000000>;
-				spi-tx-buswidth = <4>;
-				spi-rx-buswidth = <4>;
+				spi-tx-bus-width = <4>;
+				spi-rx-bus-width = <4>;
 				mediatek,nmbm;
 				mediatek,bmt-max-ratio = <1>;
 				mediatek,bmt-max-reserved-blocks = <64>;

--- a/target/linux/mediatek/files-6.1/arch/arm64/boot/dts/mediatek/mt7988a-rfb-spim-nand.dtso
+++ b/target/linux/mediatek/files-6.1/arch/arm64/boot/dts/mediatek/mt7988a-rfb-spim-nand.dtso
@@ -21,8 +21,8 @@
 				compatible = "spi-nand";
 				reg = <0>;
 				spi-max-frequency = <52000000>;
-				spi-tx-buswidth = <4>;
-				spi-rx-buswidth = <4>;
+				spi-tx-bus-width = <4>;
+				spi-rx-bus-width = <4>;
 				mediatek,nmbm;
 				mediatek,bmt-max-ratio = <1>;
 				mediatek,bmt-max-reserved-blocks = <64>;

--- a/target/linux/mediatek/patches-6.1/006-v6.2-arm64-dts-mt7986-add-spi-related-device-nodes.patch
+++ b/target/linux/mediatek/patches-6.1/006-v6.2-arm64-dts-mt7986-add-spi-related-device-nodes.patch
@@ -52,8 +52,8 @@ Signed-off-by: Matthias Brugger <matthias.bgg@gmail.com>
 +		compatible = "spi-nand";
 +		reg = <0>;
 +		spi-max-frequency = <10000000>;
-+		spi-tx-buswidth = <4>;
-+		spi-rx-buswidth = <4>;
++		spi-tx-bus-width = <4>;
++		spi-rx-bus-width = <4>;
 +	};
 +};
 +
@@ -140,8 +140,8 @@ Signed-off-by: Matthias Brugger <matthias.bgg@gmail.com>
 +		compatible = "spi-nand";
 +		reg = <0>;
 +		spi-max-frequency = <10000000>;
-+		spi-tx-buswidth = <4>;
-+		spi-rx-buswidth = <4>;
++		spi-tx-bus-width = <4>;
++		spi-rx-bus-width = <4>;
 +	};
 +};
 +

--- a/target/linux/mediatek/patches-6.1/010-v6.3-arm64-dts-mt7986-add-Bananapi-R3.patch
+++ b/target/linux/mediatek/patches-6.1/010-v6.3-arm64-dts-mt7986-add-Bananapi-R3.patch
@@ -103,8 +103,8 @@ Signed-off-by: Matthias Brugger <matthias.bgg@gmail.com>
 +				compatible = "spi-nand";
 +				reg = <0>;
 +				spi-max-frequency = <10000000>;
-+				spi-tx-buswidth = <4>;
-+				spi-rx-buswidth = <4>;
++				spi-tx-bus-width = <4>;
++				spi-rx-bus-width = <4>;
 +
 +				partitions {
 +					compatible = "fixed-partitions";


### PR DESCRIPTION
Fix the issue of dts buswidth cannot be applied properly with spi driver. Fix the name of buswidth to bus-width in dts in order to fit the format in linux spi kernel[1] so that spi-tx-bus-width & spi-rx-bus-width can be parsed properly.

[1] Documentation/devicetree/bindings/spi/spi-controller.yaml