### PR TITLE
generic: 6.1: fixup QCA807x upstream PHY

### DIFF
--- a/target/linux/generic/pending-6.1/778-net-phy-qca807x-move-interface-mode-check-to-.config.patch
+++ b/target/linux/generic/pending-6.1/778-net-phy-qca807x-move-interface-mode-check-to-.config.patch
@@ -1,0 +1,48 @@
+From 824d6c9747fb46eadf763b879fb1c072e541a65a Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Mon, 12 Feb 2024 12:26:41 +0100
+Subject: [PATCH net-next] net: phy: qca807x: move interface mode check to
+ .config_init_once
+
+Currently, we are checking whether the PHY package mode matches the
+individual PHY interface modes at PHY package probe time, but at that time
+we only know the PHY package mode and not the individual PHY interface
+modes as of_get_phy_mode() that populates it will only get called once the
+netdev to which PHY-s are attached to is being probed and thus this check
+will always fail and return -EINVAL.
+
+So, lets move this check to .config_init_once as at that point individual
+PHY interface modes should be populated.
+
+Fixes: d1cb613efbd3 ("net: phy: qcom: add support for QCA807x PHY Family")
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+---
+ drivers/net/phy/qcom/qca807x.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+--- a/drivers/net/phy/qcom/qca807x.c
++++ b/drivers/net/phy/qcom/qca807x.c
+@@ -562,6 +562,11 @@ static int qca807x_phy_package_config_in
+ 	struct qca807x_shared_priv *priv = shared->priv;
+ 	int val, ret;
+ 
++	/* Make sure PHY follow PHY package mode if enforced */
++	if (priv->package_mode != PHY_INTERFACE_MODE_NA &&
++	    phydev->interface != priv->package_mode)
++		return -EINVAL;
++
+ 	phy_lock_mdio_bus(phydev);
+ 
+ 	/* Set correct PHY package mode */
+@@ -718,11 +723,6 @@ static int qca807x_probe(struct phy_devi
+ 	shared = phydev->shared;
+ 	shared_priv = shared->priv;
+ 
+-	/* Make sure PHY follow PHY package mode if enforced */
+-	if (shared_priv->package_mode != PHY_INTERFACE_MODE_NA &&
+-	    phydev->interface != shared_priv->package_mode)
+-		return -EINVAL;
+-
+ 	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
+ 	if (!priv)
+ 		return -ENOMEM;


### PR DESCRIPTION
Currently, we are checking whether the PHY package mode matches the individual PHY interface modes at PHY package probe time, but at that time we only know the PHY package mode and not the individual PHY interface modes as of_get_phy_mode() that populates it will only get called once the netdev to which PHY-s are attached to is being probed and thus this check will always fail and return -EINVAL.

So, lets move this check to .config_init_once as at that point individual PHY interface modes should be populated.

Fixes: 16364e410039 ("generic: 6.1: backport QCA807x PHY patches")
