### PR TITLE
mediatek: add support for Cudy TR3000 v1

### DIFF
--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -5,6 +5,7 @@ set_preinit_iface() {
 		ip link set lan up
 		ifname=lan
 		;;
+	cudy,tr3000-v1|\
 	glinet,gl-mt3000)
 		ip link set eth1 up
 		ifname=eth1

--- a/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "Cudy TR3000 v1";
+	compatible = "cudy,tr3000-v1", "mediatek,mt7981-spim-snand-rfb";
+
+	aliases {
+		label-mac-device = &gmac1;
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		mode {
+			label = "mode";
+			linux,input-type = <EV_SW>;
+			linux,code = <BTN_0>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: led_0 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_1 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	usb_vbus: regulator-usb {
+		compatible = "regulator-fixed";
+
+		regulator-name = "usb-vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&pio 9 GPIO_ACTIVE_LOW>;
+		regulator-boot-on;
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy1>;
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_bdinfo_de00 1>;
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_bdinfo_de00 0>;
+	};
+};
+
+&mdio_bus {
+	phy1: phy@1 {
+		reg = <1>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		phy-mode = "2500base-x";
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+		interrupts = <38 IRQ_TYPE_LEVEL_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <100000>;
+		realtek,aldps-enable;
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00000 0x0100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+				read-only;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x0200000>;
+				read-only;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "bdinfo";
+				reg = <0x380000 0x0040000>;
+				read-only;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_bdinfo_de00: macaddr@de00 {
+						compatible = "mac-base";
+						reg = <0xde00 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+
+			};
+
+			partition@3C0000 {
+				label = "FIP";
+				reg = <0x3C0000 0x0200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x5C0000 0x4000000>;
+				compatible = "linux,ubi";
+			};
+		};
+	};
+};
+
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+	vbus-supply = <&usb_vbus>;
+};
+
+&wifi {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -56,6 +56,7 @@ mediatek_setup_interfaces()
 	dlink,aquila-pro-ai-m30-a1)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" internet
 		;;
+	cudy,tr3000-v1|\
 	glinet,gl-mt2500|\
 	glinet,gl-mt3000|\
 	glinet,gl-x3000|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -69,6 +69,7 @@ case "$board" in
 		addr=$(mtd_get_mac_binary "Factory" 0x8000)
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
 		;;
+	cudy,tr3000-v1|\
 	cudy,re3000-v1)
 		addr=$(mtd_get_mac_binary bdinfo 0xde00)
 		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -485,6 +485,23 @@ define Device/cudy_re3000-v1
 endef
 TARGET_DEVICES += cudy_re3000-v1
 
+define Device/cudy_tr3000-v1
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := TR3000
+  DEVICE_VARIANT := v1
+  DEVICE_DTS := mt7981b-cudy-tr3000-v1
+  DEVICE_DTS_DIR := ../dts
+  SUPPORTED_DEVICES += R47
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  KERNEL_IN_UBI := 1
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7981-firmware mt7981-wo-firmware
+endef
+TARGET_DEVICES += cudy_tr3000-v1
+
 define Device/cudy_wr3000-v1
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := WR3000


### PR DESCRIPTION
Commit message:
```
Hardware:
 - SoC: MediaTek MT7981B
 - CPU: 2x 1.3 GHz Cortex-A53
 - Flash: 128 MiB SPI NAND
 - RAM: 512 MiB
 - WLAN: 2.4 GHz, 5 GHz (MediaTek MT7976CN, 802.11ax)
 - Ethernet: 1x 10/100/1000/2500 Mbps RTL8221B WAN, 1x10/100/1000 Mbps MT7981 LAN
 - USB 3.0 port
 - Buttons: 1 Reset button, 1 VPN slider
 - LEDs: 1x Red, 1x White
 - Serial console: internal test points, 115200 8n1
 - Power: 5 VDC, 3 A

MAC addresses:
+---------+-------------------+-----------+
|         | MAC               | Algorithm |
+---------+-------------------+-----------+
| WAN     | 80:af:ca:xx:xx:x1 | label+1   |
| LAN     | 80:af:ca:xx:xx:x0 | label     |
| WLAN 2g | 80:af:ca:xx:xx:x0 | label     |
| WLAN 5g | 82:af:ca:xx:xx:x0 |           |
+---------+-------------------+-----------+

Installation:
The installation must be done via TFTP by disassembling the router. On other occasions Cudy has distributed intermediate firmware to make installation easier, and so I recommend checking the Wiki for this device if there is a more convenient solution than the one below.

To install using TFTP:
1. Connect to UART.
2. With the router off, press the RESET button. While the router is turning on, the button should continue to be pressed for at least 5 seconds.
3. A u-boot shell will automatically open.
4. Connect to LAN and set your IP to 192.168.1.88/24. Configure a TFTP server and an OpenWrt initramfs-kernel.bin firmware file.
5. Run these steps in u-boot using the name of your file.

setenv bootfile initramfs-kernel.bin
tftpboot
bootm

6. If you can reach LuCI or SSH now, just use the sysupgrade image with the 'Keep settings' option turned off.

```

Tested:
- Linux boot
- UART
- Ethernet WAN (including correct MAC)
- Ethernet LAN (including correct MAC)
- Wi-Fi 2.4GHz, 5GHz (including correct MAC)
- USB Power & Data
- LEDs
- SPI Flash
- Failsafe
- Configurable slider