### PR TITLE
qualcommax: ipq807x: fix LEDs on QHora-301W and WXR-5950AX12

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
@@ -63,81 +63,109 @@
 		led_system_green: led-system-green {
 			gpios = <&tlmm 1 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
 		};
 
 		led_system_red: led-system-red {
 			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
 		};
 
 		led_pwr_green: led-pwr-green {
 			gpios = <&tlmm 4 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
 		};
 
 		led-wifi-green {
 			gpios = <&tlmm 42 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
 		};
 
 		led-lan4-green {
 			gpios = <&tlmm 6 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
 		};
 
 		led-lan4-amber {
 			gpios = <&tlmm 7 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
 		};
 
 		led-lan3-green {
 			gpios = <&tlmm 8 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
 		};
 
 		led-lan3-amber {
 			gpios = <&tlmm 11 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
 		};
 
 		led-lan2-green {
 			gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
 		};
 
 		led-lan2-amber {
 			gpios = <&tlmm 13 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
 		};
 
 		led-lan1-green {
 			gpios = <&tlmm 14 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
 		};
 
 		led-lan1-amber {
 			gpios = <&tlmm 15 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
 		};
 
 		led-10g-1-green {
 			gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = "10g";
+			function-enumerator = <1>;
 		};
 
 		led-10g-1-amber {
 			gpios = <&tlmm 56 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_AMBER>;
+			function = "10g";
+			function-enumerator = <1>;
 		};
 
 		led-10g-2-green {
 			gpios = <&tlmm 51 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
+			function = "10g";
+			function-enumerator = <2>;
 		};
 
 		led-10g-2-amber {
 			gpios = <&tlmm 52 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_AMBER>;
+			function = "10g";
+			function-enumerator = <2>;
 		};
 	};
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
@@ -33,11 +33,13 @@
 		led-0 {
 			gpios = <&tlmm 21 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_WHITE>;
+			function = "router";
 		};
 
 		led-1 {
 			gpios = <&tlmm 22 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_RED>;
+			function = "router";
 		};
 
 		led_power_red: led-2 {
@@ -55,11 +57,13 @@
 		led-4 {
 			gpios = <&tlmm 43 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_WHITE>;
+			function = "internet";
 		};
 
 		led-5 {
 			gpios = <&tlmm 44 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_RED>;
+			function = "internet";
 		};
 
 		led-6 {

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
@@ -51,12 +51,12 @@ xiaomi,ax9000)
 	ucidef_set_led_netdev "lan4-port-link" "LAN4-PORT-LINK" "90000.mdio-1:00:green:lan" "lan4" "tx rx link_10 link_100 link_1000"
 	;;
 qnap,301w)
-	ucidef_set_led_netdev "lan1" "LAN1" "green:lan1" "lan1"
-	ucidef_set_led_netdev "lan2" "LAN2" "green:lan2" "lan2"
-	ucidef_set_led_netdev "lan3" "LAN3" "green:lan3" "lan3"
-	ucidef_set_led_netdev "lan4" "LAN4" "green:lan4" "lan4"
-	ucidef_set_led_netdev "10G_1" "10G_1" "green:10g_1" "10g-1"
-	ucidef_set_led_netdev "10G_2" "10G_2" "green:10g_2" "10g-2"
+	ucidef_set_led_netdev "lan1" "LAN1" "green:lan-1" "lan1"
+	ucidef_set_led_netdev "lan2" "LAN2" "green:lan-2" "lan2"
+	ucidef_set_led_netdev "lan3" "LAN3" "green:lan-3" "lan3"
+	ucidef_set_led_netdev "lan4" "LAN4" "green:lan-4" "lan4"
+	ucidef_set_led_netdev "10G_1" "10G_1" "green:10g-1" "10g-1"
+	ucidef_set_led_netdev "10G_2" "10G_2" "green:10g-2" "10g-2"
 	;;
 yuncore,ax880)
 	ucidef_set_led_netdev "wan-port-link" "WAN-PORT-LINK" "90000.mdio-1:18:green:wan" "wan" "tx rx link_10 link_100 link_1000 link_2500"


### PR DESCRIPTION
Fixes for QHora-301W depends on testing in https://github.com/openwrt/openwrt/issues/14628.