### PR TITLE
[23.05] ramips: unielec-u7621-01: Increase SPI frequency to 50MHz

### DIFF
--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
@@ -13,7 +13,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <14000000>;
+		spi-max-frequency = <50000000>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
Flash: 16MB SPI NOR flash (Macronix MX25L12805D)

Based on the manufactured datasheet this chip is capable of 50MHz.

We dont enable fast-read as mt7621 are only capable of 44mhz in a read state.

Tested on this unit without any issues.


(cherry picked from commit 443e3bd1c6e61aa39f4fc176b22ad2d75f33bcb4)
