### PR TITLE
bcm53xx: fix Linksys EA9200 ethernet regression

### DIFF
--- a/target/linux/bcm53xx/patches-5.15/304-ARM-dts-BCM5301X-Specify-switch-ports-for-remaining-.patch
+++ b/target/linux/bcm53xx/patches-5.15/304-ARM-dts-BCM5301X-Specify-switch-ports-for-remaining-.patch
@@ -395,7 +395,7 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 +};
 --- a/arch/arm/boot/dts/bcm4709-linksys-ea9200.dts
 +++ b/arch/arm/boot/dts/bcm4709-linksys-ea9200.dts
-@@ -47,3 +47,45 @@
+@@ -47,3 +47,37 @@
  &usb3_phy {
  	status = "okay";
  };
@@ -405,39 +405,31 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 +
 +	ports {
 +		port@0 {
-+			reg = <0>;
 +			label = "lan1";
 +		};
 +
 +		port@1 {
-+			reg = <1>;
 +			label = "lan2";
 +		};
 +
 +		port@2 {
-+			reg = <2>;
 +			label = "lan3";
 +		};
 +
 +		port@3 {
-+			reg = <3>;
 +			label = "lan4";
 +		};
 +
 +		port@4 {
-+			reg = <4>;
 +			label = "wan";
 +		};
 +
-+		port@8 {
-+			reg = <8>;
-+			label = "cpu";
-+			ethernet = <&gmac2>;
++		/delete-node/ port@5;
 +
-+			fixed-link {
-+				speed = <1000>;
-+				full-duplex;
-+			};
++		/delete-node/ port@7;
++
++		port@8 {
++			label = "cpu";
 +		};
 +	};
 +};


### PR DESCRIPTION
Ethernet stopped working since lan1-4 and wan ports became associated with `eth0` rather than `eth2` in commit a4792d79e8.
This commit updates the EA9200 DTS patch to ignore `eth0` and `eth1`.

Note: the same problem exists for Netgear R8000, and perhaps other `bcm53xx` targets.

Closes: #13548

Authored-by: @rmilecki