### PR TITLE
kernel-build.mk: add support for compiling only DTS

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -582,7 +582,7 @@ define Device/Build/dtb
   $(KDIR)/image-$(1).dtb: FORCE
 	$(call Image/BuildDTB,$(strip $(2))/$(strip $(3)).dts,$$@)
 
-  image_prepare: $(KDIR)/image-$(1).dtb
+  compile-dtb: $(KDIR)/image-$(1).dtb
   endif
 
 endef
@@ -593,7 +593,7 @@ define Device/Build/dtbo
   $(KDIR)/image-$(1).dtbo: FORCE
 	$(call Image/BuildDTBO,$(strip $(2))/$(strip $(3)).dtso,$$@)
 
-  image_prepare: $(KDIR)/image-$(1).dtbo
+  compile-dtb: $(KDIR)/image-$(1).dtbo
   endif
 
 endef
@@ -841,18 +841,20 @@ define BuildImage
   download:
   prepare:
   compile:
+  compile-dtb:
   clean:
   image_prepare:
 
   ifeq ($(IB),)
-    .PHONY: download prepare compile clean image_prepare kernel_prepare install install-images
+    .PHONY: download prepare compile compile-dtb clean image_prepare kernel_prepare install install-images
     compile:
 		$(call Build/Compile)
 
     clean:
 		$(call Build/Clean)
 
-    image_prepare: compile
+    compile-dtb:
+    image_prepare: compile compile-dtb
 		mkdir -p $(BIN_DIR) $(KDIR)/tmp
 		rm -rf $(BUILD_DIR)/json_info_files
 		$(call Image/Prepare)

--- a/include/kernel-build.mk
+++ b/include/kernel-build.mk
@@ -156,6 +156,10 @@ define BuildKernel
   compile: $(LINUX_DIR)/.modules
 	$(MAKE) -C image compile TARGET_BUILD=
 
+  dtb: $(STAMP_CONFIGURED)
+	$(_SINGLE)$(KERNEL_MAKE) scripts_dtc
+	$(MAKE) -C image compile-dtb TARGET_BUILD=
+
   oldconfig menuconfig nconfig xconfig: $(STAMP_PREPARED) $(STAMP_CHECKED) FORCE
 	rm -f $(LINUX_DIR)/.config.prev
 	rm -f $(STAMP_CONFIGURED)

--- a/include/subdir.mk
+++ b/include/subdir.mk
@@ -5,6 +5,9 @@
 ifeq ($(MAKECMDGOALS),prereq)
   SUBTARGETS:=prereq
   PREREQ_ONLY:=1
+# For target/linux related target add dtb to selectively compile dtbs
+else ifneq ($(filter target/linux/%,$(MAKECMDGOALS)),)
+  SUBTARGETS:=$(DEFAULT_SUBDIR_TARGETS) dtb
 else
   SUBTARGETS:=$(DEFAULT_SUBDIR_TARGETS)
 endif


### PR DESCRIPTION
Add support for compiling DTS for the selected target. This can be useful for testing if the DTS correctly compile and doesn't produce any error.

This adds a new make target. To compile only DTS use:

make target/linux/dtb

---

@hauke @jow- @ynezz @mpratt14 What do you think of this?

The main usage of this would be for CI to introduce testing for any DTS change.

The only big hack is in subdir.mk that add the specific thing for targer/linux but IMHO was much worse to add this to rules.mk DEFAULT_SUBDIR_TARGETS