### PR TITLE
qualcommax: update ess properties and phy-mode

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-mango-dvk.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-mango-dvk.dts
@@ -314,6 +314,7 @@
 		nand-ecc-strength = <4>;
 		nand-ecc-step-size = <512>;
 		nand-bus-width = <8>;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-mango-dvk.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-mango-dvk.dts
@@ -220,6 +220,7 @@
 &dp5 {
 	status = "okay";
 
+	phy-mode = "sgmii";
 	phy-handle = <&qca8081>;
 	nvmem-cells = <&macaddr_eth2>;
 	nvmem-cell-names = "mac-address";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-ess.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-ess.dtsi
@@ -501,7 +501,7 @@
 		reg = <0x0 0x3a001800 0x0 0x200>;
 		qcom,mactype = <0>;
 		local-mac-address = [000000000000];
-		phy-mode = "sgmii";
+		phy-mode = "psgmii";
 		status = "disabled";
 	};
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
@@ -372,6 +372,7 @@
 
 &dp5 {
 	status = "okay";
+	phy-mode = "sgmii";
 	phy-handle = <&qca8081_24>;
 	label = "lan";
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
@@ -519,6 +519,7 @@
 
 &dp5 {
 	status = "okay";
+	phy-mode = "sgmii";
 	phy-handle = <&qca8081>;
 	label = "wan";
 	nvmem-cells = <&macaddr_dp5>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx5300.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx5300.dts
@@ -317,21 +317,25 @@
 				label = "alt_rootfs";
 				reg = <0xac80000 0x9000000>;
 			};
+
 			partition@13c80000 {
 				label = "sysdiag";
 				reg = <0x13c80000 0x200000>;
 				read-only;
 			};
+
 			partition@13e80000 {
 				label = "0:ethphyfw";
 				reg = <0x13e80000 0x80000>;
 				read-only;
 			};
+
 			partition@13f00000 {
 				label = "syscfg";
 				reg = <0x13f00000 0xb800000>;
 				read-only;
 			};
+
 			partition@1f700000 {
 				label = "0:wififw";
 				reg = <0x1f700000 0x900000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax620.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax620.dts
@@ -106,7 +106,6 @@
 			label = "wlan5g:green";
 			gpios = <&led_gpio 5 GPIO_ACTIVE_HIGH>;
 		};
-
 	};
 };
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
@@ -350,7 +350,6 @@
 	status = "okay";
 };
 
-
 &mdio {
 	status = "okay";
 	pinctrl-0 = <&mdio_pins>;
@@ -384,7 +383,6 @@
 		reg = <28>;
 		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
 	};
-
 };
 
 &switch {
@@ -422,27 +420,27 @@
 };
 
 &dp2 {
-        status = "okay";
-        phy-handle = <&qca8075_1>;
-        label = "lan1";
+	status = "okay";
+	phy-handle = <&qca8075_1>;
+	label = "lan1";
 };
 
 &dp3 {
-        status = "okay";
-        phy-handle = <&qca8075_2>;
-        label = "lan2";
+	status = "okay";
+	phy-handle = <&qca8075_2>;
+	label = "lan2";
 };
 
 &dp4 {
-        status = "okay";
-        phy-handle = <&qca8075_3>;
-        label = "lan3";
+	status = "okay";
+	phy-handle = <&qca8075_3>;
+	label = "lan3";
 };
 
 &dp6 {
-        status = "okay";
-        phy-handle = <&qca8081>;
-        label = "wan";
+	status = "okay";
+	phy-handle = <&qca8081>;
+	label = "wan";
 };
 
 &pcie_qmp0 {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-ac-cpu.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-ac-cpu.dtsi
@@ -22,6 +22,7 @@
 	cpu-supply = <&apc_vreg>;
 	voltage-tolerance = <1>;
 };
+
 &cpu0_thermal {
 	trips {
 		cpu0_passive: cpu-passive {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-hk-cpu.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-hk-cpu.dtsi
@@ -22,6 +22,7 @@
 	cpu-supply = <&apc_vreg>;
 	voltage-tolerance = <1>;
 };
+
 &cpu0_thermal {
 	trips {
 		cpu0_passive_low: cpu-passive-low {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
@@ -13,7 +13,6 @@
 #include <dt-bindings/leds/common.h>
 #include <dt-bindings/input/input.h>
 
-
 / {
 	model = "Zyxel NBG7815";
 	compatible = "zyxel,nbg7815", "qcom,ipq8074";
@@ -59,7 +58,6 @@
 	};
 };
 
-
 &blsp1_uart3 {
 	status = "okay";
 };
@@ -104,7 +102,6 @@
 	partitions {
 		status = "disabled";
 	};
-
 
 	flash@0 {
 		#address-cells = <1>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
@@ -394,6 +394,7 @@
 
 &dp5 {
 	status = "okay";
+	phy-mode = "sgmii";
 	phy-handle = <&qca8081>;
 	label = "wan";
 	nvmem-cells = <&macaddr_lan 1>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wax630.dts
@@ -15,7 +15,7 @@
 
 	aliases {
 		serial0 = &blsp1_uart5;
-		
+
 		ethernet0 = &dp6_syn;
 		ethernet1 = &dp4;
 		label-mac-device = &dp6_syn;


### PR DESCRIPTION
The port 5 of most ipq60xx devices is connected to qca8075, a few are connected to qca8081. So assume that the default
connection is qca8075 and set the phy mode to psgmii. For qca8081 we should use 2500base-x.