### PR TITLE
ramips: mt7621: Add DNA Valokuitu Plus EX400

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -146,6 +146,10 @@ xiaomi,mi-router-cr6608|\
 xiaomi,mi-router-cr6609)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x20000"
 	;;
+dna,valokuitu-plus-ex400)
+	ubootenv_add_uci_config "/dev/ubi0_0" "0x0" "0x1f000" "0x1f000" "1"
+	ubootenv_add_uci_config "/dev/ubi0_1" "0x0" "0x1f000" "0x1f000" "1"
+	;;
 netgear,wax214v2)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	ubootenv_add_uci_sys_config "/dev/mtd1" "0x20000" "0x8000" "0x20000"

--- a/target/linux/ramips/dts/mt7621_dna_valokuitu-plus-ex400.dts
+++ b/target/linux/ramips/dts/mt7621_dna_valokuitu-plus-ex400.dts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "dna,valokuitu-plus-ex400", "mediatek,mt7621-soc";
+	model = "DNA Valokuitu Plus EX400";
+
+	aliases {
+		ethernet0 = &gmac0;
+		label-mac-device = &gmac0;
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_update_green;
+	};
+
+	chosen {
+		bootargs-override = "console=ttyS0,115200 rootfstype=squashfs,jffs2";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: led-1 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_update_green: led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_PROGRAMMING;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			reg = <0x00 0x100000>;
+			label = "uboot";
+			read-only;
+		};
+
+		partition@100000 {
+			reg = <0x100000 0xff00000>;
+			label = "ubi";
+		};
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+};
+
+&i2c {
+	status = "okay";
+};
+
+&ethphy0 {
+	/delete-property/ interrupts;
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -67,6 +67,7 @@ ramips_setup_interfaces()
 		ucidef_set_interface_lan "lan"
 		;;
 	asiarf,ap7621-001|\
+	dna,valokuitu-plus-ex400|\
 	humax,e10|\
 	keenetic,kn-3510|\
 	openfi,5pro|\
@@ -241,6 +242,9 @@ ramips_setup_macs()
 	dlink,dir-860l-b1)
 		lan_mac=$(mtd_get_mac_ascii factory lanmac)
 		wan_mac=$(mtd_get_mac_ascii factory wanmac)
+		;;
+	dna,valokuitu-plus-ex400)
+		wan_mac=$(macaddr_add "$(get_mac_label)" 1)
 		;;
 	edimax,ra21s|\
 	edimax,rg21s)

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -32,6 +32,10 @@ boot() {
 	samknows,whitebox-v8)
 		fw_setenv bootcount 0
 		;;
