### PR TITLE
ramips: add support for Mofi 5500

### DIFF
--- a/target/linux/ramips/dts/mt7621_mofinetwork_mofi5500-5gxelte.dts
+++ b/target/linux/ramips/dts/mt7621_mofinetwork_mofi5500-5gxelte.dts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "mofinetwork,mofi5500-5gxelte", "mediatek,mt7621-soc";
+	model = "MoFi Network MOFI5500-5GXeLTE";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			label = "green:internet";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		module_1 {
+			label = "blue:module_1";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		module_2 {
+			label = "blue:module_2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys-polled";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			reg = <3>;
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			reg = <4>;
+			label = "wan";
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&i2c {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi0: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi1: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "uboot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "ubootenv-tools";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1ab0000>;
+			};
+
+			partition@1b00000 {
+				label = "Recovery";
+				reg = <0x1b00000 0x500000>;
+			};
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1679,6 +1679,19 @@ define Device/mikrotik_routerboard-m33g
 endef
 TARGET_DEVICES += mikrotik_routerboard-m33g
 
+# Do not remove SUPPORTED_DEVICES! The customized Mofi version of OpenWRT (stock firmware) expects
+# to see mofi5500 as the device name. The stock firmware does not allow for forcing an installation.
+# Without this line, users cannot upload the new firmware through the stock Mofi firmware.
+define Device/mofinetwork_mofi5500-5gxelte
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 27656k
+  DEVICE_VENDOR := MoFi Network
+  DEVICE_MODEL := MOFI5500-5GXeLTE
+  DEVICE_PACKAGES := kmod-usb3 kmod-usb2 kmod-sdhci-mt7620
+  SUPPORTED_DEVICES += mofi5500
+endef
+TARGET_DEVICES += mofinetwork_mofi5500-5gxelte
+
 define Device/mqmaker_witi
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)


### PR DESCRIPTION
Installation Instructions
-------------------------

1. Update Mofi 5500 to at least stock firmware version 4.8.6. (Available on the Mofi website.) Previous versions are untested in the upgrade process.
2. Log into the LuCI web interface, usually at 192.168.10.1 and visit the "System->Backup/Flash Firmware" page.
3. Upload and flash the firmware as usual.

Hardware information:
---------------------

- MT7621AT SoC
- 4 Gigabit RJ45 PoE ports
- 2 USB ports (1xUSB2 and 1xUSB3 - GL3510 chip)
- RJ45 RS232 port on front panel (Max3232 chip)
- 32 Megabyte NOR Flash
- 512 Megabyte DDR3 SDRAM
- 2 MT7615N wifi chips (2.4GHz and 5GHz)