### PR TITLE
mvebu: add support for Fortinet FortiGate 30E

### DIFF
--- a/target/linux/mvebu/cortexa9/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/cortexa9/base-files/etc/board.d/02_network
@@ -18,12 +18,7 @@ mvebu_setup_interfaces()
 	cznic,turris-omnia)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3 lan4" "eth2"
 		;;
-	fortinet,fg-50e)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "eth1 eth2"
-		;;
-	iptime,nas1dual)
-		ucidef_set_interface_lan "eth0 eth1" "dhcp"
-		;;
+	fortinet,fg-30e|\
 	linksys,wrt1200ac|\
 	linksys,wrt1900ac-v1|\
 	linksys,wrt1900ac-v2|\
@@ -31,6 +26,12 @@ mvebu_setup_interfaces()
 	linksys,wrt3200acm|\
 	linksys,wrt32x)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
+		;;
+	fortinet,fg-50e)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "eth1 eth2"
+		;;
+	iptime,nas1dual)
+		ucidef_set_interface_lan "eth0 eth1" "dhcp"
 		;;
 	marvell,a385-db-ap)
 		ucidef_set_interfaces_lan_wan "eth0 eth1" "eth2"

--- a/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
@@ -52,6 +52,7 @@ platform_do_upgrade() {
 	solidrun,clearfog-pro-a1)
 		legacy_sdcard_do_upgrade "$1"
 		;;
+	fortinet,fg-30e|\
 	fortinet,fg-50e)
 		fortinet_do_upgrade "$1"
 		;;

--- a/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-fortinet-fg-30e.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-fortinet-fg-30e.dts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "armada-385-fortinet-fg-x0e.dtsi"
+
+/ {
+	model = "Fortinet FortiGate 30E";
+	compatible = "fortinet,fg-30e", "marvell,armada385", "marvell,armada380";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x40000000>; /* 1GB */
+	};
+};
+
+&gpio_leds {
+	led-14 {
+		label = "amber:speed_wan";
+		gpios = <&gpio2 2 GPIO_ACTIVE_HIGH>;
+		color = <LED_COLOR_ID_AMBER>;
+		linux,default-trigger = "mv88e6xxx-1:00:100Mbps";
+	};
+
+	led-15 {
+		label = "green:speed_wan";
+		gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>;
+		color = <LED_COLOR_ID_GREEN>;
+		linux,default-trigger = "mv88e6xxx-1:00:1Gbps";
+	};
+};
+
+&pinctrl {
+	pmx_switch_pins: switch-pins {
+		marvell,pins = "mpp19";
+		marvell,function = "gpio";
+	};
+};
+
+&mdio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>, <&pmx_switch_pins>;
+
+	/* Marvell 88E6176 */
+	switch@2 {
+		compatible = "marvell,mv88e6085";
+		reg = <0x2>;
+		reset-gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "wan";
+				nvmem-cells = <&macaddr_bdinfo_d880>;
+				nvmem-cell-names = "mac-address";
+				mac-address-increment = <1>;
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan4";
+				nvmem-cells = <&macaddr_bdinfo_d880>;
+				nvmem-cell-names = "mac-address";
+				mac-address-increment = <5>;
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+				nvmem-cells = <&macaddr_bdinfo_d880>;
+				nvmem-cell-names = "mac-address";
+				mac-address-increment = <4>;
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan2";
+				nvmem-cells = <&macaddr_bdinfo_d880>;
+				nvmem-cell-names = "mac-address";
+				mac-address-increment = <3>;
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "lan1";
+				nvmem-cells = <&macaddr_bdinfo_d880>;
+				nvmem-cell-names = "mac-address";
+				mac-address-increment = <2>;
+			};
+
+			port@6 {
+				reg = <6>;
+				ethernet = <&eth0>;
+				phy-connection-type = "rgmii-id";
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};

