### PR TITLE
mvebu: Fix puzzle M901/M902 LED definition

### DIFF
--- a/target/linux/mvebu/cortexa72/base-files/etc/board.d/01_leds
+++ b/target/linux/mvebu/cortexa72/base-files/etc/board.d/01_leds
@@ -8,10 +8,10 @@ board=$(board_name)
 
 case "$board" in
 iei,puzzle-m901)
-	ucidef_set_led_netdev "wan" "WAN" "white:network" "eth0" "link"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0" "link"
 	;;
 iei,puzzle-m902)
-	ucidef_set_led_netdev "wan" "WAN" "white:network" "eth2" "link"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth2" "link"
 	;;
 esac
 

--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9131-puzzle-m901.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9131-puzzle-m901.dts
@@ -78,13 +78,13 @@
 
 			led@0 {
 				reg = <0>;
-				label = "white:network";
+				label = "white:lan";
 				active-low;
 			};
 
 			led@1 {
 				reg = <1>;
-				label = "green:cloud";
+				label = "green:wan";
 				active-low;
 			};
 

--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9132-puzzle-m902.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9132-puzzle-m902.dts
@@ -123,13 +123,13 @@
 
 			led@0 {
 				reg = <0>;
-				label = "white:network";
+				label = "white:lan";
 				active-low;
 			};
 
 			led@1 {
 				reg = <1>;
-				label = "green:cloud";
+				label = "green:wan";
 				active-low;
 			};
 


### PR DESCRIPTION
Judging from the openvpn_status.sh and wan_status.sh of the IEI original firmware
The green light is wan and the white light is openvpn connection.

So I made a correction of this LED definition

Signed-off-by: TianYi Liao <p055877632@gmail.com>
