### PR TITLE
bcm27xx: switch to bcm27xx-utils

### DIFF
--- a/package/utils/bcm27xx-userland/Makefile
+++ b/package/utils/bcm27xx-userland/Makefile
@@ -41,7 +41,6 @@ define Package/bcm27xx-userland
   CATEGORY:=Utilities
   DEPENDS:=@TARGET_bcm27xx
   TITLE:=BCM27xx userland tools
-  DEFAULT:=y if TARGET_bcm27xx
 endef
 
 define Package/bcm27xx-userland/description

--- a/target/linux/bcm27xx/Makefile
+++ b/target/linux/bcm27xx/Makefile
@@ -22,7 +22,7 @@ include $(INCLUDE_DIR)/target.mk
 
 DEFAULT_PACKAGES := $(filter-out urngd,$(DEFAULT_PACKAGES))
 DEFAULT_PACKAGES += \
-	bcm27xx-gpu-fw \
+	bcm27xx-gpu-fw bcm27xx-utils \
 	kmod-usb-hid \
 	kmod-sound-core kmod-sound-arm-bcm2835 \
 	kmod-fs-vfat kmod-nls-cp437 kmod-nls-iso8859-1 \


### PR DESCRIPTION
bcm27xx-userland is now deprecated and utils should be used instead:
https://github.com/raspberrypi/userland/commit/96a7334ae9d5fc9db7ac92e59852377df63f1848