### PR TITLE
tools/libressl: update to version 3.7.3

### DIFF
--- a/tools/libressl/Makefile
+++ b/tools/libressl/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libressl
-PKG_VERSION:=3.7.2
-PKG_HASH:=b06aa538fefc9c6b33c4db4931a09a5f52d9d2357219afcbff7d93fe12ebf6f7
+PKG_VERSION:=3.7.3
+PKG_HASH:=7948c856a90c825bd7268b6f85674a8dcd254bae42e221781b24e3f8dc335db3
 
 PKG_CPE_ID:=cpe:/a:openbsd:libressl
 


### PR DESCRIPTION
Release notes:
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.7.3-relnotes.txt