### PR TITLE
bcm27xx-utils: add new package

### DIFF
--- a/package/utils/bcm27xx-utils/Makefile
+++ b/package/utils/bcm27xx-utils/Makefile
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bcm27xx-utils
+PKG_VERSION:=2024-01-15
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/raspberrypi/utils.git
+PKG_SOURCE_VERSION:=32602f565c6cb854d1f2643b51a022991cea2b1b
+PKG_MIRROR_HASH:=efbfa0f1aabbe9ecb347c3a27629fb757f67ff283c8d3b1ee7376ddc6925127b
+
+PKG_FLAGS:=nonshared
+
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENCE
+
+CMAKE_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/bcm27xx-utils
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=@TARGET_bcm27xx +libfdt
+  TITLE:=BCM27xx scripts and simple applications
+  PROVIDES:=bcm27xx-userland
+endef
+
+define Package/bcm27xx-utils/description
+  BCM27xx scripts and simple applications.
+  Replaces bcm27xx-userland scripts and applications.
+endef
+
+define Package/bcm27xx-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/dtmerge $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/dtoverlay $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/dtparam $(1)/usr/bin
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/eepdump $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/eepflash.sh $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/eepmake $(1)/usr/bin
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/otpset $(1)/usr/bin
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/overlaycheck $(1)/usr/bin
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/bin/overlaycheck_exclusions.txt $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ovmerge $(1)/usr/bin
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/pinctrl $(1)/usr/bin
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/raspinfo $(1)/usr/bin
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/vcgencmd $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/vclog $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/vcmailbox $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,bcm27xx-utils))

