### PR TITLE
linux-firmware: add missing license info for binary blobs

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -30,6 +30,8 @@ define Package/firmware-default
   URL:=http://git.kernel.org/cgit/linux/kernel/git/firmware/linux-firmware.git
   TITLE:=$(1)
   DEPENDS:=$(2)
+  LICENSE_FILES:=$(3)
+  LICENSE:=$(4)
 endef
 
 define Build/Compile

--- a/package/firmware/linux-firmware/airoha.mk
+++ b/package/firmware/linux-firmware/airoha.mk
@@ -1,4 +1,4 @@
-Package/airoha-en8811h-firmware = $(call Package/firmware-default,Airoha EN8811H 2.5G Ethernet PHY firmware)
+Package/airoha-en8811h-firmware = $(call Package/firmware-default,Airoha EN8811H 2.5G Ethernet PHY firmware,,LICENSE.airoha)
 define Package/airoha-en8811h-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/airoha
 	$(CP) \

--- a/package/firmware/linux-firmware/amd.mk
+++ b/package/firmware/linux-firmware/amd.mk
@@ -1,4 +1,4 @@
-Package/amd64-microcode = $(call Package/firmware-default,AMD64 CPU microcode,@TARGET_x86)
+Package/amd64-microcode = $(call Package/firmware-default,AMD64 CPU microcode,@TARGET_x86,LICENSE.amd-ucode)
 define Package/amd64-microcode/install
 	$(INSTALL_DIR) $(1)/lib/firmware/amd-ucode
 	$(CP) \
@@ -8,7 +8,7 @@ endef
 
 $(eval $(call BuildPackage,amd64-microcode))
 
-Package/amdgpu-firmware = $(call Package/firmware-default,AMDGPU Video Driver firmware)
+Package/amdgpu-firmware = $(call Package/firmware-default,AMDGPU Video Driver firmware,,LICENSE.amdgpura)
 define Package/amdgpu-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/amdgpu
 	$(CP) \
@@ -18,7 +18,7 @@ endef
 
 $(eval $(call BuildPackage,amdgpu-firmware))
 
-Package/radeon-firmware = $(call Package/firmware-default,Radeon Video Driver firmware)
+Package/radeon-firmware = $(call Package/firmware-default,Radeon Video Driver firmware,,LICENSE.radeon)
 define Package/radeon-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/radeon
 	$(CP) \

--- a/package/firmware/linux-firmware/broadcom.mk
+++ b/package/firmware/linux-firmware/broadcom.mk
@@ -1,4 +1,4 @@
-Package/brcmfmac-firmware-4339-sdio = $(call Package/firmware-default,Broadcom 4339 FullMAC SDIO firmware)
+Package/brcmfmac-firmware-4339-sdio = $(call Package/firmware-default,Broadcom 4339 FullMAC SDIO firmware,,LICENCE.cypressb)
 define Package/brcmfmac-firmware-4339-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/cypress
 	$(INSTALL_DATA) \
@@ -11,7 +11,7 @@ define Package/brcmfmac-firmware-4339-sdio/install
 endef
 $(eval $(call BuildPackage,brcmfmac-firmware-4339-sdio))
 
-Package/brcmfmac-firmware-43602a1-pcie = $(call Package/firmware-default,Broadcom 43602a1 FullMAC PCIe firmware)
+Package/brcmfmac-firmware-43602a1-pcie = $(call Package/firmware-default,Broadcom 43602a1 FullMAC PCIe firmware,,LICENCE.broadcom_bcm43xx)
 define Package/brcmfmac-firmware-43602a1-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
@@ -20,7 +20,7 @@ define Package/brcmfmac-firmware-43602a1-pcie/install
 endef
 $(eval $(call BuildPackage,brcmfmac-firmware-43602a1-pcie))
 
-Package/brcmfmac-firmware-4366b1-pcie = $(call Package/firmware-default,Broadcom 4366b1 FullMAC PCIe firmware)
+Package/brcmfmac-firmware-4366b1-pcie = $(call Package/firmware-default,Broadcom 4366b1 FullMAC PCIe firmware,,LICENCE.broadcom_bcm43xx)
 define Package/brcmfmac-firmware-4366b1-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
