### PR TITLE
uboot-mediatek: fix global pll clock override on mtk_spim

### DIFF
--- a/package/boot/uboot-mediatek/patches/131-spi-mtk_spim-prevent-global-pll-clock-override.patch
+++ b/package/boot/uboot-mediatek/patches/131-spi-mtk_spim-prevent-global-pll-clock-override.patch
@@ -1,0 +1,47 @@
+From 41f225dae30ea6ddcff10f120a9e732f994d3a07 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicol=C3=B2=20Veronese?= <nicveronese@gmail.com>
+Date: Tue, 3 Oct 2023 23:46:52 +0200
+Subject: [PATCH] spi: mtk_spim: prevent global pll clock override
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With commit 793e6230118032a099ec42a1ea67f434721edcc0
+ a new system to calculate the SPI clocks has been added.
+
+Unfortunately, the do_div macro overrides the global
+ priv->pll_clk_rate field. This will cause to have a reduced
+ clock rate on each subsequent SPI call.
+
+Signed-off-by: Valerio 'ftp21' Mancini <ftp21@ftp21.eu>
+Signed-off-by: Nicolò Veronese <nicveronese@gmail.com>
+---
+ drivers/spi/mtk_spim.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+--- a/drivers/spi/mtk_spim.c
++++ b/drivers/spi/mtk_spim.c
+@@ -409,7 +409,7 @@ static int mtk_spim_transfer_wait(struct
+ {
+ 	struct udevice *bus = dev_get_parent(slave->dev);
+ 	struct mtk_spim_priv *priv = dev_get_priv(bus);
+-	u32 sck_l, sck_h, clk_count, reg;
++	u32 pll_clk, sck_l, sck_h, clk_count, reg;
+ 	ulong us = 1;
+ 	int ret = 0;
+ 
+@@ -418,11 +418,12 @@ static int mtk_spim_transfer_wait(struct
+ 	else
+ 		clk_count = op->data.nbytes;
+ 
++	pll_clk = priv->pll_clk_rate;
+ 	sck_l = readl(priv->base + SPI_CFG2_REG) >> SPI_CFG2_SCK_LOW_OFFSET;
+ 	sck_h = readl(priv->base + SPI_CFG2_REG) & SPI_CFG2_SCK_HIGH_MASK;
+-	do_div(priv->pll_clk_rate, sck_l + sck_h + 2);
++	do_div(pll_clk, sck_l + sck_h + 2);
+ 
+-	us = CLK_TO_US(priv->pll_clk_rate, clk_count * 8);
++	us = CLK_TO_US(pll_clk, clk_count * 8);
+ 	us += 1000 * 1000; /* 1s tolerance */
+ 
+ 	if (us > UINT_MAX)


### PR DESCRIPTION
With patch 101-03-spi-mtk_spim-get-spi-clk-rate-only-once.patch
 a new system to calculate the SPI clocks has been added.

Unfortunately, the do_div macro overrides the global
 priv->pll_clk_rate field. This will cause to have a reduced
 clock rate on each subsequent SPI call.
 
 The patch has already been pushed to mainline:
 https://lists.denx.de/pipermail/u-boot/2023-October/532673.html