### PR TITLE
generic: 6.1: add missing symbol for EN8811H PHY driver

### DIFF
--- a/target/linux/generic/config-6.1
+++ b/target/linux/generic/config-6.1
@@ -155,6 +155,7 @@ CONFIG_AF_UNIX_OOB=y
 # CONFIG_AHCI_QORIQ is not set
 # CONFIG_AHCI_XGENE is not set
 CONFIG_AIO=y
+# CONFIG_AIR_EN8811H_PHY is not set
 # CONFIG_AIRO is not set
 # CONFIG_AIRO_CS is not set
 # CONFIG_AIX_PARTITION is not set


### PR DESCRIPTION
Disable Airoha EN8811H PHY driver by default to avoid individual targets having to disable it.
