### PR TITLE
kernel: support for rtl8367d family chips 

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/rtl8366_smi.h
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366_smi.h
@@ -30,7 +30,9 @@ typedef enum rtl8367b_chip_e {
 	RTL8367B_CHIP_RTL8367R_VB, /* chip with exception in extif assignment */
 /* Family C */
 	RTL8367B_CHIP_RTL8367RB_VB,
-	RTL8367B_CHIP_RTL8367S
+	RTL8367B_CHIP_RTL8367S,
+/* Family D */
+	RTL8367B_CHIP_RTL8367S_VB /* chip with exception in extif assignment */
 } rtl8367b_chip_t;
 
 struct rtl8366_mib_counter {

--- a/target/linux/generic/files/drivers/net/phy/rtl8366_smi.h
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366_smi.h
@@ -78,6 +78,7 @@ struct rtl8366_smi {
 	u32			phy_id;
 	rtl8367b_chip_t		rtl8367b_chip;
 	struct mii_bus		*ext_mbus;
+	struct rtl8366_vlan_mc *emu_vlanmc;
 };
 
 struct rtl8366_vlan_mc {

--- a/target/linux/generic/files/drivers/net/phy/rtl8367b.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367b.c
@@ -1040,7 +1040,7 @@ static int rtl8367b_set_vlan_mc(struct rtl8366_smi *smi, u32 index,
 	    vlanmc->priority > RTL8367B_PRIORITYMAX ||
 	    vlanmc->member > RTL8367B_VLAN_MC0_MEMBER_MASK ||
 	    vlanmc->untag > RTL8367B_UNTAG_MASK ||
-	    vlanmc->fid > RTL8367B_FIDMAX)
+	    vlanmc->fid > ((smi->rtl8367b_chip >= RTL8367B_CHIP_RTL8367S_VB) ? RTL8367D_FIDMAX : RTL8367B_FIDMAX))
 		return -EINVAL;
 
 	data[0] = (vlanmc->member & RTL8367B_VLAN_MC0_MEMBER_MASK) <<


### PR DESCRIPTION
Support for RTL8367D family chips:
-RTL8367S-VB

The RTL8367S-VB supports additional speeds up to 2500 Mbps. However, this is not implemented because the driver supports a maximum of RGMII mode at 1000 Mbps.

Vlan mc emulation was used due to garbage reading from vlanmc registers.

Routers like TP-Link Archer C5 v5 and TP-Link EC220-G5 v2 are manufactured with either rtl8367s or rtl8367s-vb chip. With this patch both will work.

Tested on TP-Link Archer C5 v4 - rtl8367s and rtl8367s-vb versions