### PR TITLE
[RFC] gettext-full/host: link libiconv when building host pkg to fix build error

### DIFF
--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -27,7 +27,7 @@ PKG_BUILD_PARALLEL:=0
 
 PKG_FIXUP:=autoreconf
 
-HOST_BUILD_DEPENDS:=gperf/host libunistring/host libxml2/host
+HOST_BUILD_DEPENDS:=gperf/host libiconv-full/host libunistring/host libxml2/host
 HOST_BUILD_PARALLEL:=0
 
 PKG_SUBDIRS:= \
@@ -101,14 +101,12 @@ HOST_CONFIGURE_ARGS += \
 	--disable-java \
 	--disable-openmp \
 	--without-emacs \
+	--with-libiconv-prefix=$(STAGING_DIR_HOSTPKG) \
 	--with-libunistring-prefix=$(STAGING_DIR_HOSTPKG) \
 	--with-libxml2-prefix=$(STAGING_DIR_HOSTPKG)
 
 HOST_CONFIGURE_VARS += \
 	EMACS="no" \
-	am_cv_lib_iconv=no \
-	am_cv_func_iconv=no \
-	ac_cv_header_iconv_h=no \
 
 HOST_CFLAGS += $(HOST_FPIC)
 


### PR DESCRIPTION
Maintainer: @jow-

On Fedora 40 system, some compile error happens when building iconv-ostream.c. Linking to libiconv-full fixes this.