### PR TITLE
ramips: convert MT7621 wireless calibration EEPROM to NVMEM format 

### DIFF
--- a/target/linux/ramips/dts/mt7621_adslr_g7.dts
+++ b/target/linux/ramips/dts/mt7621_adslr_g7.dts
@@ -64,9 +64,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				macaddr_factory_e00c: macaddr@e00c {
+					reg = <0xe00c 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -86,7 +101,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -95,7 +111,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -149,15 +166,5 @@
 	gpio {
 		groups = "i2c", "uart3", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e00c: macaddr@e00c {
-		reg = <0xe00c 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_afoundry_ew1200.dts
+++ b/target/linux/ramips/dts/mt7621_afoundry_ew1200.dts
@@ -82,6 +82,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -104,7 +108,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_afoundry_ew1200.dts
+++ b/target/linux/ramips/dts/mt7621_afoundry_ew1200.dts
@@ -71,9 +71,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -107,7 +118,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {
@@ -166,15 +178,5 @@
 	gpio {
 		groups = "i2c", "uart3", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_ampedwireless_ally.dtsi
+++ b/target/linux/ramips/dts/mt7621_ampedwireless_ally.dtsi
@@ -64,7 +64,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7615";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -73,7 +74,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7615";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -105,9 +107,20 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x40000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>;
+			};
+
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x4da8>;
+			};
 		};
 
 		/*

--- a/target/linux/ramips/dts/mt7621_arcadyan_we420223-99.dts
+++ b/target/linux/ramips/dts/mt7621_arcadyan_we420223-99.dts
@@ -130,9 +130,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "Factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
 			};
 
 			partition@50000 {
@@ -214,6 +221,7 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };

--- a/target/linux/ramips/dts/mt7621_arcadyan_wg4xx223.dtsi
+++ b/target/linux/ramips/dts/mt7621_arcadyan_wg4xx223.dtsi
@@ -79,13 +79,16 @@
 		};
 
 		factory: partition@200000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x200000 0x100000>;
-			read-only;
-
-			compatible = "nvmem-cells";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>;
+			};
 
 			/* We keep the block below to prevent eth0 MAC
 			 * from randomization. Unique WAN, LAN, WLAN MACs
@@ -162,7 +165,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_asus_rp-ac56.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rp-ac56.dts
@@ -147,6 +147,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -201,7 +205,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_asus_rp-ac56.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rp-ac56.dts
@@ -136,13 +136,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
-				read-only;
-
-				compatible = "nvmem-cells";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
@@ -188,7 +191,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_asus_rp-ac87.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rp-ac87.dts
@@ -110,13 +110,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
-				read-only;
-
-				compatible = "nvmem-cells";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 
 				macaddr_factory_8004: macaddr@8004 {
 					reg = <0x8004 0x6>;
@@ -140,7 +147,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -149,7 +157,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_asus_rt-ac57u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ac57u-v1.dts
@@ -86,9 +86,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -121,7 +136,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 
 		led {
 			led-active-low;
@@ -177,19 +193,5 @@
 	gpio {
 		groups = "sdhci";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_asus_rt-ac57u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ac57u-v1.dts
@@ -97,6 +97,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -123,7 +127,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 
 		led {
 			led-sources = <2>;

--- a/target/linux/ramips/dts/mt7621_asus_rt-acx5p.dtsi
+++ b/target/linux/ramips/dts/mt7621_asus_rt-acx5p.dtsi
@@ -80,9 +80,24 @@
 		};
 
 		factory: partition@1e0000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x1e0000 0x100000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>;
+			};
+
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x4da8>;
+			};
+
+			macaddr_factory_e000: macaddr@e000 {
+				reg = <0xe000 0x6>;
+			};
 		};
 
 		factory2: partition@2e0000 {
@@ -116,7 +131,8 @@
 	wifi0: wifi@0,0 {
 		compatible = "pci14c3,7615";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -125,7 +141,8 @@
 	wifi1: wifi@0,0 {
 		compatible = "pci14c3,7615";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -178,15 +195,5 @@
 	gpio {
 		groups = "uart2", "uart3", "i2c";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -95,13 +95,16 @@
 		};
 
 		factory: partition@1e0000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x1e0000 0x100000>;
-			read-only;
-
-			compatible = "nvmem-cells";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0xe00>;
+			};
 
 			macaddr_factory_4: macaddr@4 {
 				reg = <0x4 0x6>;
@@ -155,7 +158,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_asus_rt-ax54.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax54.dts
@@ -87,13 +87,16 @@
 		};
 
 		factory: partition@1e0000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x1e0000 0x100000>;
-			read-only;
-
-			compatible = "nvmem-cells";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0xe00>;
+			};
 
 			macaddr_factory_4: macaddr@4 {
 				reg = <0x4 0x6>;
@@ -128,7 +131,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_asus_rt-n56u-b1.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-n56u-b1.dts
@@ -116,6 +116,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -142,7 +146,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_asus_rt-n56u-b1.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-n56u-b1.dts
@@ -105,9 +105,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_8004: macaddr@8004 {
+					reg = <0x8004 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -135,7 +150,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -187,19 +203,5 @@
 	gpio {
 		groups = "uart3", "uart2", "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
-
-	macaddr_factory_8004: macaddr@8004 {
-		reg = <0x8004 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-giga.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-giga.dts
@@ -94,14 +94,17 @@
 		};
 
 		factory: partition@200000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x200000 0x100000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			sercomm,scpart-id = <2>;
 			read-only;
 
-			compatible = "nvmem-cells";
-			#address-cells = <1>;
-			#size-cells = <1>;
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x400>;
+			};
 
 			macaddr_factory_21000: macaddr@21000 {
 				reg = <0x21000 0x6>;
@@ -188,11 +191,10 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;
 
-		nvmem-cells = <&macaddr_factory_21000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_21000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(4)>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-giga.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-giga.dts
@@ -106,6 +106,10 @@
 				reg = <0x0 0x400>;
 			};
 
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x4da8>;
+			};
+
 			macaddr_factory_21000: macaddr@21000 {
 				reg = <0x21000 0x6>;
 			};
@@ -178,11 +182,10 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
 
-		nvmem-cells = <&macaddr_factory_21000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_21000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(5)>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo-plus.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo-plus.dts
@@ -112,6 +112,10 @@
 				reg = <0x0 0x400>;
 			};
 
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x4da8>;
+			};
+
 			macaddr_factory_21000: macaddr@21000 {
 				reg = <0x21000 0x6>;
 			};
@@ -171,11 +175,10 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
 
-		nvmem-cells = <&macaddr_factory_21000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_21000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(5)>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo-plus.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo-plus.dts
@@ -100,14 +100,17 @@
 		};
 
 		factory: partition@200000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x200000 0x100000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			sercomm,scpart-id = <2>;
 			read-only;
 
-			compatible = "nvmem-cells";
-			#address-cells = <1>;
-			#size-cells = <1>;
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x400>;
+			};
 
 			macaddr_factory_21000: macaddr@21000 {
 				reg = <0x21000 0x6>;
@@ -181,11 +184,10 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;
 
-		nvmem-cells = <&macaddr_factory_21000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_21000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(4)>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_belkin_rt1800.dts
+++ b/target/linux/ramips/dts/mt7621_belkin_rt1800.dts
@@ -86,9 +86,16 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x100000 0x80000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0xe00>;
+			};
 		};
 
 		partition@180000 {
@@ -133,7 +140,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_bolt_arion.dts
+++ b/target/linux/ramips/dts/mt7621_bolt_arion.dts
@@ -137,7 +137,7 @@
 };
 
 &gmac0 {
-	nvmem-cells = <&macaddr_factory_4000>;
+	nvmem-cells = <&macaddr_factory_28>;
 	nvmem-cell-names = "mac-address";
 	mac-address-increment = <3>;
 };
@@ -152,7 +152,7 @@
 		wan: port@1 {
 			status = "okay";
 			label = "wan";
-			nvmem-cells = <&macaddr_factory_4000>;
+			nvmem-cells = <&macaddr_factory_28>;
 			nvmem-cell-names = "mac-address";
 		};
 
@@ -179,7 +179,7 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	macaddr_factory_4000: macaddr@4000 {
+	macaddr_factory_28: macaddr@28 {
 		reg = <0x28 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_bolt_arion.dts
+++ b/target/linux/ramips/dts/mt7621_bolt_arion.dts
@@ -100,9 +100,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -122,7 +133,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7603";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -171,15 +183,5 @@
 	gpio {
 		groups = "jtag", "uart2", "uart3", "wdt", "rgmii2";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_bolt_arion.dts
+++ b/target/linux/ramips/dts/mt7621_bolt_arion.dts
@@ -111,6 +111,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_28: macaddr@28 {
 					reg = <0x28 0x6>;
 				};
@@ -143,7 +147,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-1166dhp.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-1166dhp.dts
@@ -143,6 +143,10 @@
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -209,7 +213,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-1166dhp.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-1166dhp.dts
@@ -133,9 +133,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 
 			partition@50000 {
@@ -210,7 +217,8 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-2533dhpl.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-2533dhpl.dts
@@ -131,9 +131,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -217,7 +232,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -226,7 +242,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -240,14 +257,4 @@
 
 &xhci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-600dhp.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-600dhp.dts
@@ -133,9 +133,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -168,7 +179,8 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -218,14 +230,4 @@
 
 &xhci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_comfast_cf-e390ax.dts
+++ b/target/linux/ramips/dts/mt7621_comfast_cf-e390ax.dts
@@ -59,7 +59,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -87,9 +88,20 @@
 			};
 
 			factory: partition@50000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x50000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
 			};
 
 			partition@90000 {
@@ -98,16 +110,6 @@
 				reg = <0x90000 0xf70000>;
 			};
 		};
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_comfast_cf-ew72-v2.dts
+++ b/target/linux/ramips/dts/mt7621_comfast_cf-ew72-v2.dts
@@ -120,6 +120,10 @@
 						reg = <0x0 0x400>;
 					};
 
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+
 					macaddr_factory_e000: macaddr@e000 {
 						compatible = "mac-base";
 						reg = <0xe000 0x6>;
@@ -169,7 +173,8 @@
 	wifi_5_0_ghz: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		// Wi-Fi device reads it's MAC address from EEPROM, (&factory + 0x8000 + 4)
 		// adding anything related to mac-address here will cause use random MAC.
 	};

--- a/target/linux/ramips/dts/mt7621_comfast_cf-ew72-v2.dts
+++ b/target/linux/ramips/dts/mt7621_comfast_cf-ew72-v2.dts
@@ -110,10 +110,16 @@
 				compatible = "nvmem-cells";
 				reg = <0x40000 0x10000>;
 				read-only;
+
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
 					macaddr_factory_e000: macaddr@e000 {
 						compatible = "mac-base";
 						reg = <0xe000 0x6>;
@@ -152,7 +158,8 @@
 	wifi_2_4_ghz: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		// Wi-Fi device reads it's MAC address from EEPROM (&factory + 4)
 		// adding anything related to mac-address here will cause use random MAC
 	};

--- a/target/linux/ramips/dts/mt7621_cudy_m1800.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_m1800.dts
@@ -81,7 +81,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };
@@ -114,9 +115,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
 			};
 
 			partition@50000 {

--- a/target/linux/ramips/dts/mt7621_cudy_wr1300-v1.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr1300-v1.dts
@@ -95,6 +95,10 @@
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -153,9 +157,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
-		nvmem-cells = <&macaddr_bdinfo_de00>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_bdinfo_de00>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <2>;
 		ieee80211-freq-limit = <5000000 6000000>;
 

--- a/target/linux/ramips/dts/mt7621_cudy_wr1300-v1.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr1300-v1.dts
@@ -85,9 +85,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 
 			partition@50000 {
@@ -109,9 +116,16 @@
 			};
 
 			bdinfo: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "bdinfo";
 				reg = <0xff0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_bdinfo_de00: macaddr@de00 {
+					reg = <0xde00 0x6>;
+				};
 			};
 		};
 	};
@@ -125,9 +139,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7603";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
-		nvmem-cells = <&macaddr_bdinfo_de00>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {
@@ -202,15 +215,5 @@
 	gpio {
 		groups = "wdt", "i2c", "jtag";
 		function = "gpio";
-	};
-};
-
-&bdinfo {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_bdinfo_de00: macaddr@de00 {
-		reg = <0xde00 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_cudy_wr1300-v2.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr1300-v2.dts
@@ -78,9 +78,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 
 			partition@50000 {
@@ -102,9 +109,16 @@
 			};
 
 			bdinfo: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "bdinfo";
 				reg = <0xff0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_bdinfo_de00: macaddr@de00 {
+					reg = <0xde00 0x6>;
+				};
 			};
 		};
 	};
@@ -118,9 +132,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
-		nvmem-cells = <&macaddr_bdinfo_de00>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 
@@ -184,15 +197,5 @@
 	gpio {
 		groups = "wdt", "i2c", "jtag";
 		function = "gpio";
-	};
-};
-
-&bdinfo {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_bdinfo_de00: macaddr@de00 {
-		reg = <0xde00 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_cudy_wr1300-v2.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr1300-v2.dts
@@ -88,6 +88,10 @@
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -141,9 +145,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
-		nvmem-cells = <&macaddr_bdinfo_de00>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_bdinfo_de00>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <2>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_cudy_wr2100.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr2100.dts
@@ -100,7 +100,8 @@
 	wifi@1,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -140,6 +141,10 @@
 
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
 				};
 			};
 

--- a/target/linux/ramips/dts/mt7621_cudy_wr2100.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr2100.dts
@@ -90,7 +90,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -130,9 +131,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 
 			partition@50000 {
@@ -154,9 +162,16 @@
 			};
 
 			bdinfo: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "bdinfo";
 				reg = <0xff0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_bdinfo_de00: macaddr@de00 {
+					reg = <0xde00 0x6>;
+				};
 			};
 		};
 	};
@@ -206,15 +221,5 @@
 			status = "okay";
 			label = "lan4";
 		};
-	};
-};
-
-&bdinfo {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_bdinfo_de00: macaddr@de00 {
-		reg = <0xde00 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_cudy_x6.dtsi
+++ b/target/linux/ramips/dts/mt7621_cudy_x6.dtsi
@@ -76,9 +76,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
 			};
 
 			/* additional partitions in DTS */
@@ -94,7 +101,8 @@
 	wifi:wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
@@ -115,9 +115,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -144,7 +159,8 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -188,19 +204,5 @@
 	gpio {
 		groups = "i2c", "jtag", "uart2", "uart3";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
@@ -126,6 +126,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -151,7 +155,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
@@ -129,9 +129,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -170,7 +185,8 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -218,19 +234,5 @@
 	gpio {
 		groups = "wdt", "rgmii2", "jtag";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
@@ -140,6 +140,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -177,7 +181,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dap-x1860-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dap-x1860-a1.dts
@@ -125,13 +125,16 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x80000>;
-			read-only;
-
-			compatible = "nvmem-cells";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0xe00>;
+			};
 
 			macaddr_factory_4: macaddr@4 {
 				reg = <0x4 0x6>;
@@ -175,7 +178,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-1935-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-1935-a1.dts
@@ -21,17 +21,3 @@
 	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
 };
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
-	};
-};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-3060-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-3060-a1.dts
@@ -111,9 +111,28 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x40000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>;
+			};
+
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x4da8>;
+			};
+
+			macaddr_factory_e000: macaddr@e000 {
+				reg = <0xe000 0x6>;
+			};
+
+			macaddr_factory_e006: macaddr@e006 {
+				reg = <0xe006 0x6>;
+			};
 		};
 
 		partition@140000 {
@@ -163,10 +182,9 @@
 	wifi0: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 6000000>;
-		nvmem-cells = <&macaddr_factory_e000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_e000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <1>;
 	};
 };
