### PR TITLE
dropbear: Name pid file by uci section name

### DIFF
--- a/package/network/services/dropbear/files/dropbear.init
+++ b/package/network/services/dropbear/files/dropbear.init
@@ -299,7 +299,7 @@ dropbear_instance()
 	done
 
 	PIDCOUNT="$(( ${PIDCOUNT} + 1))"
-	local pid_file="/var/run/${NAME}.${PIDCOUNT}.pid"
+	local pid_file="/var/run/${NAME}.${1}.pid"
 
 	procd_open_instance
 	procd_set_param command "$PROG" -F -P "$pid_file"


### PR DESCRIPTION
Name the pidfile of each dropbear instance according to the corresponding uci section name. This enables a 1:1 mapping between the definition of the service instance and its process.

Signed-off-by: Andreas Gnau <andreas.gnau@iopsys.eu> [commit message]
