### PR TITLE
build: fix opkg flags in rootfs

### DIFF
--- a/include/rootfs.mk
+++ b/include/rootfs.mk
@@ -87,6 +87,11 @@ define prepare_rootfs
 			fi; \
 		done || true \
 	)
+	awk -i inplace \
+		'/^Status:/ { \
+			if ($$3 == "user") { $$3 = "ok" } \
+			else { sub(/,\<user\>|\<user\>,/, "", $$3) } \
+		}1' $(1)/usr/lib/opkg/status
 	$(if $(SOURCE_DATE_EPOCH),sed -i "s/Installed-Time: .*/Installed-Time: $(SOURCE_DATE_EPOCH)/" $(1)/usr/lib/opkg/status)
 	@-find $(1) -name CVS -o -name .svn -o -name .git -o -name '.#*' | $(XARGS) rm -rf
 	rm -rf \


### PR DESCRIPTION
By default opkg sets the "user" flag when a package is installed, which resulted in most packages in the rootfs having this flag set incorrectly. This patch removes the "user" flag from all installed packages when preparing the rootfs image.

Fixes: #14427