### PR TITLE
buildsystem: add PKG_CVE_FIXED and PKG_CVE_IGNORE to ipkg packages and manifest files

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -221,6 +221,8 @@ $$(call addfield,Depends,$$(Package/$(1)/DEPENDS)
 )$$(call addfield,URL,$(URL)
 )$$(if $$(ABIV_$(1)),ABIVersion: $$(ABIV_$(1))
 )$(if $(PKG_CPE_ID),CPE-ID: $(PKG_CPE_ID)
+)$(if $(PKG_CVE_FIXED),CVE-FIXED: $(PKG_CVE_FIXED)
+)$(if $(PKG_CVE_IGNORE),CVE-IGNORE: $(PKG_CVE_IGNORE)
 )$(if $(filter hold,$(PKG_FLAGS)),Status: unknown hold not-installed
 )$(if $(filter essential,$(PKG_FLAGS)),Essential: yes
 )$(if $(MAINTAINER),Maintainer: $(MAINTAINER)


### PR DESCRIPTION
In a stable branch it may not be possible to update the packges version to a new one to close a CVE.

This can have several reasons:

- There is no new minor version available to fix this CVE because the version is no longer maintained.
- There are only patches available that could be backported, but it is not worth making a new version

To make the information easily accessible, the fix with the CVE number should be added to the new Makefile variable PKG_CVE_FIXES. After that, a CVE scanner can evaluate this and not mark the version as vulnerable because a patch has fixed this CVE regardless of the upstream version.

