### PR TITLE
build: fix kernel component in CycloneDX SBOM

### DIFF
--- a/scripts/package-metadata.pl
+++ b/scripts/package-metadata.pl
@@ -677,6 +677,7 @@ sub gen_image_cyclonedxsbom() {
 		license => "GPL-2.0",
 		cpe_id  => "cpe:/o:linux:linux_kernel",
 		name    => "kernel",
+		category  => "operating-system",
 	};
 
 	my %abimap;
@@ -705,6 +706,7 @@ sub gen_image_cyclonedxsbom() {
 		if ($pkg->{category}) {
 			my $category = $pkg->{category};
 			my %cat_type = (
+				"operating-system"        => "operating-system",
 				"Firmware"        => "firmware",
 				"Libraries"       => "library"
 			);


### PR DESCRIPTION
As stated in the cycloneDX documentation, the field "type" is mandatory for all components.

More details here (https://cyclonedx.org/docs/1.5/json/#components_items_type)

reviewers: @nbd168 @ynezz 