### PR TITLE
ath79: read back reset register

### DIFF
--- a/target/linux/ath79/patches-5.15/100-reset-ath79-read-back-reset-register.patch
+++ b/target/linux/ath79/patches-5.15/100-reset-ath79-read-back-reset-register.patch
@@ -1,0 +1,33 @@
+From 661edfc3dab943a67c8821353b63cc23057f7ce9 Mon Sep 17 00:00:00 2001
+From: David Bauer <mail@david-bauer.net>
+Date: Tue, 9 Jan 2024 20:48:46 +0100
+Subject: [PATCH] reset: ath79: read back reset register
+
+Read back the reset register in order to flush the cache. This fixes
+spurious reboot hangs on TP-Link TL-WDR3600 and TL-WDR4300 with Zentel
+DRAM chips.
+
+This issue was fixed in the past, but switching to the reset-driver
+specific implementation removed the old fix.
+
+Link: https://github.com/freifunk-gluon/gluon/issues/2904
+Link: https://github.com/openwrt/openwrt/issues/13043
+Link: https://dev.archive.openwrt.org/ticket/17839
+Link: f8a7bfe1cb2c ("MIPS: ath79: fix system restart")
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+---
+ drivers/reset/reset-ath79.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/reset/reset-ath79.c
++++ b/drivers/reset/reset-ath79.c
+@@ -37,6 +37,8 @@ static int ath79_reset_update(struct res
+ 	else
+ 		val &= ~BIT(id);
+ 	writel(val, ath79_reset->base);
++	/* Flush cache */
++	readl(ath79_reset->base);
+ 	spin_unlock_irqrestore(&ath79_reset->lock, flags);
+ 
+ 	return 0;

--- a/target/linux/ath79/patches-6.1/100-reset-ath79-read-back-reset-register.patch
+++ b/target/linux/ath79/patches-6.1/100-reset-ath79-read-back-reset-register.patch
@@ -1,0 +1,33 @@
+From 661edfc3dab943a67c8821353b63cc23057f7ce9 Mon Sep 17 00:00:00 2001
+From: David Bauer <mail@david-bauer.net>
+Date: Tue, 9 Jan 2024 20:48:46 +0100
+Subject: [PATCH] reset: ath79: read back reset register
+
+Read back the reset register in order to flush the cache. This fixes
+spurious reboot hangs on TP-Link TL-WDR3600 and TL-WDR4300 with Zentel
+DRAM chips.
+
+This issue was fixed in the past, but switching to the reset-driver
+specific implementation removed the old fix.
+
+Link: https://github.com/freifunk-gluon/gluon/issues/2904
+Link: https://github.com/openwrt/openwrt/issues/13043
+Link: https://dev.archive.openwrt.org/ticket/17839
+Link: f8a7bfe1cb2c ("MIPS: ath79: fix system restart")
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+---
+ drivers/reset/reset-ath79.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/reset/reset-ath79.c
++++ b/drivers/reset/reset-ath79.c
+@@ -37,6 +37,8 @@ static int ath79_reset_update(struct res
+ 	else
+ 		val &= ~BIT(id);
+ 	writel(val, ath79_reset->base);
++	/* Flush cache */
++	readl(ath79_reset->base);
+ 	spin_unlock_irqrestore(&ath79_reset->lock, flags);
+ 
+ 	return 0;


### PR DESCRIPTION
Read back the reset register in order to flush the cache. This fixes spurious reboot hangs on TP-Link TL-WDR3600 and TL-WDR4300 with Zentel DRAM chips.

This issue was fixed in the past, but switching to the reset-driver specific implementation removed the cache barrier which was previously implicitly added by reading back the register in question.

Link: https://github.com/freifunk-gluon/gluon/issues/2904
Link: https://github.com/openwrt/openwrt/issues/13043
Link: https://dev.archive.openwrt.org/ticket/17839
Link: f8a7bfe1cb2c ("MIPS: ath79: fix system restart")