### PR TITLE
dnsmasq: Add EDNS0 Upstream support

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -972,12 +972,16 @@ dnsmasq_start()
 	append_bool "$cfg" noping "--no-ping"
 	append_bool "$cfg" rapidcommit "--dhcp-rapid-commit"
 	append_bool "$cfg" scriptarp "--script-arp"
+	append_bool "$cfg" add_mac "--add-mac"
+	append_bool "$cfg" strip_mac "--strip-mac"
+	append_bool "$cfg" strip_subnet "--strip-subnet"
 
 	append_bool "$cfg" filter_aaaa "--filter-AAAA"
 	append_bool "$cfg" filter_a "--filter-A"
 
 	append_parm "$cfg" logfacility "--log-facility"
 	config_get logfacility "$cfg" "logfacility"
+	append_parm "$cfg" add_subnet "--add-subnet"
 	append_parm "$cfg" cachesize "--cache-size"
 	append_parm "$cfg" dnsforwardmax "--dns-forward-max"
 	append_parm "$cfg" port "--port"


### PR DESCRIPTION
Forward client mac address and subnet on dns queries.

Pi-hole and Adguard use this feature to send the originators ip address/subnet so it can be logged and not just the nat address of the router.

This feature has been added since version 2.56 of dnsmasq and would be nice to expose this feature in openwrt.