### PR TITLE
[23.05] ipq807x: add support for Linksys MX4200 V1 and V2

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -2,13 +2,13 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/version.mk
 
 PKG_NAME:=ipq-wifi
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firmware/qca-wireless.git
-PKG_SOURCE_DATE:=2023-11-10
-PKG_SOURCE_VERSION:=0c2e810e71ed0a59fb00246c7fa2c236ff67a0ee
-PKG_MIRROR_HASH:=fc6016540bd2c67484952d0e4432d740f0e022d9b688e851bb6321def8d36844
+PKG_SOURCE_DATE:=2024-02-25
+PKG_SOURCE_VERSION:=fc30aeeb8ec5d069710a446f4eb5e30fc26145c1
+PKG_MIRROR_HASH:=7fe83e3f36541444e0385a56fa8a048772d0531e16787cc10bce29775c7db235
 
 PKG_FLAGS:=nonshared
 
@@ -34,6 +34,7 @@ ALLWIFIBOARDS:= \
 	edgecore_eap102 \
 	edimax_cax1800 \
 	netgear_wax218 \
+	linksys_mx4200 \
 	prpl_haze \
 	qnap_301w \
 	redmi_ax6 \
@@ -122,6 +123,7 @@ $(eval $(call generate-ipq-wifi-package,compex_wpq873,Compex WPQ-873))
 $(eval $(call generate-ipq-wifi-package,dynalink_dl-wrx36,Dynalink DL-WRX36))
 $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))
+$(eval $(call generate-ipq-wifi-package,linksys_mx4200,Linksys MX4200))
 $(eval $(call generate-ipq-wifi-package,netgear_wax218,Netgear WAX218))
 $(eval $(call generate-ipq-wifi-package,qnap_301w,QNAP 301w))
 $(eval $(call generate-ipq-wifi-package,prpl_haze,prpl Haze))

--- a/target/linux/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq807x/base-files/etc/board.d/02_network
@@ -31,6 +31,8 @@ ipq807x_setup_interfaces()
 	qnap,301w)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 10g-2" "10g-1"
 		;;
+	linksys,mx4200v1|\
+	linksys,mx4200v2|\
 	redmi,ax6|\
 	xiaomi,ax3600)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"

--- a/target/linux/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -12,6 +12,8 @@ case "$FIRMWARE" in
 	buffalo,wxr-5950ax12|\
 	edgecore,eap102|\
 	edimax,cax1800|\
+	linksys,mx4200v1|\
+	linksys,mx4200v2|\
 	dynalink,dl-wrx36|\
 	netgear,wax218|\
 	qnap,301w|\

--- a/target/linux/ipq807x/base-files/etc/init.d/bootcount
+++ b/target/linux/ipq807x/base-files/etc/init.d/bootcount
@@ -9,5 +9,9 @@ boot() {
 		# Unset changed flag after sysupgrade complete
 		fw_setenv changed
 	;;
+	linksys,mx4200v1|\
+	linksys,mx4200v2)
+		mtd resetbc s_env || true
+	;;
 	esac
 }

--- a/target/linux/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq807x/base-files/lib/upgrade/platform.sh
@@ -70,6 +70,21 @@ platform_do_upgrade() {
 	netgear,wax218)
 		nand_do_upgrade "$1"
 		;;
+	linksys,mx4200v1|\
+	linksys,mx4200v2)
+		boot_part="$(fw_printenv -n boot_part)"
+		if [ "$boot_part" -eq "1" ]; then
+			fw_setenv boot_part 2
+			CI_KERNPART="alt_kernel"
+			CI_UBIPART="alt_rootfs"
+		else
+			fw_setenv boot_part 1
+			CI_UBIPART="rootfs"
+		fi
+		fw_setenv boot_part_ready 3
+		fw_setenv auto_recovery yes
+		nand_do_upgrade "$1"
+		;;
 	prpl,haze|\
 	qnap,301w)
 		kernelname="0:HLOS"

