### PR TITLE
mvebu: fix LEDs on Fortinet FortiGate devices and IIJ SA-W2

### DIFF
--- a/target/linux/generic/pending-5.15/880-01-dt-bindings-leds-add-LED_FUNCTION_MOBILE-for-mobile-.patch
+++ b/target/linux/generic/pending-5.15/880-01-dt-bindings-leds-add-LED_FUNCTION_MOBILE-for-mobile-.patch
@@ -1,0 +1,37 @@
+From 38eb5b3370c29515d2ce92adac2d6eba96f276f5 Mon Sep 17 00:00:00 2001
+From: INAGAKI Hiroshi <musashino.open@gmail.com>
+Date: Wed, 20 Mar 2024 15:32:18 +0900
+Subject: [PATCH v2 1/2] dt-bindings: leds: add LED_FUNCTION_MOBILE for mobile
+ network
+
+Add LED_FUNCTION_MOBILE for LEDs that indicate status of mobile network
+connection. This is useful to distinguish those LEDs from LEDs that
+indicates status of wired "wan" connection.
+
+example (on stock fw):
+
+IIJ SA-W2 has "Mobile" LEDs that indicate status (no signal, too low,
+low, good) of mobile network connection via dongle connected to USB
+port.
+
+- no signal: (none, turned off)
+-   too low: green:mobile & red:mobile (amber, blink)
+-       low: green:mobile & red:mobile (amber, turned on)
+-      good: green:mobile (turned on)
+
+Suggested-by: Hauke Mehrtens <hauke@hauke-m.de>
+Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+---
+ include/dt-bindings/leds/common.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/include/dt-bindings/leds/common.h
++++ b/include/dt-bindings/leds/common.h
+@@ -83,6 +83,7 @@
+ #define LED_FUNCTION_INDICATOR "indicator"
+ #define LED_FUNCTION_LAN "lan"
+ #define LED_FUNCTION_MAIL "mail"
++#define LED_FUNCTION_MOBILE "mobile"
+ #define LED_FUNCTION_MTD "mtd"
+ #define LED_FUNCTION_PANIC "panic"
+ #define LED_FUNCTION_PROGRAMMING "programming"

--- a/target/linux/generic/pending-5.15/880-02-dt-bindings-leds-add-LED_FUNCTION_SPEED_-for-link-sp.patch
+++ b/target/linux/generic/pending-5.15/880-02-dt-bindings-leds-add-LED_FUNCTION_SPEED_-for-link-sp.patch
@@ -1,0 +1,37 @@
+From e22afe910afcfb51b6ba6a0ae776939959727f54 Mon Sep 17 00:00:00 2001
+From: INAGAKI Hiroshi <musashino.open@gmail.com>
+Date: Wed, 20 Mar 2024 15:59:06 +0900
+Subject: [PATCH v2 2/2] dt-bindings: leds: add LED_FUNCTION_SPEED_* for link
+ speed on LAN/WAN
+
+Add LED_FUNCTION_SPEED_LAN and LED_FUNCTION_SPEED_WAN for LEDs that
+indicate link speed of ethernet ports on LAN/WAN. This is useful to
+distinguish those LEDs from LEDs that indicate link status (up/down).
+
+example:
+
+Fortinet FortiGate 30E/50E have LEDs that indicate link speed on each
+of the ethernet ports in addition to LEDs that indicate link status
+(up/down).
+
+- 1000 Mbps: green:speed-(lan|wan)-N
+-  100 Mbps: amber:speed-(lan|wan)-N
+-   10 Mbps: (none, turned off)
+
+Reviewed-by: Rob Herring <robh@kernel.org>
+Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+---
+ include/dt-bindings/leds/common.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/include/dt-bindings/leds/common.h
++++ b/include/dt-bindings/leds/common.h
+@@ -89,6 +89,8 @@
+ #define LED_FUNCTION_PROGRAMMING "programming"
+ #define LED_FUNCTION_RX "rx"
+ #define LED_FUNCTION_SD "sd"
++#define LED_FUNCTION_SPEED_LAN "speed-lan"
++#define LED_FUNCTION_SPEED_WAN "speed-wan"
+ #define LED_FUNCTION_STANDBY "standby"
+ #define LED_FUNCTION_TORCH "torch"
+ #define LED_FUNCTION_TX "tx"

