### PR TITLE
qualcommax: ipq60xx: add yuncore fap650 support

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq60xx
@@ -19,6 +19,11 @@ netgear,wax214)
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000" "2"
 	;;
+yuncore,fap650)
+	idx="$(find_mtd_index 0:appsblenv)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000"
+	;;
 esac
 
 config_load ubootenv

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -6,10 +6,9 @@ PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firmware/qca-wireless.git
-PKG_SOURCE_DATE:=2024-03-04
-PKG_SOURCE_VERSION:=38c02ae4302f9cb73f6914574239fe84799caa84
-PKG_MIRROR_HASH:=1e84f576d4161ea932b45a651abebdc05ff3c261ef25fc13d3d68cf9b624abb3
-
+PKG_SOURCE_DATE:=2024-03-20
+PKG_SOURCE_VERSION:=87717baa8a7c922942f4202a0ec3de3cb5643941
+PKG_MIRROR_HASH:=75f05f922780b55c0069c4ee9725f2b1aa857f3bc841bec71a44e997ece9cea15
 PKG_FLAGS:=nonshared
 
 include $(INCLUDE_DIR)/package.mk
@@ -52,6 +51,7 @@ ALLWIFIBOARDS:= \
 	xiaomi_ax9000 \
 	yyets_le1 \
 	yuncore_ax880 \
+	yuncore_fap650 \
 	zte_mf269 \
 	zte_mf287 \
 	zte_mf287plus \
@@ -169,6 +169,7 @@ $(eval $(call generate-ipq-wifi-package,xiaomi_ax3600,Xiaomi AX3600))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax9000,Xiaomi AX9000))
 $(eval $(call generate-ipq-wifi-package,yyets_le1,YYeTs LE1))
 $(eval $(call generate-ipq-wifi-package,yuncore_ax880,Yuncore AX880))
