### PR TITLE
uhttpd: start when interface to listen becomes available

### DIFF
--- a/package/network/services/uhttpd/Makefile
+++ b/package/network/services/uhttpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uhttpd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uhttpd.git

--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -219,10 +219,77 @@ start_instance()
 	procd_close_instance
 }
 
+uhttpd_interfaces()
+{
+	local cfg="$1"
+	local http https listen ips
+
+	config_get http "$cfg" listen_http
+	config_get https "$cfg" listen_https
+	for listen in $http $https; do
+		case "$listen" in
+		"" |\
+		"0.0.0.0:"* |\
+		"[::]:"* )
+			continue
+			;;
+		*.*.*.*:*)
+			ips="$ips${listen%%:*}
+"
+			;;
+		\[*\]:* )
+			listen="${listen:1}"
+			ips="$ips${listen%%]:*}
+"
+			;;
+		esac
+	done
+
+	echo "$ips" | sort -u
+}
+
+resolve_iface()
+{
+	local cfg="$1"
+	local ipaddr ip6addrs ipaddrs testip="$2"
+
+	config_get ipaddrs "$cfg" ipaddr
+	config_get ip6addrs "$cfg" ip6addr
+	for ipaddr in $ipaddrs $ip6addrs; do
+		[ "$ipaddr" = "$testip" ] && echo "$cfg"
+	done
+}
+
+get_interface_by_ip()
+{
+	config_load network
+	config_foreach resolve_iface interface "$@"
+}
+
 service_triggers()
 {
+	local iface ifaces all=0
+
 	procd_add_reload_trigger "uhttpd"
 	procd_add_raw_trigger acme.renew 5000 /etc/init.d/uhttpd reload
+
+	config_load uhttpd
+	ips="$(config_foreach uhttpd_interfaces uhttpd)"
+	[ -z "$ips" ] && return 0
+
+	for ip in $ips; do
+		iface="$(get_interface_by_ip $ip)"
+		[ -z "$iface" ] && all=1
+		ifaces="$ifaces $iface"
+	done
+
+	if [ "$all" = "1" ]; then
+		procd_add_raw_trigger "interface.*.up" 1000 /etc/init.d/uhttpd reload
+	else
+		for iface in $ifaces; do
+			procd_add_raw_trigger "interface.$iface.up" 1000 /etc/init.d/uhttpd reload
+		done
+	fi
 }
 
 start_service() {


### PR DESCRIPTION
Currently uhttpd won't start with a listening interface configured if the interface isn't already up at the time uhttpd starts. Make sure we attempt to start uhttpd when it comes up.