### PR TITLE
[23.05] ramips: migrate scripts for Edgerouter X to new layout

### DIFF
--- a/target/linux/ramips/mt7621/base-files/sbin/ubnt_erx_migrate.sh
+++ b/target/linux/ramips/mt7621/base-files/sbin/ubnt_erx_migrate.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+include /lib/upgrade
+
+. /usr/share/libubox/jshn.sh
+
+BOARD="$(board_name | sed 's/,/_/g')"
+
+RC="24.10.0-rc2"
+SITE="https://downloads.openwrt.org/releases/${RC}/targets/ramips/mt7621/"
+PATTERN="${BOARD}-squashfs-sysupgrade.bin"
+FILE=$(wget -qO- "$SITE" | grep -o 'href="[^"]*' | sed 's/href="//' | grep "$PATTERN" | head -n 1)
+tar_file="/tmp/sysupgrade.img"
+
+confirm_migration() {
+    case "$(board_name)" in
+        ubnt,edgerouter-x|\
+        ubnt,edgerouter-x-sfp)
+            compat=$(uci -q get system.@system[0].compat_version)
+            if [ "$compat" != "1.1" ]; then
+                echo "Incompatible compat version $compat" >&2
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Incompatible board $(board_name)" >&2
+            exit 1
+            ;;
+    esac
+
+    echo -e "\033[0;31mWARNING:\033[0m This script will migrate your OpenWrt system to a new layout as"
+    echo "required for the linux 6.6 kernel. This process will erase all your current settings."
+    echo "It is recommended to back up your system before proceeding."
+    echo ""
+
+    read -p "Do you want to proceed with the migration? (y/n)" confirm
+    if [ "$confirm" != "y" ]; then
+        echo "Migration canceled."
+        exit 0
+    fi
+}
+
+download_image(){
+    echo "Downloading $SITE/$FILE"
+    wget -qO "$tar_file" "$SITE/$FILE"
+    sha256=$(wget -qO- "$SITE/sha256sums" | grep "$BOARD-squashfs-sysupgrade.bin" | cut -d ' ' -f1)
+    sha256local=$(sha256sum "$tar_file" | cut -d ' ' -f1)
+    if [ "$sha256" != "$sha256local" ]; then
+            echo "Downloaded image checksum mismatch" >&2
+            exit 1
+    fi
+
+    board_dir=$( (tar tf "$tar_file" | grep -m 1 '^sysupgrade-.*/$') 2> /dev/null)
+    export board_dir="${board_dir%/}"
+
+    tar xC /tmp -f "$tar_file" 2> /dev/null
+    if [ ! -f /tmp/$board_dir/kernel ] || [ ! -f /tmp/$board_dir/root ]; then
+        echo "Invalid image file" >&2
+        exit 1
+    fi
+    cp /sbin/ubnt_erx_stage2.sh /tmp
+
+}
+
+confirm_migration
+download_image
+
+install_bin /sbin/upgraded
+
+RAM_ROOT="/tmp/root"
+COMMAND="sh /tmp/ubnt_erx_stage2.sh"
+
+json_init
+json_add_string prefix "$RAM_ROOT"
+json_add_string path "$tar_file"
+json_add_boolean force 1
+json_add_string command "$COMMAND"
+json_add_object options
+json_add_int save_partitions "$SAVE_PARTITIONS"
+json_close_object
+
+ubus call system sysupgrade "$(json_dump)"
+
+

