### PR TITLE
ath79: add support for ubnt_litebeam-m5-xw

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_litebeam-m5-xw.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_litebeam-m5-xw.dts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "ubnt,litebeam-m5-xw", "qca,ar9342";
+	model = "Ubiquiti LiteBeam M5 (XW)";
+
+	aliases {
+		led-boot = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+		led-failsafe = &led_status;
+		label-mac-device = &wmac;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-lan {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led-wlan {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			linux,default-trigger = "phy0tpt";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status: led-power {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0x760000>;
+			};
+
+			partition@7b0000 {
+				label = "cfg";
+				reg = <0x7b0000 0x040000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&calibration_art_1000>;
+	nvmem-cell-names = "calibration";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+		phy-mode = "mii";
+		reset-gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-handle = <&phy1>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -27,7 +27,8 @@ pcs,cap324|\
 tplink,cpe605-v1|\
 tplink,cpe610-v1|\
 tplink,cpe610-v2|\
-tplink,tl-wa1201-v2)
+tplink,tl-wa1201-v2|\
+ubnt,litebeam-m5-xw)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
 	;;
 tplink,tl-wdr6500-v2)

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -105,6 +105,7 @@ ath79_setup_interfaces()
 	ubnt,bullet-m-xw|\
 	ubnt,lap-120|\
 	ubnt,litebeam-ac-gen2|\
+	ubnt,litebeam-m5-xw|\
 	ubnt,nanobeam-ac|\
 	ubnt,nanobeam-ac-xc|\
 	ubnt,nanostation-ac-loco|\

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -62,6 +62,14 @@ define Device/ubnt_litebeam-ac-gen2
 endef
 TARGET_DEVICES += ubnt_litebeam-ac-gen2
 
+define Device/ubnt_litebeam-m5-xw
+  $(Device/ubnt-xw)
+  DEVICE_MODEL := LiteBeam M5
+  SUPPORTED_DEVICES += lbe-m5
+  DEVICE_PACKAGES := -kmod-usb2
+endef
+TARGET_DEVICES += ubnt_litebeam-m5-xw
+
 define Device/ubnt_nanobeam-ac
   $(Device/ubnt-wa)
   DEVICE_MODEL := NanoBeam AC


### PR DESCRIPTION
Add support for Ubiquiti LiteBeam M5 (XW).
The device was previously supported in ar71xx.
See commit: https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=d0988235dd277b9a832bbc4b2a100ac6e821f577

This adds led mapping for the device, which is equivalent to ubnt_nanostation-loco-xw but without rssileds.
Also, there is no trace of usb connectors on the board, so I remove kmod-usb2 to save space.