### PR TITLE
dnsmasq: add support for address forwarding to an upstream DNS

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -977,6 +977,7 @@ dnsmasq_start()
 	append_parm "$cfg" "maxport" "--max-port"
 	append_parm "$cfg" "domain" "--domain"
 	append_parm "$cfg" "local" "--local"
+	append_parm "$cfg" "add_subnet" "--add-subnet"
 	config_list_foreach "$cfg" "listen_address" append_listenaddress
 	config_list_foreach "$cfg" "server" append_server
 	config_list_foreach "$cfg" "rev_server" append_rev_server


### PR DESCRIPTION
This change allow the use of a dnsmasq option "--add-subnet" using dhcp configuration file. More information about this feature could be found here:

https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html