### PR TITLE
qualcommax: ipq807x: add support for Linksys MX8500

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq807x
@@ -31,7 +31,8 @@ edimax,cax1800)
 	;;
 linksys,mx4200v1|\
 linksys,mx4200v2|\
-linksys,mx5300)
+linksys,mx5300|\
+linksys,mx8500)
 	idx="$(find_mtd_index u_env)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000" "2"

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -37,6 +37,7 @@ ALLWIFIBOARDS:= \
 	edimax_cax1800 \
 	linksys_mx4200 \
 	linksys_mx5300 \
+	linksys_mx8500 \
 	netgear_lbr20 \
 	netgear_rax120v2 \
 	netgear_wax214 \
@@ -157,6 +158,7 @@ $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))
 $(eval $(call generate-ipq-wifi-package,linksys_mx4200,Linksys MX4200))
 $(eval $(call generate-ipq-wifi-package,linksys_mx5300,Linksys MX5300))
+$(eval $(call generate-ipq-wifi-package,linksys_mx8500,Linksys MX8500))
 $(eval $(call generate-ipq-wifi-package,netgear_lbr20,Netgear LBR20))
 $(eval $(call generate-ipq-wifi-package,netgear_rax120v2,Netgear RAX120v2))
 $(eval $(call generate-ipq-wifi-package,netgear_wax214,Netgear WAX214))

