### PR TITLE
hostapd: don't set ft_psk_generate_local when SAE is enabled

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -909,7 +909,7 @@ hostapd_set_bss_options() {
 			set_default reassociation_deadline 1000
 
 			case "$auth_type" in
-				psk|sae|psk-sae)
+				psk)
 					set_default ft_psk_generate_local 1
 				;;
 				*)


### PR DESCRIPTION
ft_psk_generate_local assumes that it is operating solely on a FT-PSK
network, once hostapd's attempt to derive R0KH/R1KH from PSK fails
for the SAE network which is a given; it never falls over to the
regular push/pull code. This leaves us with the only option which is
to disable ft_psk_generate_local for SAE-only and SAE-mixed networks.
