### PR TITLE
bcm63xx: add support for SmartRG SR505n

### DIFF
--- a/target/linux/bcm63xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm63xx/base-files/etc/board.d/02_network
@@ -108,7 +108,8 @@ comtrend,vg-8050)
 	ucidef_add_switch "switch0" \
 		"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "8t@eth0"
 	;;
-comtrend,vr-3032u)
+comtrend,vr-3032u|\
+smartrg,sr505n)
 	ucidef_add_switch "switch0" \
 		"0:lan:2" "1:lan:3" "2:lan:4" "3:lan:1" "8t@eth0"
 	;;

--- a/target/linux/bcm63xx/dts/bcm63168-smartrg-sr505n.dts
+++ b/target/linux/bcm63xx/dts/bcm63168-smartrg-sr505n.dts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm63268.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "SmartRG SR505n";
+	compatible = "smartrg,sr505n", "brcm,bcm63168", "brcm,bcm63268";
+
+	chosen {
+		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+		
+		reset {
+			label = "reset";
+			gpios = <&pinctrl 32 0>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+                        label = "wps";
+                        gpios = <&pinctrl 33 0>;
+                        linux,code = <KEY_WPS_BUTTON>;
+                        debounce-interval = <60>;
+                };
+
+		wlan {
+                        label = "wlan";
+                        gpios = <&pinctrl 34 0>;
+                        linux,code = <KEY_WLAN>;
+                        debounce-interval = <60>;
+                };
+	};
+};
+
+&leds {
+        status = "okay";
+
+	pinctrl-names = "default";
+        pinctrl-0 = <&pinctrl_leds>;
+
+	wps_green@1 {
+                reg = <1>;
+                active-low;
+                label = "green:wps";
+        };
+
+	inet_green@8 {
+                reg = <8>;
+                active-low;
+                label = "green:inet";
+        };
+
+	lan2_green@9 {
+		/* EPHY1 Act */
+                reg = <9>;
+                brcm,hardware-controlled;
+        };
+
+	lan3_green@10 {
+		/* EPHY2 Act */
+                reg = <10>;
+                brcm,hardware-controlled;
+        };
+
+	lan4_green@11 {
+		/* EPHY3 Act */
+                reg = <11>;
+                brcm,hardware-controlled;
+        };
+
+	lan1_green@12 {
+		/* GPHY0 Act */
+                reg = <12>;
+                brcm,hardware-controlled;
+        };
+
+	dsl_green@14 {
+                reg = <14>;
+                active-low;
+                label = "green:dsl";
+        };
+
+	inet_red@15 {
+                reg = <15>;
+                active-low;
+                label = "red:inet";
+        };
+
+	usb_green@16 {
+                reg = <16>;
+                active-low;
+                label = "green:usb";
+        };
+
+	power_green@20 {
+                reg = <20>;
+                active-low;
+                label = "green:power";
+		default-state = "on";
+
+        };
+
+	power_red@21 {
+                reg = <21>;
+                active-low;
+                label = "red:power";
+        };
+};
+
+&pinctrl {
+        pinctrl_leds: leds {
+                function = "led";
+                pins = "gpio1", "gpio8", 
+		"gpio9", "gpio10",
+		"gpio11", "gpio12",
+		"gpio14", "gpio15",
+		"gpio16", "gpio20",
+		"gpio21";
+        };
+};
+
+&hsspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <16666667>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "brcm,bcm963xx-cfe-nor-partitions";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/target/linux/bcm63xx/image/bcm63xx.mk
+++ b/target/linux/bcm63xx/image/bcm63xx.mk
@@ -1101,6 +1101,18 @@ define Device/sky_sr102
 endef
 TARGET_DEVICES += sky_sr102
 
+define Device/smartrg_sr505n
+  $(Device/bcm63xx)
+  DEVICE_VENDOR := SmartRG
+  DEVICE_MODEL := SR505n
+  CFE_BOARD_ID := 963168MBV_17AZZ
+  CHIP_ID := 63268
+  CFE_EXTRAS += --rsa-signature "$(VERSION_DIST)-$(firstword $(subst -,$(space),$(REVISION)))"
+  SOC := bcm63168
+  DEVICE_PACKAGES := $(USB2_PACKAGES)
+endef
+TARGET_DEVICES += smartrg_sr505n
+
 ### T-Com ###
 define Device/t-com_speedport-w-303v
   $(Device/bcm63xx-legacy)

