### PR TITLE
scripts/download.pl: remove stale GNOME download sites

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -314,12 +314,8 @@ foreach my $mirror (@ARGV) {
 		push @mirrors, "https://download.gnome.org/sources/$1";
 		push @mirrors, "https://mirror.csclub.uwaterloo.ca/gnome/sources/$1";
 		push @mirrors, "http://ftp.acc.umu.se/pub/GNOME/sources/$1";
-		push @mirrors, "http://ftp.kaist.ac.kr/gnome/sources/$1";
-		push @mirrors, "http://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/$1";
-		push @mirrors, "http://mirror.internode.on.net/pub/gnome/sources/$1";
-		push @mirrors, "http://ftp.belnet.be/ftp.gnome.org/sources/$1";
-		push @mirrors, "ftp://ftp.cse.buffalo.edu/pub/Gnome/sources/$1";
-		push @mirrors, "ftp://ftp.nara.wide.ad.jp/pub/X11/GNOME/sources/$1";
+		push @mirrors, "http://ftp.cse.buffalo.edu/pub/Gnome/sources/$1";
+		push @mirrors, "http://ftp.nara.wide.ad.jp/pub/X11/GNOME/sources/$1";
 		push @mirrors, "https://mirrors.ustc.edu.cn/gnome/sources/$1";
 	} else {
 		push @mirrors, $mirror;


### PR DESCRIPTION
Remove stale sites from @GNOME download site alias:
* remove 2 sites that have stale 3 years old content
* remove 2 sites that have dropped offering GNOME
* convert 2 sites from FTP to HTTP

The removed/changed site definitions are 7-15 years old, so no wonder if their policy has changed since then ;-)

Download tested all remaining/changed sites.

The change should be backported to 23.05 and 22.03