--- a/target/linux/generic/pending-6.1/880-01-dt-bindings-leds-add-LED_FUNCTION_MOBILE-for-mobile-.patch
+++ b/target/linux/generic/pending-6.1/880-01-dt-bindings-leds-add-LED_FUNCTION_MOBILE-for-mobile-.patch
@@ -1,0 +1,37 @@
+From 38eb5b3370c29515d2ce92adac2d6eba96f276f5 Mon Sep 17 00:00:00 2001
+From: INAGAKI Hiroshi <musashino.open@gmail.com>
+Date: Wed, 20 Mar 2024 15:32:18 +0900
+Subject: [PATCH v2 1/2] dt-bindings: leds: add LED_FUNCTION_MOBILE for mobile
+ network
+
+Add LED_FUNCTION_MOBILE for LEDs that indicate status of mobile network
+connection. This is useful to distinguish those LEDs from LEDs that
+indicates status of wired "wan" connection.
+
+example (on stock fw):
+
+IIJ SA-W2 has "Mobile" LEDs that indicate status (no signal, too low,
+low, good) of mobile network connection via dongle connected to USB
+port.
+
+- no signal: (none, turned off)
+-   too low: green:mobile & red:mobile (amber, blink)
+-       low: green:mobile & red:mobile (amber, turned on)
+-      good: green:mobile (turned on)
+
+Suggested-by: Hauke Mehrtens <hauke@hauke-m.de>
+Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+---
+ include/dt-bindings/leds/common.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/include/dt-bindings/leds/common.h
++++ b/include/dt-bindings/leds/common.h
+@@ -90,6 +90,7 @@
+ #define LED_FUNCTION_INDICATOR "indicator"
+ #define LED_FUNCTION_LAN "lan"
+ #define LED_FUNCTION_MAIL "mail"
++#define LED_FUNCTION_MOBILE "mobile"
+ #define LED_FUNCTION_MTD "mtd"
+ #define LED_FUNCTION_PANIC "panic"
+ #define LED_FUNCTION_PROGRAMMING "programming"

--- a/target/linux/generic/pending-6.1/880-02-dt-bindings-leds-add-LED_FUNCTION_SPEED_-for-link-sp.patch
+++ b/target/linux/generic/pending-6.1/880-02-dt-bindings-leds-add-LED_FUNCTION_SPEED_-for-link-sp.patch
@@ -1,0 +1,37 @@
+From e22afe910afcfb51b6ba6a0ae776939959727f54 Mon Sep 17 00:00:00 2001
+From: INAGAKI Hiroshi <musashino.open@gmail.com>
+Date: Wed, 20 Mar 2024 15:59:06 +0900
+Subject: [PATCH v2 2/2] dt-bindings: leds: add LED_FUNCTION_SPEED_* for link
+ speed on LAN/WAN
+
+Add LED_FUNCTION_SPEED_LAN and LED_FUNCTION_SPEED_WAN for LEDs that
+indicate link speed of ethernet ports on LAN/WAN. This is useful to
+distinguish those LEDs from LEDs that indicate link status (up/down).
+
+example:
+
+Fortinet FortiGate 30E/50E have LEDs that indicate link speed on each
+of the ethernet ports in addition to LEDs that indicate link status
+(up/down).
+
+- 1000 Mbps: green:speed-(lan|wan)-N
+-  100 Mbps: amber:speed-(lan|wan)-N
+-   10 Mbps: (none, turned off)
+
+Reviewed-by: Rob Herring <robh@kernel.org>
+Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+---
+ include/dt-bindings/leds/common.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/include/dt-bindings/leds/common.h
++++ b/include/dt-bindings/leds/common.h
+@@ -96,6 +96,8 @@
+ #define LED_FUNCTION_PROGRAMMING "programming"
+ #define LED_FUNCTION_RX "rx"
+ #define LED_FUNCTION_SD "sd"
++#define LED_FUNCTION_SPEED_LAN "speed-lan"
++#define LED_FUNCTION_SPEED_WAN "speed-wan"
+ #define LED_FUNCTION_STANDBY "standby"
+ #define LED_FUNCTION_TORCH "torch"
+ #define LED_FUNCTION_TX "tx"

