### PR TITLE
build: replace true with a custom noop script

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -238,4 +238,4 @@ prereq: $(STAGING_DIR_HOST)/bin/mkhash $(STAGING_DIR_HOST)/bin/xxd
 
 # Install ldconfig stub
 $(eval $(call TestHostCommand,ldconfig-stub,Failed to install stub, \
-	$(LN) $(firstword $(wildcard /bin/true /usr/bin/true)) $(STAGING_DIR_HOST)/bin/ldconfig))
+	$(LN) $(SCRIPT_DIR)/noop.sh $(STAGING_DIR_HOST)/bin/ldconfig))

--- a/scripts/noop.sh
+++ b/scripts/noop.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+# This script does nothing, intentionally.


### PR DESCRIPTION
Fixes building on NixOS, which has `true` in /run/current-system/sw/bin.
