### PR TITLE
realtek: support EnGenius EWS2910P v3

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -91,7 +91,7 @@ d-link,dgs-1210-28p-f)
 	ucidef_set_poe 193 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
 			lan22 lan21 lan20 lan19 lan18 lan17"
 	;;
-engenius,ews2910p)
+engenius,ews2910p-v1)
 	ucidef_set_poe 60 "$(filter_port_list "$lan_list" "lan9 lan10")"
 	;;
 hpe,1920-8g-poe-65w)

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -91,7 +91,8 @@ d-link,dgs-1210-28p-f)
 	ucidef_set_poe 193 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
 			lan22 lan21 lan20 lan19 lan18 lan17"
 	;;
-engenius,ews2910p-v1)
+engenius,ews2910p-v1|\
+engenius,ews2910p-v3)
 	ucidef_set_poe 60 "$(filter_port_list "$lan_list" "lan9 lan10")"
 	;;
 hpe,1920-8g-poe-65w)

--- a/target/linux/realtek/dts/rtl8380_engenius_ews2910p-v1.dts
+++ b/target/linux/realtek/dts/rtl8380_engenius_ews2910p-v1.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_engenius_ews2910p.dtsi"
+
+/ {
+	compatible = "engenius,ews2910p-v1", "realtek,rtl838x-soc";
+	model = "EnGenius EWS2910P v1";
+};
+
+&firmware_partition_1 {
+	compatible = "openwrt,uimage";
+	openwrt,ih-magic = <0x03802910>;
+};

--- a/target/linux/realtek/dts/rtl8380_engenius_ews2910p-v3.dts
+++ b/target/linux/realtek/dts/rtl8380_engenius_ews2910p-v3.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_engenius_ews2910p.dtsi"
+
+/ {
+	compatible = "engenius,ews2910p-v3", "realtek,rtl838x-soc";
+	model = "EnGenius EWS2910P v3";
+};
+
+&firmware_partition_1 {
+	compatible = "openwrt,uimage";
+	openwrt,ih-magic = <0x03010500>;
+};

--- a/target/linux/realtek/dts/rtl8380_engenius_ews2910p.dtsi
+++ b/target/linux/realtek/dts/rtl8380_engenius_ews2910p.dtsi
@@ -7,9 +7,6 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
-	compatible = "engenius,ews2910p", "realtek,rtl838x-soc";
-	model = "EnGenius EWS2910P";
-
 	aliases {
 		led-boot = &led_power;
 		led-failsafe = &led_fault;
@@ -165,13 +162,11 @@
 				label = "jffs2-log";
 				reg = <0xe00000 0x200000>;
 			};
