### PR TITLE
[22.03] bcm47xx: fix switch setup for Linksys WRT320N v1

### DIFF
--- a/target/linux/bcm47xx/base-files/etc/board.d/01_network
+++ b/target/linux/bcm47xx/base-files/etc/board.d/01_network
@@ -170,6 +170,7 @@ configure_by_model() {
 
 	"Asus RT-N16"* | \
 	"Linksys E3000 V1" | \
+	"Linksys WRT320N V1" | \
 	"Linksys WRT610N V2" | \
 	"Netgear WNR3500 V2" | \
 	"Netgear WNR3500L")


### PR DESCRIPTION
The config on the WRT320N V1 is not detected by the initial network configuration script. The switch remains unconfigured and WAN/LAN VLANs are not created.

This adds the correct setup for the device.