### PR TITLE
rtl838x: led initialization

### DIFF
--- a/target/linux/realtek/dts-5.15/rtl8380_netgear_gs308t-v1.dts
+++ b/target/linux/realtek/dts-5.15/rtl8380_netgear_gs308t-v1.dts
@@ -3,6 +3,7 @@
 #include "rtl8380_netgear_gigabit_3xx.dtsi"
 
 #include <dt-bindings/leds/common.h>
+#include <dt-bindings/leds/rtl838x-leds.h>
 
 / {
 	compatible = "netgear,gs308t-v1", "realtek,rtl838x-soc";
@@ -31,5 +32,25 @@
 			function = LED_FUNCTION_POWER;
 			gpios = <&gpio1 31 GPIO_ACTIVE_LOW>;
 		};
+	};
+
+	port_leds {
+		compatible = "realtek,rtl838x-leds";
+
+		// two leds per port
+		leds-per-port = <RTL838x_NUM_LEDS_TWO_LEDS>;
+
+		// serial control mode
+		led-control = <RTL838x_LEDS_CONTROL_SERIAL>;
+
+		// blink all leds on power-on
+		power-on-blink;
+
+		// beware - due to how the leds are wired (back-to-back), only one of
+		// them can be active at any given time. if both would light up,
+		// both will go off.
+		// this limits the number of useful combinations.
+		led_green: led-0-mode = <RTL838x_LEDS_MODE_LINK_ACT_1G>;
+		led_amber: led-1-mode = <RTL838x_LEDS_MODE_LINK_ACT_100M_10M>;
 	};
 };

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
@@ -229,6 +229,8 @@ static int rtl83xx_setup(struct dsa_switch *ds)
 	msleep(1000);
 	priv->r->pie_init(priv);
 
+	priv->r->led_init(priv);
+
 	return 0;
 }
 

--- a/target/linux/realtek/files-5.15/include/dt-bindings/leds/rtl838x-leds.h
+++ b/target/linux/realtek/files-5.15/include/dt-bindings/leds/rtl838x-leds.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (C) 2023 Peter Körner
+ *
+ * RTL83XX leds
+ */
+#ifndef __DT_BINDINGS_LEDS_RTL83XX_H
+#define __DT_BINDINGS_LEDS_RTL83XX_H
+
+// https://svanheule.net/realtek/maple/register/led_glb_ctrl
+#define RTL838x_NUM_LEDS_NO_LEDS (0x0)
+#define RTL838x_NUM_LEDS_ONE_LED (0x1)
+#define RTL838x_NUM_LEDS_TWO_LEDS (0x3)
+#define RTL838x_NUM_LEDS_THREE_LEDS (0x7)
+
+// https://svanheule.net/realtek/maple/register/led_mode_sel
+#define RTL838x_LEDS_CONTROL_SERIAL (0x0)
+#define RTL838x_LEDS_CONTROL_SINGLE_COLOR_SCAN (0x1)
+#define RTL838x_LEDS_CONTROL_BI_COLOR_SCAN (0x2)
+#define RTL838x_LEDS_CONTROL_LEDS_DISABLED (0x3)
+
+// https://svanheule.net/realtek/maple/register/led_mode_ctrl
+#define RTL838x_LEDS_MODE_LINK_ACT (0)
+#define RTL838x_LEDS_MODE_LINK (1)
+#define RTL838x_LEDS_MODE_ACT (2)
+#define RTL838x_LEDS_MODE_ACT_RX (3)
+#define RTL838x_LEDS_MODE_ACT_TX (4)
+#define RTL838x_LEDS_MODE_LINK_1G (7)
+#define RTL838x_LEDS_MODE_LINK_100M (8)
+#define RTL838x_LEDS_MODE_LINK_10M (9)
+#define RTL838x_LEDS_MODE_LINK_ACT_1G (10)
+#define RTL838x_LEDS_MODE_LINK_ACT_100M (11)
+#define RTL838x_LEDS_MODE_LINK_ACT_10M (12)
+#define RTL838x_LEDS_MODE_LINK_ACT_1G_100M (13)
+#define RTL838x_LEDS_MODE_LINK_ACT_1G_10M (14)
+#define RTL838x_LEDS_MODE_LINK_ACT_100M_10M (15)
+#define RTL838x_LEDS_MODE_DISABLED (31)
+
+
+#endif /* __DT_BINDINGS_LEDS_RTL83XX_H */


### PR DESCRIPTION
Adds LED initialization code to `dsa/rtl83xx/rtl838x.c` similar to the `rtl93xx` driver. The LEDs are initialized in the same way, that `rtk network on` in u-boot does on a `netgear gs308t`. LED initialization is opt-in by the device tree and currently only configured for the `gs308t`, which is the device I currently have at hand. On other systems the LEDs might be wired differently and need different configuration, although the driver code should be compatible with all variations that the soc supports.

I intend to follow this PR up with one, that adds sysfs-endpoints to control the LED-Mode from userspace and also allows for manual control over the LEDs for features like Port-Identification, LAG-Ports Identification, PoE-Status Display on LEDs.