### PR TITLE
toolchain/gcc: fix build errors on macOS with Xcode 15.3

### DIFF
--- a/toolchain/gcc/patches-11.x/020-Include-safe-ctype.h-after-C-standard-headers-to-avo.patch
+++ b/toolchain/gcc/patches-11.x/020-Include-safe-ctype.h-after-C-standard-headers-to-avo.patch
@@ -1,0 +1,139 @@
+From 9970b576b7e4ae337af1268395ff221348c4b34a Mon Sep 17 00:00:00 2001
+From: Francois-Xavier Coudert <fxcoudert@gcc.gnu.org>
+Date: Thu, 7 Mar 2024 14:36:03 +0100
+Subject: [PATCH] Include safe-ctype.h after C++ standard headers, to avoid
+ over-poisoning
+
+When building gcc's C++ sources against recent libc++, the poisoning of
+the ctype macros due to including safe-ctype.h before including C++
+standard headers such as <list>, <map>, etc, causes many compilation
+errors, similar to:
+
+  In file included from /home/dim/src/gcc/master/gcc/gensupport.cc:23:
+  In file included from /home/dim/src/gcc/master/gcc/system.h:233:
+  In file included from /usr/include/c++/v1/vector:321:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_bool.h:20:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_integral.h:32:
+  In file included from /usr/include/c++/v1/locale:202:
+  /usr/include/c++/v1/__locale:546:5: error: '__abi_tag__' attribute
+  only applies to structs, variables, functions, and namespaces
+    546 |     _LIBCPP_INLINE_VISIBILITY
+        |     ^
+  /usr/include/c++/v1/__config:813:37: note: expanded from macro
+  '_LIBCPP_INLINE_VISIBILITY'
+    813 | #  define _LIBCPP_INLINE_VISIBILITY _LIBCPP_HIDE_FROM_ABI
+        |                                     ^
+  /usr/include/c++/v1/__config:792:26: note: expanded from macro
+  '_LIBCPP_HIDE_FROM_ABI'
+    792 |
+    __attribute__((__abi_tag__(_LIBCPP_TOSTRING(
+  _LIBCPP_VERSIONED_IDENTIFIER))))
+        |                          ^
+  In file included from /home/dim/src/gcc/master/gcc/gensupport.cc:23:
+  In file included from /home/dim/src/gcc/master/gcc/system.h:233:
+  In file included from /usr/include/c++/v1/vector:321:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_bool.h:20:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_integral.h:32:
+  In file included from /usr/include/c++/v1/locale:202:
+  /usr/include/c++/v1/__locale:547:37: error: expected ';' at end of
+  declaration list
+    547 |     char_type toupper(char_type __c) const
+        |                                     ^
+  /usr/include/c++/v1/__locale:553:48: error: too many arguments
+  provided to function-like macro invocation
+    553 |     const char_type* toupper(char_type* __low, const
+    char_type* __high) const
+        |                                                ^
+  /home/dim/src/gcc/master/gcc/../include/safe-ctype.h:146:9: note:
+  macro 'toupper' defined here
+    146 | #define toupper(c) do_not_use_toupper_with_safe_ctype
+        |         ^
+
+This is because libc++ uses different transitive includes than
+libstdc++, and some of those transitive includes pull in various ctype
+declarations (typically via <locale>).
+
+There was already a special case for including <string> before
+safe-ctype.h, so move the rest of the C++ standard header includes to
+the same location, to fix the problem.
+
+gcc/ChangeLog:
+
+	* system.h: Include safe-ctype.h after C++ standard headers.
+
+Signed-off-by: Dimitry Andric <dimitry@andric.com>
+---
+ gcc/system.h | 39 ++++++++++++++++++---------------------
+ 1 file changed, 18 insertions(+), 21 deletions(-)
+
+diff --git a/gcc/system.h b/gcc/system.h
+index b0edab02885..ab29fc19776 100644
+--- a/gcc/system.h
++++ b/gcc/system.h
+@@ -194,27 +194,8 @@ extern int fprintf_unlocked (FILE *, const char *, ...);
+ #undef fread_unlocked
+ #undef fwrite_unlocked
+ 
+-/* Include <string> before "safe-ctype.h" to avoid GCC poisoning
+-   the ctype macros through safe-ctype.h */
+-
+-#ifdef __cplusplus
+-#ifdef INCLUDE_STRING
+-# include <string>
+-#endif
+-#endif
+-
+-/* There are an extraordinary number of issues with <ctype.h>.
+-   The last straw is that it varies with the locale.  Use libiberty's
+-   replacement instead.  */
+-#include "safe-ctype.h"
+-
+-#include <sys/types.h>
+-
+-#include <errno.h>
+-
+-#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
+-extern int errno;
+-#endif
++/* Include C++ standard headers before "safe-ctype.h" to avoid GCC
++   poisoning the ctype macros through safe-ctype.h */
+ 
+ #ifdef __cplusplus
+ #if defined (INCLUDE_ALGORITHM) || !defined (HAVE_SWAP_IN_UTILITY)
+@@ -229,6 +210,9 @@ extern int errno;
+ #ifdef INCLUDE_SET
+ # include <set>
+ #endif
++#ifdef INCLUDE_STRING
++# include <string>
++#endif
+ #ifdef INCLUDE_VECTOR
+ # include <vector>
+ #endif
+@@ -244,6 +228,19 @@ extern int errno;
+ # include <type_traits>
+ #endif
+ 
++/* There are an extraordinary number of issues with <ctype.h>.
++   The last straw is that it varies with the locale.  Use libiberty's
++   replacement instead.  */
++#include "safe-ctype.h"
++
++#include <sys/types.h>
++
++#include <errno.h>
++
++#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
++extern int errno;
++#endif
++
+ /* Some of glibc's string inlines cause warnings.  Plus we'd rather
+    rely on (and therefore test) GCC's string builtins.  */
+ #define __NO_STRING_INLINES
+-- 
+2.39.3
+

