### PR TITLE
mvebu: clearfog: support eMMC bootable images

### DIFF
--- a/package/boot/uboot-mvebu/Makefile
+++ b/package/boot/uboot-mvebu/Makefile
@@ -38,6 +38,14 @@ define U-Boot/clearfog-emmc
   UBOOT_IMAGE:=u-boot-with-spl.kwb
 endef
 
+define U-Boot/clearfog-sata
+  NAME:=SolidRun ClearFog A1 (SATA)
+  BUILD_DEVICES:=solidrun_clearfog-base-a1 solidrun_clearfog-pro-a1
+  BUILD_SUBTARGET:=cortexa9
+  UBOOT_CONFIG:=clearfog_sata
+  UBOOT_IMAGE:=u-boot-with-spl.kwb
+endef
+
 define U-Boot/helios4
   NAME:=Kobol Helios 4
   BUILD_DEVICES:=kobol_helios4
@@ -80,6 +88,7 @@ endef
 UBOOT_TARGETS:= \
 	clearfog \
 	clearfog-emmc \
+	clearfog-sata \
 	helios4 \
 	omnia \
 	espressobin \

--- a/package/boot/uboot-mvebu/Makefile
+++ b/package/boot/uboot-mvebu/Makefile
@@ -23,9 +23,18 @@ define U-Boot/Default
 endef
 
 define U-Boot/clearfog
-  NAME:=SolidRun ClearFog A1
+  NAME:=SolidRun ClearFog A1 (SD-Card)
   BUILD_DEVICES:=solidrun_clearfog-base-a1 solidrun_clearfog-pro-a1
   BUILD_SUBTARGET:=cortexa9
+  UBOOT_IMAGE:=u-boot-with-spl.kwb
+endef
+
+define U-Boot/clearfog-emmc
+  NAME:=SolidRun ClearFog A1 (eMMC)
+  BUILD_DEVICES:=solidrun_clearfog-base-a1 solidrun_clearfog-pro-a1
+  BUILD_SUBTARGET:=cortexa9
+  UBOOT_CUSTOMIZE_CONFIG:= \
+    --set-val SYS_MMCSD_RAW_MODE_U_BOOT_DATA_PART_OFFSET 0x1000
   UBOOT_IMAGE:=u-boot-with-spl.kwb
 endef
 
@@ -70,6 +79,7 @@ endef
 
 UBOOT_TARGETS:= \
 	clearfog \
+	clearfog-emmc \
 	helios4 \
 	omnia \
 	espressobin \

--- a/target/linux/mvebu/image/Makefile
+++ b/target/linux/mvebu/image/Makefile
@@ -122,16 +122,16 @@ endef
 
 define Build/sdcard-img
 	SIGNATURE="$(IMG_PART_SIGNATURE)" \
-	./gen_mvebu_sdcard_img.sh $@ \
-		$(if $(UBOOT),$(STAGING_DIR_IMAGE)/$(UBOOT)) \
+	./gen_mvebu_img.sh $@ \
+		$(if $(UBOOT),$(STAGING_DIR_IMAGE)/$(UBOOT) 1) \
 		c $(CONFIG_TARGET_KERNEL_PARTSIZE) $@.boot \
 		83 $(CONFIG_TARGET_ROOTFS_PARTSIZE) $(IMAGE_ROOTFS)
 endef
 
 define Build/sdcard-img-ext4
 	SIGNATURE="$(IMG_PART_SIGNATURE)" \
-	./gen_mvebu_sdcard_img.sh $@ \
-		$(if $(UBOOT),$(STAGING_DIR_IMAGE)/$(UBOOT)) \
+	./gen_mvebu_img.sh $@ \
+		$(if $(UBOOT),$(STAGING_DIR_IMAGE)/$(UBOOT) 1) \
 		83 $(CONFIG_TARGET_KERNEL_PARTSIZE) $@.bootimg \
 		83 $(CONFIG_TARGET_ROOTFS_PARTSIZE) $(IMAGE_ROOTFS)
 endef

--- a/target/linux/mvebu/image/Makefile
+++ b/target/linux/mvebu/image/Makefile
@@ -136,6 +136,22 @@ define Build/emmc-img-ext4
 		83 $(CONFIG_TARGET_ROOTFS_PARTSIZE) $(IMAGE_ROOTFS)
 endef
 
