### PR TITLE
Fix dd memory exhaustion and KERNEL_WERROR GCC version dependency

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1419,7 +1419,7 @@ config KERNEL_JFFS2_FS_SECURITY
 config KERNEL_WERROR
 	bool "Compile the kernel with warnings as errors"
 	default BUILDBOT
-	default y if GCC_USE_VERSION_12
+	default y if GCC_USE_VERSION_13
 	help
 	  A kernel build should not cause any compiler warnings, and this
 	  enables the '-Werror' (for C) and '-Dwarnings' (for Rust) flags

--- a/include/image.mk
+++ b/include/image.mk
@@ -163,7 +163,13 @@ DTC_FLAGS += $(DTC_WARN_FLAGS)
 DTCO_FLAGS += $(DTC_WARN_FLAGS)
 
 define Image/pad-to
-	dd if=$(1) of=$(1).new bs=$(2) conv=sync
+	if [ $(2) -gt 1048576 ]; then \
+		dd if=$(1) of=$(1).new \
+			bs=1048576 count=$(shell expr $(2) / 1048576) \
+			conv=sync ; \
+	else \
+		dd if=$(1) of=$(1).new bs=$(2) conv=sync  ; \
+	fi
 	mv $(1).new $(1)
 endef
 

--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -2,6 +2,7 @@
 
 choice
 	prompt "GCC compiler Version" if TOOLCHAINOPTS
+	# don't forget to adjust dependency for KERNEL_WERROR
 	default GCC_USE_VERSION_13
 	help
 	  Select the version of gcc you wish to use.


### PR DESCRIPTION
### config: fix KERNEL_WERROR GCC version dependency

    In commit 8753022aeae1 ("toolchain: gcc: switch default to 13") we've
    bumped GCC to version 13, but forget to bump GCC version config
    dependency for `KERNEL_WERROR` which resulted in `ltq-vmmc` build
    regression.

    So lets fix it by bumping the GCC version to the default 13 now and
    while at it add a small note to any future GCC version bumper, that this
    `KERNEL_WERROR` should be handled as well.

* References: openwrt/openwrt/pull/15065
* Fixes: 8753022aeae1 ("toolchain: gcc: switch default to 13")

### image.mk: fix dd memory exhaustion during padding of large images

    This commit adjusts the Image/pad-to function within image.mk to improve
    memory management when padding large images. Previously, the dd command
    was used with a block size (bs) directly derived from the target padding
    size. This could lead to inefficiencies or memory exhaustion issues when
    dealing with very large images.

    To address this, a conditional has been introduced: If the desired
    padding size exceeds 1MiB (1048576 bytes), dd now operates with a block
    size of 1MiB and calculates the necessary count to achieve the desired
    padding. This approach aims to balance memory usage and performance by
    avoiding excessively large block sizes in memory-intensive operations.

    For padding sizes of 1MiB or less, the original behavior is preserved,
    using the specified padding size as the block size.

    This change ensures more reliable and efficient image padding,
    particularly in environments with limited memory resources.

* References: https://github.com/openwrt/openwrt/pull/2862