### PR TITLE
ath79: add support for D-link DAP-1720 A1

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -31,6 +31,7 @@ asus,zenwifi-cd6n|\
 asus,zenwifi-cd6r|\
 buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\
+dlink,dap-1720-a1|\
 dlink,dir-859-a1|\
 dlink,dir-859-a3|\
 dlink,dir-869-a1|\

--- a/target/linux/ath79/dts/qca9563_dlink_dap-1720-a1.dts
+++ b/target/linux/ath79/dts/qca9563_dlink_dap-1720-a1.dts
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "D-Link DAP-1720 A1";
+	compatible = "dlink,dap-1720-a1", "qca,qca9563";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		button-wps {
+			label = "wps";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: led-status-red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+
+		led_status_green: led-status-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led-rssi-middle {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "signal"; //LED_FUNCTION_SIGNAL;
+			function-enumerator = <2>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led-rssi-top {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "signal"; //LED_FUNCTION_SIGNAL;
+			function-enumerator = <3>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led-rssi-bottom-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "signal"; //LED_FUNCTION_SIGNAL;
+			function-enumerator = <1>;
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+
+		led-rssi-bottom-red {
+			color = <LED_COLOR_ID_RED>;
+			function = "signal"; //LED_FUNCTION_SIGNAL;
+			function-enumerator = <1>;
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot"; // vendor calls it `bootloader`
+				reg = <0x000000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "u-boot,env";
+				label = "u-boot-env"; // vendor calls it `bdcfg`
+				reg = <0x040000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "devdata";
+				reg = <0x050000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_ath10k: macaddr@94 {
+						compatible = "mac-base";
+						reg = <0x94 0x11>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_ath9k: macaddr@b0 {
+						compatible = "mac-base";
+						reg = <0xb0 0x11>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_lan: macaddr@c9 {
+						compatible = "mac-base";
+						reg = <0xc9 0x11>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@60000 {
+				label = "devconf";
+				reg = <0x060000 0x10000>;
+				read-only;
+			};
+
+			partition@70000 {
+				compatible = "seama";
+				label = "firmware";
+				reg = <0x070000 0xf80000>;
+			};
+
+			partition@ff0000 {
+				label = "art"; // vendor calls it `radiocfg`
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_ath9k: cal@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+					cal_ath10k: cal@5000 {
+						reg = <0x5000 0x844>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		reset-gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy0>;
+	phy-mode = "sgmii";
+
+	nvmem-cells = <&macaddr_lan 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0000 0 0 0 0>;
+
+		nvmem-cells = <&cal_ath10k>, <&macaddr_ath10k 0>;
+		nvmem-cell-names = "calibration", "mac-address";
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&cal_ath9k>, <&macaddr_ath9k 0>;
+	nvmem-cell-names = "calibration", "mac-address";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -241,6 +241,13 @@ dlink,dap-1365-a1)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimediumhigh" "wlan0" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan0" "76" "100"
 	;;
+dlink,dap-1720-a1)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSI LOW" "red:signal-1" "wlan0" "1" "40"
+	ucidef_set_led_rssi "rssimediumlow" "RSSI MEDIUM-LOW" "green:signal-1" "wlan0" "21" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSI MEDIUM-HIGH" "green:signal-2" "wlan0" "61" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSI HIGH" "green:signal-3" "wlan0" "81" "100"
+	;;
 dlink,dir-859-a1)
 	ucidef_set_led_switch "internet" "WAN" "green:internet" "switch0" "0x20"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -34,6 +34,7 @@ ath79_setup_interfaces()
 	devolo,dvl1750x|\
 	dlink,dap-1330-a1|\
 	dlink,dap-1365-a1|\
+	dlink,dap-1720-a1|\
 	dlink,dap-2230-a1|\
 	dlink,dap-2660-a1|\
 	dlink,dap-2680-a1|\

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/09_fix-checksum
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/09_fix-checksum
@@ -21,6 +21,7 @@ dlink,dap-3320-a1|\
 dlink,dap-3662-a1)
 	fixwrgg
 	;;
+dlink,dap-1720-a1|\
 dlink,dir-629-a1|\
 dlink,dir-859-a1|\
 dlink,dir-859-a3|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1053,6 +1053,22 @@ define Device/dlink_dap-1365-a1
 endef
 TARGET_DEVICES += dlink_dap-1365-a1
 
+define Device/dlink_dap-1720-a1
+  $(Device/seama)
+  SOC := qca9563
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DAP-1720
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES := rssileds -swconfig \
+	kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
+  SEAMA_SIGNATURE := wapac28_dlink.2015_dap1720
+  IMAGE_SIZE := 15872k
+  IMAGES += recovery.bin
+  IMAGE/recovery.bin := $$(IMAGE/default) | pad-rootfs -x 64 | seama | \
+	seama-seal | check-size
+endef
+TARGET_DEVICES += dlink_dap-1720-a1
+
 define Device/dlink_dap-2xxx
   IMAGES += factory.img
   IMAGE/factory.img := append-kernel | pad-offset 6144k 160 | \


### PR DESCRIPTION
D-Link DAP-1720 rev A1 is a mains-powered AC1750 Wi-Fi range extender, manufactured by Alpha Networks [**8WAPAC28.1A1G**].
(in square brackets: PCB silkscreen markings)

Specifications:
* CPU (Qualcomm Atheros QCA9563-AL3A [**U5**]):
  775 MHz single core MIPS 74Kc;
* RAM (Winbond W9751G6KB-25J [**U3**]):
  64 MiB DDR2;
* ROM (Winbond W25Q128FV [**U16**]):
  16 MiB SPI NOR flash;
* Ethernet (AR8033-AL1A PHY [**U1**], no switch):
  1 GbE RJ45 port (no PHY LEDs);
* Wi-Fi
  * 2.4 GHz (Qualcomm Atheros QCA9563-AL3A [**U5**]):
    3x3 802.11n;
  * 5 GHz (Qualcomm Atheros QCA9880-BR4A [**U9**]):
    3x3 802.11ac Wave 1;
  * 3 foldable dual-band antennas (U.fl) [**P1**],[**P2**],[**P3**];
* GPIO LEDs:
  * RSSI low (red/green) [**D2**];
  * RSSI medium (green) [**D3**];
  * RSSI high (green) [**D4**];
  * status (red/green) [**D5**];
* GPIO buttons:
  * WPS [**SW1**], co-located with status LED;
  * reset [**SW4**], accessible via hole in the side;
* Serial/UART: Tx-Gnd-3v3-Rx [**JP1**], Tx is the square pin, 1.25mm pitch;
  125000-8-n-1 in U-boot, 115200-8-n-1 in kernel;
* Misc:
  * 12V VCC [**JP2**], fed from internal 12V/1A AC to DC converter;
  * on/off slide switch [**SW2**] (disconnects VCC mechanically);
  * unpopulated footprints for a Wi-Fi LED [**D1**];
  * unpopulated footprints for a 4-pin 3-position slide switch [**SW3**];

MAC addresses:
* Label = LAN;
* 2.4 GHz WiFi = LAN;
* 5 GHz WiFi = LAN+2;

Installation:
* `factory.bin` can be used to install OpenWrt from OEM firmware via the standard upgrade webpage at http://192.168.0.50/UpdateFirmware.html
* `recovery.bin` can be used to install OpenWrt (or revert to OEM firmware) from D-Link Web Recovery. To enter web recovery, keep reset button pressed and then power on the device. Reset button can be released when the red status LED is bright; it will then blink slowly. Set static IP to 192.168.0.10, navigate to http://192.168.0.50 and upload 'recovery.bin'. Note that in web recovery mode the device ignores ping and DHCP requests.

Note: 802.11s is not supported by the default `ath10k` driver and firmware, but is supported by the non-CT driver and firmware variants. The `-smallbuffers` driver variant is recommended due to RAM size.

Co-developed-by: @protectivedad 