### PR TITLE
mtd: spi-nor: Make support for BoHong bh25q128as generic

### DIFF
--- a/target/linux/generic/pending-5.15/405-mtd-spi-nor-Add-support-for-BoHong-bh25q128as.patch
+++ b/target/linux/generic/pending-5.15/405-mtd-spi-nor-Add-support-for-BoHong-bh25q128as.patch
@@ -1,0 +1,75 @@
+From 52d14545d2fc276b1bf9ccf48d4612fab6edfb6a Mon Sep 17 00:00:00 2001
+From: David Bauer <mail@david-bauer.net>
+Date: Thu, 6 May 2021 17:49:55 +0200
+Subject: [PATCH] mtd: spi-nor: Add support for BoHong bh25q128as
+
+Add MTD support for the BoHong bh25q128as SPI NOR chip.
+The chip has 16MB of total capacity, divided into a total of 256
+sectors, each 64KB sized. The chip also supports 4KB sectors.
+Additionally, it supports dual and quad read modes.
+
+Functionality was verified on an Tenbay WR1800K / MTK MT7621 board.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+---
+ drivers/mtd/spi-nor/Makefile |  1 +
+ drivers/mtd/spi-nor/bohong.c | 21 +++++++++++++++++++++
+ drivers/mtd/spi-nor/core.c   |  1 +
+ drivers/mtd/spi-nor/core.h   |  1 +
+ 4 files changed, 24 insertions(+)
+ create mode 100644 drivers/mtd/spi-nor/bohong.c
+
+--- a/drivers/mtd/spi-nor/Makefile
++++ b/drivers/mtd/spi-nor/Makefile
+@@ -2,6 +2,7 @@
+ 
+ spi-nor-objs			:= core.o sfdp.o swp.o otp.o sysfs.o
+ spi-nor-objs			+= atmel.o
++spi-nor-objs			+= bohong.o
+ spi-nor-objs			+= catalyst.o
+ spi-nor-objs			+= eon.o
+ spi-nor-objs			+= esmt.o
+--- /dev/null
++++ b/drivers/mtd/spi-nor/bohong.c
+@@ -0,0 +1,21 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (C) 2005, Intec Automation Inc.
++ * Copyright (C) 2014, Freescale Semiconductor, Inc.
++ */
++
++#include <linux/mtd/spi-nor.h>
++
++#include "core.h"
++
++static const struct flash_info bohong_parts[] = {
++	/* BoHong Microelectronics */
++	{ "bh25q128as", INFO(0x684018, 0, 64 * 1024, 256)
++		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++};
++
++const struct spi_nor_manufacturer spi_nor_bohong = {
++	.name = "bohong",
++	.parts = bohong_parts,
++	.nparts = ARRAY_SIZE(bohong_parts),
++};
+--- a/drivers/mtd/spi-nor/core.c
++++ b/drivers/mtd/spi-nor/core.c
+@@ -2001,6 +2001,7 @@ int spi_nor_sr2_bit7_quad_enable(struct
+ 
+ static const struct spi_nor_manufacturer *manufacturers[] = {
+ 	&spi_nor_atmel,
++	&spi_nor_bohong,
+ 	&spi_nor_catalyst,
+ 	&spi_nor_eon,
+ 	&spi_nor_esmt,
+--- a/drivers/mtd/spi-nor/core.h
++++ b/drivers/mtd/spi-nor/core.h
+@@ -631,6 +631,7 @@ struct sfdp {
+ 
+ /* Manufacturer drivers. */
+ extern const struct spi_nor_manufacturer spi_nor_atmel;
++extern const struct spi_nor_manufacturer spi_nor_bohong;
+ extern const struct spi_nor_manufacturer spi_nor_catalyst;
+ extern const struct spi_nor_manufacturer spi_nor_eon;
+ extern const struct spi_nor_manufacturer spi_nor_esmt;

--- a/target/linux/generic/pending-5.15/479-mtd-spi-nor-add-xtx-xt25f128b.patch
+++ b/target/linux/generic/pending-5.15/479-mtd-spi-nor-add-xtx-xt25f128b.patch
@@ -31,7 +31,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/mtd/spi-nor/Makefile
 +++ b/drivers/mtd/spi-nor/Makefile
-@@ -17,6 +17,7 @@ spi-nor-objs			+= sst.o
+@@ -18,6 +18,7 @@ spi-nor-objs			+= sst.o
  spi-nor-objs			+= winbond.o
  spi-nor-objs			+= xilinx.o
  spi-nor-objs			+= xmc.o
@@ -59,7 +59,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +};
 --- a/drivers/mtd/spi-nor/core.c
 +++ b/drivers/mtd/spi-nor/core.c
-@@ -1860,6 +1860,7 @@ static const struct spi_nor_manufacturer
+@@ -1861,6 +1861,7 @@ static const struct spi_nor_manufacturer
  	&spi_nor_winbond,
  	&spi_nor_xilinx,
  	&spi_nor_xmc,
@@ -69,7 +69,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static const struct flash_info *
 --- a/drivers/mtd/spi-nor/core.h
 +++ b/drivers/mtd/spi-nor/core.h
-@@ -489,6 +489,7 @@ extern const struct spi_nor_manufacturer
+@@ -490,6 +490,7 @@ extern const struct spi_nor_manufacturer
  extern const struct spi_nor_manufacturer spi_nor_winbond;
  extern const struct spi_nor_manufacturer spi_nor_xilinx;
  extern const struct spi_nor_manufacturer spi_nor_xmc;


### PR DESCRIPTION
Move the patches for BoHong bh25q128as out of ramips to make them generic.

Functionality was verified on a Wavlink WL-WN586X3 Rev.a with both main kernel (5.15.y) and testing kernel (6.1.y).
