### PR TITLE
wireless-regdb: update to 2023.09.01

### DIFF
--- a/package/firmware/wireless-regdb/Makefile
+++ b/package/firmware/wireless-regdb/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wireless-regdb
-PKG_VERSION:=2023.05.03
+PKG_VERSION:=2023.09.01
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/network/wireless-regdb/
-PKG_HASH:=f254d08ab3765aeae2b856222e11a95d44aef519a6663877c71ef68fae4c8c12
+PKG_HASH:=26d4c2a727cc59239b84735aad856b7c7d0b04e30aa5c235c4f7f47f5f053491
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
Changes:
    9dc0800 wireless-regdb: Update regulatory rules for Philippines (PH)
    111ba89 wireless-regdb: Update regulatory rules for Egypt (EG) from March 2022 guidelines
    ae1421f wireless-regdb: Update regulatory info for Türkiye (TR)
    20e5b73 wireless-regdb: Update regulatory rules for Australia (AU) for June 2023
    991b1ef wireless-regdb: update regulatory database based on preceding changes

Signed-off-by: CaffeeLake <PascalCoffeeLake@gmail.com>