--- a/target/linux/generic/pending-6.6/880-01-dt-bindings-leds-add-LED_FUNCTION_MOBILE-for-mobile-.patch
+++ b/target/linux/generic/pending-6.6/880-01-dt-bindings-leds-add-LED_FUNCTION_MOBILE-for-mobile-.patch
@@ -1,0 +1,37 @@
+From 38eb5b3370c29515d2ce92adac2d6eba96f276f5 Mon Sep 17 00:00:00 2001
+From: INAGAKI Hiroshi <musashino.open@gmail.com>
+Date: Wed, 20 Mar 2024 15:32:18 +0900
+Subject: [PATCH v2 1/2] dt-bindings: leds: add LED_FUNCTION_MOBILE for mobile
+ network
+
+Add LED_FUNCTION_MOBILE for LEDs that indicate status of mobile network
+connection. This is useful to distinguish those LEDs from LEDs that
+indicates status of wired "wan" connection.
+
+example (on stock fw):
+
+IIJ SA-W2 has "Mobile" LEDs that indicate status (no signal, too low,
+low, good) of mobile network connection via dongle connected to USB
+port.
+
+- no signal: (none, turned off)
+-   too low: green:mobile & red:mobile (amber, blink)
+-       low: green:mobile & red:mobile (amber, turned on)
+-      good: green:mobile (turned on)
+
+Suggested-by: Hauke Mehrtens <hauke@hauke-m.de>
+Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+---
+ include/dt-bindings/leds/common.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/include/dt-bindings/leds/common.h
++++ b/include/dt-bindings/leds/common.h
+@@ -90,6 +90,7 @@
+ #define LED_FUNCTION_INDICATOR "indicator"
+ #define LED_FUNCTION_LAN "lan"
+ #define LED_FUNCTION_MAIL "mail"
++#define LED_FUNCTION_MOBILE "mobile"
+ #define LED_FUNCTION_MTD "mtd"
+ #define LED_FUNCTION_PANIC "panic"
+ #define LED_FUNCTION_PROGRAMMING "programming"

--- a/target/linux/generic/pending-6.6/880-02-dt-bindings-leds-add-LED_FUNCTION_SPEED_-for-link-sp.patch
+++ b/target/linux/generic/pending-6.6/880-02-dt-bindings-leds-add-LED_FUNCTION_SPEED_-for-link-sp.patch
@@ -1,0 +1,37 @@
+From e22afe910afcfb51b6ba6a0ae776939959727f54 Mon Sep 17 00:00:00 2001
+From: INAGAKI Hiroshi <musashino.open@gmail.com>
+Date: Wed, 20 Mar 2024 15:59:06 +0900
+Subject: [PATCH v2 2/2] dt-bindings: leds: add LED_FUNCTION_SPEED_* for link
+ speed on LAN/WAN
+
+Add LED_FUNCTION_SPEED_LAN and LED_FUNCTION_SPEED_WAN for LEDs that
+indicate link speed of ethernet ports on LAN/WAN. This is useful to
+distinguish those LEDs from LEDs that indicate link status (up/down).
+
+example:
+
+Fortinet FortiGate 30E/50E have LEDs that indicate link speed on each
+of the ethernet ports in addition to LEDs that indicate link status
+(up/down).
+
+- 1000 Mbps: green:speed-(lan|wan)-N
+-  100 Mbps: amber:speed-(lan|wan)-N
+-   10 Mbps: (none, turned off)
+
+Reviewed-by: Rob Herring <robh@kernel.org>
+Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+---
+ include/dt-bindings/leds/common.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/include/dt-bindings/leds/common.h
++++ b/include/dt-bindings/leds/common.h
+@@ -96,6 +96,8 @@
+ #define LED_FUNCTION_PROGRAMMING "programming"
+ #define LED_FUNCTION_RX "rx"
+ #define LED_FUNCTION_SD "sd"
++#define LED_FUNCTION_SPEED_LAN "speed-lan"
++#define LED_FUNCTION_SPEED_WAN "speed-wan"
+ #define LED_FUNCTION_STANDBY "standby"
+ #define LED_FUNCTION_TORCH "torch"
+ #define LED_FUNCTION_TX "tx"

