### PR TITLE
lantiq: add support for Arcadyan VRV9510KWAC23

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vrv9510kwac23.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vrv9510kwac23.dts
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	compatible = "arcadyan,vrv9510kwac23", "lantiq,xway", "lantiq,vr9";
+	model = "Arcadyan VRV9510KWAC23";
+	chosen {
+		bootargs = "console=ttyLTQ0,115200 mem=254M vpe1_load_addr=0x8fe00000 vpe1_mem=2M maxvpes=1 maxtcs=1 nosmp";
+	};
+
+	aliases {
+		led-boot = &power_green;
+		led-failsafe = &upgrade;
+		led-running = &power_green;
+		led-upgrade = &power_green;
+		led-internet = &internet_green;
+		led-wifi = &wireless_green;
+	};
+
+	bcm43222-sprom {
+		compatible = "brcm,ssb-sprom";
+
+		pci-bus = <0>;
+		pci-dev = <14>;
+
+		nvmem-cells = <&macaddr_boardconfig_16 1>;
+		nvmem-cell-names = "mac-address";
+
+		brcm,sprom = "brcm/bcm43222-sprom.bin";
+		brcm,sprom-fixups = <2   0x04d2>, 
+				    <65  0x1308>, <68  0x0402>,
+				    <70  0x1cc6>, <71  0x3c49>,
+				    <72  0x1132>, <87  0x0315>,
+				    <88  0x0315>, <96  0x2048>,
+				    <97  0xfeed>, <98  0x153e>,
+				    <99  0xfb1f>, <100 0x3e54>,
+				    <101 0x3848>, <102 0xfea0>, 
+				    <103 0x145c>, <104 0xfaf0>,
+				    <105 0xfe6e>, <106 0x110c>,
+				    <107 0xfb7e>, <108 0xff00>,
+				    <109 0x13c4>, <110 0xfb30>, 
+				    <111 0x0000>, <112 0x204c>, 
+				    <113 0xfeb8>, <114 0x1508>, 
+				    <115 0xfacb>, <116 0x3e48>,
+				    <117 0x3848>, <118 0xfeb2>, 
+				    <119 0x156e>, <120 0xfabf>, 
+				    <121 0xfe57>, <122 0x1139>,
+				    <123 0xfb6d>, <124 0xff38>,
+				    <125 0x13ee>, <126 0xfb6d>,
+				    <127 0x0000>, <161 0x0000>,
+				    <162 0x0000>, <169 0x0000>,
+				    <170 0x0000>, <171 0x0000>,
+				    <172 0x0000>, <173 0x0000>,
+				    <174 0x0000>, <175 0x0000>,
+				    <176 0x0000>, <219 0x1108>,
+				    <127 0x0000>, <161 0x0000>,
+				    <162 0x0000>, <169 0x0000>,
+				    <170 0x0000>, <171 0x0000>,
+				    <172 0x0000>, <173 0x0000>,
+				    <174 0x0000>, <175 0x0000>,
+				    <176 0x0000>, <219 0x1108>;
+	};
+
+	bcm4360-sprom {
+		compatible = "brcm,bcma-sprom";
+
+		pci-bus = <2>;
+		pci-dev = <0>;
+
+		nvmem-cells = <&macaddr_boardconfig_16 1>;
+		nvmem-cell-names = "mac-address";
+
+		brcm,sprom = "brcm/bcm4360-sprom.bin";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+		wps {
+			label = "wps";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+		service {
+			label = "service";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		// from top to bottom
+		power_green: power {
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+		};
+		internet_green: internet_green {
+			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+		};
+		internet_red {
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_FAULT;
+		};
+		phone {
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+		lan {
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_LAN;
+		};
+		wireless_blue {
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_BLUE>;
+		};
+		wireless_green: wireless_green {
+			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+		};
+		upgrade: upgrade {
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_BLUE>;
+		};
+	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 32 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&localbus {
+	flash@0 {
+		compatible = "lantiq,nand-xway";
+		lantiq,cs = <1>;
+		bank-width = <2>;
+		reg = <0 0x0 0x2000000>;
+
+		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
+		pinctrl-names = "default";
+
+		nand-use-soft-ecc-engine;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "uboot";
+				reg = <0x00000 0x80000>;
+				read-only;
+			};
+			partition@80000 {
+				label = "u-boot-env";
+				reg = <0x80000 0x20000>;
+			};
+			partition@a0000 {
+				label = "kernel";
+				reg = <0xa0000 0x400000>;
+			};
+			partition@540000 {
+				label = "ubi";
+				reg = <0x4a0000 0x7a00000>;
+			};
+			boardconfig: partition@7ea0000 {
+				label = "board_config";
+				reg = <0x7ea0000 0x1000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_boardconfig_16: macaddr@16 {
+						compatible = "mac-base";
+						reg = <0x16 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&eth0 {
+	nvmem-cells = <&macaddr_boardconfig_16 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		pci_rst {
+			lantiq,pins = "io21";
+			lantiq,output = <1>;
+			lantiq,open-drain = <0>;
+			lantiq,pull = <2>;
+		};
+		pcie_rst {
+			lantiq,pins = "io25";
+			lantiq,output = <1>;
+			lantiq,open-drain = <0>;
+			lantiq,pull = <2>;
+		};
+		usb_vbus {
+			lantiq,pins = "io32";
+			lantiq,output = <1>;
+			lantiq,open-drain = <0>;
+			lantiq,pull = <2>;
+		};
+	};
+};
+
+&gswip {
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+};
+
+&gswip_mdio {
+	phy0: ethernet-phy@0 {
+		reg = <0x0>;
+	};
+	phy1: ethernet-phy@1 {
+		reg = <0x1>;
+	};
+	phy5: ethernet-phy@5 {
+		reg = <0x5>;
+	};
+	phy11: ethernet-phy@11 {
+		reg = <0x11>;
+	};
+	phy13: ethernet-phy@13 {
+		reg = <0x13>;
+	};
+};
+
+&gswip_ports {
+	port@0 {
+		reg = <0>;
+		label = "lan3";
+		phy-mode = "rgmii-id";
+		tx-internal-delay-ps = <1500>;
+		rx-internal-delay-ps = <1500>;
+		phy-handle = <&phy0>;
+	};
+	port@1 {
+		reg = <1>;
+		label = "lan2";
+		phy-mode = "rgmii-id";
+		tx-internal-delay-ps = <1500>;
+		rx-internal-delay-ps = <1500>;
+		phy-handle = <&phy1>;
+	};
+	port@2 {
+		reg = <2>;
+		label = "lan1";
+		phy-mode = "internal";
+		phy-handle = <&phy11>;
+	};
+	port@4 {
+		reg = <4>;
+		label = "wan";
+		phy-mode = "internal";
+		phy-handle = <&phy13>;
+	};
+	port@5 {
+		reg = <5>;
+		label = "lan4";
+		phy-mode = "rgmii-id";
+		tx-internal-delay-ps = <1500>;
+		rx-internal-delay-ps = <1500>;
+		phy-handle = <&phy5>;
+	};
+};
+
+&pci0 {
+	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
+	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
+};
+
+&pcie0 {
+	status = "okay";
+
+	gpio-reset = <&gpio 25 GPIO_ACTIVE_HIGH>;
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	vbus-supply = <&usb_vbus>;
+};
+
+&usb1 {
+	status = "okay";
+	vbus-supply = <&usb_vbus>;
+};
+
+&vmmc {
+	status = "okay";
+	gpios = <&gpio 30 GPIO_ACTIVE_HIGH  //fxs relay
+		 &gpio 31 GPIO_ACTIVE_HIGH  //still unknown
+		 &gpio 3  GPIO_ACTIVE_HIGH>; //reset_slic?
+};

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -107,6 +107,21 @@ define Device/arcadyan_vgv7519-nor
 endef
 TARGET_DEVICES += arcadyan_vgv7519-nor
 
+define Device/arcadyan_vrv9510kwac23
+  $(Device/dsa-migration)
+  $(Device/NAND)
+  DEVICE_VENDOR := Arcadyan
+  DEVICE_MODEL := VRV9510KWAC23
+  DEVICE_ALT0_VENDOR := Livebox
+  DEVICE_ALT0_MODEL := Next
+  BOARD_NAME := VRV9510KWAC23
+  DEVICE_PACKAGES :=  kmod-b43 wpad-basic-mbedtls broadcom-43222-sprom \
+    broadcom-4360-sprom kmod-usb-dwc2 kmod-ltq-tapi kmod-ltq-vmmc
+  KERNEL_SIZE := 4096k
+  SUPPORTED_DEVICES += arcadyan_vrv9510kwac23
+endef
+TARGET_DEVICES += arcadyan_vrv9510kwac23
+
 define Device/avm_fritz3370
   $(Device/dsa-migration)
   $(Device/AVM)

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
@@ -31,6 +31,10 @@ arcadyan,vgv7510kw22-nor|\
 arcadyan,vgv7510kw22-brn)
 	ucidef_set_led_netdev "internet" "internet" "$led_internet" "wan"
 	;;
+arcadyan,vrv9510kwac23)
+	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
+	ucidef_set_led_wlan "wifi" "wifi" "green:wlan" "phy1radio"
+	;;
 zyxel,p-2812hnu-f1|\
 zyxel,p-2812hnu-f3)
 	ucidef_set_led_wlan "wifi" "wifi" "green:wlan" "phy0radio"

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -26,6 +26,7 @@ lantiq_setup_interfaces()
 	arcadyan,vgv7510kw22-nor|\
 	arcadyan,vgv7519-brn|\
 	arcadyan,vgv7519-nor|\
+	arcadyan,vrv9510kwac23|\
 	bt,homehub-v5a|\
 	lantiq,easy80920-nand|\
 	lantiq,easy80920-nor|\
@@ -114,7 +115,8 @@ lantiq_setup_macs()
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary board_config 0x16)" 2)
 		;;
 	arcadyan,vgv7519-brn|\
-	arcadyan,vgv7519-nor)
+	arcadyan,vgv7519-nor|\
+	arcadyan,vrv9510kwac23)
 		wan_mac=$(mtd_get_mac_binary board_config 0x16)
 		;;
 	avm,fritz3370-rev2-hynix|\

