### PR TITLE
mediatek: bananapi-r3: add drivers and overlay for ReSpeaker 2-mic audio hat

### DIFF
--- a/package/kernel/linux/modules/sound.mk
+++ b/package/kernel/linux/modules/sound.mk
@@ -254,6 +254,18 @@ endef
 $(eval $(call KernelPackage,sound-soc-imx-sgtl5000))
 
 
+define KernelPackage/sound-soc-wm8960
+  TITLE:=SoC WM8960 codec support
+  KCONFIG:=CONFIG_SND_SOC_WM8960
+  FILES:=$(LINUX_DIR)/sound/soc/codecs/snd-soc-wm8960.ko
+  DEPENDS:=+kmod-sound-soc-core +kmod-i2c-core +kmod-regmap-i2c
+  AUTOLOAD:=$(call AutoProbe,snd-soc-wm8960)
+  $(call AddDepends/sound)
+endef
+
+$(eval $(call KernelPackage,sound-soc-wm8960))
+
+
 define KernelPackage/sound-soc-spdif
   TITLE:=SoC S/PDIF codec support
   KCONFIG:=CONFIG_SND_SOC_SPDIF

--- a/package/kernel/linux/modules/sound.mk
+++ b/package/kernel/linux/modules/sound.mk
@@ -236,6 +236,40 @@ endef
 $(eval $(call KernelPackage,sound-soc-imx))
 
 
+define KernelPackage/sound-soc-mt7986
+  TITLE:=MediaTek MT7986 Audio support
+  KCONFIG:=CONFIG_SND_SOC_MT7986 CONFIG_SND_SOC_MT7986_WM8960
+  FILES:= \
+	$(LINUX_DIR)/sound/soc/mediatek/common/snd-soc-mtk-common.ko \
+	$(LINUX_DIR)/sound/soc/mediatek/mt7986/snd-soc-mt7986-afe.ko
+  AUTOLOAD:=$(call AutoLoad,56,snd-soc-mtk-common snd-soc-mt7986-afe)
+  DEPENDS:=@TARGET_mediatek_filogic +kmod-sound-soc-core
+  $(call AddDepends/sound)
+endef
+
+define KernelPackage/sound-soc-mt7986/description
+ Support for audio on systems using the MediaTek MT7986 SoC.
+endef
+
+$(eval $(call KernelPackage,sound-soc-mt7986))
+
+
+define KernelPackage/sound-soc-mt7986-wm8960
+  TITLE:=MediaTek MT7986 Audio support
+  KCONFIG:=CONFIG_SND_SOC_MT7986_WM8960
+  FILES:=$(LINUX_DIR)/sound/soc/mediatek/mt7986/mt7986-wm8960.ko
+  AUTOLOAD:=$(call AutoLoad,57,mt7986-wm8960)
+  DEPENDS:=@TARGET_mediatek_filogic +kmod-sound-soc-wm8960 +kmod-sound-soc-mt7986
+  $(call AddDepends/sound)
+endef
+
+define KernelPackage/sound-soc-mt7986-wm8960/description
+ Support for use of the Wolfson Audio WM8960 codec with the MediaTek MT7986 SoC.
+endef
+
+$(eval $(call KernelPackage,sound-soc-mt7986-wm8960))
+
+
 define KernelPackage/sound-soc-imx-sgtl5000
   TITLE:=IMX SoC support for SGTL5000
   KCONFIG:=CONFIG_SND_SOC_IMX_SGTL5000

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -212,7 +212,9 @@ define Device/bananapi_bpi-r3
   DEVICE_MODEL := BPi-R3
   DEVICE_DTS := mt7986a-bananapi-bpi-r3
   DEVICE_DTS_CONFIG := config-mt7986a-bananapi-bpi-r3
-  DEVICE_DTS_OVERLAY:= mt7986a-bananapi-bpi-r3-emmc mt7986a-bananapi-bpi-r3-nand mt7986a-bananapi-bpi-r3-nor mt7986a-bananapi-bpi-r3-sd
+  DEVICE_DTS_OVERLAY:= mt7986a-bananapi-bpi-r3-emmc mt7986a-bananapi-bpi-r3-nand \
+		       mt7986a-bananapi-bpi-r3-nor mt7986a-bananapi-bpi-r3-sd \
+		       mt7986a-bananapi-bpi-r3-respeaker-2mics
   DEVICE_DTS_DIR := $(DTS_DIR)/
   DEVICE_DTS_LOADADDR := 0x43f00000
   DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-i2c-gpio kmod-mt7986-firmware kmod-sfp kmod-usb3 e2fsprogs f2fsck mkf2fs mt7986-wo-firmware

--- a/target/linux/mediatek/patches-5.15/860-v6.6-01-ASoC-mediatek-mt7986-add-common-header.patch
+++ b/target/linux/mediatek/patches-5.15/860-v6.6-01-ASoC-mediatek-mt7986-add-common-header.patch
@@ -1,0 +1,269 @@
+From d35469096915f2551ed1d26da1ab12ff500fc963 Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 17 Aug 2023 18:13:33 +0800
+Subject: [PATCH 1/9] ASoC: mediatek: mt7986: add common header
+
+Add header files for register definition and structure.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20230817101338.18782-2-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/mediatek/mt7986/mt7986-afe-common.h |  49 +++++
+ sound/soc/mediatek/mt7986/mt7986-reg.h        | 196 ++++++++++++++++++
+ 2 files changed, 245 insertions(+)
+ create mode 100644 sound/soc/mediatek/mt7986/mt7986-afe-common.h
+ create mode 100644 sound/soc/mediatek/mt7986/mt7986-reg.h
+
+--- /dev/null
++++ b/sound/soc/mediatek/mt7986/mt7986-afe-common.h
+@@ -0,0 +1,49 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * mt7986-afe-common.h  --  MediaTek 7986 audio driver definitions
++ *
++ * Copyright (c) 2023 MediaTek Inc.
++ * Authors: Vic Wu <vic.wu@mediatek.com>
++ *          Maso Huang <maso.huang@mediatek.com>
++ */
++
++#ifndef _MT_7986_AFE_COMMON_H_
++#define _MT_7986_AFE_COMMON_H_
++
++#include <sound/soc.h>
++#include <linux/clk.h>
++#include <linux/list.h>
++#include <linux/regmap.h>
++#include "../common/mtk-base-afe.h"
++
++enum {
++	MT7986_MEMIF_DL1,
++	MT7986_MEMIF_VUL12,
++	MT7986_MEMIF_NUM,
++	MT7986_DAI_ETDM = MT7986_MEMIF_NUM,
++	MT7986_DAI_NUM,
++};
++
++enum {
++	MT7986_IRQ_0,
++	MT7986_IRQ_1,
++	MT7986_IRQ_2,
++	MT7986_IRQ_NUM,
++};
++
++struct mt7986_afe_private {
++	struct clk_bulk_data *clks;
++	int num_clks;
++
++	int pm_runtime_bypass_reg_ctl;
++
++	/* dai */
++	void *dai_priv[MT7986_DAI_NUM];
++};
++
++unsigned int mt7986_afe_rate_transform(struct device *dev,
++				       unsigned int rate);
++
++/* dai register */
++int mt7986_dai_etdm_register(struct mtk_base_afe *afe);
++#endif
+--- /dev/null
++++ b/sound/soc/mediatek/mt7986/mt7986-reg.h
+@@ -0,0 +1,196 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * mt7986-reg.h  --  MediaTek 7986 audio driver reg definition
++ *
++ * Copyright (c) 2023 MediaTek Inc.
++ * Authors: Vic Wu <vic.wu@mediatek.com>
++ *          Maso Huang <maso.huang@mediatek.com>
++ */
++
++#ifndef _MT7986_REG_H_
++#define _MT7986_REG_H_
++
++#define AUDIO_TOP_CON2                  0x0008
++#define AUDIO_TOP_CON4                  0x0010
++#define AUDIO_ENGEN_CON0                0x0014
++#define AFE_IRQ_MCU_EN                  0x0100
++#define AFE_IRQ_MCU_STATUS              0x0120
++#define AFE_IRQ_MCU_CLR                 0x0128
++#define AFE_IRQ0_MCU_CFG0               0x0140
++#define AFE_IRQ0_MCU_CFG1               0x0144
++#define AFE_IRQ1_MCU_CFG0               0x0148
++#define AFE_IRQ1_MCU_CFG1               0x014c
++#define AFE_IRQ2_MCU_CFG0               0x0150
++#define AFE_IRQ2_MCU_CFG1               0x0154
++#define ETDM_IN5_CON0                   0x13f0
++#define ETDM_IN5_CON1                   0x13f4
++#define ETDM_IN5_CON2                   0x13f8
++#define ETDM_IN5_CON3                   0x13fc
++#define ETDM_IN5_CON4                   0x1400
++#define ETDM_OUT5_CON0                  0x1570
++#define ETDM_OUT5_CON4                  0x1580
++#define ETDM_OUT5_CON5                  0x1584
++#define ETDM_4_7_COWORK_CON0            0x15e0
++#define ETDM_4_7_COWORK_CON1            0x15e4
++#define AFE_CONN018_1                   0x1b44
++#define AFE_CONN018_4                   0x1b50
++#define AFE_CONN019_1                   0x1b64
++#define AFE_CONN019_4                   0x1b70
++#define AFE_CONN124_1                   0x2884
++#define AFE_CONN124_4                   0x2890
++#define AFE_CONN125_1                   0x28a4
++#define AFE_CONN125_4                   0x28b0
++#define AFE_CONN_RS_0                   0x3920
++#define AFE_CONN_RS_3                   0x392c
++#define AFE_CONN_16BIT_0                0x3960
++#define AFE_CONN_16BIT_3                0x396c
++#define AFE_CONN_24BIT_0                0x3980
++#define AFE_CONN_24BIT_3                0x398c
++#define AFE_MEMIF_CON0                  0x3d98
++#define AFE_MEMIF_RD_MON                0x3da0
++#define AFE_MEMIF_WR_MON                0x3da4
++#define AFE_DL0_BASE_MSB                0x3e40
++#define AFE_DL0_BASE                    0x3e44
++#define AFE_DL0_CUR_MSB                 0x3e48
++#define AFE_DL0_CUR                     0x3e4c
++#define AFE_DL0_END_MSB                 0x3e50
++#define AFE_DL0_END                     0x3e54
++#define AFE_DL0_RCH_MON                 0x3e58
++#define AFE_DL0_LCH_MON                 0x3e5c
++#define AFE_DL0_CON0                    0x3e60
++#define AFE_VUL0_BASE_MSB               0x4220
++#define AFE_VUL0_BASE                   0x4224
++#define AFE_VUL0_CUR_MSB                0x4228
++#define AFE_VUL0_CUR                    0x422c
++#define AFE_VUL0_END_MSB                0x4230
++#define AFE_VUL0_END                    0x4234
++#define AFE_VUL0_CON0                   0x4238
++
++#define AFE_MAX_REGISTER AFE_VUL0_CON0
++#define AFE_IRQ_STATUS_BITS             0x7
++#define AFE_IRQ_CNT_SHIFT               0
++#define AFE_IRQ_CNT_MASK	        0xffffff
++
++/* AUDIO_TOP_CON2 */
++#define CLK_OUT5_PDN                    BIT(14)
++#define CLK_OUT5_PDN_MASK               BIT(14)
++#define CLK_IN5_PDN                     BIT(7)
++#define CLK_IN5_PDN_MASK                BIT(7)
++
++/* AUDIO_TOP_CON4 */
++#define PDN_APLL_TUNER2                 BIT(12)
++#define PDN_APLL_TUNER2_MASK            BIT(12)
++
++/* AUDIO_ENGEN_CON0 */
++#define AUD_APLL2_EN                    BIT(3)
++#define AUD_APLL2_EN_MASK               BIT(3)
++#define AUD_26M_EN                      BIT(0)
++#define AUD_26M_EN_MASK                 BIT(0)
++
++/* AFE_DL0_CON0 */
++#define DL0_ON_SFT                      28
++#define DL0_ON_MASK                     0x1
++#define DL0_ON_MASK_SFT                 BIT(28)
++#define DL0_MINLEN_SFT                  20
++#define DL0_MINLEN_MASK                 0xf
++#define DL0_MINLEN_MASK_SFT             (0xf << 20)
++#define DL0_MODE_SFT                    8
++#define DL0_MODE_MASK                   0x1f
++#define DL0_MODE_MASK_SFT               (0x1f << 8)
++#define DL0_PBUF_SIZE_SFT               5
++#define DL0_PBUF_SIZE_MASK              0x3
++#define DL0_PBUF_SIZE_MASK_SFT          (0x3 << 5)
++#define DL0_MONO_SFT                    4
++#define DL0_MONO_MASK                   0x1
++#define DL0_MONO_MASK_SFT               BIT(4)
++#define DL0_HALIGN_SFT                  2
++#define DL0_HALIGN_MASK                 0x1
++#define DL0_HALIGN_MASK_SFT             BIT(2)
++#define DL0_HD_MODE_SFT                 0
++#define DL0_HD_MODE_MASK                0x3
++#define DL0_HD_MODE_MASK_SFT            (0x3 << 0)
++
++/* AFE_VUL0_CON0 */
++#define VUL0_ON_SFT                     28
++#define VUL0_ON_MASK                    0x1
++#define VUL0_ON_MASK_SFT                BIT(28)
++#define VUL0_MODE_SFT                   8
++#define VUL0_MODE_MASK                  0x1f
++#define VUL0_MODE_MASK_SFT              (0x1f << 8)
++#define VUL0_MONO_SFT                   4
++#define VUL0_MONO_MASK                  0x1
++#define VUL0_MONO_MASK_SFT              BIT(4)
++#define VUL0_HALIGN_SFT                 2
++#define VUL0_HALIGN_MASK                0x1
++#define VUL0_HALIGN_MASK_SFT            BIT(2)
++#define VUL0_HD_MODE_SFT                0
++#define VUL0_HD_MODE_MASK               0x3
++#define VUL0_HD_MODE_MASK_SFT           (0x3 << 0)
++
++/* AFE_IRQ_MCU_CON */
++#define IRQ_MCU_MODE_SFT                4
++#define IRQ_MCU_MODE_MASK               0x1f
++#define IRQ_MCU_MODE_MASK_SFT           (0x1f << 4)
++#define IRQ_MCU_ON_SFT                  0
++#define IRQ_MCU_ON_MASK                 0x1
++#define IRQ_MCU_ON_MASK_SFT             BIT(0)
++#define IRQ0_MCU_CLR_SFT                0
++#define IRQ0_MCU_CLR_MASK               0x1
++#define IRQ0_MCU_CLR_MASK_SFT           BIT(0)
++#define IRQ1_MCU_CLR_SFT                1
++#define IRQ1_MCU_CLR_MASK               0x1
++#define IRQ1_MCU_CLR_MASK_SFT           BIT(1)
++#define IRQ2_MCU_CLR_SFT                2
++#define IRQ2_MCU_CLR_MASK               0x1
++#define IRQ2_MCU_CLR_MASK_SFT           BIT(2)
++
++/* ETDM_IN5_CON2 */
++#define IN_CLK_SRC(x)                   ((x) << 10)
++#define IN_CLK_SRC_SFT                  10
++#define IN_CLK_SRC_MASK                 GENMASK(12, 10)
++
++/* ETDM_IN5_CON3 */
++#define IN_SEL_FS(x)                    ((x) << 26)
++#define IN_SEL_FS_SFT                   26
++#define IN_SEL_FS_MASK                  GENMASK(30, 26)
++
++/* ETDM_IN5_CON4 */
++#define IN_RELATCH(x)                   ((x) << 20)
++#define IN_RELATCH_SFT                  20
++#define IN_RELATCH_MASK                 GENMASK(24, 20)
++#define IN_CLK_INV                      BIT(18)
++#define IN_CLK_INV_MASK                 BIT(18)
++
++/* ETDM_IN5_CON0 & ETDM_OUT5_CON0 */
++#define RELATCH_SRC_MASK                GENMASK(30, 28)
++#define ETDM_CH_NUM_MASK                GENMASK(27, 23)
++#define ETDM_WRD_LEN_MASK               GENMASK(20, 16)
++#define ETDM_BIT_LEN_MASK               GENMASK(15, 11)
++#define ETDM_FMT_MASK                   GENMASK(8, 6)
++#define ETDM_SYNC                       BIT(1)
++#define ETDM_SYNC_MASK                  BIT(1)
++#define ETDM_EN                         BIT(0)
++#define ETDM_EN_MASK                    BIT(0)
++
++/* ETDM_OUT5_CON4 */
++#define OUT_RELATCH(x)                  ((x) << 24)
++#define OUT_RELATCH_SFT                 24
++#define OUT_RELATCH_MASK                GENMASK(28, 24)
++#define OUT_CLK_SRC(x)                  ((x) << 6)
++#define OUT_CLK_SRC_SFT                 6
++#define OUT_CLK_SRC_MASK                GENMASK(8, 6)
++#define OUT_SEL_FS(x)                   (x)
++#define OUT_SEL_FS_SFT                  0
++#define OUT_SEL_FS_MASK                 GENMASK(4, 0)
++
++/* ETDM_OUT5_CON5 */
++#define ETDM_CLK_DIV                    BIT(12)
++#define ETDM_CLK_DIV_MASK               BIT(12)
++#define OUT_CLK_INV                     BIT(9)
++#define OUT_CLK_INV_MASK                BIT(9)
++
++/* ETDM_4_7_COWORK_CON0 */
++#define OUT_SEL(x)                      ((x) << 12)
++#define OUT_SEL_SFT                     12
++#define OUT_SEL_MASK                    GENMASK(15, 12)
++#endif

