### PR TITLE
bcm53xx: build a single device per profile

### DIFF
--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -145,6 +145,7 @@ USB3_PACKAGES := $(USB2_PACKAGES) kmod-usb3 kmod-phy-bcm-ns-usb3
 define Device/Default
   # .dtb files are prefixed by SoC type, e.g. bcm4708- which is not included in device/image names
   # extract the full dtb name based on the device info
+  PROFILES = Generic $$(DEVICE_NAME)
   DEVICE_DTS := $(patsubst %.dtb,%,$(notdir $(wildcard $(if $(IB),$(KDIR),$(DTS_DIR))/*-$(subst _,-,$(1)).dtb)))
   KERNEL := kernel-bin | append-dtb | lzma-d16
   KERNEL_DEPENDS = $$(wildcard $(DTS_DIR)/$$(DEVICE_DTS).dts)


### PR DESCRIPTION
So far every build of a single bcm53xx device resulted in 18 TRX being built. Now it only builds the selected one.

Fixes: #13572

Thank you @KanjiMonster for the solution and the discussion.

