### PR TITLE
bmips: add support for SmartRG SR505n

### DIFF
--- a/target/linux/bmips/bcm63268/base-files/etc/board.d/01_leds
+++ b/target/linux/bmips/bcm63268/base-files/etc/board.d/01_leds
@@ -9,6 +9,9 @@ case "$(board_name)" in
 comtrend,vr-3032u)
 	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1" "usb2-port1"
 	;;
+smartrg,sr505n)
+	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1"
+	;;
 sercomm,h500-s-lowi |\
 sercomm,h500-s-vfes)
 	ucidef_set_led_netdev "wan" "WAN" "green:internet" "wan"

--- a/target/linux/bmips/bcm63268/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm63268/base-files/etc/board.d/02_network
@@ -5,7 +5,8 @@
 board_config_update
 
 case "$(board_name)" in
-comtrend,vr-3032u)
+comtrend,vr-3032u |\
+smartrg,sr505n)
 	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 	;;

--- a/target/linux/bmips/dts/bcm63168-smartrg-sr505n.dts
+++ b/target/linux/bmips/dts/bcm63168-smartrg-sr505n.dts
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm63268.dtsi"
+
+/ {
+	model = "SmartRG SR505n";
+	compatible = "smartrg,sr505n", "brcm,bcm63168", "brcm,bcm63268";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+		
+		reset {
+			label = "reset";
+			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		wlan {
+			label = "wlan";
+			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
+   			linux,code = <KEY_WLAN>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cfe_6a0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&hsspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <16666667>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "cfe";
+				reg = <0x000000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_cfe_6a0: macaddr@6a0 {
+						reg = <0x6a0 0x6>;
+					};
+				};
+			};
+
+			partition@10000 {
+				compatible = "brcm,bcm963xx-imagetag";
+				label = "firmware";
+				reg = <0x010000 0xfd0000>;
+			};
+
+			partition@fe0000 {
+				label = "nvram";
+				reg = <0xfe0000 0x020000>;
+			};
+		};
+	};
+};
+
+&leds {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_leds>;
+
+	wps_green@1 {
+		reg = <1>;
+		active-low;
+		function = LED_FUNCTION_WPS;
+		color = <LED_COLOR_ID_GREEN>;
+	};
+
+	inet_green@8 {
+		reg = <8>;
+		active-low;
+		label = "green:inet";
+	};
+
+	lan2_green@9 {
+		/* EPHY1 Act */
+		reg = <9>;
+		brcm,hardware-controlled;
+	};
+
+	lan3_green@10 {
+		/* EPHY2 Act */
+		reg = <10>;
+		brcm,hardware-controlled;
+	};
+
+	lan4_green@11 {
+		/* EPHY3 Act */
+		reg = <11>;
+		brcm,hardware-controlled;
+	};
+
+	lan1_green@12 {
+		/* GPHY0 Act */
+		reg = <12>;
+		brcm,hardware-controlled;
+	};
+
+	dsl_green@14 {
+		reg = <14>;
+		active-low;
+		label = "green:dsl";
+	};
+
+	inet_red@15 {
+		reg = <15>;
+		active-low;
+		label = "red:inet";
+	};
+
+	usb_green@16 {
+		reg = <16>;
+		active-low;
+		function = LED_FUNCTION_USB;
+		color = <LED_COLOR_ID_GREEN>;
+	};
+
+	led_power_green: power_green@20 {
+		reg = <20>;
+		active-low;
+		function = LED_FUNCTION_POWER;
+		color = <LED_COLOR_ID_GREEN>;
+	};
+
+	led_power_red: power_red@21 {
+		reg = <21>;
+		active-low;
+		function = LED_FUNCTION_POWER;
+		color = <LED_COLOR_ID_RED>;
+		panic-indicator;
+	};
+};
+
+&pinctrl {
+	pinctrl_leds: leds {
+		function = "led";
+		pins = "gpio1", "gpio8", 
+			"gpio9", "gpio10",
+			"gpio11", "gpio12",
+			"gpio14", "gpio15",
+			"gpio16", "gpio20",
+			"gpio21";
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			reg = <0>;
+			label = "lan2";
+
+			phy-handle = <&phy1>;
+			phy-mode = "mii";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan3";
+
+			phy-handle = <&phy2>;
+			phy-mode = "mii";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan4";
+
+			phy-handle = <&phy3>;
+			phy-mode = "mii";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan1";
+
+			phy-handle = <&phy4>;
+			phy-mode = "gmii";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};

--- a/target/linux/bmips/image/bcm63268.mk
+++ b/target/linux/bmips/image/bcm63268.mk
@@ -100,3 +100,17 @@ define Device/sercomm_shg2500
   SERCOMM_SWVER := 3207
 endef
 TARGET_DEVICES += sercomm_shg2500
+
+define Device/smartrg_sr505n
+  $(Device/bcm63xx-cfe)
+  DEVICE_VENDOR := SmartRG
+  DEVICE_MODEL := SR505n
+  DEVICE_LOADADDR := $(KERNEL_LOADADDR)
+  CHIP_ID := 63268
+  SOC := bcm63168
+  CFE_BOARD_ID := 963168MBV_17AZZ
+  FLASH_MB := 16
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    kmod-leds-bcm6328
+endef
+TARGET_DEVICES += smartrg_sr505n


### PR DESCRIPTION
Specifications:
- SoC: Broadcom BCM63168 dual 400MHz MIPS
- Flash: 16MB SPI NOR W25Q128WFG
- RAM: 128MB DDR3 W631GG6KB-15
- Ethernet: 1x 1000M, 3x 100M
- Wifi: BCM435F
- 1x USB 2.0 port
- 3x Button
- 12x LED

Flashing via serial
- Connect to the 3.3V TTL UART on the board (J6 pinout Vcc Rx Tx Gnd) at 115200-8-N-1
- Press any key in the serial console when powering up the board to enter the CFE prompt
- Configure an interface on your workstation to static IP 192.168.1.100 and connect it to the board
- Start a TFTP server with the firmware image
- On the CFE prompt, enter the command "f 192.168.1.100:openwrt-bmips-bcm63268-smartrg_sr505n-squashfs-cfe.bin"