### PR TITLE
base-files: ipcalc.sh: Rewrite into shell

### DIFF
--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -44,6 +44,7 @@ case "$1" in
     # data is n.n.n.n/m.m.m.m format, like on a Cisco router
     str2ip ipaddr "${1%/*}" || exit 1
     str2ip netmask "${1#*/}" || exit 1
+    netmask2prefix prefix "$netmask" || exit 1
     shift
     ;;
 */*)
@@ -62,6 +63,7 @@ case "$1" in
     # address and netmask as two separate arguments
     str2ip ipaddr "$1" || exit 1
     str2ip netmask "$2" || exit 1
+    netmask2prefix prefix "$netmask" || exit 1
     shift 2
     ;;
 esac
@@ -69,11 +71,6 @@ esac
 # we either have no arguments left, or we have a range start and length
 if [ $# -ne 0 ] && [ $# -ne 2 ]; then
     usage
-fi
-
-if ! bitcount prefix "$netmask"; then
-    printf "Invalid netmask (%s)\n" "$netmask" >&2
-    exit 1
 fi
 
 # complement of the netmask, i.e. the hostmask

--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -1,100 +1,109 @@
-#!/usr/bin/awk -f
+#!/bin/sh
 
-function bitcount(c) {
-	c=and(rshift(c, 1),0x55555555)+and(c,0x55555555)
-	c=and(rshift(c, 2),0x33333333)+and(c,0x33333333)
-	c=and(rshift(c, 4),0x0f0f0f0f)+and(c,0x0f0f0f0f)
-	c=and(rshift(c, 8),0x00ff00ff)+and(c,0x00ff00ff)
-	c=and(rshift(c,16),0x0000ffff)+and(c,0x0000ffff)
-	return c
+. /lib/functions/ipv4.sh
+
+PROG="$(basename "$0")"
+
+usage() {
+    echo "Usage: $PROG address/prefix [ start limit ]" >&2
+    exit 1
 }
 
-function ip2int(ip) {
-	ret=0
-	n=split(ip,a,"\\.")
-	for (x=1;x<=n;x++)
-		ret=or(lshift(ret,8),a[x])
-	return ret
-}
+if [ $# -eq 0 ]; then
+    usage
+fi
 
-function int2ip(ip,ret,x) {
-	ret=and(ip,255)
-	ip=rshift(ip,8)
-	for(;x<3;x++) {
-		ret=and(ip,255)"."ret
-		ip=rshift(ip,8)
-	}
-	return ret
-}
+case "$1" in
+*/*.*)
+    str2ip ipaddr "${1%/*}" || exit 1
+    str2ip netmask "${1#*/}" || exit 1
+    shift
+    ;;
+*/*)
+    str2ip ipaddr "${1%/*}" || exit 1
+    prefix="${1#*/}"
+    assert_uint32 "$prefix" || exit 1
+    if [ "$prefix" -gt 32 ]; then
+	printf "Prefix out of range (%s)\n" "$prefix" >&2
+	exit 1
+    fi
+    netmask=$(((0xffffffff << (32 - prefix)) & 0xffffffff))
+    shift
+    ;;
+*)
+    str2ip ipaddr "$1" || exit 1
+    str2ip netmask "$2" || exit 1
+    shift 2
+    ;;
+esac
 
