### PR TITLE
CI: add issue labeller action

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -20,6 +20,15 @@ body:
     validations:
       required: true
   - type: input
+    id: release
+    attributes:
+      label: OpenWrt release
+      description: |
+        The OpenWrt release or commit hash where this bug occurs (use command below).
+        ```. /etc/openwrt_release && echo $DISTRIB_RELEASE```
+    validations:
+      required: true
+  - type: input
     id: target
     attributes:
       label: OpenWrt target/subtarget

--- a/.github/workflows/issue-labeller.yml
+++ b/.github/workflows/issue-labeller.yml
@@ -1,0 +1,11 @@
+name: Issue Labeller
+on:
+  issues:
+    types: [ opened ]
+
+jobs:
+  label-component:
+    name: Validate and Tag Bug Report
+    permissions:
+      issues: write
+    uses: openwrt/actions-shared-workflows/.github/workflows/issue-labeller.yml@main


### PR DESCRIPTION
Add issue labeler action. This action will parse BUG issue from the
template and will make validation on the insert data.

The action will:
- Tag the issue with SNAPSHOT or release based on the provided release
- Tag the issue with the reported tag
- Tag the issue with the image kind (Official or Self Built)
- Validate the reported version exist
- Validate the reported release exist
- Validate the reported device exist

Will also tag the issue with useful tag or flag the issue as invalid.
Will also comment the issue with the invalid info provided.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

---

@ynezz @aparcar @hauke This can be tested here https://github.com/Ansuel/openwrt/issues

(if the thing fails on device validation is because the dump-target-info.pl needs to be backported)

The logic is that we checkout the bug template from main...
We parse the release and then
We checkout to that release

That way we can do version validation, target/subtarget and device since they can change from one release to another.

The real action is here https://github.com/openwrt/actions-shared-workflows/blob/main/.github/workflows/issue-labeller.yml (I had lots of fun with using raw github Rest API as I hate using random github actions on the marketplace)
(actually here was a similar action that did some kind of tag addition based on BUG template but I decided this approach to make all kind of validation and parsing for the target and release)

We continue on using the action-shared-workflows repo as it's the best way to keep all the branch using the same action and not pollute with CI related commits.