### PR TITLE
ksmbd: only v2 leases handle the directory

### DIFF
--- a/target/linux/generic/pending-6.1/540-ksmbd-oplock_fix.patch
+++ b/target/linux/generic/pending-6.1/540-ksmbd-oplock_fix.patch
@@ -1,0 +1,15 @@
+--- a/fs/smb/server/oplock.c
++++ b/fs/smb/server/oplock.c
+@@ -1190,6 +1190,12 @@ int smb_grant_oplock(struct ksmbd_work *
+ 	struct ksmbd_inode *ci = fp->f_ci;
+ 	bool prev_op_has_lease;
+ 	__le32 prev_op_state = 0;
++	
++	/* Only v2 leases handle the directory */
++	if (S_ISDIR(file_inode(fp->filp)->i_mode)) {
++		if (!lctx || lctx->version != 2)
++			return 0;
++	}
+ 
+ 	opinfo = alloc_opinfo(work, pid, tid);
+ 	if (!opinfo)


### PR DESCRIPTION
When smb2 leases is disable, ksmbd can send oplock break notification
and cause wait oplock break ack timeout. It may appear like hang when
accessing a directory. This patch make only v2 leases handle the
directory.

Cc: stable@vger.kernel.org
Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>
Signed-off-by: Steve French <stfrench@microsoft.com>

Solve issue: https://forum.openwrt.org/t/ksmbd-samba3-4-alternative-ex-cifsd-smbd-package-support-thread/51695/349

Let me know if is ok now, sorry guys I'm a newbie






