### PR TITLE
ramips: add encrypted SGE factory image for D-Link devices

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -226,6 +226,11 @@ define Build/copy-file
 	cat "$(1)" > "$@"
 endef
 
+define Build/dlink-sge-image
+	$(STAGING_DIR_HOST)/bin/dlink-sge-image $(1) $@ $@.enc
+	mv $@.enc $@
+endef
+
 define Build/edimax-header
 	$(STAGING_DIR_HOST)/bin/mkedimaximg -i $@ -o $@.new $(1)
 	@mv $@.new $@

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -684,10 +684,9 @@ define Device/dlink_dir-8xx-a1
   DEVICE_VENDOR := D-Link
   DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
   KERNEL := $$(KERNEL) | uimage-sgehdr
-  IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
-	check-size | append-metadata
-  IMAGE/factory.bin := append-kernel | append-rootfs | check-size
+  IMAGES += recovery.bin factory.bin
+  IMAGE/recovery.bin := append-kernel | append-rootfs | check-size
+  IMAGE/factory.bin := $$(IMAGE/recovery.bin) | dlink-sge-image $$$$(DEVICE_MODEL)
 endef
 
 define Device/dlink_dir-8xx-r1
@@ -707,8 +706,8 @@ define Device/dlink_dir-xx60-a1
   DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 \
 	kmod-usb-ledtrig-usbport -uboot-envtools
   KERNEL := $$(KERNEL) | uimage-sgehdr
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+  IMAGES += recovery.bin
+  IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
 endef
 
@@ -760,6 +759,8 @@ define Device/dlink_dir-853-a3
   $(Device/dlink_dir-xx60-a1)
   DEVICE_MODEL := DIR-853
   DEVICE_VARIANT := A3
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(IMAGE/recovery.bin) | dlink-sge-image $$(DEVICE_MODEL)
 endef
 TARGET_DEVICES += dlink_dir-853-a3
 


### PR DESCRIPTION
creates SGE encrypted factory images
to use via the D-Link web interface
rename the old factory unencrypted images to recovery
for use in the recovery console when recovery is needed
DIR-1935-A1 , DIR-853-A1 , DIR-853-A3 , DIR-867-A1 ,
DIR-878-A1 and DIR-882-A1
