### PR TITLE
wifi-scripts: fix creation of IBSS in legacy (non-HT) mode

### DIFF
--- a/package/network/config/wifi-scripts/files/usr/share/hostap/wdev.uc
+++ b/package/network/config/wifi-scripts/files/usr/share/hostap/wdev.uc
@@ -35,7 +35,7 @@ function iface_start(wdev)
 	if (wdev.freq)
 		system(`iw dev ${ifname} set freq ${wdev.freq} ${wdev.htmode}`);
 	if (wdev.mode == "adhoc") {
-		let cmd = ["iw", "dev", ifname, "ibss", "join", wdev.ssid, wdev.freq, wdev.htmode, "fixed-freq" ];
+		let cmd = ["iw", "dev", ifname, "ibss", "join", wdev.ssid, wdev.freq, wdev.htmode || "NOHT", "fixed-freq" ];
 		if (wdev.bssid)
 			push(cmd, wdev.bssid);
 		for (let key in [ "beacon-interval", "basic-rates", "mcast-rate", "keys" ])


### PR DESCRIPTION
When an IBBS interface is configured for IBSS legacy mode, wdev.htmode is empty. This is empty string results in an empty positional argument to the "ibbs join" command, for example:

    iw dev phy0-ibss0 ibss join crymesh 2412 '' fixed-freq beacon-interval 100

This empty argument is interpreted as an invalid HT mode by 'iw', causing the entire command to fail and print a "usage" message:

    daemon.notice netifd: radio0 (4527): Usage:    iw [options] \
        dev <devname> ibss join <SSID> <freq in MHz> ...

Although nobody will ever need more than 640K of IBSS, only add the HT mode to "ibss join" if one is given. This fixes the problem.

Fixes: e56c5f7b276a ("hostapd: add ucode support, use ucode for the main ubus object")