--- a/package/kernel/qca-ssdk/patches/103-hsl_phy-add-support-for-AQR114C-B0-PHY.patch
+++ b/package/kernel/qca-ssdk/patches/103-hsl_phy-add-support-for-AQR114C-B0-PHY.patch
@@ -1,0 +1,33 @@
+From ab3b663842f66d0ed290696cee9edb9070a36e8f Mon Sep 17 00:00:00 2001
+From: Paweł Owoc <frut3k7@gmail.com>
+Date: Wed, 7 May 2024 10:37:44 +0100
+Subject: [PATCH] hsl_phy: add support for AQR114C-B0 PHY
+
+Add support for AQR114C-B0 PHY.
+
+Signed-off-by: Paweł Owoc <frut3k7@gmail.com>
+---
+ include/hsl/phy/hsl_phy.h | 1 +
+ src/hsl/phy/hsl_phy.c     | 1 +
+ 2 files changed, 2 insertions(+)
+
+--- a/include/hsl/phy/hsl_phy.h
++++ b/include/hsl/phy/hsl_phy.h
+@@ -612,6 +612,7 @@ typedef struct {
+ #define AQUANTIA_PHY_113C_B0    0x31c31C12
+ #define AQUANTIA_PHY_113C_B1    0x31c31C13
+ #define AQUANTIA_PHY_112C       0x03a1b792
++#define AQUANTIA_PHY_114C_B0    0x31c31c22
+ #define MVL_PHY_X3410           0x31c31DD3
+ 
+ #define PHY_805XV2              0x004DD082
+--- a/src/hsl/phy/hsl_phy.c
++++ b/src/hsl/phy/hsl_phy.c
+@@ -271,6 +271,7 @@ phy_type_t hsl_phytype_get_by_phyid(a_uint32_t dev_id, a_uint32_t phy_id)
+ 		case AQUANTIA_PHY_113C_B0:
+ 		case AQUANTIA_PHY_113C_B1:
+ 		case AQUANTIA_PHY_112C:
++		case AQUANTIA_PHY_114C_B0:
+ 		case MVL_PHY_X3410:
+ 			phytype = AQUANTIA_PHY_CHIP;
+ 			break;

--- a/target/linux/generic/backport-6.6/765-v6.9-net-phy-aquantia-add-support-for-AQR114C-PHY-ID.patch
+++ b/target/linux/generic/backport-6.6/765-v6.9-net-phy-aquantia-add-support-for-AQR114C-PHY-ID.patch
@@ -1,0 +1,69 @@
+From c278ec644377249aba5b1e1ca2b5705fd1c0132c Mon Sep 17 00:00:00 2001
+From: Paweł Owoc <frut3k7@gmail.com>
+Date: Mon, 1 Apr 2024 16:51:06 +0200
+Subject: [PATCH net-next v2] net: phy: aquantia: add support for AQR114C PHY ID  
+
+Add support for AQR114C PHY ID. This PHY advertise 10G speed:
+SPEED(0x04): 0x6031
+  capabilities: -400g +5g +2.5g -200g -25g -10g-xr -100g -40g -10g/1g -10
+                +100 +1000 -10-ts -2-tl +10g
+EXTABLE(0x0B): 0x40fc
+  capabilities: -10g-cx4 -10g-lrm +10g-t +10g-kx4 +10g-kr +1000-t +1000-kx
+                +100-tx -10-t -p2mp -40g/100g -1000/100-t1 -25g -200g/400g
+                +2.5g/5g -1000-h
+
+but supports only up to 5G speed (as with AQR111/111B0).
+AQR111 init config is used to set max speed 5G.
+
+Signed-off-by: Paweł Owoc <frut3k7@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Link: https://lore.kernel.org/r/20240401145114.1699451-1-frut3k7@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/phy/aquantia/aquantia_main.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+--- a/drivers/net/phy/aquantia/aquantia_main.c
++++ b/drivers/net/phy/aquantia/aquantia_main.c
+@@ -28,6 +28,7 @@
+ #define PHY_ID_AQR412	0x03a1b712
+ #define PHY_ID_AQR113	0x31c31c40
+ #define PHY_ID_AQR113C	0x31c31c12
++#define PHY_ID_AQR114C	0x31c31c22
+ #define PHY_ID_AQR813	0x31c31cb2
+ 
+ #define MDIO_PHYXS_VEND_IF_STATUS		0xe812
+@@ -880,6 +881,25 @@ static struct phy_driver aqr_driver[] =
+ 	.link_change_notify = aqr107_link_change_notify,
+ },
+ {
++	PHY_ID_MATCH_MODEL(PHY_ID_AQR114C),
++	.name           = "Aquantia AQR114C",
++	.probe          = aqr107_probe,
++	.get_rate_matching = aqr107_get_rate_matching,
++	.config_init    = aqr111_config_init,
++	.config_aneg    = aqr_config_aneg,
++	.config_intr    = aqr_config_intr,
++	.handle_interrupt = aqr_handle_interrupt,
++	.read_status    = aqr107_read_status,
++	.get_tunable    = aqr107_get_tunable,
++	.set_tunable    = aqr107_set_tunable,
++	.suspend        = aqr107_suspend,
++	.resume         = aqr107_resume,
++	.get_sset_count = aqr107_get_sset_count,
++	.get_strings    = aqr107_get_strings,
++	.get_stats      = aqr107_get_stats,
++	.link_change_notify = aqr107_link_change_notify,
++},
++{
+ 	PHY_ID_MATCH_MODEL(PHY_ID_AQR813),
+ 	.name		= "Aquantia AQR813",
+ 	.probe		= aqr107_probe,
+@@ -916,6 +936,7 @@ static struct mdio_device_id __maybe_unu
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR412) },
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR113) },
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR113C) },
++	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR114C) },
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR813) },
+ 	{ }
+ };

--- a/target/linux/generic/hack-6.6/722-net-phy-aquantia-enable-AQR112-and-AQR412.patch
+++ b/target/linux/generic/hack-6.6/722-net-phy-aquantia-enable-AQR112-and-AQR412.patch
@@ -15,7 +15,7 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
 
 --- a/drivers/net/phy/aquantia/aquantia_main.c
 +++ b/drivers/net/phy/aquantia/aquantia_main.c
-@@ -101,6 +101,29 @@
+@@ -102,6 +102,29 @@
  #define AQR107_OP_IN_PROG_SLEEP		1000
  #define AQR107_OP_IN_PROG_TIMEOUT	100000
  
