### PR TITLE
mvebu: fix RTC of IEI-World Puzzle M90x devices

### DIFF
--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9131-puzzle-m901.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9131-puzzle-m901.dts
@@ -244,6 +244,10 @@
 	};
 };
 
+&cp0_rtc {
+	status = "disabled";
+};
+
 &cp0_syscon0 {
 	cp0_pinctrl: pinctrl {
 		compatible = "marvell,cp115-standalone-pinctrl";
@@ -365,6 +369,10 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&cp1_i2c0_pins>;
 	clock-frequency = <100000>;
+};
+
+&cp1_rtc {
+	status = "disabled";
 };
 
 &cp1_syscon0 {

--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9132-puzzle-m902.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9132-puzzle-m902.dts
@@ -302,6 +302,10 @@
 	};
 };
 
+&cp0_rtc {
+	status = "disabled";
+};
+
 &cp0_syscon0 {
 	cp0_pinctrl: pinctrl {
 		compatible = "marvell,cp115-standalone-pinctrl";
@@ -421,6 +425,10 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&cp1_i2c0_pins>;
 	clock-frequency = <100000>;
+};
+
+&cp1_rtc {
+	status = "disabled";
 };
 
 &cp1_syscon0 {
@@ -549,6 +557,10 @@
 			};
 		};
 	};
+};
+
+&cp2_rtc {
+	status = "disabled";
 };
 
 &cp2_syscon0 {

--- a/target/linux/mvebu/image/cortexa72.mk
+++ b/target/linux/mvebu/image/cortexa72.mk
@@ -65,16 +65,18 @@ TARGET_DEVICES += marvell_clearfog-gt-8k
 
 define Device/iei_puzzle-m901
   $(call Device/Default-arm64)
+  SOC := cn9131
   DEVICE_VENDOR := iEi
   DEVICE_MODEL := Puzzle-M901
-  SOC := cn9131
+  DEVICE_PACKAGES += kmod-rtc-ds1307
 endef
 TARGET_DEVICES += iei_puzzle-m901
 
 define Device/iei_puzzle-m902
   $(call Device/Default-arm64)
+  SOC := cn9132
   DEVICE_VENDOR := iEi
   DEVICE_MODEL := Puzzle-M902
-  SOC := cn9132
+  DEVICE_PACKAGES += kmod-rtc-ds1307
 endef
 TARGET_DEVICES += iei_puzzle-m902


### PR DESCRIPTION
The Puzzle devices come with an I2C-connected Epson RX8130 RTC.
Disable the (dysfunctional) RTC units of the SoC and add driver `kmod-rtc-ds1307` to support the Epson RX8130 instead.