### PR TITLE
ath79: convert to mac-base

### DIFF
--- a/target/linux/ath79/dts/ar7161_aruba_ap-105.dts
+++ b/target/linux/ath79/dts/ar7161_aruba_ap-105.dts
@@ -159,7 +159,6 @@
 
 			hwinfo: partition@fe0000 {
 				reg = <0xfe0000 0x10000>;
-				compatible = "nvmem-cells";
 				label = "hwinfo";
 				read-only;
 

--- a/target/linux/ath79/dts/ar7161_aruba_ap-175.dts
+++ b/target/linux/ath79/dts/ar7161_aruba_ap-175.dts
@@ -187,6 +187,16 @@
 				label = "hwinfo";
 				reg = <0xfe0000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_hwinfo_1c: macaddr@1c {
+						reg = <0x1c 0x6>;
+					};
+				};
 			};
 
 			partition@ff0000 {
@@ -195,16 +205,6 @@
 				read-only;
 			};
 		};
-	};
-};
-
-&hwinfo {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_hwinfo_1c: macaddr@1c {
-		reg = <0x1c 0x6>;
 	};
 };
 

--- a/target/linux/ath79/dts/ar7161_aruba_ap-175.dts
+++ b/target/linux/ath79/dts/ar7161_aruba_ap-175.dts
@@ -122,9 +122,8 @@
 
 	ath9k0: wifi@0,11 {
 		compatible = "pci168c,0029";
-		nvmem-cells = <&macaddr_hwinfo_1c>;
+		nvmem-cells = <&macaddr_hwinfo_1c 1>;
 		nvmem-cell-names = "mac-address";
-		mac-address-increment = <1>;
 		reg = <0x8800 0 0 0 0>;
 		#gpio-cells = <2>;
 		gpio-controller;
@@ -132,9 +131,8 @@
 
 	ath9k1: wifi@0,12 {
 		compatible = "pci168c,0029";
-		nvmem-cells = <&macaddr_hwinfo_1c>;
+		nvmem-cells = <&macaddr_hwinfo_1c 2>;
 		nvmem-cell-names = "mac-address";
-		mac-address-increment = <2>;
 		reg = <0x9000 0 0 0 0>;
 		#gpio-cells = <2>;
 		gpio-controller;
@@ -151,7 +149,7 @@
 
 &eth0 {
 	status = "okay";
-	nvmem-cells = <&macaddr_hwinfo_1c>;
+	nvmem-cells = <&macaddr_hwinfo_1c 0>;
 	nvmem-cell-names = "mac-address";
 
 	phy-mode = "rgmii";
@@ -194,7 +192,9 @@
 					#size-cells = <1>;
 
 					macaddr_hwinfo_1c: macaddr@1c {
+						compatible = "mac-base";
 						reg = <0x1c 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};

--- a/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
+++ b/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
@@ -159,7 +159,9 @@
 					};
 
 					macaddr_art_520c: macaddr@520c {
+						compatible = "mac-base";
 						reg = <0x520c 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -254,9 +256,8 @@
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_520c>;
+	nvmem-cells = <&macaddr_art_520c 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 
 	phy-handle = <&phy4>;
 };

--- a/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
+++ b/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
@@ -148,6 +148,20 @@
 				label = "art";
 				reg = <0x0050000 0x0010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_120c: macaddr@120c {
+						reg = <0x120c 0x6>;
+					};
+
+					macaddr_art_520c: macaddr@520c {
+						reg = <0x520c 0x6>;
+					};
+				};
 			};
 
 			partition@60000 {
@@ -245,18 +259,4 @@
 	mac-address-increment = <1>;
 
 	phy-handle = <&phy4>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_120c: macaddr@120c {
-		reg = <0x120c 0x6>;
-	};
-
-	macaddr_art_520c: macaddr@520c {
-		reg = <0x520c 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
+++ b/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
@@ -186,7 +186,6 @@
 			};
 
 			partition@660000 {
-				compatible = "nvmem-cells";
 				label = "caldata";
 				reg = <0x660000 0x010000>;
 				read-only;

--- a/target/linux/ath79/dts/ar7161_jjplus_ja76pf2.dts
+++ b/target/linux/ath79/dts/ar7161_jjplus_ja76pf2.dts
@@ -158,16 +158,19 @@
 				label = "Atheros Board Data";
 				reg = <0xff0000 0x10000>;
 				read-only;
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
 
-				macaddr_wan: macaddr@1000 {
-					reg = <0x1000 0x6>;
-				};
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_lan: macaddr@1006 {
-					reg = <0x1006 0x6>;
+					macaddr_wan: macaddr@1000 {
+						reg = <0x1000 0x6>;
+					};
+
+					macaddr_lan: macaddr@1006 {
+						reg = <0x1006 0x6>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/ar7161_meraki_mr16.dts
+++ b/target/linux/ath79/dts/ar7161_meraki_mr16.dts
@@ -141,6 +141,16 @@
 				label = "config";
 				reg = <0x80000 0x20000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_66: macaddr@66 {
+						reg = <0x66 0x6>;
+					};
+				};
 			};
 
 			partition@a0000 {
@@ -155,15 +165,5 @@
 				read-only;
 			};
 		};
-	};
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_66: macaddr@66 {
-		reg = <0x66 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar7161_meraki_mr16.dts
+++ b/target/linux/ath79/dts/ar7161_meraki_mr16.dts
@@ -74,9 +74,8 @@
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
 		qca,no-eeprom;
-		nvmem-cells = <&macaddr_config_66>;
+		nvmem-cells = <&macaddr_config_66 1>;
 		nvmem-cell-names = "mac-address";
-		mac-address-increment = <1>;
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -85,9 +84,8 @@
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
 		qca,no-eeprom;
-		nvmem-cells = <&macaddr_config_66>;
+		nvmem-cells = <&macaddr_config_66 2>;
 		nvmem-cell-names = "mac-address";
-		mac-address-increment = <2>;
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -103,7 +101,7 @@
 
 &eth0 {
 	status = "okay";
-	nvmem-cells = <&macaddr_config_66>;
+	nvmem-cells = <&macaddr_config_66 0>;
 	nvmem-cell-names = "mac-address";
 
 	pll-data = <0x00110000 0x00001099 0x00991099>;
@@ -148,7 +146,9 @@
 					#size-cells = <1>;
 
 					macaddr_config_66: macaddr@66 {
+						compatible = "mac-base";
 						reg = <0x66 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};

--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -112,28 +112,30 @@
 				reg = <0x7f0000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_art_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 
-				macaddr_art_120c: macaddr@120c {
-					reg = <0x120c 0x6>;
-				};
+					macaddr_art_120c: macaddr@120c {
+						reg = <0x120c 0x6>;
+					};
 
-				macaddr_art_520c: macaddr@520c {
-					reg = <0x520c 0x6>;
-				};
+					macaddr_art_520c: macaddr@520c {
+						reg = <0x520c 0x6>;
+					};
 
-				calibration_art_1000: calibration@1000 {
-					reg = <0x1000 0xeb8>;
-				};
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0xeb8>;
+					};
 
-				calibration_art_5000: calibration@5000 {
-					reg = <0x5000 0xeb8>;
+					calibration_art_5000: calibration@5000 {
+						reg = <0x5000 0xeb8>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -126,7 +126,9 @@
 					};
 
 					macaddr_art_520c: macaddr@520c {
+						compatible = "mac-base";
 						reg = <0x520c 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 
 					calibration_art_1000: calibration@1000 {
@@ -157,9 +159,8 @@
 	ath9k1: wifi@0,12 {
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_520c>, <&calibration_art_5000>;
+		nvmem-cells = <&macaddr_art_520c 1>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		mac-address-increment = <1>;
 		#gpio-cells = <2>;
 		gpio-controller;
 	};

--- a/target/linux/ath79/dts/ar7161_netgear_wndr3700-v2.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3700-v2.dts
@@ -35,6 +35,32 @@
 		label = "art";
 		reg = <0xff0000 0x010000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_art_0: macaddr@0 {
+				reg = <0x0 0x6>;
+			};
+
+			macaddr_art_6: macaddr@6 {
+				reg = <0x6 0x6>;
+			};
+
+			macaddr_art_c: macaddr@c {
+				reg = <0xc 0x6>;
+			};
+
+			cal_art_1000: cal@1000 {
+				reg = <0x1000 0xeb8>;
+			};
+
+			cal_art_5000: cal@5000 {
+				reg = <0x5000 0xeb8>;
+			};
+		};
 	};
 };
 
@@ -56,30 +82,4 @@
 &eth1 {
 	nvmem-cells = <&macaddr_art_6>;
 	nvmem-cell-names = "mac-address";
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
-
-	macaddr_art_c: macaddr@c {
-		reg = <0xc 0x6>;
-	};
-
-	cal_art_1000: cal@1000 {
-		reg = <0x1000 0xeb8>;
-	};
-
-	cal_art_5000: cal@5000 {
-		reg = <0x5000 0xeb8>;
-	};
 };

--- a/target/linux/ath79/dts/ar7161_netgear_wndr3700.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3700.dts
@@ -35,6 +35,32 @@
 		label = "art";
 		reg = <0x7f0000 0x010000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_art_0: macaddr@0 {
+				reg = <0x0 0x6>;
+			};
+
+			macaddr_art_6: macaddr@6 {
+				reg = <0x6 0x6>;
+			};
+
+			macaddr_art_c: macaddr@c {
+				reg = <0xc 0x6>;
+			};
+
+			cal_art_1000: cal@1000 {
+				reg = <0x1000 0xeb8>;
+			};
+
+			cal_art_5000: cal@5000 {
+				reg = <0x5000 0xeb8>;
+			};
+		};
 	};
 };
 
@@ -75,30 +101,4 @@
 &eth1 {
 	nvmem-cells = <&macaddr_art_6>;
 	nvmem-cell-names = "mac-address";
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
-
-	macaddr_art_c: macaddr@c {
-		reg = <0xc 0x6>;
-	};
-
-	cal_art_1000: cal@1000 {
-		reg = <0x1000 0xeb8>;
-	};
-
-	cal_art_5000: cal@5000 {
-		reg = <0x5000 0xeb8>;
-	};
 };

--- a/target/linux/ath79/dts/ar7161_netgear_wndr3800.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3800.dts
@@ -36,6 +36,32 @@
 		label = "art";
 		reg = <0xff0000 0x010000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_art_0: macaddr@0 {
+				reg = <0x0 0x6>;
+			};
+
+			macaddr_art_6: macaddr@6 {
+				reg = <0x6 0x6>;
+			};
+
+			macaddr_art_c: macaddr@c {
+				reg = <0xc 0x6>;
+			};
+
+			cal_art_1000: cal@1000 {
+				reg = <0x1000 0xeb8>;
+			};
+
+			cal_art_5000: cal@5000 {
+				reg = <0x5000 0xeb8>;
+			};
+		};
 	};
 };
 
@@ -57,30 +83,4 @@
 &eth1 {
 	nvmem-cells = <&macaddr_art_6>;
 	nvmem-cell-names = "mac-address";
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
-
-	macaddr_art_c: macaddr@c {
-		reg = <0xc 0x6>;
-	};
-
-	cal_art_1000: cal@1000 {
-		reg = <0x1000 0xeb8>;
-	};
-
-	cal_art_5000: cal@5000 {
-		reg = <0x5000 0xeb8>;
-	};
 };

--- a/target/linux/ath79/dts/ar7161_netgear_wndr3800ch.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3800ch.dts
@@ -36,6 +36,32 @@
 		label = "art";
 		reg = <0xff0000 0x010000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_art_0: macaddr@0 {
+				reg = <0x0 0x6>;
+			};
+
+			macaddr_art_6: macaddr@6 {
+				reg = <0x6 0x6>;
+			};
+
+			macaddr_art_c: macaddr@c {
+				reg = <0xc 0x6>;
+			};
+
+			cal_art_1000: cal@1000 {
+				reg = <0x1000 0xeb8>;
+			};
+
+			cal_art_5000: cal@5000 {
+				reg = <0x5000 0xeb8>;
+			};
+		};
 	};
 };
 
