### PR TITLE
build: fix version info in cyclonedx sbom

### DIFF
--- a/scripts/package-metadata.pl
+++ b/scripts/package-metadata.pl
@@ -722,7 +722,7 @@ sub gen_image_cyclonedxsbom() {
 		if ($image_packages{$name}) {
 			$version = $image_packages{$name};
 		}
-		$version =~ s/-\d+$// if $version;
+		$version =~ s/-r\d+$// if $version;
 		if ($name =~ /^(kernel|kmod-)/ and $version =~ /^(\d+\.\d+\.\d+)/) {
 			$version = $1;
 		}
@@ -775,7 +775,7 @@ sub gen_package_cyclonedxsbom() {
 		}
 
 		my $version = $pkg->{version};
-		$version =~ s/-\d+$// if $version;
+		$version =~ s/-r\d+$// if $version;
 		if ($name =~ /^(kernel|kmod-)/ and $version =~ /^(\d+\.\d+\.\d+)/) {
 			$version = $1;
 		}


### PR DESCRIPTION
Prior e8725a932e16eaf6ec51add8c084d959cbe32ff2, version used to be VERSION:=$(PKG_VERSION)-$(PKG_RELEASE)
After e8725a932e16eaf6ec51add8c084d959cbe32ff2, the version is: VERSION:=$(PKG_VERSION)-r$(PKG_RELEASE)

Hence the gen_*_cyclonedxsbom functions need to be updated to remove the trailing -r prefix in the version in order to generate correct version info in the SBOM.