### PR TITLE
ramips: update leds & buttons dts description

### DIFF
--- a/target/linux/ramips/dts/mt7620a_sercomm_cpj.dtsi
+++ b/target/linux/ramips/dts/mt7620a_sercomm_cpj.dtsi
@@ -38,14 +38,12 @@
 		compatible = "gpio-leds";
 
 		status_green: led-0 {
-			label = "green:status";
 			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_STATUS;
 		};
 
 		status_amber: led-1 {
-			label = "amber:status";
 			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_AMBER>;
 			function = LED_FUNCTION_STATUS;

--- a/target/linux/ramips/dts/mt7621_arcadyan_wg4xx223.dtsi
+++ b/target/linux/ramips/dts/mt7621_arcadyan_wg4xx223.dtsi
@@ -17,15 +17,13 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_status_green: led-1 {
-			label = "green:status";
+		led_status_green: led-0 {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_STATUS;
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
-		led_status_red: led-2 {
-			label = "red:status";
+		led_status_red: led-1 {
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_STATUS;
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
@@ -35,7 +33,7 @@
 	keys {
 		compatible = "gpio-keys";
 
-		reset {
+		button-0 {
 			label = "reset";
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-flash.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-flash.dts
@@ -7,8 +7,7 @@
 	model = "Beeline SmartBox Flash";
 
 	leds {
-		led-0 {
-			label = "blue:wan";
+		led-2 {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WAN;
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-giga.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-giga.dts
@@ -23,21 +23,18 @@
 		compatible = "gpio-leds";
 
 		led_status_green: led-0 {
-			label = "green:status";
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_STATUS;
 			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
 		};
 
 		led-1 {
-			label = "blue:wan";
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WAN;
 			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_status_red: led-2 {
-			label = "red:status";
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_STATUS;
 			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
@@ -47,7 +44,7 @@
 	keys {
 		compatible = "gpio-keys";
 
-		reset {
+		button-0 {
 			label = "reset";
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-pro.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-pro.dts
@@ -11,7 +11,7 @@
 	};
 
 	keys {
-		switch_bt {
+		switch-0 {
 			label = "ROUT<->REP Switch_bt";
 			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
 			linux,input-type = <EV_SW>;
@@ -39,7 +39,6 @@
 };
 
 &led_wps {
-	label = "blue:wps";
 	color = <LED_COLOR_ID_BLUE>;
 };
 

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo-plus.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo-plus.dts
@@ -23,21 +23,18 @@
 		compatible = "gpio-leds";
 
 		led-0 {
-			label = "blue:wan";
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WAN;
 			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_status_green: led-1 {
-			label = "green:status";
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_STATUS;
 			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_status_red: led-2 {
-			label = "red:status";
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_STATUS;
 			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
@@ -47,13 +44,13 @@
 	keys {
 		compatible = "gpio-keys";
 
-		wps {
+		button-0 {
 			label = "wps";
 			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
-		reset {
+		button-1 {
 			label = "reset";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;

--- a/target/linux/ramips/dts/mt7621_etisalat_s3.dts
+++ b/target/linux/ramips/dts/mt7621_etisalat_s3.dts
@@ -23,21 +23,18 @@
 		compatible = "gpio-leds";
 
 		led-0 {
-			label = "blue:wan";
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WAN;
 			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_status_green: led-1 {
-			label = "green:status";
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_STATUS;
 			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_status_red: led-2 {
-			label = "red:status";
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_STATUS;
 			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
@@ -47,13 +44,13 @@
 	keys {
 		compatible = "gpio-keys";
 
-		wps {
+		button-0 {
 			label = "wps";
 			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
-		reset {
+		button-1 {
 			label = "reset";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;

--- a/target/linux/ramips/dts/mt7621_sercomm_dxx_nand_256m.dtsi
+++ b/target/linux/ramips/dts/mt7621_sercomm_dxx_nand_256m.dtsi
@@ -19,22 +19,19 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led-1 {
-			label = "blue:wan";
+		led-0 {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WAN;
 			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
 		};
 
-		led_status_green: led-0 {
-			label = "green:status";
+		led_status_green: led-1 {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_STATUS;
 			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_status_red: led-2 {
-			label = "red:status";
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_STATUS;
 			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
@@ -44,13 +41,13 @@
 	keys {
 		compatible = "gpio-keys";
 
-		wps {
+		button-0 {
 			label = "wps";
 			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
-		reset {
+		button-1 {
 			label = "reset";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;

--- a/target/linux/ramips/dts/mt7621_sercomm_s1500.dtsi
+++ b/target/linux/ramips/dts/mt7621_sercomm_s1500.dtsi
@@ -110,7 +110,7 @@
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_WLAN;
 			function-enumerator = <24>;
-			linux,default-trigger = "phy1radio";
+			linux,default-trigger = "phy1tpt";
 			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
 		};
 
@@ -130,7 +130,7 @@
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_WLAN;
 			function-enumerator = <50>;
-			linux,default-trigger = "phy0radio";
+			linux,default-trigger = "phy0tpt";
 			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7621_sercomm_s1500.dtsi
+++ b/target/linux/ramips/dts/mt7621_sercomm_s1500.dtsi
@@ -17,13 +17,13 @@
 	keys {
 		compatible = "gpio-keys";
 
-		reset {
+		button-0 {
 			label = "reset";
 			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 
-		wps {
+		button-1 {
 			label = "wps";
 			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
@@ -34,33 +34,29 @@
 		compatible = "gpio-leds";
 
 		led-0 {
-			label = "amber:lan4";
 			color = <LED_COLOR_ID_AMBER>;
 			function = LED_FUNCTION_LAN;
-			function-enumerator = <0>;
+			function-enumerator = <4>;
 			linux,default-trigger = "mt7530-0:00:1Gbps";
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 		};
 
 		led-1 {
-			label = "green:lan4";
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_LAN;
-			function-enumerator = <1>;
+			function-enumerator = <4>;
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
 		};
 
 		led-2 {
-			label = "amber:lan3";
 			color = <LED_COLOR_ID_AMBER>;
 			function = LED_FUNCTION_LAN;
-			function-enumerator = <2>;
+			function-enumerator = <3>;
 			linux,default-trigger = "mt7530-0:01:1Gbps";
 			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
 		};
 
 		led-3 {
-			label = "green:lan3";
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_LAN;
 			function-enumerator = <3>;
@@ -68,85 +64,72 @@
 		};
 
 		led-4 {
-			label = "amber:lan2";
 			color = <LED_COLOR_ID_AMBER>;
 			function = LED_FUNCTION_LAN;
-			function-enumerator = <4>;
+			function-enumerator = <2>;
 			linux,default-trigger = "mt7530-0:02:1Gbps";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
 		led-5 {
-			label = "amber:lan1";
 			color = <LED_COLOR_ID_AMBER>;
 			function = LED_FUNCTION_LAN;
-			function-enumerator = <5>;
+			function-enumerator = <1>;
 			linux,default-trigger = "mt7530-0:03:1Gbps";
 			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
 		};
 
 		led-6 {
-			label = "green:lan1";
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_LAN;
-			function-enumerator = <6>;
+			function-enumerator = <1>;
 			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
 		};
 
 		led-7 {
-			label = "amber:wan";
 			color = <LED_COLOR_ID_AMBER>;
 			function = LED_FUNCTION_WAN;
-			function-enumerator = <0>;
 			linux,default-trigger = "mt7530-0:04:1Gbps";
 			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
 		};
 
 		led-8 {
-			label = "green:wan";
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WAN;
-			function-enumerator = <1>;
 			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
 		};
 
 		led-9 {
-			label = "green:lan2";
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_LAN;
-			function-enumerator = <7>;
+			function-enumerator = <2>;
 			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
 		};
 
 		led-10 {
-			label = "white:wlan2g";
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_WLAN;
-			function-enumerator = <0>;
+			function-enumerator = <24>;
 			linux,default-trigger = "phy1radio";
 			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
 		};
 
 		led_wps: led-11 {
 			function = LED_FUNCTION_WPS;
-			function-enumerator = <0>;
 			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
 			panic-indicator;
 		};
 
 		led_status: led-12 {
-			label = "white:status";
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_STATUS;
-			function-enumerator = <0>;
 			gpios = <&gpio 30 GPIO_ACTIVE_LOW>;
 		};
 
 		led-13 {
-			label = "white:wlan5g";
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_WLAN;
-			function-enumerator = <1>;
+			function-enumerator = <50>;
 			linux,default-trigger = "phy0radio";
 			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
 		};

--- a/target/linux/ramips/dts/mt7621_tplink_ec330-g5u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_ec330-g5u-v1.dts
@@ -29,67 +29,54 @@
 		led-0 {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_USB;
-			function-enumerator = <0>;
 			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&xhci_ehci_port1>;
 			linux,default-trigger = "usbport";
 		};
 
 		led-1 {
-			label = "blue:wps";
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WPS;
-			function-enumerator = <0>;
 			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
 		};
 
 		led-2 {
-			label = "blue:ethernet";
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_LAN;
-			function-enumerator = <0>;
 			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
 		};
 
 		led-3 {
-			label = "amber:internet";
 			color = <LED_COLOR_ID_AMBER>;
 			function = LED_FUNCTION_WAN;
-			function-enumerator = <0>;
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
 
 		led-4 {
-			label = "blue:internet";
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WAN;
-			function-enumerator = <1>;
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
 		led-5 {
-			label = "blue:wireless_5g";
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WLAN;
-			function-enumerator = <0>;
+			function-enumerator = <50>;
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy1tpt";
 		};
 
 		led-6 {
-			label = "blue:wireless_2g";
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WLAN;
-			function-enumerator = <1>;
+			function-enumerator = <24>;
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
 
 		led_power: led-7 {
-			label = "blue:power";
 			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_STATUS;
-			function-enumerator = <0>;
+			function = LED_FUNCTION_POWER;
 			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
 		};
 	};
@@ -97,28 +84,28 @@
 	keys {
 		compatible = "gpio-keys";
 
-		led {
+		button-0 {
 			label = "led";
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 			linux,code = <KEY_LIGHTS_TOGGLE>;
 		};
 
-		wifi {
+		button-1 {
 			label = "wifi on/off";
 			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 			linux,code = <KEY_RFKILL>;
 		};
 
-		reset {
+		button-2 {
 			label = "reset";
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 			linux,code = <KEY_RESTART>;
 		};
 
-		wps {
+		button-3 {
 			label = "wps";
 			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;

--- a/target/linux/ramips/dts/mt7621_wifire_s1500-nbn.dts
+++ b/target/linux/ramips/dts/mt7621_wifire_s1500-nbn.dts
@@ -28,7 +28,6 @@
 };
 
 &led_wps {
-	label = "white:wps";
 	color = <LED_COLOR_ID_WHITE>;
 };
 

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1093,6 +1093,8 @@ define Device/etisalat_s3
   SERCOMM_SWVER := 4009
   DEVICE_VENDOR := Etisalat
   DEVICE_MODEL := S3
+  DEVICE_ALT0_VENDOR := Sercomm
+  DEVICE_ALT0_MODEL := S3
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3
 endef
 TARGET_DEVICES += etisalat_s3

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -48,10 +48,10 @@ rostelecom,rt-sf-1)
 	;;
 beeline,smartbox-pro|\
 wifire,s1500-nbn)
-	ucidef_set_led_netdev "lan1" "lan1" "green:lan1" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan2" "lan2" "green:lan2" "lan2" "link tx rx"
-	ucidef_set_led_netdev "lan3" "lan3" "green:lan3" "lan3" "link tx rx"
-	ucidef_set_led_netdev "lan4" "lan4" "green:lan4" "lan4" "link tx rx"
+	ucidef_set_led_netdev "lan1" "lan1" "green:lan-1" "lan1" "link tx rx"
+	ucidef_set_led_netdev "lan2" "lan2" "green:lan-2" "lan2" "link tx rx"
+	ucidef_set_led_netdev "lan3" "lan3" "green:lan-3" "lan3" "link tx rx"
+	ucidef_set_led_netdev "lan4" "lan4" "green:lan-4" "lan4" "link tx rx"
 	ucidef_set_led_netdev "wan"  "wan"  "green:wan"  "wan"  "link tx rx"
 	;;
 belkin,rt1800)
@@ -202,9 +202,9 @@ tplink,deco-m4r-v4)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "br-lan"
 	;;
 tplink,ec330-g5u-v1)
-	ucidef_set_led_netdev "lan" "Ethernet" "blue:ethernet" "br-lan" "link tx rx"
-	ucidef_set_led_netdev "wan" "Internet" "blue:internet" "wan" "link tx rx"
-	ucidef_set_led_netdev "wan-off" "Internet-off" "amber:internet" "wan" "link"
+	ucidef_set_led_netdev "lan" "Ethernet" "blue:lan" "br-lan" "link tx rx"
+	ucidef_set_led_netdev "wan" "Internet" "blue:wan" "wan" "link tx rx"
+	ucidef_set_led_netdev "wan-off" "Internet-off" "amber:wan" "wan" "link"
 	;;
 tplink,re350-v1)
 	ucidef_set_led_netdev "wifi2g" "Wifi 2.4G" "blue:wifi2G" "wlan0"


### PR DESCRIPTION
1. **ramips: update leds & buttons dts description** (this is a follow-up after https://github.com/openwrt/openwrt/pull/13837)

      - Removes deprecated "label" property from the dts leds subnnodes;
      - Updates buttons and leds dts description according to kernel docs examples.
      
      Scope: devices well known to me.

2. **ramips: sercomm s1500: enable wlan LEDs activity blinking**

      - This commit enables wireless LEDs activity blinking for Sercomm S1500
 devices (Beeline Smartbox PRO, WiFire s1500.nbn).

3. **ramips: add alternative name to Etisalat (Sercomm) S3**