### PR TITLE
ramips: D-Link Dxx-1xx0 image fixes

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -676,14 +676,12 @@ TARGET_DEVICES += dlink_covr-x1860-a1
 
 define Device/dlink_dxx-1xx0-x1
   DEVICE_VENDOR := D-Link
-  DEVICE_PACKAGES := kmod-mt7615-firmware rssileds
+  DEVICE_PACKAGES := kmod-mt7615-firmware rssileds -uboot-envtools
   IMAGE_SIZE := 16064k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | \
-    check-size 11009992 | pad-to 11009992 | \
-    append-md5sum-ascii-salted ffff | \
-    append-string $$(DLINK_HWID) | \
-    check-size
+  IMAGE/factory.bin := append-kernel | append-rootfs | \
+    pad-rootfs -x 60 | append-md5sum-ascii-salted ffff | \
+    append-string $$$$(DLINK_HWID) | check-size
 endef
 
 define Device/dlink_dap-1620-b1


### PR DESCRIPTION
Three fixes for D-Link DAP-1620 rev B and its twin D-Link DRA-1360:

1. `uboot-envtools` is removed from default package list.
2. Makefile variable is doubly escaped, i.e. `$$$$(DLINK_HWID)`.
3. Previously the size of `factory.bin` was always 10.5 MiB, same as D-Link firmwares. This commit makes it possible to use smaller images (with no lost space due to padding) as well as larger images. Tested successfully flashing a 6.5 MiB image and a 14.5 MiB image.

Recall that factory images need to be installed via D-Link Web Recovery (at http://192.168.0.50/, server ignores pings and DHCP requests).

P.S.
I implemented the OEM firmware encryption algorithm, so firmware can be flashed via OEM firmware, but after successful flashing the device reboots to web recovery, so further debugging is required.