### PR TITLE
ramips: mt7621: use lzma-loader for Sercomm NA502

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2064,6 +2064,7 @@ TARGET_DEVICES += samknows_whitebox-v8
 
 define Device/sercomm_na502
   $(Device/nand)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 20480k
   DEVICE_VENDOR := SERCOMM
   DEVICE_MODEL := NA502


### PR DESCRIPTION
This fixes a well known "LZMA ERROR 1" error on Sercomm NA502, reported on the [OpenWrt forum](https://forum.openwrt.org/t/sercomm-na502-mt7621-lzma-error-1/176942 "Sercomm NA502 - MT7621 - LZMA ERROR 1"):

Before:
```
3: System Boot system code via Flash.
## Booting image at c1140000 ...
   Image Name:   MIPS OpenWrt Linux-5.15.137
   Image Type:   MIPS Linux Kernel Image (lzma compressed)
   Data Size:    2973829 Bytes =  2.8 MB
   Load Address: 80001000
   Entry Point:  80001000
..............................................   Verifying Checksum ... OK
   Uncompressing Kernel Image ... LZMA ERROR 1 - must RESET board to recover
```

After:
```
3: System Boot system code via Flash.
## Booting image at c1140000 ...
Image Name: MIPS OpenWrt Linux-5.15.137
Image Type: MIPS Linux Kernel Image (uncompressed)
Data Size: 2979489 Bytes = 2.8 MB
Load Address: 80001000
Entry Point: 80001000
.............................................. Verifying Checksum ... OK
OK
No initrd
## Transferring control to Linux (at address 80001000) ...
## Giving linux memsize in MB, 256

Starting kernel ...



OpenWrt kernel loader for MIPS based SoC
Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org>
Decompressing kernel... done!
Starting kernel at 80001000...

[ 0.000000] Linux version 5.15.137 (builder@buildhost) (mipsel-openwrt-linux-musl-gcc (OpenWrt GCC 12.3.0 r24337+1-d6a06acaa5) 12.3.0, GNU ld (GNU Binutils) 2.40.0) #0 SMP Thu Nov 9 08:26:34 2023
[ 0.000000] SoC Type: MediaTek MT7621 ver:1 eco:3
[ 0.000000] printk: bootconsole [early0] enabled
[ 0.000000] CPU0 revision is: 0001992f (MIPS 1004Kc)
[ 0.000000] MIPS: machine is SERCOMM NA502
[ 0.000000] Initrd not found or empty - disabling initrd
...
```