### PR TITLE
qualcommax: refresh patches

### DIFF
--- a/target/linux/qualcommax/patches-6.1/0037-v6.5-arm64-dts-qcom-ipq6018-add-QFPROM-node.patch
+++ b/target/linux/qualcommax/patches-6.1/0037-v6.5-arm64-dts-qcom-ipq6018-add-QFPROM-node.patch
@@ -31,4 +31,4 @@ Link: https://lore.kernel.org/r/20230526125305.19626-4-quic_kathirav@quicinc.com
 +
  		prng: qrng@e1000 {
  			compatible = "qcom,prng-ee";
- 			reg = <0x0 0xe3000 0x0 0x1000>;
+ 			reg = <0x0 0x000e3000 0x0 0x1000>;

--- a/target/linux/qualcommax/patches-6.1/0135-arm64-dts-qcom-ipq6018-include-the-GPLL0-as-clock-pr.patch
+++ b/target/linux/qualcommax/patches-6.1/0135-arm64-dts-qcom-ipq6018-include-the-GPLL0-as-clock-pr.patch
@@ -19,7 +19,7 @@ Reviewed-by: Konrad Dybcio <konrad.dybcio@linaro.org>
 
 --- a/arch/arm64/boot/dts/qcom/ipq6018.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq6018.dtsi
-@@ -503,8 +503,8 @@
+@@ -504,8 +504,8 @@
  			compatible = "qcom,ipq6018-apcs-apps-global";
  			reg = <0x0 0x0b111000 0x0 0x1000>;
  			#clock-cells = <1>;

--- a/target/linux/qualcommax/patches-6.1/0139-arm64-dts-qcom-ipq6018-add-LDOA2-regulator.patch
+++ b/target/linux/qualcommax/patches-6.1/0139-arm64-dts-qcom-ipq6018-add-LDOA2-regulator.patch
@@ -13,7 +13,7 @@ Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
 
 --- a/arch/arm64/boot/dts/qcom/ipq6018.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq6018.dtsi
-@@ -840,6 +840,11 @@
+@@ -841,6 +841,11 @@
  					regulator-max-microvolt = <1062500>;
  					regulator-always-on;
  				};

--- a/target/linux/qualcommax/patches-6.1/0141-arm64-dts-qcom-ipq6018-add-thermal-zones.patch
+++ b/target/linux/qualcommax/patches-6.1/0141-arm64-dts-qcom-ipq6018-add-thermal-zones.patch
@@ -53,7 +53,7 @@ Signed-off-by: Mantas Pucka <mantas@8devices.com>
  		};
  
  		L2_0: l2-cache {
-@@ -807,6 +812,122 @@
+@@ -808,6 +813,122 @@
  			};
  		};
  	};

--- a/target/linux/qualcommax/patches-6.1/0906-arm64-dts-qcom-ipq6018-add-wifi-node.patch
+++ b/target/linux/qualcommax/patches-6.1/0906-arm64-dts-qcom-ipq6018-add-wifi-node.patch
@@ -15,7 +15,7 @@ Signed-off-by: Mantas Pucka <mantas@8devices.com>
 
 --- a/arch/arm64/boot/dts/qcom/ipq6018.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq6018.dtsi
-@@ -637,6 +637,102 @@
+@@ -638,6 +638,102 @@
  			};
  		};
  

--- a/target/linux/qualcommax/patches-6.1/0907-soc-qcom-fix-smp2p-ack-on-ipq6018.patch
+++ b/target/linux/qualcommax/patches-6.1/0907-soc-qcom-fix-smp2p-ack-on-ipq6018.patch
@@ -15,7 +15,7 @@ Signed-off-by: Mantas Pucka <mantas@8devices.com>
 
 --- a/arch/arm64/boot/dts/qcom/ipq6018.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq6018.dtsi
-@@ -1056,6 +1056,7 @@
+@@ -1057,6 +1057,7 @@
  
  		wcss_smp2p_out: master-kernel {
  			qcom,entry-name = "master-kernel";

--- a/target/linux/qualcommax/patches-6.1/0909-arm64-dts-qcom-ipq6018-assign-QDSS_AT-clock-to-wifi-.patch
+++ b/target/linux/qualcommax/patches-6.1/0909-arm64-dts-qcom-ipq6018-assign-QDSS_AT-clock-to-wifi-.patch
@@ -13,7 +13,7 @@ Signed-off-by: Mantas Pucka <mantas@8devices.com>
 
 --- a/arch/arm64/boot/dts/qcom/ipq6018.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq6018.dtsi
-@@ -758,8 +758,8 @@
+@@ -759,8 +759,8 @@
  				      "wcss_reset",
  				      "wcss_q6_reset";
  


### PR DESCRIPTION
As reported by CI, new ipq6018 patches need to be refreshed.
