### PR TITLE
ramips: remove useless resets properties from SoC dtsi

### DIFF
--- a/target/linux/ramips/dts/mt7620a.dtsi
+++ b/target/linux/ramips/dts/mt7620a.dtsi
@@ -74,9 +74,6 @@
 			compatible = "ralink,mt7620a-intc", "ralink,rt2880-intc";
 			reg = <0x200 0x100>;
 
-			resets = <&sysc 19>;
-			reset-names = "intc";
-
 			interrupt-controller;
 			#interrupt-cells = <1>;
 
@@ -87,9 +84,6 @@
 		memc: memc@300 {
 			compatible = "ralink,mt7620a-memc", "ralink,rt3050-memc";
 			reg = <0x300 0x100>;
-
-			resets = <&sysc 20>;
-			reset-names = "mc";
 
 			interrupt-parent = <&intc>;
 			interrupts = <3>;
@@ -114,9 +108,6 @@
 		gpio0: gpio@600 {
 			compatible = "ralink,mt7620a-gpio", "ralink,rt2880-gpio";
 			reg = <0x600 0x34>;
-
-			resets = <&sysc 13>;
-			reset-names = "pio";
 
 			interrupt-parent = <&intc>;
 			interrupts = <6>;
@@ -284,9 +275,6 @@
 		systick: systick@d00 {
 			compatible = "ralink,mt7620a-systick", "ralink,cevt-systick";
 			reg = <0xd00 0x10>;
-
-			resets = <&sysc 28>;
-			reset-names = "intc";
 
 			interrupt-parent = <&cpuintc>;
 			interrupts = <7>;

--- a/target/linux/ramips/dts/mt7620n.dtsi
+++ b/target/linux/ramips/dts/mt7620n.dtsi
@@ -74,9 +74,6 @@
 			compatible = "ralink,mt7620a-intc", "ralink,rt2880-intc";
 			reg = <0x200 0x100>;
 
-			resets = <&sysc 19>;
-			reset-names = "intc";
-
 			interrupt-controller;
 			#interrupt-cells = <1>;
 
@@ -88,9 +85,6 @@
 			compatible = "ralink,mt7620a-memc", "ralink,rt3050-memc";
 			reg = <0x300 0x100>;
 
-			resets = <&sysc 20>;
-			reset-names = "mc";
-
 			interrupt-parent = <&intc>;
 			interrupts = <3>;
 		};
@@ -98,9 +92,6 @@
 		gpio0: gpio@600 {
 			compatible = "ralink,mt7620a-gpio", "ralink,rt2880-gpio";
 			reg = <0x600 0x34>;
-
-			resets = <&sysc 13>;
-			reset-names = "pio";
 
 			interrupt-parent = <&intc>;
 			interrupts = <6>;
@@ -246,9 +237,6 @@
 		systick: systick@d00 {
 			compatible = "ralink,mt7620a-systick", "ralink,cevt-systick";
 			reg = <0xd00 0x10>;
-
-			resets = <&sysc 28>;
-			reset-names = "intc";
 
 			interrupt-parent = <&cpuintc>;
 			interrupts = <7>;

--- a/target/linux/ramips/dts/mt7621.dtsi
+++ b/target/linux/ramips/dts/mt7621.dtsi
@@ -120,14 +120,6 @@
 			status = "disabled";
 		};
 
-		systick: systick@500 {
-			compatible = "ralink,mt7621-systick", "ralink,cevt-systick";
-			reg = <0x500 0x10>;
-
-			interrupt-parent = <&gic>;
-			interrupts = <GIC_SHARED 5 IRQ_TYPE_LEVEL_HIGH>;
-		};
-
 		memc: memory-controller@5000 {
 			compatible = "mediatek,mt7621-memc", "syscon";
 			reg = <0x5000 0x1000>;

--- a/target/linux/ramips/dts/mt7621.dtsi
+++ b/target/linux/ramips/dts/mt7621.dtsi
@@ -124,9 +124,6 @@
 			compatible = "ralink,mt7621-systick", "ralink,cevt-systick";
 			reg = <0x500 0x10>;
 
-			resets = <&sysc MT7621_RST_AUX_STCK>;
-			reset-names = "intc";
-
 			interrupt-parent = <&gic>;
 			interrupts = <GIC_SHARED 5 IRQ_TYPE_LEVEL_HIGH>;
 		};

--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -55,9 +55,6 @@
 			compatible = "ralink,mt7628an-intc", "ralink,rt2880-intc";
 			reg = <0x200 0x100>;
 
-			resets = <&sysc 9>;
-			reset-names = "intc";
-
 			interrupt-controller;
 			#interrupt-cells = <1>;
 
@@ -72,9 +69,6 @@
 		memc: memc@300 {
 			compatible = "ralink,mt7620a-memc", "ralink,rt3050-memc";
 			reg = <0x300 0x100>;
-
-			resets = <&sysc 10>;
-			reset-names = "mc";
 
 			interrupt-parent = <&intc>;
 			interrupts = <3>;
@@ -219,9 +213,6 @@
 			compatible = "mediatek,mt7628-pwm";
 			reg = <0x5000 0x1000>;
 			#pwm-cells = <2>;
-
-			resets = <&sysc 31>;
-			reset-names = "pwm";
 
 			pinctrl-names = "default";
 			pinctrl-0 = <&pwm0_pins>, <&pwm1_pins>;

--- a/target/linux/ramips/dts/rt3050.dtsi
+++ b/target/linux/ramips/dts/rt3050.dtsi
@@ -73,9 +73,6 @@
 			compatible = "ralink,rt3050-intc", "ralink,rt2880-intc";
 			reg = <0x200 0x100>;
 
-			resets = <&sysc 19>;
-			reset-names = "intc";
-
 			interrupt-controller;
 			#interrupt-cells = <1>;
 
@@ -86,9 +83,6 @@
 		memc: memc@300 {
 			compatible = "ralink,rt3050-memc";
 			reg = <0x300 0x100>;
-
-			resets = <&sysc 20>;
-			reset-names = "mc";
 
 			interrupt-parent = <&intc>;
 			interrupts = <3>;
@@ -122,9 +116,6 @@
 			ralink,register-map = [ 00 04 08 0c
 						20 24 28 2c
 						30 34 ];
-
-			resets = <&sysc 13>;
-			reset-names = "pio";
 
 			interrupt-parent = <&intc>;
 			interrupts = <6>;

--- a/target/linux/ramips/dts/rt3352.dtsi
+++ b/target/linux/ramips/dts/rt3352.dtsi
@@ -85,9 +85,6 @@
 			compatible = "ralink,rt3352-memc", "ralink,rt3050-memc";
 			reg = <0x300 0x100>;
 
-			resets = <&sysc 20>;
-			reset-names = "mc";
-
 			interrupt-parent = <&intc>;
 			interrupts = <3>;
 		};
@@ -120,8 +117,6 @@
 			ralink,register-map = [ 00 04 08 0c
 						20 24 28 2c
 						30 34 ];
-			resets = <&sysc 13>;
-			reset-names = "pio";
 
 			interrupt-parent = <&intc>;
 			interrupts = <6>;

--- a/target/linux/ramips/dts/rt3883.dtsi
+++ b/target/linux/ramips/dts/rt3883.dtsi
@@ -74,9 +74,6 @@
 			compatible = "ralink,rt3883-intc", "ralink,rt2880-intc";
 			reg = <0x200 0x100>;
 
-			resets = <&sysc 19>;
-			reset-names = "intc";
-
 			interrupt-controller;
 			#interrupt-cells = <1>;
 
@@ -87,9 +84,6 @@
 		memc: memc@300 {
 			compatible = "ralink,rt3883-memc", "ralink,rt3050-memc";
 			reg = <0x300 0x100>;
-
-			resets = <&sysc 20>;
-			reset-names = "mc";
 
 			interrupt-parent = <&intc>;
 			interrupts = <3>;
@@ -114,9 +108,6 @@
 		gpio0: gpio@600 {
 			compatible = "ralink,rt3883-gpio", "ralink,rt2880-gpio";
 			reg = <0x600 0x34>;
-
-			resets = <&sysc 13>;
-			reset-names = "pio";
 
 			interrupt-parent = <&intc>;
 			interrupts = <6>;

--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -74,9 +74,6 @@
 			compatible = "ralink,rt5350-intc", "ralink,rt2880-intc";
 			reg = <0x200 0x100>;
 
-			resets = <&sysc 19>;
-			reset-names = "intc";
-
 			interrupt-controller;
 			#interrupt-cells = <1>;
 
@@ -87,9 +84,6 @@
 		memc: memc@300 {
 			compatible = "ralink,rt5350-memc", "ralink,rt3050-memc";
 			reg = <0x300 0x100>;
-
-			resets = <&sysc 20>;
-			reset-names = "mc";
 
 			interrupt-parent = <&intc>;
 			interrupts = <3>;
@@ -114,9 +108,6 @@
 		gpio0: gpio@600 {
 			compatible = "ralink,rt5350-gpio", "ralink,rt2880-gpio";
 			reg = <0x600 0x34>;
-
-			resets = <&sysc 13>;
-			reset-names = "pio";
 
 			interrupt-parent = <&intc>;
 			interrupts = <6>;


### PR DESCRIPTION
These drivers don't request reset control. And most reset properties even have incorrect reset source definitions.

1. interrupt controller, ref: arch/mips/ralink/irq.c
2. memory controller, ref: arch/mips/ralink/of.c
3. gpio controller, ref: drivers/gpio/gpio-ralink.c (local patch)
4. systic, ref: arch/mips/ralink/cevt-rt3352.c
5. pwm, ref: drivers/pwm/pwm-mediatek-ramips.c (local patch)

Tested on MT7620 && MT7628.