### PR TITLE
kernel: crypto: add SHA512 ARM64 ASM optimized module

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -1038,6 +1038,7 @@ define KernelPackage/crypto-sha512
   KCONFIG:= \
 	CONFIG_CRYPTO_SHA512 \
 	CONFIG_CRYPTO_SHA512_ARM \
+	CONFIG_CRYPTO_SHA512_ARM64 \
 	CONFIG_CRYPTO_SHA512_OCTEON \
 	CONFIG_CRYPTO_SHA512_SSSE3
   FILES:=$(LINUX_DIR)/crypto/sha512_generic.ko
@@ -1048,6 +1049,11 @@ endef
 define KernelPackage/crypto-sha512/arm
   FILES+=$(LINUX_DIR)/arch/arm/crypto/sha512-arm.ko
   AUTOLOAD+=$(call AutoLoad,09,sha512-arm)
+endef
+
+define KernelPackage/crypto-sha512/aarch64
+  FILES+=$(LINUX_DIR)/arch/arm64/crypto/sha512-arm64.ko
+  AUTOLOAD+=$(call AutoLoad,09,sha512-arm64)
 endef
 
 KernelPackage/crypto-sha512/imx=$(KernelPackage/crypto-sha512/arm)


### PR DESCRIPTION
Kernel has an ASM optimized version of SHA512 that was ported from OpenSSL, so lets package it as it provides significant perfomance improvement compared to the generic implementation.

There is a Cryptographic Extension based version as well, but that relies on ARMv8.2 ISA which I am not aware any of the OpenWrt supported SoC-s use.
