### PR TITLE
ipq807x: fix edgecore EAP102 lan/wan

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
@@ -21,8 +21,8 @@
 		led-running = &led_system_green;
 		led-upgrade = &led_system_green;
 		/* Aliases as required by u-boot to patch MAC addresses */
-		ethernet0 = &dp5;
-		ethernet1 = &dp6;
+		ethernet0 = &dp6;
+		ethernet1 = &dp5;
 		label-mac-device = &dp5;
 	};
 
@@ -343,8 +343,8 @@
 &switch {
 	status = "okay";
 
-	switch_lan_bmp = <ESS_PORT6>; /* lan port bitmap */
-	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
+	switch_lan_bmp = <ESS_PORT5>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
 	switch_mac_mode1 = <MAC_MODE_SGMII_CHANNEL0>; /* mac mode for uniphy instance1*/
 	switch_mac_mode2 = <MAC_MODE_SGMII_CHANNEL0>; /* mac mode for uniphy instance2*/
 
@@ -368,14 +368,14 @@
 
 &dp5 {
 	status = "okay";
-	phy-handle = <&qca8081_28>;
-	label = "wan";
+	phy-handle = <&qca8081_24>;
+	label = "lan";
 };
 
 &dp6 {
 	status = "okay";
-	phy-handle = <&qca8081_24>;
-	label = "lan";
+	phy-handle = <&qca8081_28>;
+	label = "wan";
 };
 
 &wifi {


### PR DESCRIPTION
We have a report in the forum, that lan/wan is non-functional
on the EAP102 (https://forum.openwrt.org/t/edgecore-eap102/178449)
    
Fixing that by swapping label and phy-handle of the dp-nodes and
updating the lan/wan bmp.
    
Note: the original commiter of the device support seems absent for a
long time in the forum and on the OpenWrt github group.
    
Tested-by: Antonio Della Selva <antonio.dellaselva@uniurb.it>
Signed-off-by: Dirk Buchwalder <buchwalder@posteo.de>