### PR TITLE
[RFC] mediatek: SFP/RJ45 muxing of ETH1 via DTS overlays for EX5601-T0 ubootmod

### DIFF
--- a/package/boot/uboot-mediatek/patches/231-make-sys-vendor-configurable.patch
+++ b/package/boot/uboot-mediatek/patches/231-make-sys-vendor-configurable.patch
@@ -1,0 +1,59 @@
+From 2eae2d5cb19581b41ef81322a2e75e58cf3fa3ab Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicol=C3=B2=20Veronese?= <nicveronese@gmail.com>
+Date: Wed, 4 Oct 2023 10:29:03 +0200
+Subject: [PATCH] arm: mediatek: allow usage of SYS_VENDOR for custom boards
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This is a temprary patch until proper support
+ for multiple target is available in u-boot for the mediatek
+ target. Right now the TARGET_XXX is used to configure
+ the SOC type and to build the correct drivers.
+
+TARGET_XXX should be used to identify the different boards
+ and each board should have its kconfig file with the
+ SYS_XXX definitions to identify the board.
+
+Right now all the devices implemented are based on the
+ ref boards provided by MTK. If a bord need a different
+ behaviour this allow a way to build the correct board
+ file.
+
+Signed-off-by: Nicolò Veronese <nicveronese@gmail.com>
+---
+ arch/arm/mach-mediatek/Kconfig | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/mach-mediatek/Kconfig b/arch/arm/mach-mediatek/Kconfig
+index 8971e2d2b0..4afbb458f0 100644
+--- a/arch/arm/mach-mediatek/Kconfig
++++ b/arch/arm/mach-mediatek/Kconfig
+@@ -3,9 +3,6 @@ if ARCH_MEDIATEK
+ config SYS_SOC
+ 	default "mediatek"
+ 
+-config SYS_VENDOR
+-	default "mediatek"
+-
+ config MT8512
+ 	bool "MediaTek MT8512 SoC"
+ 
+@@ -106,6 +103,14 @@ config TARGET_MT8518
+ 
+ endchoice
+ 
++config SYS_VENDOR
++        string "Board vendor"
++        default "mediatek"
++        help
++          This option contains information about board vendor.
++          Based on this option board/<CONFIG_SYS_VENDOR>/<CONFIG_SYS_BOARD> will
++          be used.
++
+ config SYS_BOARD
+ 	string "Board name"
+ 	default "mt7622" if TARGET_MT7622
+-- 
+2.30.2
+

--- a/package/boot/uboot-mediatek/patches/439-add-zyxel_ex5601-t0.patch
+++ b/package/boot/uboot-mediatek/patches/439-add-zyxel_ex5601-t0.patch
@@ -1,211 +1,172 @@
 --- /dev/null
 +++ b/configs/mt7986_zyxel_ex5601-t0_defconfig
-@@ -0,0 +1,186 @@
+@@ -0,0 +1,147 @@
 +CONFIG_ARM=y
++CONFIG_SYS_VENDOR="zyxel"
++CONFIG_SYS_BOARD="ex5601"
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
 +CONFIG_POSITION_INDEPENDENT=y
 +CONFIG_ARCH_MEDIATEK=y
-+CONFIG_TARGET_MT7986=y
 +CONFIG_TEXT_BASE=0x41e00000
 +CONFIG_SYS_MALLOC_F_LEN=0x4000
-+CONFIG_SYS_HAS_NONCACHED_MEMORY=y
 +CONFIG_NR_DRAM_BANKS=1
 +CONFIG_DEFAULT_DEVICE_TREE="mt7986a-zyxel_ex5601-t0"
-+CONFIG_DEFAULT_ENV_FILE="zyxel_ex5601-t0_env"
-+CONFIG_DEFAULT_FDT_FILE="mediatek/mt7986a-zyxel_ex5601-t0.dtb"
++CONFIG_SYS_PROMPT="EX5601>"
 +CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_TARGET_MT7986=y
++CONFIG_RESET_BUTTON_SETTLE_DELAY=250
++CONFIG_PRE_CON_BUF_ADDR=0x4007EF00
 +CONFIG_DEBUG_UART_BASE=0x11002000
 +CONFIG_DEBUG_UART_CLOCK=40000000
-+CONFIG_DEBUG_UART=y
 +CONFIG_SYS_LOAD_ADDR=0x46000000
-+CONFIG_SMBIOS_PRODUCT_NAME=""
-+CONFIG_AUTOBOOT_KEYED=y
-+CONFIG_BOOTDELAY=30
-+CONFIG_AUTOBOOT_MENU_SHOW=y
-+CONFIG_CFB_CONSOLE_ANSI=y
-+CONFIG_BOARD_LATE_INIT=y
-+CONFIG_BUTTON=y
-+CONFIG_BUTTON_GPIO=y
-+CONFIG_GPIO_HOG=y
-+CONFIG_CMD_ENV_FLAGS=y
++CONFIG_DEBUG_UART=y
++CONFIG_AHCI=y
 +CONFIG_FIT=y
-+CONFIG_FIT_ENABLE_SHA256_SUPPORT=y
-+CONFIG_LED=y
-+CONFIG_LED_BLINK=y
-+CONFIG_LED_GPIO=y
++CONFIG_BOOTSTAGE=y
++CONFIG_SHOW_BOOT_PROGRESS=y
++CONFIG_BOOTDELAY=5
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_DEFAULT_FDT_FILE="mediatek/mt7986a-zyxel_ex5601-t0.dtb"
 +CONFIG_LOGLEVEL=7
