### PR TITLE
lldpd: Init script update to support full range of supported LLDPD options

### DIFF
--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -83,7 +83,8 @@ ifneq ($(CONFIG_LLDPD_WITH_SONMP),y)
 	sed -i -e '/sonmp/d' $(1)/etc/config/lldpd
 endif
 ifneq ($(CONFIG_LLDPD_WITH_SNMP),y)
-	sed -i -e '/agentxsocket/d' $(1)/etc/init.d/lldpd $(1)/etc/config/lldpd
+	sed -i -e 's/CONFIG_LLDPD_WITH_SNMP=y/CONFIG_LLDPD_WITH_SNMP=n/g' $(1)/etc/init.d/lldpd
+	sed -i -e '/agentxsocket/d' $(1)/etc/config/lldpd
 endif
 ifneq ($(CONFIG_LLDPD_WITH_LLDPMED),y)
 	sed -i -e 's/CONFIG_LLDPD_WITH_LLDPMED=y/CONFIG_LLDPD_WITH_LLDPMED=n/g' $(1)/etc/init.d/lldpd

--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -68,7 +68,8 @@ define Package/lldpd/install
 	$(INSTALL_BIN) ./files/lldpd.init $(1)/etc/init.d/lldpd
 	$(INSTALL_CONF) ./files/lldpd.config $(1)/etc/config/lldpd
 ifneq ($(CONFIG_LLDPD_WITH_CDP),y)
-	sed -i -e '/cdp/d' $(1)/etc/init.d/lldpd $(1)/etc/config/lldpd
+	sed -i -e 's/CONFIG_LLDPD_WITH_CDP=y/CONFIG_LLDPD_WITH_CDP=n/g' $(1)/etc/init.d/lldpd
+	sed -i -e '/cdp/d' $(1)/etc/config/lldpd
 endif
 ifneq ($(CONFIG_LLDPD_WITH_FDP),y)
 	sed -i -e '/fdp/d' $(1)/etc/init.d/lldpd $(1)/etc/config/lldpd

--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lldpd
 PKG_VERSION:=1.0.17
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lldpd/lldpd/releases/download/$(PKG_VERSION)/

--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -82,6 +82,10 @@ endif
 ifneq ($(CONFIG_LLDPD_WITH_SNMP),y)
 	sed -i -e '/agentxsocket/d' $(1)/etc/init.d/lldpd $(1)/etc/config/lldpd
 endif
+ifneq ($(CONFIG_LLDPD_WITH_LLDPMED),y)
+	sed -i -e 's/CONFIG_LLDPD_WITH_LLDPMED=y/CONFIG_LLDPD_WITH_LLDPMED=n/g' $(1)/etc/init.d/lldpd
+	sed -i -e '/agentxsocket/d' $(1)/etc/config/lldpd
+endif
 endef
 
 define Package/lldpd/conffiles

--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -72,7 +72,8 @@ ifneq ($(CONFIG_LLDPD_WITH_CDP),y)
 	sed -i -e '/cdp/d' $(1)/etc/config/lldpd
 endif
 ifneq ($(CONFIG_LLDPD_WITH_FDP),y)
-	sed -i -e '/fdp/d' $(1)/etc/init.d/lldpd $(1)/etc/config/lldpd
+	sed -i -e 's/CONFIG_LLDPD_WITH_FDP=y/CONFIG_LLDPD_WITH_FDP=n/g' $(1)/etc/init.d/lldpd
+	sed -i -e '/fdp/d' $(1)/etc/config/lldpd
 endif
 ifneq ($(CONFIG_LLDPD_WITH_EDP),y)
 	sed -i -e '/edp/d' $(1)/etc/init.d/lldpd $(1)/etc/config/lldpd

--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -76,7 +76,8 @@ ifneq ($(CONFIG_LLDPD_WITH_FDP),y)
 	sed -i -e '/fdp/d' $(1)/etc/config/lldpd
 endif
 ifneq ($(CONFIG_LLDPD_WITH_EDP),y)
-	sed -i -e '/edp/d' $(1)/etc/init.d/lldpd $(1)/etc/config/lldpd
+	sed -i -e 's/CONFIG_LLDPD_WITH_EDP=y/CONFIG_LLDPD_WITH_EDP=n/g' $(1)/etc/init.d/lldpd
+	sed -i -e '/edp/d' $(1)/etc/config/lldpd
 endif
 ifneq ($(CONFIG_LLDPD_WITH_SONMP),y)
 	sed -i -e 's/CONFIG_LLDPD_WITH_SONMP=y/CONFIG_LLDPD_WITH_SONMP=n/g' $(1)/etc/init.d/lldpd

--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -79,7 +79,8 @@ ifneq ($(CONFIG_LLDPD_WITH_EDP),y)
 	sed -i -e '/edp/d' $(1)/etc/init.d/lldpd $(1)/etc/config/lldpd
 endif
 ifneq ($(CONFIG_LLDPD_WITH_SONMP),y)
-	sed -i -e '/sonmp/d' $(1)/etc/init.d/lldpd $(1)/etc/config/lldpd
+	sed -i -e 's/CONFIG_LLDPD_WITH_SONMP=y/CONFIG_LLDPD_WITH_SONMP=n/g' $(1)/etc/init.d/lldpd
+	sed -i -e '/sonmp/d' $(1)/etc/config/lldpd
 endif
 ifneq ($(CONFIG_LLDPD_WITH_SNMP),y)
 	sed -i -e '/agentxsocket/d' $(1)/etc/init.d/lldpd $(1)/etc/config/lldpd

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -105,6 +105,9 @@ write_lldpd_conf()
 	local lldp_agenttype
 	config_get lldp_agenttype 'config' 'lldp_agenttype' 'nearest-bridge'
 
