### PR TITLE
qualcommax: dts: add reset delay to qca8081 phy

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
@@ -330,12 +330,14 @@
 	qca8081_24: ethernet-phy@24 {
 		compatible = "ethernet-phy-id004d.d101";
 		reg = <24>;
+		reset-deassert-us = <10000>;
 		reset-gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
 	};
 
 	qca8081_28: ethernet-phy@28 {
 		compatible = "ethernet-phy-id004d.d101";
 		reg = <28>;
+		reset-deassert-us = <10000>;
 		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-mf269.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-mf269.dts
@@ -388,12 +388,14 @@
 	qca8081_24: ethernet-phy@24 {
 		compatible = "ethernet-phy-id004d.d101";
 		reg = <24>;
+		reset-deassert-us = <10000>;
 		reset-gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
 	};
 
 	qca8081_28: ethernet-phy@28 {
 		compatible = "ethernet-phy-id004d.d101";
 		reg = <28>;
+		reset-deassert-us = <10000>;
 		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-aw1000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-aw1000.dts
@@ -267,6 +267,7 @@
 	qca8081: ethernet-phy@28 {
 		compatible = "ethernet-phy-id004d.d101";
 		reg = <28>;
+		reset-deassert-us = <10000>;
 		reset-gpios = <&tlmm 64 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
@@ -309,10 +309,11 @@
 
 	pinctrl-0 = <&mdio_pins>;
 	pinctrl-names = "default";
-   
+
 	qca8081_24: ethernet-phy@24 {
 		compatible = "ethernet-phy-id004d.d101";
 		reg = <24>;
+		reset-deassert-us = <10000>;
 		reset-gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
 
 		leds {
@@ -331,6 +332,7 @@
 	qca8081_28: ethernet-phy@28 {
 		compatible = "ethernet-phy-id004d.d101";
 		reg = <28>;
+		reset-deassert-us = <10000>;
 		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
 
 		leds {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
@@ -377,6 +377,7 @@
 	qca8081: ethernet-phy@24 {
 		compatible = "ethernet-phy-id004d.d101";
 		reg = <24>;
+		reset-deassert-us = <10000>;
 		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
 
 		leds {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-dl-wrx36.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-dl-wrx36.dts
@@ -162,6 +162,7 @@
 	qca8081: ethernet-phy@28 {
 		compatible = "ethernet-phy-id004d.d101";
 		reg = <28>;
+		reset-deassert-us = <10000>;
 		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
 
 		leds {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
@@ -294,6 +294,7 @@
 	qca8081: ethernet-phy@4{
 		compatible = "ethernet-phy-id004d.d101";
 		reg = <28>;
+		reset-deassert-us = <10000>;
 		reset-gpios = <&tlmm 31 GPIO_ACTIVE_LOW>;
 	};
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
@@ -202,6 +202,7 @@
 	qca8081: ethernet-phy@28 {
 		compatible = "ethernet-phy-id004d.d101";
 		reg = <28>;
+		reset-deassert-us = <10000>;
 		reset-gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
 	};
 };


### PR DESCRIPTION
The qca8081 phy needs to set the reset delay time, otherwise it will not be detected by the mdio bus.

Fixes: 75ad5c2 ("qualcommax: switch to qca8081 upstream PHY driver")