### PR TITLE
ramips: TP-link archer A6/C6 device tree updates

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_archer-x6-v3.dtsi
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-x6-v3.dtsi
@@ -4,6 +4,7 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
 
 / {
 	aliases {
@@ -21,14 +22,14 @@
 	keys {
 		compatible = "gpio-keys";
 
-		wps {
+		button-wps {
 			label = "wps";
-			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
-		reset {
+		button-reset {
 			label = "reset";
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
@@ -39,35 +40,44 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_power: power {
+		led_power: led-power {
 			label = "green:power";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
 		};
 
-		wan_orange {
-			label = "orange:wan";
+		led-wan-amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WAN;
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
-		lan {
-			label = "green:lan";
+		led-lan {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
-		wifi5g {
-			label = "green:wifi5g";
+		led-wifi5g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <5>;
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy1tpt";
 		};
 
-		wifi2g {
-			label = "green:wifi2g";
+		led-wifi2g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <2>;
 			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
 
-		wan_green {
-			label = "green:wan";
+		led-wan-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
 			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
 		};
 	};


### PR DESCRIPTION
Set correct GPIO (10) for the WPS button. This matches GPIO settings in vendor GPL sources.

Note that GPL sources also mention a USB indicator LED (GPIO 13) but the device has neither an external USB port nor a USB LED.

In addition, prefixes (`button-`, `led-`) are added to relevant DT entries.

Closes: #13736
