### PR TITLE
uqmi: various bugfixes and inactive SIM workaround

### DIFF
--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -247,7 +247,6 @@ proto_qmi_setup() {
 		fi
 
 		proto_notify_error "$interface" NETWORK_REGISTRATION_FAILED
-		proto_block_restart "$interface"
 		return 1
 	done
 

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -253,7 +253,7 @@ proto_qmi_setup() {
 	uqmi -s -d "$device" --network-register > /dev/null 2>&1
 
 	echo "Waiting for network registration"
-	sleep 1
+	sleep 5
 	local registration_timeout=0
 	local registration_state=""
 	while true; do

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -252,6 +252,13 @@ proto_qmi_setup() {
 
 	uqmi -s -d "$device" --network-register > /dev/null 2>&1
 
+	[ -n "$modes" ] && {
+		uqmi -s -d "$device" --set-network-modes "$modes" > /dev/null 2>&1
+		sleep 3
+		# Scan network to not rely on registration-timeout after RAT change
+		uqmi -s -d "$device" --network-scan > /dev/null 2>&1
+	}
+
 	echo "Waiting for network registration"
 	sleep 5
 	local registration_timeout=0
@@ -281,7 +288,6 @@ proto_qmi_setup() {
 		return 1
 	done
 
-	[ -n "$modes" ] && uqmi -s -d "$device" --set-network-modes "$modes" > /dev/null 2>&1
 
 	echo "Starting network $interface"
 


### PR DESCRIPTION
This PR fixes various bugs in uqmi regarding network / technology selection.

It also introduces a new recovery mechanism for SIM cards which are rejected by the network.
This can happen when the carrier tries to steer the UE to attach to a preferred roaming network.