### PR TITLE
ath79: fix dtc warnings

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -151,17 +151,13 @@ endif
 
 # Disable noisy checks by default as in upstream
 DTC_WARN_FLAGS := \
+  -Wno-interrupt_provider \
+  -Wno-unique_unit_address \
   -Wno-unit_address_vs_reg \
-  -Wno-simple_bus_reg \
-  -Wno-unit_address_format \
-  -Wno-pci_bridge \
-  -Wno-pci_device_bus_num \
-  -Wno-pci_device_reg \
   -Wno-avoid_unnecessary_addr_size \
   -Wno-alias_paths \
   -Wno-graph_child_address \
-  -Wno-graph_port \
-  -Wno-unique_unit_address
+  -Wno-simple_bus_reg
 
 DTC_FLAGS += $(DTC_WARN_FLAGS)
 DTCO_FLAGS += $(DTC_WARN_FLAGS)

--- a/target/linux/ath79/dts/ar7100.dtsi
+++ b/target/linux/ath79/dts/ar7100.dtsi
@@ -113,7 +113,7 @@
 				#reset-cells = <1>;
 			};
 
-			pcie0: pcie-controller@17010000 {
+			pcie0: pcie@17010000 {
 				compatible = "qca,ar7100-pci";
 				#address-cells = <3>;
 				#size-cells = <2>;

--- a/target/linux/ath79/dts/ar7161_aruba_ap-105.dts
+++ b/target/linux/ath79/dts/ar7161_aruba_ap-105.dts
@@ -94,7 +94,7 @@
 &pcie0 {
 	status = "okay";
 
-	ath9k0: wifi@0,11 { /* 2.4 GHz */
+	ath9k0: wifi@11,0 { /* 2.4 GHz */
 		compatible = "pci168c,0029";
 		nvmem-cells = <&macaddr_hwinfo_1c 1>;
 		nvmem-cell-names = "mac-address";
@@ -103,7 +103,7 @@
 		gpio-controller;
 	};
 
-	ath9k1: wifi@0,12 { /* 5 GHz */
+	ath9k1: wifi@12,0 { /* 5 GHz */
 		compatible = "pci168c,0029";
 		nvmem-cells = <&macaddr_hwinfo_1c 2>;
 		nvmem-cell-names = "mac-address";

--- a/target/linux/ath79/dts/ar7161_aruba_ap-175.dts
+++ b/target/linux/ath79/dts/ar7161_aruba_ap-175.dts
@@ -120,7 +120,7 @@
 &pcie0 {
 	status = "okay";
 
-	ath9k0: wifi@0,11 {
+	ath9k0: wifi@11,0 {
 		compatible = "pci168c,0029";
 		nvmem-cells = <&macaddr_hwinfo_1c 1>;
 		nvmem-cell-names = "mac-address";
@@ -129,7 +129,7 @@
 		gpio-controller;
 	};
 
-	ath9k1: wifi@0,12 {
+	ath9k1: wifi@12,0 {
 		compatible = "pci168c,0029";
 		nvmem-cells = <&macaddr_hwinfo_1c 2>;
 		nvmem-cell-names = "mac-address";

--- a/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
+++ b/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
@@ -196,7 +196,7 @@
 &pcie0 {
 	status = "okay";
 
-	ath9k0: wifi@0,11 {
+	ath9k0: wifi@11,0 {
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
 		qca,no-eeprom;
@@ -204,7 +204,7 @@
 		gpio-controller;
 	};
 
-	ath9k1: wifi@0,12 {
+	ath9k1: wifi@12,0 {
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
 		qca,no-eeprom;

--- a/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
+++ b/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
@@ -136,7 +136,7 @@
 &pcie0 {
 	status = "okay";
 
-	ath9k0: wifi@0,11 {
+	ath9k0: wifi@11,0 {
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
 		nvmem-cells = <&macaddr_lan 0>, <&cal_art_1000>;
@@ -145,7 +145,7 @@
 		gpio-controller;
 	};
 
-	ath9k1: wifi@0,12 {
+	ath9k1: wifi@12,0 {
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
 		nvmem-cells = <&macaddr_wan 1>, <&cal_art_5000>;

--- a/target/linux/ath79/dts/ar7161_fortinet_fap-220-b.dts
+++ b/target/linux/ath79/dts/ar7161_fortinet_fap-220-b.dts
@@ -95,7 +95,7 @@
 &pcie0 {
 	status = "okay";
 
-	ath9k0: wifi@0,11 { /* 2.4 GHz */
+	ath9k0: wifi@11,0 { /* 2.4 GHz */
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
 		ieee80211-freq-limit = <2402000 2482000>;
@@ -105,7 +105,7 @@
 		gpio-controller;
 	};
 
-	ath9k1: wifi@0,12 { /* 5 GHz */
+	ath9k1: wifi@12,0 { /* 5 GHz */
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
 		ieee80211-freq-limit = <2402000 2482000 4900000 5990000>;

--- a/target/linux/ath79/dts/ar7161_meraki_mr16.dts
+++ b/target/linux/ath79/dts/ar7161_meraki_mr16.dts
@@ -70,7 +70,7 @@
 &pcie0 {
 	status = "okay";
 
-	ath9k0: wifi@0,11 { /* 2.4 GHz */
+	ath9k0: wifi@11,0 { /* 2.4 GHz */
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
 		qca,no-eeprom;
@@ -80,7 +80,7 @@
 		gpio-controller;
 	};
 
-	ath9k1: wifi@0,12 { /* 5 GHz */
+	ath9k1: wifi@12,0 { /* 5 GHz */
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
 		qca,no-eeprom;

--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -147,7 +147,7 @@
 &pcie0 {
 	status = "okay";
 
-	ath9k0: wifi@0,11 {
+	ath9k0: wifi@11,0 {
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_120c>, <&calibration_art_1000>;
@@ -156,7 +156,7 @@
 		gpio-controller;
 	};
 
-	ath9k1: wifi@0,12 {
+	ath9k1: wifi@12,0 {
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_520c 1>, <&calibration_art_5000>;

--- a/target/linux/ath79/dts/ar7161_netgear_wndr.dtsi
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr.dtsi
@@ -126,7 +126,7 @@
 &pcie0 {
 	status = "okay";
 
-	ath9k0: wifi@0,11 {
+	ath9k0: wifi@11,0 {
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
 
@@ -153,7 +153,7 @@
 		};
 	};
 
-	ath9k1: wifi@0,12 {
+	ath9k1: wifi@12,0 {
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
 

--- a/target/linux/ath79/dts/ar7161_ruckus_gd11.dtsi
+++ b/target/linux/ath79/dts/ar7161_ruckus_gd11.dtsi
@@ -131,7 +131,7 @@
 &pcie0 {
 	status = "okay";
 
-	ath9k0: wifi@0,11 { /* 2.4 GHz */
+	ath9k0: wifi@11,0 { /* 2.4 GHz */
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
 		nvmem-cells = <&macaddr_bdata_60>;
@@ -140,7 +140,7 @@
 		gpio-controller;
 	};
 
-	ath9k1: wifi@0,12 { /* 5 GHz */
+	ath9k1: wifi@12,0 { /* 5 GHz */
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
 		nvmem-cells = <&macaddr_bdata_76>;

--- a/target/linux/ath79/dts/ar7161_trendnet_tew-673gru.dts
+++ b/target/linux/ath79/dts/ar7161_trendnet_tew-673gru.dts
@@ -92,13 +92,13 @@
 &pcie0 {
 	status = "okay";
 
-	wifi@0,11 {
+	wifi@11,0 {
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
 		qca,no-eeprom;
 	};
 
-	wifi@0,12 {
+	wifi@12,0 {
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
 		qca,no-eeprom;

--- a/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
+++ b/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
@@ -85,7 +85,7 @@
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
 
-		gpio = <&gpio 11 GPIO_ACTIVE_LOW>;
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 		startup-delay-us = <300000>;
 		enable-active-high;
 

--- a/target/linux/ath79/dts/ar7242_engenius_eap350-v1.dts
+++ b/target/linux/ath79/dts/ar7242_engenius_eap350-v1.dts
@@ -75,7 +75,7 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0,0 {
+	ath9k: wifi@0,0 {
 		compatible = "pci168c,002a";
 		reg = <0x0 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_0 1>;

--- a/target/linux/ath79/dts/ar7242_engenius_ecb350-v1.dts
+++ b/target/linux/ath79/dts/ar7242_engenius_ecb350-v1.dts
@@ -75,7 +75,7 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0,0 {
+	ath9k: wifi@0,0 {
 		compatible = "pci168c,002a";
 		reg = <0x0 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_0 (-1)>;

--- a/target/linux/ath79/dts/ar7242_meraki_mr12.dts
+++ b/target/linux/ath79/dts/ar7242_meraki_mr12.dts
@@ -70,7 +70,7 @@
 &pcie {
 	status = "okay";
 
-	wifi@0,0,0 {
+	wifi@0,0 {
 		compatible = "pci168c,002a";
 		reg = <0x0000 0 0 0 0>;
 		qca,no-eeprom;

--- a/target/linux/ath79/dts/ar724x.dtsi
+++ b/target/linux/ath79/dts/ar724x.dtsi
@@ -121,7 +121,7 @@
 				#reset-cells = <1>;
 			};
 
-			pcie: pcie-controller@180c0000 {
+			pcie: pcie@180c0000 {
 				compatible = "qcom,ar7240-pci";
 				#address-cells = <3>;
 				#size-cells = <2>;

--- a/target/linux/ath79/dts/ar9331_glinet_gl-mifi.dts
+++ b/target/linux/ath79/dts/ar9331_glinet_gl-mifi.dts
@@ -54,7 +54,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 6 GPIO_ACTIVE_LOW>;
+		gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
 	};
 
 	gpio-export {

--- a/target/linux/ath79/dts/ar9331_hiwifi_hc6361.dts
+++ b/target/linux/ath79/dts/ar9331_hiwifi_hc6361.dts
@@ -52,7 +52,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 		enable-active-high;
-		gpio = <&gpio 20 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/target/linux/ath79/dts/ar9331_onion_omega.dts
+++ b/target/linux/ath79/dts/ar9331_onion_omega.dts
@@ -43,7 +43,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/ath79/dts/ar9331_pisen_wmm003n.dts
+++ b/target/linux/ath79/dts/ar9331_pisen_wmm003n.dts
@@ -41,7 +41,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
+++ b/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
@@ -101,7 +101,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 19 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr10u.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr10u.dts
@@ -8,5 +8,5 @@
 };
 
 &reg_usb_vbus {
-	gpio = <&gpio 18 GPIO_ACTIVE_HIGH>;
+	gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
 };

--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr3020-v1.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr3020-v1.dts
@@ -76,7 +76,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
@@ -72,7 +72,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 18 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr703n.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr703n.dts
@@ -8,5 +8,5 @@
 };
 
 &reg_usb_vbus {
-	gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
+	gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
 };

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr710n.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr710n.dtsi
@@ -38,7 +38,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/ath79/dts/ar9342_mikrotik_routerboard-912uag-2hpnd.dts
+++ b/target/linux/ath79/dts/ar9342_mikrotik_routerboard-912uag-2hpnd.dts
@@ -20,7 +20,7 @@
 		compatible = "mikrotik,gpio-rb91x-key";
 		gpio-controller;
 		#gpio-cells = <2>;
-		gpio = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
 	};
 
 	gpio_latch: gpio_latch {

--- a/target/linux/ath79/dts/ar9342_mikrotik_routerboard-912uag-2hpnd.dts
+++ b/target/linux/ath79/dts/ar9342_mikrotik_routerboard-912uag-2hpnd.dts
@@ -77,7 +77,7 @@
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;
 
-		button@0 {
+		button-reset {
 			label = "reset";
 			linux,code = <KEY_RESTART>;
 			gpios = <&gpio_key 1 GPIO_ACTIVE_LOW>;

--- a/target/linux/ath79/dts/ar9344.dtsi
+++ b/target/linux/ath79/dts/ar9344.dtsi
@@ -32,7 +32,7 @@
 };
 
 &ahb {
-	pcie: pcie-controller@180c0000 {
+	pcie: pcie@180c0000 {
 		compatible = "qcom,ar9340-pci", "qcom,ar7240-pci";
 		#address-cells = <3>;
 		#size-cells = <2>;

--- a/target/linux/ath79/dts/ar9344_araknis_an-300-ap-i-n.dts
+++ b/target/linux/ath79/dts/ar9344_araknis_an-300-ap-i-n.dts
@@ -84,7 +84,7 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0,0 {
+	ath9k: wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_0 1>, <&calibration_art_5000>;

--- a/target/linux/ath79/dts/ar9344_engenius_eap600.dts
+++ b/target/linux/ath79/dts/ar9344_engenius_eap600.dts
@@ -34,7 +34,7 @@
 };
 
 &pcie {
-	wifi@0,0,0 {
+	wifi@0,0 {
 		nvmem-cells = <&macaddr_art_0 0>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
 	};

--- a/target/linux/ath79/dts/ar9344_engenius_ecb600.dts
+++ b/target/linux/ath79/dts/ar9344_engenius_ecb600.dts
@@ -29,7 +29,7 @@
 };
 
 &pcie {
-	wifi@0,0,0 {
+	wifi@0,0 {
 		nvmem-cells = <&macaddr_art_0 (-2)>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
 	};

--- a/target/linux/ath79/dts/ar9344_fortinet_ap-dual.dtsi
+++ b/target/linux/ath79/dts/ar9344_fortinet_ap-dual.dtsi
@@ -56,7 +56,7 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0,0 {
+	ath9k: wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0 0 0 0 0>;
 	};

--- a/target/linux/ath79/dts/ar9344_netgear_r6100.dts
+++ b/target/linux/ath79/dts/ar9344_netgear_r6100.dts
@@ -203,7 +203,7 @@
 &pcie {
 	status = "okay";
 
-	wifi@0,0,0 {
+	wifi@0,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x0000 0 0 0 0>;
 

--- a/target/linux/ath79/dts/ar9344_netgear_wndr.dtsi
+++ b/target/linux/ath79/dts/ar9344_netgear_wndr.dtsi
@@ -90,7 +90,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			ubi@ac0000 {
+			ubi@0 {
 				label = "ubi";
 				reg = <0x0 0x7500000>;
 			};
@@ -171,22 +171,23 @@
 			reg = <0x3c0000 0x300000>;
 		};
 
-		kernel@6c0000 {
-			label = "kernel";
-			reg = <0x6c0000 0x400000>;
-		};
-
-		ubiconcat0: partition@ac0000 {
-			label = "ubiconcat0";
-			reg = <0xac0000 0x1500000>;
-		};
-
 		partition@6c0000 {
 			label = "firmware";
 			reg = <0x6c0000 0x1900000>;
-			compatible = "openwrt,uimage", "denx,uimage";
-			openwrt,ih-magic = <0x33373033>;
-			openwrt,ih-type = <IH_TYPE_FILESYSTEM>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			kernel@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			ubiconcat0: partition@400000 {
+				label = "ubiconcat0";
+				reg = <0x400000 0x1500000>;
+			};
 		};
 
 		partition@1fc0000 {

--- a/target/linux/ath79/dts/ar9344_qihoo_c301.dts
+++ b/target/linux/ath79/dts/ar9344_qihoo_c301.dts
@@ -103,8 +103,6 @@
 	pinctrl-0 = <&pmx_spi_cs1>;
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;
@@ -164,8 +162,6 @@
 	};
 
 	flash@1 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <1>;
 		spi-max-frequency = <25000000>;

--- a/target/linux/ath79/dts/ar9344_qihoo_c301.dts
+++ b/target/linux/ath79/dts/ar9344_qihoo_c301.dts
@@ -48,7 +48,7 @@
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
 		regulator-always-on;
-		gpio = <&gpio 18 GPIO_ACTIVE_LOW>;
+		gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
 	};
 
 	usb_vbus: reg_usb_vbus {
@@ -57,7 +57,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 		enable-active-high;
-		gpio = <&gpio 19 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/target/linux/ath79/dts/ar9344_senao_ap-dual.dtsi
+++ b/target/linux/ath79/dts/ar9344_senao_ap-dual.dtsi
@@ -59,7 +59,7 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0,0 {
+	ath9k: wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0 0 0 0 0>;
 		ieee80211-freq-limit = <2402000 2482000>;

--- a/target/linux/ath79/dts/ar9344_watchguard_ap100.dts
+++ b/target/linux/ath79/dts/ar9344_watchguard_ap100.dts
@@ -63,7 +63,7 @@
 &pcie {
 	status = "disabled";
 
-	wifi@0,0,0 {
+	wifi@0,0 {
 		nvmem-cells = <&calibration_art_5000>;
 		nvmem-cell-names = "calibration";
 	};

--- a/target/linux/ath79/dts/ar9344_watchguard_ap200.dts
+++ b/target/linux/ath79/dts/ar9344_watchguard_ap200.dts
@@ -61,7 +61,7 @@
 };
 
 &pcie {
-	wifi@0,0,0 {
+	wifi@0,0 {
 		nvmem-cells = <&macaddr_art_0 (-1)>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
 	};

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -197,9 +197,6 @@
 
 			nand-ecc-mode = "hw";
 
-			#address-cells = <1>;
-			#size-cells = <0>;
-
 			status = "disabled";
 		};
 

--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts
@@ -72,7 +72,6 @@
 	wifi@0,0 {
 		compatible = "qcom,ath10k";
 		reg = <0 0 0 0 0>;
-		device_type = "pci";
 	};
 };
 

--- a/target/linux/ath79/dts/qca9531_tplink_tl-wr810n-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-wr810n-v1.dts
@@ -11,7 +11,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-always-on;
 	};

--- a/target/linux/ath79/dts/qca9533_tplink_cpexxx.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_cpexxx.dtsi
@@ -53,8 +53,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wa850re-v2.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wa850re-v2.dts
@@ -95,8 +95,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -150,7 +150,7 @@
 			reg = <0x18070000 0x4>;
 		};
 
-		pcie0: pcie-controller@180c0000 {
+		pcie0: pcie@180c0000 {
 			compatible = "qcom,ar7240-pci";
 			#address-cells = <3>;
 			#size-cells = <2>;

--- a/target/linux/ath79/dts/qca9557_extreme-networks_ws-ap3805i.dts
+++ b/target/linux/ath79/dts/qca9557_extreme-networks_ws-ap3805i.dts
@@ -75,7 +75,7 @@
 &pcie0 {
 	status = "okay";
 
-	wifi@0,0,0 {
+	wifi@0,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x0 0 0 0 0>;
 	};

--- a/target/linux/ath79/dts/qca9558_aruba_ap-115.dts
+++ b/target/linux/ath79/dts/qca9558_aruba_ap-115.dts
@@ -83,7 +83,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-always-on;
 	};

--- a/target/linux/ath79/dts/qca9558_engenius_esr900.dts
+++ b/target/linux/ath79/dts/qca9558_engenius_esr900.dts
@@ -76,7 +76,7 @@
 &pcie0 {
 	status = "okay";
 
-	wifi@0,0,0 {
+	wifi@0,0 {
 		compatible = "pci168c,0033";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&calibration_art_5000>;

--- a/target/linux/ath79/dts/qca9558_jjplus_jwap230.dts
+++ b/target/linux/ath79/dts/qca9558_jjplus_jwap230.dts
@@ -109,7 +109,7 @@
 &mdio0 {
 	status = "okay";
 
-	switch {
+	switch@0 {
 		compatible = "qca,ar8327";
 		reg = <0>;
 

--- a/target/linux/ath79/dts/qca9558_sophos_ap.dtsi
+++ b/target/linux/ath79/dts/qca9558_sophos_ap.dtsi
@@ -62,7 +62,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 		status = "disabled";

--- a/target/linux/ath79/dts/qca9558_tplink_archer-d7.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-d7.dtsi
@@ -72,7 +72,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 21 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 
@@ -81,7 +81,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 22 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/ath79/dts/qca9558_zyxel_nbg6716.dts
+++ b/target/linux/ath79/dts/qca9558_zyxel_nbg6716.dts
@@ -143,16 +143,20 @@
 		firmware@500000 {
 			label = "firmware";
 			reg = <0x500000 0x7b00000>;
-		};
 
-		partition@500000 {
-			label = "kernel";
-			reg = <0x500000 0x400000>;
-		};
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-		partition@900000 {
-			label = "ubi";
-			reg = <0x900000 0x7700000>;
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7700000>;
+			};
 		};
 	};
 };

--- a/target/linux/ath79/dts/qca955x.dtsi
+++ b/target/linux/ath79/dts/qca955x.dtsi
@@ -185,7 +185,7 @@
 			reg = <0x18070000 0x58>;
 		};
 
-		pcie0: pcie-controller@180c0000 {
+		pcie0: pcie@180c0000 {
 			compatible = "qcom,qca9550-pci", "qcom,ar7240-pci";
 			#address-cells = <3>;
 			#size-cells = <2>;
@@ -222,7 +222,7 @@
 			status = "disabled";
 		};
 
-		pcie1: pcie-controller@18250000 {
+		pcie1: pcie@18250000 {
 			compatible = "qcom,qca9550-pci", "qcom,ar7240-pci";
 			#address-cells = <3>;
 			#size-cells = <2>;

--- a/target/linux/ath79/dts/qca955x.dtsi
+++ b/target/linux/ath79/dts/qca955x.dtsi
@@ -313,9 +313,6 @@
 
 			nand-ecc-mode = "hw";
 
-			#address-cells = <1>;
-			#size-cells = <0>;
-
 			status = "disabled";
 		};
 

--- a/target/linux/ath79/dts/qca955x_engenius_ecb1xxx.dtsi
+++ b/target/linux/ath79/dts/qca955x_engenius_ecb1xxx.dtsi
@@ -119,7 +119,7 @@
 &pcie0 {
 	status = "okay";
 
-	wifi@0,0,0 {
+	wifi@0,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x0 0 0 0 0>;
 		qca,no-eeprom;

--- a/target/linux/ath79/dts/qca955x_senao_loader.dtsi
+++ b/target/linux/ath79/dts/qca955x_senao_loader.dtsi
@@ -26,16 +26,16 @@
 };
 
 &pcie0 {
-	ath10k_0: wifi@0,0,0 {
+	ath10k_0: wifi@0,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x0 0 0 0 0>;
 	};
 };
 
 &pcie1 {
-	ath10k_1: wifi@0,1,0 {
+	ath10k_1: wifi@0,0 {
 		compatible = "qcom,ath10k";
-		reg = <0x0 1 0 0 0>;
+		reg = <0x0 0 0 0 0>;
 	};
 };
 

--- a/target/linux/ath79/dts/qca955x_senao_router-dual.dtsi
+++ b/target/linux/ath79/dts/qca955x_senao_router-dual.dtsi
@@ -43,7 +43,7 @@
 &pcie0 {
 	status = "okay";
 
-	ath10k_0: wifi@0,0,0 {
+	ath10k_0: wifi@0,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x0000 0 0 0 0>;
 	};

--- a/target/linux/ath79/dts/qca9561_tplink_tl-wdr6500-v2.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_tl-wdr6500-v2.dts
@@ -86,9 +86,9 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
-					macaddr_uboot_0fc00: macaddr@0fc00 {
+					macaddr_uboot_fc00: macaddr@fc00 {
 						compatible = "mac-base";
-						reg = <0x0fc00 0x6>;
+						reg = <0xfc00 0x6>;
 						#nvmem-cell-cells = <1>;
 					};
 				};
@@ -134,7 +134,7 @@
 		compatible = "qcom,ath10k";
 		reg = <0 0 0 0 0>;
 
-		nvmem-cells = <&macaddr_uboot_0fc00 (-2)>, <&calibration_ath10k>;
+		nvmem-cells = <&macaddr_uboot_fc00 (-2)>, <&calibration_ath10k>;
 		nvmem-cell-names = "mac-address", "calibration";
 	};
 };
@@ -148,21 +148,21 @@
 
 	phy-handle = <&swphy4>;
 
-	nvmem-cells = <&macaddr_uboot_0fc00 1>;
+	nvmem-cells = <&macaddr_uboot_fc00 1>;
 	nvmem-cell-names = "mac-address";
 };
 
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_uboot_0fc00 0>;
+	nvmem-cells = <&macaddr_uboot_fc00 0>;
 	nvmem-cell-names = "mac-address";
 };
 
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_uboot_0fc00 (-1)>, <&calibration_ath9k>;
+	nvmem-cells = <&macaddr_uboot_fc00 (-1)>, <&calibration_ath9k>;
 	nvmem-cell-names = "mac-address", "calibration";
 };
 

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -157,7 +157,7 @@
 			status = "disabled";
 		};
 
-		pcie: pcie-controller@18250000 {
+		pcie: pcie@18250000 {
 			compatible = "qcom,ar7240-pci";
 			#address-cells = <3>;
 			#size-cells = <2>;

--- a/target/linux/ath79/patches-5.15/310-dt-bindings-PCI-qcom-ar7100-adds-binding-doc.patch
+++ b/target/linux/ath79/patches-5.15/310-dt-bindings-PCI-qcom-ar7100-adds-binding-doc.patch
@@ -37,7 +37,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +- interrupt-parent: phandle to the MIPS IRQ controller
 +
 +* Example for ar7100
-+	pcie-controller@180c0000 {
++	pcie@180c0000 {
 +		compatible = "qca,ar7100-pci";
 +		#address-cells = <3>;
 +		#size-cells = <2>;

--- a/target/linux/ath79/patches-5.15/312-dt-bindings-PCI-qcom-ar7240-adds-binding-doc.patch
+++ b/target/linux/ath79/patches-5.15/312-dt-bindings-PCI-qcom-ar7240-adds-binding-doc.patch
@@ -39,7 +39,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +- interrupt-controller: define to enable the builtin IRQ cascade.
 +
 +* Example for qca9557
-+	pcie-controller@180c0000 {
++	pcie@180c0000 {
 +		compatible = "qcom,ar7240-pci";
 +		#address-cells = <3>;
 +		#size-cells = <2>;

--- a/target/linux/ath79/patches-6.1/310-dt-bindings-PCI-qcom-ar7100-adds-binding-doc.patch
+++ b/target/linux/ath79/patches-6.1/310-dt-bindings-PCI-qcom-ar7100-adds-binding-doc.patch
@@ -37,7 +37,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +- interrupt-parent: phandle to the MIPS IRQ controller
 +
 +* Example for ar7100
-+	pcie-controller@180c0000 {
++	pcie@180c0000 {
 +		compatible = "qca,ar7100-pci";
 +		#address-cells = <3>;
 +		#size-cells = <2>;

--- a/target/linux/ath79/patches-6.1/312-dt-bindings-PCI-qcom-ar7240-adds-binding-doc.patch
+++ b/target/linux/ath79/patches-6.1/312-dt-bindings-PCI-qcom-ar7240-adds-binding-doc.patch
@@ -39,7 +39,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +- interrupt-controller: define to enable the builtin IRQ cascade.
 +
 +* Example for qca9557
-+	pcie-controller@180c0000 {
++	pcie@180c0000 {
 +		compatible = "qcom,ar7240-pci";
 +		#address-cells = <3>;
 +		#size-cells = <2>;


### PR DESCRIPTION
Found by compiling all ath79 subtargets.