### PR TITLE
ramips: convert MT7621 wireless calibration EEPROM to NVMEM format Part.2

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -104,8 +104,16 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
+				};
+
+				precal_factory_e10: precal@e10 {
+					reg = <0xe10 0x19c10>;
 				};
 			};
 		};
@@ -157,7 +165,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_asus_rt-ax54.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax54.dts
@@ -96,8 +96,16 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
+				};
+
+				precal_factory_e10: precal@e10 {
+					reg = <0xe10 0x19c10>;
 				};
 			};
 		};
@@ -130,7 +138,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_comfast_cf-e390ax.dts
+++ b/target/linux/ramips/dts/mt7621_comfast_cf-e390ax.dts
@@ -59,7 +59,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -95,6 +96,10 @@
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
 
 					macaddr_factory_e000: macaddr@e000 {
 						compatible = "mac-base";

--- a/target/linux/ramips/dts/mt7621_cudy_m1800.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_m1800.dts
@@ -80,7 +80,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };
@@ -116,6 +117,16 @@
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+				};
 			};
 
 			partition@50000 {

--- a/target/linux/ramips/dts/mt7621_cudy_x6.dtsi
+++ b/target/linux/ramips/dts/mt7621_cudy_x6.dtsi
@@ -79,6 +79,16 @@
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+				};
 			};
 
 			/* additional partitions in DTS */
@@ -94,7 +104,8 @@
 	wifi:wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_covr-x1860-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_covr-x1860-a1.dts
@@ -98,6 +98,20 @@
 			label = "factory";
 			reg = <0x100000 0x80000>;
 			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				precal_factory_e10: precal@e10 {
+					reg = <0xe10 0x19c10>;
+				};
+			};
 		};
 
 		partition@180000 {
@@ -155,7 +169,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dap-x1860-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dap-x1860-a1.dts
@@ -134,8 +134,16 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					reg = <0x4 0x6>;
+				};
+
+				precal_factory_e10: precal@e10 {
+					reg = <0xe10 0x19c10>;
 				};
 			};
 		};
@@ -177,7 +185,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr2.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr2.dts
@@ -7,6 +7,11 @@
 	model = "I-O DATA WN-AX1167GR2";
 };
 
+/* override EEPROM size to 0x4da8 for MT7615 */
+&eeprom_factory_0 {
+	reg = <0x0 0x4da8>;
+};
+
 &partitions {
 	partition@6b00000 {
 		label = "Backup";
@@ -19,6 +24,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };

--- a/target/linux/ramips/dts/mt7621_iodata_wn-ax2033gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-ax2033gr.dts
@@ -19,8 +19,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2483000>;
 	};
 };
@@ -29,8 +29,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 5710000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_iodata_wn-deax1800gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-deax1800gr.dts
@@ -137,6 +137,10 @@
 					reg = <0x4 0x6>;
 					#nvmem-cell-cells = <1>;
 				};
+
+				precal: precal@e10 {
+					reg = <0xe10 0x19c10>;
+				};
 			};
 		};
 
@@ -221,8 +225,8 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 
-		nvmem-cells = <&eeprom>;
-		nvmem-cell-names = "eeprom";
+		nvmem-cells = <&eeprom>, <&precal>;
+		nvmem-cell-names = "eeprom", "precal";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_iodata_wn-dx1167r.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-dx1167r.dts
@@ -7,6 +7,11 @@
 	model = "I-O DATA WN-DX1167R";
 };
 
+/* override EEPROM size to 0x4da8 for MT7615 */
+&eeprom_factory_0 {
+	reg = <0x0 0x4da8>;
+};
+
 &partitions {
 	partition@6b00000 {
 		label = "idmkey";
@@ -25,6 +30,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };

--- a/target/linux/ramips/dts/mt7621_iodata_wn-dx2033gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-dx2033gr.dts
@@ -25,7 +25,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2483000>;
 	};
 };
@@ -34,7 +35,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 5710000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_iodata_wn-xx-xr.dtsi
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-xx-xr.dtsi
@@ -86,6 +86,14 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};

--- a/target/linux/ramips/dts/mt7621_iptime_ax2004m.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_ax2004m.dts
@@ -82,10 +82,18 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
 				macaddr_factory_4: macaddr@4 {
 					compatible = "mac-base";
 					reg = <0x4 0x6>;
 					#nvmem-cell-cells = <1>;
+				};
+
+				precal_factory_e10: precal@e10 {
+					reg = <0xe10 0x19c10>;
 				};
 			};
 		};
