### PR TITLE
bcm27xx: refresh backport patches

### DIFF
--- a/target/linux/bcm27xx/patches-6.1/950-0286-phy-broadcom-split-out-the-BCM54213PE-from-the-BCM54.patch
+++ b/target/linux/bcm27xx/patches-6.1/950-0286-phy-broadcom-split-out-the-BCM54213PE-from-the-BCM54.patch
@@ -49,7 +49,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
  	.phy_id		= PHY_ID_BCM5461,
  	.phy_id_mask	= 0xfffffff0,
  	.name		= "Broadcom BCM5461",
-@@ -1156,7 +1164,8 @@ module_phy_driver(broadcom_drivers);
+@@ -1158,7 +1166,8 @@ module_phy_driver(broadcom_drivers);
  static struct mdio_device_id __maybe_unused broadcom_tbl[] = {
  	{ PHY_ID_BCM5411, 0xfffffff0 },
  	{ PHY_ID_BCM5421, 0xfffffff0 },


### PR DESCRIPTION
bcm27xx: refresh backport patches

Refresh backport patches for kernel 6.1.82 with make target/linux/refresh.

