### PR TITLE
mediatek: GL-MT6000: Add missing LED state definitions to DTS

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-glinet-gl-mt6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-glinet-gl-mt6000.dts
@@ -13,6 +13,10 @@
 
 	aliases {
 		serial0 = &uart0;
+		led-boot = &led_white;
+		led-failsafe = &led_white;
+		led-running = &led_blue;
+		led-upgrade = &led_white;
 	};
 
 	chosen {
@@ -51,13 +55,12 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_run: led@0 {
+		led_blue: led@0 {
 			label = "blue:run";
 			gpios = <&pio 38 GPIO_ACTIVE_LOW>;
-			default-state = "on";
 		};
 
-		led@1 {
+		led_white: led@1 {
 			label = "white:system";
 			gpios = <&pio 37 GPIO_ACTIVE_LOW>;
 		};


### PR DESCRIPTION
The DTS for GL-MT6000 is missing all OpenWrt related LED definitions, and just the blue LED is solidly on the whole time even during the boot process. No preinit indication etc.

This PR adjusts LED names and provides the OpenWrt status indicator aliases to actually use LEDs by the OpenWrt boot & sysupgrade processes.

- Name both LEDs clearly by the color
- Add the missing OpenWrt LED status indicator aliases and remove the now unnecessary default state from blue LED

After this commit, the LEDs are used as:

- bootloader, really early Linux boot: blue LED is on
- preinit/failsafe: white LED blinks rapidly
- late boot: white LED blinks slowly
- boot completed, running normally: blue LED is on

- sysupgrade: white LED blinks


Run-tested with GL-MT6000.
