### PR TITLE
ipq40xx: whw03v2: change LED color for 'running' state to blue

### DIFF
--- a/target/linux/ipq40xx/files-6.1/arch/arm/boot/dts/qcom-ipq4019-whw03v2.dts
+++ b/target/linux/ipq40xx/files-6.1/arch/arm/boot/dts/qcom-ipq4019-whw03v2.dts
@@ -13,7 +13,7 @@
 	aliases {
 		led-boot = &led_blue;
 		led-failsafe = &led_red;
-		led-running = &led_green;
+		led-running = &led_blue;
 		led-upgrade = &led_red;
 	};
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-whw03v2.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-whw03v2.dts
@@ -13,7 +13,7 @@
 	aliases {
 		led-boot = &led_blue;
 		led-failsafe = &led_red;
-		led-running = &led_green;
+		led-running = &led_blue;
 		led-upgrade = &led_red;
 	};
 


### PR DESCRIPTION
Change the RGB indicator LED color for the running state from green to blue. There are various reasons for this change:

- In stock firmware, green means internet connection is up, red means it is down, and blue means indeterminate. To track stock behavior as closely as possible, OpenWrt should indicate blue by default.

- In the current 23.x OpenWrt releases for this router, the led glows blue all the time -not green- because the bootloader sets it blue and there is an OpenWrt bug that makes it unable to control the LED. The bug is fixed in master, so without this commit there would be an unexpected change of behavior for this device in the next release.

- The ports other closely related Linksys devices (such as EA8300 and MR8300) get this right and use blue for the running state.