### PR TITLE
ramips: fix compatibility with nvmem-layout for routers based on TP-Link Archer

### DIFF
--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c20-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c20-v1.dts
@@ -81,11 +81,11 @@
 	pinctrl-0 = <&pa_pins>;
 	pinctrl-1 = <&pa_gpio_pins>;
 
-	nvmem-cells = <&macaddr_rom_f100 (-2)>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_rom_f100 (-2)>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &wifi {
-	nvmem-cells = <&macaddr_rom_f100 (-1)>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_radio_8000>, <&macaddr_rom_f100 (-1)>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c20i.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c20i.dts
@@ -60,11 +60,11 @@
 };
 
 &wmac {
-	nvmem-cells = <&macaddr_rom_f100 0>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_rom_f100 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &wifi {
-	nvmem-cells = <&macaddr_rom_f100 (-1)>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_radio_8000>, <&macaddr_rom_f100 (-1)>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c50-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c50-v1.dts
@@ -81,11 +81,11 @@
 	pinctrl-0 = <&pa_pins>;
 	pinctrl-1 = <&pa_gpio_pins>;
 
-	nvmem-cells = <&macaddr_rom_f100 (-2)>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_rom_f100 (-2)>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &wifi {
-	nvmem-cells = <&macaddr_rom_f100 (-1)>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_radio_8000>, <&macaddr_rom_f100 (-1)>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };


### PR DESCRIPTION
Added missing nvmem-cells located in the loaded file mt7620a_tplink_archer.dtsi
