### PR TITLE
ramips: add support for TP-Link RE205 v3

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_re205-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re205-v3.dts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_tplink_re200.dtsi"
+
+/ {
+	compatible = "tplink,re205-v3", "mediatek,mt7628an-soc";
+	model = "TP-Link RE205 v3";
+
+	/delete-node/ leds;
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi5g {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi2g {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		signal_blue {
+			label = "blue:signal";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		signal_red {
+			label = "red:signal";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -636,6 +636,16 @@ define Device/tplink_re200-v4
 endef
 TARGET_DEVICES += tplink_re200-v4
 
+define Device/tplink_re205-v3
+  $(Device/tplink-safeloader)
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := RE205
+  DEVICE_VARIANT := v3
+  DEVICE_PACKAGES := kmod-mt76x0e
+  TPLINK_BOARD_ID := RE205-V3
+endef
+TARGET_DEVICES += tplink_re205-v3
+
 define Device/tplink_re220-v2
   $(Device/tplink-safeloader)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -91,6 +91,9 @@ tplink,tl-mr3020-v3|\
 tplink,tl-wa801nd-v5)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	;;
+tplink,re205-v3)
+	ucidef_set_led_netdev "lan" "lan" "blue:signal" "eth0"
+	;;
 tplink,re365-v1)
 	ucidef_set_led_netdev "lan" "lan" "blue:lan" "eth0"
 	;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -24,6 +24,7 @@ ramips_setup_interfaces()
 	tplink,re200-v2|\
 	tplink,re200-v3|\
 	tplink,re200-v4|\
+	tplink,re205-v3|\
 	tplink,re220-v2|\
 	tplink,re305-v1|\
 	tplink,re305-v3|\


### PR DESCRIPTION
TP-Link RE205 v3 is a wireless range extender with Ethernet and 2.4G and 5G WiFi with external antennas.
It's based on MediaTek MT7628AN+MT7610EN like the RE200 v3/v4 but with external antennas.

Specifications
--------------

- MediaTek MT7628AN (580 Mhz)
- 64 MB of RAM
- 8 MB of FLASH
- 2T2R 2.4 GHz and 1T1R 5 GHz
- 1x 10/100 Mbps Ethernet
- 5x LED (GPIO-controlled), 2x button
- UART connection pads on PCB (57600 8n1)

There are 2.4G and 5G LEDs in blue which are controlled separately.

Installation
------------

Installation is identical to RE200 v3 devices as described at https://openwrt.org/toh/tp-link/re200#installation

Web Interface
-------------

It is possible to upgrade to OpenWrt via the web interface. Simply flash the -factory.bin from OEM. In contrast to a stock firmware, this will not overwrite U-Boot.

Recovery
--------

U-Boot seems to be locked on newer versions, if not it can be accessed over the UART as described in the link above.