### PR TITLE
realtek:  Clean up and standardize realtek-poe support

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -69,6 +69,19 @@ done
 [ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
 
 case $board in
+d-link,dgs-1210-10mp-f)
+	ucidef_set_poe 130 "$lan_list" "lan9 lan10"
+	;;
+d-link,dgs-1210-10p)
+	ucidef_set_poe 65 "$lan_list" "lan9 lan10"
+	;;
+d-link,dgs-1210-28mp-f)
+	ucidef_set_poe 370 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
+			lan22 lan21 lan20 lan19 lan18 lan17" "lan25 lan26 lan27 lan28"
+	;;
+engenius,ews2910p)
+	ucidef_set_poe 60 "$lan_list" "lan9 lan10"
+	;;
 hpe,1920-8g-poe-65w)
 	ucidef_set_poe 65 "$lan_list_rev" "lan9 lan10"
 	;;

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -41,7 +41,7 @@ define Device/d-link_dgs-1210-10p
   $(Device/d-link_dgs-1210)
   SOC := rtl8382
   DEVICE_MODEL := DGS-1210-10P
-  DEVICE_PACKAGES += lua-rs232
+  DEVICE_PACKAGES += realtek-poe
 endef
 TARGET_DEVICES += d-link_dgs-1210-10p
 
@@ -82,6 +82,7 @@ define Device/engenius_ews2910p
   IMAGE_SIZE := 8192k
   DEVICE_VENDOR := EnGenius
   DEVICE_MODEL := EWS2910P
+  DEVICE_PACKAGES += realtek-poe
   UIMAGE_MAGIC := 0x03802910
   KERNEL_INITRAMFS := \
 	kernel-bin | \
@@ -112,6 +113,7 @@ define Device/hpe_1920-8g-poe-180w
   $(Device/hpe_1920)
   SOC := rtl8380
   DEVICE_MODEL := 1920-8G-PoE+ 180W (JG922A)
+  DEVICE_PACKAGES += realtek-poe
   H3C_DEVICE_ID := 0x00010025
   SUPPORTED_DEVICES += hpe_1920-8g-poe
 endef
@@ -180,6 +182,7 @@ define Device/netgear_gs110tpp-v1
   $(Device/netgear_nge)
   DEVICE_MODEL := GS110TPP
   DEVICE_VARIANT := v1
+  DEVICE_PACKAGES += realtek-poe
 endef
 TARGET_DEVICES += netgear_gs110tpp-v1
 
@@ -196,7 +199,7 @@ define Device/netgear_gs310tp-v1
   DEVICE_MODEL := GS310TP
   DEVICE_VARIANT := v1
   UIMAGE_MAGIC := 0x4e474335
-  DEVICE_PACKAGES += lua-rs232
+  DEVICE_PACKAGES += realtek-poe
 endef
 TARGET_DEVICES += netgear_gs310tp-v1
 
@@ -267,6 +270,7 @@ define Device/zyxel_gs1900-10hp
   SOC := rtl8380
   DEVICE_MODEL := GS1900-10HP
   ZYXEL_VERS := AAZI
+  DEVICE_PACKAGES += realtek-poe
 endef
 TARGET_DEVICES += zyxel_gs1900-10hp
 
@@ -292,7 +296,7 @@ define Device/zyxel_gs1900-8hp-v1
   DEVICE_MODEL := GS1900-8HP
   DEVICE_VARIANT := v1
   ZYXEL_VERS := AAHI
-  DEVICE_PACKAGES += lua-rs232
+  DEVICE_PACKAGES += realtek-poe
 endef
 TARGET_DEVICES += zyxel_gs1900-8hp-v1
 
@@ -302,7 +306,7 @@ define Device/zyxel_gs1900-8hp-v2
   DEVICE_MODEL := GS1900-8HP
   DEVICE_VARIANT := v2
   ZYXEL_VERS := AAHI
-  DEVICE_PACKAGES += lua-rs232
+  DEVICE_PACKAGES += realtek-poe
 endef
 TARGET_DEVICES += zyxel_gs1900-8hp-v2
 
@@ -329,6 +333,7 @@ define Device/zyxel_gs1900-24hp-v1
   DEVICE_MODEL := GS1900-24HP
   DEVICE_VARIANT := v1
   ZYXEL_VERS := AAHM
+  DEVICE_PACKAGES += realtek-poe
 endef
 TARGET_DEVICES += zyxel_gs1900-24hp-v1
 
@@ -338,5 +343,6 @@ define Device/zyxel_gs1900-24hp-v2
   DEVICE_MODEL := GS1900-24HP
   DEVICE_VARIANT := v2
   ZYXEL_VERS := ABTP
+  DEVICE_PACKAGES += realtek-poe
 endef
 TARGET_DEVICES += zyxel_gs1900-24hp-v2


### PR DESCRIPTION
This patch cleans up and standardizes realtek-poe support for realtek based switches that have supported PoE ports.

The power output of switches supported by realtek-poe package can be configured in the 02_network ucidef_set_poe() function.  This was missed when some PoE capable switches supported by realtek-poe were added.

The realtek-poe package at one point replaced a lua-rs232 based script and some devices were not updated to use the realtek-poe package.  Consistently add realtek-poe package to DEVICE_PACKAGES for switches with suppored PoE.

Signed-off-by: Raylynn Knight <rayknight@me.com>