### PR TITLE
[mvebu] fix mixed ethernet port order and naming for Puzzle  M902

### DIFF
--- a/target/linux/mvebu/cortexa72/base-files/etc/board.d/01_leds
+++ b/target/linux/mvebu/cortexa72/base-files/etc/board.d/01_leds
@@ -11,7 +11,7 @@ iei,puzzle-m901)
 	ucidef_set_led_netdev "wan" "WAN" "white:network" "eth0" "link"
 	;;
 iei,puzzle-m902)
-	ucidef_set_led_netdev "wan" "WAN" "white:network" "eth2" "link"
+	ucidef_set_led_netdev "wan" "WAN" "white:network" "lan1_2G" "link"
 	;;
 mikrotik,rb5009)
 	ucidef_set_led_netdev "sfp" "SFP" "green:sfp" "sfp"

--- a/target/linux/mvebu/cortexa72/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/cortexa72/base-files/etc/board.d/02_network
@@ -23,7 +23,7 @@ iei,puzzle-m901)
 	ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4 eth5" "eth0"
 	;;
 iei,puzzle-m902)
-	ucidef_set_interfaces_lan_wan "eth0 eth1 eth3 eth4 eth5 eth6 eth7 eth8" "eth2"
+	ucidef_set_interfaces_lan_wan "lan2_2G lan3_2G lan4_2G lan5_2G lan6_2G lan1_10G lan2_10G lan3_10G" "lan1_2G"
 	;;
 marvell,armada8040-mcbin-doubleshot|\
 marvell,armada8040-mcbin-singleshot)

--- a/target/linux/mvebu/cortexa72/base-files/etc/board.d/05_compat-version
+++ b/target/linux/mvebu/cortexa72/base-files/etc/board.d/05_compat-version
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+. /lib/functions.sh
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+board=$(board_name)
+
+case "$board" in
+iei,puzzle-m902)
+	ucidef_set_compat_version "1.1"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/mvebu/cortexa72/base-files/lib/preinit/04_set_netdev_label
+++ b/target/linux/mvebu/cortexa72/base-files/lib/preinit/04_set_netdev_label
@@ -1,0 +1,15 @@
+set_netdev_labels() {
+	local dir
+	local label
+	local netdev
+
+	for dir in /sys/class/net/*; do
+		[ -r "$dir/of_node/openwrt,netdev-name" ] || continue
+		read -r label < "$dir/of_node/openwrt,netdev-name"
+		netdev="${dir##*/}"
+		[ "$netdev" = "$label" ] && continue
+		ip link set "$netdev" name "$label"
+	done
+}
+
+boot_hook_add preinit_main set_netdev_labels

--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9132-puzzle-m902.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9132-puzzle-m902.dts
@@ -264,6 +264,7 @@
 	phy-mode = "10gbase-kr";
 	phys = <&cp0_comphy2 0>;
 	phy = <&cp0_nbaset_phy0>;
+	openwrt,netdev-name = "lan1_10G";
 };
 
 &cp0_eth1 {
@@ -271,6 +272,7 @@
 	phy-mode = "2500base-x";
 	phys = <&cp0_comphy4 1>;
 	phy = <&cp0_nbaset_phy1>;
+	openwrt,netdev-name = "lan2_2G";
 };
 
 &cp0_eth2 {
@@ -278,6 +280,7 @@
 	phy-mode = "2500base-x";
 	phys = <&cp0_comphy1 2>;
 	phy = <&cp0_nbaset_phy2>;
+	openwrt,netdev-name = "lan1_2G";
 };
 
 &cp0_gpio1 {
@@ -454,6 +457,7 @@
 	phy-mode = "10gbase-kr";
 	phys = <&cp1_comphy2 0>;
 	phy = <&cp1_nbaset_phy0>;
+	openwrt,netdev-name = "lan2_10G";
 };
 
 &cp1_eth1 {
@@ -461,6 +465,7 @@
 	phy-mode = "2500base-x";
 	phys = <&cp1_comphy4 1>;
 	phy = <&cp1_nbaset_phy1>;
+	openwrt,netdev-name = "lan4_2G";
 };
 
 &cp1_eth2 {
@@ -468,6 +473,7 @@
 	phy-mode = "2500base-x";
 	phys = <&cp1_comphy1 2>;
 	phy = <&cp1_nbaset_phy2>;
+	openwrt,netdev-name = "lan3_2G";
 };
 
 &cp1_gpio1 {
@@ -562,6 +568,7 @@
 	phy-mode = "10gbase-kr";
 	phys = <&cp2_comphy2 0>;
 	phy = <&cp2_nbaset_phy0>;
+	openwrt,netdev-name = "lan3_10G";
 };
 
 &cp2_eth1 {
@@ -569,6 +576,7 @@
 	phy-mode = "2500base-x";
 	phys = <&cp2_comphy4 1>;
 	phy = <&cp2_nbaset_phy1>;
+	openwrt,netdev-name = "lan6_2G";
 };
 
 &cp2_eth2 {
@@ -576,6 +584,7 @@
 	phy-mode = "2500base-x";
 	phys = <&cp2_comphy1 2>;
 	phy = <&cp2_nbaset_phy2>;
+	openwrt,netdev-name = "lan5_2G";
 };
 
 &cp2_gpio1 {

--- a/target/linux/mvebu/image/cortexa72.mk
+++ b/target/linux/mvebu/image/cortexa72.mk
@@ -145,6 +145,10 @@ define Device/iei_puzzle-m902
   DEVICE_VENDOR := iEi
   DEVICE_MODEL := Puzzle-M902
   DEVICE_PACKAGES += kmod-rtc-ds1307
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := The Ethernet interface names were renamed \
+    to match the faceplate labels. Doing a sysupgrade while keeping \
+    the current config will break network settings.
 endef
 TARGET_DEVICES += iei_puzzle-m902
 


### PR DESCRIPTION
This patch introduces new ethernet port names and a new order of ports that is aligned with the actual face plate layout of the Puzzle M902.
The former ethernet port names eth0 to eth8 were not representing the face-plate port order nor the different port speeds, but where mixed-up.
The Puzzle M902 has its first 6 ports from the left side as 2.5GBit interfaces and the three right ports are 10G Base-T.
The new port naming scheme is implemented using dfs labels, that are used to trigger renaming OpenWrt interfaces after boot by those labels.
This port name scheme is aligned with the front pannel names of the Puzzle M902. From first (leftmost) port:
lan1_2G | lan2_2G | lan3_ 2G | lan4_2G | lan5_2G | lan6_2G | lan1_10G | lan2_10G | lan3_10G


Signed-off-by: Thomas Huehn <thomas.huehn@hs-nordhausen.de>