### PR TITLE
filogic: fix wifi eeprom filename for asus tuf-ax6000 

### DIFF
--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -45,8 +45,7 @@ case "$FIRMWARE" in
 	;;
 "mediatek/mt7986_eeprom_mt7976_dbdc.bin")
 	case "$board" in
-	asus,tuf-ax4200|\
-	asus,tuf-ax6000)
+	asus,tuf-ax4200)
 		CI_UBIPART="UBI_DEV"
 		caldata_extract_ubi "Factory" 0x0 0x1000
 		;;
@@ -54,6 +53,10 @@ case "$FIRMWARE" in
 	;;
 "mediatek/mt7986_eeprom_mt7976_dual.bin")
 	case "$board" in
+	asus,tuf-ax6000)
+		CI_UBIPART="UBI_DEV"
+		caldata_extract_ubi "Factory" 0x0 0x1000
+		;;
 	glinet,gl-mt6000)
 		caldata_extract_mmc "factory" 0x0 0x1000
 		;;


### PR DESCRIPTION
The router use mt7986_eeprom_mt7976_dual.bin for wifi. 

 
