### PR TITLE
[23.05] Backport ZTE MF287 refactoring

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -41,6 +41,7 @@ ALLWIFIBOARDS:= \
 	xiaomi_ax3600 \
 	xiaomi_ax9000 \
 	zte_mf289f \
+	zte_mf287 \
 	zte_mf287plus \
 	zyxel_nbg7815
 
@@ -129,6 +130,7 @@ $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax3600,Xiaomi AX3600))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax9000,Xiaomi AX9000))
 $(eval $(call generate-ipq-wifi-package,zte_mf289f,ZTE MF289F))
+$(eval $(call generate-ipq-wifi-package,zte_mf287,ZTE MF287))
 $(eval $(call generate-ipq-wifi-package,zte_mf287plus,ZTE MF287Plus))
 $(eval $(call generate-ipq-wifi-package,zyxel_nbg7815,Zyxel NBG7815))
 

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -108,6 +108,7 @@ ipq40xx_setup_interfaces()
 	zte,mf286d)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "wan"
 		;;
+	zte,mf287|\
 	zte,mf287plus|\
 	zte,mf287pro)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -27,6 +27,7 @@ EOF
 		;;
 	zte,mf18a |\
 	zte,mf286d |\
+	zte,mf287|\
 	zte,mf287plus |\
 	zte,mf287pro |\
 	zte,mf289f)

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287.dts
@@ -8,15 +8,10 @@
 / {
 	model = "ZTE MF287";
 	compatible = "zte,mf287";
+};
 
