### PR TITLE
realtek: add support for HPE 1920-8g-poe+ (65W)

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -31,7 +31,7 @@ lan_mac_end=""
 label_mac=""
 case $board in
 hpe,1920-8g|\
-hpe,1920-8g-poe|\
+hpe,1920-8g-poe-180w|\
 hpe,1920-16g|\
 hpe,1920-24g)
 	label_mac=$(mtd_get_mac_binary factory 0x68)
@@ -67,7 +67,7 @@ done
 [ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
 
 case $board in
-hpe,1920-8g-poe)
+hpe,1920-8g-poe-180w)
 	ucidef_set_poe 180 "$lan_list_rev" "lan9 lan10"
 	;;
 netgear,gs110tpp-v1)

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -31,6 +31,7 @@ lan_mac_end=""
 label_mac=""
 case $board in
 hpe,1920-8g|\
+hpe,1920-8g-poe-65w|\
 hpe,1920-8g-poe-180w|\
 hpe,1920-16g|\
 hpe,1920-24g)
@@ -67,6 +68,9 @@ done
 [ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
 
 case $board in
+hpe,1920-8g-poe-65w)
+	ucidef_set_poe 65 "$lan_list_rev" "lan9 lan10"
+	;;
 hpe,1920-8g-poe-180w)
 	ucidef_set_poe 180 "$lan_list_rev" "lan9 lan10"
 	;;

--- a/target/linux/realtek/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/realtek/base-files/etc/board.d/03_gpio_switches
@@ -6,7 +6,7 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
-hpe,1920-8g-poe)
+hpe,1920-8g-poe-180w)
 	ucidef_add_gpio_switch "fan_ctrl" "Fan control" "456" "0"
 	;;
 esac

--- a/target/linux/realtek/dts-5.15/rtl8380_hpe_1920-8g-poe-180w.dts
+++ b/target/linux/realtek/dts-5.15/rtl8380_hpe_1920-8g-poe-180w.dts
@@ -3,8 +3,8 @@
 #include "rtl8380_hpe_1920-8g.dtsi"
 
 / {
-	compatible = "hpe,1920-8g-poe", "realtek,rtl838x-soc";
-	model = "HPE 1920-8G-PoE+ (JG922A)";
+	compatible = "hpe,1920-8g-poe-180w", "realtek,rtl838x-soc";
+	model = "HPE 1920-8G-PoE+ 180W (JG922A)";
 };
 
 &uart1 {

--- a/target/linux/realtek/dts-5.15/rtl8380_hpe_1920-8g-poe-65w.dts
+++ b/target/linux/realtek/dts-5.15/rtl8380_hpe_1920-8g-poe-65w.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl8380_hpe_1920-8g.dtsi"
+
+/ {
+	compatible = "hpe,1920-8g-poe-65w", "realtek,rtl838x-soc";
+	model = "HPE 1920-8G-PoE+ 65W (JG921A)";
+};
+
+&uart1 {
+	status = "okay";
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -99,13 +99,14 @@ define Device/hpe_1920-8g
 endef
 TARGET_DEVICES += hpe_1920-8g
 
-define Device/hpe_1920-8g-poe
+define Device/hpe_1920-8g-poe-180w
   $(Device/hpe_1920)
   SOC := rtl8380
-  DEVICE_MODEL := 1920-8G-PoE+ (JG922A)
+  DEVICE_MODEL := 1920-8G-PoE+ 180W (JG922A)
   H3C_DEVICE_ID := 0x00010025
+  SUPPORTED_DEVICES += hpe_1920-8g-poe
 endef
-TARGET_DEVICES += hpe_1920-8g-poe
+TARGET_DEVICES += hpe_1920-8g-poe-180w
 
 define Device/hpe_1920-16g
   $(Device/hpe_1920)

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -99,6 +99,15 @@ define Device/hpe_1920-8g
 endef
 TARGET_DEVICES += hpe_1920-8g
 
+define Device/hpe_1920-8g-poe-65w
+  $(Device/hpe_1920)
+  SOC := rtl8380
+  DEVICE_MODEL := 1920-8G-PoE+ 65W (JG921A)
+  DEVICE_PACKAGES += realtek-poe
+  H3C_DEVICE_ID := 0x00010024
+endef
+TARGET_DEVICES += hpe_1920-8g-poe-65w
+
 define Device/hpe_1920-8g-poe-180w
   $(Device/hpe_1920)
   SOC := rtl8380


### PR DESCRIPTION
Hardware information:
---------------------

- RTL8380 SoC
- 8 Gigabit RJ45 PoE ports (built-in RTL8218B)
- 2 SFP ports (built-in SerDes)
- RJ45 RS232 port on front panel
- 32 MiB NOR Flash
- 128 MiB DDR3 DRAM
- PT7A7514 watchdog
- PoE chip
- Fanless

Known issues:
---------------------
- PoE LEDs are uncontrolled.

(Manual taken from f2f09bc00280)
Booting initramfs image:
------------------------

- Prepare a FTP or TFTP server serving the OpenWrt initramfs image and connect the server to a switch port.

- Connect to the console port of the device and enter the extended boot menu by typing Ctrl+B when prompted.

- Choose the menu option "<3> Enter Ethernet SubMenu".

- Set network parameters via the option "<5> Modify Ethernet Parameter". Enter the FTP/TFTP filename as "Load File Name" ("Target File Name" can be left blank, it is not required for booting from RAM). Note that the configuration is saved on flash, so it only needs to be done once.

- Select "<1> Download Application Program To SDRAM And Run".

Initial installation:
---------------------

- Boot an initramfs image as described above, then use sysupgrade to install OpenWrt permanently. After initial installation, the bootloader needs to be configured to load the correct image file

- Enter the extended boot menu again and choose "<4> File Control", then select "<2> Set Application File type".

- Enter the number of the file "openwrt-kernel.bin" (should be 1), and use the option "<1> +Main" to select it as boot image.

- Choose "<0> Exit To Main Menu" and then "<1> Boot System".

NOTE: The bootloader on these devices can only boot from the VFS filesystem which normally spans most of the flash. With OpenWrt, only the first part of the firmware partition contains a valid filesystem, the rest is used for rootfs. As the bootloader does not know about this, you must not do any file operations in the bootloader, as this may corrupt the OpenWrt installation (selecting the boot image is an exception, as it only stores a flag in the bootloader data, but doesn't write to the filesystem).

Example PoE config file (/etc/config/poe):
---------------------
```
config global
        option budget   '65'

config port
        option enable   '1'
        option id       '1'
        option name     'lan8'
        option poe_plus '1'
        option priority '2'
config port
        option enable   '1'
        option id       '2'
        option name     'lan7'
        option poe_plus '1'
        option priority '2'
config port
        option enable   '1'
        option id       '3'
        option name     'lan6'
        option poe_plus '1'
        option priority '2'
config port
        option enable   '1'
        option id       '4'
        option name     'lan5'
        option poe_plus '1'
        option priority '2'
config port
        option enable   '1'
        option id       '5'
        option name     'lan4'
        option poe_plus '1'
        option priority '2'
config port
        option enable   '1'
        option id       '6'
        option name     'lan3'
        option poe_plus '1'
        option priority '2'
config port
        option enable   '1'
        option id       '7'
        option name     'lan2'
        option poe_plus '1'
        option priority '2'
config port
        option enable   '1'
        option id       '8'
        option name     'lan1'
        option poe_plus '1'
        option priority '2'
```