@@ -175,10 +193,9 @@
 	wifi1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_factory_e000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_e000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <3>;
 	};
 };
@@ -223,19 +240,5 @@
 	gpio {
 		groups = "i2c", "uart3", "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-853-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-853-a1.dts
@@ -108,9 +108,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -144,7 +159,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 
 		/* The correct Mac addresses are set in 10_fix_wifi_mac. */
 	};
@@ -198,19 +214,5 @@
 	gpio {
 		groups = "i2c", "uart2", "uart3", "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-853-a3.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-853-a3.dts
@@ -105,9 +105,28 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x40000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>;
+			};
+
+			macaddr_factory_4: macaddr@4 {
+				reg = <0x4 0x6>;
+			};
+
+			macaddr_factory_e000: macaddr@e000 {
+				reg = <0xe000 0x6>;
+			};
+
+			macaddr_factory_e006: macaddr@e006 {
+				reg = <0xe006 0x6>;
+			};
 		};
 
 		partition@140000 {
@@ -156,11 +175,10 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
 		/* 5 GHz (phy1) does not take the address from calibration data,
 		   but setting it manually here works */
-		nvmem-cells = <&macaddr_factory_4>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 
@@ -212,23 +230,5 @@
 	gpio {
 		groups = "i2c", "uart2", "uart3", "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-853-r1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-853-r1.dts
@@ -95,12 +95,10 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 
-		mediatek,mtd-eeprom = <&factory 0x0>;
-
 		/* 5 GHz (phy1) does not take the address from calibration data,
 		   but setting it manually here works */
-		nvmem-cells = <&macaddr_factory_4>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 
@@ -154,15 +152,5 @@
 	gpio {
 		groups = "i2c", "uart3", "uart2", "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-860l-b1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-860l-b1.dts
@@ -83,9 +83,24 @@
 			};
 
 			radio: partition@34000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0x34000 0x4000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_radio_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_radio_2000: eeprom@2000 {
+					reg = <0x2000 0x200>;
+				};
 			};
 
 			factory: partition@38000 {
@@ -163,7 +178,8 @@
 &pcie0 {
 	wifi0: mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x2000>;
+		nvmem-cells = <&eeprom_radio_2000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -171,7 +187,8 @@
 &pcie1 {
 	wifi1: mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
+		nvmem-cells = <&eeprom_radio_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -180,15 +197,5 @@
 	gpio {
 		groups = "uart3", "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&radio {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_radio_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-867-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-867-a1.dts
@@ -21,17 +21,3 @@
 	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
 };
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
-	};
-};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-878-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-878-a1.dts
@@ -21,17 +21,3 @@
 	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
 };
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
-	};
-};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-878-r1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-878-r1.dts
@@ -21,17 +21,3 @@
 	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
 };
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
-	};
-};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-882-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-882-a1.dts
@@ -37,17 +37,3 @@
 	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
 };
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
-	};
-};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-882-r1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-882-r1.dts
@@ -37,17 +37,3 @@
 	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
 };
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
-	};
-};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-8xx.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-8xx.dtsi
@@ -68,7 +68,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {
@@ -81,7 +82,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_dlink_dir-xx60-a1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-xx60-a1.dtsi
@@ -76,9 +76,28 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x40000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>;
+			};
+
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x4da8>;
+			};
+
+			macaddr_factory_e000: macaddr@e000 {
+				reg = <0xe000 0x6>;
+			};
+
+			macaddr_factory_e006: macaddr@e006 {
+				reg = <0xe006 0x6>;
+			};
 		};
 
 		partition@140000 {
@@ -127,7 +146,8 @@
 	wifi0: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {
@@ -140,7 +160,8 @@
 	wifi1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {
@@ -197,19 +218,5 @@
 	gpio {
 		groups = "i2c", "uart3", "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dxx-1xx0-x1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dxx-1xx0-x1.dtsi
@@ -93,13 +93,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
-				read-only;
-
-				compatible = "nvmem-cells";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
 
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
@@ -123,7 +126,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		/* The correct MAC addresses are set in 10_fix_wifi_mac. */
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_flash-16m-a1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_flash-16m-a1.dtsi
@@ -26,9 +26,28 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x20000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@60000 {

--- a/target/linux/ramips/dts/mt7621_dlink_flash-16m-r1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_flash-16m-r1.dtsi
@@ -26,9 +26,32 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {

--- a/target/linux/ramips/dts/mt7621_edimax_re23s.dts
+++ b/target/linux/ramips/dts/mt7621_edimax_re23s.dts
@@ -86,9 +86,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				macaddr_factory_8004: macaddr@8004 {
+					reg = <0x8004 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -122,7 +137,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -131,7 +147,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -159,14 +176,4 @@
 
 &xhci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_8004: macaddr@8004 {
-		reg = <0x8004 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_edimax_rx21s.dtsi
+++ b/target/linux/ramips/dts/mt7621_edimax_rx21s.dtsi
@@ -81,9 +81,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -103,7 +118,8 @@
 	wifi0: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -112,7 +128,8 @@
 	wifi1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -170,14 +187,4 @@
 
 &xhci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1167ghbk2-s.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1167ghbk2-s.dts
@@ -136,9 +136,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -177,27 +192,12 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
-		nvmem-cells = <&macaddr_factory_e000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_e000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <1>;
 	};
 };
 
 &xhci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533ghbk.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533ghbk.dtsi
@@ -100,9 +100,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 			};
 		};
 	};
@@ -159,7 +170,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -168,7 +180,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-gs-1pci.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-gs-1pci.dtsi
@@ -25,6 +25,7 @@
 	wifi: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-gs-2pci.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-gs-2pci.dtsi
@@ -13,7 +13,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {
@@ -27,7 +28,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-gs.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-gs.dtsi
@@ -145,9 +145,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 			};
 		};
 	};

--- a/target/linux/ramips/dts/mt7621_etisalat_s3.dts
+++ b/target/linux/ramips/dts/mt7621_etisalat_s3.dts
@@ -112,6 +112,10 @@
 				reg = <0x0 0x400>;
 			};
 
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x4da8>;
+			};
+
 			macaddr_factory_21000: macaddr@21000 {
 				reg = <0x21000 0x6>;
 			};
