### PR TITLE
qualcommax: ipq807x: use ath11k_patch_mac and ath11k_remove_regdomain for MX4200 and RAX120v2

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -32,6 +32,30 @@ xor() {
 	printf "%0${retlen}x" "$ret"
 }
 
+data_2bin() {
+	local data=$1
+	local len=${#1}
+	local bin_data
+
+	for i in $(seq 0 2 $(($len - 1))); do
+		bin_data="${bin_data}\x${data:i:2}"
+	done
+
+	echo -ne $bin_data
+}
+
+data_2xor_val() {
+	local data=$1
+	local len=${#1}
+	local xor_data
+
+	for i in $(seq 0 4 $(($len - 1))); do
+		xor_data="${xor_data}${data:i:4} "
+	done
+
+	echo -n ${xor_data:0:-1}
+}
+
 append() {
 	local var="$1"
 	local value="$2"

--- a/package/base-files/files/lib/functions/caldata.sh
+++ b/package/base-files/files/lib/functions/caldata.sh
@@ -70,7 +70,7 @@ caldata_extract_reverse() {
 	local caldata
 
 	mtd=$(find_mtd_chardev "$part")
-	reversed=$(hexdump -v -s $offset -n $count -e '/1 "%02x "' $mtd)
+	reversed=$(hexdump -v -s $offset -n $count -e '1/1 "%02x "' $mtd)
 
 	for byte in $reversed; do
 		caldata="\x${byte}${caldata}"
@@ -122,49 +122,43 @@ caldata_valid() {
 	return $?
 }
 
-caldata_patch_chksum() {
-	local mac=$1
-	local mac_offset=$(($2))
+caldata_patch_data() {
+	local data=$1
+	local data_count=$((${#1} / 2))
+	local data_offset=$(($2))
 	local chksum_offset=$(($3))
 	local target=$4
-	local xor_mac
-	local xor_fw_mac
-	local xor_fw_chksum
+	local fw_data
+	local fw_chksum
 
-	xor_mac=${mac//:/}
-	xor_mac="${xor_mac:0:4} ${xor_mac:4:4} ${xor_mac:8:4}"
-
-	xor_fw_mac=$(hexdump -v -n 6 -s $mac_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
-	xor_fw_mac="${xor_fw_mac:0:4} ${xor_fw_mac:4:4} ${xor_fw_mac:8:4}"
-
-	xor_fw_chksum=$(hexdump -v -n 2 -s $chksum_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
-	xor_fw_chksum=$(xor $xor_fw_chksum $xor_fw_mac $xor_mac)
-
-	printf "%b" "\x${xor_fw_chksum:0:2}\x${xor_fw_chksum:2:2}" | \
-		dd of=$target conv=notrunc bs=1 seek=$chksum_offset count=2
-}
-
-caldata_patch_mac() {
-	local mac=$1
-	local mac_offset=$(($2))
-	local chksum_offset=$3
-	local target=$4
-
-	[ -z "$mac" -o -z "$mac_offset" ] && return
+	[ -z "$data" -o -z "$data_offset" ] && return
 
 	[ -n "$target" ] || target=/lib/firmware/$FIRMWARE
 
-	[ -n "$chksum_offset" ] && caldata_patch_chksum "$mac" "$mac_offset" "$chksum_offset" "$target"
+	fw_data=$(hexdump -v -n $data_count -s $data_offset -e '1/1 "%02x"' $target)
 
-	macaddr_2bin $mac | dd of=$target conv=notrunc oflag=seek_bytes bs=6 seek=$mac_offset count=1 || \
-		caldata_die "failed to write MAC address to eeprom file"
+	if [ "$data" != "$fw_data" ]; then
+
+		if [ -n "$chksum_offset" ]; then
+			fw_chksum=$(hexdump -v -n 2 -s $chksum_offset -e '1/1 "%02x"' $target)
+			fw_chksum=$(xor $fw_chksum $(data_2xor_val $fw_data) $(data_2xor_val $data))
+
+			data_2bin $fw_chksum | \
+				dd of=$target conv=notrunc bs=1 seek=$chksum_offset count=2 || \
+				caldata_die "failed to write chksum to eeprom file"
+		fi
+
+		data_2bin $data | \
+			dd of=$target conv=notrunc bs=1 seek=$data_offset count=$data_count || \
+			caldata_die "failed to write data to eeprom file"
+	fi
 }
 
 ath9k_patch_mac() {
 	local mac=$1
 	local target=$2
 
-	caldata_patch_mac "$mac" 0x2 "" "$target"
+	caldata_patch_data "${mac//:/}" 0x2 "" "$target"
 }
 
 ath9k_patch_mac_crc() {
@@ -173,12 +167,52 @@ ath9k_patch_mac_crc() {
 	local chksum_offset=$((mac_offset - 10))
 	local target=$4
 
-	caldata_patch_mac "$mac" "$mac_offset" "$chksum_offset" "$target"
+	caldata_patch_data "${mac//:/}" "$mac_offset" "$chksum_offset" "$target"
 }
 
 ath10k_patch_mac() {
 	local mac=$1
 	local target=$2
 
-	caldata_patch_mac "$mac" 0x6 0x2 "$target"
+	caldata_patch_data "${mac//:/}" 0x6 0x2 "$target"
+}
+
+ath11k_patch_mac() {
+	local mac=$1
+	# mac_id from 0 to 5
+	local mac_id=$2
+	local target=$3
+
+	[ -z "$mac_id" ] && return
+
+	caldata_patch_data "${mac//:/}" $(printf "0x%x" $(($mac_id * 0x6 + 0xe))) 0xa "$target"
+}
+
+ath10k_remove_regdomain() {
+	local target=$1
+
+	caldata_patch_data "0000" 0xc 0x2 "$target"
+}
+
+ath11k_remove_regdomain() {
+	local target=$1
+	local regdomain
+	local regdomain_data
+
+	regdomain=$(hexdump -v -n 2 -s 0x34 -e '1/1 "%02x"' $target)
+	caldata_patch_data "0000" 0x34 0xa "$target"
+	
+	for offset in 0x450 0x458 0x500 0x5a8; do
+		regdomain_data=$(hexdump -v -n 2 -s $offset -e '1/1 "%02x"' $target)
+
+		if [ "$regdomain" == "$regdomain_data" ]; then
+			caldata_patch_data "0000" $offset 0xa "$target"
+		fi
+	done
+}
+
+ath11k_set_macflag() {
+	local target=$1
+
+	caldata_patch_data "0100" 0x3e 0xa "$target"
 }

--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -279,12 +279,6 @@ macaddr_random() {
 	echo "$(macaddr_unsetbit_mc "$(macaddr_setbit_la "${randsrc}")")"
 }
 
-macaddr_2bin() {
-	local mac=$1
-
-	echo -ne \\x${mac//:/\\x}
-}
-
 macaddr_canonicalize() {
 	local mac="$1"
 	local canon=""

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -69,7 +69,6 @@ ipq807x_setup_macs()
 	local label_mac=""
 
 	case "$board" in
-		linksys,mx4200v1|\
 		linksys,mx4200v2)
 			label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 			for i in $(seq 3 5); do

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -16,8 +16,6 @@ case "$FIRMWARE" in
 	dynalink,dl-wrx36|\
 	edgecore,eap102|\
 	edimax,cax1800|\
-	linksys,mx4200v1|\
-	linksys,mx4200v2|\
 	linksys,mx5300|\
 	netgear,rax120v2|\
 	netgear,wax218|\
@@ -32,6 +30,19 @@ case "$FIRMWARE" in
 	zte,mf269|\
 	zyxel,nbg7815)
 		caldata_extract "0:art" 0x1000 0x20000
+		;;
+	linksys,mx4200v1)
+		caldata_extract "0:art" 0x1000 0x20000
+		ath11k_remove_regdomain
+		;;
+	linksys,mx4200v2)
+		caldata_extract "0:art" 0x1000 0x20000
+		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
+		ath11k_patch_mac $(macaddr_add $label_mac 2) 0
+		ath11k_patch_mac $(macaddr_add $label_mac 1) 1
+		ath11k_patch_mac $(macaddr_add $label_mac 3) 2
+		ath11k_remove_regdomain
+		ath11k_set_macflag
 		;;
 	prpl,haze|\
 	spectrum,sax1v1k)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -17,7 +17,6 @@ case "$FIRMWARE" in
 	edgecore,eap102|\
 	edimax,cax1800|\
 	linksys,mx5300|\
-	netgear,rax120v2|\
 	netgear,wax218|\
 	netgear,wax620|\
 	netgear,wax630|\
@@ -42,6 +41,13 @@ case "$FIRMWARE" in
 		ath11k_patch_mac $(macaddr_add $label_mac 1) 1
 		ath11k_patch_mac $(macaddr_add $label_mac 3) 2
 		ath11k_remove_regdomain
+		ath11k_set_macflag
+		;;
+	netgear,rax120v2)
+		caldata_extract "0:art" 0x1000 0x20000
+		ath11k_patch_mac $(mtd_get_mac_binary boarddata1 0xc) 0
+		ath11k_patch_mac $(mtd_get_mac_binary boarddata1 0x0) 1
+		ath11k_patch_mac $(mtd_get_mac_binary boarddata1 0x6) 2
 		ath11k_set_macflag
 		;;
 	prpl,haze|\

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -23,13 +23,6 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label) 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $(get_mac_label) 3 > /sys${DEVPATH}/macaddress
 		;;
-	linksys,mx4200v1|\
-	linksys,mx4200v2)
-		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
-		[ "$PHYNBR" = "0" ] && macaddr_add $label_mac 2 > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && macaddr_add $label_mac 1 > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "2" ] && macaddr_add $label_mac 3 > /sys${DEVPATH}/macaddress
-		;;
 	zbtlink,zbt-z800ax)
 		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label) -1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $(get_mac_label) -2 > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
Add new functions for ath11k caldata:
- ath11k_patch_mac (from 0 to 5)
- ath11k_remove_regdomain
- ath11k_set_macflag (some pre-caldata have the nvMacFlag flag unset which is needed to change the MAC address)

and use them for:
- MX4200 (only v2 variant requires MAC patching)
- RAX120v2 (pre-caldata does not contain valid MAC addresses)

Additionally for ath10k caldata:
- ath10k_remove_regdomain