### PR TITLE
qca-ssdk: disable building ISISC

### DIFF
--- a/package/kernel/qca-ssdk/Makefile
+++ b/package/kernel/qca-ssdk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qca-ssdk
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/qca-ssdk.git
 PKG_SOURCE_PROTO:=git
@@ -45,6 +45,7 @@ MAKE_FLAGS+= \
 	EXTRA_CFLAGS=-fno-stack-protector -I$(STAGING_DIR)/usr/include \
 	SoC=$(CONFIG_TARGET_SUBTARGET) \
 	PTP_FEATURE=disable SWCONFIG_FEATURE=disable \
+	ISISC_ENABLE=disable IN_QCA803X_PHY=FALSE \
 	$(LNX_CONFIG_OPTS)
 
 ifeq ($(CONFIG_TARGET_SUBTARGET), "ipq807x")


### PR DESCRIPTION
ISISC is the QCA codename for their Atheros switch family including
AR237, QCA8337 etc.

Since we have qca8k support in OpenWrt, there is no need to have SSDK
support for these switches, and boards that also have external switches
can just use qca8k.

This also avoids building support for PHY-s supported by at803x.

Signed-off-by: Robert Marko <robimarko@gmail.com>
