### PR TITLE
ds-lite: Add support for IPIP6(RFC2473) tunnel

### DIFF
--- a/package/network/ipv6/ds-lite/Makefile
+++ b/package/network/ipv6/ds-lite/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ds-lite
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk
@@ -17,13 +17,13 @@ define Package/ds-lite
   SECTION:=net
   CATEGORY:=Network
   DEPENDS:=@IPV6 +kmod-ip6-tunnel +resolveip
-  TITLE:=Dual-Stack Lite (DS-Lite) configuration support
-  MAINTAINER:=Steven Barth <steven@midlink.org>
+  TITLE:=IPv4 over IPv6 (RFC2473 and DS-Lite) configuration support
+  MAINTAINER:=Arayuki Mago <ms@missing233.com>
   PKGARCH:=all
 endef
 
 define Package/ds-lite/description
-Provides support for Dual-Stack Lite in /etc/config/network.
+Provides support for IPv4 over IPv6 (RFC2473 and DS-Lite) in /etc/config/network.
 Refer to http://wiki.openwrt.org/doc/uci/network for
 configuration details.
 endef


### PR DESCRIPTION
Add Generic Packet Tunneling in IPv6 Specification (RFC 2473) support.
(For NTT Broadband V6Plus/transix/Xpass Fixed IP)

[depends on other PRs: openwrt/luci](https://github.com/openwrt/luci/pull/6875)