@@ -29,7 +29,7 @@ define Package/brcmfmac-firmware-4366b1-pcie/install
 endef
 $(eval $(call BuildPackage,brcmfmac-firmware-4366b1-pcie))
 
-Package/brcmfmac-firmware-4366c0-pcie = $(call Package/firmware-default,Broadcom 4366c0 FullMAC PCIe firmware)
+Package/brcmfmac-firmware-4366c0-pcie = $(call Package/firmware-default,Broadcom 4366c0 FullMAC PCIe firmware,,LICENCE.broadcom_bcm43xx)
 define Package/brcmfmac-firmware-4366c0-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
@@ -38,7 +38,7 @@ define Package/brcmfmac-firmware-4366c0-pcie/install
 endef
 $(eval $(call BuildPackage,brcmfmac-firmware-4366c0-pcie))
 
-Package/brcmfmac-firmware-4329-sdio = $(call Package/firmware-default,Broadcom BCM4329 FullMac SDIO firmware)
+Package/brcmfmac-firmware-4329-sdio = $(call Package/firmware-default,Broadcom BCM4329 FullMac SDIO firmware,,LICENCE.broadcom_bcm43xx)
 define Package/brcmfmac-firmware-4329-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
@@ -47,7 +47,7 @@ define Package/brcmfmac-firmware-4329-sdio/install
 endef
 $(eval $(call BuildPackage,brcmfmac-firmware-4329-sdio))
 
-Package/brcmfmac-nvram-43430-sdio = $(call Package/firmware-default,Broadcom BCM43430 SDIO NVRAM)
+Package/brcmfmac-nvram-43430-sdio = $(call Package/firmware-default,Broadcom BCM43430 SDIO NVRAM,,LICENCE.broadcom_bcm43xx)
 define Package/brcmfmac-nvram-43430-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
@@ -95,7 +95,7 @@ define Package/brcmfmac-nvram-43430-sdio/install
 endef
 $(eval $(call BuildPackage,brcmfmac-nvram-43430-sdio))
 
-Package/brcmfmac-firmware-43430a0-sdio = $(call Package/firmware-default,Broadcom BCM43430a0 FullMac SDIO firmware)
+Package/brcmfmac-firmware-43430a0-sdio = $(call Package/firmware-default,Broadcom BCM43430a0 FullMac SDIO firmware,,LICENCE.broadcom_bcm43xx)
 define Package/brcmfmac-firmware-43430a0-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
@@ -104,7 +104,7 @@ define Package/brcmfmac-firmware-43430a0-sdio/install
 endef
 $(eval $(call BuildPackage,brcmfmac-firmware-43430a0-sdio))
 
-Package/brcmfmac-nvram-43455-sdio = $(call Package/firmware-default,Broadcom BCM43455 SDIO NVRAM)
+Package/brcmfmac-nvram-43455-sdio = $(call Package/firmware-default,Broadcom BCM43455 SDIO NVRAM,,LICENCE.broadcom_bcm43xx)
 define Package/brcmfmac-nvram-43455-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
@@ -155,7 +155,7 @@ define Package/brcmfmac-nvram-43455-sdio/install
 endef
 $(eval $(call BuildPackage,brcmfmac-nvram-43455-sdio))
 
-Package/brcmfmac-nvram-4356-sdio = $(call Package/firmware-default,Broadcom BCM4356 SDIO NVRAM)
+Package/brcmfmac-nvram-4356-sdio = $(call Package/firmware-default,Broadcom BCM4356 SDIO NVRAM,,LICENCE.broadcom_bcm43xx)
 define Package/brcmfmac-nvram-4356-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
@@ -167,7 +167,7 @@ define Package/brcmfmac-nvram-4356-sdio/install
 endef
 $(eval $(call BuildPackage,brcmfmac-nvram-4356-sdio))
 
-Package/brcmfmac-firmware-usb = $(call Package/firmware-default,Broadcom BCM43xx fullmac USB firmware)
+Package/brcmfmac-firmware-usb = $(call Package/firmware-default,Broadcom BCM43xx fullmac USB firmware,,LICENCE.broadcom_bcm43xx)
 define Package/brcmfmac-firmware-usb/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
