### PR TITLE
[openwrt-23.05] sdk: include lib/crtsavres.o for powerpc

### DIFF
--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -68,6 +68,10 @@ KERNEL_FILES_ARCH = \
 	kernel/asm-offsets.s \
 	kernel/module.lds
 
+ifeq ($(LINUX_KARCH),powerpc)
+  KERNEL_FILES_ARCH += lib/crtsavres.o
+endif
+
 KERNEL_FILES_BASE := \
 	.config \
 	Makefile \


### PR DESCRIPTION
Trying to link certain kernel modules like dahdi-linux when building with the OpenWrt SDK will fail with:
openwrt-sdk-apm821xx-sata_gcc-13.2.0_musl.Linux-x86_64/staging_dir/toolchain-powerpc_464fp_gcc-13.2.0_musl/bin/powerpc-openwrt-linux-musl-ld: cannot find arch/powerpc/lib/crtsavres.o: No such file or directory

Previously this worked with the PowerPC SDK since we carried a hack that was passing --save-restore-funcs to module LDFLAGS so the linker provided the required functions automatically as without --save-restore-funcs it doesnt do so automatically on relocatable links and as a sideffect did not require the kernel provided crtsaves.o to link against.

Now that hack has been removed as upstream kernel now compiles crtsaves.o by default so it can be linked against but its not included in the SDK.

So, lets include lib/crtsavres.o when SDK is generated for PowerPC.

Fixes: 1c28058710fd ("kernel: bump 5.15 to 5.15.148")