### PR TITLE
ramips: enable wireless LEDs activity blinking for TP-Link EC330-G5u v1

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_ec330-g5u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_ec330-g5u-v1.dts
@@ -73,7 +73,7 @@
 			function = LED_FUNCTION_WLAN;
 			function-enumerator = <0>;
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1radio";
+			linux,default-trigger = "phy1tpt";
 		};
 
 		led-6 {
@@ -82,7 +82,7 @@
 			function = LED_FUNCTION_WLAN;
 			function-enumerator = <1>;
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0radio";
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_power: led-7 {


### PR DESCRIPTION
This commit enables wireless LEDs activity blinking for TP-Link EC330-G5u v1 router.
