### PR TITLE
hostapd: fix 802.11r defaults

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -943,6 +943,10 @@ hostapd_set_bss_options() {
 				set_default pmk_r1_push 0
 
 				[ -n "$r0kh" -a -n "$r1kh" ] || {
+					if [ -z "$auth_secret" -a -z "$key" ]; then
+						wireless_setup_vif_failed FT_KEY_CANT_BE_DERIVED
+						return 1
+					fi
 					ft_key=`echo -n "$mobility_domain/${auth_secret:-${key}}" | md5sum | awk '{print $1}'`
 
 					set_default r0kh "ff:ff:ff:ff:ff:ff,*,$ft_key"

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -920,7 +920,7 @@ hostapd_set_bss_options() {
 			set_default reassociation_deadline 1000
 
 			case "$auth_type" in
-				psk|sae|psk-sae)
+				psk)
 					set_default ft_psk_generate_local 1
 				;;
 				*)


### PR DESCRIPTION
Fix a few errors with the default configuration of 802.11r when using WPA and WPA3-SAE.

The first commit limits using 11r for WPA and checks that at least WPA2 is in use.

This is because 802.11r advertises FT support in-part through the Authentication and Key Management (AKM) suites in the Robust Security Network (RSN) Information Element, which was included in the 802.11i amendment and WPA2 certification program. Pre-standard WPA did not include the RSN IE, but the WPA IE. An this IE can not advertise the AKM suite for FT.

It moves the 11r configuration from the `if [ "$wpa" -ge "1" ]` to the `if [ "$wpa" -ge "2" ]`. The diff file doesn't show it clearly because it is only a movement of code with no changes.

This bug made iPhone 11 devices to reject the connection to a radio using WPA-PSK and 11r enabled. (I don't know if other Apple devices are affected, Android phones were working properly).

The second commit fixes client roamings for WPA3-SAE and WPA2-WPA3 Personal Mixed. It was using `ft_psk_generate_local` for configuration, but this approach doesn't work when using SAE. Instead use the r0kh and r1kh configuration approach. 

Edit: Added @rany2 commit from his other [PR](https://github.com/openwrt/openwrt/pull/14340) as requested in a comment below to centralize 802.11r fixes in this PR.

