### PR TITLE
ramips: add support for Xiaomi R4AC v2 (intl)

### DIFF
--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m-intl-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m-intl-v2.dts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/leds/common.h>
+
+#include "mt7628an_xiaomi_mi-router-4.dtsi"
+
+/ {
+	compatible = "xiaomi,mi-router-4a-100m-intl-v2", "mediatek,mt7628an-soc";
+	model = "Xiaomi Mi Router 4A (100M International Edition V2)";
+
+	aliases {
+		led-boot = &led_power_yellow;
+		led-failsafe = &led_power_yellow;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_yellow;
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_blue: power_blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_yellow: power_yellow {
+			color = <LED_COLOR_ID_YELLOW>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+};
+
+&partitions {
+	partition@60000 {
+		label = "overlay";
+		reg = <0x60000 0x100000>;
+		read-only;
+	};
+
+	partition@160000 {
+		label = "firmware";
+		reg = <0x160000 0xea0000>;
+		compatible = "denx,uimage";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&eeprom_factory_8000 {
+	/* MT7613 has different eeprom size '0x4da8'			*/
+	/* See https://github.com/openwrt/openwrt/pull/13587		*/
+	/* You can also see this in mt76/mt7615/eeprom.h:		*/
+	/* MT7615_EEPROM_FULL_SIZE = MT7615_EEPROM_TXDPD_OFFSET + \	*/
+	/*       MT7615_EEPROM_TXDPD_COUNT * MT7615_EEPROM_TXDPD_SIZE	*/
+	/* where MT7615_EEPROM_TXDPD_OFFSET is 1024 + 256 * 34 = 9728:	*/
+	/*   MT7615_EEPROM_SIZE(1024 defined in mt7615.h) + \		*/
+	/*   MT7615_EEPROM_DCOC_COUNT(34) * MT7615_EEPROM_DCOC_SIZE(256)*/
+	/* where MT7615_EEPROM_TXDPD_COUNT = 44 + 3 = 47		*/
+	/* and MT7615_EEPROM_TXDPD_SIZE = 216.				*/
+	/* Altogether it will be 19880 or 0x4da8.			*/
+	reg = <0x8000 0x4da8>;
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4 (-1)>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+	mediatek,portdisable = <0x2a>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -1092,6 +1092,15 @@ define Device/xiaomi_mi-router-4a-100m-intl
 endef
 TARGET_DEVICES += xiaomi_mi-router-4a-100m-intl
 
+define Device/xiaomi_mi-router-4a-100m-intl-v2
+  IMAGE_SIZE := 14976k
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := Mi Router 4A
+  DEVICE_VARIANT := 100M International Edition V2
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap
+endef
+TARGET_DEVICES += xiaomi_mi-router-4a-100m-intl-v2
+
 define Device/xiaomi_mi-router-4c
   IMAGE_SIZE := 14976k
   DEVICE_VENDOR := Xiaomi

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -171,7 +171,8 @@ wavlink,wl-wn578a2)
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
 xiaomi,mi-router-4a-100m|\
-xiaomi,mi-router-4a-100m-intl)
+xiaomi,mi-router-4a-100m-intl|\
+xiaomi,mi-router-4a-100m-intl-v2)
 	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x01"
 	;;
 xiaomi,mi-router-4c)

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -186,7 +186,8 @@ ramips_setup_interfaces()
 			"0:wan" "3:lan" "4:lan" "6@eth0"
 		;;
 	xiaomi,mi-router-4a-100m|\
-	xiaomi,mi-router-4a-100m-intl)
+	xiaomi,mi-router-4a-100m-intl|\
+	xiaomi,mi-router-4a-100m-intl-v2)
 		ucidef_add_switch "switch0" \
 			"4:lan:1" "2:lan:2" "0:wan" "6@eth0"
 		;;
@@ -323,6 +324,7 @@ ramips_setup_macs()
 		;;
 	xiaomi,mi-router-4a-100m|\
 	xiaomi,mi-router-4a-100m-intl|\
+	xiaomi,mi-router-4a-100m-intl-v2|\
 	xiaomi,mi-router-4c)
 		wan_mac=$(mtd_get_mac_binary factory 0x4)
 		;;


### PR DESCRIPTION
The second edition of international version of Mi Router 4A 100M is very similar to the non-international one, but has another wireless chip.

 Installation
--------------

1. Initialize build-in firmware (use webgui for 192.168.31.1)
  You should install root password

2. Run OpenWRTInvasion for the first time (probably it will fail)
  Version 0.0.10 is working as well as 0.0.1.

3. Run OpenWRTInvasion for the second time
  It will create an access to your router

4. Upload sysupgrade image to router (/tmp/fw.bin)
  `pc# nc -l 8080 < …/ramips/mt76x8/…-100m-intl-v2-squashfs-sysupgrade.bin` 
  `router# nc 192.168.31.175 8080 > /tmp/fw.bin`

5. Flash new firmware 
  `router# mtd -r write /tmp/fw.bin OS1`

6. Check result Wait about 5-10 minutes after flash.
  Router should reboot itself and turn left led from orange to blue.

In case of failure one can use Xiaomi 4a 100m debrick tool (it uploads special image via tftpd in recovery mode) After that you can start again from step 1.

Another actions are very similar to original Mi Router 4A 100M

 Original mtd paritions:
-------------------------

```
Creating 9 MTD partitions on "raspi":
0x000000000000-0x000001000000 : "ALL"
0x000000000000-0x000000020000 : "Bootloader"
0x000000020000-0x000000030000 : "Config"
0x000000030000-0x000000040000 : "Factory"
0x000000040000-0x000000050000 : "crash"
0x000000050000-0x000000060000 : "cfg_bak"
0x000000060000-0x000000160000 : "overlay"
0x000000160000-0x000000dc0000 : "OS1"
0x000000dc0000-0x000001000000 : "disk"
with special sub-partition
0x0000002c0000-0x000000dc0000 : "rootfs"
```

We will use OS1+disk space:
```
0x000000160000-0x000001000000 : "firmware"
```

 Return to stock
-----------------------

There is no official firmware for now. One can flash 3.0.129 or newer firmware as on first revision of device. firmware from R4AC-100m ( first revision of Chinese version) can be flashed, but without 5G radio available on it.


Recovery
-------------

Router used same recovery method as previous versions

1. Turn router off
2. Press and hold down reset button
3. Turn router on (plug-in power cable)
4. Wait about 10 seconds
5. Connect to network with dhcp and tftpd server (at gateway)
6. Reply to tftp request of `test.bin`. File test.bin could be found in 'Xiaomi 4A 100m Debrick tool'.


MAC addresses
-------------

`&factory + 0x4` — Wi-Fi 2G MAC
`&factory + 0x28` — WAN (ethernet switch) MAC 
`&factory + 0x8004` — Wi-Fi 5G MAC