### PR TITLE
px5g-mbedtls: Fix permission of private key

### DIFF
--- a/package/utils/px5g-mbedtls/Makefile
+++ b/package/utils/px5g-mbedtls/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=px5g-mbedtls
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 PKG_LICENSE:=LGPL-2.1
 
 PKG_BUILD_FLAGS:=no-mips16

--- a/package/utils/px5g-mbedtls/px5g-mbedtls.c
+++ b/package/utils/px5g-mbedtls/px5g-mbedtls.c
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <stdbool.h>
+#include <errno.h>
 
 #include <mbedtls/bignum.h>
 #include <mbedtls/entropy.h>
@@ -55,10 +56,13 @@ static int _urandom(void *ctx, unsigned char *out, size_t len)
 	return 0;
 }
 
-static void write_file(const char *path, int len, bool pem)
+static void write_file(const char *path, size_t len, bool pem, bool cert)
 {
-	FILE *f = stdout;
+	mode_t mode = S_IRUSR | S_IWUSR;
 	const char *buf_start = buf;
+	int fd = STDERR_FILENO;
+	ssize_t written;
+	int err;
 
 	if (!pem)
 		buf_start += sizeof(buf) - len;
@@ -67,17 +71,30 @@ static void write_file(const char *path, int len, bool pem)
 		fprintf(stderr, "No data to write\n");
 		exit(1);
 	}
+	
+	if (cert)
+		mode |= S_IRGRP | S_IROTH;
 
-	if (!f) {
+	if (path)
+		fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, mode);
+
+	if (fd < 0) {
 		fprintf(stderr, "error: I/O error\n");
 		exit(1);
 	}
 
+	written = write(fd, buf_start, len);
+	if (written != len) {
+		fprintf(stderr, "writing key failed with: %s\n", strerror(errno));
+		exit(1);
+	}
+	err = fsync(fd);
+	if (err < 0) {
+		fprintf(stderr, "syncing key failed with: %s\n", strerror(errno));
+		exit(1);
+	}
 	if (path)
-		f = fopen(path, "w");
-
-	fwrite(buf_start, 1, len, f);
-	fclose(f);
+		close(fd);
 }
 
 static mbedtls_ecp_group_id ecp_curve(const char *name)
@@ -110,7 +127,7 @@ static void write_key(mbedtls_pk_context *key, const char *path, bool pem)
 			len = 0;
 	}
 
-	write_file(path, len, pem);
+	write_file(path, len, pem, false);
 }
 
 static void gen_key(mbedtls_pk_context *key, bool rsa, int ksize, int exp,
@@ -301,7 +318,7 @@ int selfsigned(char **arg)
 			return 1;
 		}
 	}
-	write_file(certpath, len, pem);
+	write_file(certpath, len, pem, true);
 
 	mbedtls_x509write_crt_free(&cert);
 	mbedtls_mpi_free(&serial);

--- a/package/utils/px5g-wolfssl/Makefile
+++ b/package/utils/px5g-wolfssl/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=px5g-wolfssl
-PKG_RELEASE:=8.2
+PKG_RELEASE:=9
 PKG_LICENSE:=GPL-2.0-or-later
 
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
Store the private key with read and write permission for the user only and not with read permissions for everyone. This converts the write_file() function from fopen() to open() because open allows to specify the permission mask of the newly created file. It also adds and fixes some existing error handling.

OpenSSL does this in the same way already.

Without this change the permissions are looking like this:
````
root@OpenWrt:/# ls -al /etc/uhttpd.crt /etc/uhttpd.key
-rw-r--r-- /etc/uhttpd.crt
-rw-r--r-- /etc/uhttpd.key
````

With this change it looks like this:
````
root@OpenWrt:/# ls -al /etc/uhttpd.key /etc/uhttpd.crt
-rw------- /etc/uhttpd.crt
-rw------- /etc/uhttpd.key
````

Reported-by: Andris P
