### PR TITLE
Qualcommax: ipq807x: wax620 and wax630: update DTS with power LED color and function

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax620.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax620.dts
@@ -7,6 +7,7 @@
 #include "ipq8074-ess.dtsi"
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
 
 / {
 	model = "Netgear WAX620";
@@ -63,46 +64,49 @@
 		compatible = "gpio-leds";
 
 		led_system_red: system-red {
-			label = "system:red";
+			function = LED_FUNCTION_FAULT;
+			color = <LED_COLOR_ID_RED>;
 			gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_system_green: system-green {
-			label = "system:green";
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&tlmm 55 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_system_blue: system-blue {
-			label = "system:blue";
+			function = LED_FUNCTION_BOOT;
+			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&tlmm 56 GPIO_ACTIVE_HIGH>;
 		};
 
-		led_lan_g {
+		led-lan-green {
 			label = "lan:green";
 			gpios = <&led_gpio 0 GPIO_ACTIVE_HIGH>;
 		};
 
-		led_lan_o {
+		led-lan-orange {
 			label = "lan:orange";
 			gpios = <&led_gpio 1 GPIO_ACTIVE_HIGH>;
 		};
 
-		led_2g_b {
+		led-2g-blue {
 			label = "wlan2g:blue";
 			gpios = <&led_gpio 2 GPIO_ACTIVE_HIGH>;
 		};
 
-		led_2g_g {
+		led-2g-green {
 			label = "wlan2g:green";
 			gpios = <&led_gpio 3 GPIO_ACTIVE_HIGH>;
 		};
 
-		led_5g_b {
+		led-5g-blue {
 			label = "wlan5g:blue";
 			gpios = <&led_gpio 4 GPIO_ACTIVE_HIGH>;
 		};
 
-		led_5g_g {
+		led-5g-green {
 			label = "wlan5g:green";
 			gpios = <&led_gpio 5 GPIO_ACTIVE_HIGH>;
 		};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
@@ -64,78 +64,81 @@
 		compatible = "gpio-leds";
 
 		led_system_red: system-red {
-			label = "system:red";
+			function = LED_FUNCTION_FAULT;
+			color = <LED_COLOR_ID_RED>;
 			gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
 		led_system_green: system-green {
-			label = "system:green";
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
 		led_system_blue: system-blue {
-			label = "system:blue";
+			function = LED_FUNCTION_BOOT;
+			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&tlmm 21 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
-		lan1-green {
+		led-lan1-green {
 			label = "lan1:green";
 			gpios = <&tlmm 26 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
-		lan1-orange {
+		led-lan1-orange {
 			label = "lan1:orange";
 			gpios = <&tlmm 27 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
-		lan2-green {
+		led-lan2-green {
 			label = "lan2:green";
 			gpios = <&tlmm 57 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
-		lan2-orange {
+		led-lan2-orange {
 			label = "lan2:orange";
 			gpios = <&tlmm 60 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
-		2g-blue {
+		led-2g-blue {
 			label = "wlan2g:blue";
 			gpios = <&tlmm 29 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
-		2g-green {
+		led-2g-green {
 			label = "wlan2g:green";
 			gpios = <&tlmm 30 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
-		5g-low-blue {
+		led-5g-low-blue {
 			label = "wlan5g_low:blue";
 			gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
-		5g-low-green {
+		led-5g-low-green {
 			label = "wlan5g_low:green";
 			gpios = <&tlmm 34 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
-		5g-high-blue {
+		led-5g-high-blue {
 			label = "wlan5g_high:blue";
 			gpios = <&tlmm 31 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
-		5g-high-green {
+		led-5g-high-green {
 			label = "wlan5g_high:green";
 			gpios = <&tlmm 32 GPIO_ACTIVE_LOW>;
 			default-state = "off";


### PR DESCRIPTION
Add Power LED color and function and renamed &dp6 phy-handle for WAX620 so it's similar to WAX630.
```
+ [WAX620 and WAX630]: Add Power LED color and function.
+ [WAX620]: Renamed &dp6 phy-handle from 
  `phy-handle = <&qca8081_28>;` to `phy-handle = <&qca8081>;` similar to WAX630.
```
Signed-off-by: Kristian Skramstad <kristian+github@83.no>