### PR TITLE
imagebuilder: fixes if targets are located in a separate feed

### DIFF
--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -80,7 +80,13 @@ endif
 
 	$(CP) -L $(TOPDIR)/target/linux/Makefile $(PKG_BUILD_DIR)/target/linux
 	$(CP) -L $(TOPDIR)/target/linux/generic $(PKG_BUILD_DIR)/target/linux
-	$(CP) -L $(TOPDIR)/target/linux/$(BOARD) $(PKG_BUILD_DIR)/target/linux
+	# check if board is installed from a feeds subdirectory
+	if [ -d $(TOPDIR)/target/linux/feeds/$(BOARD) ]; then \
+		mkdir -p $(PKG_BUILD_DIR)/target/linux/feeds; \
+		$(CP) -L $(TOPDIR)/target/linux/feeds/$(BOARD) $(PKG_BUILD_DIR)/target/linux/feeds; \
+	else \
+		$(CP) -L $(TOPDIR)/target/linux/$(BOARD) $(PKG_BUILD_DIR)/target/linux; \
+	fi
 	if [ -d $(TOPDIR)/staging_dir/host/lib/grub ]; then \
 		$(CP) $(TOPDIR)/staging_dir/host/lib/grub/ $(PKG_BUILD_DIR)/staging_dir/host/lib; \
 	fi

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -205,8 +205,13 @@ build_image: FORCE
 	@echo
 	@echo Building images...
 	rm -rf $(BUILD_DIR)/json_info_files/
-	$(NO_TRACE_MAKE) -C target/linux/$(BOARD)/image install TARGET_BUILD=1 IB=1 EXTRA_IMAGE_NAME="$(EXTRA_IMAGE_NAME)" \
-		$(if $(USER_PROFILE),PROFILE="$(USER_PROFILE)")
+	if [ -d "target/linux/feeds/$(BOARD)" ]; then \
+		$(NO_TRACE_MAKE) -C target/linux/feeds/$(BOARD)/image install TARGET_BUILD=1 IB=1 EXTRA_IMAGE_NAME="$(EXTRA_IMAGE_NAME)" \
+			$(if $(USER_PROFILE),PROFILE="$(USER_PROFILE)"); \
+	else \
+		$(NO_TRACE_MAKE) -C target/linux/$(BOARD)/image install TARGET_BUILD=1 IB=1 EXTRA_IMAGE_NAME="$(EXTRA_IMAGE_NAME)" \
+			$(if $(USER_PROFILE),PROFILE="$(USER_PROFILE)"); \
+	fi
 
 $(BIN_DIR)/profiles.json: FORCE
 	$(if $(CONFIG_JSON_OVERVIEW_IMAGE_INFO), \


### PR DESCRIPTION
The image generation would fail if targets are sourced from a feed `/target/linux/feeds`.

imagebuilder: check if BOARD is located in the feeds sub directory
Fixes the regression so that targets that were installed via a feed can also be build again with the Image Builder.                                                             
 Fixes: 84ec8c4 ("imagebuilder: copy from buildroot only target/linux")

imagebuilder: add check if target is sourced from feed
The image generation would fail if the target is included from a feed.
To fix this check if targets is found in the feed directory.

A similar fix that also addresses on part of this issue was send via the [mailinglist](https://patchwork.ozlabs.org/project/openwrt/patch/mailman.17760.1710861283.1280.openwrt-devel@lists.openwrt.org/). 
The other part was send to the [mailinglist](https://patchwork.ozlabs.org/project/openwrt/patch/20231020114527.3586387-1-fe@dev.tdt.de/) some months ago.

I have now summarised this in one pullrequest.
