### PR TITLE
mediatek: Add support for GL.iNet X3000 (Spitz AX) and XE3000 (Puli AX)

### DIFF
--- a/target/linux/mediatek/dts/mt7981a-glinet-gl-x3000-xe3000-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981a-glinet-gl-x3000-xe3000-common.dtsi
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "mt7981.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8 root=PARTLABEL=rootfs rootwait";
+	};
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	fan_5v: regulator-fan-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fan";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&pio 28 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		hub_power {
+			gpio-export,name = "hub_power";
+			gpio-export,output = <1>;
+			gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		5G_power {
+			gpio-export,name = "5G_power";
+			gpio-export,output = <1>;
+			gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		5G_control {
+			gpio-export,name = "5G_control";
+			gpio-export,output = <1>;
+			gpios = <&pio 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		5G_reset {
+			gpio-export,name = "5G_reset";
+			gpio-export,output = <0>;
+			gpios = <&pio 10 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wifi2g {
+			label = "green:wifi2g";
+			gpios = <&pio 30 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi5g {
+			label = "green:wifi5g";
+			gpios = <&pio 38 GPIO_ACTIVE_LOW>;
+		};
+
+		5g_led1 {
+			label = "green:5g:led1";
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		5g_led2 {
+			label = "green:5g:led2";
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		5g_led3 {
+			label = "green:5g:led3";
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		5g_led4 {
+			label = "green:5g:led4";
+			gpios = <&pio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&pio 31 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&mmc0 {
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc0_pins_default>;
+	pinctrl-1 = <&mmc0_pins_uhs>;
+	bus-width = <8>;
+	max-frequency = <52000000>;
+	cap-mmc-highspeed;
+	vmmc-supply = <&reg_3p3v>;
+	non-removable;
+	status = "okay";
+
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		block {
+			compatible = "block-device";
+			partitions {
+				block-partition-env {
+					partname = "u-boot-env";
+
+					nvmem-layout {
+						compatible = "u-boot,env-layout";
+					};
+				};
+
+				block-partition-factory {
+					partname = "factory";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						eeprom_factory_0: eeprom@0 {
+							reg = <0x0 0x1000>;
+						};
+
+						macaddr_factory_a: macaddr@a {
+							compatible = "mac-base";
+							reg = <0xa 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+					};
+				};
+			};
+		};
+	};
+};
+
+&mdio_bus {
+	reset-gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <600>;
+	reset-post-delay-us = <20000>;
+
+	phy5: ethernet-phy@5 {
+		reg = <5>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy5>;
+		nvmem-cells = <&macaddr_factory_a 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		nvmem-cells = <&macaddr_factory_a 1>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&pio {
+	mmc0_pins_default: mmc0-pins-default {
+		mux {
+			function = "flash";
+			groups = "emmc_8";
+		};
+	};
+	mmc0_pins_uhs: mmc0-pins-uhs {
+		mux {
+			function = "flash";
+			groups = "emmc_8";
+		};
+	};
+	pcie_pins: pcie-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie_pereset", "pcie_clk", "pcie_wake";
+		};
+	};
+	pwm0_pin: pwm0-pin-g0 {
+		mux {
+			function = "pwm";
+			groups = "pwm0_1";
+		};
+	};
+};
+
+&xhci {
+	phys = <&u2port0 PHY_TYPE_USB2>;
+	vbus-supply = <&reg_5v>;
+	mediatek,u3p-dis-msk = <0x01>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&pcie {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie_pins>;
+	status = "okay";
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm0_pin>;
+};
+
+&wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	status = "okay";
+};
+
+&fan {
+	pwms = <&pwm 0 40000 0>;
+	fan-supply = <&fan_5v>;
+	interrupt-parent = <&pio>;
+	interrupts = <29 IRQ_TYPE_EDGE_RISING>;
+	status = "okay";
+};

--- a/target/linux/mediatek/dts/mt7981a-glinet-gl-x3000.dts
+++ b/target/linux/mediatek/dts/mt7981a-glinet-gl-x3000.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7981a-glinet-gl-x3000-xe3000-common.dtsi"
+
+/ {
+	model = "GL.iNet GL-X3000";
+	compatible = "glinet,gl-x3000", "mediatek,mt7981";
+};

--- a/target/linux/mediatek/dts/mt7981a-glinet-gl-xe3000.dts
+++ b/target/linux/mediatek/dts/mt7981a-glinet-gl-xe3000.dts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7981a-glinet-gl-x3000-xe3000-common.dtsi"
+
+/ {
+	model = "GL.iNet GL-XE3000";
+	compatible = "glinet,gl-xe3000", "mediatek,mt7981";
+};
+
+&uart1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart1_pins>;
+	status = "okay";
+};
+
+&pio {
+	uart1_pins: uart1-pins-g1 {
+		mux {
+			function = "uart";
+			groups = "uart1_3";
+		};
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -32,6 +32,17 @@ cudy,re3000-v1)
 cudy,wr3000-v1)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
 	;;
+glinet,gl-x3000|\
+glinet,gl-xe3000)
+	ucidef_set_led_default "power" "POWER" "green:power" "1"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0"
+	ucidef_set_led_netdev "5g_1" "5G_1" "green:5g:led1" "wwan0"
+	ucidef_set_led_netdev "5g_2" "5G_2" "green:5g:led2" "wwan0"
+	ucidef_set_led_netdev "5g_3" "5G_3" "green:5g:led3" "wwan0"
+	ucidef_set_led_netdev "5g_4" "5G_4" "green:5g:led4" "wwan0"
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wifi2g" "phy0-ap0"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wifi5g" "phy1-ap0"
+	;;
 mercusys,mr90x-v1)
 	ucidef_set_led_netdev "lan-0" "lan-0" "green:lan-0" "lan0" "link tx rx"
 	ucidef_set_led_netdev "lan-1" "lan-1" "green:lan-1" "lan1" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -50,7 +50,9 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan1" eth1
 		;;
 	glinet,gl-mt2500|\
-	glinet,gl-mt3000)
+	glinet,gl-mt3000|\
+	glinet,gl-x3000|\
+	glinet,gl-xe3000)
 		ucidef_set_interfaces_lan_wan eth1 eth0
 		;;
 	glinet,gl-mt6000|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -74,7 +74,9 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $addr 1) > /sys${DEVPATH}/macaddress
 		;;
-	glinet,gl-mt6000)
+	glinet,gl-mt6000|\
+	glinet,gl-x3000|\
+	glinet,gl-xe3000)
 		addr=$(mmc_get_mac_binary factory 0x04)
 		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -120,7 +120,9 @@ platform_do_upgrade() {
 		default_do_upgrade "$1"
 		;;
 	glinet,gl-mt2500|\
-	glinet,gl-mt6000)
+	glinet,gl-mt6000|\
+	glinet,gl-x3000|\
+	glinet,gl-xe3000)
 		CI_KERNPART="kernel"
 		CI_ROOTPART="rootfs"
 		emmc_do_upgrade "$1"
