### PR TITLE
ipq807x: use devinfo MAC for Linksys MX4200

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -34,7 +34,7 @@ ALLWIFIBOARDS:= \
 	dynalink_dl-wrx36 \
 	edgecore_eap102 \
 	edimax_cax1800 \
-        linksys_mx4200 \
+	linksys_mx4200 \
 	netgear_rax120v2 \
 	netgear_wax218 \
 	netgear_wax620 \

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v1.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v1.dts
@@ -10,10 +10,10 @@
 	model = "Linksys MX4200v1";
 	compatible = "linksys,mx4200v1", "qcom,ipq8074";
 };
-  
+
 &wifi {
 	status = "okay";
 
-        qcom,ath11k-calibration-variant = "Linksys-MX4200v1";
+	qcom,ath11k-calibration-variant = "Linksys-MX4200v1";
 	qcom,ath11k-fw-memory-mode = <1>;
 };

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -119,24 +119,24 @@ define Device/linksys_mx4200v1
 	$(call Device/FitImage)
 	$(call Device/UbiFit)
 	DEVICE_VENDOR := Linksys
-        DEVICE_MODEL := MX4200
-        DEVICE_VARIANT := v1
+	DEVICE_MODEL := MX4200
+	DEVICE_VARIANT := v1
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
-        KERNEL_SIZE := 6144k
+	KERNEL_SIZE := 6144k
 	IMAGE_SIZE := 147456k
 	NAND_SIZE := 512m
 	KERNEL_IN_UBI :=
 	SOC := ipq8174
 	IMAGES += factory.bin
-	IMAGE/factory.bin  := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=MX4200
+	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=MX4200
 	DEVICE_PACKAGES := kmod-leds-pca963x ipq-wifi-linksys_mx4200 kmod-bluetooth
 endef
 TARGET_DEVICES += linksys_mx4200v1
 
 define Device/linksys_mx4200v2
 	$(call Device/linksys_mx4200v1)
-        DEVICE_VARIANT := v2
+	DEVICE_VARIANT := v2
 endef
 TARGET_DEVICES += linksys_mx4200v2
 

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -18,8 +18,8 @@ ipq807x_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;
 	compex,wpq873|\
-        linksys,mx4200v1|\
-        linksys,mx4200v2|\
+	linksys,mx4200v1|\
+	linksys,mx4200v2|\
 	redmi,ax6|\
 	xiaomi,ax3600)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -57,9 +57,33 @@ ipq807x_setup_interfaces()
 	esac
 }
 
+ipq807x_setup_macs()
+{
+	local board="$1"
+	local lan_mac=""
+	local wan_mac=""
+	local label_mac=""
+
+	case "$board" in
+		linksys,mx4200v1|\
+		linksys,mx4200v2)
+			label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
+			for i in $(seq 3 5); do
+				[ "$(mtd_get_mac_ascii u_env eth${i}addr)" != "$label_mac" ] && lan_mac=$label_mac
+			done
+			[ "$(mtd_get_mac_ascii u_env eth2addr)" != "$label_mac" ] && wan_mac=$label_mac
+		;;
+	esac
+
+	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac
+	[ -n "$wan_mac" ] && ucidef_set_interface_macaddr "wan" $wan_mac
+	[ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
+}
+
 board_config_update
 board=$(board_name)
 ipq807x_setup_interfaces $board
+ipq807x_setup_macs $board
 board_config_flush
 
 exit 0

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -18,6 +18,13 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label)  8 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $(get_mac_label) 16 > /sys${DEVPATH}/macaddress
 		;;
+	linksys,mx4200v1|\
+	linksys,mx4200v2)
+		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
+		[ "$PHYNBR" = "0" ] && macaddr_add $label_mac 2 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $label_mac 1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "2" ] && macaddr_add $label_mac 3 > /sys${DEVPATH}/macaddress
+		;;
 	zte,mf269)
 		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label) 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $(get_mac_label) 3 > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
Some devices (MX42CF) have a wrong MAC address configuration. The correct one is located only on the `devinfo` partition.