### PR TITLE
qca-ssdk: rework make to allow parallel building

### DIFF
--- a/package/kernel/qca-ssdk/Makefile
+++ b/package/kernel/qca-ssdk/Makefile
@@ -10,6 +10,7 @@ PKG_SOURCE_VERSION:=23a5aa4a4d5834da7a07efb58baebfbee91786b0
 PKG_MIRROR_HASH:=2310cdad1ebc424c534aa3a2c71e72e0ab3635295653a88d17dfc64c402cd151
 
 PKG_FLAGS:=nonshared
+PKG_BUILD_PARALLEL:=1
 PKG_BUILD_FLAGS:=no-lto
 
 include $(INCLUDE_DIR)/kernel.mk
@@ -21,7 +22,7 @@ define KernelPackage/qca-ssdk
   SUBMENU:=Network Devices
   TITLE:=Qualcom SSDK switch driver
   DEPENDS:=@(TARGET_qualcommax)
-  FILES:=$(PKG_BUILD_DIR)/build/bin/qca-ssdk.ko
+  FILES:=$(PKG_BUILD_DIR)/qca-ssdk.ko
   AUTOLOAD:=$(call AutoLoad,30,qca-ssdk)
 endef
 
@@ -31,7 +32,7 @@ endef
 
 GCC_VERSION=$(shell echo "$(CONFIG_GCC_VERSION)" | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')
 
-LNX_CONFIG_OPTS = LNX_MAKEOPTS='$(KERNEL_MAKEOPTS)' MODULE_TYPE=KSLIB modules
+LNX_CONFIG_OPTS = LNX_MAKEOPTS='$(KERNEL_MAKEOPTS)' PRJ_PATH=$(PKG_BUILD_DIR) MODULE_TYPE=KSLIB modules
 
 MAKE_FLAGS+= \
 	TARGET_NAME=$(CONFIG_TARGET_NAME) \
@@ -42,7 +43,7 @@ MAKE_FLAGS+= \
 	ARCH=$(LINUX_KARCH) \
 	TARGET_SUFFIX=$(CONFIG_TARGET_SUFFIX) \
 	GCC_VERSION=$(GCC_VERSION) \
-	EXTRA_CFLAGS=-fno-stack-protector -I$(STAGING_DIR)/usr/include \
+	EXTRA_CFLAGS="-fno-stack-protector -I$(STAGING_DIR)/usr/include" \
 	SoC=$(CONFIG_TARGET_SUBTARGET) \
 	PTP_FEATURE=disable SWCONFIG_FEATURE=disable \
 	ISISC_ENABLE=disable IN_QCA803X_PHY=FALSE \
@@ -56,6 +57,11 @@ endif
 ifeq ($(CONFIG_TARGET_SUBTARGET), "ipq60xx")
     MAKE_FLAGS+= CHIP_TYPE=CPPE
 endif
+
+
+define Build/Compile
+	+$(MAKE) $(PKG_JOBS) $(MAKE_FLAGS) -C $(PKG_BUILD_DIR) $(LNX_CONFIG_OPTS)
+endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/qca-ssdk

--- a/package/kernel/qca-ssdk/patches/200-allow-parallel-build.patch
+++ b/package/kernel/qca-ssdk/patches/200-allow-parallel-build.patch
@@ -1,0 +1,50 @@
+--- a/Makefile
++++ b/Makefile
+@@ -1,17 +1,19 @@
+-include ./config
+-
+ ifndef PRJ_PATH
+   PRJ_PATH=$(shell pwd)
+ endif
+ export PRJ_PATH
+ 
+-include ./make/config.mk
+-include ./make/tools.mk
+-include ./make/$(OS)_opt.mk
++include $(PRJ_PATH)/config
++
++include $(PRJ_PATH)/make/config.mk
++include $(PRJ_PATH)/make/tools.mk
++include $(PRJ_PATH)/make/$(OS)_opt.mk
+ 
+ SUB_DIR=$(patsubst %/, %, $(dir $(wildcard src/*/Makefile)))
+ SUB_LIB=$(subst src/, , $(SUB_DIR))
+ 
++include $(PRJ_PATH)/Makefile.modules
++
+ ####################################################################
+ # 			SSDK-Style Makefile
+ ####################################################################
+@@ -27,11 +29,7 @@ all: $(BIN_DIR) kslib
+ # 			LNX Modules-Style Makefile
+ ####################################################################
+ modules: $(BIN_DIR) kslib_c
+-	mkdir -p ./temp/;cp * ./temp -a;cd ./temp;cp ../Makefile.modules ./Makefile;
+-	make -C $(SYS_PATH) M=$(PRJ_PATH)/temp $(LNX_MAKEOPTS) modules
+-	cp $(PRJ_PATH)/temp/Module.symvers $(PRJ_PATH)/Module.symvers;
+-	cp temp/*.ko build/bin;
+-	rm -Rf ./temp/*.o ./temp/*.ko ./temp/*.a
++	@$(MAKE) -C $(SYS_PATH) M=$(PRJ_PATH) $(LNX_MAKEOPTS) modules
+ 	@echo "---Build [SSDK-$(VERSION)] at $(BUILD_DATE) finished."
+ 
+ kslib_c:
+--- a/make/linux_opt.mk
++++ b/make/linux_opt.mk
+@@ -777,6 +777,6 @@ LOCAL_CFLAGS += $(CPU_CFLAG) -D"KBUILD_M
+ ####################################################################
+ # 			cflags for LNX Modules-Style Makefile
+ ####################################################################
+-LNX_LOCAL_CFLAGS += $(MODULE_INC) $(MODULE_CFLAG) ${EXTRA_INC} -DFALLTHROUGH
++LNX_LOCAL_CFLAGS = $(MODULE_INC) $(MODULE_CFLAG) ${EXTRA_INC} -DFALLTHROUGH
+ export LNX_LOCAL_CFLAGS
+ 


### PR DESCRIPTION
The current build procedure always wipes away build files, this is costly as ssdk is a parent dependency on a whole host of packages and will always end up rebuilding (and in serial) the whole package.

This patch includes:

1. Module Building Optimization: Instead of creating a temporary directory (temp) and copying files into it for module building, the directly invoke the module build command with the necessary paths. This simplifies the build process and avoids unnecessary file operations, speeding up the build process and reducing disk usage.

2. Parallel Build Support: By removing the explicit creation of the temporary directory and associated file copying operations, and passing in `$(MAKE)`, `$(PKG_JOBS)` allows building in parallel.

3. Fix `EXTRA_CFLAGS`: This variable is referenced and set within MAKE_FLAGS, so doesn't preserve spaces. Should have its defined value quoted.