### PR TITLE
[23.05] ipq806x: Correct OnHub sysupgrade config logic

### DIFF
--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -81,7 +81,7 @@ platform_do_upgrade() {
 }
 
 platform_copy_config() {
-	case "${board_name}" in
+	case "$(board_name)" in
 	asus,onhub |\
 	tplink,onhub)
 		emmc_copy_config


### PR DESCRIPTION
Cherry-pick commit 7b78a19e6a16f5c05bfc6d7925b9981048c508d7 to fix issue #13409 on 23.05 release.