@@ -171,11 +175,10 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
 
-		nvmem-cells = <&macaddr_factory_21000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_21000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(3)>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_etisalat_s3.dts
+++ b/target/linux/ramips/dts/mt7621_etisalat_s3.dts
@@ -100,14 +100,17 @@
 		};
 
 		factory: partition@200000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x200000 0x100000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			sercomm,scpart-id = <2>;
 			read-only;
 
-			compatible = "nvmem-cells";
-			#address-cells = <1>;
-			#size-cells = <1>;
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x400>;
+			};
 
 			macaddr_factory_21000: macaddr@21000 {
 				reg = <0x21000 0x6>;
@@ -181,11 +184,10 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;
 
-		nvmem-cells = <&macaddr_factory_21000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_21000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(2)>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_firefly_firewrt.dts
+++ b/target/linux/ramips/dts/mt7621_firefly_firewrt.dts
@@ -70,9 +70,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -91,7 +106,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -99,7 +115,8 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -149,15 +166,5 @@
 	gpio {
 		groups = "wdt", "rgmii2";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_gehua_ghl-r-001.dts
+++ b/target/linux/ramips/dts/mt7621_gehua_ghl-r-001.dts
@@ -79,6 +79,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -108,7 +112,8 @@
 &pcie1 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_gehua_ghl-r-001.dts
+++ b/target/linux/ramips/dts/mt7621_gehua_ghl-r-001.dts
@@ -68,9 +68,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -89,7 +100,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -150,15 +162,5 @@
 	gpio {
 		groups = "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_glinet_gl-mt1300.dts
+++ b/target/linux/ramips/dts/mt7621_glinet_gl-mt1300.dts
@@ -88,9 +88,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				macaddr_factory_4000: macaddr@4000 {
+					reg = <0x4000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -110,7 +121,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -157,15 +169,5 @@
 	gpio {
 		group = "wdt", "jtag";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4000: macaddr@4000 {
-		reg = <0x4000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_h3c_tx180x.dtsi
+++ b/target/linux/ramips/dts/mt7621_h3c_tx180x.dtsi
@@ -97,9 +97,16 @@
 		};
 
 		factory: partition@180000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x0180000 0x0080000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0xe00>;
+			};
 		};
 
 		partition@200000 {
@@ -133,7 +140,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_haier-sim_wr1800k.dtsi
+++ b/target/linux/ramips/dts/mt7621_haier-sim_wr1800k.dtsi
@@ -103,13 +103,16 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x0100000 0x0080000>;
-			read-only;
-
-			compatible = "nvmem-cells";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0xe00>;
+			};
 
 			macaddr_factory_8004: macaddr@8004 {
 				reg = <0x8004 0x6>;
@@ -147,7 +150,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_hanyang_hyc-g920.dts
+++ b/target/linux/ramips/dts/mt7621_hanyang_hyc-g920.dts
@@ -75,9 +75,28 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_8004: macaddr@8004 {
+					reg = <0x8004 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -115,7 +134,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {
@@ -129,7 +149,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {
@@ -180,19 +201,5 @@
 	gpio {
 		groups = "sdhci";
 		function = "gpio";
-	};
-};
-	
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
-
-	macaddr_factory_8004: macaddr@8004 {
-		reg = <0x8004 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_hilink_hlk-7621a-evb.dts
+++ b/target/linux/ramips/dts/mt7621_hilink_hlk-7621a-evb.dts
@@ -47,9 +47,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 
 			partition@50000 {
@@ -105,7 +112,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_hiwifi_hc5962.dts
+++ b/target/linux/ramips/dts/mt7621_hiwifi_hc5962.dts
@@ -91,6 +91,10 @@
 			eeprom_factory_0: eeprom@0 {
 				reg = <0x0 0x400>;
 			};
+
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x200>;
+			};
 		};
 
 		partition@140000 {
@@ -132,7 +136,8 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_hiwifi_hc5962.dts
+++ b/target/linux/ramips/dts/mt7621_hiwifi_hc5962.dts
@@ -81,9 +81,16 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x40000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x400>;
+			};
 		};
 
 		partition@140000 {
@@ -116,7 +123,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_huasifei_ws1208v2.dts
+++ b/target/linux/ramips/dts/mt7621_huasifei_ws1208v2.dts
@@ -93,13 +93,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
-				read-only;
-
-				compatible = "nvmem-cells";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
@@ -123,7 +126,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7603";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_huasifei_ws1208v2.dts
+++ b/target/linux/ramips/dts/mt7621_huasifei_ws1208v2.dts
@@ -104,6 +104,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -135,7 +139,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_humax_e10.dts
+++ b/target/linux/ramips/dts/mt7621_humax_e10.dts
@@ -89,9 +89,28 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x30000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				macaddr_factory_10007: macaddr@10007 {
+					reg = <0x10007 0x6>;
+				};
+
+				macaddr_factory_1000d: macaddr@1000d {
+					reg = <0x1000d 0x6>;
+				};
 			};
 
 			partition@70000 {
@@ -113,7 +132,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -122,7 +142,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -160,19 +181,5 @@
 	gpio {
 		groups = "jtag", "uart2", "uart3", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_10007: macaddr@10007 {
-		reg = <0x10007 0x6>;
-	};
-
-	macaddr_factory_1000d: macaddr@1000d {
-		reg = <0x1000d 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr.dts
@@ -96,6 +96,10 @@
 				#size-cells = <1>;
 				read-only;
 
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -212,7 +216,8 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr.dts
@@ -89,15 +89,33 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			iNIC_rf: partition@50000 {
+				compatible = "nvmem-cells";
 				label = "iNIC_rf";
 				reg = <0x50000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_iNIC_rf_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_iNIC_rf_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@60000 {
@@ -186,7 +204,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&iNIC_rf 0x0>;
+		nvmem-cells = <&eeprom_iNIC_rf_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -200,24 +219,4 @@
 
 &xhci {
 	status = "disabled";
-};
-
-&iNIC_rf {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_iNIC_rf_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_iodata_wn-deax1800gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-deax1800gr.dts
@@ -130,7 +130,7 @@
 				#size-cells = <1>;
 
 				eeprom: eeprom@0 {
-					reg = <0x0 0x1aa20>;
+					reg = <0x0 0xe00>;
 				};
 
 				macaddr_factory_4: macaddr@4 {

--- a/target/linux/ramips/dts/mt7621_iodata_wn-dx1200gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-dx1200gr.dts
@@ -81,8 +81,23 @@
 		};
 
 		factory: partition@200000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x200000 0x200000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x400>;
+			};
+
+			macaddr_factory_1e000: macaddr@1e000 {
+				reg = <0x1e000 0x6>;
+			};
+
+			macaddr_factory_1e006: macaddr@1e006 {
+				reg = <0x1e006 0x6>;
+			};
 		};
 
 		partition@400000 {
@@ -183,9 +198,10 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-
-		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;
+
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -208,18 +224,4 @@
 
 &xhci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_1e000: macaddr@1e000 {
-		reg = <0x1e000 0x6>;
-	};
-
-	macaddr_factory_1e006: macaddr@1e006 {
-		reg = <0x1e006 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_iodata_wn-dx1200gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-dx1200gr.dts
@@ -91,6 +91,10 @@
 				reg = <0x0 0x400>;
 			};
 
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x4da8>;
+			};
+
 			macaddr_factory_1e000: macaddr@1e000 {
 				reg = <0x1e000 0x6>;
 			};
@@ -209,9 +213,10 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
+
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_iodata_wn-gx300gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-gx300gr.dts
@@ -89,9 +89,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -186,20 +197,11 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
 &xhci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_iodata_wnpr2600g.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wnpr2600g.dts
@@ -93,9 +93,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x040000 0x010000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -178,7 +193,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -187,21 +203,12 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
 
 &xhci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_iptime_a3002mesh.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a3002mesh.dts
@@ -89,9 +89,16 @@
 			};
 
 			factory: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
 			};
 
 			partition@40000 {
@@ -146,7 +153,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_iptime_a3004ns-dual.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a3004ns-dual.dts
@@ -63,9 +63,20 @@
 			#size-cells = <1>;
 
 			uboot: partition@0 {
+				compatible = "nvmem-cells";
 				label = "u-boot";
 				reg = <0x0 0x20000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_uboot_1fc20: macaddr@1fc20 {
+					reg = <0x1fc20 0x6>;
+				};
+
+				macaddr_uboot_1fc40: macaddr@1fc40 {
+					reg = <0x1fc40 0x6>;
+				};
 			};
 
 			partition@20000 {
@@ -75,9 +86,20 @@
 			};
 
 			factory: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 
 			partition@40000 {
@@ -141,7 +163,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {
@@ -155,7 +178,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {
@@ -169,19 +193,5 @@
 	gpio {
 		groups = "wdt", "i2c", "uart3";
 		function = "gpio";
-	};
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc20: macaddr@1fc20 {
-		reg = <0x1fc20 0x6>;
-	};
-
-	macaddr_uboot_1fc40: macaddr@1fc40 {
-		reg = <0x1fc40 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_iptime_a3004t.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a3004t.dts
@@ -76,13 +76,16 @@
 		};
 
 		factory: partition@a0000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0xa0000 0x20000>;
-			read-only;
-
-			compatible = "nvmem-cells";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>;
+			};
 
 			macaddr_factory_4: macaddr@4 {
 				reg = <0x4 0x6>;
@@ -168,7 +171,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_iptime_a6004ns-m.dtsi
+++ b/target/linux/ramips/dts/mt7621_iptime_a6004ns-m.dtsi
@@ -74,9 +74,20 @@
 			#size-cells = <1>;
 
 			uboot: partition@0 {
+				compatible = "nvmem-cells";
 				label = "u-boot";
 				reg = <0x0 0x20000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_uboot_1fc20: macaddr@1fc20 {
+					reg = <0x1fc20 0x6>;
+				};
+
+				macaddr_uboot_1fc40: macaddr@1fc40 {
+					reg = <0x1fc40 0x6>;
+				};
 			};
 
 			partition@20000 {
@@ -86,9 +97,20 @@
 			};
 
 			factory: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 			};
 
 			partition@40000 {
@@ -159,7 +181,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -168,21 +191,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
-	};
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc20: macaddr@1fc20 {
-		reg = <0x1fc20 0x6>;
-	};
-
-	macaddr_uboot_1fc40: macaddr@1fc40 {
-		reg = <0x1fc40 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_iptime_a8004t.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a8004t.dts
@@ -68,9 +68,20 @@
 			#size-cells = <1>;
 
 			uboot: partition@0 {
+				compatible = "nvmem-cells";
 				label = "u-boot";
 				reg = <0x0 0x20000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_uboot_1fc20: macaddr@1fc20 {
+					reg = <0x1fc20 0x6>;
+				};
+
+				macaddr_uboot_1fc40: macaddr@1fc40 {
+					reg = <0x1fc40 0x6>;
+				};
 			};
 
 			partition@20000 {
@@ -80,9 +91,20 @@
 			};
 
 			factory: partition@30000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x30000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 			};
 
 			partition@40000 {
@@ -146,7 +168,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -155,7 +178,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -164,19 +188,5 @@
 	gpio {
 		groups = "wdt", "jtag", "i2c";
 		function = "gpio";
-	};
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc20: macaddr@1fc20 {
-		reg = <0x1fc20 0x6>;
-	};
-
-	macaddr_uboot_1fc40: macaddr@1fc40 {
-		reg = <0x1fc40 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_iptime_ax2004m.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_ax2004m.dts
@@ -73,13 +73,16 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x80000>;
-			read-only;
-
-			compatible = "nvmem-cells";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0xe00>;
+			};
 
 			macaddr_factory_4: macaddr@4 {
 				reg = <0x4 0x6>;
@@ -168,6 +171,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };

--- a/target/linux/ramips/dts/mt7621_jcg_jhr-ac876m.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_jhr-ac876m.dts
@@ -84,9 +84,28 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -106,7 +125,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {
@@ -119,7 +139,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {
@@ -176,19 +197,5 @@
 	gpio {
 		groups = "i2c", "uart3", "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_jcg_q20.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_q20.dts
@@ -88,9 +88,24 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x100000 0x80000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0xe00>;
+			};
+
+			macaddr_factory_3fff4: macaddr@3fff4 {
+				reg = <0x3fff4 0x6>;
+			};
+
+			macaddr_factory_3fffa: macaddr@3fffa {
+				reg = <0x3fffa 0x6>;
+			};
 		};
 
 		partition@180000 {
@@ -139,7 +154,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };
@@ -182,19 +198,5 @@
 	gpio {
 		groups = "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_3fff4: macaddr@3fff4 {
-		reg = <0x3fff4 0x6>;
-	};
-
-	macaddr_factory_3fffa: macaddr@3fffa {
-		reg = <0x3fffa 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_jcg_y2.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_y2.dts
@@ -62,9 +62,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -84,7 +99,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -136,19 +152,5 @@
 	gpio {
 		groups = "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_keenetic_kn-3010.dts
+++ b/target/linux/ramips/dts/mt7621_keenetic_kn-3010.dts
@@ -123,9 +123,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "rf-eeprom";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
 			};
 
 			firmware1: partition@50000 {
@@ -229,7 +244,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -240,19 +256,5 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0400>;
 		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
-
-	macaddr_factory_28: macaddr@28 {
-		reg = <0x28 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_keenetic_kn-3010.dts
+++ b/target/linux/ramips/dts/mt7621_keenetic_kn-3010.dts
@@ -134,6 +134,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_400: eeprom@400 {
+					reg = <0x400 0x4da8>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -254,7 +258,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0400>;
+		nvmem-cells = <&eeprom_factory_400>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
+++ b/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
@@ -104,9 +104,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -133,7 +148,8 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -175,19 +191,5 @@
 	gpio {
 		groups = "jtag", "uart2", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
+++ b/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
@@ -115,6 +115,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -140,7 +144,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_linksys_e5600.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_e5600.dts
@@ -93,6 +93,10 @@
 			eeprom_factory_0: eeprom@0 {
 				reg = <0x0 0x400>;
 			};
+
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x4da8>;
+			};
 		};
 
 		partition@100000 {
@@ -152,7 +156,8 @@
 	mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_linksys_e5600.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_e5600.dts
@@ -83,9 +83,16 @@
 		};
 
 		factory: partition@c0000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0xc0000 0x40000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x400>;
+			};
 		};
 
 		partition@100000 {
@@ -136,7 +143,8 @@
 	mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_linksys_e7350.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_e7350.dts
@@ -80,9 +80,16 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x100000 0x80000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0xe00>;
+			};
 		};
 
 		partition@180000 {
@@ -127,7 +134,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_linksys_re6500.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_re6500.dts
@@ -71,9 +71,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
+				macaddr_factory_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -99,7 +114,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -107,7 +123,8 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -153,14 +170,4 @@
 
 &xhci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_linksys_re7000.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_re7000.dts
@@ -95,6 +95,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
 				macaddr_factory_2e: macaddr@2e {
 					reg = <0x2e 0x6>;
 				};
@@ -132,7 +136,8 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_linksys_re7000.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_re7000.dts
@@ -84,9 +84,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -112,7 +123,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -140,15 +152,5 @@
 			status = "okay";
 			label = "lan";
 		};
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_mercusys_mr70x-v1.dts
+++ b/target/linux/ramips/dts/mt7621_mercusys_mr70x-v1.dts
@@ -72,9 +72,16 @@
 			};
 
 			config: partition@fa0000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0xfa0000 0x010000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_config_8: macaddr@8 {
+					reg = <0x8 0x6>;
+				};
 			};
 
 			partition@fb0000 {
@@ -84,9 +91,16 @@
 			};
 
 			radio: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0xff0000 0x010000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
 			};
 		};
 	};
@@ -100,9 +114,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
-		nvmem-cells = <&macaddr_config_8>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_8>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mediatek,disable-radar-background;
 	};
 };
@@ -151,15 +164,5 @@
 	gpio {
 		groups = "i2c", "uart3";
 		function = "gpio";
-	};
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_8: macaddr@8 {
-		reg = <0x8 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_mqmaker_witi.dts
+++ b/target/linux/ramips/dts/mt7621_mqmaker_witi.dts
@@ -58,8 +58,23 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -78,20 +93,18 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_factory_e000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_e000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;
-		nvmem-cells = <&macaddr_factory_e000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_e000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 
@@ -154,15 +167,5 @@
 	gpio {
 		groups = "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_mtc_wr1201.dts
+++ b/target/linux/ramips/dts/mt7621_mtc_wr1201.dts
@@ -78,9 +78,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -150,8 +165,9 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 
 		led {
 			led-sources = <2>;
@@ -163,8 +179,9 @@
 &pcie1 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 
 		led {
 			led-sources = <2>;
@@ -177,15 +194,5 @@
 	gpio {
 		groups = "rgmii2";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_netgear_eax12.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_eax12.dts
@@ -107,9 +107,16 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x100000 0x80000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0xe00>;
+			};
 		};
 
 		partition@180000 {
@@ -171,7 +178,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_netgear_ex6150.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_ex6150.dts
@@ -118,9 +118,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -214,7 +229,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -222,7 +238,8 @@
 &pcie1 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -249,15 +266,5 @@
 	gpio {
 		groups = "sdhci", "rgmii2", "jtag";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_netgear_wac104.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_wac104.dts
@@ -107,6 +107,10 @@
 				reg = <0x0 0x400>;
 			};
 
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x200>;
+			};
+
 			macaddr_factory_4: macaddr@4 {
 				reg = <0x4 0x6>;
 			};
@@ -128,7 +132,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_netgear_wac104.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_wac104.dts
@@ -96,9 +96,20 @@
 		};
 
 		factory: partition@2e00000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x2e00000 0x100000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x400>;
+			};
+
+			macaddr_factory_4: macaddr@4 {
+				reg = <0x4 0x6>;
+			};
 		};
 
 		partition@4200000 {
@@ -126,7 +137,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -174,14 +186,4 @@
 
 &xhci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_netgear_wax202.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_wax202.dts
@@ -113,9 +113,16 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x100000 0x80000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0xe00>;
+			};
 		};
 
 		partition@180000 {
@@ -213,7 +220,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_netis_wf2881.dts
+++ b/target/linux/ramips/dts/mt7621_netis_wf2881.dts
@@ -63,9 +63,28 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x40000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x200>;
+			};
+
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x200>;
+			};
+
+			macaddr_factory_e000: macaddr@e000 {
+				reg = <0xe000 0x6>;
+			};
+
+			macaddr_factory_e006: macaddr@e006 {
+				reg = <0xe006 0x6>;
+			};
 		};
 
 		partition@140000 {
@@ -97,7 +116,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {
@@ -111,7 +131,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {
@@ -169,19 +190,5 @@
 	gpio {
 		groups = "uart3", "uart2";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_oraybox_x3a.dts
+++ b/target/linux/ramips/dts/mt7621_oraybox_x3a.dts
@@ -77,9 +77,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
 			};
 
 			partition@50000 {
@@ -119,7 +126,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
+++ b/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
@@ -70,9 +70,28 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -98,12 +117,11 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
 
 		/* 5 GHz (phy1) does not take the address from calibration data,
 		   but setting it manually here works */
-		nvmem-cells = <&macaddr_factory_4>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 
@@ -155,23 +173,5 @@
 	gpio {
 		groups = "i2c", "jtag";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_raisecom_msg1500-x-00.dts
+++ b/target/linux/ramips/dts/mt7621_raisecom_msg1500-x-00.dts
@@ -103,13 +103,16 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x100000 0x40000>;
-			read-only;
-
-			compatible = "nvmem-cells";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>;
+			};
 
 			macaddr_factory_4: macaddr@4 {
 				reg = <0x4 0x6>;
@@ -136,11 +139,10 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
 		/* 5 GHz (phy1) does not take the address from calibration data,
 		   but setting it manually here works */
-		nvmem-cells = <&macaddr_factory_4>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_renkforce_ws-wn530hp3-a.dts
+++ b/target/linux/ramips/dts/mt7621_renkforce_ws-wn530hp3-a.dts
@@ -68,9 +68,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -90,10 +101,9 @@
 	wifi0: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
-		nvmem-cells = <&macaddr_factory_4>;
-		nvmem-cell-names = "mac-address";
 	};
 };
 
@@ -154,14 +164,4 @@
 
 &xhci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_renkforce_ws-wn530hp3-a.dts
+++ b/target/linux/ramips/dts/mt7621_renkforce_ws-wn530hp3-a.dts
@@ -79,6 +79,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
 				};
@@ -111,10 +115,9 @@
 	wifi1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_factory_4>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <1>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
+++ b/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
@@ -83,6 +83,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -108,7 +112,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
+++ b/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
@@ -72,9 +72,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -101,7 +116,8 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -153,19 +169,5 @@
 	gpio {
 		groups = "sdhci";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_sercomm_dxx_nand_256m.dtsi
+++ b/target/linux/ramips/dts/mt7621_sercomm_dxx_nand_256m.dtsi
@@ -110,6 +110,10 @@
 				reg = <0x0 0x400>;
 			};
 
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x4da8>;
+			};
+
 			macaddr_factory_21000: macaddr@21000 {
 				reg = <0x21000 0x6>;
 			};
@@ -175,7 +179,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_sercomm_dxx_nand_256m.dtsi
+++ b/target/linux/ramips/dts/mt7621_sercomm_dxx_nand_256m.dtsi
@@ -98,14 +98,17 @@
 		};
 
 		factory: partition@200000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x200000 0x100000>;
 			sercomm,scpart-id = <2>;
-			read-only;
-
-			compatible = "nvmem-cells";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x400>;
+			};
 
 			macaddr_factory_21000: macaddr@21000 {
 				reg = <0x21000 0x6>;
@@ -181,7 +184,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_sercomm_na502.dts
+++ b/target/linux/ramips/dts/mt7621_sercomm_na502.dts
@@ -135,6 +135,10 @@
 				reg = <0x0 0x400>;
 			};
 
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x200>;
+			};
+
 			macaddr_factory_e000: macaddr@e000 {
 				reg = <0xe000 0x6>;
 			};
