### PR TITLE
scripts/feeds: try `git fetch` specific commit before full fetch

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -157,7 +157,7 @@ my %update_method = (
 	'src-git' => {
 		'init'          => "git clone --depth 1 '%s' '%s'",
 		'init_branch'   => "git clone --depth 1 --branch '%s' '%s' '%s'",
-		'init_commit'   => "git clone '%s' '%s' && cd '%s' && git checkout -b '%s' '%s' && cd -",
+		'init_commit'   => "mkdir '%s' && cd '%s' && git init && git remote add origin '%s' && (git fetch origin '%s' || git fetch origin) && git checkout '%s' && cd -",
 		'update'	=> "git pull --ff-only",
 		'update_force'	=> "git pull --ff-only || (git reset --hard HEAD; git pull --ff-only; exit 1)",
 		'post_update'	=> "git submodule update --init --recursive",
@@ -166,7 +166,7 @@ my %update_method = (
 	'src-git-full' => {
 		'init'          => "git clone '%s' '%s'",
 		'init_branch'   => "git clone --branch '%s' '%s' '%s'",
-		'init_commit'   => "git clone '%s' '%s' && cd '%s' && git checkout -b '%s' '%s' && cd -",
+		'init_commit'   => "mkdir '%s' && cd '%s' && git init && git remote add origin '%s' && (git fetch origin '%s' || git fetch origin) && git checkout '%s' && cd -",
 		'update'	=> "git pull --ff-only",
 		'update_force'	=> "git pull --ff-only || (git reset --hard HEAD; git pull --ff-only; exit 1)",
 		'post_update'	=> "git submodule update --init --recursive",
@@ -213,7 +213,7 @@ sub update_feed_via($$$$$) {
 		if ($m->{'init_branch'} and $branch) {
 			system(sprintf($m->{'init_branch'}, $branch, $base_branch, $safepath)) == 0 or return 1;
 		} elsif ($m->{'init_commit'} and $commit) {
-			system(sprintf($m->{'init_commit'}, $base_commit, $safepath, $safepath, $commit, $commit)) == 0 or return 1;
+			system(sprintf($m->{'init_commit'}, $safepath, $safepath, $base_commit, $commit, $commit)) == 0 or return 1;
 		} else {
 			system(sprintf($m->{'init'}, $src, $safepath)) == 0 or return 1;
 		}


### PR DESCRIPTION
`git clone` has two major issues in this scenario:

1. `git clone` won't download commits that don't belong to any branch,
   so `git checkout` will fail for them. A typical usecase is to
   download commits in the refs/changes/ namespace used by Gerrit.
2. `git clone` the entire repository wastes network traffic and disk
   storage when the commit histories of different branches are
   unrelated, which is especially severe for large repositories.

Hence, this commit replaces `git clone` with `git fetch` of the wanted
commit sha1, and fallback to a full `git fetch` if failed, which is
technically identical to `git clone`. The fallback is necessary because
the remote server may not enable `uploadpack.allowReachableSHA1InWant`,
which is the case for git.openwrt.org.

The unnecessary branch creation at checkout is also removed.