### PR TITLE
dnsmasq: invert logic for "localuse"

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -862,7 +862,7 @@ dnsmasq_start()
 {
 	local cfg="$1"
 	local disabled user_dhcpscript logfacility
-	local resolvfile resolvdir localuse=0
+	local resolvfile resolvdir localuse=1
 
 	config_get_bool disabled "$cfg" disabled 0
 	[ "$disabled" -gt 0 ] && return 0
@@ -1059,7 +1059,7 @@ dnsmasq_start()
 		config_get resolvfile "$cfg" resolvfile /tmp/resolv.conf.d/resolv.conf.auto
 		[ -n "$resolvfile" ] && [ ! -e "$resolvfile" ] && touch "$resolvfile"
 		xappend "--resolv-file=$resolvfile"
-		[ "$resolvfile" = "/tmp/resolv.conf.d/resolv.conf.auto" ] && localuse=1
+		[ "$resolvfile" != "/tmp/resolv.conf.d/resolv.conf.auto" ] && localuse=0
 		resolvdir="$(dirname "$resolvfile")"
 	fi
 	config_get_bool localuse "$cfg" localuse "$localuse"
@@ -1230,12 +1230,12 @@ dnsmasq_start()
 dnsmasq_stop()
 {
 	local cfg="$1"
-	local noresolv resolvfile localuse=0
+	local noresolv resolvfile localuse=1
 
 	config_get_bool noresolv "$cfg" noresolv 0
 	config_get resolvfile "$cfg" "resolvfile"
 
-	[ "$noresolv" = 0 ] && [ "$resolvfile" = "/tmp/resolv.conf.d/resolv.conf.auto" ] && localuse=1
+	[ "$noresolv" = 0 ] && [ "$resolvfile" != "/tmp/resolv.conf.d/resolv.conf.auto" ] && localuse=0
 	config_get_bool localuse "$cfg" localuse "$localuse"
 	[ "$localuse" -gt 0 ] && ln -sf "/tmp/resolv.conf.d/resolv.conf.auto" /tmp/resolv.conf
 


### PR DESCRIPTION
Prior to this commit, "localuse" (which enables local resolving through dnsmsasq) was off by "default". That default was in turn overridden when "noresolv" was unset (which itself is the default for "noresolv") *and* "resolvfile" was "/tmp/resolv.conf.d/resolv.conf.auto" (also the default for this parameter).

In other words, the "default" unset value for "localuse" would only be ever used in specific *non-default* configurations.

However, the problem with that logic is that a user who wants to ignore their ISP-provided resolvers by setting "noresolv" to true ends up with a device that will *only use* said resolvers for local DNS queries, serving clients' queries via dnsmasq (which now ignores the ISP resolvers). This can lead to confusion and break random setups as the DNS lookup performed on clients behalf can differ in their replies from DNS lookups performed locally on the router.

Furthermore, "localuse" is not configurable through Luci, contrary to the other two involved settings, adding further confusion for the end user.

To work around this situation, the logic that sets "localuse" is inverted: "localuse" now defaults to on by default, and IFF "noresolv" is unset (default) AND "resolvfile" is changed from default THEN "localuse" gets turned back off, allowing for more sensible behaviour.

"localuse" value set in config/dhcp still overrides the logic in all cases, as it did already.