### PR TITLE
qualcommax: ipq807x: add support for Netgear WAX630

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq807x
@@ -11,7 +11,8 @@ case "$board" in
 dynalink,dl-wrx36|\
 netgear,rax120v2|\
 netgear,wax218|\
-netgear,wax620)
+netgear,wax620|\
+netgear,wax630)
 	idx="$(find_mtd_index 0:appsblenv)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000" "2"

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -6,9 +6,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firmware/qca-wireless.git
-PKG_SOURCE_DATE:=2023-09-16
-PKG_SOURCE_VERSION:=57aa1b1562ac60f11a6bec8be02cd3b68b12b3fa
-PKG_MIRROR_HASH:=f8f9ab78ae85180a6e601d7c911d6c350b0cc132172d4baefc8f9fe07566ce0f
+PKG_SOURCE_DATE:=2023-10-12
+PKG_SOURCE_VERSION:=cd04ab7f984fe28613276c01fd0ac7afbe5516d5
+PKG_MIRROR_HASH:=857ae436fd09785749411a665b31c82cec84b68b1e096f69ebb6c2a0efb5583f
 
 PKG_FLAGS:=nonshared
 
@@ -36,6 +36,7 @@ ALLWIFIBOARDS:= \
 	netgear_rax120v2 \
 	netgear_wax218 \
 	netgear_wax620 \
+	netgear_wax630 \
 	prpl_haze \
 	qnap_301w \
 	redmi_ax6 \
@@ -142,6 +143,7 @@ $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))
 $(eval $(call generate-ipq-wifi-package,netgear_rax120v2,Netgear RAX120v2))
 $(eval $(call generate-ipq-wifi-package,netgear_wax218,Netgear WAX218))
 $(eval $(call generate-ipq-wifi-package,netgear_wax620,Netgear WAX620))
+$(eval $(call generate-ipq-wifi-package,netgear_wax630,Netgear WAX630))
 $(eval $(call generate-ipq-wifi-package,qnap_301w,QNAP 301w))
 $(eval $(call generate-ipq-wifi-package,prpl_haze,prpl Haze))
 $(eval $(call generate-ipq-wifi-package,redmi_ax6,Redmi AX6))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Netgear WAX630";
