### PR TITLE
mediatek: filogic: fix failsafe mode on devices with no lan1

### DIFF
--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -14,6 +14,15 @@ set_preinit_iface() {
 		ip link set eth0 up
 		ifname=eth0
 		;;
+	xiaomi,mi-router-ax3000t|\
+	xiaomi,mi-router-ax3000t-ubootmod|\
+	xiaomi,mi-router-wr30u-stock|\
+	xiaomi,mi-router-wr30u-ubootmod|\
+	xiaomi,redmi-router-ax6000-stock|\
+	xiaomi,redmi-router-ax6000-ubootmod)
+		ip link set eth0 up
+		ifname=lan4
+		;;
 	*)
 		ip link set eth0 up
 		ifname=lan1


### PR DESCRIPTION
Default to lan4 port, instead of (missing) lan1 port, to fix failsafe mode on Xiaomi AX3000T, WR30U, AX6000

Build system: x86/64
Build-tested: mediatek/filogic/xiaomi_mi-router-ax3000t-ubootmod
Run-tested: mediatek/filogic/xiaomi_mi-router-ax3000t-ubootmod
