### PR TITLE
dnsmasq: fix and improve init script for DNSSEC time checks

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1094,11 +1094,14 @@ dnsmasq_start()
 	[ "$dnssec" -gt 0 ] && {
 		xappend "--conf-file=$TRUSTANCHORSFILE"
 		xappend "--dnssec"
-		[ -x /etc/init.d/sysntpd ] && {
-			if /etc/init.d/sysntpd enabled && [ "$(uci_get system.ntp.enabled)" = "1" ] ; then
-				[ -f "$TIMEVALIDFILE" ] || xappend "--dnssec-no-timecheck"
-			fi
-		}
+
+		[ ! -f "$TIMEVALIDFILE" ] && {
+			{ [ -x /etc/init.d/sysntpd ] && /etc/init.d/sysntpd enabled &&
+				[ "$(uci_get system.ntp.enabled)" = "1" ]; } ||
+			{ [ -x /etc/init.d/chronyd ] && /etc/init.d/chronyd enabled; } ||
+			{ [ -x /etc/init.d/ntpd ] && /etc/init.d/ntpd enabled; }
+		} && xappend "--dnssec-no-timecheck"
+
 		config_get_bool dnsseccheckunsigned "$cfg" dnsseccheckunsigned 1
 		[ "$dnsseccheckunsigned" -eq 0 ] && xappend "--dnssec-check-unsigned=no"
 	}

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1095,7 +1095,7 @@ dnsmasq_start()
 		xappend "--conf-file=$TRUSTANCHORSFILE"
 		xappend "--dnssec"
 		[ -x /etc/init.d/sysntpd ] && {
-			if /etc/init.d/sysntpd enabled || [ "$(uci_get system.ntp.enabled)" = "1" ] ; then
+			if /etc/init.d/sysntpd enabled && [ "$(uci_get system.ntp.enabled)" = "1" ] ; then
 				[ -f "$TIMEVALIDFILE" ] || xappend "--dnssec-no-timecheck"
 			fi
 		}


### PR DESCRIPTION
The first commit fixes the dnsmasq initscript to not disable the DNSSEC time checks when sysntpd is not expected to start and call the dnsmasq hotplug script enabling the time checks later.

The second commit adds support for the chronyd and ntpd services.