### PR TITLE
armsr: ensure kmod-fs-vfat is selected for mounting EFI partition during sysupgrade

### DIFF
--- a/target/linux/armsr/Makefile
+++ b/target/linux/armsr/Makefile
@@ -15,7 +15,8 @@ include $(INCLUDE_DIR)/target.mk
 
 DEFAULT_PACKAGES += mkf2fs e2fsprogs
 # blkid used for resolving PARTUUID
-# in sysupgrade
-DEFAULT_PACKAGES += blkid
+# in sysupgrade. vfat required for
+# mounting ESP partition
+DEFAULT_PACKAGES += blkid kmod-fs-vfat
 
 $(eval $(call BuildTarget))


### PR DESCRIPTION
vfat support is needed to mount the EFI System Partition (ESP) during sysupgrade. If it is not available, the sysupgrade process will not complete.