### PR TITLE
mediatek: fiilogic: device tree `switch@1f` fix

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cetron-ct3003.dts
+++ b/target/linux/mediatek/dts/mt7981b-cetron-ct3003.dts
@@ -77,7 +77,7 @@
 };
 
 &mdio_bus {
-	switch: switch@0 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;

--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m.dts
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m.dts
@@ -90,7 +90,7 @@
 };
 
 &mdio_bus {
-	switch: switch@0 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
@@ -112,7 +112,7 @@
 };
 
 &mdio_bus {
-	switch: switch@0 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;

--- a/target/linux/mediatek/dts/mt7981b-h3c-magic-nx30-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-h3c-magic-nx30-pro.dts
@@ -81,7 +81,7 @@
 };
 
 &mdio_bus {
-	switch: switch@0 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;

--- a/target/linux/mediatek/dts/mt7981b-jcg-q30-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-jcg-q30-pro.dts
@@ -72,7 +72,7 @@
 };
 
 &mdio_bus {
-	switch: switch@0 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;

--- a/target/linux/mediatek/dts/mt7981b-qihoo-360t7.dts
+++ b/target/linux/mediatek/dts/mt7981b-qihoo-360t7.dts
@@ -74,7 +74,7 @@
 };
 
 &mdio_bus {
-	switch: switch@0 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;

--- a/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-wr30u.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-wr30u.dtsi
@@ -86,7 +86,7 @@
 };
 
 &mdio_bus {
-	switch: switch@0 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;

--- a/target/linux/mediatek/dts/mt7986a-acer-predator-w6.dts
+++ b/target/linux/mediatek/dts/mt7986a-acer-predator-w6.dts
@@ -229,7 +229,7 @@
 		mxl,led-config = <0x0 0x0 0x370 0x80>;
 	};
 
-	switch: switch@0 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
@@ -136,7 +136,7 @@
 		mxl,led-config = <0x03f0 0x0 0x0 0x0>;
 	};
 
-	switch: switch@0 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
@@ -142,7 +142,7 @@
 		mxl,led-config = <0x03f0 0x0 0x0 0x0>;
 	};
 
-	switch: switch@0 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 

--- a/target/linux/mediatek/dts/mt7986a-glinet-gl-mt6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-glinet-gl-mt6000.dts
@@ -122,7 +122,7 @@
 			realtek,aldps-enable;
 		};
 
-		switch: switch@31 {
+		switch: switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
 			reset-gpios = <&pio 18 GPIO_ACTIVE_HIGH>;

--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
@@ -141,7 +141,7 @@
 		realtek,aldps-enable;
 	};
 
-	switch: switch@31 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;

--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
@@ -72,7 +72,7 @@
 };
 
 &mdio {
-	switch: switch@0 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
@@ -199,7 +199,7 @@
 			reg = <6>;
 		};
 
-		switch@0 {
+		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
 			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;

--- a/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1.dts
+++ b/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1.dts
@@ -120,7 +120,7 @@
 		reg = <6>;
 	};
 
-	switch: switch@0 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;

--- a/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3.dts
+++ b/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3.dts
@@ -200,7 +200,7 @@
 };
 
 &mdio {
-	switch: switch@31 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		interrupt-controller;

--- a/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7986a-rfb.dtsi
+++ b/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7986a-rfb.dtsi
@@ -99,7 +99,7 @@
 		reg = <6>;
 	};
 
-	switch: switch@0 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		reset-gpios = <&pio 5 0>;

--- a/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7986b-rfb.dts
+++ b/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7986b-rfb.dts
@@ -108,7 +108,7 @@
 			phy-mode = "2500base-x";
 		};
 
-		switch@0 {
+		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
 			reset-gpios = <&pio 5 0>;

--- a/target/linux/mediatek/files-6.1/arch/arm64/boot/dts/mediatek/mt7986a-rfb.dtsi
+++ b/target/linux/mediatek/files-6.1/arch/arm64/boot/dts/mediatek/mt7986a-rfb.dtsi
@@ -99,7 +99,7 @@
 		reg = <6>;
 	};
 
-	switch: switch@0 {
+	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		reset-gpios = <&pio 5 0>;

--- a/target/linux/mediatek/patches-6.1/010-v6.3-arm64-dts-mt7986-add-Bananapi-R3.patch
+++ b/target/linux/mediatek/patches-6.1/010-v6.3-arm64-dts-mt7986-add-Bananapi-R3.patch
@@ -405,7 +405,7 @@ Signed-off-by: Matthias Brugger <matthias.bgg@gmail.com>
 +};
 +
 +&mdio {
-+	switch: switch@31 {
++	switch: switch@1f {
 +		compatible = "mediatek,mt7531";
 +		reg = <31>;
 +		interrupt-controller;


### PR DESCRIPTION
Quite a few `fiilogic` devices use the `mt7531` switch. Some of them have a DT node that looks like:
```
switch: switch@0 {
	compatible = "mediatek,mt7531";
	reg = <31>;
	...
};
```
This commit changes the DT node name to `switch@1f`.
