### PR TITLE
mediatek: fix PCIe #PERST being de-asserted too early

### DIFF
--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -83,6 +83,8 @@ proto_qmi_setup() {
 
 	echo "Waiting for SIM initialization"
 	local uninitialized_timeout=0
+	# timeout 3s for first call to avoid hanging uqmi
+	uqmi -d "$device" --get-pin-status -t 3000 > /dev/null 2>&1
 	while uqmi -s -d "$device" --get-pin-status | grep '"UIM uninitialized"' > /dev/null; do
 		[ -e "$device" ] || return 1
 		if [ "$uninitialized_timeout" -lt "$timeout" -o "$timeout" = "0" ]; then

--- a/target/linux/mediatek/patches-5.15/611-pcie-mediatek-gen3-PERST-for-100ms.patch
+++ b/target/linux/mediatek/patches-5.15/611-pcie-mediatek-gen3-PERST-for-100ms.patch
@@ -1,0 +1,17 @@
+--- a/drivers/pci/controller/pcie-mediatek-gen3.c
++++ b/drivers/pci/controller/pcie-mediatek-gen3.c
+@@ -319,7 +319,13 @@ static int mtk_pcie_startup_port(struct
+ 	msleep(100);
+ 
+ 	/* De-assert reset signals */
+-	val &= ~(PCIE_MAC_RSTB | PCIE_PHY_RSTB | PCIE_BRG_RSTB | PCIE_PE_RSTB);
++	val &= ~(PCIE_MAC_RSTB | PCIE_PHY_RSTB | PCIE_BRG_RSTB);
++	writel_relaxed(val, port->base + PCIE_RST_CTRL_REG);
++
++	msleep(100);
++
++	/* De-assert PERST# signals */
++	val &= ~(PCIE_PE_RSTB);
+ 	writel_relaxed(val, port->base + PCIE_RST_CTRL_REG);
+ 
+ 	/* Check if the link is up or not */

--- a/target/linux/mediatek/patches-5.15/922-v6.1-PCI-mediatek-gen3-change-driver-name-to-mtk-pcie-gen.patch
+++ b/target/linux/mediatek/patches-5.15/922-v6.1-PCI-mediatek-gen3-change-driver-name-to-mtk-pcie-gen.patch
@@ -9,7 +9,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/pci/controller/pcie-mediatek-gen3.c
 +++ b/drivers/pci/controller/pcie-mediatek-gen3.c
-@@ -1025,7 +1025,7 @@ static struct platform_driver mtk_pcie_d
+@@ -1031,7 +1031,7 @@ static struct platform_driver mtk_pcie_d
  	.probe = mtk_pcie_probe,
  	.remove = mtk_pcie_remove,
  	.driver = {

--- a/target/linux/mediatek/patches-6.1/611-pcie-mediatek-gen3-PERST-for-100ms.patch
+++ b/target/linux/mediatek/patches-6.1/611-pcie-mediatek-gen3-PERST-for-100ms.patch
@@ -1,0 +1,19 @@
+--- a/drivers/pci/controller/pcie-mediatek-gen3.c
++++ b/drivers/pci/controller/pcie-mediatek-gen3.c
+@@ -350,9 +350,15 @@ static int mtk_pcie_startup_port(struct
+ 	msleep(100);
+ 
+ 	/* De-assert reset signals */
+-	val &= ~(PCIE_MAC_RSTB | PCIE_PHY_RSTB | PCIE_BRG_RSTB | PCIE_PE_RSTB);
++	val &= ~(PCIE_MAC_RSTB | PCIE_PHY_RSTB | PCIE_BRG_RSTB);
+ 	writel_relaxed(val, pcie->base + PCIE_RST_CTRL_REG);
+ 
++	msleep(100);
++
++	/* De-assert PERST# signals */
++	val &= ~(PCIE_PE_RSTB);
++	writel_relaxed(val, port->base + PCIE_RST_CTRL_REG);
++
+ 	/* Check if the link is up or not */
+ 	err = readl_poll_timeout(pcie->base + PCIE_LINK_STATUS_REG, val,
+ 				 !!(val & PCIE_PORT_LINKUP), 20,


### PR DESCRIPTION
The driver for MediaTek gen3 PCIe hosts de-asserts all reset signals at the same time using a single register write operation. Delay the de-assertion of the #PERST signal by 100ms as some PCIe devices fail to come up otherwise.

See also https://forum.banana-pi.org/t/bpi-r3-nvme-connection-issue/14563/15