### PR TITLE
Fix rtl930x VLAN, LEDs and status

### DIFF
--- a/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
+++ b/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1250-12.dts
@@ -66,10 +66,10 @@
 		compatible = "realtek,rtl9300-leds";
 		active-low;
 
-		led_set0 = <0x0000 0xffff 0x0a20 0x0b80>; // LED set 0: 1000Mbps,  10/100Mbps
+		led_set0 = <0x0a20 0x0b80>; // LED set 0: 1000Mbps,  10/100Mbps
 		led_set1 = <0x0a0b 0x0a28 0x0a82 0x0a0b>; // LED set 1: (10G, 5G, 2.5G) (2.5G, 1G)
 							  // (5G, 10/100) (10G, 5G, 2.5G)
-		led_set2 = <0x0000 0xffff 0x0a20 0x0a01>; // LED set 2: 1000MBit, 10GBit
+		led_set2 = <0x0a20 0x0a01>; // LED set 2: 1000MBit, 10GBit
 	};
 };
 

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
@@ -1428,6 +1428,8 @@ static int rtl83xx_vlan_add(struct dsa_switch *ds, int port,
 	pr_debug("%s port %d, vid %d, flags %x\n",
 		__func__, port, vlan->vid, vlan->flags);
 
+	if(!vlan->vid) return 0;
+
 	if (vlan->vid > 4095) {
 		dev_err(priv->dev, "VLAN out of range: %d", vlan->vid);
 		return -ENOTSUPP;

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
@@ -137,9 +137,9 @@ static void rtl83xx_vlan_setup(struct rtl838x_switch_priv *priv)
 		priv->r->vlan_set_tagged(i, &info);
 
 	/* reset PVIDs; defaults to 1 on reset */
-	for (int i = 0; i <= priv->ds->num_ports; i++) {
-		priv->r->vlan_port_pvid_set(i, PBVLAN_TYPE_INNER, 0);
-		priv->r->vlan_port_pvid_set(i, PBVLAN_TYPE_OUTER, 0);
+	for (int i = 0; i <= priv->cpu_port; i++) {
+		priv->r->vlan_port_pvid_set(i, PBVLAN_TYPE_INNER, 1);
+		priv->r->vlan_port_pvid_set(i, PBVLAN_TYPE_OUTER, 1);
 		priv->r->vlan_port_pvidmode_set(i, PBVLAN_TYPE_INNER, PBVLAN_MODE_UNTAG_AND_PRITAG);
 		priv->r->vlan_port_pvidmode_set(i, PBVLAN_TYPE_OUTER, PBVLAN_MODE_UNTAG_AND_PRITAG);
 	}

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
@@ -1355,10 +1355,15 @@ static int rtl83xx_vlan_filtering(struct dsa_switch *ds, int port,
 		 * 2: Trap packet to CPU port
 		 * The Egress filter used 1 bit per state (0: DISABLED, 1: ENABLED)
 		 */
-		if (port != priv->cpu_port)
+		if (port != priv->cpu_port) {
 			priv->r->set_vlan_igr_filter(port, IGR_DROP);
+			priv->r->set_vlan_egr_filter(port, EGR_ENABLE);
+		}
+		else {
+			priv->r->set_vlan_igr_filter(port, IGR_TRAP);
+			priv->r->set_vlan_egr_filter(port, EGR_DISABLE);
+		}
 
-		priv->r->set_vlan_egr_filter(port, EGR_ENABLE);
 	} else {
 		/* Disable ingress and egress filtering */
 		if (port != priv->cpu_port)

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
@@ -867,6 +867,8 @@ static void rtl93xx_phylink_mac_config(struct dsa_switch *ds, int port,
 
 	if (state->duplex == DUPLEX_FULL)
 		reg |= RTL930X_DUPLEX_MODE;
+	else
+		reg &= ~RTL930X_DUPLEX_MODE; /* Clear duplex bit otherwise */
 
 	if (priv->ports[port].phy_is_integrated)
 		reg &= ~RTL930X_FORCE_EN; /* Clear MAC_FORCE_EN to allow SDS-MAC link */

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -635,6 +635,7 @@ struct rtl838x_port {
 	bool is2G5;
 	int sds_num;
 	int led_set;
+	int leds_on_this_port;
 	const struct dsa_port *dp;
 };
 

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -24,6 +24,15 @@
 
 #define RTL930X_LED_GLB_ACTIVE_LOW				BIT(22)
 
+#define RTL930X_LED_SETX_0_CTRL(x) (RTL930X_LED_SET0_0_CTRL - (x * 8))
+#define RTL930X_LED_SETX_1_CTRL(x) (RTL930X_LED_SETX_0_CTRL(x) - 4)
+
+/* get register for given set and led in the set */
+#define RTL930X_LED_SETX_LEDY(x,y) (RTL930X_LED_SETX_0_CTRL(x) - 4 * (y / 2))
+
+/* get shift for given led in any set */
+#define RTL930X_LED_SET_LEDX_SHIFT(x) (16 * (x % 2))
+
 extern struct mutex smi_lock;
 extern struct rtl83xx_soc_info soc_info;
 
@@ -2396,10 +2405,44 @@ static void rtl930x_led_init(struct rtl838x_switch_priv *priv)
 		return;
 	}
 
+	for (int set = 0; set < 4; set++) {
+		char set_name[16] = {0};
+		u32 set_config[4];
+		int leds_in_this_set = 0;
+
+		/* Reset LED set configuration */
+		sw_w32(0, RTL930X_LED_SETX_0_CTRL(set));
+		sw_w32(0, RTL930X_LED_SETX_1_CTRL(set));
+
+		/**
+		 * Each led set has 4 number of leds, and each LED is configured with 16 bits
+		 * So each 32bit register holds configuration for 2 leds
+		 * And therefore each set requires 2 registers for configuring 4 LEDs
+		 *
+		*/
+		sprintf(set_name, "led_set%d", set);
+		leds_in_this_set = of_property_count_u32_elems(node, set_name);
+
+		if (leds_in_this_set == 0 || leds_in_this_set > sizeof(set_config)) {
+			pr_err("%s led_set configuration invalid skipping over this set\n", __func__);
+			continue;
+		}
+
+		if (of_property_read_u32_array(node, set_name, set_config, leds_in_this_set)) {
+			break;
+		}
+
+		/* Write configuration as per number of LEDs */
+		for (int i=0, led = leds_in_this_set-1; led >= 0; led--,i++) {
+			sw_w32_mask(0xffff << RTL930X_LED_SET_LEDX_SHIFT(led),
+						(0xffff & set_config[i]) << RTL930X_LED_SET_LEDX_SHIFT(led),
+						RTL930X_LED_SETX_LEDY(set, led));
+		}
+	}
+
 	for (int i = 0; i < priv->cpu_port; i++) {
 		int pos = (i << 1) % 32;
 		u32 set;
-		u32 v;
 
 		sw_w32_mask(0x3 << pos, 0, RTL930X_LED_PORT_FIB_SET_SEL_CTRL(i));
 		sw_w32_mask(0x3 << pos, 0, RTL930X_LED_PORT_COPR_SET_SEL_CTRL(i));
@@ -2407,34 +2450,14 @@ static void rtl930x_led_init(struct rtl838x_switch_priv *priv)
 		if (!priv->ports[i].phy)
 			continue;
 
-		v = 0x1;
-		if (priv->ports[i].is10G)
-			v = 0x3;
-		if (priv->ports[i].phy_is_integrated)
-			v = 0x1;
-		sw_w32_mask(0x3 << pos, v << pos, RTL930X_LED_PORT_NUM_CTRL(i));
+		/* 0x0 = 1 led, 0x1 = 2 leds, 0x2 = 3 leds, 0x3 = 4 leds per port */
+		sw_w32_mask(0x3 << pos, (priv->ports[i].leds_on_this_port -1) << pos, RTL930X_LED_PORT_NUM_CTRL(i));
 
 		pm |= BIT(i);
 
 		set = priv->ports[i].led_set;
 		sw_w32_mask(0, set << pos, RTL930X_LED_PORT_COPR_SET_SEL_CTRL(i));
 		sw_w32_mask(0, set << pos, RTL930X_LED_PORT_FIB_SET_SEL_CTRL(i));
-	}
-
-	for (int i = 0; i < 4; i++) {
-		const __be32 *led_set;
-		char set_name[9];
-		u32 setlen;
-		u32 v;
-
-		sprintf(set_name, "led_set%d", i);
-		led_set = of_get_property(node, set_name, &setlen);
-		if (!led_set || setlen != 16)
-			break;
-		v = be32_to_cpup(led_set) << 16 | be32_to_cpup(led_set + 1);
-		sw_w32(v, RTL930X_LED_SET0_0_CTRL - 4 - i * 8);
-		v = be32_to_cpup(led_set + 2) << 16 | be32_to_cpup(led_set + 3);
-		sw_w32(v, RTL930X_LED_SET0_0_CTRL - i * 8);
 	}
 
 	/* Set LED mode to serial (0x1) */

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -258,9 +258,9 @@ static void rtl930x_vlan_fwd_on_inner(int port, bool is_set)
 {
 	/* Always set all tag modes to fwd based on either inner or outer tag */
 	if (is_set)
-		sw_w32_mask(0, 0xf, RTL930X_VLAN_PORT_FWD + (port << 2));
-	else
 		sw_w32_mask(0xf, 0, RTL930X_VLAN_PORT_FWD + (port << 2));
+	else
+		sw_w32_mask(0, 0xf, RTL930X_VLAN_PORT_FWD + (port << 2));
 }
 
 static void rtl930x_vlan_profile_setup(int profile)

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -827,9 +827,9 @@ static void rtl931x_vlan_fwd_on_inner(int port, bool is_set)
 {
 	/* Always set all tag modes to fwd based on either inner or outer tag */
 	if (is_set)
-		sw_w32_mask(0, 0xf, RTL931X_VLAN_PORT_FWD + (port << 2));
-	else
 		sw_w32_mask(0xf, 0, RTL931X_VLAN_PORT_FWD + (port << 2));
+	else
+		sw_w32_mask(0, 0xf, RTL931X_VLAN_PORT_FWD + (port << 2));
 }
 
 static void rtl931x_vlan_profile_setup(int profile)

--- a/target/linux/realtek/files-5.15/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-5.15/drivers/net/ethernet/rtl838x_eth.h
@@ -216,6 +216,9 @@
 /* Registers of the internal Serdes of the 8380 */
 #define RTL838X_SDS4_FIB_REG0			(0xF800)
 
+/* Default MTU with jumbo frames support */
+#define DEFAULT_MTU 9000
+
 inline int rtl838x_mac_port_ctrl(int p)
 {
 	return RTL838X_MAC_PORT_CTRL + (p << 7);


### PR DESCRIPTION
- Fix VLAN behaviour
- support jumbo frames by default
- enable 2.5 gig for rtl930x
- Fix led behaviour
- Fix detection of current port status
- Expose register and phy_mmd register r/w in sysfs
  to aid development and further debugging

