### PR TITLE
ipq40xx: Support for ZyXEL WSQ50

### DIFF
--- a/package/boot/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-envtools/files/ipq40xx
@@ -76,6 +76,9 @@ linksys,whw03v2)
 zyxel,nbg6617)
 	ubootenv_add_uci_config "/dev/mtd6" "0x0" "0x10000" "0x10000"
 	;;
+zyxel,wsq50)
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x10000" "0x10000"
+	;;
 esac
 
 config_load ubootenv

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -59,7 +59,8 @@ ALLWIFIBOARDS:= \
 	zte_mf269 \
 	zte_mf287 \
 	zte_mf287plus \
-	zyxel_nbg7815
+	zyxel_nbg7815 \
+	zyxel_wsq50
 
 ALLWIFIPACKAGES:=$(foreach BOARD,$(ALLWIFIBOARDS),ipq-wifi-$(BOARD))
 
@@ -182,5 +183,6 @@ $(eval $(call generate-ipq-wifi-package,zte_mf269,ZTE MF269))
 $(eval $(call generate-ipq-wifi-package,zte_mf287,ZTE MF287))
 $(eval $(call generate-ipq-wifi-package,zte_mf287plus,ZTE MF287Plus))
 $(eval $(call generate-ipq-wifi-package,zyxel_nbg7815,Zyxel NBG7815))
+$(eval $(call generate-ipq-wifi-package,zyxel_wsq50,Zyxel WSQ50))
 
 $(foreach PACKAGE,$(ALLWIFIPACKAGES),$(eval $(call BuildPackage,$(PACKAGE))))

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -100,7 +100,8 @@ ipq40xx_setup_interfaces()
 	netgear,rbr50|\
 	netgear,rbs50|\
 	netgear,srr60|\
-	netgear,srs60)
+	netgear,srs60|\
+	zyxel,wsq50)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
 	openmesh,a42|\

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -69,21 +69,6 @@ askey_do_upgrade() {
 	nand_do_upgrade "$1"
 }
 
-zyxel_do_upgrade() {
-	local tar_file="$1"
-
-	local board_dir=$(tar tf $tar_file | grep -m 1 '^sysupgrade-.*/$')
-	board_dir=${board_dir%/}
-
-	tar Oxf $tar_file ${board_dir}/kernel | mtd write - kernel
-
-	if [ -n "$UPGRADE_BACKUP" ]; then
-		tar Oxf $tar_file ${board_dir}/root | mtd -j "$UPGRADE_BACKUP" write - rootfs
-	else
-		tar Oxf $tar_file ${board_dir}/root | mtd write - rootfs
-	fi
-}
-
 platform_do_upgrade_mikrotik_nand() {
 	local fw_mtd=$(find_mtd_part kernel)
 	fw_mtd="${fw_mtd/block/}"

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -212,7 +212,8 @@ platform_do_upgrade() {
 		CI_UBIPART="rootfs"
 		nand_do_upgrade "$1"
 		;;
-	zyxel,nbg6617)
+	zyxel,nbg6617 |\
+	zyxel,wsq50)
 		zyxel_do_upgrade "$1"
 		;;
 	*)

--- a/target/linux/ipq40xx/base-files/lib/upgrade/zyxel.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/zyxel.sh
@@ -3,6 +3,21 @@
 #
 . /lib/functions.sh
 
