### PR TITLE
kernel: fix missing regmap-mmio dependency for rtc-r7301

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -732,6 +732,7 @@ define KernelPackage/rtc-r7301
   SUBMENU:=$(OTHER_MENU)
   TITLE:=Epson RTC7301 support
   DEFAULT:=m if ALL_KMODS && RTC_SUPPORT
+  DEPENDS:=+kmod-regmap-mmio
   KCONFIG:=CONFIG_RTC_DRV_R7301 \
 	CONFIG_RTC_CLASS=y
   FILES:=$(LINUX_DIR)/drivers/rtc/rtc-r7301.ko


### PR DESCRIPTION
Add missing regmap-mmio dependency for rtc-r7301 to fix packaging error.

Fixes: f2bc4c1f1588 ("kernel: Add kmod-rtc-r7301")