### PR TITLE
mediatek: convert LED color/function format for Xiaomi Redmi AX6000

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
@@ -2,6 +2,7 @@
 
 /dts-v1/;
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/leds/common.h>
 
@@ -202,11 +203,18 @@
 
 		led_status_rgb: led@0 {
 			reg = <0>;
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RGB>;
 			color-index = <LED_COLOR_ID_RED LED_COLOR_ID_GREEN LED_COLOR_ID_BLUE>;
 		};
 
 		led_network_rgb: led@1 {
 			reg = <1>;
+
+			/* Hardcoding here for backward compatibility */
+			function = "network";
+
+			color = <LED_COLOR_ID_RGB>;
 			color-index = <LED_COLOR_ID_RED LED_COLOR_ID_GREEN LED_COLOR_ID_BLUE>;
 		};
 	};


### PR DESCRIPTION
Commit 2d63d42f5e2f ("mediatek: convert to new LED color/function format where possible") leaves Xiaomi Redmi AX6000 un-converted, the two LEDs become dead.
Now, LEDs are alive again.

Fixes: 2d63d42f5e2f ("mediatek: convert to new LED color/function format where possible")

Run-tested: filogic/mt7986a-xiaomi-redmi-router-ax6000-ubootmod