### PR TITLE
mediatek: filogic: bpi-r3-mini: minor fixes

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-bananapi-bpi-r3-mini.dts
+++ b/target/linux/mediatek/dts/mt7986a-bananapi-bpi-r3-mini.dts
@@ -50,17 +50,22 @@
 		compatible = "gpio-leds";
 
 		status_led: led-0 {
-			label = "green:status";
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 19 GPIO_ACTIVE_HIGH>;
 		};
 
 		led-1 {
-			label = "blue:wlan2g";
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_BLUE>;
+			function-enumerator = <1>;
 			gpios = <&pio 1 GPIO_ACTIVE_HIGH>;
 		};
 
 		led-2 {
-			label = "blue:wlan5g";
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_BLUE>;
+			function-enumerator = <2>;
 			gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
 		};
 	};

--- a/target/linux/mediatek/dts/mt7986a-bananapi-bpi-r3-mini.dts
+++ b/target/linux/mediatek/dts/mt7986a-bananapi-bpi-r3-mini.dts
@@ -427,6 +427,11 @@
 	};
 
 	usb_ngff_pins: usb-ngff-pins {
+		ngff-gnss-off {
+			pins = "GPIO_6";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <1>;
+		};
 		ngff-pe-rst {
 			pins = "GPIO_7";
 			drive-strength = <8>;
@@ -444,6 +449,11 @@
 		};
 		ngff-rst {
 			pins = "GPIO_10";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <1>;
+		};
+		ngff-coex {
+			pins = "SPI1_CS";
 			drive-strength = <8>;
 			mediatek,pull-up-adv = <1>;
 		};
@@ -534,7 +544,8 @@
 &spi1 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spic_pins>;
-	status = "okay";
+	/* conflicts with M.2 pin */
+	status = "disabled";
 };
 
 &ssusb {

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -17,6 +17,8 @@ bananapi,bpi-r3-mini)
 	ucidef_set_led_netdev "lan2" "LAN" "mdio-bus:0e:yellow:lan" "eth0" "link_2500 link_100 tx rx"
 	ucidef_set_led_netdev "wan1" "WAN" "mdio-bus:0f:green:wan" "eth1" "link_2500 link_1000 tx rx"
 	ucidef_set_led_netdev "wan2" "WAN" "mdio-bus:0f:yellow:wan" "eth1" "link_2500 link_100 tx rx"
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan-1" "phy0-ap0"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan-2" "phy1-ap0"
 	;;
 bananapi,bpi-r4)
 	ucidef_set_led_netdev "wan" "wan" "mt7530-0:00:green:lan" "wan" "link tx rx"


### PR DESCRIPTION
- convert to new LED color/function format
- bind WLAN LED-s to phy*-ap0
- fix power on M.2 slot

For details please see commit message for each change.