### PR TITLE
qualcommax: ipq807x: add support for Linksys MX5300

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq807x
@@ -30,7 +30,8 @@ edimax,cax1800)
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x20000"
 	;;
 linksys,mx4200v1|\
-linksys,mx4200v2)
+linksys,mx4200v2|\
+linksys,mx5300)
 	idx="$(find_mtd_index u_env)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000" "2"

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -6,9 +6,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firmware/qca-wireless.git
-PKG_SOURCE_DATE:=2024-02-19
-PKG_SOURCE_VERSION:=1cc59e1e09f68305bbf15e2de23d1c1829aee1eb
-PKG_MIRROR_HASH:=383e7384d37cde2433b9bf6daee5d57ecd6f2c473f00901b491ae0c15d97fd53
+PKG_SOURCE_DATE:=2024-02-23
+PKG_SOURCE_VERSION:=9f9d9ba9cd77043744dcd5235497a15eea51c375
+PKG_MIRROR_HASH:=3a064a8810e6857580c4682f6b86a9dfcdb0d3aa361f4ec0c5480c54de4cc864
 
 PKG_FLAGS:=nonshared
 
@@ -37,6 +37,7 @@ ALLWIFIBOARDS:= \
 	edgecore_eap102 \
 	edimax_cax1800 \
 	linksys_mx4200 \
+	linksys_mx5300 \
 	netgear_rax120v2 \
 	netgear_wax218 \
 	netgear_wax620 \
@@ -152,6 +153,7 @@ $(eval $(call generate-ipq-wifi-package,dynalink_dl-wrx36,Dynalink DL-WRX36))
 $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))
 $(eval $(call generate-ipq-wifi-package,linksys_mx4200,Linksys MX4200))
+$(eval $(call generate-ipq-wifi-package,linksys_mx5300,Linksys MX5300))
 $(eval $(call generate-ipq-wifi-package,netgear_rax120v2,Netgear RAX120v2))
 $(eval $(call generate-ipq-wifi-package,netgear_wax218,Netgear WAX218))
 $(eval $(call generate-ipq-wifi-package,netgear_wax620,Netgear WAX620))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx5300.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx5300.dts
