### PR TITLE
Convert devolo Magic 2 WiFi next to dsa

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -69,6 +69,9 @@ ipq40xx_setup_interfaces()
 	compex,wpj428)
 		ucidef_set_interface_lan "lan1 lan2"
 		;;
+	devolo,magic-2-wifi-next)
+		ucidef_set_interface_lan "lan1 lan2 ghn"
+		;;
 	linksys,whw01)
 		ucidef_set_interface_lan "eth1 eth2"
 		;;

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-magic-2-wifi-next.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-magic-2-wifi-next.dts
@@ -231,3 +231,26 @@
 		};
 	};
 };
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport5 {
+	status = "okay";
+	label = "lan1";
+};
+
+&swport3 {
+	status = "okay";
+	label = "lan2";
+};
+
+&swport4 {
+	status = "okay";
+	label = "ghn";
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -371,7 +371,7 @@ endef
 TARGET_DEVICES += compex_wpj428
 
 define Device/devolo_magic-2-wifi-next
-	$(call Device/FitImage)
+	$(call Device/FitzImage)
 	DEVICE_VENDOR := devolo
 	DEVICE_MODEL := Magic 2 WiFi next
 	SOC := qcom-ipq4018
@@ -387,7 +387,6 @@ define Device/devolo_magic-2-wifi-next
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
 	DEFAULT := n
 endef
-# Missing DSA Setup
 TARGET_DEVICES += devolo_magic-2-wifi-next
 
 define Device/dlink_dap-2610

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -388,7 +388,7 @@ define Device/devolo_magic-2-wifi-next
 	DEFAULT := n
 endef
 # Missing DSA Setup
-#TARGET_DEVICES += devolo_magic-2-wifi-next
+TARGET_DEVICES += devolo_magic-2-wifi-next
 
 define Device/dlink_dap-2610
 	$(call Device/FitImageLzma)


### PR DESCRIPTION
Converts the devolo Magic 2 WiFi next to DSA and re-adds the product. The interface names match those of the other devices. The interface `ghn` connects to the built-in G.hn chip. This interface might toggle at runtime while the G.hn chip is in the bootloader leading to the following output: 

```
Sun Jun  4 09:02:19 2023 daemon.notice netifd: Network device 'ghn' link is down
Sun Jun  4 09:02:20 2023 kern.info kernel: [84032.716199] qca8k-ipq4019 c000000.switch ghn: Link is Up - 1Gbps/Full - flow control rx/tx
Sun Jun  4 09:02:20 2023 kern.info kernel: [84032.716868] br-lan: port 3(ghn) entered blocking state
Sun Jun  4 09:02:20 2023 kern.info kernel: [84032.724199] br-lan: port 3(ghn) entered forwarding state 
```

As the kernel grew, the kernel exceeded the limit of 4 MiB that is specified by the device loading 4 MiB statically from the flash. This makes the compression of the kernel necessary.