### PR TITLE
filogic: Add support for D-Link AQUILA PRO AI M30

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -73,6 +73,9 @@ zbtlink,zbt-z8102ax|\
 zbtlink,zbt-z8103ax)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;
+dlink,aquila-pro-ai-m30-a1)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x40000"
+	;;
 h3c,magic-nx30-pro|\
 jcg,q30-pro|\
 netcore,n60|\

--- a/package/kernel/leds-gca230718/Makefile
+++ b/package/kernel/leds-gca230718/Makefile
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2008-2010 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=leds-gca230718
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/leds-gca230718
+  SUBMENU:=LED modules
+  TITLE:=GCA230718 LED support (e.g. for D-Link M30)
+  FILES:= \
+	$(PKG_BUILD_DIR)/leds-gca230718.ko
+  AUTOLOAD:=$(call AutoProbe,leds-gca230718,1)
+  DEPENDS:=@TARGET_mediatek_filogic
+endef
+
+define KernelPackage/leds-gca230718/description
+  GCA230718 LED support (e.g. for D-Link M30) using I2C.
+endef
+
+define Build/Compile
+	$(KERNEL_MAKE) M="$(PKG_BUILD_DIR)" modules
+endef
+
+$(eval $(call KernelPackage,leds-gca230718))

--- a/package/kernel/leds-gca230718/src/Makefile
+++ b/package/kernel/leds-gca230718/src/Makefile
@@ -1,0 +1,1 @@
+obj-m := leds-gca230718.o