++CONFIG_PRE_CONSOLE_BUFFER=y
 +CONFIG_LOG=y
-+CONFIG_SYS_PROMPT="EX5601> "
-+CONFIG_CMD_BOOTMENU=y
-+CONFIG_CMD_BOOTP=y
-+CONFIG_CMD_BUTTON=y
-+CONFIG_CMD_CACHE=y
-+CONFIG_CMD_CDP=y
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_HUSH_PARSER=y
 +CONFIG_CMD_CPU=y
-+CONFIG_CMD_DHCP=y
-+CONFIG_CMD_DM=y
-+CONFIG_CMD_DNS=y
-+CONFIG_CMD_ECHO=y
-+CONFIG_CMD_ENV_READMEM=y
-+CONFIG_CMD_ERASEENV=y
-+CONFIG_CMD_EXT4=y
-+CONFIG_CMD_FAT=y
-+CONFIG_CMD_FDT=y
-+CONFIG_CMD_FS_GENERIC=y
-+CONFIG_CMD_FS_UUID=y
-+CONFIG_CMD_GPIO=y
-+CONFIG_CMD_GPT=y
-+CONFIG_CMD_HASH=y
-+CONFIG_CMD_ITEST=y
-+CONFIG_CMD_LED=y
 +CONFIG_CMD_LICENSE=y
-+CONFIG_CMD_LINK_LOCAL=y
-+# CONFIG_CMD_MBR is not set
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_CMD_STRINGS=y
++CONFIG_CMD_DM=y
++# CONFIG_CMD_FLASH is not set
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_PWM=y
 +CONFIG_CMD_MTD=y
-+CONFIG_CMD_PCI=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_CACHE=y
 +CONFIG_CMD_PSTORE=y
 +CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
-+CONFIG_CMD_SF_TEST=y
-+CONFIG_CMD_PING=y
-+CONFIG_CMD_PXE=y
-+CONFIG_CMD_PWM=y
++CONFIG_CMD_UUID=y
++CONFIG_CMD_HASH=y
 +CONFIG_CMD_SMC=y
-+CONFIG_CMD_TFTPBOOT=y
-+CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_EXT4=y
++CONFIG_CMD_FAT=y
++CONFIG_CMD_FS_GENERIC=y
++CONFIG_CMD_FS_UUID=y
 +CONFIG_CMD_UBI=y
 +CONFIG_CMD_UBI_RENAME=y
-+CONFIG_CMD_UBIFS=y
-+CONFIG_CMD_ASKENV=y
-+CONFIG_CMD_PART=y
-+CONFIG_CMD_RARP=y
-+CONFIG_CMD_SETEXPR=y
-+CONFIG_CMD_SLEEP=y
-+CONFIG_CMD_SNTP=y
-+CONFIG_CMD_SOURCE=y
-+CONFIG_CMD_STRINGS=y
-+CONFIG_CMD_USB=y
-+# CONFIG_CMD_FLASH is not set
-+CONFIG_CMD_UUID=y
-+CONFIG_DISPLAY_CPUINFO=y
-+CONFIG_DM_MTD=y
-+CONFIG_DM_REGULATOR=y
-+CONFIG_DM_REGULATOR_FIXED=y
-+CONFIG_DM_REGULATOR_GPIO=y
-+CONFIG_DM_USB=y
-+CONFIG_DM_PWM=y
-+CONFIG_PWM_MTK=y
-+CONFIG_HUSH_PARSER=y
-+CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
-+CONFIG_SYS_RELOC_GD_ENV_ADDR=y
-+CONFIG_VERSION_VARIABLE=y
-+CONFIG_PARTITION_UUIDS=y
-+CONFIG_NETCONSOLE=y
-+CONFIG_REGMAP=y
-+CONFIG_SYSCON=y
-+CONFIG_CLK=y
-+CONFIG_DM_GPIO=y
-+CONFIG_DM_SCSI=y
-+CONFIG_AHCI=y
-+CONFIG_AHCI_PCI=y
-+CONFIG_SCSI_AHCI=y
-+CONFIG_SCSI=y
-+CONFIG_CMD_SCSI=y
-+CONFIG_PHY=y
-+CONFIG_PHY_MTK_TPHY=y
-+CONFIG_PHY_FIXED=y
-+CONFIG_MTK_AHCI=y
-+CONFIG_DM_ETH=y
-+CONFIG_MEDIATEK_ETH=y
-+CONFIG_PCI=y
-+CONFIG_DM_PCI=y
-+CONFIG_PCIE_MEDIATEK=y
-+# CONFIG_MMC is not set
-+# CONFIG_DM_MMC is not set
-+CONFIG_MTD=y
-+CONFIG_MTD_UBI_FASTMAP=y
-+# CONFIG_DM_PCI is not set
-+# CONFIG_PCIE_MEDIATEK is not set
-+CONFIG_PINCTRL=y
-+CONFIG_PINCONF=y
-+CONFIG_PINCTRL_MT7622=y
-+CONFIG_POWER_DOMAIN=y
-+CONFIG_PRE_CONSOLE_BUFFER=y
-+CONFIG_PRE_CON_BUF_ADDR=0x4007EF00
-+CONFIG_MTK_POWER_DOMAIN=y
-+CONFIG_RAM=y
-+CONFIG_DM_SERIAL=y
-+CONFIG_MTK_SERIAL=y
-+CONFIG_SPI=y
-+# CONFIG_I2C is not set
-+CONFIG_DM_SPI=y
-+CONFIG_MTK_SPI_NAND=y
-+CONFIG_MTK_SPI_NAND_MTD=y
-+CONFIG_SYSRESET_WATCHDOG=y
-+CONFIG_WDT_MTK=y
-+CONFIG_LZO=y
-+CONFIG_ZSTD=y
-+CONFIG_HEXDUMP=y
-+CONFIG_RANDOM_UUID=y
-+CONFIG_REGEX=y
-+CONFIG_USB=y
-+CONFIG_USB_HOST=y
-+CONFIG_USB_XHCI_HCD=y
-+CONFIG_USB_XHCI_MTK=y
-+CONFIG_USB_STORAGE=y
 +CONFIG_OF_EMBED=y
 +CONFIG_ENV_OVERWRITE=y
 +CONFIG_ENV_IS_IN_UBI=y
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 +CONFIG_ENV_UBI_PART="ubi"
-+CONFIG_ENV_SIZE=0x1f000
-+CONFIG_ENV_SIZE_REDUND=0x1f000
 +CONFIG_ENV_UBI_VOLUME="ubootenv"
 +CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_USE_DEFAULT_ENV_FILE=y
