### PR TITLE
qualcommax: Fix Buffalo WXR-5950AX12 wifi MAC

### DIFF
--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -14,6 +14,10 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label) 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $(get_mac_label) 2 > /sys${DEVPATH}/macaddress
 		;;
+	buffalo,wxr-5950ax12)
+		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label)  8 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $(get_mac_label) 16 > /sys${DEVPATH}/macaddress
+		;;
 	zte,mf269)
 		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label) 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $(get_mac_label) 3 > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
Currently, WiFi interfaces on WXR-5950AX12 / WXR-6000AX12 devices come up with some MAC addresses inconsistent with vendor and Ethernet addresses. This adds a hotplug override in order to make it consistent with what is in u-boot env as well as OAM firmware where 1st radio MAC is set at Ethernet MAC + 8, and 2nd radio mac at Ethernet MAC + 16.

    fw_printenv | grep addr
    ethaddr=68:e1:dc:xx:xx:d8
    ipaddr=192.168.11.1
    wlan0addr=68:e1:dc:xx:xx:e0
    wlan1addr=68:e1:dc:xx:xx:e8
    wlan2addr=00:00:00:00:00:00

For OEM bootlog and MAC assagnment check
https://openwrt.org/toh/buffalo/wxr-5950ax12#openwrt_uimage_tftp_bootlog

Tested-by: Samir Ibradžić sibradzic@gmail.com # Buffalo WXR-6000AX12P
Signed-off-by: Samir Ibradžić <sibradzic@gmail.com>