### PR TITLE
ipq807x: add support for Yuncore AX880

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -6,9 +6,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firmware/qca-wireless.git
-PKG_SOURCE_DATE:=2023-10-12
-PKG_SOURCE_VERSION:=cd04ab7f984fe28613276c01fd0ac7afbe5516d5
-PKG_MIRROR_HASH:=857ae436fd09785749411a665b31c82cec84b68b1e096f69ebb6c2a0efb5583f
+PKG_SOURCE_DATE:=2023-11-02
+PKG_SOURCE_VERSION:=371d4dce9b9a4b4dfd59bc902bb216f7133743cb
+PKG_MIRROR_HASH:=9c309f81cb1e464580ccdacc3f7a660df8a5a07a8b87f71e9d00f630ac0412ad
 
 PKG_FLAGS:=nonshared
 
@@ -44,6 +44,7 @@ ALLWIFIBOARDS:= \
 	xiaomi_ax3600 \
 	xiaomi_ax9000 \
 	yyets_le1 \
+	yuncore_ax880 \
 	zte_mf289f \
 	zte_mf287 \
 	zte_mf287plus \
@@ -151,6 +152,7 @@ $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax3600,Xiaomi AX3600))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax9000,Xiaomi AX9000))
 $(eval $(call generate-ipq-wifi-package,yyets_le1,YYeTs LE1))
+$(eval $(call generate-ipq-wifi-package,yuncore_ax880,Yuncore AX880))
 $(eval $(call generate-ipq-wifi-package,zte_mf289f,ZTE MF289F))
 $(eval $(call generate-ipq-wifi-package,zte_mf287,ZTE MF287))
 $(eval $(call generate-ipq-wifi-package,zte_mf287plus,ZTE MF287Plus))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: MIT, GPL-2.0 or later
