### PR TITLE
ipq40xx: Netgear LBR20 fix for proper img builds

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -849,6 +849,7 @@ define Device/netgear_lbr20
 	KERNEL_SIZE := 7340032
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
+	UBINIZE_OPTS := -E 5
 	IMAGE/factory.img := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | \
 		append-uImage-fakehdr filesystem | pad-to $$$$(KERNEL_SIZE) | \
 		append-ubi | netgear-dni


### PR DESCRIPTION
Without UBINIZE_OPTS it is almost sure to have error:
"ubi0 error: ubi_attach_mtd_dev: failed to atach mtd23, error -22"

Adding line solve this problem.

Signed-off-by: Marcin Gajda <mgajda@o2.pl>