### PR TITLE
mediatek: backport PWM drivers

### DIFF
--- a/target/linux/mediatek/patches-6.1/805-v6.5-pwm-mediatek-Add-support-for-MT7981.patch
+++ b/target/linux/mediatek/patches-6.1/805-v6.5-pwm-mediatek-Add-support-for-MT7981.patch
@@ -1,0 +1,147 @@
+From 967da67a745fb73fd0fc7aa61fd197b76fceb273 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Fri, 21 Apr 2023 00:23:21 +0100
+Subject: [PATCH] pwm: mediatek: Add support for MT7981
+
+The PWM unit on MT7981 uses different register offsets than previous
+MediaTek PWM units. Add support for these new offsets and add support
+for PWM on MT7981 which has 3 PWM channels, one of them is typically
+used for a temperature controlled fan.
+While at it, also reorder pwm_mediatek_of_data entries to restore
+alphabetic order.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Reviewed-by: Matthias Brugger <matthias.bgg@gmail.com>
+Signed-off-by: Thierry Reding <thierry.reding@gmail.com>
+---
+ drivers/pwm/pwm-mediatek.c | 39 ++++++++++++++++++++++++++++++--------
+ 1 file changed, 31 insertions(+), 8 deletions(-)
+
+--- a/drivers/pwm/pwm-mediatek.c
++++ b/drivers/pwm/pwm-mediatek.c
+@@ -38,6 +38,7 @@ struct pwm_mediatek_of_data {
+ 	unsigned int num_pwms;
+ 	bool pwm45_fixup;
+ 	bool has_ck_26m_sel;
++	const unsigned int *reg_offset;
+ };
+ 
+ /**
+@@ -59,10 +60,14 @@ struct pwm_mediatek_chip {
+ 	const struct pwm_mediatek_of_data *soc;
+ };
+ 
+-static const unsigned int pwm_mediatek_reg_offset[] = {
++static const unsigned int mtk_pwm_reg_offset_v1[] = {
+ 	0x0010, 0x0050, 0x0090, 0x00d0, 0x0110, 0x0150, 0x0190, 0x0220
+ };
+ 
++static const unsigned int mtk_pwm_reg_offset_v2[] = {
++	0x0080, 0x00c0, 0x0100, 0x0140, 0x0180, 0x01c0, 0x0200, 0x0240
++};
++
+ static inline struct pwm_mediatek_chip *
+ to_pwm_mediatek_chip(struct pwm_chip *chip)
+ {
+@@ -111,7 +116,7 @@ static inline void pwm_mediatek_writel(s
+ 				       unsigned int num, unsigned int offset,
+ 				       u32 value)
+ {
+-	writel(value, chip->regs + pwm_mediatek_reg_offset[num] + offset);
++	writel(value, chip->regs + chip->soc->reg_offset[num] + offset);
+ }
+ 
+ static int pwm_mediatek_config(struct pwm_chip *chip, struct pwm_device *pwm,
+@@ -285,60 +290,77 @@ static const struct pwm_mediatek_of_data
+ 	.num_pwms = 8,
+ 	.pwm45_fixup = false,
+ 	.has_ck_26m_sel = false,
++	.reg_offset = mtk_pwm_reg_offset_v1,
+ };
+ 
+ static const struct pwm_mediatek_of_data mt6795_pwm_data = {
+ 	.num_pwms = 7,
+ 	.pwm45_fixup = false,
+ 	.has_ck_26m_sel = false,
++	.reg_offset = mtk_pwm_reg_offset_v1,
+ };
+ 
+ static const struct pwm_mediatek_of_data mt7622_pwm_data = {
+ 	.num_pwms = 6,
+ 	.pwm45_fixup = false,
+ 	.has_ck_26m_sel = true,
++	.reg_offset = mtk_pwm_reg_offset_v1,
+ };
+ 
+ static const struct pwm_mediatek_of_data mt7623_pwm_data = {
+ 	.num_pwms = 5,
+ 	.pwm45_fixup = true,
+ 	.has_ck_26m_sel = false,
++	.reg_offset = mtk_pwm_reg_offset_v1,
+ };
+ 
+ static const struct pwm_mediatek_of_data mt7628_pwm_data = {
+ 	.num_pwms = 4,
+ 	.pwm45_fixup = true,
+ 	.has_ck_26m_sel = false,
++	.reg_offset = mtk_pwm_reg_offset_v1,
+ };
+ 
+ static const struct pwm_mediatek_of_data mt7629_pwm_data = {
+ 	.num_pwms = 1,
+ 	.pwm45_fixup = false,
+ 	.has_ck_26m_sel = false,
++	.reg_offset = mtk_pwm_reg_offset_v1,
+ };
+ 
+-static const struct pwm_mediatek_of_data mt8183_pwm_data = {
+-	.num_pwms = 4,
++static const struct pwm_mediatek_of_data mt7981_pwm_data = {
++	.num_pwms = 3,
+ 	.pwm45_fixup = false,
+ 	.has_ck_26m_sel = true,
++	.reg_offset = mtk_pwm_reg_offset_v2,
+ };
+ 
+-static const struct pwm_mediatek_of_data mt8365_pwm_data = {
+-	.num_pwms = 3,
++static const struct pwm_mediatek_of_data mt7986_pwm_data = {
++	.num_pwms = 2,
+ 	.pwm45_fixup = false,
+ 	.has_ck_26m_sel = true,
++	.reg_offset = mtk_pwm_reg_offset_v1,
+ };
+ 
+-static const struct pwm_mediatek_of_data mt7986_pwm_data = {
+-	.num_pwms = 2,
++static const struct pwm_mediatek_of_data mt8183_pwm_data = {
++	.num_pwms = 4,
++	.pwm45_fixup = false,
++	.has_ck_26m_sel = true,
++	.reg_offset = mtk_pwm_reg_offset_v1,
++};
++
++static const struct pwm_mediatek_of_data mt8365_pwm_data = {
++	.num_pwms = 3,
+ 	.pwm45_fixup = false,
+ 	.has_ck_26m_sel = true,
++	.reg_offset = mtk_pwm_reg_offset_v1,
+ };
+ 
+ static const struct pwm_mediatek_of_data mt8516_pwm_data = {
+ 	.num_pwms = 5,
+ 	.pwm45_fixup = false,
+ 	.has_ck_26m_sel = true,
++	.reg_offset = mtk_pwm_reg_offset_v1,
+ };
+ 
+ static const struct of_device_id pwm_mediatek_of_match[] = {
+@@ -348,6 +370,7 @@ static const struct of_device_id pwm_med
+ 	{ .compatible = "mediatek,mt7623-pwm", .data = &mt7623_pwm_data },
+ 	{ .compatible = "mediatek,mt7628-pwm", .data = &mt7628_pwm_data },
+ 	{ .compatible = "mediatek,mt7629-pwm", .data = &mt7629_pwm_data },
++	{ .compatible = "mediatek,mt7981-pwm", .data = &mt7981_pwm_data },
+ 	{ .compatible = "mediatek,mt7986-pwm", .data = &mt7986_pwm_data },
+ 	{ .compatible = "mediatek,mt8183-pwm", .data = &mt8183_pwm_data },
+ 	{ .compatible = "mediatek,mt8365-pwm", .data = &mt8365_pwm_data },

--- a/target/linux/mediatek/patches-6.1/806-v6.9-pwm-mediatek-add-support-for-MT7988.patch
+++ b/target/linux/mediatek/patches-6.1/806-v6.9-pwm-mediatek-add-support-for-MT7988.patch
@@ -1,0 +1,44 @@
+From eb58bf4afd708eb3c64c7b9b2c5fbfacdcdee3e5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafa=C5=82=20Mi=C5=82ecki?= <rafal@milecki.pl>
+Date: Wed, 14 Feb 2024 15:04:54 +0100
+Subject: [PATCH] pwm: mediatek: add support for MT7988
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+MT7988 uses new registers layout just like MT7981 but it supports 8 PWM
+interfaces.
+
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
+Reviewed-by: Daniel Golle <daniel@makrotopia.org>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20240214140454.6438-2-zajec5@gmail.com
+Signed-off-by: Uwe Kleine-König <u.kleine-koenig@pengutronix.de>
+---
+ drivers/pwm/pwm-mediatek.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+--- a/drivers/pwm/pwm-mediatek.c
++++ b/drivers/pwm/pwm-mediatek.c
+@@ -342,6 +342,13 @@ static const struct pwm_mediatek_of_data
+ 	.reg_offset = mtk_pwm_reg_offset_v1,
+ };
+ 
++static const struct pwm_mediatek_of_data mt7988_pwm_data = {
++	.num_pwms = 8,
++	.pwm45_fixup = false,
++	.has_ck_26m_sel = false,
++	.reg_offset = mtk_pwm_reg_offset_v2,
++};
++
+ static const struct pwm_mediatek_of_data mt8183_pwm_data = {
+ 	.num_pwms = 4,
+ 	.pwm45_fixup = false,
+@@ -372,6 +379,7 @@ static const struct of_device_id pwm_med
+ 	{ .compatible = "mediatek,mt7629-pwm", .data = &mt7629_pwm_data },
+ 	{ .compatible = "mediatek,mt7981-pwm", .data = &mt7981_pwm_data },
+ 	{ .compatible = "mediatek,mt7986-pwm", .data = &mt7986_pwm_data },
++	{ .compatible = "mediatek,mt7988-pwm", .data = &mt7988_pwm_data },
+ 	{ .compatible = "mediatek,mt8183-pwm", .data = &mt8183_pwm_data },
+ 	{ .compatible = "mediatek,mt8365-pwm", .data = &mt8365_pwm_data },
+ 	{ .compatible = "mediatek,mt8516-pwm", .data = &mt8516_pwm_data },

--- a/target/linux/mediatek/patches-6.6/806-v6.9-pwm-mediatek-add-support-for-MT7988.patch
+++ b/target/linux/mediatek/patches-6.6/806-v6.9-pwm-mediatek-add-support-for-MT7988.patch
@@ -1,0 +1,44 @@
+From eb58bf4afd708eb3c64c7b9b2c5fbfacdcdee3e5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafa=C5=82=20Mi=C5=82ecki?= <rafal@milecki.pl>
+Date: Wed, 14 Feb 2024 15:04:54 +0100
+Subject: [PATCH] pwm: mediatek: add support for MT7988
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+MT7988 uses new registers layout just like MT7981 but it supports 8 PWM
+interfaces.
+
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
+Reviewed-by: Daniel Golle <daniel@makrotopia.org>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20240214140454.6438-2-zajec5@gmail.com
+Signed-off-by: Uwe Kleine-König <u.kleine-koenig@pengutronix.de>
+---
+ drivers/pwm/pwm-mediatek.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+--- a/drivers/pwm/pwm-mediatek.c
++++ b/drivers/pwm/pwm-mediatek.c
+@@ -341,6 +341,13 @@ static const struct pwm_mediatek_of_data
+ 	.reg_offset = mtk_pwm_reg_offset_v1,
+ };
+ 
++static const struct pwm_mediatek_of_data mt7988_pwm_data = {
++	.num_pwms = 8,
++	.pwm45_fixup = false,
++	.has_ck_26m_sel = false,
++	.reg_offset = mtk_pwm_reg_offset_v2,
++};
++
+ static const struct pwm_mediatek_of_data mt8183_pwm_data = {
+ 	.num_pwms = 4,
+ 	.pwm45_fixup = false,
+@@ -371,6 +378,7 @@ static const struct of_device_id pwm_med
+ 	{ .compatible = "mediatek,mt7629-pwm", .data = &mt7629_pwm_data },
+ 	{ .compatible = "mediatek,mt7981-pwm", .data = &mt7981_pwm_data },
+ 	{ .compatible = "mediatek,mt7986-pwm", .data = &mt7986_pwm_data },
++	{ .compatible = "mediatek,mt7988-pwm", .data = &mt7988_pwm_data },
+ 	{ .compatible = "mediatek,mt8183-pwm", .data = &mt8183_pwm_data },
+ 	{ .compatible = "mediatek,mt8365-pwm", .data = &mt8365_pwm_data },
+ 	{ .compatible = "mediatek,mt8516-pwm", .data = &mt8516_pwm_data },


### PR DESCRIPTION
 * MT7981 and MT7988 backported to Linux 6.1
 * MT7988 backported to Linux 6.6