+	compatible = "netgear,wax630", "qcom,ipq8074";
+
+	aliases {
+		serial0 = &blsp1_uart5;
+		
+		ethernet0 = &dp6_syn;
+		ethernet1 = &dp4;
+		label-mac-device = &dp6_syn;
+
+		led-boot = &led_system_blue;
+		led-failsafe = &led_system_red;
+		led-running = &led_system_green;
+		led-upgrade = &led_system_blue;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	led-spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&tlmm 18 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&tlmm 19 GPIO_ACTIVE_HIGH>;
+
+		led_gpio: led-gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <1>;
+			enable-gpios = <&tlmm 20 GPIO_ACTIVE_HIGH>;
+			spi-max-frequency = <1000000>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system_red: system-red {
+			label = "system:red";
+			gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led_system_green: system-green {
+			label = "system:green";
+			gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led_system_blue: system-blue {
+			label = "system:blue";
+			gpios = <&tlmm 21 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan1-green {
+			label = "lan1:green";
+			gpios = <&tlmm 26 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan1-orange {
+			label = "lan1:orange";
+			gpios = <&tlmm 27 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan2-green {
+			label = "lan2:green";
+			gpios = <&tlmm 57 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan2-orange {
+			label = "lan2:orange";
+			gpios = <&tlmm 60 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		2g-blue {
+			label = "wlan2g:blue";
+			gpios = <&tlmm 29 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		2g-green {
+			label = "wlan2g:green";
+			gpios = <&tlmm 30 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		5g-low-blue {
+			label = "wlan5g_low:blue";
+			gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		5g-low-green {
+			label = "wlan5g_low:green";
+			gpios = <&tlmm 34 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		5g-high-blue {
+			label = "wlan5g_high:blue";
+			gpios = <&tlmm 31 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		5g-high-green {
+			label = "wlan5g_high:green";
+			gpios = <&tlmm 32 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+
+	switch_cpu_bmp = <0x01>;	
+	switch_lan_bmp = <0x3e>;
+	switch_wan_bmp = <0x40>;
+	switch_mac_mode = <0x00>;
+	switch_mac_mode1 = <0xff>;
+	switch_mac_mode2 = <0x0d>;
+	bm_tick_mode = <0x00>;
+	tm_tick_mode = <0x00>;
+
+	qcom,port_phyinfo {
+		port@3 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+
+		port@5 {
+			port_id = <6>;
+			phy_address = <28>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+
+	qca8075: ethernet-phy@3 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <3>;
+	};
+
+	qca8081: ethernet-phy@28 {
+		compatible = "ethernet-phy-id004d.d101";
+		reg = <28>;
+		reset-gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&dp4 {
+	status = "okay";
+	phy-handle = <&qca8075>;
+	label = "lan2";
+};
+
+&dp6_syn {
+	status = "okay";
+	phy-handle = <&qca8081>;
+	label = "lan1";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+		};
+	};
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Netgear-WAX630";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -23,6 +23,16 @@ define Device/UbiFit
 	IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 
+define Build/wax6xx-netgear-tar
+	mkdir $@.tmp
+	mv $@ $@.tmp/nand-ipq807x-apps.img
+	md5sum $@.tmp/nand-ipq807x-apps.img | cut -c 1-32 > $@.tmp/nand-ipq807x-apps.md5sum
+	echo $(DEVICE_MODEL) > $@.tmp/metadata.txt
+	echo $(DEVICE_MODEL)"_V9.9.9.9" > $@.tmp/version
+	tar -C $@.tmp/ -cf $@ .
+	rm -rf $@.tmp
+endef
+
 define Device/buffalo_wxr-5950ax12
 	$(call Device/FitImage)
 	DEVICE_VENDOR := Buffalo
@@ -145,6 +155,21 @@ define Device/netgear_wax620
 		ipq-wifi-netgear_wax620
 endef
 TARGET_DEVICES += netgear_wax620
+
+define Device/netgear_wax630
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Netgear
+	DEVICE_MODEL := WAX630
+	DEVICE_DTS_CONFIG := config@hk01
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	SOC := ipq8074
+	IMAGES := ui-factory.tar factory.ubi sysupgrade.bin
+	IMAGE/ui-factory.tar := append-ubi | wax6xx-netgear-tar
+	DEVICE_PACKAGES += kmod-spi-gpio ipq-wifi-netgear_wax630
+endef
+TARGET_DEVICES += netgear_wax630
 
 define Device/prpl_haze
 	$(call Device/FitImage)

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -115,20 +115,6 @@ define Device/netgear_rax120v2
 endef
 TARGET_DEVICES += netgear_rax120v2
 
-define Device/netgear_wax620
-	$(call Device/FitImage)
-	$(call Device/UbiFit)
-	DEVICE_VENDOR := Netgear
-	DEVICE_MODEL := WAX620
-	DEVICE_DTS_CONFIG := config@hk07
-	BLOCKSIZE := 128k
-	PAGESIZE := 2048
-	SOC := ipq8072
-	DEVICE_PACKAGES += kmod-spi-gpio kmod-gpio-nxp-74hc164 \
-		ipq-wifi-netgear_wax620
-endef
-TARGET_DEVICES += netgear_wax620
-
 define Device/netgear_wax218
 	$(call Device/FitImage)
 	$(call Device/UbiFit)
@@ -145,6 +131,20 @@ define Device/netgear_wax218
 		ipq-wifi-netgear_wax218
 endef
 TARGET_DEVICES += netgear_wax218
+
+define Device/netgear_wax620
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Netgear
+	DEVICE_MODEL := WAX620
+	DEVICE_DTS_CONFIG := config@hk07
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	SOC := ipq8072
+	DEVICE_PACKAGES += kmod-spi-gpio kmod-gpio-nxp-74hc164 \
+		ipq-wifi-netgear_wax620
+endef
+TARGET_DEVICES += netgear_wax620
 
 define Device/prpl_haze
 	$(call Device/FitImage)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
@@ -12,13 +12,13 @@ edgecore,eap102)
 netgear,rax120v2)
 	ucidef_set_led_netdev "aqr" "AQR" "white:aqr" "lan5"
 	;;
-netgear,wax620)
-	ucidef_set_led_netdev "lan" "LAN" "lan:green" "lan"
-	;;
 netgear,wax218)
 	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "lan"
 	ucidef_set_led_wlan "wlan5g" "WIFI 5GHz" "blue:wlan5g" "phy0radio"
 	ucidef_set_led_wlan "wlan2g" "WIFI 2.4GHz" "blue:wlan2g" "phy1radio"
+	;;
+netgear,wax620)
+	ucidef_set_led_netdev "lan" "LAN" "lan:green" "lan"
 	;;
 redmi,ax6|\
 xiaomi,ax3600)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
@@ -20,6 +20,10 @@ netgear,wax218)
 netgear,wax620)
 	ucidef_set_led_netdev "lan" "LAN" "lan:green" "lan"
 	;;
+netgear,wax630)
+	ucidef_set_led_netdev "lan1" "LAN1" "lan1:green" "lan1"
+	ucidef_set_led_netdev "lan2" "LAN2" "lan2:green" "lan2"
+	;;
 redmi,ax6|\
 xiaomi,ax3600)
 	ucidef_set_led_netdev "wan" "WAN" "blue:network" "wan"

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -29,6 +29,9 @@ ipq807x_setup_interfaces()
 	netgear,wax620)
 		ucidef_set_interface_lan "lan" "dhcp"
 		;;
+	netgear,wax630)
+		ucidef_set_interface_lan "lan1 lan2" "dhcp"
+		;;
 	prpl,haze)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -17,6 +17,7 @@ case "$FIRMWARE" in
 	netgear,rax120v2|\
 	netgear,wax218|\
 	netgear,wax620|\
+	netgear,wax630|\
 	qnap,301w|\
 	redmi,ax6|\
 	xiaomi,ax3600|\

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -70,7 +70,8 @@ platform_do_upgrade() {
 	edimax,cax1800|\
 	netgear,rax120v2|\
 	netgear,wax218|\
-	netgear,wax620)
+	netgear,wax620|\
+	netgear,wax630)
 		nand_do_upgrade "$1"
 		;;
 	prpl,haze|\


### PR DESCRIPTION
```
Specifications:
* CPU: Qualcomm IPQ8074A, SoC Version: 2.0, Quad core 1651 MHz
* RAM: 1 GiB of DDR3 466 MHz
* Flash: NAND 512 MiB (Winbond W29N04GZ)
* 6 RGB LEDs: Power, LAN1, LAN2, 2.4GHz, 5GHz H and 5GHz L
* UART: One 4-pin populated header next to the heatsink and a chip.
  GND RXD TXD, beginning from the external antennas. 115200n8.

Lan:
* One 100/1000/2.5GBASE-T Gigabit Ethernet 802.3bt/at
* One 100/1000 Gigabit Ethernet

Wlan:
* 4x4 in 2.4GHz  : 802.11b/g/n/ax
* 4x4 in 5.0GHz L: 802.11a/n/ac/ax
* 4x4 in 5.0GHz H: 802.11a/n/ac/ax
* OFDM and OFDMA
* Bidir and MU-MIMO
* Internal antenna 2.86/4.41/4.98 dBi (2.4GHz/5GHz L/5GHz H)

Power:
* 802.3bt/at 30.1W
* DC 12V/3.5A

Mounting: Wall and ceiling
```

```
1.  Download the OpenWrt initramfs image. Copy the image to a TFTP server
2.  Connect to the console on the AP, and connect the LAN port to your LAN
3.  Stop auto boot to get to U-boot shell, interrupt the autoboot process by pressing '0' when prompted
4.  Set active_fw in env
    # setenv active_fw 1
5.  Transfer the initramfs image with TFTP
    # setenv serverip 192.168.1.10 (IP of TFTP server host)
    # setenv ipaddr 192.168.1.1 (IP used by the router for getting the image, must be in the same subnet as the TFTP host)
    # tftpboot openwrt-qualcommax-ipq807x-netgear_wax630-initramfs-uImage.itb
6.  Reboot and load the image
    # bootm
7.  SCP factory image to the AP
    # scp openwrt-qualcommax-ipq807x-netgear_wax630-squashfs-factory.ubi root@192.168.1.1:/tmp/
8.  Connect to device using SSH (use the LAN port)
9.  Flash squashfs-factory.ubi from within the initramfs instance of OpenWRT
    Before you flash, please check your mtd partitions where mtdX is the right mtd rootfs partition.
    # cat /proc/mtd (To check MTD partitions)
    # ubiformat /dev/mtd18 -y -f /tmp/openwrt-qualcommax-ipq807x-netgear_wax630-squashfs-factory.ubi
10. Set active_fw to 0
    # /usr/sbin/fw_setenv active_fw 0
11. Reboot the AP and your done
    # reboot
```

Signed-off-by: Kristian Skramstad <kristian+github@83.no>
