### PR TITLE
realtek: add Zyxel GS1900-8 v2

### DIFF
--- a/target/linux/realtek/dts-5.15/rtl8380_zyxel_gs1900-8.dts
+++ b/target/linux/realtek/dts-5.15/rtl8380_zyxel_gs1900-8.dts
@@ -4,7 +4,7 @@
 
 / {
 	compatible = "zyxel,gs1900-8", "realtek,rtl838x-soc";
-	model = "ZyXEL GS1900-8 Switch";
+	model = "ZyXEL GS1900-8v1/v2 Switch";
 };
 
 &gpio1 {

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -313,6 +313,10 @@ define Device/zyxel_gs1900-8
   $(Device/zyxel_gs1900)
   SOC := rtl8380
   DEVICE_MODEL := GS1900-8
+  DEVICE_VARIANT := v1
+  DEVICE_ALT0_VENDOR := ZyXEL
+  DEVICE_ALT0_MODEL := GS1900-8
+  DEVICE_ALT0_VARIANT := v2
   ZYXEL_VERS := AAHH
 endef
 TARGET_DEVICES += zyxel_gs1900-8


### PR DESCRIPTION
The Zyxel GS1900-8 v2 or Rev.B1 is a newer variant of the GS1900-8, but otherwise similar to the other GS1900 switches.

Differences
------------
* Front Button labeled RESTORE
* NO Power Switch on rear
* Serial Header next to the barrel power connector
* Part Number ends 0102F

Signed-off-by: Goetz Goerisch <ggoerisch@gmail.com>