### PR TITLE
toolchain: binutils: switch to version 2.42 by default

### DIFF
--- a/toolchain/binutils/Config.in
+++ b/toolchain/binutils/Config.in
@@ -2,7 +2,7 @@
 
 choice
 	prompt "Binutils Version" if TOOLCHAINOPTS
-	default BINUTILS_USE_VERSION_2_40
+	default BINUTILS_USE_VERSION_2_42
 	help
 	  Select the version of binutils you wish to use.
 

--- a/toolchain/binutils/Config.version
+++ b/toolchain/binutils/Config.version
@@ -9,13 +9,13 @@ config BINUTILS_VERSION_2_39
 	bool
 
 config BINUTILS_VERSION_2_40
-	default y if !TOOLCHAINOPTS
 	bool
 
 config BINUTILS_VERSION_2_41
 	bool
 
 config BINUTILS_VERSION_2_42
+	default y if !TOOLCHAINOPTS
 	bool
 
 config BINUTILS_VERSION


### PR DESCRIPTION
Change the default binutils version to 2.42.
