### PR TITLE
Add support for switch Zyxel GS1900-24EP

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -105,6 +105,9 @@ zyxel,gs1900-8hp-v1|\
 zyxel,gs1900-8hp-v2)
 	ucidef_set_poe 70 "$lan_list"
 	;;
+zyxel,gs1900-24ep)
+	ucidef_set_poe 130 "lan1 lan2 lan3 lan4 lan5 lan6 lan7 lan8 lan9 lan10 lan11 lan12"
+	;;
 zyxel,gs1900-24hp-v1|\
 zyxel,gs1900-24hp-v2)
 	ucidef_set_poe 170 "$(filter_port_list "$lan_list" "lan25 lan26")"

--- a/target/linux/realtek/dts-5.15/rtl8382_zyxel_gs1900-24ep.dts
+++ b/target/linux/realtek/dts-5.15/rtl8382_zyxel_gs1900-24ep.dts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_zyxel_gs1900.dtsi"
+
+/ {
+	compatible = "zyxel,gs1900-24ep", "realtek,rtl838x-soc";
+	model = "ZyXEL GS1900-24EP Switch";
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&mdio {
+	EXTERNAL_PHY(0)
+	EXTERNAL_PHY(1)
+	EXTERNAL_PHY(2)
+	EXTERNAL_PHY(3)
+	EXTERNAL_PHY(4)
+	EXTERNAL_PHY(5)
+	EXTERNAL_PHY(6)
+	EXTERNAL_PHY(7)
+
+	EXTERNAL_PHY(16)
+	EXTERNAL_PHY(17)
+	EXTERNAL_PHY(18)
+	EXTERNAL_PHY(19)
+	EXTERNAL_PHY(20)
+	EXTERNAL_PHY(21)
+	EXTERNAL_PHY(22)
+	EXTERNAL_PHY(23)
+};
+
+&switch0 {
+	ports {
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, internal)
+		SWITCH_PORT(9, 10, internal)
+		SWITCH_PORT(10, 11, internal)
+		SWITCH_PORT(11, 12, internal)
+		SWITCH_PORT(12, 13, internal)
+		SWITCH_PORT(13, 14, internal)
+		SWITCH_PORT(14, 15, internal)
+		SWITCH_PORT(15, 16, internal)
+
+		SWITCH_PORT(16, 17, qsgmii)
+		SWITCH_PORT(17, 18, qsgmii)
+		SWITCH_PORT(18, 19, qsgmii)
+		SWITCH_PORT(19, 20, qsgmii)
+		SWITCH_PORT(20, 21, qsgmii)
+		SWITCH_PORT(21, 22, qsgmii)
+		SWITCH_PORT(22, 23, qsgmii)
+		SWITCH_PORT(23, 24, qsgmii)
+	};
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -358,6 +358,15 @@ define Device/zyxel_gs1900-24e
 endef
 TARGET_DEVICES += zyxel_gs1900-24e
 
+define Device/zyxel_gs1900-24ep
+  $(Device/zyxel_gs1900)
+  SOC := rtl8382
+  DEVICE_MODEL := GS1900-24EP
+  ZYXEL_VERS := ABTO
+  DEVICE_PACKAGES += realtek-poe
+endef
+TARGET_DEVICES += zyxel_gs1900-24ep
+
 define Device/zyxel_gs1900-24hp-v1
   $(Device/zyxel_gs1900)
   SOC := rtl8382


### PR DESCRIPTION
This device is very similar to the GS1900-24E switch, except that the first 12 of 24 eth ports are PoE.

Zyxel version code for this device is: ABTO