### PR TITLE
qualcommax: ipq8074: use upstreamed CPUFreq NVMEM support

### DIFF
--- a/target/linux/qualcommax/patches-6.1/0024-v6.7-dt-bindings-arm-qcom-ids-Add-IDs-for-IPQ8174-family.patch
+++ b/target/linux/qualcommax/patches-6.1/0024-v6.7-dt-bindings-arm-qcom-ids-Add-IDs-for-IPQ8174-family.patch
@@ -1,0 +1,29 @@
+From 93e161c8f4b9b051e5e746814138cb5520b4b897 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Fri, 1 Sep 2023 20:10:04 +0200
+Subject: [PATCH] dt-bindings: arm: qcom,ids: Add IDs for IPQ8174 family
+
+IPQ8174 (Oak) family is part of the IPQ8074 family, but the ID-s for it
+are missing so lets add them.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+Reviewed-by: Kathiravan T <quic_kathirav@quicinc.com>
+Acked-by: Conor Dooley <conor.dooley@microchip.com>
+Link: https://lore.kernel.org/r/20230901181041.1538999-1-robimarko@gmail.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+---
+ include/dt-bindings/arm/qcom,ids.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/include/dt-bindings/arm/qcom,ids.h
++++ b/include/dt-bindings/arm/qcom,ids.h
+@@ -121,6 +121,9 @@
+ #define QCOM_ID_SM6125			394
+ #define QCOM_ID_IPQ8070A		395
+ #define QCOM_ID_IPQ8071A		396
++#define QCOM_ID_IPQ8172			397
++#define QCOM_ID_IPQ8173			398
++#define QCOM_ID_IPQ8174			399
+ #define QCOM_ID_IPQ6018			402
+ #define QCOM_ID_IPQ6028			403
+ #define QCOM_ID_IPQ6000			421

--- a/target/linux/qualcommax/patches-6.1/0025-v6.7-cpufreq-qcom-nvmem-add-support-for-IPQ8074.patch
+++ b/target/linux/qualcommax/patches-6.1/0025-v6.7-cpufreq-qcom-nvmem-add-support-for-IPQ8074.patch
@@ -1,10 +1,11 @@
-From 11592aa862e67f4477dee7e94d5c8244d893de1b Mon Sep 17 00:00:00 2001
+From df75a00c60c6e58bc36e4c63e9d7f1910412b132 Mon Sep 17 00:00:00 2001
 From: Robert Marko <robimarko@gmail.com>
-Date: Sat, 31 Dec 2022 13:03:41 +0100
+Date: Fri, 13 Oct 2023 19:20:02 +0200
 Subject: [PATCH] cpufreq: qcom-nvmem: add support for IPQ8074
 
-IPQ8074 comes in 2 families:
+IPQ8074 comes in 3 families:
 * IPQ8070A/IPQ8071A (Acorn) up to 1.4GHz
+* IPQ8172/IPQ8173/IPQ8174 (Oak) up to 1.4GHz
 * IPQ8072A/IPQ8074A/IPQ8076A/IPQ8078A (Hawkeye) up to 2.2GHz
 
 So, in order to be able to share one OPP table lets add support for IPQ8074
@@ -14,14 +15,12 @@ IPQ8074 compatible is blacklisted from DT platdev as the cpufreq device
 will get created by NVMEM CPUFreq driver.
 
 Signed-off-by: Robert Marko <robimarko@gmail.com>
----
-Changes in v2:
-* Print an error if SMEM ID is not part of the IPQ8074 family
-and restrict the speed to Acorn variant (1.4GHz)
+Acked-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>
 ---
  drivers/cpufreq/cpufreq-dt-platdev.c |  1 +
- drivers/cpufreq/qcom-cpufreq-nvmem.c | 43 ++++++++++++++++++++++++++++
- 2 files changed, 44 insertions(+)
+ drivers/cpufreq/qcom-cpufreq-nvmem.c | 48 ++++++++++++++++++++++++++++
+ 2 files changed, 49 insertions(+)
 
 --- a/drivers/cpufreq/cpufreq-dt-platdev.c
 +++ b/drivers/cpufreq/cpufreq-dt-platdev.c
