### PR TITLE
ipq4019: add support for ZTE MF282 Plus aka DreiTube

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -57,7 +57,8 @@ ipq40xx_setup_interfaces()
 	mikrotik,lhgg-60ad|\
 	mikrotik,sxtsq-5-ac|\
 	netgear,ex6100v2|\
-	netgear,ex6150v2)
+	netgear,ex6150v2|\
+	zte,mf282plus)
 		ucidef_set_interface_lan "lan"
 		;;
 	avm,fritzbox-7530)

--- a/target/linux/ipq40xx/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ipq40xx/base-files/etc/board.d/03_gpio_switches
@@ -35,6 +35,7 @@ sony,ncp-hg100-cellular)
 wallys,dr40x9)
 	ucidef_add_gpio_switch "sim_card_select" "SIM card select" "423" "0"
 	;;
+zte,mf282plus|\
 zte,mf286d|\
 zte,mf287pro|\
 zte,mf289f)

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -26,6 +26,7 @@ EOF
 		return 1
 		;;
 	zte,mf18a |\
+	zte,mf282plus|\
 	zte,mf286d |\
 	zte,mf287|\
 	zte,mf287plus |\

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-mf282plus.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-mf282plus.dts
@@ -1,0 +1,448 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// Copyright (c) 2022, Pawel Dembicki <paweldembicki@gmail.com>.
+// Copyright (c) 2023, Andreas Böhler <dev@aboehler.at>
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/soc/qcom,tcsr.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "ZTE MF282Plus";
+	compatible = "zte,mf282plus";
+
+	aliases {
+		led-boot = &led_internal;
+		led-failsafe = &led_internal;
+		led-running = &led_internal;
+		led-upgrade = &led_internal;
+	};
+
+	chosen {
+		/*
+		 * bootargs forced by u-boot bootipq command:
+		 * 'ubi.mtd=rootfs root=mtd:ubi_rootfs rootfstype=squashfs rootwait'
+		 */
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		modem {
+			gpio-export,name = "modem-reset";
+			gpio-export,output = <0>;
+			gpios = <&tlmm 8 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_internal: led-0 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&tlmm 10 GPIO_ACTIVE_LOW>;
+			label = "blue:internal_led";
+			default-state = "keep";
+		};
+
+		led-1 {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&tlmm 61 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wifi {
+			label = "wifi";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&tlmm 11 GPIO_ACTIVE_LOW>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&tlmm 68 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	soc {
+		rng@22000 {
+			status = "okay";
+		};
+
+		mdio@90000 {
+			status = "okay";
+			pinctrl-0 = <&mdio_pins>;
+			pinctrl-names = "default";
+			reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
+			reset-delay-us = <2000>;
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			/* select hostmode */
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+			status = "okay";
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+
+		usb2@60f8800 {
+			status = "okay";
+		};
+
+		usb3@8af8800 {
+			status = "okay";
+		};
+
+		crypto@8e3a000 {
+			status = "okay";
+		};
+
+		watchdog@b017000 {
+			status = "okay";
+		};
+	};
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&blsp1_spi1 {
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	cs-gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>;
+
+	flash@0 {
+		/* u-boot is looking for "n25q128a11" property */
+		compatible = "jedec,spi-nor", "n25q128a11";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		spi-max-frequency = <24000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "0:MIBIB";
+				reg = <0x40000 0x20000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "0:QSEE";
+				reg = <0x60000 0x60000>;
+				read-only;
+				};
+
+			partition@c0000 {
+				label = "0:CDT";
+				reg = <0xc0000 0x10000>;
+				read-only;
+			};
+
+			partition@d0000 {
+				label = "0:DDRPARAMS";
+				reg = <0xd0000 0x10000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "0:APPSBLENV";
+				reg = <0xe0000 0x10000>;
+				read-only;
+			};
+
+			partition@f0000 {
+				label = "0:APPSBL";
+				reg = <0xf0000 0xc0000>;
+				read-only;
+			};
+
+			partition@1b0000 {
+				label = "0:reserved1";
+				reg = <0x1b0000 0x50000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_config_0>;
+};
+
+&nand {
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	nand@0 {
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "fota-flag";
+				reg = <0x0 0xa0000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				label = "ART";
+				reg = <0xa0000 0x80000>;
+				read-only;
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				precal_art_1000: precal@1000 {
+					reg = <0x1000 0x2f20>;
+				};
+
+				precal_art_5000: precal@5000 {
+					reg = <0x5000 0x2f20>;
+				};
+			};
+
+			partition@120000 {
+				label = "mac";
+				reg = <0x120000 0x80000>;
+				read-only;
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_config_0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+			};
+
+			partition@1a0000 {
+				label = "reserved2";
+				reg = <0x1a0000 0xc0000>;
+				read-only;
+			};
+
+			partition@260000 {
+				label = "cfg-param";
+				reg = <0x260000 0x400000>;
+				read-only;
+			};
+
+			partition@660000 {
+				label = "log";
+				reg = <0x660000 0x400000>;
+			};
+
+			partition@a60000 {
+				label = "oops";
+				reg = <0xa60000 0xa0000>;
+			};
+
+			partition@b00000 {
+				label = "reserved3";
+				reg = <0xb00000 0x500000>;
+				read-only;
+			};
+
+			partition@1000000 {
+				label = "web";
+				reg = <0x1000000 0x800000>;
+			};
+
+			partition@1800000 {
+				label = "rootfs";
+				reg = <0x1800000 0x1d00000>;
+			};
+
+			partition@3500000 {
+				label = "data";
+				reg = <0x3500000 0x1900000>;
+			};
+
+			partition@4e00000 {
+				label = "fota";
+				reg = <0x4e00000 0x2800000>;
+			};
+
+			partition@7600000 {
+				label = "extra-cfg";
+				reg = <0x7600000 0xa00000>;
+			};
+		};
+	};
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "lan";
+};
+
+&tlmm {
+	i2c_0_pins: i2c_0_pinmux {
+		mux {
+			pins = "gpio20", "gpio21";
+			function = "blsp_i2c0";
+			bias-disable;
+		};
+	};
+
+	mdio_pins: mdio_pinmux {
+		mux_1 {
+			pins = "gpio6";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mux_2 {
+			pins = "gpio7";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
+	nand_pins: nand_pins {
+		pullups {
+			pins =	"gpio52", "gpio53", "gpio58",
+				"gpio59";
+			function = "qpic";
+			bias-pull-up;
+		};
+
+		pulldowns {
+			pins =	"gpio54", "gpio55", "gpio56",
+				"gpio57", "gpio60",
+				"gpio62", "gpio63", "gpio64",
+				"gpio65", "gpio66", "gpio67",
+				"gpio69";
+			function = "qpic";
+			bias-pull-down;
+		};
+	};
+
+	serial_pins: serial_pinmux {
+		mux {
+			pins = "gpio16", "gpio17";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		pinmux {
+			function = "blsp_spi0";
+			pins = "gpio13", "gpio14", "gpio15";
+			drive-strength = <12>;
+			bias-disable;
+		};
+
+		pinmux_cs {
+			function = "gpio";
+			pins = "gpio12";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+/*
+ * The MD5 sum of the board file of the MF286D is identical to the board
+ * file in the OEM firmware
+ */
+&wifi0 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_1000>, <&macaddr_config_0>;
+	mac-address-increment = <1>;
+	qcom,ath10k-calibration-variant = "zte,mf286d";
+};
+
+/*
+ * The MD5 sum of the board file of the MF286D is identical to the board
+ * file in the OEM firmware
+ */
+&wifi1 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_5000>, <&macaddr_config_0>;
+	mac-address-increment = <1>;
+	qcom,ath10k-calibration-variant = "zte,mf286d";
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -1160,6 +1160,20 @@ define Device/zte_mf28x_common
 	DEVICE_PACKAGES := kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
 endef
 
+define Device/zte_mf282plus
+	$(call Device/zte_mf28x_common)
+	DEVICE_MODEL := MF282Plus
+#	The recovery image is used to return back to stock (an initramfs-based image
+#	that can be flashed to the device via sysupgrade
+#	The factory image is used to install from the stock firmware by using an
+#	exploit for the web interface
+	IMAGES += factory.bin recovery.bin
+	IMAGE/factory.bin  := append-ubi
+	IMAGE/recovery.bin := append-squashfs4-fakeroot | sysupgrade-tar kernel=$$$$(BIN_DIR)/$$(KERNEL_INITRAMFS_IMAGE) rootfs=$$$$@ | append-metadata
+	DEVICE_PACKAGES := kmod-usb-acm kmod-usb-net-rndis
+endef
+TARGET_DEVICES += zte_mf282plus
+
 define Device/zte_mf286d
 	$(call Device/zte_mf28x_common)
 	DEVICE_MODEL := MF286D


### PR DESCRIPTION
The ZTE MF282 Plus is a LTE router used (exclusively?) by the network operator "3". It is very similar to the MF286/MF287 but in the form factor of the MF282.

Specifications
==============

SoC: IPQ4019
RAM: 256MiB
Flash: 8MiB SPI-NOR + 128MiB SPI-NAND
LAN: 1x GBit LAN
LTE: ZTE Cat6
WiFi: 802.11a/b/g/n/ac SoC-integrated

MAC addresses
=============

LAN: from config
WiFi 1: from config + 1
WiFi 2: from config + 2

Installation
============

Option 1 - TFTP
---------------

TFTP installation using UART is preferred. Disassemble the device and connect serial. Put the initramfs image as openwrt.bin to your TFTP server and configure a static IP of 192.168.1.100. Load the initramfs image by typing:

  setenv serverip 192.168.1.100
  setenv ipaddr 192.168.1.1
  tftpboot 0x84000000 openwrt.bin
  bootm 0x84000000

From this intiramfs boot you can take a backup of the currently installed partitions as no vendor firmware is available for download:

  ubiattach -m9
  cat /dev/ubi0_0 > /tmp/ubi0_0
  cat /dev/ubi0_1 > /tmp/ubi0_1

Copy the files /tmp/ubi0_0 and /tmp/ubi0_1 somewhere save.

Once booted, transfer the sysupgrade image and run sysupgrade. You might have to delete the stock volumes first:

  ubirmvol /dev/ubi0 -N ubi_rootfs
  ubirmvol /dev/ubi0 -N kernel

Option 2 - From stock firmware
------------------------------

The installation from stock requires an exploit first. The exploit consists of a backup file that forces the firmware to download telnetd via TFTP from 192.168.0.22 and run it. Once exploited, you can connect via telnet and login as admin:admin.

The exploit will be available at the device wiki page.

Once inside the stock firmware, you can transfer the -factory.bin file to /tmp by using "scp" from the stock frmware or "tftp".

ZTE has blocked writing to the NAND. Fortunately, it's easy to allow write access - you need to read from one file in /proc. Once done, you need to erase the UBI partition and flash OpenWrt. Before performing the operation, make sure that mtd9 is the partition labelled "rootfs" by calling "cat /proc/mtd".

Complete commands:

  cd /tmp
  tftp -g -r factory.bin 192.168.0.22
  cat /proc/driver/sensor_id
  flash_erase /dev/mtd9 0 0
  dd if=/tmp/factory.bin of=/dev/mtdblock9 bs=131072

Afterwards, reboot your device and you should have a working OpenWrt installation.

Restore Stock
=============

Option 1 - via UART
-------------------

Boot an OpenWrt initramfs image via TFTP as for the initial installation. Transfer the two backed-up files to your box to /tmp.

Then, run the following commands - replace $kernel_length and $rootfs_size by the size of ubi0_0 and ubi0_1 in bytes.

  ubiattach -m 9
  ubirmvol /dev/ubi0 -N kernel
  ubirmvol /dev/ubi0 -N rootfs
  ubirmvol /dev/ubi0 -N rootfs_data
  ubimkvol /dev/ubi0 -N kernel -s $kernel_length
  ubimkvol /dev/ubi0 -N ubi_rootfs -s $rootfs_size
  ubiupdatevol /dev/ubi0_0 /tmp/ubi0_0
  ubiupdatevol /dev/ubi0_1 /tmp/ubi0_1

Option 2 - from within OpenWrt
------------------------------

This option requires to flash an initramfs version first so that access to the flash is possible. This can be achieved by sysupgrading to the recovery.bin version and rebooting. Once rebooted, you are again in a default OpenWrt installation, but no partition is mounted.

Follow the commands from Option 1 to flash back to stock.

LTE Modem
=========

The LTE modem is similar to the MF286R, it provides an RNDIS interface and an AT interface.

Other Notes
===========

There is one GPIO Switch "Power button blocker" which, if enabled, does not trigger a reset of the SoC if the modem reboots. If disabled, the SoC is rebooted along with the modem. The modem can be rebooted via the exported GPIO "modem-reset" in /sys/class/gpio.