### PR TITLE
scripts/ext-toolchain: implement external GCC version detection

### DIFF
--- a/scripts/ext-toolchain.sh
+++ b/scripts/ext-toolchain.sh
@@ -27,6 +27,7 @@ CFLAGS=""
 TOOLCHAIN="."
 
 LIBC_TYPE=""
+GCC_VERSION=""
 
 
 # Library specs
@@ -197,6 +198,19 @@ find_bins() {
 	fi
 
 	return 1
+}
+
+find_gcc_version() {
+	if [ -f $TOOLCHAIN/info.mk ]; then
+		GCC_VERSION=$(grep GCC_VERSION $TOOLCHAIN/info.mk | sed 's/GCC_VERSION=//')
+		return 0
+	fi
+
+	echo "Warning! Can't find info.mk, trying to detect with alternative way."
+
+	# Very fragile detection
+	GCC_VERSION=$(find $TOOLCHAIN/bin | grep -oE "gcc-[0-9]+\.[0-9]+\.[0-9]+$" | \
+		head -1 | sed 's/gcc-//')
 }
 
 
@@ -383,6 +397,13 @@ print_config() {
 		return 1
 	fi
 
+	if [ -n "$GCC_VERSION" ]; then
+		echo "CONFIG_EXTERNAL_GCC_VERSION=\"$GCC_VERSION\"" >> "$config"
+	else
+		echo "Can't detect GCC version. Aborting!" >&2
+		return 1
+	fi
+
 	local lib
 	for lib in C RT PTHREAD GCC STDCPP SSP GFORTRAN GOMP; do
 		local file
@@ -564,6 +585,7 @@ while [ -n "$1" ]; do
 		--config)
 			if probe_cc; then
 				probe_libc
+				find_gcc_version
 				print_config "$1"
 				exit $?
 			fi

--- a/toolchain/Config.in
+++ b/toolchain/Config.in
@@ -150,6 +150,14 @@ menuconfig EXTERNAL_TOOLCHAIN
 
 	endchoice
 
+	config EXTERNAL_GCC_VERSION
+		string
+		prompt "External Toolchain GCC Version" if DEVEL
+		depends on EXTERNAL_TOOLCHAIN && !NATIVE_TOOLCHAIN
+		help
+		  Manually specify the GCC version used by the selected
+		  external toolchain.
+
 	config TOOLCHAIN_LIBC
 		string
 		depends on EXTERNAL_TOOLCHAIN && !NATIVE_TOOLCHAIN

--- a/toolchain/gcc/Config.version
+++ b/toolchain/gcc/Config.version
@@ -8,6 +8,7 @@ config GCC_VERSION_13
 
 config GCC_VERSION
 	string
+	default EXTERNAL_GCC_VERSION	if EXTERNAL_TOOLCHAIN && !NATIVE_TOOLCHAIN
 	default "11.3.0"	if GCC_VERSION_11
 	default "13.2.0"	if GCC_VERSION_13
 	default "12.3.0"


### PR DESCRIPTION
Some package may needs to enable compatibility option based on the GCC version.

Currently the GCC version is set based on the default value and doesn't actually reflect the real value provided by the external toolchain if used.

Fix this by correctly detecting the GCC version in the external toolchain and set the correct value in CONFIG_GCC_VERSION.

A new option is added in menuconfig to manually set the GCC version if needed.