### PR TITLE
ath79: generic: fix the alphabetical order in 02_network

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -496,6 +496,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "3:lan:3" "4:lan:2" "5:lan:1" "6@eth0" "2:wan:4" "1:wan:5"
 		;;
+	tplink,deco-m4r-v1|\
+	tplink,deco-s4-v2)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "3:lan:1" "5:lan:2"
+		;;
 	tplink,eap225-wall-v2)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
@@ -571,11 +576,6 @@ ath79_setup_interfaces()
 	ubnt,unifi-ap-pro)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan"
-		;;
-	tplink,deco-m4r-v1|\
-	tplink,deco-s4-v2)
-		ucidef_add_switch "switch0" \
-			"0@eth0" "3:lan:1" "5:lan:2"
 		;;
 	hiwifi,hc6361|\
 	xiaomi,mi-router-4q|\


### PR DESCRIPTION
This commit fixes the alphabetical order in 02_network.
The 2 deco devices in ath79_setup_interfaces() were in the wrong place.

Signed-off-by: Foica David <superh552@gmail.com>