### PR TITLE
[23.05] mediatek-filogic: backport fixup patches for Asus TUF AX6000

### DIFF
--- a/target/linux/generic/hack-5.15/765-mxl-gpy-control-LED-reg-from-DT.patch
+++ b/target/linux/generic/hack-5.15/765-mxl-gpy-control-LED-reg-from-DT.patch
@@ -55,7 +55,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  /* SGMII */
  #define VSPEC1_SGMII_CTRL	0x08
  #define VSPEC1_SGMII_CTRL_ANEN	BIT(12)		/* Aneg enable */
-@@ -80,6 +87,31 @@ static const struct {
+@@ -80,6 +87,35 @@ static const struct {
  	{9, 0x73},
  };
  
@@ -64,6 +64,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 +	struct device_node *node = phydev->mdio.dev.of_node;
 +	u32 led_regs[PHY_LED_NUM_LEDS];
 +	int i, ret;
++	u16 val = 0xff00;
 +
 +	if (!IS_ENABLED(CONFIG_OF_MDIO))
 +		return 0;
@@ -71,8 +72,11 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 +	if (of_property_read_u32_array(node, "mxl,led-config", led_regs, PHY_LED_NUM_LEDS))
 +		return 0;
 +
++	if (of_property_read_bool(node, "mxl,led-drive-vdd"))
++		val &= 0x0fff;
++
 +	/* Enable LED function handling on all ports*/
-+	phy_write(phydev, PHY_LED, 0xFF00);
++	phy_write(phydev, PHY_LED, val);
 +
 +	/* Write LED register values */
 +	for (i = 0; i < PHY_LED_NUM_LEDS; i++) {
@@ -87,7 +91,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  static int gpy_config_init(struct phy_device *phydev)
  {
  	int ret;
-@@ -91,7 +123,10 @@ static int gpy_config_init(struct phy_de
+@@ -91,7 +127,10 @@ static int gpy_config_init(struct phy_de
  
  	/* Clear all pending interrupts */
  	ret = phy_read(phydev, PHY_ISTAT);

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
@@ -131,6 +131,7 @@
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <5>;
 
+		mxl,led-drive-vdd;
 		mxl,led-config = <0x03f0 0x0 0x0 0x0>;
 	};
 

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -46,8 +46,7 @@ case "$FIRMWARE" in
 "mediatek/mt7986_eeprom_mt7976_dbdc.bin")
 	case "$board" in
 	asus,rt-ax59u|\
-	asus,tuf-ax4200|\
-	asus,tuf-ax6000)
+	asus,tuf-ax4200)
 		CI_UBIPART="UBI_DEV"
 		caldata_extract_ubi "Factory" 0x0 0x1000
 		;;
@@ -55,6 +54,10 @@ case "$FIRMWARE" in
 	;;
 "mediatek/mt7986_eeprom_mt7976_dual.bin")
 	case "$board" in
+	asus,tuf-ax6000)
+		CI_UBIPART="UBI_DEV"
+		caldata_extract_ubi "Factory" 0x0 0x1000
+		;;
 	glinet,gl-mt6000)
 		caldata_extract_mmc "factory" 0x0 0x1000
 		;;

--- a/target/linux/mediatek/patches-5.15/732-net-phy-mxl-gpy-don-t-use-SGMII-AN-if-using-phylink.patch
+++ b/target/linux/mediatek/patches-5.15/732-net-phy-mxl-gpy-don-t-use-SGMII-AN-if-using-phylink.patch
@@ -14,7 +14,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/mxl-gpy.c
 +++ b/drivers/net/phy/mxl-gpy.c
-@@ -191,8 +191,11 @@ static bool gpy_2500basex_chk(struct phy
+@@ -195,8 +195,11 @@ static bool gpy_2500basex_chk(struct phy
  
  	phydev->speed = SPEED_2500;
  	phydev->interface = PHY_INTERFACE_MODE_2500BASEX;
@@ -28,7 +28,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	return true;
  }
  
-@@ -216,6 +219,14 @@ static int gpy_config_aneg(struct phy_de
+@@ -220,6 +223,14 @@ static int gpy_config_aneg(struct phy_de
  	u32 adv;
  	int ret;
  
@@ -43,7 +43,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	if (phydev->autoneg == AUTONEG_DISABLE) {
  		/* Configure half duplex with genphy_setup_forced,
  		 * because genphy_c45_pma_setup_forced does not support.
-@@ -306,6 +317,8 @@ static void gpy_update_interface(struct
+@@ -310,6 +321,8 @@ static void gpy_update_interface(struct
  	switch (phydev->speed) {
  	case SPEED_2500:
  		phydev->interface = PHY_INTERFACE_MODE_2500BASEX;
@@ -52,7 +52,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		ret = phy_modify_mmd(phydev, MDIO_MMD_VEND1, VSPEC1_SGMII_CTRL,
  				     VSPEC1_SGMII_CTRL_ANEN, 0);
  		if (ret < 0)
-@@ -317,7 +330,7 @@ static void gpy_update_interface(struct
+@@ -321,7 +334,7 @@ static void gpy_update_interface(struct
  	case SPEED_100:
  	case SPEED_10:
  		phydev->interface = PHY_INTERFACE_MODE_SGMII;


### PR DESCRIPTION
This PR contains three patches from main that improve Support for the Asus TUF AX6000.

I've run tested them.