### PR TITLE
mediatek: Add support for TP-Link EAP225v5

### DIFF
--- a/target/linux/mediatek/dts/mt7629-tplink_eap225-v5.dts
+++ b/target/linux/mediatek/dts/mt7629-tplink_eap225-v5.dts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include "mt7629.dtsi"
+
+/ {
+	model = "TP-Link EAP225 v5";
+	compatible = "tplink,eap225-v5", "mediatek,mt7629";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_amber;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_amber;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-override = "console=ttyS0,115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&pio 21 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&pio 55 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led_status_amber: status_amber {
+			label = "amber:status";
+			gpios = <&pio 56 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_pins>;
+	pinctrl-1 = <&ephy_leds_pins>;
+	status = "okay";
+
+	mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&phy0>;
+		nvmem-cells = <&macaddr_factory_8>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy0: ethernet-phy@0 {
+			reg = <0>;
+		};
+	};
+};
+
+&qspi {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&qspi_pins>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x00080000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "Partition";
+				reg = <0x00080000 0x00010000>;
+				read-only;
+			};
+
+			partition@90000 {
+				label = "Factory";
+				reg = <0x00090000 0x00010000>;
+				compatible = "nvmem-cells";
+				read-only;
+
+				macaddr_factory_8: macaddr@8 {
+					reg = <0x8 0x6>;
+				};
+			};
+
+			partition@A0000 {
+				label = "Radio";
+				reg = <0x000A0000 0x00010000>;
+				read-only;
+			};
+
+			partition@B0000 {
+				label = "Extra";
+				reg = <0x000B0000 0x00010000>;
+				read-only;
+			};
+
+			/* Vendor layout: kernel (0x000C0000 0x001A0000) - rootfs (0x00260000 0x00BE0000) */
+			/* OpenWrt flash layout: combine kernel and rootfs from OEM layout */
+			partition@C0000 {
+				label = "firmware";
+				reg = <0x000C0000 0x00D80000>;
+			};
+
+			partition@E40000 {
+				label = "Config";
+				reg = <0x00E40000 0x0001B0000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pio {
+	eth_pins: eth-pins {
+		mux {
+			function = "eth";
+			groups = "mdc_mdio";
+		};
+	};
+
+	ephy_leds_pins: ephy-leds-pins {
+		mux {
+			function = "led";
+			groups = "ephy_leds";
+		};
+	};
+
+	qspi_pins: qspi-pins {
+		mux {
+			function = "flash";
+			groups = "spi_nor";
+		};
+	};
+
+	uart0_pins: uart0-pins {
+		mux {
+			function = "uart";
+			groups = "uart0_txd_rxd" ;
+		};
+	};
+
+	watchdog_pins: watchdog-pins {
+		mux {
+			function = "watchdog";
+			groups = "watchdog";
+		};
+	};
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+	status = "okay";
+};
+
+&watchdog {
+	pinctrl-names = "default";
+	pinctrl-0 = <&watchdog_pins>;
+	status = "okay";
+};

--- a/target/linux/mediatek/image/mt7629.mk
+++ b/target/linux/mediatek/image/mt7629.mk
@@ -48,3 +48,12 @@ define Device/netgear_ex6250-v2
 	pad-rootfs | check-size | netgear-encrypted-factory
 endef
 TARGET_DEVICES += netgear_ex6250-v2
+
+define Device/tplink_eap225-v5
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := EAP225
+  DEVICE_VARIANT := v5
+  DEVICE_DTS := mt7629-tplink_eap225-v5
+  DEVICE_DTS_DIR := ../dts
+endef
+TARGET_DEVICES += tplink_eap225-v5

--- a/target/linux/mediatek/mt7629/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7629/base-files/etc/board.d/02_network
@@ -16,7 +16,8 @@ mediatek_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "6@eth0"
 		;;
-	netgear,ex6250-v2)
+	netgear,ex6250-v2|\
+	tplink,eap225-v5)
 		ucidef_set_interface_lan "eth0"
 		;;
 	esac


### PR DESCRIPTION
Device specification:
- MT7629 with 16MB NOR flash W25Q128 and 128 MB DDR3 RAM.
- MT7761N and MT7762N wireless chips (currenlty no driver in OpenWrt available)
  - WiFi is NOT working on this device
- Dual core but second CPU doesn't seem to work (Error message during boot: "CPU1: failed to come online")

There are two similar merge requests for similar devices with the same issues:
- https://github.com/openwrt/openwrt/pull/12286
- https://github.com/openwrt/openwrt/pull/5084

UART interface is next to the reset button, pinout:
- 1: TX (the pin with the arrow marker)
- 2: RX
- 3: GND
- 4: VCC

UART settings: 115200,8n1, 3.3V

U-Boot menu can be entered by pressing Ctrl+B during startup.

Booting initramfs:
- Set your computers IP adress to 192.168.1.110
- Run a TFTP server providing the initramfs image
- Power on the AP, press Ctrl+B to get to the U-Boot menu
- Select "1. System Load Linux to SDRAM via TFTP"
- Update kernel file name, input server IP and input device IP (if they deviate from the defaults)
- After booting, create a backup of all partitions, especially for kernel and root_fs. They are required for reverting back to stock firmware
- The sysupgrade image can be flashed now

MAC adresses:
- LAN and 2.4GHz use the same MAC (the one printed on the device)
- 5GHz WiFi MAC is LAN MAC + 1

GPIOs:
- GPIO 21 is the reset pin (low active)
- GPIO 55 is for the green LED (active high)
- GPIO 56 is for the yellow/amber LED (active high)
