### PR TITLE
dnsmasq: Backport 2 upstream patches

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.90
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/patches/0001-Fix-spurious-resource-limit-exceeded-messages.patch
+++ b/package/network/services/dnsmasq/patches/0001-Fix-spurious-resource-limit-exceeded-messages.patch
@@ -1,0 +1,43 @@
+From 1ed783b8d7343c42910a61f12a8fc6237eb80417 Mon Sep 17 00:00:00 2001
+From: Simon Kelley <simon@thekelleys.org.uk>
+Date: Mon, 19 Feb 2024 12:22:43 +0000
+Subject: Fix spurious "resource limit exceeded" messages.
+
+Replies from upstream with a REFUSED rcode can result in
+log messages stating that a resource limit has been exceeded,
+which is not the case.
+
+Thanks to Dominik Derigs and the Pi-hole project for
+spotting this.
+---
+ CHANGELOG     | 5 +++++
+ src/forward.c | 6 +++---
+ 2 files changed, 8 insertions(+), 3 deletions(-)
+
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -1,3 +1,8 @@
++version 2.91
++	Fix spurious "resource limit exceeded messages". Thanks to 
++	Dominik Derigs for the bug report.
++	
++
+ version 2.90
+ 	Fix reversion in --rev-server introduced in 2.88 which
+ 	caused breakage if the prefix length is not exactly divisible
+--- a/src/forward.c
++++ b/src/forward.c
+@@ -937,10 +937,10 @@ static void dnssec_validate(struct frec
+ 	status = dnssec_validate_reply(now, header, plen, daemon->namebuff, daemon->keyname, &forward->class, 
+ 				       !option_bool(OPT_DNSSEC_IGN_NS) && (forward->sentto->flags & SERV_DO_DNSSEC),
+ 				       NULL, NULL, NULL, &orig->validate_counter);
+-    }
+ 
+-  if (STAT_ISEQUAL(status, STAT_ABANDONED))
+-    log_resource = 1;
++      if (STAT_ISEQUAL(status, STAT_ABANDONED))
++	log_resource = 1;
++    }
+   
+   /* Can't validate, as we're missing key data. Put this
+      answer aside, whilst we get that. */     

