### PR TITLE
hostapd: increase PKG_RELEASE to fix builds

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git


### PR DESCRIPTION
Recent hostapd changes just edited the ucode files. It is required to bump the PKG_RELEASE to include the newest changes in the latest builds.