@@ -1,0 +1,544 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Linksys MX5300";
+	compatible = "linksys,mx5300", "qcom,ipq8074";
+
+	aliases {
+		serial0 = &blsp1_uart5;
+		/*
+		 * Aliases as required by u-boot
+		 * to patch MAC addresses
+		 */
+		ethernet0 = &dp1;
+		ethernet1 = &dp2;
+		ethernet2 = &dp3;
+		ethernet3 = &dp4;
+		ethernet4 = &dp5;
+		led-boot = &led_system_blue;
+		led-running = &led_system_blue;
+		led-failsafe = &led_system_red;
+		led-upgrade = &led_system_green;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_0 rootfstype=squashfs ro";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset-button {
+			label = "reset";
+			gpios = <&tlmm 67 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps-button {
+			label = "wps";
+			gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&tlmm {
+	button_pins: button-state {
+		pins = "gpio54", "gpio67";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+
+	mdio_pins: mdio-state {
+		mdc-pins {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio-pins {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	/*
+	 * QCA4024 is not currently supported, keep for documentation purposes
+	 *spi_3_pins: spi-3-state {
+	 *	spi-pins {
+	 *		pins = "gpio50", "gpio52", "gpio53";
+	 *		function = "blsp3_spi";
+	 *		drive-strength = <8>;
+	 *		bias-disable;
+	 *	};
+	 *
+	 *	cs-pins {
+	 *		pins = "gpio22";
+	 *		function = "blsp3_spi2";
+	 *		drive-strength = <8>;
+	 *		bias-disable;
+	 *	};
+	 *};
+	 *
+	 *quartz_pins: quartz-state {
+	 *	interrupt-pins {
+	 *		pins = "gpio48";
+	 *		function = "gpio";
+	 *		bias-disable;
+	 *		input;
+	 *	};
+	 *
+	 *	reset-pins {
+	 *		pins = "gpio21";
+	 *		function = "gpio";
+	 *		bias-disable;
+	 *		output-high;
+	 *	};
+	 *};
+	 */
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	/*
+	 * Bootloader will find the NAND DT node by the compatible and
+	 * then "fixup" it by adding the partitions from the SMEM table
+	 * using the legacy bindings thus making it impossible for us
+	 * to change the partition table or utilize NVMEM for calibration.
+	 * So add a dummy partitions node that bootloader will populate
+	 * and set it as disabled so the kernel ignores it instead of
+	 * printing warnings due to the broken way bootloader adds the
+	 * partitions.
+	 */
+	partitions {
+		status = "disabled";
+	};
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:sbl1";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "0:mibib";
+				reg = <0x100000 0x100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "0:bootconfig";
+				reg = <0x200000 0x80000>;
+				read-only;
+			};
+
+			partition@280000 {
+				label = "0:bootconfig1";
+				reg = <0x280000 0x80000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "0:qsee";
+				reg = <0x300000 0x300000>;
+				read-only;
+			};
+
+			partition@600000 {
+				label = "0:qsee_1";
+				reg = <0x600000 0x300000>;
+				read-only;
+			};
+
+			partition@900000 {
+				label = "0:devcfg";
+				reg = <0x900000 0x80000>;
+				read-only;
+			};
+
+			partition@980000 {
+				label = "0:devcfg_1";
+				reg = <0x980000 0x80000>;
+				read-only;
+			};
+
+			partition@a00000 {
+				label = "0:apdp";
+				reg = <0xa00000 0x80000>;
+				read-only;
+			};
+
+			partition@a80000 {
+				label = "0:apdp_1";
+				reg = <0xa80000 0x80000>;
+				read-only;
+			};
+
+			partition@b00000 {
+				label = "0:rpm";
+				reg = <0xb00000 0x80000>;
+				read-only;
+			};
+
+			partition@b80000 {
+				label = "0:rpm_1";
+				reg = <0xb80000 0x80000>;
+				read-only;
+			};
+
+			partition@c00000 {
+				label = "0:cdt";
+				reg = <0xc00000 0x80000>;
+				read-only;
+			};
+
+			partition@c80000 {
+				label = "0:cdt_1";
+				reg = <0xc80000 0x80000>;
+				read-only;
+			};
+
+			partition@d00000 {
+				label = "0:appsblenv";
+				reg = <0xd00000 0x80000>;
+			};
+
+			partition@d80000 {
+				label = "0:appsbl";
+				reg = <0xd80000 0x100000>;
+				read-only;
+			};
+
+			partition@e80000 {
+				label = "0:appsbl_1";
+				reg = <0xe80000 0x100000>;
+				read-only;
+			};
+
+			partition@f80000 {
+				label = "0:art";
+				reg = <0xf80000 0x80000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					caldata_qca9984: caldata@33000 {
+						reg = <0x33000 0x2f20>;
+					};
+				};
+			};
+
+			partition@1000000 {
+				label = "u_env";
+				reg = <0x1000000 0x40000>;
+			};
+
+			partition@1040000 {
+				label = "s_env";
+				reg = <0x1040000 0x20000>;
+			};
+
+			partition@1060000 {
+				label = "devinfo";
+				reg = <0x1060000 0x20000>;
+				read-only;
+			};
+
+			partition@1080000 {
+				label = "kernel";
+				reg = <0x1080000 0x9600000>;
+			};
+
+			partition@1680000 {
+				label = "rootfs";
+				reg = <0x1680000 0x9000000>;
+			};
+
+			partition@a680000 {
+				label = "alt_kernel";
+				reg = <0xa680000 0x9600000>;
+			};
+
+			partition@ac80000 {
+				label = "alt_rootfs";
+				reg = <0xac80000 0x9000000>;
+			};
+			partition@13c80000 {
+				label = "sysdiag";
+				reg = <0x13c80000 0x200000>;
+				read-only;
+			};
+			partition@13e80000 {
+				label = "0:ethphyfw";
+				reg = <0x13e80000 0x80000>;
+				read-only;
+			};
+			partition@13f00000 {
+				label = "syscfg";
+				reg = <0x13f00000 0xb800000>;
+				read-only;
+			};
+			partition@1f700000 {
+				label = "0:wififw";
+				reg = <0x1f700000 0x900000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&blsp1_i2c2 {
+	status = "okay";
+
+	led-controller@62 {
+		compatible = "nxp,pca9633";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x62>;
+		nxp,hw-blink;
+
+		led_system_red: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_green: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+
+	rtc@68 {
+		compatible = "dallas,ds1307";
+		reg = <0x68>;
+	};
+};
+
+/*
+ * QCA4024 is not currently supported, keep for documentation purposes
+ *&blsp1_spi4 {
+ *	status = "okay";
+ *
+ *	pinctrl-0 = <&spi_3_pins &quartz_pins>;
+ *	pinctrl-names = "default";
+ *
+ *	iot@3 {
+ *		compatible = "qca,qca4024";
+ *		reg = <0>;
+ *		spi-max-frequency = <24000000>;
+ *	};
+ *};
+ */
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+
+	ethernet-phy-package@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "qcom,qca8075-package";
+		reg = <0>;
+
+		qca8075_0: ethernet-phy@0 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <0>;
+		};
+
+		qca8075_1: ethernet-phy@1 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <1>;
+		};
+
+		qca8075_2: ethernet-phy@2 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <2>;
+		};
+
+		qca8075_3: ethernet-phy@3 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <3>;
+		};
+
+		qca8075_4: ethernet-phy@4 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <4>;
+		};
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
+	switch_mac_mode = <MAC_MODE_PSGMII>; /* mac mode for uniphy instance0*/
+
+	qcom,port_phyinfo {
+		port@1 {
+			port_id = <1>;
+			phy_address = <0>;
+		};
+		port@2 {
+			port_id = <2>;
+			phy_address = <1>;
+		};
+		port@3 {
+			port_id = <3>;
+			phy_address = <2>;
+		};
+		port@4 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+		port@5 {
+			port_id = <5>;
+			phy_address = <4>;
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp1 {
+	status = "okay";
+	phy-handle = <&qca8075_0>;
+	label = "lan1";
+};
+
+&dp2 {
+	status = "okay";
+	phy-handle = <&qca8075_1>;
+	label = "lan2";
+};
+
+&dp3 {
+	status = "okay";
+	phy-handle = <&qca8075_2>;
+	label = "lan3";
+};
+
+&dp4 {
+	status = "okay";
+	phy-handle = <&qca8075_3>;
+	label = "lan4";
+};
+
+&dp5 {
+	status = "okay";
+	phy-handle = <&qca8075_4>;
+	label = "wan";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&usb_0 {
+	status = "okay";
+};
+
+&pcie_qmp1 {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+
+	perst-gpio = <&tlmm 58 GPIO_ACTIVE_LOW>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi0: wifi@1,0 {
+			status = "okay";
+
+			compatible = "qcom,ath10k";
+			reg = <0x00010000 0 0 0 0>;
+
+			qcom,ath10k-calibration-variant = "Linksys-MX5300";
+			nvmem-cell-names = "pre-calibration";
+			nvmem-cells = <&caldata_qca9984>;
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Linksys-MX5300";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -126,6 +126,23 @@ define Device/linksys_mx4200v2
 endef
 TARGET_DEVICES += linksys_mx4200v2
 
+define Device/linksys_mx5300
+	$(call Device/FitImage)
+	DEVICE_VENDOR := Linksys
+	DEVICE_MODEL := MX5300
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	KERNEL_SIZE := 6144k
+	IMAGE_SIZE := 147456k
+	NAND_SIZE := 512m
+	SOC := ipq8072
+	IMAGES += factory.bin
+	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=MX5300
+	DEVICE_PACKAGES := kmod-leds-pca963x kmod-rtc-ds1307 \
+		ipq-wifi-linksys_mx5300 kmod-ath10k-ct ath10k-firmware-qca9984-ct
+endef
+TARGET_DEVICES += linksys_mx5300
+
 define Device/netgear_rax120v2
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -23,6 +23,7 @@ ipq807x_setup_interfaces()
 	compex,wpq873|\
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
+	prpl,haze|\
 	redmi,ax6|\
 	xiaomi,ax3600)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
@@ -44,9 +45,6 @@ ipq807x_setup_interfaces()
 		;;
 	netgear,wax630)
 		ucidef_set_interface_lan "lan1 lan2" "dhcp"
-		;;
-	prpl,haze)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
 	qnap,301w)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 10g-2" "10g-1"

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ ipq807x_setup_interfaces()
 	arcadyan,aw1000|\
 	buffalo,wxr-5950ax12|\
 	dynalink,dl-wrx36|\
+	linksys,mx5300|\
 	xiaomi,ax9000)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -18,6 +18,7 @@ case "$FIRMWARE" in
 	edimax,cax1800|\
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
+	linksys,mx5300|\
 	netgear,rax120v2|\
 	netgear,wax218|\
 	netgear,wax620|\

--- a/target/linux/qualcommax/ipq807x/base-files/etc/init.d/bootcount
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/init.d/bootcount
@@ -11,7 +11,8 @@ boot() {
 		fw_setenv changed
 	;;
 	linksys,mx4200v1|\
-	linksys,mx4200v2)
+	linksys,mx4200v2|\
+	linksys,mx5300)
 		mtd resetbc s_env || true
 	;;
 	esac

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -75,7 +75,8 @@ platform_do_upgrade() {
 		nand_do_upgrade "$1"
 		;;
 	linksys,mx4200v1|\
-	linksys,mx4200v2)
+	linksys,mx4200v2|\
+	linksys,mx5300)
 		boot_part="$(fw_printenv -n boot_part)"
 		if [ "$boot_part" -eq "1" ]; then
 			fw_setenv boot_part 2

