### PR TITLE
TOTEST: DONOTMERGE: AHHHHHHHHHHHHHH: mt76: test precal patches mt7915

### DIFF
--- a/package/kernel/mt76/patches/0002-wifi-mt76-fix-typo-in-mt76_get_of_eeprom_from_nvmem-.patch
+++ b/package/kernel/mt76/patches/0002-wifi-mt76-fix-typo-in-mt76_get_of_eeprom_from_nvmem-.patch
@@ -1,0 +1,40 @@
+From 150039e9ef733827a9d24618b54cba418339f2ef Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 17 Oct 2023 17:02:11 +0200
+Subject: [PATCH 2/6] wifi: mt76: fix typo in mt76_get_of_eeprom_from_nvmem
+ function
+
+Fix typo in mt76_get_of_eeprom_from_nvmem where eeprom was misspelled as
+epprom.
+
+Fixes: 5bef3a406c6e ("wifi: mt76: add support for providing eeprom in nvmem cells")
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+/eeprom.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/eeprom.c b/eeprom.c
+index 2558788f7ffb..1de3c734e136 100644
+--- a/eeprom.c
++++ b/eeprom.c
+@@ -106,7 +106,7 @@ static int mt76_get_of_epprom_from_mtd(struct mt76_dev *dev, void *eep, int offs
+ #endif
+ }
+ 
+-static int mt76_get_of_epprom_from_nvmem(struct mt76_dev *dev, void *eep, int len)
++static int mt76_get_of_eeprom_from_nvmem(struct mt76_dev *dev, void *eep, int len)
+ {
+ 	struct device_node *np = dev->dev->of_node;
+ 	struct nvmem_cell *cell;
+@@ -153,7 +153,7 @@ int mt76_get_of_eeprom(struct mt76_dev *dev, void *eep, int offset, int len)
+ 	if (!ret)
+ 		return 0;
+ 
+-	return mt76_get_of_epprom_from_nvmem(dev, eep, len);
++	return mt76_get_of_eeprom_from_nvmem(dev, eep, len);
+ }
+ EXPORT_SYMBOL_GPL(mt76_get_of_eeprom);
+ 
+-- 
+2.40.1
+

