### PR TITLE
ath79: add HS UART to QCA955x and enable on ELECOM WAB-I1750-PS

### DIFF
--- a/target/linux/ath79/dts/qca9556_mikrotik_routerboard-wap-g-5hact2hnd.dts
+++ b/target/linux/ath79/dts/qca9556_mikrotik_routerboard-wap-g-5hact2hnd.dts
@@ -11,7 +11,6 @@
 
 	aliases {
 		mdio-gpio1 = &mdio2;
-		serial0 = &uart;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/qca9557_meraki_mr18.dts
+++ b/target/linux/ath79/dts/qca9557_meraki_mr18.dts
@@ -171,10 +171,6 @@
 	};
 };
 
-&uart {
-	status = "okay";
-};
-
 &mdio0 {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9558_comfast_cf-e380ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_comfast_cf-e380ac-v2.dts
@@ -11,7 +11,6 @@
 	model = "COMFAST CF-E380AC";
 
 	aliases {
-		serial0 = &uart;
 		label-mac-device = &eth1;
 		led-boot = &led_lan;
 		led-failsafe = &led_lan;

--- a/target/linux/ath79/dts/qca9558_dlink_dir-629-a1.dts
+++ b/target/linux/ath79/dts/qca9558_dlink_dir-629-a1.dts
@@ -16,7 +16,6 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
-		serial0 = &uart;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/qca9558_elecom_wab-i1750-ps.dts
+++ b/target/linux/ath79/dts/qca9558_elecom_wab-i1750-ps.dts
@@ -5,29 +5,6 @@
 / {
 	compatible = "elecom,wab-i1750-ps", "qca,qca9558";
 	model = "ELECOM WAB-I1750-PS";
-
-	ahb {
-		apb {
-			/* "SERIAL" port (RJ-45) on the case */
-			uart1: uart@18500000 {
-				compatible = "qca,ar9330-uart";
-				reg = <0x18500000 0x14>;
-
-				pinctrl-names = "default";
-				pinctrl-0 = <&pmx_uart1_in_pins &pmx_uart1_out_pins
-					     &jtag_disable_pins>;
-
-				interrupts = <6>;
-				interrupt-parent = <&miscintc>;
-
-				clocks = <&pll ATH79_CLK_UART1>;
-				clock-names = "uart";
-
-				/* QCA955x HS UART is not supported */
-				status = "disabled";
-			};
-		};
-	};
 };
 
 &gpio {
@@ -66,4 +43,12 @@
 		 */
 		pinctrl-single,bits = <0x3c 0x3010000 0xffff0000>;
 	};
+};
+
+/* "SERIAL" port (RJ-45) on the case */
+&uart1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pmx_uart1_in_pins &pmx_uart1_out_pins
+		     &jtag_disable_pins>;
+	status = "okay";
 };

--- a/target/linux/ath79/dts/qca9558_mikrotik_routerboard-92x.dtsi
+++ b/target/linux/ath79/dts/qca9558_mikrotik_routerboard-92x.dtsi
@@ -10,7 +10,6 @@
 		led-boot = &led_user;
 		led-failsafe = &led_user;
 		led-upgrade = &led_user;
-		serial0 = &uart;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/qca9558_mikrotik_routerboard-96x.dtsi
+++ b/target/linux/ath79/dts/qca9558_mikrotik_routerboard-96x.dtsi
@@ -10,7 +10,6 @@
 		led-boot = &led_user;
 		led-failsafe = &led_user;
 		led-upgrade = &led_user;
-		serial0 = &uart;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/qca9558_openmesh_a60.dtsi
+++ b/target/linux/ath79/dts/qca9558_openmesh_a60.dtsi
@@ -12,7 +12,6 @@
 	};
 
 	aliases {
-		serial0 = &uart;
 		led-boot = &led_status_green;
 		led-failsafe = &led_status_green;
 		led-running = &led_status_green;

--- a/target/linux/ath79/dts/qca9558_openmesh_mr.dtsi
+++ b/target/linux/ath79/dts/qca9558_openmesh_mr.dtsi
@@ -12,7 +12,6 @@
 	};
 
 	aliases {
-		serial0 = &uart;
 		led-boot = &led_power_blue;
 		led-failsafe = &led_power_blue;
 		led-running = &led_power_blue;

--- a/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v1.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v1.dts
@@ -15,7 +15,6 @@
 	};
 
 	aliases {
-		serial0 = &uart;
 		led-boot = &led_power_blue;
 		led-failsafe = &led_power_blue;
 		led-running = &led_power_blue;

--- a/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
@@ -15,7 +15,6 @@
 	};
 
 	aliases {
-		serial0 = &uart;
 		led-boot = &led_power_blue;
 		led-failsafe = &led_power_blue;
 		led-running = &led_power_blue;

--- a/target/linux/ath79/dts/qca955x.dtsi
+++ b/target/linux/ath79/dts/qca955x.dtsi
@@ -8,6 +8,11 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
+	aliases {
+		serial0 = &uart0;
+		serial1 = &uart1;
+	};
+
 	chosen {
 		bootargs = "console=ttyS0,115200n8";
 	};

--- a/target/linux/ath79/dts/qca955x.dtsi
+++ b/target/linux/ath79/dts/qca955x.dtsi
@@ -178,6 +178,18 @@
 
 				#reset-cells = <1>;
 			};
+
+			uart1: uart@18500000 {
+				compatible = "qca,ar9330-uart";
+				reg = <0x18500000 0x14>;
+
+				interrupts = <6>;
+
+				clocks = <&pll ATH79_CLK_REF>;
+				clock-names = "uart";
+
+				status = "disabled";
+			};
 		};
 
 		gmac: gmac@18070000 {

--- a/target/linux/ath79/dts/qca955x.dtsi
+++ b/target/linux/ath79/dts/qca955x.dtsi
@@ -41,7 +41,7 @@
 				#qca,ddr-wb-channel-cells = <1>;
 			};
 
-			uart: uart@18020000 {
+			uart0: uart@18020000 {
 				compatible = "ns16550a";
 				reg = <0x18020000 0x20>;
 

--- a/target/linux/ath79/dts/qca955x_elecom_wab.dtsi
+++ b/target/linux/ath79/dts/qca955x_elecom_wab.dtsi
@@ -227,10 +227,6 @@
 	};
 };
 
-&uart {
-	status = "okay";
-};
-
 &usb_phy0 {
 	status = "okay";
 };


### PR DESCRIPTION
This patch series adds HighSpeed UART support to QCA955x SoCs and enables it on ELECOM WAB-I1750-PS.