### PR TITLE
Minor fixes to pass shellcheck

### DIFF
--- a/package/base-files/files/bin/board_detect
+++ b/package/base-files/files/bin/board_detect
@@ -5,8 +5,8 @@ CFG=$1
 [ -n "$CFG" ] || CFG=/etc/board.json
 
 [ -d "/etc/board.d/" -a ! -s "$CFG" ] && {
-	for a in $(ls /etc/board.d/*); do
-		[ -s $a ] || continue;
+	for a in /etc/board.d/*; do
+		[ -s "$a" ] || continue;
 		$(. $a)
 	done
 }

--- a/package/base-files/files/sbin/firstboot
+++ b/package/base-files/files/sbin/firstboot
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/sbin/jffs2reset $@
+/sbin/jffs2reset "$@"


### PR DESCRIPTION
These are just two minor patches to the following two scripts that comes with the `base-files` package to solve errors given by the [ShellCheck](https://www.shellcheck.net/) utility:
- `/bin/board_detect`
- `/sbin/firstboot`

The first script contained parsing of the `ls` command which is not recommended:
> In shell scripting, the use of command expansion - for looping over a set of files - is not
recommended. Command expansion, in fact, may cause word splitting. This issue refers to the
process by which the shell splits a string into separate words based on whitespace or other
delimiters. Word splitting can cause problems for certain filenames.

While the second script contained potential re-splitting:
> In shell scripting, "splitting" refers to the process by which the shell splits a string into
separate words based on whitespace or other delimiters. This can happen when a variable is
expanded. For example, if an array's string item contains the whitespaces, each resulting
substring will be considered as a different array's element. This can cause several runtime
issues and bugs.