### PR TITLE
ramips: add missing syscon compatible strings for MT7688 and RT3052

### DIFF
--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -39,7 +39,7 @@
 		#size-cells = <1>;
 
 		sysc: syscon@0 {
-			compatible = "ralink,mt7628-sysc", "syscon";
+			compatible = "ralink,mt7628-sysc", "ralink,mt7688-sysc", "syscon";
 			reg = <0x0 0x100>;
 			#clock-cells = <1>;
 			#reset-cells = <1>;

--- a/target/linux/ramips/dts/rt3050.dtsi
+++ b/target/linux/ramips/dts/rt3050.dtsi
@@ -40,7 +40,7 @@
 		#size-cells = <1>;
 
 		sysc: syscon@0 {
-			compatible = "ralink,rt3050-sysc", "syscon";
+			compatible = "ralink,rt3050-sysc", "ralink,rt3052-sysc", "syscon";
 			reg = <0x0 0x100>;
 			#clock-cells = <1>;
 			#reset-cells = <1>;


### PR DESCRIPTION
MT7688 devices use the "mt7628an.dtsi" as the template. And RT3052 devices use the "rt3050.dtsi" as template. Therefore, we need to add the corresponding system controller compatible strings to make them work properly.

Fixes: 1f818b09f8ae ("ramips: add proper system clock and reset driver support for legacy SoCs")
Fixes: https://github.com/openwrt/openwrt/issues/14305

cc @ikazuhiro @paraka