@@ -45,7 +45,7 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
  struct aqr107_hw_stat {
  	const char *name;
  	int reg;
-@@ -232,6 +255,51 @@ static int aqr_config_aneg(struct phy_de
+@@ -233,6 +256,51 @@ static int aqr_config_aneg(struct phy_de
  	return genphy_c45_check_and_restart_aneg(phydev, changed);
  }
  
@@ -97,7 +97,7 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
  static int aqr_config_intr(struct phy_device *phydev)
  {
  	bool en = phydev->interrupts == PHY_INTERRUPT_ENABLED;
-@@ -809,7 +877,7 @@ static struct phy_driver aqr_driver[] =
+@@ -810,7 +878,7 @@ static struct phy_driver aqr_driver[] =
  	PHY_ID_MATCH_MODEL(PHY_ID_AQR112),
  	.name		= "Aquantia AQR112",
  	.probe		= aqr107_probe,
@@ -106,7 +106,7 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
  	.config_intr	= aqr_config_intr,
  	.handle_interrupt = aqr_handle_interrupt,
  	.get_tunable    = aqr107_get_tunable,
-@@ -827,7 +895,7 @@ static struct phy_driver aqr_driver[] =
+@@ -828,7 +896,7 @@ static struct phy_driver aqr_driver[] =
  	PHY_ID_MATCH_MODEL(PHY_ID_AQR412),
  	.name		= "Aquantia AQR412",
  	.probe		= aqr107_probe,

--- a/target/linux/generic/hack-6.6/723-net-phy-aquantia-fix-system-side-protocol-mi.patch
+++ b/target/linux/generic/hack-6.6/723-net-phy-aquantia-fix-system-side-protocol-mi.patch
@@ -14,7 +14,7 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
 
 --- a/drivers/net/phy/aquantia/aquantia_main.c
 +++ b/drivers/net/phy/aquantia/aquantia_main.c
-@@ -288,10 +288,16 @@ static int aqr_config_aneg_set_prot(stru
+@@ -289,10 +289,16 @@ static int aqr_config_aneg_set_prot(stru
  	phy_write_mmd(phydev, MDIO_MMD_VEND1, AQUANTIA_VND1_GSTART_RATE,
  		      aquantia_syscfg[if_type].start_rate);
  

--- a/target/linux/generic/hack-6.6/725-net-phy-aquantia-add-PHY_IDs-for-AQR112-variants.patch
+++ b/target/linux/generic/hack-6.6/725-net-phy-aquantia-add-PHY_IDs-for-AQR112-variants.patch
@@ -12,16 +12,16 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/aquantia/aquantia_main.c
 +++ b/drivers/net/phy/aquantia/aquantia_main.c
-@@ -29,6 +29,8 @@
- #define PHY_ID_AQR113	0x31c31c40
+@@ -30,6 +30,8 @@
  #define PHY_ID_AQR113C	0x31c31c12
+ #define PHY_ID_AQR114C	0x31c31c22
  #define PHY_ID_AQR813	0x31c31cb2
 +#define PHY_ID_AQR112C	0x03a1b790
 +#define PHY_ID_AQR112R	0x31c31d12
  
  #define MDIO_PHYXS_VEND_IF_STATUS		0xe812
  #define MDIO_PHYXS_VEND_IF_STATUS_TYPE_MASK	GENMASK(7, 3)
-@@ -972,6 +974,30 @@ static struct phy_driver aqr_driver[] =
+@@ -992,6 +994,30 @@ static struct phy_driver aqr_driver[] =
  	.get_stats	= aqr107_get_stats,
  	.link_change_notify = aqr107_link_change_notify,
  },
@@ -52,9 +52,9 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  };
  
  module_phy_driver(aqr_driver);
-@@ -991,6 +1017,8 @@ static struct mdio_device_id __maybe_unu
- 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR113) },
+@@ -1012,6 +1038,8 @@ static struct mdio_device_id __maybe_unu
  	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR113C) },
