### PR TITLE
mediatek: filogic: convert ASUS device to use NVMEM-on-UBI

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-asus-rt-ax59u.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-rt-ax59u.dts
@@ -14,6 +14,7 @@
 
 	aliases {
 		serial0 = &uart0;
+		label-mac-device = &gmac0;
 		led-boot = &led_status_green;
 		led-failsafe = &led_status_red;
 		led-running = &led_status_green;
@@ -22,7 +23,7 @@
 
 	chosen {
 		stdout-path = "serial0:115200n8";
-		bootargs-override = "ubi.mtd=UBI_DEV";
+		bootargs-override = "";
 	};
 
 	memory {
@@ -89,6 +90,8 @@
 		/* LAN */
 		compatible = "mediatek,eth-mac";
 		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4>;
+		nvmem-cell-names = "mac-address";
 		phy-mode = "2500base-x";
 
 		fixed-link {
@@ -206,31 +209,72 @@
 	pinctrl-0 = <&spi_flash_pins>;
 	status = "okay";
 
-	spi_nand: spi_nand@0 {
+	spi_nand: flash@0 {
 		compatible = "spi-nand";
+		reg = <0>;
 		#address-cells = <1>;
 		#size-cells = <1>;
-		reg = <0>;
 
 		spi-max-frequency = <20000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 
-		partitions: partitions {
+		/*
+		 * ASUS bootloader tries to replace the partitions defined in
+		 * Device Tree and by that also deletes all additional properties
+		 * needed for UBI and NVMEM-on-UBI.
+		 * Prevent this from happening by tricking the loader to delete and
+		 * replace a bait node instead.
+		 */
+		partitions: dummy {
+			compatible = "u-boot-dummy-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x0>;
+				label = "remove_me";
+			};
+		};
+
+		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
 
 			partition@0 {
-				label = "u-boot";
 				reg = <0x0 0x400000>;
+				label = "u-boot";
 				read-only;
 			};
 
 			partition@400000 {
+				compatible = "linux,ubi";
+				reg = <0x400000 0xfc00000>;
 				label = "UBI_DEV";
-				reg = <0x400000 0x7c00000>;
+
+				volumes {
+					ubi_factory: ubi-volume-factory {
+						volname = "Factory";
+					};
+				};
 			};
+		};
+	};
+};
+
+&ubi_factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		eeprom_factory_0: eeprom@0 {
+			reg = <0x0 0x1000>;
+		};
+
+		macaddr_factory_4: macaddr@4 {
+			reg = <0x4 0x6>;
 		};
 	};
 };
@@ -240,10 +284,12 @@
 };
 
 &wifi {
-	status = "okay";
-	pinctrl-names = "default", "dbdc";
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 	pinctrl-0 = <&wf_2g_5g_pins>;
 	pinctrl-1 = <&wf_dbdc_pins>;
+	pinctrl-names = "default", "dbdc";
+	status = "okay";
 };
 
 &trng {

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
@@ -13,6 +13,7 @@
 
 	aliases {
 		serial0 = &uart0;
+		label-mac-device = &gmac0;
 		led-boot = &led_system;
 		led-failsafe = &led_system;
 		led-running = &led_system;
@@ -21,7 +22,7 @@
 
 	chosen {
 		stdout-path = "serial0:115200n8";
-		bootargs-override = "ubi.mtd=UBI_DEV";
+		bootargs-override = "";
 	};
 
 	memory {
@@ -101,6 +102,8 @@
 		/* LAN */
 		compatible = "mediatek,eth-mac";
 		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4>;
+		nvmem-cell-names = "mac-address";
 		phy-mode = "2500base-x";
 
 		fixed-link {
@@ -215,21 +218,62 @@
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 
-		partitions: partitions {
+		/*
+		 * ASUS bootloader tries to replace the partitions defined in
+		 * Device Tree and by that also deletes all additional properties
+		 * needed for UBI and NVMEM-on-UBI.
+		 * Prevent this from happening by tricking the loader to delete and
+		 * replace a bait node instead.
+		 */
+		partitions: dummy {
+			compatible = "u-boot-dummy-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x0>;
+				label = "remove_me";
+			};
+		};
+
+		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
 
 			partition@0 {
-				label = "bootloader";
 				reg = <0x0 0x400000>;
+				label = "bootloader";
 				read-only;
 			};
 
 			partition@400000 {
-				label = "UBI_DEV";
+				compatible = "linux,ubi";
 				reg = <0x400000 0xfc00000>;
+				label = "UBI_DEV";
+
+				volumes {
+					ubi_factory: ubi-volume-factory {
+						volname = "Factory";
+					};
+				};
 			};
+		};
+	};
+};
+
+&ubi_factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		eeprom_factory_0: eeprom@0 {
+			reg = <0x0 0x1000>;
+		};
+
+		macaddr_factory_4: macaddr@4 {
+			reg = <0x4 0x6>;
 		};
 	};
 };
