### PR TITLE
ath79: add support for D-Link COVR-C1200 A1 

### DIFF
--- a/target/linux/ath79/dts/qca9563_dlink_covr-c1200-a1.dts
+++ b/target/linux/ath79/dts/qca9563_dlink_covr-c1200-a1.dts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9563_dlink_covr.dtsi"
+
+/ {
+	compatible = "dlink,covr-c1200-a1", "qca,qca9563";
+	model = "D-Link COVR-C1200 A1";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_white;
+		led-upgrade = &led_power_red;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		led_power_red: power_red {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_white: power_white {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_orange: power_orange {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+};

--- a/target/linux/ath79/dts/qca9563_dlink_covr-p2500-a1.dts
+++ b/target/linux/ath79/dts/qca9563_dlink_covr-p2500-a1.dts
@@ -1,11 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "qca956x.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
-#include <dt-bindings/mtd/partitions/uimage.h>
+#include "qca9563_dlink_covr.dtsi"
 
 / {
 	compatible = "dlink,covr-p2500-a1", "qca,qca9563";
@@ -16,22 +11,6 @@
 		led-failsafe = &led_power_red;
 		led-running = &led_power_green;
 		led-upgrade = &led_power_red;
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		wps {
-			label = "wps";
-			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
-		};
-
-		reset {
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
-		};
 	};
 
 	leds {
@@ -70,144 +49,4 @@
 			linux,default-trigger = "phy1radio";
 		};
 	};
-
-	virtual_flash {
-		compatible = "mtd-concat";
-
-		devices = <&fwconcat0 &fwconcat1>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				compatible = "openwrt,uimage", "denx,uimage";
-				openwrt,ih-magic = <0x68737173>;
-				label = "firmware";
-				reg = <0x0 0x0>;
-			};
-		};
-	};
-};
-
-&spi {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <50000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x0 0x40000>;
-				read-only;
-			};
-
-			partition@40000 {
-				label = "u-boot-env";
-				reg = <0x40000 0x10000>;
-				read-only;
-			};
-
-			fwconcat0: partition@50000 {
-				label = "fwconcat0";
-				reg = <0x50000 0xe30000>;
-			};
-
-			partition@e80000 {
-				label = "loader";
-				reg = <0xe80000 0x10000>;
-				read-only;
-			};
-
-			fwconcat1: partition@e90000 {
-				label = "fwconcat1";
-				reg = <0xe90000 0x160000>;
-			};
-
-			art: partition@ff0000 {
-				label = "art";
-				reg = <0xff0000 0x10000>;
-				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					calibration_ath9k: calibration@1000 {
-						reg = <0x1000 0x440>;
-					};
-
-					precalibration_ath10k: pre-calibration@5000 {
-						reg = <0x5000 0x2f20>;
-					};
-				};
-			};
-		};
-	};
-};
-
-&pcie {
-	status = "okay";
-
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0 0 0 0 0>;
-
-		nvmem-cells = <&precalibration_ath10k>;
-		nvmem-cell-names = "pre-calibration";
-	};
-};
-
-&gpio {
-	phy-reset {
-		gpio-hog;
-		gpios = <11 GPIO_ACTIVE_LOW>;
-		output-low;
-		line-name = "phy-reset";
-	};
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy0: ethernet-phy@0 {
-		reg = <0>;
-		phy-mode = "sgmii";
-		qca,mib-poll-interval = <500>;
-
-		qca,ar8327-initvals = <
-			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
-			0x10 0x81000080 /* POWER_ON_STRAP */
-			0x50 0xcc35cc35 /* LED_CTRL0 */
-			0x54 0xcb37cb37 /* LED_CTRL1 */
-			0x58 0x00000000 /* LED_CTRL2 */
-			0x5c 0x00f3cf00 /* LED_CTRL3 */
-			0x7c 0x0000007e /* PORT0_STATUS */
-			>;
-	};
-};
-
-&eth0 {
-	status = "okay";
-
-	pll-data = <0x03000101 0x00000101 0x00001919>;
-
-	phy-mode = "sgmii";
-	phy-handle = <&phy0>;
-};
-
-&wmac {
-	status = "okay";
-
-	nvmem-cells = <&calibration_ath9k>;
-	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/dts/qca9563_dlink_covr.dtsi
+++ b/target/linux/ath79/dts/qca9563_dlink_covr.dtsi
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x68737173>;
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			fwconcat0: partition@50000 {
+				label = "fwconcat0";
+				reg = <0x50000 0xe30000>;
+			};
+
+			partition@e80000 {
+				label = "loader";
+				reg = <0xe80000 0x10000>;
+				read-only;
+			};
+
+			fwconcat1: partition@e90000 {
+				label = "fwconcat1";
+				reg = <0xe90000 0x160000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					calibration_ath9k: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+					precalibration_ath10k: pre-calibration@5000 {
+						reg = <0x5000 0x2f20>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	wifi0: wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0 0 0 0 0>;
+
+		nvmem-cells = <&precalibration_ath10k>;
+		nvmem-cell-names = "pre-calibration";
+	};
+};
+
+&gpio {
+	phy-reset {
+		gpio-hog;
+		gpios = <11 GPIO_ACTIVE_LOW>;
+		output-low;
+		line-name = "phy-reset";
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		qca,mib-poll-interval = <500>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x10 0x81000080 /* POWER_ON_STRAP */
+			0x50 0xcc35cc35 /* LED_CTRL0 */
+			0x54 0xcb37cb37 /* LED_CTRL1 */
+			0x58 0x00000000 /* LED_CTRL2 */
+			0x5c 0x00f3cf00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001919>;
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&calibration_ath9k>;
+	nvmem-cell-names = "calibration";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -289,6 +289,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:wan" "3:lan" "4:lan"
 		;;
+	dlink,covr-c1200-a1)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:wan" "2:lan"
+		;;
 	dlink,covr-p2500-a1)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:wan" "4:plc"
@@ -640,6 +644,11 @@ ath79_setup_macs()
 	devolo,dlan-pro-1200plus-ac|\
 	devolo,magic-2-wifi)
 		label_mac=$(macaddr_add "$(mtd_get_mac_binary art 0x1002)" 3)
