### PR TITLE
lldpd: allow glob patterns for interface(s) parsing

### DIFF
--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lldpd
 PKG_VERSION:=1.0.17
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lldpd/lldpd/releases/download/$(PKG_VERSION)/

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -80,12 +80,20 @@ get_config_cid_ifaces() {
 	config_get _ifaces 'config' "$2"
 
 	local _iface _ifnames=""
+	# Set noglob to prevent '*' capturing diverse file names in the for ... in
+	set -o noglob
 	for _iface in $_ifaces; do
-		local _ifname=""
-		if network_get_device _ifname "$_iface" || [ -e "/sys/class/net/$_iface" ]; then
-			append _ifnames "${_ifname:-$_iface}" ","
+
+		local _l2device=""
+		if network_get_physdev _l2device "$_iface" || [ -e "/sys/class/net/$_iface" ]; then
+			append _ifnames "${_l2device:-$_iface}" ","
+		else
+			# Glob case (interface is e.g. '!eth1' or 'eth*' or '*')
+			append _ifnames "$_iface" ","
 		fi
 	done
+	# Turn noglob off i.e. enable glob again
+	set +o noglob
 
 	export -n "${1}=$_ifnames"
 }


### PR DESCRIPTION
For interface related parameters, the man page documents functionality such as:

```
*,!eth*,!!eth1

uses all interfaces, except interfaces starting with "eth",
but including "eth1".
```

Before this change: only interfaces like `eth0, eth1` etc were accepted. 
After this change: interface masks and inversions are now also accepted: `*,!eth*,!!eth1,lan1,lan2,lan3,!lan4`

Tested extensively on: 22.03.6

'Optionally' depends upon #14850 (from which it optionally inherits a package release bump)

Review welcome: @robimarko @stintel @pprindeville
