### PR TITLE
[23.05]: Dnsmasq fixes

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.89
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.89
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/patches/010-CVE-2023-28450-Set-the-default-maximum-DNS-UDP-packet-size-to-1232.patch
+++ b/package/network/services/dnsmasq/patches/010-CVE-2023-28450-Set-the-default-maximum-DNS-UDP-packet-size-to-1232.patch
@@ -1,0 +1,51 @@
+From eb92fb32b746f2104b0f370b5b295bb8dd4bd5e5 Mon Sep 17 00:00:00 2001
+From: Simon Kelley <simon@thekelleys.org.uk>
+Date: Tue, 7 Mar 2023 22:07:46 +0000
+Subject: Set the default maximum DNS UDP packet size to 1232.
+
+http://www.dnsflagday.net/2020/ refers.
+
+Thanks to Xiang Li for the prompt.
+---
+ CHANGELOG     | 9 ++++++++-
+ man/dnsmasq.8 | 3 ++-
+ src/config.h  | 2 +-
+ 3 files changed, 11 insertions(+), 3 deletions(-)
+
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -1,3 +1,11 @@
++	Set the default maximum DNS UDP packet sice to 1232. This
++	has been the recommended value since 2020 because it's the
++	largest value that avoid fragmentation, and fragmentation
++	is just not reliable on the modern internet, especially
++	for IPv6. It's still possible to override this with
++	--edns-packet-max for special circumstances.
++
++	
+ version 2.89
+         Fix bug introduced in 2.88 (commit fe91134b) which can result
+ 	in corruption of the DNS cache internal data structures and
+--- a/man/dnsmasq.8
++++ b/man/dnsmasq.8
+@@ -183,7 +183,8 @@ to zero completely disables DNS function
+ .TP
+ .B \-P, --edns-packet-max=<size>
+ Specify the largest EDNS.0 UDP packet which is supported by the DNS
+-forwarder. Defaults to 4096, which is the RFC5625-recommended size.
++forwarder. Defaults to 1232, which is the recommended size following the
++DNS flag day in 2020. Only increase if you know what you are doing.
+ .TP
+ .B \-Q, --query-port=<query_port>
+ Send outbound DNS queries from, and listen for their replies on, the
+--- a/src/config.h
++++ b/src/config.h
+@@ -19,7 +19,7 @@
+ #define CHILD_LIFETIME 150 /* secs 'till terminated (RFC1035 suggests > 120s) */
+ #define TCP_MAX_QUERIES 100 /* Maximum number of queries per incoming TCP connection */
+ #define TCP_BACKLOG 32  /* kernel backlog limit for TCP connections */
+-#define EDNS_PKTSZ 4096 /* default max EDNS.0 UDP packet from RFC5625 */
++#define EDNS_PKTSZ 1232 /* default max EDNS.0 UDP packet from from  /dnsflagday.net/2020 */
+ #define SAFE_PKTSZ 1232 /* "go anywhere" UDP packet size, see https://dnsflagday.net/2020/ */
+ #define KEYBLOCK_LEN 40 /* choose to minimise fragmentation when storing DNSSEC keys */
+ #define DNSSEC_WORK 50 /* Max number of queries to validate one question */

--- a/package/network/services/dnsmasq/patches/020-Fix-use-after-free-in-cache_remove_uid.patch
+++ b/package/network/services/dnsmasq/patches/020-Fix-use-after-free-in-cache_remove_uid.patch
@@ -1,0 +1,44 @@
+From 568fb02449a8b43cce7c8da212558ecf022a5f40 Mon Sep 17 00:00:00 2001
+From: Simon Kelley <simon@thekelleys.org.uk>
+Date: Mon, 13 Nov 2023 22:08:08 +0000
+Subject: Fix use-after-free in cache_remove_uid().
+
+Thanks to Kevin Darbyshire-Bryant for the bug report.
+---
+ src/cache.c | 23 +++++++++++++----------
+ 1 file changed, 13 insertions(+), 10 deletions(-)
+
+--- a/src/cache.c
++++ b/src/cache.c
+@@ -412,18 +412,21 @@ unsigned int cache_remove_uid(const unsi
+ {
+   int i;
+   unsigned int removed = 0;
+-  struct crec *crecp, **up;
++  struct crec *crecp, *tmp, **up;
+ 
+   for (i = 0; i < hash_size; i++)
+-    for (crecp = hash_table[i], up = &hash_table[i]; crecp; crecp = crecp->hash_next)
+-      if ((crecp->flags & (F_HOSTS | F_DHCP | F_CONFIG)) && crecp->uid == uid)
+-	{
+-	  *up = crecp->hash_next;
+-	  free(crecp);
+-	  removed++;
+-	}
+-      else
+-	up = &crecp->hash_next;
++    for (crecp = hash_table[i], up = &hash_table[i]; crecp; crecp = tmp)
++      {
++	tmp = crecp->hash_next;
++	if ((crecp->flags & (F_HOSTS | F_DHCP | F_CONFIG)) && crecp->uid == uid)
++	  {
++	    *up = tmp;
++	    free(crecp);
++	    removed++;
++	  }
++	else
++	  up = &crecp->hash_next;
++      }
+   
+   return removed;
+ }


### PR DESCRIPTION
 * dnsmasq: Fix CVE-2023-28450
    
    This backports a fix from dnsmasq 2.90 to fix CVE-2023-28450.
    This only affects DNSSEC.
    
 * dnsmasq: Fix use after free
    
    Backport a patch from upstream dnsmasq 2.90 which fixes a use after free.