### PR TITLE
hostapd: don't use trim when reading conf file

### DIFF
--- a/package/network/services/hostapd/files/hostapd.uc
+++ b/package/network/services/hostapd/files/hostapd.uc
@@ -593,7 +593,7 @@ function iface_load_config(filename)
 		push(config.radio.data, line);
 	}
 
-	while ((line = trim(f.read("line"))) != null) {
+	while ((line = f.read("line")) != null) {
 		if (line == "#default_macaddr")
 			bss.default_macaddr = true;
 


### PR DESCRIPTION
If the wpa_passphrase ends in space trim removes those spaces and this either breaks the whole radio (if the result is less than 8 chars) or brings up the interface using password with removed trailing spaces.
Fixes #13591