@@ -216,6 +218,8 @@ platform_copy_config() {
 	acer,predator-w6|\
 	glinet,gl-mt2500|\
 	glinet,gl-mt6000|\
+	glinet,gl-x3000|\
+	glinet,gl-xe3000|\
 	jdcloud,re-cp-03|\
 	ubnt,unifi-6-plus)
 		emmc_copy_config

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -535,6 +535,31 @@ define Device/glinet_gl-mt6000
 endef
 TARGET_DEVICES += glinet_gl-mt6000
 
+define Device/glinet_gl-x3000-xe3000-common
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7981-firmware mt7981-wo-firmware mkf2fs \
+    kmod-fs-f2fs kmod-hwmon-pwmfan kmod-usb3 kmod-usb-serial-option \
+    kmod-usb-storage kmod-usb-net-qmi-wwan uqmi
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+
+define Device/glinet_gl-x3000
+  DEVICE_MODEL := GL-X3000
+  DEVICE_DTS := mt7981a-glinet-gl-x3000
+  SUPPORTED_DEVICES := glinet,gl-x3000
+  $(call Device/glinet_gl-x3000-xe3000-common)
+endef
+TARGET_DEVICES += glinet_gl-x3000
+
+define Device/glinet_gl-xe3000
+  DEVICE_MODEL := GL-XE3000
+  DEVICE_DTS := mt7981a-glinet-gl-xe3000
+  SUPPORTED_DEVICES := glinet,gl-xe3000
+  $(call Device/glinet_gl-x3000-xe3000-common)
+endef
+TARGET_DEVICES += glinet_gl-xe3000
+
 define Device/h3c_magic-nx30-pro
   DEVICE_VENDOR := H3C
   DEVICE_MODEL := Magic NX30 Pro

