### PR TITLE
qualcommax: ipq807x: ZyXEL NBG7815: Fix random Wifi MAC.

### DIFF
--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -30,4 +30,10 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && macaddr_add $label_mac 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "2" ] && macaddr_add $label_mac 3 > /sys${DEVPATH}/macaddress
 		;;
+	zyxel,nbg7815)
+		label_mac=$(get_mac_label)
+		[ "$PHYNBR" = "0" ] && macaddr_add $label_mac 2 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $label_mac 3 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "2" ] && macaddr_add $label_mac 4 > /sys${DEVPATH}/macaddress
+		;;
 esac


### PR DESCRIPTION
For this particualar device we get random MAC's for Wifi on every (re-)boot. This is because art partition does not contain valid MAC addresses.

ZyXEL is doing it like:

```
   base_addr=$(fw_printenv ethaddr | awk -F"=" '{print $2}' |sed 's/"//g')
   set_wlan_mac(){
        mac_addr=$(echo $base_addr | cut -c 1-16)
        lastchar=$(echo $base_addr | cut -c 17-17)
        curchar24G=
        curchar5G=
        case $lastchar in
                0)      curchar24G="2"
                        curchar5G="3"
                        curchar5G_2="4"
                ;;
                8)      curchar24G="A"
                        curchar5G="B"
                        curchar5G_2="C"
                ;;
                *)
                        echo "Wrong end character in Mac address!"
        ;;
```

While 0/8=LAN and 1/9=WAN and 2,3,4 respectivley A,B,C for Wifi.

As we just increment it we can do:

```
   label_mac=$(fw_printenv | awk -F'=' '/ethaddr/ {print $2}')
	   [ "$PHYNBR" = "0" ] && macaddr_add $label_mac 2 > /sys${DEVPATH}/macaddress
	   [ "$PHYNBR" = "1" ] && macaddr_add $label_mac 3 > /sys${DEVPATH}/macaddress
	   [ "$PHYNBR" = "2" ] && macaddr_add $label_mac 4 > /sys${DEVPATH}/macaddress
```

I'm just unsure if this is the proper way to retrive the initial MAC. The MAC from Bootloader is always there and is identical to the MAC printed on the backside of the device itself.

This is my first pull request ever. So don't slap me to hard if I did sth. wrong.
