### PR TITLE
ramips: add support for Netgear WAX214v2

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -146,6 +146,10 @@ xiaomi,mi-router-cr6608|\
 xiaomi,mi-router-cr6609)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x20000"
 	;;
+netgear,wax214v2)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	ubootenv_add_uci_sys_config "/dev/mtd1" "0x20000" "0x8000" "0x20000"
+	;;
 esac
 
 config_load ubootenv

--- a/target/linux/ramips/dts/mt7621_netgear_wax214v2.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_wax214v2.dts
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "netgear,wax214v2", "mediatek,mt7621-soc";
+	model = "Netgear WAX214v2";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_amber;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_blue;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_green: power_green {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_blue: power_blue {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_amber: power_amber {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wifin_green {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		wifia_green {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x80000>;
+		};
+
+		partition@100000 {
+			label = "Factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				precal_factory_e10: precal@e10 {
+					reg = <0xe10 0x19c10>;
+				};
+			};
+		};
+
+		partition@180000 {
+			label = "firmware";
+			reg = <0x180000 0x2600000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x2200000>;
+			};
+		};
+
+		partition@2780000 {
+			label = "firmware_backup";
+			reg = <0x2780000 0x2600000>;
+			read-only;
+		};
+
+		partition@4d80000 {
+			label = "CFG";
+			reg = <0x4d80000 0x800000>;
+			read-only;
+		};
+
+		partition@5580000 {
+			label = "RAE";
+			reg = <0x5580000 0x400000>;
+			read-only;
+		};
+
+		partition@5980000 {
+			label = "POT";
+			reg = <0x5980000 0x100000>;
+			read-only;
+		};
+
+		partition@5a80000 {
+			label = "Language";
+			reg = <0x5a80000 0x400000>;
+			read-only;
+		};
+
+		partition@5e80000 {
+			label = "Traffic";
+			reg = <0x5e80000 0x200000>;
+			read-only;
+		};
+
+		partition@6080000 {
+			label = "Cert";
+			reg = <0x6080000 0x100000>;
+			read-only;
+		};
+
+		partition@6180000 {
+			label = "NTGRcryptK";
+			reg = <0x6180000 0x100000>;
+			read-only;
+		};
+
+		partition@6280000 {
+			label = "NTGRcryptD";
+			reg = <0x6280000 0x500000>;
+			read-only;
+		};
+
+		partition@6780000 {
+			label = "LOG";
+			reg = <0x6780000 0x100000>;
+			read-only;
+		};
+
+		partition@6880000 {
+			label = "User_data";
+			reg = <0x6880000 0x640000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "uart2", "jtag";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2113,6 +2113,24 @@ define Device/netgear_wax202
 endef
 TARGET_DEVICES += netgear_wax202
 
+define Device/netgear_wax214v2
+  $(Device/nand)
+  DEVICE_VENDOR := NETGEAR
+  DEVICE_MODEL := WAX214v2
+  DEVICE_PACKAGES := kmod-mt7915-firmware
+  NETGEAR_ENC_MODEL := WAX214v2
+  NETGEAR_ENC_REGION := US
+  IMAGE_SIZE := 38912k
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel 0x80001000 | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
+	append-squashfs4-fakeroot
+  IMAGES += factory.img
+  IMAGE/factory.img := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size | netgear-encrypted-factory
+endef
+TARGET_DEVICES += netgear_wax214v2
+
 define Device/netgear_wndr3700-v5
   $(Device/dsa-migration)
   $(Device/netgear_sercomm_nor)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -47,6 +47,7 @@ ramips_setup_interfaces()
 	mikrotik,routerboard-m11g|\
 	netgear,eax12|\
 	netgear,ex6150|\
+	netgear,wax214v2|\
 	sercomm,na502|\
 	sercomm,na502s|\
 	thunder,timecloud|\
@@ -323,6 +324,10 @@ ramips_setup_macs()
 	netgear,wax202)
 		lan_mac=$(mtd_get_mac_ascii Config mac)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
+		label_mac=$lan_mac
+		;;
+	netgear,wax214v2)
+		lan_mac=$(mtd_get_mac_ascii Config ethaddr)
 		label_mac=$lan_mac
 		;;
 	yuncore,ax820)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -153,6 +153,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 3 > /sys${DEVPATH}/macaddress
 		;;