--- a/package/kernel/leds-gca230718/src/leds-gca230718.c
+++ b/package/kernel/leds-gca230718/src/leds-gca230718.c
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * GCA230718 LED support (e.g. for D-Link M30) using I2C
+ *
+ * Copyright 2022 Roland Reinl <reinlroland+github@gmail.com>
+ *
+ * This driver can control RGBW LEDs which are connected to a GCA230718.
+ */
+
+#include <linux/delay.h>
+#include <linux/led-class-multicolor.h>
+#include <linux/leds.h>
+#include <linux/module.h>
+#include <linux/of_device.h>
+#include <linux/property.h>
+#include <linux/i2c.h>
+#include <linux/mutex.h>
+#include <linux/version.h>
+
+#define GCA230718_MAX_LEDS                                      (4u)
+
+#define GCA230718_OPMODE_DISABLED                               (0x00u)
+#define GCA230718_OPMODE_NO_TOGGLE                              (0x01u)
+#define GCA230718_OPMODE_TOGGLE_RAMP_CONTROL_DISABLED           (0x02u)
+#define GCA230718_OPMODE_TOGGLE_RAMP_CONTROL_ENSABLED           (0x03u)
+
+#define GCA230718_1ST_SEQUENCE_BYTE_1                           (0x02u)
+#define GCA230718_2ND_SEQUENCE_BYTE_1                           (0x01u)
+#define GCA230718_3RD_SEQUENCE_BYTE_1                           (0x03u)
+
+struct gca230718_led
+{
+	enum led_brightness brightness;
+	struct i2c_client *client;
+	struct led_classdev ledClassDev;
+};
+
+struct gca230718_private
+{
+	struct mutex lock;
+	struct gca230718_led leds[GCA230718_MAX_LEDS];
+};
+
+static void gca230718_init_private_led_data(struct gca230718_private* data)
+{
+	u8 ledIndex;
+	for (ledIndex = 0; ledIndex < GCA230718_MAX_LEDS; ledIndex++)
+	{
+		data->leds[ledIndex].client = NULL;
+	}
+}
+
+static void gca230718_send_sequence(struct i2c_client *client, u8 byte0, struct gca230718_private* gca230718_privateData)
+{
+	int status = 0;
+	u8 ledIndex;
+	const u8 resetCommand[2] = { 0x81, 0xE4 };
+	const u8 resetCommandRegister = 0x00;
+
+	u8 controlCommand[13];
+	const u8 controlCommandRegister = 0x03;
+
+	controlCommand[0] = 0x0C; /* Unknown */
+	controlCommand[1] = byte0;
+	controlCommand[2] = GCA230718_OPMODE_NO_TOGGLE;
+	/* Byte 3-6 are set below to the brighness value of the individual LEDs */
+	controlCommand[7] = 0x01; /* Frequency, doesn't care as long as GCA230718_OPMODE_NO_TOGGLE is used above */
+	/* Byte 8-11 are set below to the brighness value of the individual LEDs */
+	controlCommand[12] = 0x87;
+
+	for (ledIndex = 0; ledIndex < GCA230718_MAX_LEDS; ledIndex++)
+	{
+		controlCommand[3 + ledIndex] = gca230718_privateData->leds[ledIndex].brightness;
+		controlCommand[8 + ledIndex] = gca230718_privateData->leds[ledIndex].brightness;
+	}
+
+	mutex_lock(&(gca230718_privateData->lock));
+
+	if ((status = i2c_smbus_write_i2c_block_data(client, resetCommandRegister, sizeof(resetCommand), resetCommand)) != 0)
+	{
+		pr_info("Error %i during call of i2c_smbus_write_i2c_block_data for reset command\n", status);
+	}
+	else if ((status = i2c_smbus_write_i2c_block_data(client, controlCommandRegister, sizeof(controlCommand), controlCommand)) != 0)
+	{
+		pr_info("Error %i during call of i2c_smbus_write_i2c_block_data for control command\n", status);
+	}
+
+	mutex_unlock(&(gca230718_privateData->lock));
+}
+
+static int gca230718_set_brightness(struct led_classdev *led_cdev, enum led_brightness value)
+{
+	struct gca230718_led* led;
+	struct i2c_client* client;
+
+	led = container_of(led_cdev, struct gca230718_led, ledClassDev);
+	client = led->client;
+
+	if (client != NULL)
+	{
+		struct gca230718_private* gca230718_privateData;
+
+		led->brightness = value;
+		gca230718_privateData = i2c_get_clientdata(client);
+
+		gca230718_send_sequence(client, GCA230718_2ND_SEQUENCE_BYTE_1, gca230718_privateData);
+	}
+
+	return 0;
+}
+
+static int gca230718_probe(struct i2c_client *client, const struct i2c_device_id *id)
+{
+	int status = 0;
+	struct gca230718_private* gca230718_privateData;
+
+	pr_info("Enter gca230718_probe for device address %u\n", client->addr);
+	gca230718_privateData = devm_kzalloc(&(client->dev), sizeof(struct gca230718_private), GFP_KERNEL);
+
+	if (gca230718_privateData == NULL)
+	{
+		pr_info("Error during allocating memory for private data\n");
+		status = -ENOMEM;
+	}
+	else
+	{
+		struct device_node* ledNode;
+		mutex_init(&gca230718_privateData->lock);
+		gca230718_init_private_led_data(gca230718_privateData);
+		i2c_set_clientdata(client, gca230718_privateData);
+
+		for_each_child_of_node(client->dev.of_node, ledNode)
+		{
+			u32 regValue = 0;
+			if (of_property_read_u32(ledNode, "reg", &regValue) != 0)
+			{
+				pr_info("Missing entry \"reg\" in node %s\n", ledNode->name); 
+			}
+			else if (regValue >= GCA230718_MAX_LEDS)
+			{
+				pr_info("Invalid entry \"reg\" in node %s (%u)\n", ledNode->name, regValue);
+			}
+			else
+			{
+				struct led_classdev* ledClassDev = &(gca230718_privateData->leds[regValue].ledClassDev);
+				struct led_init_data init_data = {};
+
+				gca230718_privateData->leds[regValue].client = client;
+				init_data.fwnode = of_fwnode_handle(ledNode);
+
+				pr_info("Creating LED for node %s: reg=%u\n", ledNode->name, regValue); 
+
+				ledClassDev->name = of_get_property(ledNode, "label", NULL);
+				if (ledClassDev->name == NULL)
+				{
+					ledClassDev->name = ledNode->name;
+				}
+
+				ledClassDev->brightness = LED_OFF;
+				ledClassDev->max_brightness = LED_FULL;
+				ledClassDev->brightness_set_blocking = gca230718_set_brightness;
+	
+				if (devm_led_classdev_register_ext(&(client->dev), ledClassDev, &init_data) != 0)
+				{
+					pr_info("Error during call of devm_led_classdev_register_ext");
+				}
+			}
+		}
+	}
+
+	if (status == 0)
+	{
+		/* 
+		Send full initialization sequence.
+		Afterwards only GCA230718_2ND_SEQUENCE_BYTE_1 must be send to upddate the brightness values.
+		*/
+		gca230718_send_sequence(client, GCA230718_1ST_SEQUENCE_BYTE_1, gca230718_privateData);
+		gca230718_send_sequence(client, GCA230718_2ND_SEQUENCE_BYTE_1, gca230718_privateData);
+		gca230718_send_sequence(client, GCA230718_3RD_SEQUENCE_BYTE_1, gca230718_privateData);
+	}
+
+	return status;
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,18,0)
+static void gca230718_remove(struct i2c_client *client)
+#else
+static int gca230718_remove(struct i2c_client *client)
+#endif
+{
+	struct gca230718_private* gca230718_privateData;
+	gca230718_privateData = i2c_get_clientdata(client);
+	mutex_destroy(&gca230718_privateData->lock);
+	gca230718_init_private_led_data(gca230718_privateData);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
+	return 0;
+#endif
+}
+
+static const struct i2c_device_id gca230718_i2c_ids[] = {
+	{ "gca230718", 0 },
+	{},
+};
+MODULE_DEVICE_TABLE(i2c, gca230718_i2c_ids);
+
+static const struct of_device_id gca230718_dt_ids[] = {
+	{ .compatible = "unknown,gca230718" },
+	{},
+};
+MODULE_DEVICE_TABLE(of, gca230718_dt_ids);
+
+static struct i2c_driver gca230718_driver = {
+	.probe		= gca230718_probe,
+	.remove		= gca230718_remove,
+	.id_table	= gca230718_i2c_ids,
+	.driver = {
+		.name		= KBUILD_MODNAME,
+		.of_match_table	= gca230718_dt_ids,
+	},
+};
+
+module_i2c_driver(gca230718_driver);
+
+MODULE_AUTHOR("Roland Reinl <reinlroland+github@gmail.com>");
+MODULE_DESCRIPTION("GCA230718 LED support (e.g. for D-Link M30) using I2C");
+MODULE_LICENSE("GPL");