--- a/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-fortinet-fg-50e.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-fortinet-fg-50e.dts
@@ -1,263 +1,51 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-/dts-v1/;
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
-#include "armada-385.dtsi"
+#include "armada-385-fortinet-fg-x0e.dtsi"
 
 / {
 	model = "Fortinet FortiGate 50E";
 	compatible = "fortinet,fg-50e", "marvell,armada385", "marvell,armada380";
 
-	aliases {
-		led-boot = &led_status_green;
-		led-failsafe = &led_status_red;
-		led-running = &led_status_green;
-		led-upgrade = &led_status_green;
-		label-mac-device = &eth0;
-	};
-
-	chosen {
-		stdout-path = "serial0:9600n8";
-	};
-
 	memory@0 {
 		device_type = "memory";
 		reg = <0x00000000 0x80000000>; /* 2GB */
 	};
-
-	soc {
-		ranges = <MBUS_ID(0xf0, 0x01) 0 0xf1000000 0x100000
-			  MBUS_ID(0x01, 0x1d) 0 0xfff00000 0x100000
-			  MBUS_ID(0x09, 0x19) 0 0xf1100000 0x10000
-			  MBUS_ID(0x09, 0x15) 0 0xf1110000 0x10000
-			  MBUS_ID(0x0c, 0x04) 0 0xf1200000 0x100000>;
-	};
-
-	gpio-keys {
-		compatible = "gpio-keys";
-		pinctrl-names = "default";
-		pinctrl-0 = <&pmx_gpio_keys_pins>;
-
-		reset {
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio1 22 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	gpio-leds {
-		compatible = "gpio-leds";
-		pinctrl-names = "default";
-		pinctrl-0 = <&pmx_gpio_leds_pins>;
-
-		led-0 {
-			label = "red:alarm";
-			gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_ALARM;
-		};
-
-		led-1 {
-			label = "red:ha";
-			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_RED>;
-		};
-
-		led_status_green: led-2 {
-			label = "green:sta";
-			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-		};
-
-		led-3 {
-			label = "green:ha";
-			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_GREEN>;
-		};
-
-		led-4 {
-			label = "amber:alarm";
-			gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_AMBER>;
-			function = LED_FUNCTION_ALARM;
-		};
-
-		led_status_red: led-5 {
-			label = "red:sta";
-			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_STATUS;
-		};
-
-		led-6 {
-			label = "green:speed_wan1";
-			gpios = <&gpio2 0 GPIO_ACTIVE_HIGH>;
-			color = <LED_COLOR_ID_GREEN>;
-			linux,default-trigger = "f1072004.mdio-mii:00:1Gbps";
-		};
-
-		led-7 {
-			label = "green:speed_wan2";
-			gpios = <&gpio2 1 GPIO_ACTIVE_HIGH>;
-			color = <LED_COLOR_ID_GREEN>;
-			linux,default-trigger = "f1072004.mdio-mii:01:1Gbps";
-		};
-
-		led-8 {
-			label = "amber:speed_lan5";
-			gpios = <&gpio2 2 GPIO_ACTIVE_HIGH>;
-			color = <LED_COLOR_ID_AMBER>;
-			linux,default-trigger = "mv88e6xxx-1:00:100Mbps";
-		};
-
-		led-9 {
-			label = "green:speed_lan5";
-			gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>;
-			color = <LED_COLOR_ID_GREEN>;
-			linux,default-trigger = "mv88e6xxx-1:00:1Gbps";
-		};
-
-		led-10 {
-			label = "green:speed_lan4";
-			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_GREEN>;
-			linux,default-trigger = "mv88e6xxx-1:01:1Gbps";
-		};
-
-		led-11 {
-			label = "amber:speed_lan4";
-			gpios = <&gpio2 5 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_AMBER>;
-			linux,default-trigger = "mv88e6xxx-1:01:100Mbps";
-		};
-
-		led-12 {
-			label = "amber:speed_lan3";
-			gpios = <&gpio2 6 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_AMBER>;
-			linux,default-trigger = "mv88e6xxx-1:02:100Mbps";
-		};
-
-		led-13 {
-			label = "green:speed_lan3";
-			gpios = <&gpio2 7 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_GREEN>;
-			linux,default-trigger = "mv88e6xxx-1:02:1Gbps";
-		};
-
-		led-14 {
-			label = "green:speed_lan1";
-			gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_GREEN>;
-			linux,default-trigger = "mv88e6xxx-1:04:1Gbps";
-		};
-
-		led-15 {
-			label = "amber:speed_lan1";
-			gpios = <&gpio2 13 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_AMBER>;
-			linux,default-trigger = "mv88e6xxx-1:04:100Mbps";
-		};
-
-		led-16 {
-			label = "green:speed_lan2";
-			gpios = <&gpio2 14 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_GREEN>;
-			linux,default-trigger = "mv88e6xxx-1:03:1Gbps";
-		};
-
-		led-17 {
-			label = "amber:speed_lan2";
-			gpios = <&gpio2 15 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_AMBER>;
-			linux,default-trigger = "mv88e6xxx-1:03:100Mbps";
-		};
-	};
-
-	reg_usb_vbus: regulator-usb-vbus {
-		compatible = "fixed-regulator";
-		regulator-name = "usb-vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio1 21 GPIO_ACTIVE_LOW>;
-		regulator-always-on;
-	};
 };
 
-&i2c0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&i2c0_pins>;
-	status = "okay";
-
-	gpio2: gpio@24 {
-		compatible = "nxp,pca9555";
-		reg = <0x24>;
-		gpio-controller;
-		#gpio-cells = <0x2>;
+&gpio_leds {
+	led-14 {
+		label = "green:speed_wan1";
+		gpios = <&gpio2 0 GPIO_ACTIVE_HIGH>;
+		color = <LED_COLOR_ID_GREEN>;
+		linux,default-trigger = "f1072004.mdio-mii:00:1Gbps";
 	};
 
-	hwmon@28 {
-		compatible = "nuvoton,nct7802";
-		reg = <0x28>;
+	led-15 {
+		label = "green:speed_wan2";
+		gpios = <&gpio2 1 GPIO_ACTIVE_HIGH>;
+		color = <LED_COLOR_ID_GREEN>;
+		linux,default-trigger = "f1072004.mdio-mii:01:1Gbps";
 	};
-};
 
-&uart0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&uart0_pins>;
-	status = "okay";
+	led-16 {
+		label = "amber:speed_lan5";
+		gpios = <&gpio2 2 GPIO_ACTIVE_HIGH>;
+		color = <LED_COLOR_ID_AMBER>;
+		linux,default-trigger = "mv88e6xxx-1:00:100Mbps";
+	};
+
+	led-17 {
+		label = "green:speed_lan5";
+		gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>;
+		color = <LED_COLOR_ID_GREEN>;
+		linux,default-trigger = "mv88e6xxx-1:00:1Gbps";
+	};
 };
 
 &pinctrl {
 	pmx_phy_switch_pins: phy-switch-pins {
 		marvell,pins = "mpp19", "mpp20", "mpp23", "mpp34", "mpp41";
 		marvell,function = "gpio";
-	};
-
-	pmx_gpio_leds_pins: gpio-leds-pins {
-		marvell,pins = "mpp30", "mpp32", "mpp33", "mpp35",
-			       "mpp45", "mpp47";
-		marvell,function = "gpio";
-	};
-
-	pmx_usb_pins: usb-pins {
-		marvell,pins = "mpp53";
-		marvell,function = "gpio";
-	};
-
-	pmx_gpio_keys_pins: gpio-keys-pins {
-		marvell,pins = "mpp54";
-		marvell,function = "gpio";
-	};
-};
-
-&bm {
-	status = "okay";
-};
-
-&bm_bppi {
-	status = "okay";
-};
-
-&eth0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&ge0_rgmii_pins>;
-	status = "okay";
-
-	phy-connection-type = "rgmii-id";
-	buffer-manager = <&bm>;
-	bm,pool-long = <0>;
-	bm,pool-short = <1>;
-	nvmem-cells = <&macaddr_bdinfo_d880>;
-	nvmem-cell-names = "mac-address";
-
-	fixed-link {
-		speed = <1000>;
-		full-duplex;
 	};
 };
 
@@ -384,123 +172,6 @@
 					speed = <1000>;
 					full-duplex;
 				};
-			};
-		};
-	};
-};
-
-&usb3_0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pmx_usb_pins>;
-	status = "okay";
-
-	vbus-supply = <&reg_usb_vbus>;
-};
-
-&spi1 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&spi1_pins>;
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <50000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				reg = <0x0 0x1c0000>;
-				label = "u-boot";
-				read-only;
-			};
-
-			partition@1c0000 {
-				reg = <0x1c0000 0x10000>;
-				label = "firmware-info";
-
-				/*
-				 *  0x10 - 0x2f : image name (image1)
-				 *  0x30 - 0x4f : image name (image2)
-				 * 0x170 (1byte): active image (0x0/0x1)
-				 * 0x184 - 0x185: kernel block count (image1)
-				 * 0x18c - 0x18d: rootfs block count (image1)
-				 * 0x194 - 0x195: kernel block count (image2)
-				 * 0x19c - 0x19d: rootfs block count (image2)
-				 * 0x1be (1byte): bit7 -> active flag (image1)?
-				 * 0x1ce (1byte): bit7 -> active flag (image2)?
-				 *
-				 * Note: block size --> 0x200 (512 bytes)
-				 */
-			};
-
-			partition@1d0000 {
-				reg = <0x1d0000 0x10000>;
-				label = "dtb";
-				read-only;
-			};
-
-			partition@1e0000 {
-				reg = <0x1e0000 0x10000>;
-				label = "u-boot-env";
-				read-only;
-			};
-
-			partition@1f0000 {
-				reg = <0x1f0000 0x10000>;
-				label = "board-info";
-				read-only;
-
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				macaddr_bdinfo_d880: macaddr@d880 {
-					reg = <0xd880 0x6>;
-				};
-			};
-
-			partition@200000 {
-				reg = <0x200000 0x600000>;
-				label = "kernel";
-			};
-
-			partition@800000 {
-				reg = <0x800000 0x1800000>;
-				label = "rootfs";
-			};
-
-			partition@2000000 {
-				reg = <0x2000000 0x600000>;
-				label = "kn2";
-				read-only;
-			};
-
-			partition@2600000 {
-				reg = <0x2600000 0x1800000>;
-				label = "rfs2";
-				read-only;
-			};
-
-			partition@3e00000 {
-				reg = <0x3e00000 0x1200000>;
-				label = "part1";
-				read-only;
-			};
-
-			partition@5000000 {
-				reg = <0x5000000 0x1200000>;
-				label = "part2";
-				read-only;
-			};
-
-			partition@6200000 {
-				reg = <0x6200000 0x1e00000>;
-				label = "config";
-				read-only;
 			};
 		};
 	};

