### PR TITLE
sdk: include lib/crtsavres.o for powerpc

### DIFF
--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -68,6 +68,10 @@ KERNEL_FILES_ARCH = \
 	kernel/asm-offsets.s \
 	kernel/module.lds
 
+ifeq ($(LINUX_KARCH),powerpc)
+  KERNEL_FILES_ARCH += lib/crtsavres.o
+endif
+
 KERNEL_FILES_BASE := \
 	.config \
 	Makefile \


### PR DESCRIPTION
Trying to link certain kernel modules like dahdi-linux when building with the OpenWrt SDK will fail with:
`openwrt-sdk-apm821xx-sata_gcc-13.2.0_musl.Linux-x86_64/staging_dir/toolchain-powerpc_464fp_gcc-13.2.0_musl/bin/powerpc-openwrt-linux-musl-ld: cannot find arch/powerpc/lib/crtsavres.o: No such file or directory`

So, lets include lib/crtsavres.o when SDK is generated for PowerPC.