--- a/toolchain/gcc/patches-12.x/020-Include-safe-ctype.h-after-C-standard-headers-to-avo.patch
+++ b/toolchain/gcc/patches-12.x/020-Include-safe-ctype.h-after-C-standard-headers-to-avo.patch
@@ -1,0 +1,139 @@
+From 9970b576b7e4ae337af1268395ff221348c4b34a Mon Sep 17 00:00:00 2001
+From: Francois-Xavier Coudert <fxcoudert@gcc.gnu.org>
+Date: Thu, 7 Mar 2024 14:36:03 +0100
+Subject: [PATCH] Include safe-ctype.h after C++ standard headers, to avoid
+ over-poisoning
+
+When building gcc's C++ sources against recent libc++, the poisoning of
+the ctype macros due to including safe-ctype.h before including C++
+standard headers such as <list>, <map>, etc, causes many compilation
+errors, similar to:
+
+  In file included from /home/dim/src/gcc/master/gcc/gensupport.cc:23:
+  In file included from /home/dim/src/gcc/master/gcc/system.h:233:
+  In file included from /usr/include/c++/v1/vector:321:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_bool.h:20:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_integral.h:32:
+  In file included from /usr/include/c++/v1/locale:202:
+  /usr/include/c++/v1/__locale:546:5: error: '__abi_tag__' attribute
+  only applies to structs, variables, functions, and namespaces
+    546 |     _LIBCPP_INLINE_VISIBILITY
+        |     ^
+  /usr/include/c++/v1/__config:813:37: note: expanded from macro
+  '_LIBCPP_INLINE_VISIBILITY'
+    813 | #  define _LIBCPP_INLINE_VISIBILITY _LIBCPP_HIDE_FROM_ABI
+        |                                     ^
+  /usr/include/c++/v1/__config:792:26: note: expanded from macro
+  '_LIBCPP_HIDE_FROM_ABI'
+    792 |
+    __attribute__((__abi_tag__(_LIBCPP_TOSTRING(
+  _LIBCPP_VERSIONED_IDENTIFIER))))
+        |                          ^
+  In file included from /home/dim/src/gcc/master/gcc/gensupport.cc:23:
+  In file included from /home/dim/src/gcc/master/gcc/system.h:233:
+  In file included from /usr/include/c++/v1/vector:321:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_bool.h:20:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_integral.h:32:
+  In file included from /usr/include/c++/v1/locale:202:
+  /usr/include/c++/v1/__locale:547:37: error: expected ';' at end of
+  declaration list
+    547 |     char_type toupper(char_type __c) const
+        |                                     ^
+  /usr/include/c++/v1/__locale:553:48: error: too many arguments
+  provided to function-like macro invocation
+    553 |     const char_type* toupper(char_type* __low, const
+    char_type* __high) const
+        |                                                ^
+  /home/dim/src/gcc/master/gcc/../include/safe-ctype.h:146:9: note:
+  macro 'toupper' defined here
+    146 | #define toupper(c) do_not_use_toupper_with_safe_ctype
+        |         ^
+
+This is because libc++ uses different transitive includes than
+libstdc++, and some of those transitive includes pull in various ctype
+declarations (typically via <locale>).
+
+There was already a special case for including <string> before
+safe-ctype.h, so move the rest of the C++ standard header includes to
+the same location, to fix the problem.
+
+gcc/ChangeLog:
+
+	* system.h: Include safe-ctype.h after C++ standard headers.
+
+Signed-off-by: Dimitry Andric <dimitry@andric.com>
+---
+ gcc/system.h | 39 ++++++++++++++++++---------------------
+ 1 file changed, 18 insertions(+), 21 deletions(-)
+
+diff --git a/gcc/system.h b/gcc/system.h
+index b0edab02885..ab29fc19776 100644
+--- a/gcc/system.h
++++ b/gcc/system.h
+@@ -194,27 +194,8 @@ extern int fprintf_unlocked (FILE *, const char *, ...);
+ #undef fread_unlocked
+ #undef fwrite_unlocked
+ 
+-/* Include <string> before "safe-ctype.h" to avoid GCC poisoning
+-   the ctype macros through safe-ctype.h */
+-
+-#ifdef __cplusplus
+-#ifdef INCLUDE_STRING
+-# include <string>
+-#endif
+-#endif
+-
+-/* There are an extraordinary number of issues with <ctype.h>.
+-   The last straw is that it varies with the locale.  Use libiberty's
+-   replacement instead.  */
+-#include "safe-ctype.h"
+-
+-#include <sys/types.h>
+-
+-#include <errno.h>
+-
+-#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
+-extern int errno;
+-#endif
++/* Include C++ standard headers before "safe-ctype.h" to avoid GCC
++   poisoning the ctype macros through safe-ctype.h */
+ 
+ #ifdef __cplusplus
+ #if defined (INCLUDE_ALGORITHM) || !defined (HAVE_SWAP_IN_UTILITY)
+@@ -229,6 +210,9 @@ extern int errno;
+ #ifdef INCLUDE_SET
+ # include <set>
+ #endif
++#ifdef INCLUDE_STRING
++# include <string>
++#endif
+ #ifdef INCLUDE_VECTOR
+ # include <vector>
+ #endif
+@@ -245,6 +229,19 @@ extern int errno;
+ # include <type_traits>
+ #endif
+ 
++/* There are an extraordinary number of issues with <ctype.h>.
++   The last straw is that it varies with the locale.  Use libiberty's
++   replacement instead.  */
++#include "safe-ctype.h"
++
++#include <sys/types.h>
++
++#include <errno.h>
++
++#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
++extern int errno;
++#endif
++
+ /* Some of glibc's string inlines cause warnings.  Plus we'd rather
+    rely on (and therefore test) GCC's string builtins.  */
+ #define __NO_STRING_INLINES
+-- 
+2.39.3
+

