### PR TITLE
dnsmasq: don't source functions.sh twice

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1,8 +1,6 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2007-2012 OpenWrt.org
 
-. /lib/functions.sh
-
 START=19
 
 USE_PROCD=1


### PR DESCRIPTION
It's already pulled in from /etc/rc.common.

Fixes #13758.

cc: @dave14305 @yogo1212 
