### PR TITLE
generic: refresh AMD PHY patch

### DIFF
--- a/target/linux/generic/backport-6.1/832-v6.7-net-phy-amd-Support-the-Altima-AMI101L.patch
+++ b/target/linux/generic/backport-6.1/832-v6.7-net-phy-amd-Support-the-Altima-AMI101L.patch
@@ -16,7 +16,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
 
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -146,9 +146,9 @@ endif # RTL8366_SMI
+@@ -72,9 +72,9 @@ config SFP
  comment "MII PHY device drivers"
  
  config AMD_PHY


### PR DESCRIPTION
CI is currently failling due to the AMD PHY patch not being refreshed, so lets refresh it.

Fixes: 33a6189fde56 ("generic: Support Altima AMI101L PHY")
