### PR TITLE
build: add support for checksec.sh based mitigation reports

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -34,6 +34,13 @@ menu "Global build settings"
 		  directory containing Software Bill Of Materials in CycloneDX
 		  format.
 
+	config JSON_CHECKSEC_MITIGATIONS_REPORT
+		bool
+		prompt "Create binaries hardening report (based on checksec.sh)"
+		help
+		  Create a JSON file *.checksec.json in the build
+		  directory containing the result of checksec.
+
 	config ALL_NONSHARED
 		bool "Select all target specific packages by default"
 		select ALL_KMODS

--- a/include/image.mk
+++ b/include/image.mk
@@ -285,6 +285,10 @@ ifndef IB
 		$(TMP_DIR)/.packageinfo \
 		$(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED)).manifest > \
 		$(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED)).bom.cdx.json)
+	$(if $(CONFIG_JSON_CHECKSEC_MITIGATIONS_REPORT), \
+		$(PYTHON) $(SCRIPT_DIR)/checksec-mitigation-report.py \
+		$(BUILD_DIR) \
+		$(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED)).checksec.json)
 endif
 endef
 

--- a/include/package-ipkg.mk
+++ b/include/package-ipkg.mk
@@ -218,6 +218,19 @@ $(_endef)
 	$(if $(PROVIDES),@for pkg in $(filter-out $(1),$(PROVIDES)); do cp $(PKG_INFO_DIR)/$(1).provides $(PKG_INFO_DIR)/$$$$pkg.provides; done)
 	$(CheckDependencies)
 
+# We need to run checksec.sh before stripping for working stack canary check.
+    ifneq ($$(CONFIG_JSON_CHECKSEC_MITIGATIONS_REPORT),)
+	( \
+		mkdir -p $(PKG_BUILD_DIR)/CHECKSEC/$(1)/ && \
+		checksec --output=json --dir=$$(IDIR_$(1)) > $(PKG_BUILD_DIR)/CHECKSEC/$(1)/checksec_report.json && \
+		$(PYTHON) $(SCRIPT_DIR)/checksec-format-output.py \
+			$(PKG_BUILD_DIR)/CHECKSEC/$(1)/checksec_report.json \
+			$$(IDIR_$(1)) \
+			$(PKG_NAME) \
+			$(if $(PKG_VERSION),$(PKG_VERSION),"N/A") \
+			$(PKG_BUILD_DIR)/CHECKSEC/$(1)/checksec_report_formatted.json \
+	)
+    endif
 	$(RSTRIP) $$(IDIR_$(1))
 
     ifneq ($$(CONFIG_IPK_FILES_CHECKSUMS),)

--- a/scripts/checksec-format-output.py
+++ b/scripts/checksec-format-output.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+from sys import argv
+import json
+
+if len(argv) != 6:
+    print("Usage: checkseck_format_output.py input build_dir package_name package_version output")
+    exit(1)
+
+input_path = Path(argv[1])
+builddir_path = argv[2]
+name = argv[3]
+version = argv[4]
+output_path = Path(argv[5])
+output={}
+
+with open(input_path, "r") as read_file:
+    output["elflist"]={}
+    data = json.load(read_file)
+    del data['dir']
+    for k in list(data):
+        new=k.replace(builddir_path, "")
+        output["elflist"][new]=data.pop(k)
+        output["elflist"][new]["rpath"]="no"
+        output["elflist"][new]["filename"] = output["elflist"][new]["filename"].replace(builddir_path, "")
+
+
+    
+    output['package'] = name
+    output['version'] = version
+    with open(output_path, "w") as write_file:
+        json.dump(output, write_file)
+

