### PR TITLE
kernel: ledtrig-netdev: fix link status check

### DIFF
--- a/target/linux/generic/hack-5.10/801-ledtrig-netdev-only-init-namespace.patch
+++ b/target/linux/generic/hack-5.10/801-ledtrig-netdev-only-init-namespace.patch
@@ -1,0 +1,38 @@
+From 62c679f6b4ca68841a446339ea80ae0e431947e6 Mon Sep 17 00:00:00 2001
+From: Liangbin Lian <jjm2473@gmail.com>
+Date: Tue, 26 Dec 2023 14:08:01 +0800
+Subject: [PATCH] ledtrig-netdev: we only care about new device in init
+ namespace
+
+Signed-off-by: Liangbin Lian <jjm2473@gmail.com>
+---
+ drivers/leds/trigger/ledtrig-netdev.c | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+--- a/drivers/leds/trigger/ledtrig-netdev.c
++++ b/drivers/leds/trigger/ledtrig-netdev.c
+@@ -307,8 +307,9 @@ static int netdev_trig_notify(struct not
+ 		return NOTIFY_DONE;
+ 
+ 	if (!(dev == trigger_data->net_dev ||
+-	      (evt == NETDEV_CHANGENAME && !strcmp(dev->name, trigger_data->device_name)) ||
+-	      (evt == NETDEV_REGISTER && !strcmp(dev->name, trigger_data->device_name))))
++		((evt == NETDEV_CHANGENAME || evt == NETDEV_REGISTER)
++			&& net_eq(dev_net(dev), &init_net)
++			&& !strcmp(dev->name, trigger_data->device_name))))
+ 		return NOTIFY_DONE;
+ 
+ 	cancel_delayed_work_sync(&trigger_data->work);
+@@ -328,8 +329,10 @@ static int netdev_trig_notify(struct not
+ 		trigger_data->net_dev = dev;
+ 		break;
+ 	case NETDEV_UNREGISTER:
+-		dev_put(trigger_data->net_dev);
+-		trigger_data->net_dev = NULL;
++		if (dev->reg_state >= NETREG_UNREGISTERING) {
++			dev_put(trigger_data->net_dev);
++			trigger_data->net_dev = NULL;
++		}
+ 		break;
+ 	case NETDEV_UP:
+ 	case NETDEV_CHANGE:

--- a/target/linux/generic/hack-5.10/802-ledtrig-netdev-fix-carrier-status-check.patch
+++ b/target/linux/generic/hack-5.10/802-ledtrig-netdev-fix-carrier-status-check.patch
@@ -1,0 +1,24 @@
+From b09e2f05ea1d740403397a55dd8e59ad637554e5 Mon Sep 17 00:00:00 2001
+From: Liangbin Lian <jjm2473@gmail.com>
+Date: Tue, 26 Dec 2023 17:10:08 +0800
+Subject: [PATCH] ledtrig-netdev: fix carrier status check
+
+Referring to carrier_show in net/core/net-sysfs.c,
+we can see that netif_carrier_ok is only meaningful on netif_running.
+
+Signed-off-by: Liangbin Lian <jjm2473@gmail.com>
+---
+ drivers/leds/trigger/ledtrig-netdev.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/leds/trigger/ledtrig-netdev.c
++++ b/drivers/leds/trigger/ledtrig-netdev.c
+@@ -133,7 +133,7 @@ static ssize_t device_name_store(struct
+ 
+ 	clear_bit(NETDEV_LED_MODE_LINKUP, &trigger_data->mode);
+ 	if (trigger_data->net_dev != NULL)
+-		if (netif_carrier_ok(trigger_data->net_dev))
++		if (netif_running(trigger_data->net_dev) && netif_carrier_ok(trigger_data->net_dev))
+ 			set_bit(NETDEV_LED_MODE_LINKUP, &trigger_data->mode);
+ 
+ 	trigger_data->last_activity = 0;


### PR DESCRIPTION
Patch 1:
The eth0 in the Docker container affects the led status, but I don't think anyone cares about the eth0 status of the Docker container, and currently ledtrig-netdev does not support net namespace.

So filter out all non-init namespace new device events.

Patch 2:
Referring to carrier_show in net/core/net-sysfs.c,
we can see that netif_carrier_ok is only meaningful on netif_running.

fix wrong carrier status on some net drivers.

Tested on RK3588.

Signed-off-by: Liangbin Lian <jjm2473@gmail.com>