### PR TITLE
generic: 6.1: backport patch to enable PHYLIB_LEDS kconfig dynamically

### DIFF
--- a/target/linux/generic/backport-6.1/837-v6.4-net-phy-hide-the-PHYLIB_LEDS-knob.patch
+++ b/target/linux/generic/backport-6.1/837-v6.4-net-phy-hide-the-PHYLIB_LEDS-knob.patch
@@ -1,0 +1,43 @@
+From 9b78d919632b7149d311aaad5a977e4b48b10321 Mon Sep 17 00:00:00 2001
+From: Paolo Abeni <pabeni@redhat.com>
+Date: Wed, 26 Apr 2023 10:15:31 +0200
+Subject: [PATCH] net: phy: hide the PHYLIB_LEDS knob
+
+commit 4bb7aac70b5d ("net: phy: fix circular LEDS_CLASS dependencies")
+solved a build failure, but introduces a new config knob with a default
+'y' value: PHYLIB_LEDS.
+
+The latter is against the current new config policy. The exception
+was raised to allow the user to catch bad configurations without led
+support.
+
+Anyway the current definition of PHYLIB_LEDS does not fit the above
+goal: if LEDS_CLASS is disabled, the new config will be available
+only with PHYLIB disabled, too.
+
+Hide the mentioned config, to preserve the randconfig testing done so
+far, while respecting the mentioned policy.
+
+Suggested-by: Andrew Lunn <andrew@lunn.ch>
+Suggested-by: Arnd Bergmann <arnd@arndb.de>
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+Link: https://lore.kernel.org/r/d82489be8ed911c383c3447e9abf469995ccf39a.1682496488.git.pabeni@redhat.com
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/phy/Kconfig | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+--- a/drivers/net/phy/Kconfig
++++ b/drivers/net/phy/Kconfig
+@@ -45,10 +45,8 @@ config LED_TRIGGER_PHY
+ 		for any speed known to the PHY.
+ 
+ config PHYLIB_LEDS
+-	bool "Support probing LEDs from device tree"
++	def_bool OF
+ 	depends on LEDS_CLASS=y || LEDS_CLASS=PHYLIB
+-	depends on OF
+-	default y
+ 	help
+ 	  When LED class support is enabled, phylib can automatically
+ 	  probe LED setting from device tree.

--- a/target/linux/generic/hack-6.1/700-swconfig_switch_drivers.patch
+++ b/target/linux/generic/hack-6.1/700-swconfig_switch_drivers.patch
@@ -12,7 +12,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -69,6 +69,80 @@ config SFP
+@@ -67,6 +67,80 @@ config SFP
  	depends on HWMON || HWMON=n
  	select MDIO_I2C
  

--- a/target/linux/mediatek/patches-6.1/500-gsw-rtl8367s-mt7622-support.patch
+++ b/target/linux/mediatek/patches-6.1/500-gsw-rtl8367s-mt7622-support.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -381,6 +381,12 @@ config ROCKCHIP_PHY
+@@ -379,6 +379,12 @@ config ROCKCHIP_PHY
  	help
  	  Currently supports the integrated Ethernet PHY.
  

--- a/target/linux/mediatek/patches-6.1/730-v6.5-net-phy-add-driver-for-MediaTek-SoC-built-in-GE-PHYs.patch
+++ b/target/linux/mediatek/patches-6.1/730-v6.5-net-phy-add-driver-for-MediaTek-SoC-built-in-GE-PHYs.patch
@@ -42,7 +42,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  L:	linux-i2c@vger.kernel.org
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -311,6 +311,18 @@ config MEDIATEK_GE_PHY
+@@ -309,6 +309,18 @@ config MEDIATEK_GE_PHY
  	help
  	  Supports the MediaTek Gigabit Ethernet PHYs.
  

--- a/target/linux/mediatek/patches-6.1/733-net-phy-add-driver-for-MediaTek-2.5G-PHY.patch
+++ b/target/linux/mediatek/patches-6.1/733-net-phy-add-driver-for-MediaTek-2.5G-PHY.patch
@@ -13,7 +13,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -323,6 +323,13 @@ config MEDIATEK_GE_SOC_PHY
+@@ -321,6 +321,13 @@ config MEDIATEK_GE_SOC_PHY
  	  present in the SoCs efuse and will dynamically calibrate VCM
  	  (common-mode voltage) during startup.
  


### PR DESCRIPTION
Backport patch to enable PHYLIB_LEDS kconfig dynamically instead of having to select this config for every target that makes use of PHY LEDs API.

All affected patch are automatically refreshed.