@@ -185,9 +189,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
-		nvmem-cells = <&macaddr_factory_e000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_e000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <1>;
 		ieee80211-freq-limit = <5000000 6000000>;
 	};

--- a/target/linux/ramips/dts/mt7621_sercomm_na502.dts
+++ b/target/linux/ramips/dts/mt7621_sercomm_na502.dts
@@ -125,8 +125,19 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x40000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x400>;
+			};
+
+			macaddr_factory_e000: macaddr@e000 {
+				reg = <0xe000 0x6>;
+			};
 		};
 
 		partition@140000 {
@@ -186,9 +197,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
-		nvmem-cells = <&macaddr_factory_e000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_e000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <2>;
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
@@ -216,14 +226,4 @@
 
 &uartlite3 {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_sercomm_na502s.dts
+++ b/target/linux/ramips/dts/mt7621_sercomm_na502s.dts
@@ -239,6 +239,10 @@
 				reg = <0x0 0x400>;
 			};
 
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x200>;
+			};
+
 			macaddr_factory_e000: macaddr@e000 {
 				reg = <0xe000 0x6>;
 			};
@@ -289,9 +293,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
-		nvmem-cells = <&macaddr_factory_e000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_e000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <1>;
 		ieee80211-freq-limit = <5000000 6000000>;
 	};

