### PR TITLE
dnsmasq: Drop support for the 'netmask' parameter

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.89
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -540,7 +540,9 @@ dhcp_add() {
 	[ static = "$proto" ] || return 0
 
 	# Override interface netmask with dhcp config if applicable
-	config_get netmask "$cfg" netmask "${subnet##*/}"
+	config_get netmask "$cfg" netmask
+
+	[ -n "$netmask" ] && echo "dnsmasq: the 'netmask' parameter is no longer supported and is being ignored." >&2
 
 	#check for an already active dhcp server on the interface, unless 'force' is set
 	config_get_bool force "$cfg" force 0
@@ -583,10 +585,11 @@ dhcp_add() {
 	nettag="${networkid:+set:${networkid},}"
 
 	# make sure the DHCP range is not empty
-	if [ "$dhcpv4" != "disabled" ] && ipcalc "${subnet%%/*}" "$netmask" "$start" "$limit" ; then
+	if [ "$dhcpv4" != "disabled" ] && ipcalc "$subnet" "$start" "$limit" ; then
 		[ "$dynamicdhcpv4" = "0" ] && END="static"
 
-		xappend "--dhcp-range=$tags$nettag$START,$END,$NETMASK,$leasetime${options:+ $options}"
+		# don't need a netmask for the pool since we're not a relay
+		xappend "--dhcp-range=$tags$nettag$START,$END,,$leasetime${options:+ $options}"
 	fi
 
 	if [ "$dynamicdhcpv6" = "0" ] ; then


### PR DESCRIPTION
This isn't documented and it's causing us to invoke ipcalc.sh using a non-standard notation.

Emit a message that this parameter is ignored.

cc: @jow- @yogo1212 @vgaetera @dangowrt @ldir-EDB0 @hnyman @ptpt52 @hauke 