--- a/target/linux/mediatek/dts/mt7981b-dlink-aquila-pro-ai-m30-a1.dts
+++ b/target/linux/mediatek/dts/mt7981b-dlink-aquila-pro-ai-m30-a1.dts
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "D-Link AQUILA PRO AI M30 A1";
+	compatible = "dlink,aquila-pro-ai-m30-a1", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_status_white;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_white;
+		led-upgrade = &led_status_blue;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		button-wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		button-leds-on-off {
+			label = "leds-on-off";
+			linux,code = <KEY_LIGHTS_TOGGLE>;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cells = <&macaddr_odm 1>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		label = "internet";
+
+		nvmem-cells = <&macaddr_odm 0>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan1";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan2";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan4";
+			};
+
+			port@6 {
+				reg = <6>;
+				label = "cpu";
+				ethernet = <&gmac0>;
+				phy-mode = "2500base-x";
+
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
+				};
+			};
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		compatible = "spi-nand";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x3200000>;
+			};
+
+			partition@3780000 {
+				label = "ubi1";
+				reg = <0x3780000 0x3200000>;
+				read-only;
+			};
+
+			partition@6980000 {
+				label = "Odm";
+				reg = <0x6980000 0x40000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_odm: macaddr@81 {
+						compatible = "mac-base";
+						reg = <0x81 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+				
+			};
+
+			partition@69c0000 {
+				label = "Config1";
+				reg = <0x69c0000 0x80000>;
+				read-only;
+			};
+
+			partition@6a40000 {
+				label = "Config2";
+				reg = <0x6a40000 0x80000>;
+				read-only;
+			};
+
+			partition@6ac0000 {
+				label = "Storage";
+				reg = <0x6ac0000 0xA00000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_00>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_00>;
+		};
+	};
+
+	i2c_pins_g0: i2c-pins-g0 {
+		mux {
+			function = "i2c";
+			groups = "i2c0_1";
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_odm 2>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&i2c0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c_pins_g0>;
+
+	gca230718@40 {
+		compatible = "unknown,gca230718";
+		reg = <0x40>;
+
+		led_status_red: led@0 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			reg = <0>;
+		};
+
+		led@1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			reg = <1>;
+		};
+
+		led_status_blue: led@2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			reg = <2>;
+		};
+
+		led_status_white: led@3 {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_STATUS;
+			reg = <3>;
+		};
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -51,6 +51,9 @@ mediatek_setup_interfaces()
 	comfast,cf-e393ax)
 		ucidef_set_interfaces_lan_wan "lan1" eth1
 		;;
