### PR TITLE
ramips: Revert "ramips: convert MT7915 EEPROM to NVMEM format"

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -95,16 +95,13 @@
 		};
 
 		factory: partition@1e0000 {
-			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x1e0000 0x100000>;
-			#address-cells = <1>;
-			#size-cells = <1>;
 			read-only;
 
-			eeprom_factory_0: eeprom@0 {
-				reg = <0x0 0xe00>;
-			};
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
 			macaddr_factory_4: macaddr@4 {
 				reg = <0x4 0x6>;
@@ -158,8 +155,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&factory 0x0000>;
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_asus_rt-ax54.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax54.dts
@@ -87,16 +87,13 @@
 		};
 
 		factory: partition@1e0000 {
-			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x1e0000 0x100000>;
-			#address-cells = <1>;
-			#size-cells = <1>;
 			read-only;
 
-			eeprom_factory_0: eeprom@0 {
-				reg = <0x0 0xe00>;
-			};
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
 			macaddr_factory_4: macaddr@4 {
 				reg = <0x4 0x6>;
@@ -131,8 +128,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&factory 0x0000>;
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_comfast_cf-e390ax.dts
+++ b/target/linux/ramips/dts/mt7621_comfast_cf-e390ax.dts
@@ -59,8 +59,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&factory 0x0>;
 	};
 };
 
@@ -88,20 +87,9 @@
 			};
 
 			factory: partition@50000 {
-				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x50000 0x10000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 				read-only;
-
-				eeprom_factory_0: eeprom@0 {
-					reg = <0x0 0xe00>;
-				};
-
-				macaddr_factory_e000: macaddr@e000 {
-					reg = <0xe000 0x6>;
-				};
 			};
 
 			partition@90000 {
@@ -110,6 +98,16 @@
 				reg = <0x90000 0xf70000>;
 			};
 		};
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_cudy_m1800.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_m1800.dts
@@ -81,8 +81,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&factory 0x0000>;
 		mediatek,disable-radar-background;
 	};
 };
@@ -115,16 +114,9 @@
 			};
 
 			factory: partition@40000 {
-				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 				read-only;
-
-				eeprom_factory_0: eeprom@0 {
-					reg = <0x0 0xe00>;
-				};
 			};
 
 			partition@50000 {

--- a/target/linux/ramips/dts/mt7621_cudy_x6.dtsi
+++ b/target/linux/ramips/dts/mt7621_cudy_x6.dtsi
@@ -76,16 +76,9 @@
 			};
 
 			factory: partition@40000 {
-				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 				read-only;
-
-				eeprom_factory_0: eeprom@0 {
-					reg = <0x0 0xe00>;
-				};
 			};
 
 			/* additional partitions in DTS */
@@ -101,8 +94,7 @@
 	wifi:wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&factory 0x0000>;
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dap-x1860-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dap-x1860-a1.dts
@@ -125,16 +125,13 @@
 		};
 
 		factory: partition@100000 {
-			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x80000>;
-			#address-cells = <1>;
-			#size-cells = <1>;
 			read-only;
 
-			eeprom_factory_0: eeprom@0 {
-				reg = <0x0 0xe00>;
-			};
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
 			macaddr_factory_4: macaddr@4 {
 				reg = <0x4 0x6>;
@@ -178,8 +175,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&factory 0x0>;
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_iptime_ax2004m.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_ax2004m.dts
@@ -73,16 +73,13 @@
 		};
 
 		factory: partition@100000 {
-			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x80000>;
-			#address-cells = <1>;
-			#size-cells = <1>;
 			read-only;
 
-			eeprom_factory_0: eeprom@0 {
-				reg = <0x0 0xe00>;
-			};
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
 			macaddr_factory_4: macaddr@4 {
 				reg = <0x4 0x6>;
@@ -171,7 +168,6 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&factory 0x0>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_mercusys_mr70x-v1.dts
+++ b/target/linux/ramips/dts/mt7621_mercusys_mr70x-v1.dts
@@ -72,16 +72,9 @@
 			};
 
 			config: partition@fa0000 {
-				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0xfa0000 0x010000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 				read-only;
-
-				macaddr_config_8: macaddr@8 {
-					reg = <0x8 0x6>;
-				};
 			};
 
 			partition@fb0000 {
@@ -91,16 +84,9 @@
 			};
 
 			radio: partition@ff0000 {
-				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0xff0000 0x010000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 				read-only;
-
-				eeprom_radio_0: eeprom@0 {
-					reg = <0x0 0xe00>;
-				};
 			};
 		};
 	};
