### PR TITLE
realtek: rtl838x: add support for Netgear GS110TUP

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -91,6 +91,9 @@ hpe,1920-8g-poe-180w)
 netgear,gs110tpp-v1)
 	ucidef_set_poe 130 "$lan_list" "lan9 lan10"
 	;;
+netgear,gs110tup-v1)
+	ucidef_set_poe 240 "$lan_list" "lan9 lan10"
+	;;
 netgear,gs310tp-v1)
 	ucidef_set_poe 55 "$lan_list" "lan9 lan10"
 	;;

--- a/target/linux/realtek/dts-5.15/rtl8380_netgear_gigabit_1xx_ngg.dtsi
+++ b/target/linux/realtek/dts-5.15/rtl8380_netgear_gigabit_1xx_ngg.dtsi
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_netgear_gigabit.dtsi"
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x00e0000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0x00e0000 0x0010000>;
+			};
+
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0x00f0000 0x0010000>;
+			};
+
+			partition@100000 {
+				label = "jffs";
+				reg = <0x0100000 0x0100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x0200000 0x0100000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "firmware";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x4e474720>;
+				reg = <0x0300000 0x0e80000>;
+			};
+
+			partition@1180000 {
+				label = "runtime2";
+				reg = <0x1180000 0x0e80000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/dts-5.15/rtl8380_netgear_gs110tup-v1.dts
+++ b/target/linux/realtek/dts-5.15/rtl8380_netgear_gs110tup-v1.dts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_netgear_gigabit_1xx_ngg.dtsi"
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "netgear,gs110tup-v1", "realtek,rtl838x-soc";
+	model = "Netgear GS110TUP v1";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: led-0 {
+			label = "red:status";
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio1 31 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-1 {
+			label = "green:status";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio1 32 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-2 {
+			label = "blue:status";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio1 34 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&mdio {
+	EXTERNAL_PHY(16)
+	EXTERNAL_PHY(24)
+};
+
+&switch0 {
+	ports {
+		SWITCH_PORT(16, 9, qsgmii)
+		SWITCH_SFP_PORT(24, 10, rgmii-id)
+	};
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -171,6 +171,24 @@ define Device/netgear_nge
   DEVICE_VENDOR := NETGEAR
 endef
 
+# "NGG" refers to the uImage magic
+define Device/netgear_ngg
+  KERNEL := \
+	kernel-bin | \
+	append-dtb | \
+	lzma | \
+	uImage lzma
+  KERNEL_INITRAMFS := \
+	kernel-bin | \
+	append-dtb | \
+	lzma | \
+	uImage lzma
+  SOC := rtl8380
+  IMAGE_SIZE := 14848k
+  UIMAGE_MAGIC := 0x4e474720
+  DEVICE_VENDOR := NETGEAR
+endef
+
 define Device/netgear_gs108t-v3
   $(Device/netgear_nge)
   DEVICE_MODEL := GS108T
@@ -185,6 +203,14 @@ define Device/netgear_gs110tpp-v1
   DEVICE_PACKAGES += realtek-poe
 endef
 TARGET_DEVICES += netgear_gs110tpp-v1
+
+define Device/netgear_gs110tup-v1
+  $(Device/netgear_ngg)
+  DEVICE_MODEL := GS110TUP
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES += realtek-poe
+endef
+TARGET_DEVICES += netgear_gs110tup-v1
 
 define Device/netgear_gs308t-v1
   $(Device/netgear_nge)


### PR DESCRIPTION
The GS110TUP is a managed switch similar to the GS110TPP, but with port 10 as SFP instead of RJ-45 and a total budget of 240 watts. Ports 1-4 support 60-watt 802.3bt PoE and ports 5-8 support 30-watt 802.3at.

The Flash layout of the two switches are identical, and the U-Boot configurations are the same except for having a different magic number, so installation can be done via the same U-Boot method.

The following command will be needed to enable the port LEDs as per https://forum.openwrt.org/t/netgear-gs108tv3-gs110tpv3-gs110tpp-switch-support/72510/51 :
    fw_setenv bootcmd "rtk network on; boota"

Additionally, port 9 (1000base-T from a separate QSGMII PHY) does not function without this. I do not have an SFP module on hand so I haven't been able to test port 10.