### PR TITLE
ramips: convert legacy SoCs wireless calibration EEPROM to NVMEM format

### DIFF
--- a/target/linux/ramips/dts/mt7620a_aigale_ai-br100.dts
+++ b/target/linux/ramips/dts/mt7620a_aigale_ai-br100.dts
@@ -73,9 +73,20 @@
 			};
 
 			factory: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@40000 {
@@ -110,15 +121,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_alfa-network_ac1200rm.dts
+++ b/target/linux/ramips/dts/mt7620a_alfa-network_ac1200rm.dts
@@ -132,9 +132,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -147,15 +158,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_alfa-network_ac1200rm.dts
+++ b/target/linux/ramips/dts/mt7620a_alfa-network_ac1200rm.dts
@@ -84,7 +84,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {
@@ -141,6 +142,10 @@
 
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
 				};
 
 				macaddr_factory_28: macaddr@28 {

--- a/target/linux/ramips/dts/mt7620a_alfa-network_r36m-e4g.dts
+++ b/target/linux/ramips/dts/mt7620a_alfa-network_r36m-e4g.dts
@@ -189,9 +189,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -208,15 +219,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_asus_rp-n53.dts
+++ b/target/linux/ramips/dts/mt7620a_asus_rp-n53.dts
@@ -120,9 +120,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -143,7 +154,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
@@ -167,6 +179,7 @@
 		compatible = "pci1814,5592";
 		reg = <0x0000 0 0 0 0>;
 		ralink,2ghz = <0>;
-		ralink,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_asus_rt-ac51u.dts
+++ b/target/linux/ramips/dts/mt7620a_asus_rt-ac51u.dts
@@ -8,6 +8,7 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_asus_rt-ac54u.dts
+++ b/target/linux/ramips/dts/mt7620a_asus_rt-ac54u.dts
@@ -10,7 +10,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7620a_asus_rt-ac5x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_asus_rt-ac5x.dtsi
@@ -90,6 +90,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};

--- a/target/linux/ramips/dts/mt7620a_asus_rt-ac5x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_asus_rt-ac5x.dtsi
@@ -79,9 +79,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -129,19 +140,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_bdcom_wap2100-sk.dts
+++ b/target/linux/ramips/dts/mt7620a_bdcom_wap2100-sk.dts
@@ -82,9 +82,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -124,7 +135,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -143,15 +155,5 @@
 	default {
 		groups = "spi refclk", "uartf", "wled";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_bdcom_wap2100-sk.dts
+++ b/target/linux/ramips/dts/mt7620a_bdcom_wap2100-sk.dts
@@ -93,6 +93,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -146,7 +150,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_buffalo_whr-1166d.dts
+++ b/target/linux/ramips/dts/mt7620a_buffalo_whr-1166d.dts
@@ -125,6 +125,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -182,7 +186,8 @@
 	wifi@0,0 {
 		compatible = "pci0,0";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_buffalo_whr-1166d.dts
+++ b/target/linux/ramips/dts/mt7620a_buffalo_whr-1166d.dts
@@ -114,9 +114,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -159,7 +170,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -172,15 +184,5 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_buffalo_whr-300hp2.dts
+++ b/target/linux/ramips/dts/mt7620a_buffalo_whr-300hp2.dts
@@ -114,9 +114,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -146,18 +157,9 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
 	pinctrl-names = "default", "pa_gpio";
 	pinctrl-0 = <&pa_pins>;
 	pinctrl-1 = <&pa_gpio_pins>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_buffalo_whr-600d.dts
+++ b/target/linux/ramips/dts/mt7620a_buffalo_whr-600d.dts
@@ -114,9 +114,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -146,7 +161,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -157,16 +173,7 @@
 	wifi@0,0 {
 		compatible = "pci1814,5592";
 		reg = <0x0000 0 0 0 0>;
-		ralink,mtd-eeprom = <&factory 0x8000>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_cameo_810.dtsi
+++ b/target/linux/ramips/dts/mt7620a_cameo_810.dtsi
@@ -81,9 +81,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			factory5g: partition@50000 {
@@ -141,10 +152,8 @@
 	pinctrl-names = "default", "pa_gpio";
 	pinctrl-0 = <&pa_pins>;
 	pinctrl-1 = <&pa_gpio_pins>;
-
-	ralink,mtd-eeprom = <&factory 0x0>;
-	nvmem-cells = <&macaddr_factory_28>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_28>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &pcie {
@@ -159,15 +168,5 @@
 		nvmem-cells = <&macaddr_factory_28>;
 		nvmem-cell-names = "mac-address";
 		mac-address-increment = <2>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_cameo_810.dtsi
+++ b/target/linux/ramips/dts/mt7620a_cameo_810.dtsi
@@ -92,6 +92,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -163,10 +167,9 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_factory_28>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_28>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <2>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_dlink_dch-m225.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dch-m225.dts
@@ -119,9 +119,20 @@
 			};
 
 			factory: partition@34000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x34000 0x4000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			nvram: partition@38000 {
@@ -173,18 +184,9 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
 	pinctrl-names = "default", "pa_gpio";
 	pinctrl-0 = <&pa_pins>;
 	pinctrl-1 = <&pa_gpio_pins>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_dlink_dir-510l.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dir-510l.dts
@@ -94,9 +94,20 @@
 			};
 
 			config: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0xff0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_config_e05d: eeprom@e05d {
+					reg = <0xe05d 0x200>;
+				};
+
+				macaddr_config_e490: macaddr@e490 {
+					reg = <0xe490 0x6>;
+				};
 			};
 		};
 	};
@@ -117,10 +128,9 @@
 &pcie0 {
 	mt76x0e@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_config_e490>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_config_e05d>, <&macaddr_config_e490>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(2)>;
-		mediatek,mtd-eeprom = <&config 0xe05d>;
 	};
 };
 
@@ -128,15 +138,5 @@
 	default {
 		groups = "i2c", "uartf";
 		function = "gpio";
-	};
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_e490: macaddr@e490 {
-		reg = <0xe490 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_dlink_dir-806a-b1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dir-806a-b1.dts
@@ -91,9 +91,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "Factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_8004: macaddr@8004 {
+					reg = <0x8004 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -124,9 +139,8 @@
 	pinctrl-0 = <&pa_pins>;
 	pinctrl-1 = <&pa_gpio_pins>;
 
-	ralink,mtd-eeprom = <&factory 0x0>;
-	nvmem-cells = <&macaddr_factory_4>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+	nvmem-cell-names = "eeprom", "mac-address";
 	mac-address-increment = <(-1)>;
 };
 
@@ -147,19 +161,5 @@
 		led {
 			led-active-low;
 		};
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
-
-	macaddr_factory_8004: macaddr@8004 {
-		reg = <0x8004 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_dlink_dir-806a-b1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dir-806a-b1.dts
@@ -102,6 +102,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -151,11 +155,9 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-
-		nvmem-cells = <&macaddr_factory_8004>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_8004>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(-3)>;
 
 		led {

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
@@ -115,9 +115,20 @@
 			};
 
 			config: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0xff0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_config_e083: eeprom@e083 {
+					reg = <0xe083 0x200>;
+				};
+
+				macaddr_config_e496: macaddr@e496 {
+					reg = <0xe496 0x6>;
+				};
 			};
 		};
 	};
@@ -145,10 +156,9 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_config_e496>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_config_e083>, <&macaddr_config_e496>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(2)>;
-		mediatek,mtd-eeprom = <&config 0xe083>;
 
 		led {
 			led-sources = <0>;
@@ -191,14 +201,4 @@
 &gsw {
 	mediatek,port4-gmac;
 	mediatek,ephy-base = /bits/ 8 <8>;
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_e496: macaddr@e496 {
-		reg = <0xe496 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-960.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-960.dts
@@ -30,5 +30,7 @@
 };
 
 &wifi {
-	mediatek,mtd-eeprom = <&config 0xe08e>;
+	nvmem-cells = <&eeprom_config_e08e>, <&macaddr_config_e50e>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	mac-address-increment = <2>;
 };

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-961-a1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-961-a1.dts
@@ -58,5 +58,7 @@
 };
 
 &wifi {
-	mediatek,mtd-eeprom = <&config 0xe29e>;
+	nvmem-cells = <&eeprom_config_e29e>, <&macaddr_config_e50e>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	mac-address-increment = <2>;
 };

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-96x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-96x.dtsi
@@ -120,9 +120,6 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_config_e50e>;
-		nvmem-cell-names = "mac-address";
-		mac-address-increment = <(2)>;
 	};
 };
 
