### PR TITLE
treewide: disable QUILT refresh for unsupported packages

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -108,6 +108,9 @@ define Build/Prepare
 	mkdir -p $(PKG_BUILD_DIR)
 endef
 
+define Build/Quilt
+endef
+
 define Build/Compile/Default
 
 endef

--- a/package/kernel/linux/Makefile
+++ b/package/kernel/linux/Makefile
@@ -37,6 +37,9 @@ endef
 define Build/Configure
 endef
 
+define Build/Quilt
+endef
+
 define Build/Compile
 endef
 

--- a/package/libs/toolchain/Makefile
+++ b/package/libs/toolchain/Makefile
@@ -454,6 +454,9 @@ define Build/Prepare
 	mkdir -p $(PKG_BUILD_DIR)
 endef
 
+define Build/Quilt
+endef
+
 LIBGCC_A=$(lastword $(wildcard $(TOOLCHAIN_DIR)/lib/gcc/*/*/libgcc_pic.a))
 LIBGCC_MAP=$(lastword $(wildcard $(TOOLCHAIN_DIR)/lib/gcc/*/*/libgcc.map))
 LIBGCC_SO=$(lastword $(wildcard $(TOOLCHAIN_DIR)/lib/libgcc_s.so.*))

--- a/package/system/urandom-seed/Makefile
+++ b/package/system/urandom-seed/Makefile
@@ -18,6 +18,9 @@ define Build/Prepare
 	mkdir -p $(PKG_BUILD_DIR)
 endef
 
+define Build/Quilt
+endef
+
 define Build/Compile/Default
 endef
 Build/Compile = $(Build/Compile/Default)


### PR DESCRIPTION
Some packages won't ever have something to patch as they normally install files or are meta-packages.

For these special packages, disable QUILT refresh.

---

@hauke some progress for 'make package/refresh'

I'm not so sure if urandom-seed should be treated this way tho... 