### PR TITLE
devcontainer: Add development environment for gihub codespace

### DIFF
--- a/.devcontainer/ci-env/devcontainer.json
+++ b/.devcontainer/ci-env/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "CI build container",
+  "image": "ghcr.io/openwrt/buildbot/buildworker-v3.8.0:v9",
+  "features": {
+  },
+  "remoteUser": "buildbot",
+  "customizations": {
+    "vscode": {
+      "extensions": ["ms-vscode.cpptools", "plorefice.devicetree"]
+    }
+  }
+}


### PR DESCRIPTION
This adds a configuration for github codespace using our buildbot container. This allows users to start VS code in the browser using the buildbot build container.

Deep link to create a code space using this CI container: https://github.com/codespaces/new?hide_repo_select=true&ref=codespace&repo=482385820&skip_quickstart=true&machine=basicLinux32gb&geo=EuropeWest&devcontainer_path=.devcontainer%2Fci-env%2Fdevcontainer.json