### PR TITLE
mediatek: filogic: add support for ASUS RT-AX57GO

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -374,6 +374,20 @@ endef
 
 $(eval $(call KernelPackage,phy-smsc))
 
+define KernelPackage/phy-airoha-en8801sc
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Airoha EN8801SC Ethernet PHY
+  KCONFIG:=CONFIG_AIROHA_EN8801SC_PHY
+  FILES:= \
+   $(LINUX_DIR)/drivers/net/phy/en8801sc.ko
+  AUTOLOAD:=$(call AutoLoad,18,en8801sc,1)
+endef
+
+define KernelPackage/phy-airoha-en8801sc/description
+  Kernel modules for Airoha EN8801SC Ethernet PHY
+endef
+
+$(eval $(call KernelPackage,phy-airoha-en8801sc))
 
 define KernelPackage/phy-airoha-en8811h
   SUBMENU:=$(NETWORK_DEVICES_MENU)

--- a/target/linux/generic/pending-6.1/798-net-phy-airoha-Add-the-Airoha-en8801sc-PHY-driver.patch
+++ b/target/linux/generic/pending-6.1/798-net-phy-airoha-Add-the-Airoha-en8801sc-PHY-driver.patch
@@ -1,0 +1,642 @@
+--- a/drivers/net/phy/Kconfig
++++ b/drivers/net/phy/Kconfig
+@@ -148,6 +148,11 @@ config AIR_EN8811H_PHY
+ 	help
+ 	  Currently supports the Airoha EN8811H PHY.
+ 
++config AIROHA_EN8801SC_PHY
++	tristate "Drivers for Airoha EN8801S Gigabit PHYs for MediaTek SoC."
++	help
++	  Currently supports the Airoha EN8801S PHY for MediaTek SoC.
++
+ config AMD_PHY
+ 	tristate "AMD and Altima PHYs"
+ 	help
+--- a/drivers/net/phy/Makefile
++++ b/drivers/net/phy/Makefile
+@@ -48,6 +48,7 @@ obj-y				+= $(sfp-obj-y) $(sfp-obj-m)
+ obj-$(CONFIG_ADIN_PHY)		+= adin.o
+ obj-$(CONFIG_ADIN1100_PHY)	+= adin1100.o
+ obj-$(CONFIG_AIR_EN8811H_PHY)   += air_en8811h.o
++obj-$(CONFIG_AIROHA_EN8801SC_PHY)      += en8801sc.o
+ obj-$(CONFIG_AMD_PHY)		+= amd.o
+ obj-$(CONFIG_AQUANTIA_PHY)	+= aquantia/
+ obj-$(CONFIG_AX88796B_PHY)	+= ax88796b.o
+--- /dev/null
++++ b/drivers/net/phy/en8801sc.c
+@@ -0,0 +1,454 @@
++// SPDX-License-Identifier: GPL-2.0
++/* FILE NAME:  en8801sc.c
++ * PURPOSE:
++ *      EN8801S phy driver for Linux
++ * NOTES:
++ *
++ */
++
++/* INCLUDE FILE DECLARATIONS
++ */
++
++#include <linux/kernel.h>
++#include <linux/string.h>
++#include <linux/errno.h>
++#include <linux/unistd.h>
++#include <linux/interrupt.h>
++#include <linux/init.h>
++#include <linux/delay.h>
++#include <linux/netdevice.h>
++#include <linux/etherdevice.h>
++#include <linux/skbuff.h>
++#include <linux/spinlock.h>
++#include <linux/mm.h>
++#include <linux/module.h>
++#include <linux/mii.h>
++#include <linux/ethtool.h>
++#include <linux/phy.h>
++#include <linux/delay.h>
++
++#include <linux/uaccess.h>
++#include <linux/version.h>
++
++#include "en8801sc.h"
++
++MODULE_DESCRIPTION("Airoha EN8801S PHY drivers for MT7981 SoC");
++MODULE_AUTHOR("Airoha");
++MODULE_LICENSE("GPL");
++
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
++#define phydev_mdio_bus(dev) ((dev)->bus)
++#else
++#define phydev_mdio_bus(dev) ((dev)->mdio.bus)
++#endif
++
++enum {
++    PHY_STATE_DONE = 0,
++    PHY_STATE_INIT = 1,
++    PHY_STATE_PROCESS = 2,
++};
++
++static int preSpeed = 0;
++/************************************************************************
++*                  F U N C T I O N S
++************************************************************************/
++unsigned int airoha_cl45_write(struct mii_bus *bus, u32 port, u32 devad, u32 reg, u16 val)
++{
++    mdiobus_write(bus, port, MII_MMD_ACC_CTL_REG, devad);
++    mdiobus_write(bus, port, MII_MMD_ADDR_DATA_REG, reg);
++    mdiobus_write(bus, port, MII_MMD_ACC_CTL_REG, MMD_OP_MODE_DATA | devad);
++    mdiobus_write(bus, port, MII_MMD_ADDR_DATA_REG, val);
++    return 0;
++}
++
++unsigned int airoha_cl45_read(struct mii_bus *bus, u32 port, u32 devad, u32 reg, u32 *read_data)
++{
++    mdiobus_write(bus, port, MII_MMD_ACC_CTL_REG, devad);
++    mdiobus_write(bus, port, MII_MMD_ADDR_DATA_REG, reg);
++    mdiobus_write(bus, port, MII_MMD_ACC_CTL_REG, MMD_OP_MODE_DATA | devad);
++    *read_data = mdiobus_read(bus, port, MII_MMD_ADDR_DATA_REG);
++    return 0;
++}
++
++unsigned int airoha_cl22_read(struct mii_bus *ebus, unsigned int phy_addr,unsigned int phy_register,unsigned int *read_data)
++{
++    *read_data = mdiobus_read(ebus, phy_addr, phy_register);
++    return 0;
++}
++
++unsigned int airoha_cl22_write(struct mii_bus *ebus, unsigned int phy_addr, unsigned int phy_register,unsigned int write_data)
++{
++    mdiobus_write(ebus, phy_addr, phy_register, write_data);
++    return 0;
++}
++
++void airoha_pbus_write(struct mii_bus *ebus, unsigned long pbus_id, unsigned long pbus_address, unsigned long pbus_data)
++{
++    airoha_cl22_write(ebus, pbus_id, 0x1F, (unsigned int)(pbus_address >> 6));
++    airoha_cl22_write(ebus, pbus_id, (unsigned int)((pbus_address >> 2) & 0xf), (unsigned int)(pbus_data & 0xFFFF));
++    airoha_cl22_write(ebus, pbus_id, 0x10, (unsigned int)(pbus_data >> 16));
++    return;
++}
++
++unsigned long airoha_pbus_read(struct mii_bus *ebus, unsigned long pbus_id, unsigned long pbus_address)
++{
++    unsigned long pbus_data;
++    unsigned int pbus_data_low, pbus_data_high;
++
++    airoha_cl22_write(ebus, pbus_id, 0x1F, (unsigned int)(pbus_address >> 6));
++    airoha_cl22_read(ebus, pbus_id, (unsigned int)((pbus_address >> 2) & 0xf), &pbus_data_low);
++    airoha_cl22_read(ebus, pbus_id, 0x10, &pbus_data_high);
++    pbus_data = (pbus_data_high << 16) + pbus_data_low;
++    return pbus_data;
++}
++
++/* Airoha Token Ring Write function */
++void airoha_tr_reg_write(struct mii_bus *ebus, unsigned long tr_address, unsigned long tr_data)
++{
++    airoha_cl22_write(ebus, EN8801S_MDIO_PHY_ID, 0x1F, 0x52b5);       /* page select */
++    airoha_cl22_write(ebus, EN8801S_MDIO_PHY_ID, 0x11, (unsigned int)(tr_data & 0xffff));
++    airoha_cl22_write(ebus, EN8801S_MDIO_PHY_ID, 0x12, (unsigned int)(tr_data >> 16));
++    airoha_cl22_write(ebus, EN8801S_MDIO_PHY_ID, 0x10, (unsigned int)(tr_address | TrReg_WR));
++    airoha_cl22_write(ebus, EN8801S_MDIO_PHY_ID, 0x1F, 0x0);          /* page resetore */
++    return;
++}
++
++/* Airoha Token Ring Read function */
++unsigned long airoha_tr_reg_read(struct mii_bus *ebus, unsigned long tr_address)
++{
++    unsigned long tr_data;
++    unsigned int tr_data_low, tr_data_high;
++
++    airoha_cl22_write(ebus, EN8801S_MDIO_PHY_ID, 0x1F, 0x52b5);       /* page select */
++    airoha_cl22_write(ebus, EN8801S_MDIO_PHY_ID, 0x10, (unsigned int)(tr_address | TrReg_RD));
++    airoha_cl22_read(ebus, EN8801S_MDIO_PHY_ID, 0x11, &tr_data_low);
++    airoha_cl22_read(ebus, EN8801S_MDIO_PHY_ID, 0x12, &tr_data_high);
++    airoha_cl22_write(ebus, EN8801S_MDIO_PHY_ID, 0x1F, 0x0);          /* page resetore */
++    tr_data = (tr_data_high << 16) + tr_data_low;
++    return tr_data;
++}
++
++void en8801s_led_init(struct mii_bus *mbus)
++{
++    u32 reg_value;
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x186c, 0x3);
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0X1870, 0x100);
++    reg_value = (airoha_pbus_read(mbus, EN8801S_PBUS_PHY_ID, 0x1880) & ~(0x3));
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x1880, reg_value);
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1f, 0x21, 0x8008);
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1f, 0x22, 0x600);
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1f, 0x23, 0xc00);
++    /* LED0: 10M/100M */
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1f, 0x24, 0x8006);
++    /* LED0: blink 10M/100M Tx/Rx */
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1f, 0x25, 0x3c);
++    /* LED1: 1000M */
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1f, 0x26, 0x8001);
++    /* LED1: blink 1000M Tx/Rx */
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1f, 0x27, 0x3);
++}
++
++static int en8801s_phy_process(struct phy_device *phydev)
++{
++    struct mii_bus *mbus = phydev_mdio_bus(phydev);
++    u32 reg_value = 0;
++
++    reg_value = airoha_pbus_read(mbus, EN8801S_PBUS_PHY_ID, 0x19e0);
++    reg_value |= (1 << 0);
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x19e0, reg_value);
++    reg_value = airoha_pbus_read(mbus, EN8801S_PBUS_PHY_ID, 0x19e0);
++    reg_value &= ~(1 << 0);
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x19e0, reg_value);
++    return 0;
++}
++
++static int en8801s_phase1_init(struct phy_device *phydev)
++{
++    unsigned long pbus_data;
++    unsigned int pbusAddress;
++    u32 reg_value;
++    int retry;
++    struct mii_bus *mbus = phydev_mdio_bus(phydev);
++
++    msleep(1500);
++
++    pbusAddress = EN8801S_PBUS_DEFAULT_ID;
++    retry = MAX_OUI_CHECK;
++    while(1)
++    {
++        pbus_data = airoha_pbus_read(mbus, pbusAddress, EN8801S_RG_ETHER_PHY_OUI);      /* PHY OUI */
++        if(EN8801S_PBUS_OUI == pbus_data)
++        {
++            pbus_data = airoha_pbus_read(mbus, pbusAddress, EN8801S_RG_SMI_ADDR);       /* SMI ADDR */
++            pbus_data = (pbus_data & 0xffff0000) | (unsigned long)(EN8801S_PBUS_PHY_ID << 8) | (unsigned long)(EN8801S_MDIO_PHY_ID );
++            printk("[Airoha] EN8801S SMI_ADDR=%lx (renew)\n", pbus_data);
++            airoha_pbus_write(mbus, pbusAddress, EN8801S_RG_SMI_ADDR, pbus_data);
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, EN8801S_RG_BUCK_CTL, 0x03);
++            mdelay(10);
++            break;
++        }
++        else
++        {
++            pbusAddress = EN8801S_PBUS_PHY_ID;
++        }
++        retry --;
++        if (0 == retry)
++        {
++            printk("[Airoha] EN8801S probe fail !\n");
++            return 0;
++        }
++    }
++
++    reg_value = (airoha_pbus_read(mbus, EN8801S_PBUS_PHY_ID, EN8801S_RG_LTR_CTL) & 0xfffffffc) | 0x10 | (EN8801S_RX_POLARITY << 1) | EN8801S_TX_POLARITY;
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, EN8801S_RG_LTR_CTL, reg_value);
++    mdelay(10);
++    reg_value &= 0xffffffef;
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, EN8801S_RG_LTR_CTL, reg_value);
++
++    retry = MAX_RETRY;
++    while (1)
++    {
++        mdelay(10);
++        reg_value = phy_read(phydev, MII_PHYSID2);
++        if (reg_value == EN8801S_PHY_ID2)
++        {
++            break;    /* wait GPHY ready */
++        }
++        retry--;
++        if (0 == retry)
++        {
++            printk("[Airoha] EN8801S initialize fail !\n");
++            return 0;
++        }
++    }
++    /* Software Reset PHY */
++    reg_value = phy_read(phydev, MII_BMCR);
++    reg_value |= BMCR_RESET;
++    phy_write(phydev, MII_BMCR, reg_value);
++    retry = MAX_RETRY;
++    do
++    {
++        mdelay(10);
++        reg_value = phy_read(phydev, MII_BMCR);
++        retry--;
++        if (0 == retry)
++        {
++            printk("[Airoha] EN8801S reset fail !\n");
++            return 0;
++        }
++    } while (reg_value & BMCR_RESET);
++
++    printk("[Airoha] EN8801S Phase1 initialize OK ! (%s)\n", EN8801S_DRIVER_VERSION);
++    return 0;
++}
++
++static int en8801s_phase2_init(struct phy_device *phydev)
++{
++    gephy_all_REG_LpiReg1Ch      GPHY_RG_LPI_1C;
++    gephy_all_REG_dev1Eh_reg324h GPHY_RG_1E_324;
++    gephy_all_REG_dev1Eh_reg012h GPHY_RG_1E_012;
++    gephy_all_REG_dev1Eh_reg017h GPHY_RG_1E_017;
++    unsigned long pbus_data;
++    u32 reg_value;
++    int retry;
++    struct mii_bus *mbus = phydev_mdio_bus(phydev);
++
++    reg_value = (airoha_pbus_read(mbus, EN8801S_PBUS_PHY_ID, EN8801S_RG_LTR_CTL) & 0xfffffffc) | 0x10 | (EN8801S_RX_POLARITY << 1) | EN8801S_TX_POLARITY;
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, EN8801S_RG_LTR_CTL, reg_value);
++    mdelay(10);
++    reg_value &= 0xffffffef;
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, EN8801S_RG_LTR_CTL, reg_value);
++
++    pbus_data = airoha_pbus_read(mbus, EN8801S_PBUS_PHY_ID, 0x1690);
++    pbus_data |= (1 << 31);
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x1690, pbus_data);
++
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x0600, 0x0c000c00);
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x10, 0xD801);
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x0,  0x9140);
++
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x0A14, 0x0003);
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x0600, 0x0c000c00);
++    /* Set FCM control */
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x1404, 0x004b);
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x140c, 0x0007);
++
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x142c, 0x05050505);
++    /* Set GPHY Perfomance*/
++    /* Token Ring */
++    airoha_tr_reg_write(mbus, RgAddr_PMA_01h,     0x6FB90A);
++    airoha_tr_reg_write(mbus, RgAddr_PMA_18h,     0x0E2F00);
++    airoha_tr_reg_write(mbus, RgAddr_DSPF_06h,    0x2EBAEF);
++    airoha_tr_reg_write(mbus, RgAddr_DSPF_11h,    0x040001);
++    airoha_tr_reg_write(mbus, RgAddr_DSPF_03h,    0x000004);
++    airoha_tr_reg_write(mbus, RgAddr_DSPF_1Ch,    0x003210);
++    airoha_tr_reg_write(mbus, RgAddr_DSPF_14h,    0x00024A);
++    airoha_tr_reg_write(mbus, RgAddr_DSPF_0Ch,    0x00704D);
++    airoha_tr_reg_write(mbus, RgAddr_DSPF_0Dh,    0x02314F);
++    airoha_tr_reg_write(mbus, RgAddr_DSPF_10h,    0x005010);
++    airoha_tr_reg_write(mbus, RgAddr_DSPF_0Fh,    0x003028);
++    airoha_tr_reg_write(mbus, RgAddr_TR_26h,      0x444444);
++    airoha_tr_reg_write(mbus, RgAddr_R1000DEC_15h,0x0055A0);
++    /* CL22 & CL45 */
++    phy_write(phydev, 0x1f, 0x03);
++    GPHY_RG_LPI_1C.DATA = phy_read(phydev, RgAddr_LpiReg1Ch);
++    GPHY_RG_LPI_1C.DataBitField.smi_deton_th = 0x0C;
++    phy_write(phydev, RgAddr_LpiReg1Ch, GPHY_RG_LPI_1C.DATA);
++    phy_write(phydev, 0x1f, 0x0);
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1E, 0x122, 0xffff);
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1E, 0x234, 0x0180);
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1E, 0x238, 0x0120);
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1E, 0x120, 0x9014);
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1E, 0x239, 0x0117);
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1E, 0x14A, 0xEE20);
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1E, 0x19B, 0x0111);
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1F, 0x268, 0x07F4);
++
++    airoha_cl45_read(mbus, EN8801S_MDIO_PHY_ID, 0x1E, 0x324, &reg_value);
++    GPHY_RG_1E_324.DATA=(u16)reg_value;
++    GPHY_RG_1E_324.DataBitField.smi_det_deglitch_off = 0;
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1E, 0x324, (u32)GPHY_RG_1E_324.DATA);
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1E, 0x19E, 0xC2);
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1E, 0x013, 0x0);
++
++    /* EFUSE */
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x1C08, 0x40000040);
++    retry = MAX_RETRY;
++    while (0 != retry)
++    {
++        mdelay(1);
++        reg_value = airoha_pbus_read(mbus, EN8801S_PBUS_PHY_ID, 0x1C08);
++        if ((reg_value & (1 << 30)) == 0)
++        {
++            break;
++        }
++        retry--;
++    }
++    reg_value = airoha_pbus_read(mbus, EN8801S_PBUS_PHY_ID, 0x1C38);          /* RAW#2 */
++    GPHY_RG_1E_012.DataBitField.da_tx_i2mpb_a_tbt = reg_value & 0x03f;
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1E, 0x12, (u32)GPHY_RG_1E_012.DATA);
++    GPHY_RG_1E_017.DataBitField.da_tx_i2mpb_b_tbt=(reg_value >> 8) & 0x03f;
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1E, 0x12, (u32)GPHY_RG_1E_017.DATA);
++
++    airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x1C08, 0x40400040);
++    retry = MAX_RETRY;
++    while (0 != retry)
++    {
++        mdelay(1);
++        reg_value = airoha_pbus_read(mbus, EN8801S_PBUS_PHY_ID, 0x1C08);
++        if ((reg_value & (1 << 30)) == 0)
++        {
++            break;
++        }
++        retry--;
++    }
++    reg_value = airoha_pbus_read(mbus, EN8801S_PBUS_PHY_ID, 0x1C30);          /* RAW#16 */
++    GPHY_RG_1E_324.DataBitField.smi_det_deglitch_off = (reg_value >> 12) & 0x01;
++    airoha_cl45_write(mbus, EN8801S_MDIO_PHY_ID, 0x1E, 0x324, (u32)GPHY_RG_1E_324.DATA);
++
++    en8801s_led_init(mbus);
++
++#if 1 // impedance matching fix for MT7981+EN8801 from Airoha
++    airoha_cl22_write(mbus, EN8801S_PBUS_PHY_ID, 0x1F, 0x30);
++    airoha_cl22_write(mbus, EN8801S_PBUS_PHY_ID, 0xA, 0x32);
++    airoha_cl22_write(mbus, EN8801S_PBUS_PHY_ID, 0x10, 0x418);
++#endif
++    printk("[Airoha] EN8801S Phase2 initialize OK !\n");
++    return 0;
++}
++
++static int en8801s_read_status(struct phy_device *phydev)
++{
++    int ret;
++    struct mii_bus *mbus = phydev_mdio_bus(phydev);
++    u32 reg_value;
++    static int phystate = PHY_STATE_INIT;
++
++    ret = genphy_read_status(phydev);
++    if (LINK_DOWN == phydev->link) preSpeed =0;
++
++    if (phystate == PHY_STATE_PROCESS) {
++        en8801s_phy_process(phydev);
++        phystate = PHY_STATE_DONE;
++    }
++
++    if ((preSpeed != phydev->speed) && (LINK_UP == phydev->link))
++    {
++        preSpeed = phydev->speed;
++
++        if (phystate == PHY_STATE_INIT) {
++            en8801s_phase2_init(phydev);
++            phystate = PHY_STATE_PROCESS;
++        }
++
++        if (preSpeed == SPEED_10) {
++            reg_value = airoha_pbus_read(mbus, EN8801S_PBUS_PHY_ID, 0x1694);
++            reg_value |= (1 << 31);
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x1694, reg_value);
++            phystate = PHY_STATE_PROCESS;
++        } else {
++            reg_value = airoha_pbus_read(mbus, EN8801S_PBUS_PHY_ID, 0x1694);
++            reg_value &= ~(1 << 31);
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x1694, reg_value);
++            phystate = PHY_STATE_PROCESS;
++        }
++
++        airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x0600, 0x0c000c00);
++        if (SPEED_1000 == preSpeed)
++        {
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x10, 0xD801);
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x0,  0x9140);
++
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x0A14, 0x0003);
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x0600, 0x0c000c00);
++            mdelay(2);      /* delay 2 ms */
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x1404, 0x004b);
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x140c, 0x0007);
++        }
++        else if (SPEED_100 == preSpeed)
++        {
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x10, 0xD401);
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x0,  0x9140);
++
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x0A14, 0x0007);
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x0600, 0x0c11);
++            mdelay(2);      /* delay 2 ms */
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x1404, 0x0027);
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x140c, 0x0007);
++        }
++        else if (SPEED_10 == preSpeed)
++        {
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x10, 0xD001);
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x0,  0x9140);
++
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x0A14, 0x000b);
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x0600, 0x0c11);
++            mdelay(2);      /* delay 2 ms */
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x1404, 0x0027);
++            airoha_pbus_write(mbus, EN8801S_PBUS_PHY_ID, 0x140c, 0x0007);
++        }
++    }
++    return ret;
++}
++
++static struct phy_driver Airoha_driver[] = {
++{
++    .phy_id         = EN8801S_PHY_ID,
++    .name           = "Airoha EN8801S",
++    .phy_id_mask    = 0x0ffffff0,
++    .features       = PHY_GBIT_FEATURES,
++    .config_init    = en8801s_phase1_init,
++    .config_aneg    = genphy_config_aneg,
++    .read_status    = en8801s_read_status,
++    .suspend        = genphy_suspend,
++    .resume         = genphy_resume,
++} };
++
++module_phy_driver(Airoha_driver);
++
++static struct mdio_device_id __maybe_unused Airoha_tbl[] = {
++    { EN8801S_PHY_ID, 0x0ffffff0 },
++    { }
++};
++
++MODULE_DEVICE_TABLE(mdio, Airoha_tbl);
+--- /dev/null
++++ b/drivers/net/phy/en8801sc.h
+@@ -0,0 +1,158 @@
++// SPDX-License-Identifier: GPL-2.0
++/* FILE NAME:  en8801sc.h
++ * PURPOSE:
++ *      Define EN8801S driver function
++ *
++ * NOTES:
++ *
++ */
++
++#ifndef __AIROHA_H
++#define __AIROHA_H
++
++/* NAMING DECLARATIONS
++ */
++#define EN8801S_DRIVER_VERSION  "1.0.0"
++
++#define PHY_ADDRESS_RANGE       0x18
++#define EN8801S_PBUS_DEFAULT_ID 0x1e
++#define EN8801S_MDIO_PHY_ID     0x18       /* Range PHY_ADDRESS_RANGE .. 0x1e */
++#define EN8801S_PBUS_PHY_ID     (EN8801S_MDIO_PHY_ID + 1)
++
++#define EN8801S_RG_ETHER_PHY_OUI 0x19a4
++#define EN8801S_RG_SMI_ADDR      0x19a8
++#define EN8801S_RG_BUCK_CTL      0x1a20
++#define EN8801S_RG_LTR_CTL      0x0cf8
++
++#define EN8801S_PBUS_OUI        0x17a5
++#define EN8801S_PHY_ID1         0x03a2
++#define EN8801S_PHY_ID2         0x9471
++#define EN8801S_PHY_ID          (unsigned long)((EN8801S_PHY_ID1 << 16) | EN8801S_PHY_ID2)
++
++#define DEV1E_REG013_VALUE      0
++#define DEV1E_REG19E_VALUE      0xC2
++#define DEV1E_REG324_VALUE      0x200
++
++#define TRUE                    1
++#define FALSE                   0
++#define LINK_UP                 1
++#define LINK_DOWN               0
++
++//#define TEST_BOARD
++#if defined(TEST_BOARD)
++/* SFP sample for verification */
++#define EN8801S_TX_POLARITY     1
++#define EN8801S_RX_POLARITY     0
++#else
++/* chip on board */
++#define EN8801S_TX_POLARITY     0
++#define EN8801S_RX_POLARITY     1       /* The pin default assignment is set to 1 */
++#endif
++
++#define MAX_RETRY               5
++#define MAX_OUI_CHECK           2
++/* CL45 MDIO control */
++#define MII_MMD_ACC_CTL_REG     0x0d
++#define MII_MMD_ADDR_DATA_REG   0x0e
++#define MMD_OP_MODE_DATA        BIT(14)
++
++#define MAX_TRG_COUNTER         5
++
++/* CL22 Reg Support Page Select */
++#define RgAddr_Reg1Fh        0x1f
++#define CL22_Page_Reg        0x0000
++#define CL22_Page_ExtReg     0x0001
++#define CL22_Page_MiscReg    0x0002
++#define CL22_Page_LpiReg     0x0003
++#define CL22_Page_tReg       0x02A3
++#define CL22_Page_TrReg      0x52B5
++
++/* CL45 Reg Support DEVID */
++#define DEVID_03             0x03
++#define DEVID_07             0x07
++#define DEVID_1E             0x1E
++#define DEVID_1F             0x1F
++
++/* TokenRing Reg Access */
++#define TrReg_PKT_XMT_STA    0x8000
++#define TrReg_WR             0x8000
++#define TrReg_RD             0xA000
++
++#define RgAddr_LpiReg1Ch     0x1c
++#define RgAddr_PMA_01h       0x0f82
++#define RgAddr_PMA_18h       0x0fb0
++#define RgAddr_DSPF_03h      0x1686
++#define RgAddr_DSPF_06h      0x168c
++#define RgAddr_DSPF_0Ch      0x1698
++#define RgAddr_DSPF_0Dh      0x169a
++#define RgAddr_DSPF_0Fh      0x169e
++#define RgAddr_DSPF_10h      0x16a0
++#define RgAddr_DSPF_11h      0x16a2
++#define RgAddr_DSPF_14h      0x16a8
++#define RgAddr_DSPF_1Ch      0x16b8
++#define RgAddr_TR_26h        0x0ecc
++#define RgAddr_R1000DEC_15h  0x03aa
++
++/* DATA TYPE DECLARATIONS
++ */
++typedef struct
++{
++    u16 DATA_Lo;
++    u16 DATA_Hi;
++}TR_DATA_T;
++
++typedef union
++{
++    struct
++    {
++        /* b[15:00] */
++        u16 smi_deton_wt                             : 3;
++        u16 smi_det_mdi_inv                          : 1;
++        u16 smi_detoff_wt                            : 3;
++        u16 smi_sigdet_debouncing_en                 : 1;
++        u16 smi_deton_th                             : 6;
++        u16 rsv_14                                   : 2;
++    } DataBitField;
++    u16 DATA;
++} gephy_all_REG_LpiReg1Ch, *Pgephy_all_REG_LpiReg1Ch;
++
++typedef union
++{
++    struct
++    {
++        /* b[15:00] */
++        u16 rg_smi_detcnt_max                        : 6;
++        u16 rsv_6                                    : 2;
++        u16 rg_smi_det_max_en                        : 1;
++        u16 smi_det_deglitch_off                     : 1;
++        u16 rsv_10                                   : 6;
++    } DataBitField;
++    u16 DATA;
++} gephy_all_REG_dev1Eh_reg324h, *Pgephy_all_REG_dev1Eh_reg324h;
++
++typedef union
++{
++    struct
++    {
++        /* b[15:00] */
++        u16 da_tx_i2mpb_a_tbt                        : 6;
++        u16 rsv_6                                    : 4;
++        u16 da_tx_i2mpb_a_gbe                        : 6;
++    } DataBitField;
++    u16 DATA;
++} gephy_all_REG_dev1Eh_reg012h, *Pgephy_all_REG_dev1Eh_reg012h;
++
++typedef union
++{
++    struct
++    {
++        /* b[15:00] */
++        u16 da_tx_i2mpb_b_tbt                        : 6;
++        u16 rsv_6                                    : 2;
++        u16 da_tx_i2mpb_b_gbe                        : 6;
++        u16 rsv_14                                   : 2;
++    } DataBitField;
++    u16 DATA;
++} gephy_all_REG_dev1Eh_reg017h, *Pgephy_all_REG_dev1Eh_reg017h;
++
++#endif /* End of __AIROHA_H */

