### PR TITLE
mac80211: fix flush during station removal

### DIFF
--- a/package/kernel/mac80211/patches/subsys/001-wifi-mac80211-do-not-pass-ap_vlan-vif-pointer-to-dri.patch
+++ b/package/kernel/mac80211/patches/subsys/001-wifi-mac80211-do-not-pass-ap_vlan-vif-pointer-to-dri.patch
@@ -1,0 +1,64 @@
+From ee0db868ee4d88493dfdc82f59e3b4e449ddddd5 Mon Sep 17 00:00:00 2001
+From: Oldřich Jedlička <oldium.pro@gmail.com>
+Date: Sat, 4 Nov 2023 15:13:33 +0100
+Subject: wifi: mac80211: do not pass AP_VLAN vif pointer to drivers during
+ flush
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+[ Upstream commit 3e3a2b645c043f7e3e488d5011478cefb69bbe8b ]
+
+This fixes WARN_ONs when using AP_VLANs after station removal. The flush
+call passed AP_VLAN vif to driver, but because these vifs are virtual and
+not registered with drivers, we need to translate to the correct AP vif
+first.
+
+Closes: https://github.com/openwrt/openwrt/issues/12420
+Fixes: 0b75a1b1e42e ("wifi: mac80211: flush queues on STA removal")
+Fixes: d00800a289c9 ("wifi: mac80211: add flush_sta method")
+Tested-by: Konstantin Demin <rockdrilla@gmail.com>
+Tested-by: Koen Vandeputte <koen.vandeputte@citymesh.com>
+Signed-off-by: Oldřich Jedlička <oldium.pro@gmail.com>
+Link: https://lore.kernel.org/r/20231104141333.3710-1-oldium.pro@gmail.com
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+---
+ net/mac80211/driver-ops.h | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+--- a/net/mac80211/driver-ops.h
++++ b/net/mac80211/driver-ops.h
+@@ -23,7 +23,7 @@
+ static inline struct ieee80211_sub_if_data *
+ get_bss_sdata(struct ieee80211_sub_if_data *sdata)
+ {
+-	if (sdata->vif.type == NL80211_IFTYPE_AP_VLAN)
++	if (sdata && sdata->vif.type == NL80211_IFTYPE_AP_VLAN)
+ 		sdata = container_of(sdata->bss, struct ieee80211_sub_if_data,
+ 				     u.ap);
+ 
+@@ -638,10 +638,13 @@ static inline void drv_flush(struct ieee
+ 			     struct ieee80211_sub_if_data *sdata,
+ 			     u32 queues, bool drop)
+ {
+-	struct ieee80211_vif *vif = sdata ? &sdata->vif : NULL;
++	struct ieee80211_vif *vif;
+ 
+ 	might_sleep();
+ 
++	sdata = get_bss_sdata(sdata);
++	vif = sdata ? &sdata->vif : NULL;
++
+ 	if (sdata && !check_sdata_in_driver(sdata))
+ 		return;
+ 
+@@ -657,6 +660,8 @@ static inline void drv_flush_sta(struct
+ {
+ 	might_sleep();
+ 
++	sdata = get_bss_sdata(sdata);
++
+ 	if (sdata && !check_sdata_in_driver(sdata))
+ 		return;
+ 


### PR DESCRIPTION
The queue flushing during station removal passes AP_VLAN vifs to drivers. But because those are virtual interfaces and not registered with drivers, we need to translate them to AP vif first.

Fixes: openwrt#12420

In order to test this, you need to have VLANs enabled in hostapd configuration. Some information can be
found in [OpenWrt Forum](https://forum.openwrt.org/t/individual-per-passphrase-wifi-vlans-using-wpa-psk-file-no-radius-required/161696/4). The configuration sections `wifi-station` and `wifi-vlan` mentioned later in the forum correspond to the content of manually specified `wpa_psk_file` and `vlan_file` files as described [here](https://openwrt.org/docs/guide-user/network/wifi/basic#wpa_psk_file).

I will send this patch upstream when it gets tested.

Symptoms fixed by this patch: When the client station gets disconnected and hostapd with VLANs feature is used, the following is logged:

```
Sun Sep 24 21:02:04 2023 daemon.notice hostapd: phy0-ap0: AP-STA-DISCONNECTED 7a:bd:bc:d2:13:72
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.405978] ------------[ cut here ]------------
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.405999] WARNING: CPU: 0 PID: 1583 at backports-6.5/net/mac80211/driver-ops.h:645 __ieee80211_flush_queues+0x1ac/0x1c4 [mac80211]
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.406544] phy0-ap0-vlan1: Failed check-sdata-in-driver check, flags: 0x1Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.406551] Modules linked in: ath9k ath9k_common pppoe ppp_async nft_fib_inet nf_flow_table_inet ath9k_hw ath10k_pci ath10k_core ath pppox ppp_generic nft_tproxy nft_socket nft_reject_ipv6 nft_reject_ipv4 nft_reject_inet nft_reject_bridge nft_reject nft_redir nft_quota nft_queue nft_objref nft_numgen nft_nat nft_meta_bridge nft_masq nft_log nft_limit nft_hash nft_fwd_netdev nft_flow_offload nft_fib_ipv6 nft_fib_ipv4 nft_fib nft_dup_netdev nft_ct nft_chain_nat nf_tables nf_nat nf_flow_table nf_conntrack_netlink nf_conntrack_bridge nf_conntrack mac80211 lzo cfg80211 slhc rng_core nfnetlink_queue nfnetlink_log nfnetlink nf_tproxy_ipv6 nf_tproxy_ipv4 nf_socket_ipv6 nf_socket_ipv4 nf_reject_ipv6 nf_reject_ipv4 nf_log_syslog nf_dup_netdev nf_defrag_ipv6 nf_defrag_ipv4 lzo_rle lzo_decompress lzo_compress libcrc32c crc_ccitt compat ledtrig_usbport rfkill sha512_generic seqiv jitterentropy_rng drbg md5 hmac cmac crypto_acompress fsl_mph_dr_of ehci_platform ehci_fsl ehci_hcd gpio_button_hotplug
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.406946]  usbcore nls_base usb_common crc32c_generic
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.406972] CPU: 0 PID: 1583 Comm: hostapd Not tainted 6.1.52 #0
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.406988] Stack : 807b0000 00000028 80c1c864 800c1d40 00000000 00000004 00000000 00000000
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.407031]         8289ba24 80970000 80830000 806ea684 818d3668 00000001 8289b9c8 499dad96
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.407071]         00000000 00000000 806ea684 8289b8f8 ffffefff 00000000 00000000 ffffffea
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.407111]         0000013d 8289b904 0000013d 807b19c0 00000001 806ea684 00000000 830476dc
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.407151]         00000009 84d504e0 807b0000 00000028 00000000 00000020 00000000 80970000
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.407191]         ...
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.407201] Call Trace:
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.407206] [<80066e4c>] show_stack+0x28/0xf0
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.407241] [<80608e98>] dump_stack_lvl+0x38/0x60
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.407263] [<80086240>] __warn+0x9c/0xe8
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.407283] [<80086318>] warn_slowpath_fmt+0x8c/0xac
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.407316] [<830476dc>] __ieee80211_flush_queues+0x1ac/0x1c4 [mac80211]
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.408080] [<8300af50>] __sta_info_destroy_part2+0x1a0/0x2e8 [mac80211]
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.408797] [<8300b43c>] sta_info_destroy_addr_bss+0x5c/0x84 [mac80211]
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.409514] [<82995478>] nl80211_del_station+0xd4/0x154 [cfg80211]
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.409759] [<804bfff8>] genl_rcv_msg+0x198/0x3d4
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.409799] [<804beb6c>] netlink_rcv_skb+0xb8/0x164
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.409817] [<804bf60c>] genl_rcv+0x30/0x48
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.409836] [<804be090>] netlink_unicast+0x230/0x354
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.409853] [<804be4d8>] netlink_sendmsg+0x324/0x488
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.409871] [<804388e0>] ____sys_sendmsg+0xc4/0x29c
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.409892] [<8043a488>] ___sys_sendmsg+0x7c/0xcc
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.409911] [<8043a9b4>] sys_sendmsg+0x4c/0xb8
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.409927] [<8006e1e4>] syscall_common+0x34/0x58
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.409943]
Sun Sep 24 21:02:04 2023 kern.warn kernel: [ 1196.409947] ---[ end trace 0000000000000000 ]---
```