### PR TITLE
ipq40xx: Add support Netgear LBR20

### DIFF
--- a/package/boot/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-envtools/files/ipq40xx
@@ -53,7 +53,8 @@ aruba,ap-303)
 aruba,ap-365)
 	ubootenv_add_uci_config "/dev/mtd8" "0x0" "0x10000" "0x10000"
 	;;
-buffalo,wtr-m2133hp)
+buffalo,wtr-m2133hp|\
+netgear,lbr20)
 	ubootenv_add_uci_config "/dev/mtd8" "0x0" "0x40000" "0x20000"
 	;;
 linksys,ea6350v3)

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -38,6 +38,7 @@ ALLWIFIBOARDS:= \
 	edimax_cax1800 \
 	linksys_mx4200 \
 	linksys_mx5300 \
+	netgear_lbr20 \
 	netgear_rax120v2 \
 	netgear_wax218 \
 	netgear_wax620 \
@@ -154,6 +155,7 @@ $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))
 $(eval $(call generate-ipq-wifi-package,linksys_mx4200,Linksys MX4200))
 $(eval $(call generate-ipq-wifi-package,linksys_mx5300,Linksys MX5300))
+$(eval $(call generate-ipq-wifi-package,netgear_lbr20,Netgear LBR20))
 $(eval $(call generate-ipq-wifi-package,netgear_rax120v2,Netgear RAX120v2))
 $(eval $(call generate-ipq-wifi-package,netgear_wax218,Netgear WAX218))
 $(eval $(call generate-ipq-wifi-package,netgear_wax620,Netgear WAX620))

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -124,6 +124,10 @@ ipq40xx_setup_interfaces()
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
 		;;
+	netgear,lbr20)
+		ucidef_set_interface_lan "lan1 lan2"
+		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
+		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"
 		;;

