### PR TITLE
mac80211: realtek: fix rtw88 driver and add fw

### DIFF
--- a/package/firmware/linux-firmware/realtek.mk
+++ b/package/firmware/linux-firmware/realtek.mk
@@ -145,3 +145,32 @@ define Package/rtl8822ce-firmware/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtw88/rtw8822c_wow_fw.bin $(1)/lib/firmware/rtw88
 endef
 $(eval $(call BuildPackage,rtl8822ce-firmware))
+
+Package/rtl8851be-firmware = $(call Package/firmware-default,RealTek RTL8851BE firmware)
+define Package/rtl8851be-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/rtw89
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtw89/rtw8851b_fw.bin $(1)/lib/firmware/rtw89
+endef
+$(eval $(call BuildPackage,rtl8851be-firmware))
+
+Package/rtl8852ae-firmware = $(call Package/firmware-default,RealTek RTL8852AE firmware)
+define Package/rtl8852ae-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/rtw89
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtw89/rtw8852a_fw.bin $(1)/lib/firmware/rtw89
+endef
+$(eval $(call BuildPackage,rtl8852ae-firmware))
+
+Package/rtl8852be-firmware = $(call Package/firmware-default,RealTek RTL8852BE firmware)
+define Package/rtl8852be-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/rtw89
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtw89/rtw8852b_fw.bin $(1)/lib/firmware/rtw89
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtw89/rtw8852b_fw-1.bin $(1)/lib/firmware/rtw89
+endef
+$(eval $(call BuildPackage,rtl8852be-firmware))
+
+Package/rtl8852ce-firmware = $(call Package/firmware-default,RealTek RTL8852CE firmware)
+define Package/rtl8852ce-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/rtw89
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtw89/rtw8852c_fw.bin $(1)/lib/firmware/rtw89
+endef
+$(eval $(call BuildPackage,rtl8852ce-firmware))

--- a/package/firmware/linux-firmware/realtek.mk
+++ b/package/firmware/linux-firmware/realtek.mk
@@ -86,6 +86,13 @@ define Package/rtl8723bu-firmware/install
 endef
 $(eval $(call BuildPackage,rtl8723bu-firmware))
 
+Package/rtl8723de-firmware = $(call Package/firmware-default,RealTek RTL8723DE firmware)
+define Package/rtl8723de-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/rtw88
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtw88/rtw8723d_fw.bin $(1)/lib/firmware/rtw88
+endef
+$(eval $(call BuildPackage,rtl8723de-firmware))
+
 Package/rtl8761a-firmware = $(call Package/firmware-default,RealTek RTL8761A firmware)
 define Package/rtl8761a-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtl_bt
@@ -116,6 +123,13 @@ define Package/rtl8821ae-firmware/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8821aefw_wowlan.bin $(1)/lib/firmware/rtlwifi
 endef
 $(eval $(call BuildPackage,rtl8821ae-firmware))
+
+Package/rtl8821ce-firmware = $(call Package/firmware-default,RealTek RTL8821CE firmware)
+define Package/rtl8821ce-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/rtw88
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtw88/rtw8821c_fw.bin $(1)/lib/firmware/rtw88
+endef
+$(eval $(call BuildPackage,rtl8821ce-firmware))
 
 Package/rtl8822be-firmware = $(call Package/firmware-default,RealTek RTL8822BE firmware)
 define Package/rtl8822be-firmware/install

--- a/package/kernel/mac80211/realtek.mk
+++ b/package/kernel/mac80211/realtek.mk
@@ -2,7 +2,8 @@ PKG_DRIVERS += \
 	rtlwifi rtlwifi-pci rtlwifi-btcoexist rtlwifi-usb rtl8192c-common \
 	rtl8192ce rtl8192se rtl8192de rtl8192cu rtl8723bs rtl8821ae \
 	rtl8xxxu rtw88 rtw88-pci rtw88-usb rtw88-8821c rtw88-8822b rtw88-8822c \
-	rtw88-8723d rtw88-8821ce rtw88-8822be rtw88-8822bu rtw88-8822ce rtw88-8723de
+	rtw88-8723d rtw88-8821ce rtw88-8821cu rtw88-8822be rtw88-8822bu \
+	rtw88-8822ce rtw88-8723de
 
 config-$(call config_package,rtlwifi) += RTL_CARDS RTLWIFI
 config-$(call config_package,rtlwifi-pci) += RTLWIFI_PCI
