### PR TITLE
[23.05] ramips: add support for Sercomm CPJ routers

### DIFF
--- a/scripts/sercomm-pid.py
+++ b/scripts/sercomm-pid.py
@@ -34,7 +34,7 @@ def get_pid(args):
 		enc = args.hw_version.rjust(8, '0').encode('ascii')
 		struct.pack_into('>8s', buf, 0x0, enc)
 
-		enc = binascii.hexlify(args.hw_id.encode())
+		enc = binascii.hexlify(args.hw_id.encode()).upper()
 		struct.pack_into('>6s', buf, 0x8, enc)
 
 	enc = args.sw_version.rjust(4, '0').encode('ascii')

--- a/target/linux/ramips/dts/mt7620a_rostelecom_rt-fl-1.dts
+++ b/target/linux/ramips/dts/mt7620a_rostelecom_rt-fl-1.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a_sercomm_cpj.dtsi"
+
+/ {
+	compatible = "rostelecom,rt-fl-1", "ralink,mt7620a-soc";
+	model = "Rostelecom RT-FL-1";
+};

--- a/target/linux/ramips/dts/mt7620a_rostelecom_s1010.dts
+++ b/target/linux/ramips/dts/mt7620a_rostelecom_s1010.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a_sercomm_cpj.dtsi"
+
+/ {
+	compatible = "rostelecom,s1010", "ralink,mt7620a-soc";
+	model = "Rostelecom S1010";
+};

--- a/target/linux/ramips/dts/mt7620a_sercomm_cpj.dtsi
+++ b/target/linux/ramips/dts/mt7620a_sercomm_cpj.dtsi
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		label-mac-device = &ethernet;
+
+		led-boot = &status_green;
+		led-failsafe = &status_amber;
+		led-running = &status_green;
+		led-upgrade = &status_amber;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-0 {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		button-1 {
+			label = "wps";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		status_green: led-0 {
+			label = "green:status";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		status_amber: led-1 {
+			label = "amber:status";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led-6 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led-7 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <24>;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,uimage";
+				/* sercomm krnl hdr with fw chksums */
+				openwrt,offset = <0x100>;
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_label 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+/* mt7612 */
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_label 6>;
+		nvmem-cell-names = "eeprom", "mac-address";
+
+		/* 5 GHz WLAN phy green led */
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <70000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* whole flash */
+			partition@0_all {
+				label = "ALL";
+				reg = <0x0 0x1000000>;
+				read-only;
+			};
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "ftd_and_bootflag";
+				reg = <0x30000 0x20000>;
+			};
+
+			factory: partition@50000 {
+				label = "Factory";
+				reg = <0x50000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+				};
+			};
+
+			partition@60000 {
+				label = "SC Nvram(permanent data)";
+				reg = <0x60000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_label: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			fwconcat0: partition@70000 {
+				label = "Firmware";
+				reg = <0x70000 0x790000>;
+
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "Kernel";
+					reg = <0x0 0x200000>;
+				};
+
+				partition@200000 {
+					label = "RootFS";
+					reg = <0x200000 0x590000>;
+				};
+			};
+
+			fwconcat1: partition@800000 {
+				label = "Firmware2";
+				reg = <0x800000 0x790000>;
+
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "Kernel2";
+					reg = <0x0 0x200000>;
+				};
+
+				partition@200000 {
+					label = "RootFS2";
+					reg = <0x200000 0x590000>;
+				};
+			};
+
+			partition@f90000 {
+				label = "MAC IP";
+				reg = <0xf90000 0x10000>;
+				read-only;
+			};
+
+			partition@fa0000 {
+				label = "Critical Log";
+				reg = <0xfa0000 0x10000>;
+				read-only;
+			};
+
+			partition@fb000 {
+				label = "Critical Log Bak";
+				reg = <0xfb0000 0x10000>;
+				read-only;
+			};
+
+			partition@fc0000 {
+				label = "Xml Config";
+				reg = <0xfc0000 0x20000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "Xml Config Bak";
+				reg = <0xfe0000 0x20000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "ephy", "rgmii1", "uartf", "wled";
+		function = "gpio";
+	};
+};
+
+/* mt7620 */
+&wmac {
+	nvmem-cells = <&macaddr_label 2>;
+	nvmem-cell-names = "mac-address";
+
+	ralink,mtd-eeprom = <&factory 0x0>;
+};

