### PR TITLE
ipq40xx: add support for Asus Lyra Mini (MAP-AC1300)

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -31,6 +31,7 @@ ipq40xx_setup_interfaces()
 		;;
 	8dev,jalapeno|\
 	alfa-network,ap120c-ac|\
+	asus,map-ac1300|\
 	asus,map-ac2200|\
 	cilab,meshpoint-one|\
 	edgecore,ecw5211|\
@@ -160,6 +161,11 @@ ipq40xx_setup_macs()
 	case "$board" in
 	8dev,habanero-dvk)
 		label_mac=$(mtd_get_mac_binary "ART" 0x1006)
+		;;
+	asus,map-ac1300)
+		label_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)
+		lan_mac=$(macaddr_add "$label_mac" 1)
+		wan_mac=$(macaddr_add "$label_mac" 3)
 		;;
 	asus,rt-ac42u)
 		label_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -53,6 +53,7 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-ahb-a000000.wifi.bin")
 	case "$board" in
+	asus,map-ac1300|\
 	asus,map-ac2200|\
 	asus,rt-ac42u|\
 	asus,rt-ac58u)
@@ -150,6 +151,7 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-ahb-a800000.wifi.bin")
 	case "$board" in
+	asus,map-ac1300|\
 	asus,map-ac2200|\
 	asus,rt-ac58u)
 		caldata_extract_ubi "Factory" 0x5000 0x2f20

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -7,6 +7,12 @@ preinit_set_mac_address() {
 		ip link set dev eth0 address $(macaddr_add "$base_mac" 1)
 		ip link set dev eth1 address $(macaddr_add "$base_mac" 3)
 		;;
+	asus,map-ac1300)
+		base_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)
+		ip link set dev eth0 address $(macaddr_add "$base_mac" 1)
+		ip link set dev lan address $(macaddr_add "$base_mac" 1)
+		ip link set dev wan address $(macaddr_add "$base_mac" 3)
+		;;		
 	asus,rt-ac42u)
 		base_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)
 		ip link set dev eth0 address $base_mac

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -6,6 +6,7 @@ RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 
 platform_check_image() {
 	case "$(board_name)" in
+	asus,map-ac1300 |\
 	asus,rt-ac42u |\
 	asus,rt-ac58u)
 		local ubidev=$(nand_find_ubi $CI_UBIPART)
