### PR TITLE
Add option CONFIG_FORGET_OPKG_KEYS

### DIFF
--- a/package/system/opkg/Makefile
+++ b/package/system/opkg/Makefile
@@ -55,7 +55,9 @@ endef
 
 define Package/opkg/conffiles
 /etc/opkg.conf
+ifneq ($(CONFIG_FORGET_OPKG_KEYS),y)
 /etc/opkg/keys/
+endif
 /etc/opkg/customfeeds.conf
 endef
 


### PR DESCRIPTION
This option allows to remove all existing files in /etc/opkg/keys if CONFIG_FORGET_OPKG_KEYS=y is set. This is needed to remove old keys on upgrade, if no single key has been configured.

This fixes https://github.com/freifunk-gluon/gluon/issues/2665

It is not yet tested