### PR TITLE
Add support for Tuoshi LT22M 4G Wireless Router

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -108,6 +108,11 @@ snr,cpe-w4n-mt)
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x1000"
 	;;
+tuoshi,lt22m)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x10000"
+	;;
 xiaomi,miwifi-mini)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
 	ubootenv_add_uci_sys_config "/dev/mtd9" "0x0" "0x4000" "0x10000"

--- a/target/linux/generic/hack-5.15/782-usb-net-Marvell_ML352_modem_support.patch
+++ b/target/linux/generic/hack-5.15/782-usb-net-Marvell_ML352_modem_support.patch
@@ -1,0 +1,22 @@
+--- a/drivers/usb/serial/option.c
++++ b/drivers/usb/serial/option.c
+@@ -617,6 +617,10 @@ static void option_instat_callback(struc
+ /* Luat Air72*U series based on UNISOC UIS8910 uses UNISOC's vendor ID */
+ #define LUAT_PRODUCT_AIR720U			0x4e00
+ 
++/* Marvell products */
++#define MARVELL_VENDOR_ID			0x1286
++#define MARVELL_PRODUCT_ML352			0x4e3c
++
+ /* Device flags */
+ 
+ /* Highest interface number which can be used with NCTRL() and RSVD() */
+@@ -2287,6 +2291,7 @@ static const struct usb_device_id option
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(SIERRA_VENDOR_ID, SIERRA_PRODUCT_EM9191, 0xff, 0xff, 0x40) },
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(SIERRA_VENDOR_ID, SIERRA_PRODUCT_EM9191, 0xff, 0, 0) },
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(UNISOC_VENDOR_ID, TOZED_PRODUCT_LT70C, 0xff, 0, 0) },
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(UNISOC_VENDOR_ID, LUAT_PRODUCT_AIR720U, 0xff, 0, 0) },
++	{ USB_DEVICE(MARVELL_VENDOR_ID, MARVELL_PRODUCT_ML352) },
+ 	{ } /* Terminating entry */
+ };
+ MODULE_DEVICE_TABLE(usb, option_ids);