--- a/target/linux/ramips/image/common-sercomm.mk
+++ b/target/linux/ramips/image/common-sercomm.mk
@@ -23,6 +23,35 @@ define Build/sercomm-crypto
 	rm -f $@.enc $@.key
 endef
 
+define Build/sercomm-factory-cpj
+	dd bs=$$((0x1fff00)) count=1 if=$@ of=$@.kernel conv=notrunc \
+		2>/dev/null
+	dd bs=$$((0x1fff00)) skip=1 if=$@ of=$@.rootfs1 conv=notrunc \
+		2>/dev/null
+	cp $@.rootfs1 $@.rootfs2
+	$(TOPDIR)/scripts/sercomm-kernel-header.py \
+		--kernel-image $@.kernel \
+		--kernel-offset $(SERCOMM_KERNEL_OFFSET) \
+		--rootfs-image $@.rootfs1 \
+		--rootfs-offset $(SERCOMM_ROOTFS_OFFSET) \
+		--output-header $@.header1
+	$(TOPDIR)/scripts/sercomm-kernel-header.py \
+		--kernel-image $@.kernel \
+		--kernel-offset $(SERCOMM_KERNEL2_OFFSET) \
+		--rootfs-image $@.rootfs2 \
+		--rootfs-offset $(SERCOMM_ROOTFS2_OFFSET) \
+		--output-header $@.header2
+	cat $@.header1 $@.kernel > $@.kernel1
+	cat $@.header2 $@.kernel > $@.kernel2
+	rm $@.header1 $@.header2 $@.kernel
+	$(call Build/sercomm-part-tag-common,kernel $@.kernel1)
+	$(call Build/sercomm-part-tag-common,kernel2 $@.kernel2)
+	$(call Build/sercomm-part-tag-common,rootfs $@.rootfs1)
+	$(call Build/sercomm-part-tag-common,rootfs2 $@.rootfs2)
+	cat $@.kernel2 $@.rootfs2 $@.kernel1 $@.rootfs1 > $@
+	rm $@.kernel1 $@.rootfs1 $@.kernel2 $@.rootfs2
+endef
+
 define Build/sercomm-factory-cqr
 	$(TOPDIR)/scripts/sercomm-pid.py \
 		--hw-version $(SERCOMM_HWVER) \
@@ -117,10 +146,44 @@ define Build/sercomm-reset-slot1-chksum
 		dd of=$@ seek=$$((0x118)) bs=1 conv=notrunc 2>/dev/null
 endef
 
+define Build/sercomm-sysupgrade-cpj
+	dd bs=$$((0x1fff00)) count=1 if=$@ of=$@.kernel conv=notrunc \
+		2>/dev/null
+	dd bs=$$((0x1fff00)) skip=1 if=$@ of=$@.rootfs conv=notrunc \
+		2>/dev/null
+	$(TOPDIR)/scripts/sercomm-kernel-header.py \
+		--kernel-image $@.kernel \
+		--kernel-offset $(SERCOMM_KERNEL_OFFSET) \
+		--rootfs-image $@.rootfs \
+		--rootfs-offset $(SERCOMM_ROOTFS_OFFSET) \
+		--output-header $@.header
+	cat $@.header $@.kernel $@.rootfs > $@
+	rm $@.header $@.kernel $@.rootfs
+endef
+
 define Device/sercomm
   $(Device/nand)
   LOADER_TYPE := bin
   IMAGES += factory.img