+	dna,valokuitu-plus-ex400)
+		fw_setenv boot_cnt_primary 0
+		fw_setenv boot_cnt_alt 0
+		;;
 	zyxel,lte3301-plus)
 		[ $(printf %d $(fw_printenv -n DebugFlag)) -gt 0 ] || fw_setenv DebugFlag 1
 		[ $(printf %d $(fw_printenv -n Image1Stable)) -gt 0 ] || fw_setenv Image1Stable 1

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/dna.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/dna.sh
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2023 Mauri Sandberg
+#
+
+# The vendor UBI is split in volumes 0-3. Volumes 0 and 1 contain U-Boot
+# environments env1 and env2, respectively. The vendor root file systems
+# are in volumes 2 (rootfs_0) and 3 (rootfs_1). Drop the two roots and
+# explicitly use rootfs_0 as a boot partition that contains the dtb and the
+# OpenWrt kernel. This is because the vendor U-Boot expects to find them there.
+# Then continue upgrade with the default method - a SquashFS rootfs will be
+# installed and the rest of UBI will be used as an overlay.
+
+# The 'kernel' inside the sysupgrage.tar is an UBIFS image that contains
+# /boot/dtb and /boot/kernel. The 'root' is an OpenWrt SquashFS root
+
+. /lib/functions.sh
+. /lib/upgrade/nand.sh
+
+dna_do_upgrade () {
+	tar -xaf $1
+
+	# get the size of the new bootfs
+	local _bootfs_size=$(wc -c < ./sysupgrade-dna_valokuitu-plus-ex400/kernel)
+	[ -n "$_bootfs_size" -a "$_bootfs_size" -gt "0" ] || nand_do_upgrade_failed
+
+	# remove existing rootfses and recreate rootfs_0
+	ubirmvol /dev/ubi0 --name=rootfs_0 > /dev/null 2>&1
+	ubirmvol /dev/ubi0 --name=rootfs_1 > /dev/null 2>&1
+	ubirmvol /dev/ubi0 --name=rootfs > /dev/null 2>&1
+	ubirmvol /dev/ubi0 --name=rootfs_data > /dev/null 2>&1
+	ubimkvol /dev/ubi0 --type=static --size=${_bootfs_size} --name=rootfs_0
+
+	# update the rootfs_0 contents
+	local _kern_ubivol=$( nand_find_volume "ubi0" "rootfs_0" )
+	ubiupdatevol /dev/${_kern_ubivol} sysupgrade-dna_valokuitu-plus-ex400/kernel
+
+	fw_setenv root_vol rootfs_0
+	fw_setenv boot_cnt_primary 0
+	fw_setenv boot_cnt_alt 0
+
+	# proceed to upgrade the default way
+	CI_KERNPART=none
+	nand_do_upgrade "$1"
+}

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -150,6 +150,9 @@ platform_do_upgrade() {
 	buffalo,wsr-2533dhpls)
 		buffalo_do_upgrade "$1"
 		;;
+	dna,valokuitu-plus-ex400)
+		dna_do_upgrade "$1"
+		;;
 	elecom,wrc-x1800gs)
 		[ "$(fw_printenv -n bootmenu_delay)" != "0" ] || \
 			fw_setenv bootmenu_delay 3


### PR DESCRIPTION
Add DNA Valokuitu  Plus EX400.

Specifications:
    - Device: DNA Valokuitu Plus EX400
    - SoC: MT7621A
    - Flash: 256MB NAND
    - RAM:  256MB
    - Ethernet: Built-in, 2 x 1GbE
    - Wifi: MT7603 2.4 GHz, MT7615 5 GHz (4x internal antennas)
    - USB: 1x 3.0
    - LED: 1x green/red, 1x green
    - Buttons: Reset

Known issues:
     - MACs for wifi are stored in currently unknown place but it's obtained
       allright

```
root@DNA:/tmp# mount
ubi0:rootfs_0 on /rom type ubifs (rw,noatime)
devtmpfs on /dev type devtmpfs (rw,relatime,size=127036k,nr_inodes=31759,mode=755)
proc on /proc type proc (rw,nosuid,nodev,noexec,noatime)
sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,noatime)
devpts on /dev/pts type devpts (rw,nosuid,noexec,noatime,mode=600)
tmpfs on /tmp type tmpfs (rw,nosuid,nodev,noatime)
overlayfs:/overlay on / type overlay (rw,noatime,lowerdir=/,upperdir=/overlay,workdir=/lib/overlay.tmp)
debugfs on /sys/kernel/debug type debugfs (rw,noatime)

root@DNA:/tmp# cat /proc/mtd
dev:    size   erasesize  name
mtd0: 00100000 00020000 "uboot"
mtd1: 0ff00000 00020000 "ubi"

root@DNA:/tmp# ubinfo (filtered)
Volume ID:   0 (on ubi0)
Size:        1 LEBs (126976 bytes, 124.0 KiB)
Name:        env1
-----------------------------------
Volume ID:   1 (on ubi0)
Size:        1 LEBs (126976 bytes, 124.0 KiB)
Name:        env2
-----------------------------------
Volume ID:   2 (on ubi0)
Size:        980 LEBs (124436480 bytes, 118.7 MiB)
Name:        rootfs_0
-----------------------------------
Volume ID:   3 (on ubi0)
Size:        980 LEBs (124436480 bytes, 118.7 MiB)
Name:        rootfs_1
```