### PR TITLE
ramips: reset mt7620 ethernet phy and frame engine via reset controller

### DIFF
--- a/target/linux/ramips/dts/mt7620a.dtsi
+++ b/target/linux/ramips/dts/mt7620a.dtsi
@@ -490,8 +490,8 @@
 		compatible = "mediatek,mt7620-gsw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&sysc 23>;
-		reset-names = "esw";
+		resets = <&sysc 24>;
+		reset-names = "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/dts/mt7620n.dtsi
+++ b/target/linux/ramips/dts/mt7620n.dtsi
@@ -317,8 +317,8 @@
 		compatible = "mediatek,mt7620-gsw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&sysc 23>;
-		reset-names = "esw";
+		resets = <&sysc 24>;
+		reset-names = "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
@@ -61,6 +61,17 @@ static irqreturn_t gsw_interrupt_mt7620(int irq, void *_priv)
 	return IRQ_HANDLED;
 }
 
+static void gsw_reset_ephy(struct mt7620_gsw *gsw)
+{
+	if (!gsw->rst_ephy)
+		return;
+
+	reset_control_assert(gsw->rst_ephy);
+	usleep_range(10, 20);
+	reset_control_deassert(gsw->rst_ephy);
+	usleep_range(10, 20);
+}
+
 static void mt7620_ephy_init(struct mt7620_gsw *gsw)
 {
 	u32 i;
@@ -79,7 +90,7 @@ static void mt7620_ephy_init(struct mt7620_gsw *gsw)
 		mtk_switch_w32(gsw, mtk_switch_r32(gsw, GSW_REG_GPC1) |
 			(gsw->ephy_base << 16),
 			GSW_REG_GPC1);
-		fe_reset(MT7620A_RESET_EPHY);
+		gsw_reset_ephy(gsw);
 
 		pr_info("gsw: ephy base address: %d\n", gsw->ephy_base);
 	}
@@ -262,6 +273,12 @@ static int mt7620_gsw_probe(struct platform_device *pdev)
 	gsw->dev = &pdev->dev;
 
 	gsw->irq = platform_get_irq(pdev, 0);
+
+	gsw->rst_ephy = devm_reset_control_get_exclusive(&pdev->dev, "ephy");
+	if (IS_ERR(gsw->rst_ephy)) {
+		dev_err(gsw->dev, "failed to get EPHY reset: %pe\n", gsw->rst_ephy);
+		gsw->rst_ephy = NULL;
+	}
 
 	platform_set_drvdata(pdev, gsw);
 

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.h
@@ -12,6 +12,8 @@
  *   Copyright (C) 2013-2015 Michael Lee <igvtee@gmail.com>
  */
 
+#include <linux/reset.h>
+
 #ifndef _RALINK_GSW_MT7620_H__
 #define _RALINK_GSW_MT7620_H__
 
