### PR TITLE
ramips: New device support zte,mf286c3 (mt7621)

### DIFF
--- a/target/linux/ramips/dts/mt7621_zte_mf286c3.dts
+++ b/target/linux/ramips/dts/mt7621_zte_mf286c3.dts
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "zte,mf286c3", "mediatek,mt7621-soc";
+	model = "ZTE MF286C3";
+
+	chosen {
+		bootargs-override = "console=ttyS0,57600n8";
+	};
+
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <50>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&button_pins>;
+
+		key-wps {
+			gpios = <&aw9523 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		key-wlan {
+			gpios = <&aw9523 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WLAN>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "Factory";
+			reg = <0x100000 0x100000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				eeprom1: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
+			};
+		};
+
+		partition@200000 {
+			label = "inventory";
+			reg = <0x200000 0x100000>;
+			read-only;
+		};
+
+		partition@300000 {
+			label = "customer";
+			reg = <0x300000 0x100000>;
+			read-only;
+		};
+
+		partition@400000 {
+			label = "zone";
+			reg = <0x400000 0x100000>;
+			read-only;
+		};
+
+		partition@500000 {
+			label = "reserved0";
+			reg = <0x500000 0x500000>;
+			read-only;
+		};
+
+		partition@a00000 {
+			label = "kernel";
+			reg = <0xa00000 0x500000>;
+		};
+
+		partition@f00000 {
+			label = "ubi";
+			reg = <0xf00000 0x7100000>;
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+
+	aw9523: gpio-expander@5b {
+		compatible = "awinic,aw9523-pinctrl";
+		reg = <0x5b>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-ranges = <&aw9523 0 0 16>;
+
+		reset-gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+
+		button_pins: button-pins {
+			pins = "gpio14", "gpio15";
+			function = "gpio";
+			input-enable;
+		};
+
+		led_pins: led-pins {
+			pins = "gpio0", "gpio1", "gpio2", "gpio3", "gpio5", "gpio6",
+				"gpio8", "gpio9", "gpio10", "gpio11", "gpio12";
+			function = "gpio";
+			input-disable;
+			output-low;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0 0 0 0 0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+		nvmem-cells = <&eeprom0>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom1>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3752,6 +3752,19 @@ define Device/zio_freezio
 endef
 TARGET_DEVICES += zio_freezio
 
+define Device/zte_mf286c3
+  $(Device/nand)
+  $(Device/uimage-lzma-loader)
+  VID_HDR_OFFSET := 2048
+  IMAGE_SIZE := 41984k
+  KERNEL_SIZE := 5120k
+  DEVICE_VENDOR := ZTE
+  DEVICE_MODEL := MF286C3
+  DEVICE_PACKAGES := kmod-mt7603 kmod-usb3 kmod-mt7615e \
+	kmod-mt7663-firmware-ap
+endef
+TARGET_DEVICES += zte_mf286c3
+
 define Device/zyxel_lte3301-plus
   $(Device/nand)
   DEVICE_VENDOR := Zyxel

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -277,6 +277,9 @@ z-router,zr-2660)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
 	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "wan" "link"
 	;;
+zte,mf286c3)
+	ucidef_set_led_netdev "internet" "internet" "blue:indicator-3" "wan"
+	;;
 zyxel,lte3301-plus)
 	ucidef_set_led_netdev "internet" "internet" "white:internet" "wwan0"
 	;;

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -156,6 +156,7 @@ platform_do_upgrade() {
 	xiaomi,mi-router-cr6609|\
 	xiaomi,redmi-router-ac2100|\
 	z-router,zr-2660|\
+	zte,mf286c3|\
 	zyxel,nwa50ax|\
 	zyxel,nwa55axe)
 		nand_do_upgrade "$1"


### PR DESCRIPTION
MF286C3 LTE CPE with GSM, WCDMA and WiFi

Specifications:
SoC: MediaTek MT7621 (MIPS1004Kc 32-bit 880MHz)
RAM: 256MiB
Flash: SPI-NAND 128 MiB
Switch: 1 WAN (LAN), 3 LAN (Gigabit)
Buttons: Reset, WPS, WLAN
Power: DC 12V 1A
WiFi: MT7603 and MT7663
UART: 115200n8
UART Layout:
VCC-RX-TX-GND

Led Layout:
Power-WLAN-PHONE-3G/4G-SIGNAL(5 LEDS)

Buttons:
Reset-WPS-WLAN

Original mtd paritions:
Creating 14 MTD partitions on "MT7621-NAND":
0x000000000000-0x000007f80000 : "ALL"
0x000000000000-0x000000080000 : "Bootloader"
0x000000080000-0x000000100000 : "Config"
0x000000100000-0x000000200000 : "Factory"
0x000000200000-0x000000300000 : "inventory"
0x000000300000-0x000000400000 : "customer"
0x000000400000-0x000000500000 : "zone"
0x000000500000-0x000000a00000 : "reserved0"
0x000000a00000-0x000000f00000 : "kernel0"
0x000000f00000-0x000001400000 : "kernel1"
0x000001400000-0x000003800000 : "ubi0"
0x000003800000-0x000005c00000 : "ubi1"
0x000005c00000-0x000006600000 : "reserved1"
0x000006600000-0x000007500000 : "reserved2"

Installation:
A. Through OpenWrt Dashboard:
If your router comes with OpenWrt preinstalled (modified by the seller), you can easily upgrade by going to the dashboard (192.168.1.1) and then navigate to System -> Backup/Flash firmware, then flash the firmware

B. Through TFTP
Standard installation via UART:

Connect USB Serial Adapter to the UART, (NOTE: Don't connect the VCC pin).
Power on the router. Make sure that you can access your router via UART.
Restart the router then repeatedly press ctrl + c to skip default boot.
Type > bootmenu
Press '2' to select upgrade firmware
Press 'Y' on 'Run image after upgrading?'
Press '0' and hit 'enter' to select TFTP client (default)
Fill the U-Boot's IP address and TFTP server's IP address.
Finally, enter the 'firmware' filename.