### PR TITLE
ath79: fix mac detection eap225 outdoor v3

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_eap225-outdoor-v1.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_eap225-outdoor-v1.dts
@@ -35,12 +35,6 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		macaddr_info_8: macaddr@8 {
-			compatible = "mac-base";
-			reg = <0x8 0x6>;
-			#nvmem-cell-cells = <1>;
-		};
-
 		precalibration_ath10k: pre-calibration@5000 {
 			reg = <0x5000 0x2f20>;
 		};

--- a/target/linux/ath79/dts/qca9563_tplink_eap225-outdoor-v3.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_eap225-outdoor-v3.dts
@@ -35,12 +35,6 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		macaddr_info_8: macaddr@8 {
-			compatible = "mac-base";
-			reg = <0x8 0x6>;
-			#nvmem-cell-cells = <1>;
-		};
-
 		precalibration_ath10k: pre-calibration@5000 {
 			reg = <0x5000 0x2f20>;
 		};

--- a/target/linux/ath79/dts/qca9563_tplink_eap225-v1.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_eap225-v1.dts
@@ -56,12 +56,6 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		macaddr_info_8: macaddr@8 {
-			compatible = "mac-base";
-			reg = <0x8 0x6>;
-			#nvmem-cell-cells = <1>;
-		};
-
 		calibration_ath10k: calibration@5000 {
 			reg = <0x5000 0x844>;
 		};

--- a/target/linux/ath79/dts/qca9563_tplink_eap225-v3.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_eap225-v3.dts
@@ -35,12 +35,6 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		macaddr_info_8: macaddr@8 {
-			compatible = "mac-base";
-			reg = <0x8 0x6>;
-			#nvmem-cell-cells = <1>;
-		};
-
 		precalibration_ath10k: pre-calibration@5000 {
 			reg = <0x5000 0x2f20>;
 		};

--- a/target/linux/ath79/dts/qca9563_tplink_eap225-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_eap225-v4.dts
@@ -35,12 +35,6 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		macaddr_info_8: macaddr@8 {
-			compatible = "mac-base";
-			reg = <0x8 0x6>;
-			#nvmem-cell-cells = <1>;
-		};
-
 		precalibration_ath10k: pre-calibration@5000 {
 			reg = <0x5000 0x2f20>;
 		};

--- a/target/linux/ath79/dts/qca9563_tplink_eap245-v1.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_eap245-v1.dts
@@ -49,12 +49,6 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		macaddr_info_8: macaddr@8 {
-			compatible = "mac-base";
-			reg = <0x8 0x6>;
-			#nvmem-cell-cells = <1>;
-		};
-
 		calibration_ath10k: calibration@5000 {
 			reg = <0x5000 0x844>;
 		};

--- a/target/linux/ath79/dts/qca9563_tplink_eap2x5-1port.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_eap2x5-1port.dtsi
@@ -55,6 +55,18 @@
 				label = "info";
 				reg = <0x030000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_info_8: macaddr@8 {
+						compatible = "mac-base";
+						reg = <0x8 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			partition@40000 {


### PR DESCRIPTION
This should fix a bug introduced in
e816591e226a540000171a5a676e7033d3f0f128 where source of mac address was switched from 'info' partition to 'art'.

This patch updates a few devices that share same 'parent' device tree file. I suspect all of them had their mac detection broken with that commit. I have verified that this patch fixes the problem for eap225-outdoor-v3 - device that I actually own.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
