### PR TITLE
ramips: TP-Link Archer C5 v4: license and file formatting fixes

### DIFF
--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c5-v4.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c5-v4.dts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
 #include <dt-bindings/leds/common.h>
 
 #include "mt7620a_tplink_archer.dtsi"

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1227,7 +1227,7 @@ define Device/tplink_archer-c5-v4
   DEVICE_MODEL := Archer C5
   DEVICE_VARIANT := v4
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
-  kmod-mt76x2 kmod-switch-rtl8367b
+	kmod-mt76x2 kmod-switch-rtl8367b
 endef
 TARGET_DEVICES += tplink_archer-c5-v4
 


### PR DESCRIPTION
mt7620a_tplink_archer-c5-v4.dts - added missing SPDX-License-Identifier

mt7620.mk: added missing tabulator