### PR TITLE
ipq40xx: wpj428: switch to zimage to fit kernel partition

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -354,7 +354,7 @@ endef
 #TARGET_DEVICES += compex_wpj419
 
 define Device/compex_wpj428
-	$(call Device/FitImage)
+	$(call Device/FitzImage)
 	DEVICE_VENDOR := Compex
 	DEVICE_MODEL := WPJ428
 	SOC := qcom-ipq4028


### PR DESCRIPTION
Like with some other ipq40xx devices, the kernel image size for the WPJ428 is limited in stock u-boot. For that reason, the current release doesn't include an image for the board.
By switching to the zImage format, the kernel image size is reduced which re-enables the build process. The image boots and behaved normally through a few days of testing.

Before the switch to kernel version 6.1, it was possible to reduce the image size by enough when disabling UBIFS and its otherwise unneeded dependencies.