### PR TITLE
kirkwood: add ix4-200d support to uboot-envtools

### DIFF
--- a/package/boot/uboot-envtools/files/kirkwood
+++ b/package/boot/uboot-envtools/files/kirkwood
@@ -17,6 +17,7 @@ cloudengines,pogoe02|\
 cloudengines,pogoplugv4|\
 globalscale,sheevaplug|\
 iom,ix2-200|\
+iom,ix4-200d|\
 linksys,e4200-v2|\
 linksys,ea4500|\
 netgear,readynas-duo-v2|\


### PR DESCRIPTION
This adds support for the Iomega ix4-200d device in uboot-envtools.
