### PR TITLE
ath79: add support for UniFi UK-Ultra

### DIFF
--- a/target/linux/ath79/dts/qca9563_ubnt_uk-ultra.dts
+++ b/target/linux/ath79/dts/qca9563_ubnt_uk-ultra.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9563_ubnt_unifiac-lite.dtsi"
+
+/ {
+	compatible = "ubnt,uk-ultra", "qca,qca9563";
+	model = "Ubiquiti UniFi Swiss Army Knife Ultra";
+};
+
+&leds {
+	led-rssi0 {
+		label = "white:rssi0";
+		gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+	};
+
+	led-rssi1 {
+		label = "white:rssi1";
+		gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
+	};
+
+	led-rssi2 {
+		label = "white:rssi2";
+		gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+	};
+
+	led-rssi3 {
+		label = "white:rssi3";
+		gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+/**
+ * Antenna selection on GPIO5 and GPIO6
+ * High = Internal ; Low = External
+ */

--- a/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
+++ b/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
@@ -13,7 +13,7 @@
 		led-upgrade = &led_blue;
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 
 		led_white: led_white {

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -494,6 +494,13 @@ ubnt,rocket-m)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:link3" "wlan0" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:link4" "wlan0" "76" "100"
 	;;
+ubnt,uk-ultra)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "white:rssi0" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "white:rssi1" "wlan0" "26" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "white:rssi2" "wlan0" "51" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "white:rssi3" "wlan0" "76" "100"
+	;;
 wallys,dr531)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
 	ucidef_set_led_switch "wan" "WAN" "green:wan" "switch0" "0x2"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -113,6 +113,7 @@ ath79_setup_interfaces()
 	ubnt,powerbridge-m|\
 	ubnt,rocket-5ac-lite|\
 	ubnt,rocket-m|\
+	ubnt,uk-ultra|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-lr|\
 	ubnt,unifiac-mesh|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
@@ -92,6 +92,10 @@ ubnt,nanostation-m)
 ubnt,nanostation-m-xw)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "2"
 	;;
+ubnt,uk-ultra)
+	ucidef_add_gpio_switch "ant0_internal" "ANT0 Internal" "5" "1"
+	ucidef_add_gpio_switch "ant1_internal" "ANT1 Internal" "6" "1"
+	;;
 zbtlink,zbt-wd323)
 	ucidef_add_gpio_switch "io0" "IO#0" "0"
 	ucidef_add_gpio_switch "io1" "IO#1" "1"

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -36,6 +36,7 @@ case "$FIRMWARE" in
 	sophos,ap100|\
 	sophos,ap100c|\
 	ubnt,bullet-ac|\
+	ubnt,uk-ultra|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-lr|\
 	ubnt,unifiac-mesh|\

--- a/target/linux/ath79/image/common-ubnt.mk
+++ b/target/linux/ath79/image/common-ubnt.mk
@@ -121,6 +121,13 @@ define Device/ubnt-xw
   UBNT_VERSION := 6.0.4
 endef
 
+define Device/ubnt_unifiac
+  DEVICE_VENDOR := Ubiquiti
+  SOC := qca9563
+  IMAGE_SIZE := 15488k
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+endef
+
 define Device/ubnt-unifi-jffs2
   $(Device/ubnt)
   KERNEL_SIZE := 3072k

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -244,13 +244,6 @@ define Device/ubnt_unifi-ap-lr
 endef
 TARGET_DEVICES += ubnt_unifi-ap-lr
 
-define Device/ubnt_unifiac
-  DEVICE_VENDOR := Ubiquiti
-  SOC := qca9563
-  IMAGE_SIZE := 15488k
-  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
-endef
-
 define Device/ubnt_unifiac-lite
   $(Device/ubnt_unifiac)
   DEVICE_MODEL := UniFi AC Lite

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -229,6 +229,13 @@ define Device/ubnt_routerstation-pro
 endef
 TARGET_DEVICES += ubnt_routerstation-pro
 
+define Device/ubnt_uk-ultra
+  $(Device/ubnt_unifiac)
+  DEVICE_MODEL := UniFi Swiss Army Knife Ultra
+  DEVICE_PACKAGES += rssileds -swconfig
+endef
+TARGET_DEVICES += ubnt_uk-ultra
+
 define Device/ubnt_unifi-ap
   $(Device/ubnt-bz)
   DEVICE_MODEL := UniFi AP


### PR DESCRIPTION
Hardware
--------
CPU:   Qualcomm Atheros QCA9563
RAM:   128M DDR2
FLASH: 16MB SPI-NOR
WiFi:  Qualcomm Atheros QCA9563 2x2:2 802.11n 2.4GHz
       Qualcomm Atheros QCA9880 2x2:2 802.11ac 5GHz

Antennas
--------
The device features internal antennas as well as external antenna
connectors. By default, the internal antennas are used.

Two GPIOs are exported by name, which can be used to control the
antenna-path mux. Writing a logical 0 enables the external antenna
connectors.

Installation
------------
1. Download the OpenWrt sysupgrade image to the device. You can use scp
   for this task. The default username and password are "ubnt" and the
   device is reachable at 192.168.1.20.

   $ scp -O openwrt-sysupgrade.bin ubnt@192.168.1.20:/tmp/firmware.bin

2. Connect to the device using SSH.

   $ ssh ubnt@192.168.1.20

3. Disable the write-protect

   $ echo "5edfacbf" > /proc/ubnthal/.uf

4. Verify kernel0 and kernel1 match mtd2 and mtd3

   $ cat /proc/mtd

5. Write the sysupgrade image to kernel0 and kernel1

   $ dd if=/tmp/firmware.bin of=/dev/mtdblock2
   $ dd if=/tmp/firmware.bin of=/dev/mtdblock3

6. Write the bootselect flag to boot from kernel0

   $ dd if=/dev/zero bs=1 count=1 of=/dev/mtd4

7. Reboot the device

   $ reboot

Signed-off-by: David Bauer <mail@david-bauer.net>
(cherry picked from commit https://github.com/openwrt/openwrt/commit/bf94e0a38389b2ce5d33be9c97d104d36dd5ebd6)