@@ -27,6 +28,7 @@ config-$(call config_package,rtw88-pci) += RTW88_PCI
 config-$(call config_package,rtw88-usb) += RTW88_USB
 config-$(call config_package,rtw88-8821c) += RTW88_8821C
 config-$(call config_package,rtw88-8821ce) += RTW88_8821CE
+config-$(call config_package,rtw88-8821cu) += RTW88_8821CU
 config-$(call config_package,rtw88-8822b) += RTW88_8822B
 config-$(call config_package,rtw88-8822be) += RTW88_8822BE
 config-$(call config_package,rtw88-8822bu) += RTW88_8822BU
@@ -246,6 +248,14 @@ define KernelPackage/rtw88-8821ce
   DEPENDS+= +kmod-rtw88-pci +kmod-rtw88-8821c
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8821ce.ko
   AUTOLOAD:=$(call AutoProbe,rtw88_8821ce)
+endef
+
+define KernelPackage/rtw88-8821cu
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTL8821CU support
+  DEPENDS+= +kmod-rtw88-usb +kmod-rtw88-8821c
+  FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8821cu.ko
+  AUTOLOAD:=$(call AutoProbe,rtw88_8821cu)
 endef
 
 define KernelPackage/rtw88-8822be

--- a/package/kernel/mac80211/realtek.mk
+++ b/package/kernel/mac80211/realtek.mk
@@ -3,7 +3,7 @@ PKG_DRIVERS += \
 	rtl8192ce rtl8192se rtl8192de rtl8192cu rtl8723bs rtl8821ae \
 	rtl8xxxu rtw88 rtw88-pci rtw88-usb rtw88-8821c rtw88-8822b rtw88-8822c \
 	rtw88-8723d rtw88-8821ce rtw88-8821cu rtw88-8822be rtw88-8822bu \
-	rtw88-8822ce rtw88-8723de
+	rtw88-8822ce rtw88-8822cu rtw88-8723de
 
 config-$(call config_package,rtlwifi) += RTL_CARDS RTLWIFI
 config-$(call config_package,rtlwifi-pci) += RTLWIFI_PCI
@@ -34,6 +34,7 @@ config-$(call config_package,rtw88-8822be) += RTW88_8822BE
 config-$(call config_package,rtw88-8822bu) += RTW88_8822BU
 config-$(call config_package,rtw88-8822c) += RTW88_8822C
 config-$(call config_package,rtw88-8822ce) += RTW88_8822CE
+config-$(call config_package,rtw88-8822cu) += RTW88_8822CU
 config-$(call config_package,rtw88-8723d) += RTW88_8723D
 config-$(call config_package,rtw88-8723de) += RTW88_8723DE
 config-$(CONFIG_PACKAGE_RTW88_DEBUG) += RTW88_DEBUG
@@ -280,6 +281,14 @@ define KernelPackage/rtw88-8822ce
   DEPENDS+= +kmod-rtw88-pci +kmod-rtw88-8822c
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8822ce.ko
   AUTOLOAD:=$(call AutoProbe,rtw88_8822ce)
+endef
+
+define KernelPackage/rtw88-8822cu
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTL8822CU support
+  DEPENDS+= +kmod-rtw88-usb +kmod-rtw88-8822c
+  FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8822cu.ko
+  AUTOLOAD:=$(call AutoProbe,rtw88_8822cu)
 endef
 
 define KernelPackage/rtw88-8723de

--- a/package/kernel/mac80211/realtek.mk
+++ b/package/kernel/mac80211/realtek.mk
@@ -196,7 +196,7 @@ endef
 define KernelPackage/rtw88-usb
   $(call KernelPackage/mac80211/Default)
   TITLE:=Realtek RTW88 USB chips support
-  DEPENDS+= @USB_SUPPORT +kmod-rtw88
+  DEPENDS+= @USB_SUPPORT +kmod-rtw88 +kmod-usb-core
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_usb.ko
   AUTOLOAD:=$(call AutoProbe,rtw88_usb)
   HIDDEN:=1
@@ -205,7 +205,7 @@ endef
 define KernelPackage/rtw88-8822b
   $(call KernelPackage/mac80211/Default)
   TITLE:=Realtek RTL8822B family support
-  DEPENDS+= +kmod-rtw88 +@DRIVER_11AC_SUPPORT
+  DEPENDS+= +kmod-rtw88 +rtl8822be-firmware +@DRIVER_11AC_SUPPORT
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8822b.ko
   AUTOLOAD:=$(call AutoProbe,rtw88_8822b)
   HIDDEN:=1
@@ -214,7 +214,7 @@ endef
 define KernelPackage/rtw88-8822c
   $(call KernelPackage/mac80211/Default)
   TITLE:=Realtek RTL8822C family support
