### PR TITLE
procd: create /dev/fd symlink

### DIFF
--- a/package/system/procd/Makefile
+++ b/package/system/procd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=procd
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/procd.git

--- a/package/system/procd/files/hotplug.json
+++ b/package/system/procd/files/hotplug.json
@@ -11,6 +11,7 @@
 						[ "eq", "DEVNAME", "null" ],
 						[
 							[ "makedev", "/dev/%DEVNAME%", "0666" ],
+							[ "exec", "/bin/ln", "-s", "/proc/self/fd", "/dev/fd" ],
 							[ "exec", "/bin/ln", "-s", "/proc/self/fd/0", "/dev/stdin" ],
 							[ "exec", "/bin/ln", "-s", "/proc/self/fd/1", "/dev/stdout" ],
 							[ "exec", "/bin/ln", "-s", "/proc/self/fd/2", "/dev/stderr" ],


### PR DESCRIPTION
This is needed for ksh/bash style process substitution such as <(command) and >(command) which was introduced in ash as of busybox version 1.34.0 to work.