--- a/scripts/checksec-mitigation-report.py
+++ b/scripts/checksec-mitigation-report.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+from sys import argv
+import json
+
+if len(argv) != 3:
+    print("Usage: checksec_mitigation_report.py build_dir output")
+    exit(1)
+
+builddir_path = argv[1]
+output_path = Path(argv[2])
+
+print(builddir_path)
+print(output_path)
+
+
+output = {
+}
+
+with open(output_path, "w") as write_file:
+    output["packagelist"]=[]
+
+    builddir = Path(builddir_path)
+    for report in list(builddir.rglob("checksec_report_formatted.json")):
+        with open(report, "r") as read_file:
+            data = json.load(read_file)
+            output["packagelist"].append(data)
+    json.dump(output, write_file)
+
+print("#############################################")
+print("############# HARDENING RESULTS #############")
+print("#############################################")
+
+# elf list
+number_of_elf=0
+for package in output["packagelist"]:
+    number_of_elf += len(package["elflist"])
+
+print("NB_ELF = " + str(number_of_elf))
+
+#relro result
+number_of_relro=0
+relro_positive_result=["n/a", "full", "partial"]
+for package in output["packagelist"]:
+    for k in list(package["elflist"]):
+        elf=package["elflist"][k]
+        if elf["relro"] in relro_positive_result:
+            number_of_relro+=1
+
+# now result
+number_of_now=0
+now_positive_result=["n/a", "full"]
+for package in output["packagelist"]:
+    for k in list(package["elflist"]):
+        elf=package["elflist"][k]
+        if elf["relro"] in now_positive_result :
+            number_of_now+=1;
+
+# stack protector result
+number_of_ssp=0
+for package in output["packagelist"]:
+    for k in list(package["elflist"]):
+        elf=package["elflist"][k]
+        if elf["canary"] == "yes":
+            number_of_ssp+=1;
+
+# nx result
+number_of_nx=0
+for package in output["packagelist"]:
+    for k in list(package["elflist"]):
+        elf=package["elflist"][k]
+        if elf["nx"] == "yes":
+            number_of_nx+=1;
+
+# PIE result 
+number_of_pie=0
+pie_positive_result=["yes", "dso"]
+for package in output["packagelist"]:
+    for k in list(package["elflist"]):
+        elf=package["elflist"][k]
+        if elf["pie"] in pie_positive_result:
+            number_of_pie+=1;
+
+# rpath
+number_of_rpath=0
+for package in output["packagelist"]:
+    for k in list(package["elflist"]):
+        elf=package["elflist"][k]
+        if elf["rpath"] == "yes":
+            number_of_rpath+=1;
+
+# fortify
+number_of_fortify=0
+for package in output["packagelist"]:
+    for k in list(package["elflist"]):
+        elf=package["elflist"][k]
+        if elf["fortify_source"] != "no" :
+            number_of_fortify+=1;
+
+
+print('RELRO =  {:2.2%}'.format(number_of_relro / number_of_elf))
+print('NOW =  {:2.2%}'.format(number_of_now / number_of_elf))
+print('NX =  {:2.2%}'.format(number_of_nx / number_of_elf))
+print('PIE =  {:2.2%}'.format(number_of_pie / number_of_elf))
+print('SSP =  {:2.2%}'.format(number_of_ssp / number_of_elf))
+print('FORTIFY =  {:2.2%}'.format(number_of_fortify / number_of_elf))
+print('RPATH =  {:2.2%}'.format(number_of_rpath / number_of_elf))
+

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -85,6 +85,8 @@ tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USES_MINOR),y) += kernel2minor
 tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USE_SPARSE),y) += sparse
 tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USE_LLVM_BUILD),y) += llvm-bpf
 tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_USE_MOLD),y) += mold
+tools-$(if $(CONFIG_BUILD_ALL_HOST_TOOLS)$(CONFIG_JSON_CHECKSEC_MITIGATIONS_REPORT),y) += checksec.sh
+
 
 # builddir dependencies
 $(curdir)/autoconf/compile := $(curdir)/m4/compile

