### PR TITLE
ipq40xx: use NVMEM-on-UBI for ASUS devices

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -178,9 +178,6 @@ ipq40xx_setup_macs()
 	cilab,meshpoint-one)
 		label_mac=$(mtd_get_mac_binary "ART" 0x1006)
 		;;
-	asus,rt-ac42u)
-		label_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)
-		;;
 	avm,fritzbox-7530)
 		local tffsdev=$(find_mtd_chardev "nand-tffs")
 		wan_mac=$(/usr/bin/fritz_tffs_nand -b -d $tffsdev -n macdsl)

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -9,9 +9,6 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case "$board" in
-	asus,rt-ac42u)
-		caldata_extract_ubi "Factory" 0x9000 0x2f20
-		;;
 	avm,fritzrepeater-3000)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3D000 -e 0x212 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader0") || \
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C800 -e 0x212 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader0") || \
@@ -43,9 +40,6 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-ahb-a000000.wifi.bin")
 	case "$board" in
-	asus,rt-ac42u)
-		caldata_extract_ubi "Factory" 0x1000 0x2f20
-		;;
 	avm,fritzbox-4040)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")
 		;;

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -2,15 +2,6 @@
 
 preinit_set_mac_address() {
 	case $(board_name) in
-	asus,rt-ac42u)
-		base_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)
-		ip link set dev eth0 address $base_mac
-		ip link set dev lan1 address $base_mac
-		ip link set dev lan2 address $base_mac
-		ip link set dev lan3 address $base_mac
-		ip link set dev lan4 address $base_mac
-		ip link set dev wan address $(mtd_get_mac_binary_ubi Factory 0x9006)
-		;;
 	engenius,eap2200)
 		base_mac=$(cat /sys/class/net/eth0/address)
 		ip link set dev eth1 address $(macaddr_add "$base_mac" 1)

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
@@ -18,6 +18,7 @@
 	aliases {
 		// TODO: Verify if the ethernet0 alias is needed
 		ethernet0 = &gmac;
+		label-mac-device = &gmac;
 		led-boot = &led_power;
 		led-failsafe = &led_power;
 		led-running = &led_power;
@@ -233,9 +234,40 @@
 				read-only;
 			};
 			partition@400000 {
-				label = "ubi";
+				compatible = "linux,ubi";
 				reg = <0x00400000 0x07C00000>;
+				label = "ubi";
+
+				volumes {
+					ubi_factory: ubi-volume-factory {
+						volname = "Factory";
+					};
+				};
 			};
+		};
+	};
+};
+
+&ubi_factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		precal_factory_1000: precal@1000 {
+			reg = <0x1000 0x2f20>;
+		};
+
+		macaddr_factory_1006: macaddr@1006 {
+			reg = <0x1006 0x6>;
+		};
+
+		precal_factory_9000: precal@9000 {
+			reg = <0x9000 0x2f20>;
+		};
+
+		macaddr_factory_9006: macaddr@9006 {
+			reg = <0x9006 0x6>;
 		};
 	};
 };
@@ -273,6 +305,8 @@
 
 &gmac {
 	status = "okay";
+	nvmem-cells = <&macaddr_factory_1006>;
+	nvmem-cell-names = "mac-address";
 };
 
 &switch {
@@ -297,10 +331,14 @@
 
 &swport5 {
 	status = "okay";
+	nvmem-cells = <&macaddr_factory_9006>;
+	nvmem-cell-names = "mac-address";
 };
 
 &wifi0 {
 	status = "okay";
+	nvmem-cell-names = "pre-calibration";
+	nvmem-cells = <&precal_factory_1000>;
 	qcom,ath10k-calibration-variant = "ASUS-RT-AC42U";
 };
 
@@ -316,5 +354,7 @@
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		qcom,ath10k-calibration-variant = "ASUS-RT-AC42U";
+		nvmem-cell-names = "pre-calibration";
+		nvmem-cells = <&precal_factory_9000>;
 	};
 };


### PR DESCRIPTION
Some recent ASUS devices started storing their factory data inside a UBI volume. Instead of extracting WiFi EEPROM data and MAC addresses in userspace, use the now available new way to reference the NVMEM bits in device tree.

Lacking the hardware no runtime testing has been done on my end, hence I rely on users to give feedback if this series works as intended.

User tested and confirmed MAC addresses and WiFi EEPROM:
 - [ ] ASUS RT-AC42U
 - [x] ASUS RT-AC58U
 - [x] ASUS Lyra MAP-AC2200

Similar changes for mediatek/filogic-based ASUS devices:
https://github.com/openwrt/openwrt/pull/14676