### PR TITLE
Kernel Bump v2

### DIFF
--- a/scripts/kernel_bump.sh
+++ b/scripts/kernel_bump.sh
@@ -18,8 +18,10 @@ REQUIRED_COMMANDS='
 	exit
 	git
 	printf
+	sed
 	set
 	shift
+	sort
 '
 
 _msg()
@@ -115,7 +117,9 @@ bump_kernel()
 	git switch --force-create '__openwrt_kernel_files_mover'
 
 	if [ "${config_only:-false}" != 'true' ]; then
-		for _path in "${_target_dir}/"*; do
+		for _path in $(git ls-tree -d -r --name-only '__openwrt_kernel_files_mover' "${_target_dir}" |
+			       sed -n "s|^\(.*-${source_version}\).*|\1|p" |
+			       sort -u); do
 			if [ ! -e "${_path}" ] || \
 			   [ "${_path}" = "${_path%%"-${source_version}"}" ]; then
 				continue

--- a/scripts/kernel_bump.sh
+++ b/scripts/kernel_bump.sh
@@ -171,6 +171,8 @@ bump_kernel()
 	git switch "${initial_branch:?Unable to switch back to original branch. Quitting.}"
 	GIT_EDITOR=true git merge --no-ff '__openwrt_kernel_files_mover'
 	git branch --delete '__openwrt_kernel_files_mover'
+	echo "Deleting merge commit ($(git rev-parse HEAD))."
+	git rebase HEAD~1
 
 	echo "Original commitish was '${initial_commitish}'."
 	echo 'Kernel bump complete. Remember to use `git log --follow`.'

--- a/scripts/kernel_bump.sh
+++ b/scripts/kernel_bump.sh
@@ -137,9 +137,15 @@ bump_kernel()
 		done
 	fi
 
-	find "${_target_dir}" -iname "config-${source_version}" | while read -r _config; do
-		_path="${_config%%"/config-${source_version}"}"
-		git mv "${_config}" "${_path}/config-${target_version}"
+	for _config in $(git ls-files "${_target_dir}" |
+	                 sed -n "s|^\(.*config-${source_version}\).*|\1|p" |
+	                 sort -u); do
+		if [ ! -e "${_config}" ]; then
+			continue
+		fi
+
+		_subtarget="${_config%%"/config-${source_version}"}"
+		git mv "${_config}" "${_subtarget}/config-${target_version}"
 	done
 
 	git commit \

--- a/scripts/kernel_bump.sh
+++ b/scripts/kernel_bump.sh
@@ -205,7 +205,9 @@ main()
 	target_version="${target_version:-${TARGET_VERSION:-}}"
 
 	if [ -z "${source_version:-}" ] || [ -z "${target_version:-}" ]; then
-		e_err "Source (${source_version}) and target (${target_version}) versions need to be defined."
+		e_err "Source (${source_version:-missing source version}) and target (${target_version:-missing target version}) versions need to be defined."
+		echo
+		usage
 		exit 1
 	fi
 

--- a/scripts/kernel_bump.sh
+++ b/scripts/kernel_bump.sh
@@ -134,7 +134,7 @@ bump_kernel()
 		--signoff \
 		--message "kernel/${platform_name}: Create kernel files for v${target_version} (from v${source_version})" \
 		--message 'This is an automatically generated commit.' \
-		--message 'During a `git bisect` session, `git bisect --skip` is recommended.'
+		--message 'When doing `git bisect`, consider `git bisect --skip`.'
 
 	git checkout 'HEAD~' "${_target_dir}"
 	git commit \

--- a/scripts/kernel_bump.sh
+++ b/scripts/kernel_bump.sh
@@ -80,13 +80,6 @@ init()
 	trap cleanup EXIT HUP INT QUIT ABRT ALRM TERM
 }
 
-do_source_target()
-{
-	_target_dir="${1:?Missing argument to function}"
-	_op="${2:?Missing argument to function}"
-
-}
-
 bump_kernel()
 {
 	platform_name="${platform_name##*'/'}"

--- a/scripts/kernel_bump.sh
+++ b/scripts/kernel_bump.sh
@@ -77,6 +77,11 @@ init()
 	initial_branch="$(git rev-parse --abbrev-ref HEAD)"
 	initial_commitish="$(git rev-parse HEAD)"
 
+	if [ -n "$(git status --porcelain | grep -v '^?? .*')" ]; then
+		echo 'Git respository not in a clean state, will not continue.'
+		exit 1
+	fi
+
 	source_version="${source_version#v}"
 	target_version="${target_version#v}"
 

--- a/scripts/kernel_bump.sh
+++ b/scripts/kernel_bump.sh
@@ -77,6 +77,9 @@ init()
 	initial_branch="$(git rev-parse --abbrev-ref HEAD)"
 	initial_commitish="$(git rev-parse HEAD)"
 
+	source_version="${source_version#v}"
+	target_version="${target_version#v}"
+
 	trap cleanup EXIT HUP INT QUIT ABRT ALRM TERM
 }
 
@@ -180,10 +183,10 @@ main()
 			platform_name="${OPTARG}"
 			;;
 		's')
-			source_version="${OPTARG#v}"
+			source_version="${OPTARG}"
 			;;
 		't')
-			target_version="${OPTARG#v}"
+			target_version="${OPTARG}"
 			;;
 		':')
 			e_err "Option -${OPTARG} requires an argument."


### PR DESCRIPTION
A bunch of fixes and improvements, also based on discussions in the first version, found in #14713.

* scripts/kernel_bump: Delete merge commit
* scripts/kernel_bump: Allow bumping sub-targets
* scripts/kernel_bump: Use the git index to find the needed config files
* scripts/kernel_bump: Use git to obtain the list of files
* scripts/kernel_bump: Allow for migrating only configuration files
* scripts/kernel_bump: Do no run on dirty repositories
* scripts/kernel_bump: Drop unused function
* scripts/kernel_bump: Avoid potential copyright claim
