### PR TITLE
valgrind: update to 3.22.0

### DIFF
--- a/package/devel/valgrind/Makefile
+++ b/package/devel/valgrind/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=valgrind
-PKG_VERSION:=3.21.0
+PKG_VERSION:=3.22.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceware.org/pub/valgrind/
-PKG_HASH:=10ce1618bb3e33fad16eb79552b0a3e1211762448a0d7fce11c8a6243b9ac971
+PKG_HASH:=c811db5add2c5f729944caf47c4e7a65dcaabb9461e472b578765dd7bf6d2d4c
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=GPL-2.0+

--- a/package/devel/valgrind/patches/130-mips_fix_soft_float.patch
+++ b/package/devel/valgrind/patches/130-mips_fix_soft_float.patch
@@ -48,7 +48,7 @@ This fixes the following error message when compiling with a GCC 10 MIPS BE 32:
  
 --- a/coregrind/m_machine.c
 +++ b/coregrind/m_machine.c
-@@ -2106,6 +2106,7 @@ Bool VG_(machine_get_hwcaps)( void )
+@@ -2109,6 +2109,7 @@ Bool VG_(machine_get_hwcaps)( void )
             we are using alternative way to determine FP mode */
          ULong result = 0;
  
@@ -56,7 +56,7 @@ This fixes the following error message when compiling with a GCC 10 MIPS BE 32:
          if (!VG_MINIMAL_SETJMP(env_unsup_insn)) {
             __asm__ volatile (
                ".set push\n\t"
-@@ -2123,6 +2124,9 @@ Bool VG_(machine_get_hwcaps)( void )
+@@ -2126,6 +2127,9 @@ Bool VG_(machine_get_hwcaps)( void )
  
             fpmode = (result != 0x3FF0000000000000ull);
          }


### PR DESCRIPTION
Release Notes:
https://sourceware.org/git/?p=valgrind.git;a=blob;f=NEWS;h=f11da4be88687b8768268953253ddba13184bedf;hb=bd4db67b1d386c352040b1d8fab82f5f3340fc59

Refresh patch:
- 30-mips_fix_soft_float.patch
