### PR TITLE
[23.05] ramips: correct the PCIe port number for Unielec u7621-01

### DIFF
--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01.dtsi
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01.dtsi
@@ -50,25 +50,24 @@
 	status = "okay";
 };
 
-&pcie0 {
+&pcie1 { // MT7603EN
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
-		ieee80211-freq-limit = <2400000 2500000>;
+
+		led {
+			led-active-low;
+		};
 	};
 };
 
-&pcie1 {
+&pcie2 { // MT7612E
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-
-		led {
-			led-sources = <2>;
-		};
 	};
 };
 


### PR DESCRIPTION
MT7621 gets a new PCIe driver in the 5.15+ kernel. Allocating wrong PCIe port will cause the PCIe NIC to not work properly. This commit fixes the wrong port numbers on Unielec u7621-01.

According to the bootlog, MT7612E (5 GHz) is connected to pcie2, and MT7603E (2 GHz) is connected to pcie1:

[    1.294844] mt7621-pci 1e140000.pcie: pcie0 no card, disable it (RST & CLK)
[    1.308635] mt7621-pci 1e140000.pcie: PCIE1 enabled
[    1.318277] mt7621-pci 1e140000.pcie: PCIE2 enabled

Also correct the led activity for the MT7603e - not used on the MT7612e


(cherry picked from commit 39e55bdbe27a09579658178796a9b732e126e703)
