### PR TITLE
lantiq: Revert "lantiq: xrx200: mark subtarget as source-only"

### DIFF
--- a/target/linux/lantiq/xrx200/target.mk
+++ b/target/linux/lantiq/xrx200/target.mk
@@ -1,7 +1,7 @@
 ARCH:=mips
 SUBTARGET:=xrx200
 BOARDNAME:=XRX200
-FEATURES+=atm nand ramdisk source-only
+FEATURES+=atm nand ramdisk
 CPU_TYPE:=24kc
 
 DEFAULT_PACKAGES+=kmod-leds-gpio \


### PR DESCRIPTION
This reverts commit 0c117e1f6ccbee684ea0589d9024ca9dec4679c9.

Activate the lantiq/xrx200 target again.

There are still some problems with the GSWIP, but it is not leaking packets to the wrong bridge in normal operations.
It shows some error messages at configuration like these:
````
[   54.308861] gswip 1e108000.switch: port 5 failed to add ce:9d:84:d1:81:f0 vid 1 to fdb: -22
[   54.325633] gswip 1e108000.switch: port 5 failed to add e8:de:27:95:c1:b4 vid 0 to fdb: -22
[   54.351242] gswip 1e108000.switch: port 5 failed to add e8:de:27:95:c1:b4 vid 1 to fdb: -22
[   54.358311] gswip 1e108000.switch: port 5 failed to delete ce:9d:84:d1:81:f0 vid 1 from fdb: -2
````