### PR TITLE
ramips: clean up useless dts partition labels

### DIFF
--- a/target/linux/ramips/dts/mt7620a_aigale_ai-br100.dts
+++ b/target/linux/ramips/dts/mt7620a_aigale_ai-br100.dts
@@ -75,7 +75,7 @@
 				read-only;
 			};
 
-			factory: partition@30000 {
+			partition@30000 {
 				label = "factory";
 				reg = <0x30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_alfa-network_ac1200rm.dts
+++ b/target/linux/ramips/dts/mt7620a_alfa-network_ac1200rm.dts
@@ -134,7 +134,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_alfa-network_r36m-e4g.dts
+++ b/target/linux/ramips/dts/mt7620a_alfa-network_r36m-e4g.dts
@@ -192,7 +192,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_alfa-network_tube-e4g.dts
+++ b/target/linux/ramips/dts/mt7620a_alfa-network_tube-e4g.dts
@@ -164,7 +164,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_asus_rp-n53.dts
+++ b/target/linux/ramips/dts/mt7620a_asus_rp-n53.dts
@@ -119,7 +119,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_asus_rt-ac5x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_asus_rt-ac5x.dtsi
@@ -81,7 +81,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_bdcom_wap2100-sk.dts
+++ b/target/linux/ramips/dts/mt7620a_bdcom_wap2100-sk.dts
@@ -84,7 +84,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_buffalo_whr-1166d.dts
+++ b/target/linux/ramips/dts/mt7620a_buffalo_whr-1166d.dts
@@ -116,7 +116,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_buffalo_whr-300hp2.dts
+++ b/target/linux/ramips/dts/mt7620a_buffalo_whr-300hp2.dts
@@ -116,7 +116,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_buffalo_whr-600d.dts
+++ b/target/linux/ramips/dts/mt7620a_buffalo_whr-600d.dts
@@ -116,7 +116,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_cameo_810.dtsi
+++ b/target/linux/ramips/dts/mt7620a_cameo_810.dtsi
@@ -85,7 +85,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -111,7 +111,7 @@
 				};
 			};
 