@@ -170,6 +178,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
 	};
 };

--- a/target/linux/ramips/dts/mt7621_linksys_ea6350-v4.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_ea6350-v4.dts
@@ -7,6 +7,11 @@
 	model = "Linksys EA6350 v4";
 };
 
+/* override EEPROM size to 0x400 for MT7603 */
+&eeprom_factory_0 {
+	reg = <0x0 0x400>;
+};
+
 &gmac1 {
 	phy-handle = <&ethphy4>;
 };

--- a/target/linux/ramips/dts/mt7621_linksys_ea7300-v2.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_ea7300-v2.dts
@@ -6,3 +6,8 @@
 	compatible = "linksys,ea7300-v2", "mediatek,mt7621-soc";
 	model = "Linksys EA7300 v2";
 };
+
+/* override EEPROM size to 0x400 for MT7603 */
+&eeprom_factory_0 {
+	reg = <0x0 0x400>;
+};

--- a/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
+++ b/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
@@ -101,6 +101,20 @@
 			label = "factory";
 			reg = <0xc0000 0x40000>;
 			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+			};
 		};
 
 		partition@100000 {
@@ -165,7 +179,8 @@
 	mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -173,7 +188,8 @@
 	mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_mercusys_mr70x-v1.dts
+++ b/target/linux/ramips/dts/mt7621_mercusys_mr70x-v1.dts
@@ -99,6 +99,16 @@
 				label = "radio";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_radio_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+				};
 			};
 		};
 	};
@@ -112,9 +122,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
-		nvmem-cells = <&macaddr_config_8 0>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_8 0>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_netgear_eax12.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_eax12.dts
@@ -110,6 +110,20 @@
 			label = "Factory";
 			reg = <0x100000 0x80000>;
 			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				precal_factory_e10: precal@e10 {
+					reg = <0xe10 0x19c10>;
+				};
+			};
 		};
 
 		partition@180000 {
@@ -171,7 +185,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_bzv.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_bzv.dtsi
@@ -147,7 +147,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -156,7 +157,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -347,6 +349,14 @@
 				compatible = "fixed-layout";
 				#address-cells = <1>;
 				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 
 				macaddr_factory_4: macaddr@4 {
 					compatible = "mac-base";

--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_chj.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_chj.dtsi
@@ -81,7 +81,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -90,7 +91,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -274,6 +276,14 @@
 				compatible = "fixed-layout";
 				#address-cells = <1>;
 				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
 
 				macaddr_factory_4: macaddr@4 {
 					compatible = "mac-base";

--- a/target/linux/ramips/dts/mt7621_tplink_archer-ax23-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-ax23-v1.dts
@@ -132,6 +132,16 @@
 				label = "radio";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_radio_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+				};
 			};
 		};
 	};
@@ -145,9 +155,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
-		nvmem-cells = <&macaddr_config_8 0>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_8 0>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_eap613-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap613-v1.dts
@@ -113,6 +113,16 @@
 				label = "radio";
 				reg = <0xff0000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_radio_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+				};
 			};
 		};
 	};
@@ -133,7 +143,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
+		nvmem-cells = <&eeprom_radio_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts
@@ -133,6 +133,16 @@
 				label = "radio";
 				reg = <0xff0000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_radio_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+				};
 			};
 		};
 	};
@@ -153,7 +163,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
+		nvmem-cells = <&eeprom_radio_0>;
+		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_ex220-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_ex220-v1.dts
@@ -161,6 +161,20 @@
 				label = "radio";
 				reg = <0x90000 0x20000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_radio_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+
+					precal_radio_e10: precal@e10 {
+						reg = <0xe10 0x19c10>;
+					};
+				};
 			};
 
 			partition@b0000 {
@@ -186,9 +200,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x0>;
-		nvmem-cells = <&macaddr_rom_file_f100 0>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_radio_0>, <&precal_radio_e10>, <&macaddr_rom_file_f100 0>;
+		nvmem-cell-names = "eeprom", "precal", "mac-address";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_ubnt_unifi-6-lite.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi-6-lite.dts
@@ -49,6 +49,14 @@
 					eeprom_factory_0: eeprom@0 {
 						reg = <0x0 0x400>;
 					};
+
+					eeprom_factory_20000: eeprom@20000 {
+						reg = <0x20000 0xe00>;
+					};
+
+					precal_factory_20e10: precal@20e10 {
+						reg = <0x20e10 0x19c10>;
+					};
 				};
 			};
 
