### PR TITLE
ramips: fix and clean up D-Link MAC address

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-1935-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-1935-a1.dts
@@ -6,18 +6,4 @@
 / {
 	compatible = "dlink,dir-1935-a1", "mediatek,mt7621-soc";
 	model = "D-Link DIR-1935 A1";
-
-	aliases {
-		label-mac-device = &gmac0;
-	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_factory_e000>;
-	nvmem-cell-names = "mac-address";
-};
-
-&gmac1 {
-	nvmem-cells = <&macaddr_factory_e006>;
-	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-867-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-867-a1.dts
@@ -6,18 +6,4 @@
 / {
 	compatible = "dlink,dir-867-a1", "mediatek,mt7621-soc";
 	model = "D-Link DIR-867 A1";
-
-	aliases {
-		label-mac-device = &gmac0;
-	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_factory_e000>;
-	nvmem-cell-names = "mac-address";
-};
-
-&gmac1 {
-	nvmem-cells = <&macaddr_factory_e006>;
-	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-878-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-878-a1.dts
@@ -6,18 +6,4 @@
 / {
 	compatible = "dlink,dir-878-a1", "mediatek,mt7621-soc";
 	model = "D-Link DIR-878 A1";
-
-	aliases {
-		label-mac-device = &gmac0;
-	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_factory_e000>;
-	nvmem-cell-names = "mac-address";
-};
-
-&gmac1 {
-	nvmem-cells = <&macaddr_factory_e006>;
-	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-878-r1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-878-r1.dts
@@ -6,18 +6,4 @@
 / {
 	compatible = "dlink,dir-878-r1", "mediatek,mt7621-soc";
 	model = "D-Link DIR-878 R1";
-
-	aliases {
-		label-mac-device = &gmac0;
-	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_factory_e000>;
-	nvmem-cell-names = "mac-address";
-};
-
-&gmac1 {
-	nvmem-cells = <&macaddr_factory_e006>;
-	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-882-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-882-a1.dts
@@ -6,10 +6,6 @@
 / {
 	compatible = "dlink,dir-882-a1", "mediatek,mt7621-soc";
 	model = "D-Link DIR-882 A1";
-
-	aliases {
-		label-mac-device = &gmac0;
-	};
 };
 
 &leds {
@@ -26,14 +22,4 @@
 		trigger-sources = <&xhci_ehci_port1>;
 		linux,default-trigger = "usbport";
 	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_factory_e000>;
-	nvmem-cell-names = "mac-address";
-};
-
-&gmac1 {
-	nvmem-cells = <&macaddr_factory_e006>;
-	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-882-r1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-882-r1.dts
@@ -6,10 +6,6 @@
 / {
 	compatible = "dlink,dir-882-r1", "mediatek,mt7621-soc";
 	model = "D-Link DIR-882 R1";
-
-	aliases {
-		label-mac-device = &gmac0;
-	};
 };
 
 &leds {
@@ -26,14 +22,4 @@
 		trigger-sources = <&xhci_ehci_port1>;
 		linux,default-trigger = "usbport";
 	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_factory_e000>;
-	nvmem-cell-names = "mac-address";
-};
-
-&gmac1 {
-	nvmem-cells = <&macaddr_factory_e006>;
-	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-8xx.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-8xx.dtsi
@@ -8,6 +8,7 @@
 
 / {
 	aliases {
+		label-mac-device = &gmac0;
 		led-boot = &led_power_orange;
 		led-failsafe = &led_power_green;
 		led-running = &led_power_green;
@@ -71,8 +72,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_e000 1>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {
@@ -85,8 +86,8 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_8000>;
-		nvmem-cell-names = "eeprom";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_e000 2>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {
@@ -95,10 +96,18 @@
 	};
 };
 
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000 0>;
+	nvmem-cell-names = "mac-address";
+};
+
 &gmac1 {
 	status = "okay";
 	label = "wan";
 	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_e006 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &mdio {

--- a/target/linux/ramips/dts/mt7621_dlink_dir-xx60-a1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-xx60-a1.dtsi
@@ -101,10 +101,6 @@
 					reg = <0xe000 0x6>;
 					#nvmem-cell-cells = <1>;
 				};
-
-				macaddr_factory_e006: macaddr@e006 {
-					reg = <0xe006 0x6>;
-				};
 			};
 		};
 
@@ -154,8 +150,8 @@
 	wifi0: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_factory_e000 1>;
-		nvmem-cell-names = "eeprom";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_e000 1>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {
@@ -168,8 +164,8 @@
 	wifi1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_factory_e000 2>;
-		nvmem-cell-names = "eeprom";
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_e000 2>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <5000000 6000000>;
 
 		led {
@@ -188,7 +184,7 @@
 	label = "wan";
 	phy-handle = <&ethphy4>;
 
-	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cells = <&macaddr_factory_e000 3>;
 	nvmem-cell-names = "mac-address";
 };
 

--- a/target/linux/ramips/dts/mt7621_dlink_flash-16m-a1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_flash-16m-a1.dtsi
@@ -44,7 +44,9 @@
 					};
 
 					macaddr_factory_e000: macaddr@e000 {
+						compatible = "mac-base";
 						reg = <0xe000 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 
 					macaddr_factory_e006: macaddr@e006 {

--- a/target/linux/ramips/dts/mt7621_dlink_flash-16m-r1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_flash-16m-r1.dtsi
@@ -50,7 +50,9 @@
 					};
 
 					macaddr_factory_e000: macaddr@e000 {
+						compatible = "mac-base";
 						reg = <0xe000 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 
 					macaddr_factory_e006: macaddr@e006 {


### PR DESCRIPTION
add back WIFI eprom addresses pointer in mt7621_dlink_dir-xx60-a1.dtsi 
Change MAC address pointer from factory_e006 to factory_e000 + 3
	same as used in D-link firmware 1.11 DIR-1960-A1
	DIR-1960-A1,DIR-2640-A1,DIR-2660-A1,DIR-3060-A1

Clean-up MAC addresses in D-Link NOR devices DTS's 
Change WIFI MAC Addressees to the same as NAND cousins macaddr_factory_e000 + ?
	as later devices don't have the MAC address in factory configuration
	same as used in D-Link firmware 1.30 DIR-878-A1
	DIR-867-A1,DIR-878-A1,DIR-878-R1,DIR-882-A1,DIR-882-R1,DIR-1935-A1

* D-link software differs between source of wan address
 all these devices have the following MAC addresses use
LAN  = Label 
2.4G = Label +1
5G    = Label +2
WAN = Label +3