### PR TITLE
util-linux: update to v2.39.3

### DIFF
--- a/package/utils/util-linux/Makefile
+++ b/package/utils/util-linux/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=util-linux
-PKG_VERSION:=2.39.2
+PKG_VERSION:=2.39.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/$(PKG_NAME)/v2.39
-PKG_HASH:=87abdfaa8e490f8be6dde976f7c80b9b5ff9f301e1b67e3899e1f05a59a1531f
+PKG_HASH:=7b6605e48d1a49f43cc4b4cfc59f313d0dd5402fa40b96810bd572e167dfed0f
 PKG_CPE_ID:=cpe:/a:kernel:util-linux
 
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
```
Changes:
2da5c904e build-sys: release++ (v2.39.3)
03c939edd docs: update v2.39.3-ReleaseNotes
dafb120ef docs: update AUTHORS file
bfc9691ce po-man: merge changes
d2232b609 po: merge changes
4ab356c1c po: add ro.po (from translationproject.org)
7e147d16c po: update es.po (from translationproject.org)
e8cb61f07 lsfd: fix memory leak in append_filter_expr()
192d8aaa0 lsfd: avoid undefined behavior
756588f8c lsfd: (man) fix the form for the optional argument of --inet option
8d78c1306 Add Phytium FTC310 & FTC664 support
b75322cdb Add Phytium FTC862 cpu model. fix:https://github.com/openwrt/openwrt/pull/2486
ec1b0eb36 libmount: accept '\' as escape for options separator
2e5f5c8d8 tests: add ts_skip_docker
0b3254cac Merge branch 'stable-2.39/bcachefs-fixes' of https://github.com/t-8ch/util-linux into PR/stable-v2.39.3
649843934 tests: skip broken tests on docker
fa9b53658 libblkid: (bcachefs) add support for sub-device labels
3c5d991b0 libblkid: (bcachefs) adapt to major.minor version
ece194082 libuuid: avoid truncate clocks.txt to improve performance
84a62c1a5 libuuid/src/gen_uuid.c: fix cs_min declaration
93239aa78 libmount: fix possible NULL dereference [coverity scan]
a6def815e meson: install wall executable with group 'tty'
c6c1c69c3 meson: install write executable with group 'tty'
bf2cd1d5a libmount: improve mnt_table_next_child_fs()
c14f5bf37 docs: add SPDX to boilerplate.c
fdd9f11f5 disk-utils: add SPDX and Copyright notices
e7dbe9c78 include/audit-arch: add missing SPDX
5ec7b14a7 setterm: avoid restoring flags from uninitialized memory
64d2300e6 Fix man page for col to correct documentation error
7cc2c9625 Update col.c to fix option mistake
122d7e7af umount: handle bindmounts during --recursive
da18b31ff lscpu: fix caches separator for --parse=<list>
3a5c9c1dd Use empty libuser config file.
7058d793d libblkid: exfat: fix fail to find volume label
d065ff00a blkpr: store return value of getopt_long in int
9ca6f1712 lib/path: Set errno in case of fgets failure
e2f0aa5c2 autotools: fix AC_DEFINE_UNQUOTED() use
cefd05c47 autotools: fix librtas check
f27fbafb2 lib/path: fix typos
f8ab70477 lib/path: set errno in case of error
5ec30a362 lib/path: fix possible out of boundary access
edc723cd3 libblkid: reset errno before calling probefuncs
8de89778b setpriv: fix group argument completion
41599054c libfdisk: reset errno before calling read()
cce4e4405 blkid: fix call to err_exclusive_options
b718f985c docs: use HTTPS for GitHub clone URLs
2bddfa692 libblkid: (probe) handle probe without chain gracefully
3d3121678 lib/idcache: always gracefully handle null cache
368521e45 script-playutils: close filestream in case ignore_line() fails
087b0d238 libblkid: (vxfs) report endianness
7e5056f33 libblkid: (ntfs) validate that sector_size is a power of two
f368ccc75 libsmartcols: handle nameless tables in export format
f5cace8da ldattach: don't call exit() from signal handler
03c12a34c lslogins: fix realloc() loop allocation size
83ba179b1 lib/env: avoid underflow of read_all_alloc() return value
813851fba libblkid: avoid memory leak of cachefile path
4459623cd libmount: gracefully handle NULL path in mnt_resolve_target()
dbde7a537 more: avoid out-of-bound access
c26badd5d libfdisk: handle allocation failure in fdisk_new_partition
5c250aa64 login: Use pid_t for child_pid
be3f1712e login: move comment
98be90b5b build-sys: fix libmount/src/hooks.c use
a711af02d lscpu: Use 4K buffer size instead of BUFSIZ
45c6136cb autotools: fix typos
aa98c4ecc libmount: make.stx_mnt_id use more robust
c697c2bb6 libmount: report statx in features list
13711f3ab libmount: fix statx() includes
e9ed5a2b8 libblkid: (vfat) avoid modifying shared buffer
d2cadf099 libblkid: (jmicron_raid) use checksum APIs
c54c99efd libblkid: (jmicron_raid) avoid modifying shared buffer
64418c52b libblkid: (zonefs) avoid modifying shared buffer
b66da7ce4 losetup: fix JSON MAJ:MIN
44d7bf2c8 lslogins: (man) fix -y option formatting
7d6c71e51 include: add DragonFlyBSD GPT partition types
6b9fda87c libblkid: (bcachefs) fix size validation
acbf17ae8 libblkid: (bcachefs) fix compiler warning [-Werror=sign-compare]
1ec71634a libblkid: (bcachefs) fix not detecting large superblocks
68564ebb5 libmount: Fix regression when mounting with atime
```