### PR TITLE
mediatek: clean duplicated #include in Xiaomi Redmi AX6000's dts

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
@@ -2,7 +2,6 @@
 
 /dts-v1/;
 #include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/leds/common.h>
 


### PR DESCRIPTION
Clean duplication of #include <dt-bindings/leds/common.h>.
Thanks musashino205

Fixes: 1493e8f8cbe2 ("mediatek: convert LED color/function format for Xiaomi Redmi AX6000")