### PR TITLE
mediatek: Add a second u-boot for Redmi AX6S

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -171,6 +171,14 @@ define U-Boot/mt7622_ubnt_unifi-6-lr-v3
   FIP_COMPRESS:=1
 endef
 
+define U-Boot/mt7622_xiaomi_redmi-router-ax6s-ubi-loader
+  NAME:=Xiaomi Redmi Router AX6S (as UBI loader)
+  UBOOT_CONFIG:=mt7622_xiaomi_redmi-router-ax6s-ubi-loader
+  BUILD_DEVICES:=xiaomi_redmi-router-ax6s
+  BUILD_SUBTARGET:=mt7622
+  UBOOT_IMAGE:=u-boot.bin
+endef
+
 define U-Boot/mt7623a_unielec_u7623
   NAME:=UniElec U7623 (mt7623)
   BUILD_DEVICES:=unielec_u7623-02
@@ -635,6 +643,7 @@ UBOOT_TARGETS := \
 	mt7622_ubnt_unifi-6-lr-v1 \
 	mt7622_ubnt_unifi-6-lr-v2 \
 	mt7622_ubnt_unifi-6-lr-v3 \
+  mt7622_xiaomi_redmi-router-ax6s-ubi-loader \
 	mt7623n_bpir2 \
 	mt7623a_unielec_u7623 \
 	mt7628_rfb \

--- a/package/boot/uboot-mediatek/patches/100-02-drivers-mtd-add-support-for-MediaTek-SPI-NAND-flash-.patch
+++ b/package/boot/uboot-mediatek/patches/100-02-drivers-mtd-add-support-for-MediaTek-SPI-NAND-flash-.patch
@@ -783,7 +783,7 @@ Signed-off-by: Weijie Gao <weijie.gao@mediatek.com>
 +}
 --- /dev/null
 +++ b/drivers/mtd/mtk-snand/mtk-snand-ids.c
-@@ -0,0 +1,515 @@
+@@ -0,0 +1,519 @@
 +// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 +/*
 + * Copyright (C) 2020 MediaTek Inc. All Rights Reserved.