--- a/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200.dtsi
+++ b/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200.dtsi
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2023, Mohammad Sayful Islam <Sayf.mohammad01@gmail.com> */
+
+#include "ipq8074.dtsi"
+#include "ipq8074-ac-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+
+	aliases {
+		serial0 = &blsp1_uart5;
+		serial1 = &blsp1_uart3;
+		/*
+		 * Aliases as required by u-boot
+		 * to patch MAC addresses
+		 */
+		ethernet1 = &dp2;
+		ethernet2 = &dp3;
+		ethernet3 = &dp4;
+		ethernet4 = &dp5;
+		led-boot = &led_system_blue;
+		led-running = &led_system_blue;
+		led-failsafe = &led_system_red;
+		led-upgrade = &led_system_green;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_0";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset-button {
+			label = "reset";
+			gpios = <&tlmm 52 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps-button {
+			label = "wps";
+			gpios = <&tlmm 67 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&tlmm {
+	button_pins: button-state {
+		pins = "gpio52", "gpio67";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+
+	mdio_pins: mdio-state {
+		mdc-pins {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio-pins {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	iot_pins: iot-state {
+		recovery-pins {
+			pins = "gpio22";
+			function = "gpio";
+			input;
+		};
+
+		reset-pins {
+			pins = "gpio21";
+			function = "gpio";
+			bias-pull-up;
+		};
+	};
+};
+
+&blsp1_uart3 {
+	status = "okay";
+
+	pinctrl-0 = <&hsuart_pins &iot_pins>;
+	pinctrl-names = "default";
+
+	/* Silicon Labs EFR32MG21 IoT */
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	/*
+	 * Bootloader will find the NAND DT node by the compatible and
+	 * then "fixup" it by adding the partitions from the SMEM table
+	 * using the legacy bindings thus making it impossible for us
+	 * to change the partition table or utilize NVMEM for calibration.
+	 * So add a dummy partitions node that bootloader will populate
+	 * and set it as disabled so the kernel ignores it instead of
+	 * printing warnings due to the broken way bootloader adds the
+	 * partitions.
+	 */
+	partitions {
+		status = "disabled";
+	};
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:sbl1";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "0:mibib";
+				reg = <0x100000 0x100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "0:bootconfig";
+				reg = <0x200000 0x80000>;
+				read-only;
+			};
+
+			partition@280000 {
+				label = "0:bootconfig1";
+				reg = <0x280000 0x80000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "0:qsee";
+				reg = <0x300000 0x300000>;
+				read-only;
+			};
+
+			partition@600000 {
+				label = "0:qsee_1";
+				reg = <0x600000 0x300000>;
+				read-only;
+			};
+
+			partition@900000 {
+				label = "0:devcfg";
+				reg = <0x900000 0x80000>;
+				read-only;
+			};
+
+			partition@980000 {
+				label = "0:devcfg_1";
+				reg = <0x980000 0x80000>;
+				read-only;
+			};
+
+			partition@a00000 {
+				label = "0:apdp";
+				reg = <0xa00000 0x80000>;
+				read-only;
+			};
+
+			partition@a80000 {
+				label = "0:apdp_1";
+				reg = <0xa80000 0x80000>;
+				read-only;
+			};
+
+			partition@b00000 {
+				label = "0:rpm";
+				reg = <0xb00000 0x80000>;
+				read-only;
+			};
+
+			partition@b80000 {
+				label = "0:rpm_1";
+				reg = <0xb80000 0x80000>;
+				read-only;
+			};
+
+			partition@c00000 {
+				label = "0:cdt";
+				reg = <0xc00000 0x80000>;
+				read-only;
+			};
+
+			partition@c80000 {
+				label = "0:cdt_1";
+				reg = <0xc80000 0x80000>;
+				read-only;
+			};
+
+			partition@d00000 {
+				label = "0:appsblenv";
+				reg = <0xd00000 0x80000>;
+			};
+
+			partition@d80000 {
+				label = "0:appsbl";
+				reg = <0xd80000 0x100000>;
+				read-only;
+			};
+
+			partition@e80000 {
+				label = "0:appsbl_1";
+				reg = <0xe80000 0x100000>;
+				read-only;
+			};
+
+			partition@f80000 {
+				label = "0:art";
+				reg = <0xf80000 0x80000>;
+				read-only;
+			};
+
+			partition@1000000 {
+				label = "u_env";
+				reg = <0x1000000 0x40000>;
+			};
+
+			partition@1040000 {
+				label = "s_env";
+				reg = <0x1040000 0x20000>;
+			};
+
+			partition@1060000 {
+				label = "devinfo";
+				reg = <0x1060000 0x20000>;
+				read-only;
+			};
+
+			partition@1080000 {
+				label = "kernel";
+				reg = <0x1080000 0x9600000>;
+			};
+
+			partition@1680000 {
+				label = "rootfs";
+				reg = <0x1680000 0x9000000>;
+			};
+
+			partition@a680000 {
+				label = "alt_kernel";
+				reg = <0xa680000 0x9600000>;
+			};
+
+			partition@ac80000 {
+				label = "alt_rootfs";
+				reg = <0xac80000 0x9000000>;
+			};
+			partition@13c80000 {
+				label = "sysdiag";
+				reg = <0x13c80000 0x200000>;
+				read-only;
+			};
+			partition@13e80000 {
+				label = "0:ethphyfw";
+				reg = <0x13e80000 0x80000>;
+				read-only;
+			};
+			partition@13f00000 {
+				label = "syscfg";
+				reg = <0x13f00000 0xb800000>;
+				read-only;
+			};
+			partition@1f700000 {
+				label = "0:wififw";
+				reg = <0x1f700000 0x900000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&blsp1_i2c2 {
+	status = "okay";
+
+	led-controller@62 {
+		compatible = "nxp,pca9633";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x62>;
+		nxp,hw-blink;
+
+		led_system_red: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_green: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+
+	qca8075_1: ethernet-phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <1>;
+	};
+
+	qca8075_2: ethernet-phy@2 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <2>;
+	};
+
+	qca8075_3: ethernet-phy@3 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <3>;
+	};
+
+	qca8075_4: ethernet-phy@4 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <4>;
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_lan_bmp = <(0x8 | 0x10 | 0x20)>; /* lan port bitmap */
+	switch_wan_bmp = <0x4>; /* wan port bitmap */
+	switch_mac_mode = <0x0>; /* mac mode for uniphy instance0 */
+	switch_mac_mode1 = <0xff>; /* mac mode for uniphy instance1 */
+	switch_mac_mode2 = <0xff>; /* mac mode for uniphy instance2 */
+
+	qcom,port_phyinfo {
+		port@2 {
+			port_id = <2>;
+			phy_address = <1>;
+		};
+		port@3 {
+			port_id = <3>;
+			phy_address = <2>;
+		};
+		port@4 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+		port@5 {
+			port_id = <5>;
+			phy_address = <4>;
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp2 {
+	status = "okay";
+	phy-handle = <&qca8075_1>;
+	label = "wan";
+};
+
+&dp3 {
+	status = "okay";
+	phy-handle = <&qca8075_2>;
+	label = "lan1";
+};
+
+&dp4 {
+	status = "okay";
+	phy-handle = <&qca8075_3>;
+	label = "lan2";
+};
+
+&dp5 {
+	status = "okay";
+	phy-handle = <&qca8075_4>;
+	label = "lan3";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&usb_0 {
+	status = "okay";
+};

--- a/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v1.dts
+++ b/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v1.dts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2023, Mohammad Sayful Islam <Sayf.mohammad01@gmail.com> */
+
+/dts-v1/;
+
+#include "ipq8074-512m.dtsi"
+#include "ipq8174-mx4200.dtsi"
+
+/ {
+	model = "Linksys MX4200v1";
+	compatible = "linksys,mx4200v1", "qcom,ipq8074";
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Linksys-MX4200v1";
+	qcom,ath11k-fw-memory-mode = <1>;
+};

--- a/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v2.dts
+++ b/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v2.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2023, Mohammad Sayful Islam <Sayf.mohammad01@gmail.com> */
+
+/dts-v1/;
+
+#include "ipq8174-mx4200.dtsi"
+
+/ {
+	model = "Linksys MX4200v2";
+	compatible = "linksys,mx4200v2", "qcom,ipq8074";
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Linksys-MX4200v2";
+};

--- a/target/linux/ipq807x/image/generic.mk
+++ b/target/linux/ipq807x/image/generic.mk
@@ -77,6 +77,29 @@ define Device/edimax_cax1800
 endef
 TARGET_DEVICES += edimax_cax1800
 
+define Device/linksys_mx4200v1
+	$(call Device/FitImage)
+	DEVICE_VENDOR := Linksys
+	DEVICE_MODEL := MX4200
+	DEVICE_VARIANT := v1
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	KERNEL_SIZE := 6144k
+	IMAGE_SIZE := 147456k
+	NAND_SIZE := 512m
+	SOC := ipq8174
+	IMAGES += factory.bin
+	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=MX4200
+	DEVICE_PACKAGES := kmod-leds-pca963x ipq-wifi-linksys_mx4200 kmod-bluetooth
+endef
+TARGET_DEVICES += linksys_mx4200v1
+
+define Device/linksys_mx4200v2
+	$(call Device/linksys_mx4200v1)
+	DEVICE_VARIANT := v2
+endef
+TARGET_DEVICES += linksys_mx4200v2
+
 define Device/netgear_wax218
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/ipq807x/patches-5.15/0128-cpufreq-qcom-nvmem-add-support-for-IPQ8074.patch
+++ b/target/linux/ipq807x/patches-5.15/0128-cpufreq-qcom-nvmem-add-support-for-IPQ8074.patch
@@ -3,8 +3,9 @@ From: Robert Marko <robimarko@gmail.com>
 Date: Sat, 31 Dec 2022 13:03:41 +0100
 Subject: [PATCH] cpufreq: qcom-nvmem: add support for IPQ8074
 
-IPQ8074 comes in 2 families:
+IPQ8074 comes in 3 families:
 * IPQ8070A/IPQ8071A (Acorn) up to 1.4GHz
+* IPQ8172/IPQ8173/IPQ8174 (Oak) up to 1.4GHz
 * IPQ8072A/IPQ8074A/IPQ8076A/IPQ8078A (Hawkeye) up to 2.2GHz
 
 So, in order to be able to share one OPP table lets add support for IPQ8074
@@ -16,8 +17,8 @@ will get created by NVMEM CPUFreq driver.
 Signed-off-by: Robert Marko <robimarko@gmail.com>
 ---
  drivers/cpufreq/cpufreq-dt-platdev.c |  1 +
- drivers/cpufreq/qcom-cpufreq-nvmem.c | 39 ++++++++++++++++++++++++++++
- 2 files changed, 40 insertions(+)
+ drivers/cpufreq/qcom-cpufreq-nvmem.c | 42 ++++++++++++++++++++++++++++
+ 2 files changed, 43 insertions(+)
 
 --- a/drivers/cpufreq/cpufreq-dt-platdev.c
 +++ b/drivers/cpufreq/cpufreq-dt-platdev.c
@@ -41,7 +42,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  struct qcom_cpufreq_drv;
  
  struct qcom_cpufreq_match_data {
-@@ -217,6 +220,37 @@ len_error:
+@@ -217,6 +220,40 @@ len_error:
  	return ret;
  }
  
@@ -60,6 +61,9 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 +	switch (msm_id) {
 +	case QCOM_ID_IPQ8070A:
 +	case QCOM_ID_IPQ8071A:
++	case QCOM_ID_IPQ8172:
++	case QCOM_ID_IPQ8173:
++	case QCOM_ID_IPQ8174:
 +		drv->versions = IPQ8074_ACORN_VERSION;
 +		break;
 +	case QCOM_ID_IPQ8072A:
@@ -79,7 +83,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  static const struct qcom_cpufreq_match_data match_data_kryo = {
  	.get_version = qcom_cpufreq_kryo_name_version,
  };
-@@ -231,6 +265,10 @@ static const struct qcom_cpufreq_match_d
+@@ -231,6 +268,10 @@ static const struct qcom_cpufreq_match_d
  	.genpd_names = qcs404_genpd_names,
  };
  
@@ -90,7 +94,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  static int qcom_cpufreq_probe(struct platform_device *pdev)
  {
  	struct qcom_cpufreq_drv *drv;
-@@ -430,6 +468,7 @@ static const struct of_device_id qcom_cp
+@@ -430,6 +471,7 @@ static const struct of_device_id qcom_cp
  	{ .compatible = "qcom,msm8996", .data = &match_data_kryo },
  	{ .compatible = "qcom,qcs404", .data = &match_data_qcs404 },
  	{ .compatible = "qcom,ipq8064", .data = &match_data_krait },

--- a/target/linux/ipq807x/patches-5.15/0132-v6.7-dt-bindings-arm-qcom-ids-Add-IDs-for-IPQ8174-family.patch
+++ b/target/linux/ipq807x/patches-5.15/0132-v6.7-dt-bindings-arm-qcom-ids-Add-IDs-for-IPQ8174-family.patch
@@ -1,0 +1,29 @@
+From 93e161c8f4b9b051e5e746814138cb5520b4b897 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Fri, 1 Sep 2023 20:10:04 +0200
+Subject: [PATCH] dt-bindings: arm: qcom,ids: Add IDs for IPQ8174 family
+
+IPQ8174 (Oak) family is part of the IPQ8074 family, but the ID-s for it
+are missing so lets add them.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+Reviewed-by: Kathiravan T <quic_kathirav@quicinc.com>
+Acked-by: Conor Dooley <conor.dooley@microchip.com>
+Link: https://lore.kernel.org/r/20230901181041.1538999-1-robimarko@gmail.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+---
+ include/dt-bindings/arm/qcom,ids.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/include/dt-bindings/arm/qcom,ids.h
++++ b/include/dt-bindings/arm/qcom,ids.h
+@@ -121,6 +121,9 @@
+ #define QCOM_ID_SM6125			394
+ #define QCOM_ID_IPQ8070A		395
+ #define QCOM_ID_IPQ8071A		396
++#define QCOM_ID_IPQ8172			397
++#define QCOM_ID_IPQ8173			398
++#define QCOM_ID_IPQ8174			399
+ #define QCOM_ID_IPQ6018			402
+ #define QCOM_ID_IPQ6028			403
+ #define QCOM_ID_IPQ6000			421


### PR DESCRIPTION
Backport of:

46a2490e8f24a1ad47e53b0b4ee875fa3658f2c1
45f86a12787d6d0deadcaedd67fed8bbb541743b

It also includes some changes to the kernel patches by @SpectreDev1 and some tweaks of my own.

### Linksys MX4200 is a 802.11ax Tri-band router/AP.

### Specifications

* CPU: Qualcomm IPQ8174 Quad core Cortex-A53 1.4GHz
* RAM: 512MB DDR3 (v1) | 1GB DDR3 (v2)
* Storage: 512MB NAND
* Ethernet: 4 x 1GbE RJ45 ports (QCA8075)
* WLAN:
        * 2.4GHz: Qualcomm QCN5024 2x2 802.11b/g/n/ax 574 Mbps PHY rate
        * 5GHz: Qualcomm QCN5054 2x2@80MHz 802.11a/b/g/n/ac/ax 2402 PHY rate
        * 5GHz: Qualcomm QCN5054 4x4@80MHz 802.11a/b/g/n/ac/ax 2402 PHY rate
* LED-s: RGB system led
* Buttons:
        * 1 x soft reset
        * 1 x WPS
* Power: 12V DC Jack

### Installation instructions

Open Linksys Web UI - http://192.168.1.1/ca or http://10.65.1.1/ca depending on your setup. Login with your admin password. The default password can be found on a sticker under the device. To enter into the support mode, click on the “CA” link and the bottom of the page. Open the “Connectivity” menu and upload the squash-factory image with the “Choose file” button. Click start. Ignore all the prompts and warnings by click “yes” in all the popups.

The Wifi radios are turned off by default. To configure the router, you will need to connect your computer to the LAN port of the device. Then you would need to write openwrt to the other partition for it to work
- First Check booted partition:
`fw_printenv -n boot_part`

- If booted in partition 1, install Openwrt to the other partition with:
`mtd -r -e alt_kernel -n write openwrt-ipq807x-generic-linksys_mx4200v(X)-squashfs-factory.bin alt_kernel`

- If booted in partition 2, use:
`mtd -r -e kernel -n write openwrt-ipq807x-generic-linksys_mx4200v(X)-squashfs-factory.bin kernel`

Replace (X) with your model version, either 1 or 2.