+zyxel_get_rootfs() {
+	local rootfsdev
+
+	if read cmdline < /proc/cmdline; then
+		case "$cmdline" in
+			*root=*)
+				rootfsdev="${cmdline##*root=}"
+				rootfsdev="${rootfsdev%% *}"
+			;;
+		esac
+
+		echo "${rootfsdev}"
+	fi
+}
+
 zyxel_do_upgrade() {
 	local tar_file="$1"
 	local board=$(board_name)
@@ -17,6 +32,75 @@ zyxel_do_upgrade() {
 			tar Oxf $tar_file ${board_dir}/root | mtd -j "$UPGRADE_BACKUP" write - rootfs
 		else
 			tar Oxf $tar_file ${board_dir}/root | mtd write - rootfs
+		fi
+		;;
+	zyxel,wsq50)
+		# Identify our rootfs and kernel partitions
+		local rootfs="$(zyxel_get_rootfs)"
+		local kernel=
+		local loop_supported=
+
+		[ -z "$rootfs" ] && echo "Upgrade failed: rootfs partition not found! Rebooting..." && reboot -f
+
+		[ -f "/usr/sbin/losetup" ] && loop_supported=true
+
+		case "$rootfs" in
+			"/dev/mmcblk0p5") # "rootfs"
+				kernel=$(find_mmc_part "kernel")
+			;;
+			"/dev/mmcblk0p8") # "rootfs_1"
+				kernel=$(find_mmc_part "kernel_1")
+			;;
+			*)
+				echo "rootfs partition did not match expected value!"
+			;;
+		esac
+
+		[ -z "$kernel" ] && echo "Upgrade failed: kernel partition not found! Rebooting..." && reboot -f
+
+		# Stop / detach all loop devices if we can - if losetup is missing we will have limited storage
+		[ "$loop_supported" = true ] && losetup --detach-all
+
+		# Flash both kernel and rootfs
+		echo "Flashing kernel to $kernel"
+		tar xf $tar_file ${board_dir}/kernel -O >"${kernel}"
+
+		echo "Flashing rootfs to ${rootfs}"
+		tar xf $tar_file ${board_dir}/root -O >"${rootfs}"
+
+		# Format new OverlayFS if we can
+		if [ "$loop_supported" = true ]; then
+			# Create a padded rootfs for overlay creation, reboot if failed
+			local offset=$(tar xf $tar_file ${board_dir}/root -O | wc -c)
+			[ $offset -lt 65536 ] && {
+				echo "Wrong size for rootfs: ${offset}"
+				sleep 10
+				reboot -f
+			}
+
+			# Mount loop for rootfs_data
+			local loopdev="$(losetup -f)"
+			losetup -o $offset $loopdev $rootfs || {
+				echo "Failed to mount looped rootfs_data."
+				sleep 10
+				reboot -f
+			}
+
+			# Format new rootfs_data
+			echo "Format new rootfs_data at position ${offset}."
+			mkfs.ext4 -F -L rootfs_data $loopdev
+			mkdir /tmp/new_root
+			mount -t ext4 $loopdev /tmp/new_root && {
+				echo "Saving config to rootfs_data at position ${offset}."
+				cp -v "$UPGRADE_BACKUP" "/tmp/new_root/$BACKUP_FILE"
+				umount /tmp/new_root
+			}
+
+			# Cleanup
+			losetup -d $loopdev >/dev/null 2>&1
+			sync
+			umount -a
+			reboot -f
 		fi
 		;;
 	*)

