### PR TITLE
mvebu: Linksys WRT3200ACM and WRT32X: Remove SDIO wifi driver

### DIFF
--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -265,7 +265,7 @@ define Device/linksys_wrt3200acm
   DEVICE_ALT0_VENDOR := Linksys
   DEVICE_ALT0_MODEL := Rango
   DEVICE_DTS := armada-385-linksys-rango
-  DEVICE_PACKAGES += kmod-btmrvl kmod-mwifiex-sdio mwlwifi-firmware-88w8964
+  DEVICE_PACKAGES += kmod-btmrvl mwlwifi-firmware-88w8964
   SUPPORTED_DEVICES += armada-385-linksys-rango linksys,rango
 endef
 TARGET_DEVICES += linksys_wrt3200acm
@@ -277,7 +277,7 @@ define Device/linksys_wrt32x
   DEVICE_ALT0_VENDOR := Linksys
   DEVICE_ALT0_MODEL := Venom
   DEVICE_DTS := armada-385-linksys-venom
-  DEVICE_PACKAGES += kmod-btmrvl kmod-mwifiex-sdio mwlwifi-firmware-88w8964
+  DEVICE_PACKAGES += kmod-btmrvl mwlwifi-firmware-88w8964
   KERNEL_SIZE := 6144k
   KERNEL := kernel-bin | append-dtb
   SUPPORTED_DEVICES += armada-385-linksys-venom linksys,venom


### PR DESCRIPTION
The Linksys WRT3200ACM and WRT32X have an additional 1x1 88W8887 wifi 
device connected over SDIO in addition to the main 4x4 88W8964 wifi. 
The 88W8887 wifi chip is provisioned for the US regulatory domain also 
on devices sold in the EU. The 88W8964 wifi chip is provisioned for FR 
on devices sold in the EU. When Linux sees these two different Reg 
domains it tried to merge them and only allows what is allowed in both 
regions. This removes support for DFS channels.

As a workaround remove the driver for the SDIO wifi device.
If you need the extra wifi device just install the driver manually.
  opkg install kmod-mwifiex-sdio

Fixes: #9956