+endef
+
+define Device/sercomm_cpj
+  SOC := mt7620a
+  DEVICE_VENDOR := Rostelecom
+  DEVICE_ALT0_VENDOR := Sercomm
+  IMAGE_SIZE := 7743k
+  SERCOMM_HWID := CPJ
+  SERCOMM_HWVER := 10000
+  SERCOMM_SWVER := 1001
+  SERCOMM_KERNEL_OFFSET := 0x70100
+  SERCOMM_ROOTFS_OFFSET := 0x270000
+  SERCOMM_KERNEL2_OFFSET := 0x800100
+  SERCOMM_ROOTFS2_OFFSET := 0xa00000
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
+	sercomm-sysupgrade-cpj | pad-rootfs | check-size | \
+	append-metadata
+  ARTIFACTS := initramfs-factory.img
+  DEVICE_PACKAGES := kmod-mt76x2
 endef
 
 define Device/sercomm_cxx_dxx

--- a/target/linux/ramips/image/common-sercomm.mk
+++ b/target/linux/ramips/image/common-sercomm.mk
@@ -38,10 +38,6 @@ define Build/sercomm-factory-cqr
 	mv $@.fhdr $@
 endef
 
-define Build/sercomm-fix-buc-pid
-	printf 1 | dd seek=$$((0x13)) of=$@ bs=1 conv=notrunc 2>/dev/null
-endef
-
 define Build/sercomm-kernel
 	$(TOPDIR)/scripts/sercomm-kernel-header.py \
 		--kernel-image $@ \
@@ -102,6 +98,10 @@ define Build/sercomm-payload
 		--pid-file $@.pid
 	mv $@.tmp $@
 	rm $@.pid
+endef
+
+define Build/sercomm-pid-setbit
+	printf 1 | dd seek=$$(($(1))) of=$@ bs=1 conv=notrunc 2>/dev/null
 endef
 
 define Build/sercomm-prepend-tagged-kernel

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -2,6 +2,7 @@
 # MT7620A Profiles
 #
 
+include ./common-sercomm.mk
 include ./common-tp-link.mk
 
 DEVICE_VARS += DLINK_ROM_ID DLINK_FAMILY_MEMBER DLINK_FIRMWARE_SIZE DLINK_IMAGE_OFFSET
@@ -1070,6 +1071,27 @@ define Device/ravpower_rp-wd03
 	Upgrade via sysupgrade mechanism is not possible, so new installation via TFTP is required.
 endef
 TARGET_DEVICES += ravpower_rp-wd03
+
+define Device/rostelecom_rt-fl-1
+  $(Device/sercomm_cpj)
+  DEVICE_MODEL := RT-FL-1
+  DEVICE_ALT0_MODEL := RT-FL-1
+  ARTIFACT/initramfs-factory.img := \
+	append-image-stage initramfs-kernel.bin | check-size | \
+	sercomm-factory-cpj | gzip | sercomm-payload | \
+	sercomm-pid-setbit 0x11 | sercomm-crypto
+endef
+TARGET_DEVICES += rostelecom_rt-fl-1
+
+define Device/rostelecom_s1010
+  $(Device/sercomm_cpj)
+  DEVICE_MODEL := S1010
+  DEVICE_ALT0_MODEL := S1010.RT
+  ARTIFACT/initramfs-factory.img := \
+	append-image-stage initramfs-kernel.bin | check-size | \
+	sercomm-factory-cpj | gzip | sercomm-payload | sercomm-crypto
+endef
+TARGET_DEVICES += rostelecom_s1010
 
 define Device/sanlinking_d240
   SOC := mt7620a

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2518,7 +2518,7 @@ define Device/wifire_s1500-nbn
   IMAGE_SIZE := 51200k
   IMAGE/factory.img := append-kernel | sercomm-kernel-factory | \
 	sercomm-reset-slot1-chksum | append-ubi | check-size | \
