### PR TITLE
target: Make TARGET_SERIAL independent of GRUB configuration

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -218,11 +218,6 @@ menu "Target Images"
 		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
 		default y
 
-	config GRUB_SERIAL
-		string "Serial port device"
-		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
-		default "ttyS0"
-
 	config GRUB_BAUDRATE
 		int "Serial port baud rate"
 		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
@@ -231,7 +226,8 @@ menu "Target Images"
 
 	config GRUB_FLOWCONTROL
 		bool "Use RTE/CTS on serial console"
-		depends on GRUB_SERIAL != ""
+		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
+		depends on TARGET_SERIAL != ""
 
 	config GRUB_BOOTOPTS
 		string "Extra kernel boot options"
@@ -276,6 +272,11 @@ menu "Target Images"
 		depends on TARGET_x86
 		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
 		select PACKAGE_kmod-e1000
+
+	config TARGET_SERIAL
+		string "Serial port device"
+		depends on TARGET_x86 || TARGET_armsr
+		default "ttyS0"
 
 	config TARGET_IMAGES_GZIP
 		bool "GZip images"

--- a/target/linux/armsr/base-files.mk
+++ b/target/linux/armsr/base-files.mk
@@ -1,6 +1,6 @@
-GRUB_SERIAL:=$(call qstrip,$(CONFIG_GRUB_SERIAL))
+GRUB_SERIAL:=$(call qstrip,$(CONFIG_TARGET_SERIAL))
 ifeq ($(GRUB_SERIAL),)
-$(error This platform requires CONFIG_GRUB_SERIAL be set!)
+$(error This platform requires CONFIG_TARGET_SERIAL be set!)
 endif
 
 define Package/base-files/install-target

--- a/target/linux/armsr/image/Makefile
+++ b/target/linux/armsr/image/Makefile
@@ -15,7 +15,7 @@ ifneq ($(CONFIG_GRUB_CONSOLE),)
   GRUB_TERMINALS += console
 endif
 
-GRUB_SERIAL:=$(call qstrip,$(CONFIG_GRUB_SERIAL))
+GRUB_SERIAL:=$(call qstrip,$(CONFIG_TARGET_SERIAL))
 
 GRUB_SERIAL_CONFIG := serial --unit=0 --speed=$(CONFIG_GRUB_BAUDRATE) --word=8 --parity=no --stop=1 --rtscts=$(if $(CONFIG_GRUB_FLOWCONTROL),on,off)
 GRUB_TERMINALS += serial

--- a/target/linux/x86/base-files.mk
+++ b/target/linux/x86/base-files.mk
@@ -1,6 +1,6 @@
-GRUB_SERIAL:=$(call qstrip,$(CONFIG_GRUB_SERIAL))
+GRUB_SERIAL:=$(call qstrip,$(CONFIG_TARGET_SERIAL))
 ifeq ($(GRUB_SERIAL),)
-$(error This platform requires CONFIG_GRUB_SERIAL be set!)
+$(error This platform requires CONFIG_TARGET_SERIAL be set!)
 endif
 
 define Package/base-files/install-target

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -16,7 +16,7 @@ ifneq ($(CONFIG_GRUB_CONSOLE),)
   GRUB_TERMINALS += console
 endif
 
-GRUB_SERIAL:=$(call qstrip,$(CONFIG_GRUB_SERIAL))
+GRUB_SERIAL:=$(call qstrip,$(CONFIG_TARGET_SERIAL))
 
 GRUB_CONSOLE_CMDLINE += console=$(GRUB_SERIAL),$(CONFIG_GRUB_BAUDRATE)n8$(if $(CONFIG_GRUB_FLOWCONTROL),r,)
 GRUB_SERIAL_CONFIG := serial --unit=0 --speed=$(CONFIG_GRUB_BAUDRATE) --word=8 --parity=no --stop=1 --rtscts=$(if $(CONFIG_GRUB_FLOWCONTROL),on,off)


### PR DESCRIPTION
GRUB_SERIAL is also used for the default serial on the target and not only in grub. When no grub was build it was not available and the build fails.

Rename GRUB_SERIAL to TARGET_SERIAL and make it always available on x86 and armsr targets.

Fixes: #14063
Fixes: b10768476f9d ("x86,armsr: interpolate GRUB_SERIAL into /etc/inittab")