### PR TITLE
ramips: add support for TP-Link EX220 v1

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_ex220-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_ex220-v1.dts
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tplink,ex220-v1", "mediatek,mt7621-soc";
+	model = "TP-Link EX220 v1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-wps {
+			label = "rfkill";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-wps {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led-wan-orange {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led-wan-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led-wifi5g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <5>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led-wifi2g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <2>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_power: led-power {
+			label = "green:power"; // to be removed once #13837 is merged
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "boot";
+				reg = <0x00 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "config";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "isp_config";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "rom_file";
+				reg = <0x70000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_rom_file_f100: macaddr@f100 {
+						compatible = "mac-base";
+						reg = <0xf100 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@80000 {
+				label = "cloud";
+				reg = <0x80000 0x10000>;
+				read-only;
+			};
+
+			radio: partition@90000 {
+				label = "radio";
+				reg = <0x90000 0x20000>;
+				read-only;
+			};
+
+			partition@b0000 {
+				label = "config_bak";
+				reg = <0xb0000 0x10000>;
+				read-only;
+			};
+
+			partition@c0000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0xc0000 0xf30000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x0>;
+		nvmem-cells = <&macaddr_rom_file_f100 0>;
+		nvmem-cell-names = "mac-address";
+		mediatek,disable-radar-background;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_rom_file_f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_rom_file_f100 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2381,6 +2381,20 @@ define Device/tplink_er605-v2
 endef
 TARGET_DEVICES += tplink_er605-v2
 
+define Device/tplink_ex220-v1
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := EX220
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  TPLINK_BOARD_ID := EX220-V1
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel 0x80001000 | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  IMAGE_SIZE := 15744k
+endef
+TARGET_DEVICES += tplink_ex220-v1
+
 define Device/tplink_mr600-v2-eu
   $(Device/dsa-migration)
   $(Device/tplink-v2)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -193,7 +193,8 @@ snr,snr-cpe-me1)
 tplink,archer-a6-v3|\
 tplink,archer-ax23-v1|\
 tplink,archer-c6-v3|\
-tplink,archer-c6u-v1)
+tplink,archer-c6u-v1|\
+tplink,ex220-v1)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "br-lan"
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -180,6 +180,10 @@ case "$board" in
 		hw_mac_addr="$(mtd_get_mac_binary product-info 0x8)"
 		macaddr_add "$hw_mac_addr" "$PHYNBR" > "/sys${DEVPATH}/macaddress"
 		;;
+	tplink,ex220-v1)
+		hw_mac_addr="$(mtd_get_mac_binary rom_file 0xf100)"
+		[ "$PHYNBR" = "1" ] &&  macaddr_add "$hw_mac_addr" 2 > "/sys${DEVPATH}/macaddress"
+		;;
 	yuncore,ax820)
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary Factory 0xe000)" > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
This device is very similar, if not identical, to the TP-Link AX23 v1 but is targeted at service providers and features a completely different flash layout.

Hardware
--------

CPU:    MediaTek MT7621 DAT
RAM:    128MB DDR3 (integrated)
FLASH:  16MB SPI-NOR
WiFi:   MediaTek MT7905 + MT7975 (2.4 / 5 DBDC) 802.11ax
SERIAL: 115200 8N1
        LEDs - (3V3 - GND - RX - TX) - ETH ports

Installation
------------

Flashing is only possible via a serial connection using the sysupgrade image; the factory image must be signed. You can flash the sysupgrade image directly through the U-Boot console, or preferably, by booting the initramfs image and flashing with the sysupgrade command. Follow these steps for sysupgrade flashing:

1. Establish a UART serial connection.
2. Set up a TFTP server at 192.168.0.2 and copy the initramfs image there.
3. Power on the device and press any key to interrupt normal boot.
4. Load the initramfs image using tftpboot.
5. Boot with bootm.
6. If you haven't done so already, back up all stock mtd partitions.
7. Copy the sysupgrade image to the router.
8. Flash OpenWrt through either LuCI or the sysupgrade command. Remember not to attempt saving settings.

Revert to stock firmware
------------------------

Flash stock firmware via OEM web-recovery mode. If you don't have access to the stock firmware image, you will need to restore the firmware partition backed up earlier.

Web-Recovery
------------

The router supports an HTTP recovery mode:

1. Turn off the router.
2. Press the reset button and power on the device.
3. When all LEDs start flashing, release reset and quickly press it again.

The interface is reachable at 192.168.0.1 and supports installation of the OEM factory image. Note that flashing OpenWrt this way is not possible, as mentioned above.

