### PR TITLE
ramips: mt7621: extend LED-button script for WSM20

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/rc.button/lights_toggle
+++ b/target/linux/ramips/mt7621/base-files/etc/rc.button/lights_toggle
@@ -1,16 +1,41 @@
 #!/bin/sh
 
-[[ "${ACTION}" = "released" ]] || exit 0
-
+# include to get to $(board_name)
 . /lib/functions.sh
 
+# set led path depending on model
 case "$(board_name)" in
 tplink,ec330-g5u-v1)
 	led_light="/sys/class/gpio/led-light/value"
-	echo "$((!$(cat $led_light)))" > "$led_light"
+	led_logic="toggle"
 ;;
-	*)
+# on/off buttons
+zyxel,wsm20)
+	led_light="/sys/class/leds/white:system/brightness"
+	led_logic="on/off"
+;;
+*)
+	return 0
 ;;
 esac
+
+# set new state depending on button logic
+case "$led_logic" in
+toggle)
+        [[ "${ACTION}" = "released" ]] || exit 0
+	led_value=$((!$(cat $led_light)))
+;;
+on/off)
+        [ "${ACTION}" = "released" ] || [ "${ACTION}" = "pressed" ] || exit 0
+	led_value="0"
+        [ "${ACTION}" = "pressed" ]  || led_value="1"
+;;
+*)
+	return 0
+;;
+esac
+
+# finally, apply new state
+echo "$led_value" > "$led_light"
 
 return 0

--- a/target/linux/ramips/mt7621/base-files/etc/rc.button/lights_toggle
+++ b/target/linux/ramips/mt7621/base-files/etc/rc.button/lights_toggle
@@ -1,16 +1,53 @@
 #!/bin/sh
 
-[[ "${ACTION}" = "released" ]] || exit 0
-
+# include to get to $(board_name)
 . /lib/functions.sh
+# include to get to $(get_dt_led)
+. /lib/functions/leds.sh
 
+# functions to implement the button logic
+# note: assume $ACTION to be set and have to set $led_value as new value or exit
+
+## toggle on/off on "released" events
+## needs as first argument the path to a file containing the old value
+btn_toggle() {
+	# ignore "pressed" events
+	[ "${ACTION}" = "released" ] || exit 0
+	read -r led_value < "$1" || exit 1
+	[ "$led_value" = "0" ] && led_value=1 || led_value=0
+}
+## "released": 1 "pressed" -> 0
+btn_onoff() {
+	led_value=0
+	[ "${ACTION}" = "pressed" ] || led_value=1
+}
+
+# only handle "released" and "pressed" events here
+[ "${ACTION}" = "released" ] || [ "${ACTION}" = "pressed" ] || exit 0
+
+# select and call logic depending on model
 case "$(board_name)" in
 tplink,ec330-g5u-v1)
-	led_light="/sys/class/gpio/led-light/value"
-	echo "$((!$(cat $led_light)))" > "$led_light"
+	# this is a raw gpio device, so do things by hand
+	led_light_path="/sys/class/gpio/led-light/value"
+	# determine new value based on button logic
+	btn_toggle "${led_light_path}"
+	# set the value directly
+	echo "${led_value}" > "${led_light_path}"
 ;;
-	*)
+zyxel,wsm20)
+	# get the name/label of the led, e.g., here: "white:system"
+	led_light_name="$(get_dt_led running)"
+	# determine new value based on button logic
+	btn_onoff
+	# set the value using led_on/led_off helpers
+	if [ "${led_value}" -gt 0 ]; then
+		led_on "${led_light_name}"
+	else
+		led_off "${led_light_name}"
+	fi
+;;
+*)
+	exit 0
 ;;
 esac
-
-return 0


### PR DESCRIPTION
This script (/etc/rc.button/lights_toggle) so far only worked for TP-Link EC330-G5u v1 and now got extended
- to include support for Zyxel WSM20, which also has a button that is supposed to control the front (main) LED, and
- to make it easy to add support for other models as well.

This is a more than a simple 'add this model'-patch since
- the path to the LED is different for the two currently supported models, and
- the logic behind the buttons is different: for the TP-Link this is apparently a toggle button, while the WSM20 has an on/off button (that stays in either on or off state until pressed again).

The current patch now first sets, depending on model, the LED path and the type of button (toggle or on/off) and then handles the LED control depending on that type. This should make it easy to add new models while keeping the amount of code duplication small.