### PR TITLE
qca-nss-dp: cp instead of symlink for `nss_dp_arch.h`

### DIFF
--- a/package/kernel/qca-nss-dp/Makefile
+++ b/package/kernel/qca-nss-dp/Makefile
@@ -39,7 +39,7 @@ EXTRA_CFLAGS+= \
 
 NSS_DP_HAL_DIR:=$(PKG_BUILD_DIR)/hal
 define Build/Configure
-	$(LN) $(NSS_DP_HAL_DIR)/soc_ops/$(CONFIG_TARGET_SUBTARGET)/nss_$(CONFIG_TARGET_SUBTARGET).h \
+	$(CP) $(NSS_DP_HAL_DIR)/soc_ops/$(CONFIG_TARGET_SUBTARGET)/nss_$(CONFIG_TARGET_SUBTARGET).h \
 		$(PKG_BUILD_DIR)/exports/nss_dp_arch.h
 endef
 


### PR DESCRIPTION
Build files shouldn't be symlinked into the staging directory, as doing so would create a race condition if the build folder for 'qca-nss-dp' gets deleted for any reason.

We should instead just copy over the required platform file to avoid breaking compilation for any dependent packages.