### PR TITLE
dropbear: use dropbearkey as ssh-keygen

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dropbear
 PKG_VERSION:=2022.83
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \
@@ -57,7 +57,7 @@ define Package/dropbear
   CATEGORY:=Base system
   TITLE:=Small SSH2 client/server
   DEPENDS:= +DROPBEAR_ZLIB:zlib
-  ALTERNATIVES:=
+  ALTERNATIVES:=100:/usr/bin/ssh-keygen:/usr/sbin/dropbear
   $(if $(CONFIG_DROPBEAR_SCP),ALTERNATIVES+= \
 	  100:/usr/bin/scp:/usr/sbin/dropbear,)
   $(if $(CONFIG_DROPBEAR_DBCLIENT),ALTERNATIVES+= \


### PR DESCRIPTION
By default the OpenWrt is compiled with DropBear's clone of the OpenSSH `ssh-keygen` called [dropbearkey](https://manpages.ubuntu.com/manpages/noble/en/man1/dropbearkey.1.html). But it can be compiled with the OpenSSH client instead of the dropbear. 

Their commands differs that's why on the wiki page [Generating public and private keys](https://openwrt.org/docs/guide-user/security/dropbear.public-key.auth) we have two versions.

When developing luci-app-sshtunnel I added a button to generate a new key pair. And I had to add a [check](https://github.com/openwrt/luci/blob/master/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js#L115C12-L115C12
): use the ssh-keygen by default but if it absent then use the dropbearkey.

Their commands also differs because flags `-q -N ''` wasn't supported by dropbearkey but this is fixed now. So we can now safely make an alias `ssh-keygen` to the `dropbearkey`.
Then users can use same commands in their scripts, have a better interoperability, reuse an old knowledge and not waste time to find a proper command to generate a cert with the dropbearkey.

The PR will create a symlink from `ssh-keygen` to `dropbear`. The DropBear should recognize the `ssh-keygen` programs and it's author is fine to add this support https://github.com/mkj/dropbear/issues/263

Then we'll need to add an alternative for the `openssh-keygen` so on installation it will substitute the DropBear's `ssh-keygen` with own. https://github.com/openwrt/packages/commit/9a3d317e151b77c63746a922806f2c7011d22668

Please confirm that you are fine with the change and will accept the PR. If yes, then I'll make a PR to the dropbear and openssh-keygen.
