### PR TITLE
base-files: ipcalc.sh: Improvements

### DIFF
--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -12,6 +12,8 @@ function bitcount(c) {
 function ip2int(ip,   ret, n, x) {
 	ret=0
 	n=split(ip,a,"\\.")
+	if (n != 4)
+		return
 	for (x=1;x<=n;x++)
 		ret=or(lshift(ret,8),a[x])
 	return ret
@@ -32,17 +34,29 @@ function compl32(v,   ret) {
 	return ret
 }
 
+function notquad(addr) {
+	print "Not a dotted-quad "addr > "/dev/stderr"
+	exit(1)
+}
+
 BEGIN {
 	slpos=index(ARGV[1],"/")
 	if (slpos == 0) {
 		ipaddr=ip2int(ARGV[1])
+		if (ipaddr == "")
+			notquad(ARGV[1])
 		dotpos=index(ARGV[2],".")
 		if (dotpos == 0)
 			netmask=compl32(2**(32-int(ARGV[2]))-1)
-		else
+		else {
 			netmask=ip2int(ARGV[2])
+			if (netmask == "")
+				notquad(ARGV[2])
+		}
 	} else {
 		ipaddr=ip2int(substr(ARGV[1],0,slpos-1))
+		if (ipaddr == "")
+			notquad(substr(ARGV[1],0,slpos-1))
 		netmask=compl32(2**(32-int(substr(ARGV[1],slpos+1)))-1)
 		ARGV[4]=ARGV[3]
 		ARGV[3]=ARGV[2]

--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -73,6 +73,7 @@ BEGIN {
 		print "BROADCAST="int2ip(broadcast)
 	}
 	print "PREFIX="prefix
+	print "HOSTS="compl32(netmask)
 
 	# range calculations:
 	# ipcalc <ip> <netmask> <range_start> <range_size>

--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -9,7 +9,7 @@ function bitcount(c) {
 	return c
 }
 
-function ip2int(ip) {
+function ip2int(ip,   ret, n, x) {
 	ret=0
 	n=split(ip,a,"\\.")
 	for (x=1;x<=n;x++)
@@ -17,7 +17,7 @@ function ip2int(ip) {
 	return ret
 }
 
-function int2ip(ip,ret,x) {
+function int2ip(ip,   ret, x) {
 	ret=and(ip,255)
 	ip=rshift(ip,8)
 	for(;x<3;x++) {
@@ -27,7 +27,7 @@ function int2ip(ip,ret,x) {
 	return ret
 }
 
-function compl32(v) {
+function compl32(v,   ret) {
 	ret=xor(v, 0xffffffff)
 	return ret
 }

--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -f
+#!/usr/bin/awk -E
 
 function bitcount(c) {
 	c=and(rshift(c, 1),0x55555555)+and(c,0x55555555)
@@ -20,6 +20,8 @@ function ip2int(ip,   ret, n, x) {
 }
 
 function int2ip(ip,   ret, x) {
+	if (use_decimal)
+		return ip
 	ret=and(ip,255)
 	ip=rshift(ip,8)
 	for(;x<3;x++) {
@@ -40,7 +42,21 @@ function notquad(addr) {
 }
 
 BEGIN {
+	use_decimal=0
+	if (ARGC >= 2 && ARGV[1] == "-d") {
+		for (n=1;n<ARGC-1;++n)
+			ARGV[n]=ARGV[n+1]
+		--ARGC
+		use_decimal=1
+	}
+
 	slpos=index(ARGV[1],"/")
+
+	if (ARGC < ((slpos != 0) ? 2 : 3)) {
+		print "Usage: "ARGV[0]" <ip> <netmask> [ <start> <num> ]" > "/dev/stderr"
+		exit(1)
+	}
+
 	if (slpos == 0) {
 		ipaddr=ip2int(ARGV[1])
 		if (ipaddr == "")

--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -E
+#!/usr/bin/awk -f
 
 function bitcount(c) {
 	c=and(rshift(c, 1),0x55555555)+and(c,0x55555555)
@@ -43,12 +43,14 @@ function notquad(addr) {
 
 BEGIN {
 	use_decimal=0
-	if (ARGC >= 2 && ARGV[1] == "-d") {
-		for (n=1;n<ARGC-1;++n)
-			ARGV[n]=ARGV[n+1]
-		--ARGC
+##	if (ARGC >= 2 && ARGV[1] == "-d") {
+##		for (n=1;n<ARGC-1;++n)
+##			ARGV[n]=ARGV[n+1]
+##		--ARGC
+##		use_decimal=1
+##	}
+	if (ENVIRON["USEDECIMAL"] != "")
 		use_decimal=1
-	}
 
 	slpos=index(ARGV[1],"/")
 


### PR DESCRIPTION
We currently accept an arbitrary number of octets as a dotted quad.  This Berkeley-ism has been a source of pain & suffering (we don't even follow the Berkeley semantics, further adding to the confusion).  A quad is *four* octets.  Hence the name.  Throw an error if we see anything else.

Scope local variables so there's no potential for clashes.

Include the number of hosts in a subnet as part of the info we dump.

Allow output to be in decimal, as it facilitates doing address comparisons as signed integers in shell scripts.  We can't take flags because busybox doesn't support the `-E` flag (yet... I've opened a bug to have this added), so for now we do this via an environment variable but we can roll that back when busybox gets fixed.