### PR TITLE
[fix]: patch target/linux/generic/pending-6.1/705-net-dsa-tag_mtk-add-padding-for-tx-packets.patch

### DIFF
--- a/target/linux/generic/pending-6.1/705-net-dsa-tag_mtk-add-padding-for-tx-packets.patch
+++ b/target/linux/generic/pending-6.1/705-net-dsa-tag_mtk-add-padding-for-tx-packets.patch
@@ -9,12 +9,16 @@ end of small packets.
 Fixes: 5cd8985a1909 ("net-next: dsa: add Mediatek tag RX/TX handler")
 Signed-off-by: Felix Fietkau <nbd@nbd.name>
 ---
+ net/dsa/tag_mtk.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
 
+diff --git a/net/dsa/tag_mtk.c b/net/dsa/tag_mtk.c
+index 415d8ece242a..51b8edd418ba 100644
 --- a/net/dsa/tag_mtk.c
 +++ b/net/dsa/tag_mtk.c
-@@ -27,6 +27,13 @@ static struct sk_buff *mtk_tag_xmit(stru
- 
- 	skb_set_queue_mapping(skb, dp->index);
+@@ -25,6 +25,13 @@ static struct sk_buff *mtk_tag_xmit(struct sk_buff *skb,
+ 	u8 xmit_tpid;
+ 	u8 *mtk_tag;
  
 +	/* The Ethernet switch we are interfaced with needs packets to be at
 +	 * least 64 bytes (including FCS) otherwise their padding might be
@@ -26,3 +30,5 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	/* Build the special tag after the MAC Source Address. If VLAN header
  	 * is present, it's required that VLAN header and special tag is
  	 * being combined. Only in this way we can allow the switch can parse
+-- 
+2.42.0


### PR DESCRIPTION
fix patch target/linux/generic/pending-6.1/705-net-dsa-tag_mtk-add-padding-for-tx-packets.patch

`git am` refuses to accept this patch. Change fixes it.