### PR TITLE
rockchip: fix boot from non-MMC devices

### DIFF
--- a/target/linux/rockchip/image/Makefile
+++ b/target/linux/rockchip/image/Makefile
@@ -21,7 +21,7 @@ endef
 
 define Build/boot-script
 	# Make an U-boot image and copy it to the boot partition
-	mkimage -A arm -O linux -T script -C none -a 0 -e 0 -d $(if $(1),$(1),mmc).bootscript $@.boot/boot.scr
+	mkimage -A arm -O linux -T script -C none -a 0 -e 0 -d $(if $(1),$(1),default).bootscript $@.boot/boot.scr
 endef
 
 define Build/pine64-img

--- a/target/linux/rockchip/image/default.bootscript
+++ b/target/linux/rockchip/image/default.bootscript
@@ -1,4 +1,4 @@
-part uuid mmc ${devnum}:2 uuid
+part uuid ${devtype} ${devnum}:2 uuid
 
 if test $stdout = 'serial@fe660000' ;
 then serial_addr=',0xfe660000';
@@ -10,6 +10,6 @@ fi;
 
 setenv bootargs "console=ttyS2,1500000 console=tty1 earlycon=uart8250,mmio32${serial_addr} swiotlb=1 root=PARTUUID=${uuid} rw rootwait";
 
-load mmc ${devnum}:1 ${kernel_addr_r} kernel.img
+load ${devtype} ${devnum}:1 ${kernel_addr_r} kernel.img
 
 bootm ${kernel_addr_r}


### PR DESCRIPTION
Booting from non-MMC devices on Rockchip targets without this
change results in a boot failure:

```
Model: FriendlyElec NanoPi R5S
Net:   eth0: ethernet@fe2a0000
Hit any key to stop autoboot:  0
** Booting bootflow 'nvme#0.blk#1.bootdev.part_1' with script
** No partition table - mmc 0 **
** No partition table - mmc 0 **
Couldn't find partition mmc 0:1
Can't set block device
Wrong Image Type for bootm command
ERROR -91: Protocol wrong type for socket: can't get kernel image!
Boot failed (err=1)
```

This change fixes the default boot script for Rockchip targets to
support booting from non-MMC devices such as NVMe or USB drives.

Some targets with only a boot rom (e.g. NanoPi R5S) may require u-boot
to be installed on the eMMC or a MicroSD card in order to boot from
non-MMC devices.

Fixes: #14420