### PR TITLE
realtek: 5.15: rtl93xx: support 2500baseT and 5000baseT on USXGMII links

### DIFF
--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
@@ -429,8 +429,11 @@ static void rtl93xx_phylink_validate(struct dsa_switch *ds, int port,
 		phylink_set(mask, 10000baseCR_Full);
 	}
 
-	if (state->interface == PHY_INTERFACE_MODE_USXGMII)
+	if (state->interface == PHY_INTERFACE_MODE_USXGMII) {
+		phylink_set(mask, 2500baseT_Full);
+		phylink_set(mask, 5000baseT_Full);
 		phylink_set(mask, 10000baseT_Full);
+	}
 
 	phylink_set(mask, 10baseT_Half);
 	phylink_set(mask, 10baseT_Full);


### PR DESCRIPTION
The USXGMII implementation of Realtek switches can not only support 10GbE but also 2.5Gb and 5Gb on top of the usual data rates. Mark those as supported to allow them to be negotiated.

This change has been tested on a ZyXEL XGS1250-12 with the following link partners:
 - NWA50AX Pro (2.5Gb)
 - RTL8152 USB NIC (2.5Gb)
 - AQC111 USB NIC (2.5Gb & 5Gb)

Gbit and 10GbE has also been tested to still work fine with a variety of devices.

This fixes #12507
