### PR TITLE
uboot-envtools: add env settings for ubnt,unifi-6-lr-v2

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_mt7622
+++ b/package/boot/uboot-envtools/files/mediatek_mt7622
@@ -57,6 +57,9 @@ ubnt,unifi-6-lr-v2-ubootmod|\
 ubnt,unifi-6-lr-v3-ubootmod)
 	ubootenv_add_uci_config "/dev/mtd$(find_mtd_index "u-boot-env")" "0x0" "0x4000" "0x1000"
 	;;
+ubnt,unifi-6-lr-v2)
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x1000" "0x1000" "1"
+	;;
 xiaomi,redmi-router-ax6s)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x40000"
 	;;


### PR DESCRIPTION
This has been tested on two of my Unifi 6 LR v2s:

```bash
$ fw_printenv # before
Cannot parse config file '/etc/fw_env.config': No such file or directory
$ cat /etc/fw_env.config
/dev/mtd3 0x0000 0x1000 0x1000 1
$ fw_printenv
arch=arm
baudrate=115200
board=mt7622_evb
board_name=mt7622_evb
bootcmd=bootubnt
bootdelay=3
bootfile=uImage
cpu=armv7
device_model=U6-LR
ethact=mtk_eth
ethaddr=<redacted>
ethcard=AQR112C
ipaddr=<redacted>
is_default=true
loadaddr=0x5007FF28
macaddr=<redacted>
serverip=<redacted>
soc=mt7622
stderr=serial
stdin=serial
stdout=serial
vendor=mediatek
is_ble_stp=true
```

I had to reverse-engineer the working settings above to the UCI script. I don't know how to test that the change in the package would give the right fw_env.config, however. How should I go about testing that?