### PR TITLE
tools/cmake: update to 3.27.5

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
-PKG_VERSION:=3.27.4
+PKG_VERSION:=3.27.7
 PKG_VERSION_MAJOR:=$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:kitware:cmake
@@ -15,7 +15,7 @@ PKG_CPE_ID:=cpe:/a:kitware:cmake
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Kitware/CMake/releases/download/v$(PKG_VERSION)/ \
 		https://cmake.org/files/v$(PKG_VERSION_MAJOR)/
-PKG_HASH:=0a905ca8635ca81aa152e123bdde7e54cbe764fdd9a70d62af44cad8b92967af
+PKG_HASH:=08f71a106036bf051f692760ef9558c0577c42ac39e96ba097e7662bd4158d8e
 
 HOST_BUILD_PARALLEL:=1
 HOST_CONFIGURE_PARALLEL:=1


### PR DESCRIPTION
Release Notes:
- https://www.kitware.com/cmake-3-27-5-available-for-download/
- https://www.kitware.com/cmake-3-27-6-available-for-download/
- https://www.kitware.com/cmake-3-27-7-available-for-download/
