### PR TITLE
mvebu: add reset delays of PHYs for Fortinet FortiGate 50E

### DIFF
--- a/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-fortinet-fg-50e.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-fortinet-fg-50e.dts
@@ -297,6 +297,8 @@
 		interrupt-parent = <&gpio0>;
 		interrupts = <20 IRQ_TYPE_LEVEL_LOW>;
 		reset-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <10000>;
 		/*
 		 * LINK/ACT   (Green): LED[0], Active Low
 		 * SPEED 100M (Amber): LED[1], Active High
@@ -313,6 +315,8 @@
 		interrupt-parent = <&gpio1>;
 		interrupts = <9 IRQ_TYPE_LEVEL_LOW>;
 		reset-gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <10000>;
 		/*
 		 * LINK/ACT   (Green): LED[0], Active Low
 		 * SPEED 100M (Amber): LED[1], Active High


### PR DESCRIPTION
Add reset-(de)assert-us to ethernet PHYs on Fortinet FortiGate 50E to solve instability after HW resetting of PHYs. (ex.: restarting "network" service, etc...)

this issue was reported on: https://github.com/openwrt/openwrt/issues/13391

Fixes: 102dc5a62506 ("mvebu: add support for Fortinet FortiGate 50E")

---

This fix needs to be backported to 23.05.