### PR TITLE
[RFC] bcm27xx: support booting from USB/NVMe

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -307,7 +307,11 @@ if [ -n "$CONF_RESTORE" ]; then
 
 	[ "$VERBOSE" -gt 1 ] && TAR_V="v" || TAR_V=""
 	v "Restoring config files..."
-	tar -C / -x${TAR_V}zf "$CONF_RESTORE"
+	if [ "$(type -t platform_restore_backup)" == 'platform_restore_backup' ]; then
+		platform_restore_backup "$TAR_V"
+	else
+		tar -C / -x${TAR_V}zf "$CONF_RESTORE"
+	fi
 	exit $?
 fi
 

--- a/target/linux/bcm27xx/base-files/lib/preinit/79_move_config
+++ b/target/linux/bcm27xx/base-files/lib/preinit/79_move_config
@@ -16,7 +16,10 @@ move_config() {
 		insmod vfat
 		mkdir -p /boot
 		mount -t vfat -o rw,noatime /dev/$partdev /boot
-		[ -f "/boot/$BACKUP_FILE" ] && mv -f "/boot/$BACKUP_FILE" /
+		if [ -f "/boot/$BACKUP_FILE" ]; then
+			mv -f "/boot/$BACKUP_FILE" /
+			export BCM27XX_SET_ROOT_PART=1
+		fi
 	fi
 }
 

--- a/target/linux/bcm27xx/base-files/lib/preinit/81_set_root_part
+++ b/target/linux/bcm27xx/base-files/lib/preinit/81_set_root_part
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+. /lib/upgrade/platform.sh
+
+do_set_root_part() {
+	if [ "$BCM27XX_SET_ROOT_PART" -eq "1" ]; then
+		bcm27xx_set_root_part
+		unset BCM27XX_SET_ROOT_PART
+	fi
+}
+
+[ "$INITRAMFS" = "1" ] || boot_hook_add preinit_main do_set_root_part

--- a/target/linux/bcm27xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/bcm27xx/base-files/lib/upgrade/platform.sh
@@ -85,15 +85,46 @@ platform_do_upgrade() {
 	get_image "$@" | dd of="/dev/$diskdev" bs=1 skip=440 count=4 seek=440 conv=fsync
 }
 
+bcm27xx_set_root_part() {
+	local root_part
+
+	if [ -f "/boot/partuuid.txt" ]; then
+		root_part="PARTUUID=$(cat "/boot/partuuid.txt")-02"
+	else
+		root_part="/dev/mmcblk0p2"
+	fi
+
+	sed -i "s#\broot=[^ ]*#root=${root_part}#g" "/boot/cmdline.txt"
+}
+
 platform_copy_config() {
 	local partdev
 
 	if export_partdevice partdev 1; then
 		mkdir -p /boot
 		[ -f /boot/kernel*.img ] || mount -t vfat -o rw,noatime "/dev/$partdev" /boot
-		cp -af "$UPGRADE_BACKUP" "/boot/$BACKUP_FILE"
+
 		tar -C / -zxvf "$UPGRADE_BACKUP" boot/cmdline.txt boot/config.txt
+		bcm27xx_set_root_part
+
+		local backup_tmp="/tmp/backup-update"
+		mkdir -p $backup_tmp
+		tar -C $backup_tmp -zxvf $UPGRADE_BACKUP
+		cp -af /boot/cmdline.txt $backup_tmp/boot/
+
+		local work_dir=$(pwd)
+		cd $backup_tmp
+		tar -C $backup_tmp -zcvf /boot/$BACKUP_FILE *
+		cd $work_dir
+
 		sync
 		umount /boot
 	fi
+}
+
+platform_restore_backup() {
+	local TAR_V=$1
+
+	tar -C / -x${TAR_V}zf "$CONF_RESTORE"
+	bcm27xx_set_root_part
 }

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -15,13 +15,19 @@ endef
 
 ### Image scripts ###
 define Build/boot-common
+	echo $(IMG_PART_SIGNATURE) > $@-partuuid.txt
+	sed \
+		-e 's#@ROOT@#PARTUUID=$(IMG_PART_SIGNATURE)-02#g' \
+		cmdline.txt > $@-cmdline.txt
+
 	rm -f $@.boot
 	mkfs.fat -n boot -C $@.boot $(FAT32_BLOCKS)
 	mcopy -i $@.boot $(KDIR)/COPYING.linux ::
 	mcopy -i $@.boot $(KDIR)/LICENCE.broadcom ::
-	mcopy -i $@.boot cmdline.txt ::
+	mcopy -i $@.boot $@-cmdline.txt ::cmdline.txt
 	mcopy -i $@.boot config.txt ::
 	mcopy -i $@.boot distroconfig.txt ::
+	mcopy -i $@.boot $@-partuuid.txt ::partuuid.txt
 	mcopy -i $@.boot $(IMAGE_KERNEL) ::$(KERNEL_IMG)
 	$(foreach dts,$(shell echo $(DEVICE_DTS)),mcopy -i $@.boot $(DTS_DIR)/$(dts).dtb ::;)
 	mmd -i $@.boot ::/overlays

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -49,6 +49,7 @@ define Build/boot-2711
 endef
 
 define Build/sdcard-img
+	SIGNATURE="$(IMG_PART_SIGNATURE)" \
 	./gen_rpi_sdcard_img.sh $@ $@.boot $(IMAGE_ROOTFS) \
 		$(CONFIG_TARGET_KERNEL_PARTSIZE) $(CONFIG_TARGET_ROOTFS_PARTSIZE)
 endef

--- a/target/linux/bcm27xx/image/cmdline.txt
+++ b/target/linux/bcm27xx/image/cmdline.txt
@@ -1,1 +1,1 @@
-console=serial0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=squashfs,ext4 rootwait
+console=serial0,115200 console=tty1 root=@ROOT@ rootfstype=squashfs,ext4 rootwait

--- a/target/linux/bcm27xx/image/gen_rpi_sdcard_img.sh
+++ b/target/linux/bcm27xx/image/gen_rpi_sdcard_img.sh
@@ -19,7 +19,7 @@ kernel_type=c
 rootfs_type=83
 sect=63
 
-set $(ptgen -o $OUTPUT -h $head -s $sect -l $align -t $kernel_type -p ${BOOTFSSIZE}M -t $rootfs_type -p ${ROOTFSSIZE}M)
+set $(ptgen -o $OUTPUT -h $head -s $sect -l $align -t $kernel_type -p ${BOOTFSSIZE}M -t $rootfs_type -p ${ROOTFSSIZE}M ${SIGNATURE:+-S 0x$SIGNATURE})
 
 BOOTOFFSET="$(($1 / 512))"
 ROOTFSOFFSET="$(($3 / 512))"


### PR DESCRIPTION
This is my attempt to add USB booting to Raspberry Pi. There have been other attempts in the past, such as https://github.com/openwrt/openwrt/pull/9843
Comments/ideas are welcome :)