### PR TITLE
base-files: replace /etc/sysctl with /etc/sysctl.d in keep.d

### DIFF
--- a/package/base-files/files/lib/upgrade/keep.d/base-files-essential
+++ b/package/base-files/files/lib/upgrade/keep.d/base-files-essential
@@ -7,5 +7,5 @@
 /etc/shadow
 /etc/shells
 /etc/shinit
-/etc/sysctl.conf
+/etc/sysctl.d/
 /etc/rc.local


### PR DESCRIPTION
sysctl just includes sysctl.d and is not supposed for editing, thus replace it in keep.d