### PR TITLE
rockchip: add Radxa CM3 IO support

### DIFF
--- a/package/boot/rkbin/Makefile
+++ b/package/boot/rkbin/Makefile
@@ -25,6 +25,12 @@ define Trusted-Firmware-A/Default
   BUILD_TARGET:=rockchip
 endef
 
+define Trusted-Firmware-A/rk3566
+  BUILD_SUBTARGET:=armv8
+  ATF:=rk35/rk3568_bl31_v1.43.elf
+  TPL:=rk35/rk3566_ddr_1056MHz_v1.18.bin
+endef
+
 define Trusted-Firmware-A/rk3568
   BUILD_SUBTARGET:=armv8
   ATF:=rk35/rk3568_bl31_v1.43.elf
@@ -32,6 +38,7 @@ define Trusted-Firmware-A/rk3568
 endef
 
 TFA_TARGETS:= \
+	rk3566 \
 	rk3568
 
 define Build/Compile

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -126,6 +126,22 @@ define U-Boot/rockpro64-rk3399
 endef
 
 
+# RK3566 boards
+
+define U-Boot/rk3566/Default
+  BUILD_SUBTARGET:=armv8
+  DEPENDS:=+PACKAGE_u-boot-$(1):trusted-firmware-a-rk3566
+  ATF:=rk3568_bl31_v1.43.elf
+  TPL:=rk3566_ddr_1056MHz_v1.18.bin
+endef
+
+define U-Boot/radxa-cm3-io-rk3566
+  $(U-Boot/rk3566/Default)
+  NAME:=CM3 IO
+  BUILD_DEVICES:= \
+    radxa_cm3-io
+endef
+
 # RK3568 boards
 
 define U-Boot/rk3568/Default
@@ -162,6 +178,7 @@ UBOOT_TARGETS := \
   roc-cc-rk3328 \
   rock64-rk3328 \
   rock-pi-e-rk3328 \
+  radxa-cm3-io-rk3566 \
   nanopi-r5c-rk3568 \
   nanopi-r5s-rk3568
 

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -32,6 +32,7 @@ case "$(board_name)" in
 friendlyarm,nanopi-r2c|\
 friendlyarm,nanopi-r2c-plus|\
 friendlyarm,nanopi-r2s|\
+radxa,cm3-io|\
 xunlong,orangepi-r1-plus|\
 xunlong,orangepi-r1-plus-lts)
 	set_interface_core 2 "eth0"

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -95,6 +95,15 @@ define Device/pine64_rockpro64
 endef
 TARGET_DEVICES += pine64_rockpro64
 
+define Device/radxa_cm3-io
+  DEVICE_VENDOR := Radxa
+  DEVICE_MODEL := CM3 IO
+  SOC := rk3566
+  DEVICE_DTS := rockchip/rk3566-radxa-cm3-io
+  UBOOT_DEVICE_NAME := radxa-cm3-io-rk3566
+endef
+TARGET_DEVICES += radxa_cm3-io
+
 define Device/radxa_rock-pi-4a
   DEVICE_VENDOR := Radxa
   DEVICE_MODEL := ROCK Pi 4A