@@ -155,12 +152,19 @@
 
 			config: partition@ff0000 {
 				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
 				label = "config";
 				reg = <0xff0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_config_e08e: eeprom@e08e {
+					reg = <0xe08e 0x200>;
+				};
+
+				eeprom_config_e29e: eeprom@e29e {
+					reg = <0xe29e 0x200>;
+				};
 
 				macaddr_config_e50e: macaddr@e50e {
 					reg = <0xe50e 0x6>;

--- a/target/linux/ramips/dts/mt7620a_domywifi.dtsi
+++ b/target/linux/ramips/dts/mt7620a_domywifi.dtsi
@@ -125,6 +125,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -175,7 +179,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7620a_domywifi.dtsi
+++ b/target/linux/ramips/dts/mt7620a_domywifi.dtsi
@@ -114,9 +114,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -175,15 +186,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_dovado_tiny-ac.dts
+++ b/target/linux/ramips/dts/mt7620a_dovado_tiny-ac.dts
@@ -79,9 +79,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -153,7 +160,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_edimax_br-6208ac-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_br-6208ac-v2.dts
@@ -152,6 +152,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -213,7 +217,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_edimax_br-6208ac-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_br-6208ac-v2.dts
@@ -141,9 +141,24 @@
 
 			// Factory
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
 			};
 
 			// Cimage
@@ -187,7 +202,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -199,19 +215,5 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
-
-	macaddr_factory_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
@@ -99,9 +99,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -183,7 +194,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -204,14 +216,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
@@ -110,6 +110,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -205,7 +209,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		mediatek,2ghz = <0>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
@@ -211,7 +211,7 @@
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
-		mediatek,2ghz = <0>;
+		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7620a_edimax_ew-7478apc.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_ew-7478apc.dts
@@ -102,6 +102,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -197,7 +201,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		mediatek,2ghz = <0>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_edimax_ew-7478apc.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_ew-7478apc.dts
@@ -203,7 +203,7 @@
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
-		mediatek,2ghz = <0>;
+		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7620a_edimax_ew-7478apc.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_ew-7478apc.dts
@@ -91,9 +91,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -175,7 +186,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -196,14 +208,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_edimax_ew-747x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_edimax_ew-747x.dtsi
@@ -91,6 +91,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -196,10 +200,9 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_factory_4>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <2>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_edimax_ew-747x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_edimax_ew-747x.dtsi
@@ -80,9 +80,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -174,9 +185,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-	nvmem-cells = <&macaddr_factory_4>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &pcie {
@@ -191,15 +201,5 @@
 		nvmem-cells = <&macaddr_factory_4>;
 		nvmem-cell-names = "mac-address";
 		mac-address-increment = <2>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_engenius_epg600.dts
+++ b/target/linux/ramips/dts/mt7620a_engenius_epg600.dts
@@ -116,15 +116,33 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			rf: partition@50000 {
+				compatible = "nvmem-cells";
 				label = "rf";
 				reg = <0x50000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_rf_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_rf_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@60000 {
@@ -194,12 +212,14 @@
 	wifi@0,1,0 {
 		compatible = "pci1814,3091";
 		reg = <0x0 1 0 0 0>;
-		ralink,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&rf 0x0>;
+	nvmem-cells = <&eeprom_rf_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {
@@ -214,15 +234,5 @@
 	default {
 		groups = "ephy", "wled", "spi refclk", "i2c", "uartf", "nd_sd";
 		function = "gpio";
-	};
-};
-
-&rf {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_rf_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_engenius_esr600.dts
+++ b/target/linux/ramips/dts/mt7620a_engenius_esr600.dts
@@ -98,15 +98,33 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			iNIC_rf: partition@50000 {
+				compatible = "nvmem-cells";
 				label = "iNIC_rf";
 				reg = <0x50000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_iNIC_rf_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_iNIC_rf_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@60000 {
@@ -179,12 +197,14 @@
 	wifi@0,0 {
 		compatible = "pci1814,5592";
 		reg = <0x0 0 0 0 0>;
-		ralink,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&iNIC_rf 0x0>;
+	nvmem-cells = <&eeprom_iNIC_rf_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {
@@ -193,14 +213,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&iNIC_rf {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_iNIC_rf_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_fon_fon2601.dts
+++ b/target/linux/ramips/dts/mt7620a_fon_fon2601.dts
@@ -77,9 +77,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -142,7 +153,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 
 	pinctrl-names = "default", "pa_gpio";
 	pinctrl-0 = <&pa_pins>, <&wled_pins>;
@@ -167,14 +179,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_fon_fon2601.dts
+++ b/target/linux/ramips/dts/mt7620a_fon_fon2601.dts
@@ -88,6 +88,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -168,7 +172,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt300a.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt300a.dts
@@ -95,9 +95,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4000: macaddr@4000 {
+					reg = <0x4000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -134,22 +145,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	gpio {
 		groups = "wled","ephy","uartf","i2c";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4000: macaddr@4000 {
-		reg = <0x4000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt300n.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt300n.dts
@@ -90,9 +90,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4000: macaddr@4000 {
+					reg = <0x4000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -125,22 +136,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	gpio {
 		groups = "wled","ephy","i2c";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4000: macaddr@4000 {
-		reg = <0x4000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt750.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt750.dts
@@ -101,6 +101,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4000: macaddr@4000 {
 					reg = <0x4000 0x6>;
 				};
@@ -151,7 +155,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt750.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt750.dts
@@ -90,9 +90,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4000: macaddr@4000 {
+					reg = <0x4000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -129,7 +140,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -147,15 +159,5 @@
 	gpio {
 		groups = "wled","ephy","uartf";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4000: macaddr@4000 {
-		reg = <0x4000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_head-weblink_hdrm200.dts
+++ b/target/linux/ramips/dts/mt7620a_head-weblink_hdrm200.dts
@@ -93,6 +93,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -187,7 +191,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_head-weblink_hdrm200.dts
+++ b/target/linux/ramips/dts/mt7620a_head-weblink_hdrm200.dts
@@ -82,9 +82,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -156,7 +167,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
@@ -182,14 +194,4 @@
 
 &uart {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5761.dts
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5761.dts
@@ -64,7 +64,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5861.dts
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5861.dts
@@ -101,7 +101,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
@@ -52,9 +52,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -96,22 +107,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	gpio {
 		groups = "uartf", "wled";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
@@ -63,6 +63,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};

--- a/target/linux/ramips/dts/mt7620a_hnet_c108.dts
+++ b/target/linux/ramips/dts/mt7620a_hnet_c108.dts
@@ -109,9 +109,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -141,7 +152,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
@@ -153,14 +165,4 @@
 
 &pcie {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_humax_e2.dts
+++ b/target/linux/ramips/dts/mt7620a_humax_e2.dts
@@ -99,6 +99,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_10007: macaddr@10007 {
 					reg = <0x10007 0x6>;
 				};
@@ -128,7 +132,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_humax_e2.dts
+++ b/target/linux/ramips/dts/mt7620a_humax_e2.dts
@@ -88,13 +88,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x30000>;
-				read-only;
-
-				compatible = "nvmem-cells";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 
 				macaddr_factory_10007: macaddr@10007 {
 					reg = <0x10007 0x6>;
@@ -131,7 +134,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {

--- a/target/linux/ramips/dts/mt7620a_iodata_wn-ac1167gr.dts
+++ b/target/linux/ramips/dts/mt7620a_iodata_wn-ac1167gr.dts
@@ -108,9 +108,16 @@
 			};
 
 			iNIC_rf: partition@48000 {
+				compatible = "nvmem-cells";
 				label = "iNIC_rf";
 				reg = <0x48000 0x8000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_iNIC_rf_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -214,7 +221,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&iNIC_rf 0x0>;
+		nvmem-cells = <&eeprom_iNIC_rf_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_iodata_wn-ac1167gr.dts
+++ b/target/linux/ramips/dts/mt7620a_iodata_wn-ac1167gr.dts
@@ -91,9 +91,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x8000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			iNIC_rf: partition@48000 {
@@ -209,15 +220,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_iodata_wn-ac733gr3.dts
+++ b/target/linux/ramips/dts/mt7620a_iodata_wn-ac733gr3.dts
@@ -105,9 +105,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x8000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			iNIC_rf: partition@48000 {
@@ -187,15 +198,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_iodata_wn-ac733gr3.dts
+++ b/target/linux/ramips/dts/mt7620a_iodata_wn-ac733gr3.dts
@@ -122,9 +122,16 @@
 			};
 
 			iNIC_rf: partition@48000 {
+				compatible = "nvmem-cells";
 				label = "iNIC_rf";
 				reg = <0x48000 0x8000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_iNIC_rf_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -192,7 +199,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&iNIC_rf 0x0>;
+		nvmem-cells = <&eeprom_iNIC_rf_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_iptime.dtsi
+++ b/target/linux/ramips/dts/mt7620a_iptime.dtsi
@@ -40,6 +40,10 @@
 					reg = <0x1f400 0x200>;
 				};
 
+				eeprom_uboot_1f800: eeprom@1f800 {
+					reg = <0x1f800 0x200>;
+				};
+
 				macaddr_uboot_1fc20: macaddr@1fc20 {
 					reg = <0x1fc20 0x6>;
 				};
@@ -80,7 +84,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&uboot 0x1f800>;
+		nvmem-cells = <&eeprom_uboot_1f800>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7620a_iptime.dtsi
+++ b/target/linux/ramips/dts/mt7620a_iptime.dtsi
@@ -29,9 +29,20 @@
 			#size-cells = <1>;
 
 			uboot: partition@0 {
+				compatible = "nvmem-cells";
 				label = "u-boot";
 				reg = <0x0 0x20000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_uboot_1f400: eeprom@1f400 {
+					reg = <0x1f400 0x200>;
+				};
+
+				macaddr_uboot_1fc20: macaddr@1fc20 {
+					reg = <0x1fc20 0x6>;
+				};
 			};
 
 			partition@20000 {
@@ -82,16 +93,6 @@
 &wmac {
 	pinctrl-names = "default";
 	pinctrl-0 = <&wled_pins>;
-
-	ralink,mtd-eeprom = <&uboot 0x1f400>;
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc20: macaddr@1fc20 {
-		reg = <0x1fc20 0x6>;
-	};
+	nvmem-cells = <&eeprom_uboot_1f400>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_kimax_u25awf-h1.dts
+++ b/target/linux/ramips/dts/mt7620a_kimax_u25awf-h1.dts
@@ -73,9 +73,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -101,22 +112,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "uartf", "ephy", "wled";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_lava_lr-25g001.dts
+++ b/target/linux/ramips/dts/mt7620a_lava_lr-25g001.dts
@@ -92,9 +92,20 @@
 			};
 
 			config: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0xff0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_config_e08a: eeprom@e08a {
+					reg = <0xe08a 0x200>;
+				};
+
+				macaddr_config_e07e: macaddr@e07e {
+					reg = <0xe07e 0x6>;
+				};
 			};
 		};
 	};
@@ -150,10 +161,9 @@
 &pcie0 {
 	mt76x0e@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_config_e07e>;
-		nvmem-cell-names = "mac-address";
-		mac-address-increment = <(2)>;
-		mediatek,mtd-eeprom = <&config 0xe08a>;
+		nvmem-cells = <&eeprom_config_e08a>, <&macaddr_config_e07e>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		mac-address-increment = <2>;
 	};
 };
 
@@ -161,15 +171,5 @@
 	gpio {
 		groups = "uartf", "i2c";
 		function = "gpio";
-	};
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_e07e: macaddr@e07e {
-		reg = <0xe07e 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_lb-link_bl-w1200.dts
+++ b/target/linux/ramips/dts/mt7620a_lb-link_bl-w1200.dts
@@ -76,6 +76,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -165,7 +169,8 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 
 		led {
 			led-sources = <2>;

--- a/target/linux/ramips/dts/mt7620a_lb-link_bl-w1200.dts
+++ b/target/linux/ramips/dts/mt7620a_lb-link_bl-w1200.dts
@@ -65,9 +65,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -141,7 +152,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -168,14 +180,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dts
+++ b/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dts
@@ -58,13 +58,3 @@
 
 	mediatek,portmap = "llllw";
 };
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
-};

--- a/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dtsi
@@ -66,6 +66,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -95,7 +99,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dtsi
@@ -55,9 +55,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -93,8 +104,8 @@
 	pinctrl-names = "default", "pa_gpio";
 	pinctrl-0 = <&pa_pins>;
 	pinctrl-1 = <&pa_gpio_pins>;
-
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {

--- a/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1s.dts
+++ b/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1s.dts
@@ -115,13 +115,3 @@
 	mediatek,port4-gmac;
 	mediatek,ephy-base = /bits/ 8 <8>;
 };
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
-};

--- a/target/linux/ramips/dts/mt7620a_linksys_e1700.dts
+++ b/target/linux/ramips/dts/mt7620a_linksys_e1700.dts
@@ -76,9 +76,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -150,15 +161,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_microduino_microwrt.dts
+++ b/target/linux/ramips/dts/mt7620a_microduino_microwrt.dts
@@ -54,9 +54,20 @@
 			};
 
 			factory: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@40000 {
@@ -87,22 +98,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "wled", "i2c", "wdt", "uartf";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_netcore_nw5212.dts
+++ b/target/linux/ramips/dts/mt7620a_netcore_nw5212.dts
@@ -93,9 +93,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -115,8 +122,9 @@
 };
 
 &ethernet {
-	mtd-mac-address = <&factory 0x28>;
 	mediatek,portmap = "llllw";
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
 };
 
 &ehci {

--- a/target/linux/ramips/dts/mt7620a_netcore_nw5212.dts
+++ b/target/linux/ramips/dts/mt7620a_netcore_nw5212.dts
@@ -100,6 +100,10 @@
 				#size-cells = <1>;
 				read-only;
 
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -136,5 +140,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_netgear_ex2700.dts
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex2700.dts
@@ -112,9 +112,24 @@
 			};
 
 			art: partition@3f0000 {
+				compatible = "nvmem-cells";
 				label = "art";
 				reg = <0x3f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_art_0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_art_6: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
+
+				eeprom_art_1000: eeprom@1000 {
+					reg = <0x1000 0x200>;
+				};
 			};
 		};
 	};
@@ -126,29 +141,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&art 0x1000>;
-
-	nvmem-cells = <&macaddr_art_6>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_art_1000>, <&macaddr_art_6>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &state_default {
 	default {
 		groups = "i2c", "uartf", "spi refclk";
 		function = "gpio";
-	};
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_netgear_ex3x00_ex61xx.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex3x00_ex61xx.dtsi
@@ -109,6 +109,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -142,7 +146,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_netgear_ex3x00_ex61xx.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex3x00_ex61xx.dtsi
@@ -98,9 +98,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -142,7 +153,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
@@ -152,12 +164,3 @@
 	};
 };
 
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
-};

--- a/target/linux/ramips/dts/mt7620a_netgear_wn3x00rp.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_wn3x00rp.dtsi
@@ -116,9 +116,24 @@
 			};
 
 			art: partition@7f0000 {
+				compatible = "nvmem-cells";
 				label = "art";
 				reg = <0x7f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_art_0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_art_6: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
+
+				eeprom_art_1000: eeprom@1000 {
+					reg = <0x1000 0x200>;
+				};
 			};
 		};
 	};
@@ -130,29 +145,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&art 0x1000>;
-
-	nvmem-cells = <&macaddr_art_6>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_art_1000>, <&macaddr_art_6>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &state_default {
 	default {
 		groups = "i2c", "uartf", "spi refclk";
 		function = "gpio";
-	};
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_netis_wf2770.dts
+++ b/target/linux/ramips/dts/mt7620a_netis_wf2770.dts
@@ -74,9 +74,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -161,15 +172,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_netis_wf2770.dts
+++ b/target/linux/ramips/dts/mt7620a_netis_wf2770.dts
@@ -85,6 +85,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -166,7 +170,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_ohyeah_oy-0001.dts
+++ b/target/linux/ramips/dts/mt7620a_ohyeah_oy-0001.dts
@@ -73,9 +73,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -105,7 +116,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &sdhci {
@@ -118,14 +130,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_phicomm_k2x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_phicomm_k2x.dtsi
@@ -80,6 +80,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -102,7 +106,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_phicomm_k2x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_phicomm_k2x.dtsi
@@ -69,9 +69,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 		};
 	};
@@ -102,15 +113,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
@@ -67,19 +67,19 @@
 				read-only;
 			};
 
-			partition@20000 {
+			partition@30000 {
 				label = "u-boot-env";
 				reg = <0x30000 0x10000>;
 				read-only;
 			};
 
-			factory: partition@30000 {
+			factory: partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
 			};
 
-			partition@40000 {
+			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
@@ -74,9 +74,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -118,15 +129,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
@@ -85,6 +85,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -123,7 +127,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_planex_cs-qr10.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_cs-qr10.dts
@@ -80,9 +80,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -136,15 +147,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_planex_db-wrt01.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_db-wrt01.dts
@@ -64,9 +64,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -96,15 +107,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-750dhp.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-750dhp.dts
@@ -84,9 +84,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -116,7 +127,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -127,15 +139,5 @@
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-750dhp.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-750dhp.dts
@@ -95,6 +95,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -138,6 +142,7 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-ex300np.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-ex300np.dts
@@ -99,9 +99,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -136,15 +147,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-ex750np.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-ex750np.dts
@@ -104,9 +104,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -141,7 +152,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -152,15 +164,5 @@
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-ex750np.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-ex750np.dts
@@ -115,6 +115,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -163,6 +167,7 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_ralink_mt7620a-mt7610e-evb.dts
+++ b/target/linux/ramips/dts/mt7620a_ralink_mt7620a-mt7610e-evb.dts
@@ -50,9 +50,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -82,7 +89,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_sanlinking_d240.dts
+++ b/target/linux/ramips/dts/mt7620a_sanlinking_d240.dts
@@ -111,9 +111,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -147,7 +158,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
@@ -173,14 +185,4 @@
 
 &pcie {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_sitecom_wlr-4100-v1-002.dts
+++ b/target/linux/ramips/dts/mt7620a_sitecom_wlr-4100-v1-002.dts
@@ -103,9 +103,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -175,22 +186,13 @@
 &wmac {
 	status = "okay";
 
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	gpio {
 		groups = "uartf", "i2c", "wled", "spi refclk";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_sitecom_wlr-4100-v1-002.dts
+++ b/target/linux/ramips/dts/mt7620a_sitecom_wlr-4100-v1-002.dts
@@ -184,8 +184,6 @@
 };
 
 &wmac {
-	status = "okay";
-
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
@@ -106,9 +106,16 @@
 			};
 
 			rom: partition@7d0000 {
+				compatible = "nvmem-cells";
 				label = "rom";
 				reg = <0x7d0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_rom_f100: macaddr@f100 {
+					reg = <0xf100 0x6>;
+				};
 			};
 
 			partition@7e0000 {
@@ -118,9 +125,16 @@
 			};
 
 			radio: partition@7f0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 		};
 	};
@@ -164,9 +178,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&radio 0x0>;
-	nvmem-cells = <&macaddr_rom_f100>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_rom_f100>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &ehci {
@@ -188,15 +201,5 @@
 		nvmem-cells = <&macaddr_rom_f100>;
 		nvmem-cell-names = "mac-address";
 		mac-address-increment = <(-1)>;
-	};
-};
-
-&rom {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_rom_f100: macaddr@f100 {
-		reg = <0xf100 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
@@ -135,6 +135,10 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x200>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 		};
 	};
@@ -197,9 +201,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
-		nvmem-cells = <&macaddr_rom_f100>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_rom_f100>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(-1)>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
@@ -139,9 +139,16 @@
 			};
 
 			rom: partition@7d0000 {
+				compatible = "nvmem-cells";
 				label = "rom";
 				reg = <0x7d0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_rom_f100: macaddr@f100 {
+					reg = <0xf100 0x6>;
+				};
 			};
 
 			partition@7e0000 {
@@ -151,9 +158,16 @@
 			};
 
 			radio: partition@7f0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 		};
 	};
@@ -180,7 +194,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&radio 0x0>;
+	nvmem-cells = <&eeprom_radio_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -191,15 +206,5 @@
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&radio 0x8000>;
-	};
-};
-
-&rom {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_rom_f100: macaddr@f100 {
-		reg = <0xf100 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
@@ -168,6 +168,10 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x200>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 		};
 	};
@@ -205,6 +209,7 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
+		nvmem-cells = <&eeprom_radio_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_tplink_archer.dtsi
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer.dtsi
@@ -69,9 +69,16 @@
 			};
 
 			rom: partition@7d0000 {
+				compatible = "nvmem-cells";
 				label = "rom";
 				reg = <0x7d0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_rom_f100: macaddr@f100 {
+					reg = <0xf100 0x6>;
+				};
 			};
 
 			partition@7e0000 {
@@ -81,9 +88,16 @@
 			};
 
 			radio: partition@7f0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 		};
 	};
@@ -107,7 +121,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&radio 0x0>;
+	nvmem-cells = <&eeprom_radio_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -119,15 +134,5 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&radio 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&rom {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_rom_f100: macaddr@f100 {
-		reg = <0xf100 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_tplink_archer.dtsi
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer.dtsi
@@ -98,6 +98,10 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x200>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 		};
 	};
@@ -132,7 +136,8 @@
 &pcie0 {
 	wifi: mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
+		nvmem-cells = <&eeprom_radio_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_tplink_re2x0-v1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_tplink_re2x0-v1.dtsi
@@ -80,6 +80,10 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x200>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 		};
 	};
@@ -102,10 +106,9 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
-		nvmem-cells = <&macaddr_uboot_1fc00>;
-		nvmem-cell-names = "mac-address";
-		mac-address-increment = <2>;
 		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_uboot_1fc00>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		mac-address-increment = <2>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_tplink_re2x0-v1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_tplink_re2x0-v1.dtsi
@@ -45,9 +45,16 @@
 			#size-cells = <1>;
 
 			uboot: partition@0 {
+				compatible = "nvmem-cells";
 				label = "u-boot";
 				reg = <0x0 0x20000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_uboot_1fc00: macaddr@1fc00 {
+					reg = <0x1fc00 0x6>;
+				};
 			};
 
 			partition@20000 {
@@ -63,9 +70,16 @@
 			};
 
 			radio: partition@7f0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 		};
 	};
@@ -77,9 +91,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&radio 0x0>;
-	nvmem-cells = <&macaddr_uboot_1fc00>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_uboot_1fc00>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &pcie {
@@ -94,15 +107,5 @@
 		nvmem-cell-names = "mac-address";
 		mac-address-increment = <2>;
 		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn530hg4.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn530hg4.dts
@@ -72,9 +72,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -134,16 +145,6 @@
 	pinctrl-names = "default", "pa_gpio";
 	pinctrl-0 = <&pa_pins>;
 	pinctrl-1 = <&pa_gpio_pins>;
-
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn530hg4.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn530hg4.dts
@@ -83,6 +83,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -136,7 +140,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn535k1.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn535k1.dts
@@ -104,6 +104,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -131,7 +135,8 @@
 &pcie0 {
 	wifi0: wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn535k1.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn535k1.dts
@@ -93,13 +93,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
-				read-only;
-
-				compatible = "nvmem-cells";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
@@ -174,7 +177,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn579x3.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn579x3.dts
@@ -121,9 +121,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -201,22 +212,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	gpio {
 		groups = "ephy", "i2c", "wled", "uartf";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn579x3.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn579x3.dts
@@ -132,6 +132,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -165,7 +169,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_wevo_air-duo.dts
+++ b/target/linux/ramips/dts/mt7620a_wevo_air-duo.dts
@@ -82,13 +82,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
-				read-only;
-
-				compatible = "nvmem-cells";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
@@ -197,6 +200,6 @@
 &wmac {
 	pinctrl-names = "default";
 	pinctrl-0 = <&wled_pins>;
-
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_wevo_air-duo.dts
+++ b/target/linux/ramips/dts/mt7620a_wevo_air-duo.dts
@@ -93,6 +93,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -187,7 +191,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
+++ b/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
@@ -98,9 +98,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -144,11 +155,11 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-
 	pinctrl-names = "default", "pa_gpio";
 	pinctrl-0 = <&pa_pins>;
 	pinctrl-1 = <&pa_gpio_pins>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -167,15 +178,5 @@
 	gpio {
 		groups = "ephy", "i2c", "rgmii1";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
+++ b/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
@@ -109,6 +109,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -169,7 +173,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_youku_x2.dts
+++ b/target/linux/ramips/dts/mt7620a_youku_x2.dts
@@ -27,7 +27,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
@@ -91,6 +91,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};

--- a/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
@@ -80,9 +80,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -113,8 +124,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 	pinctrl-names = "default", "pa_gpio";
 	pinctrl-0 = <&pa_pins>;
 	pinctrl-1 = <&pa_gpio_pins>;
@@ -130,14 +141,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_yukai_bocco.dts
+++ b/target/linux/ramips/dts/mt7620a_yukai_bocco.dts
@@ -103,9 +103,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -143,15 +154,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-ape522ii.dts
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-ape522ii.dts
@@ -91,6 +91,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -130,7 +134,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-ape522ii.dts
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-ape522ii.dts
@@ -80,9 +80,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -105,11 +116,11 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-
 	pinctrl-names = "default", "pa_gpio";
 	pinctrl-0 = <&pa_pins>;
 	pinctrl-1 = <&pa_gpio_pins>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -128,15 +139,5 @@
 	gpio {
 		groups = "wled", "i2c", "uartf", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026-5g.dtsi
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026-5g.dtsi
@@ -44,7 +44,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026.dtsi
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026.dtsi
@@ -64,6 +64,10 @@
 					reg = <0x0 0x200>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026.dtsi
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026.dtsi
@@ -53,9 +53,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -92,22 +103,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "i2c", "uartf", "spi refclk", "ephy", "wled";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826.dtsi
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826.dtsi
@@ -75,9 +75,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -117,7 +128,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
@@ -129,14 +141,4 @@
 
 &pcie {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_zte_q7.dts
+++ b/target/linux/ramips/dts/mt7620a_zte_q7.dts
@@ -69,9 +69,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -98,7 +109,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &sdhci {
@@ -111,14 +123,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
+++ b/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
@@ -112,9 +112,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -163,7 +174,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {
@@ -172,14 +184,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620n_asus_rt-n12p.dts
+++ b/target/linux/ramips/dts/mt7620n_asus_rt-n12p.dts
@@ -91,9 +91,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -113,22 +124,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "ephy", "wled", "i2c", "wdt", "pa", "spi refclk";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_asus_rt-n14u.dts
+++ b/target/linux/ramips/dts/mt7620n_asus_rt-n14u.dts
@@ -96,9 +96,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -126,22 +137,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "ephy", "wled", "i2c";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_buffalo_wmr-300.dts
+++ b/target/linux/ramips/dts/mt7620n_buffalo_wmr-300.dts
@@ -80,9 +80,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -102,22 +113,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "i2c", "ephy";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_comfast_cf-wr800n.dts
+++ b/target/linux/ramips/dts/mt7620n_comfast_cf-wr800n.dts
@@ -86,9 +86,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -106,22 +117,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "ephy", "wled", "spi refclk", "i2c";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_elecom_wrh-300cr.dts
+++ b/target/linux/ramips/dts/mt7620n_elecom_wrh-300cr.dts
@@ -83,9 +83,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -119,22 +130,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "i2c", "ephy", "wled";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_kimax_u35wf.dts
+++ b/target/linux/ramips/dts/mt7620n_kimax_u35wf.dts
@@ -73,9 +73,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -101,22 +112,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "ephy", "wled";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_kingston_mlw221.dts
+++ b/target/linux/ramips/dts/mt7620n_kingston_mlw221.dts
@@ -79,9 +79,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -114,22 +125,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "i2c", "ephy", "wled";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_kingston_mlwg2.dts
+++ b/target/linux/ramips/dts/mt7620n_kingston_mlwg2.dts
@@ -79,9 +79,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -114,22 +125,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "i2c", "ephy", "wled";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_netgear_n300.dtsi
+++ b/target/linux/ramips/dts/mt7620n_netgear_n300.dtsi
@@ -57,9 +57,20 @@
 			};
 
 			factory: partition@3f0000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x3f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 		};
 	};
@@ -73,22 +84,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "pa", "ephy", "wled";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_netgear_pr2000.dts
+++ b/target/linux/ramips/dts/mt7620n_netgear_pr2000.dts
@@ -104,9 +104,16 @@
 			};
 
 			factory: partition@f60000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0xf60000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			board_data: partition@f70000 {
@@ -187,9 +194,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-	nvmem-cells = <&macaddr_board_data_b0>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_board_data_b0>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &state_default {

--- a/target/linux/ramips/dts/mt7620n_netgear_pr2000.dts
+++ b/target/linux/ramips/dts/mt7620n_netgear_pr2000.dts
@@ -110,9 +110,16 @@
 			};
 
 			board_data: partition@f70000 {
+				compatible = "nvmem-cells";
 				label = "board_data";
 				reg = <0xf70000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_board_data_b0: macaddr@b0 {
+					reg = <0xb0 0x6>;
+				};
 			};
 
 			partition@f80000 {
@@ -166,8 +173,9 @@
 };
 
 &ethernet {
-	mtd-mac-address = <&board_data 0xb0>;
 	mediatek,portmap = "wllll";
+	nvmem-cells = <&macaddr_board_data_b0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &ehci {
@@ -180,7 +188,8 @@
 
 &wmac {
 	ralink,mtd-eeprom = <&factory 0x0>;
-	mtd-mac-address = <&board_data 0xb0>;
+	nvmem-cells = <&macaddr_board_data_b0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &state_default {

--- a/target/linux/ramips/dts/mt7620n_nexx_wt3020.dtsi
+++ b/target/linux/ramips/dts/mt7620n_nexx_wt3020.dtsi
@@ -60,9 +60,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -86,22 +97,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "ephy", "wled", "pa", "i2c", "wdt", "uartf";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_snr_cpe-w4n-mt.dts
+++ b/target/linux/ramips/dts/mt7620n_snr_cpe-w4n-mt.dts
@@ -91,9 +91,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "Factory";
 				reg = <0x40000 0x100000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -118,5 +125,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620n_snr_cpe-w4n-mt.dts
+++ b/target/linux/ramips/dts/mt7620n_snr_cpe-w4n-mt.dts
@@ -93,7 +93,7 @@
 			factory: partition@40000 {
 				compatible = "nvmem-cells";
 				label = "Factory";
-				reg = <0x40000 0x100000>;
+				reg = <0x40000 0x10000>;
 				#address-cells = <1>;
 				#size-cells = <1>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_sunvalley_filehub.dtsi
+++ b/target/linux/ramips/dts/mt7620n_sunvalley_filehub.dtsi
@@ -80,9 +80,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -128,22 +139,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	gpio {
 		groups = "wled", "ephy";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_vonets_var11n-300.dts
+++ b/target/linux/ramips/dts/mt7620n_vonets_var11n-300.dts
@@ -60,9 +60,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -82,22 +93,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "i2c";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_wrtnode_wrtnode.dts
+++ b/target/linux/ramips/dts/mt7620n_wrtnode_wrtnode.dts
@@ -53,9 +53,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -83,22 +94,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "ephy", "wled", "pa", "i2c", "wdt", "uartf", "spi refclk";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-cpe102.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-cpe102.dts
@@ -76,9 +76,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -106,22 +117,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "i2c", "spi refclk", "wled";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wa05.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wa05.dts
@@ -84,9 +84,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -114,22 +125,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "i2c", "spi refclk", "wled";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-we2026.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-we2026.dts
@@ -77,9 +77,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -99,22 +110,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "i2c", "spi refclk", "wled";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wr8305rt.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wr8305rt.dts
@@ -80,9 +80,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -113,22 +124,13 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
 	default {
 		groups = "i2c", "uartf", "spi refclk", "wled";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-lite-iii-a.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-lite-iii-a.dts
@@ -108,9 +108,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "RF-EEPROM";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -140,5 +147,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni-ii.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni-ii.dts
@@ -108,9 +108,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -137,7 +148,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {
@@ -146,14 +158,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni.dts
@@ -108,9 +108,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -137,7 +148,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {
@@ -146,14 +158,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-600dhp.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-600dhp.dts
@@ -144,6 +144,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -172,7 +176,8 @@
 &pcie0 {
 	rt5592@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		ralink,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7628an_alfa-network_awusfree1.dts
+++ b/target/linux/ramips/dts/mt7628an_alfa-network_awusfree1.dts
@@ -114,9 +114,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -131,15 +142,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_asus_rt-ac1200-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_asus_rt-ac1200-v2.dts
@@ -7,6 +7,11 @@
 	model = "ASUS RT-AC1200 V2";
 };
 
+&eeprom_factory_8000 {
+	/* V2 has different eeprom size '0x4da8' for MT7613 */
+	reg = <0x8000 0x4da8>;
+};
+
 &state_default {
 	spis {
 		groups = "spis";

--- a/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dtsi
+++ b/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dtsi
@@ -73,13 +73,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
-				read-only;
-
-				compatible = "nvmem-cells";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
@@ -117,7 +120,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {

--- a/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dtsi
+++ b/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dtsi
@@ -84,6 +84,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -132,7 +136,8 @@
 	mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7628an_asus_rt-n1x.dtsi
+++ b/target/linux/ramips/dts/mt7628an_asus_rt-n1x.dtsi
@@ -75,9 +75,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -101,7 +112,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
@@ -121,14 +133,4 @@
 
 &ohci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_buffalo_wcr-1166ds.dts
+++ b/target/linux/ramips/dts/mt7628an_buffalo_wcr-1166ds.dts
@@ -140,9 +140,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 
 			partition@50000 {
@@ -175,5 +182,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_buffalo_wcr-1166ds.dts
+++ b/target/linux/ramips/dts/mt7628an_buffalo_wcr-1166ds.dts
@@ -102,7 +102,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -149,6 +150,10 @@
 
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
 				};
 			};
 

--- a/target/linux/ramips/dts/mt7628an_comfast_cf-wr617ac.dts
+++ b/target/linux/ramips/dts/mt7628an_comfast_cf-wr617ac.dts
@@ -81,6 +81,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_8004: macaddr@8004 {
 					reg = <0x8004 0x6>;
 				};
@@ -107,10 +111,9 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_factory_8004>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_8004>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <2>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_comfast_cf-wr617ac.dts
+++ b/target/linux/ramips/dts/mt7628an_comfast_cf-wr617ac.dts
@@ -77,6 +77,10 @@
 				#size-cells = <1>;
 				read-only;
 
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
 				macaddr_factory_8004: macaddr@8004 {
 					reg = <0x8004 0x6>;
 				};
@@ -122,5 +126,6 @@
 
 &wmac {
 	status = "okay";
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_comfast_cf-wr617ac.dts
+++ b/target/linux/ramips/dts/mt7628an_comfast_cf-wr617ac.dts
@@ -70,9 +70,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_factory_8004: macaddr@8004 {
+					reg = <0x8004 0x6>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -94,7 +105,8 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		mtd-mac-address = < 0x8004>;
+		nvmem-cells = <&macaddr_factory_8004>;
+		nvmem-cell-names = "mac-address";
 		mac-address-increment = <2>;
 	};
 };
@@ -111,13 +123,4 @@
 &wmac {
 	status = "okay";
 	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-	macaddr_factory_e000: macaddr@4 {
-		reg = <0xe000 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_comfast_cf-wr758ac-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_comfast_cf-wr758ac-v2.dts
@@ -6,3 +6,8 @@
 	compatible = "comfast,cf-wr758ac-v2", "mediatek,mt7628an-soc";
 	model = "COMFAST CF-WR758AC V2";
 };
+
+&eeprom_factory_8000 {
+	/* V2 has different eeprom size '0x4da8' for MT7613 */
+	reg = <0x8000 0x4da8>;
+};

--- a/target/linux/ramips/dts/mt7628an_comfast_cf-wr758ac.dtsi
+++ b/target/linux/ramips/dts/mt7628an_comfast_cf-wr758ac.dtsi
@@ -84,9 +84,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -101,7 +112,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
@@ -111,14 +123,4 @@
 
 &esw {
 	mediatek,portdisable = <0x2f>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_comfast_cf-wr758ac.dtsi
+++ b/target/linux/ramips/dts/mt7628an_comfast_cf-wr758ac.dtsi
@@ -53,7 +53,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -93,6 +94,10 @@
 
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
 				};
 
 				macaddr_factory_e000: macaddr@e000 {

--- a/target/linux/ramips/dts/mt7628an_cudy_wr1000.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_wr1000.dts
@@ -89,9 +89,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -132,7 +143,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
@@ -142,14 +154,4 @@
 
 &esw {
 	mediatek,portmap = <0x2f>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_cudy_wr1000.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_wr1000.dts
@@ -100,6 +100,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -130,7 +134,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7628an_dlink_dap-1325-a1.dts
+++ b/target/linux/ramips/dts/mt7628an_dlink_dap-1325-a1.dts
@@ -82,7 +82,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 
 	nvmem-cells = <&macaddr_factory_28>;
 	nvmem-cell-names = "mac-address";
@@ -114,9 +115,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -125,15 +137,5 @@
 				reg = <0x50000 0x7b0000>;
 			};
 		};
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_elecom_wrc-1167fs.dts
+++ b/target/linux/ramips/dts/mt7628an_elecom_wrc-1167fs.dts
@@ -113,6 +113,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -159,7 +163,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_elecom_wrc-1167fs.dts
+++ b/target/linux/ramips/dts/mt7628an_elecom_wrc-1167fs.dts
@@ -102,9 +102,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -163,15 +174,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
@@ -88,7 +88,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &spi0 {
@@ -117,9 +118,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -133,14 +145,4 @@
 
 &uart1 {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_glinet_vixmini_microuter.dtsi
+++ b/target/linux/ramips/dts/mt7628an_glinet_vixmini_microuter.dtsi
@@ -60,7 +60,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &spi0 {
@@ -89,9 +90,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			/*
@@ -103,15 +115,5 @@
 				label = "firmware";
 			};
 		};
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_hak5_wifi-pineapple-mk7.dts
+++ b/target/linux/ramips/dts/mt7628an_hak5_wifi-pineapple-mk7.dts
@@ -101,9 +101,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -125,15 +136,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_hilink_hlk-7628n.dts
+++ b/target/linux/ramips/dts/mt7628an_hilink_hlk-7628n.dts
@@ -67,9 +67,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -89,15 +100,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_hilink_hlk-7688a.dts
+++ b/target/linux/ramips/dts/mt7628an_hilink_hlk-7688a.dts
@@ -81,9 +81,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -115,15 +126,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5761a.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5761a.dts
@@ -58,7 +58,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5861b.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5861b.dts
@@ -53,13 +53,3 @@
 		};
 	};
 };
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
-	};
-};

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5861b.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5861b.dts
@@ -42,10 +42,9 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
-		nvmem-cells = <&macaddr_factory_2e>;
-		nvmem-cell-names = "mac-address";
 		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_2e>;
+		nvmem-cell-names = "eeprom", "mac-address";
 
 		led {
 			led-sources = <2>;

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5x61a.dtsi
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5x61a.dtsi
@@ -57,9 +57,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -97,15 +112,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5x61a.dtsi
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5x61a.dtsi
@@ -68,6 +68,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};

--- a/target/linux/ramips/dts/mt7628an_iptime.dtsi
+++ b/target/linux/ramips/dts/mt7628an_iptime.dtsi
@@ -72,6 +72,10 @@
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 
 			partition@40000 {
@@ -111,7 +115,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_iptime.dtsi
+++ b/target/linux/ramips/dts/mt7628an_iptime.dtsi
@@ -43,9 +43,16 @@
 			#size-cells = <1>;
 
 			uboot: partition@0 {
+				compatible = "nvmem-cells";
 				label = "u-boot";
 				reg = <0x0 0x20000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_uboot_1fc20: macaddr@1fc20 {
+					reg = <0x1fc20 0x6>;
+				};
 			};
 
 			partition@20000 {
@@ -55,9 +62,16 @@
 			};
 
 			factory: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 
 			partition@40000 {
@@ -105,15 +119,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc20: macaddr@1fc20 {
-		reg = <0x1fc20 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_jotale_js76x8.dtsi
+++ b/target/linux/ramips/dts/mt7628an_jotale_js76x8.dtsi
@@ -81,9 +81,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -124,15 +135,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_keenetic_kn-1613.dts
+++ b/target/linux/ramips/dts/mt7628an_keenetic_kn-1613.dts
@@ -141,6 +141,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_400: eeprom@400 {
+					reg = <0x400 0x4da8>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -219,7 +223,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0400>;
+		nvmem-cells = <&eeprom_factory_400>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_keenetic_kn-1613.dts
+++ b/target/linux/ramips/dts/mt7628an_keenetic_kn-1613.dts
@@ -130,9 +130,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "rf-eeprom";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			firmware1: partition@50000 {
@@ -196,7 +207,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -209,15 +221,5 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0400>;
 		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_kroks.dtsi
+++ b/target/linux/ramips/dts/mt7628an_kroks.dtsi
@@ -65,8 +65,19 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -90,16 +101,6 @@
 	};
 };
 
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
-};
-
 &ethernet {
 	nvmem-cells = <&macaddr_factory_4>;
 	nvmem-cell-names = "mac-address";
@@ -108,7 +109,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0000>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &uart1 {

--- a/target/linux/ramips/dts/mt7628an_linksys_e5400.dts
+++ b/target/linux/ramips/dts/mt7628an_linksys_e5400.dts
@@ -78,13 +78,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
-				read-only;
-
-				compatible = "nvmem-cells";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
@@ -155,9 +158,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-	nvmem-cells = <&macaddr_factory_28>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_28>;
+	nvmem-cell-names = "eeprom", "mac-address";
 	mac-address-increment = <2>;
 };
 

--- a/target/linux/ramips/dts/mt7628an_linksys_e5400.dts
+++ b/target/linux/ramips/dts/mt7628an_linksys_e5400.dts
@@ -89,6 +89,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -135,11 +139,10 @@
 	wifi5: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
 
-		nvmem-cells = <&macaddr_factory_28>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_28>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <3>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_mediatek_linkit-smart-7688.dts
+++ b/target/linux/ramips/dts/mt7628an_mediatek_linkit-smart-7688.dts
@@ -108,9 +108,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -159,15 +170,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_mediatek_mt7628an-eval-board.dts
+++ b/target/linux/ramips/dts/mt7628an_mediatek_mt7628an-eval-board.dts
@@ -38,9 +38,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 
 			partition@50000 {
@@ -55,5 +62,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
@@ -60,9 +60,16 @@
 			};
 
 			art: partition@1e000 {
+				compatible = "nvmem-cells";
 				label = "art";
 				reg = <0x1e000 0x2000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_art_1000: eeprom@1000 {
+					reg = <0x1000 0x200>;
+				};
 			};
 
 			partition@20000 {
@@ -108,7 +115,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&art 0x1000>;
+		nvmem-cells = <&eeprom_art_1000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
@@ -87,7 +87,6 @@
 	status = "okay";
 
 	mediatek,mtd-eeprom = <&factory 0x0>;
-	ralink,mtd-eeprom = <&art 0x0>;
 };
 
 &pcie {

--- a/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
@@ -43,9 +43,20 @@
 			};
 
 			factory: partition@1d800 {
+				compatible = "nvmem-cells";
 				label = "factory_info";
 				reg = <0x1d800 0x800>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_d: macaddr@d {
+					reg = <0xd 0x6>;
+				};
 			};
 
 			art: partition@1e000 {
@@ -86,7 +97,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -98,15 +110,5 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&art 0x1000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_d: macaddr@d {
-		reg = <0xd 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_minew_g1-c.dts
+++ b/target/linux/ramips/dts/mt7628an_minew_g1-c.dts
@@ -105,9 +105,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -131,20 +142,11 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &sdhci {
 	status = "okay";
 	mediatek,cd-high;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_motorola_mwr03.dts
+++ b/target/linux/ramips/dts/mt7628an_motorola_mwr03.dts
@@ -79,6 +79,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -130,7 +134,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_motorola_mwr03.dts
+++ b/target/linux/ramips/dts/mt7628an_motorola_mwr03.dts
@@ -68,9 +68,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -127,15 +138,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_netgear_r6xxx.dtsi
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6xxx.dtsi
@@ -80,9 +80,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x20000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@60000 {
@@ -97,7 +108,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
@@ -114,15 +126,5 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_netgear_r6xxx.dtsi
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6xxx.dtsi
@@ -91,6 +91,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -124,7 +128,8 @@
 &pcie0 {
 	wifi5: wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_onion_omega2.dtsi
+++ b/target/linux/ramips/dts/mt7628an_onion_omega2.dtsi
@@ -118,9 +118,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -164,15 +175,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_rakwireless_rak633.dts
+++ b/target/linux/ramips/dts/mt7628an_rakwireless_rak633.dts
@@ -52,9 +52,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -94,15 +105,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_ravpower_rp-wd009.dts
+++ b/target/linux/ramips/dts/mt7628an_ravpower_rp-wd009.dts
@@ -106,7 +106,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5470000 6000000>;
 	};
 };
@@ -146,6 +147,10 @@
 
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
 				};
 
 				macaddr_factory_4: macaddr@4 {

--- a/target/linux/ramips/dts/mt7628an_ravpower_rp-wd009.dts
+++ b/target/linux/ramips/dts/mt7628an_ravpower_rp-wd009.dts
@@ -137,9 +137,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -183,20 +194,11 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
 	nvmem-cells = <&macaddr_factory_4>;
 	nvmem-cell-names = "mac-address";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_skylab_skw92a.dts
+++ b/target/linux/ramips/dts/mt7628an_skylab_skw92a.dts
@@ -54,7 +54,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &spi0 {
@@ -83,9 +84,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -99,14 +111,4 @@
 
 &uart1 {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_tama_w06.dts
+++ b/target/linux/ramips/dts/mt7628an_tama_w06.dts
@@ -75,9 +75,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -98,15 +109,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_totolink_lr1200.dts
+++ b/target/linux/ramips/dts/mt7628an_totolink_lr1200.dts
@@ -100,7 +100,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -152,6 +153,10 @@
 
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
 				};
 
 				macaddr_factory_28: macaddr@28 {

--- a/target/linux/ramips/dts/mt7628an_totolink_lr1200.dts
+++ b/target/linux/ramips/dts/mt7628an_totolink_lr1200.dts
@@ -108,7 +108,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
@@ -142,9 +143,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -153,15 +165,5 @@
 				reg = <0x50000 0x7b0000>;
 			};
 		};
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_8m-split-uboot.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_8m-split-uboot.dtsi
@@ -81,6 +81,10 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 		};
 	};

--- a/target/linux/ramips/dts/mt7628an_tplink_8m-split-uboot.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_8m-split-uboot.dtsi
@@ -53,9 +53,16 @@
 			};
 
 			rom: partition@7d0000 {
+				compatible = "nvmem-cells";
 				label = "rom";
 				reg = <0x7d0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_rom_f100: macaddr@f100 {
+					reg = <0xf100 0x6>;
+				};
 			};
 
 			partition@7e0000 {
@@ -64,9 +71,16 @@
 			};
 
 			radio: partition@7f0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 		};
 	};
@@ -75,10 +89,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&radio 0x0>;
-
-	nvmem-cells = <&macaddr_rom_f100>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_rom_f100>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &ethernet {
@@ -88,14 +100,4 @@
 
 &esw {
 	mediatek,portmap = <0x3e>;
-};
-
-&rom {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_rom_f100: macaddr@f100 {
-		reg = <0xf100 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
@@ -45,9 +45,20 @@
 			};
 
 			factory: partition@7d0000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x7d0000 0x30000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_factory_f100: macaddr@f100 {
+					reg = <0xf100 0x6>;
+				};
+
+				eeprom_factory_20000: eeprom@20000 {
+					reg = <0x20000 0x400>;
+				};
 			};
 		};
 	};
@@ -56,23 +67,11 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x20000>;
-
-	nvmem-cells = <&macaddr_factory_f100>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_factory_f100>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &ethernet {
 	nvmem-cells = <&macaddr_factory_f100>;
 	nvmem-cell-names = "mac-address";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_f100: macaddr@f100 {
-		reg = <0xf100 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
@@ -59,6 +59,10 @@
 				eeprom_factory_20000: eeprom@20000 {
 					reg = <0x20000 0x400>;
 				};
+
+				eeprom_factory_28000: eeprom@28000 {
+					reg = <0x28000 0x200>;
+				};
 			};
 		};
 	};

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v4.dts
@@ -99,10 +99,9 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x28000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_factory_f100>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_28000>, <&macaddr_factory_f100>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(-1)>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v5.dts
@@ -94,10 +94,9 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_rom_f100>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_rom_f100>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(-1)>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v3.dts
@@ -94,10 +94,9 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x28000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_factory_f100>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_28000>, <&macaddr_factory_f100>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(-1)>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v4.dts
@@ -92,10 +92,9 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_rom_f100>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_rom_f100>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(-1)>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_re200.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_re200.dtsi
@@ -96,15 +96,29 @@
 			};
 
 			config: partition@7c0000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0x7c0000 0x30000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_config_2008: macaddr@2008 {
+					reg = <0x2008 0x6>;
+				};
 			};
 
 			radio: partition@7f0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 		};
 	};
@@ -126,10 +140,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&radio 0x0>;
-
-	nvmem-cells = <&macaddr_config_2008>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_2008>;
+	nvmem-cell-names = "eeprom", "mac-address";
 	mac-address-increment = <1>;
 };
 
@@ -145,15 +157,5 @@
 		nvmem-cells = <&macaddr_config_2008>;
 		nvmem-cell-names = "mac-address";
 		mac-address-increment = <2>;
-	};
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_2008: macaddr@2008 {
-		reg = <0x2008 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_re200.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_re200.dtsi
@@ -119,6 +119,10 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 		};
 	};
@@ -152,10 +156,9 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_config_2008>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_config_2008>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <2>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_re305-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re305-v1.dts
@@ -61,16 +61,18 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 		};
 	};
 };
 
 &wlan5g {
-	mediatek,mtd-eeprom = <&radio 0x8000>;
-
-	nvmem-cells = <&macaddr_config_10008>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_radio_8000>, <&macaddr_config_10008>;
+	nvmem-cell-names = "eeprom", "mac-address";
 	mac-address-increment = <2>;
 };
 

--- a/target/linux/ramips/dts/mt7628an_tplink_re305-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re305-v1.dts
@@ -33,9 +33,16 @@
 			};
 
 			config: partition@600000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0x600000 0x50000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_config_10008: macaddr@10008 {
+					reg = <0x10008 0x6>;
+				};
 			};
 
 			/*
@@ -44,9 +51,16 @@
 			*/
 
 			radio: partition@7f0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 		};
 	};
@@ -61,24 +75,12 @@
 };
 
 &wmac {
-	mediatek,mtd-eeprom = <&radio 0x0>;
-
-	nvmem-cells = <&macaddr_config_10008>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_10008>;
+	nvmem-cell-names = "eeprom", "mac-address";
 	mac-address-increment = <1>;
 };
 
 &ethernet {
 	nvmem-cells = <&macaddr_config_10008>;
 	nvmem-cell-names = "mac-address";
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_10008: macaddr@10008 {
-		reg = <0x10008 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_re305-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re305-v3.dts
@@ -33,15 +33,29 @@
 			};
 
 			config: partition@7c0000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0x7c0000 0x30000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_config_2008: macaddr@2008 {
+					reg = <0x2008 0x6>;
+				};
 			};
 
 			radio: partition@7f0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 		};
 	};
@@ -56,24 +70,12 @@
 };
 
 &wmac {
-	mediatek,mtd-eeprom = <&radio 0x0>;
-
-	nvmem-cells = <&macaddr_config_2008>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_2008>;
+	nvmem-cell-names = "eeprom", "mac-address";
 	mac-address-increment = <(-1)>;
 };
 
 &ethernet {
 	nvmem-cells = <&macaddr_config_2008>;
 	nvmem-cell-names = "mac-address";
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_2008: macaddr@2008 {
-		reg = <0x2008 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_re305-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re305-v3.dts
@@ -56,16 +56,18 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 		};
 	};
 };
 
 &wlan5g {
-	mediatek,mtd-eeprom = <&radio 0x8000>;
-
-	nvmem-cells = <&macaddr_config_2008>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_radio_8000>, <&macaddr_config_2008>;
+	nvmem-cell-names = "eeprom", "mac-address";
 	mac-address-increment = <(-2)>;
 };
 

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
@@ -121,9 +121,20 @@
 			};
 
 			factory: partition@7d0000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x7d0000 0x30000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_20000: eeprom@20000 {
+					reg = <0x20000 0x400>;
+				};
+
+				macaddr_factory_f100: macaddr@f100 {
+					reg = <0xf100 0x6>;
+				};
 			};
 		};
 	};
@@ -139,23 +150,11 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x20000>;
-
-	nvmem-cells = <&macaddr_factory_f100>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_factory_f100>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &ethernet {
 	nvmem-cells = <&macaddr_factory_f100>;
 	nvmem-cell-names = "mac-address";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_f100: macaddr@f100 {
-		reg = <0xf100 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v5.dts
@@ -70,9 +70,20 @@
 			};
 
 			factory: partition@3f0000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x3f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_f100: macaddr@f100 {
+					reg = <0xf100 0x6>;
+				};
 			};
 		};
 	};
@@ -89,10 +100,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-
-	nvmem-cells = <&macaddr_factory_f100>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_f100>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &ethernet {
@@ -108,15 +117,5 @@
 	gpio {
 		groups = "p0led_an", "p2led_an", "perst";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_f100: macaddr@f100 {
-		reg = <0xf100 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr841n-v14.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr841n-v14.dts
@@ -81,9 +81,20 @@
 			};
 
 			factory: partition@3f0000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x3f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_f100: macaddr@f100 {
+					reg = <0xf100 0x6>;
+				};
 			};
 		};
 	};
@@ -100,10 +111,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-
-	nvmem-cells = <&macaddr_factory_f100>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_f100>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &ethernet {
@@ -127,15 +136,5 @@
 		gpio-hog;
 		gpios = <43 GPIO_ACTIVE_HIGH>;
 		output-high;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_f100: macaddr@f100 {
-		reg = <0xf100 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr902ac-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr902ac-v3.dts
@@ -90,10 +90,9 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x28000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_factory_f100>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_28000>, <&macaddr_factory_f100>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(-1)>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_unielec_u7628-01-16m.dts
+++ b/target/linux/ramips/dts/mt7628an_unielec_u7628-01-16m.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -55,14 +66,4 @@
 &ethernet {
 	nvmem-cells = <&macaddr_factory_28>;
 	nvmem-cell-names = "mac-address";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_unielec_u7628-01.dtsi
+++ b/target/linux/ramips/dts/mt7628an_unielec_u7628-01.dtsi
@@ -88,7 +88,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {

--- a/target/linux/ramips/dts/mt7628an_vocore_vocore2.dtsi
+++ b/target/linux/ramips/dts/mt7628an_vocore_vocore2.dtsi
@@ -40,9 +40,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -64,7 +75,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
@@ -95,14 +107,4 @@
 
 &uart2 {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn531a3.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn531a3.dts
@@ -108,9 +108,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -125,7 +136,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
@@ -135,14 +147,4 @@
 
 &esw {
 	mediatek,portmap = <0x2f>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn531a3.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn531a3.dts
@@ -77,7 +77,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -117,6 +118,10 @@
 
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
 				};
 
 				macaddr_factory_28: macaddr@28 {

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn570ha1.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn570ha1.dts
@@ -67,7 +67,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -107,6 +108,10 @@
 
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
 				};
 
 				macaddr_factory_2e: macaddr@2e {

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn570ha1.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn570ha1.dts
@@ -98,9 +98,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -115,7 +126,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
@@ -125,14 +137,4 @@
 
 &esw {
 	mediatek,portmap = <0x2f>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn575a3.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn575a3.dts
@@ -93,9 +93,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -110,7 +121,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
@@ -120,14 +132,4 @@
 
 &esw {
 	mediatek,portmap = <0x2f>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn575a3.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn575a3.dts
@@ -62,7 +62,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -102,6 +103,10 @@
 
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
 				};
 
 				macaddr_factory_28: macaddr@28 {

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn576a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn576a2.dts
@@ -132,9 +132,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -149,7 +160,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
@@ -171,14 +183,4 @@
 
 &ohci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn576a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn576a2.dts
@@ -101,7 +101,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -141,6 +142,10 @@
 
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
 				};
 
 				macaddr_factory_28: macaddr@28 {

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn577a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn577a2.dts
@@ -97,9 +97,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -114,7 +125,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
@@ -136,14 +148,4 @@
 
 &ohci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn577a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn577a2.dts
@@ -66,7 +66,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -106,6 +107,10 @@
 
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
 				};
 
 				macaddr_factory_28: macaddr@28 {

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn578a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn578a2.dts
@@ -127,9 +127,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -144,7 +155,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
@@ -166,14 +178,4 @@
 
 &ohci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn578a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn578a2.dts
@@ -96,7 +96,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -136,6 +137,10 @@
 
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
 				};
 
 				macaddr_factory_28: macaddr@28 {

--- a/target/linux/ramips/dts/mt7628an_widora_neo.dtsi
+++ b/target/linux/ramips/dts/mt7628an_widora_neo.dtsi
@@ -74,9 +74,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -167,15 +178,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_wiznet_wizfi630s.dts
+++ b/target/linux/ramips/dts/mt7628an_wiznet_wizfi630s.dts
@@ -117,9 +117,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -161,15 +172,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_wrtnode_wrtnode2.dtsi
+++ b/target/linux/ramips/dts/mt7628an_wrtnode_wrtnode2.dtsi
@@ -48,9 +48,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -90,15 +101,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-ra75.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-ra75.dts
@@ -95,7 +95,7 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	mediatek,mtd-eeprom = <&factory 0x0>;
 };
 
 

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-ra75.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-ra75.dts
@@ -95,9 +95,9 @@
 };
 
 &wmac {
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
-
 
 &esw {
 	mediatek,portmap = <0x3e>;
@@ -111,22 +111,3 @@
 &ohci {
 	status = "disabled";
 };
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
-	macaddr_factory_8004: macaddr@8004 {
-		reg = <0x8004 0x6>;
-	};
-};
-
-

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-ra75.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-ra75.dts
@@ -84,7 +84,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4.dtsi
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4.dtsi
@@ -58,6 +58,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4.dtsi
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4.dtsi
@@ -47,9 +47,28 @@
 			};
 
 			factory: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
+
+				macaddr_factory_8004: macaddr@8004 {
+					reg = <0x8004 0x6>;
+				};
 			};
 
 			partition@40000 {
@@ -79,5 +98,6 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m-intl.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m-intl.dts
@@ -57,7 +57,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m-intl.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m-intl.dts
@@ -72,13 +72,3 @@
 	mediatek,portmap = <0x3e>;
 	mediatek,portdisable = <0x2a>;
 };
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
-};

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m.dts
@@ -57,7 +57,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m.dts
@@ -72,13 +72,3 @@
 	mediatek,portmap = <0x3e>;
 	mediatek,portdisable = <0x2a>;
 };
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
-};

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4c.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4c.dts
@@ -71,13 +71,3 @@
 	mediatek,portmap = <0x3d>;
 	mediatek,portdisable = <0x29>;
 };
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
-};

--- a/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-3c.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-3c.dts
@@ -74,7 +74,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
@@ -113,9 +114,20 @@
 			};
 
 			factory: partition@50000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x50000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@60000 {
@@ -142,15 +154,5 @@
 				reg = <0x140000 0xec0000>;
 			};
 		};
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-nano.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-nano.dts
@@ -72,7 +72,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
@@ -105,9 +106,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -116,15 +128,5 @@
 				reg = <0x50000 0xfb0000>;
 			};
 		};
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we1226.dts
+++ b/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we1226.dts
@@ -86,9 +86,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -103,7 +114,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ethernet {
@@ -113,14 +125,4 @@
 
 &esw {
 	mediatek,portmap = <0x2f>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
+++ b/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
@@ -132,6 +132,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -216,7 +220,8 @@
 	mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
+++ b/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
@@ -121,9 +121,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "rf-eeprom";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			firmware1: partition@50000 {
@@ -193,7 +204,8 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pcie {
@@ -213,15 +225,5 @@
 	gpio {
 		groups = "gpio", "i2s", "refclk", "spi cs1", "uart1", "wled_an";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/rt2880_airlink101_ar670w.dts
+++ b/target/linux/ramips/dts/rt2880_airlink101_ar670w.dts
@@ -31,9 +31,20 @@
 			};
 
 			factory: partition@30000 {
-				reg = <0x30000 0x10000>;
+				compatible = "nvmem-cells";
 				label = "factory";
+				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_2000: eeprom@2000 {
+					reg = <0x2000 0x200>;
+				};
+
+				macaddr_factory_2004: macaddr@2004 {
+					reg = <0x2004 0x6>;
+				};
 			};
 
 			partition@40000 {
@@ -105,15 +116,6 @@
 
 &wmac {
 	status = "okay";
-	ralink,mtd-eeprom = <&factory 0x2000>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2004: macaddr@2004 {
-		reg = <0x2004 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_2000>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt2880_airlink101_ar670w.dts
+++ b/target/linux/ramips/dts/rt2880_airlink101_ar670w.dts
@@ -115,7 +115,6 @@
 };
 
 &wmac {
-	status = "okay";
 	nvmem-cells = <&eeprom_factory_2000>;
 	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt2880_airlink101_ar725w.dts
+++ b/target/linux/ramips/dts/rt2880_airlink101_ar725w.dts
@@ -125,7 +125,6 @@
 };
 
 &wmac {
-	status = "okay";
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt2880_airlink101_ar725w.dts
+++ b/target/linux/ramips/dts/rt2880_airlink101_ar725w.dts
@@ -36,9 +36,20 @@
 			};
 
 			factory: partition@40000 {
-				reg = <0x40000 0x10000>;
+				compatible = "nvmem-cells";
 				label = "factory";
+				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -115,15 +126,6 @@
 
 &wmac {
 	status = "okay";
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt2880_asus_rt-n15.dts
+++ b/target/linux/ramips/dts/rt2880_asus_rt-n15.dts
@@ -40,9 +40,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -113,15 +124,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt2880_belkin_f5d8235-v1.dts
+++ b/target/linux/ramips/dts/rt2880_belkin_f5d8235-v1.dts
@@ -244,7 +244,6 @@
 };
 
 &wmac {
-	status = "okay";
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt2880_belkin_f5d8235-v1.dts
+++ b/target/linux/ramips/dts/rt2880_belkin_f5d8235-v1.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -234,15 +245,6 @@
 
 &wmac {
 	status = "okay";
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt2880_buffalo_wli-tx4-ag300n.dts
+++ b/target/linux/ramips/dts/rt2880_buffalo_wli-tx4-ag300n.dts
@@ -40,9 +40,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -116,15 +127,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt2880_buffalo_wzr-agl300nh.dts
+++ b/target/linux/ramips/dts/rt2880_buffalo_wzr-agl300nh.dts
@@ -40,9 +40,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -138,15 +149,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt2880_dlink_dap-1522-a1.dts
+++ b/target/linux/ramips/dts/rt2880_dlink_dap-1522-a1.dts
@@ -32,9 +32,20 @@
 			};
 
 			factory: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_2000: eeprom@2000 {
+					reg = <0x2000 0x200>;
+				};
+
+				macaddr_factory_2004: macaddr@2004 {
+					reg = <0x2004 0x6>;
+				};
 			};
 
 			partition@40000 {
@@ -138,15 +149,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x2000>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2004: macaddr@2004 {
-		reg = <0x2004 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_2000>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt2880_ralink_v11st-fe.dts
+++ b/target/linux/ramips/dts/rt2880_ralink_v11st-fe.dts
@@ -37,9 +37,16 @@
 			};
 
 			factory: partition@40000 {
-				reg = <0x00040000 0x00010000>;
+				compatible = "nvmem-cells";
 				label = "factory";
+				reg = <0x00040000 0x00010000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -80,5 +87,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3050_8devices_carambola.dts
+++ b/target/linux/ramips/dts/rt3050_8devices_carambola.dts
@@ -35,9 +35,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -72,19 +83,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3050_allnet_all0256n.dtsi
+++ b/target/linux/ramips/dts/rt3050_allnet_all0256n.dtsi
@@ -63,9 +63,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -94,15 +105,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3050_alphanetworks_asl26555-16m.dts
+++ b/target/linux/ramips/dts/rt3050_alphanetworks_asl26555-16m.dts
@@ -55,9 +55,20 @@
 			};
 
 			devdata: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "devdata";
 				reg = <0xff0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_devdata_4000: eeprom@4000 {
+					reg = <0x4000 0x200>;
+				};
+
+				macaddr_devdata_4004: macaddr@4004 {
+					reg = <0x4004 0x6>;
+				};
 			};
 		};
 	};
@@ -66,14 +77,4 @@
 &ethernet {
 	nvmem-cells = <&macaddr_devdata_4004>;
 	nvmem-cell-names = "mac-address";
-};
-
-&devdata {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_devdata_4004: macaddr@4004 {
-		reg = <0x4004 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3050_alphanetworks_asl26555-8m.dts
+++ b/target/linux/ramips/dts/rt3050_alphanetworks_asl26555-8m.dts
@@ -25,9 +25,20 @@
 			};
 
 			devdata: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "uboot-env";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_devdata_4000: eeprom@4000 {
+					reg = <0x4000 0x200>;
+				};
+
+				macaddr_devdata_4004: macaddr@4004 {
+					reg = <0x4004 0x6>;
+				};
 			};
 
 			partition@40000 {
@@ -60,14 +71,4 @@
 &ethernet {
 	nvmem-cells = <&macaddr_devdata_4004>;
 	nvmem-cell-names = "mac-address";
-};
-
-&devdata {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_devdata_4004: macaddr@4004 {
-		reg = <0x4004 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3050_alphanetworks_asl26555.dtsi
+++ b/target/linux/ramips/dts/rt3050_alphanetworks_asl26555.dtsi
@@ -89,7 +89,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&devdata 0x4000>;
+	nvmem-cells = <&eeprom_devdata_4000>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {

--- a/target/linux/ramips/dts/rt3050_arcwireless_freestation5.dts
+++ b/target/linux/ramips/dts/rt3050_arcwireless_freestation5.dts
@@ -35,9 +35,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -103,19 +114,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3050_asus_rt-g32-b1.dts
+++ b/target/linux/ramips/dts/rt3050_asus_rt-g32-b1.dts
@@ -51,9 +51,20 @@
 			};
 
 			devconf: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "devconf";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_devconf_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_devconf_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -82,15 +93,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&devconf 0x0>;
-};
-
-&devconf {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_devconf_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_devconf_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3050_asus_rt-n10-plus.dts
+++ b/target/linux/ramips/dts/rt3050_asus_rt-n10-plus.dts
@@ -38,9 +38,20 @@
 			};
 
 			devconf: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "devconf";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_devconf_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_devconf_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -88,15 +99,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&devconf 0x0>;
-};
-
-&devconf {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_devconf_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_devconf_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3050_asus_wl-330n.dts
+++ b/target/linux/ramips/dts/rt3050_asus_wl-330n.dts
@@ -72,9 +72,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -103,15 +114,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3050_asus_wl-330n3g.dts
+++ b/target/linux/ramips/dts/rt3050_asus_wl-330n3g.dts
@@ -77,9 +77,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -108,19 +119,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3050_dlink_dcs-930.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dcs-930.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -105,19 +116,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3050_dlink_dir-300-b1.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dir-300-b1.dts
@@ -32,9 +32,20 @@
 			};
 
 			devdata: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "devdata";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_devdata_4000: eeprom@4000 {
+					reg = <0x4000 0x200>;
+				};
+
+				macaddr_devdata_4004: macaddr@4004 {
+					reg = <0x4004 0x6>;
+				};
 			};
 
 			partition@40000 {
@@ -115,15 +126,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&devdata 0x4000>;
-};
-
-&devdata {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_devdata_4004: macaddr@4004 {
-		reg = <0x4004 0x6>;
-	};
+	nvmem-cells = <&eeprom_devdata_4000>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3050_dlink_dir-600-b1.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dir-600-b1.dts
@@ -32,9 +32,20 @@
 			};
 
 			devdata: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "devdata";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_devdata_4000: eeprom@4000 {
+					reg = <0x4000 0x200>;
+				};
+
+				macaddr_devdata_4004: macaddr@4004 {
+					reg = <0x4004 0x6>;
+				};
 			};
 
 			factory: partition@40000 {
@@ -115,15 +126,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&devdata 0x4000>;
-};
-
-&devdata {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_devdata_4004: macaddr@4004 {
-		reg = <0x4004 0x6>;
-	};
+	nvmem-cells = <&eeprom_devdata_4000>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3050_dlink_dir-615-d.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dir-615-d.dts
@@ -33,9 +33,16 @@
 			};
 
 			devdata: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "devdata";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_devdata_4000: eeprom@4000 {
+					reg = <0x4000 0x200>;
+				};
 			};
 
 			partition@40000 {
@@ -105,7 +112,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&devdata 0x4000>;
+	nvmem-cells = <&eeprom_devdata_4000>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {

--- a/target/linux/ramips/dts/rt3050_dlink_dir-620-a1.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dir-620-a1.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -120,19 +131,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3050_edimax_3g-6200n.dts
+++ b/target/linux/ramips/dts/rt3050_edimax_3g-6200n.dts
@@ -39,9 +39,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@3e0000 {
@@ -116,19 +127,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3050_edimax_3g-6200nl.dts
+++ b/target/linux/ramips/dts/rt3050_edimax_3g-6200nl.dts
@@ -39,9 +39,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@3e0000 {
@@ -103,19 +114,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3050_huawei_d105.dts
+++ b/target/linux/ramips/dts/rt3050_huawei_d105.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -96,19 +107,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3050_jcg_jhr-n805r.dts
+++ b/target/linux/ramips/dts/rt3050_jcg_jhr-n805r.dts
@@ -68,9 +68,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -92,15 +103,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3050_netcore_nw718.dts
+++ b/target/linux/ramips/dts/rt3050_netcore_nw718.dts
@@ -79,9 +79,20 @@
 			};
 
 			factory: partition@50000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x50000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@60000 {
@@ -110,19 +121,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3050_sparklan_wcr-150gn.dts
+++ b/target/linux/ramips/dts/rt3050_sparklan_wcr-150gn.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -102,19 +113,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3050_teltonika_rut5xx.dts
+++ b/target/linux/ramips/dts/rt3050_teltonika_rut5xx.dts
@@ -70,9 +70,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -101,19 +112,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3050_tenda_w150m.dts
+++ b/target/linux/ramips/dts/rt3050_tenda_w150m.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -120,15 +131,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3050_trendnet_tew-638apb-v2.dts
+++ b/target/linux/ramips/dts/rt3050_trendnet_tew-638apb-v2.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -100,15 +111,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3052_accton_wr6202.dts
+++ b/target/linux/ramips/dts/rt3052_accton_wr6202.dts
@@ -66,9 +66,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -108,19 +119,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_alfa-network_w502u.dts
+++ b/target/linux/ramips/dts/rt3052_alfa-network_w502u.dts
@@ -42,9 +42,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -106,19 +117,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_argus_atp-52b.dts
+++ b/target/linux/ramips/dts/rt3052_argus_atp-52b.dts
@@ -37,8 +37,19 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -98,19 +109,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_asiarf_awapn2403.dts
+++ b/target/linux/ramips/dts/rt3052_asiarf_awapn2403.dts
@@ -61,9 +61,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -87,5 +94,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3052_asus_rt-n13u.dts
+++ b/target/linux/ramips/dts/rt3052_asus_rt-n13u.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -100,19 +111,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_aximcom_mr-102n.dts
+++ b/target/linux/ramips/dts/rt3052_aximcom_mr-102n.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -118,19 +129,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_aztech_hw550-3g.dts
+++ b/target/linux/ramips/dts/rt3052_aztech_hw550-3g.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -118,19 +129,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_belkin_f5d8235-v2.dts
+++ b/target/linux/ramips/dts/rt3052_belkin_f5d8235-v2.dts
@@ -26,9 +26,20 @@
 			#size-cells = <1>;
 
 			uboot: partition@0 {
+				compatible = "nvmem-cells";
 				label = "uboot";
 				reg = <0x0 0x50000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_uboot_40000: eeprom@40000 {
+					reg = <0x40000 0x200>;
+				};
+
+				macaddr_uboot_40004: macaddr@40004 {
+					reg = <0x40004 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -135,19 +146,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&uboot 0x40000>;
+	nvmem-cells = <&eeprom_uboot_40000>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_40004: macaddr@40004 {
-		reg = <0x40004 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_buffalo_whr-g300n.dts
+++ b/target/linux/ramips/dts/rt3052_buffalo_whr-g300n.dts
@@ -37,9 +37,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -122,15 +133,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3052_dlink_dap-1350.dts
+++ b/target/linux/ramips/dts/rt3052_dlink_dap-1350.dts
@@ -36,9 +36,20 @@
 			};
 
 			devdata: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "devdata";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_devdata_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_devdata_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
 			};
 
 			partition@40000 {
@@ -127,19 +138,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&devdata 0x0>;
+	nvmem-cells = <&eeprom_devdata_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&devdata {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_devdata_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_engenius_esr-9753.dts
+++ b/target/linux/ramips/dts/rt3052_engenius_esr-9753.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -100,15 +111,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3052_fon_fonera-20n.dts
+++ b/target/linux/ramips/dts/rt3052_fon_fonera-20n.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -146,19 +157,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_hauppauge_broadway.dts
+++ b/target/linux/ramips/dts/rt3052_hauppauge_broadway.dts
@@ -31,9 +31,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -89,19 +100,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_huawei_hg255d.dts
+++ b/target/linux/ramips/dts/rt3052_huawei_hg255d.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@60000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x60000 0x20000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@80000 {
@@ -134,19 +145,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_jcg_jhr-n825r.dts
+++ b/target/linux/ramips/dts/rt3052_jcg_jhr-n825r.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -87,15 +98,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3052_jcg_jhr-n926r.dts
+++ b/target/linux/ramips/dts/rt3052_jcg_jhr-n926r.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -133,15 +144,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3052_mofinetwork_mofi3500-3gn.dts
+++ b/target/linux/ramips/dts/rt3052_mofinetwork_mofi3500-3gn.dts
@@ -120,7 +120,6 @@
 };
 
 &wmac {
-	status = "okay";
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3052_mofinetwork_mofi3500-3gn.dts
+++ b/target/linux/ramips/dts/rt3052_mofinetwork_mofi3500-3gn.dts
@@ -38,9 +38,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -114,7 +121,8 @@
 
 &wmac {
 	status = "okay";
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {

--- a/target/linux/ramips/dts/rt3052_netgear_wnce2001.dts
+++ b/target/linux/ramips/dts/rt3052_netgear_wnce2001.dts
@@ -92,9 +92,20 @@
 			};
 
 			factory: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@40000 {
@@ -142,15 +153,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3052_nexaira_bc2.dts
+++ b/target/linux/ramips/dts/rt3052_nexaira_bc2.dts
@@ -31,9 +31,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -84,19 +95,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_omnima_miniembwifi.dts
+++ b/target/linux/ramips/dts/rt3052_omnima_miniembwifi.dts
@@ -63,9 +63,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -94,19 +105,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_petatel_psr-680w.dts
+++ b/target/linux/ramips/dts/rt3052_petatel_psr-680w.dts
@@ -42,9 +42,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -93,19 +104,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_planex_mzk-w300nh2.dts
+++ b/target/linux/ramips/dts/rt3052_planex_mzk-w300nh2.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@3e0000 {
@@ -117,15 +128,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3052_planex_mzk-wdpr.dts
+++ b/target/linux/ramips/dts/rt3052_planex_mzk-wdpr.dts
@@ -35,9 +35,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@7f0000 {
@@ -82,19 +93,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_prolink_pwh2004.dts
+++ b/target/linux/ramips/dts/rt3052_prolink_pwh2004.dts
@@ -38,9 +38,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -89,5 +96,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3052_ralink_v22rw-2x2.dts
+++ b/target/linux/ramips/dts/rt3052_ralink_v22rw-2x2.dts
@@ -38,9 +38,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -95,7 +102,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {

--- a/target/linux/ramips/dts/rt3052_sitecom_wl-351.dts
+++ b/target/linux/ramips/dts/rt3052_sitecom_wl-351.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -122,19 +133,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_skyline_sl-r7205.dts
+++ b/target/linux/ramips/dts/rt3052_skyline_sl-r7205.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -95,19 +106,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_tenda_3g300m.dts
+++ b/target/linux/ramips/dts/rt3052_tenda_3g300m.dts
@@ -94,9 +94,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -125,19 +136,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_tenda_w306r-v2.dts
+++ b/target/linux/ramips/dts/rt3052_tenda_w306r-v2.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -94,15 +105,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-4m.dts
+++ b/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-4m.dts
@@ -28,9 +28,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			partition@50000 {

--- a/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-8m.dts
+++ b/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-8m.dts
@@ -28,9 +28,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			partition@50000 {

--- a/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn.dtsi
+++ b/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn.dtsi
@@ -72,7 +72,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {

--- a/target/linux/ramips/dts/rt3052_unbranded_xdx-rn502j.dts
+++ b/target/linux/ramips/dts/rt3052_unbranded_xdx-rn502j.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -94,19 +105,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_upvel_ur-326n4g.dts
+++ b/target/linux/ramips/dts/rt3052_upvel_ur-326n4g.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4004: macaddr@4004 {
+					reg = <0x4004 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -115,19 +126,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4004: macaddr@4004 {
-		reg = <0x4004 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_upvel_ur-336un.dts
+++ b/target/linux/ramips/dts/rt3052_upvel_ur-336un.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4004: macaddr@4004 {
+					reg = <0x4004 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -115,19 +126,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4004: macaddr@4004 {
-		reg = <0x4004 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_zyxel_keenetic.dts
+++ b/target/linux/ramips/dts/rt3052_zyxel_keenetic.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -114,19 +125,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &otg {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3052_zyxel_nbg-419n.dts
+++ b/target/linux/ramips/dts/rt3052_zyxel_nbg-419n.dts
@@ -38,9 +38,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -100,15 +111,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3352_allnet_all5002.dts
+++ b/target/linux/ramips/dts/rt3352_allnet_all5002.dts
@@ -69,9 +69,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -100,7 +111,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {
@@ -109,14 +121,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3352_dlink_dir-615-h1.dts
+++ b/target/linux/ramips/dts/rt3352_dlink_dir-615-h1.dts
@@ -89,9 +89,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -122,15 +133,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3352_dlink_dir-620-d1.dts
+++ b/target/linux/ramips/dts/rt3352_dlink_dir-620-d1.dts
@@ -66,9 +66,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -99,7 +110,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {
@@ -108,14 +120,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3352_zte_mf283plus.dts
+++ b/target/linux/ramips/dts/rt3352_zte_mf283plus.dts
@@ -85,9 +85,20 @@
 			};
 
 			factory: partition@70000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x70000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@80000 {
@@ -120,7 +131,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {
@@ -129,14 +141,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3352_zyxel_nbg-419n-v2.dts
+++ b/target/linux/ramips/dts/rt3352_zyxel_nbg-419n-v2.dts
@@ -83,9 +83,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -114,7 +125,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {
@@ -123,14 +135,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3662_asus_rt-n56u.dts
+++ b/target/linux/ramips/dts/rt3662_asus_rt-n56u.dts
@@ -37,9 +37,24 @@
 			};
 
 			factory: partition@40000 {
-				reg = <0x00040000 0x00010000>;
+				compatible = "nvmem-cells";
 				label = "factory";
+				reg = <0x00040000 0x00010000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -129,14 +144,16 @@
 	wifi@0,0 {
 		compatible = "pci1814,3091";
 		reg = <0x10000 0 0 0 0>;
-		ralink,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
 &wmac {
 	status = "okay";
 	ralink,2ghz = <0>;
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {
@@ -145,14 +162,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3662_asus_rt-n56u.dts
+++ b/target/linux/ramips/dts/rt3662_asus_rt-n56u.dts
@@ -150,7 +150,6 @@
 };
 
 &wmac {
-	status = "okay";
 	ralink,2ghz = <0>;
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/rt3662_dlink_dir-645.dts
+++ b/target/linux/ramips/dts/rt3662_dlink_dir-645.dts
@@ -94,9 +94,20 @@
 			};
 
 			factory: partition@34000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x34000 0x4000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@38000 {
@@ -137,7 +148,8 @@
 
 &wmac {
 	ralink,5ghz = <0>;
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {
@@ -146,14 +158,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
+++ b/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
@@ -166,7 +166,6 @@
 };
 
 &wmac {
-	status = "okay";
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
+++ b/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
@@ -75,15 +75,33 @@
 			};
 
 			factory: partition@40000 {
-				reg = <0x00040000 0x00010000>;
+				compatible = "nvmem-cells";
 				label = "factory";
+				reg = <0x00040000 0x00010000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 
 			devdata: partition@50000 {
-				reg = <0x00050000 0x00020000>;
+				compatible = "nvmem-cells";
 				label = "devdata";
+				reg = <0x00050000 0x00020000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_devdata_d: macaddr@d {
+					reg = <0xd 0x6>;
+				};
 			};
 
 			partition@70000 {
@@ -149,7 +167,8 @@
 
 &wmac {
 	status = "okay";
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pci {
@@ -163,7 +182,8 @@
 		compatible = "pci0,0";
 		reg = <0x10000 0 0 0 0>;
 		ralink,5ghz = <0>;
-		ralink,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -173,14 +193,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&devdata {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_devdata_d: macaddr@d {
-		reg = <0xd 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3662_engenius_esr600h.dts
+++ b/target/linux/ramips/dts/rt3662_engenius_esr600h.dts
@@ -89,9 +89,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -151,7 +162,8 @@
 		compatible = "pci1814,3091";
 		reg = <0x0 1 0 0 0>;
 		ralink,5ghz = <0>;
-		ralink,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -159,7 +171,8 @@
 	status = "okay";
 
 	ralink,2ghz = <0>;
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {

--- a/target/linux/ramips/dts/rt3662_engenius_esr600h.dts
+++ b/target/linux/ramips/dts/rt3662_engenius_esr600h.dts
@@ -168,8 +168,6 @@
 };
 
 &wmac {
-	status = "okay";
-
 	ralink,2ghz = <0>;
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/rt3662_loewe_wmdr-143n.dts
+++ b/target/linux/ramips/dts/rt3662_loewe_wmdr-143n.dts
@@ -68,7 +68,6 @@
 };
 
 &wmac {
-	status = "okay";
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3662_loewe_wmdr-143n.dts
+++ b/target/linux/ramips/dts/rt3662_loewe_wmdr-143n.dts
@@ -31,9 +31,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -62,5 +69,6 @@
 
 &wmac {
 	status = "okay";
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3662_omnima_hpm.dts
+++ b/target/linux/ramips/dts/rt3662_omnima_hpm.dts
@@ -110,9 +110,20 @@
 			};
 
 			factory: partition@40000 {
-				reg = <0x00040000 0x00010000>;
+				compatible = "nvmem-cells";
 				label = "factory";
+				reg = <0x00040000 0x00010000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -147,7 +158,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {
@@ -156,14 +168,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
+++ b/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
@@ -37,9 +37,20 @@
 			};
 
 			factory: partition@34000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x34000 0x4000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_2000: eeprom@2000 {
+					reg = <0x2000 0x200>;
+				};
 			};
 
 			partition@38000 {
@@ -135,14 +146,16 @@
 	wifi@0,0 {
 		compatible = "pci1814,3091";
 		reg = <0x10000 0 0 0 0>;
-		ralink,mtd-eeprom = <&factory 0x2000>;
+		nvmem-cells = <&eeprom_factory_2000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
 &wmac {
 	status = "okay";
 	ralink,2ghz = <0>;
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {

--- a/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
+++ b/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
@@ -152,7 +152,6 @@
 };
 
 &wmac {
-	status = "okay";
 	ralink,2ghz = <0>;
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/rt3883_belkin_f9k110x.dtsi
+++ b/target/linux/ramips/dts/rt3883_belkin_f9k110x.dtsi
@@ -88,7 +88,6 @@
 };
 
 &wmac {
-	status = "okay";
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt3883_belkin_f9k110x.dtsi
+++ b/target/linux/ramips/dts/rt3883_belkin_f9k110x.dtsi
@@ -42,9 +42,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -78,7 +89,8 @@
 
 &wmac {
 	status = "okay";
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pci {
@@ -92,7 +104,8 @@
 		compatible = "pci1814,3091";
 		reg = <0x10000 0 0 0 0>;
 		ralink,5ghz = <0>;
-		ralink,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/rt3883_sitecom_wlr-6000.dts
+++ b/target/linux/ramips/dts/rt3883_sitecom_wlr-6000.dts
@@ -122,9 +122,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
+				macaddr_factory_8004: macaddr@8004 {
+					reg = <0x8004 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -164,14 +179,16 @@
 	wifi@0,0 {
 		compatible = "pci1814,3091";
 		reg = <0x10000 0 0 0 0>;
-		ralink,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
 &wmac {
 	status = "okay";
 	ralink,2ghz = <0>;
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &ehci {
@@ -180,14 +197,4 @@
 
 &ohci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_8004: macaddr@8004 {
-		reg = <0x8004 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3883_sitecom_wlr-6000.dts
+++ b/target/linux/ramips/dts/rt3883_sitecom_wlr-6000.dts
@@ -185,7 +185,6 @@
 };
 
 &wmac {
-	status = "okay";
 	ralink,2ghz = <0>;
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/rt3883_trendnet_tew-691gr.dts
+++ b/target/linux/ramips/dts/rt3883_trendnet_tew-691gr.dts
@@ -37,9 +37,20 @@
 			};
 
 			factory: partition@40000 {
-				reg = <0x00040000 0x00010000>;
+				compatible = "nvmem-cells";
 				label = "factory";
+				reg = <0x00040000 0x00010000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -115,19 +126,8 @@
 
 &wmac {
 	status = "okay";
-	ralink,mtd-eeprom = <&factory 0x0>;
 	ralink,5ghz = <0>;
-	nvmem-cells = <&macaddr_factory_4>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+	nvmem-cell-names = "eeprom", "mac-address";
 	mac-address-increment = <1>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt3883_trendnet_tew-691gr.dts
+++ b/target/linux/ramips/dts/rt3883_trendnet_tew-691gr.dts
@@ -125,7 +125,6 @@
 };
 
 &wmac {
-	status = "okay";
 	ralink,5ghz = <0>;
 	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
 	nvmem-cell-names = "eeprom", "mac-address";

--- a/target/linux/ramips/dts/rt3883_trendnet_tew-692gr.dts
+++ b/target/linux/ramips/dts/rt3883_trendnet_tew-692gr.dts
@@ -151,7 +151,6 @@
 };
 
 &wmac {
-	status = "okay";
 	ralink,5ghz = <0>;
 	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
 	nvmem-cell-names = "eeprom", "mac-address";

--- a/target/linux/ramips/dts/rt3883_trendnet_tew-692gr.dts
+++ b/target/linux/ramips/dts/rt3883_trendnet_tew-692gr.dts
@@ -37,9 +37,20 @@
 			};
 
 			factory: partition@40000 {
-				reg = <0x00040000 0x00010000>;
+				compatible = "nvmem-cells";
 				label = "factory";
+				reg = <0x00040000 0x00010000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -141,19 +152,8 @@
 
 &wmac {
 	status = "okay";
-	ralink,mtd-eeprom = <&factory 0x0>;
 	ralink,5ghz = <0>;
-	nvmem-cells = <&macaddr_factory_4>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+	nvmem-cell-names = "eeprom", "mac-address";
 	mac-address-increment = <3>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt5350_7links_px-4885.dtsi
+++ b/target/linux/ramips/dts/rt5350_7links_px-4885.dtsi
@@ -67,9 +67,20 @@
 			};
 
 			devconf: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "devconf";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_devconf_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_devconf_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -98,15 +109,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&devconf 0x0>;
-};
-
-&devconf {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_devconf_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_devconf_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_airlive_air3gii.dts
+++ b/target/linux/ramips/dts/rt5350_airlive_air3gii.dts
@@ -61,9 +61,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -92,15 +103,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_allnet_all5003.dts
+++ b/target/linux/ramips/dts/rt5350_allnet_all5003.dts
@@ -69,9 +69,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -100,15 +111,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_asiarf_awm002-evb.dtsi
+++ b/target/linux/ramips/dts/rt5350_asiarf_awm002-evb.dtsi
@@ -69,9 +69,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -89,7 +100,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {
@@ -101,14 +113,4 @@
 
 &esw {
 	mediatek,portmap = <0x3f>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt5350_belkin_f7c027.dts
+++ b/target/linux/ramips/dts/rt5350_belkin_f7c027.dts
@@ -88,9 +88,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -128,7 +135,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &state_default {

--- a/target/linux/ramips/dts/rt5350_dlink_dcs-930l-b1.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dcs-930l-b1.dts
@@ -72,9 +72,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -103,15 +114,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_dlink_dir-300-b7.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dir-300-b7.dts
@@ -115,7 +115,6 @@
 };
 
 &wmac {
-	status = "okay";
 	ralink,led-polarity = <1>;
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/rt5350_dlink_dir-300-b7.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dir-300-b7.dts
@@ -72,9 +72,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -106,15 +117,6 @@
 &wmac {
 	status = "okay";
 	ralink,led-polarity = <1>;
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_dlink_dir-320-b1.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dir-320-b1.dts
@@ -94,9 +94,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -126,15 +137,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_dlink_dir-610-a1.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dir-610-a1.dts
@@ -116,7 +116,6 @@
 };
 
 &wmac {
-	status = "okay";
 	ralink,led-polarity = <1>;
 	nvmem-cells = <&eeprom_devdata_4000>;
 	nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/rt5350_dlink_dir-610-a1.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dir-610-a1.dts
@@ -66,9 +66,20 @@
 			};
 
 			devdata: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "devdata";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_devdata_4000: eeprom@4000 {
+					reg = <0x4000 0x200>;
+				};
+
+				macaddr_devdata_4004: macaddr@4004 {
+					reg = <0x4004 0x6>;
+				};
 			};
 
 			factory: partition@40000 {
@@ -107,15 +118,6 @@
 &wmac {
 	status = "okay";
 	ralink,led-polarity = <1>;
-	ralink,mtd-eeprom = <&devdata 0x4000>;
-};
-
-&devdata {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_devdata_4004: macaddr@4004 {
-		reg = <0x4004 0x6>;
-	};
+	nvmem-cells = <&eeprom_devdata_4000>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_dlink_dwr-512-b.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dwr-512-b.dts
@@ -103,8 +103,19 @@
 			};
 
 			config: partition@7f0000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0x7f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_config_e07e: macaddr@e07e {
+					reg = <0xe07e 0x6>;
+				};
+
+				eeprom_config_e08a: eeprom@e08a {
+					reg = <0xe08a 0x200>;
+				};
 			};
 		};
 	};
@@ -140,18 +151,7 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&config 0xe08a>;
 	ralink,led-polarity = <1>;
-	nvmem-cells = <&macaddr_config_e07e>;
-	nvmem-cell-names = "mac-address";
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_e07e: macaddr@e07e {
-		reg = <0xe07e 0x6>;
-	};
+	nvmem-cells = <&eeprom_config_e08a>, <&macaddr_config_e07e>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };

--- a/target/linux/ramips/dts/rt5350_easyacc_wizard-8800.dts
+++ b/target/linux/ramips/dts/rt5350_easyacc_wizard-8800.dts
@@ -31,9 +31,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -62,15 +73,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_hame_mpr-a1.dts
+++ b/target/linux/ramips/dts/rt5350_hame_mpr-a1.dts
@@ -83,9 +83,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -114,15 +125,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_hame_mpr-a2.dts
+++ b/target/linux/ramips/dts/rt5350_hame_mpr-a2.dts
@@ -83,9 +83,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -115,15 +126,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_hilink_hlk-rm04.dts
+++ b/target/linux/ramips/dts/rt5350_hilink_hlk-rm04.dts
@@ -76,9 +76,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -108,15 +119,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_hootoo_ht-tm02.dts
+++ b/target/linux/ramips/dts/rt5350_hootoo_ht-tm02.dts
@@ -73,9 +73,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -105,15 +116,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_intenso_memory2move.dts
+++ b/target/linux/ramips/dts/rt5350_intenso_memory2move.dts
@@ -76,9 +76,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -107,15 +118,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_nexx_wt1520.dtsi
+++ b/target/linux/ramips/dts/rt5350_nexx_wt1520.dtsi
@@ -44,9 +44,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -71,15 +82,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_nixcore_x1.dtsi
+++ b/target/linux/ramips/dts/rt5350_nixcore_x1.dtsi
@@ -134,9 +134,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -178,15 +189,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_olimex_rt5350f-olinuxino.dtsi
+++ b/target/linux/ramips/dts/rt5350_olimex_rt5350f-olinuxino.dtsi
@@ -34,9 +34,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -70,8 +81,9 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
 	ralink,led-polarity = <1>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &i2c {
@@ -80,14 +92,4 @@
 
 &uart {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/rt5350_omnima_miniembplug.dts
+++ b/target/linux/ramips/dts/rt5350_omnima_miniembplug.dts
@@ -86,9 +86,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -110,15 +121,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_planex_mzk-dp150n.dts
+++ b/target/linux/ramips/dts/rt5350_planex_mzk-dp150n.dts
@@ -61,9 +61,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -100,16 +111,7 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
 	ralink,led-polarity = <1>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_poray_m3.dts
+++ b/target/linux/ramips/dts/rt5350_poray_m3.dts
@@ -68,9 +68,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -100,16 +111,7 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
 	ralink,led-polarity = <1>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_poray_m4.dtsi
+++ b/target/linux/ramips/dts/rt5350_poray_m4.dtsi
@@ -60,9 +60,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -92,16 +103,7 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
 	ralink,led-polarity = <1>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_poray_x5.dts
+++ b/target/linux/ramips/dts/rt5350_poray_x5.dts
@@ -100,9 +100,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -132,16 +143,7 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
 	ralink,led-polarity = <1>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_poray_x8.dts
+++ b/target/linux/ramips/dts/rt5350_poray_x8.dts
@@ -61,9 +61,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -93,16 +104,7 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
 	ralink,led-polarity = <1>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_tenda_3g150b.dts
+++ b/target/linux/ramips/dts/rt5350_tenda_3g150b.dts
@@ -79,9 +79,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -110,16 +121,7 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
 	ralink,led-polarity = <1>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_trendnet_tew-714tru.dts
+++ b/target/linux/ramips/dts/rt5350_trendnet_tew-714tru.dts
@@ -82,9 +82,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -114,15 +125,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_unbranded_a5-v11.dts
+++ b/target/linux/ramips/dts/rt5350_unbranded_a5-v11.dts
@@ -84,9 +84,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -116,15 +127,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_vocore_vocore.dtsi
+++ b/target/linux/ramips/dts/rt5350_vocore_vocore.dtsi
@@ -182,9 +182,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -222,7 +233,8 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &spi1 {
@@ -232,15 +244,5 @@
 		compatible = "linux,spidev";
 		spi-max-frequency = <10000000>;
 		reg = <0>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/rt5350_wansview_ncs601w.dts
+++ b/target/linux/ramips/dts/rt5350_wansview_ncs601w.dts
@@ -31,9 +31,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -62,15 +73,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_wiznet_wizfi630a.dts
+++ b/target/linux/ramips/dts/rt5350_wiznet_wizfi630a.dts
@@ -100,10 +100,20 @@
 			};
 
 			factory: partition@40000 {
-				#size-cells = <1>;
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -139,15 +149,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_zorlik_zl5900v2.dts
+++ b/target/linux/ramips/dts/rt5350_zorlik_zl5900v2.dts
@@ -66,9 +66,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -97,15 +108,6 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_zyxel_keenetic-4g-b.dts
+++ b/target/linux/ramips/dts/rt5350_zyxel_keenetic-4g-b.dts
@@ -89,9 +89,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -122,15 +133,6 @@
 
 &wmac {
 	ralink,led-polarity = <1>;
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_zyxel_keenetic-lite-b.dts
+++ b/target/linux/ramips/dts/rt5350_zyxel_keenetic-lite-b.dts
@@ -73,9 +73,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -106,15 +117,6 @@
 
 &wmac {
 	ralink,led-polarity = <1>;
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/rt5350_zyxel_keenetic-start.dts
+++ b/target/linux/ramips/dts/rt5350_zyxel_keenetic-start.dts
@@ -118,7 +118,6 @@
 };
 
 &wmac {
-	status = "okay";
 	ralink,led-polarity = <1>;
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/rt5350_zyxel_keenetic-start.dts
+++ b/target/linux/ramips/dts/rt5350_zyxel_keenetic-start.dts
@@ -75,9 +75,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -109,15 +120,6 @@
 &wmac {
 	status = "okay";
 	ralink,led-polarity = <1>;
-	ralink,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2128,7 +2128,7 @@ define Device/telco-electronics_x1
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Telco Electronics
   DEVICE_MODEL := X1
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt76 -uboot-envtools
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7603 kmod-mt76x2 -uboot-envtools
 endef
 TARGET_DEVICES += telco-electronics_x1
 


### PR DESCRIPTION
Notice:
1. All NIC models are judged based on the commit message or the makefile default packages.
2. All Ralink RTxxxx SoCs use the same rt2800 wireless driver, the EEPROM size is the same 0x200.
3. MT7620 build-in WiFi is driven by rt2800 so the EEPROM size is the same 0x200.
4. MT7628 build-in WiFi is driven by kmod-mt7603 so the EEPROM size is the same 0x400.
5. Only three devices use MT7613 PCIe NIC, see commit message.
6. The remaining MT76 PCIe NIC are all MT7610 or MT7612, EEPROM size is 0x200.
7. MT76 devices use property `mediatek,mtd-eeprom` and Ralink devices use `ralink,mtd-eeprom`.

|Package Name|NIC Model|EEPROM size||
|-|-|-|-|
|kmod-mt76x0e|MT7610|0x200|same as MT7612|
|kmod-mt76x2|MT7602/MT7612|0x200||
|kmod-mt7663-firmware-ap|MT7613|0x4da8||