++CONFIG_DEFAULT_ENV_FILE="zyxel_ex5601-t0_env"
 +CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_PROT_UDP=y
 +CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_NETCONSOLE=y
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
 +CONFIG_REGMAP=y
 +CONFIG_SYSCON=y
++CONFIG_SCSI_AHCI=y
++CONFIG_MTK_AHCI=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
 +CONFIG_CLK=y
++CONFIG_GPIO_HOG=y
++# CONFIG_I2C is not set
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTD_UBI_FASTMAP=y
 +CONFIG_PHY_FIXED=y
-+CONFIG_DM_ETH=y
 +CONFIG_MEDIATEK_ETH=y
++CONFIG_PHY=y
++CONFIG_PHY_MTK_TPHY=y
 +CONFIG_PINCTRL=y
 +CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7622=y
 +CONFIG_PINCTRL_MT7986=y
 +CONFIG_POWER_DOMAIN=y
 +CONFIG_MTK_POWER_DOMAIN=y
 +CONFIG_DM_REGULATOR=y
 +CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_DM_PWM=y
++CONFIG_PWM_MTK=y
++CONFIG_RAM=y
++CONFIG_SCSI=y
++CONFIG_DM_SCSI=y
 +CONFIG_DM_SERIAL=y
 +CONFIG_MTK_SERIAL=y
-+CONFIG_HEXDUMP=y
-+CONFIG_USE_DEFAULT_ENV_FILE=y
-+CONFIG_MTD_SPI_NAND=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
 +CONFIG_MTK_SPIM=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_MTK=y
++CONFIG_USB_STORAGE=y
++CONFIG_WDT=y
++CONFIG_WDT_MTK=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
++CONFIG_LMB_MAX_REGIONS=64
++CONFIG_ENV_SIZE=0x1f000
 +CONFIG_CMD_NAND=y
 +CONFIG_CMD_NAND_TRIMFFS=y
-+CONFIG_LMB_MAX_REGIONS=64
-+CONFIG_USE_IPADDR=y
-+CONFIG_IPADDR="192.168.1.1"
-+CONFIG_USE_SERVERIP=y
-+CONFIG_SERVERIP="192.168.1.254"
++CONFIG_CMD_BOOTP=y
++CONFIG_CMD_BUTTON=y
++CONFIG_CMD_ECHO=y
++CONFIG_CMD_ENV_READMEM=y
++CONFIG_CMD_FDT=y
++CONFIG_CMD_ITEST=y
++CONFIG_CMD_SF_TEST=y
++CONFIG_CMD_TFTPBOOT=y
++CONFIG_CMD_SETEXPR=y
++CONFIG_CMD_SLEEP=y
++CONFIG_CMD_SOURCE=y
++CONFIG_DISPLAY_CPUINFO=y
++CONFIG_CMD_LED=y
++CONFIG_RESET_BUTTON_SETTLE_DELAY=250
 --- /dev/null
 +++ b/arch/arm/dts/mt7986a-zyxel_ex5601-t0.dts
-@@ -0,0 +1,181 @@
+@@ -0,0 +1,209 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Author: Valerio 'ftp21' Mancini <ftp21@ftp21.eu>
-+ * Author: Nicolò Veronese <nicveronese@gmail.com>
++ * Author: Nicolo' Veronese <nicveronese@gmail.com>
 + */
 +
 +/dts-v1/;
-+#include <dt-bindings/input/linux-event-codes.h>
 +#include "mt7986.dtsi"
