### PR TITLE
ipq40xx: add support for Linksys WHW03 V1

### DIFF
--- a/package/boot/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-envtools/files/ipq40xx
@@ -67,6 +67,9 @@ linksys,mr8300)
 linksys,whw01)
 	ubootenv_add_uci_config "/dev/mtd6" "0x0" "0x40000" "0x10000"
 	;;
+linksys,whw03)
+        ubootenv_add_uci_config "/dev/mmcblk0p11" "0x0" "0x100000"
+        ;;
 linksys,whw03v2)
 	ubootenv_add_uci_config "/dev/mtd6" "0x0" "0x80000" "0x20000"
 	;;

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -37,6 +37,7 @@ ipq40xx_setup_interfaces()
 	glinet,gl-ap1300|\
 	glinet,gl-b2200|\
 	google,wifi|\
+	linksys,whw03|\
 	linksys,whw03v2|\
 	luma,wrtq-329acn|\
 	mikrotik,cap-ac|\
@@ -214,6 +215,10 @@ ipq40xx_setup_macs()
 	linksys,mr8300)
 		wan_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
+		;;
+	linksys,whw03)
+		wan_mac=$(mmc_get_mac_ascii devinfo hw_mac_addr)
+		lan_mac="$wan_mac"
 		;;
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2|\

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -40,6 +40,10 @@ case "$FIRMWARE" in
 		# OEM assigns 4 sequential MACs
 		ath10k_patch_mac $(macaddr_setbit_la $(macaddr_add "$(cat /sys/class/net/eth0/address)" 4))
 		;;
+	linksys,whw03)
+		caldata_extract_mmc "0:ART" 0x9000 0x2f20
+		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 3)
+		;;
 	netgear,rbr40|\
 	netgear,rbs40|\
 	netgear,rbr50|\
@@ -103,6 +107,10 @@ case "$FIRMWARE" in
 	linksys,mr8300)
 		caldata_extract "ART" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
+		;;
+	linksys,whw03)
+		caldata_extract_mmc "0:ART" 0x1000 0x2f20
+		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
 		;;
 	meraki,mr33 |\
 	meraki,mr74)
@@ -199,6 +207,10 @@ case "$FIRMWARE" in
 	linksys,mr8300)
 		caldata_extract "ART" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 3)
+		;;
+	linksys,whw03)
+		caldata_extract_mmc "0:ART" 0x5000 0x2f20
+		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
 		;;
 	meraki,mr33 |\
 	meraki,mr74)

--- a/target/linux/ipq40xx/base-files/etc/init.d/bootcount
+++ b/target/linux/ipq40xx/base-files/etc/init.d/bootcount
@@ -2,6 +2,35 @@
 
 START=99
 
+mmc_resetbc() {
+	local part_label="$1"
+
+	. /lib/functions.sh
+
+	local part_device="$(find_mmc_part "$part_label")"
+	if [ "$part_device" = "" ]; then
+		>&2 echo "mmc_resetbc: Unknown partition label: $part_label"
+		return 1
+	fi
+
+	local magic_number="$(hexdump -e '"0x%02x\n"' -n 4 "$part_device")"
+	if [ "$magic_number" != "0x20110811" ]; then
+		>&2 echo "mmc_resetbc: Unexpected partition magic: $magic_number"
+		return 1
+	fi
+
+	local last_count=$(hexdump -e '"0x%02x\n"' -n 4 -s 4 "$part_device")
+	if [ "$last_count" != "0x00" ]; then
+		printf "\x00" | dd of="$part_device" bs=4 seek=1 count=1 conv=notrunc 2>/dev/null
+
+		last_count=$(hexdump -e '"0x%02x\n"' -n 4 -s 4 "$part_device")
+		if [ "$last_count" != "0x00" ]; then
+			>&2 echo "mmc_resetbc: Unable to reset boot counter"
+			return 1
+		fi
+	fi
+}
+
 boot() {
 	case $(board_name) in
 	alfa-network,ap120c-ac)
@@ -14,6 +43,9 @@ boot() {
 	linksys,whw01|\
 	linksys,whw03v2)
 		mtd resetbc s_env || true
