### PR TITLE
strace: update to 6.6

### DIFF
--- a/package/devel/strace/Makefile
+++ b/package/devel/strace/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=strace
-PKG_VERSION:=6.5
+PKG_VERSION:=6.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://strace.io/files/$(PKG_VERSION)
-PKG_HASH:=dfb051702389e1979a151892b5901afc9e93bbc1c70d84c906ade3224ca91980
+PKG_HASH:=421b4186c06b705163e64dc85f271ebdcf67660af8667283147d5e859fc8a96c
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Release Notes:
https://github.com/strace/strace/releases/tag/v6.6
