### PR TITLE
ramips: mtk_eth_soc: fix NULL pointer dereference for syncp

### DIFF
--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -1601,6 +1601,7 @@ static int fe_probe(struct platform_device *pdev)
 			goto err_free_dev;
 		}
 		spin_lock_init(&priv->hw_stats->stats_lock);
+		u64_stats_init(&priv->hw_stats->syncp);
 	}
 
 	sysclk = devm_clk_get(&pdev->dev, NULL);
@@ -1628,7 +1629,6 @@ static int fe_probe(struct platform_device *pdev)
 	priv->tx_ring.tx_ring_size = NUM_DMA_DESC;
 	priv->rx_ring.rx_ring_size = NUM_DMA_DESC;
 	INIT_WORK(&priv->pending_work, fe_pending_work);
-	u64_stats_init(&priv->hw_stats->syncp);
 
 	napi_weight = 16;
 	if (priv->flags & FE_FLAG_NAPI_WEIGHT) {


### PR DESCRIPTION
u64_stats_init() has been unable to handle NULL pointer since 6.1 kernel. This patch fixes kernel oops on mt76x8 and rt305x sub-target.
```
[    0.882987] CPU 0 Unable to handle kernel paging request at virtual address 00000000, epc == 80392b5c, ra == 80392ad0
[    0.893869] Oops[#1]:
[    0.896174] CPU: 0 PID: 1 Comm: swapper Not tainted 6.1.77 #0
[    0.902011] $ 0   : 00000000 00000001 80394254 80cd6638
[    0.907339] $ 4   : 00000000 80c3dcd0 00000010 00000000
[    0.912658] $ 8   : 00000024 805a9018 00000000 a5b45827
[    0.917978] $12   : 2a0cca91 ace9f5e9 79bb155f a7c3b196
[    0.923299] $16   : 80cd6000 80c9c010 80c9c000 8078ef1c
[    0.928620] $20   : 808f0000 80790000 80798094 808c0000
[    0.933940] $24   : 00000000 97b6752b
[    0.939260] $28   : 80c3c000 80c3dcb0 00000008 80392ad0
[    0.944581] Hi    : 00000004
[    0.947498] Lo    : 2f911c00
[    0.950416] epc   : 80392b5c fe_probe+0x228/0x45c
[    0.955204] ra    : 80392ad0 fe_probe+0x19c/0x45c
[    0.959978] Status: 11008403 KERNEL EXL IE
[    0.964236] Cause : 0080000c (ExcCode 03)
[    0.968300] BadVA : 00000000
[    0.971219] PrId  : 00019655 (MIPS 24KEc)
[    0.975284] Modules linked in:
[    0.978381] Process swapper (pid: 1, threadinfo=(ptrval), task=(ptrval), tls=00000000)
[    0.986414] Stack : 80c9d630 80207a6c 00000000 802c752c 00000000 80c3dcc8 8098cac0 00000000
[    0.994930]         80ec1dc0 80c9d630 00000000 8020a220 806a99c4 806a99b4 80986d8c 803aa3f4
[    1.003442]         00000000 00000004 806b4410 80c9d630 80ec1dc0 8020b6d8 80c9c010 8078eda0
[    1.011956]         8078eda0 80c9c010 8078eda0 8078eda0 00000000 00000000 807bd138 803457d4
[    1.020467]         00000000 8078eda0 00000000 00000000 807bd138 80c9c010 00000000 80342e70
[    1.028979]         ...
[    1.031465] Call Trace:
[    1.033941] [<80392b5c>] fe_probe+0x228/0x45c
[    1.038371] [<803457d4>] platform_probe+0x50/0xa4
[    1.043159] [<80342e70>] really_probe+0xd4/0x378
[    1.047882] [<80343348>] driver_probe_device+0x4c/0x154
[    1.053198] [<80343b5c>] __driver_attach+0xac/0x1bc
[    1.058150] [<80340c04>] bus_for_each_dev+0x68/0xa4
[    1.063111] [<803422d8>] bus_add_driver+0x1c8/0x244
[    1.068073] [<803444f4>] driver_register+0x98/0x15c
[    1.073028] [<80000638>] do_one_initcall+0x50/0x28c
[    1.077985] [<80799120>] kernel_init_freeable+0x1d0/0x26c
[    1.083499] [<805a9304>] kernel_init+0x20/0x10c
[    1.088103] [<80002358>] ret_from_kernel_thread+0x14/0x1c
[    1.093593]
[    1.095100] Code: ae030638  ae020640  ae03063c <ac800000> 8e0204e0  30420040  10400008  24070010  960305f4
[    1.105039]
[    1.106599] ---[ end trace 0000000000000000 ]---
[    1.111293] Kernel panic - not syncing: Fatal exception
[    1.116597] Rebooting in 1 seconds..
```
