### PR TITLE
mvebu: eDPU: add support for version with external switch

### DIFF
--- a/package/boot/uboot-mvebu/patches/0001-arm-mvebu-Espressobin-move-FDT-fixup-into-a-separate.patch
+++ b/package/boot/uboot-mvebu/patches/0001-arm-mvebu-Espressobin-move-FDT-fixup-into-a-separate.patch
@@ -1,0 +1,54 @@
+From 8621f6d22a9589651c6f25742294dd19a26db430 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robert.marko@sartura.hr>
+Date: Thu, 3 Aug 2023 13:34:13 +0200
+Subject: [PATCH 1/3] arm: mvebu: Espressobin: move FDT fixup into a separate
+ function
+
+Currently, Esspresobin FDT is being fixed up directly in ft_board_setup()
+which makes it hard to add support for any other board to be fixed up.
+
+So, lets just move the FDT fixup code to a separate function and call it
+if compatible matches, there should be no functional change.
+
+Signed-off-by: Robert Marko <robert.marko@sartura.hr>
+---
+ board/Marvell/mvebu_armada-37xx/board.c | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+--- a/board/Marvell/mvebu_armada-37xx/board.c
++++ b/board/Marvell/mvebu_armada-37xx/board.c
+@@ -359,18 +359,14 @@ int last_stage_init(void)
+ #endif
+ 
+ #ifdef CONFIG_OF_BOARD_SETUP
+-int ft_board_setup(void *blob, struct bd_info *bd)
++static int espressobin_fdt_setup(void *blob)
+ {
+-#ifdef CONFIG_ENV_IS_IN_SPI_FLASH
+ 	int ret;
+ 	int spi_off;
+ 	int parts_off;
+ 	int part_off;
+ 
+ 	/* Fill SPI MTD partitions for Linux kernel on Espressobin */
+-	if (!of_machine_is_compatible("globalscale,espressobin"))
+-		return 0;
+-
+ 	spi_off = fdt_node_offset_by_compatible(blob, -1, "jedec,spi-nor");
+ 	if (spi_off < 0)
+ 		return 0;
+@@ -455,6 +451,14 @@ int ft_board_setup(void *blob, struct bd
+ 		return 0;
+ 	}
+ 
++	return 0;
++}
++
++int ft_board_setup(void *blob, struct bd_info *bd)
++{
++#ifdef CONFIG_ENV_IS_IN_SPI_FLASH
++	if (of_machine_is_compatible("globalscale,espressobin"))
++		return espressobin_fdt_setup(blob);
+ #endif
+ 	return 0;
+ }

