### PR TITLE
build: optionally propagate errors in scan and feed update

### DIFF
--- a/include/scan.mk
+++ b/include/scan.mk
@@ -56,6 +56,7 @@ define PackageDir
 			$(NO_TRACE_MAKE) --no-print-dir -r DUMP=1 FEED="$(call feedname,$(2))" -C $(SCAN_DIR)/$(2) $(SCAN_MAKEOPTS) > $(TOPDIR)/logs/$(SCAN_DIR)/$(2)/dump.txt 2>&1; \
 			$$(call progress,ERROR: please fix $(SCAN_DIR)/$(2)/Makefile - see logs/$(SCAN_DIR)/$(2)/dump.txt for details\n) \
 			rm -f $$@; \
+			$(if $(SCAN_STRICT),exit 2;,) \
 		}; \
 		echo; \
 	} > $$@.tmp

--- a/scripts/feeds
+++ b/scripts/feeds
@@ -127,11 +127,11 @@ sub update_index($)
 	-d "./feeds/$name.tmp" or mkdir "./feeds/$name.tmp" or return 1;
 	-d "./feeds/$name.tmp/info" or mkdir "./feeds/$name.tmp/info" or return 1;
 
-	system("$mk -s prepare-mk OPENWRT_BUILD= TMP_DIR=\"$ENV{TOPDIR}/feeds/$name.tmp\"");
-	system("$mk -s -f include/scan.mk IS_TTY=1 SCAN_TARGET=\"packageinfo\" SCAN_DIR=\"feeds/$name\" SCAN_NAME=\"package\" SCAN_DEPTH=5 SCAN_EXTRA=\"\" TMP_DIR=\"$ENV{TOPDIR}/feeds/$name.tmp\"");
-	system("$mk -s -f include/scan.mk IS_TTY=1 SCAN_TARGET=\"targetinfo\" SCAN_DIR=\"feeds/$name\" SCAN_NAME=\"target\" SCAN_DEPTH=5 SCAN_EXTRA=\"\" SCAN_MAKEOPTS=\"TARGET_BUILD=1\" TMP_DIR=\"$ENV{TOPDIR}/feeds/$name.tmp\"");
-	system("ln -sf $name.tmp/.packageinfo ./feeds/$name.index");
-	system("ln -sf $name.tmp/.targetinfo ./feeds/$name.targetindex");
+	system("$mk -s prepare-mk OPENWRT_BUILD= TMP_DIR=\"$ENV{TOPDIR}/feeds/$name.tmp\"") == 0 or return 1;
+	system("$mk -s -f include/scan.mk IS_TTY=1 SCAN_TARGET=\"packageinfo\" SCAN_DIR=\"feeds/$name\" SCAN_NAME=\"package\" SCAN_DEPTH=5 SCAN_EXTRA=\"\" TMP_DIR=\"$ENV{TOPDIR}/feeds/$name.tmp\"") == 0 or return 1;
+	system("$mk -s -f include/scan.mk IS_TTY=1 SCAN_TARGET=\"targetinfo\" SCAN_DIR=\"feeds/$name\" SCAN_NAME=\"target\" SCAN_DEPTH=5 SCAN_EXTRA=\"\" SCAN_MAKEOPTS=\"TARGET_BUILD=1\" TMP_DIR=\"$ENV{TOPDIR}/feeds/$name.tmp\"") == 0 or return 1;
+	system("ln -sf $name.tmp/.packageinfo ./feeds/$name.index") == 0 or return 1;
+	system("ln -sf $name.tmp/.targetinfo ./feeds/$name.targetindex") == 0 or return 1;
 
 	return 0;
 }
@@ -822,8 +822,10 @@ sub update {
 	$ENV{SCAN_COOKIE} = $$;
 	$ENV{OPENWRT_VERBOSE} = 's';
 
-	getopts('ahif', \%opts);
+	getopts('ahifs', \%opts);
 	%argv_feeds = map { $_ => 1 } @ARGV;
+
+	$ENV{SCAN_STRICT} = ($opts{s} ? '1' : '');
 
 	if ($opts{h}) {
 		usage();
@@ -906,6 +908,7 @@ Commands:
 	    -a :           Update all feeds listed within feeds.conf. Otherwise the specified feeds will be updated.
 	    -i :           Recreate the index only. No feed update from repository is performed.
 	    -f :           Force updating feeds even if there are changed, uncommitted files.
+	    -s :           Strict mode. Fail on package Makefile errors.
 
 	clean:             Remove downloaded/generated files.
 


### PR DESCRIPTION
Currently, when an error occurs during scanning of a package Makefile, an
error message is logged, but the error is not actually propagated. This
makes it easy for build scripts to accidentally proceed based on an incomplete
package scan.

Add a `-s` option to `feed update` that enables strict error checking.