### PR TITLE
[23.05] ramips: add support for Rostelecom RT-FE-1A

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -43,6 +43,7 @@ beeline,smartbox-giga|\
 beeline,smartbox-turbo|\
 beeline,smartbox-turbo-plus|\
 etisalat,s3|\
+rostelecom,rt-fe-1a|\
 rostelecom,rt-sf-1)
 	ubootenv_add_uci_config "/dev/mtd0" "0x80000" "0x1000" "0x20000"
 	;;

--- a/target/linux/ramips/dts/mt7621_rostelecom_rt-fe-1a.dts
+++ b/target/linux/ramips/dts/mt7621_rostelecom_rt-fe-1a.dts
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "rostelecom,rt-fe-1a", "mediatek,mt7621-soc";
+	model = "Rostelecom RT-FE-1A";
+
+	aliases {
+		label-mac-device = &gmac0;
+
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <50>;
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <24>;
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_status_green: led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-0 {
+			label = "wps";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		button-1 {
+			label = "reset";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1 &ubiconcat2 \
+			   &ubiconcat3>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x5420000>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "sercomm,sc-partitions", "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x100000>;
+			sercomm,scpart-id = <0>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "dynamic partition map";
+			reg = <0x100000 0x100000>;
+			sercomm,scpart-id = <1>;
+			read-only;
+		};
+
+		partition@200000 {
+			label = "Factory";
+			reg = <0x200000 0x100000>;
+			sercomm,scpart-id = <2>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_2g: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				eeprom_5g: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				macaddr_label: macaddr@21000 {
+					compatible = "mac-base";
+					reg = <0x21000 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition@300000 {
+			label = "Boot Flag";
+			reg = <0x300000 0x100000>;
+			sercomm,scpart-id = <3>;
+		};
+
+		partition@400000 {
+			label = "kernel";
+			reg = <0x400000 0x600000>;
+			sercomm,scpart-id = <4>;
+		};
+
+		partition@a00000 {
+			label = "Kernel 2";
+			reg = <0xa00000 0x600000>;
+			sercomm,scpart-id = <5>;
+			read-only;
+		};
+
+		ubiconcat0: partition@1000000 {
+			label = "File System 1";
+			reg = <0x1000000 0x1800000>;
+			sercomm,scpart-id = <6>;
+		};
+
+		partition@2800000 {
+			label = "File System 2";
+			reg = <0x2800000 0x1800000>;
+			sercomm,scpart-id = <7>;
+			read-only;
+		};
+
+		ubiconcat1: partition@4000000 {
+			label = "Configuration/log";
+			reg = <0x4000000 0x800000>;
+			sercomm,scpart-id = <8>;
+		};
+
+		ubiconcat2: partition@4800000 {
+			label = "application tmp buffer (Ftool)";
+			reg = <0x4800000 0xc00000>;
+			sercomm,scpart-id = <9>;
+		};
+
+		ubiconcat3: partition@5400000 {
+			label = "free space (in stock firmware)";
+			reg = <0x5400000 0x2820000>;
+			sercomm,scpart-id = <10>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		nvmem-cells = <&eeprom_5g>, <&macaddr_label 3>;
+		nvmem-cell-names = "eeprom", "mac-address";
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		nvmem-cells = <&eeprom_2g>, <&macaddr_label 2>;
+		nvmem-cell-names = "eeprom", "mac-address";
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_label 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_label 11>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	ethphy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1947,6 +1947,20 @@ define Device/renkforce_ws-wn530hp3-a
 endef
 TARGET_DEVICES += renkforce_ws-wn530hp3-a
 
+define Device/rostelecom_rt-fe-1a
+  $(Device/sercomm_dxx)
+  IMAGE_SIZE := 24576k
+  SERCOMM_HWID := CX4
+  SERCOMM_HWVER := 11300
+  SERCOMM_SWVER := 2010
+  DEVICE_VENDOR := Rostelecom
+  DEVICE_MODEL := RT-FE-1A
+  DEVICE_ALT0_VENDOR := Sercomm
+  DEVICE_ALT0_MODEL := RT-FE-1A
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware
+endef
+TARGET_DEVICES += rostelecom_rt-fe-1a
+
 define Device/rostelecom_rt-sf-1
   $(Device/sercomm_dxx)
   IMAGE_SIZE := 32768k

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -102,6 +102,7 @@ platform_do_upgrade() {
 	netgear,wax202|\
 	netis,wf2881|\
 	raisecom,msg1500-x-00|\
+	rostelecom,rt-fe-1a|\
 	rostelecom,rt-sf-1|\
 	sercomm,na502|\
 	sercomm,na502s|\


### PR DESCRIPTION
Rostelecom RT-FE-1A is a wireless WiFi 5 router manufactured by Sercomm company.

Device specification
--------------------
```
SoC Type: MediaTek MT7621AT
RAM: 256 MiB
Flash: 128 MiB
Wireless 2.4 GHz (MT7603EN): b/g/n, 2x2
Wireless 5 GHz (MT7615E): a/n/ac, 4x4
Ethernet: 5x GbE (WAN, LAN1, LAN2, LAN3, LAN4)
USB ports: No
Button: 2 buttons (Reset & WPS)
LEDs:
   - 1x Power (green, unmanaged)
   - 1x Status (green, gpio)
   - 1x 2.4G (green, hardware, mt76-phy0)
   - 1x 2.4G (blue, gpio)
   - 1x 5G (green, hardware, mt76-phy1)
   - 1x 5G (blue, gpio)
   - 5x Ethernet (green, hardware, 4x LAN & WAN) Power: 12 VDC, 1.5 A
Connector type: barrel
Bootloader: U-Boot
```
