### PR TITLE
ipq807x: fix multiple error on ESS switch port define

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8070-cax1800.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8070-cax1800.dts
@@ -271,28 +271,11 @@
 &switch {
 	status = "okay";
 
-	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4)>; /* lan port bitmap */
-	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
+	switch_lan_bmp = <ESS_PORT5>; /* lan port bitmap */
 	switch_mac_mode = <MAC_MODE_PSGMII>; /* mac mode for uniphy instance0*/
 
 	qcom,port_phyinfo {
-		port@0 {
-			port_id = <1>;
-			phy_address = <0>;
-		};
-		port@1 {
-			port_id = <2>;
-			phy_address = <1>;
-		};
-		port@2 {
-			port_id = <3>;
-			phy_address = <2>;
-		};
-		port@3 {
-			port_id = <4>;
-			phy_address = <3>;
-		};
-		port@4 {
+		port@5 {
 			port_id = <5>;
 			phy_address = <4>;
 		};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-ax3600.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-ax3600.dtsi
@@ -235,24 +235,24 @@
 &switch {
 	status = "okay";
 
-	switch_lan_bmp = <(ESS_PORT2 | ESS_PORT3 | ESS_PORT4)>; /* lan port bitmap */
-	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
+	switch_lan_bmp = <(ESS_PORT3 | ESS_PORT4 | ESS_PORT5)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT2>; /* wan port bitmap */
 	switch_mac_mode = <MAC_MODE_PSGMII>; /* mac mode for uniphy instance0*/
 
 	qcom,port_phyinfo {
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			phy_address = <1>;
 		};
-		port@2 {
+		port@3 {
 			port_id = <3>;
 			phy_address = <2>;
 		};
-		port@3 {
+		port@4 {
 			port_id = <4>;
 			phy_address = <3>;
 		};
-		port@4 {
+		port@5 {
 			port_id = <5>;
 			phy_address = <4>;
 		};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
@@ -343,18 +343,18 @@
 &switch {
 	status = "okay";
 
-	switch_lan_bmp = <ESS_PORT5>; /* lan port bitmap */
-	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
+	switch_lan_bmp = <ESS_PORT6>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
 	switch_mac_mode1 = <MAC_MODE_SGMII_CHANNEL0>; /* mac mode for uniphy instance1*/
 	switch_mac_mode2 = <MAC_MODE_SGMII_CHANNEL0>; /* mac mode for uniphy instance2*/
 
 	qcom,port_phyinfo {
-		port@4 {
+		port@5 {
 			port_id = <5>;
 			phy_address = <24>;
 			port_mac_sel = "QGMAC_PORT";
 		};
-		port@5 {
+		port@6 {
 			port_id = <6>;
 			phy_address = <28>;
 			port_mac_sel = "QGMAC_PORT";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
@@ -321,8 +321,8 @@
 &switch {
 	status = "okay";
 
-	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4 | ESS_PORT5)>; /* lan port bitmap */
-	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4 | ESS_PORT6)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
 	malibu_first_phy_addr = <16>; /* PHY addr of the first malibu PHY */
 	switch_mac_mode = <MAC_MODE_QSGMII>; /* mac mode for uniphy instance0*/
 	switch_mac_mode1 = <MAC_MODE_USXGMII>; /* mac mode for uniphy instance1*/

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
@@ -325,18 +325,18 @@
 &switch {
 	status = "okay";
 
-	switch_lan_bmp = <ESS_PORT5>; /* lan port bitmap */
-	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
+	switch_lan_bmp = <ESS_PORT6>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
 	switch_mac_mode1 = <MAC_MODE_SGMII_CHANNEL0>; /* mac mode for uniphy instance1*/
 	switch_mac_mode2 = <MAC_MODE_SGMII_CHANNEL0>; /* mac mode for uniphy instance2*/
 
 	qcom,port_phyinfo {
-		port@4 {
+		port@5 {
 			port_id = <5>;
 			phy_address = <24>;
 			port_mac_sel = "QGMAC_PORT";
 		};
-		port@5 {
+		port@6 {
 			port_id = <6>;
 			phy_address = <28>;
 			port_mac_sel = "QGMAC_PORT";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
@@ -388,23 +388,23 @@
 	switch_mac_mode1 = <MAC_MODE_SGMII_PLUS>; /* mac mode for uniphy instance1*/
 
 	qcom,port_phyinfo {
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			phy_address = <0>;
 		};
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			phy_address = <1>;
 		};
-		port@2 {
+		port@3 {
 			port_id = <3>;
 			phy_address = <2>;
 		};
-		port@3 {
+		port@4 {
 			port_id = <4>;
 			phy_address = <3>;
 		};
-		port@4 {
+		port@5 {
 			port_id = <5>;
 			phy_address = <24>;
 			port_mac_sel = "QGMAC_PORT";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-dl-wrx36.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-dl-wrx36.dts
@@ -175,23 +175,23 @@
 	switch_mac_mode2 = <MAC_MODE_SGMII_PLUS>; /* mac mode for uniphy instance2*/
 
 	qcom,port_phyinfo {
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			phy_address = <0>;
 		};
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			phy_address = <1>;
 		};
-		port@2 {
+		port@3 {
 			port_id = <3>;
 			phy_address = <2>;
 		};
-		port@3 {
+		port@4 {
 			port_id = <4>;
 			phy_address = <3>;
 		};
-		port@5 {
+		port@6 {
 			port_id = <6>;
 			phy_address = <28>;
 			port_mac_sel = "QGMAC_PORT";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
@@ -193,23 +193,23 @@
 	switch_mac_mode2 = <MAC_MODE_USXGMII>; /* mac mode for uniphy instance2*/
 
 	qcom,port_phyinfo {
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			phy_address = <0>;
 		};
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			phy_address = <1>;
 		};
-		port@2 {
+		port@3 {
 			port_id = <3>;
 			phy_address = <2>;
 		};
-		port@3 {
+		port@4 {
 			port_id = <4>;
 			phy_address = <3>;
 		};
-		port@4 {
+		port@6 {
 			port_id = <6>;
 			phy_address = <8>;
 			compatible = "ethernet-phy-ieee802.3-c45";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax218.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax218.dts
@@ -89,12 +89,12 @@
 &switch {
 	status = "okay";
 
-	switch_wan_bmp = <ESS_PORT6>;
+	switch_lan_bmp = <ESS_PORT6>;
 	switch_mac_mode = <MAC_MODE_PSGMII>;
 	switch_mac_mode2 = <MAC_MODE_SGMII_CHANNEL0>;
 
 	qcom,port_phyinfo {
-		port@5 {
+		port@6 {
 			port_id = <6>;
 			phy_address = <28>;
 			port_mac_sel = "QGMAC_PORT";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax620.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax620.dts
@@ -117,12 +117,12 @@
 &switch {
 	status = "okay";
 
-	switch_wan_bmp = <ESS_PORT6>;
+	switch_lan_bmp = <ESS_PORT6>;
 	switch_mac_mode = <MAC_MODE_PSGMII>;
 	switch_mac_mode2 = <MAC_MODE_SGMII_CHANNEL0>;
 
 	qcom,port_phyinfo {
-		port@5 {
+		port@6 {
 			port_id = <6>;
 			phy_address = <28>;
 			port_mac_sel = "QGMAC_PORT";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
@@ -407,7 +407,7 @@
 			port_id = <4>;
 			phy_address = <3>;
 		};
-		port@5 {
+		port@6 {
 			port_id = <6>;
 			phy_address = <28>;
 			port_mac_sel = "QGMAC_PORT";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
@@ -298,40 +298,40 @@
 &switch {
 	status = "okay";
 
-	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4 | ESS_PORT5)>;
-	switch_wan_bmp = <ESS_PORT6>;
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4 | ESS_PORT6)>;
+	switch_wan_bmp = <ESS_PORT5>;
 	switch_mac_mode = <MAC_MODE_PSGMII>;
 	switch_mac_mode1 = <MAC_MODE_SGMII_CHANNEL0>;
 	switch_mac_mode2 = <MAC_MODE_USXGMII>;
 
 	qcom,port_phyinfo {
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			phy_address = <0>;
 		};
 
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			phy_address = <1>;
 		};
 
-		port@2 {
+		port@3 {
 			port_id = <3>;
 			phy_address = <2>;
 		};
 
-		port@3 {
+		port@4 {
 			port_id = <4>;
 			phy_address = <3>;
 		};
 
-		port@4 {
+		port@5 {
 			port_id = <5>;
 			phy_address = <28>;
 			port_mac_sel = "QGMAC_PORT";
 		};
 
-		port@5 {
+		port@6 {
 			port_id = <6>;
 			ethernet-phy-ieee802.3-c45;
 			phy_address = <8>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-rax120v2.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-rax120v2.dts
@@ -195,8 +195,8 @@
 &switch {
 	status = "okay";
 
-	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4 | ESS_PORT5)>; /* lan port bitmap */
-	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4 | ESS_PORT6)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
 	switch_mac_mode = <MAC_MODE_PSGMII>; /* mac mode for uniphy instance0*/
 	switch_mac_mode2 = <MAC_MODE_USXGMII>; /* mac mode for uniphy instance2*/
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
@@ -151,18 +151,17 @@
 &switch {
 	status = "okay";
 
-	switch_lan_bmp = <ESS_PORT4>;
-	switch_wan_bmp = <ESS_PORT6>;
+	switch_lan_bmp = <ESS_PORT4 | ESS_PORT6>;
 	switch_mac_mode = <MAC_MODE_PSGMII>;
 	switch_mac_mode2 = <MAC_MODE_USXGMII>;
 
 	qcom,port_phyinfo {
-		port@3 {
+		port@4 {
 			port_id = <4>;
 			phy_address = <3>;
 		};
 
-		port@5 {
+		port@6 {
 			port_id = <6>;
 			phy_address = <28>;
 			port_mac_sel = "QGMAC_PORT";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
@@ -267,40 +267,40 @@
 &switch {
 	status = "okay";
 
-	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4 | ESS_PORT5)>;
-	switch_wan_bmp = <ESS_PORT6>;
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4 | ESS_PORT6)>;
+	switch_wan_bmp = <ESS_PORT5>;
 	switch_mac_mode = <MAC_MODE_QSGMII>;
 	switch_mac_mode1 = <MAC_MODE_USXGMII>;
 	switch_mac_mode2 = <MAC_MODE_USXGMII>;
 
 	qcom,port_phyinfo {
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			phy_address = <0x18>;
 		};
 
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			phy_address = <0x19>;
 		};
 
-		port@2 {
+		port@3 {
 			port_id = <3>;
 			phy_address = <0x1a>;
 		};
 
-		port@3 {
+		port@4 {
 			port_id = <4>;
 			phy_address = <0x1b>;
 		};
 
-		port@4 {
+		port@5 {
 			port_id = <5>;
 			ethernet-phy-ieee802.3-c45;
 			phy_address = <0x0>;
 		};
 
-		port@5 {
+		port@6 {
 			port_id = <6>;
 			ethernet-phy-ieee802.3-c45;
 			phy_address = <0x8>;


### PR DESCRIPTION
Fix multiple error on ESS switch port define.
- Fix wrong switch CPU and WAN bmp define. (many times wan port are actually set in lan mask and lan port in wan mask)
- Renumber phyinfo port, use port_id instead of phy_address as it doesn't make sense using that for port enumeration
- Drop additional port for devices that have them not connected.