@@ -114,8 +100,9 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_8>;
-		nvmem-cell-names = "eeprom", "mac-address";
+		mediatek,mtd-eeprom = <&radio 0x0>;
+		nvmem-cells = <&macaddr_config_8>;
+		nvmem-cell-names = "mac-address";
 		mediatek,disable-radar-background;
 	};
 };
@@ -164,5 +151,15 @@
 	gpio {
 		groups = "i2c", "uart3";
 		function = "gpio";
+	};
+};
+
+&config {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_config_8: macaddr@8 {
+		reg = <0x8 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_netgear_eax12.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_eax12.dts
@@ -107,16 +107,9 @@
 		};
 
 		factory: partition@100000 {
-			compatible = "nvmem-cells";
 			label = "Factory";
 			reg = <0x100000 0x80000>;
-			#address-cells = <1>;
-			#size-cells = <1>;
 			read-only;
-
-			eeprom_factory_0: eeprom@0 {
-				reg = <0x0 0xe00>;
-			};
 		};
 
 		partition@180000 {
@@ -178,8 +171,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&factory 0x0>;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_tplink_archer-ax23-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-ax23-v1.dts
@@ -105,16 +105,9 @@
 			};
 
 			config: partition@fa0000 {
-				compatible = "nvmem-cells";
 				label = "config";
 				reg = <0xfa0000 0x010000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 				read-only;
-
-				macaddr_config_8: macaddr@8 {
-					reg = <0x8 0x6>;
-				};
 			};
 
 			partition@fb0000 {
@@ -124,16 +117,9 @@
 			};
 
 			radio: partition@ff0000 {
-				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0xff0000 0x010000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 				read-only;
-
-				eeprom_radio_0: eeprom@0 {
-					reg = <0x0 0xe00>;
-				};
 			};
 		};
 	};
@@ -147,8 +133,9 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_8>;
-		nvmem-cell-names = "eeprom", "mac-address";
+		mediatek,mtd-eeprom = <&radio 0x0>;
+		nvmem-cells = <&macaddr_config_8>;
+		nvmem-cell-names = "mac-address";
 		mediatek,disable-radar-background;
 	};
 };
@@ -202,5 +189,15 @@
 	gpio {
 		groups = "i2c", "uart3", "jtag", "wdt";
 		function = "gpio";
+	};
+};
+
+&config {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_config_8: macaddr@8 {
+		reg = <0x8 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_eap613-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap613-v1.dts
@@ -108,16 +108,9 @@
 			};
 
 			radio: partition@ff0000 {
-				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0xff0000 0x10000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 				read-only;
-
-				eeprom_radio_0: eeprom@0 {
-					reg = <0x0 0xe00>;
-				};
 			};
 		};
 	};
@@ -138,8 +131,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_radio_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&radio 0x0>;
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts
@@ -90,16 +90,9 @@
 			};
 
 			info: partition@90000 {
-				compatible = "nvmem-cells";
 				label = "product-info";
 				reg = <0x90000 0x10000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 				read-only;
-
-				macaddr_info_8: macaddr@8 {
-					reg = <0x8 0x6>;
-				};
 			};
 
 			partition@a0000 {
@@ -127,16 +120,9 @@
 			};
 
 			radio: partition@ff0000 {
-				compatible = "nvmem-cells";
 				label = "radio";
 				reg = <0xff0000 0x10000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 				read-only;
-
-				eeprom_radio_0: eeprom@0 {
-					reg = <0x0 0xe00>;
-				};
 			};
 		};
 	};
