### PR TITLE
[23.05] ath79: backport support for MikroTik RouterBOARD 750 r2 (hEX lite)

### DIFF
--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-16m.dtsi
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-16m.dtsi
@@ -75,9 +75,3 @@
 		};
 	};
 };
-
-&wmac {
-	status = "okay";
-
-	qca,no-eeprom;
-};

--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-750-r2.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-750-r2.dts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9533_mikrotik_routerboard-16m.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-750-r2", "qca,qca9533";
+	model = "MikroTik RouterBOARD 750 r2 (hEX lite)";
+
+	aliases {
+		led-boot = &led_usr;
+		led-failsafe = &led_usr;
+		led-upgrade = &led_usr;
+		led-running = &led_usr;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+
+		led_usr: usr {
+			label = "green:usr";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led1 {
+			label = "green:port1";
+			gpios = <&ssr 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led2 {
+			label = "green:port2";
+			gpios = <&ssr 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led3 {
+			label = "green:port3";
+			gpios = <&ssr 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led4 {
+			label = "green:port4";
+			gpios = <&ssr 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led5 {
+			label = "green:port5";
+			gpios = <&ssr 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pinmux {
+	pmx_spi_cs1: pinmux_spi_cs1 {
+		pinctrl-single,bits = <0x8 0x0a000000 0xff000000>;
+	};
+};
+
+&spi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pmx_spi_cs1>;
+
+	cs-gpios = <0>, <&gpio 11 GPIO_ACTIVE_LOW>;
+
+	ssr: ssr@1 {
+		compatible = "fairchild,74hc595";
+		gpio-controller;
+		#gpio-cells = <2>;
+		registers-number = <1>;
+		reg = <1>;
+		spi-max-frequency = <10000000>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+};

--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-95x.dtsi
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-95x.dtsi
@@ -83,6 +83,12 @@
 	};
 };
 
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};
+
 &eth0 {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-lhg-hb.dtsi
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-lhg-hb.dtsi
@@ -66,6 +66,12 @@
 	};
 };
 
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};
+
 &eth0 {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-map-2nd.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-map-2nd.dts
@@ -93,6 +93,12 @@
 	};
 };
 
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};
+
 &eth0 {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-mapl-2nd.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-mapl-2nd.dts
@@ -42,6 +42,12 @@
 	};
 };
 
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};
+
 &eth0 {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-wap-2nd.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-wap-2nd.dts
@@ -36,6 +36,12 @@
 	};
 };
 
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};
+
 &eth0 {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-wapr-2nd.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-wapr-2nd.dts
@@ -50,6 +50,12 @@
 	};
 };
 
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};
+
 &eth0 {
 	status = "okay";
 

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -9,6 +9,15 @@ define Device/mikrotik_routerboard-493g
 endef
 TARGET_DEVICES += mikrotik_routerboard-493g
 
+define Device/mikrotik_routerboard-750-r2
+  $(Device/mikrotik_nor)
+  SOC := qca9533
+  DEVICE_MODEL := RouterBOARD 750 r2 (hEX lite)
+  IMAGE_SIZE := 16256k
+  SUPPORTED_DEVICES += rb-750-r2
+endef
+TARGET_DEVICES += mikrotik_routerboard-750-r2
+
 define Device/mikrotik_routerboard-911-lite
   $(Device/mikrotik_nor)
   SOC := ar9344

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
@@ -16,6 +16,7 @@ mikrotik,routerboard-lhg-5nd)
 	ucidef_set_led_rssi "rssimediumhigh" "rssimediumhigh" "green:rssimediumhigh" "wlan0" "60" "100"
 	ucidef_set_led_rssi "rssihigh" "rssihigh" "green:rssihigh" "wlan0" "80" "100"
 	;;
+mikrotik,routerboard-750-r2|\
 mikrotik,routerboard-951ui-2hnd|\
 mikrotik,routerboard-951ui-2nd|\
 mikrotik,routerboard-952ui-5ac2nd)

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -14,6 +14,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch1" \
 			"0@eth1" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"
 		;;
+	mikrotik,routerboard-750-r2)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:4" "2:lan:1" "3:lan:3" "4:lan:2"
+		;;
 	mikrotik,routerboard-911-lite|\
 	mikrotik,routerboard-912uag-2hpnd|\
 	mikrotik,routerboard-lhg-2nd|\


### PR DESCRIPTION
Support for MikroTik RouterBOARD 750 r2 (marketed as hEX lite) was already provided by the ar71xx target. However, only recently it has been re-added to the new ath79 target. This patch backports the commit in master with the hope that the device can be supported by the soon-to-be-released OpenWrt 23.05.