-			partition@1000000 {
-				compatible = "openwrt,uimage";
+			firmware_partition_1: partition@1000000 {
 				label = "firmware";
 				reg = <0x1000000 0x800000>;
-				openwrt,ih-magic = <0x03802910>;
 			};
-			partition@1800000 {
+			firmware_partition_2: partition@1800000 {
 				label = "firmware2";
 				reg = <0x1800000 0x800000>;
 			};

--- a/target/linux/realtek/image/common.mk
+++ b/target/linux/realtek/image/common.mk
@@ -31,6 +31,18 @@ define Device/d-link_dgs-1210
   CAMEO_BOARD_VERSION := 32
 endef
 
+# The "IMG-" uImage name allows flashing the iniramfs from the vendor Web UI.
+# Avoided for sysupgrade, as the vendor FW would do an incomplete flash.
+define Device/engenius_ews2910p
+  IMAGE_SIZE := 8192k
+  DEVICE_VENDOR := EnGenius
+  KERNEL_INITRAMFS := \
+	kernel-bin | \
+	append-dtb | \
+	libdeflate-gzip | \
+	uImage gzip -n 'IMG-0.00.00-c0.0.00'
+endef
+
 define Device/hpe_1920
   DEVICE_VENDOR := HPE
   IMAGE_SIZE := 29632k

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -102,6 +102,15 @@ define Device/engenius_ews2910p-v1
 endef
 TARGET_DEVICES += engenius_ews2910p-v1
 
+define Device/engenius_ews2910p-v3
+  $(Device/engenius_ews2910p)
+  SOC := rtl8380
+  DEVICE_MODEL := EWS2910P
+  DEVICE_VARIANT := v3
+  UIMAGE_MAGIC := 0x03010500
+endef
+TARGET_DEVICES += engenius_ews2910p-v3
+
 define Device/hpe_1920-8g
   $(Device/hpe_1920)
   SOC := rtl8380

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -91,22 +91,16 @@ define Device/d-link_dgs-1210-28p-f
 endef
 TARGET_DEVICES += d-link_dgs-1210-28p-f
 
-# The "IMG-" uImage name allows flashing the iniramfs from the vendor Web UI.
-# Avoided for sysupgrade, as the vendor FW would do an incomplete flash.
-define Device/engenius_ews2910p
+define Device/engenius_ews2910p-v1
+  $(Device/engenius_ews2910p)
   SOC := rtl8380
-  IMAGE_SIZE := 8192k
-  DEVICE_VENDOR := EnGenius
   DEVICE_MODEL := EWS2910P
+  DEVICE_VARIANT := v1
   DEVICE_PACKAGES += realtek-poe
   UIMAGE_MAGIC := 0x03802910
-  KERNEL_INITRAMFS := \
-	kernel-bin | \
-	append-dtb | \
-	libdeflate-gzip | \
-	uImage gzip -n 'IMG-0.00.00-c0.0.00'
+  SUPPORTED_DEVICES += engenius,ews2910p
 endef
-TARGET_DEVICES += engenius_ews2910p
+TARGET_DEVICES += engenius_ews2910p-v1
 
 define Device/hpe_1920-8g
   $(Device/hpe_1920)


### PR DESCRIPTION
Add support for V3 of the Engenius EWS2910P PoE switch. Like its v1
brother, This is an RTL8380 based switch with two SFP slots, and PoE
802.3af one every RJ-45 port.

Unlike its older brother, the max budget is 55W instead of 61.6 W.
Investigation into the communication protocol with the PoE controller
is ongoing, though it appears the vendor firmware configures the PSE
with a per-port budget of 30.0W.

Specifications:
---------------
* SoC:       Realtek RTL8380M
* Flash:     32 MiB SPI flash Macronix MX25L25635E
* RAM:       256 MiB (As reported by bootloader)
* Ethernet:  16x 10/100/1000 Mbps with PoE
              2x SFP slots
* Buttons:   1 "Reset" button on front panel
             1 "LED mode: button on front panel
             1 "On/Off" Toggle switch on the back
* Power:     48V-54V DC barrel jack
* UART:      1 serial header (JP1) with populated 2.54mm pitch header
             Labeled GRTV for ground, rx, tx, and 3.3V respectively
* PoE:       1 STM ST32... microcontroller (U15)
             1 RTL8238B PSE controller
Works:
------
  - (8) RJ-45 ethernet ports
  - Switch functions
  - LEDs and buttons

Not yet enabled:
----------------
  - Power-over-Ethernet (requires realtek-poe support for RTL8232B)

Install via web interface:
-------------------------

The factory firmware will accept and flash the initramfs image. It is
recommended to flash to "Partition 0". Flashing to "Partition 1" is
not supported at this point.

The factory web GUI will show the following warning:

 " Warning: The firmware version is v0.00.00-c0.0.00
     The firmware image you are uploading is older than the current
     firmware of the switch. The device will reset back to default
     settings. Are you sure you want to proceed?"

This is expected when flashing OpenWrt. After the initramfs image
boots, flash the -sysupgrade using either the commandline or LuCI.

Install via serial console/tftp:
--------------------------------

See commit 2cfaab4549f5 ("realtek: add support for EnGenius EWS2910P").