@@ -35,17 +34,19 @@ and restrict the speed to Acorn variant (1.4GHz)
  	{ .compatible = "qcom,msm8960", },
 --- a/drivers/cpufreq/qcom-cpufreq-nvmem.c
 +++ b/drivers/cpufreq/qcom-cpufreq-nvmem.c
-@@ -31,6 +31,9 @@
+@@ -31,6 +31,11 @@
  
  #include <dt-bindings/arm/qcom,ids.h>
  
-+#define IPQ8074_HAWKEYE_VERSION		BIT(0)
-+#define IPQ8074_ACORN_VERSION		BIT(1)
++enum ipq8074_versions {
++	IPQ8074_HAWKEYE_VERSION = 0,
++	IPQ8074_ACORN_VERSION,
++};
 +
  struct qcom_cpufreq_drv;
  
  struct qcom_cpufreq_match_data {
-@@ -204,6 +207,41 @@ len_error:
+@@ -204,6 +209,44 @@ len_error:
  	return ret;
  }
  
@@ -65,19 +66,22 @@ and restrict the speed to Acorn variant (1.4GHz)
 +	switch (msm_id) {
 +	case QCOM_ID_IPQ8070A:
 +	case QCOM_ID_IPQ8071A:
-+		drv->versions = IPQ8074_ACORN_VERSION;
++	case QCOM_ID_IPQ8172:
++	case QCOM_ID_IPQ8173:
++	case QCOM_ID_IPQ8174:
++		drv->versions = BIT(IPQ8074_ACORN_VERSION);
 +		break;
 +	case QCOM_ID_IPQ8072A:
 +	case QCOM_ID_IPQ8074A:
 +	case QCOM_ID_IPQ8076A:
 +	case QCOM_ID_IPQ8078A:
-+		drv->versions = IPQ8074_HAWKEYE_VERSION;
++		drv->versions = BIT(IPQ8074_HAWKEYE_VERSION);
 +		break;
 +	default:
 +		dev_err(cpu_dev,
 +			"SoC ID %u is not part of IPQ8074 family, limiting to 1.4GHz!\n",
 +			msm_id);
-+		drv->versions = IPQ8074_ACORN_VERSION;
++		drv->versions = BIT(IPQ8074_ACORN_VERSION);
 +		break;
 +	}
 +
@@ -87,7 +91,7 @@ and restrict the speed to Acorn variant (1.4GHz)
  static const struct qcom_cpufreq_match_data match_data_kryo = {
  	.get_version = qcom_cpufreq_kryo_name_version,
  };
-@@ -218,6 +256,10 @@ static const struct qcom_cpufreq_match_d
+@@ -218,6 +261,10 @@ static const struct qcom_cpufreq_match_d
  	.genpd_names = qcs404_genpd_names,
  };
  
@@ -98,7 +102,7 @@ and restrict the speed to Acorn variant (1.4GHz)
  static int qcom_cpufreq_probe(struct platform_device *pdev)
  {
  	struct qcom_cpufreq_drv *drv;
-@@ -363,6 +405,7 @@ static const struct of_device_id qcom_cp
+@@ -363,6 +410,7 @@ static const struct of_device_id qcom_cp
  	{ .compatible = "qcom,msm8996", .data = &match_data_kryo },
  	{ .compatible = "qcom,qcs404", .data = &match_data_qcs404 },
  	{ .compatible = "qcom,ipq8064", .data = &match_data_krait },


### PR DESCRIPTION
IPQ8074 CPUFreq NVMEM support has finally landed upstream, so lets use the upstreamed version.

This has a benefit of also supporting IPQ8174 (Oak) family for which SMEM SoC ID-s were also upstreamed.
