### PR TITLE
buildsystem: add new KERNEL option for ACPI handling 

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -41,6 +41,52 @@ config KERNEL_DEBUG_FS
 	  write to these files. Many common debugging facilities, such as
 	  ftrace, require the existence of debugfs.
 
+config KERNEL_CONFIGFS_FS
+	bool "Compile the kernel with configuration filesystem support"
+	default n
+	help
+	  configfs is a RAM-based filesystem that provides the converse
+	  of sysfs's functionality. Where sysfs is a filesystem-based
+	  view of kernel objects, configfs is a filesystem-based manager
+	  of kernel objects, or config_items.
+
+	  Both sysfs and configfs can and should exist together on the
+	  same system. One is not a replacement for the other.
+
+config KERNEL_ACPI_TABLE_UPGRADE
+	bool "Compile the kernel with ACPI tables upgrading via initrd"
+	depends on HAS_ACPI
+	default y
+	help
+	  This option provides functionality to upgrade arbitrary ACPI tables
+	  via initrd. No functional change if no ACPI tables are passed via
+	  initrd, therefore it's safe to say Y.
+	  See Documentation/admin-guide/acpi/initrd_table_override.rst for details
+
+config KERNEL_ACPI_CONFIGFS
+	bool "Compile the kernel with ACPI enabled configfs support"
+	default n
+	depends on HAS_ACPI
+	select KERNEL_CONFIGFS_FS
+	help
+	  Select this option to enable support for ACPI configuration from
+	  userspace. The configurable ACPI groups will be visible under
+	  /config/acpi, assuming configfs is mounted under /config.
+
+config KERNEL_ACPI_DEBUG
+	bool "Compile the kernel with ACPI debugging support"
+	default n
+	depends on HAS_ACPI
+	select KERNEL_ACPI_CONFIGFS
+	help
+	  The ACPI subsystem can produce debug output.  Saying Y enables this
+	  output and increases the kernel size by around 50K.
+
+	  Use the acpi.debug_layer and acpi.debug_level kernel command-line
+	  parameters documented in Documentation/firmware-guide/acpi/debug.rst and
+	  Documentation/admin-guide/kernel-parameters.rst to control the type and
+	  amount of debug output.
+
 config KERNEL_MIPS_FP_SUPPORT
 	bool
 	default y if TARGET_pistachio

