### PR TITLE
ramips: add support for D-Link COVR-X1860 A1

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_covr-x1860-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_covr-x1860-a1.dts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,covr-x1860-a1", "mediatek,mt7621-soc";
+	model = "D-Link COVR-X1860 A1";
+
+	aliases {
+		led-boot = &status_orange;
+		led-failsafe = &status_red;
+		led-running = &status_white;
+		led-upgrade = &status_red;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		status_white: power {
+			label = "white:status";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		status_orange: status_orange {
+			label = "orange:status";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+		};
+
+		partition@180000 {
+			label = "config2";
+			reg = <0x180000 0x40000>;
+			read-only;
+		};
+
+		partition@1c0000 {
+			label = "kernel";
+			reg = <0x1c0000 0x800000>;
+		};
+
+		fwconcat0: partition@9c0000 {
+			label = "fwconcat0";
+			reg = <0x9c0000 0x2000000>;
+		};
+
+		partition@29c0000 {
+			label = "kernel2";
+			reg = <0x29c0000 0x800000>;
+			read-only;
+		};
+
+		fwconcat1: partition@31c0000 {
+			label = "fwconcat1";
+			reg = <0x31c0000 0x2a00000>;
+		};
+
+		partition@5bc0000 {
+			label = "private";
+			reg = <0x5bc0000 0x1400000>;
+			read-only;
+		};
+
+		partition@6fc0000 {
+			label = "mydlink";
+			reg = <0x6fc0000 0x600000>;
+			read-only;
+		};
+
+		partition@75c0000 {
+			label = "myconfig";
+			reg = <0x75c0000 0xa00000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		mediatek,disable-radar-background;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	phy-handle = <&ethphy4>;
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "internet";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "ethernet";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -9,6 +9,14 @@ DEFAULT_SOC := mt7621
 
 DEVICE_VARS += ELECOM_HWNAME LINKSYS_HWNAME DLINK_HWID
 
+define Build/append-dlink-covr-metadata
+	echo -ne '{"supported_devices": "$(1)", "firmware": "' > $@metadata.tmp
+	$(MKHASH) md5 "$@" | head -c32 >> $@metadata.tmp
+	echo '"}' >> $@metadata.tmp
+	fwtool -I $@metadata.tmp $@
+	rm $@metadata.tmp
+endef
+
 define Build/arcadyan-trx
 	echo -ne "hsqs" > $@.hsqs
 	$(eval trx_magic=$(word 1,$(1)))
@@ -640,6 +648,31 @@ define Device/cudy_x6-v2
   SUPPORTED_DEVICES += cudy,x6 R30
 endef
 TARGET_DEVICES += cudy_x6-v2
+
+define Device/dlink_covr-x1860-a1
+  $(Device/dsa-migration)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 8192k
+  IMAGE_SIZE := 40960k
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := COVR-X1860
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES := kmod-mt7915-firmware
+  UBINIZE_OPTS := -E 5
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel 0x80001000 | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
+	append-squashfs4-fakeroot
+  IMAGES += factory.bin recovery.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size
+  IMAGE/factory.bin := $$(IMAGE/recovery.bin) | \
+	append-dlink-covr-metadata $$(DEVICE_MODEL) | \
+	dlink-sge-image $$(DEVICE_MODEL)
+endef
+TARGET_DEVICES += dlink_covr-x1860-a1
 
 define Device/dlink_dxx-1xx0-x1
   DEVICE_VENDOR := D-Link

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -98,6 +98,9 @@ ramips_setup_interfaces()
 	zyxel,nr7101)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
+	dlink,covr-x1860-a1)
+		ucidef_set_interfaces_lan_wan "ethernet" "internet"
+		;;
 	gnubee,gb-pc1)
 		ucidef_set_interface_lan "ethblack ethblue"
 		;;
@@ -218,6 +221,11 @@ ramips_setup_macs()
 		lan_mac=$(cat /sys/class/net/eth0/address)
 		label_mac=$lan_mac
 		wan_mac=$(macaddr_add "$lan_mac" 1)
