### PR TITLE
ramips: add support for TP-Link Archer C50 v6 (CA/EU/RU)

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v6.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v6.dts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_tplink_8m-split-uboot.dtsi"
+
+/ {
+	compatible = "tplink,archer-c50-v6", "mediatek,mt7628an-soc";
+	model = "TP-Link Archer C50 v6 (CA/EU/RU)";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2 {
+			label = "green:wlan2g";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5 {
+			label = "green:wlan5g";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_orange {
+			label = "orange:wan";
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "p0led_an", "p1led_an", "p2led_an",
+				   "p3led_an", "p4led_an", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_rom_f100>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		mac-address-increment = <(-1)>;
+	};
+};
+
+&eeprom_radio_8000 {
+	/* V2 has different eeprom size '0x4da8' for MT7613 */
+	reg = <0x8000 0x4da8>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -593,6 +593,19 @@ define Device/tplink_archer-c50-v4
 endef
 TARGET_DEVICES += tplink_archer-c50-v4
 
+define Device/tplink_archer-c50-v6
+  $(Device/tplink-v2)
+  IMAGE_SIZE := 7616k
+  DEVICE_MODEL := Archer C50
+  DEVICE_VARIANT := v6 (CA/EU/RU)
+  TPLINK_FLASHLAYOUT := 8MSUmtk
+  TPLINK_HWID := 0x0C500006
+  TPLINK_HWREVADD := 0x6
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap
+  IMAGES := sysupgrade.bin
+endef
+TARGET_DEVICES += tplink_archer-c50-v6
+
 define Device/tplink_re200-v2
   $(Device/tplink-safeloader)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -76,7 +76,8 @@ tplink,tl-wr850n-v2)
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
 	;;
 tplink,archer-c50-v3|\
-tplink,archer-c50-v4)
+tplink,archer-c50-v4|\
+tplink,archer-c50-v6)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
 	ucidef_set_led_wlan "wlan2g" "wlan2g" "green:wlan2g" "phy0tpt"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -46,6 +46,7 @@ ramips_setup_interfaces()
 	tplink,archer-c20-v5|\
 	tplink,archer-c50-v3|\
 	tplink,archer-c50-v4|\
+	tplink,archer-c50-v6|\
 	tplink,tl-mr3420-v5|\
 	tplink,tl-wr840n-v4|\
 	tplink,tl-wr840n-v5|\
@@ -294,7 +295,8 @@ ramips_setup_macs()
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0xf100)" 1)
 		;;
 	tplink,archer-c20-v5|\
-	tplink,archer-c50-v4)
+	tplink,archer-c50-v4|\
+	tplink,archer-c50-v6)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary rom 0xf100)" 1)
 		;;
 	wavlink,wl-wn570ha1|\

--- a/target/linux/ramips/mt76x8/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt76x8/base-files/lib/upgrade/platform.sh
@@ -29,7 +29,8 @@ platform_do_upgrade() {
 		default_do_upgrade "$1"
 		;;
 	tplink,archer-c20-v5|\
-	tplink,archer-c50-v4)
+	tplink,archer-c50-v4|\
+	tplink,archer-c50-v6)
 		MTD_ARGS="-t romfile"
 		default_do_upgrade "$1"
 		;;


### PR DESCRIPTION
Related to the forum discussion: https://forum.openwrt.org/t/tp-link-archer-c50-eu-v6-0-5-ghz-interface-not-present/95532

It would be great if this could be integrated!