### PR TITLE
[23.05] cherry-pick some new ramips boards to openwrt-23.05 branch

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -20,6 +20,7 @@ alfa-network,tube-e4g|\
 engenius,epg600|\
 engenius,esr600h|\
 linksys,re7000|\
+meig,slt866|\
 sitecom,wlr-4100-v1-002|\
 zyxel,keenetic-lite-iii-a)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x1000"

--- a/target/linux/generic/hack-5.15/780-usb-net-MeigLink_modem_support.patch
+++ b/target/linux/generic/hack-5.15/780-usb-net-MeigLink_modem_support.patch
@@ -10,26 +10,52 @@ Subject: [PATCH] net/usb/qmi_wwan: add MeigLink modem support
 
 --- a/drivers/net/usb/qmi_wwan.c
 +++ b/drivers/net/usb/qmi_wwan.c
-@@ -1086,6 +1086,7 @@ static const struct usb_device_id produc
+@@ -1080,12 +1080,18 @@ static const struct usb_device_id produc
+ 		USB_DEVICE_AND_INTERFACE_INFO(0x03f0, 0x581d, USB_CLASS_VENDOR_SPEC, 1, 7),
+ 		.driver_info = (unsigned long)&qmi_wwan_info,
+ 	},
++	{	/* Meiglink SGM828 */
++		USB_DEVICE_AND_INTERFACE_INFO(0x2dee, 0x4d49, USB_CLASS_VENDOR_SPEC, 0x10, 0x05),
++		.driver_info = (unsigned long)&qmi_wwan_info,
++	},
++
+ 	{QMI_MATCH_FF_FF_FF(0x2c7c, 0x0125)},	/* Quectel EC25, EC20 R2.0  Mini PCIe */
+ 	{QMI_MATCH_FF_FF_FF(0x2c7c, 0x0306)},	/* Quectel EP06/EG06/EM06 */
+ 	{QMI_MATCH_FF_FF_FF(0x2c7c, 0x0512)},	/* Quectel EG12/EM12 */
  	{QMI_MATCH_FF_FF_FF(0x2c7c, 0x0620)},	/* Quectel EM160R-GL */
  	{QMI_MATCH_FF_FF_FF(0x2c7c, 0x0800)},	/* Quectel RM500Q-GL */
  	{QMI_MATCH_FF_FF_FF(0x2c7c, 0x0801)},	/* Quectel RM520N */
-+	{QMI_MATCH_FF_FF_FF(0x05c6, 0xf601)},   /* MeigLink SLM750 */
++	{QMI_MATCH_FF_FF_FF(0x05c6, 0xf601)},	/* MeigLink SLM750 */
  
  	/* 3. Combined interface devices matching on interface number */
  	{QMI_FIXED_INTF(0x0408, 0xea42, 4)},	/* Yota / Megafon M100-1 */
 --- a/drivers/usb/serial/option.c
 +++ b/drivers/usb/serial/option.c