--- a/target/linux/ramips/mt7621/base-files/sbin/ubnt_erx_stage2.sh
+++ b/target/linux/ramips/mt7621/base-files/sbin/ubnt_erx_stage2.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+include /lib/upgrade
+
+
+# Manually handle kernel partitions
+CI_KERNPART="none"
+
+BOARD="$(board_name | sed 's/,/_/g')"
+tar_file=$IMAGE
+board_dir=$( (tar tf "$tar_file" | grep -m 1 '^sysupgrade-.*/$') 2> /dev/null)
+board_dir="${board_dir%/}"
+
+ubnt_update_kernel_flag() {
+    local UBNT_ERX_KERNEL_INDEX_OFFSET=160
+    local factory_mtd=$(find_mtd_part factory)
+    if [ -z "$factory_mtd" ]; then
+        echo "cannot find factory partition" >&2
+        return 1
+    fi
+
+    local kernel_index=$(hexdump -s $UBNT_ERX_KERNEL_INDEX_OFFSET -n 1 -e '/1 "%X "' ${factory_mtd})
+
+    if [ $kernel_index = "0" ]; then
+        echo "Kernel flag already set to kernel slot 1" >&2
+        return 0
+    fi
+
+    if ! (echo -e "\x00" | dd of=${factory_mtd} bs=1 count=1 seek=$UBNT_ERX_KERNEL_INDEX_OFFSET); then
+        echo 'Failed to update kernel boot index' >&2
+        return 1
+    fi
+}
+
+prepare_kernel(){
+    v "Flashing kernel..."
+    local kernel1_mtd=$(find_mtd_part kernel1)
+    local kernel2_mtd=$(find_mtd_part kernel2)
+    if [ -z "$kernel1_mtd" ] || [ -z "$kernel2_mtd" ]; then
+        echo "cannot find kernel1 or kernel2 partition" >&2
+        exit 1
+    fi
+
+    ubnt_update_kernel_flag || exit 1
+
+    local kernel_file="/tmp/$board_dir/kernel"
+    local kernel_length=$( (cat "$kernel_file" | wc -c) 2> /dev/null)
+    dd if=$kernel_file bs=1024 count=3072 | mtd write - "kernel1"
+    if [ $kernel_length -ge 3145728 ]; then
+        dd if=$kernel_file bs=1024 skip=3072 | mtd write - "kernel2"
+    fi
+}
+
+prepare_rootfs(){
+    v "Flashing rootfs..."
+    local rootfs_file="/tmp/$board_dir/root"
+    local rootfs_length=$( (cat "$rootfs_file" | wc -c) 2> /dev/null)
+    local rootfs_type="$(identify_tar "$tar_file" "$board_dir/root" "")"
+
+    nand_upgrade_prepare_ubi "$rootfs_length" "$rootfs_type" "" "0" || return 1
+
+    local ubidev="$( nand_find_ubi "$CI_UBIPART" )"
+    local root_ubivol="$( nand_find_volume $ubidev "$CI_ROOTPART" )"
+    ubiupdatevol /dev/$root_ubivol -s "$rootfs_length" "$rootfs_file"
+}
+
+prepare_kernel
+prepare_rootfs
+
+v "Rebooting system..."
+
+umount -a
+reboot -f
+sleep 5
+echo b 2>/dev/null >/proc/sysrq-trigger
+


### PR DESCRIPTION
UPDATE: I have reworked this PR to instead include a migration script that can be run to upgrade from 23.05.x -> 24.x, since the below method was not suitable for inclusion in a stable release.


This PR backports required parts from PR #15194, to allow for direct sysupgrade to builds from main or future 24.x where the kernels are greater than 3MB.

The OEM layout on the Edgerouter X has two kernel slots that are 3MB each. Starting with Linux 6.1 the kernel images no longer fit into this layout.

This PR will prepare the Edgerouter X towards using a single kernel slot that is 6MB, this is achieved with the following changes:

- Adjust dts to make kernel1 6MB and drop kernel2 slot
- Patch ubnt.sh to always flash to kernel1 slot (Likewise set the flag in factory partition to make sure kernel1 slot is active)
- Set compat version to 2.0, to ensure the system has the updated ubnt.sh providing support for the new layout.

This backport pre-seeds the dts layout  and `ubnt.sh`  changes, so that on a subsequent sysupgrade the system will be fully converted to single slot 6MB kernel layout. This will allow to directly sysupgrade to builds with larger kernels with no further manual intervention for user.

- The first sysupgrade to this version will switch dts layout to 6MB kernel slot and preintstall `ubnt.sh` change. (kernel could land in either kernel1 or kernel2 slot)
- On the subsequent sysupgrade, kernel will be installed installed to kernel1 slot and system will have been converted to 6MB kernel slot.