### PR TITLE
x86/64: Improve NVIDIA Spectrum Platform image config

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -31,9 +31,6 @@ cisco-mx100-hw)
 	ucidef_set_network_device_path "eth11" "pci0000:00/0000:00:01.1/0000:02:00.2"
 	ucidef_set_interfaces_lan_wan "mgmt eth2 eth3 eth4 eth5 eth6 eth7 eth8 eth9 eth10 eth11" "wan"
 	;;
-mellanox-technologies-ltd-msn2100)
-	ucidef_set_interface_lan "eth1 eth2 eth3 eth4 eth5 eth6 eth7 eth8 eth9 eth10 eth11 eth12 eth13 eth14 eth15 eth16"
-	;;
 pc-engines-apu1|pc-engines-apu2|pc-engines-apu3)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
 	;;

--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -4,11 +4,21 @@ define Device/generic
   DEVICE_PACKAGES += \
 	kmod-amazon-ena kmod-amd-xgbe kmod-bnx2 kmod-e1000e kmod-e1000 \
 	kmod-forcedeth kmod-fs-vfat kmod-igb kmod-igc kmod-ixgbe kmod-r8169 \
-	kmod-tg3 kmod-mlxsw-core kmod-mlxsw-pci kmod-mlxsw-i2c \
+	kmod-tg3
+  GRUB2_VARIANT := generic
+endef
+TARGET_DEVICES += generic
+
+define Device/nvidia_spectrum
+  DEVICE_VENDOR := NVIDIA
+  DEVICE_MODEL := Spectrum Platform
+  DEVICE_PACKAGES += \
+  	kmod-e1000e kmod-igb kmod-ixgbe kmod-mlx5-core kmod-fs-vfat \
+  	kmod-mlxsw-core kmod-mlxsw-pci kmod-mlxsw-i2c \
   	kmod-mlxsw-spectrum kmod-mlxsw-minimal kmod-mlxfw \
   	kmod-leds-mlxcpld kmod-lib-objagg kmod-lib-parman \
   	kmod-hwmon-coretemp kmod-hwmon-drivetemp kmod-hwmon-jc42 \
   	kmod-i2c-i801 mlxsw_spectrum-firmware
   GRUB2_VARIANT := generic
 endef
-TARGET_DEVICES += generic
+TARGET_DEVICES += nvidia_spectrum


### PR DESCRIPTION
***x86/64: decomposition nvidia spectrum platform image profile***

There are complaints that the x86/64 generic profile after add
NVIDIA Spectrum support results in generated images that are too large.

Also change the image name as the driver apparently supports
more than just spectrum-1 platforms.

***x86: remove port config for mellanox-technologies-ltd-msn2100***

NVIDIA Spectrum Platform supports Port Lanes function,
designation port config does not much sense.

Fixes: #13886
Signed-off-by: Tan Zien <nabsdh9@gmail.com>