--- a/target/linux/ramips/dts/mt7628an_tuoshi_lt22m.dts
+++ b/target/linux/ramips/dts/mt7628an_tuoshi_lt22m.dts
@@ -1,0 +1,190 @@
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	compatible = "tuoshi,lt22m", "mediatek,mt7628an-soc";
+	model = "Tuoshi LT22M 4G Wireless Router";
+
+	leds {
+		compatible = "gpio-leds";
+		led-wlan {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN;
+			linux,default-trigger = "phy0tpt";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan-1 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2g {
+			color = <LED_COLOR_ID_BLUE>;
+			function = "wwan";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3g {
+			color = <LED_COLOR_ID_BLUE>;
+			function = "wwan-3g";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4g {
+			color = <LED_COLOR_ID_BLUE>;
+			function = "wwan-4g";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		modem_enable {
+			gpio-export,name = "modem_enable";
+			gpio-export,output = <0>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&fwconcat0 &fwconcat1 &fwconcat2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x0>;
+				label = "firmware";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x27151967>;
+			};
+		};
+	};
+
+};
+
+&state_default {
+	gpio {
+		groups = "i2c";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+	partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					macaddr_factory_28: macaddr@28 {
+						compatible = "mac-base";
+						reg = <0x28 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				
+					// macaddr@4 is used by WiFi
+					// macaddr@28 (same mac as macaddr@4) is used by
+					//            ethernet
+					// macaddr@2e (macaddr@4 plus 2) was used for LAN2
+					//            on the original firmware
+				};
+			};
+
+			fwconcat0: partition@50000 {
+				label = "fwconcat0"; // original: "firmware"
+				reg = <0x50000 0x770000>;
+			};
+
+			// the original firmware mapped <0x50000 0x129d70> as "kernel"
+			// and <0x179d70 0x646290> as rootfs. That's not needed since
+			// OpenWrt auto-detects this.
+
+			fwconcat1: partition@800000 {
+				label = "fwconcat1"; // original: unused space
+				reg = <0x800000 0x50000>;
+			};
+
+			partition@7c0000 {
+				label = "storage";
+				reg = <0x7c0000 0x40000>;
+				read-only;
+			};
+
+			partition@850000 {
+				compatible = "denx,uimage";
+				label = "firmware2";
+				reg = <0x850000 0x770000>;
+				read-only;
+			};
+			fwconcat2: partition@fc0000 {
+				label = "fwconcat2"; // original: unused space
+				reg = <0xfc0000 0x40000>;
+			};
+
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory_0 0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28 0>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -871,6 +871,20 @@ define Device/tplink_tl-wr902ac-v4
 endef
 TARGET_DEVICES += tplink_tl-wr902ac-v4
 
+define Device/tuoshi_lt22m
+  IMAGE_SIZE := 7616k
+  DEVICE_VENDOR := Tuoshi
+  DEVICE_MODEL := LT22M 4G Wireless Router
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport uboot-envtools \
+    kmod-usb-net-rndis kmod-serial-option
+  UIMAGE_MAGIC := 0x27151967
+  UIMAGE_NAME := JBoneCloud M7628NNxCPET
+  FACTORY_IMAGE_SIZE := 6150k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$(FACTORY_IMAGE_SIZE)
+endef
+TARGET_DEVICES += tuoshi_lt22m
+
 define Device/unielec_u7628-01-16m
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := UniElec

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -126,6 +126,9 @@ tplink,tl-wr902ac-v3)
 	;;
 tplink,tl-wr902ac-v4)
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
+tuoshi,lt22m)
+	ucidef_set_led_switch "lan0" "LAN1" "blue:lan-1" "switch0" "0x1"
+	ucidef_set_led_switch "lan1" "LAN2" "blue:lan-2" "switch0" "0x2"
 	;;
 unielec,u7628-01-16m)
 	ucidef_set_led_switch "lan1" "lan1" "green:lan1" "switch0" "0x2"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -163,6 +163,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:wan" "6@eth0"
 		;;
+	tuoshi,lt22m)
+		ucidef_add_switch "switch0" \
+			"0:lan:1" "1:lan:2" "6t@eth0"
+		;;
 	vocore,vocore2|\
 	vocore,vocore2-lite)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
@@ -1,0 +1,15 @@
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+board=$(board_name)
+
+case "$board" in
+	tuoshi,lt22m)
+        ucidef_add_gpio_switch "modem_enabled" "LTE modem enabled" "modem_enabled" "1"
+    ;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/ramips/mt76x8/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt76x8/base-files/etc/init.d/bootcount
@@ -8,6 +8,10 @@ boot() {
 		[ -n "$(fw_printenv bootcount bootchanged 2>/dev/null)" ] &&\
 			echo -e "bootcount\nbootchanged\n" | /usr/sbin/fw_setenv -s -
 		;;
+	tuoshi,lt22m)
+		fw_setenv Image1Stable 1
+		fw_setenv Image1Try 0
+		;;
 	xiaomi,mi-router-4c|\
 	xiaomi,miwifi-nano)
 		fw_setenv flag_boot_success 1


### PR DESCRIPTION
The Tuoshi LT22M is a small 4G wireless router. Specifications:

* Product page: http://www.tuoshi.net/productview.asp?id=233
* SoC: MT7628DAN
* Flash: 16 MiB (to be compatible with stock firmware, 8 MB are usable for firmware)
* Bootloader: U-Boot
* RAM: 64 MiB
* Hardware Switch with 2 physical ethernet ports
* LTE-Modem: Marvell ML352

While a firmware image can be almost 8MB in size, the original firmware limits the upload
to ~6.3 MB. So first a smaller factory image must be flashed and a larger image can be
flashed afterwards via sysupgrade.

There is a 2nd firmware partition that contains a stock firmware. To go back to stock, just
overwrite the first 4 bytes of the "firmware" partition. Then the bootloader automatically
copies the backup firmware on next boot.
