### PR TITLE
scripts/download.pl: Remove stale download site definitions

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -256,15 +256,14 @@ foreach my $mirror (@ARGV) {
 		push @mirrors, "https://mirrors.ustc.edu.cn/debian/$1"
 	} elsif ($mirror =~ /^\@APACHE\/(.+)$/) {
 		push @mirrors, "https://dlcdn.apache.org/$1";
-		push @mirrors, "https://mirror.netcologne.de/apache.org/$1";
 		push @mirrors, "https://mirror.aarnet.edu.au/pub/apache/$1";
 		push @mirrors, "https://mirror.csclub.uwaterloo.ca/apache/$1";
 		push @mirrors, "https://archive.apache.org/dist/$1";
-		push @mirrors, "http://mirror.cogentco.com/pub/apache/$1";
-		push @mirrors, "http://mirror.navercorp.com/apache/$1";
-		push @mirrors, "http://ftp.jaist.ac.jp/pub/apache/$1";
-		push @mirrors, "ftp://apache.cs.utah.edu/apache.org/$1";
-		push @mirrors, "ftp://apache.mirrors.ovh.net/ftp.apache.org/dist/$1";
+		push @mirrors, "https://mirror.cogentco.com/pub/apache/$1";
+		push @mirrors, "https://mirror.navercorp.com/apache/$1";
+		push @mirrors, "https://ftp.jaist.ac.jp/pub/apache/$1";
+		push @mirrors, "https://apache.cs.utah.edu/apache.org/$1";
+		push @mirrors, "http://apache.mirrors.ovh.net/ftp.apache.org/dist/$1";
 		push @mirrors, "https://mirrors.tuna.tsinghua.edu.cn/apache/$1";
 		push @mirrors, "https://mirrors.ustc.edu.cn/apache/$1";
 	} elsif ($mirror =~ /^\@GITHUB\/(.+)$/) {
@@ -275,23 +274,19 @@ foreach my $mirror (@ARGV) {
 	} elsif ($mirror =~ /^\@GNU\/(.+)$/) {
 		push @mirrors, "https://mirror.csclub.uwaterloo.ca/gnu/$1";
 		push @mirrors, "https://mirror.netcologne.de/gnu/$1";
-		push @mirrors, "http://ftp.kddilabs.jp/GNU/gnu/$1";
-		push @mirrors, "http://www.nic.funet.fi/pub/gnu/gnu/$1";
-		push @mirrors, "http://mirror.internode.on.net/pub/gnu/$1";
-		push @mirrors, "http://mirror.navercorp.com/gnu/$1";
-		push @mirrors, "ftp://mirrors.rit.edu/gnu/$1";
-		push @mirrors, "ftp://download.xs4all.nl/pub/gnu/$1";
+		push @mirrors, "https://ftp.kddilabs.jp/GNU/gnu/$1";
+		push @mirrors, "https://www.nic.funet.fi/pub/gnu/gnu/$1";
+		push @mirrors, "https://mirror.navercorp.com/gnu/$1";
+		push @mirrors, "https://mirrors.rit.edu/gnu/$1";
 		push @mirrors, "https://ftp.gnu.org/gnu/$1";
 		push @mirrors, "https://mirrors.tuna.tsinghua.edu.cn/gnu/$1";
 		push @mirrors, "https://mirrors.ustc.edu.cn/gnu/$1";
 	} elsif ($mirror =~ /^\@SAVANNAH\/(.+)$/) {
 		push @mirrors, "https://mirror.netcologne.de/savannah/$1";
 		push @mirrors, "https://mirror.csclub.uwaterloo.ca/nongnu/$1";
-		push @mirrors, "http://ftp.acc.umu.se/mirror/gnu.org/savannah/$1";
-		push @mirrors, "http://nongnu.uib.no/$1";
-		push @mirrors, "http://ftp.igh.cnrs.fr/pub/nongnu/$1";
-		push @mirrors, "ftp://cdimage.debian.org/mirror/gnu.org/savannah/$1";
-		push @mirrors, "ftp://ftp.acc.umu.se/mirror/gnu.org/savannah/$1";
+		push @mirrors, "https://ftp.acc.umu.se/mirror/gnu.org/savannah/$1";
+		push @mirrors, "https://nongnu.uib.no/$1";
+		push @mirrors, "https://cdimage.debian.org/mirror/gnu.org/savannah/$1";
 	} elsif ($mirror =~ /^\@KERNEL\/(.+)$/) {
 		my @extra = ( $1 );
 		if ($filename =~ /linux-\d+\.\d+(?:\.\d+)?-rc/) {
@@ -301,19 +296,17 @@ foreach my $mirror (@ARGV) {
 		}
 		foreach my $dir (@extra) {
 			push @mirrors, "https://cdn.kernel.org/pub/$dir";
-			push @mirrors, "https://download.xs4all.nl/ftp.kernel.org/pub/$dir";
 			push @mirrors, "https://mirrors.mit.edu/kernel/$dir";
 			push @mirrors, "http://ftp.nara.wide.ad.jp/pub/kernel.org/$dir";
 			push @mirrors, "http://www.ring.gr.jp/archives/linux/kernel.org/$dir";
-			push @mirrors, "ftp://ftp.riken.jp/Linux/kernel.org/$dir";
-			push @mirrors, "ftp://www.mirrorservice.org/sites/ftp.kernel.org/pub/$dir";
-			push @mirrors, "https://mirrors.tuna.tsinghua.edu.cn/kernel/$dir";
+			push @mirrors, "https://ftp.riken.jp/Linux/kernel.org/$dir";
+			push @mirrors, "https://www.mirrorservice.org/sites/ftp.kernel.org/pub/$dir";
 			push @mirrors, "https://mirrors.ustc.edu.cn/kernel.org/$dir";
 		}
 	} elsif ($mirror =~ /^\@GNOME\/(.+)$/) {
 		push @mirrors, "https://download.gnome.org/sources/$1";
 		push @mirrors, "https://mirror.csclub.uwaterloo.ca/gnome/sources/$1";
-		push @mirrors, "http://ftp.acc.umu.se/pub/GNOME/sources/$1";
+		push @mirrors, "https://ftp.acc.umu.se/pub/GNOME/sources/$1";
 		push @mirrors, "http://ftp.cse.buffalo.edu/pub/Gnome/sources/$1";
 		push @mirrors, "http://ftp.nara.wide.ad.jp/pub/X11/GNOME/sources/$1";
 		push @mirrors, "https://mirrors.ustc.edu.cn/gnome/sources/$1";


### PR DESCRIPTION
I did the first round yesterday when I noticed problem with GNOME, but decided to check also all other mirror site aliases. And there were several dead or erroneous sites...

-----
Remove the stale site definitions from APACHE, GNU, KERNEL etc.

* Remove site that had dropped APACHE
* Convert non-responding ftp sites to https/http
* Remove KERNEL site leading to wrong directory
* Remove dead sites