+		;;
+	linksys,whw03)
+		mmc_resetbc s_env || true
 		;;
 	netgear,wac510)
 		fw_setenv boot_cnt=0

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -30,6 +30,12 @@ preinit_set_mac_address() {
 		ip link set dev lan1 address $(macaddr_add "$base_mac" 1)
 		ip link set dev eth0 address $(macaddr_setbit "$base_mac" 7)
 		;;
+	linksys,whw03)
+		base_mac=$(mmc_get_mac_ascii devinfo hw_mac_addr)
+		ip link set dev eth0 address "$base_mac"
+		ip link set dev lan address "$base_mac"
+		ip link set dev wan address "$base_mac"
+		;;
 	mikrotik,wap-ac|\
 	mikrotik,wap-ac-lte|\
 	mikrotik,wap-r-ac)

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -175,6 +175,9 @@ platform_do_upgrade() {
 	linksys,whw03v2)
 		platform_do_upgrade_linksys "$1"
 		;;
+	linksys,whw03)
+		platform_do_upgrade_linksys_emmc "$1"
+		;;
 	meraki,mr33 |\
 	meraki,mr74)
 		CI_KERNPART="part.safe"
@@ -236,7 +239,8 @@ platform_do_upgrade() {
 platform_copy_config() {
 	case "$(board_name)" in
 	glinet,gl-b2200 |\
-	google,wifi)
+	google,wifi |\
+	linksys,whw03)
 		emmc_copy_config
 		;;
 	esac