@@ -148,6 +149,7 @@ platform_do_upgrade() {
 		CI_KERNPART="linux"
 		nand_do_upgrade "$1"
 		;;
+	asus,map-ac1300 |\
 	asus,rt-ac42u |\
 	asus,rt-ac58u)
 		CI_KERNPART="linux"

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-asus.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-asus.dtsi
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x8000000>;
+	};
+
+	soc {
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+	};
+};
+
+&blsp1_spi1 { /* BLSP1 QUP1 */
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+   
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <30000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "SBL1";
+				reg = <0x00000000 0x00040000>;
+				read-only;
+			};
+			partition@40000 {
+				label = "MIBIB";
+				reg = <0x00040000 0x00020000>;
+				read-only;
+			};
+			partition@60000 {
+				label = "QSEE";
+				reg = <0x00060000 0x00060000>;
+				read-only;
+			};
+			partition@c0000 {
+				label = "CDT";
+				reg = <0x000c0000 0x00010000>;
+				read-only;
+			};
+			partition@d0000 {
+				label = "DDRPARAMS";
+				reg = <0x000d0000 0x00010000>;
+				read-only;
+			};
+			partition@e0000 {
+				label = "APPSBLENV"; /* uboot env*/
+				reg = <0x000e0000 0x00010000>;
+				read-only;
+			};
+			partition@f0000 {
+				label = "APPSBL"; /* uboot */
+				reg = <0x000f0000 0x00080000>;
+				read-only;
+			};
+			partition@170000 {
+				label = "ART";
+				reg = <0x00170000 0x00010000>;
+				read-only;
+			};
+			/* 0x00180000 - 0x00200000 unused */
+		};
+	};
+
+	spi-nand@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <30000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x00000000 0x08000000>;
+			};
+		};
+	};
+};
+
+&usb3 {
+	status = "okay";
+	
+	dwc3@8a00000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		usb3_port1: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
+
+		usb3_port2: port@2 {
+			reg = <2>;
+			#trigger-source-cells = <0>;
+		};
+	};		
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-map-ac1300.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-map-ac1300.dts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/leds/common.h>
+#include "qcom-ipq4018-asus.dtsi"
+#include "qcom-ipq401x-map-acxx00.dtsi"
+
+/ {
+	model = "ASUS Lyra Mini";
+	compatible = "asus,map-ac1300";
+
+	aliases {
+		led-boot = &led_blue0;
+		led-failsafe = &led_red0;
+		led-running = &led_blue0;
+		led-upgrade = &led_red0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset-button {
+			label = "reset-button";
+			gpios = <&tlmm 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps-button {
+			label = "wps-button";
+			gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+	
+};
+
+&tlmm {
+	i2c_0_pins: i2c_0_pinmux {
+		pinmux {
+			function = "blsp_i2c0";
+			pins = "gpio58", "gpio59";
+			drive-strength = <16>;
+			bias-disable;
+		};
+	};
+
+	serial_pins: serial_pinmux {
+		mux {
+			pins = "gpio60", "gpio61";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		mux {
+			function = "blsp_spi0";
+			pins = "gpio55", "gpio56", "gpio57";
+			drive-strength = <12>;
+			bias-disable;
+		};
+		
+		mux_cs {
+			function = "gpio";
+			pins = "gpio54", "gpio1";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+
+	};
+};
+
+&blsp1_spi1 { /* BLSP1 QUP1 */
+	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>,
+		   <&tlmm 1 GPIO_ACTIVE_LOW>;
+};
+
+&swport4 {
+	status = "okay";
+	label = "wan";
+};
+
+&swport5 {
+	status = "okay";	
+	label = "lan";
+};
+
+&wifi0 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "ASUS-MAP-AC1300";
+};
+
+&wifi1 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "ASUS-MAP-AC1300";
+};

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-rt-ac58u.dts
@@ -1,86 +1,18 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 #include "qcom-ipq4019.dtsi"
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/soc/qcom,tcsr.h>
 #include <dt-bindings/leds/common.h>
+#include "qcom-ipq4018-asus.dtsi"
 
 / {
 	model = "ASUS RT-AC58U";
 	compatible = "asus,rt-ac58u";
-
-	memory {
-		device_type = "memory";
-		reg = <0x80000000 0x8000000>;
-	};
 
 	aliases {
 		led-boot = &led_power;
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
-	};
-
-	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
-		mdio@90000 {
-			status = "okay";
-		};
-
-		tcsr@1949000 {
-			compatible = "qcom,tcsr";
-			reg = <0x1949000 0x100>;
-			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
-		};
-
-		tcsr@194b000 {
-			compatible = "qcom,tcsr";
-			reg = <0x194b000 0x100>;
-			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
-		};
-
-		ess_tcsr@1953000 {
-			compatible = "qcom,tcsr";
-			reg = <0x1953000 0x1000>;
-			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
-		};
-
-		tcsr@1957000 {
-			compatible = "qcom,tcsr";
-			reg = <0x1957000 0x100>;
-			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				usb3_port1: port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-
-				usb3_port2: port@2 {
-					reg = <2>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -151,14 +83,6 @@
 	};
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&blsp_dma {
-	status = "okay";
-};
-
 &tlmm {
 	serial_pins: serial_pinmux {
 		mux {
@@ -187,116 +111,8 @@
 };
 
 &blsp1_spi1 { /* BLSP1 QUP1 */
-	pinctrl-0 = <&spi_0_pins>;
-	pinctrl-names = "default";
-	status = "okay";
 	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>,
 		   <&tlmm 59 GPIO_ACTIVE_HIGH>;
-
-	flash@0 {
-		/*
-		 * U-boot looks for "n25q128a11" node,
-		 * if we don't have it, it will spit out the following warning:
-		 * "ipq: fdt fixup unable to find compatible node".
-		 */
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		linux,modalias = "m25p80", "mx25l1606e", "n25q128a11";
-		spi-max-frequency = <30000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "SBL1";
-				reg = <0x00000000 0x00040000>;
-				read-only;
-			};
-			partition@40000 {
-				label = "MIBIB";
-				reg = <0x00040000 0x00020000>;
-				read-only;
-			};
-			partition@60000 {
-				label = "QSEE";
-				reg = <0x00060000 0x00060000>;
-				read-only;
-			};
-			partition@c0000 {
-				label = "CDT";
-				reg = <0x000c0000 0x00010000>;
-				read-only;
-			};
-			partition@d0000 {
-				label = "DDRPARAMS";
-				reg = <0x000d0000 0x00010000>;
-				read-only;
-			};
-			partition@e0000 {
-				label = "APPSBLENV"; /* uboot env*/
-				reg = <0x000e0000 0x00010000>;
-				read-only;
-			};
-			partition@f0000 {
-				label = "APPSBL"; /* uboot */
-				reg = <0x000f0000 0x00080000>;
-				read-only;
-			};
-			partition@170000 {
-				label = "ART";
-				reg = <0x00170000 0x00010000>;
-				read-only;
-			};
-			/* 0x00180000 - 0x00200000 unused */
-		};
-	};
-
-	spi-nand@1 {
-		compatible = "spi-nand";
-		reg = <1>;
-		spi-max-frequency = <30000000>;
-
-		/*
-		 * U-boot looks for "spinand,mt29f" node,
-		 * if we don't have it, it will spit out the following warning:
-		 * "ipq: fdt fixup unable to find compatible node".
-		 */
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "ubi";
-				reg = <0x00000000 0x08000000>;
-			};
-		};
-	};
-};
-
-&blsp1_uart1 {
-	pinctrl-0 = <&serial_pins>;
-	pinctrl-names = "default";
-	status = "okay";
-};
-
-&usb3_ss_phy {
-	status = "okay";
-};
-
-&usb3_hs_phy {
-	status = "okay";
-};
-
-&gmac {
-	status = "okay";
-};
-
-&switch {
-	status = "okay";
 };
 
 &swport1 {

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-asus.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-asus.dtsi
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x10000000>; /* 256MB */
+	};
+		
+	soc {
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+		};		
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+	};
+};
+
+&nand {
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	nand@0 {
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "SBL1";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "MIBIB";
+				reg = <0x80000 0x80000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "QSEE";
+				reg = <0x100000 0x100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "CDT";
+				reg = <0x200000 0x80000>;
+				read-only;
+			};
+
+			partition@280000 {
+				label = "APPSBL";
+				reg = <0x280000 0x140000>;
+				read-only;
+			};
+
+			partition@3c0000 {
+				label = "APPSBLENV";
+				reg = <0x3c0000 0x40000>;
+				read-only;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7c00000>;
+			};
+		};
+	};
+};
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-map-ac2200.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-map-ac2200.dts
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 #include "qcom-ipq4019.dtsi"
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/soc/qcom,tcsr.h>
 #include <dt-bindings/leds/common.h>
