### PR TITLE
ramips: add support for ZyXEL LTE5398-M904

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -127,6 +127,7 @@ xiaomi,redmi-router-ac2100)
 zyxel,lte3301-plus)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x80000"
 	;;
+zyxel,lte5398-m904|\
 zyxel,nr7101)
 	idx="$(find_mtd_index Config)"
 	[ -n "$idx" ] && \

--- a/target/linux/ramips/dts/mt7621_zyxel_lte5398-m904.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte5398-m904.dts
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "zyxel,lte5398-m904", "mediatek,mt7621-soc";
+	model = "ZyXEL LTE5398-M904";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_green;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		power_blue {
+			label = "blue:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "usbport";
+			trigger-sources = <&ehci_port2>;
+		};
+
+		internet {
+			label = "green:internet";
+			gpios = <&gpio 23 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi {
+			label = "green:wifi";
+			gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		voice {
+			label = "green:voice";
+			gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
+		};
+
+		lte_green {
+			label = "green:lte";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		lte_orange {
+			label = "orange:lte";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		lte_red {
+			label = "red:lte";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		lte_power {
+			gpio-export,name = "lte_power";
+			gpio-export,output = <0>;
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		};
+
+		usb_power {
+			gpio-export,name = "usb_power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x80000>;
+		};
+
+		factory: partition@100000 {
+			compatible = "nvmem-cells";
+			label = "Factory";
+			reg = <0x100000 0x40000>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+			read-only;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x400>;
+			};
+
+			eeprom_factory_8000: eeprom@8000 {
+				reg = <0x8000 0x4da8>;
+			};
+
+			macaddr_factory_fe6e: macaddr@fe6e {
+				reg = <0xfe6e 0x6>;
+			};
+		};
+
+		partition@140000 {
+			label = "Kernel";
+			reg = <0x140000 0x1ec0000>;
+		};
+
+		partition@540000 {
+			label = "ubi";
+			reg = <0x540000 0x1ac0000>;
+		};
+
+		partition@2140000 {
+			label = "Kernel2";
+			reg = <0x2140000 0x1ec0000>;
+		};
+
+		partition@4000000 {
+			label = "wwan";
+			reg = <0x4000000 0x100000>;
+		};
+
+		partition@4100000 {
+			label = "data";
+			reg = <0x4100000 0x1000000>;
+		};
+
+		partition@5100000 {
+			label = "rom-d";
+			reg = <0x5100000 0x100000>;
+			read-only;
+		};
+
+		partition@5200000 {
+			label = "reserve";
+			reg = <0x5200000 0x80000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "rgmii2", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_fe6e>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+	};
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2974,6 +2974,21 @@ define Device/zyxel_lte3301-plus
 endef
 TARGET_DEVICES += zyxel_lte3301-plus
 
+define Device/zyxel_lte5398-m904
+  $(Device/nand)
+  DEVICE_VENDOR := ZyXEL
+  DEVICE_MODEL := LTE5398-M904
+  KERNEL_SIZE := 31488k
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3 uqmi \
+  kmod-usb-net-qmi-wwan kmod-usb-serial-option kmod-usb-ledtrig-usbport
+  KERNEL := $(KERNEL_DTB) | uImage lzma | \
+	zytrx-header $$(DEVICE_MODEL) $$(VERSION_DIST)-$$(REVISION)
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | uImage lzma | \
+	zytrx-header $$(DEVICE_MODEL) 9.99(ABQU.1)$$(VERSION_DIST)-recovery
+  KERNEL_INITRAMFS_SUFFIX := -recovery.bin
+endef
+TARGET_DEVICES += zyxel_lte5398-m904
+
 define Device/zyxel_nr7101
   $(Device/nand)
   DEVICE_VENDOR := ZyXEL

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -248,6 +248,9 @@ yuncore,ax820)
 zyxel,lte3301-plus)
 	ucidef_set_led_netdev "internet" "internet" "white:internet" "wwan0"
 	;;
+zyxel,lte5398-m904)
+	ucidef_set_led_netdev "internet" "LTE/3G Internet Activity" "green:internet" "wwan0" "rx tx"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -148,6 +148,10 @@ ramips_setup_interfaces()
 	ubnt,usw-flex)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"
 		;;
+	zyxel,lte5398-m904)
+		ucidef_set_interface_lan "lan1 lan2"
+		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
+		;;
 	zyxel,wap6805)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		ucidef_set_interface "qtn" ifname "eth1" protocol "static" ipaddr "1.1.1.1" netmask "255.255.255.0"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -29,7 +29,8 @@ ubnt,edgerouter-x-sfp)
 	ucidef_add_gpio_switch "poe_power_port3" "PoE Power Port3" "403"
 	ucidef_add_gpio_switch "poe_power_port4" "PoE Power Port4" "404"
 	;;
-zyxel,lte3301-plus)
+zyxel,lte3301-plus|\
+zyxel,lte5398-m904)
 	ucidef_add_gpio_switch "usb_power" "Power USB Port" "usb_power" "1"
 	ucidef_add_gpio_switch "lte_power" "Power LTE modem" "lte_power" "1"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -34,6 +34,7 @@ boot() {
 		[ $(printf %d $(fw_printenv -n Image1Stable)) -gt 0 ] || fw_setenv Image1Stable 1
 		[ $(printf %d $(fw_printenv -n Image1Try)) -gt 0 ] && fw_setenv Image1Try 0
 		;;
+	zyxel,lte5398-m904|\
 	zyxel,nr7101)
 		[ $(printf %d $(fw_printenv -n DebugFlag)) -gt 0 ] || fw_setenv DebugFlag 0x1
 		[ $(printf %d $(fw_printenv -n Image1Stable)) -gt 0 ] || fw_setenv Image1Stable 1

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -149,6 +149,7 @@ platform_do_upgrade() {
 		platform_upgrade_ubnt_erx "$1"
 		;;
 	zyxel,lte3301-plus|\
+	zyxel,lte5398-m904|\
 	zyxel,nr7101)
 		fw_setenv CheckBypass 0
 		fw_setenv Image1Stable 0


### PR DESCRIPTION
ZyXEL LTE5398-M904 is a dual band 802.11ac indoor LTE/3G CPE with an FXS port.

Specifications:

* SoC: Mediatek MT7621AT
* RAM: 256 MB
* Flash: 128MB NAND (MX30LF1G18AC)
* WiFi: MediaTek MT7603 2.4G + MediaTek MT7615 5G
* Switch: 2 GbE ports MT7530
* LTE/3G: Quectel EG18-EA LTE-A Cat. 18
* SIM: 1 micro-SIM card slot
* Buttons: Reset, WPS
* LEDs: power (G/B), internet (G), LTE (R/G/Orange), WiFi (G), voice (G)
* VoIP: 1 FXS RJ11 port
* Power: 12V, 2A

UART serial console:

57600,8N1
Unpopulated header J5:

 [o] GND
 [ ] key - no pin
 [o] RX
 [o] TX
 [o] 3.3V Vcc

Installation:

Noting the differences specified below, follow the steps from: 2449a63208 (ramips: mt7621: Add support for ZyXEL NR7101, 2021-04-19)

* Default OEM firmware IP is 192.168.1.1
* SSH is on port 22
* Bootloader TFTP server IP is 10.10.10.13

Unsupported:

* FXS/Voice

Please note that this PR depends on https://github.com/openwrt/firmware-utils/pull/17 being merged and firmware-tools version bumped to include it in order to build the final stage images.