### PR TITLE
[22.03] ramips: fix "no traffic" problem and DMA kernel panic at startup on rt305x and mt7628 devices

### DIFF
--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -429,8 +429,8 @@
 		interrupt-parent = <&cpuintc>;
 		interrupts = <5>;
 
-		resets = <&rstctrl 21>;
-		reset-names = "fe";
+		resets = <&rstctrl 21>, <&rstctrl 23>;
+		reset-names = "fe", "esw";
 
 		mediatek,switch = <&esw>;
 	};
@@ -439,8 +439,8 @@
 		compatible = "mediatek,mt7628-esw", "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&rstctrl 23 &rstctrl 24>;
-		reset-names = "esw", "ephy";
+		resets = <&rstctrl 24>;
+		reset-names = "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/dts/rt3050.dtsi
+++ b/target/linux/ramips/dts/rt3050.dtsi
@@ -306,8 +306,8 @@
 		compatible = "ralink,rt3050-eth";
 		reg = <0x10100000 0x10000>;
 
-		resets = <&rstctrl 21>;
-		reset-names = "fe";
+		resets = <&rstctrl 21>, <&rstctrl 23>;
+		reset-names = "fe", "esw";
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <5>;
@@ -319,8 +319,8 @@
 		compatible = "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&rstctrl 23 &rstctrl 24>;
-		reset-names = "esw", "ephy";
+		resets = <&rstctrl 24>;
+		reset-names = "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/dts/rt3352.dtsi
+++ b/target/linux/ramips/dts/rt3352.dtsi
@@ -318,8 +318,8 @@
 		compatible = "ralink,rt3352-eth", "ralink,rt3050-eth";
 		reg = <0x10100000 0x10000>;
 
-		resets = <&rstctrl 21>;
-		reset-names = "fe";
+		resets = <&rstctrl 21>, <&rstctrl 23>;
+		reset-names = "fe", "esw";
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <5>;
@@ -331,8 +331,8 @@
 		compatible = "ralink,rt3352-esw", "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&rstctrl 23 &rstctrl 24>;
-		reset-names = "esw", "ephy";
+		resets = <&rstctrl 24>;
+		reset-names = "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -343,8 +343,8 @@
 		compatible = "ralink,rt5350-eth";
 		reg = <0x10100000 0x10000>;
 
-		resets = <&rstctrl 21>;
-		reset-names = "fe";
+		resets = <&rstctrl 21>, <&rstctrl 23>;
+		reset-names = "fe", "esw";
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <5>;
@@ -356,8 +356,8 @@
 		compatible = "ralink,rt5350-esw", "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&rstctrl 23 &rstctrl 24>;
-		reset-names = "esw", "ephy";
+		resets = <&rstctrl 24>;
+		reset-names = "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
@@ -235,7 +235,6 @@ struct rt305x_esw {
 	int			led_frequency;
 	struct esw_vlan vlans[RT305X_ESW_NUM_VLANS];
 	struct esw_port ports[RT305X_ESW_NUM_PORTS];
-	struct reset_control	*rst_esw;
 	struct reset_control	*rst_ephy;
 
 };
@@ -257,18 +256,6 @@ static inline void esw_rmw_raw(struct rt305x_esw *esw, unsigned reg,
 
 	t = __raw_readl(esw->base + reg) & ~mask;
 	__raw_writel(t | val, esw->base + reg);
-}
-
-static void esw_reset(struct rt305x_esw *esw)
-{
-	if (!esw->rst_esw)
-		return;
-
-	reset_control_assert(esw->rst_esw);
-	usleep_range(60, 120);
-	reset_control_deassert(esw->rst_esw);
-	/* the esw takes long to reset otherwise the board hang */
-	msleep(10);
 }
 
 static void esw_reset_ephy(struct rt305x_esw *esw)
@@ -463,8 +450,6 @@ static void esw_hw_init(struct rt305x_esw *esw)
 	int i;
 	u8 port_disable = 0;
 	u8 port_map = RT305X_ESW_PMAP_LLLLLL;
