### PR TITLE
[23.05] Backport CONFIG_WERROR fixes

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1340,3 +1340,19 @@ config KERNEL_UBIFS_FS_SECURITY
 
 config KERNEL_JFFS2_FS_SECURITY
 	bool "JFFS2 Security Labels"
+
+config KERNEL_WERROR
+	bool "Compile the kernel with warnings as errors"
+	default BUILDBOT
+	default y if GCC_USE_VERSION_12
+	help
+	  A kernel build should not cause any compiler warnings, and this
+	  enables the '-Werror' (for C) and '-Dwarnings' (for Rust) flags
+	  to enforce that rule by default. Certain warnings from other tools
+	  such as the linker may be upgraded to errors with this option as
+	  well.
+
+	  However, if you have a new (or very old) compiler or linker with odd
+	  and unusual warnings, or you have some architecture with problems,
+	  you may need to disable this config option in order to
+	  successfully build the kernel.

--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1343,8 +1343,6 @@ config KERNEL_JFFS2_FS_SECURITY
 
 config KERNEL_WERROR
 	bool "Compile the kernel with warnings as errors"
-	default BUILDBOT
-	default y if GCC_USE_VERSION_12
 	help
 	  A kernel build should not cause any compiler warnings, and this
 	  enables the '-Werror' (for C) and '-Dwarnings' (for Rust) flags

--- a/target/linux/generic/config-5.15
+++ b/target/linux/generic/config-5.15
@@ -7476,7 +7476,7 @@ CONFIG_WATCHDOG_OPEN_TIMEOUT=0
 # CONFIG_WD80x3 is not set
 # CONFIG_WDAT_WDT is not set
 # CONFIG_WDTPCI is not set
-CONFIG_WERROR=y
+# CONFIG_WERROR is not set
 # CONFIG_WEXT_CORE is not set
 # CONFIG_WEXT_PRIV is not set
 # CONFIG_WEXT_PROC is not set

--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -16,11 +16,6 @@ choice
 		bool "gcc 13.x"
 endchoice
 
-config GCC_USE_DEFAULT_VERSION
-	bool
-	default y if !TOOLCHAINOPTS || GCC_USE_VERSION_12
-	imply KERNEL_WERROR
-
 config GCC_USE_GRAPHITE
 	bool
 	prompt "Compile in support for the new Graphite framework in GCC 4.4+" if TOOLCHAINOPTS

--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -16,6 +16,11 @@ choice
 		bool "gcc 13.x"
 endchoice
 
+config GCC_USE_DEFAULT_VERSION
+	bool
+	default y if !TOOLCHAINOPTS || GCC_USE_VERSION_12
+	imply KERNEL_WERROR
+
 config GCC_USE_GRAPHITE
 	bool
 	prompt "Compile in support for the new Graphite framework in GCC 4.4+" if TOOLCHAINOPTS

--- a/toolchain/gcc/Config.version
+++ b/toolchain/gcc/Config.version
@@ -11,3 +11,8 @@ config GCC_VERSION
 	default "11.3.0"	if GCC_VERSION_11
 	default "13.1.0"	if GCC_VERSION_13
 	default "12.3.0"
+
+config GCC_USE_DEFAULT_VERSION
+	bool
+	default y if !TOOLCHAINOPTS || GCC_USE_VERSION_12
+	imply KERNEL_WERROR


### PR DESCRIPTION
In commit b2d1eb717b6 ("generic: 5.15: enable Werror by default for kernel compile") `CONFIG_WERROR=y` was enabled and all warnings/errors reported with GCC 12 were fixed.

Keeping this in sync with past/future GCC/kernel versions and config option combinations is going to be uphill battle, so lets backport the `KERNEL_WERROR` config option, which keeps it enabled by default for tested/known working combinations and on buildbots. On the CI its [enabled explicitly](https://github.com/openwrt/actions-shared-workflows/blob/main/.github/workflows/reusable_build.yml#L446-L450).

In other words, it should keep the current behavior, but makes it configurable. 

References: #12687 #12622 #12734 #12713 #15064 

Cc: @robimarko @dangowrt @Ansuel 