### PR TITLE
ramips: hsdma-mtk: fix build on 5.15 kernel

### DIFF
--- a/target/linux/ramips/modules.mk
+++ b/target/linux/ramips/modules.mk
@@ -101,7 +101,8 @@ define KernelPackage/hsdma-mtk
 	CONFIG_MTK_HSDMA
   FILES:= \
 	$(LINUX_DIR)/drivers/dma/virt-dma.ko \
-	$(LINUX_DIR)/drivers/dma/mediatek/hsdma-mt7621.ko
+	$(LINUX_DIR)/drivers/staging/mt7621-dma/hsdma-mt7621.ko@lt5.17 \
+	$(LINUX_DIR)/drivers/dma/mediatek/hsdma-mt7621.ko@ge5.17
   AUTOLOAD:=$(call AutoLoad,53,hsdma-mt7621)
 endef
 


### PR DESCRIPTION
No build test. If the CI check passes, it should be fine.

Fixes build error:
```
ERROR: module '/__w/openwrt/openwrt/openwrt/build_dir/target-mipsel-openwrt-linux-musl_musl/linux-ramips_mt7621/linux-5.15.148/drivers/dma/mediatek/hsdma-mt7621.ko' is missing.
make[2]: *** [/__w/openwrt/openwrt/openwrt/target/linux/ramips/modules.mk:112: /__w/openwrt/openwrt/openwrt/bin/targets/ramips/mt7621/packages/kmod-hsdma-mtk_5.15.148-1_mipsel_24kc.ipk] Error 1
```
https://github.com/openwrt/openwrt/actions/runs/7855457411/job/21443910949?pr=14592#step:32:38