### PR TITLE
uboot-envtools: update to 2024.01

### DIFF
--- a/package/boot/uboot-envtools/Makefile
+++ b/package/boot/uboot-envtools/Makefile
@@ -9,15 +9,15 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uboot-envtools
 PKG_DISTNAME:=u-boot
-PKG_VERSION:=2023.07.02
-PKG_RELEASE:=3
+PKG_VERSION:=2024.01
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_DISTNAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \
     https://ftp.denx.de/pub/u-boot \
     https://mirror.cyberbits.eu/u-boot \
     ftp://ftp.denx.de/pub/u-boot
-PKG_HASH:=6b6a48581c14abb0f95bd87c1af4d740922406d7b801002a9f94727fdde021d5
+PKG_HASH:=b99611f1ed237bf3541bdc8434b68c96a6e05967061f992443cb30aabebef5b3
 PKG_SOURCE_SUBDIR:=$(PKG_DISTNAME)-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_DISTNAME)-$(PKG_VERSION)
 

--- a/package/boot/uboot-envtools/patches/002-Revert-tools-env-use-run-to-store-lockfile.patch
+++ b/package/boot/uboot-envtools/patches/002-Revert-tools-env-use-run-to-store-lockfile.patch
@@ -10,8 +10,6 @@ This reverts upstream commit
  tools/env/fw_env_main.c | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
-diff --git a/tools/env/fw_env_main.c b/tools/env/fw_env_main.c
-index 0b201b9e62..1d193bd437 100644
 --- a/tools/env/fw_env_main.c
 +++ b/tools/env/fw_env_main.c
 @@ -73,7 +73,7 @@ void usage_printenv(void)
@@ -32,7 +30,7 @@ index 0b201b9e62..1d193bd437 100644
  		" -s, --script         batch mode to minimize writes\n"
  		"\n"
  		"Examples:\n"
-@@ -206,7 +206,7 @@ int parse_setenv_args(int argc, char *argv[])
+@@ -206,7 +206,7 @@ int parse_setenv_args(int argc, char *ar
  
  int main(int argc, char *argv[])
  {
@@ -41,4 +39,3 @@ index 0b201b9e62..1d193bd437 100644
  	int lockfd = -1;
  	int retval = EXIT_SUCCESS;
  	char *_cmdname;
-


### PR DESCRIPTION
Update to latest version.

Refresh patches:
- 002-Revert-tools-env-use-run-to-store-lockfile.patch
