### PR TITLE
mediatek: fix build failure of mt7623/mt7629 with kernel 6.6

### DIFF
--- a/target/linux/mediatek/image/mt7623.mk
+++ b/target/linux/mediatek/image/mt7623.mk
@@ -1,3 +1,7 @@
+ifneq ($(KERNEL),6.1)
+DTS_DIR := $(DTS_DIR)/mediatek
+endif
+
 DEVICE_VARS += UBOOT_TARGET UBOOT_OFFSET UBOOT_IMAGE
 
 # The bootrom of MT7623 expects legacy MediaTek headers present in

--- a/target/linux/mediatek/image/mt7629.mk
+++ b/target/linux/mediatek/image/mt7629.mk
@@ -1,3 +1,7 @@
+ifneq ($(KERNEL),6.1)
+DTS_DIR := $(DTS_DIR)/mediatek
+endif
+
 define Device/mediatek_mt7629-rfb
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7629 rfb AP


### PR DESCRIPTION
In kernel 6.6, dts files for mediatek arm target are moved into arch/arm/boot/dts/mediatek. 

To avoid dts compile failure, change DTS_DIR to the mediatek subfolder for kernel 6.6.
