### PR TITLE
[23.05]: kernel: mac80211: mac80211 stops pushing data and packet rate drops to 0 with large buffer sizes

### DIFF
--- a/package/kernel/mac80211/patches/subsys/306-wifi-mac80211-proper-mark-iTXQs-for-resumption.patch
+++ b/package/kernel/mac80211/patches/subsys/306-wifi-mac80211-proper-mark-iTXQs-for-resumption.patch
@@ -1,0 +1,51 @@
+From: Alexander Wetzel <alexander@wetzel-home.de>
+Subject: [PATCH] wifi: mac80211: Proper mark iTXQs for resumption
+Date: Fri, 30 Dec 2022 13:18:49 +0100
+
+When a running wake_tx_queue() call is aborted due to a hw queue stop
+the corresponding iTXQ is not always correctly marked for resumption:
+wake_tx_push_queue() can stops the queue run without setting
+@IEEE80211_TXQ_STOP_NETIF_TX.
+
+Without the @IEEE80211_TXQ_STOP_NETIF_TX flag __ieee80211_wake_txqs()
+will not schedule a new queue run and remaining frames in the queue get
+stuck till another frame is queued to it.
+
+Fix the issue for all drivers - also the ones with custom wake_tx_queue
+callbacks - by moving the logic into ieee80211_tx_dequeue() and drop the
+redundant @txqs_stopped.
+
+@IEEE80211_TXQ_STOP_NETIF_TX is also renamed to @IEEE80211_TXQ_DIRTY to
+better describe the flag.
+
+Fixes: c850e31f79f0 ("wifi: mac80211: add internal handler for wake_tx_queue")
+Signed-off-by: Alexander Wetzel <alexander@wetzel-home.de>
+Tested-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+Tested-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>
+---
+
+--- a/net/mac80211/util.c
++++ b/net/mac80211/util.c
+@@ -292,22 +292,12 @@ static void wake_tx_push_queue(struct ie
+ 			       struct ieee80211_sub_if_data *sdata,
+ 			       struct ieee80211_txq *queue)
+ {
+-	int q = sdata->vif.hw_queue[queue->ac];
+ 	struct ieee80211_tx_control control = {
+ 		.sta = queue->sta,
+ 	};
+ 	struct sk_buff *skb;
+-	unsigned long flags;
+-	bool q_stopped;
+ 
+ 	while (1) {
+-		spin_lock_irqsave(&local->queue_stop_reason_lock, flags);
+-		q_stopped = local->queue_stop_reasons[q];
+-		spin_unlock_irqrestore(&local->queue_stop_reason_lock, flags);
+-
+-		if (q_stopped)
+-			break;
+-
+ 		skb = ieee80211_tx_dequeue(&local->hw, queue);
+ 		if (!skb)
+ 			break;

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -1405,10 +1405,7 @@ wpa_supplicant_add_network() {
 			case "$eap_type" in
 				tls)
 					json_get_vars client_cert priv_key priv_key_pwd
-     					# When PKCS#12/PFX file (.p12/.pfx) is used, client_cert should be commented out
-     					if [[ -n "$priv_key" && "$priv_key" != *".p12"* && "$priv_key" != *".pfx"* ]]; then
-                                                append network_data "client_cert=\"$client_cert\"" "$N$T"
-                                        fi
+					append network_data "client_cert=\"$client_cert\"" "$N$T"
 					append network_data "private_key=\"$priv_key\"" "$N$T"
 					append network_data "private_key_passwd=\"$priv_key_pwd\"" "$N$T"
 

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -1405,7 +1405,10 @@ wpa_supplicant_add_network() {
 			case "$eap_type" in
 				tls)
 					json_get_vars client_cert priv_key priv_key_pwd
-					append network_data "client_cert=\"$client_cert\"" "$N$T"
+     					# When PKCS#12/PFX file (.p12/.pfx) is used, client_cert should be commented out
+     					if [[ -n "$priv_key" && "$priv_key" != *".p12"* && "$priv_key" != *".pfx"* ]]; then
+                                                append network_data "client_cert=\"$client_cert\"" "$N$T"
+                                        fi
 					append network_data "private_key=\"$priv_key\"" "$N$T"
 					append network_data "private_key_passwd=\"$priv_key_pwd\"" "$N$T"
 


### PR DESCRIPTION
I am facing an issue, where my wireless driver is unable to push data with large buffer sizes and packet rate drops to 0.

With more investigation I see that there is an issue with the “wake_tx_queue " ieee80211_ops callback ieee80211_handle_wake_tx_queue in Openwrt.

Originally mac80211 v6.1.24 brought in the model, where the driver pulls data frames from the mac80211 queue instead of letting mac80211 push them via drv_tx(), if the driver indicates that it uses this model by implementing the .wake_tx_queue driver operation. This makes “.wake_tx_queue” an optional callback in v6.1.24.

Whereas, since openwrt pulls patches from newer versions, it did bring in patches from v6.2 which reverts this model, and again makes “.wake_tx_queue” a mandatory callback in Openwrt.

[git.openwrt.org Git - openwrt/openwrt.git/blob - package/kernel/mac80211/patches/subsys/306-01-v6.2-wifi-mac80211-add-internal-handler-for-wake_tx_queue.patch](https://git.openwrt.org/?p=openwrt/openwrt.git;a=blob;f=package/kernel/mac80211/patches/subsys/306-01-v6.2-wifi-mac80211-add-internal-handler-for-wake_tx_queue.patch;h=d14ba05e695c8ff4d464afea7ca190fad9025159;hb=1c26bcb10819f072964a658e2cc29bb87613a6f5)

To mitigate this situation, we assign “ieee80211_handle_wake_tx_queue" as the wake_tx_queue callback in our wireless driver.

I also see that there was a regression in mac80211 which was fixed as a part of the following patch

https://patchwork.kernel.org/project/linux-wireless/patch/20221230121850.218810-1-alexander@wetzel-home.de/

This is cherry-picked into 6.1.24 Mac80211 as suitable for it, but Openwrt with its patches has brought back in the "wake_tx_push_queue" function but did not bring the changes from the above patch to fix the issue.

So if I bring that in as in the patch currently added everything is back to normal,