### PR TITLE
[23.05] mediatek: filogic: add support for ASUS RT-AX59U

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -12,6 +12,9 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 case "$board" in
+asus,rt-ax59u)
+	ubootenv_add_uci_config "/dev/mtd0" "0x100000" "0x20000" "0x20000"
+	;;
 bananapi,bpi-r3)
 	rootdev="$(cmdline_get_var root)"
 	rootdev="${rootdev##*/}"

--- a/target/linux/mediatek/dts/mt7986a-asus-rt-ax59u.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-rt-ax59u.dts
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+
+	model = "ASUS RT-AX59U";
+	compatible = "asus,rt-ax59u", "mediatek,mt7986a";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-override = "ubi.mtd=UBI_DEV";
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x20000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-0 {
+			label = "wps";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		button-1 {
+			label = "reset";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: led-1 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		out {
+			gpio-export,name = "led-light";
+			gpio-export,output = <0>;
+			gpios = <&pio 22 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		/* LAN */
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@1 {
+					reg = <1>;
+					label = "wan";
+				};
+
+				port@2 {
+					reg = <2>;
+					label = "lan1";
+				};
+
+				port@3 {
+					reg = <3>;
+					label = "lan2";
+				};
+
+				port@4 {
+					reg = <4>;
+					label = "lan3";
+				};
+
+				port@6 {
+					reg = <6>;
+					label = "cpu";
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <8>;
+			mediatek,pull-down-adv = <0>; /* bias-disable */
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			       "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			       "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			       "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			       "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			       "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			       "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <4>;
+		};
+	};
+
+	wf_dbdc_pins: wf-dbdc-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_dbdc";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+				"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+				"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+				"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+				"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+				"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+				"WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <4>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+
+	spi_nand: spi_nand@0 {
+		compatible = "spi-nand";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+
+		spi-max-frequency = <20000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x400000>;
+				read-only;
+			};
+
+			partition@400000 {
+				label = "UBI_DEV";
+				reg = <0x400000 0x7c00000>;
+			};
+		};
+	};
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	pinctrl-names = "default", "dbdc";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+	pinctrl-1 = <&wf_dbdc_pins>;
+};
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&ssusb {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -14,6 +14,15 @@ mediatek_setup_interfaces()
 	acer,predator-w6)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 game" eth1
 		;;
+	asus,rt-ax59u|\
+	cetron,ct3003|\
+	confiabits,mt7981|\
+	cudy,wr3000-v1|\
+	jcg,q30-pro|\
+	qihoo,360t7|\
+	routerich,ax3000)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
+		;;
 	asus,tuf-ax4200|\
 	mediatek,mt7981-rfb|\
 	zbtlink,zbt-z8102ax)
@@ -24,14 +33,6 @@ mediatek_setup_interfaces()
 		;;
 	bananapi,bpi-r3)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp2" "eth1 wan"
-		;;
-	cetron,ct3003|\
-	confiabits,mt7981|\
-	cudy,wr3000-v1|\
-	jcg,q30-pro|\
-	qihoo,360t7|\
-	routerich,ax3000)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
 		;;
 	cmcc,rax3000m|\
 	h3c,magic-nx30-pro)
@@ -86,6 +87,7 @@ mediatek_setup_macs()
 	local label_mac=""
 
 	case $board in
+	asus,rt-ax59u|\
 	asus,tuf-ax4200|\
 	asus,tuf-ax6000)
 		CI_UBIPART="UBI_DEV"

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -45,6 +45,7 @@ case "$FIRMWARE" in
 	;;
 "mediatek/mt7986_eeprom_mt7976_dbdc.bin")
 	case "$board" in
+	asus,rt-ax59u|\
 	asus,tuf-ax4200|\
 	asus,tuf-ax6000)
 		CI_UBIPART="UBI_DEV"

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -16,6 +16,16 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && cat $key_path/6gMAC > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "2" ] && cat $key_path/5gMAC > /sys${DEVPATH}/macaddress
 		;;
+	asus,rt-ax59u)
+		CI_UBIPART="UBI_DEV"
+		addr=$(mtd_get_mac_binary_ubi "Factory" 0x4)
+		# Originally, phy1 is phy0 mac with LA and 28th bits set. However, this would conflict
+		# addresses on multiple VIFs with the other radio when bit 28 is already set.
+		# Set LA and 28 bits and increment mac-address instead.
+		[ "$PHYNBR" = "1" ] && \
+			macaddr_setbit_la $(macaddr_setbit $(macaddr_add $addr 1) 28) > \
+			/sys${DEVPATH}/macaddress
+		;;
 	asus,tuf-ax4200|\
 	asus,tuf-ax6000)
 		CI_UBIPART="UBI_DEV"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -1,5 +1,16 @@
 REQUIRE_IMAGE_METADATA=1
 
