### PR TITLE
base-files: functions.sh: prepend() always adds separator

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -45,7 +45,7 @@ prepend() {
 	local value="$2"
 	local sep="${3:- }"
 
-	eval "export ${NO_EXPORT:+-n} -- \"$var=\${$value:+\${$value}\$sep}\$var\""
+	eval "export ${NO_EXPORT:+-n} -- \"$var=\$value\${$var:+\${sep}\${$var}}\""
 }
 
 list_contains() {


### PR DESCRIPTION
It shouldn't gate on the value, since the value will ostensibly always be set; instead it should depend on the variable being prepended to being non-empty.