--- a/target/linux/ramips/dts/mt7621_sercomm_na502s.dts
+++ b/target/linux/ramips/dts/mt7621_sercomm_na502s.dts
@@ -229,8 +229,19 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x40000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x400>;
+			};
+
+			macaddr_factory_e000: macaddr@e000 {
+				reg = <0xe000 0x6>;
+			};
 		};
 
 		partition@140000 {
@@ -290,9 +301,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
-		nvmem-cells = <&macaddr_factory_e000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_e000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <2>;
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
@@ -349,14 +359,4 @@
 
 &uartlite2 {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_sercomm_s1500.dtsi
+++ b/target/linux/ramips/dts/mt7621_sercomm_s1500.dtsi
@@ -177,13 +177,20 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x100000 0x100000>;
-			read-only;
-
-			compatible = "nvmem-cells";
 			#address-cells = <1>;
 			#size-cells = <1>;
+			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x200>;
+			};
+
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x200>;
+			};
 
 			macaddr_factory_1000: macaddr@1000 {
 				reg = <0x1000 0x6>;
@@ -220,10 +227,9 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 
-		nvmem-cells = <&macaddr_factory_1000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_1000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <2>;
 	};
 };
@@ -233,10 +239,9 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <2400000 2500000>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
 
-		nvmem-cells = <&macaddr_factory_1000>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_1000>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me1.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me1.dts
@@ -114,7 +114,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -154,6 +155,10 @@
 
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
 				};
 
 				macaddr_factory_e000: macaddr@e000 {

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me1.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me1.dts
@@ -104,7 +104,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -144,13 +145,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "Factory";
 				reg = <0x40000 0x10000>;
-				read-only;
-
-				compatible = "nvmem-cells";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-lite.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-lite.dts
@@ -74,9 +74,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -144,7 +159,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -155,19 +171,5 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-lite.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-lite.dts
@@ -85,6 +85,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -169,7 +173,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-sfp.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-sfp.dts
@@ -113,9 +113,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -200,20 +215,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };

