### PR TITLE
ipq807x: yuncore ax880 add dualboot support

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq807x
@@ -19,6 +19,7 @@ netgear,wax630)
 	;;
 compex,wpq873|\
 edgecore,eap102|\
+yuncore,ax880|\
 zyxel,nbg7815)
 	idx="$(find_mtd_index 0:appsblenv)"
 	[ -n "$idx" ] && \

--- a/target/linux/qualcommax/ipq807x/base-files/etc/init.d/bootcount
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/init.d/bootcount
@@ -4,8 +4,7 @@ START=99
 
 boot() {
 	case $(board_name) in
-	edgecore,eap102|\
-	yuncore,ax880)
+	edgecore,eap102)
 		fw_setenv upgrade_available 0
 		# Unset changed flag after sysupgrade complete
 		fw_setenv changed
@@ -13,6 +12,13 @@ boot() {
 	linksys,mx4200v1|\
 	linksys,mx4200v2)
 		mtd resetbc s_env || true
+	;;
+	yuncore,ax880)
+		(
+		# Using brackets and & to prevent block on sleep
+		echo resetting owrt_bootcount in 5 min...
+		sleep 300 && fw_setenv owrt_bootcount 0
+		) &
 	;;
 	esac
 }

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -4,6 +4,28 @@ REQUIRE_IMAGE_METADATA=1
 RAMFS_COPY_BIN='fw_printenv fw_setenv head'
 RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 
+ax880_env_setup() {
+	local ubifile=$(board_name)
+	local active=$(fw_printenv -n owrt_slotactive)
+	[ -z "$active" ] && active=$(hexdump -s 0x94 -n 4 -e '4 "%d"' /dev/mtd$(find_mtd_index 0:bootconfig))
+	cat > /tmp/env_tmp << EOF
+owrt_slotactive=${active}
+owrt_bootcount=0
+bootfile=${ubifile}.ubi
+owrt_bootcountcheck=if test \$owrt_bootcount > 4; then run owrt_tftprecover; fi; if test \$owrt_bootcount = 3; then run owrt_slotswap; else echo bootcountcheck successfull; fi
+owrt_bootinc=if test \$owrt_bootcount < 5; then echo save env part; setexpr owrt_bootcount \${owrt_bootcount} + 1 && saveenv; else echo save env skipped; fi; echo current bootcount: \$owrt_bootcount
+bootcmd=run owrt_bootinc && run owrt_bootcountcheck && run owrt_slotselect && run owrt_bootlinux
+owrt_bootlinux=echo booting linux... && ubi part fs && ubi read 0x44000000 kernel && bootm; reset
+owrt_setslot0=setenv bootargs console=ttyMSM0,115200n8 ubi.mtd=rootfs rootwait && setenv mtdparts mtdparts=nand0:0x3400000@0(fs)
+owrt_setslot1=setenv bootargs console=ttyMSM0,115200n8 ubi.mtd=rootfs_1 rootwait && setenv mtdparts mtdparts=nand0:0x3400000@0x3c00000(fs)
+owrt_slotswap=setexpr owrt_slotactive 1 - \${owrt_slotactive} && saveenv && echo slot swapped. new active slot: \$owrt_slotactive
+owrt_slotselect=setenv mtdids nand0=nand0,nand1=spi0.0; if test \$owrt_slotactive = 0; then run owrt_setslot0; else run owrt_setslot1; fi
+owrt_tftprecover=echo trying to recover firmware with tftp... && sleep 10 && dhcp && flash rootfs && flash rootfs_1 && setenv owrt_bootcount 0 && setenv owrt_slotactive 0 && saveenv && reset
+owrt_env_ver=7
+EOF
+	fw_setenv --script /tmp/env_tmp
+}
+
 xiaomi_initramfs_prepare() {
 	# Wipe UBI if running initramfs
 	[ "$(rootfs_type)" = "tmpfs" ] || return 0
@@ -114,15 +136,18 @@ platform_do_upgrade() {
 		nand_do_upgrade "$1"
 		;;
 	yuncore,ax880)
-		active="$(fw_printenv -n active)"
-		if [ "$active" -eq "1" ]; then
-			CI_UBIPART="rootfs_1"
-		else
+		#create env vars if needed
+		[ "$(fw_printenv -n owrt_env_ver 2>/dev/null)" != "7" ] && ax880_env_setup
+		active="$(fw_printenv -n owrt_slotactive 2>/dev/null)"
+		if [ "$active" = "1" ]; then
 			CI_UBIPART="rootfs"
+		else
+			CI_UBIPART="rootfs_1"
 		fi
-		# force altbootcmd which handles partition change in u-boot
-		fw_setenv bootcount 3
-		fw_setenv upgrade_available 1
+		# reset bootcount
+		fw_setenv owrt_bootcount 0
+		#switch active fw slot
+		fw_setenv owrt_slotactive $((1 - active))
 		nand_do_upgrade "$1"
 		;;
 	zte,mf269)


### PR DESCRIPTION
ipq807x: this pr corrects some shortcomings for the yuncore ax880 and add dualboot support for this device

- new env vars will be saved to the env part on sysupgrade via platform.sh script
- bootable slot is controller by env var owrt_active instead of stock fw smem controlled bootable slot. 
- uboot will increment bootcount env var on each boot, bootcount script will reset this counter on successfull and stable boot (5 min after boot)
- sysupgrade will flash new fw to the unused slot based on env var owrt_active