--- a/toolchain/gcc/patches-12.x/021-libcc1-fix-vector-include.patch
+++ b/toolchain/gcc/patches-12.x/021-libcc1-fix-vector-include.patch
@@ -1,0 +1,65 @@
+From 5213047b1d50af63dfabb5e5649821a6cb157e33 Mon Sep 17 00:00:00 2001
+From: Francois-Xavier Coudert <fxcoudert@gcc.gnu.org>
+Date: Sat, 16 Mar 2024 09:50:00 +0100
+Subject: [PATCH] libcc1: fix <vector> include
+
+Use INCLUDE_VECTOR before including system.h, instead of directly
+including <vector>, to avoid running into poisoned identifiers.
+
+Signed-off-by: Dimitry Andric <dimitry@andric.com>
+
+libcc1/ChangeLog:
+
+	PR middle-end/111632
+	* libcc1plugin.cc: Fix include.
+	* libcp1plugin.cc: Fix include.
+---
+ libcc1/libcc1plugin.cc | 3 +--
+ libcc1/libcp1plugin.cc | 3 +--
+ 2 files changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/libcc1/libcc1plugin.cc b/libcc1/libcc1plugin.cc
+index 72d17c3b81c..e64847466f4 100644
+--- a/libcc1/libcc1plugin.cc
++++ b/libcc1/libcc1plugin.cc
+@@ -32,6 +32,7 @@
+ #undef PACKAGE_VERSION
+ 
+ #define INCLUDE_MEMORY
++#define INCLUDE_VECTOR
+ #include "gcc-plugin.h"
+ #include "system.h"
+ #include "coretypes.h"
+@@ -69,8 +70,6 @@
+ #include "gcc-c-interface.h"
+ #include "context.hh"
+ 
+-#include <vector>
+-
+ using namespace cc1_plugin;
+ 
+ 
+diff --git a/libcc1/libcp1plugin.cc b/libcc1/libcp1plugin.cc
+index 0eff7c68d29..da68c5d0ac1 100644
+--- a/libcc1/libcp1plugin.cc
++++ b/libcc1/libcp1plugin.cc
+@@ -33,6 +33,7 @@
+ #undef PACKAGE_VERSION
+ 
+ #define INCLUDE_MEMORY
++#define INCLUDE_VECTOR
+ #include "gcc-plugin.h"
+ #include "system.h"
+ #include "coretypes.h"
+@@ -71,8 +72,6 @@
+ #include "rpc.hh"
+ #include "context.hh"
+ 
+-#include <vector>
+-
+ using namespace cc1_plugin;
+ 
+ 
+-- 
+2.39.3
+