+	local lldp_portidsubtype
+	config_get lldp_portidsubtype 'config' 'lldp_portidsubtype' 'macaddress'
+
 	# Clear out the config file first
 	echo -n > "$LLDPD_CONF"
 	[ -n "$ifnames" ] && echo "configure system interface pattern" "$ifnames" >> "$LLDPD_CONF"
@@ -120,7 +123,7 @@ write_lldpd_conf()
 		fi
 	fi
 	[ -n "$lldp_agenttype" ] && echo "configure lldp agent-type" "\"$lldp_agenttype\"" >> "$LLDPD_CONF"
-
+	[ -n "$lldp_portidsubtype" ] && echo "configure lldp portidsubtype" "\"$lldp_portidsubtype\"" >> "$LLDPD_CONF"
 
 	# Since lldpd's sysconfdir is /tmp, we'll symlink /etc/lldpd.d to /tmp/$LLDPD_CONFS_DIR
 	[ -e $LLDPD_CONFS_DIR ] || ln -s /etc/lldpd.d $LLDPD_CONFS_DIR

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -122,6 +122,9 @@ write_lldpd_conf()
 	local lldp_portidsubtype
 	config_get lldp_portidsubtype 'config' 'lldp_portidsubtype' 'macaddress'
 
+	local lldp_platform
+	config_get lldp_platform 'config' 'lldp_platform' ""
+
 	# Clear out the config file first
 	echo -n > "$LLDPD_CONF"
 	[ -n "$ifnames" ] && echo "configure system interface pattern" "$ifnames" >> "$LLDPD_CONF"
@@ -138,6 +141,7 @@ write_lldpd_conf()
 	fi
 	[ -n "$lldp_agenttype" ] && echo "configure lldp agent-type" "\"$lldp_agenttype\"" >> "$LLDPD_CONF"
 	[ -n "$lldp_portidsubtype" ] && echo "configure lldp portidsubtype" "\"$lldp_portidsubtype\"" >> "$LLDPD_CONF"
+	[ -n "$lldp_platform" ] && echo "configure system platform" "\"$lldp_platform\"" >> "$LLDPD_CONF"
 
 	# Since lldpd's sysconfdir is /tmp, we'll symlink /etc/lldpd.d to /tmp/$LLDPD_CONFS_DIR
 	[ -e $LLDPD_CONFS_DIR ] || ln -s /etc/lldpd.d $LLDPD_CONFS_DIR
