### PR TITLE
dnsmasq: fix dnsmasq.init crash-loops with anonymous tags, add match_tag field

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.90
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -461,16 +461,17 @@ dhcp_tag_add() {
 	# NOTE: dnsmasq has explicit "option6:" prefix for DHCPv6 so no collisions
 	local cfg="$1"
 
-	tag="$cfg"
-
-	[ -n "$tag" ] || return 0
+	config_get match_tag "$cfg" match_tag
+	[ -n "$match_tag" ] || match_tag="$cfg"
+	# Try older 'named' tag syntax
+	[ -n "$match_tag" ] || return 0
 
 	config_get_bool force "$cfg" force 0
 	[ "$force" = "0" ] && force=
 
 	config_get option "$cfg" dhcp_option
 	for o in $option; do
-		xappend "--dhcp-option${force:+-force}=tag:$tag,$o"
+		xappend "--dhcp-option${force:+-force}=tag:$match_tag,$o"
 	done
 }
 


### PR DESCRIPTION
Instead of just exiting and causing dnsmasq to crashloop, prefer the tag name from property "match_tag". Allow anonymous tag sections.

If no match_tag, defer to the tag name, failing that, bail.


@pprindeville Is there some weird shell magic I've overlooked?

