### PR TITLE
[23.05] ipq40xx: whw03v2: enable additional 5 GHz channels

### DIFF
--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -245,3 +245,37 @@ define KernelPackage/input-leds/description
 endef
 
 $(eval $(call KernelPackage,input-leds))
+
+
+define KernelPackage/leds-lp55xx-common
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=LED common driver for LP5521/LP5523/LP55231/LP5562 controllers
+  DEPENDS:=+kmod-i2c-core
+  KCONFIG:=CONFIG_LEDS_LP55XX_COMMON
+  FILES:=$(LINUX_DIR)/drivers/leds/leds-lp55xx-common.ko
+  AUTOLOAD:=$(call AutoLoad,60,leds-lp55xx-common,1)
+endef
+
+define KernelPackage/leds-lp55xx-common/description
+ This option enables support for Texas Instruments
+ LP5521/LP5523/LP55231/LP5562 common driver.
+endef
+
+$(eval $(call KernelPackage,leds-lp55xx-common))
+
+
+define KernelPackage/leds-lp5562
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=LED driver for LP5562 controllers
+  DEPENDS:=+kmod-i2c-core +kmod-leds-lp55xx-common
+  KCONFIG:=CONFIG_LEDS_LP5562
+  FILES:=$(LINUX_DIR)/drivers/leds/leds-lp5562.ko
+  AUTOLOAD:=$(call AutoLoad,60,leds-lp5562,1)
+endef
+
+define KernelPackage/leds-lp5562/description
+ This option enables support for Texas Instruments LP5562
+ LED controllers.
+endef
+
+$(eval $(call KernelPackage,leds-lp5562))

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-whw03v2.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-whw03v2.dts
@@ -488,7 +488,6 @@
 	qcom,coexist-support = <1>;
 	qcom,coexist-gpio-pin = <0x34>;
 
-	ieee80211-freq-limit = <2401000 2473000>;
 	qcom,ath10k-calibration-variant = "linksys-whw03v2";
 
 	nvmem-cell-names = "pre-calibration", "mac-address";
@@ -499,7 +498,7 @@
 &wifi1 {
 	status = "okay";
 
-	ieee80211-freq-limit = <5170000 5250000>;
+	ieee80211-freq-limit = <5170000 5330000>;
 	qcom,ath10k-calibration-variant = "linksys-whw03v2";
 
 	nvmem-cell-names = "pre-calibration", "mac-address";
@@ -510,7 +509,7 @@
 &wifi2 {
 	status = "okay";
 
-	ieee80211-freq-limit = <5735000 5835000>;
+	ieee80211-freq-limit = <5490000 5835000>;
 	qcom,ath10k-calibration-variant = "linksys-whw03v2";
 
 	nvmem-cell-names = "pre-calibration", "mac-address";

--- a/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
+++ b/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
@@ -21,6 +21,10 @@
 		ethernet2 = &dp3;
 		ethernet3 = &dp2;
 		label-mac-device = &dp6_syn;
+		led-boot = &led_system_blue;
+		led-failsafe = &led_system_red;
+		led-running = &led_system_green;
+		led-upgrade = &led_system_blue;
 	};
 
 	chosen {
@@ -77,6 +81,13 @@
 			drive-strength = <8>;
 			bias-pull-up;
 		};
+	};
+
+	i2c_3_pins: i2c-3-state {
+		pins = "gpio46", "gpio47";
+		function = "blsp2_i2c";
+		drive-strength = <8>;
+		bias-disable;
 	};
 };
 
@@ -305,4 +316,42 @@
 	status = "okay";
 
 	qcom,ath11k-calibration-variant = "prpl-Haze";
+};
+
+&blsp1_i2c3{
+	pinctrl-0 = <&i2c_3_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	led-controller@30 {
+		compatible = "ti,lp5562";
+		reg = <0x30>;
+		clock-mode = /bits/ 8 <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		led_system_red: chan@0 {
+			chan-name = "red";
+			led-cur = /bits/ 8 <0x20>;
+			max-cur = /bits/ 8 <0x60>;
+			color = <LED_COLOR_ID_RED>;
+			reg = <0>;
+		};
+
+		led_system_green: chan@1 {
+			chan-name = "green";
+			led-cur = /bits/ 8 <0x20>;
+			max-cur = /bits/ 8 <0x60>;
+			color = <LED_COLOR_ID_GREEN>;
+			reg = <1>;
+		};
+
+		led_system_blue: chan@2 {
+			chan-name = "blue";
+			led-cur = /bits/ 8 <0x20>;
+			max-cur = /bits/ 8 <0x60>;
+			color = <LED_COLOR_ID_BLUE>;
+			reg = <2>;
+		};
+	};
 };

--- a/target/linux/ipq807x/image/generic.mk
+++ b/target/linux/ipq807x/image/generic.mk
@@ -104,7 +104,7 @@ define Device/prpl_haze
 	DEVICE_DTS_CONFIG := config@hk09
 	SOC := ipq8072
 	DEVICE_PACKAGES += ath11k-firmware-qcn9074 ipq-wifi-prpl_haze kmod-ath11k-pci \
-		mkf2fs f2fsck kmod-fs-f2fs
+		mkf2fs f2fsck kmod-fs-f2fs kmod-leds-lp5562
 endef
 TARGET_DEVICES += prpl_haze
 


### PR DESCRIPTION
@robimarko, @Ansuel,

backport of https://github.com/openwrt/openwrt/pull/15056
cherry picked from 1c32cee348f54e9f64b5928ee1a1efe491eec137

thank you!