--- a/target/linux/qualcommax/patches-6.1/0062-v6.8-arm64-dts-qcom-ipq8074-Add-QUP4-SPI-node.patch
+++ b/target/linux/qualcommax/patches-6.1/0062-v6.8-arm64-dts-qcom-ipq8074-Add-QUP4-SPI-node.patch
@@ -1,0 +1,38 @@
+From 6a25e70214fde6dcf900271c819c8d7fe7b9a4b0 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Thu, 23 Nov 2023 13:12:54 +0100
+Subject: [PATCH] arm64: dts: qcom: ipq8074: Add QUP4 SPI node
+
+Add node to support the QUP4 SPI controller inside of IPQ8074.
+Some devices use this bus to communicate to a Bluetooth controller.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+Link: https://lore.kernel.org/r/20231123121324.1046164-1-robimarko@gmail.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+---
+ arch/arm64/boot/dts/qcom/ipq8074.dtsi | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+--- a/arch/arm64/boot/dts/qcom/ipq8074.dtsi
++++ b/arch/arm64/boot/dts/qcom/ipq8074.dtsi
+@@ -529,6 +529,20 @@
+ 			status = "disabled";
+ 		};
+ 
++		blsp1_spi4: spi@78b8000 {
++			compatible = "qcom,spi-qup-v2.2.1";
++			#address-cells = <1>;
++			#size-cells = <0>;
++			reg = <0x78b8000 0x600>;
++			interrupts = <GIC_SPI 98 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&gcc GCC_BLSP1_QUP4_SPI_APPS_CLK>,
++				 <&gcc GCC_BLSP1_AHB_CLK>;
++			clock-names = "core", "iface";
++			dmas = <&blsp_dma 18>, <&blsp_dma 19>;
++			dma-names = "tx", "rx";
++			status = "disabled";
++		};
++
+ 		blsp1_i2c5: i2c@78b9000 {
+ 			compatible = "qcom,i2c-qup-v2.2.1";
+ 			#address-cells = <1>;

--- a/target/linux/qualcommax/patches-6.1/0111-arm64-dts-qcom-ipq8074-use-msi-parent-for-PCIe.patch
+++ b/target/linux/qualcommax/patches-6.1/0111-arm64-dts-qcom-ipq8074-use-msi-parent-for-PCIe.patch
@@ -12,7 +12,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 
 --- a/arch/arm64/boot/dts/qcom/ipq8074.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq8074.dtsi
-@@ -720,7 +720,7 @@
+@@ -734,7 +734,7 @@
  			reg = <0x0b000000 0x1000>, <0x0b002000 0x1000>;
  			ranges = <0 0xb00a000 0xffd>;
  
@@ -21,7 +21,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  				compatible = "arm,gic-v2m-frame";
  				msi-controller;
  				reg = <0x0 0xffd>;
-@@ -833,8 +833,7 @@
+@@ -847,8 +847,7 @@
  			ranges = <0x81000000 0x0 0x00000000 0x10200000 0x0 0x10000>,   /* I/O */
  				 <0x82000000 0x0 0x10220000 0x10220000 0x0 0xfde0000>; /* MEM */
  
@@ -31,7 +31,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  			#interrupt-cells = <1>;
  			interrupt-map-mask = <0 0 0 0x7>;
  			interrupt-map = <0 0 0 1 &intc 0 142
-@@ -895,8 +894,7 @@
+@@ -909,8 +908,7 @@
  			ranges = <0x81000000 0x0 0x00000000 0x20200000 0x0 0x10000>,   /* I/O */
  				 <0x82000000 0x0 0x20220000 0x20220000 0x0 0xfde0000>; /* MEM */
  

--- a/target/linux/qualcommax/patches-6.1/0120-arm64-dts-qcom-Enable-Q6v5-WCSS-for-ipq8074-SoC.patch
+++ b/target/linux/qualcommax/patches-6.1/0120-arm64-dts-qcom-Enable-Q6v5-WCSS-for-ipq8074-SoC.patch
@@ -61,7 +61,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  		spmi_bus: spmi@200f000 {
  			compatible = "qcom,spmi-pmic-arb";
  			reg = <0x0200f000 0x001000>,
-@@ -935,6 +966,56 @@
+@@ -949,6 +980,56 @@
  				      "axi_s_sticky";
  			status = "disabled";
  		};

--- a/target/linux/qualcommax/patches-6.1/0121-arm64-dts-ipq8074-Add-WLAN-node.patch
+++ b/target/linux/qualcommax/patches-6.1/0121-arm64-dts-ipq8074-Add-WLAN-node.patch
@@ -15,7 +15,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 
 --- a/arch/arm64/boot/dts/qcom/ipq8074.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq8074.dtsi
-@@ -1016,6 +1016,117 @@
+@@ -1030,6 +1030,117 @@
  				};
  			};
  		};


