### PR TITLE
ipq806x: fix broken onhub dtsi

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-onhub.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-onhub.dtsi
@@ -345,7 +345,6 @@
 	status = "okay";
 	phy-mode = "rgmii";
 	qcom,id = <0>;
-	phy-handle = <&phy1>;
 
 	pinctrl-0 = <&rgmii0_pins>;
 	pinctrl-names = "default";
@@ -360,7 +359,6 @@
 	status = "okay";
 	phy-mode = "sgmii";
 	qcom,id = <2>;
-	phy-handle = <&phy0>;
 
 	fixed-link {
 		speed = <1000>;


### PR DESCRIPTION
Fix broken onhub dtsi. The gmac node have a redundant phy-handle that doesn't point to the swconfig phy node as they got dropped in the DSA conversion. Drop these extra binding to restore correct compilation of this subtarget.

Fixes: 337e36e0ef98 ("ipq806x: convert each device to DSA implementation")