@@ -340,10 +384,12 @@
 };
 
 &wifi {
-	status = "okay";
-	pinctrl-names = "default", "dbdc";
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 	pinctrl-0 = <&wf_2g_5g_pins>;
 	pinctrl-1 = <&wf_dbdc_pins>;
+	pinctrl-names = "default", "dbdc";
+	status = "okay";
 };
 
 &trng {

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
@@ -13,6 +13,7 @@
 
 	aliases {
 		serial0 = &uart0;
+		label-mac-device = &gmac0;
 		led-boot = &led_system;
 		led-failsafe = &led_system;
 		led-running = &led_system;
@@ -21,7 +22,7 @@
 
 	chosen {
 		stdout-path = "serial0:115200n8";
-		bootargs-override = "ubi.mtd=UBI_DEV";
+		bootargs-override = "";
 	};
 
 	memory {
@@ -101,6 +102,8 @@
 		/* LAN */
 		compatible = "mediatek,eth-mac";
 		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4>;
+		nvmem-cell-names = "mac-address";
 		phy-mode = "2500base-x";
 
 		fixed-link {
@@ -219,29 +222,70 @@
 
 	spi_nand_flash: flash@0 {
 		compatible = "spi-nand";
+		reg = <0>;
 		#address-cells = <1>;
 		#size-cells = <1>;
-		reg = <0>;
 
 		spi-max-frequency = <20000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 
-		partitions: partitions {
+		/*
+		 * ASUS bootloader tries to replace the partitions defined in
+		 * Device Tree and by that also deletes all additional properties
+		 * needed for UBI and NVMEM-on-UBI.
+		 * Prevent this from happening by tricking the loader to delete and
+		 * replace a bait node instead.
+		 */
+		partitions: dummy {
+			compatible = "u-boot-dummy-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x0>;
+				label = "remove_me";
+			};
+		};
+
+		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
 
 			partition@0 {
-				label = "bootloader";
 				reg = <0x0 0x400000>;
+				label = "bootloader";
 				read-only;
 			};
 
 			partition@400000 {
-				label = "UBI_DEV";
+				compatible = "linux,ubi";
 				reg = <0x400000 0xfc00000>;
+				label = "UBI_DEV";
+
+				volumes {
+					ubi_factory: ubi-volume-factory {
+						volname = "Factory";
+					};
+				};
 			};
+		};
+	};
+};
+
+&ubi_factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		eeprom_factory_0: eeprom@0 {
+			reg = <0x0 0x1000>;
+		};
+
+		macaddr_factory_4: macaddr@4 {
+			reg = <0x4 0x6>;
 		};
 	};
 };
@@ -360,10 +404,12 @@
 };
 
 &wifi {
-	status = "okay";
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 	pinctrl-names = "default", "dbdc";
 	pinctrl-0 = <&wf_2g_5g_pins>;
 	pinctrl-1 = <&wf_dbdc_pins>;
+	status = "okay";
 };
 
 &trng {

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -109,12 +109,6 @@ mediatek_setup_macs()
 	local label_mac=""
 
 	case $board in
-	asus,tuf-ax6000)
-		CI_UBIPART="UBI_DEV"
-		addr=$(mtd_get_mac_binary_ubi "Factory" 0x4)
-		wan_mac="${addr}"
-		lan_mac="${addr}"
-		;;
 	bananapi,bpi-r3)
 		wan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -109,7 +109,6 @@ mediatek_setup_macs()
 	local label_mac=""
 
 	case $board in
-	asus,rt-ax59u|\
 	asus,tuf-ax4200|\
 	asus,tuf-ax6000)
 		CI_UBIPART="UBI_DEV"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -109,7 +109,6 @@ mediatek_setup_macs()
 	local label_mac=""
 
 	case $board in
-	asus,tuf-ax4200|\
 	asus,tuf-ax6000)
 		CI_UBIPART="UBI_DEV"
 		addr=$(mtd_get_mac_binary_ubi "Factory" 0x4)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -57,14 +57,6 @@ case "$FIRMWARE" in
 		;;
 	esac
 	;;
-"mediatek/mt7986_eeprom_mt7976_dbdc.bin")
-	case "$board" in
-	asus,tuf-ax4200)
-		CI_UBIPART="UBI_DEV"
-		caldata_extract_ubi "Factory" 0x0 0x1000
-		;;
-	esac
-	;;
 "mediatek/mt7986_eeprom_mt7976_dual.bin")
 	case "$board" in
 	asus,tuf-ax6000)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -59,10 +59,6 @@ case "$FIRMWARE" in
 	;;
 "mediatek/mt7986_eeprom_mt7976_dual.bin")
 	case "$board" in
-	asus,tuf-ax6000)
-		CI_UBIPART="UBI_DEV"
-		caldata_extract_ubi "Factory" 0x0 0x1000
-		;;
 	jdcloud,re-cp-03)
 		caldata_extract_mmc "factory" 0x0 0x1000
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -59,7 +59,6 @@ case "$FIRMWARE" in
 	;;
 "mediatek/mt7986_eeprom_mt7976_dbdc.bin")
 	case "$board" in
-	asus,rt-ax59u|\
 	asus,tuf-ax4200)
 		CI_UBIPART="UBI_DEV"
 		caldata_extract_ubi "Factory" 0x0 0x1000


### PR DESCRIPTION
Some recent ASUS devices started storing their factory data inside a UBI volume. Instead of extracting WiFi EEPROM data and MAC addresses in userspace, use the now available new way to reference the NVMEM bits in device tree.

Lacking the hardware no runtime testing has been done on my end, hence I rely on users to give feedback if the works as intended.

User tested and confirmed MAC addresses and WiFi EEPROM:
 - [x] ASUS RT-AX59U
 - [x] ASUS TUF-AX4200
 - [ ] ASUS TUF-AX6000
