### PR TITLE
ipq40xx: fix image building for ZTE MF287 series

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -1162,7 +1162,7 @@ define Device/zte_mf287_common
 #	exploit for the web interface
 	IMAGES += factory.bin recovery.bin
 	IMAGE/factory.bin  := append-ubi
-	IMAGE/recovery.bin := append-squashfs4-fakeroot | sysupgrade-tar kernel=$$$$(BIN_DIR)/openwrt-$$(BOARD)$$(if $$(SUBTARGET),-$$(SUBTARGET))-$$(DEVICE_NAME)-initramfs-zImage.itb rootfs=$$$$@ | append-metadata
+	IMAGE/recovery.bin := append-squashfs4-fakeroot | sysupgrade-tar kernel=$$$$(BIN_DIR)/$$(KERNEL_INITRAMFS_IMAGE) rootfs=$$$$@ | append-metadata
 endef
 
 define Device/zte_mf287plus


### PR DESCRIPTION
For the ZTE MF287 series, a special recovery image is built. The Makefile worked fine on snapshot, but created corrupt images on the 23.05 images. By using the appropriate variable, this should be fixed.