@@ -179,7 +179,7 @@ define Package/brcmfmac-firmware-usb/install
 endef
 $(eval $(call BuildPackage,brcmfmac-firmware-usb))
 
-Package/brcmsmac-firmware = $(call Package/firmware-default,Broadcom BCM43xx softmac PCIe firmware)
+Package/brcmsmac-firmware = $(call Package/firmware-default,Broadcom BCM43xx softmac PCIe firmware,,LICENCE.broadcom_bcm43xx)
 define Package/brcmsmac-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \

--- a/package/firmware/linux-firmware/marvell.mk
+++ b/package/firmware/linux-firmware/marvell.mk
@@ -1,4 +1,4 @@
-Package/mwl8k-firmware = $(call Package/firmware-default,Marvell 8366/8687 firmware)
+Package/mwl8k-firmware = $(call Package/firmware-default,Marvell 8366/8687 firmware,,LICENCE.Marvell)
 define Package/mwl8k-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mwl8k
 	$(INSTALL_DATA) \
@@ -11,7 +11,7 @@ define Package/mwl8k-firmware/install
 endef
 $(eval $(call BuildPackage,mwl8k-firmware))
 
-Package/mwifiex-pcie-firmware = $(call Package/firmware-default,Marvell 8897 firmware)
+Package/mwifiex-pcie-firmware = $(call Package/firmware-default,Marvell 8897 firmware,,LICENCE.Marvell)
 define Package/mwifiex-pcie-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mrvl
 	$(INSTALL_DATA) \
@@ -20,7 +20,7 @@ define Package/mwifiex-pcie-firmware/install
 endef
 $(eval $(call BuildPackage,mwifiex-pcie-firmware))
 
-Package/mwifiex-sdio-firmware = $(call Package/firmware-default,Marvell 8887/8997 firmware)
+Package/mwifiex-sdio-firmware = $(call Package/firmware-default,Marvell 8887/8997 firmware,,LICENCE.Marvell)
 define Package/mwifiex-sdio-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mrvl
 	$(INSTALL_DATA) \
@@ -31,7 +31,7 @@ define Package/mwifiex-sdio-firmware/install
 endef
 $(eval $(call BuildPackage,mwifiex-sdio-firmware))
 
-Package/libertas-usb-firmware = $(call Package/firmware-default,Marvell 8388/8682 USB firmware)
+Package/libertas-usb-firmware = $(call Package/firmware-default,Marvell 8388/8682 USB firmware,,LICENCE.Marvell)
 define Package/libertas-usb-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/libertas
 	$(INSTALL_DATA) \
@@ -41,7 +41,7 @@ define Package/libertas-usb-firmware/install
 endef
 $(eval $(call BuildPackage,libertas-usb-firmware))
 
-Package/libertas-sdio-firmware = $(call Package/firmware-default,Marvell 8385/8686/8688 SDIO firmware)
+Package/libertas-sdio-firmware = $(call Package/firmware-default,Marvell 8385/8686/8688 SDIO firmware,,LICENCE.Marvell)
 define Package/libertas-sdio-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/libertas
 	$(INSTALL_DATA) \
@@ -60,7 +60,7 @@ define Package/libertas-sdio-firmware/install
 endef
 $(eval $(call BuildPackage,libertas-sdio-firmware))
 
-Package/libertas-spi-firmware = $(call Package/firmware-default,Marvell 8686 SPI firmware)
+Package/libertas-spi-firmware = $(call Package/firmware-default,Marvell 8686 SPI firmware,,LICENCE.Marvell)
 define Package/libertas-spi-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/libertas
 	$(INSTALL_DATA) \

--- a/package/firmware/linux-firmware/mediatek.mk
+++ b/package/firmware/linux-firmware/mediatek.mk
@@ -1,4 +1,4 @@
-Package/mt7601u-firmware = $(call Package/firmware-default,MediaTek MT7601U firmware)
+Package/mt7601u-firmware = $(call Package/firmware-default,MediaTek MT7601U firmware,,LICENCE.mediatek)
 define Package/mt7601u-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
 	$(INSTALL_DATA) \
