### PR TITLE
build: add explicit --no-show-signature for git

### DIFF
--- a/scripts/get_source_date_epoch.sh
+++ b/scripts/get_source_date_epoch.sh
@@ -15,8 +15,8 @@ try_version() {
 }
 
 try_git() {
-	SOURCE_DATE_EPOCH=$(git -C "$SOURCE" log -1 --format=format:%ct \
-		"$SOURCE" 2>/dev/null)
+	SOURCE_DATE_EPOCH=$(git -C "$SOURCE" log -1 --no-show-signature \
+		--format=format:%ct "$SOURCE" 2>/dev/null)
 	[ -n "$SOURCE_DATE_EPOCH" ]
 }
 


### PR DESCRIPTION
Fixes compatibility for users who have 'log.showSignature' set to 'true' in their '~/.gitconfig'.