-	sercomm-factory-cqr | sercomm-fix-buc-pid | sercomm-mkhash | \
+	sercomm-factory-cqr | sercomm-pid-setbit 0x13 | sercomm-mkhash | \
 	sercomm-crypto
   SERCOMM_HWID := BUC
   SERCOMM_HWVER := 10000

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -198,6 +198,14 @@ zbtlink,zbt-we826-e)
 ravpower,rp-wd03)
 	ucidef_set_led_netdev "internet" "internet" "green:wifi" "eth0"
 	;;
+rostelecom,rt-fl-1|\
+rostelecom,s1010)
+	ucidef_set_led_switch "lan-1" "lan-1" "green:lan-1" "switch0" "0x02"
+	ucidef_set_led_switch "lan-2" "lan-2" "green:lan-2" "switch0" "0x04"
+	ucidef_set_led_switch "lan-3" "lan-3" "green:lan-3" "switch0" "0x08"
+	ucidef_set_led_switch "lan-4" "lan-4" "green:lan-4" "switch0" "0x10"
+	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
+	;;
 tplink,archer-c2-v1)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch1" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch1" "0x01"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -406,7 +406,7 @@ ramips_setup_macs()
 		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
 	zyxel,keenetic-lite-iii-a)
-		lan_mac=$(mtd_get_mac_binary RF-EEPROM 0x4)		
+		lan_mac=$(mtd_get_mac_binary RF-EEPROM 0x4)
 		wan_mac=$(mtd_get_mac_binary RF-EEPROM 0x28)
 		label_mac=$wan_mac
 		;;

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -118,6 +118,8 @@ ramips_setup_interfaces()
 	netgear,jwnr2010-v5|\
 	phicomm,k2-v22.4|\
 	phicomm,k2-v22.5|\
+	rostelecom,rt-fl-1|\
+	rostelecom,s1010|\
 	trendnet,tew-810dr|\
 	zbtlink,zbt-we2026)
 		ucidef_add_switch "switch0" \
@@ -385,6 +387,11 @@ ramips_setup_macs()
 		;;
 	linksys,e1700)
 		wan_mac=$(mtd_get_mac_ascii config WAN_MAC_ADDR)
+		;;
+	rostelecom,rt-fl-1|\
+	rostelecom,s1010)
+		label_mac=$(mtd_get_mac_binary "SC Nvram(permanent data)" 0x0)
+		wan_mac=$(macaddr_add "$label_mac" 10)
 		;;
 	snr,cpe-w4n-mt)
 		lan_mac=$(mtd_get_mac_binary Factory 0x28)

--- a/target/linux/ramips/mt7620/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7620/base-files/lib/upgrade/platform.sh
@@ -30,6 +30,14 @@ platform_do_upgrade() {
 		}
 		default_do_upgrade "$1"
 		;;
+	rostelecom,rt-fl-1|\
+	rostelecom,s1010)
+		idx="$(find_mtd_index ftd_and_bootflag)"
+		[ -n "$idx" ] && \
+			printf 0 | dd bs=1 seek=$((0x18007)) count=1 \
+				of=/dev/mtdblock$idx
+		default_do_upgrade "$1"
+		;;
 	*)
 		default_do_upgrade "$1"
 		;;


### PR DESCRIPTION
This commit adds support for following wireless routers:
 - Rostelecom RT-FL-1 (Serсomm RT-FL-1)
 - Rostelecom S1010 (Serсomm S1010.RT)

Devices specification
---------------------
```
   SoC:          MediaTek MT7620A, MIPS
   RAM:          64 MB
   Flash:        16 MB SPI NOR
   Wireless 2.4: MT7620 (b/g/n, 2x2)
   Wireless 5:   MT7612EN (a/n/ac, 2x2)
   Ethernet:     5xFE (WAN, LAN1-4)
   BootLoader:   U-Boot
   Buttons:      2 (wps, reset)
   LEDs:         1 amber and 1 green status GPIO leds
                 5 green ethernet GPIO leds
                 1 green GPIO 2.4 GHz WLAN led
                 1 green PHY 5 GHz WLAN led
                 1 green unmanaged power led
   USB ports:    No
   Power:        12 VDC, 1 A
   Connector:    Barrel
```
