### PR TITLE
realtek: fix reboot on D-Link DGS-1210-16

### DIFF
--- a/target/linux/realtek/dts-5.15/rtl8382_d-link_dgs-1210-16.dts
+++ b/target/linux/realtek/dts-5.15/rtl8382_d-link_dgs-1210-16.dts
@@ -2,6 +2,7 @@
 
 #include "rtl838x.dtsi"
 #include "rtl83xx_d-link_dgs-1210_common.dtsi"
+#include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
 
 / {
 	compatible = "d-link,dgs-1210-16", "realtek,rtl838x-soc";


### PR DESCRIPTION
D-Link DGS-1210-16 hangs when rebooting and has
no support for the reset button.

This commit fixes both by enabling the same GPIOs
for reboot and the reset button as already used
for D-Link DGS-1210-20 and D-Link DGS-1210-28.
