### PR TITLE
ramips: Disable unpolulated LED on Tama W06

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tama_w06.dts
+++ b/target/linux/ramips/dts/mt7628an_tama_w06.dts
@@ -114,4 +114,8 @@
 
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
+
+	led {
+		status = "disabled";
+	};
 };


### PR DESCRIPTION
mt76 wlan driver also registers LED, but the device doesn't have wmac's LED, so disable it.
