### PR TITLE
base-files: support parse DT LED color and function

### DIFF
--- a/target/linux/generic/backport-5.15/831-v6.1-dt-bindings-leds-Expand-LED_COLOR_ID-definitions.patch
+++ b/target/linux/generic/backport-5.15/831-v6.1-dt-bindings-leds-Expand-LED_COLOR_ID-definitions.patch
@@ -1,0 +1,47 @@
+From 472d7b9e8141729ec1e3fe6821b88563f6379533 Mon Sep 17 00:00:00 2001
+From: Olliver Schinagl <oliver@schinagl.nl>
+Date: Tue, 30 Aug 2022 15:46:13 +0200
+Subject: [PATCH] dt-bindings: leds: Expand LED_COLOR_ID definitions
+
+In commit 853a78a7d6c7 (dt-bindings: leds: Add LED_COLOR_ID definitions,
+Sun Jun 9 20:19:04 2019 +0200) the most basic color definitions where
+added. However, there's a little more very common LED colors.
+
+While the documentation states 'add what is missing', engineers tend to
+be lazy and will just use what currently exists. So this patch will take
+(a) list from online retailers [0], [1], [2] and use the common LED colors from
+there, this being reasonable as this is what is currently available to purchase.
+
+Note, that LIME seems to be the modern take to 'Yellow-green' or
+'Yellowish-green' from some older datasheets.
+
+[0]: https://www.digikey.com/en/products/filter/led-lighting-color/125
+[1]: https://eu.mouser.com/c/optoelectronics/led-lighting/led-emitters/standard-leds-smd
+[2]: https://nl.farnell.com/en-NL/c/optoelectronics-displays/led-products/standard-single-colour-leds-under-75ma
+
+Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>
+Acked-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Acked-by: Alexander Dahl <ada@thorsis.com>
+Acked-by: Jacek Anaszewski <jacek.anaszewski@gmail.com>
+Link: https://lore.kernel.org/r/20220830134613.1564059-1-oliver@schinagl.nl
+Signed-off-by: Rob Herring <robh@kernel.org>
+---
+ include/dt-bindings/leds/common.h | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+--- a/include/dt-bindings/leds/common.h
++++ b/include/dt-bindings/leds/common.h
+@@ -33,7 +33,12 @@
+ #define LED_COLOR_ID_MULTI	8	/* For multicolor LEDs */
+ #define LED_COLOR_ID_RGB	9	/* For multicolor LEDs that can do arbitrary color,
+ 					   so this would include RGBW and similar */
+-#define LED_COLOR_ID_MAX	10
++#define LED_COLOR_ID_PURPLE	10
++#define LED_COLOR_ID_ORANGE	11
++#define LED_COLOR_ID_PINK	12
++#define LED_COLOR_ID_CYAN	13
++#define LED_COLOR_ID_LIME	14
++#define LED_COLOR_ID_MAX	15
+ 
+ /* Standard LED functions */
+ /* Keyboard LEDs, usually it would be input4::capslock etc. */

--- a/target/linux/generic/backport-5.15/833-v6.8-leds-core-Add-more-colors-from-DT-bindings-to-led_co.patch.patch
+++ b/target/linux/generic/backport-5.15/833-v6.8-leds-core-Add-more-colors-from-DT-bindings-to-led_co.patch.patch
@@ -1,0 +1,29 @@
+From a067943129b4ec6b835e02cfd5fbef01093c1471 Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megi@xff.cz>
+Date: Sun, 8 Oct 2023 16:40:13 +0200
+Subject: [PATCH] leds: core: Add more colors from DT bindings to led_colors
+
+The colors are already part of DT bindings. Make sure the kernel is
+able to convert them to strings.
+
+Signed-off-by: Ondrej Jirman <megi@xff.cz>
+Link: https://lore.kernel.org/r/20231008144014.1180334-1-megi@xff.cz
+Signed-off-by: Lee Jones <lee@kernel.org>
+---
+ drivers/leds/led-core.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/drivers/leds/led-core.c
++++ b/drivers/leds/led-core.c
+@@ -36,6 +36,11 @@ const char * const led_colors[LED_COLOR_
+ 	[LED_COLOR_ID_IR] = "ir",
+ 	[LED_COLOR_ID_MULTI] = "multicolor",
+ 	[LED_COLOR_ID_RGB] = "rgb",
++	[LED_COLOR_ID_PURPLE] = "purple",
++	[LED_COLOR_ID_ORANGE] = "orange",
++	[LED_COLOR_ID_PINK] = "pink",
++	[LED_COLOR_ID_CYAN] = "cyan",
++	[LED_COLOR_ID_LIME] = "lime",
+ };
+ EXPORT_SYMBOL_GPL(led_colors);
+ 

--- a/target/linux/generic/backport-6.1/833-v6.8-leds-core-Add-more-colors-from-DT-bindings-to-led_co.patch.patch
+++ b/target/linux/generic/backport-6.1/833-v6.8-leds-core-Add-more-colors-from-DT-bindings-to-led_co.patch.patch
@@ -1,0 +1,29 @@
+From a067943129b4ec6b835e02cfd5fbef01093c1471 Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megi@xff.cz>
+Date: Sun, 8 Oct 2023 16:40:13 +0200
+Subject: [PATCH] leds: core: Add more colors from DT bindings to led_colors
+
+The colors are already part of DT bindings. Make sure the kernel is
+able to convert them to strings.
+
+Signed-off-by: Ondrej Jirman <megi@xff.cz>
+Link: https://lore.kernel.org/r/20231008144014.1180334-1-megi@xff.cz
+Signed-off-by: Lee Jones <lee@kernel.org>
+---
+ drivers/leds/led-core.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/drivers/leds/led-core.c
++++ b/drivers/leds/led-core.c
+@@ -36,6 +36,11 @@ const char * const led_colors[LED_COLOR_
+ 	[LED_COLOR_ID_IR] = "ir",
+ 	[LED_COLOR_ID_MULTI] = "multicolor",
+ 	[LED_COLOR_ID_RGB] = "rgb",
++	[LED_COLOR_ID_PURPLE] = "purple",
++	[LED_COLOR_ID_ORANGE] = "orange",
++	[LED_COLOR_ID_PINK] = "pink",
++	[LED_COLOR_ID_CYAN] = "cyan",
++	[LED_COLOR_ID_LIME] = "lime",
+ };
+ EXPORT_SYMBOL_GPL(led_colors);
+ 


### PR DESCRIPTION
The 'label' property in led node has been deprecated and we'd better to avoid using it. This patch allows us to extract DT OF LED name from the newly introduced LED properties "color", "function" and "function-enumerator".