### PR TITLE
toolchain/musl: Update to 1.2.5

### DIFF
--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=elfutils
-PKG_VERSION:=0.189
+PKG_VERSION:=0.191
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceware.org/$(PKG_NAME)/ftp/$(PKG_VERSION)
-PKG_HASH:=39bd8f1a338e2b7cd4abc3ff11a0eddc6e690f69578a57478d8179b4148708c8
+PKG_HASH:=df76db71366d1d708365fc7a6c60ca48398f14367eb2b8954efc8897147ad871
 
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later

--- a/package/libs/elfutils/patches/005-build_only_libs.patch
+++ b/package/libs/elfutils/patches/005-build_only_libs.patch
@@ -7,5 +7,5 @@
 -	  libasm debuginfod src po doc tests
 +	  libasm
  
- EXTRA_DIST = elfutils.spec GPG-KEY NOTES CONTRIBUTING \
+ EXTRA_DIST = elfutils.spec GPG-KEY NOTES CONTRIBUTING SECURITY \
  	     COPYING COPYING-GPLV2 COPYING-LGPLV3

--- a/toolchain/musl/common.mk
+++ b/toolchain/musl/common.mk
@@ -8,12 +8,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=musl
-PKG_VERSION:=1.2.4
+PKG_VERSION:=1.2.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://musl.libc.org/releases/
-PKG_HASH:=7a35eae33d5372a7c0da1188de798726f68825513b7ae3ebe97aaaa52114f039
+PKG_HASH:=a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4
 PKG_CPE_ID:=cpe:/a:musl-libc:musl
 
 LIBC_SO_VERSION:=$(PKG_VERSION)

--- a/toolchain/musl/patches/900-iconv_size_hack.patch
+++ b/toolchain/musl/patches/900-iconv_size_hack.patch
@@ -6,7 +6,7 @@
  "ucs2\0\0\314"
 +#ifdef FULL_ICONV
  "eucjp\0\0\320"
- "shiftjis\0sjis\0\0\321"
+ "shiftjis\0sjis\0cp932\0\0\321"
  "iso2022jp\0\0\322"
 @@ -56,6 +57,7 @@ static const unsigned char charmaps[] =
  "gb2312\0\0\332"


### PR DESCRIPTION
Update musl C library to 1.2.5

* add `902-basename_hack.patch` to keep the declaration of 'basename'. See explanation below.
* refresh `900-iconv_size_hack.patch`

Nice that musl 1.2.5 was release released well ahead the possible branching of 24.0x, so that there is possibility to have it in main/master for some time before the next release branch.

Compiled for mediatek/filogic MT6000, compiled firmware flashed, runs ok.
Also compiled for ipq806x/generic R7800.

----------------

**Brief explanation of changes from upstream:**

This release adds extension functions statx and preadv2/pwritev2, with fallback implementations for older kernels, and adds two new ports: loongarch64 and riscv32. Minor changes to the printf family of functions have been made for conformance to new standards interpretations/requirements. TLSDESC support for riscv64 has also been added.

Bugs fixed include some DNS issues related to new TCP fallback functionality, several rare race conditions, potentially incorrect return value when glob aborts, and several signifiant arch-specific bugs affecting TLSDESC on arm, riscv64 icache flushing, and sh sigsetjmp and dlsym RTLD_NEXT.

**1.2.5 release notes:**

new features:
- statx function (linux extension; via syscall and fallback using fstatat)
- clone function is now usable and gives _Fork-like consistency in child
- statvfs now provides f_type result
- preadv2 and pwritev2 (linux extension) syscall wrappers
- riscv64 TLSDESC support

new ports:
- loongarch64
- riscv32

compatibility:
- DNS resolver can now handle answers with long CNAME chains
- string.h no longer provides (C23-incompat) non-prototype decl of basename
- fstatat statx backend now matches stat syscall non-automounting behavior
- mntent interfaces now handle escaped whitespace in paths/options

standards updates:
- printf %lc of nul wchar now produces output
- snprintf and swprintf no longer fail on n > INT_MAX
- ppoll is now exposed in default feature profile

