### PR TITLE
mediatek: add NMBM layout for H3C Magic NX30 Pro

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -58,6 +58,7 @@ cmcc,rax3000m)
 	esac
 	;;
 cetron,ct3003|\
+h3c,magic-nx30-pro-nmbm|\
 netgear,wax220|\
 zbtlink,zbt-z8102ax|\
 zbtlink,zbt-z8103ax)

--- a/target/linux/mediatek/dts/mt7981b-h3c-magic-nx30-pro-nmbm.dts
+++ b/target/linux/mediatek/dts/mt7981b-h3c-magic-nx30-pro-nmbm.dts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include "mt7981b-h3c-magic-nx30-pro.dts"
+
+/ {
+	model = "H3C Magic NX30 Pro (NMBM layout)";
+	compatible = "h3c,magic-nx30-pro-nmbm", "mediatek,mt7981";
+};
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+
+	spi-cal-enable;
+	spi-cal-mode = "read-data";
+	spi-cal-datalen = <7>;
+	spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
+	spi-cal-addrlen = <5>;
+	spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+};

--- a/target/linux/mediatek/dts/mt7981b-h3c-magic-nx30-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-h3c-magic-nx30-pro.dts
@@ -97,7 +97,7 @@
 	pinctrl-0 = <&spi0_flash_pins>;
 	status = "okay";
 
-	spi_nand@0 {
+	spi_nand: spi_nand@0 {
 		compatible = "spi-nand";
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -36,6 +36,7 @@ mediatek_setup_interfaces()
 		;;
 	cmcc,rax3000m|\
 	h3c,magic-nx30-pro|\
+	h3c,magic-nx30-pro-nmbm|\
 	zbtlink,zbt-z8103ax)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" eth1
 		;;
@@ -132,7 +133,8 @@ mediatek_setup_macs()
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add "$label_mac" 2)
 		;;
-	h3c,magic-nx30-pro)
+	h3c,magic-nx30-pro|\
+	h3c,magic-nx30-pro-nmbm)
 		wan_mac=$(mtd_get_mac_ascii pdt_data_1 ethaddr)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		label_mac=$wan_mac

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -70,7 +70,8 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
 		;;
-	h3c,magic-nx30-pro)
+	h3c,magic-nx30-pro|\
+	h3c,magic-nx30-pro-nmbm)
 		addr=$(mtd_get_mac_ascii pdt_data_1 ethaddr)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -426,6 +426,23 @@ define Device/h3c_magic-nx30-pro
 endef
 TARGET_DEVICES += h3c_magic-nx30-pro
 
+define Device/h3c_magic-nx30-pro-nmbm
+  DEVICE_VENDOR := H3C
+  DEVICE_MODEL := Magic NX30 Pro (NMBM layout)
+  DEVICE_DTS := mt7981b-h3c-magic-nx30-pro-nmbm
+  DEVICE_DTS_DIR := ../dts
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+  IMAGE_SIZE := 65536k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7981-firmware mt7981-wo-firmware
+endef
+TARGET_DEVICES += h3c_magic-nx30-pro-nmbm
+
 define Device/jcg_q30-pro
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := Q30 PRO


### PR DESCRIPTION
Add support for MediaTek NMBM on H3C NX30 Pro to simplify flashing.

The layout is same as the stock layout. Providing the layout will improve compatibility with the stock firmware, uboot and BL2.

As we all know, NMBM replaces writing to bad blocks transparently. So when we encounter the following situation:

1. NMBM is already enabled.
2. And there is any bad block in the range of blocks to be flashed.
3. The firmware (and FIP, BL2) to be flashed will disable NMBM.
 
then what the old firmware will have written (in the location of bad blocks) will not be what the new firmware will read. The new firmware will only find these block are bad blocks and the useful data are actually in the NMBM reserved area. Vice versa, when flashing from the NMBM disabled one to the enabled one, if the second condition met, there will be the same risk.

Therefore, even if one successfully matched the type of uboot, BL2 and firmware, switching between the two types without ensuring there is no bad blocks in that range is dangerous and may cause serious data loss and even bricking.

To flash the firmware, connect to the SSH/telnet of the router.
If there is sysupgrade, just use it to flash the sysupgrade image.
Otherwise execute the following command:

`ubiformat /dev/mtd4 -f openwrt-mediatek-filogic-h3c_magic-nx30-pro-nmbm-squashfs-factory.bin`

(Do not flash the BL2 partition, keep the stock BL2 unchanged to ensure NMBM is supported.)

If someone want easy flash and don't mind using third-party uboot, it is also possible to use the uboot provided in
https://github.com/hanwckf/bl-mt798x.

The same layout has been provided by
https://github.com/immortalwrt/immortalwrt for months and no one
complained about storage corruption.