### PR TITLE
ipq806x: add support for Fortinet FAP421E

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -37,6 +37,15 @@ extreme,ap3935)
 	ucidef_set_led_netdev "wan" "wan" "orange:lan1" "eth1"
 	ucidef_set_led_netdev "lan" "lan" "orange:lan2" "eth0"
 	;;
+fortinet,fap-421e)
+	ucidef_set_led_netdev "eth1-100" "ETH1-100" "amber:eth1" "eth0" "link_100"
+	ucidef_set_led_netdev "eth1-1000" "ETH1-1000" "yellow:eth1" "eth0" "link_1000"
+	ucidef_set_led_netdev "eth2-100" "ETH2-100" "amber:eth2" "eth1" "link_100"
+	ucidef_set_led_netdev "eth2-1000" "ETH2-1000" "yellow:eth2" "eth1" "link_1000"
+	ucidef_set_led_wlan "wlan2g" "2.4G" "yellow:2g" "phy1tpt"
+	ucidef_set_led_wlan "wlan5g" "5G" "yellow:5g" "phy0tpt"
+	ucidef_set_led_usbport "usb" "USB" "amber:power" "usb1-port1" "usb2-port1"
+	;;
 meraki,mr52)
 	ucidef_set_led_netdev "eth0" "eth0" "green:lan1" "eth0"
 	ucidef_set_led_netdev "eth1" "eth1" "green:lan2" "eth1"

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -56,6 +56,7 @@ ipq806x_setup_interfaces()
 	qcom,ipq8064-db149)
 		ucidef_set_interface_lan "eth1 eth2 eth3 lan1 lan2 lan3 lan4" "wan"
 		;;
+	fortinet,fap-421e |\
 	ubnt,unifi-ac-hd)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;

--- a/target/linux/ipq806x/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ipq806x/base-files/etc/board.d/05_compat-version
@@ -14,6 +14,7 @@ case "$(board_name)" in
 	asrock,g10 |\
 	buffalo,wxr-2533dhp |\
 	compex,wpq864 |\
