### PR TITLE
mediatek: filogic: add support for Ubiquiti UniFi 6 Plus (U6+)

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -48,6 +48,9 @@ cetron,ct3003|\
 netgear,wax220)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;
+ubnt,unifi-6-plus)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x10000"
+	;;
 xiaomi,mi-router-wr30u-112m-nmbm|\
 xiaomi,mi-router-wr30u-stock|\
 xiaomi,redmi-router-ax6000-stock)

--- a/target/linux/mediatek/dts/mt7981a-ubnt-unifi-6-plus.dts
+++ b/target/linux/mediatek/dts/mt7981a-ubnt-unifi-6-plus.dts
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include "mt7981.dtsi"
+
+/ {
+	model = "Ubiquiti UniFi 6 Plus";
+	compatible = "ubnt,unifi-6-plus", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_white;
+		led-failsafe = &led_white;
+		led-running = &led_blue;
+		led-upgrade = &led_blue;
+		label-mac-device = &gmac1;
+	};
+
+	chosen {
+		bootargs-override = "console=ttyS0,115200n8 rootwait root=/dev/mmcblk0p7";
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_blue: dome-blue {
+			label = "blue:dome";
+			gpios = <&pio 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_white: dome-white {
+			label = "white:dome";
+			gpios = <&pio 34 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&pio {
+	spi2_flash_pins: spi2-pins {
+		mux {
+			function = "spi";
+			groups = "spi2", "spi2_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <8>;
+			bias-pull-up = <103>;
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <8>;
+			bias-pull-down = <103>;
+		};
+	};
+
+	mmc0_pins_default: mmc0-pins-default {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+
+	mmc0_pins_uhs: mmc0-pins-uhs {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+};
+
+&spi2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi2_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom: partition@00000 {
+				label = "EEPROM";
+				reg = <0x00000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_eeprom_0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_eeprom_6: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
+			};
+
+			partition@10000 {
+				label = "u-boot-env";
+				reg = <0x10000 0x80000>;
+			};
+		};
+	};
+};
+
+&mmc0 {
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc0_pins_default>;
+	pinctrl-1 = <&mmc0_pins_uhs>;
+	bus-width = <8>;
+	max-frequency = <52000000>;
+	cap-mmc-highspeed;
+	vmmc-supply = <&reg_3p3v>;
+	non-removable;
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_eeprom_0>;
+	};
+};
+
+&wifi {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -16,6 +16,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
 		;;
 	netgear,wax220|\
+	ubnt,unifi-6-plus|\
 	zyxel,nwa50ax-pro)
 		ucidef_set_interface_lan "eth0"
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -14,6 +14,13 @@ case "$FIRMWARE" in
 		;;
 	esac
 	;;
+"mediatek/mt7981_eeprom_mt7976_dbdc.bin")
+	case "$board" in
+	ubnt,unifi-6-plus)
+		caldata_extract_mmc "factory" 0x0 0x1000
+		;;
+	esac
+	;;
 "mediatek/mt7986_eeprom_mt7976.bin")
 	case "$board" in
 	acer,predator-w6)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -58,6 +58,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 3 > /sys${DEVPATH}/macaddress
 		;;
+	ubnt,unifi-6-plus)
+		addr=$(mtd_get_mac_binary EEPROM 0x6)
+		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
+		;;
 	qihoo,360t7)
 		addr=$(mtd_get_mac_ascii factory lanMac)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -88,6 +88,11 @@ platform_do_upgrade() {
 		CI_UBIPART="ubi0"
 		nand_do_upgrade "$1"
 		;;
+	ubnt,unifi-6-plus)
+		CI_KERNPART="kernel0"
+		EMMC_ROOT_DEV="$(cmdline_get_var root)"
+		emmc_do_upgrade "$1"
+		;;
 	h3c,magic-nx30-pro|\
 	mediatek,mt7981-rfb|\
 	qihoo,360t7|\
@@ -144,6 +149,9 @@ platform_copy_config() {
 			emmc_copy_config
 			;;
 		esac
+		;;
+	ubnt,unifi-6-plus)
+		emmc_copy_config
 		;;
 	esac
 }

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -521,6 +521,16 @@ define Device/tplink_tl-xdr6088
 endef
 TARGET_DEVICES += tplink_tl-xdr6088
 
+define Device/ubnt_unifi-6-plus
+  DEVICE_VENDOR := Ubiquiti
+  DEVICE_MODEL := UniFi 6 Plus
+  DEVICE_DTS := mt7981a-ubnt-unifi-6-plus
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7981-firmware mt7981-wo-firmware e2fsprogs f2fsck mkf2fs fdisk partx-utils
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += ubnt_unifi-6-plus
+
 define Device/xiaomi_mi-router-wr30u-112m-nmbm
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := Mi Router WR30U (112M UBI with NMBM-Enabled layout)


### PR DESCRIPTION
Ubiquiti U6+ is a dual-band WiFi 6 PoE access point. It is a drop-in upgrade of the U6 lite.

Specifications
---

- SoC: MediaTek MT7981A dual-core ARM Cortex-A53 1.3 GHz
- RAM: 256 MB DDR3-2133 RAM
- Flash: 16 MB SPI NOR and 4 GB eMMC
- LAN: 1x Gigabit Ethernet with 802.3af/at support
- WLAN: MediaTek MT7976C 2x2 MIMO dual-band WiFi 6
- LEDs: 1x blue and 1x white
- Buttons: 1x reset button

Installation
---

1. Power device using a PoE injector or switch
2. Connect via Ethernet to the device with static IP 192.168.1.2
3. SSH into the device with password: ubnt

        $ ssh ubnt@192.168.1.20

4. Unlock kernel partitions for writing

        $ echo 5edfacbf > /proc/ubnthal/.uf

5. Confirm correct partitions

        $ grep PARTNAME /sys/block/mmcblk0/mmcblk0p6/uevent
        PARTNAME=kernel0
        $ grep PARTNAME /sys/block/mmcblk0/mmcblk0p7/uevent
        PARTNAME=kernel1
        $ grep PARTNAME /sys/block/mmcblk0/mmcblk0p8/uevent
        PARTNAME=bs

6. Set and confirm bootloader environment

        $ fw_setenv boot_openwrt "fdt addr \$(fdtcontroladdr); fdt rm /signature; bootubnt"
        $ fw_setenv bootcmd_real "run boot_openwrt"
        $ fw_printenv

7. Copy sysupgrade image to /tmp/openwrt.bin via scp
8. Copy kernel and rootfs to mmcblk0p6 and mmcblk0p7, respectively

        $ tar xf /tmp/openwrt.bin sysupgrade-ubnt_unifi-6-plus/kernel -O | dd of=/dev/mmcblk0p6
        $ tar xf /tmp/openwrt.bin sysupgrade-ubnt_unifi-6-plus/root -O | dd of=/dev/mmcblk0p7

9. Ensure device boots from mmcblk0p6

        $ echo -ne "\x00\x00\x00\x00\x2b\xe8\x4d\xa3" > /dev/mmcblk0p8

10. Reboot the device

        $ reboot
