### PR TITLE
netifd: check if /sbin/wifi exists before calling it

### DIFF
--- a/package/network/config/netifd/Makefile
+++ b/package/network/config/netifd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/netifd.git

--- a/package/network/config/netifd/files/etc/init.d/network
+++ b/package/network/config/netifd/files/etc/init.d/network
@@ -30,12 +30,12 @@ reload_service() {
 
 	init_switch
 	ubus call network reload || rv=1
-	/sbin/wifi reload_legacy
+	[ -x /sbin/wifi ] && /sbin/wifi reload_legacy
 	return $rv
 }
 
 stop_service() {
-	/sbin/wifi down
+	[ -x /sbin/wifi ] && /sbin/wifi down
 	ifdown -a
 	sleep 1
 }


### PR DESCRIPTION
Avoid harmless error from network script by checking presence of now-optional wifi support script, most notably confusing users of x86 snapshots.
Not needed nor may harm existing releases.

Fixes: https://github.com/openwrt/openwrt/issues/14964

Signed-off-by: Andris PE <neandris@gmail.com>