--- a/target/linux/generic/pending-6.1/892-v6.1-mtd-spinand-winbond-add-W25N01KV.patch
+++ b/target/linux/generic/pending-6.1/892-v6.1-mtd-spinand-winbond-add-W25N01KV.patch
@@ -1,0 +1,90 @@
+--- a/drivers/mtd/nand/spi/winbond.c
++++ b/drivers/mtd/nand/spi/winbond.c
+@@ -15,6 +15,12 @@
+ 
+ #define WINBOND_CFG_BUF_READ		BIT(3)
+ 
++#define W25N01KV_STATUS_ECC_MASK		(3 << 4)
++#define W25N01KV_STATUS_ECC_NO_BITFLIPS		(0 << 4)
++#define W25N01KV_STATUS_ECC_1_3_BITFLIPS	(1 << 4)
++#define W25N01KV_STATUS_ECC_4_BITFLIPS		(3 << 4)
++#define W25N01KV_STATUS_ECC_UNCOR_ERROR		(2 << 4)
++
+ static SPINAND_OP_VARIANTS(read_cache_variants,
+ 		SPINAND_PAGE_READ_FROM_CACHE_QUADIO_OP(0, 2, NULL, 0),
+ 		SPINAND_PAGE_READ_FROM_CACHE_X4_OP(0, 1, NULL, 0),
+@@ -30,6 +36,58 @@ static SPINAND_OP_VARIANTS(write_cache_v
+ static SPINAND_OP_VARIANTS(update_cache_variants,
+ 		SPINAND_PROG_LOAD_X4(false, 0, NULL, 0),
+ 		SPINAND_PROG_LOAD(false, 0, NULL, 0));
++		
++static int w25n01kv_ecc_get_status(struct spinand_device *spinand,
++					u8 status)
++{
++	switch (status & W25N01KV_STATUS_ECC_MASK) {
++	case W25N01KV_STATUS_ECC_NO_BITFLIPS:
++		return 0;
++
++	case W25N01KV_STATUS_ECC_1_3_BITFLIPS:
++		return 3;
++
++	case W25N01KV_STATUS_ECC_4_BITFLIPS:
++		return 4;
++
++	case W25N01KV_STATUS_ECC_UNCOR_ERROR:
++		return -EBADMSG;
++
++	default:
++		break;
++	}
++
++	return -EINVAL;
++}
++
++static int w25n01kv_ooblayout_ecc(struct mtd_info *mtd, int section,
++				  struct mtd_oob_region *region)
++{
++	if (section > 3)
++		return -ERANGE;
++
++	region->offset = 64 + (8 * section);
++	region->length = 7;
++
++	return 0;
++}
++
++static int w25n01kv_ooblayout_free(struct mtd_info *mtd, int section,
++				   struct mtd_oob_region *region)
++{
++	if (section > 3)
++		return -ERANGE;
++
++	region->offset = (16 * section) + 2;
++	region->length = 14;
++
++	return 0;
++}
++
++static const struct mtd_ooblayout_ops w25n01kv_ooblayout = {
++	.ecc = w25n01kv_ooblayout_ecc,
++	.free = w25n01kv_ooblayout_free,
++};
+ 
+ static int w25m02gv_ooblayout_ecc(struct mtd_info *mtd, int section,
+ 				  struct mtd_oob_region *region)
+@@ -160,6 +218,15 @@ static const struct spinand_info winbond
+ 					      &update_cache_variants),
+ 		     0,
+ 		     SPINAND_ECCINFO(&w25m02gv_ooblayout, NULL)),
++	SPINAND_INFO("W25N01KV",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xae, 0x21),
++		     NAND_MEMORG(1, 2048, 96, 64, 1024, 20, 1, 1, 1),
++		     NAND_ECCREQ(4, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     0,
++		     SPINAND_ECCINFO(&w25n01kv_ooblayout, w25n01kv_ecc_get_status)),
+ 	SPINAND_INFO("W25N02KV",
+ 		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xaa, 0x22),
+ 		     NAND_MEMORG(1, 2048, 128, 64, 2048, 40, 1, 1, 1),

