### PR TITLE
hostapd: fix undeclared variable iface_name

### DIFF
--- a/package/network/services/hostapd/files/hostapd.uc
+++ b/package/network/services/hostapd/files/hostapd.uc
@@ -278,12 +278,12 @@ function iface_reload_config(phydev, config, old_config)
 		return false;
 
 	let iface = hostapd.interfaces[phy];
+	let iface_name = old_config.bss[0].ifname;
 	if (!iface) {
 		hostapd.printf(`Could not find previous interface ${iface_name}`);
 		return false;
 	}
 
-	let iface_name = old_config.bss[0].ifname;
 	let first_bss = hostapd.bss[iface_name];
 	if (!first_bss) {
 		hostapd.printf(`Could not find bss of previous interface ${iface_name}`);


### PR DESCRIPTION
Saw this in logs and decided to fix it:
```
Tue Nov 14 03:41:14 2023 daemon.notice hostapd: Error reloading config: access to undeclared variable iface_name In iface_reload_config(), file /usr/share/hostap/hostapd.uc, line 282, byte 55:   called from function iface_set_config (/usr/share/hostap/hostapd.uc:529:59)   called from function [anonymous function] (/usr/share/hostap/hostapd.uc:747:32)   called from anonymous function (/usr/share/hostap/hostapd.uc:630:22)   `        hostapd.printf(`Could not find previous interface ${iface_name}`);`   Near here --------------------------------------------------^
```