### PR TITLE
wireless-regdb: update to 2024.01.23

### DIFF
--- a/package/firmware/wireless-regdb/Makefile
+++ b/package/firmware/wireless-regdb/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wireless-regdb
-PKG_VERSION:=2023.09.01
+PKG_VERSION:=2024.01.23
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/network/wireless-regdb/
-PKG_HASH:=26d4c2a727cc59239b84735aad856b7c7d0b04e30aa5c235c4f7f47f5f053491
+PKG_HASH:=c8a61c9acf76fa7eb4239e89f640dee3e87098d9f69b4d3518c9c60fc6d20c55
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 
@@ -16,7 +16,7 @@ define Package/wireless-regdb
   PKGARCH:=all
   SECTION:=firmware
   CATEGORY:=Firmware
-  URL:=https://git.kernel.org/pub/scm/linux/kernel/git/sforshee/wireless-regdb.git/
+  URL:=https://git.kernel.org/pub/scm/linux/kernel/git/wens/wireless-regdb.git/
   TITLE:=Wireless Regulatory Database
 endef
 


### PR DESCRIPTION
The maintainer and repository of wireless-regdb has changed.
    https://lore.kernel.org/all/CAGb2v657baNMPKU3QADijx7hZa=GUcSv2LEDdn6N=QQaFX8r-g@mail.gmail.com/

Changes:
    37dcea0 wireless-regdb: Update keys and maintainer information
    9e0aee6 wireless-regdb: Makefile: Reproducible signatures
    8c784a1 wireless-regdb: Update regulatory rules for China (CN)
    149c709 wireless-regdb: Update regulatory rules for Japan (JP) for December 2023
    bd69898 wireless-regdb: Update regulatory rules for Singapore (SG) for September 2023
    d695bf2 wireless-regdb: Update and disable 5470-5730MHz band according to TPC ↵
    4541300 wireless-regdb: update regulatory database based on preceding changes
