### PR TITLE
base-files: Add support for triggering multiple LEDs in diag

### DIFF
--- a/package/base-files/files/lib/functions/leds.sh
+++ b/package/base-files/files/lib/functions/leds.sh
@@ -1,94 +1,103 @@
 # Copyright (C) 2013 OpenWrt.org
 
 get_dt_led_path() {
-	local ledpath
 	local basepath="/proc/device-tree"
 	local nodepath="$basepath/aliases/led-$1"
+	local ledlist
 
-	[ -f "$nodepath" ] && ledpath=$(cat "$nodepath")
-	[ -n "$ledpath" ] && ledpath="$basepath$ledpath"
+	for ledpath in $(ls -1 "$nodepath"* 2>/dev/null); do
+		[ -f "$ledpath" ] && ledpath=$(cat "$ledpath")
+		[ -n "$ledpath" ] && ledpath="$basepath$ledpath"
+		ledlist="${ledlist} ${ledpath}"
+	done
 
-	echo "$ledpath"
+	echo "$ledlist" | tr ' ' '\n' | sort -u
 }
 
 get_dt_led() {
 	local label
-	local ledpath=$(get_dt_led_path $1)
+	local ledpathlist
 
-	[ -n "$ledpath" ] && \
-		label=$(cat "$ledpath/label" 2>/dev/null) || \
-		label=$(cat "$ledpath/chan-name" 2>/dev/null) || \
-		label=$(basename "$ledpath")
+	for ledpath in $(get_dt_led_path $1 | tr ' ' '\n'); do
+		[ -n "$ledpath" ] && \
+			label=$(cat "$ledpath/label" 2>/dev/null) || \
+			label=$(cat "$ledpath/chan-name" 2>/dev/null) || \
+			label=$(basename "$ledpath")
+		ledpathlist="${ledpathlist} ${label}"
+	done
 
-	echo "$label"
+	echo "$ledpathlist" | awk '{$1=$1};1'
 }
 
 led_set_attr() {
-	[ -f "/sys/class/leds/$1/$2" ] && echo "$3" > "/sys/class/leds/$1/$2"
+	for ledpath in $1; do
+		[ -f "/sys/class/leds/$ledpath/$2" ] && echo "$3" > "/sys/class/leds/$ledpath/$2"
+	done
 }
 
 led_timer() {
-	led_set_attr $1 "trigger" "timer"
-	led_set_attr $1 "delay_on" "$2"
-	led_set_attr $1 "delay_off" "$3"
+	led_set_attr "${1}" "delay_on" "$2"
+	led_set_attr "${1}" "delay_off" "$3"
+	led_set_attr "${1}" "trigger" "timer"
 }
 
 led_on() {
-	led_set_attr $1 "trigger" "none"
-	led_set_attr $1 "brightness" 255
+	led_set_attr "${1}" "trigger" "none"
+	led_set_attr "${1}" "brightness" 255
 }
 
 led_off() {
-	led_set_attr $1 "trigger" "none"
-	led_set_attr $1 "brightness" 0
+	led_set_attr "${1}" "trigger" "none"
+	led_set_attr "${1}" "brightness" 0
 }
 
 status_led_restore_trigger() {
 	local trigger
-	local ledpath=$(get_dt_led_path $1)
 
-	[ -n "$ledpath" ] && \
-		trigger=$(cat "$ledpath/linux,default-trigger" 2>/dev/null)
+	for ledpath in $(get_dt_led_path $1); do
+		[ -n "$ledpath" ] && \
+			trigger=$(cat "$ledpath/linux,default-trigger" 2>/dev/null)
 
-	[ -n "$trigger" ] && \
-		led_set_attr "$(get_dt_led $1)" "trigger" "$trigger"
+		[ -n "$trigger" ] && \
+			led_set_attr "$(get_dt_led $1)" "trigger" "$trigger"
+	done
 }
 
 status_led_set_timer() {
-	led_timer $status_led "$1" "$2"
+	led_timer "${status_led}" "$1" "$2"
 	[ -n "$status_led2" ] && led_timer $status_led2 "$1" "$2"
 }
 
 status_led_set_heartbeat() {
-	led_set_attr $status_led "trigger" "heartbeat"
+	led_set_attr "${status_led}" "trigger" "heartbeat"
 }
 
 status_led_on() {
-	led_on $status_led
+	led_on "${status_led}"
 	[ -n "$status_led2" ] && led_on $status_led2
 }
 
 status_led_off() {
-	led_off $status_led
+	led_off "${status_led}"
 	[ -n "$status_led2" ] && led_off $status_led2
 }
 
 status_led_blink_slow() {
-	led_timer $status_led 1000 1000
+	led_timer "${status_led}" 1000 1000
 }
 
 status_led_blink_fast() {
-	led_timer $status_led 100 100
+	led_timer "${status_led}" 100 100
 }
 
 status_led_blink_preinit() {
-	led_timer $status_led 100 100
+	led_timer "${status_led}" 100 100
 }
 
 status_led_blink_failsafe() {
-	led_timer $status_led 50 50
+	led_timer "${status_led}" 50 50
 }
 
 status_led_blink_preinit_regular() {
-	led_timer $status_led 200 200
+	led_timer "${status_led}" 200 200
 }


### PR DESCRIPTION
base-files: Add support for multiple LED's in diagnostic system (relating to `diag.sh` and `leds.sh`).

### Introduction

This permits using multiple LED's at once to indicate a state such as `running` or `failsafe` by efficiently globbling
aliases. This can then, for example, trigger RGB LED's red/green/blue channels simultaneously for a white light.

Backwards compatibility has been maintained and this has been passed through the attentions of multiple
people on the #openwrt-devel IRC channel and code improved (Thanks PaulFertser / robimarko / grid).

### Usage

This can just be merged in without any impact to existing devices, backwards-compatibility has been maintained.

Future devices can then specify aliases in their device tree files with a similar format (formatted for readability):

```
	aliases {
		led-boot = &status_green;
		led-boot-aux1 = &status_red;
		led-boot-aux2 = &status_blue;

		led-running = &status_green;
		led-running-aux1 = &status_red;
		led-running-aux2 = &status_blue;

		led-failsafe = &status_red;
		led-upgrade = &status_blue;
	};
```

Taking `led-boot` as an example, the code attempts to glob-match any alias starting `led-boot*` (which will match the existing `led-boot` alias) and then iterates over each of them to set the LED state.

It can even be something like this and still function as designed:

```
	aliases {
		led-boot-red = &status_red;
		led-boot-green = &status_green;
		led-boot-blue = &status_blue;

		led-running-chan0 = &status_red;
		led-running-chan1 = &status_green;
		led-running-chan2 = &status_blue;

		led-failsafe = &status_red;
		led-upgrade = &status_blue;
	};
```

This has been successfully tested with the ZyXEL WSQ50 / WSQ60 devices (pending acceptance) and works as expected. Please don't hesitate to ask any questions or ping me on IRC.

Signed-off-by: Jason Gaunt <github@akao.co.uk>