### PR TITLE
 lantiq: add support for AVM Fritzbox 3490, 5490, 5491 and 7490

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -1739,6 +1739,7 @@ define KernelPackage/usb3
 	+TARGET_ramips_mt7621:kmod-usb-xhci-mtk \
 	+TARGET_mediatek:kmod-usb-xhci-mtk \
 	+TARGET_apm821xx_nand:kmod-usb-xhci-pci-renesas \
+	+TARGET_lantiq_xrx200:kmod-usb-xhci-pci-renesas \
 	+TARGET_mvebu_cortexa9:kmod-usb-xhci-pci-renesas
   KCONFIG:= \
 	CONFIG_USB_PCI=y \

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3490-micron.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3490-micron.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritz3490.dtsi"
+
+/ {
+	compatible = "avm,fritz3490-micron", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 3490 (Micron NAND)";
+};
+
+&nand1 {
+	nand-ecc-engine = <&nand1>;
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3490.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3490.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritz3490.dtsi"
+
+/ {
+	compatible = "avm,fritz3490", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 3490";
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3490.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3490.dtsi
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritzxx90.dtsi"
+
+/ {
+	compatible = "avm,fritz3490", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 3490";
+};
+
+&aliases {
+	led-dsl = &led_info_green;
+	led-internet = &led_internet;
+	led-wifi = &led_wifi;
+};
+
+&leds {
+	led_lan: lan {
+		label = "green:lan";
+		gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+	};
+
+	led_wifi: wifi {
+		label = "green:wlan";
+		gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+	};
+
+	led_internet: internet {
+		label = "green:internet";
+		gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gswip_mdio {
+	phy0: ethernet-phy@0 {
+		reg = <0x00>;
+		reset-gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+	};
+
+	phy1: ethernet-phy@1 {
+		reg = <0x01>;
+		reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+	};
+
+	phy11: ethernet-phy@11 {
+		reg = <0x11>;
+	};
+
+	phy13: ethernet-phy@13 {
+		reg = <0x13>;
+	};
+};
+
+&gswip_ports {
+	port@0 {
+		reg = <0>;
+		label = "lan3";
+		phy-mode = "rgmii-rxid";
+		phy-handle = <&phy0>;
+	};
+
+	port@1 {
+		reg = <1>;
+		label = "lan4";
+		phy-mode = "rgmii-rxid";
+		phy-handle = <&phy1>;
+	};
+
+	port@2 {
+		reg = <2>;
+		label = "lan2";
+		phy-mode = "internal";
+		phy-handle = <&phy11>;
+	};
+
+	port@4 {
+		reg = <4>;
+		label = "lan1";
+		phy-mode = "internal";
+		phy-handle = <&phy13>;
+	};
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz5490-micron.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz5490-micron.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritz5490.dtsi"
+
+/ {
+	compatible = "avm,fritz5490-micron", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 5490/5491 (Micron NAND)";
+};
+
+&nand1 {
+	nand-ecc-engine = <&nand1>;
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz5490.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz5490.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritz5490.dtsi"
+
+/ {
+	compatible = "avm,fritz5490", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 5490/5491";
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz5490.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz5490.dtsi
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritzxx90.dtsi"
+
+/ {
+	compatible = "avm,fritz5490", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 5490/5491";
+};
+
+&aliases {
+	led-dsl = &led_info_green;
+	led-internet = &led_internet;
+	led-wifi = &led_wifi;
+};
+
+&leds {
+	led_fiber: fiber {
+		label = "green:fiber";
+		gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+	};
+
+	led_wifi: wifi {
+		label = "green:wlan";
+		gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+	};
+
+	led_internet: internet {
+		label = "green:internet";
+		gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gswip_mdio {
+	phy5: ethernet-phy@5 {
+		reg = <0x05>;
+	};
+
+	phy6: ethernet-phy@6 {
+		reg = <0x06>;
+		reset-gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+	};
+
+	phy9: ethernet-phy@9 {
+		reg = <0x09>;
+	};
+};
+
+&gswip_ports {
+	port@0 {
+		reg = <0>;
+		label = "wan";
+		phy-mode = "rgmii";
+		phy-handle = <&phy6>;
+	};
+
+	port@2 {
+		reg = <2>;
+		label = "lan2";
+		phy-mode = "internal";
+		phy-handle = <&phy5>;
+	};
+
+	port@4 {
+		reg = <4>;
+		label = "lan1";
+		phy-mode = "internal";
+		phy-handle = <&phy9>;
+	};
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490-micron.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490-micron.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritz7490.dtsi"
+
+/ {
+	compatible = "avm,fritz7490-micron", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 7490 (Micron NAND)";
+};
+
+&nand1 {
+	nand-ecc-engine = <&nand1>;
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritz7490.dtsi"
+
+/ {
+	compatible = "avm,fritz7490", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 7490";
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dtsi
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritzxx90.dtsi"
+
+/ {
+	compatible = "avm,fritz7490", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 7490";
+};
+
+&aliases {
+	led-dsl = &led_info_green;
+	led-internet = &led_internet;
+	led-wifi = &led_wifi;
+};
+
+&leds {
+	led_internet: internet {
+		label = "green:internet";
+		gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+	};
+
+	led_fon: fon {
+		label = "green:fon";
+		gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+	};
+
+	led_wifi: wifi {
+		label = "green:wlan";
+		gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gswip_mdio {
+	phy0: ethernet-phy@0 {
+		reg = <0x00>;
+		reset-gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+	};
+
+	phy1: ethernet-phy@1 {
+		reg = <0x01>;
+		reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+	};
+
+	phy11: ethernet-phy@11 {
+		reg = <0x11>;
+	};
+
+	phy13: ethernet-phy@13 {
+		reg = <0x13>;
+	};
+};
+
+&gswip_ports {
+	port@0 {
+		reg = <0>;
+		label = "lan3";
+		phy-mode = "rgmii-rxid";
+		phy-handle = <&phy0>;
+	};
+
+	port@1 {
+		reg = <1>;
+		label = "lan4";
+		phy-mode = "rgmii-rxid";
+		phy-handle = <&phy1>;
+	};
+
+	port@2 {
+		reg = <2>;
+		label = "lan2";
+		phy-mode = "internal";
+		phy-handle = <&phy11>;
+	};
+
+	port@4 {
+		reg = <4>;
+		label = "lan1";
+		phy-mode = "internal";
+		phy-handle = <&phy13>;
+	};
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritzxx90.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritzxx90.dtsi
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	aliases: aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_info_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_info_red;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		power {
+			label = "power";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_POWER>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		led_info_green: info_green {
+			label = "green:info";
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+		};
+
+		led_info_red: info_red {
+			label = "red:info";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+	gpio-ranges = <&gpio 0 0 56>;
+
+	state_default: pinmux {
+		phy-rst {
+			lantiq,pins = "io32", "io44";
+			lantiq,pull = <0>;
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
+
+		pcie-rst {
+			lantiq,pins = "io21";
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
+	};
+
+	usb-vbus {
+		gpio-hog;
+		line-name = "usb-vbus";
+		gpios = <14 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+
+	pcie-enable-dev {
+		gpio-hog;
+		line-name = "pcie-enable-dev";
+		gpios = <22 GPIO_ACTIVE_LOW>;
+		output-low;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@4 {
+		compatible = "jedec,spi-nor";
+		reg = <4>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			urlader: partition@0 {
+				reg = <0x0 0x40000>;
+				label = "urlader";
+				read-only;
+			};
+
+			partition@40000 {
+				reg = <0x40000 0x60000>;
+				label = "tffs (1)";
+				read-only;
+			};
+
+			partition@a0000 {
+				reg = <0xa0000 0x60000>;
+				label = "tffs (2)";
+				read-only;
+			};
+		};
+	};
+};
+
+&localbus {
+	nand1: nand@1 {
+		compatible = "lantiq,nand-xway";
+		bank-width = <2>;
+		reg = <0x1 0x0 0x2000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x03000000>;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	gpio-reset = <&gpio 21 GPIO_ACTIVE_LOW>;
+	lantiq,switch-pcie-endianess;
+};

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -149,6 +149,42 @@ define Device/avm_fritz3390
 endef
 TARGET_DEVICES += avm_fritz3390
 
+define Device/avm_fritz5490
+  $(Device/dsa-migration)
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 5490
+  DEVICE_ALT0_VENDOR := AVM
+  DEVICE_ALT0_MODEL := FRITZ!Box 5491
+  DEVICE_VARIANT := Other NAND
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-switch-qca8k kmod-usb3 fritz-tffs \
+	-ltq-vdsl-vr9-vectoring-fw-installer -kmod-ltq-vdsl-vr9-mei \
+	-kmod-ltq-vdsl-vr9 -kmod-ltq-atm-vr9 -kmod-ltq-ptm-vr9 \
+	-ltq-vdsl-vr9-app -kmod-owl-loader \
+	-dsl-vrx200-firmware-xdsl-a -dsl-vrx200-firmware-xdsl-b-patch
+endef
+TARGET_DEVICES += avm_fritz5490
+
+define Device/avm_fritz5490-micron
+  $(Device/dsa-migration)
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 5490
+  DEVICE_ALT0_VENDOR := AVM
+  DEVICE_ALT0_MODEL := FRITZ!Box 5491
+  DEVICE_VARIANT := Micron NAND
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-switch-qca8k kmod-usb3 fritz-tffs \
+	-ltq-vdsl-vr9-vectoring-fw-installer -kmod-ltq-vdsl-vr9-mei \
+	-kmod-ltq-vdsl-vr9 -kmod-ltq-atm-vr9 -kmod-ltq-ptm-vr9 \
+	-ltq-vdsl-vr9-app -kmod-owl-loader \
+	-dsl-vrx200-firmware-xdsl-a -dsl-vrx200-firmware-xdsl-b-patch
+endef
+TARGET_DEVICES += avm_fritz5490-micron
+
 define Device/avm_fritz7360sl
   $(Device/dsa-migration)
   $(Device/AVM)

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -149,6 +149,30 @@ define Device/avm_fritz3390
 endef
 TARGET_DEVICES += avm_fritz3390
 
+define Device/avm_fritz3490
+  $(Device/dsa-migration)
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 3490
+  DEVICE_VARIANT := Other NAND
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-usb3 fritz-tffs -kmod-owl-loader
+endef
+TARGET_DEVICES += avm_fritz3490
+
+define Device/avm_fritz3490-micron
+  $(Device/dsa-migration)
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 3490
+  DEVICE_VARIANT := Micron NAND
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-usb3 fritz-tffs -kmod-owl-loader
+endef
+TARGET_DEVICES += avm_fritz3490-micron
+
 define Device/avm_fritz5490
   $(Device/dsa-migration)
   $(Device/AVM)

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -208,6 +208,30 @@ define Device/avm_fritz7430
 endef
 TARGET_DEVICES += avm_fritz7430
 
+define Device/avm_fritz7490
+  $(Device/dsa-migration)
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 7490
+  DEVICE_VARIANT := Other NAND
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-usb3 fritz-tffs -kmod-owl-loader
+endef
+TARGET_DEVICES += avm_fritz7490
+
+define Device/avm_fritz7490-micron
+  $(Device/dsa-migration)
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 7490
+  DEVICE_VARIANT := Micron NAND
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-usb3 fritz-tffs -kmod-owl-loader
+endef
+TARGET_DEVICES += avm_fritz7490-micron
+
 define Device/bt_homehub-v5a
   $(Device/dsa-migration)
   $(Device/NAND)

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
@@ -42,6 +42,8 @@ arcadyan,vgv7519-brn)
 avm,fritz3370-rev2-hynix|\
 avm,fritz3370-rev2-micron|\
 avm,fritz3390|\
+avm,fritz3490|\
+avm,fritz3490-micron|\
 avm,fritz5490|\
 avm,fritz5490-micron|\
 avm,fritz7490|\

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
@@ -42,6 +42,8 @@ arcadyan,vgv7519-brn)
 avm,fritz3370-rev2-hynix|\
 avm,fritz3370-rev2-micron|\
 avm,fritz3390|\
+avm,fritz5490|\
+avm,fritz5490-micron|\
 avm,fritz7490|\
 avm,fritz7490-micron)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x17"

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
@@ -41,7 +41,9 @@ arcadyan,vgv7519-brn)
 	;;
 avm,fritz3370-rev2-hynix|\
 avm,fritz3370-rev2-micron|\
-avm,fritz3390)
+avm,fritz3390|\
+avm,fritz7490|\
+avm,fritz7490-micron)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x17"
 	;;
 bt,homehub-v5a)

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -18,6 +18,10 @@ lantiq_setup_interfaces()
 	arcadyan,arv7519rw22)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"
 		;;
+	avm,fritz5490|\
+	avm,fritz5490-micron)
+		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
+		;;
 	arcadyan,vgv7510kw22-brn|\
 	arcadyan,vgv7510kw22-nor|\
 	arcadyan,vgv7519-brn|\
@@ -118,6 +122,8 @@ lantiq_setup_macs()
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 0xa91)" 1)
 		;;
 	avm,fritz3390|\
+	avm,fritz5490|\
+	avm,fritz5490-micron|\
 	avm,fritz7362sl|\
 	avm,fritz7490|\
 	avm,fritz7490-micron)

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -36,6 +36,8 @@ lantiq_setup_interfaces()
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
 	avm,fritz3390|\
+	avm,fritz3490|\
+	avm,fritz3490-micron|\
 	avm,fritz7360sl|\
 	avm,fritz7360-v2|\
 	avm,fritz7362sl|\
@@ -70,6 +72,8 @@ lantiq_setup_dsl()
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
 	avm,fritz3390|\
+	avm,fritz3490|\
+	avm,fritz3490-micron|\
 	avm,fritz7360sl|\
 	avm,fritz7362sl|\
 	avm,fritz7412|\
@@ -122,6 +126,8 @@ lantiq_setup_macs()
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 0xa91)" 1)
 		;;
 	avm,fritz3390|\
+	avm,fritz3490|\
+	avm,fritz3490-micron|\
 	avm,fritz5490|\
 	avm,fritz5490-micron|\
 	avm,fritz7362sl|\

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -36,6 +36,8 @@ lantiq_setup_interfaces()
 	avm,fritz7360-v2|\
 	avm,fritz7362sl|\
 	avm,fritz7430|\
+	avm,fritz7490|\
+	avm,fritz7490-micron|\
 	buffalo,wbmr-300hpd|\
 	tplink,tdw8970|\
 	tplink,tdw8980|\
@@ -67,7 +69,9 @@ lantiq_setup_dsl()
 	avm,fritz7360sl|\
 	avm,fritz7362sl|\
 	avm,fritz7412|\
-	avm,fritz7430)
+	avm,fritz7430|\
+	avm,fritz7490|\
+	avm,fritz7490-micron)
 		annex="b"
 		;;
 	esac
@@ -114,7 +118,9 @@ lantiq_setup_macs()
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 0xa91)" 1)
 		;;
 	avm,fritz3390|\
-	avm,fritz7362sl)
+	avm,fritz7362sl|\
+	avm,fritz7490|\
+	avm,fritz7490-micron)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(fritz_tffs -n macdsl -i $(find_mtd_part "tffs (1)"))
 		;;

--- a/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
+++ b/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
@@ -15,6 +15,8 @@ platform_do_upgrade() {
 	avm,fritz7362sl|\
 	avm,fritz7412|\
 	avm,fritz7430|\
+	avm,fritz7490|\
+	avm,fritz7490-micron|\
 	bt,homehub-v5a|\
 	zyxel,p-2812hnu-f1|\
 	zyxel,p-2812hnu-f3)

--- a/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
+++ b/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
@@ -12,6 +12,8 @@ platform_do_upgrade() {
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
 	avm,fritz3390|\
+	avm,fritz3490|\
+	avm,fritz3490-micron|\
 	avm,fritz5490|\
 	avm,fritz5490-micron|\
 	avm,fritz7362sl|\

--- a/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
+++ b/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
@@ -12,6 +12,8 @@ platform_do_upgrade() {
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
 	avm,fritz3390|\
+	avm,fritz5490|\
+	avm,fritz5490-micron|\
 	avm,fritz7362sl|\
 	avm,fritz7412|\
 	avm,fritz7430|\


### PR DESCRIPTION
This is a rebased version of https://github.com/openwrt/openwrt/pull/5075
The original author appears busy, but if he finds time I will gladly close this PR to continue with the original one.

I tested it with my 5490 with non-Micron (Toshiba) flash and the device comes up without issues:
[openwrt-lantiq-xrx200-avm_fritz5490-initramfs-kernel.bin.gz](https://github.com/openwrt/openwrt/files/13759382/openwrt-lantiq-xrx200-avm_fritz5490-initramfs-kernel.bin.gz)
[openwrt-lantiq-xrx200-avm_fritz5490-squashfs-sysupgrade.bin.gz](https://github.com/openwrt/openwrt/files/13759383/openwrt-lantiq-xrx200-avm_fritz5490-squashfs-sysupgrade.bin.gz)

It would be great if support for these devices could be integrated in the main OpenWRT branch!!