### PR TITLE
ipq40xx: whw03v2: fix handling of RGB LED

### DIFF
--- a/target/linux/ipq40xx/files-6.1/arch/arm/boot/dts/qcom-ipq4019-whw03v2.dts
+++ b/target/linux/ipq40xx/files-6.1/arch/arm/boot/dts/qcom-ipq4019-whw03v2.dts
@@ -277,21 +277,18 @@
 		led_red: red@0 {
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_INDICATOR;
-			linux,default-trigger = "none";
 			reg = <0>;
 		};
 
 		led_green: green@1 {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_INDICATOR;
-			linux,default-trigger = "none";
 			reg = <1>;
 		};
 
 		led_blue: blue@2 {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_INDICATOR;
-			linux,default-trigger = "default-on";
 			reg = <2>;
 		};
 	};

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-whw03v2.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-whw03v2.dts
@@ -277,21 +277,18 @@
 		led_red: red@0 {
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_INDICATOR;
-			linux,default-trigger = "none";
 			reg = <0>;
 		};
 
 		led_green: green@1 {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_INDICATOR;
-			linux,default-trigger = "none";
 			reg = <1>;
 		};
 
 		led_blue: blue@2 {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_INDICATOR;
-			linux,default-trigger = "default-on";
 			reg = <2>;
 		};
 	};


### PR DESCRIPTION
The RGB LED should glow green in the 'running' state, but it was glowing cyan because the blue component defaulted to 'on'.

This was not noticed earlier because the LED [was not working](https://github.com/openwrt/openwrt/issues/13803) before [this fix](https://github.com/openwrt/openwrt/commit/e814acc59948943c776ac319a348f72c0d19f33c) was applied.
