### PR TITLE
ath79: Fix recognized RAM size for TP-Link Archer C6 V2 (US) and convert to nvmem layout

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_archer-c6-v2-us.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c6-v2-us.dts
@@ -6,6 +6,11 @@
 	compatible = "tplink,archer-c6-v2-us", "qca,qca9563";
 	model = "TP-Link Archer C6 v2 (US) / A6 v2 (US/TW)";
 
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x08000000>;
+	};
+
 	aliases {
 		label-mac-device = &eth0;
 

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c6-v2-us.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c6-v2-us.dts
@@ -134,10 +134,20 @@
 				read-only;
 			};
 
-			art: partition@ff0000 {
+			partition@ff0000 {
 				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+				};
 			};
 		};
 	};
@@ -149,8 +159,6 @@
 };
 
 &wmac {
-	mtd-cal-data = <&art 0x1000>;
-
-	nvmem-cells = <&macaddr_info_8>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_info_8>, <&calibration_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
 };


### PR DESCRIPTION
This commit fixes a bug that RAM size autodetection not working properly, by cutting half of total memory size, setting statically RAM size in dts file.

Run-tested on my TP-Link Archer C6 V2 (US).