--- a/target/linux/mvebu/files-6.1/arch/arm/boot/dts/armada-380-iij-sa-w2.dts
+++ b/target/linux/mvebu/files-6.1/arch/arm/boot/dts/armada-380-iij-sa-w2.dts
@@ -68,12 +68,14 @@
 		led-0 {
 			gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
 			linux,default-trigger = "phy0tpt";
 		};
 
 		led-1 {
 			gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_5GHZ;
 		};
 
 		led-2 {
@@ -91,37 +93,45 @@
 		led-4 {
 			gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_MOBILE;
 		};
 
 		led-5 {
 			gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_MOBILE;
 		};
 
 		led-6 {
 			gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
 			linux,default-trigger = "phy1tpt";
 		};
 
 		led-7 {
 			gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_2GHZ;
 		};
 
 		led_power_green: led-8 {
 			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
 		};
 
 		led_power_red: led-9 {
 			gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
 		};
 
 		led-10 {
 			gpios = <&gpio1 22 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			function-enumerator = <1>;
 			linux,default-trigger = "usbport";
 			trigger-sources = <&hub_port2>;
 		};
@@ -129,6 +139,8 @@
 		led-11 {
 			gpios = <&gpio1 23 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			function-enumerator = <0>;
 			linux,default-trigger = "usbport";
 			trigger-sources = <&hub_port1>;
 		};

--- a/target/linux/mvebu/files-6.1/arch/arm/boot/dts/armada-385-fortinet-fg-30e.dts
+++ b/target/linux/mvebu/files-6.1/arch/arm/boot/dts/armada-385-fortinet-fg-30e.dts
@@ -16,12 +16,14 @@
 	led-14 {
 		gpios = <&gpio2 2 GPIO_ACTIVE_HIGH>;
 		color = <LED_COLOR_ID_AMBER>;
+		function = LED_FUNCTION_SPEED_WAN;
 		linux,default-trigger = "mv88e6xxx-1:00:100Mbps";
 	};
 
 	led-15 {
 		gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>;
 		color = <LED_COLOR_ID_GREEN>;
+		function = LED_FUNCTION_SPEED_WAN;
 		linux,default-trigger = "mv88e6xxx-1:00:1Gbps";
 	};
 };

--- a/target/linux/mvebu/files-6.1/arch/arm/boot/dts/armada-385-fortinet-fg-50e.dts
+++ b/target/linux/mvebu/files-6.1/arch/arm/boot/dts/armada-385-fortinet-fg-50e.dts
@@ -16,24 +16,32 @@
 	led-14 {
 		gpios = <&gpio2 0 GPIO_ACTIVE_HIGH>;
 		color = <LED_COLOR_ID_GREEN>;
+		function = LED_FUNCTION_SPEED_WAN;
+		function-enumerator = <1>;
 		linux,default-trigger = "f1072004.mdio-mii:00:1Gbps";
 	};
 
 	led-15 {
 		gpios = <&gpio2 1 GPIO_ACTIVE_HIGH>;
 		color = <LED_COLOR_ID_GREEN>;
+		function = LED_FUNCTION_SPEED_WAN;
+		function-enumerator = <2>;
 		linux,default-trigger = "f1072004.mdio-mii:01:1Gbps";
 	};
 
 	led-16 {
 		gpios = <&gpio2 2 GPIO_ACTIVE_HIGH>;
 		color = <LED_COLOR_ID_AMBER>;
+		function = LED_FUNCTION_SPEED_LAN;
+		function-enumerator = <5>;
 		linux,default-trigger = "mv88e6xxx-1:00:100Mbps";
 	};
 
 	led-17 {
 		gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>;
 		color = <LED_COLOR_ID_GREEN>;
+		function = LED_FUNCTION_SPEED_LAN;
+		function-enumerator = <5>;
 		linux,default-trigger = "mv88e6xxx-1:00:1Gbps";
 	};
 };

