### PR TITLE
base-files: use cidr for config_generate

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -3,6 +3,7 @@
 CFG=/etc/board.json
 
 . /usr/share/libubox/jshn.sh
+. /lib/functions/ipv4.sh
 
 [ -s $CFG ] || /bin/board_detect || exit 1
 [ -s /etc/config/network -a -s /etc/config/system ] && exit 0
@@ -42,8 +43,7 @@ generate_static_network() {
 		set network.loopback='interface'
 		set network.loopback.device='lo'
 		set network.loopback.proto='static'
-		set network.loopback.ipaddr='127.0.0.1'
-		set network.loopback.netmask='255.0.0.0'
+		add_list network.loopback.ipaddr='127.0.0.1/8'
 	EOF
 		[ -e /proc/sys/net/ipv6 ] && {
 			uci -q batch <<-EOF
@@ -160,18 +160,19 @@ generate_network() {
 
 	case "$protocol" in
 		static)
-			local ipad
+			local ipad netm prefix
 			case "$1" in
 				lan) ipad=${ipaddr:-"192.168.1.1"} ;;
 				*) ipad=${ipaddr:-"192.168.$((addr_offset++)).1"} ;;
 			esac
 
 			netm=${netmask:-"255.255.255.0"}
+			str2ip netm "$netm"
+			netmask2prefix prefix "$netm"
 
 			uci -q batch <<-EOF
 				set network.$1.proto='static'
-				set network.$1.ipaddr='$ipad'
-				set network.$1.netmask='$netm'
+				add_list network.$1.ipaddr='$ipad/$prefix'
 			EOF
 			[ -e /proc/sys/net/ipv6 ] && uci set network.$1.ip6assign='60'
 		;;


### PR DESCRIPTION
Generate network configuration replacing netmask with CIDR.

Depends on:
https://github.com/openwrt/openwrt/pull/13765

Using CIDR provides the following advantages:
* Consolidate notation for IPv4 and IPv6 addresses.
* Consolidate notation for IP addresses and routing targets.
* Simplify network configuration and troubleshooting.
* Follow the transition from net-tools to iproute2.

Resulting configuration example:
```
config interface 'loopback'
	option device 'lo'
	option proto 'static'
	list ipaddr '127.0.0.1/8'

config interface 'lan'
	option device 'br-lan'
	option proto 'static'
	list ipaddr '192.168.1.1/24'
```