### PR TITLE
iwlwifi-firmware-ax411: Add support for Intel AX411

### DIFF
--- a/package/firmware/linux-firmware/intel.mk
+++ b/package/firmware/linux-firmware/intel.mk
@@ -199,6 +199,14 @@ define Package/iwlwifi-firmware-ax210/install
 endef
 $(eval $(call BuildPackage,iwlwifi-firmware-ax210))
 
+Package/iwlwifi-firmware-ax411 = $(call Package/firmware-default,Intel AX411 firmware)
+define Package/iwlwifi-firmware-ax411/install
+	$(INSTALL_DIR) $(1)/lib/firmware
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-so-a0-gf4-a0-89.ucode $(1)/lib/firmware
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-so-a0-gf4-a0.pnvm $(1)/lib/firmware
+endef
+$(eval $(call BuildPackage,iwlwifi-firmware-ax411))
+
 Package/iwlwifi-firmware-be200 = $(call Package/firmware-default,Intel BE200 firmware)
 define Package/iwlwifi-firmware-be200/install
 	$(INSTALL_DIR) $(1)/lib/firmware


### PR DESCRIPTION
To support the AX411 all we need is the appropriate firmware. This adds the latest supported version and makes the Intel AX411 usable.

Signed-off-by: Joerg Bayer <sg-o@live.de>