### PR TITLE
mt7621: grab macaddr straight from u-boot-env

### DIFF
--- a/target/linux/ramips/dts/mt7621_edimax_rx21s.dtsi
+++ b/target/linux/ramips/dts/mt7621_edimax_rx21s.dtsi
@@ -78,6 +78,13 @@
 				label = "u-boot-env";
 				reg = <0x30000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_uboot_ethaddr: ethaddr {
+					};
+				};
 			};
 
 			partition@40000 {
@@ -160,21 +167,33 @@
 		port@1 {
 			status = "okay";
 			label = "lan4";
+
+			nvmem-cells = <&macaddr_uboot_ethaddr>;
+			nvmem-cell-names = "mac-address";
 		};
 
 		port@2 {
 			status = "okay";
 			label = "lan3";
+
+			nvmem-cells = <&macaddr_uboot_ethaddr>;
+			nvmem-cell-names = "mac-address";
 		};
 
 		port@3 {
 			status = "okay";
 			label = "lan2";
+
+			nvmem-cells = <&macaddr_uboot_ethaddr>;
+			nvmem-cell-names = "mac-address";
 		};
 
 		port@4 {
 			status = "okay";
 			label = "lan1";
+
+			nvmem-cells = <&macaddr_uboot_ethaddr>;
+			nvmem-cell-names = "mac-address";
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533ghbk.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533ghbk.dtsi
@@ -12,6 +12,7 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
+		label-mac-device = &gmac1;
 	};
 
 	leds {
@@ -109,6 +110,12 @@
 						reg = <0x0 0x4da8>;
 					};
 
+					macaddr_factory_4: mac-address@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
 					eeprom_factory_8000: eeprom@8000 {
 						reg = <0x8000 0x4da8>;
 					};
@@ -118,10 +125,18 @@
 	};
 };
 
+&gmac0 {
+	nvmem-cells = <&eeprom_factory_0 (-1)>;
+	nvmem-cell-names = "mac-address";
+};
+
 &gmac1 {
 	status = "okay";
 	label = "wan";
 	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&eeprom_factory_0 (-2)>;
+	nvmem-cell-names = "mac-address";
 };
 
 &ethphy0 {

--- a/target/linux/ramips/dts/mt7621_h3c_tx180x.dtsi
+++ b/target/linux/ramips/dts/mt7621_h3c_tx180x.dtsi
@@ -8,6 +8,7 @@
 
 / {
 	aliases {
+		label-mac-device = &gmac1;
 		led-boot = &led_status_amber;
 		led-failsafe = &led_status_green;
 		led-running = &led_status_green;
@@ -52,10 +53,18 @@
 	};
 };
 
+&gmac0 {
+	nvmem-cells = <&macaddr_uboot_ethaddr 1>;
+	nvmem-cell-names = "mac-address";
+};
+
 &gmac1 {
 	status = "okay";
 	label = "wan";
 	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_uboot_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &ethphy4 {
@@ -84,6 +93,15 @@
 		partition@80000 {
 			label = "u-boot-env";
 			reg = <0x0080000 0x0080000>;
+
+			nvmem-layout {
+				compatible = "u-boot,env";
+				env-size = <0x20000>;
+
+				macaddr_uboot_ethaddr: ethaddr {
+					#nvmem-cell-cells = <1>;
+				};
+			};
 		};
 
 		partition@100000 {

--- a/target/linux/ramips/dts/mt7621_iptime_t5004.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_t5004.dts
@@ -55,6 +55,15 @@
 		partition@80000 {
 			label = "u-boot-env";
 			reg = <0x80000 0xc0000>;
+
+			nvmem-layout {
+				compatible = "u-boot,env";
+				env-size = <0x1000>;
+
+				macaddr_uboot_ethaddr: ethaddr {
+					#nvmem-cell-cells = <1>;
+				};
+			};
 		};
 
 		partition@140000 {
@@ -85,10 +94,18 @@
 	};
 };
 
+&gmac0 {
+	nvmem-cells = <&macaddr_uboot_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
 &gmac1 {
 	status = "okay";
 	label = "wan";
 	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_uboot_ethaddr 1>;
+	nvmem-cell-names = "mac-address";
 };
 
 &ethphy0 {

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -274,10 +274,6 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		label_mac=$wan_mac
 		;;
-	iptime,t5004)
-		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
-		wan_mac=$(macaddr_add "$lan_mac" 1)
-		;;
 	jdcloud,re-sp-01b)
 		lan_mac=$(mtd_get_mac_ascii config mac)
 		wan_mac=$lan_mac

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -261,7 +261,6 @@ ramips_setup_macs()
 		;;
 	edimax,ra21s|\
 	edimax,rg21s)
-		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		;;
 	elecom,wrc-2533ghbk2-t|\

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -270,13 +270,6 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		label_mac=$wan_mac
 		;;
-	h3c,tx1800-plus|\
-	h3c,tx1801-plus|\
-	h3c,tx1806)
-		label_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
-		lan_mac=$(macaddr_add "$label_mac" 1)
-		wan_mac=$label_mac
-		;;
 	iodata,wnpr2600g)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		label_mac=$wan_mac

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -263,12 +263,6 @@ ramips_setup_macs()
 	edimax,rg21s)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		;;
-	elecom,wrc-2533ghbk2-t|\
-	elecom,wrc-2533ghbk-i)
-		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
-		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
-		label_mac=$wan_mac
-		;;
 	iodata,wnpr2600g)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		label_mac=$wan_mac


### PR DESCRIPTION
Avoids userspace handling.

not sure if this is even correct. ping @DragonBluep @rmilecki 

@musashino205 can you test if this works on that iodata device?