--- a/target/linux/mvebu/files-6.1/arch/arm/boot/dts/armada-385-fortinet-fg-x0e.dtsi
+++ b/target/linux/mvebu/files-6.1/arch/arm/boot/dts/armada-385-fortinet-fg-x0e.dtsi
@@ -54,6 +54,7 @@
 		led-1 {
 			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_RED>;
+			function = "ha";
 		};
 
 		led_status_green: led-2 {
@@ -65,6 +66,7 @@
 		led-3 {
 			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = "ha";
 		};
 
 		led-4 {
@@ -82,48 +84,64 @@
 		led-6 {
 			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <4>;
 			linux,default-trigger = "mv88e6xxx-1:01:1Gbps";
 		};
 
 		led-7 {
 			gpios = <&gpio2 5 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <4>;
 			linux,default-trigger = "mv88e6xxx-1:01:100Mbps";
 		};
 
 		led-8 {
 			gpios = <&gpio2 6 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <3>;
 			linux,default-trigger = "mv88e6xxx-1:02:100Mbps";
 		};
 
 		led-9 {
 			gpios = <&gpio2 7 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <3>;
 			linux,default-trigger = "mv88e6xxx-1:02:1Gbps";
 		};
 
 		led-10 {
 			gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <1>;
 			linux,default-trigger = "mv88e6xxx-1:04:1Gbps";
 		};
 
 		led-11 {
 			gpios = <&gpio2 13 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <1>;
 			linux,default-trigger = "mv88e6xxx-1:04:100Mbps";
 		};
 
 		led-12 {
 			gpios = <&gpio2 14 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <2>;
 			linux,default-trigger = "mv88e6xxx-1:03:1Gbps";
 		};
 
 		led-13 {
 			gpios = <&gpio2 15 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <2>;
 			linux,default-trigger = "mv88e6xxx-1:03:100Mbps";
 		};
 	};

--- a/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-380-iij-sa-w2.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-380-iij-sa-w2.dts
@@ -68,12 +68,14 @@
 		led-0 {
 			gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
 			linux,default-trigger = "phy0tpt";
 		};
 
 		led-1 {
 			gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_5GHZ;
 		};
 
 		led-2 {
@@ -91,37 +93,45 @@
 		led-4 {
 			gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_MOBILE;
 		};
 
 		led-5 {
 			gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_MOBILE;
 		};
 
 		led-6 {
 			gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
 			linux,default-trigger = "phy1tpt";
 		};
 
 		led-7 {
 			gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_2GHZ;
 		};
 
 		led_power_green: led-8 {
 			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
 		};
 
 		led_power_red: led-9 {
 			gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
 		};
 
 		led-10 {
 			gpios = <&gpio1 22 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			function-enumerator = <1>;
 			linux,default-trigger = "usbport";
 			trigger-sources = <&hub_port2>;
 		};
@@ -129,6 +139,8 @@
 		led-11 {
 			gpios = <&gpio1 23 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			function-enumerator = <0>;
 			linux,default-trigger = "usbport";
 			trigger-sources = <&hub_port1>;
 		};

--- a/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-fortinet-fg-30e.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-fortinet-fg-30e.dts
@@ -16,12 +16,14 @@
 	led-14 {
 		gpios = <&gpio2 2 GPIO_ACTIVE_HIGH>;
 		color = <LED_COLOR_ID_AMBER>;
+		function = LED_FUNCTION_SPEED_WAN;
 		linux,default-trigger = "mv88e6xxx-1:00:100Mbps";
 	};
 
 	led-15 {
 		gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>;
 		color = <LED_COLOR_ID_GREEN>;
+		function = LED_FUNCTION_SPEED_WAN;
 		linux,default-trigger = "mv88e6xxx-1:00:1Gbps";
 	};
 };

--- a/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-fortinet-fg-50e.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-fortinet-fg-50e.dts
@@ -16,24 +16,32 @@
 	led-14 {
 		gpios = <&gpio2 0 GPIO_ACTIVE_HIGH>;
 		color = <LED_COLOR_ID_GREEN>;
+		function = LED_FUNCTION_SPEED_WAN;
+		function-enumerator = <1>;
 		linux,default-trigger = "f1072004.mdio-mii:00:1Gbps";
 	};
 
 	led-15 {
 		gpios = <&gpio2 1 GPIO_ACTIVE_HIGH>;
 		color = <LED_COLOR_ID_GREEN>;
+		function = LED_FUNCTION_SPEED_WAN;
+		function-enumerator = <2>;
 		linux,default-trigger = "f1072004.mdio-mii:01:1Gbps";
 	};
 
 	led-16 {
 		gpios = <&gpio2 2 GPIO_ACTIVE_HIGH>;
 		color = <LED_COLOR_ID_AMBER>;
+		function = LED_FUNCTION_SPEED_LAN;
+		function-enumerator = <5>;
 		linux,default-trigger = "mv88e6xxx-1:00:100Mbps";
 	};
 
 	led-17 {
 		gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>;
 		color = <LED_COLOR_ID_GREEN>;
+		function = LED_FUNCTION_SPEED_LAN;
+		function-enumerator = <5>;
 		linux,default-trigger = "mv88e6xxx-1:00:1Gbps";
 	};
 };

