### PR TITLE
procd: prevent adding empty "" fields to mDNS TXT records which prevents mDNS broadcast

### DIFF
--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -601,7 +601,7 @@ procd_add_mdns_service() {
 	json_add_int port "$port"
 	[ -n "$1" ] && {
 		json_add_array txt
-		for txt in "$@"; do json_add_string "" "$txt"; done
+		for txt in "$@"; do [ -n "$txt" ] && json_add_string "" "$txt"; done
 		json_select ..
 	}
 	json_select ..


### PR DESCRIPTION
while this bug may actually be interesting to explicitly add nothing to a TXT record, we still carry extra `"",` fields:

Before:

```sh
procd_add_mdns "blah" \
			 "tcp" "50" \
			 "" \
			 ""

ubus call service list | jsonfilter -e "$[*]['instances'][*]['data']['mdns']"
```
`..."", "" ] } }`

After:
```sh
procd_add_mdns "blah" \
			 "tcp" "50" \
			 "" \
			 ""

ubus call service list | jsonfilter -e "$[*]['instances'][*]['data']['mdns']"
```
`...] } }`


Note: carrying the extra `"",` fields prevents umdns from broadcasting an entry with them, so this should be considered a bug to be fixed.