@@ -157,8 +143,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_radio_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&radio 0x0>;
 		mediatek,disable-radar-background;
 	};
 };
@@ -199,5 +184,15 @@
 			status = "okay";
 			label = "lan1";
 		};
+	};
+};
+
+&info {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_info_8: macaddr@8 {
+		reg = <0x8 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_ubnt_unifi-6-lite.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi-6-lite.dts
@@ -47,10 +47,6 @@
 				eeprom_factory_0: eeprom@0 {
 					reg = <0x0 0x400>;
 				};
-
-				eeprom_factory_20000: eeprom@20000 {
-					reg = <0x20000 0xe00>;
-				};
 			};
 
 			eeprom: partition@b0000 {
@@ -108,8 +104,10 @@
 &wlan_5g {
 	compatible = "mediatek,mt76";
 
-	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_eeprom_6>;
-	nvmem-cell-names = "eeprom", "mac-address";
+	mediatek,mtd-eeprom = <&factory 0x20000>;
+
+	nvmem-cells = <&macaddr_eeprom_6>;
+	nvmem-cell-names = "mac-address";
 
 	/* This is a workaround.
 	 *

--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn573hx1.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn573hx1.dts
@@ -61,8 +61,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&factory 0x0>;
 	};
 };
 
@@ -88,19 +87,8 @@
 			};
 
 			factory:partition@50000 {
-				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x50000 0x40000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				eeprom_factory_0: eeprom@0 {
-					reg = <0x0 0xe00>;
-				};
-
-				macaddr_factory_3fff4: macaddr@3fff4 {
-					reg = <0x3fff4 0x6>;
-				};
 			};
 
 			partition@90000 {
@@ -130,4 +118,16 @@
 			label = "lan";
 		};
 	};
+};
+
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_3fff4: macaddr@3fff4 {
+		reg = <0x3fff4 0x6>;
+	};
+
 };

--- a/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
@@ -112,20 +112,9 @@
 			 */
 
 			factory: partition@50000 {
-				compatible = "nvmem-cells";
 				label = "Factory";
 				reg = <0x50000 0x40000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 				read-only;
-
-				eeprom_factory_0: eeprom@0 {
-					reg = <0x0 0xe00>;
-				};
-
-				macaddr_factory_e000: macaddr@e000 {
-					reg = <0xe000 0x6>;
-				};
 			};
 
 			partition@90000 {
@@ -145,8 +134,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&factory 0x0>;
 		mediatek,disable-radar-background;
 	};
 };
@@ -188,5 +176,15 @@
 	gpio {
 		groups = "jtag", "wdt";
 		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_yuncore_fap640.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_fap640.dts
@@ -120,24 +120,9 @@
 			 */
 
 			factory: partition@50000 {
-				compatible = "nvmem-cells";
 				label = "Factory";
 				reg = <0x50000 0x40000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 				read-only;
-
-				eeprom_factory_0: eeprom@0 {
-					reg = <0x0 0xe00>;
-				};
-
-				macaddr_factory_0004: macaddr@0004 {
-					reg = <0x0004 0x6>;
-				};
-
-				macaddr_factory_e006: macaddr@e006 {
-					reg = <0xe006 0x6>;
-				};
 			};
 
 			partition@90000 {
@@ -157,8 +142,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&factory 0x0>;
 		mediatek,disable-radar-background;
 	};
 };
@@ -217,3 +201,18 @@
 		function = "gpio";
 	};
 };
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_0004: macaddr@0004 {
+		reg = <0x0004 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};
+

