### PR TITLE
rlt930x: don't warn when ledsets are not present in device tree

### DIFF
--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -2421,9 +2421,15 @@ static void rtl930x_led_init(struct rtl838x_switch_priv *priv)
 		 *
 		*/
 		sprintf(set_name, "led_set%d", set);
+
+		if (!of_property_present(node, set_name)) {
+			pr_debug("%s led_set node '%s' not present\n", set_name);
+			continue;
+		}
+
 		leds_in_this_set = of_property_count_u32_elems(node, set_name);
 
-		if (leds_in_this_set == 0 || leds_in_this_set > sizeof(set_config)) {
+		if (leds_in_this_set <= 0 || leds_in_this_set > sizeof(set_config)) {
 			pr_err("%s led_set configuration invalid skipping over this set\n", __func__);
 			continue;
 		}


### PR DESCRIPTION
Check first if ledset is present then check if led set is configured properly or not. also take care of negative values resulting from `of_property_count_u32_elems`

Fix this issue,
https://github.com/openwrt/openwrt/pull/14221#issuecomment-1929229162