### PR TITLE
ramips: simplification of dts/dtsi definition for TP-Link Archer routers

### DIFF
--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
@@ -1,8 +1,8 @@
-#include "mt7620a.dtsi"
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
 #include <dt-bindings/leds/common.h>
+
+#include "mt7620a_tplink_archer.dtsi"
 
 / {
 	compatible = "tplink,archer-c2-v1", "ralink,mt7620a-soc";
@@ -15,9 +15,6 @@
 		led-upgrade = &led_wps;
 	};
 
-	chosen {
-		bootargs = "console=ttyS0,115200";
-	};
 
 	leds {
 		compatible = "gpio-leds";
@@ -56,22 +53,6 @@
 		};
 	};
 
-	keys {
-		compatible = "gpio-keys";
-
-		reset_wps {
-			label = "reset_wps";
-			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-
-		rfkill {
-			label = "rfkill";
-			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RFKILL>;
-		};
-	};
-
 	rtl8367rb {
 		compatible = "realtek,rtl8367b";
 		cpu_port = <6>;
@@ -80,81 +61,10 @@
 	};
 };
 
-&spi0 {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <30000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x0 0x20000>;
-				read-only;
-			};
-
-			partition@20000 {
-				compatible = "tplink,firmware";
-				label = "firmware";
-				reg = <0x20000 0x7a0000>;
-			};
-
-			partition@7c0000 {
-				label = "config";
-				reg = <0x7c0000 0x10000>;
-				read-only;
-			};
-
-			partition@7d0000 {
-				label = "rom";
-				reg = <0x7d0000 0x10000>;
-				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					macaddr_rom_f100: macaddr@f100 {
-						compatible = "mac-base";
-						reg = <0xf100 0x6>;
-						#nvmem-cell-cells = <1>;
-					};
-				};
-			};
-
-			partition@7e0000 {
-				label = "romfile";
-				reg = <0x7e0000 0x10000>;
-				read-only;
-			};
-
-			partition@7f0000 {
-				label = "radio";
-				reg = <0x7f0000 0x10000>;
-				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					eeprom_radio_0: eeprom@0 {
-						reg = <0x0 0x200>;
-					};
-
-					eeprom_radio_8000: eeprom@8000 {
-						reg = <0x8000 0x200>;
-					};
-				};
-			};
-		};
+&state_default {
+	gpio {
+		groups = "i2c", "uartf", "wled", "ephy", "spi refclk";
+		function = "gpio";
 	};
 };
 
@@ -176,46 +86,13 @@
 	};
 };
 
-&gpio1 {
-	status = "okay";
-};
-
-&gpio2 {
-	status = "okay";
-};
-
-&gpio3 {
-	status = "okay";
-};
-
-&state_default {
-	gpio {
-		groups = "i2c", "uartf", "wled", "ephy", "spi refclk";
-		function = "gpio";
-	};
-};
 
 &wmac {
 	nvmem-cells = <&eeprom_radio_0>, <&macaddr_rom_f100 0>;
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
-&ehci {
-	status = "okay";
-};
-
-&ohci {
-	status = "okay";
-};
-
-&pcie {
-	status = "okay";
-};
-
-&pcie0 {
-	mt76@0,0 {
-		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_rom_f100 (-1)>;
-		nvmem-cell-names = "eeprom", "mac-address";
-	};
+&wifi {
+	nvmem-cells = <&eeprom_radio_8000>, <&macaddr_rom_f100 (-1)>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };

--- a/target/linux/ramips/dts/mt7620a_tplink_archer.dtsi
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer.dtsi
@@ -132,11 +132,6 @@
 	status = "okay";
 };
 
-&wmac {
-	nvmem-cells = <&eeprom_radio_0>;
-	nvmem-cell-names = "eeprom";
-};
-
 &pcie {
 	status = "okay";
 };
@@ -144,8 +139,6 @@
 &pcie0 {
 	wifi: mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_radio_8000>;
-		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };


### PR DESCRIPTION
mt7620a_tplink_archer.dtsi: remove unnecessary nvmem-cells definitions that are being redefined anyway.
mt7620a_tplink_archer-c2-v1.dts: import from the mt7620a_tplink_archer.dtsi file and thus simplify the rest of the definition.