@@ -112,8 +120,6 @@
 &wlan_5g {
 	compatible = "mediatek,mt76";
 
-	mediatek,mtd-eeprom = <&factory 0x20000>;
-
 	/* This is a workaround.
 	 *
 	 * Ubiquiti uses a +2 offset in the first octet relative
@@ -126,8 +132,8 @@
 	 * mac80211 increases the first octet by two for each VAP, leading
 	 * to conflicting MAC addresses for subsequent interfaces.
 	 */
-	nvmem-cells = <&macaddr_eeprom_6 1>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_eeprom_6 1>, <&eeprom_factory_20000>, <&precal_factory_20e10>;
+	nvmem-cell-names = "mac-address", "eeprom", "precal";
 
 	ieee80211-freq-limit = <5000000 6000000>;
 

--- a/target/linux/ramips/dts/mt7621_ubnt_unifi-flexhd.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi-flexhd.dts
@@ -61,6 +61,20 @@
 				label = "factory";
 				reg = <0x70000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
 			};
 
 			eeprom: partition@80000 {
@@ -128,22 +142,20 @@
 &pcie0 {
 	wifi@0,0 {
 		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
 		// On newer devices there is a MediaTek MAC in the above
 		// device EEPROM, so override it with a calculated one.
-		nvmem-cells = <&macaddr_eeprom_0 1>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_eeprom_0 1>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 
 &pcie1 {
 	wifi@0,0 {
 		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
 		// On newer devices there is a MediaTek MAC in the above
 		// device EEPROM, so override it with a calculated one.
-		nvmem-cells = <&macaddr_eeprom_0 2>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_eeprom_0 2>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_ubnt_unifi-nanohd.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi-nanohd.dts
@@ -36,6 +36,20 @@
 				label = "factory";
 				reg = <0x70000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
 			};
 
 			eeprom: partition@80000 {
@@ -86,9 +100,11 @@
 };
 
 &wlan_2g {
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &wlan_5g {
-	mediatek,mtd-eeprom = <&factory 0x8000>;
+	nvmem-cells = <&eeprom_factory_8000>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn533a8.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn533a8.dts
@@ -7,6 +7,11 @@
 	model = "Wavlink WL-WN533A8";
 };
 
+/* override EEPROM size to 0x4da8 for MT7615 */
+&eeprom_factory_0 {
+	reg = <0x0 0x4da8>;
+};
+
 &wifi0{
 	ieee80211-freq-limit = <2400000 5490000>;
 };

--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn53xax.dtsi
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn53xax.dtsi
@@ -101,6 +101,14 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+
 					macaddr_factory_e000: macaddr@e000 {
 						reg = <0xe000 0x6>;
 					};
@@ -134,7 +142,8 @@
 	wifi0: mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 
@@ -142,7 +151,8 @@
 	wifi1: mt76@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn573hx1.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn573hx1.dts
@@ -61,7 +61,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
 	};
 };
 
@@ -94,6 +95,14 @@
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+
+					precal_factory_e10: precal@e10 {
+						reg = <0xe10 0x19c10>;
+					};
 
 					macaddr_factory_3fff4: macaddr@3fff4 {
 						reg = <0x3fff4 0x6>;

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3g.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3g.dts
@@ -86,7 +86,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7603";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -95,7 +96,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4.dts
@@ -50,7 +50,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7603";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
@@ -59,7 +60,8 @@
 	wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-3g-v2.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-3g-v2.dtsi
@@ -23,12 +23,14 @@
 };
 
 &wifi0 {
-	mediatek,mtd-eeprom = <&factory 0x8000>;
+	nvmem-cells = <&eeprom_factory_8000>;
+	nvmem-cell-names = "eeprom";
 	ieee80211-freq-limit = <5000000 6000000>;
 };
 
 &wifi1 {
-	mediatek,mtd-eeprom = <&factory 0x0000>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 	ieee80211-freq-limit = <2400000 2500000>;
 };
 

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-common.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-common.dtsi
@@ -70,6 +70,14 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+
 					macaddr_factory_e000: macaddr@e000 {
 						reg = <0xe000 0x6>;
 					};

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-gigabit-v2.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-gigabit-v2.dts
@@ -35,6 +35,11 @@
 	};
 };
 
+/* override EEPROM size to 0x4da8 for MT7613 */
+&eeprom_factory_8000 {
+	reg = <0x8000 0x4da8>;
+};
+
 &partitions {
 	partition@180000 {
 		// size changed against to the common dtsi
@@ -49,12 +54,14 @@
 };
 
 &wifi0 {
-	mediatek,mtd-eeprom = <&factory 0x0000>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 	ieee80211-freq-limit = <2400000 2500000>;
 };
 
 &wifi1 {
-	mediatek,mtd-eeprom = <&factory 0x8000>;
+	nvmem-cells = <&eeprom_factory_8000>;
+	nvmem-cell-names = "eeprom";
 	ieee80211-freq-limit = <5000000 6000000>;
 };
 

--- a/target/linux/ramips/dts/mt7621_xiaomi_nand_128m.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_nand_128m.dtsi
@@ -56,6 +56,14 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x200>;
+				};
+
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};

