### PR TITLE
rtl83xx: fix STP by trapping BPDUs

### DIFF
--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
@@ -152,7 +152,7 @@ static void rtl83xx_vlan_setup(struct rtl838x_switch_priv *priv)
 static void rtl83xx_setup_bpdu_traps(struct rtl838x_switch_priv *priv)
 {
 	for (int i = 0; i < priv->cpu_port; i++)
-		priv->r->set_receive_management_action(i, BPDU, COPY2CPU);
+		priv->r->set_receive_management_action(i, BPDU, TRAP2CPU);
 }
 
 static void rtl83xx_port_set_salrn(struct rtl838x_switch_priv *priv,


### PR DESCRIPTION
The current `COPY2CPU` makes switch to ignore Bridge Protocol Data Units (BPDUs) and that means that Spanning Tree Protocol (STP) doesn't work.

I tested and I confirm it works on:
- Zyxel GS1900-8
- Zyxel GS1900-24 v1
- Zyxel GS1900-48

