### PR TITLE
kernel: net: mlx4: mark it broken

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1306,7 +1306,7 @@ $(eval $(call KernelPackage,be2net))
 define KernelPackage/mlx4-core
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Mellanox ConnectX(R) mlx4 core Network Driver
-  DEPENDS:=@PCI_SUPPORT +kmod-ptp
+  DEPENDS:=@PCI_SUPPORT +kmod-ptp @BROKEN
   FILES:= \
 	$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlx4/mlx4_core.ko \
 	$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlx4/mlx4_en.ko


### PR DESCRIPTION
mlx4 currently has link-related issues in openwrt, will be mark broken.
issues report: https://github.com/openwrt/openwrt/issues/13310

Signed-off-by: Tan Zien <nabsdh9@gmail.com>