### PR TITLE
uboot-mediatek: bpi-r3: Typo of ubi command in uboot predefined commands

### DIFF
--- a/package/boot/uboot-mediatek/patches/430-add-bpi-r3.patch
+++ b/package/boot/uboot-mediatek/patches/430-add-bpi-r3.patch
@@ -870,7 +870,7 @@
 +ubi_init_emmc_install=run sdmmc_read_emmc_install && run ubi_write_emmc_install
 +ubi_prepare_rootfs=if ubi check rootfs_data ; then else if env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi ; fi
 +ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
-+ubi_write_emmc_install=ubi check emmc_install && ubi remote emmc_install ; ubi create emmc_install 0x800000 dynamic ; ubi write $loadaddr emmc_install 0x800000
++ubi_write_emmc_install=ubi check emmc_install && ubi remove emmc_install ; ubi create emmc_install 0x800000 dynamic ; ubi write $loadaddr emmc_install 0x800000
 +ubi_write_production=ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic 2 && ubi write $loadaddr fit $filesize
 +ubi_write_recovery=ubi check recovery && ubi remove recovery ; run ubi_remove_rootfs ; ubi create recovery $filesize dynamic 3 && ubi write $loadaddr recovery $filesize
 +_init_env=setenv _init_env ; setenv _create_env ; saveenv ; saveenv


### PR DESCRIPTION
There is a typo `ubi remote` should be `ubi remove` in uboot predefined commands for bpi-r3 target

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
