### PR TITLE
utils/busybox: Enable DEFAULT_FEATURE_SYSLOG_INFO

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -81,7 +81,7 @@ config BUSYBOX_DEFAULT_FEATURE_CLEAN_UP
 	default n
 config BUSYBOX_DEFAULT_FEATURE_SYSLOG_INFO
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_SYSLOG
 	bool
 	default y


### PR DESCRIPTION
Close FS#4077 (Github issue #9059) by allowing services relying on Busybox
logging utilities to also log at INFO level instead of only ERROR level.
This is possibly only relevant for cron, which currently logs all normal
events at ERROR without any possibility for the user to configure.