### PR TITLE
mac80211: fix legacy rate decode

### DIFF
--- a/package/kernel/mac80211/patches/subsys/341-mac80211-fix-legacy-rate-decode.patch
+++ b/package/kernel/mac80211/patches/subsys/341-mac80211-fix-legacy-rate-decode.patch
@@ -1,0 +1,12 @@
+--- a/net/mac80211/sta_info.c
++++ b/net/mac80211/sta_info.c
+@@ -2363,6 +2363,9 @@ static void sta_stats_decode_rate(struct
+ 
+ 		sband = local->hw.wiphy->bands[band];
+ 
++		if (WARN_ON_ONCE(!sband))
++			break;
++
+ 		if (WARN_ON_ONCE(!sband->bitrates))
+ 			break;
+ 


### PR DESCRIPTION
Fix a null pointer dereference in legacy rate decoding. See: https://github.com/openwrt/openwrt/issues/13198