### PR TITLE
bcm53xx: add GPIO to Linksys EA9200 DTS

### DIFF
--- a/target/linux/bcm53xx/patches-5.15/325-ARM-dts-fix-linksys-ea9200-gpio.patch
+++ b/target/linux/bcm53xx/patches-5.15/325-ARM-dts-fix-linksys-ea9200-gpio.patch
@@ -1,0 +1,82 @@
+--- a/arch/arm/boot/dts/bcm4709-linksys-ea9200.dts
++++ b/arch/arm/boot/dts/bcm4709-linksys-ea9200.dts
+@@ -5,6 +5,7 @@
+ 
+ /dts-v1/;
+ 
++#include <dt-bindings/leds/common.h>
+ #include "bcm4709.dtsi"
+ #include "bcm5301x-nand-cs0-bch8.dtsi"
+ 
+@@ -36,18 +37,71 @@
+ 			gpios = <&chipcommon 3 GPIO_ACTIVE_LOW>;
+ 		};
+ 
++		button-rfkill {
++			label = "WiFi";
++			linux,code = <KEY_RFKILL>;
++			gpios = <&chipcommon 4 GPIO_ACTIVE_LOW>;
++		};
++
+ 		button-restart {
+ 			label = "Reset";
+ 			linux,code = <KEY_RESTART>;
+ 			gpios = <&chipcommon 17 GPIO_ACTIVE_LOW>;
+ 		};
+ 	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-power {
++			color = <LED_COLOR_ID_WHITE>;
++			function = LED_FUNCTION_POWER;
++			label = "white:power";
++			gpios = <&chipcommon 8 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-on";
++		};
++
++		led-wifi {
++			color = <LED_COLOR_ID_AMBER>;
++			function = LED_FUNCTION_WLAN;
++			label = "amber:wifi";
++			gpios = <&chipcommon 0 GPIO_ACTIVE_LOW>;
++ 			linux,default-trigger = "rfkill-none";
++		};
++
++		led-usb2 {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_USB;
++			label = "green:usb2";
++			gpios = <&chipcommon 6 GPIO_ACTIVE_LOW>;
++			trigger-sources = <&ohci_port2>, <&ehci_port2>;
++			linux,default-trigger = "usbport";
++		};
++
++		led-usb3 {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_USB;
++			label = "green:usb3";
++			gpios = <&chipcommon 7 GPIO_ACTIVE_LOW>;
++			trigger-sources = <&ohci_port1>, <&ehci_port1>,
++					  <&xhci_port1>;
++			linux,default-trigger = "usbport";
++		};
++	};
+ };
+ 
+ &usb3_phy {
+ 	status = "okay";
+ };
+ 
++&usb2 {
++	vcc-gpio = <&chipcommon 13 GPIO_ACTIVE_HIGH>;
++};
++
++&usb3 {
++	vcc-gpio = <&chipcommon 14 GPIO_ACTIVE_HIGH>;
++};
++
+ &srab {
+ 	status = "okay";
+ 

--- a/target/linux/bcm53xx/patches-6.1/325-ARM-dts-fix-linksys-ea9200-gpio.patch
+++ b/target/linux/bcm53xx/patches-6.1/325-ARM-dts-fix-linksys-ea9200-gpio.patch
@@ -1,0 +1,82 @@
+--- a/arch/arm/boot/dts/bcm4709-linksys-ea9200.dts
++++ b/arch/arm/boot/dts/bcm4709-linksys-ea9200.dts
+@@ -5,6 +5,7 @@
+ 
+ /dts-v1/;
+ 
++#include <dt-bindings/leds/common.h>
+ #include "bcm4709.dtsi"
+ #include "bcm5301x-nand-cs0-bch8.dtsi"
+ 
+@@ -36,18 +37,71 @@
+ 			gpios = <&chipcommon 3 GPIO_ACTIVE_LOW>;
+ 		};
+ 
++		button-rfkill {
++			label = "WiFi";
++			linux,code = <KEY_RFKILL>;
++			gpios = <&chipcommon 4 GPIO_ACTIVE_LOW>;
++		};
++
+ 		button-restart {
+ 			label = "Reset";
+ 			linux,code = <KEY_RESTART>;
+ 			gpios = <&chipcommon 17 GPIO_ACTIVE_LOW>;
+ 		};
+ 	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-power {
++			color = <LED_COLOR_ID_WHITE>;
++			function = LED_FUNCTION_POWER;
++			label = "white:power";
++			gpios = <&chipcommon 8 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-on";
++		};
++
++		led-wifi {
++			color = <LED_COLOR_ID_AMBER>;
++			function = LED_FUNCTION_WLAN;
++			label = "amber:wifi";
++			gpios = <&chipcommon 0 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "rfkill-none";
++		};
++
++		led-usb2 {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_USB;
++			label = "green:usb2";
++			gpios = <&chipcommon 6 GPIO_ACTIVE_LOW>;
++			trigger-sources = <&ohci_port2>, <&ehci_port2>;
++			linux,default-trigger = "usbport";
++		};
++
++		led-usb3 {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_USB;
++			label = "green:usb3";
++			gpios = <&chipcommon 7 GPIO_ACTIVE_LOW>;
++			trigger-sources = <&ohci_port1>, <&ehci_port1>,
++					  <&xhci_port1>;
++			linux,default-trigger = "usbport";
++		};
++	};
+ };
+ 
+ &usb3_phy {
+ 	status = "okay";
+ };
+ 
++&usb2 {
++	vcc-gpio = <&chipcommon 13 GPIO_ACTIVE_HIGH>;
++};
++
++&usb3 {
++	vcc-gpio = <&chipcommon 14 GPIO_ACTIVE_HIGH>;
++};
++
+ &srab {
+ 	status = "okay";
+ 


### PR DESCRIPTION
Upstream kernel only supports two buttons (reset, wps).
This commit adds one button (rfkill), two VCC enables (usb2, usb3), and four LEDs (power, wifi, usb2, usb3).
Tested on my EA9200.

(Vendor's firmware has an option to disable ethernet PHY LEDs, but I don't know how it is done.)