+$(eval $(call generate-ipq-wifi-package,yuncore_fap650,Yuncore FAP650))
 $(eval $(call generate-ipq-wifi-package,zte_mf269,ZTE MF269))
 $(eval $(call generate-ipq-wifi-package,zte_mf287,ZTE MF287))
 $(eval $(call generate-ipq-wifi-package,zte_mf287plus,ZTE MF287Plus))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-512m.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-512m.dtsi
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "ipq6018.dtsi"
+
+&rpm_msg_ram {
+	reg = <0x0 0x00060000 0x0 0x6000>;
+	no-map;
+};
+
+&tz {
+	reg = <0x0 0x4a600000 0x0 0x00400000>;
+	no-map;
+};
+
+&smem_region {
+	reg = <0x0 0x4aa00000 0x0 0x00100000>;
+	no-map;
+};
+
+&q6_region {
+	reg = <0x0 0x4ab00000 0x0 0x03700000>;
+	no-map;
+};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-fap650.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-fap650.dts
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: MIT, GPL-2.0 or later
+/* Copyright (c) 2023, Ruslan Isaev <legale.legale@gmail.com> */
+
+/dts-v1/;
+
+#include "ipq6018-512m.dtsi"
+#include "ipq6018-cp-cpu.dtsi"
+#include "ipq6018-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Yuncore FAP650";
+	compatible = "yuncore,fap650", "qcom,ipq6018";
+	
+	aliases {
+		ethernet0 = &dp5;
+		ethernet1 = &dp4;
+		ethernet2 = &dp3;
+		ethernet3 = &dp2;
+		ethernet4 = &dp1;
+		label-mac-device = &dp5;
+		serial0 = &blsp1_uart3;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 19 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&tlmm 32 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan2g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&tlmm 37 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan5g {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&tlmm 35 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&blsp1_uart3 {
+	pinctrl-0 = <&serial_3_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio64";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio65";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 75 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <10000>;
+	reset-post-delay-us = <50000>;
+
+	ethernet-phy-package@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "qcom,qca8075-package";
+		reg = <0>;
+
+		qcom,package-mode = "psgmii";
+
+		qca8075_0: ethernet-phy@0 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <0>;
+		};
+
+		qca8075_1: ethernet-phy@1 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <1>;
+		};
+
+		qca8075_2: ethernet-phy@2 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <2>;
+		};
+
+		qca8075_3: ethernet-phy@3 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <3>;
+		};
+
+		qca8075_4: ethernet-phy@4 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <4>;
+		};
+	};
+};
+
+&switch {
+	status = "okay";
+	switch_lan_bmp = <(ESS_PORT1|ESS_PORT2|ESS_PORT3|ESS_PORT4)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
+	switch_mac_mode = <MAC_MODE_PSGMII>; /* mac mode for uniphy instance0*/
+
+	qcom,port_phyinfo {
+		port@1 {
+			port_id = <1>;
+			phy_address = <0>;
+		};
+
+		port@2 {
+			port_id = <2>;
+			phy_address = <1>;
+		};
+
+		port@3 {
+			port_id = <3>;
+			phy_address = <2>;
+		};
+
+		port@4 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+
+		port@5 {
+			port_id = <5>;
+			phy_address = <4>;
+		};
+	};
+};
+
+&usb2 {
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp1 {
+	status = "okay";
+	phy-handle = <&qca8075_0>;
+	label = "lan1";
+};
+
+&dp2 {
+	status = "okay";
+	phy-handle = <&qca8075_1>;
+	label = "lan2";
+};
+
+&dp3 {
+	status = "okay";
+	phy-handle = <&qca8075_2>;
+	label = "lan3";
+};
+
+&dp4 {
+	status = "okay";
+	phy-handle = <&qca8075_3>;
+	label = "lan4";
+};
+
+&dp5 {
+	status = "okay";
+	phy-handle = <&qca8075_4>;
+	phy-mode = "psgmii";
+	label = "wan";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&blsp1_spi1 {
+	status = "okay";
+	
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+
+			partition@0 {
+				reg = <0x00000000 0x000c0000>;
+				label = "0:sbl1";
+			};
+
+			partition@c0000 {
+				reg = <0x000c0000 0x00010000>;
+				label = "0:mibib";
+			};
+
+			partition@d0000 {
+				reg = <0x000d0000 0x00020000>;
+				label = "0:bootconfig";
+			};
+
+			partition@f0000 {
+				reg = <0x000f0000 0x00020000>;
+				label = "0:bootconfig1";
+			};
+
+			partition@110000 {
+				reg = <0x00110000 0x001a0000>;
+				label = "0:qsee";
+			};
+
+			partition@2b0000 {
+				reg = <0x002b0000 0x001a0000>;
+				label = "0:qsee_1";
+			};
+
+			partition@450000 {
+				reg = <0x00450000 0x00010000>;
+				label = "0:devcfg";
+			};
+
+			partition@460000 {
+				reg = <0x00460000 0x00010000>;
+				label = "0:devcfg_1";
+			};
+
+			partition@470000 {
+				reg = <0x00470000 0x00040000>;
+				label = "0:rpm";
+			};
+
+			partition@4b0000 {
+				reg = <0x004b0000 0x00040000>;
+				label = "0:rpm_1";
+			};
+
+			partition@4f0000 {
+				reg = <0x004f0000 0x00010000>;
+				label = "0:cdt";
+			};
+
+			partition@500000 {
+				reg = <0x00500000 0x00010000>;
+				label = "0:cdt_1";
+			};
+
+			partition@510000 {
+				reg = <0x00510000 0x00010000>;
+				label = "0:appsblenv";
+			};
+
+			partition@520000 {
+				reg = <0x00520000 0x000a0000>;
+				label = "0:appsbl";
+			};
+
+			partition@5c0000 {
+				reg = <0x005c0000 0x000a0000>;
+				label = "0:appsbl_1";
+			};
+
+			partition@660000 {
+				reg = <0x00660000 0x00040000>;
+				label = "0:art";
+			};
+		};
+	};
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+	
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "rootfs";
+				reg = <0x00000000 0x03c00000>;
+			};
+
+			partition@3c00000 {
+				label = "rootfs_1";
+				reg = <0x03c00000 0x03c00000>;
+			};
+		};
+	};
+};
+
+&wifi {
+ 	qcom,ath11k-calibration-variant = "Yuncore-FAP650";
+	qcom,ath11k-fw-memory-mode = <1>;
+	status = "okay";
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&qusb_phy_1 {
+	status = "okay";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+};

--- a/target/linux/qualcommax/image/ipq60xx.mk
+++ b/target/linux/qualcommax/image/ipq60xx.mk
@@ -23,3 +23,19 @@ define Device/netgear_wax214
        DEVICE_PACKAGES := ipq-wifi-netgear_wax214
 endef
 TARGET_DEVICES += netgear_wax214
+
+define Device/yuncore_fap650
+    $(call Device/FitImage)
+    $(call Device/UbiFit)
+    DEVICE_VENDOR := Yuncore
+    DEVICE_MODEL := FAP650
+    BLOCKSIZE := 128k
+    PAGESIZE := 2048
+    DEVICE_DTS_CONFIG := config@cp03-c1
+    SOC := ipq6018
+    DEVICE_PACKAGES := ipq-wifi-yuncore_fap650
+    IMAGES := factory.ubi factory.ubin sysupgrade.bin
+    IMAGE/factory.ubin := append-ubi | qsdk-ipq-factory-nand
+endef
+TARGET_DEVICES += yuncore_fap650
+

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/01_leds
@@ -1,0 +1,18 @@
+
+. /lib/functions/leds.sh
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+board=$(board_name)
+
+case "$board" in
+yuncore,fap650)
+	ucidef_set_led_netdev "wlan5ghz" "WLAN 5GHz LED" "blue:wlan-5ghz" "wlan0" "tx rx"
+	ucidef_set_led_netdev "wlan2ghz" "WLAN 2.4GHz LED" "green:wlan-2ghz" "wlan1" "tx rx"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
@@ -17,6 +17,9 @@ ipq60xx_setup_interfaces()
 	netgear,wax214)
 		ucidef_set_interfaces_lan_wan "lan"
 		;;
