### PR TITLE
[23.05] mac80211: ath11k: sync with upstream

### DIFF
--- a/package/kernel/mac80211/patches/ath11k/0085-wifi-ath11k-fix-memory-leak-in-WMI-firmware-stats.patch
+++ b/package/kernel/mac80211/patches/ath11k/0085-wifi-ath11k-fix-memory-leak-in-WMI-firmware-stats.patch
@@ -1,0 +1,51 @@
+From 6aafa1c2d3e3fea2ebe84c018003f2a91722e607 Mon Sep 17 00:00:00 2001
+From: P Praneesh <quic_ppranees@quicinc.com>
+Date: Tue, 6 Jun 2023 14:41:28 +0530
+Subject: [PATCH] wifi: ath11k: fix memory leak in WMI firmware stats
+
+Memory allocated for firmware pdev, vdev and beacon statistics
+are not released during rmmod.
+
+Fix it by calling ath11k_fw_stats_free() function before hardware
+unregister.
+
+While at it, avoid calling ath11k_fw_stats_free() while processing
+the firmware stats received in the WMI event because the local list
+is getting spliced and reinitialised and hence there are no elements
+in the list after splicing.
+
+Tested-on: QCN9074 hw1.0 PCI WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: P Praneesh <quic_ppranees@quicinc.com>
+Signed-off-by: Aditya Kumar Singh <quic_adisi@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230606091128.14202-1-quic_adisi@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 1 +
+ drivers/net/wireless/ath/ath11k/wmi.c | 5 +++++
+ 2 files changed, 6 insertions(+)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -9792,6 +9792,7 @@ void ath11k_mac_destroy(struct ath11k_ba
+ 		if (!ar)
+ 			continue;
+ 
++		ath11k_fw_stats_free(&ar->fw_stats);
+ 		ieee80211_free_hw(ar->hw);
+ 		pdev->ar = NULL;
+ 	}
+--- a/drivers/net/wireless/ath/ath11k/wmi.c
++++ b/drivers/net/wireless/ath/ath11k/wmi.c
+@@ -8119,6 +8119,11 @@ complete:
+ 	rcu_read_unlock();
+ 	spin_unlock_bh(&ar->data_lock);
+ 
++	/* Since the stats's pdev, vdev and beacon list are spliced and reinitialised
++	 * at this point, no need to free the individual list.
++	 */
++	return;
++
+ free:
+ 	ath11k_fw_stats_free(&stats);
+ }

