### PR TITLE
unpack.mk: use staging zstdcat

### DIFF
--- a/include/unpack.mk
+++ b/include/unpack.mk
@@ -30,7 +30,7 @@ ifeq ($(strip $(UNPACK_CMD)),)
     endif
     ifeq (zst,$(EXT))
       EXT:=$(call ext,$(PKG_SOURCE:.$(EXT)=))
-      DECOMPRESS_CMD:=zstdcat $(DL_DIR)/$(PKG_SOURCE) |
+      DECOMPRESS_CMD:=$(STAGING_DIR_HOST)/bin/zstdcat $(DL_DIR)/$(PKG_SOURCE) |
     endif
     ifeq ($(filter tgz tbz tbz2 txz,$(EXT1)),$(EXT1))
       EXT:=tar


### PR DESCRIPTION
ZSTD is not part of the prereq, and we are building ZSTD anyway so lets use our staging zstdcat instead of relying on the host distro having it. This way we can also be sure that we are using the same version.