+	dlink,aquila-pro-ai-m30-a1)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" internet
+		;;
 	glinet,gl-mt2500|\
 	glinet,gl-mt3000|\
 	glinet,gl-x3000|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -74,6 +74,10 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $addr 1) > /sys${DEVPATH}/macaddress
 		;;
+	dlink,aquila-pro-ai-m30-a1)
+		addr=$(mtd_get_mac_binary "Odm" 0x81)
+		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
+		;;
 	glinet,gl-mt6000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000)

--- a/target/linux/mediatek/filogic/base-files/etc/init.d/bootcount
+++ b/target/linux/mediatek/filogic/base-files/etc/init.d/bootcount
@@ -5,6 +5,13 @@ START=99
 
 boot() {
 	case $(board_name) in
+	dlink,aquila-pro-ai-m30-a1)
+		if grep -q bootpart=ubi0 /proc/cmdline; then
+			fw_setenv bootpart 0
+		else
+			fw_setenv bootpart 1
+		fi
+		;;
 	zyxel,ex5700-telenor)
 		fw_setenv uboot_bootcount 0
 		;;

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -491,6 +491,21 @@ define Device/cudy_wr3000-v1
 endef
 TARGET_DEVICES += cudy_wr3000-v1
 
+define Device/dlink_aquila-pro-ai-m30-a1
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := AQUILA PRO AI M30
+  DEVICE_VARIANT := A1
+  DEVICE_DTS := mt7981b-dlink-aquila-pro-ai-m30-a1
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-leds-gca230718 kmod-mt7981-firmware mt7981-wo-firmware
+  KERNEL_IN_UBI := 1
+  IMAGES += recovery.bin
+  IMAGE_SIZE := 51200k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/recovery.bin := sysupgrade-tar | pad-to $$(IMAGE_SIZE) | dlink-ai-recovery-header DLK6E6110001 \x6A\x28\xEE\x0B \x00\x00\x2C\x00 \x00\x00\x20\x03 \x61\x6E
+endef
+TARGET_DEVICES += dlink_aquila-pro-ai-m30-a1
+
 define Device/glinet_gl-mt2500
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-MT2500

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -52,33 +52,6 @@ define Build/uboot-fit
 	@mv $@.new $@
 endef
 
-# Append header to a D-Link M32/R32 Kernel 1 partition
-define Build/m32-r32-recovery-header-kernel1
-	$(eval header_start=$(word 1,$(1)))
-# create $@.header without the checksum
-	echo -en "$(header_start)\x00\x00" > "$@.header"
-# Calculate checksum over data area ($@) and append it to the header.
-# The checksum is the 2byte-sum over the whole data area.
-# Every overflow during the checksum calculation must increment the current checksum value by 1.
-	od -v -w2 -tu2 -An --endian little "$@" | awk '{ s+=$$1; } END { s%=65535; printf "%c%c",s%256,s/256; }' >> "$@.header"
-	echo -en "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x8D\x57\x30\x0B" >> "$@.header"
-# Byte 0-3: Erase Start 0x002C0000
-# Byte 4-7: Erase Length 0x02D00000
-# Byte 8-11: Data offset: 0x002C0000
-# Byte 12-15: Data Length: 0x02D00000
-	echo -en "\x00\x00\x2C\x00\x00\x00\xD0\x02\x00\x00\x2C\x00\x00\x00\xD0\x02" >> "$@.header"
-# Only zeros
-	echo -en "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" >> "$@.header"
-# Last 16 bytes, but without checksum
-	echo -en "\x42\x48\x02\x00\x00\x00\x08\x00\x00\x00\x00\x00\x60\x6E" >> "$@.header"
-# Calculate and append checksum: The checksum must be set so that the 2byte-sum of the whole header is 0.
-# Every overflow during the checksum calculation must increment the current checksum value by 1.
-	od -v -w2 -tu2 -An --endian little "$@.header" | awk '{s+=65535-$$1;}END{s%=65535;printf "%c%c",s%256,s/256;}' >> "$@.header"
-	cat "$@.header" "$@" > "$@.new"
-	mv "$@.new" "$@"
-	rm "$@.header"
-endef
-
 define Build/mt7622-gpt
 	cp $@ $@.tmp 2>/dev/null || true
 	ptgen -g -o $@.tmp -a 1 -l 1024 \
@@ -210,7 +183,7 @@ define Device/dlink_eagle-pro-ai-m32-a1
   $(Device/dlink_eagle-pro-ai-ax3200-a1)
   DEVICE_MODEL := EAGLE PRO AI M32
   DEVICE_DTS := mt7622-dlink-eagle-pro-ai-m32-a1