+	netgear,wax214v2)
+		hw_mac_addr=$(mtd_get_mac_ascii Config ethaddr)
+		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 3 > /sys${DEVPATH}/macaddress
+		;;
 	mercusys,mr70x-v1|\
 	tplink,archer-ax23-v1)
 		hw_mac_addr="$(mtd_get_mac_binary config 0x8)"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -122,6 +122,7 @@ platform_do_upgrade() {
 	netgear,wac104|\
 	netgear,wac124|\
 	netgear,wax202|\
+	netgear,wax214v2|\
 	netis,wf2881|\
 	raisecom,msg1500-x-00|\
 	rostelecom,rt-fe-1a|\


### PR DESCRIPTION
Netgear WAX214v2 is an 802.11ax (Wi-Fi 6) wireless access point.

Specifications:
* SoC: MediaTek MT7621AT
* RAM: 512 MiB
* Flash: NAND 128 MiB (ESMT PSU1GA30DT)
* Wi-Fi: 2.4/5 GHz 4T4R (MediaTek MT7915E)
* Ethernet: 1x 10/100/1000 Mbps LAN
* Switch: MediaTek MT7530 (SoC built-in)
* LEDs/Keys
  * Power (green, blue, amber)
  * LAN (green, amber)
  * WLAN 2.4GHz (green, blue)
  * WLAN 5GHz (green, blue)
  * Reset button
* USB: None
* UART: Marked J1 on board, 115200 8N1
* Power
  * 12 VDC, 1.5 A
  * IEEE 802.3at (PoE+)

Load addresses (same as Netgear WAX202):
* stock
  * 0x80010000: FIT image
  * 0x81001000: kernel image -> entry
* OpenWrt
  * 0x80010000: FIT image
  * 0x82000000: uncompressed kernel+relocate image
  * 0x80001000: relocated kernel image -> entry

MAC addresses as verified by OEM firmware:

| vendor | OpenWrt | address |
| ------ | ------- | ------- |
| eth0 | lan | label |
| ra0 | phy0 | label + 2 |
| rax0 | phy1 | label + 3 |

Installation:
* Flash the factory image by TFTP to the bootloader. NMRP can be used to TFTP without opening the case.

Revert to stock firmware:
* Flash the stock firmware to the bootloader using TFTP/NMRP.

References to WAX214v2 GPL source:
https://www.downloads.netgear.com/files/GPL/WAX214v2-V1.0.1.5-gpl-src.tar.gz

* openwrt/target/linux/ramips/dts/mt7621-ax-nand-wax214v2.dts
  DTS file for this device.

Stock boot log: [netgear_wax214v2_stock_boot_log.txt](https://github.com/openwrt/openwrt/files/13939736/netgear_wax214v2_stock_boot_log.txt)

OpenWrt boot log: [netgear_wax214v2_openwrt_boot_log.txt](https://github.com/openwrt/openwrt/files/13939740/netgear_wax214v2_openwrt_boot_log.txt)

OpenWrt boot log (commit bc312043703b17ddd6ab039ea18fea0214b6b5f0): [netgear_wax214v2_openwrt_boot_log_commit_bc31204.txt](https://github.com/openwrt/openwrt/files/13962816/netgear_wax214v2_openwrt_boot_log_commit_bc31204.txt)

OpenWrt boot log (commit 1f2553e3841c83c88e3774dadffc2b0409cbb6f0): [netgear_wax214v2_openwrt_boot_log_commit_1f2553e.txt](https://github.com/openwrt/openwrt/files/13964412/netgear_wax214v2_openwrt_boot_log_commit_1f2553e.txt)

OpenWrt boot log (commit d3977eb9d11de116d739fd5b925e40f7c3199069): [netgear_wax214v2_openwrt_boot_log_commit_d3977eb.txt](https://github.com/openwrt/openwrt/files/13964661/netgear_wax214v2_openwrt_boot_log_commit_d3977eb.txt)

OpenWrt boot log (commit 8a515d4300e423e00d7e7fc0b643bfe17e349f5f): [netgear_wax214v2_openwrt_boot_log_commit_8a515d4.txt](https://github.com/user-attachments/files/15519704/netgear_wax214v2_openwrt_boot_log_commit_8a515d4.txt)

OpenWrt boot log (commit f212d365bae7fbd75913b65f31296480d86171c0): [netgear_wax214v2_openwrt_boot_log_commit_f212d36.txt](https://github.com/user-attachments/files/16112574/netgear_wax214v2_openwrt_boot_log_commit_f212d36.txt)