### PR TITLE
generic: kernel: fix libata ledtrig support in 6.6

### DIFF
--- a/target/linux/generic/pending-6.6/834-ledtrig-libata.patch
+++ b/target/linux/generic/pending-6.6/834-ledtrig-libata.patch
@@ -45,7 +45,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	depends on ACPI
 --- a/drivers/ata/libata-core.c
 +++ b/drivers/ata/libata-core.c
-@@ -685,6 +685,19 @@ static inline void ata_set_tf_cdl(struct
+@@ -685,6 +685,17 @@ static inline void ata_set_tf_cdl(struct
  	qc->flags |= ATA_QCFLAG_HAS_CDL | ATA_QCFLAG_RESULT_TF;
  }
  
@@ -53,19 +53,17 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +#define LIBATA_BLINK_DELAY 20 /* ms */
 +static inline void ata_led_act(struct ata_port *ap)
 +{
-+	unsigned long led_delay = LIBATA_BLINK_DELAY;
-+
 +	if (unlikely(!ap->ledtrig))
 +		return;
 +
-+	led_trigger_blink_oneshot(ap->ledtrig, &led_delay, &led_delay, 0);
++	led_trigger_blink_oneshot(ap->ledtrig, LIBATA_BLINK_DELAY, LIBATA_BLINK_DELAY, 0);
 +}
 +#endif
 +
  /**
   *	ata_build_rw_tf - Build ATA taskfile for given read/write request
   *	@qc: Metadata associated with the taskfile to build
-@@ -4771,6 +4784,9 @@ void __ata_qc_complete(struct ata_queued
+@@ -4771,6 +4782,9 @@ void __ata_qc_complete(struct ata_queued
  		link->active_tag = ATA_TAG_POISON;
  		ap->nr_active_links--;
  	}
@@ -75,7 +73,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  	/* clear exclusive status */
  	if (unlikely(qc->flags & ATA_QCFLAG_CLEAR_EXCL &&
-@@ -5494,6 +5510,9 @@ struct ata_port *ata_port_alloc(struct a
+@@ -5494,6 +5508,9 @@ struct ata_port *ata_port_alloc(struct a
  	ap->stats.unhandled_irq = 1;
  	ap->stats.idle_irq = 1;
  #endif
@@ -85,7 +83,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	ata_sff_port_init(ap);
  
  	return ap;
-@@ -5530,6 +5549,12 @@ static void ata_host_release(struct kref
+@@ -5530,6 +5547,12 @@ static void ata_host_release(struct kref
  		kfree(ap->pmp_link);
  		kfree(ap->slave_link);
  		kfree(ap->ncq_sense_buf);
@@ -98,7 +96,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		kfree(ap);
  		host->ports[i] = NULL;
  	}
-@@ -5920,7 +5945,23 @@ int ata_host_register(struct ata_host *h
+@@ -5920,7 +5943,23 @@ int ata_host_register(struct ata_host *h
  		host->ports[i]->print_id = atomic_inc_return(&ata_print_id);
  		host->ports[i]->local_port_no = i + 1;
  	}


### PR DESCRIPTION
Upstream commit e298d8a38b23 [0] changed method how to blink delays are pased to function. Downstream commit must follow it.

[0] https://lore.kernel.org/r/20230510162234.291439-2-hdegoede@redhat.com

