### PR TITLE
kernel: rtl8367, rtl8367b: set the appropriate cpu_port value based on the use of realtek,extif0 to extif2

### DIFF
--- a/target/linux/apm821xx/dts/netgear-wndap6x0.dtsi
+++ b/target/linux/apm821xx/dts/netgear-wndap6x0.dtsi
@@ -224,7 +224,6 @@
 
 	rtl8367b {
 		compatible = "realtek,rtl8367b";
-		cpu_port = <5>;
 		realtek,extif0 = <1 2 1 1 1 1 1 1 2>;
 		mii-bus = <&mdio0>;
 	};

--- a/target/linux/generic/files/drivers/net/phy/rtl8367.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367.c
@@ -1641,7 +1641,7 @@ static int rtl8367_switch_init(struct rtl8366_smi *smi)
 	int err;
 
 	dev->name = "RTL8367";
-	dev->cpu_port = RTL8367_CPU_PORT_NUM;
+	dev->cpu_port = smi->cpu_port;
 	dev->ports = RTL8367_NUM_PORTS;
 	dev->vlans = RTL8367_NUM_VIDS;
 	dev->ops = &rtl8367_sw_ops;
@@ -1721,6 +1721,11 @@ static int rtl8367_detect(struct rtl8366_smi *smi)
 
 	dev_info(smi->parent, "RTL%s ver. %u chip found\n",
 		 chip_name, rtl_ver & RTL8367_RTL_VER_MASK);
+
+	if (of_property_present(smi->parent->of_node, "realtek,extif1"))
+		smi->cpu_port = RTL8367_CPU_PORT_NUM - 1;
+
+	dev_info(smi->parent, "CPU port: %u\n", smi->cpu_port);
 
 	return 0;
 }

--- a/target/linux/generic/files/drivers/net/phy/rtl8367b.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367b.c
@@ -1583,6 +1583,13 @@ static int rtl8367b_detect(struct rtl8366_smi *smi)
 
 	dev_info(smi->parent, "RTL%s chip found\n", chip_name);
 
+	if (of_property_present(smi->parent->of_node, "realtek,extif2"))
+		smi->cpu_port = RTL8367B_CPU_PORT_NUM + 2;
+	else if (of_property_present(smi->parent->of_node, "realtek,extif1") && (chip_ver != 0x1010)) /* for the RTL8367R-VB chip, extif1 corresponds to cpu_port 5 */ 
+		smi->cpu_port = RTL8367B_CPU_PORT_NUM + 1;
+
+	dev_info(smi->parent, "CPU port: %u\n", smi->cpu_port);
+
 	return 0;
 }
 
@@ -1621,9 +1628,7 @@ static int  rtl8367b_probe(struct platform_device *pdev)
 	smi->cmd_write = 0xb8;
 	smi->ops = &rtl8367b_smi_ops;
 	smi->num_ports = RTL8367B_NUM_PORTS;
-	if (of_property_read_u32(pdev->dev.of_node, "cpu_port", &smi->cpu_port)
-	    || smi->cpu_port >= smi->num_ports)
-		smi->cpu_port = RTL8367B_CPU_PORT_NUM;
+	smi->cpu_port = RTL8367B_CPU_PORT_NUM;
 	smi->num_vlan_mc = RTL8367B_NUM_VLANS;
 	smi->mib_counters = rtl8367b_mib_counters;
 	smi->num_mib_counters = ARRAY_SIZE(rtl8367b_mib_counters);

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
@@ -55,7 +55,6 @@
 
 	rtl8367rb {
 		compatible = "realtek,rtl8367b";
-		cpu_port = <6>;
 		realtek,extif1 = <1 0 1 1 1 1 1 1 2>;
 		mii-bus = <&mdio0>;
 	};

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c5-v4.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c5-v4.dts
@@ -74,7 +74,6 @@
 
 	rtl8367s {
 		compatible = "realtek,rtl8367b";
-		cpu_port = <7>;
 		realtek,extif2 = <1 0 1 1 1 1 1 1 2>;
 		mii-bus = <&mdio0>;
 		phy-id = <29>;

--- a/target/linux/ramips/dts/mt7620a_tplink_ec220-g5-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_ec220-g5-v2.dts
@@ -82,7 +82,6 @@
 
 	rtl8367s {
 		compatible = "realtek,rtl8367b";
-		cpu_port = <7>;
 		realtek,extif2 = <1 0 1 1 1 1 1 1 2>;
 		mii-bus = <&mdio0>;
 		phy-id = <29>;

--- a/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
+++ b/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
@@ -85,7 +85,6 @@
 
 	rtl8367rb {
 		compatible = "realtek,rtl8367b";
-		cpu_port = <7>;
 		realtek,extif2 = <1 0 1 1 1 1 1 1 2>;
 		mii-bus = <&mdio0>;
 	};


### PR DESCRIPTION
For rtl8367: Set the appropriate cpu_port value based on the use of realtek,extif0 or realtek,extif1 parameter.
For rtl8367b: Set the appropriate cpu_port value based on the use of realtek,extif0 to realtek,extif2 instead of the additional cpu_port parameter.

Tested on ramips: TP-Link Archer C5 v4
Other routers with the realtek definition,extif0-2 were also checked. For all cpu_port matches that defined in 02_network (last two columns below).
<body>

 realtek,rtl8367 | chip | dts→cpu_port | dts→extif | according to dts→extif (this patch) | 02_network→@&ZeroWidthSpace;eth0
-- | -- | -- | -- | -- | --
ar7242_tplink_tl-wr2543-v1 | RTL8367R | not defined (9) | 0 | **9** | 9
rt3662_asus_rt-n56u | RTL8367M | not defined (9) | 1 | **8** | 8
rt3662_edimax_br-6475nd | RTL8367R | not defined (9) | 0 | **9** | 9
rt3662_samsung_cy-swr1100 | RTL8367R | not defined (9) | 0 | **9** | 9
</body>
<body>

 realtek,rtl8367b | chip | dts→cpu_port | dts→extif | according to dts→extif (this patch) |  02_network→@&ZeroWidthSpace;eth0
-- | -- | -- | -- | -- | --
mt7620a_tplink_archer-c2-v1 | RTL8367RB | 6 | 1 | **6** | 6
mt7620a_tplink_archer-c5-v4 | RTL8367S | 7 | 2 | **7** | 7
mt7620a_tplink_ec220-g5-v2 | RTL8367S | 7 | 2 | **7** | 7
mt7620a_zyxel_keenetic-viva | RTL8367RB | 7 | 2 | **7** | 7
Netgear-wndap620 | RTL8363SB | 5 | 0 | **5** | 5
Netgear-wndap660 | RTL8363SB | 5 | 0 | **5** | 5
mt7620a_iodata_wn-ac733gr3 | RTL8367RB | not defined (5) | 1 | **6** | 6
rt3662_dlink_dir-645 | RTL8367RB | not defined (5) | 1 | **6** | 6
rt3883_belkin_f9k1109v1 | RTL8367R-VB | not defined (5) | 1 | **5** | 5
</body>

