### PR TITLE
ucode: ensure host libjson-c is built prior to ucode

### DIFF
--- a/package/utils/ucode/Makefile
+++ b/package/utils/ucode/Makefile
@@ -19,6 +19,7 @@ PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=ISC
 
 PKG_ABI_VERSION:=20230711
+HOST_BUILD_DEPENDS:=libjson-c/host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk


### PR DESCRIPTION
It appears that the host ucode build requires libjson-c/host before it can be built. Prior to this patch I was seeing multi-threaded build failures on slower machines.. it never seemed to happen on faster machines as I assume some other package built earlier in the process required it to be built.