### PR TITLE
tools/cmake: disable cmake script debugger

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -30,6 +30,7 @@ HOST_CONFIGURE_VARS += \
 	MAKE="$(STAGING_DIR_HOST)/bin/ninja"
 
 HOST_CONFIGURE_ARGS := \
+	--no-debugger \
 	$(if $(MAKE_JOBSERVER),--parallel="$(MAKE_JOBSERVER)") \
 	--prefix="$(STAGING_DIR_HOST)" \
 	--system-expat \


### PR DESCRIPTION
ping @neheb @PolynomialDivision 

please pull this ASAP, I've been dealing with this for a month without realizing it was simple to avoid.
(I thought it was a zstd thing but it's not)