### PR TITLE
ramips: fix ZyXEL NR7101 bricking typo

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -95,7 +95,7 @@ ramips_setup_interfaces()
 		;;
 	cudy,m1800|\
 	yuncore,ax820|\
-	zyxel,nt7101)
+	zyxel,nr7101)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
 	gnubee,gb-pc1)


### PR DESCRIPTION
A typo snuck in with the addition of Cudy M1800, changing "nr7101" to "nt7101". The result is a default network config for NR7101 without the only ethernet interface on the NR7101, thereby soft bricking it.

Fixes: f6d394e9f2fd ("ramips: add support for Cudy M1800")
