### PR TITLE
base-files: fix uid/gid auto-enumeration to avoid 16-bit limit

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -408,7 +408,7 @@ group_add_next() {
 		return
 	fi
 	gids=$(cut -d: -f3 ${IPKG_INSTROOT}/etc/group)
-	gid=65536
+	gid=32768
 	while echo "$gids" | grep -q "^$gid$"; do
 		gid=$((gid + 1))
 	done
@@ -439,7 +439,7 @@ user_add() {
 	local rc
 	[ -z "$uid" ] && {
 		uids=$(cut -d: -f3 ${IPKG_INSTROOT}/etc/passwd)
-		uid=65536
+		uid=32768
 		while echo "$uids" | grep -q "^$uid$"; do
 			uid=$((uid + 1))
 		done


### PR DESCRIPTION
uid/gid range auto-set in functions.sh should start within 16bit unsigned integer range to avoid "wraparound" issues with permissions where jffs2  is employed for storage and chown 65536 (i.e., currently first auto-created user) becomes equivalent to chown 0. See #13927 for details.

The patch was tested on Archer A7 v5 running OpenWRT 23.05

(Incidentally, this should also fix unrelated but symptomatically similar permissions issues for LXC instances)