### PR TITLE
ipq40xx: whw03v2: enable the platform's common 5 GHz channel ranges

### DIFF
--- a/target/linux/ipq40xx/files-6.1/arch/arm/boot/dts/qcom-ipq4019-whw03v2.dts
+++ b/target/linux/ipq40xx/files-6.1/arch/arm/boot/dts/qcom-ipq4019-whw03v2.dts
@@ -487,7 +487,6 @@
 	qcom,coexist-support = <1>;
 	qcom,coexist-gpio-pin = <0x34>;
 
-	ieee80211-freq-limit = <2401000 2473000>;
 	qcom,ath10k-calibration-variant = "linksys-whw03v2";
 
 	nvmem-cell-names = "pre-calibration", "mac-address";
@@ -497,7 +496,7 @@
 &wifi1 {
 	status = "okay";
 
-	ieee80211-freq-limit = <5170000 5250000>;
+	ieee80211-freq-limit = <5170000 5330000>;
 	qcom,ath10k-calibration-variant = "linksys-whw03v2";
 
 	nvmem-cell-names = "pre-calibration", "mac-address";
@@ -507,7 +506,7 @@
 &wifi2 {
 	status = "okay";
 
-	ieee80211-freq-limit = <5735000 5835000>;
+	ieee80211-freq-limit = <5490000 5835000>;
 	qcom,ath10k-calibration-variant = "linksys-whw03v2";
 
 	nvmem-cell-names = "pre-calibration", "mac-address";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-whw03v2.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-whw03v2.dts
@@ -487,7 +487,6 @@
 	qcom,coexist-support = <1>;
 	qcom,coexist-gpio-pin = <0x34>;
 
-	ieee80211-freq-limit = <2401000 2473000>;
 	qcom,ath10k-calibration-variant = "linksys-whw03v2";
 
 	nvmem-cell-names = "pre-calibration", "mac-address";
@@ -497,7 +496,7 @@
 &wifi1 {
 	status = "okay";
 
-	ieee80211-freq-limit = <5170000 5250000>;
+	ieee80211-freq-limit = <5170000 5330000>;
 	qcom,ath10k-calibration-variant = "linksys-whw03v2";
 
 	nvmem-cell-names = "pre-calibration", "mac-address";
@@ -507,7 +506,7 @@
 &wifi2 {
 	status = "okay";
 
-	ieee80211-freq-limit = <5735000 5835000>;
+	ieee80211-freq-limit = <5490000 5835000>;
 	qcom,ath10k-calibration-variant = "linksys-whw03v2";
 
 	nvmem-cell-names = "pre-calibration", "mac-address";


### PR DESCRIPTION
@hauke,

Devices based on the same reference design, including WHW03 V1 (out of tree), all include these 5 GHz channel ranges:
- 36 ~ 64
- 100 ~ 165

However this WHW03 V2 port only includes these restricted ranges:
- 36 ~ **48**
- **149** ~ 165

This is probably because the DTS was extracted from a device taylor-made for a restrictive region, or from a device with firmware with no DFS support.

### Testing

i created a custom build and ran the WHW03 V2 as a wifi repeater. i ran two tests:

1. Baseline:
    I repeated an 80 MHz wifi in channels 149-161 (aka 80 MHz chan 155) into channels 36-48 (aka 80 MHz chan 42), then tested the resulting speed from station to base and back through the WHW03 V2 repeater to establish baseline performance.

2. Crossover test:
    I changed channels of both wifis and tested repeating from channels 100-112 (aka 80 MHz chan 106) into channels 52-64 (aka 80 MHz chan 58). The performance was same as baseline, proving that there is no crosstalk between both 5 GHz adapters working at their nearest frequencies, chans 64 and 100, and that said spacing is enough for the crossover filters to isolate the adapters (they share the antennas).

Discussion leading to this PR is here: https://github.com/openwrt/openwrt/issues/15048

Thanks to @testuser7 for the help.