### PR TITLE
ath11k-firmware: update IPQ6018 to 2.5.0.1-03982

### DIFF
--- a/package/firmware/ath11k-firmware/Makefile
+++ b/package/firmware/ath11k-firmware/Makefile
@@ -11,7 +11,7 @@ PKG_NAME:=ath11k-firmware
 PKG_SOURCE_DATE:=2024-03-14
 PKG_SOURCE_VERSION:=795809c7041582bd51bdfaa1f548b916ae8d4382
 PKG_MIRROR_HASH:=7d6d2946531c336a402f51e453d5b0e2b5c17201432d6cfa5482eb3626270212
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/quic/upstream-wifi-fw.git
@@ -62,25 +62,10 @@ define Download/qcn9074-board
 endef
 $(eval $(call Download,qcn9074-board))
 
-define Download/ath11k-firmware-old
-  URL:=https://git.codelinaro.org/clo/ath-firmware/ath11k-firmware.git
-  VERSION:=540105aa5c0903b5f773d4e80b8501e8da5217e7
-  PROTO:=git
-  FILE:=ath11k-firmware-old.tar.xz
-  SUBDIR:=ath11k-firmware-old
-  MIRROR_HASH:=a35a164726fab2adc4ad447c974c06746355ba74deab9b849d39f06b5187bb6d
-endef
-$(eval $(call Download,ath11k-firmware-old))
-
-define Build/Prepare
-	$(call Build/Prepare/Default)
-	xzcat $(DL_DIR)/ath11k-firmware-old.tar.xz | tar -C $(PKG_BUILD_DIR)/ -xf -
-endef
-
 define Package/ath11k-firmware-ipq6018/install
 	$(INSTALL_DIR) $(1)/lib/firmware/IPQ6018
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/ath11k-firmware-old/IPQ6018/hw1.0/2.4.0.1/WLAN.HK.2.4.0.1-01746-QCAHKSWPL_SILICONZ-1/* \
+		$(PKG_BUILD_DIR)/ath11k-firmware/IPQ6018/hw1.0/2.5.0.1/WLAN.HK.2.5.0.1-03982-QCAHKSWPL_SILICONZ-3/* \
 		$(1)/lib/firmware/IPQ6018/
 endef
 


### PR DESCRIPTION
ath11k-firmware: update IPQ6018 to 2.5.0.1-03982

That new version seems to work more stable including mesh.
On version 2.4.0.1-01746 rproc was immediately crashing if mesh was active.

Signed-off-by: Dirk Buchwalder <buchwalder@posteo.de>