+		;;
+	dlink,covr-x1860-a1)
+		label_mac=$(mtd_get_mac_ascii config2 factory_mac)
+		wan_mac=$(macaddr_add "$label_mac" 3)
+		lan_mac=$label_mac
 		;;
 	dlink,dir-860l-b1)
 		lan_mac=$(mtd_get_mac_ascii factory lanmac)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -46,6 +46,13 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_add $lan_mac_addr 2 > /sys${DEVPATH}/macaddress
 		;;
+	dlink,covr-x1860-a1)
+		label_mac=$(mtd_get_mac_ascii config2 factory_mac)
+		[ "$PHYNBR" = "0" ] && \
+			macaddr_add $label_mac 1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && \
+			macaddr_add $label_mac 2 > /sys${DEVPATH}/macaddress
+		;;
 	dlink,dap-x1860-a1)
 		hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"
 		[ "$PHYNBR" = "0" ] && \

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -63,6 +63,7 @@ platform_do_upgrade() {
 	beeline,smartbox-turbo|\
 	beeline,smartbox-turbo-plus|\
 	belkin,rt1800|\
+	dlink,covr-x1860-a1|\
 	dlink,dap-x1860-a1|\
 	dlink,dir-1960-a1|\
 	dlink,dir-2640-a1|\


### PR DESCRIPTION
The pull request is based on the discussion in https://forum.openwrt.org/t/add-support-for-d-link-covr-x1860

The COVR-X1860 are MT7621-based AX1800 devices (similar to DAP-X1860, but with two Ethernet ports and external power supply) that are sold in sets of two (COVR-X1862) and three (COVR-X1863).

Specification:
 - MT7621
 - MT7915 + MT7975 2x2 802.11ax (DBDC)
 - 256MB RAM
 - 128 MB flash
 - 3 LEDs (red, orange, white), routed to one indicator in the top of the device
 - 2 buttons (WPS in the back and Reset at the bottom of the device)

MAC addresses:
 - LAN MAC (printed on the device) is stored in config2 partition as ASCII (entry factory_mac=xx:xx:xx:xx:xx:xx)
 - WAN MAC: LAN MAC + 3
 - 2.4G MAC: LAN MAC + 1
 - 5G MAC: LAN MAC + 2

The pins for the serial console are already labeled on the board (VCC, TX, RX, GND). Serial settings: 3.3V, 115200,8n1

Flashing via OEM Web Interface:
 - Download openwrt-ramips-mt7621-dlink_covr-x1860-a1-squashfs-factory.bin via the OEM web interface firmware update
 - The configuration wizard can be skipped by directly going to http://192.168.0.1/UpdateFirmware_Simple.html

Flashing via Recovery Web Interface:
 - Set your IP address to 192.168.0.10, subnetmask 255.255.255.0
 - Press the reset button while powering on the deivce
 - Keep the reset button pressed until the status LED blinks red
 - Open a Chromium based browser and goto http://192.168.0.1
 - Download openwrt-ramips-mt7621-dlink_covr-x1860-a1-squashfs-recovery.bin

Revert back to stock using the Recovery Web Interface:
 - Set your IP address to 192.168.0.10, subnetmask 255.255.255.25
 - Press the reset button while powering on the deivce
 - Keep the reset button pressed until the status LED blinks red
 - Open a Chromium based browser and goto http://192.168.0.1
 - Flash a decrypted firmware image from D-Link. Decrypting an firmware image is described below.

Decrypting a D-Link firmware image:
 - Download https://github.com/openwrt/firmware-utils/blob/master/src/dlink-sge-image.c and https://raw.githubusercontent.com/openwrt/firmware-utils/master/src/dlink-sge-image.h
 - Compile a binary from the downloaded file, e.g. gcc dlink-sge-image.c -lcrypto -o dlink-sge-image
 - Run ./dlink-sge-image COVR-X1860 <OriginalFirmware> <OutputFile> -d
 - Example for firmware 102b01: ./dlink-sge-image COVR-X1860 COVR-X1860_RevA_Firmware_102b01.bin COVR-X1860_RevA_Firmware_102b01_Decrypted.bin -d