### PR TITLE
mediatek/filogic: rename `eth1` to `sfp1` on `banana-pi-r3`

### DIFF
--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -21,7 +21,8 @@ mediatek_setup_interfaces()
 		ucidef_set_interface_lan "eth0"
 		;;
 	bananapi,bpi-r3)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp2" "eth1 wan"
+		ucidef_set_network_device_path "sfp1" "eth1"
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp2" "sfp1 wan"
 		;;
 	cudy,wr3000-v1)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"


### PR DESCRIPTION
This renames ambigious eth1 to become sfp1 to bring clarity about what was eth1.

The usage of eth1 is easily to be confused with eth0 which is a CPU port of a internal switch chip.
