### PR TITLE
rockchip: add Radxa E25 support

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -165,6 +165,13 @@ define U-Boot/nanopi-r5s-rk3568
     friendlyarm_nanopi-r5s
 endef
 
+define U-Boot/radxa-e25-rk3568
+  $(U-Boot/rk3568/Default)
+  NAME:=E25
+  BUILD_DEVICES:= \
+    radxa_e25
+endef
+
 UBOOT_TARGETS := \
   nanopc-t4-rk3399 \
   nanopi-r4s-rk3399 \
@@ -180,7 +187,8 @@ UBOOT_TARGETS := \
   rock-pi-e-rk3328 \
   radxa-cm3-io-rk3566 \
   nanopi-r5c-rk3568 \
-  nanopi-r5s-rk3568
+  nanopi-r5s-rk3568 \
+  radxa-e25-rk3568
 
 UBOOT_CONFIGURE_VARS += USE_PRIVATE_LIBGCC=yes
 

--- a/package/kernel/linux/modules/block.mk
+++ b/package/kernel/linux/modules/block.mk
@@ -65,7 +65,7 @@ define KernelPackage/ata-ahci-platform
     $(LINUX_DIR)/drivers/ata/ahci_platform.ko \
     $(LINUX_DIR)/drivers/ata/libahci_platform.ko
   AUTOLOAD:=$(call AutoLoad,40,libahci libahci_platform ahci_platform,1)
-  $(call AddDepends/ata,@TARGET_ipq806x||TARGET_layerscape||TARGET_sunxi)
+  $(call AddDepends/ata,@TARGET_ipq806x||TARGET_layerscape||TARGET_rockchip||TARGET_sunxi)
 endef
 
 define KernelPackage/ata-ahci-platform/description

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -16,7 +16,8 @@ rockchip_setup_interfaces()
 	xunlong,orangepi-r1-plus-lts)
 		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
 		;;
-	friendlyarm,nanopi-r5c)
+	friendlyarm,nanopi-r5c|\
+	radxa,e25)
 		ucidef_set_interfaces_lan_wan 'eth0' 'eth1'
 		;;
 	friendlyarm,nanopi-r5s)

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -43,7 +43,8 @@ friendlyarm,nanopi-r4s-enterprise)
 	set_interface_core 10 "eth0"
 	set_interface_core 20 "eth1"
 	;;
-friendlyarm,nanopi-r5c)
+friendlyarm,nanopi-r5c|\
+radxa,e25)
 	set_interface_core 2 "eth0"
 	set_interface_core 4 "eth1"
 	;;

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -104,6 +104,16 @@ define Device/radxa_cm3-io
 endef
 TARGET_DEVICES += radxa_cm3-io
 
+define Device/radxa_e25
+  DEVICE_VENDOR := Radxa
+  DEVICE_MODEL := E25
+  SOC := rk3568
+  DEVICE_DTS := rockchip/rk3568-radxa-e25
+  UBOOT_DEVICE_NAME := radxa-e25-rk3568
+  DEVICE_PACKAGES := kmod-r8169 kmod-ata-ahci-platform
+endef
+TARGET_DEVICES += radxa_e25
+
 define Device/radxa_rock-pi-4a
   DEVICE_VENDOR := Radxa
   DEVICE_MODEL := ROCK Pi 4A

