### PR TITLE
[23.05] mediatek: filogic: Cudy WR3000 v1 wps button fix

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
@@ -34,7 +34,7 @@
 		wps {
 			label = "wps";
 			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&pio 0 GPIO_ACTIVE_HIGH>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
 		};
 	};
 


### PR DESCRIPTION
WPS button activation method is wrong .  It should be active low

Signed-off-by: Robert Senderek <robert.senderek@10g.pl>
(cherry picked from commit 611a9894b23c5c2261d607cc0ccfd8dcd1fb2bcf)
