### PR TITLE
qualcommax: ipq807x: wax630: correct UNIPHY2 MAC mode

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
@@ -153,7 +153,7 @@
 
 	switch_lan_bmp = <(ESS_PORT4 | ESS_PORT6)>;
 	switch_mac_mode = <MAC_MODE_PSGMII>;
-	switch_mac_mode2 = <MAC_MODE_USXGMII>;
+	switch_mac_mode2 = <MAC_MODE_SGMII_PLUS>;
 
 	qcom,port_phyinfo {
 		port@4 {


### PR DESCRIPTION
UNIPHY2 on the WAX630 is connected to a QCA8081 PHY which is only 2.5G and it does not support using USXGMII at all but rather only SGMII or SGMII+.
