### PR TITLE
[openwrt-23.05] mediatek: enable rootwait for cmcc rax3000m emmc version

### DIFF
--- a/package/boot/uboot-mediatek/patches/437-add-cmcc_rax3000m.patch
+++ b/package/boot/uboot-mediatek/patches/437-add-cmcc_rax3000m.patch
@@ -585,7 +585,7 @@
 +serverip=192.168.1.254
 +loadaddr=0x46000000
 +console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
-+bootargs=root=/dev/mmcblk0p65
++bootargs=root=/dev/mmcblk0p65 rootwait
 +bootcmd=if pstore check ; then run boot_recovery ; else run boot_emmc ; fi
 +bootconf=config-1#mt7981b-cmcc-rax3000m-emmc
 +bootdelay=0

--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-emmc.dtso
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-emmc.dtso
@@ -7,6 +7,13 @@
 	compatible = "cmcc,rax3000m", "mediatek,mt7981";
 
 	fragment@0 {
+		target = <&chosen>;
+		__overlay_ {
+			bootargs-append = " rootwait";
+		};
+	};
+
+	fragment@1 {
 		target = <&mmc0>;
 		__overlay__ {
 			bus-width = <8>;
@@ -22,7 +29,7 @@
 		};
 	};
 
-	fragment@1 {
+	fragment@2 {
 		target = <&pio>;
 		__overlay__ {
 			mmc0_pins_default: mmc0-pins {

--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m.dts
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m.dts
@@ -21,7 +21,7 @@
 		serial0 = &uart0;
 	};
 
-	chosen {
+	chosen: chosen {
 		stdout-path = "serial0:115200n8";
 	};
 

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -129,8 +129,8 @@ mediatek_setup_macs()
 	cmcc,rax3000m)
 		case "$(cmdline_get_var root)" in
 		/dev/mmc*)
-			wan_mac=$(mmc_get_mac_binary factory 0x2a)
-			lan_mac=$(mmc_get_mac_binary factory 0x24)
+			wan_mac=$(mmc_get_mac_binary factory 0x24)
+			lan_mac=$(mmc_get_mac_binary factory 0x2a)
 			label_mac=$wan_mac
 		;;
 		esac


### PR DESCRIPTION
Sometimes the mmc deivce may come up later than kernel attempts to mount rootfs, resulting kernel panic.
Enable rootwait to fix it.