### PR TITLE
ath79: nand: add SUPPORTED_DEVICES for Meraki MR18

### DIFF
--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -312,6 +312,7 @@ define Device/meraki_mr18
 # KERNEL_INITRAMFS := $$(KERNEL)
   KERNEL_INITRAMFS :=
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  SUPPORTED_DEVICES += mr18
 endef
 TARGET_DEVICES += meraki_mr18
 


### PR DESCRIPTION
This adds the board name from ar71xx to support upgrade without -F for the Meraki MR18.

See this issue on forum: https://forum.openwrt.org/t/meraki-mr18-device-not-supported-by-this-image/188857