### PR TITLE
[22.03] build: export GIT_CEILING_DIRECTORIES for package builds

### DIFF
--- a/include/host-build.mk
+++ b/include/host-build.mk
@@ -130,6 +130,7 @@ define Host/Exports/Default
   $(1) : export STAGING_PREFIX=$$(HOST_BUILD_PREFIX)
   $(1) : export PKG_CONFIG_PATH=$$(STAGING_DIR_HOST)/lib/pkgconfig:$$(HOST_BUILD_PREFIX)/lib/pkgconfig
   $(1) : export PKG_CONFIG_LIBDIR=$$(HOST_BUILD_PREFIX)/lib/pkgconfig
+  $(1) : export GIT_CEILING_DIRECTORIES=$$(BUILD_DIR_HOST)
   $(if $(HOST_CONFIG_SITE),$(1) : export CONFIG_SITE:=$(HOST_CONFIG_SITE))
   $(if $(IS_PACKAGE_BUILD),$(1) : export PATH=$$(TARGET_PATH_PKG))
 endef

--- a/include/package.mk
+++ b/include/package.mk
@@ -173,6 +173,7 @@ define Build/Exports/Default
   $(1) : export CONFIG_SITE:=$$(CONFIG_SITE)
   $(1) : export PKG_CONFIG_PATH:=$$(PKG_CONFIG_PATH)
   $(1) : export PKG_CONFIG_LIBDIR:=$$(PKG_CONFIG_PATH)
+  $(1) : export GIT_CEILING_DIRECTORIES:=$$(BUILD_DIR)
 endef
 Build/Exports=$(Build/Exports/Default)
 


### PR DESCRIPTION
Backported from https://github.com/openwrt/openwrt/pull/12710 to OpenWrt 22.03:

```
A package may run git as part of its build process, and if the package source code is not from a git checkout, then git may traverse up the directory tree to find buildroot's repository directory (.git).

For instance, Poetry Core, a Python build backend, will read the contents of .gitignore for paths to exclude when creating a Python package. If it finds buildroot's .gitignore file, then Poetry Core will exclude all of the package's files[1].

This exports GIT_CEILING_DIRECTORIES for both package and host builds so that git will not traverse beyond $(BUILD_DIR)/$(BUILD_DIR_HOST).

[1]: https://github.com/python-poetry/poetry/issues/5547
```