### PR TITLE
x86: Fix bios boot partition is under 1 MiB

### DIFF
--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -49,7 +49,7 @@ define Build/combined
 		$@ \
 		$(CONFIG_TARGET_KERNEL_PARTSIZE) $@.boot \
 		$(CONFIG_TARGET_ROOTFS_PARTSIZE) $(IMAGE_ROOTFS) \
-		256
+		1024
 endef
 
 define Build/grub-config


### PR DESCRIPTION
Fix: "warning: Your BIOS Boot Partition is under 1 MiB, please increase its size."