@@ -90,6 +92,7 @@ enum {
 
 struct mt7620_gsw {
 	struct device		*dev;
+	struct reset_control	*rst_ephy;
 	void __iomem		*base;
 	int			irq;
 	bool			ephy_disable;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -141,7 +141,7 @@ void fe_reset(u32 reset_bits)
 	usleep_range(10, 20);
 }
 
-void fe_reset_fe(struct fe_priv *priv)
+static void fe_reset_fe(struct fe_priv *priv)
 {
 	if (!priv->resets)
 		return;
@@ -1366,10 +1366,7 @@ static int __init fe_init(struct net_device *dev)
 	struct device_node *port;
 	int err;
 
-	if (priv->soc->reset_fe)
-		priv->soc->reset_fe(priv);
-	else
-		fe_reset_fe(priv);
+	fe_reset_fe(priv);
 
 	if (priv->soc->switch_init) {
 		err = priv->soc->switch_init(priv);

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -61,8 +61,6 @@
 #define NEXT_TX_DESP_IDX(X)	(((X) + 1) & (ring->tx_ring_size - 1))
 #define NEXT_RX_DESP_IDX(X)	(((X) + 1) & (ring->rx_ring_size - 1))
 
-#define SYSC_REG_RSTCTRL	0x34
-
 static int fe_msg_level = -1;
 module_param_named(msg_level, fe_msg_level, int, 0);
 MODULE_PARM_DESC(msg_level, "Message level (-1=defaults,0=none,...,16=all)");
@@ -125,20 +123,6 @@ void fe_m32(struct fe_priv *eth, u32 clear, u32 set, unsigned reg)
 	val |= set;
 	__raw_writel(val, fe_base + reg);
 	spin_unlock(&eth->page_lock);
-}
-
-void fe_reset(u32 reset_bits)
-{
-	u32 t;
-
-	t = rt_sysc_r32(SYSC_REG_RSTCTRL);
-	t |= reset_bits;
-	rt_sysc_w32(t, SYSC_REG_RSTCTRL);
-	usleep_range(10, 20);
-
-	t &= ~reset_bits;
-	rt_sysc_w32(t, SYSC_REG_RSTCTRL);
-	usleep_range(10, 20);
 }
 
 static void fe_reset_fe(struct fe_priv *priv)

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
@@ -157,8 +157,6 @@ enum fe_work_flag {
 #define MT7620A_FE_GDMA1_MAC_ADRL	(MT7620A_GDMA_OFFSET + 0x0C)
 #define MT7620A_FE_GDMA1_MAC_ADRH	(MT7620A_GDMA_OFFSET + 0x10)
 
-#define MT7620A_RESET_EPHY	BIT(24)
-
 #define RT5350_TX_BASE_PTR0	(RT5350_PDMA_OFFSET + 0x00)
 #define RT5350_TX_MAX_CNT0	(RT5350_PDMA_OFFSET + 0x04)
 #define RT5350_TX_CTX_IDX0	(RT5350_PDMA_OFFSET + 0x08)
@@ -512,8 +510,6 @@ void fe_stats_update(struct fe_priv *priv);
 void fe_fwd_config(struct fe_priv *priv);
 void fe_reg_w32(u32 val, enum fe_reg reg);
 u32 fe_reg_r32(enum fe_reg reg);
-
-void fe_reset(u32 reset_bits);
 
 static inline void *priv_netdev(struct fe_priv *priv)
 {

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
@@ -157,8 +157,6 @@ enum fe_work_flag {
 #define MT7620A_FE_GDMA1_MAC_ADRL	(MT7620A_GDMA_OFFSET + 0x0C)
 #define MT7620A_FE_GDMA1_MAC_ADRH	(MT7620A_GDMA_OFFSET + 0x10)
 
-#define MT7620A_RESET_FE	BIT(21)
-#define MT7620A_RESET_ESW	BIT(23)
 #define MT7620A_RESET_EPHY	BIT(24)
 
 #define RT5350_TX_BASE_PTR0	(RT5350_PDMA_OFFSET + 0x00)
@@ -382,7 +380,6 @@ struct fe_soc_data {
 	const u16 *reg_table;
 
 	void (*init_data)(struct fe_soc_data *data, struct net_device *netdev);
-	void (*reset_fe)(struct fe_priv *priv);
 	void (*set_mac)(struct fe_priv *priv, unsigned char *mac);
 	int (*fwd_config)(struct fe_priv *priv);
 	void (*tx_dma)(struct fe_tx_dma *txd);
@@ -517,7 +514,6 @@ void fe_reg_w32(u32 val, enum fe_reg reg);
 u32 fe_reg_r32(enum fe_reg reg);
 
 void fe_reset(u32 reset_bits);
-void fe_reset_fe(struct fe_priv *priv);
 
 static inline void *priv_netdev(struct fe_priv *priv)
 {

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_mt7620.c
@@ -286,11 +286,6 @@ static void mt7620_port_init(struct fe_priv *priv, struct device_node *np)
 	}
 }
 
-static void mt7620_fe_reset(struct fe_priv *priv)
-{
-	fe_reset(MT7620A_RESET_FE | MT7620A_RESET_ESW);
-}
-
 static void mt7620_rxcsum_config(bool enable)
 {
 	if (enable)
@@ -348,7 +343,6 @@ static void mt7620_init_data(struct fe_soc_data *data,
 
 static struct fe_soc_data mt7620_data = {
 	.init_data = mt7620_init_data,
-	.reset_fe = mt7620_fe_reset,
 	.set_mac = mt7620_set_mac,
 	.fwd_config = mt7620_fwd_config,
 	.tx_dma = mt7620_tx_dma,


### PR DESCRIPTION
Just some minor improvements to the mt7620 eth platform driver. The code logic is the same as before.

1. Use reset controller to reset mt7620 frame engine instead of directly writing system control registers.
2. Use reset controller to reset mt7620 ethernet phy instead of directly writing system control registers. The reset line of "ephy" is 24, so the DTS resets properties have been updated to get the correct reset signal.

Depend on: https://github.com/openwrt/openwrt/pull/14194