### PR TITLE
bcm53xx: Linksys EA9200 nvram and 02_network fixes

### DIFF
--- a/package/utils/nvram/files/nvram-bcm53xx.init
+++ b/package/utils/nvram/files/nvram-bcm53xx.init
@@ -9,6 +9,7 @@ clear_partialboots() {
 	# clear partialboots
 
 	case $(board_name) in
+		linksys,ea9200|\
 		linksys,panamera)
 			COMMIT=1
 			nvram set partialboots=0

--- a/target/linux/bcm53xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm53xx/base-files/etc/board.d/02_network
@@ -50,6 +50,7 @@ bcm53xx_setup_macs()
 		offset=1
 		;;
 	dlink,dir-885l | \
+	linksys,ea9200 | \
 	linksys,panamera | \
 	netgear,r7900 | \
 	netgear,r8000 | \


### PR DESCRIPTION
1) clear nvram partialboots upon successful boot
This behavior is already defined for EA9500; enabled for EA9200 too.

2) fix MAC address in `board.d/02_network`
Use the correct nvram variable to derive lan/wan MAC addresses.
