### PR TITLE
[23.05] ath79: restore Ethernet traffic on Ubiquiti Bullet and Rocket M XW

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
@@ -11,7 +11,6 @@
 	status = "okay";
 
 	phy4: ethernet-phy@4 {
-		phy-mode = "rgmii";
 		reg = <4>;
 		max-speed = <100>;
 	};
@@ -20,7 +19,7 @@
 &eth0 {
 	status = "okay";
 
-	phy-mode = "rgmii";
+	phy-mode = "rgmii-txid";
 	phy-handle = <&phy4>;
 
 	gmac-config {

--- a/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
@@ -13,6 +13,7 @@
 	phy4: ethernet-phy@4 {
 		phy-mode = "rgmii";
 		reg = <4>;
+		max-speed = <100>;
 	};
 };
 

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -28,6 +28,9 @@ TARGET_DEVICES += ubnt_bullet-ac
 define Device/ubnt_bullet-m-xw
   $(Device/ubnt-xw)
   DEVICE_MODEL := Bullet M
+  DEVICE_ALT0_VENDOR := Ubiquiti
+  DEVICE_ALT0_MODEL := Rocket M
+  DEVICE_ALT0_VARIANT := XW
   DEVICE_PACKAGES += rssileds
   SUPPORTED_DEVICES += bullet-m-xw
 endef


### PR DESCRIPTION
Since commit https://github.com/openwrt/openwrt/commit/6f2e1b7485f0460b09168aef57931fe0ddedb884 ("ath79: disable delays on AT803X config init")
Ubiquiti XW boards equipped with AR8035 PHY suffered from lack of
outbound traffic on the Ethernet port. This was caused by the fact, the
U-boot has set this during boot and it wasn't reset by the PHY driver,
and the corresponding setting in device tree was wrong.

Set the 'phy-mode = "rgmii-txid"' at the &eth0, and drop this property
from PHY node, as it is not parsed there. This causes the device to
connect using Ethernet once again.

In addition, limit the advertised link speeds on those devices to 100Mbps, because onboard magnetics don't support gigabit, and with some broken link partners this may lead to lack of link establishment altogether, if the downshift procedure fails.

While at that, this series adds an alias for Rocket M XW, as it is working with the Bullet image without issues.

Fixes: https://github.com/openwrt/openwrt/issues/9178