### PR TITLE
ipq40xx: ZTE MF28x fix sysupgrade

### DIFF
--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -214,6 +214,7 @@ platform_do_upgrade() {
 	teltonika,rutx10 |\
 	teltonika,rutx50 |\
 	zte,mf18a |\
+	zte,mf282plus |\
 	zte,mf286d |\
 	zte,mf287 |\
 	zte,mf287plus |\

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -215,6 +215,7 @@ platform_do_upgrade() {
 	teltonika,rutx50 |\
 	zte,mf18a |\
 	zte,mf286d |\
+	zte,mf287 |\
 	zte,mf287plus |\
 	zte,mf287pro |\
 	zte,mf289f)


### PR DESCRIPTION
While adding support for the MF287 and MF282Plus an entry in platform.sh was overlooked - this fixes sysupgrade on these devices.

The fix for the MF287 needs to be backported to 23.05. The 23.05 branch does not support the MF282 Plus, so this is not required.