### PR TITLE
qualcommax: Skip compiling unnecessary dtbs

### DIFF
--- a/target/linux/qualcommax/Makefile
+++ b/target/linux/qualcommax/Makefile
@@ -4,7 +4,7 @@ ARCH:=aarch64
 BOARD:=qualcommax
 BOARDNAME:=Qualcomm Atheros 802.11ax WiSoC-s
 FEATURES:=squashfs ramdisk fpu nand rtc emmc
-KERNELNAME:=Image dtbs
+KERNELNAME:=Image
 CPU_TYPE:=cortex-a53
 SUBTARGETS:=ipq807x ipq60xx
 


### PR DESCRIPTION
Currently the compile phase of the kernel builds `Image dtbs modules`. However, none of the dtbs that get built are used for the final image.

This ends up unnecessarily taking CPU cycles and produces a lot of `WARNINGS` that can lead users to believe there's cause for concern. I believe the same principle can be applied to other targets.

```
DTC     arch/arm64/boot/dts/qcom/msm8996-mtp.dtb
arch/arm64/boot/dts/qcom/msm8996.dtsi:2954.36-2962.5: Warning (clocks_property):
/soc/clock-controller@6400000: Missing property '#clock-cells' in node
/soc/mailbox@9820000 or bad phandle (referred from clocks[2])

DTC     arch/arm64/boot/dts/qcom/msm8996-sony-xperia-tone-dora.dtb
arch/arm64/boot/dts/qcom/msm8996.dtsi:2954.36-2962.5: Warning (clocks_property):
/soc/clock-controller@6400000: Missing property '#clock-cells' in node
/soc/mailbox@9820000 or bad phandle (referred from clocks[2])

DTC     arch/arm64/boot/dts/qcom/msm8996-sony-xperia-tone-kagura.dtb
arch/arm64/boot/dts/qcom/msm8996.dtsi:2954.36-2962.5: Warning (clocks_property):
/soc/clock-controller@6400000: Missing property '#clock-cells' in node
/soc/mailbox@9820000 or bad phandle (referred from clocks[2])

DTC     arch/arm64/boot/dts/qcom/msm8996-sony-xperia-tone-keyaki.dtb
arch/arm64/boot/dts/qcom/msm8996.dtsi:2954.36-2962.5: Warning (clocks_property):
/soc/clock-controller@6400000: Missing property '#clock-cells' in node
/soc/mailbox@9820000 or bad phandle (referred from clocks[2])

DTC     arch/arm64/boot/dts/qcom/msm8996-xiaomi-gemini.dtb
arch/arm64/boot/dts/qcom/msm8996.dtsi:2954.36-2962.5: Warning (clocks_property):
/soc/clock-controller@6400000: Missing property '#clock-cells' in node
/soc/mailbox@9820000 or bad phandle (referred from clocks[2])

DTC     arch/arm64/boot/dts/qcom/msm8996-xiaomi-natrium.dtb
arch/arm64/boot/dts/qcom/msm8996.dtsi:2954.36-2962.5: Warning (clocks_property):
/soc/clock-controller@6400000: Missing property '#clock-cells' in node
/soc/mailbox@9820000 or bad phandle (referred from clocks[2])

DTC     arch/arm64/boot/dts/qcom/msm8996-xiaomi-scorpio.dtb
arch/arm64/boot/dts/qcom/msm8996.dtsi:2954.36-2962.5: Warning (clocks_property):
/soc/clock-controller@6400000: Missing property '#clock-cells' in node
/soc/mailbox@9820000 or bad phandle (referred from clocks[2])
```