--- a/target/linux/rockchip/patches-6.1/024-v6.3-arm64-dts-rockchip-Add-Radxa-CM3I-E25.patch
+++ b/target/linux/rockchip/patches-6.1/024-v6.3-arm64-dts-rockchip-Add-Radxa-CM3I-E25.patch
@@ -1,0 +1,689 @@
+From 2bf2f4d9f673013a58109626b87329310537a611 Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Fri, 9 Dec 2022 18:25:24 +0800
+Subject: [PATCH] arm64: dts: rockchip: Add Radxa CM3I E25
+
+Radxa E25 is a network application carrier board for the Radxa CM3
+Industrial (CM3I) SoM, which is based on the Rockchip RK3568 SoC.
+
+It has the following features:
+
+- MicroSD card socket, on board eMMC flash
+- 2x 2.5GbE Realtek RTL8125B Ethernet transceiver
+- 1x USB Type-C port (Power and Serial console)
+- 1x USB 3.0 OTG port
+- mini PCIe socket (USB or PCIe)
+- ngff PCIe socket (USB or SATA)
+- 1x User LED and 16x RGB LEDs
+- 26-pin expansion header
+
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+Link: https://lore.kernel.org/r/20221209102524.129367-3-amadeus@jmu.edu.cn
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/Makefile         |   1 +
+ .../boot/dts/rockchip/rk3568-radxa-cm3i.dtsi  | 416 ++++++++++++++++++
+ .../boot/dts/rockchip/rk3568-radxa-e25.dts    | 229 ++++++++++
+ 3 files changed, 646 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3i.dtsi
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
+
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -78,4 +78,5 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-bp
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-evb1-v10.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-nanopi-r5c.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-nanopi-r5s.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-radxa-e25.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-rock-3a.dtb
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3i.dtsi
+@@ -0,0 +1,416 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++#include "rk3568.dtsi"
++
++/ {
++	model = "Radxa CM3 Industrial Board";
++	compatible = "radxa,cm3i", "rockchip,rk3568";
++
++	aliases {
++		mmc0 = &sdhci;
++	};
++
++	chosen {
++		stdout-path = "serial2:115200n8";
++	};
++
++	gpio-leds {
++		compatible = "gpio-leds";
++
++		led_user: led-0 {
++			gpios = <&gpio0 RK_PA6 GPIO_ACTIVE_HIGH>;
++			function = LED_FUNCTION_HEARTBEAT;
++			color = <LED_COLOR_ID_GREEN>;
++			linux,default-trigger = "heartbeat";
++			pinctrl-names = "default";
++			pinctrl-0 = <&led_user_en>;
++		};
++	};
++
++	pcie30_avdd0v9: pcie30-avdd0v9-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "pcie30_avdd0v9";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <900000>;
++		regulator-max-microvolt = <900000>;
++		vin-supply = <&vcc3v3_sys>;
++	};
++
++	pcie30_avdd1v8: pcie30-avdd1v8-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "pcie30_avdd1v8";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc3v3_sys>;
++	};
++
++	vcc3v3_sys: vcc3v3-sys-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc5v_input>;
++	};
++
++	vcc5v0_sys: vcc5v0-sys-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v_input>;
++	};
++
++	/* labeled +5v_input in schematic */
++	vcc5v_input: vcc5v-input-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v_input";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++};
++
++&combphy0 {
++	status = "okay";
++};
++
++&combphy1 {
++	status = "okay";
++};
++
++&combphy2 {
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_cpu>;
++};
++
++&cpu1 {
++	cpu-supply = <&vdd_cpu>;
++};
++
++&cpu2 {
++	cpu-supply = <&vdd_cpu>;
++};
++
++&cpu3 {
++	cpu-supply = <&vdd_cpu>;
++};
++
++&display_subsystem {
++	status = "disabled";
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu>;
++	status = "okay";
++};
++
++&i2c0 {
++	status = "okay";
++
++	vdd_cpu: regulator@1c {
++		compatible = "tcs,tcs4525";
++		reg = <0x1c>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <800000>;
++		regulator-max-microvolt = <1150000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc5v_input>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	rk809: pmic@20 {
++		compatible = "rockchip,rk809";
++		reg = <0x20>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_LOW>;
++		#clock-cells = <1>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_int>;
++		rockchip,system-power-controller;
++		wakeup-source;
++
++		vcc1-supply = <&vcc3v3_sys>;
++		vcc2-supply = <&vcc3v3_sys>;
++		vcc3-supply = <&vcc3v3_sys>;
++		vcc4-supply = <&vcc3v3_sys>;
++		vcc5-supply = <&vcc3v3_sys>;
++		vcc6-supply = <&vcc3v3_sys>;
++		vcc7-supply = <&vcc3v3_sys>;
++		vcc8-supply = <&vcc3v3_sys>;
++		vcc9-supply = <&vcc3v3_sys>;
++
++		regulators {
++			vdd_logic: DCDC_REG1 {
++				regulator-name = "vdd_logic";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-init-microvolt = <900000>;
++				regulator-initial-mode = <0x2>;
++				regulator-min-microvolt = <500000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_gpu: DCDC_REG2 {
++				regulator-name = "vdd_gpu";
++				regulator-always-on;
++				regulator-init-microvolt = <900000>;
++				regulator-initial-mode = <0x2>;
++				regulator-min-microvolt = <500000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_ddr: DCDC_REG3 {
++				regulator-name = "vcc_ddr";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-initial-mode = <0x2>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vdd_npu: DCDC_REG4 {
++				regulator-name = "vdd_npu";
++				regulator-init-microvolt = <900000>;
++				regulator-initial-mode = <0x2>;
++				regulator-min-microvolt = <500000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v8: DCDC_REG5 {
++				regulator-name = "vcc_1v8";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdda0v9_image: LDO_REG1 {
++				regulator-name = "vdda0v9_image";
++				regulator-min-microvolt = <900000>;
++				regulator-max-microvolt = <900000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdda_0v9: LDO_REG2 {
++				regulator-name = "vdda_0v9";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <900000>;
++				regulator-max-microvolt = <900000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdda0v9_pmu: LDO_REG3 {
++				regulator-name = "vdda0v9_pmu";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <900000>;
++				regulator-max-microvolt = <900000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <900000>;
++				};
++			};
++
++			vccio_acodec: LDO_REG4 {
++				regulator-name = "vccio_acodec";
++				regulator-always-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vccio_sd: LDO_REG5 {
++				regulator-name = "vccio_sd";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc3v3_pmu: LDO_REG6 {
++				regulator-name = "vcc3v3_pmu";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vcca_1v8: LDO_REG7 {
++				regulator-name = "vcca_1v8";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcca1v8_pmu: LDO_REG8 {
++				regulator-name = "vcca1v8_pmu";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcca1v8_image: LDO_REG9 {
++				regulator-name = "vcca1v8_image";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_3v3: SWITCH_REG1 {
++				regulator-name = "vcc_3v3";
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc3v3_sd: SWITCH_REG2 {
++				regulator-name = "vcc3v3_sd";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++		};
++	};
++};
++
++&pinctrl {
++	leds {
++		led_user_en: led_user_en {
++			rockchip,pins = <0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pmic {
++		pmic_int: pmic_int {
++			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++};
++
++&pmu_io_domains {
++	pmuio1-supply = <&vcc3v3_pmu>;
++	pmuio2-supply = <&vcc3v3_pmu>;
++	vccio1-supply = <&vccio_acodec>;
++	vccio2-supply = <&vcc_1v8>;
++	vccio3-supply = <&vccio_sd>;
++	vccio4-supply = <&vcc_1v8>;
++	vccio5-supply = <&vcc_3v3>;
++	vccio6-supply = <&vcc_1v8>;
++	vccio7-supply = <&vcc_3v3>;
++	status = "okay";
++};
++
++&saradc {
++	vref-supply = <&vcca_1v8>;
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	max-frequency = <200000000>;
++	non-removable;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd &emmc_datastrobe>;
++	vmmc-supply = <&vcc_3v3>;
++	vqmmc-supply = <&vcc_1v8>;
++	status = "okay";
++};
++
++&tsadc {
++	rockchip,hw-tshut-mode = <1>;
++	rockchip,hw-tshut-polarity = <0>;
++	status = "okay";
++};
++
++&uart2 {
++	status = "okay";
++};
++
++&usb2phy0 {
++	status = "okay";
++};
++
++&usb2phy1 {
++	status = "okay";
++};
++
++&usb_host0_xhci {
++	extcon = <&usb2phy0>;
++};
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
+@@ -0,0 +1,229 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++#include "rk3568-radxa-cm3i.dtsi"
++
++/ {
++	model = "Radxa E25";
++	compatible = "radxa,e25", "rockchip,rk3568";
++
++	aliases {
++		mmc0 = &sdmmc0;
++		mmc1 = &sdhci;
++	};
++
++	pwm-leds {
++		compatible = "pwm-leds-multicolor";
++
++		multi-led {
++			color = <LED_COLOR_ID_RGB>;
++			max-brightness = <255>;
++
++			led-red {
++				color = <LED_COLOR_ID_RED>;
++				pwms = <&pwm1 0 1000000 0>;
++			};
++
++			led-green {
++				color = <LED_COLOR_ID_GREEN>;
++				pwms = <&pwm2 0 1000000 0>;
++			};
++
++			led-blue {
++				color = <LED_COLOR_ID_BLUE>;
++				pwms = <&pwm12 0 1000000 0>;
++			};
++		};
++	};
++
++	vbus_typec: vbus-typec-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vbus_typec_en>;
++		regulator-name = "vbus_typec";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc3v3_minipcie: vcc3v3-minipcie-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio3 RK_PA7 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&minipcie_enable_h>;
++		regulator-name = "vcc3v3_minipcie";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc3v3_ngff: vcc3v3-ngff-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&ngffpcie_enable_h>;
++		regulator-name = "vcc3v3_ngff";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	/* actually fed by vcc5v0_sys, dependent
++	 * on pi6c clock generator
++	 */
++	vcc3v3_pcie30x1: vcc3v3-pcie30x1-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie30x1_enable_h>;
++		regulator-name = "vcc3v3_pcie30x1";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc3v3_pi6c_05>;
++	};
++
++	vcc3v3_pi6c_05: vcc3v3-pi6c-05-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpios = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie_enable_h>;
++		regulator-name = "vcc3v3_pcie";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++};
++
++&pcie2x1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie20_reset_h>;
++	reset-gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pi6c_05>;
++	status = "okay";
++};
++
++&pcie30phy {
++	data-lanes = <1 2>;
++	status = "okay";
++};
++
++&pcie3x1 {
++	num-lanes = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie30x1m0_pins>;
++	reset-gpios = <&gpio0 RK_PC3 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie30x1>;
++	status = "okay";
++};
++
++&pcie3x2 {
++	num-lanes = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie30x2_reset_h>;
++	reset-gpios = <&gpio2 RK_PD6 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pi6c_05>;
++	status = "okay";
++};
++
++&pinctrl {
++	pcie {
++		pcie20_reset_h: pcie20-reset-h {
++			rockchip,pins = <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie30x1_enable_h: pcie30x1-enable-h {
++			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie30x2_reset_h: pcie30x2-reset-h {
++			rockchip,pins = <2 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie_enable_h: pcie-enable-h {
++			rockchip,pins = <0 RK_PC7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb {
++		minipcie_enable_h: minipcie-enable-h {
++			rockchip,pins = <3 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		ngffpcie_enable_h: ngffpcie-enable-h {
++			rockchip,pins = <0 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		vbus_typec_en: vbus_typec_en {
++			rockchip,pins = <0 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&pwm1 {
++	status = "okay";
++};
++
++&pwm2 {
++	status = "okay";
++};
++
++&pwm12 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm12m1_pins>;
++	status = "okay";
++};
++
++&sdmmc0 {
++	bus-width = <4>;
++	cap-sd-highspeed;
++	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
++	/* Also used in pcie30x1_clkreqnm0 */
++	disable-wp;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc0_bus4 &sdmmc0_clk &sdmmc0_cmd>;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc3v3_sd>;
++	vqmmc-supply = <&vccio_sd>;
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usb_host0_xhci {
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	status = "okay";
++};
++
++&usb2phy0_otg {
++	phy-supply = <&vbus_typec>;
++	status = "okay";
++};
++
++&usb2phy1_host {
++	phy-supply = <&vcc3v3_minipcie>;
++	status = "okay";
++};
++
++&usb2phy1_otg {
++	phy-supply = <&vcc3v3_ngff>;
++	status = "okay";
++};

--- a/target/linux/rockchip/patches-6.1/025-v6.3-arm64-dts-rockchip-Update-eMMC-SD.patch
+++ b/target/linux/rockchip/patches-6.1/025-v6.3-arm64-dts-rockchip-Update-eMMC-SD.patch
@@ -1,0 +1,48 @@
+From c80992abd2877590059e9cb254213c16824e2106 Mon Sep 17 00:00:00 2001
+From: Jagan Teki <jagan@amarulasolutions.com>
+Date: Wed, 18 Jan 2023 13:34:53 +0530
+Subject: [PATCH] arm64: dts: rockchip: Update eMMC, SD aliases for Radxa SoM
+ boards
+
+Radxa has produced Compute Modules like RK3399pro VMARC and CM3i with
+onboarding eMMC flash, so the eMMC is the primary MMC device.
+
+On the other hand, Rockchip boot orders start from eMMC from an MMC
+device perspective.
+
+Mark, the eMMC has mmc0 to satisfy the above two conditions.
+
+Reported-by: FUKAUMI Naoki <naoki@radxa.com>
+Signed-off-by: Jagan Teki <jagan@amarulasolutions.com>
+Link: https://lore.kernel.org/r/20230118080454.11643-1-jagan@amarulasolutions.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3399pro-vmarc-som.dtsi | 4 ++--
+ arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts     | 3 +--
+ 2 files changed, 3 insertions(+), 4 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3399pro-vmarc-som.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399pro-vmarc-som.dtsi
+@@ -13,8 +13,8 @@
+ 	compatible = "vamrs,rk3399pro-vmarc-som", "rockchip,rk3399pro";
+ 
+ 	aliases {
+-		mmc0 = &sdmmc;
+-		mmc1 = &sdhci;
++		mmc0 = &sdhci;
++		mmc1 = &sdmmc;
+ 	};
+ 
+ 	vcc3v3_pcie: vcc-pcie-regulator {
+--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
+@@ -8,8 +8,7 @@
+ 	compatible = "radxa,e25", "rockchip,rk3568";
+ 
+ 	aliases {
+-		mmc0 = &sdmmc0;
+-		mmc1 = &sdhci;
++		mmc1 = &sdmmc0;
+ 	};
+ 
+ 	pwm-leds {

--- a/target/linux/rockchip/patches-6.1/026-v6.3-arm64-dts-rockchip-Add-missing-CM3i.patch
+++ b/target/linux/rockchip/patches-6.1/026-v6.3-arm64-dts-rockchip-Add-missing-CM3i.patch
@@ -1,0 +1,35 @@
+From c4d2b02d63ee38b381fbc886c02eecfec4f981cc Mon Sep 17 00:00:00 2001
+From: Jagan Teki <jagan@amarulasolutions.com>
+Date: Mon, 23 Jan 2023 12:46:51 +0530
+Subject: [PATCH] arm64: dts: rockchip: Add missing CM3i fallback compatible
+ for Radxa E25
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In order to function the Radxa E25 Carrier board, it is mandatory to
+mount the Radxa CM3i module. 
+
+Add Radxa CM3i compatible as fallback compatible to string to satisfy
+the Module and Carrier board topology.
+
+Fixes: 2bf2f4d9f673 ("arm64: dts: rockchip: Add Radxa CM3I E25")
+Cc: Chukun Pan <amadeus@jmu.edu.cn>
+Signed-off-by: Jagan Teki <jagan@amarulasolutions.com>
+Link: https://lore.kernel.org/r/20230123071654.73139-2-jagan@amarulasolutions.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
+@@ -5,7 +5,7 @@
+ 
+ / {
+ 	model = "Radxa E25";
+-	compatible = "radxa,e25", "rockchip,rk3568";
++	compatible = "radxa,e25", "radxa,cm3i", "rockchip,rk3568";
+ 
+ 	aliases {
+ 		mmc1 = &sdmmc0;

--- a/target/linux/rockchip/patches-6.1/027-v6.3-arm64-dts-rockchip-Correct-the-model-name-for-Radxa-E25.patch
+++ b/target/linux/rockchip/patches-6.1/027-v6.3-arm64-dts-rockchip-Correct-the-model-name-for-Radxa-E25.patch
@@ -1,0 +1,28 @@
+From ef9134d9bbce071c9e4ebdcbb6f8fb1a5dd0a67e Mon Sep 17 00:00:00 2001
+From: Jagan Teki <jagan@amarulasolutions.com>
+Date: Mon, 23 Jan 2023 12:46:53 +0530
+Subject: [PATCH] arm64: dts: rockchip: Correct the model name for Radxa E25
+
+Radxa E25 is a Carrier board, so update the model name for Radxa E25
+as suggested by the Radxa website.
+
+Fixes: 2bf2f4d9f673 ("arm64: dts: rockchip: Add Radxa CM3I E25")
+Cc: Chukun Pan <amadeus@jmu.edu.cn>
+Signed-off-by: Jagan Teki <jagan@amarulasolutions.com>
+Link: https://lore.kernel.org/r/20230123071654.73139-4-jagan@amarulasolutions.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
+@@ -4,7 +4,7 @@
+ #include "rk3568-radxa-cm3i.dtsi"
+ 
+ / {
+-	model = "Radxa E25";
++	model = "Radxa E25 Carrier Board";
+ 	compatible = "radxa,e25", "radxa,cm3i", "rockchip,rk3568";
+ 
+ 	aliases {

--- a/target/linux/rockchip/patches-6.1/028-v6.6-arm64-dts-rockchip-Fix-PCIe-regulators-on-Radxa-E25.patch
+++ b/target/linux/rockchip/patches-6.1/028-v6.6-arm64-dts-rockchip-Fix-PCIe-regulators-on-Radxa-E25.patch
@@ -1,0 +1,79 @@
+From a87852e37f782257ebc57cc44a0d3fbf806471f6 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Mon, 24 Jul 2023 14:52:16 +0000
+Subject: [PATCH] arm64: dts: rockchip: Fix PCIe regulators on Radxa E25
+
+Despite its name, the regulator vcc3v3_pcie30x1 has nothing to do with
+pcie30x1. Instead, it supply power to VBAT1-5 on the M.2 KEY B port as
+seen on page 8 of the schematic [1].
+
+pcie30x1 is used for the mini PCIe slot, and as seen on page 9 the
+vcc3v3_minipcie regulator is instead related to pcie30x1.
+
+The M.2 KEY B port can be used for WWAN USB2 modules or SATA drives.
+
+Use correct regulator vcc3v3_minipcie for pcie30x1.
+
+[1] https://dl.radxa.com/cm3p/e25/radxa-e25-v1.4-sch.pdf
+
+Fixes: 2bf2f4d9f673 ("arm64: dts: rockchip: Add Radxa CM3I E25")
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+Link: https://lore.kernel.org/r/20230724145213.3833099-1-jonas@kwiboo.se
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ .../arm64/boot/dts/rockchip/rk3568-radxa-e25.dts | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
+@@ -47,6 +47,9 @@
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
++	/* actually fed by vcc5v0_sys, dependent
++	 * on pi6c clock generator
++	 */
+ 	vcc3v3_minipcie: vcc3v3-minipcie-regulator {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+@@ -54,9 +57,9 @@
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&minipcie_enable_h>;
+ 		regulator-name = "vcc3v3_minipcie";
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-		vin-supply = <&vcc5v0_sys>;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc3v3_pi6c_05>;
+ 	};
+ 
+ 	vcc3v3_ngff: vcc3v3-ngff-regulator {
+@@ -71,9 +74,6 @@
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
+-	/* actually fed by vcc5v0_sys, dependent
+-	 * on pi6c clock generator
+-	 */
+ 	vcc3v3_pcie30x1: vcc3v3-pcie30x1-regulator {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+@@ -83,7 +83,7 @@
+ 		regulator-name = "vcc3v3_pcie30x1";
+ 		regulator-min-microvolt = <3300000>;
+ 		regulator-max-microvolt = <3300000>;
+-		vin-supply = <&vcc3v3_pi6c_05>;
++		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
+ 	vcc3v3_pi6c_05: vcc3v3-pi6c-05-regulator {
+@@ -117,7 +117,7 @@
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pcie30x1m0_pins>;
+ 	reset-gpios = <&gpio0 RK_PC3 GPIO_ACTIVE_HIGH>;
+-	vpcie3v3-supply = <&vcc3v3_pcie30x1>;
++	vpcie3v3-supply = <&vcc3v3_minipcie>;
+ 	status = "okay";
+ };
+ 

--- a/target/linux/rockchip/patches-6.1/029-v6.6-arm64-dts-rockchip-Enable-SATA-on-Radxa-E25.patch
+++ b/target/linux/rockchip/patches-6.1/029-v6.6-arm64-dts-rockchip-Enable-SATA-on-Radxa-E25.patch
@@ -1,0 +1,41 @@
+From 2bdfe84fbd57a4ed9fd65a67210442559ce078f0 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Mon, 24 Jul 2023 14:52:16 +0000
+Subject: [PATCH] arm64: dts: rockchip: Enable SATA on Radxa E25
+
+The M.2 KEY B port can be used for WWAN USB2 modules or SATA drives.
+
+Enable sata1 node to fix use of SATA drives on the M.2 slot.
+
+Fixes: 2bf2f4d9f673 ("arm64: dts: rockchip: Add Radxa CM3I E25")
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+Link: https://lore.kernel.org/r/20230724145213.3833099-1-jonas@kwiboo.se
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
+@@ -99,6 +99,10 @@
+ 	};
+ };
+ 
++&combphy1 {
++	phy-supply = <&vcc3v3_pcie30x1>;
++};
++
+ &pcie2x1 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pcie20_reset_h>;
+@@ -178,6 +182,10 @@
+ 	status = "okay";
+ };
+ 
++&sata1 {
++	status = "okay";
++};
++
+ &sdmmc0 {
+ 	bus-width = <4>;
+ 	cap-sd-highspeed;

--- a/target/linux/rockchip/patches-6.1/112-radxa-e25-add-led-aliases.patch
+++ b/target/linux/rockchip/patches-6.1/112-radxa-e25-add-led-aliases.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marius Durbaca <mariusd84@gmail.com>
+Date: Tue Feb 27 16:25:27 2024 +0200
+Subject: [PATCH] arm64: dts: rockchip: Update LED properties for Radxa 
+E25
+
+Add OpenWrt's LED aliases for showing system status.
+
+Signed-off-by: Marius Durbaca <mariusd84@gmail.com>
+---
+
+--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
+@@ -9,6 +9,10 @@
+ 
+ 	aliases {
+ 		mmc1 = &sdmmc0;
++		led-boot = &led_user;
++		led-failsafe = &led_user;
++		led-running = &led_user;
++		led-upgrade = &led_user;
+ 	};
+ 
+ 	pwm-leds {


### PR DESCRIPTION
Radxa E25 is a network application carrier board for the Radxa CM3
Industrial (CM3I) SoM, which is based on the Rockchip RK3568 SoC.

It has the following features:

- MicroSD card socket, on board eMMC flash
- 2x 2.5GbE Realtek RTL8125B Ethernet transceiver
- 1x USB Type-C port (Power and Serial console)
- 1x USB 3.0 OTG port
- mini PCIe socket (USB or PCIe)
- ngff PCIe socket (USB or SATA)
- 1x User LED and 16x RGB LEDs
- 26-pin expansion header

Installation:
Uncompress the OpenWrt sysupgrade and write it to a micro SD card or
internal eMMC using dd.

Signed-off-by: Marius Durbaca <mariusd84@gmail.com>