### PR TITLE
download: Try link() before copy() from local mirror

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -182,8 +182,8 @@ sub download
 			return;
 		}
 
-		print("Copying $filename from $link\n");
-		copy($link, "$target/$filename.dl");
+		print("Linking/Copying $filename from $link\n");
+		link($link, "$target/$filename.dl") or copy($link, "$target/$filename.dl");
 
 		$hash_cmd and do {
 			if (system("cat '$target/$filename.dl' | $hash_cmd > '$target/$filename.hash'")) {


### PR DESCRIPTION
When using a local file:// mirror, try saving space and time by linking the file into our local download directory, before falling back to the original copying.