### PR TITLE
bcm47xx: add support for Linksys EA6500 v1

### DIFF
--- a/target/linux/bcm47xx/image/mips74k.mk
+++ b/target/linux/bcm47xx/image/mips74k.mk
@@ -326,6 +326,15 @@ define Device/linksys_e4200-v1
 endef
 TARGET_DEVICES += linksys_e4200-v1
 
+define Device/linksys_ea6500-v1
+  $(Device/standard-noloader-gz)
+  DEVICE_VENDOR := Linksys
+  DEVICE_MODEL := EA6500
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-b43 $(USB2_PACKAGES)
+endef
+TARGET_DEVICES += linksys_ea6500-v1
+
 define Device/netgear_r6200-v1
   DEVICE_MODEL := R6200
   DEVICE_VARIANT := v1

--- a/target/linux/bcm47xx/patches-5.15/140-MIPS-BCM47XX-Add-support-for-Linksys-EA6500-v1.patch
+++ b/target/linux/bcm47xx/patches-5.15/140-MIPS-BCM47XX-Add-support-for-Linksys-EA6500-v1.patch
@@ -1,0 +1,104 @@
+--- a/arch/mips/bcm47xx/board.c
++++ b/arch/mips/bcm47xx/board.c
+@@ -199,6 +199,7 @@ struct bcm47xx_board_type_list3 bcm47xx_
+ 	{{BCM47XX_BOARD_ZTE_H218N, "ZTE H218N"}, "0x053d", "1234", "0x1305"},
+ 	{{BCM47XX_BOARD_NETGEAR_WNR3500L, "Netgear WNR3500L"}, "0x04CF", "3500", "02"},
+ 	{{BCM47XX_BOARD_NETGEAR_WNR3500L_V2, "Netgear WNR3500L V2"}, "0x052b", "3500L", "02"},
++	{{BCM47XX_BOARD_LINKSYS_EA6500V1, "Linksys EA6500 V1"}, "0xC617", "${serno}", "0x1103"},
+ 	{{BCM47XX_BOARD_LINKSYS_WRT54G_TYPE_0101, "Linksys WRT54G/GS/GL"}, "0x0101", "42", "0x10"},
+ 	{{BCM47XX_BOARD_LINKSYS_WRT54G_TYPE_0467, "Linksys WRT54G/GS/GL"}, "0x0467", "42", "0x10"},
+ 	{{BCM47XX_BOARD_LINKSYS_WRT54G_TYPE_0708, "Linksys WRT54G/GS/GL"}, "0x0708", "42", "0x10"},
+--- a/arch/mips/bcm47xx/buttons.c
++++ b/arch/mips/bcm47xx/buttons.c
+@@ -247,6 +247,12 @@ bcm47xx_buttons_linksys_e4200v1[] __init
+ };
+ 
+ static const struct gpio_keys_button
++bcm47xx_buttons_linksys_ea6500v1[] __initconst = {
++	BCM47XX_GPIO_KEY(4, KEY_WPS_BUTTON),
++	BCM47XX_GPIO_KEY(3, KEY_RESTART),
++};
++
++static const struct gpio_keys_button
+ bcm47xx_buttons_linksys_wrt150nv1[] __initconst = {
+ 	BCM47XX_GPIO_KEY(4, KEY_WPS_BUTTON),
+ 	BCM47XX_GPIO_KEY(6, KEY_RESTART),
+@@ -635,6 +641,9 @@ int __init bcm47xx_buttons_register(void
+ 	case BCM47XX_BOARD_LINKSYS_E4200V1:
+ 		err = bcm47xx_copy_bdata(bcm47xx_buttons_linksys_e4200v1);
+ 		break;
++	case BCM47XX_BOARD_LINKSYS_EA6500V1:
++		err = bcm47xx_copy_bdata(bcm47xx_buttons_linksys_ea6500v1);
++		break;
+ 	case BCM47XX_BOARD_LINKSYS_WRT150NV1:
+ 		err = bcm47xx_copy_bdata(bcm47xx_buttons_linksys_wrt150nv1);
+ 		break;
+--- a/arch/mips/bcm47xx/leds.c
++++ b/arch/mips/bcm47xx/leds.c
+@@ -278,6 +278,11 @@ bcm47xx_leds_linksys_e4200v1[] __initcon
+ };
+ 
+ static const struct gpio_led
++bcm47xx_leds_linksys_ea6500v1[] __initconst = {
++	BCM47XX_GPIO_LED(1, "white", "power", 1, LEDS_GPIO_DEFSTATE_ON),
++};
++
++static const struct gpio_led
+ bcm47xx_leds_linksys_wrt150nv1[] __initconst = {
+ 	BCM47XX_GPIO_LED(1, "unk", "power", 0, LEDS_GPIO_DEFSTATE_ON),
+ 	BCM47XX_GPIO_LED(3, "amber", "wps", 1, LEDS_GPIO_DEFSTATE_OFF),
+@@ -702,6 +707,9 @@ void __init bcm47xx_leds_register(void)
+ 	case BCM47XX_BOARD_LINKSYS_E4200V1:
+ 		bcm47xx_set_pdata(bcm47xx_leds_linksys_e4200v1);
+ 		break;
++	case BCM47XX_BOARD_LINKSYS_EA6500V1:
++		bcm47xx_set_pdata(bcm47xx_leds_linksys_ea6500v1);
++		break;
+ 	case BCM47XX_BOARD_LINKSYS_WRT150NV1:
+ 		bcm47xx_set_pdata(bcm47xx_leds_linksys_wrt150nv1);
+ 		break;
+--- a/arch/mips/include/asm/mach-bcm47xx/bcm47xx_board.h
++++ b/arch/mips/include/asm/mach-bcm47xx/bcm47xx_board.h
+@@ -66,6 +66,7 @@ enum bcm47xx_board {
+ 	BCM47XX_BOARD_LINKSYS_E3000V1,
+ 	BCM47XX_BOARD_LINKSYS_E3200V1,
+ 	BCM47XX_BOARD_LINKSYS_E4200V1,
++	BCM47XX_BOARD_LINKSYS_EA6500V1,
+ 	BCM47XX_BOARD_LINKSYS_WRT150NV1,
+ 	BCM47XX_BOARD_LINKSYS_WRT150NV11,
+ 	BCM47XX_BOARD_LINKSYS_WRT160NV1,
+--- a/drivers/bcma/driver_chipcommon_sflash.c
++++ b/drivers/bcma/driver_chipcommon_sflash.c
+@@ -33,7 +33,7 @@ struct bcma_sflash_tbl_e {
+ static const struct bcma_sflash_tbl_e bcma_sflash_st_tbl[] = {
+ 	{ "M25P20", 0x11, 0x10000, 4, },
+ 	{ "M25P40", 0x12, 0x10000, 8, },
+-
++	{ "MX25L8006E", 0x13, 0x10000, 16, },
+ 	{ "M25P16", 0x14, 0x10000, 32, },
+ 	{ "M25P32", 0x15, 0x10000, 64, },
+ 	{ "M25P64", 0x16, 0x10000, 128, },
+@@ -112,8 +112,6 @@ int bcma_sflash_init(struct bcma_drv_cc
+ 					break;
+ 			}
+ 			break;
+-		case 0x13:
+-			return -ENOTSUPP;
+ 		default:
+ 			for (e = bcma_sflash_st_tbl; e->name; e++) {
+ 				if (e->id == id)
+--- a/drivers/firmware/broadcom/bcm47xx_nvram.c
++++ b/drivers/firmware/broadcom/bcm47xx_nvram.c
+@@ -91,7 +91,11 @@ static int bcm47xx_nvram_find_and_copy(v
+ 		}
+ 	}
+ 
+-	/* Try embedded NVRAM at 4 KB and 1 KB as last resorts */
++	/* Try embedded NVRAM at 512 KB, 4 KB and 1 KB as last resorts */
++
++	offset = 512 * 1024;
++	if (bcm47xx_nvram_is_valid(flash_start + offset))
++		goto found;
+ 
+ 	offset = 4096;
+ 	if (bcm47xx_nvram_is_valid(flash_start + offset))


### PR DESCRIPTION
Specifications:
- BCM4706 600MHz MIPS 74Kc
- NOR flash: 1MB Macronix MX25L8006E
- NAND flash: 128MB Samsung K9F1G08U0D
- Ethernet: 5x GbE
- 2.4GHz wifi: BCM4331
- 5GHz wifi: BCM4360
- 2x USB 2.0 port
- 2x button
- 1x LED

Serial install instructions:
- Connect to 3.3V TTL serial console (Header DJ1 pinout Vcc Tx Rx NC Gnd)
- On the serial console, press CTRL-C on startup to access CFE prompt
- Configure workstation to IP address 192.168.1.100 and connect to a LAN port on router
- On CFE prompt, enter "flash -noheader : nflash1.trx"
- tftp send openwrt image to 192.168.1.1
- After flashing is complete, enter "go" in CFE

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