@@ -57,30 +83,4 @@
 &eth1 {
 	nvmem-cells = <&macaddr_art_6>;
 	nvmem-cell-names = "mac-address";
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
-
-	macaddr_art_c: macaddr@c {
-		reg = <0xc 0x6>;
-	};
-
-	cal_art_1000: cal@1000 {
-		reg = <0x1000 0xeb8>;
-	};
-
-	cal_art_5000: cal@5000 {
-		reg = <0x5000 0xeb8>;
-	};
 };

--- a/target/linux/ath79/dts/ar7161_netgear_wndrmac-v1.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndrmac-v1.dts
@@ -35,6 +35,32 @@
 		label = "art";
 		reg = <0xff0000 0x010000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_art_0: macaddr@0 {
+				reg = <0x0 0x6>;
+			};
+
+			macaddr_art_6: macaddr@6 {
+				reg = <0x6 0x6>;
+			};
+
+			macaddr_art_c: macaddr@c {
+				reg = <0xc 0x6>;
+			};
+
+			cal_art_1000: cal@1000 {
+				reg = <0x1000 0xeb8>;
+			};
+
+			cal_art_5000: cal@5000 {
+				reg = <0x5000 0xeb8>;
+			};
+		};
 	};
 };
 
@@ -56,30 +82,4 @@
 &eth1 {
 	nvmem-cells = <&macaddr_art_6>;
 	nvmem-cell-names = "mac-address";
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
-
-	macaddr_art_c: macaddr@c {
-		reg = <0xc 0x6>;
-	};
-
-	cal_art_1000: cal@1000 {
-		reg = <0x1000 0xeb8>;
-	};
-
-	cal_art_5000: cal@5000 {
-		reg = <0x5000 0xeb8>;
-	};
 };

--- a/target/linux/ath79/dts/ar7161_netgear_wndrmac-v2.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndrmac-v2.dts
@@ -36,6 +36,32 @@
 		label = "art";
 		reg = <0xff0000 0x010000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_art_0: macaddr@0 {
+				reg = <0x0 0x6>;
+			};
+
+			macaddr_art_6: macaddr@6 {
+				reg = <0x6 0x6>;
+			};
+
+			macaddr_art_c: macaddr@c {
+				reg = <0xc 0x6>;
+			};
+
+			cal_art_1000: cal@1000 {
+				reg = <0x1000 0xeb8>;
+			};
+
+			cal_art_5000: cal@5000 {
+				reg = <0x5000 0xeb8>;
+			};
+		};
 	};
 };
 
@@ -57,30 +83,4 @@
 &eth1 {
 	nvmem-cells = <&macaddr_art_6>;
 	nvmem-cell-names = "mac-address";
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
-
-	macaddr_art_c: macaddr@c {
-		reg = <0xc 0x6>;
-	};
-
-	cal_art_1000: cal@1000 {
-		reg = <0x1000 0xeb8>;
-	};
-
-	cal_art_5000: cal@5000 {
-		reg = <0x5000 0xeb8>;
-	};
 };

--- a/target/linux/ath79/dts/ar7161_ruckus_gd11.dtsi
+++ b/target/linux/ath79/dts/ar7161_ruckus_gd11.dtsi
@@ -223,21 +223,3 @@
 &usb_phy {
 	status = "okay";
 };
-
-&board_data {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_bdata_60: macaddr@60 {
-		reg = <0x60 0x6>;
-	};
-
-	macaddr_bdata_66: macaddr@66 {
-		reg = <0x66 0x6>;
-	};
-
-	macaddr_bdata_76: macaddr@76 {
-		reg = <0x76 0x6>;
-	};
-};

--- a/target/linux/ath79/dts/ar7161_ruckus_zf7341.dts
+++ b/target/linux/ath79/dts/ar7161_ruckus_zf7341.dts
@@ -6,3 +6,23 @@
 	model = "Ruckus ZoneFlex 7341[-U]";
 	compatible = "ruckus,zf7341", "qca,ar7161";
 };
+
+&board_data {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_bdata_60: macaddr@60 {
+			reg = <0x60 0x6>;
+		};
+
+		macaddr_bdata_66: macaddr@66 {
+			reg = <0x66 0x6>;
+		};
+
+		macaddr_bdata_76: macaddr@76 {
+			reg = <0x76 0x6>;
+		};
+	};
+};

--- a/target/linux/ath79/dts/ar7161_ruckus_zf7351.dts
+++ b/target/linux/ath79/dts/ar7161_ruckus_zf7351.dts
@@ -113,3 +113,23 @@
 		gpio-hog;
 	};
 };
+
+&board_data {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_bdata_60: macaddr@60 {
+			reg = <0x60 0x6>;
+		};
+
+		macaddr_bdata_66: macaddr@66 {
+			reg = <0x66 0x6>;
+		};
+
+		macaddr_bdata_76: macaddr@76 {
+			reg = <0x76 0x6>;
+		};
+	};
+};

