### PR TITLE
rockchip: fix device packages for nanopi r4s enterprise edition

### DIFF
--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -61,7 +61,7 @@ define Device/friendlyarm_nanopi-r4s-enterprise
   DEVICE_VARIANT := 4GB LPDDR4
   SOC := rk3399
   UBOOT_DEVICE_NAME := nanopi-r4s-rk3399
-  DEVICE_PACKAGES := kmod-r8168
+  DEVICE_PACKAGES := kmod-r8169
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r4s-enterprise
 


### PR DESCRIPTION
```
In official OpenWrt we use kmod-r8169 driver provided by upstream kernel instead of kmod-r8168 driver from Realtek.

Fixes: afca1236f318 ("rockchip: add NanoPi R4S Enterprise Edition build")
```