### PR TITLE
realtek: 5.15: rtl93xx: support 100BASE-T and 10BASE-T MAC modes

### DIFF
--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
@@ -854,8 +854,10 @@ static void rtl93xx_phylink_mac_config(struct dsa_switch *ds, int port,
 	case SPEED_1000:
 		reg |= 2 << 3;
 		break;
+	case SPEED_100:
+		reg |= 1 << 3;
+		break;
 	default:
-		reg |= 2 << 3;
 		break;
 	}
 


### PR DESCRIPTION
The MAC embedded in rtl93xx switch SoCs needs different mac mode bits set to support 10BaseT and 100BaseT link modes. Set them accordingly.

Previously 100BASE-T and 10BASE-T links on  rtl93xx-based switches were not working.

This change has been tested on a ZyXEL XGS1250-12.