### PR TITLE
openssl: update to 3.0.11

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.0.10
+PKG_VERSION:=3.0.11
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
@@ -24,7 +24,7 @@ PKG_SOURCE_URL:= \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/old/$(PKG_BASE)/
 
-PKG_HASH:=1761d4f5b13a1028b9b6f3d4b8e17feb0cedc9370f6afe61d7193d2cdce83323
+PKG_HASH:=b3425d3bb4a2218d0697eb41f7fc0cdede016ed19ca49d168b78e8d947887f55
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
This update contains bugfixes and security fixes

Changes between 3.0.10 and 3.0.11 [19 Sep 2023]
 * Fix POLY1305 MAC implementation corrupting XMM registers on Windows. ([CVE-2023-4807])

compile && run tested on ramips/mt7621 devices: beeline smartbox turbo-plus, wifire s1500, xiaomi mi router 3 pro
