### PR TITLE
devel/gdb: Update to version 14.1 (and import mpfr from packages feed)

### DIFF
--- a/package/devel/gdb/Makefile
+++ b/package/devel/gdb/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gdb
-PKG_VERSION:=13.2
-PKG_RELEASE:=2
+PKG_VERSION:=14.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/gdb
-PKG_HASH:=fd5bebb7be1833abdb6e023c2f498a354498281df9d05523d8915babeb893f0a
+PKG_HASH:=d66df51276143451fcbff464cc8723d68f1e9df45a6a2d5635a54e71643edb80
 
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -33,7 +33,7 @@ endef
 define Package/gdb
 $(call Package/gdb/Default)
   TITLE:=GNU Debugger
-  DEPENDS+=+libreadline +libncurses +zlib +libgmp
+  DEPENDS+=+libreadline +libncurses +zlib +libgmp +libmpfr
 endef
 
 define Package/gdb/description
@@ -64,8 +64,6 @@ CONFIGURE_ARGS+= \
 	--disable-sim \
 	--disable-werror \
 	--disable-source-highlight \
-	--without-mpc \
-	--without-mpfr \
 	--without-isl \
 	--without-xxhash \
 	--with-libgmp-prefix=$(STAGING_DIR)/usr

--- a/package/devel/gdb/patches/110-shared_libgcc.patch
+++ b/package/devel/gdb/patches/110-shared_libgcc.patch
@@ -1,6 +1,6 @@
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1435,13 +1435,13 @@ if test -z "$LD"; then
+@@ -1400,13 +1400,13 @@ if test -z "$LD"; then
    fi
  fi
  
@@ -17,7 +17,7 @@
    AC_LANG_PUSH(C++)
    AC_LINK_IFELSE([AC_LANG_SOURCE([
  #if (__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 5)
-@@ -1838,7 +1838,7 @@ AC_ARG_WITH(stage1-ldflags,
+@@ -1836,7 +1836,7 @@ AC_ARG_WITH(stage1-ldflags,
   # trust that they are doing what they want.
   if test "$with_static_standard_libraries" = yes -a "$stage1_libs" = "" \
       -a "$have_static_libs" = yes; then
@@ -26,7 +26,7 @@
   fi])
  AC_SUBST(stage1_ldflags)
  
-@@ -1867,7 +1867,7 @@ AC_ARG_WITH(boot-ldflags,
+@@ -1865,7 +1865,7 @@ AC_ARG_WITH(boot-ldflags,
   # statically.  But if the user explicitly specified the libraries to
   # use, trust that they are doing what they want.
   if test "$poststage1_libs" = ""; then
@@ -37,7 +37,7 @@
  
 --- a/configure
 +++ b/configure
-@@ -5442,14 +5442,14 @@ if test -z "$LD"; then
+@@ -5413,14 +5413,14 @@ if test -z "$LD"; then
    fi
  fi
  
@@ -56,7 +56,7 @@
    ac_ext=cpp
  ac_cpp='$CXXCPP $CPPFLAGS'
  ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-@@ -8440,7 +8440,7 @@ else
+@@ -8464,7 +8464,7 @@ else
   # trust that they are doing what they want.
   if test "$with_static_standard_libraries" = yes -a "$stage1_libs" = "" \
       -a "$have_static_libs" = yes; then
@@ -65,7 +65,7 @@
   fi
  fi
  
-@@ -8476,7 +8476,7 @@ else
+@@ -8500,7 +8500,7 @@ else
   # statically.  But if the user explicitly specified the libraries to
   # use, trust that they are doing what they want.
   if test "$poststage1_libs" = ""; then

--- a/package/devel/gdb/patches/130-gdb-ctrl-c.patch
+++ b/package/devel/gdb/patches/130-gdb-ctrl-c.patch
@@ -24,7 +24,7 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
 
 --- a/gdbserver/linux-low.cc
 +++ b/gdbserver/linux-low.cc
-@@ -5467,7 +5467,7 @@ linux_process_target::request_interrupt
+@@ -5481,7 +5481,7 @@ linux_process_target::request_interrupt
  {
    /* Send a SIGINT to the process group.  This acts just like the user
       typed a ^C on the controlling terminal.  */

--- a/package/libs/mpfr/Makefile
+++ b/package/libs/mpfr/Makefile
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2023 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mpfr
+PKG_VERSION:=4.2.1
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=@GNU/mpfr http://www.mpfr.org/mpfr-$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_HASH:=277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2
+
+PKG_LICENSE:=LGPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING.LESSER
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_CPE_ID:=cpe:/a:mpfr:gnu_mpfr
+
+PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libmpfr
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=GNU MPFR library
+  URL:=https://www.mpfr.org/
+  DEPENDS:=+libgmp
+  ABI_VERSION:=6
+endef
+
+define Package/libmpfr/description
+MPFR is a portable library written in C for arbitrary precision
+arithmetic on floating-point numbers. It is based on the GNU MP library.
+It aims to provide a class of floating-point numbers with precise
+semantics.
+endef
+
+CONFIGURE_ARGS += \
+	--enable-thread-safe
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/mpf* $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmpfr.{a,so*} $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/mpfr.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libmpfr/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmpfr.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libmpfr))

--- a/package/libs/mpfr/patches/001-only-src.patch
+++ b/package/libs/mpfr/patches/001-only-src.patch
@@ -1,0 +1,22 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -38,7 +38,7 @@ AUTOMAKE_OPTIONS = gnu
+ # old Automake version.
+ ACLOCAL_AMFLAGS = -I m4
+ 
+-SUBDIRS = doc src tests tune tools/bench
++SUBDIRS = src
+ 
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = mpfr.pc
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -401,7 +401,7 @@ AUTOMAKE_OPTIONS = gnu
+ # libtoolize and in case some developer needs to switch back to an
+ # old Automake version.
+ ACLOCAL_AMFLAGS = -I m4
+-SUBDIRS = doc src tests tune tools/bench
++SUBDIRS = src
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = mpfr.pc
+ nobase_dist_doc_DATA = AUTHORS BUGS COPYING COPYING.LESSER NEWS TODO \


### PR DESCRIPTION
As the toolchain gdb was bumped to version 14.1 two days ago by @PolynomialDivision , also update the devel/gdb package to version 14.1. Import mpfr from packages feed, as it is now required by gdb.

* mpfr is now required, remove the 'without' and add a dependency
* remove mpc 'without' that is parsed wrongly as the directory "no", causing "-Lno/lib" and "-Ino/include" compile directives.
* refresh patches

Import mpfr from the packages feed.
(I can remove the mpfr from packages feed myself, once it has been imported into the main repo.)

Remote debugging run-tested with qualcommax/DL-WRX36


cc @PolynomialDivision  @jefferyto 