--- a/target/linux/ipq40xx/base-files/etc/init.d/modem_switch
+++ b/target/linux/ipq40xx/base-files/etc/init.d/modem_switch
@@ -1,0 +1,34 @@
+#!/bin/sh /etc/rc.common
+
+START=15
+STOP=10
+
+boot() {
+	case $(board_name) in
+		netgear,lbr20)
+			echo "0" > /sys/class/gpio/lte_rst/value
+			echo "0" > /sys/class/gpio/lte_pwrkey/value
+			echo "0" > /sys/class/gpio/lte_usb_boot/value
+			echo "0" > /sys/class/gpio/lte_pwm/value
+			sleep 1
+			echo "1" > /sys/class/gpio/lte_pwm/value
+			echo "1" > /sys/class/gpio/lte_pwrkey/value
+			echo "1" > /sys/class/gpio/lte_rst/value
+			sleep 1
+			echo "0" > /sys/class/gpio/lte_pwrkey/value
+			sleep 1
+			echo "1" > /sys/class/gpio/lte_pwrkey/value
+		;;
+	esac
+}
+
+shutdown() {
+	case $(board_name) in
+		netgear,lbr20)
+			echo "0" > /sys/class/gpio/lte_pwrkey/value
+			sleep 1
+			echo "1" > /sys/class/gpio/lte_pwrkey/value
+			sleep 10
+		;;
+	esac
+}

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -120,6 +120,7 @@ platform_do_upgrade() {
 	glinet,gl-ap1300 |\
 	luma,wrtq-329acn |\
 	mobipromo,cm520-79f |\
+	netgear,lbr20 |\
 	netgear,wac510 |\
 	p2w,r619ac-64m |\
 	p2w,r619ac-128m |\

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-lbr20.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-lbr20.dts
@@ -1,0 +1,516 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Netgear LBR20";
+	compatible = "netgear,lbr20";
+
+	chosen {
+		bootargs-append = "ubi.mtd=ubi root=/dev/ubiblock0_0";
+	};
+
+	aliases {
+		led-boot = &led_backlight_white;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+		label-mac-device = &gmac;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&tlmm 49 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: led-status-green {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		led_status_red: led-status-red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&tlmm 23 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		lte_rst {
+			gpio-export,name = "lte_rst";
+			gpio-export,output = <1>;
+			gpios = <&tlmm 28 GPIO_ACTIVE_HIGH>;
+		};
+
+		lte_pwrkey {
+			gpio-export,name = "lte_pwrkey";
+			gpio-export,output = <1>;
+			gpios = <&tlmm 29 GPIO_ACTIVE_HIGH>;
+		};
+
+		lte_usb_boot {
+			gpio-export,name = "lte_usb_boot";
+			gpio-export,output = <0>;
+			gpios = <&tlmm 30 GPIO_ACTIVE_HIGH>;
+		};
+
+		lte_pwm {
+			gpio-export,name = "lte_pwm";
+			gpio-export,output = <1>;
+			gpios = <&tlmm 31 GPIO_ACTIVE_HIGH>;
+		};
+
+	};
+
+	soc {
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			status = "okay";
+
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+		
+	};
+};
+
+&prng {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&tlmm {
+	mdio_pins: mdio-pinmux {
+		mux_mdio {
+			pins = "gpio6";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mux_mdc {
+			pins = "gpio7";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
+	serial_pins: serial-pinmux {
+		function = "blsp_uart0";
+		pins = "gpio16", "gpio17";
+		bias-disable;
+	};
+
+	nand_pins: nand-pins {
+		pullups {
+			pins =	"gpio52", "gpio53", "gpio58", "gpio59";
+			function = "qpic";
+			bias-pull-up;
+		};
+
+		pulldowns {
+			pins =	"gpio54", "gpio55", "gpio56",
+				"gpio57", "gpio60", "gpio61",
+				"gpio62", "gpio63", "gpio64",
+				"gpio65", "gpio66", "gpio67",
+				"gpio68", "gpio69";
+			function = "qpic";
+			bias-pull-down;
+		};
+	};
+};
+
+&nand {
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	nand@0 {
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x00000000 0x00100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "0:MIBIB";
+				reg = <0x00100000 0x00100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "0:BOOTCONFIG";
+				reg = <0x00200000 0x00100000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "0:QSEE";
+				reg = <0x00300000 0x00100000>;
+				read-only;
+			};
+
+			partition@400000 {
+				label = "0:QSEE_1";
+				reg = <0x00400000 0x00100000>;
+				read-only;
+			};
+
+			partition@500000 {
+				label = "0:CDT";
+				reg = <0x00500000 0x00080000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "0:CDT_1";
+				reg = <0x00580000 0x00080000>;
+				read-only;
+			};
+
+			partition@600000 {
+				label = "0:BOOTCONFIG1";
+				reg = <0x00600000 0x00080000>;
+				read-only;
+			};
+
+			partition@680000 {
+				label = "0:APPSBLENV";
+				reg = <0x00680000 0x00080000>;
+			};
+
+			partition@700000 {
+				label = "0:APPSBL";
+				reg = <0x00700000 0x00200000>;
+				read-only;
+			};
+
+			partition@900000 {
+				label = "0:APPSBL_1";
+				reg = <0x00900000 0x00200000>;
+				read-only;
+			};
+
+			partition@b00000 {
+				label = "0:ART";
+				reg = <0x00b00000 0x00080000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					precal_art_1000: precal@1000 {
+						reg = <0x1000 0x2f20>;
+					};
+
+					precal_art_5000: precal@5000 {
+						reg = <0x5000 0x2f20>;
+					};
+
+					precal_art_9000: precal@9000 {
+						reg = <0x9000 0x2f20>;
+					};
+
+				};
+			};
+
+			partition@b80000 {
+				label = "0:ART.bak";
+				reg = <0x00b80000 0x00080000>;
+				read-only;
+			};
+
+			partition@c00000 {
+				label = "config";
+				reg = <0x00c00000 0x00100000>;
+				read-only;
+			};
+
+			partition@d00000 {
+				label = "boarddata1";
+				reg = <0x00d00000 0x00080000>;
+				read-only;
+				
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					mac_address_lan: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					mac_address_wan: macaddr@6 {
+						compatible = "mac-base";
+						reg = <0x6 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					mac_address_wlan_5g: macaddr@c {
+						compatible = "mac-base";
+						reg = <0xc 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					mac_address_wlan_2nd5g: macaddr@12 {
+						compatible = "mac-base";
+						reg = <0x12 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+				};
+			};
+
+			partition@d80000 {
+				label = "boarddata2";
+				reg = <0x00d80000 0x00040000>;
+				read-only;
+			};
+
+			partition@dc0000 {
+				label = "pot";
+				reg = <0x00dc0000 0x00100000>;
+				read-only;
+			};
+
+			partition@ec0000 {
+				label = "boarddata1.bak";
+				reg = <0x00ec0000 0x00080000>;
+				read-only;
+			};
+
+			partition@f40000 {
+				label = "boarddata2.bak";
+				reg = <0x00f40000 0x00040000>;
+				read-only;
+			};
+
+			partition@f80000 {
+				label = "language";
+				reg = <0x00f80000 0x00300000>;
+				read-only;
+			};
+
+			partition@1280000 {
+				label = "cert";
+				reg = <0x01280000 0x00080000>;
+				read-only;
+			};
+
+			partition@1300000 {
+				label = "ntgrdata";
+				reg = <0x01300000 0x09300000>;
+			};
+
+			partition@a600000 {
+				label = "kernel";
+				reg = <0x0a600000 0x00700000>;
+			};
+
+			partition@a9c0000 {
+				label = "ubi";
+				reg = <0x0ad00000 0x05300000>;
+			};
+
+		};
+	};
+};
+
+&blsp1_i2c3 {
+	status = "okay";
+
+	led-controller {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "ti,tlc59108"; /* really is tlc59208f */
+		reg = <0x27>;
+
+		led_backlight_green: led-backlight-green {
+			function = LED_FUNCTION_BACKLIGHT;
+			color = <LED_COLOR_ID_GREEN>;
+			reg = <0x0>;
+			linux,default-trigger = "default-off";
+		};
+
+		led_backlight_red: led-backlight-red {
+			function = LED_FUNCTION_BACKLIGHT;
+			color = <LED_COLOR_ID_RED>;
+			reg = <0x1>;
+			linux,default-trigger = "default-off";
+		};
+
+		led_backlight_blue: led-backlight-blue {
+			function = LED_FUNCTION_BACKLIGHT;
+			color = <LED_COLOR_ID_BLUE>;
+			reg = <0x2>;
+			linux,default-trigger = "default-off";
+		};
+
+		led_backlight_white: led-backlight-white {
+			function = LED_FUNCTION_BACKLIGHT;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x3>;
+			linux,default-trigger = "default-off";
+		};
+
+	};
+};
+
+&blsp1_uart1 {
+	status = "okay";
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&mac_address_lan 0>;
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+	label = "lan1";
+};
+
+&swport5 {
+	status = "okay";
+	label = "lan2";
+};
+
+&pcie0 {
+	status = "okay";
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "qcom,ath10k";
+			status = "okay";
+			reg = <0x00010000 0 0 0 0>;
+			ieee80211-freq-limit = <5170000 5350000>;
+			nvmem-cell-names = "pre-calibration", "mac-address";
+			nvmem-cells = <&precal_art_9000>, <&mac_address_wlan_2nd5g 0>;
+			qcom,ath10k-calibration-variant = "Netgear-LBR20";
+		};
+	};
+};
+
+&wifi0 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_1000>, <&mac_address_lan 0>;
+	qcom,ath10k-calibration-variant = "Netgear-LBR20";
+};
+
+&wifi1 {
+	status = "okay";
+	ieee80211-freq-limit = <5470000 5815000>;
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_5000>, <&mac_address_wlan_5g 0>;
+	qcom,ath10k-calibration-variant = "Netgear-LBR20";
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -841,6 +841,24 @@ define Device/netgear_orbi
 	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct e2fsprogs kmod-fs-ext4 losetup
 endef
 
+define Device/netgear_lbr20
+	$(call Device/netgear_orbi)
+	DEVICE_MODEL := LBR20
+	NETGEAR_BOARD_ID := LBR20
+	NETGEAR_HW_ID := 29766182+0+256+512+2x2+2x2+2x2+1
+	KERNEL_SIZE := 7340032
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	IMAGE/factory.img := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | \
+		append-uImage-fakehdr filesystem | pad-to $$$$(KERNEL_SIZE) | \
+		append-ubi | netgear-dni
+	IMAGE/sysupgrade.bin := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | \
+		append-uImage-fakehdr filesystem | sysupgrade-tar kernel=$$$$@ | \
+		append-metadata
+	DEVICE_PACKAGES := ipq-wifi-netgear_lbr20 ath10k-firmware-qca9888-ct kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+endef
+TARGET_DEVICES += netgear_lbr20
+
 define Device/netgear_rbx40
 	$(call Device/netgear_orbi)
 	NETGEAR_HW_ID := 29765515+0+4096+512+2x2+2x2+2x2


### PR DESCRIPTION
**Netgear LBR20** is a router with two gigabit ethernets , three wifi radios and integrated LTE cat.18 modem.

### Hardware specification:
SoC Type: Qualcomm IPQ4019
RAM: 512 MiB
Flash: 256 MiB , SLC NAND, 2 Gbit (Macronix MX30LF2G18AC) 
Bootloader: U-Boot
Modem: LTE CAT.18 Quectel EG-18EA ,  Max. 1.2Gbps downlink / 150Mbps uplink 
WiFi class AC2200:
- radio0 : 5G on QCA9888 , WiFi5- 802.11a/n/ac MU-MIMO 2x2 , 887Mbps , 80MHz - limited for low channels
- radio1: 2,4G on IPQ4019 ,WiFi4- 802.11b/g/n MIMO2x2 300Mbps 40Mhz
- radio2: 5G on IPQ4019 , WiFi5- 802.11a/n/ac MU-MIMO 2x2 , 887Mbps ,80Mhz - limited for high channels  (from 100 up to 165) . Because of DFS remember to set country before turning on.

Ethernet: 2x1GbE (WAN/LAN1, LAN2)
LEDs:  section power : green and red  , section on top (orbi) drives by TLC59208F: red, green ,blue and white
USB ports: No
Buttons:  2 Reset and SYNC(WPS)
Power: 12 VDC, 2,5 A
Connector type: Barrel

### OpenWRT Installation
1. Simplest way is just do upgrade from webpage with *factory.img
2. You can also do it with standard tool for Netgear's debricking - NMPRFlash
3. Most advanced way is to open device , connect to UART console and :
- Prepare OpenWrt initramfs image in TFTP server root (server IP 192.168.1.10)
- Connect serial console (115200,8n1) to UART connector
- Connect TFTP server to RJ-45 port
- Stop in u-Boot and run u-Boot command:

> setenv serverip 192.168.1.10
> set fdt_high 0x85000000
> tftpboot 0x83000000 openwrt-ipq40xx-generic-netgear_lbr20-initramfs-zImage.itb
> bootm 0x83000000

- Login via ssh
- upload or download *sysupgrade.bin ( like wget ... or scp transfer)
-  Install image via "sysupgrade -n" (like “sysupgrade -n /tmp/openwrt-ipq40xx-generic-netgear_lbr20-squashfs-sysupgrade.bin”)

### Back to Stock FW
- Download firmware from official Netgear's webpage , it will be *.img file after decompressing.
- Use NMRPFlash tool  ( detailed instructions on project page https://github.com/jclehner/nmrpflash )

### Opening the case:
- Unscrew nuts and remove washers from antenna's connectors.
- There are two Torx T10 screws under the label next to antenna connectors. You have to peel off this label from left and right corner to get it
- Two parts of shell covers will slide out from each-other , you have to peel off two small rubber pads and nameplate sticker on bottom to do that.
- PCB is screwed with 4Pcs of Torx T10 screws
- Before lifting up PCB remove pigtiles for LTE antennas and release them from PCB and radiator (black and white wires)
- On other side of PCB ,in left bottom corner there is already soldered with 4 pins UART connector for console. Counting from left it is  +3,3V , TX , RX ,GND (refer to this picture: https://i.ibb.co/Pmrf9KB/20240116-103524.jpg )

BDF's files are in firmware_qca-wireless  https://github.com/openwrt/firmware_qca-wireless/ and also sent to ath10k@lists.infradead.org. 

Signed-off-by: Marcin Gajda <mgajda@o2.pl>