### PR TITLE
mediatek: add CMCC RAX3000M support

### DIFF
--- a/package/boot/arm-trusted-firmware-mediatek/Makefile
+++ b/package/boot/arm-trusted-firmware-mediatek/Makefile
@@ -94,6 +94,22 @@ define Trusted-Firmware-A/mt7622-sdmmc-2ddr
   DDR3_FLYBY:=1
 endef
 
+define Trusted-Firmware-A/mt7981-emmc-ddr4
+  NAME:=MediaTek MT7981 (eMMC, DDR4)
+  BOOT_DEVICE:=emmc
+  BUILD_SUBTARGET:=filogic
+  PLAT:=mt7981
+  DDR_TYPE:=ddr4
+endef
+
+define Trusted-Firmware-A/mt7981-spim-nand-ddr4
+  NAME:=MediaTek MT7981 (SPI-NAND via SPIM, DDR4)
+  BOOT_DEVICE:=spim-nand
+  BUILD_SUBTARGET:=filogic
+  PLAT:=mt7981
+  DDR_TYPE:=ddr4
+endef
+
 define Trusted-Firmware-A/mt7981-nor-ddr3
   NAME:=MediaTek MT7981 (SPI-NOR, DDR3)
   BOOT_DEVICE:=nor
@@ -349,6 +365,8 @@ TFA_TARGETS:= \
 	mt7981-sdmmc-ddr3 \
 	mt7981-snand-ddr3 \
 	mt7981-spim-nand-ddr3 \
+	mt7981-emmc-ddr4 \
+	mt7981-spim-nand-ddr4 \
 	mt7986-emmc-ddr3 \
 	mt7986-nor-ddr3 \
 	mt7986-sdmmc-ddr3 \

--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -37,6 +37,23 @@ bananapi,bpi-r3)
 		;;
 	esac
 	;;
+cmcc,rax3000m)
+	case "$(cmdline_get_var root)" in
+	/dev/mmc*)
+		local envdev=$(find_mmc_part "ubootenv" "mmcblk0")
+		ubootenv_add_uci_config "$envdev" "0x0" "0x40000" "0x40000" "1"
+		ubootenv_add_uci_config "$envdev" "0x40000" "0x40000" "0x40000" "1"
+		;;
+	*)
+		. /lib/upgrade/nand.sh
+		local envubi=$(nand_find_ubi ubi)
+		local envdev=/dev/$(nand_find_volume $envubi ubootenv)
+		local envdev2=/dev/$(nand_find_volume $envubi ubootenv2)
+		ubootenv_add_uci_config "$envdev" "0x0" "0x1f000" "0x1f000" "1"
+		ubootenv_add_uci_config "$envdev2" "0x0" "0x1f000" "0x1f000" "1"
+		;;
+	esac
+	;;
 glinet,gl-mt3000)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x20000"
 	;;

--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -200,6 +200,30 @@ define U-Boot/mt7629_rfb
   UBOOT_CONFIG:=mt7629_rfb
 endef
 
+define U-Boot/mt7981_cmcc_rax3000m-emmc
+  NAME:=CMCC RAX3000M
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=cmcc_rax3000m
+  UBOOT_CONFIG:=mt7981_cmcc_rax3000m-emmc
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=emmc
+  BL2_SOC:=mt7981
+  BL2_DDRTYPE:=ddr4
+  DEPENDS:=+trusted-firmware-a-mt7981-emmc-ddr4
+endef
+
+define U-Boot/mt7981_cmcc_rax3000m-nand
+  NAME:=CMCC RAX3000M
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=cmcc_rax3000m
+  UBOOT_CONFIG:=mt7981_cmcc_rax3000m-nand
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand
+  BL2_SOC:=mt7981
+  BL2_DDRTYPE:=ddr4
+  DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ddr4
+endef
+
 define U-Boot/mt7981_h3c_magic-nx30-pro
   NAME:=H3C Magic NX30 Pro
   BUILD_SUBTARGET:=filogic
@@ -496,6 +520,8 @@ UBOOT_TARGETS := \
 	mt7628_rfb \
 	ravpower_rp-wd009 \
 	mt7629_rfb \
+	mt7981_cmcc_rax3000m-emmc \
+	mt7981_cmcc_rax3000m-nand \
 	mt7981_h3c_magic-nx30-pro \
 	mt7981_rfb-spim-nand \
 	mt7981_rfb-emmc \