@@ -900,6 +900,10 @@ Signed-off-by: Weijie Gao <weijie.gao@mediatek.com>
 +	SNAND_INFO("GD5F1GQ4xAYIG", SNAND_ID(SNAND_ID_ADDR, 0xc8, 0xf1),
 +		   SNAND_MEMORG_1G_2K_64,
 +		   &snand_cap_read_from_cache_quad_q2d,
++		   &snand_cap_program_load_x4),
++	SNAND_INFO("GD5F1GQ5UExxG", SNAND_ID(SNAND_ID_ADDR, 0xc8, 0x51),
++		   SNAND_MEMORG_1G_2K_128,
++		   &snand_cap_read_from_cache_quad,
 +		   &snand_cap_program_load_x4),
 +	SNAND_INFO("GD5F2GQ4UExIG", SNAND_ID(SNAND_ID_ADDR, 0xc8, 0xd2),
 +		   SNAND_MEMORG_2G_2K_128,

--- a/package/boot/uboot-mediatek/patches/452-add-xiaomi-redmi-ax6s.patch
+++ b/package/boot/uboot-mediatek/patches/452-add-xiaomi-redmi-ax6s.patch
@@ -1,0 +1,320 @@
+From 57dc777bddf0baf3c27177576c40b5113309ce54 Mon Sep 17 00:00:00 2001
+From: Chuanhong Guo <gch981213@gmail.com>
+Date: Sat, 2 Mar 2024 20:30:16 +0800
+Subject: [PATCH] add xiaomi redmi ax6s
+
+---
+ arch/arm/dts/Makefile                         |   1 +
+ .../dts/mt7622-xiaomi-redmi-router-ax6s.dts   | 166 ++++++++++++++++++
+ ...omi_redmi-router-ax6s-ubi-loader_defconfig |  98 +++++++++++
+ xiaomi-redmi-router-ax6s-ubi-loader_env       |  22 +++
+ 4 files changed, 287 insertions(+)
+ create mode 100644 arch/arm/dts/mt7622-xiaomi-redmi-router-ax6s.dts
+ create mode 100644 configs/mt7622_xiaomi_redmi-router-ax6s-ubi-loader_defconfig
+ create mode 100644 xiaomi-redmi-router-ax6s-ubi-loader_env
+
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -1425,6 +1425,7 @@ dtb-$(CONFIG_ARCH_MEDIATEK) += \
+ 	mt7622-linksys-e8450-ubi.dtb \
+ 	mt7622-ubnt-unifi-6-lr.dtb \
+ 	mt7622-ubnt-unifi-6-lr-v3.dtb \
++	mt7622-xiaomi-redmi-router-ax6s.dtb \
+ 	mt7623n-bananapi-bpi-r2.dtb \
+ 	mt7629-rfb.dtb \
+ 	mt7981-rfb.dtb \
+--- /dev/null
++++ b/arch/arm/dts/mt7622-xiaomi-redmi-router-ax6s.dts
+@@ -0,0 +1,166 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++
++/dts-v1/;
++#include <dt-bindings/input/linux-event-codes.h>
++#include <dt-bindings/leds/common.h>
++#include "mt7622.dtsi"
++#include "mt7622-u-boot.dtsi"
++
++/ {
++	#address-cells = <1>;
++	#size-cells = <1>;
++	model = "Xiaomi Redmi Router AX6S";
++	compatible = "xiaomi,redmi-router-ax6s", "mediatek,mt7622";
++
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	aliases {
++		spi0 = &snand;
++		ethernet0 = &eth;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x40000000 0x8000000>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led_power_blue: power_blue {
++			function = LED_FUNCTION_POWER;
++			color = <LED_COLOR_ID_BLUE>;
++			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
++		};
++
++		led_power_amber: power_amber {
++			function = LED_FUNCTION_POWER;
++			color = <LED_COLOR_ID_AMBER>;
++			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
++		};
++
++		led_net_blue: net_blue {
++			label = "blue:net";
++			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
++		};
++
++		led_net_amber: net_amber {
++			label = "amber:net";
++			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
++		};
++
++	};
++
++	keys {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "reset";
++			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_RESTART>;
++		};
++
++		mesh {
++			label = "mesh";
++			gpios = <&gpio 102 GPIO_ACTIVE_LOW>;
++			linux,code = <BTN_9>;
++			linux,input-type = <EV_SW>;
++		};
++	};
++
++	reg_1p8v: regulator-1p8v {
++		compatible = "regulator-fixed";
++		regulator-name = "fixed-1.8V";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	reg_3p3v: regulator-3p3v {
++		compatible = "regulator-fixed";
++		regulator-name = "fixed-3.3V";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-boot-on;
++		regulator-always-on;
++	};
++};
++
++&pcie {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie0_pins>;
++	status = "okay";
++
++	pcie@0,0 {
++		status = "okay";
++	};
++};
++
++&pinctrl {
++	pcie0_pins: pcie0-pins {
++		mux {
++			function = "pcie";
++			groups = "pcie0_pad_perst",
++				 "pcie0_1_waken",
++				 "pcie0_1_clkreq";
++		};
++	};
++
++	snfi_pins: snfi-pins {
++		mux {
++			function = "flash";
++			groups = "snfi";
++		};
++	};
++
++	uart0_pins: uart0 {
++		mux {
++			function = "uart";
++			groups = "uart0_0_tx_rx" ;
++		};
++	};
++
++	watchdog_pins: watchdog-default {
++		mux {
++			function = "watchdog";
++			groups = "watchdog";
++		};
++	};
++};
++
++&snand {
++	pinctrl-names = "default";
++	pinctrl-0 = <&snfi_pins>;
++	quad-spi;
++	status = "okay";
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_pins>;
++	mediatek,force-highspeed;
++	status = "okay";
++};
++
++&watchdog {
++	pinctrl-names = "default";
++	pinctrl-0 = <&watchdog_pins>;
++	status = "okay";
++};
++
++&eth {
++	status = "okay";
++	mediatek,gmac-id = <0>;
++	phy-mode = "2500base-x";
++	mediatek,switch = "mt7531";
++	reset-gpios = <&gpio 54 GPIO_ACTIVE_HIGH>;
++
++	fixed-link {
++		speed = <2500>;
++		full-duplex;
++	};
++};
+--- /dev/null
++++ b/configs/mt7622_xiaomi_redmi-router-ax6s-ubi-loader_defconfig
+@@ -0,0 +1,98 @@
++CONFIG_ARM=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7622-xiaomi-redmi-router-ax6s"
++CONFIG_PRE_CON_BUF_ADDR=0x4007EF00
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=25000000
++CONFIG_SYS_LOAD_ADDR=0x40080000
++CONFIG_PCI=y
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_BOOTDELAY=30
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_DEFAULT_FDT_FILE="mediatek/mt7622-xiaomi-redmi-router-ax6s"
++CONFIG_LOGLEVEL=7
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_LOG=y
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_LAST_STAGE_INIT=y
++CONFIG_HUSH_PARSER=y
++# CONFIG_AUTO_COMPLETE is not set
++CONFIG_SYS_PROMPT="MT7622> "
++CONFIG_CMD_LICENSE=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++# CONFIG_CMD_UNLZ4 is not set
++# CONFIG_CMD_UNZIP is not set
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_MTD=y
++# CONFIG_CMD_BOOTP is not set
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_FS_GENERIC=y
++CONFIG_CMD_FS_UUID=y
++CONFIG_CMD_MTDPARTS=y
++CONFIG_MTDPARTS_DEFAULT="mtdparts=spi-nand0:512k(preloader),2816k(reserved),117248k(ubi)"
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_DOS_PARTITION=y
++CONFIG_EFI_PARTITION=y
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_USE_DEFAULT_ENV_FILE=y
++CONFIG_DEFAULT_ENV_FILE="xiaomi-redmi-router-ax6s-ubi-loader_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_PROT_UDP=y
++CONFIG_BOOTP_SEND_HOSTNAME=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_NETCONSOLE=y
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_GPIO_HOG=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTK_SPI_NAND=y
++CONFIG_MTK_SPI_NAND_MTD=y
++CONFIG_UBI_SILENCE_MSG=y
++CONFIG_MTD_UBI_FASTMAP=y
++CONFIG_PHY_FIXED=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PCIE_MEDIATEK=y
++CONFIG_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7622=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_RAM=y
++CONFIG_DM_SERIAL=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_UBIFS_SILENCE_MSG=y
++CONFIG_LZ4=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
+--- /dev/null
++++ b/xiaomi-redmi-router-ax6s-ubi-loader_env
+@@ -0,0 +1,22 @@
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x46000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootled_pwr=power_blue
++bootled_rec=power_amber
++bootcmd=run boot_or_recovery
++bootconf=config-1
++bootdelay=0
++bootfile=openwrt-mediatek-mt7622-xiaomi_redmi-router-ax6s-initramfs-recovery.itb
++bootfile_upg=openwrt-mediatek-mt7622-xiaomi_redmi-router-ax6s-squashfs-sysupgrade.itb
++boot_or_recovery=run boot_production ; led $bootled_pwr off ; led $bootled_rec on ; if ubi check fit ; then run boot_tftp_forever ; else run tftp_production ; fi
++boot_tftp=tftpboot $loadaddr $bootfile && bootm $loadaddr#$bootconf
++boot_tftp_forever=while true ; do run boot_tftp ; sleep 1 ; done
++boot_production=run ubi_read_production && bootm $loadaddr#$bootconf
++ubi_format=ubi detach ; mtd erase ubi && ubi part ubi
++ubi_init=ubi part ubi || run ubi_format
++ubi_prepare_rootfs=if ubi check rootfs_data ; then else if env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi ; fi
++ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++ubi_write_production=ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic 2 && ubi write $loadaddr fit $filesize
++ubi_read_production=run ubi_init && ubi read $loadaddr fit && iminfo $loadaddr && run ubi_prepare_rootfs
++tftp_production=tftpboot $loadaddr $bootfile_upg && iminfo $loadaddr && run ubi_write_production && reset

--- a/target/linux/mediatek/dts/mt7622-xiaomi-redmi-router-ax6s.dts
+++ b/target/linux/mediatek/dts/mt7622-xiaomi-redmi-router-ax6s.dts
@@ -22,7 +22,8 @@
 
 	chosen {
 		stdout-path = "serial0:115200n8";
-		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8 swiotlb=512";
+		rootdisk = <&ubi_rootfs>;
+		bootargs = "earlycon=uart8250,mmio32,0x11002000 swiotlb=512 ubi.block=0,fit root=/dev/fit0";
 	};
 
 	memory {
@@ -230,7 +231,7 @@
 
 		mediatek,bmt-v2;
 		mediatek,bmt-table-size = <0x1000>;
-		mediatek,bmt-remap-range = <0x0 0x6c0000>;
+		mediatek,bmt-remap-range = <0x0 0x340000>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -295,12 +296,9 @@
 				read-only;
 			};
 
-			/* Shrunk and renamed from "firmware"
-			 * as to not break luci size checks
-			 */
 			partition@2c0000 {
-				label = "kernel";
-				reg = <0x2c0000 0x400000>;
+				label = "ubi-loader";
+				reg = <0x2c0000 0x80000>;
 			};
 
 			/* ubi partition is the result of squashing
@@ -310,9 +308,16 @@
 			 * - overlay
 			 * - obr
 			 */
-			partition@6c0000 {
+			partition@340000 {
 				label = "ubi";
-				reg = <0x6C0000 0x6f00000>;
+				reg = <0x340000 0x7280000>;
+				compatible = "linux,ubi";
+
+				volumes {
+					ubi_rootfs: ubi-volume-fit {
+						volname = "fit";
+					};
+				};
 			};
 		};
 	};

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -37,6 +37,21 @@ define Build/bl31-uboot
 	cat $(STAGING_DIR_IMAGE)/mt7622_$1-u-boot.fip >> $@
 endef
 
