### PR TITLE
gettext-full: Fix link error with host's libacl

### DIFF
--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -25,6 +25,8 @@ PKG_INSTALL:=1
 PKG_BUILD_DEPENDS:=gettext-full/host libunistring libxml2
 PKG_BUILD_PARALLEL:=0
 
+PKG_FIXUP:=autoreconf
+
 HOST_BUILD_DEPENDS:=gperf/host libunistring/host libxml2/host
 HOST_BUILD_PARALLEL:=0
 


### PR DESCRIPTION
Hi, on my host system i get a link error when trying to build ` libintl-full `package.
OpenWrt tries to use my host library path `/usr/lib`. This commit fixes the problem.

Host system: `Void Linux`
Target: `ipq806x Netgear r7800`

Error message:
```
/usr/lib/libacl.so: file not recognized: file format not recognized
collect2: error: ld returned 1 exit status
libtool:   error: error: relink 'libgettextlib.la' with the above command before installing it
```
