### PR TITLE
ramips: Added D-Link DIR-615 H/V ver.P1

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -476,7 +476,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"4:lan:1" "2:lan:2" "0:wan" "6@eth0"
 		;;
-	zyxel,keenetic-start)
+	zyxel,keenetic-start|\
+	dir-615-p1)
 		ucidef_add_switch "switch0" \
 			"0:lan:3" "1:lan:2" "2:lan:1" "3:lan:0" "4:wan" "6@eth0"
 		;;

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -145,6 +145,9 @@ ramips_board_detect() {
 	*"DIR-615 H1")
 		name="dir-615-h1"
 		;;
+	*"DIR-615 P1")
+		name="dir-615-p1"
+		;;
 	*"DIR-620 A1")
 		name="dir-620-a1"
 		;;

--- a/target/linux/ramips/dts/DIR-615-P1.dts
+++ b/target/linux/ramips/dts/DIR-615-P1.dts
@@ -1,0 +1,113 @@
+/dts-v1/;
+
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dir-615-p1", "ralink,mt7620n-soc";
+	model = "Dlink DIR-615 P1";
+	
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+	
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "dir-615:green:power";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+	mediatek,portmap = "wllll";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "ephy", "wled", "pa", "i2c", "wdt", "uartf";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "mx25l6405d","jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -189,6 +189,14 @@ define Device/dch-m225
 endef
 TARGET_DEVICES += dch-m225
 
+define Device/dlink_dir-615-p1
+  DTS := DIR-615-P1
+  SUPPORTED_DEVICES := dir-615-p1
+  DEVICE_TITLE := D-Link DIR-615 P1
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += dlink_dir-615-p1
+
 define Device/dir-810l
   DTS := DIR-810L
   DEVICE_PACKAGES := kmod-mt76x0e


### PR DESCRIPTION
Added support for D-Link DIR-615 H/V ver.P1 8MB/32MB. 
The changes were made in the branch on 19.07.
Since "OpenWRT support for 4/32 devices has ended in 2022. v19.07.10 was the last official build for 4/32 devices.
Performance was checked on v19.07.10. by downloading openwrt-ramips-mt7620-dlink_dir-615-p1-squashfs-sysupgrade.bin via TFTP.
