### PR TITLE
ramips: add support for Wavlink WL-WN531G3

### DIFF
--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn531g3.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn531g3.dts
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7620a.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "wavlink,wl-wn531g3", "ralink,mt7620a-soc";
+	model = "Wavlink WL-WN531G3";
+
+	aliases {
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_red;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		turbo {
+			label = "turbo";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		touchlink {
+			label = "touchlink";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: led_status_blue {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: led_status_red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_factory_28: macaddr@28 {
+						reg = <0x28 0x6>;
+					};
+
+					macaddr_factory_2e: macaddr@2e {
+						reg = <0x2e 0x6>;
+					};
+
+					eeprom_radio_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+
+					eeprom_radio_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+				};
+			};
+
+			partition@50000 {
+				label = "params";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x60000 0x7a0000>;
+			};
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins>, <&rgmii2_pins>, <&mdio_pins>;
+
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+
+	mediatek,portmap = "llllw";
+
+	port@4 {
+		status = "okay";
+		phy-handle = <&phy4>;
+		phy-mode = "rgmii";
+
+		nvmem-cells = <&macaddr_factory_2e>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	port@5 {
+		status = "okay";
+		phy-handle = <&phy5>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		phy4: ethernet-phy@4 {
+			reg = <4>;
+			phy-mode = "rgmii";
+		};
+
+		phy5: ethernet-phy@5 {
+			reg = <5>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_radio_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gsw {
+	mediatek,port4-gmac;
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_radio_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uartf";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1340,6 +1340,15 @@ define Device/wavlink_wl-wn530hg4
 endef
 TARGET_DEVICES += wavlink_wl-wn530hg4
 
+define Device/wavlink_wl-wn531g3
+  SOC := mt7620a
+  IMAGE_SIZE := 7808k
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := WL-WN531G3
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-phy-realtek kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += wavlink_wl-wn531g3
+
 define Device/wavlink_wl-wn535k1
   SOC := mt7620a
   IMAGE_SIZE := 7360k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -253,6 +253,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch1" \
 			"0:lan:3" "1:lan:2" "2:lan:1" "4:lan:4" "3:wan" "7@eth0"
 		;;
+	wavlink,wl-wn531g3)
+		ucidef_add_switch "switch0" \
+			"0:lan:4" "1:lan:3" "2:lan:2" "5:lan:1" "4:wan" "6@eth0"
+		;;
 	wavlink,wl-wn535k1)
 		ucidef_add_switch "switch0" \
 			"2:lan:2" "5:lan:1" "4:wan" "6@eth0"
@@ -426,12 +430,13 @@ ramips_setup_macs()
 	tplink,ec220-g5-v2)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary rom 0xf100)" 1)
 		;;
+	wavlink,wl-wn531g3|\
+	zbtlink,zbt-we1026-5g-16m)
+		label_mac=$(mtd_get_mac_binary factory 0x4)
+		;;
 	wavlink,wl-wn535k1)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		label_mac=$(mtd_get_mac_binary factory 0x8004)
-		;;
-	zbtlink,zbt-we1026-5g-16m)
-		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
 	zyxel,keenetic-lite-iii-a)
 		lan_mac=$(mtd_get_mac_binary RF-EEPROM 0x4)


### PR DESCRIPTION
This device is similiar to the Wavlink WL-WN531A3.
Hardware
--------
SoC:   Mediatek MT7620A
RAM:   64MB
FLASH: 8MB NOR (GigaDevice GD25Q64CS)
ETH:
  - 2x 10/100/1000 Mbps Ethernet (RTL8211F)
  - 3x 10/100 Mbps Ethernet (integrated in SOC)
WIFI:
  - 2.4GHz: 1x (integrated in SOC) (2x2:2)
  - 5GHz:   1x MT7612E (2x2:2)
  - 4 external antennas
BTN:
  - 1x Reset button
  - 1x Touchlink button
  - 1x Turbo button
  - 1x Wps button
  - 1x ON/OFF switch
LEDS:
  - 1x Red led (system status)
  - 1x Blue led (system status)
  - 5x Blue leds (ethernet ports)
  - 1x Power led
  - 1x Wifi led
UART:
  - 57600-8-N-1

Everything works correctly.

Installation
------------
Flash the initramfs image in the OEM firmware interface
When Openwrt boots, flash the sysupgrade image otherwise you won't be
able to keep configuration between reboots.
In my case the whole device was locked and there was no way
to flash the image, except for flashing directly to the flash
via an spi-flasher. You need to put the sysupgrade image file at
the beginning of 0x60000.

Notes
-----
1) Router mac addresses:
   LAN XX:XX:XX:XX:XX:F0 (factory @ 0x28)
   WAN XX:XX:XX:XX:XX:F1 (factory @ 0x2e)
   WIFI 2G XX:XX:XX:XX:XX:F2 (factory @ 0x04)
   WIFI 5G XX:XX:XX:XX:XX:F3 (factory @ 0x8004)

   LABEL XX:XX:XX:XX:XX:F2