### PR TITLE
x86: add support for Mellanox Spectrum SN2000 Series

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -216,6 +216,7 @@ menu "Target Images"
 	config GRUB_CONSOLE
 		bool "Use Console Terminal (in addition to Serial)"
 		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
+		default n if TARGET_x86_64_DEVICE_mellanox_spectrum-sn2000
 		default y
 
 	config GRUB_SERIAL

--- a/package/firmware/linux-firmware/mellanox.mk
+++ b/package/firmware/linux-firmware/mellanox.mk
@@ -1,0 +1,9 @@
+Package/mlxsw_spectrum-firmware = $(call Package/firmware-default,Mellanox Spectrum firmware)
+define Package/mlxsw_spectrum-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/mellanox
+	$(CP) \
+		$(PKG_BUILD_DIR)/mellanox/mlxsw_spectrum-*.mfa2 \
+		$(1)/lib/firmware/mellanox
+endef
+
+$(eval $(call BuildPackage,mlxsw_spectrum-firmware))

--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -77,6 +77,23 @@ endef
 $(eval $(call KernelPackage,hwmon-adt7475))
 
 
+define KernelPackage/hwmon-coretemp
+  TITLE:=Intel Core/Core2/Atom temperature sensor
+  KCONFIG:=CONFIG_SENSORS_CORETEMP
+  FILES:=$(LINUX_DIR)/drivers/hwmon/coretemp.ko
+  AUTOLOAD:=$(call AutoProbe,coretemp)
+  $(call AddDepends/hwmon,)
+endef
+
+define KernelPackage/hwmon-coretemp/description
+  Kernel module for Intel Core/Core2/Atom temperature monitoring support.
+  Most of the family 6 CPUs are supported.
+  Check Documentation/hwmon/coretemp.rst for details.
+endef
+
+$(eval $(call KernelPackage,hwmon-coretemp))
+
+
 define KernelPackage/hwmon-dme1737
   TITLE:=SMSC DME1737 and compatible monitoring support
   KCONFIG:=CONFIG_SENSORS_DME1737

--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -147,6 +147,22 @@ endef
 $(eval $(call KernelPackage,leds-apu))
 
 
+define KernelPackage/leds-mlxcpld
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=LED support for the Mellanox boards
+  FILES:=$(LINUX_DIR)/drivers/leds/leds-mlxcpld.ko
+  KCONFIG:=CONFIG_LEDS_MLXCPLD
+  AUTOLOAD:=$(call AutoProbe,leds-mlxcpld)
+endef
+
+define KernelPackage/leds-mlxcpld/description
+  This option enables support for the LEDs on the Mellanox
+  boards.
+endef
+
+$(eval $(call KernelPackage,leds-mlxcpld))
+
+
 define KernelPackage/leds-pca955x
   SUBMENU:=$(LEDS_MENU)
   TITLE:=LED driver for PCA955x I2C chips

--- a/package/kernel/linux/modules/lib.mk
+++ b/package/kernel/linux/modules/lib.mk
@@ -318,3 +318,29 @@ define KernelPackage/oid-registry
 endef
 
 $(eval $(call KernelPackage,oid-registry))
+
+
+define KernelPackage/lib-objagg
+  SUBMENU:=$(LIB_MENU)
+  TITLE:=objagg support
+  FILES:=$(LINUX_DIR)/lib/objagg.ko
+  KCONFIG:= \
+  CONFIG_OBJAGG \
+  CONFIG_TEST_OBJAGG=n
+  AUTOLOAD:=$(call AutoProbe,objagg)
+endef
+
+$(eval $(call KernelPackage,lib-objagg))
+
+
+define KernelPackage/lib-parman
+  SUBMENU:=$(LIB_MENU)
+  TITLE:=parman support
+  FILES:=$(LINUX_DIR)/lib/parman.ko
+  KCONFIG:= \
+  CONFIG_PARMAN \
+  CONFIG_TEST_PARMAN=n
+  AUTOLOAD:=$(call AutoProbe,parman)
+endef
+
+$(eval $(call KernelPackage,lib-parman))

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1327,7 +1327,7 @@ $(eval $(call KernelPackage,mlx4-core))
 define KernelPackage/mlx5-core
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Mellanox ConnectX(R) mlx5 core Network Driver
-  DEPENDS:=@PCI_SUPPORT +kmod-ptp
+  DEPENDS:=@PCI_SUPPORT +kmod-ptp +kmod-mlxfw
   FILES:=$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko
   KCONFIG:= CONFIG_MLX5_CORE \
 	CONFIG_MLX5_CORE_EN=y \
