### PR TITLE
qca-nss-dp: fix typo in 0002-edma_tx_rx-support patch

### DIFF
--- a/package/kernel/qca-nss-dp/patches/0002-edma_tx_rx-support-newer-kernels-time-stamping-API.patch
+++ b/package/kernel/qca-nss-dp/patches/0002-edma_tx_rx-support-newer-kernels-time-stamping-API.patch
@@ -40,7 +40,7 @@ Signed-off-by: Baruch Siach <baruch@tkos.co.il>
  		ndev->phydev->drv->txtstamp(ndev->phydev, skb, 0);
 +#else
 +	if (ndev && phy_has_txtstamp(ndev->phydev))
-+		phy_rxtstamp(ndev->phydev, skb, 0);
++		phy_txtstamp(ndev->phydev, skb, 0);
 +#endif
  }
  EXPORT_SYMBOL(nss_phy_tstamp_tx_buf);


### PR DESCRIPTION
Might be a typo in drv->txtstamp function:
```
+		phy_rxtstamp(ndev->phydev, skb, 0);
to
+		phy_txtstamp(ndev->phydev, skb, 0);
```
Signed-off-by: Kristian Skramstad kristian+github@83.no