### PR TITLE
generic: 6.1: add patch enabling assisted learning for qca8k

### DIFF
--- a/target/linux/generic/pending-6.1/712-net-dsa-qca8k-enable-assisted-learning-on-CPU-port.patch
+++ b/target/linux/generic/pending-6.1/712-net-dsa-qca8k-enable-assisted-learning-on-CPU-port.patch
@@ -1,0 +1,57 @@
+From 0f6599167c126ce32c85d4f8a1f3d1775a268572 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Fri, 6 Oct 2023 12:44:00 +0200
+Subject: [PATCH] net: dsa: qca8k: enable assisted learning on CPU port
+
+Enable assisted learning on CPU port.
+
+It has been verified that there is a problem in packet roaming
+from one BSS to another in the same security settings from one
+physical R7800 to another physical R7800 where they are in the
+same L2 broadcast domain backhauled/linked together via one
+of the ethernet ports.
+DHCP will fail to complete and traffic cannot flow for around 300
+seconds.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/net/dsa/qca/qca8k-8xxx.c | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+--- a/drivers/net/dsa/qca/qca8k-8xxx.c
++++ b/drivers/net/dsa/qca/qca8k-8xxx.c
+@@ -1991,6 +1991,12 @@ qca8k_setup(struct dsa_switch *ds)
+ 			dev_err(priv->dev, "failed enabling QCA header mode on port %d", dp->index);
+ 			return ret;
+ 		}
++
++		/* Disable learning by default on all ports */
++		ret = regmap_clear_bits(priv->regmap, QCA8K_PORT_LOOKUP_CTRL(dp->index),
++								QCA8K_PORT_LOOKUP_LEARN);
++		if (ret)
++			return ret;
+ 	}
+ 
+ 	/* Forward all unknown frames to CPU port for Linux processing */
+@@ -2020,11 +2026,6 @@ qca8k_setup(struct dsa_switch *ds)
+ 		if (ret)
+ 			return ret;
+ 
+-		ret = regmap_clear_bits(priv->regmap, QCA8K_PORT_LOOKUP_CTRL(port),
+-					QCA8K_PORT_LOOKUP_LEARN);
+-		if (ret)
+-			return ret;
+-
+ 		/* For port based vlans to work we need to set the
+ 		 * default egress vid
+ 		 */
+@@ -2076,6 +2077,9 @@ qca8k_setup(struct dsa_switch *ds)
+ 	/* Set max number of LAGs supported */
+ 	ds->num_lag_ids = QCA8K_NUM_LAGS;
+ 
++	/* HW learn on CPU port is limited and require manual setting */
++	ds->assisted_learning_on_cpu_port = true;
++
+ 	return 0;
+ }
+ 


### PR DESCRIPTION
Add patch enabling assisted learning for qca8k to fix roaming issue between BSS and BSS on the same L2 broadcast domain.

@nicklowe Can you test?