### PR TITLE
x86/64: add kmod-vhost-net to default device package

### DIFF
--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -4,7 +4,7 @@ define Device/generic
   DEVICE_PACKAGES += \
 	kmod-amazon-ena kmod-amd-xgbe kmod-bnx2 kmod-e1000e kmod-e1000 \
 	kmod-forcedeth kmod-fs-vfat kmod-igb kmod-igc kmod-ixgbe kmod-r8169 \
-	kmod-tg3
+	kmod-tg3 kmod-vhost-net
   GRUB2_VARIANT := generic
 endef
 TARGET_DEVICES += generic


### PR DESCRIPTION
Allow to use the generic x86/64 images in vms without modification.
the
Fixes: 8b1cc1582ad9 ("x86: remove built-in vhost-net driver")

Allow to run the CIs.