### PR TITLE
build: align SOURCE path for build system and SDK

### DIFF
--- a/include/package-defaults.mk
+++ b/include/package-defaults.mk
@@ -20,7 +20,7 @@ define Package/Default
   PROVIDES:=
   EXTRA_DEPENDS:=
   MAINTAINER:=$(PKG_MAINTAINER)
-  SOURCE:=$(patsubst $(TOPDIR)/%,%,$(CURDIR))
+  SOURCE:=$(patsubst $(TOPDIR)/%,%,$(patsubst $(TOPDIR)/package/%,feeds/base/%,$(CURDIR)))
   ifneq ($(PKG_VERSION),)
     ifneq ($(PKG_RELEASE),)
       VERSION:=$(PKG_VERSION)-$(PKG_RELEASE)

--- a/include/toplevel.mk
+++ b/include/toplevel.mk
@@ -77,7 +77,8 @@ _ignore = $(foreach p,$(IGNORE_PACKAGES),--ignore $(p))
 
 prepare-tmpinfo: FORCE
 	@+$(MAKE) -r -s $(STAGING_DIR_HOST)/.prereq-build $(PREP_MK)
-	mkdir -p tmp/info
+	mkdir -p tmp/info feeds
+	[ -e $(TOPDIR)/feeds/base ] || ln -sf $(TOPDIR)/package $(TOPDIR)/feeds/base
 	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="packageinfo" SCAN_DIR="package" SCAN_NAME="package" SCAN_DEPTH=5 SCAN_EXTRA=""
 	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="targetinfo" SCAN_DIR="target/linux" SCAN_NAME="target" SCAN_DEPTH=3 SCAN_EXTRA="" SCAN_MAKEOPTS="TARGET_BUILD=1"
 	for type in package target; do \


### PR DESCRIPTION
This is a second attempt of #9754 where I committed a semi unrelated file instead of the right one - sorry.

Building a package in the build system or the SDK results in different values for the `SOURCE` property, it's either `packages/<package name>` or `feeds/base/<package name>`. The reason is that the SDK handles `openwrt.git` as an external feed called while the build system contains the *base* packages directly.

Since packages created with either method are (ideally) the same (bit for bit), align the content of SOURCE. To do so this commit creates a symlink from `feeds/base` to `$(TOPDIR)/package` and adopts the SOURCE when building from inside the build system.