### PR TITLE
mediatek: fix old name for ex5601-t0

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
@@ -11,7 +11,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	model = "Zyxel EX5601-T0-STOCK";
+	model = "Zyxel EX5601-T0";
 	compatible = "zyxel,ex5601-t0-stock", "mediatek,mt7986a-rfb-snand";
 
 	memory@40000000 {

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
@@ -11,8 +11,8 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	model = "Zyxel EX5601-T0";
-	compatible = "zyxel,ex5601-t0", "mediatek,mt7986a-rfb-snand";
+	model = "Zyxel EX5601-T0-STOCK";
+	compatible = "zyxel,ex5601-t0-stock", "mediatek,mt7986a-rfb-snand";
 
 	memory@40000000 {
 		device_type = "memory";

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -117,7 +117,7 @@ case "$board" in
 	routerich,ax3000|\
 	zbtlink,zbt-z8102ax|\
 	zbtlink,zbt-z8103ax|\
-	zyxel,ex5601-t0|\
+	zyxel,ex5601-t0-stock|\
 	zyxel,ex5601-t0-ubootmod)
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
It is my first PR to OpenWRT I hope I did everything right....

I noticed that there is still the old name in this config file.
I think it was a typo in this pr: 
https://github.com/openwrt/openwrt/pull/13143/commits/b5df398a36f153f036c0a5ff9b221abb0f6f240a#diff-8ec1cbbd6a379eb2fb53ae765af2f7c5e7d3432ed6fa72ef86aedcb2f4811e19