### PR TITLE
ramips: dts: unielec-u7621-01:add missing address/size cells

### DIFF
--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
@@ -15,6 +15,9 @@
 		reg = <0>;
 		spi-max-frequency = <14000000>;
 
+		#address-cells = <1>;
+		#size-cells = <1>;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;


### PR DESCRIPTION
Fixes the following warnings:

```
[ 2.126546] spi-nor spi0.0: mx25l12805d (16384 Kbytes)
[ 2.136953] 4 fixed-partitions partitions found on MTD device spi0.0
[ 2.149672] OF: Bad cell count for /palmbus@1e000000/spi@b00/flash@0/partitions
[ 2.164283] OF: Bad cell count for /palmbus@1e000000/spi@b00/flash@0/partitions
[ 2.179493] OF: Bad cell count for /palmbus@1e000000/spi@b00/flash@0/partitions
[ 2.194184] OF: Bad cell count for /palmbus@1e000000/spi@b00/flash@0/partitions
```
