### PR TITLE
ramips: add support for ELECOM WMC-M1267GST2, WMC-S1267GS2

### DIFF
--- a/target/linux/ramips/dts/mt7621_elecom_wmc-m1267gst2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wmc-m1267gst2.dts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_elecom_wrc-gs-1pci.dtsi"
+
+/ {
+	compatible = "elecom,wmc-m1267gst2", "mediatek,mt7621-soc";
+	model = "ELECOM WMC-M1267GST2";
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_fff4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr_factory_fffa>;
+	nvmem-cell-names = "mac-address";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0x1800000>;
+	};
+
+	partition@1850000 {
+		label = "tm_pattern";
+		reg = <0x1850000 0x400000>;
+		read-only;
+	};
+
+	partition@1c50000 {
+		label = "tm_key";
+		reg = <0x1c50000 0x100000>;
+		read-only;
+	};
+
+	partition@1d50000 {
+		label = "nvram";
+		reg = <0x1d50000 0xb0000>;
+		read-only;
+	};
+
+	partition@1e00000 {
+		label = "user_data";
+		reg = <0x1e00000 0x200000>;
+		read-only;
+	};
+};
+
+&wifi {
+	nvmem-cells = <&macaddr_factory_4 (-1)>;
+	nvmem-cell-names = "mac-address";
+};
+
+&factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_factory_4: macaddr@4 {
+			compatible = "mac-base";
+			reg = <0x4 0x6>;
+			#nvmem-cell-cells = <1>;
+		};
+
+		macaddr_factory_fff4: macaddr@fff4 {
+			reg = <0xfff4 0x6>;
+		};
+
+		macaddr_factory_fffa: macaddr@fffa {
+			reg = <0xfffa 0x6>;
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wmc-s1267gs2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wmc-s1267gs2.dts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_elecom_wrc-gs-1pci.dtsi"
+
+/ {
+	compatible = "elecom,wmc-s1267gs2", "mediatek,mt7621-soc";
+	model = "ELECOM WMC-S1267GS2";
+
+	aliases {
+		/*
+		 * A MAC address printed to the label is an address of
+		 * 5 GHz band on stock firmware, but there is no
+		 * per-band MAC address support on Linux Kernel and that
+		 * address is not assigned to any wlan devices now.
+		 */
+		/delete-property/ label-mac-device;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_fff4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "disabled";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0x1800000>;
+	};
+
+	partition@1850000 {
+		label = "tm_pattern";
+		reg = <0x1850000 0x400000>;
+		read-only;
+	};
+
+	partition@1c50000 {
+		label = "tm_key";
+		reg = <0x1c50000 0x100000>;
+		read-only;
+	};
+
+	partition@1d50000 {
+		label = "nvram";
+		reg = <0x1d50000 0xb0000>;
+		read-only;
+	};
+
+	partition@1e00000 {
+		label = "user_data";
+		reg = <0x1e00000 0x200000>;
+		read-only;
+	};
+};
+
+&wifi {
+	nvmem-cells = <&macaddr_factory_4 (-1)>;
+	nvmem-cell-names = "mac-address";
+};
+
+&factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_factory_4: macaddr@4 {
+			compatible = "mac-base";
+			reg = <0x4 0x6>;
+			#nvmem-cell-cells = <1>;
+		};
+
+		macaddr_factory_fff4: macaddr@fff4 {
+			reg = <0xfff4 0x6>;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -998,6 +998,14 @@ define Device/elecom_wmc-m1267gst2
 endef
 TARGET_DEVICES += elecom_wmc-m1267gst2
 
+define Device/elecom_wmc-s1267gs2
+  $(Device/elecom_wrc-gs)
+  IMAGE_SIZE := 24576k
+  DEVICE_MODEL := WMC-S1267GS2
+  ELECOM_HWNAME := WMC-DLGST2
+endef
+TARGET_DEVICES += elecom_wmc-s1267gs2
+
 define Device/elecom_wrc-1167ghbk2-s
   $(Device/dsa-migration)
   IMAGE_SIZE := 15488k

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -979,6 +979,25 @@ define Device/edimax_rg21s
 endef
 TARGET_DEVICES += edimax_rg21s
 
+define Device/elecom_wrc-gs
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  DEVICE_VENDOR := ELECOM
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
+	elecom-wrc-gs-factory $$$$(ELECOM_HWNAME) 0.00 -N | \
+	append-string MT7621_ELECOM_$$$$(ELECOM_HWNAME)
+  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+endef
+
+define Device/elecom_wmc-m1267gst2
+  $(Device/elecom_wrc-gs)
+  IMAGE_SIZE := 24576k
+  DEVICE_MODEL := WMC-M1267GST2
+  ELECOM_HWNAME := WMC-DLGST2
+endef
+TARGET_DEVICES += elecom_wmc-m1267gst2
+
 define Device/elecom_wrc-1167ghbk2-s
   $(Device/dsa-migration)
   IMAGE_SIZE := 15488k
@@ -990,17 +1009,6 @@ define Device/elecom_wrc-1167ghbk2-s
   DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
 endef
 TARGET_DEVICES += elecom_wrc-1167ghbk2-s
-
-define Device/elecom_wrc-gs
-  $(Device/dsa-migration)
-  $(Device/uimage-lzma-loader)
-  DEVICE_VENDOR := ELECOM
-  IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
-	elecom-wrc-gs-factory $$$$(ELECOM_HWNAME) 0.00 -N | \
-	append-string MT7621_ELECOM_$$$$(ELECOM_HWNAME)
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
-endef
 
 define Device/elecom_wrc-1167gs2-b
   $(Device/elecom_wrc-gs)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -102,16 +102,17 @@ ramips_setup_interfaces()
 	dlink,covr-x1860-a1)
 		ucidef_set_interfaces_lan_wan "ethernet" "internet"
 		;;
+	elecom,wmc-s1267gs2|\
+	linksys,re6500|\
+	netgear,wac104|\
+	zyxel,lte3301-plus)
+		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
+		;;
 	gnubee,gb-pc1)
 		ucidef_set_interface_lan "ethblack ethblue"
 		;;
 	gnubee,gb-pc2)
 		ucidef_set_interface_lan "ethblack ethblue ethyellow"
-		;;
-	linksys,re6500|\
-	netgear,wac104|\
-	zyxel,lte3301-plus)
-		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
 	mikrotik,routerboard-750gr3)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"


### PR DESCRIPTION
This patch series adds support for WMC-M1267GST2 (mesh router) and WMC-S1267GS2 (mesh extender).

Note: ```Device/elecom_wrc-gs``` was moved before ```Device/elecom_wrc-1167ghbk2-s``` in **image/mt7621.mk**