### PR TITLE
build: add metadata even w/o SUPPORTED_DEVICES

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -75,10 +75,10 @@ metadata_json = \
 		"metadata_version": "1.1", \
 		"compat_version": "$(call json_quote,$(compat_version))", \
 		$(if $(DEVICE_COMPAT_MESSAGE),"compat_message": "$(call json_quote,$(DEVICE_COMPAT_MESSAGE))"$(comma)) \
-		$(if $(filter-out 1.0,$(compat_version)),"new_supported_devices": \
+		$(if $(SUPPORTED_DEVICES),$(if $(filter-out 1.0,$(compat_version)),"new_supported_devices": \
 			[$(call metadata_devices,$(SUPPORTED_DEVICES))]$(comma) \
 			"supported_devices": ["$(call json_quote,$(legacy_supported_message))"]$(comma)) \
-		$(if $(filter 1.0,$(compat_version)),"supported_devices":[$(call metadata_devices,$(SUPPORTED_DEVICES))]$(comma)) \
+		$(if $(filter 1.0,$(compat_version)),"supported_devices":[$(call metadata_devices,$(SUPPORTED_DEVICES))]$(comma))) \
 		"version": { \
 			"dist": "$(call json_quote,$(VERSION_DIST))", \
 			"version": "$(call json_quote,$(VERSION_NUMBER))", \
@@ -89,7 +89,7 @@ metadata_json = \
 	}'
 
 define Build/append-metadata
-	$(if $(SUPPORTED_DEVICES),-echo $(call metadata_json) | fwtool -I - $@)
+	-echo $(call metadata_json) | fwtool -I - $@
 	sha256sum "$@" | cut -d" " -f1 > "$@.sha256sum"
 	[ ! -s "$(BUILD_KEY)" -o ! -s "$(BUILD_KEY).ucert" -o ! -s "$@" ] || { \
 		cp "$(BUILD_KEY).ucert" "$@.ucert" ;\


### PR DESCRIPTION
Until now metadata-append is called but actual metadata is only added if SUPPORTED_DEVICES is set. For x86 target the variable isn't set, resulting in an attached signature but no JSON metadata, containing the image version etc.

With this patch, the logic is slightly changed so that the supported_devices key is only added if the corresponding variable is defined, all other keys are added independently.