--- a/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-fortinet-fg-x0e.dtsi
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-fortinet-fg-x0e.dtsi
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include "armada-385.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+		label-mac-device = &eth0;
+	};
+
+	chosen {
+		stdout-path = "serial0:9600n8";
+	};
+
+	soc {
+		ranges = <MBUS_ID(0xf0, 0x01) 0 0xf1000000 0x100000
+			  MBUS_ID(0x01, 0x1d) 0 0xfff00000 0x100000
+			  MBUS_ID(0x09, 0x19) 0 0xf1100000 0x10000
+			  MBUS_ID(0x09, 0x15) 0 0xf1110000 0x10000
+			  MBUS_ID(0x0c, 0x04) 0 0xf1200000 0x100000>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pmx_gpio_keys_pins>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio1 22 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio_leds: gpio-leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pmx_gpio_leds_pins>;
+
+		led-0 {
+			label = "red:alarm";
+			gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_ALARM;
+		};
+
+		led-1 {
+			label = "red:ha";
+			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+		};
+
+		led_status_green: led-2 {
+			label = "green:sta";
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led-3 {
+			label = "green:ha";
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+
+		led-4 {
+			label = "amber:alarm";
+			gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_ALARM;
+		};
+
+		led_status_red: led-5 {
+			label = "red:sta";
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led-6 {
+			label = "green:speed_lan4";
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			linux,default-trigger = "mv88e6xxx-1:01:1Gbps";
+		};
+
+		led-7 {
+			label = "amber:speed_lan4";
+			gpios = <&gpio2 5 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_AMBER>;
+			linux,default-trigger = "mv88e6xxx-1:01:100Mbps";
+		};
+
+		led-8 {
+			label = "amber:speed_lan3";
+			gpios = <&gpio2 6 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_AMBER>;
+			linux,default-trigger = "mv88e6xxx-1:02:100Mbps";
+		};
+
+		led-9 {
+			label = "green:speed_lan3";
+			gpios = <&gpio2 7 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			linux,default-trigger = "mv88e6xxx-1:02:1Gbps";
+		};
+
+		led-10 {
+			label = "green:speed_lan1";
+			gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			linux,default-trigger = "mv88e6xxx-1:04:1Gbps";
+		};
+
+		led-11 {
+			label = "amber:speed_lan1";
+			gpios = <&gpio2 13 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_AMBER>;
+			linux,default-trigger = "mv88e6xxx-1:04:100Mbps";
+		};
+
+		led-12 {
+			label = "green:speed_lan2";
+			gpios = <&gpio2 14 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			linux,default-trigger = "mv88e6xxx-1:03:1Gbps";
+		};
+
+		led-13 {
+			label = "amber:speed_lan2";
+			gpios = <&gpio2 15 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_AMBER>;
+			linux,default-trigger = "mv88e6xxx-1:03:100Mbps";
+		};
+	};
+
+	reg_usb_vbus: regulator-usb-vbus {
+		compatible = "fixed-regulator";
+		regulator-name = "usb-vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio1 21 GPIO_ACTIVE_LOW>;
+		regulator-always-on;
+	};
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+	status = "okay";
+
+	gpio2: gpio@24 {
+		compatible = "nxp,pca9555";
+		reg = <0x24>;
+		gpio-controller;
+		#gpio-cells = <0x2>;
+	};
+
+	hwmon@28 {
+		compatible = "nuvoton,nct7802";
+		reg = <0x28>;
+	};
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+	status = "okay";
+};
+
+&pinctrl {
+	pmx_gpio_leds_pins: gpio-leds-pins {
+		marvell,pins = "mpp30", "mpp32", "mpp33", "mpp35",
+			       "mpp45", "mpp47";
+		marvell,function = "gpio";
+	};
+
+	pmx_usb_pins: usb-pins {
+		marvell,pins = "mpp53";
+		marvell,function = "gpio";
+	};
+
+	pmx_gpio_keys_pins: gpio-keys-pins {
+		marvell,pins = "mpp54";
+		marvell,function = "gpio";
+	};
+};
+
+&bm {
+	status = "okay";
+};
+
+&bm_bppi {
+	status = "okay";
+};
+
+&eth0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&ge0_rgmii_pins>;
+	status = "okay";
+
+	phy-connection-type = "rgmii-id";
+	buffer-manager = <&bm>;
+	bm,pool-long = <0>;
+	bm,pool-short = <1>;
+	nvmem-cells = <&macaddr_bdinfo_d880>;
+	nvmem-cell-names = "mac-address";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&usb3_0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pmx_usb_pins>;
+	status = "okay";
+
+	vbus-supply = <&reg_usb_vbus>;
+};
+
+&spi1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi1_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x1c0000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			partition@1c0000 {
+				reg = <0x1c0000 0x10000>;
+				label = "firmware-info";
+
+				/*
+				 *  0x10 - 0x2f : image name (image1)
+				 *  0x30 - 0x4f : image name (image2)
+				 * 0x170 (1byte): active image (0x0/0x1)
+				 * 0x184 - 0x185: kernel block count (image1)
+				 * 0x18c - 0x18d: rootfs block count (image1)
+				 * 0x194 - 0x195: kernel block count (image2)
+				 * 0x19c - 0x19d: rootfs block count (image2)
+				 * 0x1be (1byte): bit7 -> active flag (image1)?
+				 * 0x1ce (1byte): bit7 -> active flag (image2)?
+				 *
+				 * Note: block size --> 0x200 (512 bytes)
+				 */
+			};
+
+			partition@1d0000 {
+				reg = <0x1d0000 0x10000>;
+				label = "dtb";
+				read-only;
+			};
+
+			partition@1e0000 {
+				reg = <0x1e0000 0x10000>;
+				label = "u-boot-env";
+				read-only;
+			};
+
+			partition@1f0000 {
+				reg = <0x1f0000 0x10000>;
+				label = "board-info";
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_bdinfo_d880: macaddr@d880 {
+					reg = <0xd880 0x6>;
+				};
+			};
+
+			partition@200000 {
+				reg = <0x200000 0x600000>;
+				label = "kernel";
+			};
+
+			partition@800000 {
+				reg = <0x800000 0x1800000>;
+				label = "rootfs";
+			};
+
+			partition@2000000 {
+				reg = <0x2000000 0x600000>;
+				label = "kn2";
+				read-only;
+			};
+
+			partition@2600000 {
+				reg = <0x2600000 0x1800000>;
+				label = "rfs2";
+				read-only;
+			};
+
+			partition@3e00000 {
+				reg = <0x3e00000 0x1200000>;
+				label = "part1";
+				read-only;
+			};
+
+			partition@5000000 {
+				reg = <0x5000000 0x1200000>;
+				label = "part2";
+				read-only;
+			};
+
+			partition@6200000 {
+				reg = <0x6200000 0x1e00000>;
+				label = "config";
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -95,6 +95,21 @@ define Device/cznic_turris-omnia
 endef
 TARGET_DEVICES += cznic_turris-omnia
 
+define Device/fortinet_fg-30e
+  DEVICE_VENDOR := Fortinet
+  DEVICE_MODEL := FortiGate 30E
+  SOC := armada-385
+  KERNEL := kernel-bin | append-dtb
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | fortigate-header | \
+    gzip-filename FGT30E
+  KERNEL_SIZE := 6144k
+  DEVICE_DTS := armada-385-fortinet-fg-30e
+  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | \
+    sysupgrade-tar rootfs=$$$$@ | append-metadata
+  DEVICE_PACKAGES := kmod-hwmon-nct7802
+endef
+TARGET_DEVICES += fortinet_fg-30e
+
 define Device/fortinet_fg-50e
   DEVICE_VENDOR := Fortinet
   DEVICE_MODEL := FortiGate 50E


### PR DESCRIPTION
Fortinet FortiGate 30E (FG-30E) is a UTM, based on Armada 385 (88F6820).

Specification:

- SoC          : Marvell Armada 385 88F6820
- RAM          : DDR3 1 GiB (4x Micron MT41K256M8DA-125, "D9PSH")
- Flash        : SPI-NOR 128 MiB (Macronix MX66L1G45GMI-10G)
- Ethernet     : 5x 10/100/1000 Mbps
  - Switch     : Marvell 88E6176
- LEDs/Keys    : 16x/1x
- UART         : "CONSOLE" port (RJ-45, RS-232C level)
  - port       : ttyS0
  - settings   : 9600bps 8n1
  - assignment : 1:NC , 2:NC , 3:TXD, 4:GND,
                5:GND, 6:RXD, 7:NC , 8:NC
  - note       : compatible with Cisco console cable
- HW Monitoring: nuvoTon NCT7802Y
- Power        : 12 VDC, 2 A
  - plug       : Modex 5557-02R

Flash instruction using initramfs image:

 1. Power on FG-30E and interrupt to show bootmenu
 2. Call "[I]: System information." -> "[S]: Set serial port baudrate." and set baudrate to 9600 bps
 3. Call "[R]: Review TFTP parameters.", check TFTP parameters and connect computer to "Image download port" in the parameters
 4. Prepare TFTP server with the parameters obtained above
 5. Rename OpenWrt initramfs image to "image.out" and put to TFTP directory
 6. Call "[T]: Initiate TFTP firmware transfer." to download initramfs image from TFTP server
 7. Type "r" key when the following message is showed, to boot initramfs image without flashing to spi-nor flash

    "Save as Default firmware/Backup firmware/Run image without saving:[D/B/R]?"

 8. On initramfs image, backup mtd if needed

    minimum:

    - "firmware-info"
    - "kernel"
    - "rootfs"

 9. On initramfs image, upload sysupgrade image to the device and perform sysupgrade
10. Wait ~200 seconds to complete flashing and rebooting. If the device is booted with stock firmware, login to bootmenu and call "[B]: Boot with backup firmware and set as default." to set the first OS image as default and boot it.

Notes:

- Both colors of Bi-color LEDs on the front panel cannot be turned on at the same time.

- "PWR" and "Logo" LEDs are connected to power source directly.

- The following partitions are added for OpenWrt. These partitions are contained in "uboot" partition (0x0-0x1fffff) on stock firmware.

  - "firmware-info"
  - "dtb"
  - "u-boot-env"
  - "board-info"

Image header for bootmenu tftp:

```
  0x0 - 0xf  : ?
 0x10 - 0x2f : Image Name
 0x30 - 0x17f: ?
0x180 - 0x183: Kernel Offset*
0x184 - 0x187: Kernel Length*
0x188 - 0x18b: RootFS Offset (ext2)*
0x18c - 0x18f: RootFS Length (ext2)*
0x190 - 0x193: DTB Offset
0x194 - 0x197: DTB Length
0x198 - 0x19b: Data Offset (jffs2)
0x19c - 0x19f: Data Length (jffs2)
0x1a0 - 0x1ff: ?
```

*: required for initramfs image

MAC addresses:

```
(eth0): 70:4C:A5:xx:xx:CE (board-info, 0xd880 (hex))
WAN   : 70:4C:A5:xx:xx:CF
LAN 1 : 70:4C:A5:xx:xx:D0
LAN 2 : 70:4C:A5:xx:xx:D1
LAN 3 : 70:4C:A5:xx:xx:D2
LAN 4 : 70:4C:A5:xx:xx:D3
```
