### PR TITLE
mediatek: improve support for WSR-2533DHP2 and add support for WSR-3200AX4S

### DIFF
--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
@@ -2,6 +2,7 @@
 /dts-v1/;
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
 
 #include "mt7622.dtsi"
 #include "mt6380.dtsi"
@@ -29,43 +30,53 @@
 	leds {
 		compatible = "gpio-leds";
 
-		wireless_amber {
+		led-0 {
 			label = "amber:wireless";
 			gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN;
 		};
 
-		power_amber: power_amber {
+		power_amber: led-1 {
 			label = "amber:power";
 			gpios = <&pio 3 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_POWER;
 		};
 
-		power_green: power_green {
+		power_green: led-2 {
 			label = "green:power";
 			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
-			default-state = "on";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
 		};
 
-		wireless_green {
+		led-3 {
 			label = "green:wireless";
 			gpios = <&pio 15 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
 		};
 
-		internet {
+		led-4 {
 			label = "green:internet";
 			gpios = <&pio 19 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
 		};
 
-		router {
+		led-5 {
 			label = "green:router";
 			gpios = <&pio 20 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
 		};
 	};
 
 	keys {
 		compatible = "gpio-keys";
-		poll-interval = <100>;
 
-		reset {
+		key-reset {
 			label = "reset";
 			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
@@ -74,14 +85,14 @@
 		/* GPIO 1 and 16 are a tri-state switch button with
 		 * ROUTER / AP / WB.
 		 */
-		router {
+		key-router {
 			label = "router";
 			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 			linux,input-type = <EV_SW>;
 		};
 
-		bridge {
+		key-bridge {
 			label = "wb";
 			gpios = <&pio 16 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_1>;
@@ -89,14 +100,14 @@
 		};
 
 		/* GPIO 18 is a switch button with AUTO / MANUAL. */
-		manual {
+		key-manual {
 			label = "manual";
 			gpios = <&pio 18 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_2>;
 			linux,input-type = <EV_SW>;
 		};
 
-		wps {
+		key-wps {
 			label = "wps";
 			gpios = <&pio 102 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;

--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
@@ -17,6 +17,7 @@
 		led-failsafe = &power_amber;
 		led-running = &power_green;
 		led-upgrade = &power_green;
+		label-mac-device = &gmac0;
 	};
 
 	chosen {

--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
@@ -229,9 +229,8 @@
 
 		phy-connection-type = "2500base-x";
 
-		nvmem-cells = <&macaddr_factory_4>;
+		nvmem-cells = <&macaddr_factory_4 (-1)>;
 		nvmem-cell-names = "mac-address";
-		mac-address-increment = <(-1)>;
 
 		fixed-link {
 			speed = <2500>;
@@ -284,9 +283,22 @@
 			};
 
 			factory: partition@1c0000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x1c0000 0x40000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			partition@200000 {
@@ -348,14 +360,4 @@
 
 &rtc {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
@@ -1,118 +1,18 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/leds/common.h>
 
-#include "mt7622.dtsi"
-#include "mt6380.dtsi"
+#include "mt7622-buffalo-wsr.dtsi"
 
 / {
 	model = "Buffalo WSR-2533DHP2";
 	compatible = "buffalo,wsr-2533dhp2", "mediatek,mt7622";
 
 	aliases {
-		serial0 = &uart0;
-		led-boot = &power_green;
-		led-failsafe = &power_amber;
-		led-running = &power_green;
-		led-upgrade = &power_green;
 		label-mac-device = &gmac0;
-	};
-
-	chosen {
-		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8 swiotlb=512";
 	};
 
 	memory {
 		reg = <0 0x40000000 0 0x0F000000>;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led-0 {
-			label = "amber:wireless";
-			gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
-			color = <LED_COLOR_ID_AMBER>;
-			function = LED_FUNCTION_WLAN;
-		};
-
-		power_amber: led-1 {
-			label = "amber:power";
-			gpios = <&pio 3 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_AMBER>;
-			function = LED_FUNCTION_POWER;
-		};
-
-		power_green: led-2 {
-			label = "green:power";
-			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_POWER;
-		};
-
-		led-3 {
-			label = "green:wireless";
-			gpios = <&pio 15 GPIO_ACTIVE_HIGH>;
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_WLAN;
-		};
-
-		led-4 {
-			label = "green:internet";
-			gpios = <&pio 19 GPIO_ACTIVE_HIGH>;
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_WAN;
-		};
-
-		led-5 {
-			label = "green:router";
-			gpios = <&pio 20 GPIO_ACTIVE_HIGH>;
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_INDICATOR;
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		key-reset {
-			label = "reset";
-			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-
-		/* GPIO 1 and 16 are a tri-state switch button with
-		 * ROUTER / AP / WB.
-		 */
-		key-router {
-			label = "router";
-			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
-			linux,code = <BTN_0>;
-			linux,input-type = <EV_SW>;
-		};
-
-		key-bridge {
-			label = "wb";
-			gpios = <&pio 16 GPIO_ACTIVE_LOW>;
-			linux,code = <BTN_1>;
-			linux,input-type = <EV_SW>;
-		};
-
-		/* GPIO 18 is a switch button with AUTO / MANUAL. */
-		key-manual {
-			label = "manual";
-			gpios = <&pio 18 GPIO_ACTIVE_LOW>;
-			linux,code = <BTN_2>;
-			linux,input-type = <EV_SW>;
-		};
-
-		key-wps {
-			label = "wps";
-			gpios = <&pio 102 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WPS_BUTTON>;
-		};
 	};
 
 	rtkgsw: rtkgsw@0 {
@@ -123,41 +23,7 @@
 	};
 };
 
-&cpu0 {
-	proc-supply = <&mt6380_vcpu_reg>;
-	sram-supply = <&mt6380_vm_reg>;
-};
-
-&cpu1 {
-	proc-supply = <&mt6380_vcpu_reg>;
-	sram-supply = <&mt6380_vm_reg>;
-};
-
-&pcie0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pcie0_pins>;
-	status = "okay";
-};
-
-&slot0 {
-	status = "okay";
-
-	wifi@0,0 {
-		compatible = "mediatek,mt76";
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x5000>;
-		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
 &pio {
-	eth_pins: eth-pins {
-		mux {
-			function = "eth";
-			groups = "mdc_mdio", "rgmii_via_gmac2";
-		};
-	};
-
 	/* Parallel nand is shared pin with eMMC */
 	parallel_nand_pins: parallel-nand-pins {
 		mux {
@@ -176,67 +42,11 @@
 			bias-pull-up;
 		};
 	};
-
-	pcie0_pins: pcie0-pins {
-		mux {
-			function = "pcie";
-			groups = "pcie0_pad_perst",
-				 "pcie0_1_waken",
-				 "pcie0_1_clkreq";
-		};
-	};
-
-	pmic_bus_pins: pmic-bus-pins {
-		mux {
-			function = "pmic";
-			groups = "pmic_bus";
-		};
-	};
-
-	uart0_pins: uart0-pins {
-		mux {
-			function = "uart";
-			groups = "uart0_0_tx_rx" ;
-		};
-	};
-
-	watchdog_pins: watchdog-pins {
-		mux {
-			function = "watchdog";
-			groups = "watchdog";
-		};
-	};
 };
 
-&bch {
-	status = "okay";
-};
-
-&eth {
-	pinctrl-names = "default";
-	pinctrl-0 = <&eth_pins>;
-	status = "okay";
-
-	gmac0: mac@0 {
-		compatible = "mediatek,eth-mac";
-		reg = <0>;
-
-		phy-connection-type = "2500base-x";
-
-		nvmem-cells = <&macaddr_factory_4 (-1)>;
-		nvmem-cell-names = "mac-address";
-
-		fixed-link {
-			speed = <2500>;
-			full-duplex;
-			pause;
-		};
-	};
-
-	mdio: mdio-bus {
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4 (-1)>;
+	nvmem-cell-names = "mac-address";
 };
 
 &nandc {
@@ -320,36 +130,4 @@
 			};
 		};
 	};
-};
-
-&pwm {
-	status = "okay";
-};
-
-&pwrap {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pmic_bus_pins>;
-	status = "okay";
-};
-
-&uart0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&uart0_pins>;
-	status = "okay";
-};
-
-&watchdog {
-	pinctrl-names = "default";
-	pinctrl-0 = <&watchdog_pins>;
-	status = "okay";
-};
-
-&wmac {
-	status = "okay";
-
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&rtc {
-	status = "disabled";
 };

--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
@@ -193,13 +193,6 @@
 		};
 	};
 
-	pwm7_pins: pwm1-2-pins {
-		mux {
-			function = "pwm";
-			groups = "pwm_ch7_2";
-		};
-	};
-
 	uart0_pins: uart0-pins {
 		mux {
 			function = "uart";
@@ -330,8 +323,6 @@
 };
 
 &pwm {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pwm7_pins>;
 	status = "okay";
 };
 

--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr-3200ax4s.dts
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr-3200ax4s.dts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7622-buffalo-wsr.dtsi"
+
+/ {
+	model = "Buffalo WSR-3200AX4S";
+	compatible = "buffalo,wsr-3200ax4s", "mediatek,mt7622";
+
+	memory {
+		reg = <0 0x40000000 0 0x1f000000>;
+	};
+};
+
+&pio {
+	/* Serial NAND is shared pin with SPI-NOR */
+	serial_nand_pins: serial-nand-pins {
+		mux {
+			function = "flash";
+			groups = "snfi";
+		};
+
+		conf-cmd-dat {
+			pins = "SPI_WP", "SPI_HOLD", "SPI_MOSI",
+			       "SPI_MISO", "SPI_CS";
+			input-enable;
+			drive-strength = <16>;
+			bias-pull-up;
+		};
+
+		conf-clk {
+			pins = "SPI_CLK";
+			drive-strength = <16>;
+			bias-pull-down;
+		};
+	};
+};
+
+&mdio {
+	switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <0x1f>;
+		reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan4";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan3";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan1";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "wan";
+			};
+
+			port@6 {
+				reg = <6>;
+				label = "cpu";
+				ethernet = <&gmac0>;
+				phy-connection-type = "2500base-x";
+
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
+				};
+			};
+		};
+	};
+};
+
+&snfi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&serial_nand_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <104000000>;
+		nand-ecc-engine = <&snfi>;
+		mediatek,bmt-v2;
+		mediatek,bmt-table-size = <0x1000>;
+		/*
+		 * - Preloader - (kernel (6MiB, in firmware))
+		 * - Kernel2 - WTB
+		 */
+		mediatek,bmt-remap-range = <0x0 0x8c0000>,
+					   <0x1ac0000 0x5200000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Preloader";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "ATF";
+				reg = <0x80000 0x40000>;
+				read-only;
+			};
+
+			partition@c0000 {
+				label = "u-boot";
+				reg = <0xc0000 0x80000>;
+				read-only;
+			};
+
+			partition@140000 {
+				label = "u-boot-env";
+				reg = <0x140000 0x80000>;
+				read-only;
+			};
+
+			factory: partition@1c0000 {
+				label = "factory";
+				reg = <0x1c0000 0x100000>;
+				read-only;
+			};
+
+			partition@2c0000 {
+				compatible = "brcm,trx";
+				brcm,trx-magic = <0x33504844>;
+				label = "firmware";
+				reg = <0x2c0000 0x1800000>;
+			};
+
+			partition@1ac0000 {
+				label = "Kernel2";
+				reg = <0x1ac0000 0x1800000>;
+			};
+
+			partition@32c0000 {
+				label = "glbcfg";
+				reg = <0x32c0000 0x200000>;
+				read-only;
+			};
+
+			partition@34c0000 {
+				label = "board_data";
+				reg = <0x34c0000 0x200000>;
+				read-only;
+			};
+
+			partition@36c0000 {
+				label = "WTB";
+				reg = <0x36c0000 0x3600000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr.dtsi
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr.dtsi
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7622.dtsi"
+#include "mt6380.dtsi"
+
+/ {
+	aliases {
+		serial0 = &uart0;
+		led-boot = &power_green;
+		led-failsafe = &power_amber;
+		led-running = &power_green;
+		led-upgrade = &power_green;
+	};
+
+	chosen {
+		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8 swiotlb=512";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			label = "amber:wireless";
+			gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN;
+		};
+
+		power_amber: led-1 {
+			label = "amber:power";
+			gpios = <&pio 3 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		power_green: led-2 {
+			label = "green:power";
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		led-3 {
+			label = "green:wireless";
+			gpios = <&pio 15 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+		};
+
+		led-4 {
+			label = "green:internet";
+			gpios = <&pio 19 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+		};
+
+		led-5 {
+			label = "green:router";
+			gpios = <&pio 20 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		key-reset {
+			label = "reset";
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		/* GPIO 1 and 16 are a tri-state switch button with
+		 * ROUTER / AP / WB.
+		 */
+		key-router {
+			label = "router";
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		key-bridge {
+			label = "wb";
+			gpios = <&pio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
+		};
+
+		/* GPIO 18 is a switch button with AUTO / MANUAL. */
+		key-manual {
+			label = "manual";
+			gpios = <&pio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_2>;
+			linux,input-type = <EV_SW>;
+		};
+
+		key-wps {
+			label = "wps";
+			gpios = <&pio 102 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&cpu0 {
+	proc-supply = <&mt6380_vcpu_reg>;
+	sram-supply = <&mt6380_vm_reg>;
+};
+
+&cpu1 {
+	proc-supply = <&mt6380_vcpu_reg>;
+	sram-supply = <&mt6380_vm_reg>;
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+	status = "okay";
+};
+
+&slot0 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x5000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pio {
+	eth_pins: eth-pins {
+		mux {
+			function = "eth";
+			groups = "mdc_mdio", "rgmii_via_gmac2";
+		};
+	};
+
+	pcie0_pins: pcie0-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie0_pad_perst",
+				 "pcie0_1_waken",
+				 "pcie0_1_clkreq";
+		};
+	};
+
+	pmic_bus_pins: pmic-bus-pins {
+		mux {
+			function = "pmic";
+			groups = "pmic_bus";
+		};
+	};
+
+	uart0_pins: uart0-pins {
+		mux {
+			function = "uart";
+			groups = "uart0_0_tx_rx" ;
+		};
+	};
+
+	watchdog_pins: watchdog-pins {
+		mux {
+			function = "watchdog";
+			groups = "watchdog";
+		};
+	};
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_pins>;
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+
+		phy-connection-type = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+};
+
+&bch {
+	status = "okay";
+};
+
+&pwm {
+	status = "okay";
+};
+
+&pwrap {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pmic_bus_pins>;
+	status = "okay";
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+	status = "okay";
+};
+
+&watchdog {
+	pinctrl-names = "default";
+	pinctrl-0 = <&watchdog_pins>;
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};
+
+&rtc {
+	status = "disabled";
+};

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -6,19 +6,24 @@ define Image/Prepare
 	echo -ne '\xde\xad\xc0\xde' > $(KDIR)/ubi_mark
 endef
 
-define Build/buffalo-kernel-trx
+define Build/buffalo-trx
 	$(eval magic=$(word 1,$(1)))
-	$(eval dummy=$(word 2,$(1)))
+	$(eval kern_bin=$(if $(1),$(IMAGE_KERNEL),$@))
+	$(eval rtfs_bin=$(word 2,$(1)))
+	$(eval apnd_bin=$(word 3,$(1)))
 	$(eval kern_size=$(if $(KERNEL_SIZE),$(KERNEL_SIZE),0x400000))
 
-	$(if $(dummy),touch $(dummy))
+	$(if $(rtfs_bin),touch $(rtfs_bin))
 	$(STAGING_DIR_HOST)/bin/otrx create $@.new \
 		$(if $(magic),-M $(magic),) \
-		-f $@ \
-		$(if $(dummy),\
+		-f $(kern_bin) \
+		$(if $(rtfs_bin),\
 			-a 0x20000 \
 			-b $$(( $(subst k, * 1024,$(kern_size)) )) \
-			-f $(dummy),)
+			-f $(rtfs_bin),) \
+		$(if $(apnd_bin),\
+			-A $(apnd_bin) \
+			-a 0x20000)
 	mv $@.new $@
 endef
 
@@ -49,19 +54,6 @@ define Build/mt7622-gpt
 		)
 	cat $@.tmp >> $@
 	rm $@.tmp
-endef
-
-define Build/trx-nand
-	# kernel: always use 4 MiB (-28 B or TRX header) to allow upgrades even
-	#	  if it grows up between releases
-	# root: UBI with one extra block containing UBI mark to trigger erasing
-	#	rest of partition
-	$(STAGING_DIR_HOST)/bin/otrx create $@.new \
-		-M 0x32504844 \
-		-f $(IMAGE_KERNEL) -a 0x20000 -b 0x400000 \
-		-f $@ \
-		-A $(KDIR)/ubi_mark -a 0x20000
-	mv $@.new $@
 endef
 
 define Device/bananapi_bpi-r64
@@ -120,13 +112,15 @@ define Device/buffalo_wsr-2533dhp2
   IMAGES += factory.bin factory-uboot.bin
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
-	buffalo-kernel-trx
-  IMAGE/factory.bin := append-ubi | trx-nand | \
+	buffalo-trx
+  IMAGE/factory.bin := append-ubi | \
+	buffalo-trx 0x32504844 $$$$@ $(KDIR)/ubi_mark | \
 	buffalo-enc WSR-2533DHP2 $$(BUFFALO_TAG_VERSION) -l | \
 	buffalo-tag-dhp WSR-2533DHP2 JP JP | buffalo-enc-tag -l | buffalo-dhp-image
-  IMAGE/factory-uboot.bin := append-ubi | trx-nand
-  IMAGE/sysupgrade.bin := append-kernel | \
-	buffalo-kernel-trx 0x32504844 $(KDIR)/tmp/$$(DEVICE_NAME).null | \
+  IMAGE/factory-uboot.bin := append-ubi | \
+	buffalo-trx 0x32504844 $$$$@ $(KDIR)/ubi_mark
+  IMAGE/sysupgrade.bin := \
+	buffalo-trx 0x32504844 $(KDIR)/tmp/$$(DEVICE_NAME).null | \
 	sysupgrade-tar kernel=$$$$@ | append-metadata
   DEVICE_PACKAGES := kmod-mt7615-firmware swconfig
 endef

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -1,5 +1,7 @@
 DTS_DIR := $(DTS_DIR)/mediatek
 
+DEVICE_VARS += BUFFALO_TRX_MAGIC
+
 define Image/Prepare
 	# For UBI we want only one extra block
 	rm -f $(KDIR)/ubi_mark
@@ -95,33 +97,38 @@ define Device/bananapi_bpi-r64
 endef
 TARGET_DEVICES += bananapi_bpi-r64
 
-define Device/buffalo_wsr-2533dhp2
+define Device/buffalo_wsr
   DEVICE_VENDOR := Buffalo
-  DEVICE_MODEL := WSR-2533DHP2
-  DEVICE_DTS := mt7622-buffalo-wsr-2533dhp2
   DEVICE_DTS_DIR := ../dts
-  IMAGE_SIZE := 59392k
   KERNEL_SIZE := 6144k
   BLOCKSIZE := 128k
   PAGESIZE := 2048
-  SUBPAGESIZE := 512
   UBINIZE_OPTS := -E 5
   BUFFALO_TAG_PLATFORM := MTK
   BUFFALO_TAG_VERSION := 9.99
   BUFFALO_TAG_MINOR := 9.99
   IMAGES += factory.bin factory-uboot.bin
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
+  KERNEL_INITRAMFS = kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
 	buffalo-trx
-  IMAGE/factory.bin := append-ubi | \
-	buffalo-trx 0x32504844 $$$$@ $(KDIR)/ubi_mark | \
-	buffalo-enc WSR-2533DHP2 $$(BUFFALO_TAG_VERSION) -l | \
-	buffalo-tag-dhp WSR-2533DHP2 JP JP | buffalo-enc-tag -l | buffalo-dhp-image
+  IMAGE/factory.bin = append-ubi | \
+	buffalo-trx $$$$(BUFFALO_TRX_MAGIC) $$$$@ $(KDIR)/ubi_mark | \
+	buffalo-enc $$(DEVICE_MODEL) $$(BUFFALO_TAG_VERSION) -l | \
+	buffalo-tag-dhp $$(DEVICE_MODEL) JP JP | buffalo-enc-tag -l | buffalo-dhp-image
   IMAGE/factory-uboot.bin := append-ubi | \
-	buffalo-trx 0x32504844 $$$$@ $(KDIR)/ubi_mark
+	buffalo-trx $$$$(BUFFALO_TRX_MAGIC) $$$$@ $(KDIR)/ubi_mark
   IMAGE/sysupgrade.bin := \
-	buffalo-trx 0x32504844 $(KDIR)/tmp/$$(DEVICE_NAME).null | \
+	buffalo-trx $$$$(BUFFALO_TRX_MAGIC) $(KDIR)/tmp/$$(DEVICE_NAME).null | \
 	sysupgrade-tar kernel=$$$$@ | append-metadata
+endef
+
+define Device/buffalo_wsr-2533dhp2
+  $(Device/buffalo_wsr)
+  DEVICE_MODEL := WSR-2533DHP2
+  DEVICE_DTS := mt7622-buffalo-wsr-2533dhp2
+  IMAGE_SIZE := 59392k
+  SUBPAGESIZE := 512
+  BUFFALO_TRX_MAGIC := 0x32504844
   DEVICE_PACKAGES := kmod-mt7615-firmware swconfig
   DEVICE_COMPAT_VERSION := 1.1
   DEVICE_COMPAT_MESSAGE := Partition table has been changed due to kernel size restrictions. \
@@ -129,6 +136,16 @@ define Device/buffalo_wsr-2533dhp2
 	(Warning: your configurations will be erased!)
 endef
 TARGET_DEVICES += buffalo_wsr-2533dhp2
+
+define Device/buffalo_wsr-3200ax4s
+  $(Device/buffalo_wsr)
+  DEVICE_MODEL := WSR-3200AX4S
+  DEVICE_DTS := mt7622-buffalo-wsr-3200ax4s
+  IMAGE_SIZE := 24576k
+  BUFFALO_TRX_MAGIC := 0x33504844
+  DEVICE_PACKAGES := kmod-mt7915-firmware
+endef
+TARGET_DEVICES += buffalo_wsr-3200ax4s
 
 define Device/elecom_wrc-2533gent
   DEVICE_VENDOR := Elecom

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -101,7 +101,7 @@ define Device/buffalo_wsr-2533dhp2
   DEVICE_DTS := mt7622-buffalo-wsr-2533dhp2
   DEVICE_DTS_DIR := ../dts
   IMAGE_SIZE := 59392k
-  KERNEL_SIZE := 4096k
+  KERNEL_SIZE := 6144k
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   SUBPAGESIZE := 512
@@ -123,6 +123,10 @@ define Device/buffalo_wsr-2533dhp2
 	buffalo-trx 0x32504844 $(KDIR)/tmp/$$(DEVICE_NAME).null | \
 	sysupgrade-tar kernel=$$$$@ | append-metadata
   DEVICE_PACKAGES := kmod-mt7615-firmware swconfig
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := Partition table has been changed due to kernel size restrictions. \
+	Please upgrade via sysupgrade with factory-uboot.bin image and '-F' option. \
+	(Warning: your configurations will be erased!)
 endef
 TARGET_DEVICES += buffalo_wsr-2533dhp2
 

--- a/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
@@ -9,6 +9,7 @@ mediatek_setup_interfaces()
 
 	case $board in
 	bananapi,bpi-r64|\
+	buffalo,wsr-3200ax4s|\
 	elecom,wrc-x3200gst3|\
 	linksys,e8450|\
 	linksys,e8450-ubi|\
@@ -55,6 +56,11 @@ mediatek_setup_macs()
 	local label_mac=""
 
 	case $board in
+	buffalo,wsr-3200ax4s)
+		lan_mac=$(mtd_get_mac_ascii board_data "mac")
+		wan_mac=$lan_mac
+		label_mac=$lan_mac
+		;;
 	reyee,ax3200-e5|\
 	ruijie,rg-ew3200gx-pro)
 		lan_mac=$(macaddr_add $(get_mac_label) 1)

--- a/target/linux/mediatek/mt7622/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/mt7622/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -13,6 +13,11 @@ case "$board" in
 	bananapi,bpi-r64)
 		[ "$PHYNBR" = "0" ] && macaddr_add $(cat /sys/class/net/eth0/address) 2 > /sys${DEVPATH}/macaddress
 		;;
+	buffalo,wsr-3200ax4s)
+		basemac=$(mtd_get_mac_ascii board_data "mac")
+		[ "$PHYNBR" = "0" ] && macaddr_add $basemac 1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $basemac 8 > /sys${DEVPATH}/macaddress
+		;;
 	reyee,ax3200-e5|\
 	ruijie,rg-ew3200gx-pro)
 		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label) 3 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/mt7622/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/mediatek/mt7622/base-files/etc/uci-defaults/05_fix-compat-version
@@ -1,7 +1,8 @@
 . /lib/functions.sh
 
 case "$(board_name)" in
-	bananapi,bpi-r64)
+	bananapi,bpi-r64|\
+	buffalo,wsr-2533dhp2)
 	uci set system.@system[0].compat_version="1.1"
 	uci commit system
 	;;

--- a/target/linux/mediatek/mt7622/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/mediatek/mt7622/base-files/etc/uci-defaults/09_fix_crc
@@ -7,4 +7,8 @@ buffalo,wsr-2533dhp2)
 	mtd -M 0x44485032 ${kernel_size:+-c 0x$kernel_size} fixtrx firmware && exit 0
 	exit 1
 	;;
+buffalo,wsr-3200ax4s)
+	mtd -M 0x44485033 ${kernel_size:+-c 0x$kernel_size} fixtrx firmware && exit 0
+	exit 1
+	;;
 esac

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
@@ -21,7 +21,8 @@ platform_do_upgrade() {
 			;;
 		esac
 		;;
-	buffalo,wsr-2533dhp2)
+	buffalo,wsr-2533dhp2|\
+	buffalo,wsr-3200ax4s)
 		local magic="$(get_magic_long "$1")"
 
 		# use "mtd write" if the magic is "DHP2 (0x44485032)"
@@ -67,7 +68,8 @@ platform_check_image() {
 	[ "$#" -gt 1 ] && return 1
 
 	case "$board" in
-	buffalo,wsr-2533dhp2)
+	buffalo,wsr-2533dhp2|\
+	buffalo,wsr-3200ax4s)
 		buffalo_check_image "$board" "$magic" "$1" || return 1
 		;;
 	elecom,wrc-x3200gst3|\


### PR DESCRIPTION
This PR improves support for Buffalo WSR-2533DHP2 and adds support for Buffalo WSR-3200AX4S.