+ 	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR114C) },
  	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR813) },
 +	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR112C) },
 +	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR112R) },

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx8500.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx8500.dts
@@ -1,0 +1,523 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Linksys MX8500";
+	compatible = "linksys,mx8500", "qcom,ipq8074";
+
+	aliases {
+		serial0 = &blsp1_uart5;
+		serial1 = &blsp1_uart3;
+		led-boot = &led_system_blue;
+		led-running = &led_system_blue;
+		led-failsafe = &led_system_red;
+		led-upgrade = &led_system_green;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_0 rootfstype=squashfs ro";
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		bt_pwr {
+			gpio-export,name = "bt_pwr";
+			gpio-export,output = <1>;
+			gpios = <&tlmm 21 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset-button {
+			label = "reset";
+			gpios = <&tlmm 67 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps-button {
+			label = "wps";
+			gpios = <&tlmm 64 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&tlmm {
+	button_pins: button-state {
+		pins = "gpio64", "gpio67";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+
+	mdio_pins: mdio-state {
+		mdc-pins {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio-pins {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&blsp1_uart3 {
+	status = "okay";
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	/*
+	 * Bootloader will find the NAND DT node by the compatible and
+	 * then "fixup" it by adding the partitions from the SMEM table
+	 * using the legacy bindings thus making it impossible for us
+	 * to change the partition table or utilize NVMEM for calibration.
+	 * So add a dummy partitions node that bootloader will populate
+	 * and set it as disabled so the kernel ignores it instead of
+	 * printing warnings due to the broken way bootloader adds the
+	 * partitions.
+	 */
+	partitions {
+		status = "disabled";
+	};
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:sbl1";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "0:mibib";
+				reg = <0x100000 0x100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "0:bootconfig";
+				reg = <0x200000 0x80000>;
+				read-only;
+			};
+
+			partition@280000 {
+				label = "0:bootconfig1";
+				reg = <0x280000 0x80000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "0:qsee";
+				reg = <0x300000 0x300000>;
+				read-only;
+			};
+
+			partition@600000 {
+				label = "0:qsee_1";
+				reg = <0x600000 0x300000>;
+				read-only;
+			};
+
+			partition@900000 {
+				label = "0:devcfg";
+				reg = <0x900000 0x80000>;
+				read-only;
+			};
+
+			partition@980000 {
+				label = "0:devcfg_1";
+				reg = <0x980000 0x80000>;
+				read-only;
+			};
+
+			partition@a00000 {
+				label = "0:apdp";
+				reg = <0xa00000 0x80000>;
+				read-only;
+			};
+
+			partition@a80000 {
+				label = "0:apdp_1";
+				reg = <0xa80000 0x80000>;
+				read-only;
+			};
+
+			partition@b00000 {
+				label = "0:rpm";
+				reg = <0xb00000 0x80000>;
+				read-only;
+			};
+
+			partition@b80000 {
+				label = "0:rpm_1";
+				reg = <0xb80000 0x80000>;
+				read-only;
+			};
+
+			partition@c00000 {
+				label = "0:cdt";
+				reg = <0xc00000 0x80000>;
+				read-only;
+			};
+
+			partition@c80000 {
+				label = "0:cdt_1";
+				reg = <0xc80000 0x80000>;
+				read-only;
+			};
+
+			partition@d00000 {
+				label = "0:appsblenv";
+				reg = <0xd00000 0x80000>;
+			};
+
+			partition@d80000 {
+				label = "0:appsbl";
+				reg = <0xd80000 0x100000>;
+				read-only;
+			};
+
+			partition@e80000 {
+				label = "0:appsbl_1";
+				reg = <0xe80000 0x100000>;
+				read-only;
+			};
+
+			partition@f80000 {
+				label = "0:art";
+				reg = <0xf80000 0x80000>;
+				read-only;
+			};
+
+			partition@1000000 {
+				label = "u_env";
+				reg = <0x1000000 0x40000>;
+			};
+
+			partition@1040000 {
+				label = "s_env";
+				reg = <0x1040000 0x20000>;
+			};
+
+			partition@1060000 {
+				label = "devinfo";
+				reg = <0x1060000 0x20000>;
+				read-only;
+			};
+
+			partition@1080000 {
+				label = "kernel";
+				reg = <0x1080000 0x9600000>;
+			};
+
+			partition@1680000 {
+				label = "rootfs";
+				reg = <0x1680000 0x9000000>;
+			};
+
+			partition@a680000 {
+				label = "alt_kernel";
+				reg = <0xa680000 0x9600000>;
+			};
+
+			partition@ac80000 {
+				label = "alt_rootfs";
+				reg = <0xac80000 0x9000000>;
+			};
+
+			partition@13c80000 {
+				label = "sysdiag";
+				reg = <0x13c80000 0x200000>;
+				read-only;
+			};
+
+			partition@13e80000 {
+				label = "0:ethphyfw";
+				reg = <0x13e80000 0x100000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					aqr_fw: firmware@0 {
+						/* Skip the QCOM MBN Header of 40 bytes */
+						reg = <0x28 0x60002>;
+					};
+				};
+			};
+
+			partition@13f80000 {
+				label = "syscfg";
+				reg = <0x13f80000 0xb180000>;
+				read-only;
+			};
+
+			partition@1f100000 {
+				label = "app_data";
+				reg = <0x1f100000 0x500000>;
+				read-only;
+			};
+
+			partition@1f600000 {
+				label = "0:wififw";
+				reg = <0x1f600000 0xa00000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&blsp1_i2c2 {
+	status = "okay";
+
+	led-controller@62 {
+		compatible = "nxp,pca9633";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x62>;
+		nxp,hw-blink;
+
+		led_system_red: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_green: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+
+	ethernet-phy-package@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "qcom,qca8075-package";
+		reg = <0>;
+
+		qcom,package-mode = "qsgmii";
+
+		qca8075_0: ethernet-phy@0 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <0>;
+		};
+
+		qca8075_1: ethernet-phy@1 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <1>;
+		};
+
+		qca8075_2: ethernet-phy@2 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <2>;
+		};
+
+		qca8075_3: ethernet-phy@3 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <3>;
+		};
+	};
+
+	aqr114c: ethernet-phy@8 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <8>;
+		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+		firmware-name = "marvell/AQR-G4_v5.6.5-AQR_WNC_SAQA-L2_GT_ID45287_VER24005.cld";
+		nvmem-cells = <&aqr_fw>;
+		nvmem-cell-names = "firmware";
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
+	switch_mac_mode = <MAC_MODE_QSGMII>; /* mac mode for uniphy instance0*/
+	switch_mac_mode2 = <MAC_MODE_USXGMII>; /* mac mode for uniphy instance2*/
+
+	qcom,port_phyinfo {
+		port@1 {
+			port_id = <1>;
+			phy_address = <0>;
+		};
+
+		port@2 {
+			port_id = <2>;
+			phy_address = <1>;
+		};
+
+		port@3 {
+			port_id = <3>;
+			phy_address = <2>;
+		};
+
+		port@4 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+
+		port@6 {
+			port_id = <6>;
+			phy_address = <8>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			ethernet-phy-ieee802.3-c45;
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp1 {
+	status = "okay";
+	phy-mode = "qsgmii";
+	phy-handle = <&qca8075_0>;
+	label = "lan1";
+};
+
+&dp2 {
+	status = "okay";
+	phy-mode = "qsgmii";
+	phy-handle = <&qca8075_1>;
+	label = "lan2";
+};
+
+&dp3 {
+	status = "okay";
+	phy-mode = "qsgmii";
+	phy-handle = <&qca8075_2>;
+	label = "lan3";
+};
+
+&dp4 {
+	status = "okay";
+	phy-mode = "qsgmii";
+	phy-handle = <&qca8075_3>;
+	label = "lan4";
+};
+
+&dp6_syn {
+	status = "okay";
+	phy-mode = "usxgmii";
+	phy-handle = <&aqr114c>;
+	label = "wan";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&usb_0 {
+	status = "okay";
+};
+
+&pcie_qmp0 {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+
+	perst-gpio = <&tlmm 61 GPIO_ACTIVE_LOW>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			status = "okay";
+
+			/* ath11k has no DT compatible for PCI cards */
+			compatible = "pci17cb,1104";
+			reg = <0x00010000 0 0 0 0>;
+
+			qcom,ath11k-calibration-variant = "Linksys-MX8500";
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Linksys-MX8500";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -103,20 +103,26 @@ define Device/edimax_cax1800
 endef
 TARGET_DEVICES += edimax_cax1800
 
-define Device/linksys_mx4200v1
+define Device/linksys_mx
 	$(call Device/FitImage)
 	DEVICE_VENDOR := Linksys
-	DEVICE_MODEL := MX4200
-	DEVICE_VARIANT := v1
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	KERNEL_SIZE := 6144k
 	IMAGE_SIZE := 147456k
 	NAND_SIZE := 512m
-	SOC := ipq8174
+	SOC := ipq8072
 	IMAGES += factory.bin
-	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=MX4200
-	DEVICE_PACKAGES := kmod-leds-pca963x ipq-wifi-linksys_mx4200 kmod-bluetooth
+	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=$$$$(DEVICE_MODEL)
+	DEVICE_PACKAGES := kmod-leds-pca963x
+endef
+
+define Device/linksys_mx4200v1
+	$(call Device/linksys_mx)
+	DEVICE_MODEL := MX4200
+	DEVICE_VARIANT := v1
+	SOC := ipq8174
+	DEVICE_PACKAGES += ipq-wifi-linksys_mx4200 kmod-bluetooth
 endef
 TARGET_DEVICES += linksys_mx4200v1
 
@@ -127,19 +133,10 @@ endef
 TARGET_DEVICES += linksys_mx4200v2
 
 define Device/linksys_mx5300
-	$(call Device/FitImage)
-	DEVICE_VENDOR := Linksys
+	$(call Device/linksys_mx)
 	DEVICE_MODEL := MX5300
-	BLOCKSIZE := 128k
-	PAGESIZE := 2048
-	KERNEL_SIZE := 6144k
-	IMAGE_SIZE := 147456k
-	NAND_SIZE := 512m
-	SOC := ipq8072
-	IMAGES += factory.bin
-	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=MX5300
-	DEVICE_PACKAGES := kmod-leds-pca963x kmod-rtc-ds1307 \
-		ipq-wifi-linksys_mx5300 kmod-ath10k-ct ath10k-firmware-qca9984-ct
+	DEVICE_PACKAGES += kmod-rtc-ds1307 ipq-wifi-linksys_mx5300 \
+		kmod-ath10k-ct ath10k-firmware-qca9984-ct
 endef
 TARGET_DEVICES += linksys_mx5300
 

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -140,6 +140,14 @@ define Device/linksys_mx5300
 endef
 TARGET_DEVICES += linksys_mx5300
 
+define Device/linksys_mx8500
+	$(call Device/linksys_mx)
+	DEVICE_MODEL := MX8500
+	DEVICE_PACKAGES += ipq-wifi-linksys_mx8500 kmod-ath11k-pci \
+		ath11k-firmware-qcn9074 kmod-bluetooth
+endef
+TARGET_DEVICES += linksys_mx8500
+
 define Device/netgear_rax120v2
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -15,6 +15,7 @@ ipq807x_setup_interfaces()
 	buffalo,wxr-5950ax12|\
 	dynalink,dl-wrx36|\
 	linksys,mx5300|\
+	linksys,mx8500|\
 	xiaomi,ax9000|\
 	zbtlink,zbt-z800ax)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
@@ -75,6 +76,11 @@ ipq807x_setup_macs()
 				[ "$(mtd_get_mac_ascii u_env eth${i}addr)" != "$label_mac" ] && lan_mac=$label_mac
 			done
 			[ "$(mtd_get_mac_ascii u_env eth2addr)" != "$label_mac" ] && wan_mac=$label_mac
+		;;
+		linksys,mx8500)
+			label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
+			lan_mac=$(macaddr_add $label_mac 1)
+			wan_mac=$label_mac
 		;;
 	esac
 

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -29,7 +29,8 @@ case "$FIRMWARE" in
 	zte,mf269)
 		caldata_extract "0:art" 0x1000 0x20000
 		;;
-	linksys,mx4200v1)
+	linksys,mx4200v1|\
+	linksys,mx8500)
 		caldata_extract "0:art" 0x1000 0x20000
 		ath11k_remove_regdomain
 		;;
@@ -66,6 +67,10 @@ case "$FIRMWARE" in
 "ath11k/QCN9074/hw1.0/cal-pci-0000:01:00.0.bin"|\
 "ath11k/QCN9074/hw1.0/cal-pci-0001:01:00.0.bin")
 	case "$board" in
+	linksys,mx8500)
+		caldata_extract "0:art" 0x26800 0x20000
+		ath11k_remove_regdomain
+		;;
 	prpl,haze)
 		caldata_extract_mmc "0:ART" 0x26800 0x20000
 		;;

--- a/target/linux/qualcommax/ipq807x/base-files/etc/init.d/bootcount
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/init.d/bootcount
@@ -12,7 +12,8 @@ boot() {
 	;;
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
-	linksys,mx5300)
+	linksys,mx5300|\
+	linksys,mx8500)
 		mtd resetbc s_env || true
 	;;
 	esac

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -77,7 +77,8 @@ platform_do_upgrade() {
 		;;
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
-	linksys,mx5300)
+	linksys,mx5300|\
+	linksys,mx8500)
 		boot_part="$(fw_printenv -n boot_part)"
 		if [ "$boot_part" -eq "1" ]; then
 			fw_setenv boot_part 2

