### PR TITLE
mediatek: add SPDX header for Confiabits MT7981 DTS

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-confiabits-mt7981.dts
+++ b/target/linux/mediatek/dts/mt7981b-confiabits-mt7981.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
 /dts-v1/;
 
 #include "mt7981.dtsi"


### PR DESCRIPTION
Fixing ambiguous licensing.

Original PR: #13609 