+define Build/sata-img
+	SIGNATURE="$(IMG_PART_SIGNATURE)" \
+	./gen_mvebu_img.sh $@ \
+		$(if $(UBOOT_SATA),$(STAGING_DIR_IMAGE)/$(UBOOT_SATA) 1) \
+		c $(CONFIG_TARGET_KERNEL_PARTSIZE) $@.boot \
+		83 $(CONFIG_TARGET_ROOTFS_PARTSIZE) $(IMAGE_ROOTFS)
+endef
+
+define Build/sata-img-ext4
+	SIGNATURE="$(IMG_PART_SIGNATURE)" \
+	./gen_mvebu_img.sh $@ \
+		$(if $(UBOOT_SATA),$(STAGING_DIR_IMAGE)/$(UBOOT_SATA) 1) \
+		83 $(CONFIG_TARGET_KERNEL_PARTSIZE) $@.bootimg \
+		83 $(CONFIG_TARGET_ROOTFS_PARTSIZE) $(IMAGE_ROOTFS)
+endef
+
 define Build/sdcard-img
 	SIGNATURE="$(IMG_PART_SIGNATURE)" \
 	./gen_mvebu_img.sh $@ \

--- a/target/linux/mvebu/image/Makefile
+++ b/target/linux/mvebu/image/Makefile
@@ -120,6 +120,22 @@ define Build/ctera-firmware
 	rm -rf $@.tmp
 endef
 
+define Build/emmc-img
+	SIGNATURE="$(IMG_PART_SIGNATURE)" \
+	./gen_mvebu_img.sh $@ \
+		$(if $(UBOOT_EMMC),$(STAGING_DIR_IMAGE)/$(UBOOT_EMMC) 4096) \
+		c $(CONFIG_TARGET_KERNEL_PARTSIZE) $@.boot \
+		83 $(CONFIG_TARGET_ROOTFS_PARTSIZE) $(IMAGE_ROOTFS)
+endef
+
+define Build/emmc-img-ext4
+	SIGNATURE="$(IMG_PART_SIGNATURE)" \
+	./gen_mvebu_img.sh $@ \
+		$(if $(UBOOT_EMMC),$(STAGING_DIR_IMAGE)/$(UBOOT_EMMC) 4096) \
+		83 $(CONFIG_TARGET_KERNEL_PARTSIZE) $@.bootimg \
+		83 $(CONFIG_TARGET_ROOTFS_PARTSIZE) $(IMAGE_ROOTFS)
+endef
+
 define Build/sdcard-img
 	SIGNATURE="$(IMG_PART_SIGNATURE)" \
 	./gen_mvebu_img.sh $@ \

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -402,12 +402,14 @@ define Device/solidrun_clearfog-base-a1
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin
   DEVICE_PACKAGES := mkf2fs e2fsprogs partx-utils
-  IMAGES := emmc.img.gz sdcard.img.gz
+  IMAGES := emmc.img.gz sata.img.gz sdcard.img.gz
   IMAGE/emmc.img.gz := boot-scr | boot-img-ext4 | emmc-img-ext4 | gzip | append-metadata
+  IMAGE/sata.img.gz := boot-scr | boot-img-ext4 | sata-img-ext4 | gzip | append-metadata
   IMAGE/sdcard.img.gz := boot-scr | boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
   DEVICE_DTS := armada-388-clearfog-base armada-388-clearfog-pro
   UBOOT := clearfog-u-boot-with-spl.kwb
   UBOOT_EMMC := clearfog-emmc-u-boot-with-spl.kwb
+  UBOOT_SATA := clearfog-sata-u-boot-with-spl.kwb
   BOOT_SCRIPT := clearfog
   SUPPORTED_DEVICES += armada-388-clearfog-base
   DEVICE_COMPAT_VERSION := 1.1
@@ -422,12 +424,14 @@ define Device/solidrun_clearfog-pro-a1
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin
   DEVICE_PACKAGES := mkf2fs e2fsprogs partx-utils
-  IMAGES := emmc.img.gz sdcard.img.gz
+  IMAGES := emmc.img.gz sata.img.gz sdcard.img.gz
   IMAGE/emmc.img.gz := boot-scr | boot-img-ext4 | emmc-img-ext4 | gzip | append-metadata
+  IMAGE/sata.img.gz := boot-scr | boot-img-ext4 | sata-img-ext4 | gzip | append-metadata
   IMAGE/sdcard.img.gz := boot-scr | boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
   DEVICE_DTS := armada-388-clearfog-pro armada-388-clearfog-base
   UBOOT := clearfog-u-boot-with-spl.kwb
   UBOOT_EMMC := clearfog-emmc-u-boot-with-spl.kwb
+  UBOOT_SATA := clearfog-sata-u-boot-with-spl.kwb
   BOOT_SCRIPT := clearfog
   SUPPORTED_DEVICES += armada-388-clearfog armada-388-clearfog-pro
 endef

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -402,10 +402,12 @@ define Device/solidrun_clearfog-base-a1
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin
   DEVICE_PACKAGES := mkf2fs e2fsprogs partx-utils
