### PR TITLE
hostapd: select libopenssl-legacy for hostapd-basic-openssl

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -209,7 +209,7 @@ define Package/hostapd-basic-openssl
 $(call Package/hostapd/Default,$(1))
   TITLE+= (WPA-PSK, 11r and 11w)
   VARIANT:=basic-openssl
-  DEPENDS+=+PACKAGE_hostapd-basic-openssl:libopenssl
+  DEPENDS+=$(OPENSSL_DEPENDS)
 endef
 
 define Package/hostapd-basic-openssl/description


### PR DESCRIPTION
According to commit 560965d libopenssl-legacy is required for the openssl variants; also select it for hostapd-basic-openssl as the IDEA and SEED ciphers and MDC2 and WHIRLPOOL digests need it.

More information here: https://github.com/openwrt/openwrt/issues/15120
