### PR TITLE
mediatek: filogic: Cudy WR3000 v1 wps button fix

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
@@ -36,7 +36,7 @@
 		wps {
 			label = "wps";
 			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&pio 0 GPIO_ACTIVE_HIGH>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
 		};
 	};
 


### PR DESCRIPTION
WPS button activation method is wrong .  It should be active low

Using button testing method
https://openwrt.org/docs/guide-user/hardware/hardware.button
tested OpenWrt version
Linux version 5.15.137 (builder@buildhost) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 12.3.0 r23630-842932a63d) 12.3.0, GNU ld (GNU Binutils) 2.40.0) #0 SMP Tue Nov 14 13:38:11 2023


```
Thu Feb 22 16:28:26 2024 user.notice root: the button was wps and the action was released
Thu Feb 22 16:28:26 2024 user.notice root: the button was wps and the action was pressed
```

It should be opposite.  