### PR TITLE
libnl: update to 3.8.0

### DIFF
--- a/package/libs/libnl/Makefile
+++ b/package/libs/libnl/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnl
-PKG_VERSION:=3.7.0
+PKG_VERSION:=3.8.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/thom311/libnl/releases/download/libnl$(subst .,_,$(PKG_VERSION))
-PKG_HASH:=9fe43ccbeeea72c653bdcf8c93332583135cda46a79507bfd0a483bb57f65939
+PKG_HASH:=bb726c6d7a08b121978d73ff98425bf313fa26a27a331d465e4f1d7ec5b838c6
 
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Changes:
6b2533c0 libnl-3.8.0 release
1558bd62 build: replace old "NOTE" in configure output and add summary f66383a4 build: avoid aclocal warning about missing "m4" directory e4402a4c build: run `autoupdate` for AM_PROG_LIBTOOL 5761b6af build: add "-Wno-portability" to AC_INIT_AUTOMAKE() 661f10a1 license: fix/adjust license for "src/nl-cls-add.c" c8fcb412 license: fix/adjust license for "src/nl-addr-{add,delete,list}.c" e3e6fd6d tests: use thread-safe localtime_r() instead of localtime() f520471c lib/xfrm: use thread-safe gmtime_r() instead of gmtime() be5add72 tests: avoid srandom()/random() in favor of _nltst_rand_u32() 40578a62 lib: use getprotobyname_r(), getprotobynumber_r() if available 8ee8b05f lib: fix error handling in nl_str2ip_proto() 09f03f29 tests: check nl_str2ip_proto()
74bffbf6 route: fix documentation comment for nl_nh_group_info 59f8db0d clang-format: add "-l" alias for option in "tools/clang-format.sh" 935cc90a clang-format: ignore reformatting commit in ".git-blame-ignore-revs" 53da4712 clang-format: reformat files with new format 65c43bfe clang-format: update ".clang-format" from linux kernel
4c39a2ce include: use <linux/$file> instead of <linux-private/linux/$file>
a1e9fb3d include/linux: add all linux headers that we use d37ffe15 include/linux: update all linux headers
1af767a8 include: add missing "extern "C"" specifier to public headers e0a5d12b all: drop "extern "C"" from internal code d9a1e0ce build: add "check-local-build-headers" test target to build public headers 02b87012 build: add a "check-local" build target
f9413915 include: fix headers "include/netlink/route/{netconf.h,route/qdisc/red.h}" to be self-contained 680df173 idiag: "fix" license for "idiag-socket-details" tool 2f210d9a github: test build on alpine:latest for musl dcc4c0a5 Revert "gitignore: ignore patch files"
39106309 github: add test for linking with mold and fail on unknown versions f475c3b2 route/nh: drop not implemented "nh" API from headers 4c681e77 build: fix exporting symbol rtnl_link_info_ops_get 260c9575 include: don't explicitly include headers from "nl-default.h" 98c1e696 tests: cleanup include of netlink headers 42bec462 build: cleanup default include list in Makefile.am 4c1a119a include: include private linux headers with explicit path ca063725 python: add make target for python build
25c90193 python: drop unused "python/netlink/fixes.h" 3f3da7fd gitignore: ignore python build artifacts
61ef5609 gitignore: ignore generated doc files
298c5dc6 include: drop "netlink-private/netlink.h" and move declarations 862eed54 all: cleanup includes and use "nm-default.h" 2b3cd741 include: add "nl-default.h" header
8952ce6f build: move "lib/defs.h" to "include/config.h" 1010776d include: split and drop "netlink-private/types.h" d1d57846 include: rename "nl-shared-core" to "nl-priv-dynamic-core" fc91c4f8 include: rename "nl-hidden-route" to "nl-priv-dynamic-route" 9bb6f770 include: rename "nl-intern-route" to "nl-priv-static-route" b5195db9 genl: rename private header "nl-priv-genl.h" to "nl-genl.h" 0eacf658 include: make "netlink/route/link/{inet,inet6}.h" self-contained ad014ad1 route/tc: avoid unalinged access in rtnl_tc_msg_parse() 05bd6366 add support for TC action statistics
776fc5a6 lib: move "include/netlink-private/object-api" to include/nl-shared-core fad34560 lib: move "include/netlink-private/cache-api" to include/nl-shared-core ed2be537 route: move "include/netlink-private/route/link/sriov.h" to lib/route/link-sriov.h 97f61eda lib: move "include/netlink-private/socket.h" to lib/nl-core.h 96e1cc5b route: move "include/netlink-private/route/nexthop-encap.h" to lib/route 391e03d3 route: merge "include/netlink-private/tc.h" to lib/route/tc-api.h 7fc4f5b3 route: move rtnl_tc_build_rate_table() to "tc-api.h" cf41e14d route: move "include/netlink-private/route/tc-api.h" to lib/route db810cfb route: move hidden symbols from "include/netlink-private/route/tc-api.h" ff08e618 build: don't add lib/route to include directory for all libs eb8da16d include: move "include/netlink-private/route/link/api.h" to lib/route 8b2074aa include: move "include/netlink-private/route/utils.h" to nl-intern-route fd470c06 include: move "include/netlink-private/route/mpls.h" to "lib/mpls.h" 78056ad2 genl: add comment about wrongly exported symbol genl_resolve_id() befc4ab4 include: move "include/netlink-private/genl.h" to "lib/genl/nl-priv-genl.h" f6c26127 nl-aux: add "include/nl-aux-{core,route}" headers 2da8481b base: move "netlink-private/utils.h" to "base/nl-base-utils.h" d3e9b513 include/utils: move nl-auto base defines to "utils.h" 543b9f8f clang-format: reformat "include/netlink-private/nl-auto.h" aa565460 route: cleanup ATTR_DIFF() macros
beba5a18 cli: add nl-nh-list utility
780d06ae route: add nh type
1b6433d9 neigh: add support of NHID attribute
e0140c5f include: import kernel headers "linux/{neighbour,nexthop,rtnetlink}.h" eef06744 utils: add static-assert for signedness of arguments of _NL_CMP_DIRECT() macro 679c4c51 cli: use <netlink-private/utils.h> in cli and _nl_{init,exit} a9c5de52 lib: use _nl_{init,exit} instead of __{init,exit} 102f9bd2 include/private: add _nl_init/_nl_exit macros 6782678e include/private: drop unused __deprecated macro a0535a58 all: use "_nl_packed" macro instead of "__attribute__((packed))" 8c9f98cf all: rework ATTR_DIFF() macros to not generate attribute names ca34ad52 lib: handle negative and zero size in nla_memcpy() 859b89dc include: drop now unused min()/max()/min_t()/max_t() macros 2e0ae977 all: use _NL_{MIN,MAX}() macros
57c451fa utils: add various helpers to "include/netlink-private/utils.h" a9a9dcea style: format "include/netlink-private/utils.h" with clang-format 590e8a61 tools: improve failure message with "tools/clang-format.sh -n" 06dc5ae0 github: fix format checking with clang-format 7738f239 route/trivial: sort entries in "libnl-route-3.sym" asciibetically fc805c56 route/bond: Add support for link_info for bond 6af26981 lib: accept NULL argument in nla_nest_cancel() for robustness e9662091 macsec: Drop offload capability validation check 35a68109 github: update flake8 linter to not explicitly select checks 9a266405 python: add ".flake8" file for configuring "flake8" e6b934a5 python: fix flake8 warnings E712
2cea738b python: fix flake8 warnings E711
d561096c python: fix flake8 warnings E302
29b06d0f python: fix flake8 warnings E741
4dc1f498 python: fix flake8 warnings F841
f4875c69 python: fix flake8 warnings W605
9a3d91df python: fix flake8 warnings F401
6baf2339 clang-format: add "tools/clang-format-container.sh" script ee2876e3 github: add test for checking clang-format style 45c7aae3 clang-format: add "tools/clang-format.sh" script 02e0fd3f github: check python-black code formatting in github actions 2dd53895 build: add ".git-blame-ignore-revs" file for "blame.ignoreRevsFile" git config 3c753e3c python: reformat all Python files with python-black 298ee58e python add "pyproject.toml" for configuring black a0e4b7f9 github: skip Python flake8 test with clang build c4240c0b github: run "Build Release" test also with clang 143cee1d bridge: fix bridge info parsing
96bbe55c test-cache-mngr: Flush output after object dumps cf5dcbcd test-cache-mngr: Add option to print timestamps bd570952 test-cache-mngr: Add an option to iterate over all supported address families bf80da90 test-cache-mngr: Add dump interval options 80febeea test-cache-mngr: Add an option to control which oo_dump function is used 6519a917 route/link: prevent segfault in af_request_type() a68260f8 github: fix installing python dependencies via pip 39c04bc7 build: drop redundant "autogen.sh" call from "tools/build_release.sh" d411b88d build: change proper working directory in "doc/autogen.sh" 2fa73ce0 build: ensure "autogen.sh" scripts fail on error fc786296 gitignore: ignore "*~" files
4c4e614b docs: rtnl_link_put() 'releases' instead of 'returns' 336b15dc include/linux: update copy of kernel header "linux/ipv6.h" e2cacc26 route/link: improve handling of IFLA_INET6_CONF ec8c493c route/link: remove rtnl_link_inet6_set_conf() API e790f8ad route/link: various fixes for rtnl_link_inet6_get_conf() API d83c6d54 route/link: add accessor API for IPv6 DEVCONF 9167504d bridge: drop unnecessary goto in bridge_info_parse() 984d6e93 bridge: don't normalize the u8 argument in rtnl_link_bridge_set_vlan_filtering() to boolean 3662a5da bridge: expose rtnl_link_bridge_get_vlan_protocol() in host byte order 5a1ef219 bridge: fix parsing vlan-protocol in bridge_info_parse() ad1c2927 bridge: minor cleanups in "bridge_info.c" 1c74725a bridge: use SPDX license identifiers in bridge_info files 26ca549d bridge: reformat bridge_info file with clang-format 08dc5d9c bridge: extend libnl with options needed for VLAN aware forwarding 7391a38e bridge: Add support for link_info of a bridge 1f1e8385 route/vlan: drop unnecessary "else" in vlan_put_attrs() 2bc30e57 route/vlan: fix error handling in 'lib/route/link/vlan.c' 8273d6ce build: add comments to linker version scripts about the version tags 6ac7a812 doc: fix typo
07d274ab doc: fix typo
0461a425 attr: reject zero length addresses
8d40d9eb route: construct all-zero addresses for default route destination 25d42a4f addr: allow constructing all-zero addresses 0c0aee82 addr: create an all-zero addresses when parsing "any" or "default"
