### PR TITLE
ipq807x: add Arcadyan AW1000 support

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -28,6 +28,7 @@ endef
 # <https://wireless.wiki.kernel.org/en/users/drivers/ath10k/boardfiles>
 
 ALLWIFIBOARDS:= \
+	arcadyan_aw1000 \
 	buffalo_wxr-5950ax12 \
 	compex_wpq873 \
 	dynalink_dl-wrx36 \
@@ -136,6 +137,7 @@ endef
 # Board files should follow this name structure:
 #   board-<devicename>.<qca4019|qca9888|qca9889|qca9984|qca99x0|ipq8074>
 
+$(eval $(call generate-ipq-wifi-package,arcadyan_aw1000,Arcadyan AW1000))
 $(eval $(call generate-ipq-wifi-package,buffalo_wxr-5950ax12,Buffalo WXR-5950AX12))
 $(eval $(call generate-ipq-wifi-package,compex_wpq873,Compex WPQ-873))
 $(eval $(call generate-ipq-wifi-package,dynalink_dl-wrx36,Dynalink DL-WRX36))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-aw1000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-aw1000.dts
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2023, Chukun Pan <amadeus@jmu.edu.cn> */
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Arcadyan AW1000";
+	compatible = "arcadyan,aw1000", "qcom,ipq8074";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		serial0 = &blsp1_uart5;
+		/*
+		 * Aliases as required by u-boot
+		 * to patch MAC addresses
+		 */
+		ethernet0 = &dp1;
+		ethernet1 = &dp2;
+		ethernet2 = &dp3;
+		ethernet3 = &dp4;
+		ethernet4 = &dp6_syn;
+		label-mac-device = &dp1;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		lte-pwrkey {
+			gpio-export,name = "lte_pwrkey";
+			gpio-export,output = <1>;
+			gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
+		};
+
+		lte-power {
+			gpio-export,name = "lte_power";
+			gpio-export,output = <1>;
+			gpios = <&tlmm 30 GPIO_ACTIVE_HIGH>;
+		};
+
+		lte-reset {
+			gpio-export,name = "lte_reset";
+			gpio-export,output = <1>;
+			gpios = <&tlmm 63 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb-vbus {
+			gpio-export,name = "usb_vbus";
+			gpio-export,output = <0>;
+			gpios = <&tlmm 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wlan {
+			label = "wlan";
+			linux,code = <KEY_WLAN>;
+			gpios = <&tlmm 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&tlmm 62 GPIO_ACTIVE_LOW>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&tlmm 67 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	led-spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&tlmm 18 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&tlmm 19 GPIO_ACTIVE_HIGH>;
+
+		led_gpio: led-gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <2>;
+			spi-max-frequency = <1000000>;
+			enable-gpios = <&tlmm 20 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&led_gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi {
+			label = "green:wifi";
+			gpios = <&led_gpio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		internet {
+			label = "green:internet";
+			gpios = <&led_gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		5g-red {
+			label = "red:5g";
+			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		5g-green {
+			label = "green:5g";
+			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		5g-blue {
+			label = "blue:5g";
+			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		signal-red {
+			label = "red:signal";
+			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		signal-green {
+			label = "green:signal";
+			gpios = <&led_gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		signal-blue {
+			label = "blue:signal";
+			gpios = <&led_gpio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		phone {
+			label = "green:phone";
+			gpios = <&led_gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <8>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+		};
+	};
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&qusb_phy_1 {
+	status = "okay";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&ssphy_1 {
+	status = "okay";
+};
+
+&usb_0 {
+	status = "okay";
+};
+
+&usb_1 {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+
+	qca8075_0: ethernet-phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0>;
+	};
+
+	qca8075_1: ethernet-phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <1>;
+	};
+
+	qca8075_2: ethernet-phy@2 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <2>;
+	};
+
+	qca8075_3: ethernet-phy@3 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <3>;
+	};
+
+	qca8081: ethernet-phy@28 {
+		compatible = "ethernet-phy-id004d.d101";
+		reg = <28>;
+		reset-gpios = <&tlmm 64 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
+	switch_mac_mode = <MAC_MODE_QSGMII>; /* mac mode for uniphy instance0*/
+	switch_mac_mode2 = <MAC_MODE_SGMII_PLUS>; /* mac mode for uniphy instance2*/
+
+	qcom,port_phyinfo {
+		port@1 {
+			port_id = <1>;
+			phy_address = <0>;
+		};
+		port@2 {
+			port_id = <2>;
+			phy_address = <1>;
+		};
+		port@3 {
+			port_id = <3>;
+			phy_address = <2>;
+		};
+		port@4 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+		port@6 {
+			port_id = <6>;
+			phy_address = <28>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp1 {
+	status = "okay";
+	phy-handle = <&qca8075_0>;
+	label = "lan1";
+};
+
+&dp2 {
+	status = "okay";
+	phy-handle = <&qca8075_1>;
+	label = "lan2";
+};
+
+&dp3 {
+	status = "okay";
+	phy-handle = <&qca8075_2>;
+	label = "lan3";
+};
+
+&dp4 {
+	status = "okay";
+	phy-handle = <&qca8075_3>;
+	label = "lan4";
+};
+
+&dp6_syn {
+	status = "okay";
+	phy-handle = <&qca8081>;
+	label = "wan";
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Arcadyan-AW1000";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -48,16 +48,16 @@ endef
 TARGET_DEVICES += buffalo_wxr-5950ax12
 
 define Device/compex_wpq873
-       $(call Device/FitImage)
-       $(call Device/UbiFit)
-       DEVICE_VENDOR := Compex
-       DEVICE_MODEL := WPQ873
-       BLOCKSIZE := 128k
-       PAGESIZE := 2048
-       DEVICE_DTS_CONFIG := config@hk09.wpq873
-       SOC := ipq8072
-       DEVICE_PACKAGES := ipq-wifi-compex_wpq873
-       IMAGE/factory.ubi := append-ubi | qsdk-ipq-factory-nand
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Compex
+	DEVICE_MODEL := WPQ873
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_DTS_CONFIG := config@hk09.wpq873
+	SOC := ipq8072
+	DEVICE_PACKAGES := ipq-wifi-compex_wpq873
+	IMAGE/factory.ubi := append-ubi | qsdk-ipq-factory-nand
 endef
 TARGET_DEVICES += compex_wpq873
 
@@ -242,18 +242,6 @@ endif
 endef
 TARGET_DEVICES += xiaomi_ax9000
 
-define Device/zyxel_nbg7815
-	$(call Device/FitImage)
-	$(call Device/EmmcImage)
-	DEVICE_VENDOR := ZYXEL
-	DEVICE_MODEL := NBG7815
-	DEVICE_DTS_CONFIG := config@nbg7815
-	SOC := ipq8074
-	DEVICE_PACKAGES += ipq-wifi-zyxel_nbg7815 kmod-ath11k-pci kmod-hwmon-tmp103 \
-		kmod-bluetooth
-endef
-TARGET_DEVICES += zyxel_nbg7815
-
 define Device/yuncore_ax880
 	$(call Device/FitImage)
 	$(call Device/UbiFit)
@@ -269,3 +257,14 @@ define Device/yuncore_ax880
 endef
 TARGET_DEVICES += yuncore_ax880
 
+define Device/zyxel_nbg7815
+	$(call Device/FitImage)
+	$(call Device/EmmcImage)
+	DEVICE_VENDOR := ZYXEL
+	DEVICE_MODEL := NBG7815
+	DEVICE_DTS_CONFIG := config@nbg7815
+	SOC := ipq8074
+	DEVICE_PACKAGES += ipq-wifi-zyxel_nbg7815 kmod-ath11k-pci \
+		kmod-bluetooth kmod-hwmon-tmp103
+endef
+TARGET_DEVICES += zyxel_nbg7815

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -33,6 +33,20 @@ define Build/wax6xx-netgear-tar
 	rm -rf $@.tmp
 endef
 
+define Device/arcadyan_aw1000
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Arcadyan
+	DEVICE_MODEL := AW1000
+	BLOCKSIZE := 256k
+	PAGESIZE := 4096
+	DEVICE_DTS_CONFIG := config@hk09
+	SOC := ipq8072
+	DEVICE_PACKAGES := ipq-wifi-arcadyan_aw1000 kmod-spi-gpio \
+		kmod-gpio-nxp-74hc164 kmod-usb-serial-option uqmi
+endef
+TARGET_DEVICES += arcadyan_aw1000
+
 define Device/buffalo_wxr-5950ax12
 	$(call Device/FitImage)
 	DEVICE_VENDOR := Buffalo

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
@@ -6,6 +6,10 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+arcadyan,aw1000)
+	ucidef_set_led_netdev "5g" "5G" "green:5g" "wwan0"
+	ucidef_set_led_netdev "wan" "WAN" "green:internet" "wan"
+	;;
 edgecore,eap102)
 	ucidef_set_led_netdev "wan" "WAN" "green:wanpoe" "wan"
 	;;

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -11,6 +11,7 @@ ipq807x_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
+	arcadyan,aw1000|\
 	buffalo,wxr-5950ax12|\
 	dynalink,dl-wrx36|\
 	xiaomi,ax9000)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -16,6 +16,11 @@ ipq807x_setup_interfaces()
 	xiaomi,ax9000)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;
+	compex,wpq873|\
+	redmi,ax6|\
+	xiaomi,ax3600)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
+		;;
 	edgecore,eap102|\
 	yuncore,ax880)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
@@ -38,11 +43,6 @@ ipq807x_setup_interfaces()
 		;;
 	qnap,301w)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 10g-2" "10g-1"
-		;;
-	compex,wpq873|\
-	redmi,ax6|\
-	xiaomi,ax3600)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
 	zyxel,nbg7815)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 10g" "wan"

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -11,9 +11,9 @@ case "$FIRMWARE" in
 	case "$board" in
 	buffalo,wxr-5950ax12|\
 	compex,wpq873|\
+	dynalink,dl-wrx36|\
 	edgecore,eap102|\
 	edimax,cax1800|\
-	dynalink,dl-wrx36|\
 	netgear,rax120v2|\
 	netgear,wax218|\
 	netgear,wax620|\
@@ -27,7 +27,7 @@ case "$FIRMWARE" in
 		caldata_extract "0:art" 0x1000 0x20000
 		;;
 	prpl,haze)
-                caldata_extract_mmc "0:ART" 0x1000 0x20000
+		caldata_extract_mmc "0:ART" 0x1000 0x20000
 		;;
 	esac
 	;;
@@ -35,7 +35,7 @@ case "$FIRMWARE" in
 "ath11k/QCN9074/hw1.0/cal-pci-0001:01:00.0.bin")
 	case "$board" in
 	prpl,haze)
