### PR TITLE
octeontx: update default network config

### DIFF
--- a/target/linux/octeontx/base-files/etc/board.d/02_network
+++ b/target/linux/octeontx/base-files/etc/board.d/02_network
@@ -9,6 +9,17 @@ board=$(board_name)
 board_config_update
 
 case "$board" in
+gw,gw610x|\
+gw,gw6903)
+	ucidef_set_interfaces_lan 'eth0'
+	;;
+gw,gw620x|\
+gw,gw630x)
+	ucidef_set_interfaces_lan_wan 'eth0' 'eth1'
+	;;
+gw,gw640x)
+	ucidef_set_interfaces_lan_wan 'eth0 eth1 eth2 eth3' 'eth4'
+	;;
 esac
 
 board_config_flush


### PR DESCRIPTION
Update the default network configuration for Gateworks Newport boards such that the left-most front-panel NIC is WAN and any additional are in LAN bridge:
 - gw610x/gw6903; single NIC: eth0
 - gw620x/gw630x; two NIC's from left to right are: eth1 eth0
 - gw640x; multiple NIC's from left to right: eth4 eth0 eth1 eth2 eth3