--- a/target/linux/qualcommax/patches-6.6/0063-v6.9-arm64-dts-qcom-ipq8074-Remove-unused-gpio-from-QPIC-.patch
+++ b/target/linux/qualcommax/patches-6.6/0063-v6.9-arm64-dts-qcom-ipq8074-Remove-unused-gpio-from-QPIC-.patch
@@ -1,0 +1,32 @@
+From 5f78d9213ae753e2242b0f6a5d4a5e98e55ddc76 Mon Sep 17 00:00:00 2001
+From: Paweł Owoc <frut3k7@gmail.com>
+Date: Wed, 13 Mar 2024 11:27:06 +0100
+Subject: [PATCH] arm64: dts: qcom: ipq8074: Remove unused gpio from QPIC pins
+
+gpio16 will only be used for LCD support, as its NAND/LCDC data[8]
+so its bit 9 of the parallel QPIC interface, and ONFI NAND is only 8
+or 16-bit with only 8-bit one being supported in our case so that pin
+is unused.
+
+It should be dropped from the default NAND pinctrl configuration
+as its unused and only needed for LCD.
+
+Signed-off-by: Paweł Owoc <frut3k7@gmail.com>
+Reviewed-by: Kathiravan Thirumoorthy <quic_kathirav@quicinc.com>
+Link: https://lore.kernel.org/r/20240313102713.1727458-1-frut3k7@gmail.com
+Signed-off-by: Bjorn Andersson <andersson@kernel.org>
+---
+ arch/arm64/boot/dts/qcom/ipq8074.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/qcom/ipq8074.dtsi
++++ b/arch/arm64/boot/dts/qcom/ipq8074.dtsi
+@@ -372,7 +372,7 @@
+ 				       "gpio5", "gpio6", "gpio7",
+ 				       "gpio8", "gpio10", "gpio11",
+ 				       "gpio12", "gpio13", "gpio14",
+-				       "gpio15", "gpio16", "gpio17";
++				       "gpio15", "gpio17";
+ 				function = "qpic";
+ 				drive-strength = <8>;
+ 				bias-disable;


