### PR TITLE
[23.05] ramips: mt7621: use lzma-loader for Sercomm NA502

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1973,6 +1973,7 @@ TARGET_DEVICES += samknows_whitebox-v8
 
 define Device/sercomm_na502
   $(Device/nand)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 20480k
   DEVICE_VENDOR := SERCOMM
   DEVICE_MODEL := NA502


### PR DESCRIPTION
This is the `openwrt-23.05` backport of commit d41b8a570f209c352571f209c2c8f2b52b8d27af / PR #13925.



 