### PR TITLE
mvebu: add kernel module for Turris Omnia Wi-Fi 6

### DIFF
--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -104,7 +104,7 @@ define Device/cznic_turris-omnia
   DEVICE_PACKAGES :=  \
     mkf2fs e2fsprogs kmod-fs-vfat kmod-nls-cp437 kmod-nls-iso8859-1 \
     wpad-basic-mbedtls kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct \
-    partx-utils kmod-i2c-mux-pca954x kmod-leds-turris-omnia
+    kmod-mt7915-firmware partx-utils kmod-i2c-mux-pca954x kmod-leds-turris-omnia
   IMAGES := sysupgrade.img.gz
   IMAGE/sysupgrade.img.gz := boot-scr | boot-img | sdcard-img | gzip | append-metadata
   SUPPORTED_DEVICES += armada-385-turris-omnia


### PR DESCRIPTION
The following kernel module package was added to the build recipe for the
Turris Omnia: kmod-mt7915-firmware

This module enables support for the official Wi-Fi 6 upgrade kit sold by
CZ.NIC, which includes the AW7915-NP1 miniPCIE board based on Mediatek
MT7915AN, providing 5 GHz Wi-Fi 6 connectivity. With this commit we now
support the latest Turris Omnia Wi-Fi 6 Edition.