### PR TITLE
ramips: Add support for Creality WB-01

### DIFF
--- a/target/linux/ramips/dts/mt7628an_creality_wb-01.dts
+++ b/target/linux/ramips/dts/mt7628an_creality_wb-01.dts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "creality,wb-01", "mediatek,mt7628an-soc";
+	model = "Creality WB-01";
+
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-upgrade = &led_status;
+		led-running = &led_status;
+		label-mac-device = &wmac;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wlan2 {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_YELLOW>;
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status: status {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		led_sd {
+			function = LED_FUNCTION_SD;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&esw {
+	mediatek,portmap = <0x3f>;
+	mediatek,portdisable = <0x3e>;
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "p3led_an", "p1led_an", "p0led_an", "wled_an";
+		function = "gpio";
+	};
+};
+
+&wmac {
+	status = "okay";
+	mediatek,mtd-eeprom = <&factory 0x0>;
+
+	nvmem-cells = <&macaddr_factory_04>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&sdhci {
+	status = "okay";
+	mediatek,cd-low;
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_04: macaddr@04 {
+		reg = <0x04 0x6>;
+	};
+
+	macaddr_factory_28: macaddr@28 {
+		reg = <0x28 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -6,6 +6,20 @@ include ./common-tp-link.mk
 
 DEFAULT_SOC := mt7628an
 
+define Build/creality_wb-01-factory
+	mv $@ $(dir $@)factory.bin
+	$(eval kernel_size=851968)
+	( \
+		echo '#!/bin/sh'; \
+		echo '[ -z "$$2" ] && file="factory.bin" || file="$$2/factory.bin"'; \
+		echo 'file_size=$$(wc -c < $$file)'; \
+		echo 'rootfs_size=$$((file_size - $(kernel_size)))'; \
+		echo 'mtd_write -o 0 -l $(kernel_size) write $$file Kernel'; \
+		echo 'mtd_write -r -o $(kernel_size) -l $$rootfs_size write $$file RootFS'; \
+	) > $(dir $@)install.sh
+	tar cjf $@ -C $(dir $@) factory.bin install.sh
+endef
+
 define Build/elecom-header
 	$(eval model_id=$(1))
 	( \
@@ -166,6 +180,17 @@ define Device/comfast_cf-wr758ac-v2
   SUPPORTED_DEVICES += joowin,jw-wr758ac-v2
 endef
 TARGET_DEVICES += comfast_cf-wr758ac-v2
+
+define Device/creality_wb-01
+  IMAGE_SIZE := 16064k
+  IMAGES += cxsw_update.tar.bz2
+  IMAGE/cxsw_update.tar.bz2 := $$(sysupgrade_bin) | creality_wb-01-factory
+  DEVICE_VENDOR := Creality
+  DEVICE_MODEL := WB-01
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620
+  SUPPORTED_DEVICES += creality_wb-01
+endef
+TARGET_DEVICES += creality_wb-01
 
 define Device/cudy_tr1200-v1
   IMAGE_SIZE := 15872k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -24,6 +24,9 @@ yuncore,m300)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0xf"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
+creality,wb-01)
+	ucidef_set_led_switch "lan" "lan" "blue:lan" "switch0" "0x1"
+	;;
 cudy,wr1000)
 	ucidef_set_led_switch "wan" "wan" "blue:wan" "switch0" "0x10"
 	ucidef_set_led_switch "lan1" "lan1" "blue:lan1" "switch0" "0x08"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -173,6 +173,7 @@ ramips_setup_interfaces()
 			"0:lan" "1:lan" "2:lan" "3:lan" "6t@eth0"
 		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
 		;;
+	creality,wb-01|\
 	tplink,tl-mr3020-v3)
 		ucidef_add_switch "switch0" \
 			"0:lan" "6@eth0"


### PR DESCRIPTION
CREALITY BOX WB01 is small footprint router based on MediaTek MT7688

Specifications:
- SoC: MediaTek MT7688 580MHz
- RAM: DDR2 128M
- Flash: BY25Q128AS (16 MiB, SPI NOR) handled by BoHong bh25q128as driver
- WiFi: 2.4GHz 1T1R internal panel antenna
- Ethernet: 1x LAN (10/100)
- USB: 2x USB2.0 port
- UART: 3.3V, TX, RX, GND / 56700 8N1 / only pads on PCB
- micro USB input (for power only)
- reset button
- FCC ID: 2AXH6CREALITY-BOX

MAC addresses as verified by OEM firmware:
```
vendor   OpenWrt    source
LAN      eth0       factory 0x2e
2.4GHz   phy0-ap0   factory 0x04 (label)
```

LEDs
```
color    vendor                OpenWRT     configurable
red      SD card activity        -             yes
green    Claoud connectivity   status          yes
blue     LAN activity          eth0            yes
yellow   WIFI activity         phy0tpt         yes
```

Return to OEM & debrick
- download "cxsw_update.tar.bz2" from manufacturer site
- extract archive to FAT32 USB stick root
- put USB stick in USB2 port
- press & hold reset button
- power on device while holding reset
- wait approx 10 sec
- release reset button

Installation with SD Card
- power on device
- wait for device to finish starting
- copy "openwrt-ramips-mt76x8-creality_wb-01-squashfs-cxsw_update.tar.bz2" to root of FAT32 SD card
- rename openwrt-ramips-mt76x8-creality_wb-01-squashfs-cxsw_update.tar.bz2 to "cxsw_update.tar.bz2"
- put SD card in device
- divice will install OpenWRT on internal flash

Installation via telnet:
- extract the "factory.bin" and "install.sh" from newly created openwrt-ramips-mt76x8-creality_wb-01-squashfs-cxsw_update.tar.bz2 to FAT32 USB stick root
- telnet to 10.10.10.254, user: root, password: cxswprin
- plug the USB in USB1 port
- cd /media/usbdisk/
- sh install.sh
- device will write "factory.bin" to internal flash

