### PR TITLE
qualcommax: 301w: enable using kernel for AQR firmware loadin

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
@@ -275,14 +275,14 @@
 	aqr113c_0: ethernet-phy@0 {
 		compatible ="ethernet-phy-ieee802.3-c45";
 		reg = <0>;
-		reset-gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
 		firmware-name = "marvell/AQR-G4_v5.4.C-AQR_CIG_WF-1945_0x0_ID44778_VER1630.cld";
 	};
 
 	aqr113c_8: ethernet-phy@8 {
 		compatible ="ethernet-phy-ieee802.3-c45";
 		reg = <8>;
-		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
 		firmware-name = "marvell/AQR-G4_v5.4.C-AQR_CIG_WF-1945_0x8_ID44776_VER1630.cld";
 	};
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
@@ -276,12 +276,14 @@
 		compatible ="ethernet-phy-ieee802.3-c45";
 		reg = <0>;
 		reset-gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
+		firmware-name = "marvell/AQR-G4_v5.4.C-AQR_CIG_WF-1945_0x0_ID44778_VER1630.cld";
 	};
 
 	aqr113c_8: ethernet-phy@8 {
 		compatible ="ethernet-phy-ieee802.3-c45";
 		reg = <8>;
 		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+		firmware-name = "marvell/AQR-G4_v5.4.C-AQR_CIG_WF-1945_0x8_ID44776_VER1630.cld";
 	};
 
 	qca8075_16: ethernet-phy@16 {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
@@ -260,7 +260,99 @@
 		spi-max-frequency = <50000000>;
 
 		partitions {
-			compatible = "qcom,smem-part";
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:sbl1";
+				reg = <0x0 0x50000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "0:mibib";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "0:qsee";
+				reg = <0x60000 0x180000>;
+				read-only;
+			};
+
+			partition@1e0000 {
+				label = "0:devcfg";
+				reg = <0x1e0000 0x10000>;
+				read-only;
+			};
+
+			partition@1f0000 {
+				label = "0:apdp";
+				reg = <0x1f0000 0x10000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "0:rpm";
+				reg = <0x200000 0x40000>;
+				read-only;
+			};
+
+			partition@240000 {
+				label = "0:cdt";
+				reg = <0x240000 0x10000>;
+				read-only;
+			};
+
+			partition@250000 {
+				label = "0:appsblenv";
+				reg = <0x250000 0x20000>;
+			};
+
+			partition@270000 {
+				label = "0:appsbl";
+				reg = <0x250000 0x100000>;
+				read-only;
+			};
+
+			partition@370000 {
+				label = "0:art";
+				reg = <0x370000 0x40000>;
+				read-only;
+			};
+
+			partition@3b0000 {
+				label = "0:ethphyfw1";
+				reg = <0x3b0000 0x80000>;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				aqr0_fw: firmware@0 {
+					reg = <0x0 0x5fc02>;
+				};
+			};
+
+			partition@430000 {
+				label = "0:ethphyfw2";
+				reg = <0x430000 0x80000>;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				aqr1_fw: firmware@0 {
+					reg = <0x0 0x5fc02>;
+				};
+			};
+
+			partition@4b0000 {
+				label = "reserved";
+				reg = <0x4b0000 0x350000>;
+			};
 		};
 	};
 };
@@ -277,6 +369,8 @@
 		reg = <0>;
 		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
 		firmware-name = "marvell/AQR-G4_v5.4.C-AQR_CIG_WF-1945_0x0_ID44778_VER1630.cld";
+		nvmem-cell-names = "firmware";
+		nvmem-cells = <&aqr0_fw>;
 	};
 
 	aqr113c_8: ethernet-phy@8 {
@@ -284,6 +378,8 @@
 		reg = <8>;
 		reset-gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
 		firmware-name = "marvell/AQR-G4_v5.4.C-AQR_CIG_WF-1945_0x8_ID44776_VER1630.cld";
+		nvmem-cell-names = "firmware";
+		nvmem-cells = <&aqr1_fw>;
 	};
 
 	qca8075_16: ethernet-phy@16 {


### PR DESCRIPTION
Currently, AQR firmware is loaded via U-Boot as previously there was no support for the kernel to load the firmware, however, that has recently changed and with the MDIO frequency fixed as well we can now rely on the kernel to load the firmware instead.

This has multiple benefits:
1. We do not have to modify the U-Boot environment during installation
2. AQR LED-s are properly configured as in the stock FW and both of them work
3. There is no need to wrap the firmware with an MBN header
4. Firmware can be easily extracted from the stock firmware

This PR allows loading the firmware via 2 ways:
1. Just place the FW binaries to `/lib/firmware`
2. Flash FW binaries to the respective `0:ethphyfw1` and `0:ethphyfw2` partitions and then they will be loaded via NVMEM.