### PR TITLE
config: fix CONFIG_GDB appearing in main menuconfig menu

### DIFF
--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -16,11 +16,6 @@ choice
 		bool "gcc 13.x"
 endchoice
 
-config GCC_USE_DEFAULT_VERSION
-	bool
-	default y if !TOOLCHAINOPTS || GCC_USE_VERSION_13
-	imply KERNEL_WERROR
-
 config GCC_USE_GRAPHITE
 	bool
 	prompt "Compile in support for the new Graphite framework in GCC 4.4+" if TOOLCHAINOPTS

--- a/toolchain/gcc/Config.version
+++ b/toolchain/gcc/Config.version
@@ -12,3 +12,8 @@ config GCC_VERSION
 	default "11.3.0"	if GCC_VERSION_11
 	default "12.3.0"	if GCC_VERSION_12
 	default "13.2.0"
+
+config GCC_USE_DEFAULT_VERSION
+	bool
+	default y if !TOOLCHAINOPTS || GCC_USE_VERSION_13
+	imply KERNEL_WERROR


### PR DESCRIPTION
I noticed that CONFIG_GDB was suddenly appearing in the main menuconfig menu despite the fact that it should be visible only when TOOLCHAINOPTS is selected and under a dedicated menu.

After some trial and error, it seems that this was caused by the recent addition of GCC_USE_DEFAULT_VERSION, and after even more trial and error it gets fixed as soon GCC_USE_DEFAULT_VERSION is placed after GCC_VERSION.

So, lets simply put GCC_USE_DEFAULT_VERSION after GCC_VERSION.

Fixes: 501ef81040ba ("config: select KERNEL_WERROR if building with default GCC version")
