### PR TITLE
rockchip: remove `swiotlb` parameter from boot script

### DIFF
--- a/target/linux/rockchip/image/default.bootscript
+++ b/target/linux/rockchip/image/default.bootscript
@@ -8,7 +8,7 @@ elif test $stdout = 'serial@ff1a0000' ;
 then serial_addr=',0xff1a0000';
 fi;
 
-setenv bootargs "console=ttyS2,1500000 console=tty1 earlycon=uart8250,mmio32${serial_addr} swiotlb=1 root=PARTUUID=${uuid} rw rootwait";
+setenv bootargs "console=ttyS2,1500000 console=tty1 earlycon=uart8250,mmio32${serial_addr} root=PARTUUID=${uuid} rw rootwait";
 
 load ${devtype} ${devnum}:1 ${kernel_addr_r} kernel.img
 

--- a/target/linux/rockchip/image/default.bootscript
+++ b/target/linux/rockchip/image/default.bootscript
@@ -8,7 +8,7 @@ elif test $stdout = 'serial@ff1a0000' ;
 then serial_addr=',0xff1a0000';
 fi;
 
-setenv bootargs "console=ttyS2,1500000 console=tty1 earlycon=uart8250,mmio32${serial_addr} root=PARTUUID=${uuid} rw rootwait";
+setenv bootargs "console=ttyS2,1500000 earlycon=uart8250,mmio32${serial_addr} root=PARTUUID=${uuid} rw rootwait";
 
 load ${devtype} ${devnum}:1 ${kernel_addr_r} kernel.img
 


### PR DESCRIPTION
- remove swiotlb parameter from boot script

   We have hardware IOMMU support and this is totally unnecessary. The given value is also unreasonable, it's too small and causes kernel panic in some cases:

   [ 5706.856473] sdhci-dwcmshc fe310000.mmc: swiotlb buffer is full (sz: 28672 bytes), total 512 (slots), used 498 (slots)
   [ 5706.864451] sdhci-dwcmshc fe310000.mmc: swiotlb buffer is full (sz: 65536 bytes), total 512 (slots), used 464 (slots)

   This parameter seems to be added by mistake, so remove it.

   Fixes: e35c7ab51fd1 ("rockchip: merge bootscript")

- remove redundant 'console' parameter from boot script

   ttyS2 is the default console used for all rockchip boards.
   The redundant 'console=tty1' parameter now breaks the console due to recent procd update.


Cc: @PolynomialDivision 