### PR TITLE
[22.03] ath79: read back reset register

### DIFF
--- a/target/linux/ath79/patches-5.10/100-reset-ath79-read-back-reset-register.patch
+++ b/target/linux/ath79/patches-5.10/100-reset-ath79-read-back-reset-register.patch
@@ -1,0 +1,38 @@
+From 5d25f925d3f72ceadf922f946d5422ad77fbfc20 Mon Sep 17 00:00:00 2001
+From: David Bauer <mail@david-bauer.net>
+Date: Thu, 11 Jan 2024 13:01:18 +0100
+Subject: [PATCH] reset: ath79: read back reset register
+
+Read back the reset register in order to flush the cache. This fixes
+spurious reboot hangs on TP-Link TL-WDR3600 and TL-WDR4300 with Zentel
+DRAM chips.
+
+This issue was fixed in the past, but switching to the reset-driver
+specific implementation removed the old fix.
+
+Link: https://github.com/freifunk-gluon/gluon/issues/2904
+Link: https://github.com/openwrt/openwrt/issues/13043
+Link: https://dev.archive.openwrt.org/ticket/17839
+Link: f8a7bfe1cb2c ("MIPS: ath79: fix system restart")
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+---
+ drivers/reset/reset-ath79.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/reset/reset-ath79.c b/drivers/reset/reset-ath79.c
+index e48d8fcb3133..ed368bf3ff3b 100644
+--- a/drivers/reset/reset-ath79.c
++++ b/drivers/reset/reset-ath79.c
+@@ -37,6 +37,8 @@ static int ath79_reset_update(struct reset_controller_dev *rcdev,
+ 	else
+ 		val &= ~BIT(id);
+ 	writel(val, ath79_reset->base);
++	/* Flush cache */
++	readl(ath79_reset->base);
+ 	spin_unlock_irqrestore(&ath79_reset->lock, flags);
+ 
+ 	return 0;
+-- 
+2.34.1
+


### PR DESCRIPTION
Backport of  #14378 to kernel 5.10.206.
With this patch applied, I was able to reboot an affected TP-Link WDR4300 50+ times without any hangs.

cc @blocktrron 