### PR TITLE
ramips: removing unnecessary compatibility for TP-Link Archer C2 v1

### DIFF
--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
@@ -73,7 +73,7 @@
 	};
 
 	rtl8367rb {
-		compatible = "realtek,rtl8367b", "rtl8367b";
+		compatible = "realtek,rtl8367b";
 		cpu_port = <6>;
 		realtek,extif1 = <1 0 1 1 1 1 1 1 2>;
 		mii-bus = <&mdio0>;


### PR DESCRIPTION
Removing: compatible = "rtl8367b"
This string is not used anywhere in the code.