### PR TITLE
tools: b43-tools: fix compilation with GCC14

### DIFF
--- a/tools/b43-tools/Makefile
+++ b/tools/b43-tools/Makefile
@@ -23,7 +23,7 @@ define Host/Compile
 		$(HOST_MAKE_FLAGS) \
 		$(1) QUIET_SPARSE=:
 	+$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR)/assembler \
-		CFLAGS="$(HOST_CFLAGS) -include endian.h" \
+		CFLAGS="$(HOST_CFLAGS) -include endian.h -Wno-error=int-conversion" \
 		$(HOST_MAKE_FLAGS) \
 		LDFLAGS= \
 		$(1) QUIET_SPARSE=:


### PR DESCRIPTION
GCC14 no longer treats integer types and pointer types as equivalent in assignments (including implied assignments of function arguments and return values), and instead fails the compilation with a type error.

So, as a workaround lets disable the newly introduced error -Werror=int-conversion and just make it print a warning to enable compiling with GCC14 as Fedora 40 now defaults to it.
