### PR TITLE
kernel: add support for Realtek 8723DS interface

### DIFF
--- a/package/kernel/mac80211/realtek.mk
+++ b/package/kernel/mac80211/realtek.mk
@@ -3,7 +3,7 @@ PKG_DRIVERS += \
 	rtl8192ce rtl8192se rtl8192de rtl8192cu rtl8723bs rtl8821ae \
 	rtl8xxxu rtw88 rtw88-pci rtw88-usb rtw88-8821c rtw88-8822b rtw88-8822c \
 	rtw88-8723d rtw88-8821ce rtw88-8821cu rtw88-8822be rtw88-8822bu \
-	rtw88-8822ce rtw88-8822cu rtw88-8723de
+	rtw88-8822ce rtw88-8822cu rtw88-8723de rtw88-8723ds rtw88-sdio
 
 config-$(call config_package,rtlwifi) += RTL_CARDS RTLWIFI
 config-$(call config_package,rtlwifi-pci) += RTLWIFI_PCI
@@ -25,6 +25,7 @@ config-y += STAGING
 
 config-$(call config_package,rtw88) += RTW88 RTW88_CORE
 config-$(call config_package,rtw88-pci) += RTW88_PCI
+config-$(call config_package,rtw88-sdio) += RTW88_SDIO
 config-$(call config_package,rtw88-usb) += RTW88_USB
 config-$(call config_package,rtw88-8821c) += RTW88_8821C
 config-$(call config_package,rtw88-8821ce) += RTW88_8821CE
@@ -37,6 +38,7 @@ config-$(call config_package,rtw88-8822ce) += RTW88_8822CE
 config-$(call config_package,rtw88-8822cu) += RTW88_8822CU
 config-$(call config_package,rtw88-8723d) += RTW88_8723D
 config-$(call config_package,rtw88-8723de) += RTW88_8723DE
+config-$(call config_package,rtw88-8723ds) += RTW88_8723DS
 config-$(CONFIG_PACKAGE_RTW88_DEBUG) += RTW88_DEBUG
 config-$(CONFIG_PACKAGE_RTW88_DEBUGFS) += RTW88_DEBUGFS
 
@@ -198,6 +200,15 @@ define KernelPackage/rtw88-pci
   HIDDEN:=1
 endef
 
+define KernelPackage/rtw88-sdio
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTW88 SDIO chips support
+  DEPENDS+= +kmod-rtw88 +kmod-mmc
+  FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_sdio.ko
+  AUTOLOAD:=$(call AutoProbe,rtw88_sdoi)
+  HIDDEN:=1
+endef
+
 define KernelPackage/rtw88-usb
   $(call KernelPackage/mac80211/Default)
   TITLE:=Realtek RTW88 USB chips support
@@ -241,6 +252,14 @@ define KernelPackage/rtw88-8723d
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8723d.ko
   AUTOLOAD:=$(call AutoProbe,rtw88_8723d)
   HIDDEN:=1
+endef
+
+define KernelPackage/rtw88-8723ds
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTL8723DS family support
+  DEPENDS+= +kmod-rtw88-sdio +kmod-rtw88-8723d
+  FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8723ds.ko
+  AUTOLOAD:=$(call AutoProbe,rtw88_8723ds)
 endef
 
 define KernelPackage/rtw88-8821ce

--- a/target/linux/d1/image/Makefile
+++ b/target/linux/d1/image/Makefile
@@ -63,7 +63,7 @@ define Device/lichee_rv_dock
   DEVICE_VENDOR := Sipeed
   DEVICE_MODEL := LicheePi RV (dock)
   DEVICE_DTS := allwinner/sun20i-d1-lichee-rv-dock
-  DEVICE_PACKAGES += kmod-rtl8723bs
+  DEVICE_PACKAGES += kmod-rtw88-8723ds wpad-basic-mbedtls
   UBOOT := lichee_rv_dock
 endef
 TARGET_DEVICES += lichee_rv_dock

--- a/target/linux/d1/image/Makefile
+++ b/target/linux/d1/image/Makefile
@@ -73,7 +73,7 @@ define Device/mangopi_mq_pro
   DEVICE_VENDOR := MangoPi
   DEVICE_MODEL := MQ Pro
   DEVICE_DTS := allwinner/sun20i-d1-mangopi-mq-pro
-  DEVICE_PACKAGES += kmod-rtl8723bs
+  DEVICE_PACKAGES += kmod-rtw88-8723ds wpad-basic-mbedtls
   UBOOT := mangopi_mq_pro
 endef
 TARGET_DEVICES += mangopi_mq_pro


### PR DESCRIPTION
The RTL8723DS is a low-cost BT+wifi SDIO adapter. Package the required rtw88 SDIO module and the module itself, and add it to the LicheePi Nano Dock.

To support the Bluetooth part of the device, subsequent PRs will be submitted (linux-firmware does not yet have the firmware for it).

Signed-off-by: Zoltan HERPAI <wigyori@uid0.hu>