-                caldata_extract_mmc "0:ART" 0x26800 0x20000
+		caldata_extract_mmc "0:ART" 0x26800 0x20000
 		;;
 	xiaomi,ax9000)
 		caldata_extract "0:art" 0x26800 0x20000

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -9,6 +9,7 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath11k/IPQ8074/hw2.0/cal-ahb-c000000.wifi.bin")
 	case "$board" in
+	arcadyan,aw1000|\
 	buffalo,wxr-5950ax12|\
 	compex,wpq873|\
 	dynalink,dl-wrx36|\

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -1,0 +1,17 @@
+[ "$ACTION" == "add" ] || exit 0
+
+PHYNBR=${DEVPATH##*/phy}
+
+[ -n $PHYNBR ] || exit 0
+
+. /lib/functions.sh
+. /lib/functions/system.sh
+
+board=$(board_name)
+
+case "$board" in
+	arcadyan,aw1000)
+		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label) 1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $(get_mac_label) 2 > /sys${DEVPATH}/macaddress
+		;;
+esac

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/mmc.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/mmc.sh
@@ -18,11 +18,11 @@ mmc_do_upgrade() {
 	local rootfs=
 	local kernel=
 
-			[ -z "$kernel" ] && kernel=$(find_mmc_part ${kernelname})
-			[ -z "$rootfs" ] && rootfs=$(find_mmc_part ${rootfsname})
+	[ -z "$kernel" ] && kernel=$(find_mmc_part ${kernelname})
+	[ -z "$rootfs" ] && rootfs=$(find_mmc_part ${rootfsname})
 
-			[ -z "$kernel" ] && echo "Upgrade failed: kernel partition not found! Rebooting..." && reboot -f
-			[ -z "$rootfs" ] && echo "Upgrade failed: rootfs partition not found! Rebooting..." && reboot -f
+	[ -z "$kernel" ] && echo "Upgrade failed: kernel partition not found! Rebooting..." && reboot -f
+	[ -z "$rootfs" ] && echo "Upgrade failed: rootfs partition not found! Rebooting..." && reboot -f
 
 	mmc_do_flash $tar_file $kernel $rootfs
 

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -43,14 +43,7 @@ platform_pre_upgrade() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
-	buffalo,wxr-5950ax12)
-		CI_KERN_UBIPART="rootfs"
-		CI_ROOT_UBIPART="user_property"
-		buffalo_upgrade_prepare
-		nand_do_flash_file "$1" || nand_do_upgrade_failed
-		nand_do_restore_config || nand_do_upgrade_failed
-		buffalo_upgrade_optvol
-		;;
+	arcadyan,aw1000|\
 	compex,wpq873|\
 	dynalink,dl-wrx36|\
 	edimax,cax1800|\
