### PR TITLE
[RFC] ath79: add encrypted Alpha Networks factory image for D-Link devices

### DIFF
--- a/target/linux/ath79/image/common-alpha.mk
+++ b/target/linux/ath79/image/common-alpha.mk
@@ -1,0 +1,32 @@
+DEVICE_VARS += ALPHA_KEY_IV
+
+define alpha-xor
+	$(shell X="$(1)"; Y="$(2)"; \
+		for((i=0; i<$${#X}; i++)); do \
+			printf -v x "%d" "'$${X:i:1}"; \
+			Yi=$$((i % $${#Y})); \
+			printf -v y "%d" "'$${Y:Yi:1}"; \
+			printf "%02x" $$((x ^ y ^ (i+1))); \
+		done)
+endef
+
+define Build/alpha_encimg
+	$(eval mangled_key :=$(call alpha-xor,$(word 1,$(ALPHA_KEY_IV)),$(SEAMA_SIGNATURE)))
+	$(eval mangled_iv  :=$(call alpha-xor,$(word 2,$(ALPHA_KEY_IV)),$(SEAMA_SIGNATURE)))
+	let \
+		size="$$(stat -c%s $@)" \
+		pad="(16 - (size % 16))"; \
+		dd bs=$$pad count=1 if=/dev/zero 2>/dev/null >> $@; \
+		printf '%08x' $$size | sed 's/../\\\\x&/g' | xargs echo -ne >> $@; \
+		dd bs=12 count=1 if=/dev/zero 2>/dev/null >> $@
+	$(STAGING_DIR_HOST)/bin/openssl aes-256-cbc -nosalt -nopad \
+		-K $(mangled_key) -iv $(mangled_iv) -in $@ -out $@.aes
+	mv $@.aes $@
+endef
+
+define Device/alpha-encimg
+  IMAGES += factory.bin recovery.bin
+  IMAGE/recovery.bin := $$(IMAGE/default) | pad-rootfs -x 64 | seama | \
+	seama-seal | check-size
+  IMAGE/factory.bin := $$(IMAGE/recovery.bin) | alpha_encimg
+endef

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1,3 +1,4 @@
+include ./common-alpha.mk
 include ./common-buffalo.mk
 include ./common-nec.mk
 include ./common-netgear.mk
@@ -1274,24 +1275,21 @@ endef
 TARGET_DEVICES += dlink_dir-835-a1
 
 define Device/dlink_dir-842-c
+  $(Device/alpha-encimg)
   SOC := qca9563
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-842
   KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma
   KERNEL_INITRAMFS := $$(KERNEL) | seama
-  IMAGES += factory.bin
   SEAMA_MTDBLOCK := 5
   SEAMA_SIGNATURE := wrgac65_dlink.2015_dir842
+  ALPHA_KEY_IV := xQYoRZeD726UAbRb846kO7TeNw8eZa6u zufEbNF3kUafxFiE
+  IMAGE_SIZE := 15680k
   # 64 bytes offset:
   # - 28 bytes seama_header
   # - 36 bytes of META data (4-bytes aligned)
   IMAGE/default := append-kernel | uImage lzma | \
 	pad-offset $$$$(BLOCKSIZE) 64 | append-rootfs
-  IMAGE/sysupgrade.bin := $$(IMAGE/default) | seama | pad-rootfs | \
-	check-size | append-metadata
-  IMAGE/factory.bin := $$(IMAGE/default) | pad-rootfs -x 64 | seama | \
-	seama-seal | check-size
-  IMAGE_SIZE := 15680k
 endef
 
 define Device/dlink_dir-842-c1
@@ -1312,6 +1310,7 @@ define Device/dlink_dir-842-c3
   $(Device/dlink_dir-842-c)
   DEVICE_VARIANT := C3
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  SEAMA_SIGNATURE := $$(SEAMA_SIGNATURE)EU
 endef
 TARGET_DEVICES += dlink_dir-842-c3
 

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -1,3 +1,4 @@
+include ./common-alpha.mk
 include ./common-buffalo.mk
 include ./common-nec.mk
 include ./common-senao.mk
@@ -15,14 +16,16 @@ TARGET_DEVICES += buffalo_whr-g301n
 
 define Device/dlink_dap-1720-a1
   $(Device/seama)
+  $(Device/alpha-encimg)
   SOC := qca9563
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DAP-1720
   DEVICE_VARIANT := A1
   IMAGE_SIZE := 15872k
   SEAMA_SIGNATURE := wapac28_dlink.2015_dap1720
-  DEVICE_PACKAGES := -swconfig ath10k-firmware-qca988x-ct \
-	kmod-ath10k-ct-smallbuffers rssileds
+  ALPHA_KEY_IV := qBiz6o/1RVQTtJBd3FS7FDbqogE8yoBm EfDMqWWxHCOhEqgY
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct-smallbuffers \
+		     -swconfig rssileds
 endef
 TARGET_DEVICES += dlink_dap-1720-a1
 
@@ -46,11 +49,13 @@ TARGET_DEVICES += dlink_dir-615-e4
 
 define Device/dlink_dir-859-a
   $(Device/seama)
+  $(Device/alpha-encimg)
   SOC := qca9563
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-859
   IMAGE_SIZE := 15872k
   SEAMA_SIGNATURE := wrgac37_dlink.2013gui_dir859
+  ALPHA_KEY_IV := KY0H9R2PDL3eu1J4uCVd1CK7BJ7vF1kc qbStAzIRvWeQHz5U
   DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct-smallbuffers
 endef
 


### PR DESCRIPTION
Currently, OpenWrt generates factory images for several D-Link
devices manufactured by Alpha Networks (in particular: DIR-842,
DIR-859, DAP-1720, DIR-X1860) that must be flashed via the D-Link web
recovery mode. This is cumbersome, as devices in recovery mode offer no
DHCP, and not all web browsers upload the firmware as required by
the recovery webserver ('application/octet-stream' binary form-data).

To use the vendor upgrade firmware web UI for installation, the firmware
needs to be encrypted using AES-256-CBC (with non-standard paddings and
no salt). The AES key and IV are created by mangling the key and IV
hard-coded in the GPL sources officially released by D-Link (see, e.g.,
`DIR842C3_GPL312EUb01DLink/tools/encimg/fw_sign_data.c`), and can also be
extracted from the official firmware image via `strings /htdocs/cgibin`.

 The mangling process is described by the following code excerpt:
```
 python -c 'import sys; s,k,i=sys.argv[1:]; X=lambda x: bytes(
   (j+1)^ord(a)^ord(b) for j,(a,b) in enumerate(zip(x,9*s))
   ).hex(); print(X(k),X(i))' $(SEAMA_SIGNATURE) $(32B_KEY) $(16B_IV)
```
 In fact, this is the firmware encryption method implemented by
 firmware-utils' nec-enc. An equivalent is implemented in Makefile as `alpha-xor`.

 * Rename current `factory.bin` images to `recovery.bin`
 * Add new `factory.bin` image (AES-encrypted `recovery.bin`)

Installation:
 * Web UI: http://192.168.0.1, flash `factory.bin`
 * Recovery Web UI: Keep reset button pressed during power-on,
   flash `recovery.bin` via http://192.168.0.1

Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>
Signed-off-by: Rani Hod <rani.hod@gmail.com>
