### PR TITLE
filogic: add support for Qihoo 360T7 with 108M ubi

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-qihoo-360t7-108m.dts
+++ b/target/linux/mediatek/dts/mt7981b-qihoo-360t7-108m.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include "mt7981b-qihoo-360t7.dts"
+
+/ {
+	model = "Qihoo 360T7 (with 108M ubi)";
+	compatible = "qihoo,360t7-108m", "mediatek,mt7981";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -20,6 +20,7 @@ mediatek_setup_interfaces()
 	cudy,wr3000-v1|\
 	jcg,q30-pro|\
 	qihoo,360t7|\
+	qihoo,360t7-108m|\
 	routerich,ax3000)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
 		;;
@@ -148,7 +149,8 @@ mediatek_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii u-boot-env mac)
 		label_mac=$lan_mac
 		;;
-	qihoo,360t7)
+	qihoo,360t7|\
+	qihoo,360t7-108m)
 		lan_mac=$(mtd_get_mac_ascii factory lanMac)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		label_mac=$wan_mac

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -112,7 +112,8 @@ case "$board" in
 	openembed,som7981)
 		[ "$PHYNBR" = "1" ] && cat /sys/class/net/eth0/address > /sys${DEVPATH}/macaddress
 		;;
-	qihoo,360t7)
+	qihoo,360t7|\
+	qihoo,360t7-108m)
 		addr=$(mtd_get_mac_ascii factory lanMac)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -132,6 +132,7 @@ platform_do_upgrade() {
 	mediatek,mt7981-rfb|\
 	netcore,n60|\
 	qihoo,360t7|\
+	qihoo,360t7-108m|\
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -904,6 +904,27 @@ define Device/qihoo_360t7
 endef
 TARGET_DEVICES += qihoo_360t7
 
+define Device/qihoo_360t7-108m
+  DEVICE_VENDOR := Qihoo
+  DEVICE_MODEL := 360T7 (with 108M ubi)
+  DEVICE_DTS := mt7981b-qihoo-360t7-108m
+  DEVICE_DTS_DIR := ../dts
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 110592k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+    KERNEL = kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  DEVICE_PACKAGES := kmod-mt7981-firmware mt7981-wo-firmware
+  KERNEL_INITRAMFS = kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+endef
+TARGET_DEVICES += qihoo_360t7-108m
+
 define Device/routerich_ax3000
   DEVICE_VENDOR := Routerich
   DEVICE_MODEL := AX3000


### PR DESCRIPTION
A lot of Qihoo 360T7 users are using a custom u-boot layout from @hanwckf and his repos with an old base openwrt 21.02 and proprietary Mediatek wireless drivers. 
Switching to Openwrt u-boot is quite difficult and pointless in this case so we can just build images with already set ubi size. 
This allows easy switching between versions with different wireless drivers (mt76 and mtwifi).

Build system: x86/64
Build-tested: x86/64
Run-tested: filogic/qihoo_360t7-108m (both stable and testing kernel versions)