### PR TITLE
wolfssl: update to 5.6.6

### DIFF
--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wolfssl
-PKG_VERSION:=5.6.4-stable
+PKG_VERSION:=5.6.6-stable
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/wolfSSL/wolfssl/archive/v$(PKG_VERSION)
-PKG_HASH:=031691906794ff45e1e792561cf31759f5d29ac74936bc8dffb8b14f16d820b4
+PKG_HASH:=3d2ca672d41c2c2fa667885a80d6fa03c3e91f0f4f72f87aef2bc947e8c87237
 
 PKG_FIXUP:=libtool libtool-abiver
 PKG_INSTALL:=1

--- a/package/libs/wolfssl/patches/100-disable-hardening-check.patch
+++ b/package/libs/wolfssl/patches/100-disable-hardening-check.patch
@@ -1,6 +1,6 @@
 --- a/wolfssl/wolfcrypt/settings.h
 +++ b/wolfssl/wolfcrypt/settings.h
-@@ -2630,7 +2630,7 @@ extern void uITRON4_free(void *p) ;
+@@ -2774,7 +2774,7 @@ extern void uITRON4_free(void *p) ;
  
  /* warning for not using harden build options (default with ./configure) */
  /* do not warn if big integer support is disabled */


### PR DESCRIPTION
Release Notes:
https://github.com/wolfSSL/wolfssl/releases/tag/v5.6.6-stable

Refresh patches:
- 100-disable-hardening-check.patch
