### PR TITLE
X86: add kmod dwmac intel

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1542,6 +1542,26 @@ endef
 
 $(eval $(call KernelPackage,sfp))
 
+
+define KernelPackage/stmmac-core
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Synopsis Ethernet Controller core (NXP,STMMicro,others)
+  DEPENDS:=@(TARGET_armsr_armv8) +kmod-pcs-xpcs +kmod-ptp \
+    +kmod-of-mdio
+  KCONFIG:=CONFIG_STMMAC_ETH \
+    CONFIG_STMMAC_SELFTESTS=n \
+    CONFIG_STMMAC_PLATFORM \
+    CONFIG_CONFIG_DWMAC_DWC_QOS_ETH=n \
+    CONFIG_DWMAC_GENERIC
+  FILES=$(LINUX_DIR)/drivers/net/ethernet/stmicro/stmmac/stmmac.ko \
+    $(LINUX_DIR)/drivers/net/ethernet/stmicro/stmmac/stmmac-platform.ko \
+    $(LINUX_DIR)/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.ko
+  AUTOLOAD=$(call AutoLoad,40,stmmac stmmac-platform dwmac-generic)
+endef
+
+$(eval $(call KernelPackage,stmmac-core))
+
+
 define KernelPackage/igc
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Intel(R) Ethernet Controller I225 Series support

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1546,7 +1546,7 @@ $(eval $(call KernelPackage,sfp))
 define KernelPackage/stmmac-core
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Synopsis Ethernet Controller core (NXP,STMMicro,others)
-  DEPENDS:=@(TARGET_armsr_armv8) +kmod-pcs-xpcs +kmod-ptp \
+  DEPENDS:=@TARGET_x86_64||TARGET_armsr_armv8 +kmod-pcs-xpcs +kmod-ptp \
     +kmod-of-mdio
   KCONFIG:=CONFIG_STMMAC_ETH \
     CONFIG_STMMAC_SELFTESTS=n \

--- a/target/linux/armsr/modules.mk
+++ b/target/linux/armsr/modules.mk
@@ -216,24 +216,6 @@ endef
 
 $(eval $(call KernelPackage,imx7-ulp-wdt))
 
-define KernelPackage/stmmac-core
-  SUBMENU=$(NETWORK_DEVICES_MENU)
-  TITLE:=Synopsis Ethernet Controller core (NXP,STMMicro,others)
-  DEPENDS:=@(TARGET_armsr_armv8) +kmod-pcs-xpcs +kmod-ptp \
-    +kmod-of-mdio
-  KCONFIG:=CONFIG_STMMAC_ETH \
-    CONFIG_STMMAC_SELFTESTS=n \
-    CONFIG_STMMAC_PLATFORM \
-    CONFIG_CONFIG_DWMAC_DWC_QOS_ETH=n \
-    CONFIG_DWMAC_GENERIC
-  FILES=$(LINUX_DIR)/drivers/net/ethernet/stmicro/stmmac/stmmac.ko \
-    $(LINUX_DIR)/drivers/net/ethernet/stmicro/stmmac/stmmac-platform.ko \
-    $(LINUX_DIR)/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.ko
-  AUTOLOAD=$(call AutoLoad,40,stmmac stmmac-platform dwmac-generic)
-endef
-
-$(eval $(call KernelPackage,stmmac-core))
-
 define KernelPackage/dwmac-imx
   SUBMENU=$(NETWORK_DEVICES_MENU)
   TITLE:=NXP i.MX8 Ethernet controller

--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -2,7 +2,7 @@ define Device/generic
   DEVICE_VENDOR := Generic
   DEVICE_MODEL := x86/64
   DEVICE_PACKAGES += \
-	kmod-amazon-ena kmod-amd-xgbe kmod-bnx2 kmod-e1000e kmod-e1000 \
+	kmod-amazon-ena kmod-amd-xgbe kmod-bnx2 kmod-dwmac-intel kmod-e1000e kmod-e1000 \
 	kmod-forcedeth kmod-fs-vfat kmod-igb kmod-igc kmod-ixgbe kmod-r8169 \
 	kmod-tg3 kmod-mlxsw-core kmod-mlxsw-pci kmod-mlxsw-i2c \
   	kmod-mlxsw-spectrum kmod-mlxsw-minimal kmod-mlxfw \

--- a/target/linux/x86/modules.mk
+++ b/target/linux/x86/modules.mk
@@ -18,6 +18,18 @@ endef
 $(eval $(call KernelPackage,amd-xgbe))
 
 
+define KernelPackage/dwmac-intel
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Intel GMAC support
+  DEPENDS:=@TARGET_x86_64 +kmod-stmmac-core
+  KCONFIG:=CONFIG_DWMAC_INTEL
+  FILES=$(LINUX_DIR)/drivers/net/ethernet/stmicro/stmmac/dwmac-intel.ko
+  AUTOLOAD=$(call AutoLoad,45,dwmac-intel)
+endef
+
+$(eval $(call KernelPackage,dwmac-intel))
+
+
 define KernelPackage/f71808e-wdt
   SUBMENU:=$(OTHER_MENU)
   TITLE:=Fintek F718xx/F818xx Watchdog Timer


### PR DESCRIPTION
 * armsr: Move kmod-stmmac-core to common place
    
    Move the kmod-stmmac-core package to the common place to share it with
    x86 later.
    
* x86: Add kmod-dwmac-intel
    
    This adds the Intel Ethernet driver for the Intel Quark/EHL/TGL chips.
    
    Fixes: #13994