### PR TITLE
mediatek: filogic: Fix GPIOs for Zbtlink ZBT-Z8102AX

### DIFF
--- a/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
@@ -5,7 +5,7 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
-zbtlink,zbt-z8103ax)
+zbtlink,zbt-z8102ax)
 	ucidef_add_gpio_switch "5g1" "Power 1st modem" "5g1" "1"
 	ucidef_add_gpio_switch "5g2" "Power 2nd modem" "5g2" "1"
 	ucidef_add_gpio_switch "pcie" "Power PCIe port" "pcie" "1"


### PR DESCRIPTION
The PGIO configuration should be added for the ZBT-Z8102AX and not the ZBT-Z8103AX

Fixes: c8c2f522625c ("mediatek: add support for Zbtlink ZBT-Z8102AX")