### PR TITLE
ramips: add TP-LINK TL-WR902AC v4

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr902ac-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr902ac-v4.dts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_tplink_8m.dtsi"
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tplink,tl-wr902ac-v4", "mediatek,mt7628an-soc";
+	model = "TP-Link TL-WR902AC v4";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		button-sw1 {
+			label = "sw1";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		button-sw2 {
+			label = "sw2";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+		};
+
+		button-wps {
+			label = "wps";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ohci_port1>, <&ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-4 {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eeprom_factory_28000 {
+	/* tl-wr902ac-v4 has different eeprom size '0x4da8' for MT7613 */
+	reg = <0x28000 0x4da8>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_factory_28000>, <&macaddr_factory_f100 (-1)>;
+		nvmem-cell-names = "eeprom", "mac-address";
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "i2s", "p0led_an", "p2led_an", "p4led_an", "uart1", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&wmac {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory_28000>, <&macaddr_factory_f100 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -855,6 +855,22 @@ define Device/tplink_tl-wr902ac-v3
 endef
 TARGET_DEVICES += tplink_tl-wr902ac-v3
 
+define Device/tplink_tl-wr902ac-v4
+  $(Device/tplink-v2)
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := TL-WR902AC
+  DEVICE_VARIANT := v4
+  TPLINK_FLASHLAYOUT := 8Mmtk
+  TPLINK_HWID := 0x000dc88f
+  TPLINK_HWREV := 0x89
+  TPLINK_HWREVADD := 0x1
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap kmod-usb2 kmod-usb-ohci \
+	kmod-usb-ledtrig-usbport
+  IMAGES := sysupgrade.bin tftp-recovery.bin
+  IMAGE/tftp-recovery.bin := pad-extra 128k | $$(IMAGE/factory.bin)
+endef
+TARGET_DEVICES += tplink_tl-wr902ac-v4
+
 define Device/unielec_u7628-01-16m
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := UniElec

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -124,6 +124,9 @@ tplink,tl-wr902ac-v3)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x10"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
+tplink,tl-wr902ac-v4)
+	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
+	;;
 unielec,u7628-01-16m)
 	ucidef_set_led_switch "lan1" "lan1" "green:lan1" "switch0" "0x2"
 	ucidef_set_led_switch "lan2" "lan2" "green:lan2" "switch0" "0x4"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -29,6 +29,7 @@ ramips_setup_interfaces()
 	tplink,re305-v3|\
 	tplink,tl-wr802n-v4|\
 	tplink,tl-wa801nd-v5|\
+	tplink,tl-wr902ac-v4|\
 	widora,neo-16m|\
 	widora,neo-32m)
 		ucidef_add_switch "switch0"


### PR DESCRIPTION
Seems to be very similar to: https://openwrt.org/toh/tp-link/tl-wr902ac_v3 
1 x usb
1 x eth
Powered by mini usb port.
Can use the same TFTP method to install.

Based on dmesg from already flashed device:

SoC Type: MediaTek MT7628AN ver:1 eco:2
CPU0 revision is: 00019655 (MIPS 24KEc)
Memory: 56028K/65536K available
CPU Clock: 580MHz
