### PR TITLE
rtl93xx: fix condition intended to only select internal serdes ports

### DIFF
--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
@@ -559,7 +559,7 @@ static int rtl93xx_phylink_mac_link_state(struct dsa_switch *ds, int port,
 	}
 
 	if (priv->family_id == RTL9310_FAMILY_ID
-		&& (port >= 52 || port <= 55)) { /* Internal serdes */
+		&& (port >= 52 && port <= 55)) { /* Internal serdes */
 			state->speed = SPEED_10000;
 			state->link = 1;
 			state->duplex = 1;


### PR DESCRIPTION
This condition was introduced in 51c8f76 to correctly report the speed of the internal serdes ports as 10G, but instead makes all ports read 10G because the or-operator should have been an and-operator.

This fixes #9953

Please note that I do not have a rtl93xx device to test this on, but the code in question was obviously wrong and the change is quite miniscule.