### PR TITLE
pcre2: fix wrong symbolic link for pcre2-config

### DIFF
--- a/package/libs/pcre2/Makefile
+++ b/package/libs/pcre2/Makefile
@@ -84,8 +84,8 @@ CMAKE_OPTIONS += \
 define Build/InstallDev
 	$(call Build/InstallDev/cmake,$(1))
 	$(SED) 	's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' $(1)/usr/bin/pcre2-config
-	$(INSTALL_DIR) $(2)/bin
-	$(LN) ../../usr/bin/pcre2-config $(2)/bin/pcre2-config
+	$(INSTALL_DIR) $(1)/bin
+	$(LN) ../usr/bin/pcre2-config $(1)/bin/pcre2-config
 endef
 
 define Package/libpcre2/install


### PR DESCRIPTION
Fix wrong symbolic link for pcre2-config that for some reason is extremely wrong.

$(2) is used that is never defined and $(1) should be used to point to STAGING_DIR resulting in the link never created.
Also the link is wrong as it points to nothing and goes up one extra level resulting in the link being broken.