### PR TITLE
uboot-mediatek: Sync phy-mode for Xiaomi Redmi Router AX6000

### DIFF
--- a/package/boot/uboot-mediatek/patches/431-add-xiaomi_redmi-ax6000.patch
+++ b/package/boot/uboot-mediatek/patches/431-add-xiaomi_redmi-ax6000.patch
@@ -239,12 +239,12 @@
 +&eth {
 +	status = "okay";
 +	mediatek,gmac-id = <0>;
-+	phy-mode = "sgmii";
++	phy-mode = "2500base-x";
 +	mediatek,switch = "mt7531";
 +	reset-gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
 +
 +	fixed-link {
-+		speed = <1000>;
++		speed = <2500>;
 +		full-duplex;
 +	};
 +};


### PR DESCRIPTION
Commit 572ea6807053 ("uboot-mediatek: add patches for MT7988 and builds for RFB") renamed HSGMII to 2500basex, but forgot to update the dts of Redmi Router AX6000, makes the network unusable. This patch makes the network usable again.