--- a/target/linux/mediatek/patches-5.15/860-v6.6-02-ASoC-mediatek-mt7986-support-etdm-in-platform-driver.patch
+++ b/target/linux/mediatek/patches-5.15/860-v6.6-02-ASoC-mediatek-mt7986-support-etdm-in-platform-driver.patch
@@ -1,0 +1,430 @@
+From 948a288897015fb3ee63b3f720b396b590c17fd7 Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 17 Aug 2023 18:13:34 +0800
+Subject: [PATCH 2/9] ASoC: mediatek: mt7986: support etdm in platform driver
+
+Add mt7986 etdm dai driver support.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20230817101338.18782-3-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/mediatek/mt7986/mt7986-dai-etdm.c | 411 ++++++++++++++++++++
+ 1 file changed, 411 insertions(+)
+ create mode 100644 sound/soc/mediatek/mt7986/mt7986-dai-etdm.c
+
+--- /dev/null
++++ b/sound/soc/mediatek/mt7986/mt7986-dai-etdm.c
+@@ -0,0 +1,411 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * MediaTek ALSA SoC Audio DAI eTDM Control
++ *
++ * Copyright (c) 2023 MediaTek Inc.
++ * Authors: Vic Wu <vic.wu@mediatek.com>
++ *          Maso Huang <maso.huang@mediatek.com>
++ */
++
++#include <linux/bitfield.h>
++#include <linux/bitops.h>
++#include <linux/regmap.h>
++#include <sound/pcm_params.h>
++#include "mt7986-afe-common.h"
++#include "mt7986-reg.h"
++
++#define HOPPING_CLK  0
++#define APLL_CLK     1
++#define MTK_DAI_ETDM_FORMAT_I2S   0
++#define MTK_DAI_ETDM_FORMAT_DSPA  4
++#define MTK_DAI_ETDM_FORMAT_DSPB  5
++
++enum {
++	MTK_ETDM_RATE_8K = 0,
++	MTK_ETDM_RATE_12K = 1,
++	MTK_ETDM_RATE_16K = 2,
++	MTK_ETDM_RATE_24K = 3,
++	MTK_ETDM_RATE_32K = 4,
++	MTK_ETDM_RATE_48K = 5,
++	MTK_ETDM_RATE_96K = 7,
++	MTK_ETDM_RATE_192K = 9,
++	MTK_ETDM_RATE_11K = 16,
++	MTK_ETDM_RATE_22K = 17,
++	MTK_ETDM_RATE_44K = 18,
++	MTK_ETDM_RATE_88K = 19,
++	MTK_ETDM_RATE_176K = 20,
++};
++
++struct mtk_dai_etdm_priv {
++	bool bck_inv;
++	bool lrck_inv;
++	bool slave_mode;
++	unsigned int format;
++};
++
++static unsigned int mt7986_etdm_rate_transform(struct device *dev, unsigned int rate)
++{
++	switch (rate) {
++	case 8000:
++		return MTK_ETDM_RATE_8K;
++	case 11025:
++		return MTK_ETDM_RATE_11K;
++	case 12000:
++		return MTK_ETDM_RATE_12K;
++	case 16000:
++		return MTK_ETDM_RATE_16K;
++	case 22050:
++		return MTK_ETDM_RATE_22K;
++	case 24000:
++		return MTK_ETDM_RATE_24K;
++	case 32000:
++		return MTK_ETDM_RATE_32K;
++	case 44100:
++		return MTK_ETDM_RATE_44K;
++	case 48000:
++		return MTK_ETDM_RATE_48K;
++	case 88200:
++		return MTK_ETDM_RATE_88K;
++	case 96000:
++		return MTK_ETDM_RATE_96K;
++	case 176400:
++		return MTK_ETDM_RATE_176K;
++	case 192000:
++		return MTK_ETDM_RATE_192K;
++	default:
++		dev_warn(dev, "%s(), rate %u invalid, using %d!!!\n",
++			 __func__, rate, MTK_ETDM_RATE_48K);
++		return MTK_ETDM_RATE_48K;
++	}
++}
++
++static int get_etdm_wlen(unsigned int bitwidth)
++{
++	return bitwidth <= 16 ? 16 : 32;
++}
++
++/* dai component */
++/* interconnection */
++
++static const struct snd_kcontrol_new o124_mix[] = {
++	SOC_DAPM_SINGLE_AUTODISABLE("I032_Switch", AFE_CONN124_1, 0, 1, 0),
++};
++
++static const struct snd_kcontrol_new o125_mix[] = {
++	SOC_DAPM_SINGLE_AUTODISABLE("I033_Switch", AFE_CONN125_1, 1, 1, 0),
++};
++
++static const struct snd_soc_dapm_widget mtk_dai_etdm_widgets[] = {
++
++	/* DL */
++	SND_SOC_DAPM_MIXER("I150", SND_SOC_NOPM, 0, 0, NULL, 0),
++	SND_SOC_DAPM_MIXER("I151", SND_SOC_NOPM, 0, 0, NULL, 0),
++	/* UL */
++	SND_SOC_DAPM_MIXER("O124", SND_SOC_NOPM, 0, 0, o124_mix, ARRAY_SIZE(o124_mix)),
++	SND_SOC_DAPM_MIXER("O125", SND_SOC_NOPM, 0, 0, o125_mix, ARRAY_SIZE(o125_mix)),
++};
++
++static const struct snd_soc_dapm_route mtk_dai_etdm_routes[] = {
++	{"I150", NULL, "ETDM Capture"},
++	{"I151", NULL, "ETDM Capture"},
++	{"ETDM Playback", NULL, "O124"},
++	{"ETDM Playback", NULL, "O125"},
++	{"O124", "I032_Switch", "I032"},
++	{"O125", "I033_Switch", "I033"},
++};
++
++/* dai ops */
++static int mtk_dai_etdm_startup(struct snd_pcm_substream *substream,
++				struct snd_soc_dai *dai)
++{
++	struct mtk_base_afe *afe = snd_soc_dai_get_drvdata(dai);
++	struct mt7986_afe_private *afe_priv = afe->platform_priv;
++	int ret;
++
++	ret = clk_bulk_prepare_enable(afe_priv->num_clks, afe_priv->clks);
++	if (ret)
++		return dev_err_probe(afe->dev, ret, "Failed to enable clocks\n");
++
++	regmap_update_bits(afe->regmap, AUDIO_TOP_CON2, CLK_OUT5_PDN_MASK, 0);
++	regmap_update_bits(afe->regmap, AUDIO_TOP_CON2, CLK_IN5_PDN_MASK, 0);
++
++	return 0;
++}
++
++static void mtk_dai_etdm_shutdown(struct snd_pcm_substream *substream,
++				  struct snd_soc_dai *dai)
++{
++	struct mtk_base_afe *afe = snd_soc_dai_get_drvdata(dai);
++	struct mt7986_afe_private *afe_priv = afe->platform_priv;
++
++	regmap_update_bits(afe->regmap, AUDIO_TOP_CON2, CLK_OUT5_PDN_MASK,
++			   CLK_OUT5_PDN);
++	regmap_update_bits(afe->regmap, AUDIO_TOP_CON2, CLK_IN5_PDN_MASK,
++			   CLK_IN5_PDN);
++
++	clk_bulk_disable_unprepare(afe_priv->num_clks, afe_priv->clks);
++}
++
++static unsigned int get_etdm_ch_fixup(unsigned int channels)
++{
++	if (channels > 16)
++		return 24;
++	else if (channels > 8)
++		return 16;
++	else if (channels > 4)
++		return 8;
++	else if (channels > 2)
++		return 4;
++	else
++		return 2;
++}
++
++static int mtk_dai_etdm_config(struct mtk_base_afe *afe,
++			       struct snd_pcm_hw_params *params,
++			       struct snd_soc_dai *dai,
++			       int stream)
++{
++	struct mt7986_afe_private *afe_priv = afe->platform_priv;
++	struct mtk_dai_etdm_priv *etdm_data = afe_priv->dai_priv[dai->id];
++	unsigned int rate = params_rate(params);
++	unsigned int etdm_rate = mt7986_etdm_rate_transform(afe->dev, rate);
++	unsigned int afe_rate = mt7986_afe_rate_transform(afe->dev, rate);
++	unsigned int channels = params_channels(params);
++	unsigned int bit_width = params_width(params);
++	unsigned int wlen = get_etdm_wlen(bit_width);
++	unsigned int val = 0;
++	unsigned int mask = 0;
++
++	dev_dbg(afe->dev, "%s(), stream %d, rate %u, bitwidth %u\n",
++		 __func__, stream, rate, bit_width);
++
++	/* CON0 */
++	mask |= ETDM_BIT_LEN_MASK;
++	val |= FIELD_PREP(ETDM_BIT_LEN_MASK, bit_width - 1);
++	mask |= ETDM_WRD_LEN_MASK;
++	val |= FIELD_PREP(ETDM_WRD_LEN_MASK, wlen - 1);
++	mask |= ETDM_FMT_MASK;
++	val |= FIELD_PREP(ETDM_FMT_MASK, etdm_data->format);
++	mask |= ETDM_CH_NUM_MASK;
++	val |= FIELD_PREP(ETDM_CH_NUM_MASK, get_etdm_ch_fixup(channels) - 1);
++	mask |= RELATCH_SRC_MASK;
++	val |= FIELD_PREP(RELATCH_SRC_MASK, APLL_CLK);
++
++	switch (stream) {
++	case SNDRV_PCM_STREAM_PLAYBACK:
++		/* set ETDM_OUT5_CON0 */
++		regmap_update_bits(afe->regmap, ETDM_OUT5_CON0, mask, val);
++
++		/* set ETDM_OUT5_CON4 */
++		regmap_update_bits(afe->regmap, ETDM_OUT5_CON4,
++				   OUT_RELATCH_MASK, OUT_RELATCH(afe_rate));
++		regmap_update_bits(afe->regmap, ETDM_OUT5_CON4,
++				   OUT_CLK_SRC_MASK, OUT_CLK_SRC(APLL_CLK));
++		regmap_update_bits(afe->regmap, ETDM_OUT5_CON4,
++				   OUT_SEL_FS_MASK, OUT_SEL_FS(etdm_rate));
++
++		/* set ETDM_OUT5_CON5 */
++		regmap_update_bits(afe->regmap, ETDM_OUT5_CON5,
++				   ETDM_CLK_DIV_MASK, ETDM_CLK_DIV);
++		break;
++	case SNDRV_PCM_STREAM_CAPTURE:
++		/* set ETDM_IN5_CON0 */
++		regmap_update_bits(afe->regmap, ETDM_IN5_CON0, mask, val);
++		regmap_update_bits(afe->regmap, ETDM_IN5_CON0,
++				   ETDM_SYNC_MASK, ETDM_SYNC);
++
++		/* set ETDM_IN5_CON2 */
++		regmap_update_bits(afe->regmap, ETDM_IN5_CON2,
++				   IN_CLK_SRC_MASK, IN_CLK_SRC(APLL_CLK));
++
++		/* set ETDM_IN5_CON3 */
++		regmap_update_bits(afe->regmap, ETDM_IN5_CON3,
++				   IN_SEL_FS_MASK, IN_SEL_FS(etdm_rate));
++
++		/* set ETDM_IN5_CON4 */
++		regmap_update_bits(afe->regmap, ETDM_IN5_CON4,
++				   IN_RELATCH_MASK, IN_RELATCH(afe_rate));
++		break;
++	default:
++		break;
++	}
++
++	return 0;
++}
++
++static int mtk_dai_etdm_hw_params(struct snd_pcm_substream *substream,
++				  struct snd_pcm_hw_params *params,
++				  struct snd_soc_dai *dai)
++{
++	struct mtk_base_afe *afe = snd_soc_dai_get_drvdata(dai);
++
++	mtk_dai_etdm_config(afe, params, dai, SNDRV_PCM_STREAM_PLAYBACK);
++	mtk_dai_etdm_config(afe, params, dai, SNDRV_PCM_STREAM_CAPTURE);
++
++	return 0;
++}
++
++static int mtk_dai_etdm_trigger(struct snd_pcm_substream *substream, int cmd,
++				struct snd_soc_dai *dai)
++{
++	struct mtk_base_afe *afe = snd_soc_dai_get_drvdata(dai);
++
++	dev_dbg(afe->dev, "%s(), cmd %d, dai id %d\n", __func__, cmd, dai->id);
++	switch (cmd) {
++	case SNDRV_PCM_TRIGGER_START:
++	case SNDRV_PCM_TRIGGER_RESUME:
++		regmap_update_bits(afe->regmap, ETDM_IN5_CON0, ETDM_EN_MASK,
++				   ETDM_EN);
++		regmap_update_bits(afe->regmap, ETDM_OUT5_CON0, ETDM_EN_MASK,
++				   ETDM_EN);
++		break;
++	case SNDRV_PCM_TRIGGER_STOP:
++	case SNDRV_PCM_TRIGGER_SUSPEND:
++		regmap_update_bits(afe->regmap, ETDM_IN5_CON0, ETDM_EN_MASK,
++				   0);
++		regmap_update_bits(afe->regmap, ETDM_OUT5_CON0, ETDM_EN_MASK,
++				   0);
++		break;
++	default:
++		break;
++	}
++
++	return 0;
++}
++
++static int mtk_dai_etdm_set_fmt(struct snd_soc_dai *dai, unsigned int fmt)
++{
++	struct mtk_base_afe *afe = snd_soc_dai_get_drvdata(dai);
++	struct mt7986_afe_private *afe_priv = afe->platform_priv;
++	struct mtk_dai_etdm_priv *etdm_data;
++	void *priv_data;
++
++	switch (dai->id) {
++	case MT7986_DAI_ETDM:
++		break;
++	default:
++		dev_warn(afe->dev, "%s(), id %d not support\n",
++			 __func__, dai->id);
++		return -EINVAL;
++	}
++
++	priv_data = devm_kzalloc(afe->dev, sizeof(struct mtk_dai_etdm_priv),
++				 GFP_KERNEL);
++	if (!priv_data)
++		return -ENOMEM;
++
++	afe_priv->dai_priv[dai->id] = priv_data;
++	etdm_data = afe_priv->dai_priv[dai->id];
++
++	switch (fmt & SND_SOC_DAIFMT_FORMAT_MASK) {
++	case SND_SOC_DAIFMT_I2S:
++		etdm_data->format = MTK_DAI_ETDM_FORMAT_I2S;
++		break;
++	case SND_SOC_DAIFMT_DSP_A:
++		etdm_data->format = MTK_DAI_ETDM_FORMAT_DSPA;
++		break;
++	case SND_SOC_DAIFMT_DSP_B:
++		etdm_data->format = MTK_DAI_ETDM_FORMAT_DSPB;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	switch (fmt & SND_SOC_DAIFMT_INV_MASK) {
++	case SND_SOC_DAIFMT_NB_NF:
++		etdm_data->bck_inv = false;
++		etdm_data->lrck_inv = false;
++		break;
++	case SND_SOC_DAIFMT_NB_IF:
++		etdm_data->bck_inv = false;
++		etdm_data->lrck_inv = true;
++		break;
++	case SND_SOC_DAIFMT_IB_NF:
++		etdm_data->bck_inv = true;
++		etdm_data->lrck_inv = false;
++		break;
++	case SND_SOC_DAIFMT_IB_IF:
++		etdm_data->bck_inv = true;
++		etdm_data->lrck_inv = true;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	switch (fmt & SND_SOC_DAIFMT_MASTER_MASK) {
++	case SND_SOC_DAIFMT_CBM_CFM:
++		etdm_data->slave_mode = true;
++		break;
++	case SND_SOC_DAIFMT_CBS_CFS:
++		etdm_data->slave_mode = false;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static const struct snd_soc_dai_ops mtk_dai_etdm_ops = {
++	.startup = mtk_dai_etdm_startup,
++	.shutdown = mtk_dai_etdm_shutdown,
++	.hw_params = mtk_dai_etdm_hw_params,
++	.trigger = mtk_dai_etdm_trigger,
++	.set_fmt = mtk_dai_etdm_set_fmt,
++};
++
++/* dai driver */
++#define MTK_ETDM_RATES (SNDRV_PCM_RATE_8000_48000 |\
++			SNDRV_PCM_RATE_88200 |\
++			SNDRV_PCM_RATE_96000 |\
++			SNDRV_PCM_RATE_176400 |\
++			SNDRV_PCM_RATE_192000)
++
++#define MTK_ETDM_FORMATS (SNDRV_PCM_FMTBIT_S16_LE |\
++			  SNDRV_PCM_FMTBIT_S24_LE |\
++			  SNDRV_PCM_FMTBIT_S32_LE)
++
++static struct snd_soc_dai_driver mtk_dai_etdm_driver[] = {
++	{
++		.name = "ETDM",
++		.id = MT7986_DAI_ETDM,
++		.capture = {
++			.stream_name = "ETDM Capture",
++			.channels_min = 1,
++			.channels_max = 2,
++			.rates = MTK_ETDM_RATES,
++			.formats = MTK_ETDM_FORMATS,
++		},
++		.playback = {
++			.stream_name = "ETDM Playback",
++			.channels_min = 1,
++			.channels_max = 2,
++			.rates = MTK_ETDM_RATES,
++			.formats = MTK_ETDM_FORMATS,
++		},
++		.ops = &mtk_dai_etdm_ops,
++		.symmetric_rate = 1,
++		.symmetric_sample_bits = 1,
++	},
++};
++
++int mt7986_dai_etdm_register(struct mtk_base_afe *afe)
++{
++	struct mtk_base_afe_dai *dai;
++
++	dai = devm_kzalloc(afe->dev, sizeof(*dai), GFP_KERNEL);
++	if (!dai)
++		return -ENOMEM;
++
++	list_add(&dai->list, &afe->sub_dais);
++
++	dai->dai_drivers = mtk_dai_etdm_driver;
++	dai->num_dai_drivers = ARRAY_SIZE(mtk_dai_etdm_driver);
++
++	dai->dapm_widgets = mtk_dai_etdm_widgets;
++	dai->num_dapm_widgets = ARRAY_SIZE(mtk_dai_etdm_widgets);
++	dai->dapm_routes = mtk_dai_etdm_routes;
++	dai->num_dapm_routes = ARRAY_SIZE(mtk_dai_etdm_routes);
++
++	return 0;
++}

--- a/target/linux/mediatek/patches-5.15/860-v6.6-03-ASoC-mediatek-mt7986-add-platform-driver.patch
+++ b/target/linux/mediatek/patches-5.15/860-v6.6-03-ASoC-mediatek-mt7986-add-platform-driver.patch
@@ -1,0 +1,685 @@
+From fc7776dee86bc07d22820a904760a95f49a2f12e Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 17 Aug 2023 18:13:35 +0800
+Subject: [PATCH 3/9] ASoC: mediatek: mt7986: add platform driver
+
+Add mt7986 platform driver.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20230817101338.18782-4-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/mediatek/Kconfig                 |  10 +
+ sound/soc/mediatek/Makefile                |   1 +
+ sound/soc/mediatek/mt7986/Makefile         |   8 +
+ sound/soc/mediatek/mt7986/mt7986-afe-pcm.c | 622 +++++++++++++++++++++
+ 4 files changed, 641 insertions(+)
+ create mode 100644 sound/soc/mediatek/mt7986/Makefile
+ create mode 100644 sound/soc/mediatek/mt7986/mt7986-afe-pcm.c
+
+--- a/sound/soc/mediatek/Kconfig
++++ b/sound/soc/mediatek/Kconfig
+@@ -54,6 +54,16 @@ config SND_SOC_MT6797_MT6351
+ 	  Select Y if you have such device.
+ 	  If unsure select "N".
+ 
++config SND_SOC_MT7986
++	tristate "ASoC support for Mediatek MT7986 chip"
++	depends on ARCH_MEDIATEK
++	select SND_SOC_MEDIATEK
++	help
++	  This adds ASoC platform driver support for MediaTek MT7986 chip
++	  that can be used with other codecs.
++	  Select Y if you have such device.
++	  If unsure select "N".
++
+ config SND_SOC_MT8173
+ 	tristate "ASoC support for Mediatek MT8173 chip"
+ 	depends on ARCH_MEDIATEK
+--- a/sound/soc/mediatek/Makefile
++++ b/sound/soc/mediatek/Makefile
+@@ -2,6 +2,7 @@
+ obj-$(CONFIG_SND_SOC_MEDIATEK) += common/
+ obj-$(CONFIG_SND_SOC_MT2701) += mt2701/
+ obj-$(CONFIG_SND_SOC_MT6797) += mt6797/
++obj-$(CONFIG_SND_SOC_MT7986) += mt7986/
+ obj-$(CONFIG_SND_SOC_MT8173) += mt8173/
+ obj-$(CONFIG_SND_SOC_MT8183) += mt8183/
+ obj-$(CONFIG_SND_SOC_MT8192) += mt8192/
+--- /dev/null
++++ b/sound/soc/mediatek/mt7986/Makefile
+@@ -0,0 +1,8 @@
++# SPDX-License-Identifier: GPL-2.0
++
++# platform driver
++snd-soc-mt7986-afe-objs := \
++	mt7986-afe-pcm.o \
++	mt7986-dai-etdm.o
++
++obj-$(CONFIG_SND_SOC_MT7986) += snd-soc-mt7986-afe.o
+--- /dev/null
++++ b/sound/soc/mediatek/mt7986/mt7986-afe-pcm.c
+@@ -0,0 +1,622 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * MediaTek ALSA SoC AFE platform driver for MT7986
++ *
++ * Copyright (c) 2023 MediaTek Inc.
++ * Authors: Vic Wu <vic.wu@mediatek.com>
++ *          Maso Huang <maso.huang@mediatek.com>
++ */
++
++#include <linux/clk.h>
++#include <linux/delay.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_address.h>
++#include <linux/pm_runtime.h>
++
++#include "mt7986-afe-common.h"
++#include "mt7986-reg.h"
++#include "../common/mtk-afe-platform-driver.h"
++#include "../common/mtk-afe-fe-dai.h"
++
++enum {
++	MTK_AFE_RATE_8K = 0,
++	MTK_AFE_RATE_11K = 1,
++	MTK_AFE_RATE_12K = 2,
++	MTK_AFE_RATE_16K = 4,
++	MTK_AFE_RATE_22K = 5,
++	MTK_AFE_RATE_24K = 6,
++	MTK_AFE_RATE_32K = 8,
++	MTK_AFE_RATE_44K = 9,
++	MTK_AFE_RATE_48K = 10,
++	MTK_AFE_RATE_88K = 13,
++	MTK_AFE_RATE_96K = 14,
++	MTK_AFE_RATE_176K = 17,
++	MTK_AFE_RATE_192K = 18,
++};
++
++enum {
++	CLK_INFRA_AUD_BUS_CK = 0,
++	CLK_INFRA_AUD_26M_CK,
++	CLK_INFRA_AUD_L_CK,
++	CLK_INFRA_AUD_AUD_CK,
++	CLK_INFRA_AUD_EG2_CK,
++	CLK_NUM
++};
++
++static const char *aud_clks[CLK_NUM] = {
++	[CLK_INFRA_AUD_BUS_CK] = "aud_bus_ck",
++	[CLK_INFRA_AUD_26M_CK] = "aud_26m_ck",
++	[CLK_INFRA_AUD_L_CK] = "aud_l_ck",
++	[CLK_INFRA_AUD_AUD_CK] = "aud_aud_ck",
++	[CLK_INFRA_AUD_EG2_CK] = "aud_eg2_ck",
++};
++
++unsigned int mt7986_afe_rate_transform(struct device *dev, unsigned int rate)
++{
++	switch (rate) {
++	case 8000:
++		return MTK_AFE_RATE_8K;
++	case 11025:
++		return MTK_AFE_RATE_11K;
++	case 12000:
++		return MTK_AFE_RATE_12K;
++	case 16000:
++		return MTK_AFE_RATE_16K;
++	case 22050:
++		return MTK_AFE_RATE_22K;
++	case 24000:
++		return MTK_AFE_RATE_24K;
++	case 32000:
++		return MTK_AFE_RATE_32K;
++	case 44100:
++		return MTK_AFE_RATE_44K;
++	case 48000:
++		return MTK_AFE_RATE_48K;
++	case 88200:
++		return MTK_AFE_RATE_88K;
++	case 96000:
++		return MTK_AFE_RATE_96K;
++	case 176400:
++		return MTK_AFE_RATE_176K;
++	case 192000:
++		return MTK_AFE_RATE_192K;
++	default:
++		dev_warn(dev, "%s(), rate %u invalid, using %d!!!\n",
++			 __func__, rate, MTK_AFE_RATE_48K);
++		return MTK_AFE_RATE_48K;
++	}
++}
++
++static const struct snd_pcm_hardware mt7986_afe_hardware = {
++	.info = SNDRV_PCM_INFO_MMAP |
++		SNDRV_PCM_INFO_INTERLEAVED |
++		SNDRV_PCM_INFO_MMAP_VALID,
++	.formats = SNDRV_PCM_FMTBIT_S16_LE |
++		   SNDRV_PCM_FMTBIT_S24_LE |
++		   SNDRV_PCM_FMTBIT_S32_LE,
++	.period_bytes_min = 256,
++	.period_bytes_max = 4 * 48 * 1024,
++	.periods_min = 2,
++	.periods_max = 256,
++	.buffer_bytes_max = 8 * 48 * 1024,
++	.fifo_size = 0,
++};
++
++static int mt7986_memif_fs(struct snd_pcm_substream *substream,
++			   unsigned int rate)
++{
++	struct snd_soc_pcm_runtime *rtd = substream->private_data;
++	struct snd_soc_component *component = snd_soc_rtdcom_lookup(rtd, AFE_PCM_NAME);
++	struct mtk_base_afe *afe = snd_soc_component_get_drvdata(component);
++
++	return mt7986_afe_rate_transform(afe->dev, rate);
++}
++
++static int mt7986_irq_fs(struct snd_pcm_substream *substream,
++			 unsigned int rate)
++{
++	struct snd_soc_pcm_runtime *rtd = substream->private_data;
++	struct snd_soc_component *component = snd_soc_rtdcom_lookup(rtd, AFE_PCM_NAME);
++	struct mtk_base_afe *afe = snd_soc_component_get_drvdata(component);
++
++	return mt7986_afe_rate_transform(afe->dev, rate);
++}
++
++#define MTK_PCM_RATES (SNDRV_PCM_RATE_8000_48000 |\
++		       SNDRV_PCM_RATE_88200 |\
++		       SNDRV_PCM_RATE_96000 |\
++		       SNDRV_PCM_RATE_176400 |\
++		       SNDRV_PCM_RATE_192000)
++
++#define MTK_PCM_FORMATS (SNDRV_PCM_FMTBIT_S16_LE |\
++			 SNDRV_PCM_FMTBIT_S24_LE |\
++			 SNDRV_PCM_FMTBIT_S32_LE)
++
++static struct snd_soc_dai_driver mt7986_memif_dai_driver[] = {
++	/* FE DAIs: memory intefaces to CPU */
++	{
++		.name = "DL1",
++		.id = MT7986_MEMIF_DL1,
++		.playback = {
++			.stream_name = "DL1",
++			.channels_min = 1,
++			.channels_max = 2,
++			.rates = MTK_PCM_RATES,
++			.formats = MTK_PCM_FORMATS,
++		},
++		.ops = &mtk_afe_fe_ops,
++	},
++	{
++		.name = "UL1",
++		.id = MT7986_MEMIF_VUL12,
++		.capture = {
++			.stream_name = "UL1",
++			.channels_min = 1,
++			.channels_max = 2,
++			.rates = MTK_PCM_RATES,
++			.formats = MTK_PCM_FORMATS,
++		},
++		.ops = &mtk_afe_fe_ops,
++	},
++};
++
++static const struct snd_kcontrol_new o018_mix[] = {
++	SOC_DAPM_SINGLE_AUTODISABLE("I150_Switch", AFE_CONN018_4, 22, 1, 0),
++};
++
++static const struct snd_kcontrol_new o019_mix[] = {
++	SOC_DAPM_SINGLE_AUTODISABLE("I151_Switch", AFE_CONN019_4, 23, 1, 0),
++};
++
++static const struct snd_soc_dapm_widget mt7986_memif_widgets[] = {
++	/* DL */
++	SND_SOC_DAPM_MIXER("I032", SND_SOC_NOPM, 0, 0, NULL, 0),
++	SND_SOC_DAPM_MIXER("I033", SND_SOC_NOPM, 0, 0, NULL, 0),
++
++	/* UL */
++	SND_SOC_DAPM_MIXER("O018", SND_SOC_NOPM, 0, 0,
++			   o018_mix, ARRAY_SIZE(o018_mix)),
++	SND_SOC_DAPM_MIXER("O019", SND_SOC_NOPM, 0, 0,
++			   o019_mix, ARRAY_SIZE(o019_mix)),
++};
++
++static const struct snd_soc_dapm_route mt7986_memif_routes[] = {
++	{"I032", NULL, "DL1"},
++	{"I033", NULL, "DL1"},
++	{"UL1", NULL, "O018"},
++	{"UL1", NULL, "O019"},
++	{"O018", "I150_Switch", "I150"},
++	{"O019", "I151_Switch", "I151"},
++};
++
++static const struct snd_soc_component_driver mt7986_afe_pcm_dai_component = {
++	.name = "mt7986-afe-pcm-dai",
++};
++
++static const struct mtk_base_memif_data memif_data[MT7986_MEMIF_NUM] = {
++	[MT7986_MEMIF_DL1] = {
++		.name = "DL1",
++		.id = MT7986_MEMIF_DL1,
++		.reg_ofs_base = AFE_DL0_BASE,
++		.reg_ofs_cur = AFE_DL0_CUR,
++		.reg_ofs_end = AFE_DL0_END,
++		.reg_ofs_base_msb = AFE_DL0_BASE_MSB,
++		.reg_ofs_cur_msb = AFE_DL0_CUR_MSB,
++		.reg_ofs_end_msb = AFE_DL0_END_MSB,
++		.fs_reg = AFE_DL0_CON0,
++		.fs_shift =  DL0_MODE_SFT,
++		.fs_maskbit =  DL0_MODE_MASK,
++		.mono_reg = AFE_DL0_CON0,
++		.mono_shift = DL0_MONO_SFT,
++		.enable_reg = AFE_DL0_CON0,
++		.enable_shift = DL0_ON_SFT,
++		.hd_reg = AFE_DL0_CON0,
++		.hd_shift = DL0_HD_MODE_SFT,
++		.hd_align_reg = AFE_DL0_CON0,
++		.hd_align_mshift = DL0_HALIGN_SFT,
++		.pbuf_reg = AFE_DL0_CON0,
++		.pbuf_shift = DL0_PBUF_SIZE_SFT,
++		.minlen_reg = AFE_DL0_CON0,
++		.minlen_shift = DL0_MINLEN_SFT,
++	},
++	[MT7986_MEMIF_VUL12] = {
++		.name = "VUL12",
++		.id = MT7986_MEMIF_VUL12,
++		.reg_ofs_base = AFE_VUL0_BASE,
++		.reg_ofs_cur = AFE_VUL0_CUR,
++		.reg_ofs_end = AFE_VUL0_END,
++		.reg_ofs_base_msb = AFE_VUL0_BASE_MSB,
++		.reg_ofs_cur_msb = AFE_VUL0_CUR_MSB,
++		.reg_ofs_end_msb = AFE_VUL0_END_MSB,
++		.fs_reg = AFE_VUL0_CON0,
++		.fs_shift = VUL0_MODE_SFT,
++		.fs_maskbit = VUL0_MODE_MASK,
++		.mono_reg = AFE_VUL0_CON0,
++		.mono_shift = VUL0_MONO_SFT,
++		.enable_reg = AFE_VUL0_CON0,
++		.enable_shift = VUL0_ON_SFT,
++		.hd_reg = AFE_VUL0_CON0,
++		.hd_shift = VUL0_HD_MODE_SFT,
++		.hd_align_reg = AFE_VUL0_CON0,
++		.hd_align_mshift = VUL0_HALIGN_SFT,
++	},
++};
++
++static const struct mtk_base_irq_data irq_data[MT7986_IRQ_NUM] = {
++	[MT7986_IRQ_0] = {
++		.id = MT7986_IRQ_0,
++		.irq_cnt_reg = AFE_IRQ0_MCU_CFG1,
++		.irq_cnt_shift = AFE_IRQ_CNT_SHIFT,
++		.irq_cnt_maskbit = AFE_IRQ_CNT_MASK,
++		.irq_fs_reg = AFE_IRQ0_MCU_CFG0,
++		.irq_fs_shift = IRQ_MCU_MODE_SFT,
++		.irq_fs_maskbit = IRQ_MCU_MODE_MASK,
++		.irq_en_reg = AFE_IRQ0_MCU_CFG0,
++		.irq_en_shift = IRQ_MCU_ON_SFT,
++		.irq_clr_reg = AFE_IRQ_MCU_CLR,
++		.irq_clr_shift = IRQ0_MCU_CLR_SFT,
++	},
++	[MT7986_IRQ_1] = {
++		.id = MT7986_IRQ_1,
++		.irq_cnt_reg = AFE_IRQ1_MCU_CFG1,
++		.irq_cnt_shift = AFE_IRQ_CNT_SHIFT,
++		.irq_cnt_maskbit = AFE_IRQ_CNT_MASK,
++		.irq_fs_reg = AFE_IRQ1_MCU_CFG0,
++		.irq_fs_shift = IRQ_MCU_MODE_SFT,
++		.irq_fs_maskbit = IRQ_MCU_MODE_MASK,
++		.irq_en_reg = AFE_IRQ1_MCU_CFG0,
++		.irq_en_shift = IRQ_MCU_ON_SFT,
++		.irq_clr_reg = AFE_IRQ_MCU_CLR,
++		.irq_clr_shift = IRQ1_MCU_CLR_SFT,
++	},
++	[MT7986_IRQ_2] = {
++		.id = MT7986_IRQ_2,
++		.irq_cnt_reg = AFE_IRQ2_MCU_CFG1,
++		.irq_cnt_shift = AFE_IRQ_CNT_SHIFT,
++		.irq_cnt_maskbit = AFE_IRQ_CNT_MASK,
++		.irq_fs_reg = AFE_IRQ2_MCU_CFG0,
++		.irq_fs_shift = IRQ_MCU_MODE_SFT,
++		.irq_fs_maskbit = IRQ_MCU_MODE_MASK,
++		.irq_en_reg = AFE_IRQ2_MCU_CFG0,
++		.irq_en_shift = IRQ_MCU_ON_SFT,
++		.irq_clr_reg = AFE_IRQ_MCU_CLR,
++		.irq_clr_shift = IRQ2_MCU_CLR_SFT,
++	},
++};
++
++static bool mt7986_is_volatile_reg(struct device *dev, unsigned int reg)
++{
++	/*
++	 * Those auto-gen regs are read-only, so put it as volatile because
++	 * volatile registers cannot be cached, which means that they cannot
++	 * be set when power is off
++	 */
++
++	switch (reg) {
++	case AFE_DL0_CUR_MSB:
++	case AFE_DL0_CUR:
++	case AFE_DL0_RCH_MON:
++	case AFE_DL0_LCH_MON:
++	case AFE_VUL0_CUR_MSB:
++	case AFE_VUL0_CUR:
++	case AFE_IRQ_MCU_STATUS:
++	case AFE_MEMIF_RD_MON:
++	case AFE_MEMIF_WR_MON:
++		return true;
++	default:
++		return false;
++	};
++}
++
++static const struct regmap_config mt7986_afe_regmap_config = {
++	.reg_bits = 32,
++	.reg_stride = 4,
++	.val_bits = 32,
++	.volatile_reg = mt7986_is_volatile_reg,
++	.max_register = AFE_MAX_REGISTER,
++	.num_reg_defaults_raw = ((AFE_MAX_REGISTER / 4) + 1),
++};
++
++static int mt7986_init_clock(struct mtk_base_afe *afe)
++{
++	struct mt7986_afe_private *afe_priv = afe->platform_priv;
++	int ret, i;
++
++	afe_priv->clks = devm_kcalloc(afe->dev, CLK_NUM,
++				sizeof(*afe_priv->clks), GFP_KERNEL);
++	if (!afe_priv->clks)
++		return -ENOMEM;
++	afe_priv->num_clks = CLK_NUM;
++
++	for (i = 0; i < afe_priv->num_clks; i++)
++		afe_priv->clks[i].id = aud_clks[i];
++
++	ret = devm_clk_bulk_get(afe->dev, afe_priv->num_clks, afe_priv->clks);
++	if (ret)
++		return dev_err_probe(afe->dev, ret, "Failed to get clocks\n");
++
++	return 0;
++}
++
++static irqreturn_t mt7986_afe_irq_handler(int irq_id, void *dev)
++{
++	struct mtk_base_afe *afe = dev;
++	struct mtk_base_afe_irq *irq;
++	u32 mcu_en, status, status_mcu;
++	int i, ret;
++	irqreturn_t irq_ret = IRQ_HANDLED;
++
++	/* get irq that is sent to MCU */
++	regmap_read(afe->regmap, AFE_IRQ_MCU_EN, &mcu_en);
++
++	ret = regmap_read(afe->regmap, AFE_IRQ_MCU_STATUS, &status);
++	/* only care IRQ which is sent to MCU */
++	status_mcu = status & mcu_en & AFE_IRQ_STATUS_BITS;
++
++	if (ret || status_mcu == 0) {
++		dev_err(afe->dev, "%s(), irq status err, ret %d, status 0x%x, mcu_en 0x%x\n",
++			__func__, ret, status, mcu_en);
++
++		irq_ret = IRQ_NONE;
++		goto err_irq;
++	}
++
++	for (i = 0; i < MT7986_MEMIF_NUM; i++) {
++		struct mtk_base_afe_memif *memif = &afe->memif[i];
++
++		if (!memif->substream)
++			continue;
++
++		if (memif->irq_usage < 0)
++			continue;
++
++		irq = &afe->irqs[memif->irq_usage];
++
++		if (status_mcu & (1 << irq->irq_data->irq_en_shift))
++			snd_pcm_period_elapsed(memif->substream);
++	}
++
++err_irq:
++	/* clear irq */
++	regmap_write(afe->regmap, AFE_IRQ_MCU_CLR, status_mcu);
++
++	return irq_ret;
++}
++
++static int mt7986_afe_runtime_suspend(struct device *dev)
++{
++	struct mtk_base_afe *afe = dev_get_drvdata(dev);
++	struct mt7986_afe_private *afe_priv = afe->platform_priv;
++
++	if (!afe->regmap || afe_priv->pm_runtime_bypass_reg_ctl)
++		goto skip_regmap;
++
++	/* disable clk*/
++	regmap_update_bits(afe->regmap, AUDIO_TOP_CON4, 0x3fff, 0x3fff);
++	regmap_update_bits(afe->regmap, AUDIO_ENGEN_CON0, AUD_APLL2_EN_MASK, 0);
++	regmap_update_bits(afe->regmap, AUDIO_ENGEN_CON0, AUD_26M_EN_MASK, 0);
++
++	/* make sure all irq status are cleared, twice intended */
++	regmap_update_bits(afe->regmap, AFE_IRQ_MCU_CLR, 0xffff, 0xffff);
++
++skip_regmap:
++	clk_bulk_disable_unprepare(afe_priv->num_clks, afe_priv->clks);
++
++	return 0;
++}
++
++static int mt7986_afe_runtime_resume(struct device *dev)
++{
++	struct mtk_base_afe *afe = dev_get_drvdata(dev);
++	struct mt7986_afe_private *afe_priv = afe->platform_priv;
++	int ret;
++
++	ret = clk_bulk_prepare_enable(afe_priv->num_clks, afe_priv->clks);
++	if (ret)
++		return dev_err_probe(afe->dev, ret, "Failed to enable clocks\n");
++
++	if (!afe->regmap || afe_priv->pm_runtime_bypass_reg_ctl)
++		return 0;
++
++	/* enable clk*/
++	regmap_update_bits(afe->regmap, AUDIO_TOP_CON4, 0x3fff, 0);
++	regmap_update_bits(afe->regmap, AUDIO_ENGEN_CON0, AUD_APLL2_EN_MASK,
++			   AUD_APLL2_EN);
++	regmap_update_bits(afe->regmap, AUDIO_ENGEN_CON0, AUD_26M_EN_MASK,
++			   AUD_26M_EN);
++
++	return 0;
++}
++
++static int mt7986_afe_component_probe(struct snd_soc_component *component)
++{
++	return mtk_afe_add_sub_dai_control(component);
++}
++
++static const struct snd_soc_component_driver mt7986_afe_component = {
++	.name = AFE_PCM_NAME,
++	.probe = mt7986_afe_component_probe,
++	.pointer	= mtk_afe_pcm_pointer,
++	.pcm_construct	= mtk_afe_pcm_new,
++};
++
++static int mt7986_dai_memif_register(struct mtk_base_afe *afe)
++{
++	struct mtk_base_afe_dai *dai;
++
++	dai = devm_kzalloc(afe->dev, sizeof(*dai), GFP_KERNEL);
++	if (!dai)
++		return -ENOMEM;
++
++	list_add(&dai->list, &afe->sub_dais);
++
++	dai->dai_drivers = mt7986_memif_dai_driver;
++	dai->num_dai_drivers = ARRAY_SIZE(mt7986_memif_dai_driver);
++
++	dai->dapm_widgets = mt7986_memif_widgets;
++	dai->num_dapm_widgets = ARRAY_SIZE(mt7986_memif_widgets);
++	dai->dapm_routes = mt7986_memif_routes;
++	dai->num_dapm_routes = ARRAY_SIZE(mt7986_memif_routes);
++
++	return 0;
++}
++
++typedef int (*dai_register_cb)(struct mtk_base_afe *);
++static const dai_register_cb dai_register_cbs[] = {
++	mt7986_dai_etdm_register,
++	mt7986_dai_memif_register,
++};
++
++static int mt7986_afe_pcm_dev_probe(struct platform_device *pdev)
++{
++	struct mtk_base_afe *afe;
++	struct mt7986_afe_private *afe_priv;
++	struct device *dev;
++	int i, irq_id, ret;
++
++	afe = devm_kzalloc(&pdev->dev, sizeof(*afe), GFP_KERNEL);
++	if (!afe)
++		return -ENOMEM;
++	platform_set_drvdata(pdev, afe);
++
++	afe->platform_priv = devm_kzalloc(&pdev->dev, sizeof(*afe_priv),
++					  GFP_KERNEL);
++	if (!afe->platform_priv)
++		return -ENOMEM;
++
++	afe_priv = afe->platform_priv;
++	afe->dev = &pdev->dev;
++	dev = afe->dev;
++
++	afe->base_addr = devm_platform_ioremap_resource(pdev, 0);
++	if (IS_ERR(afe->base_addr))
++		return PTR_ERR(afe->base_addr);
++
++	/* initial audio related clock */
++	ret = mt7986_init_clock(afe);
++	if (ret)
++		return dev_err_probe(dev, ret, "Cannot initialize clocks\n");
++
++	ret = devm_pm_runtime_enable(dev);
++	if (ret)
++		return ret;
++
++	/* enable clock for regcache get default value from hw */
++	afe_priv->pm_runtime_bypass_reg_ctl = true;
++	pm_runtime_get_sync(&pdev->dev);
++
++	afe->regmap = devm_regmap_init_mmio(&pdev->dev, afe->base_addr,
++		      &mt7986_afe_regmap_config);
++
++	pm_runtime_put_sync(&pdev->dev);
++	if (IS_ERR(afe->regmap))
++		return PTR_ERR(afe->regmap);
++
++	afe_priv->pm_runtime_bypass_reg_ctl = false;
++
++	/* init memif */
++	afe->memif_size = MT7986_MEMIF_NUM;
++	afe->memif = devm_kcalloc(dev, afe->memif_size, sizeof(*afe->memif),
++				  GFP_KERNEL);
++	if (!afe->memif)
++		return -ENOMEM;
++
++	for (i = 0; i < afe->memif_size; i++) {
++		afe->memif[i].data = &memif_data[i];
++		afe->memif[i].irq_usage = -1;
++	}
++
++	mutex_init(&afe->irq_alloc_lock);
++
++	/* irq initialize */
++	afe->irqs_size = MT7986_IRQ_NUM;
++	afe->irqs = devm_kcalloc(dev, afe->irqs_size, sizeof(*afe->irqs),
++				 GFP_KERNEL);
++	if (!afe->irqs)
++		return -ENOMEM;
++
++	for (i = 0; i < afe->irqs_size; i++)
++		afe->irqs[i].irq_data = &irq_data[i];
++
++	/* request irq */
++	irq_id = platform_get_irq(pdev, 0);
++	if (irq_id < 0) {
++		ret = irq_id;
++		return dev_err_probe(dev, ret, "No irq found\n");
++	}
++	ret = devm_request_irq(dev, irq_id, mt7986_afe_irq_handler,
++			       IRQF_TRIGGER_NONE, "asys-isr", (void *)afe);
++	if (ret)
++		return dev_err_probe(dev, ret, "Failed to request irq for asys-isr\n");
++
++	/* init sub_dais */
++	INIT_LIST_HEAD(&afe->sub_dais);
++
++	for (i = 0; i < ARRAY_SIZE(dai_register_cbs); i++) {
++		ret = dai_register_cbs[i](afe);
++		if (ret)
++			return dev_err_probe(dev, ret, "DAI register failed, i: %d\n", i);
++	}
++
++	/* init dai_driver and component_driver */
++	ret = mtk_afe_combine_sub_dai(afe);
++	if (ret)
++		return dev_err_probe(dev, ret, "mtk_afe_combine_sub_dai fail\n");
++
++	afe->mtk_afe_hardware = &mt7986_afe_hardware;
++	afe->memif_fs = mt7986_memif_fs;
++	afe->irq_fs = mt7986_irq_fs;
++
++	afe->runtime_resume = mt7986_afe_runtime_resume;
++	afe->runtime_suspend = mt7986_afe_runtime_suspend;
++
++	/* register component */
++	ret = devm_snd_soc_register_component(&pdev->dev,
++					      &mt7986_afe_component,
++					      NULL, 0);
++	if (ret)
++		return dev_err_probe(dev, ret, "Cannot register AFE component\n");
++
++	ret = devm_snd_soc_register_component(afe->dev,
++					      &mt7986_afe_pcm_dai_component,
++					      afe->dai_drivers,
++					      afe->num_dai_drivers);
++	if (ret)
++		return dev_err_probe(dev, ret, "Cannot register PCM DAI component\n");
++
++	return 0;
++}
++
++static void mt7986_afe_pcm_dev_remove(struct platform_device *pdev)
++{
++	pm_runtime_disable(&pdev->dev);
++	if (!pm_runtime_status_suspended(&pdev->dev))
++		mt7986_afe_runtime_suspend(&pdev->dev);
++}
++
++static const struct of_device_id mt7986_afe_pcm_dt_match[] = {
++	{ .compatible = "mediatek,mt7986-afe" },
++	{ /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(of, mt7986_afe_pcm_dt_match);
++
++static const struct dev_pm_ops mt7986_afe_pm_ops = {
++	SET_RUNTIME_PM_OPS(mt7986_afe_runtime_suspend,
++			   mt7986_afe_runtime_resume, NULL)
++};
++
++static struct platform_driver mt7986_afe_pcm_driver = {
++	.driver = {
++		   .name = "mt7986-audio",
++		   .of_match_table = mt7986_afe_pcm_dt_match,
++		   .pm = &mt7986_afe_pm_ops,
++	},
++	.probe = mt7986_afe_pcm_dev_probe,
++	.remove_new = mt7986_afe_pcm_dev_remove,
++};
++module_platform_driver(mt7986_afe_pcm_driver);
++
++MODULE_DESCRIPTION("MediaTek SoC AFE platform driver for ALSA MT7986");
++MODULE_AUTHOR("Vic Wu <vic.wu@mediatek.com>");
++MODULE_LICENSE("GPL");

--- a/target/linux/mediatek/patches-5.15/860-v6.6-04-ASoC-mediatek-mt7986-add-machine-driver-with-wm8960.patch
+++ b/target/linux/mediatek/patches-5.15/860-v6.6-04-ASoC-mediatek-mt7986-add-machine-driver-with-wm8960.patch
@@ -1,0 +1,243 @@
+From ddf6abc1c78072f8ccad59166be95f0ca5af8ca4 Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 17 Aug 2023 18:13:36 +0800
+Subject: [PATCH 4/9] ASoC: mediatek: mt7986: add machine driver with wm8960
+
+Add support for mt7986 board with wm8960.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20230817101338.18782-5-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/mediatek/Kconfig                |  10 ++
+ sound/soc/mediatek/mt7986/Makefile        |   1 +
+ sound/soc/mediatek/mt7986/mt7986-wm8960.c | 196 ++++++++++++++++++++++
+ 3 files changed, 207 insertions(+)
+ create mode 100644 sound/soc/mediatek/mt7986/mt7986-wm8960.c
+
+--- a/sound/soc/mediatek/Kconfig
++++ b/sound/soc/mediatek/Kconfig
+@@ -64,6 +64,16 @@ config SND_SOC_MT7986
+ 	  Select Y if you have such device.
+ 	  If unsure select "N".
+ 
++config SND_SOC_MT7986_WM8960
++	tristate "ASoc Audio driver for MT7986 with WM8960 codec"
++	depends on SND_SOC_MT7986 && I2C
++	select SND_SOC_WM8960
++	help
++	  This adds support for ASoC machine driver for MediaTek MT7986
++	  boards with the WM8960 codecs.
++	  Select Y if you have such device.
++	  If unsure select "N".
++
+ config SND_SOC_MT8173
+ 	tristate "ASoC support for Mediatek MT8173 chip"
+ 	depends on ARCH_MEDIATEK
+--- a/sound/soc/mediatek/mt7986/Makefile
++++ b/sound/soc/mediatek/mt7986/Makefile
+@@ -6,3 +6,4 @@ snd-soc-mt7986-afe-objs := \
+ 	mt7986-dai-etdm.o
+ 
+ obj-$(CONFIG_SND_SOC_MT7986) += snd-soc-mt7986-afe.o
++obj-$(CONFIG_SND_SOC_MT7986_WM8960) += mt7986-wm8960.o
+--- /dev/null
++++ b/sound/soc/mediatek/mt7986/mt7986-wm8960.c
+@@ -0,0 +1,196 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * mt7986-wm8960.c  --  MT7986-WM8960 ALSA SoC machine driver
++ *
++ * Copyright (c) 2023 MediaTek Inc.
++ * Authors: Vic Wu <vic.wu@mediatek.com>
++ *          Maso Huang <maso.huang@mediatek.com>
++ */
++
++#include <linux/module.h>
++#include <sound/soc.h>
++
++#include "mt7986-afe-common.h"
++
++struct mt7986_wm8960_priv {
++	struct device_node *platform_node;
++	struct device_node *codec_node;
++};
++
++static const struct snd_soc_dapm_widget mt7986_wm8960_widgets[] = {
++	SND_SOC_DAPM_HP("Headphone", NULL),
++	SND_SOC_DAPM_MIC("AMIC", NULL),
++};
++
++static const struct snd_kcontrol_new mt7986_wm8960_controls[] = {
++	SOC_DAPM_PIN_SWITCH("Headphone"),
++	SOC_DAPM_PIN_SWITCH("AMIC"),
++};
++
++SND_SOC_DAILINK_DEFS(playback,
++	DAILINK_COMP_ARRAY(COMP_CPU("DL1")),
++	DAILINK_COMP_ARRAY(COMP_DUMMY()),
++	DAILINK_COMP_ARRAY(COMP_EMPTY()));
++
++SND_SOC_DAILINK_DEFS(capture,
++	DAILINK_COMP_ARRAY(COMP_CPU("UL1")),
++	DAILINK_COMP_ARRAY(COMP_DUMMY()),
++	DAILINK_COMP_ARRAY(COMP_EMPTY()));
++
++SND_SOC_DAILINK_DEFS(codec,
++	DAILINK_COMP_ARRAY(COMP_CPU("ETDM")),
++	DAILINK_COMP_ARRAY(COMP_CODEC(NULL, "wm8960-hifi")),
++	DAILINK_COMP_ARRAY(COMP_EMPTY()));
++
++static struct snd_soc_dai_link mt7986_wm8960_dai_links[] = {
++	/* FE */
++	{
++		.name = "wm8960-playback",
++		.stream_name = "wm8960-playback",
++		.trigger = {SND_SOC_DPCM_TRIGGER_POST,
++			    SND_SOC_DPCM_TRIGGER_POST},
++		.dynamic = 1,
++		.dpcm_playback = 1,
++		SND_SOC_DAILINK_REG(playback),
++	},
++	{
++		.name = "wm8960-capture",
++		.stream_name = "wm8960-capture",
++		.trigger = {SND_SOC_DPCM_TRIGGER_POST,
++			    SND_SOC_DPCM_TRIGGER_POST},
++		.dynamic = 1,
++		.dpcm_capture = 1,
++		SND_SOC_DAILINK_REG(capture),
++	},
++	/* BE */
++	{
++		.name = "wm8960-codec",
++		.no_pcm = 1,
++		.dai_fmt = SND_SOC_DAIFMT_I2S |
++			SND_SOC_DAIFMT_NB_NF |
++			SND_SOC_DAIFMT_CBS_CFS |
++			SND_SOC_DAIFMT_GATED,
++		.dpcm_playback = 1,
++		.dpcm_capture = 1,
++		SND_SOC_DAILINK_REG(codec),
++	},
++};
++
++static struct snd_soc_card mt7986_wm8960_card = {
++	.name = "mt7986-wm8960",
++	.owner = THIS_MODULE,
++	.dai_link = mt7986_wm8960_dai_links,
++	.num_links = ARRAY_SIZE(mt7986_wm8960_dai_links),
++	.controls = mt7986_wm8960_controls,
++	.num_controls = ARRAY_SIZE(mt7986_wm8960_controls),
++	.dapm_widgets = mt7986_wm8960_widgets,
++	.num_dapm_widgets = ARRAY_SIZE(mt7986_wm8960_widgets),
++};
++
++static int mt7986_wm8960_machine_probe(struct platform_device *pdev)
++{
++	struct snd_soc_card *card = &mt7986_wm8960_card;
++	struct snd_soc_dai_link *dai_link;
++	struct device_node *platform, *codec;
++	struct mt7986_wm8960_priv *priv;
++	int ret, i;
++
++	priv = devm_kzalloc(&pdev->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	platform = of_get_child_by_name(pdev->dev.of_node, "platform");
++
++	if (platform) {
++		priv->platform_node = of_parse_phandle(platform, "sound-dai", 0);
++		of_node_put(platform);
++
++		if (!priv->platform_node) {
++			dev_err(&pdev->dev, "Failed to parse platform/sound-dai property\n");
++			return -EINVAL;
++		}
++	} else {
++		dev_err(&pdev->dev, "Property 'platform' missing or invalid\n");
++		return -EINVAL;
++	}
++
++	for_each_card_prelinks(card, i, dai_link) {
++		if (dai_link->platforms->name)
++			continue;
++		dai_link->platforms->of_node = priv->platform_node;
++	}
++
++	card->dev = &pdev->dev;
++
++	codec = of_get_child_by_name(pdev->dev.of_node, "codec");
++
++	if (codec) {
++		priv->codec_node = of_parse_phandle(codec, "sound-dai", 0);
++		of_node_put(codec);
++
++		if (!priv->codec_node) {
++			of_node_put(priv->platform_node);
++			dev_err(&pdev->dev, "Failed to parse codec/sound-dai property\n");
++			return -EINVAL;
++		}
++	} else {
++		of_node_put(priv->platform_node);
++		dev_err(&pdev->dev, "Property 'codec' missing or invalid\n");
++		return -EINVAL;
++	}
++
++	for_each_card_prelinks(card, i, dai_link) {
++		if (dai_link->codecs->name)
++			continue;
++		dai_link->codecs->of_node = priv->codec_node;
++	}
++
++	ret = snd_soc_of_parse_audio_routing(card, "audio-routing");
++	if (ret) {
++		dev_err(&pdev->dev, "Failed to parse audio-routing: %d\n", ret);
++		goto err_of_node_put;
++	}
++
++	ret = devm_snd_soc_register_card(&pdev->dev, card);
++	if (ret) {
++		dev_err(&pdev->dev, "%s snd_soc_register_card fail: %d\n", __func__, ret);
++		goto err_of_node_put;
++	}
++
++err_of_node_put:
++	of_node_put(priv->codec_node);
++	of_node_put(priv->platform_node);
++	return ret;
++}
++
++static void mt7986_wm8960_machine_remove(struct platform_device *pdev)
++{
++	struct snd_soc_card *card = platform_get_drvdata(pdev);
++	struct mt7986_wm8960_priv *priv = snd_soc_card_get_drvdata(card);
++
++	of_node_put(priv->codec_node);
++	of_node_put(priv->platform_node);
++}
++
++static const struct of_device_id mt7986_wm8960_machine_dt_match[] = {
++	{.compatible = "mediatek,mt7986-wm8960-sound"},
++	{ /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(of, mt7986_wm8960_machine_dt_match);
++
++static struct platform_driver mt7986_wm8960_machine = {
++	.driver = {
++		.name = "mt7986-wm8960",
++		.of_match_table = mt7986_wm8960_machine_dt_match,
++	},
++	.probe = mt7986_wm8960_machine_probe,
++	.remove_new = mt7986_wm8960_machine_remove,
++};
++
++module_platform_driver(mt7986_wm8960_machine);
++
++/* Module information */
++MODULE_DESCRIPTION("MT7986 WM8960 ALSA SoC machine driver");
++MODULE_AUTHOR("Vic Wu <vic.wu@mediatek.com>");
++MODULE_LICENSE("GPL");
++MODULE_ALIAS("mt7986 wm8960 soc card");

--- a/target/linux/mediatek/patches-5.15/860-v6.6-05-ASoC-dt-bindings-mediatek-mt7986-wm8960-add-mt7986-w.patch
+++ b/target/linux/mediatek/patches-5.15/860-v6.6-05-ASoC-dt-bindings-mediatek-mt7986-wm8960-add-mt7986-w.patch
@@ -1,0 +1,87 @@
+From 72469f950b629e57e60fbcbefed45e083619b986 Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 17 Aug 2023 18:13:37 +0800
+Subject: [PATCH 5/9] ASoC: dt-bindings: mediatek,mt7986-wm8960: add
+ mt7986-wm8960 document
+
+Add document for mt7986 board with wm8960.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20230817101338.18782-6-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ .../sound/mediatek,mt7986-wm8960.yaml         | 67 +++++++++++++++++++
+ 1 file changed, 67 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/sound/mediatek,mt7986-wm8960.yaml
+
+--- /dev/null
++++ b/Documentation/devicetree/bindings/sound/mediatek,mt7986-wm8960.yaml
+@@ -0,0 +1,67 @@
++# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/sound/mediatek,mt7986-wm8960.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: MediaTek MT7986 sound card with WM8960 codec
++
++maintainers:
++  - Maso Huang <maso.huang@mediatek.com>
++
++allOf:
++  - $ref: sound-card-common.yaml#
++
++properties:
++  compatible:
++    const: mediatek,mt7986-wm8960-sound
++
++  platform:
++    type: object
++    additionalProperties: false
++    properties:
++      sound-dai:
++        description: The phandle of MT7986 platform.
++        maxItems: 1
++    required:
++      - sound-dai
++
++  codec:
++    type: object
++    additionalProperties: false
++    properties:
++      sound-dai:
++        description: The phandle of wm8960 codec.
++        maxItems: 1
++    required:
++      - sound-dai
++
++unevaluatedProperties: false
++
++required:
++  - compatible
++  - audio-routing
++  - platform
++  - codec
++
++examples:
++  - |
++    sound {
++        compatible = "mediatek,mt7986-wm8960-sound";
++        model = "mt7986-wm8960";
++        audio-routing =
++            "Headphone", "HP_L",
++            "Headphone", "HP_R",
++            "LINPUT1", "AMIC",
++            "RINPUT1", "AMIC";
++
++        platform {
++            sound-dai = <&afe>;
++        };
++
++        codec {
++            sound-dai = <&wm8960>;
++        };
++    };
++
++...

--- a/target/linux/mediatek/patches-5.15/860-v6.6-06-ASoC-dt-bindings-mediatek-mt7986-afe-add-audio-afe-d.patch
+++ b/target/linux/mediatek/patches-5.15/860-v6.6-06-ASoC-dt-bindings-mediatek-mt7986-afe-add-audio-afe-d.patch
@@ -1,0 +1,180 @@
+From d16202eb38585adbc16e32d11188dbc2127015de Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 17 Aug 2023 18:13:38 +0800
+Subject: [PATCH 6/9] ASoC: dt-bindings: mediatek,mt7986-afe: add audio afe
+ document
+
+Add mt7986 audio afe document.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20230817101338.18782-7-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ .../bindings/sound/mediatek,mt7986-afe.yaml   | 160 ++++++++++++++++++
+ 1 file changed, 160 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/sound/mediatek,mt7986-afe.yaml
+
+--- /dev/null
++++ b/Documentation/devicetree/bindings/sound/mediatek,mt7986-afe.yaml
+@@ -0,0 +1,160 @@
++# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/sound/mediatek,mt7986-afe.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: MediaTek AFE PCM controller for MT7986
++
++maintainers:
++  - Maso Huang <maso.huang@mediatek.com>
++
++properties:
++  compatible:
++    oneOf:
++      - const: mediatek,mt7986-afe
++      - items:
++          - enum:
++              - mediatek,mt7981-afe
++              - mediatek,mt7988-afe
++          - const: mediatek,mt7986-afe
++
++  reg:
++    maxItems: 1
++
++  interrupts:
++    maxItems: 1
++
++  clocks:
++    minItems: 5
++    items:
++      - description: audio bus clock
++      - description: audio 26M clock
++      - description: audio intbus clock
++      - description: audio hopping clock
++      - description: audio pll clock
++      - description: mux for pcm_mck
++      - description: audio i2s/pcm mck
++
++  clock-names:
++    minItems: 5
++    items:
++      - const: bus_ck
++      - const: 26m_ck
++      - const: l_ck
++      - const: aud_ck
++      - const: eg2_ck
++      - const: sel
++      - const: i2s_m
++
++required:
++  - compatible
++  - reg
++  - interrupts
++  - clocks
++  - clock-names
++
++allOf:
++  - if:
++      properties:
++        compatible:
++          contains:
++            const: mediatek,mt7986-afe
++    then:
++      properties:
++        clocks:
++          items:
++            - description: audio bus clock
++            - description: audio 26M clock
++            - description: audio intbus clock
++            - description: audio hopping clock
++            - description: audio pll clock
++        clock-names:
++          items:
++            - const: bus_ck
++            - const: 26m_ck
++            - const: l_ck
++            - const: aud_ck
++            - const: eg2_ck
++
++  - if:
++      properties:
++        compatible:
++          contains:
++            const: mediatek,mt7981-afe
++    then:
++      properties:
++        clocks:
++          items:
++            - description: audio bus clock
++            - description: audio 26M clock
++            - description: audio intbus clock
++            - description: audio hopping clock
++            - description: audio pll clock
++            - description: mux for pcm_mck
++        clock-names:
++          items:
++            - const: bus_ck
++            - const: 26m_ck
++            - const: l_ck
++            - const: aud_ck
++            - const: eg2_ck
++            - const: sel
++
++  - if:
++      properties:
++        compatible:
++          contains:
++            const: mediatek,mt7988-afe
++    then:
++      properties:
++        clocks:
++          items:
++            - description: audio bus clock
++            - description: audio 26M clock
++            - description: audio intbus clock
++            - description: audio hopping clock
++            - description: audio pll clock
++            - description: mux for pcm_mck
++            - description: audio i2s/pcm mck
++        clock-names:
++          items:
++            - const: bus_ck
++            - const: 26m_ck
++            - const: l_ck
++            - const: aud_ck
++            - const: eg2_ck
++            - const: sel
++            - const: i2s_m
++
++additionalProperties: false
++
++examples:
++  - |
++    #include <dt-bindings/interrupt-controller/arm-gic.h>
++    #include <dt-bindings/interrupt-controller/irq.h>
++    #include <dt-bindings/clock/mt7986-clk.h>
++
++    afe@11210000 {
++        compatible = "mediatek,mt7986-afe";
++        reg = <0x11210000 0x9000>;
++        interrupts = <GIC_SPI 106 IRQ_TYPE_LEVEL_HIGH>;
++        clocks = <&infracfg_ao CLK_INFRA_AUD_BUS_CK>,
++                 <&infracfg_ao CLK_INFRA_AUD_26M_CK>,
++                 <&infracfg_ao CLK_INFRA_AUD_L_CK>,
++                 <&infracfg_ao CLK_INFRA_AUD_AUD_CK>,
++                 <&infracfg_ao CLK_INFRA_AUD_EG2_CK>;
++        clock-names = "bus_ck",
++                      "26m_ck",
++                      "l_ck",
++                      "aud_ck",
++                      "eg2_ck";
++        assigned-clocks = <&topckgen CLK_TOP_A1SYS_SEL>,
++                          <&topckgen CLK_TOP_AUD_L_SEL>,
++                          <&topckgen CLK_TOP_A_TUNER_SEL>;
++        assigned-clock-parents = <&topckgen CLK_TOP_APLL2_D4>,
++                                 <&apmixedsys CLK_APMIXED_APLL2>,
++                                 <&topckgen CLK_TOP_APLL2_D4>;
++    };
++
++...

--- a/target/linux/mediatek/patches-5.15/860-v6.7-07-ASoC-mediatek-mt7986-drop-the-remove-callback-of-mt7.patch
+++ b/target/linux/mediatek/patches-5.15/860-v6.7-07-ASoC-mediatek-mt7986-drop-the-remove-callback-of-mt7.patch
@@ -1,0 +1,42 @@
+From f3f0934e5c7b9c16e0cb2435be3555382e6293ad Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Tue, 24 Oct 2023 11:50:17 +0800
+Subject: [PATCH 7/9] ASoC: mediatek: mt7986: drop the remove callback of
+ mt7986_wm8960
+
+Drop the remove callback of mt7986_wm8960.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20231024035019.11732-2-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/mediatek/mt7986/mt7986-wm8960.c | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+--- a/sound/soc/mediatek/mt7986/mt7986-wm8960.c
++++ b/sound/soc/mediatek/mt7986/mt7986-wm8960.c
+@@ -163,15 +163,6 @@ err_of_node_put:
+ 	return ret;
+ }
+ 
+-static void mt7986_wm8960_machine_remove(struct platform_device *pdev)
+-{
+-	struct snd_soc_card *card = platform_get_drvdata(pdev);
+-	struct mt7986_wm8960_priv *priv = snd_soc_card_get_drvdata(card);
+-
+-	of_node_put(priv->codec_node);
+-	of_node_put(priv->platform_node);
+-}
+-
+ static const struct of_device_id mt7986_wm8960_machine_dt_match[] = {
+ 	{.compatible = "mediatek,mt7986-wm8960-sound"},
+ 	{ /* sentinel */ }
+@@ -184,7 +175,6 @@ static struct platform_driver mt7986_wm8
+ 		.of_match_table = mt7986_wm8960_machine_dt_match,
+ 	},
+ 	.probe = mt7986_wm8960_machine_probe,
+-	.remove_new = mt7986_wm8960_machine_remove,
+ };
+ 
+ module_platform_driver(mt7986_wm8960_machine);

--- a/target/linux/mediatek/patches-5.15/860-v6.7-08-ASoC-mediatek-mt7986-remove-the-mt7986_wm8960_priv-s.patch
+++ b/target/linux/mediatek/patches-5.15/860-v6.7-08-ASoC-mediatek-mt7986-remove-the-mt7986_wm8960_priv-s.patch
@@ -1,0 +1,105 @@
+From 98b8fb2cb4fcab1903d0baf611bf0c3f822a08dc Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Tue, 24 Oct 2023 11:50:18 +0800
+Subject: [PATCH 8/9] ASoC: mediatek: mt7986: remove the mt7986_wm8960_priv
+ structure
+
+Remove the mt7986_wm8960_priv structure.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20231024035019.11732-3-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/mediatek/mt7986/mt7986-wm8960.c | 33 +++++++++--------------
+ 1 file changed, 12 insertions(+), 21 deletions(-)
+
+--- a/sound/soc/mediatek/mt7986/mt7986-wm8960.c
++++ b/sound/soc/mediatek/mt7986/mt7986-wm8960.c
+@@ -12,11 +12,6 @@
+ 
+ #include "mt7986-afe-common.h"
+ 
+-struct mt7986_wm8960_priv {
+-	struct device_node *platform_node;
+-	struct device_node *codec_node;
+-};
+-
+ static const struct snd_soc_dapm_widget mt7986_wm8960_widgets[] = {
+ 	SND_SOC_DAPM_HP("Headphone", NULL),
+ 	SND_SOC_DAPM_MIC("AMIC", NULL),
+@@ -92,20 +87,18 @@ static int mt7986_wm8960_machine_probe(s
+ 	struct snd_soc_card *card = &mt7986_wm8960_card;
+ 	struct snd_soc_dai_link *dai_link;
+ 	struct device_node *platform, *codec;
+-	struct mt7986_wm8960_priv *priv;
++	struct device_node *platform_dai_node, *codec_dai_node;
+ 	int ret, i;
+ 
+-	priv = devm_kzalloc(&pdev->dev, sizeof(*priv), GFP_KERNEL);
+-	if (!priv)
+-		return -ENOMEM;
++	card->dev = &pdev->dev;
+ 
+ 	platform = of_get_child_by_name(pdev->dev.of_node, "platform");
+ 
+ 	if (platform) {
+-		priv->platform_node = of_parse_phandle(platform, "sound-dai", 0);
++		platform_dai_node = of_parse_phandle(platform, "sound-dai", 0);
+ 		of_node_put(platform);
+ 
+-		if (!priv->platform_node) {
++		if (!platform_dai_node) {
+ 			dev_err(&pdev->dev, "Failed to parse platform/sound-dai property\n");
+ 			return -EINVAL;
+ 		}
+@@ -117,24 +110,22 @@ static int mt7986_wm8960_machine_probe(s
+ 	for_each_card_prelinks(card, i, dai_link) {
+ 		if (dai_link->platforms->name)
+ 			continue;
+-		dai_link->platforms->of_node = priv->platform_node;
++		dai_link->platforms->of_node = platform_dai_node;
+ 	}
+ 
+-	card->dev = &pdev->dev;
+-
+ 	codec = of_get_child_by_name(pdev->dev.of_node, "codec");
+ 
+ 	if (codec) {
+-		priv->codec_node = of_parse_phandle(codec, "sound-dai", 0);
++		codec_dai_node = of_parse_phandle(codec, "sound-dai", 0);
+ 		of_node_put(codec);
+ 
+-		if (!priv->codec_node) {
+-			of_node_put(priv->platform_node);
++		if (!codec_dai_node) {
++			of_node_put(platform_dai_node);
+ 			dev_err(&pdev->dev, "Failed to parse codec/sound-dai property\n");
+ 			return -EINVAL;
+ 		}
+ 	} else {
+-		of_node_put(priv->platform_node);
++		of_node_put(platform_dai_node);
+ 		dev_err(&pdev->dev, "Property 'codec' missing or invalid\n");
+ 		return -EINVAL;
+ 	}
+@@ -142,7 +133,7 @@ static int mt7986_wm8960_machine_probe(s
+ 	for_each_card_prelinks(card, i, dai_link) {
+ 		if (dai_link->codecs->name)
+ 			continue;
+-		dai_link->codecs->of_node = priv->codec_node;
++		dai_link->codecs->of_node = codec_dai_node;
+ 	}
+ 
+ 	ret = snd_soc_of_parse_audio_routing(card, "audio-routing");
+@@ -158,8 +149,8 @@ static int mt7986_wm8960_machine_probe(s
+ 	}
+ 
+ err_of_node_put:
+-	of_node_put(priv->codec_node);
+-	of_node_put(priv->platform_node);
++	of_node_put(platform_dai_node);
++	of_node_put(codec_dai_node);
+ 	return ret;
+ }
+ 

--- a/target/linux/mediatek/patches-5.15/860-v6.7-09-ASoC-mediatek-mt7986-add-sample-rate-checker.patch
+++ b/target/linux/mediatek/patches-5.15/860-v6.7-09-ASoC-mediatek-mt7986-add-sample-rate-checker.patch
@@ -1,0 +1,49 @@
+From 4e229f4264f4be7a6a554487714c0913ef59cf7f Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Tue, 24 Oct 2023 11:50:19 +0800
+Subject: [PATCH 9/9] ASoC: mediatek: mt7986: add sample rate checker
+
+mt7986 only supports 8/12/16/24/32/48/96/192 kHz
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20231024035019.11732-4-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/mediatek/mt7986/mt7986-dai-etdm.c | 23 +++++++++++++++++----
+ 1 file changed, 19 insertions(+), 4 deletions(-)
+
+--- a/sound/soc/mediatek/mt7986/mt7986-dai-etdm.c
++++ b/sound/soc/mediatek/mt7986/mt7986-dai-etdm.c
+@@ -237,12 +237,27 @@ static int mtk_dai_etdm_hw_params(struct
+ 				  struct snd_pcm_hw_params *params,
+ 				  struct snd_soc_dai *dai)
+ {
++	unsigned int rate = params_rate(params);
+ 	struct mtk_base_afe *afe = snd_soc_dai_get_drvdata(dai);
+ 
+-	mtk_dai_etdm_config(afe, params, dai, SNDRV_PCM_STREAM_PLAYBACK);
+-	mtk_dai_etdm_config(afe, params, dai, SNDRV_PCM_STREAM_CAPTURE);
+-
+-	return 0;
++	switch (rate) {
++	case 8000:
++	case 12000:
++	case 16000:
++	case 24000:
++	case 32000:
++	case 48000:
++	case 96000:
++	case 192000:
++		mtk_dai_etdm_config(afe, params, dai, SNDRV_PCM_STREAM_PLAYBACK);
++		mtk_dai_etdm_config(afe, params, dai, SNDRV_PCM_STREAM_CAPTURE);
++		return 0;
++	default:
++		dev_err(afe->dev,
++			"Sample rate %d invalid. Supported rates: 8/12/16/24/32/48/96/192 kHz\n",
++			rate);
++		return -EINVAL;
++	}
+ }
+ 
+ static int mtk_dai_etdm_trigger(struct snd_pcm_substream *substream, int cmd,

--- a/target/linux/mediatek/patches-5.15/861-pending-10-ASoC-mediatek-mt7986-silence-error-in-case-of-EPROBE.patch
+++ b/target/linux/mediatek/patches-5.15/861-pending-10-ASoC-mediatek-mt7986-silence-error-in-case-of-EPROBE.patch
@@ -1,0 +1,26 @@
+From e4cde335d1771863a60b6931e51357b8470e85c4 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sun, 10 Dec 2023 22:41:39 +0000
+Subject: [PATCH] ASoC: mediatek: mt7986: silence error in case of
+ -EPROBE_DEFER
+
+If probe is defered no error should be printed. Mute it.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ sound/soc/mediatek/mt7986/mt7986-wm8960.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/sound/soc/mediatek/mt7986/mt7986-wm8960.c
++++ b/sound/soc/mediatek/mt7986/mt7986-wm8960.c
+@@ -144,7 +144,9 @@ static int mt7986_wm8960_machine_probe(s
+ 
+ 	ret = devm_snd_soc_register_card(&pdev->dev, card);
+ 	if (ret) {
+-		dev_err(&pdev->dev, "%s snd_soc_register_card fail: %d\n", __func__, ret);
++		if (ret != -EPROBE_DEFER)
++			dev_err(&pdev->dev, "%s snd_soc_register_card fail: %d\n", __func__, ret);
++
+ 		goto err_of_node_put;
+ 	}
+ 

--- a/target/linux/mediatek/patches-5.15/862-arm64-dts-mt7986-add-afe.patch
+++ b/target/linux/mediatek/patches-5.15/862-arm64-dts-mt7986-add-afe.patch
@@ -1,0 +1,40 @@
+From 1c09b694a1e9378931085e77d834a4d9786a5356 Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 7 Sep 2023 10:54:37 +0800
+Subject: [PATCH] arm64: dts: mt7986: add afe
+
+---
+ arch/arm64/boot/dts/mediatek/mt7986a.dtsi     | 23 +++++++++++
+ 1 files changed, 23 insertions(+)
+
+--- a/arch/arm64/boot/dts/mediatek/mt7986a.dtsi
++++ b/arch/arm64/boot/dts/mediatek/mt7986a.dtsi
+@@ -248,6 +248,28 @@
+ 			status = "disabled";
+ 		};
+ 
++		afe: audio-controller@11210000 {
++			compatible = "mediatek,mt7986-afe";
++			reg = <0 0x11210000 0 0x9000>;
++			interrupts = <GIC_SPI 106 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&infracfg CLK_INFRA_AUD_BUS_CK>,
++				 <&infracfg CLK_INFRA_AUD_26M_CK>,
++				 <&infracfg CLK_INFRA_AUD_L_CK>,
++				 <&infracfg CLK_INFRA_AUD_AUD_CK>,
++				 <&infracfg CLK_INFRA_AUD_EG2_CK>;
++			clock-names = "aud_bus_ck",
++				      "aud_26m_ck",
++				      "aud_l_ck",
++				      "aud_aud_ck",
++				      "aud_eg2_ck";
++			assigned-clocks = <&topckgen CLK_TOP_A1SYS_SEL>,
++					  <&topckgen CLK_TOP_AUD_L_SEL>,
++					  <&topckgen CLK_TOP_A_TUNER_SEL>;
++			assigned-clock-parents = <&topckgen CLK_TOP_APLL2_D4>,
++						 <&apmixedsys CLK_APMIXED_APLL2>,
++						 <&topckgen CLK_TOP_APLL2_D4>;
++		};
++
+ 		pwm: pwm@10048000 {
+ 			compatible = "mediatek,mt7986-pwm";
+ 			reg = <0 0x10048000 0 0x1000>;

--- a/target/linux/mediatek/patches-5.15/863-arm64-dts-mt7986-add-sound-wm8960.patch
+++ b/target/linux/mediatek/patches-5.15/863-arm64-dts-mt7986-add-sound-wm8960.patch
@@ -1,0 +1,61 @@
+From 1c09b694a1e9378931085e77d834a4d9786a5356 Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 7 Sep 2023 10:54:37 +0800
+Subject: [PATCH] arm64: dts: mt7986: add sound wm8960
+
+---
+ .../dts/mediatek/mt7986a-rfb-spim-nand.dts    | 39 +++++++++++++++++++
+ 1 files changed, 39 insertions(+)
+
+--- a/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nand.dts
++++ b/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nand.dts
+@@ -4,6 +4,35 @@
+ 
+ / {
+ 	compatible = "mediatek,mt7986a-rfb-snand";
++
++	sound_wm8960 {
++		compatible = "mediatek,mt7986-wm8960-sound";
++		audio-routing = "Headphone", "HP_L",
++				"Headphone", "HP_R",
++				"LINPUT1", "AMIC",
++				"RINPUT1", "AMIC";
++
++		status = "okay";
++
++		platform {
++			sound-dai = <&afe>;
++		};
++
++		codec {
++			sound-dai = <&wm8960>;
++		};
++	};
++};
++
++&i2c0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c_pins>;
++	status = "okay";
++
++	wm8960: wm8960@1a {
++		compatible = "wlf,wm8960";
++		reg = <0x1a>;
++	};
+ };
+ 
+ &spi0 {
+@@ -50,3 +79,13 @@
+ &wifi {
+ 	mediatek,mtd-eeprom = <&factory 0>;
+ };
++
++&pio {
++	i2c_pins: i2c-pins-3-4 {
++		mux {
++			function = "i2c";
++			groups = "i2c";
++		};
++	};
++};
++

--- a/target/linux/mediatek/patches-5.15/864-arm64-dts-mt7986-add-sound-overlay-for-bpi-r3.patch
+++ b/target/linux/mediatek/patches-5.15/864-arm64-dts-mt7986-add-sound-overlay-for-bpi-r3.patch
@@ -1,0 +1,65 @@
+--- /dev/null
++++ b/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3-respeaker-2mics.dtso
+@@ -0,0 +1,62 @@
++// SPDX-License-Identifier: (GPL-2.0 OR MIT)
++/*
++ * Copyright (C) 2023 MediaTek Inc.
++ * Author: Maso Huang <Maso.Huang@mediatek.com>
++ */
++
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "bananapi,bpi-r3", "mediatek,mt7986a";
++
++	fragment@0 {
++		target-path = "/";
++		__overlay__ {
++			sound_wm8960 {
++				compatible = "mediatek,mt7986-wm8960-sound";
++				audio-routing = "Headphone", "HP_L",
++					"Headphone", "HP_R",
++					"LINPUT1", "AMIC",
++					"RINPUT1", "AMIC";
++
++				status = "okay";
++
++				platform {
++					sound-dai = <&afe>;
++				};
++
++				codec {
++					sound-dai = <&wm8960>;
++				};
++			};
++		};
++	};
++
++	fragment@1 {
++		target = <&i2c0>;
++		__overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c_pins>;
++			clock-frequency = <400000>;
++			status = "okay";
++
++			wm8960: wm8960@1a {
++				compatible = "wlf,wm8960";
++				reg = <0x1a>;
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&pio>;
++		__overlay__ {
++			i2c_pins: i2c-pins-3-4 {
++				mux {
++					function = "i2c";
++					groups = "i2c";
++				};
++			};
++		};
++	};
++};

--- a/target/linux/mediatek/patches-5.15/941-arm64-dts-mt7986-move-cpuboot-in-a-dedicated-node.patch
+++ b/target/linux/mediatek/patches-5.15/941-arm64-dts-mt7986-move-cpuboot-in-a-dedicated-node.patch
@@ -24,7 +24,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	};
  
  	timer {
-@@ -518,10 +512,11 @@
+@@ -540,10 +534,11 @@
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL_HIGH>;
  			memory-region = <&wo_emi0>, <&wo_ilm0>, <&wo_dlm0>,
@@ -38,7 +38,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		};
  
  		wed1: wed@15011000 {
-@@ -531,10 +526,11 @@
+@@ -553,10 +548,11 @@
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 206 IRQ_TYPE_LEVEL_HIGH>;
  			memory-region = <&wo_emi1>, <&wo_ilm1>, <&wo_dlm1>,
@@ -52,7 +52,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		};
  
  		wo_ccif0: syscon@151a5000 {
-@@ -551,6 +547,11 @@
+@@ -573,6 +569,11 @@
  			interrupts = <GIC_SPI 212 IRQ_TYPE_LEVEL_HIGH>;
  		};
  

--- a/target/linux/mediatek/patches-5.15/945-arm64-dts-mt7986-move-ilm-in-a-dedicated-node.patch
+++ b/target/linux/mediatek/patches-5.15/945-arm64-dts-mt7986-move-ilm-in-a-dedicated-node.patch
@@ -34,7 +34,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		wo_data: wo-data@4fd80000 {
  			reg = <0 0x4fd80000 0 0x240000>;
  			no-map;
-@@ -511,11 +501,10 @@
+@@ -533,11 +523,10 @@
  			reg = <0 0x15010000 0 0x1000>;
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL_HIGH>;
@@ -49,7 +49,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			mediatek,wo-cpuboot = <&wo_cpuboot>;
  		};
  
-@@ -525,11 +514,10 @@
+@@ -547,11 +536,10 @@
  			reg = <0 0x15011000 0 0x1000>;
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 206 IRQ_TYPE_LEVEL_HIGH>;
@@ -64,7 +64,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			mediatek,wo-cpuboot = <&wo_cpuboot>;
  		};
  
-@@ -547,6 +535,16 @@
+@@ -569,6 +557,16 @@
  			interrupts = <GIC_SPI 212 IRQ_TYPE_LEVEL_HIGH>;
  		};
  

--- a/target/linux/mediatek/patches-5.15/946-arm64-dts-mt7986-move-dlm-in-a-dedicated-node.patch
+++ b/target/linux/mediatek/patches-5.15/946-arm64-dts-mt7986-move-dlm-in-a-dedicated-node.patch
@@ -34,7 +34,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	};
  
  	timer {
-@@ -501,10 +491,11 @@
+@@ -523,10 +513,11 @@
  			reg = <0 0x15010000 0 0x1000>;
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL_HIGH>;
@@ -48,7 +48,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			mediatek,wo-cpuboot = <&wo_cpuboot>;
  		};
  
-@@ -514,10 +505,11 @@
+@@ -536,10 +527,11 @@
  			reg = <0 0x15011000 0 0x1000>;
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 206 IRQ_TYPE_LEVEL_HIGH>;
@@ -62,7 +62,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			mediatek,wo-cpuboot = <&wo_cpuboot>;
  		};
  
-@@ -545,6 +537,16 @@
+@@ -567,6 +559,16 @@
  			reg = <0 0x151f0000 0 0x8000>;
  		};
  

--- a/target/linux/mediatek/patches-6.1/860-v6.6-01-ASoC-mediatek-mt7986-add-common-header.patch
+++ b/target/linux/mediatek/patches-6.1/860-v6.6-01-ASoC-mediatek-mt7986-add-common-header.patch
@@ -1,0 +1,269 @@
+From d35469096915f2551ed1d26da1ab12ff500fc963 Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 17 Aug 2023 18:13:33 +0800
+Subject: [PATCH 1/9] ASoC: mediatek: mt7986: add common header
+
+Add header files for register definition and structure.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20230817101338.18782-2-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/mediatek/mt7986/mt7986-afe-common.h |  49 +++++
+ sound/soc/mediatek/mt7986/mt7986-reg.h        | 196 ++++++++++++++++++
+ 2 files changed, 245 insertions(+)
+ create mode 100644 sound/soc/mediatek/mt7986/mt7986-afe-common.h
+ create mode 100644 sound/soc/mediatek/mt7986/mt7986-reg.h
+
+--- /dev/null
++++ b/sound/soc/mediatek/mt7986/mt7986-afe-common.h
+@@ -0,0 +1,49 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * mt7986-afe-common.h  --  MediaTek 7986 audio driver definitions
++ *
++ * Copyright (c) 2023 MediaTek Inc.
++ * Authors: Vic Wu <vic.wu@mediatek.com>
++ *          Maso Huang <maso.huang@mediatek.com>
++ */
++
++#ifndef _MT_7986_AFE_COMMON_H_
++#define _MT_7986_AFE_COMMON_H_
++
++#include <sound/soc.h>
++#include <linux/clk.h>
++#include <linux/list.h>
++#include <linux/regmap.h>
++#include "../common/mtk-base-afe.h"
++
++enum {
++	MT7986_MEMIF_DL1,
++	MT7986_MEMIF_VUL12,
++	MT7986_MEMIF_NUM,
++	MT7986_DAI_ETDM = MT7986_MEMIF_NUM,
++	MT7986_DAI_NUM,
++};
++
++enum {
++	MT7986_IRQ_0,
++	MT7986_IRQ_1,
++	MT7986_IRQ_2,
++	MT7986_IRQ_NUM,
++};
++
++struct mt7986_afe_private {
++	struct clk_bulk_data *clks;
++	int num_clks;
++
++	int pm_runtime_bypass_reg_ctl;
++
++	/* dai */
++	void *dai_priv[MT7986_DAI_NUM];
++};
++
++unsigned int mt7986_afe_rate_transform(struct device *dev,
++				       unsigned int rate);
++
++/* dai register */
++int mt7986_dai_etdm_register(struct mtk_base_afe *afe);
++#endif
+--- /dev/null
++++ b/sound/soc/mediatek/mt7986/mt7986-reg.h
+@@ -0,0 +1,196 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * mt7986-reg.h  --  MediaTek 7986 audio driver reg definition
++ *
++ * Copyright (c) 2023 MediaTek Inc.
++ * Authors: Vic Wu <vic.wu@mediatek.com>
++ *          Maso Huang <maso.huang@mediatek.com>
++ */
++
++#ifndef _MT7986_REG_H_
++#define _MT7986_REG_H_
++
++#define AUDIO_TOP_CON2                  0x0008
++#define AUDIO_TOP_CON4                  0x0010
++#define AUDIO_ENGEN_CON0                0x0014
++#define AFE_IRQ_MCU_EN                  0x0100
++#define AFE_IRQ_MCU_STATUS              0x0120
++#define AFE_IRQ_MCU_CLR                 0x0128
++#define AFE_IRQ0_MCU_CFG0               0x0140
++#define AFE_IRQ0_MCU_CFG1               0x0144
++#define AFE_IRQ1_MCU_CFG0               0x0148
++#define AFE_IRQ1_MCU_CFG1               0x014c
++#define AFE_IRQ2_MCU_CFG0               0x0150
++#define AFE_IRQ2_MCU_CFG1               0x0154
++#define ETDM_IN5_CON0                   0x13f0
++#define ETDM_IN5_CON1                   0x13f4
++#define ETDM_IN5_CON2                   0x13f8
++#define ETDM_IN5_CON3                   0x13fc
++#define ETDM_IN5_CON4                   0x1400
++#define ETDM_OUT5_CON0                  0x1570
++#define ETDM_OUT5_CON4                  0x1580
++#define ETDM_OUT5_CON5                  0x1584
++#define ETDM_4_7_COWORK_CON0            0x15e0
++#define ETDM_4_7_COWORK_CON1            0x15e4
++#define AFE_CONN018_1                   0x1b44
++#define AFE_CONN018_4                   0x1b50
++#define AFE_CONN019_1                   0x1b64
++#define AFE_CONN019_4                   0x1b70
++#define AFE_CONN124_1                   0x2884
++#define AFE_CONN124_4                   0x2890
++#define AFE_CONN125_1                   0x28a4
++#define AFE_CONN125_4                   0x28b0
++#define AFE_CONN_RS_0                   0x3920
++#define AFE_CONN_RS_3                   0x392c
++#define AFE_CONN_16BIT_0                0x3960
++#define AFE_CONN_16BIT_3                0x396c
++#define AFE_CONN_24BIT_0                0x3980
++#define AFE_CONN_24BIT_3                0x398c
++#define AFE_MEMIF_CON0                  0x3d98
++#define AFE_MEMIF_RD_MON                0x3da0
++#define AFE_MEMIF_WR_MON                0x3da4
++#define AFE_DL0_BASE_MSB                0x3e40
++#define AFE_DL0_BASE                    0x3e44
++#define AFE_DL0_CUR_MSB                 0x3e48
++#define AFE_DL0_CUR                     0x3e4c
++#define AFE_DL0_END_MSB                 0x3e50
++#define AFE_DL0_END                     0x3e54
++#define AFE_DL0_RCH_MON                 0x3e58
++#define AFE_DL0_LCH_MON                 0x3e5c
++#define AFE_DL0_CON0                    0x3e60
++#define AFE_VUL0_BASE_MSB               0x4220
++#define AFE_VUL0_BASE                   0x4224
++#define AFE_VUL0_CUR_MSB                0x4228
++#define AFE_VUL0_CUR                    0x422c
++#define AFE_VUL0_END_MSB                0x4230
++#define AFE_VUL0_END                    0x4234
++#define AFE_VUL0_CON0                   0x4238
++
++#define AFE_MAX_REGISTER AFE_VUL0_CON0
++#define AFE_IRQ_STATUS_BITS             0x7
++#define AFE_IRQ_CNT_SHIFT               0
++#define AFE_IRQ_CNT_MASK	        0xffffff
++
++/* AUDIO_TOP_CON2 */
++#define CLK_OUT5_PDN                    BIT(14)
++#define CLK_OUT5_PDN_MASK               BIT(14)
++#define CLK_IN5_PDN                     BIT(7)
++#define CLK_IN5_PDN_MASK                BIT(7)
++
++/* AUDIO_TOP_CON4 */
++#define PDN_APLL_TUNER2                 BIT(12)
++#define PDN_APLL_TUNER2_MASK            BIT(12)
++
++/* AUDIO_ENGEN_CON0 */
++#define AUD_APLL2_EN                    BIT(3)
++#define AUD_APLL2_EN_MASK               BIT(3)
++#define AUD_26M_EN                      BIT(0)
++#define AUD_26M_EN_MASK                 BIT(0)
++
++/* AFE_DL0_CON0 */
++#define DL0_ON_SFT                      28
++#define DL0_ON_MASK                     0x1
++#define DL0_ON_MASK_SFT                 BIT(28)
++#define DL0_MINLEN_SFT                  20
++#define DL0_MINLEN_MASK                 0xf
++#define DL0_MINLEN_MASK_SFT             (0xf << 20)
++#define DL0_MODE_SFT                    8
++#define DL0_MODE_MASK                   0x1f
++#define DL0_MODE_MASK_SFT               (0x1f << 8)
++#define DL0_PBUF_SIZE_SFT               5
++#define DL0_PBUF_SIZE_MASK              0x3
++#define DL0_PBUF_SIZE_MASK_SFT          (0x3 << 5)
++#define DL0_MONO_SFT                    4
++#define DL0_MONO_MASK                   0x1
++#define DL0_MONO_MASK_SFT               BIT(4)
++#define DL0_HALIGN_SFT                  2
++#define DL0_HALIGN_MASK                 0x1
++#define DL0_HALIGN_MASK_SFT             BIT(2)
++#define DL0_HD_MODE_SFT                 0
++#define DL0_HD_MODE_MASK                0x3
++#define DL0_HD_MODE_MASK_SFT            (0x3 << 0)
++
++/* AFE_VUL0_CON0 */
++#define VUL0_ON_SFT                     28
++#define VUL0_ON_MASK                    0x1
++#define VUL0_ON_MASK_SFT                BIT(28)
++#define VUL0_MODE_SFT                   8
++#define VUL0_MODE_MASK                  0x1f
++#define VUL0_MODE_MASK_SFT              (0x1f << 8)
++#define VUL0_MONO_SFT                   4
++#define VUL0_MONO_MASK                  0x1
++#define VUL0_MONO_MASK_SFT              BIT(4)
++#define VUL0_HALIGN_SFT                 2
++#define VUL0_HALIGN_MASK                0x1
++#define VUL0_HALIGN_MASK_SFT            BIT(2)
++#define VUL0_HD_MODE_SFT                0
++#define VUL0_HD_MODE_MASK               0x3
++#define VUL0_HD_MODE_MASK_SFT           (0x3 << 0)
++
++/* AFE_IRQ_MCU_CON */
++#define IRQ_MCU_MODE_SFT                4
++#define IRQ_MCU_MODE_MASK               0x1f
++#define IRQ_MCU_MODE_MASK_SFT           (0x1f << 4)
++#define IRQ_MCU_ON_SFT                  0
++#define IRQ_MCU_ON_MASK                 0x1
++#define IRQ_MCU_ON_MASK_SFT             BIT(0)
++#define IRQ0_MCU_CLR_SFT                0
++#define IRQ0_MCU_CLR_MASK               0x1
++#define IRQ0_MCU_CLR_MASK_SFT           BIT(0)
++#define IRQ1_MCU_CLR_SFT                1
++#define IRQ1_MCU_CLR_MASK               0x1
++#define IRQ1_MCU_CLR_MASK_SFT           BIT(1)
++#define IRQ2_MCU_CLR_SFT                2
++#define IRQ2_MCU_CLR_MASK               0x1
++#define IRQ2_MCU_CLR_MASK_SFT           BIT(2)
++
++/* ETDM_IN5_CON2 */
++#define IN_CLK_SRC(x)                   ((x) << 10)
++#define IN_CLK_SRC_SFT                  10
++#define IN_CLK_SRC_MASK                 GENMASK(12, 10)
++
++/* ETDM_IN5_CON3 */
++#define IN_SEL_FS(x)                    ((x) << 26)
++#define IN_SEL_FS_SFT                   26
++#define IN_SEL_FS_MASK                  GENMASK(30, 26)
++
++/* ETDM_IN5_CON4 */
++#define IN_RELATCH(x)                   ((x) << 20)
++#define IN_RELATCH_SFT                  20
++#define IN_RELATCH_MASK                 GENMASK(24, 20)
++#define IN_CLK_INV                      BIT(18)
++#define IN_CLK_INV_MASK                 BIT(18)
++
++/* ETDM_IN5_CON0 & ETDM_OUT5_CON0 */
++#define RELATCH_SRC_MASK                GENMASK(30, 28)
++#define ETDM_CH_NUM_MASK                GENMASK(27, 23)
++#define ETDM_WRD_LEN_MASK               GENMASK(20, 16)
++#define ETDM_BIT_LEN_MASK               GENMASK(15, 11)
++#define ETDM_FMT_MASK                   GENMASK(8, 6)
++#define ETDM_SYNC                       BIT(1)
++#define ETDM_SYNC_MASK                  BIT(1)
++#define ETDM_EN                         BIT(0)
++#define ETDM_EN_MASK                    BIT(0)
++
++/* ETDM_OUT5_CON4 */
++#define OUT_RELATCH(x)                  ((x) << 24)
++#define OUT_RELATCH_SFT                 24
++#define OUT_RELATCH_MASK                GENMASK(28, 24)
++#define OUT_CLK_SRC(x)                  ((x) << 6)
++#define OUT_CLK_SRC_SFT                 6
++#define OUT_CLK_SRC_MASK                GENMASK(8, 6)
++#define OUT_SEL_FS(x)                   (x)
++#define OUT_SEL_FS_SFT                  0
++#define OUT_SEL_FS_MASK                 GENMASK(4, 0)
++
++/* ETDM_OUT5_CON5 */
++#define ETDM_CLK_DIV                    BIT(12)
++#define ETDM_CLK_DIV_MASK               BIT(12)
++#define OUT_CLK_INV                     BIT(9)
++#define OUT_CLK_INV_MASK                BIT(9)
++
++/* ETDM_4_7_COWORK_CON0 */
++#define OUT_SEL(x)                      ((x) << 12)
++#define OUT_SEL_SFT                     12
++#define OUT_SEL_MASK                    GENMASK(15, 12)
++#endif

--- a/target/linux/mediatek/patches-6.1/860-v6.6-02-ASoC-mediatek-mt7986-support-etdm-in-platform-driver.patch
+++ b/target/linux/mediatek/patches-6.1/860-v6.6-02-ASoC-mediatek-mt7986-support-etdm-in-platform-driver.patch
@@ -1,0 +1,430 @@
+From 948a288897015fb3ee63b3f720b396b590c17fd7 Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 17 Aug 2023 18:13:34 +0800
+Subject: [PATCH 2/9] ASoC: mediatek: mt7986: support etdm in platform driver
+
+Add mt7986 etdm dai driver support.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20230817101338.18782-3-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/mediatek/mt7986/mt7986-dai-etdm.c | 411 ++++++++++++++++++++
+ 1 file changed, 411 insertions(+)
+ create mode 100644 sound/soc/mediatek/mt7986/mt7986-dai-etdm.c
+
+--- /dev/null
++++ b/sound/soc/mediatek/mt7986/mt7986-dai-etdm.c
+@@ -0,0 +1,411 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * MediaTek ALSA SoC Audio DAI eTDM Control
++ *
++ * Copyright (c) 2023 MediaTek Inc.
++ * Authors: Vic Wu <vic.wu@mediatek.com>
++ *          Maso Huang <maso.huang@mediatek.com>
++ */
++
++#include <linux/bitfield.h>
++#include <linux/bitops.h>
++#include <linux/regmap.h>
++#include <sound/pcm_params.h>
++#include "mt7986-afe-common.h"
++#include "mt7986-reg.h"
++
++#define HOPPING_CLK  0
++#define APLL_CLK     1
++#define MTK_DAI_ETDM_FORMAT_I2S   0
++#define MTK_DAI_ETDM_FORMAT_DSPA  4
++#define MTK_DAI_ETDM_FORMAT_DSPB  5
++
++enum {
++	MTK_ETDM_RATE_8K = 0,
++	MTK_ETDM_RATE_12K = 1,
++	MTK_ETDM_RATE_16K = 2,
++	MTK_ETDM_RATE_24K = 3,
++	MTK_ETDM_RATE_32K = 4,
++	MTK_ETDM_RATE_48K = 5,
++	MTK_ETDM_RATE_96K = 7,
++	MTK_ETDM_RATE_192K = 9,
++	MTK_ETDM_RATE_11K = 16,
++	MTK_ETDM_RATE_22K = 17,
++	MTK_ETDM_RATE_44K = 18,
++	MTK_ETDM_RATE_88K = 19,
++	MTK_ETDM_RATE_176K = 20,
++};
++
++struct mtk_dai_etdm_priv {
++	bool bck_inv;
++	bool lrck_inv;
++	bool slave_mode;
++	unsigned int format;
++};
++
++static unsigned int mt7986_etdm_rate_transform(struct device *dev, unsigned int rate)
++{
++	switch (rate) {
++	case 8000:
++		return MTK_ETDM_RATE_8K;
++	case 11025:
++		return MTK_ETDM_RATE_11K;
++	case 12000:
++		return MTK_ETDM_RATE_12K;
++	case 16000:
++		return MTK_ETDM_RATE_16K;
++	case 22050:
++		return MTK_ETDM_RATE_22K;
++	case 24000:
++		return MTK_ETDM_RATE_24K;
++	case 32000:
++		return MTK_ETDM_RATE_32K;
++	case 44100:
++		return MTK_ETDM_RATE_44K;
++	case 48000:
++		return MTK_ETDM_RATE_48K;
++	case 88200:
++		return MTK_ETDM_RATE_88K;
++	case 96000:
++		return MTK_ETDM_RATE_96K;
++	case 176400:
++		return MTK_ETDM_RATE_176K;
++	case 192000:
++		return MTK_ETDM_RATE_192K;
++	default:
++		dev_warn(dev, "%s(), rate %u invalid, using %d!!!\n",
++			 __func__, rate, MTK_ETDM_RATE_48K);
++		return MTK_ETDM_RATE_48K;
++	}
++}
++
++static int get_etdm_wlen(unsigned int bitwidth)
++{
++	return bitwidth <= 16 ? 16 : 32;
++}
++
++/* dai component */
++/* interconnection */
++
++static const struct snd_kcontrol_new o124_mix[] = {
++	SOC_DAPM_SINGLE_AUTODISABLE("I032_Switch", AFE_CONN124_1, 0, 1, 0),
++};
++
++static const struct snd_kcontrol_new o125_mix[] = {
++	SOC_DAPM_SINGLE_AUTODISABLE("I033_Switch", AFE_CONN125_1, 1, 1, 0),
++};
++
++static const struct snd_soc_dapm_widget mtk_dai_etdm_widgets[] = {
++
++	/* DL */
++	SND_SOC_DAPM_MIXER("I150", SND_SOC_NOPM, 0, 0, NULL, 0),
++	SND_SOC_DAPM_MIXER("I151", SND_SOC_NOPM, 0, 0, NULL, 0),
++	/* UL */
++	SND_SOC_DAPM_MIXER("O124", SND_SOC_NOPM, 0, 0, o124_mix, ARRAY_SIZE(o124_mix)),
++	SND_SOC_DAPM_MIXER("O125", SND_SOC_NOPM, 0, 0, o125_mix, ARRAY_SIZE(o125_mix)),
++};
++
++static const struct snd_soc_dapm_route mtk_dai_etdm_routes[] = {
++	{"I150", NULL, "ETDM Capture"},
++	{"I151", NULL, "ETDM Capture"},
++	{"ETDM Playback", NULL, "O124"},
++	{"ETDM Playback", NULL, "O125"},
++	{"O124", "I032_Switch", "I032"},
++	{"O125", "I033_Switch", "I033"},
++};
++
++/* dai ops */
++static int mtk_dai_etdm_startup(struct snd_pcm_substream *substream,
++				struct snd_soc_dai *dai)
++{
++	struct mtk_base_afe *afe = snd_soc_dai_get_drvdata(dai);
++	struct mt7986_afe_private *afe_priv = afe->platform_priv;
++	int ret;
++
++	ret = clk_bulk_prepare_enable(afe_priv->num_clks, afe_priv->clks);
++	if (ret)
++		return dev_err_probe(afe->dev, ret, "Failed to enable clocks\n");
++
++	regmap_update_bits(afe->regmap, AUDIO_TOP_CON2, CLK_OUT5_PDN_MASK, 0);
++	regmap_update_bits(afe->regmap, AUDIO_TOP_CON2, CLK_IN5_PDN_MASK, 0);
++
++	return 0;
++}
++
++static void mtk_dai_etdm_shutdown(struct snd_pcm_substream *substream,
++				  struct snd_soc_dai *dai)
++{
++	struct mtk_base_afe *afe = snd_soc_dai_get_drvdata(dai);
++	struct mt7986_afe_private *afe_priv = afe->platform_priv;
++
++	regmap_update_bits(afe->regmap, AUDIO_TOP_CON2, CLK_OUT5_PDN_MASK,
++			   CLK_OUT5_PDN);
++	regmap_update_bits(afe->regmap, AUDIO_TOP_CON2, CLK_IN5_PDN_MASK,
++			   CLK_IN5_PDN);
++
++	clk_bulk_disable_unprepare(afe_priv->num_clks, afe_priv->clks);
++}
++
++static unsigned int get_etdm_ch_fixup(unsigned int channels)
++{
++	if (channels > 16)
++		return 24;
++	else if (channels > 8)
++		return 16;
++	else if (channels > 4)
++		return 8;
++	else if (channels > 2)
++		return 4;
++	else
++		return 2;
++}
++
++static int mtk_dai_etdm_config(struct mtk_base_afe *afe,
++			       struct snd_pcm_hw_params *params,
++			       struct snd_soc_dai *dai,
++			       int stream)
++{
++	struct mt7986_afe_private *afe_priv = afe->platform_priv;
++	struct mtk_dai_etdm_priv *etdm_data = afe_priv->dai_priv[dai->id];
++	unsigned int rate = params_rate(params);
++	unsigned int etdm_rate = mt7986_etdm_rate_transform(afe->dev, rate);
++	unsigned int afe_rate = mt7986_afe_rate_transform(afe->dev, rate);
++	unsigned int channels = params_channels(params);
++	unsigned int bit_width = params_width(params);
++	unsigned int wlen = get_etdm_wlen(bit_width);
++	unsigned int val = 0;
++	unsigned int mask = 0;
++
++	dev_dbg(afe->dev, "%s(), stream %d, rate %u, bitwidth %u\n",
++		 __func__, stream, rate, bit_width);
++
++	/* CON0 */
++	mask |= ETDM_BIT_LEN_MASK;
++	val |= FIELD_PREP(ETDM_BIT_LEN_MASK, bit_width - 1);
++	mask |= ETDM_WRD_LEN_MASK;
++	val |= FIELD_PREP(ETDM_WRD_LEN_MASK, wlen - 1);
++	mask |= ETDM_FMT_MASK;
++	val |= FIELD_PREP(ETDM_FMT_MASK, etdm_data->format);
++	mask |= ETDM_CH_NUM_MASK;
++	val |= FIELD_PREP(ETDM_CH_NUM_MASK, get_etdm_ch_fixup(channels) - 1);
++	mask |= RELATCH_SRC_MASK;
++	val |= FIELD_PREP(RELATCH_SRC_MASK, APLL_CLK);
++
++	switch (stream) {
++	case SNDRV_PCM_STREAM_PLAYBACK:
++		/* set ETDM_OUT5_CON0 */
++		regmap_update_bits(afe->regmap, ETDM_OUT5_CON0, mask, val);
++
++		/* set ETDM_OUT5_CON4 */
++		regmap_update_bits(afe->regmap, ETDM_OUT5_CON4,
++				   OUT_RELATCH_MASK, OUT_RELATCH(afe_rate));
++		regmap_update_bits(afe->regmap, ETDM_OUT5_CON4,
++				   OUT_CLK_SRC_MASK, OUT_CLK_SRC(APLL_CLK));
++		regmap_update_bits(afe->regmap, ETDM_OUT5_CON4,
++				   OUT_SEL_FS_MASK, OUT_SEL_FS(etdm_rate));
++
++		/* set ETDM_OUT5_CON5 */
++		regmap_update_bits(afe->regmap, ETDM_OUT5_CON5,
++				   ETDM_CLK_DIV_MASK, ETDM_CLK_DIV);
++		break;
++	case SNDRV_PCM_STREAM_CAPTURE:
++		/* set ETDM_IN5_CON0 */
++		regmap_update_bits(afe->regmap, ETDM_IN5_CON0, mask, val);
++		regmap_update_bits(afe->regmap, ETDM_IN5_CON0,
++				   ETDM_SYNC_MASK, ETDM_SYNC);
++
++		/* set ETDM_IN5_CON2 */
++		regmap_update_bits(afe->regmap, ETDM_IN5_CON2,
++				   IN_CLK_SRC_MASK, IN_CLK_SRC(APLL_CLK));
++
++		/* set ETDM_IN5_CON3 */
++		regmap_update_bits(afe->regmap, ETDM_IN5_CON3,
++				   IN_SEL_FS_MASK, IN_SEL_FS(etdm_rate));
++
++		/* set ETDM_IN5_CON4 */
++		regmap_update_bits(afe->regmap, ETDM_IN5_CON4,
++				   IN_RELATCH_MASK, IN_RELATCH(afe_rate));
++		break;
++	default:
++		break;
++	}
++
++	return 0;
++}
++
++static int mtk_dai_etdm_hw_params(struct snd_pcm_substream *substream,
++				  struct snd_pcm_hw_params *params,
++				  struct snd_soc_dai *dai)
++{
++	struct mtk_base_afe *afe = snd_soc_dai_get_drvdata(dai);
++
++	mtk_dai_etdm_config(afe, params, dai, SNDRV_PCM_STREAM_PLAYBACK);
++	mtk_dai_etdm_config(afe, params, dai, SNDRV_PCM_STREAM_CAPTURE);
++
++	return 0;
++}
++
++static int mtk_dai_etdm_trigger(struct snd_pcm_substream *substream, int cmd,
++				struct snd_soc_dai *dai)
++{
++	struct mtk_base_afe *afe = snd_soc_dai_get_drvdata(dai);
++
++	dev_dbg(afe->dev, "%s(), cmd %d, dai id %d\n", __func__, cmd, dai->id);
++	switch (cmd) {
++	case SNDRV_PCM_TRIGGER_START:
++	case SNDRV_PCM_TRIGGER_RESUME:
++		regmap_update_bits(afe->regmap, ETDM_IN5_CON0, ETDM_EN_MASK,
++				   ETDM_EN);
++		regmap_update_bits(afe->regmap, ETDM_OUT5_CON0, ETDM_EN_MASK,
++				   ETDM_EN);
++		break;
++	case SNDRV_PCM_TRIGGER_STOP:
++	case SNDRV_PCM_TRIGGER_SUSPEND:
++		regmap_update_bits(afe->regmap, ETDM_IN5_CON0, ETDM_EN_MASK,
++				   0);
++		regmap_update_bits(afe->regmap, ETDM_OUT5_CON0, ETDM_EN_MASK,
++				   0);
++		break;
++	default:
++		break;
++	}
++
++	return 0;
++}
++
++static int mtk_dai_etdm_set_fmt(struct snd_soc_dai *dai, unsigned int fmt)
++{
++	struct mtk_base_afe *afe = snd_soc_dai_get_drvdata(dai);
++	struct mt7986_afe_private *afe_priv = afe->platform_priv;
++	struct mtk_dai_etdm_priv *etdm_data;
++	void *priv_data;
++
++	switch (dai->id) {
++	case MT7986_DAI_ETDM:
++		break;
++	default:
++		dev_warn(afe->dev, "%s(), id %d not support\n",
++			 __func__, dai->id);
++		return -EINVAL;
++	}
++
++	priv_data = devm_kzalloc(afe->dev, sizeof(struct mtk_dai_etdm_priv),
++				 GFP_KERNEL);
++	if (!priv_data)
++		return -ENOMEM;
++
++	afe_priv->dai_priv[dai->id] = priv_data;
++	etdm_data = afe_priv->dai_priv[dai->id];
++
++	switch (fmt & SND_SOC_DAIFMT_FORMAT_MASK) {
++	case SND_SOC_DAIFMT_I2S:
++		etdm_data->format = MTK_DAI_ETDM_FORMAT_I2S;
++		break;
++	case SND_SOC_DAIFMT_DSP_A:
++		etdm_data->format = MTK_DAI_ETDM_FORMAT_DSPA;
++		break;
++	case SND_SOC_DAIFMT_DSP_B:
++		etdm_data->format = MTK_DAI_ETDM_FORMAT_DSPB;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	switch (fmt & SND_SOC_DAIFMT_INV_MASK) {
++	case SND_SOC_DAIFMT_NB_NF:
++		etdm_data->bck_inv = false;
++		etdm_data->lrck_inv = false;
++		break;
++	case SND_SOC_DAIFMT_NB_IF:
++		etdm_data->bck_inv = false;
++		etdm_data->lrck_inv = true;
++		break;
++	case SND_SOC_DAIFMT_IB_NF:
++		etdm_data->bck_inv = true;
++		etdm_data->lrck_inv = false;
++		break;
++	case SND_SOC_DAIFMT_IB_IF:
++		etdm_data->bck_inv = true;
++		etdm_data->lrck_inv = true;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	switch (fmt & SND_SOC_DAIFMT_MASTER_MASK) {
++	case SND_SOC_DAIFMT_CBM_CFM:
++		etdm_data->slave_mode = true;
++		break;
++	case SND_SOC_DAIFMT_CBS_CFS:
++		etdm_data->slave_mode = false;
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static const struct snd_soc_dai_ops mtk_dai_etdm_ops = {
++	.startup = mtk_dai_etdm_startup,
++	.shutdown = mtk_dai_etdm_shutdown,
++	.hw_params = mtk_dai_etdm_hw_params,
++	.trigger = mtk_dai_etdm_trigger,
++	.set_fmt = mtk_dai_etdm_set_fmt,
++};
++
++/* dai driver */
++#define MTK_ETDM_RATES (SNDRV_PCM_RATE_8000_48000 |\
++			SNDRV_PCM_RATE_88200 |\
++			SNDRV_PCM_RATE_96000 |\
++			SNDRV_PCM_RATE_176400 |\
++			SNDRV_PCM_RATE_192000)
++
++#define MTK_ETDM_FORMATS (SNDRV_PCM_FMTBIT_S16_LE |\
++			  SNDRV_PCM_FMTBIT_S24_LE |\
++			  SNDRV_PCM_FMTBIT_S32_LE)
++
++static struct snd_soc_dai_driver mtk_dai_etdm_driver[] = {
++	{
++		.name = "ETDM",
++		.id = MT7986_DAI_ETDM,
++		.capture = {
++			.stream_name = "ETDM Capture",
++			.channels_min = 1,
++			.channels_max = 2,
++			.rates = MTK_ETDM_RATES,
++			.formats = MTK_ETDM_FORMATS,
++		},
++		.playback = {
++			.stream_name = "ETDM Playback",
++			.channels_min = 1,
++			.channels_max = 2,
++			.rates = MTK_ETDM_RATES,
++			.formats = MTK_ETDM_FORMATS,
++		},
++		.ops = &mtk_dai_etdm_ops,
++		.symmetric_rate = 1,
++		.symmetric_sample_bits = 1,
++	},
++};
++
++int mt7986_dai_etdm_register(struct mtk_base_afe *afe)
++{
++	struct mtk_base_afe_dai *dai;
++
++	dai = devm_kzalloc(afe->dev, sizeof(*dai), GFP_KERNEL);
++	if (!dai)
++		return -ENOMEM;
++
++	list_add(&dai->list, &afe->sub_dais);
++
++	dai->dai_drivers = mtk_dai_etdm_driver;
++	dai->num_dai_drivers = ARRAY_SIZE(mtk_dai_etdm_driver);
++
++	dai->dapm_widgets = mtk_dai_etdm_widgets;
++	dai->num_dapm_widgets = ARRAY_SIZE(mtk_dai_etdm_widgets);
++	dai->dapm_routes = mtk_dai_etdm_routes;
++	dai->num_dapm_routes = ARRAY_SIZE(mtk_dai_etdm_routes);
++
++	return 0;
++}

--- a/target/linux/mediatek/patches-6.1/860-v6.6-03-ASoC-mediatek-mt7986-add-platform-driver.patch
+++ b/target/linux/mediatek/patches-6.1/860-v6.6-03-ASoC-mediatek-mt7986-add-platform-driver.patch
@@ -1,0 +1,685 @@
+From fc7776dee86bc07d22820a904760a95f49a2f12e Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 17 Aug 2023 18:13:35 +0800
+Subject: [PATCH 3/9] ASoC: mediatek: mt7986: add platform driver
+
+Add mt7986 platform driver.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20230817101338.18782-4-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/mediatek/Kconfig                 |  10 +
+ sound/soc/mediatek/Makefile                |   1 +
+ sound/soc/mediatek/mt7986/Makefile         |   8 +
+ sound/soc/mediatek/mt7986/mt7986-afe-pcm.c | 622 +++++++++++++++++++++
+ 4 files changed, 641 insertions(+)
+ create mode 100644 sound/soc/mediatek/mt7986/Makefile
+ create mode 100644 sound/soc/mediatek/mt7986/mt7986-afe-pcm.c
+
+--- a/sound/soc/mediatek/Kconfig
++++ b/sound/soc/mediatek/Kconfig
+@@ -54,6 +54,16 @@ config SND_SOC_MT6797_MT6351
+ 	  Select Y if you have such device.
+ 	  If unsure select "N".
+ 
++config SND_SOC_MT7986
++	tristate "ASoC support for Mediatek MT7986 chip"
++	depends on ARCH_MEDIATEK
++	select SND_SOC_MEDIATEK
++	help
++	  This adds ASoC platform driver support for MediaTek MT7986 chip
++	  that can be used with other codecs.
++	  Select Y if you have such device.
++	  If unsure select "N".
++
+ config SND_SOC_MT8173
+ 	tristate "ASoC support for Mediatek MT8173 chip"
+ 	depends on ARCH_MEDIATEK
+--- a/sound/soc/mediatek/Makefile
++++ b/sound/soc/mediatek/Makefile
+@@ -2,6 +2,7 @@
+ obj-$(CONFIG_SND_SOC_MEDIATEK) += common/
+ obj-$(CONFIG_SND_SOC_MT2701) += mt2701/
+ obj-$(CONFIG_SND_SOC_MT6797) += mt6797/
++obj-$(CONFIG_SND_SOC_MT7986) += mt7986/
+ obj-$(CONFIG_SND_SOC_MT8173) += mt8173/
+ obj-$(CONFIG_SND_SOC_MT8183) += mt8183/
+ obj-$(CONFIG_SND_SOC_MT8186) += mt8186/
+--- /dev/null
++++ b/sound/soc/mediatek/mt7986/Makefile
+@@ -0,0 +1,8 @@
++# SPDX-License-Identifier: GPL-2.0
++
++# platform driver
++snd-soc-mt7986-afe-objs := \
++	mt7986-afe-pcm.o \
++	mt7986-dai-etdm.o
++
++obj-$(CONFIG_SND_SOC_MT7986) += snd-soc-mt7986-afe.o
+--- /dev/null
++++ b/sound/soc/mediatek/mt7986/mt7986-afe-pcm.c
+@@ -0,0 +1,622 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * MediaTek ALSA SoC AFE platform driver for MT7986
++ *
++ * Copyright (c) 2023 MediaTek Inc.
++ * Authors: Vic Wu <vic.wu@mediatek.com>
++ *          Maso Huang <maso.huang@mediatek.com>
++ */
++
++#include <linux/clk.h>
++#include <linux/delay.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_address.h>
++#include <linux/pm_runtime.h>
++
++#include "mt7986-afe-common.h"
++#include "mt7986-reg.h"
++#include "../common/mtk-afe-platform-driver.h"
++#include "../common/mtk-afe-fe-dai.h"
++
++enum {
++	MTK_AFE_RATE_8K = 0,
++	MTK_AFE_RATE_11K = 1,
++	MTK_AFE_RATE_12K = 2,
++	MTK_AFE_RATE_16K = 4,
++	MTK_AFE_RATE_22K = 5,
++	MTK_AFE_RATE_24K = 6,
++	MTK_AFE_RATE_32K = 8,
++	MTK_AFE_RATE_44K = 9,
++	MTK_AFE_RATE_48K = 10,
++	MTK_AFE_RATE_88K = 13,
++	MTK_AFE_RATE_96K = 14,
++	MTK_AFE_RATE_176K = 17,
++	MTK_AFE_RATE_192K = 18,
++};
++
++enum {
++	CLK_INFRA_AUD_BUS_CK = 0,
++	CLK_INFRA_AUD_26M_CK,
++	CLK_INFRA_AUD_L_CK,
++	CLK_INFRA_AUD_AUD_CK,
++	CLK_INFRA_AUD_EG2_CK,
++	CLK_NUM
++};
++
++static const char *aud_clks[CLK_NUM] = {
++	[CLK_INFRA_AUD_BUS_CK] = "aud_bus_ck",
++	[CLK_INFRA_AUD_26M_CK] = "aud_26m_ck",
++	[CLK_INFRA_AUD_L_CK] = "aud_l_ck",
++	[CLK_INFRA_AUD_AUD_CK] = "aud_aud_ck",
++	[CLK_INFRA_AUD_EG2_CK] = "aud_eg2_ck",
++};
++
++unsigned int mt7986_afe_rate_transform(struct device *dev, unsigned int rate)
++{
++	switch (rate) {
++	case 8000:
++		return MTK_AFE_RATE_8K;
++	case 11025:
++		return MTK_AFE_RATE_11K;
++	case 12000:
++		return MTK_AFE_RATE_12K;
++	case 16000:
++		return MTK_AFE_RATE_16K;
++	case 22050:
++		return MTK_AFE_RATE_22K;
++	case 24000:
++		return MTK_AFE_RATE_24K;
++	case 32000:
++		return MTK_AFE_RATE_32K;
++	case 44100:
++		return MTK_AFE_RATE_44K;
++	case 48000:
++		return MTK_AFE_RATE_48K;
++	case 88200:
++		return MTK_AFE_RATE_88K;
++	case 96000:
++		return MTK_AFE_RATE_96K;
++	case 176400:
++		return MTK_AFE_RATE_176K;
++	case 192000:
++		return MTK_AFE_RATE_192K;
++	default:
++		dev_warn(dev, "%s(), rate %u invalid, using %d!!!\n",
++			 __func__, rate, MTK_AFE_RATE_48K);
++		return MTK_AFE_RATE_48K;
++	}
++}
++
++static const struct snd_pcm_hardware mt7986_afe_hardware = {
++	.info = SNDRV_PCM_INFO_MMAP |
++		SNDRV_PCM_INFO_INTERLEAVED |
++		SNDRV_PCM_INFO_MMAP_VALID,
++	.formats = SNDRV_PCM_FMTBIT_S16_LE |
++		   SNDRV_PCM_FMTBIT_S24_LE |
++		   SNDRV_PCM_FMTBIT_S32_LE,
++	.period_bytes_min = 256,
++	.period_bytes_max = 4 * 48 * 1024,
++	.periods_min = 2,
++	.periods_max = 256,
++	.buffer_bytes_max = 8 * 48 * 1024,
++	.fifo_size = 0,
++};
++
++static int mt7986_memif_fs(struct snd_pcm_substream *substream,
++			   unsigned int rate)
++{
++	struct snd_soc_pcm_runtime *rtd = substream->private_data;
++	struct snd_soc_component *component = snd_soc_rtdcom_lookup(rtd, AFE_PCM_NAME);
++	struct mtk_base_afe *afe = snd_soc_component_get_drvdata(component);
++
++	return mt7986_afe_rate_transform(afe->dev, rate);
++}
++
++static int mt7986_irq_fs(struct snd_pcm_substream *substream,
++			 unsigned int rate)
++{
++	struct snd_soc_pcm_runtime *rtd = substream->private_data;
++	struct snd_soc_component *component = snd_soc_rtdcom_lookup(rtd, AFE_PCM_NAME);
++	struct mtk_base_afe *afe = snd_soc_component_get_drvdata(component);
++
++	return mt7986_afe_rate_transform(afe->dev, rate);
++}
++
++#define MTK_PCM_RATES (SNDRV_PCM_RATE_8000_48000 |\
++		       SNDRV_PCM_RATE_88200 |\
++		       SNDRV_PCM_RATE_96000 |\
++		       SNDRV_PCM_RATE_176400 |\
++		       SNDRV_PCM_RATE_192000)
++
++#define MTK_PCM_FORMATS (SNDRV_PCM_FMTBIT_S16_LE |\
++			 SNDRV_PCM_FMTBIT_S24_LE |\
++			 SNDRV_PCM_FMTBIT_S32_LE)
++
++static struct snd_soc_dai_driver mt7986_memif_dai_driver[] = {
++	/* FE DAIs: memory intefaces to CPU */
++	{
++		.name = "DL1",
++		.id = MT7986_MEMIF_DL1,
++		.playback = {
++			.stream_name = "DL1",
++			.channels_min = 1,
++			.channels_max = 2,
++			.rates = MTK_PCM_RATES,
++			.formats = MTK_PCM_FORMATS,
++		},
++		.ops = &mtk_afe_fe_ops,
++	},
++	{
++		.name = "UL1",
++		.id = MT7986_MEMIF_VUL12,
++		.capture = {
++			.stream_name = "UL1",
++			.channels_min = 1,
++			.channels_max = 2,
++			.rates = MTK_PCM_RATES,
++			.formats = MTK_PCM_FORMATS,
++		},
++		.ops = &mtk_afe_fe_ops,
++	},
++};
++
++static const struct snd_kcontrol_new o018_mix[] = {
++	SOC_DAPM_SINGLE_AUTODISABLE("I150_Switch", AFE_CONN018_4, 22, 1, 0),
++};
++
++static const struct snd_kcontrol_new o019_mix[] = {
++	SOC_DAPM_SINGLE_AUTODISABLE("I151_Switch", AFE_CONN019_4, 23, 1, 0),
++};
++
++static const struct snd_soc_dapm_widget mt7986_memif_widgets[] = {
++	/* DL */
++	SND_SOC_DAPM_MIXER("I032", SND_SOC_NOPM, 0, 0, NULL, 0),
++	SND_SOC_DAPM_MIXER("I033", SND_SOC_NOPM, 0, 0, NULL, 0),
++
++	/* UL */
++	SND_SOC_DAPM_MIXER("O018", SND_SOC_NOPM, 0, 0,
++			   o018_mix, ARRAY_SIZE(o018_mix)),
++	SND_SOC_DAPM_MIXER("O019", SND_SOC_NOPM, 0, 0,
++			   o019_mix, ARRAY_SIZE(o019_mix)),
++};
++
++static const struct snd_soc_dapm_route mt7986_memif_routes[] = {
++	{"I032", NULL, "DL1"},
++	{"I033", NULL, "DL1"},
++	{"UL1", NULL, "O018"},
++	{"UL1", NULL, "O019"},
++	{"O018", "I150_Switch", "I150"},
++	{"O019", "I151_Switch", "I151"},
++};
++
++static const struct snd_soc_component_driver mt7986_afe_pcm_dai_component = {
++	.name = "mt7986-afe-pcm-dai",
++};
++
++static const struct mtk_base_memif_data memif_data[MT7986_MEMIF_NUM] = {
++	[MT7986_MEMIF_DL1] = {
++		.name = "DL1",
++		.id = MT7986_MEMIF_DL1,
++		.reg_ofs_base = AFE_DL0_BASE,
++		.reg_ofs_cur = AFE_DL0_CUR,
++		.reg_ofs_end = AFE_DL0_END,
++		.reg_ofs_base_msb = AFE_DL0_BASE_MSB,
++		.reg_ofs_cur_msb = AFE_DL0_CUR_MSB,
++		.reg_ofs_end_msb = AFE_DL0_END_MSB,
++		.fs_reg = AFE_DL0_CON0,
++		.fs_shift =  DL0_MODE_SFT,
++		.fs_maskbit =  DL0_MODE_MASK,
++		.mono_reg = AFE_DL0_CON0,
++		.mono_shift = DL0_MONO_SFT,
++		.enable_reg = AFE_DL0_CON0,
++		.enable_shift = DL0_ON_SFT,
++		.hd_reg = AFE_DL0_CON0,
++		.hd_shift = DL0_HD_MODE_SFT,
++		.hd_align_reg = AFE_DL0_CON0,
++		.hd_align_mshift = DL0_HALIGN_SFT,
++		.pbuf_reg = AFE_DL0_CON0,
++		.pbuf_shift = DL0_PBUF_SIZE_SFT,
++		.minlen_reg = AFE_DL0_CON0,
++		.minlen_shift = DL0_MINLEN_SFT,
++	},
++	[MT7986_MEMIF_VUL12] = {
++		.name = "VUL12",
++		.id = MT7986_MEMIF_VUL12,
++		.reg_ofs_base = AFE_VUL0_BASE,
++		.reg_ofs_cur = AFE_VUL0_CUR,
++		.reg_ofs_end = AFE_VUL0_END,
++		.reg_ofs_base_msb = AFE_VUL0_BASE_MSB,
++		.reg_ofs_cur_msb = AFE_VUL0_CUR_MSB,
++		.reg_ofs_end_msb = AFE_VUL0_END_MSB,
++		.fs_reg = AFE_VUL0_CON0,
++		.fs_shift = VUL0_MODE_SFT,
++		.fs_maskbit = VUL0_MODE_MASK,
++		.mono_reg = AFE_VUL0_CON0,
++		.mono_shift = VUL0_MONO_SFT,
++		.enable_reg = AFE_VUL0_CON0,
++		.enable_shift = VUL0_ON_SFT,
++		.hd_reg = AFE_VUL0_CON0,
++		.hd_shift = VUL0_HD_MODE_SFT,
++		.hd_align_reg = AFE_VUL0_CON0,
++		.hd_align_mshift = VUL0_HALIGN_SFT,
++	},
++};
++
++static const struct mtk_base_irq_data irq_data[MT7986_IRQ_NUM] = {
++	[MT7986_IRQ_0] = {
++		.id = MT7986_IRQ_0,
++		.irq_cnt_reg = AFE_IRQ0_MCU_CFG1,
++		.irq_cnt_shift = AFE_IRQ_CNT_SHIFT,
++		.irq_cnt_maskbit = AFE_IRQ_CNT_MASK,
++		.irq_fs_reg = AFE_IRQ0_MCU_CFG0,
++		.irq_fs_shift = IRQ_MCU_MODE_SFT,
++		.irq_fs_maskbit = IRQ_MCU_MODE_MASK,
++		.irq_en_reg = AFE_IRQ0_MCU_CFG0,
++		.irq_en_shift = IRQ_MCU_ON_SFT,
++		.irq_clr_reg = AFE_IRQ_MCU_CLR,
++		.irq_clr_shift = IRQ0_MCU_CLR_SFT,
++	},
++	[MT7986_IRQ_1] = {
++		.id = MT7986_IRQ_1,
++		.irq_cnt_reg = AFE_IRQ1_MCU_CFG1,
++		.irq_cnt_shift = AFE_IRQ_CNT_SHIFT,
++		.irq_cnt_maskbit = AFE_IRQ_CNT_MASK,
++		.irq_fs_reg = AFE_IRQ1_MCU_CFG0,
++		.irq_fs_shift = IRQ_MCU_MODE_SFT,
++		.irq_fs_maskbit = IRQ_MCU_MODE_MASK,
++		.irq_en_reg = AFE_IRQ1_MCU_CFG0,
++		.irq_en_shift = IRQ_MCU_ON_SFT,
++		.irq_clr_reg = AFE_IRQ_MCU_CLR,
++		.irq_clr_shift = IRQ1_MCU_CLR_SFT,
++	},
++	[MT7986_IRQ_2] = {
++		.id = MT7986_IRQ_2,
++		.irq_cnt_reg = AFE_IRQ2_MCU_CFG1,
++		.irq_cnt_shift = AFE_IRQ_CNT_SHIFT,
++		.irq_cnt_maskbit = AFE_IRQ_CNT_MASK,
++		.irq_fs_reg = AFE_IRQ2_MCU_CFG0,
++		.irq_fs_shift = IRQ_MCU_MODE_SFT,
++		.irq_fs_maskbit = IRQ_MCU_MODE_MASK,
++		.irq_en_reg = AFE_IRQ2_MCU_CFG0,
++		.irq_en_shift = IRQ_MCU_ON_SFT,
++		.irq_clr_reg = AFE_IRQ_MCU_CLR,
++		.irq_clr_shift = IRQ2_MCU_CLR_SFT,
++	},
++};
++
++static bool mt7986_is_volatile_reg(struct device *dev, unsigned int reg)
++{
++	/*
++	 * Those auto-gen regs are read-only, so put it as volatile because
++	 * volatile registers cannot be cached, which means that they cannot
++	 * be set when power is off
++	 */
++
++	switch (reg) {
++	case AFE_DL0_CUR_MSB:
++	case AFE_DL0_CUR:
++	case AFE_DL0_RCH_MON:
++	case AFE_DL0_LCH_MON:
++	case AFE_VUL0_CUR_MSB:
++	case AFE_VUL0_CUR:
++	case AFE_IRQ_MCU_STATUS:
++	case AFE_MEMIF_RD_MON:
++	case AFE_MEMIF_WR_MON:
++		return true;
++	default:
++		return false;
++	};
++}
++
++static const struct regmap_config mt7986_afe_regmap_config = {
++	.reg_bits = 32,
++	.reg_stride = 4,
++	.val_bits = 32,
++	.volatile_reg = mt7986_is_volatile_reg,
++	.max_register = AFE_MAX_REGISTER,
++	.num_reg_defaults_raw = ((AFE_MAX_REGISTER / 4) + 1),
++};
++
++static int mt7986_init_clock(struct mtk_base_afe *afe)
++{
++	struct mt7986_afe_private *afe_priv = afe->platform_priv;
++	int ret, i;
++
++	afe_priv->clks = devm_kcalloc(afe->dev, CLK_NUM,
++				sizeof(*afe_priv->clks), GFP_KERNEL);
++	if (!afe_priv->clks)
++		return -ENOMEM;
++	afe_priv->num_clks = CLK_NUM;
++
++	for (i = 0; i < afe_priv->num_clks; i++)
++		afe_priv->clks[i].id = aud_clks[i];
++
++	ret = devm_clk_bulk_get(afe->dev, afe_priv->num_clks, afe_priv->clks);
++	if (ret)
++		return dev_err_probe(afe->dev, ret, "Failed to get clocks\n");
++
++	return 0;
++}
++
++static irqreturn_t mt7986_afe_irq_handler(int irq_id, void *dev)
++{
++	struct mtk_base_afe *afe = dev;
++	struct mtk_base_afe_irq *irq;
++	u32 mcu_en, status, status_mcu;
++	int i, ret;
++	irqreturn_t irq_ret = IRQ_HANDLED;
++
++	/* get irq that is sent to MCU */
++	regmap_read(afe->regmap, AFE_IRQ_MCU_EN, &mcu_en);
++
++	ret = regmap_read(afe->regmap, AFE_IRQ_MCU_STATUS, &status);
++	/* only care IRQ which is sent to MCU */
++	status_mcu = status & mcu_en & AFE_IRQ_STATUS_BITS;
++
++	if (ret || status_mcu == 0) {
++		dev_err(afe->dev, "%s(), irq status err, ret %d, status 0x%x, mcu_en 0x%x\n",
++			__func__, ret, status, mcu_en);
++
++		irq_ret = IRQ_NONE;
++		goto err_irq;
++	}
++
++	for (i = 0; i < MT7986_MEMIF_NUM; i++) {
++		struct mtk_base_afe_memif *memif = &afe->memif[i];
++
++		if (!memif->substream)
++			continue;
++
++		if (memif->irq_usage < 0)
++			continue;
++
++		irq = &afe->irqs[memif->irq_usage];
++
++		if (status_mcu & (1 << irq->irq_data->irq_en_shift))
++			snd_pcm_period_elapsed(memif->substream);
++	}
++
++err_irq:
++	/* clear irq */
++	regmap_write(afe->regmap, AFE_IRQ_MCU_CLR, status_mcu);
++
++	return irq_ret;
++}
++
++static int mt7986_afe_runtime_suspend(struct device *dev)
++{
++	struct mtk_base_afe *afe = dev_get_drvdata(dev);
++	struct mt7986_afe_private *afe_priv = afe->platform_priv;
++
++	if (!afe->regmap || afe_priv->pm_runtime_bypass_reg_ctl)
++		goto skip_regmap;
++
++	/* disable clk*/
++	regmap_update_bits(afe->regmap, AUDIO_TOP_CON4, 0x3fff, 0x3fff);
++	regmap_update_bits(afe->regmap, AUDIO_ENGEN_CON0, AUD_APLL2_EN_MASK, 0);
++	regmap_update_bits(afe->regmap, AUDIO_ENGEN_CON0, AUD_26M_EN_MASK, 0);
++
++	/* make sure all irq status are cleared, twice intended */
++	regmap_update_bits(afe->regmap, AFE_IRQ_MCU_CLR, 0xffff, 0xffff);
++
++skip_regmap:
++	clk_bulk_disable_unprepare(afe_priv->num_clks, afe_priv->clks);
++
++	return 0;
++}
++
++static int mt7986_afe_runtime_resume(struct device *dev)
++{
++	struct mtk_base_afe *afe = dev_get_drvdata(dev);
++	struct mt7986_afe_private *afe_priv = afe->platform_priv;
++	int ret;
++
++	ret = clk_bulk_prepare_enable(afe_priv->num_clks, afe_priv->clks);
++	if (ret)
++		return dev_err_probe(afe->dev, ret, "Failed to enable clocks\n");
++
++	if (!afe->regmap || afe_priv->pm_runtime_bypass_reg_ctl)
++		return 0;
++
++	/* enable clk*/
++	regmap_update_bits(afe->regmap, AUDIO_TOP_CON4, 0x3fff, 0);
++	regmap_update_bits(afe->regmap, AUDIO_ENGEN_CON0, AUD_APLL2_EN_MASK,
++			   AUD_APLL2_EN);
++	regmap_update_bits(afe->regmap, AUDIO_ENGEN_CON0, AUD_26M_EN_MASK,
++			   AUD_26M_EN);
++
++	return 0;
++}
++
++static int mt7986_afe_component_probe(struct snd_soc_component *component)
++{
++	return mtk_afe_add_sub_dai_control(component);
++}
++
++static const struct snd_soc_component_driver mt7986_afe_component = {
++	.name = AFE_PCM_NAME,
++	.probe = mt7986_afe_component_probe,
++	.pointer	= mtk_afe_pcm_pointer,
++	.pcm_construct	= mtk_afe_pcm_new,
++};
++
++static int mt7986_dai_memif_register(struct mtk_base_afe *afe)
++{
++	struct mtk_base_afe_dai *dai;
++
++	dai = devm_kzalloc(afe->dev, sizeof(*dai), GFP_KERNEL);
++	if (!dai)
++		return -ENOMEM;
++
++	list_add(&dai->list, &afe->sub_dais);
++
++	dai->dai_drivers = mt7986_memif_dai_driver;
++	dai->num_dai_drivers = ARRAY_SIZE(mt7986_memif_dai_driver);
++
++	dai->dapm_widgets = mt7986_memif_widgets;
++	dai->num_dapm_widgets = ARRAY_SIZE(mt7986_memif_widgets);
++	dai->dapm_routes = mt7986_memif_routes;
++	dai->num_dapm_routes = ARRAY_SIZE(mt7986_memif_routes);
++
++	return 0;
++}
++
++typedef int (*dai_register_cb)(struct mtk_base_afe *);
++static const dai_register_cb dai_register_cbs[] = {
++	mt7986_dai_etdm_register,
++	mt7986_dai_memif_register,
++};
++
++static int mt7986_afe_pcm_dev_probe(struct platform_device *pdev)
++{
++	struct mtk_base_afe *afe;
++	struct mt7986_afe_private *afe_priv;
++	struct device *dev;
++	int i, irq_id, ret;
++
++	afe = devm_kzalloc(&pdev->dev, sizeof(*afe), GFP_KERNEL);
++	if (!afe)
++		return -ENOMEM;
++	platform_set_drvdata(pdev, afe);
++
++	afe->platform_priv = devm_kzalloc(&pdev->dev, sizeof(*afe_priv),
++					  GFP_KERNEL);
++	if (!afe->platform_priv)
++		return -ENOMEM;
++
++	afe_priv = afe->platform_priv;
++	afe->dev = &pdev->dev;
++	dev = afe->dev;
++
++	afe->base_addr = devm_platform_ioremap_resource(pdev, 0);
++	if (IS_ERR(afe->base_addr))
++		return PTR_ERR(afe->base_addr);
++
++	/* initial audio related clock */
++	ret = mt7986_init_clock(afe);
++	if (ret)
++		return dev_err_probe(dev, ret, "Cannot initialize clocks\n");
++
++	ret = devm_pm_runtime_enable(dev);
++	if (ret)
++		return ret;
++
++	/* enable clock for regcache get default value from hw */
++	afe_priv->pm_runtime_bypass_reg_ctl = true;
++	pm_runtime_get_sync(&pdev->dev);
++
++	afe->regmap = devm_regmap_init_mmio(&pdev->dev, afe->base_addr,
++		      &mt7986_afe_regmap_config);
++
++	pm_runtime_put_sync(&pdev->dev);
++	if (IS_ERR(afe->regmap))
++		return PTR_ERR(afe->regmap);
++
++	afe_priv->pm_runtime_bypass_reg_ctl = false;
++
++	/* init memif */
++	afe->memif_size = MT7986_MEMIF_NUM;
++	afe->memif = devm_kcalloc(dev, afe->memif_size, sizeof(*afe->memif),
++				  GFP_KERNEL);
++	if (!afe->memif)
++		return -ENOMEM;
++
++	for (i = 0; i < afe->memif_size; i++) {
++		afe->memif[i].data = &memif_data[i];
++		afe->memif[i].irq_usage = -1;
++	}
++
++	mutex_init(&afe->irq_alloc_lock);
++
++	/* irq initialize */
++	afe->irqs_size = MT7986_IRQ_NUM;
++	afe->irqs = devm_kcalloc(dev, afe->irqs_size, sizeof(*afe->irqs),
++				 GFP_KERNEL);
++	if (!afe->irqs)
++		return -ENOMEM;
++
++	for (i = 0; i < afe->irqs_size; i++)
++		afe->irqs[i].irq_data = &irq_data[i];
++
++	/* request irq */
++	irq_id = platform_get_irq(pdev, 0);
++	if (irq_id < 0) {
++		ret = irq_id;
++		return dev_err_probe(dev, ret, "No irq found\n");
++	}
++	ret = devm_request_irq(dev, irq_id, mt7986_afe_irq_handler,
++			       IRQF_TRIGGER_NONE, "asys-isr", (void *)afe);
++	if (ret)
++		return dev_err_probe(dev, ret, "Failed to request irq for asys-isr\n");
++
++	/* init sub_dais */
++	INIT_LIST_HEAD(&afe->sub_dais);
++
++	for (i = 0; i < ARRAY_SIZE(dai_register_cbs); i++) {
++		ret = dai_register_cbs[i](afe);
++		if (ret)
++			return dev_err_probe(dev, ret, "DAI register failed, i: %d\n", i);
++	}
++
++	/* init dai_driver and component_driver */
++	ret = mtk_afe_combine_sub_dai(afe);
++	if (ret)
++		return dev_err_probe(dev, ret, "mtk_afe_combine_sub_dai fail\n");
++
++	afe->mtk_afe_hardware = &mt7986_afe_hardware;
++	afe->memif_fs = mt7986_memif_fs;
++	afe->irq_fs = mt7986_irq_fs;
++
++	afe->runtime_resume = mt7986_afe_runtime_resume;
++	afe->runtime_suspend = mt7986_afe_runtime_suspend;
++
++	/* register component */
++	ret = devm_snd_soc_register_component(&pdev->dev,
++					      &mt7986_afe_component,
++					      NULL, 0);
++	if (ret)
++		return dev_err_probe(dev, ret, "Cannot register AFE component\n");
++
++	ret = devm_snd_soc_register_component(afe->dev,
++					      &mt7986_afe_pcm_dai_component,
++					      afe->dai_drivers,
++					      afe->num_dai_drivers);
++	if (ret)
++		return dev_err_probe(dev, ret, "Cannot register PCM DAI component\n");
++
++	return 0;
++}
++
++static void mt7986_afe_pcm_dev_remove(struct platform_device *pdev)
++{
++	pm_runtime_disable(&pdev->dev);
++	if (!pm_runtime_status_suspended(&pdev->dev))
++		mt7986_afe_runtime_suspend(&pdev->dev);
++}
++
++static const struct of_device_id mt7986_afe_pcm_dt_match[] = {
++	{ .compatible = "mediatek,mt7986-afe" },
++	{ /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(of, mt7986_afe_pcm_dt_match);
++
++static const struct dev_pm_ops mt7986_afe_pm_ops = {
++	SET_RUNTIME_PM_OPS(mt7986_afe_runtime_suspend,
++			   mt7986_afe_runtime_resume, NULL)
++};
++
++static struct platform_driver mt7986_afe_pcm_driver = {
++	.driver = {
++		   .name = "mt7986-audio",
++		   .of_match_table = mt7986_afe_pcm_dt_match,
++		   .pm = &mt7986_afe_pm_ops,
++	},
++	.probe = mt7986_afe_pcm_dev_probe,
++	.remove_new = mt7986_afe_pcm_dev_remove,
++};
++module_platform_driver(mt7986_afe_pcm_driver);
++
++MODULE_DESCRIPTION("MediaTek SoC AFE platform driver for ALSA MT7986");
++MODULE_AUTHOR("Vic Wu <vic.wu@mediatek.com>");
++MODULE_LICENSE("GPL");

--- a/target/linux/mediatek/patches-6.1/860-v6.6-04-ASoC-mediatek-mt7986-add-machine-driver-with-wm8960.patch
+++ b/target/linux/mediatek/patches-6.1/860-v6.6-04-ASoC-mediatek-mt7986-add-machine-driver-with-wm8960.patch
@@ -1,0 +1,243 @@
+From ddf6abc1c78072f8ccad59166be95f0ca5af8ca4 Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 17 Aug 2023 18:13:36 +0800
+Subject: [PATCH 4/9] ASoC: mediatek: mt7986: add machine driver with wm8960
+
+Add support for mt7986 board with wm8960.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20230817101338.18782-5-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/mediatek/Kconfig                |  10 ++
+ sound/soc/mediatek/mt7986/Makefile        |   1 +
+ sound/soc/mediatek/mt7986/mt7986-wm8960.c | 196 ++++++++++++++++++++++
+ 3 files changed, 207 insertions(+)
+ create mode 100644 sound/soc/mediatek/mt7986/mt7986-wm8960.c
+
+--- a/sound/soc/mediatek/Kconfig
++++ b/sound/soc/mediatek/Kconfig
+@@ -64,6 +64,16 @@ config SND_SOC_MT7986
+ 	  Select Y if you have such device.
+ 	  If unsure select "N".
+ 
++config SND_SOC_MT7986_WM8960
++	tristate "ASoc Audio driver for MT7986 with WM8960 codec"
++	depends on SND_SOC_MT7986 && I2C
++	select SND_SOC_WM8960
++	help
++	  This adds support for ASoC machine driver for MediaTek MT7986
++	  boards with the WM8960 codecs.
++	  Select Y if you have such device.
++	  If unsure select "N".
++
+ config SND_SOC_MT8173
+ 	tristate "ASoC support for Mediatek MT8173 chip"
+ 	depends on ARCH_MEDIATEK
+--- a/sound/soc/mediatek/mt7986/Makefile
++++ b/sound/soc/mediatek/mt7986/Makefile
+@@ -6,3 +6,4 @@ snd-soc-mt7986-afe-objs := \
+ 	mt7986-dai-etdm.o
+ 
+ obj-$(CONFIG_SND_SOC_MT7986) += snd-soc-mt7986-afe.o
++obj-$(CONFIG_SND_SOC_MT7986_WM8960) += mt7986-wm8960.o
+--- /dev/null
++++ b/sound/soc/mediatek/mt7986/mt7986-wm8960.c
+@@ -0,0 +1,196 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * mt7986-wm8960.c  --  MT7986-WM8960 ALSA SoC machine driver
++ *
++ * Copyright (c) 2023 MediaTek Inc.
++ * Authors: Vic Wu <vic.wu@mediatek.com>
++ *          Maso Huang <maso.huang@mediatek.com>
++ */
++
++#include <linux/module.h>
++#include <sound/soc.h>
++
++#include "mt7986-afe-common.h"
++
++struct mt7986_wm8960_priv {
++	struct device_node *platform_node;
++	struct device_node *codec_node;
++};
++
++static const struct snd_soc_dapm_widget mt7986_wm8960_widgets[] = {
++	SND_SOC_DAPM_HP("Headphone", NULL),
++	SND_SOC_DAPM_MIC("AMIC", NULL),
++};
++
++static const struct snd_kcontrol_new mt7986_wm8960_controls[] = {
++	SOC_DAPM_PIN_SWITCH("Headphone"),
++	SOC_DAPM_PIN_SWITCH("AMIC"),
++};
++
++SND_SOC_DAILINK_DEFS(playback,
++	DAILINK_COMP_ARRAY(COMP_CPU("DL1")),
++	DAILINK_COMP_ARRAY(COMP_DUMMY()),
++	DAILINK_COMP_ARRAY(COMP_EMPTY()));
++
++SND_SOC_DAILINK_DEFS(capture,
++	DAILINK_COMP_ARRAY(COMP_CPU("UL1")),
++	DAILINK_COMP_ARRAY(COMP_DUMMY()),
++	DAILINK_COMP_ARRAY(COMP_EMPTY()));
++
++SND_SOC_DAILINK_DEFS(codec,
++	DAILINK_COMP_ARRAY(COMP_CPU("ETDM")),
++	DAILINK_COMP_ARRAY(COMP_CODEC(NULL, "wm8960-hifi")),
++	DAILINK_COMP_ARRAY(COMP_EMPTY()));
++
++static struct snd_soc_dai_link mt7986_wm8960_dai_links[] = {
++	/* FE */
++	{
++		.name = "wm8960-playback",
++		.stream_name = "wm8960-playback",
++		.trigger = {SND_SOC_DPCM_TRIGGER_POST,
++			    SND_SOC_DPCM_TRIGGER_POST},
++		.dynamic = 1,
++		.dpcm_playback = 1,
++		SND_SOC_DAILINK_REG(playback),
++	},
++	{
++		.name = "wm8960-capture",
++		.stream_name = "wm8960-capture",
++		.trigger = {SND_SOC_DPCM_TRIGGER_POST,
++			    SND_SOC_DPCM_TRIGGER_POST},
++		.dynamic = 1,
++		.dpcm_capture = 1,
++		SND_SOC_DAILINK_REG(capture),
++	},
++	/* BE */
++	{
++		.name = "wm8960-codec",
++		.no_pcm = 1,
++		.dai_fmt = SND_SOC_DAIFMT_I2S |
++			SND_SOC_DAIFMT_NB_NF |
++			SND_SOC_DAIFMT_CBS_CFS |
++			SND_SOC_DAIFMT_GATED,
++		.dpcm_playback = 1,
++		.dpcm_capture = 1,
++		SND_SOC_DAILINK_REG(codec),
++	},
++};
++
++static struct snd_soc_card mt7986_wm8960_card = {
++	.name = "mt7986-wm8960",
++	.owner = THIS_MODULE,
++	.dai_link = mt7986_wm8960_dai_links,
++	.num_links = ARRAY_SIZE(mt7986_wm8960_dai_links),
++	.controls = mt7986_wm8960_controls,
++	.num_controls = ARRAY_SIZE(mt7986_wm8960_controls),
++	.dapm_widgets = mt7986_wm8960_widgets,
++	.num_dapm_widgets = ARRAY_SIZE(mt7986_wm8960_widgets),
++};
++
++static int mt7986_wm8960_machine_probe(struct platform_device *pdev)
++{
++	struct snd_soc_card *card = &mt7986_wm8960_card;
++	struct snd_soc_dai_link *dai_link;
++	struct device_node *platform, *codec;
++	struct mt7986_wm8960_priv *priv;
++	int ret, i;
++
++	priv = devm_kzalloc(&pdev->dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	platform = of_get_child_by_name(pdev->dev.of_node, "platform");
++
++	if (platform) {
++		priv->platform_node = of_parse_phandle(platform, "sound-dai", 0);
++		of_node_put(platform);
++
++		if (!priv->platform_node) {
++			dev_err(&pdev->dev, "Failed to parse platform/sound-dai property\n");
++			return -EINVAL;
++		}
++	} else {
++		dev_err(&pdev->dev, "Property 'platform' missing or invalid\n");
++		return -EINVAL;
++	}
++
++	for_each_card_prelinks(card, i, dai_link) {
++		if (dai_link->platforms->name)
++			continue;
++		dai_link->platforms->of_node = priv->platform_node;
++	}
++
++	card->dev = &pdev->dev;
++
++	codec = of_get_child_by_name(pdev->dev.of_node, "codec");
++
++	if (codec) {
++		priv->codec_node = of_parse_phandle(codec, "sound-dai", 0);
++		of_node_put(codec);
++
++		if (!priv->codec_node) {
++			of_node_put(priv->platform_node);
++			dev_err(&pdev->dev, "Failed to parse codec/sound-dai property\n");
++			return -EINVAL;
++		}
++	} else {
++		of_node_put(priv->platform_node);
++		dev_err(&pdev->dev, "Property 'codec' missing or invalid\n");
++		return -EINVAL;
++	}
++
++	for_each_card_prelinks(card, i, dai_link) {
++		if (dai_link->codecs->name)
++			continue;
++		dai_link->codecs->of_node = priv->codec_node;
++	}
++
++	ret = snd_soc_of_parse_audio_routing(card, "audio-routing");
++	if (ret) {
++		dev_err(&pdev->dev, "Failed to parse audio-routing: %d\n", ret);
++		goto err_of_node_put;
++	}
++
++	ret = devm_snd_soc_register_card(&pdev->dev, card);
++	if (ret) {
++		dev_err(&pdev->dev, "%s snd_soc_register_card fail: %d\n", __func__, ret);
++		goto err_of_node_put;
++	}
++
++err_of_node_put:
++	of_node_put(priv->codec_node);
++	of_node_put(priv->platform_node);
++	return ret;
++}
++
++static void mt7986_wm8960_machine_remove(struct platform_device *pdev)
++{
++	struct snd_soc_card *card = platform_get_drvdata(pdev);
++	struct mt7986_wm8960_priv *priv = snd_soc_card_get_drvdata(card);
++
++	of_node_put(priv->codec_node);
++	of_node_put(priv->platform_node);
++}
++
++static const struct of_device_id mt7986_wm8960_machine_dt_match[] = {
++	{.compatible = "mediatek,mt7986-wm8960-sound"},
++	{ /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(of, mt7986_wm8960_machine_dt_match);
++
++static struct platform_driver mt7986_wm8960_machine = {
++	.driver = {
++		.name = "mt7986-wm8960",
++		.of_match_table = mt7986_wm8960_machine_dt_match,
++	},
++	.probe = mt7986_wm8960_machine_probe,
++	.remove_new = mt7986_wm8960_machine_remove,
++};
++
++module_platform_driver(mt7986_wm8960_machine);
++
++/* Module information */
++MODULE_DESCRIPTION("MT7986 WM8960 ALSA SoC machine driver");
++MODULE_AUTHOR("Vic Wu <vic.wu@mediatek.com>");
++MODULE_LICENSE("GPL");
++MODULE_ALIAS("mt7986 wm8960 soc card");

--- a/target/linux/mediatek/patches-6.1/860-v6.6-05-ASoC-dt-bindings-mediatek-mt7986-wm8960-add-mt7986-w.patch
+++ b/target/linux/mediatek/patches-6.1/860-v6.6-05-ASoC-dt-bindings-mediatek-mt7986-wm8960-add-mt7986-w.patch
@@ -1,0 +1,87 @@
+From 72469f950b629e57e60fbcbefed45e083619b986 Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 17 Aug 2023 18:13:37 +0800
+Subject: [PATCH 5/9] ASoC: dt-bindings: mediatek,mt7986-wm8960: add
+ mt7986-wm8960 document
+
+Add document for mt7986 board with wm8960.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20230817101338.18782-6-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ .../sound/mediatek,mt7986-wm8960.yaml         | 67 +++++++++++++++++++
+ 1 file changed, 67 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/sound/mediatek,mt7986-wm8960.yaml
+
+--- /dev/null
++++ b/Documentation/devicetree/bindings/sound/mediatek,mt7986-wm8960.yaml
+@@ -0,0 +1,67 @@
++# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/sound/mediatek,mt7986-wm8960.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: MediaTek MT7986 sound card with WM8960 codec
++
++maintainers:
++  - Maso Huang <maso.huang@mediatek.com>
++
++allOf:
++  - $ref: sound-card-common.yaml#
++
++properties:
++  compatible:
++    const: mediatek,mt7986-wm8960-sound
++
++  platform:
++    type: object
++    additionalProperties: false
++    properties:
++      sound-dai:
++        description: The phandle of MT7986 platform.
++        maxItems: 1
++    required:
++      - sound-dai
++
++  codec:
++    type: object
++    additionalProperties: false
++    properties:
++      sound-dai:
++        description: The phandle of wm8960 codec.
++        maxItems: 1
++    required:
++      - sound-dai
++
++unevaluatedProperties: false
++
++required:
++  - compatible
++  - audio-routing
++  - platform
++  - codec
++
++examples:
++  - |
++    sound {
++        compatible = "mediatek,mt7986-wm8960-sound";
++        model = "mt7986-wm8960";
++        audio-routing =
++            "Headphone", "HP_L",
++            "Headphone", "HP_R",
++            "LINPUT1", "AMIC",
++            "RINPUT1", "AMIC";
++
++        platform {
++            sound-dai = <&afe>;
++        };
++
++        codec {
++            sound-dai = <&wm8960>;
++        };
++    };
++
++...

--- a/target/linux/mediatek/patches-6.1/860-v6.6-06-ASoC-dt-bindings-mediatek-mt7986-afe-add-audio-afe-d.patch
+++ b/target/linux/mediatek/patches-6.1/860-v6.6-06-ASoC-dt-bindings-mediatek-mt7986-afe-add-audio-afe-d.patch
@@ -1,0 +1,180 @@
+From d16202eb38585adbc16e32d11188dbc2127015de Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 17 Aug 2023 18:13:38 +0800
+Subject: [PATCH 6/9] ASoC: dt-bindings: mediatek,mt7986-afe: add audio afe
+ document
+
+Add mt7986 audio afe document.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20230817101338.18782-7-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ .../bindings/sound/mediatek,mt7986-afe.yaml   | 160 ++++++++++++++++++
+ 1 file changed, 160 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/sound/mediatek,mt7986-afe.yaml
+
+--- /dev/null
++++ b/Documentation/devicetree/bindings/sound/mediatek,mt7986-afe.yaml
+@@ -0,0 +1,160 @@
++# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/sound/mediatek,mt7986-afe.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: MediaTek AFE PCM controller for MT7986
++
++maintainers:
++  - Maso Huang <maso.huang@mediatek.com>
++
++properties:
++  compatible:
++    oneOf:
++      - const: mediatek,mt7986-afe
++      - items:
++          - enum:
++              - mediatek,mt7981-afe
++              - mediatek,mt7988-afe
++          - const: mediatek,mt7986-afe
++
++  reg:
++    maxItems: 1
++
++  interrupts:
++    maxItems: 1
++
++  clocks:
++    minItems: 5
++    items:
++      - description: audio bus clock
++      - description: audio 26M clock
++      - description: audio intbus clock
++      - description: audio hopping clock
++      - description: audio pll clock
++      - description: mux for pcm_mck
++      - description: audio i2s/pcm mck
++
++  clock-names:
++    minItems: 5
++    items:
++      - const: bus_ck
++      - const: 26m_ck
++      - const: l_ck
++      - const: aud_ck
++      - const: eg2_ck
++      - const: sel
++      - const: i2s_m
++
++required:
++  - compatible
++  - reg
++  - interrupts
++  - clocks
++  - clock-names
++
++allOf:
++  - if:
++      properties:
++        compatible:
++          contains:
++            const: mediatek,mt7986-afe
++    then:
++      properties:
++        clocks:
++          items:
++            - description: audio bus clock
++            - description: audio 26M clock
++            - description: audio intbus clock
++            - description: audio hopping clock
++            - description: audio pll clock
++        clock-names:
++          items:
++            - const: bus_ck
++            - const: 26m_ck
++            - const: l_ck
++            - const: aud_ck
++            - const: eg2_ck
++
++  - if:
++      properties:
++        compatible:
++          contains:
++            const: mediatek,mt7981-afe
++    then:
++      properties:
++        clocks:
++          items:
++            - description: audio bus clock
++            - description: audio 26M clock
++            - description: audio intbus clock
++            - description: audio hopping clock
++            - description: audio pll clock
++            - description: mux for pcm_mck
++        clock-names:
++          items:
++            - const: bus_ck
++            - const: 26m_ck
++            - const: l_ck
++            - const: aud_ck
++            - const: eg2_ck
++            - const: sel
++
++  - if:
++      properties:
++        compatible:
++          contains:
++            const: mediatek,mt7988-afe
++    then:
++      properties:
++        clocks:
++          items:
++            - description: audio bus clock
++            - description: audio 26M clock
++            - description: audio intbus clock
++            - description: audio hopping clock
++            - description: audio pll clock
++            - description: mux for pcm_mck
++            - description: audio i2s/pcm mck
++        clock-names:
++          items:
++            - const: bus_ck
++            - const: 26m_ck
++            - const: l_ck
++            - const: aud_ck
++            - const: eg2_ck
++            - const: sel
++            - const: i2s_m
++
++additionalProperties: false
++
++examples:
++  - |
++    #include <dt-bindings/interrupt-controller/arm-gic.h>
++    #include <dt-bindings/interrupt-controller/irq.h>
++    #include <dt-bindings/clock/mt7986-clk.h>
++
++    afe@11210000 {
++        compatible = "mediatek,mt7986-afe";
++        reg = <0x11210000 0x9000>;
++        interrupts = <GIC_SPI 106 IRQ_TYPE_LEVEL_HIGH>;
++        clocks = <&infracfg_ao CLK_INFRA_AUD_BUS_CK>,
++                 <&infracfg_ao CLK_INFRA_AUD_26M_CK>,
++                 <&infracfg_ao CLK_INFRA_AUD_L_CK>,
++                 <&infracfg_ao CLK_INFRA_AUD_AUD_CK>,
++                 <&infracfg_ao CLK_INFRA_AUD_EG2_CK>;
++        clock-names = "bus_ck",
++                      "26m_ck",
++                      "l_ck",
++                      "aud_ck",
++                      "eg2_ck";
++        assigned-clocks = <&topckgen CLK_TOP_A1SYS_SEL>,
++                          <&topckgen CLK_TOP_AUD_L_SEL>,
++                          <&topckgen CLK_TOP_A_TUNER_SEL>;
++        assigned-clock-parents = <&topckgen CLK_TOP_APLL2_D4>,
++                                 <&apmixedsys CLK_APMIXED_APLL2>,
++                                 <&topckgen CLK_TOP_APLL2_D4>;
++    };
++
++...

--- a/target/linux/mediatek/patches-6.1/860-v6.7-07-ASoC-mediatek-mt7986-drop-the-remove-callback-of-mt7.patch
+++ b/target/linux/mediatek/patches-6.1/860-v6.7-07-ASoC-mediatek-mt7986-drop-the-remove-callback-of-mt7.patch
@@ -1,0 +1,42 @@
+From f3f0934e5c7b9c16e0cb2435be3555382e6293ad Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Tue, 24 Oct 2023 11:50:17 +0800
+Subject: [PATCH 7/9] ASoC: mediatek: mt7986: drop the remove callback of
+ mt7986_wm8960
+
+Drop the remove callback of mt7986_wm8960.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20231024035019.11732-2-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/mediatek/mt7986/mt7986-wm8960.c | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+--- a/sound/soc/mediatek/mt7986/mt7986-wm8960.c
++++ b/sound/soc/mediatek/mt7986/mt7986-wm8960.c
+@@ -163,15 +163,6 @@ err_of_node_put:
+ 	return ret;
+ }
+ 
+-static void mt7986_wm8960_machine_remove(struct platform_device *pdev)
+-{
+-	struct snd_soc_card *card = platform_get_drvdata(pdev);
+-	struct mt7986_wm8960_priv *priv = snd_soc_card_get_drvdata(card);
+-
+-	of_node_put(priv->codec_node);
+-	of_node_put(priv->platform_node);
+-}
+-
+ static const struct of_device_id mt7986_wm8960_machine_dt_match[] = {
+ 	{.compatible = "mediatek,mt7986-wm8960-sound"},
+ 	{ /* sentinel */ }
+@@ -184,7 +175,6 @@ static struct platform_driver mt7986_wm8
+ 		.of_match_table = mt7986_wm8960_machine_dt_match,
+ 	},
+ 	.probe = mt7986_wm8960_machine_probe,
+-	.remove_new = mt7986_wm8960_machine_remove,
+ };
+ 
+ module_platform_driver(mt7986_wm8960_machine);

--- a/target/linux/mediatek/patches-6.1/860-v6.7-08-ASoC-mediatek-mt7986-remove-the-mt7986_wm8960_priv-s.patch
+++ b/target/linux/mediatek/patches-6.1/860-v6.7-08-ASoC-mediatek-mt7986-remove-the-mt7986_wm8960_priv-s.patch
@@ -1,0 +1,105 @@
+From 98b8fb2cb4fcab1903d0baf611bf0c3f822a08dc Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Tue, 24 Oct 2023 11:50:18 +0800
+Subject: [PATCH 8/9] ASoC: mediatek: mt7986: remove the mt7986_wm8960_priv
+ structure
+
+Remove the mt7986_wm8960_priv structure.
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20231024035019.11732-3-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/mediatek/mt7986/mt7986-wm8960.c | 33 +++++++++--------------
+ 1 file changed, 12 insertions(+), 21 deletions(-)
+
+--- a/sound/soc/mediatek/mt7986/mt7986-wm8960.c
++++ b/sound/soc/mediatek/mt7986/mt7986-wm8960.c
+@@ -12,11 +12,6 @@
+ 
+ #include "mt7986-afe-common.h"
+ 
+-struct mt7986_wm8960_priv {
+-	struct device_node *platform_node;
+-	struct device_node *codec_node;
+-};
+-
+ static const struct snd_soc_dapm_widget mt7986_wm8960_widgets[] = {
+ 	SND_SOC_DAPM_HP("Headphone", NULL),
+ 	SND_SOC_DAPM_MIC("AMIC", NULL),
+@@ -92,20 +87,18 @@ static int mt7986_wm8960_machine_probe(s
+ 	struct snd_soc_card *card = &mt7986_wm8960_card;
+ 	struct snd_soc_dai_link *dai_link;
+ 	struct device_node *platform, *codec;
+-	struct mt7986_wm8960_priv *priv;
++	struct device_node *platform_dai_node, *codec_dai_node;
+ 	int ret, i;
+ 
+-	priv = devm_kzalloc(&pdev->dev, sizeof(*priv), GFP_KERNEL);
+-	if (!priv)
+-		return -ENOMEM;
++	card->dev = &pdev->dev;
+ 
+ 	platform = of_get_child_by_name(pdev->dev.of_node, "platform");
+ 
+ 	if (platform) {
+-		priv->platform_node = of_parse_phandle(platform, "sound-dai", 0);
++		platform_dai_node = of_parse_phandle(platform, "sound-dai", 0);
+ 		of_node_put(platform);
+ 
+-		if (!priv->platform_node) {
++		if (!platform_dai_node) {
+ 			dev_err(&pdev->dev, "Failed to parse platform/sound-dai property\n");
+ 			return -EINVAL;
+ 		}
+@@ -117,24 +110,22 @@ static int mt7986_wm8960_machine_probe(s
+ 	for_each_card_prelinks(card, i, dai_link) {
+ 		if (dai_link->platforms->name)
+ 			continue;
+-		dai_link->platforms->of_node = priv->platform_node;
++		dai_link->platforms->of_node = platform_dai_node;
+ 	}
+ 
+-	card->dev = &pdev->dev;
+-
+ 	codec = of_get_child_by_name(pdev->dev.of_node, "codec");
+ 
+ 	if (codec) {
+-		priv->codec_node = of_parse_phandle(codec, "sound-dai", 0);
++		codec_dai_node = of_parse_phandle(codec, "sound-dai", 0);
+ 		of_node_put(codec);
+ 
+-		if (!priv->codec_node) {
+-			of_node_put(priv->platform_node);
++		if (!codec_dai_node) {
++			of_node_put(platform_dai_node);
+ 			dev_err(&pdev->dev, "Failed to parse codec/sound-dai property\n");
+ 			return -EINVAL;
+ 		}
+ 	} else {
+-		of_node_put(priv->platform_node);
++		of_node_put(platform_dai_node);
+ 		dev_err(&pdev->dev, "Property 'codec' missing or invalid\n");
+ 		return -EINVAL;
+ 	}
+@@ -142,7 +133,7 @@ static int mt7986_wm8960_machine_probe(s
+ 	for_each_card_prelinks(card, i, dai_link) {
+ 		if (dai_link->codecs->name)
+ 			continue;
+-		dai_link->codecs->of_node = priv->codec_node;
++		dai_link->codecs->of_node = codec_dai_node;
+ 	}
+ 
+ 	ret = snd_soc_of_parse_audio_routing(card, "audio-routing");
+@@ -158,8 +149,8 @@ static int mt7986_wm8960_machine_probe(s
+ 	}
+ 
+ err_of_node_put:
+-	of_node_put(priv->codec_node);
+-	of_node_put(priv->platform_node);
++	of_node_put(platform_dai_node);
++	of_node_put(codec_dai_node);
+ 	return ret;
+ }
+ 

--- a/target/linux/mediatek/patches-6.1/860-v6.7-09-ASoC-mediatek-mt7986-add-sample-rate-checker.patch
+++ b/target/linux/mediatek/patches-6.1/860-v6.7-09-ASoC-mediatek-mt7986-add-sample-rate-checker.patch
@@ -1,0 +1,49 @@
+From 4e229f4264f4be7a6a554487714c0913ef59cf7f Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Tue, 24 Oct 2023 11:50:19 +0800
+Subject: [PATCH 9/9] ASoC: mediatek: mt7986: add sample rate checker
+
+mt7986 only supports 8/12/16/24/32/48/96/192 kHz
+
+Signed-off-by: Maso Huang <maso.huang@mediatek.com>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20231024035019.11732-4-maso.huang@mediatek.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/mediatek/mt7986/mt7986-dai-etdm.c | 23 +++++++++++++++++----
+ 1 file changed, 19 insertions(+), 4 deletions(-)
+
+--- a/sound/soc/mediatek/mt7986/mt7986-dai-etdm.c
++++ b/sound/soc/mediatek/mt7986/mt7986-dai-etdm.c
+@@ -237,12 +237,27 @@ static int mtk_dai_etdm_hw_params(struct
+ 				  struct snd_pcm_hw_params *params,
+ 				  struct snd_soc_dai *dai)
+ {
++	unsigned int rate = params_rate(params);
+ 	struct mtk_base_afe *afe = snd_soc_dai_get_drvdata(dai);
+ 
+-	mtk_dai_etdm_config(afe, params, dai, SNDRV_PCM_STREAM_PLAYBACK);
+-	mtk_dai_etdm_config(afe, params, dai, SNDRV_PCM_STREAM_CAPTURE);
+-
+-	return 0;
++	switch (rate) {
++	case 8000:
++	case 12000:
++	case 16000:
++	case 24000:
++	case 32000:
++	case 48000:
++	case 96000:
++	case 192000:
++		mtk_dai_etdm_config(afe, params, dai, SNDRV_PCM_STREAM_PLAYBACK);
++		mtk_dai_etdm_config(afe, params, dai, SNDRV_PCM_STREAM_CAPTURE);
++		return 0;
++	default:
++		dev_err(afe->dev,
++			"Sample rate %d invalid. Supported rates: 8/12/16/24/32/48/96/192 kHz\n",
++			rate);
++		return -EINVAL;
++	}
+ }
+ 
+ static int mtk_dai_etdm_trigger(struct snd_pcm_substream *substream, int cmd,

--- a/target/linux/mediatek/patches-6.1/861-pending-10-ASoC-mediatek-mt7986-silence-error-in-case-of-EPROBE.patch
+++ b/target/linux/mediatek/patches-6.1/861-pending-10-ASoC-mediatek-mt7986-silence-error-in-case-of-EPROBE.patch
@@ -1,0 +1,26 @@
+From e4cde335d1771863a60b6931e51357b8470e85c4 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sun, 10 Dec 2023 22:41:39 +0000
+Subject: [PATCH] ASoC: mediatek: mt7986: silence error in case of
+ -EPROBE_DEFER
+
+If probe is defered no error should be printed. Mute it.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ sound/soc/mediatek/mt7986/mt7986-wm8960.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/sound/soc/mediatek/mt7986/mt7986-wm8960.c
++++ b/sound/soc/mediatek/mt7986/mt7986-wm8960.c
+@@ -144,7 +144,9 @@ static int mt7986_wm8960_machine_probe(s
+ 
+ 	ret = devm_snd_soc_register_card(&pdev->dev, card);
+ 	if (ret) {
+-		dev_err(&pdev->dev, "%s snd_soc_register_card fail: %d\n", __func__, ret);
++		if (ret != -EPROBE_DEFER)
++			dev_err(&pdev->dev, "%s snd_soc_register_card fail: %d\n", __func__, ret);
++
+ 		goto err_of_node_put;
+ 	}
+ 

--- a/target/linux/mediatek/patches-6.1/862-arm64-dts-mt7986-add-afe.patch
+++ b/target/linux/mediatek/patches-6.1/862-arm64-dts-mt7986-add-afe.patch
@@ -1,0 +1,40 @@
+From 1c09b694a1e9378931085e77d834a4d9786a5356 Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 7 Sep 2023 10:54:37 +0800
+Subject: [PATCH] arm64: dts: mt7986: add afe
+
+---
+ arch/arm64/boot/dts/mediatek/mt7986a.dtsi     | 23 +++++++++++
+ 1 files changed, 23 insertions(+)
+
+--- a/arch/arm64/boot/dts/mediatek/mt7986a.dtsi
++++ b/arch/arm64/boot/dts/mediatek/mt7986a.dtsi
+@@ -248,6 +248,28 @@
+ 			status = "disabled";
+ 		};
+ 
++		afe: audio-controller@11210000 {
++			compatible = "mediatek,mt7986-afe";
++			reg = <0 0x11210000 0 0x9000>;
++			interrupts = <GIC_SPI 106 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&infracfg CLK_INFRA_AUD_BUS_CK>,
++				 <&infracfg CLK_INFRA_AUD_26M_CK>,
++				 <&infracfg CLK_INFRA_AUD_L_CK>,
++				 <&infracfg CLK_INFRA_AUD_AUD_CK>,
++				 <&infracfg CLK_INFRA_AUD_EG2_CK>;
++			clock-names = "aud_bus_ck",
++				      "aud_26m_ck",
++				      "aud_l_ck",
++				      "aud_aud_ck",
++				      "aud_eg2_ck";
++			assigned-clocks = <&topckgen CLK_TOP_A1SYS_SEL>,
++					  <&topckgen CLK_TOP_AUD_L_SEL>,
++					  <&topckgen CLK_TOP_A_TUNER_SEL>;
++			assigned-clock-parents = <&topckgen CLK_TOP_APLL2_D4>,
++						 <&apmixedsys CLK_APMIXED_APLL2>,
++						 <&topckgen CLK_TOP_APLL2_D4>;
++		};
++
+ 		pwm: pwm@10048000 {
+ 			compatible = "mediatek,mt7986-pwm";
+ 			reg = <0 0x10048000 0 0x1000>;

--- a/target/linux/mediatek/patches-6.1/863-arm64-dts-mt7986-add-sound-wm8960.patch
+++ b/target/linux/mediatek/patches-6.1/863-arm64-dts-mt7986-add-sound-wm8960.patch
@@ -1,0 +1,61 @@
+From 1c09b694a1e9378931085e77d834a4d9786a5356 Mon Sep 17 00:00:00 2001
+From: Maso Huang <maso.huang@mediatek.com>
+Date: Thu, 7 Sep 2023 10:54:37 +0800
+Subject: [PATCH] arm64: dts: mt7986: add sound wm8960
+
+---
+ .../dts/mediatek/mt7986a-rfb-spim-nand.dts    | 39 +++++++++++++++++++
+ 1 files changed, 39 insertions(+)
+
+--- a/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nand.dts
++++ b/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nand.dts
+@@ -4,6 +4,35 @@
+ 
+ / {
+ 	compatible = "mediatek,mt7986a-rfb-snand";
++
++	sound_wm8960 {
++		compatible = "mediatek,mt7986-wm8960-sound";
++		audio-routing = "Headphone", "HP_L",
++				"Headphone", "HP_R",
++				"LINPUT1", "AMIC",
++				"RINPUT1", "AMIC";
++
++		status = "okay";
++
++		platform {
++			sound-dai = <&afe>;
++		};
++
++		codec {
++			sound-dai = <&wm8960>;
++		};
++	};
++};
++
++&i2c0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c_pins>;
++	status = "okay";
++
++	wm8960: wm8960@1a {
++		compatible = "wlf,wm8960";
++		reg = <0x1a>;
++	};
+ };
+ 
+ &spi0 {
+@@ -50,3 +79,13 @@
+ &wifi {
+ 	mediatek,mtd-eeprom = <&factory 0>;
+ };
++
++&pio {
++	i2c_pins: i2c-pins-3-4 {
++		mux {
++			function = "i2c";
++			groups = "i2c";
++		};
++	};
++};
++

--- a/target/linux/mediatek/patches-6.1/864-arm64-dts-mt7986-add-sound-overlay-for-bpi-r3.patch
+++ b/target/linux/mediatek/patches-6.1/864-arm64-dts-mt7986-add-sound-overlay-for-bpi-r3.patch
@@ -1,0 +1,75 @@
+--- /dev/null
++++ b/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3-respeaker-2mics.dtso
+@@ -0,0 +1,62 @@
++// SPDX-License-Identifier: (GPL-2.0 OR MIT)
++/*
++ * Copyright (C) 2023 MediaTek Inc.
++ * Author: Maso Huang <Maso.Huang@mediatek.com>
++ */
++
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "bananapi,bpi-r3", "mediatek,mt7986a";
++
++	fragment@0 {
++		target-path = "/";
++		__overlay__ {
++			sound_wm8960 {
++				compatible = "mediatek,mt7986-wm8960-sound";
++				audio-routing = "Headphone", "HP_L",
++					"Headphone", "HP_R",
++					"LINPUT1", "AMIC",
++					"RINPUT1", "AMIC";
++
++				status = "okay";
++
++				platform {
++					sound-dai = <&afe>;
++				};
++
++				codec {
++					sound-dai = <&wm8960>;
++				};
++			};
++		};
++	};
++
++	fragment@1 {
++		target = <&i2c0>;
++		__overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c_pins>;
++			clock-frequency = <400000>;
++			status = "okay";
++
++			wm8960: wm8960@1a {
++				compatible = "wlf,wm8960";
++				reg = <0x1a>;
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&pio>;
++		__overlay__ {
++			i2c_pins: i2c-pins-3-4 {
++				mux {
++					function = "i2c";
++					groups = "i2c";
++				};
++			};
++		};
++	};
++};
+--- a/arch/arm64/boot/dts/mediatek/Makefile
++++ b/arch/arm64/boot/dts/mediatek/Makefile
+@@ -12,6 +12,7 @@ dtb-$(CONFIG_ARCH_MEDIATEK) += mt7986a-b
+ dtb-$(CONFIG_ARCH_MEDIATEK) += mt7986a-bananapi-bpi-r3-nand.dtbo
+ dtb-$(CONFIG_ARCH_MEDIATEK) += mt7986a-bananapi-bpi-r3-nor.dtbo
+ dtb-$(CONFIG_ARCH_MEDIATEK) += mt7986a-bananapi-bpi-r3-sd.dtbo
++dtb-$(CONFIG_ARCH_MEDIATEK) += mt7986a-bananapi-bpi-r3-respeaker-2mics.dtbo
+ dtb-$(CONFIG_ARCH_MEDIATEK) += mt7986a-rfb.dtb
+ dtb-$(CONFIG_ARCH_MEDIATEK) += mt7986b-rfb.dtb
+ dtb-$(CONFIG_ARCH_MEDIATEK) += mt8167-pumpkin.dtb

--- a/target/linux/mediatek/patches-6.1/941-arm64-dts-mt7986-move-cpuboot-in-a-dedicated-node.patch
+++ b/target/linux/mediatek/patches-6.1/941-arm64-dts-mt7986-move-cpuboot-in-a-dedicated-node.patch
@@ -24,7 +24,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	};
  
  	timer {
-@@ -518,10 +512,11 @@
+@@ -540,10 +534,11 @@
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL_HIGH>;
  			memory-region = <&wo_emi0>, <&wo_ilm0>, <&wo_dlm0>,
@@ -38,7 +38,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		};
  
  		wed1: wed@15011000 {
-@@ -531,10 +526,11 @@
+@@ -553,10 +548,11 @@
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 206 IRQ_TYPE_LEVEL_HIGH>;
  			memory-region = <&wo_emi1>, <&wo_ilm1>, <&wo_dlm1>,
@@ -52,7 +52,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		};
  
  		wo_ccif0: syscon@151a5000 {
-@@ -551,6 +547,11 @@
+@@ -573,6 +569,11 @@
  			interrupts = <GIC_SPI 212 IRQ_TYPE_LEVEL_HIGH>;
  		};
  

--- a/target/linux/mediatek/patches-6.1/945-arm64-dts-mt7986-move-ilm-in-a-dedicated-node.patch
+++ b/target/linux/mediatek/patches-6.1/945-arm64-dts-mt7986-move-ilm-in-a-dedicated-node.patch
@@ -34,7 +34,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		wo_data: wo-data@4fd80000 {
  			reg = <0 0x4fd80000 0 0x240000>;
  			no-map;
-@@ -511,11 +501,10 @@
+@@ -533,11 +523,10 @@
  			reg = <0 0x15010000 0 0x1000>;
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL_HIGH>;
@@ -49,7 +49,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			mediatek,wo-cpuboot = <&wo_cpuboot>;
  		};
  
-@@ -525,11 +514,10 @@
+@@ -547,11 +536,10 @@
  			reg = <0 0x15011000 0 0x1000>;
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 206 IRQ_TYPE_LEVEL_HIGH>;
@@ -64,7 +64,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			mediatek,wo-cpuboot = <&wo_cpuboot>;
  		};
  
-@@ -547,6 +535,16 @@
+@@ -569,6 +557,16 @@
  			interrupts = <GIC_SPI 212 IRQ_TYPE_LEVEL_HIGH>;
  		};
  

--- a/target/linux/mediatek/patches-6.1/946-arm64-dts-mt7986-move-dlm-in-a-dedicated-node.patch
+++ b/target/linux/mediatek/patches-6.1/946-arm64-dts-mt7986-move-dlm-in-a-dedicated-node.patch
@@ -34,7 +34,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	};
  
  	timer {
-@@ -501,10 +491,11 @@
+@@ -523,10 +513,11 @@
  			reg = <0 0x15010000 0 0x1000>;
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL_HIGH>;
@@ -48,7 +48,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			mediatek,wo-cpuboot = <&wo_cpuboot>;
  		};
  
-@@ -514,10 +505,11 @@
+@@ -536,10 +527,11 @@
  			reg = <0 0x15011000 0 0x1000>;
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 206 IRQ_TYPE_LEVEL_HIGH>;
@@ -62,7 +62,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			mediatek,wo-cpuboot = <&wo_cpuboot>;
  		};
  
-@@ -545,6 +537,16 @@
+@@ -567,6 +559,16 @@
  			reg = <0 0x151f0000 0 0x8000>;
  		};
  

--- a/target/linux/ramips/modules.mk
+++ b/target/linux/ramips/modules.mk
@@ -113,18 +113,17 @@ $(eval $(call KernelPackage,hsdma-mtk))
 
 define KernelPackage/sound-mt7620
   TITLE:=MT7620 PCM/I2S Alsa Driver
-  DEPENDS:=@TARGET_ramips +kmod-sound-soc-core +kmod-regmap-i2c +kmod-dma-ralink @!TARGET_ramips_rt288x
+  DEPENDS:=@TARGET_ramips @!TARGET_ramips_rt288x +kmod-dma-ralink \
+	+kmod-sound-soc-core +kmod-sound-soc-wm8960
   KCONFIG:= \
 	CONFIG_SND_RALINK_SOC_I2S \
 	CONFIG_SND_SIMPLE_CARD \
-	CONFIG_SND_SIMPLE_CARD_UTILS \
-	CONFIG_SND_SOC_WM8960
+	CONFIG_SND_SIMPLE_CARD_UTILS
   FILES:= \
 	$(LINUX_DIR)/sound/soc/ralink/snd-soc-ralink-i2s.ko \
 	$(LINUX_DIR)/sound/soc/generic/snd-soc-simple-card.ko \
-	$(LINUX_DIR)/sound/soc/generic/snd-soc-simple-card-utils.ko \
-	$(LINUX_DIR)/sound/soc/codecs/snd-soc-wm8960.ko
-  AUTOLOAD:=$(call AutoLoad,90,snd-soc-wm8960 snd-soc-ralink-i2s snd-soc-simple-card)
+	$(LINUX_DIR)/sound/soc/generic/snd-soc-simple-card-utils.ko
+  AUTOLOAD:=$(call AutoLoad,90,snd-soc-ralink-i2s snd-soc-simple-card)
   $(call AddDepends/sound)
 endef
 


### PR DESCRIPTION
Backport commits from upstream Linux adding driver for the audio engine part of the MT7986 SoC, package the resulting modules and add a device tree overlay to allow using the [ReSpeaker 2-mic hat](https://www.seeedstudio.com/ReSpeaker-2-Mics-Pi-HAT.html) with the BananaPi BPi-R3.

![image](https://github.com/openwrt/openwrt/assets/9948313/296952bc-4e2b-4644-a834-c41a7a2b3fe4)

Supported sample formats: S16_LE, S24_LE, S32_LE
Supported sample rates: 8/12/16/24/32/48/96/192 kHz

```    
              |  BPi-R3  |  ReSpeaker 2-mic
      Signal  |  26-pin  |  40-pin
    ----------+----------+-------------------
     VCC 5V   |    2     |    2
     I2C SDA  |    3     |    3
     I2C SCL  |    5     |    5
     GND      |    6     |    6
     PCM CLK  |   12     |   12
     PCM FS   |   15     |   35
     PCM DIN  |   26     |   38
     GND      |   25     |   39
     PCM DOUT |   22     |   40
```

Once connected, install the driver and tell U-Boot to apply the DT overlay:
```
opkg update
opkg install kmod-sound-soc-mt7986-wm8960
fw_setenv bootconf_base "config-mt7986a-bananapi-bpi-r3#mt7986a-bananapi-bpi-r3-respeaker-2mics"
reboot
```

To setup the ReSpeaker for Stereo out on the Headphone plug:
```
amixer sset 'Right Output Mixer PCM' on
amixer sset 'Left Output Mixer PCM' on
amixer sset 'PCM Playback -6dB' off
amixer sset 'O018 I150_Switch' on
amixer sset 'O019 I151_Switch' on
amixer sset 'O124 I032_Switch' on
amixer sset 'O125 I033_Switch' on
amixer sset 'Headphone' 121
amixer sset 'Playback' 255
```

Discussion see also
https://forum.banana-pi.org/t/bpi-r3-with-respeaker-2-mic-hat-soundcard/16815