--- a/target/linux/ramips/dts/mt7621_storylink_sap-g3200u3.dts
+++ b/target/linux/ramips/dts/mt7621_storylink_sap-g3200u3.dts
@@ -67,9 +67,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -88,7 +103,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -96,7 +112,8 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -150,15 +167,5 @@
 	gpio {
 		groups = "uart3", "jtag";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_telco-electronics_x1.dts
+++ b/target/linux/ramips/dts/mt7621_telco-electronics_x1.dts
@@ -106,9 +106,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -176,7 +187,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7603";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -191,15 +203,5 @@
 		led {
 			led-sources = <2>;
 		};
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_telco-electronics_x1.dts
+++ b/target/linux/ramips/dts/mt7621_telco-electronics_x1.dts
@@ -117,6 +117,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e006: macaddr@e006 {
 					reg = <0xe006 0x6>;
 				};
@@ -197,7 +201,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_tenbay_t-mb5eu-v01.dts
+++ b/target/linux/ramips/dts/mt7621_tenbay_t-mb5eu-v01.dts
@@ -105,7 +105,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };
@@ -194,9 +195,20 @@
 			};
 
 			factory: partition@50000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x50000 0x40000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
 			};
 
 			partition@90000 {
@@ -205,15 +217,5 @@
 				reg = <0x90000 0xf70000>;
 			};
 		};
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_totolink_a7000r.dts
+++ b/target/linux/ramips/dts/mt7621_totolink_a7000r.dts
@@ -63,9 +63,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -85,7 +100,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -94,7 +110,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -148,15 +165,5 @@
 	gpio {
 		groups = "i2c", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_totolink_x5000r.dts
+++ b/target/linux/ramips/dts/mt7621_totolink_x5000r.dts
@@ -70,9 +70,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -92,7 +107,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };
@@ -145,19 +161,5 @@
 	gpio {
 		groups = "i2c", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tozed_zlt-s12-pro.dts
+++ b/target/linux/ramips/dts/mt7621_tozed_zlt-s12-pro.dts
@@ -160,13 +160,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
-				read-only;
-
-				compatible = "nvmem-cells";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
@@ -199,7 +202,8 @@
 	wifi1: mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tozed_zlt-s12-pro.dts
+++ b/target/linux/ramips/dts/mt7621_tozed_zlt-s12-pro.dts
@@ -171,6 +171,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -193,7 +197,8 @@
 	wifi0: mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_archer-ax23-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-ax23-v1.dts
@@ -105,9 +105,16 @@
 			};
 
 			config: partition@fa0000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0xfa0000 0x010000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_config_8: macaddr@8 {
+					reg = <0x8 0x6>;
+				};
 			};
 
 			partition@fb0000 {
@@ -117,9 +124,16 @@
 			};
 
 			radio: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0xff0000 0x010000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
 			};
 		};
 	};
@@ -133,9 +147,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
-		nvmem-cells = <&macaddr_config_8>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_8>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mediatek,disable-radar-background;
 	};
 };
@@ -189,15 +202,5 @@
 	gpio {
 		groups = "i2c", "uart3", "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_8: macaddr@8 {
-		reg = <0x8 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
@@ -116,9 +116,16 @@
 			};
 
 			config: partition@fa0000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0xfa0000 0x010000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_config_8: macaddr@8 {
+					reg = <0x8 0x6>;
+				};
 			};
 
 			partition@fb0000 {
@@ -128,9 +135,16 @@
 			};
 
 			radio: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0xff0000 0x010000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 		};
 	};
@@ -144,9 +158,8 @@
 	mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
-		nvmem-cells = <&macaddr_config_8>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_8>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -217,14 +230,4 @@
 
 &xhci {
 	vbus-supply = <&reg_usb_vbus>;
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_8: macaddr@8 {
-		reg = <0x8 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
@@ -145,6 +145,10 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 			};
 		};
 	};
@@ -168,9 +172,8 @@
 	mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
-		nvmem-cells = <&macaddr_config_8>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_config_8>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(-1)>;
 		ieee80211-freq-limit = <5000000 6000000>;
 	};

--- a/target/linux/ramips/dts/mt7621_tplink_archer-x6-v3.dtsi
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-x6-v3.dtsi
@@ -122,6 +122,10 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 			};
 		};
 	};
@@ -153,9 +157,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
-		nvmem-cells = <&macaddr_config_8>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_config_8>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <2>;
 		ieee80211-freq-limit = <5000000 6000000>;
 	};

--- a/target/linux/ramips/dts/mt7621_tplink_archer-x6-v3.dtsi
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-x6-v3.dtsi
@@ -99,15 +99,29 @@
 			};
 
 			config: partition@fa0000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0xfa0000 0x50000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_config_8: macaddr@8 {
+					reg = <0x8 0x6>;
+				};
 			};
 
 			radio: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0xff0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 		};
 	};
@@ -128,9 +142,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
-		nvmem-cells = <&macaddr_config_8>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_8>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <1>;
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
@@ -183,15 +196,5 @@
 			status = "okay";
 			label = "lan4";
 		};
-	};
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_8: macaddr@8 {
-		reg = <0x8 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_deco-m4r-v4.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_deco-m4r-v4.dts
@@ -157,6 +157,10 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 			};
 		};
 	};
@@ -205,7 +209,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
+		nvmem-cells = <&eeprom_radio_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_deco-m4r-v4.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_deco-m4r-v4.dts
@@ -147,9 +147,16 @@
 			};
 
 			radio: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0xff0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 		};
 	};
@@ -188,7 +195,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
+		nvmem-cells = <&eeprom_radio_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_eap235-wall-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap235-wall-v1.dts
@@ -131,6 +131,10 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 			};
 		};
 	};
@@ -158,10 +162,9 @@
 &pcie1 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_info_8>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_info_8>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <1>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_eap235-wall-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap235-wall-v1.dts
@@ -82,9 +82,16 @@
 			};
 
 			info: partition@90000 {
+				compatible = "nvmem-cells";
 				label = "product-info";
 				reg = <0x90000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_info_8: macaddr@8 {
+					reg = <0x8 0x6>;
+				};
 			};
 
 			partition@a0000 {
@@ -114,9 +121,16 @@
 			};
 
 			radio: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0xff0000 0x010000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 		};
 	};
@@ -136,9 +150,8 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
-		nvmem-cells = <&macaddr_info_8>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_0>, <&macaddr_info_8>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 
@@ -189,15 +202,5 @@
 			status = "okay";
 			label = "lan1";
 		};
-	};
-};
-
-&info {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_info_8: macaddr@8 {
-		reg = <0x8 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_eap613-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap613-v1.dts
@@ -108,9 +108,16 @@
 			};
 
 			radio: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0xff0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
 			};
 		};
 	};
@@ -131,7 +138,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
+		nvmem-cells = <&eeprom_radio_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts
@@ -90,9 +90,16 @@
 			};
 
 			info: partition@90000 {
+				compatible = "nvmem-cells";
 				label = "product-info";
 				reg = <0x90000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_info_8: macaddr@8 {
+					reg = <0x8 0x6>;
+				};
 			};
 
 			partition@a0000 {
@@ -120,9 +127,16 @@
 			};
 
 			radio: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0xff0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
 			};
 		};
 	};
@@ -143,7 +157,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
+		nvmem-cells = <&eeprom_radio_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };
@@ -184,15 +199,5 @@
 			status = "okay";
 			label = "lan1";
 		};
-	};
-};
-
-&info {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_info_8: macaddr@8 {
-		reg = <0x8 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_ec330-g5u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_ec330-g5u-v1.dts
@@ -225,16 +225,23 @@
 		};
 
 		factory: partition@7800000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x7800000 0x400000>;
 			read-only;
-
-			compatible = "nvmem-cells";
 
 			nvmem-layout {
 				compatible = "fixed-layout";
 				#address-cells = <1>;
 				#size-cells = <1>;
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				eeprom_factory_14000: eeprom@14000 {
+					reg = <0x14000 0x4da8>;
+				};
 
 				macaddr_factory_165: macaddr@165 {
 					compatible = "mac-base";
@@ -242,8 +249,6 @@
 					#nvmem-cell-cells = <1>;
 				};
 			};
-
-
 		};
 
 		partition@0_wholeflash {
@@ -262,11 +267,9 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <2400000 2500000>;
-
-		nvmem-cells = <&macaddr_factory_165 0>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_165 0>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 
@@ -274,11 +277,9 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x14000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-
-		nvmem-cells = <&macaddr_factory_165 2>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_14000>, <&macaddr_factory_165 2>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_tplink_mr600-v2-eu.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_mr600-v2-eu.dts
@@ -138,6 +138,10 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 			};
 		};
 	};
@@ -162,10 +166,9 @@
 	mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_romfile_f100>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_romfile_f100>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(-1)>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_mr600-v2-eu.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_mr600-v2-eu.dts
@@ -109,9 +109,16 @@
 			};
 
 			romfile: partition@fc0000 {
+				compatible = "nvmem-cells";
 				label = "romfile";
 				reg = <0xfc0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_romfile_f100: romfile@f100 {
+					reg = <0xf100 0x6>;
+				};
 			};
 
 			partition@fd0000 {
@@ -121,9 +128,16 @@
 			};
 
 			radio: partition@fe0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0xfe0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 		};
 	};
@@ -138,10 +152,8 @@
 	mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_romfile_f100>;
-		nvmem-cell-names = "mac-address";
-		mediatek,mtd-eeprom = <&radio 0x0>;
-		mtd-mac-address = <&romfile 0xf100>;
+		nvmem-cells = <&eeprom_radio_0>, <&macaddr_romfile_f100>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -193,15 +205,5 @@
 			status = "okay";
 			label = "lan3";
 		};