--- a/package/kernel/mac80211/patches/ath11k/0086-wifi-ath11k-Add-missing-check-for-ioremap.patch
+++ b/package/kernel/mac80211/patches/ath11k/0086-wifi-ath11k-Add-missing-check-for-ioremap.patch
@@ -1,0 +1,38 @@
+From 16e0077e14a73866e9b0f4a6bf4ad3d4a5cb0f2a Mon Sep 17 00:00:00 2001
+From: Jiasheng Jiang <jiasheng@iscas.ac.cn>
+Date: Tue, 13 Jun 2023 12:19:40 +0300
+Subject: [PATCH] wifi: ath11k: Add missing check for ioremap
+
+Add check for ioremap() and return the error if it fails in order to
+guarantee the success of ioremap(), same as in
+ath11k_qmi_load_file_target_mem().
+
+Fixes: 6ac04bdc5edb ("ath11k: Use reserved host DDR addresses from DT for PCI devices")
+Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230608022858.27405-1-jiasheng@iscas.ac.cn
+---
+ drivers/net/wireless/ath/ath11k/qmi.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/drivers/net/wireless/ath/ath11k/qmi.c
++++ b/drivers/net/wireless/ath/ath11k/qmi.c
+@@ -2061,6 +2061,9 @@ static int ath11k_qmi_assign_target_mem_
+ 			ab->qmi.target_mem[idx].iaddr =
+ 				ioremap(ab->qmi.target_mem[idx].paddr,
+ 					ab->qmi.target_mem[i].size);
++			if (!ab->qmi.target_mem[idx].iaddr)
++				return -EIO;
++
+ 			ab->qmi.target_mem[idx].size = ab->qmi.target_mem[i].size;
+ 			host_ddr_sz = ab->qmi.target_mem[i].size;
+ 			ab->qmi.target_mem[idx].type = ab->qmi.target_mem[i].type;
+@@ -2086,6 +2089,8 @@ static int ath11k_qmi_assign_target_mem_
+ 					ab->qmi.target_mem[idx].iaddr =
+ 						ioremap(ab->qmi.target_mem[idx].paddr,
+ 							ab->qmi.target_mem[i].size);
++					if (!ab->qmi.target_mem[idx].iaddr)
++						return -EIO;
+ 				} else {
+ 					ab->qmi.target_mem[idx].paddr =
+ 						ATH11K_QMI_CALDB_ADDRESS;

--- a/package/kernel/mac80211/patches/ath11k/0087-wifi-ath11k-Add-missing-ops-config-for-IPQ5018-in.patch
+++ b/package/kernel/mac80211/patches/ath11k/0087-wifi-ath11k-Add-missing-ops-config-for-IPQ5018-in.patch
@@ -1,0 +1,30 @@
+From 469ddb20cae61cad9c4f208a4c8682305905a511 Mon Sep 17 00:00:00 2001
+From: Ziyang Huang <hzyitc@outlook.com>
+Date: Thu, 15 Jun 2023 14:41:47 +0300
+Subject: [PATCH] wifi: ath11k: Add missing ops config for IPQ5018 in
+ ath11k_ahb_probe()
+
+Without this patch, the IPQ5018 WiFi will fail and print the following
+logs:
+
+	[   11.033179] ath11k c000000.wifi: unsupported device type 7
+	[   11.033223] ath11k: probe of c000000.wifi failed with error -95
+
+Fixes: 25edca7bb18a ("wifi: ath11k: add ipq5018 device support")
+Signed-off-by: Ziyang Huang <hzyitc@outlook.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/TYZPR01MB5556D7AA10ABEDDDD2D8F39EC953A@TYZPR01MB5556.apcprd01.prod.exchangelabs.com
+---
+ drivers/net/wireless/ath/ath11k/ahb.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/net/wireless/ath/ath11k/ahb.c
++++ b/drivers/net/wireless/ath/ath11k/ahb.c
+@@ -1127,6 +1127,7 @@ static int ath11k_ahb_probe(struct platf
+ 	switch (hw_rev) {
+ 	case ATH11K_HW_IPQ8074:
+ 	case ATH11K_HW_IPQ6018_HW10:
++	case ATH11K_HW_IPQ5018_HW10:
+ 		hif_ops = &ath11k_ahb_hif_ops_ipq8074;
+ 		pci_ops = NULL;
+ 		break;

--- a/package/kernel/mac80211/patches/ath11k/0088-wifi-ath11k-Restart-firmware-after-cold-boot-calibration.patch
+++ b/package/kernel/mac80211/patches/ath11k/0088-wifi-ath11k-Restart-firmware-after-cold-boot-calibration.patch
@@ -1,0 +1,47 @@
+From 80c5390e1f5e5b16d820512265530ef26073d8e0 Mon Sep 17 00:00:00 2001
+From: Ziyang Huang <hzyitc@outlook.com>
+Date: Thu, 15 Jun 2023 14:41:48 +0300
+Subject: [PATCH] wifi: ath11k: Restart firmware after cold boot calibration
+ for IPQ5018
+
+Restart is required after cold boot calibration on IPQ5018. Otherwise,
+we get the following exception:
+
+	[   14.412829] qcom-q6-mpd cd00000.remoteproc: fatal error received: err_smem_ver.2.1:
+	[   14.412829] QC Image Version : QC_IMAGE_VERSION_STRING=WLAN.HK.2.6.0.1-00974-QCAHKSWPL_SILICONZ-1
+	[   14.412829] Image Variant : IMAGE_VARIANT_STRING=5018.wlanfw2.map_spr_spr_evalQ
+	[   14.412829] DALSysLogEvent.c:174 Assertion 0 failed param0 :zero,param1 :zero,param2 :zero
+	[   14.412829] Thread ID : 0x00000048 Thread name : WLAN RT0 Process ID : 0x00000001 Process name :wlan0
+	[   14.412829]
+	[   14.412829] Registers:
+	[   14.412829] SP : 0x4c81c120
+	[   14.412829] FP : 0x4c81c138
+	[   14.412829] PC : 0xb022c590
+	[   14.412829] SSR : 0x00000000
+	[   14.412829] BADVA : 0x00000000
+	[   14.412829] LR : 0xb0008490
+	[   14.412829]
+	[   14.412829] StackDump
+	[   14.412829] from:0x4c81c120
+	[   14.412829] to: 0x00000000:
+	[   14.412829]
+	[   14.463006] remoteproc remoteproc0: crash detected in cd00000.remoteproc: type fatal error
+
+Fixes: 8dfe875aa24a ("wifi: ath11k: update hw params for IPQ5018")
+Signed-off-by: Ziyang Huang <hzyitc@outlook.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/TYZPR01MB55566969818BD4B49E770445C953A@TYZPR01MB5556.apcprd01.prod.exchangelabs.com
+---
+ drivers/net/wireless/ath/ath11k/core.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/net/wireless/ath/ath11k/core.c
++++ b/drivers/net/wireless/ath/ath11k/core.c
+@@ -668,6 +668,7 @@ static const struct ath11k_hw_params ath
+ 		.hal_params = &ath11k_hw_hal_params_ipq8074,
+ 		.single_pdev_only = false,
+ 		.cold_boot_calib = true,
++		.cbcal_restart_fw = true,
+ 		.fix_l1ss = true,
+ 		.supports_dynamic_smps_6ghz = false,
+ 		.alloc_cacheable_memory = true,

--- a/package/kernel/mac80211/patches/ath11k/0089-wifi-ath11k-Add-missing-hw_ops-get_ring_selector-for.patch
+++ b/package/kernel/mac80211/patches/ath11k/0089-wifi-ath11k-Add-missing-hw_ops-get_ring_selector-for.patch
@@ -1,0 +1,58 @@
+From ce282d8de71f07f0056ea319541141152c65f552 Mon Sep 17 00:00:00 2001
+From: Ziyang Huang <hzyitc@outlook.com>
+Date: Thu, 15 Jun 2023 14:41:48 +0300
+Subject: [PATCH] wifi: ath11k: Add missing hw_ops->get_ring_selector() for
+ IPQ5018
+
+During sending data after clients connected, hw_ops->get_ring_selector()
+will be called. But for IPQ5018, this member isn't set, and the
+following NULL pointer exception will be occurred:
+
+	[   38.840478] 8<--- cut here ---
+	[   38.840517] Unable to handle kernel NULL pointer dereference at virtual address 00000000
+	...
+	[   38.923161] PC is at 0x0
+	[   38.927930] LR is at ath11k_dp_tx+0x70/0x730 [ath11k]
+	...
+	[   39.063264] Process hostapd (pid: 1034, stack limit = 0x801ceb3d)
+	[   39.068994] Stack: (0x856a9a68 to 0x856aa000)
+	...
+	[   39.438467] [<7f323804>] (ath11k_dp_tx [ath11k]) from [<7f314e6c>] (ath11k_mac_op_tx+0x80/0x190 [ath11k])
+	[   39.446607] [<7f314e6c>] (ath11k_mac_op_tx [ath11k]) from [<7f17dbe0>] (ieee80211_handle_wake_tx_queue+0x7c/0xc0 [mac80211])
+	[   39.456162] [<7f17dbe0>] (ieee80211_handle_wake_tx_queue [mac80211]) from [<7f174450>] (ieee80211_probereq_get+0x584/0x704 [mac80211])
+	[   39.467443] [<7f174450>] (ieee80211_probereq_get [mac80211]) from [<7f178c40>] (ieee80211_tx_prepare_skb+0x1f8/0x248 [mac80211])
+	[   39.479334] [<7f178c40>] (ieee80211_tx_prepare_skb [mac80211]) from [<7f179e28>] (__ieee80211_subif_start_xmit+0x32c/0x3d4 [mac80211])
+	[   39.491053] [<7f179e28>] (__ieee80211_subif_start_xmit [mac80211]) from [<7f17af08>] (ieee80211_tx_control_port+0x19c/0x288 [mac80211])
+	[   39.502946] [<7f17af08>] (ieee80211_tx_control_port [mac80211]) from [<7f0fc704>] (nl80211_tx_control_port+0x174/0x1d4 [cfg80211])
+	[   39.515017] [<7f0fc704>] (nl80211_tx_control_port [cfg80211]) from [<808ceac4>] (genl_rcv_msg+0x154/0x340)
+	[   39.526814] [<808ceac4>] (genl_rcv_msg) from [<808cdb74>] (netlink_rcv_skb+0xb8/0x11c)
+	[   39.536446] [<808cdb74>] (netlink_rcv_skb) from [<808ce1d0>] (genl_rcv+0x28/0x34)
+	[   39.544344] [<808ce1d0>] (genl_rcv) from [<808cd234>] (netlink_unicast+0x174/0x274)
+	[   39.551895] [<808cd234>] (netlink_unicast) from [<808cd510>] (netlink_sendmsg+0x1dc/0x440)
+	[   39.559362] [<808cd510>] (netlink_sendmsg) from [<808596e0>] (____sys_sendmsg+0x1a8/0x1fc)
+	[   39.567697] [<808596e0>] (____sys_sendmsg) from [<8085b1a8>] (___sys_sendmsg+0xa4/0xdc)
+	[   39.575941] [<8085b1a8>] (___sys_sendmsg) from [<8085b310>] (sys_sendmsg+0x44/0x74)
+	[   39.583841] [<8085b310>] (sys_sendmsg) from [<80300060>] (ret_fast_syscall+0x0/0x40)
+	...
+	[   39.620734] Code: bad PC value
+	[   39.625869] ---[ end trace 8aef983ad3cbc032 ]---
+
+Fixes: ba60f2793d3a ("wifi: ath11k: initialize hw_ops for IPQ5018")
+Signed-off-by: Ziyang Huang <hzyitc@outlook.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/TYZPR01MB5556D6E3F63EAB5129D11420C953A@TYZPR01MB5556.apcprd01.prod.exchangelabs.com
+---
+ drivers/net/wireless/ath/ath11k/hw.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/wireless/ath/ath11k/hw.c
++++ b/drivers/net/wireless/ath/ath11k/hw.c
+@@ -1178,7 +1178,7 @@ const struct ath11k_hw_ops ipq5018_ops =
+ 	.mpdu_info_get_peerid = ath11k_hw_ipq8074_mpdu_info_get_peerid,
+ 	.rx_desc_mac_addr2_valid = ath11k_hw_ipq9074_rx_desc_mac_addr2_valid,
+ 	.rx_desc_mpdu_start_addr2 = ath11k_hw_ipq9074_rx_desc_mpdu_start_addr2,
+-
++	.get_ring_selector = ath11k_hw_ipq8074_get_tcl_ring_selector,
+ };
+ 
+ #define ATH11K_TX_RING_MASK_0 BIT(0)

--- a/package/kernel/mac80211/patches/ath11k/0090-Revert-wifi-ath11k-Enable-threaded-NAPI.patch
+++ b/package/kernel/mac80211/patches/ath11k/0090-Revert-wifi-ath11k-Enable-threaded-NAPI.patch
@@ -1,0 +1,44 @@
+From d265ebe41c911314bd273c218a37088835959fa1 Mon Sep 17 00:00:00 2001
+From: Kalle Valo <quic_kvalo@quicinc.com>
+Date: Thu, 20 Jul 2023 18:14:44 +0300
+Subject: [PATCH] Revert "wifi: ath11k: Enable threaded NAPI"
+
+This reverts commit 13aa2fb692d3717767303817f35b3e650109add3.
+
+This commit broke QCN9074 initialisation:
+
+[  358.960477] ath11k_pci 0000:04:00.0: ce desc not available for wmi command 36866
+[  358.960481] ath11k_pci 0000:04:00.0: failed to send WMI_STA_POWERSAVE_PARAM_CMDID
+[  358.960484] ath11k_pci 0000:04:00.0: could not set uapsd params -105
+
+As there's no fix available let's just revert it to get QCN9074 working again.
+
+Closes: https://bugzilla.kernel.org/show_bug.cgi?id=217536
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Signed-off-by: Kalle Valo <kvalo@kernel.org>
+Link: https://lore.kernel.org/r/20230720151444.2016637-1-kvalo@kernel.org
+---
+ drivers/net/wireless/ath/ath11k/ahb.c  | 1 -
+ drivers/net/wireless/ath/ath11k/pcic.c | 1 -
+ 2 files changed, 2 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/ahb.c
++++ b/drivers/net/wireless/ath/ath11k/ahb.c
+@@ -376,7 +376,6 @@ static void ath11k_ahb_ext_irq_enable(st
+ 		struct ath11k_ext_irq_grp *irq_grp = &ab->ext_irq_grp[i];
+ 
+ 		if (!irq_grp->napi_enabled) {
+-			dev_set_threaded(&irq_grp->napi_ndev, true);
+ 			napi_enable(&irq_grp->napi);
+ 			irq_grp->napi_enabled = true;
+ 		}
+--- a/drivers/net/wireless/ath/ath11k/pcic.c
++++ b/drivers/net/wireless/ath/ath11k/pcic.c
+@@ -466,7 +466,6 @@ void ath11k_pcic_ext_irq_enable(struct a
+ 		struct ath11k_ext_irq_grp *irq_grp = &ab->ext_irq_grp[i];
+ 
+ 		if (!irq_grp->napi_enabled) {
+-			dev_set_threaded(&irq_grp->napi_ndev, true);
+ 			napi_enable(&irq_grp->napi);
+ 			irq_grp->napi_enabled = true;
+ 		}

--- a/package/kernel/mac80211/patches/ath11k/0091-wifi-ath11k-Split-coldboot-calibration-hw_param.patch
+++ b/package/kernel/mac80211/patches/ath11k/0091-wifi-ath11k-Split-coldboot-calibration-hw_param.patch
@@ -1,0 +1,180 @@
+From 011e5a3052a22d3758d17442bf0c04c68bf79bea Mon Sep 17 00:00:00 2001
+From: Seevalamuthu Mariappan <quic_seevalam@quicinc.com>
+Date: Wed, 26 Jul 2023 19:40:30 +0530
+Subject: [PATCH 3/5] wifi: ath11k: Split coldboot calibration hw_param
+
+QCN9074 enables coldboot calibration only in Factory Test Mode (FTM).
+Hence, split cold_boot_calib to two hw_params for mission and FTM
+mode.
+
+Tested-on: QCN9074 hw1.0 PCI WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Seevalamuthu Mariappan <quic_seevalam@quicinc.com>
+Signed-off-by: Raj Kumar Bhagat <quic_rajkbhag@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230726141032.3061-2-quic_rajkbhag@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/ahb.c  |  3 +--
+ drivers/net/wireless/ath/ath11k/core.c | 36 ++++++++++++++++++++------
+ drivers/net/wireless/ath/ath11k/core.h |  1 +
+ drivers/net/wireless/ath/ath11k/hw.h   |  3 ++-
+ drivers/net/wireless/ath/ath11k/qmi.c  |  6 ++---
+ 5 files changed, 35 insertions(+), 14 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/ahb.c
++++ b/drivers/net/wireless/ath/ath11k/ahb.c
+@@ -422,8 +422,7 @@ static int ath11k_ahb_fwreset_from_cold_
+ {
+ 	int timeout;
+ 
+-	if (ath11k_cold_boot_cal == 0 || ab->qmi.cal_done ||
+-	    ab->hw_params.cold_boot_calib == 0 ||
++	if (!ath11k_core_coldboot_cal_support(ab) || ab->qmi.cal_done ||
+ 	    ab->hw_params.cbcal_restart_fw == 0)
+ 		return 0;
+ 
+--- a/drivers/net/wireless/ath/ath11k/core.c
++++ b/drivers/net/wireless/ath/ath11k/core.c
+@@ -86,7 +86,8 @@ static const struct ath11k_hw_params ath
+ 		.supports_shadow_regs = false,
+ 		.idle_ps = false,
+ 		.supports_sta_ps = false,
+-		.cold_boot_calib = true,
++		.coldboot_cal_mm = true,
++		.coldboot_cal_ftm = true,
+ 		.cbcal_restart_fw = true,
+ 		.fw_mem_mode = 0,
+ 		.num_vdevs = 16 + 1,
+@@ -167,7 +168,8 @@ static const struct ath11k_hw_params ath
+ 		.supports_shadow_regs = false,
+ 		.idle_ps = false,
+ 		.supports_sta_ps = false,
+-		.cold_boot_calib = true,
++		.coldboot_cal_mm = true,
++		.coldboot_cal_ftm = true,
+ 		.cbcal_restart_fw = true,
+ 		.fw_mem_mode = 0,
+ 		.num_vdevs = 16 + 1,
+@@ -248,7 +250,8 @@ static const struct ath11k_hw_params ath
+ 		.supports_shadow_regs = true,
+ 		.idle_ps = true,
+ 		.supports_sta_ps = true,
+-		.cold_boot_calib = false,
++		.coldboot_cal_mm = false,
++		.coldboot_cal_ftm = false,
+ 		.cbcal_restart_fw = false,
+ 		.fw_mem_mode = 0,
+ 		.num_vdevs = 16 + 1,
+@@ -332,7 +335,8 @@ static const struct ath11k_hw_params ath
+ 		.supports_shadow_regs = false,
+ 		.idle_ps = false,
+ 		.supports_sta_ps = false,
+-		.cold_boot_calib = false,
++		.coldboot_cal_mm = false,
++		.coldboot_cal_ftm = false,
+ 		.cbcal_restart_fw = false,
+ 		.fw_mem_mode = 2,
+ 		.num_vdevs = 8,
+@@ -413,7 +417,8 @@ static const struct ath11k_hw_params ath
+ 		.supports_shadow_regs = true,
+ 		.idle_ps = true,
+ 		.supports_sta_ps = true,
+-		.cold_boot_calib = false,
++		.coldboot_cal_mm = false,
++		.coldboot_cal_ftm = false,
+ 		.cbcal_restart_fw = false,
+ 		.fw_mem_mode = 0,
+ 		.num_vdevs = 16 + 1,
+@@ -495,7 +500,8 @@ static const struct ath11k_hw_params ath
+ 		.supports_shadow_regs = true,
+ 		.idle_ps = true,
+ 		.supports_sta_ps = true,
+-		.cold_boot_calib = false,
++		.coldboot_cal_mm = false,
++		.coldboot_cal_ftm = false,
+ 		.cbcal_restart_fw = false,
+ 		.fw_mem_mode = 0,
+ 		.num_vdevs = 16 + 1,
+@@ -578,7 +584,8 @@ static const struct ath11k_hw_params ath
+ 		.supports_shadow_regs = true,
+ 		.idle_ps = true,
+ 		.supports_sta_ps = true,
+-		.cold_boot_calib = true,
++		.coldboot_cal_mm = true,
++		.coldboot_cal_ftm = true,
+ 		.cbcal_restart_fw = false,
+ 		.fw_mem_mode = 0,
+ 		.num_vdevs = 16 + 1,
+@@ -667,7 +674,8 @@ static const struct ath11k_hw_params ath
+ 		.supports_suspend = false,
+ 		.hal_params = &ath11k_hw_hal_params_ipq8074,
+ 		.single_pdev_only = false,
+-		.cold_boot_calib = true,
++		.coldboot_cal_mm = true,
++		.coldboot_cal_ftm = true,
+ 		.cbcal_restart_fw = true,
+ 		.fix_l1ss = true,
+ 		.supports_dynamic_smps_6ghz = false,
+@@ -749,6 +757,18 @@ void ath11k_fw_stats_free(struct ath11k_
+ 	ath11k_fw_stats_bcn_free(&stats->bcn);
+ }
+ 
++bool ath11k_core_coldboot_cal_support(struct ath11k_base *ab)
++{
++	if (!ath11k_cold_boot_cal)
++		return false;
++
++	if (ath11k_ftm_mode)
++		return ab->hw_params.coldboot_cal_ftm;
++
++	else
++		return ab->hw_params.coldboot_cal_mm;
++}
++
+ int ath11k_core_suspend(struct ath11k_base *ab)
+ {
+ 	int ret;
+--- a/drivers/net/wireless/ath/ath11k/core.h
++++ b/drivers/net/wireless/ath/ath11k/core.h
+@@ -1186,6 +1186,7 @@ void ath11k_core_halt(struct ath11k *ar)
+ int ath11k_core_resume(struct ath11k_base *ab);
+ int ath11k_core_suspend(struct ath11k_base *ab);
+ void ath11k_core_pre_reconfigure_recovery(struct ath11k_base *ab);
++bool ath11k_core_coldboot_cal_support(struct ath11k_base *ab);
+ 
+ const struct firmware *ath11k_core_firmware_request(struct ath11k_base *ab,
+ 						    const char *filename);
+--- a/drivers/net/wireless/ath/ath11k/hw.h
++++ b/drivers/net/wireless/ath/ath11k/hw.h
+@@ -187,7 +187,8 @@ struct ath11k_hw_params {
+ 	bool supports_shadow_regs;
+ 	bool idle_ps;
+ 	bool supports_sta_ps;
+-	bool cold_boot_calib;
++	bool coldboot_cal_mm;
++	bool coldboot_cal_ftm;
+ 	bool cbcal_restart_fw;
+ 	int fw_mem_mode;
+ 	u32 num_vdevs;
+--- a/drivers/net/wireless/ath/ath11k/qmi.c
++++ b/drivers/net/wireless/ath/ath11k/qmi.c
+@@ -2082,7 +2082,7 @@ static int ath11k_qmi_assign_target_mem_
+ 				return -EINVAL;
+ 			}
+ 
+-			if (ath11k_cold_boot_cal && ab->hw_params.cold_boot_calib) {
++			if (ath11k_core_coldboot_cal_support(ab)) {
+ 				if (hremote_node) {
+ 					ab->qmi.target_mem[idx].paddr =
+ 							res.start + host_ddr_sz;
+@@ -3212,8 +3212,8 @@ static void ath11k_qmi_driver_event_work
+ 				break;
+ 			}
+ 
+-			if (ath11k_cold_boot_cal && ab->qmi.cal_done == 0 &&
+-			    ab->hw_params.cold_boot_calib) {
++			if (ab->qmi.cal_done == 0 &&
++			    ath11k_core_coldboot_cal_support(ab)) {
+ 				ath11k_qmi_process_coldboot_calibration(ab);
+ 			} else {
+ 				clear_bit(ATH11K_FLAG_CRASH_FLUSH,

--- a/package/kernel/mac80211/patches/ath11k/0092-wifi-ath11k-Add-coldboot-calibration-support-for-QCN.patch
+++ b/package/kernel/mac80211/patches/ath11k/0092-wifi-ath11k-Add-coldboot-calibration-support-for-QCN.patch
@@ -1,0 +1,176 @@
+From bdfc967bf5fcd762473a01d39edb81f1165ba290 Mon Sep 17 00:00:00 2001
+From: Anilkumar Kolli <quic_akolli@quicinc.com>
+Date: Wed, 26 Jul 2023 19:40:31 +0530
+Subject: [PATCH 4/5] wifi: ath11k: Add coldboot calibration support for
+ QCN9074
+
+QCN9074 supports 6 GHz, which has increased number of channels
+compared to 5 GHz/2 GHz. So, to support coldboot calibration in
+QCN9074 ATH11K_COLD_BOOT_FW_RESET_DELAY extended to 60 seconds. To
+avoid code redundancy, fwreset_from_cold_boot moved to QMI and made
+common for both ahb and pci. Coldboot calibration is enabled only in
+FTM mode for QCN9074. QCN9074 requires firmware restart after coldboot,
+hence enable cbcal_restart_fw in hw_params.
+
+This support can be enabled/disabled using hw params for different
+hardware. Currently it is not enabled for QCA6390.
+
+Tested-on: QCN9074 hw1.0 PCI WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Anilkumar Kolli <quic_akolli@quicinc.com>
+Signed-off-by: Seevalamuthu Mariappan <quic_seevalam@quicinc.com>
+Signed-off-by: Raj Kumar Bhagat <quic_rajkbhag@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230726141032.3061-3-quic_rajkbhag@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/ahb.c  | 28 ++------------------------
+ drivers/net/wireless/ath/ath11k/core.c |  4 ++--
+ drivers/net/wireless/ath/ath11k/pci.c  |  2 ++
+ drivers/net/wireless/ath/ath11k/qmi.c  | 28 ++++++++++++++++++++++++++
+ drivers/net/wireless/ath/ath11k/qmi.h  |  3 ++-
+ 5 files changed, 36 insertions(+), 29 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/ahb.c
++++ b/drivers/net/wireless/ath/ath11k/ahb.c
+@@ -14,6 +14,7 @@
+ #include "ahb.h"
+ #include "debug.h"
+ #include "hif.h"
++#include "qmi.h"
+ #include <linux/remoteproc.h>
+ #include "pcic.h"
+ #include <linux/soc/qcom/smem.h>
+@@ -418,31 +419,6 @@ static void ath11k_ahb_power_down(struct
+ 	rproc_shutdown(ab_ahb->tgt_rproc);
+ }
+ 
+-static int ath11k_ahb_fwreset_from_cold_boot(struct ath11k_base *ab)
+-{
+-	int timeout;
+-
+-	if (!ath11k_core_coldboot_cal_support(ab) || ab->qmi.cal_done ||
+-	    ab->hw_params.cbcal_restart_fw == 0)
+-		return 0;
+-
+-	ath11k_dbg(ab, ATH11K_DBG_AHB, "wait for cold boot done\n");
+-	timeout = wait_event_timeout(ab->qmi.cold_boot_waitq,
+-				     (ab->qmi.cal_done  == 1),
+-				     ATH11K_COLD_BOOT_FW_RESET_DELAY);
+-	if (timeout <= 0) {
+-		ath11k_cold_boot_cal = 0;
+-		ath11k_warn(ab, "Coldboot Calibration failed timed out\n");
+-	}
+-
+-	/* reset the firmware */
+-	ath11k_ahb_power_down(ab);
+-	ath11k_ahb_power_up(ab);
+-
+-	ath11k_dbg(ab, ATH11K_DBG_AHB, "exited from cold boot mode\n");
+-	return 0;
+-}
+-
+ static void ath11k_ahb_init_qmi_ce_config(struct ath11k_base *ab)
+ {
+ 	struct ath11k_qmi_ce_cfg *cfg = &ab->qmi.ce_cfg;
+@@ -1225,7 +1201,7 @@ static int ath11k_ahb_probe(struct platf
+ 		goto err_ce_free;
+ 	}
+ 
+-	ath11k_ahb_fwreset_from_cold_boot(ab);
++	ath11k_qmi_fwreset_from_cold_boot(ab);
+ 
+ 	return 0;
+ 
+--- a/drivers/net/wireless/ath/ath11k/core.c
++++ b/drivers/net/wireless/ath/ath11k/core.c
+@@ -336,8 +336,8 @@ static const struct ath11k_hw_params ath
+ 		.idle_ps = false,
+ 		.supports_sta_ps = false,
+ 		.coldboot_cal_mm = false,
+-		.coldboot_cal_ftm = false,
+-		.cbcal_restart_fw = false,
++		.coldboot_cal_ftm = true,
++		.cbcal_restart_fw = true,
+ 		.fw_mem_mode = 2,
+ 		.num_vdevs = 8,
+ 		.num_peers = 128,
+--- a/drivers/net/wireless/ath/ath11k/pci.c
++++ b/drivers/net/wireless/ath/ath11k/pci.c
+@@ -15,6 +15,7 @@
+ #include "mhi.h"
+ #include "debug.h"
+ #include "pcic.h"
++#include "qmi.h"
+ 
+ #define ATH11K_PCI_BAR_NUM		0
+ #define ATH11K_PCI_DMA_MASK		32
+@@ -897,6 +898,7 @@ unsupported_wcn6855_soc:
+ 		ath11k_err(ab, "failed to init core: %d\n", ret);
+ 		goto err_irq_affinity_cleanup;
+ 	}
++	ath11k_qmi_fwreset_from_cold_boot(ab);
+ 	return 0;
+ 
+ err_irq_affinity_cleanup:
+--- a/drivers/net/wireless/ath/ath11k/qmi.c
++++ b/drivers/net/wireless/ath/ath11k/qmi.c
+@@ -9,6 +9,7 @@
+ #include "qmi.h"
+ #include "core.h"
+ #include "debug.h"
++#include "hif.h"
+ #include <linux/of.h>
+ #include <linux/of_address.h>
+ #include <linux/ioport.h>
+@@ -2842,6 +2843,33 @@ int ath11k_qmi_firmware_start(struct ath
+ 	return 0;
+ }
+ 
++int ath11k_qmi_fwreset_from_cold_boot(struct ath11k_base *ab)
++{
++	int timeout;
++
++	if (!ath11k_core_coldboot_cal_support(ab) || ab->qmi.cal_done ||
++	    ab->hw_params.cbcal_restart_fw == 0)
++		return 0;
++
++	ath11k_dbg(ab, ATH11K_DBG_QMI, "wait for cold boot done\n");
++
++	timeout = wait_event_timeout(ab->qmi.cold_boot_waitq,
++				     (ab->qmi.cal_done == 1),
++				     ATH11K_COLD_BOOT_FW_RESET_DELAY);
++
++	if (timeout <= 0) {
++		ath11k_warn(ab, "Coldboot Calibration timed out\n");
++		return -ETIMEDOUT;
++	}
++
++	/* reset the firmware */
++	ath11k_hif_power_down(ab);
++	ath11k_hif_power_up(ab);
++	ath11k_dbg(ab, ATH11K_DBG_QMI, "exit wait for cold boot done\n");
++	return 0;
++}
++EXPORT_SYMBOL(ath11k_qmi_fwreset_from_cold_boot);
++
+ static int ath11k_qmi_process_coldboot_calibration(struct ath11k_base *ab)
+ {
+ 	int timeout;
+--- a/drivers/net/wireless/ath/ath11k/qmi.h
++++ b/drivers/net/wireless/ath/ath11k/qmi.h
+@@ -37,7 +37,7 @@
+ 
+ #define QMI_WLANFW_MAX_DATA_SIZE_V01		6144
+ #define ATH11K_FIRMWARE_MODE_OFF		4
+-#define ATH11K_COLD_BOOT_FW_RESET_DELAY		(40 * HZ)
++#define ATH11K_COLD_BOOT_FW_RESET_DELAY		(60 * HZ)
+ 
+ #define ATH11K_QMI_DEVICE_BAR_SIZE		0x200000
+ 
+@@ -519,5 +519,6 @@ void ath11k_qmi_msg_recv_work(struct wor
+ void ath11k_qmi_deinit_service(struct ath11k_base *ab);
+ int ath11k_qmi_init_service(struct ath11k_base *ab);
+ void ath11k_qmi_free_resource(struct ath11k_base *ab);
++int ath11k_qmi_fwreset_from_cold_boot(struct ath11k_base *ab);
+ 
+ #endif

--- a/package/kernel/mac80211/patches/ath11k/0093-wifi-ath11k-Remove-cal_done-check-during-probe.patch
+++ b/package/kernel/mac80211/patches/ath11k/0093-wifi-ath11k-Remove-cal_done-check-during-probe.patch
@@ -1,0 +1,33 @@
+From 13329d0cb7212b058bd8451a99d215a8f97645ea Mon Sep 17 00:00:00 2001
+From: Seevalamuthu Mariappan <quic_seevalam@quicinc.com>
+Date: Wed, 26 Jul 2023 19:40:32 +0530
+Subject: [PATCH] wifi: ath11k: Remove cal_done check during probe
+
+In some race conditions, calibration done QMI message is received even
+before host wait starts for calibration to be done.
+Due to this, resetting firmware was not performed after calibration.
+
+Hence, remove cal_done check in ath11k_qmi_fwreset_from_cold_boot()
+as this is called only from probe.
+
+Tested-on: QCN9074 hw1.0 PCI WLAN.HK.2.7.0.1-01744-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Seevalamuthu Mariappan <quic_seevalam@quicinc.com>
+Signed-off-by: Raj Kumar Bhagat <quic_rajkbhag@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230726141032.3061-4-quic_rajkbhag@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/qmi.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/wireless/ath/ath11k/qmi.c
++++ b/drivers/net/wireless/ath/ath11k/qmi.c
+@@ -2847,7 +2847,7 @@ int ath11k_qmi_fwreset_from_cold_boot(st
+ {
+ 	int timeout;
+ 
+-	if (!ath11k_core_coldboot_cal_support(ab) || ab->qmi.cal_done ||
++	if (!ath11k_core_coldboot_cal_support(ab) ||
+ 	    ab->hw_params.cbcal_restart_fw == 0)
+ 		return 0;
+ 

--- a/package/kernel/mac80211/patches/ath11k/0094-wifi-ath11k-mhi-add-a-warning-message-for-MHI_CB_EE.patch
+++ b/package/kernel/mac80211/patches/ath11k/0094-wifi-ath11k-mhi-add-a-warning-message-for-MHI_CB_EE.patch
@@ -1,0 +1,34 @@
+From 4a93b554cf9fa64faa7cf164c0d32fc3ce67108b Mon Sep 17 00:00:00 2001
+From: Arowa Suliman <arowa@chromium.org>
+Date: Sat, 26 Aug 2023 08:42:42 +0300
+Subject: [PATCH] wifi: ath11k: mhi: add a warning message for MHI_CB_EE_RDDM
+ crash
+
+Currently, the ath11k driver does not print a crash signature when a
+MHI_CB_EE_RDDM crash happens. Checked by triggering a simulated crash using the
+command and checking dmesg for logs:
+
+echo assert > /sys/kernel/debug/ath11k/../simulate_fw_crash
+
+Add a warning when firmware crash MHI_CB_EE_RDDM happens.
+
+Tested-on: WCN6855 hw2.0 PCI WLAN.HSP.1.1-03125-QCAHSPSWPL_V1_V2_SILICONZ_LITE-3.6510.23
+
+Signed-off-by: Arowa Suliman <arowa@chromium.org>
+Reviewed-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230714001126.463127-1-arowa@chromium.org
+---
+ drivers/net/wireless/ath/ath11k/mhi.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/net/wireless/ath/ath11k/mhi.c
++++ b/drivers/net/wireless/ath/ath11k/mhi.c
+@@ -333,6 +333,7 @@ static void ath11k_mhi_op_status_cb(stru
+ 		ath11k_warn(ab, "firmware crashed: MHI_CB_SYS_ERROR\n");
+ 		break;
+ 	case MHI_CB_EE_RDDM:
++		ath11k_warn(ab, "firmware crashed: MHI_CB_EE_RDDM\n");
+ 		if (!(test_bit(ATH11K_FLAG_UNREGISTERING, &ab->dev_flags)))
+ 			queue_work(ab->workqueue_aux, &ab->reset_work);
+ 		break;

--- a/package/kernel/mac80211/patches/ath11k/0095-wifi-ath11k-add-chip-id-board-name-while-searching-b.patch
+++ b/package/kernel/mac80211/patches/ath11k/0095-wifi-ath11k-add-chip-id-board-name-while-searching-b.patch
@@ -1,0 +1,214 @@
+From 1133af5aea588a58043244a4ecb5ce511b310356 Mon Sep 17 00:00:00 2001
+From: Wen Gong <quic_wgong@quicinc.com>
+Date: Wed, 30 Aug 2023 02:02:26 -0400
+Subject: [PATCH] wifi: ath11k: add chip id board name while searching
+ board-2.bin for WCN6855
+
+Sometimes board-2.bin does not have the board data which matched the
+parameters such as bus type, vendor, device, subsystem-vendor,
+subsystem-device, qmi-chip-id and qmi-board-id, then wlan will load fail.
+
+Hence add another type which only matches the bus type and qmi-chip-id,
+then the ratio of missing board data reduced.
+
+Tested-on: WCN6855 hw2.0 PCI WLAN.HSP.1.1-03125-QCAHSPSWPL_V1_V2_SILICONZ_LITE-3.6510.23
+
+Signed-off-by: Wen Gong <quic_wgong@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230830060226.18664-1-quic_wgong@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/core.c | 108 ++++++++++++++++++++-----
+ 1 file changed, 87 insertions(+), 21 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/core.c
++++ b/drivers/net/wireless/ath/ath11k/core.c
+@@ -985,9 +985,15 @@ int ath11k_core_check_dt(struct ath11k_b
+ 	return 0;
+ }
+ 
++enum ath11k_bdf_name_type {
++	ATH11K_BDF_NAME_FULL,
++	ATH11K_BDF_NAME_BUS_NAME,
++	ATH11K_BDF_NAME_CHIP_ID,
++};
++
+ static int __ath11k_core_create_board_name(struct ath11k_base *ab, char *name,
+ 					   size_t name_len, bool with_variant,
+-					   bool bus_type_mode)
++					   enum ath11k_bdf_name_type name_type)
+ {
+ 	/* strlen(',variant=') + strlen(ab->qmi.target.bdf_ext) */
+ 	char variant[9 + ATH11K_QMI_BDF_EXT_STR_LENGTH] = { 0 };
+@@ -998,11 +1004,8 @@ static int __ath11k_core_create_board_na
+ 
+ 	switch (ab->id.bdf_search) {
+ 	case ATH11K_BDF_SEARCH_BUS_AND_BOARD:
+-		if (bus_type_mode)
+-			scnprintf(name, name_len,
+-				  "bus=%s",
+-				  ath11k_bus_str(ab->hif.bus));
+-		else
++		switch (name_type) {
++		case ATH11K_BDF_NAME_FULL:
+ 			scnprintf(name, name_len,
+ 				  "bus=%s,vendor=%04x,device=%04x,subsystem-vendor=%04x,subsystem-device=%04x,qmi-chip-id=%d,qmi-board-id=%d%s",
+ 				  ath11k_bus_str(ab->hif.bus),
+@@ -1012,6 +1015,19 @@ static int __ath11k_core_create_board_na
+ 				  ab->qmi.target.chip_id,
+ 				  ab->qmi.target.board_id,
+ 				  variant);
++			break;
++		case ATH11K_BDF_NAME_BUS_NAME:
++			scnprintf(name, name_len,
++				  "bus=%s",
++				  ath11k_bus_str(ab->hif.bus));
++			break;
++		case ATH11K_BDF_NAME_CHIP_ID:
++			scnprintf(name, name_len,
++				  "bus=%s,qmi-chip-id=%d",
++				  ath11k_bus_str(ab->hif.bus),
++				  ab->qmi.target.chip_id);
++			break;
++		}
+ 		break;
+ 	default:
+ 		scnprintf(name, name_len,
+@@ -1030,19 +1046,29 @@ static int __ath11k_core_create_board_na
+ static int ath11k_core_create_board_name(struct ath11k_base *ab, char *name,
+ 					 size_t name_len)
+ {
+-	return __ath11k_core_create_board_name(ab, name, name_len, true, false);
++	return __ath11k_core_create_board_name(ab, name, name_len, true,
++					       ATH11K_BDF_NAME_FULL);
+ }
+ 
+ static int ath11k_core_create_fallback_board_name(struct ath11k_base *ab, char *name,
+ 						  size_t name_len)
+ {
+-	return __ath11k_core_create_board_name(ab, name, name_len, false, false);
++	return __ath11k_core_create_board_name(ab, name, name_len, false,
++					       ATH11K_BDF_NAME_FULL);
+ }
+ 
+ static int ath11k_core_create_bus_type_board_name(struct ath11k_base *ab, char *name,
+ 						  size_t name_len)
+ {
+-	return __ath11k_core_create_board_name(ab, name, name_len, false, true);
++	return __ath11k_core_create_board_name(ab, name, name_len, false,
++					       ATH11K_BDF_NAME_BUS_NAME);
++}
++
++static int ath11k_core_create_chip_id_board_name(struct ath11k_base *ab, char *name,
++						 size_t name_len)
++{
++	return __ath11k_core_create_board_name(ab, name, name_len, false,
++					       ATH11K_BDF_NAME_CHIP_ID);
+ }
+ 
+ const struct firmware *ath11k_core_firmware_request(struct ath11k_base *ab,
+@@ -1289,16 +1315,21 @@ int ath11k_core_fetch_board_data_api_1(s
+ #define BOARD_NAME_SIZE 200
+ int ath11k_core_fetch_bdf(struct ath11k_base *ab, struct ath11k_board_data *bd)
+ {
+-	char boardname[BOARD_NAME_SIZE], fallback_boardname[BOARD_NAME_SIZE];
++	char *boardname = NULL, *fallback_boardname = NULL, *chip_id_boardname = NULL;
+ 	char *filename, filepath[100];
+-	int ret;
++	int ret = 0;
+ 
+ 	filename = ATH11K_BOARD_API2_FILE;
++	boardname = kzalloc(BOARD_NAME_SIZE, GFP_KERNEL);
++	if (!boardname) {
++		ret = -ENOMEM;
++		goto exit;
++	}
+ 
+-	ret = ath11k_core_create_board_name(ab, boardname, sizeof(boardname));
++	ret = ath11k_core_create_board_name(ab, boardname, BOARD_NAME_SIZE);
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to create board name: %d", ret);
+-		return ret;
++		goto exit;
+ 	}
+ 
+ 	ab->bd_api = 2;
+@@ -1307,13 +1338,19 @@ int ath11k_core_fetch_bdf(struct ath11k_
+ 						 ATH11K_BD_IE_BOARD_NAME,
+ 						 ATH11K_BD_IE_BOARD_DATA);
+ 	if (!ret)
+-		goto success;
++		goto exit;
++
++	fallback_boardname = kzalloc(BOARD_NAME_SIZE, GFP_KERNEL);
++	if (!fallback_boardname) {
++		ret = -ENOMEM;
++		goto exit;
++	}
+ 
+ 	ret = ath11k_core_create_fallback_board_name(ab, fallback_boardname,
+-						     sizeof(fallback_boardname));
++						     BOARD_NAME_SIZE);
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to create fallback board name: %d", ret);
+-		return ret;
++		goto exit;
+ 	}
+ 
+ 	ret = ath11k_core_fetch_board_data_api_n(ab, bd, fallback_boardname,
+@@ -1321,7 +1358,28 @@ int ath11k_core_fetch_bdf(struct ath11k_
+ 						 ATH11K_BD_IE_BOARD_NAME,
+ 						 ATH11K_BD_IE_BOARD_DATA);
+ 	if (!ret)
+-		goto success;
++		goto exit;
++
++	chip_id_boardname = kzalloc(BOARD_NAME_SIZE, GFP_KERNEL);
++	if (!chip_id_boardname) {
++		ret = -ENOMEM;
++		goto exit;
++	}
++
++	ret = ath11k_core_create_chip_id_board_name(ab, chip_id_boardname,
++						    BOARD_NAME_SIZE);
++	if (ret) {
++		ath11k_err(ab, "failed to create chip id board name: %d", ret);
++		goto exit;
++	}
++
++	ret = ath11k_core_fetch_board_data_api_n(ab, bd, chip_id_boardname,
++						 ATH11K_BD_IE_BOARD,
++						 ATH11K_BD_IE_BOARD_NAME,
++						 ATH11K_BD_IE_BOARD_DATA);
++
++	if (!ret)
++		goto exit;
+ 
+ 	ab->bd_api = 1;
+ 	ret = ath11k_core_fetch_board_data_api_1(ab, bd, ATH11K_DEFAULT_BOARD_FILE);
+@@ -1334,14 +1392,22 @@ int ath11k_core_fetch_bdf(struct ath11k_
+ 			ath11k_err(ab, "failed to fetch board data for %s from %s\n",
+ 				   fallback_boardname, filepath);
+ 
++		ath11k_err(ab, "failed to fetch board data for %s from %s\n",
++			   chip_id_boardname, filepath);
++
+ 		ath11k_err(ab, "failed to fetch board.bin from %s\n",
+ 			   ab->hw_params.fw.dir);
+-		return ret;
+ 	}
+ 
+-success:
+-	ath11k_dbg(ab, ATH11K_DBG_BOOT, "using board api %d\n", ab->bd_api);
+-	return 0;
++exit:
++	kfree(boardname);
++	kfree(fallback_boardname);
++	kfree(chip_id_boardname);
++
++	if (!ret)
++		ath11k_dbg(ab, ATH11K_DBG_BOOT, "using board api %d\n", ab->bd_api);
++
++	return ret;
+ }
+ 
+ int ath11k_core_fetch_regdb(struct ath11k_base *ab, struct ath11k_board_data *bd)

--- a/package/kernel/mac80211/patches/ath11k/0096-wifi-ath11k-fix-boot-failure-with-one-MSI-vector.patch
+++ b/package/kernel/mac80211/patches/ath11k/0096-wifi-ath11k-fix-boot-failure-with-one-MSI-vector.patch
@@ -1,0 +1,103 @@
+From 39564b475ac5a589e6c22c43a08cbd283c295d2c Mon Sep 17 00:00:00 2001
+From: Baochen Qiang <quic_bqiang@quicinc.com>
+Date: Thu, 7 Sep 2023 09:56:06 +0800
+Subject: [PATCH] wifi: ath11k: fix boot failure with one MSI vector
+
+Commit 5b32b6dd96633 ("ath11k: Remove core PCI references from
+PCI common code") breaks with one MSI vector because it moves
+affinity setting after IRQ request, see below log:
+
+[ 1417.278835] ath11k_pci 0000:02:00.0: failed to receive control response completion, polling..
+[ 1418.302829] ath11k_pci 0000:02:00.0: Service connect timeout
+[ 1418.302833] ath11k_pci 0000:02:00.0: failed to connect to HTT: -110
+[ 1418.303669] ath11k_pci 0000:02:00.0: failed to start core: -110
+
+The detail is, if do affinity request after IRQ activated,
+which is done in request_irq(), kernel caches that request and
+returns success directly. Later when a subsequent MHI interrupt is
+fired, kernel will do the real affinity setting work, as a result,
+changs the MSI vector. However at that time host has configured
+old vector to hardware, so host never receives CE or DP interrupts.
+
+Fix it by setting affinity before registering MHI controller
+where host is, for the first time, doing IRQ request.
+
+Tested-on: WCN6855 hw2.0 PCI WLAN.HSP.1.1-03125-QCAHSPSWPL_V1_V2_SILICONZ_LITE-3
+Tested-on: WCN6855 hw2.1 PCI WLAN.HSP.1.1-03125-QCAHSPSWPL_V1_V2_SILICONZ_LITE-3.6510.23
+Tested-on: WCN6750 hw1.0 AHB WLAN.MSL.1.0.1-01160-QCAMSLSWPLZ-1
+
+Fixes: 5b32b6dd9663 ("ath11k: Remove core PCI references from PCI common code")
+Signed-off-by: Baochen Qiang <quic_bqiang@quicinc.com>
+Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
+Link: https://lore.kernel.org/r/20230907015606.16297-1-quic_bqiang@quicinc.com
+---
+ drivers/net/wireless/ath/ath11k/pci.c | 24 ++++++++++++------------
+ 1 file changed, 12 insertions(+), 12 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath11k/pci.c
++++ b/drivers/net/wireless/ath/ath11k/pci.c
+@@ -852,10 +852,16 @@ unsupported_wcn6855_soc:
+ 	if (ret)
+ 		goto err_pci_disable_msi;
+ 
++	ret = ath11k_pci_set_irq_affinity_hint(ab_pci, cpumask_of(0));
++	if (ret) {
++		ath11k_err(ab, "failed to set irq affinity %d\n", ret);
++		goto err_pci_disable_msi;
++	}
++
+ 	ret = ath11k_mhi_register(ab_pci);
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to register mhi: %d\n", ret);
+-		goto err_pci_disable_msi;
++		goto err_irq_affinity_cleanup;
+ 	}
+ 
+ 	ret = ath11k_hal_srng_init(ab);
+@@ -876,12 +882,6 @@ unsupported_wcn6855_soc:
+ 		goto err_ce_free;
+ 	}
+ 
+-	ret = ath11k_pci_set_irq_affinity_hint(ab_pci, cpumask_of(0));
+-	if (ret) {
+-		ath11k_err(ab, "failed to set irq affinity %d\n", ret);
+-		goto err_free_irq;
+-	}
+-
+ 	/* kernel may allocate a dummy vector before request_irq and
+ 	 * then allocate a real vector when request_irq is called.
+ 	 * So get msi_data here again to avoid spurious interrupt
+@@ -890,20 +890,17 @@ unsupported_wcn6855_soc:
+ 	ret = ath11k_pci_config_msi_data(ab_pci);
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to config msi_data: %d\n", ret);
+-		goto err_irq_affinity_cleanup;
++		goto err_free_irq;
+ 	}
+ 
+ 	ret = ath11k_core_init(ab);
+ 	if (ret) {
+ 		ath11k_err(ab, "failed to init core: %d\n", ret);
+-		goto err_irq_affinity_cleanup;
++		goto err_free_irq;
+ 	}
+ 	ath11k_qmi_fwreset_from_cold_boot(ab);
+ 	return 0;
+ 
+-err_irq_affinity_cleanup:
+-	ath11k_pci_set_irq_affinity_hint(ab_pci, NULL);
+-
+ err_free_irq:
+ 	ath11k_pcic_free_irq(ab);
+ 
+@@ -916,6 +913,9 @@ err_hal_srng_deinit:
+ err_mhi_unregister:
+ 	ath11k_mhi_unregister(ab_pci);
+ 
++err_irq_affinity_cleanup:
++	ath11k_pci_set_irq_affinity_hint(ab_pci, NULL);
++
+ err_pci_disable_msi:
+ 	ath11k_pci_free_msi(ab_pci);
+ 

--- a/package/kernel/mac80211/patches/ath11k/100-wifi-ath11k-use-unique-QRTR-instance-ID.patch
+++ b/package/kernel/mac80211/patches/ath11k/100-wifi-ath11k-use-unique-QRTR-instance-ID.patch
@@ -93,7 +93,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  	default:
  		return "UNKNOWN";
  	}
-@@ -336,27 +366,14 @@ static void ath11k_mhi_op_status_cb(stru
+@@ -337,27 +367,14 @@ static void ath11k_mhi_op_status_cb(stru
  		if (!(test_bit(ATH11K_FLAG_UNREGISTERING, &ab->dev_flags)))
  			queue_work(ab->workqueue_aux, &ab->reset_work);
  		break;
@@ -138,7 +138,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  int ath11k_mhi_register(struct ath11k_pci *ar_pci);
 --- a/drivers/net/wireless/ath/ath11k/pci.c
 +++ b/drivers/net/wireless/ath/ath11k/pci.c
-@@ -370,13 +370,20 @@ static void ath11k_pci_sw_reset(struct a
+@@ -371,13 +371,20 @@ static void ath11k_pci_sw_reset(struct a
  static void ath11k_pci_init_qmi_ce_config(struct ath11k_base *ab)
  {
  	struct ath11k_qmi_ce_cfg *cfg = &ab->qmi.ce_cfg;

--- a/package/kernel/mac80211/patches/ath11k/901-wifi-ath11k-pci-fix-compilation-in-5.16-and-older.patch
+++ b/package/kernel/mac80211/patches/ath11k/901-wifi-ath11k-pci-fix-compilation-in-5.16-and-older.patch
@@ -15,7 +15,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 
 --- a/drivers/net/wireless/ath/ath11k/pci.c
 +++ b/drivers/net/wireless/ath/ath11k/pci.c
-@@ -458,7 +458,11 @@ static int ath11k_pci_alloc_msi(struct a
+@@ -459,7 +459,11 @@ static int ath11k_pci_alloc_msi(struct a
  	pci_read_config_dword(pci_dev, pci_dev->msi_cap + PCI_MSI_ADDRESS_LO,
  			      &ab->pci.msi.addr_lo);
  

--- a/package/kernel/mac80211/patches/ath11k/902-ath11k-Disable-coldboot-calibration-for-IPQ8074.patch
+++ b/package/kernel/mac80211/patches/ath11k/902-ath11k-Disable-coldboot-calibration-for-IPQ8074.patch
@@ -13,12 +13,14 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 
 --- a/drivers/net/wireless/ath/ath11k/core.c
 +++ b/drivers/net/wireless/ath/ath11k/core.c
-@@ -86,7 +86,7 @@ static const struct ath11k_hw_params ath
+@@ -86,8 +86,8 @@ static const struct ath11k_hw_params ath
  		.supports_shadow_regs = false,
  		.idle_ps = false,
  		.supports_sta_ps = false,
--		.cold_boot_calib = true,
-+		.cold_boot_calib = false,
+-		.coldboot_cal_mm = true,
+-		.coldboot_cal_ftm = true,
++		.coldboot_cal_mm = false,
++		.coldboot_cal_ftm = false,
  		.cbcal_restart_fw = true,
  		.fw_mem_mode = 0,
  		.num_vdevs = 16 + 1,

--- a/package/kernel/mac80211/patches/ath11k/903-ath11k-support-setting-FW-memory-mode-via-DT.patch
+++ b/package/kernel/mac80211/patches/ath11k/903-ath11k-support-setting-FW-memory-mode-via-DT.patch
@@ -31,7 +31,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  	{
  		.hw_rev = ATH11K_HW_IPQ8074,
  		.name = "ipq8074 hw2.0",
-@@ -1953,7 +1953,8 @@ static void ath11k_core_reset(struct wor
+@@ -2040,7 +2040,8 @@ static void ath11k_core_reset(struct wor
  static int ath11k_init_hw_params(struct ath11k_base *ab)
  {
  	const struct ath11k_hw_params *hw_params = NULL;
@@ -41,7 +41,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  
  	for (i = 0; i < ARRAY_SIZE(ath11k_hw_params); i++) {
  		hw_params = &ath11k_hw_params[i];
-@@ -1969,7 +1970,30 @@ static int ath11k_init_hw_params(struct
+@@ -2056,7 +2057,31 @@ static int ath11k_init_hw_params(struct
  
  	ab->hw_params = *hw_params;
  
@@ -62,7 +62,8 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 +			ab->hw_params.fw_mem_mode = 2;
 +			ab->hw_params.num_vdevs = 8;
 +			ab->hw_params.num_peers = 128;
-+			ab->hw_params.cold_boot_calib = false;
++			ab->hw_params.coldboot_cal_mm = false;
++			ab->hw_params.coldboot_cal_ftm = false;
 +		} else
 +			ath11k_info(ab, "Unsupported FW memory mode: %u\n", fw_mem_mode);
 +	}


### PR DESCRIPTION
Synchronize the ath11k backports with upstream linux. Most of them are changes in kernel 6.5, the rest are fixes for the ath11k_pci. The most important one is "Revert 'wifi: ath11k: Enable threaded NAPI'", which fixes the problem that QCN9074 cannot be used after restarting on the x86 platform.

[   23.462718] ath11k_pci 0000:02:00.0: failed to vdev 0 create peer for AP: -110
[   28.503020] ath11k_pci 0000:02:00.0: Timeout in receiving vdev delete response

Changes to ipq8074 coldboot part pick from commit b33bfcf ("mac80211: ath11k: sync with ath-next").