### PR TITLE
imx-cortexa9 ventana updates

### DIFF
--- a/target/linux/imx/cortexa9/base-files/etc/board.d/02_network
+++ b/target/linux/imx/cortexa9/base-files/etc/board.d/02_network
@@ -34,7 +34,7 @@ gw,imx6q-gw53xx|\
 gw,imx6q-gw5400-a|\
 gw,imx6q-gw54xx|\
 gw,imx6q-gw552x)
-	ucidef_set_interfaces_lan_wan 'eth0' 'eth1'
+	ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
 	;;
 wand,imx6dl-wandboard)
 	ucidef_set_interface_wan 'eth0'

--- a/target/linux/imx/image/cortexa9.mk
+++ b/target/linux/imx/image/cortexa9.mk
@@ -120,7 +120,8 @@ define Device/gateworks_ventana
 	imx6q-gw5913
   DEVICE_PACKAGES := kmod-sky2 kmod-sound-core kmod-sound-soc-imx \
 	kmod-sound-soc-imx-sgtl5000 kmod-can kmod-can-flexcan kmod-can-raw \
-	kmod-hwmon-gsc kmod-leds-gpio kmod-pps-gpio kobs-ng
+	kmod-hwmon-gsc kmod-leds-gpio kmod-pps-gpio kobs-ng \
+	kmod-gpio-button-hotplug
   KERNEL += | boot-overlay
   IMAGES := img.gz nand.ubi bootfs.tar.gz dtb
   IMAGE/nand.ubi := append-ubi


### PR DESCRIPTION
A couple of minor updates affecting Gateworks imx6qdl based ventana boards:
imx: add gpio-button-hotplug to ventana images
imx: update default network config for ventana

Hoping for a review from @xback