### PR TITLE
add config option to extract debuginfo from binaries

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -219,6 +219,13 @@ menu "Global build settings"
 		help
 		  Specifies arguments passed to the strip command when stripping binaries.
 
+	config EXTRACT_DEBUGINFO
+		bool
+		prompt "Extract debug information"
+		depends on (USE_STRIP || NO_STRIP)
+		help
+		  Extract debug info to separate files and replace it with an appropriate GNU debuglink section.
+
 	config SSTRIP_DISCARD_TRAILING_ZEROES
 		bool "Strip trailing zero bytes"
 		depends on USE_SSTRIP && !USE_MOLD

--- a/include/package-ipkg.mk
+++ b/include/package-ipkg.mk
@@ -102,6 +102,7 @@ ifeq ($(DUMP),)
     ABIV_$(1):=$(call FormatABISuffix,$(1),$(ABI_VERSION))
     PDIR_$(1):=$(call FeedPackageDir,$(1))
     IPKG_$(1):=$$(PDIR_$(1))/$(1)$$(ABIV_$(1))_$(VERSION)_$(PKGARCH).ipk
+    DBGINFO_$(1):=$$(PDIR_$(1))/$(1)$$(ABIV_$(1))_$(VERSION)_$(PKGARCH).debuginfo
     IDIR_$(1):=$(PKG_BUILD_DIR)/ipkg-$(PKGARCH)/$(1)
     KEEP_$(1):=$(strip $(call Package/$(1)/conffiles))
 
@@ -218,7 +219,14 @@ $(_endef)
 	$(if $(PROVIDES),@for pkg in $(filter-out $(1),$(PROVIDES)); do cp $(PKG_INFO_DIR)/$(1).provides $(PKG_INFO_DIR)/$$$$pkg.provides; done)
 	$(CheckDependencies)
 
+    ifneq ($$(CONFIG_EXTRACT_DEBUGINFO),)
+	[ ! -d $$(DBGINFO_$(1)) ] || rm -rf $$(DBGINFO_$(1))
+	mkdir -p $$(DBGINFO_$(1))
+	export DEBUGINFO_DIR=$$(DBGINFO_$(1)); \
+		$(RSTRIP) $$(IDIR_$(1))
+    else
 	$(RSTRIP) $$(IDIR_$(1))
+    endif
 
     ifneq ($$(CONFIG_IPK_FILES_CHECKSUMS),)
 	(cd $$(IDIR_$(1)); \

--- a/target/sdk/files/Config.in
+++ b/target/sdk/files/Config.in
@@ -79,6 +79,13 @@ menu "Global build settings"
 		help
 		  Specifies arguments passed to the strip command when stripping binaries.
 
+	config EXTRACT_DEBUGINFO
+		bool
+		prompt "Extract debug information"
+		depends on (USE_STRIP || NO_STRIP)
+		help
+		  Extract debug info to separate files and replace it with an appropriate GNU debuglink section.
+
 endmenu
 
 menu "Advanced configuration options (for developers)"


### PR DESCRIPTION
This commit adds CONFIG_EXTRACT_DEBUGINFO.
When enabled, debug sections of any ELF files are copied to

  bin/packages/${arch}_${cpu_type}/$feed/$pkg.debuginfo/

before they are stripped.

Sadly, this approach doesn't work with sstrip (sstrip leaves nothing to
attach the debuglink to).

The separation of debug information also occurs with CONFIG_NO_STRIP.
In that case, only the extracted debug information is stripped from ELF
files.

The resulting files can, for example, be used with GDB (add-symbol-file)
to help debugging core files.

  Core was generated by `/tmp/test'.
  Program terminated with signal SIGTRAP, Trace/breakpoint trap.
  #0  0x00401733 in ?? ()
  (gdb) add-symbol-file aa18fe5cf46f5d78499859e2ad916c55709866aa83e587c2ee9a5904f4609577-test
  add symbol table from file "aa18fe5cf46f5d78499859e2ad916c55709866aa83e587c2ee9a5904f4609577-test"
  (y or n) y
  Reading symbols from aa18fe5cf46f5d78499859e2ad916c55709866aa83e587c2ee9a5904f4609577-test...
  (gdb) bt
  #0  0x00401733 in main (argc=<optimized out>, argv=<optimized out>) at main.c:11

They can also be used with debuginfod.

  debuginfod -F bin/packages/mipsel_24kc/
  ..
  DEBUGINFOD_URLS=http://localhost:8002 ..-gdb --iex "set debuginfod enabled on" exe core

The GDB built by Openwrt has to be changed in order to support debuginfod.


funded by OpenZen