### PR TITLE
ramips: fix Mercusys MR70X LAN port assignments

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -17,6 +17,7 @@ ramips_setup_interfaces()
 	h3c,tx1806|\
 	haier,har-20s2u1|\
 	hiwifi,hc5962|\
+	mercusys,mr70x-v1|\
 	netgear,wax202|\
 	sim,simax1800t|\
 	xiaomi,mi-router-3-pro|\


### PR DESCRIPTION
A bug report in the forum found that the MR70X lists four LAN ports in LuCI while it has only three. This adds the device to the network setup file to fix the issue.

Identified-by: Forum User "Lexeyko"

This needs to be backported to 23.05.