++#include <dt-bindings/input/linux-event-codes.h>
 +#include <dt-bindings/gpio/gpio.h>
 +
 +/ {
 +	#address-cells = <1>;
 +	#size-cells = <1>;
 +	model = "Zyxel EX5601-T0 ubootmod";
-+	compatible = "mediatek,mt7986", "mediatek,mt7986-sd-rfb";
++	compatible = "mediatek,mt7986", "zyxel,mt7986-ex5601-t0";
 +
 +	chosen {
 +		stdout-path = &uart0;
@@ -214,12 +175,18 @@
 +
 +	memory@40000000 {
 +		device_type = "memory";
-+		reg = <0x40000000 0x20000000>;
++		reg = <0x40000000 0x40000000>;
++	};
++
++	config {
++		u-boot,boot-led = "green:status";
++		u-boot,error-led = "red:status";
 +	};
 +
 +	keys {
 +		compatible = "gpio-keys";
-+		factory {
++
++		reset {
 +			label = "reset";
 +			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
 +			linux,code = <KEY_RESTART>;
@@ -235,13 +202,19 @@
 +	leds {
 +		compatible = "gpio-leds";
 +
-+		led_status_green: pwr {
++		green_pwr {
 +			label = "green:status";
-+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
++			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
++			default-state = "on";
++		};
++
++		red_pwr {
++			label = "red:status";
++			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 +			default-state = "off";
 +		};
 +
-+		led_sfp_green: sfp {
++		sfp {
 +			label = "green:sfp";
 +			gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
 +			default-state = "off";
@@ -254,18 +227,15 @@
 +	status = "okay";
 +};
 +
-+&uart1 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&uart1_pins>;
-+	status = "disabled";
-+};
-+
 +&eth {
-+	status = "okay";
-+	mediatek,gmac-id = <0>;
-+	phy-mode = "2500base-x";
 +	mediatek,switch = "mt7531";
++	mediatek,gmac-id = <0>;
 +	reset-gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
++	phy-mode = "2500base-x";
++	status = "okay";
++
++	nvmem-cells = <&macaddr_factory_002a>;
++	nvmem-cell-names = "mac-address";
 +
 +	fixed-link {
 +		speed = <2500>;
@@ -274,20 +244,6 @@
 +};
 +
 +&pinctrl {
-+	spic_pins: spi1-pins-func-1 {
-+		mux {
-+			function = "spi";
-+			groups = "spi1_2";
-+		};
-+	};
-+
-+	uart1_pins: spi1-pins-func-3 {
-+		mux {
-+			function = "uart";
-+			groups = "uart1_2";
-+		};
-+	};
-+
 +	spi_flash_pins: spi0-pins-func-1 {
 +		mux {
 +			function = "flash";
@@ -308,12 +264,27 @@
 +	};
 +};
 +
++&gpio {
++	sfp_presence {
++		gpio-hog;
++		gpios = <57 GPIO_ACTIVE_LOW>;
++		input;
++		line-name = "sfp-presence";
++	};
++
++	sfp_mux {
++		gpio-hog;
++		gpios = <10 GPIO_ACTIVE_LOW>;
++		output-low;
++		line-name = "sfp-mux";
++	};
++};
++
 +&spi0 {
 +	#address-cells = <1>;
 +	#size-cells = <0>;
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&spi_flash_pins>;
-+	status = "okay";
 +	must_tx;
 +	enhance_timing;
 +	dma_ext;
@@ -321,6 +292,7 @@
 +	support_quad;
 +	tick_dly = <1>;
 +	sample_sel = <0>;
++	status = "okay";
 +
 +	spi_nand@0 {
 +		compatible = "spi-nand";
@@ -344,7 +316,7 @@
 +				reg = <0x0100000 0x0080000>;
 +			};
 +
-+			partition@180000 {
++			factory: partition@180000 {
 +				label = "Factory";
 +				reg = <0x180000 0x0200000>;
 +			};
@@ -371,16 +343,34 @@
 +	status = "disabled";
 +};
 +
++
++&factory {
++	#address-cells = <1>;
++	#size-cells = <1>;
++
++	macaddr_factory_0004: macaddr@0004 {
++		reg = <0x0004 0x6>;
++	};
++
++	macaddr_factory_0024: macaddr@0024 {
++		reg = <0x0024 0x6>;
++	};
++
++	macaddr_factory_002a: macaddr@002a {
++		reg = <0x002a 0x6>;
++	};
++};
 --- /dev/null
 +++ b/zyxel_ex5601-t0_env
-@@ -0,0 +1,55 @@
+@@ -0,0 +1,56 @@
 +ethaddr_factory=mtd read Factory 0x40080000 0x0 0x20000 && env readmem -b ethaddr 0x4008002A 0x6 ; setenv ethaddr_factory
 +ipaddr=192.168.1.1
 +serverip=192.168.1.254
++netmask=255.255.255.0
 +loadaddr=0x46000000
 +console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
 +bootargs=console=ttyS0,115200n8 console_msg_format=syslog
-+bootcmd=if pstore check ; then run boot_recovery ; else run boot_ubi ; fi
++bootcmd=if pstore check ; then run boot_recovery ; else if env exists flag_recover ; then run boot_recovery ; else run boot_ubi ; fi ; fi
 +bootconf=config-1
 +bootdelay=0
 +bootfile=openwrt-mediatek-filogic-zyxel_ex5601-t0-ubootmod-initramfs-recovery.itb
@@ -429,3 +419,445 @@
 +_firstboot=setenv _firstboot ; run ethaddr_factory ; run _switch_to_menu ; run _init_env ; run boot_first
 +_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
 +_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"
+--- /dev/null
++++ b/board/zyxel/ex5601/Makefile
+@@ -0,0 +1,3 @@
++# SPDX-License-Identifier:      GPL-2.0
++
++obj-y   += board.o
+--- /dev/null
++++ b/board/zyxel/ex5601/board.c
+@@ -0,0 +1,433 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (C) 2022 MediaTek Inc.
++ * Author: Nicolo' Veronese <nicveronese@gmail.com>
++ */
++
++#define LOG_CATEGORY LOGC_BOARD
++
++#include <common.h>
++#include <bootstage.h>
++#include <button.h>
++#include <config.h>
++#include <dm.h>
++#include <env.h>
++#include <hang.h>
++#include <init.h>
++#include <led.h>
++#include <log.h>
++#include <mtd.h>
++
++#include <asm/global_data.h>
++#include <asm/gpio.h>
++#include <linux/delay.h>
++#include <linux/mtd/mtd.h>
++#include <nmbm/nmbm.h>
++#include <nmbm/nmbm-mtd.h>
++
++#ifndef CONFIG_RESET_BUTTON_LABEL
++#define CONFIG_RESET_BUTTON_LABEL "reset"
++#endif
++
++#ifndef CONFIG_RESET_BUTTON_SETTLE_DELAY
++#define CONFIG_RESET_BUTTON_SETTLE_DELAY 250
++#endif
++
++#define CONFIG_GPIO_SFP_PRESENCE_LABEL "sfp_presence"
++#define CONFIG_GPIO_SFP_MUX_LABEL "sfp_mux"
++#define CONFIG_LED_SFP_LABEL "green:sfp"
++#define CONFIG_ENV_SFP_PRESENCE "sfp_inserted"
++
++// LED Error patterns
++#define ERROR_PATTERN_GENERIC 0
++#define ERROR_PATTERN_RESET 5
++#define ERROR_PATTERN_RECOVERY 10
++
++DECLARE_GLOBAL_DATA_PTR;
++
++enum recovery_cmd
++{
++    RECOVERY_CMD_NONE = 0,
++    RECOVERY_CMD_RECOVERY,
++    RECOVERY_CMD_TFTP,
++};
++
++// Board methods definitions
++int board_init_leds(void);
++int board_detect_buttons(int seconds);
++int board_detect_sfp(void);
++
++// Helper methods definitions
++#ifdef CONFIG_DM_GPIO
++static int get_gpio_by_label(char *gpio_string, struct gpio_desc **desc);
++static int read_gpio(struct gpio_desc *desc, int *value);
++static int write_gpio(struct gpio_desc *desc, int value);
++#endif
++
++#ifdef CONFIG_LED
++static int get_led_by_label(char *led_string, struct udevice **dev);
++static int get_led_boot(struct udevice **dev);
++static int get_led_error(struct udevice **dev);
++static int set_led_boot(enum led_state_t cmd);
++static int set_led_error(enum led_state_t cmd);
++static void set_led_error_blink(u32 nb_blink);
++#endif
++
++int board_init(void)
++{
++    return 0;
++}
++
++int board_late_init(void)
++{
++    // Not 100% sure what is this for!
++    gd->env_valid = ENV_VALID;
++
++    // Init LEDs
++    board_init_leds();
++
++    // Detect buttons for boot options
++    board_detect_buttons(CONFIG_BOOTDELAY);
++
++    // Check SFP Presence
++    board_detect_sfp();
++
++    return 0;
++}
++
++#ifdef CONFIG_SHOW_BOOT_PROGRESS
++void show_boot_progress(int progress)
++{
++    log_debug("Boot reached stage %d\n", progress);
++
++    switch (progress)
++    {
++    case BOOTSTAGE_ID_ENTER_CLI_LOOP:
++        /* Autoboot failed for some reason, enable red LED. */
++        log_debug("Entering console, enable RED LED\n");
++        // Fallthrou
++    case BOOTSTAGE_ID_NEED_RESET:
++#ifdef CONFIG_LED
++        set_led_error_blink(ERROR_PATTERN_GENERIC);
++#endif
++        break;
++    default:
++        // Nothing to do
++    }
++}
++#endif
++
++int board_init_leds()
++{
++#ifdef CONFIG_LED
++    set_led_boot(LEDST_ON);
++    set_led_error(LEDST_OFF);
++#endif
++
++    return 0;
++}
++
++int board_detect_buttons(int seconds)
++{
++    int value;
++    int cmd = RECOVERY_CMD_NONE;
++    ulong start = get_timer(0);
++    ulong delay = seconds * CONFIG_SYS_HZ;
++
++    // Buttons
++    struct udevice *dev_btn_rst;
++
++    if (button_get_by_label(CONFIG_RESET_BUTTON_LABEL, &dev_btn_rst))
++    {
++        log_warning("Unable to find 'reset' button for recovery bootoptions\n");
++        return -ENOENT;
++    }
++
++    log_debug("bootoptions 'reset' button found!\n");
++
++// This is heavily suggested to be set
++// debounce and some other bl0 shenanigans are happening!
++#ifdef CONFIG_RESET_BUTTON_SETTLE_DELAY
++    if (CONFIG_RESET_BUTTON_SETTLE_DELAY > 0)
++    {
++        button_get_state(dev_btn_rst);
++        mdelay(CONFIG_RESET_BUTTON_SETTLE_DELAY);
++    }
++#endif
++
++    if (button_get_state(dev_btn_rst) != BUTTON_ON)
++    {
++        // No button pressed, nothing to do.
++        return 0;
++    }
++
++    log_notice("reset pushed, resetting environment\n");
++    set_led_error_blink(ERROR_PATTERN_RESET);
++
++    // Mark evn as invalid
++    gd->env_valid = ENV_INVALID;
++
++    // Load env to memory
++    env_relocate();
++
++    // Lets wait to see what the user want to do!
++    while (get_timer(start) < delay)
++    {
++        // Continue reading the button!
++        value = button_get_state(dev_btn_rst);
++        udelay(100);
++    }
++
++    // Read the buttons for the last time!
++    value = button_get_state(dev_btn_rst);
++    log_notice("reset status: %d\n", value);
++
++    if (value)
++    {
++        cmd = RECOVERY_CMD_RECOVERY;
++    }
++
++    switch (cmd)
++    {
++    case RECOVERY_CMD_RECOVERY:
++        log_info("Executing RECOVERY_CMD_RECOVERY!\n");
++
++#ifdef CONFIG_LED
++        // Signal with the LEDs that we are gonna boot recovery!
++        set_led_error_blink(ERROR_PATTERN_RECOVERY);
++        set_led_boot(LEDST_ON);
++#endif
++
++        // flagging that we have to boot recovery,
++        // clear bootdelay, then continue with boot.
++        env_set_ulong("flag_recover", 1);
++        env_set_ulong("bootdelay", 0);
++
++        return 0;
++    default:
++        // nothing to do, jump to shell? How?
++        env_set_ulong("noboot", 1);
++        env_set_ulong("bootdelay", 0);
++        break;
++    }
++
++    return 0;
++}
++
++int board_detect_sfp()
++{
++#ifdef CONFIG_DM_GPIO
++
++    struct gpio_desc *gpio_sfp;
++    struct gpio_desc *gpio_mux;
++    struct udevice *led_sfp;
++    int value;
++    int ret;
++
++    ret = get_led_by_label(CONFIG_LED_SFP_LABEL, &led_sfp);
++    if (ret)
++    {
++        log_warning("%s: unable to find SFP led: %s\n",
++                    __func__, CONFIG_LED_SFP_LABEL);
++        // We havent found the LED to seignal SFP detection
++        led_sfp = NULL;
++    }
++
++    if (get_gpio_by_label(CONFIG_GPIO_SFP_PRESENCE_LABEL, &gpio_sfp) ||
++        get_gpio_by_label(CONFIG_GPIO_SFP_MUX_LABEL, &gpio_mux))
++    {
++        log_err("%s: Unable to find GPIOs for SFP\n", __func__);
++        return -ENOENT;
++    }
++
++    ret = read_gpio(gpio_sfp, &value);
++    log_debug("%s: read_gpio for gpio '%s', returned %d, with value %d\n",
++              __func__, CONFIG_GPIO_SFP_PRESENCE_LABEL, ret, value);
++
++    // Reset env value
++    env_set(CONFIG_ENV_SFP_PRESENCE, NULL);
++
++    // If we find the SFP module (GPIO is active, ACTIVE_LOW)
++    if (value)
++    {
++        log_info("SFP module is inserted!\n");
++
++        // Prepare an env to signal SFP status
++        env_set_ulong(CONFIG_ENV_SFP_PRESENCE, value);
++    }
++
++    // Switch mac0 Mux to/from SFP
++    write_gpio(gpio_mux, value);
++
++    // Turn on/off LED
++    led_set_state(led_sfp, value);
++
++    return 0;
++
++#endif
++}
++
++int board_nmbm_init(void)
++{
++#ifdef CONFIG_ENABLE_NAND_NMBM
++    struct mtd_info *lower, *upper;
++    int ret;
++
++    printf("\n");
++    printf("Initializing NMBM ...\n");
++
++    mtd_probe_devices();
++
++    lower = get_mtd_device_nm("spi-nand0");
++    if (IS_ERR(lower) || !lower)
++    {
++        printf("Lower MTD device 'spi-nand0' not found\n");
++        return 0;
++    }
++
++    ret = nmbm_attach_mtd(lower,
++                          NMBM_F_CREATE | NMBM_F_EMPTY_PAGE_ECC_OK,
++                          CONFIG_NMBM_MAX_RATIO,
++                          CONFIG_NMBM_MAX_BLOCKS, &upper);
++
++    printf("\n");
++
++    if (ret)
++        return 0;
++
++    add_mtd_device(upper);
++#endif
++
++    return 0;
++}
++
++/*
++ * HELPER FUNCTIONS
++ */
++#ifdef CONFIG_DM_GPIO
++static int get_gpio_by_label(char *gpio_string, struct gpio_desc **desc)
++{
++    int ret = gpio_hog_lookup_name(gpio_string, desc);
++    if (ret)
++    {
++        log_err("%s: could not find %s gpio label\n",
++                __func__, gpio_string);
++        return -ENOENT;
++    }
++
++    return 0;
++}
++
++static int read_gpio(struct gpio_desc *desc, int *value)
++{
++    int ret = dm_gpio_get_value(desc);
++
++    if (IS_ERR_VALUE(ret))
++    {
++        return ret;
++    }
++
++    *value = ret;
++    return 0;
++}
++
++static int write_gpio(struct gpio_desc *desc, int value)
++{
++    return dm_gpio_set_value(desc, value);
++}
++#endif
++
++#ifdef CONFIG_LED
++static int get_led_by_label(char *led_string, struct udevice **dev)
++{
++    int ret;
++
++    ret = led_get_by_label(led_string, dev);
++    if (ret)
++    {
++        log_err("%s: could not find %s led, get=%d\n",
++                __func__, led_string, ret);
++        return ret;
++    }
++
++    return 0;
++}
++
++static int get_led_boot(struct udevice **dev)
++{
++    char *led_string;
++
++    led_string = ofnode_conf_read_str("u-boot,boot-led");
++    if (!led_string)
++    {
++        log_err("%s: could not find %s config string\n",
++                __func__, "u-boot,boot-led");
++        return -ENOENT;
++    }
++
++    return get_led_by_label(led_string, dev);
++}
++
++static int get_led_error(struct udevice **dev)
++{
++    char *led_string;
++
++    led_string = ofnode_conf_read_str("u-boot,error-led");
++    if (!led_string)
++    {
++        log_err("%s: could not find %s config string\n",
++                __func__, "u-boot,boot-led");
++        return -ENOENT;
++    }
++
++    return get_led_by_label(led_string, dev);
++}
++
++static int set_led_boot(enum led_state_t cmd)
++{
++    struct udevice *dev;
++
++    if (get_led_boot(&dev))
++        return -ENOENT;
++    return led_set_state(dev, cmd);
++}
++
++static int set_led_error(enum led_state_t cmd)
++{
++    struct udevice *dev;
++
++    if (get_led_error(&dev))
++        return -ENOENT;
++    return led_set_state(dev, cmd);
++}
++
++static void __maybe_unused set_led_error_blink(u32 nb_blink)
++{
++    int ret;
++    struct udevice *dev;
++    u32 i;
++
++    ret = get_led_error(&dev);
++    if (ret)
++    {
++        return;
++    }
++
++    // Disable green LED
++    set_led_boot(LEDST_OFF);
++
++    /* make u-boot,error-led blinking */
++    /* if U32_MAX and 125ms interval, for 17.02 years */
++    for (i = 0; i < 2 * nb_blink; i++)
++    {
++        led_set_state(dev, LEDST_TOGGLE);
++        mdelay(125);
++        schedule();
++    }
++    led_set_state(dev, LEDST_ON);
++
++    /* infinite: the boot process must be stopped */
++    if (nb_blink == U32_MAX)
++        hang();
++}
++#endif

--- a/package/boot/uboot-mediatek/patches/439-add-zyxel_ex5601-t0.patch
+++ b/package/boot/uboot-mediatek/patches/439-add-zyxel_ex5601-t0.patch
@@ -362,7 +362,7 @@
 +};
 --- /dev/null
 +++ b/zyxel_ex5601-t0_env
-@@ -0,0 +1,56 @@
+@@ -0,0 +1,60 @@
 +ethaddr_factory=mtd read Factory 0x40080000 0x0 0x20000 && env readmem -b ethaddr 0x4008002A 0x6 ; setenv ethaddr_factory
 +ipaddr=192.168.1.1
 +serverip=192.168.1.254
@@ -372,6 +372,9 @@
 +bootargs=console=ttyS0,115200n8 console_msg_format=syslog
 +bootcmd=if pstore check ; then run boot_recovery ; else if env exists flag_recover ; then run boot_recovery ; else run boot_ubi ; fi ; fi
 +bootconf=config-1
++bootconf_base=config-1
++bootconf_rj45=mt7986a-zyxel-ex5601-t0-rj45
++bootconf_sfp=mt7986a-zyxel-ex5601-t0-sfp
 +bootdelay=0
 +bootfile=openwrt-mediatek-filogic-zyxel_ex5601-t0-ubootmod-initramfs-recovery.itb
 +bootfile_bl2=openwrt-mediatek-filogic-zyxel_ex5601-t0-ubootmod-preloader.bin
@@ -392,10 +395,11 @@
 +bootmenu_7=[31mLoad BL2 preloader via TFTP then write to NAND.[0m=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
 +bootmenu_8=Reboot.=reset
 +bootmenu_9=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_update_conf=if env exists sfp_inserted ; then setenv bootconf $bootconf_base#$bootconf_sfp ; else setenv bootconf $bootconf_base#$bootconf_rj45 ; fi
 +boot_first=if button reset ; then run boot_tftp_recovery ; setenv flag_recover 1 ; run boot_default ; fi ; bootmenu
 +boot_default=if env exists flag_recover ; then else run bootcmd ; fi ; run boot_recovery ; setenv replacevol 1 ; run boot_tftp_forever
-+boot_production=run ubi_read_production && bootm $loadaddr#$bootconf
-+boot_recovery=run ubi_read_recovery && bootm $loadaddr#$bootconf
++boot_production=run boot_update_conf ; run ubi_read_production && bootm $loadaddr#$bootconf
++boot_recovery=run boot_update_conf ; run ubi_read_recovery && bootm $loadaddr#$bootconf
 +boot_ubi=run boot_production ; run boot_recovery ; run boot_tftp_forever
 +boot_tftp_forever=while true ; do run boot_tftp_recovery ; sleep 1 ; done
 +boot_tftp_recovery=tftpboot $loadaddr $bootfile && env exists replacevol && iminfo $loadaddr && run ubi_write_recovery ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
@@ -198,8 +198,8 @@
 	gmac1: mac@1 {
 		compatible = "mediatek,eth-mac";
 		reg = <1>;
-		phy-mode = "2500base-x";
-		phy = <&phy6>;
+
+		status = "disabled";
 	};
 
 	mdio: mdio-bus {

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-rj45.dtso
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-rj45.dtso
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Author: Nicolò Veronese >nicveronese@gmail.com>
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+        compatible = "zyxel,ex5601-t0-ubootmod", "mediatek,mt7986a";
+
+        fragment@0 {
+                target-path = "/soc/ethernet@15100000/mac@1";
+
+                __overlay__ {
+                        phy-mode = "2500base-x";
+                        phy = <&phy6>;
+                        status = "okay";
+                };
+        };
+};

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-sfp.dtso
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-sfp.dtso
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Author: Nicolò Veronese >nicveronese@gmail.com>
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "zyxel,ex5601-t0-ubootmod", "mediatek,mt7986a";
+
+	fragment@0 {
+		target-path = "/";
+
+		__overlay__ {
+			sfp_wan: sfp0 {
+				compatible = "sff,sfp";
+				i2c-bus = <&i2c0>;
+				los-gpios = <&pio 23 GPIO_ACTIVE_HIGH>;
+				mod-def0-gpios = <&pio 57 GPIO_ACTIVE_LOW>;
+				tx-disable-gpios = <&pio 26 GPIO_ACTIVE_HIGH>;
+				/* tx-fault-gpios = <&pio 28 GPIO_ACTIVE_HIGH>; */
+				maximum-power-milliwatt = <3000>;
+			};
+		};
+	};
+
+	fragment@1 {
+                target-path = "/soc/ethernet@15100000/mac@1";
+
+		__overlay__ {
+		        phy-mode = "2500base-x";
+			managed = "in-band-status";
+			sfp = <&sfp_wan>;
+			status = "okay";
+		};
+	};
+
+        fragment@2 {
+                target-path = "/soc/pinctrl@1001f000";
+
+                __overlay__ {
+			sfp-mux-hog {
+				gpio-hog;
+				gpios = <10 GPIO_ACTIVE_LOW>;
+				output-high;
+				line-name = "sfp-gmac1-mux";
+			};
+
+                };
+        };
+
+};

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
@@ -114,6 +114,10 @@
 };
 
 &gmac1 {
+	phy-mode = "2500base-x";
+	phy = <&phy6>;
+	status = "okay";
+	
 	nvmem-cells = <&macaddr_factory_0024 0>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-ubootmod.dts
@@ -97,10 +97,6 @@
 };
 
 &gmac1 {
-	phy-mode = "2500base-x";
-	phy = <&phy6>; 
-	status = "okay";
-
 	nvmem-cells = <&macaddr_factory_0024 0>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-ubootmod.dts
@@ -20,6 +20,7 @@
 };
 
 &nand_partitions {
+
 	partition@0 {
 		label = "bl2";
 		reg = <0x0 0x100000>;
@@ -96,6 +97,10 @@
 };
 
 &gmac1 {
+	phy-mode = "2500base-x";
+	phy = <&phy6>; 
+	status = "okay";
+
 	nvmem-cells = <&macaddr_factory_0024 0>;
 	nvmem-cell-names = "mac-address";
 };
@@ -103,4 +108,20 @@
 &wifi {
 	nvmem-cells = <&eeprom_factory>;
 	nvmem-cell-names = "eeprom";
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c_pins>;
+	status = "okay";
+};
+
+
+&pio {
+	i2c_pins: i2c-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c";
+		};
+	};
 };

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -774,7 +774,10 @@ define Device/zyxel_ex5601-t0-ubootmod
   DEVICE_VARIANT := (OpenWrt U-Boot layout)
   DEVICE_DTS := mt7986a-zyxel-ex5601-t0-ubootmod
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7986-firmware mt7986-wo-firmware kmod-usb3
+  DEVICE_DTS_OVERLAY := \
+	mt7986a-zyxel-ex5601-t0-sfp \
+	mt7986a-zyxel-ex5601-t0-rj45
+  DEVICE_PACKAGES := kmod-mt7986-firmware mt7986-wo-firmware kmod-usb3 kmod-sfp
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   IMAGES := sysupgrade.itb
   UBINIZE_OPTS := -E 5


### PR DESCRIPTION
This is a draft to have feedback on how to have a supported SFP slot
 while we are waiting for proper support in mainline [1], [2], [3].
 
 TD-DR:
 Right now a single SerDev is muxed with two PHYs, the
 Linux kernel does not support this use case.

This PR hase the basic scope to add overlays support to uboot, and to the FIT image.
The bootloader will perform the SFP detection and will load the correct FIT configuration.

This has been implemented with a custom `board.c` file. This allowed us to perform some
 "fancy" feedback to the user and a failsafe boot using the reset button via the initram.

[1]: https://lore.kernel.org/netdev/20230830180437.583e6383@kernel.org/T/
[2]: https://www.spinics.net/lists/netdev/msg950159.html
[3]: https://bootlin.com/pub/conferences/2023/netdev/multi-port-multi-phy-interfaces.pdf

Signed-off-by: Nicolò Veronese <nicveronese@gmail.com>