--- a/target/linux/mediatek/dts/mt7981b-asus_rt-ax57go.dts
+++ b/target/linux/mediatek/dts/mt7981b-asus_rt-ax57go.dts
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include "mt7981.dtsi"
+/ {
+	model = "RT-AX57GO";
+	compatible = "asus,rt-ax57go", "mediatek,mt7981";
+	
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-override = "ubi.mtd=UBI_DEV";
+	};
+
+	memory {
+		// fpga ddr2: 128MB*2
+		reg = <0 0x40000000 0 0x10000000>;
+	};
+
+	reserved-memory {
+		/* 24 KiB reserved for PWM[ch0,ch1,ch2] */
+		pwm_reserved: pwmbuf@4C7FA000 {
+			reg = <0 0x4C7FA000 0 0x6000>;
+			no-map;
+		};
+	};
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+	};
+
+	timer {
+		clock-frequency = <12996791>;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: led-1 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 2 GPIO_ACTIVE_LOW>;
+		};
+		
+		led_status_white: led-3 {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+        status = "okay";
+	/* lan */
+        gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "sgmii";
+		phy-handle = <&phy1>;
+	};
+	/* wan */
+	gmac1: mac@1 {
+                compatible = "mediatek,eth-mac";
+                reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&phy0>;
+        };
+
+        mdio: mdio-bus {
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                phy0: ethernet-phy@0 {
+			compatible = "ethernet-phy-id03a2.9461";
+			reg = <0>;
+			phy-mode = "gmii";
+			nvmem-cells = <&phy_calibration>;
+			nvmem-cell-names = "phy-cal-data";
+                };
+		phy1: ethernet-phy@1 {
+			compatible = "ethernet-phy-id03a2.9471";
+			reg = <24>;
+			reset-gpios = <&pio 39 1>;
+			reset-assert-us = <600>;
+			reset-deassert-us = <20000>;
+			phy-mode = "sgmii";
+		};
+        };
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+	spi_nand: spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x400000>;
+				read-only;
+			};
+
+			partition@400000 {
+				label = "UBI_DEV";
+				reg = <0x400000 0x7c00000>;
+			};
+
+		};
+	};
+};
+
+&spi1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spic_pins>;
+	status = "disabled";
+};
+
+&pio {
+
+	i2c_pins: i2c-pins-g0 {
+                mux {
+                        function = "i2c";
+                        groups = "i2c0_0";
+                };
+        };
+
+        pcm_pins: pcm-pins-g0 {
+                mux {
+                        function = "pcm";
+                        groups = "pcm";
+                };
+        };
+
+        pwm0_pin: pwm0-pin-g0 {
+                mux {
+                        function = "pwm";
+                        groups = "pwm0_0";  // GPIO 13
+                };
+        };
+
+        pwm1_pin: pwm1-pin-g1 {
+                mux {
+                        function = "pwm";
+                        groups = "pwm1_0";  // GPIO 14
+                };
+        };
+
+        pwm2_pin: pwm2-pin {
+                mux {
+                        function = "pwm";
+                        groups = "pwm2";   // GPIO 7
+                };
+        };
+
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+
+	spic_pins: spi1-pins {
+		mux {
+			function = "spi";
+			groups = "spi1_1";
+		};
+	};
+
+	uart1_pins: uart1-pins-g1 {
+                mux {
+                        function = "uart";
+                        groups = "uart1_1";
+                };
+        };
+
+	uart2_pins: uart2-pins-g1 {
+		mux {
+                        function = "uart";
+                        groups = "uart2_1";
+                };
+        };
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm0_pin &pwm1_pin &pwm2_pin>;
+	interrupts = <GIC_SPI 137 IRQ_TYPE_LEVEL_HIGH>;
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+};
+
+&xhci {
+	mediatek,u3p-dis-msk = <0x0>;
+	phys = <&u2port0 PHY_TYPE_USB2>,
+	       <&u3port0 PHY_TYPE_USB3>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -14,6 +14,9 @@ mediatek_setup_interfaces()
 	acer,predator-w6)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 game" eth1
 		;;