bugs fixed:
- some long DNS answers were wrongly rejected despite new TCP support
- glob could wrongly return GLOB_NOMATCH if aborted before any matches
- multithreaded set*id could malfunction from thread sequencing logic bug
- certain use of threads after fork could deadlock thread-list lock
- posix_spawn child could deadlock in race with async parent death
- mbrtowc return value was wrong if argument n exceeded UINT_MAX
- 80-bit extended acoshl and powl got some corner cases wrong
- syslog incorrectly generated localized timestamps

arch-specific bugs fixed:
- arm (32-bit) TLSDESC malfunctioned due to addends being processed wrong
- riscv64 icache flush operation was non-functional
- sh sigsetjmp failed to properly restore call-saved register r8 on return
- sh dlsym RTLD_NEXT did not identify calling module correctly

---------------

**Reasoning for 902-basename_hack.patch:**

Upstream removed the declaration of 'baseline' from string.h with 
https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7

I noticed that some packages failed to compile due to "implicit declaration of baseline", so I added that declaration back for now.  At least elfutils  and rpcd-mod-luci failed. for that reason. In the longer run it might be better to fix the packages?   (cc @luizluca @jow- )


Example failure:

elfutils:
```
find-debuginfo.c: In function 'find_debuginfo_in_path':
find-debuginfo.c:167:58: error: implicit declaration of function 'basename' [-Werror=implicit-function-declaration]
  167 |   const char *file_basename = file_name == NULL ? NULL : basename (file_name);
      |                                                          ^~~~~~~~
find-debuginfo.c:167:56: error: pointer/integer type mismatch in conditional expression [-Werror]
  167 |   const char *file_basename = file_name == NULL ? NULL : basename (file_name);
      |                                                        ^
find-debuginfo.c:281:20: error: assignment to 'const char *' from 'int' makes pointer from integer without a cast [-Werror=int-conversion]
  281 |               file = basename (debuglink_file);
      |                    ^
find-debuginfo.c:309:32: error: passing argument 4 of 'try_open' makes pointer from integer without a cast [-Werror=int-conversion]
  309 |                                basename (file), &fname);
      |                                ^~~~~~~~~~~~~~~
      |                                |
      |                                int
find-debuginfo.c:44:60: note: expected 'const char *' but argument is of type 'int'
   44 |           const char *dir, const char *subdir, const char *debuglink,
      |                                                ~~~~~~~~~~~~^~~~~~~~~
cc1: all warnings being treated as errors
make[6]: *** [Makefile:717: find-debuginfo.o] Error 1
```

rpcd-mod-luci:

```
/Openwrt/DL-WRX36/build_dir/target-aarch64_cortex-a53_musl/rpcd-mod-luci-20230123/luci.c:676:53: error: implicit declaration of function 'basename' [-Werror=implicit-function-declaration]
  676 |                 blobmsg_add_string(&blob, "master", basename(link));
      |                                                     ^~~~~~~~
/Openwrt/DL-WRX36/build_dir/target-aarch64_cortex-a53_musl/rpcd-mod-luci-20230123/luci.c:676:53: error: passing argument 3 of 'blobmsg_add_string' makes pointer from integer without a cast [-Werror=int-conversion]
  676 |                 blobmsg_add_string(&blob, "master", basename(link));
      |                                                     ^~~~~~~~~~~~~~
      |                                                     |
      |                                                     int
In file included from /Openwrt/DL-WRX36/staging_dir/target-aarch64_cortex-a53_musl/usr/include/libubus.h:23,
                 from /Openwrt/DL-WRX36/build_dir/target-aarch64_cortex-a53_musl/rpcd-mod-luci-20230123/luci.c:43:
/Openwrt/DL-WRX36/staging_dir/target-aarch64_cortex-a53_musl/usr/include/libubox/blobmsg.h:235:72: note: expected 'const char *' but argument is of type 'int'
  235 | blobmsg_add_string(struct blob_buf *buf, const char *name, const char *string)
      |                                                            ~~~~~~~~~~~~^~~~~~
cc1: all warnings being treated as errors
ninja: build stopped: subcommand failed.
make[3]: *** [Makefile:58: /Openwrt/DL-WRX36/build_dir/target-aarch64_cortex-a53_musl/rpcd-mod-luci-20230123/.built] Error 1
```

There are likely also more packages failing similarly, but I noticed those two in my own build.
