### PR TITLE
kernel: build with KERNEL_WERROR by default

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1418,8 +1418,7 @@ config KERNEL_JFFS2_FS_SECURITY
 
 config KERNEL_WERROR
 	bool "Compile the kernel with warnings as errors"
-	default BUILDBOT
-	default y if GCC_USE_VERSION_12
+	default y
 	help
 	  A kernel build should not cause any compiler warnings, and this
 	  enables the '-Werror' (for C) and '-Dwarnings' (for Rust) flags


### PR DESCRIPTION
Instead of only enabling CONFIG_KERNEL_WERROR by default on the buildbots or specifically for GCC 12 (?), always enable it by default. Not doing that leads to build failures on the buildbot which went unnoticed by developer's local builds as well as CI, apparently.

Fixes: ce8c639a6c ("kernel: introduce KERNEL_WERROR config option")