-	/*
-	 * This node is used to restart modem module to avoid anomalous
-	 * behaviours on initial communication.
-	 */
-	gpio-restart {
-		compatible = "gpio-restart";
-		gpios = <&tlmm 5 GPIO_ACTIVE_HIGH>;
-	};
+&gpio_modem_reset {
+	gpios = <&tlmm 5 GPIO_ACTIVE_HIGH>;
 };
 
 &key_reset {

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287.dts
@@ -6,57 +6,38 @@
 #include "qcom-ipq4018-mf287_common.dtsi"
 
 / {
-	model = "ZTE MF287Pro";
-	compatible = "zte,mf287pro";
+	model = "ZTE MF287";
+	compatible = "zte,mf287";
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		modem {
-			gpio-export,name = "modem-reset";
-			gpio-export,output = <0>;
-			gpios = <&tlmm 8 GPIO_ACTIVE_HIGH>;
-		};
-	};
-
-	regulator-usb-vbus {
-		compatible = "regulator-fixed";
-		regulator-name = "USB_VBUS";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		regulator-always-on;
-		regulator-boot-on;
-		gpio = <&tlmm 25 GPIO_ACTIVE_LOW>;
+	/*
+	 * This node is used to restart modem module to avoid anomalous
+	 * behaviours on initial communication.
+	 */
+	gpio-restart {
+		compatible = "gpio-restart";
+		gpios = <&tlmm 5 GPIO_ACTIVE_HIGH>;
 	};
 };
 
 &key_reset {
-	gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+	gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
 };
 
 &key_wps {
-	gpios = <&tlmm 68 GPIO_ACTIVE_LOW>;
+	gpios = <&tlmm 2 GPIO_ACTIVE_LOW>;
 };
 
 &led_status {
-	gpios = <&tlmm 35 GPIO_ACTIVE_LOW>;
-};
-
-&mdio {
-	status = "okay";
-	pinctrl-0 = <&mdio_pins>;
-	pinctrl-names = "default";
-	reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
-	reset-delay-us = <2000>;
+	gpios = <&tlmm 0 GPIO_ACTIVE_LOW>;
 };
 
 &blsp1_spi1 {
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>,
-				<&tlmm 54 GPIO_ACTIVE_HIGH>;
+	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>,
+		   <&tlmm 59 GPIO_ACTIVE_HIGH>,
+		   <&tlmm 1 GPIO_ACTIVE_HIGH>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
@@ -132,13 +113,13 @@
 
 			partition@0 {
 				label = "fota-flag";
-				reg = <0x0 0xa0000>;
+				reg = <0x0 0x140000>;
 				read-only;
 			};
 
-			partition@a0000 {
+			partition@140000 {
 				label = "ART";
-				reg = <0xa0000 0x80000>;
+				reg = <0x140000 0x140000>;
 				read-only;
 				compatible = "nvmem-cells";
 				#address-cells = <1>;
@@ -153,9 +134,9 @@
 				};
 			};
 
-			partition@120000 {
+			partition@280000 {
 				label = "mac";
-				reg = <0x120000 0x80000>;
+				reg = <0x280000 0x140000>;
 				read-only;
 				compatible = "nvmem-cells";
 				#address-cells = <1>;
@@ -166,40 +147,25 @@
 				};
 			};
 
-			partition@1a0000 {
-				label = "reserved2";
-				reg = <0x1a0000 0xc0000>;
-			};
-
-			partition@260000 {
+			partition@3c0000 {
 				label = "cfg-param";
-				reg = <0x260000 0x400000>;
+				reg = <0x3c0000 0x600000>;
 				read-only;
 			};
 
-			partition@660000 {
-				label = "log";
-				reg = <0x660000 0x400000>;
-			};
-
-			partition@a60000 {
+			partition@9c0000 {
 				label = "oops";
-				reg = <0xa60000 0xa0000>;
+				reg = <0x9c0000 0x140000>;
 			};
 
 			partition@b00000 {
-				label = "reserved3";
-				reg = <0xb00000 0x500000>;
-			};
-
-			partition@1000000 {
 				label = "web";
-				reg = <0x1000000 0x800000>;
+				reg = <0xb00000 0x800000>;
 			};
 
-			partition@1800000 {
+			partition@1300000 {
 				label = "rootfs";
-				reg = <0x1800000 0x1d00000>;
+				reg = <0x1300000 0x2200000>;
 			};
 
 			partition@3500000 {
@@ -213,34 +179,21 @@
 			};
 		};
 	};
+
+	zigbee@2 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		compatible = "silabs,em3581";
+		reg = <2>;
+		spi-max-frequency = <12000000>;
+	};
 };
 
 &tlmm {
-	i2c_0_pins: i2c_0_pinmux {
-		mux {
-			pins = "gpio20", "gpio21";
-			function = "blsp_i2c0";
-			bias-disable;
-		};
-	};
-
-	mdio_pins: mdio_pinmux {
-		mux_1 {
-			pins = "gpio6";
-			function = "mdio";
-			bias-pull-up;
-		};
-
-		mux_2 {
-			pins = "gpio7";
-			function = "mdc";
-			bias-pull-up;
-		};
-	};
-
 	serial_pins: serial_pinmux {
 		mux {
-			pins = "gpio16", "gpio17";
+			pins = "gpio60", "gpio61";
 			function = "blsp_uart0";
 			bias-disable;
 		};
@@ -249,14 +202,14 @@
 	spi_0_pins: spi_0_pinmux {
 		pinmux {
 			function = "blsp_spi0";
-			pins = "gpio12", "gpio13", "gpio14", "gpio15";
+			pins = "gpio55", "gpio56", "gpio57";
 			drive-strength = <12>;
 			bias-disable;
 		};
 
 		pinmux_cs {
 			function = "gpio";
-			pins = "gpio12", "gpio54";
+			pins = "gpio54", "gpio59", "gpio1";
 			drive-strength = <2>;
 			bias-disable;
 			output-high;
@@ -264,12 +217,10 @@
 	};
 };
 
-/* The MF287Plus and MF287Pro share the same board data file */
 &wifi0 {
-	qcom,ath10k-calibration-variant = "zte,mf287plus";
+	qcom,ath10k-calibration-variant = "zte,mf287";
 };
 
-/* The MF287Plus and MF287Pro share the same board data file */
 &wifi1{
-	qcom,ath10k-calibration-variant = "zte,mf287plus";
+	qcom,ath10k-calibration-variant = "zte,mf287";
 };

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287_common.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287_common.dtsi
@@ -171,7 +171,6 @@
 	status = "okay";
 	nvmem-cell-names = "pre-calibration", "mac-address";
 	nvmem-cells = <&precal_art_1000>, <&macaddr_mac_0>;
-	qcom,ath10k-calibration-variant = "zte,mf287plus";
 };
 
 &wifi1 {
@@ -179,5 +178,4 @@
 	nvmem-cell-names = "pre-calibration", "mac-address";
 	nvmem-cells = <&precal_art_5000>, <&macaddr_mac_0>;
 	mac-address-increment = <1>;
-	qcom,ath10k-calibration-variant = "zte,mf287plus";
 };

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287_common.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287_common.dtsi
@@ -35,6 +35,16 @@
 		};
 	};
 
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		gpio_modem_reset: modem {
+			gpio-export,name = "modem-reset";
+			gpio-export,output = <0>;
+		};
+	};
+
 	keys {
 		compatible = "gpio-keys";
 

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287plus.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287plus.dts
@@ -8,15 +8,10 @@
 / {
 	model = "ZTE MF287Plus";
 	compatible = "zte,mf287plus";
+};
 
-	/*
-	 * This node is used to restart modem module to avoid anomalous
-	 * behaviours on initial communication.
-	 */
-	gpio-restart {
-		compatible = "gpio-restart";
-		gpios = <&tlmm 5 GPIO_ACTIVE_HIGH>;
-	};
+&gpio_modem_reset {
+	gpios = <&tlmm 5 GPIO_ACTIVE_HIGH>;
 };
 
 &key_reset {

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287plus.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287plus.dts
@@ -3,7 +3,7 @@
 // Copyright (c) 2022, Giammarco Marzano <stich86@gmail.com>.
 // Copyright (c) 2023, Andreas Böhler <dev@aboehler.at>
 
-#include "qcom-ipq4018-mf287.dtsi"
+#include "qcom-ipq4018-mf287_common.dtsi"
 
 / {
 	model = "ZTE MF287Plus";
@@ -215,4 +215,12 @@
 			output-high;
 		};
 	};
+};
+
+&wifi0 {
+	qcom,ath10k-calibration-variant = "zte,mf287plus";
+};
+
+&wifi1{
+	qcom,ath10k-calibration-variant = "zte,mf287plus";
 };

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287pro.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-mf287pro.dts
@@ -9,17 +9,6 @@
 	model = "ZTE MF287Pro";
 	compatible = "zte,mf287pro";
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		modem {
-			gpio-export,name = "modem-reset";
-			gpio-export,output = <0>;
-			gpios = <&tlmm 8 GPIO_ACTIVE_HIGH>;
-		};
-	};
-
 	regulator-usb-vbus {
 		compatible = "regulator-fixed";
 		regulator-name = "USB_VBUS";
@@ -29,6 +18,10 @@
 		regulator-boot-on;
 		gpio = <&tlmm 25 GPIO_ACTIVE_LOW>;
 	};
