### PR TITLE
mbedtls: security bump to version 2.28.7

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=2.28.5
+PKG_VERSION:=2.28.7
 PKG_RELEASE:=2
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ARMmbed/mbedtls/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=849e86b626e42ded6bf67197b64aa771daa54e2a7e2868dc67e1e4711959e5e3
+PKG_HASH:=1df6073f0cf6a4e1953890bf5e0de2a8c7e6be50d6d6c69fa9fefcb1d14e981a
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=gpl-2.0.txt


### PR DESCRIPTION
[- Fix CVE-2024-23170 and CVE-2024-23775, one is RSA side channel private key recovery](https://github.com/Mbed-TLS/mbedtls/releases/tag/v2.28.7)

Signed-off-by: orangepizza <tjtncks@gmail.com>

need to backported to every maintained versions : 23.05 and 22.03 may need a point release there too