### PR TITLE
rockchip: make SMP affinity of RTL8152 on XHCI more robust

### DIFF
--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -9,7 +9,7 @@ get_device_irq() {
 
 	# wait up to 10 seconds for the irq/device to appear
 	while [ "${seconds}" -le 10 ]; do
-		line=$(grep -m 1 "${device}\$" /proc/interrupts) && break
+		line=$(grep -E -m 1 "${device}\$" /proc/interrupts) && break
 		seconds="$(( seconds + 2 ))"
 		sleep 2
 	done
@@ -34,7 +34,7 @@ friendlyarm,nanopi-r2s|\
 xunlong,orangepi-r1-plus|\
 xunlong,orangepi-r1-plus-lts)
 	set_interface_core 2 "eth0"
-	set_interface_core 4 "eth1" "xhci-hcd:usb1"
+	set_interface_core 4 "eth1" "xhci-hcd:usb[0-9]+"
 	;;
 friendlyarm,nanopi-r4s)
 	set_interface_core 10 "eth0"


### PR DESCRIPTION
XHCI bus numbers are assigned dynamically, it may varies among boards
match the device irq name with regexp, drop the hardcoded name.