### PR TITLE
ath79: Modify GL.iNer GL-S200 lan wan interface

### DIFF
--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -44,8 +44,6 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"6@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0@eth0"
 		;;
-	glinet,gl-s200-nor|\
-	glinet,gl-s200-nor-nand|\
 	netgear,pgzng1)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;


### PR DESCRIPTION
Specifications:
lan: eth0
wan: eth1

Problem Description:
    The lan wan port is reversed with the current machine.

Signed-off-by: Weiping Yang <weiping.yang@gl-inet.com>
