### PR TITLE
ipq40xx: add support for Netgear RBX40

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -88,6 +88,8 @@ ipq40xx_setup_interfaces()
 	aruba,ap-303h|\
 	buffalo,wtr-m2133hp|\
 	ezviz,cs-w3-wd1200g-eup|\
+	netgear,rbr40|\
+	netgear,rbs40|\
 	netgear,rbr50|\
 	netgear,rbs50|\
 	netgear,srr60|\

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -40,6 +40,8 @@ case "$FIRMWARE" in
 		# OEM assigns 4 sequential MACs
 		ath10k_patch_mac $(macaddr_setbit_la $(macaddr_add "$(cat /sys/class/net/eth0/address)" 4))
 		;;
+	netgear,rbr40|\
+	netgear,rbs40|\
 	netgear,rbr50|\
 	netgear,rbs50|\
 	netgear,srr60|\
@@ -117,6 +119,8 @@ case "$FIRMWARE" in
 		( [ -f "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data" 0x0 0x2f20 ) || \
 		( [ -d "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data/data_0" 0x0 0x2f20 )
 		;;
+	netgear,rbr40|\
+	netgear,rbs40|\
 	netgear,rbr50|\
 	netgear,rbs50|\
 	netgear,srr60|\
@@ -211,6 +215,8 @@ case "$FIRMWARE" in
 		( [ -f "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data" 0x8000 0x2f20 ) || \
 		( [ -d "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data/data_2" 0x0 0x2f20 )
 		;;
+	netgear,rbr40|\
+	netgear,rbs40|\
 	netgear,rbr50|\
 	netgear,rbs50|\
 	netgear,srr60|\

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -191,6 +191,8 @@ platform_do_upgrade() {
 	mikrotik,hap-ac3)
 		platform_do_upgrade_mikrotik_nand "$1"
 		;;
+	netgear,rbr40|\
+	netgear,rbs40|\
 	netgear,rbr50 |\
 	netgear,rbs50 |\
 	netgear,srr60 |\

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rbr40.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rbr40.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019-orbi.dtsi"
+
+/ {
+	model = "NETGEAR RBR40";
+	compatible = "netgear,rbr40";
+
+	chosen {
+		bootargs = "root=/dev/mmcblk0p20 blkdevparts=mmcblk0:512K@17K(0:SBL1)ro,512K(0:BOOTCONFIG)ro,512K(0:QSEE)ro,512K(0:QSEE_ALT)ro,256K(0:CDT)ro,256K(0:CDT_ALT)ro,256K(0:DDRPARAMS)ro,256K(0:APPSBLENV)ro,1M(0:APPSBL)ro,1M(0:APPSBL_ALT)ro,256K(0:ART)ro,256K(ARTMTD)ro,2M(language)ro,256K(config)ro,256K(pot)ro,256K(traffic_meter)ro,256K(pot_bak)ro,256K(traffic_meter.bak)ro,3840K(kernel),31488K(rootfs),35328K@9233K(firmware),256K(mtdoops)ro,1457651200(reserved)ro,-(unallocated) rootfstype=squashfs,ext4 rootwait";
+	};
+};

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rbs40.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rbs40.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019-orbi.dtsi"
+
+/ {
+	model = "NETGEAR RBS40";
+	compatible = "netgear,rbs40";
+
+	chosen {
+		bootargs = "root=/dev/mmcblk0p20 blkdevparts=mmcblk0:512K@17K(0:SBL1)ro,512K(0:BOOTCONFIG)ro,512K(0:QSEE)ro,512K(0:QSEE_ALT)ro,256K(0:CDT)ro,256K(0:CDT_ALT)ro,256K(0:DDRPARAMS)ro,256K(0:APPSBLENV)ro,1M(0:APPSBL)ro,1M(0:APPSBL_ALT)ro,256K(0:ART)ro,256K(ARTMTD)ro,2M(language)ro,256K(config)ro,256K(pot)ro,256K(traffic_meter)ro,256K(pot_bak)ro,256K(traffic_meter.bak)ro,3840K(kernel),31488K(rootfs),35328K@9233K(firmware),256K(mtdoops)ro,1457651200(reserved)ro,-(unallocated) rootfstype=squashfs,ext4 rootwait";
+	};
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -826,6 +826,30 @@ define Device/netgear_orbi
 	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct e2fsprogs kmod-fs-ext4 losetup
 endef
 
+define Device/netgear_rbx40
+	$(call Device/netgear_orbi)
+	NETGEAR_HW_ID := 29765515+0+4096+512+2x2+2x2+2x2
+	KERNEL_SIZE := 3932160
+	ROOTFS_SIZE := 32243712
+	IMAGE_SIZE := 36175872
+endef
+
+define Device/netgear_rbr40
+	$(call Device/netgear_rbx40)
+	DEVICE_MODEL := RBR40
+	DEVICE_VARIANT := v1
+	NETGEAR_BOARD_ID := RBR40
+endef
+TARGET_DEVICES += netgear_rbr40
+
+define Device/netgear_rbs40
+	$(call Device/netgear_rbx40)
+	DEVICE_MODEL := RBS40
+	DEVICE_VARIANT := v1
+	NETGEAR_BOARD_ID := RBS40
+endef
+TARGET_DEVICES += netgear_rbs40
+
 define Device/netgear_rbx50
 	$(call Device/netgear_orbi)
 	NETGEAR_HW_ID := 29765352+0+4000+512+2x2+2x2+4x4


### PR DESCRIPTION
This adds support for the RBR40 and RBS40 (sold together as RBK40), two netgear routers identical to SRR60/SRS60 in all but antennae (and hardware id). See 2cb24b3f3c for details.