+define Build/uboot-bin
+	cat $(STAGING_DIR_IMAGE)/mt7622_$1-u-boot.bin >> $@
+endef
+
+define Build/uboot-fit
+	$(TOPDIR)/scripts/mkits.sh \
+		-D $(DEVICE_NAME) -o $@.its -k $@ \
+		-C $(word 1,$(1)) \
+		-a 0x41e00000 -e 0x41e00000 \
+		-c "config-1" \
+		-A $(LINUX_KARCH) -v u-boot
+	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
+	@mv $@.new $@
+endef
+
 # Append header to a D-Link M32/R32 Kernel 1 partition
 define Build/m32-r32-recovery-header-kernel1
 	$(eval header_start=$(word 1,$(1)))
@@ -458,12 +473,20 @@ define Device/xiaomi_redmi-router-ax6s
   BOARD_NAME := xiaomi,redmi-router-ax6s
   DEVICE_PACKAGES := kmod-mt7915-firmware
   UBINIZE_OPTS := -E 5
-  IMAGES += factory.bin
   BLOCKSIZE := 128k
   PAGESIZE := 2048
-  KERNEL_SIZE := 4096k
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGES := sysupgrade.itb
+  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+  ARTIFACTS := ubi-loader.itb
+  ARTIFACT/ubi-loader.itb := uboot-bin xiaomi_redmi-router-ax6s-ubi-loader | lzma | uboot-fit lzma
+ifneq ($(CONFIG_TARGET_ROOTFS_SQUASHFS),)
+  ARTIFACTS += factory.bin
+  ARTIFACT/factory.bin := uboot-bin xiaomi_redmi-router-ax6s-ubi-loader | lzma | uboot-fit lzma | pad-to 512k | ubinize-image fit squashfs-sysupgrade.itb
+endif
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := SPI-NAND flash layout changes require bootloader update
 endef
