### PR TITLE
ramips: fix "no traffic" problem and DMA kernel panic at startup on rt305x and mt7628 devices

### DIFF
--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -411,8 +411,8 @@
 		interrupt-parent = <&cpuintc>;
 		interrupts = <5>;
 
-		resets = <&sysc 21>;
-		reset-names = "fe";
+		resets = <&sysc 21>, <&sysc 23>;
+		reset-names = "fe", "esw";
 
 		mediatek,switch = <&esw>;
 	};
@@ -421,8 +421,8 @@
 		compatible = "mediatek,mt7628-esw", "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&sysc 23>, <&sysc 24>;
-		reset-names = "esw", "ephy";
+		resets = <&sysc 24>;
+		reset-names = "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/dts/rt3050.dtsi
+++ b/target/linux/ramips/dts/rt3050.dtsi
@@ -301,8 +301,8 @@
 
 		clocks = <&sysc 11>;
 
-		resets = <&sysc 21>;
-		reset-names = "fe";
+		resets = <&sysc 21>, <&sysc 23>;
+		reset-names = "fe", "esw";
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <5>;
@@ -314,8 +314,8 @@
 		compatible = "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&sysc 23>, <&sysc 24>;
-		reset-names = "esw", "ephy";
+		resets = <&sysc 24>;
+		reset-names = "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/dts/rt3352.dtsi
+++ b/target/linux/ramips/dts/rt3352.dtsi
@@ -319,8 +319,8 @@
 
 		clocks = <&sysc 12>;
 
-		resets = <&sysc 21>;
-		reset-names = "fe";
+		resets = <&sysc 21>, <&sysc 23>;
+		reset-names = "fe", "esw";
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <5>;
@@ -332,8 +332,8 @@
 		compatible = "ralink,rt3352-esw", "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&sysc 23>, <&sysc 24>;
-		reset-names = "esw", "ephy";
+		resets = <&sysc 24>;
+		reset-names = "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -340,8 +340,8 @@
 
 		clocks = <&sysc 12>;
 
-		resets = <&sysc 21>;
-		reset-names = "fe";
+		resets = <&sysc 21>, <&sysc 23>;
+		reset-names = "fe", "esw";
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <5>;
@@ -353,8 +353,8 @@
 		compatible = "ralink,rt5350-esw", "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&sysc 23>, <&sysc 24>;
-		reset-names = "esw", "ephy";
+		resets = <&sysc 24>;
+		reset-names = "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -149,7 +149,7 @@ void fe_reset_fe(struct fe_priv *priv)
 	reset_control_assert(priv->resets);
 	usleep_range(60, 120);
 	reset_control_deassert(priv->resets);
-	usleep_range(60, 120);
+	usleep_range(1000, 1200);
 }
 
 static inline void fe_int_disable(u32 mask)

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -143,12 +143,12 @@ void fe_reset(u32 reset_bits)
 
 void fe_reset_fe(struct fe_priv *priv)
 {
-	if (!priv->rst_fe)
+	if (!priv->resets)
 		return;
 
-	reset_control_assert(priv->rst_fe);
+	reset_control_assert(priv->resets);
 	usleep_range(60, 120);
-	reset_control_deassert(priv->rst_fe);
+	reset_control_deassert(priv->resets);
 	usleep_range(60, 120);
 }
 
@@ -1595,9 +1595,11 @@ static int fe_probe(struct platform_device *pdev)
 
 	priv = netdev_priv(netdev);
 	spin_lock_init(&priv->page_lock);
-	priv->rst_fe = devm_reset_control_get(&pdev->dev, "fe");
-	if (IS_ERR(priv->rst_fe))
-		priv->rst_fe = NULL;
+	priv->resets = devm_reset_control_array_get_exclusive(&pdev->dev);
+	if (IS_ERR(priv->resets)) {
+		dev_err(&pdev->dev, "Failed to get resets for FE and ESW cores: %pe\n", priv->resets);
+		priv->resets = NULL;
+	}
 
 	if (soc->init_data)
 		soc->init_data(soc, netdev);

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
@@ -497,8 +497,7 @@ struct fe_priv {
 	struct work_struct		pending_work;
 	DECLARE_BITMAP(pending_flags, FE_FLAG_MAX);
 
-	struct reset_control		*rst_ppe;
-	struct reset_control		*rst_fe;
+	struct reset_control		*resets;
 	struct mtk_foe_entry		*foe_table;
 	dma_addr_t			foe_table_phys;
 	struct flow_offload __rcu	**foe_flow_table;


### PR DESCRIPTION
This series fixes bootup and Ethernet support on rt305x subtarget. It combines the MAC core and switch core reset again, but using device tree properties, rather than reverting the changes introduced in 60fadae62b64b14faff818e4156d9c6eb3f96b65. However, reverting those changes or moving resets around in device tree wasn't enough - the wait duration after the reset needs increasing, to allow both cores to sync up after reset.

The final commit cleans up the way reset controller lines are accessed from the code, but is mostly aesthetic in nature.

As the issue was introduced before v22.03 release, this series needs backporting to 22.03 and 23.05 stable branches, possibly together with #14151, which also needs backporting to 23.05.

Build tested on: ramips/rt305x, ramips/mt76x8, ramips/mt7620
Run tested on: ZTE MF283+ (RT3352), Hame MPR-A2 (RT5350), TP-Link TL-WR802N v4 (MT7628N), Nexx WT3020 8M (MT7620)

Closes: #9284