### PR TITLE
dnsmasq: Invoke new ipcalc with CIDR notation

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.89
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -539,8 +539,13 @@ dhcp_add() {
 	# Do not support non-static interfaces for now
 	[ static = "$proto" ] || return 0
 
+	ipaddr="${subnet%%/*}"
+	prefix_or_netmask="${subnet##*/}"
+
 	# Override interface netmask with dhcp config if applicable
-	config_get netmask "$cfg" netmask "${subnet##*/}"
+	config_get netmask "$cfg" netmask
+
+	[ -n "$netmask" ] && prefix_or_netmask="$netmask"
 
 	#check for an already active dhcp server on the interface, unless 'force' is set
 	config_get_bool force "$cfg" force 0
@@ -583,7 +588,7 @@ dhcp_add() {
 	nettag="${networkid:+set:${networkid},}"
 
 	# make sure the DHCP range is not empty
-	if [ "$dhcpv4" != "disabled" ] && ipcalc "${subnet%%/*}" "$netmask" "$start" "$limit" ; then
+	if [ "$dhcpv4" != "disabled" ] && ipcalc "$ipaddr/$prefix_or_netmask" "$start" "$limit" ; then
 		[ "$dynamicdhcpv4" = "0" ] && END="static"
 
 		xappend "--dhcp-range=$tags$nettag$START,$END,$NETMASK,$leasetime${options:+ $options}"


### PR DESCRIPTION
The new rewritten ipcalc.sh understands 3 notations:

ipaddr/prefix ...
ipaddr/dotted-netmask ...
ipaddr dotted-netmask ...

It's currently using none of the above, but instead "ipaddr prefix ...".

This behavior came in as
https://github.com/openwrt/openwrt/commit/eda27e8382f3e5253defab5419e95d4b51f72de3 a long time ago.

cc: @vgaetera @yogo1212 @jow- @ldir-EDB0 @dangowrt @rsalvaterra 