### PR TITLE
tools/cmake: update to 3.28.0

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
-PKG_VERSION:=3.27.9
+PKG_VERSION:=3.28.0
 PKG_VERSION_MAJOR:=$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:kitware:cmake
@@ -15,7 +15,7 @@ PKG_CPE_ID:=cpe:/a:kitware:cmake
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Kitware/CMake/releases/download/v$(PKG_VERSION)/ \
 		https://cmake.org/files/v$(PKG_VERSION_MAJOR)/
-PKG_HASH:=609a9b98572a6a5ea477f912cffb973109ed4d0a6a6b3f9e2353d2cdc048708e
+PKG_HASH:=e1dcf9c817ae306e73a45c2ba6d280c65cf4ec00dd958eb144adaf117fb58e71
 
 HOST_BUILD_PARALLEL:=1
 HOST_CONFIGURE_PARALLEL:=1

--- a/tools/cmake/patches/120-curl-fix-libressl-linking.patch
+++ b/tools/cmake/patches/120-curl-fix-libressl-linking.patch
@@ -20,7 +20,7 @@ Signed-off-by: Jo-Philipp Wich <jo@mein.io>
 ---
 --- a/Utilities/cmcurl/CMakeLists.txt
 +++ b/Utilities/cmcurl/CMakeLists.txt
-@@ -590,6 +590,14 @@ if(CURL_USE_OPENSSL)
+@@ -650,6 +650,14 @@ if(CURL_USE_OPENSSL)
    endif()
    set(SSL_ENABLED ON)
    set(USE_OPENSSL ON)

--- a/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
+++ b/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
@@ -1,6 +1,6 @@
 --- a/bootstrap
 +++ b/bootstrap
-@@ -1486,7 +1486,10 @@ int main(){ printf("1%c", (char)0x0a); r
+@@ -1491,7 +1491,10 @@ int main(){ printf("1%c", (char)0x0a); r
  ' > "test.c"
  cmake_original_make_flags="${cmake_make_flags}"
  if test "x${cmake_parallel_make}" != "x"; then


### PR DESCRIPTION
Release Notes:
- https://www.kitware.com/cmake-3-28-0-available-for-download/

Refresh patches:
- 120-curl-fix-libressl-linking.patch
- 130-bootstrap_parallel_make_flag.patch