@@ -42,7 +42,7 @@ define Package/rt73-usb-firmware/install
 endef
 $(eval $(call BuildPackage,rt73-usb-firmware))
 
-Package/mt7622bt-firmware = $(call Package/firmware-default,mt7622bt firmware)
+Package/mt7622bt-firmware = $(call Package/firmware-default,mt7622bt firmware,,LICENCE.mediatek)
 define Package/mt7622bt-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
 	$(INSTALL_DATA) \
@@ -51,7 +51,7 @@ define Package/mt7622bt-firmware/install
 endef
 $(eval $(call BuildPackage,mt7622bt-firmware))
 
-Package/mt7921bt-firmware = $(call Package/firmware-default,mt7921bt firmware)
+Package/mt7921bt-firmware = $(call Package/firmware-default,mt7921bt firmware,,LICENCE.mediatek)
 define Package/mt7921bt-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
 	$(INSTALL_DATA) \
@@ -60,7 +60,7 @@ define Package/mt7921bt-firmware/install
 endef
 $(eval $(call BuildPackage,mt7921bt-firmware))
 
-Package/mt7922bt-firmware = $(call Package/firmware-default,mt7922bt firmware)
+Package/mt7922bt-firmware = $(call Package/firmware-default,mt7922bt firmware,,LICENCE.mediatek)
 define Package/mt7922bt-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
 	$(INSTALL_DATA) \
@@ -69,7 +69,7 @@ define Package/mt7922bt-firmware/install
 endef
 $(eval $(call BuildPackage,mt7922bt-firmware))
 
-Package/mt7981-wo-firmware = $(call Package/firmware-default,MT7981 offload firmware)
+Package/mt7981-wo-firmware = $(call Package/firmware-default,MT7981 offload firmware,,LICENCE.mediatek)
 define Package/mt7981-wo-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
 	$(INSTALL_DATA) \
@@ -78,7 +78,7 @@ define Package/mt7981-wo-firmware/install
 endef
 $(eval $(call BuildPackage,mt7981-wo-firmware))
 
-Package/mt7986-wo-firmware = $(call Package/firmware-default,MT7986 offload firmware)
+Package/mt7986-wo-firmware = $(call Package/firmware-default,MT7986 offload firmware,,LICENCE.mediatek)
 define Package/mt7986-wo-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
 	$(INSTALL_DATA) \
@@ -88,7 +88,7 @@ define Package/mt7986-wo-firmware/install
 endef
 $(eval $(call BuildPackage,mt7986-wo-firmware))
 
-Package/mt7988-2p5g-phy-firmware = $(call Package/firmware-default,MT7988 built-in 2.5G Ethernet PHY firmware)
+Package/mt7988-2p5g-phy-firmware = $(call Package/firmware-default,MT7988 built-in 2.5G Ethernet PHY firmware,,LICENCE.mediatek)
 define Package/mt7988-2p5g-phy-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mediatek/mt7988
 	$(INSTALL_DATA) \

--- a/package/firmware/linux-firmware/qca.mk
+++ b/package/firmware/linux-firmware/qca.mk
@@ -1,4 +1,4 @@
-Package/ar3k-firmware = $(call Package/firmware-default,ath3k firmware)
+Package/ar3k-firmware = $(call Package/firmware-default,ath3k firmware,,LICENSE.QualcommAtheros_ar3k)
 define Package/ar3k-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ar3k
 	$(CP) \
@@ -21,7 +21,7 @@ define Package/ath6k-firmware/install
 endef
 $(eval $(call BuildPackage,ath6k-firmware))
 
-Package/ath9k-htc-firmware = $(call Package/firmware-default,AR9271/AR7010 firmware)
+Package/ath9k-htc-firmware = $(call Package/firmware-default,AR9271/AR7010 firmware,,LICENCE.open-ath9k-htc-firmware)
 define Package/ath9k-htc-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath9k_htc
 	$(INSTALL_DATA) \
@@ -31,7 +31,7 @@ define Package/ath9k-htc-firmware/install
 endef
 $(eval $(call BuildPackage,ath9k-htc-firmware))
 
-Package/carl9170-firmware = $(call Package/firmware-default,AR9170 firmware)
+Package/carl9170-firmware = $(call Package/firmware-default,AR9170 firmware,,carl9170fw/GPL)
 define Package/carl9170-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/carl9170-1.fw $(1)/lib/firmware