--- a/target/linux/ramips/dts/mt7621_xiaomi_router-ac2100.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_router-ac2100.dtsi
@@ -2,6 +2,11 @@
 
 #include "mt7621_xiaomi_nand_128m.dtsi"
 
+/* override EEPROM size to 0x4da8 for MT7615 */
+&eeprom_factory_8000 {
+	reg = <0x8000 0x4da8>;
+};
+
 &pcie {
 	status = "okay";
 };
@@ -10,7 +15,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
@@ -19,7 +25,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
@@ -121,6 +121,14 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+
+					precal_factory_e10: precal@e10 {
+						reg = <0xe10 0x19c10>;
+					};
+
 					macaddr_factory_e000: macaddr@e000 {
 						compatible = "mac-base";
 						reg = <0xe000 0x6>;
@@ -146,7 +154,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_yuncore_fap640.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_fap640.dts
@@ -129,6 +129,14 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+
+					precal_factory_e10: precal@e10 {
+						reg = <0xe10 0x19c10>;
+					};
+
 					macaddr_factory_4: macaddr@4 {
 						reg = <0x4 0x6>;
 					};
@@ -156,7 +164,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_yuncore_fap690.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_fap690.dts
@@ -99,8 +99,16 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+
 					macaddr_factory_4: macaddr@4 {
 						reg = <0x4 0x6>;
+					};
+
+					precal_factory_e10: precal@e10 {
+						reg = <0xe10 0x19c10>;
 					};
 				};
 			};
@@ -122,7 +130,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_zyxel_nwa-ax.dtsi
+++ b/target/linux/ramips/dts/mt7621_zyxel_nwa-ax.dtsi
@@ -40,6 +40,20 @@
 			label = "factory";
 			reg = <0x100000 0x80000>;
 			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				precal_factory_e10: precal@e10 {
+					reg = <0xe10 0x19c10>;
+				};
+			};
 		};
 
 		partition@180000 {
@@ -118,9 +132,8 @@
 	wlan_5g: wifi@0,0 {
 		reg = <0x0 0 0 0 0>;
 		compatible = "mediatek,mt76";
-
-		mediatek,mtd-eeprom = <&factory 0x0>;
-
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
 		/* MAC-Address set in userspace */
 	};
 };

--- a/target/linux/ramips/dts/mt7621_zyxel_wsm20.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_wsm20.dts
@@ -112,6 +112,14 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				precal_factory_e10: precal@e10 {
+					reg = <0xe10 0x19c10>;
+				};
+
 				macaddr_factory_1fdfa: macaddr@1fdfa {
 					reg = <0x1fdfa 0x6>;
 				};
@@ -199,7 +207,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
 		mediatek,disable-radar-background;
 	};
 };


### PR DESCRIPTION
This PR will convert all ramips devices wireless EEPROM to NVMEM format.

Information:
1. Some MT7915 calibration data consists of two parts. The first part "eeprom" size is 0xe00. The second part "precal" size is 0x19c10.

2. Though some MT7915 devices may not have precal data, it's better to assume that precal data exists as no users/developers confirm it. On the other hand, some devices definitely do not contain precal data because the EEPROM partition size is smaller than the precal NVMEM cell size.

3. EEPROM size table

|Package Name|NIC Model|EEPROM size||
|-|-|-|-|
|kmod-mt7603|MT7603|0x400|2 GHz only|
|kmod-mt76x0e|MT7610|0x200|same as MT7612|
|kmod-mt76x2|MT7602/MT7612|0x200||
|kmod-mt7663-firmware-*|MT7613|0x4da8|same as MT7615|
|kmod-mt7615-firmware|MT7615|0x4da8||
|kmod-mt7915-firmware|MT7915|0xe00 + [0x19c10] ||

Links:
Part.1: https://github.com/openwrt/openwrt/pull/13587
Part.1.fix: https://github.com/openwrt/openwrt/pull/13706

cc @Ansuel