### PR TITLE
[23.05] ramips: fix lzma-loader boot and Ethernet-related kernel panic on rt305x and related devices.

### DIFF
--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -429,8 +429,8 @@
 		interrupt-parent = <&cpuintc>;
 		interrupts = <5>;
 
-		resets = <&rstctrl 21>;
-		reset-names = "fe";
+		resets = <&rstctrl 21>, <&rstctrl 23>;
+		reset-names = "fe", "esw";
 
 		mediatek,switch = <&esw>;
 	};
@@ -439,8 +439,8 @@
 		compatible = "mediatek,mt7628-esw", "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&rstctrl 23 &rstctrl 24>;
-		reset-names = "esw", "ephy";
+		resets = <&rstctrl 24>;
+		reset-names = "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/dts/rt3050.dtsi
+++ b/target/linux/ramips/dts/rt3050.dtsi
@@ -306,8 +306,8 @@
 		compatible = "ralink,rt3050-eth";
 		reg = <0x10100000 0x10000>;
 
-		resets = <&rstctrl 21>;
-		reset-names = "fe";
+		resets = <&rstctrl 21>, <&rstctrl 23>;
+		reset-names = "fe", "esw";
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <5>;
@@ -319,8 +319,8 @@
 		compatible = "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&rstctrl 23 &rstctrl 24>;
-		reset-names = "esw", "ephy";
+		resets = <&rstctrl 24>;
+		reset-names = "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/dts/rt3352.dtsi
+++ b/target/linux/ramips/dts/rt3352.dtsi
@@ -318,8 +318,8 @@
 		compatible = "ralink,rt3352-eth", "ralink,rt3050-eth";
 		reg = <0x10100000 0x10000>;
 
-		resets = <&rstctrl 21>;
-		reset-names = "fe";
+		resets = <&rstctrl 21>, <&rstctrl 23>;
+		reset-names = "fe", "esw";
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <5>;
@@ -331,8 +331,8 @@
 		compatible = "ralink,rt3352-esw", "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&rstctrl 23 &rstctrl 24>;
-		reset-names = "esw", "ephy";
+		resets = <&rstctrl 24>;
+		reset-names = "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -343,8 +343,8 @@
 		compatible = "ralink,rt5350-eth";
 		reg = <0x10100000 0x10000>;
 
-		resets = <&rstctrl 21>;
-		reset-names = "fe";
+		resets = <&rstctrl 21>, <&rstctrl 23>;
+		reset-names = "fe", "esw";
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <5>;
@@ -356,8 +356,8 @@
 		compatible = "ralink,rt5350-esw", "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&rstctrl 23 &rstctrl 24>;
-		reset-names = "esw", "ephy";
+		resets = <&rstctrl 24>;
+		reset-names = "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -149,7 +149,7 @@ void fe_reset_fe(struct fe_priv *priv)
 	reset_control_assert(priv->resets);
 	usleep_range(60, 120);
 	reset_control_deassert(priv->resets);
-	usleep_range(60, 120);
+	usleep_range(1000, 1200);
 }
 
 static inline void fe_int_disable(u32 mask)

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -143,12 +143,12 @@ void fe_reset(u32 reset_bits)
 
 void fe_reset_fe(struct fe_priv *priv)
 {
-	if (!priv->rst_fe)
+	if (!priv->resets)
 		return;
 
-	reset_control_assert(priv->rst_fe);
+	reset_control_assert(priv->resets);
 	usleep_range(60, 120);
-	reset_control_deassert(priv->rst_fe);
+	reset_control_deassert(priv->resets);
 	usleep_range(60, 120);
 }
 
@@ -1595,9 +1595,11 @@ static int fe_probe(struct platform_device *pdev)
 
 	priv = netdev_priv(netdev);
 	spin_lock_init(&priv->page_lock);
