### PR TITLE
generic: mtk_eth_soc: add support for flow-control settings

### DIFF
--- a/target/linux/generic/backport-6.6/752-30-v6.10-net-ethernet-mtk_eth_soc-implement-.-get-set-_pausep.patch
+++ b/target/linux/generic/backport-6.6/752-30-v6.10-net-ethernet-mtk_eth_soc-implement-.-get-set-_pausep.patch
@@ -1,0 +1,55 @@
+From 064fbc4e9b5a6dbda7fe7b67dc7e9e95d31f8d75 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Thu, 4 Jul 2024 11:14:55 +0100
+Subject: [PATCH] net: ethernet: mtk_eth_soc: implement .{get,set}_pauseparam
+ ethtool ops
+
+Implement operations to get and set flow-control link parameters.
+Both is done by simply calling phylink_ethtool_{get,set}_pauseparam().
+Fix whitespace in mtk_ethtool_ops while at it.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+Reviewed-by: Michal Kubiak <michal.kubiak@intel.com>
+Reviewed-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Tested-by: Rui Salvaterra <rsalvaterra@gmail.com>
+Link: https://patch.msgid.link/e3ece47323444631d6cb479f32af0dfd6d145be0.1720088047.git.daniel@makrotopia.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/mediatek/mtk_eth_soc.c | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
++++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+@@ -4462,6 +4462,20 @@ static int mtk_set_rxnfc(struct net_devi
+ 	return ret;
+ }
+ 
++static void mtk_get_pauseparam(struct net_device *dev, struct ethtool_pauseparam *pause)
++{
++	struct mtk_mac *mac = netdev_priv(dev);
++
++	phylink_ethtool_get_pauseparam(mac->phylink, pause);
++}
++
++static int mtk_set_pauseparam(struct net_device *dev, struct ethtool_pauseparam *pause)
++{
++	struct mtk_mac *mac = netdev_priv(dev);
++
++	return phylink_ethtool_set_pauseparam(mac->phylink, pause);
++}
++
+ static u16 mtk_select_queue(struct net_device *dev, struct sk_buff *skb,
+ 			    struct net_device *sb_dev)
+ {
+@@ -4490,8 +4504,10 @@ static const struct ethtool_ops mtk_etht
+ 	.get_strings		= mtk_get_strings,
+ 	.get_sset_count		= mtk_get_sset_count,
+ 	.get_ethtool_stats	= mtk_get_ethtool_stats,
++	.get_pauseparam		= mtk_get_pauseparam,
++	.set_pauseparam		= mtk_set_pauseparam,
+ 	.get_rxnfc		= mtk_get_rxnfc,
+-	.set_rxnfc              = mtk_set_rxnfc,
++	.set_rxnfc		= mtk_set_rxnfc,
+ };
+ 
+ static const struct net_device_ops mtk_netdev_ops = {

--- a/target/linux/generic/pending-6.6/702-net-ethernet-mtk_eth_soc-enable-threaded-NAPI.patch
+++ b/target/linux/generic/pending-6.6/702-net-ethernet-mtk_eth_soc-enable-threaded-NAPI.patch
@@ -10,7 +10,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -5020,6 +5020,8 @@ static int mtk_probe(struct platform_dev
+@@ -5036,6 +5036,8 @@ static int mtk_probe(struct platform_dev
  	 * for NAPI to work
  	 */
  	init_dummy_netdev(&eth->dummy_dev);

--- a/target/linux/generic/pending-6.6/737-net-ethernet-mtk_eth_soc-add-paths-and-SerDes-modes-.patch
+++ b/target/linux/generic/pending-6.6/737-net-ethernet-mtk_eth_soc-add-paths-and-SerDes-modes-.patch
@@ -510,7 +510,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	return 0;
  }
  
-@@ -4554,6 +4701,7 @@ static const struct net_device_ops mtk_n
+@@ -4570,6 +4717,7 @@ static const struct net_device_ops mtk_n
  static int mtk_add_mac(struct mtk_eth *eth, struct device_node *np)
  {
  	const __be32 *_id = of_get_property(np, "reg", NULL);
@@ -518,7 +518,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	phy_interface_t phy_mode;
  	struct phylink *phylink;
  	struct mtk_mac *mac;
-@@ -4590,16 +4738,41 @@ static int mtk_add_mac(struct mtk_eth *e
+@@ -4606,16 +4754,41 @@ static int mtk_add_mac(struct mtk_eth *e
  	mac->id = id;
  	mac->hw = eth;
  	mac->of_node = np;
@@ -568,7 +568,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	}
  
  	memset(mac->hwlro_ip, 0, sizeof(mac->hwlro_ip));
-@@ -4682,8 +4855,21 @@ static int mtk_add_mac(struct mtk_eth *e
+@@ -4698,8 +4871,21 @@ static int mtk_add_mac(struct mtk_eth *e
  		phy_interface_zero(mac->phylink_config.supported_interfaces);
  		__set_bit(PHY_INTERFACE_MODE_INTERNAL,
  			  mac->phylink_config.supported_interfaces);
@@ -590,7 +590,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	phylink = phylink_create(&mac->phylink_config,
  				 of_fwnode_handle(mac->of_node),
  				 phy_mode, &mtk_phylink_ops);
-@@ -4734,6 +4920,26 @@ free_netdev:
+@@ -4750,6 +4936,26 @@ free_netdev:
  	return err;
  }
  
@@ -617,7 +617,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  void mtk_eth_set_dma_device(struct mtk_eth *eth, struct device *dma_dev)
  {
  	struct net_device *dev, *tmp;
-@@ -4880,7 +5086,8 @@ static int mtk_probe(struct platform_dev
+@@ -4896,7 +5102,8 @@ static int mtk_probe(struct platform_dev
  			regmap_write(cci, 0, 3);
  	}
  
@@ -627,7 +627,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		err = mtk_sgmii_init(eth);
  
  		if (err)
-@@ -4991,6 +5198,24 @@ static int mtk_probe(struct platform_dev
+@@ -5007,6 +5214,24 @@ static int mtk_probe(struct platform_dev
  		}
  	}
  
@@ -652,7 +652,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	if (MTK_HAS_CAPS(eth->soc->caps, MTK_SHARED_INT)) {
  		err = devm_request_irq(eth->dev, eth->irq[0],
  				       mtk_handle_irq, 0,
-@@ -5094,6 +5319,11 @@ static int mtk_remove(struct platform_de
+@@ -5110,6 +5335,11 @@ static int mtk_remove(struct platform_de
  		mtk_stop(eth->netdev[i]);
  		mac = netdev_priv(eth->netdev[i]);
  		phylink_disconnect_phy(mac->phylink);


### PR DESCRIPTION
Add patch implementing operations to get and set flow-control link parameters of mtk_eth_soc to Linux 6.1 and Linux 6.6 generic patchset. This allows setting and retrieving current flow-control settings via `ethtool` or via `ubus` and UCI network config.

Example:
```
root@bpi-r4:/# ethtool -a eth2
Pause parameters for eth2:
Autonegotiate:  on
RX:             off
TX:             off
RX negotiated: off
TX negotiated: off
```

```
root@OpenWrt:/# ubus call network.device status '{"name":"eth2"}'
{
        "external": false,
        "present": true,
        "type": "Network device",
        "up": true,
        "carrier": true,
        "auth_status": false,
        "link-advertising": [
                "10baseT-H",
                "10baseT-F",
                "100baseT-H",
                "100baseT-F",
                "1000baseT-F",
                "1000baseX-F"
        ],
        "link-partner-advertising": [
                "10baseT-H",
                "10baseT-F",
                "100baseT-H",
                "100baseT-F",
                "1000baseT-F"
        ],
        "link-supported": [
                "10baseT-H",
                "10baseT-F",
                "100baseT-H",
                "100baseT-F",
                "1000baseT-F",
                "1000baseX-F"
        ],
        "speed": "1000F",
        "autoneg": true,
        "flow-control": {
                "autoneg": true,
                "supported": [
                        "pause",
                        "asym_pause"
                ],
                "link-advertising": [

                ],
                "link-partner-advertising": [
                        "pause"
                ],
                "negotiated": [

                ]
        },
        "hw-tc-offload": true,
        "devtype": "ethernet",
        "mtu": 1500,
        "mtu6": 1500,
        "macaddr": "36:26:4f:c2:de:13",
        "txqueuelen": 1000,
        "ipv6": false,
        "ip6segmentrouting": false,
        "promisc": false,
        "rpfilter": 0,
        "acceptlocal": false,
        "igmpversion": 0,
        "mldversion": 0,
        "neigh4reachabletime": 30000,
        "neigh6reachabletime": 30000,
        "neigh4gcstaletime": 60,
        "neigh6gcstaletime": 60,
        "neigh4locktime": 100,
        "dadtransmits": 1,
        "multicast": true,
        "sendredirects": true,
        "drop_v4_unicast_in_l2_multicast": false,
        "drop_v6_unicast_in_l2_multicast": false,
        "drop_gratuitous_arp": false,
        "drop_unsolicited_na": false,
        "arp_accept": false,
        "gro": true,
        "statistics": {
                "collisions": 0,
                "rx_frame_errors": 0,
                "tx_compressed": 0,
                "multicast": 0,
                "rx_length_errors": 0,
                "tx_dropped": 0,
                "rx_bytes": 54843533,
                "rx_missed_errors": 0,
                "tx_errors": 0,
                "rx_compressed": 0,
                "rx_over_errors": 0,
                "tx_fifo_errors": 0,
                "rx_crc_errors": 0,
                "rx_packets": 93039,
                "tx_heartbeat_errors": 0,
                "rx_dropped": 0,
                "tx_aborted_errors": 0,
                "tx_packets": 41172,
                "rx_errors": 0,
                "tx_bytes": 13169372,
                "tx_window_errors": 0,
                "rx_fifo_errors": 0,
                "tx_carrier_errors": 0
        }
}
```