### PR TITLE
ramips: lzma-loader: use virtual memory segments for uart base address

### DIFF
--- a/target/linux/ramips/image/lzma-loader/src/board.c
+++ b/target/linux/ramips/image/lzma-loader/src/board.c
@@ -40,7 +40,7 @@
 #define UART_LSR			(UART_BASE + 0x14)
 #define UART_LSR_MASK			UART_LSR_THRE
 #elif defined(SOC_RT305X)
-#define UART_BASE			KSEG1ADDR(0x10000500)
+#define UART_BASE			KSEG1ADDR(0x10000c00)
 #define UART_THR			(UART_BASE + 0x04)
 #define UART_LSR			(UART_BASE + 0x1c)
 #define UART_LSR_MASK			UART_LSR_THRE

--- a/target/linux/ramips/image/lzma-loader/src/board.c
+++ b/target/linux/ramips/image/lzma-loader/src/board.c
@@ -11,19 +11,33 @@
  */
 
 #include <stdint.h>
+#include <stddef.h>
+
+#define KSEG0			0x80000000
+#define KSEG1			0xa0000000
+
+#define _ATYPE_ 		__PTRDIFF_TYPE__
+#define _ATYPE32_		int
+
+#define _ACAST32_		(_ATYPE_)(_ATYPE32_)
+
+#define CPHYSADDR(a)		((_ACAST32_(a)) & 0x1fffffff)
+
+#define KSEG0ADDR(a)		(CPHYSADDR(a) | KSEG0)
+#define KSEG1ADDR(a)		(CPHYSADDR(a) | KSEG1)
 
 #if defined(SOC_MT7620) || defined(SOC_RT3883)
-#define UART_BASE			0xb0000c00
+#define UART_BASE			KSEG1ADDR(0x10000c00)
 #define UART_THR			(UART_BASE + 0x04)
 #define UART_LSR			(UART_BASE + 0x1c)
 #define UART_LSR_THRE_MASK	0x40
 #elif defined(SOC_MT7621)
-#define UART_BASE			0xbe000c00
+#define UART_BASE			KSEG1ADDR(0x1e000c00)
 #define UART_THR			(UART_BASE + 0x00)
 #define UART_LSR			(UART_BASE + 0x14)
 #define UART_LSR_THRE_MASK	0x20
 #elif defined(SOC_RT305X)
-#define UART_BASE			0x10000500
+#define UART_BASE			KSEG1ADDR(0x10000500)
 #define UART_THR			(UART_BASE + 0x04)
 #define UART_LSR			(UART_BASE + 0x1c)
 #define UART_LSR_THRE_MASK	0x20

--- a/target/linux/ramips/image/lzma-loader/src/board.c
+++ b/target/linux/ramips/image/lzma-loader/src/board.c
@@ -26,21 +26,24 @@
 #define KSEG0ADDR(a)		(CPHYSADDR(a) | KSEG0)
 #define KSEG1ADDR(a)		(CPHYSADDR(a) | KSEG1)
 
+#define UART_LSR_THRE		0x20
+#define UART_LSR_TEMT		0x40
+
 #if defined(SOC_MT7620) || defined(SOC_RT3883)
 #define UART_BASE			KSEG1ADDR(0x10000c00)
 #define UART_THR			(UART_BASE + 0x04)
 #define UART_LSR			(UART_BASE + 0x1c)
-#define UART_LSR_THRE_MASK	0x40
+#define UART_LSR_MASK			UART_LSR_TEMT
 #elif defined(SOC_MT7621)
 #define UART_BASE			KSEG1ADDR(0x1e000c00)
 #define UART_THR			(UART_BASE + 0x00)
 #define UART_LSR			(UART_BASE + 0x14)
-#define UART_LSR_THRE_MASK	0x20
+#define UART_LSR_MASK			UART_LSR_THRE
 #elif defined(SOC_RT305X)
 #define UART_BASE			KSEG1ADDR(0x10000500)
 #define UART_THR			(UART_BASE + 0x04)
 #define UART_LSR			(UART_BASE + 0x1c)
-#define UART_LSR_THRE_MASK	0x20
+#define UART_LSR_MASK			UART_LSR_THRE
 #else
 #error "Unsupported SOC..."
 #endif
@@ -56,7 +59,7 @@ void board_init(void)
 
 void board_putc(int ch)
 {
-	while ((READREG(UART_LSR) & UART_LSR_THRE_MASK) == 0);
+	while ((READREG(UART_LSR) & UART_LSR_MASK) == 0);
 	WRITEREG(UART_THR, ch);
-	while ((READREG(UART_LSR) & UART_LSR_THRE_MASK) == 0);
+	while ((READREG(UART_LSR) & UART_LSR_MASK) == 0);
 }


### PR DESCRIPTION
The native bus address for UART was entered for rt305x UART_BASE, but the bootloaders have memory space remapped with the same virtual memory map the kernel uses for program addressing at boot time.

In UBoot, the remapped address is often defined as TEXT_BASE. In the kernel, for rt305x this remapped address is RT305X_SYSC_BASE. (arch/mips/include/asm/mach-ralink/rt305x.h)

Because the ralink I/O busses begin at a low address of 0x10000000, they are remapped using KSEG0 or KSEG1, which for all 32-bit MIPS SOCs (arch/mips/include/asm/addrspace.h)
are offsets of 0x80000000 and 0xa0000000 respectively. This is consistent with the other UART_BASE macros here and with MIPS memory map documentation.

Before the recent rework of the lzma-loader for ramips, the original board-$(PLATFORM).c files also did not use KSEG1ADDR for UART_BASE despite being defined, which made this mistake easier to occur.

Fix this by defining KSEG1ADDR again and actually use it. Copy and paste from the kernel's macros for consistency.

Link: https://training.mips.com/basic_mips/PDF/Memory_Map.pdf