### PR TITLE
ramips: add support for BOLT BL100

### DIFF
--- a/target/linux/ramips/dts/mt7620a_bolt_bl100.dts
+++ b/target/linux/ramips/dts/mt7620a_bolt_bl100.dts
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	compatible = "bolt,bl100", "ralink,mt7620a-soc";
+	model = "Bolt BL100";
+
+	aliases {
+		led-boot = &led_reset;
+		led-failsafe = &led_reset;
+		led-running = &led_power;
+		led-upgrade = &led_reset;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_reset: reset {
+			function = LED_FUNCTION_BOOT;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lte1 {
+			label = "blue:lte1";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lte2 {
+			label = "blue:lte2";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lte3 {
+			label = "blue:lte3";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lte4 {
+			label = "blue:lte4";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+		
+		led_lte5 {
+			label = "red:lte5";
+			gpios = <&gpio2 24 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lte6 {
+			label = "red:lte6";
+			gpios = <&gpio2 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wps {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio2 22 GPIO_ACTIVE_LOW>;
+		};
+
+		led_voip {
+			label = "blue:voip";
+			gpios = <&gpio2 23 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wlan2 {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+		
+		led_wlan5 {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+		
+		led_lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+		
+		led_wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "WPS";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		};
+
+		reset {
+			label = "RST";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <70000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				compatible = "nvmem-cells";
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+
+					macaddr_factory_28: macaddr@28 {
+						compatible = "mac-base";
+						reg = <0x28 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x50000 0xf80000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x26112015>;
+			};
+
+			partition@fd0000 {
+				label = "crash";
+				reg = <0xfd0000 0x10000>;
+			};
+
+			partition@fe0000 {
+				label = "reserved";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "Bdata";
+				reg = <0xff0000 0x10000>;
+			};
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+
+	mediatek,portmap = "llllw";
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	
+	pinctrl-names = "default", "pa_gpio";
+	pinctrl-0 = <&pa_pins>;
+	pinctrl-1 = <&pa_gpio_pins>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uartf", "rgmii1", "rgmii2", "ephy", "wled", "nd_sd";
+		function = "gpio";
+	};
+};
+

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -149,6 +149,16 @@ define Device/bdcom_wap2100-sk
 endef
 TARGET_DEVICES += bdcom_wap2100-sk
 
+define Device/bolt_bl100
+  SOC := mt7620a
+  IMAGE_SIZE := 15872k
+  DEVICE_VENDOR := Bolt
+  DEVICE_MODEL := BL100
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci
+  UIMAGE_MAGIC := 0x26112015
+endef
+TARGET_DEVICES += bolt_bl100
+
 define Device/buffalo_whr-1166d
   SOC := mt7620a
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -40,6 +40,11 @@ asus,rt-n14u)
 bdcom,wap2100-sk)
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan2g" "wlan0"
 	;;
+bolt,bl100)
+	ucidef_set_led_default "power" "power" "blue:power" "1"
+	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0.1"
+	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth0.2"
+	;;
 comfast,cf-wr800n)
 	ucidef_set_led_netdev "lan" "lan" "white:ethernet" eth0.1
 	ucidef_set_led_netdev "wifi_led" "wifi" "white:wifi" "wlan0"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -34,6 +34,7 @@ ramips_setup_interfaces()
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
 	alfa-network,r36m-e4g|\
+	bolt,bl100|\
 	zbtlink,zbt-we1026-h-32m)
 		ucidef_add_switch "switch0" \
 			"3:lan" "4:wan" "6@eth0"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/03_gpio_switches
@@ -6,6 +6,9 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+bolt,bl100)
+	ucidef_add_gpio_switch "modem_enable" "Enable LTE Modem" "28" "1"
+	;;
 dlink,dir-510l)
 	ucidef_add_gpio_switch "usb_enable1" "USB 1A enable" "12" "0"
 	ucidef_add_gpio_switch "usb_enable05" "USB 0.5A enable" "13" "1"


### PR DESCRIPTION
```
BL100 is a router made by Bolt by a provider in Indonesia
The original firmware created using Mediatek SDK and kernel 2.6.36

- Chipset: MediaTek MT7620A ver 2, eco 6
- RAM: 64 MB
- Bootloader: U Boot
- Flash: Winbond W25Q128BV (16 MB)
- Ports: 2x 10/100 Ethernet, 1x RJ-11 VoIP
- Modem: Qualcomm LTE B40 (2300 Mhz) VID:05c6 PID:9026
- Wireless: Internal MT7620A (2.4 Ghz) & Mediatek MT76x2E (5.8 Ghz)
- Switch: MediaTek MT7620A built-in 5-port 10/100M switch
- Voltage: DC 12V 1A
- Antenna Port: 2x External Antenna, 2 LTE U.FL, 2 WiFi U.FL
- Serial Port: Yes, 3.3 V TTL, Baud 57600 8N1
- Buttons: Reset and WPS
- LED: 15 Total
  - 4 blue lte, 2 red lte, 1 reset, 1 power.
  - 1 wps, 1 voip, 1 wlan2, 1 wlan5, 1 lan, 1 wan, 1 wlan.

Installation via stock firmware
1. Unlock Telnet access by downloading the backup .tar.gz file
2. Change the Telnet configuration to LAN_Telnet=1
3. Import backup configuration
4. Restart the router
5. Login to telnet with username and password = admin : db40
6. Download sysupgrade binary and mtd_write to the kernel partition
`mtd_write write openwrt-bolt_bl100-squashfs-sysupgrade.bin Kernel`
```