### PR TITLE
bcm27xx: add support for RPI A, A+, 3A+, Zero2 and Zero2W

### DIFF
--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -71,7 +71,7 @@ define Device/Default
 endef
 
 define Device/rpi
-  DEVICE_MODEL := B/B+/CM/Zero/ZeroW
+  DEVICE_MODEL := A/A+/B/B+/CM/Zero/ZeroW
 ifdef CONFIG_LINUX_6_6
   DEVICE_DTS := \
 	broadcom/bcm2708-rpi-b broadcom/bcm2708-rpi-b-rev1 broadcom/bcm2708-rpi-b-plus \
@@ -84,7 +84,11 @@ else
 	bcm2708-rpi-zero bcm2708-rpi-zero-w
 endif
   SUPPORTED_DEVICES := \
-	rpi-b rpi-b-plus rpi-cm rpi-zero rpi-zero-w \
+	rpi-a rpi-a-plus \
+	rpi-b rpi-b-plus \
+	rpi-cm \
+	rpi-zero rpi-zero-w \
+	raspberrypi,model-a raspberrypi,model-a-plus \
 	raspberrypi,model-b raspberrypi,model-b-plus raspberrypi,model-b-rev2 \
 	raspberrypi,compute-module raspberrypi,compute-module-1 \
 	raspberrypi,model-zero raspberrypi,model-zero-w
@@ -101,7 +105,7 @@ define Device/rpi-2
   DEVICE_MODEL := 2B/2B 1.2
   DEVICE_VARIANT := (32bit)
   DEVICE_ALT0_VENDOR := Raspberry Pi
-  DEVICE_ALT0_MODEL := 3B/3B+/CM3
+  DEVICE_ALT0_MODEL := 3A+/3B/3B+/CM3/Zero2/Zero2W
   DEVICE_ALT0_VARIANT := (32bit)
   DEVICE_ALT1_VENDOR := Raspberry Pi
   DEVICE_ALT1_MODEL := 4B/400/CM4
@@ -119,15 +123,21 @@ else
 	bcm2710-rpi-3-b bcm2710-rpi-3-b-plus \
 	bcm2711-rpi-4-b bcm2711-rpi-400 \
 	bcm2710-rpi-cm3 bcm2711-rpi-cm4 \
-	bcm2710-rpi-zero-2
+	bcm2710-rpi-zero-2 bcm2710-rpi-zero-2-w
 endif
   SUPPORTED_DEVICES := \
-	rpi-2-b rpi-3-b rpi-3-b-plus rpi-cm rpi-zero-2 \
+	rpi-2-b \
+	rpi-3-a-plus \
+	rpi-3-b rpi-3-b-plus \
+	rpi-4-b rpi-400 \
+	rpi-cm \
+	rpi-zero-2 rpi-zero-2-w \
 	raspberrypi,2-model-b raspberrypi,2-model-b-rev2 \
+	raspberrypi,3-model-a-plus \
 	raspberrypi,3-model-b raspberrypi,3-model-b-plus \
 	raspberrypi,3-compute-module raspberrypi,compute-module-3 \
 	raspberrypi,400 raspberrypi,4-compute-module raspberrypi,4-model-b \
-	raspberrypi,model-zero-2
+	raspberrypi,model-zero-2 raspberrypi,model-zero-2-w
   DEVICE_PACKAGES := \
 	cypress-firmware-43430-sdio \
 	brcmfmac-nvram-43430-sdio \
@@ -142,7 +152,7 @@ ifeq ($(SUBTARGET),bcm2709)
 endif
 
 define Device/rpi-3
-  DEVICE_MODEL := 3B/3B+/CM3
+  DEVICE_MODEL := 3A+/3B/3B+/CM3/Zero2/Zero2W
   DEVICE_VARIANT := (64bit)
   DEVICE_ALT0_VENDOR := Raspberry Pi
   DEVICE_ALT0_MODEL := 2B-1.2
@@ -152,13 +162,16 @@ define Device/rpi-3
 	broadcom/bcm2710-rpi-2-b \
 	broadcom/bcm2710-rpi-3-b broadcom/bcm2710-rpi-3-b-plus \
 	broadcom/bcm2710-rpi-cm3 \
-	broadcom/bcm2710-rpi-zero-2
+	broadcom/bcm2710-rpi-zero-2 broadcom/bcm2710-rpi-zero-2-w
   SUPPORTED_DEVICES := \
-	rpi-3-b rpi-3-b-plus rpi-zero-2 \
+	rpi-3-a-plus \
+	rpi-3-b rpi-3-b-plus \
+	rpi-zero-2 rpi-zero-2-w \
 	raspberrypi,2-model-b-rev2 \
+	raspberrypi,3-model-a-plus \
 	raspberrypi,3-model-b raspberrypi,3-model-b-plus \
 	raspberrypi,3-compute-module raspberrypi,compute-module-3 \
-	raspberrypi,model-zero-2
+	raspberrypi,model-zero-2 raspberrypi,model-zero-2-w
   DEVICE_PACKAGES := \
 	cypress-firmware-43430-sdio \
 	brcmfmac-nvram-43430-sdio \


### PR DESCRIPTION
These devices were already supported. I merely added missing entries to:
1. make them easier to locate in firmware selector
2. allow firmware upgrades to proceed without dire warnings

Sample dire warning contains:
    upgrade: Device raspberrypi,model-zero-2-w not supported by this image
    upgrade: Supported devices: rpi-3-b rpi-3-b-plus rpi-zero-2 \
      raspberrypi,2-model-b-rev2 raspberrypi,3-model-b \
      raspberrypi,3-model-b-plus raspberrypi,3-compute-module \
      raspberrypi,compute-module-3 raspberrypi,model-zero-2

With this patch, the firmware upgrade proceeds normally.