### PR TITLE
bmips: add support for Sagemcom F@ST 3864 OP

### DIFF
--- a/target/linux/bmips/bcm63268/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm63268/base-files/etc/board.d/02_network
@@ -18,6 +18,7 @@ sercomm,h500-s-vfes)
 	uci add_list firewall.@zone[0].network='qtn'
 	;;
 comtrend,vg-8050 |\
+sagem,fast-3864-op |\
 sercomm,shg2500)
 	ucidef_set_bridge_device switch
 	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"

--- a/target/linux/bmips/bcm63268/base-files/lib/upgrade/platform.sh
+++ b/target/linux/bmips/bcm63268/base-files/lib/upgrade/platform.sh
@@ -10,7 +10,8 @@ platform_check_image() {
 platform_do_upgrade() {
 	case "$(board_name)" in
 	comtrend,vg-8050 |\
-	comtrend,vr-3032u)
+	comtrend,vr-3032u |\
+	sagem,fast-3864-op)
 		CI_JFFS2_CLEAN_MARKERS=1
 		nand_do_upgrade "$1"
 		;;

--- a/target/linux/bmips/dts/bcm63168-sagem-fast-3864-op.dts
+++ b/target/linux/bmips/dts/bcm63168-sagem-fast-3864-op.dts
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm63268.dtsi"
+
+/ {
+	model = "Sagemcom F@ST 3864 OP";
+	compatible = "sagem,fast-3864-op", "brcm,bcm63168", "brcm,bcm63268";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		wlan {
+			label = "wlan";
+			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WLAN>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cferom_6a0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&leds {
+	status = "okay";
+	brcm,serial-leds;
+	brcm,serial-dat-low;
+	brcm,serial-shift-inv;
+	brcm,serial-mux;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_leds &pinctrl_serial_led>;
+
+	led@0 {
+		reg = <0>;
+		active-low;
+		function = LED_FUNCTION_WPS;
+		color = <LED_COLOR_ID_GREEN>;
+	};
+
+	led@1 {
+		reg = <1>;
+		active-low;
+		function = LED_FUNCTION_WPS;
+		color = <LED_COLOR_ID_RED>;
+	};
+
+	led@2 {
+		reg = <2>;
+		active-low;
+		label = "red:internet";
+	};
+
+	led@3 {
+		reg = <3>;
+		active-low;
+		label = "green:dsl";
+	};
+
+	led@4 {
+		reg = <4>;
+		active-low;
+		label = "green:fxs";
+	};
+
+	led@5 {
+		reg = <5>;
+		active-low;
+		label = "red:fxs";
+	};
+
+	led@8 {
+		reg = <8>;
+		active-low;
+		label = "green:internet";
+	};
+
+	led@9 {
+		reg = <9>;
+		active-low;
+		label = "green:dsl_bonding";
+	};
+
+	led_power_red: led@15 {
+		reg = <15>;
+		active-low;
+		function = LED_FUNCTION_POWER;
+		color = <LED_COLOR_ID_RED>;
+	};
+
+	led_power_green: led@20 {
+		reg = <20>;
+		active-low;
+		function = LED_FUNCTION_POWER;
+		color = <LED_COLOR_ID_GREEN>;
+	};
+};
+
+&mdio_ext {
+	switch@1e {
+		compatible = "brcm,bcm53125";
+		reg = <0x1e>;
+
+		dsa,member = <1 0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@1 {
+				reg = <1>;
+				label = "lan4";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan2";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "lan1";
+			};
+
+			port@8 {
+				reg = <8>;
+
+				phy-mode = "rgmii";
+				ethernet = <&switch0port4>;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+					asym-pause;
+					pause;
+				};
+			};
+		};
+	};
+};
+
+&nflash {
+	status = "okay";
+
+	nandcs@0 {
+		compatible = "brcm,nandcs";
+		reg = <0>;
+		nand-ecc-step-size = <512>;
+		nand-ecc-strength = <15>;
+		nand-on-flash-bbt;
+		brcm,nand-oob-sector-size = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "cferom_nvram";
+				reg = <0x00000000 0x00020000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_cferom_6a0: macaddr@6a0 {
+						reg = <0x6a0 0x6>;
+					};
+				};
+			};
+
+			partition@20000 {
+				compatible = "brcm,wfi-split";
+				label = "wfi";
+				reg = <0x00020000 0x7ac0000>;
+			};
+
+			partition@7ae0000 {
+				label = "stock_hidden1";
+				reg = <0x07ae0000 0x0020000>;
+				read-only;
+			};
+
+			partition@7b00000 {
+				label = "stock_data";
+				reg = <0x07b00000 0x0400000>;
+				read-only;
+			};
+
+			partition@7f00000 {
+				label = "stock_hidden2";
+				reg = <0x07f00000 0x0100000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pinctrl {
+	pinctrl_leds: leds {
+		function = "led";
+		pins = "gpio8", "gpio9", "gpio15",
+		       "gpio20";
+	};
+};
+
+&switch0 {
+	dsa,member = <0 0>;
+
+	ports {
+		port@3 {
+			reg = <3>;
+			label = "wan";
+
+			phy-handle = <&phy4>;
+		};
+
+		switch0port4: port@4 {
+			reg = <4>;
+			label = "extsw";
+
+			phy-mode = "rgmii";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};

--- a/target/linux/bmips/image/bcm63268.mk
+++ b/target/linux/bmips/image/bcm63268.mk
@@ -38,6 +38,26 @@ define Device/comtrend_vr-3032u
 endef
 TARGET_DEVICES += comtrend_vr-3032u
 
+define Device/sagem_fast-3864-op
+  $(Device/bcm63xx-nand)
+  DEVICE_VENDOR := Sagemcom
+  DEVICE_MODEL := F@ST 3864
+  DEVICE_VARIANT := OP
+  CHIP_ID := 63268
+  SOC := bcm63168
+  CFE_RAM_FILE := sagem,fast-3864-op/cferam.000
+  CFE_RAM_JFFS2_NAME := cferam.000
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  SUBPAGESIZE := 512
+  VID_HDR_OFFSET := 2048
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    kmod-leds-bcm6328
+  CFE_WFI_FLASH_TYPE := 3
+  CFE_WFI_VERSION := 0x5732
+endef
+TARGET_DEVICES += sagem_fast-3864-op
+
 define Device/sercomm_h500-s-lowi
   $(Device/sercomm-nand)
   DEVICE_VENDOR := Sercomm


### PR DESCRIPTION
    Specifications:
    * SoC: BCM63168
    * RAM: NT5CC64M16GP-DI, DDR3 128MiB
    * NAND: W29N01HVSINA, 128MiB
    * Ethernet: 4x1000M LAN, 1x 1000M WAN
    * Serial interface: on board but not populated, 3.3V, 115200, 8N1

    Notes:
    * Use DSA for VLAN and switches
    * Ethernet ports and USB works
    * gpio-leds are not working
    * WLAN, xDSL, and FXS are not going to work

https://openwrt.org/inbox/toh/sagem/f_st3864op

I'm adding support for a BCM63168 OEM router and i found that the "gpio-leds" does not work BMIPS target. It worked on the old BCM63xx target. I removed the "gpio-leds" in the DTS and compiled it against the latest BMIPS codes, then tried to control the LEDs via `/sys/class/gpio`, it doesn't work, except for GPIO8. (I tried to toggle all 52 GPIOs)

In my DTS, LEDs driven by the 74HC164 shift-register and GPIO LEDs (<24) are controlled by the hardware LED controller and working as expected. However, my router has LEDs that are attached to GPIOs >32, and "gpio-leds" is the only option, as the LED controller hardware only supports up to 24 LEDs. 

In my BMIPS image, command `ls /sys/class/gpio` gives: `export       gpiochip460  unexport` and `cat /sys/class/gpio/gpiochip460/ngpio` gives `52`. But I remembered back in the BCM63xx target, there were two gpiochip instances.

[This wiki page](https://openwrt.org/docs/techref/hardware/soc/soc.broadcom.bcm63xx#gpios) said that:
```
When having more than 32 GPIOs they are splitted between 2 gpiochips. The labels in the Linux kernel are:

bcm63xx-gpio.0
bcm63xx-gpio.1
```

So I think there might be some problem with the GPIO controller driver on the BMIPS target?

Interestingly, buttons connected to GPIO32 to 34 works without any issue. This script fails on setting GPIO39 high(460+39):
```
root@OpenWrt:~# cat /sys/class/gpio/gpiochip*/base | head -n1
460
root@OpenWrt:~# echo 499 > /sys/class/gpio/export
root@OpenWrt:~# echo out > /sys/class/gpio/gpio499/direction
root@OpenWrt:~# cat /sys/class/gpio/gpio499/value
0
root@OpenWrt:~# echo 1 > /sys/class/gpio/gpio499/value
root@OpenWrt:~# cat /sys/class/gpio/gpio499/value
0
root@OpenWrt:~# cat  /sys/class/gpio/gpio499/active_low
0
```
Further investigation shows that the above script works from GPIO32 to GPIO35. GPIO36 to GPIO39 cannot be controlled (the value stays zero). Recall the [BCM63xx DTS](https://github.com/rikka0w0/openwrt-fast3864op/blob/47bd137ba3afd910c32da007f1e9418a2abf7381/target/linux/bcm63xx/dts/bcm63168-sagem-fast-3864op.dts#L87) which had GPIO36 to GPIO39 worked, the LED connect to GPIO39 should be on if the GPIO is set to low, but this isn't the case.

I also tried to remove the LEDs from DTS and probe all GPIOs with [this script](https://openwrt.org/docs/techref/hardware/port.gpio#script_blink), but the LEDs mentioned above never turned on. Could they be somehow hardware-controlled?

Prebuild firmware (Use with caution):
[openwrt-firmware.zip](https://github.com/openwrt/openwrt/files/14604811/openwrt-firmware.zip)
