### PR TITLE
ipq806x: Correct OnHub sysupgrade config logic

### DIFF
--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -82,7 +82,7 @@ platform_do_upgrade() {
 }
 
 platform_copy_config() {
-	case "${board_name}" in
+	case "$(board_name)" in
 	asus,onhub |\
 	tplink,onhub)
 		emmc_copy_config


### PR DESCRIPTION
There's a typo in here: board_name is a function, not a variable. This issue was pointed out on the OpenWrt forum.

Closes: #13409