-			factory5g: partition@50000 {
+			partition@50000 {
 				label = "factory5g";
 				reg = <0x50000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_dlink_dch-m225.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dch-m225.dts
@@ -121,7 +121,7 @@
 				read-only;
 			};
 
-			factory: partition@34000 {
+			partition@34000 {
 				label = "factory";
 				reg = <0x34000 0x4000>;
 				read-only;
@@ -141,7 +141,7 @@
 				};
 			};
 
-			nvram: partition@38000 {
+			partition@38000 {
 				label = "nvram";
 				reg = <0x38000 0x8000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_dlink_dir-510l.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dir-510l.dts
@@ -96,7 +96,7 @@
 				reg = <0x210000 0xde0000>;
 			};
 
-			config: partition@ff0000 {
+			partition@ff0000 {
 				label = "config";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_dlink_dir-806a-b1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dir-806a-b1.dts
@@ -88,7 +88,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "Factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
@@ -118,7 +118,7 @@
 				reg = <0x10000 0xfe0000>;
 			};
 
-			config: partition@ff0000 {
+			partition@ff0000 {
 				label = "config";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a2.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a2.dts
@@ -115,7 +115,7 @@
 				reg = <0x10000 0xfe0000>;
 			};
 
-			config: partition@ff0000 {
+			partition@ff0000 {
 				label = "config";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-96x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-96x.dtsi
@@ -154,7 +154,7 @@
 				reg = <0x10000 0xfe0000>;
 			};
 
-			config: partition@ff0000 {
+			partition@ff0000 {
 				label = "config";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_domywifi.dtsi
+++ b/target/linux/ramips/dts/mt7620a_domywifi.dtsi
@@ -115,7 +115,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_dovado_tiny-ac.dts
+++ b/target/linux/ramips/dts/mt7620a_dovado_tiny-ac.dts
@@ -80,7 +80,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_edimax_br-6208ac-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_br-6208ac-v2.dts
@@ -134,7 +134,7 @@
 			};
 
 			// Factory
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
@@ -102,7 +102,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_edimax_ew-7478apc.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_ew-7478apc.dts
@@ -94,7 +94,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_edimax_ew-747x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_edimax_ew-747x.dtsi
@@ -83,7 +83,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_engenius_epg600.dts
+++ b/target/linux/ramips/dts/mt7620a_engenius_epg600.dts
@@ -117,7 +117,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -133,7 +133,7 @@
 				};
 			};
 
-			rf: partition@50000 {
+			partition@50000 {
 				label = "rf";
 				reg = <0x50000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_engenius_esr600.dts
+++ b/target/linux/ramips/dts/mt7620a_engenius_esr600.dts
@@ -99,7 +99,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -115,7 +115,7 @@
 				};
 			};
 
-			iNIC_rf: partition@50000 {
+			partition@50000 {
 				label = "iNIC_rf";
 				reg = <0x50000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_fon_fon2601.dts
+++ b/target/linux/ramips/dts/mt7620a_fon_fon2601.dts
@@ -78,7 +78,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt300a.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt300a.dts
@@ -94,7 +94,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt300n.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt300n.dts
@@ -89,7 +89,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt750.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt750.dts
@@ -89,7 +89,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_head-weblink_hdrm200.dts
+++ b/target/linux/ramips/dts/mt7620a_head-weblink_hdrm200.dts
@@ -81,7 +81,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -105,7 +105,7 @@
 				};
 			};
 
-			firmware: partition@50000 {
+			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
@@ -51,7 +51,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -87,7 +87,7 @@
 				read-only;
 			};
 
-			bdinfo: partition@fe0000 {
+			partition@fe0000 {
 				label = "bdinfo";
 				reg = <0xfe0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_hnet_c108.dts
+++ b/target/linux/ramips/dts/mt7620a_hnet_c108.dts
@@ -111,7 +111,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_humax_e2.dts
+++ b/target/linux/ramips/dts/mt7620a_humax_e2.dts
@@ -92,7 +92,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x30000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_iodata_wn-ac1167gr.dts
+++ b/target/linux/ramips/dts/mt7620a_iodata_wn-ac1167gr.dts
@@ -92,7 +92,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x8000>;
 				read-only;
@@ -112,7 +112,7 @@
 				};
 			};
 
-			iNIC_rf: partition@48000 {
+			partition@48000 {
 				label = "iNIC_rf";
 				reg = <0x48000 0x8000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_iodata_wn-ac733gr3.dts
+++ b/target/linux/ramips/dts/mt7620a_iodata_wn-ac733gr3.dts
@@ -106,7 +106,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x8000>;
 				read-only;
@@ -126,7 +126,7 @@
 				};
 			};
 
-			iNIC_rf: partition@48000 {
+			partition@48000 {
 				label = "iNIC_rf";
 				reg = <0x48000 0x8000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_iptime.dtsi
+++ b/target/linux/ramips/dts/mt7620a_iptime.dtsi
@@ -28,7 +28,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			uboot: partition@0 {
+			partition@0 {
 				label = "u-boot";
 				reg = <0x0 0x20000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_kimax_u25awf-h1.dts
+++ b/target/linux/ramips/dts/mt7620a_kimax_u25awf-h1.dts
@@ -74,7 +74,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_lava_lr-25g001.dts
+++ b/target/linux/ramips/dts/mt7620a_lava_lr-25g001.dts
@@ -93,7 +93,7 @@
 				reg = <0x10000 0xfe0000>;
 			};
 
-			config: partition@ff0000 {
+			partition@ff0000 {
 				label = "config";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_lb-link_bl-w1200.dts
+++ b/target/linux/ramips/dts/mt7620a_lb-link_bl-w1200.dts
@@ -66,7 +66,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dtsi
@@ -54,7 +54,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_linksys_e1700.dts
+++ b/target/linux/ramips/dts/mt7620a_linksys_e1700.dts
@@ -78,7 +78,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_microduino_microwrt.dts
+++ b/target/linux/ramips/dts/mt7620a_microduino_microwrt.dts
@@ -53,7 +53,7 @@
 				read-only;
 			};
 
-			factory: partition@30000 {
+			partition@30000 {
 				label = "factory";
 				reg = <0x30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_netcore_nw5212.dts
+++ b/target/linux/ramips/dts/mt7620a_netcore_nw5212.dts
@@ -94,7 +94,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_netgear_ex2700.dts
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex2700.dts
@@ -115,7 +115,7 @@
 				reg = <0x40000 0x3b0000>;
 			};
 
-			art: partition@3f0000 {
+			partition@3f0000 {
 				label = "art";
 				reg = <0x3f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_netgear_ex3x00_ex61xx.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex3x00_ex61xx.dtsi
@@ -101,7 +101,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_netgear_wn3x00rp.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_wn3x00rp.dtsi
@@ -119,7 +119,7 @@
 				reg = <0x40000 0x7b0000>;
 			};
 
-			art: partition@7f0000 {
+			partition@7f0000 {
 				label = "art";
 				reg = <0x7f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_netis_wf2770.dts
+++ b/target/linux/ramips/dts/mt7620a_netis_wf2770.dts
@@ -75,7 +75,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_ohyeah_oy-0001.dts
+++ b/target/linux/ramips/dts/mt7620a_ohyeah_oy-0001.dts
@@ -74,7 +74,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_phicomm_k2x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_phicomm_k2x.dtsi
@@ -72,7 +72,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
@@ -75,7 +75,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_planex_cs-qr10.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_cs-qr10.dts
@@ -81,7 +81,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_planex_db-wrt01.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_db-wrt01.dts
@@ -65,7 +65,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-750dhp.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-750dhp.dts
@@ -86,7 +86,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-ex300np.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-ex300np.dts
@@ -100,7 +100,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-ex750np.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-ex750np.dts
@@ -106,7 +106,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_ralink_mt7620a-evb.dts
+++ b/target/linux/ramips/dts/mt7620a_ralink_mt7620a-evb.dts
@@ -49,7 +49,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_ralink_mt7620a-mt7530-evb.dts
+++ b/target/linux/ramips/dts/mt7620a_ralink_mt7620a-mt7530-evb.dts
@@ -30,7 +30,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_ralink_mt7620a-mt7610e-evb.dts
+++ b/target/linux/ramips/dts/mt7620a_ralink_mt7620a-mt7610e-evb.dts
@@ -49,7 +49,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_ralink_mt7620a-v22sg-evb.dts
+++ b/target/linux/ramips/dts/mt7620a_ralink_mt7620a-v22sg-evb.dts
@@ -43,7 +43,7 @@
 				read-only;
 			};
 
-			factory: partition@60000 {
+			partition@60000 {
 				label = "factory";
 				reg = <0x60000 0x20000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_sanlinking_d240.dts
+++ b/target/linux/ramips/dts/mt7620a_sanlinking_d240.dts
@@ -113,7 +113,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_sitecom_wlr-4100-v1-002.dts
+++ b/target/linux/ramips/dts/mt7620a_sitecom_wlr-4100-v1-002.dts
@@ -105,7 +105,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
@@ -111,7 +111,7 @@
 				read-only;
 			};
 
-			rom: partition@7d0000 {
+			partition@7d0000 {
 				label = "rom";
 				reg = <0x7d0000 0x10000>;
 				read-only;
@@ -135,7 +135,7 @@
 				read-only;
 			};
 
-			radio: partition@7f0000 {
+			partition@7f0000 {
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
@@ -144,7 +144,7 @@
 				reg = <0x20000 0x7b0000>;
 			};
 
-			rom: partition@7d0000 {
+			partition@7d0000 {
 				label = "rom";
 				reg = <0x7d0000 0x10000>;
 				read-only;
@@ -166,7 +166,7 @@
 				read-only;
 			};
 
-			radio: partition@7f0000 {
+			partition@7f0000 {
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_tplink_archer.dtsi
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer.dtsi
@@ -68,7 +68,7 @@
 				read-only;
 			};
 
-			rom: partition@7d0000 {
+			partition@7d0000 {
 				label = "rom";
 				reg = <0x7d0000 0x10000>;
 				read-only;
@@ -92,7 +92,7 @@
 				read-only;
 			};
 
-			radio: partition@7f0000 {
+			partition@7f0000 {
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_tplink_re2x0-v1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_tplink_re2x0-v1.dtsi
@@ -44,7 +44,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			uboot: partition@0 {
+			partition@0 {
 				label = "u-boot";
 				reg = <0x0 0x20000>;
 				read-only;
@@ -74,7 +74,7 @@
 				read-only;
 			};
 
-			radio: partition@7f0000 {
+			partition@7f0000 {
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn530hg4.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn530hg4.dts
@@ -75,7 +75,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn535k1.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn535k1.dts
@@ -96,7 +96,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn579x3.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn579x3.dts
@@ -124,7 +124,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_wevo_air-duo.dts
+++ b/target/linux/ramips/dts/mt7620a_wevo_air-duo.dts
@@ -80,7 +80,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
+++ b/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
@@ -102,7 +102,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
@@ -83,7 +83,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_yukai_bocco.dts
+++ b/target/linux/ramips/dts/mt7620a_yukai_bocco.dts
@@ -102,7 +102,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-ape522ii.dts
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-ape522ii.dts
@@ -79,7 +79,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026.dtsi
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026.dtsi
@@ -52,7 +52,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826.dtsi
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826.dtsi
@@ -77,7 +77,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_zte_q7.dts
+++ b/target/linux/ramips/dts/mt7620a_zte_q7.dts
@@ -71,7 +71,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
+++ b/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
@@ -116,7 +116,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_asus_rt-n12p.dts
+++ b/target/linux/ramips/dts/mt7620n_asus_rt-n12p.dts
@@ -94,7 +94,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_asus_rt-n14u.dts
+++ b/target/linux/ramips/dts/mt7620n_asus_rt-n14u.dts
@@ -100,7 +100,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_buffalo_wmr-300.dts
+++ b/target/linux/ramips/dts/mt7620n_buffalo_wmr-300.dts
@@ -81,7 +81,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_comfast_cf-wr800n.dts
+++ b/target/linux/ramips/dts/mt7620n_comfast_cf-wr800n.dts
@@ -87,7 +87,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-116-a1.dts
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-116-a1.dts
@@ -79,7 +79,7 @@
 				reg = <0x10000 0x7e0000>;
 			};
 
-			config: partition@7f0000 {
+			partition@7f0000 {
 				label = "config";
 				reg = <0x7f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-921-c1.dts
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-921-c1.dts
@@ -121,7 +121,7 @@
 				reg = <0x10000 0xfe0000>;
 			};
 
-			config: partition@ff0000 {
+			partition@ff0000 {
 				label = "config";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-922-e2.dts
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-922-e2.dts
@@ -124,7 +124,7 @@
 				reg = <0x10000 0xfe0000>;
 			};
 
-			config: partition@ff0000 {
+			partition@ff0000 {
 				label = "config";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_elecom_wrh-300cr.dts
+++ b/target/linux/ramips/dts/mt7620n_elecom_wrh-300cr.dts
@@ -85,7 +85,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_kimax_u35wf.dts
+++ b/target/linux/ramips/dts/mt7620n_kimax_u35wf.dts
@@ -72,7 +72,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_kingston_mlw221.dts
+++ b/target/linux/ramips/dts/mt7620n_kingston_mlw221.dts
@@ -78,7 +78,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_kingston_mlwg2.dts
+++ b/target/linux/ramips/dts/mt7620n_kingston_mlwg2.dts
@@ -78,7 +78,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_netgear_n300.dtsi
+++ b/target/linux/ramips/dts/mt7620n_netgear_n300.dtsi
@@ -56,7 +56,7 @@
 				read-only;
 			};
 
-			factory: partition@3f0000 {
+			partition@3f0000 {
 				label = "factory";
 				reg = <0x3f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_netgear_pr2000.dts
+++ b/target/linux/ramips/dts/mt7620n_netgear_pr2000.dts
@@ -105,7 +105,7 @@
 				reg = <0x40000 0xf20000>;
 			};
 
-			factory: partition@f60000 {
+			partition@f60000 {
 				label = "factory";
 				reg = <0xf60000 0x10000>;
 				read-only;
@@ -121,7 +121,7 @@
 				};
 			};
 
-			board_data: partition@f70000 {
+			partition@f70000 {
 				label = "board_data";
 				reg = <0xf70000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_nexx_wt3020.dtsi
+++ b/target/linux/ramips/dts/mt7620n_nexx_wt3020.dtsi
@@ -61,7 +61,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_snr_cpe-w4n-mt.dts
+++ b/target/linux/ramips/dts/mt7620n_snr_cpe-w4n-mt.dts
@@ -87,7 +87,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "Factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_sunvalley_filehub.dtsi
+++ b/target/linux/ramips/dts/mt7620n_sunvalley_filehub.dtsi
@@ -79,7 +79,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_vonets_var11n-300.dts
+++ b/target/linux/ramips/dts/mt7620n_vonets_var11n-300.dts
@@ -59,7 +59,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_wrtnode_wrtnode.dts
+++ b/target/linux/ramips/dts/mt7620n_wrtnode_wrtnode.dts
@@ -54,7 +54,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-cpe102.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-cpe102.dts
@@ -75,7 +75,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wa05.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wa05.dts
@@ -86,7 +86,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-we2026.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-we2026.dts
@@ -79,7 +79,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wr8305rt.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wr8305rt.dts
@@ -81,7 +81,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-lite-iii-a.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-lite-iii-a.dts
@@ -105,7 +105,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "RF-EEPROM";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni-ii.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni-ii.dts
@@ -111,7 +111,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni.dts
@@ -111,7 +111,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_adslr_g7.dts
+++ b/target/linux/ramips/dts/mt7621_adslr_g7.dts
@@ -63,7 +63,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_afoundry_ew1200.dts
+++ b/target/linux/ramips/dts/mt7621_afoundry_ew1200.dts
@@ -72,7 +72,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_alfa-network_quad-e4g.dts
+++ b/target/linux/ramips/dts/mt7621_alfa-network_quad-e4g.dts
@@ -241,7 +241,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_ampedwireless_ally.dtsi
+++ b/target/linux/ramips/dts/mt7621_ampedwireless_ally.dtsi
@@ -110,7 +110,7 @@
 			reg = <0x80000 0x80000>;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_arcadyan_we420223-99.dts
+++ b/target/linux/ramips/dts/mt7621_arcadyan_we420223-99.dts
@@ -121,7 +121,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "Factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_arcadyan_wg4xx223.dtsi
+++ b/target/linux/ramips/dts/mt7621_arcadyan_wg4xx223.dtsi
@@ -76,7 +76,7 @@
 			reg = <0x100000 0x100000>;
 		};
 
-		factory: partition@200000 {
+		partition@200000 {
 			label = "Factory";
 			reg = <0x200000 0x100000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_asiarf_ap7621.dtsi
+++ b/target/linux/ramips/dts/mt7621_asiarf_ap7621.dtsi
@@ -74,7 +74,7 @@
 				reg = <0x38000 0x8000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_asus_rp-ac56.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rp-ac56.dts
@@ -139,7 +139,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -169,7 +169,7 @@
 				reg = <0x50000 0xfa0000>;
 			};
 
-			radio: partition@ff0000 {
+			partition@ff0000 {
 				label = "radio";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_asus_rp-ac87.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rp-ac87.dts
@@ -111,7 +111,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_asus_rt-ac57u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ac57u-v1.dts
@@ -88,7 +88,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_asus_rt-acx5p.dtsi
+++ b/target/linux/ramips/dts/mt7621_asus_rt-acx5p.dtsi
@@ -81,7 +81,7 @@
 			read-only;
 		};
 
-		factory: partition@1e0000 {
+		partition@1e0000 {
 			label = "factory";
 			reg = <0x1e0000 0x100000>;
 			read-only;
@@ -105,7 +105,7 @@
 			};
 		};
 
-		factory2: partition@2e0000 {
+		partition@2e0000 {
 			label = "factory2";
 			reg = <0x2e0000 0x100000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -92,7 +92,7 @@
 			read-only;
 		};
 
-		factory: partition@1e0000 {
+		partition@1e0000 {
 			label = "factory";
 			reg = <0x1e0000 0x100000>;
 			read-only;
@@ -116,7 +116,7 @@
 			};
 		};
 
-		factory2: partition@2e0000 {
+		partition@2e0000 {
 			label = "factory2";
 			reg = <0x2e0000 0x100000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_asus_rt-ax54.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax54.dts
@@ -85,7 +85,7 @@
 			read-only;
 		};
 
-		factory: partition@1e0000 {
+		partition@1e0000 {
 			label = "factory";
 			reg = <0x1e0000 0x100000>;
 			read-only;
@@ -109,7 +109,7 @@
 			};
 		};
 
-		factory2: partition@2e0000 {
+		partition@2e0000 {
 			label = "factory2";
 			reg = <0x2e0000 0x100000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_asus_rt-n56u-b1.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-n56u-b1.dts
@@ -109,7 +109,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-giga.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-giga.dts
@@ -90,7 +90,7 @@
 			sercomm,scpart-id = <1>;
 		};
 
-		factory: partition@200000 {
+		partition@200000 {
 			label = "Factory";
 			reg = <0x200000 0x100000>;
 			sercomm,scpart-id = <2>;

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo-plus.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo-plus.dts
@@ -96,7 +96,7 @@
 			read-only;
 		};
 
-		factory: partition@200000 {
+		partition@200000 {
 			label = "Factory";
 			reg = <0x200000 0x100000>;
 			sercomm,scpart-id = <2>;

--- a/target/linux/ramips/dts/mt7621_belkin_rt1800.dts
+++ b/target/linux/ramips/dts/mt7621_belkin_rt1800.dts
@@ -86,7 +86,7 @@
 			reg = <0x80000 0x80000>;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "Factory";
 			reg = <0x100000 0x80000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_bolt_arion.dts
+++ b/target/linux/ramips/dts/mt7621_bolt_arion.dts
@@ -102,7 +102,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-1166dhp.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-1166dhp.dts
@@ -134,7 +134,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-2533dhpl.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-2533dhpl.dts
@@ -132,7 +132,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-600dhp.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-600dhp.dts
@@ -134,7 +134,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_comfast_cf-e390ax.dts
+++ b/target/linux/ramips/dts/mt7621_comfast_cf-e390ax.dts
@@ -90,7 +90,7 @@
 				read-only;
 			};
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "factory";
 				reg = <0x50000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_comfast_cf-ew72-v2.dts
+++ b/target/linux/ramips/dts/mt7621_comfast_cf-ew72-v2.dts
@@ -106,7 +106,7 @@
 				read-only;
 			};
 			
-			factory: partition@40000  {
+			partition@40000  {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_cudy_m1800.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_m1800.dts
@@ -113,7 +113,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_cudy_wr1300-v1.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr1300-v1.dts
@@ -87,7 +87,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -125,7 +125,7 @@
 				read-only;
 			};
 
-			bdinfo: partition@ff0000 {
+			partition@ff0000 {
 				label = "bdinfo";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_cudy_wr2100.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr2100.dts
@@ -133,7 +133,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -171,7 +171,7 @@
 				read-only;
 			};
 
-			bdinfo: partition@ff0000 {
+			partition@ff0000 {
 				label = "bdinfo";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_cudy_x6.dtsi
+++ b/target/linux/ramips/dts/mt7621_cudy_x6.dtsi
@@ -75,7 +75,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
@@ -118,7 +118,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
@@ -130,7 +130,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_dlink_covr-x1860-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_covr-x1860-a1.dts
@@ -98,7 +98,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x80000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_dlink_dap-x1860-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dap-x1860-a1.dts
@@ -128,7 +128,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x80000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_dlink_dir-3060-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-3060-a1.dts
@@ -113,7 +113,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_dlink_dir-853-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-853-a1.dts
@@ -111,7 +111,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_dlink_dir-853-a3.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-853-a3.dts
@@ -108,7 +108,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_dlink_dir-860l-b1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-860l-b1.dts
@@ -85,7 +85,7 @@
 				read-only;
 			};
 
-			radio: partition@34000 {
+			partition@34000 {
 				label = "radio";
 				reg = <0x34000 0x4000>;
 				read-only;
@@ -109,7 +109,7 @@
 				};
 			};
 
-			factory: partition@38000 {
+			partition@38000 {
 				label = "factory";
 				reg = <0x38000 0x8000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_dlink_dir-xx60-a1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-xx60-a1.dtsi
@@ -78,7 +78,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_dlink_dxx-1xx0-x1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dxx-1xx0-x1.dtsi
@@ -95,7 +95,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_dlink_flash-16m-a1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_flash-16m-a1.dtsi
@@ -25,7 +25,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x20000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_dlink_flash-16m-r1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_flash-16m-r1.dtsi
@@ -25,7 +25,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_edimax_re23s.dts
+++ b/target/linux/ramips/dts/mt7621_edimax_re23s.dts
@@ -87,7 +87,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_edimax_rx21s.dtsi
+++ b/target/linux/ramips/dts/mt7621_edimax_rx21s.dtsi
@@ -80,7 +80,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1167ghbk2-s.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1167ghbk2-s.dts
@@ -140,7 +140,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533ghbk.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533ghbk.dtsi
@@ -95,7 +95,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_etisalat_s3.dts
+++ b/target/linux/ramips/dts/mt7621_etisalat_s3.dts
@@ -96,7 +96,7 @@
 			read-only;
 		};
 
-		factory: partition@200000 {
+		partition@200000 {
 			label = "Factory";
 			reg = <0x200000 0x100000>;
 			sercomm,scpart-id = <2>;

--- a/target/linux/ramips/dts/mt7621_firefly_firewrt.dts
+++ b/target/linux/ramips/dts/mt7621_firefly_firewrt.dts
@@ -71,7 +71,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_gehua_ghl-r-001.dts
+++ b/target/linux/ramips/dts/mt7621_gehua_ghl-r-001.dts
@@ -69,7 +69,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_glinet_gl-mt1300.dts
+++ b/target/linux/ramips/dts/mt7621_glinet_gl-mt1300.dts
@@ -87,7 +87,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_gnubee_gb-pc1.dts
+++ b/target/linux/ramips/dts/mt7621_gnubee_gb-pc1.dts
@@ -73,7 +73,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_gnubee_gb-pc2.dts
+++ b/target/linux/ramips/dts/mt7621_gnubee_gb-pc2.dts
@@ -93,7 +93,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_h3c_tx180x.dtsi
+++ b/target/linux/ramips/dts/mt7621_h3c_tx180x.dtsi
@@ -94,7 +94,7 @@
 			read-only;
 		};
 
-		factory: partition@180000 {
+		partition@180000 {
 			label = "factory";
 			reg = <0x0180000 0x0080000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_haier-sim_wr1800k.dtsi
+++ b/target/linux/ramips/dts/mt7621_haier-sim_wr1800k.dtsi
@@ -98,7 +98,7 @@
 			reg = <0x0080000 0x0080000>;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x0100000 0x0080000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_hanyang_hyc-g920.dts
+++ b/target/linux/ramips/dts/mt7621_hanyang_hyc-g920.dts
@@ -77,7 +77,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_hilink_hlk-7621a-evb.dts
+++ b/target/linux/ramips/dts/mt7621_hilink_hlk-7621a-evb.dts
@@ -46,7 +46,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_hiwifi_hc5962.dts
+++ b/target/linux/ramips/dts/mt7621_hiwifi_hc5962.dts
@@ -82,7 +82,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_huasifei_ws1208v2.dts
+++ b/target/linux/ramips/dts/mt7621_huasifei_ws1208v2.dts
@@ -95,7 +95,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_humax_e10.dts
+++ b/target/linux/ramips/dts/mt7621_humax_e10.dts
@@ -92,7 +92,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x30000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr.dts
@@ -91,7 +91,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -113,7 +113,7 @@
 				};
 			};
 
-			iNIC_rf: partition@50000 {
+			partition@50000 {
 				label = "iNIC_rf";
 				reg = <0x50000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_iodata_wn-dx1200gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-dx1200gr.dts
@@ -83,7 +83,7 @@
 			read-only;
 		};
 
-		factory: partition@200000 {
+		partition@200000 {
 			label = "factory";
 			reg = <0x200000 0x200000>;
 

--- a/target/linux/ramips/dts/mt7621_iodata_wn-gx300gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-gx300gr.dts
@@ -91,7 +91,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_iodata_wn-xx-xr.dtsi
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-xx-xr.dtsi
@@ -80,7 +80,7 @@
 			read-only;
 		};
 
-		factory: partition@200000 {
+		partition@200000 {
 			label = "factory";
 			reg = <0x0200000 0x0100000>;
 

--- a/target/linux/ramips/dts/mt7621_iodata_wnpr2600g.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wnpr2600g.dts
@@ -94,7 +94,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x040000 0x010000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_iptime_a3002mesh.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a3002mesh.dts
@@ -91,7 +91,7 @@
 				read-only;
 			};
 
-			factory: partition@30000 {
+			partition@30000 {
 				label = "factory";
 				reg = <0x30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_iptime_a3004ns-dual.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a3004ns-dual.dts
@@ -65,7 +65,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			uboot: partition@0 {
+			partition@0 {
 				label = "u-boot";
 				reg = <0x0 0x20000>;
 				read-only;
@@ -91,7 +91,7 @@
 				read-only;
 			};
 
-			factory: partition@30000 {
+			partition@30000 {
 				label = "factory";
 				reg = <0x30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_iptime_a3004t.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a3004t.dts
@@ -74,7 +74,7 @@
 			read-only;
 		};
 
-		factory: partition@a0000 {
+		partition@a0000 {
 			label = "factory";
 			reg = <0xa0000 0x20000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_iptime_a6004ns-m.dtsi
+++ b/target/linux/ramips/dts/mt7621_iptime_a6004ns-m.dtsi
@@ -76,7 +76,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			uboot: partition@0 {
+			partition@0 {
 				label = "u-boot";
 				reg = <0x0 0x20000>;
 				read-only;
@@ -102,7 +102,7 @@
 				read-only;
 			};
 
-			factory: partition@30000 {
+			partition@30000 {
 				label = "factory";
 				reg = <0x30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_iptime_a8004t.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a8004t.dts
@@ -69,7 +69,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			uboot: partition@0 {
+			partition@0 {
 				label = "u-boot";
 				reg = <0x0 0x20000>;
 				read-only;
@@ -95,7 +95,7 @@
 				read-only;
 			};
 
-			factory: partition@30000 {
+			partition@30000 {
 				label = "factory";
 				reg = <0x30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_iptime_ax2004m.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_ax2004m.dts
@@ -74,7 +74,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x80000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_jcg_jhr-ac876m.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_jhr-ac876m.dts
@@ -85,7 +85,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_jcg_q20.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_q20.dts
@@ -90,7 +90,7 @@
 			reg = <0x80000 0x80000>;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "Factory";
 			reg = <0x100000 0x80000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_jcg_y2.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_y2.dts
@@ -61,7 +61,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_keenetic_kn-3010.dts
+++ b/target/linux/ramips/dts/mt7621_keenetic_kn-3010.dts
@@ -107,7 +107,7 @@
 		reg = <0>;
 		spi-max-frequency = <31000000>;
 
-		partitions: partitions {
+		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -124,7 +124,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "rf-eeprom";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
+++ b/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
@@ -107,7 +107,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_linksys_e5600.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_e5600.dts
@@ -87,7 +87,7 @@
 			read-only;
 		};
 
-		factory: partition@c0000 {
+		partition@c0000 {
 			label = "factory";
 			reg = <0xc0000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_linksys_e7350.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_e7350.dts
@@ -80,7 +80,7 @@
 			reg = <0x80000 0x80000>;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "Factory";
 			reg = <0x100000 0x80000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
+++ b/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
@@ -101,7 +101,7 @@
 			reg = <0x80000 0x40000>;
 		};
 
-		factory: partition@c0000 {
+		partition@c0000 {
 			label = "factory";
 			reg = <0xc0000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_linksys_re6500.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_re6500.dts
@@ -72,7 +72,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_linksys_re7000.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_re7000.dts
@@ -86,7 +86,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_mediatek_ap-mt7621a-v60.dts
+++ b/target/linux/ramips/dts/mt7621_mediatek_ap-mt7621a-v60.dts
@@ -93,7 +93,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_mercusys_mr70x-v1.dts
+++ b/target/linux/ramips/dts/mt7621_mercusys_mr70x-v1.dts
@@ -74,7 +74,7 @@
 				reg = <0x040000 0xf60000>;
 			};
 
-			config: partition@fa0000 {
+			partition@fa0000 {
 				label = "config";
 				reg = <0xfa0000 0x010000>;
 				read-only;
@@ -98,7 +98,7 @@
 				read-only;
 			};
 
-			radio: partition@ff0000 {
+			partition@ff0000 {
 				label = "radio";
 				reg = <0xff0000 0x010000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_mqmaker_witi.dts
+++ b/target/linux/ramips/dts/mt7621_mqmaker_witi.dts
@@ -57,7 +57,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 

--- a/target/linux/ramips/dts/mt7621_mtc_wr1201.dts
+++ b/target/linux/ramips/dts/mt7621_mtc_wr1201.dts
@@ -81,7 +81,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_netgear_eax12.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_eax12.dts
@@ -110,7 +110,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "Factory";
 			reg = <0x100000 0x80000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_netgear_ex6150.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_ex6150.dts
@@ -121,7 +121,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_netgear_r6220.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_r6220.dts
@@ -41,7 +41,7 @@
 			reg = <0x600000 0x1c00000>;
 		};
 
-		factory: partition@2e00000 {
+		partition@2e00000 {
 			label = "factory";
 			reg = <0x2e00000 0x100000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_bzv.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_bzv.dtsi
@@ -346,7 +346,7 @@
 			read-only;
 		};
 
-		factory: partition@4600000 {
+		partition@4600000 {
 			label = "factory";
 			reg = <0x4600000 0x200000>;
 			sercomm,scpart-id = <16>;

--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_chj.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_chj.dtsi
@@ -270,7 +270,7 @@
 			read-only;
 		};
 
-		factory: partition@4600000 {
+		partition@4600000 {
 			label = "factory";
 			reg = <0x4600000 0x200000>;
 			sercomm,scpart-id = <16>;

--- a/target/linux/ramips/dts/mt7621_netgear_wac104.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_wac104.dts
@@ -98,7 +98,7 @@
 			reg = <0x600000 0x1c00000>;
 		};
 
-		factory: partition@2e00000 {
+		partition@2e00000 {
 			label = "factory";
 			reg = <0x2e00000 0x100000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_netgear_wax202.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_wax202.dts
@@ -115,7 +115,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "Factory";
 			reg = <0x100000 0x80000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_netgear_wndr3700-v5.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_wndr3700-v5.dts
@@ -36,7 +36,7 @@
 				read-only;
 			};
 
-			factory: partition@f30000 {
+			partition@f30000 {
 				label = "factory";
 				reg = <0xf30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_netis_wf2881.dts
+++ b/target/linux/ramips/dts/mt7621_netis_wf2881.dts
@@ -65,7 +65,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_oraybox_x3a.dts
+++ b/target/linux/ramips/dts/mt7621_oraybox_x3a.dts
@@ -80,7 +80,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
+++ b/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
@@ -73,7 +73,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_planex_vr500.dts
+++ b/target/linux/ramips/dts/mt7621_planex_vr500.dts
@@ -61,7 +61,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_raisecom_msg1500-x-00.dts
+++ b/target/linux/ramips/dts/mt7621_raisecom_msg1500-x-00.dts
@@ -102,7 +102,7 @@
 			};
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "Factory";
 			reg = <0x100000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_renkforce_ws-wn530hp3-a.dts
+++ b/target/linux/ramips/dts/mt7621_renkforce_ws-wn530hp3-a.dts
@@ -67,7 +67,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
+++ b/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
@@ -74,7 +74,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_sercomm_dxx_nand_256m.dtsi
+++ b/target/linux/ramips/dts/mt7621_sercomm_dxx_nand_256m.dtsi
@@ -94,7 +94,7 @@
 			read-only;
 		};
 
-		factory: partition@200000 {
+		partition@200000 {
 			label = "Factory";
 			reg = <0x200000 0x100000>;
 			sercomm,scpart-id = <2>;

--- a/target/linux/ramips/dts/mt7621_sercomm_na502.dts
+++ b/target/linux/ramips/dts/mt7621_sercomm_na502.dts
@@ -127,7 +127,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x40000>;
 

--- a/target/linux/ramips/dts/mt7621_sercomm_na502s.dts
+++ b/target/linux/ramips/dts/mt7621_sercomm_na502s.dts
@@ -231,7 +231,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x40000>;
 

--- a/target/linux/ramips/dts/mt7621_sercomm_s1500.dtsi
+++ b/target/linux/ramips/dts/mt7621_sercomm_s1500.dtsi
@@ -159,7 +159,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "Factory";
 			reg = <0x100000 0x100000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me1.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me1.dts
@@ -145,7 +145,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "Factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-lite.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-lite.dts
@@ -71,7 +71,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-sfp.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-sfp.dts
@@ -109,7 +109,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_storylink_sap-g3200u3.dts
+++ b/target/linux/ramips/dts/mt7621_storylink_sap-g3200u3.dts
@@ -68,7 +68,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_telco-electronics_x1.dts
+++ b/target/linux/ramips/dts/mt7621_telco-electronics_x1.dts
@@ -105,7 +105,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -131,7 +131,7 @@
 				};
 			};
 
-			firmware: partition@50000 {
+			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;

--- a/target/linux/ramips/dts/mt7621_tenbay_t-mb5eu-v01.dts
+++ b/target/linux/ramips/dts/mt7621_tenbay_t-mb5eu-v01.dts
@@ -193,7 +193,7 @@
 				read-only;
 			};
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "factory";
 				reg = <0x50000 0x40000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_thunder_timecloud.dts
+++ b/target/linux/ramips/dts/mt7621_thunder_timecloud.dts
@@ -81,7 +81,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_totolink_a7000r.dts
+++ b/target/linux/ramips/dts/mt7621_totolink_a7000r.dts
@@ -62,7 +62,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_totolink_x5000r.dts
+++ b/target/linux/ramips/dts/mt7621_totolink_x5000r.dts
@@ -69,7 +69,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_tozed_zlt-s12-pro.dts
+++ b/target/linux/ramips/dts/mt7621_tozed_zlt-s12-pro.dts
@@ -161,7 +161,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_archer-ax23-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-ax23-v1.dts
@@ -110,7 +110,7 @@
 				reg = <0x040000 0xf60000>;
 			};
 
-			config: partition@fa0000 {
+			partition@fa0000 {
 				label = "config";
 				reg = <0xfa0000 0x010000>;
 				read-only;
@@ -134,7 +134,7 @@
 				read-only;
 			};
 
-			radio: partition@ff0000 {
+			partition@ff0000 {
 				label = "radio";
 				reg = <0xff0000 0x010000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
@@ -121,7 +121,7 @@
 				reg = <0x040000 0xf60000>;
 			};
 
-			config: partition@fa0000 {
+			partition@fa0000 {
 				label = "config";
 				reg = <0xfa0000 0x010000>;
 				read-only;
@@ -145,7 +145,7 @@
 				read-only;
 			};
 
-			radio: partition@ff0000 {
+			partition@ff0000 {
 				label = "radio";
 				reg = <0xff0000 0x010000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_archer-x6-v3.dtsi
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-x6-v3.dtsi
@@ -107,7 +107,7 @@
 				reg = <0x40000 0xf60000>;
 			};
 
-			config: partition@fa0000 {
+			partition@fa0000 {
 				label = "config";
 				reg = <0xfa0000 0x50000>;
 				read-only;
@@ -125,7 +125,7 @@
 				};
 			};
 
-			radio: partition@ff0000 {
+			partition@ff0000 {
 				label = "radio";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_deco-m4r-v4.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_deco-m4r-v4.dts
@@ -128,7 +128,7 @@
 				reg = <0x40000 0xf60000>;
 			};
 
-			config: partition@fa0000 {
+			partition@fa0000 {
 				label = "config";
 				reg = <0xfa0000 0x010000>;
 				read-only;
@@ -150,7 +150,7 @@
 				read-only;
 			};
 
-			radio: partition@ff0000 {
+			partition@ff0000 {
 				label = "radio";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_eap235-wall-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap235-wall-v1.dts
@@ -80,7 +80,7 @@
 				read-only;
 			};
 
-			info: partition@90000 {
+			partition@90000 {
 				label = "product-info";
 				reg = <0x90000 0x10000>;
 				read-only;
@@ -124,7 +124,7 @@
 				read-only;
 			};
 
-			radio: partition@ff0000 {
+			partition@ff0000 {
 				label = "radio";
 				reg = <0xff0000 0x010000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_eap613-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap613-v1.dts
@@ -108,7 +108,7 @@
 				read-only;
 			};
 
-			radio: partition@ff0000 {
+			partition@ff0000 {
 				label = "radio";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts
@@ -88,7 +88,7 @@
 				read-only;
 			};
 
-			info: partition@90000 {
+			partition@90000 {
 				label = "product-info";
 				reg = <0x90000 0x10000>;
 				read-only;
@@ -128,7 +128,7 @@
 				read-only;
 			};
 
-			radio: partition@ff0000 {
+			partition@ff0000 {
 				label = "radio";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_ec330-g5u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_ec330-g5u-v1.dts
@@ -211,7 +211,7 @@
 			reg = <0x7400000 0x400000>;
 		};
 
-		factory: partition@7800000 {
+		partition@7800000 {
 			label = "factory";
 			reg = <0x7800000 0x400000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
@@ -137,7 +137,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_ex220-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_ex220-v1.dts
@@ -156,7 +156,7 @@
 				read-only;
 			};
 
-			radio: partition@90000 {
+			partition@90000 {
 				label = "radio";
 				reg = <0x90000 0x20000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_mr600-v2-eu.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_mr600-v2-eu.dts
@@ -112,7 +112,7 @@
 				reg = <0x20000 0xfa0000>;
 			};
 
-			romfile: partition@fc0000 {
+			partition@fc0000 {
 				label = "romfile";
 				reg = <0xfc0000 0x10000>;
 				read-only;
@@ -136,7 +136,7 @@
 				read-only;
 			};
 
-			radio: partition@fe0000 {
+			partition@fe0000 {
 				label = "radio";
 				reg = <0xfe0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_re350-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_re350-v1.dts
@@ -111,7 +111,7 @@
 				reg = <0x20000 0x5e0000>;
 			};
 
-			config: partition@600000 {
+			partition@600000 {
 				label = "config";
 				reg = <0x600000 0x50000>;
 				read-only;
@@ -129,7 +129,7 @@
 				};
 			};
 
-			radio: partition@7f0000 {
+			partition@7f0000 {
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_re650-v2.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_re650-v2.dts
@@ -120,7 +120,7 @@
 				reg = <0x20000 0x7a0000>;
 			};
 
-			config: partition@7c0000 {
+			partition@7c0000 {
 				label = "config";
 				reg = <0x7c0000 0x2d440>;
 				read-only;
@@ -138,7 +138,7 @@
 				};
 			};
 
-			radio: partition@7f0000 {
+			partition@7f0000 {
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_rexx0-v1.dtsi
+++ b/target/linux/ramips/dts/mt7621_tplink_rexx0-v1.dtsi
@@ -117,7 +117,7 @@
 				reg = <0x20000 0xde0000>;
 			};
 
-			config: partition@e00000 {
+			partition@e00000 {
 				label = "config";
 				reg = <0xe00000 0x50000>;
 				read-only;
@@ -139,7 +139,7 @@
 			 * firmware, so we do not use it either
 			 */
 
-			radio: partition@ff0000 {
+			partition@ff0000 {
 				label = "radio";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_tplink_tl-wpa8631p-v3.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_tl-wpa8631p-v3.dts
@@ -114,7 +114,7 @@
 				reg = <0x20000 0x710000>;
 			};
 
-			config: partition@730000 {
+			partition@730000 {
 				label = "config";
 				reg = <0x730000 0xc0000>;
 				read-only;
@@ -132,7 +132,7 @@
 				};
 			};
 
-			radio: partition@7f0000 {
+			partition@7f0000 {
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x.dtsi
+++ b/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x.dtsi
@@ -82,7 +82,7 @@
 			read-only;
 		};
 
-		factory: partition@e0000 {
+		partition@e0000 {
 			label = "factory";
 			reg = <0xe0000 0x60000>;
 

--- a/target/linux/ramips/dts/mt7621_ubnt_unifi-6-lite.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi-6-lite.dts
@@ -36,7 +36,7 @@
 				read-only;
 			};
 
-			factory: partition@70000 {
+			partition@70000 {
 				label = "factory";
 				reg = <0x70000 0x40000>;
 				read-only;
@@ -60,7 +60,7 @@
 				};
 			};
 
-			eeprom: partition@b0000 {
+			partition@b0000 {
 				label = "eeprom";
 				reg = <0xb0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_ubnt_unifi-flexhd.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi-flexhd.dts
@@ -57,7 +57,7 @@
 				read-only;
 			};
 
-			factory: partition@70000 {
+			partition@70000 {
 				label = "factory";
 				reg = <0x70000 0x10000>;
 				read-only;
@@ -77,7 +77,7 @@
 				};
 			};
 
-			eeprom: partition@80000 {
+			partition@80000 {
 				label = "eeprom";
 				reg = <0x80000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_ubnt_unifi-nanohd.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi-nanohd.dts
@@ -32,7 +32,7 @@
 				read-only;
 			};
 
-			factory: partition@70000 {
+			partition@70000 {
 				label = "factory";
 				reg = <0x70000 0x10000>;
 				read-only;
@@ -52,7 +52,7 @@
 				};
 			};
 
-			eeprom: partition@80000 {
+			partition@80000 {
 				label = "eeprom";
 				reg = <0x80000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_ubnt_usw-flex.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_usw-flex.dts
@@ -140,7 +140,7 @@
 				read-only;
 			};
 
-			part_eeprom: partition@80000 {
+			partition@80000 {
 				label = "eeprom";
 				reg = <0x80000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
@@ -32,7 +32,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-06-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-06-16m.dts
@@ -37,7 +37,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -57,7 +57,7 @@
 				};
 			};
 
-			firmware: partition@50000 {
+			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-06-32m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-06-32m.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -58,7 +58,7 @@
 				};
 			};
 
-			firmware: partition@50000 {
+			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x1fb0000>;

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-06-64m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-06-64m.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -58,7 +58,7 @@
 				};
 			};
 
-			firmware: partition@50000 {
+			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3fb0000>;

--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn53xax.dtsi
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn53xax.dtsi
@@ -94,7 +94,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn573hx1.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn573hx1.dts
@@ -87,7 +87,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "factory";
 				reg = <0x50000 0x40000>;
 

--- a/target/linux/ramips/dts/mt7621_wavlink_ws-wn572hp3-4g.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_ws-wn572hp3-4g.dts
@@ -85,7 +85,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dtsi
+++ b/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dtsi
@@ -64,7 +64,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_winstars_ws-wn583a6.dts
+++ b/target/linux/ramips/dts/mt7621_winstars_ws-wn583a6.dts
@@ -87,7 +87,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3-pro.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3-pro.dts
@@ -124,7 +124,7 @@
 			read-only;
 		};
 
-		factory: partition@c0000 {
+		partition@c0000 {
 			label = "factory";
 			reg = <0x0c0000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-common.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-common.dtsi
@@ -60,7 +60,7 @@
 				read-only;
 			};
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "factory";
 				reg = <0x50000 0x10000>;
 				read-only;
@@ -106,7 +106,7 @@
 				read-only;
 			};
 
-			firmware: partition@180000 {
+			partition@180000 {
 				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x180000 0xe80000>;

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr660x.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr660x.dtsi
@@ -85,7 +85,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "Factory";
 			reg = <0x100000 0x80000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_xiaomi_nand_128m.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_nand_128m.dtsi
@@ -46,7 +46,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_xiaoyu_xy-c5.dts
+++ b/target/linux/ramips/dts/mt7621_xiaoyu_xy-c5.dts
@@ -66,7 +66,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
+++ b/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
@@ -114,7 +114,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_youhua_wr1200js.dts
+++ b/target/linux/ramips/dts/mt7621_youhua_wr1200js.dts
@@ -88,7 +88,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_youku_yk-l2.dts
+++ b/target/linux/ramips/dts/mt7621_youku_yk-l2.dts
@@ -92,7 +92,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
@@ -111,7 +111,7 @@
 			 * firmware, so we do not use it either
 			 */
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "Factory";
 				reg = <0x50000 0x40000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_yuncore_fap640.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_fap640.dts
@@ -124,7 +124,7 @@
 			 * firmware, so we do not use it either
 			 */
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "Factory";
 				reg = <0x50000 0x40000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_yuncore_fap690.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_fap690.dts
@@ -93,7 +93,7 @@
 			 * firmware, so we do not use it either
 			 */
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "Factory";
 				reg = <0x50000 0x40000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-we1326.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-we1326.dts
@@ -58,7 +58,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-we3526.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-we3526.dts
@@ -55,7 +55,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -83,7 +83,7 @@
 				};
 			};
 
-			firmware: partition@50000 {
+			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
@@ -110,7 +110,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602.dtsi
@@ -109,7 +109,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1608.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1608.dtsi
@@ -83,7 +83,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg2626.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg2626.dts
@@ -73,7 +73,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
@@ -73,7 +73,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
@@ -125,7 +125,7 @@
 			label = "uboot_env";
 			reg = <0x80000 0x80000>; /* 64 KB */
 		};
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x40000>;
 

--- a/target/linux/ramips/dts/mt7621_zyxel_lte5398-m904.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte5398-m904.dts
@@ -120,7 +120,7 @@
 			reg = <0x80000 0x80000>;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "Factory";
 			reg = <0x100000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_zyxel_nr7101.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_nr7101.dts
@@ -88,7 +88,7 @@
 			reg = <0x80000 0x80000>;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "Factory";
 			reg = <0x100000 0x40000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_zyxel_nwa-ax.dtsi
+++ b/target/linux/ramips/dts/mt7621_zyxel_nwa-ax.dtsi
@@ -36,7 +36,7 @@
 			read-only;
 		};
 
-		factory: partition@100000 {
+		partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x80000>;
 			read-only;
@@ -106,7 +106,7 @@
 			reg = <0x7700000 0x80000>;
 		};
 
-		mrd: partition@7780000 {
+		partition@7780000 {
 			label = "mrd";
 			reg = <0x7780000 0x80000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_zyxel_wap6805.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_wap6805.dts
@@ -76,7 +76,7 @@
 			read-only;
 		};
 
-		factory: partition@200000 {
+		partition@200000 {
 			label = "Factory";
 			reg = <0x200000 0x100000>;
 			read-only;

--- a/target/linux/ramips/dts/mt7621_zyxel_wsm20.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_wsm20.dts
@@ -102,7 +102,7 @@
 			label = "Config";
 		};
 
-		factory: partition@200000 {
+		partition@200000 {
 			reg = <0x200000 0x1c0000>;
 			label = "Factory";
 			read-only;

--- a/target/linux/ramips/dts/mt7628an_alfa-network_awusfree1.dts
+++ b/target/linux/ramips/dts/mt7628an_alfa-network_awusfree1.dts
@@ -115,7 +115,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dtsi
+++ b/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dtsi
@@ -57,7 +57,7 @@
 		spi-max-frequency = <58000000>;
 		m25p,fast-read;
 
-		partitions: partitions {
+		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -74,7 +74,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_asus_rt-n1x.dtsi
+++ b/target/linux/ramips/dts/mt7628an_asus_rt-n1x.dtsi
@@ -79,7 +79,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_buffalo_wcr-1166ds.dts
+++ b/target/linux/ramips/dts/mt7628an_buffalo_wcr-1166ds.dts
@@ -142,7 +142,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_comfast_cf-wr617ac.dts
+++ b/target/linux/ramips/dts/mt7628an_comfast_cf-wr617ac.dts
@@ -72,7 +72,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_comfast_cf-wr758ac.dtsi
+++ b/target/linux/ramips/dts/mt7628an_comfast_cf-wr758ac.dtsi
@@ -84,7 +84,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_cudy_wr1000.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_wr1000.dts
@@ -91,7 +91,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_d-team_pbr-d1.dts
+++ b/target/linux/ramips/dts/mt7628an_d-team_pbr-d1.dts
@@ -115,7 +115,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_dlink_dap-1325-a1.dts
+++ b/target/linux/ramips/dts/mt7628an_dlink_dap-1325-a1.dts
@@ -117,7 +117,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_duzun_dm06.dts
+++ b/target/linux/ramips/dts/mt7628an_duzun_dm06.dts
@@ -116,7 +116,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_elecom_wrc-1167fs.dts
+++ b/target/linux/ramips/dts/mt7628an_elecom_wrc-1167fs.dts
@@ -105,7 +105,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
@@ -121,7 +121,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_glinet_vixmini_microuter.dtsi
+++ b/target/linux/ramips/dts/mt7628an_glinet_vixmini_microuter.dtsi
@@ -75,7 +75,7 @@
 		reg = <0>;
 		spi-max-frequency = <10000000>;
 
-		partitions: partitions {
+		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -92,7 +92,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_hak5_wifi-pineapple-mk7.dts
+++ b/target/linux/ramips/dts/mt7628an_hak5_wifi-pineapple-mk7.dts
@@ -100,7 +100,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_hilink_hlk-7628n.dts
+++ b/target/linux/ramips/dts/mt7628an_hilink_hlk-7628n.dts
@@ -68,7 +68,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_hilink_hlk-7688a.dts
+++ b/target/linux/ramips/dts/mt7628an_hilink_hlk-7688a.dts
@@ -82,7 +82,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5x61a.dtsi
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5x61a.dtsi
@@ -56,7 +56,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
@@ -96,7 +96,7 @@
 				read-only;
 			};
 
-			bdinfo: partition@fe0000 {
+			partition@fe0000 {
 				label = "bdinfo";
 				reg = <0xfe0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_iptime.dtsi
+++ b/target/linux/ramips/dts/mt7628an_iptime.dtsi
@@ -42,7 +42,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			uboot: partition@0 {
+			partition@0 {
 				label = "u-boot";
 				reg = <0x0 0x20000>;
 				read-only;
@@ -64,7 +64,7 @@
 				read-only;
 			};
 
-			factory: partition@30000 {
+			partition@30000 {
 				label = "factory";
 				reg = <0x30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_jotale_js76x8.dtsi
+++ b/target/linux/ramips/dts/mt7628an_jotale_js76x8.dtsi
@@ -80,7 +80,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_keenetic_kn-1613.dts
+++ b/target/linux/ramips/dts/mt7628an_keenetic_kn-1613.dts
@@ -114,7 +114,7 @@
 		reg = <0>;
 		spi-max-frequency = <32000000>;
 
-		partitions: partitions {
+		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -131,7 +131,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "rf-eeprom";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_kroks.dtsi
+++ b/target/linux/ramips/dts/mt7628an_kroks.dtsi
@@ -49,7 +49,7 @@
 		spi-max-frequency = <25000000>;
 		m25p,fast-read;
 
-		partitions: partitions {
+		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -64,7 +64,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 

--- a/target/linux/ramips/dts/mt7628an_linksys_e5400.dts
+++ b/target/linux/ramips/dts/mt7628an_linksys_e5400.dts
@@ -79,7 +79,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_mediatek_linkit-smart-7688.dts
+++ b/target/linux/ramips/dts/mt7628an_mediatek_linkit-smart-7688.dts
@@ -107,7 +107,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_mediatek_mt7628an-eval-board.dts
+++ b/target/linux/ramips/dts/mt7628an_mediatek_mt7628an-eval-board.dts
@@ -37,7 +37,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
@@ -44,7 +44,7 @@
 				reg = <0x0 0x1d800>;
 			};
 
-			factory: partition@1d800 {
+			partition@1d800 {
 				label = "factory_info";
 				reg = <0x1d800 0x800>;
 				read-only;
@@ -64,7 +64,7 @@
 				};
 			};
 
-			art: partition@1e000 {
+			partition@1e000 {
 				label = "art";
 				reg = <0x1e000 0x2000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_minew_g1-c.dts
+++ b/target/linux/ramips/dts/mt7628an_minew_g1-c.dts
@@ -104,7 +104,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_motorola_mwr03.dts
+++ b/target/linux/ramips/dts/mt7628an_motorola_mwr03.dts
@@ -70,7 +70,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_netgear_r6xxx.dtsi
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6xxx.dtsi
@@ -84,7 +84,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x20000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_onion_omega2.dtsi
+++ b/target/linux/ramips/dts/mt7628an_onion_omega2.dtsi
@@ -117,7 +117,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_oraybox_x1.dts
+++ b/target/linux/ramips/dts/mt7628an_oraybox_x1.dts
@@ -91,7 +91,7 @@
 				reg = <0x50000 0xf00000>;
 			};
 
-			bdinfo: partition@fe0000 {
+			partition@fe0000 {
 				label = "bdinfo";
 				reg = <0xfe0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_rakwireless_rak633.dts
+++ b/target/linux/ramips/dts/mt7628an_rakwireless_rak633.dts
@@ -51,7 +51,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_ravpower_rp-wd009.dts
+++ b/target/linux/ramips/dts/mt7628an_ravpower_rp-wd009.dts
@@ -140,7 +140,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_skylab_skw92a.dts
+++ b/target/linux/ramips/dts/mt7628an_skylab_skw92a.dts
@@ -86,7 +86,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_tama_w06.dts
+++ b/target/linux/ramips/dts/mt7628an_tama_w06.dts
@@ -78,7 +78,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_totolink_lr1200.dts
+++ b/target/linux/ramips/dts/mt7628an_totolink_lr1200.dts
@@ -143,7 +143,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_tplink_8m-split-uboot.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_8m-split-uboot.dtsi
@@ -52,7 +52,7 @@
 				read-only;
 			};
 
-			rom: partition@7d0000 {
+			partition@7d0000 {
 				label = "rom";
 				reg = <0x7d0000 0x10000>;
 				read-only;
@@ -75,7 +75,7 @@
 				reg = <0x7e0000 0x10000>;
 			};
 
-			radio: partition@7f0000 {
+			partition@7f0000 {
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_tplink_re200.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_re200.dtsi
@@ -99,7 +99,7 @@
 				reg = <0x20000 0x7a0000>;
 			};
 
-			config: partition@7c0000 {
+			partition@7c0000 {
 				label = "config";
 				reg = <0x7c0000 0x30000>;
 				read-only;
@@ -117,7 +117,7 @@
 				};
 			};
 
-			radio: partition@7f0000 {
+			partition@7f0000 {
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_tplink_re305-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re305-v1.dts
@@ -32,7 +32,7 @@
 				reg = <0x20000 0x5e0000>;
 			};
 
-			config: partition@600000 {
+			partition@600000 {
 				label = "config";
 				reg = <0x600000 0x50000>;
 				read-only;
@@ -55,7 +55,7 @@
 				stock firmware so it is left out as well.
 			*/
 
-			radio: partition@7f0000 {
+			partition@7f0000 {
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_tplink_re305-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re305-v3.dts
@@ -32,7 +32,7 @@
 				reg = <0x20000 0x7a0000>;
 			};
 
-			config: partition@7c0000 {
+			partition@7c0000 {
 				label = "config";
 				reg = <0x7c0000 0x30000>;
 				read-only;
@@ -50,7 +50,7 @@
 				};
 			};
 
-			radio: partition@7f0000 {
+			partition@7f0000 {
 				label = "radio";
 				reg = <0x7f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
@@ -125,7 +125,7 @@
 				read-only;
 			};
 
-			factory: partition@7d0000 {
+			partition@7d0000 {
 				label = "factory";
 				reg = <0x7d0000 0x30000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v5.dts
@@ -72,7 +72,7 @@
 				reg = <0x20000 0x3d0000>;
 			};
 
-			factory: partition@3f0000 {
+			partition@3f0000 {
 				label = "factory";
 				reg = <0x3f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr841n-v14.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr841n-v14.dts
@@ -85,7 +85,7 @@
 				reg = <0x10000 0x3e0000>;
 			};
 
-			factory: partition@3f0000 {
+			partition@3f0000 {
 				label = "factory";
 				reg = <0x3f0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_unielec_u7628-01-16m.dts
+++ b/target/linux/ramips/dts/mt7628an_unielec_u7628-01-16m.dts
@@ -37,7 +37,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_vocore_vocore2.dtsi
+++ b/target/linux/ramips/dts/mt7628an_vocore_vocore2.dtsi
@@ -39,7 +39,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn531a3.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn531a3.dts
@@ -111,7 +111,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn570ha1.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn570ha1.dts
@@ -101,7 +101,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn575a3.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn575a3.dts
@@ -95,7 +95,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn576a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn576a2.dts
@@ -135,7 +135,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn577a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn577a2.dts
@@ -101,7 +101,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn578a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn578a2.dts
@@ -131,7 +131,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_widora_neo.dtsi
+++ b/target/linux/ramips/dts/mt7628an_widora_neo.dtsi
@@ -73,7 +73,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_wiznet_wizfi630s.dts
+++ b/target/linux/ramips/dts/mt7628an_wiznet_wizfi630s.dts
@@ -115,7 +115,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_wrtnode_wrtnode2.dtsi
+++ b/target/linux/ramips/dts/mt7628an_wrtnode_wrtnode2.dtsi
@@ -47,7 +47,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4.dtsi
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4.dtsi
@@ -46,7 +46,7 @@
 				read-only;
 			};
 
-			factory: partition@30000 {
+			partition@30000 {
 				label = "factory";
 				reg = <0x30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-3c.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-3c.dts
@@ -117,7 +117,7 @@
 				read-only;
 			};
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "factory";
 				reg = <0x50000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-nano.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-nano.dts
@@ -109,7 +109,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we1226.dts
+++ b/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we1226.dts
@@ -88,7 +88,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
+++ b/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
@@ -123,7 +123,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "rf-eeprom";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt2880_airlink101_ar670w.dts
+++ b/target/linux/ramips/dts/rt2880_airlink101_ar670w.dts
@@ -31,7 +31,7 @@
 				read-only;
 			};
 
-			factory: partition@30000 {
+			partition@30000 {
 				reg = <0x30000 0x10000>;
 				label = "factory";
 				read-only;

--- a/target/linux/ramips/dts/rt2880_airlink101_ar725w.dts
+++ b/target/linux/ramips/dts/rt2880_airlink101_ar725w.dts
@@ -36,7 +36,7 @@
 				label = "u-boot-env";
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				reg = <0x40000 0x10000>;
 				label = "factory";
 				read-only;

--- a/target/linux/ramips/dts/rt2880_asus_rt-n15.dts
+++ b/target/linux/ramips/dts/rt2880_asus_rt-n15.dts
@@ -40,7 +40,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt2880_belkin_f5d8235-v1.dts
+++ b/target/linux/ramips/dts/rt2880_belkin_f5d8235-v1.dts
@@ -37,7 +37,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt2880_buffalo_wli-tx4-ag300n.dts
+++ b/target/linux/ramips/dts/rt2880_buffalo_wli-tx4-ag300n.dts
@@ -40,7 +40,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt2880_buffalo_wzr-agl300nh.dts
+++ b/target/linux/ramips/dts/rt2880_buffalo_wzr-agl300nh.dts
@@ -39,7 +39,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt2880_dlink_dap-1522-a1.dts
+++ b/target/linux/ramips/dts/rt2880_dlink_dap-1522-a1.dts
@@ -32,7 +32,7 @@
 				read-only;
 			};
 
-			factory: partition@30000 {
+			partition@30000 {
 				label = "factory";
 				reg = <0x30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt2880_ralink_v11st-fe.dts
+++ b/target/linux/ramips/dts/rt2880_ralink_v11st-fe.dts
@@ -37,7 +37,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				reg = <0x00040000 0x00010000>;
 				label = "factory";
 				read-only;

--- a/target/linux/ramips/dts/rt3050_8devices_carambola.dts
+++ b/target/linux/ramips/dts/rt3050_8devices_carambola.dts
@@ -34,7 +34,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_allnet_all0256n.dtsi
+++ b/target/linux/ramips/dts/rt3050_allnet_all0256n.dtsi
@@ -62,7 +62,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_alphanetworks_asl26555-16m.dts
+++ b/target/linux/ramips/dts/rt3050_alphanetworks_asl26555-16m.dts
@@ -54,7 +54,7 @@
 				read-only;
 			};
 
-			devdata: partition@ff0000 {
+			partition@ff0000 {
 				label = "devdata";
 				reg = <0xff0000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_alphanetworks_asl26555-8m.dts
+++ b/target/linux/ramips/dts/rt3050_alphanetworks_asl26555-8m.dts
@@ -24,7 +24,7 @@
 				read-only;
 			};
 
-			devdata: partition@30000 {
+			partition@30000 {
 				label = "uboot-env";
 				reg = <0x30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_arcwireless_freestation5.dts
+++ b/target/linux/ramips/dts/rt3050_arcwireless_freestation5.dts
@@ -34,7 +34,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_asus_rt-g32-b1.dts
+++ b/target/linux/ramips/dts/rt3050_asus_rt-g32-b1.dts
@@ -50,7 +50,7 @@
 				read-only;
 			};
 
-			devconf: partition@40000 {
+			partition@40000 {
 				label = "devconf";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_asus_rt-n10-plus.dts
+++ b/target/linux/ramips/dts/rt3050_asus_rt-n10-plus.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			devconf: partition@40000 {
+			partition@40000 {
 				label = "devconf";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_asus_wl-330n.dts
+++ b/target/linux/ramips/dts/rt3050_asus_wl-330n.dts
@@ -73,7 +73,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_asus_wl-330n3g.dts
+++ b/target/linux/ramips/dts/rt3050_asus_wl-330n3g.dts
@@ -78,7 +78,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_dlink_dcs-930.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dcs-930.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_dlink_dir-300-b1.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dir-300-b1.dts
@@ -32,7 +32,7 @@
 				read-only;
 			};
 
-			devdata: partition@30000 {
+			partition@30000 {
 				label = "devdata";
 				reg = <0x30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_dlink_dir-600-b1.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dir-600-b1.dts
@@ -32,7 +32,7 @@
 				read-only;
 			};
 
-			devdata: partition@30000 {
+			partition@30000 {
 				label = "devdata";
 				reg = <0x30000 0x10000>;
 				read-only;
@@ -52,7 +52,7 @@
 				};
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "devconf";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_dlink_dir-615-d.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dir-615-d.dts
@@ -33,7 +33,7 @@
 				read-only;
 			};
 
-			devdata: partition@30000 {
+			partition@30000 {
 				label = "devdata";
 				reg = <0x30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_dlink_dir-620-a1.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dir-620-a1.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_edimax_3g-6200n.dts
+++ b/target/linux/ramips/dts/rt3050_edimax_3g-6200n.dts
@@ -39,7 +39,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_edimax_3g-6200nl.dts
+++ b/target/linux/ramips/dts/rt3050_edimax_3g-6200nl.dts
@@ -39,7 +39,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_huawei_d105.dts
+++ b/target/linux/ramips/dts/rt3050_huawei_d105.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_jcg_jhr-n805r.dts
+++ b/target/linux/ramips/dts/rt3050_jcg_jhr-n805r.dts
@@ -67,7 +67,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_netcore_nw718.dts
+++ b/target/linux/ramips/dts/rt3050_netcore_nw718.dts
@@ -82,7 +82,7 @@
 				read-only;
 			};
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "factory";
 				reg = <0x50000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_sparklan_wcr-150gn.dts
+++ b/target/linux/ramips/dts/rt3050_sparklan_wcr-150gn.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_teltonika_rut5xx.dts
+++ b/target/linux/ramips/dts/rt3050_teltonika_rut5xx.dts
@@ -71,7 +71,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_tenda_w150m.dts
+++ b/target/linux/ramips/dts/rt3050_tenda_w150m.dts
@@ -37,7 +37,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3050_trendnet_tew-638apb-v2.dts
+++ b/target/linux/ramips/dts/rt3050_trendnet_tew-638apb-v2.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_accton_wr6202.dts
+++ b/target/linux/ramips/dts/rt3052_accton_wr6202.dts
@@ -67,7 +67,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_alfa-network_w502u.dts
+++ b/target/linux/ramips/dts/rt3052_alfa-network_w502u.dts
@@ -42,7 +42,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_argus_atp-52b.dts
+++ b/target/linux/ramips/dts/rt3052_argus_atp-52b.dts
@@ -36,7 +36,7 @@
 				reg = <0x30000 0x10000>;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 

--- a/target/linux/ramips/dts/rt3052_asiarf_awapn2403.dts
+++ b/target/linux/ramips/dts/rt3052_asiarf_awapn2403.dts
@@ -62,7 +62,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_asus_rt-n13u.dts
+++ b/target/linux/ramips/dts/rt3052_asus_rt-n13u.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_aximcom_mr-102n.dts
+++ b/target/linux/ramips/dts/rt3052_aximcom_mr-102n.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_aztech_hw550-3g.dts
+++ b/target/linux/ramips/dts/rt3052_aztech_hw550-3g.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_belkin_f5d8235-v2.dts
+++ b/target/linux/ramips/dts/rt3052_belkin_f5d8235-v2.dts
@@ -25,7 +25,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			uboot: partition@0 {
+			partition@0 {
 				label = "uboot";
 				reg = <0x0 0x50000>;
 				read-only;
@@ -56,7 +56,7 @@
 				reg = <0x7e0000 0x10000>;
 			};
 
-			factory: partition@7f0000 {
+			partition@7f0000 {
 				label = "factory";
 				reg = <0x7f0000 0x10000>;
 			};

--- a/target/linux/ramips/dts/rt3052_buffalo_whr-g300n.dts
+++ b/target/linux/ramips/dts/rt3052_buffalo_whr-g300n.dts
@@ -36,7 +36,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_dlink_dap-1350.dts
+++ b/target/linux/ramips/dts/rt3052_dlink_dap-1350.dts
@@ -36,7 +36,7 @@
 				read-only;
 			};
 
-			devdata: partition@30000 {
+			partition@30000 {
 				label = "devdata";
 				reg = <0x30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_engenius_esr-9753.dts
+++ b/target/linux/ramips/dts/rt3052_engenius_esr-9753.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_fon_fonera-20n.dts
+++ b/target/linux/ramips/dts/rt3052_fon_fonera-20n.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_hauppauge_broadway.dts
+++ b/target/linux/ramips/dts/rt3052_hauppauge_broadway.dts
@@ -30,7 +30,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_huawei_hg255d.dts
+++ b/target/linux/ramips/dts/rt3052_huawei_hg255d.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@60000 {
+			partition@60000 {
 				label = "factory";
 				reg = <0x60000 0x20000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_jcg_jhr-n825r.dts
+++ b/target/linux/ramips/dts/rt3052_jcg_jhr-n825r.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_jcg_jhr-n926r.dts
+++ b/target/linux/ramips/dts/rt3052_jcg_jhr-n926r.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_mofinetwork_mofi3500-3gn.dts
+++ b/target/linux/ramips/dts/rt3052_mofinetwork_mofi3500-3gn.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_netgear_wnce2001.dts
+++ b/target/linux/ramips/dts/rt3052_netgear_wnce2001.dts
@@ -96,7 +96,7 @@
 				read-only;
 			};
 
-			factory: partition@30000 {
+			partition@30000 {
 				label = "factory";
 				reg = <0x30000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_nexaira_bc2.dts
+++ b/target/linux/ramips/dts/rt3052_nexaira_bc2.dts
@@ -31,7 +31,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_omnima_miniembwifi.dts
+++ b/target/linux/ramips/dts/rt3052_omnima_miniembwifi.dts
@@ -65,7 +65,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_petatel_psr-680w.dts
+++ b/target/linux/ramips/dts/rt3052_petatel_psr-680w.dts
@@ -42,7 +42,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_planex_mzk-w300nh2.dts
+++ b/target/linux/ramips/dts/rt3052_planex_mzk-w300nh2.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_planex_mzk-wdpr.dts
+++ b/target/linux/ramips/dts/rt3052_planex_mzk-wdpr.dts
@@ -34,7 +34,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_poray_ip2202.dts
+++ b/target/linux/ramips/dts/rt3052_poray_ip2202.dts
@@ -37,7 +37,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_prolink_pwh2004.dts
+++ b/target/linux/ramips/dts/rt3052_prolink_pwh2004.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_ralink_v22rw-2x2.dts
+++ b/target/linux/ramips/dts/rt3052_ralink_v22rw-2x2.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_sitecom_wl-351.dts
+++ b/target/linux/ramips/dts/rt3052_sitecom_wl-351.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_skyline_sl-r7205.dts
+++ b/target/linux/ramips/dts/rt3052_skyline_sl-r7205.dts
@@ -37,7 +37,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_tenda_3g300m.dts
+++ b/target/linux/ramips/dts/rt3052_tenda_3g300m.dts
@@ -93,7 +93,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_tenda_w306r-v2.dts
+++ b/target/linux/ramips/dts/rt3052_tenda_w306r-v2.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-4m.dts
+++ b/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-4m.dts
@@ -27,7 +27,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-8m.dts
+++ b/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-8m.dts
@@ -27,7 +27,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_unbranded_xdx-rn502j.dts
+++ b/target/linux/ramips/dts/rt3052_unbranded_xdx-rn502j.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_upvel_ur-326n4g.dts
+++ b/target/linux/ramips/dts/rt3052_upvel_ur-326n4g.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_upvel_ur-336un.dts
+++ b/target/linux/ramips/dts/rt3052_upvel_ur-336un.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_zyxel_keenetic.dts
+++ b/target/linux/ramips/dts/rt3052_zyxel_keenetic.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3052_zyxel_nbg-419n.dts
+++ b/target/linux/ramips/dts/rt3052_zyxel_nbg-419n.dts
@@ -38,7 +38,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3352_allnet_all5002.dts
+++ b/target/linux/ramips/dts/rt3352_allnet_all5002.dts
@@ -68,7 +68,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3352_dlink_dir-615-h1.dts
+++ b/target/linux/ramips/dts/rt3352_dlink_dir-615-h1.dts
@@ -94,7 +94,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3352_dlink_dir-620-d1.dts
+++ b/target/linux/ramips/dts/rt3352_dlink_dir-620-d1.dts
@@ -67,7 +67,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3352_zte_mf283plus.dts
+++ b/target/linux/ramips/dts/rt3352_zte_mf283plus.dts
@@ -84,7 +84,7 @@
 				read-only;
 			};
 
-			factory: partition@70000 {
+			partition@70000 {
 				label = "factory";
 				reg = <0x70000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3352_zyxel_nbg-419n-v2.dts
+++ b/target/linux/ramips/dts/rt3352_zyxel_nbg-419n-v2.dts
@@ -86,7 +86,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3662_asus_rt-n56u.dts
+++ b/target/linux/ramips/dts/rt3662_asus_rt-n56u.dts
@@ -37,7 +37,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				reg = <0x00040000 0x00010000>;
 				label = "factory";
 				read-only;

--- a/target/linux/ramips/dts/rt3662_dlink_dir-645.dts
+++ b/target/linux/ramips/dts/rt3662_dlink_dir-645.dts
@@ -95,7 +95,7 @@
 				read-only;
 			};
 
-			factory: partition@34000 {
+			partition@34000 {
 				label = "factory";
 				reg = <0x34000 0x4000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
+++ b/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
@@ -77,7 +77,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x00040000 0x00010000>;
 				read-only;
@@ -97,7 +97,7 @@
 				};
 			};
 
-			devdata: partition@50000 {
+			partition@50000 {
 				label = "devdata";
 				reg = <0x00050000 0x00020000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3662_engenius_esr600h.dts
+++ b/target/linux/ramips/dts/rt3662_engenius_esr600h.dts
@@ -91,7 +91,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3662_loewe_wmdr-143n.dts
+++ b/target/linux/ramips/dts/rt3662_loewe_wmdr-143n.dts
@@ -30,7 +30,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3662_omnima_hpm.dts
+++ b/target/linux/ramips/dts/rt3662_omnima_hpm.dts
@@ -112,7 +112,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				reg = <0x00040000 0x00010000>;
 				label = "factory";
 				read-only;

--- a/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
+++ b/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
@@ -37,7 +37,7 @@
 				read-only;
 			};
 
-			factory: partition@34000 {
+			partition@34000 {
 				label = "factory";
 				reg = <0x34000 0x4000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3883_belkin_f9k110x.dtsi
+++ b/target/linux/ramips/dts/rt3883_belkin_f9k110x.dtsi
@@ -41,7 +41,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3883_sitecom_wlr-6000.dts
+++ b/target/linux/ramips/dts/rt3883_sitecom_wlr-6000.dts
@@ -122,7 +122,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt3883_trendnet_tew-691gr.dts
+++ b/target/linux/ramips/dts/rt3883_trendnet_tew-691gr.dts
@@ -37,7 +37,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				reg = <0x00040000 0x00010000>;
 				label = "factory";
 				read-only;

--- a/target/linux/ramips/dts/rt3883_trendnet_tew-692gr.dts
+++ b/target/linux/ramips/dts/rt3883_trendnet_tew-692gr.dts
@@ -37,7 +37,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				reg = <0x00040000 0x00010000>;
 				label = "factory";
 				read-only;

--- a/target/linux/ramips/dts/rt5350_7links_px-4885.dtsi
+++ b/target/linux/ramips/dts/rt5350_7links_px-4885.dtsi
@@ -66,7 +66,7 @@
 				read-only;
 			};
 
-			devconf: partition@40000 {
+			partition@40000 {
 				label = "devconf";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_airlive_air3gii.dts
+++ b/target/linux/ramips/dts/rt5350_airlive_air3gii.dts
@@ -62,7 +62,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_allnet_all5003.dts
+++ b/target/linux/ramips/dts/rt5350_allnet_all5003.dts
@@ -68,7 +68,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_asiarf_awm002-evb.dtsi
+++ b/target/linux/ramips/dts/rt5350_asiarf_awm002-evb.dtsi
@@ -72,7 +72,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_belkin_f7c027.dts
+++ b/target/linux/ramips/dts/rt5350_belkin_f7c027.dts
@@ -91,7 +91,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_dlink_dcs-930l-b1.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dcs-930l-b1.dts
@@ -74,7 +74,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_dlink_dir-300-b7.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dir-300-b7.dts
@@ -74,7 +74,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_dlink_dir-320-b1.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dir-320-b1.dts
@@ -97,7 +97,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_dlink_dir-610-a1.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dir-610-a1.dts
@@ -68,7 +68,7 @@
 				read-only;
 			};
 
-			devdata: partition@30000 {
+			partition@30000 {
 				label = "devdata";
 				reg = <0x30000 0x10000>;
 				read-only;
@@ -88,7 +88,7 @@
 				};
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_dlink_dwr-512-b.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dwr-512-b.dts
@@ -104,7 +104,7 @@
 				reg = <0x10000 0x7e0000>;
 			};
 
-			config: partition@7f0000 {
+			partition@7f0000 {
 				label = "config";
 				reg = <0x7f0000 0x10000>;
 

--- a/target/linux/ramips/dts/rt5350_easyacc_wizard-8800.dts
+++ b/target/linux/ramips/dts/rt5350_easyacc_wizard-8800.dts
@@ -30,7 +30,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_hame_mpr-a1.dts
+++ b/target/linux/ramips/dts/rt5350_hame_mpr-a1.dts
@@ -84,7 +84,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_hame_mpr-a2.dts
+++ b/target/linux/ramips/dts/rt5350_hame_mpr-a2.dts
@@ -84,7 +84,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_hilink_hlk-rm04.dts
+++ b/target/linux/ramips/dts/rt5350_hilink_hlk-rm04.dts
@@ -75,7 +75,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_hootoo_ht-tm02.dts
+++ b/target/linux/ramips/dts/rt5350_hootoo_ht-tm02.dts
@@ -75,7 +75,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_intenso_memory2move.dts
+++ b/target/linux/ramips/dts/rt5350_intenso_memory2move.dts
@@ -77,7 +77,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_nexx_wt1520.dtsi
+++ b/target/linux/ramips/dts/rt5350_nexx_wt1520.dtsi
@@ -43,7 +43,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_nixcore_x1.dtsi
+++ b/target/linux/ramips/dts/rt5350_nixcore_x1.dtsi
@@ -133,7 +133,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_olimex_rt5350f-olinuxino.dtsi
+++ b/target/linux/ramips/dts/rt5350_olimex_rt5350f-olinuxino.dtsi
@@ -33,7 +33,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_omnima_miniembplug.dts
+++ b/target/linux/ramips/dts/rt5350_omnima_miniembplug.dts
@@ -87,7 +87,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_planex_mzk-dp150n.dts
+++ b/target/linux/ramips/dts/rt5350_planex_mzk-dp150n.dts
@@ -62,7 +62,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_poray_m3.dts
+++ b/target/linux/ramips/dts/rt5350_poray_m3.dts
@@ -69,7 +69,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_poray_m4.dtsi
+++ b/target/linux/ramips/dts/rt5350_poray_m4.dtsi
@@ -61,7 +61,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_poray_x5.dts
+++ b/target/linux/ramips/dts/rt5350_poray_x5.dts
@@ -101,7 +101,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_poray_x8.dts
+++ b/target/linux/ramips/dts/rt5350_poray_x8.dts
@@ -62,7 +62,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_tenda_3g150b.dts
+++ b/target/linux/ramips/dts/rt5350_tenda_3g150b.dts
@@ -78,7 +78,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_trendnet_tew-714tru.dts
+++ b/target/linux/ramips/dts/rt5350_trendnet_tew-714tru.dts
@@ -83,7 +83,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_unbranded_a5-v11.dts
+++ b/target/linux/ramips/dts/rt5350_unbranded_a5-v11.dts
@@ -85,7 +85,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_vocore_vocore.dtsi
+++ b/target/linux/ramips/dts/rt5350_vocore_vocore.dtsi
@@ -183,7 +183,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_wansview_ncs601w.dts
+++ b/target/linux/ramips/dts/rt5350_wansview_ncs601w.dts
@@ -30,7 +30,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_wiznet_wizfi630a.dts
+++ b/target/linux/ramips/dts/rt5350_wiznet_wizfi630a.dts
@@ -99,7 +99,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_zorlik_zl5900v2.dts
+++ b/target/linux/ramips/dts/rt5350_zorlik_zl5900v2.dts
@@ -68,7 +68,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_zyxel_keenetic-4g-b.dts
+++ b/target/linux/ramips/dts/rt5350_zyxel_keenetic-4g-b.dts
@@ -92,7 +92,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_zyxel_keenetic-lite-b.dts
+++ b/target/linux/ramips/dts/rt5350_zyxel_keenetic-lite-b.dts
@@ -75,7 +75,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/rt5350_zyxel_keenetic-start.dts
+++ b/target/linux/ramips/dts/rt5350_zyxel_keenetic-start.dts
@@ -76,7 +76,7 @@
 				read-only;
 			};
 
-			factory: partition@40000 {
+			partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;


### PR DESCRIPTION
These labels are no longer in use.