### PR DESCRIPTION
Hardware specification:
========
SoC: Qualcomm IPQ8072A
Flash: 512MB (Winbond W29N04GZBIBA)
RAM: 1GB (2x Nanya DDR3L NT5CC256M16ER-EK)
Ethernet: 5x 10/100/1000Mbps (Qualcomm QCA8075)
WiFi1: 5GHz ac 4x4 (Qualcomm QCA9984 + Skyworks SKY85746-11) - channels 100-169
WiFi2: 5GHz ax 4x4 (Qualcomm QCN5054 + Skyworks SKY85755-11) - channels 36-64
WiFi3: 2.4GHz ax 4x4 (Qualcomm QCN5024 + Skyworks SKY8340-11)
IoT: Bluetooth 5, Zigbee and Thread (Qualcomm QCA4024 + Skyworks SE2433T-R)
IoT Flash: 4MB (Macronix MX25R3235F)
RTC: ST M41T00S
LED: 1x RGB status (NXP PCA9633)
USB: 1x USB 3.0
Button: WPS, Reset

Flash instructions:
========
1. Manually upgrade firmware using openwrt-qualcommax-ipq807x-linksys_mx5300-squashfs-factory.bin image. More details can be found here: https://www.linksys.com/hk/support-article/?articleNum=274497
  After first boot check actual partition:
    - `fw_printenv -n boot_part`
  and install firmware on second partition using command in case of 2:
    - `mtd -r -e kernel -n write openwrt-qualcommax-ipq807x-linksys_mx5300-squashfs-factory.bin kernel`
  and in case of 1:
    - `mtd -r -e alt_kernel -n write openwrt-qualcommax-ipq807x-linksys_mx5300-squashfs-factory.bin alt_kernel`

