### PR TITLE
ppp: pppoe.so has no MTU option; remove it

### DIFF
--- a/package/network/services/ppp/files/ppp.sh
+++ b/package/network/services/ppp/files/ppp.sh
@@ -222,9 +222,6 @@ proto_pppoe_setup() {
 
 	/sbin/modprobe -qa slhc ppp_generic pppox pppoe
 
-	json_get_var mtu mtu
-	mtu="${mtu:-1492}"
-
 	json_get_var ac ac
 	json_get_var service service
 	json_get_var host_uniq host_uniq


### PR DESCRIPTION
The underlying device MTU is what matters.

https://www.man7.org/linux/man-pages/man8/pppd.8.html#PPPOE_OPTIONS