### PR TITLE
treewide: fix MERCUSYS brand spelling

### DIFF
--- a/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1.dts
+++ b/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1.dts
@@ -8,7 +8,7 @@
 
 / {
 	compatible = "mercusys,mr90x-v1", "mediatek,mt7986b";
-	model = "Mercusys MR90X v1";
+	model = "MERCUSYS MR90X v1";
 
 	aliases {
 		serial0 = &uart0;

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -488,7 +488,7 @@ endef
 TARGET_DEVICES += mediatek_mt7988a-rfb
 
 define Device/mercusys_mr90x-v1
-  DEVICE_VENDOR := Mercusys
+  DEVICE_VENDOR := MERCUSYS
   DEVICE_MODEL := MR90X v1
   DEVICE_DTS := mt7986b-mercusys-mr90x-v1
   DEVICE_DTS_DIR := ../dts

--- a/target/linux/ramips/dts/mt7621_mercusys_mr70x-v1.dts
+++ b/target/linux/ramips/dts/mt7621_mercusys_mr70x-v1.dts
@@ -7,7 +7,7 @@
 
 / {
 	compatible = "mercusys,mr70x-v1", "mediatek,mt7621-soc";
-	model = "Mercusys MR70X v1";
+	model = "MERCUSYS MR70X v1";
 
 	aliases {
 		led-boot = &led_power_green;

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1619,7 +1619,7 @@ TARGET_DEVICES += mediatek_mt7621-eval-board
 define Device/mercusys_mr70x-v1
   $(Device/dsa-migration)
   $(Device/tplink-safeloader)
-  DEVICE_VENDOR := Mercusys
+  DEVICE_VENDOR := MERCUSYS
   DEVICE_MODEL := MR70X
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools


### PR DESCRIPTION
This commit fixes `MERCUSYS` brand spelling. The brand name contains only capital letters.

Link: https://www.mercusys.com/
Link: https://github.com/torvalds/linux/blob/master/drivers/net/wireless/realtek/rtl8xxxu/rtl8xxxu_core.c#L7779
