### PR TITLE
llvm-bpf: update to 17.0.6

### DIFF
--- a/tools/llvm-bpf/Makefile
+++ b/tools/llvm-bpf/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=llvm-project
-PKG_VERSION:=15.0.7
+PKG_VERSION:=17.0.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).src.tar.xz
 PKG_SOURCE_URL:=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(PKG_VERSION)
-PKG_HASH:=8b5fcb24b4128cf04df1b0b9410ce8b1a729cb3c544e6da885d234280dedeac6
+PKG_HASH:=58a8818c60e6627064f312dbf46c02d9949956558340938b71cf731ad8bc0813
 PKG_CPE_ID:=cpe:/a:llvm:llvm
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)-$(PKG_VERSION).src


### PR DESCRIPTION
Changelogs for llvm project are available at their discord, so changelog no linked here; propably tons of fixes and improvements since it's been a while from previous llvm update and there's already 2 major versions after previously used version. It also builds now on musl-1.2.4 > hosts as well without tinkering it.