### PR TITLE
ath79: support Fortinet FAP-220-B

### DIFF
--- a/target/linux/ath79/dts/ar7161_fortinet_fap-220-b.dts
+++ b/target/linux/ath79/dts/ar7161_fortinet_fap-220-b.dts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7100.dtsi"
+#include "arxxxx_fortinet_loader.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "fortinet,fap-220-b", "qca,ar7161";
+	model = "Fortinet FAP-220-B";
+
+	chosen {
+		bootargs = "console=ttyS0,9600";
+	};
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &eth1;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power-green {
+			label = "green:power";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		status-green {
+			label = "green:status";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		status-yellow {
+			label = "yellow:status";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+
+		mode-green {
+			label = "green:mode";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		mode-yellow {
+			label = "yellow:mode";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g-green {
+			label = "green:wlan2g";
+			gpios = <&ath9k0 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan2g-yellow {
+			label = "yellow:wlan2g";
+			gpios = <&ath9k0 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0assoc";
+		};
+
+		wlan5g-green {
+			label = "green:wlan5g";
+			gpios = <&ath9k1 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g-yellow {
+			label = "yellow:wlan5g";
+			gpios = <&ath9k1 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1assoc";
+		};
+	};
+
+	virtual_flash {
+		devices = <&fwconcat0 &fwconcat1 &fwconcat2>;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	ath9k0: wifi@0,11 { /* 2.4 GHz */
+		compatible = "pci168c,0029";
+		reg = <0x8800 0 0 0 0>;
+		ieee80211-freq-limit = <2402000 2482000>;
+		nvmem-cells = <&macaddr_art_120c>, <&cal_art_1000>;
+		nvmem-cell-names = "mac-address", "calibration";
+		mac-address-increment = <1>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+
+	ath9k1: wifi@0,12 { /* 5 GHz */
+		compatible = "pci168c,0029";
+		reg = <0x9000 0 0 0 0>;
+		ieee80211-freq-limit = <2402000 2482000 4900000 5990000>;
+		nvmem-cells = <&macaddr_art_520c>, <&cal_art_5000>;
+		nvmem-cell-names = "mac-address", "calibration";
+		mac-address-increment = <9>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0x0>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	compatible = "syscon", "simple-mfd";
+};
+
+&eth1 {
+	status = "okay";
+	nvmem-cells = <&macaddr_art_120c>;
+	nvmem-cell-names = "mac-address";
+
+	pll-data = <0x00110000 0x00001099 0x00991099>;
+	phy-handle = <&phy0>;
+	phy-mode = "rgmii";
+};
+
+&usb1 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&uboot {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	/* Currently doesn't work, because this one lacks colons as delimiters */
+	macaddr_uboot_3ff80: mac-address-ascii@3ff80 {
+		reg = <0x3ff80 0xc>;
+	};
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	cal_art_1000: calibration@1000 {
+		reg = <0x1000 0xeb8>;
+	};
+
+	macaddr_art_120c: mac-address@120c {
+		reg = <0x120c 0x6>;
+	};
+
+	cal_art_5000: calibration@5000 {
+		reg = <0x5000 0xeb8>;
+	};
+
+	macaddr_art_520c: mac-address@520c {
+		reg = <0x520c 0x6>;
+	};
+};

--- a/target/linux/ath79/dts/ar9344_fortinet_ap-dual.dtsi
+++ b/target/linux/ath79/dts/ar9344_fortinet_ap-dual.dtsi
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 #include "ar9344.dtsi"
-#include "ar934x_fortinet_loader.dtsi"
+#include "arxxxx_fortinet_loader.dtsi"
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>

--- a/target/linux/ath79/dts/arxxxx_fortinet_loader.dtsi
+++ b/target/linux/ath79/dts/arxxxx_fortinet_loader.dtsi
@@ -36,7 +36,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			partition@0 {
+			uboot: partition@0 {
 				label = "u-boot";
 				reg = <0x000000 0x040000>;
 				read-only;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -47,6 +47,7 @@ ath79_setup_interfaces()
 	engenius,ecb600|\
 	enterasys,ws-ap3705i|\
 	extreme-networks,ws-ap3805i|\
+	fortinet,fap-220-b|\
 	fortinet,fap-221-b|\
 	glinet,gl-ar300m-lite|\
 	glinet,gl-usb150|\

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -55,6 +55,7 @@ platform_do_upgrade() {
 		ROOTFS_FILE="root.squashfs"
 		platform_do_upgrade_failsafe_datachk "$1"
 		;;
+	fortinet,fap-220-b|\
 	fortinet,fap-221-b)
 		SKIP_HASH="1"
 		ENV_SCRIPT="/dev/null"

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1532,12 +1532,9 @@ define Device/extreme-networks_ws-ap3805i
 endef
 TARGET_DEVICES += extreme-networks_ws-ap3805i
 
-define Device/fortinet_fap-221-b
+define Device/fortinet_fap_common
   $(Device/senao_loader_okli)
-  SOC := ar9344
   DEVICE_VENDOR := Fortinet
-  DEVICE_MODEL := FAP-221-B
-  FACTORY_IMG_NAME := FP221B-9.99-AP-build999-999999-patch99
   IMAGE_SIZE := 9216k
   LOADER_FLASH_OFFS := 0x040000
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
@@ -1545,6 +1542,13 @@ define Device/fortinet_fap-221-b
 	check-size | pad-to $$$$(IMAGE_SIZE) | \
 	append-loader-okli-uimage $(1) | pad-to 10944k | \
 	gzip-filename $$$$(FACTORY_IMG_NAME)
+endef
+
+define Device/fortinet_fap-221-b
+  $(Device/fortinet_fap_common)
+  SOC := ar9344
+  DEVICE_MODEL := FAP-221-B
+  FACTORY_IMG_NAME := FP221B-9.99-AP-build999-999999-patch99
 endef
 TARGET_DEVICES += fortinet_fap-221-b
 

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1544,6 +1544,16 @@ define Device/fortinet_fap_common
 	gzip-filename $$$$(FACTORY_IMG_NAME)
 endef
 
+define Device/fortinet_fap-220-b
+  $(Device/fortinet_fap_common)
+  SOC := ar7161
+  DEVICE_MODEL := FAP-220-B
+  FACTORY_IMG_NAME := FAP22B-9.99-AP-build999-999999-patch99
+  DEVICE_PACKAGES := -uboot-envtools kmod-usb-ohci kmod-usb2 \
+	kmod-owl-loader
+endef
+TARGET_DEVICES += fortinet_fap-220-b
+
 define Device/fortinet_fap-221-b
   $(Device/fortinet_fap_common)
   SOC := ar9344


### PR DESCRIPTION
Fortinet FAP-220-B is a dual-radio, dual-band 802.11n enterprise managed
access point with PoE input and single gigabit Ethernet interface.

Hardware highlights:
Power: 802.3af PoE input on Ethernet port, +12V input on 5.5/2.1mm DC jack.
SoC: Atheros AR7161 (MIPS 24kc at 680MHz)
RAM: 64MB DDR400
Flash: 16MB SPI-NOR
Wi-Fi 1: Atheros AR9220 2T2R 802.11abgn (dual-band)
Wi-Fi 2: Atheros AR9223 2T2R 802.11bgn (single-band)
Ethernet: Atheros AR8021 single gigabit Phy (RGMII)
Console: External RS232 port using Cisco 8P8C connector (9600-8-N-1)
USB: Single USB 2.0 host port
LEDs: Power (single colour, green), Wi-Fi 1, Wi-Fi 2, Ethernet, Mode, Status
(dual-colour, green and yellow)
Buttons: reset button hidden in bottom grill,
  in the top row, 2nd column from the right.
Label MAC address: eth0

FCC ID: TVE-220102

Big thanks for Michael Pratt for providing support for FAP-221-B, which
shares the entirety of image configuration with this device, this saved
me a ton of work.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>