### PR TITLE
x86,armsr: interpolate @GRUB_SERIAL@ into /etc/inittab

### DIFF
--- a/target/linux/armsr/base-files.mk
+++ b/target/linux/armsr/base-files.mk
@@ -1,0 +1,8 @@
+GRUB_SERIAL:=$(call qstrip,$(CONFIG_GRUB_SERIAL))
+ifeq ($(GRUB_SERIAL),)
+$(error This platform requires CONFIG_GRUB_SERIAL be set!)
+endif
+
+define Package/base-files/install-target
+	$(SED) "s#@GRUB_SERIAL@#$(GRUB_SERIAL)#" $(1)/etc/inittab
+endef

--- a/target/linux/armsr/base-files/etc/inittab
+++ b/target/linux/armsr/base-files/etc/inittab
@@ -1,7 +1,7 @@
 ::sysinit:/etc/init.d/rcS S boot
 ::shutdown:/etc/init.d/rcS K shutdown
 ttyAMA0::askfirst:/usr/libexec/login.sh
-ttyS0::askfirst:/usr/libexec/login.sh
+@GRUB_SERIAL@::askfirst:/usr/libexec/login.sh
 tty0::askfirst:/usr/libexec/login.sh
 hvc0::askfirst:/usr/libexec/login.sh
 ttymxc0::askfirst:/usr/libexec/login.sh

--- a/target/linux/armsr/image/Makefile
+++ b/target/linux/armsr/image/Makefile
@@ -17,14 +17,10 @@ endif
 
 GRUB_SERIAL:=$(call qstrip,$(CONFIG_GRUB_SERIAL))
 
-ifneq ($(GRUB_SERIAL),)
-  GRUB_SERIAL_CONFIG := serial --unit=0 --speed=$(CONFIG_GRUB_BAUDRATE) --word=8 --parity=no --stop=1 --rtscts=$(if $(CONFIG_GRUB_FLOWCONTROL),on,off)
-  GRUB_TERMINALS += serial
-endif
+GRUB_SERIAL_CONFIG := serial --unit=0 --speed=$(CONFIG_GRUB_BAUDRATE) --word=8 --parity=no --stop=1 --rtscts=$(if $(CONFIG_GRUB_FLOWCONTROL),on,off)
+GRUB_TERMINALS += serial
 
-ifneq ($(GRUB_TERMINALS),)
-  GRUB_TERMINAL_CONFIG := terminal_input $(GRUB_TERMINALS); terminal_output $(GRUB_TERMINALS)
-endif
+GRUB_TERMINAL_CONFIG := terminal_input $(GRUB_TERMINALS); terminal_output $(GRUB_TERMINALS)
 
 ROOTPART:=$(call qstrip,$(CONFIG_TARGET_ROOTFS_PARTNAME))
 ROOTPART:=$(if $(ROOTPART),$(ROOTPART),PARTUUID=$(IMG_PART_SIGNATURE)-02)

--- a/target/linux/x86/base-files.mk
+++ b/target/linux/x86/base-files.mk
@@ -1,0 +1,8 @@
+GRUB_SERIAL:=$(call qstrip,$(CONFIG_GRUB_SERIAL))
+ifeq ($(GRUB_SERIAL),)
+$(error This platform requires CONFIG_GRUB_SERIAL be set!)
+endif
+
+define Package/base-files/install-target
+	$(SED) "s#@GRUB_SERIAL@#$(GRUB_SERIAL)#" $(1)/etc/inittab
+endef

--- a/target/linux/x86/base-files/etc/inittab
+++ b/target/linux/x86/base-files/etc/inittab
@@ -1,5 +1,5 @@
 ::sysinit:/etc/init.d/rcS S boot
 ::shutdown:/etc/init.d/rcS K shutdown
-ttyS0::askfirst:/usr/libexec/login.sh
+@GRUB_SERIAL@::askfirst:/usr/libexec/login.sh
 hvc0::askfirst:/usr/libexec/login.sh
 tty1::askfirst:/usr/libexec/login.sh

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -18,15 +18,11 @@ endif
 
 GRUB_SERIAL:=$(call qstrip,$(CONFIG_GRUB_SERIAL))
 
-ifneq ($(GRUB_SERIAL),)
-  GRUB_CONSOLE_CMDLINE += console=$(GRUB_SERIAL),$(CONFIG_GRUB_BAUDRATE)n8$(if $(CONFIG_GRUB_FLOWCONTROL),r,)
-  GRUB_SERIAL_CONFIG := serial --unit=0 --speed=$(CONFIG_GRUB_BAUDRATE) --word=8 --parity=no --stop=1 --rtscts=$(if $(CONFIG_GRUB_FLOWCONTROL),on,off)
-  GRUB_TERMINALS += serial
-endif
+GRUB_CONSOLE_CMDLINE += console=$(GRUB_SERIAL),$(CONFIG_GRUB_BAUDRATE)n8$(if $(CONFIG_GRUB_FLOWCONTROL),r,)
+GRUB_SERIAL_CONFIG := serial --unit=0 --speed=$(CONFIG_GRUB_BAUDRATE) --word=8 --parity=no --stop=1 --rtscts=$(if $(CONFIG_GRUB_FLOWCONTROL),on,off)
+GRUB_TERMINALS += serial
 
-ifneq ($(GRUB_TERMINALS),)
-  GRUB_TERMINAL_CONFIG := terminal_input $(GRUB_TERMINALS); terminal_output $(GRUB_TERMINALS)
-endif
+GRUB_TERMINAL_CONFIG := terminal_input $(GRUB_TERMINALS); terminal_output $(GRUB_TERMINALS)
 
 ROOTPART:=$(call qstrip,$(CONFIG_TARGET_ROOTFS_PARTNAME))
 ROOTPART:=$(if $(ROOTPART),$(ROOTPART),PARTUUID=$(IMG_PART_SIGNATURE)-02)


### PR DESCRIPTION
On platforms where `/dev/ttyS0` isn't the console port, allow substituting in `$(CONFIG_GRUB_SERIAL)` as `@GRUB_SERIAL@` into `/etc/inittab`.
