### PR TITLE
[23.05] kirkwood: fix Ctera C200 V1 ubi part name

### DIFF
--- a/target/linux/kirkwood/patches-5.15/114-ctera-c-200-v1.patch
+++ b/target/linux/kirkwood/patches-5.15/114-ctera-c-200-v1.patch
@@ -49,3 +49,12 @@
  			function = LED_FUNCTION_STATUS;
  			color = <LED_COLOR_ID_GREEN>;
  			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+@@ -240,7 +252,7 @@
+ 	};
+ 
+ 	partition@7a00000 {
+-		label = "rootfs";
++		label = "ubi";
+ 		reg = <0x7a00000 0x8600000>;
+ 	};
+ };


### PR DESCRIPTION
In 749237967a12 downstream dts was replaced with upstream accepted patch. But in upstream version last partition was called "rootfs" instead "ubi". OpenWrt require "ubi" label for ubi rootfs. This patch restore proper label.

Fixes: 749237967a12 ("kirkwood: Replace dtses with upstream accepted")

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
(cherry picked from commit 9075cfd609e905bc7162574a24a7fb457e65a374 accepted by @chunkeey)
