### PR TITLE
bcm63xx: re-enable building of sagem_fast-2704n as the profile is also used for two models 8/64: tp-link_td-w8960n_v5 and tp-link_td-w8968_v3

### DIFF
--- a/target/linux/bcm63xx/image/bcm63xx.mk
+++ b/target/linux/bcm63xx/image/bcm63xx.mk
@@ -1022,7 +1022,7 @@ define Device/sagem_fast-2704n
   CHIP_ID := 6318
   FLASH_MB := 8
   DEVICE_PACKAGES := $(B43_PACKAGES) $(USB2_PACKAGES)
-  DEFAULT := n
+# Same profile works on tp-link_td-w8960n_v5 and tp-link_td-w8968_v3 (8/64)
 endef
 TARGET_DEVICES += sagem_fast-2704n
 


### PR DESCRIPTION
This profile was deselected at commit:
https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=f5cb556d4f70e7aac428857fe782b58ece0cf188

However the same profile works also on two models 8/64:
 - tp-link_td-w8960n_v5 https://openwrt.org/toh/hwdata/tp-link/tp-link_td-w8960n_v5
 - tp-link_td-w8968_v3 https://openwrt.org/toh/hwdata/tp-link/tp-link_td-w8968_v3

Added a comment to point this out

Note: this pr replace #13890 and 'should' pass formalities.
I remain available in any case to test a possible stub profile on a tp-link_td-w8960n_v5 if the creation of this be deemed a better approach.