### PR TITLE
mtd-utils: update to 2.1.6

### DIFF
--- a/tools/mtd-utils/Makefile
+++ b/tools/mtd-utils/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mtd-utils
-PKG_VERSION:=2.1.5
+PKG_VERSION:=2.1.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://infraroot.at/pub/mtd/
-PKG_HASH:=386e27fd121699b6b729bc2e8e04dda987b31cca6b16e12fb6cc6dcf26449f46
+PKG_HASH:=c1d853bc4adf83bcabd2792fc95af33bdd8643c97e8f7b3f0180af36af76f0e5
 PKG_CPE_ID:=cpe:/a:mtd-utils_project:mtd-utils
 
 PKG_FIXUP:=autoreconf

--- a/tools/mtd-utils/patches/110-portability.patch
+++ b/tools/mtd-utils/patches/110-portability.patch
@@ -70,7 +70,7 @@
  #include <sys/types.h>
 --- a/ubifs-utils/mkfs.ubifs/mkfs.ubifs.c
 +++ b/ubifs-utils/mkfs.ubifs/mkfs.ubifs.c
-@@ -1541,6 +1541,7 @@ static int add_inode(struct stat *st, in
+@@ -1542,6 +1542,7 @@ static int add_inode(struct stat *st, in
  
  	if (c->default_compr != UBIFS_COMPR_NONE)
  		use_flags |= UBIFS_COMPR_FL;
@@ -78,7 +78,7 @@
  	if (flags & FS_COMPR_FL)
  		use_flags |= UBIFS_COMPR_FL;
  	if (flags & FS_SYNC_FL)
-@@ -1553,6 +1554,7 @@ static int add_inode(struct stat *st, in
+@@ -1554,6 +1555,7 @@ static int add_inode(struct stat *st, in
  		use_flags |= UBIFS_DIRSYNC_FL;
  	if (fctx)
  		use_flags |= UBIFS_CRYPT_FL;
@@ -86,7 +86,7 @@
  	memset(ino, 0, UBIFS_INO_NODE_SZ);
  
  	ino_key_init(&key, inum);
-@@ -1638,7 +1640,9 @@ static int add_dir_inode(const char *pat
+@@ -1639,7 +1641,9 @@ static int add_dir_inode(const char *pat
  		fd = dirfd(dir);
  		if (fd == -1)
  			return sys_err_msg("dirfd failed");
@@ -96,7 +96,7 @@
  			flags = 0;
  	}
  
-@@ -1849,6 +1853,7 @@ static int add_file(const char *path_nam
+@@ -1850,6 +1854,7 @@ static int add_file(const char *path_nam
  		dn->ch.node_type = UBIFS_DATA_NODE;
  		key_write(&key, &dn->key);
  		out_len = NODE_BUFFER_SIZE - UBIFS_DATA_NODE_SZ;
@@ -104,7 +104,7 @@
  		if (c->default_compr == UBIFS_COMPR_NONE &&
  		    !c->encrypted && (flags & FS_COMPR_FL))
  #ifdef WITHOUT_LZO
-@@ -1857,6 +1862,7 @@ static int add_file(const char *path_nam
+@@ -1858,6 +1863,7 @@ static int add_file(const char *path_nam
  			use_compr = UBIFS_COMPR_LZO;
  #endif
  		else
@@ -112,7 +112,7 @@
  			use_compr = c->default_compr;
  		compr_type = compress_data(buf, bytes_read, &dn->data,
  					   &out_len, use_compr);
-@@ -1916,7 +1922,9 @@ static int add_non_dir(const char *path_
+@@ -1917,7 +1923,9 @@ static int add_non_dir(const char *path_
  		if (fd == -1)
  			return sys_err_msg("failed to open file '%s'",
  					   path_name);


### PR DESCRIPTION
Release Notes:
https://lists.infradead.org/pipermail/linux-mtd/2023-August/100922.html

Refresh patch:
- 110-portability.patch