-	priv->rst_fe = devm_reset_control_get(&pdev->dev, "fe");
-	if (IS_ERR(priv->rst_fe))
-		priv->rst_fe = NULL;
+	priv->resets = devm_reset_control_array_get_exclusive(&pdev->dev);
+	if (IS_ERR(priv->resets)) {
+		dev_err(&pdev->dev, "Failed to get resets for FE and ESW cores: %pe\n", priv->resets);
+		priv->resets = NULL;
+	}
 
 	if (soc->init_data)
 		soc->init_data(soc, netdev);

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
@@ -497,8 +497,7 @@ struct fe_priv {
 	struct work_struct		pending_work;
 	DECLARE_BITMAP(pending_flags, FE_FLAG_MAX);
 
-	struct reset_control		*rst_ppe;
-	struct reset_control		*rst_fe;
+	struct reset_control		*resets;
 	struct mtk_foe_entry		*foe_table;
 	dma_addr_t			foe_table_phys;
 	struct flow_offload __rcu	**foe_flow_table;

--- a/target/linux/ramips/image/lzma-loader/src/board.c
+++ b/target/linux/ramips/image/lzma-loader/src/board.c
@@ -40,7 +40,7 @@
 #define UART_LSR			(UART_BASE + 0x14)
 #define UART_LSR_MASK			UART_LSR_THRE
 #elif defined(SOC_RT305X)
-#define UART_BASE			KSEG1ADDR(0x10000500)
+#define UART_BASE			KSEG1ADDR(0x10000c00)
 #define UART_THR			(UART_BASE + 0x04)
 #define UART_LSR			(UART_BASE + 0x1c)
 #define UART_LSR_MASK			UART_LSR_THRE

--- a/target/linux/ramips/image/lzma-loader/src/board.c
+++ b/target/linux/ramips/image/lzma-loader/src/board.c
@@ -11,19 +11,33 @@
  */
 
 #include <stdint.h>
+#include <stddef.h>
+
+#define KSEG0			0x80000000
+#define KSEG1			0xa0000000
+
+#define _ATYPE_ 		__PTRDIFF_TYPE__
+#define _ATYPE32_		int
+
+#define _ACAST32_		(_ATYPE_)(_ATYPE32_)
+
+#define CPHYSADDR(a)		((_ACAST32_(a)) & 0x1fffffff)
+
+#define KSEG0ADDR(a)		(CPHYSADDR(a) | KSEG0)
+#define KSEG1ADDR(a)		(CPHYSADDR(a) | KSEG1)
 
 #if defined(SOC_MT7620) || defined(SOC_RT3883)
-#define UART_BASE			0xb0000c00
+#define UART_BASE			KSEG1ADDR(0x10000c00)
 #define UART_THR			(UART_BASE + 0x04)
 #define UART_LSR			(UART_BASE + 0x1c)
 #define UART_LSR_THRE_MASK	0x40
 #elif defined(SOC_MT7621)
-#define UART_BASE			0xbe000c00
+#define UART_BASE			KSEG1ADDR(0x1e000c00)
 #define UART_THR			(UART_BASE + 0x00)
 #define UART_LSR			(UART_BASE + 0x14)
 #define UART_LSR_THRE_MASK	0x20
 #elif defined(SOC_RT305X)
-#define UART_BASE			0x10000500
+#define UART_BASE			KSEG1ADDR(0x10000500)
 #define UART_THR			(UART_BASE + 0x04)
 #define UART_LSR			(UART_BASE + 0x1c)
 #define UART_LSR_THRE_MASK	0x20

--- a/target/linux/ramips/image/lzma-loader/src/board.c
+++ b/target/linux/ramips/image/lzma-loader/src/board.c
@@ -26,21 +26,24 @@
 #define KSEG0ADDR(a)		(CPHYSADDR(a) | KSEG0)
 #define KSEG1ADDR(a)		(CPHYSADDR(a) | KSEG1)
 
+#define UART_LSR_THRE		0x20
+#define UART_LSR_TEMT		0x40
+
 #if defined(SOC_MT7620) || defined(SOC_RT3883)
 #define UART_BASE			KSEG1ADDR(0x10000c00)
 #define UART_THR			(UART_BASE + 0x04)
 #define UART_LSR			(UART_BASE + 0x1c)
-#define UART_LSR_THRE_MASK	0x40
+#define UART_LSR_MASK			UART_LSR_TEMT
 #elif defined(SOC_MT7621)
 #define UART_BASE			KSEG1ADDR(0x1e000c00)
 #define UART_THR			(UART_BASE + 0x00)
 #define UART_LSR			(UART_BASE + 0x14)
-#define UART_LSR_THRE_MASK	0x20
+#define UART_LSR_MASK			UART_LSR_THRE
 #elif defined(SOC_RT305X)
 #define UART_BASE			KSEG1ADDR(0x10000500)
 #define UART_THR			(UART_BASE + 0x04)
 #define UART_LSR			(UART_BASE + 0x1c)
-#define UART_LSR_THRE_MASK	0x20
+#define UART_LSR_MASK			UART_LSR_THRE
 #else
 #error "Unsupported SOC..."
 #endif
@@ -56,7 +59,7 @@ void board_init(void)
 
 void board_putc(int ch)
 {
-	while ((READREG(UART_LSR) & UART_LSR_THRE_MASK) == 0);
+	while ((READREG(UART_LSR) & UART_LSR_MASK) == 0);
 	WRITEREG(UART_THR, ch);
-	while ((READREG(UART_LSR) & UART_LSR_THRE_MASK) == 0);
+	while ((READREG(UART_LSR) & UART_LSR_MASK) == 0);
 }


### PR DESCRIPTION
This series cherry-picks fixes booting issues handled in #14194 and #14151 pull requests to 23.05 branch, with minor conflicts in device tree resolved. Both are merged together, since #14151 was required for booting and testing the mtk_eth_soc fixes.

Build tested on: ramips/rt305x, ramips/mt76x8, ramips/mt7620
Run tested on: ZTE MF283+ (RT3352), Hame MPR-A2 (RT5350), TP-Link TL-WR802N v4 (MT7628N), Nexx WT3020 8M (MT7620)