--- a/target/linux/mediatek/patches-6.1/253-pinctrl-mediatek-mt7981-add-additional-uart-group.patch
+++ b/target/linux/mediatek/patches-6.1/253-pinctrl-mediatek-mt7981-add-additional-uart-group.patch
@@ -1,0 +1,63 @@
+From patchwork Wed Jan 17 12:42:33 2024
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Jean Thomas <jean.thomas@wifirst.fr>
+X-Patchwork-Id: 13521682
+Return-Path:
+ <linux-mediatek-bounces+linux-mediatek=archiver.kernel.org@lists.infradead.org>
+From: Jean Thomas <jean.thomas@wifirst.fr>
+To: sean.wang@kernel.org,
+	linus.walleij@linaro.org,
+	matthias.bgg@gmail.com,
+	angelogioacchino.delregno@collabora.com,
+	linux-mediatek@lists.infradead.org,
+	linux-gpio@vger.kernel.org,
+	linux-kernel@vger.kernel.org,
+	linux-arm-kernel@lists.infradead.org
+Cc: Jean Thomas <jean.thomas@wifirst.fr>
+Subject: [PATCH 1/2] pinctrl: mediatek: mt7981: add additional uart group
+Date: Wed, 17 Jan 2024 13:42:33 +0100
+Message-Id: <20240117124234.3137050-1-jean.thomas@wifirst.fr>
+MIME-Version: 1.0
+List-Id: <linux-mediatek.lists.infradead.org>
+
+Add uart1_3 (pins 26, 27) group to the pinctrl driver for the
+MediaTek MT7981 SoC.
+
+Signed-off-by: Jean Thomas <jean.thomas@wifirst.fr>
+Reviewed-by: Daniel Golle <daniel@makrotopia.org>
+---
+ drivers/pinctrl/mediatek/pinctrl-mt7981.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+--- a/drivers/pinctrl/mediatek/pinctrl-mt7981.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mt7981.c
+@@ -737,6 +737,9 @@ static int mt7981_uart1_1_funcs[] = { 2,
+ static int mt7981_uart1_2_pins[] = { 9, 10, };
+ static int mt7981_uart1_2_funcs[] = { 2, 2, };
+ 
++static int mt7981_uart1_3_pins[] = { 26, 27, };
++static int mt7981_uart1_3_funcs[] = { 2, 2, };
++
+ /* UART2 */
+ static int mt7981_uart2_1_pins[] = { 22, 23, 24, 25, };
+ static int mt7981_uart2_1_funcs[] = { 3, 3, 3, 3, };
+@@ -871,6 +874,8 @@ static const struct group_desc mt7981_gr
+ 	PINCTRL_PIN_GROUP("uart1_1", mt7981_uart1_1),
+ 	/* @GPIO(9,10): UART1(2) */
+ 	PINCTRL_PIN_GROUP("uart1_2", mt7981_uart1_2),
++	/* @GPIO(26,27): UART1(2) */
++	PINCTRL_PIN_GROUP("uart1_3", mt7981_uart1_3),
+ 	/* @GPIO(22,25): UART1(3) */
+ 	PINCTRL_PIN_GROUP("uart2_1", mt7981_uart2_1),
+ 	/* @GPIO(22,24) PTA_EXT(4) */
+@@ -933,7 +938,7 @@ static const struct group_desc mt7981_gr
+ static const char *mt7981_wa_aice_groups[] = { "wa_aice1", "wa_aice2", "wm_aice1_1",
+ 	"wa_aice3", "wm_aice1_2", };
+ static const char *mt7981_uart_groups[] = { "net_wo0_uart_txd_0", "net_wo0_uart_txd_1",
+-	"net_wo0_uart_txd_2", "uart0", "uart1_0", "uart1_1", "uart1_2", "uart2_0",
++	"net_wo0_uart_txd_2", "uart0", "uart1_0", "uart1_1", "uart1_2", "uart1_3", "uart2_0",
+ 	"uart2_0_tx_rx", "uart2_1", "wm_uart_0", "wm_aurt_1", "wm_aurt_2", };
+ static const char *mt7981_dfd_groups[] = { "dfd", "dfd_ntrst", };
+ static const char *mt7981_wdt_groups[] = { "watchdog", "watchdog1", };

--- a/target/linux/mediatek/patches-6.1/254-pinctrl-mediatek-mt7981-add-additional-emmc-group.patch
+++ b/target/linux/mediatek/patches-6.1/254-pinctrl-mediatek-mt7981-add-additional-emmc-group.patch
@@ -1,0 +1,82 @@
+From patchwork Wed Jan 17 14:55:47 2024
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Jean Thomas <jean.thomas@wifirst.fr>
+X-Patchwork-Id: 13521855
+Return-Path:
+ <linux-mediatek-bounces+linux-mediatek=archiver.kernel.org@lists.infradead.org>
+From: Jean Thomas <jean.thomas@wifirst.fr>
+To: sean.wang@kernel.org,
+	linus.walleij@linaro.org,
+	matthias.bgg@gmail.com,
+	angelogioacchino.delregno@collabora.com,
+	linux-mediatek@lists.infradead.org,
+	linux-gpio@vger.kernel.org,
+	linux-kernel@vger.kernel.org,
+	linux-arm-kernel@lists.infradead.org
+Cc: Jean Thomas <jean.thomas@wifirst.fr>,
+	Daniel Golle <daniel@makrotopia.org>
+Subject: [PATCH v2 2/2] pinctrl: mediatek: mt7981: add additional emmc groups
+Date: Wed, 17 Jan 2024 15:55:47 +0100
+Message-Id: <20240117145547.3354242-1-jean.thomas@wifirst.fr>
+List-Id: <linux-mediatek.lists.infradead.org>
+
+Add new emmc groups in the pinctrl driver for the
+MediaTek MT7981 SoC:
+* emmc reset, with pin 15.
+* emmc 4-bit bus-width, with pins 16 to 19, and 24 to 25.
+* emmc 8-bit bus-width, with pins 16 to 25.
+
+The existing emmc_45 group is kept for legacy reasons, even
+if this is the union of emmc_reset and emmc_8 groups.
+
+Signed-off-by: Jean Thomas <jean.thomas@wifirst.fr>
+Reviewed-by: Daniel Golle <daniel@makrotopia.org>
+---
+ drivers/pinctrl/mediatek/pinctrl-mt7981.c | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+--
+2.39.2
+
+--- a/drivers/pinctrl/mediatek/pinctrl-mt7981.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mt7981.c
+@@ -700,6 +700,15 @@ static int mt7981_drv_vbus_pins[] = { 14
+ static int mt7981_drv_vbus_funcs[] = { 1, };
+ 
+ /* EMMC */
++static int mt7981_emmc_reset_pins[] = { 15, };
++static int mt7981_emmc_reset_funcs[] = { 2, };
++
++static int mt7981_emmc_4_pins[] = { 16, 17, 18, 19, 24, 25, };
++static int mt7981_emmc_4_funcs[] = { 2, 2, 2, 2, 2, 2, };
++
++static int mt7981_emmc_8_pins[] = { 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, };
++static int mt7981_emmc_8_funcs[] = { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, };
++
+ static int mt7981_emmc_45_pins[] = { 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, };
+ static int mt7981_emmc_45_funcs[] = { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, };
+ 
+@@ -854,6 +863,12 @@ static const struct group_desc mt7981_gr
+ 	PINCTRL_PIN_GROUP("udi", mt7981_udi),
+ 	/* @GPIO(14) DRV_VBUS(1) */
+ 	PINCTRL_PIN_GROUP("drv_vbus", mt7981_drv_vbus),
++	/* @GPIO(15): EMMC_RSTB(2) */
++	PINCTRL_PIN_GROUP("emmc_reset", mt7981_emmc_reset),
++	/* @GPIO(16,17,18,19,24,25): EMMC_DATx, EMMC_CLK, EMMC_CMD */
++	PINCTRL_PIN_GROUP("emmc_4", mt7981_emmc_4),
++	/* @GPIO(16,17,18,19,20,21,22,23,24,25): EMMC_DATx, EMMC_CLK, EMMC_CMD */
++	PINCTRL_PIN_GROUP("emmc_8", mt7981_emmc_8),
+ 	/* @GPIO(15,25): EMMC(2) */
+ 	PINCTRL_PIN_GROUP("emmc_45", mt7981_emmc_45),
+ 	/* @GPIO(16,21): SNFI(3) */
+@@ -957,7 +972,7 @@ static const char *mt7981_i2c_groups[] =
+ static const char *mt7981_pcm_groups[] = { "pcm", };
+ static const char *mt7981_udi_groups[] = { "udi", };
+ static const char *mt7981_usb_groups[] = { "drv_vbus", };
+-static const char *mt7981_flash_groups[] = { "emmc_45", "snfi", };
++static const char *mt7981_flash_groups[] = { "emmc_reset", "emmc_4", "emmc_8", "emmc_45", "snfi", };
+ static const char *mt7981_ethernet_groups[] = { "smi_mdc_mdio", "gbe_ext_mdc_mdio",
+ 	"wf0_mode1", "wf0_mode3", "mt7531_int", };
+ static const char *mt7981_ant_groups[] = { "ant_sel", };

--- a/target/linux/mediatek/patches-6.6/253-pinctrl-mediatek-mt7981-add-additional-uart-group.patch
+++ b/target/linux/mediatek/patches-6.6/253-pinctrl-mediatek-mt7981-add-additional-uart-group.patch
@@ -1,0 +1,63 @@
+From patchwork Wed Jan 17 12:42:33 2024
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Jean Thomas <jean.thomas@wifirst.fr>
+X-Patchwork-Id: 13521682
+Return-Path:
+ <linux-mediatek-bounces+linux-mediatek=archiver.kernel.org@lists.infradead.org>
+From: Jean Thomas <jean.thomas@wifirst.fr>
+To: sean.wang@kernel.org,
+	linus.walleij@linaro.org,
+	matthias.bgg@gmail.com,
+	angelogioacchino.delregno@collabora.com,
+	linux-mediatek@lists.infradead.org,
+	linux-gpio@vger.kernel.org,
+	linux-kernel@vger.kernel.org,
+	linux-arm-kernel@lists.infradead.org
+Cc: Jean Thomas <jean.thomas@wifirst.fr>
+Subject: [PATCH 1/2] pinctrl: mediatek: mt7981: add additional uart group
+Date: Wed, 17 Jan 2024 13:42:33 +0100
+Message-Id: <20240117124234.3137050-1-jean.thomas@wifirst.fr>
+MIME-Version: 1.0
+List-Id: <linux-mediatek.lists.infradead.org>
+
+Add uart1_3 (pins 26, 27) group to the pinctrl driver for the
+MediaTek MT7981 SoC.
+
+Signed-off-by: Jean Thomas <jean.thomas@wifirst.fr>
+Reviewed-by: Daniel Golle <daniel@makrotopia.org>
+---
+ drivers/pinctrl/mediatek/pinctrl-mt7981.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+--- a/drivers/pinctrl/mediatek/pinctrl-mt7981.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mt7981.c
+@@ -737,6 +737,9 @@ static int mt7981_uart1_1_funcs[] = { 2,
+ static int mt7981_uart1_2_pins[] = { 9, 10, };
+ static int mt7981_uart1_2_funcs[] = { 2, 2, };
+ 
++static int mt7981_uart1_3_pins[] = { 26, 27, };
++static int mt7981_uart1_3_funcs[] = { 2, 2, };
++
+ /* UART2 */
+ static int mt7981_uart2_1_pins[] = { 22, 23, 24, 25, };
+ static int mt7981_uart2_1_funcs[] = { 3, 3, 3, 3, };
+@@ -871,6 +874,8 @@ static const struct group_desc mt7981_gr
+ 	PINCTRL_PIN_GROUP("uart1_1", mt7981_uart1_1),
+ 	/* @GPIO(9,10): UART1(2) */
+ 	PINCTRL_PIN_GROUP("uart1_2", mt7981_uart1_2),
++	/* @GPIO(26,27): UART1(2) */
++	PINCTRL_PIN_GROUP("uart1_3", mt7981_uart1_3),
+ 	/* @GPIO(22,25): UART1(3) */
+ 	PINCTRL_PIN_GROUP("uart2_1", mt7981_uart2_1),
+ 	/* @GPIO(22,24) PTA_EXT(4) */
+@@ -933,7 +938,7 @@ static const struct group_desc mt7981_gr
+ static const char *mt7981_wa_aice_groups[] = { "wa_aice1", "wa_aice2", "wm_aice1_1",
+ 	"wa_aice3", "wm_aice1_2", };
+ static const char *mt7981_uart_groups[] = { "net_wo0_uart_txd_0", "net_wo0_uart_txd_1",
+-	"net_wo0_uart_txd_2", "uart0", "uart1_0", "uart1_1", "uart1_2", "uart2_0",
++	"net_wo0_uart_txd_2", "uart0", "uart1_0", "uart1_1", "uart1_2", "uart1_3", "uart2_0",
+ 	"uart2_0_tx_rx", "uart2_1", "wm_uart_0", "wm_aurt_1", "wm_aurt_2", };
+ static const char *mt7981_dfd_groups[] = { "dfd", "dfd_ntrst", };
+ static const char *mt7981_wdt_groups[] = { "watchdog", "watchdog1", };

--- a/target/linux/mediatek/patches-6.6/254-pinctrl-mediatek-mt7981-add-additional-emmc-group.patch
+++ b/target/linux/mediatek/patches-6.6/254-pinctrl-mediatek-mt7981-add-additional-emmc-group.patch
@@ -1,0 +1,82 @@
+From patchwork Wed Jan 17 14:55:47 2024
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Jean Thomas <jean.thomas@wifirst.fr>
+X-Patchwork-Id: 13521855
+Return-Path:
+ <linux-mediatek-bounces+linux-mediatek=archiver.kernel.org@lists.infradead.org>
+From: Jean Thomas <jean.thomas@wifirst.fr>
+To: sean.wang@kernel.org,
+	linus.walleij@linaro.org,
+	matthias.bgg@gmail.com,
+	angelogioacchino.delregno@collabora.com,
+	linux-mediatek@lists.infradead.org,
+	linux-gpio@vger.kernel.org,
+	linux-kernel@vger.kernel.org,
+	linux-arm-kernel@lists.infradead.org
+Cc: Jean Thomas <jean.thomas@wifirst.fr>,
+	Daniel Golle <daniel@makrotopia.org>
+Subject: [PATCH v2 2/2] pinctrl: mediatek: mt7981: add additional emmc groups
+Date: Wed, 17 Jan 2024 15:55:47 +0100
+Message-Id: <20240117145547.3354242-1-jean.thomas@wifirst.fr>
+List-Id: <linux-mediatek.lists.infradead.org>
+
+Add new emmc groups in the pinctrl driver for the
+MediaTek MT7981 SoC:
+* emmc reset, with pin 15.
+* emmc 4-bit bus-width, with pins 16 to 19, and 24 to 25.
+* emmc 8-bit bus-width, with pins 16 to 25.
+
+The existing emmc_45 group is kept for legacy reasons, even
+if this is the union of emmc_reset and emmc_8 groups.
+
+Signed-off-by: Jean Thomas <jean.thomas@wifirst.fr>
+Reviewed-by: Daniel Golle <daniel@makrotopia.org>
+---
+ drivers/pinctrl/mediatek/pinctrl-mt7981.c | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+--
+2.39.2
+
+--- a/drivers/pinctrl/mediatek/pinctrl-mt7981.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mt7981.c
+@@ -700,6 +700,15 @@ static int mt7981_drv_vbus_pins[] = { 14
+ static int mt7981_drv_vbus_funcs[] = { 1, };
+ 
+ /* EMMC */
++static int mt7981_emmc_reset_pins[] = { 15, };
++static int mt7981_emmc_reset_funcs[] = { 2, };
++
++static int mt7981_emmc_4_pins[] = { 16, 17, 18, 19, 24, 25, };
++static int mt7981_emmc_4_funcs[] = { 2, 2, 2, 2, 2, 2, };
++
++static int mt7981_emmc_8_pins[] = { 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, };
++static int mt7981_emmc_8_funcs[] = { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, };
++
+ static int mt7981_emmc_45_pins[] = { 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, };
+ static int mt7981_emmc_45_funcs[] = { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, };
+ 
+@@ -854,6 +863,12 @@ static const struct group_desc mt7981_gr
+ 	PINCTRL_PIN_GROUP("udi", mt7981_udi),
+ 	/* @GPIO(14) DRV_VBUS(1) */
+ 	PINCTRL_PIN_GROUP("drv_vbus", mt7981_drv_vbus),
++	/* @GPIO(15): EMMC_RSTB(2) */
++	PINCTRL_PIN_GROUP("emmc_reset", mt7981_emmc_reset),
++	/* @GPIO(16,17,18,19,24,25): EMMC_DATx, EMMC_CLK, EMMC_CMD */
++	PINCTRL_PIN_GROUP("emmc_4", mt7981_emmc_4),
++	/* @GPIO(16,17,18,19,20,21,22,23,24,25): EMMC_DATx, EMMC_CLK, EMMC_CMD */
++	PINCTRL_PIN_GROUP("emmc_8", mt7981_emmc_8),
+ 	/* @GPIO(15,25): EMMC(2) */
+ 	PINCTRL_PIN_GROUP("emmc_45", mt7981_emmc_45),
+ 	/* @GPIO(16,21): SNFI(3) */
+@@ -957,7 +972,7 @@ static const char *mt7981_i2c_groups[] =
+ static const char *mt7981_pcm_groups[] = { "pcm", };
+ static const char *mt7981_udi_groups[] = { "udi", };
+ static const char *mt7981_usb_groups[] = { "drv_vbus", };
+-static const char *mt7981_flash_groups[] = { "emmc_45", "snfi", };
++static const char *mt7981_flash_groups[] = { "emmc_reset", "emmc_4", "emmc_8", "emmc_45", "snfi", };
+ static const char *mt7981_ethernet_groups[] = { "smi_mdc_mdio", "gbe_ext_mdc_mdio",
+ 	"wf0_mode1", "wf0_mode3", "mt7531_int", };
+ static const char *mt7981_ant_groups[] = { "ant_sel", };


### PR DESCRIPTION
The GL.iNet X3000 and XE3000 are Wi-Fi 6 5G cellular routers, based on MediaTek MT7981A SoC. The XE3000 is the same device as the X3000, except for an additional battery.

Specifications:
 - SoC: Filogic 820 MT7981A (1.3GHz)
 - RAM: DDR4 512M
 - Flash: eMMC 8G, MicroSD card slot
 - WiFi: 2.4GHz and 5GHz with 6 antennas
 - Ethernet:
   - 1x LAN (10/100/1000M)
   - 1x WAN (10/100/1000/2500M)
 - 5G: Quectel RM520N-GL with two nano-SIM card slots
 - USB: 1x USB 2.0 port
 - UART:
   - 3.3V, TX, RX, GND / 115200 8N1

MAC addresses as verified by OEM firmware:
vendor   OpenWrt    address     source
WAN      eth0       label       factory 0x0a (label)
LAN      eth1       label + 1
2g       phy0-ap0   label + 2   factory 0x04
5g       phy1-ap0   label + 3

Installation via U-Boot rescue:
1. Press and hold reset button while booting the device
2. Wait for the Internet led to blink 5 times
3. Release reset button
4. The rescue page is accessible via http://192.168.1.1
5. Select the OpenWrt sysupgrade image and start upgrade
6. Wait for the router to flash new firmware and reboot

Revert to stock firmware:
1. Download the stock firmware from GL.iNet website
2. Use the method explained above to flash the stock firmware

Switch the modem network port to the USB interface:
1. Connect to the AT commands (/dev/ttyUSB2) port using e.g. minicom: minicom -D /dev/ttyUSB2
2. Check the modem mode with 'AT+QCFG="data_interface"':
  - 0,0 indicates that the network port uses the PCIe interface
  - 1,0 indicates that the network port uses the USB interface
3. Switch to the USB interface if necessary with 'AT+QCFG="data_interface",0,0', and reboot