### PR TITLE
wireless-regdb: add missing license information

### DIFF
--- a/package/firmware/wireless-regdb/Makefile
+++ b/package/firmware/wireless-regdb/Makefile
@@ -3,6 +3,8 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=wireless-regdb
 PKG_VERSION:=2024.01.23
 PKG_RELEASE:=1
+PKG_LICENSE:=ISC
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/network/wireless-regdb/


### PR DESCRIPTION
@nbd168 Add the missing license information PKG_LICENSE and PKG_LICENSE_FILES.