### PR TITLE
uboot-d1: define default BUILD_SUBTARGET

### DIFF
--- a/package/boot/uboot-d1/Makefile
+++ b/package/boot/uboot-d1/Makefile
@@ -19,6 +19,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define U-Boot/Default
   BUILD_TARGET:=d1
+  BUILD_SUBTARGET:=generic
   UBOOT_IMAGE:=u-boot-sunxi-with-spl.bin
   UENV:=default
   DTS_DIR:=arch/riscv/dts


### PR DESCRIPTION
As commit 3ce1e4c3d3da ("d1: define subtarget specifically") added the 'generic' subtarget,
without 'BUILD_SUBTARGET' the correspond U-Boot package will be no longer selected automatically.

Cc: @aparcar @wigyori
