### PR TITLE
config: Enable ext4 journaling by default.

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -127,6 +127,7 @@ menu "Target Images"
 		config TARGET_EXT4_JOURNAL
 			bool "Create a journaling filesystem"
 			depends on TARGET_ROOTFS_EXT4FS
+			default y
 			help
 			  Create an ext4 filesystem with a journal.
 


### PR DESCRIPTION
Not having a journal by default is a major "gotcha".

Because openwrt does not fsck on boot, a power loss without journaling can result in a dirty filesystem that openwrt will mount as read-only which requires intervention to restore the router to working order.

I think most people would expect ext4 to have a journal and be able to handle a power loss, especially those running on desktop/server class x86 hardware.

Maybe there are some under-powered ext4-using targets that would suffer from using a journal? Someone more familiar with targets other than x86 will have to comment.

Anyways, I think a broken router from a power-loss is worse than the minor overhead of journaling.