-function compl32(v) {
-	ret=xor(v, 0xffffffff)
-	return ret
-}
+if [ $# -ne 0 ] && [ $# -ne 2 ]; then
+    usage
+fi
 
-BEGIN {
-	slpos=index(ARGV[1],"/")
-	if (slpos != 0) {
-		# rearrange arguments to not use compound notation
-		ARGV[4]=ARGV[3]
-		ARGV[3]=ARGV[2]
-		ARGV[2]=substr(ARGV[1],slpos+1)
-		ARGV[1]=substr(ARGV[1],0,slpos-1)
-	}
-	ipaddr=ip2int(ARGV[1])
-	dotpos=index(ARGV[2],".")
-	if (dotpos == 0)
-		netmask=compl32(2**(32-int(ARGV[2]))-1)
-	else
-		netmask=ip2int(ARGV[2])
+if ! bitcount prefix "$netmask"; then
+    printf "Invalid netmask (%s)\n" "$netmask" >&2
+    exit 1
+fi
 
-	network=and(ipaddr,netmask)
-	prefix=32-bitcount(compl32(netmask))
+# complement of the netmask, i.e. the hostmask
+hostmask=$((netmask ^ 0xffffffff))
+network=$((ipaddr & netmask))
+broadcast=$((network | hostmask))
 
-	print "IP="int2ip(ipaddr)
-	print "NETMASK="int2ip(netmask)
-	print "NETWORK="int2ip(network)
-	if (prefix<=30) {
-		broadcast=or(network,compl32(netmask))
-		print "BROADCAST="int2ip(broadcast)
-	}
-	print "PREFIX="prefix
+ip2str IP "$ipaddr"
+ip2str NETMASK "$netmask"
+ip2str NETWORK "$network"
 
-	# range calculations:
-	# ipcalc <ip> <netmask> <range_start> <range_size>
+echo "IP=$IP"
+echo "NETMASK=$NETMASK"
+if [ "$prefix" -le 30 ]; then
+    ip2str BROADCAST "$broadcast"
+    echo "BROADCAST=$BROADCAST"
+fi
+echo "NETWORK=$NETWORK"
+echo "PREFIX=$prefix"
 
-	if (ARGC <= 3)
-		exit(0)
+[ $# -eq 0 ] && exit 0
 
-	if (prefix<=30)
-		limit=network+1
-	else
-		limit=network
+if [ "$prefix" -le 30 ]; then
+    lower=$((network + 1))
+else
+    lower="$network"
+fi
 
-	start=or(network,and(ip2int(ARGV[3]),compl32(netmask)))
-	if (start<limit) start=limit
-	if (start==ipaddr) start=ipaddr+1
+start="$1"
+assert_uint32 "$start" || exit 1
+start=$((network | (start & hostmask)))
+[ "$start" -lt "$lower" ] && start="$lower"
+[ "$start" -eq "$ipaddr" ] && start=$((start + 1))
 
-	if (prefix<=30)
-		limit=or(network,compl32(netmask))-1
-	else
-		limit=or(network,compl32(netmask))
+if [ "$prefix" -le 30 ]; then
+    upper=$(((network | hostmask) - 1))
+else
+    upper="$network"
+fi
 
-	end=start+ARGV[4]-1
-	if (end>limit) end=limit
-	if (end==ipaddr) end=ipaddr-1
+range="$2"
+assert_uint32 "$range" || exit 1
+end=$((start + range - 1))
+[ "$end" -gt "$upper" ] && end="$upper"
+[ "$end" -eq "$ipaddr" ] && end=$((end - 1))
 
-	if (start>end) {
-		print "network ("int2ip(network)"/"prefix") too small" > "/dev/stderr"
-		exit(1)
-	}
+if [ "$start" -gt "$end" ]; then
+    echo "network ($NETWORK/$prefix) too small" >&2
+    exit 1
+fi
 
-	if (ipaddr >= start && ipaddr <= end) {
-		print "warning: ipaddr inside range - this might not be supported in future releases of Openwrt" > "/dev/stderr"
-		# turn this into an error after Openwrt 24 has been released
-		# exit(1)
-	}
+ip2str START "$start"
+ip2str END "$end"
 
-	print "START="int2ip(start)
-	print "END="int2ip(end)
-}
+if [ "$start" -le "$ipaddr" ] && [ "$ipaddr" -le "$end" ]; then
+    echo "error: address $IP inside range $START..$END" >&2
+    exit 1
+fi
+
+echo "START=$START"
+echo "END=$END"
+
+exit 0

--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -55,7 +55,7 @@ case "$1" in
 	printf "Prefix out of range (%s)\n" "$prefix" >&2
 	exit 1
     fi
-    netmask=$(((0xffffffff << (32 - prefix)) & 0xffffffff))
+    prefix2netmask netmask "$prefix" || exit 1
     shift
     ;;
 *)

--- a/package/base-files/files/lib/functions/ipv4.sh
+++ b/package/base-files/files/lib/functions/ipv4.sh
@@ -144,3 +144,16 @@ ip2str() {
     export -- "$__var=$((__n >> 24)).$(((__n >> 16) & 255)).$(((__n >> 8) & 255)).$((__n & 255))"
 }
 
+# convert prefix into an integer bitmask
+prefix2netmask() {
+    local __var="$1" __n="$2"
+    assert_uint32 "$__n" || return 1
+
+    if [ "$__n" -gt 32 ]; then
+	printf "Prefix out-of-range (%s)" "$__n" >&2
+	return 1
+    fi
+
+    export -- "$__var=$(((~(uint_max >> __n)) & uint_max))"
+}
+

--- a/package/base-files/files/lib/functions/ipv4.sh
+++ b/package/base-files/files/lib/functions/ipv4.sh
@@ -1,5 +1,7 @@
 uint_max=4294967295
 
+# check that $1 is only base 10 digits, and that it doesn't
+# exceed 2^32-1
 assert_uint32() {
     local __n="$1"
 
@@ -21,6 +23,7 @@ assert_uint32() {
     return 0
 }
 
+# return a count of the number of bits set in $1
 bitcount() {
     local __var="$1" __c="$2"
     assert_uint32 "$__c" || return 1
@@ -35,6 +38,8 @@ bitcount() {
 }
 
 # tedious but portable with busybox's limited shell
+# we check each octet to be in the range of 0..255,
+# and also make sure there's no extaneous characters.
 str2ip() {
     local __var="$1" __ip="$2" __n __val=0
 
@@ -131,6 +136,7 @@ str2ip() {
     return 0
 }
 
+# convert back from an integer to dotted-quad.
 ip2str() {
     local __var="$1" __n="$2"
     assert_uint32 "$__n" || return 1

--- a/package/base-files/files/lib/functions/ipv4.sh
+++ b/package/base-files/files/lib/functions/ipv4.sh
@@ -1,5 +1,23 @@
 uint_max=4294967295
 
+d_10_0_0_0=167772160
+d_10_255_255_255=184549375
+
+d_172_16_0_0=2886729728
+d_172_31_255_255=2887778303
+
+d_192_168_0_0=3232235520
+d_192_168_255_255=3232301055
+
+d_169_254_0_0=2851995648
+d_169_254_255_255=2852061183
+
+d_127_0_0_0=2130706432
+d_127_255_255_255=2147483647
+
+d_224_0_0_0=3758096384
+d_239_255_255_255=4026531839
+
 # check that $1 is only base 10 digits, and that it doesn't
 # exceed 2^32-1
 assert_uint32() {
@@ -194,5 +212,57 @@ netmask2prefix() {
     bitcount __bits "$__n"		# already checked
 
     export -- "$__var=$__bits"
+}
+
+# check the argument as being an rfc-1918 address
+is_rfc1918() {
+    local __var="$1" __x="$2" __val=0
+    assert_uint32 "$__x" || return 1
+
+    if [ $d_10_0_0_0 -le $__x ] && [ $__x -le $d_10_255_255_255 ]; then
+	__val=1
+    elif [ $d_172_16_0_0 -le $__x ] && [ $__x -le $d_172_31_255_255 ]; then
+	__val=1
+    elif [ $d_192_168_0_0 -le $__x ] && [ $__x -le $d_192_168_255_255 ]; then
+	__val=1
+    fi
+
+    export -- "$__var=$__val"
+}
+
+# check the argument as being an rfc-3927 address
+is_rfc3927() {
+    local __var="$1" __x="$2" __val=0
+    assert_uint32 "$__x" || return 1
+
+    if [ $d_169_254_0_0 -le $__x ] && [ $__x -le $d_169_254_255_255 ]; then
+	__val=1
+    fi
+
+    export -- "$__var=$__val"
+}
+
+# check the argument as being an rfc-1122 loopback address
+is_loopback() {
+    local __var="$1" __x="$2" __val=0
+    assert_uint32 "$__x" || return 1
+
+    if [ $d_127_0_0_0 -le $__x ] && [ $__x -le $d_127_255_255_255 ]; then
+	__val=1
+    fi
+
+    export -- "$__var=$__val"
+}
+
+# check the argument as being a multicast address
+is_multicast() {
+    local __var="$1" __x="$2" __val=0
+    assert_uint32 "$__x" || return 1
+
+    if [ $d_224_0_0_0 -le $__x ] && [ $__x -le $d_239_255_255_255 ]; then
+	__val=1
+    fi
+
+    export -- "$__var=$__val"
 }
 

--- a/package/base-files/files/lib/functions/ipv4.sh
+++ b/package/base-files/files/lib/functions/ipv4.sh
@@ -1,0 +1,140 @@
+uint_max=4294967295
+
+assert_uint32() {
+    local __n="$1"
+
+    if [ -z "$__n" -o -n "${__n//[0-9]/}" ]; then
+	printf "Not a decimal integer (%s)\n" "$__n ">&2
+	return 1
+    fi
+
+    if [ "$__n" -gt $uint_max ]; then
+	printf "Out of range (%s)\n" "$__n" >&2
+	return 1
+    fi
+
+    if [ "$((__n + 0))" != "$__n" ]; then
+	printf "Not normalized notation (%s)\n" "$__n" >&2
+	return 1
+    fi
+
+    return 0
+}
+
+bitcount() {
+    local __var="$1" __c="$2"
+    assert_uint32 "$__c" || return 1
+
+    __c=$((((__c >> 1) & 0x55555555) + (__c & 0x55555555)))
+    __c=$((((__c >> 2) & 0x33333333) + (__c & 0x33333333)))
+    __c=$((((__c >> 4) & 0x0f0f0f0f) + (__c & 0x0f0f0f0f)))
+    __c=$((((__c >> 8) & 0x00ff00ff) + (__c & 0x00ff00ff)))
+    __c=$((((__c >> 16) & 0x0000ffff) + (__c & 0x0000ffff)))
+
+    export -- "$__var=$__c"
+}
+
+# tedious but portable with busybox's limited shell
+str2ip() {
+    local __var="$1" __ip="$2" __n __val=0
+
+    case "$__ip" in
+    [0-9].*)
+	__n="${__ip:0:1}"
+	__ip="${__ip:2}"
+	;;
+    [1-9][0-9].*)
+	__n="${__ip:0:2}"
+	__ip="${__ip:3}"
+	;;
+    1[0-9][0-9].*|2[0-4][0-9].*|25[0-5].*)
+	__n="${__ip:0:3}"
+	__ip="${__ip:4}"
+	;;
+    *)
+	printf "Not a dotted quad (%s)\n" "$2" >&2
+	return 1
+	;;
+    esac
+
+    __val=$((__n << 24))
+
+    case "$__ip" in
+    [0-9].*)
+	__n="${__ip:0:1}"
+	__ip="${__ip:2}"
+	;;
+    [1-9][0-9].*)
+	__n="${__ip:0:2}"
+	__ip="${__ip:3}"
+	;;
+    1[0-9][0-9].*|2[0-4][0-9].*|25[0-5].*)
+	__n="${__ip:0:3}"
+	__ip="${__ip:4}"
+	;;
+    *)
+	printf "Not a dotted quad (%s)\n" "$2" >&2
+	return 1
+	;;
+    esac
+
+    __val=$((__val + (__n << 16)))
+
+    case "$__ip" in
+    [0-9].*)
+	__n="${__ip:0:1}"
+	__ip="${__ip:2}"
+	;;
+    [1-9][0-9].*)
+	__n="${__ip:0:2}"
+	__ip="${__ip:3}"
+	;;
+    1[0-9][0-9].*|2[0-4][0-9].*|25[0-5].*)
+	__n="${__ip:0:3}"
+	__ip="${__ip:4}"
+	;;
+    *)
+	printf "Not a dotted quad (%s)\n" "$2" >&2
+	return 1
+	;;
+    esac
+
+    __val=$((__val + (__n << 8)))
+
+    case "$__ip" in
+    [0-9])
+	__n="${__ip:0:1}"
+	__ip="${__ip:1}"
+	;;
+    [1-9][0-9])
+	__n="${__ip:0:2}"
+	__ip="${__ip:2}"
+	;;
+    1[0-9][0-9]|2[0-4][0-9]|25[0-5])
+	__n="${__ip:0:3}"
+	__ip="${__ip:3}"
+	;;
+    *)
+	printf "Not a dotted quad (%s)\n" "$2" >&2
+	return 1
+	;;
+    esac
+
+    __val=$((__val + __n))
+
+    if [ -n "$__ip" ]; then
+	printf "Not a dotted quad (%s)\n" "$2" >&2
+	return 1
+    fi
+
+    export -- "$__var=$__val"
+    return 0
+}
+
+ip2str() {
+    local __var="$1" __n="$2"
+    assert_uint32 "$__n" || return 1
+
+    export -- "$__var=$((__n >> 24)).$(((__n >> 16) & 255)).$(((__n >> 8) & 255)).$((__n & 255))"
+}
+


### PR DESCRIPTION
This is a rewrite of ipcalc.sh into shell because there are init.d wrappers that need to be able to invoke some of the internal functions used in ipcalc.sh as library functions.

We also add decimal output of addresses and net masks so that they may easily be used in computation for range checking, etc. in init.d wrappers.

It's a pretty direct rewrite of the original awk code, plus input validation in ip2int(), and some factoring of common terms (we use the complement of the netmask much more often than we use the netmask itself, for instance).

cc: @yogo1212 @Ansuel 