### PR TITLE
[RFC, RFT] base-files: rename ethernet with DT property "label" while preinit

### DIFF
--- a/package/base-files/files/lib/preinit/05_rename_eth
+++ b/package/base-files/files/lib/preinit/05_rename_eth
@@ -1,0 +1,65 @@
+_preinit_find_eth_from_node() {
+	local devnode
+	local netdev
+
+	for netdev in $(ls -d /sys/class/net/*); do
+		# "br-lan", "lo", etc...
+		[ -L "$netdev/of_node" ] || continue
+
+		devnode="$(readlink -f "$netdev/of_node")"
+		[ "$devnode" = "$1" ] && \
+			basename $netdev && \
+			return 0
+	done
+
+	return 1
+}
+
+preinit_rename_eth_with_label() {
+	local basepath="/sys/firmware/devicetree/base"
+	local aliases="$basepath/aliases"
+	local ethlist eth _eth
+	local node
+	local label
+	local netdev
+	local exists
+	local state
+
+	[ -d "$aliases" ] || return
+
+	ethlist="$(ls $aliases/ethernet[0-9] 2>/dev/null)"
+
+	for eth in $ethlist; do
+		node="${basepath}$(cat $eth)"
+		# skip disabled devices
+		[ "$(cat $node/status)" = "disabled" ] && continue
+
+		_eth="$(_preinit_find_eth_from_node "$node")" || continue
+
+		[ ! -r "$node/label" ] && continue
+		label="$(cat $node/label)"
+		[ "$label" = "$_eth" ] && continue
+
+		# check duplicates
+		exists=0
+		for netdev in $(ls -d /sys/class/net/*); do
+			[ "${netdev/*\//}" = "$label" ] && \
+				exists=1 && break
+		done
+		if [ "$exists" = "1" ]; then
+			echo "\"$label\" already exists! (cannot rename from \"$_eth\")"
+			continue
+		fi
+
+		state="$(ip link show dev $_eth | grep -o "state \(UP\|DOWN\)")"
+		[ "${state#* }" = "UP" ] && \
+			ip link set $_eth down
+		if ip link set $_eth name $label; then
+			[ "${state#* }" = "UP" ] && ip link set $label up
+		else
+			[ "${state#* }" = "UP" ] && ip link set $_eth up
+		fi
+	done
+}
+
+boot_hook_add preinit_main preinit_rename_eth_with_label


### PR DESCRIPTION
This is more of just a thought on my part, and I opened it because I wanted to know what the community and team members thought.

---

Rename ethernet adapters registered as "ethernetN" in `aliases {}` node with the value in DT property "label" of that adapter, while preinit. This is useful to distinguish the adapters with the user-friendly names by users.

Note: Disabled ethernet adapters or adapters that has no "label" property will be ignored.

example:

- DeviceTree:

```
/ {
	aliases {
		ethernet0 = &cp0_eth0
		ethernet1 = &cp1_eth1;
	};
};

/* "eth0" */
&cp0_eth0 {
	status = "okay";

	phy-connection-type = "sgmii";
	phys = <&cp0_comphy2 0>;

	fixed-link {
		speed = <1000>; full-duplex; }; };

/* "eth1" */
&cp0_eth1 {
	status = "okay";

	label = "wan";
	phy-connection-type = "sgmii";
	phy-handle = <&ethphy1>;
	phys = <&cp0_comphy0 1>;
};
```

- Result:

  - "eth0": won't be renamed (no "label" property)
  - "eth1": will be renamed to "wan"

