### PR TITLE
dnsmasq: rework network interface ignore

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1244,10 +1244,11 @@ dnsmasq_stop()
 
 add_interface_trigger()
 {
-	local interface ignore
+	local interface ifname ignore
 
 	config_get interface "$1" interface
 	config_get_bool ignore "$1" ignore 0
+	network_get_device ifname "$interface" || ignore=0
 
 	[ -n "$interface" ] && [ $ignore -eq 0 ] && procd_add_interface_trigger "interface.*" "$interface" /etc/init.d/dnsmasq reload
 }


### PR DESCRIPTION
In some situations (slow protocol or interfaces with auto 0), the interfaces are not available during the dnsmasq initialization and hence, the ignore setting will be skipped.

Install an interface trigger for ignored interfaces in case their ifname cannot be resolved.

Fixes https://github.com/openwrt/openwrt/issues/14490