### PR TITLE
ramips: add support for TP-Link Archer C5 v4

### DIFF
--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c5-v4.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c5-v4.dts
@@ -1,0 +1,127 @@
+#include <dt-bindings/leds/common.h>
+
+#include "mt7620a_tplink_archer.dtsi"
+
+/ {
+	compatible = "tplink,archer-c5-v4", "ralink,mt7620a-soc";
+	model = "TP-Link Archer C5 v4";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: led-0 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <2>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led-2 {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <5>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-3 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-6 {
+			function = LED_FUNCTION_USB;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ohci_port1>, <&ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		led-7 {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	rtl8367s {
+		compatible = "realtek,rtl8367b";
+		cpu_port = <7>;
+		realtek,extif2 = <1 0 1 1 1 1 1 1 2>;
+		mii-bus = <&mdio0>;
+		phy-id = <29>;
+	};
+};
+
+&spi0 {
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uartf", "ephy", "rgmii2";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &mdio_pins>;
+
+	port@5 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+	};
+
+	mdio0: mdio-bus {
+		status = "okay";
+		reset-gpios = <&gpio2 20 GPIO_ACTIVE_LOW>;
+		reset-delay-us = <10000>;
+	};
+};
+
+&wmac {
+	pinctrl-names = "default", "pa_gpio";
+	pinctrl-0 = <&pa_pins>;
+	pinctrl-1 = <&pa_gpio_pins>;
+
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_rom_f100 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&wifi {
+	nvmem-cells = <&eeprom_radio_8000>, <&macaddr_rom_f100 2>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};

--- a/target/linux/ramips/dts/mt7620a_tplink_archer.dtsi
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer.dtsi
@@ -118,7 +118,7 @@
 &ethernet {
 	pinctrl-names = "default";
 
-	nvmem-cells = <&macaddr_rom_f100>;
+	nvmem-cells = <&macaddr_rom_f100 0>;
 	nvmem-cell-names = "mac-address";
 
 	mediatek,portmap = "wllll";

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1214,6 +1214,23 @@ define Device/tplink_archer-c2-v1
 endef
 TARGET_DEVICES += tplink_archer-c2-v1
 
+define Device/tplink_archer-c5-v4
+  $(Device/tplink-v2)
+  SOC := mt7620a
+  IMAGE_SIZE := 7808k
+  TPLINK_FLASHLAYOUT := 8Mmtk
+  TPLINK_HWID := 0x04da857c
+  TPLINK_HWREV := 0x0c000600
+  TPLINK_HWREVADD := 0x04000000
+  IMAGES += tftp-recovery.bin
+  IMAGE/tftp-recovery.bin := pad-extra 128k | $$(IMAGE/factory.bin)
+  DEVICE_MODEL := Archer C5
+  DEVICE_VARIANT := v4
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
+  kmod-mt76x2 kmod-switch-rtl8367b
+endef
+TARGET_DEVICES += tplink_archer-c5-v4
+
 define Device/tplink_archer-c50-v1
   $(Device/tplink-v2)
   SOC := mt7620a

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -225,6 +225,10 @@ tplink,archer-c20i)
 	ucidef_set_led_switch "lan" "lan" "blue:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "blue:wan" "switch0" "0x01"
 	;;
+tplink,archer-c5-v4)
+	ucidef_set_led_switch "lan" "lan" "green:lan" "switch1" "0x0f"
+	ucidef_set_led_switch "wan" "wan" "green:wan" "switch1" "0x10"
+	;;
 tplink,archer-c50-v1)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -235,6 +235,12 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan:3" "2:lan:4" "3:lan:1" "4:lan:2" "0:wan" "6@eth0"
 		;;
+	tplink,archer-c5-v4)
+		ucidef_add_switch "switch0"
+		ucidef_add_switch_attr "switch0" "enable" "0"
+		ucidef_add_switch "switch1" \
+			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "7@eth0"
+		;;
 	tplink,archer-mr200)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "6t@eth0"
@@ -407,6 +413,7 @@ ramips_setup_macs()
 	tplink,archer-c2-v1|\
 	tplink,archer-c20-v1|\
 	tplink,archer-c20i|\
+	tplink,archer-c5-v4|\
 	tplink,archer-c50-v1|\
 	tplink,archer-mr200)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary rom 0xf100)" 1)


### PR DESCRIPTION
Patch https://github.com/openwrt/openwrt/pull/14586 successor. PR https://github.com/openwrt/openwrt/pull/14314 compatible with main branch.

TP-Link Archer C5 v4 is a dual band router with 5 GbE ports
Advertised as AC1200 for its 867Mbps (2x2) 5GHz band
and 300 Mbps (2x2) 2.4GHz band.

Specs:
- SoC: MediaTek MT7620A
- Ethernet: 5x GbE ports (Realtek RTL8367S)
- Wireless 2.4GHz: MediaTek MT7620A
- Wireless 5GHz: MediaTek MT7612E
- RAM: 64MiB
- ROM: 8MiB (GD25Q64CSIG)
- 1 USB 2.0 port
- 2 Buttons (WPS and reset)
- 8 LEDs

Currently, you can install OpenWrt via serial console or TFTP.

Flash instructions via serial console:
1. Rename the factory.bin to to test.bin
2. start a TFTP server from IP address 192.168.0.225 and serve the image named test.bin
3. connect your device to the LAN port
4. power up the router and press 4 on the console to stop the boot process.
5. enter the following commands on the router console
	tftp 0x80060000 test.bin
	erase tplink 0x20000 0x7a0000
	cp.b 0x80060000 0x20000 0x7a0000
	reset

Flash instructions via TFTP:
1. Update orginal firmware of the router to the latest one.
2. Rename openwrt-ramips-mt7620-tplink_archer-c5-v4-squashfs-tftp-recovery.bin to tp_recovery.bin
3. Change computer IP to 192.168.0.66
4. Run TFTP serwer
5. Start the router with the reset button pressed, the file will be automatically downloaded and after a while the router will restart.
6. After updating, set your computer's IP to DHCP

A little note: Since there are problems with the performance of 2.4GHz WiFi for Mediatek MT7620 with enabled 802.11w Management Frame Protection, use WPA2-PSK security. For 5GHz this problem does not occur, so you can enable WPA3-SAE or WPA2-PSK/WPA3-SAE security mode.

Additionally, limit the WiFi power to that allowed in your country because OpenWrt does not take into account the antenna gain for this router (5dBi).