### PR TITLE
tools: libdeflate: update to 1.20

### DIFF
--- a/tools/libdeflate/Makefile
+++ b/tools/libdeflate/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdeflate
-PKG_VERSION:=1.19
+PKG_VERSION:=1.20
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/ebiggers/libdeflate/releases/download/v$(PKG_VERSION)
-PKG_HASH:=d9bb9bdd8cc5a8c1f7f6226fa0053dd72861e15f366e7ff7d0d191eac16d66f3
+PKG_HASH:=c52cf0239fd644d71c9e88613dd7431a5306ebee1280c5791c71ca264869250a
 
 include $(INCLUDE_DIR)/host-build.mk
 


### PR DESCRIPTION
Changes:
* Improved CRC-32 performance on recent x86 CPUs by adding VPCLMULQDQ-accelerated implementations using 256-bit and 512-bit vectors.

* Improved Adler-32 performance on recent x86 CPUs by adding VNNI-accelerated implementations using 256-bit and 512-bit vectors.

* Improved CRC-32 and Adler-32 performance on short inputs.

* Optimized the portable implementation of Adler-32.

* Added some basic optimizations for RISC-V.

* Dropped support for gcc versions older than v4.9 (released in 2014) and clang versions older than v3.9 (released in 2016).

* Dropped support for CRC-32 acceleration on 32-bit ARM using the ARMv8 pmull or crc32 instructions. This code only worked on CPUs that also have a 64-bit mode, and it was already disabled on many compiler versions due to compiler limitations. CRC-32 acceleration remains fully supported on 64-bit ARM.