--- a/target/linux/rockchip/patches-6.1/016-v6.3-arm64-dts-rockchip-Add-Radxa-Compute-Module-3-IO-board.patch
+++ b/target/linux/rockchip/patches-6.1/016-v6.3-arm64-dts-rockchip-Add-Radxa-Compute-Module-3-IO-board.patch
@@ -1,0 +1,233 @@
+From 096ebfb74b19f2d4bdcbc33ae02e857ff4b3e0a0 Mon Sep 17 00:00:00 2001
+From: Jagan Teki <jagan@amarulasolutions.com>
+Date: Thu, 12 Jan 2023 16:29:02 +0530
+Subject: [PATCH] arm64: dts: rockchip: Add Radxa Compute Module 3 IO board
+
+Radxa Compute Module 3(CM3) IO board is an application board from Radxa
+and is compatible with Raspberry Pi CM4 IO form factor.
+
+Specification:
+- 1x HDMI,
+- 2x MIPI DSI
+- 2x MIPI CSI2
+- 1x eDP
+- 1x PCIe card
+- 2x SATA
+- 2x USB 2.0 Host
+- 1x USB 3.0
+- 1x USB 2.0 OTG
+- Phone jack
+- microSD slot
+- 40-pin GPIO expansion header
+- 12V DC
+
+Radxa CM3 needs to mount on top of this IO board in order to create
+complete Radxa CM3 IO board platform.
+
+Add support for Radxa CM3 IO Board.
+
+Co-developed-by: FUKAUMI Naoki <naoki@radxa.com>
+Signed-off-by: FUKAUMI Naoki <naoki@radxa.com>
+Co-developed-by: Manoj Sai <abbaraju.manojsai@amarulasolutions.com>
+Signed-off-by: Manoj Sai <abbaraju.manojsai@amarulasolutions.com>
+Signed-off-by: Jagan Teki <jagan@amarulasolutions.com>
+Link: https://lore.kernel.org/r/20230112105902.192852-3-jagan@amarulasolutions.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/Makefile         |   1 +
+ .../boot/dts/rockchip/rk3566-radxa-cm3-io.dts | 179 ++++++++++++++++++
+ 2 files changed, 180 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
+
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -70,6 +70,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-pi
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-pinenote-v1.2.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-quartz64-a.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-quartz64-b.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-radxa-cm3-io.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-roc-pc.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-soquartz-cm4.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-bpi-r2-pro.dtb
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
+@@ -0,0 +1,179 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2022 Radxa Limited
++ * Copyright (c) 2022 Amarula Solutions(India)
++ */
++
++/dts-v1/;
++#include <dt-bindings/soc/rockchip,vop2.h>
++#include "rk3566.dtsi"
++#include "rk3566-radxa-cm3.dtsi"
++
++/ {
++	model = "Radxa Compute Module 3(CM3) IO Board";
++	compatible = "radxa,radxa-cm3-io", "radxa,radxa-cm3", "rockchip,rk3566";
++
++	aliases {
++		mmc1 = &sdmmc0;
++	};
++
++	chosen: chosen {
++		stdout-path = "serial2:1500000n8";
++	};
++
++	hdmi-con {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi_out_con>;
++			};
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-1 {
++			gpios = <&gpio4 RK_PA4 GPIO_ACTIVE_LOW>;
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_ACTIVITY;
++			linux,default-trigger = "heartbeat";
++			pinctrl-names = "default";
++			pinctrl-0 = <&pi_nled_activity>;
++		};
++	};
++
++	vcc5v0_usb30: vcc5v0-usb30-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_usb30";
++		enable-active-high;
++		gpio = <&gpio3 RK_PC2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_usb30_en_h>;
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sys>;
++	};
++
++	vcca1v8_image: vcca1v8-image-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcca1v8_image";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_1v8_p>;
++	};
++
++	vdda0v9_image: vdda0v9-image-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcca0v9_image";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <900000>;
++		regulator-max-microvolt = <900000>;
++		vin-supply = <&vdda_0v9>;
++	};
++};
++
++&combphy1 {
++	status = "okay";
++};
++
++&hdmi {
++	avdd-0v9-supply = <&vdda0v9_image>;
++	avdd-1v8-supply = <&vcca1v8_image>;
++	status = "okay";
++};
++
++&hdmi_in {
++	hdmi_in_vp0: endpoint {
++		remote-endpoint = <&vp0_out_hdmi>;
++	};
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
++&hdmi_sound {
++	status = "okay";
++};
++
++&pinctrl {
++	leds {
++		pi_nled_activity: pi-nled-activity {
++			rockchip,pins = <4 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	sdcard {
++		sdmmc_pwren: sdmmc-pwren {
++			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb {
++		vcc5v0_usb30_en_h: vcc5v0-host-en-h {
++			rockchip,pins = <3 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&sdmmc0 {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	vqmmc-supply = <&vccio_sd>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc0_bus4 &sdmmc0_clk &sdmmc0_cmd &sdmmc0_det &sdmmc0_pwren>;
++	status = "okay";
++};
++
++&uart2 {
++	status = "okay";
++};
++
++&usb2phy0_host {
++	phy-supply = <&vcc5v0_usb30>;
++	status = "okay";
++};
++
++&usb2phy1_host {
++	status = "okay";
++};
++
++&usb2phy1_otg {
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host1_xhci {
++	status = "okay";
++};
++
++&vop {
++	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
++	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&vp0 {
++	vp0_out_hdmi: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
++		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
++		remote-endpoint = <&hdmi_in_vp0>;
++	};
++};

--- a/target/linux/rockchip/patches-6.1/017-v6.3-arm64-dts-rockchip-Enable-Ethernet-for-Radxa-CM3-IO.patch
+++ b/target/linux/rockchip/patches-6.1/017-v6.3-arm64-dts-rockchip-Enable-Ethernet-for-Radxa-CM3-IO.patch
@@ -1,0 +1,131 @@
+From cc52bfc04726a574fc4440bbbe0c710890e7040a Mon Sep 17 00:00:00 2001
+From: Manoj Sai <abbaraju.manojsai@amarulasolutions.com>
+Date: Wed, 25 Jan 2023 21:40:22 +0530
+Subject: [PATCH] arm64: dts: rockchip: Enable Ethernet for Radxa CM3 IO
+
+Add ethernet nodes for enabling gmac1 on the Radxa CM3 IO board.
+
+Signed-off-by: Manoj Sai <abbaraju.manojsai@amarulasolutions.com>
+Link: https://lore.kernel.org/r/20230125161023.12115-1-jagan@amarulasolutions.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ .../boot/dts/rockchip/rk3566-radxa-cm3-io.dts | 93 +++++++++++++++++++
+ 1 file changed, 93 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
+@@ -21,6 +21,13 @@
+ 		stdout-path = "serial2:1500000n8";
+ 	};
+ 
++	gmac1_clkin: external-gmac1-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <125000000>;
++		clock-output-names = "gmac1_clkin";
++		#clock-cells = <0>;
++	};
++
+ 	hdmi-con {
+ 		compatible = "hdmi-connector";
+ 		type = "a";
+@@ -83,6 +90,29 @@
+ 	status = "okay";
+ };
+ 
++&gmac1 {
++	assigned-clocks = <&cru SCLK_GMAC1_RX_TX>, <&cru SCLK_GMAC1>;
++	assigned-clock-parents = <&cru SCLK_GMAC1_RGMII_SPEED>, <&gmac1_clkin>;
++	assigned-clock-rates = <0>, <125000000>;
++	clock_in_out = "input";
++	phy-handle = <&rgmii_phy1>;
++	phy-mode = "rgmii";
++	pinctrl-names = "default";
++	pinctrl-0 = <&gmac1m0_miim
++		     &gmac1m0_tx_bus2
++		     &gmac1m0_rx_bus2
++		     &gmac1m0_rgmii_clk
++		     &gmac1m0_rgmii_bus
++		     &gmac1m0_clkinout>;
++	snps,reset-gpio = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	/* Reset time is 20ms, 100ms for rtl8211f */
++	snps,reset-delays-us = <0 20000 100000>;
++	tx_delay = <0x46>;
++	rx_delay = <0x2e>;
++	status = "okay";
++};
++
+ &hdmi {
+ 	avdd-0v9-supply = <&vdda0v9_image>;
+ 	avdd-1v8-supply = <&vcca1v8_image>;
+@@ -105,7 +135,70 @@
+ 	status = "okay";
+ };
+ 
++&mdio1 {
++	rgmii_phy1: ethernet-phy@0 {
++		compatible="ethernet-phy-ieee802.3-c22";
++		reg= <0x0>;
++	};
++};
++
+ &pinctrl {
++	gmac1 {
++		gmac1m0_miim: gmac1m0-miim {
++			rockchip,pins =
++				/* gmac1_mdcm0 */
++				<3 RK_PC4 3 &pcfg_pull_none_drv_level_15>,
++				/* gmac1_mdiom0 */
++				<3 RK_PC5 3 &pcfg_pull_none_drv_level_15>;
++		};
++
++		gmac1m0_rx_bus2: gmac1m0-rx-bus2 {
++			rockchip,pins =
++				/* gmac1_rxd0m0 */
++				<3 RK_PB1 3 &pcfg_pull_none_drv_level_15>,
++				/* gmac1_rxd1m0 */
++				<3 RK_PB2 3 &pcfg_pull_none_drv_level_15>,
++				/* gmac1_rxdvcrsm0 */
++				<3 RK_PB3 3 &pcfg_pull_none_drv_level_15>;
++		};
++
++		gmac1m0_tx_bus2: gmac1m0-tx-bus2 {
++			rockchip,pins =
++				/* gmac1_txd0m0 */
++				<3 RK_PB5 3 &pcfg_pull_none_drv_level_15>,
++				/* gmac1_txd1m0 */
++				<3 RK_PB6 3 &pcfg_pull_none_drv_level_15>,
++				/* gmac1_txenm0 */
++				<3 RK_PB7 3 &pcfg_pull_none_drv_level_15>;
++		};
++
++		gmac1m0_rgmii_clk: gmac1m0-rgmii-clk {
++			rockchip,pins =
++				/* gmac1_rxclkm0 */
++				<3 RK_PA7 3 &pcfg_pull_none_drv_level_15>,
++				/* gmac1_txclkm0 */
++				<3 RK_PA6 3 &pcfg_pull_none_drv_level_15>;
++		};
++
++		gmac1m0_rgmii_bus: gmac1m0-rgmii-bus {
++			rockchip,pins =
++				/* gmac1_rxd2m0 */
++				<3 RK_PA4 3 &pcfg_pull_none_drv_level_15>,
++				/* gmac1_rxd3m0 */
++				<3 RK_PA5 3 &pcfg_pull_none_drv_level_15>,
++				/* gmac1_txd2m0 */
++				<3 RK_PA2 3 &pcfg_pull_none_drv_level_15>,
++				/* gmac1_txd3m0 */
++				<3 RK_PA3 3 &pcfg_pull_none_drv_level_15>;
++		};
++
++		gmac1m0_clkinout: gmac1m0-clkinout {
++			rockchip,pins =
++				/* gmac1_mclkinoutm0 */
++				<3 RK_PC0 3 &pcfg_pull_none_drv_level_15>;
++		};
++	};
++
+ 	leds {
+ 		pi_nled_activity: pi-nled-activity {
+ 			rockchip,pins = <4 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;

--- a/target/linux/rockchip/patches-6.1/018-v6.3-arm64-dts-rockchip-Add-rk3566-based-Radxa-Compute-Module-3.patch
+++ b/target/linux/rockchip/patches-6.1/018-v6.3-arm64-dts-rockchip-Add-rk3566-based-Radxa-Compute-Module-3.patch
@@ -1,0 +1,386 @@
+From 7469ab529bcad50490f6ff651c3e4f03bfa88fe0 Mon Sep 17 00:00:00 2001
+From: Jagan Teki <jagan@amarulasolutions.com>
+Date: Thu, 12 Jan 2023 16:29:01 +0530
+Subject: [PATCH] arm64: dts: rockchip: Add rk3566 based Radxa Compute Module 3
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Radxa Compute Module 3(CM3) is one of the modules from a series
+System On Module based on the Radxa ROCK 3 series and is compatible
+with Raspberry Pi CM4 pinout and form factor.
+
+Specification:
+- Rockchip RK3566
+- up to 8GB LPDDR4
+- up to 128GB high performance eMMC
+- Optional wireless LAN, 2.4GHz and 5.0GHz IEEE 802.11b/g/n/ac wireless,
+  BT 5.0, BLE with onboard and external antenna.
+- Gigabit Ethernet PHY
+
+Radxa CM3 needs to mount on top of this IO board in order to create
+complete Radxa CM3 IO board platform.
+
+Since Radxa CM3 is compatible with Raspberry Pi CM4 pinout so it is
+possible to mount Radxa CM3 on top of the Rasberry Pi CM4 IO board.
+
+Add support for Radxa CM3.
+
+Co-developed-by: FUKAUMI Naoki <naoki@radxa.com>
+Signed-off-by: FUKAUMI Naoki <naoki@radxa.com>
+Signed-off-by: Jagan Teki <jagan@amarulasolutions.com>
+Link: https://lore.kernel.org/r/20230112105902.192852-2-jagan@amarulasolutions.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ .../boot/dts/rockchip/rk3566-radxa-cm3.dtsi   | 345 ++++++++++++++++++
+ 1 file changed, 345 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3.dtsi
+
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3.dtsi
+@@ -0,0 +1,345 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2022 Radxa Limited
++ * Copyright (c) 2022 Amarula Solutions(India)
++ */
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++
++/ {
++	compatible = "radxa,radxa-cm3", "rockchip,rk3566";
++
++	aliases {
++		mmc0 = &sdhci;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-0 {
++			gpios = <&gpio0 RK_PA6 GPIO_ACTIVE_HIGH>;
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_STATUS;
++			linux,default-trigger = "timer";
++			default-state = "on";
++			pinctrl-names = "default";
++			pinctrl-0 = <&user_led2>;
++		};
++	};
++
++	vcc_sys: vcc-sys-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc_1v8: vcc-1v8-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_1v8";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_1v8_p>;
++	};
++
++	vcc_3v3: vcc-3v3-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_3v3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc3v3_sys>;
++	};
++
++	vcca_1v8: vcca-1v8-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcca_1v8";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_1v8_p>;
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_cpu>;
++};
++
++&cpu1 {
++	cpu-supply = <&vdd_cpu>;
++};
++
++&cpu2 {
++	cpu-supply = <&vdd_cpu>;
++};
++
++&cpu3 {
++	cpu-supply = <&vdd_cpu>;
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu_npu>;
++	status = "okay";
++};
++
++&i2c0 {
++	status = "okay";
++
++	vdd_cpu: regulator@1c {
++		compatible = "tcs,tcs4525";
++		reg = <0x1c>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <712500>;
++		regulator-max-microvolt = <1390000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	rk817: pmic@20 {
++		compatible = "rockchip,rk817";
++		reg = <0x20>;
++		#clock-cells = <1>;
++		clock-output-names = "rk817-clkout1", "rk817-clkout2";
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_int_l>;
++		rockchip,system-power-controller;
++		wakeup-source;
++
++		vcc1-supply = <&vcc_sys>;
++		vcc2-supply = <&vcc_sys>;
++		vcc3-supply = <&vcc_sys>;
++		vcc4-supply = <&vcc_sys>;
++		vcc5-supply = <&vcc_sys>;
++		vcc6-supply = <&vcc_sys>;
++		vcc7-supply = <&vcc_sys>;
++
++		regulators {
++			vdd_logic: DCDC_REG1 {
++				regulator-name = "vdd_logic";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-initial-mode = <0x2>;
++				regulator-min-microvolt = <500000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <900000>;
++				};
++			};
++
++			vdd_gpu_npu: DCDC_REG2 {
++				regulator-name = "vdd_gpu_npu";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-initial-mode = <0x2>;
++				regulator-min-microvolt = <500000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_ddr: DCDC_REG3 {
++				regulator-name = "vcc_ddr";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-initial-mode = <0x2>;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc3v3_sys: DCDC_REG4 {
++				regulator-name = "vcc3v3_sys";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-initial-mode = <0x2>;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vcca1v8_pmu: LDO_REG1 {
++				regulator-name = "vcca1v8_pmu";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdda_0v9: LDO_REG2 {
++				regulator-name = "vdda_0v9";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <900000>;
++				regulator-max-microvolt = <900000>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdda0v9_pmu: LDO_REG3 {
++				regulator-name = "vdda0v9_pmu";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <900000>;
++				regulator-max-microvolt = <900000>;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <900000>;
++				};
++			};
++
++			vccio_acodec: LDO_REG4 {
++				regulator-name = "vccio_acodec";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vccio_sd: LDO_REG5 {
++				regulator-name = "vccio_sd";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc3v3_pmu: LDO_REG6 {
++				regulator-name = "vcc3v3_pmu";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vcc_1v8_p: LDO_REG7 {
++				regulator-name = "vcc_1v8_p";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc1v8_dvp: LDO_REG8 {
++				regulator-name = "vcc1v8_dvp";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc2v8_dvp: LDO_REG9 {
++				regulator-name = "vcc2v8_dvp";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <2800000>;
++				regulator-max-microvolt = <2800000>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++		};
++	};
++};
++
++&pinctrl {
++	pmic {
++		pmic_int_l: pmic-int-l {
++			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	leds {
++		user_led2: user-led2 {
++			rockchip,pins = <0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&pmu_io_domains {
++	pmuio1-supply = <&vcc3v3_pmu>;
++	pmuio2-supply = <&vcc_3v3>;
++	vccio1-supply = <&vccio_acodec>;
++	vccio2-supply = <&vcc_1v8>;
++	vccio3-supply = <&vccio_sd>;
++	vccio4-supply = <&vcc_1v8>;
++	vccio5-supply = <&vcc_3v3>;
++	vccio6-supply = <&vcc_3v3>;
++	vccio7-supply = <&vcc_3v3>;
++	status = "okay";
++};
++
++&saradc {
++	vref-supply = <&vcca_1v8>;
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	max-frequency = <200000000>;
++	mmc-hs200-1_8v;
++	non-removable;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd &emmc_datastrobe>;
++	vmmc-supply = <&vcc_3v3>;
++	vqmmc-supply = <&vcc_1v8>;
++	status = "okay";
++};
++
++&usb2phy0 {
++	status = "okay";
++};
++
++&usb2phy1 {
++	status = "okay";
++};
++
++&tsadc {
++	rockchip,hw-tshut-mode = <1>;
++	rockchip,hw-tshut-polarity = <0>;
++	status = "okay";
++};

--- a/target/linux/rockchip/patches-6.1/019-v6.3-arm64-dts-rockchip-Enable-WiFi-BT-support-for-Radxa-CM3.patch
+++ b/target/linux/rockchip/patches-6.1/019-v6.3-arm64-dts-rockchip-Enable-WiFi-BT-support-for-Radxa-CM3.patch
@@ -1,0 +1,134 @@
+From af5a803bf212e077e5fb7a1d4cf6be02f74a74ca Mon Sep 17 00:00:00 2001
+From: Jagan Teki <jagan@amarulasolutions.com>
+Date: Wed, 25 Jan 2023 21:40:23 +0530
+Subject: [PATCH] arm64: dts: rockchip: rk3566: Enable WiFi, BT support for
+ Radxa CM3
+
+Radxa Compute Module 3 has an onboard AW_CM256SM WiFi/BT module.
+
+Add nodes for enabling it.
+
+Signed-off-by: Jagan Teki <jagan@amarulasolutions.com>
+Link: https://lore.kernel.org/r/20230125161023.12115-2-jagan@amarulasolutions.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ .../boot/dts/rockchip/rk3566-radxa-cm3.dtsi   | 80 +++++++++++++++++++
+ 1 file changed, 80 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3.dtsi
+@@ -66,6 +66,15 @@
+ 		regulator-max-microvolt = <1800000>;
+ 		vin-supply = <&vcc_1v8_p>;
+ 	};
++
++	sdio_pwrseq: pwrseq-sdio {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rk817 1>;
++		clock-names = "ext_clock";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_reg_on_h>;
++		reset-gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_LOW>;
++	};
+ };
+ 
+ &cpu0 {
+@@ -287,6 +296,20 @@
+ };
+ 
+ &pinctrl {
++	bluetooth {
++		bt_host_wake_h: bt-host-wake-h {
++			rockchip,pins = <2 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		bt_reg_on_h: bt-reg-on-h {
++			rockchip,pins = <2 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		bt_wake_host_h: bt-wake-host-h {
++			rockchip,pins = <2 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
+ 	pmic {
+ 		pmic_int_l: pmic-int-l {
+ 			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
+@@ -298,6 +321,16 @@
+ 			rockchip,pins = <0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
++
++	wifi {
++		wifi_reg_on_h: wifi-reg-on-h {
++			rockchip,pins = <2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		wifi_host_wake_h: wifi-host-wake-h {
++			rockchip,pins = <2 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
+ };
+ 
+ &pmu_io_domains {
+@@ -318,6 +351,34 @@
+ 	status = "okay";
+ };
+ 
++&sdmmc1 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	bus-width = <4>;
++	disable-wp;
++	cap-sd-highspeed;
++	cap-sdio-irq;
++	keep-power-in-suspend;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	non-removable;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc1_bus4 &sdmmc1_clk &sdmmc1_cmd>;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc_3v3>;
++	vqmmc-supply = <&vcc_1v8>;
++	status = "okay";
++
++	wifi@1 {
++		compatible = "brcm,bcm43455-fmac";
++		reg = <1>;
++		interrupt-parent = <&gpio2>;
++		interrupts = <RK_PC1 IRQ_TYPE_LEVEL_HIGH>;
++		interrupt-names = "host-wake";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_host_wake_h>;
++	};
++};
++
+ &sdhci {
+ 	bus-width = <8>;
+ 	max-frequency = <200000000>;
+@@ -330,6 +391,25 @@
+ 	status = "okay";
+ };
+ 
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1m0_ctsn &uart1m0_rtsn &uart1m0_xfer>;
++	status = "okay";
++
++	bluetooth {
++		compatible = "brcm,bcm4345c5";
++		clocks = <&rk817 1>;
++		clock-names = "lpo";
++		device-wakeup-gpios = <&gpio2 RK_PB2 GPIO_ACTIVE_HIGH>;
++		host-wakeup-gpios = <&gpio2 RK_PB1 GPIO_ACTIVE_HIGH>;
++		reset-gpios = <&gpio2 RK_PC0 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&bt_host_wake_h &bt_reg_on_h &bt_wake_host_h>;
++		vbat-supply = <&vcc_3v3>;
++		vddio-supply = <&vcc_1v8>;
++	};
++};
++
+ &usb2phy0 {
+ 	status = "okay";
+ };

--- a/target/linux/rockchip/patches-6.1/020-v6.4-arm64-dts-rockchip-Enable-USB-OTG-for-rk3566-Radxa-CM3.patch
+++ b/target/linux/rockchip/patches-6.1/020-v6.4-arm64-dts-rockchip-Enable-USB-OTG-for-rk3566-Radxa-CM3.patch
@@ -1,0 +1,32 @@
+From 477ed3ade6a46e445b4e2348b710c51df4f6f4b1 Mon Sep 17 00:00:00 2001
+From: Manoj Sai <abbaraju.manojsai@amarulasolutions.com>
+Date: Thu, 23 Feb 2023 19:29:29 +0530
+Subject: [PATCH] arm64: dts: rockchip: Enable USB OTG for rk3566 Radxa CM3
+
+Enable USB OTG support for Radxa Compute Module 3 IO Board
+
+Signed-off-by: Manoj Sai <abbaraju.manojsai@amarulasolutions.com>
+Signed-off-by: Jagan Teki <jagan@amarulasolutions.com>
+Link: https://lore.kernel.org/r/20230223135929.630787-1-abbaraju.manojsai@amarulasolutions.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
+@@ -254,6 +254,14 @@
+ 	status = "okay";
+ };
+ 
++&usb2phy0_otg {
++	status = "okay";
++};
++
++&usb_host0_xhci {
++	status = "okay";
++};
++
+ &vop {
+ 	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
+ 	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;

--- a/target/linux/rockchip/patches-6.1/021-v6.3-arm64-dts-rockchip-Fix-compatible-for-Radxa-CM3.patch
+++ b/target/linux/rockchip/patches-6.1/021-v6.3-arm64-dts-rockchip-Fix-compatible-for-Radxa-CM3.patch
@@ -1,0 +1,45 @@
+From 8f19828844f20b22182719cf53be64f8c955aee8 Mon Sep 17 00:00:00 2001
+From: Jagan Teki <jagan@amarulasolutions.com>
+Date: Mon, 23 Jan 2023 12:46:50 +0530
+Subject: [PATCH] arm64: dts: rockchip: Fix compatible for Radxa CM3
+
+The compatible string "radxa,radxa-cm3" referring the product name
+as "Radxa Radxa CM3" but the actual product name is "Radxa CM3".
+
+Fix the compatible strings.
+
+Fixes: 24a28d3eb07d ("dt-bindings: arm: rockchip: Add Radxa Compute Module 3")
+Fixes: 7469ab529bca ("arm64: dts: rockchip: Add rk3566 based Radxa Compute Module 3")
+Fixes: 096ebfb74b19 ("arm64: dts: rockchip: Add Radxa Compute Module 3 IO board")
+Suggested-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Signed-off-by: Jagan Teki <jagan@amarulasolutions.com>
+Acked-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Link: https://lore.kernel.org/r/20230123071654.73139-1-jagan@amarulasolutions.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts | 2 +-
+ arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3.dtsi   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
+@@ -11,7 +11,7 @@
+ 
+ / {
+ 	model = "Radxa Compute Module 3(CM3) IO Board";
+-	compatible = "radxa,radxa-cm3-io", "radxa,radxa-cm3", "rockchip,rk3566";
++	compatible = "radxa,cm3-io", "radxa,cm3", "rockchip,rk3566";
+ 
+ 	aliases {
+ 		mmc1 = &sdmmc0;
+--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3.dtsi
+@@ -8,7 +8,7 @@
+ #include <dt-bindings/leds/common.h>
+ 
+ / {
+-	compatible = "radxa,radxa-cm3", "rockchip,rk3566";
++	compatible = "radxa,cm3", "rockchip,rk3566";
+ 
+ 	aliases {
+ 		mmc0 = &sdhci;

--- a/target/linux/rockchip/patches-6.1/022-v6.5-arm64-dts-rockchip-minor-whitespace-cleanup-around.patch
+++ b/target/linux/rockchip/patches-6.1/022-v6.5-arm64-dts-rockchip-minor-whitespace-cleanup-around.patch
@@ -1,0 +1,28 @@
+From f99a75f11f46a24dabb33e90893eebf61dca0566 Mon Sep 17 00:00:00 2001
+From: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Date: Sun, 2 Jul 2023 20:52:42 +0200
+Subject: [PATCH] arm64: dts: rockchip: minor whitespace cleanup around '='
+
+The DTS code coding style expects exactly one space before and after '='
+sign.
+
+Signed-off-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Link: https://lore.kernel.org/r/20230702185242.44421-1-krzysztof.kozlowski@linaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ .../boot/dts/rockchip/rk3566-radxa-cm3-io.dts    |  4 ++--
+ 1 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
+@@ -137,8 +137,8 @@
+ 
+ &mdio1 {
+ 	rgmii_phy1: ethernet-phy@0 {
+-		compatible="ethernet-phy-ieee802.3-c22";
+-		reg= <0x0>;
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <0x0>;
+ 	};
+ };
+ 

--- a/target/linux/rockchip/patches-6.1/023-v6.8-arm64-dts-rockchip-Add-ethernet0-alias-to-the-dts-for-RK3566-boards.patch
+++ b/target/linux/rockchip/patches-6.1/023-v6.8-arm64-dts-rockchip-Add-ethernet0-alias-to-the-dts-for-RK3566-boards.patch
@@ -1,0 +1,28 @@
+From 36d9b3ae708e865cdab95692db5a24c5d975383d Mon Sep 17 00:00:00 2001
+From: Dragan Simic <dsimic@manjaro.org>
+Date: Tue, 12 Dec 2023 09:01:39 +0100
+Subject: [PATCH] arm64: dts: rockchip: Add ethernet0 alias to the dts for
+ RK3566 boards
+
+Add ethernet0 alias to the board dts files for a few supported RK3566 boards
+that had it missing.  Also, remove the ethernet0 alias from one RK3566 SoM
+dtsi file, which doesn't enable the GMAC, and add the ethernet0 alias back to
+the dependent board dts files, which actually enable the GMAC.
+
+Signed-off-by: Dragan Simic <dsimic@manjaro.org>
+Link: https://lore.kernel.org/r/d2a272e0ae0fff0adfab8bb0238243b11d348799.1702368023.git.dsimic@manjaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts     | 1 +
+ 1 files changed, 1 insertions(+), 0 deletion(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
+@@ -14,6 +14,7 @@
+ 	compatible = "radxa,cm3-io", "radxa,cm3", "rockchip,rk3566";
+ 
+ 	aliases {
++		ethernet0 = &gmac1;
+ 		mmc1 = &sdmmc0;
+ 	};
+ 

--- a/target/linux/rockchip/patches-6.1/111-radxa-cm3-io-add-led-aliases.patch
+++ b/target/linux/rockchip/patches-6.1/111-radxa-cm3-io-add-led-aliases.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marius Durbaca <mariusd84@gmail.com>
+Date: Tue Feb 20 15:05:27 2024 +0200
+Subject: [PATCH] arm64: dts: rockchip: Update LED properties for Radxa 
+CM3 IO board
+
+Add OpenWrt's LED aliases for showing system status.
+
+Suggested-by: Tianling Shen <cnsztl@immortalwrt.org>
+Signed-off-by: Marius Durbaca <mariusd84@gmail.com>
+---
+
+--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3-io.dts
+@@ -16,6 +16,10 @@
+ 	aliases {
+ 		ethernet0 = &gmac1;
+ 		mmc1 = &sdmmc0;
++		led-boot = &status_led;
++		led-failsafe = &status_led;
++		led-running = &status_led;
++		led-upgrade = &status_led;
+ 	};
+ 
+ 	chosen: chosen {
+--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-cm3.dtsi
+@@ -17,7 +17,7 @@
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+-		led-0 {
++		status_led: led-0 {
+ 			gpios = <&gpio0 RK_PA6 GPIO_ACTIVE_HIGH>;
+ 			color = <LED_COLOR_ID_GREEN>;
+ 			function = LED_FUNCTION_STATUS;


### PR DESCRIPTION
Hardware
--------
RockChip RK3566 ARM64 (4 cores)
- up to 8GB LPDDR4X
- 1x HDMI,
- 2x MIPI DSI
- 2x MIPI CSI2
- 1x eDP
- 1x PCIe card
- 2x SATA
- 2x USB 2.0 Host
- 1x USB 3.0
- 1x USB 2.0 OTG
- 10/100/1000 Base-T
- microSD slot
- 40-pin GPIO expansion header
- 12V DC

Radxa CM3 needs to mount on top of this IO board in order to create
complete Radxa CM3 IO board platform.

Installation
------------
Uncompress the OpenWrt sysupgrade and write it to a micro SD card or
internal eMMC using dd.

Signed-off-by: Marius Durbaca <mariusd84@gmail.com>
