### PR TITLE
mediatek: fix DTS defining mt7530 switch phys but not referencing them

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-acer-predator-w6.dts
+++ b/target/linux/mediatek/dts/mt7986a-acer-predator-w6.dts
@@ -348,21 +348,25 @@
 		port@0 {
 			reg = <0>;
 			label = "game";
+			phy-handle = <&swphy0>;
 		};
 
 		port@1 {
 			reg = <1>;
 			label = "lan1";
+			phy-handle = <&swphy1>;
 		};
 
 		port@2 {
 			reg = <2>;
 			label = "lan2";
+			phy-handle = <&swphy2>;
 		};
 
 		port@3 {
 			reg = <3>;
 			label = "lan3";
+			phy-handle = <&swphy3>;
 		};
 
 		port@6 {
@@ -383,7 +387,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		phy@0 {
+		swphy0: phy@0 {
 			reg = <0>;
 
 			mediatek,led-config = <
@@ -397,7 +401,7 @@
 			>;
 		};
 
-		phy@1 {
+		swphy1: phy@1 {
 			reg = <1>;
 
 			mediatek,led-config = <
@@ -411,7 +415,7 @@
 			>;
 		};
 
-		phy@2 {
+		swphy2: phy@2 {
 			reg = <2>;
 
 			mediatek,led-config = <
@@ -425,7 +429,7 @@
 			>;
 		};
 
-		phy@3 {
+		swphy3: phy@3 {
 			reg = <3>;
 
 			mediatek,led-config = <

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
@@ -286,21 +286,25 @@
 		port@1 {
 			reg = <1>;
 			label = "lan1";
+			phy-handle = <&swphy1>;
 		};
 
 		port@2 {
 			reg = <2>;
 			label = "lan2";
+			phy-handle = <&swphy2>;
 		};
 
 		port@3 {
 			reg = <3>;
 			label = "lan3";
+			phy-handle = <&swphy3>;
 		};
 
 		port@4 {
 			reg = <4>;
 			label = "lan4";
+			phy-handle = <&swphy4>;
 		};
 
 		port@6 {
@@ -321,7 +325,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		phy@1 {
+		swphy1: phy@1 {
 			reg = <1>;
 
 			mediatek,led-config = <
@@ -335,7 +339,7 @@
 			>;
 		};
 
-		phy@2 {
+		swphy2: phy@2 {
 			reg = <2>;
 
 			mediatek,led-config = <
@@ -349,7 +353,7 @@
 			>;
 		};
 
-		phy@3 {
+		swphy3: phy@3 {
 			reg = <3>;
 
 			mediatek,led-config = <
@@ -363,7 +367,7 @@
 			>;
 		};
 
-		phy@4 {
+		swphy4: phy@4 {
 			reg = <4>;
 
 			mediatek,led-config = <

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
@@ -298,21 +298,25 @@
 		port@1 {
 			reg = <4>;
 			label = "lan1";
+			phy-handle = <&swphy1>;
 		};
 
 		port@2 {
 			reg = <3>;
 			label = "lan2";
+			phy-handle = <&swphy2>;
 		};
 
 		port@3 {
 			reg = <2>;
 			label = "lan3";
+			phy-handle = <&swphy3>;
 		};
 
 		port@4 {
 			reg = <1>;
 			label = "lan4";
+			phy-handle = <&swphy4>;
 		};
 
 		port@5 {
@@ -341,7 +345,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		phy@1 {
+		swphy1: phy@1 {
 			reg = <1>;
 
 			mediatek,led-config = <
@@ -355,7 +359,7 @@
 			>;
 		};
 
-		phy@2 {
+		swphy2: phy@2 {
 			reg = <2>;
 
 			mediatek,led-config = <
@@ -369,7 +373,7 @@
 			>;
 		};
 
-		phy@3 {
+		swphy3: phy@3 {
 			reg = <3>;
 
 			mediatek,led-config = <
@@ -383,7 +387,7 @@
 			>;
 		};
 
-		phy@4 {
+		swphy4: phy@4 {
 			reg = <4>;
 
 			mediatek,led-config = <


### PR DESCRIPTION
mediatek: fix DTS defining mt7530 switch phys but not referencing them

The upstream solution to define the MDIO bus in DT is a bit more strict than our previous downstream solution doing the same thing and now requires switch PHYs to be referenced in DT as well.

Arınç Ünal told us in https://github.com/openwrt/openwrt/pull/15141:
"With [the now upstream patch written by him which we backported], the switch MDIO bus won't be assigned to ds->user_mii_bus when the switch MDIO bus is defined on the device tree anymore. This was not the case with the downstream patch.
When ds->user_mii_bus is populated, DSA will 1:1 map the port with PHY. Meaning port with address 1 will be mapped to PHY with address 1. 
Because that ds->user_mii_bus is not populated when the switch MDIO bus is defined on the device tree, on every port node, the PHY address must be supplied by the phy-handle property."

Add those phy-handles to affected devices' DT.

Fixes: https://github.com/openwrt/openwrt/commit/4354b34f6fc5a36842112191732dadd9a2f4bea4 ("generic: 6.6: sync mt7530 DSA driver with upstream")
Fixes: https://github.com/openwrt/openwrt/commit/401a6ccfaf835da0008f1d7a01b7757e063777ff ("generic: 6.1: sync mt7530 DSA driver with upstream")
Signed-off-by: Daniel Golle <daniel@makrotopia.org>