### PR TITLE
mvebu: add support for the Omnia Wi-Fi 6 model

### DIFF
--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -104,7 +104,8 @@ define Device/cznic_turris-omnia
   DEVICE_PACKAGES :=  \
     mkf2fs e2fsprogs kmod-fs-vfat kmod-nls-cp437 kmod-nls-iso8859-1 \
     wpad-basic-mbedtls kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct \
-    partx-utils kmod-i2c-mux-pca954x kmod-leds-turris-omnia
+    partx-utils kmod-i2c-mux-pca954x kmod-leds-turris-omnia \
+    kmod-mt7915e kmod-mt7915-firmware
   IMAGES := sysupgrade.img.gz
   IMAGE/sysupgrade.img.gz := boot-scr | boot-img | sdcard-img | gzip | append-metadata
   SUPPORTED_DEVICES += armada-385-turris-omnia


### PR DESCRIPTION
After releasing the original Turris Omnia, cz.nic started selling Wi-Fi 6 upgrade kits in December 2022, and the iteration of the hardware that's currently being sold comes with the Wi-Fi 6 hardware out of the box. The card is is a AW7915-NP1 miniPCI-e card.

I assume quite a lot of people on old hardware have upgraded, so including the driver for the card is relevant to both old and new hardware.
