### PR TITLE
ramips: mt7621: disable Edgerouter X image generation

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2504,6 +2504,7 @@ define Device/ubnt_edgerouter_common
 	ubnt-erx-factory-image $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.tar
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   DEVICE_PACKAGES += -wpad-basic-mbedtls -uboot-envtools
+  DEFAULT := n
 endef
 
 define Device/ubnt_edgerouter-x


### PR DESCRIPTION
With kernel 6.1 image size is too large for Edgerouter X current size limit and is causing the buildbots to fail building so images for other devices are not updated as well.

So, disable building Edgerouter X images until a workaround is found.
