### PR TITLE
tools: zstd: install headers as well

### DIFF
--- a/tools/zstd/Makefile
+++ b/tools/zstd/Makefile
@@ -34,7 +34,7 @@ define Host/Compile
 endef
 
 define Host/Install
-	+$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR)/lib install-pc install-static PREFIX=$(HOST_BUILD_PREFIX)
+	+$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR)/lib install-pc install-static install-includes PREFIX=$(HOST_BUILD_PREFIX)
 	+$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR)/programs install PREFIX=$(HOST_BUILD_PREFIX)
 endef
 


### PR DESCRIPTION
We forgot to make sure install-includes is called for the libzstd in order for it to install the required headers.

Fixes: 4b920e799fba ("tools: zstd: convert to make and drop meson dependency")