+		;;
+	dlink,covr-c1200-a1)
+		lan_mac=$(mtd_get_mac_ascii art "protest_lan_mac")
+		wan_mac=$(mtd_get_mac_ascii art "protest_wan_mac")
+		label_mac=$lan_mac
 		;;
 	dlink,covr-p2500-a1)
 		lan_mac=$(mtd_get_mac_ascii art "protest_lan_mac")

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -17,6 +17,7 @@ case "$board" in
 	adtran,bsap1840)
 		macaddr_add "$(mtd_get_mac_binary 'Board data' 2)" $(($PHYNBR * 8 + 1)) > /sys${DEVPATH}/macaddress
 		;;
+	dlink,covr-c1200-a1|\
 	dlink,covr-p2500-a1)
 		[ "$PHYNBR" -eq 0 ] && \
 			mtd_get_mac_ascii art "protest_ath1_mac" > /sys${DEVPATH}/macaddress

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1020,6 +1020,16 @@ define Device/dlink_covr
 	append-loader-okli-uimage $(1) | pad-to 15616k
 endef
 
+define Device/dlink_covr-c1200-a1
+  $(Device/dlink_covr)
+  DEVICE_MODEL := COVR-C1200
+  DEVICE_VARIANT := A1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(IMAGE/recovery.bin) | \
+	dlink-sge-signature COVR-C1200 | dlink-sge-image COVR-C1200
+endef
+TARGET_DEVICES += dlink_covr-c1200-a1
+
 define Device/dlink_covr-p2500-a1
   $(Device/dlink_covr)
   DEVICE_MODEL := COVR-P2500

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1006,21 +1006,25 @@ define Device/devolo_magic-2-wifi
 endef
 TARGET_DEVICES += devolo_magic-2-wifi
 
-define Device/dlink_covr-p2500-a1
+define Device/dlink_covr
   $(Device/loader-okli-uimage)
   SOC := qca9563
   DEVICE_VENDOR := D-Link
-  DEVICE_MODEL := COVR-P2500
-  DEVICE_VARIANT := A1
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
   LOADER_FLASH_OFFS := 0x050000
   LOADER_KERNEL_MAGIC := 0x68737173
   KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x68737173
   IMAGE_SIZE := 14528k
-  IMAGES += factory.bin recovery.bin
   IMAGE/recovery.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | check-size | pad-to 14528k | \
 	append-loader-okli-uimage $(1) | pad-to 15616k
+endef
+
+define Device/dlink_covr-p2500-a1
+  $(Device/dlink_covr)
+  DEVICE_MODEL := COVR-P2500
+  DEVICE_VARIANT := A1
+  IMAGES += factory.bin recovery.bin
   IMAGE/factory.bin := $$(IMAGE/recovery.bin) | \
 	dlink-sge-image COVR-P2500 | dlink-sge-signature COVR-P2500
 endef


### PR DESCRIPTION
The COVR-C1200 devices are sold as "Whole Home Mesh Wi-Fi"
sets in packs of two (COVR-C1202) and three (COVR-C1203).

Specifications:
 * QCA9563, 16 MiB flash, 128 MiB RAM, 2x3:2 802.11n
 * QCA9886 2x2:2 801.11ac Wave 2
 * AR8337, 2 Gigabit ports (1: WAN; 2: LAN)
 * USB Type-C power connector (5V, 3A)

Installation COVR Point A:
 * In factory reset state: OEM Web UI is at 192.168.0.50
   no DHCP, skip wizard by directly accessing:
     http://192.168.0.50/UpdateFirmware_Simple.html
 * After completing setup wizard: Web UI is at 192.168.0.1
     DHCP enabled, login with empty password
 * Flash factory.bin
 * Perform a factory reset to restore OpenWrt UCI defaults

Installation COVR Points B:
 * OEM Web UI is at 192.168.0.50, no DHCP, empty password
 * Flash factory.bin
 * Perform a factory reset to restore OpenWrt UCI defaults

Recovery:
 * Keep reset button pressed during power on
 * Recovery Web UI is at 192.168.0.50, no DHCP
 * Flash factory.bin
   used to work best with Chromium-based browsers or curl:
     curl -F firmware=@factory.bin \
       http://192.168.0.50/upgrade.cgi
   since this fails to work on modern Linux systems,
   there is also a script dlink_recovery_upload.py

Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>

-------------------------------------------------------

These devices are very similar to COVR-P2500 (#12114, only LEDs and switch ports differ, besides this device lacking HomePlugAV2 PLC support), so it makes sense to have them share a common .dtsi.

MAC address offsets differ slightly among various versions and / or regions of these devices, so we cannot (yet) set these via device tree directly, but need `mtd_get_mac_ascii` to parse them.

The very first attempt to support this device was in #4174, meanwhile the tool `dlink-sge-image` is available for factory image generation. Unlike COVR-P2500, a recovery image is not needed here, as the bootloader will also accept the encrypted version (however the RSA signature is only verified when flashing via regular OEM web-based updater).