### PR DESCRIPTION
Hardware specification:
========
SoC: Qualcomm IPQ8072A
Flash: 512MB (Fidelix FMND4G08S3J-ID)
RAM: 1GB (2x Kingston DDR3L D2516ECMDXGJD)
Ethernet: 1x 10/100/1000/2500/5000Mbps (Marvell AQR114C)
Ethernet: 4x 10/100/1000Mbps (Qualcomm QCA8075)
WiFi1: 6GHz ax 4x4 (Qualcomm QCN9024 + Skyworks SKY85784-11) - channels 33-229
WiFi2: 5GHz ax 4x4 (Qualcomm QCN5054 + Skyworks SKY85755-11) - channels 36-177
WiFi3: 2.4GHz ax 4x4 (Qualcomm QCN5024 + Skyworks SKY8340-11)
IoT: Bluetooth 5, Zigbee and Thread (NXP K32W041)
LED: 1x RGB status (NXP PCA9633)
USB: 1x USB 3.0
Button: WPS, Reset

Flash instructions:
========
1. Manually upgrade firmware using openwrt-qualcommax-ipq807x-linksys_mx8500-squashfs-factory.bin image.
    More details can be found here: https://www.linksys.com/support-article?articleNum=47547
    After first boot check actual partition:
    - `fw_printenv -n boot_part`

    and install firmware on second partition using command in case of 2:
    - `mtd -r -e kernel -n write openwrt-qualcommax-ipq807x-linksys_mx8500-squashfs-factory.bin kernel`

    and in case of 1:
    - `mtd -r -e alt_kernel -n write openwrt-qualcommax-ipq807x-linksys_mx8500-squashfs-factory.bin alt_kernel`