@@ -59,6 +52,14 @@ platform_do_upgrade() {
 	netgear,wax620|\
 	netgear,wax630)
 		nand_do_upgrade "$1"
+		;;
+	buffalo,wxr-5950ax12)
+		CI_KERN_UBIPART="rootfs"
+		CI_ROOT_UBIPART="user_property"
+		buffalo_upgrade_prepare
+		nand_do_flash_file "$1" || nand_do_upgrade_failed
+		nand_do_restore_config || nand_do_upgrade_failed
+		buffalo_upgrade_optvol
 		;;
 	edgecore,eap102)
 		active="$(fw_printenv -n active)"

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -51,7 +51,13 @@ platform_do_upgrade() {
 		nand_do_restore_config || nand_do_upgrade_failed
 		buffalo_upgrade_optvol
 		;;
-	dynalink,dl-wrx36)
+	compex,wpq873|\
+	dynalink,dl-wrx36|\
+	edimax,cax1800|\
+	netgear,rax120v2|\
+	netgear,wax218|\
+	netgear,wax620|\
+	netgear,wax630)
 		nand_do_upgrade "$1"
 		;;
 	edgecore,eap102)
@@ -66,33 +72,11 @@ platform_do_upgrade() {
 		fw_setenv upgrade_available 1
 		nand_do_upgrade "$1"
 		;;
-	compex,wpq873|\
-	edimax,cax1800|\
-	netgear,rax120v2|\
-	netgear,wax218|\
-	netgear,wax620|\
-	netgear,wax630)
-		nand_do_upgrade "$1"
-		;;
 	prpl,haze|\
 	qnap,301w)
 		kernelname="0:HLOS"
 		rootfsname="rootfs"
 		mmc_do_upgrade "$1"
