### PR TITLE
kernel: crypto: package SHA3

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -958,6 +958,18 @@ endif
 $(eval $(call KernelPackage,crypto-sha1))
 
 
+define KernelPackage/crypto-sha3
+  TITLE:=SHA3 digest CryptoAPI module
+  DEPENDS:=+kmod-crypto-hash
+  KCONFIG:= CONFIG_CRYPTO_SHA3
+  FILES:=$(LINUX_DIR)/crypto/sha3_generic.ko
+  AUTOLOAD:=$(call AutoLoad,09,sha3_generic)
+  $(call AddDepends/crypto)
+endef
+
+$(eval $(call KernelPackage,crypto-sha3))
+
+
 define KernelPackage/crypto-sha256
   TITLE:=SHA224 SHA256 digest CryptoAPI module
   DEPENDS:=+kmod-crypto-hash


### PR DESCRIPTION
SHA3 is now required by jitterentropy_rng in kernel 6.6, so lets start preparing by packaging SHA3 support as its supported in 5.15 and 6.1 kernels as well.

AFAIK, only ARMv8.2 has a crypto extension for SHA3, however I am not aware of any SoC we support that uses ARMv8.2 ISA so its not enabled currently.
