### PR TITLE
qualcommax: add SMP affinity script

### DIFF
--- a/target/linux/qualcommax/ipq807x/base-files/etc/init.d/smp_affinity
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/init.d/smp_affinity
@@ -1,0 +1,36 @@
+#!/bin/sh /etc/rc.common
+
+START=93
+
+enable_affinity_ipq807x() {
+	set_affinity() {
+		irq=$(awk "/$1/{ print substr(\$1, 1, length(\$1)-1); exit }" /proc/interrupts)
+		[ -n "$irq" ] && echo $2 > /proc/irq/$irq/smp_affinity
+	}
+
+	# assign 4 rx interrupts to each core
+	set_affinity 'reo2host-destination-ring1' 1
+	set_affinity 'reo2host-destination-ring2' 2
+	set_affinity 'reo2host-destination-ring3' 4
+	set_affinity 'reo2host-destination-ring4' 8
+
+	# assign 3 tcl completions to last 3 CPUs
+	set_affinity 'wbm2host-tx-completions-ring1' 2
+	set_affinity 'wbm2host-tx-completions-ring2' 4
+	set_affinity 'wbm2host-tx-completions-ring3' 8
+
+	# assign 3 ppdu mac interrupts to last 3 cores
+	set_affinity 'ppdu-end-interrupts-mac1' 2
+	set_affinity 'ppdu-end-interrupts-mac2' 4
+	set_affinity 'ppdu-end-interrupts-mac3' 8
+
+	# assign lan/wan to core 4
+	set_affinity 'edma_txcmpl' 8
+	set_affinity 'edma_rxfill' 8
+	set_affinity 'edma_rxdesc' 8
+	set_affinity 'edma_misc' 8
+}
+
+boot() {
+	enable_affinity_ipq807x
+}


### PR DESCRIPTION
By default Linux will default to most IRQ-s being mapped to core 0 which during high loads will completely swamp the core 0, so lets add the widely used script that has been floating around forums for a long time to try and optimize the IRQ mapping a bit.

This would really benefit from a wider testing, so I am opening this PR for that reason.