+#include "qcom-ipq4019-asus.dtsi"
+#include "qcom-ipq401x-map-acxx00.dtsi"
 
 / {
 	model = "ASUS Lyra MAP-AC2200";
@@ -16,46 +15,6 @@
 		led-running = &led_blue0;
 		led-upgrade = &led_red0;
 		ethernet1 = &swport4;
-	};
-
-	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
-		mdio@90000 {
-			status = "okay";
-		};
-
-		tcsr@1949000 {
-			compatible = "qcom,tcsr";
-			reg = <0x1949000 0x100>;
-			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
-		};
-
-		ess_tcsr@1953000 {
-			compatible = "qcom,tcsr";
-			reg = <0x1953000 0x1000>;
-			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
-		};
-
-		tcsr@1957000 {
-			compatible = "qcom,tcsr";
-			reg = <0x1957000 0x100>;
-			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
-		};
-
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -75,60 +34,6 @@
 	};
 };
 
-&nand {
-	pinctrl-0 = <&nand_pins>;
-	pinctrl-names = "default";
-	status = "okay";
-
-	nand@0 {
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "SBL1";
-				reg = <0x0 0x80000>;
-				read-only;
-			};
-
-			partition@80000 {
-				label = "MIBIB";
-				reg = <0x80000 0x80000>;
-				read-only;
-			};
-
-			partition@100000 {
-				label = "QSEE";
-				reg = <0x100000 0x100000>;
-				read-only;
-			};
-
-			partition@200000 {
-				label = "CDT";
-				reg = <0x200000 0x80000>;
-				read-only;
-			};
-
-			partition@280000 {
-				label = "APPSBL";
-				reg = <0x280000 0x140000>;
-				read-only;
-			};
-
-			partition@3c0000 {
-				label = "APPSBLENV";
-				reg = <0x3c0000 0x40000>;
-				read-only;
-			};
-
-			partition@400000 {
-				label = "ubi";
-				reg = <0x400000 0x7c00000>;
-			};
-		};
-	};
-};
 
 &tlmm {
 	i2c_0_pins: i2c_0_pinmux {
@@ -184,16 +89,16 @@
 	};
 };
 