--- a/target/linux/ath79/dts/ar7161_ruckus_zf7363.dts
+++ b/target/linux/ath79/dts/ar7161_ruckus_zf7363.dts
@@ -33,7 +33,25 @@
 };
 
 &board_data {
-	macaddr_bdata_6c: macaddr@6c {
-		reg = <0x6c 0x6>;
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_bdata_60: macaddr@60 {
+			reg = <0x60 0x6>;
+		};
+
+		macaddr_bdata_66: macaddr@66 {
+			reg = <0x66 0x6>;
+		};
+
+		macaddr_bdata_6c: macaddr@6c {
+			reg = <0x6c 0x6>;
+		};
+
+		macaddr_bdata_76: macaddr@76 {
+			reg = <0x76 0x6>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar7240_buffalo_whr-g301n.dts
+++ b/target/linux/ath79/dts/ar7240_buffalo_whr-g301n.dts
@@ -147,6 +147,16 @@
 				reg = <0x3f0000 0x10000>;
 				label = "art";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_120c: macaddr@120c {
+						reg = <0x120c 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -182,15 +192,5 @@
 &pinmux {
 	switch_led_pins: switch_led_pins {
 		pinctrl-single,bits = <0x0 0x0 0xf8>;
-	};
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_120c: macaddr@120c {
-		reg = <0x120c 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar7240_buffalo_whr-g301n.dts
+++ b/target/linux/ath79/dts/ar7240_buffalo_whr-g301n.dts
@@ -154,7 +154,9 @@
 					#size-cells = <1>;
 
 					macaddr_art_120c: macaddr@120c {
+						compatible = "mac-base";
 						reg = <0x120c 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -163,16 +165,15 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_art_120c>;
+	nvmem-cells = <&macaddr_art_120c 0>;
 	nvmem-cell-names = "mac-address";
 };
 
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_120c>;
+	nvmem-cells = <&macaddr_art_120c 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &pcie {
@@ -182,7 +183,7 @@
 		compatible = "pci168c,002a";
 		reg = <0x0000 0 0 0 0>;
 		qca,no-eeprom;
-		nvmem-cells = <&macaddr_art_120c>;
+		nvmem-cells = <&macaddr_art_120c 0>;
 		nvmem-cell-names = "mac-address";
 		#gpio-cells = <2>;
 		gpio-controller;

--- a/target/linux/ath79/dts/ar7240_engenius_enh202-v1.dts
+++ b/target/linux/ath79/dts/ar7240_engenius_enh202-v1.dts
@@ -96,11 +96,13 @@
 };
 
 &art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
+		macaddr_art_0: macaddr@0 {
+			reg = <0x0 0x6>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar7240_netgear_wnr1000-v2.dts
+++ b/target/linux/ath79/dts/ar7240_netgear_wnr1000-v2.dts
@@ -168,6 +168,20 @@
 				label = "art";
 				reg = <0x3f0000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -197,19 +211,5 @@
 		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;
-	};
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar7240_netgear_wnr1000-v2.dts
+++ b/target/linux/ath79/dts/ar7240_netgear_wnr1000-v2.dts
@@ -175,7 +175,9 @@
 					#size-cells = <1>;
 
 					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
 						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 
 					macaddr_art_6: macaddr@6 {
@@ -188,7 +190,7 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -205,9 +207,8 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,002b";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0>;
+		nvmem-cells = <&macaddr_art_0 1>;
 		nvmem-cell-names = "mac-address";
-		mac-address-increment = <1>;
 		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;

--- a/target/linux/ath79/dts/ar7240_netgear_wnr612-v2.dtsi
+++ b/target/linux/ath79/dts/ar7240_netgear_wnr612-v2.dtsi
@@ -101,6 +101,20 @@
 				reg = <0x3f0000 0x10000>;
 				label = "art";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -130,19 +144,5 @@
 		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;
-	};
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar7240_netgear_wnr612-v2.dtsi
+++ b/target/linux/ath79/dts/ar7240_netgear_wnr612-v2.dtsi
@@ -108,7 +108,9 @@
 					#size-cells = <1>;
 
 					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
 						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 
 					macaddr_art_6: macaddr@6 {
@@ -121,7 +123,7 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -138,9 +140,8 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,002b";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0>;
+		nvmem-cells = <&macaddr_art_0 1>;
 		nvmem-cell-names = "mac-address";
-		mac-address-increment = <1>;
 		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;

--- a/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
+++ b/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
@@ -127,20 +127,22 @@
 				reg = <0xfc0000 0x040000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_art_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 
-				macaddr_art_6: macaddr@6 {
-					reg = <0x6 0x6>;
-				};
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
 
-				calibration_art_1000: calibration@1000 {
-					reg = <0x1000 0x440>;
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/ar7240_ruckus_zf7025.dts
+++ b/target/linux/ath79/dts/ar7240_ruckus_zf7025.dts
@@ -150,6 +150,24 @@
 				reg = <0xfc0000 0x40000>;
 				label = "board-data";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_board_data_60: macaddr@60 {
+						reg = <0x60 0x6>;
+					};
+
+					macaddr_board_data_66: macaddr@66 {
+						reg = <0x66 0x6>;
+					};
+
+					macaddr_board_data_6c: macaddr@6c {
+						reg = <0x6c 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -174,23 +192,5 @@
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&macaddr_board_data_60>;
 		nvmem-cell-names = "mac-address";
-	};
-};
-
-&board_data {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_board_data_60: macaddr@60 {
-		reg = <0x60 0x6>;
-	};
-
-	macaddr_board_data_66: macaddr@66 {
-		reg = <0x66 0x6>;
-	};
-
-	macaddr_board_data_6c: macaddr@6c {
-		reg = <0x6c 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar7240_tplink.dtsi
+++ b/target/linux/ath79/dts/ar7240_tplink.dtsi
@@ -84,7 +84,9 @@
 					#size-cells = <1>;
 
 					macaddr_uboot_1fc00: macaddr@1fc00 {
+						compatible = "mac-base";
 						reg = <0x1fc00 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -114,7 +116,7 @@
 	ath9k: wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		qca,no-eeprom;
-		nvmem-cells = <&macaddr_uboot_1fc00>;
+		nvmem-cells = <&macaddr_uboot_1fc00 0>;
 		nvmem-cell-names = "mac-address";
 		#gpio-cells = <2>;
 		gpio-controller;

--- a/target/linux/ath79/dts/ar7240_tplink.dtsi
+++ b/target/linux/ath79/dts/ar7240_tplink.dtsi
@@ -77,6 +77,16 @@
 				reg = <0x0 0x20000>;
 				label = "u-boot";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -114,15 +124,5 @@
 &pinmux {
 	pinmux_switch_led_pins: switch_led_pins {
 		pinctrl-single,bits = <0x0 0x0 0xf8>;
-	};
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr.dtsi
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr.dtsi
@@ -30,15 +30,13 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 (-1)>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-1)>;
 };
 
 &eth1 {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &ath9k {

--- a/target/linux/ath79/dts/ar7241_netgear_wnr2000-v3.dts
+++ b/target/linux/ath79/dts/ar7241_netgear_wnr2000-v3.dts
@@ -171,6 +171,20 @@
 				label = "art";
 				reg = <0x3f0000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -202,19 +216,5 @@
 		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;
-	};
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar7241_netgear_wnr2000-v3.dts
+++ b/target/linux/ath79/dts/ar7241_netgear_wnr2000-v3.dts
@@ -178,7 +178,9 @@
 					#size-cells = <1>;
 
 					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
 						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 
 					macaddr_art_6: macaddr@6 {
@@ -193,7 +195,7 @@
 &eth0 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -210,9 +212,8 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,002e";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0>;
+		nvmem-cells = <&macaddr_art_0 1>;
 		nvmem-cell-names = "mac-address";
-		mac-address-increment = <1>;
 		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;

--- a/target/linux/ath79/dts/ar7241_netgear_wnr2200-16m.dts
+++ b/target/linux/ath79/dts/ar7241_netgear_wnr2200-16m.dts
@@ -35,6 +35,20 @@
 		label = "art";
 		reg = <0xff0000 0x10000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_art_0: macaddr@0 {
+				reg = <0x0 0x6>;
+			};
+
+			macaddr_art_6: macaddr@6 {
+				reg = <0x6 0x6>;
+			};
+		};
 	};
 };
 
@@ -52,18 +66,4 @@
 	nvmem-cells = <&macaddr_art_0>;
 	nvmem-cell-names = "mac-address";
 	mac-address-increment = <1>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar7241_netgear_wnr2200-16m.dts
+++ b/target/linux/ath79/dts/ar7241_netgear_wnr2200-16m.dts
@@ -42,7 +42,9 @@
 			#size-cells = <1>;
 
 			macaddr_art_0: macaddr@0 {
+				compatible = "mac-base";
 				reg = <0x0 0x6>;
+				#nvmem-cell-cells = <1>;
 			};
 
 			macaddr_art_6: macaddr@6 {
@@ -53,7 +55,7 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -63,7 +65,6 @@
 };
 
 &ath9k {
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };

--- a/target/linux/ath79/dts/ar7241_netgear_wnr2200-8m.dts
+++ b/target/linux/ath79/dts/ar7241_netgear_wnr2200-8m.dts
@@ -42,7 +42,9 @@
 			#size-cells = <1>;
 
 			macaddr_art_0: macaddr@0 {
+				compatible = "mac-base";
 				reg = <0x0 0x6>;
+				#nvmem-cell-cells = <1>;
 			};
 
 			macaddr_art_6: macaddr@6 {
@@ -53,7 +55,7 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -63,7 +65,6 @@
 };
 
 &ath9k {
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };

--- a/target/linux/ath79/dts/ar7241_netgear_wnr2200-8m.dts
+++ b/target/linux/ath79/dts/ar7241_netgear_wnr2200-8m.dts
@@ -35,6 +35,20 @@
 		label = "art";
 		reg = <0x7f0000 0x10000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_art_0: macaddr@0 {
+				reg = <0x0 0x6>;
+			};
+
+			macaddr_art_6: macaddr@6 {
+				reg = <0x6 0x6>;
+			};
+		};
 	};
 };
 
@@ -52,18 +66,4 @@
 	nvmem-cells = <&macaddr_art_0>;
 	nvmem-cell-names = "mac-address";
 	mac-address-increment = <1>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar7241_tplink.dtsi
+++ b/target/linux/ath79/dts/ar7241_tplink.dtsi
@@ -71,7 +71,9 @@
 					#size-cells = <1>;
 
 					macaddr_uboot_1fc00: macaddr@1fc00 {
+						compatible = "mac-base";
 						reg = <0x1fc00 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -99,7 +101,7 @@
 		#gpio-cells = <2>;
 		gpio-controller;
 		qca,no-eeprom;
-		nvmem-cells = <&macaddr_uboot_1fc00>;
+		nvmem-cells = <&macaddr_uboot_1fc00 0>;
 		nvmem-cell-names = "mac-address";
 	};
 };
@@ -107,12 +109,11 @@
 &eth0 {		/* WAN interface, initialized last as eth1 */
 	status = "okay";
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &eth1 {		/* LAN interface, initialized first as eth0 */
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ath79/dts/ar7241_tplink.dtsi
+++ b/target/linux/ath79/dts/ar7241_tplink.dtsi
@@ -64,6 +64,16 @@
 				reg = <0x0 0x20000>;
 				label = "u-boot";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -105,14 +115,4 @@
 &eth1 {		/* LAN interface, initialized first as eth0 */
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
+++ b/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
@@ -102,6 +102,16 @@
 				reg = <0x0 0x20000>;
 				label = "u-boot";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -145,14 +155,4 @@
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
 	mac-address-increment = <1>;
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
+++ b/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
@@ -109,7 +109,9 @@
 					#size-cells = <1>;
 
 					macaddr_uboot_1fc00: macaddr@1fc00 {
+						compatible = "mac-base";
 						reg = <0x1fc00 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -138,7 +140,7 @@
 		#gpio-cells = <2>;
 		gpio-controller;
 		qca,no-eeprom;
-		nvmem-cells = <&macaddr_uboot_1fc00>;
+		nvmem-cells = <&macaddr_uboot_1fc00 0>;
 		nvmem-cell-names = "mac-address";
 	};
 };
@@ -146,13 +148,11 @@
 &eth0 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 (-1)>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-1)>;
 };
 
 &eth1 {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi-ap-outdoor-plus.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi-ap-outdoor-plus.dts
@@ -87,20 +87,22 @@
 				reg = <0xff0000 0x10000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_art_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 
-				macaddr_art_6: macaddr@6 {
-					reg = <0x6 0x6>;
-				};
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
 
-				calibration_art_1000: calibration@1000 {
-					reg = <0x1000 0xeb8>;
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0xeb8>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi-ap.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi-ap.dtsi
@@ -73,16 +73,18 @@
 				reg = <0x7f0000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_art_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 
-				calibration_art_1000: calibration@1000 {
-					reg = <0x1000 0x440>;
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/ar7242_buffalo_bhr-4grv.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_bhr-4grv.dts
@@ -20,11 +20,13 @@
 };
 
 &art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
+		macaddr_art_0: macaddr@0 {
+			reg = <0x0 0x6>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g302h-a1a0.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g302h-a1a0.dts
@@ -138,16 +138,18 @@
 				label = "art";
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_art_120c: macaddr@120c {
-					reg = <0x120c 0x6>;
-				};
+					macaddr_art_120c: macaddr@120c {
+						reg = <0x120c 0x6>;
+					};
 
-				calibration_art_1000: calibration@1000 {
-					reg = <0x1000 0xeb8>;
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0xeb8>;
+					};
 				};
 			};
 

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
@@ -83,11 +83,13 @@
 };
 
 &art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	macaddr_art_1002: macaddr@1002 {
-		reg = <0x1002 0x6>;
+		macaddr_art_1002: macaddr@1002 {
+			reg = <0x1002 0x6>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar7242_engenius_eap350-v1.dts
+++ b/target/linux/ath79/dts/ar7242_engenius_eap350-v1.dts
@@ -88,11 +88,13 @@
 };
 
 &art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
+		macaddr_art_0: macaddr@0 {
+			reg = <0x0 0x6>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar7242_engenius_eap350-v1.dts
+++ b/target/linux/ath79/dts/ar7242_engenius_eap350-v1.dts
@@ -63,7 +63,7 @@
 &eth0 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 
 	phy-handle = <&phy4>;
@@ -78,9 +78,8 @@
 	ath9k: wifi@0,0,0 {
 		compatible = "pci168c,002a";
 		reg = <0x0 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0>;
+		nvmem-cells = <&macaddr_art_0 1>;
 		nvmem-cell-names = "mac-address";
-		mac-address-increment = <1>;
 		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;
@@ -94,7 +93,9 @@
 		#size-cells = <1>;
 
 		macaddr_art_0: macaddr@0 {
+			compatible = "mac-base";
 			reg = <0x0 0x6>;
+			#nvmem-cell-cells = <1>;
 		};
 	};
 };

--- a/target/linux/ath79/dts/ar7242_engenius_ecb350-v1.dts
+++ b/target/linux/ath79/dts/ar7242_engenius_ecb350-v1.dts
@@ -88,11 +88,13 @@
 };
 
 &art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
+		macaddr_art_0: macaddr@0 {
+			reg = <0x0 0x6>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar7242_engenius_ecb350-v1.dts
+++ b/target/linux/ath79/dts/ar7242_engenius_ecb350-v1.dts
@@ -63,7 +63,7 @@
 &eth0 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 
 	phy-handle = <&phy4>;
@@ -78,9 +78,8 @@
 	ath9k: wifi@0,0,0 {
 		compatible = "pci168c,002a";
 		reg = <0x0 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0>;
+		nvmem-cells = <&macaddr_art_0 (-1)>;
 		nvmem-cell-names = "mac-address";
-		mac-address-increment = <(-1)>;
 		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;
@@ -94,7 +93,9 @@
 		#size-cells = <1>;
 
 		macaddr_art_0: macaddr@0 {
+			compatible = "mac-base";
 			reg = <0x0 0x6>;
+			#nvmem-cell-cells = <1>;
 		};
 	};
 };

--- a/target/linux/ath79/dts/ar7242_meraki_mr12.dts
+++ b/target/linux/ath79/dts/ar7242_meraki_mr12.dts
@@ -140,6 +140,16 @@
 				label = "config";
 				reg = <0x80000 0x20000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_66: macaddr@66 {
+						reg = <0x66 0x6>;
+					};
+				};
 			};
 
 			partition@a0000 {
@@ -154,15 +164,5 @@
 				read-only;
 			};
 		};
-	};
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_66: macaddr@66 {
-		reg = <0x66 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar7242_meraki_mr12.dts
+++ b/target/linux/ath79/dts/ar7242_meraki_mr12.dts
@@ -74,9 +74,8 @@
 		compatible = "pci168c,002a";
 		reg = <0x0000 0 0 0 0>;
 		qca,no-eeprom;
-		nvmem-cells = <&macaddr_config_66>;
+		nvmem-cells = <&macaddr_config_66 1>;
 		nvmem-cell-names = "mac-address";
-		mac-address-increment = <1>;
 	};
 };
 
@@ -91,7 +90,7 @@
 &eth0 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_config_66>;
+	nvmem-cells = <&macaddr_config_66 0>;
 	nvmem-cell-names = "mac-address";
 
 	pll-data = <0x02000000 0x00000101 0x00001313>;
@@ -107,7 +106,7 @@
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_config_66>;
+	nvmem-cells = <&macaddr_config_66 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -147,7 +146,9 @@
 					#size-cells = <1>;
 
 					macaddr_config_66: macaddr@66 {
+						compatible = "mac-base";
 						reg = <0x66 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};

--- a/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
+++ b/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
@@ -107,6 +107,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -119,6 +129,16 @@
 				label = "art";
 				reg = <0x7f0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_art_1000: cal@1000 {
+						reg = <0x1000 0x440>;
+					};
+				};
 			};
 		};
 	};
@@ -155,25 +175,5 @@
 	fixed-link {
 		speed = <1000>;
 		full-duplex;
-	};
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	cal_art_1000: cal@1000 {
-		reg = <0x1000 0x440>;
 	};
 };

--- a/target/linux/ath79/dts/ar7242_ubnt_edgeswitch-5xp.dts
+++ b/target/linux/ath79/dts/ar7242_ubnt_edgeswitch-5xp.dts
@@ -75,13 +75,3 @@
 		full-duplex;
 	};
 };
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-};

--- a/target/linux/ath79/dts/ar7242_ubnt_edgeswitch-8xp.dts
+++ b/target/linux/ath79/dts/ar7242_ubnt_edgeswitch-8xp.dts
@@ -186,13 +186,3 @@
 		full-duplex;
 	};
 };
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-};

