### PR TITLE
generic: rtl8366_smi: rename and drop conflicting vlan GPL symbols

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/rtl8366_smi.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366_smi.c
@@ -590,7 +590,7 @@ static int rtl8366_set_pvid(struct rtl8366_smi *smi, unsigned port,
 	return -ENOSPC;
 }
 
-int rtl8366_enable_vlan(struct rtl8366_smi *smi, int enable)
+static int rtl8366_smi_enable_vlan(struct rtl8366_smi *smi, int enable)
 {
 	int err;
 
@@ -607,9 +607,8 @@ int rtl8366_enable_vlan(struct rtl8366_smi *smi, int enable)
 
 	return err;
 }
-EXPORT_SYMBOL_GPL(rtl8366_enable_vlan);
 
-static int rtl8366_enable_vlan4k(struct rtl8366_smi *smi, int enable)
+static int rtl8366_smi_enable_vlan4k(struct rtl8366_smi *smi, int enable)
 {
 	int err;
 
@@ -629,7 +628,7 @@ static int rtl8366_enable_vlan4k(struct rtl8366_smi *smi, int enable)
 	return 0;
 }
 
-int rtl8366_enable_all_ports(struct rtl8366_smi *smi, int enable)
+static int rtl8366_smi_enable_all_ports(struct rtl8366_smi *smi, int enable)
 {
 	int port;
 	int err;
@@ -642,16 +641,15 @@ int rtl8366_enable_all_ports(struct rtl8366_smi *smi, int enable)
 
 	return 0;
 }
-EXPORT_SYMBOL_GPL(rtl8366_enable_all_ports);
 
-int rtl8366_reset_vlan(struct rtl8366_smi *smi)
+static int rtl8366_smi_reset_vlan(struct rtl8366_smi *smi)
 {
 	struct rtl8366_vlan_mc vlanmc;
 	int err;
 	int i;
 
-	rtl8366_enable_vlan(smi, 0);
-	rtl8366_enable_vlan4k(smi, 0);
+	rtl8366_smi_enable_vlan(smi, 0);
+	rtl8366_smi_enable_vlan4k(smi, 0);
 
 	/* clear VLAN member configurations */
 	vlanmc.vid = 0;
@@ -667,14 +665,13 @@ int rtl8366_reset_vlan(struct rtl8366_smi *smi)
 
 	return 0;
 }
-EXPORT_SYMBOL_GPL(rtl8366_reset_vlan);
 
 static int rtl8366_init_vlan(struct rtl8366_smi *smi)
 {
 	int port;
 	int err;
 
-	err = rtl8366_reset_vlan(smi);
+	err = rtl8366_smi_reset_vlan(smi);
 	if (err)
 		return err;
 
@@ -695,7 +692,7 @@ static int rtl8366_init_vlan(struct rtl8366_smi *smi)
 			return err;
 	}
 
-	return rtl8366_enable_vlan(smi, 1);
+	return rtl8366_smi_enable_vlan(smi, 1);
 }
 
 #ifdef CONFIG_RTL8366_SMI_DEBUG_FS
@@ -1073,15 +1070,15 @@ int rtl8366_sw_reset_switch(struct switch_dev *dev)
 	if (err)
 		return err;
 
-	err = rtl8366_reset_vlan(smi);
+	err = rtl8366_smi_reset_vlan(smi);
 	if (err)
 		return err;
 
-	err = rtl8366_enable_vlan(smi, 1);
+	err = rtl8366_smi_enable_vlan(smi, 1);
 	if (err)
 		return err;
 
-	return rtl8366_enable_all_ports(smi, 1);
+	return rtl8366_smi_enable_all_ports(smi, 1);
 }
 EXPORT_SYMBOL_GPL(rtl8366_sw_reset_switch);
 
@@ -1343,9 +1340,9 @@ int rtl8366_sw_set_vlan_enable(struct switch_dev *dev,
 		return -EINVAL;
 
 	if (attr->ofs == 1)
-		err = rtl8366_enable_vlan(smi, val->value.i);
+		err = rtl8366_smi_enable_vlan(smi, val->value.i);
 	else
-		err = rtl8366_enable_vlan4k(smi, val->value.i);
+		err = rtl8366_smi_enable_vlan4k(smi, val->value.i);
 
 	return err;
 }
@@ -1494,7 +1491,7 @@ int rtl8366_smi_init(struct rtl8366_smi *smi)
 		goto err_free_sck;
 	}
 
-	err = rtl8366_enable_all_ports(smi, 1);
+	err = rtl8366_smi_enable_all_ports(smi, 1);
 	if (err)
 		goto err_free_sck;
 

--- a/target/linux/generic/files/drivers/net/phy/rtl8366_smi.h
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366_smi.h
@@ -115,10 +115,6 @@ int rtl8366_smi_write_reg_noack(struct rtl8366_smi *smi, u32 addr, u32 data);
 int rtl8366_smi_read_reg(struct rtl8366_smi *smi, u32 addr, u32 *data);
 int rtl8366_smi_rmwr(struct rtl8366_smi *smi, u32 addr, u32 mask, u32 data);
 
-int rtl8366_reset_vlan(struct rtl8366_smi *smi);
-int rtl8366_enable_vlan(struct rtl8366_smi *smi, int enable);
-int rtl8366_enable_all_ports(struct rtl8366_smi *smi, int enable);
-
 #ifdef CONFIG_RTL8366_SMI_DEBUG_FS
 int rtl8366_debugfs_open(struct inode *inode, struct file *file);
 #endif


### PR DESCRIPTION
Symbol rtl8366_enable_vlan and rtl8366_reset_vlan are also present in the DSA driver upstream and conflicts as they are EXPORTED.

Rename them to rtl8366_smi_enable_vlan and rtl8366_smi_reset_vlan to fix the conflict. While at it also make them static and drop the EXPORT_SYMBOL_GPL as they are not actually used by any other driver and exporting them is useless.