-  IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | pad-to $$(IMAGE_SIZE) | m32-r32-recovery-header-kernel1 DLK6E6010001
+  IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | pad-to $$(IMAGE_SIZE) | dlink-ai-recovery-header DLK6E6010001 \x8D\x57\x30\x0B \x00\x00\x2C\x00 \x00\x00\xD0\x02 \x60\x6E
 endef
 TARGET_DEVICES += dlink_eagle-pro-ai-m32-a1
 
@@ -218,7 +191,7 @@ define Device/dlink_eagle-pro-ai-r32-a1
   $(Device/dlink_eagle-pro-ai-ax3200-a1)
   DEVICE_MODEL := EAGLE PRO AI R32
   DEVICE_DTS := mt7622-dlink-eagle-pro-ai-r32-a1
-  IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | pad-to $$(IMAGE_SIZE) | m32-r32-recovery-header-kernel1 DLK6E6015001
+  IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | pad-to $$(IMAGE_SIZE) | dlink-ai-recovery-header DLK6E6015001 \x8D\x57\x30\x0B \x00\x00\x2C\x00 \x00\x00\xD0\x02 \x60\x6E
 endef
 TARGET_DEVICES += dlink_eagle-pro-ai-r32-a1
 


### PR DESCRIPTION
Specification:
 - MT7981 CPU using 2.4GHz and 5GHz WiFi (both AX)
 - MT7531 switch
 - 512MB RAM
 - 128MB NAND flash with two UBI partitions with identical size
 - 1 multi color LED (red, green, blue, white) connected via GCA230718
 - 3 buttons (WPS, reset, LED on/off)
 - 1 1Gbit WAN port
 - 4 1Gbit LAN ports

Disassembly:
 - There are four screws at the bottom: 2 under the rubber feets, 2 under the label.
 - After removing the screws, the white plastic part can be shifted out of the blue part.
 - Be careful because the antennas are mounted on the side and the top of the white part.

Serial Interface
 - The serial interface can be connected to the 4 pin holes on the side of the board.
 - Pins (from front to rear):
   - 3.3V
   - RX
   - TX
   - GND
 - Settings: 115200, 8N1

MAC addresses:
 - WAN MAC is stored in partition "Odm" at offset 0x81
 - LAN (as printed on the device) is WAN MAC + 1
 - WLAN MAC (2.4 GHz) is WAN MAC + 2
 - WLAN MAC (5GHz) is WAN MAC + 3

Flashing via Recovery Web Interface:
 - The recovery web interface always flashes to the currently active partition.
 - If OpenWrt is flahsed to the second partition, it will not boot.
 - Ensure that you have an OEM image available (encrypted and decrypted version). Decryption is described in the end.
 - Set your IP address to 192.168.200.10, subnetmask 255.255.255.0
 - Press the reset button while powering on the device
 - Keep the reset button pressed until the LED blinks red
 - Open a Chromium based and goto http://192.168.200.1/ (recovery web interface)
 - Download openwrt-mediatek-filogic-dlink_aquila-pro-ai-m30-a1-squashfs-recovery.bin
 - The recovery web interface always reports successful flashing, even if it fails
 - After flashing, the recovery web interface will try to forward the browser to 192.168.0.1 (can be ignored)
 - If OpenWrt was flashed to the first partition, OpenWrt will boot (The status LED will start blinking white and stay white in the end). In this case you're done and can use OpenWrt.
 - If OpenWrt was flashed to the second partition, OpenWrt won't boot (The status LED will stay red forever). In this case, the following steps are reuqired:
   - Start the web recovery interface again and flash the **decrypted OEM image**. This will be flashed to the second partition as well. The OEM firmware web interface is afterwards accessible via http://192.168.200.1/.
   - Now flash the **encrypted OEM image** via OEM firmware web interface. In this case, the new firmware is flashed to the first partition. After flashing and the following reboot, the OEM firmware web interface should still be accessible via http://192.168.200.1/.
   - Start the web recovery interface again and flash the OpenWrt recovery image. Now it will be flashed to the first partition, OpenWrt will boot correctly afterwards and is accessible via 192.168.1.1.

