### PR TITLE
busybox: enable DHCP relay applet

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -2696,7 +2696,7 @@ config BUSYBOX_DEFAULT_DUMPLEASES
 	default n
 config BUSYBOX_DEFAULT_DHCPRELAY
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_UDHCPC
 	bool
 	default y


### PR DESCRIPTION
With the ISC DHCP software being discontinued another simple and small option for DHCP relay is needed.

Kea is too big for embedded platforms and their limited RAM and flash image capacity and dnsmasq requires too much (non-Luci-supported even) configuration changes to make it simply a DHCP relay.  A simpler solution is needed.

Just as the Busybox `udhcpc` applet is a nice small and simple DHCP client for embedded devices, the Busybox DHCP relay applet is a nice small and simple DHCP relay solution for embedded devices.