### PR TITLE
libnl: update to 3.9.0

### DIFF
--- a/package/libs/libnl/Makefile
+++ b/package/libs/libnl/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnl
-PKG_VERSION:=3.8.0
+PKG_VERSION:=3.9.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/thom311/libnl/releases/download/libnl$(subst .,_,$(PKG_VERSION))
-PKG_HASH:=bb726c6d7a08b121978d73ff98425bf313fa26a27a331d465e4f1d7ec5b838c6
+PKG_HASH:=aed507004d728a5cf11eab48ca4bf9e6e1874444e33939b9d3dfed25018ee9bb
 
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Changes:
bdf83151 libnl-3.9.0 release
aa7353fd include/linux-private: import 'seg6 local' headers from kernel tree 9466f680 lib: remove unused assignment in nl_addr_parse() acd05d6e route/tc: avoid integer overflow in rtnl_tc_calc_cell_log() daa8efcb xfrm: return -NLE_MISSING_ATTR from xfrmnl_sa_get_auth_params() d8a1ff30 xfrm: fix leaking usertemplate in xfrmnl_sp_parse() 4fcb0757 socket: workaround coverity warning about time_t handling f743c62f github: update Fedora image and version for clang-format f33e8cd6 clang-format: rework container script
aea3f9f2 lib: fix signed overflow warning in nl_object_diff() 57e01706 socket: explicitly cast time() to uint32_t 46e8739e src: fix leak in "nl-cls-add"
a06c8f76 route/cls: add get/take wrappers for rtnl_act_append() 7912b4f9 route/cls: fix leak in error handling of rtnl_flower_append_action() efd65feb route: fix just introduced use-after-free in rtnl_act_parse() 105a6be1 route: use cleanup macro in rtnl_act_parse() 78246da7 nl-aux-route: add cleanup macro for rtnl_act_put_all() 72762b20 base: add _NL_AUTO_DEFINE_FCN_INDIRECT0() macro a70f789a route: fix memleak in rtnl_act_parse()
65ab16f2 base: don't use static array indices for buffer argument of _nl_inet_ntop() 444e2c04 route/can: implement can_device_stats
a4718e67 github: build with "-fexceptions" CFLAGS
2f485cc7 xfrm: refactor error handling in XFRM parsing 01bd8fb0 include: add "nl-aux-xfrm" helpers
49c20efa xfrm: fix crashes in case of ENOMEM
9e7b5c86 xfrm: refactor nl_addr_build() calls in XFRM code dbfd87b1 xfrm: use cleanup attribute for nl_addr in XFRM parsing db424835 xfrm: fix error code for NLE_ENOMEM in xfrmnl_ae_parse() 9c97deff xfrm: fix parsing address in xfrmnl_ae_parse() 8b6dc834 nl-aux-core: add _nl_addr_build() helper
057aac13 nl-base-utils: add _nl_addr_family_to_size() helper 664f8f1b xfrm: clear XFRM_SP_ATTR_TMPL when removing the last template from a policy c4c22d26 xfrm/sp: fix reference counters of sa selector/tmpl addresses 5979fcb0 route/link: add bonding interface options set rtnl apis a735989c build: fix declaring special targets as ".PHONY" 052a97cb Makefile.am: avoid use of non-portable echo arguments 9aab12df python: Use correct decorator syntax in HTBQdisc
