### PR TITLE
base-files: Create /root w/ appropriate permissions

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -199,7 +199,8 @@ define Package/base-files/install
 		$(1)/usr/lib \
 		$(1)/usr/bin \
 		$(1)/sys \
-		$(1)/www \
+		$(1)/www
+	mkdir -p -m 750 \
 		$(1)/root
 
 	$(LN) /proc/mounts $(1)/etc/mtab


### PR DESCRIPTION
If /root is created with too permissive permissions, then sshd won't trust the contents of /root/.ssh as being adequately protected.

Make it secure-by-default.