### PR TITLE
qualcommax: ipq807x: add support for Spectrum SAX1V1K

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq807x
@@ -56,6 +56,11 @@ qnap,301w)
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x20000" "0x20000" "1"
 	;;
+spectrum,sax1v1k)
+	mmcpart="$(find_mmc_part 0:APPSBLENV)"
+	[ -n "$mmcpart" ] && \
+		ubootenv_add_uci_config "$mmcpart" "0x0" "0x40000" "0x40000" "1"
+	;;
 esac
 
 config_load ubootenv

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -46,6 +46,7 @@ ALLWIFIBOARDS:= \
 	prpl_haze \
 	qnap_301w \
 	redmi_ax6 \
+	spectrum_sax1v1k \
 	wallys_dr40x9 \
 	xiaomi_ax3600 \
 	xiaomi_ax9000 \
@@ -165,6 +166,7 @@ $(eval $(call generate-ipq-wifi-package,netgear_wax630,Netgear WAX630))
 $(eval $(call generate-ipq-wifi-package,qnap_301w,QNAP 301w))
 $(eval $(call generate-ipq-wifi-package,prpl_haze,prpl Haze))
 $(eval $(call generate-ipq-wifi-package,redmi_ax6,Redmi AX6))
+$(eval $(call generate-ipq-wifi-package,spectrum_sax1v1k,Spectrum SAX1V1K))
 $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax3600,Xiaomi AX3600))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax9000,Xiaomi AX9000))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-sax1v1k.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-sax1v1k.dts
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Spectrum SAX1V1K";
+	compatible = "spectrum,sax1v1k", "qcom,ipq8074";
+
+	aliases {
+		led-boot = &led_system_red;
+		led-failsafe = &led_system_red;
+		led-running = &led_system_blue;
+		led-upgrade = &led_system_red;
+		serial0 = &blsp1_uart5;
+		/* Aliases as required by u-boot to patch MAC addresses */
+		ethernet0 = &dp6_syn;
+		ethernet1 = &dp4;
+		ethernet2 = &dp3;
+		ethernet3 = &dp2;
+		label-mac-device = &dp6_syn;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 34 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system_blue: system-blue {
+			gpios = <&tlmm 26 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_red: system-red {
+			gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&mdio {
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	ethernet-phy-package@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "qcom,qca8075-package";
+		reg = <0>;
+
+		qcom,package-mode = "qsgmii";
+
+		qca8075_1: ethernet-phy@1 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <1>;
+		};
+
+		qca8075_2: ethernet-phy@2 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <2>;
+		};
+
+		qca8075_3: ethernet-phy@3 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <3>;
+		};
+	};
+
+	qca8081: ethernet-phy@28 {
+		compatible = "ethernet-phy-id004d.d101";
+		reg = <28>;
+		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&sdhc_1 {
+	/* Following same rule as QNAP 301W
+	 * the emmc has a problem with the hs400 > hs200 speed switch.
+	 * Therefore remove the mmc-hs400-1_8v property
+	*/
+	/delete-property/ mmc-hs400-1_8v;
+	mmc-hs200-1_8v;
+	mmc-ddr-1_8v;
+	vqmmc-supply = <&l11>;
+	status = "okay";
+};
+
+&switch {
+	switch_lan_bmp = <(ESS_PORT2 | ESS_PORT3 | ESS_PORT4)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT6>; /* wan port bitmap */
+	switch_mac_mode = <MAC_MODE_QSGMII>; /* mac mode for uniphy instance0*/
+	switch_mac_mode2 = <MAC_MODE_SGMII_PLUS>; /* mac mode for uniphy instance2*/
+	status = "okay";
+
+	qcom,port_phyinfo {
+		port@2 {
+			port_id = <2>;
+			phy_address = <1>;
+		};
+
+		port@3 {
+			port_id = <3>;
+			phy_address = <2>;
+		};
+
+		port@4 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+
+		port@6 {
+			port_id = <6>;
+			phy_address = <28>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp2 {
+	phy-mode = "qsgmii";
+	phy-handle = <&qca8075_1>;
+	label = "lan3";
+	status = "okay";
+};
+
+&dp3 {
+	phy-mode = "qsgmii";
+	phy-handle = <&qca8075_2>;
+	label = "lan2";
+	status = "okay";
+};
+
+&dp4 {
+	phy-mode = "qsgmii";
+	phy-handle = <&qca8075_3>;
+	label = "lan1";
+	status = "okay";
+};
+
+&dp6_syn {
+	phy-handle = <&qca8081>;
+	label = "wan";
+	status = "okay";
+};
+
+&wifi {
+	qcom,ath11k-calibration-variant = "Spectrum-SAX1V1K";
+	status = "okay";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -247,6 +247,18 @@ define Device/redmi_ax6
 endef
 TARGET_DEVICES += redmi_ax6
 
+define Device/spectrum_sax1v1k
+	$(call Device/FitImage)
+	$(call Device/EmmcImage)
+	DEVICE_VENDOR := Spectrum
+	DEVICE_MODEL := SAX1V1K
+	DEVICE_DTS_CONFIG := config@rt5010w-d187-rev6
+	SOC := ipq8072
+	IMAGES := sysupgrade.bin
+	DEVICE_PACKAGES := ipq-wifi-spectrum_sax1v1k
+endef
+TARGET_DEVICES += spectrum_sax1v1k
+
 define Device/xiaomi_ax3600
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -27,6 +27,7 @@ ipq807x_setup_interfaces()
 	linksys,mx4200v2|\
 	prpl,haze|\
 	redmi,ax6|\
+	spectrum,sax1v1k|\
 	xiaomi,ax3600)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -33,7 +33,8 @@ case "$FIRMWARE" in
 	zyxel,nbg7815)
 		caldata_extract "0:art" 0x1000 0x20000
 		;;
-	prpl,haze)
+	prpl,haze|\
+	spectrum,sax1v1k)
 		caldata_extract_mmc "0:ART" 0x1000 0x20000
 		;;
 	esac

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -92,7 +92,8 @@ platform_do_upgrade() {
 		nand_do_upgrade "$1"
 		;;
 	prpl,haze|\
-	qnap,301w)
+	qnap,301w|\
+	spectrum,sax1v1k)
 		kernelname="0:HLOS"
 		rootfsname="rootfs"
 		mmc_do_upgrade "$1"


