### PR TITLE
config: select KERNEL_WERROR if building with default GCC version

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1418,8 +1418,6 @@ config KERNEL_JFFS2_FS_SECURITY
 
 config KERNEL_WERROR
 	bool "Compile the kernel with warnings as errors"
-	default BUILDBOT
-	default y if GCC_USE_VERSION_12
 	help
 	  A kernel build should not cause any compiler warnings, and this
 	  enables the '-Werror' (for C) and '-Dwarnings' (for Rust) flags

--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -16,6 +16,11 @@ choice
 		bool "gcc 13.x"
 endchoice
 
+config GCC_USE_DEFAULT_VERSION
+	bool
+	default y if !TOOLCHAINOPTS || GCC_USE_VERSION_13
+	imply KERNEL_WERROR
+
 config GCC_USE_GRAPHITE
 	bool
 	prompt "Compile in support for the new Graphite framework in GCC 4.4+" if TOOLCHAINOPTS


### PR DESCRIPTION
At the moment we have to manually follow the default GCC version also in config/Config-kernel.in. This tends to be forgotten at GCC version bumps (just happened when switching from version 12 to 13). Instead, introduce a hidden Kconfig symbol which implies `KERNEL_WERROR` in `toolchain/gcc/Config.in` where it is visible for developers changing the default version.

Also remove the explicit default on BUILDBOT to avoid a circular dependency and also because buildbots anyway implicitly always select the default GCC version.

Reference: https://github.com/openwrt/openwrt/pull/15064