+asus_initial_setup()
+{
+	# initialize UBI if it's running on initramfs
+	[ "$(rootfs_type)" = "tmpfs" ] || return 0
+
+	ubirmvol /dev/ubi0 -N rootfs
+	ubirmvol /dev/ubi0 -N rootfs_data
+	ubirmvol /dev/ubi0 -N jffs2
+	ubimkvol /dev/ubi0 -N jffs2 -s 0x3e000
+}
+
 xiaomi_initial_setup()
 {
 	# initialize UBI and setup uboot-env if it's running on initramfs
@@ -56,6 +67,7 @@ platform_do_upgrade() {
 		CI_ROOTPART="rootfs"
 		emmc_do_upgrade "$1"
 		;;
+	asus,rt-ax59u|\
 	asus,tuf-ax4200|\
 	asus,tuf-ax6000)
 		CI_UBIPART="UBI_DEV"
@@ -183,6 +195,11 @@ platform_pre_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
+	asus,rt-ax59u|\
+	asus,tuf-ax4200|\
+	asus,tuf-ax6000)
+		asus_initial_setup
+		;;
 	xiaomi,mi-router-wr30u-stock|\
 	xiaomi,redmi-router-ax6000-stock)
 		xiaomi_initial_setup

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -137,6 +137,16 @@ define Device/acer_predator-w6
 endef
 TARGET_DEVICES += acer_predator-w6
 
+define Device/asus_rt-ax59u
+  DEVICE_VENDOR := ASUS
+  DEVICE_MODEL := RT-AX59U
+  DEVICE_DTS := mt7986a-asus-rt-ax59u
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7986-firmware mt7986-wo-firmware
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += asus_rt-ax59u
+
 define Device/asus_tuf-ax4200
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := TUF-AX4200


### PR DESCRIPTION
(based on support for ASUS RT-AX59U by liushiyou006)

SOC: MediaTek MT7986
RAM: 512MB DDR4
FLASH: 128MB SPI-NAND (Winbond W25N01GV)
WIFI: Mediatek MT7986 DBDC 802.11ax 2.4/5 GHz
ETH: MediaTek MT7531 Switch
UART: 3V3 115200 8N1 (Pinout silkscreened / Do not connect VCC)

Upgrade from AsusWRT to OpenWRT using UART

    Download the OpenWrt initramfs image.
    Copy the image to a TFTP server reachable at 192.168.1.70/24. Rename the image to rtax59u.bin.

    Connect the PC with TFTP server to the RT-AX59U.
    Set a static ip on the ethernet interface of your PC.
    (ip address: 192.168.1.70, subnet mask:255.255.255.0)
    Conect to the serial console, interrupt the autoboot process by pressing '4' when prompted.

    Download & Boot the OpenWrt initramfs image.

    $ setenv ipaddr 192.168.1.1
    $ setenv serverip 192.168.1.70
    $ tftpboot 0x46000000 rtax59u.bin
    $ bootm 0x46000000

    Wait for OpenWrt to boot. Transfer the sysupgrade image to the device using scp and install using sysupgrade.

    $ sysupgrade -n <path-to-sysupgrade.bin>

Upgrade from AsusWRT to OpenWRT using WebUI

    Download transit TRX file from https://drive.google.com/drive/folders/1A20QdjK7Udagu31FSszpWAk8-cGlCwsq

    Upgrade firmware from WebUI (192.168.50.1) using downloaded TRX file

    Wait for OpenWRT to boot (192.168.1.1).

    Upgrade system with sysupgrade image using luci or uploading it through scp and executing sysupgrade command

MAC Address for WLAN 5g is not following the same algorithm as in AsusWRT. We have increased by one the WLAN 5g to avoid collisions with other networks from WLAN 2g when bit 28 is already set.

                : Stock             : OpenWrt
    WLAN 2g (1) : C8:xx:xx:0D:xx:D4 : C8:xx:xx:0D:xx:D4
    WLAN 2g (2) :                   : CA:xx:xx:0D:xx:D4
    WLAN 2g (3) :                   : CE:xx:xx:0D:xx:D4
    WLAN 5g (1) : CA:xx:xx:1D:xx:D4 : CA:xx:xx:1D:xx:D5
    WLAN 5g (2) :                   : CE:xx:xx:1D:xx:D5
    WLAN 5g (3) :                   : C2:xx:xx:1D:xx:D5
    
    WLAN 2g (1) : 08:xx:xx:76:xx:BE : 08:xx:xx:76:xx:BE
    WLAN 2g (2) :                   : 0A:xx:xx:76:xx:BE
    WLAN 2g (3) :                   : 0E:xx:xx:76:xx:BE
    WLAN 5g (1) : 0A:xx:xx:76:xx:BE : 0A:xx:xx:76:xx:BF
    WLAN 5g (2) :                   : 0E:xx:xx:76:xx:BF
    WLAN 5g (3) :                   : 02:xx:xx:76:xx:BF

