### PR TITLE
quilt.mk: don't error on refresh/update if patches doesn't exist

### DIFF
--- a/include/quilt.mk
+++ b/include/quilt.mk
@@ -106,13 +106,14 @@ define Kernel/Patch/Default
 endef
 
 define Quilt/RefreshDir
-	mkdir -p $(2)
-	-rm -f $(2)/* 2>/dev/null >/dev/null
-	@( \
+	-rm -rf $(2) 2>/dev/null >/dev/null
+	[ -f $(1)/.quilt_no_patch ] || mkdir -p $(2)
+	@[ -f $(1)/.quilt_no_patch ] || { \
 		for patch in $$$$($(if $(3),grep "^$(3)",cat) $(1)/patches/series | awk '{print $$$$1}'); do \
 			$(CP) -v "$(1)/patches/$$$$patch" $(2); \
 		done; \
-	)
+	}
+	@-rm -f $(1)/.quilt_no_patch 2>/dev/null >/dev/null;
 endef
 
 define Quilt/Refresh/Host
@@ -156,7 +157,7 @@ define Quilt/Template
 	}
 	@[ -f "$(1)/patches/series" ] || { \
 		echo "The source directory contains no quilt patches."; \
-		false; \
+		touch $(1)/patches/series $(1)/.quilt_no_patch; \
 	}
 	@[ -n "$$$$(ls $(1)/patches/series)" -o \
 	   "$$$$(cat $(1)/patches/series | $(MKHASH) md5)" = "$$(sort $(1)/patches/series | $(MKHASH) md5)" ] || { \
@@ -165,10 +166,12 @@ define Quilt/Template
 	}
 
   $(3)refresh: $(3)quilt-check
-	@cd "$(1)"; $(QUILT_CMD) pop -a -f >/dev/null 2>/dev/null
-	@cd "$(1)"; while $(QUILT_CMD) next 2>/dev/null >/dev/null && $(QUILT_CMD) push; do \
-		QUILT_DIFF_OPTS="-p" $(QUILT_CMD) refresh -p ab --no-index --no-timestamps; \
-	done; ! $(QUILT_CMD) next 2>/dev/null >/dev/null
+	@[ -f $(1)/.quilt_no_patch ] || { \
+		cd "$(1)"; $(QUILT_CMD) pop -a -f >/dev/null 2>/dev/null; \
+		while $(QUILT_CMD) next 2>/dev/null >/dev/null && $(QUILT_CMD) push; do \
+			QUILT_DIFF_OPTS="-p" $(QUILT_CMD) refresh -p ab --no-index --no-timestamps; \
+		done; ! $(QUILT_CMD) next 2>/dev/null >/dev/null; \
+	}
 	$(Quilt/Refresh/$(4))
 	
   $(3)update: $(3)quilt-check

--- a/include/quilt.mk
+++ b/include/quilt.mk
@@ -34,8 +34,8 @@ endif
 ifneq ($(if $(DUMP),1,$(__quilt_inc)),1)
 __quilt_inc:=1
 
-PATCH_DIR?=./patches
-FILES_DIR?=./files
+PATCH_DIR?=$(CURDIR)/patches
+FILES_DIR?=$(CURDIR)/files
 HOST_PATCH_DIR?=$(PATCH_DIR)
 HOST_FILES_DIR?=$(FILES_DIR)
 


### PR DESCRIPTION
The current code fails if we have package or host tools with no patches
to apply. The error printend is the following: (taking ubus as an
example)

make[2]: Entering directory '/home/ansuel/openwrt-ansuel/openwrt/scripts/config'
make[2]: 'conf' is up to date.
make[2]: Leaving directory '/home/ansuel/openwrt-ansuel/openwrt/scripts/config'
make[1]: Entering directory '/home/ansuel/openwrt-ansuel/openwrt'
make[2]: Entering directory '/home/ansuel/openwrt-ansuel/openwrt/package/system/ubus'
The source directory contains no quilt patches.
make[2]: *** [Makefile:81: quilt-check] Error 1
make[2]: Leaving directory '/home/ansuel/openwrt-ansuel/openwrt/package/system/ubus'
time: package/system/ubus/refresh#0.06#0.00#0.07
    ERROR: package/system/ubus failed to build.
make[1]: *** [package/Makefile:120: package/system/ubus/refresh] Error 1
make[1]: Leaving directory '/home/ansuel/openwrt-ansuel/openwrt'
make: *** [/home/ansuel/openwrt-ansuel/openwrt/include/toplevel.mk:232: package/ubus/refresh] Error 2

We exit 1 after saying that there are no patches because later in the
function quilt pop fails to execute.

Having no patches for a package and calling refresh should not be
a critical error and the function should just do nothing.

To handle this improve quilt.mk with the following addition.
- If we don't have any patch for the package, we print a warning and we
  create an empty series. This is useful to trick quilt and make it do
  nothing.
  We also create a status file .quilt_no_patch to detect in the other
  function that we don't have patches to handle.
- In refresh makefile target, we check if .quilt_no_patch exist and
  we skip quilt cleanup if this exist.
- In RefreshDir function we change the logic and now we delete the
  patches directory and not only the content. This is done as a cleanup
  to clean case with empty patches directory.
- In RefreshDir we check if .quilt_no_patch exist and we skip creating
  the patches directory and copying the refreshed patches.
- In RefreshDir we delete at the end any trace of .quilt_no_patch if
  present.

This is needed to support run like package/refresh that will run the
refresh process on any package present in the buildroot.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

---

@hauke remember that problem with refresh not working with empty patch... Simple fix!