--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -9,6 +9,7 @@ sub target_config_features(@) {
 	my $ret;
 
 	while ($_ = shift @_) {
+		/^acpi$/ and $ret .= "\tselect HAS_ACPI$1\n";
 		/^arm_v(\w+)$/ and $ret .= "\tselect arm_v$1\n";
 		/^audio$/ and $ret .= "\tselect AUDIO_SUPPORT\n";
 		/^boot-part$/ and $ret .= "\tselect USES_BOOT_PART\n";

--- a/target/Config.in
+++ b/target/Config.in
@@ -2,6 +2,9 @@ source "tmp/.config-target.in"
 
 # Kernel/Hardware features
 
+config HAS_ACPI
+	bool
+
 config HAS_TESTING_KERNEL
 	bool
 

--- a/target/linux/x86/64/target.mk
+++ b/target/linux/x86/64/target.mk
@@ -1,5 +1,6 @@
 ARCH:=x86_64
 BOARDNAME:=x86_64
+FEATURES+=acpi
 
 define Target/Description
         Build images for 64 bit systems including virtualized guests.

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -36,7 +36,7 @@ BOOTOPTS:=$(call qstrip,$(CONFIG_GRUB_BOOTOPTS))
 
 define Build/combined
 	$(CP) $(KDIR)/$(KERNEL_NAME) $@.boot/boot/vmlinuz
-	-$(CP) $(STAGING_DIR_ROOT)/boot/. $@.boot/boot/
+	-$(CP) $(TARGET_DIR_ORIG)/boot/. $@.boot/boot/
 	$(CP) $(STAGING_DIR_IMAGE)/grub2/boot.img $@.boot/boot/grub/
 	$(CP) $(STAGING_DIR_IMAGE)/grub2/$(if $(filter $(1),efi),gpt,$(GRUB2_VARIANT))-core.img \
 		$@.boot/boot/grub/core.img
@@ -63,6 +63,7 @@ define Build/grub-config
 		-e 's#@CMDLINE@#$(BOOTOPTS) $(GRUB_CONSOLE_CMDLINE)#g' \
 		-e 's#@TIMEOUT@#$(GRUB_TIMEOUT)#g' \
 		-e 's#@TITLE@#$(GRUB_TITLE)#g' \
+		-e 's#@INITRD_ACPI@#$(if $(wildcard $(TARGET_DIR_ORIG)/boot/initrd-acpi),initrd /boot/initrd-acpi)#g' \
 		./grub-$(1).cfg > $@.boot/boot/grub/grub.cfg
 endef
 
@@ -85,7 +86,7 @@ define Build/iso
 		$(STAGING_DIR_IMAGE)/grub2/cdboot.img \
 		$(STAGING_DIR_IMAGE)/grub2/eltorito.img \
 		> $@.boot/boot/grub/eltorito.img
-	-$(CP) $(STAGING_DIR_ROOT)/boot/. $@.boot/boot/
+	-$(CP) $(TARGET_DIR_ORIG)/boot/. $@.boot/boot/
 	$(if $(filter $(1),efi),
 		mkfs.fat -C $@.boot/boot/grub/isoboot.img -S 512 1440
 		mmd -i $@.boot/boot/grub/isoboot.img ::/efi ::/efi/boot

--- a/target/linux/x86/image/grub-efi.cfg
+++ b/target/linux/x86/image/grub-efi.cfg
@@ -7,7 +7,9 @@ search -l kernel -s root
 
 menuentry "@TITLE@" {
 	linux /boot/vmlinuz @GPT_ROOTPART@ @CMDLINE@ noinitrd
+	@INITRD_ACPI@
 }
 menuentry "@TITLE@ (failsafe)" {
 	linux /boot/vmlinuz failsafe=true @GPT_ROOTPART@ @CMDLINE@ noinitrd
+	@INITRD_ACPI@
 }

--- a/target/linux/x86/image/grub-iso.cfg
+++ b/target/linux/x86/image/grub-iso.cfg
@@ -12,4 +12,5 @@ fi
 
 menuentry "@TITLE@" {
 	linux /boot/vmlinuz root=/dev/sr0 rootfstype=iso9660 rootwait @CMDLINE@ noinitrd
+	@INITRD_ACPI@
 }

--- a/target/linux/x86/image/grub-pc.cfg
+++ b/target/linux/x86/image/grub-pc.cfg
@@ -7,7 +7,9 @@ set root='(hd0,msdos1)'
 
 menuentry "@TITLE@" {
 	linux /boot/vmlinuz @ROOTPART@ @CMDLINE@ noinitrd
+	@INITRD_ACPI@
 }
 menuentry "@TITLE@ (failsafe)" {
 	linux /boot/vmlinuz failsafe=true @ROOTPART@ @CMDLINE@ noinitrd
+	@INITRD_ACPI@
 }


### PR DESCRIPTION
The main reason for this change is to add the ability to overwrite acpi tables via initrd. 

Commit https://github.com/openwrt/openwrt/commit/d6d2d7a06345165309376574743892ad2b6efe7e
Many ACPI tables on x86_64 system contain errors or have incomplete ACPI tabs. By enabling the new option 'KERNEL_ACPI_TABLE_UPGRADE', the tables that come via ACPI can be overwritten by new ones from an initrd. New tables can be created via the [acpica-unix]( https://github.com/openwrt/packages/blob/master/utils/acpica-unix/Makefile) tool.

The generated binary must then be [packed](https://wiki.archlinux.org/title/DSDT) into an initrd and passed to the
kernel by the bootloader during boot . Also, by overwriting the tables, it is possible to add information that is not generally valid for all Boards to buses that are not scannable for example I2C. So no general valid ACPI tables for GPIOs can be added, because it was not added by the manufacturer but by **itself**.

Keyword in this context would be the device tree for GPIOs, LEDs or other I2C devices. These devices cannot be used on systems with ACPI, because of the missing information's. By adding the required information`s via an additional
new ACPI table, they can then be used because the driver now has the required information.

Commit https://github.com/openwrt/openwrt/commit/2b209cee933d8c8d3744241e35ebce5aa1a1f81e
Add the possibility to make the new ACPI initrd known to grub2 during the build process, so that it could be loaded at boot time. In order for grub2 to recognize the initrd, the initrd must be copied to the root directory during the image creation process. The last step is to create the image with the root filesystem, bootloader and bootloader configuration. Only if the initrd is present then the booloader configuration is adjust to load the initrd

- Example for a package to build an initrd to add a new acpi table, generate by the iasl compiler form the [acpi-unix](https://github.com/openwrt/packages/blob/master/utils/acpica-unix/Makefile) tool.
- Pullrequest to build acpi-unix for the host https://github.com/openwrt/packages/pull/22460 to generate aml files.

iasl: is the the compiler form the acpi-unix tool
kahn.dsl: is the acpi table that add a new feature (LEDs/GPIOs)
 ```
 define Build/Compile
         # Compile the acpi source with the acpi-unix tool iasl
         $(STAGING_DIR_HOST)/usr/bin/iasl \
                 $(PKG_BUILD_DIR)/src/khan.dsl

        # Generate the directory structure for the initrd
        mkdir -p $(PKG_BUILD_DIR)/kernel/firmware/acpi

        # Copy the generate acpi table to the new initrd directory
        $(CP) $(PKG_BUILD_DIR)/src/khan.aml \
                $(PKG_BUILD_DIR)/kernel/firmware/acpi

        # Generate the install dir for the new initrd
        mkdir -p $(PKG_BUILD_DIR)/boot/

        # Generate a new initrd and copy it to the root directory for
        # bootloader
        cd $(PKG_BUILD_DIR); $(FIND) kernel | \
                $(STAGING_DIR_HOST)/bin/cpio \
                -H newc --create > \
                $(PKG_BUILD_DIR)/boot/initrd-acpi
endef
```