--- a/package/kernel/mt76/patches/0003-wifi-mt76-limit-support-of-precal-loading-for-mt7915.patch
+++ b/package/kernel/mt76/patches/0003-wifi-mt76-limit-support-of-precal-loading-for-mt7915.patch
@@ -1,0 +1,78 @@
+From c60e96e1fa6c0a48c7396d0091a2a1d985741526 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 17 Oct 2023 19:23:56 +0200
+Subject: [PATCH 3/6] wifi: mt76: limit support of precal loading for mt7915 to
+ MTD only
+
+Limit support for precal loading for mt7915 only to MTD. Passing data
+from DT doesn't support offset and NVMEM require a different cell name
+and doesn't support offset hence only MTD way is actually supported.
+
+Rename mt76_get_of_eeprom_from_mtd to mt76_get_of_data_from_mtd as it is
+now used for a more generic purpose and export it.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+/eeprom.c        | 5 +++--
+/mt76.h          | 1 +
+/mt7915/eeprom.c | 2 +-
+ 3 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/eeprom.c b/eeprom.c
+index 1de3c734e136..817074a5d2fc 100644
+--- a/eeprom.c
++++ b/eeprom.c
+@@ -28,7 +28,7 @@ static int mt76_get_of_eeprom_data(struct mt76_dev *dev, void *eep, int len)
+ 	return 0;
+ }
+ 
+-static int mt76_get_of_epprom_from_mtd(struct mt76_dev *dev, void *eep, int offset, int len)
++int mt76_get_of_data_from_mtd(struct mt76_dev *dev, void *eep, int offset, int len)
+ {
+ #ifdef CONFIG_MTD
+ 	struct device_node *np = dev->dev->of_node;
+@@ -105,6 +105,7 @@ static int mt76_get_of_epprom_from_mtd(struct mt76_dev *dev, void *eep, int offs
+ 	return -ENOENT;
+ #endif
+ }
++EXPORT_SYMBOL_GPL(mt76_get_of_data_from_mtd);
+ 
+ static int mt76_get_of_eeprom_from_nvmem(struct mt76_dev *dev, void *eep, int len)
+ {
+@@ -149,7 +150,7 @@ int mt76_get_of_eeprom(struct mt76_dev *dev, void *eep, int offset, int len)
+ 	if (!ret)
+ 		return 0;
+ 
+-	ret = mt76_get_of_epprom_from_mtd(dev, eep, offset, len);
++	ret = mt76_get_of_data_from_mtd(dev, eep, offset, len);
+ 	if (!ret)
+ 		return 0;
+ 
+diff --git a/mt76.h b/mt76.h
+index e8757865a3d0..f6c850557447 100644
+--- a/mt76.h
++++ b/mt76.h
+@@ -1095,6 +1095,7 @@ void mt76_seq_puts_array(struct seq_file *file, const char *str,
+ 
+ int mt76_eeprom_init(struct mt76_dev *dev, int len);
+ void mt76_eeprom_override(struct mt76_phy *phy);
++int mt76_get_of_data_from_mtd(struct mt76_dev *dev, void *eep, int offset, int len);
+ int mt76_get_of_eeprom(struct mt76_dev *dev, void *data, int offset, int len);
+ 
+ struct mt76_queue *
+diff --git a/mt7915/eeprom.c b/mt7915/eeprom.c
+index 76be7308460b..5228f710b3da 100644
+--- a/mt7915/eeprom.c
++++ b/mt7915/eeprom.c
+@@ -25,7 +25,7 @@ static int mt7915_eeprom_load_precal(struct mt7915_dev *dev)
+ 
+ 	offs = is_mt7915(&dev->mt76) ? MT_EE_PRECAL : MT_EE_PRECAL_V2;
+ 
+-	return mt76_get_of_eeprom(mdev, dev->cal, offs, val);
++	return mt76_get_of_data_from_mtd(mdev, dev->cal, offs, val);
+ }
+ 
+ static int mt7915_check_eeprom(struct mt7915_dev *dev)
+-- 
+2.40.1
+

--- a/package/kernel/mt76/patches/0004-wifi-mt76-make-mt76_get_of_eeprom-static-again.patch
+++ b/package/kernel/mt76/patches/0004-wifi-mt76-make-mt76_get_of_eeprom-static-again.patch
@@ -1,0 +1,68 @@
+From f00fe587de86c5935f9a728a36c0f16189ad4816 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 17 Oct 2023 19:48:26 +0200
+Subject: [PATCH 4/6] wifi: mt76: make mt76_get_of_eeprom static again
+
+Since mt76_get_of_eeprom is not used by mt7915 anymore, unexport it and
+make it static again.
+
+Also drop offset arg as it's only supported for MTD and was always set
+to 0, hardcode the MTD functio instead.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+/eeprom.c | 7 +++----
+/mt76.h   | 1 -
+ 2 files changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/eeprom.c b/eeprom.c
+index 817074a5d2fc..748f4b643a5e 100644
+--- a/eeprom.c
++++ b/eeprom.c
+@@ -138,7 +138,7 @@ static int mt76_get_of_eeprom_from_nvmem(struct mt76_dev *dev, void *eep, int le
+ 	return ret;
+ }
+ 
+-int mt76_get_of_eeprom(struct mt76_dev *dev, void *eep, int offset, int len)
++static int mt76_get_of_eeprom(struct mt76_dev *dev, void *eep, int len)
+ {
+ 	struct device_node *np = dev->dev->of_node;
+ 	int ret;
+@@ -150,13 +150,12 @@ int mt76_get_of_eeprom(struct mt76_dev *dev, void *eep, int offset, int len)
+ 	if (!ret)
+ 		return 0;
+ 
+-	ret = mt76_get_of_data_from_mtd(dev, eep, offset, len);
++	ret = mt76_get_of_data_from_mtd(dev, eep, 0, len);
+ 	if (!ret)
+ 		return 0;
+ 
+ 	return mt76_get_of_eeprom_from_nvmem(dev, eep, len);
+ }
+-EXPORT_SYMBOL_GPL(mt76_get_of_eeprom);
+ 
+ void
+ mt76_eeprom_override(struct mt76_phy *phy)
+@@ -410,6 +409,6 @@ mt76_eeprom_init(struct mt76_dev *dev, int len)
+ 	if (!dev->eeprom.data)
+ 		return -ENOMEM;
+ 
+-	return !mt76_get_of_eeprom(dev, dev->eeprom.data, 0, len);
++	return !mt76_get_of_eeprom(dev, dev->eeprom.data, len);
+ }
+ EXPORT_SYMBOL_GPL(mt76_eeprom_init);
+diff --git a/mt76.h b/mt76.h
+index f6c850557447..41e4f398083e 100644
+--- a/mt76.h
++++ b/mt76.h
+@@ -1096,7 +1096,6 @@ void mt76_seq_puts_array(struct seq_file *file, const char *str,
+ int mt76_eeprom_init(struct mt76_dev *dev, int len);
+ void mt76_eeprom_override(struct mt76_phy *phy);
+ int mt76_get_of_data_from_mtd(struct mt76_dev *dev, void *eep, int offset, int len);
+-int mt76_get_of_eeprom(struct mt76_dev *dev, void *data, int offset, int len);
+ 
+ struct mt76_queue *
+ mt76_init_queue(struct mt76_dev *dev, int qid, int idx, int n_desc,
+-- 
+2.40.1
+

--- a/package/kernel/mt76/patches/0005-wifi-mt76-permit-to-use-alternative-cell-name-to-eep.patch
+++ b/package/kernel/mt76/patches/0005-wifi-mt76-permit-to-use-alternative-cell-name-to-eep.patch
@@ -1,0 +1,76 @@
+From 1067dfd7fddcda621c97e10cca493c8a634509b3 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 17 Oct 2023 19:53:15 +0200
+Subject: [PATCH 5/6] wifi: mt76: permit to use alternative cell name to eeprom
+ NVMEM load
+
+Generilize mt76_get_of_eeprom_from_nvmem to use alternative cell name by
+passing the cell name as an arg and expose it.
+
+Rename it to mt76_get_of_data_from_nvmem to better reflect the now more
+generic usage.
+
+This is to permit driver to load additional cell, like precal cell.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+/eeprom.c | 8 +++++---
+/mt76.h   | 2 ++
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/eeprom.c b/eeprom.c
+index 748f4b643a5e..ac6c0a0e876f 100644
+--- a/eeprom.c
++++ b/eeprom.c
+@@ -107,7 +107,8 @@ int mt76_get_of_data_from_mtd(struct mt76_dev *dev, void *eep, int offset, int l
+ }
+ EXPORT_SYMBOL_GPL(mt76_get_of_data_from_mtd);
+ 
+-static int mt76_get_of_eeprom_from_nvmem(struct mt76_dev *dev, void *eep, int len)
++int mt76_get_of_data_from_nvmem(struct mt76_dev *dev, void *eep,
++				const char *cell_name, int len)
+ {
+ 	struct device_node *np = dev->dev->of_node;
+ 	struct nvmem_cell *cell;
+@@ -115,7 +116,7 @@ static int mt76_get_of_eeprom_from_nvmem(struct mt76_dev *dev, void *eep, int le
+ 	size_t retlen;
+ 	int ret = 0;
+ 
+-	cell = of_nvmem_cell_get(np, "eeprom");
++	cell = of_nvmem_cell_get(np, cell_name);
+ 	if (IS_ERR(cell))
+ 		return PTR_ERR(cell);
+ 
+@@ -137,6 +138,7 @@ static int mt76_get_of_eeprom_from_nvmem(struct mt76_dev *dev, void *eep, int le
+ 
+ 	return ret;
+ }
++EXPORT_SYMBOL_GPL(mt76_get_of_data_from_nvmem);
+ 
+ static int mt76_get_of_eeprom(struct mt76_dev *dev, void *eep, int len)
+ {
+@@ -154,7 +156,7 @@ static int mt76_get_of_eeprom(struct mt76_dev *dev, void *eep, int len)
+ 	if (!ret)
+ 		return 0;
+ 
+-	return mt76_get_of_eeprom_from_nvmem(dev, eep, len);
++	return mt76_get_of_data_from_nvmem(dev, eep, "eeprom", len);
+ }
+ 
+ void
+diff --git a/mt76.h b/mt76.h
+index 41e4f398083e..c9934258c49d 100644
+--- a/mt76.h
++++ b/mt76.h
+@@ -1096,6 +1096,8 @@ void mt76_seq_puts_array(struct seq_file *file, const char *str,
+ int mt76_eeprom_init(struct mt76_dev *dev, int len);
+ void mt76_eeprom_override(struct mt76_phy *phy);
+ int mt76_get_of_data_from_mtd(struct mt76_dev *dev, void *eep, int offset, int len);
++int mt76_get_of_data_from_nvmem(struct mt76_dev *dev, void *eep,
++				const char *cell_name, int len);
+ 
+ struct mt76_queue *
+ mt76_init_queue(struct mt76_dev *dev, int qid, int idx, int n_desc,
+-- 
+2.40.1
+

--- a/package/kernel/mt76/patches/0006-wifi-mt76-permit-to-load-precal-from-NVMEM-cell-for-.patch
+++ b/package/kernel/mt76/patches/0006-wifi-mt76-permit-to-load-precal-from-NVMEM-cell-for-.patch
@@ -1,0 +1,45 @@
+From 38e5fc4f8ee5f5456b1ac85eef270793cfeb3a19 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 17 Oct 2023 19:57:26 +0200
+Subject: [PATCH 6/6] wifi: mt76: permit to load precal from NVMEM cell for
+ mt7915
+
+Permit to load precal from NVMEM cell for mt7915. The NVMEM cell must be
+named "precal" to be correctly loaded.
+
+NVMEM cell must already account the correct offset and be placed after
+the EEPROM as the function expect the data right from the start.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+/mt7915/eeprom.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/mt7915/eeprom.c b/mt7915/eeprom.c
+index 5228f710b3da..3bb2643d1b26 100644
+--- a/mt7915/eeprom.c
++++ b/mt7915/eeprom.c
+@@ -11,6 +11,7 @@ static int mt7915_eeprom_load_precal(struct mt7915_dev *dev)
+ 	u8 *eeprom = mdev->eeprom.data;
+ 	u32 val = eeprom[MT_EE_DO_PRE_CAL];
+ 	u32 offs;
++	int ret;
+ 
+ 	if (!dev->flash_mode)
+ 		return 0;
+@@ -25,7 +26,11 @@ static int mt7915_eeprom_load_precal(struct mt7915_dev *dev)
+ 
+ 	offs = is_mt7915(&dev->mt76) ? MT_EE_PRECAL : MT_EE_PRECAL_V2;
+ 
+-	return mt76_get_of_data_from_mtd(mdev, dev->cal, offs, val);
++	ret = mt76_get_of_data_from_mtd(mdev, dev->cal, offs, val);
++	if (!ret)
++		return ret;
++
++	return mt76_get_of_data_from_nvmem(mdev, dev->cal, "precal", val);
+ }
+ 
+ static int mt7915_check_eeprom(struct mt7915_dev *dev)
+-- 
+2.40.1
+


### PR DESCRIPTION
@DragonBluep can you test this?

the thing changed and for mt7915 now 2 cell are needed eeprom and precal 
precal have it's own size and is placed right after the eeprom.