### PR TITLE
mediatek: mt7622: expand kernel size to 6MiB for Xiaomi AX6S (RB03/RB01)

### DIFF
--- a/target/linux/mediatek/dts/mt7622-xiaomi-redmi-router-ax6s.dts
+++ b/target/linux/mediatek/dts/mt7622-xiaomi-redmi-router-ax6s.dts
@@ -300,7 +300,7 @@
 			 */
 			partition@2c0000 {
 				label = "kernel";
-				reg = <0x2c0000 0x400000>;
+				reg = <0x2c0000 0x600000>;
 			};
 
 			/* ubi partition is the result of squashing
@@ -310,9 +310,9 @@
 			 * - overlay
 			 * - obr
 			 */
-			partition@6c0000 {
+			partition@8c0000 {
 				label = "ubi";
-				reg = <0x6C0000 0x6f00000>;
+				reg = <0x8c0000 0x6d00000>;
 			};
 		};
 	};

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -461,9 +461,13 @@ define Device/xiaomi_redmi-router-ax6s
   IMAGES += factory.bin
   BLOCKSIZE := 128k
   PAGESIZE := 2048
-  KERNEL_SIZE := 4096k
+  KERNEL_SIZE := 6144k
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := Partition table has been changed due to kernel size restrictions. \
+	Please upgrade firmware manually using factory.bin image! \
+	(Warning: your configurations will be erased!)
 endef
-# TARGET_DEVICES += xiaomi_redmi-router-ax6s
+TARGET_DEVICES += xiaomi_redmi-router-ax6s

--- a/target/linux/mediatek/mt7622/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/mediatek/mt7622/base-files/etc/uci-defaults/05_fix-compat-version
@@ -13,6 +13,10 @@ case "$(board_name)" in
 	uci set system.@system[0].compat_version="2.0"
 	uci commit system
 	;;
+	xiaomi,redmi-router-ax6s)
+		uci set system.@system[0].compat_version="1.1"
+		uci commit system
+	;;
 esac
 
 exit 0


### PR DESCRIPTION
Expand kernel partition size on Xiaomi AX6S for the kernel larger than 4 MiB.
To prevent upgrading from old firmware before this commit, bump the compat version to 1.1

Manual upgrade from OpenWRT to new OpenWRT:
```
cd /tmp
dd if=factory.bin bs=1M count=4 | mtd write - kernel
dd if=factory.bin bs=1M skip=4 count=2 | mtd write - ubi
dd if=factory.bin bs=1M skip=6  | mtd -p 2097152 write - ubi
echo c > /proc/sysrq-trigger
```

OpenWRT install under Stock firmware:
1) XMiR-Patcher
2) https://openwrt.org/toh/xiaomi/ax3200#installation