### PR TITLE
hostapd: fail R0KH and R1KH derivation when wpa_psk_file is used

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -932,6 +932,10 @@ hostapd_set_bss_options() {
 				set_default pmk_r1_push 0
 
 				[ -n "$r0kh" -a -n "$r1kh" ] || {
+					if [ -z "$auth_secret" -a -z "$key" ]; then
+						wireless_setup_vif_failed FT_KEY_CANT_BE_DERIVED
+						return 1
+					fi
 					ft_key=`echo -n "$mobility_domain/${auth_secret:-${key}}" | md5sum | awk '{print $1}'`
 
 					set_default r0kh "ff:ff:ff:ff:ff:ff,*,$ft_key"


### PR DESCRIPTION
When wpa_psk_file is used, there is a chance that no PSK is set. This means
that the FT key will be generated using only the mobility domain which
could be considered a security vulnerability but only for a very specific
and niche config.