### PR TITLE
devel/gdb: Disable libzstd explicitly (to avoid dependency)

### DIFF
--- a/package/devel/gdb/Makefile
+++ b/package/devel/gdb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gdb
 PKG_VERSION:=13.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/gdb
@@ -58,6 +58,7 @@ CONFIGURE_ARGS+= \
 	--with-system-zlib \
 	--without-expat \
 	--without-lzma \
+	--without-zstd \
 	--disable-unit-tests \
 	--disable-ubsan \
 	--disable-sim \


### PR DESCRIPTION
gdb 13 has got libzstd support, and libzstd gets detected at buildbot build. 
Explicitly disable it to avoid dependency.

Fixes: f79de8ec65 ("gdb: Update to 13.2")

run-tested with mt7622/rt3200

------

Buildbot builds all libraries, so also libzstd gets detected.
That causes  missing dependency errors like below:

https://downloads.openwrt.org/snapshots/faillogs/aarch64_cortex-a72/base/gdb/compile.txt

```
checking pkg-config is at least version 0.9.0... yes
yes
checking for libzstd >= 1.4.0... checking for fnmatch... yes
checking for mbsrtowcs... yes
...
make[4]: Leaving directory '/builder/shared-workdir/build/sdk/build_dir/target-aarch64_cortex-a72_musl/gdb-13.2'
Package gdb is missing dependencies for the following libraries:
libzstd.so.1
make[3]: *** [Makefile:106: /builder/shared-workdir/build/sdk/bin/packages/aarch64_cortex-a72/base/gdb_13.2-1_aarch64_cortex-a72.ipk] Error 1
```


