### PR TITLE
Revert "x86: add support for Mellanox Spectrum SN2000 Switches"

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -31,9 +31,6 @@ cisco-mx100-hw)
 	ucidef_set_network_device_path "eth11" "pci0000:00/0000:00:01.1/0000:02:00.2"
 	ucidef_set_interfaces_lan_wan "mgmt eth2 eth3 eth4 eth5 eth6 eth7 eth8 eth9 eth10 eth11" "wan"
 	;;
-mellanox-technologies-ltd-msn2100)
-	ucidef_set_interface_lan "eth1 eth2 eth3 eth4 eth5 eth6 eth7 eth8 eth9 eth10 eth11 eth12 eth13 eth14 eth15 eth16"
-	;;
 pc-engines-apu1|pc-engines-apu2|pc-engines-apu3)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
 	;;

--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -4,11 +4,7 @@ define Device/generic
   DEVICE_PACKAGES += \
 	kmod-amazon-ena kmod-amd-xgbe kmod-bnx2 kmod-e1000e kmod-e1000 \
 	kmod-forcedeth kmod-fs-vfat kmod-igb kmod-igc kmod-ixgbe kmod-r8169 \
-	kmod-tg3 kmod-mlxsw-core kmod-mlxsw-pci kmod-mlxsw-i2c \
-  	kmod-mlxsw-spectrum kmod-mlxsw-minimal kmod-mlxfw \
-  	kmod-leds-mlxcpld kmod-lib-objagg kmod-lib-parman \
-  	kmod-hwmon-coretemp kmod-hwmon-drivetemp kmod-hwmon-jc42 \
-  	kmod-i2c-i801 mlxsw_spectrum-firmware
+	kmod-tg3
   GRUB2_VARIANT := generic
 endef
 TARGET_DEVICES += generic


### PR DESCRIPTION
This reverts commit 3004c20614fdb29732f750417a578274a8ed988e.

The commit added the needed packages for the new target to the generic x86_64 image. This results into unwanted modules and firmware files for other x86 devices. (#13886)

Additionally, there is the following error message while booting the image on other x86 devices:
[    8.531720] kmodloader: 1 module could not be probed
[    8.532613] kmodloader: - leds-mlxcpld - 0

For now, the needed packages will have to be selected manually while configuring the image.