-  DEPENDS+= +kmod-rtw88 +@DRIVER_11AC_SUPPORT
+  DEPENDS+= +kmod-rtw88 +rtl8822ce-firmware +@DRIVER_11AC_SUPPORT
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8822c.ko
   AUTOLOAD:=$(call AutoProbe,rtw88_8822c)
   HIDDEN:=1
@@ -223,7 +223,7 @@ endef
 define KernelPackage/rtw88-8723d
   $(call KernelPackage/mac80211/Default)
   TITLE:=Realtek RTL8723D family support
-  DEPENDS+= +kmod-rtw88
+  DEPENDS+= +kmod-rtw88 +rtl8723de-firmware
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8723d.ko
   AUTOLOAD:=$(call AutoProbe,rtw88_8723d)
   HIDDEN:=1
@@ -240,7 +240,7 @@ endef
 define KernelPackage/rtw88-8822bu
   $(call KernelPackage/mac80211/Default)
   TITLE:=Realtek RTL8822BU support
-  DEPENDS+= +kmod-rtw88-usb +rtl8822be-firmware +kmod-rtw88-8822b
+  DEPENDS+= +kmod-rtw88-usb +kmod-rtw88-8822b
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8822bu.ko
   AUTOLOAD:=$(call AutoProbe,rtw88_8822bu)
 endef

--- a/package/kernel/mac80211/realtek.mk
+++ b/package/kernel/mac80211/realtek.mk
@@ -1,8 +1,8 @@
 PKG_DRIVERS += \
 	rtlwifi rtlwifi-pci rtlwifi-btcoexist rtlwifi-usb rtl8192c-common \
 	rtl8192ce rtl8192se rtl8192de rtl8192cu rtl8723bs rtl8821ae \
-	rtl8xxxu rtw88 rtw88-pci rtw88-usb rtw88-8822b rtw88-8822c rtw88-8723d \
-	rtw88-8822be rtw88-8822bu rtw88-8822ce rtw88-8723de
+	rtl8xxxu rtw88 rtw88-pci rtw88-usb rtw88-8821c rtw88-8822b rtw88-8822c \
+	rtw88-8723d rtw88-8821ce rtw88-8822be rtw88-8822bu rtw88-8822ce rtw88-8723de
 
 config-$(call config_package,rtlwifi) += RTL_CARDS RTLWIFI
 config-$(call config_package,rtlwifi-pci) += RTLWIFI_PCI
@@ -25,6 +25,8 @@ config-y += STAGING
 config-$(call config_package,rtw88) += RTW88 RTW88_CORE
 config-$(call config_package,rtw88-pci) += RTW88_PCI
 config-$(call config_package,rtw88-usb) += RTW88_USB
+config-$(call config_package,rtw88-8821c) += RTW88_8821C
+config-$(call config_package,rtw88-8821ce) += RTW88_8821CE
 config-$(call config_package,rtw88-8822b) += RTW88_8822B
 config-$(call config_package,rtw88-8822be) += RTW88_8822BE
 config-$(call config_package,rtw88-8822bu) += RTW88_8822BU
@@ -202,6 +204,15 @@ define KernelPackage/rtw88-usb
   HIDDEN:=1
 endef
 
+define KernelPackage/rtw88-8821c
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTL8821C family support
+  DEPENDS+= +kmod-rtw88 +rtl8821ce-firmware +@DRIVER_11AC_SUPPORT
+  FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8821c.ko
+  AUTOLOAD:=$(call AutoProbe,rtw88_8821c)
+  HIDDEN:=1
+endef
+
 define KernelPackage/rtw88-8822b
   $(call KernelPackage/mac80211/Default)
   TITLE:=Realtek RTL8822B family support
@@ -227,6 +238,14 @@ define KernelPackage/rtw88-8723d
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8723d.ko
   AUTOLOAD:=$(call AutoProbe,rtw88_8723d)
   HIDDEN:=1
+endef
+
+define KernelPackage/rtw88-8821ce
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTL8821CE support
+  DEPENDS+= +kmod-rtw88-pci +kmod-rtw88-8821c
+  FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8821ce.ko
+  AUTOLOAD:=$(call AutoProbe,rtw88_8821ce)
 endef
 
 define KernelPackage/rtw88-8822be


### PR DESCRIPTION
The RTW88 PCI/USB driver uses the same firmware,
so add firmware package and dependencies.

Also CI report that:
  Package kmod-rtw88-usb is missing dependencies for the following libraries:
  usbcore.ko
This pull request fixes it.