### PR TITLE
mac80211: ath11k: support DT property to limit channels

### DIFF
--- a/package/kernel/mac80211/patches/ath11k/101-wifi-ath11k-add-support-DT-ieee80211-freq-limit.patch
+++ b/package/kernel/mac80211/patches/ath11k/101-wifi-ath11k-add-support-DT-ieee80211-freq-limit.patch
@@ -1,0 +1,24 @@
+From 1338da257f299d35b4d954b9fda2cc7e0a54a69d Mon Sep 17 00:00:00 2001
+From: Christian Lamparter <chunkeey@gmail.com>
+Date: Sun, 11 Jun 2023 14:37:32 +0200
+Subject: [PATCH] wifi: ath11k: add support DT ieee80211-freq-limit
+
+The common DT property can be used to limit the available
+channels/frequencies. But ath11k has to manually call
+wiphy_read_of_freq_limits().
+
+Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -9455,6 +9455,7 @@ static int __ath11k_mac_register(struct
+ 	if (ret)
+ 		goto err;
+ 
++	wiphy_read_of_freq_limits(ar->hw->wiphy);
+ 	ath11k_mac_setup_ht_vht_cap(ar, cap, &ht_cap);
+ 	ath11k_mac_setup_he_cap(ar, cap);
+ 


### PR DESCRIPTION
Limiting allowed channels per device may be required and is commonly supported on other drivers, so include a pending patch to add support for the same.
