### PR TITLE
mac80211: ath11k: sync with ath-next

### DIFF
--- a/package/kernel/mac80211/patches/ath11k/0016-wifi-ath11k-add-chip-id-board-name-while-searching-b.patch
+++ b/package/kernel/mac80211/patches/ath11k/0016-wifi-ath11k-add-chip-id-board-name-while-searching-b.patch
@@ -1,0 +1,214 @@
+From 1133af5aea588a58043244a4ecb5ce511b310356 Mon Sep 17 00:00:00 2001
+From: Wen Gong <quic_wgong@quicinc.com>
+Date: Wed, 30 Aug 2023 02:02:26 -0400
+Subject: [PATCH] wifi: ath11k: add chip id board name while searching
+ board-2.bin for WCN6855
+
+Sometimes board-2.bin does not have the board data which matched the
+parameters such as bus type, vendor, device, subsystem-vendor,
+subsystem-device, qmi-chip-id and qmi-board-id, then wlan will load fail.
+
+Hence add another type which only matches the bus type and qmi-chip-id,
+then the ratio of missing board data reduced.
+
+Tested-on: WCN6855 hw2.0 PCI WLAN.HSP.1.1-03125-QCAHSPSWPL_V1_V2_SILICONZ_LITE-3.6510.23
+
+Signed-off-by: Wen Gong <quic_wgong@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230830060226.18664-1-quic_wgong@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/core.c | 108 ++++++++++++++++++++-----
+ 1 file changed, 87 insertions(+), 21 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/core.c
++++ b/drivers/net/wireless/ath/ath11k/core.c
+@@ -985,9 +985,15 @@ int ath11k_core_check_dt(struct ath11k_b
+ 	return 0;
+ }
+ 
++enum ath11k_bdf_name_type {
++	ATH11K_BDF_NAME_FULL,
++	ATH11K_BDF_NAME_BUS_NAME,
++	ATH11K_BDF_NAME_CHIP_ID,
++};
++
+ static int __ath11k_core_create_board_name(struct ath11k_base *ab, char *name,
+ 					   size_t name_len, bool with_variant,
+-					   bool bus_type_mode)
++					   enum ath11k_bdf_name_type name_type)
+ {
+ 	/* strlen(',variant=') + strlen(ab->qmi.target.bdf_ext) */
+ 	char variant[9 + ATH11K_QMI_BDF_EXT_STR_LENGTH] = { 0 };
+@@ -998,11 +1004,8 @@ static int __ath11k_core_create_board_na
+ 
+ 	switch (ab->id.bdf_search) {
+ 	case ATH11K_BDF_SEARCH_BUS_AND_BOARD:
+-		if (bus_type_mode)
+-			scnprintf(name, name_len,
+-				  "bus=%s",
+-				  ath11k_bus_str(ab->hif.bus));
+-		else
++		switch (name_type) {
++		case ATH11K_BDF_NAME_FULL:
+ 			scnprintf(name, name_len,
+ 				  "bus=%s,vendor=%04x,device=%04x,subsystem-vendor=%04x,subsystem-device=%04x,qmi-chip-id=%d,qmi-board-id=%d%s",
+ 				  ath11k_bus_str(ab->hif.bus),
+@@ -1012,6 +1015,19 @@ static int __ath11k_core_create_board_na
+ 				  ab->qmi.target.chip_id,
+ 				  ab->qmi.target.board_id,
+ 				  variant);
++			break;
++		case ATH11K_BDF_NAME_BUS_NAME:
++			scnprintf(name, name_len,
++				  "bus=%s",
++				  ath11k_bus_str(ab->hif.bus));
++			break;
++		case ATH11K_BDF_NAME_CHIP_ID:
++			scnprintf(name, name_len,
++				  "bus=%s,qmi-chip-id=%d",
++				  ath11k_bus_str(ab->hif.bus),
++				  ab->qmi.target.chip_id);
++			break;
++		}
+ 		break;
+ 	default:
+ 		scnprintf(name, name_len,
+@@ -1030,19 +1046,29 @@ static int __ath11k_core_create_board_na
+ static int ath11k_core_create_board_name(struct ath11k_base *ab, char *name,
+ 					 size_t name_len)
+ {
+-	return __ath11k_core_create_board_name(ab, name, name_len, true, false);
++	return __ath11k_core_create_board_name(ab, name, name_len, true,
++					       ATH11K_BDF_NAME_FULL);
+ }
+ 
+ static int ath11k_core_create_fallback_board_name(struct ath11k_base *ab, char *name,
+ 						  size_t name_len)
+ {
+-	return __ath11k_core_create_board_name(ab, name, name_len, false, false);
++	return __ath11k_core_create_board_name(ab, name, name_len, false,
++					       ATH11K_BDF_NAME_FULL);
+ }
+ 
+ static int ath11k_core_create_bus_type_board_name(struct ath11k_base *ab, char *name,
+ 						  size_t name_len)
+ {
+-	return __ath11k_core_create_board_name(ab, name, name_len, false, true);
++	return __ath11k_core_create_board_name(ab, name, name_len, false,
++					       ATH11K_BDF_NAME_BUS_NAME);
++}
++
++static int ath11k_core_create_chip_id_board_name(struct ath11k_base *ab, char *name,
++						 size_t name_len)
++{
++	return __ath11k_core_create_board_name(ab, name, name_len, false,
++					       ATH11K_BDF_NAME_CHIP_ID);
+ }
+ 
+ const struct firmware *ath11k_core_firmware_request(struct ath11k_base *ab,
+@@ -1289,16 +1315,21 @@ int ath11k_core_fetch_board_data_api_1(s
+ #define BOARD_NAME_SIZE 200
+ int ath11k_core_fetch_bdf(struct ath11k_base *ab, struct ath11k_board_data *bd)
+ {
+-	char boardname[BOARD_NAME_SIZE], fallback_boardname[BOARD_NAME_SIZE];
++	char *boardname = NULL, *fallback_boardname = NULL, *chip_id_boardname = NULL;
+ 	char *filename, filepath[100];
+-	int ret;
++	int ret = 0;
+ 
+ 	filename = ATH11K_BOARD_API2_FILE;
++	boardname = kzalloc(BOARD_NAME_SIZE, GFP_KERNEL);
++	if (!boardname) {
++		ret = -ENOMEM;
++		goto exit;
++	}
+ 
+-	ret = ath11k_core_create_board_name(ab, boardname, sizeof(boardname));
++	ret = ath11k_core_create_board_name(ab, boardname, BOARD_NAME_SIZE);
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to create board name: %d", ret);
+-		return ret;
++		goto exit;
+ 	}
+ 
+ 	ab->bd_api = 2;
+@@ -1307,13 +1338,19 @@ int ath11k_core_fetch_bdf(struct ath11k_
+ 						 ATH11K_BD_IE_BOARD_NAME,
+ 						 ATH11K_BD_IE_BOARD_DATA);
+ 	if (!ret)
+-		goto success;
++		goto exit;
++
++	fallback_boardname = kzalloc(BOARD_NAME_SIZE, GFP_KERNEL);
++	if (!fallback_boardname) {
++		ret = -ENOMEM;
++		goto exit;
++	}
+ 
+ 	ret = ath11k_core_create_fallback_board_name(ab, fallback_boardname,
+-						     sizeof(fallback_boardname));
++						     BOARD_NAME_SIZE);
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to create fallback board name: %d", ret);
+-		return ret;
++		goto exit;
+ 	}
+ 
+ 	ret = ath11k_core_fetch_board_data_api_n(ab, bd, fallback_boardname,
+@@ -1321,7 +1358,28 @@ int ath11k_core_fetch_bdf(struct ath11k_
+ 						 ATH11K_BD_IE_BOARD_NAME,
+ 						 ATH11K_BD_IE_BOARD_DATA);
+ 	if (!ret)
+-		goto success;
++		goto exit;
++
++	chip_id_boardname = kzalloc(BOARD_NAME_SIZE, GFP_KERNEL);
++	if (!chip_id_boardname) {
++		ret = -ENOMEM;
++		goto exit;
++	}
++
++	ret = ath11k_core_create_chip_id_board_name(ab, chip_id_boardname,
++						    BOARD_NAME_SIZE);
++	if (ret) {
++		ath11k_err(ab, "failed to create chip id board name: %d", ret);
++		goto exit;
++	}
++
++	ret = ath11k_core_fetch_board_data_api_n(ab, bd, chip_id_boardname,
++						 ATH11K_BD_IE_BOARD,
++						 ATH11K_BD_IE_BOARD_NAME,
++						 ATH11K_BD_IE_BOARD_DATA);
++
++	if (!ret)
++		goto exit;
+ 
+ 	ab->bd_api = 1;
+ 	ret = ath11k_core_fetch_board_data_api_1(ab, bd, ATH11K_DEFAULT_BOARD_FILE);
+@@ -1334,14 +1392,22 @@ int ath11k_core_fetch_bdf(struct ath11k_
+ 			ath11k_err(ab, "failed to fetch board data for %s from %s\n",
+ 				   fallback_boardname, filepath);
+ 
++		ath11k_err(ab, "failed to fetch board data for %s from %s\n",
++			   chip_id_boardname, filepath);
++
+ 		ath11k_err(ab, "failed to fetch board.bin from %s\n",
+ 			   ab->hw_params.fw.dir);
+-		return ret;
+ 	}
+ 
+-success:
+-	ath11k_dbg(ab, ATH11K_DBG_BOOT, "using board api %d\n", ab->bd_api);
+-	return 0;
++exit:
++	kfree(boardname);
++	kfree(fallback_boardname);
++	kfree(chip_id_boardname);
++
++	if (!ret)
++		ath11k_dbg(ab, ATH11K_DBG_BOOT, "using board api %d\n", ab->bd_api);
++
++	return ret;
+ }
+ 
+ int ath11k_core_fetch_regdb(struct ath11k_base *ab, struct ath11k_board_data *bd)

--- a/package/kernel/mac80211/patches/ath11k/0017-wifi-ath11k-fix-boot-failure-with-one-MSI-vector.patch
+++ b/package/kernel/mac80211/patches/ath11k/0017-wifi-ath11k-fix-boot-failure-with-one-MSI-vector.patch
@@ -1,0 +1,103 @@
+From 39564b475ac5a589e6c22c43a08cbd283c295d2c Mon Sep 17 00:00:00 2001
+From: Baochen Qiang <quic_bqiang@quicinc.com>
+Date: Thu, 7 Sep 2023 09:56:06 +0800
+Subject: [PATCH] wifi: ath11k: fix boot failure with one MSI vector
+
+Commit 5b32b6dd96633 ("ath11k: Remove core PCI references from
+PCI common code") breaks with one MSI vector because it moves
+affinity setting after IRQ request, see below log:
+
+[ 1417.278835] ath11k_pci 0000:02:00.0: failed to receive control response completion, polling..
+[ 1418.302829] ath11k_pci 0000:02:00.0: Service connect timeout
+[ 1418.302833] ath11k_pci 0000:02:00.0: failed to connect to HTT: -110
+[ 1418.303669] ath11k_pci 0000:02:00.0: failed to start core: -110
+
+The detail is, if do affinity request after IRQ activated,
+which is done in request_irq(), kernel caches that request and
+returns success directly. Later when a subsequent MHI interrupt is
+fired, kernel will do the real affinity setting work, as a result,
+changs the MSI vector. However at that time host has configured
+old vector to hardware, so host never receives CE or DP interrupts.
+
+Fix it by setting affinity before registering MHI controller
+where host is, for the first time, doing IRQ request.
+
+Tested-on: WCN6855 hw2.0 PCI WLAN.HSP.1.1-03125-QCAHSPSWPL_V1_V2_SILICONZ_LITE-3
+Tested-on: WCN6855 hw2.1 PCI WLAN.HSP.1.1-03125-QCAHSPSWPL_V1_V2_SILICONZ_LITE-3.6510.23
+Tested-on: WCN6750 hw1.0 AHB WLAN.MSL.1.0.1-01160-QCAMSLSWPLZ-1
+
+Fixes: 5b32b6dd9663 ("ath11k: Remove core PCI references from PCI common code")
+Signed-off-by: Baochen Qiang <quic_bqiang@quicinc.com>
+Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230907015606.16297-1-quic_bqiang@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/pci.c | 24 ++++++++++++------------
+ 1 file changed, 12 insertions(+), 12 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/pci.c
++++ b/drivers/net/wireless/ath/ath11k/pci.c
+@@ -852,10 +852,16 @@ unsupported_wcn6855_soc:
+ 	if (ret)
+ 		goto err_pci_disable_msi;
+ 
++	ret = ath11k_pci_set_irq_affinity_hint(ab_pci, cpumask_of(0));
++	if (ret) {
++		ath11k_err(ab, "failed to set irq affinity %d\n", ret);
++		goto err_pci_disable_msi;
++	}
++
+ 	ret = ath11k_mhi_register(ab_pci);
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to register mhi: %d\n", ret);
+-		goto err_pci_disable_msi;
++		goto err_irq_affinity_cleanup;
+ 	}
+ 
+ 	ret = ath11k_hal_srng_init(ab);
+@@ -876,12 +882,6 @@ unsupported_wcn6855_soc:
+ 		goto err_ce_free;
+ 	}
+ 
+-	ret = ath11k_pci_set_irq_affinity_hint(ab_pci, cpumask_of(0));
+-	if (ret) {
+-		ath11k_err(ab, "failed to set irq affinity %d\n", ret);
+-		goto err_free_irq;
+-	}
+-
+ 	/* kernel may allocate a dummy vector before request_irq and
+ 	 * then allocate a real vector when request_irq is called.
+ 	 * So get msi_data here again to avoid spurious interrupt
+@@ -890,20 +890,17 @@ unsupported_wcn6855_soc:
+ 	ret = ath11k_pci_config_msi_data(ab_pci);
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to config msi_data: %d\n", ret);
+-		goto err_irq_affinity_cleanup;
++		goto err_free_irq;
+ 	}
+ 
+ 	ret = ath11k_core_init(ab);
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to init core: %d\n", ret);
+-		goto err_irq_affinity_cleanup;
++		goto err_free_irq;
+ 	}
+ 	ath11k_qmi_fwreset_from_cold_boot(ab);
+ 	return 0;
+ 
+-err_irq_affinity_cleanup:
+-	ath11k_pci_set_irq_affinity_hint(ab_pci, NULL);
+-
+ err_free_irq:
+ 	ath11k_pcic_free_irq(ab);
+ 
+@@ -916,6 +913,9 @@ err_hal_srng_deinit:
+ err_mhi_unregister:
+ 	ath11k_mhi_unregister(ab_pci);
+ 
++err_irq_affinity_cleanup:
++	ath11k_pci_set_irq_affinity_hint(ab_pci, NULL);
++
+ err_pci_disable_msi:
+ 	ath11k_pci_free_msi(ab_pci);
+ 

--- a/package/kernel/mac80211/patches/ath11k/0018-wifi-ath11k-drop-NULL-pointer-check-in-ath11k_update.patch
+++ b/package/kernel/mac80211/patches/ath11k/0018-wifi-ath11k-drop-NULL-pointer-check-in-ath11k_update.patch
@@ -1,0 +1,32 @@
+From ac13a7842ab46a87aa315514d6d7e19b03cb2adc Mon Sep 17 00:00:00 2001
+From: Dmitry Antipov <dmantipov@yandex.ru>
+Date: Wed, 6 Sep 2023 12:36:55 +0300
+Subject: [PATCH] wifi: ath11k: drop NULL pointer check in
+ ath11k_update_per_peer_tx_stats()
+
+Since 'user_stats' is a fixed-size array of 'struct htt_ppdu_user_stats'
+in 'struct htt_ppdu_stats', any of its member can't be NULL and so
+relevant check may be dropped.
+
+Found by Linux Verification Center (linuxtesting.org) with SVACE.
+
+Signed-off-by: Dmitry Antipov <dmantipov@yandex.ru>
+Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230906093704.14001-1-dmantipov@yandex.ru
+---
+ drivers/net/wireless/ath/ath11k/dp_rx.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/dp_rx.c
++++ b/drivers/net/wireless/ath/ath11k/dp_rx.c
+@@ -1388,9 +1388,6 @@ ath11k_update_per_peer_tx_stats(struct a
+ 	u8 tid = HTT_PPDU_STATS_NON_QOS_TID;
+ 	bool is_ampdu = false;
+ 
+-	if (!usr_stats)
+-		return;
+-
+ 	if (!(usr_stats->tlv_flags & BIT(HTT_PPDU_STATS_TAG_USR_RATE)))
+ 		return;
+ 

--- a/package/kernel/mac80211/patches/ath11k/0019-wifi-ath11k-drop-redundant-check-in-ath11k_dp_rx_mon.patch
+++ b/package/kernel/mac80211/patches/ath11k/0019-wifi-ath11k-drop-redundant-check-in-ath11k_dp_rx_mon.patch
@@ -1,0 +1,38 @@
+From 82ae3f4635382ff23e2ece55b5d5e713223951ec Mon Sep 17 00:00:00 2001
+From: Dmitry Antipov <dmantipov@yandex.ru>
+Date: Thu, 24 Aug 2023 10:50:44 +0300
+Subject: [PATCH] wifi: ath11k: drop redundant check in
+ ath11k_dp_rx_mon_dest_process()
+
+In 'ath11k_dp_rx_mon_dest_process()', 'mon_dst_srng' points to
+a member of 'srng_list', which is a fixed-size array inside
+'struct ath11k_hal'. This way, if 'ring_id' is valid (i. e.
+between 0 and HAL_SRNG_RING_ID_MAX - 1 inclusive), 'mon_dst_srng'
+can't be NULL and so relevant check may be dropped.
+
+Found by Linux Verification Center (linuxtesting.org) with SVACE.
+
+Signed-off-by: Dmitry Antipov <dmantipov@yandex.ru>
+Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230824075121.121144-1-dmantipov@yandex.ru
+---
+ drivers/net/wireless/ath/ath11k/dp_rx.c | 7 -------
+ 1 file changed, 7 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/dp_rx.c
++++ b/drivers/net/wireless/ath/ath11k/dp_rx.c
+@@ -5094,13 +5094,6 @@ static void ath11k_dp_rx_mon_dest_proces
+ 
+ 	mon_dst_srng = &ar->ab->hal.srng_list[ring_id];
+ 
+-	if (!mon_dst_srng) {
+-		ath11k_warn(ar->ab,
+-			    "HAL Monitor Destination Ring Init Failed -- %p",
+-			    mon_dst_srng);
+-		return;
+-	}
+-
+ 	spin_lock_bh(&pmon->mon_lock);
+ 
+ 	ath11k_hal_srng_access_begin(ar->ab, mon_dst_srng);

--- a/package/kernel/mac80211/patches/ath11k/0020-wifi-ath11k-remove-unused-members-of-struct-ath11k_b.patch
+++ b/package/kernel/mac80211/patches/ath11k/0020-wifi-ath11k-remove-unused-members-of-struct-ath11k_b.patch
@@ -1,0 +1,46 @@
+From 9066794113c4813b6ce4a66ed6ce14ecdf35625d Mon Sep 17 00:00:00 2001
+From: Dmitry Antipov <dmantipov@yandex.ru>
+Date: Thu, 24 Aug 2023 10:50:45 +0300
+Subject: [PATCH] wifi: ath11k: remove unused members of 'struct ath11k_base'
+
+Remove set but otherwise unused 'wlan_init_status' and
+'wmi_ready' members of 'struct ath11k_base', adjust
+'ath11k_wmi_tlv_rdy_parse()' accordingly.
+
+Signed-off-by: Dmitry Antipov <dmantipov@yandex.ru>
+Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230824075121.121144-2-dmantipov@yandex.ru
+---
+ drivers/net/wireless/ath/ath11k/core.h | 2 --
+ drivers/net/wireless/ath/ath11k/wmi.c  | 2 --
+ 2 files changed, 4 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/core.h
++++ b/drivers/net/wireless/ath/ath11k/core.h
+@@ -901,8 +901,6 @@ struct ath11k_base {
+ 	struct list_head peers;
+ 	wait_queue_head_t peer_mapping_wq;
+ 	u8 mac_addr[ETH_ALEN];
+-	bool wmi_ready;
+-	u32 wlan_init_status;
+ 	int irq_num[ATH11K_IRQ_NUM_MAX];
+ 	struct ath11k_ext_irq_grp ext_irq_grp[ATH11K_EXT_IRQ_GRP_NUM_MAX];
+ 	struct ath11k_targ_cap target_caps;
+--- a/drivers/net/wireless/ath/ath11k/wmi.c
++++ b/drivers/net/wireless/ath/ath11k/wmi.c
+@@ -7222,14 +7222,12 @@ static int ath11k_wmi_tlv_rdy_parse(stru
+ 		memset(&fixed_param, 0, sizeof(fixed_param));
+ 		memcpy(&fixed_param, (struct wmi_ready_event *)ptr,
+ 		       min_t(u16, sizeof(fixed_param), len));
+-		ab->wlan_init_status = fixed_param.ready_event_min.status;
+ 		rdy_parse->num_extra_mac_addr =
+ 			fixed_param.ready_event_min.num_extra_mac_addr;
+ 
+ 		ether_addr_copy(ab->mac_addr,
+ 				fixed_param.ready_event_min.mac_addr.addr);
+ 		ab->pktlog_defs_checksum = fixed_param.pktlog_defs_checksum;
+-		ab->wmi_ready = true;
+ 		break;
+ 	case WMI_TAG_ARRAY_FIXED_STRUCT:
+ 		addr_list = (struct wmi_mac_addr *)ptr;

--- a/package/kernel/mac80211/patches/ath11k/0021-wifi-ath11k-use-kstrtoul_from_user-where-appropriate.patch
+++ b/package/kernel/mac80211/patches/ath11k/0021-wifi-ath11k-use-kstrtoul_from_user-where-appropriate.patch
@@ -1,0 +1,60 @@
+From 458f66c30df2b8495790cf6fca76ebad44046921 Mon Sep 17 00:00:00 2001
+From: Dmitry Antipov <dmantipov@yandex.ru>
+Date: Thu, 21 Sep 2023 11:16:57 +0300
+Subject: [PATCH] wifi: ath11k: use kstrtoul_from_user() where appropriate
+
+Use 'kstrtoul_from_user()' in 'ath11k_write_file_spectral_count()'
+and 'ath11k_write_file_spectral_bins()'
+
+Signed-off-by: Dmitry Antipov <dmantipov@yandex.ru>
+Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230824075121.121144-4-dmantipov@yandex.ru
+---
+ drivers/net/wireless/ath/ath11k/spectral.c | 26 +++++++---------------
+ 1 file changed, 8 insertions(+), 18 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/spectral.c
++++ b/drivers/net/wireless/ath/ath11k/spectral.c
+@@ -386,16 +386,11 @@ static ssize_t ath11k_write_file_spectra
+ {
+ 	struct ath11k *ar = file->private_data;
+ 	unsigned long val;
+-	char buf[32];
+-	ssize_t len;
+-
+-	len = min(count, sizeof(buf) - 1);
+-	if (copy_from_user(buf, user_buf, len))
+-		return -EFAULT;
++	ssize_t ret;
+ 
+-	buf[len] = '\0';
+-	if (kstrtoul(buf, 0, &val))
+-		return -EINVAL;
++	ret = kstrtoul_from_user(user_buf, count, 0, &val);
++	if (ret)
++		return ret;
+ 
+ 	if (val > ATH11K_SPECTRAL_SCAN_COUNT_MAX)
+ 		return -EINVAL;
+@@ -441,16 +436,11 @@ static ssize_t ath11k_write_file_spectra
+ {
+ 	struct ath11k *ar = file->private_data;
+ 	unsigned long val;
+-	char buf[32];
+-	ssize_t len;
+-
+-	len = min(count, sizeof(buf) - 1);
+-	if (copy_from_user(buf, user_buf, len))
+-		return -EFAULT;
++	ssize_t ret;
+ 
+-	buf[len] = '\0';
+-	if (kstrtoul(buf, 0, &val))
+-		return -EINVAL;
++	ret = kstrtoul_from_user(user_buf, count, 0, &val);
++	if (ret)
++		return ret;
+ 
+ 	if (val < ATH11K_SPECTRAL_MIN_BINS ||
+ 	    val > ar->ab->hw_params.spectral.max_fft_bins)

--- a/package/kernel/mac80211/patches/ath11k/0022-wifi-ath11k-remove-unnecessary-void-conversions.patch
+++ b/package/kernel/mac80211/patches/ath11k/0022-wifi-ath11k-remove-unnecessary-void-conversions.patch
@@ -1,0 +1,248 @@
+From 87fd0602610d6965c45afc61780ac98842e8f902 Mon Sep 17 00:00:00 2001
+From: Wu Yunchuan <yunchuan@nfschina.com>
+Date: Thu, 21 Sep 2023 11:50:05 +0300
+Subject: [PATCH] wifi: ath11k: remove unnecessary (void*) conversions
+
+No need cast (void *) to (struct ath11k_base *),
+struct hal_rx_msdu_link *), (struct ath11k_buffer_addr *) or
+other types.
+
+Signed-off-by: Wu Yunchuan <yunchuan@nfschina.com>
+Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230919045150.524304-1-yunchuan@nfschina.com
+---
+ drivers/net/wireless/ath/ath11k/dp.c       |  2 +-
+ drivers/net/wireless/ath/ath11k/dp_rx.c    | 13 +++++--------
+ drivers/net/wireless/ath/ath11k/hal.c      |  8 +++-----
+ drivers/net/wireless/ath/ath11k/hal_rx.c   | 17 +++++++----------
+ drivers/net/wireless/ath/ath11k/hal_tx.c   |  2 +-
+ drivers/net/wireless/ath/ath11k/mac.c      |  4 ++--
+ drivers/net/wireless/ath/ath11k/spectral.c |  2 +-
+ drivers/net/wireless/ath/ath11k/wmi.c      |  6 +++---
+ 8 files changed, 23 insertions(+), 31 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/dp.c
++++ b/drivers/net/wireless/ath/ath11k/dp.c
+@@ -1009,7 +1009,7 @@ void ath11k_dp_vdev_tx_attach(struct ath
+ 
+ static int ath11k_dp_tx_pending_cleanup(int buf_id, void *skb, void *ctx)
+ {
+-	struct ath11k_base *ab = (struct ath11k_base *)ctx;
++	struct ath11k_base *ab = ctx;
+ 	struct sk_buff *msdu = skb;
+ 
+ 	dma_unmap_single(ab->dev, ATH11K_SKB_CB(msdu)->paddr, msdu->len,
+--- a/drivers/net/wireless/ath/ath11k/dp_rx.c
++++ b/drivers/net/wireless/ath/ath11k/dp_rx.c
+@@ -1256,7 +1256,7 @@ static int ath11k_htt_tlv_ppdu_stats_par
+ 	int cur_user;
+ 	u16 peer_id;
+ 
+-	ppdu_info = (struct htt_ppdu_stats_info *)data;
++	ppdu_info = data;
+ 
+ 	switch (tag) {
+ 	case HTT_PPDU_STATS_TAG_COMMON:
+@@ -4486,8 +4486,7 @@ int ath11k_dp_rx_monitor_link_desc_retur
+ 	src_srng_desc = ath11k_hal_srng_src_get_next_entry(ar->ab, hal_srng);
+ 
+ 	if (src_srng_desc) {
+-		struct ath11k_buffer_addr *src_desc =
+-				(struct ath11k_buffer_addr *)src_srng_desc;
++		struct ath11k_buffer_addr *src_desc = src_srng_desc;
+ 
+ 		*src_desc = *((struct ath11k_buffer_addr *)p_last_buf_addr_info);
+ 	} else {
+@@ -4506,8 +4505,7 @@ void ath11k_dp_rx_mon_next_link_desc_get
+ 					 u8 *rbm,
+ 					 void **pp_buf_addr_info)
+ {
+-	struct hal_rx_msdu_link *msdu_link =
+-			(struct hal_rx_msdu_link *)rx_msdu_link_desc;
++	struct hal_rx_msdu_link *msdu_link = rx_msdu_link_desc;
+ 	struct ath11k_buffer_addr *buf_addr_info;
+ 
+ 	buf_addr_info = (struct ath11k_buffer_addr *)&msdu_link->buf_addr_info;
+@@ -4548,7 +4546,7 @@ static void ath11k_hal_rx_msdu_list_get(
+ 	u32 first = FIELD_PREP(RX_MSDU_DESC_INFO0_FIRST_MSDU_IN_MPDU, 1);
+ 	u8  tmp  = 0;
+ 
+-	msdu_link = (struct hal_rx_msdu_link *)msdu_link_desc;
++	msdu_link = msdu_link_desc;
+ 	msdu_details = &msdu_link->msdu_link[0];
+ 
+ 	for (i = 0; i < HAL_RX_NUM_MSDU_DESC; i++) {
+@@ -4645,8 +4643,7 @@ ath11k_dp_rx_mon_mpdu_pop(struct ath11k
+ 	bool is_frag, is_first_msdu;
+ 	bool drop_mpdu = false;
+ 	struct ath11k_skb_rxcb *rxcb;
+-	struct hal_reo_entrance_ring *ent_desc =
+-			(struct hal_reo_entrance_ring *)ring_entry;
++	struct hal_reo_entrance_ring *ent_desc = ring_entry;
+ 	int buf_id;
+ 	u32 rx_link_buf_info[2];
+ 	u8 rbm;
+--- a/drivers/net/wireless/ath/ath11k/hal.c
++++ b/drivers/net/wireless/ath/ath11k/hal.c
+@@ -571,7 +571,7 @@ u32 ath11k_hal_ce_get_desc_size(enum hal
+ void ath11k_hal_ce_src_set_desc(void *buf, dma_addr_t paddr, u32 len, u32 id,
+ 				u8 byte_swap_data)
+ {
+-	struct hal_ce_srng_src_desc *desc = (struct hal_ce_srng_src_desc *)buf;
++	struct hal_ce_srng_src_desc *desc = buf;
+ 
+ 	desc->buffer_addr_low = paddr & HAL_ADDR_LSB_REG_MASK;
+ 	desc->buffer_addr_info =
+@@ -586,8 +586,7 @@ void ath11k_hal_ce_src_set_desc(void *bu
+ 
+ void ath11k_hal_ce_dst_set_desc(void *buf, dma_addr_t paddr)
+ {
+-	struct hal_ce_srng_dest_desc *desc =
+-		(struct hal_ce_srng_dest_desc *)buf;
++	struct hal_ce_srng_dest_desc *desc = buf;
+ 
+ 	desc->buffer_addr_low = paddr & HAL_ADDR_LSB_REG_MASK;
+ 	desc->buffer_addr_info =
+@@ -597,8 +596,7 @@ void ath11k_hal_ce_dst_set_desc(void *bu
+ 
+ u32 ath11k_hal_ce_dst_status_get_length(void *buf)
+ {
+-	struct hal_ce_srng_dst_status_desc *desc =
+-		(struct hal_ce_srng_dst_status_desc *)buf;
++	struct hal_ce_srng_dst_status_desc *desc = buf;
+ 	u32 len;
+ 
+ 	len = FIELD_GET(HAL_CE_DST_STATUS_DESC_FLAGS_LEN, desc->flags);
+--- a/drivers/net/wireless/ath/ath11k/hal_rx.c
++++ b/drivers/net/wireless/ath/ath11k/hal_rx.c
+@@ -265,7 +265,7 @@ out:
+ void ath11k_hal_rx_buf_addr_info_set(void *desc, dma_addr_t paddr,
+ 				     u32 cookie, u8 manager)
+ {
+-	struct ath11k_buffer_addr *binfo = (struct ath11k_buffer_addr *)desc;
++	struct ath11k_buffer_addr *binfo = desc;
+ 	u32 paddr_lo, paddr_hi;
+ 
+ 	paddr_lo = lower_32_bits(paddr);
+@@ -279,7 +279,7 @@ void ath11k_hal_rx_buf_addr_info_set(voi
+ void ath11k_hal_rx_buf_addr_info_get(void *desc, dma_addr_t *paddr,
+ 				     u32 *cookie, u8 *rbm)
+ {
+-	struct ath11k_buffer_addr *binfo = (struct ath11k_buffer_addr *)desc;
++	struct ath11k_buffer_addr *binfo = desc;
+ 
+ 	*paddr =
+ 		(((u64)FIELD_GET(BUFFER_ADDR_INFO1_ADDR, binfo->info1)) << 32) |
+@@ -292,7 +292,7 @@ void ath11k_hal_rx_msdu_link_info_get(vo
+ 				      u32 *msdu_cookies,
+ 				      enum hal_rx_buf_return_buf_manager *rbm)
+ {
+-	struct hal_rx_msdu_link *link = (struct hal_rx_msdu_link *)link_desc;
++	struct hal_rx_msdu_link *link = link_desc;
+ 	struct hal_rx_msdu_details *msdu;
+ 	int i;
+ 
+@@ -699,7 +699,7 @@ u32 ath11k_hal_reo_qdesc_size(u32 ba_win
+ void ath11k_hal_reo_qdesc_setup(void *vaddr, int tid, u32 ba_window_size,
+ 				u32 start_seq, enum hal_pn_type type)
+ {
+-	struct hal_rx_reo_queue *qdesc = (struct hal_rx_reo_queue *)vaddr;
++	struct hal_rx_reo_queue *qdesc = vaddr;
+ 	struct hal_rx_reo_queue_ext *ext_desc;
+ 
+ 	memset(qdesc, 0, sizeof(*qdesc));
+@@ -809,8 +809,7 @@ static inline void
+ ath11k_hal_rx_handle_ofdma_info(void *rx_tlv,
+ 				struct hal_rx_user_status *rx_user_status)
+ {
+-	struct hal_rx_ppdu_end_user_stats *ppdu_end_user =
+-		(struct hal_rx_ppdu_end_user_stats *)rx_tlv;
++	struct hal_rx_ppdu_end_user_stats *ppdu_end_user = rx_tlv;
+ 
+ 	rx_user_status->ul_ofdma_user_v0_word0 = __le32_to_cpu(ppdu_end_user->info6);
+ 
+@@ -821,8 +820,7 @@ static inline void
+ ath11k_hal_rx_populate_byte_count(void *rx_tlv, void *ppduinfo,
+ 				  struct hal_rx_user_status *rx_user_status)
+ {
+-	struct hal_rx_ppdu_end_user_stats *ppdu_end_user =
+-		(struct hal_rx_ppdu_end_user_stats *)rx_tlv;
++	struct hal_rx_ppdu_end_user_stats *ppdu_end_user = rx_tlv;
+ 
+ 	rx_user_status->mpdu_ok_byte_count =
+ 		FIELD_GET(HAL_RX_PPDU_END_USER_STATS_INFO8_MPDU_OK_BYTE_COUNT,
+@@ -1540,8 +1538,7 @@ void ath11k_hal_rx_reo_ent_buf_paddr_get
+ 					 u32 *sw_cookie, void **pp_buf_addr,
+ 					 u8 *rbm, u32 *msdu_cnt)
+ {
+-	struct hal_reo_entrance_ring *reo_ent_ring =
+-		(struct hal_reo_entrance_ring *)rx_desc;
++	struct hal_reo_entrance_ring *reo_ent_ring = rx_desc;
+ 	struct ath11k_buffer_addr *buf_addr_info;
+ 	struct rx_mpdu_desc *rx_mpdu_desc_info_details;
+ 
+--- a/drivers/net/wireless/ath/ath11k/hal_tx.c
++++ b/drivers/net/wireless/ath/ath11k/hal_tx.c
+@@ -37,7 +37,7 @@ static const u8 dscp_tid_map[DSCP_TID_MA
+ void ath11k_hal_tx_cmd_desc_setup(struct ath11k_base *ab, void *cmd,
+ 				  struct hal_tx_info *ti)
+ {
+-	struct hal_tcl_data_cmd *tcl_cmd = (struct hal_tcl_data_cmd *)cmd;
++	struct hal_tcl_data_cmd *tcl_cmd = cmd;
+ 
+ 	tcl_cmd->buf_addr_info.info0 =
+ 		FIELD_PREP(BUFFER_ADDR_INFO0_ADDR, ti->paddr);
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -6970,8 +6970,8 @@ err:
+ 
+ static int ath11k_mac_vif_unref(int buf_id, void *skb, void *ctx)
+ {
+-	struct ieee80211_vif *vif = (struct ieee80211_vif *)ctx;
+-	struct ath11k_skb_cb *skb_cb = ATH11K_SKB_CB((struct sk_buff *)skb);
++	struct ieee80211_vif *vif = ctx;
++	struct ath11k_skb_cb *skb_cb = ATH11K_SKB_CB(skb);
+ 
+ 	if (skb_cb->vif == vif)
+ 		skb_cb->vif = NULL;
+--- a/drivers/net/wireless/ath/ath11k/spectral.c
++++ b/drivers/net/wireless/ath/ath11k/spectral.c
+@@ -592,7 +592,7 @@ int ath11k_spectral_process_fft(struct a
+ 		return -EINVAL;
+ 	}
+ 
+-	tlv = (struct spectral_tlv *)data;
++	tlv = data;
+ 	tlv_len = FIELD_GET(SPECTRAL_TLV_HDR_LEN, __le32_to_cpu(tlv->header));
+ 	/* convert Dword into bytes */
+ 	tlv_len *= ATH11K_SPECTRAL_DWORD_SIZE;
+--- a/drivers/net/wireless/ath/ath11k/wmi.c
++++ b/drivers/net/wireless/ath/ath11k/wmi.c
+@@ -2281,7 +2281,7 @@ int ath11k_wmi_send_scan_start_cmd(struc
+ 	tlv->header = FIELD_PREP(WMI_TLV_TAG, WMI_TAG_ARRAY_UINT32) |
+ 		      FIELD_PREP(WMI_TLV_LEN, len);
+ 	ptr += TLV_HDR_SIZE;
+-	tmp_ptr = (u32 *)ptr;
++	tmp_ptr = ptr;
+ 
+ 	for (i = 0; i < params->num_chan; ++i)
+ 		tmp_ptr[i] = params->chan_list[i];
+@@ -4148,7 +4148,7 @@ static int ath11k_init_cmd_send(struct a
+ 	ptr += TLV_HDR_SIZE + len;
+ 
+ 	if (param->hw_mode_id != WMI_HOST_HW_MODE_MAX) {
+-		hw_mode = (struct wmi_pdev_set_hw_mode_cmd_param *)ptr;
++		hw_mode = ptr;
+ 		hw_mode->tlv_header = FIELD_PREP(WMI_TLV_TAG,
+ 						 WMI_TAG_PDEV_SET_HW_MODE_CMD) |
+ 				      FIELD_PREP(WMI_TLV_LEN,
+@@ -4168,7 +4168,7 @@ static int ath11k_init_cmd_send(struct a
+ 		len = sizeof(*band_to_mac);
+ 
+ 		for (idx = 0; idx < param->num_band_to_mac; idx++) {
+-			band_to_mac = (void *)ptr;
++			band_to_mac = ptr;
+ 
+ 			band_to_mac->tlv_header = FIELD_PREP(WMI_TLV_TAG,
+ 							     WMI_TAG_PDEV_BAND_TO_MAC) |

--- a/package/kernel/mac80211/patches/ath11k/0023-wifi-ath11k-fix-ath11k_mac_op_remain_on_channel-stac.patch
+++ b/package/kernel/mac80211/patches/ath11k/0023-wifi-ath11k-fix-ath11k_mac_op_remain_on_channel-stac.patch
@@ -1,0 +1,96 @@
+From 4fd15bb705d3faa7e6adab2daba2e3af80d9b6bd Mon Sep 17 00:00:00 2001
+From: Dmitry Antipov <dmantipov@yandex.ru>
+Date: Tue, 26 Sep 2023 07:29:04 +0300
+Subject: [PATCH] wifi: ath11k: fix ath11k_mac_op_remain_on_channel() stack
+ usage
+
+When compiling with clang 16.0.6, I've noticed the following:
+
+drivers/net/wireless/ath/ath11k/mac.c:8903:12: warning: stack frame
+size (1032) exceeds limit (1024) in 'ath11k_mac_op_remain_on_channel'
+[-Wframe-larger-than]
+static int ath11k_mac_op_remain_on_channel(struct ieee80211_hw *hw,
+           ^
+68/1032 (6.59%) spills, 964/1032 (93.41%) variables
+
+So switch to kzalloc()'ed instance of 'struct scan_req_params' like
+it's done in 'ath11k_mac_op_hw_scan()'. Compile tested only.
+
+Signed-off-by: Dmitry Antipov <dmantipov@yandex.ru>
+Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230926042906.13725-1-dmantipov@yandex.ru
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 44 +++++++++++++++------------
+ 1 file changed, 25 insertions(+), 19 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -8908,7 +8908,7 @@ static int ath11k_mac_op_remain_on_chann
+ {
+ 	struct ath11k *ar = hw->priv;
+ 	struct ath11k_vif *arvif = ath11k_vif_to_arvif(vif);
+-	struct scan_req_params arg;
++	struct scan_req_params *arg;
+ 	int ret;
+ 	u32 scan_time_msec;
+ 
+@@ -8940,27 +8940,31 @@ static int ath11k_mac_op_remain_on_chann
+ 
+ 	scan_time_msec = ar->hw->wiphy->max_remain_on_channel_duration * 2;
+ 
+-	memset(&arg, 0, sizeof(arg));
+-	ath11k_wmi_start_scan_init(ar, &arg);
+-	arg.num_chan = 1;
+-	arg.chan_list = kcalloc(arg.num_chan, sizeof(*arg.chan_list),
+-				GFP_KERNEL);
+-	if (!arg.chan_list) {
++	arg = kzalloc(sizeof(*arg), GFP_KERNEL);
++	if (!arg) {
+ 		ret = -ENOMEM;
+ 		goto exit;
+ 	}
++	ath11k_wmi_start_scan_init(ar, arg);
++	arg->num_chan = 1;
++	arg->chan_list = kcalloc(arg->num_chan, sizeof(*arg->chan_list),
++				 GFP_KERNEL);
++	if (!arg->chan_list) {
++		ret = -ENOMEM;
++		goto free_arg;
++	}
+ 
+-	arg.vdev_id = arvif->vdev_id;
+-	arg.scan_id = ATH11K_SCAN_ID;
+-	arg.chan_list[0] = chan->center_freq;
+-	arg.dwell_time_active = scan_time_msec;
+-	arg.dwell_time_passive = scan_time_msec;
+-	arg.max_scan_time = scan_time_msec;
+-	arg.scan_flags |= WMI_SCAN_FLAG_PASSIVE;
+-	arg.scan_flags |= WMI_SCAN_FILTER_PROBE_REQ;
+-	arg.burst_duration = duration;
++	arg->vdev_id = arvif->vdev_id;
++	arg->scan_id = ATH11K_SCAN_ID;
++	arg->chan_list[0] = chan->center_freq;
++	arg->dwell_time_active = scan_time_msec;
++	arg->dwell_time_passive = scan_time_msec;
++	arg->max_scan_time = scan_time_msec;
++	arg->scan_flags |= WMI_SCAN_FLAG_PASSIVE;
++	arg->scan_flags |= WMI_SCAN_FILTER_PROBE_REQ;
++	arg->burst_duration = duration;
+ 
+-	ret = ath11k_start_scan(ar, &arg);
++	ret = ath11k_start_scan(ar, arg);
+ 	if (ret) {
+ 		ath11k_warn(ar->ab, "failed to start roc scan: %d\n", ret);
+ 
+@@ -8986,7 +8990,9 @@ static int ath11k_mac_op_remain_on_chann
+ 	ret = 0;
+ 
+ free_chan_list:
+-	kfree(arg.chan_list);
++	kfree(arg->chan_list);
++free_arg:
++	kfree(arg);
+ exit:
+ 	mutex_unlock(&ar->conf_mutex);
+ 	return ret;

--- a/package/kernel/mac80211/patches/ath11k/0024-wifi-ath11k-mac-fix-struct-ieee80211_sband_iftype_da.patch
+++ b/package/kernel/mac80211/patches/ath11k/0024-wifi-ath11k-mac-fix-struct-ieee80211_sband_iftype_da.patch
@@ -1,0 +1,67 @@
+From 9e61589ac3c2d23c528d3ffd44604d98553ea1cb Mon Sep 17 00:00:00 2001
+From: Kalle Valo <quic_kvalo@quicinc.com>
+Date: Wed, 27 Sep 2023 17:27:08 +0300
+Subject: [PATCH] wifi: ath11k: mac: fix struct ieee80211_sband_iftype_data
+ handling
+
+Commit e8c1841278a7 ("wifi: cfg80211: annotate iftype_data pointer with
+sparse") added sparse checks for struct ieee80211_sband_iftype_data handling
+which immediately found an issue in ath11k:
+
+drivers/net/wireless/ath/ath11k/mac.c:7952:22: warning: incorrect type in argument 1 (different address spaces)
+drivers/net/wireless/ath/ath11k/mac.c:7952:22:    expected struct ieee80211_sta_he_cap const *he_cap
+drivers/net/wireless/ath/ath11k/mac.c:7952:22:    got struct ieee80211_sta_he_cap const [noderef] __iftype_data *
+
+The problem here is that we are accessing sband->iftype_data directly even
+though we should use for_each_sband_iftype_data() or similar. Fortunately
+there's ieee80211_get_he_iftype_cap_vif() which is just what we need here so
+use it to get HE capabilities.
+
+Tested-on: WCN6855 hw2.0 PCI WLAN.HSP.1.1-03125-QCAHSPSWPL_V1_V2_SILICONZ_LITE-3.6510.23
+
+Reported-by: Johannes Berg <johannes@sipsolutions.net>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230927142708.2897504-2-kvalo@kernel.org
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -7913,12 +7913,14 @@ ath11k_mac_get_tx_mcs_map(const struct i
+ 
+ static bool
+ ath11k_mac_bitrate_mask_get_single_nss(struct ath11k *ar,
++				       struct ath11k_vif *arvif,
+ 				       enum nl80211_band band,
+ 				       const struct cfg80211_bitrate_mask *mask,
+ 				       int *nss)
+ {
+ 	struct ieee80211_supported_band *sband = &ar->mac.sbands[band];
+ 	u16 vht_mcs_map = le16_to_cpu(sband->vht_cap.vht_mcs.tx_mcs_map);
++	const struct ieee80211_sta_he_cap *he_cap;
+ 	u16 he_mcs_map = 0;
+ 	u8 ht_nss_mask = 0;
+ 	u8 vht_nss_mask = 0;
+@@ -7949,7 +7951,11 @@ ath11k_mac_bitrate_mask_get_single_nss(s
+ 			return false;
+ 	}
+ 
+-	he_mcs_map = le16_to_cpu(ath11k_mac_get_tx_mcs_map(&sband->iftype_data->he_cap));
++	he_cap = ieee80211_get_he_iftype_cap_vif(sband, arvif->vif);
++	if (!he_cap)
++		return false;
++
++	he_mcs_map = le16_to_cpu(ath11k_mac_get_tx_mcs_map(he_cap));
+ 
+ 	for (i = 0; i < ARRAY_SIZE(mask->control[band].he_mcs); i++) {
+ 		if (mask->control[band].he_mcs[i] == 0)
+@@ -8365,7 +8371,7 @@ ath11k_mac_op_set_bitrate_mask(struct ie
+ 		ieee80211_iterate_stations_atomic(ar->hw,
+ 						  ath11k_mac_disable_peer_fixed_rate,
+ 						  arvif);
+-	} else if (ath11k_mac_bitrate_mask_get_single_nss(ar, band, mask,
++	} else if (ath11k_mac_bitrate_mask_get_single_nss(ar, arvif, band, mask,
+ 							  &single_nss)) {
+ 		rate = WMI_FIXED_RATE_NONE;
+ 		nss = single_nss;

--- a/package/kernel/mac80211/patches/ath11k/0025-wifi-ath11k-fix-CAC-running-state-during-virtual-int.patch
+++ b/package/kernel/mac80211/patches/ath11k/0025-wifi-ath11k-fix-CAC-running-state-during-virtual-int.patch
@@ -1,0 +1,80 @@
+From 69fcb525905600a151997cd16367bb92c34a2b14 Mon Sep 17 00:00:00 2001
+From: Aditya Kumar Singh <quic_adisi@quicinc.com>
+Date: Tue, 3 Oct 2023 17:26:54 +0300
+Subject: [PATCH] wifi: ath11k: fix CAC running state during virtual interface
+ start
+
+Currently channel definition's primary channel's DFS CAC time
+as well as primary channel's state i.e usable are used to set
+the CAC_RUNNING flag for the ath11k radio structure. However,
+this is wrong since certain channel definition are possbile
+where primary channel may not be a DFS channel but, secondary
+channel is a DFS channel. For example - channel 36 with 160 MHz
+bandwidth.
+In such cases, the flag will not be set which is wrong.
+
+Fix this issue by using cfg80211_chandef_dfs_usable() function
+from cfg80211 which return trues if at least one channel is in
+usable state.
+
+While at it, modify the CAC running debug log message to print
+the CAC time as well in milli-seconds.
+
+Tested-on: QCN9074 hw1.0 PCI WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
+Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230912051857.2284-3-quic_adisi@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 19 +++++++++++--------
+ 1 file changed, 11 insertions(+), 8 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -5,6 +5,7 @@
+  */
+ 
+ #include <net/mac80211.h>
++#include <net/cfg80211.h>
+ #include <linux/etherdevice.h>
+ #include <linux/bitfield.h>
+ #include <linux/inetdevice.h>
+@@ -7196,6 +7197,7 @@ ath11k_mac_vdev_start_restart(struct ath
+ 	struct wmi_vdev_start_req_arg arg = {};
+ 	const struct cfg80211_chan_def *chandef = &ctx->def;
+ 	int ret = 0;
++	unsigned int dfs_cac_time;
+ 
+ 	lockdep_assert_held(&ar->conf_mutex);
+ 
+@@ -7275,20 +7277,21 @@ ath11k_mac_vdev_start_restart(struct ath
+ 	ath11k_dbg(ab, ATH11K_DBG_MAC,  "vdev %pM started, vdev_id %d\n",
+ 		   arvif->vif->addr, arvif->vdev_id);
+ 
+-	/* Enable CAC Flag in the driver by checking the channel DFS cac time,
+-	 * i.e dfs_cac_ms value which will be valid only for radar channels
+-	 * and state as NL80211_DFS_USABLE which indicates CAC needs to be
++	/* Enable CAC Flag in the driver by checking the all sub-channel's DFS
++	 * state as NL80211_DFS_USABLE which indicates CAC needs to be
+ 	 * done before channel usage. This flags is used to drop rx packets.
+ 	 * during CAC.
+ 	 */
+ 	/* TODO Set the flag for other interface types as required */
+-	if (arvif->vdev_type == WMI_VDEV_TYPE_AP &&
+-	    chandef->chan->dfs_cac_ms &&
+-	    chandef->chan->dfs_state == NL80211_DFS_USABLE) {
++	if (arvif->vdev_type == WMI_VDEV_TYPE_AP && ctx->radar_enabled &&
++	    cfg80211_chandef_dfs_usable(ar->hw->wiphy, chandef)) {
+ 		set_bit(ATH11K_CAC_RUNNING, &ar->dev_flags);
++		dfs_cac_time = cfg80211_chandef_dfs_cac_time(ar->hw->wiphy,
++							     chandef);
+ 		ath11k_dbg(ab, ATH11K_DBG_MAC,
+-			   "CAC Started in chan_freq %d for vdev %d\n",
+-			   arg.channel.freq, arg.vdev_id);
++			   "cac started dfs_cac_time %u center_freq %d center_freq1 %d for vdev %d\n",
++			   dfs_cac_time, arg.channel.freq, chandef->center_freq1,
++			   arg.vdev_id);
+ 	}
+ 
+ 	ret = ath11k_mac_set_txbf_conf(arvif);

--- a/package/kernel/mac80211/patches/ath11k/0026-wifi-ath11k-fix-Tx-power-value-during-active-CAC.patch
+++ b/package/kernel/mac80211/patches/ath11k/0026-wifi-ath11k-fix-Tx-power-value-during-active-CAC.patch
@@ -1,0 +1,43 @@
+From 77f1ee6fd8b6e470f721d05a2e269039d5cafcb7 Mon Sep 17 00:00:00 2001
+From: Aditya Kumar Singh <quic_adisi@quicinc.com>
+Date: Tue, 3 Oct 2023 17:26:54 +0300
+Subject: [PATCH] wifi: ath11k: fix Tx power value during active CAC
+
+Tx power is fetched from firmware's pdev stats. However, during active
+CAC, firmware does not fill the current Tx power and sends the max
+initialised value filled during firmware init. If host sends this power
+to user space, this is wrong since in certain situations, the Tx power
+could be greater than the max allowed by the regulatory. Hence, host
+should not be fetching the Tx power during an active CAC.
+
+Fix this issue by returning -EAGAIN error so that user space knows that there's
+no valid value available.
+
+Tested-on: QCN9074 hw1.0 PCI WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Fixes: 9a2aa68afe3d ("wifi: ath11k: add get_txpower mac ops")
+Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
+Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230912051857.2284-4-quic_adisi@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -9060,6 +9060,14 @@ static int ath11k_mac_op_get_txpower(str
+ 	if (ar->state != ATH11K_STATE_ON)
+ 		goto err_fallback;
+ 
++	/* Firmware doesn't provide Tx power during CAC hence no need to fetch
++	 * the stats.
++	 */
++	if (test_bit(ATH11K_CAC_RUNNING, &ar->dev_flags)) {
++		mutex_unlock(&ar->conf_mutex);
++		return -EAGAIN;
++	}
++
+ 	req_param.pdev_id = ar->pdev->pdev_id;
+ 	req_param.stats_id = WMI_REQUEST_PDEV_STAT;
+ 

--- a/package/kernel/mac80211/patches/ath11k/0027-wifi-ath11k-call-ath11k_mac_fils_discovery-without-c.patch
+++ b/package/kernel/mac80211/patches/ath11k/0027-wifi-ath11k-call-ath11k_mac_fils_discovery-without-c.patch
@@ -1,0 +1,37 @@
+From e149353e6562f3e3246f75dfc4cca6a0cc5b4efc Mon Sep 17 00:00:00 2001
+From: Aloka Dixit <quic_alokad@quicinc.com>
+Date: Mon, 9 Oct 2023 10:13:54 +0300
+Subject: [PATCH] wifi: ath11k: call ath11k_mac_fils_discovery() without
+ condition
+
+Mac80211 does not set flags BSS_CHANGED_FILS_DISCOVERY and
+BSS_CHANGED_UNSOL_BCAST_PROBE_RESP if there are no updates to
+FILS discovery and unsolicited broadcast probe response transmission
+configurations respectively. This results in the transmissions getting
+stopped during BSS change operations which do not include these
+attributes. Remove the checks for the flags and always send the existing
+configuration to firmware.
+
+Tested-on: IPQ8074 hw2.0 AHB WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Aloka Dixit <quic_alokad@quicinc.com>
+Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20231004044915.6817-1-quic_alokad@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -3732,9 +3732,7 @@ static void ath11k_mac_op_bss_info_chang
+ 				    arvif->vdev_id, ret);
+ 	}
+ 
+-	if (changed & BSS_CHANGED_FILS_DISCOVERY ||
+-	    changed & BSS_CHANGED_UNSOL_BCAST_PROBE_RESP)
+-		ath11k_mac_fils_discovery(arvif, info);
++	ath11k_mac_fils_discovery(arvif, info);
+ 
+ 	if (changed & BSS_CHANGED_ARP_FILTER) {
+ 		ipv4_cnt = min(vif->cfg.arp_addr_cnt, ATH11K_IPV4_MAX_COUNT);

--- a/package/kernel/mac80211/patches/ath11k/0028-wifi-ath11k-ath11k_debugfs_register-fix-format-trunc.patch
+++ b/package/kernel/mac80211/patches/ath11k/0028-wifi-ath11k-ath11k_debugfs_register-fix-format-trunc.patch
@@ -1,0 +1,39 @@
+From a47111663491ff2829df0626493ce81b48dd880a Mon Sep 17 00:00:00 2001
+From: Kalle Valo <quic_kvalo@quicinc.com>
+Date: Tue, 10 Oct 2023 09:22:50 +0300
+Subject: [PATCH] wifi: ath11k: ath11k_debugfs_register(): fix
+ format-truncation warning
+
+In v6.6-rc4 with GCC 13.2 I see a new warning:
+
+drivers/net/wireless/ath/ath11k/debugfs.c: In function 'ath11k_debugfs_register':
+drivers/net/wireless/ath/ath11k/debugfs.c:1597:51: error: '%d' directive output may be truncated writing between 1 and 3 bytes into a region of size 2 [-Werror=format-truncation=]
+drivers/net/wireless/ath/ath11k/debugfs.c:1597:48: note: directive argument in the range [0, 255]
+drivers/net/wireless/ath/ath11k/debugfs.c:1597:9: note: 'snprintf' output between 5 and 7 bytes into a destination of size 5
+
+Increase the size of pdev_name to 10 bytes to make sure there's enough room for
+the string. Also change the format to '%u' as ar->pdev_idx is u8.
+
+Compile tested only.
+
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20231010062250.2580951-1-kvalo@kernel.org
+---
+ drivers/net/wireless/ath/ath11k/debugfs.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/debugfs.c
++++ b/drivers/net/wireless/ath/ath11k/debugfs.c
+@@ -1591,10 +1591,10 @@ static const struct file_operations fops
+ int ath11k_debugfs_register(struct ath11k *ar)
+ {
+ 	struct ath11k_base *ab = ar->ab;
+-	char pdev_name[5];
++	char pdev_name[10];
+ 	char buf[100] = {0};
+ 
+-	snprintf(pdev_name, sizeof(pdev_name), "%s%d", "mac", ar->pdev_idx);
++	snprintf(pdev_name, sizeof(pdev_name), "%s%u", "mac", ar->pdev_idx);
+ 
+ 	ar->debug.debugfs_pdev = debugfs_create_dir(pdev_name, ab->debugfs_soc);
+ 	if (IS_ERR(ar->debug.debugfs_pdev))

--- a/package/kernel/mac80211/patches/ath11k/0029-wifi-ath11k-add-parsing-of-phy-bitmap-for-reg-rules.patch
+++ b/package/kernel/mac80211/patches/ath11k/0029-wifi-ath11k-add-parsing-of-phy-bitmap-for-reg-rules.patch
@@ -1,0 +1,84 @@
+From 534c2dd8099a9cc4bad8ea8b3c7fa1f730e10d5d Mon Sep 17 00:00:00 2001
+From: Aditya Kumar Singh <quic_adisi@quicinc.com>
+Date: Tue, 10 Oct 2023 10:27:19 +0300
+Subject: [PATCH] wifi: ath11k: add parsing of phy bitmap for reg rules
+
+Certain regulatory domains could put restrictions on phy mode operation.
+For example, in a few countries HE Operation is not allowed. For such
+countries, firmware indicates this via phy bitmap in each reg rule.
+
+Currently, there is no logic to parse this info and then pass it on to the
+cfg80211/regulatory.
+
+Add parsing of this phy bitmap from the regulatory channel change event and
+then accordingly map it to cfg80211/regulatory flags and pass it on to it.
+
+While at it, correct typo in debug print s/dsf/dfs.
+
+Tested-on: IPQ8074 hw2.0 AHB WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
+Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20231004092655.25020-1-quic_adisi@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/reg.c | 11 +++++++++++
+ drivers/net/wireless/ath/ath11k/reg.h |  3 +++
+ drivers/net/wireless/ath/ath11k/wmi.c |  5 +++--
+ 3 files changed, 17 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/reg.c
++++ b/drivers/net/wireless/ath/ath11k/reg.c
+@@ -352,6 +352,16 @@ static u32 ath11k_map_fw_reg_flags(u16 r
+ 	return flags;
+ }
+ 
++static u32 ath11k_map_fw_phy_flags(u32 phy_flags)
++{
++	u32 flags = 0;
++
++	if (phy_flags & ATH11K_REG_PHY_BITMAP_NO11AX)
++		flags |= NL80211_RRF_NO_HE;
++
++	return flags;
++}
++
+ static bool
+ ath11k_reg_can_intersect(struct ieee80211_reg_rule *rule1,
+ 			 struct ieee80211_reg_rule *rule2)
+@@ -685,6 +695,7 @@ ath11k_reg_build_regd(struct ath11k_base
+ 		}
+ 
+ 		flags |= ath11k_map_fw_reg_flags(reg_rule->flags);
++		flags |= ath11k_map_fw_phy_flags(reg_info->phybitmap);
+ 
+ 		ath11k_reg_update_rule(tmp_regd->reg_rules + i,
+ 				       reg_rule->start_freq,
+--- a/drivers/net/wireless/ath/ath11k/reg.h
++++ b/drivers/net/wireless/ath/ath11k/reg.h
+@@ -24,6 +24,9 @@ enum ath11k_dfs_region {
+ 	ATH11K_DFS_REG_UNDEF,
+ };
+ 
++/* Phy bitmaps */
++#define ATH11K_REG_PHY_BITMAP_NO11AX	BIT(5)
++
+ /* ATH11K Regulatory API's */
+ void ath11k_reg_init(struct ath11k *ar);
+ void ath11k_reg_free(struct ath11k_base *ab);
+--- a/drivers/net/wireless/ath/ath11k/wmi.c
++++ b/drivers/net/wireless/ath/ath11k/wmi.c
+@@ -5440,10 +5440,11 @@ static int ath11k_pull_reg_chan_list_ext
+ 	}
+ 
+ 	ath11k_dbg(ab, ATH11K_DBG_WMI,
+-		   "cc_ext %s dsf %d BW: min_2ghz %d max_2ghz %d min_5ghz %d max_5ghz %d",
++		   "cc_ext %s dfs %d BW: min_2ghz %d max_2ghz %d min_5ghz %d max_5ghz %d phy_bitmap 0x%x",
+ 		   reg_info->alpha2, reg_info->dfs_region,
+ 		   reg_info->min_bw_2ghz, reg_info->max_bw_2ghz,
+-		   reg_info->min_bw_5ghz, reg_info->max_bw_5ghz);
++		   reg_info->min_bw_5ghz, reg_info->max_bw_5ghz,
++		   reg_info->phybitmap);
+ 
+ 	ath11k_dbg(ab, ATH11K_DBG_WMI,
+ 		   "num_2ghz_reg_rules %d num_5ghz_reg_rules %d",

--- a/package/kernel/mac80211/patches/ath11k/0030-wifi-ath11k-Remove-unused-struct-ath11k_htc_frame.patch
+++ b/package/kernel/mac80211/patches/ath11k/0030-wifi-ath11k-Remove-unused-struct-ath11k_htc_frame.patch
@@ -1,0 +1,38 @@
+From 480d230bef0ecd06e72ae3a84117142e38e77503 Mon Sep 17 00:00:00 2001
+From: Jeff Johnson <quic_jjohnson@quicinc.com>
+Date: Mon, 9 Oct 2023 09:36:54 -0700
+Subject: [PATCH] wifi: ath11k: Remove unused struct ath11k_htc_frame
+
+struct ath11k_htc_frame is unused, and since it illogically contains
+two consecutive flexible arrays, it could never be used, so remove it.
+
+No functional changes, compile tested only.
+
+Signed-off-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20231009-ath11k_htc_frame-v1-1-81d405b7a195@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/htc.h | 12 ------------
+ 1 file changed, 12 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/htc.h
++++ b/drivers/net/wireless/ath/ath11k/htc.h
+@@ -156,18 +156,6 @@ struct ath11k_htc_record {
+ 	};
+ } __packed __aligned(4);
+ 
+-/* note: the trailer offset is dynamic depending
+- * on payload length. this is only a struct layout draft
+- */
+-struct ath11k_htc_frame {
+-	struct ath11k_htc_hdr hdr;
+-	union {
+-		struct ath11k_htc_msg msg;
+-		u8 payload[0];
+-	};
+-	struct ath11k_htc_record trailer[0];
+-} __packed __aligned(4);
+-
+ enum ath11k_htc_svc_gid {
+ 	ATH11K_HTC_SVC_GRP_RSVD = 0,
+ 	ATH11K_HTC_SVC_GRP_WMI = 1,

--- a/package/kernel/mac80211/patches/ath11k/0031-wifi-ath11k-Introduce-and-use-ath11k_sta_to_arsta.patch
+++ b/package/kernel/mac80211/patches/ath11k/0031-wifi-ath11k-Introduce-and-use-ath11k_sta_to_arsta.patch
@@ -1,0 +1,384 @@
+From 10c65f97b424fcee439463f933140df2a0022f98 Mon Sep 17 00:00:00 2001
+From: Jeff Johnson <quic_jjohnson@quicinc.com>
+Date: Mon, 9 Oct 2023 09:39:42 -0700
+Subject: [PATCH] wifi: ath11k: Introduce and use ath11k_sta_to_arsta()
+
+Currently, the logic to return an ath11k_sta pointer, given a
+ieee80211_sta pointer, uses typecasting throughout the driver. In
+general, conversion functions are preferable to typecasting since
+using a conversion function allows the compiler to validate the types
+of both the input and output parameters.
+
+ath11k already defines a conversion function ath11k_vif_to_arvif() for
+a similar conversion. So introduce ath11k_sta_to_arsta() for this use
+case, and convert all of the existing typecasting to use this
+function.
+
+No functional changes, compile tested only.
+
+Signed-off-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20231009-ath11k_sta_to_arsta-v1-1-1563e3a307e8@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/core.h        |  5 ++++
+ drivers/net/wireless/ath/ath11k/debugfs.c     |  4 +--
+ drivers/net/wireless/ath/ath11k/debugfs_sta.c | 30 +++++++++----------
+ drivers/net/wireless/ath/ath11k/dp_rx.c       |  8 ++---
+ drivers/net/wireless/ath/ath11k/dp_tx.c       |  4 +--
+ drivers/net/wireless/ath/ath11k/mac.c         | 18 +++++------
+ drivers/net/wireless/ath/ath11k/peer.c        |  2 +-
+ drivers/net/wireless/ath/ath11k/wmi.c         |  6 ++--
+ 8 files changed, 41 insertions(+), 36 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/core.h
++++ b/drivers/net/wireless/ath/ath11k/core.h
+@@ -1223,6 +1223,11 @@ static inline struct ath11k_vif *ath11k_
+ 	return (struct ath11k_vif *)vif->drv_priv;
+ }
+ 
++static inline struct ath11k_sta *ath11k_sta_to_arsta(struct ieee80211_sta *sta)
++{
++	return (struct ath11k_sta *)sta->drv_priv;
++}
++
+ static inline struct ath11k *ath11k_ab_to_ar(struct ath11k_base *ab,
+ 					     int mac_id)
+ {
+--- a/drivers/net/wireless/ath/ath11k/debugfs.c
++++ b/drivers/net/wireless/ath/ath11k/debugfs.c
+@@ -1459,7 +1459,7 @@ static void ath11k_reset_peer_ps_duratio
+ 					  struct ieee80211_sta *sta)
+ {
+ 	struct ath11k *ar = data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 
+ 	spin_lock_bh(&ar->data_lock);
+ 	arsta->ps_total_duration = 0;
+@@ -1510,7 +1510,7 @@ static void ath11k_peer_ps_state_disable
+ 					 struct ieee80211_sta *sta)
+ {
+ 	struct ath11k *ar = data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 
+ 	spin_lock_bh(&ar->data_lock);
+ 	arsta->peer_ps_state = WMI_PEER_PS_STATE_DISABLED;
+--- a/drivers/net/wireless/ath/ath11k/debugfs_sta.c
++++ b/drivers/net/wireless/ath/ath11k/debugfs_sta.c
+@@ -136,7 +136,7 @@ static ssize_t ath11k_dbg_sta_dump_tx_st
+ 					    size_t count, loff_t *ppos)
+ {
+ 	struct ieee80211_sta *sta = file->private_data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	struct ath11k_htt_data_stats *stats;
+ 	static const char *str_name[ATH11K_STATS_TYPE_MAX] = {"succ", "fail",
+@@ -243,7 +243,7 @@ static ssize_t ath11k_dbg_sta_dump_rx_st
+ 					    size_t count, loff_t *ppos)
+ {
+ 	struct ieee80211_sta *sta = file->private_data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	struct ath11k_rx_peer_stats *rx_stats = arsta->rx_stats;
+ 	int len = 0, i, retval = 0;
+@@ -340,7 +340,7 @@ static int
+ ath11k_dbg_sta_open_htt_peer_stats(struct inode *inode, struct file *file)
+ {
+ 	struct ieee80211_sta *sta = inode->i_private;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	struct debug_htt_stats_req *stats_req;
+ 	int type = ar->debug.htt_stats.type;
+@@ -376,7 +376,7 @@ static int
+ ath11k_dbg_sta_release_htt_peer_stats(struct inode *inode, struct file *file)
+ {
+ 	struct ieee80211_sta *sta = inode->i_private;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 
+ 	mutex_lock(&ar->conf_mutex);
+@@ -413,7 +413,7 @@ static ssize_t ath11k_dbg_sta_write_peer
+ 						size_t count, loff_t *ppos)
+ {
+ 	struct ieee80211_sta *sta = file->private_data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	int ret, enable;
+ 
+@@ -453,7 +453,7 @@ static ssize_t ath11k_dbg_sta_read_peer_
+ 					       size_t count, loff_t *ppos)
+ {
+ 	struct ieee80211_sta *sta = file->private_data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	char buf[32] = {0};
+ 	int len;
+@@ -480,7 +480,7 @@ static ssize_t ath11k_dbg_sta_write_delb
+ 					  size_t count, loff_t *ppos)
+ {
+ 	struct ieee80211_sta *sta = file->private_data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	u32 tid, initiator, reason;
+ 	int ret;
+@@ -531,7 +531,7 @@ static ssize_t ath11k_dbg_sta_write_addb
+ 					       size_t count, loff_t *ppos)
+ {
+ 	struct ieee80211_sta *sta = file->private_data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	u32 tid, status;
+ 	int ret;
+@@ -581,7 +581,7 @@ static ssize_t ath11k_dbg_sta_write_addb
+ 					  size_t count, loff_t *ppos)
+ {
+ 	struct ieee80211_sta *sta = file->private_data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	u32 tid, buf_size;
+ 	int ret;
+@@ -632,7 +632,7 @@ static ssize_t ath11k_dbg_sta_read_aggr_
+ 					     size_t count, loff_t *ppos)
+ {
+ 	struct ieee80211_sta *sta = file->private_data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	char buf[64];
+ 	int len = 0;
+@@ -652,7 +652,7 @@ static ssize_t ath11k_dbg_sta_write_aggr
+ 					      size_t count, loff_t *ppos)
+ {
+ 	struct ieee80211_sta *sta = file->private_data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	u32 aggr_mode;
+ 	int ret;
+@@ -697,7 +697,7 @@ ath11k_write_htt_peer_stats_reset(struct
+ 				  size_t count, loff_t *ppos)
+ {
+ 	struct ieee80211_sta *sta = file->private_data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	struct htt_ext_stats_cfg_params cfg_params = { 0 };
+ 	int ret;
+@@ -756,7 +756,7 @@ static ssize_t ath11k_dbg_sta_read_peer_
+ 						 size_t count, loff_t *ppos)
+ {
+ 	struct ieee80211_sta *sta = file->private_data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	char buf[20];
+ 	int len;
+@@ -783,7 +783,7 @@ static ssize_t ath11k_dbg_sta_read_curre
+ 						       loff_t *ppos)
+ {
+ 	struct ieee80211_sta *sta = file->private_data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	u64 time_since_station_in_power_save;
+ 	char buf[20];
+@@ -817,7 +817,7 @@ static ssize_t ath11k_dbg_sta_read_total
+ 						     size_t count, loff_t *ppos)
+ {
+ 	struct ieee80211_sta *sta = file->private_data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	char buf[20];
+ 	u64 power_save_duration;
+--- a/drivers/net/wireless/ath/ath11k/dp_rx.c
++++ b/drivers/net/wireless/ath/ath11k/dp_rx.c
+@@ -1099,7 +1099,7 @@ int ath11k_dp_rx_ampdu_start(struct ath1
+ 			     struct ieee80211_ampdu_params *params)
+ {
+ 	struct ath11k_base *ab = ar->ab;
+-	struct ath11k_sta *arsta = (void *)params->sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(params->sta);
+ 	int vdev_id = arsta->arvif->vdev_id;
+ 	int ret;
+ 
+@@ -1117,7 +1117,7 @@ int ath11k_dp_rx_ampdu_stop(struct ath11
+ {
+ 	struct ath11k_base *ab = ar->ab;
+ 	struct ath11k_peer *peer;
+-	struct ath11k_sta *arsta = (void *)params->sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(params->sta);
+ 	int vdev_id = arsta->arvif->vdev_id;
+ 	dma_addr_t paddr;
+ 	bool active;
+@@ -1456,7 +1456,7 @@ ath11k_update_per_peer_tx_stats(struct a
+ 	}
+ 
+ 	sta = peer->sta;
+-	arsta = (struct ath11k_sta *)sta->drv_priv;
++	arsta = ath11k_sta_to_arsta(sta);
+ 
+ 	memset(&arsta->txrate, 0, sizeof(arsta->txrate));
+ 
+@@ -5242,7 +5242,7 @@ int ath11k_dp_rx_process_mon_status(stru
+ 			goto next_skb;
+ 		}
+ 
+-		arsta = (struct ath11k_sta *)peer->sta->drv_priv;
++		arsta = ath11k_sta_to_arsta(peer->sta);
+ 		ath11k_dp_rx_update_peer_stats(arsta, ppdu_info);
+ 
+ 		if (ath11k_debugfs_is_pktlog_peer_valid(ar, peer->addr))
+--- a/drivers/net/wireless/ath/ath11k/dp_tx.c
++++ b/drivers/net/wireless/ath/ath11k/dp_tx.c
+@@ -467,7 +467,7 @@ void ath11k_dp_tx_update_txcompl(struct
+ 	}
+ 
+ 	sta = peer->sta;
+-	arsta = (struct ath11k_sta *)sta->drv_priv;
++	arsta = ath11k_sta_to_arsta(sta);
+ 
+ 	memset(&arsta->txrate, 0, sizeof(arsta->txrate));
+ 	pkt_type = FIELD_GET(HAL_TX_RATE_STATS_INFO0_PKT_TYPE,
+@@ -627,7 +627,7 @@ static void ath11k_dp_tx_complete_msdu(s
+ 		ieee80211_free_txskb(ar->hw, msdu);
+ 		return;
+ 	}
+-	arsta = (struct ath11k_sta *)peer->sta->drv_priv;
++	arsta = ath11k_sta_to_arsta(peer->sta);
+ 	status.sta = peer->sta;
+ 	status.skb = msdu;
+ 	status.info = info;
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -2832,7 +2832,7 @@ static void ath11k_peer_assoc_prepare(st
+ 
+ 	lockdep_assert_held(&ar->conf_mutex);
+ 
+-	arsta = (struct ath11k_sta *)sta->drv_priv;
++	arsta = ath11k_sta_to_arsta(sta);
+ 
+ 	memset(arg, 0, sizeof(*arg));
+ 
+@@ -4313,7 +4313,7 @@ static int ath11k_mac_op_set_key(struct
+ 		ath11k_warn(ab, "peer %pM disappeared!\n", peer_addr);
+ 
+ 	if (sta) {
+-		arsta = (struct ath11k_sta *)sta->drv_priv;
++		arsta = ath11k_sta_to_arsta(sta);
+ 
+ 		switch (key->cipher) {
+ 		case WLAN_CIPHER_SUITE_TKIP:
+@@ -4904,7 +4904,7 @@ static int ath11k_mac_station_add(struct
+ {
+ 	struct ath11k_base *ab = ar->ab;
+ 	struct ath11k_vif *arvif = ath11k_vif_to_arvif(vif);
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct peer_create_params peer_param;
+ 	int ret;
+ 
+@@ -5028,7 +5028,7 @@ static int ath11k_mac_op_sta_state(struc
+ {
+ 	struct ath11k *ar = hw->priv;
+ 	struct ath11k_vif *arvif = ath11k_vif_to_arvif(vif);
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k_peer *peer;
+ 	int ret = 0;
+ 
+@@ -5194,7 +5194,7 @@ static void ath11k_mac_op_sta_set_4addr(
+ 					struct ieee80211_sta *sta, bool enabled)
+ {
+ 	struct ath11k *ar = hw->priv;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 
+ 	if (enabled && !arsta->use_4addr_set) {
+ 		ieee80211_queue_work(ar->hw, &arsta->set_4addr_wk);
+@@ -5208,7 +5208,7 @@ static void ath11k_mac_op_sta_rc_update(
+ 					u32 changed)
+ {
+ 	struct ath11k *ar = hw->priv;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k_vif *arvif = ath11k_vif_to_arvif(vif);
+ 	struct ath11k_peer *peer;
+ 	u32 bw, smps;
+@@ -6201,7 +6201,7 @@ static void ath11k_mac_op_tx(struct ieee
+ 	}
+ 
+ 	if (control->sta)
+-		arsta = (struct ath11k_sta *)control->sta->drv_priv;
++		arsta = ath11k_sta_to_arsta(control->sta);
+ 
+ 	ret = ath11k_dp_tx(ar, arvif, arsta, skb);
+ 	if (unlikely(ret)) {
+@@ -8233,7 +8233,7 @@ static void ath11k_mac_set_bitrate_mask_
+ 					     struct ieee80211_sta *sta)
+ {
+ 	struct ath11k_vif *arvif = data;
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arvif->ar;
+ 
+ 	spin_lock_bh(&ar->data_lock);
+@@ -8637,7 +8637,7 @@ static void ath11k_mac_op_sta_statistics
+ 					 struct ieee80211_sta *sta,
+ 					 struct station_info *sinfo)
+ {
+-	struct ath11k_sta *arsta = (struct ath11k_sta *)sta->drv_priv;
++	struct ath11k_sta *arsta = ath11k_sta_to_arsta(sta);
+ 	struct ath11k *ar = arsta->arvif->ar;
+ 	s8 signal;
+ 	bool db2dbm = test_bit(WMI_TLV_SERVICE_HW_DB2DBM_CONVERSION_SUPPORT,
+--- a/drivers/net/wireless/ath/ath11k/peer.c
++++ b/drivers/net/wireless/ath/ath11k/peer.c
+@@ -446,7 +446,7 @@ int ath11k_peer_create(struct ath11k *ar
+ 	peer->sec_type_grp = HAL_ENCRYPT_TYPE_OPEN;
+ 
+ 	if (sta) {
+-		arsta = (struct ath11k_sta *)sta->drv_priv;
++		arsta = ath11k_sta_to_arsta(sta);
+ 		arsta->tcl_metadata |= FIELD_PREP(HTT_TCL_META_DATA_TYPE, 0) |
+ 				       FIELD_PREP(HTT_TCL_META_DATA_PEER_ID,
+ 						  peer->peer_id);
+--- a/drivers/net/wireless/ath/ath11k/wmi.c
++++ b/drivers/net/wireless/ath/ath11k/wmi.c
+@@ -6453,7 +6453,7 @@ static int ath11k_wmi_tlv_rssi_chain_par
+ 		goto exit;
+ 	}
+ 
+-	arsta = (struct ath11k_sta *)sta->drv_priv;
++	arsta = ath11k_sta_to_arsta(sta);
+ 
+ 	BUILD_BUG_ON(ARRAY_SIZE(arsta->chain_signal) >
+ 		     ARRAY_SIZE(stats_rssi->rssi_avg_beacon));
+@@ -6541,7 +6541,7 @@ static int ath11k_wmi_tlv_fw_stats_data_
+ 							   arvif->bssid,
+ 							   NULL);
+ 			if (sta) {
+-				arsta = (struct ath11k_sta *)sta->drv_priv;
++				arsta = ath11k_sta_to_arsta(sta);
+ 				arsta->rssi_beacon = src->beacon_snr;
+ 				ath11k_dbg(ab, ATH11K_DBG_WMI,
+ 					   "stats vdev id %d snr %d\n",
+@@ -7468,7 +7468,7 @@ static void ath11k_wmi_event_peer_sta_ps
+ 		goto exit;
+ 	}
+ 
+-	arsta = (struct ath11k_sta *)sta->drv_priv;
++	arsta = ath11k_sta_to_arsta(sta);
+ 
+ 	spin_lock_bh(&ar->data_lock);
+ 

--- a/package/kernel/mac80211/patches/ath11k/903-ath11k-support-setting-FW-memory-mode-via-DT.patch
+++ b/package/kernel/mac80211/patches/ath11k/903-ath11k-support-setting-FW-memory-mode-via-DT.patch
@@ -31,7 +31,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  	{
  		.hw_rev = ATH11K_HW_IPQ8074,
  		.name = "ipq8074 hw2.0",
-@@ -1974,7 +1974,8 @@ static void ath11k_core_reset(struct wor
+@@ -2040,7 +2040,8 @@ static void ath11k_core_reset(struct wor
  static int ath11k_init_hw_params(struct ath11k_base *ab)
  {
  	const struct ath11k_hw_params *hw_params = NULL;
@@ -41,7 +41,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  
  	for (i = 0; i < ARRAY_SIZE(ath11k_hw_params); i++) {
  		hw_params = &ath11k_hw_params[i];
-@@ -1990,7 +1991,31 @@ static int ath11k_init_hw_params(struct
+@@ -2056,7 +2057,31 @@ static int ath11k_init_hw_params(struct
  
  	ab->hw_params = *hw_params;
  

--- a/package/kernel/mac80211/patches/ath11k/905-ath11k-remove-intersection-support-for-regulatory-ru.patch
+++ b/package/kernel/mac80211/patches/ath11k/905-ath11k-remove-intersection-support-for-regulatory-ru.patch
@@ -23,7 +23,7 @@ Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
 
 --- a/drivers/net/wireless/ath/ath11k/reg.c
 +++ b/drivers/net/wireless/ath/ath11k/reg.c
-@@ -352,129 +352,6 @@ static u32 ath11k_map_fw_reg_flags(u16 r
+@@ -362,129 +362,6 @@ static u32 ath11k_map_fw_phy_flags(u32 p
  	return flags;
  }
  
@@ -153,7 +153,7 @@ Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
  static const char *
  ath11k_reg_get_regdom_str(enum nl80211_dfs_regions dfs_region)
  {
-@@ -609,9 +486,9 @@ ath11k_reg_update_weather_radar_band(str
+@@ -619,9 +496,9 @@ ath11k_reg_update_weather_radar_band(str
  
  struct ieee80211_regdomain *
  ath11k_reg_build_regd(struct ath11k_base *ab,
@@ -165,7 +165,7 @@ Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
  	struct cur_reg_rule *reg_rule;
  	u8 i = 0, j = 0, k = 0;
  	u8 num_rules;
-@@ -628,26 +505,26 @@ ath11k_reg_build_regd(struct ath11k_base
+@@ -638,26 +515,26 @@ ath11k_reg_build_regd(struct ath11k_base
  		num_rules += reg_info->num_6ghz_rules_ap[WMI_REG_INDOOR_AP];
  
  	if (!num_rules)
@@ -199,16 +199,16 @@ Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
  		   reg_info->dfs_region, num_rules);
  	/* Update reg_rules[] below. Firmware is expected to
  	 * send these rules in order(2 GHz rules first and then 5 GHz)
-@@ -686,7 +563,7 @@ ath11k_reg_build_regd(struct ath11k_base
- 
+@@ -697,7 +574,7 @@ ath11k_reg_build_regd(struct ath11k_base
  		flags |= ath11k_map_fw_reg_flags(reg_rule->flags);
+ 		flags |= ath11k_map_fw_phy_flags(reg_info->phybitmap);
  
 -		ath11k_reg_update_rule(tmp_regd->reg_rules + i,
 +		ath11k_reg_update_rule(new_regd->reg_rules + i,
  				       reg_rule->start_freq,
  				       reg_rule->end_freq, max_bw,
  				       reg_rule->ant_gain, reg_rule->reg_power,
-@@ -701,7 +578,7 @@ ath11k_reg_build_regd(struct ath11k_base
+@@ -712,7 +589,7 @@ ath11k_reg_build_regd(struct ath11k_base
  		    reg_info->dfs_region == ATH11K_DFS_REG_ETSI &&
  		    (reg_rule->end_freq > ETSI_WEATHER_RADAR_BAND_LOW &&
  		    reg_rule->start_freq < ETSI_WEATHER_RADAR_BAND_HIGH)){
@@ -217,7 +217,7 @@ Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
  							     reg_rule, &i,
  							     flags, max_bw);
  			continue;
-@@ -712,37 +589,20 @@ ath11k_reg_build_regd(struct ath11k_base
+@@ -723,37 +600,20 @@ ath11k_reg_build_regd(struct ath11k_base
  				   "\t%d. (%d - %d @ %d) (%d, %d) (%d ms) (FLAGS %d) (%d, %d)\n",
  				   i + 1, reg_rule->start_freq, reg_rule->end_freq,
  				   max_bw, reg_rule->ant_gain, reg_rule->reg_power,
@@ -260,7 +260,7 @@ Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
  
 --- a/drivers/net/wireless/ath/ath11k/reg.h
 +++ b/drivers/net/wireless/ath/ath11k/reg.h
-@@ -30,7 +30,7 @@ void ath11k_reg_free(struct ath11k_base
+@@ -33,7 +33,7 @@ void ath11k_reg_free(struct ath11k_base
  void ath11k_regd_update_work(struct work_struct *work);
  struct ieee80211_regdomain *
  ath11k_reg_build_regd(struct ath11k_base *ab,
@@ -271,7 +271,7 @@ Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
  #endif
 --- a/drivers/net/wireless/ath/ath11k/wmi.c
 +++ b/drivers/net/wireless/ath/ath11k/wmi.c
-@@ -7059,24 +7059,12 @@ static void ath11k_wmi_htc_tx_complete(s
+@@ -7060,24 +7060,12 @@ static void ath11k_wmi_htc_tx_complete(s
  		wake_up(&wmi->tx_ce_desc_wq);
  }
  
@@ -296,7 +296,7 @@ Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
  	int ret = 0, pdev_idx, i, j;
  	struct ath11k *ar;
  
-@@ -7140,17 +7128,7 @@ static int ath11k_reg_chan_list_event(st
+@@ -7141,17 +7129,7 @@ static int ath11k_reg_chan_list_event(st
  		    (char *)reg_info->alpha2, 2))
  		goto mem_free;
  

--- a/package/kernel/mac80211/patches/subsys/313-wifi-cfg80211-export-DFS-CAC-time-and-usable-state-h.patch
+++ b/package/kernel/mac80211/patches/subsys/313-wifi-cfg80211-export-DFS-CAC-time-and-usable-state-h.patch
@@ -1,0 +1,111 @@
+From 30ca8b0c4d6c9fb1d76e5894b1e8bf7c6a12224d Mon Sep 17 00:00:00 2001
+From: Aditya Kumar Singh <quic_adisi@quicinc.com>
+Date: Tue, 12 Sep 2023 10:48:55 +0530
+Subject: [PATCH] wifi: cfg80211: export DFS CAC time and usable state helper
+ functions
+
+cfg80211 has cfg80211_chandef_dfs_usable() function to know whether
+at least one channel in the chandef is in usable state or not. Also,
+cfg80211_chandef_dfs_cac_time() function is there which tells the CAC
+time required for the given chandef.
+
+Make these two functions visible to drivers by exporting their symbol
+to global list of kernel symbols.
+
+Lower level drivers can make use of these two functions to be aware
+if CAC is required on the given chandef and for how long. For example
+drivers which maintains the CAC state internally can make use of these.
+
+Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
+Reviewed-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Link: https://lore.kernel.org/r/20230912051857.2284-2-quic_adisi@quicinc.com
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+ include/net/cfg80211.h | 24 ++++++++++++++++++++++++
+ net/wireless/chan.c    |  2 ++
+ net/wireless/core.h    | 17 -----------------
+ 3 files changed, 26 insertions(+), 17 deletions(-)
+
+--- a/include/net/cfg80211.h
++++ b/include/net/cfg80211.h
+@@ -1008,6 +1008,30 @@ int cfg80211_chandef_dfs_required(struct
+ 				  enum nl80211_iftype iftype);
+ 
+ /**
++ * cfg80211_chandef_dfs_usable - checks if chandef is DFS usable and we
++ *				 can/need start CAC on such channel
++ * @wiphy: the wiphy to validate against
++ * @chandef: the channel definition to check
++ *
++ * Return: true if all channels available and at least
++ *	   one channel requires CAC (NL80211_DFS_USABLE)
++ */
++bool cfg80211_chandef_dfs_usable(struct wiphy *wiphy,
++				 const struct cfg80211_chan_def *chandef);
++
++/**
++ * cfg80211_chandef_dfs_cac_time - get the DFS CAC time (in ms) for given
++ *				   channel definition
++ * @wiphy: the wiphy to validate against
++ * @chandef: the channel definition to check
++ *
++ * Returns: DFS CAC time (in ms) which applies for this channel definition
++ */
++unsigned int
++cfg80211_chandef_dfs_cac_time(struct wiphy *wiphy,
++			      const struct cfg80211_chan_def *chandef);
++
++/**
+  * nl80211_send_chandef - sends the channel definition.
+  * @msg: the msg to send channel definition
+  * @chandef: the channel definition to check
+--- a/net/wireless/chan.c
++++ b/net/wireless/chan.c
+@@ -666,6 +666,7 @@ bool cfg80211_chandef_dfs_usable(struct
+ 
+ 	return (r1 + r2 > 0);
+ }
++EXPORT_SYMBOL(cfg80211_chandef_dfs_usable);
+ 
+ /*
+  * Checks if center frequency of chan falls with in the bandwidth
+@@ -965,6 +966,7 @@ cfg80211_chandef_dfs_cac_time(struct wip
+ 
+ 	return max(t1, t2);
+ }
++EXPORT_SYMBOL(cfg80211_chandef_dfs_cac_time);
+ 
+ static bool cfg80211_secondary_chans_ok(struct wiphy *wiphy,
+ 					u32 center_freq, u32 bandwidth,
+--- a/net/wireless/core.h
++++ b/net/wireless/core.h
+@@ -469,29 +469,12 @@ int cfg80211_scan(struct cfg80211_regist
+ 
+ extern struct work_struct cfg80211_disconnect_work;
+ 
+-/**
+- * cfg80211_chandef_dfs_usable - checks if chandef is DFS usable
+- * @wiphy: the wiphy to validate against
+- * @chandef: the channel definition to check
+- *
+- * Checks if chandef is usable and we can/need start CAC on such channel.
+- *
+- * Return: true if all channels available and at least
+- *	   one channel requires CAC (NL80211_DFS_USABLE)
+- */
+-bool cfg80211_chandef_dfs_usable(struct wiphy *wiphy,
+-				 const struct cfg80211_chan_def *chandef);
+-
+ void cfg80211_set_dfs_state(struct wiphy *wiphy,
+ 			    const struct cfg80211_chan_def *chandef,
+ 			    enum nl80211_dfs_state dfs_state);
+ 
+ void cfg80211_dfs_channels_update_work(struct work_struct *work);
+ 
+-unsigned int
+-cfg80211_chandef_dfs_cac_time(struct wiphy *wiphy,
+-			      const struct cfg80211_chan_def *chandef);
+-
+ void cfg80211_sched_dfs_chan_update(struct cfg80211_registered_device *rdev);
+ 
+ int

--- a/package/kernel/mac80211/patches/subsys/320-cfg80211-allow-grace-period-for-DFS-available-after-.patch
+++ b/package/kernel/mac80211/patches/subsys/320-cfg80211-allow-grace-period-for-DFS-available-after-.patch
@@ -61,7 +61,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	}
  }
  
-@@ -873,6 +875,49 @@ static bool cfg80211_get_chans_dfs_avail
+@@ -874,6 +876,49 @@ static bool cfg80211_get_chans_dfs_avail
  	return true;
  }
  
@@ -113,15 +113,15 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  {
 --- a/net/wireless/core.h
 +++ b/net/wireless/core.h
-@@ -487,6 +487,8 @@ void cfg80211_set_dfs_state(struct wiphy
+@@ -474,6 +474,8 @@ void cfg80211_set_dfs_state(struct wiphy
  			    enum nl80211_dfs_state dfs_state);
  
  void cfg80211_dfs_channels_update_work(struct work_struct *work);
 +void cfg80211_update_last_available(struct wiphy *wiphy,
 +				    const struct cfg80211_chan_def *chandef);
  
- unsigned int
- cfg80211_chandef_dfs_cac_time(struct wiphy *wiphy,
+ void cfg80211_sched_dfs_chan_update(struct cfg80211_registered_device *rdev);
+ 
 --- a/net/wireless/mlme.c
 +++ b/net/wireless/mlme.c
 @@ -915,6 +915,8 @@ void cfg80211_dfs_channels_update_work(s


### PR DESCRIPTION
Synchronize the ath11k backports with the current ath-next tree.

All of the changes are various bugfixes, there is no new major feature.
Notable bugfixes are:
* WCN6855 board name fixes
* One MSI vector booting is working again
This is rather important for most of the older platforms.

* DFS CAC state in virtual interfaces was fixed
* TX power during CAC reporting

DFS CAC time export was a prerequisite and has been backported as a subsystem change.
