### PR TITLE
ramips: add support for TP-Link Archer MR200v5

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_archer-mr200-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-mr200-v5.dts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tplink,archer-mr200-v5", "mediatek,mt7628an-soc";
+	model = "TP-Link Archer MR200 v5";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
+	};
+	
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		signal1 {
+			label = "white:signal1";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		signal2 {
+			label = "white:signal2";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		signal3 {
+			label = "white:signal3";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};	
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <104000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x20000 0x7b0000>;
+			};
+
+			partition@7d0000 {
+				label = "config";
+				reg = <0x7d0000 0x10000>;
+				read-only;
+			};
+
+			partition@7e0000 {
+				label = "romfile";
+				reg = <0x7e0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_romfile_f100: macaddr@f100 {
+						compatible = "mac-base";
+						reg = <0xf100 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@7f0000 {
+				label = "radio";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_radio_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_radio_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "p0led_an", "p1led_an", "p2led_an", "p3led_an", "p4led_an", "uart1", "wdt";
+		function = "gpio";
+	};
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_romfile_f100 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	status = "okay";
+};
+
+&esw {
+	mediatek,portdisable = <0x30>;
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_romfile_f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_romfile_f100 (-1)>;
+		nvmem-cell-names = "eeprom", "mac-address";
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -606,6 +606,21 @@ define Device/tplink_archer-c50-v6
 endef
 TARGET_DEVICES += tplink_archer-c50-v6
 
+define Device/tplink_archer-mr200-v5
+  $(Device/tplink-v2)
+  IMAGE_SIZE := 7872k
+  DEVICE_MODEL := Archer MR200
+  DEVICE_VARIANT := v5
+  TPLINK_FLASHLAYOUT := 8MLmtk
+  TPLINK_HWID := 0x20000005
+  TPLINK_HWREV := 0x5
+  TPLINK_HWREVADD := 0x5
+  DEVICE_PACKAGES := kmod-mt76x0e uqmi kmod-usb2 kmod-usb-serial-option
+  IMAGES := sysupgrade.bin tftp-recovery.bin
+  IMAGE/tftp-recovery.bin := pad-extra 128k | $$(IMAGE/factory.bin)
+endef
+TARGET_DEVICES += tplink_archer-mr200-v5
+
 define Device/tplink_re200-v2
   $(Device/tplink-safeloader)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -83,6 +83,10 @@ tplink,archer-c50-v6)
 	ucidef_set_led_wlan "wlan2g" "wlan2g" "green:wlan2g" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "wlan5g" "green:wlan5g" "phy1tpt"
 	;;
+tplink,archer-mr200-v5)
+	ucidef_set_led_netdev "lan" "lan" "white:lan" "eth0"
+	ucidef_set_led_netdev "wan" "wan" "white:wan" "wwan0"
+	;;
 tplink,re200-v2|\
 tplink,re200-v3|\
 tplink,re200-v4|\

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -153,6 +153,11 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
 		;;
+	tplink,archer-mr200-v5)
+		ucidef_add_switch "switch0" \
+			"0:lan" "1:lan" "2:lan" "3:lan" "6t@eth0"
+		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
+		;;
 	tplink,tl-mr3020-v3)
 		ucidef_add_switch "switch0" \
 			"0:lan" "6@eth0"


### PR DESCRIPTION
Specifications:
	
```
CPU:     MT7628AN 580MHZ
RAM:     64MB DDR2
FLASH:   8MB EN25QH64 NOR SPI
WIFI:    2.4GHz 2x2 MT7628 b/g/n internal
WIFI:    5GHz 1x1 MT7610E ac/n PCI
LTE:     Qualcomm MDM9207
ETH:     4xLAN 100base-T integrated
SWITCH:  RT3050-ESW Port 0,1,2,3: LAN, Port 6: CPU
LEDS:    LAN, WAN, Power, 3x signal strength, WiFi
BTNS:    Reset, WiFi toggle
UART:    Near ETH ports, Vcc-GND-RX-TX, 115200, 8N1
```

Installation:

```
1. Update using recovery mode 

 - set your IP to 192.168.0.225, subnet mask: 255.255.255.0 
 - start tftp server, rename tftp-recovery.bin to tp_recovery.bin and place it into the server's directory 
 - while holdig "reset" button, power on the device 
 - keep holding "reset" until the file is being transferred
```

Notes:

```
This board has only one MAC address programmed in the "romfile" partition:

- MAC for phy0 (2.4GHz) at romfile 0xf100 (0)
- MAC for phy1 (5GHz) at romfile 0xf100 (-1)
- stock firmware re-uses phy0 MAC for ethernet
- stock firmware uses romfile 0xf100 (1) for WWAN; not used since QMI interface is raw IP
```

A lot of thanks to the OpenWrt forum for providing important and necessary help, especially gurangax, mrhaav & AndrewZ.

---

Some nitpicks where I wasn't exactly sure what is correct:

1. According to the flash's datasheet the maximum frequency for FAST_READ is 104MHz which I've used in the .dts. Does MT7628AN support this? I unfortunately couldn't figure this out on my own :(
2. I wasn't able to set the MAC for WWAN; is it correct that it's not relevant for a modem in raw IP mode?