-# TARGET_DEVICES += xiaomi_redmi-router-ax6s
+TARGET_DEVICES += xiaomi_redmi-router-ax6s

--- a/target/linux/mediatek/mt7622/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/mediatek/mt7622/base-files/etc/uci-defaults/05_fix-compat-version
@@ -9,7 +9,8 @@ case "$(board_name)" in
 	uci set system.@system[0].compat_version="1.1"
 	uci commit system
 	;;
-	linksys,e8450-ubi)
+	linksys,e8450-ubi|\
+	xiaomi,redmi-router-ax6s)
 	uci set system.@system[0].compat_version="2.0"
 	uci commit system
 	;;

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
@@ -10,7 +10,8 @@ platform_do_upgrade() {
 	linksys,e8450-ubi|\
 	ubnt,unifi-6-lr-v1-ubootmod|\
 	ubnt,unifi-6-lr-v2-ubootmod|\
-	ubnt,unifi-6-lr-v3-ubootmod)
+	ubnt,unifi-6-lr-v3-ubootmod|\
+	xiaomi,redmi-router-ax6s)
 		[ -e /dev/fit0 ] && fitblk /dev/fit0
 		[ -e /dev/fitrw ] && fitblk /dev/fitrw
 		bootdev="$(fitblk_get_bootdev)"
