### PR TITLE
Fix Wrong LED Name for MR90X

### DIFF
--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -17,7 +17,7 @@ cudy,wr3000-v1)
 	;;
 mercusys,mr90x-v1)
 	ucidef_set_led_netdev "lan0" "lan0" "green:lan0" "lan0" "link tx rx"
-	ucidef_set_led_netdev "lan1" "lan2" "green:lan1" "lan1" "link tx rx"
+	ucidef_set_led_netdev "lan1" "lan1" "green:lan1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan2" "green:lan2" "lan2" "link tx rx"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
 	;;


### PR DESCRIPTION
Minor correction to the lan1 LED's name as it should have been lan1, not lan2.

Signed-off-by: Alvin Chang <alvin.chang@gmail.com>