--- a/package/boot/uboot-mediatek/patches/437-add-cmcc_rax3000m.patch
+++ b/package/boot/uboot-mediatek/patches/437-add-cmcc_rax3000m.patch
@@ -1,0 +1,697 @@
+--- /dev/null
++++ b/configs/mt7981_cmcc_rax3000m-emmc_defconfig
+@@ -0,0 +1,175 @@
++CONFIG_ARM=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TARGET_MT7981=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7981-cmcc-rax3000m-emmc"
++CONFIG_DEFAULT_ENV_FILE="cmcc_rax3000m-emmc_env"
++CONFIG_DEFAULT_FDT_FILE="mediatek/mt7981-cmcc-rax3000m-emmc.dtb"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_SMBIOS_PRODUCT_NAME=""
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_BOOTDELAY=30
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_CFB_CONSOLE_ANSI=y
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_GPIO_HOG=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_FIT=y
++CONFIG_FIT_ENABLE_SHA256_SUPPORT=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++CONFIG_LOGLEVEL=7
++CONFIG_LOG=y
++CONFIG_SYS_PROMPT="MT7981> "
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_BOOTP=y
++CONFIG_CMD_BUTTON=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_CPU=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_ECHO=y
++CONFIG_CMD_ENV_READMEM=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_EXT4=y
++CONFIG_CMD_FAT=y
++CONFIG_CMD_FDT=y
++CONFIG_CMD_FS_GENERIC=y
++CONFIG_CMD_FS_UUID=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_ITEST=y
++CONFIG_CMD_LED=y
++CONFIG_CMD_LICENSE=y
++CONFIG_CMD_LINK_LOCAL=y
++# CONFIG_CMD_MBR is not set
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_SF_TEST=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_PXE=y
++CONFIG_CMD_PWM=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_TFTPBOOT=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_PART=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_SETEXPR=y
++CONFIG_CMD_SLEEP=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_SOURCE=y
++CONFIG_CMD_STRINGS=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_UUID=y
++CONFIG_DISPLAY_CPUINFO=y
++CONFIG_DM_MMC=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_DM_USB=y
++CONFIG_DM_PWM=y
++CONFIG_PWM_MTK=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_PARTITION_UUIDS=y
++CONFIG_NETCONSOLE=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_CLK=y
++CONFIG_DM_GPIO=y
++CONFIG_DM_SCSI=y
++CONFIG_AHCI=y
++CONFIG_AHCI_PCI=y
++CONFIG_SCSI_AHCI=y
++CONFIG_SCSI=y
++CONFIG_CMD_SCSI=y
++CONFIG_PHY=y
++CONFIG_PHY_MTK_TPHY=y
++CONFIG_PHY_FIXED=y
++CONFIG_MTK_AHCI=y
++CONFIG_DM_ETH=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PCI=y
++CONFIG_DM_PCI=y
++CONFIG_PCIE_MEDIATEK=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7622=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_PRE_CON_BUF_ADDR=0x4007EF00
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_RAM=y
++CONFIG_DM_SERIAL=y
++CONFIG_MTK_SERIAL=y
++CONFIG_MMC=y
++CONFIG_MMC_DEFAULT_DEV=1
++CONFIG_MMC_HS200_SUPPORT=y
++CONFIG_MMC_MTK=y
++CONFIG_MMC_SUPPORTS_TUNING=y
++CONFIG_SUPPORT_EMMC_BOOT=y
++CONFIG_SPI=y
++CONFIG_SYSRESET_WATCHDOG=y
++CONFIG_WDT_MTK=y
++CONFIG_LZO=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
++CONFIG_RANDOM_UUID=y
++CONFIG_REGEX=y
++CONFIG_USB=y
++CONFIG_USB_HOST=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_MTK=y
++CONFIG_USB_STORAGE=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_ENV_OFFSET=0x400000
++CONFIG_ENV_OFFSET_REDUND=0x440000
++CONFIG_ENV_SIZE=0x40000
++CONFIG_ENV_SIZE_REDUND=0x40000
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_CLK=y
++CONFIG_SUPPORT_EMMC_BOOT=y
++CONFIG_PHY_FIXED=y
++CONFIG_DM_ETH=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7981=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_SERIAL=y
++CONFIG_MTK_SERIAL=y
++CONFIG_HEXDUMP=y
++CONFIG_USE_DEFAULT_ENV_FILE=y
++CONFIG_CMD_SF=y
++CONFIG_LMB_MAX_REGIONS=64
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
+--- /dev/null
++++ b/configs/mt7981_cmcc_rax3000m-nand_defconfig
+@@ -0,0 +1,175 @@
++CONFIG_ARM=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TARGET_MT7981=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7981-cmcc-rax3000m-nand"
++CONFIG_DEFAULT_ENV_FILE="cmcc_rax3000m-nand_env"
++CONFIG_DEFAULT_FDT_FILE="mediatek/mt7981-cmcc-rax3000m-nand.dtb"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_SMBIOS_PRODUCT_NAME=""
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_BOOTDELAY=30
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_CFB_CONSOLE_ANSI=y
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_GPIO_HOG=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_FIT=y
++CONFIG_FIT_ENABLE_SHA256_SUPPORT=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++CONFIG_LOGLEVEL=7
++CONFIG_LOG=y
++CONFIG_SYS_PROMPT="MT7981> "
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_BOOTP=y
++CONFIG_CMD_BUTTON=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_CPU=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_ECHO=y
++CONFIG_CMD_ENV_READMEM=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_EXT4=y
++CONFIG_CMD_FAT=y
++CONFIG_CMD_FDT=y
++CONFIG_CMD_FS_GENERIC=y
++CONFIG_CMD_FS_UUID=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_ITEST=y
++CONFIG_CMD_LED=y
++CONFIG_CMD_LICENSE=y
++CONFIG_CMD_LINK_LOCAL=y
++# CONFIG_CMD_MBR is not set
++CONFIG_CMD_PCI=y
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_SF_TEST=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_PXE=y
++CONFIG_CMD_PWM=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_TFTPBOOT=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_CMD_UBIFS=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_PART=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_SETEXPR=y
++CONFIG_CMD_SLEEP=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_SOURCE=y
++CONFIG_CMD_STRINGS=y
++CONFIG_CMD_UUID=y
++CONFIG_DISPLAY_CPUINFO=y
++CONFIG_DM_MTD=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_DM_PWM=y
++CONFIG_PWM_MTK=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_PARTITION_UUIDS=y
++CONFIG_NETCONSOLE=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_CLK=y
++CONFIG_DM_GPIO=y
++CONFIG_DM_SCSI=y
++CONFIG_AHCI=y
++CONFIG_AHCI_PCI=y
++CONFIG_SCSI_AHCI=y
++CONFIG_SCSI=y
++CONFIG_CMD_SCSI=y
++CONFIG_PHY=y
++CONFIG_PHY_MTK_TPHY=y
++CONFIG_PHY_FIXED=y
++CONFIG_MTK_AHCI=y
++CONFIG_DM_ETH=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PCI=y
++# CONFIG_MMC is not set
++# CONFIG_DM_MMC is not set
++CONFIG_MTD=y
++CONFIG_MTD_UBI_FASTMAP=y
++CONFIG_DM_PCI=y
++CONFIG_PCIE_MEDIATEK=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7622=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_PRE_CON_BUF_ADDR=0x4007EF00
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_RAM=y
++CONFIG_DM_SERIAL=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPI_NAND=y
++CONFIG_MTK_SPI_NAND_MTD=y
++CONFIG_SYSRESET_WATCHDOG=y
++CONFIG_WDT_MTK=y
++CONFIG_LZO=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
++CONFIG_RANDOM_UUID=y
++CONFIG_REGEX=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_SIZE=0x1f000
++CONFIG_ENV_SIZE_REDUND=0x1f000
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_CLK=y
++CONFIG_PHY_FIXED=y
++CONFIG_DM_ETH=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7981=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_SERIAL=y
++CONFIG_MTK_SERIAL=y
++CONFIG_HEXDUMP=y
++CONFIG_USE_DEFAULT_ENV_FILE=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTK_SPIM=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_NAND=y
++CONFIG_CMD_NAND_TRIMFFS=y
++CONFIG_LMB_MAX_REGIONS=64
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
+--- /dev/null
++++ b/arch/arm/dts/mt7981-cmcc-rax3000m.dtsi
+@@ -0,0 +1,85 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Copyright (c) 2022 MediaTek Inc.
++ * Author: Sam Shih <sam.shih@mediatek.com>
++ */
++
++/dts-v1/;
++#include "mt7981.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/linux-event-codes.h>
++
++/ {
++	#address-cells = <1>;
++	#size-cells = <1>;
++	model = "CMCC RAX3000M";
++	compatible = "mediatek,mt7981", "mediatek,mt7981-rfb";
++
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x40000000 0x20000000>;
++	};
++
++	keys {
++		compatible = "gpio-keys";
++
++		button-reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
++		};
++
++		button-mesh {
++			label = "mesh";
++			linux,code = <BTN_9>;
++			linux,input-type = <EV_SW>;
++			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-0 {
++			label = "green:status";
++			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
++		};
++
++		led-1 {
++			label = "blue:status";
++			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
++		};
++
++		led-2 {
++			label = "red:status";
++			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&eth {
++	status = "okay";
++	mediatek,gmac-id = <0>;
++	phy-mode = "2500base-x";
++	mediatek,switch = "mt7531";
++	reset-gpios = <&gpio 39 GPIO_ACTIVE_HIGH>;
++
++	fixed-link {
++		speed = <2500>;
++		full-duplex;
++	};
++};
++
++&uart0 {
++	mediatek,force-highspeed;
++	status = "okay";
++};
++
++&watchdog {
++	status = "disabled";
++};
+--- /dev/null
++++ b/arch/arm/dts/mt7981-cmcc-rax3000m-emmc.dts
+@@ -0,0 +1,53 @@
++// SPDX-License-Identifier: GPL-2.0-only
++
++/dts-v1/;
++#include "mt7981-cmcc-rax3000m.dtsi"
++
++/ {
++	reg_3p3v: regulator-3p3v {
++		compatible = "regulator-fixed";
++		regulator-name = "fixed-3.3V";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++};
++
++&mmc0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc0_pins_default>;
++	max-frequency = <26000000>;
++	bus-width = <8>;
++	cap-mmc-hw-reset;
++	vmmc-supply = <&reg_3p3v>;
++	non-removable;
++	status = "okay";
++};
++
++&pinctrl {
++	mmc0_pins_default: mmc0default {
++		mux {
++			function = "flash";
++			groups =  "emmc_45";
++		};
++		conf-cmd-dat {
++			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO",
++				"SPI0_CS",  "SPI0_HOLD", "SPI0_WP",
++				"SPI1_CLK", "SPI1_MOSI", "SPI1_MISO";
++			input-enable;
++			drive-strength = <MTK_DRIVE_4mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_01>;
++		};
++		conf-clk {
++			pins = "SPI1_CS";
++			drive-strength = <MTK_DRIVE_6mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_10>;
++		};
++		conf-rst {
++			pins = "PWM0";
++			drive-strength = <MTK_DRIVE_4mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_01>;
++		};
++	};
++};
+--- /dev/null
++++ b/arch/arm/dts/mt7981-cmcc-rax3000m-nand.dts
+@@ -0,0 +1,77 @@
++// SPDX-License-Identifier: GPL-2.0-only
++
++/dts-v1/;
++#include "mt7981-cmcc-rax3000m.dtsi"
++
++&pinctrl {
++	spi_flash_pins: spi0-pins-func-1 {
++		mux {
++			function = "flash";
++			groups = "spi0", "spi0_wp_hold";
++		};
++
++		conf-pu {
++			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_00>;
++		};
++
++		conf-pd {
++			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_00>;
++		};
++	};
++};
++
++&spi0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi_flash_pins>;
++	status = "okay";
++	must_tx;
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <2>;
++	sample_sel = <0>;
++
++	spi_nand@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "bl2";
++				reg = <0x0 0x100000>;
++			};
++
++			partition@100000 {
++				label = "orig-env";
++				reg = <0x100000 0x80000>;
++			};
++
++			partition@160000 {
++				label = "factory";
++				reg = <0x180000 0x200000>;
++			};
++
++			partition@380000 {
++				label = "fip";
++				reg = <0x380000 0x200000>;
++			};
++
++			partition@580000 {
++				label = "ubi";
++				reg = <0x580000 0x7200000>;
++			};
++		};
++	};
++};
+--- /dev/null
++++ b/cmcc_rax3000m-emmc_env
+@@ -0,0 +1,55 @@
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x46000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootargs=root=/dev/mmcblk0p65
++bootcmd=if pstore check ; then run boot_recovery ; else run boot_emmc ; fi
++bootconf=config-1#mt7981b-cmcc-rax3000m-emmc
++bootdelay=0
++bootfile=openwrt-mediatek-filogic-cmcc_rax3000m-initramfs-recovery.itb
++bootfile_bl2=openwrt-mediatek-filogic-cmcc_rax3000m-emmc-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-cmcc_rax3000m-emmc-bl31-uboot.fip
++bootfile_upg=openwrt-mediatek-filogic-cmcc_rax3000m-squashfs-sysupgrade.itb
++bootled_pwr=red:status
++bootled_rec=blue:status
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=0
++bootmenu_title=      [0;34m( ( ( [1;39mOpenWrt[0;34m ) ) )  [0;36m[eMMC][0m
++bootmenu_0=Initialize environment.=run _firstboot
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=Boot system via TFTP.=run boot_tftp ; run bootmenu_confirm_return
++bootmenu_2=Boot production system from eMMC.=run boot_production ; run bootmenu_confirm_return
++bootmenu_3=Boot recovery system from eMMC.=run boot_recovery ; run bootmenu_confirm_return
++bootmenu_4=Load production system via TFTP then write to eMMC.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_production ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_5=Load recovery system via TFTP then write to eMMC.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_recovery ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_6=[31mLoad BL31+U-Boot FIP via TFTP then write to eMMC.[0m=run boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_7=[31mLoad BL2 preloader via TFTP then write to eMMC.[0m=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_8=Reboot.=reset
++bootmenu_9=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_first=if button reset ; then led $bootled_rec on ; run boot_tftp_recovery ; setenv flag_recover 1 ; run boot_default ; fi ; bootmenu
++boot_default=if env exists flag_recover ; then else run bootcmd ; fi ; run boot_recovery ; setenv replacevol 1 ; run boot_tftp_forever
++boot_production=led $bootled_pwr on ; run emmc_read_production && bootm $loadaddr#$bootconf ; led $bootled_pwr off
++boot_recovery=led $bootled_rec on ; run emmc_read_recovery && bootm $loadaddr#$bootconf ; led $bootled_rec off
++boot_emmc=run boot_production ; run boot_recovery
++boot_tftp_forever=led $bootled_rec on ; while true ; do run boot_tftp_recovery ; sleep 1 ; done
++boot_tftp_production=tftpboot $loadaddr $bootfile_upg && env exists replacevol && iminfo $loadaddr && run emmc_write_production ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp_recovery=tftpboot $loadaddr $bootfile && env exists replacevol && iminfo $loadaddr && run emmc_write_recovery ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp_write_fip=tftpboot $loadaddr $bootfile_fip && run emmc_write_fip
++boot_tftp_write_bl2=tftpboot $loadaddr $bootfile_bl2 && run emmc_write_bl2
++boot_tftp=tftpboot $loadaddr $bootfile && bootm $loadaddr#$bootconf
++mmc_write_vol=imszb $loadaddr image_size && test 0x$image_size -le 0x$part_size && mmc erase 0x$part_addr 0x$image_size && mmc write $loadaddr 0x$part_addr 0x$image_size
++mmc_read_vol=mmc read $loadaddr $part_addr 0x100 && imszb $loadaddr image_size && test 0x$image_size -le 0x$part_size && mmc read $loadaddr 0x$part_addr 0x$image_size && setexpr filesize $image_size * 0x200
++part_default=production
++part_recovery=recovery
++reset_factory=eraseenv && reset
++emmc_read_production=part start mmc 0 $part_default part_addr && part size mmc 0 $part_default part_size && run mmc_read_vol
++emmc_read_recovery=part start mmc 0 $part_recovery part_addr && part size mmc 0 $part_recovery part_size && run mmc_read_vol
++emmc_write_bl2=mmc partconf 0 1 1 1 && mmc erase 0x0 0x400 && mmc write $fileaddr 0x0 0x400 ; mmc partconf 0 1 1 0
++emmc_write_fip=mmc erase 0x3400 0x2000 && mmc write $fileaddr 0x3400 0x2000 && mmc erase 0x2000 0x800
++emmc_write_production=part start mmc 0 $part_default part_addr && part size mmc 0 $part_default part_size && run mmc_write_vol
++emmc_write_recovery=part start mmc 0 $part_recovery part_addr && part size mmc 0 $part_recovery part_size && run mmc_write_vol
++_init_env=setenv _init_env ; setenv _create_env ; saveenv ; saveenv
++_firstboot=setenv _firstboot ; run _switch_to_menu ; run _init_env ; run boot_first
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"
+--- /dev/null
++++ b/cmcc_rax3000m-nand_env
+@@ -0,0 +1,56 @@
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x46000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootconf=config-1#mt7981b-cmcc-rax3000m-nand
++bootcmd=if pstore check ; then run boot_recovery ; else run boot_ubi ; fi
++bootdelay=0
++bootfile=openwrt-mediatek-filogic-cmcc_rax3000m-initramfs-recovery.itb
++bootfile_bl2=openwrt-mediatek-filogic-cmcc_rax3000m-nand-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-cmcc_rax3000m-nand-bl31-uboot.fip
++bootfile_upg=openwrt-mediatek-filogic-cmcc_rax3000m-squashfs-sysupgrade.itb
++bootled_pwr=red:status
++bootled_rec=blue:status
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=0
++bootmenu_title=      [0;34m( ( ( [1;39mOpenWrt[0;34m ) ) )  [0;36m[SPI-NAND][0m
++bootmenu_0=Initialize environment.=run _firstboot
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=Boot system via TFTP.=run boot_tftp ; run bootmenu_confirm_return
++bootmenu_2=Boot production system from NAND.=run boot_production ; run bootmenu_confirm_return
++bootmenu_3=Boot recovery system from NAND.=run boot_recovery ; run bootmenu_confirm_return
++bootmenu_4=Load production system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_production ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_5=Load recovery system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_recovery ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_6=[31mLoad BL31+U-Boot FIP via TFTP then write to NAND.[0m=run boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_7=[31mLoad BL2 preloader via TFTP then write to NAND.[0m=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_8=Reboot.=reset
++bootmenu_9=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_first=if button reset ; then led $bootled_rec on ; run boot_tftp_recovery ; setenv flag_recover 1 ; run boot_default ; fi ; bootmenu
++boot_default=if env exists flag_recover ; then else run bootcmd ; fi ; run boot_recovery ; setenv replacevol 1 ; run boot_tftp_forever
++boot_production=led $bootled_pwr on ; run ubi_read_production && bootm $loadaddr#$bootconf ; led $bootled_pwr off
++boot_recovery=led $bootled_rec on ; run ubi_read_recovery && bootm $loadaddr#$bootconf ; led $bootled_rec off
++boot_ubi=run boot_production ; run boot_recovery ; run boot_tftp_forever
++boot_tftp_forever=led $bootled_rec on ; while true ; do run boot_tftp_recovery ; sleep 1 ; done
++boot_tftp_production=tftpboot $loadaddr $bootfile_upg && env exists replacevol && iminfo $loadaddr && run ubi_write_production ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp_recovery=tftpboot $loadaddr $bootfile && env exists replacevol && iminfo $loadaddr && run ubi_write_recovery ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp=tftpboot $loadaddr $bootfile && bootm $loadaddr#$bootconf
++boot_tftp_write_fip=tftpboot $loadaddr $bootfile_fip && run mtd_write_fip && run reset_factory
++boot_tftp_write_bl2=tftpboot $loadaddr $bootfile_bl2 && run mtd_write_bl2
++part_default=production
++part_recovery=recovery
++reset_factory=ubi part ubi ; mw $loadaddr 0x0 0x800 ; ubi write $loadaddr ubootenv 0x800 ; ubi write $loadaddr ubootenv2 0x800
++mtd_write_fip=mtd erase fip && mtd write fip $loadaddr
++mtd_write_bl2=mtd erase bl2 && mtd write bl2 $loadaddr
++ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x100000 dynamic 0 || run ubi_format ; ubi check ubootenv2 || ubi create ubootenv2 0x100000 dynamic 1 || run ubi_format
++ubi_format=ubi detach ; mtd erase ubi && ubi part ubi ; reset
++ubi_prepare_rootfs=if ubi check rootfs_data ; then else if env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi ; fi
++ubi_read_production=ubi read $loadaddr fit && iminfo $loadaddr && run ubi_prepare_rootfs
++ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery
++ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++ubi_write_production=ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic 2 && ubi write $loadaddr fit $filesize
++ubi_write_recovery=ubi check recovery && ubi remove recovery ; run ubi_remove_rootfs ; ubi create recovery $filesize dynamic 3 && ubi write $loadaddr recovery $filesize
++_init_env=setenv _init_env ; run ubi_create_env ; saveenv ; saveenv
++_firstboot=setenv _firstboot ; run _switch_to_menu ; run _init_env ; run boot_first
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"

--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-emmc.dtso
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-emmc.dtso
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "cmcc,rax3000m", "mediatek,mt7981";
+
+	fragment@0 {
+		target = <&mmc0>;
+		__overlay__ {
+			bus-width = <8>;
+			max-frequency = <26000000>;
+			no-sd;
+			no-sdio;
+			non-removable;
+			pinctrl-names = "default", "state_uhs";
+			pinctrl-0 = <&mmc0_pins_default>;
+			pinctrl-1 = <&mmc0_pins_uhs>;
+			vmmc-supply = <&reg_3p3v>;
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&pio>;
+		__overlay__ {
+			mmc0_pins_default: mmc0-pins {
+				mux {
+					function = "flash";
+					groups = "emmc_45";
+				};
+			};
+
+			mmc0_pins_uhs: mmc0-uhs-pins {
+				mux {
+					function = "flash";
+					groups = "emmc_45";
+				};
+			};
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-nand.dtso
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-nand.dtso
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "cmcc,rax3000m", "mediatek,mt7981";
+
+	fragment@0 {
+		target = <&gmac0>;
+		__overlay__ {
+			nvmem-cells = <&macaddr_factory_2a 0>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+
+	fragment@1 {
+		target = <&gmac1>;
+		__overlay__ {
+			nvmem-cells = <&macaddr_factory_24 0>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+
+	fragment@2 {
+		target = <&pio>;
+		__overlay__ {
+			spi0_flash_pins: spi0-pins {
+				mux {
+					function = "spi";
+					groups = "spi0", "spi0_wp_hold";
+				};
+
+				conf-pu {
+					pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+					drive-strength = <8>;
+					mediatek,pull-up-adv = <0>; /* bias-disable */
+				};
+
+				conf-pd {
+					pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+					drive-strength = <8>;
+					mediatek,pull-up-adv = <0>; /* bias-disable */
+				};
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&spi0>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi0_flash_pins>;
+			status = "okay";
+
+			spi_nand@0 {
+				compatible = "spi-nand";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				reg = <0>;
+
+				spi-max-frequency = <52000000>;
+				spi-tx-bus-width = <4>;
+				spi-rx-bus-width = <4>;
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					partition@0 {
+						label = "bl2";
+						reg = <0x00000 0x0100000>;
+						read-only;
+					};
+
+					partition@100000 {
+						label = "u-boot-env";
+						reg = <0x100000 0x80000>;
+					};
+
+					factory: partition@180000 {
+						label = "factory";
+						reg = <0x180000 0x200000>;
+						read-only;
+
+						compatible = "nvmem-cells";
+						nvmem-layout {
+							compatible = "fixed-layout";
+							#address-cells = <1>;
+							#size-cells = <1>;
+
+							macaddr_factory_24: macaddr@24 {
+								compatible = "mac-base";
+								reg = <0x24 0x6>;
+								#nvmem-cell-cells = <1>;
+							};
+
+							macaddr_factory_2a: macaddr@2a {
+								compatible = "mac-base";
+								reg = <0x2a 0x6>;
+								#nvmem-cell-cells = <1>;
+							};
+						};
+					};
+
+					partition@380000 {
+						label = "fip";
+						reg = <0x380000 0x200000>;
+						read-only;
+					};
+
+					partition@580000 {
+						label = "ubi";
+						reg = <0x580000 0x7200000>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&wifi>;
+		__overlay__ {
+			mediatek,mtd-eeprom = <&factory 0x0>;
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m.dts
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m.dts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (C) 2023 Tianling Shen <cnsztl@immortalwrt.org>
+ */
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "CMCC RAX3000M";
+	compatible = "cmcc,rax3000m", "mediatek,mt7981";
+
+	aliases {
+		led-boot = &red_led;
+		led-failsafe = &red_led;
+		led-running = &green_led;
+		led-upgrade = &green_led;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x20000000>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		button-mesh {
+			label = "mesh";
+			linux,code = <BTN_9>;
+			linux,input-type = <EV_SW>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		green_led: led-0 {
+			label = "green:status";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			label = "blue:status";
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		red_led: led-2 {
+			label = "red:status";
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+	};
+};
+
+&mdio_bus {
+	switch: switch@0 {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan3";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan1";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -29,6 +29,7 @@ mediatek_setup_interfaces()
 	glinet,gl-mt3000)
 		ucidef_set_interfaces_lan_wan eth1 eth0
 		;;
+	cmcc,rax3000m|\
 	h3c,magic-nx30-pro)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" eth1
 		;;
@@ -90,6 +91,15 @@ mediatek_setup_macs()
 		lan_mac=$(mtd_get_mac_binary "art" 0)
 		wan_mac=$(macaddr_add "$lan_mac" 3)
 		label_mac=$lan_mac
+		;;
+	cmcc,rax3000m)
+		case "$(cmdline_get_var root)" in
+		/dev/mmc*)
+			wan_mac=$(mmc_get_mac_binary factory 0x2a)
+			lan_mac=$(mmc_get_mac_binary factory 0x24)
+			label_mac=$wan_mac
+		;;
+		esac
 		;;
 	glinet,gl-mt6000)
 		label_mac=$(mmc_get_mac_binary factory 0x0a)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -16,6 +16,13 @@ case "$FIRMWARE" in
 	;;
 "mediatek/mt7981_eeprom_mt7976_dbdc.bin")
 	case "$board" in
+	cmcc,rax3000m)
+		case "$(cmdline_get_var root)" in
+		/dev/mmc*)
+			caldata_extract_mmc "factory" 0x0 0x1000
+			;;
+		esac
+		;;
 	ubnt,unifi-6-plus)
 		caldata_extract_mmc "factory" 0x0 0x1000
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -35,6 +35,17 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $addr 2) > /sys${DEVPATH}/macaddress
 		;;
+	cmcc,rax3000m)
+		case "$(cmdline_get_var root)" in
+		/dev/mmc*)
+			addr=$(mmc_get_mac_binary factory 0xa)
+			;;
+		*)
+			addr=$(mtd_get_mac_binary factory 0xa)
+			;;
+		esac
+		[ "$PHYNBR" = "1" ] && echo "$addr" > /sys${DEVPATH}/macaddress
+		;;
 	cudy,wr3000-v1)
 		addr=$(mtd_get_mac_binary bdinfo 0xde00)
 		# Originally, phy0 is phy1 mac with LA bit set. However, this would conflict

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -81,6 +81,18 @@ platform_do_upgrade() {
 			;;
 		esac
 		;;
+	cmcc,rax3000m)
+		case "$(cmdline_get_var root)" in
+		/dev/mmc*)
+			CI_KERNPART="production"
+			emmc_do_upgrade "$1"
+			;;
+		*)
+			CI_KERNPART="fit"
+			nand_do_upgrade "$1"
+			;;
+		esac
+		;;
 	cudy,wr3000-v1)
 		default_do_upgrade "$1"
 		;;
@@ -130,7 +142,8 @@ platform_check_image() {
 	[ "$#" -gt 1 ] && return 1
 
 	case "$board" in
-	bananapi,bpi-r3)
+	bananapi,bpi-r3|\
+	cmcc,rax3000m)
 		[ "$magic" != "d00dfeed" ] && {
 			echo "Invalid image type."
 			return 1
@@ -148,7 +161,8 @@ platform_check_image() {
 
 platform_copy_config() {
 	case "$(board_name)" in
-	bananapi,bpi-r3)
+	bananapi,bpi-r3|\
+	cmcc,rax3000m)
 		case "$(cmdline_get_var root)" in
 		/dev/mmc*)
 			emmc_copy_config

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -204,6 +204,39 @@ define Device/cetron_ct3003
 endef
 TARGET_DEVICES += cetron_ct3003
 
+define Device/cmcc_rax3000m
+  DEVICE_VENDOR := CMCC
+  DEVICE_MODEL := RAX3000M
+  DEVICE_DTS := mt7981b-cmcc-rax3000m
+  DEVICE_DTS_OVERLAY := mt7981b-cmcc-rax3000m-emmc mt7981b-cmcc-rax3000m-nand
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTC_FLAGS := --pad 4096
+  DEVICE_DTS_LOADADDR := 0x43f00000
+  DEVICE_PACKAGES := kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 \
+	e2fsprogs f2fsck mkf2fs
+  KERNEL_LOADADDR := 0x44000000
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
+  IMAGE/sysupgrade.itb := append-kernel | \
+	 fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
+	 pad-rootfs | append-metadata
+  ARTIFACTS := \
+	emmc-gpt.bin emmc-preloader.bin emmc-bl31-uboot.fip \
+	nand-preloader.bin nand-bl31-uboot.fip
+  ARTIFACT/emmc-gpt.bin := mt798x-gpt emmc
+  ARTIFACT/emmc-preloader.bin := mt7981-bl2 emmc-ddr4
+  ARTIFACT/emmc-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-emmc
+  ARTIFACT/nand-preloader.bin := mt7981-bl2 spim-nand-ddr4
+  ARTIFACT/nand-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-nand
+endef
+TARGET_DEVICES += cmcc_rax3000m
+
 define Device/cudy_wr3000-v1
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := WR3000


### PR DESCRIPTION
```
Hardware specification:
  SoC: MediaTek MT7981B 2x A53
  Flash: 64GB eMMC or 128 MB SPI-NAND
  RAM: 512MB
  Ethernet: 4x 10/100/1000 Mbps
  Switch: MediaTek MT7531AE
  WiFi: MediaTek MT7976C
  Button: Reset, Mesh
  Power: DC 12V 1A
- UART: 3.3v, 115200n8
  --------------------------
  |         Layout         |
  |   -----------------    |
  | 4 | GND TX VCC RX | <= |
  |   -----------------    |
  --------------------------

Gain SSH access:
1. Login into web interface, and download the configuration.
2. Enter fakeroot, decompress the configuration:
   tar -zxf cfg_export_config_file.conf
3. Edit 'etc/config/dropbear', set 'enable' to '1'.
4. Edit 'etc/shadow', update (remove) root password:
   'root::19523:0:99999:7:::'
5. Repack 'etc' directory:
   tar -zcf cfg_export_config_file.conf etc/
   * If you find an error about 'etc/wireless/mediatek/DBDC_card0.dat',
     just ignore it.
6. Upload new configuration via web interface, now you can SSH to RAX3000M.

Check stroage type:
Check the label on the back of the device:
"CH EC CMIIT ID: xxxx" is eMMC version
"CH    CMIIT ID: xxxx" is NAND version

eMMC Flash instructions:
1. SSH to RAX3000M, and backup everything, especially 'factory' part.
   ('data' partition can be ignored, it's useless.)
2. Write new GPT table:
   dd if=openwrt-mediatek-filogic-cmcc_rax3000m-emmc-gpt.bin of=/dev/mmcblk0 bs=512 seek=0 count=34 conv=fsync
3. Erase and write new BL2:
   echo 0 > /sys/block/mmcblk0boot0/force_ro
   dd if=/dev/zero of=/dev/mmcblk0boot0 bs=512 count=8192 conv=fsync
   dd if=openwrt-mediatek-filogic-cmcc_rax3000m-emmc-preloader.bin of=/dev/mmcblk0boot0 bs=512 conv=fsync
4. Erase and write new FIP:
   dd if=/dev/zero of=/dev/mmcblk0 bs=512 seek=13312 count=8192 conv=fsync
   dd if=openwrt-mediatek-filogic-cmcc_rax3000m-emmc-bl31-uboot.fip of=/dev/mmcblk0 bs=512 seek=13312 conv=fsync
5. Set static IP on your PC:
   IP 192.168.1.254, GW 192.168.1.1
6. Serve OpenWrt initramfs image using TFTP server.
7. Cut off the power and re-engage, wait for TFTP recovery to complete.
8. After OpenWrt has booted, perform sysupgrade.
9. Additionally, if you want to have eMMC recovery boot feature:
     (Don't worry! You will always have TFTP recovery boot feature.)
   dd if=openwrt-mediatek-filogic-cmcc_rax3000m-initramfs-recovery.itb of=/dev/mmcblk0p4 bs=512 conv=fsync

NAND Flash instructions:
1. SSH to RAX3000M, and backup everything, especially 'Factory' part.
2. Erase and write new BL2:
   mtd erase BL2
   mtd write openwrt-mediatek-filogic-cmcc_rax3000m-nand-preloader.bin BL2
3. Erase and write new FIP:
   mtd erase FIP
   mtd write openwrt-mediatek-filogic-cmcc_rax3000m-nand-bl31-uboot.fip FIP
4. Set static IP on your PC:
   IP 192.168.1.254, GW 192.168.1.1
5. Serve OpenWrt initramfs image using TFTP server.
6. Cut off the power and re-engage, wait for TFTP recovery to complete.
7. After OpenWrt has booted, erase UBI volumes:
   ubidetach -p /dev/mtd0
   ubiformat -y /dev/mtd0
   ubiattach -p /dev/mtd0
8. Create new ubootenv volumes:
   ubimkvol /dev/ubi0 -n 0 -N ubootenv -s 128KiB
   ubimkvol /dev/ubi0 -n 1 -N ubootenv2 -s 128KiB
9. Additionally, if you want to have NAND recovery boot feature:
     (Don't worry! You will always have TFTP recovery boot feature.)
   ubimkvol /dev/ubi0 -n 2 -N recovery -s 20MiB
   ubiupdatevol /dev/ubi0_2 openwrt-mediatek-filogic-cmcc_rax3000m-initramfs-recovery.itb
10. Perform sysupgrade.
```

- - -

BTW I find a strange issue that the MTD partitions defined in dts overlay seem to be reversed, not sure why:
```
[    0.753116] 5 fixed-partitions partitions found on MTD device spi0.0
[    0.759478] Creating 5 MTD partitions on "spi0.0":
[    0.764268] 0x000000580000-0x000007780000 : "ubi"
[    0.832004] 0x000000380000-0x000000580000 : "fip"
[    0.838513] 0x000000180000-0x000000380000 : "factory"
[    0.845646] 0x000000100000-0x000000180000 : "u-boot-env"
[    0.851689] 0x000000000000-0x000000100000 : "bl2"
```