+	yuncore,fap650)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
+		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"
 		;;

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11-caldata
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11-caldata
@@ -15,6 +15,9 @@ case "$FIRMWARE" in
 	netgear,wax214)
 		caldata_extract "0:art" 0x1000 0x10000
 		;;
+	yuncore,fap650)
+		caldata_extract "0:art" 0x1000 0x20000
+		;;
 	esac
 	;;
 *)

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/init.d/bootcount
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/init.d/bootcount
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+
+. /lib/functions.sh
+
+boot() {
+	case $(board_name) in
+		yuncore,fap650)
+			fw_setenv owrt_bootcount 0
+		;;
+		esac
+}
+

--- a/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
@@ -8,9 +8,44 @@ platform_check_image() {
 	return 0;
 }
 
+
+yuncore_fap650_env_setup() {
+	local ubifile=$(board_name)
+	local active=$(fw_printenv -n owrt_slotactive)
+	[ -z "$active" ] && active=$(hexdump -s 0x94 -n 4 -e '4 "%d"' /dev/mtd$(find_mtd_index 0:bootconfig))
+	cat > /tmp/env_tmp << EOF
+owrt_slotactive=${active}
+owrt_bootcount=0
+bootfile=${ubifile}.ubi
+owrt_bootcountcheck=if test \$owrt_bootcount > 4; then run owrt_tftprecover; fi; if test \$owrt_bootcount = 3; then run owrt_slotswap; else echo bootcountcheck successfull; fi
+owrt_bootinc=if test \$owrt_bootcount < 5; then echo save env part; setexpr owrt_bootcount \${owrt_bootcount} + 1 && saveenv; else echo save env skipped; fi; echo current bootcount: \$owrt_bootcount
+bootcmd=run owrt_bootinc && run owrt_bootcountcheck && run owrt_slotselect && run owrt_bootlinux
+owrt_bootlinux=echo booting linux... && ubi part fs && ubi read 0x44000000 kernel && bootm; reset
+owrt_setslot0=setenv bootargs console=ttyMSM0,115200n8 ubi.mtd=rootfs root=mtd:rootfs rootfstype=squashfs rootwait swiotlb=1 && setenv mtdparts mtdparts=nand0:0x3c00000@0(fs)
+owrt_setslot1=setenv bootargs console=ttyMSM0,115200n8 ubi.mtd=rootfs_1 root=mtd:rootfs rootfstype=squashfs rootwait swiotlb=1 && setenv mtdparts mtdparts=nand0:0x3c00000@0x3c00000(fs)
+owrt_slotswap=setexpr owrt_slotactive 1 - \${owrt_slotactive} && saveenv && echo slot swapped. new active slot: \$owrt_slotactive
+owrt_slotselect=setenv mtdids nand0=nand0,nand1=spi0.0; if test \$owrt_slotactive = 0; then run owrt_setslot0; else run owrt_setslot1; fi
+owrt_tftprecover=echo trying to recover firmware with tftp... && sleep 10 && dhcp && flash rootfs && flash rootfs_1 && setenv owrt_bootcount 0 && setenv owrt_slotactive 0 && saveenv && reset
+owrt_env_ver=7
+EOF
+	fw_setenv --script /tmp/env_tmp
+}
+
 platform_do_upgrade() {
 	case "$(board_name)" in
 	netgear,wax214)