--- a/target/linux/ramips/dts/mt7621_yuncore_fap690.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_fap690.dts
@@ -90,20 +90,9 @@
 			 */
 
 			factory: partition@50000 {
-				compatible = "nvmem-cells";
 				label = "Factory";
 				reg = <0x50000 0x40000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 				read-only;
-
-				eeprom_factory_0: eeprom@0 {
-					reg = <0x0 0xe00>;
-				};
-
-				macaddr_factory_0004: macaddr@0004 {
-					reg = <0x0004 0x6>;
-				};
 			};
 
 			partition@90000 {
@@ -123,8 +112,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&factory 0x0>;
 		mediatek,disable-radar-background;
 	};
 };
@@ -147,5 +135,15 @@
 	gpio {
 		groups = "jtag", "wdt";
 		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_0004: macaddr@0004 {
+		reg = <0x0004 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_zyxel_nwa-ax.dtsi
+++ b/target/linux/ramips/dts/mt7621_zyxel_nwa-ax.dtsi
@@ -37,16 +37,9 @@
 		};
 
 		factory: partition@100000 {
-			compatible = "nvmem-cells";
 			label = "factory";
 			reg = <0x100000 0x80000>;
-			#address-cells = <1>;
-			#size-cells = <1>;
 			read-only;
-
-			eeprom_factory_0: eeprom@0 {
-				reg = <0x0 0xe00>;
-			};
 		};
 
 		partition@180000 {
@@ -100,16 +93,9 @@
 		};
 
 		mrd: partition@7780000 {
-			compatible = "nvmem-cells";
 			label = "mrd";
 			reg = <0x7780000 0x80000>;
-			#address-cells = <1>;
-			#size-cells = <1>;
 			read-only;
-
-			macaddr_mrd_1fff8: macaddr@1fff8 {
-				reg = <0x1fff8 0x6>;
-			};
 		};
 	};
 };
@@ -123,8 +109,7 @@
 		reg = <0x0 0 0 0 0>;
 		compatible = "mediatek,mt76";
 
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&factory 0x0>;
 
 		/* MAC-Address set in userspace */
 	};
@@ -141,6 +126,16 @@
 			status = "okay";
 			label = "lan";
 		};
+	};
+};
+
+&mrd {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_mrd_1fff8: macaddr@1fff8 {
+		reg = <0x1fff8 0x6>;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_zyxel_wsm20.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_wsm20.dts
@@ -103,24 +103,9 @@
 		};
 
 		factory: partition@200000 {
-			compatible = "nvmem-cells";
 			reg = <0x200000 0x1c0000>;
-			#address-cells = <1>;
-			#size-cells = <1>;
 			label = "Factory";
 			read-only;
-
-			eeprom_factory_0: eeprom@0 {
-				reg = <0x0 0xe00>;
-			};
-
-			macaddr_factory_1fdfa: macaddr@1fdfa {
-				reg = <0x1fdfa 0x6>;
-			};
-
-			macaddr_factory_1fdf4: macaddr@1fdf4 {
-				reg = <0x1fdf4 0x6>;
-			};
 		};
 
 		partition@3c0000 {
@@ -200,8 +185,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		mediatek,mtd-eeprom = <&factory 0x0>;
 		mediatek,disable-radar-background;
 	};
 };
@@ -231,5 +215,19 @@
 	gpio {
 		groups = "i2c", "uart3", "jtag", "wdt";
 		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_1fdfa: macaddr@1fdfa {
+		reg = <0x1fdfa 0x6>;
+	};
+
+	macaddr_factory_1fdf4: macaddr@1fdf4 {
+		reg = <0x1fdf4 0x6>;
 	};
 };


### PR DESCRIPTION
Some MT7915 devices need to load the second part of the eeprom to work properly. The mt76 driver is not yet ready to read the pre-cal data via the NVMEM cell. Therefore, partially revert commit to fix the device probe issue on some devices. H3C, Haier and JCG series devices don't need the second eeprom part so they can still keep the changes.