### PR TITLE
Opt out lto usage

### DIFF
--- a/package/libs/libselinux/Makefile
+++ b/package/libs/libselinux/Makefile
@@ -18,6 +18,8 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Thomas Petazzoni <thomas.petazzoni@bootlin.com>
 PKG_CPE_ID:=cpe:/a:selinuxproject:libselinux
 
+PKG_BUILD_FLAGS:=no-lto
+
 HOST_BUILD_DEPENDS:=libsepol/host musl-fts/host pcre2/host
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/libs/libsepol/Makefile
+++ b/package/libs/libsepol/Makefile
@@ -16,6 +16,8 @@ PKG_HASH:=78fdaf69924db780bac78546e43d9c44074bad798c2c415d0b9bb96d065ee8a2
 PKG_MAINTAINER:=Thomas Petazzoni <thomas.petazzoni@bootlin.com>
 PKG_CPE_ID:=cpe:/a:selinuxproject:libsepol
 
+PKG_BUILD_FLAGS:=no-lto
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk
 

--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -20,7 +20,7 @@ PKG_FIXUP:=autoreconf
 PKG_FLAGS:=nonshared
 
 PKG_INSTALL:=1
-PKG_BUILD_FLAGS:=gc-sections
+PKG_BUILD_FLAGS:=gc-sections no-lto
 PKG_BUILD_PARALLEL:=1
 PKG_LICENSE:=GPL-2.0
 PKG_CPE_ID:=cpe:/a:netfilter_core_team:iptables

--- a/package/network/utils/iwinfo/Makefile
+++ b/package/network/utils/iwinfo/Makefile
@@ -17,6 +17,8 @@ PKG_MIRROR_HASH:=5eddf584a1c3ed5637162d6bfc573ed1ce3691fcb38bdd55bf9f1e11e82ccc4
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=GPL-2.0
 
+PKG_BUILD_FLAGS:=no-lto
+
 IWINFO_ABI_VERSION:=20230701
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/utils/lua/Makefile
+++ b/package/utils/lua/Makefile
@@ -21,6 +21,8 @@ PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYRIGHT
 PKG_CPE_ID:=cpe:/a:lua:lua
 
+PKG_BUILD_FLAGS:=no-lto
+
 HOST_PATCH_DIR := ./patches-host
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
This fixes building packages: "iwinfo", "libselinux", "libsepol" and  "lua" when option CONFIG_USE_LTO is enabled.