### PR TITLE
ath79: fortinet: convert to nvmem-layout

### DIFF
--- a/target/linux/ath79/dts/ar7161_fortinet_fap-220-b.dts
+++ b/target/linux/ath79/dts/ar7161_fortinet_fap-220-b.dts
@@ -99,9 +99,8 @@
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
 		ieee80211-freq-limit = <2402000 2482000>;
-		nvmem-cells = <&macaddr_art_120c>, <&cal_art_1000>;
+		nvmem-cells = <&macaddr_uboot_3ff80 9>, <&cal_art_1000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		mac-address-increment = <9>;
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -110,9 +109,8 @@
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
 		ieee80211-freq-limit = <2402000 2482000 4900000 5990000>;
-		nvmem-cells = <&macaddr_art_520c>, <&cal_art_5000>;
+		nvmem-cells = <&macaddr_uboot_3ff80 2>, <&cal_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		mac-address-increment = <2>;
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -133,7 +131,7 @@
 
 &eth1 {
 	status = "okay";
-	nvmem-cells = <&macaddr_art_120c>;
+	nvmem-cells = <&macaddr_uboot_3ff80 0>;
 	nvmem-cell-names = "mac-address";
 
 	pll-data = <0x00110000 0x00001099 0x00991099>;
@@ -149,35 +147,18 @@
 	status = "okay";
 };
 
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	/* Currently doesn't work, because this one lacks colons as delimiters */
-	macaddr_uboot_3ff80: mac-address-ascii@3ff80 {
-		reg = <0x3ff80 0xc>;
-	};
-};
-
 &art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	cal_art_1000: calibration@1000 {
-		reg = <0x1000 0xeb8>;
-	};
+		cal_art_1000: calibration@1000 {
+			reg = <0x1000 0xeb8>;
+		};
 
-	macaddr_art_120c: mac-address@120c {
-		reg = <0x120c 0x6>;
-	};
-
-	cal_art_5000: calibration@5000 {
-		reg = <0x5000 0xeb8>;
-	};
-
-	macaddr_art_520c: mac-address@520c {
-		reg = <0x520c 0x6>;
+		cal_art_5000: calibration@5000 {
+			reg = <0x5000 0xeb8>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar7161_fortinet_fap-220-b.dts
+++ b/target/linux/ath79/dts/ar7161_fortinet_fap-220-b.dts
@@ -101,7 +101,7 @@
 		ieee80211-freq-limit = <2402000 2482000>;
 		nvmem-cells = <&macaddr_art_120c>, <&cal_art_1000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		mac-address-increment = <1>;
+		mac-address-increment = <9>;
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -112,7 +112,7 @@
 		ieee80211-freq-limit = <2402000 2482000 4900000 5990000>;
 		nvmem-cells = <&macaddr_art_520c>, <&cal_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		mac-address-increment = <9>;
+		mac-address-increment = <2>;
 		#gpio-cells = <2>;
 		gpio-controller;
 	};

--- a/target/linux/ath79/dts/ar9344_fortinet_fap-221-b.dts
+++ b/target/linux/ath79/dts/ar9344_fortinet_fap-221-b.dts
@@ -6,6 +6,10 @@
 	compatible = "fortinet,fap-221-b", "qca,ar9344";
 	model = "Fortinet FAP-221-B";
 
+	aliases {
+		label-mac-device = <&eth0>;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 
@@ -51,25 +55,34 @@
 &ath9k {
 	ieee80211-freq-limit = <2402000 2482000>;
 
-	nvmem-cells = <&calibration_pcie>;
-	nvmem-cell-names = "calibration";
+	nvmem-cells = <&calibration_pcie>, <&macaddr_uboot_3ff80 8>;
+	nvmem-cell-names = "calibration", "mac-address";
+};
+
+&eth0 {
+	nvmem-cells = <&macaddr_uboot_3ff80 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &wmac {
 	ieee80211-freq-limit = <2402000 2482000 4900000 5990000>;
 
-	nvmem-cells = <&calibration_wmac>;
-	nvmem-cell-names = "calibration";
+	nvmem-cells = <&calibration_wmac>, <&macaddr_uboot_3ff80 1>;
+	nvmem-cell-names = "calibration", "mac-address";
 };
 
 &art {
-	compatible = "nvmem-cells";
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	calibration_wmac: calibration@1000 {
-		reg = <0x1000 0x440>;
-	};
+		calibration_wmac: calibration@1000 {
+			reg = <0x1000 0x440>;
+		};
 
-	calibration_pcie: calibration@5000 {
-		reg = <0x5000 0x440>;
+		calibration_pcie: calibration@5000 {
+			reg = <0x5000 0x440>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/arxxxx_fortinet_loader.dtsi
+++ b/target/linux/ath79/dts/arxxxx_fortinet_loader.dtsi
@@ -40,6 +40,18 @@
 				label = "u-boot";
 				reg = <0x000000 0x040000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_3ff80: mac-address@3ff80 {
+						compatible = "mac-base";
+						reg = <0x3ff80 0xc>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			fwconcat0: partition@40000 {

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -726,10 +726,6 @@ ath79_setup_macs()
 	enterasys,ws-ap3705i)
 		label_mac=$(mtd_get_mac_ascii u-boot-env0 ethaddr)
 		;;
-	fortinet,fap-221-b)
-		lan_mac=$(mtd_get_mac_text u-boot 0x3ff80 12)
-		label_mac=$lan_mac
-		;;
 	hak5,lan-turtle|\
 	hak5,packet-squirrel)
 		label_mac=$(mtd_get_mac_binary u-boot 0x1fc00)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -47,9 +47,6 @@ case "$board" in
 	engenius,esr900)
 		macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" "$PHYNBR" > /sys${DEVPATH}/macaddress
 		;;
-	fortinet,fap-221-b)
-		macaddr_add "$(mtd_get_mac_text u-boot 0x3ff80 12)" $((PHYNBR*7+1)) > /sys${DEVPATH}/macaddress
-		;;
 	iodata,wn-ac1600dgr)
 		# There is no eeprom data for 5 GHz wlan in "art" partition
 		# which would allow to patch the macaddress

--- a/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -25,9 +25,6 @@ preinit_set_mac_address() {
 	siemens,ws-ap3610)
 		ip link set dev eth0 address $(mtd_get_mac_ascii cfg1 ethaddr)
 		;;
-	fortinet,fap-221-b)
-		ip link set dev eth0 address $(mtd_get_mac_text u-boot 0x3ff80 12)
-		;;
 	moxa,awk-1137c)
 		ip link set dev eth0 address $(mtd_get_mac_ascii u-boot-env mac_addr)
 		;;


### PR DESCRIPTION
This series converts both FAP-220-B and FAP-221-B models to use `nvmem-layout` for parsing MAC addresses, so no userspace scripts are needed to configure them. While at that, the nvmem-layout is consolidated in the common part.

Run tested on FAP-220-B. 