### PR TITLE
fix 814-v6.6-0012-nvmem-sec-qfprom-Add-Qualcomm-secure-QFPROM-support…

### DIFF
--- a/target/linux/generic/backport-6.1/814-v6.6-0012-nvmem-sec-qfprom-Add-Qualcomm-secure-QFPROM-support.patch
+++ b/target/linux/generic/backport-6.1/814-v6.6-0012-nvmem-sec-qfprom-Add-Qualcomm-secure-QFPROM-support.patch
@@ -59,7 +59,7 @@ Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
 + * Copyright (c) 2023, Qualcomm Innovation Center, Inc. All rights reserved.
 + */
 +
-+#include <linux/firmware/qcom/qcom_scm.h>
++#include <linux/qcom_scm.h>
 +#include <linux/mod_devicetable.h>
 +#include <linux/nvmem-provider.h>
 +#include <linux/platform_device.h>


### PR DESCRIPTION
Fix broken `target/linux/generic/backport-6.1/814-v6.6-0012-nvmem-sec-qfprom-Add-Qualcomm-secure-QFPROM-support.patch`

This backported patch is broken, since kernel 6.1 has not 'include/linux/firmware' directory yet.

Fix the bug #14115