--- a/package/boot/uboot-mvebu/patches/0002-arm-mvebu-Espressobin-move-network-setup-into-a-sepa.patch
+++ b/package/boot/uboot-mvebu/patches/0002-arm-mvebu-Espressobin-move-network-setup-into-a-sepa.patch
@@ -1,0 +1,53 @@
+From 3f8c18894a50fd45b81a807f217893f289500bc6 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robert.marko@sartura.hr>
+Date: Thu, 3 Aug 2023 14:24:31 +0200
+Subject: [PATCH 2/3] arm: mvebu: Espressobin: move network setup into a
+ separate function
+
+Currently, Esspresobin switch is being setup directly in last_stage_init()
+which makes it hard to add support for any other board to be setup.
+
+So, lets just move the switch setup code to a separate function and call it
+if compatible matches, there should be no functional change.
+
+Signed-off-by: Robert Marko <robert.marko@sartura.hr>
+---
+ board/Marvell/mvebu_armada-37xx/board.c | 16 +++++++++++-----
+ 1 file changed, 11 insertions(+), 5 deletions(-)
+
+--- a/board/Marvell/mvebu_armada-37xx/board.c
++++ b/board/Marvell/mvebu_armada-37xx/board.c
+@@ -300,15 +300,11 @@ static int mii_multi_chip_mode_write(str
+ 	return 0;
+ }
+ 
+-/* Bring-up board-specific network stuff */
+-int last_stage_init(void)
++static int espressobin_last_stage_init(void)
+ {
+ 	struct udevice *bus;
+ 	ofnode node;
+ 
+-	if (!of_machine_is_compatible("globalscale,espressobin"))
+-		return 0;
+-
+ 	node = ofnode_by_compatible(ofnode_null(), "marvell,orion-mdio");
+ 	if (!ofnode_valid(node) ||
+ 	    uclass_get_device_by_ofnode(UCLASS_MDIO, node, &bus) ||
+@@ -356,6 +352,16 @@ int last_stage_init(void)
+ 
+ 	return 0;
+ }
++
++/* Bring-up board-specific network stuff */
++int last_stage_init(void)
++{
++
++	if (of_machine_is_compatible("globalscale,espressobin"))
++		return espressobin_last_stage_init();
++
++	return 0;
++}
+ #endif
+ 
+ #ifdef CONFIG_OF_BOARD_SETUP

--- a/package/boot/uboot-mvebu/patches/0003-arm-mvebu-eDPU-support-new-board-revision.patch
+++ b/package/boot/uboot-mvebu/patches/0003-arm-mvebu-eDPU-support-new-board-revision.patch
@@ -1,0 +1,297 @@
+From 83c00ee665b8dde813458b2b07cf97ce8409248d Mon Sep 17 00:00:00 2001
+From: Robert Marko <robert.marko@sartura.hr>
+Date: Fri, 4 Aug 2023 22:39:06 +0200
+Subject: [PATCH 3/3] arm: mvebu: eDPU: support new board revision
+
+There is a new eDPU revision that uses Marvell 88E6361 switch onboard.
+We can rely on detecting the switch to enable and fixup the Linux DTS
+so a single DTS can be used.
+
+There is currently no support for the 88E6361 switch and thus no working
+networking in U-Boot, so we disable both ports.
+
+Signed-off-by: Robert Marko <robert.marko@sartura.hr>
+---
+ arch/arm/dts/armada-3720-eDPU-u-boot.dtsi |  13 ++-
+ arch/arm/dts/armada-3720-eDPU.dts         |  47 ++++++++
+ board/Marvell/mvebu_armada-37xx/board.c   | 125 ++++++++++++++++++++++
+ configs/eDPU_defconfig                    |   2 +
+ 4 files changed, 182 insertions(+), 5 deletions(-)
+
+--- a/arch/arm/dts/armada-3720-eDPU-u-boot.dtsi
++++ b/arch/arm/dts/armada-3720-eDPU-u-boot.dtsi
+@@ -32,14 +32,17 @@
+ 	bootph-all;
+ };
+ 
+-&eth0 {
+-	/* G.hn does not work without additional configuration */
+-	status = "disabled";
+-};
+-
+ &eth1 {
+ 	fixed-link {
+ 		speed = <1000>;
+ 		full-duplex;
+ 	};
+ };
++
++/*
++ * eDPU v2 has a MV88E6361 switch on the MDIO bus and U-boot is used
++ * to patch the Linux DTS if its found so enable MDIO by default.
++ */
++&mdio {
++	status = "okay";
++};
+--- a/arch/arm/dts/armada-3720-eDPU.dts
++++ b/arch/arm/dts/armada-3720-eDPU.dts
+@@ -12,3 +12,50 @@
+ &eth0 {
+ 	phy-mode = "2500base-x";
+ };
++
++/*
++ * External MV88E6361 switch is only available on v2 of the board.
++ * U-Boot will enable the MDIO bus and switch nodes.
++ */
++&mdio {
++	status = "disabled";
++	pinctrl-names = "default";
++	pinctrl-0 = <&smi_pins>;
++
++	/* Actual device is MV88E6361 */
++	switch: switch@0 {
++		compatible = "marvell,mv88e6190";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		reg = <0>;
++		status = "disabled";
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++				label = "cpu";
++				phy-mode = "2500base-x";
++				managed = "in-band-status";
++				ethernet = <&eth0>;
++			};
++
++			port@9 {
++				reg = <9>;
++				label = "downlink";
++				phy-mode = "2500base-x";
++				managed = "in-band-status";
++			};
++
++			port@a {
++				reg = <10>;
++				label = "uplink";
++				phy-mode = "2500base-x";
++				managed = "in-band-status";
++				sfp = <&sfp_eth1>;
++			};
++		};
++	};
++};
+--- a/board/Marvell/mvebu_armada-37xx/board.c
++++ b/board/Marvell/mvebu_armada-37xx/board.c
+@@ -13,6 +13,7 @@
+ #include <mmc.h>
+ #include <miiphy.h>
+ #include <phy.h>
++#include <fdt_support.h>
+ #include <asm/global_data.h>
+ #include <asm/io.h>
+ #include <asm/arch/cpu.h>
+@@ -49,6 +50,7 @@ DECLARE_GLOBAL_DATA_PTR;
+ /* Single-chip mode */
+ /* Switch Port Registers */
+ #define MVEBU_SW_LINK_CTRL_REG		(1)
++#define MVEBU_SW_PORT_SWITCH_ID		(3)
+ #define MVEBU_SW_PORT_CTRL_REG		(4)
+ #define MVEBU_SW_PORT_BASE_VLAN		(6)
+ 
+@@ -56,6 +58,8 @@ DECLARE_GLOBAL_DATA_PTR;
+ #define MVEBU_G2_SMI_PHY_CMD_REG	(24)
+ #define MVEBU_G2_SMI_PHY_DATA_REG	(25)
+ 
++#define SWITCH_88E6361_PRODUCT_NUMBER	0x2610
++
+ /*
+  * Memory Controller Registers
+  *
+@@ -72,6 +76,27 @@ DECLARE_GLOBAL_DATA_PTR;
+ #define A3700_MC_CTRL2_SDRAM_TYPE_DDR3	2
+ #define A3700_MC_CTRL2_SDRAM_TYPE_DDR4	3
+ 
++static bool is_edpu_plus(void)
++{
++	struct udevice *bus;
++	ofnode node;
++	int val;
++
++	node = ofnode_by_compatible(ofnode_null(), "marvell,orion-mdio");
++	if (!ofnode_valid(node) ||
++	    uclass_get_device_by_ofnode(UCLASS_MDIO, node, &bus) ||
++	    device_probe(bus)) {
++		printf("Cannot find MDIO bus\n");
++		return -ENODEV;
++	}
++
++	val = dm_mdio_read(bus, 0x0, MDIO_DEVAD_NONE, MVEBU_SW_PORT_SWITCH_ID);
++	if (val == SWITCH_88E6361_PRODUCT_NUMBER)
++		return true;
++	else
++		return false;
++}
++
+ int board_early_init_f(void)
+ {
+ 	return 0;
+@@ -353,6 +378,41 @@ static int espressobin_last_stage_init(v
+ 	return 0;
+ }
+ 
++static int edpu_plus_last_stage_init(void)
++{
++	struct udevice *dev;
++	int ret;
++
++	if (is_edpu_plus()) {
++		ret = uclass_get_device_by_name(UCLASS_ETH,
++						"ethernet@40000",
++						&dev);
++		if (!ret) {
++			device_remove(dev, DM_REMOVE_NORMAL);
++			device_unbind(dev);
++		}
++
++		/* Currently no networking support on the eDPU+ board */
++		ret = uclass_get_device_by_name(UCLASS_ETH,
++						"ethernet@30000",
++						&dev);
++		if (!ret) {
++			device_remove(dev, DM_REMOVE_NORMAL);
++			device_unbind(dev);
++		}
++	} else {
++		ret = uclass_get_device_by_name(UCLASS_ETH,
++						"ethernet@30000",
++						&dev);
++		if (!ret) {
++			device_remove(dev, DM_REMOVE_NORMAL);
++			device_unbind(dev);
++		}
++	}
++
++	return 0;
++}
++
+ /* Bring-up board-specific network stuff */
+ int last_stage_init(void)
+ {
+@@ -360,6 +420,9 @@ int last_stage_init(void)
+ 	if (of_machine_is_compatible("globalscale,espressobin"))
+ 		return espressobin_last_stage_init();
+ 
++	if (of_machine_is_compatible("methode,edpu"))
++		return edpu_plus_last_stage_init();
++
+ 	return 0;
+ }
+ #endif
+@@ -460,12 +523,74 @@ static int espressobin_fdt_setup(void *b
+ 	return 0;
+ }
+ 
++static int edpu_plus_fdt_setup(void *blob)
++{
++	const char *ports[] = { "downlink", "uplink" };
++	uint8_t mac[ETH_ALEN];
++	const char *path;
++	int i, ret;
++
++	if (is_edpu_plus()) {
++		ret = fdt_set_status_by_compatible(blob,
++						   "marvell,orion-mdio",
++						   FDT_STATUS_OKAY);
++		if (ret)
++			printf("Failed to enable MDIO!\n");
++
++		ret = fdt_set_status_by_alias(blob,
++					      "ethernet1",
++					      FDT_STATUS_DISABLED);
++		if (ret)
++			printf("Failed to disable ethernet1!\n");
++
++		path = fdt_get_alias(blob, "ethernet0");
++		if (path)
++			do_fixup_by_path_string(blob, path, "phy-mode", "2500base-x");
++		else
++			printf("Failed to update ethernet0 phy-mode to 2500base-x!\n");
++
++		ret = fdt_set_status_by_compatible(blob,
++						   "marvell,mv88e6190",
++						   FDT_STATUS_OKAY);
++		if (ret)
++			printf("Failed to enable MV88E6361!\n");
++
++		/*
++		 * MAC-s for Uplink and Downlink ports are stored under
++		 * non standard variable names, so lets manually fixup the
++		 * switch port nodes to have the desired MAC-s.
++		 */
++		for (i = 0; i < 2; i++) {
++			if (eth_env_get_enetaddr(ports[i], mac)) {
++				do_fixup_by_prop(blob,
++						 "label",
++						 ports[i],
++						 strlen(ports[i]) + 1,
++						 "mac-address",
++						 mac, ARP_HLEN, 1);
++
++				do_fixup_by_prop(blob,
++						 "label",
++						 ports[i],
++						 strlen(ports[i]) + 1,
++						 "local-mac-address",
++						 mac, ARP_HLEN, 1);
++			}
++		}
++	}
++
++	return 0;
++}
++
+ int ft_board_setup(void *blob, struct bd_info *bd)
+ {
+ #ifdef CONFIG_ENV_IS_IN_SPI_FLASH
+ 	if (of_machine_is_compatible("globalscale,espressobin"))
+ 		return espressobin_fdt_setup(blob);
+ #endif
++	if (of_machine_is_compatible("methode,edpu"))
++		return edpu_plus_fdt_setup(blob);
++
+ 	return 0;
+ }
+ #endif
+--- a/configs/eDPU_defconfig
++++ b/configs/eDPU_defconfig
+@@ -17,12 +17,14 @@ CONFIG_DEBUG_UART=y
+ # CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
+ CONFIG_FIT=y
+ CONFIG_FIT_VERBOSE=y
++CONFIG_OF_BOARD_SETUP=y
+ CONFIG_DISTRO_DEFAULTS=y
+ CONFIG_USE_PREBOOT=y
+ # CONFIG_DISPLAY_CPUINFO is not set
+ # CONFIG_DISPLAY_BOARDINFO is not set
+ CONFIG_DISPLAY_BOARDINFO_LATE=y
+ CONFIG_BOARD_EARLY_INIT_F=y
++CONFIG_LAST_STAGE_INIT=y
+ CONFIG_SYS_MAXARGS=32
+ CONFIG_SYS_PBSIZE=1048
+ # CONFIG_CMD_ELF is not set

