### PR TITLE
kernel: usb-audio remove Kconfig USB_AUDIO

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -534,7 +534,6 @@ $(eval $(call KernelPackage,usb-wdm))
 define KernelPackage/usb-audio
   TITLE:=Support for USB audio devices
   KCONFIG:= \
-	CONFIG_USB_AUDIO \
 	CONFIG_SND_USB=y \
 	CONFIG_SND_USB_AUDIO
   $(call AddDepends/usb)


### PR DESCRIPTION
CONFIG_USB_AUDIO is a "USB Audio Gadget" driver, not a usb device driver

CONFIG_USB_AUDIO is "USB Audio support" before linux 2.6

some links:
https://elixir.bootlin.com/linux/v2.5.75/source/drivers/usb/class/Kconfig#L7
https://elixir.bootlin.com/linux/v2.6.31/source/drivers/usb/gadget/Kconfig#L667
https://elixir.bootlin.com/linux/v5.10.176/source/drivers/usb/gadget/legacy/Kconfig#L75
https://elixir.bootlin.com/linux/v5.15.135/source/drivers/usb/gadget/legacy/Kconfig#L75