@@ -307,6 +311,7 @@ reload_service() {
 		unconfigure system description
 		unconfigure system hostname
 		unconfigure system ip management pattern
+		unconfigure system platform
 	EOF
 	if [ "$CONFIG_LLDPD_WITH_LLDPMED" == "y" ]; then
 		$LLDPCLI -u $LLDPSOCKET &> /dev/null <<-EOF

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -43,6 +43,7 @@ get_config_restart_hash() {
 		config_get_bool v 'config' 'lldpmed_no_inventory'; append _string "$v" ","
 	fi
 	config_get_bool v 'config' 'enable_lldp' 1; append _string "$v" ","
+	config_get_bool v 'config' 'force_lldp'; append _string "$v" ","
 	config_get_bool v 'config' 'enable_cdp'; append _string "$v" ","
 	config_get_bool v 'config' 'enable_edp'; append _string "$v" ","
 	config_get_bool v 'config' 'enable_fdp'; append _string "$v" ","
@@ -131,6 +132,8 @@ write_lldpd_conf()
 
 start_service() {
 
+	local enable_lldp
+	local force_lldp
 	local enable_cdp
 	local enable_fdp
 	local enable_sonmp
@@ -144,6 +147,8 @@ start_service() {
 	local filter
 
 	config_load 'lldpd'
+	config_get_bool enable_lldp 'config' 'enable_lldp' 1
+	config_get_bool force_lldp 'config' 'force_lldp' 0
 	config_get_bool enable_cdp 'config' 'enable_cdp' 0
 	config_get_bool enable_fdp 'config' 'enable_fdp' 0
 	config_get_bool enable_sonmp 'config' 'enable_sonmp' 0
@@ -167,6 +172,15 @@ start_service() {
 	procd_open_instance
 	procd_set_param command ${LLDPDBIN}
 	procd_append_param command -d
+
+	if [ $enable_lldp -gt 0 ]; then
+		if [ $force_lldp -gt 0 ]; then
+			procd_append_param command '-l'
+		fi
+	else
+		# Disable LLDP
+		procd_append_param command '-ll'
+	fi
 
 	[ $enable_cdp -gt 0 ] && procd_append_param command '-c'
 	[ $enable_fdp -gt 0 ] && procd_append_param command '-f'

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -4,6 +4,7 @@
 START=90
 STOP=01
 
+CONFIG_LLDPD_WITH_CDP=y
 CONFIG_LLDPD_WITH_LLDPMED=y
 
 USE_PROCD=1
@@ -44,7 +45,12 @@ get_config_restart_hash() {
 	fi
 	config_get_bool v 'config' 'enable_lldp' 1; append _string "$v" ","
 	config_get_bool v 'config' 'force_lldp'; append _string "$v" ","
-	config_get_bool v 'config' 'enable_cdp'; append _string "$v" ","
+	if [ "$CONFIG_LLDPD_WITH_CDP" == "y" ]; then
+		config_get_bool v 'config' 'enable_cdp'; append _string "$v" ","
+		config_get      v 'config' 'cdp_version'; append _string "$v" ","
+		config_get_bool v 'config' 'force_cdp'; append _string "$v" ","
+		config_get_bool v 'config' 'force_cdpv2'; append _string "$v" ","
+	fi
 	config_get_bool v 'config' 'enable_edp'; append _string "$v" ","
 	config_get_bool v 'config' 'enable_fdp'; append _string "$v" ","
 	config_get_bool v 'config' 'enable_sonmp'; append _string "$v" ","
@@ -135,6 +141,9 @@ start_service() {
 	local enable_lldp
 	local force_lldp
 	local enable_cdp
+	local cdp_version
+	local force_cdp
+	local force_cdpv2
 	local enable_fdp
 	local enable_sonmp
 	local enable_edp
@@ -149,7 +158,12 @@ start_service() {
 	config_load 'lldpd'
 	config_get_bool enable_lldp 'config' 'enable_lldp' 1
 	config_get_bool force_lldp 'config' 'force_lldp' 0
-	config_get_bool enable_cdp 'config' 'enable_cdp' 0
+	if [ "$CONFIG_LLDPD_WITH_CDP" == "y" ]; then
+		config_get_bool enable_cdp 'config' 'enable_cdp' 0
+		config_get cdp_version 'config' 'cdp_version' 'cdpv1v2'
+		config_get_bool force_cdp 'config' 'force_cdp' 0
+		config_get_bool force_cdpv2 'config' 'force_cdpv2' 0
+	fi
 	config_get_bool enable_fdp 'config' 'enable_fdp' 0
 	config_get_bool enable_sonmp 'config' 'enable_sonmp' 0
 	config_get_bool enable_edp 'config' 'enable_edp' 0
@@ -182,12 +196,34 @@ start_service() {
 		procd_append_param command '-ll'
 	fi
 
-	[ $enable_cdp -gt 0 ] && procd_append_param command '-c'
+	if [ "$CONFIG_LLDPD_WITH_CDP" == "y" ] && [ $enable_cdp -gt 0 ]; then
+		if [ $cdp_version == "cdpv2" ]; then
+			if [ $force_cdp -gt 0 ]; then
+				# CDPv1 disabled, CDPv2 forced
+				procd_append_param command '-ccccc'
+			else
+				# CDPv1 disabled, CDPv2 enabled
+				procd_append_param command '-cccc'
+			fi
+		elif [ $cdp_version == "cdpv1v2" ]; then
+			if [ $force_cdp -gt 0 ] && [ $force_cdpv2 -gt 0 ]; then
+				# CDPv1 enabled, CDPv2 forced
+				procd_append_param command '-ccc'
+			elif [ $force_cdp -gt 0 ]; then
+				# CDPv1 forced, CDPv2 enabled
+				procd_append_param command '-cc'
+			else
+				# CDPv1 and CDPv2 enabled
+				procd_append_param command '-c'
+			fi
+		fi
+	fi
+
 	[ $enable_fdp -gt 0 ] && procd_append_param command '-f'
 	[ $enable_sonmp -gt 0 ] && procd_append_param command '-s'
 	[ $enable_edp -gt 0 ] && procd_append_param command '-e'
 	[ $readonly_mode -gt 0 ] && procd_append_param command '-r'
-	[ $lldp_no_version -gt 0 ] && procd_append_param command '-k'
+	[ $lldp_no_version -gt 0 ] && procd_append_param commanpackage/network/services/lldpd/Makefile package/network/services/lldpd/files/lldpd.initd '-k'
 	[ "$CONFIG_LLDPD_WITH_LLDPMED" == "y" ] && [ $lldpmed_no_inventory -gt 0 ] && procd_append_param command '-i'
 	[ -n "$lldp_class" ] && procd_append_param command -M "$lldp_class"
 	[ -n "$agentxsocket" ] && procd_append_param command -x -X "$agentxsocket"

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -4,6 +4,8 @@
 START=90
 STOP=01
 
+CONFIG_LLDPD_WITH_LLDPMED=y
+
 USE_PROCD=1
 LLDPDBIN=/usr/sbin/lldpd
 LLDPCLI=/usr/sbin/lldpcli
@@ -37,6 +39,9 @@ get_config_restart_hash() {
 	config_get      v 'config' 'filter'; append _string "$v" ","
 	config_get_bool v 'config' 'readonly_mode'; append _string "$v" ","
 	config_get_bool v 'config' 'lldp_no_version'; append _string "$v" ","
+	if [ "$CONFIG_LLDPD_WITH_LLDPMED" == "y" ]; then
+		config_get_bool v 'config' 'lldpmed_no_inventory'; append _string "$v" ","
+	fi
 	config_get_bool v 'config' 'enable_lldp' 1; append _string "$v" ","
 	config_get_bool v 'config' 'enable_cdp'; append _string "$v" ","
 	config_get_bool v 'config' 'enable_edp'; append _string "$v" ","
@@ -110,6 +115,7 @@ start_service() {
 	local lldp_class
 	local lldp_location
 	local lldp_no_version
+	local lldpmed_no_inventory
 	local readonly_mode
 	local agentxsocket
 	local filter
@@ -122,6 +128,9 @@ start_service() {
 	config_get lldp_class 'config' 'lldp_class'
 	config_get lldp_location 'config' 'lldp_location'
 	config_get_bool lldp_no_version 'config' 'lldp_no_version' 0
+	if [ "$CONFIG_LLDPD_WITH_LLDPMED" == "y" ]; then
+		config_get_bool lldpmed_no_inventory 'config' 'lldpmed_no_inventory' 0
+	fi
 	config_get_bool readonly_mode 'config' 'readonly_mode' 0
 	config_get agentxsocket 'config' 'agentxsocket'
 	config_get filter 'config' 'filter' 15
@@ -142,6 +151,7 @@ start_service() {
 	[ $enable_edp -gt 0 ] && procd_append_param command '-e'
 	[ $readonly_mode -gt 0 ] && procd_append_param command '-r'
 	[ $lldp_no_version -gt 0 ] && procd_append_param command '-k'
+	[ "$CONFIG_LLDPD_WITH_LLDPMED" == "y" ] && [ $lldpmed_no_inventory -gt 0 ] && procd_append_param command '-i'
 	[ -n "$lldp_class" ] && procd_append_param command -M "$lldp_class"
 	[ -n "$agentxsocket" ] && procd_append_param command -x -X "$agentxsocket"
 	[ -n "$filter" ] && procd_append_param command -H "$filter"

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -5,6 +5,7 @@ START=90
 STOP=01
 
 CONFIG_LLDPD_WITH_CDP=y
+CONFIG_LLDPD_WITH_EDP=y
 CONFIG_LLDPD_WITH_FDP=y
 CONFIG_LLDPD_WITH_LLDPMED=y
 CONFIG_LLDPD_WITH_SNMP=y
@@ -56,7 +57,10 @@ get_config_restart_hash() {
 		config_get_bool v 'config' 'force_cdp'; append _string "$v" ","
 		config_get_bool v 'config' 'force_cdpv2'; append _string "$v" ","
 	fi
-	config_get_bool v 'config' 'enable_edp'; append _string "$v" ","
+	if [ "$CONFIG_LLDPD_WITH_EDP" == "y" ]; then
+		config_get_bool v 'config' 'enable_edp'; append _string "$v" ","
+		config_get_bool v 'config' 'force_edp'; append _string "$v" ","
+	fi
 	if [ "$CONFIG_LLDPD_WITH_FDP" == "y" ]; then
 		config_get_bool v 'config' 'enable_fdp'; append _string "$v" ","
 		config_get_bool v 'config' 'force_fdp'; append _string "$v" ","
@@ -171,6 +175,7 @@ start_service() {
 	local enable_sonmp
 	local force_sonmp
 	local enable_edp
+	local force_edp
 	local lldp_class
 	local lldp_location
 	local lldp_no_version
@@ -196,7 +201,10 @@ start_service() {
 		config_get_bool enable_sonmp 'config' 'enable_sonmp' 0
 		config_get_bool force_sonmp 'config' 'force_sonmp' 0
 	fi
-	config_get_bool enable_edp 'config' 'enable_edp' 0
+	if [ "$CONFIG_LLDPD_WITH_EDP" == "y" ]; then
+		config_get_bool enable_edp 'config' 'enable_edp' 0
+		config_get_bool force_edp 'config' 'force_edp' 0
+	fi
 	config_get lldp_class 'config' 'lldp_class'
 	config_get lldp_location 'config' 'lldp_location'
 	config_get_bool lldp_no_version 'config' 'lldp_no_version' 0
@@ -271,7 +279,15 @@ start_service() {
 		fi
 	fi
 
-	[ $enable_edp -gt 0 ] && procd_append_param command '-e'
+	if [ "$CONFIG_LLDPD_WITH_EDP" == "y" ] && [ $enable_edp -gt 0 ]; then
+		if [ $force_edp -gt 0 ]; then
+			# EDP enbled and forced
+			procd_append_param command '-ee'
+		else
+			# EDP enbled
+			procd_append_param command '-e'
+		fi
+	fi
 
 	[ $readonly_mode -gt 0 ] && procd_append_param command '-r'
 	[ $lldp_no_version -gt 0 ] && procd_append_param commanpackage/network/services/lldpd/Makefile package/network/services/lldpd/files/lldpd.initd '-k'

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -36,6 +36,7 @@ get_config_restart_hash() {
 	config_get      v 'config' 'cid_interface'; append _string "$v" ","
 	config_get      v 'config' 'filter'; append _string "$v" ","
 	config_get_bool v 'config' 'readonly_mode'; append _string "$v" ","
+	config_get_bool v 'config' 'lldp_no_version'; append _string "$v" ","
 	config_get_bool v 'config' 'enable_lldp' 1; append _string "$v" ","
 	config_get_bool v 'config' 'enable_cdp'; append _string "$v" ","
 	config_get_bool v 'config' 'enable_edp'; append _string "$v" ","
@@ -108,6 +109,7 @@ start_service() {
 	local enable_edp
 	local lldp_class
 	local lldp_location
+	local lldp_no_version
 	local readonly_mode
 	local agentxsocket
 	local filter
@@ -119,6 +121,7 @@ start_service() {
 	config_get_bool enable_edp 'config' 'enable_edp' 0
 	config_get lldp_class 'config' 'lldp_class'
 	config_get lldp_location 'config' 'lldp_location'
+	config_get_bool lldp_no_version 'config' 'lldp_no_version' 0
 	config_get_bool readonly_mode 'config' 'readonly_mode' 0
 	config_get agentxsocket 'config' 'agentxsocket'
 	config_get filter 'config' 'filter' 15
@@ -138,6 +141,7 @@ start_service() {
 	[ $enable_sonmp -gt 0 ] && procd_append_param command '-s'
 	[ $enable_edp -gt 0 ] && procd_append_param command '-e'
 	[ $readonly_mode -gt 0 ] && procd_append_param command '-r'
+	[ $lldp_no_version -gt 0 ] && procd_append_param command '-k'
 	[ -n "$lldp_class" ] && procd_append_param command -M "$lldp_class"
 	[ -n "$agentxsocket" ] && procd_append_param command -x -X "$agentxsocket"
 	[ -n "$filter" ] && procd_append_param command -H "$filter"

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -5,10 +5,16 @@ START=90
 STOP=01
 
 USE_PROCD=1
+LLDPDBIN=/usr/sbin/lldpd
 LLDPCLI=/usr/sbin/lldpcli
 LLDPSOCKET=/var/run/lldpd.socket
 LLDPD_CONF=/tmp/lldpd.conf
 LLDPD_CONFS_DIR=/tmp/lldpd.d
+
+LLDPD_RUN=/var/run/lldpd
+LLDPD_RESTART_HASH=${LLDPD_RUN}/lldpd.restart_hash
+
+. "$IPKG_INSTROOT/lib/functions/network.sh"
 
 find_release_info()
 {
@@ -19,10 +25,27 @@ find_release_info()
 	echo "${PRETTY_NAME:-Unknown OpenWrt release} @ $(cat /proc/sys/kernel/hostname)"
 }
 
+get_config_restart_hash() {
+	local var="$1"
+	local _string _hash v
+
+	config_load 'lldpd'
+
+	config_get      v 'config' 'lldp_class'; append _string "$v" ","
+	config_get      v 'config' 'agentxsocket'; append _string "$v" ","
+	config_get_bool v 'config' 'readonly_mode'; append _string "$v" ","
+	config_get_bool v 'config' 'enable_lldp' 1; append _string "$v" ","
+	config_get_bool v 'config' 'enable_cdp'; append _string "$v" ","
+	config_get_bool v 'config' 'enable_edp'; append _string "$v" ","
+	config_get_bool v 'config' 'enable_fdp'; append _string "$v" ","
+	config_get_bool v 'config' 'enable_sonmp'; append _string "$v" ","
+
+	_hash=`echo -n "${_string}" | md5sum | awk '{ print \$1 }'`
+	export -n "$var=$_hash"
+}
+
 write_lldpd_conf()
 {
-	. /lib/functions/network.sh
-
 	local lldp_description
 
 	config_load 'lldpd'
@@ -60,10 +83,6 @@ write_lldpd_conf()
 	[ -e $LLDPD_CONFS_DIR ] || ln -s /etc/lldpd.d $LLDPD_CONFS_DIR
 }
 
-service_triggers() {
-	procd_add_reload_trigger "lldpd"
-}
-
 start_service() {
 
 	local enable_cdp
@@ -85,14 +104,15 @@ start_service() {
 	config_get_bool readonly_mode 'config' 'readonly_mode' 0
 	config_get agentxsocket 'config' 'agentxsocket'
 
-	mkdir -p /var/run/lldp
-	chown lldp:lldp /var/run/lldp
+	mkdir -p ${LLDPD_RUN}
+	chown lldp:lldp ${LLDPD_RUN}
 
 	# When lldpd starts, it also loads up what we write in this config file
 	write_lldpd_conf
 
 	procd_open_instance
-	procd_set_param command /usr/sbin/lldpd -d
+	procd_set_param command ${LLDPDBIN}
+	procd_append_param command -d
 
 	[ $enable_cdp -gt 0 ] && procd_append_param command '-c'
 	[ $enable_fdp -gt 0 ] && procd_append_param command '-f'
@@ -102,13 +122,38 @@ start_service() {
 	[ -n "$lldp_class" ] && procd_append_param command -M "$lldp_class"
 	[ -n "$agentxsocket" ] && procd_append_param command -x -X "$agentxsocket"
 
+    # Overwrite default configuration locations processed by lldpcli at start
+	procd_append_param command -O "$LLDPD_CONF"
+
+	local restart_hash
+	get_config_restart_hash restart_hash
+	echo -n "$restart_hash" > $LLDPD_RESTART_HASH
+
 	# set auto respawn behavior
 	procd_set_param respawn
 	procd_close_instance
 }
 
+service_triggers() {
+	procd_add_config_trigger "config.change" "lldpd" /etc/init.d/lldpd reload
+}
+
 reload_service() {
 	running || return 1
+	
+	local running_hash=""
+	local config_hash=""
+
+	get_config_restart_hash config_hash
+	if [ -f ${LLDPD_RESTART_HASH} ]; then running_hash=`cat $LLDPD_RESTART_HASH`; fi
+
+	if [ "x$running_hash" != "x$config_hash" ]; then
+		# Restart LLDPd
+		# Some parameters can't be configured at runtime
+		restart
+		return 0
+	fi
+	
 	$LLDPCLI -u $LLDPSOCKET &> /dev/null <<-EOF
 		pause
 		unconfigure lldp custom-tlv
@@ -130,5 +175,6 @@ reload_service() {
 }
 
 stop_service() {
-	rm -rf /var/run/lldp $LLDPSOCKET
+	rm -rf ${LLDPD_RUN} $LLDPSOCKET 2>/dev/null
 }
+

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -7,6 +7,7 @@ STOP=01
 CONFIG_LLDPD_WITH_CDP=y
 CONFIG_LLDPD_WITH_FDP=y
 CONFIG_LLDPD_WITH_LLDPMED=y
+CONFIG_LLDPD_WITH_SNMP=y
 CONFIG_LLDPD_WITH_SONMP=y
 
 USE_PROCD=1
@@ -37,7 +38,9 @@ get_config_restart_hash() {
 	config_load 'lldpd'
 
 	config_get      v 'config' 'lldp_class'; append _string "$v" ","
-	config_get      v 'config' 'agentxsocket'; append _string "$v" ","
+	if [ "$CONFIG_LLDPD_WITH_SNMP" == "y" ]; then
+		config_get      v 'config' 'agentxsocket'; append _string "$v" ","
+	fi
 	config_get      v 'config' 'cid_interface'; append _string "$v" ","
 	config_get      v 'config' 'filter'; append _string "$v" ","
 	config_get_bool v 'config' 'readonly_mode'; append _string "$v" ","
@@ -201,7 +204,9 @@ start_service() {
 		config_get_bool lldpmed_no_inventory 'config' 'lldpmed_no_inventory' 0
 	fi
 	config_get_bool readonly_mode 'config' 'readonly_mode' 0
-	config_get agentxsocket 'config' 'agentxsocket'
+	if [ "$CONFIG_LLDPD_WITH_SNMP" == "y" ]; then
+		config_get agentxsocket 'config' 'agentxsocket'
+	fi
 	config_get filter 'config' 'filter' 15
 
 	mkdir -p ${LLDPD_RUN}
@@ -272,7 +277,7 @@ start_service() {
 	[ $lldp_no_version -gt 0 ] && procd_append_param commanpackage/network/services/lldpd/Makefile package/network/services/lldpd/files/lldpd.initd '-k'
 	[ "$CONFIG_LLDPD_WITH_LLDPMED" == "y" ] && [ $lldpmed_no_inventory -gt 0 ] && procd_append_param command '-i'
 	[ -n "$lldp_class" ] && procd_append_param command -M "$lldp_class"
-	[ -n "$agentxsocket" ] && procd_append_param command -x -X "$agentxsocket"
+	[ "$CONFIG_LLDPD_WITH_SNMP" == "y" ] && [ -n "$agentxsocket" ] && procd_append_param command -x -X "$agentxsocket"
 	[ -n "$filter" ] && procd_append_param command -H "$filter"
 
     # ChassisID interfaces

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -125,6 +125,12 @@ write_lldpd_conf()
 	local lldp_platform
 	config_get lldp_platform 'config' 'lldp_platform' ""
 
+	local lldp_tx_interval
+	config_get lldp_tx_interval 'config' 'lldp_tx_interval' 0
+
+	local lldp_tx_hold
+	config_get lldp_tx_hold 'config' 'lldp_tx_hold' 0
+
 	# Clear out the config file first
 	echo -n > "$LLDPD_CONF"
 	[ -n "$ifnames" ] && echo "configure system interface pattern" "$ifnames" >> "$LLDPD_CONF"
@@ -142,6 +148,8 @@ write_lldpd_conf()
 	[ -n "$lldp_agenttype" ] && echo "configure lldp agent-type" "\"$lldp_agenttype\"" >> "$LLDPD_CONF"
 	[ -n "$lldp_portidsubtype" ] && echo "configure lldp portidsubtype" "\"$lldp_portidsubtype\"" >> "$LLDPD_CONF"
 	[ -n "$lldp_platform" ] && echo "configure system platform" "\"$lldp_platform\"" >> "$LLDPD_CONF"
+	[ $lldp_tx_interval -gt 0 ] && echo "configure lldp tx-interval" "$lldp_tx_interval" >> "$LLDPD_CONF"
+	[ $lldp_tx_hold -gt 0 ] && echo "configure lldp tx-hold" "$lldp_tx_hold" >> "$LLDPD_CONF"
 
 	# Since lldpd's sysconfdir is /tmp, we'll symlink /etc/lldpd.d to /tmp/$LLDPD_CONFS_DIR
 	[ -e $LLDPD_CONFS_DIR ] || ln -s /etc/lldpd.d $LLDPD_CONFS_DIR

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -34,6 +34,7 @@ get_config_restart_hash() {
 	config_get      v 'config' 'lldp_class'; append _string "$v" ","
 	config_get      v 'config' 'agentxsocket'; append _string "$v" ","
 	config_get      v 'config' 'cid_interface'; append _string "$v" ","
+	config_get      v 'config' 'filter'; append _string "$v" ","
 	config_get_bool v 'config' 'readonly_mode'; append _string "$v" ","
 	config_get_bool v 'config' 'enable_lldp' 1; append _string "$v" ","
 	config_get_bool v 'config' 'enable_cdp'; append _string "$v" ","
@@ -109,6 +110,7 @@ start_service() {
 	local lldp_location
 	local readonly_mode
 	local agentxsocket
+	local filter
 
 	config_load 'lldpd'
 	config_get_bool enable_cdp 'config' 'enable_cdp' 0
@@ -119,6 +121,7 @@ start_service() {
 	config_get lldp_location 'config' 'lldp_location'
 	config_get_bool readonly_mode 'config' 'readonly_mode' 0
 	config_get agentxsocket 'config' 'agentxsocket'
+	config_get filter 'config' 'filter' 15
 
 	mkdir -p ${LLDPD_RUN}
 	chown lldp:lldp ${LLDPD_RUN}
@@ -137,6 +140,7 @@ start_service() {
 	[ $readonly_mode -gt 0 ] && procd_append_param command '-r'
 	[ -n "$lldp_class" ] && procd_append_param command -M "$lldp_class"
 	[ -n "$agentxsocket" ] && procd_append_param command -x -X "$agentxsocket"
+	[ -n "$filter" ] && procd_append_param command -H "$filter"
 
     # ChassisID interfaces
 	local ifnames

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -7,6 +7,7 @@ STOP=01
 CONFIG_LLDPD_WITH_CDP=y
 CONFIG_LLDPD_WITH_FDP=y
 CONFIG_LLDPD_WITH_LLDPMED=y
+CONFIG_LLDPD_WITH_SONMP=y
 
 USE_PROCD=1
 LLDPDBIN=/usr/sbin/lldpd
@@ -57,7 +58,10 @@ get_config_restart_hash() {
 		config_get_bool v 'config' 'enable_fdp'; append _string "$v" ","
 		config_get_bool v 'config' 'force_fdp'; append _string "$v" ","
 	fi
-	config_get_bool v 'config' 'enable_sonmp'; append _string "$v" ","
+	if [ "$CONFIG_LLDPD_WITH_SONMP" == "y" ]; then
+		config_get_bool v 'config' 'enable_sonmp'; append _string "$v" ","
+		config_get_bool v 'config' 'force_sonmp'; append _string "$v" ","
+	fi
 
 	_hash=`echo -n "${_string}" | md5sum | awk '{ print \$1 }'`
 	export -n "$var=$_hash"
@@ -150,6 +154,7 @@ start_service() {
 	local enable_fdp
 	local force_fdp
 	local enable_sonmp
+	local force_sonmp
 	local enable_edp
 	local lldp_class
 	local lldp_location
@@ -172,7 +177,10 @@ start_service() {
 		config_get_bool enable_fdp 'config' 'enable_fdp' 0
 		config_get_bool force_fdp 'config' 'force_fdp' 0
 	fi
-	config_get_bool enable_sonmp 'config' 'enable_sonmp' 0
+	if [ "$CONFIG_LLDPD_WITH_SONMP" == "y" ]; then
+		config_get_bool enable_sonmp 'config' 'enable_sonmp' 0
+		config_get_bool force_sonmp 'config' 'force_sonmp' 0
+	fi
 	config_get_bool enable_edp 'config' 'enable_edp' 0
 	config_get lldp_class 'config' 'lldp_class'
 	config_get lldp_location 'config' 'lldp_location'
@@ -236,8 +244,18 @@ start_service() {
 		fi
 	fi
 
-	[ $enable_sonmp -gt 0 ] && procd_append_param command '-s'
+	if [ "$CONFIG_LLDPD_WITH_SONMP" == "y" ] && [ $enable_sonmp -gt 0 ]; then
+		if [ $force_sonmp -gt 0 ]; then
+			# SONMP enabled and forced
+			procd_append_param command '-ss'
+		else
+			# SONMP enabled
+			procd_append_param command '-s'
+		fi
+	fi
+
 	[ $enable_edp -gt 0 ] && procd_append_param command '-e'
+
 	[ $readonly_mode -gt 0 ] && procd_append_param command '-r'
 	[ $lldp_no_version -gt 0 ] && procd_append_param commanpackage/network/services/lldpd/Makefile package/network/services/lldpd/files/lldpd.initd '-k'
 	[ "$CONFIG_LLDPD_WITH_LLDPMED" == "y" ] && [ $lldpmed_no_inventory -gt 0 ] && procd_append_param command '-i'

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -102,6 +102,9 @@ write_lldpd_conf()
 		config_get lldpmed_fast_start_tx_interval 'config' 'lldpmed_fast_start_tx_interval' 0
 	fi
 
+	local lldp_agenttype
+	config_get lldp_agenttype 'config' 'lldp_agenttype' 'nearest-bridge'
+
 	# Clear out the config file first
 	echo -n > "$LLDPD_CONF"
 	[ -n "$ifnames" ] && echo "configure system interface pattern" "$ifnames" >> "$LLDPD_CONF"
@@ -116,6 +119,7 @@ write_lldpd_conf()
 			echo "configure med fast-start" "enable" >> "$LLDPD_CONF"
 		fi
 	fi
+	[ -n "$lldp_agenttype" ] && echo "configure lldp agent-type" "\"$lldp_agenttype\"" >> "$LLDPD_CONF"
 
 
 	# Since lldpd's sysconfdir is /tmp, we'll symlink /etc/lldpd.d to /tmp/$LLDPD_CONFS_DIR

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -33,6 +33,7 @@ get_config_restart_hash() {
 
 	config_get      v 'config' 'lldp_class'; append _string "$v" ","
 	config_get      v 'config' 'agentxsocket'; append _string "$v" ","
+	config_get      v 'config' 'cid_interface'; append _string "$v" ","
 	config_get_bool v 'config' 'readonly_mode'; append _string "$v" ","
 	config_get_bool v 'config' 'enable_lldp' 1; append _string "$v" ","
 	config_get_bool v 'config' 'enable_cdp'; append _string "$v" ","
@@ -42,6 +43,21 @@ get_config_restart_hash() {
 
 	_hash=`echo -n "${_string}" | md5sum | awk '{ print \$1 }'`
 	export -n "$var=$_hash"
+}
+
+get_config_cid_ifaces() {
+	local _ifaces
+	config_get _ifaces 'config' 'cid_interface'
+
+	local _iface _ifnames=""
+	for _iface in $_ifaces; do
+		local _ifname=""
+		if network_get_device _ifname "$_iface" || [ -e "/sys/class/net/$_iface" ]; then
+			append _ifnames "${_ifname:-$_iface}" ","
+		fi
+	done
+
+	export -n "${1}=$_ifnames"
 }
 
 write_lldpd_conf()
@@ -121,6 +137,11 @@ start_service() {
 	[ $readonly_mode -gt 0 ] && procd_append_param command '-r'
 	[ -n "$lldp_class" ] && procd_append_param command -M "$lldp_class"
 	[ -n "$agentxsocket" ] && procd_append_param command -x -X "$agentxsocket"
+
+    # ChassisID interfaces
+	local ifnames
+	get_config_cid_ifaces ifnames
+	[ -n "$ifnames" ] && procd_append_param command -C "$ifnames"
 
     # Overwrite default configuration locations processed by lldpcli at start
 	procd_append_param command -O "$LLDPD_CONF"

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -5,6 +5,7 @@ START=90
 STOP=01
 
 CONFIG_LLDPD_WITH_CDP=y
+CONFIG_LLDPD_WITH_FDP=y
 CONFIG_LLDPD_WITH_LLDPMED=y
 
 USE_PROCD=1
@@ -52,7 +53,10 @@ get_config_restart_hash() {
 		config_get_bool v 'config' 'force_cdpv2'; append _string "$v" ","
 	fi
 	config_get_bool v 'config' 'enable_edp'; append _string "$v" ","
-	config_get_bool v 'config' 'enable_fdp'; append _string "$v" ","
+	if [ "$CONFIG_LLDPD_WITH_FDP" == "y" ]; then
+		config_get_bool v 'config' 'enable_fdp'; append _string "$v" ","
+		config_get_bool v 'config' 'force_fdp'; append _string "$v" ","
+	fi
 	config_get_bool v 'config' 'enable_sonmp'; append _string "$v" ","
 
 	_hash=`echo -n "${_string}" | md5sum | awk '{ print \$1 }'`
@@ -60,8 +64,7 @@ get_config_restart_hash() {
 }
 
 get_config_cid_ifaces() {
-	local _ifaces
-	config_get _ifaces 'config' 'cid_interface'
+	local _ifacesCONFIG_LLDPD_WITH_FDP
 
 	local _iface _ifnames=""
 	for _iface in $_ifaces; do
@@ -145,6 +148,7 @@ start_service() {
 	local force_cdp
 	local force_cdpv2
 	local enable_fdp
+	local force_fdp
 	local enable_sonmp
 	local enable_edp
 	local lldp_class
@@ -164,7 +168,10 @@ start_service() {
 		config_get_bool force_cdp 'config' 'force_cdp' 0
 		config_get_bool force_cdpv2 'config' 'force_cdpv2' 0
 	fi
-	config_get_bool enable_fdp 'config' 'enable_fdp' 0
+	if [ "$CONFIG_LLDPD_WITH_FDP" == "y" ]; then
+		config_get_bool enable_fdp 'config' 'enable_fdp' 0
+		config_get_bool force_fdp 'config' 'force_fdp' 0
+	fi
 	config_get_bool enable_sonmp 'config' 'enable_sonmp' 0
 	config_get_bool enable_edp 'config' 'enable_edp' 0
 	config_get lldp_class 'config' 'lldp_class'
@@ -219,7 +226,16 @@ start_service() {
 		fi
 	fi
 
-	[ $enable_fdp -gt 0 ] && procd_append_param command '-f'
+	if [ "$CONFIG_LLDPD_WITH_FDP" == "y" ] && [ $enable_fdp -gt 0 ]; then
+		if [ $force_fdp -gt 0 ]; then
+			# FDP enbled and forced
+			procd_append_param command '-ff'
+		else
+			# FDP enabled
+			procd_append_param command '-f'
+		fi
+	fi
+
 	[ $enable_sonmp -gt 0 ] && procd_append_param command '-s'
 	[ $enable_edp -gt 0 ] && procd_append_param command '-e'
 	[ $readonly_mode -gt 0 ] && procd_append_param command '-r'
@@ -278,6 +294,7 @@ reload_service() {
 		$LLDPCLI -u $LLDPSOCKET &> /dev/null <<-EOF
 			unconfigure med fast-start
 		EOF
+
 	fi
 	# Rewrite lldpd.conf
 	# If something changed it should be included by the lldpcli call

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -94,6 +94,14 @@ write_lldpd_conf()
 	local lldp_syscapabilities
 	config_get lldp_syscapabilities 'config' 'lldp_syscapabilities'
 
+	if [ "$CONFIG_LLDPD_WITH_LLDPMED" == "y" ]; then
+		local lldpmed_fast_start
+		config_get_bool lldpmed_fast_start 'config' 'lldpmed_fast_start' 0
+
+		local lldpmed_fast_start_tx_interval
+		config_get lldpmed_fast_start_tx_interval 'config' 'lldpmed_fast_start_tx_interval' 0
+	fi
+
 	# Clear out the config file first
 	echo -n > "$LLDPD_CONF"
 	[ -n "$ifnames" ] && echo "configure system interface pattern" "$ifnames" >> "$LLDPD_CONF"
@@ -101,6 +109,14 @@ write_lldpd_conf()
 	[ -n "$lldp_hostname" ] && echo "configure system hostname" "\"$lldp_hostname\"" >> "$LLDPD_CONF"
 	[ -n "$lldp_mgmt_ip" ] && echo "configure system ip management pattern" "\"$lldp_mgmt_ip\"" >> "$LLDPD_CONF"
 	[ -n "$lldp_syscapabilities" ] && echo "configure system capabilities enabled" "\"$lldp_syscapabilities\"" >> "$LLDPD_CONF"
+	if [ "$CONFIG_LLDPD_WITH_LLDPMED" == "y" ] && [ $lldpmed_fast_start -gt 0 ]; then
+		if [ $lldpmed_fast_start_tx_interval -gt 0 ]; then
+			echo "configure med fast-start tx-interval" "\"$lldpmed_fast_start_tx_interval\"" >> "$LLDPD_CONF"
+		else
+			echo "configure med fast-start" "enable" >> "$LLDPD_CONF"
+		fi
+	fi
+
 
 	# Since lldpd's sysconfdir is /tmp, we'll symlink /etc/lldpd.d to /tmp/$LLDPD_CONFS_DIR
 	[ -e $LLDPD_CONFS_DIR ] || ln -s /etc/lldpd.d $LLDPD_CONFS_DIR
@@ -192,7 +208,7 @@ reload_service() {
 		restart
 		return 0
 	fi
-	
+
 	$LLDPCLI -u $LLDPSOCKET &> /dev/null <<-EOF
 		pause
 		unconfigure lldp custom-tlv
@@ -201,6 +217,11 @@ reload_service() {
 		unconfigure system hostname
 		unconfigure system ip management pattern
 	EOF
+	if [ "$CONFIG_LLDPD_WITH_LLDPMED" == "y" ]; then
+		$LLDPCLI -u $LLDPSOCKET &> /dev/null <<-EOF
+			unconfigure med fast-start
+		EOF
+	fi
 	# Rewrite lldpd.conf
 	# If something changed it should be included by the lldpcli call
 	write_lldpd_conf


### PR DESCRIPTION
* LLDPD will now bind only to the specified interfaces.
* LLDPD now supports "LLDP Med Fast Start".
* LLDP location parameter is now fully implemented and respects the uci setting.
* LLDPD socket is now closed on exit.
* LLDPD now supports enabling or disabling CDP protocol as well as LLDP.
* LLDP location default is now changed to generic location. Please see LLDPD man page for details of these feaures.

Update of https://github.com/openwrt/openwrt/pull/13018
