### PR TITLE
hostapd: SAE passwords from a separate file

### DIFF
--- a/package/network/services/hostapd/files/hostapd.uc
+++ b/package/network/services/hostapd/files/hostapd.uc
@@ -10,6 +10,7 @@ hostapd.data.pending_config = {};
 hostapd.data.file_fields = {
 	vlan_file: true,
 	wpa_psk_file: true,
+	sae_password_file: true,
 	accept_mac_file: true,
 	deny_mac_file: true,
 	eap_user_file: true,

--- a/package/network/services/hostapd/patches/994-SAE-passwords-from-a-separate-file.patch
+++ b/package/network/services/hostapd/patches/994-SAE-passwords-from-a-separate-file.patch
@@ -1,0 +1,103 @@
+From e748e50c629f3e8d3c1c99843ef5439e568ed3ec Mon Sep 17 00:00:00 2001
+From: Shiva Sankar Gajula <quic_sgajula@quicinc.com>
+Date: Wed, 29 Nov 2023 14:56:27 +0530
+Subject: [PATCH] SAE passwords from a separate file
+
+Add a new hostapd configuration parameter sae_password_file to read SAE
+passwords (i.e., the entries that use the previously added sae_password
+parameter) from a separate file.
+
+sae_password_file uses the following format for storing passphrases:
+
+<password/credential>[|mac=<peer mac>][|vlanid=<VLAN ID>]
+[|pk=<m:ECPrivateKey-base64>][|id=<identifier>]
+
+Examples:
+
+<password>
+<password>|id=<pw identifier>
+<password>|mac=02:03:04:05:06:01|vlanid=1
+<password>|vlanid=3|id=<pw identifier>
+
+Signed-off-by: Shiva Sankar Gajula <quic_sgajula@quicinc.com>
+---
+ hostapd/config_file.c | 40 ++++++++++++++++++++++++++++++++++++++++
+ hostapd/hostapd.conf  |  4 ++++
+ 2 files changed, 44 insertions(+)
+
+--- a/hostapd/config_file.c
++++ b/hostapd/config_file.c
+@@ -2157,6 +2157,7 @@ static int add_airtime_weight(struct hos
+
+
+ #ifdef CONFIG_SAE
++
+ static int parse_sae_password(struct hostapd_bss_config *bss, const char *val)
+ {
+ 	struct sae_password_entry *pw;
+@@ -2260,6 +2261,38 @@ fail:
+ 	os_free(pw);
+ 	return -1;
+ }
++
++
++static int parse_sae_password_file(struct hostapd_bss_config *bss,
++				   const char *fname)
++{
++	FILE *f;
++	char buf[500], *pos;
++	unsigned int line = 0;
++
++	f = fopen(fname, "r");
++	if (!f) {
++		wpa_printf(MSG_ERROR, "sae_password_file '%s' not found.",
++			   fname);
++		return -1;
++	}
++
++	while (fgets(buf, sizeof(buf), f)) {
++		pos = os_strchr(buf, '\n');
++		if (pos)
++			*pos = '\0';
++		line++;
++		if (parse_sae_password(bss, buf)) {
++			wpa_printf(MSG_ERROR,
++				   "Invalid SAE password at line %d in '%s'",
++				   line, fname);
++			return -1;
++		}
++	}
++
++	return 0;
++}
++
+ #endif /* CONFIG_SAE */
+
+
+@@ -4320,6 +4353,13 @@ static int hostapd_config_fill(struct ho
+ 				   line);
+ 			return 1;
+ 		}
++	} else if (os_strcmp(buf, "sae_password_file") == 0) {
++		if (parse_sae_password_file(bss, pos) < 0) {
++			wpa_printf(MSG_ERROR,
++				   "Line %d: Invalid sae_password in file",
++				   line);
++			return 1;
++		}
+ #endif /* CONFIG_SAE */
+ 	} else if (os_strcmp(buf, "vendor_elements") == 0) {
+ 		if (parse_wpabuf_hex(line, buf, &bss->vendor_elements, pos))
+--- a/hostapd/hostapd.conf
++++ b/hostapd/hostapd.conf
+@@ -2019,6 +2019,10 @@ own_ip_addr=127.0.0.1
+ #sae_password=really secret|mac=ff:ff:ff:ff:ff:ff
+ #sae_password=example secret|mac=02:03:04:05:06:07|id=pw identifier
+ #sae_password=example secret|vlanid=3|id=pw identifier
++#
++# SAE passwords can also be read from a separate file in which each line
++# contains and entry in the same format as sae_password uses.
++#sae_password_file=/tc/hostapd.sae_passwords
+
+ # SAE threshold for anti-clogging mechanism (dot11RSNASAEAntiCloggingThreshold)
+ # This parameter defines how many open SAE instances can be in progress at the


### PR DESCRIPTION
## hostapd: SAE passwords from a separate file

[Upstream Backport]

Add a new hostapd configuration parameter sae_password_file to read SAE
passwords (i.e., the entries that use the previously added sae_password
parameter) from a separate file.

sae_password_file uses the following format for storing passphrases:

<password/credential>[|mac=<peer mac>][|vlanid=<VLAN ID>]
[|pk=<m:ECPrivateKey-base64>][|id=<identifier>]

Examples:

<password>
<password>|id=<pw identifier>
<password>|mac=02:03:04:05:06:01|vlanid=1
<password>|vlanid=3|id=<pw identifier>

## hostapd: add UCI option for sae_password_file

This PR adds the ability to set the sae_password_file option.

It functions exactly the same as the sae_password hostapd option except
the entries are loaded from a file. This is useful to have a per-device
SAE password and to assign devices to different VLANs without needing
to spin-up a RADIUS server.