### PR TITLE
ramips: add Wavlink WL-WN572HG3 router

### DIFF
--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn572hg3.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn572hg3.dts
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "wavlink,wl-wn572hg3", "ralink,mt7620a-soc";
+	model = "Wavlink WL-WN572HG3";
+
+	aliases {
+		label-mac-device = &ethernet;
+		led-boot = &led_status_high;
+		led-failsafe = &led_status_high;
+		led-running = &led_activity_mid;
+		led-upgrade = &led_activity_mid;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led-3 {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_activity_mid: led-4 {
+			function = LED_FUNCTION_ACTIVITY;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_high: led-5 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <24000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+
+					macaddr_factory_28: macaddr@28 {
+						compatible = "mac-base";
+						reg = <0x28 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x790000>;
+			};
+
+			partition@7e0000 {
+				label = "board_data";
+				reg = <0x7e0000 0x10000>;
+				read-only;
+			};
+
+			partition@7f0000 {
+				label = "nvram";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uartf", "ephy", "wled";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii2_pins>, <&mdio_pins>;
+
+	nvmem-cells = <&macaddr_factory_28 0>;
+	nvmem-cell-names = "mac-address";
+
+	mediatek,portmap = "llllw";
+
+	port@4 {
+		status = "okay";
+		phy-handle = <&phy4>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		status = "okay";
+		phy4: ethernet-phy@4 {
+			reg = <4>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&gsw {
+	mediatek,port4-gmac;
+	mediatek,ephy-base = /bits/ 8 <8>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&wmac {
+	pinctrl-names = "default", "pa_gpio";
+	pinctrl-0 = <&pa_pins>;
+	pinctrl-1 = <&pa_gpio_pins>;
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1406,6 +1406,15 @@ define Device/wavlink_wl-wn535k1
 endef
 TARGET_DEVICES += wavlink_wl-wn535k1
 
+define Device/wavlink_wl-wn572hg3
+  SOC := mt7620a
+  IMAGE_SIZE := 7744k
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := WL-WN572HG3
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-phy-realtek
+endef
+TARGET_DEVICES += wavlink_wl-wn572hg3
+
 define Device/wavlink_wl-wn579x3
   SOC := mt7620a
   IMAGE_SIZE := 7744k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -261,6 +261,10 @@ wavlink,wl-wn535k1)
 	ucidef_set_led_switch "lan2" "lan2" "green:lan2" "switch0" "0x04"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
+wavlink,wl-wn572hg3)
+	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x02"
+	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
+	;;
 wavlink,wl-wn579x3)
 	ucidef_set_led_switch "lan" "lan" "blue:lan" "switch0" "0x20"
 	ucidef_set_led_switch "wan" "wan" "blue:wan" "switch0" "0x10"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -268,6 +268,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"2:lan:2" "5:lan:1" "4:wan" "6@eth0"
 		;;
+	wavlink,wl-wn572hg3)
+		ucidef_add_switch "switch0" \
+			"1:lan" "4:wan" "6@eth0"
+		;;
 	wavlink,wl-wn579x3)
 		ucidef_add_switch "switch0" \
 			"5:lan" "4:wan" "6@eth0"
@@ -407,6 +411,7 @@ ramips_setup_macs()
 	lenovo,newifi-y1s|\
 	ohyeah,oy-0001|\
 	wavlink,wl-wn530hg4|\
+	wavlink,wl-wn572hg3|\
 	wevo,air-duo|\
 	youku,x2|\
 	youku,yk-l1|\


### PR DESCRIPTION
Adds support for Wavlink AC 1200 (WL-WN572HG3) router.

Thanks to varu for a lot of work.
See [furum](https://forum.openwrt.org/t/wl-wn572hg3-soft-hack/50890) thread.


### Specifications:
* Soc: MT7620A
* RAM: 64MiB
* Flash: NOR 8MiB GD25Q64B
* Wi-Fi:
  * MT7612E: 5GHz
  * MT7620A: 2.4GHz
* Ethernet: 1x 10/100Mb LAN + 1x 1Gb-WAN
* USB: 1x 2.0 - only used internally
* UART: 57600, 8N1
* LEDs:
  * 7 blue at the front
    * 1 Power (fixed)
    * 2 LAN / WAN
    * 2 WIFI 2.4 / 5 (annotated wifi/low)
    * 2 Status: running / boot,failsafe (annotated mid/high)
* Buttons: 1 reset button
* POE: Passive 24 VDC, 0.5 A

### Installation:
* Set host computer's ip to 192.168.10.100
* save sysupgrade image file as 'firmware.bin'
* setup tftp server on computer, serving the file from root
* connect your computer to the LAN port of the WAVLINK router via an Ethernet cable
* press and hold the reset button while powering on the router
* keep it pressed for ten seconds
* wait for firmware to be uploaded