### PR TITLE
ramips: Unielec u7621-01: remove invalid led status

### DIFF
--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01.dtsi
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01.dtsi
@@ -8,13 +8,6 @@
 / {
 	compatible = "unielec,u7621-01", "mediatek,mt7621-soc";
 
-	aliases {
-		led-boot = &led_status;
-		led-failsafe = &led_status;
-		led-running = &led_status;
-		led-upgrade = &led_status;
-	};
-
 	gpio-export {
 		compatible = "gpio-export";
 		#size-cells = <0>;
@@ -33,15 +26,6 @@
 			label = "reset";
 			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led_status: status {
-			label = "green:status";
-			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
 		};
 	};
 };


### PR DESCRIPTION
The original commit had an invalid setting of the led status for this device.

There is no gpio pin connected to that led so lets remove these from the u7621-01 dtsi file.