--- a/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-fortinet-fg-x0e.dtsi
+++ b/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-fortinet-fg-x0e.dtsi
@@ -54,6 +54,7 @@
 		led-1 {
 			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_RED>;
+			function = "ha";
 		};
 
 		led_status_green: led-2 {
@@ -65,6 +66,7 @@
 		led-3 {
 			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = "ha";
 		};
 
 		led-4 {
@@ -82,48 +84,64 @@
 		led-6 {
 			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <4>;
 			linux,default-trigger = "mv88e6xxx-1:01:1Gbps";
 		};
 
 		led-7 {
 			gpios = <&gpio2 5 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <4>;
 			linux,default-trigger = "mv88e6xxx-1:01:100Mbps";
 		};
 
 		led-8 {
 			gpios = <&gpio2 6 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <3>;
 			linux,default-trigger = "mv88e6xxx-1:02:100Mbps";
 		};
 
 		led-9 {
 			gpios = <&gpio2 7 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <3>;
 			linux,default-trigger = "mv88e6xxx-1:02:1Gbps";
 		};
 
 		led-10 {
 			gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <1>;
 			linux,default-trigger = "mv88e6xxx-1:04:1Gbps";
 		};
 
 		led-11 {
 			gpios = <&gpio2 13 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <1>;
 			linux,default-trigger = "mv88e6xxx-1:04:100Mbps";
 		};
 
 		led-12 {
 			gpios = <&gpio2 14 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <2>;
 			linux,default-trigger = "mv88e6xxx-1:03:1Gbps";
 		};
 
 		led-13 {
 			gpios = <&gpio2 15 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_SPEED_LAN;
+			function-enumerator = <2>;
 			linux,default-trigger = "mv88e6xxx-1:03:100Mbps";
 		};
 	};


### PR DESCRIPTION
This patch series fixes LEDs on Fortinet FortiGate 30E/50E and IIJ SA-W2.

related issue: https://github.com/openwrt/openwrt/issues/14628

cc: @Ansuel 