### PR TITLE
ipq806x: Fix nighthawk R7800/XR450/XR500 wan MAC

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-nighthawk.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-nighthawk.dtsi
@@ -427,7 +427,7 @@
 	pinctrl-0 = <&rgmii2_pins>;
 	pinctrl-names = "default";
 
-	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cells = <&macaddr_art_6 0>;
 	nvmem-cell-names = "mac-address";
 
 	fixed-link {


### PR DESCRIPTION
Correct the NVMEM mac-base field usage to read the wan MAC correctly from flash. 
(The mac-base field needs always an offset)

Before this fix, the wan MAC is a random one. Other MACs are read correctly.

Reference to discussion at 
* https://github.com/openwrt/openwrt/pull/13952#issuecomment-1842749122
* https://forum.openwrt.org/t/build-for-netgear-r7800/316/3808?u=hnyman

Fixes: d264d3a60 ("ipq806x: remove mac-address-increment")
