### PR TITLE
base-files: functions.sh: Add prepend() homologue to append()

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -40,6 +40,14 @@ append() {
 	eval "export ${NO_EXPORT:+-n} -- \"$var=\${$var:+\${$var}\${value:+\$sep}}\$value\""
 }
 
+prepend() {
+	local var="$1"
+	local value="$2"
+	local sep="${3:- }"
+
+	eval "export ${NO_EXPORT:+-n} -- \"$var=\${$value:+\${$value}\$sep}\$var\""
+}
+
 list_contains() {
 	local var="$1"
 	local str="$2"


### PR DESCRIPTION
Add `prepend()` function to `functions.sh` to prepend a value (and optional separator) to a variable.  Useful for building strings right-to-left, such as domain names, etc.