--- a/toolchain/gcc/patches-13.x/020-Include-safe-ctype.h-after-C-standard-headers-to-avo.patch
+++ b/toolchain/gcc/patches-13.x/020-Include-safe-ctype.h-after-C-standard-headers-to-avo.patch
@@ -1,0 +1,139 @@
+From 9970b576b7e4ae337af1268395ff221348c4b34a Mon Sep 17 00:00:00 2001
+From: Francois-Xavier Coudert <fxcoudert@gcc.gnu.org>
+Date: Thu, 7 Mar 2024 14:36:03 +0100
+Subject: [PATCH] Include safe-ctype.h after C++ standard headers, to avoid
+ over-poisoning
+
+When building gcc's C++ sources against recent libc++, the poisoning of
+the ctype macros due to including safe-ctype.h before including C++
+standard headers such as <list>, <map>, etc, causes many compilation
+errors, similar to:
+
+  In file included from /home/dim/src/gcc/master/gcc/gensupport.cc:23:
+  In file included from /home/dim/src/gcc/master/gcc/system.h:233:
+  In file included from /usr/include/c++/v1/vector:321:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_bool.h:20:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_integral.h:32:
+  In file included from /usr/include/c++/v1/locale:202:
+  /usr/include/c++/v1/__locale:546:5: error: '__abi_tag__' attribute
+  only applies to structs, variables, functions, and namespaces
+    546 |     _LIBCPP_INLINE_VISIBILITY
+        |     ^
+  /usr/include/c++/v1/__config:813:37: note: expanded from macro
+  '_LIBCPP_INLINE_VISIBILITY'
+    813 | #  define _LIBCPP_INLINE_VISIBILITY _LIBCPP_HIDE_FROM_ABI
+        |                                     ^
+  /usr/include/c++/v1/__config:792:26: note: expanded from macro
+  '_LIBCPP_HIDE_FROM_ABI'
+    792 |
+    __attribute__((__abi_tag__(_LIBCPP_TOSTRING(
+  _LIBCPP_VERSIONED_IDENTIFIER))))
+        |                          ^
+  In file included from /home/dim/src/gcc/master/gcc/gensupport.cc:23:
+  In file included from /home/dim/src/gcc/master/gcc/system.h:233:
+  In file included from /usr/include/c++/v1/vector:321:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_bool.h:20:
+  In file included from
+  /usr/include/c++/v1/__format/formatter_integral.h:32:
+  In file included from /usr/include/c++/v1/locale:202:
+  /usr/include/c++/v1/__locale:547:37: error: expected ';' at end of
+  declaration list
+    547 |     char_type toupper(char_type __c) const
+        |                                     ^
+  /usr/include/c++/v1/__locale:553:48: error: too many arguments
+  provided to function-like macro invocation
+    553 |     const char_type* toupper(char_type* __low, const
+    char_type* __high) const
+        |                                                ^
+  /home/dim/src/gcc/master/gcc/../include/safe-ctype.h:146:9: note:
+  macro 'toupper' defined here
+    146 | #define toupper(c) do_not_use_toupper_with_safe_ctype
+        |         ^
+
+This is because libc++ uses different transitive includes than
+libstdc++, and some of those transitive includes pull in various ctype
+declarations (typically via <locale>).
+
+There was already a special case for including <string> before
+safe-ctype.h, so move the rest of the C++ standard header includes to
+the same location, to fix the problem.
+
+gcc/ChangeLog:
+
+	* system.h: Include safe-ctype.h after C++ standard headers.
+
+Signed-off-by: Dimitry Andric <dimitry@andric.com>
+---
+ gcc/system.h | 39 ++++++++++++++++++---------------------
+ 1 file changed, 18 insertions(+), 21 deletions(-)
+
+diff --git a/gcc/system.h b/gcc/system.h
+index b0edab02885..ab29fc19776 100644
+--- a/gcc/system.h
++++ b/gcc/system.h
+@@ -194,27 +194,8 @@ extern int fprintf_unlocked (FILE *, const char *, ...);
+ #undef fread_unlocked
+ #undef fwrite_unlocked
+ 
+-/* Include <string> before "safe-ctype.h" to avoid GCC poisoning
+-   the ctype macros through safe-ctype.h */
+-
+-#ifdef __cplusplus
+-#ifdef INCLUDE_STRING
+-# include <string>
+-#endif
+-#endif
+-
+-/* There are an extraordinary number of issues with <ctype.h>.
+-   The last straw is that it varies with the locale.  Use libiberty's
+-   replacement instead.  */
+-#include "safe-ctype.h"
+-
+-#include <sys/types.h>
+-
+-#include <errno.h>
+-
+-#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
+-extern int errno;
+-#endif
++/* Include C++ standard headers before "safe-ctype.h" to avoid GCC
++   poisoning the ctype macros through safe-ctype.h */
+ 
+ #ifdef __cplusplus
+ #if defined (INCLUDE_ALGORITHM) || !defined (HAVE_SWAP_IN_UTILITY)
+@@ -229,6 +210,9 @@ extern int errno;
+ #ifdef INCLUDE_SET
+ # include <set>
+ #endif
++#ifdef INCLUDE_STRING
++# include <string>
++#endif
+ #ifdef INCLUDE_VECTOR
+ # include <vector>
+ #endif
+@@ -245,6 +229,19 @@ extern int errno;
+ # include <type_traits>
+ #endif
+ 
++/* There are an extraordinary number of issues with <ctype.h>.
++   The last straw is that it varies with the locale.  Use libiberty's
++   replacement instead.  */
++#include "safe-ctype.h"
++
++#include <sys/types.h>
++
++#include <errno.h>
++
++#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
++extern int errno;
++#endif
++
+ /* Some of glibc's string inlines cause warnings.  Plus we'd rather
+    rely on (and therefore test) GCC's string builtins.  */
+ #define __NO_STRING_INLINES
+-- 
+2.39.3
+