-		;;
-	zyxel,nbg7815)
-		local config_mtdnum="$(find_mtd_index 0:bootconfig)"
-		[ -z "$config_mtdnum" ] && reboot
-		part_num="$(hexdump -e '1/1 "%01x|"' -n 1 -s 168 -C /dev/mtd$config_mtdnum | cut -f 1 -d "|" | head -n1)"
-		if [ "$part_num" -eq "0" ]; then
-			kernelname="0:HLOS"
-			rootfsname="rootfs"
-			mmc_do_upgrade "$1"
-		else
-			kernelname="0:HLOS_1"
-			rootfsname="rootfs_1"
-			mmc_do_upgrade "$1"
-		fi
 		;;
 	redmi,ax6|\
 	xiaomi,ax3600|\
@@ -124,6 +108,20 @@ platform_do_upgrade() {
 		fw_setenv bootcount 3
 		fw_setenv upgrade_available 1
 		nand_do_upgrade "$1"
+		;;
+	zyxel,nbg7815)
+		local config_mtdnum="$(find_mtd_index 0:bootconfig)"
+		[ -z "$config_mtdnum" ] && reboot
+		part_num="$(hexdump -e '1/1 "%01x|"' -n 1 -s 168 -C /dev/mtd$config_mtdnum | cut -f 1 -d "|" | head -n1)"
+		if [ "$part_num" -eq "0" ]; then
+			kernelname="0:HLOS"
+			rootfsname="rootfs"
+			mmc_do_upgrade "$1"
+		else
+			kernelname="0:HLOS_1"
+			rootfsname="rootfs_1"
+			mmc_do_upgrade "$1"
+		fi
 		;;
 	*)
 		default_do_upgrade "$1"

