### PR TITLE
qualcommax: Fix Buffalo WXR-5950AX12 Ethernet DTS

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
@@ -267,8 +267,9 @@
 &switch {
 	status = "okay";
 
-	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4 | ESS_PORT6)>;
-	switch_wan_bmp = <ESS_PORT5>;
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4 | ESS_PORT5)>;
+	switch_wan_bmp = <ESS_PORT6>;
+	malibu_first_phy_addr = <0x18>;
 	switch_mac_mode = <MAC_MODE_QSGMII>;
 	switch_mac_mode1 = <MAC_MODE_USXGMII>;
 	switch_mac_mode2 = <MAC_MODE_USXGMII>;


### PR DESCRIPTION
* Revert the switch_lan_bmp and switch_wan_bmp to match the values from
  the original device support DTS
* Add specific malibu_first_phy_addr, as it differs from default for
  this device

Fixes: #14234
Tested-by: Samir Ibradžić <sibradzic@gmail.com> # Buffalo WXR-6000AX12P
Signed-off-by: Samir Ibradžić <sibradzic@gmail.com>