--- a/target/linux/ipq40xx/files-6.1/arch/arm/boot/dts/qcom-ipq4019-whw03.dts
+++ b/target/linux/ipq40xx/files-6.1/arch/arm/boot/dts/qcom-ipq4019-whw03.dts
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Linksys WHW03 (Velop)";
+	compatible = "linksys,whw03", "qcom,ipq4019";
+
+	aliases {
+		led-boot = &led_blue;
+		led-failsafe = &led_red;
+		led-running = &led_blue;
+		led-upgrade = &led_red;
+	};
+
+	// Default bootargs includes rootfstype=ext4 and needs to be overriden.
+	chosen {
+		bootargs-append = " rootfstype=squashfs";
+	};
+
+	soc {
+		ess-tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+	};
+
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+
+&tlmm {
+	mdio_pins: mdio-pinmux {
+		mux-1 {
+			pins = "gpio6";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mux-2 {
+			pins = "gpio7";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
+	sd_pins: sd-pinmux {
+		pins = "gpio23", "gpio24", "gpio25", "gpio26",
+			"gpio27", "gpio28", "gpio29", "gpio30",
+			"gpio31", "gpio32";
+		function = "sdio";
+	};
+
+	i2c_0_pins: i2c-0-pinmux {
+		pins = "gpio58", "gpio59";
+		function = "blsp_i2c0";
+		bias-disable;
+	};
+
+	serial_0_pins: serial0-pinmux {
+		pins = "gpio16", "gpio17";
+		function = "blsp_uart0";
+		bias-disable;
+	};
+
+	serial_1_pins: serial1-pinmux {
+		pins = "gpio8", "gpio9", "gpio10", "gpio11";
+		function = "blsp_uart1";
+		bias-disable;
+	};
+
+	spi_0_pins: spi-0-pinmux {
+		mux {
+			pins = "gpio13", "gpio14", "gpio15";
+			function = "blsp_spi0";
+			drive-strength = <12>;
+			bias-disable;
+		};
+
+		mux-cs {
+			pins = "gpio12";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+
+	spi_1_pins: spi-1-pinmux {
+		mux-1 {
+			pins = "gpio44", "gpio46", "gpio47";
+			function = "blsp_spi1";
+			bias-disable;
+		};
+
+		mux-2 {
+			pins = "gpio45", "gpio49";
+			function = "gpio";
+			bias-pull-up;
+			output-high;
+		};
+
+		host-interrupt {
+			pins = "gpio42";
+			function = "gpio";
+			input;
+		};
+	};
+
+	wifi_0_pins: wifi0-pinmux {
+		pins = "gpio52";
+		function = "gpio";
+		drive-strength = <6>;
+		bias-pull-up;
+		output-high;
+	};
+
+	zigbee-0 {
+		gpio-hog;
+		gpios = <29 GPIO_ACTIVE_HIGH>;
+		bias-disable;
+		output-low;
+	};
+
+	zigbee-1 {
+		gpio-hog;
+		gpios = <50 GPIO_ACTIVE_HIGH>;
+		bias-disable;
+		input;
+	};
+
+	bluetooth-enable {
+		gpio-hog;
+		gpios = <32 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 41 GPIO_ACTIVE_LOW>;
+};
+
+&ethphy0 {
+	status = "disabled";
+};
+
+&ethphy1 {
+	status = "disabled";
+};
+
+&ethphy2 {
+	status = "disabled";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&cryptobam {
+	num-channels = <4>;
+	qcom,num-ees = <2>;
+
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&vqmmc {
+	status = "okay";
+};
+
+&blsp1_uart1 {
+	status = "okay";
+	pinctrl-0 = <&serial_0_pins>;
+	pinctrl-names = "default";
+};
+
+&blsp1_uart2 {
+	status = "okay";
+	pinctrl-0 = <&serial_1_pins>;
+	pinctrl-names = "default";
+
+	bluetooth {
+		compatible = "csr,8811";
+
+		enable-gpios = <&tlmm 32 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&blsp1_spi2 {
+	pinctrl-0 = <&spi_1_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	cs-gpios = <&tlmm 45 GPIO_ACTIVE_HIGH>;
+
+	zigbee@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		compatible = "silabs,em3581";
+		reg = <0>;
+		spi-max-frequency = <12000000>;
+	};
+};
+
+&blsp1_i2c3 {
+	pinctrl-0 = <&i2c_0_pins>;
+	pinctrl-names = "default";
+
+	status = "okay";
+
+	// RGB LEDs
+	pca9633: led-controller@62 {
+		compatible = "nxp,pca9633";
+		nxp,hw-blink;
+		reg = <0x62>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		led_red: red@0 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_INDICATOR;
+			reg = <0>;
+		};
+
+		led_green: green@1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			reg = <1>;
+		};
+
+		led_blue: blue@2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_INDICATOR;
+			reg = <2>;
+		};
+	};
+};
+
+&sdhci {
+	vqmmc-supply = <&vqmmc>;
+	pinctrl-0 = <&sd_pins>;
+	pinctrl-names = "default";
+	cd-gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
+	sd-ldo-gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 40 GPIO_ACTIVE_LOW>;
+	clkreq-gpios = <&tlmm 39 GPIO_ACTIVE_LOW>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi2: wifi@1,0 {
+			compatible = "qcom,ath10k";
+			reg = <0x00000000 0 0 0 0>;
+		};
+	};
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+	label = "lan";
+};
+
+&swport5 {
+	status = "okay";
+	label = "wan";
+};
+
+&wifi0 {
+	pinctrl-0 = <&wifi_0_pins>;
+	pinctrl-names = "default";
+
+	status = "okay";
+
+	qcom,coexist-support = <1>;
+	qcom,coexist-gpio-pin = <52>;
+
+	qcom,ath10k-calibration-variant = "linksys-whw03";
+};
+
+&wifi1 {
+	status = "okay";
+
+	ieee80211-freq-limit = <5170000 5330000>;
+	qcom,ath10k-calibration-variant = "linksys-whw03";
+};
+
+&wifi2 {
+	status = "okay";
+
+	ieee80211-freq-limit = <5490000 5835000>;
+	qcom,ath10k-calibration-variant = "linksys-whw03";
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -723,6 +723,19 @@ define Device/linksys_mr8300
 endef
 TARGET_DEVICES += linksys_mr8300
 
+define Device/linksys_whw03
+	$(call Device/FitzImage)
+	DEVICE_VENDOR := Linksys
+	DEVICE_MODEL := WHW03
+	SOC := qcom-ipq4019
+	KERNEL_SIZE := 8192k
+	IMAGE_SIZE := 131072k
+	IMAGES += factory.bin
+	IMAGE/factory.bin  := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | linksys-image type=WHW03
+	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct kmod-leds-pca963x kmod-spi-dev kmod-bluetooth kmod-fs-ext4 e2fsprogs kmod-fs-f2fs mkf2fs losetup
+endef
+TARGET_DEVICES += linksys_whw03
+
 define Device/linksys_whw03v2
 	$(call Device/FitzImage)
 	DEVICE_VENDOR := Linksys


### PR DESCRIPTION
@dangowrt @hauke @mans0n 

WIP, please help me through.

this is Linksys WHW03 (after the fact called WHW03 V1). it is the eMMC version of WHW03 V2, which is NAND and has an [official port](https://openwrt.org/toh/linksys/whw03_v2).

### status

the device is fully working, but i still got some issues with details of the port. also, the port is missing board_data. i'll either extract it later or point this port to use board_data from V2, which i guess should be effectively the same. the DTS is only provided for one kernel; i will duplicate it when it has no outstanding issues.

### naming

Linksys called this device "WHW03" (there is no V1). this port is named "whw03" (V2 is named "whw03v2"). is that ok? if it is, should [this](https://github.com/openwrt/openwrt/commit/c82fb6a6a6ef37991975c2ba66be98c18fb49146#diff-0d47fc991783da7b957922e86a76d266dc782bfe50bed060ef5a7129133a45fdR728-R729) include `DEVICE_VARIANT := V1` anyway?

<details>
<summary>precal</summary>

**SOLUTION:** stays as it is. [precal could be loaded using NVMEM](https://github.com/openwrt/openwrt/pull/15132#issuecomment-2052700317), but this [does not support the required MAC patching](https://github.com/openwrt/openwrt/pull/15132#issuecomment-2054135089).

precal is loaded programmatically. i suppose i *could* load it declaratively from the eMMC via nvmen-cells. it seems i would have to hardcode the extents of the ART partition in the DTS for this. given that the eMMC has a GUID Partition Table that could be edited, this is an inferior solution, but not the end of the world. the problem is that i also need to patch the mac addresses into the precals, and the macs are arithmetically calculated. i don't think this works well with the nvmen-cells mechanism, or does it?

anyway, is precal loading acceptable in its current form (ie, programmatic)?
</details>

### [new] MAC addresses

the device has only 2 ethernet ports. stock FW tries to autodetect (not very well, btw) which one is WAN and which one is LAN. i think it is for this reason that the stock FW use the same MAC address for both ports. this MAC is the only address stored in the nonvolatile config of the router. the 3 wifis then use MAC+1, MAC+2, and MAC+3.

i've replicated this behavior, resulting in eth0, wan@eth0, lan@eth0, br-lan all using the same MAC. the port seems to work fine, but it is a bit weird. i could switch some of these adapters to different addresses. i could use addresses from: macaddr_setbit_la(MAC), macaddr_generate_from_mmc_cid(), any other ah-hoc bit setting on MAC. i **cannot** use MAC+4, as this would trespass on centrally assigned addresses.

any recommendations? i suppose i could change lan@eth0 and br-lan to macaddr_setbit_la(MAC). but what should i do with eth0 then?

### [new] default wifi

i can easily obtain the stock wifi name and password from the factory config partition. is it ok for openwrt to mimic stock in this regard and start with the wifis thus configured and enabled? could someone point to an example port where the wifis are set by default?

### [new] bluetooth and zigbee

there are bluetooth and zigbee adapters configured in this port. i am also loading the BT kernel module, but not zigbee, for the simple reason that the official WHW03 V2 openwrt port does that. but i see no reason to include the BT kernel module: is it any use without userland? should users interested in BT just install the kernel module themselves?

<details>
<summary>dts: wifi leds</summary>

**SOLUTION:** deleted, leds do not exist.

these were included in the stock DT. should i leave them as comments, delete them, or include them?
```
&wifi0 {
	//wifi-led-gpios = <&tlmm 20 GPIO_ACTIVE_LOW>;
	//wifi-rssi-gpios = <&tlmm 21 GPIO_ACTIVE_LOW>;
};
```
</details>

### leds

these led outputs are detected by the kernel but the leds do not exist. can i stop them from being picked up?
```
/sys/class/leds/ath10k-phy0 -> ../../devices/platform/soc/40000000.pci/pci0000:00/0000:00:00.0/0000:01:00.0/leds/ath10k-phy0
/sys/class/leds/mmc0::      -> ../../devices/platform/soc/7824900.mmc/leds/mmc0::
```

### f2fs inadequacy

the device has a 4GB eMMC:
```
root@OpenWrt:/# lsblk -o NAME,PARTLABEL,SIZE,FSTYPE,FSSIZE,MOUNTPOINTS
NAME         PARTLABEL       SIZE FSTYPE   FSSIZE MOUNTPOINTS
loop0                      120.8M f2fs     118.8M /overlay
mmcblk0                      3.6G                 
├─mmcblk0p1  0:SBL1          512K                 
├─mmcblk0p2  0:BOOTCONFIG    512K                 
├─mmcblk0p3  0:QSEE          512K                 
├─mmcblk0p4  0:QSEE_1        512K                 
├─mmcblk0p5  0:CDT           256K                 
├─mmcblk0p6  0:CDT_1         256K                 
├─mmcblk0p7  0:BOOTCONFIG1   256K                 
├─mmcblk0p8  0:APPSBL          1M                 
├─mmcblk0p9  0:APPSBL_1        1M                 
├─mmcblk0p10 0:ART           256K                 
├─mmcblk0p11 u_env             1M                 
├─mmcblk0p12 s_env             1M                 
├─mmcblk0p13 devinfo           1M                 
├─mmcblk0p14 kernel          136M                 
├─mmcblk0p15 rootfs          128M squashfs        
├─mmcblk0p16 alt_kernel      136M                 
├─mmcblk0p17 alt_rootfs      128M squashfs   7.3M /rom
├─mmcblk0p18 sysdiag         512K                 
└─mmcblk0p19 syscfg          3.4G ext4            
mmcblk0boot0                   4M                 
mmcblk0boot1                   4M                 
```

the kernel/rootfs partitions share the disk space, with the 136MiB kernel partitions having 8MiB for the kernel and then overflowing into the 128MiB rootfs partitions.

in the rootfs partitions, in the unused space after the squashfs images, the port creates f2fs images for rootfs_data. these f2fs images are mounted via loop0 and are currently about 120MiB in size.

unfortunately f2fs is extremely wasteful for small partitions, wasting 35% (40+ MiB) of the available 120MB. is there any way to force the selection of ext4 FS even when the loop device is larger than 100MB?

EDIT:

btw, here is relevant code:
- [formatting of overlay](https://github.com/openwrt/fstools/blob/08cd7083cac4bddf88459efa0881ee52858e7d0a/libfstools/common.c#L166-L169)
- [decision of FS to be used for overlay](https://github.com/openwrt/fstools/blob/08cd7083cac4bddf88459efa0881ee52858e7d0a/libfstools/common.c#L96-L112)

see also:
- https://github.com/openwrt/fstools/issues/6
- https://github.com/openwrt/fstools/issues/7


### using the whole 4GB of the eMMC

right now, about 80MiB are available on each copy of rootfs_data. this is ok by default, to be able to share the device with a stock firmware in the alternate firmware slot, or to facilitate going back to stock. however, i would like to optionally be able to use all of the eMMC.

my plan was to define uboot variables that when set would switch the port to using the 3.4 GiB space in the mmcblk0p19 `syscfg` partition. i originally thought of using `dmsetup` during boot to break up the space of `syscfg` into `rootfs_data`, `alt_rootfs_data`, and `extra` partitions (with `extra` being optional extra storage that is left alone and survives sysupgrades).

EDIT: maybe this could be better done with lvm?

however i don't know how to override openwrt's default startup eMMC behavior (create and mount /dev/loop0), and i could not find examples of it being done. maybe via a preinit script? can i force openwrt to use a particular partition chosen during boot for rootfs_data instead of the extra space behind squashfs in the rootfs partition?

(i think if an eMMC partition is named `rootfs_data` it automatically gets chosen in place of the extra space, am i right? but this isn't very good for me: i've got two firmwares, regular and `alt_*`; i would like two rootfs_data partitions.)

thanks in advance for reviews and comments.