### PR TITLE
README: replace "MacOSX" with "macOS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ An advanced user may require additional or specific package. (Toolchain, SDK, ..
 
 ## Development
 
-To build your own firmware you need a GNU/Linux, BSD or MacOSX system (case
+To build your own firmware you need a GNU/Linux, BSD or macOS system (case
 sensitive filesystem required). Cygwin is unsupported because of the lack of a
 case sensitive file system.
 


### PR DESCRIPTION
In October 2018, the last version of the operating system named `Mac OS X` ended its life cycle.

It's time to change it to `macOS`.