Flashing via U-Boot:
 - Open the case, connect to the UART console
 - Set your IP address to 192.168.200.2, subnet mask 255.255.255.0. Connect to one of the LAN interfaces of the router
 - Run a tftp server which provides openwrt-mediatek-filogic-dlink_aquila-pro-ai-m30-a1-initramfs-kernel.bin.
 - Power on the device and select "7. Load image" in the U-Boot menu
 - Enter image file, tftp server IP and device IP (if they differ from the default).
 - TFTP download to RAM will start. After a few seconds OpenWrt initramfs should start
 - The initramfs is accessible via 192.168.1.1, change your IP address accordingly (or use multiple IP addresses on your interface)
 - Perform a sysupgrade using openwrt-mediatek-filogic-dlink_aquila-pro-ai-m30-a1-squashfs-sysupgrade.bin
 - Reboot the device. OpenWrt should start from flash now

Revert back to stock using the Recovery Web Interface:
 - Set your IP address to 192.168.200.2, subnetmask 255.255.255.0
 - Press the reset button while powering on the device
 - Keep the reset button pressed until the LED blinks red
 - Open a Chromium based and goto http://192.168.200.1 (recovery web interface)
 - Flash a decrypted firmware image from D-Link. Decrypting an firmware image is described below.

Decrypting a D-Link firmware image:
 - Download https://github.com/RolandoMagico/firmware-utils/blob/M32/src/m32-firmware-util.c
 - Compile a binary from the downloaded file, e.g. gcc m32-firmware-util.c -lcrypto -o m32-firmware-util
 - Run ./m32-firmware-util M30 --DecryptFactoryImage <OriginalFirmware> <OutputFile>
 - Example for firmware M30A1_FW101B05: ./m32-firmware-util M30 --DecryptFactoryImage M30A1_FW101B05\(0725091522\).bin M30A1_FW101B05\(0725091522\)_decrypted.bin

Flashing via OEM web interface is not possible, as it will change the active partition and OpenWrt is only running on the first UBI partition.

Controlling the LEDs:
 - The LEDs are controlled by a chip called "GCA230718" which is connected to the main CPU via I2C (address 0x40)
 - I didn't find any documentation or driver for it, so the information below is purely based on my investigations
 - If there is already I driver for it, please tell me. Maybe I didn't search enough
 - I implemented a kernel module (leds-gca230718) to access the LEDs via DTS
 - The LED controller supports PWM for brightness control and ramp control for smooth blinking. This is not implemented in the driver
 - The LED controller supports toggling (on -> off -> on -> off) where the brightness of the LEDs can be set individually for each on cycle
 - Until now, only simple active/inactive control is implemented (like when the LEDs would have been connected via GPIO)
 - Controlling the LEDs requires three sequences sent to the chip. Each sequence consists of
   - A reset command (0x81 0xE4) written to register 0x00
   - A control command (for example 0x0C 0x02 0x01 0x00 0x00 0x00 0xFF 0x01 0x00 0x00 0x00 0xFF 0x87 written to register 0x03)
 - The reset command is always the same
 - In the control command
   - byte 0 is always the same
   - byte 1 (0x02 in the example above) must be changed in every sequence: 0x02 -> 0x01 -> 0x03)
   - byte 2 is set to 0x01 which disables toggling. 0x02 would be LED toggling without ramp control, 0x03 would be toggling with ramp control
   - byte 3 to 6 define the brightness values for the LEDs (R,G,B,W) for the first on cycle when toggling
   - byte 7 defines the toggling frequency (if toggling enabled)
   - byte 8 to 11 define the brightness values for the LEDs (R,G,B,W) for the second on cycle when toggling
   - byte 12 is constant 0x87

Comparison to M32/R32:
 - The algorithms for decrypting the OEM firmware are the same for M30/M32/R32, only the keys differ
 - The keys are available in the GPL sources for the M32
 - The M32/R32 contained raw data in the firmware images (kernel, rootfs), the R30 uses a sysupgrade tar instead
 - Creation of the recovery image is quite similar, only the header start string changes. So mostly takeover from M32/R32 for that.
 - Turned out that the bytes at offset 0x0E and 0x0F in the recovery image header are the checksum over the data area
 - This checksum was not checked in the recovery web interface of M32/R32 devices, but is now active in R30
 - I adapted the recovery image creation to also calculate the checksum over the data area
 - The recovery image header for M30 contains addresses which don't match the memory layout in the DTS. The same addresses are also present in the OEM images
 - The recovery web interface either calculates the correct addresses from it or has it's own logic to determine where which information must be written