2. Installation using serial connection from OEM firmware (default login: root, password: admin):
    - `fw_printenv -n boot_part`
  In case of 2:
    - `flash_erase /dev/mtd21 0 0`
      `nandwrite -p /dev/mtd21 openwrt-qualcommax-ipq807x-linksys_mx5300-squashfs-factory.bin`
  or in case of 1:
    - `flash_erase /dev/mtd23 0 0`
      `nandwrite -p /dev/mtd23 openwrt-qualcommax-ipq807x-linksys_mx5300-squashfs-factory.bin`
  After first boot install firmware on second partition:
    - `mtd -r -e kernel -n write openwrt-qualcommax-ipq807x-linksys_mx5300-squashfs-factory.bin kernel`
  or:
    - `mtd -r -e alt_kernel -n write openwrt-qualcommax-ipq807x-linksys_mx5300-squashfs-factory.bin alt_kernel`

3. Installation from initramfs image using USB FAT32 formatted drive:
  Stop u-boot and run:
    - `usb start && fatload usb 0:1 $loadaddr openwrt-qualcommax-ipq807x-linksys_mx5300-initramfs-uImage.itb && bootm $loadaddr`
  Write firmware to the flash from initramfs:
    - `mtd -e kernel -n write openwrt-qualcommax-ipq807x-linksys_mx5300-squashfs-factory.bin kernel`
  and:
    - `mtd -r -e alt_kernel -n write openwrt-qualcommax-ipq807x-linksys_mx5300-squashfs-factory.bin alt_kernel`

4. Back to the OEM firmware:
    - `mtd -e kernel -n write FW_MX5300_1.1.9.200251_prod.img kernel`
  and:
    - `mtd -r -e alt_kernel -n write FW_MX5300_1.1.9.200251_prod.img alt_kernel`

5. USB recovery using USB FAT32 formatted drive:
    - `fw_setenv usbimage 'openwrt-qualcommax-ipq807x-linksys_mx5300-initramfs-uImage.itb'`
      `fw_setenv bootusb 'usb start && fatload usb 0:1 $loadaddr $usbimage && bootm $loadaddr'`
      `fw_setenv bootcmd 'run bootusb; aq_load_fw && if test $auto_recovery = no; then bootipq; elif test $boot_part = 1; then run bootpart1; else run bootpart2; fi'`

Notes:
========
IoT device is accesible over spi. Not yet supported.