### PR TITLE
ipq806x: Stabilize LAN 2 MAC address, interface ordering

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -46,8 +46,7 @@ ipq806x_setup_interfaces()
 		ucidef_set_network_device_conduit "lan1" "eth1"
 		ucidef_set_network_device_conduit "wan" "eth0"
 		;;
-	edgecore,ecw5410 |\
-	extreme,ap3935)
+	edgecore,ecw5410)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
 	qcom,ipq8064-ap161)
@@ -63,6 +62,7 @@ ipq806x_setup_interfaces()
 	meraki,mr42)
 		ucidef_set_interface_lan "eth0"
 		;;
+	extreme,ap3935 |\
 	meraki,mr52)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		;;

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8068-ap3935.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8068-ap3935.dts
@@ -195,6 +195,7 @@
 					reg = <0x2a0000 0x0010000>;
 
 					ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
 					};
 				};
 
@@ -327,7 +328,7 @@
 	phy-mode = "rgmii";
 	phy-handle = <&phy1>;
 
-	nvmem-cells = <&ethaddr>;
+	nvmem-cells = <&ethaddr 0>;
 	nvmem-cell-names = "mac-address";
 
 	fixed-link {
@@ -344,6 +345,9 @@
 
 	phy-mode = "sgmii";
 	phy-handle = <&phy2>;
+
+	nvmem-cells = <&ethaddr 1>;
+	nvmem-cell-names = "mac-address";
 };
 
 &adm_dma {


### PR DESCRIPTION
Part 1 of #13629 split.

* Sets the LAN 2 MAC address in the DTS by deriving it from LAN 1's address. The factory OS derives this from the `eth1addr` u-boot env variable, but the nvmem_u-boot-env driver doesn't support parsing MAC addresses from fields other than `ethaddr`. But for all of the device samples I've checked (~10) it derives the correct MAC.

* Updates 02_network to ensure that interfaces are assigned to roles correctly and consistently.

With this patch, the interfaces enumerate consistently between boots and end up with the correct MAC addresses assigned.