### PR TITLE
ipq806x: 6.6: refresh patches

### DIFF
--- a/target/linux/ipq806x/patches-6.6/902-ARM-decompressor-support-for-ATAGs-rootblock-parsing.patch
+++ b/target/linux/ipq806x/patches-6.6/902-ARM-decompressor-support-for-ATAGs-rootblock-parsing.patch
@@ -177,7 +177,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  #include <linux/bootconfig.h>
  #include <linux/console.h>
  #include <linux/nmi.h>
-@@ -929,6 +930,17 @@ void start_kernel(void)
+@@ -930,6 +931,17 @@ void start_kernel(void)
  	pr_notice("Kernel command line: %s\n", saved_command_line);
  	/* parameters may set static keys */
  	jump_label_init();


### PR DESCRIPTION
Refresh patches for kernel 6.6.23 with make target/linux/refresh.