### PR TITLE
qualcommax: ipq807x: 301w: correct PHY mode for AQR

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
@@ -485,12 +485,14 @@
 &dp5 {
 	status = "okay";
 	qcom,mactype = <1>;
+	phy-mode = "usxgmii";
 	phy-handle = <&aqr113c_8>;
 	label = "10g-1";
 };
 
 &dp6_syn {
 	status = "okay";
+	phy-mode = "usxgmii";
 	phy-handle = <&aqr113c_0>;
 	label = "10g-2";
 };


### PR DESCRIPTION
Interfaces that have AQR-s attached to them are using USXGMII and not just the default SGMII.
This was fine until SSDK added some sanity checking and now on Qnap 301W it would fail with:
[   24.740197] nss-dp 3a001800.dp5 10g-1 (uninitialized): failed to connect to phy device
[   24.740264] nss-dp: probe of 3a001800.dp5 failed with error -14

So, lets fix 10G AQR ports by declaring the correct PHY mode.
