### PR TITLE
ath79: add WWAN serial driver and qmi for GL.iNET GL-E750 (Mudi)

### DIFF
--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -190,7 +190,8 @@ define Device/glinet_gl-e750
   SOC := qca9531
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-E750
-  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct kmod-usb2
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct kmod-usb2 \
+	kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
   SUPPORTED_DEVICES += gl-e750
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 131072k

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -8,7 +8,6 @@ ath79_setup_interfaces()
 
 	case "$board" in
 	aerohive,hiveap-121|\
-	glinet,gl-e750|\
 	meraki,mr18)
 		ucidef_set_interface_lan "eth0"
 		;;
@@ -25,6 +24,11 @@ ath79_setup_interfaces()
 	glinet,gl-ar750s-nor-nand)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:2" "3:lan:1" "1:wan"
+		;;
+	glinet,gl-e750|\
+	zte,mf282)
+		ucidef_set_interface_lan "eth0"
+		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
 		;;
 	glinet,gl-xe300)
 		ucidef_set_interface_wan "eth1"
@@ -68,10 +72,6 @@ ath79_setup_interfaces()
 	zte,mf281)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "5:lan"
-		;;
-	zte,mf282)
-		ucidef_set_interface_lan "eth0"
-		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
 		;;
 	zte,mf286|\
 	zte,mf286a|\


### PR DESCRIPTION
The driver for the cellular modems serial interface and qmi was missing from the default device packages. The driver is required to interact with the modem using AT commands.