### PR TITLE
ramips: add support for D-Link DIR-2055 A1

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-2055-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-2055-a1.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_dlink_dir_nand_128m.dtsi"
+
+/ {
+	compatible = "dlink,dir-2055-a1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-2055 A1";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -771,6 +771,14 @@ define Device/dlink_dir-1960-a1
 endef
 TARGET_DEVICES += dlink_dir-1960-a1
 
+define Device/dlink_dir-2055-a1
+  $(Device/dlink_dir_nand_128m)
+  DEVICE_PACKAGES += -kmod-usb-ledtrig-usbport
+  DEVICE_MODEL := DIR-2055
+  DEVICE_VARIANT := A1
+endef
+TARGET_DEVICES += dlink_dir-2055-a1
+
 define Device/dlink_dir-2150-a1
   $(Device/dlink_dir_nand_128m)
   DEVICE_MODEL := DIR-2150

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -92,6 +92,7 @@ dlink,dap-x1860-a1)
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan1" "76" "100"
 	;;
 dlink,dir-1960-a1|\
+dlink,dir-2055-a1|\
 dlink,dir-2150-a1|\
 dlink,dir-2640-a1|\
 dlink,dir-2660-a1)

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -71,6 +71,7 @@ platform_do_upgrade() {
 	dlink,covr-x1860-a1|\
 	dlink,dap-x1860-a1|\
 	dlink,dir-1960-a1|\
+        dlink,dir-2055-a1|\
 	dlink,dir-2150-a1|\
 	dlink,dir-2640-a1|\
 	dlink,dir-2660-a1|\


### PR DESCRIPTION
Add support for D-Link DIR-2055 A1 based on similarities to DIR-1960 A1, as well as various DIR-8xx A1 models. Existing DIR-1960 A1 openwrt "factory" firmware installs without modifications via the D-Link Recovery GUI and has no known incompatibilities with the DIR-2055 A1.

Changes to be committed:
new file:   target/linux/ramips/dts/mt7621_dlink_dir-2055-a1.dts
modified:   target/linux/ramips/image/mt7621.mk
modified:   target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
modified:   target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh

Specifications:

    Board: Not known
    SoC: MediaTek MT7621 Family (MT7621AT)
    RAM: 256 MB (Micron 9OK17 D9PTK, should be DDR3 MT41K128M16JT-125)
    Flash: 128 MB (Winbond W29N01HVSINA)
    WiFi: MediaTek MT7615 Family (MT7615N x2)
    Switch: 1 WAN, 4 LAN (Gigabit)
    Ports: 1 USB 3.0 (front)
    Buttons: Reset, WiFi Toggle, WPS
    LEDs: Power (white/orange), Internet (white/orange), WiFi 2.4G (white), WiFi 5G (white)

Notes:

    Only known difference vs. the DIR-1960 A1 is that the DIR-2055 A1 doesn't have a USB activity LED

Serial port:

    Tested to be identical to various DIR-8xx A1 models with a similar enclosure/pcb design:
        Parameters: 57600, 8N1, 3.3V TTL no flow control
        Location: J1 header (close to the Reset, WiFi and WPS buttons)
        Pinout: 1 - VCC 2 - RXD 3 - TXD 4 - GND
            Did not connect VCC when using

Installation:

    D-Link Recovery GUI: power down the router, press and hold the reset button, then re-plug it. Keep the reset button pressed until the power LED starts flashing orange, manually assign a static IP address under the 192.168.0.xxx subnet (e.g. 192.168.0.2) and go to http://192.168.0.1

    Some modern browsers may have problems flashing via the Recovery GUI, if that occurs consider uploading the firmware through cURL:

    curl -v -i -F "firmware=@file.bin" 192.168.0.1

Signed-off-by: Keith Harrison <keithh@protonmail.com>
