### PR TITLE
f2fs-tools: avoid dead symlinks in root

### DIFF
--- a/package/utils/f2fs-tools/Makefile
+++ b/package/utils/f2fs-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=f2fs-tools
 PKG_VERSION:=1.16.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/snapshot/
@@ -133,10 +133,10 @@ Package/mkf2fs-selinux/install = $(Package/mkf2fs/install)
 define Package/f2fsck/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/fsck.f2fs $(1)/usr/sbin
-	ln -s /usr/sbin/fsck.f2fs $(1)/usr/sbin/defrag.f2fs
-	ln -s /usr/sbin/fsck.f2fs $(1)/usr/sbin/dump.f2fs
-	ln -s /usr/sbin/fsck.f2fs $(1)/usr/sbin/sload.f2fs
-	ln -s /usr/sbin/fsck.f2fs $(1)/usr/sbin/resize.f2fs
+	$(LN) ../sbin/fsck.f2fs $(1)/usr/sbin/defrag.f2fs
+	$(LN) ../sbin/fsck.f2fs $(1)/usr/sbin/dump.f2fs
+	$(LN) ../sbin/fsck.f2fs $(1)/usr/sbin/sload.f2fs
+	$(LN) ../sbin/fsck.f2fs $(1)/usr/sbin/resize.f2fs
 endef
 
 Package/f2fsck-selinux/install = $(Package/f2fsck/install)


### PR DESCRIPTION
When building on the host, this avoids creating dead symlinks. Matches what is done elsewhere.

ping @hauke @Ansuel 