### PR TITLE
qualcommax: add pending GPLL parent fixes

### DIFF
--- a/target/linux/qualcommax/patches-6.1/0131-clk-qcom-ipq8074-drop-the-CLK_SET_RATE_PARENT-flag-f.patch
+++ b/target/linux/qualcommax/patches-6.1/0131-clk-qcom-ipq8074-drop-the-CLK_SET_RATE_PARENT-flag-f.patch
@@ -1,0 +1,71 @@
+From 007ad475ba7f0d5d4d3e43a06e46a8a46d31c9d2 Mon Sep 17 00:00:00 2001
+From: Kathiravan Thirumoorthy <quic_kathirav@quicinc.com>
+Date: Thu, 14 Sep 2023 12:29:51 +0530
+Subject: [PATCH] clk: qcom: ipq8074: drop the CLK_SET_RATE_PARENT flag from
+ PLL clocks
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+GPLL, NSS crypto PLL clock rates are fixed and shouldn't be scaled based
+on the request from dependent clocks. Doing so will result in the
+unexpected behaviour. So drop the CLK_SET_RATE_PARENT flag from the PLL
+clocks.
+
+Cc: stable@vger.kernel.org
+Fixes: b8e7e519625f ("clk: qcom: ipq8074: add remaining PLL’s")
+Signed-off-by: Kathiravan Thirumoorthy <quic_kathirav@quicinc.com>
+---
+ drivers/clk/qcom/gcc-ipq8074.c | 6 ------
+ 1 file changed, 6 deletions(-)
+
+--- a/drivers/clk/qcom/gcc-ipq8074.c
++++ b/drivers/clk/qcom/gcc-ipq8074.c
+@@ -76,7 +76,6 @@ static struct clk_fixed_factor gpll0_out
+ 				&gpll0_main.clkr.hw },
+ 		.num_parents = 1,
+ 		.ops = &clk_fixed_factor_ops,
+-		.flags = CLK_SET_RATE_PARENT,
+ 	},
+ };
+ 
+@@ -122,7 +121,6 @@ static struct clk_alpha_pll_postdiv gpll
+ 				&gpll2_main.clkr.hw },
+ 		.num_parents = 1,
+ 		.ops = &clk_alpha_pll_postdiv_ro_ops,
+-		.flags = CLK_SET_RATE_PARENT,
+ 	},
+ };
+ 
+@@ -155,7 +153,6 @@ static struct clk_alpha_pll_postdiv gpll
+ 				&gpll4_main.clkr.hw },
+ 		.num_parents = 1,
+ 		.ops = &clk_alpha_pll_postdiv_ro_ops,
+-		.flags = CLK_SET_RATE_PARENT,
+ 	},
+ };
+ 
+@@ -189,7 +186,6 @@ static struct clk_alpha_pll_postdiv gpll
+ 				&gpll6_main.clkr.hw },
+ 		.num_parents = 1,
+ 		.ops = &clk_alpha_pll_postdiv_ro_ops,
+-		.flags = CLK_SET_RATE_PARENT,
+ 	},
+ };
+ 
+@@ -202,7 +198,6 @@ static struct clk_fixed_factor gpll6_out
+ 				&gpll6_main.clkr.hw },
+ 		.num_parents = 1,
+ 		.ops = &clk_fixed_factor_ops,
+-		.flags = CLK_SET_RATE_PARENT,
+ 	},
+ };
+ 
+@@ -267,7 +262,6 @@ static struct clk_alpha_pll_postdiv nss_
+ 				&nss_crypto_pll_main.clkr.hw },
+ 		.num_parents = 1,
+ 		.ops = &clk_alpha_pll_postdiv_ro_ops,
+-		.flags = CLK_SET_RATE_PARENT,
+ 	},
+ };
+ 