--- a/target/linux/ipq40xx/base-files/lib/upgrade/zyxel.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/zyxel.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2016 lede-project.org
+#
+. /lib/functions.sh
+
+zyxel_do_upgrade() {
+	local tar_file="$1"
+	local board=$(board_name)
+	local board_dir=$(tar tf $tar_file | grep -m 1 '^sysupgrade-.*/$')
+	board_dir=${board_dir%/}
+
+	case "$board" in
+	zyxel,nbg6617)
+		tar Oxf $tar_file ${board_dir}/kernel | mtd write - kernel
+
+		if [ -n "$UPGRADE_BACKUP" ]; then
+			tar Oxf $tar_file ${board_dir}/root | mtd -j "$UPGRADE_BACKUP" write - rootfs
+		else
+			tar Oxf $tar_file ${board_dir}/root | mtd write - rootfs
+		fi
+		;;
+	*)
+		echo "Unknown board ${board} - aborting"
+		return 1
+		;;
+	esac
+
+	nand_do_upgrade "$1"
+
+	return 0
+}

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wsq50.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wsq50.dts
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/input/linux-event-codes.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Zyxel WSQ50";
+	compatible = "zyxel,wsq50";
+
+	aliases {
+		led-boot = &status_green;
+		led-boot-aux1 = &status_red;
+		led-boot-aux2 = &status_blue;
+		led-running = &status_green;
+		led-running-aux1 = &status_red;
+		led-running-aux2 = &status_blue;
+		led-failsafe = &status_red;
+		led-upgrade = &status_blue;
+	};
+
+	chosen {
+		bootargs-append = " clk_ignore_unused fstools_ignore_partname=1";
+		stdout-path = &blsp1_uart1;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 0x12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	soc {
+		tcsr@1949000 {
+			reg = <0x1949000 0x100>;
+			compatible = "qcom,tcsr";
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			reg = <0x194b000 0x100>;
+			compatible = "qcom,tcsr";
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+		};
+
+		ess_tcsr@1953000 {
+			reg = <0x1953000 0x1000>;
+			compatible = "qcom,tcsr";
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			reg = <0x1957000 0x100>;
+			compatible = "qcom,tcsr";
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+	};
+};
+
+&tlmm {
+	serial1_pins: serial1_pinmux {
+		pins = "gpio16", "gpio17";
+		function = "blsp_uart1";
+		bias-disable;
+	};
+
+	serial2_pins: serial2_pinmux {
+		pins = "gpio8", "gpio9", "gpio10", "gpio11";
+		function = "blsp_uart2";
+		bias-disable;
+	};
+
+	led_pins: led_pinmux {
+		pins = "gpio44", "gpio45", "gpio46";
+		output-high;
+		bias-pull-up;
+	};
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&blsp1_i2c3 {
+	status = "okay";
+
+	tricolor: lp5562@30 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "ti,lp5562";
+		reg = <0x30>;
+		clock-mode = /bits/ 8 <1>;
+
+		status_red: chan@0 {
+			reg = <0>;
+			chan-name = "red:status";
+			led-cur = /bits/ 8 <144>;
+			max-cur = /bits/ 8 <255>;
+			color = <LED_COLOR_ID_RED>;
+		};
+
+		status_green: chan@1 {
+			reg = <1>;
+			chan-name = "green:status";
+			led-cur = /bits/ 8 <69>;
+			max-cur = /bits/ 8 <255>;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+
+		status_blue: chan@2 {
+			reg = <2>;
+			chan-name = "blue:status";
+			led-cur = /bits/ 8 <192>;
+			max-cur = /bits/ 8 <255>;
+			color = <LED_COLOR_ID_BLUE>;
+		};
+	};
+};
+
+&blsp1_spi1 {
+	status = "okay";
+
+	flash@0 {
+		reg = <0>;
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <24000000>;
+
+		partitions {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "fixed-partitions";
+
+			partition0@0 {
+				label = "0:QSEE";
+				reg = <0x00060000 0x00060000>;
+				read-only;
+			};
+
+			partition1@E0000 {
+				label = "u-boot";
+				reg = <0x000E0000 0x00080000>;
+				read-only;
+			};
+
+			partition2@160000 {
+				label = "u-boot-env";
+				reg = <0x00160000 0x00010000>;
+			};
+
+			partition3@170000 {
+				label = "0:ART";
+				reg = <0x00170000 0x00010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_gmac0: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_gmac1: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+
+					precal_wifi0: precal@1000 {
+						reg = <0x1000 0x2f20>;
+					};
+
+					macaddr_wifi0: macaddr@1006 {
+						reg = <0x1006 0x6>;
+					};
+
+					precal_wifi1: precal@5000 {
+						reg = <0x5000 0x2f20>;
+					};
+
+					macaddr_wifi1: macaddr@5006 {
+						reg = <0x5006 0x6>;
+					};
+
+					precal_wifi2: precal@9000 {
+						reg = <0x9000 0x2f20>;
+					};
+
+					macaddr_wifi2: macaddr@9006 {
+						reg = <0x9006 0x6>;
+					};
+				};
+			};
+
+			partition4@180000 {
+				label = "dualflag";
+				reg = <0x00180000 0x00010000>;
+			};
+
+			partition5@190000 {
+				label = "CRT";
+				reg = <0x00190000 0x00010000>;
+				read-only;
+			};
+
+			partition6@1A0000 {
+				label = "reserved";
+				reg = <0x001A0000 0x00260000>;
+			};
+		};
+	};
+};
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial1_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp1_uart2 {
+	pinctrl-0 = <&serial2_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&sdhci {
+	status = "okay";
+	non-removable;
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport2 {
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac1>;
+	label = "lan3";
+};
+
+&swport3 {
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac1>;
+	label = "lan2";
+};
+
+&swport4 {
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac1>;
+	label = "lan1";
+};
+
+&swport5 { /* WAN */
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0 0>;
+};
+
+&wifi0 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_wifi0>, <&macaddr_wifi0>;
+	qcom,ath10k-calibration-variant = "Zyxel-WSQ50";
+};
+
+&wifi1 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_wifi1>, <&macaddr_wifi1>;
+	qcom,ath10k-calibration-variant = "Zyxel-WSQ50";
+};
+
+&pcie0 { /* QCA9984 */
+	status = "okay";
+	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	wake-gpio = <&tlmm 40 GPIO_ACTIVE_LOW>;
+	clkreq-gpio = <&tlmm 39 GPIO_ACTIVE_LOW>;
+
+	bridge@0,0 {
+		#address-cells = <3>;
+		#size-cells = <2>;
+		reg = <0x00000000 0 0 0 0>;
+		ranges;
+
+		wifi2: wifi@1,0 {
+			reg = <0x00010000 0 0 0 0>;
+			ieee80211-freq-limit = <5170000 5875000>;
+			compatible = "qcom,ath10k";
+			nvmem-cell-names = "pre-calibration", "mac-address";
+			nvmem-cells = <&precal_wifi2>, <&macaddr_wifi2>;
+			qcom,ath10k-calibration-variant = "Zyxel-WSQ50";
+		};
+	};
+};
+
+&usb2 {
+	status = "okay";
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -43,6 +43,13 @@ define Device/DniImage
 		append-rootfs | pad-rootfs | check-size | append-metadata
 endef
 
+define Device/ZyXELImageLzma
+	$(call Device/FitImageLzma)
+	IMAGES += factory.bin
+	IMAGE/factory.bin := append-rootfs | pad-rootfs | pad-to $$$$(BLOCKSIZE) | zyxel-ras-image separate-kernel
+	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-to $$$$(BLOCKSIZE) | sysupgrade-tar rootfs=$$$$@ | append-metadata
+endef
+
 define Build/append-rootfshdr
 	mkimage -A $(LINUX_KARCH) \
 		-O linux -T filesystem \
@@ -1311,3 +1318,19 @@ define Device/zyxel_wre6606
 endef
 # Missing DSA Setup
 #TARGET_DEVICES += zyxel_wre6606
+
+define Device/zyxel_wsq50
+	$(call Device/ZyXELImageLzma)
+	DEVICE_VENDOR := ZyXEL
+	DEVICE_MODEL := WSQ50
+	SOC := qcom-ipq4019
+	BLOCKSIZE := 64k
+	RAS_BOARD := WSQ50
+	RAS_ROOTFS_SIZE := 20934k
+	RAS_VERSION := "$(VERSION_DIST) $(REVISION)"
+	DEVICE_PACKAGES := \
+		-ath10k-firmware-qca4019 -ath10k-firmware-qca4019-ct -ath10k-firmware-qca9984 -ath10k-firmware-qca9984-ct \
+		ath10k-firmware-qca4019-ct-full-htt ath10k-firmware-qca9984-ct-full-htt \
+		kmod-ath3k kmod-bluetooth kmod-fs-ext4 tune2fs e2fsprogs losetup blockd
+endef
+TARGET_DEVICES += zyxel_wsq50


### PR DESCRIPTION
ipq40xx: add support for the ZyXEL WSQ50

### Introduction

This patch adds support for the ZyXEL WSQ50 device:

(Taken from [https://deviwiki.com/wiki/ZyXEL_WSQ50](https://deviwiki.com/wiki/ZyXEL_WSQ50))

- SOC:  IPQ4019 / QCA Dakota
- CPU:  Quad-Core ARMv7 Processor rev 5 (v7l) Cortex-A7
- DRAM: 512 MiB DDR3L
- NOR:  8 Mb Micron M25P80 Serial Flash Embedded Memory
- ETH: Qualcomm Atheros QCA8075 Gigabit Switch (3 x LAN, 1 x WAN)
- USB: 1 x 2.0 (via Synopsys DesignWare DWC3 controller in the SoC)
- WLAN1: Qualcomm Atheros QCA4018 2.4GHz 802.11bgn 2:2x2
- WLAN2: Qualcomm Atheros QCA4018 5GHz 802.11a/n/ac 2:2x2
- WLAN3: Qualcomm Atheros QCA9984 5GHz 802.11a/n/ac Wave2 4:4x4
- BT: Qualcomm CSR8811 BT 4.1 LE
- INPUT: RESET Button
- LEDS: Singular RGB LED broken out into 3 channels (red / green / blue) 

All of the above hardware is working with this patch. 

### Initial installation

This device needs a 3.3v logic USB serial adapter to flash the initial firmware, as well as some knowledge of u-boot and a custom ZyXEL firmware unlocking script. You can install via USB or over Ethernet. 

If you want to install the firmware from a USB stick, make sure this formatted as FAT32, you've copied across the `*-factory.bin` image to it and placed it in the USB port on the back of the unit.

#### Prepare the device

1. Unplug all cables, pull off the rubber feet, remove 4 screws and then carefully lever the device case apart
2. Locate the UART header on the front side of the PCB (by the LYNwave.com stamp) - it's an unsoldered 0.1" pitch 4 pin header at the front of the unit (opposite the Ethernet ports)
3. Connect a suitable serial adapter (soldering on pins if you need to), the pinouts are as follows: `[ V | G |  RX | TX ]` (3.3v, Ground, RX and TX respectively) - V is the square copper trace on the PCB (closest the USB port), the rest are usual round copper traces
4. Open the serial adapter with the usual `115200 8N1` settings in your favourite terminal application
5. Reset the unit back to factory defaults - hold the RESET button whilst attaching power, you'll eventually see `Erase rootfs_data partition...` over the UART
6. Power cycle the unit again and when prompted, press any key to stop autoboot
7. Follow the instructions on this web page to unlock the bootloader: [ZyXEL U-Boot Unlocker](https://akao.co.uk/tools/zyxel_unlocker/)
8. With the bootloader now unlocked, run `run boot_mmc_1` to boot into the failsafe firmware
9. When booting you should be able to log in as `root` / `1234` (but you may need to enter failsafe mode and `mount_root` and `passwd` to change it)

#### Installing via USB

1. Locate where the USB mounted, typically under `/tmp/storage/`, this may help you easily find it: `cd /tmp/storage/*/*`
2. Use the native firmware flasher `FW_upgrade` (note the capitalisation, there's another lowercase `fw_upgrade` which this wraps) to flash the firmware: `FW_upgrade ./openwrt-ipq40xx-generic-zyxel_wsq50-squashfs-factory.bin`

#### Installing via Ethernet

1. Plug in an Ethernet cable to the WAN port connected your home LAN and then run `udhcpc` to get an IP
2. Activate DNS It won't have DNS, so run `echo "nameserver 8.8.8.8" > /etc/resolv.conf`
3. Download the firmware from your favourite webserver with `curl -k --output /tmp/newfw.bin https://example.com/openwrt-ipq40xx-generic-zyxel_wsq50-squashfs-factory.bin`
4. Use the native firmware flasher `FW_upgrade` (note the capitalisation, there's another lowercase `fw_upgrade` which this wraps) to flash the firmware: `FW_upgrade /tmp/newfw.bin`

When either of those have finished, `reboot` the unit and enjoy OpenWrt properly :)

Pictures and full documentation will come with a wiki page when approved, however the process is as follows;

### Future upgrades

The usual sysupgrade process is supported, just install updates via the OpenWrt LuCI GUI.

### Booting the failsafe firmware again

If for whatever reason you want to boot ZyXEL's failsafe firmware again (God help you), just repeat steps 1-8 above and go through the usual setup procedure and then install any firmware update for it to overwrite OpenWrt.

Signed-off-by: Jason Gaunt <github@akao.co.uk>