### PR TITLE
qualcommax: ipq807x: correct PHY mode for AQR

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
@@ -268,6 +268,7 @@
 &dp6_syn {
 	status = "okay";
 	qcom,mactype = <1>;
+	phy-mode = "usxgmii";
 	phy-handle = <&aqr113c>;
 	label = "wan";
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
@@ -405,6 +405,7 @@
 
 &dp6_syn {
 	status = "okay";
+	phy-mode = "usxgmii";
 	phy-handle = <&aqr113c>;
 	label = "10g";
 	nvmem-cells = <&macaddr_lan 0>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-rax120v2.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-rax120v2.dts
@@ -274,6 +274,7 @@
 
 &dp6_syn {
 	status = "okay";
+	phy-mode = "usxgmii";
 	phy-handle = <&aqr111b0>;
 	label = "lan5";
 	nvmem-cells = <&macaddr_dp6_syn>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
@@ -327,6 +327,7 @@
 
 &dp5_syn {
 	status = "okay";
+	phy-mode = "usxgmii";
 	phy-handle = <&aqr113c_1>;
 	label = "wan";
 	nvmem-cells = <&macaddr_appsblenv_ethaddr>;
@@ -335,6 +336,7 @@
 
 &dp6_syn {
 	status = "okay";
+	phy-mode = "usxgmii";
 	phy-handle = <&aqr113c_2>;
 	label = "lan1";
 	nvmem-cells = <&macaddr_appsblenv_ethaddr>;


### PR DESCRIPTION
Interfaces that have AQR-s attached to them are using USXGMII and not just the default SGMII.
This was fine until SSDK added some sanity checking and now on Qnap 301W it would fail with:
[   24.740197] nss-dp 3a001800.dp5 10g-1 (uninitialized): failed to connect to phy device
[   24.740264] nss-dp: probe of 3a001800.dp5 failed with error -14

Since this is not Qnap 301W specific lets fix it subtarget wide by declaring the correct PHY mode for 10G AQR-s.
