### PR TITLE
ipq807x: fix wrong define for LAN and WAN ess mask

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8070-cax1800.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8070-cax1800.dts
@@ -271,9 +271,8 @@
 &switch {
 	status = "okay";
 
-	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
-	switch_lan_bmp = <0x1e>; /* lan port bitmap */
-	switch_wan_bmp = <0x20>; /* wan port bitmap */
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
 	switch_mac_mode = <0x0>; /* mac mode for uniphy instance0*/
 	switch_mac_mode1 = <0xff>; /* mac mode for uniphy instance1*/
 	switch_mac_mode2 = <0xff>; /* mac mode for uniphy instance2*/

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-ax3600.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-ax3600.dtsi
@@ -235,9 +235,8 @@
 &switch {
 	status = "okay";
 
-	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
-	switch_lan_bmp = <0x1e>; /* lan port bitmap */
-	switch_wan_bmp = <0x20>; /* wan port bitmap */
+	switch_lan_bmp = <(ESS_PORT2 | ESS_PORT3 | ESS_PORT4)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
 	switch_mac_mode = <0x0>; /* mac mode for uniphy instance0*/
 	switch_mac_mode1 = <0xff>; /* mac mode for uniphy instance1*/
 	switch_mac_mode2 = <0xff>; /* mac mode for uniphy instance2*/
@@ -245,10 +244,6 @@
 	tm_tick_mode = <0>; /* tm tick mode */
 
 	qcom,port_phyinfo {
-		port@0 {
-			port_id = <1>;
-			phy_address = <0>;
-		};
 		port@1 {
 			port_id = <2>;
 			phy_address = <1>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
@@ -343,9 +343,8 @@
 &switch {
 	status = "okay";
 
-	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
-	switch_lan_bmp = <0x3e>; /* lan port bitmap */
-	switch_wan_bmp = <0x40>; /* wan port bitmap */
+	switch_lan_bmp = <ESS_PORT5>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
 	switch_mac_mode = <0xff>; /* mac mode for uniphy instance0*/
 	switch_mac_mode1 = <0xf>; /* mac mode for uniphy instance1*/
 	switch_mac_mode2 = <0xf>; /* mac mode for uniphy instance2*/

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
@@ -321,9 +321,8 @@
 &switch {
 	status = "okay";
 
-	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
-	switch_lan_bmp = <0x3e>; /* lan port bitmap */
-	switch_wan_bmp = <0xc0>; /* wan port bitmap */
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4 | ESS_PORT5)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
 	switch_mac_mode = <0xb>; /* mac mode for uniphy instance0*/
 	switch_mac_mode1 = <0xd>; /* mac mode for uniphy instance1*/
 	switch_mac_mode2 = <0xd>; /* mac mode for uniphy instance2*/

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
@@ -325,9 +325,8 @@
 &switch {
 	status = "okay";
 
-	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
-	switch_lan_bmp = <0x3e>; /* lan port bitmap */
-	switch_wan_bmp = <0x40>; /* wan port bitmap */
+	switch_lan_bmp = <ESS_PORT5>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
 	switch_mac_mode = <0xff>; /* mac mode for uniphy instance0*/
 	switch_mac_mode1 = <0xf>; /* mac mode for uniphy instance1*/
 	switch_mac_mode2 = <0xf>; /* mac mode for uniphy instance2*/

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
@@ -382,9 +382,8 @@
 &switch {
 	status = "okay";
 
-	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
-	switch_lan_bmp = <0x1e>; /* lan port bitmap */
-	switch_wan_bmp = <0x20>; /* wan port bitmap */
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
 	switch_mac_mode = <0xb>; /* mac mode for uniphy instance0*/
 	switch_mac_mode1 = <0xc>; /* mac mode for uniphy instance1*/
 	switch_mac_mode2 = <0xff>; /* mac mode for uniphy instance2*/

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-dl-wrx36.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-dl-wrx36.dts
@@ -169,9 +169,8 @@
 &switch {
 	status = "okay";
 
-	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
-	switch_lan_bmp = <0x3e>; /* lan port bitmap */
-	switch_wan_bmp = <0x40>; /* wan port bitmap */
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
 	switch_mac_mode = <0xb>; /* mac mode for uniphy instance0*/
 	switch_mac_mode1 = <0xff>; /* mac mode for uniphy instance1*/
 	switch_mac_mode2 = <0xc>; /* mac mode for uniphy instance2*/

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
@@ -186,9 +186,8 @@
 &switch {
 	status = "okay";
 
-	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
-	switch_lan_bmp = <0x1e>; /* lan port bitmap */
-	switch_wan_bmp = <0x60>; /* wan port bitmap */
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
 	switch_mac_mode = <0x0>; /* mac mode for uniphy instance0*/
 	switch_mac_mode1 = <0xe>; /* mac mode for uniphy instance1*/
 	switch_mac_mode2 = <0xd>; /* mac mode for uniphy instance2*/

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax218.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax218.dts
@@ -89,9 +89,7 @@
 &switch {
 	status = "okay";
 
-	switch_cpu_bmp = <0x1>;
-	switch_lan_bmp = <0x3e>;
-	switch_wan_bmp = <0x40>;
+	switch_wan_bmp = <ESS_PORT6>;
 	switch_mac_mode = <0x00>;
 	switch_mac_mode1 = <0xff>;
 	switch_mac_mode2 = <0x0f>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax620.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax620.dts
@@ -117,9 +117,7 @@
 &switch {
 	status = "okay";
 
-	switch_cpu_bmp = <0x01>;	
-	switch_lan_bmp = <0x3e>;
-	switch_wan_bmp = <0x40>;
+	switch_wan_bmp = <ESS_PORT6>;
 	switch_mac_mode = <0x00>;
 	switch_mac_mode1 = <0xff>;
 	switch_mac_mode2 = <0x0f>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
@@ -388,9 +388,8 @@
 &switch {
 	status = "okay";
 
-	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
-	switch_lan_bmp = <0x3e>; /* lan port bitmap */
-	switch_wan_bmp = <0x40>; /* wan port bitmap */
+	switch_lan_bmp = <(ESS_PORT2 | ESS_PORT3 | ESS_PORT4)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
 	switch_mac_mode = <0x0>; /* mac mode for uniphy instance0*/
 	switch_mac_mode1 = <0x0f>; /* mac mode for uniphy instance1*/
 	switch_mac_mode2 = <0x0f>; /* mac mode for uniphy instance2*/

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-ess.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-ess.dtsi
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include <dt-bindings/net/qcom-ipq-ess.h>
+
 &clocks {
 	bias_pll_cc_clk {
 		compatible = "fixed-clock";
@@ -19,8 +21,8 @@
 		compatible = "qcom,ess-switch-ipq807x";
 		reg = <0x3a000000 0x1000000>;
 		switch_access_mode = "local bus";
-		switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
-		switch_inner_bmp = <0x80>; /*inner port bitmap*/
+		switch_cpu_bmp = <ESS_PORT0>;  /* cpu port bitmap */
+		switch_inner_bmp = <ESS_PORT7>; /*inner port bitmap*/
 		clocks = <&gcc GCC_CMN_12GPLL_AHB_CLK>,
 			 <&gcc GCC_CMN_12GPLL_SYS_CLK>,
 			 <&gcc GCC_UNIPHY0_AHB_CLK>,

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
@@ -298,9 +298,8 @@
 &switch {
 	status = "okay";
 
-	switch_cpu_bmp = <0x1>;
-	switch_lan_bmp = <0x3e>;
-	switch_wan_bmp = <0x40>;
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4 | ESS_PORT5)>;
+	switch_wan_bmp = <ESS_PORT6>;
 	switch_mac_mode = <0x0>;
 	switch_mac_mode1 = <0xf>;
 	switch_mac_mode2 = <0xd>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-rax120v2.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-rax120v2.dts
@@ -195,8 +195,8 @@
 &switch {
 	status = "okay";
 
-	switch_lan_bmp = <0x3e>; /* lan port bitmap */
-	switch_wan_bmp = <0x40>; /* wan port bitmap */
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4 | ESS_PORT5)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
 	switch_mac_mode = <0x0>; /* mac mode for uniphy instance0*/
 	switch_mac_mode1 = <0xff>; /* mac mode for uniphy instance1*/
 	switch_mac_mode2 = <0xd>; /* mac mode for uniphy instance2*/

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
@@ -150,10 +150,9 @@
 
 &switch {
 	status = "okay";
-
-	switch_cpu_bmp = <0x01>;	
-	switch_lan_bmp = <0x3e>;
-	switch_wan_bmp = <0x40>;
+	
+	switch_lan_bmp = <ESS_PORT4>;
+	switch_wan_bmp = <ESS_PORT6>;
 	switch_mac_mode = <0x00>;
 	switch_mac_mode1 = <0xff>;
 	switch_mac_mode2 = <0x0d>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
@@ -267,9 +267,8 @@
 &switch {
 	status = "okay";
 
-	switch_cpu_bmp = <0x1>;
-	switch_lan_bmp = <0x3e>;
-	switch_wan_bmp = <0x40>;
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4 | ESS_PORT5)>;
+	switch_wan_bmp = <ESS_PORT6>;
 	switch_mac_mode = <0xb>;
 	switch_mac_mode1 = <0xd>;
 	switch_mac_mode2 = <0xd>;

--- a/target/linux/qualcommax/files/include/dt-bindings/net/qcom-ipq-ess.h
+++ b/target/linux/qualcommax/files/include/dt-bindings/net/qcom-ipq-ess.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#ifndef _DT_BINDINGS_NET_QCOM_IPQ_ESS_H
+#define _DT_BINDINGS_NET_QCOM_IPQ_ESS_H
+
+#define ESS_PORT0	0x1
+#define ESS_PORT1	0x2
+#define ESS_PORT2	0x4
+#define ESS_PORT3	0x8
+#define ESS_PORT4	0x10
+#define ESS_PORT5	0x20
+#define ESS_PORT6	0x40
+#define ESS_PORT7	0x80
+
+#endif /* _DT_BINDINGS_NET_QCOM_IPQ_ESS_H */


### PR DESCRIPTION
switch_lan_bmp and switch_wan_bmp have wrong values and now cause problems with the new version of the qca-ssdk.

Fix the wrong entry and drop the redundant switch_cpu_bmp.

Also introduce some convenient define to better understand values in this map.