### PR TITLE
mediatek: add support for YunCore AX835

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-yuncore-ax835.dts
+++ b/target/linux/mediatek/dts/mt7981b-yuncore-ax835.dts
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include "mt7981.dtsi"
+
+/ {
+	compatible = "yuncore,ax835", "mediatek,mt7981";
+	model = "YunCore AX835";
+
+	aliases {
+		ethernet0 = &gmac0;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	reg_led_vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "led_vbus";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+		gpio = <&pio 5 GPIO_ACTIVE_HIGH>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: led_system {
+			label = "red:system";
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wifi24 {
+			label = "green:wifi2";
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_wifi5 {
+			label = "blue:wifi5";
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led_hwwatchdog {
+			// a gpio-wdt watchdog couldn't be made to work.
+			// the device rebooted after 5 minutes.
+			label = "hwwatchdog";
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "timer";
+			led-pattern = <1000>, <1000>;
+		};
+
+		// there's another "syswatchdog" on gpio2
+	};
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+
+	spi2_flash_pins: spi2-pins {
+		mux {
+			function = "spi";
+			groups = "spi2", "spi2_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <8>;
+			bias-pull-up = <103>;
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <8>;
+			bias-pull-down = <103>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "disabled";
+};
+
+&spi2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi2_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@00000 {
+				label = "BL2";
+				reg = <0x00000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@50000 {
+				label = "Factory";
+				reg = <0x50000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory: eeprom@0 {
+					reg = <0x0 0x1000>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_24: macaddr@24 {
+					reg = <0x24 0x6>;
+				};
+
+				macaddr_factory_2a: macaddr@2a {
+					reg = <0x2a 0x6>;
+				};
+			};
+
+			partition@100000 {
+				label = "FIP";
+				reg = <0x100000 0x80000>;
+				read-only;
+			};
+
+			partition@180000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0x180000 0xe00000>;
+			};
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		lan: port@3 {
+			reg = <3>;
+			label = "lan";
+
+			nvmem-cell-names = "mac-address";
+			nvmem-cells = <&macaddr_factory_2a 0>;
+		};
+
+		port@4 {
+			reg = <4>;
+			label = "wan";
+
+			nvmem-cell-names = "mac-address";
+			nvmem-cells = <&macaddr_factory_2a 0>;
+		};
+
+		port@6 {
+			reg = <6>;
+			label = "cpu";
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory 0>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -66,7 +66,8 @@ mediatek_setup_interfaces()
 		ucidef_set_interface_lan "eth0"
 		;;
 	smartrg,sdg-8622|\
-	smartrg,sdg-8632)
+	smartrg,sdg-8632|\
+	yuncore,ax835)
 		ucidef_set_interfaces_lan_wan lan wan
 		;;
 	tplink,tl-xdr6086)
@@ -169,6 +170,9 @@ mediatek_setup_macs()
 	xiaomi,redmi-router-ax6000-ubootmod)
 		wan_mac=$(mtd_get_mac_ascii Bdata ethaddr_wan)
 		label_mac=$wan_mac
+		;;
+	yuncore,ax835)
+		label_mac=$(mtd_get_mac_binary "Factory" 0x4)
 		;;
 	esac
 

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -111,7 +111,8 @@ platform_do_upgrade() {
 			;;
 		esac
 		;;
-	cudy,wr3000-v1)
+	cudy,wr3000-v1|\
+	yuncore,ax835)
 		default_do_upgrade "$1"
 		;;
 	glinet,gl-mt2500|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -880,6 +880,25 @@ endif
 endef
 TARGET_DEVICES += xiaomi_redmi-router-ax6000-ubootmod
 
+define Device/yuncore_ax835
+  DEVICE_VENDOR := YunCore
+  DEVICE_MODEL := AX835
+  DEVICE_DTS := mt7981b-yuncore-ax835
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x47000000
+  IMAGES := sysupgrade.bin
+  IMAGE_SIZE := 14336k
+  SUPPORTED_DEVICES += mediatek,mt7981-spim-nor-rfb
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | check-size | append-metadata
+  DEVICE_PACKAGES := kmod-mt7981-firmware mt7981-wo-firmware
+endef
+TARGET_DEVICES += yuncore_ax835
+
+
 define Device/zbtlink_zbt-z8102ax
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-Z8102AX


### PR DESCRIPTION
[stock dmesg](https://github.com/openwrt/openwrt/files/12495923/dmesg.log)

The sections in this message are the points which remain unclear.
There are corresponding `TODO`s in the dts file.

# Watchdog

For the moment, the external IC watchdog is triggered using the LED subsystem.
This works but isn't very nice.

A spreadsheet from the manufacturer mentions two watchdog-related GPIOs:

- hwwatchdog:  gpio7 active_low (JTAG_JTCLK). This was exposed as a LED.
  "to feed external watchdog IC"
- syswatchdog: gpio2 (no more info than that, image works without touching it)

This doesn't work for some reason:
```
	watchdog {
		compatible = "linux,wdt-gpio";
		gpios = <&pio 7 GPIO_ACTIVE_LOW>;
		hw_algo = "toggle";
		hw_margin_ms = <1000>;
		always-running;
	};
```

# stock initializes an additional UART

The command line includes: `earlycon=uart8250,mmio32,0x11002000` - no idea what that is (which UART that is, what it is connected to).
It appears to work without.

```
	chosen {
		// ..
		bootargs = ".. loglevel=8 earlycon=uart8250,mmio32,0x11002000";
		u-boot,bootconf = "config-1";
	};
```

```
# /sys/devices/platform/serial8250/
lrwxrwxrwx    1 root     root             0 Aug 25 10:13 driver -> ../../../bus/platform/drivers/serial8250
-rw-r--r--    1 root     root          4096 Aug 25 10:13 driver_override
-r--r--r--    1 root     root          4096 Aug 25 10:13 modalias
drwxr-xr-x    2 root     root             0 Aug 25 10:13 power
lrwxrwxrwx    1 root     root             0 Aug 25 10:13 subsystem -> ../../../bus/platform
drwxr-xr-x    4 root     root             0 Jan  1  1970 tty
-rw-r--r--    1 root     root          4096 Aug 25 10:13 uevent
# /sys/devices/platform/serial8250/tty/
drwxr-xr-x    3 root     root             0 Jan  1  1970 ttyS1
drwxr-xr-x    3 root     root             0 Jan  1  1970 ttyS2
```

# GPIO 5 needs to be high for LEDs to function

GPIO 5 is required to be high to allow other LEDs to function.
I haven't had any issues leaving it be. I assume u-boot initialises it.
Hauke provided a way to bring the GPIO up using `regulator-fixed`.

In the stock firmware the GPIO is exported as a LED called `onekey` (gpio5 active_high) and set from `/etc/init.d/boot`.
The GPIO is called JTAG JTDI - according to the spreadsheet.
Its function is described as follows:  "Higher level circuit to enable all LED light; Lower level circuit to close"