### PR TITLE
ipq40xx: allow use of ancillary partitions in WHW03 V2

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-whw03v2.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-whw03v2.dts
@@ -416,16 +416,19 @@
 				reg = <0xae00000 0x9b00000>;
 			};
 
-			partition@14900000 {
-				label = "sysdiag";
+			stock_partition@14900000 {
+				label = "stock_sysdiag";
 				reg = <0x14900000 0x200000>;
-				read-only;
 			};
 
-			partition@14b00000 {
-				label = "syscfg";
+			stock_partition@14b00000 {
+				label = "stock_syscfg";
 				reg = <0x14b00000 0xb500000>;
-				read-only;
+			};
+
+			partition@14900000 {
+				label = "extra";
+				reg = <0x14900000 0xb700000>;
 			};
 		};
 	};


### PR DESCRIPTION
As provisioned by the OEM, WHW03 V2 has dual firmware sets plus a shared partition for data storage (mtd14: "syscfg", 181 MiB).

This partition is the largest one of the device, and in OpenWrt it would be useful as persistent storage surviving sysupgrade, but unfortunately it is declared read-only.

There is also a smaller unused partition in the same situation (mtd13: "sysdiag", 2 MiB),

### Version 1:

This commit makes the two aforementioned partitions writable, for the benefit of users who may want to use them.

### Version 2:

This commit repurposes the space of the two aforementioned unused partitions to define a new "extra" partition for users who may want to take advantage of the extra storage.

Also, the stock partitions are kept accessible and writable, to assist in returning to stock firmware if ever desired.
