### PR TITLE
uboot-mvebu: armada 388 clearfog: support additional ddr configurations

### DIFF
--- a/package/boot/uboot-mvebu/patches/0004-arm-mvebu-clearfog-read-number-of-ddr-channels-from-.patch
+++ b/package/boot/uboot-mvebu/patches/0004-arm-mvebu-clearfog-read-number-of-ddr-channels-from-.patch
@@ -1,0 +1,85 @@
+From 1dbc6d3739869af38e6157cd8b9bc4314ca3c9fe Mon Sep 17 00:00:00 2001
+From: Josua Mayer <josua@solid-run.com>
+Date: Mon, 18 Jul 2022 20:04:54 +0300
+Subject: [PATCH 1/2] arm: mvebu: clearfog: read number of ddr channels from
+ tlv data
+
+Extend the existing tlv vendor extension used for ram size by one byte to
+also store the number of ddr channels.
+The length of the tlv entry can indicate whether the new information is
+present. If not default to single channel.
+
+Signed-off-by: Josua Mayer <josua@solid-run.com>
+---
+ board/solidrun/clearfog/clearfog.c | 14 +++++++++++++-
+ board/solidrun/common/tlv_data.c   |  7 ++++++-
+ board/solidrun/common/tlv_data.h   |  1 +
+ 3 files changed, 20 insertions(+), 2 deletions(-)
+
+diff --git a/board/solidrun/clearfog/clearfog.c b/board/solidrun/clearfog/clearfog.c
+index 6edb4221551..4f4532b537e 100644
+--- a/board/solidrun/clearfog/clearfog.c
++++ b/board/solidrun/clearfog/clearfog.c
+@@ -36,7 +36,7 @@ DECLARE_GLOBAL_DATA_PTR;
+ #define BOARD_GPP_POL_LOW	0x0
+ #define BOARD_GPP_POL_MID	0x0
+ 
+-static struct tlv_data cf_tlv_data;
++static struct tlv_data cf_tlv_data = { 0 };
+ 
+ static void cf_read_tlv_data(void)
+ {
+@@ -168,6 +168,18 @@ struct mv_ddr_topology_map *mv_ddr_topology_map_get(void)
+ 		break;
+ 	}
+ 
++	switch (cf_tlv_data.ram_channels) {
++	default:
++	case 1:
++		for (uint8_t i = 0; i < 5; i++)
++			ifp->as_bus_params[i].cs_bitmask = 0x1;
++		break;
++	case 2:
++		for (uint8_t i = 0; i < 5; i++)
++			ifp->as_bus_params[i].cs_bitmask = 0x3;
++		break;
++	}
++
+ 	/* Return the board topology as defined in the board code */
+ 	return &board_topology_map;
+ }
+diff --git a/board/solidrun/common/tlv_data.c b/board/solidrun/common/tlv_data.c
+index 11d6e4a1380..cf5824886c3 100644
+--- a/board/solidrun/common/tlv_data.c
++++ b/board/solidrun/common/tlv_data.c
+@@ -45,9 +45,14 @@ static void parse_tlv_vendor_ext(struct tlvinfo_tlv *tlv_entry,
+ 
+ 	if (val[4] != SR_TLV_CODE_RAM_SIZE)
+ 		return;
+-	if (tlv_entry->length != 6)
++	if (tlv_entry->length < 6)
+ 		return;
+ 	td->ram_size = val[5];
++
++	/* extension with additional data field for number of ddr channels */
++	if (tlv_entry->length >= 7) {
++		td->ram_channels = val[6];
++	}
+ }
+ 
+ static void parse_tlv_data(u8 *eeprom, struct tlvinfo_header *hdr,
+diff --git a/board/solidrun/common/tlv_data.h b/board/solidrun/common/tlv_data.h
+index a1432e4b8e1..be3f782ac4a 100644
+--- a/board/solidrun/common/tlv_data.h
++++ b/board/solidrun/common/tlv_data.h
+@@ -10,6 +10,7 @@ struct tlv_data {
+ 	/* Store product name of both SOM and carrier */
+ 	char tlv_product_name[2][32];
+ 	unsigned int ram_size;
++	uint8_t ram_channels;
+ };
+ 
+ void read_tlv_data(struct tlv_data *td);
+-- 
+2.35.3
+

--- a/package/boot/uboot-mvebu/patches/0005-arm-mvebu-clearfog-support-512MB-memory-size-from-tl.patch
+++ b/package/boot/uboot-mvebu/patches/0005-arm-mvebu-clearfog-support-512MB-memory-size-from-tl.patch
@@ -1,0 +1,31 @@
+From b1b4941c2e3e16a21dc15604220725cf7f2de7c5 Mon Sep 17 00:00:00 2001
+From: Josua Mayer <josua@solid-run.com>
+Date: Wed, 20 Jul 2022 19:10:56 +0300
+Subject: [PATCH 2/2] arm: mvebu: clearfog: support 512MB memory size from tlv
+ eeprom
+
+Handle 2GBit memory size value "2" from tlv eeprom on ddr
+initialisation, to support SoMs with 512MB ddr memory.
+
+Signed-off-by: Josua Mayer <josua@solid-run.com>
+---
+ board/solidrun/clearfog/clearfog.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/board/solidrun/clearfog/clearfog.c b/board/solidrun/clearfog/clearfog.c
+index 4f4532b537e..6fa2fe5fe3e 100644
+--- a/board/solidrun/clearfog/clearfog.c
++++ b/board/solidrun/clearfog/clearfog.c
+@@ -159,6 +159,9 @@ struct mv_ddr_topology_map *mv_ddr_topology_map_get(void)
+ 	cf_read_tlv_data();
+ 
+ 	switch (cf_tlv_data.ram_size) {
++	case 2:
++		ifp->memory_size = MV_DDR_DIE_CAP_2GBIT;
++		break;
+ 	case 4:
+ 	default:
+ 		ifp->memory_size = MV_DDR_DIE_CAP_4GBIT;
+-- 
+2.35.3
+


### PR DESCRIPTION
Add sup port for additional DDR configurations of the Armada 388 SoM used in SolidRun Clearfog products.

Patches as submitted in v1 to u-boot mailinglist:
https://lists.denx.de/pipermail/u-boot/2023-October/533148.html