### PR TITLE
ath79: fix packetloss on some WLR-7100

### DIFF
--- a/target/linux/ath79/dts/ar1022_sitecom_wlr-7100.dts
+++ b/target/linux/ath79/dts/ar1022_sitecom_wlr-7100.dts
@@ -65,6 +65,8 @@
 	gmac-config {
 		device = <&gmac>;
 		rgmii-gmac0 = <1>;
+		rxdv-delay = <3>;
+		rxd-delay = <3>;
 	};
 };
 


### PR DESCRIPTION
On some WLR-7100 routers, significant packet loss was observed. This is fixed by configuring a delay on the GMAC0 RXD and RXDV lines.

The values used in this commit are copied from the values used by the stock firmare (based on register dumping).

Out of four test routers, the problem was consistently observed on two. It is unclear what the relevant difference is exactly (the two working routers were v1 001 with AR1022 and v1 002 with AR9342, the two broken routers were both v1 002 with AR1022). All PCB routing also seems identical, so maybe there is some stray capacitance on some of these that adds just enough delay or so...

With this change, the packet loss disappears on the broken routers, without introducing new packet loss on the previously working routers.

Note that the PHY *also* has delays enabled (through `qca,ar8327-initvals`) on both RX and TX lines, but apparently that is not enough, or it is not effective (registers have been verified to be written).

For detailed discussion of this issue and debug history, see https://forum.openwrt.org/t/sitecom-wlr-7100-development-progress/79641