--- a/target/linux/bcm63xx/patches-5.15/519-board_bcm63268.patch
+++ b/target/linux/bcm63xx/patches-5.15/519-board_bcm63268.patch
@@ -1,12 +1,47 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -2697,6 +2697,273 @@ static struct board_info __initdata boar
+@@ -2697,6 +2697,308 @@ static struct board_info __initdata boar
  #endif /* CONFIG_BCM63XX_CPU_6368 */
  
  /*
 + * known 63268/63269 boards
 + */
 +#ifdef CONFIG_BCM63XX_CPU_63268
++static struct board_info __initdata board_963168MBV_17AZZ = {
++	.name = "963168MBV_17AZZ",
++	.expected_cpu_id = 0x63268,
++
++	.has_ohci0 = 1,
++	.has_ehci0 = 1,
++	.num_usbh_ports = 1,
++
++	.has_enetsw = 1,
++	.enetsw = {
++		.used_ports = {
++			[0] = {
++				.used = 1,
++				.phy_id = 1,
++				.name = "Port 2",
++			},
++			[1] = {
++				.used = 1,
++				.phy_id = 2,
++				.name = "Port 3",
++			},
++			[2] = {
++				.used = 1,
++				.phy_id = 3,
++				.name = "Port 4",
++			},
++			[3] = {
++				.used = 1,
++				.phy_id = 4,
++				.name = "Port 1",
++			},
++		},
++	},
++};
++
 +static struct board_info __initdata board_963268bu_p300 = {
 +	.name = "963268BU_P300",
 +	.expected_cpu_id = 0x63268,
@@ -274,11 +309,12 @@
   * all boards
   */
  static const struct board_info __initconst *bcm963xx_boards[] = {
-@@ -2801,6 +3068,15 @@ static const struct board_info __initcon
+@@ -2801,6 +3103,16 @@ static const struct board_info __initcon
  	&board_VR3026e,
  	&board_WAP5813n,
  #endif /* CONFIG_BCM63XX_CPU_6368 */
 +#ifdef CONFIG_BCM63XX_CPU_63268
++	&board_963168MBV_17AZZ,
 +	&board_963268bu_p300,
 +	&board_963269bhr,
 +	&board_BSKYB_63168,
@@ -290,7 +326,7 @@
  };
  
  static struct of_device_id const bcm963xx_boards_dt[] = {
-@@ -2918,6 +3194,14 @@ static struct of_device_id const bcm963x
+@@ -2918,6 +3230,15 @@ static struct of_device_id const bcm963x
  	{ .compatible = "zyxel,p870hw-51a-v2", .data = &board_P870HW51A_V2, },
  #endif /* CONFIG_BCM63XX_CPU_6368 */
  #ifdef CONFIG_BCM63XX_CPU_63268
@@ -302,6 +338,7 @@
 +	{ .compatible = "sercomm,h500-s-lowi", .data = &board_H500s, },
 +	{ .compatible = "sercomm,h500-s-vfes", .data = &board_H500s, },
 +	{ .compatible = "sky,sr102", .data = &board_BSKYB_63168, },
++	{ .compatible = "smartrg,sr505n", .data = &board_963168MBV_17AZZ, },
  #endif /* CONFIG_BCM63XX_CPU_63268 */
  #endif /* CONFIG_OF */
  	{ },

--- a/target/linux/bcm63xx/patches-5.15/531-board_bcm6348-bt-voyager-2500v-bb.patch
+++ b/target/linux/bcm63xx/patches-5.15/531-board_bcm6348-bt-voyager-2500v-bb.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -3230,6 +3230,22 @@ void __init board_bcm963xx_init(void)
+@@ -3267,6 +3267,22 @@ void __init board_bcm963xx_init(void)
  		val &= MPI_CSBASE_BASE_MASK;
  	}
  	boot_addr = (u8 *)KSEG1ADDR(val);


### PR DESCRIPTION
Specifications:
- SoC: Broadcom BCM63168 dual 400MHz MIPS
- Flash: 16MB SPI NOR W25Q128WFG
- RAM: 128MB DDR3 W631GG6KB-15
- Ethernet: 1x 1000M, 3x 100M
- Wifi: BCM435F
- 1x USB 2.0 port
- 3x Button
- 12x LED

Flashing via serial
- Connect to the 3.3V TTL UART on the board (J6 pinout Vcc Rx Tx Gnd) at 115200-8-N-1
- Press any key in the serial console when powering up the board to enter the CFE prompt
- Configure an interface on your workstation to static IP 192.168.1.100 and connect it to the board
- Start a TFTP server with the firmware image
- On the CFE prompt, enter the command "f 192.168.1.100:openwrt-bcm63xx-smp-smartrg_sr505n-squashfs-cfe.bin"