@@ -1353,6 +1353,119 @@ define KernelPackage/mlx5-core/description
 endef
 
 $(eval $(call KernelPackage,mlx5-core))
+
+
+define KernelPackage/mlxfw
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Mellanox Technologies firmware flash module
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlxfw/mlxfw.ko
+  KCONFIG:=CONFIG_MLXFW
+  AUTOLOAD:=$(call AutoProbe,mlxfw)
+endef
+
+define KernelPackage/mlxfw/description
+  This driver supports Mellanox Technologies Firmware
+  flashing common logic.
+endef
+
+$(eval $(call KernelPackage,mlxfw))
+
+
+define KernelPackage/mlxsw-core
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Mellanox Technologies Switch ASICs support
+  DEPENDS:=+kmod-mlxfw +kmod-hwmon-core
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlxsw/mlxsw_core.ko
+  KCONFIG:= \
+  CONFIG_MLXSW_CORE \
+  CONFIG_MLXSW_CORE_HWMON=y \
+  CONFIG_MLXSW_CORE_THERMAL=y
+  AUTOLOAD:=$(call AutoProbe,mlxsw_core)
+endef
+
+define KernelPackage/mlxsw-core/description
+  This driver supports Mellanox Technologies Switch ASICs family.
+endef
+
+$(eval $(call KernelPackage,mlxsw-core))
+
+
+define KernelPackage/mlxsw-i2c
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=I2C bus implementation for Mellanox Technologies Switch ASICs
+  DEPENDS:=+kmod-mlxsw-core +kmod-i2c-core
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlxsw/mlxsw_i2c.ko
+  KCONFIG:=CONFIG_MLXSW_I2C
+  AUTOLOAD:=$(call AutoProbe,mlxsw_i2c)
+endef
+
+define KernelPackage/mlxsw-i2c/description
+  This is I2C bus implementation for Mellanox Technologies Switch ASICs.
+endef
+
+$(eval $(call KernelPackage,mlxsw-i2c))
+
+
+define KernelPackage/mlxsw-minimal
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Mellanox Technologies minimal I2C support
+  DEPENDS:=+kmod-mlxsw-core +kmod-mlxsw-i2c
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlxsw/mlxsw_minimal.ko
+  KCONFIG:=CONFIG_MLXSW_MINIMAL
+  AUTOLOAD:=$(call AutoProbe,mlxsw_minimal)
+endef
+
+define KernelPackage/mlxsw-minimal/description
+  This driver supports I2C access for Mellanox Technologies Switch
+  ASICs.
+endef
+
+$(eval $(call KernelPackage,mlxsw-minimal))
+
+
+define KernelPackage/mlxsw-pci
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=PCI bus implementation for Mellanox Technologies Switch ASICs
+  DEPENDS:=@PCI_SUPPORT +kmod-mlxsw-core
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlxsw/mlxsw_pci.ko
+  KCONFIG:=CONFIG_MLXSW_PCI
+  AUTOLOAD:=$(call AutoProbe,mlxsw_pci)
+endef
+
+define KernelPackage/mlxsw-pci/description
+  This is PCI bus implementation for Mellanox Technologies Switch ASICs.
+endef
+
+$(eval $(call KernelPackage,mlxsw-pci))
+
+
+define KernelPackage/mlxsw-spectrum
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Mellanox Technologies Spectrum family support
+  DEPENDS:= \
+  +kmod-mlxsw-core +kmod-mlxsw-pci +kmod-lib-objagg +kmod-lib-parman \
+  +kmod-ip6-tunnel +kmod-ptp +kmod-sched-act-sample +kmod-vxlan
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlxsw/mlxsw_spectrum.ko
+  KCONFIG:= \
+  CONFIG_MLXSW_SPECTRUM \
+  CONFIG_NET_SWITCHDEV=y \
+  CONFIG_MLXSW_SPECTRUM_DCB=y \
+  CONFIG_DCB=y \
+  CONFIG_AMD_XGBE_DCB=n \
+  CONFIG_IXGBE_DCB=n \
+  CONFIG_I40E_DCB=n \
+  CONFIG_QLCNIC_DCB=n \
+  CONFIG_FSL_DPAA2_ETH_DCB=n \
+  CONFIG_FSL_DPAA2_SWITCH=n
+  AUTOLOAD:=$(call AutoProbe,mlxsw_spectrum)
+endef
+
+define KernelPackage/mlxsw-spectrum/description
+  This driver supports Mellanox Technologies
+  Spectrum/Spectrum-2/Spectrum-3/Spectrum-4 Ethernet Switch ASICs.
+endef
+
+$(eval $(call KernelPackage,mlxsw-spectrum))
 
 
 define KernelPackage/net-selftests