-@@ -247,6 +247,8 @@ static void option_instat_callback(struc
+@@ -247,6 +247,11 @@ static void option_instat_callback(struc
  #define UBLOX_PRODUCT_R410M			0x90b2
  /* These Yuga products use Qualcomm's vendor ID */
  #define YUGA_PRODUCT_CLM920_NC5			0x9625
 +/* These MeigLink products use Qualcomm's vendor ID */
 +#define MEIGLINK_PRODUCT_SLM750			0xf601
++
++#define MEIGLINK_VENDOR_ID			0x2dee
++#define MEIGLINK_PRODUCT_SLM828			0x4d49
  
  #define QUECTEL_VENDOR_ID			0x2c7c
  /* These Quectel products use Quectel's vendor ID */
-@@ -1185,6 +1187,11 @@ static const struct usb_device_id option
+@@ -1144,6 +1149,11 @@ static const struct usb_device_id option
+ 	{ USB_DEVICE(QUALCOMM_VENDOR_ID, 0x0023)}, /* ONYX 3G device */
+ 	{ USB_DEVICE(QUALCOMM_VENDOR_ID, 0x9000), /* SIMCom SIM5218 */
+ 	  .driver_info = NCTRL(0) | NCTRL(1) | NCTRL(2) | NCTRL(3) | RSVD(4) },
++	/* MeiG */
++	{ USB_DEVICE_AND_INTERFACE_INFO(MEIGLINK_VENDOR_ID, MEIGLINK_PRODUCT_SLM828, USB_CLASS_VENDOR_SPEC, 0x10, 0x01) },
++	{ USB_DEVICE_AND_INTERFACE_INFO(MEIGLINK_VENDOR_ID, MEIGLINK_PRODUCT_SLM828, USB_CLASS_VENDOR_SPEC, 0x10, 0x02) },
++	{ USB_DEVICE_AND_INTERFACE_INFO(MEIGLINK_VENDOR_ID, MEIGLINK_PRODUCT_SLM828, USB_CLASS_VENDOR_SPEC, 0x10, 0x03) },
++	{ USB_DEVICE_AND_INTERFACE_INFO(MEIGLINK_VENDOR_ID, MEIGLINK_PRODUCT_SLM828, USB_CLASS_VENDOR_SPEC, 0x10, 0x04) },
+ 	/* Quectel products using Qualcomm vendor ID */
+ 	{ USB_DEVICE(QUALCOMM_VENDOR_ID, QUECTEL_PRODUCT_UC15)},
+ 	{ USB_DEVICE(QUALCOMM_VENDOR_ID, QUECTEL_PRODUCT_UC20),
+@@ -1185,6 +1195,11 @@ static const struct usb_device_id option
  	  .driver_info = ZLP },
  	{ USB_DEVICE(QUECTEL_VENDOR_ID, QUECTEL_PRODUCT_BG96),
  	  .driver_info = RSVD(4) },

--- a/target/linux/generic/hack-5.15/781-usb-net-rndis-support-asr.patch
+++ b/target/linux/generic/hack-5.15/781-usb-net-rndis-support-asr.patch
@@ -1,0 +1,56 @@
+--- a/drivers/net/usb/rndis_host.c
++++ b/drivers/net/usb/rndis_host.c
+@@ -630,6 +630,16 @@ static const struct driver_info	zte_rndi
+ 	.tx_fixup =	rndis_tx_fixup,
+ };
+ 
++static const struct driver_info asr_rndis_info = {
++	.description =	"Asr RNDIS device",
++	.flags =	FLAG_WWAN | FLAG_POINTTOPOINT | FLAG_FRAMING_RN | FLAG_NO_SETINT | FLAG_NOARP,
++	.bind =		rndis_bind,
++	.unbind =	rndis_unbind,
++	.status =	rndis_status,
++	.rx_fixup =	rndis_rx_fixup,
++	.tx_fixup =	rndis_tx_fixup,
++};
++
+ /*-------------------------------------------------------------------------*/
+ 
+ static const struct usb_device_id	products [] = {
+@@ -666,6 +676,36 @@ static const struct usb_device_id	produc
+ 	USB_INTERFACE_INFO(USB_CLASS_WIRELESS_CONTROLLER, 1, 3),
+ 	.driver_info = (unsigned long) &rndis_info,
+ }, {
++	/* Quectel EG060V rndis device */
++	USB_DEVICE_AND_INTERFACE_INFO(0x2c7c, 0x6004,
++				      USB_CLASS_WIRELESS_CONTROLLER, 1, 3),
++	.driver_info = (unsigned long) &asr_rndis_info,
++}, {
++	/* Quectel EC200A rndis device */
++	USB_DEVICE_AND_INTERFACE_INFO(0x2c7c, 0x6005,
++				      USB_CLASS_WIRELESS_CONTROLLER, 1, 3),
++	.driver_info = (unsigned long) &asr_rndis_info,
++}, {
++	/* Quectel EC200T rndis device */
++	USB_DEVICE_AND_INTERFACE_INFO(0x2c7c, 0x6026,
++				      USB_CLASS_WIRELESS_CONTROLLER, 1, 3),
++	.driver_info = (unsigned long) &asr_rndis_info,
++}, {
++	/* Simcom A7906E rndis device */
++	USB_DEVICE_AND_INTERFACE_INFO(0x1e0e, 0x9011,
++				      USB_CLASS_WIRELESS_CONTROLLER, 1, 3),
++	.driver_info = (unsigned long) &asr_rndis_info,
++}, {
++	/* Meig SLM770A */
++	USB_DEVICE_AND_INTERFACE_INFO(0x2dee, 0x4d57,
++				      USB_CLASS_WIRELESS_CONTROLLER, 1, 3),
++	.driver_info = (unsigned long) &asr_rndis_info,
++}, {
++	/* Meig SLM828 */
++	USB_DEVICE_AND_INTERFACE_INFO(0x2dee, 0x4d49,
++				      USB_CLASS_WIRELESS_CONTROLLER, 1, 3),
++	.driver_info = (unsigned long) &asr_rndis_info,
++}, {
+ 	/* Novatel Verizon USB730L */
+ 	USB_INTERFACE_INFO(USB_CLASS_MISC, 4, 1),
+ 	.driver_info = (unsigned long) &rndis_info,

--- a/target/linux/generic/pending-5.15/804-nvmem-core-support-mac-base-fixed-layout-cells.patch
+++ b/target/linux/generic/pending-5.15/804-nvmem-core-support-mac-base-fixed-layout-cells.patch
@@ -20,10 +20,11 @@ string.
  
 --- a/drivers/nvmem/core.c
 +++ b/drivers/nvmem/core.c
-@@ -7,9 +7,11 @@
+@@ -7,9 +7,12 @@
   */
  
  #include <linux/device.h>
++#include <linux/ctype.h>
 +#include <linux/etherdevice.h>
  #include <linux/export.h>
  #include <linux/fs.h>
@@ -32,7 +33,7 @@ string.
  #include <linux/init.h>
  #include <linux/kref.h>
  #include <linux/module.h>
-@@ -696,6 +698,37 @@ static int nvmem_validate_keepouts(struc
+@@ -696,6 +699,62 @@ static int nvmem_validate_keepouts(struc
  	return 0;
  }
  
@@ -67,24 +68,54 @@ string.
 +	return 0;
 +}
 +
++static int nvmem_mac_base_hex_read(void *context, const char *id, int index, unsigned int offset,
++				   void *buf, size_t bytes)
++{
++	u8 mac[ETH_ALEN], *hexstr;
++	int i;
++
++	if (WARN_ON(bytes != 2 * ETH_ALEN))
++		return -EINVAL;
++
++	hexstr = (u8 *)buf;
++	for (i = 0; i < ETH_ALEN; i++) {
++		if (!isxdigit(hexstr[i * 2]) || !isxdigit(hexstr[i * 2 + 1]))
++			return -EINVAL;
++
++		mac[i] = (hex_to_bin(hexstr[i * 2]) << 4) | hex_to_bin(hexstr[i * 2 + 1]);
++	}
++
++	if (index)
++		eth_addr_add(mac, index);
++
++	ether_addr_copy(buf, mac);
++
++	return 0;
++}
++
  static int nvmem_add_cells_from_dt(struct nvmem_device *nvmem, struct device_node *np)
  {
  	struct nvmem_layout *layout = nvmem->layout;
-@@ -731,6 +764,20 @@ static int nvmem_add_cells_from_dt(struc
+@@ -731,6 +790,25 @@ static int nvmem_add_cells_from_dt(struc
  		if (layout && layout->fixup_cell_info)
  			layout->fixup_cell_info(nvmem, layout, &info);
  
 +		if (of_device_is_compatible(np, "fixed-layout")) {
 +			if (of_device_is_compatible(child, "mac-base")) {
-+				if (info.bytes == 6) {
++				if (info.bytes == ETH_ALEN) {
 +					info.raw_len = info.bytes;
 +					info.bytes = ETH_ALEN;
 +					info.read_post_process = nvmem_mac_base_raw_read;
++				} else if (info.bytes == 2 * ETH_ALEN) {
++					info.raw_len = info.bytes;
++					info.bytes = ETH_ALEN;
++					info.read_post_process = nvmem_mac_base_hex_read;
 +				} else if (info.bytes == 3 * ETH_ALEN - 1) {
 +					info.raw_len = info.bytes;
 +					info.bytes = ETH_ALEN;
 +					info.read_post_process = nvmem_mac_base_ascii_read;
 +				}
++
 +			}
 +		}
 +

--- a/target/linux/ramips/dts/mt7621_comfast_cf-e390ax.dts
+++ b/target/linux/ramips/dts/mt7621_comfast_cf-e390ax.dts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "comfast,cf-e390ax", "mediatek,mt7621-soc";
+	model = "COMFAST CF-E390AX";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: status_blue {
+			label = "blue:status";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_red;
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <14000000>;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@50000 {
+				label = "factory";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@90000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x90000 0xf70000>;
+			};
+		};
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e000>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <1>;
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+

--- a/target/linux/ramips/dts/mt7621_comfast_cf-ew72-v2.dts
+++ b/target/linux/ramips/dts/mt7621_comfast_cf-ew72-v2.dts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "comfast,cf-ew72-v2", "mediatek,mt7621-soc";
+	model = "COMFAST CF-EW72 V2";
+	
+	// There are at least two HW variants of cf-ew72-v2: 
+	// With external RAM chip and with integrated RAM (RAM chip not soldered).
+	// Both act same.
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		// The only both visible and controllable indicator is wifi LED.
+		// CF-EW72 have 8 LEDs: 
+		//  "wlan" is the only LED is controllable with GPIO and have proper hole in shell.
+		//  "power", "wan" and "lan" LEDs have proper holes in shell, but can not be controlled with GPIO
+		//  "hidden_led_2" and "hidden_led_4" can be controlled with GPIO, but have no proper holes in shell
+		//     "hidden_led_2" is between POWER and WAN LEDs
+		//     "hidden_led_4" is between WAN and LAN LEDs
+		//  "noconn_led_6" and "noconn_led_8" exist, but have no proper holes in shell and not controlled:
+		//     "noconn_led_6" is between LAN and WLAN LEDs
+		//     "noconn_led_8" is after WLAN LED
+		
+		// LED "hidden_led_2" between POWER and WAN LEDs is controllable with GPIO, but it has no proper hole in shell;
+		// LED "hidden_led_4" between WAN and LAN LEDs is controllable with GPIO, but it has no proper hole in shell;
+
+		// TABLE of LEDs. All leds are blue.
+		//
+		// Place (WAN->ANT) | Num | GPIO | LED name (LuCI)   | Note
+		// -----------------|-----|-----------------------------------------------------------------------------------------         
+		//            power | 1   |      |                   | POWER LED. Not controlled with GPIO.
+		//     hidden_led_2 | 2   | 13   | blue:hidden_led_2 | This LED does not have proper hole in shell.
+		//              wan | 3   |      |                   | WAN LED. Not controlled with GPIO.
+		//     hidden_led_4 | 4   | 16   | blue:hidden_led_4 | This LED does not have proper hole in shell.
+		//              lan | 5   |      |                   | LAN LED. Not controlled with GPIO.
+		//     noconn_led_6 | 6   |      |                   | Not controlled with GPIO, possibly not connected
+		//             wlan | 7   | 15   | blue:wlan         | WLAN LED. Wireless indicator.
+		//     noconn_led_8 | 8   |      |                   | Not controlled with GPIO, possibly not connected
+
+		hidden_led_2_blue {
+			label = "blue:hidden_led_2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		hidden_led_4_blue {
+			label = "blue:hidden_led_4";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan_blue {
+			label = "blue:wlan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	aliases {
+		label-mac-device = &wan;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "w25q128";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,fast-read;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+			
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+			
+			factory: partition@40000  {
+				label = "factory";
+				compatible = "nvmem-cells";
+				reg = <0x40000 0x10000>;
+				read-only;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+					macaddr_factory_e000: macaddr@e000 {
+						compatible = "mac-base";
+						reg = <0xe000 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					// Serial number can be found in "factory" at 0xE100. 
+					//   it starts and ends with double quotes `"` and is ASCII string
+				};
+			};
+			
+			partition@50000  {
+				label = "firmware";
+				compatible = "denx,uimage";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&gpio {
+	groups = "i2c", "uart2", "uart3", "sdhci", "jtag";
+	function = "gpio";
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi_2_4_ghz: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		// Wi-Fi device reads it's MAC address from EEPROM (&factory + 4)
+		// adding anything related to mac-address here will cause use random MAC
+	};
+};
+
+&pcie1 {
+	wifi_5_0_ghz: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		// Wi-Fi device reads it's MAC address from EEPROM, (&factory + 0x8000 + 4)
+		// adding anything related to mac-address here will cause use random MAC.
+	};
+};
+
+&pcie2 {
+	status = "disabled";
+};
+
+&switch0 {
+	mediatek,mcm;
+	ports {
+		wan: port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e000 1>;
+			nvmem-cell-names = "mac-address";
+		};
+		
+		lan: port@1 {
+			status = "okay";
+			label = "lan";
+			nvmem-cells = <&macaddr_factory_e000 0>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_meig_slt866.dts
+++ b/target/linux/ramips/dts/mt7621_meig_slt866.dts
@@ -1,0 +1,245 @@
+#include "mt7621.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "meig,slt866", "mediatek,mt7621-soc";
+	model = "MeiG SLT866";
+
+	aliases {
+		led-boot = &led_internet;
+		led-failsafe = &led_internet;
+		led-upgrade = &led_internet;
+		label-mac-device = &gmac1;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		signal4 {
+			label = "blue:signal4";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		lanwan {
+			label = "blue:lanwan";
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_internet: internet {
+			label = "blue:internet";
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi {
+			label = "blue:wifi";
+			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		signal3 {
+			label = "blue:signal3";
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		signal2 {
+			label = "blue:signal2";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		signal1 {
+			label = "blue:signal1";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	regulator-pa-5g {
+		compatible = "regulator-fixed";
+		regulator-name = "pa-5g";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		reg = <0>;
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <20000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				label = "Factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+				compatible = "nvmem-cells";
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
+			};
+
+			partition@50000 {
+				label = "firmware";
+				compatible = "denx,uimage";
+				reg = <0x50000 0xf90000>;
+			};
+
+			partition@fe0000 {
+				label = "m_custom";
+				reg = <0xfe0000 0x20000>;
+				read-only;
+				compatible = "nvmem-cells";
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_custom_0: macaddr@0 {
+						reg = <0x0 0xc>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_custom_40: macaddr@40 {
+						reg = <0x40 0xc>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_custom_100: macaddr@100 {
+						reg = <0x100 0xc>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_custom_140: macaddr@140 {
+						reg = <0x140 0xc>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@1000000 {
+				label = "fota_bak";
+				reg = <0x1000000 0x1000000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_custom_40 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_custom_0 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@3 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_custom_100 0>;
+		nvmem-cell-names = "eeprom", "mac-address";
+	};
+};
+
+&pcie1 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_custom_140 0>;
+		nvmem-cell-names = "eeprom", "mac-address";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -513,6 +513,20 @@ define Device/bolt_arion
 endef
 TARGET_DEVICES += bolt_arion
 
+define Device/comfast_cf-e390ax
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 15808k
+  DEVICE_VENDOR := ComFast
+  DEVICE_MODEL := CF-E390AX
+  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
+	check-size | append-metadata
+  IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | check-size
+endef
+TARGET_DEVICES += comfast_cf-e390ax
+
 define Device/cudy_m1800
   $(Device/dsa-migration)
   DEVICE_VENDOR := Cudy

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1552,6 +1552,17 @@ define Device/mediatek_mt7621-eval-board
 endef
 TARGET_DEVICES += mediatek_mt7621-eval-board
 
+define Device/meig_slt866
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 15104k
+  DEVICE_VENDOR := MeiG
+  DEVICE_MODEL := SLT866
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
+	kmod-usb-net-qmi-wwan kmod-usb-serial-option kmod-usb3 \
+	kmod-usb-net-rndis
+endef
+TARGET_DEVICES += meig_slt866
+
 define Device/mercusys_mr70x-v1
   $(Device/dsa-migration)
   $(Device/tplink-safeloader)

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -527,6 +527,21 @@ define Device/comfast_cf-e390ax
 endef
 TARGET_DEVICES += comfast_cf-e390ax
 
+define Device/comfast_cf-ew72-v2
+    $(Device/dsa-migration)
+    $(Device/uimage-lzma-loader)
+    IMAGE_SIZE := 15808k
+    DEVICE_VENDOR := ComFast
+    DEVICE_MODEL := CF-EW72 V2
+    DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
+        -uboot-envtools
+    IMAGES += factory.bin
+    IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
+        check-size | append-metadata
+    IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | check-size
+endef
+TARGET_DEVICES += comfast_cf-ew72-v2
+
 define Device/cudy_m1800
   $(Device/dsa-migration)
   DEVICE_VENDOR := Cudy

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -137,6 +137,10 @@ linksys,ea8100-v2)
 	ucidef_set_led_netdev "lan4" "lan4 link" "green:lan4" "lan4" "link"
 	ucidef_set_led_netdev "wan" "wan link" "green:wan" "wan" "link"
 	;;
+meig,slt866)
+	ucidef_set_led_netdev "lan" "eth" "blue:lanwan" "lan" "link tx rx"
+	ucidef_set_led_netdev "wwan0" "net" "blue:internet" "wwan0" "link tx rx"
+	;;
 mikrotik,routerboard-760igs)
 	ucidef_set_led_netdev "sfp" "SFP" "blue:sfp" "sfp"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -146,7 +146,8 @@ ramips_setup_interfaces()
 		ucidef_set_interface "qtn" ifname "eth1" protocol "static" ipaddr "1.1.1.1" netmask "255.255.255.0"
 		;;
 	comfast,cf-e390ax|\
-	comfast,cf-ew72-v2)
+	comfast,cf-ew72-v2|\
+	meig,slt866)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
 	*)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -145,7 +145,8 @@ ramips_setup_interfaces()
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		ucidef_set_interface "qtn" ifname "eth1" protocol "static" ipaddr "1.1.1.1" netmask "255.255.255.0"
 		;;
-	comfast,cf-e390ax)
+	comfast,cf-e390ax|\
+	comfast,cf-ew72-v2)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
 	*)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -145,6 +145,9 @@ ramips_setup_interfaces()
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		ucidef_set_interface "qtn" ifname "eth1" protocol "static" ipaddr "1.1.1.1" netmask "255.255.255.0"
 		;;
+	comfast,cf-e390ax)
+		ucidef_set_interfaces_lan_wan "lan" "wan"
+		;;
 	*)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;
@@ -197,6 +200,11 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii board_data "mac")
 		lan_mac=$wan_mac
 		label_mac=$wan_mac
+		;;
+	comfast,cf-e390ax)
+		lan_mac=$(cat /sys/class/net/eth0/address)
+		label_mac=$lan_mac
+		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
 	dlink,dir-860l-b1)
 		lan_mac=$(mtd_get_mac_ascii factory lanmac)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -27,6 +27,10 @@ case "$board" in
 		hw_mac_addr=$(macaddr_unsetbit $hw_mac_addr 28)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $hw_mac_addr > /sys${DEVPATH}/macaddress
 		;;
+	comfast,cf-e390ax)
+		[ "$PHYNBR" = "0" ] && echo -n "$(mtd_get_mac_binary factory 0x0004)" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && echo -n "$(mtd_get_mac_binary factory 0x8004)" > /sys${DEVPATH}/macaddress
+		;;
 	cudy,x6-v1|\
 	cudy,x6-v2)
 		hw_mac_addr="$(mtd_get_mac_binary bdinfo 0xde00)"


### PR DESCRIPTION
Pick commits adding new ramips/mt7621 devices from main branch to openwrt-23.05 branch:
 * ComFast CF-E390AX https://github.com/openwrt/openwrt/commit/f24c9b9d863c2635e472e83028d28cc8d0a7c7c6
 * ComFast CF-EW72 V2 https://github.com/openwrt/openwrt/commit/ff95f859ebf710d2914472a3feeeb0d187d14459
 * MeiG SLT866 https://github.com/openwrt/openwrt/commit/f32baf6a65fbe294b9eb7b93f39b2aea1c3402ae, https://github.com/openwrt/openwrt/commit/7db87d7c6846977402899b27881824b3df4f50ab, https://github.com/openwrt/openwrt/commit/f8414f1a6fa0b784117353a93d821fa923da1aaf, https://github.com/openwrt/openwrt/commit/bc335f296740ac386e1ef09a49f1844419b0ccf9