### PR TITLE
x86: base-files improve sophos devices support

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -45,28 +45,78 @@ roqos-roqos-core-rc10)
 	;;
 sophos-sg-105r1|sophos-xg-105r1| \
 sophos-sg-105wr1|sophos-xg-105wr1| \
-sophos-sg-105r2|sophos-xg-105r2| \
-sophos-sg-105wr2|sophos-xg-105wr2| \
 sophos-sg-115r1|sophos-xg-115r1| \
 sophos-sg-115wr1|sophos-xg-115wr1| \
-sophos-sg-115r2|sophos-xg-115r2| \
-sophos-sg-115wr2|sophos-xg-115wr2| \
 sophos-xg-85*|sophos-xg-86*)
 	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3" "eth1"
 	;;
 sophos-sg-125r1|sophos-xg-125r1| \
 sophos-sg-125wr1|sophos-xg-125wr1| \
-sophos-sg-125r2|sophos-xg-125r2| \
-sophos-sg-125wr2|sophos-xg-125wr2| \
 sophos-sg-135r1|sophos-xg-135r1| \
-sophos-sg-135wr1|sophos-xg-135wr1| \
-sophos-sg-135r2|sophos-xg-135r2| \
-sophos-sg-135wr2|sophos-xg-135wr2)
+sophos-sg-135wr1|sophos-xg-135wr1)
 	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3 eth4 eth5 eth6 eth7" "eth1"
 	;;
-sophos-sg-135r3|sophos-xg-135r3| \
-sophos-sg-135wr3|sophos-xg-135wr3)
-	ucidef_set_interfaces_lan_wan "eth0 eth1 eth2 eth3 eth5 eth7 eth8" "eth6"
+sophos-sg-105r2|sophos-sg-105wr2| \
+sophos-sg-115r2|sophos-sg-115wr2)
+	ucidef_set_network_device_path "eth0" "pci0000:00/0000:00:1c.0/0000:01:00.0"
+	ucidef_set_network_device_path "wan"  "pci0000:00/0000:00:1c.1/0000:02:00.0"
+	ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:1c.2/0000:03:00.0"
+	ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:1c.3/0000:04:00.0/0000:05:01.0/0000:06:00.0"
+	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3" "wan"
+	;;
+sophos-xg-105r2|sophos-xg-105wr2| \
+sophos-xg-115r2|sophos-xg-115wr2)
+	ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:1c.0/0000:01:00.0"
+	ucidef_set_network_device_path "wan"  "pci0000:00/0000:00:1c.1/0000:02:00.0"
+	ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:1c.2/0000:03:00.0"
+	ucidef_set_network_device_path "eth4" "pci0000:00/0000:00:1c.3/0000:04:00.0/0000:05:01.0/0000:06:00.0"
+	ucidef_set_interfaces_lan_wan "eth1 eth3 eth4" "wan"
+	;;
+sophos-sg-125r2|sophos-sg-125wr2| \
+sophos-sg-135r2|sophos-sg-135wr2)
+	ucidef_set_network_device_path "eth0" "pci0000:00/0000:00:14.0"
+	ucidef_set_network_device_path "wan"  "pci0000:00/0000:00:14.1"
+	ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:14.2"
+	ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:14.3"
+	ucidef_set_network_device_path "eth4" "pci0000:00/0000:00:01.0/0000:01:00.0/0000:02:02.0/0000:03:00.0"
+	ucidef_set_network_device_path "eth5" "pci0000:00/0000:00:01.0/0000:01:00.0/0000:02:03.0/0000:04:00.0"
+	ucidef_set_network_device_path "eth6" "pci0000:00/0000:00:02.0/0000:05:00.0/0000:06:02.0/0000:07:00.0"
+	ucidef_set_network_device_path "eth7" "pci0000:00/0000:00:02.0/0000:05:00.0/0000:06:03.0/0000:08:00.0"
+	ucidef_set_interfaces_lan_wan  "eth0 eth2 eth3 eth4 eth5 eth6 eth7" "wan"
+	;;
+sophos-xg-125r2|sophos-xg-125wr2| \
+sophos-xg-135r2|sophos-xg-135wr2)
+	ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:14.0"
+	ucidef_set_network_device_path "wan"  "pci0000:00/0000:00:14.1"
+	ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:14.2"
+	ucidef_set_network_device_path "eth4" "pci0000:00/0000:00:14.3"
+	ucidef_set_network_device_path "eth5" "pci0000:00/0000:00:01.0/0000:01:00.0/0000:02:02.0/0000:03:00.0"
+	ucidef_set_network_device_path "eth6" "pci0000:00/0000:00:01.0/0000:01:00.0/0000:02:03.0/0000:04:00.0"
+	ucidef_set_network_device_path "eth7" "pci0000:00/0000:00:02.0/0000:05:00.0/0000:06:02.0/0000:07:00.0"
+	ucidef_set_network_device_path "eth8" "pci0000:00/0000:00:02.0/0000:05:00.0/0000:06:03.0/0000:08:00.0"
+	ucidef_set_interfaces_lan_wan  "eth1 eth3 eth4 eth5 eth6 eth7 eth8" "wan"
+	;;
+sophos-sg-135r3|sophos-sg-135wr3)
+	ucidef_set_network_device_path "eth0" "pci0000:00/0000:00:17.0/0000:0c:00.0"
+	ucidef_set_network_device_path "wan"  "pci0000:00/0000:00:16.0/0000:0b:00.1"
+	ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:16.0/0000:0b:00.0"
+	ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:17.0/0000:0c:00.1"
+	ucidef_set_network_device_path "eth4" "pci0000:00/0000:00:09.0/0000:02:00.0"
+	ucidef_set_network_device_path "eth5" "pci0000:00/0000:00:0a.0/0000:03:00.0"
+	ucidef_set_network_device_path "eth6" "pci0000:00/0000:00:0b.0/0000:04:00.0"
+	ucidef_set_network_device_path "eth7" "pci0000:00/0000:00:0c.0/0000:05:00.0"
+	ucidef_set_interfaces_lan_wan  "eth0 eth2 eth3 eth4 eth5 eth6 eth7" "wan"
+	;;
+sophos-xg-135r3|sophos-xg-135wr3)
+	ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:17.0/0000:0c:00.0"
+	ucidef_set_network_device_path "wan"  "pci0000:00/0000:00:16.0/0000:0b:00.1"
+	ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:16.0/0000:0b:00.0"
+	ucidef_set_network_device_path "eth4" "pci0000:00/0000:00:17.0/0000:0c:00.1"
+	ucidef_set_network_device_path "eth5" "pci0000:00/0000:00:09.0/0000:02:00.0"
+	ucidef_set_network_device_path "eth6" "pci0000:00/0000:00:0a.0/0000:03:00.0"
+	ucidef_set_network_device_path "eth7" "pci0000:00/0000:00:0b.0/0000:04:00.0"
+	ucidef_set_network_device_path "eth8" "pci0000:00/0000:00:0c.0/0000:05:00.0"
+	ucidef_set_interfaces_lan_wan  "eth1 eth3 eth4 eth5 eth6 eth7 eth8" "wan"
 	;;
 traverse-technologies-geos)
 	ucidef_set_interface_lan "eth0 eth1"


### PR DESCRIPTION
* Sophos SG line and XG line of devices have different markings for ports on the cases, this commit addresses that and assigns proper ports to match the markings on the case.
