### PR TITLE
mediatek: MERCUSYS MR90X v1: remove deprecated led "label" properties

### DIFF
--- a/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1.dts
+++ b/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1.dts
@@ -3,6 +3,7 @@
 /dts-v1/;
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
 
 #include "mt7986b.dtsi"
 
@@ -41,34 +42,43 @@
 		compatible = "gpio-leds";
 
 	 	led-0 {
-			label = "green:lan2";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
 			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
 		};
 
 		led-1 {
-			label = "green:lan1";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
 			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
 		};
 
 		led-2 {
-			label = "green:lan0";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <0>;
 			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
 		};
 
 		led-3 {
-			label = "green:wan";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
 			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
 		};
 
 		led-4 {
-			label = "orange:status";
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_STATUS;
 			gpios = <&pio 16 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
 		};
 
 		led_status_green: led-5 {
-			label = "green:status";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
 			gpios = <&pio 17 GPIO_ACTIVE_HIGH>;
-			panic-indicator;
 		};
 	};
 };

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -16,9 +16,9 @@ cudy,wr3000-v1)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
 	;;
 mercusys,mr90x-v1)
-	ucidef_set_led_netdev "lan0" "lan0" "green:lan0" "lan0" "link tx rx"
-	ucidef_set_led_netdev "lan1" "lan2" "green:lan1" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan2" "lan2" "green:lan2" "lan2" "link tx rx"
+	ucidef_set_led_netdev "lan-0" "lan-0" "green:lan-0" "lan0" "link tx rx"
+	ucidef_set_led_netdev "lan-1" "lan-1" "green:lan-1" "lan1" "link tx rx"
+	ucidef_set_led_netdev "lan-2" "lan-2" "green:lan-2" "lan2" "link tx rx"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
 	;;
 netgear,wax220)


### PR DESCRIPTION
This commit:
1. Removes deprecated `label` property from the dts leds subnnodes (except the `led_status_green` led, which is referenced in `aliases` node);
2. Adds `color`, `function`, `function-enumerator` properties to the subnodes in accordance with kernel documentation and examples;
3. Updates `01_leds` script.

Link: https://www.kernel.org/doc/Documentation/devicetree/bindings/leds/common.yaml
Link: https://www.kernel.org/doc/Documentation/devicetree/bindings/leds/leds-gpio.yaml

