### PR TITLE
toolchain: link include directory when using external toolchain

### DIFF
--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -76,9 +76,22 @@ $(TOOLCHAIN_DIR)/info.mk $(STAGING_DIR)/.prepared: $(TOOLCHAIN_DIR)/stamp/.ver_c
 endif
 endif
 
+ifeq ($(CONFIG_EXTERNAL_TOOLCHAIN),)
+  $(TOOLCHAIN_DIR)/include: ;
+else
+  $(TOOLCHAIN_DIR)/include: .config;
+	@for dir in $(TOOLCHAIN_DIR); do ( \
+		$(if $(QUIET),,set -x;) \
+		mkdir -p "$$dir"; \
+		cd "$$dir"; \
+		ln -nsf $(TOOLCHAIN_ROOT_DIR)/include include; \
+	); done
+	@touch $@
+endif
+
 # prerequisites for the individual targets
 $(curdir)/ := .config prereq
-$(curdir)//compile = $(STAGING_DIR)/.prepared $(TOOLCHAIN_DIR)/info.mk $(tools/stamp-compile)
+$(curdir)//compile = $(STAGING_DIR)/.prepared $(TOOLCHAIN_DIR)/info.mk $(TOOLCHAIN_DIR)/include $(tools/stamp-compile)
 
 ifndef DUMP_TARGET_DB
 $(TOOLCHAIN_DIR)/stamp/.gcc_final_installed:


### PR DESCRIPTION
Some packages, eg perl, explicitly reference directories in $(TOOLCHAIN_DIR), which, for an external toolchain, don't currently exist. This commit adds a target for external toolchains to symlink the include directory to support other packages which may be doing this.
