### PR TITLE
kernel: Add MultiPath TCP support

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1125,6 +1125,12 @@ if KERNEL_IP_MROUTE
 
 endif
 
+config KERNEL_MPTCP
+	bool "Enable MultiPath TCP support"
+	default n
+	help
+	  IPv4 MultiPath TCP to kernel support.
+
 #
 # IPv6 configuration
 #
@@ -1165,6 +1171,13 @@ if KERNEL_IPV6
 
 	config KERNEL_LWTUNNEL_BPF
 		def_bool n
+
+        config KERNEL_MPTCP_IPV6
+                bool "Enable IPv6 MultiPath TCP support"
+                def_bool y
+                depends on KERNEL_MPTCP
+                help
+                  IPv6 MultiPath TCP to kernel support.
 
 endif
 

--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -1476,6 +1476,21 @@ endef
 
 $(eval $(call KernelPackage,xdp-sockets-diag))
 
+define KernelPackage/inet-mptcp-diag
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
+  TITLE:=INET diag support for MultiPath TCP
+  DEPENDS:= @KERNEL_MPTCP +kmod-inet-diag
+  KCONFIG:= CONFIG_INET_MPTCP_DIAG
+  FILES:= $(LINUX_DIR)/net/mptcp/mptcp_diag.ko
+  AUTOLOAD:=$(call AutoProbe,mptcp_diag)
+endef
+
+define KernelPackage/inet-mptcp-diag/description
+Support for INET MultiPath TCP socket monitoring interface used by
+native Linux tools such as ss.
+endef
+
+$(eval $(call KernelPackage,inet-mptcp-diag))
 
 define KernelPackage/wireguard
   SUBMENU:=$(NETWORK_SUPPORT_MENU)


### PR DESCRIPTION
Add MultiPath TCP support by setting the config and module files. ​

Multipath TCP (MPTCP) is an effort to allow simultaneous use of multiple IP addresses/interfaces through a modification of TCP that presents a regular TCP interface to applications, while actually spreading data across multiple subflows. The benefits of this include better resource utilization, better throughput, and smoother occurrence of failures (font: https://openwrt.org/docs/guide-user/network/mptcp).

This commit is a recreation of PR openwrt#12884 since the original author has abandoned the merge request.