### PR TITLE
ath79: add support for GL.iNet GL-S200

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -105,7 +105,9 @@ dongwon,dw02-412h-128m|\
 glinet,gl-ar300m-lite|\
 glinet,gl-ar300m-nand|\
 glinet,gl-ar300m-nor|\
-glinet,gl-ar300m16)
+glinet,gl-ar300m16|\
+glinet,gl-s200-nor|\
+glinet,gl-s200-nor-nand)
 	idx="$(find_mtd_index u-boot-env)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000"

--- a/target/linux/ath79/dts/qca9531_glinet_gl-s200-nor-nand.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-s200-nor-nand.dts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "qca9531_glinet_gl-s200.dtsi"
+
+/ {
+	compatible = "glinet,gl-s200-nor-nand", "qca,qca9531";
+	model = "GL.iNet GL-S200 (NOR/NAND)";
+};
+
+&nor_partitions {
+	partition@60000 {
+		label = "kernel";
+		reg = <0x060000 0x400000>;
+	};
+	parition@460000 {
+		label = "nor_reserved";
+		reg = <0x460000 0xb80000>;
+	};
+	parition@fe0000 {
+		label = "log";
+		reg = <0xfe0000 0x020000>;
+	};
+};
+
+&flash_nand {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/qca9531_glinet_gl-s200-nor.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-s200-nor.dts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "qca9531_glinet_gl-s200.dtsi"
+
+/ {
+	compatible = "glinet,gl-s200-nor", "qca,qca9531";
+	model = "GL.iNet GL-S200 (NOR)";
+};
+
+&nor_partitions {
+	partition@60000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x060000 0xf80000>;
+	};
+	partition@fe0000 {
+		label = "log";
+		reg = <0xfe0000 0x020000>;
+	};
+};

--- a/target/linux/ath79/dts/qca9531_glinet_gl-s200.dtsi
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-s200.dtsi
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "glinet,gl-s200", "qca,qca9531";
+	model = "GL.iNet GL-S200";
+
+	aliases {
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			linux,input-type = <EV_KEY>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		switch {
+			label = "switch";
+			linux,code = <KEY_SETUP>;
+			linux,input-type = <EV_SW>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		blue_led {
+			label = "gl-s200:blue";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		white_led {
+			label = "gl-s200:white";
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		orange_led {
+			label = "gl-s200:orange";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_zigbee_reset {
+			gpio-export,name = "gpio1";
+			gpio-export,output = <1>;
+			gpio-export,direction_may_change;
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_zwave_reset {
+			gpio-export,name = "gpio2";
+			gpio-export,output = <1>;
+			gpio-export,direction_may_change;
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_zigbee_upgrade {
+			gpio-export,name = "gpio11";
+			gpio-export,output = <1>;
+			gpio-export,direction_may_change;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_zwave_upgrade {
+			gpio-export,name = "gpio17";
+			gpio-export,output = <1>;
+			gpio-export,direction_may_change;
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+	 };
+};
+
+&gpio {
+	ngpios = <17>;
+	gpio-line-names =
+		"","reset-zigbee","reset-zwave","reset",
+		"LED-orange","","","","","","",
+		"upgrade-zigbee","LED-white","LED-blue",
+		"switch","","","upgrade-zwave";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		nor_partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			art: partition@50000 {
+				label = "art";
+				reg = <0x050000 0x010000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_wan_lan: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+				};
+			};
+		};
+	};
+
+	flash_nand: flash@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <25000000>;
+		status = "disabled";
+		
+		nand_partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			nand_ubi: partition@0 {
+				label = "ubi";
+				reg = <0x000000 0x8000000>;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	nvmem-cells = <&macaddr_wan_lan 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_wan_lan 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+	nvmem-cells = <&calibration_art_1000>;
+	nvmem-cell-names = "calibration";
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -203,6 +203,35 @@ define Device/glinet_gl-e750
 endef
 TARGET_DEVICES += glinet_gl-e750
 
+define Device/glinet_gl-s200-common
+  SOC := qca9531
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := GL-S200
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-serial-ch341
+  SUPPORTED_DEVICES += gl-s200 glinet,gl-s200
+endef
+
+define Device/glinet_gl-s200-nor
+  $(Device/glinet_gl-s200-common)
+  DEVICE_VARIANT := NOR
+  IMAGE_SIZE := 16000k
+endef
+TARGET_DEVICES += glinet_gl-s200-nor
+
+define Device/glinet_gl-s200-nor-nand
+  $(Device/glinet_gl-s200-common)
+  DEVICE_VARIANT := NOR/NAND
+  KERNEL_SIZE := 4096k
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  VID_HDR_OFFSET := 2048
+  IMAGES += factory.img
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
+  SUPPORTED_DEVICES += gl-s200 glinet,gl-s200
+endef
+TARGET_DEVICES += glinet_gl-s200-nor-nand
+
 define Device/glinet_gl-xe300
   SOC := qca9531
   DEVICE_VENDOR := GL.iNet

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -40,6 +40,8 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"6@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0@eth0"
 		;;
+	glinet,gl-s200-nor|\
+	glinet,gl-s200-nor-nand|\
 	netgear,pgzng1)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;

--- a/target/linux/ath79/nand/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/nand/base-files/lib/upgrade/platform.sh
@@ -20,6 +20,8 @@ platform_do_upgrade() {
 		;;
 	glinet,gl-ar750s-nor|\
 	glinet,gl-ar750s-nor-nand|\
+	glinet,gl-s200-nor|\
+	glinet,gl-s200-nor-nand|\
 	glinet,gl-x1200-nor|\
 	glinet,gl-x1200-nor-nand)
 		nand_nor_do_upgrade "$1"


### PR DESCRIPTION
Specifications:
SoC: QCA9531(650MHz)
RAM: DDR2 128M
Flash: SPI NOR 16M + SPI NAND 128M
WiFi: 2.4GHz with 2 antennas(WiFi/Thread)
Ethernet:
    1xLAN(10/100M)
    2xWAN(10/100M)
Button: 1x Reset Button
Switch: 1x Mode switch
LED: 1x Blue LED + 1x White LED + 1x Orange LED
IOT: Thread + ZigBee/Zwave

By uboot web failsafe:
Push the reset button for 5 seconds util the power led flash faster, then use broswer to access http://192.168.1.1

Afterwards upgrade can use sysupgrade image.

Signed-off-by: Weiping Yang <weiping.yang@gl-inet.com>