### PR TITLE
netifd: silence steering script if queue mask unavailable

### DIFF
--- a/package/network/config/netifd/files/usr/libexec/network/packet-steering.sh
+++ b/package/network/config/netifd/files/usr/libexec/network/packet-steering.sh
@@ -29,7 +29,7 @@ set_hex_val() {
 	local val="$2"
 	val="$(printf %x "$val")"
 	[ -n "$DEBUG" ] && echo "$file = $val"
-	echo "$val" > "$file"
+	cat "$file" 2>/dev/null >"$file" && echo "$val" > "$file"
 }
 
 packet_steering="$(uci get "network.@globals[0].packet_steering")"


### PR DESCRIPTION
Having single device queue exposed makes it non-programmable (effectively zero == follow IRQ) , before attempting to program CPU mask try to write back existing mask silently to assure mask is programmable before attempting to set final mask. This avoids omnipresent non-specific "sh: write error: No such file or directory" during steering setup.
simpler tests do not work in ash script while works interactive.

Fixes: https://github.com/openwrt/openwrt/issues/12095

Signed-off-by: Andris PE <neandris@gmail.com>