### PR TITLE
toolchain: link ldd when using external toolchain

### DIFF
--- a/package/libs/toolchain/Makefile
+++ b/package/libs/toolchain/Makefile
@@ -655,12 +655,23 @@ else
 	exit 0
   endef
 
+  define Package/glibc/install
+  endef
+
+  LD_MUSL_NAME = $(notdir $(firstword $(wildcard $(TOOLCHAIN_ROOT_DIR)/lib/libc.so*)))
+
+  define Package/musl/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(LN) ../../lib/$(LD_MUSL_NAME) $(1)/usr/bin/ldd
+  endef
+
   define Package/libc/install
 	for file in $(call qstrip,$(CONFIG_LIBC_FILE_SPEC)); do \
 		$(INSTALL_DIR) $(1)/lib ; \
 		$(CP) $(call qstrip,$(CONFIG_LIBC_ROOT_DIR))/$$$$file $(1)/lib/ ; \
 	done ; \
 	exit 0
+	$(call Package/$(LIBC)/install,$1)
   endef
 
   define Package/libpthread/install


### PR DESCRIPTION
When using an external toolchain, ldd is not linked into the rootfs. This causes subsequent upgrades to fail with 'Failed to exec upgraded'. This patch adds the symlink when using an external toolchain and musl.