### PR TITLE
base-files: use CDN for package downloads

### DIFF
--- a/package/base-files/image-config.in
+++ b/package/base-files/image-config.in
@@ -190,7 +190,7 @@ if VERSIONOPT
 	config VERSION_REPO
 		string
 		prompt "Release repository"
-		default "https://downloads.openwrt.org/snapshots"
+		default "https://downloads.cdn.openwrt.org/snapshots"
 		help
 			This is the repository address embedded in the image, it defaults
 			to the trunk snapshot repo; the url may contain the following placeholders:


### PR DESCRIPTION
For a while we got a CDN running for a fallback for package sources that aren't available upstream, this commits extends the usage for package downloads. Now packages are downloaded from the CDN by default.

If this works at scale, we should backport it to the existing releases.