-	};
-};
-
-&romfile {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_romfile_f100: romfile@f100 {
-		reg = <0xf100 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_re350-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_re350-v1.dts
@@ -131,6 +131,10 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
 			};
 		};
 	};
@@ -152,10 +156,9 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_config_10008>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_config_10008>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <2>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_re350-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_re350-v1.dts
@@ -108,15 +108,29 @@
 			};
 
 			config: partition@600000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0x600000 0x50000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_config_10008: macaddr@10008 {
+					reg = <0x10008 0x6>;
+				};
 			};
 
 			radio: partition@7f0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 		};
 	};
@@ -129,9 +143,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
-		nvmem-cells = <&macaddr_config_10008>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_10008>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <1>;
 	};
 };
@@ -169,15 +182,5 @@
 	gpio {
 		groups = "rgmii2", "wdt";
 		function = "gpio";
-	};
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_10008: macaddr@10008 {
-		reg = <0x10008 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_re650-v2.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_re650-v2.dts
@@ -117,15 +117,33 @@
 			};
 
 			config: partition@7c0000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0x7c0000 0x2d440>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_config_10008: macaddr@10008 {
+					reg = <0x10008 0x6>;
+				};
 			};
 
 			radio: partition@7f0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 			};
 		};
 	};
@@ -146,9 +164,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
-		nvmem-cells = <&macaddr_config_10008>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_10008>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <1>;
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
@@ -158,9 +175,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
-		nvmem-cells = <&macaddr_config_10008>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_config_10008>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <2>;
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
@@ -181,15 +197,5 @@
 			status = "okay";
 			label = "lan";
 		};
-	};
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_10008: macaddr@10008 {
-		reg = <0x10008 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_rexx0-v1.dtsi
+++ b/target/linux/ramips/dts/mt7621_tplink_rexx0-v1.dtsi
@@ -114,9 +114,16 @@
 			};
 
 			config: partition@e00000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0xe00000 0x50000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_config_10008: macaddr@10008 {
+					reg = <0x10008 0x6>;
+				};
 			};
 
 			/* range 0xe50000 to 0xff0000 is empty in vendor
@@ -124,9 +131,20 @@
 			 */
 
 			radio: partition@ff0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0xff0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 			};
 		};
 	};
@@ -147,9 +165,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
-		nvmem-cells = <&macaddr_config_10008>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_10008>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <1>;
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
@@ -159,9 +176,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
-		nvmem-cells = <&macaddr_config_10008>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_config_10008>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <2>;
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
@@ -182,15 +198,5 @@
 			status = "okay";
 			label = "lan";
 		};
-	};
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_10008: macaddr@10008 {
-		reg = <0x10008 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_tl-wpa8631p-v3.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_tl-wpa8631p-v3.dts
@@ -135,6 +135,10 @@
 				eeprom_radio_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_radio_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 			};
 		};
 	};
@@ -165,9 +169,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
-		nvmem-cells = <&macaddr_config_2008>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_config_2008>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <1>;
 		ieee80211-freq-limit = <5000000 6000000>;
 	};

--- a/target/linux/ramips/dts/mt7621_tplink_tl-wpa8631p-v3.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_tl-wpa8631p-v3.dts
@@ -112,15 +112,29 @@
 			};
 
 			config: partition@730000 {
+				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0x730000 0xc0000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_config_2008: macaddr@2008 {
+					reg = <0x2008 0x6>;
+				};
 			};
 
 			radio: partition@7f0000 {
+				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_radio_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 		};
 	};
@@ -141,9 +155,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
-		nvmem-cells = <&macaddr_config_2008>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_2008>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -190,15 +203,5 @@
 			status = "okay";
 			label = "lan3";
 		};