### PR DESCRIPTION
Spectrum SAX1V1K is a AX WIFI router with 3 1G and 1 2.5G ports. 
The router is provided to Spectrum customers.
It is OEM of Askey RT5010W
https://forum.openwrt.org/t/spectrum-sax1v1k-askey-rt5010w-openwrt-support/149923

It continues the original work by @MeisterLone to get this device supported.

### Specifications:
```
  •  CPU: Qualcomm IPQ8072A Quad core Cortex-A53 2.2GHz
  •  RAM: 2048MB of DDR3
  •  Storage: 1024MB eMMC
  •  Ethernet: 3x 1G RJ45 ports (QCA8075) + 1 2.5G Port (QCA8081)
  •  WLAN:
     • 2.4GHz: Qualcomm QCN5024 4x4 802.11b/g/n/ax 1174 Mbps PHY rate
     • 5GHz: Qualcomm QCN5054 4x4 802.11a/b/g/n/ac/ax 2402 PHY rate

  •  LED: 1 gpio-controlled dual color led (blue/red)
  •  Buttons: 1x reset
  •  Power: 12V DC jack
``` 


### Notes:
```
  •  This commit adds only single partition support, that means
     sysupgrade is upgrading the current rootfs partition.
  •  Installation can be done by serial connection only.
  •  A poulated serial header is onboard
     https://forum.openwrt.org/t/spectrum-sax1v1k-askey-rt5010w-openwrt-support/149923/6
  •  RX/TX is working, u-boot bootwait is active, secure boot is enabled.
```

### Installation Instructions:

	**Most part of the installation is performed from an initramfs image.**

	Boot initramfs : Using serial connection
	1. Boot up the device and wait till it displays "VERIFY_IB: Success. verify IB ok"
	2. Once that message appears, 
	    login with username 'root'
	    password serial number of your router in uppercase.
	3. Use vi to paste the 'open.sh' script from @MeisterLone github on your device
	    https://github.com/gotofbi/Qualcommax_NSS_sax1v1k/blob/main/open.sh
	4. chmod 755 open.sh
	5. ./open.sh
	6. Set your ip to 192.168.0.1
	7. Run a TFTP server and host the initramfs image on the TFTP server and name it "recovery.img"
	8. Reboot device. On boot it will try TFTP. 

	Install OpenWrt from initramfs image:
	1. Use SCP (or other way) to transfer OpenWrt factory image
	2. Connect to device using SSH (on a LAN port)
	3. Flash firmware: sysupgrade
	   # sysupgrade -n -v /tmp/openwrt_sysupgrade.bin
	4. Set U-boot env variable: bootcmd
	   # fw_setenv bootcmd "run fix_uboot; run setup_and_boot"
	5. Reboot the device
	   # reboot
	6. Once device is booted, residue of previous firmware will prevent openwrt to work properly.
	    Factory Reset is MUST required
	    # Once serial console is displaying to login, hold reset button for 10 sec
	7. Now everything should be operational.

        Note: this PR adds only single partition support, that means sysupgrade is
              upgrading the current rootfs partition

### QCA Firmware PR
https://github.com/openwrt/firmware_qca-wireless/pull/36