### PR TITLE
linux-firmware: package Intel AX201 firmware

### DIFF
--- a/package/firmware/linux-firmware/intel.mk
+++ b/package/firmware/linux-firmware/intel.mk
@@ -184,6 +184,13 @@ define Package/iwlwifi-firmware-ax200/install
 endef
 $(eval $(call BuildPackage,iwlwifi-firmware-ax200))
 
+Package/iwlwifi-firmware-ax201 = $(call Package/firmware-default,Intel AX201 firmware)
+define Package/iwlwifi-firmware-ax201/install
+	$(INSTALL_DIR) $(1)/lib/firmware
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-QuZ-a0-hr-b0-77.ucode $(1)/lib/firmware
+endef
+$(eval $(call BuildPackage,iwlwifi-firmware-ax201))
+
 Package/iwlwifi-firmware-ax210 = $(call Package/firmware-default,Intel AX210 firmware)
 define Package/iwlwifi-firmware-ax210/install
 	$(INSTALL_DIR) $(1)/lib/firmware


### PR DESCRIPTION
Alexander reported following:

```
 iwlwifi 0000:00:14.3: Detected crf-id 0x3617, cnv-id 0x20000302 wfpm id 0x80000000
 iwlwifi 0000:00:14.3: PCI dev a0f0/0074, rev=0x351, rfid=0x10a100
 iwlwifi 0000:00:14.3: Direct firmware load for iwlwifi-QuZ-a0-hr-b0-77.ucode failed with error -2
```

It seems, that as of the current date, the highest firmware API version supported by Linux 6.8-rc7 is still 77.

Closes: #14771