### PR TITLE
ipq807x: prpl-haze: enable LED driver on device tree

### DIFF
--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -261,3 +261,37 @@ define KernelPackage/input-leds/description
 endef
 
 $(eval $(call KernelPackage,input-leds))
+
+
+define KernelPackage/leds-lp55xx-common
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=LED common driver for LP5521/LP5523/LP55231/LP5562 controllers
+  DEPENDS:=+kmod-i2c-core
+  KCONFIG:=CONFIG_LEDS_LP55XX_COMMON
+  FILES:=$(LINUX_DIR)/drivers/leds/leds-lp55xx-common.ko
+  AUTOLOAD:=$(call AutoLoad,60,leds-lp55xx-common,1)
+endef
+
+define KernelPackage/leds-lp55xx-common/description
+ This option enables support for Texas Instruments
+ LP5521/LP5523/LP55231/LP5562 common driver.
+endef
+
+$(eval $(call KernelPackage,leds-lp55xx-common))
+
+
+define KernelPackage/leds-lp5562
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=LED driver for LP5562 controllers
+  DEPENDS:=+kmod-i2c-core +kmod-leds-lp55xx-common
+  KCONFIG:=CONFIG_LEDS_LP5562
+  FILES:=$(LINUX_DIR)/drivers/leds/leds-lp5562.ko
+  AUTOLOAD:=$(call AutoLoad,60,leds-lp5562,1)
+endef
+
+define KernelPackage/leds-lp5562/description
+ This option enables support for Texas Instruments LP5562
+ LED controllers.
+endef
+
+$(eval $(call KernelPackage,leds-lp5562))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
@@ -21,6 +21,10 @@
 		ethernet2 = &dp3;
 		ethernet3 = &dp2;
 		label-mac-device = &dp6_syn;
+		led-boot = &led_system_blue;
+		led-failsafe = &led_system_red;
+		led-running = &led_system_green;
+		led-upgrade = &led_system_blue;
 	};
 
 	chosen {
@@ -77,6 +81,13 @@
 			drive-strength = <8>;
 			bias-pull-up;
 		};
+	};
+
+	i2c_3_pins: i2c-3-state {
+		pins = "gpio46", "gpio47";
+		function = "blsp2_i2c";
+		drive-strength = <8>;
+		bias-disable;
 	};
 };
 
@@ -302,4 +313,42 @@
 	status = "okay";
 
 	qcom,ath11k-calibration-variant = "prpl-Haze";
+};
+
+&blsp1_i2c3{
+	pinctrl-0 = <&i2c_3_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	led-controller@30 {
+		compatible = "ti,lp5562";
+		reg = <0x30>;
+		clock-mode = /bits/ 8 <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		led_system_red: chan@0 {
+			chan-name = "red";
+			led-cur = /bits/ 8 <0x20>;
+			max-cur = /bits/ 8 <0x60>;
+			color = <LED_COLOR_ID_RED>;
+			reg = <0>;
+		};
+
+		led_system_green: chan@1 {
+			chan-name = "green";
+			led-cur = /bits/ 8 <0x20>;
+			max-cur = /bits/ 8 <0x60>;
+			color = <LED_COLOR_ID_GREEN>;
+			reg = <1>;
+		};
+
+		led_system_blue: chan@2 {
+			chan-name = "blue";
+			led-cur = /bits/ 8 <0x20>;
+			max-cur = /bits/ 8 <0x60>;
+			color = <LED_COLOR_ID_BLUE>;
+			reg = <2>;
+		};
+	};
 };

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -220,7 +220,7 @@ define Device/prpl_haze
 	DEVICE_DTS_CONFIG := config@hk09
 	SOC := ipq8072
 	DEVICE_PACKAGES += ath11k-firmware-qcn9074 ipq-wifi-prpl_haze kmod-ath11k-pci \
-		mkf2fs f2fsck kmod-fs-f2fs
+		mkf2fs f2fsck kmod-fs-f2fs kmod-leds-lp5562
 endef
 TARGET_DEVICES += prpl_haze
 


### PR DESCRIPTION
Enable prpl-haze LED driver LP5562 on device tree.

You also need to set:
CONFIG_LEDS_LP5562=y
CONFIG_LEDS_LP55XX_COMMON=y
in kernel config

Signed-off-by: CheWei Chien <chewei.chien@wnc.com.tw>