### PR TITLE
ath79: register ttyATH1 as Linux/OpenWrt console on ELECOM WAB-I1750-PS

### DIFF
--- a/target/linux/ath79/dts/qca9558_elecom_wab-i1750-ps.dts
+++ b/target/linux/ath79/dts/qca9558_elecom_wab-i1750-ps.dts
@@ -5,6 +5,10 @@
 / {
 	compatible = "elecom,wab-i1750-ps", "qca,qca9558";
 	model = "ELECOM WAB-I1750-PS";
+
+	chosen {
+		bootargs = "console=ttyATH1,115200n8 console=ttyS0,115200n8";
+	};
 };
 
 &gpio {

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/tty/10-inittab-add-console
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/tty/10-inittab-add-console
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+inittab_add_console() {
+	local console
+
+	case $(board_name) in
+	elecom,wab-i1750-ps)
+		console="ttyATH1"
+		;;
+	*)
+		return
+		;;
+	esac
+
+	[ "$DEVNAME" != "$console" ] && \
+		return
+
+	# check existing (commented out) entry
+	grep -q "^#\{0,1\}${console}::askfirst" "/etc/inittab" && \
+		return
+
+	# append entry
+	echo -e "\n${console}::askfirst:/usr/libexec/login.sh" \
+		>> /etc/inittab
+}
+
+[ "${ACTION}" = "add" ] && inittab_add_console


### PR DESCRIPTION
This patch series registers ttyATH1 ("SERIAL" port) on ELECOM WAB-I1750-PS as Linux/OpenWrt console for debugging/recoverying/configuration by users.

cdb4515b4b7d4ac0cb9730c43e8af4d38a632427 depends on https://github.com/openwrt/procd/pull/7.

The same changes should also be applicable to devolo WiFi Pro 1750e that has the similar PCB.