+		nand_do_upgrade "$1"
+		;;
+	yuncore,fap650)
+		[ "$(fw_printenv -n owrt_env_ver 2>/dev/null)" != "7" ] && yuncore_fap650_env_setup
+		local active="$(fw_printenv -n owrt_slotactive 2>/dev/null)"
+		if [ "$active" = "1" ]; then
+			CI_UBIPART="rootfs"
+		else
+			CI_UBIPART="rootfs_1"
+		fi
+		fw_setenv owrt_bootcount 0
+		fw_setenv owrt_slotactive $((1 - active))
 		nand_do_upgrade "$1"
 		;;
 	*)


### PR DESCRIPTION
This commit adds support for the Yuncore FAP650 device.


Specifications:
- Qualcomm IPQ6018+QCA8075+QCN5022+QCN5052
- 512 MB of RAM (DDR3)
- 8 MB of serial flash (SPI NOR)
- 128 MB of parallel flash (NAND)
- 2x2 2.4 GHz WiFi (IPQ6010)
- 2x2 5 GHz WiFi (IPQ6010)
- 2x 2dBi 2.4G MIMO antenna
- 2x 3dBi 5.8G MIMO antenna
- 5x 1 Gbps Ethernet (QCA8075)
- POE: 48V (IEEE 802.3af)
- power: 12V (~1.5A)
- 1x passthru port (rj45 - rj45)
- 1x cisco rj45 console port
- size: 160mm*86mm*29mm


BACKUP YOUR STOCK FIRMWARE:
```
export device=fap650
mkdir -p /tmp/fw_dump_$device
cd /tmp/fw_dump_$device
dmesg > dmesg_$device.log
dtc -I fs /sys/firmware/devicetree/base > $device.dts
cat /proc/device-tree/model > model
cat /proc/mtd > proc_mtd
while read p; do
mtd_dev=$(echo $p | cut -d: -f1)
echo $mtd_dev
dd if=/dev/$mtd_dev of=$mtd_dev
done < proc_mtd
md5sum * > md5sum.log
tar -cvzf ../$device.tar.gz .
export sum=$(md5sum /tmp/$device.tar.gz | cut -d' ' -f1)
mv ../$device.tar.gz /tmp/${device}_${sum}.tar.gz
echo fw backup saved to: /tmp/${device}_${sum}.tar.gz
```
Upload your backup via tftp to the safe place.

INSTALLATION:
1. stock firmware web ui
Rename factory.bin fw image file to factory.ubin. Flash this image
like ordinary stock fw upgrade.

2. stock firmware telnet method
Enter telnet cli (login: root, password: 476t*_f0%g09y) and upload
 factory.bin fw image and rename it to factory.ubin
`cd /tmp && wget <your_web_server_ip>/factory.ubin`
`sysupgrade factory.ubin

3. initramfs method
    Put imitramfs image to your TFTP server and rename it for example to fap650.initram
    Enable serial console and enter to the u-boot cli.
    Exec these commands:
    `tftpboot <your_tftp_server_ip>:fap650.initram`
    `dhcp`

    When downloading is finished:
    `bootm`
    After booting the device, you need to upload to the device factory.ubi fw image.
    ```
    cd /tmp && wget <your_web_server_ip>/factory.ubi`
    export rootfs=$(cat /proc/mtd | grep rootfs | cut -d: -f1)
    export rootfs_1=$(cat /proc/mtd | grep rootfs_1 | cut -d: -f1)
    ubiformat /dev/${rootfs} -y -f factory.ubi
    ubiformat /dev/${rootfs_1} -y -f factory.ubi
    reboot
    ```

4. u-boot factory.ubi image method
    Put factory.ubi to your TFTP server
    Enter u-boot cli and exec these commands:
    `tftpboot <your_tftp_server_ip>:factory.ubi`
    `dhcp`
    After downloading is finished:
    `flash rootfs`
    `flash rootfs_1`
    `reset`



STOCK FIRMWARE RECOVERY:
Boot initramfs image.
Upload your rootfs mtd partition to the device using scp or download
it from the device using wget.
Enter device ssh cli and exec:
```
cd /tmp && wget <your_web_server_ip>/rootfs_mtd`
export rootfs=$(cat /proc/mtd | grep rootfs | cut -d: -f1)
export rootfs_1=$(cat /proc/mtd | grep rootfs_1 | cut -d: -f1)
ubiformat /dev/${rootfs} -y -f /tmp/rootfs_mtd
ubiformat /dev/${rootfs_1} -y -f /tmp/rootfs_mtd
reboot
```



Signed-off-by: Isaev Ruslan <legale.legale@gmail.com>




