### PR TITLE
kernel: include metadata for built-in modules

### DIFF
--- a/package/kernel/linux/Makefile
+++ b/package/kernel/linux/Makefile
@@ -61,6 +61,9 @@ define Package/kernel/install
 	$(INSTALL_DIR) $(1)/$(MODULES_SUBDIR)
 	$(INSTALL_DATA) $(LINUX_DIR)/modules.builtin $(1)/$(MODULES_SUBDIR)
 	$(SED) 's,.*/,,' $(1)/$(MODULES_SUBDIR)/modules.builtin
+	strings $(LINUX_DIR)/modules.builtin.modinfo | \
+		grep -E -v "\.(file$(if CONFIG_MODULE_STRIPPED,|parmtype))=" | \
+		tr '\n' '\0' > $(1)/$(MODULES_SUBDIR)/modules.builtin.modinfo
 endef
 
 define Package/kernel/extra_provides

--- a/package/kernel/linux/Makefile
+++ b/package/kernel/linux/Makefile
@@ -58,7 +58,9 @@ define Package/kernel
 endef
 
 define Package/kernel/install
-  # nothing to do
+	$(INSTALL_DIR) $(1)/$(MODULES_SUBDIR)
+	$(INSTALL_DATA) $(LINUX_DIR)/modules.builtin $(1)/$(MODULES_SUBDIR)
+	$(SED) 's,.*/,,' $(1)/$(MODULES_SUBDIR)/modules.builtin
 endef
 
 define Package/kernel/extra_provides


### PR DESCRIPTION
Description
---
Add `modules.builtin` and `modules.builtin.modinfo` to the `kernel` package for improved handling of built-in modules. As with other distros, this enables `modprobe <module>` to consistently return success for both loaded/built-in modules, a useful feature for presence-testing. and allows `modinfo` to print related module details.

Given OpenWrt's few built-in modules, this change and the related `kmodloader` support only add ~2.5 KB to a compressed filesystem image size.

Related
---
A separate PR updates `kmodloader` to parse and use these files: https://github.com/openwrt/ubox/pull/1
These PRs are complementary but independent since `kmodloader` will still work without the files above.

Examples
---
Some samples of new and changed functionality (with updated `kmodloader`) are below.
```
# Print parameters for existing loadable modules:

root@OpenWrt:/# modinfo mac80211
filename:       /lib/modules/6.1.65/mac80211.ko
license:        GPL
depends:        cfg80211,compat
name:           mac80211
vermagic:       6.1.65 SMP mod_unload MIPS32_R2 32BIT
parm:           minstrel_vht_only (bool)
parm:           max_nullfunc_tries (int)
parm:           max_probe_tries (int)
parm:           beacon_loss_count (int)
parm:           probe_wait_ms (int)
parm:           ieee80211_default_rc_algo (charp)


# Recognize built-in modules, treat consistent with loadable ones

root@OpenWrt:/# rmmod sch_fq_codel
module is builtin

root@OpenWrt:/# modinfo sch_cake
filename:       /lib/modules/6.1.65/sch_cake.ko
license:        Dual BSD/GPL
depends:
intree:         Y
name:           sch_cake
vermagic:       6.1.65 SMP mod_unload MIPS32_R2 32BIT

root@OpenWrt:/# modprobe sch_fq_codel && echo SUCCESS || echo FAIL
SUCCESS
root@OpenWrt:/# modprobe sch_cake && echo SUCCESS || echo FAIL
SUCCESS


# Recognize aliases for built-in modules, treat consistent with loadable ones

root@OpenWrt:/# modinfo unix
name:           unix
filename:       (builtin)
alias:          net-pf-1
license:        GPL

root@OpenWrt:/# modprobe net-pf-1 && echo SUCCESS || echo FAIL
SUCCESS
```

Testing
--- 

- Compile and run-tested against master on malta/mipseb32.
- Confirmed `kmodloader` continues to function with or without `modules.builtin` and `modules.builtin.modinfo`.
- Checked size impact of changes: updates to `kmodloader`, with inclusion of `modules.builtin` and `modules.builtin.modinfo`, increased OpenWrt compressed filesystem image size by ~2.5 KB.
- Additional testing details in related `kmodloader` PR above.

Review
-
CC previous contributors: @blogic @nbd168  @hauke @Ansuel @neheb @yousong 
Thanks in advance for your feedback...