### PR TITLE
ipq-wifi: bump version from 2024-01-06-71f45cff to 2024-02-17-10279ccf

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -6,9 +6,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firmware/qca-wireless.git
-PKG_SOURCE_DATE:=2024-01-06
-PKG_SOURCE_VERSION:=71f45cff8944405b7cc2bf5c19df2bd8fe7f2421
-PKG_MIRROR_HASH:=90c3c1659c54cdb4685d0a71633746c1000230e459801eb8ce12c805a994cc37
+PKG_SOURCE_DATE:=2024-02-17
+PKG_SOURCE_VERSION:=10279ccfdab2f7377d0e1ea60a2db9d7d6c85c92
+PKG_MIRROR_HASH:=cf4ff68617e4be31e43e7bc69dbb6111fb2d789017690d53c41709aeae247ea2
 
 PKG_FLAGS:=nonshared
 
@@ -35,6 +35,7 @@ ALLWIFIBOARDS:= \
 	edgecore_eap102 \
 	edimax_cax1800 \
 	linksys_mx4200 \
+	netgear_lbr20 \
 	netgear_rax120v2 \
 	netgear_wax218 \
 	netgear_wax620 \
@@ -146,6 +147,7 @@ $(eval $(call generate-ipq-wifi-package,dynalink_dl-wrx36,Dynalink DL-WRX36))
 $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))
 $(eval $(call generate-ipq-wifi-package,linksys_mx4200,Linksys MX4200))
+$(eval $(call generate-ipq-wifi-package,netgear_lbr20,Netgear LBR20))
 $(eval $(call generate-ipq-wifi-package,netgear_rax120v2,Netgear RAX120v2))
 $(eval $(call generate-ipq-wifi-package,netgear_wax218,Netgear WAX218))
 $(eval $(call generate-ipq-wifi-package,netgear_wax620,Netgear WAX620))


### PR DESCRIPTION
Support for Netgear LBR20 added in (#14604) requires a newer version of ipq-wifi including (openwrt/firmware_qca-wireless#28)

Signed-off-by: Marcin Gajda <mgajda@o2.pl>