### PR TITLE
hostapd: add support for per-device WPS credentials

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -304,7 +304,7 @@ hostapd_common_add_bss_config() {
 
 	config_add_string 'key1:wepkey' 'key2:wepkey' 'key3:wepkey' 'key4:wepkey' 'password:wpakey'
 
-	config_add_string wpa_psk_file
+	config_add_string wpa_psk_file wps_psk_file
 
 	config_add_int multi_ap
 
@@ -672,7 +672,7 @@ hostapd_set_bss_options() {
 			wps_not_configured=1
 		;;
 		psk|sae|psk-sae)
-			json_get_vars key wpa_psk_file
+			json_get_vars key wpa_psk_file wps_psk_file
 			if [ "$auth_type" = "psk" ] && [ "$ppsk" -ne 0 ] ; then
 				json_get_vars auth_secret auth_port
 				set_default auth_port 1812
@@ -692,6 +692,7 @@ hostapd_set_bss_options() {
 				[ -e "$wpa_psk_file" ] || touch "$wpa_psk_file"
 				append bss_conf "wpa_psk_file=$wpa_psk_file" "$N"
 			}
+			[ -n "$wps_psk_file" ] && append bss_conf "#uci_wps_psk_file=/etc/hostapd/$wps_psk_file" "$N"
 			[ "$eapol_version" -ge "1" -a "$eapol_version" -le "2" ] && append bss_conf "eapol_version=$eapol_version" "$N"
 
 			set_default dynamic_vlan 0

--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -689,7 +689,10 @@ hostapd_set_bss_options() {
 			fi
 			[ -z "$wpa_psk_file" ] && set_default wpa_psk_file /var/run/hostapd-$ifname.psk
 			[ -n "$wpa_psk_file" ] && {
-				[ -e "$wpa_psk_file" ] || touch "$wpa_psk_file"
+				[ -e "$wpa_psk_file" ] || {
+					touch "$wpa_psk_file"
+					chown network:network "$wpa_psk_file"
+				}
 				append bss_conf "wpa_psk_file=$wpa_psk_file" "$N"
 			}
 			[ -n "$wps_psk_file" ] && append bss_conf "#uci_wps_psk_file=/etc/hostapd/$wps_psk_file" "$N"

--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -418,6 +418,14 @@ hostapd_set_psk() {
 	for_each_station hostapd_set_psk_file ${ifname}
 }
 
+hostapd_set_wps_psk() {
+	local ifname="$1"
+	local wps_psk_file="$2"
+
+	[ -f /etc/hostapd/${wps_psk_file} ] && \
+		cat /etc/hostapd/${wps_psk_file} >> /var/run/hostapd-${ifname}.psk
+}
+
 append_iw_roaming_consortium() {
 	[ -n "$1" ] && append bss_conf "roaming_consortium=$1" "$N"
 }

--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -639,7 +639,7 @@ mac80211_set_ifname() {
 mac80211_prepare_vif() {
 	json_select config
 
-	json_get_vars ifname mode ssid wds powersave macaddr enable wpa_psk_file vlan_file
+	json_get_vars ifname mode ssid wds powersave macaddr enable wpa_psk_file vlan_file wps_psk_file
 
 	[ -n "$ifname" ] || {
 		local prefix;
@@ -673,6 +673,7 @@ mac80211_prepare_vif() {
 
 	[ "$mode" == "ap" ] && {
 		[ -z "$wpa_psk_file" ] && hostapd_set_psk "$ifname"
+		[ -n "$wps_psk_file" ] && hostapd_set_wps_psk "$ifname" "$wps_psk_file"
 		[ -z "$vlan_file" ] && hostapd_set_vlan "$ifname"
 	}
 

--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -682,6 +682,7 @@ endef
 define Package/hostapd-full/conffiles
 /etc/config/radius
 /etc/radius
+/etc/hostapd
 endef
 
 ifeq ($(CONFIG_VARIANT),full)
@@ -699,7 +700,7 @@ Package/hostapd-mbedtls/conffiles = $(Package/hostapd-full/conffiles)
 endif
 
 define Install/hostapd
-	$(INSTALL_DIR) $(1)/usr/sbin $(1)/usr/share/hostap
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/usr/share/hostap $(1)/etc/hostapd
 	$(INSTALL_DATA) ./files/hostapd.uc $(1)/usr/share/hostap/
 	$(if $(findstring full,$(CONFIG_VARIANT)),$(Install/hostapd/full))
 endef

--- a/package/network/services/hostapd/files/wpad.init
+++ b/package/network/services/hostapd/files/wpad.init
@@ -8,6 +8,7 @@ NAME=wpad
 
 start_service() {
 	if [ -x "/usr/sbin/hostapd" ]; then
+		[ -d /etc/hostapd ] && chown network:network /etc/hostapd
 		mkdir -p /var/run/hostapd
 		chown network:network /var/run/hostapd
 		procd_open_instance hostapd

--- a/package/network/services/hostapd/patches/601-ucode_support.patch
+++ b/package/network/services/hostapd/patches/601-ucode_support.patch
@@ -204,6 +204,17 @@ as adding/removing interfaces.
  void hostapd_new_assoc_sta(struct hostapd_data *hapd, struct sta_info *sta,
  			   int reassoc);
  void hostapd_interface_deinit_free(struct hostapd_iface *iface);
+ --- a/src/ap/wps_hostapd.c
++++ b/src/ap/wps_hostapd.c
+@@ -135,6 +135,8 @@ static int hostapd_wps_new_psk_cb(void *
+ 	p->next = ssid->wpa_psk;
+ 	ssid->wpa_psk = p;
+ 
++	hostapd_ucode_wps_psk_file_notify(hapd, mac_addr, psk, psk_len);
++
+ 	if (ssid->wpa_psk_file) {
+ 		FILE *f;
+ 		char hex[PMK_LEN * 2 + 1];
 --- a/src/drivers/driver.h
 +++ b/src/drivers/driver.h
 @@ -3856,6 +3856,25 @@ struct wpa_driver_ops {

--- a/package/network/services/hostapd/src/src/ap/ucode.c
+++ b/package/network/services/hostapd/src/src/ap/ucode.c
@@ -811,3 +811,52 @@ void hostapd_ucode_free_bss(struct hostapd_data *hapd)
 	ucv_put(wpa_ucode_call(2));
 	ucv_gc(vm);
 }
+
+#ifdef CONFIG_WPS
+void hostapd_ucode_wps_psk_file_notify(struct hostapd_data *hapd,
+				       const u8 *mac_addr, const u8 *psk,
+				       size_t psk_len)
+{
+	char *encryption, mac[ETH_ALEN * 2 + 5 + 1], key[PMK_LEN * 2 + 1];
+	u16 auth_type;
+
+	auth_type = hapd->wps->auth_types;
+	if (auth_type == (WPS_AUTH_WPAPSK | WPS_AUTH_WPA2PSK))
+		auth_type = WPS_AUTH_WPA2PSK;
+
+	if (auth_type != WPS_AUTH_OPEN &&
+	    auth_type != WPS_AUTH_WPAPSK &&
+	    auth_type != WPS_AUTH_WPA2PSK) {
+		wpa_printf(MSG_DEBUG, "WPS: Ignored credentials for "
+			   "unsupported authentication type 0x%x",
+			   auth_type);
+		return;
+	}
+
+	switch (auth_type) {
+		case WPS_AUTH_WPA2PSK:
+			encryption = "psk2";
+			break;
+		case WPS_AUTH_WPAPSK:
+			encryption = "psk";
+			break;
+		default:
+			encryption = "none";
+			break;
+	}
+
+	os_snprintf(mac, ETH_ALEN * 2 + 5 + 1, MACSTR, MAC2STR(mac_addr));
+	wpa_snprintf_hex(key, PMK_LEN * 2 + 1, psk, psk_len);
+
+	if (wpa_ucode_call_prepare("station_wps_psk"))
+		return;
+
+	uc_value_push(ucv_string_new(hapd->conf->iface));
+	uc_value_push(ucv_string_new(encryption));
+	uc_value_push(ucv_string_new(hapd->wps->ssid));
+	uc_value_push(ucv_string_new(mac));
+	uc_value_push(ucv_string_new(key));
+	ucv_put(wpa_ucode_call(5));
+	ucv_gc(vm);
+}
+#endif /* CONFIG_WPS */

--- a/package/network/services/hostapd/src/src/ap/ucode.h
+++ b/package/network/services/hostapd/src/src/ap/ucode.h
@@ -26,6 +26,11 @@ void hostapd_ucode_free_iface(struct hostapd_iface *iface);
 void hostapd_ucode_add_bss(struct hostapd_data *hapd);
 void hostapd_ucode_free_bss(struct hostapd_data *hapd);
 void hostapd_ucode_reload_bss(struct hostapd_data *hapd);
+#ifdef CONFIG_WPS
+void hostapd_ucode_wps_psk_file_notify(struct hostapd_data *hapd,
+				      const u8 *mac_addr, const u8 *psk,
+				      size_t psk_len);
+#endif /* CONFIG_WPS */
 
 #else
 
@@ -48,6 +53,13 @@ static inline void hostapd_ucode_add_bss(struct hostapd_data *hapd)
 static inline void hostapd_ucode_free_bss(struct hostapd_data *hapd)
 {
 }
+#ifdef CONFIG_WPS
+static inline void
+hostapd_ucode_wps_psk_file_notify(struct hostapd_data *hapd, const u8 *mac_addr,
+				 const u8 *psk, size_t psk_len)
+{
+}
+#endif /* CONFIG_WPS */
 
 #endif
 


### PR DESCRIPTION
Introduce new uci option for wifi-iface section, wps_psk_file to
describe where to store the per-device WPS generated PSK.

wps_psk_file option refer just to the filename and not the full path.
Every file will be saved and stored in the /etc/hostapd directory.

Example:

config wifi-iface 'default_radio0'
	option device 'radio0'
	option network 'lan'
	option mode 'ap'
	option ssid 'OpenWrt'
	option encryption 'psk2'
	option key '12345678'
	option wps_pushbutton '1'
	option wps_psk_file 'test.psk'

Will result in all the WPS entry for this section to be stored in
/etc/hostapd/test.psk.

Setting the same wps_psk_file for multiple wifi-iface is allowed and
supported. In such scenario AP will correctly use the same per-device
PSK.

Propagate wps_psk_file uci option to hostapd config to make is usable by
ucode scripts and react on new WPS psk entry.

Since this option is not part of hostapd options, we prefix it with "#"
similar to how is done with other special option like default_mac_addr.

With psk_file set, WPS generates per-device PSK on WPS push-button auth.
These per-device PSK are saved in the psk_file but our current
implementation drop and reset the psk_file at every service restart (or
system reboot) dropping these PSK, causing the station to not reconnect
anymore on the next auth.

Implement ucode to send an event "station_wps_psk", ucode will then
create a file in the path passed from #uci_wps_psk_file in the hostapd
config that will contain strings as they were written
to the .psk file. File is created if it doesn't exit, new entry are
appended if it does already exist.

An example .wps_psk file emitted from this event is:

wps=1 1c:99:57:51:6b:07 95579019c5cb93e63c2fd6cc10b5d13084e8c421bbc3063037c78b1067f19cc1

With psk_file set, WPS push-button auth generates per-device PSK and
such entry are saved in the psk_file in format:

wps=1 MAC_ADDR PSK

We save these entry in section provided uci option wps_psk_file as
permanent storage. Restore these entry and append to the psk file after
each hostapd reload since the psk_file gets reset everytime.
