### PR TITLE
mediatek: fix sysupgrade error for WR30U

### DIFF
--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -93,7 +93,6 @@ platform_do_upgrade() {
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088|\
-	xiaomi,mi-router-wr30u-112m-nmbm|\
 	xiaomi,mi-router-wr30u-ubootmod|\
 	xiaomi,redmi-router-ax6000-ubootmod)
 		CI_KERNPART="fit"


### PR DESCRIPTION
The NMBM-Enabled layout did not use fit image,
it just need default process. So it was been removed in platform.sh.

It will fix sysupgrade error for xiaomi,mi-router-wr30u-112m-nmbm.