+};
+
+&gpio_modem_reset {
+	gpios = <&tlmm 8 GPIO_ACTIVE_HIGH>;
 };
 
 &key_reset {

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -1164,7 +1164,6 @@ TARGET_DEVICES += zte_mf286d
 
 define Device/zte_mf287_common
 	$(call Device/zte_mf28x_common)
-	DEVICE_PACKAGES += ipq-wifi-zte_mf287plus
 	SOC := qcom-ipq4018
 #	The recovery image is used to return back to stock (an initramfs-based image
 #	that can be flashed to the device via sysupgrade
@@ -1177,15 +1176,23 @@ endef
 
 define Device/zte_mf287plus
 	$(call Device/zte_mf287_common)
+	DEVICE_PACKAGES += ipq-wifi-zte_mf287plus
 	DEVICE_DTS_CONFIG := config@ap.dk01.1-c2
 	DEVICE_MODEL := MF287Plus
-	DEVICE_ALT0_VENDOR := ZTE
-	DEVICE_ALT0_MODEL := MF287
 endef
 TARGET_DEVICES += zte_mf287plus
 
+define Device/zte_mf287
+	$(call Device/zte_mf287_common)
+	DEVICE_PACKAGES += ipq-wifi-zte_mf287
+	DEVICE_DTS_CONFIG := config@ap.dk01.1-c2
+	DEVICE_MODEL := MF287
+endef
+TARGET_DEVICES += zte_mf287
+
 define Device/zte_mf287pro
 	$(call Device/zte_mf287_common)
+	DEVICE_PACKAGES += ipq-wifi-zte_mf287plus
 	DEVICE_DTS_CONFIG := config@ap.dk04.1-c1
 	DEVICE_MODEL := MF287Pro
 endef


### PR DESCRIPTION
Cherry-picked from 9c7578d560708c040dc04d0db37ef682db58f6b5 and 053f8f92d1395fa5d33b0b8f2fef44a4b926c112 to enable proper ZTE MF287 support in 23.05.