### PR TITLE
qualcommax: ipq60xx: mango-dvk: fix QCA8081 reset timings

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-mango-dvk.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-mango-dvk.dts
@@ -261,6 +261,8 @@
 		compatible = "ethernet-phy-id004d.d101";
 		reg = <24>;
 		reset-gpios = <&tlmm 77 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <50000>;
 	};
 };
 


### PR DESCRIPTION
Add missing reset delay properties for QCA8081 PHY. Without delays PHY operation is unreliable.