--- a/target/linux/qualcommax/patches-6.1/0132-clk-qcom-apss-ipq6018-add-the-GPLL0-clock-also-as-cl.patch
+++ b/target/linux/qualcommax/patches-6.1/0132-clk-qcom-apss-ipq6018-add-the-GPLL0-clock-also-as-cl.patch
@@ -1,0 +1,43 @@
+From c917237a7cb17b97cc48e073881a9873f3caeaa2 Mon Sep 17 00:00:00 2001
+From: Kathiravan Thirumoorthy <quic_kathirav@quicinc.com>
+Date: Thu, 14 Sep 2023 12:29:57 +0530
+Subject: [PATCH] clk: qcom: apss-ipq6018: add the GPLL0 clock also as clock
+ provider
+
+While the kernel is booting up, APSS PLL will be running at 800MHz with
+GPLL0 as source. Once the cpufreq driver is available, APSS PLL will be
+configured and select the rate based on the opp table and the source will
+be changed to APSS_PLL_EARLY.
+
+Without this patch, CPU Freq driver reports that CPU is running at 24MHz
+instead of the 800MHz.
+
+Reviewed-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Tested-by: Robert Marko <robimarko@gmail.com>
+Signed-off-by: Kathiravan Thirumoorthy <quic_kathirav@quicinc.com>
+---
+ drivers/clk/qcom/apss-ipq6018.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/clk/qcom/apss-ipq6018.c
++++ b/drivers/clk/qcom/apss-ipq6018.c
+@@ -20,16 +20,19 @@
+ 
+ enum {
+ 	P_XO,
++	P_GPLL0,
+ 	P_APSS_PLL_EARLY,
+ };
+ 
+ static const struct clk_parent_data parents_apcs_alias0_clk_src[] = {
+ 	{ .fw_name = "xo" },
++	{ .fw_name = "gpll0" },
+ 	{ .fw_name = "pll" },
+ };
+ 
+ static const struct parent_map parents_apcs_alias0_clk_src_map[] = {
+ 	{ P_XO, 0 },
++	{ P_GPLL0, 4 },
+ 	{ P_APSS_PLL_EARLY, 5 },
+ };
+ 

--- a/target/linux/qualcommax/patches-6.1/0133-arm64-dts-qcom-ipq8074-include-the-GPLL0-as-clock-pr.patch
+++ b/target/linux/qualcommax/patches-6.1/0133-arm64-dts-qcom-ipq8074-include-the-GPLL0-as-clock-pr.patch
@@ -1,0 +1,32 @@
+From 3b48a7d925a757b3fa53c04baaf68bb8313c3ffb Mon Sep 17 00:00:00 2001
+From: Kathiravan Thirumoorthy <quic_kathirav@quicinc.com>
+Date: Thu, 14 Sep 2023 12:29:58 +0530
+Subject: [PATCH] arm64: dts: qcom: ipq8074: include the GPLL0 as clock
+ provider for mailbox
+
+While the kernel is booting up, APSS PLL will be running at 800MHz with
+GPLL0 as source. Once the cpufreq driver is available, APSS PLL will be
+configured to the rate based on the opp table and the source also will
+be changed to APSS_PLL_EARLY. So allow the mailbox to consume the GPLL0,
+with this inclusion, CPU Freq correctly reports that CPU is running at
+800MHz rather than 24MHz.
+
+Signed-off-by: Kathiravan Thirumoorthy <quic_kathirav@quicinc.com>
+Reviewed-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+---
+ arch/arm64/boot/dts/qcom/ipq8074.dtsi | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/arch/arm64/boot/dts/qcom/ipq8074.dtsi
++++ b/arch/arm64/boot/dts/qcom/ipq8074.dtsi
+@@ -920,8 +920,8 @@
+ 		apcs_glb: mailbox@b111000 {
+ 			compatible = "qcom,ipq8074-apcs-apps-global";
+ 			reg = <0x0b111000 0x1000>;
+-			clocks = <&a53pll>, <&xo>;
+-			clock-names = "pll", "xo";
++			clocks = <&a53pll>, <&xo>, <&gcc GPLL0>;
++			clock-names = "pll", "xo", "gpll0";
+ 
+ 			#clock-cells = <1>;
+ 			#mbox-cells = <1>;


### PR DESCRIPTION
SBL will configure IPQ807x cores to boot at 800MHz as a safe default frequency that is provided by GPLL0, but GPLL0 is not currently configured as a possible parent in the APSS clock driver not being passed to it via DTS which will then cause the kernel to not properly identify the current CPU frequency during booting and will think that CPU is currently at XO frequency of 19.2MHz instead of 800MHz cores are actually at and print: `cpufreq: cpufreq_online: CPU0: Running at unlisted initial frequency: 19200 KHz, changing to: 1017600 KHz`

So, lets import patches pending upstream to prevent GPLL scaling and feed the GPLL0 clock to APSS clock driver so we get:
`cpufreq: cpufreq_online: CPU0: Running at unlisted initial frequency: 800000 KHz, changing to: 1017600 KHz
`
This is mostly cosmetic fix, but with all of the possible SBL and FW versions there could be edge cases resolved by this and not scaling GPLL-s anymore.
