### PR TITLE
build: fix toplevel check target

### DIFF
--- a/include/toplevel.mk
+++ b/include/toplevel.mk
@@ -210,7 +210,9 @@ prereq:: prepare-tmpinfo .config
 	@+$(NO_TRACE_MAKE) -r -s $@
 
 check: .config FORCE
-check val.% var.%: FORCE
+	@+$(NO_TRACE_MAKE) -r -s $@ QUIET= V=s
+
+val.% var.%: FORCE
 	@+$(NO_TRACE_MAKE) -r -s $@ QUIET= V=s
 
 WARN_PARALLEL_ERROR = $(if $(BUILD_LOG),,$(and $(filter -j,$(MAKEFLAGS)),$(findstring s,$(OPENWRT_VERBOSE))))


### PR DESCRIPTION
Partially revert changes to verbose logging that break the 'check' target dependencies and trigger many runtime warnings like:
  /home/kodidev/openwrt-project/include/toplevel.mk:213: *** mixed implicit and normal rules: deprecated syntax

Fixes: e4a43cda0 ("build: allow var.% targets to bypass the prepare steps")

CC: @mpratt14 @Ansuel This follows up from https://github.com/openwrt/openwrt/pull/14039#issuecomment-1879761144