### PR TITLE
ath79: update WA/XC devices UBNT_VERSION to 8.7.4

### DIFF
--- a/target/linux/ath79/image/common-ubnt.mk
+++ b/target/linux/ath79/image/common-ubnt.mk
@@ -74,7 +74,7 @@ define Device/ubnt-2wa
   UBNT_BOARD := WA
   UBNT_CHIP := ar934x
   UBNT_TYPE := 2WA
-  UBNT_VERSION := 8.5.3
+  UBNT_VERSION := 8.7.4
 endef
 
 define Device/ubnt-wa
@@ -84,7 +84,7 @@ define Device/ubnt-wa
   UBNT_BOARD := WA
   UBNT_CHIP := ar934x
   UBNT_TYPE := WA
-  UBNT_VERSION := 8.5.3
+  UBNT_VERSION := 8.7.4
 endef
 
 define Device/ubnt-xc
@@ -93,7 +93,7 @@ define Device/ubnt-xc
   UBNT_BOARD := XC
   UBNT_CHIP := qca955x
   UBNT_TYPE := XC
-  UBNT_VERSION := 8.5.3
+  UBNT_VERSION := 8.7.4
 endef
 
 define Device/ubnt-xm


### PR DESCRIPTION
Ubiquiti WA devices with newer hw version (sold 2023) require UBNT_VERSION to be at least 8.7.4, otherwise the image is rejected.

For consistency, also increase version number for XC devices.