### PR TITLE
busybox: enable sha hash for /etc/shadow

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -1333,7 +1333,7 @@ config BUSYBOX_DEFAULT_USE_BB_CRYPT
 	default n
 config BUSYBOX_DEFAULT_USE_BB_CRYPT_SHA
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_ADD_SHELL
 	bool
 	default n

--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -1366,7 +1366,7 @@ config BUSYBOX_DEFAULT_CHPASSWD
 	default n
 config BUSYBOX_DEFAULT_FEATURE_DEFAULT_PASSWD_ALGO
 	string
-	default "md5"
+	default "sha256"
 config BUSYBOX_DEFAULT_CRYPTPW
 	bool
 	default n


### PR DESCRIPTION
It appears `md5` is no longer state of the art. Let's switch it to something slightly newer to increase security.

Suggested-by: abnoeh <abnoeh@mail.com>