+	fortinet,fap-421e |\
 	nec,wg2600hp |\
 	nec,wg2600hp3 |\
 	netgear,d7800 |\

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -13,6 +13,7 @@ platform_do_upgrade() {
 	arris,tr4400-v2 |\
 	askey,rt4230w-rev6 |\
 	compex,wpq864|\
+	fortinet,fap-421e|\
 	netgear,d7800 |\
 	netgear,r7500 |\
 	netgear,r7500v2 |\

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-fap-421e.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-fap-421e.dts
@@ -1,0 +1,410 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq8064-smb208.dtsi"
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Fortinet FAP-421E";
+	compatible = "fortinet,fap-421e", "qcom,ipq8064";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x42000000 0xe000000>;
+	};
+
+	reserved-memory {
+		rsvd@41200000 {
+			no-map;
+			reg = <0x41200000 0x300000>;
+		};
+		wifi_dump@44000000 {
+			no-map;
+			reg = <0x44000000 0x600000>;
+		};
+	};
+
+	aliases {
+		led-boot = &led_power_yellow;
+		led-failsafe = &led_power_yellow;
+		led-running = &led_power_yellow;
+		led-upgrade = &led_power_yellow;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs-override = "console=ttyMSM0,9600n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+		
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 56 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		eth1_amber {
+			label = "amber:eth1";
+			gpios = <&qcom_pinmux 27 GPIO_ACTIVE_LOW>;
+		};
+
+		eth1_yellow {
+			label = "yellow:eth1";
+			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_LOW>;
+		};
+
+		eth2_amber {
+			label = "amber:eth2";
+			gpios = <&qcom_pinmux 29 GPIO_ACTIVE_LOW>;
+		};
+
+		eth2_yellow {
+			label = "yellow:eth2";
+			gpios = <&qcom_pinmux 28 GPIO_ACTIVE_LOW>;
+		};
+
+		power_amber {
+			label = "amber:power";
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_yellow: power_yellow {
+			label = "yellow:power";
+			gpios = <&qcom_pinmux 58 GPIO_ACTIVE_LOW>;
+		};
+
+		2g_yellow {
+			label = "yellow:2g";
+			gpios = <&qcom_pinmux 30 GPIO_ACTIVE_LOW>;
+		};
+
+		5g_yellow {
+			label = "yellow:5g";
+			gpios = <&qcom_pinmux 64 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&qcom_pinmux {
+	button_pins: button_pins {
+		mux {
+			bias-pull-up;
+			drive-strength = <2>;
+			pins = "gpio56";
+		};
+	};
+
+	led_pins: led_pins {
+		mux {
+			bias-pull-down;
+			drive-strength = <2>;
+			function = "gpio";
+			output-low;
+			pins = "gpio23";
+		};
+	};
+
+	rgmii2_pins: rgmii2-pins {
+		mux {
+			bias-disable;
+			drive-strength = <16>;
+			function = "rgmii2";
+			pins = "gpio66";
+		};
+	};
+
+	spi_pins: spi_pins {
+		mux {
+			pins = "gpio18", "gpio19", "gpio21";
+			function = "gsbi5";
+			bias-pull-down;
+		};
+
+		data {
+			pins = "gpio18", "gpio19";
+			drive-strength = <10>;
+		};
+
+		cs {
+			pins = "gpio20";
+			drive-strength = <10>;
+			bias-pull-up;
+		};
+
+		clk {
+			pins = "gpio21";
+			drive-strength = <12>;
+		};
+	};
+
+	uart0_pins: uart0_pins {
+		mux {
+			bias-disable;
+			drive-strength = <12>;
+			function = "gsbi7";
+			pins = "gpio6", "gpio7";
+		};
+	};
+	
+	usb_pwr_en_pins: usb_pwr_en_pins {
+		mux {
+			pins = "gpio22";
+			function = "gpio";
+			drive-strength = <12>;
+			bias-pull-down;
+			output-low;
+		};
+	};
+};
+
+&gsbi7 {
+	status = "okay";
+
+	qcom,mode = <GSBI_PROT_I2C_UART>;
+};
+
+&gsbi7_serial{
+	status = "okay";
+
+	pinctrl-0 = <&uart0_pins>;
+	pinctrl-names = "default";
+};
+
+&gsbi5 {
+	status = "okay";
+
+	qcom,mode = <GSBI_PROT_SPI>;
+
+	spi@1a280000 {
+		status = "okay";
+
+		pinctrl-0 = <&spi_pins>;
+		pinctrl-names = "default";
+		cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
+
+		flash@0 {
+			compatible = "jedec,spi-nor";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			spi-max-frequency = <50000000>;
+			reg = <0>;
+			m25p,fast-read;
+
+			partition@0 {
+				label = "SBL1";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "MIBIB";
+				reg = <0x20000 0x20000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "SBL2";
+				reg = <0x40000 0x40000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "SBL3";
+				reg = <0x80000 0x80000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "DDRCONFIG";
+				reg = <0x100000 0x10000>;
+				read-only;
+			};
+
+			partition@110000 {
+				label = "SSD";
+				reg = <0x110000 0x10000>;
+				read-only;
+			};
+
+			partition@120000 {
+				label = "TZ";
+				reg = <0x120000 0x80000>;
+				read-only;
+			};
+
+			partition@1a0000 {
+				label = "RPM";
+				reg = <0x1a0000 0x80000>;
+				read-only;
+			};
+
+			partition@220000 {
+				label = "APPSBL";
+				reg = <0x220000 0x80000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_appsbl_7ff80: mac-address@7ff80 {
+						compatible = "mac-base";
+						reg = <0x7ff80 0xc>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@2a0000 {
+				label = "APPSBLENV";
+				reg = <0x2a0000 0x40000>;
+			};
+
+			partition@2e0000 {
+				label = "ART";
+				reg = <0x2e0000 0x40000>;
+				read-only;
+			};
+
+			partition@320000 {
+				label = "kernel";
+				reg = <0x320000 0x600000>;
+			};
+
+			partition@920000 {
+				label = "ubi";
+				reg = <0x920000 0x1400000>;
+			};
+
+			partition@1d20000 {
+				label = "reserved";
+				reg = <0x1d20000 0x260000>;
+				read-only;
+			};
+
+			partition@1f80000 {
+				label = "config";
+				reg = <0x1f80000 0x80000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&hs_phy_1 {
+	status = "okay";
+};
+
+&ss_phy_1 {
+	status = "okay";
+};
+
+&usb3_1 {
+	status = "okay";
+
+	pinctrl-0 = <&usb_pwr_en_pins>;
+	pinctrl-names = "default";
+};
+
+&pcie0 {
+	status = "okay";
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_appsbl_7ff80 8>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&pcie1 {
+	status = "okay";
+
+	max-link-speed = <1>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_appsbl_7ff80 16>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&adm_dma {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	#address-cells = <0x1>;
+	#size-cells = <0x0>;
+	gpios = <&qcom_pinmux 1 GPIO_ACTIVE_HIGH>,
+			<&qcom_pinmux 0 GPIO_ACTIVE_HIGH>;
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+	};
+
+	phy2: ethernet-phy@2 {
+		reg = <2>;
+	};
+};
+
+&gmac0 {
+	status = "okay";
+
+	phy-mode = "rgmii";
+	qcom,id = <0>;
+	pinctrl-0 = <&rgmii2_pins>;
+	pinctrl-names = "default";
+	nvmem-cells = <&macaddr_appsbl_7ff80 0>;
+	nvmem-cell-names = "mac-address";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gmac2 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	qcom,id = <2>;
+	nvmem-cells = <&macaddr_appsbl_7ff80 1>;
+	nvmem-cell-names = "mac-address";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -177,6 +177,18 @@ define Device/extreme_ap3935
 endef
 TARGET_DEVICES += extreme_ap3935
 
+define Device/fortinet_fap-421e
+	$(call Device/FitImage)
+	DEVICE_VENDOR := Fortinet
+	DEVICE_MODEL := FAP-421E
+	SOC := qcom-ipq8064
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	BOARD_NAME := fap-421e
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct
+endef
+TARGET_DEVICES += fortinet_fap-421e
+
 define Device/linksys_ea7500-v1
 	$(call Device/LegacyImage)
 	$(Device/kernel-size-migration)


### PR DESCRIPTION
Hardware
--------
```
SoC:    Qualcomm IPQ8064
RAM:    235MB
Flash:  128MB NAND (Micron MT29F1G08ABBDAH4)
        32MB SPI-NOR (Spansion FL256SAIFRO)
WLAN2:  Qualcomm Atheros QCA9980
WLAN5:  Qualcomm Atheros QCA9980
ETH:    LAN1 - Atheros AR8035
        LAN2 - Atheros AR8033
USB:    USB-A, 2.0
LED:    Power (yellow/amber)
        LAN1 (yellow/amber)
        LAN2 (yellow/amber)
        WLAN2G (yellow)
        WLAN5G (yellow)
BTN:    Reset
Serial: RJ45 Port (9600 8n1) Cisco console cable, TTL voltage

MAC Address:    LAN1 (label) at APPSBL partition
                LAN2: label + 1
                WLAN2: label + 8
                WLAN5: label + 16
```
Installation
------------

- Connect to the RJ45 console (TTL)
- Connect LAN1 to host, set host ip as 192.168.1.10
- Start a tftp server to serve the initramfs image
- Open console connection (9600n8)
- Connect power through the DC jack

`Hit any key to stop autoboot:  5`: press any key
`Enter G,Q,or H:`: press `K` to access the hidden option
`Enter password:`: `fap22b1!$` to access a limited u-boot console
`(FAP) #`: `tftpboot your_initramfs_image_name.itb`
`(FAP) #`: `bootm`

Once OpenWrt has booted, install the firmware through sysupgrade