2. Installation using serial connection from OEM firmware (default login: root, password: admin):
    - `fw_printenv -n boot_part`

    In case of 2:
    - `flash_erase /dev/mtd21 0 0`
    - `nandwrite -p /dev/mtd21 openwrt-qualcommax-ipq807x-linksys_mx8500-squashfs-factory.bin`

    or in case of 1:
    - `flash_erase /dev/mtd23 0 0`
    - `nandwrite -p /dev/mtd23 openwrt-qualcommax-ipq807x-linksys_mx8500-squashfs-factory.bin`

    After first boot install firmware on second partition:
    - `mtd -r -e kernel -n write openwrt-qualcommax-ipq807x-linksys_mx8500-squashfs-factory.bin kernel`

    or:
    - `mtd -r -e alt_kernel -n write openwrt-qualcommax-ipq807x-linksys_mx8500-squashfs-factory.bin alt_kernel`

3. Installation from initramfs image using USB drive:
    Put the initramfs image on the USB drive:
    - `dd bs=1M if=openwrt-qualcommax-ipq807x-linksys_mx8500-initramfs-uImage.itb of=/dev/sda`

    Stop u-boot and run:
    - `usb start && usbboot $loadaddr 0 && bootm $loadaddr`

    Write firmware to the flash from initramfs:
    - `mtd -e kernel -n write openwrt-qualcommax-ipq807x-linksys_mx8500-squashfs-factory.bin kernel`

    and:
    - `mtd -r -e alt_kernel -n write openwrt-qualcommax-ipq807x-linksys_mx8500-squashfs-factory.bin alt_kernel`

