### PR TITLE
uboot-mediatek: correct board name for BananaPi BPi-R3 Mini

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -417,7 +417,7 @@ define U-Boot/mt7986_bananapi_bpi-r3-nor
 endef
 
 define U-Boot/mt7986_bananapi_bpi-r3-mini-emmc
-  NAME:=BananaPi BPi-R3
+  NAME:=BananaPi BPi-R3 Mini
   BUILD_SUBTARGET:=filogic
   BUILD_DEVICES:=bananapi_bpi-r3-mini
   UBOOT_CONFIG:=mt7986a_bpi-r3-mini-emmc
@@ -429,7 +429,7 @@ define U-Boot/mt7986_bananapi_bpi-r3-mini-emmc
 endef
 
 define U-Boot/mt7986_bananapi_bpi-r3-mini-snand
-  NAME:=BananaPi BPi-R3
+  NAME:=BananaPi BPi-R3 Mini
   BUILD_SUBTARGET:=filogic
   BUILD_DEVICES:=bananapi_bpi-r3-mini
   UBOOT_CONFIG:=mt7986a_bpi-r3-mini-snand


### PR DESCRIPTION
It should be "BananaPi BPi-R3 Mini" instead of just "BananaPi BPi-R3".

Fixes: bc25519f98cd ("uboot-mediatek: add builds for BananaPi BPi-R3 mini")