-
-	esw_reset(esw);
 
 	/* vodoo from original driver */
 	esw_w32(esw, 0xC8A07850, RT305X_ESW_REG_FCT0);
@@ -1435,12 +1420,11 @@ static int esw_probe(struct platform_device *pdev)
 	if (reg_init)
 		esw->reg_led_polarity = be32_to_cpu(*reg_init);
 
-	esw->rst_esw = devm_reset_control_get(&pdev->dev, "esw");
-	if (IS_ERR(esw->rst_esw))
-		esw->rst_esw = NULL;
-	esw->rst_ephy = devm_reset_control_get(&pdev->dev, "ephy");
-	if (IS_ERR(esw->rst_ephy))
+	esw->rst_ephy = devm_reset_control_get_exclusive(&pdev->dev, "ephy");
+	if (IS_ERR(esw->rst_ephy)) {
+		dev_err(esw->dev, "failed to get EPHY reset: %pe\n", esw->rst_ephy);
 		esw->rst_ephy = NULL;
+	}
 
 	spin_lock_init(&esw->reg_rw_lock);
 	platform_set_drvdata(pdev, esw);

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -149,7 +149,7 @@ void fe_reset_fe(struct fe_priv *priv)
 	reset_control_assert(priv->resets);
 	usleep_range(60, 120);
 	reset_control_deassert(priv->resets);
-	usleep_range(60, 120);
+	usleep_range(1000, 1200);
 }
 
 static inline void fe_int_disable(u32 mask)

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -143,12 +143,12 @@ void fe_reset(u32 reset_bits)
 
 void fe_reset_fe(struct fe_priv *priv)
 {
-	if (!priv->rst_fe)
+	if (!priv->resets)
 		return;
 
-	reset_control_assert(priv->rst_fe);
+	reset_control_assert(priv->resets);
 	usleep_range(60, 120);
-	reset_control_deassert(priv->rst_fe);
+	reset_control_deassert(priv->resets);
 	usleep_range(60, 120);
 }
 
@@ -1597,9 +1597,11 @@ static int fe_probe(struct platform_device *pdev)
 
 	priv = netdev_priv(netdev);
 	spin_lock_init(&priv->page_lock);
-	priv->rst_fe = devm_reset_control_get(&pdev->dev, "fe");
-	if (IS_ERR(priv->rst_fe))
-		priv->rst_fe = NULL;
+	priv->resets = devm_reset_control_array_get_exclusive(&pdev->dev);
+	if (IS_ERR(priv->resets)) {
+		dev_err(&pdev->dev, "Failed to get resets for FE and ESW cores: %pe\n", priv->resets);
+		priv->resets = NULL;
+	}
 
 	if (soc->init_data)
 		soc->init_data(soc, netdev);

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
@@ -497,8 +497,7 @@ struct fe_priv {
 	struct work_struct		pending_work;
 	DECLARE_BITMAP(pending_flags, FE_FLAG_MAX);
 
-	struct reset_control		*rst_ppe;
-	struct reset_control		*rst_fe;
+	struct reset_control		*resets;
 	struct mtk_foe_entry		*foe_table;
 	dma_addr_t			foe_table_phys;
 	struct flow_offload __rcu	**foe_flow_table;


### PR DESCRIPTION
This series fixes bootup and Ethernet support on rt305x subtarget. It combines the MAC core and switch core reset again, but using device tree properties, rather than reverting the changes introduced in 60fadae62b64b14faff818e4156d9c6eb3f96b65. However, reverting those changes or moving resets around in device tree wasn't enough - the wait duration after the reset needs increasing, to allow both cores to sync up after reset.

The final commit cleans up the way reset controller lines are accessed from the code, but is mostly aesthetic in nature.

This series is backport of #14194.

Build tested on: ramips/rt305x, ramips/mt76x8, ramips/mt7620
Run tested on: ZTE MF283+ (RT3352), Hame MPR-A2 (RT5350), TP-Link TL-WR802N v4 (MT7628N), Nexx WT3020 8M (MT7620)

Closes: #9284