### PR TITLE
ramips: TP-Link Archer C5 v4: disable 802.11w Management Frame Protection at default

### DIFF
--- a/target/linux/ramips/mt7620/base-files/etc/uci-defaults/06_disable_ieee80211w
+++ b/target/linux/ramips/mt7620/base-files/etc/uci-defaults/06_disable_ieee80211w
@@ -1,0 +1,10 @@
+. /lib/functions.sh
+
+case "$(board_name)" in
+	tplink,archer-c5-v4)
+		uci set wireless.default_radio1.ieee80211w="0"
+		uci commit wireless
+		;;
+esac
+
+exit 0


### PR DESCRIPTION
Since there are problems with the performance of 2.4GHz WiFi for Mediatek MT7620, disable at default 802.11w Management Frame Protection for router TP-Link Archer C5 v4.