--- a/tools/checksec.sh/Makefile
+++ b/tools/checksec.sh/Makefile
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2008-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=checksec.sh
+PKG_SOURCE_VERSION:=36a67b388193d26289773f4153cb3b9f5bf5c9ec
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/slimm609/checksec.sh.git
+PKG_MIRROR_HASH:=b1b881f68c413a69e58b79590b6a6149e6ed5b2f98ddb5bc16184fa15e8b4e77
+
+
+include $(INCLUDE_DIR)/host-build.mk
+
+define Host/Compile
+endef
+
+define Host/Install
+  $(CP) $(HOST_BUILD_DIR)/checksec  $(STAGING_DIR_HOST)/bin/
+endef
+
+
+$(eval $(call HostBuild))

--- a/tools/checksec.sh/patches/01_pull_request_230.patch
+++ b/tools/checksec.sh/patches/01_pull_request_230.patch
@@ -1,0 +1,45 @@
+From 751578067682cb6d48e9dd35da4abdd2b99a3ece Mon Sep 17 00:00:00 2001
+From: Cedric DOURLENT <cedric.dourlent@softathome.com>
+Date: Fri, 8 Dec 2023 09:40:59 +0100
+Subject: [PATCH] add result N/A for fortify when fortifiable value is 0
+
+---
+ checksec                  | 6 +++++-
+ tests/hardening-checks.sh | 7 +++++++
+ 2 files changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/checksec b/checksec
+index 52bd3c4..0de23b3 100755
+--- a/checksec
++++ b/checksec
+@@ -828,7 +828,11 @@ filecheck() {
+   if grep -q '_chk$' <<< "$FS_func"; then
+     echo_message '\033[32mYes\033[m' 'Yes,' ' fortify_source="yes" ' '"fortify_source":"yes",'
+   else
+-    echo_message "\033[31mNo\033[m" "No," ' fortify_source="no" ' '"fortify_source":"no",'
++    if [[ "${FS_cnt_total}" == "0" ]]; then
++      echo_message "\033[31mN/A\033[m" "N/A," ' fortify_source="n/a" ' '"fortify_source":"n/a",'
++    else
++      echo_message "\033[31mNo\033[m" "No," ' fortify_source="no" ' '"fortify_source":"no",'
++    fi
+   fi
+   echo_message "\t${FS_cnt_checked}\t" "${FS_cnt_checked}", "fortified=\"${FS_cnt_checked}\" " "\"fortified\":\"${FS_cnt_checked}\","
+   echo_message "\t${FS_cnt_total}\t\t" "${FS_cnt_total}" "fortify-able=\"${FS_cnt_total}\"" "\"fortify-able\":\"${FS_cnt_total}\""
+diff --git a/tests/hardening-checks.sh b/tests/hardening-checks.sh
+index ba3f252..da254b0 100755
+--- a/tests/hardening-checks.sh
++++ b/tests/hardening-checks.sh
+@@ -267,6 +267,13 @@ for bin in none none32 none_cl none_cl32; do
+     exit 1
+   fi
+ done
++# N/A
++for bin in rel.o rel32.o rel_cl.o rel_cl32.o; do
++  if [[ $("${PARENT}"/checksec --file="${DIR}/binaries/${bin}" --format=csv | cut -d, -f8) != "N/A" ]]; then
++    echo "No Fortify validation failed on \"${bin}\": $("${PARENT}"/checksec --file="${DIR}/binaries/${bin}" --format=csv | cut -d, -f8)"
++    exit 1
++  fi
++done
+ echo "Fortify validation tests passed"
+ 
+ #============================================


### PR DESCRIPTION
Checksec is a bash script to check the properties of executables (like PIE, RELRO, Canaries, ASLR, Fortify Source). 
It has been originally written by Tobias Klein
Generate the reports during the build will help to identify the package without appropriate flags during compilation and help to provide a correcte status to the different partners of a project.

@aparcar: Could you review this PR?