--- a/target/linux/generic/backport-5.15/893-v6.5-01-net-dsa-mv88e6xxx-pass-directly-chip-structure-to-mv.patch
+++ b/target/linux/generic/backport-5.15/893-v6.5-01-net-dsa-mv88e6xxx-pass-directly-chip-structure-to-mv.patch
@@ -1,0 +1,46 @@
+From 19f291d8a65cd19e7595006c7872cd95aa6f9e93 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexis=20Lothor=C3=A9?= <alexis.lothore@bootlin.com>
+Date: Fri, 4 Aug 2023 19:13:10 +0200
+Subject: [PATCH 893/898] net: dsa: mv88e6xxx: pass directly chip structure to
+ mv88e6xxx_phy_is_internal
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Since this function is a simple helper, we do not need to pass a full
+dsa_switch structure, we can directly pass the mv88e6xxx_chip structure.
+Doing so will allow to share this function with any other function
+not manipulating dsa_switch structure but needing info about number of
+internal phys
+
+Signed-off-by: Alexis Lothoré <alexis.lothore@bootlin.com>
+Reviewed-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -459,10 +459,8 @@ restore_link:
+ 	return err;
+ }
+ 
+-static int mv88e6xxx_phy_is_internal(struct dsa_switch *ds, int port)
++static int mv88e6xxx_phy_is_internal(struct mv88e6xxx_chip *chip, int port)
+ {
+-	struct mv88e6xxx_chip *chip = ds->priv;
+-
+ 	return port < chip->info->num_internal_phys;
+ }
+ 
+@@ -704,7 +702,7 @@ static void mv88e6xxx_mac_config(struct
+ 
+ 	mv88e6xxx_reg_lock(chip);
+ 
+-	if (mode != MLO_AN_PHY || !mv88e6xxx_phy_is_internal(ds, port)) {
++	if (mode != MLO_AN_PHY || !mv88e6xxx_phy_is_internal(chip, port)) {
+ 		/* In inband mode, the link may come up at any time while the
+ 		 * link is not forced down. Force the link down while we
+ 		 * reconfigure the interface mode.

--- a/target/linux/generic/backport-5.15/893-v6.5-02-net-dsa-mv88e6xxx-use-mv88e6xxx_phy_is_internal-in-m.patch
+++ b/target/linux/generic/backport-5.15/893-v6.5-02-net-dsa-mv88e6xxx-use-mv88e6xxx_phy_is_internal-in-m.patch
@@ -1,0 +1,31 @@
+From 03a50b4f81d9e8bcf86165d6b2ac9376d02e5df9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexis=20Lothor=C3=A9?= <alexis.lothore@bootlin.com>
+Date: Mon, 29 May 2023 10:02:42 +0200
+Subject: [PATCH 894/898] net: dsa: mv88e6xxx: use mv88e6xxx_phy_is_internal in
+ mv88e6xxx_port_ppu_updates
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Make sure to use existing helper to get internal PHYs count instead of
+redoing it manually
+
+Signed-off-by: Alexis Lothoré <alexis.lothore@bootlin.com>
+Reviewed-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -473,7 +473,7 @@ static int mv88e6xxx_port_ppu_updates(st
+ 	 * report whether the port is internal.
+ 	 */
+ 	if (chip->info->family == MV88E6XXX_FAMILY_6250)
+-		return port < chip->info->num_internal_phys;
++		return mv88e6xxx_phy_is_internal(chip, port);
+ 
+ 	err = mv88e6xxx_port_read(chip, port, MV88E6XXX_PORT_STS, &reg);
+ 	if (err) {

--- a/target/linux/generic/backport-5.15/893-v6.5-03-net-dsa-mv88e6xxx-add-field-to-specify-internal-phys.patch
+++ b/target/linux/generic/backport-5.15/893-v6.5-03-net-dsa-mv88e6xxx-add-field-to-specify-internal-phys.patch
@@ -1,0 +1,69 @@
+From 07120894b24cc3cf2318925baeaaf0893e3312e4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexis=20Lothor=C3=A9?= <alexis.lothore@bootlin.com>
+Date: Mon, 29 May 2023 10:02:43 +0200
+Subject: [PATCH 895/898] net: dsa: mv88e6xxx: add field to specify internal
+ phys layout
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+mv88e6xxx currently assumes that switch equipped with internal phys have
+those phys mapped contiguously starting from port 0 (see
+mv88e6xxx_phy_is_internal). However, some switches have internal PHYs but
+NOT starting from port 0. For example 88e6393X, 88E6193X and 88E6191X have
+integrated PHYs available on ports 1 to 8
+To properly support this offset, add a new field to allow specifying an
+internal PHYs layout. If field is not set, default layout is assumed (start
+at port 0)
+
+Signed-off-by: Alexis Lothoré <alexis.lothore@bootlin.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c    | 4 +++-
+ drivers/net/dsa/mv88e6xxx/chip.h    | 5 +++++
+ drivers/net/dsa/mv88e6xxx/global2.c | 5 ++++-
+ 3 files changed, 12 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -461,7 +461,9 @@ restore_link:
+ 
+ static int mv88e6xxx_phy_is_internal(struct mv88e6xxx_chip *chip, int port)
+ {
+-	return port < chip->info->num_internal_phys;
++	return port >= chip->info->internal_phys_offset &&
++		port < chip->info->num_internal_phys +
++			chip->info->internal_phys_offset;
+ }
+ 
+ static int mv88e6xxx_port_ppu_updates(struct mv88e6xxx_chip *chip, int port)
+--- a/drivers/net/dsa/mv88e6xxx/chip.h
++++ b/drivers/net/dsa/mv88e6xxx/chip.h
+@@ -165,6 +165,11 @@ struct mv88e6xxx_info {
+ 
+ 	/* Supports PTP */
+ 	bool ptp_support;
++
++	/* Internal PHY start index. 0 means that internal PHYs range starts at
++	 * port 0, 1 means internal PHYs range starts at port 1, etc
++	 */
++	unsigned int internal_phys_offset;
+ };
+ 
+ struct mv88e6xxx_atu_entry {
+--- a/drivers/net/dsa/mv88e6xxx/global2.c
++++ b/drivers/net/dsa/mv88e6xxx/global2.c
+@@ -1185,8 +1185,11 @@ int mv88e6xxx_g2_irq_mdio_setup(struct m
+ 				struct mii_bus *bus)
+ {
+ 	int phy, irq, err, err_phy;
++	int phy_start = chip->info->internal_phys_offset;
++	int phy_end = chip->info->internal_phys_offset +
++		      chip->info->num_internal_phys;
+ 
+-	for (phy = 0; phy < chip->info->num_internal_phys; phy++) {
++	for (phy = phy_start; phy < phy_end; phy++) {
+ 		irq = irq_find_mapping(chip->g2_irq.domain, phy);
+ 		if (irq < 0) {
+ 			err = irq;

--- a/target/linux/generic/backport-5.15/893-v6.5-04-net-dsa-mv88e6xxx-fix-88E6393X-family-internal-phys-.patch
+++ b/target/linux/generic/backport-5.15/893-v6.5-04-net-dsa-mv88e6xxx-fix-88E6393X-family-internal-phys-.patch
@@ -1,0 +1,52 @@
+From 492b06747f544c19b5ffe531a24b67858764c50e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexis=20Lothor=C3=A9?= <alexis.lothore@bootlin.com>
+Date: Mon, 29 May 2023 10:02:44 +0200
+Subject: [PATCH 896/898] net: dsa: mv88e6xxx: fix 88E6393X family internal
+ phys layout
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+88E6393X/88E6193X/88E6191X switches have in fact 8 internal PHYs, but those
+are not present starting at port 0: supported ports go from 1 to 8
+
+Signed-off-by: Alexis Lothoré <alexis.lothore@bootlin.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -5370,7 +5370,8 @@ static const struct mv88e6xxx_info mv88e
+ 		.name = "Marvell 88E6191X",
+ 		.num_databases = 4096,
+ 		.num_ports = 11,	/* 10 + Z80 */
+-		.num_internal_phys = 9,
++		.num_internal_phys = 8,
++		.internal_phys_offset = 1,
+ 		.max_vid = 8191,
+ 		.port_base_addr = 0x0,
+ 		.phy_base_addr = 0x0,
+@@ -5392,7 +5393,8 @@ static const struct mv88e6xxx_info mv88e
+ 		.name = "Marvell 88E6193X",
+ 		.num_databases = 4096,
+ 		.num_ports = 11,	/* 10 + Z80 */
+-		.num_internal_phys = 9,
++		.num_internal_phys = 8,
++		.internal_phys_offset = 1,
+ 		.max_vid = 8191,
+ 		.port_base_addr = 0x0,
+ 		.phy_base_addr = 0x0,
+@@ -5702,7 +5704,8 @@ static const struct mv88e6xxx_info mv88e
+ 		.name = "Marvell 88E6393X",
+ 		.num_databases = 4096,
+ 		.num_ports = 11,	/* 10 + Z80 */
+-		.num_internal_phys = 9,
++		.num_internal_phys = 8,
++		.internal_phys_offset = 1,
+ 		.max_vid = 8191,
+ 		.port_base_addr = 0x0,
+ 		.phy_base_addr = 0x0,

--- a/target/linux/generic/backport-5.15/893-v6.5-05-net-dsa-mv88e6xxx-pass-mv88e6xxx_chip-structure-to-p.patch
+++ b/target/linux/generic/backport-5.15/893-v6.5-05-net-dsa-mv88e6xxx-pass-mv88e6xxx_chip-structure-to-p.patch
@@ -1,0 +1,113 @@
+From 68690045f8e220826517c0d6f9388ffc1faa57ea Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexis=20Lothor=C3=A9?= <alexis.lothore@bootlin.com>
+Date: Mon, 29 May 2023 10:02:45 +0200
+Subject: [PATCH 897/898] net: dsa: mv88e6xxx: pass mv88e6xxx_chip structure to
+ port_max_speed_mode
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Some switches families have minor differences on supported link speed for
+ports. Instead of redefining a new port_max_speed_mode for each different
+configuration, allow to pass mv88e6xxx_chip structure to allow
+differentiating those chips by known chip id
+
+Signed-off-by: Alexis Lothoré <alexis.lothore@bootlin.com>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+Update one more instance of port_max_speed_mode that 5.15 has.
+[Robert Marko]
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c |  2 +-
+ drivers/net/dsa/mv88e6xxx/chip.h |  3 ++-
+ drivers/net/dsa/mv88e6xxx/port.c | 12 ++++++++----
+ drivers/net/dsa/mv88e6xxx/port.h | 12 ++++++++----
+ 4 files changed, 19 insertions(+), 10 deletions(-)
+
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -443,7 +443,7 @@ static int mv88e6xxx_port_setup_mac(stru
+ 	}
+ 
+ 	if (speed == SPEED_MAX && chip->info->ops->port_max_speed_mode)
+-		mode = chip->info->ops->port_max_speed_mode(port);
++		mode = chip->info->ops->port_max_speed_mode(chip, port);
+ 
+ 	if (chip->info->ops->port_set_pause) {
+ 		err = chip->info->ops->port_set_pause(chip, port, pause);
+--- a/drivers/net/dsa/mv88e6xxx/chip.h
++++ b/drivers/net/dsa/mv88e6xxx/chip.h
+@@ -485,7 +485,8 @@ struct mv88e6xxx_ops {
+ 				     int speed, int duplex);
+ 
+ 	/* What interface mode should be used for maximum speed? */
+-	phy_interface_t (*port_max_speed_mode)(int port);
++	phy_interface_t (*port_max_speed_mode)(struct mv88e6xxx_chip *chip,
++					       int port);
+ 
+ 	int (*port_tag_remap)(struct mv88e6xxx_chip *chip, int port);
+ 
+--- a/drivers/net/dsa/mv88e6xxx/port.c
++++ b/drivers/net/dsa/mv88e6xxx/port.c
+@@ -357,7 +357,8 @@ int mv88e6341_port_set_speed_duplex(stru
+ 					       duplex);
+ }
+ 
+-phy_interface_t mv88e6341_port_max_speed_mode(int port)
++phy_interface_t mv88e6341_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					      int port)
+ {
+ 	if (port == 5)
+ 		return PHY_INTERFACE_MODE_2500BASEX;
+@@ -402,7 +403,8 @@ int mv88e6390_port_set_speed_duplex(stru
+ 					       duplex);
+ }
+ 
+-phy_interface_t mv88e6390_port_max_speed_mode(int port)
++phy_interface_t mv88e6390_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					      int port)
+ {
+ 	if (port == 9 || port == 10)
+ 		return PHY_INTERFACE_MODE_2500BASEX;
+@@ -427,7 +429,8 @@ int mv88e6390x_port_set_speed_duplex(str
+ 					       duplex);
+ }
+ 
+-phy_interface_t mv88e6390x_port_max_speed_mode(int port)
++phy_interface_t mv88e6390x_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					       int port)
+ {
+ 	if (port == 9 || port == 10)
+ 		return PHY_INTERFACE_MODE_XAUI;
+@@ -527,7 +530,8 @@ int mv88e6393x_port_set_speed_duplex(str
+ 	return 0;
+ }
+ 
+-phy_interface_t mv88e6393x_port_max_speed_mode(int port)
++phy_interface_t mv88e6393x_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					       int port)
+ {
+ 	if (port == 0 || port == 9 || port == 10)
+ 		return PHY_INTERFACE_MODE_10GBASER;
+--- a/drivers/net/dsa/mv88e6xxx/port.h
++++ b/drivers/net/dsa/mv88e6xxx/port.h
+@@ -350,10 +350,14 @@ int mv88e6390x_port_set_speed_duplex(str
+ int mv88e6393x_port_set_speed_duplex(struct mv88e6xxx_chip *chip, int port,
+ 				     int speed, int duplex);
+ 
+-phy_interface_t mv88e6341_port_max_speed_mode(int port);
+-phy_interface_t mv88e6390_port_max_speed_mode(int port);
+-phy_interface_t mv88e6390x_port_max_speed_mode(int port);
+-phy_interface_t mv88e6393x_port_max_speed_mode(int port);
++phy_interface_t mv88e6341_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					      int port);
++phy_interface_t mv88e6390_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					      int port);
++phy_interface_t mv88e6390x_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					       int port);
++phy_interface_t mv88e6393x_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					       int port);
+ 
+ int mv88e6xxx_port_set_state(struct mv88e6xxx_chip *chip, int port, u8 state);
+ 

--- a/target/linux/generic/backport-5.15/893-v6.5-06-net-dsa-mv88e6xxx-enable-support-for-88E6361-switch.patch
+++ b/target/linux/generic/backport-5.15/893-v6.5-06-net-dsa-mv88e6xxx-enable-support-for-88E6361-switch.patch
@@ -1,0 +1,165 @@
+From f318a015330a11befd8c69336efc6284e240f535 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexis=20Lothor=C3=A9?= <alexis.lothore@bootlin.com>
+Date: Mon, 29 May 2023 10:02:46 +0200
+Subject: [PATCH 898/898] net: dsa: mv88e6xxx: enable support for 88E6361
+ switch
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Marvell 88E6361 is an 8-port switch derived from the
+88E6393X/88E9193X/88E6191X switches family. It can benefit from the
+existing mv88e6xxx driver by simply adding the proper switch description in
+the driver. Main differences with other switches from this
+family are:
+- 8 ports exposed (instead of 11): ports 1, 2 and 8 not available
+- No 5GBase-x nor SFI/USXGMII support
+
+Signed-off-by: Alexis Lothoré <alexis.lothore@bootlin.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+Adapt to 5.15 since we dont have phylink_get_caps yet.
+So, update the old mv88e6393x_phylink_validate instead.
+Remove max_sid since 5.15 driver does not support it yet.
+[Robert Marko]
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c | 49 +++++++++++++++++++++++++++++++-
+ drivers/net/dsa/mv88e6xxx/chip.h |  3 +-
+ drivers/net/dsa/mv88e6xxx/port.c | 14 +++++++--
+ drivers/net/dsa/mv88e6xxx/port.h |  1 +
+ 4 files changed, 62 insertions(+), 5 deletions(-)
+
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -648,6 +648,8 @@ static void mv88e6393x_phylink_validate(
+ {
+ 	bool is_6191x =
+ 		chip->info->prod_num == MV88E6XXX_PORT_SWITCH_ID_PROD_6191X;
++	bool is_6361 =
++		chip->info->prod_num == MV88E6XXX_PORT_SWITCH_ID_PROD_6361;
+ 
+ 	if (((port == 0 || port == 9) && !is_6191x) || port == 10) {
+ 		phylink_set(mask, 10000baseT_Full);
+@@ -662,8 +664,28 @@ static void mv88e6393x_phylink_validate(
+ 		phylink_set(mask, 2500baseT_Full);
+ 	}
+ 
++	if (port == 0 || port == 9 || port == 10) {
++		phylink_set(mask, 1000baseX_Full);
++
++		/* 6191X supports >1G modes only on port 10 */
++		if (!is_6191x || port == 10) {
++			phylink_set(mask, 2500baseX_Full);
++			phylink_set(mask, 2500baseT_Full);
++
++			if (!is_6361) {
++				phylink_set(mask, 10000baseT_Full);
++				phylink_set(mask, 10000baseKR_Full);
++				phylink_set(mask, 10000baseCR_Full);
++				phylink_set(mask, 10000baseSR_Full);
++				phylink_set(mask, 10000baseLR_Full);
++				phylink_set(mask, 10000baseLRM_Full);
++				phylink_set(mask, 10000baseER_Full);
++				phylink_set(mask, 5000baseT_Full);
++			}
++		}
++	}
++
+ 	phylink_set(mask, 1000baseT_Full);
+-	phylink_set(mask, 1000baseX_Full);
+ 
+ 	mv88e6065_phylink_validate(chip, port, mask, state);
+ }
+@@ -5649,6 +5671,31 @@ static const struct mv88e6xxx_info mv88e
+ 		.ptp_support = true,
+ 		.ops = &mv88e6352_ops,
+ 	},
++	[MV88E6361] = {
++		.prod_num = MV88E6XXX_PORT_SWITCH_ID_PROD_6361,
++		.family = MV88E6XXX_FAMILY_6393,
++		.name = "Marvell 88E6361",
++		.num_databases = 4096,
++		.num_macs = 16384,
++		.num_ports = 11,
++		/* Ports 1, 2 and 8 are not routed */
++		.invalid_port_mask = BIT(1) | BIT(2) | BIT(8),
++		.num_internal_phys = 5,
++		.internal_phys_offset = 3,
++		.max_vid = 4095,
++		.port_base_addr = 0x0,
++		.phy_base_addr = 0x0,
++		.global1_addr = 0x1b,
++		.global2_addr = 0x1c,
++		.age_time_coeff = 3750,
++		.g1_irqs = 10,
++		.g2_irqs = 14,
++		.atu_move_port_mask = 0x1f,
++		.pvt = true,
++		.multi_chip = true,
++		.ptp_support = true,
++		.ops = &mv88e6393x_ops,
++	},
+ 	[MV88E6390] = {
+ 		.prod_num = MV88E6XXX_PORT_SWITCH_ID_PROD_6390,
+ 		.family = MV88E6XXX_FAMILY_6390,
+--- a/drivers/net/dsa/mv88e6xxx/chip.h
++++ b/drivers/net/dsa/mv88e6xxx/chip.h
+@@ -81,6 +81,7 @@ enum mv88e6xxx_model {
+ 	MV88E6350,
+ 	MV88E6351,
+ 	MV88E6352,
++	MV88E6361,
+ 	MV88E6390,
+ 	MV88E6390X,
+ 	MV88E6393X,
+@@ -99,7 +100,7 @@ enum mv88e6xxx_family {
+ 	MV88E6XXX_FAMILY_6351,	/* 6171 6175 6350 6351 */
+ 	MV88E6XXX_FAMILY_6352,	/* 6172 6176 6240 6352 */
+ 	MV88E6XXX_FAMILY_6390,  /* 6190 6190X 6191 6290 6390 6390X */
+-	MV88E6XXX_FAMILY_6393,	/* 6191X 6193X 6393X */
++	MV88E6XXX_FAMILY_6393,	/* 6191X 6193X 6361 6393X */
+ };
+ 
+ /**
+--- a/drivers/net/dsa/mv88e6xxx/port.c
++++ b/drivers/net/dsa/mv88e6xxx/port.c
+@@ -451,6 +451,10 @@ int mv88e6393x_port_set_speed_duplex(str
+ 	if (speed == SPEED_MAX)
+ 		speed = (port > 0 && port < 9) ? 1000 : 10000;
+ 
++	if (chip->info->prod_num == MV88E6XXX_PORT_SWITCH_ID_PROD_6361 &&
++	    speed > 2500)
++		return -EOPNOTSUPP;
++
+ 	if (speed == 200 && port != 0)
+ 		return -EOPNOTSUPP;
+ 
+@@ -533,10 +537,14 @@ int mv88e6393x_port_set_speed_duplex(str
+ phy_interface_t mv88e6393x_port_max_speed_mode(struct mv88e6xxx_chip *chip,
+ 					       int port)
+ {
+-	if (port == 0 || port == 9 || port == 10)
+-		return PHY_INTERFACE_MODE_10GBASER;
+ 
+-	return PHY_INTERFACE_MODE_NA;
++	if (port != 0 && port != 9 && port != 10)
++		return PHY_INTERFACE_MODE_NA;
++
++	if (chip->info->prod_num == MV88E6XXX_PORT_SWITCH_ID_PROD_6361)
++		return PHY_INTERFACE_MODE_2500BASEX;
++
++	return PHY_INTERFACE_MODE_10GBASER;
+ }
+ 
+ static int mv88e6xxx_port_set_cmode(struct mv88e6xxx_chip *chip, int port,
+--- a/drivers/net/dsa/mv88e6xxx/port.h
++++ b/drivers/net/dsa/mv88e6xxx/port.h
+@@ -128,6 +128,7 @@
+ #define MV88E6XXX_PORT_SWITCH_ID_PROD_6220	0x2200
+ #define MV88E6XXX_PORT_SWITCH_ID_PROD_6240	0x2400
+ #define MV88E6XXX_PORT_SWITCH_ID_PROD_6250	0x2500
++#define MV88E6XXX_PORT_SWITCH_ID_PROD_6361	0x2610
+ #define MV88E6XXX_PORT_SWITCH_ID_PROD_6290	0x2900
+ #define MV88E6XXX_PORT_SWITCH_ID_PROD_6321	0x3100
+ #define MV88E6XXX_PORT_SWITCH_ID_PROD_6141	0x3400

--- a/target/linux/generic/backport-6.1/807-v6.5-01-net-dsa-mv88e6xxx-pass-directly-chip-structure-to-mv.patch
+++ b/target/linux/generic/backport-6.1/807-v6.5-01-net-dsa-mv88e6xxx-pass-directly-chip-structure-to-mv.patch
@@ -1,0 +1,64 @@
+From 4f86eb098e18fd0f032877dfa1a7e8c1503ca409 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexis=20Lothor=C3=A9?= <alexis.lothore@bootlin.com>
+Date: Mon, 29 May 2023 10:02:41 +0200
+Subject: [PATCH 1/6] net: dsa: mv88e6xxx: pass directly chip structure to
+ mv88e6xxx_phy_is_internal
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Since this function is a simple helper, we do not need to pass a full
+dsa_switch structure, we can directly pass the mv88e6xxx_chip structure.
+Doing so will allow to share this function with any other function
+not manipulating dsa_switch structure but needing info about number of
+internal phys
+
+Signed-off-by: Alexis Lothoré <alexis.lothore@bootlin.com>
+Reviewed-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c | 10 ++++------
+ 1 file changed, 4 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -470,10 +470,8 @@ restore_link:
+ 	return err;
+ }
+ 
+-static int mv88e6xxx_phy_is_internal(struct dsa_switch *ds, int port)
++static int mv88e6xxx_phy_is_internal(struct mv88e6xxx_chip *chip, int port)
+ {
+-	struct mv88e6xxx_chip *chip = ds->priv;
+-
+ 	return port < chip->info->num_internal_phys;
+ }
+ 
+@@ -591,7 +589,7 @@ static void mv88e6095_phylink_get_caps(s
+ 
+ 	config->mac_capabilities = MAC_SYM_PAUSE | MAC_10 | MAC_100;
+ 
+-	if (mv88e6xxx_phy_is_internal(chip->ds, port)) {
++	if (mv88e6xxx_phy_is_internal(chip, port)) {
+ 		__set_bit(PHY_INTERFACE_MODE_MII, config->supported_interfaces);
+ 	} else {
+ 		if (cmode < ARRAY_SIZE(mv88e6185_phy_interface_modes) &&
+@@ -839,7 +837,7 @@ static void mv88e6xxx_get_caps(struct ds
+ 	chip->info->ops->phylink_get_caps(chip, port, config);
+ 	mv88e6xxx_reg_unlock(chip);
+ 
+-	if (mv88e6xxx_phy_is_internal(ds, port)) {
++	if (mv88e6xxx_phy_is_internal(chip, port)) {
+ 		__set_bit(PHY_INTERFACE_MODE_INTERNAL,
+ 			  config->supported_interfaces);
+ 		/* Internal ports with no phy-mode need GMII for PHYLIB */
+@@ -860,7 +858,7 @@ static void mv88e6xxx_mac_config(struct
+ 
+ 	mv88e6xxx_reg_lock(chip);
+ 
+-	if (mode != MLO_AN_PHY || !mv88e6xxx_phy_is_internal(ds, port)) {
++	if (mode != MLO_AN_PHY || !mv88e6xxx_phy_is_internal(chip, port)) {
+ 		/* In inband mode, the link may come up at any time while the
+ 		 * link is not forced down. Force the link down while we
+ 		 * reconfigure the interface mode.

--- a/target/linux/generic/backport-6.1/807-v6.5-02-net-dsa-mv88e6xxx-use-mv88e6xxx_phy_is_internal-in-m.patch
+++ b/target/linux/generic/backport-6.1/807-v6.5-02-net-dsa-mv88e6xxx-use-mv88e6xxx_phy_is_internal-in-m.patch
@@ -1,0 +1,31 @@
+From 73cbfad9296eed004992806e056db5b48583ca41 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexis=20Lothor=C3=A9?= <alexis.lothore@bootlin.com>
+Date: Mon, 29 May 2023 10:02:42 +0200
+Subject: [PATCH 2/6] net: dsa: mv88e6xxx: use mv88e6xxx_phy_is_internal in
+ mv88e6xxx_port_ppu_updates
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Make sure to use existing helper to get internal PHYs count instead of
+redoing it manually
+
+Signed-off-by: Alexis Lothoré <alexis.lothore@bootlin.com>
+Reviewed-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -484,7 +484,7 @@ static int mv88e6xxx_port_ppu_updates(st
+ 	 * report whether the port is internal.
+ 	 */
+ 	if (chip->info->family == MV88E6XXX_FAMILY_6250)
+-		return port < chip->info->num_internal_phys;
++		return mv88e6xxx_phy_is_internal(chip, port);
+ 
+ 	err = mv88e6xxx_port_read(chip, port, MV88E6XXX_PORT_STS, &reg);
+ 	if (err) {

--- a/target/linux/generic/backport-6.1/807-v6.5-03-net-dsa-mv88e6xxx-add-field-to-specify-internal-phys.patch
+++ b/target/linux/generic/backport-6.1/807-v6.5-03-net-dsa-mv88e6xxx-add-field-to-specify-internal-phys.patch
@@ -1,0 +1,69 @@
+From 1414d30660d201f515a9d877571ceea9ca190b6a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexis=20Lothor=C3=A9?= <alexis.lothore@bootlin.com>
+Date: Mon, 29 May 2023 10:02:43 +0200
+Subject: [PATCH 3/6] net: dsa: mv88e6xxx: add field to specify internal phys
+ layout
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+mv88e6xxx currently assumes that switch equipped with internal phys have
+those phys mapped contiguously starting from port 0 (see
+mv88e6xxx_phy_is_internal). However, some switches have internal PHYs but
+NOT starting from port 0. For example 88e6393X, 88E6193X and 88E6191X have
+integrated PHYs available on ports 1 to 8
+To properly support this offset, add a new field to allow specifying an
+internal PHYs layout. If field is not set, default layout is assumed (start
+at port 0)
+
+Signed-off-by: Alexis Lothoré <alexis.lothore@bootlin.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c    | 4 +++-
+ drivers/net/dsa/mv88e6xxx/chip.h    | 5 +++++
+ drivers/net/dsa/mv88e6xxx/global2.c | 5 ++++-
+ 3 files changed, 12 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -472,7 +472,9 @@ restore_link:
+ 
+ static int mv88e6xxx_phy_is_internal(struct mv88e6xxx_chip *chip, int port)
+ {
+-	return port < chip->info->num_internal_phys;
++	return port >= chip->info->internal_phys_offset &&
++		port < chip->info->num_internal_phys +
++			chip->info->internal_phys_offset;
+ }
+ 
+ static int mv88e6xxx_port_ppu_updates(struct mv88e6xxx_chip *chip, int port)
+--- a/drivers/net/dsa/mv88e6xxx/chip.h
++++ b/drivers/net/dsa/mv88e6xxx/chip.h
+@@ -167,6 +167,11 @@ struct mv88e6xxx_info {
+ 
+ 	/* Supports PTP */
+ 	bool ptp_support;
++
++	/* Internal PHY start index. 0 means that internal PHYs range starts at
++	 * port 0, 1 means internal PHYs range starts at port 1, etc
++	 */
++	unsigned int internal_phys_offset;
+ };
+ 
+ struct mv88e6xxx_atu_entry {
+--- a/drivers/net/dsa/mv88e6xxx/global2.c
++++ b/drivers/net/dsa/mv88e6xxx/global2.c
+@@ -1185,8 +1185,11 @@ int mv88e6xxx_g2_irq_mdio_setup(struct m
+ 				struct mii_bus *bus)
+ {
+ 	int phy, irq, err, err_phy;
++	int phy_start = chip->info->internal_phys_offset;
++	int phy_end = chip->info->internal_phys_offset +
++		      chip->info->num_internal_phys;
+ 
+-	for (phy = 0; phy < chip->info->num_internal_phys; phy++) {
++	for (phy = phy_start; phy < phy_end; phy++) {
+ 		irq = irq_find_mapping(chip->g2_irq.domain, phy);
+ 		if (irq < 0) {
+ 			err = irq;

--- a/target/linux/generic/backport-6.1/807-v6.5-04-net-dsa-mv88e6xxx-fix-88E6393X-family-internal-phys-.patch
+++ b/target/linux/generic/backport-6.1/807-v6.5-04-net-dsa-mv88e6xxx-fix-88E6393X-family-internal-phys-.patch
@@ -1,0 +1,52 @@
+From eb8c75f82a6711387f3b9e03e28923f3e75a761b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexis=20Lothor=C3=A9?= <alexis.lothore@bootlin.com>
+Date: Mon, 29 May 2023 10:02:44 +0200
+Subject: [PATCH 4/6] net: dsa: mv88e6xxx: fix 88E6393X family internal phys
+ layout
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+88E6393X/88E6193X/88E6191X switches have in fact 8 internal PHYs, but those
+are not present starting at port 0: supported ports go from 1 to 8
+
+Signed-off-by: Alexis Lothoré <alexis.lothore@bootlin.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -5942,7 +5942,8 @@ static const struct mv88e6xxx_info mv88e
+ 		.name = "Marvell 88E6191X",
+ 		.num_databases = 4096,
+ 		.num_ports = 11,	/* 10 + Z80 */
+-		.num_internal_phys = 9,
++		.num_internal_phys = 8,
++		.internal_phys_offset = 1,
+ 		.max_vid = 8191,
+ 		.max_sid = 63,
+ 		.port_base_addr = 0x0,
+@@ -5965,7 +5966,8 @@ static const struct mv88e6xxx_info mv88e
+ 		.name = "Marvell 88E6193X",
+ 		.num_databases = 4096,
+ 		.num_ports = 11,	/* 10 + Z80 */
+-		.num_internal_phys = 9,
++		.num_internal_phys = 8,
++		.internal_phys_offset = 1,
+ 		.max_vid = 8191,
+ 		.max_sid = 63,
+ 		.port_base_addr = 0x0,
+@@ -6284,7 +6286,8 @@ static const struct mv88e6xxx_info mv88e
+ 		.name = "Marvell 88E6393X",
+ 		.num_databases = 4096,
+ 		.num_ports = 11,	/* 10 + Z80 */
+-		.num_internal_phys = 9,
++		.num_internal_phys = 8,
++		.internal_phys_offset = 1,
+ 		.max_vid = 8191,
+ 		.max_sid = 63,
+ 		.port_base_addr = 0x0,

--- a/target/linux/generic/backport-6.1/807-v6.5-05-net-dsa-mv88e6xxx-pass-mv88e6xxx_chip-structure-to-p.patch
+++ b/target/linux/generic/backport-6.1/807-v6.5-05-net-dsa-mv88e6xxx-pass-mv88e6xxx_chip-structure-to-p.patch
@@ -1,0 +1,110 @@
+From cef945452c8468efce75ba0dc8420510a5b84af9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexis=20Lothor=C3=A9?= <alexis.lothore@bootlin.com>
+Date: Mon, 29 May 2023 10:02:45 +0200
+Subject: [PATCH 5/6] net: dsa: mv88e6xxx: pass mv88e6xxx_chip structure to
+ port_max_speed_mode
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Some switches families have minor differences on supported link speed for
+ports. Instead of redefining a new port_max_speed_mode for each different
+configuration, allow to pass mv88e6xxx_chip structure to allow
+differentiating those chips by known chip id
+
+Signed-off-by: Alexis Lothoré <alexis.lothore@bootlin.com>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c |  2 +-
+ drivers/net/dsa/mv88e6xxx/chip.h |  3 ++-
+ drivers/net/dsa/mv88e6xxx/port.c | 12 ++++++++----
+ drivers/net/dsa/mv88e6xxx/port.h | 12 ++++++++----
+ 4 files changed, 19 insertions(+), 10 deletions(-)
+
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -3326,7 +3326,7 @@ static int mv88e6xxx_setup_port(struct m
+ 		caps = pl_config.mac_capabilities;
+ 
+ 		if (chip->info->ops->port_max_speed_mode)
+-			mode = chip->info->ops->port_max_speed_mode(port);
++			mode = chip->info->ops->port_max_speed_mode(chip, port);
+ 		else
+ 			mode = PHY_INTERFACE_MODE_NA;
+ 
+--- a/drivers/net/dsa/mv88e6xxx/chip.h
++++ b/drivers/net/dsa/mv88e6xxx/chip.h
+@@ -508,7 +508,8 @@ struct mv88e6xxx_ops {
+ 				     int speed, int duplex);
+ 
+ 	/* What interface mode should be used for maximum speed? */
+-	phy_interface_t (*port_max_speed_mode)(int port);
++	phy_interface_t (*port_max_speed_mode)(struct mv88e6xxx_chip *chip,
++					       int port);
+ 
+ 	int (*port_tag_remap)(struct mv88e6xxx_chip *chip, int port);
+ 
+--- a/drivers/net/dsa/mv88e6xxx/port.c
++++ b/drivers/net/dsa/mv88e6xxx/port.c
+@@ -342,7 +342,8 @@ int mv88e6341_port_set_speed_duplex(stru
+ 					       duplex);
+ }
+ 
+-phy_interface_t mv88e6341_port_max_speed_mode(int port)
++phy_interface_t mv88e6341_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					      int port)
+ {
+ 	if (port == 5)
+ 		return PHY_INTERFACE_MODE_2500BASEX;
+@@ -381,7 +382,8 @@ int mv88e6390_port_set_speed_duplex(stru
+ 					       duplex);
+ }
+ 
+-phy_interface_t mv88e6390_port_max_speed_mode(int port)
++phy_interface_t mv88e6390_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					      int port)
+ {
+ 	if (port == 9 || port == 10)
+ 		return PHY_INTERFACE_MODE_2500BASEX;
+@@ -403,7 +405,8 @@ int mv88e6390x_port_set_speed_duplex(str
+ 					       duplex);
+ }
+ 
+-phy_interface_t mv88e6390x_port_max_speed_mode(int port)
++phy_interface_t mv88e6390x_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					       int port)
+ {
+ 	if (port == 9 || port == 10)
+ 		return PHY_INTERFACE_MODE_XAUI;
+@@ -500,7 +503,8 @@ int mv88e6393x_port_set_speed_duplex(str
+ 	return 0;
+ }
+ 
+-phy_interface_t mv88e6393x_port_max_speed_mode(int port)
++phy_interface_t mv88e6393x_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					       int port)
+ {
+ 	if (port == 0 || port == 9 || port == 10)
+ 		return PHY_INTERFACE_MODE_10GBASER;
+--- a/drivers/net/dsa/mv88e6xxx/port.h
++++ b/drivers/net/dsa/mv88e6xxx/port.h
+@@ -359,10 +359,14 @@ int mv88e6390x_port_set_speed_duplex(str
+ int mv88e6393x_port_set_speed_duplex(struct mv88e6xxx_chip *chip, int port,
+ 				     int speed, int duplex);
+ 
+-phy_interface_t mv88e6341_port_max_speed_mode(int port);
+-phy_interface_t mv88e6390_port_max_speed_mode(int port);
+-phy_interface_t mv88e6390x_port_max_speed_mode(int port);
+-phy_interface_t mv88e6393x_port_max_speed_mode(int port);
++phy_interface_t mv88e6341_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					      int port);
++phy_interface_t mv88e6390_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					      int port);
++phy_interface_t mv88e6390x_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					       int port);
++phy_interface_t mv88e6393x_port_max_speed_mode(struct mv88e6xxx_chip *chip,
++					       int port);
+ 
+ int mv88e6xxx_port_set_state(struct mv88e6xxx_chip *chip, int port, u8 state);
+ 

--- a/target/linux/generic/backport-6.1/807-v6.5-06-net-dsa-mv88e6xxx-enable-support-for-88E6361-switch.patch
+++ b/target/linux/generic/backport-6.1/807-v6.5-06-net-dsa-mv88e6xxx-enable-support-for-88E6361-switch.patch
@@ -1,0 +1,153 @@
+From 23680321789863bab2d60af507858ce50ff9f56a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alexis=20Lothor=C3=A9?= <alexis.lothore@bootlin.com>
+Date: Mon, 29 May 2023 10:02:46 +0200
+Subject: [PATCH 6/6] net: dsa: mv88e6xxx: enable support for 88E6361 switch
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Marvell 88E6361 is an 8-port switch derived from the
+88E6393X/88E9193X/88E6191X switches family. It can benefit from the
+existing mv88e6xxx driver by simply adding the proper switch description in
+the driver. Main differences with other switches from this
+family are:
+- 8 ports exposed (instead of 11): ports 1, 2 and 8 not available
+- No 5GBase-x nor SFI/USXGMII support
+
+Signed-off-by: Alexis Lothoré <alexis.lothore@bootlin.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c | 42 ++++++++++++++++++++++++++++----
+ drivers/net/dsa/mv88e6xxx/chip.h |  3 ++-
+ drivers/net/dsa/mv88e6xxx/port.c | 14 ++++++++---
+ drivers/net/dsa/mv88e6xxx/port.h |  1 +
+ 4 files changed, 51 insertions(+), 9 deletions(-)
+
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -797,6 +797,8 @@ static void mv88e6393x_phylink_get_caps(
+ 	unsigned long *supported = config->supported_interfaces;
+ 	bool is_6191x =
+ 		chip->info->prod_num == MV88E6XXX_PORT_SWITCH_ID_PROD_6191X;
++	bool is_6361 =
++		chip->info->prod_num == MV88E6XXX_PORT_SWITCH_ID_PROD_6361;
+ 
+ 	mv88e6xxx_translate_cmode(chip->ports[port].cmode, supported);
+ 
+@@ -811,13 +813,17 @@ static void mv88e6393x_phylink_get_caps(
+ 		/* 6191X supports >1G modes only on port 10 */
+ 		if (!is_6191x || port == 10) {
+ 			__set_bit(PHY_INTERFACE_MODE_2500BASEX, supported);
+-			__set_bit(PHY_INTERFACE_MODE_5GBASER, supported);
+-			__set_bit(PHY_INTERFACE_MODE_10GBASER, supported);
++			config->mac_capabilities |= MAC_2500FD;
++
++			/* 6361 only supports up to 2500BaseX */
++			if (!is_6361) {
++				__set_bit(PHY_INTERFACE_MODE_5GBASER, supported);
++				__set_bit(PHY_INTERFACE_MODE_10GBASER, supported);
++				config->mac_capabilities |= MAC_5000FD |
++					MAC_10000FD;
++			}
+ 			/* FIXME: USXGMII is not supported yet */
+ 			/* __set_bit(PHY_INTERFACE_MODE_USXGMII, supported); */
+-
+-			config->mac_capabilities |= MAC_2500FD | MAC_5000FD |
+-				MAC_10000FD;
+ 		}
+ 	}
+ 
+@@ -6229,6 +6235,32 @@ static const struct mv88e6xxx_info mv88e
+ 		.ptp_support = true,
+ 		.ops = &mv88e6352_ops,
+ 	},
++	[MV88E6361] = {
++		.prod_num = MV88E6XXX_PORT_SWITCH_ID_PROD_6361,
++		.family = MV88E6XXX_FAMILY_6393,
++		.name = "Marvell 88E6361",
++		.num_databases = 4096,
++		.num_macs = 16384,
++		.num_ports = 11,
++		/* Ports 1, 2 and 8 are not routed */
++		.invalid_port_mask = BIT(1) | BIT(2) | BIT(8),
++		.num_internal_phys = 5,
++		.internal_phys_offset = 3,
++		.max_vid = 4095,
++		.max_sid = 63,
++		.port_base_addr = 0x0,
++		.phy_base_addr = 0x0,
++		.global1_addr = 0x1b,
++		.global2_addr = 0x1c,
++		.age_time_coeff = 3750,
++		.g1_irqs = 10,
++		.g2_irqs = 14,
++		.atu_move_port_mask = 0x1f,
++		.pvt = true,
++		.multi_chip = true,
++		.ptp_support = true,
++		.ops = &mv88e6393x_ops,
++	},
+ 	[MV88E6390] = {
+ 		.prod_num = MV88E6XXX_PORT_SWITCH_ID_PROD_6390,
+ 		.family = MV88E6XXX_FAMILY_6390,
+--- a/drivers/net/dsa/mv88e6xxx/chip.h
++++ b/drivers/net/dsa/mv88e6xxx/chip.h
+@@ -82,6 +82,7 @@ enum mv88e6xxx_model {
+ 	MV88E6350,
+ 	MV88E6351,
+ 	MV88E6352,
++	MV88E6361,
+ 	MV88E6390,
+ 	MV88E6390X,
+ 	MV88E6393X,
+@@ -100,7 +101,7 @@ enum mv88e6xxx_family {
+ 	MV88E6XXX_FAMILY_6351,	/* 6171 6175 6350 6351 */
+ 	MV88E6XXX_FAMILY_6352,	/* 6172 6176 6240 6352 */
+ 	MV88E6XXX_FAMILY_6390,  /* 6190 6190X 6191 6290 6390 6390X */
+-	MV88E6XXX_FAMILY_6393,	/* 6191X 6193X 6393X */
++	MV88E6XXX_FAMILY_6393,	/* 6191X 6193X 6361 6393X */
+ };
+ 
+ /**
+--- a/drivers/net/dsa/mv88e6xxx/port.c
++++ b/drivers/net/dsa/mv88e6xxx/port.c
+@@ -424,6 +424,10 @@ int mv88e6393x_port_set_speed_duplex(str
+ 	u16 reg, ctrl;
+ 	int err;
+ 
++	if (chip->info->prod_num == MV88E6XXX_PORT_SWITCH_ID_PROD_6361 &&
++	    speed > 2500)
++		return -EOPNOTSUPP;
++
+ 	if (speed == 200 && port != 0)
+ 		return -EOPNOTSUPP;
+ 
+@@ -506,10 +510,14 @@ int mv88e6393x_port_set_speed_duplex(str
+ phy_interface_t mv88e6393x_port_max_speed_mode(struct mv88e6xxx_chip *chip,
+ 					       int port)
+ {
+-	if (port == 0 || port == 9 || port == 10)
+-		return PHY_INTERFACE_MODE_10GBASER;
+ 
+-	return PHY_INTERFACE_MODE_NA;
++	if (port != 0 && port != 9 && port != 10)
++		return PHY_INTERFACE_MODE_NA;
++
++	if (chip->info->prod_num == MV88E6XXX_PORT_SWITCH_ID_PROD_6361)
++		return PHY_INTERFACE_MODE_2500BASEX;
++
++	return PHY_INTERFACE_MODE_10GBASER;
+ }
+ 
+ static int mv88e6xxx_port_set_cmode(struct mv88e6xxx_chip *chip, int port,
+--- a/drivers/net/dsa/mv88e6xxx/port.h
++++ b/drivers/net/dsa/mv88e6xxx/port.h
+@@ -133,6 +133,7 @@
+ #define MV88E6XXX_PORT_SWITCH_ID_PROD_6220	0x2200
+ #define MV88E6XXX_PORT_SWITCH_ID_PROD_6240	0x2400
+ #define MV88E6XXX_PORT_SWITCH_ID_PROD_6250	0x2500
++#define MV88E6XXX_PORT_SWITCH_ID_PROD_6361	0x2610
+ #define MV88E6XXX_PORT_SWITCH_ID_PROD_6290	0x2900
+ #define MV88E6XXX_PORT_SWITCH_ID_PROD_6321	0x3100
+ #define MV88E6XXX_PORT_SWITCH_ID_PROD_6141	0x3400

--- a/target/linux/generic/hack-5.15/711-net-dsa-mv88e6xxx-disable-ATU-violation.patch
+++ b/target/linux/generic/hack-5.15/711-net-dsa-mv88e6xxx-disable-ATU-violation.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] net/dsa/mv88e6xxx: disable ATU violation
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -2993,6 +2993,9 @@ static int mv88e6xxx_setup_port(struct m
+@@ -3015,6 +3015,9 @@ static int mv88e6xxx_setup_port(struct m
  	else
  		reg = 1 << port;
  

--- a/target/linux/generic/hack-6.1/711-net-dsa-mv88e6xxx-disable-ATU-violation.patch
+++ b/target/linux/generic/hack-6.1/711-net-dsa-mv88e6xxx-disable-ATU-violation.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] net/dsa/mv88e6xxx: disable ATU violation
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -3480,6 +3480,9 @@ static int mv88e6xxx_setup_port(struct m
+@@ -3486,6 +3486,9 @@ static int mv88e6xxx_setup_port(struct m
  	else
  		reg = 1 << port;
  

--- a/target/linux/generic/pending-5.15/768-net-dsa-mv88e6xxx-Request-assisted-learning-on-CPU-port.patch
+++ b/target/linux/generic/pending-5.15/768-net-dsa-mv88e6xxx-Request-assisted-learning-on-CPU-port.patch
@@ -17,7 +17,7 @@ Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -6341,6 +6341,7 @@ static int mv88e6xxx_register_switch(str
+@@ -6391,6 +6391,7 @@ static int mv88e6xxx_register_switch(str
  	ds->ops = &mv88e6xxx_switch_ops;
  	ds->ageing_time_min = chip->info->age_time_coeff;
  	ds->ageing_time_max = chip->info->age_time_coeff * U8_MAX;

--- a/target/linux/generic/pending-6.1/768-net-dsa-mv88e6xxx-Request-assisted-learning-on-CPU-port.patch
+++ b/target/linux/generic/pending-6.1/768-net-dsa-mv88e6xxx-Request-assisted-learning-on-CPU-port.patch
@@ -17,7 +17,7 @@ Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -6988,6 +6988,7 @@ static int mv88e6xxx_register_switch(str
+@@ -7023,6 +7023,7 @@ static int mv88e6xxx_register_switch(str
  	ds->ops = &mv88e6xxx_switch_ops;
  	ds->ageing_time_min = chip->info->age_time_coeff;
  	ds->ageing_time_max = chip->info->age_time_coeff * U8_MAX;

--- a/target/linux/mvebu/cortexa53/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/cortexa53/base-files/etc/board.d/02_network
@@ -21,9 +21,16 @@ globalscale,espressobin-ultra)
 	ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3" "wan"
 	;;
 marvell,armada-3720-db|\
-methode,udpu|\
-methode,edpu)
+methode,udpu)
 	ucidef_set_interfaces_lan_wan "eth1" "eth0"
+	;;
+methode,edpu)
+	# eDPU+ has a 88E6361 switch, so we check for it
+	if ip link | grep -q uplink; then
+	ucidef_set_interfaces_lan_wan "downlink" "uplink"
+	else
+	ucidef_set_interfaces_lan_wan "eth1" "eth0"
+	fi
 	;;
 *)
 	ucidef_set_interface_lan "eth0"

--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/armada-3720-eDPU.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/armada-3720-eDPU.dts
@@ -17,3 +17,50 @@
 &eth0 {
 	phy-mode = "1000base-x";
 };
+
+/*
+ * External MV88E6361 switch is only available on v2 of the board.
+ * U-Boot will enable the MDIO bus and switch nodes.
+ */
+&mdio {
+	status = "disabled";
+	pinctrl-names = "default";
+	pinctrl-0 = <&smi_pins>;
+
+	/* Actual device is MV88E6361 */
+	switch: switch@0 {
+		compatible = "marvell,mv88e6190";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+		status = "disabled";
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "cpu";
+				phy-mode = "2500base-x";
+				managed = "in-band-status";
+				ethernet = <&eth0>;
+			};
+
+			port@9 {
+				reg = <9>;
+				label = "downlink";
+				phy-mode = "2500base-x";
+				managed = "in-band-status";
+			};
+
+			port@a {
+				reg = <10>;
+				label = "uplink";
+				phy-mode = "2500base-x";
+				managed = "in-band-status";
+				sfp = <&sfp_eth1>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
New revision of eDPU uses an Marvell MV88E6361 switch to connect the SFP
cage and G.hn IC instead of connecting them directly to the ethernet
controllers.

The same image can be used on both versions as U-Boot will enable the
switch node and disable the unused ethernet controller.