@@ -48,8 +49,7 @@ platform_do_upgrade() {
 	elecom,wrc-x3200gst3|\
 	mediatek,mt7622-rfb1-ubi|\
 	netgear,wax206|\
-	totolink,a8000ru|\
-	xiaomi,redmi-router-ax6s)
+	totolink,a8000ru)
 		nand_do_upgrade "$1"
 		;;
 	linksys,e8450)
@@ -84,8 +84,7 @@ platform_check_image() {
 	elecom,wrc-x3200gst3|\
 	mediatek,mt7622-rfb1-ubi|\
 	netgear,wax206|\
-	totolink,a8000ru|\
-	xiaomi,redmi-router-ax6s)
+	totolink,a8000ru)
 		nand_do_platform_check "$board" "$1"
 		return $?
 		;;


### PR DESCRIPTION
The vendor u-boot knows nothing about UBI, and we used to have a fixed-size kernel partition for vendor u-boot and UBI for rootfs. However, that fixed partition becomes too small eventually, and expanding it requires complicated procedure.

This commit changed the flash layout and added a second u-boot where the kernel supposed to be.
Now the vendor u-boot chainloads our mainline u-boot, and our u-boot reads kernel+rootfs from UBI, verifies it, and boot into OpenWrt.

Converting from old layout:
1. prepare a tftp server at 192.168.1.254 to serve the sysupgrade image:
   openwrt-mediatek-mt7622-xiaomi_redmi-router-ax6s-squashfs-sysupgrade.itb

2. upload the ubi-loader.itb to OpenWrt /tmp, and flash it to the old kernel partition:
   mtd -r write openwrt-mediatek-mt7622-xiaomi_redmi-router-ax6s-ubi-loader.itb
3. The router should reboot and flash the sysupgrade image via TFTP.

Flashing from vendor firmware should go like this:
1. set environment to boot from the first firmware partition
2. flash ubi-loader.itb into the first firmware
3. reboot, and u-boot should tftp & flash OpenWrt from 192.168.1.254 like mentioned above.

Help wanted:
This entire PR is made on a different board with a Xiaomi u-boot dump. It's not tested on a real Redmi-AX6S.
It would be great if someone with serial console access can:
1. Test this PR.
4. write a new flash instruction for flashing from vendor firmware.
