### PR TITLE
ramips: building repair - carl9170: re-fix fortified-memset warning

### DIFF
--- a/package/kernel/mac80211/patches/ath/432-carl9170_re-fix_fortified-memset_warning.patch
+++ b/package/kernel/mac80211/patches/ath/432-carl9170_re-fix_fortified-memset_warning.patch
@@ -1,0 +1,51 @@
+[PATCH 1/2] carl9170: re-fix fortified-memset warning
+@ 2023-06-23 15:23 Arnd Bergmann
+  2023-06-23 15:24 ` [PATCH 2/2] mac80211: make ieee80211_tx_info padding explicit Arnd Bergmann
+                   ` (2 more replies)
+  0 siblings, 3 replies; 9+ messages in thread
+From: Arnd Bergmann @ 2023-06-23 15:23 UTC (permalink / raw)
+  To: Christian Lamparter, Kalle Valo, Kees Cook, Johannes Berg
+  Cc: Arnd Bergmann, linux-wireless, linux-kernel
+
+From: Arnd Bergmann <arnd@arndb.de>
+
+The carl9170_tx_release() function sometimes triggers a fortified-memset
+warning in my randconfig builds:
+
+In file included from include/linux/string.h:254,
+                 from drivers/net/wireless/ath/carl9170/tx.c:40:
+In function 'fortify_memset_chk',
+    inlined from 'carl9170_tx_release' at drivers/net/wireless/ath/carl9170/tx.c:283:2,
+    inlined from 'kref_put' at include/linux/kref.h:65:3,
+    inlined from 'carl9170_tx_put_skb' at drivers/net/wireless/ath/carl9170/tx.c:342:9:
+include/linux/fortify-string.h:493:25: error: call to '__write_overflow_field' declared with attribute warning: detected write beyond size of field (1st parameter); maybe use struct_group()? [-Werror=attribute-warning]
+  493 |                         __write_overflow_field(p_size_field, size);
+
+Kees previously tried to avoid this by using memset_after(), but it seems
+this does not fully address the problem. I noticed that the memset_after()
+here is done on a different part of the union (status) than the original
+cast was from (rate_driver_data), which may confuse the compiler.
+
+Unfortunately, the memset_after() trick does not work on driver_rates[]
+because that is part of an anonymous struct, and I could not get
+struct_group() to do this either. Using two separate memset() calls
+on the two members does address the warning though.
+
+Fixes: fb5f6a0e8063b ("mac80211: Use memset_after() to clear tx status")
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+---
+ drivers/net/wireless/ath/carl9170/tx.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/wireless/ath/carl9170/tx.c
++++ b/drivers/net/wireless/ath/carl9170/tx.c
+@@ -280,7 +280,8 @@ static void carl9170_tx_release(struct k
+ 	 * carl9170_tx_fill_rateinfo() has filled the rate information
+ 	 * before we get to this point.
+ 	 */
+-	memset_after(&txinfo->status, 0, rates);
++	memset(&txinfo->pad, 0, sizeof(txinfo->pad));
++	memset(&txinfo->rate_driver_data, 0, sizeof(txinfo->rate_driver_data));
+ 
+ 	if (atomic_read(&ar->tx_total_queued))
+ 		ar->tx_schedule = true;


### PR DESCRIPTION
Fix for carl9170 not compiling issue, causing the buildbots to fail building for some ramips subplatforms e.g rt305x for kernel 6.1 and above.
