### PR TITLE
wifi-scripts: save wpa_psk_file on permanent storage by default

### DIFF
--- a/package/network/config/wifi-scripts/Makefile
+++ b/package/network/config/wifi-scripts/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wifi-scripts
 PKG_VERSION:=1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>

--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -689,7 +689,10 @@ hostapd_set_bss_options() {
 			fi
 			[ -z "$wpa_psk_file" ] && set_default wpa_psk_file /var/run/hostapd-$ifname.psk
 			[ -n "$wpa_psk_file" ] && {
-				[ -e "$wpa_psk_file" ] || touch "$wpa_psk_file"
+				[ -e "$wpa_psk_file" ] || {
+					touch "$wpa_psk_file"
+					chown network:network "$wpa_psk_file"
+				}
 				append bss_conf "wpa_psk_file=$wpa_psk_file" "$N"
 			}
 			[ "$eapol_version" -ge "1" -a "$eapol_version" -le "2" ] && append bss_conf "eapol_version=$eapol_version" "$N"

--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -687,7 +687,14 @@ hostapd_set_bss_options() {
 				wireless_setup_vif_failed INVALID_WPA_PSK
 				return 1
 			fi
-			[ -z "$wpa_psk_file" ] && set_default wpa_psk_file /var/run/hostapd-$ifname.psk
+			[ -z "$wpa_psk_file" ] && {
+				[ -d /etc/hostapd ] || {
+					mkdir /etc/hostapd
+					chown network:netwrok /etc/hostapd
+				}
+				set_default wpa_psk_file /etc/hostapd/hostapd-$ifname.psk
+				ln -s /etc/hostapd/hostapd-$ifname.psk /var/run/hostapd-$ifname.psk
+			}
 			[ -n "$wpa_psk_file" ] && {
 				[ -e "$wpa_psk_file" ] || {
 					touch "$wpa_psk_file"

--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git
@@ -679,23 +679,39 @@ define Install/hostapd/full
 	$(INSTALL_DATA) ./files/radius.users $(1)/etc/radius/users
 endef
 
+define Package/hostapd/conffiles
+/etc/hostapd
+endef
+
+Package/wpad-mesh-openssl/conffiles = $(Package/hostapd/conffiles)
+Package/wpad-mesh-wolfssl/conffiles = $(Package/hostapd/conffiles)
+Package/wpad-mesh-mbedtls/conffiles = $(Package/hostapd/conffiles)
+Package/wpad/conffiles = $(Package/hostapd/conffiles)
+Package/wpad-openssl/conffiles = $(Package/hostapd/conffiles)
+Package/wpad-wolfssl/conffiles = $(Package/hostapd/conffiles)
+Package/wpad-mbedtls/conffiles = $(Package/hostapd/conffiles)
+Package/hostapd-openssl/conffiles = $(Package/hostapd/conffiles)
+Package/hostapd-wolfssl/conffiles = $(Package/hostapd/conffiles)
+Package/hostapd-mbedtls/conffiles = $(Package/hostapd/conffiles)
+
 define Package/hostapd-full/conffiles
+$(Package/hostapd/conffiles)
 /etc/config/radius
 /etc/radius
 endef
 
 ifeq ($(CONFIG_VARIANT),full)
-Package/wpad-mesh-openssl/conffiles = $(Package/hostapd-full/conffiles)
-Package/wpad-mesh-wolfssl/conffiles = $(Package/hostapd-full/conffiles)
-Package/wpad-mesh-mbedtls/conffiles = $(Package/hostapd-full/conffiles)
-Package/wpad/conffiles = $(Package/hostapd-full/conffiles)
-Package/wpad-openssl/conffiles = $(Package/hostapd-full/conffiles)
-Package/wpad-wolfssl/conffiles = $(Package/hostapd-full/conffiles)
-Package/wpad-mbedtls/conffiles = $(Package/hostapd-full/conffiles)
-Package/hostapd/conffiles = $(Package/hostapd-full/conffiles)
-Package/hostapd-openssl/conffiles = $(Package/hostapd-full/conffiles)
-Package/hostapd-wolfssl/conffiles = $(Package/hostapd-full/conffiles)
-Package/hostapd-mbedtls/conffiles = $(Package/hostapd-full/conffiles)
+Package/wpad-mesh-openssl/conffiles += $(Package/hostapd-full/conffiles)
+Package/wpad-mesh-wolfssl/conffiles += $(Package/hostapd-full/conffiles)
+Package/wpad-mesh-mbedtls/conffiles += $(Package/hostapd-full/conffiles)
+Package/wpad/conffiles += $(Package/hostapd-full/conffiles)
+Package/wpad-openssl/conffiles += $(Package/hostapd-full/conffiles)
+Package/wpad-wolfssl/conffiles += $(Package/hostapd-full/conffiles)
+Package/wpad-mbedtls/conffiles += $(Package/hostapd-full/conffiles)
+Package/hostapd/conffiles += $(Package/hostapd-full/conffiles)
+Package/hostapd-openssl/conffiles += $(Package/hostapd-full/conffiles)
+Package/hostapd-wolfssl/conffiles += $(Package/hostapd-full/conffiles)
+Package/hostapd-mbedtls/conffiles += $(Package/hostapd-full/conffiles)
 endif
 
 define Install/hostapd


### PR DESCRIPTION
Hostapd require access to the wpa_psk_file to insert data in the context
of WPS usage.

From hostapd.conf documentation:
  Note: If wpa_psk_file is set, WPS is used to generate random, per-device PSKs
  that will be appended to the wpa_psk_file. If wpa_psk_file is not set, the
  default PSK (wpa_psk/wpa_passphrase) will be delivered to Enrollees. Use of
  per-device PSKs is recommended as the more secure option (i.e., make sure to
  set wpa_psk_file when using WPS with WPA-PSK).

Since we set the option by default, we involuntary enabled also this WPS
feature, that was broken all this time because we create the
wpa_psk_file as root and hostapd doesn't have access to it to write the
per-device psk.

Giving correct permission makes hostapd correctly write the entry and
permits devices connected with WPS Push-Button to re-authenticate on
next connection.

Save wpa_psk_file on permanent storage by default. Currently it's always
created in /var/run with the hostapd files.

Any user that would use this option would save this file on permanent
storage to declare specific PSK per devices or for each VLAN.

The file is also used for WPS to store the per-device PSK and keeping it
on /var/run on normal installation (excluding installation with
permanent /var) would result in the wpa_psk_file getting wiped on
reboot, losing all the per-device PSK saved by hostapd.

To fix this, move the wpa_psk_file to /etc/hostapd and set the default
value for the wpa_psk_file option to point to this directory.
