### PR TITLE
mediatek: mt7622: simplify 02_network

### DIFF
--- a/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
@@ -8,25 +8,17 @@ mediatek_setup_interfaces()
 	local board="$1"
 
 	case $board in
-	bananapi,bpi-r64|\
-	buffalo,wsr-3200ax4s|\
-	dlink,eagle-pro-ai-r32-a1|\
-	elecom,wrc-x3200gst3|\
-	linksys,e8450|\
-	linksys,e8450-ubi|\
-	mediatek,mt7622-rfb1|\
-	mediatek,mt7622-rfb1-ubi|\
-	netgear,wax206|\
-	reyee,ax3200-e5|\
-	ruijie,rg-ew3200gx-pro)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" wan
-		;;
 	buffalo,wsr-2533dhp2)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
 	dlink,eagle-pro-ai-m32-a1)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" wan
+		;;
+	elecom,wrc-2533gent|\
+	totolink,a8000ru)
+		ucidef_add_switch "switch0" \
+			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6u@eth0" "5u@eth1"
 		;;
 	ubnt,unifi-6-lr*)
 		ucidef_set_interface_lan "eth0"
@@ -35,8 +27,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
 		;;
 	*)
-		ucidef_add_switch "switch0" \
-				  "0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6u@eth0" "5u@eth1"
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" wan
 		;;
 	esac
 }


### PR DESCRIPTION
Most mt7622 devices use the mt7531 switch, which have been switched to dsa driver for a long time. So use dsa as the default configuration and configure these rtl8367s devices separately. This reduces the amount of code.