### PR TITLE
wifi-scripts: Support HE Iftypes with multiple entries

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -432,9 +432,9 @@ mac80211_hostapd_setup_base() {
 			he_bss_color:128 \
 			he_bss_color_enabled:1
 
-		he_phy_cap=$(iw phy "$phy" info | sed -n '/HE Iftypes: AP/,$p' | awk -F "[()]" '/HE PHY Capabilities/ { print $2 }' | head -1)
+		he_phy_cap=$(iw phy "$phy" info | sed -n '/HE Iftypes: .*AP/,$p' | awk -F "[()]" '/HE PHY Capabilities/ { print $2 }' | head -1)
 		he_phy_cap=${he_phy_cap:2}
-		he_mac_cap=$(iw phy "$phy" info | sed -n '/HE Iftypes: AP/,$p' | awk -F "[()]" '/HE MAC Capabilities/ { print $2 }' | head -1)
+		he_mac_cap=$(iw phy "$phy" info | sed -n '/HE Iftypes: .*AP/,$p' | awk -F "[()]" '/HE MAC Capabilities/ { print $2 }' | head -1)
 		he_mac_cap=${he_mac_cap:2}
 
 		append base_cfg "ieee80211ax=1" "$N"


### PR DESCRIPTION
With mac80211_hwsim I have seen such entries in OpenWrt 22.03:
    HE Iftypes: managed, AP
The mac80211.sh script did not detect the entry and failed. Allow arbitrary other entries before to fix this problem.