--- a/package/network/services/dnsmasq/patches/0002-PATCH-Fix-error-introduced-in-51471cafa5a4fa44d6fe49.patch
+++ b/package/network/services/dnsmasq/patches/0002-PATCH-Fix-error-introduced-in-51471cafa5a4fa44d6fe49.patch
@@ -1,0 +1,31 @@
+From ccff85ad72d2f858d9743d40525128e4f62d41a8 Mon Sep 17 00:00:00 2001
+From: renmingshuai <renmingshuai@huawei.com>
+Date: Wed, 21 Feb 2024 00:24:25 +0000
+Subject: [PATCH] Fix error introduced in
+ 51471cafa5a4fa44d6fe490885d9910bd72a5907
+
+Signed-off-by: renmingshuai <renmingshuai@huawei.com>
+---
+ src/dnssec.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/src/dnssec.c
++++ b/src/dnssec.c
+@@ -1547,7 +1547,7 @@ static int prove_non_existence_nsec3(str
+       nsecs[i] = NULL; /* Speculative, will be restored if OK. */
+       
+       if (!(p = skip_name(nsec3p, header, plen, 15)))
+-	return 0; /* bad packet */
++	return DNSSEC_FAIL_BADPACKET; /* bad packet */
+       
+       p += 10; /* type, class, TTL, rdlen */
+       
+@@ -1640,7 +1640,7 @@ static int prove_non_existence_nsec3(str
+   if (!wildname)
+     {
+       if (!(wildcard = strchr(next_closest, '.')) || wildcard == next_closest)
+-	return 0;
++	return DNSSEC_FAIL_NONSEC;
+       
+       wildcard--;
+       *wildcard = '*';

--- a/package/network/services/dnsmasq/patches/100-remove-old-runtime-kernel-support.patch
+++ b/package/network/services/dnsmasq/patches/100-remove-old-runtime-kernel-support.patch
@@ -13,7 +13,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
 
 --- a/src/dnsmasq.c
 +++ b/src/dnsmasq.c
-@@ -103,10 +103,6 @@ int main (int argc, char **argv)
+@@ -105,10 +105,6 @@ int main (int argc, char **argv)
    
    read_opts(argc, argv, compile_opts);
   
@@ -26,7 +26,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  
 --- a/src/dnsmasq.h
 +++ b/src/dnsmasq.h
-@@ -1248,7 +1248,7 @@ extern struct daemon {
+@@ -1277,7 +1277,7 @@ extern struct daemon {
    int inotifyfd;
  #endif
  #if defined(HAVE_LINUX_NETWORK)
@@ -35,7 +35,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  #elif defined(HAVE_BSD_NETWORK)
    int dhcp_raw_fd, dhcp_icmp_fd, routefd;
  #endif
-@@ -1453,9 +1453,6 @@ int read_write(int fd, unsigned char *pa
+@@ -1491,9 +1491,6 @@ int read_write(int fd, unsigned char *pa
  void close_fds(long max_fd, int spare1, int spare2, int spare3);
  int wildcard_match(const char* wildcard, const char* match);
  int wildcard_matchn(const char* wildcard, const char* match, int num);
@@ -140,7 +140,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
       my_syslog(LOG_ERR, _("failed to update ipset %s: %s"), setname, strerror(errno));
 --- a/src/util.c
 +++ b/src/util.c
-@@ -855,22 +855,3 @@ int wildcard_matchn(const char* wildcard
+@@ -866,22 +866,3 @@ int wildcard_matchn(const char* wildcard
  
    return (!num) || (*wildcard == *match);
  }

--- a/package/network/services/dnsmasq/patches/200-ubus_dns.patch
+++ b/package/network/services/dnsmasq/patches/200-ubus_dns.patch
@@ -1,8 +1,6 @@
-diff --git a/src/dnsmasq.c b/src/dnsmasq.c
-index 30fb419..776351a 100644
 --- a/src/dnsmasq.c
 +++ b/src/dnsmasq.c
-@@ -2025,6 +2025,10 @@ static void check_dns_listeners(time_t now)
+@@ -2021,6 +2021,10 @@ static void check_dns_listeners(time_t n
  		  daemon->pipe_to_parent = pipefd[1];
  		}
  
@@ -13,11 +11,9 @@ index 30fb419..776351a 100644
  	      /* start with no upstream connections. */
  	      for (s = daemon->servers; s; s = s->next)
  		 s->tcpfd = -1; 
-diff --git a/src/dnsmasq.h b/src/dnsmasq.h
-index e455c3f..c84ba48 100644
 --- a/src/dnsmasq.h
 +++ b/src/dnsmasq.h
-@@ -1673,14 +1673,26 @@ void emit_dbus_signal(int action, struct dhcp_lease *lease, char *hostname);
+@@ -1670,14 +1670,26 @@ void emit_dbus_signal(int action, struct
  
  /* ubus.c */
  #ifdef HAVE_UBUS
@@ -44,11 +40,9 @@ index e455c3f..c84ba48 100644
  #endif
  
  /* ipset.c */
-diff --git a/src/forward.c b/src/forward.c
-index 32f37e4..3d28963 100644
 --- a/src/forward.c
 +++ b/src/forward.c
-@@ -803,7 +803,7 @@ static size_t process_reply(struct dns_header *header, time_t now, struct server
+@@ -803,7 +803,7 @@ static size_t process_reply(struct dns_h
  	  cache_secure = 0;
  	}
        
@@ -57,8 +51,6 @@ index 32f37e4..3d28963 100644
  	cache_secure = 0;
        
        /* check_for_bogus_wildcard() does it's own caching, so
-diff --git a/src/rfc1035.c b/src/rfc1035.c
-index 387d894..7bf7967 100644
 --- a/src/rfc1035.c
 +++ b/src/rfc1035.c
 @@ -13,8 +13,10 @@
@@ -73,7 +65,7 @@ index 387d894..7bf7967 100644
  
  int extract_name(struct dns_header *header, size_t plen, unsigned char **pp, 
  		 char *name, int isExtract, int extrabytes)
-@@ -384,10 +386,65 @@ static int private_net6(struct in6_addr *a, int ban_localhost)
+@@ -384,10 +386,65 @@ static int private_net6(struct in6_addr
      ((u32 *)a)[0] == htonl(0x20010db8); /* RFC 6303 4.6 */
  }
  
@@ -140,7 +132,7 @@ index 387d894..7bf7967 100644
    int done = 0;
    
    if (!(p = skip_questions(header, qlen)))
-@@ -404,7 +461,7 @@ int do_doctor(struct dns_header *header, size_t qlen, char *namebuff)
+@@ -404,7 +461,7 @@ int do_doctor(struct dns_header *header,
        
        GETSHORT(qtype, p); 
        GETSHORT(qclass, p);
@@ -149,7 +141,7 @@ index 387d894..7bf7967 100644
        GETSHORT(rdlen, p);
        
        if (qclass == C_IN && qtype == T_A)
-@@ -415,6 +472,9 @@ int do_doctor(struct dns_header *header, size_t qlen, char *namebuff)
+@@ -415,6 +472,9 @@ int do_doctor(struct dns_header *header,
  	  if (!CHECK_LEN(header, p, qlen, INADDRSZ))
  	    return done;
  	  
@@ -159,7 +151,7 @@ index 387d894..7bf7967 100644
  	  /* alignment */
  	  memcpy(&addr.addr4, p, INADDRSZ);
  	  
-@@ -444,6 +504,14 @@ int do_doctor(struct dns_header *header, size_t qlen, char *namebuff)
+@@ -444,6 +504,14 @@ int do_doctor(struct dns_header *header,
  	      break;
  	    }
  	}
@@ -174,11 +166,9 @@ index 387d894..7bf7967 100644
        
        if (!ADD_RDLEN(header, p, qlen, rdlen))
  	 return done; /* bad packet */
-diff --git a/src/ubus.c b/src/ubus.c
-index a5758e7..f2a75a8 100644
 --- a/src/ubus.c
 +++ b/src/ubus.c
-@@ -72,6 +72,13 @@ static struct ubus_object ubus_object = {
+@@ -72,6 +72,13 @@ static struct ubus_object ubus_object =
    .subscribe_cb = ubus_subscribe_cb,
  };
  
@@ -192,7 +182,7 @@ index a5758e7..f2a75a8 100644
  static void ubus_subscribe_cb(struct ubus_context *ctx, struct ubus_object *obj)
  {
    (void)ctx;
-@@ -105,13 +112,21 @@ static void ubus_disconnect_cb(struct ubus_context *ubus)
+@@ -105,13 +112,21 @@ static void ubus_disconnect_cb(struct ub
  char *ubus_init()
  {
    struct ubus_context *ubus = NULL;


### PR DESCRIPTION
These two patches are fixing minor problems with DNSSEC found shortly after the dnsmasq 2.90 release.