### PR TITLE
filogic: Asus TUF AX6000 fix inverted LED for 2.5Gb LAN port

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
@@ -131,6 +131,7 @@
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <5>;
 
+		mxl,led-drive-vdd;
 		mxl,led-config = <0x03f0 0x0 0x0 0x0>;
 	};
 


### PR DESCRIPTION
Router Asus TUF AX6000 have second MaxLinear GPY211 PHY  controller for 2.5Gb LAN port. 
The 5'th LAN port have inverted status of the LED.
Based on the commit from main branch https://github.com/openwrt/openwrt/commit/90fbec89be263a3838558c5b674f3c4072cc2f1d we could set proper status of the LED.
