### PR TITLE
lldpd: fix default configuration

### DIFF
--- a/package/network/services/lldpd/Config.in
+++ b/package/network/services/lldpd/Config.in
@@ -8,22 +8,22 @@ config LLDPD_WITH_PRIVSEP
 
 config LLDPD_WITH_CDP
 	bool
-	default y
+	default n
 	prompt "Enable support for the Cisco Discovery Protocol (CDP) version 1 and 2"
 
 config LLDPD_WITH_FDP
 	bool
-	default y
+	default n
 	prompt "Enable support for the Foundry Discovery Protocol (FDP)"
 
 config LLDPD_WITH_EDP
 	bool
-	default y
+	default n
 	prompt "Enable support for the Extreme Discovery Protocol (EDP)"
 
 config LLDPD_WITH_SONMP
 	bool
-	default y
+	default n
 	prompt "Enable support for the SynOptics Network Management Protocol"
 
 config LLDPD_WITH_LLDPMED

--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lldpd
 PKG_VERSION:=1.0.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lldpd/lldpd/releases/download/$(PKG_VERSION)/

--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -82,6 +82,9 @@ endif
 ifneq ($(CONFIG_LLDPD_WITH_SNMP),y)
 	sed -i -e '/agentxsocket/d' $(1)/etc/init.d/lldpd $(1)/etc/config/lldpd
 endif
+ifneq ($(CONFIG_LLDPD_WITH_LLDPMED),y)
+	sed -i -e '/lldp_class/d' $(1)/etc/init.d/lldpd $(1)/etc/config/lldpd
+endif
 endef
 
 define Package/lldpd/conffiles

--- a/package/network/services/lldpd/files/lldpd.config
+++ b/package/network/services/lldpd/files/lldpd.config
@@ -16,5 +16,4 @@ config lldpd config
 	#option lldp_mgmt_ip "!192.168.1.1"
 
 	# interfaces to listen on
-	list interface "loopback"
 	list interface "lan"

--- a/package/network/services/lldpd/files/lldpd.config
+++ b/package/network/services/lldpd/files/lldpd.config
@@ -7,7 +7,7 @@ config lldpd config
 	option agentxsocket /var/run/agentx.sock
 
 	option lldp_class 4
-	option lldp_location "2:FR:6:Commercial Rd:3:Roseville:19:4"
+	option lldp_location ""
 
 	# if empty, the distribution description is sent
 	#option lldp_description "OpenWrt System"

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -38,6 +38,10 @@ write_lldpd_conf()
 	for iface in $ifaces; do
 		local ifname=""
 		if network_get_device ifname "$iface" || [ -e "/sys/class/net/$iface" ]; then
+			if [ -e "/sys/class/net/$ifname/bridge" -o -e "/sys/class/net/$ifname/lower_bridge" ] ; then
+				local ports=$(jsonfilter -i /etc/board.json -e "@.network.$iface.device")
+				[ "${ports// /,}" ] && ifname="${ports// /,}"
+			fi
 			append ifnames "${ifname:-$iface}" ","
 		fi
 	done


### PR DESCRIPTION
The lldpd package in it's current default configuration is de-func for all use cases. This series fixes issues for many devices and use cases but not all.

Still no runtime reconfiguration if devices are added or removed from br-lan.
LLDP will still not work on devices with switches where frames to LLDP Multicast Address are not forwarded to the CPU. 

Signed-off-by: Sebastian Pflieger <sebastian@pflieger.email>
