### PR TITLE
lldpd: implement lldp_policy parameter

### DIFF
--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lldpd
 PKG_VERSION:=1.0.17
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lldpd/lldpd/releases/download/$(PKG_VERSION)/

--- a/package/network/services/lldpd/files/lldpd.config
+++ b/package/network/services/lldpd/files/lldpd.config
@@ -7,6 +7,8 @@ config lldpd config
 	option agentxsocket /var/run/agentx.sock
 
 	option lldp_class 4
+	# lldp_policy only needed for lldp_class 2-3
+	# option lldp_policy 'application streaming-video unknown'
 	option lldp_location "address country EU"
 
 	# if empty, the distribution description is sent

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -118,6 +118,12 @@ write_lldpd_conf()
 		local lldp_location
 		config_get lldp_location 'config' 'lldp_location'
 
+		local lldp_class
+		config_get lldp_class 'config' 'lldp_class'
+
+		local lldp_policy
+		config_get lldp_policy 'config' 'lldp_policy'
+
 	fi
 
 	local lldp_agenttype
@@ -153,6 +159,12 @@ write_lldpd_conf()
 		# other 'configure med xxx' statements go here
 
 		[ -n "$lldp_location" ] && echo "configure med location" "$lldp_location" >> "$LLDPD_CONF"
+
+		# Manual states that if Class (-M) is 2 or 3, at least one network policy must be defined
+		case "$lldp_class" in
+			2 | 3 ) [ -n "$lldp_policy" ] && echo "configure med policy $lldp_policy" >> "$LLDPD_CONF"
+			;;
+		esac
 
 	fi
 


### PR DESCRIPTION
For certain `lldp_class` scenarios (2 & 3) a policy must be set also. Class 4 is default, although it's good to handle the policy eventuality.

Here, set a default `lldp_policy` for 2 & 3 `lldp_class` scenarios. Any `lldp_policy` can now be set.

Depends on PR #14584 (which introduced an `if` block)

Tested on 22.03.5, 22.03.6