--- a/toolchain/gcc/patches-13.x/021-libcc1-fix-vector-include.patch
+++ b/toolchain/gcc/patches-13.x/021-libcc1-fix-vector-include.patch
@@ -1,0 +1,65 @@
+From 5213047b1d50af63dfabb5e5649821a6cb157e33 Mon Sep 17 00:00:00 2001
+From: Francois-Xavier Coudert <fxcoudert@gcc.gnu.org>
+Date: Sat, 16 Mar 2024 09:50:00 +0100
+Subject: [PATCH] libcc1: fix <vector> include
+
+Use INCLUDE_VECTOR before including system.h, instead of directly
+including <vector>, to avoid running into poisoned identifiers.
+
+Signed-off-by: Dimitry Andric <dimitry@andric.com>
+
+libcc1/ChangeLog:
+
+	PR middle-end/111632
+	* libcc1plugin.cc: Fix include.
+	* libcp1plugin.cc: Fix include.
+---
+ libcc1/libcc1plugin.cc | 3 +--
+ libcc1/libcp1plugin.cc | 3 +--
+ 2 files changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/libcc1/libcc1plugin.cc b/libcc1/libcc1plugin.cc
+index 72d17c3b81c..e64847466f4 100644
+--- a/libcc1/libcc1plugin.cc
++++ b/libcc1/libcc1plugin.cc
+@@ -32,6 +32,7 @@
+ #undef PACKAGE_VERSION
+ 
+ #define INCLUDE_MEMORY
++#define INCLUDE_VECTOR
+ #include "gcc-plugin.h"
+ #include "system.h"
+ #include "coretypes.h"
+@@ -69,8 +70,6 @@
+ #include "gcc-c-interface.h"
+ #include "context.hh"
+ 
+-#include <vector>
+-
+ using namespace cc1_plugin;
+ 
+ 
+diff --git a/libcc1/libcp1plugin.cc b/libcc1/libcp1plugin.cc
+index 0eff7c68d29..da68c5d0ac1 100644
+--- a/libcc1/libcp1plugin.cc
++++ b/libcc1/libcp1plugin.cc
+@@ -33,6 +33,7 @@
+ #undef PACKAGE_VERSION
+ 
+ #define INCLUDE_MEMORY
++#define INCLUDE_VECTOR
+ #include "gcc-plugin.h"
+ #include "system.h"
+ #include "coretypes.h"
+@@ -71,8 +72,6 @@
+ #include "rpc.hh"
+ #include "context.hh"
+ 
+-#include <vector>
+-
+ using namespace cc1_plugin;
+ 
+ 
+-- 
+2.39.3
+


