### PR TITLE
qca-ssdk: general maintenance

### DIFF
--- a/package/kernel/qca-ssdk/Makefile
+++ b/package/kernel/qca-ssdk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qca-ssdk
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/qca-ssdk.git
 PKG_SOURCE_PROTO:=git
@@ -43,6 +43,7 @@ MAKE_FLAGS+= \
 	TARGET_SUFFIX=$(CONFIG_TARGET_SUFFIX) \
 	GCC_VERSION=$(GCC_VERSION) \
 	EXTRA_CFLAGS=-fno-stack-protector -I$(STAGING_DIR)/usr/include \
+	SoC=$(CONFIG_TARGET_SUBTARGET) \
 	$(LNX_CONFIG_OPTS)
 
 ifeq ($(CONFIG_TARGET_SUBTARGET), "ipq807x")

--- a/package/kernel/qca-ssdk/Makefile
+++ b/package/kernel/qca-ssdk/Makefile
@@ -44,10 +44,11 @@ MAKE_FLAGS+= \
 	GCC_VERSION=$(GCC_VERSION) \
 	EXTRA_CFLAGS=-fno-stack-protector -I$(STAGING_DIR)/usr/include \
 	SoC=$(CONFIG_TARGET_SUBTARGET) \
+	PTP_FEATURE=disable SWCONFIG_FEATURE=disable \
 	$(LNX_CONFIG_OPTS)
 
 ifeq ($(CONFIG_TARGET_SUBTARGET), "ipq807x")
-    MAKE_FLAGS+= CHIP_TYPE=HPPE PTP_FEATURE=disable SWCONFIG_FEATURE=disable
+    MAKE_FLAGS+= CHIP_TYPE=HPPE
 endif
 
 define Build/InstallDev


### PR DESCRIPTION
This is just some basic maintenance.

We pass the SoC family to build to avoid building needed components like support for the new 2.5G quad port,
and move the PTP and swconfig disable to the general build options as its not special to `ipq807x`


