### PR TITLE
ipq40xx: add support for Extreme Networks WS-AP391x series APs

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -74,6 +74,9 @@ ipq40xx_setup_interfaces()
 	devolo,magic-2-wifi-next)
 		ucidef_set_interface_lan "lan1 lan2 ghn"
 		;;
+	extreme-networks,ws-ap391x)
+		ucidef_set_interfaces_lan_wan "sw-eth1 sw-eth2 sw-eth3 sw-eth5" "sw-eth4"
+		;;
 	linksys,whw01)
 		ucidef_set_interface_lan "eth1 eth2"
 		;;

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -94,7 +94,8 @@ case "$FIRMWARE" in
 		caldata_extract "ART" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) 2)
 		;;
-	extreme-networks,ws-ap3915i)
+	extreme-networks,ws-ap3915i |\
+	extreme-networks,ws-ap391x)
 		caldata_extract "ART" 0x1000 0x2f20
 		ath10k_patch_mac $(mtd_get_mac_ascii CFG1 RADIOADDR0)
 		;;
@@ -189,7 +190,8 @@ case "$FIRMWARE" in
 		caldata_extract "ART" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) 3)
 		;;
-	extreme-networks,ws-ap3915i)
+	extreme-networks,ws-ap3915i |\
+	extreme-networks,ws-ap391x)
 		caldata_extract "ART" 0x5000 0x2f20
 		ath10k_patch_mac $(mtd_get_mac_ascii CFG1 RADIOADDR1)
 		;;

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -20,7 +20,8 @@ preinit_set_mac_address() {
 		base_mac=$(cat /sys/class/net/eth0/address)
 		ip link set dev eth1 address $(macaddr_add "$base_mac" 1)
 		;;
-	extreme-networks,ws-ap3915i)
+	extreme-networks,ws-ap3915i|\
+	extreme-networks,ws-ap391x)
 		ip link set dev eth0 address $(mtd_get_mac_ascii CFG1 ethaddr)
 		;;
 	linksys,ea8300|\

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4029-ws-ap391x.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4029-ws-ap391x.dts
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "Extreme Networks WS-AP391x";
+	compatible = "extreme-networks,ws-ap391x";
+
+	aliases {
+		led-boot = &led_system_green;
+		led-failsafe = &led_system_red;
+		led-running = &led_system_green;
+		led-upgrade = &led_system_red;
+	};
+
+	soc {
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system_green: system_green {
+			label = "system:green";
+			gpios = <&tlmm 49 GPIO_ACTIVE_LOW>;
+		};
+
+		/*
+		 * system:amber ==> AP3917
+		 * system:red ==> AP3916
+		 * */
+		led_system_red: system_red {
+			label = "system:red_or_system:amber";
+			gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wlan24_green: wlan24_green {
+			label = "wlan24:green";
+			gpios = <&tlmm 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		/*
+		 * wlan24:amber ==> AP3915/AP3917
+		 * pse:green ==> AP3912
+		 * */
+		led_wlan24_amber: wlan24_amber {
+			label = "wlan24:amber_or_pse:green";
+			gpios = <&tlmm 32 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wlan5_green: wlan5_green {
+			label = "wlan5:green";
+			gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		/* iot:blue ==>  AP3917 */
+		led_iot_green: iot_green {
+			label = "iot:green_or_iot:blue";
+			gpios = <&tlmm 10 GPIO_ACTIVE_LOW>;
+		};
+
+		/* eth:green ==> only AP3912/AP3916 */
+		led_eth_green: eth_green {
+			label = "eth:green";
+			gpios = <&tlmm 41 GPIO_ACTIVE_LOW>;
+		};
+
+		/*
+		 * eth:amber ==> only AP3912/AP3916
+		 * usb_enable ==> only AP3915e
+		 */
+		led_eth_amber: eth_amber {
+			label = "eth:amber_or_usb_enable";
+			gpios = <&tlmm 52 GPIO_ACTIVE_LOW>;
+		};
+
+		/*
+		 * wlan5:amber ==> AP3915/AP3917
+		 * cam:green ==> only AP3916
+		 */
+		led_wlan5_amber: wlan5_amber {
+			label = "wlan5:amber_or_cam:green";
+			gpios = <&tlmm 26 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART >;
+		};
+	};
+};
+
+&prng {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport1 {
+	status = "okay";
+	label = "sw-eth1";
+};
+
+&swport2 {
+	status = "okay";
+	label = "sw-eth2";
+};
+
+&swport3 {
+	status = "okay";
+	label = "sw-eth3";
+};
+
+/* "GE2" on AP3917/AP3916/WiNG-AP7662 */
+&swport4 {
+	status = "okay";
+	label = "sw-eth4";
+};
+
+/*
+ * "GE1" on AP3917/AP3916/AP3915/AP7662
+ * "LAN1" on EXTR-AP3912
+ */
+&swport5 {
+	status = "okay";
+	label = "sw-eth5";
+};
+
+&tlmm {
+	mdio_pins: mdio_pinmux {
+		mux_1 {
+			pins = "gpio6";
+			function = "mdio";
+			bias-pull-up;
+		};
+		mux_2 {
+			pins = "gpio7";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		pin {
+			function = "blsp_spi0";
+			pins = "gpio13", "gpio14", "gpio15";
+			drive-strength = <12>;
+			bias-disable;
+		};
+		pin_cs {
+			function = "gpio";
+			pins = "gpio12";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+
+	serial_pins: serial_0_pinmux {
+		mux {
+			pins = "gpio16", "gpio17";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+};
+
+&wifi0 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "Extreme-Networks-WS-AP3915i";
+};
+
+&wifi1 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "Extreme-Networks-WS-AP3915i";
+};
+
+&blsp1_spi1 {
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	cs-gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <24000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* Layout for 0x0 - 0xe0000 unknown */
+
+			partition@e0000 {
+				label = "CFG1";
+				compatible = "u-boot,env-redundant-bool";
+				reg = <0xe0000 0x10000>;
+				read-only;
+			};
+
+			partition@f0000 {
+				label = "BootBAK";
+				reg = <0xf0000 0x70000>;
+				read-only;
+			};
+
+			partition@160000 {
+				label = "WINGCFG1";
+				reg = <0x160000 0x10000>;
+				read-only;
+			};
+
+			partition@170000 {
+				label = "ART";
+				reg = <0x170000 0x10000>;
+				read-only;
+			};
+
+			partition@180000 {
+				label = "BootPRI";
+				reg = <0x180000 0x70000>;
+				read-only;
+			};
+
+			partition@1f0000 {
+				label = "WINGCFG2";
+				reg = <0x1f0000 0x10000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "FS";
+				reg = <0x200000 0x80000>;
+				read-only;
+			};
+
+			partition@280000 {
+				label = "firmware";
+				reg = <0x280000 0xeb0000>;
+			};
+
+			partition@1130000 {
+				label = "firmware2";
+				reg = <0x1130000 0xeb0000>;
+			};
+
+			partition@1fe0000 {
+				label = "CFG2";
+				compatible = "u-boot,env-redundant-bool";
+				reg = <0x1fe0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -538,6 +538,16 @@ define Device/extreme-networks_ws-ap3915i
 endef
 TARGET_DEVICES += extreme-networks_ws-ap3915i
 
+define Device/extreme-networks_ws-ap391x
+	$(call Device/FitImage)
+	DEVICE_VENDOR := Extreme Networks
+	DEVICE_MODEL := WS-AP391x
+	IMAGE_SIZE := 15040k
+	SOC := qcom-ipq4029
+	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | check-size | append-metadata
+endef
+TARGET_DEVICES += extreme-networks_ws-ap391x
+
 define Device/ezviz_cs-w3-wd1200g-eup
 	$(call Device/FitImage)
 	DEVICE_VENDOR := EZVIZ


### PR DESCRIPTION
This in a single image to run many types of hardware in the AP391x
series (AP3912/AP3915/AP3916/AP3917/AP7662).

Hardware
--------
Qualcomm IPQ4029 WiSoC
2T2R 802.11 abgn
2T2R 802.11 nac
Macronix MX25L25635E SPI-NOR (32M)
512M DDR3 RAM
1-4x Gigabit Ethernet
Senao EXT1025 HD Camera (AP3916 only)
USB 2.0 Port (AP3915e only)

1x Cisco RJ-45 Console port
  - except for AP3916 and AP3912 where there is no external serial
    console and it is TDB how to solder one. Possibly J12 is UART with
    pin1 = 3.3V, pin2 = GND, pin3 = TXD, pin4 = RXD.
  - Settings: 115200 8N1

Installation With Serial Console
--------------------------------

1. Attach to the Console port. Power up the device and press the s key
   to interrupt autoboot.

2. The default username / password to the bootloader is admin / new2day

3. Check uboot variables using printenv, and update if necessary:

   $ setenv AP_MODE 0
   $ setenv WATCHDOG_COUNT 0
   $ setenv WATCHDOG_LIMIT 0
   $ setenv AP_PERSONALITY identifi
   $ setenv serverip <SERVER_IPADDR>
   $ setenv ipaddr <UNIQUE_IPADDR>
   $ setenv MOSTRECENTKERNEL 0; ## OpenWRT only uses the primary image
   $ saveenv
   $ saveenv ## 2nd time to write the secondary copy

4. On the TFTP server located at <SERVER_IPADDR>, download the OpenWrt
   initramfs image. Rename and serve it as vmlinux.gz.uImage.3912

5. TFTP boot the OpenWrt initramfs image from the AP serial console:

   $ run boot_net

6. Wait for OpenWrt to start. Internet port sw-eth5 is assiged to LAN
   bridge and sw-eth4 (if available) is assigned to WAN.  The LAN port
   will use default IP address 192.168.1.1 and run a DHCP server.

   If you already have a working DHCP server or already have 192.168.1.1
   on your network you MUST DISCONNECT the LAN cable from your active
   network immediately after the power/status LED turns green!

   At this point, you need to temporarily reconfigure the AP to have
   a way to transfer the OpenWRT sysupgrade image to it.

   Reconfigure the newly converted OpenWRT AP using serial console or
   plug in a PC to a sw-eth5 as a separate network. Note -- the LAN/WAN
   port assignments were designed to make it possible to convert to
   OpenWRT without serial console and using a common firmware
   image for many AP models -- they may not make the most sense when
   fully deployed.

7. Download and transfer the sysupgrade image to the device using e.g.
   SCP.

8. Install OpenWrt to the device using "sysupgrade"

   $ sysupgrade -n /path/to/openwrt.bin

9. After it boots up again, as in step 6, connect to AP and reconfigure
   for final deployment.

This build supports APs in the AP391x series and similar such as WiNG
AP7662.

Ethernet devices within OpenWRT are named "sw-eth1" thru "sw-eth5".
Mapping from OpenWRT internal naming to external naming on the case is
as follows:

```
            |sw-eth1|sw-eth2|sw-eth3|sw-eth4|sw-eth5
------------+-------+-------+-------+-------+-------
AP3917      |       |       |       |  GE2  |  GE1
------------+-------+-------+-------+-------+-------
AP7662      |       |       |       |  GE2  |  GE1
------------+-------+-------+-------+-------+-------
AP3916      |       |       |       |  CAM* |  GE1
------------+-------+-------+-------+-------+-------
AP3915      |       |       |       |       |  GE1
------------+-------+-------+-------+-------+-------
AP3912      |       |  P1   |  P2   |  P3   | LAN1
------------+-------+-------+-------+-------+-------
```

By default sw-eth4 is mapped to WAN. All others are assigned to the
LAN.

CAM* - On AP3916, sw-eth4 is the camera's interface.  You should
reconfigure this to be on LAN after OpenWRT boots from flash.

Installation Without Serial Console
-----------------------------------

The main premise is to set u-boot environment variables using the
Extreme Networks firmware's rdwr_boot_cfg program.

$ rdwr_boot_cfg

Utility to manipulate the boot ROM config blocks
All errors are written to the sytem log file (/tmp/log/ap.log)

```
Usage: rdwr_boot_cfg <read_all|read_var|read_var_f|write_var|rm_var> ...
   read_all             read the entire active block
   read_var <var>       read a single variable from the active block
   read_var_f <var>     read a single variable from the active block
(formatted)
   write_var <var=val>  write a single variable/value pair to both
blocks
   rm_var <var>         delete a single variable from both blocks
```

WARNING: Be very sure you have set the u-boot environment correctly.
If not, it can only be fixed by attaching serial console!

Be aware that the Extreme Networks shell environment will automatically
reboot every 5 minutes if there is no controller present.

Read and understand these steps fully before attempting.  It is easy
to make mistakes!

1. Place the OpenWRT initramfs on the TFTP server and name it as
   vmlinux.gz.uImage.3912

2. Boot up to Extreme Networks WING-Campus mode OS.  Port GE1/LAN1
   will be a DHCP **client**.  Find out the IP address from your DHCP
   server and SSH in.  Default user/passwd is admin/new2day or
   admin/admin123.

   If it is booting to WING-Distributed mode, use this command to
   convert to Campus mode.

   $ operational-mode centralized

3. Upon bootup you have about 5mins to changed these u-boot variables
   if necessary using the rdwr_boot_cfg command in Linux shell:

   $ rdwr_boot_cfg write_var AP_MODE=0
   $ rdwr_boot_cfg write_var MOSTRECENTKERNEL=0
   $ rdwr_boot_cfg write_var WATCHDOG_COUNT=0
   $ rdwr_boot_cfg write_var WATCHDOG_LIMIT=0
   $ rdwr_boot_cfg write_var AP_PERSONALITY=identifi
   $ rdwr_boot_cfg write_var serverip=<SERVER_IPADDR>
   $ rdwr_boot_cfg write_var ipaddr=<UNIQUE_IPADDR>
   $ rdwr_boot_cfg write_var bootcmd="run boot_net"

4. Reboot AP.

5. Connect PC with ethernet to GE1/LAN1 port.  You should get a
   DHCP address in the 192.168.1.x range and should be able to
   SSH to the new OpenWRT TFTP recovery/installation shell.

6. At this point, u-boot is still set to TFTP boot, so you have to
   replace the TFTP image with the original Extreme Networks image so
   that you can change the u-boot environment.

   See the instructions for Extracting Extreme Networks firmware
   image.

   DON'T REBOOT YET!

7. Next you must follow steps 6 thru 8 from the Installation with serial
   console.  After which you should have OpenWRT installed to primary
   flash firmware.

8. Now Reboot.  This time it will boot using TFTP into Extreme Networks
   image.  You may need to reconnect cables at this point -- GE1/LAN1
   will be a DHCP **client** and you can SSH in -- just like step 2.
   Get the IP address from you own DHCP server.

9. Set u-boot env as follows:

   $ rdwr_boot_cfg write_var MOSTRECENTKERNEL=0
   $ rdwr_boot_cfg write_var WATCHDOG_COUNT=0
   $ rdwr_boot_cfg write_var bootcmd="run boot_flash"

10. Reboot AP.  This time it should be into OpenWRT.  GE1/LAN1 will be
   a DHCP **server** and have static IP 192.168.1.1 -- just like step 5.

11. SSH into the LAN port and reconfigure to final configuration. Don't
   make any changes that prevent you from SSH or Luci access!

Restoring Extreme Networks firmware
-----------------------------------

Assuming you have the original Extreme Networks image:

1. Login to OpenWRT shell

2. scp the Extreme Networks packaged firmware image file AP391x-*.img to
   /tmp

3. Extract the firmware uimage file:

   $ tar xjf AP391x-*.img vmlinux.gz.uImage

4. Force run sysupgrade:

   $ sysupgrade -F /tmp/AP391x-*.img /

5. Restore the u-boot varable(s):

   $ rdwr_boot_cfg write_var WATCHDOG_LIMIT=3

USB 2.0 Port on AP3915e
-----------------------
Enable this by setting LED "eth:amber_or_usb_enable" to ALWAYS ON.