--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -31,6 +31,9 @@ cisco-mx100-hw)
 	ucidef_set_network_device_path "eth11" "pci0000:00/0000:00:01.1/0000:02:00.2"
 	ucidef_set_interfaces_lan_wan "mgmt eth2 eth3 eth4 eth5 eth6 eth7 eth8 eth9 eth10 eth11" "wan"
 	;;
+mellanox-technologies-ltd-msn2100)
+	ucidef_set_interface_lan "eth1 eth2 eth3 eth4 eth5 eth6 eth7 eth8 eth9 eth10 eth11 eth12 eth13 eth14 eth15 eth16"
+	;;
 pc-engines-apu1|pc-engines-apu2|pc-engines-apu3)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
 	;;

--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -8,3 +8,16 @@ define Device/generic
   GRUB2_VARIANT := generic
 endef
 TARGET_DEVICES += generic
+
+define Device/mellanox_spectrum-sn2000
+  DEVICE_VENDOR := Mellanox
+  DEVICE_MODEL := Spectrum SN2000 Series
+  DEVICE_PACKAGES += \
+  	kmod-mlxsw-core kmod-mlxsw-pci kmod-mlxsw-i2c \
+  	kmod-mlxsw-spectrum kmod-mlxsw-minimal kmod-mlxfw \
+  	kmod-leds-mlxcpld kmod-lib-objagg kmod-lib-parman \
+  	kmod-hwmon-coretemp kmod-hwmon-drivetemp kmod-hwmon-jc42 \
+  	kmod-i2c-i801 kmod-igb mlxsw_spectrum-firmware
+  GRUB2_VARIANT := generic
+endef
+TARGET_DEVICES += mellanox_spectrum-sn2000


### PR DESCRIPTION
The Mellanox Spectrum SN2000 Series Switches are Managed Ethernet Switches with a maximum speed of 100Gb/s and up to 56 ports.
<br>

Tested on a Mellanox Spectrum SN2100 with the following specs:
- CPU: Intel ATOM x86 dual-core 2.4GHz
- RAM: 8GB
- Disk: 16GB SSD
- Ports: 16x QSFP28 100GbE, 1x 100M Mgmt Port, 1x RJ45 Serial Port
- USB: 1x mini 2.0
- Button: 1x (reset)
- LEDs: 6x
<br>


Installation:
- Create a bootable USB device (either by flashing this image onto it or another Linux distribution)
- Unzip the image (openwrt-x86-64-mellanox_spectrum-sn2000-ext4-combined.img.gz) and copy it onto the USB device
- Plug the USB device into the Mellanox Switch and boot from it
- Flash the image (e.g., with dd) onto the internal SSD of the switch (should be /dev/sda)

To enter the BIOS, reboot the switch and press CTRL+B while you see the BIOS information text (American Megatrends …). The default password to enter the BIOS is admin. To boot from the USB device, switch to the Boot index tab and set your USB device at the top of the boot order (the internal SSD should be currently there). Don't forget to set the SSD back at the top after you have flashed the image.
<br>


Commit cb6df97c23cb72b4c288b48eb150689809e18bdb adds needed packages to run the image on the switches.
Commit d3d006d67d95ac8c3e1fb517238e8b7f799bc1ac adds an x86_64 target profile entry inside the build system configuration interface.