### PR TITLE
ramips: Add support for Cudy WR1300 v3

### DIFF
--- a/target/linux/ramips/dts/mt7621_cudy_wr1300-v2v3.dtsi
+++ b/target/linux/ramips/dts/mt7621_cudy_wr1300-v2v3.dtsi
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: sys {
+			label = "green:sys";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "green:wps";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf80000>;
+			};
+
+			partition@fd0000 {
+				label = "debug";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "backup";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			bdinfo: partition@ff0000 {
+				label = "bdinfo";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "i2c", "jtag";
+		function = "gpio";
+	};
+};
+
+&bdinfo {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_bdinfo_de00: macaddr@de00 {
+		reg = <0xde00 0x6>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_cudy_wr1300-v3.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr1300-v3.dts
@@ -3,11 +3,11 @@
 #include "mt7621_cudy_wr1300-v2v3.dtsi"
 
 / {
-	compatible = "cudy,wr1300-v2", "mediatek,mt7621-soc";
-	model = "Cudy WR1300 v2";
+	compatible = "cudy,wr1300-v3", "mediatek,mt7621-soc";
+	model = "Cudy WR1300 v3";
 };
 
-&pcie1 {
+&pcie0 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
@@ -15,10 +15,15 @@
 		nvmem-cells = <&macaddr_bdinfo_de00>;
 		nvmem-cell-names = "mac-address";
 		ieee80211-freq-limit = <2400000 2500000>;
+
+		led {
+			led-sources = <0>;
+			led-active-low;
+		};
 	};
 };
 
-&pcie0 {
+&pcie1 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -584,6 +584,18 @@ define Device/cudy_wr1300-v2
 endef
 TARGET_DEVICES += cudy_wr1300-v2
 
+define Device/cudy_wr1300-v3
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 15872k
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := WR1300
+  DEVICE_VARIANT := v3
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
+	-uboot-envtools
+  SUPPORTED_DEVICES += cudy,wr1300 R30
+endef
+TARGET_DEVICES += cudy_wr1300-v3
+
 define Device/cudy_wr2100
   $(Device/dsa-migration)
   DEVICE_VENDOR := Cudy


### PR DESCRIPTION
Specifications:
 - SoC: MediaTek MT7621AT
 - RAM: 128 MB (DDR3)
 - Flash: 16 MB (SPI NOR)
 - WiFi: MediaTek MT7603E, MediaTek MT7613BE
 - Switch: 1 WAN, 4 LAN (Gigabit)
 - Buttons: Reset, WPS
 - LEDs: System, Wan, Lan 1-4, WiFi 2.4G, WiFi 5G, WPS
 - Power: DC 12V 1A tip positive

Download and flash the manufacturer's built OpenWRT image available at http://www.cudytech.com/openwrt_software_download
Install the new OpenWRT image via luci (System -> Backup/Flash firmware) Be sure to NOT keep settings. The force upgrade may need to be checked due to differences in router naming conventions.

Cudy WR1300 v3 differs from v2 only in swapped WiFi chip PCIe slots. Common nodes are extracted to .dtsi and new v2 and v3 dts are created.

Cudy WR1300 v2 dts now contains ieee80211-freq-limit.

The same manufacturer's built OpenWRT image is provided for both v2 and v3 devices as a step in installing, but for proper WiFi functionality, a separate build is required.

Recovery:
 - Loads only signed manufacture firmware due to bootloader RSA verification
 - serve tftp-recovery image as /recovery.bin on 192.168.1.88/24
 - connect to any lan ethernet port
 - power on the device while holding the reset button
 - wait at least 8 seconds before releasing reset button for image to download
 - See http://www.cudytech.com/newsinfo/547425.html

Backported from main to 23.05.