--- a/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
+++ b/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
@@ -9,6 +9,7 @@ platform_do_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
+	arcadyan,vrv9510kwac23|\
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
 	avm,fritz3390|\


### PR DESCRIPTION
The Arcadyan VRV9510KWAC23 (commercial name Livebox Next) is a Lantiq router distributed by Orange Spain

Hardware:
-   SoC: Lantiq VRX200
-   CPU: 2x MIPS 34Kc 500 MHz
-   RAM: 256 MiB DDR2
-   Flash: 128 MiB NAND
-   Ethernet: Built-in Gigabit Ethernet switch, 5x 1GbE
-   Wifi 2.4GHz: Broadcom BCM43222KFBG 802.11b/g/b MIMO 2T2R
-   Wifi 5GHz: Broadcom BCM4360KMLG 802.11ac MIMO 3T3R
-   USB: 2x USB 2.0
-   DSL: Built-in VDSL/ADSL2+ XWAY VRX208
-   LEDs: 8x
-   Buttons: 4x
-   Phone: Lantiq PEF 42068 V XWAY SLIC120

Install instructions:
Detailed instructions can be found on the wiki https://openwrt.org/toh/arcadyan/vrv9510kwac23
1. Boot into UART mode and upload the the https://raw.githubusercontent.com/danielhuici/arcadyan-vrv9510kwac23-utils/main/u-boot.asc file via serial console to boot into U-Boot.
2. Perform a backup of the NAND
3. Setup a TFTP server and serve the https://github.com/danielhuici/arcadyan-vrv9510kwac23-utils/raw/main/u-boot.ltq.lzo.nandspl. Replace the OEM bootloader with this one. Erase your NAND and write the image into it
4. Reboot the router
5. Serve the OpenWrt ramdisk image on your TFTP server and boot it via U-Boot
6. When OpenWrt boots, flash the SquashFS OpenWrt image using LuCi interface, so OpenWrt gets installed into the NAND
