### PR TITLE
build: cache kernel module package compiling

### DIFF
--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -9,10 +9,6 @@ endif
 
 INITRAMFS_EXTRA_FILES ?= $(GENERIC_PLATFORM_DIR)/image/initramfs-base-files.txt
 
-ifneq (,$(KERNEL_CC))
-  KERNEL_MAKEOPTS += CC="$(KERNEL_CC)"
-endif
-
 export HOST_EXTRACFLAGS=-I$(STAGING_DIR_HOST)/include
 
 # defined in quilt.mk

--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -119,6 +119,10 @@ KERNEL_MAKE_FLAGS = \
 	cmd_syscalls= \
 	$(if $(__package_mk),KBUILD_EXTRA_SYMBOLS="$(wildcard $(PKG_SYMVERS_DIR)/*.symvers)")
 
+ifneq (,$(KERNEL_CC))
+  KERNEL_MAKE_FLAGS += CC="$(KERNEL_CC)"
+endif
+
 KERNEL_NOSTDINC_FLAGS = \
 	-nostdinc $(if $(DUMP),, -isystem $(shell $(TARGET_CC) -print-file-name=include))
 

--- a/package/kernel/mac80211/patches/build/004-fix-kconf-compiling.patch
+++ b/package/kernel/mac80211/patches/build/004-fix-kconf-compiling.patch
@@ -1,0 +1,47 @@
+--- a/Makefile.real
++++ b/Makefile.real
+@@ -6,6 +6,18 @@ else
+ export BACKPORTS_GIT_TRACKER_DEF=
+ endif
+ 
++ifneq ($(LLVM),)
++ifneq ($(filter %/,$(LLVM)),)
++LLVM_PREFIX := $(LLVM)
++else ifneq ($(filter -%,$(LLVM)),)
++LLVM_SUFFIX := $(LLVM)
++endif
++
++HOSTCC	= $(LLVM_PREFIX)clang$(LLVM_SUFFIX)
++else
++HOSTCC	= gcc
++endif
++
+ # disable built-in rules for this file
+ .SUFFIXES:
+ 
+@@ -24,21 +36,21 @@ listnewconfig oldaskconfig oldconfig \
+ silentoldconfig olddefconfig oldnoconfig \
+ allnoconfig allyesconfig allmodconfig \
+ alldefconfig randconfig:
+-	@$(MAKE) -C kconf conf
++	@$(MAKE) -C kconf CC=$(HOSTCC) conf
+ 	@./kconf/conf --$@ Kconfig
+ 
+ .PHONY: usedefconfig
+ usedefconfig:
+-	@$(MAKE) -C kconf conf
++	@$(MAKE) -C kconf CC=$(HOSTCC) conf
+ 	@./kconf/conf --defconfig=defconfig Kconfig
+ 
+ .PHONY: savedefconfig
+ savedefconfig:
+-	@$(MAKE) -C kconf conf
++	@$(MAKE) -C kconf CC=$(HOSTCC) conf
+ 	@./kconf/conf --savedefconfig=defconfig Kconfig
+ 
+ defconfig-%::
+-	@$(MAKE) -C kconf conf
++	@$(MAKE) -C kconf CC=$(HOSTCC) conf
+ 	@./kconf/conf --defconfig=defconfigs/$(@:defconfig-%=%) Kconfig
+ 
+ .config:


### PR DESCRIPTION
Kernel module packages compiling is not cached (e.g. mac80211)
even with CONFIG_CCACHE on.

CC should be set to KERNEL_CC in KERNEL_MAKE_FLAGS at kernel.mk
to allow kernel module packages using ccache.

Signed-off-by: Zeyu Dong <dzy201415@gmail.com>