-&cryptobam {
+&swport4 {
 	status = "okay";
+	
+	label = "wan";
 };
 
-&blsp_dma {
+&swport5 {
 	status = "okay";
-};
-
-&qpic_bam {
-	status = "okay";
+	
+	label = "lan";
 };
 
 &wifi0 {
@@ -211,6 +116,7 @@
 	status = "okay";
 	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+	clkreq-gpio = <&tlmm 39 GPIO_ACTIVE_LOW>;
 
 	bridge@0,0 {
 		reg = <0x00000000 0 0 0 0>;
@@ -228,136 +134,11 @@
 	};
 };
 
+&usb2 {
+	status = "okay";
+};
+
 &usb2_hs_phy {
 	/* Bluetooth module attached via USB */
 	status = "okay";
-};
-
-&blsp1_i2c3 {
-	pinctrl-0 = <&i2c_0_pins>;
-	pinctrl-names = "default";
-	status = "okay";
-
-	led-controller@32 {
-		/* 9-channel RGB LED controller */
-		compatible = "national,lp5523";
-		reg = <0x32>;
-		clock-mode = /bits/ 8 <1>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		/*
-		 * There is only one single extremely bright RGB-LED.
-		 * The RGB-color channels are running in parallel to
-		 * increase the current delivery capabilities beyond
-		 * what a single PWM-output of the controller can do.
-		 */
-
-		led_blue0: led@0 {
-			chan-name = "blue-0";
-			led-cur = /bits/ 8 <0xfa>;
-			max-cur = /bits/ 8 <0xff>;
-			reg = <0>;
-			color = <LED_COLOR_ID_BLUE>;
-			function-enumerator = <0>;
-		};
-
-		led@1 {
-			chan-name = "blue-1";
-			led-cur = /bits/ 8 <0xfa>;
-			max-cur = /bits/ 8 <0xff>;
-			reg = <1>;
-			color = <LED_COLOR_ID_BLUE>;
-			function-enumerator = <1>;
-		};
-
-		led@2 {
-			chan-name = "blue-2";
-			led-cur = /bits/ 8 <0xfa>;
-			max-cur = /bits/ 8 <0xff>;
-			reg = <2>;
-			color = <LED_COLOR_ID_BLUE>;
-			function-enumerator = <2>;
-		};
-
-		led_green0: led@3 {
-			chan-name = "green-0";
-			led-cur = /bits/ 8 <0xfa>;
-			max-cur = /bits/ 8 <0xff>;
-			reg = <3>;
-			color = <LED_COLOR_ID_GREEN>;
-			function-enumerator = <0>;
-		};
-
-		led@4 {
-			chan-name = "green-1";
-			led-cur = /bits/ 8 <0xfa>;
-			max-cur = /bits/ 8 <0xff>;
-			reg = <4>;
-			color = <LED_COLOR_ID_GREEN>;
-			function-enumerator = <1>;
-		};
-
-		led@5 {
-			chan-name = "green-2";
-			led-cur = /bits/ 8 <0xfa>;
-			max-cur = /bits/ 8 <0xff>;
-			reg = <5>;
-			color = <LED_COLOR_ID_GREEN>;
-			function-enumerator = <2>;
-		};
-
-		led_red0: led@6 {
-			chan-name = "red-0";
-			led-cur = /bits/ 8 <0xfa>;
-			max-cur = /bits/ 8 <0xff>;
-			reg = <6>;
-			color = <LED_COLOR_ID_RED>;
-			function-enumerator = <0>;
-		};
-
-		led@7 {
-			chan-name = "red-1";
-			led-cur = /bits/ 8 <0xfa>;
-			max-cur = /bits/ 8 <0xff>;
-			reg = <7>;
-			color = <LED_COLOR_ID_RED>;
-			function-enumerator = <1>;
-		};
-
-		led@8 {
-			chan-name = "red-2";
-			led-cur = /bits/ 8 <0xfa>;
-			max-cur = /bits/ 8 <0xff>;
-			reg = <8>;
-			color = <LED_COLOR_ID_RED>;
-			function-enumerator = <2>;
-		};
-	};
-};
-
-&blsp1_uart1 {
-	pinctrl-0 = <&serial_pins>;
-	pinctrl-names = "default";
-	status = "okay";
-};
-
-&gmac {
-	status = "okay";
-};
-
-&switch {
-	status = "okay";
-};
-
-&swport4 {
-	status = "okay";
-
-	label = "wan";
-};
-
-&swport5 {
-	status = "okay";
-
-	label = "lan";
 };

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rt-ac42u.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rt-ac42u.dts
@@ -1,86 +1,18 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 #include "qcom-ipq4019.dtsi"
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
 #include <dt-bindings/leds/common.h>
-#include <dt-bindings/soc/qcom,tcsr.h>
+#include "qcom-ipq4019-asus.dtsi"
 
 / {
 	model = "ASUS RT-AC42U";
 	compatible = "asus,rt-ac42u";
-
-	memory {
-		device_type = "memory";
-		reg = <0x80000000 0x10000000>; /* 256MB */
-	};
 
 	aliases {
 		led-boot = &led_power;
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
-	};
-
-	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
-		mdio@90000 {
-			status = "okay";
-		};
-
-		tcsr@1949000 {
-			compatible = "qcom,tcsr";
-			reg = <0x1949000 0x100>;
-			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
-		};
-
-		tcsr@194b000 {
-			compatible = "qcom,tcsr";
-			reg = <0x194b000 0x100>;
-			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
-		};
-
-		ess_tcsr@1953000 {
-			compatible = "qcom,tcsr";
-			reg = <0x1953000 0x1000>;
-			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
-		};
-
-		tcsr@1957000 {
-			compatible = "qcom,tcsr";
-			reg = <0x1957000 0x100>;
-			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				usb3_port1: port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-
-				usb3_port2: port@2 {
-					reg = <2>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -168,20 +100,8 @@
 	};
 };
 
-&cryptobam {
-	status = "okay";
-};
-
-&blsp_dma {
-	status = "okay";
-};
-
-&qpic_bam {
-	status = "okay";
-};
-
 &tlmm {
-	serial_0_pins: serial0_pinmux {
+	serial_pins: serial_pinmux {
 		mux {
 			pins = "gpio16", "gpio17";
 			function = "blsp_uart0";
@@ -206,57 +126,21 @@
 	};
 };
 
-&blsp1_uart1 {
-	pinctrl-0 = <&serial_0_pins>;
-	pinctrl-names = "default";
+&usb3 {
 	status = "okay";
-};
+	
+	dwc3@8a00000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-&nand {
-	pinctrl-0 = <&nand_pins>;
-	pinctrl-names = "default";
-	status = "okay";
+		usb3_port1: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
 
-	nand@0 {
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "SBL1";
-				reg = <0x00000000 0x00080000>;
-				read-only;
-			};
-			partition@80000 {
-				label = "MIBIB";
-				reg = <0x00080000 0x00080000>;
-				read-only;
-			};
-			partition@100000 {
-				label = "QSEE";
-				reg = <0x00100000 0x00100000>;
-				read-only;
-			};
-			partition@200000 {
-				label = "CDT";
-				reg = <0x00200000 0x00080000>;
-				read-only;
-			};
-			partition@280000 {
-				label = "APPSBL";
-				reg = <0x00280000 0x00140000>;
-				read-only;
-			};
-			partition@3C0000 {
-				label = "APPSBLENV";
-				reg = <0x003C0000 0x00040000>;
-				read-only;
-			};
-			partition@400000 {
-				label = "ubi";
-				reg = <0x00400000 0x07C00000>;
-			};
+		usb3_port2: port@2 {
+			reg = <2>;
+			#trigger-source-cells = <0>;
 		};
 	};
 };
@@ -266,14 +150,6 @@
 };
 
 &usb3_hs_phy {
-	status = "okay";
-};
-
-&gmac {
-	status = "okay";
-};
-
-&switch {
 	status = "okay";
 };
 
@@ -317,7 +193,6 @@
 		wifi2: wifi@1,0 {
 			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
-
 			qcom,ath10k-calibration-variant = "ASUS-RT-AC42U";
 		};
 	};

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq401x-map-acxx00.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq401x-map-acxx00.dtsi
@@ -102,3 +102,41 @@
 		};
 	};
 };
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq401x-map-acxx00.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq401x-map-acxx00.dtsi
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+&blsp1_i2c3 {
+	pinctrl-0 = <&i2c_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	led-controller@32 {
+		/* 9-channel RGB LED controller */
+		compatible = "national,lp5523";
+		reg = <0x32>;
+		clock-mode = /bits/ 8 <1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/*
+		 * There is only one single extremely bright RGB-LED.
+		 * The RGB-color channels are running in parallel to
+		 * increase the current delivery capabilities beyond
+		 * what a single PWM-output of the controller can do.
+		 */
+
+		led_blue0: led@0 {
+			chan-name = "blue-0";
+			led-cur = /bits/ 8 <0xfa>;
+			max-cur = /bits/ 8 <0xff>;
+			reg = <0>;
+			color = <LED_COLOR_ID_BLUE>;
+			function-enumerator = <0>;
+		};
+
+		led@1 {
+			chan-name = "blue-1";
+			led-cur = /bits/ 8 <0xfa>;
+			max-cur = /bits/ 8 <0xff>;
+			reg = <1>;
+			color = <LED_COLOR_ID_BLUE>;
+			function-enumerator = <1>;
+		};
+
+		led@2 {
+			chan-name = "blue-2";
+			led-cur = /bits/ 8 <0xfa>;
+			max-cur = /bits/ 8 <0xff>;
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function-enumerator = <2>;
+		};
+
+		led_green0: led@3 {
+			chan-name = "green-0";
+			led-cur = /bits/ 8 <0xfa>;
+			max-cur = /bits/ 8 <0xff>;
+			reg = <3>;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <0>;
+		};
+
+		led@4 {
+			chan-name = "green-1";
+			led-cur = /bits/ 8 <0xfa>;
+			max-cur = /bits/ 8 <0xff>;
+			reg = <4>;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <1>;
+		};
+
+		led@5 {
+			chan-name = "green-2";
+			led-cur = /bits/ 8 <0xfa>;
+			max-cur = /bits/ 8 <0xff>;
+			reg = <5>;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <2>;
+		};
+
+		led_red0: led@6 {
+			chan-name = "red-0";
+			led-cur = /bits/ 8 <0xfa>;
+			max-cur = /bits/ 8 <0xff>;
+			reg = <6>;
+			color = <LED_COLOR_ID_RED>;
+			function-enumerator = <0>;
+		};
+
+		led@7 {
+			chan-name = "red-1";
+			led-cur = /bits/ 8 <0xfa>;
+			max-cur = /bits/ 8 <0xff>;
+			reg = <7>;
+			color = <LED_COLOR_ID_RED>;
+			function-enumerator = <1>;
+		};
+
+		led@8 {
+			chan-name = "red-2";
+			led-cur = /bits/ 8 <0xfa>;
+			max-cur = /bits/ 8 <0xff>;
+			reg = <8>;
+			color = <LED_COLOR_ID_RED>;
+			function-enumerator = <2>;
+		};
+	};
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -190,6 +190,19 @@ define Device/aruba_ap-365
 endef
 TARGET_DEVICES += aruba_ap-365
 
+define Device/asus_map-ac1300
+	$(call Device/FitImageLzma)
+	DEVICE_VENDOR := ASUS
+	DEVICE_MODEL := Lyra Mini (MAP-AC1300)
+	SOC := qcom-ipq4018
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	IMAGE_SIZE := 131072k
+	KERNEL_INSTALL := 1
+
+endef
+TARGET_DEVICES += asus_map-ac1300
+
 define Device/asus_map-ac2200
 	$(call Device/FitImageLzma)
 	DEVICE_VENDOR := ASUS


### PR DESCRIPTION
Hardware
CHIPSET: IPQ4018 + QCA8072
LAN: 2x 1G
FLASH: GD5F1GQ4X 128 MiB + MX25L165D 2 MiB
RAM: 256 MiB
IO: Reset + WPS button
LED: Single Bright RGB led
POWER: 5V 2A

Flash layout similar to other asus brand routers.

Mac adresses extarcted from same mtd adress.

Orginal -> Openwrt
ath0 2C:FD:A1:8D:80:B8 -> phy0-ap0 2C:FD:A1:8D:80:B8
ath1 2C:FD:A1:8D:80:BA -> phy1-ap0 2C:FD:A1:8D:80:BA
br0  2C:FD:A1:8D:80:B9 -> eth0 2C:FD:A1:8D:80:B9
eth0 2C:FD:A1:8D:80:B9 -> wan 2C:FD:A1:8D:80:B9
eth1 2C:FD:A1:8D:80:BB -> br-lan 2C:FD:A1:8D:80:BB
eth2 2C:FD:A1:8D:80:B9 -> lan 2C:FD:A1:8D:80:BB

Status:
Lan ports: Configured as oem port closer to power jack as wan and other as lan
Wlan: radio1@5Ghz 300 Mbps trouhgput. radio0@2.4Ghz 50Mbps troughput
Led: works
Buttons: reset works, wps untested.

Installation:
1. Reset device to orginal settings and enable ssh, set username and password: admin/password
2. Upload openwrt-ipq40xx-generic-asus_map-ac1300-initramfs-uImage.itb
    `scp openwrt-ipq40xx-generic-asus_map-ac1300-initramfs-uImage.itb admin@192.168.72.1:/tmp`
3. ssh to router:
   `ssh admin@192.168.72.1`
4. run in router:
    `mtd-write -d linux -i /tmp/openwrt-ipq40xx-generic-asus_map-ac1300-initramfs-uImage.itb`
5. Reboot with command or with powercycling device
6. OpenWrt should boot and is ready after sort brust of flashing blue light
7. wget/scp openwrt-ipq40xx-generic-asus_map-ac1300-squashfs-sysupgrade.bin to /tmp dir of device
    `scp openwrt-ipq40xx-generic-asus_map-ac1300-initramfs-uImage.itb root@192.168.1.1:/tmp`
8. ssh to OpenWrt device. 
    `ssh root@192.168.1.1 `
9.run command: 
   `sysupgrade -n /tmp/openwrt-ipq40xx-generic-asus_map-ac2200-squashfs-sysupgrade.bin`
10. After reboot OpenWrt is installed to device.


