### PR TITLE
CI: labeler: add d1 target

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -30,6 +30,10 @@
   - "package/boot/arm-trusted-firmware-bcm63xx/**"
 "target/bmips":
   - "target/linux/bmips/**"
+"target/d1":
+  - "target/linux/d1/**"
+  - "package/boot/uboot-d1/**"
+  - "package/boot/opensbi/**"
 "target/gemini":
   - "target/linux/gemini/**"
 "target/imx":


### PR DESCRIPTION
Add support for 'd1' target and its specific packages in labeler.