+	asus,rt-ax57go)
+		ucidef_set_interfaces_lan_wan eth0 eth1
+		;;
 	asus,rt-ax59u|\
 	cetron,ct3003|\
 	confiabits,mt7981|\
@@ -113,6 +116,12 @@ mediatek_setup_macs()
 	local label_mac=""
 
 	case $board in
+	asus,rt-ax57go)
+		CI_UBIPART="UBI_DEV"
+		addr=$(mtd_get_mac_binary_ubi "Factory" 0x4)
+		wan_mac="${addr}"
+		lan_mac="${addr}"
+		;;
 	bananapi,bpi-r3)
 		wan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -24,6 +24,10 @@ case "$FIRMWARE" in
 	;;
 "mediatek/mt7981_eeprom_mt7976_dbdc.bin")
 	case "$board" in
+	asus,rt-ax57go)
+		CI_UBIPART="UBI_DEV"
+		caldata_extract_ubi "Factory" 0x0 0x1000
+		;;
 	cmcc,rax3000m)
 		case "$(cmdline_get_var root)" in
 		/dev/mmc*)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -16,6 +16,7 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && cat $key_path/6gMAC > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "2" ] && cat $key_path/5gMAC > /sys${DEVPATH}/macaddress
 		;;
+	asus,rt-ax57go|\
 	asus,rt-ax59u)
 		CI_UBIPART="UBI_DEV"
 		addr=$(mtd_get_mac_binary_ubi "Factory" 0x4)

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -10,6 +10,7 @@ preinit_set_mac_address() {
 		ip link set dev game address "$(cat $key_path/LANMAC)"
 		ip link set dev eth1 address "$(cat $key_path/WANMAC)"
 		;;
+	asus,rt-ax57go|\
 	asus,tuf-ax4200|\
 	asus,tuf-ax6000)
 		CI_UBIPART="UBI_DEV"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -73,6 +73,7 @@ platform_do_upgrade() {
 		CI_ROOTPART="rootfs"
 		emmc_do_upgrade "$1"
 		;;
+	asus,rt-ax57go|\
 	asus,rt-ax59u|\
 	asus,tuf-ax4200|\
 	asus,tuf-ax6000)