--- a/target/linux/qualcommax/patches-6.1/0400-mtd-rawnand-add-support-for-TH58NYG3S0HBAI4.patch
+++ b/target/linux/qualcommax/patches-6.1/0400-mtd-rawnand-add-support-for-TH58NYG3S0HBAI4.patch
@@ -1,0 +1,42 @@
+From 8d8b37d3af2bdccf0a37d2017d876bfc6ce42552 Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Fri, 20 Oct 2023 23:18:21 +0800
+Subject: [PATCH 1/1] mtd: rawnand: add support for TH58NYG3S0HBAI4 NAND flash
+
+The Toshiba TH58NYG3S0HBAI4 is detected with 128 byte OOB while the flash
+has 256 bytes OOB. Since it is not an ONFI compliant NAND, the model name
+cannot be read from anywhere, add a static NAND ID entry to correct this.
+
+However, the NAND ID of this flash is inconsistent with the datasheet.
+The actual NAND ID is only 4 ID bytes, the last ID byte is missing.
+
+Datasheet available at (the ID table is on page 50):
+https://europe.kioxia.com/content/dam/kioxia/newidr/productinfo/datasheet/201910/DST_TH58NYG3S0HBAI4-TDE_EN_31565.pdf
+
+Datasheet NAND ID: {0x98, 0xa3, 0x91, 0x26, 0x76}
+Actual NAND ID: {0x98, 0xa3, 0x91, 0x26}
+
+It seems that this flash may be counterfeit, but another Toshiba flash
+also has the same problem. Maybe the driver has a bug, or some Toshiba
+nand flash is like this. Anyway, add a static NAND ID entry with only
+4 ID bytes as a hack to make sure it works.
+
+Tested on Arcadyan AW1000 flashed with OpenWrt.
+
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+---
+ drivers/mtd/nand/raw/nand_ids.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/mtd/nand/raw/nand_ids.c
++++ b/drivers/mtd/nand/raw/nand_ids.c
+@@ -55,6 +55,9 @@ struct nand_flash_dev nand_flash_ids[] =
+ 		{ .id = {0xad, 0xde, 0x14, 0xa7, 0x42, 0x4a} },
+ 		  SZ_16K, SZ_8K, SZ_4M, NAND_NEED_SCRAMBLING, 6, 1664,
+ 		  NAND_ECC_INFO(40, SZ_1K) },
++	{"TH58NYG3S0HBAI4 8G 1.8V 8-bit", /* Last ID bytes missing */
++		{ .id = {0x98, 0xa3, 0x91, 0x26} },
++		  SZ_4K, SZ_1K, SZ_256K, 0, 4, 256, NAND_ECC_INFO(8, SZ_512) },
+ 	{"TH58NVG2S3HBAI4 4G 3.3V 8-bit",
+ 		{ .id = {0x98, 0xdc, 0x91, 0x15, 0x76} },
+ 		  SZ_2K, SZ_512, SZ_128K, 0, 5, 128, NAND_ECC_INFO(8, SZ_512) },


### PR DESCRIPTION
Hardware specification:
  SoC: Qualcomm IPQ8072A
  Flash: Toshiba NAND 1GiB
  RAM: 1 GiB of DDR3 466 MHz
  Ethernet: 4x 1Gbps + 1x 2.5Gbps
  WiFi1: QCN5024 2.4GHz ax 4x4
  WiFi2: QCN5054 5GHz ax 4x4
  Button: WiFi, WPS, Reset
  Modem: RG500Q-EA
  USB: 1 x USB 3.0
  Power: DC 12V 4A

Flash instructions:
  1. Download the initramfs image, rename it to initramfs.bin, and host it with the tftp server.
  2. Interrupt U-Boot and run these commands:
     tftpboot initramfs.bin
     bootm
  3. After openwrt boots up, use scp or luci web to upload sysupgrade.bin to upgrade.