--- a/package/utils/bcm27xx-utils/patches/0001-raspinfo-adapt-to-OpenWrt.patch
+++ b/package/utils/bcm27xx-utils/patches/0001-raspinfo-adapt-to-OpenWrt.patch
@@ -1,0 +1,255 @@
+From 0db3fb3119eda8c2360454c2a01f84602a879c38 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
+Date: Tue, 16 Jan 2024 15:32:12 +0100
+Subject: [PATCH] raspinfo: adapt to OpenWrt
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+---
+ raspinfo/raspinfo | 186 ++++------------------------------------------
+ 1 file changed, 13 insertions(+), 173 deletions(-)
+
+--- a/raspinfo/raspinfo
++++ b/raspinfo/raspinfo
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/bin/sh
+ 
+ # Some of the regex's used in sed
+ # Catch basic IP6 address   "s/\([0-9a-fA-F]\{1,4\}:\)\{7,7\}[0-9a-fA-F]\{1,4\}/y.y.y.y.y.y.y.y/g"
+@@ -6,147 +6,6 @@
+ # IP4 d.d.d.d decimal	    "s/\([0-9]\{1,3\}\.\)\{3,3\}[0-9]\{1,3\}/x.x.x.x/g"
+ # mac address	            "s/\([0-9a-fA-F]\{2,2\}\:\)\{5,5\}[0-9a-fA-F]\{2,2\}/m.m.m.m/g"
+ 
+-
+-display_info_drm() {
+-   # If running X then can use xrandr, otherwise
+-   # dump the /sys/class entries for the displays
+-   if command -v xrandr > /dev/null &&
+-      DISPLAY=${DISPLAY:-:0} xrandr --listmonitors &>/dev/null;
+-   then
+-      echo "Running (F)KMS and X"
+-      echo
+-
+-      DISPLAY=${DISPLAY:-:0} xrandr --verbose
+-   else
+-      echo "Running (F)KMS, console"
+-      echo
+-
+-      for card in /sys/class/drm/card[0-9]-*;
+-      do
+-         echo $card
+-
+-         # if kmsprint isn't installed print basic mode info
+-         if ! command -v kmsprint > /dev/null; then
+-            if [ -f $card/modes ];
+-            then
+-               cat $card/modes
+-            else
+-               echo "No modes found"
+-            fi
+-         fi
+-
+-         if [ -f $card/edid ];
+-         then
+-            base64 $card/edid
+-         else
+-            echo "No EDID found"
+-         fi
+-         echo
+-      done
+-   fi
+-
+-   # kmsprint is more useful, but not always installed
+-   echo
+-   if command -v kmsprint > /dev/null; then
+-      kmsprint
+-      echo
+-      kmsprint -m
+-   else
+-      echo "kmsprint is not installed. Install with: sudo apt install kms++-utils"
+-   fi
+-
+-   echo
+-
+-   # dump the /sys/class entries for the displays
+-   cardfound=0
+-   for card in `seq 0 9`;
+-   do
+-      if sudo test -f "/sys/kernel/debug/dri/${card}/state";
+-      then
+-        for hdmi in 0 1;
+-        do
+-         if sudo test -f "/sys/kernel/debug/dri/${card}/hdmi${hdmi}_regs";
+-         then
+-            echo "HDMI${hdmi}: $(sudo cat /sys/kernel/debug/dri/$card/hdmi${hdmi}_regs | grep HOTPLUG)"
+-         fi
+-      done
+-      echo
+-      echo "/sys/kernel/debug/dri/$card/state:"
+-      sudo cat "/sys/kernel/debug/dri/$card/state"
+-      echo
+-      cardfound=1
+-      fi
+-   done
+-   if [ "$cardfound" == "0" ];
+-   then
+-      echo "kms state not found"
+-   fi
+-   echo
+-
+-}
+-
+-display_info_legacy() {
+-   # Legacy mode
+-   echo "Running Legacy framebuffer"
+-   echo
+-
+-   for card in `seq 0 9`;
+-   do
+-      F="/dev/fb${card}"
+-      if test -e $F;
+-      then
+-         echo Framebuffer: $F
+-         fbset -s -fb $F
+-      fi
+-   done
+-
+-   disps=`tvservice -l | awk '/Display Number/{print substr($3,1,1)}'`
+-
+-   tmp=$(mktemp)
+-
+-   for display in $disps
+-   do
+-      echo
+-      echo "Display: " $display
+-
+-      tvservice -v $display -s
+-      tvservice -v $display -n
+-      tvservice -v $display -m CEA
+-      tvservice -v $display -m DMT
+-
+-      echo
+-      tvservice -v $display -d $tmp > /dev/null
+-      base64 $tmp
+-   done
+-
+-   rm $tmp
+-}
+-
+-display_info() {
+-   # Check if we are running a KMS/DRM system
+-
+-   if [ -d "/dev/dri" ];
+-   then
+-      display_info_drm
+-   else
+-      display_info_legacy
+-   fi
+-}
+-
+-audio_info() {
+-   aplay -l
+-   echo
+-   aplay -L
+-   echo
+-   systemctl --user status pipewire.socket pipewire.service pulseaudio.service pulseaudio.socket
+-   echo
+-   if command -v pactl > /dev/null; then
+-      pactl info
+-   else
+-      echo pactl not installed
+-   fi
+-}
+-
+ OUT=raspinfo.txt
+ 
+ rm -f $OUT
+@@ -163,8 +22,6 @@ echo
+ cat /etc/os-release | head -4
+ echo
+ 
+-cat /etc/rpi-issue
+-echo
+ uname -a
+ 
+ cat /proc/cpuinfo | tail -3
+@@ -190,17 +47,6 @@ echo
+ cat /proc/swaps
+ 
+ echo
+-echo "Package version information"
+-echo "---------------------------"
+-
+-apt-cache policy raspberrypi-ui-mods | head -2
+-apt-cache policy raspberrypi-sys-mods | head -2
+-apt-cache policy openbox | head -2
+-apt-cache policy lxpanel | head -2
+-apt-cache policy pcmanfm | head -2
+-apt-cache policy rpd-plym-splash | head -2
+-
+-echo
+ echo "Networking Information"
+ echo "----------------------"
+ echo
+@@ -212,21 +58,11 @@ echo "USB Information"
+ echo "---------------"
+ echo
+ 
+-lsusb -t
+-
+-echo
+-echo "Display Information"
+-echo "-------------------"
+-echo
+-
+-display_info
+-
+-echo
+-echo "Audio Information"
+-echo "-------------------"
+-echo
+-
+-audio_info
++if command -v lsusb > /dev/null; then
++   lsusb -t
++else
++   echo usbutils not installed
++fi
+ 
+ echo
+ echo "config.txt"
+@@ -250,7 +86,7 @@ echo "-----------------"
+ echo
+ 
+ if command -v pinctrl > /dev/null; then
+-   sudo pinctrl 2>&1
++   pinctrl 2>&1
+ elif command -v raspi-gpio > /dev/null; then
+    raspi-gpio get 2>&1
+ else
+@@ -263,9 +99,9 @@ echo "------------------"
+ echo
+ 
+ if command -v vcdbg > /dev/null; then
+-   sudo vcdbg log msg 2>&1
++   vcdbg log msg 2>&1
+ elif command -v vclog > /dev/null; then
+-   sudo vclog --msg 2>&1
++   vclog --msg 2>&1
+ else
+    echo "vcdbg not found"
+ fi
+@@ -284,5 +120,9 @@ echo
+ echo "EEPROM"
+ echo "------"
+ echo
+-sudo rpi-eeprom-update
++if command -v rpi-eeprom-update > /dev/null; then
++   rpi-eeprom-update
++else
++   echo bcm27xx-eeprom not installed
++fi
+ fi


### PR DESCRIPTION
According to https://github.com/raspberrypi/userland/commit/96a7334ae9d5fc9db7ac92e59852377df63f1848, the userland repository has been deprecated and the useful tools have been moved to the utils repository:
https://github.com/raspberrypi/utils
Add new bcm27xx-utils package in preparation for a future deprecation of bcm27xx-userland.