--- a/package/firmware/linux-firmware/qca_ath10k.mk
+++ b/package/firmware/linux-firmware/qca_ath10k.mk
@@ -1,4 +1,4 @@
-Package/ath10k-board-qca4019 = $(call Package/firmware-default,ath10k qca4019 board firmware)
+Package/ath10k-board-qca4019 = $(call Package/firmware-default,ath10k qca4019 board firmware,,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-board-qca4019/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA4019/hw1.0
 	$(INSTALL_DATA) \
@@ -6,7 +6,7 @@ define Package/ath10k-board-qca4019/install
 		$(1)/lib/firmware/ath10k/QCA4019/hw1.0/
 endef
 $(eval $(call BuildPackage,ath10k-board-qca4019))
-Package/ath10k-firmware-qca4019 = $(call Package/firmware-default,ath10k qca4019 firmware)
+Package/ath10k-firmware-qca4019 = $(call Package/firmware-default,ath10k qca4019 firmware,,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-firmware-qca4019/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA4019/hw1.0
 	$(INSTALL_DATA) \
@@ -15,7 +15,7 @@ define Package/ath10k-firmware-qca4019/install
 endef
 $(eval $(call BuildPackage,ath10k-firmware-qca4019))
 
-Package/ath10k-board-qca9377 = $(call Package/firmware-default,ath10k qca9377 board firmware)
+Package/ath10k-board-qca9377 = $(call Package/firmware-default,ath10k qca9377 board firmware,,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-board-qca9377/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA9377/hw1.0
 	$(INSTALL_DATA) \
@@ -23,7 +23,7 @@ define Package/ath10k-board-qca9377/install
 		$(1)/lib/firmware/ath10k/QCA9377/hw1.0/
 endef
 $(eval $(call BuildPackage,ath10k-board-qca9377))
-Package/ath10k-firmware-qca9377 = $(call Package/firmware-default,ath10k qca9377 firmware,+ath10k-board-qca9377)
+Package/ath10k-firmware-qca9377 = $(call Package/firmware-default,ath10k qca9377 firmware,+ath10k-board-qca9377,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-firmware-qca9377/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA9377/hw1.0
 	$(INSTALL_DATA) \
@@ -32,7 +32,7 @@ define Package/ath10k-firmware-qca9377/install
 endef
 $(eval $(call BuildPackage,ath10k-firmware-qca9377))
 
-Package/ath10k-board-qca9887 = $(call Package/firmware-default,ath10k qca9887 board firmware)
+Package/ath10k-board-qca9887 = $(call Package/firmware-default,ath10k qca9887 board firmware,,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-board-qca9887/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA9887/hw1.0
 	$(INSTALL_DATA) \
@@ -40,7 +40,7 @@ define Package/ath10k-board-qca9887/install
 		$(1)/lib/firmware/ath10k/QCA9887/hw1.0/board.bin
 endef
 $(eval $(call BuildPackage,ath10k-board-qca9887))
-Package/ath10k-firmware-qca9887 = $(call Package/firmware-default,ath10k qca9887 firmware,+ath10k-board-qca9887)
+Package/ath10k-firmware-qca9887 = $(call Package/firmware-default,ath10k qca9887 firmware,+ath10k-board-qca9887,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-firmware-qca9887/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA9887/hw1.0
 	$(INSTALL_DATA) \
@@ -49,7 +49,7 @@ define Package/ath10k-firmware-qca9887/install
 endef
 $(eval $(call BuildPackage,ath10k-firmware-qca9887))
 
-Package/ath10k-board-qca9888 = $(call Package/firmware-default,ath10k qca9888 board firmware)
+Package/ath10k-board-qca9888 = $(call Package/firmware-default,ath10k qca9888 board firmware,,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-board-qca9888/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA9888/hw2.0
 	$(INSTALL_DATA) \
@@ -57,7 +57,7 @@ define Package/ath10k-board-qca9888/install
 		$(1)/lib/firmware/ath10k/QCA9888/hw2.0/board-2.bin
 endef
 $(eval $(call BuildPackage,ath10k-board-qca9888))
-Package/ath10k-firmware-qca9888 = $(call Package/firmware-default,ath10k qca9888 firmware,+ath10k-board-qca9888)
+Package/ath10k-firmware-qca9888 = $(call Package/firmware-default,ath10k qca9888 firmware,+ath10k-board-qca9888,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-firmware-qca9888/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA9888/hw2.0
 	$(INSTALL_DATA) \
@@ -66,7 +66,7 @@ define Package/ath10k-firmware-qca9888/install
 endef
 $(eval $(call BuildPackage,ath10k-firmware-qca9888))
 
-Package/ath10k-board-qca988x = $(call Package/firmware-default,ath10k qca988x board firmware)
+Package/ath10k-board-qca988x = $(call Package/firmware-default,ath10k qca988x board firmware,,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-board-qca988x/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA988X/hw2.0
 	$(INSTALL_DATA) \
@@ -74,7 +74,7 @@ define Package/ath10k-board-qca988x/install
 		$(1)/lib/firmware/ath10k/QCA988X/hw2.0/
 endef
 $(eval $(call BuildPackage,ath10k-board-qca988x))
-Package/ath10k-firmware-qca988x = $(call Package/firmware-default,ath10k qca988x firmware,+ath10k-board-qca988x)
+Package/ath10k-firmware-qca988x = $(call Package/firmware-default,ath10k qca988x firmware,+ath10k-board-qca988x,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-firmware-qca988x/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA988X/hw2.0
 	$(INSTALL_DATA) \
@@ -83,7 +83,7 @@ define Package/ath10k-firmware-qca988x/install
 endef
 $(eval $(call BuildPackage,ath10k-firmware-qca988x))
 
-Package/ath10k-firmware-qca6174 = $(call Package/firmware-default,ath10k qca6174 firmware)
+Package/ath10k-firmware-qca6174 = $(call Package/firmware-default,ath10k qca6174 firmware,,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-firmware-qca6174/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA6174/hw2.1
 	$(INSTALL_DATA) \
@@ -102,7 +102,7 @@ define Package/ath10k-firmware-qca6174/install
 endef
 $(eval $(call BuildPackage,ath10k-firmware-qca6174))
 
-Package/ath10k-board-qca99x0 = $(call Package/firmware-default,ath10k qca99x0 board firmware)
+Package/ath10k-board-qca99x0 = $(call Package/firmware-default,ath10k qca99x0 board firmware,,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-board-qca99x0/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA99X0/hw2.0
 	$(INSTALL_DATA) \
@@ -111,7 +111,7 @@ define Package/ath10k-board-qca99x0/install
 endef
 $(eval $(call BuildPackage,ath10k-board-qca99x0))
 
-Package/ath10k-firmware-qca99x0 = $(call Package/firmware-default,ath10k qca99x0 firmware,+ath10k-board-qca99x0)
+Package/ath10k-firmware-qca99x0 = $(call Package/firmware-default,ath10k qca99x0 firmware,+ath10k-board-qca99x0,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-firmware-qca99x0/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA99X0/hw2.0
 	$(INSTALL_DATA) \
@@ -120,7 +120,7 @@ define Package/ath10k-firmware-qca99x0/install
 endef
 $(eval $(call BuildPackage,ath10k-firmware-qca99x0))
 
-Package/ath10k-board-qca9984 = $(call Package/firmware-default,ath10k qca9984 board firmware)
+Package/ath10k-board-qca9984 = $(call Package/firmware-default,ath10k qca9984 board firmware,,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-board-qca9984/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA9984/hw1.0
 	$(INSTALL_DATA) \
@@ -128,7 +128,7 @@ define Package/ath10k-board-qca9984/install
 		$(1)/lib/firmware/ath10k/QCA9984/hw1.0/board-2.bin
 endef
 $(eval $(call BuildPackage,ath10k-board-qca9984))
-Package/ath10k-firmware-qca9984 = $(call Package/firmware-default,ath10k qca9984 firmware,+ath10k-board-qca9984)
+Package/ath10k-firmware-qca9984 = $(call Package/firmware-default,ath10k qca9984 firmware,+ath10k-board-qca9984,LICENSE.QualcommAtheros_ath10k)
 define Package/ath10k-firmware-qca9984/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA9984/hw1.0
 	$(INSTALL_DATA) \

--- a/package/firmware/linux-firmware/qca_ath11k.mk
+++ b/package/firmware/linux-firmware/qca_ath11k.mk
@@ -1,4 +1,4 @@
-Package/ath11k-firmware-qca6390 = $(call Package/firmware-default,QCA6390 ath11k firmware)
+Package/ath11k-firmware-qca6390 = $(call Package/firmware-default,QCA6390 ath11k firmware,,LICENCE.atheros_firmware)
 define Package/ath11k-firmware-qca6390/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/QCA6390/hw2.0
 	$(INSTALL_DATA) \
@@ -6,7 +6,7 @@ define Package/ath11k-firmware-qca6390/install
 endef
 $(eval $(call BuildPackage,ath11k-firmware-qca6390))
 
-Package/ath11k-firmware-wcn6750 = $(call Package/firmware-default,WCN6750 ath11k firmware)
+Package/ath11k-firmware-wcn6750 = $(call Package/firmware-default,WCN6750 ath11k firmware,,LICENCE.atheros_firmware)
 define Package/ath11k-firmware-wcn6750/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/WCN6750/hw1.0
 	$(INSTALL_DATA) \
@@ -14,7 +14,7 @@ define Package/ath11k-firmware-wcn6750/install
 endef
 $(eval $(call BuildPackage,ath11k-firmware-wcn6750))
 
-Package/ath11k-firmware-wcn6855 = $(call Package/firmware-default,WCN6855 ath11k firmware)
+Package/ath11k-firmware-wcn6855 = $(call Package/firmware-default,WCN6855 ath11k firmware,,LICENCE.atheros_firmware)
 define Package/ath11k-firmware-wcn6855/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/WCN6855/hw2.0
 	$(INSTALL_DATA) \

--- a/package/firmware/linux-firmware/realtek.mk
+++ b/package/firmware/linux-firmware/realtek.mk
@@ -20,7 +20,7 @@ define Package/r8169-firmware/install
 endef
 $(eval $(call BuildPackage,r8169-firmware))
 
-Package/rtl8188eu-firmware = $(call Package/firmware-default,RealTek RTL8188EU firmware)
+Package/rtl8188eu-firmware = $(call Package/firmware-default,RealTek RTL8188EU firmware,,LICENCE.rtlwifi_firmware.txt)
 define Package/rtl8188eu-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi
 	$(CP) \
@@ -29,7 +29,7 @@ define Package/rtl8188eu-firmware/install
 endef
 $(eval $(call BuildPackage,rtl8188eu-firmware))
 
-Package/rtl8188fu-firmware = $(call Package/firmware-default,RealTek RTL8188FU firmware)
+Package/rtl8188fu-firmware = $(call Package/firmware-default,RealTek RTL8188FU firmware,,LICENCE.rtlwifi_firmware.txt)
 define Package/rtl8188fu-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi
 	$(CP) \
@@ -38,7 +38,7 @@ define Package/rtl8188fu-firmware/install
 endef
 $(eval $(call BuildPackage,rtl8188fu-firmware))
 
-Package/rtl8192ce-firmware = $(call Package/firmware-default,RealTek RTL8192CE firmware)
+Package/rtl8192ce-firmware = $(call Package/firmware-default,RealTek RTL8192CE firmware,,LICENCE.rtlwifi_firmware.txt)
 define Package/rtl8192ce-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8192cfw.bin $(1)/lib/firmware/rtlwifi
@@ -47,7 +47,7 @@ define Package/rtl8192ce-firmware/install
 endef
 $(eval $(call BuildPackage,rtl8192ce-firmware))
 
-Package/rtl8192cu-firmware = $(call Package/firmware-default,RealTek RTL8192CU firmware)
+Package/rtl8192cu-firmware = $(call Package/firmware-default,RealTek RTL8192CU firmware,,LICENCE.rtlwifi_firmware.txt)
 define Package/rtl8192cu-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8192cufw.bin $(1)/lib/firmware/rtlwifi
@@ -57,28 +57,28 @@ define Package/rtl8192cu-firmware/install
 endef
 $(eval $(call BuildPackage,rtl8192cu-firmware))
 
-Package/rtl8192de-firmware = $(call Package/firmware-default,RealTek RTL8192DE firmware)
+Package/rtl8192de-firmware = $(call Package/firmware-default,RealTek RTL8192DE firmware,,LICENCE.rtlwifi_firmware.txt)
 define Package/rtl8192de-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8192defw.bin $(1)/lib/firmware/rtlwifi
 endef
 $(eval $(call BuildPackage,rtl8192de-firmware))
 
-Package/rtl8192eu-firmware = $(call Package/firmware-default,RealTek RTL8192EU firmware)
+Package/rtl8192eu-firmware = $(call Package/firmware-default,RealTek RTL8192EU firmware,,LICENCE.rtlwifi_firmware.txt)
 define Package/rtl8192eu-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8192eu_nic.bin $(1)/lib/firmware/rtlwifi
 endef
 $(eval $(call BuildPackage,rtl8192eu-firmware))
 
-Package/rtl8192se-firmware = $(call Package/firmware-default,RealTek RTL8192SE firmware)
+Package/rtl8192se-firmware = $(call Package/firmware-default,RealTek RTL8192SE firmware,,LICENCE.rtlwifi_firmware.txt)
 define Package/rtl8192se-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8192sefw.bin $(1)/lib/firmware/rtlwifi
 endef
 $(eval $(call BuildPackage,rtl8192se-firmware))
 
-Package/rtl8723au-firmware = $(call Package/firmware-default,RealTek RTL8723AU firmware)
+Package/rtl8723au-firmware = $(call Package/firmware-default,RealTek RTL8723AU firmware,,LICENCE.rtlwifi_firmware.txt)
 define Package/rtl8723au-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8723aufw_A.bin $(1)/lib/firmware/rtlwifi
@@ -87,7 +87,7 @@ define Package/rtl8723au-firmware/install
 endef
 $(eval $(call BuildPackage,rtl8723au-firmware))
 
-Package/rtl8723bu-firmware = $(call Package/firmware-default,RealTek RTL8723BU firmware)
+Package/rtl8723bu-firmware = $(call Package/firmware-default,RealTek RTL8723BU firmware,,LICENCE.rtlwifi_firmware.txt)
 define Package/rtl8723bu-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8723bu_nic.bin $(1)/lib/firmware/rtlwifi
@@ -125,7 +125,7 @@ define Package/rtl8761bu-firmware/install
 endef
 $(eval $(call BuildPackage,rtl8761bu-firmware))
 
-Package/rtl8821ae-firmware = $(call Package/firmware-default,RealTek RTL8821AE firmware)
+Package/rtl8821ae-firmware = $(call Package/firmware-default,RealTek RTL8821AE firmware,,LICENCE.rtlwifi_firmware.txt)
 define Package/rtl8821ae-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8821aefw.bin $(1)/lib/firmware/rtlwifi

--- a/package/firmware/linux-firmware/ti.mk
+++ b/package/firmware/linux-firmware/ti.mk
@@ -1,4 +1,4 @@
-Package/wl12xx-firmware = $(call Package/firmware-default,TI WL12xx firmware)
+Package/wl12xx-firmware = $(call Package/firmware-default,TI WL12xx firmware,,LICENCE.ti-connectivity)
 define Package/wl12xx-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ti-connectivity
 	$(INSTALL_DATA) \
@@ -15,7 +15,7 @@ define Package/wl12xx-firmware/install
 endef
 $(eval $(call BuildPackage,wl12xx-firmware))
 
-Package/wl18xx-firmware = $(call Package/firmware-default,TI WL18xx firmware)
+Package/wl18xx-firmware = $(call Package/firmware-default,TI WL18xx firmware,,LICENCE.ti-connectivity)
 define Package/wl18xx-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ti-connectivity
 	$(INSTALL_DATA) \


### PR DESCRIPTION
The firmware blobs all have different licenses from the different manufacturers of the binary blobs. This information is contained in the `linux-firmware` repository. This pullrequest extends the package handling so that this information can be added as an additional argument during packages generation.

See https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tree/