### PR TITLE
kernel: Avoid marking flow with sack-unacked packets as retransmit in ct

### DIFF
--- a/package/kernel/linux/files/sysctl-nf-conntrack.conf
+++ b/package/kernel/linux/files/sysctl-nf-conntrack.conf
@@ -3,6 +3,7 @@
 
 net.netfilter.nf_conntrack_acct=1
 net.netfilter.nf_conntrack_checksum=0
+net.netfilter.nf_conntrack_tcp_max_retrans=5
 net.netfilter.nf_conntrack_tcp_timeout_established=7440
 net.netfilter.nf_conntrack_udp_timeout=60
 net.netfilter.nf_conntrack_udp_timeout_stream=180


### PR DESCRIPTION
Kernel does counting of packets after ack packet and on param-th packet it marks flow with (lower) re-transmit timeout. Push the threshold past 4 data packets before sack is expected and dont wrongly interpret first-time data
  packets as retransmits.

Ref: linux/net/netfilter/nf_conntrack_proto_tcp.c

Signed-off-by: Andris PE <neandris@gmail.com>