### PR TITLE
kernel/fixes to ksmbd builds under 5.15.145

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -359,8 +359,7 @@ define KernelPackage/fs-ksmbd
   DEPENDS:= \
 	  +kmod-nls-base \
 	  +kmod-nls-utf8 \
-	  +kmod-crypto-md4 \
-          +kmod-crypto-md5 \
+	  +kmod-crypto-md5 \
 	  +kmod-crypto-hmac \
 	  +kmod-crypto-ecb \
 	  +kmod-crypto-des \

--- a/target/linux/generic/hack-5.15/940-ksmbd-have-a-dependency-on-cifs-arc4.patch
+++ b/target/linux/generic/hack-5.15/940-ksmbd-have-a-dependency-on-cifs-arc4.patch
@@ -1,0 +1,31 @@
+From: Namjae Jeon <linkinjeon@kernel.org>
+To: sashal@kernel.org, gregkh@linuxfoundation.org, stable@vger.kernel.org
+Cc: smfrench@gmail.com, Namjae Jeon <linkinjeon@kernel.org>
+Subject: [PATCH v2 5.15.y 1/8] ksmbd: have a dependency on cifs ARC4
+Date: Wed, 27 Dec 2023 19:25:58 +0900	[thread overview]
+Message-ID: <20231227102605.4766-2-linkinjeon@kernel.org> (raw)
+In-Reply-To: <20231227102605.4766-1-linkinjeon@kernel.org>
+
+Omitted the change that has a dependency on cifs ARC4 from backporting
+commit f9929ef6a2a5("ksmbd: add support for key exchange").
+This patch make ksmbd have a dependeny on cifs ARC4.
+
+Fixes: c5049d2d73b2 ("ksmbd: add support for key exchange")
+Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>
+---
+ fs/Kconfig | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/fs/Kconfig
++++ b/fs/Kconfig
+@@ -369,8 +369,8 @@ source "fs/ksmbd/Kconfig"
+ 
+ config SMBFS_COMMON
+ 	tristate
+-	default y if CIFS=y
+-	default m if CIFS=m
++	default y if CIFS=y || SMB_SERVER=y
++	default m if CIFS=m || SMB_SERVER=m
+ 
+ source "fs/coda/Kconfig"
+ source "fs/afs/Kconfig"


### PR DESCRIPTION
These two commits are related to fixes to the 5.15.145 bump, specifically ksmbd changes.  Appropriate to keep them as two commits?  @DragonBluep @namjaejeon were original authors. See comments [here](https://github.com/openwrt/openwrt/commit/8de4cc77a6d5c25e48566d0203f159287ac7f3fe).