@@ -248,6 +249,7 @@ platform_pre_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
+	asus,rt-ax57go|\
 	asus,rt-ax59u|\
 	asus,tuf-ax4200|\
 	asus,tuf-ax6000)

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -175,6 +175,22 @@ $(call Device/adtran_smartrg)
 endef
 TARGET_DEVICES += smartrg_sdg-8632
 
+define Device/asus_rt-ax57go
+  DEVICE_VENDOR := ASUS
+  DEVICE_MODEL := RT-AX57GO
+  DEVICE_DTS := mt7981b-asus_rt-ax57go
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x47000000
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-airoha-en8801sc
+  IMAGES := sysupgrade.bin
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += asus_rt-ax57go
+
 define Device/asus_rt-ax59u
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-AX59U

--- a/target/linux/mediatek/patches-6.1/965-net-ethernet-mtk_eth_soc-update-mtk_sgmiii_init.patch
+++ b/target/linux/mediatek/patches-6.1/965-net-ethernet-mtk_eth_soc-update-mtk_sgmiii_init.patch
@@ -1,0 +1,97 @@
+--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
++++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+@@ -4896,31 +4896,25 @@ void mtk_eth_set_dma_device(struct mtk_e
+ 	rtnl_unlock();
+ }
+ 
+-static int mtk_sgmii_init(struct mtk_eth *eth)
++int mtk_sgmii_init(struct mtk_xgmii *ss, struct device_node *r, u32 ana_rgc3)
+ {
+ 	struct device_node *np;
+-	struct regmap *regmap;
+-	u32 flags;
+ 	int i;
+ 
++	ss->ana_rgc3 = ana_rgc3;
++
+ 	for (i = 0; i < MTK_MAX_DEVS; i++) {
+-		np = of_parse_phandle(eth->dev->of_node, "mediatek,sgmiisys", i);
++		np = of_parse_phandle(r, "mediatek,sgmiisys", i);
+ 		if (!np)
+ 			break;
+ 
+-		regmap = syscon_node_to_regmap(np);
+-		flags = 0;
+-		if (of_property_read_bool(np, "mediatek,pnswap"))
+-			flags |= MTK_SGMII_FLAG_PN_SWAP;
+-
+-		of_node_put(np);
+-
+-		if (IS_ERR(regmap))
+-			return PTR_ERR(regmap);
+-
+-		eth->sgmii_pcs[i] = mtk_pcs_lynxi_create(eth->dev, regmap,
+-							 eth->soc->ana_rgc3,
+-							 flags);
++		ss->regmap_sgmii[i] = syscon_node_to_regmap(np);
++		if (IS_ERR(ss->regmap_sgmii[i]))
++			return PTR_ERR(ss->regmap_sgmii[i]);
++
++		ss->flags[i] &= ~(MTK_SGMII_PN_SWAP);
++		if (of_property_read_bool(np, "pn_swap"))
++			ss->flags[i] |= MTK_SGMII_PN_SWAP;
+ 	}
+ 
+ 	return 0;
+@@ -5015,7 +5009,14 @@ static int mtk_probe(struct platform_dev
+ 
+ 	if (MTK_HAS_CAPS(eth->soc->caps, MTK_SGMII) &&
+ 	    !mtk_is_netsys_v3_or_greater(eth)) {
+-		err = mtk_sgmii_init(eth);
++		eth->xgmii = devm_kzalloc(eth->dev, sizeof(*eth->xgmii),
++					  GFP_KERNEL);
++		if (!eth->xgmii)
++			return -ENOMEM;
++
++		eth->xgmii->eth = eth;
++		err = mtk_sgmii_init(eth->xgmii, pdev->dev.of_node,
++				     eth->soc->ana_rgc3);
+ 
+ 		if (err)
+ 			return err;
+--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.h
++++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.h
+@@ -90,6 +90,7 @@
+ #define MTK_FE_INT_TSO_FAIL	BIT(12)
+ #define MTK_FE_INT_TSO_ILLEGAL	BIT(13)
+ #define MTK_FE_INT_TSO_ALIGN	BIT(14)
++#define MTK_SGMII_PN_SWAP	       BIT(16)
+ #define MTK_FE_INT_RFIFO_OV	BIT(18)
+ #define MTK_FE_INT_RFIFO_UF	BIT(19)
+ #define MTK_GDM1_AF		BIT(28)
+@@ -1247,6 +1248,15 @@ struct mtk_soc_data {
+ /* currently no SoC has more than 3 macs */
+ #define MTK_MAX_DEVS	3
+ 
++struct mtk_xgmii {
++	struct mtk_eth	*eth;
++	struct regmap   *regmap_sgmii[MTK_MAX_DEVS];
++	struct regmap   *regmap_usxgmii[MTK_MAX_DEVS];
++	struct regmap   *regmap_pextp[MTK_MAX_DEVS];
++	struct regmap	*regmap_pll;
++	u32             flags[MTK_MAX_DEVS];
++	u32             ana_rgc3;
++};
+ /* struct mtk_eth -	This is the main datasructure for holding the state
+  *			of the driver
+  * @dev:		The device pointer
+@@ -1322,7 +1332,8 @@ struct mtk_eth {
+ 	dma_addr_t			phy_scratch_ring;
+ 	void				*scratch_head;
+ 	struct clk			*clks[MTK_CLK_MAX];
+-
++	
++	struct mtk_xgmii                *xgmii;
+ 	struct mii_bus			*mii_bus;
+ 	struct work_struct		pending_work;
+ 	unsigned long			state;


### PR DESCRIPTION
Hardware
-----------
SOC:   MediaTek MT7981b
RAM:   512MB DDR4
FLASH: 128MB SPI-NAND (Winbond W25N01KV)
WIFI:  Mediatek MT7981b DBDC 802.11ax 2.4/5 GHz
PHY:   Airoha en8801sc
UART:  3V3 115200 8N1 (Pinout silkscreened / Do not ocnnect VCC)
-----------

Patch Description
-----------------
1: 798-net-phy-airoha-Add-the-Airoha-en8801sc-PHY-driver.patch
   Add airoha en8801sc phy driver for RT-AX57GO
2: 892-v6.1-mtd-spinand-winbond-add-W25N01KV.patch
   support winbond W2N01KV for RT-AX7GO
3: 965-net-ethernet-mtk_eth_soc-update-mtk_sgmii_init.patch
   sync mtk_sgmii_int from sdk

Installation
----------------------------------------------------------- 
Install openwrt image:
1. Download the OpenWrt initramfs image.
    Copy the image to a TFTP server reachable at 192.168.1.70/24. 
    Rename the image to rtax57go.bin.

3. Connect the PC with TFTP server to the RT-AX57GO. 
    Set a static ip on the ethernet interface of your PC. (ip address: 192.168.1.70, subnet mask:255.255.255.0).
    Conect to the serial console, interrupt the autoboot process by pressing '4' when prompted.

5. Download & Boot the OpenWrt initramfs image.
   $ setenv ipaddr 192.168.1.1
   $ setenv serverip 192.168.1.70 
   $ tftpboot 0x46000000 rtax57go.bin 
   $ bootm 0x46000000

6. Wait for OpenWrt to boot. Transfer the sysupgrade image to the device using scp and install using sysupgrade.
   $ sysupgrade -n <path-to-sysupgrade.bin>