### PR DESCRIPTION
``` bash
make toolchain/gcc/initial/{clean,compile} V=s
make toolchain/gcc/final/{clean,compile} V=s
```

```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__locale:550:5: error: '__abi_tag__' attribute only applies to structs, variables, functions, and namespaces
    _LIBCPP_INLINE_VISIBILITY
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__config:891:37: note: expanded from macro '_LIBCPP_INLINE_VISIBILITY'
#  define _LIBCPP_INLINE_VISIBILITY _LIBCPP_HIDE_FROM_ABI
                                    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__config:870:26: note: expanded from macro '_LIBCPP_HIDE_FROM_ABI'
          __attribute__((__abi_tag__(_LIBCPP_TOSTRING(_LIBCPP_ODR_SIGNATURE))))
```

Fixed using backport of upstream commits [1-2] as discussed here
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111632#c21

[1] Include safe-ctype.h after C++ standard headers, to avoid over-poisoning
https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=9970b576b7e4ae337af1268395ff221348c4b34a

[2] libcc1: fix <vector> include
https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=5213047b1d50af63dfabb5e5649821a6cb157e33

Tested `gcc-11`, `gcc-12` and `gcc-13` on the following architectures: `x64`, `WRT3200ACM`, `TL-WR1043N/ND v4`.

Complete build logs
https://httpstorm.com/share/.openwrt/test/2024-03-12_xcode-15.3/x64.2024-03-17.12-gcc-initial-xcode-15.3.txt
https://httpstorm.com/share/.openwrt/test/2024-03-12_xcode-15.3/x64.2024-03-17.14-gcc-final-xcode-15.3.txt

@PolynomialDivision @hauke @Ansuel @guidosarducci @mpratt14 @nbd168