### PR TITLE
rockchip: fix eth1 irq affinity

### DIFF
--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -34,7 +34,7 @@ friendlyarm,nanopi-r2s|\
 xunlong,orangepi-r1-plus|\
 xunlong,orangepi-r1-plus-lts)
 	set_interface_core 2 "eth0"
-	set_interface_core 4 "eth1" "xhci-hcd:usb3"
+	set_interface_core 4 "eth1" "xhci-hcd:usb1"
 	;;
 friendlyarm,nanopi-r4s)
 	set_interface_core 10 "eth0"


### PR DESCRIPTION
NanoPi R2S and some other RK3328 boards use RTL8152 as eth1, which is connected to xhci-hcd:usb1 but not xhci-hcd:usb3

root@OpenWrt:~# cat /proc/interrupts
           CPU0       CPU1       CPU2       CPU3
 11:      53449     171813     129595      87823     GICv2  30 Level     arch_timer
 18:          0          0          0          0     GICv2  94 Level     rockchip_usb2phy
 19:          0          0          0          0     GICv2  32 Level     ff1f0000.dma-controller
 20:          0          0          0          0     GICv2  33 Level     ff1f0000.dma-controller
 21:          4          0          0          0     GICv2  89 Level     ttyS2
 22:          0          0          0          0     GICv2  43 Level     ff350800.iommu
 23:          0          0          0          0     GICv2 106 Level     ff360480.iommu
 24:          0    1417932          0          0     GICv2  56 Level     eth0
 25:        334          0          0    4422194     GICv2  99 Level     xhci-hcd:usb1
 26:          0          0          0          0     GICv2  48 Level     ehci_hcd:usb3
 27:          0          0          0          0     GICv2  49 Level     ohci_hcd:usb2
 28:       3285          0          0          0     GICv2  69 Level     ff160000.i2c
 29:          0          0          0          0  rockchip_gpio_irq  24 Level     rk805
 30:          0          0          0          0     rk805   0 Edge      rk805_pwrkey_fall
 35:          0          0          0          0     rk805   5 Edge      RTC alarm
 37:          0          0          0          0     rk805   7 Edge      rk805_pwrkey_rise
 38:          0          0          0          0     GICv2  90 Level     rockchip_thermal
 39:          0          0          0          0     GICv2  72 Edge      ff1a0000.watchdog
 40:       2601          0          0          0     GICv2  44 Level     dw-mci
 41:          0          0          0          0  rockchip_gpio_irq   0 Edge      keys
IPI0:      1559       1208        893       1131       Rescheduling interrupts
IPI1:    774029      21475     539474      12403       Function call interrupts
IPI2:         0          0          0          0       CPU stop interrupts
IPI3:         0          0          0          0       CPU stop (for crash dump) interrupts
IPI4:      2447       1801       2787       2025       Timer broadcast interrupts
IPI5:       213        264        237        392       IRQ work interrupts
IPI6:         0          0          0          0       CPU wake-up interrupts
Err:          0

Fix 40-net-smp-affinity to match the correct device irq name.