-	};
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_2008: macaddr@2008 {
-		reg = <0x2008 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_ubnt_unifi-6-lite.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi-6-lite.dts
@@ -37,15 +37,33 @@
 			};
 
 			factory: partition@70000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x70000 0x40000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 			};
 
 			eeprom: partition@b0000 {
+				compatible = "nvmem-cells";
 				label = "eeprom";
 				reg = <0xb0000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				macaddr_eeprom_0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_eeprom_6: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
 			};
 
 			partition@c0000 {
@@ -79,10 +97,8 @@
 };
 
 &wlan_2g {
-	mediatek,mtd-eeprom = <&factory 0x0>;
-
-	nvmem-cells = <&macaddr_eeprom_0>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_eeprom_0>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &wlan_5g {
@@ -110,18 +126,4 @@
 	ieee80211-freq-limit = <5000000 6000000>;
 
 	mediatek,disable-radar-background;
-};
-
-&eeprom {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_eeprom_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_eeprom_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_ubnt_unifi-6-lite.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi-6-lite.dts
@@ -47,6 +47,10 @@
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
+
+				eeprom_factory_20000: eeprom@20000 {
+					reg = <0x20000 0xe00>;
+				};
 			};
 
 			eeprom: partition@b0000 {
@@ -104,10 +108,8 @@
 &wlan_5g {
 	compatible = "mediatek,mt76";
 
-	mediatek,mtd-eeprom = <&factory 0x20000>;
-
-	nvmem-cells = <&macaddr_eeprom_6>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_eeprom_6>;
+	nvmem-cell-names = "eeprom", "mac-address";
 
 	/* This is a workaround.
 	 *

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
@@ -33,9 +33,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -55,18 +70,4 @@
 &gmac1 {
 	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
@@ -44,6 +44,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01.dtsi
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01.dtsi
@@ -54,7 +54,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01.dtsi
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01.dtsi
@@ -64,7 +64,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn573hx1.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn573hx1.dts
@@ -61,7 +61,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -87,8 +88,19 @@
 			};
 
 			factory:partition@50000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x50000 0x40000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				macaddr_factory_3fff4: macaddr@3fff4 {
+					reg = <0x3fff4 0x6>;
+				};
 			};
 
 			partition@90000 {
@@ -118,16 +130,4 @@
 			label = "lan";
 		};
 	};
-};
-
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_3fff4: macaddr@3fff4 {
-		reg = <0x3fff4 0x6>;
-	};
-
 };

--- a/target/linux/ramips/dts/mt7621_wavlink_ws-wn572hp3-4g.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_ws-wn572hp3-4g.dts
@@ -95,6 +95,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -137,7 +141,9 @@
 	wifi1: mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -176,8 +182,3 @@
 		function = "gpio";
 	};
 };
-
-&wifi1{
-	ieee80211-freq-limit = <5000000 6000000>;
-};
-

--- a/target/linux/ramips/dts/mt7621_wavlink_ws-wn572hp3-4g.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_ws-wn572hp3-4g.dts
@@ -84,9 +84,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -109,10 +124,12 @@
 };
 
 &pcie0 {
-	wifi0: mt76@0,0 {
+	mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -158,24 +175,6 @@
 		groups = "wdt";
 		function = "gpio";
 	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
-	};
-};
-
-&wifi0{
-	ieee80211-freq-limit = <2400000 2500000>;
 };
 
 &wifi1{

--- a/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dtsi
+++ b/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dtsi
@@ -63,9 +63,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_2e: macaddr@2e {
+					reg = <0x2e 0x6>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -85,7 +100,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 
 		led {
 			led-sources = <0>;
@@ -151,19 +167,5 @@
 	gpio {
 		groups = "wdt", "rgmii2";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_2e: macaddr@2e {
-		reg = <0x2e 0x6>;
-	};
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dtsi
+++ b/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dtsi
@@ -74,6 +74,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_2e: macaddr@2e {
 					reg = <0x2e 0x6>;
 				};
@@ -114,7 +118,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_winstars_ws-wn583a6.dts
+++ b/target/linux/ramips/dts/mt7621_winstars_ws-wn583a6.dts
@@ -84,9 +84,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -106,7 +121,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -152,18 +168,4 @@
 
 &xhci {
 	status = "disabled";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_winstars_ws-wn583a6.dts
+++ b/target/linux/ramips/dts/mt7621_winstars_ws-wn583a6.dts
@@ -95,6 +95,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -130,7 +134,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3-pro.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3-pro.dts
@@ -132,9 +132,28 @@
 		};
 
 		factory: partition@c0000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x0c0000 0x40000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>;
+			};
+
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x4da8>;
+			};
+
+			macaddr_factory_e000: macaddr@e000 {
+				reg = <0xe000 0x6>;
+			};
+
+			macaddr_factory_e006: macaddr@e006 {
+				reg = <0xe006 0x6>;
+			};
 		};
 
 		partition@100000 {
@@ -179,7 +198,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -188,7 +208,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -236,19 +257,5 @@
 	gpio {
 		groups = "jtag", "uart2", "uart3", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr660x.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr660x.dtsi
@@ -86,9 +86,24 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x100000 0x80000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0xe00>;
+			};
+
+			macaddr_factory_3fff4: macaddr@3fff4 {
+				reg = <0x3fff4 0x6>;
+			};
+
+			macaddr_factory_3fffa: macaddr@3fffa {
+				reg = <0x3fffa 0x6>;
+			};
 		};
 
 		partition@180000 {
@@ -135,7 +150,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };
@@ -183,19 +199,5 @@
 	gpio {
 		groups = "jtag", "uart3", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_3fff4: macaddr@3fff4 {
-		reg = <0x3fff4 0x6>;
-	};
-
-	macaddr_factory_3fffa: macaddr@3fffa {
-		reg = <0x3fffa 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
+++ b/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
@@ -113,9 +113,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -139,7 +150,8 @@
 	wifi@0,0 {
 		compatible = "pci1400,7603";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -197,15 +209,5 @@
 	gpio {
 		groups = "wdt", "rgmii2";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
+++ b/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
@@ -124,6 +124,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -159,7 +163,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_youhua_wr1200js.dts
+++ b/target/linux/ramips/dts/mt7621_youhua_wr1200js.dts
@@ -86,9 +86,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -107,7 +122,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -172,19 +188,5 @@
 	gpio {
 		groups = "i2c", "uart2", "uart3", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_youhua_wr1200js.dts
+++ b/target/linux/ramips/dts/mt7621_youhua_wr1200js.dts
@@ -97,6 +97,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -130,7 +134,8 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_youku_yk-l2.dts
+++ b/target/linux/ramips/dts/mt7621_youku_yk-l2.dts
@@ -100,6 +100,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -140,7 +144,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 		led {
 			led-sources = <2>;

--- a/target/linux/ramips/dts/mt7621_youku_yk-l2.dts
+++ b/target/linux/ramips/dts/mt7621_youku_yk-l2.dts
@@ -89,9 +89,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -112,7 +127,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7603";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 		led {
 			led-active-low;
@@ -181,19 +197,5 @@
 	gpio {
 		groups = "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
@@ -112,9 +112,20 @@
 			 */
 
 			factory: partition@50000 {
+				compatible = "nvmem-cells";
 				label = "Factory";
 				reg = <0x50000 0x40000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
 			};
 
 			partition@90000 {
@@ -134,7 +145,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };
@@ -176,15 +188,5 @@
 	gpio {
 		groups = "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_yuncore_fap640.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_fap640.dts
@@ -120,9 +120,24 @@
 			 */
 
 			factory: partition@50000 {
+				compatible = "nvmem-cells";
 				label = "Factory";
 				reg = <0x50000 0x40000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				macaddr_factory_0004: macaddr@0004 {
+					reg = <0x0004 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@90000 {
@@ -142,7 +157,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };
@@ -201,18 +217,3 @@
 		function = "gpio";
 	};
 };
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_0004: macaddr@0004 {
-		reg = <0x0004 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
-	};
-};
-

--- a/target/linux/ramips/dts/mt7621_yuncore_fap690.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_fap690.dts
@@ -90,9 +90,20 @@
 			 */
 
 			factory: partition@50000 {
+				compatible = "nvmem-cells";
 				label = "Factory";
 				reg = <0x50000 0x40000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				macaddr_factory_0004: macaddr@0004 {
+					reg = <0x0004 0x6>;
+				};
 			};
 
 			partition@90000 {
@@ -112,7 +123,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };
@@ -135,15 +147,5 @@
 	gpio {
 		groups = "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_0004: macaddr@0004 {
-		reg = <0x0004 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-we1326.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-we1326.dts
@@ -59,9 +59,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -139,7 +154,8 @@
 	wifi1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {
@@ -151,18 +167,4 @@
 
 &sdhci {
 	status = "okay";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-we1326.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-we1326.dts
@@ -70,6 +70,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -140,7 +144,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-we3526.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-we3526.dts
@@ -56,9 +56,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -91,7 +106,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7603";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -143,19 +159,5 @@
 	gpio {
 		groups = "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-we3526.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-we3526.dts
@@ -67,6 +67,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -93,7 +97,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
@@ -122,6 +122,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -156,7 +160,8 @@
 	wifi1: wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
@@ -111,9 +111,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -132,7 +147,8 @@
 	wifi0: wifi@0,0 {
 		compatible = "pci14c3,7603";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -197,19 +213,5 @@
 	gpio {
 		groups = "i2c", "uart2", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602.dtsi
@@ -110,9 +110,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -131,7 +146,8 @@
 	wifi0: wifi@0,0 {
 		compatible = "pci14c3,7603";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -196,19 +212,5 @@
 	gpio {
 		groups = "i2c", "uart2", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602.dtsi
@@ -121,6 +121,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -155,7 +159,8 @@
 	wifi1: wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1608.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1608.dtsi
@@ -95,6 +95,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -130,7 +134,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1608.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1608.dtsi
@@ -84,13 +84,16 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
-				read-only;
-
-				compatible = "nvmem-cells";
 				#address-cells = <1>;
 				#size-cells = <1>;
+				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
 
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
@@ -118,7 +121,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg2626.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg2626.dts
@@ -72,9 +72,24 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
 			};
 
 			partition@50000 {
@@ -96,7 +111,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -104,7 +120,8 @@
 &pcie1 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -154,15 +171,5 @@
 	gpio {
 		groups = "wdt", "rgmii2";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
@@ -83,6 +83,10 @@
 					reg = <0x0 0x400>;
 				};
 
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
@@ -113,7 +117,8 @@
 	wifi1: wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
@@ -72,9 +72,20 @@
 			};
 
 			factory: partition@40000 {
+				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
 				read-only;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
 			};
 
 			firmware: partition@50000 {
@@ -93,7 +104,8 @@
 	wifi0: wifi@0,0 {
 		compatible = "pci14c3,7603";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -155,15 +167,5 @@
 	gpio {
 		groups = "wdt", "rgmii2";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
@@ -126,8 +126,19 @@
 			reg = <0x80000 0x80000>; /* 64 KB */
 		};
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x40000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>;
+			};
+
+			macaddr_factory_fe6e: macaddr@fe6e {
+				reg = <0xfe6e 0x6>;
+			};
 		};
 		partition@140000 {
 			label = "Kernel";
@@ -197,21 +208,9 @@
 		compatible = "pci14c3,7615";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,firmware-eeprom = "mt7615e_eeprom.bin";
-		mediatek,mtd-eeprom = <&factory 0x0000>;
-		nvmem-cells = <&macaddr_factory_fe6e>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_fe6e>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mac-address-increment = <(1)>;
 	};
 
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-	mtd-mac-address = <&factory 0xfe6e>;
-
-	macaddr_factory_fe6e: macaddr@fe6e {
-		reg = <0xfe6e 0x6>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_zyxel_nr7101.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_nr7101.dts
@@ -89,9 +89,20 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x100000 0x40000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x400>;
+			};
+
+			macaddr_factory_e000: macaddr@e000 {
+				reg = <0xe000 0x6>;
+			};
 		};
 
 		partition@140000 {
@@ -139,7 +150,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -161,15 +173,5 @@
 	gpio {
 		groups = "i2c", "uart3", "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_zyxel_nwa-ax.dtsi
+++ b/target/linux/ramips/dts/mt7621_zyxel_nwa-ax.dtsi
@@ -37,9 +37,16 @@
 		};
 
 		factory: partition@100000 {
+			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x80000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0xe00>;
+			};
 		};
 
 		partition@180000 {
@@ -93,9 +100,16 @@
 		};
 
 		mrd: partition@7780000 {
+			compatible = "nvmem-cells";
 			label = "mrd";
 			reg = <0x7780000 0x80000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			macaddr_mrd_1fff8: macaddr@1fff8 {
+				reg = <0x1fff8 0x6>;
+			};
 		};
 	};
 };
@@ -109,7 +123,8 @@
 		reg = <0x0 0 0 0 0>;
 		compatible = "mediatek,mt76";
 
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 
 		/* MAC-Address set in userspace */
 	};
@@ -126,16 +141,6 @@
 			status = "okay";
 			label = "lan";
 		};
-	};
-};
-
-&mrd {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_mrd_1fff8: macaddr@1fff8 {
-		reg = <0x1fff8 0x6>;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_zyxel_wap6805.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_wap6805.dts
@@ -74,9 +74,20 @@
 		};
 
 		factory: partition@200000 {
+			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x200000 0x100000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x400>;
+			};
+
+			macaddr_factory_e000: macaddr@e000 {
+				reg = <0xe000 0x6>;
+			};
 		};
 
 		partition@300000 {
@@ -123,7 +134,8 @@
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -170,15 +182,5 @@
 	gpio {
 		groups = "i2c", "uart3", "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_zyxel_wsm20.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_wsm20.dts
@@ -103,9 +103,24 @@
 		};
 
 		factory: partition@200000 {
+			compatible = "nvmem-cells";
 			reg = <0x200000 0x1c0000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
 			label = "Factory";
 			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0xe00>;
+			};
+
+			macaddr_factory_1fdfa: macaddr@1fdfa {
+				reg = <0x1fdfa 0x6>;
+			};
+
+			macaddr_factory_1fdf4: macaddr@1fdf4 {
+				reg = <0x1fdf4 0x6>;
+			};
 		};
 
 		partition@3c0000 {
@@ -185,7 +200,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };
@@ -215,19 +231,5 @@
 	gpio {
 		groups = "i2c", "uart3", "jtag", "wdt";
 		function = "gpio";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_1fdfa: macaddr@1fdfa {
-		reg = <0x1fdfa 0x6>;
-	};
-
-	macaddr_factory_1fdf4: macaddr@1fdf4 {
-		reg = <0x1fdf4 0x6>;
 	};
 };


### PR DESCRIPTION
Notice:
1. Some MT7621 devices have complex dtsi dependencies, so they are not included.
2. All NIC models are judged based on the commit message or the makefile default packages.

|Package Name|NIC Model|EEPROM size||
|-|-|-|-|
|kmod-mt7603|MT7603|0x400|2 GHz only|
|kmod-mt76x0e|MT7610|0x200|same as MT7612|
|kmod-mt76x2|MT7602/MT7612|0x200||
|kmod-mt7663-firmware-ap|MT7613|0x4da8|same as MT7615|
|kmod-mt7615-firmware|MT7615|0x4da8||
|kmod-mt7915-firmware|MT7915|0xe00||