### PR TITLE
realtek: fix network connectivity on GS750E

### DIFF
--- a/target/linux/realtek/dts-5.15/rtl8393_netgear_gs750e.dts
+++ b/target/linux/realtek/dts-5.15/rtl8393_netgear_gs750e.dts
@@ -191,7 +191,7 @@
 		SWITCH_PORT(7, 8, qsgmii)
 
 		SWITCH_PORT(8, 9, qsgmii)
-		SWITCH_PORT(9, 0, qsgmii)
+		SWITCH_PORT(9, 10, qsgmii)
 		SWITCH_PORT(10, 11, qsgmii)
 		SWITCH_PORT(11, 12, qsgmii)
 		SWITCH_PORT(12, 13, qsgmii)

--- a/target/linux/realtek/dts-5.15/rtl8393_netgear_gs750e.dts
+++ b/target/linux/realtek/dts-5.15/rtl8393_netgear_gs750e.dts
@@ -107,7 +107,8 @@
 		compatible = "realtek,rtl838x-mdio";
 		#address-cells = <1>;
 		#size-cells = <0>;
-		reset-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
+		// Switch doesn't come back properly after a reset so don't.
+		// reset-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
 
 		/* External phy RTL8218B #1 */
 		EXTERNAL_PHY(0)


### PR DESCRIPTION
Currently OpenWRT does not know how to properly reset the network switch. This would result in a switch that seemed to come up properly but was unable to handle any traffic. Presumably something earlier in the boot chain is configuring a part of the switch that gets wiped out when its reset.

For now comment out the reset GPIO entry in the device tree until the driver better supports bringing up the switch after a reset.