### PR TITLE
sunxi: generalize top-level BOARDNAME and update suported SoCs

### DIFF
--- a/target/linux/sunxi/Makefile
+++ b/target/linux/sunxi/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 ARCH:=arm
 BOARD:=sunxi
-BOARDNAME:=Allwinner A1x/A20/A3x/H3/H5/R40
+BOARDNAME:=Allwinner ARM SoCs
 FEATURES:=fpu usb ext4 display rootfs-part rtc squashfs
 SUBTARGETS:=cortexa8 cortexa7 cortexa53
 
@@ -21,6 +21,7 @@ KERNELNAME:=zImage dtbs
 # A80: octa Cortex-A15/A7
 # H3: quad Cortex-A7
 # R40: quad Cortex-A7
+# A64/H5/H6/H616: quad Cortex-A53
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/linux/sunxi/cortexa53/target.mk
+++ b/target/linux/sunxi/cortexa53/target.mk
@@ -5,6 +5,6 @@
 include $(TOPDIR)/rules.mk
 
 ARCH:=aarch64
-BOARDNAME:=Allwinner A64/H5
+BOARDNAME:=Allwinner A64/H5/H6/H616
 CPU_TYPE:=cortex-a53
 KERNELNAME:=Image dtbs


### PR DESCRIPTION
Allwinner created to may SoC variants to list them all at top-level.

Signed-off-by: Sebastian Pflieger <sebastian@pflieger.email>