### PR TITLE
ci: add workflow for automated GitHub release

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,24 @@
+name: Create GitHub release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          prerelease: true


### PR DESCRIPTION
Implement a GitHub Actions workflow for automated project releases[^1].

The workflow triggers on Git tags, ensuring that a GitHub release is created whenever a new tag is pushed.

This is a start of a streamlined and consistent release process for GitHub, reducing manual intervention[^2].

[^1]: I was made aware yesterday, that 23.05.0 release is missing on GitHub.
[^2]: Added manual check to [High-level release process](https://openwrt.org/docs/guide-developer/releases/release-process?do=diff&rev2%5B0%5D=1650626698&rev2%5B1%5D=1697689949&difftype=sidebyside) anyway