+/* Copyright (c) 2023, Ruslan Isaev <legale.legale@gmail.com> */
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Yuncore AX880";
+	compatible = "yuncore,ax880", "qcom,ipq8074", "qcom,ipq8074-hk09";
+
+	aliases {
+		serial0 = &blsp1_uart5;
+		serial1 = &blsp1_uart3;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		/* Aliases as required by u-boot to patch MAC addresses */
+		ethernet0 = &dp5_syn;
+		ethernet1 = &dp6_syn;
+		label-mac-device = &dp5_syn;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 57 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "system";
+			color = "red";
+			gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan2g {
+			label = "wlan2g";
+			color = "green";
+			linux,default-trigger = "phy0tpt";
+			gpios = <&tlmm 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan5g {
+			label = "wlan5g";
+			color = "blue";
+			linux,default-trigger = "phy1tpt";
+			gpios = <&tlmm 9 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	button_pins: button_pins {
+		reset_button {
+			pins = "gpio57";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&blsp1_spi1 {
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:sbl1";
+				reg = <0x0 0x50000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "0:mibib";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "0:bootconfig";
+				reg = <0x60000 0x20000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "0:bootconfig1";
+				reg = <0x80000 0x20000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				label = "0:qsee_1";
+				reg = <0xa0000 0x180000>;
+				read-only;
+			};
+
+			partition@220000 {
+				label = "0:qsee";
+				reg = <0x220000 0x180000>;
+				read-only;
+			};
+
+			partition@3a0000 {
+				label = "0:devcfg";
+				reg = <0x3a0000 0x10000>;
+				read-only;
+			};
+
+			partition@3b0000 {
+				label = "0:devcfg_1";
+				reg = <0x3b0000 0x10000>;
+				read-only;
+			};
+
+			partition@3c0000 {
+				label = "0:apdp";
+				reg = <0x3c0000 0x10000>;
+				read-only;
+			};
+
+			partition@3d0000 {
+				label = "0:apdp_1";
+				reg = <0x3d0000 0x10000>;
+				read-only;
+			};
+
+			partition@3e0000 {
+				label = "0:rpm_1";
+				reg = <0x3e0000 0x40000>;
+				read-only;
+			};
+
+			partition@420000 {
+				label = "0:rpm";
+				reg = <0x420000 0x40000>;
+				read-only;
+			};
+
+			partition@460000 {
+				label = "0:cdt_1";
+				reg = <0x460000 0x10000>;
+				read-only;
+			};
+
+			partition@470000 {
+				label = "0:cdt";
+				reg = <0x470000 0x10000>;
+				read-only;
+			};
+
+			partition@480000 {
+				label = "0:appsblenv";
+				reg = <0x480000 0x10000>;
+			};
+
+			partition@490000 {
+				label = "0:appsbl_1";
+				reg = <0x490000 0xa0000>;
+				read-only;
+			};
+
+			partition@550000 {
+				label = "0:appsbl";
+				reg = <0x530000 0xa0000>;
+				read-only;
+			};
+
+			partition@610000 {
+				label = "0:art";
+				reg = <0x5d0000 0x40000>;
+				read-only;
+			};
+
+			partition@650000 {
+				label = "0:ethphyfw";
+				reg = <0x610000 0x80000>;
+				read-only;
+			};
+
+		};
+	};
+};
+
+//serial interface
+&blsp1_uart3 {
+	status = "okay";
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&usb_0 {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "rootfs_1";
+				reg = <0x0000000 0x3400000>;
+			};
+
+			partition@3400000 {
+				label = "0:wififw";
+				reg = <0x3400000 0x800000>;
+				read-only;
+			};
+
+			rootfs: partition@3c00000 {
+				label = "rootfs";
+				reg = <0x3c00000 0x3400000>;
+			};
+
+			partition@7000000 {
+				label = "0:wififw_1";
+				reg = <0x7000000 0x800000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+   
+	qca8081_24: ethernet-phy@24 {
+		compatible = "ethernet-phy-id004d.d101";
+		reg = <24>;
+		reset-gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
+	};
+
+	qca8081_28: ethernet-phy@28 {
+		compatible = "ethernet-phy-id004d.d101";
+		reg = <28>;
+		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
+	switch_lan_bmp = <0x3e>; /* lan port bitmap */
+	switch_wan_bmp = <0x40>; /* wan port bitmap */
+	switch_mac_mode = <0xff>; /* mac mode for uniphy instance0*/
+	switch_mac_mode1 = <0xf>; /* mac mode for uniphy instance1*/
+	switch_mac_mode2 = <0xf>; /* mac mode for uniphy instance2*/
+	bm_tick_mode = <0>; /* bm tick mode */
+	tm_tick_mode = <0>; /* tm tick mode */
+
+	qcom,port_phyinfo {
+		port@4 {
+			port_id = <5>;
+			phy_address = <24>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+		port@5 {
+			port_id = <6>;
+			phy_address = <28>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp5_syn {
+	status = "okay";
+	phy-handle = <&qca8081_24>;
+	label = "wan";
+};
+
+&dp6_syn {
+	status = "okay";
+	phy-handle = <&qca8081_28>;
+	label = "lan";
+};
+
+&wifi {
+	status = "okay";
+	qcom,ath11k-calibration-variant = "Yuncore-AX880";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -253,3 +253,19 @@ define Device/zyxel_nbg7815
 		kmod-bluetooth
 endef
 TARGET_DEVICES += zyxel_nbg7815
+
+define Device/yuncore_ax880
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Yuncore
+	DEVICE_MODEL := AX880
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_DTS_CONFIG := config@hk09
+	SOC := ipq8072
+	DEVICE_PACKAGES := ipq-wifi-yuncore_ax880
+	IMAGES += factory.bin
+	IMAGE/factory.bin := append-ubi | qsdk-ipq-factory-nand
+endef
+TARGET_DEVICES += yuncore_ax880
+

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -16,7 +16,8 @@ ipq807x_setup_interfaces()
 	xiaomi,ax9000)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;
-	edgecore,eap102)
+	edgecore,eap102|\
+	yuncore,ax880)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
 	edimax,cax1800)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -22,6 +22,7 @@ case "$FIRMWARE" in
 	redmi,ax6|\
 	xiaomi,ax3600|\
 	xiaomi,ax9000|\
+	yuncore,ax880|\
 	zyxel,nbg7815)
 		caldata_extract "0:art" 0x1000 0x20000
 		;;

--- a/target/linux/qualcommax/ipq807x/base-files/etc/init.d/bootcount
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/init.d/bootcount
@@ -4,7 +4,8 @@ START=99
 
 boot() {
 	case $(board_name) in
-	edgecore,eap102)
+	edgecore,eap102|\
+	yuncore,ax880)
 		fw_setenv upgrade_available 0
 		# Unset changed flag after sysupgrade complete
 		fw_setenv changed

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -113,6 +113,18 @@ platform_do_upgrade() {
 		CI_ROOT_UBIPART="rootfs"
 		nand_do_upgrade "$1"
 		;;
+	yuncore,ax880)
+		active="$(fw_printenv -n active)"
+		if [ "$active" -eq "1" ]; then
+			CI_UBIPART="rootfs_1"
+		else
+			CI_UBIPART="rootfs"
+		fi
+		# force altbootcmd which handles partition change in u-boot
+		fw_setenv bootcount 3
+		fw_setenv upgrade_available 1
+		nand_do_upgrade "$1"
+		;;
 	*)
 		default_do_upgrade "$1"
 		;;


### PR DESCRIPTION
SPECIFICATION:
    - Chipset:  IPQ8072A +QCN5054+QCN5024+QCA8081*2
    - Flash NOR-8MB AND NAND-128MB
    - RAM 1Gb DDR
    - IEEE 802.11:  802.11ax/ac/b/g/n
    - 4*4 2.4G Wi-Fi standard   802.11b/g/n/ax
    - 4*4 5.8G Wi-Fi Standard   802.11 a/n/ac/ax
    - 2x 1 Gbps Ethernet (QCA8081) with 802.3at PoE input support
    - 1x  Reset
    - 1x  Bluetooth(optional)
    - 1x  DC Port 12V 3A
    - 4x Antenna    IPEX Connector, 3dBi omni antennas
    - Data Rate:    3657Mbps ( 2.4G: 1182Mbps (11ax 4x4); 5.8G: 2475Mbps (11ax 4x4))
    - RF Power: 2.4g ≤ 20dBm; 5.8g ≤ 19dBm
    - LED light:    Sys; 5.8G wifi; 2.4G wifi; WAN; LAN
    - Max Power Consumption:    ≤ 22W
    - Size: 198mm * 198mm * 41.02mm

BACKUP YOUR STOCK FIRMWARE:
```
export device=ax880
mkdir -p /tmp/fw_dump_$device
cd /tmp/fw_dump_$device
dmesg > dmesg_$device.log
dtc -I fs /sys/firmware/devicetree/base > $device.dts
cat /proc/device-tree/model > model
cat /proc/mtd > proc_mtd
while read p; do
mtd_dev=$(echo $p | cut -d: -f1)
echo $mtd_dev
dd if=/dev/$mtd_dev of=$mtd_dev
done < proc_mtd
md5sum * > md5sum.log
tar -cvzf ../$device.tar.gz .
export sum=$(md5sum /tmp/$device.tar.gz | cut -d' ' -f1)
mv ../$device.tar.gz /tmp/${device}_${sum}.tar.gz
echo fw backup saved to: /tmp/${device}_${sum}.tar.gz
```
Upload your backup via tftp to the safe place.

INSTALLATION:
1. stock firmware web ui
Rename factory.bin fw image file to factory.ubin. Flash this image
like ordinary stock fw upgrade.

2. stock firmware telnet method
Enter telnet cli (login: root, password: 476t*_f0%g09y) and upload
 factory.bin fw image and rename it to factory.ubin
`cd /tmp && wget <your_web_server_ip>/factory.ubin`
`sysupgrade factory.ubin

3. initramfs method
    Put openwrt-ipq807x-generic-yuncore_ax880-initramfs-uImage.itb to your
    TFTP server and rename it to ax880.initram
    Enable serial console and enter to the u-boot cli.
    Exec these commands:
    `tftpboot <your_tftp_server_ip>:ax880.initram`
    `dhcp`

    When downloading is finished:
    `bootm`
    After booting the device, you need to upload to the device factory.ubi fw image.
    ```
    cd /tmp && wget <your_web_server_ip>/factory.ubi`
    export rootfs=$(cat /proc/mtd | grep rootfs | cut -d: -f1)
    export rootfs_1=$(cat /proc/mtd | grep rootfs_1 | cut -d: -f1)
    ubiformat /dev/${rootfs} -y -f factory.ubi
    ubiformat /dev/${rootfs_1} -y -f factory.ubi
    reboot
    ```

4. u-boot factory.ubi image method
    Put openwrt-ipq807x-generic-yuncore_ax880-squashfs-factory.ubi to your
    TFTP server and rename it to ax880.ubi
    Enter u-boot cli and exec these commands:
    `tftpboot <your_tftp_server_ip>:ax880.ubi`
    `dhcp`
    After downloading is finished:
    `flash rootfs`
    `flash rootfs_1`
    `reset`

5. u-boot factory.bin method
    Put openwrt-ipq807x-generic-yuncore_ax880-squashfs-factory.bin to your
    TFTP server and rename it to ax880.bin
    Enter u-boot cli and exec these commands:
    `tftpboot <your_tftp_server_ip>:ax880.bin`
    `dhcp`
    After downloading is finished:
    `imgaddr=$fileaddr`
    Erase rootfs memory:
    `nand erase 0x00000000 0x03400000`
    Write rootfs:
    `nand write $fileaddr 0x00000000 $filesize`
    Erase rootfs_1 memory:
    `nand erase 0x3c00000 0x3400000`
    Write rootfs_1
    `nand write $fileaddr 0x3c00000 $filesize`
    `reset`

STOCK FIRMWARE RECOVERY:
Boot initramfs image.
Upload your rootfs mtd partition to the device using scp or download
it from the device using wget.
Enter device ssh cli and exec:
```
cd /tmp && wget <your_web_server_ip>/mtd21`
export rootfs=$(cat /proc/mtd | grep rootfs | cut -d: -f1)
export rootfs_1=$(cat /proc/mtd | grep rootfs_1 | cut -d: -f1)
ubiformat /dev/${rootfs} -y -f /tmp/mtd21
ubiformat /dev/${rootfs_1} -y -f /tmp/mtd21
reboot
```

Signed-off-by: Isaev Ruslan <legale.legale@gmail.com>