-  IMAGES := sdcard.img.gz
+  IMAGES := emmc.img.gz sdcard.img.gz
+  IMAGE/emmc.img.gz := boot-scr | boot-img-ext4 | emmc-img-ext4 | gzip | append-metadata
   IMAGE/sdcard.img.gz := boot-scr | boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
   DEVICE_DTS := armada-388-clearfog-base armada-388-clearfog-pro
   UBOOT := clearfog-u-boot-with-spl.kwb
+  UBOOT_EMMC := clearfog-emmc-u-boot-with-spl.kwb
   BOOT_SCRIPT := clearfog
   SUPPORTED_DEVICES += armada-388-clearfog-base
   DEVICE_COMPAT_VERSION := 1.1
@@ -420,10 +422,12 @@ define Device/solidrun_clearfog-pro-a1
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin
   DEVICE_PACKAGES := mkf2fs e2fsprogs partx-utils
-  IMAGES := sdcard.img.gz
+  IMAGES := emmc.img.gz sdcard.img.gz
+  IMAGE/emmc.img.gz := boot-scr | boot-img-ext4 | emmc-img-ext4 | gzip | append-metadata
   IMAGE/sdcard.img.gz := boot-scr | boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
   DEVICE_DTS := armada-388-clearfog-pro armada-388-clearfog-base
   UBOOT := clearfog-u-boot-with-spl.kwb
+  UBOOT_EMMC := clearfog-emmc-u-boot-with-spl.kwb
   BOOT_SCRIPT := clearfog
   SUPPORTED_DEVICES += armada-388-clearfog armada-388-clearfog-pro
 endef

--- a/target/linux/mvebu/image/gen_mvebu_emmc_img.sh
+++ b/target/linux/mvebu/image/gen_mvebu_emmc_img.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2016 Josua Mayer
+
+usage() {
+	echo "$0 <outfile> [<bootloader> <type_partitionN> <size_partitionN> <img_partitionN>]?"
+}
+
+# always require first 2 or 3 arguments
+# then in pairs up to 8 more for a total of up to 4 partitions
+if [ $# -lt 1 ] || [ $# -gt 14 ] || [ $((($# - 1) % 3)) -ne 0 ]; then
+	if [ $# -lt 2 ] || [ $# -gt 15 ] || [ $((($# - 2) % 3)) -ne 0 ]; then
+		usage
+		exit 1
+	else
+		BOOTLOADER="$2"
+	fi
+fi
+
+set -e
+
+# parameters
+OUTFILE="$1"; shift
+if [ -n "$BOOTLOADER" ]; then
+	shift
+fi
+
+# generate image file
+printf "Creating %s from /dev/zero: " "$OUTFILE"
+dd if=/dev/zero of="$OUTFILE" bs=512 count=1 >/dev/null
+printf "Done\n"
+
+while [ "$#" -ge 3 ]; do
+	ptgen_args="$ptgen_args -t $1 -p $(($2 * 1024 + 256))"
+	parts="$parts$3 "
+	shift; shift; shift
+done
+
+head=16
+sect=63
+
+# create real partition table using fdisk
+printf "Creating partition table: "
+set $(ptgen -o "$OUTFILE" -h $head -s $sect -l 8192 -S 0x$SIGNATURE $ptgen_args)
+printf "Done\n"
+
+# install bootloader
+if [ -n "$BOOTLOADER" ]; then
+	printf "Writing bootloader: "
+	dd of="$OUTFILE" if="$BOOTLOADER" bs=512 seek=4096 conv=notrunc 2>/dev/null
+	printf "Done\n"
+fi
+
+i=1
+while [ "$#" -ge 2 ]; do
+	img="${parts%% *}"
+	parts="${parts#* }"
+
+	printf "Writing %s to partition %i: " "$img" $i
+	(
+		cat "$img"
+		# add padding to avoid leaving behind old overlay fs data
+		dd if=/dev/zero bs=128k count=1 2>/dev/null
+	) | dd of="$OUTFILE" bs=512 seek=$(($1 / 512)) conv=notrunc 2>/dev/null
+	printf "Done\n"
+
+	i=$((i+1))
+	shift; shift
+done


### PR DESCRIPTION
Armada 388 Clearfog * boards can boot from all eMMC partitions.
Previously openwrt only generated a single image for sdcard, literally called "sdcard".

This image is incompatible with eMMC *if loading u-boot from data partition* is intended,
because for eMMC the SoC ignores LBA-1 where u-boot is located by default.

Loading U-Boot from Data partition is optional, users may have u-boot installed to eMMC boot0/boot1 partitions themselves in the past. For these users the emmc image changes nothing.

For everyone else it is very convenient to have a single image combining u-boot and rootfs.


Therefore add supporting to to generate an additional emmc image with u-boot at LBA-4096 and appropriate free space before partition #1.
