### PR TITLE
tools: pkgconf: provide prefix for host and hostpkg stagind directory

### DIFF
--- a/tools/pkgconf/files/pkg-config
+++ b/tools/pkgconf/files/pkg-config
@@ -4,6 +4,8 @@ ${STAGING_DIR_HOST}/bin/pkg-config.real \
 --keep-system-cflags \
 --keep-system-libs \
 --define-variable=prefix="${STAGING_PREFIX}" \
+--define-variable=prefix_host="${STAGING_DIR_HOST}" \
+--define-variable=prefix_hostpkg="${STAGING_DIR_HOSTPKG}" \
 --define-variable=exec_prefix="${STAGING_PREFIX}" \
 --define-variable=bindir="${STAGING_PREFIX}/bin" \
 $PKG_CONFIG_EXTRAARGS "$@"


### PR DESCRIPTION
Some package might require to fix their pkg-config file to point to host or hostpkg file. This is the case for glib2 library that provides with pkg-config variables, tools to generates files from xml. Those tools should use the host binary instead of the targets one to correctly build packages that makes use of such tools.