--- a/target/linux/ath79/dts/ar7242_ubnt_sw.dtsi
+++ b/target/linux/ath79/dts/ar7242_ubnt_sw.dtsi
@@ -104,6 +104,20 @@
 				reg = <0x7f0000 0x010000>;
 				label = "art";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -126,14 +140,4 @@
 
 	nvmem-cells = <&macaddr_art_6>;
 	nvmem-cell-names = "mac-address";
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar724x_ubnt_xm.dtsi
+++ b/target/linux/ath79/dts/ar724x_ubnt_xm.dtsi
@@ -62,6 +62,20 @@
 				label = "art";
 				reg = <0x7f0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -88,18 +102,4 @@
 
 	nvmem-cells = <&macaddr_art_6>;
 	nvmem-cell-names = "mac-address";
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh.dtsi
+++ b/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh.dtsi
@@ -137,6 +137,16 @@
 				label = "art";
 				reg = <0x1fe0000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_1120c: macaddr@1120c {
+						reg = <0x1120c 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -249,14 +259,4 @@
 
 &usb_phy {
 	status = "okay";
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_1120c: macaddr@1120c {
-		reg = <0x1120c 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wa901nd-v2.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wa901nd-v2.dts
@@ -73,6 +73,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@1 {
@@ -120,14 +130,4 @@
 	mtd-cal-data = <&art 0x1000>;
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
@@ -99,6 +99,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -135,14 +145,4 @@
 	mtd-cal-data = <&art 0x1000>;
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr941-v2.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr941-v2.dts
@@ -122,6 +122,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x20000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -157,14 +167,4 @@
 	mtd-cal-data = <&art 0x1000>;
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9330_glinet_gl-ar150.dts
+++ b/target/linux/ath79/dts/ar9330_glinet_gl-ar150.dts
@@ -105,6 +105,16 @@
 				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -137,14 +147,4 @@
 	mtd-cal-data = <&art 0x1000>;
 	nvmem-cells = <&macaddr_art_0>;
 	nvmem-cell-names = "mac-address";
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9330_openmesh_om2p.dtsi
+++ b/target/linux/ath79/dts/ar9330_openmesh_om2p.dtsi
@@ -122,6 +122,20 @@
 				label = "ART";
 				reg = <0xfc0000 0x040000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -145,18 +159,4 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9330_pqi_air-pen.dts
+++ b/target/linux/ath79/dts/ar9330_pqi_air-pen.dts
@@ -86,6 +86,20 @@
 				label = "art";
 				reg = <0x050000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_2: macaddr@2 {
+						reg = <0x2 0x6>;
+					};
+
+					macaddr_art_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
+				};
 			};
 
 			partition@60000 {
@@ -135,18 +149,4 @@
 	mtd-cal-data = <&art 0x1000>;
 	nvmem-cells = <&macaddr_art_2>;
 	nvmem-cell-names = "mac-address";
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_2: macaddr@2 {
-		reg = <0x2 0x6>;
-	};
-
-	macaddr_art_1002: macaddr@1002 {
-		reg = <0x1002 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9330_ziking_cpe46b.dts
+++ b/target/linux/ath79/dts/ar9330_ziking_cpe46b.dts
@@ -85,7 +85,9 @@
 					#size-cells = <1>;
 
 					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
 						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -96,16 +98,15 @@
 &eth0 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 };
 
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 2>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <2>;
 };
 
 &wmac {

--- a/target/linux/ath79/dts/ar9330_ziking_cpe46b.dts
+++ b/target/linux/ath79/dts/ar9330_ziking_cpe46b.dts
@@ -78,6 +78,16 @@
 				label = "art";
 				reg = <0x7f0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -102,14 +112,4 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_8dev_carambola2.dts
+++ b/target/linux/ath79/dts/ar9331_8dev_carambola2.dts
@@ -92,6 +92,20 @@
 				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -123,18 +137,4 @@
 &wmac {
 	status = "okay";
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_alfa-network_ap121f.dtsi
+++ b/target/linux/ath79/dts/ar9331_alfa-network_ap121f.dtsi
@@ -101,20 +101,22 @@
 				reg = <0x040000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				cal_art_1000: cal@1000 {
-					reg = <0x1000 0x440>;
-				};
+					cal_art_1000: cal@1000 {
+						reg = <0x1000 0x440>;
+					};
 
-				macaddr_art_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 
-				macaddr_art_1002: macaddr@1002 {
-					reg = <0x1002 0x6>;
+					macaddr_art_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
 				};
 			};
 

--- a/target/linux/ath79/dts/ar9331_etactica_eg200.dts
+++ b/target/linux/ath79/dts/ar9331_etactica_eg200.dts
@@ -109,6 +109,16 @@
 			art: art@ff0000 {
 				reg = <0xff0000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -117,14 +127,4 @@
 &wmac {
 	status = "okay";
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_glinet_6408.dts
+++ b/target/linux/ath79/dts/ar9331_glinet_6408.dts
@@ -28,6 +28,16 @@
 				reg = <0x0 0x20000>;
 				label = "u-boot";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -60,14 +70,4 @@
 
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_glinet_6416.dts
+++ b/target/linux/ath79/dts/ar9331_glinet_6416.dts
@@ -28,6 +28,16 @@
 				reg = <0x0 0x20000>;
 				label = "u-boot";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -60,14 +70,4 @@
 
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_glinet_gl-mifi.dts
+++ b/target/linux/ath79/dts/ar9331_glinet_gl-mifi.dts
@@ -113,6 +113,16 @@
 				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -143,14 +153,4 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_glinet_gl-usb150.dts
+++ b/target/linux/ath79/dts/ar9331_glinet_gl-usb150.dts
@@ -108,6 +108,16 @@
 				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -117,14 +127,4 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_hak5_lan-turtle.dtsi
+++ b/target/linux/ath79/dts/ar9331_hak5_lan-turtle.dtsi
@@ -68,6 +68,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -91,14 +101,4 @@
 
 &usb_phy {
 	status = "okay";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_hak5_lan-turtle.dtsi
+++ b/target/linux/ath79/dts/ar9331_hak5_lan-turtle.dtsi
@@ -24,9 +24,8 @@
 &eth0 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 (-1)>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-1)>;
 
 	gmac-config {
 		device = <&gmac>;
@@ -39,9 +38,8 @@
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &pinmux {
@@ -75,7 +73,9 @@
 					#size-cells = <1>;
 
 					macaddr_uboot_1fc00: macaddr@1fc00 {
+						compatible = "mac-base";
 						reg = <0x1fc00 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};

--- a/target/linux/ath79/dts/ar9331_hak5_wifi-pineapple-nano.dts
+++ b/target/linux/ath79/dts/ar9331_hak5_wifi-pineapple-nano.dts
@@ -102,6 +102,16 @@
 				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -119,14 +129,4 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_hiwifi_hc6361.dts
+++ b/target/linux/ath79/dts/ar9331_hiwifi_hc6361.dts
@@ -77,7 +77,6 @@
 			};
 
 			bdinfo: partition@10000 {
-				compatible = "nvmem-cells";
 				reg = <0x10000 0x10000>;
 				label = "bdinfo";
 				read-only;

--- a/target/linux/ath79/dts/ar9331_onion_omega.dts
+++ b/target/linux/ath79/dts/ar9331_onion_omega.dts
@@ -72,9 +72,8 @@
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 (-1)>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-1)>;
 
 	gmac-config {
 		device = <&gmac>;
@@ -107,7 +106,9 @@
 					#size-cells = <1>;
 
 					macaddr_uboot_1fc00: macaddr@1fc00 {
+						compatible = "mac-base";
 						reg = <0x1fc00 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -132,6 +133,6 @@
 
 	mtd-cal-data = <&art 0x1000>;
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ath79/dts/ar9331_onion_omega.dts
+++ b/target/linux/ath79/dts/ar9331_onion_omega.dts
@@ -100,6 +100,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -124,14 +134,4 @@
 
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_pisen_ts-d084.dts
+++ b/target/linux/ath79/dts/ar9331_pisen_ts-d084.dts
@@ -55,6 +55,16 @@
 				reg = <0x0 0x20000>;
 				label = "u-boot";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			firmware: partition@20000 {
@@ -105,14 +115,4 @@
 	mtd-cal-data = <&art 0x1000>;
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_pisen_wmm003n.dts
+++ b/target/linux/ath79/dts/ar9331_pisen_wmm003n.dts
@@ -63,6 +63,16 @@
 				reg = <0x0 0x20000>;
 				label = "u-boot";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			firmware: partition@20000 {
@@ -114,14 +124,4 @@
 	mtd-cal-data = <&art 0x1000>;
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
+++ b/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
@@ -144,6 +144,16 @@
 				label = "config";
 				reg = <0x20000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
 			};
 
 			art: partition@30000 {
@@ -193,14 +203,4 @@
 	nvmem-cells = <&macaddr_config_0>;
 	nvmem-cell-names = "mac-address";
 	mac-address-increment = <2>;
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
+++ b/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
@@ -109,15 +109,14 @@
 &eth0 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_config_0>;
+	nvmem-cells = <&macaddr_config_0 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_config_0>;
+	nvmem-cells = <&macaddr_config_0 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -151,7 +150,9 @@
 					#size-cells = <1>;
 
 					macaddr_config_0: macaddr@0 {
+						compatible = "mac-base";
 						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -200,7 +201,6 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_config_0>;
+	nvmem-cells = <&macaddr_config_0 2>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <2>;
 };

--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr3020-v1.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr3020-v1.dts
@@ -113,6 +113,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -161,14 +171,4 @@
 	mtd-cal-data = <&art 0x1000>;
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
@@ -108,6 +108,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -150,14 +160,4 @@
 	mtd-cal-data = <&art 0x1000>;
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr703n_tl-mr10u.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr703n_tl-mr10u.dtsi
@@ -60,6 +60,16 @@
 				reg = <0x0 0x20000>;
 				label = "u-boot";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -113,14 +123,4 @@
 	mtd-cal-data = <&art 0x1000>;
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-8m.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-8m.dtsi
@@ -25,6 +25,16 @@
 				reg = <0x0 0x20000>;
 				label = "u-boot";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -58,14 +68,4 @@
 
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-8m.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-8m.dtsi
@@ -32,7 +32,9 @@
 					#size-cells = <1>;
 
 					macaddr_uboot_1fc00: macaddr@1fc00 {
+						compatible = "mac-base";
 						reg = <0x1fc00 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -53,19 +55,18 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };
 
 &eth1 {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 (-1)>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-1)>;
 };
 
 &wmac {
 	mtd-cal-data = <&art 0x1000>;
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr741nd-v4.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr741nd-v4.dtsi
@@ -108,7 +108,9 @@
 					#size-cells = <1>;
 
 					macaddr_uboot_1fc00: macaddr@1fc00 {
+						compatible = "mac-base";
 						reg = <0x1fc00 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -131,9 +133,8 @@
 &eth0 {		/* WAN interface, initialized last as eth1 */
 	status = "okay";
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 
 	gmac-config {
 		device = <&gmac>;
@@ -146,7 +147,7 @@
 &eth1 {		/* LAN interface, initialized first as eth0 */
 	status = "okay";
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -154,6 +155,6 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr741nd-v4.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr741nd-v4.dtsi
@@ -101,6 +101,16 @@
 				reg = <0x0 0x20000>;
 				label = "u-boot";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			firmware: partition@20000 {
@@ -146,14 +156,4 @@
 	mtd-cal-data = <&art 0x1000>;
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9341_engenius_eap300-v2.dts
+++ b/target/linux/ath79/dts/ar9341_engenius_eap300-v2.dts
@@ -57,11 +57,13 @@
 };
 
 &art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
+		macaddr_art_0: macaddr@0 {
+			reg = <0x0 0x6>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar9341_engenius_ens202ext-v1.dts
+++ b/target/linux/ath79/dts/ar9341_engenius_ens202ext-v1.dts
@@ -88,11 +88,13 @@
 };
 
 &art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
+		macaddr_art_0: macaddr@0 {
+			reg = <0x0 0x6>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar9341_openmesh_om2p-hs.dtsi
+++ b/target/linux/ath79/dts/ar9341_openmesh_om2p-hs.dtsi
@@ -132,6 +132,20 @@
 				label = "ART";
 				reg = <0xfc0000 0x040000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -155,18 +169,4 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9341_pcs_cr3000.dts
+++ b/target/linux/ath79/dts/ar9341_pcs_cr3000.dts
@@ -118,6 +118,16 @@
 				label = "art";
 				reg = <0x7f0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -148,15 +158,5 @@
 	gmac-config {
 		device = <&gmac>;
 		switch-phy-swap = <1>;
-	};
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar9341_pcs_cr3000.dts
+++ b/target/linux/ath79/dts/ar9341_pcs_cr3000.dts
@@ -125,7 +125,9 @@
 					#size-cells = <1>;
 
 					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
 						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -143,16 +145,15 @@
 	status = "okay";
 
 	phy-handle = <&swphy0>;
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &eth1 {
 	phy-handle = <&swphy4>;
 	pll-data = <0x06000000 0x00000101 0x00001616>;
 
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 
 	gmac-config {

--- a/target/linux/ath79/dts/ar9341_pisen_wmb001n.dts
+++ b/target/linux/ath79/dts/ar9341_pisen_wmb001n.dts
@@ -180,6 +180,16 @@
 				label = "art";
 				reg = <0xff0000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -213,14 +223,4 @@
 &wmac {
 	status = "okay";
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9341_tplink_tl-mr3420-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-mr3420-v2.dts
@@ -64,6 +64,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -105,14 +115,4 @@
 
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9341_tplink_tl-mr3420-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-mr3420-v2.dts
@@ -71,7 +71,9 @@
 					#size-cells = <1>;
 
 					macaddr_uboot_1fc00: macaddr@1fc00 {
+						compatible = "mac-base";
 						reg = <0x1fc00 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -100,19 +102,18 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 (-1)>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-1)>;
 };
 
 &eth1 {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };
 
 &wmac {
 	mtd-cal-data = <&art 0x1000>;
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wa.dtsi
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wa.dtsi
@@ -32,6 +32,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -74,14 +84,4 @@
 	mtd-cal-data = <&art 0x1000>;
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
@@ -54,7 +54,9 @@
 					#size-cells = <1>;
 
 					macaddr_uboot_1fc00: macaddr@1fc00 {
+						compatible = "mac-base";
 						reg = <0x1fc00 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -75,19 +77,18 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 (-1)>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-1)>;
 };
 
 &eth1 {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };
 
 &wmac {
 	mtd-cal-data = <&art 0x1000>;
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
@@ -47,6 +47,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -80,14 +90,4 @@
 
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
@@ -72,7 +72,9 @@
 					#size-cells = <1>;
 
 					macaddr_uboot_1fc00: macaddr@1fc00 {
+						compatible = "mac-base";
 						reg = <0x1fc00 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -101,21 +103,20 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 (-1)>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-1)>;
 };
 
 &eth1 {
 	phy-handle = <&swphy4>;
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };
 
 &wmac {
 	mtd-cal-data = <&art 0x1000>;
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
@@ -65,6 +65,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -108,14 +118,4 @@
 
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr941nd-v5.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr941nd-v5.dts
@@ -57,6 +57,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -90,14 +100,4 @@
 
 	nvmem-cells = <&macaddr_uboot_1fc00>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr941nd-v5.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr941nd-v5.dts
@@ -64,7 +64,9 @@
 					#size-cells = <1>;
 
 					macaddr_uboot_1fc00: macaddr@1fc00 {
+						compatible = "mac-base";
 						reg = <0x1fc00 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -85,19 +87,18 @@
 };
 
 &eth0 {		// WAN port, initialized last as eth1
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &eth1 {		// LAN ports, initialized first as eth0
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };
 
 &wmac {
 	mtd-cal-data = <&art 0x1000>;
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ath79/dts/ar9342_ruckus_zf7321.dts
+++ b/target/linux/ath79/dts/ar9342_ruckus_zf7321.dts
@@ -49,6 +49,26 @@
 	};
 };
 
+&board_data {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_board_data_60: macaddr@60 {
+			reg = <0x60 0x6>;
+		};
+
+		macaddr_board_data_66: macaddr@66 {
+			reg = <0x66 0x6>;
+		};
+
+		cal_board_data_41000: cal@41000 {
+			reg = <0x41000 0x440>;
+		};
+	};
+};
+
 &eth0 {
 	nvmem-cells = <&macaddr_board_data_66>;
 };

--- a/target/linux/ath79/dts/ar9342_ubnt_aircube-ac.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_aircube-ac.dts
@@ -63,20 +63,22 @@
 				reg = <0xff0000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_art_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 
-				calibration_art_1000: calibration@1000 {
-					reg = <0x1000 0x440>;
-				};
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
 
-				calibration_art_5000: calibration@5000 {
-					reg = <0x5000 0x844>;
+					calibration_art_5000: calibration@5000 {
+						reg = <0x5000 0x844>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/ar9342_ubnt_wa.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_wa.dtsi
@@ -70,6 +70,16 @@
 				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -80,14 +90,4 @@
 
 	ieee80211-freq-limit = <2402000 2482000>;
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
@@ -98,6 +98,16 @@
 				label = "art";
 				reg = <0x7f0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -112,14 +122,4 @@
 &eth0 {
 	nvmem-cells = <&macaddr_art_0>;
 	nvmem-cell-names = "mac-address";
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9342_zyxel_nwa11xx.dtsi
+++ b/target/linux/ath79/dts/ar9342_zyxel_nwa11xx.dtsi
@@ -92,8 +92,6 @@
 				reg = <0xfe0000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
@@ -118,16 +116,18 @@
 				reg = <0xff0000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				calibration_ath9k: calibration@1000 {
-					reg = <0x1000 0x440>;
-				};
+					calibration_ath9k: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
 
-				macaddr_art_1002: macaddr@1002 {
-					reg = <0x1002 0x6>;
+					macaddr_art_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/ar9344_aerohive_hiveap-121.dts
+++ b/target/linux/ath79/dts/ar9344_aerohive_hiveap-121.dts
@@ -141,6 +141,16 @@
 				label = "hw-info";
 				reg = <0x90000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_hw_info_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
 			};
 
 			partition@a0000 {
@@ -228,15 +238,5 @@
 		rgmii-gmac0 = <1>;
 		rxd-delay = <1>;
 		rxdv-delay = <1>;
-	};
-};
-
-&hw_info {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_hw_info_0: macaddr@0 {
-		reg = <0x0 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar9344_aerohive_hiveap-121.dts
+++ b/target/linux/ath79/dts/ar9344_aerohive_hiveap-121.dts
@@ -106,9 +106,8 @@
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
 
-		nvmem-cells = <&macaddr_hw_info_0>;
+		nvmem-cells = <&macaddr_hw_info_0 2>;
 		nvmem-cell-names = "mac-address";
-		mac-address-increment = <2>;
 	};
 };
 
@@ -148,7 +147,9 @@
 					#size-cells = <1>;
 
 					macaddr_hw_info_0: macaddr@0 {
+						compatible = "mac-base";
 						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -171,9 +172,8 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_hw_info_0>;
+	nvmem-cells = <&macaddr_hw_info_0 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &nand {
@@ -227,7 +227,7 @@
 
 	pll-data = <0x06000000 0x00000101 0x00001313>;
 
-	nvmem-cells = <&macaddr_hw_info_0>;
+	nvmem-cells = <&macaddr_hw_info_0 0>;
 	nvmem-cell-names = "mac-address";
 
 	phy-mode = "rgmii-id";

--- a/target/linux/ath79/dts/ar9344_alfa-network_n5q.dts
+++ b/target/linux/ath79/dts/ar9344_alfa-network_n5q.dts
@@ -136,24 +136,26 @@
 				reg = <0x070000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				cal_art_1000: cal@1000 {
-					reg = <0x1000 0x440>;
-				};
+					cal_art_1000: cal@1000 {
+						reg = <0x1000 0x440>;
+					};
 
-				macaddr_art_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 
-				macaddr_art_6: macaddr@6 {
-					reg = <0x6 0x6>;
-				};
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
 
-				macaddr_art_1002: macaddr@1002 {
-					reg = <0x1002 0x6>;
+					macaddr_art_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
 				};
 			};
 

--- a/target/linux/ath79/dts/ar9344_araknis_an-300-ap-i-n.dts
+++ b/target/linux/ath79/dts/ar9344_araknis_an-300-ap-i-n.dts
@@ -72,7 +72,7 @@
 &eth0 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 
 	phy-handle = <&phy0>;
@@ -87,9 +87,8 @@
 	ath9k: wifi@0,0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0>, <&calibration_art_5000>;
+		nvmem-cells = <&macaddr_art_0 1>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		mac-address-increment = <1>;
 		ieee80211-freq-limit = <2402000 2482000>;
 		#gpio-cells = <2>;
 		gpio-controller;
@@ -101,9 +100,8 @@
 
 	ieee80211-freq-limit = <4900000 5990000>;
 
-	nvmem-cells = <&macaddr_art_0>, <&calibration_art_1000>;
+	nvmem-cells = <&macaddr_art_0 2>, <&calibration_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
-	mac-address-increment = <2>;
 };
 
 &art {
@@ -113,7 +111,9 @@
 		#size-cells = <1>;
 
 		macaddr_art_0: macaddr@0 {
+			compatible = "mac-base";
 			reg = <0x0 0x6>;
+			#nvmem-cell-cells = <1>;
 		};
 
 		calibration_art_1000: calibration@1000 {

--- a/target/linux/ath79/dts/ar9344_araknis_an-300-ap-i-n.dts
+++ b/target/linux/ath79/dts/ar9344_araknis_an-300-ap-i-n.dts
@@ -107,19 +107,21 @@
 };
 
 &art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
+		macaddr_art_0: macaddr@0 {
+			reg = <0x0 0x6>;
+		};
 
-	calibration_art_1000: calibration@1000 {
-		reg = <0x1000 0x440>;
-	};
+		calibration_art_1000: calibration@1000 {
+			reg = <0x1000 0x440>;
+		};
 
-	calibration_art_5000: calibration@5000 {
-		reg = <0x5000 0x440>;
+		calibration_art_5000: calibration@5000 {
+			reg = <0x5000 0x440>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar9344_atheros_db120.dts
+++ b/target/linux/ath79/dts/ar9344_atheros_db120.dts
@@ -140,24 +140,26 @@
 				reg = <0x7f0000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_art_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 
-				macaddr_art_6: macaddr@6 {
-					reg = <0x6 0x6>;
-				};
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
 
-				calibration_art_1000: calibration@1000 {
-					reg = <0x1000 0x440>;
-				};
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
 
-				calibration_art_5000: calibration@5000 {
-					reg = <0x5000 0x440>;
+					calibration_art_5000: calibration@5000 {
+						reg = <0x5000 0x440>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/ar9344_comfast_cf-e120a-v3.dts
+++ b/target/linux/ath79/dts/ar9344_comfast_cf-e120a-v3.dts
@@ -100,6 +100,20 @@
 				label = "art";
 				reg = <0x010000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -138,18 +152,4 @@
 &wmac {
 	status = "okay";
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9344_compex_wpj344-16m.dts
+++ b/target/linux/ath79/dts/ar9344_compex_wpj344-16m.dts
@@ -78,6 +78,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x030000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_2e010: macaddr@2e010 {
+						reg = <0x2e010 0x6>;
+					};
+				};
 			};
 
 			partition@30000 {
@@ -142,14 +152,4 @@
 
 	phy-mode = "rgmii";
 	phy-handle = <&phy0>;
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_2e010: macaddr@2e010 {
-		reg = <0x2e010 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9344_devolo_dlan_wifi.dtsi
+++ b/target/linux/ath79/dts/ar9344_devolo_dlan_wifi.dtsi
@@ -116,6 +116,16 @@
 				label = "art";
 				reg = <0xff0000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -167,15 +177,5 @@
 			0x0c 0x00000000 /* PORT6 PAD MODE CTRL */
 			0x7c 0x0000007e /* PORT0_STATUS */
 		>;
-	};
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_1002: macaddr@1002 {
-		reg = <0x1002 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar9344_devolo_dlan_wifi.dtsi
+++ b/target/linux/ath79/dts/ar9344_devolo_dlan_wifi.dtsi
@@ -123,7 +123,9 @@
 					#size-cells = <1>;
 
 					macaddr_art_1002: macaddr@1002 {
+						compatible = "mac-base";
 						reg = <0x1002 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -140,9 +142,8 @@
 
 	pll-data = <0x02000000 0x00000101 0x00001616>;
 
-	nvmem-cells = <&macaddr_art_1002>;
+	nvmem-cells = <&macaddr_art_1002 2>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <2>;
 
 	phy-mode = "rgmii";
 	phy-handle = <&phy0>;

--- a/target/linux/ath79/dts/ar9344_dlink_dir-8x5.dtsi
+++ b/target/linux/ath79/dts/ar9344_dlink_dir-8x5.dtsi
@@ -116,8 +116,6 @@
 				reg = <0xfe0000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
@@ -142,16 +140,18 @@
 				reg = <0xff0000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				cal_art_1000: cal@1000 {
-					reg = <0x1000 0x440>;
-				};
+					cal_art_1000: cal@1000 {
+						reg = <0x1000 0x440>;
+					};
 
-				cal_art_5000: cal@5000 {
-					reg = <0x5000 0x440>;
+					cal_art_5000: cal@5000 {
+						reg = <0x5000 0x440>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/ar9344_engenius_eap600.dts
+++ b/target/linux/ath79/dts/ar9344_engenius_eap600.dts
@@ -48,19 +48,21 @@
 };
 
 &art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
+		macaddr_art_0: macaddr@0 {
+			reg = <0x0 0x6>;
+		};
 
-	calibration_art_1000: calibration@1000 {
-		reg = <0x1000 0x440>;
-	};
+		calibration_art_1000: calibration@1000 {
+			reg = <0x1000 0x440>;
+		};
 
-	calibration_art_5000: calibration@5000 {
-		reg = <0x5000 0x440>;
+		calibration_art_5000: calibration@5000 {
+			reg = <0x5000 0x440>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar9344_engenius_eap600.dts
+++ b/target/linux/ath79/dts/ar9344_engenius_eap600.dts
@@ -29,22 +29,20 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 (-2)>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-2)>;
 };
 
 &pcie {
 	wifi@0,0,0 {
-		nvmem-cells = <&macaddr_art_0>, <&calibration_art_5000>;
+		nvmem-cells = <&macaddr_art_0 0>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
 	};
 };
 
 &wmac {
-	nvmem-cells = <&macaddr_art_0>, <&calibration_art_1000>;
+	nvmem-cells = <&macaddr_art_0 (-1)>, <&calibration_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
-	mac-address-increment = <(-1)>;
 };
 
 &art {
@@ -54,7 +52,9 @@
 		#size-cells = <1>;
 
 		macaddr_art_0: macaddr@0 {
+			compatible = "mac-base";
 			reg = <0x0 0x6>;
+			#nvmem-cell-cells = <1>;
 		};
 
 		calibration_art_1000: calibration@1000 {

--- a/target/linux/ath79/dts/ar9344_engenius_ecb600.dts
+++ b/target/linux/ath79/dts/ar9344_engenius_ecb600.dts
@@ -43,19 +43,21 @@
 };
 
 &art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
+		macaddr_art_0: macaddr@0 {
+			reg = <0x0 0x6>;
+		};
 
-	calibration_art_1000: calibration@1000 {
-		reg = <0x1000 0x440>;
-	};
+		calibration_art_1000: calibration@1000 {
+			reg = <0x1000 0x440>;
+		};
 
-	calibration_art_5000: calibration@5000 {
-		reg = <0x5000 0x440>;
+		calibration_art_5000: calibration@5000 {
+			reg = <0x5000 0x440>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar9344_engenius_ecb600.dts
+++ b/target/linux/ath79/dts/ar9344_engenius_ecb600.dts
@@ -24,22 +24,20 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 };
 
 &pcie {
 	wifi@0,0,0 {
-		nvmem-cells = <&macaddr_art_0>, <&calibration_art_5000>;
+		nvmem-cells = <&macaddr_art_0 (-2)>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		mac-address-increment = <(-2)>;
 	};
 };
 
 &wmac {
-	nvmem-cells = <&macaddr_art_0>, <&calibration_art_1000>;
+	nvmem-cells = <&macaddr_art_0 (-1)>, <&calibration_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
-	mac-address-increment = <(-1)>;
 };
 
 &art {
@@ -49,7 +47,9 @@
 		#size-cells = <1>;
 
 		macaddr_art_0: macaddr@0 {
+			compatible = "mac-base";
 			reg = <0x0 0x6>;
+			#nvmem-cell-cells = <1>;
 		};
 
 		calibration_art_1000: calibration@1000 {

--- a/target/linux/ath79/dts/ar9344_netgear_pgzng1.dts
+++ b/target/linux/ath79/dts/ar9344_netgear_pgzng1.dts
@@ -289,20 +289,22 @@
 			reg = <0xffe0000 0x20000>;
 			read-only;
 
-			compatible = "nvmem-cells";
-			#address-cells = <1>;
-			#size-cells = <1>;
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
 
-			macaddr_caldata_0: macaddr@0 {
-				reg = <0x0 0x6>;
-			};
+				macaddr_caldata_0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
 
-			macaddr_caldata_6: macaddr@6 {
-				reg = <0x6 0x6>;
-			};
+				macaddr_caldata_6: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
 
-			cal_caldata_1000: cal@1000 {
-				reg = <0x1000 0x440>;
+				cal_caldata_1000: cal@1000 {
+					reg = <0x1000 0x440>;
+				};
 			};
 		};
 	};

--- a/target/linux/ath79/dts/ar9344_netgear_r6100.dts
+++ b/target/linux/ath79/dts/ar9344_netgear_r6100.dts
@@ -130,6 +130,32 @@
 			label = "caldata";
 			reg = <0x0020000 0x0040000>;
 			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				cal_ath9k: calibration@1000 {
+					reg = <0x1000 0x440>;
+				};
+
+				cal_ath10k: calibration@5000 {
+					reg = <0x5000 0x844>;
+				};
+
+				macaddr_caldata_0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_caldata_6: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
+
+				macaddr_caldata_c: macaddr@c {
+					reg = <0xc 0x6>;
+				};
+			};
 		};
 
 		partition@60000 {
@@ -203,30 +229,4 @@
 
 	nvmem-cells = <&cal_ath9k>;
 	nvmem-cell-names = "calibration";
-};
-
-&caldata {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	cal_ath9k: calibration@1000 {
-		reg = <0x1000 0x440>;
-	};
-
-	cal_ath10k: calibration@5000 {
-		reg = <0x5000 0x844>;
-	};
-
-	macaddr_caldata_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_caldata_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
-
-	macaddr_caldata_c: macaddr@c {
-		reg = <0xc 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9344_netgear_wndr.dtsi
+++ b/target/linux/ath79/dts/ar9344_netgear_wndr.dtsi
@@ -127,6 +127,28 @@
 			label = "caldata";
 			reg = <0x80000 0x40000>;
 			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_caldata_0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_caldata_c: macaddr@c {
+					reg = <0xc 0x6>;
+				};
+
+				cal_art_1000: cal@1000 {
+					reg = <0x1000 0x440>;
+				};
+
+				cal_art_5000: cal@5000 {
+					reg = <0x5000 0x440>;
+				};
+			};
 		};
 
 		partition@c0000 {
@@ -257,27 +279,5 @@
 		nvmem-cell-names = "mac-address", "calibration";
 		#gpio-cells = <2>;
 		gpio-controller;
-	};
-};
-
-&caldata {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_caldata_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_caldata_c: macaddr@c {
-		reg = <0xc 0x6>;
-	};
-
-	cal_art_1000: cal@1000 {
-		reg = <0x1000 0x440>;
-	};
-
-	cal_art_5000: cal@5000 {
-		reg = <0x5000 0x440>;
 	};
 };

--- a/target/linux/ath79/dts/ar9344_ocedo_raccoon.dts
+++ b/target/linux/ath79/dts/ar9344_ocedo_raccoon.dts
@@ -114,28 +114,30 @@
 				reg = <0xff0000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_art_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 
-				macaddr_art_6: macaddr@6 {
-					reg = <0x6 0x6>;
-				};
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
 
-				macaddr_art_c: macaddr@c {
-					reg = <0xc 0x6>;
-				};
+					macaddr_art_c: macaddr@c {
+						reg = <0xc 0x6>;
+					};
 
-				calibration_art_1000: calibration@1000 {
-					reg = <0x1000 0x440>;
-				};
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
 
-				calibration_art_5000: calibration@5000 {
-					reg = <0x5000 0x440>;
+					calibration_art_5000: calibration@5000 {
+						reg = <0x5000 0x440>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/ar9344_openmesh_mr600.dtsi
+++ b/target/linux/ath79/dts/ar9344_openmesh_mr600.dtsi
@@ -75,20 +75,22 @@
 				reg = <0xff0000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_art_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 
-				calibration_art_1000: calibration@1000 {
-					reg = <0x1000 0x440>;
-				};
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
 
-				calibration_art_5000: calibration@5000 {
-					reg = <0x5000 0x440>;
+					calibration_art_5000: calibration@5000 {
+						reg = <0x5000 0x440>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/ar9344_openmesh_mr600.dtsi
+++ b/target/linux/ath79/dts/ar9344_openmesh_mr600.dtsi
@@ -81,7 +81,9 @@
 					#size-cells = <1>;
 
 					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
 						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 
 					calibration_art_1000: calibration@1000 {
@@ -112,7 +114,7 @@
 
 	pll-data = <0x02000000 0x00000101 0x00001313>;
 
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 
 	phy-mode = "rgmii-id";
@@ -129,9 +131,8 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_0>, <&calibration_art_1000>;
+	nvmem-cells = <&macaddr_art_0 1>, <&calibration_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
-	mac-address-increment = <1>;
 };
 
 &pcie {
@@ -140,9 +141,8 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0>, <&calibration_art_5000>;
+		nvmem-cells = <&macaddr_art_0 8>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		mac-address-increment = <8>;
 
 		gpio-controller;
 		#gpio-cells = <2>;

--- a/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts
+++ b/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts
@@ -159,7 +159,9 @@
 					#size-cells = <1>;
 
 					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
 						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 
 					calibration_art_1000: calibration@1000 {
@@ -190,7 +192,7 @@
 
 	pll-data = <0x02000000 0x00000101 0x00001313>;
 
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 
 	phy-mode = "rgmii-id";
@@ -208,17 +210,15 @@
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_0>, <&calibration_art_1000>;
+	nvmem-cells = <&macaddr_art_0 2>, <&calibration_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
-	mac-address-increment = <2>;
 };
 
 &pcie {
@@ -227,8 +227,7 @@
 	wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0>, <&calibration_art_5000>;
+		nvmem-cells = <&macaddr_art_0 16>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		mac-address-increment = <16>;
 	};
 };

--- a/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts
+++ b/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts
@@ -153,20 +153,22 @@
 				reg = <0xff0000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_art_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 
-				calibration_art_1000: calibration@1000 {
-					reg = <0x1000 0x440>;
-				};
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
 
-				calibration_art_5000: calibration@5000 {
-					reg = <0x5000 0x440>;
+					calibration_art_5000: calibration@5000 {
+						reg = <0x5000 0x440>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/ar9344_openmesh_om5p.dts
+++ b/target/linux/ath79/dts/ar9344_openmesh_om5p.dts
@@ -135,6 +135,20 @@
 				label = "ART";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -160,18 +174,4 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9344_pcs_cap324.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cap324.dts
@@ -114,7 +114,9 @@
 					#size-cells = <1>;
 
 					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
 						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -128,9 +130,8 @@
 	ath9k: wifi@0,0 {
 		compatible = "168c,0030";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0>;
+		nvmem-cells = <&macaddr_art_0 (-2)>;
 		nvmem-cell-names = "mac-address";
-		mac-address-increment = <(-2)>;
 		mtd-cal-data = <&art 0x5000>;
 		qca,no-eeprom;
 		ieee80211-freq-limit = <2402000 2482000>;
@@ -144,9 +145,8 @@
 
 	ieee80211-freq-limit = <4900000 5990000>;
 	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 (-1)>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-1)>;
 };
 
 &mdio0 {
@@ -164,7 +164,7 @@
 	/* default for ar934x, except for 1000M */
 	pll-data = <0x06000000 0x00000101 0x00001616>;
 
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 
 	phy-mode = "rgmii";

--- a/target/linux/ath79/dts/ar9344_pcs_cap324.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cap324.dts
@@ -107,6 +107,16 @@
 				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -159,14 +169,4 @@
 
 	phy-mode = "rgmii";
 	phy-handle = <&phy0>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9344_pcs_cr5000.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cr5000.dts
@@ -99,6 +99,20 @@
 				label = "art";
 				reg = <0x7f0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_5002: macaddr@5002 {
+						reg = <0x5002 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -201,18 +215,4 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_5002: macaddr@5002 {
-		reg = <0x5002 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-16m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-16m.dts
@@ -49,13 +49,3 @@
 		reg = <0x070000 0xf90000>;
 	};
 };
-
-&pridata {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_pridata_400: macaddr@400 {
-		reg = <0x400 0x6>;
-	};
-};

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-16m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-16m.dts
@@ -24,15 +24,14 @@
 
 	phy-handle = <&swphy4>;
 
-	nvmem-cells = <&macaddr_pridata_400>;
+	nvmem-cells = <&macaddr_pridata_400 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_pridata_400>;
+	nvmem-cells = <&macaddr_pridata_400 0>;
 	nvmem-cell-names = "mac-address";
 
 	gmac-config {

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-8m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-8m.dts
@@ -24,15 +24,14 @@
 
 	phy-handle = <&swphy4>;
 
-	nvmem-cells = <&macaddr_pridata_400>;
+	nvmem-cells = <&macaddr_pridata_400 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_pridata_400>;
+	nvmem-cells = <&macaddr_pridata_400 0>;
 	nvmem-cell-names = "mac-address";
 
 	gmac-config {

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-8m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-8m.dts
@@ -49,13 +49,3 @@
 		reg = <0x070000 0x790000>;
 	};
 };
-
-&pridata {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_pridata_400: macaddr@400 {
-		reg = <0x400 0x6>;
-	};
-};

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750g-v8-16m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750g-v8-16m.dts
@@ -31,7 +31,7 @@
 
 	pll-data = <0x06000000 0x00000101 0x00001616>;
 
-	nvmem-cells = <&macaddr_pridata_400>;
+	nvmem-cells = <&macaddr_pridata_400 0>;
 	nvmem-cell-names = "mac-address";
 
 	phy-mode = "rgmii";

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750g-v8-16m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750g-v8-16m.dts
@@ -45,13 +45,3 @@
 		reg = <0x070000 0xf90000>;
 	};
 };
-
-&pridata {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_pridata_400: macaddr@400 {
-		reg = <0x400 0x6>;
-	};
-};

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750g-v8-8m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750g-v8-8m.dts
@@ -45,13 +45,3 @@
 		reg = <0x070000 0x790000>;
 	};
 };
-
-&pridata {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_pridata_400: macaddr@400 {
-		reg = <0x400 0x6>;
-	};
-};

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750g-v8-8m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750g-v8-8m.dts
@@ -31,7 +31,7 @@
 
 	pll-data = <0x06000000 0x00000101 0x00001616>;
 
-	nvmem-cells = <&macaddr_pridata_400>;
+	nvmem-cells = <&macaddr_pridata_400 0>;
 	nvmem-cell-names = "mac-address";
 
 	phy-mode = "rgmii";

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750x.dtsi
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750x.dtsi
@@ -85,6 +85,16 @@
 				label = "pri-data";
 				reg = <0x050000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_pridata_400: macaddr@400 {
+						reg = <0x400 0x6>;
+					};
+				};
 			};
 
 			art: partition@60000 {

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750x.dtsi
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750x.dtsi
@@ -92,7 +92,9 @@
 					#size-cells = <1>;
 
 					macaddr_pridata_400: macaddr@400 {
+						compatible = "mac-base";
 						reg = <0x400 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};

--- a/target/linux/ath79/dts/ar9344_ruckus_zf7372.dts
+++ b/target/linux/ath79/dts/ar9344_ruckus_zf7372.dts
@@ -127,11 +127,29 @@
 };
 
 &board_data {
-	macaddr_board_data_6c: macaddr@6c {
-		reg = <0x6c 0x6>;
-	};
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	macaddr_board_data_76: macaddr@76 {
-		reg = <0x76 0x6>;
+		macaddr_board_data_60: macaddr@60 {
+			reg = <0x60 0x6>;
+		};
+
+		macaddr_board_data_66: macaddr@66 {
+			reg = <0x66 0x6>;
+		};
+
+		macaddr_board_data_6c: macaddr@6c {
+			reg = <0x6c 0x6>;
+		};
+
+		macaddr_board_data_76: macaddr@76 {
+			reg = <0x76 0x6>;
+		};
+
+		cal_board_data_41000: cal@41000 {
+			reg = <0x41000 0x440>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar9344_samsung_wam250.dts
+++ b/target/linux/ath79/dts/ar9344_samsung_wam250.dts
@@ -66,9 +66,8 @@
 
 	phy-handle = <&swphy0>;
 
-	nvmem-cells = <&macaddr_art_1002>;
+	nvmem-cells = <&macaddr_art_1002 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 
 	gmac-config {
 		device = <&gmac>;
@@ -79,7 +78,7 @@
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_1002>;
+	nvmem-cells = <&macaddr_art_1002 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -144,7 +143,9 @@
 					#size-cells = <1>;
 
 					macaddr_art_1002: macaddr@1002 {
+						compatible = "mac-base";
 						reg = <0x1002 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};

--- a/target/linux/ath79/dts/ar9344_samsung_wam250.dts
+++ b/target/linux/ath79/dts/ar9344_samsung_wam250.dts
@@ -137,6 +137,16 @@
 				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -155,14 +165,4 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_1002: macaddr@1002 {
-		reg = <0x1002 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9344_teltonika_rut955-h7v3c0.dts
+++ b/target/linux/ath79/dts/ar9344_teltonika_rut955-h7v3c0.dts
@@ -164,15 +164,14 @@
 
 	phy-handle = <&swphy4>;
 
-	nvmem-cells = <&macaddr_config_0>;
+	nvmem-cells = <&macaddr_config_0 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_config_0>;
+	nvmem-cells = <&macaddr_config_0 0>;
 	nvmem-cell-names = "mac-address";
 };
 

--- a/target/linux/ath79/dts/ar9344_teltonika_rut955.dts
+++ b/target/linux/ath79/dts/ar9344_teltonika_rut955.dts
@@ -163,15 +163,14 @@
 
 	phy-handle = <&swphy4>;
 
-	nvmem-cells = <&macaddr_config_0>;
+	nvmem-cells = <&macaddr_config_0 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_config_0>;
+	nvmem-cells = <&macaddr_config_0 0>;
 	nvmem-cell-names = "mac-address";
 };
 

--- a/target/linux/ath79/dts/ar9344_teltonika_rut9xx.dtsi
+++ b/target/linux/ath79/dts/ar9344_teltonika_rut9xx.dtsi
@@ -79,6 +79,16 @@
 				label = "config";
 				reg = <0x20000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
 			};
 
 			art: partition@30000 {
@@ -167,15 +177,5 @@
 		pinctrl-single,bits =	<0x00 0x00000000 0x000000ff>,
 					<0x10 0x004f0000 0x00ff0000>,
 					<0x3c 0x000b0000 0x00ff0000>;
-	};
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_0: macaddr@0 {
-		reg = <0x0 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar9344_teltonika_rut9xx.dtsi
+++ b/target/linux/ath79/dts/ar9344_teltonika_rut9xx.dtsi
@@ -86,7 +86,9 @@
 					#size-cells = <1>;
 
 					macaddr_config_0: macaddr@0 {
+						compatible = "mac-base";
 						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -154,9 +156,8 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_config_0>;
+	nvmem-cells = <&macaddr_config_0 2>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <2>;
 };
 
 &pinmux {

--- a/target/linux/ath79/dts/ar9344_tplink_cpe.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe.dtsi
@@ -55,6 +55,16 @@
 				label = "info";
 				reg = <0x030000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_info_8: macaddr@8 {
+						reg = <0x8 0x6>;
+					};
+				};
 			};
 
 			partition@40000 {
@@ -114,15 +124,5 @@
 		gpios = <19 GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "tp-link:ext:lna1";
-	};
-};
-
-&info {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_info_8: macaddr@8 {
-		reg = <0x8 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr3500-v1.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr3500-v1.dts
@@ -49,16 +49,30 @@
 	status = "okay";
 };
 
-&ath9k {
-	mac-address-increment = <1>;
+&wmac {
+	status = "okay";
+	nvmem-cells = <&macaddr_uboot_1fc00 0>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,0033";
+		reg = <0x0000 0 0 0 0>;
+		#gpio-cells = <2>;
+		gpio-controller;
+		nvmem-cells = <&macaddr_uboot_1fc00 1>, <&cal_art_5000>;
+		nvmem-cell-names = "mac-address", "calibration";
+	};
 };
 
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 (-1)>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-1)>;
 
 	gmac-config {
 		device = <&gmac>;
@@ -72,7 +86,6 @@
 
 	phy-handle = <&swphy4>;
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 2>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <2>;
 };

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
@@ -76,7 +76,22 @@
 };
 
 &wmac {
-	mac-address-increment = <(-1)>;
+	status = "okay";
+	nvmem-cells = <&macaddr_uboot_1fc00 (-1)>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,0033";
+		reg = <0x0000 0 0 0 0>;
+		#gpio-cells = <2>;
+		gpio-controller;
+		nvmem-cells = <&macaddr_uboot_1fc00 0>, <&cal_art_5000>;
+		nvmem-cell-names = "mac-address", "calibration";
+	};
 };
 
 &mdio0 {
@@ -104,7 +119,7 @@
 	/* default for ar934x, except for 1000M */
 	pll-data = <0x06000000 0x00000101 0x00001616>;
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 
 	phy-mode = "rgmii";

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
@@ -90,7 +90,9 @@
 					#size-cells = <1>;
 
 					macaddr_uboot_1fc00: macaddr@1fc00 {
+						compatible = "mac-base";
 						reg = <0x1fc00 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -122,23 +124,4 @@
 			};
 		};
 	};
-};
-
-&pcie {
-	status = "okay";
-
-	ath9k: wifi@0,0 {
-		compatible = "pci168c,0033";
-		reg = <0x0000 0 0 0 0>;
-		#gpio-cells = <2>;
-		gpio-controller;
-		nvmem-cells = <&macaddr_uboot_1fc00>, <&cal_art_5000>;
-		nvmem-cell-names = "mac-address", "calibration";
-	};
-};
-
-&wmac {
-	status = "okay";
-	nvmem-cells = <&macaddr_uboot_1fc00>, <&cal_art_1000>;
-	nvmem-cell-names = "mac-address", "calibration";
 };

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
@@ -83,6 +83,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -95,6 +105,20 @@
 				label = "art";
 				reg = <0x7f0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_art_1000: cal@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+					cal_art_5000: cal@5000 {
+						reg = <0x5000 0x440>;
+					};
+				};
 			};
 		};
 	};
@@ -117,28 +141,4 @@
 	status = "okay";
 	nvmem-cells = <&macaddr_uboot_1fc00>, <&cal_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	cal_art_1000: cal@1000 {
-		reg = <0x1000 0x440>;
-	};
-
-	cal_art_5000: cal@5000 {
-		reg = <0x5000 0x440>;
-	};
 };

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wr841hp-v2.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wr841hp-v2.dts
@@ -95,6 +95,16 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						reg = <0x1fc00 0x6>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -156,15 +166,5 @@
 	gmac-config {
 		device = <&gmac>;
 		switch-phy-swap = <1>;
-	};
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wr841hp-v2.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wr841hp-v2.dts
@@ -102,7 +102,9 @@
 					#size-cells = <1>;
 
 					macaddr_uboot_1fc00: macaddr@1fc00 {
+						compatible = "mac-base";
 						reg = <0x1fc00 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -143,7 +145,7 @@
 
 	mtd-cal-data = <&art 0x1000>;
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -152,15 +154,14 @@
 
 	phy-handle = <&swphy0>;
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 
 	gmac-config {

--- a/target/linux/ath79/dts/ar9344_ubnt_unifi-ap-pro.dts
+++ b/target/linux/ath79/dts/ar9344_ubnt_unifi-ap-pro.dts
@@ -105,20 +105,22 @@
 				reg = <0xff0000 0x10000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_art_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 
-				calibration_art_1000: calibration@1000 {
-					reg = <0x1000 0x440>;
-				};
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
 
-				calibration_art_5000: calibration@5000 {
-					reg = <0x5000 0x440>;
+					calibration_art_5000: calibration@5000 {
+						reg = <0x5000 0x440>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/ar9344_watchguard_ap100.dts
+++ b/target/linux/ath79/dts/ar9344_watchguard_ap100.dts
@@ -56,9 +56,8 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 (-2)>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-2)>;
 };
 
 &pcie {
@@ -73,9 +72,8 @@
 &wmac {
 	/delete-property/ ieee80211-freq-limit;
 
-	nvmem-cells = <&macaddr_art_0>, <&calibration_art_1000>;
+	nvmem-cells = <&macaddr_art_0 (-2)>, <&calibration_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
-	mac-address-increment = <(-2)>;
 };
 
 &art {
@@ -85,7 +83,9 @@
 		#size-cells = <1>;
 
 		macaddr_art_0: macaddr@0 {
+			compatible = "mac-base";
 			reg = <0x0 0x6>;
+			#nvmem-cell-cells = <1>;
 		};
 
 		calibration_art_1000: calibration@1000 {

--- a/target/linux/ath79/dts/ar9344_watchguard_ap100.dts
+++ b/target/linux/ath79/dts/ar9344_watchguard_ap100.dts
@@ -79,19 +79,21 @@
 };
 
 &art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
+		macaddr_art_0: macaddr@0 {
+			reg = <0x0 0x6>;
+		};
 
-	calibration_art_1000: calibration@1000 {
-		reg = <0x1000 0x440>;
-	};
+		calibration_art_1000: calibration@1000 {
+			reg = <0x1000 0x440>;
+		};
 
-	calibration_art_5000: calibration@5000 {
-		reg = <0x5000 0x440>;
+		calibration_art_5000: calibration@5000 {
+			reg = <0x5000 0x440>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar9344_watchguard_ap200.dts
+++ b/target/linux/ath79/dts/ar9344_watchguard_ap200.dts
@@ -56,23 +56,20 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 (-2)>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-2)>;
 };
 
 &pcie {
 	wifi@0,0,0 {
-		nvmem-cells = <&macaddr_art_0>, <&calibration_art_5000>;
+		nvmem-cells = <&macaddr_art_0 (-1)>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		mac-address-increment = <(-1)>;
 	};
 };
 
 &wmac {
-	nvmem-cells = <&macaddr_art_0>, <&calibration_art_1000>;
+	nvmem-cells = <&macaddr_art_0 (-2)>, <&calibration_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
-	mac-address-increment = <(-2)>;
 };
 
 &art {
@@ -82,7 +79,9 @@
 		#size-cells = <1>;
 
 		macaddr_art_0: macaddr@0 {
+			compatible = "mac-base";
 			reg = <0x0 0x6>;
+			#nvmem-cell-cells = <1>;
 		};
 
 		calibration_art_1000: calibration@1000 {

--- a/target/linux/ath79/dts/ar9344_watchguard_ap200.dts
+++ b/target/linux/ath79/dts/ar9344_watchguard_ap200.dts
@@ -76,19 +76,21 @@
 };
 
 &art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
+		macaddr_art_0: macaddr@0 {
+			reg = <0x0 0x6>;
+		};
 
-	calibration_art_1000: calibration@1000 {
-		reg = <0x1000 0x440>;
-	};
+		calibration_art_1000: calibration@1000 {
+			reg = <0x1000 0x440>;
+		};
 
-	calibration_art_5000: calibration@5000 {
-		reg = <0x5000 0x440>;
+		calibration_art_5000: calibration@5000 {
+			reg = <0x5000 0x440>;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar9344_winchannel_wb2000.dts
+++ b/target/linux/ath79/dts/ar9344_winchannel_wb2000.dts
@@ -124,16 +124,18 @@
 				reg = <0xfe0000 0x10000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				calibration_art_1000: calibration@1000 {
-					reg = <0x1000 0x440>;
-				};
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
 
-				calibration_art_5000: calibration@5000 {
-					reg = <0x5000 0x440>;
+					calibration_art_5000: calibration@5000 {
+						reg = <0x5000 0x440>;
+					};
 				};
 			};
 
@@ -142,12 +144,14 @@
 				reg = <0xff0000 0x10000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_addr_0: macaddr@0 {
-					reg = <0x0 0x6>;
+					macaddr_addr_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/ar9344_winchannel_wb2000.dts
+++ b/target/linux/ath79/dts/ar9344_winchannel_wb2000.dts
@@ -150,7 +150,9 @@
 					#size-cells = <1>;
 
 					macaddr_addr_0: macaddr@0 {
+						compatible = "mac-base";
 						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -164,9 +166,8 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_addr_0>, <&calibration_art_5000>;
+		nvmem-cells = <&macaddr_addr_0 0x10>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		mac-address-increment = <0x10>;
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -183,7 +184,7 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_addr_0>, <&calibration_art_1000>;
+	nvmem-cells = <&macaddr_addr_0 0>, <&calibration_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
 };
 
@@ -200,9 +201,8 @@
 
 	pll-data = <0xe000000 0x04000101 0x04001313>;
 
-	nvmem-cells = <&macaddr_addr_0>;
+	nvmem-cells = <&macaddr_addr_0 0x21>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <0x21>;
 
 	phy-mode = "rgmii-rxid";
 	phy-handle = <&phy4>;

--- a/target/linux/ath79/dts/ar9344_zbtlink_zbt-wd323.dts
+++ b/target/linux/ath79/dts/ar9344_zbtlink_zbt-wd323.dts
@@ -133,6 +133,20 @@
 			art: art@ff0000 {
 				reg = <0xff0000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
 			};
 		};
 	};
@@ -158,19 +172,5 @@
 
 	enable_gpio21: pinmux_enable_gpio21 {
 		pinctrl-single,bits = <0x14 0x0 0xff00>;
-	};
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar934x_ruckus_zf73xx.dtsi
+++ b/target/linux/ath79/dts/ar934x_ruckus_zf73xx.dtsi
@@ -178,21 +178,3 @@
 &usb_phy {
 	status = "okay";
 };
-
-&board_data {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_board_data_60: macaddr@60 {
-		reg = <0x60 0x6>;
-	};
-
-	macaddr_board_data_66: macaddr@66 {
-		reg = <0x66 0x6>;
-	};
-
-	cal_board_data_41000: cal@41000 {
-		reg = <0x41000 0x440>;
-	};
-};

--- a/target/linux/ath79/dts/qca9563_dlink_covr-p2500-a1.dts
+++ b/target/linux/ath79/dts/qca9563_dlink_covr-p2500-a1.dts
@@ -133,8 +133,6 @@
 				reg = <0xff0000 0x10000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;

--- a/target/linux/ath79/dts/qcn5502_asus.dtsi
+++ b/target/linux/ath79/dts/qcn5502_asus.dtsi
@@ -85,20 +85,22 @@
 				reg = <0x050000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				cal_factory_1000: cal@1000 {
-					reg = <0x1000 0x440>;
-				};
+					cal_factory_1000: cal@1000 {
+						reg = <0x1000 0x440>;
+					};
 
-				macaddr_factory_1002: macaddr@1002 {
-					reg = <0x1002 0x6>;
-				};
+					macaddr_factory_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
 
-				precal_factory_5000: precal@5000 {
-					reg = <0x5000 0x2f20>;
+					precal_factory_5000: precal@5000 {
+						reg = <0x5000 0x2f20>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/qcn5502_netgear_ex7300-v2.dts
+++ b/target/linux/ath79/dts/qcn5502_netgear_ex7300-v2.dts
@@ -182,20 +182,22 @@
 				label = "artmtd";
 				reg = <0xfe0000 0x10000>;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_artmtd_0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
+					macaddr_artmtd_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 
-				macaddr_artmtd_6: macaddr@6 {
-					reg = <0x6 0x6>;
-				};
+					macaddr_artmtd_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
 
-				macaddr_artmtd_c: macaddr@c {
-					reg = <0xc 0x6>;
+					macaddr_artmtd_c: macaddr@c {
+						reg = <0xc 0x6>;
+					};
 				};
 			};
 
@@ -204,16 +206,18 @@
 				reg = <0xff0000 0x10000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				cal_art_1000: cal@1000 {
-					reg = <0x1000 0x440>;
-				};
+					cal_art_1000: cal@1000 {
+						reg = <0x1000 0x440>;
+					};
 
-				precal_art_5000: precal@5000 {
-					reg = <0x5000 0x2f20>;
+					precal_art_5000: precal@5000 {
+						reg = <0x5000 0x2f20>;
+					};
 				};
 			};
 		};

--- a/target/linux/ath79/dts/qcn5502_tplink_archer-a9-v6.dts
+++ b/target/linux/ath79/dts/qcn5502_tplink_archer-a9-v6.dts
@@ -88,7 +88,7 @@
 	phy-mode = "sgmii";
 	phy-handle = <&phy0>;
 
-	nvmem-cells = <&macaddr_info_8>;
+	nvmem-cells = <&macaddr_info_8 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -118,10 +118,8 @@
 		compatible = "pci168c,0046";
 		reg = <0 0 0 0 0>;
 
-		nvmem-cells = <&macaddr_info_8>, <&precal_art_5000>;
+		nvmem-cells = <&macaddr_info_8 (-1)>, <&precal_art_5000>;
 		nvmem-cell-names = "mac-address", "pre-calibration";
-
-		mac-address-increment = <(-1)>;
 	};
 };
 
@@ -162,16 +160,18 @@
 				reg = <0x050000 0x010000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				cal_art_1000: cal@1000 {
-					reg = <0x1000 0x440>;
-				};
+					cal_art_1000: cal@1000 {
+						reg = <0x1000 0x440>;
+					};
 
-				precal_art_5000: precal@5000 {
-					reg = <0x5000 0x2f20>;
+					precal_art_5000: precal@5000 {
+						reg = <0x5000 0x2f20>;
+					};
 				};
 			};
 
@@ -180,12 +180,16 @@
 				reg = <0x060000 0x020000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_info_8: macaddr@8 {
-					reg = <0x8 0x6>;
+					macaddr_info_8: macaddr@8 {
+						compatible = "mac-base";
+						reg = <0x8 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
 				};
 			};
 
@@ -234,6 +238,6 @@
 	/* TODO: missing support in ath9k */
 	status = "disabled";
 
-	nvmem-cells = <&cal_art_1000>, <&macaddr_info_8>;
+	nvmem-cells = <&cal_art_1000>, <&macaddr_info_8 0>;
 	nvmem-cell-names = "calibration", "mac-address";
 };

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v3.dtsi
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v3.dtsi
@@ -63,7 +63,6 @@
 };
 
 &eth1 {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 (-1)>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <(-1)>;
 };

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v4.dts
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v4.dts
@@ -66,6 +66,6 @@
 };
 
 &eth1 {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v6.dts
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v6.dts
@@ -30,6 +30,6 @@
 };
 
 &eth1 {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr941hp-v1.dts
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr941hp-v1.dts
@@ -120,6 +120,18 @@
 				label = "config";
 				reg = <0x750000 0x0a0000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_8: macaddr@8 {
+						compatible = "mac-base";
+						reg = <0x8 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			art: partition@7f0000 {
@@ -136,15 +148,14 @@
 
 	phy-handle = <&swphy0>;
 
-	nvmem-cells = <&macaddr_config_8>;
+	nvmem-cells = <&macaddr_config_8 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_config_8>;
+	nvmem-cells = <&macaddr_config_8 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -152,16 +163,6 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_config_8>;
+	nvmem-cells = <&macaddr_config_8 0>;
 	nvmem-cell-names = "mac-address";
-};
-
-&config {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_config_8: macaddr@8 {
-		reg = <0x8 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wx.dtsi
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wx.dtsi
@@ -28,6 +28,18 @@
 				label = "u-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc00: macaddr@1fc00 {
+						compatible = "mac-base";
+						reg = <0x1fc00 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			partition@20000 {
@@ -50,9 +62,8 @@
 
 	phy-handle = <&swphy4>;
 
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &eth1 {
@@ -63,16 +74,6 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
-};
-
-&uboot {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_uboot_1fc00: macaddr@1fc00 {
-		reg = <0x1fc00 0x6>;
-	};
 };


### PR DESCRIPTION
ping @rmilecki @Ansuel 

After this PR and https://github.com/openwrt/openwrt/pull/13997 , mac-address-increment is no longer used and patch can be removed.