4. Back to the OEM firmware:
    - `mtd -e kernel -n write FW_MX8500_1.0.11.208937_prod.img kernel`

    and:
    - `mtd -r -e alt_kernel -n write FW_MX8500_1.0.11.208937_prod.img alt_kernel`

5. USB recovery:
    Put the initramfs image on the USB:
    - `dd bs=1M if=openwrt-qualcommax-ipq807x-linksys_mx8500-initramfs-uImage.itb of=/dev/sda`

    Set u-boot env:
    - `fw_setenv bootusb 'usb start && usbboot $loadaddr 0 && bootm $loadaddr'`
    - `fw_setenv bootcmd 'run bootusb; if test $auto_recovery = no; then bootipq; elif test $boot_part = 1; then run bootpart1; else run bootpart2; fi'`

AQR firmware:
========
1. Firmware loading:
    To properly load the firmware and initialize AQR PHY, we must use the u-boot `aq_load_fw` function.
    To do this, you need to modify u-boot env:
    With USB recovery:
    - `fw_setenv bootcmd 'aq_load_fw; run bootusb; if test $auto_recovery = no; then bootipq; elif test $boot_part = 1; then run bootpart1; else run bootpart2; fi'`

    and without:
    - `fw_setenv bootcmd 'aq_load_fw; if test $auto_recovery = no; then bootipq; elif test $boot_part = 1; then run bootpart1; else run bootpart2; fi'`
2. Firmware updating:
    Newer firmware (`AQR-G4_v5.6.5-AQR_WNC_SAQA-L2_GT_ID45287_VER24005.cld`) is available in the latest OEM firmware.
    To load this firmware via u-boot, we need to add the MBN header and update `0:ethphyfw` partition.
    For MBN header we can use script from this repository: https://github.com/testuser7/aqr_mbn_tool
    - `python aqr_mbn_tool.py AQR-G4_v5.6.5-AQR_WNC_SAQA-L2_GT_ID45287_VER24005.cld`

    To update partition we need to install `kmod-mtd-rw` package first:
    - `insmod mtd-rw.ko i_want_a_brick=1`
    - `mtd -e /dev/mtd26 -n write aqr_fw.mbn /dev/mtd26`