### PR TITLE
oxnas: do not use pcie-controller

### DIFF
--- a/target/linux/oxnas/patches-5.15/340-oxnas-pcie.patch
+++ b/target/linux/oxnas/patches-5.15/340-oxnas-pcie.patch
@@ -38,7 +38,7 @@
  			};
  		};
 +
-+		pcie0: pcie-controller@47c00000 {
++		pcie0: pcie@47c00000 {
 +			compatible = "plxtech,nas782x-pcie";
 +			device_type = "pci";
 +			#address-cells = <3>;
@@ -78,7 +78,7 @@
 +			status = "disabled";
 +		};
 +
-+		pcie1: pcie-controller@47e00000 {
++		pcie1: pcie@47e00000 {
 +			compatible = "plxtech,nas782x-pcie";
 +			device_type = "pci";
 +			#address-cells = <3>;


### PR DESCRIPTION
This was deprecated in kernel 4.14

ping @Ansuel @dangowrt 