### PR TITLE
mbedtls: Update to version 2.28.5

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=2.28.4
+PKG_VERSION:=2.28.5
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ARMmbed/mbedtls/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=578c4dcd15bbff3f5cd56aa07cd4f850fc733634e3d5947be4f7157d5bfd81ac
+PKG_HASH:=849e86b626e42ded6bf67197b64aa771daa54e2a7e2868dc67e1e4711959e5e3
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=gpl-2.0.txt

--- a/package/libs/mbedtls/patches/100-x509-crt-verify-SAN-iPAddress.patch
+++ b/package/libs/mbedtls/patches/100-x509-crt-verify-SAN-iPAddress.patch
@@ -33,7 +33,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
  #include <windows.h>
  #else
  #include <time.h>
-@@ -3001,6 +3005,61 @@ find_parent:
+@@ -3002,6 +3006,61 @@ find_parent:
      }
  }
  
@@ -95,7 +95,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
  /*
   * Check for CN match
   */
-@@ -3021,24 +3080,51 @@ static int x509_crt_check_cn(const mbedt
+@@ -3022,24 +3081,51 @@ static int x509_crt_check_cn(const mbedt
      return -1;
  }
  
@@ -158,7 +158,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
  }
  
  /*
-@@ -3049,31 +3135,23 @@ static void x509_crt_verify_name(const m
+@@ -3050,31 +3136,23 @@ static void x509_crt_verify_name(const m
                                   uint32_t *flags)
  {
      const mbedtls_x509_name *name;


### PR DESCRIPTION
This fixes some minor security problems.
Changelog: https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-2.28.5