### PR TITLE
mediatek: filogic: add Adtran SmartRG Mount Stuart series

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -109,6 +109,11 @@ openembed,som7981)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x80000"
 	ubootenv_add_uci_sys_config "/dev/mtd3" "0x0" "0x100000" "0x100000"
 	;;
+smartrg,sdg-8733|\
+smartrg,sdg-8734)
+	local envdev=$(find_mmc_part "u-boot-env" "mmcblk0")
+	ubootenv_add_uci_config "$envdev" "0x0" "0x8000" "0x8000"
+	;;
 ubnt,unifi-6-plus)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x10000"
 	;;

--- a/target/linux/generic/hack-6.6/722-net-phy-aquantia-enable-AQR112-and-AQR412.patch
+++ b/target/linux/generic/hack-6.6/722-net-phy-aquantia-enable-AQR112-and-AQR412.patch
@@ -15,9 +15,9 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
 
 --- a/drivers/net/phy/aquantia/aquantia_main.c
 +++ b/drivers/net/phy/aquantia/aquantia_main.c
-@@ -102,6 +102,29 @@
- #define AQR107_OP_IN_PROG_SLEEP		1000
- #define AQR107_OP_IN_PROG_TIMEOUT	100000
+@@ -127,6 +127,29 @@ struct aqr107_priv {
+ 	u64 sgmii_stats[AQR107_SGMII_STAT_SZ];
+ };
  
 +/* registers in MDIO_MMD_VEND1 region */
 +#define AQUANTIA_VND1_GLOBAL_SC			0x000
@@ -42,9 +42,9 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
 +#define AQUANTIA_VND1_GSYSCFG_5G		3
 +#define AQUANTIA_VND1_GSYSCFG_10G		4
 +
- struct aqr107_hw_stat {
- 	const char *name;
- 	int reg;
+ static int aqr107_get_sset_count(struct phy_device *phydev)
+ {
+ 	return AQR107_SGMII_STAT_SZ;
 @@ -233,6 +256,51 @@ static int aqr_config_aneg(struct phy_de
  	return genphy_c45_check_and_restart_aneg(phydev, changed);
  }
@@ -97,7 +97,7 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
  static int aqr_config_intr(struct phy_device *phydev)
  {
  	bool en = phydev->interrupts == PHY_INTERRUPT_ENABLED;
-@@ -810,7 +878,7 @@ static struct phy_driver aqr_driver[] =
+@@ -838,7 +906,7 @@ static struct phy_driver aqr_driver[] =
  	PHY_ID_MATCH_MODEL(PHY_ID_AQR112),
  	.name		= "Aquantia AQR112",
  	.probe		= aqr107_probe,
@@ -106,7 +106,7 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
  	.config_intr	= aqr_config_intr,
  	.handle_interrupt = aqr_handle_interrupt,
  	.get_tunable    = aqr107_get_tunable,
-@@ -828,7 +896,7 @@ static struct phy_driver aqr_driver[] =
+@@ -863,7 +931,7 @@ static struct phy_driver aqr_driver[] =
  	PHY_ID_MATCH_MODEL(PHY_ID_AQR412),
  	.name		= "Aquantia AQR412",
  	.probe		= aqr107_probe,

--- a/target/linux/generic/hack-6.6/725-net-phy-aquantia-add-PHY_IDs-for-AQR112-variants.patch
+++ b/target/linux/generic/hack-6.6/725-net-phy-aquantia-add-PHY_IDs-for-AQR112-variants.patch
@@ -21,9 +21,9 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  #define MDIO_PHYXS_VEND_IF_STATUS		0xe812
  #define MDIO_PHYXS_VEND_IF_STATUS_TYPE_MASK	GENMASK(7, 3)
-@@ -992,6 +994,30 @@ static struct phy_driver aqr_driver[] =
- 	.get_stats	= aqr107_get_stats,
- 	.link_change_notify = aqr107_link_change_notify,
+@@ -1062,6 +1064,30 @@ static struct phy_driver aqr_driver[] =
+ 	.led_polarity_set = aqr_phy_led_polarity_set,
+ #endif
  },
 +{
 +	PHY_ID_MATCH_MODEL(PHY_ID_AQR112C),
@@ -52,7 +52,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  };
  
  module_phy_driver(aqr_driver);
-@@ -1012,6 +1038,8 @@ static struct mdio_device_id __maybe_unu
+@@ -1082,6 +1108,8 @@ static struct mdio_device_id __maybe_unu
  	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR113C) },
  	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR114C) },
  	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR813) },

--- a/target/linux/generic/pending-6.6/743-net-phy-aquantia-add-support-for-PHY-LEDs.patch
+++ b/target/linux/generic/pending-6.6/743-net-phy-aquantia-add-support-for-PHY-LEDs.patch
@@ -1,0 +1,368 @@
+From c6a1759365fc35463138a7d9e335ee53f384b8df Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Fri, 10 May 2024 02:53:52 +0100
+Subject: [PATCH] net: phy: aquantia: add support for PHY LEDs
+
+Aquantia Ethernet PHYs got 3 LED output pins which are typically used
+to indicate link status and activity.
+Add a minimal LED controller driver supporting the most common uses
+with the 'netdev' trigger as well as software-driven forced control of
+the LEDs.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ drivers/net/phy/aquantia/Makefile        |   3 +
+ drivers/net/phy/aquantia/aquantia.h      |  84 +++++++++++++
+ drivers/net/phy/aquantia/aquantia_leds.c | 152 +++++++++++++++++++++++
+ drivers/net/phy/aquantia/aquantia_main.c | 127 +++++++++++++------
+ 4 files changed, 329 insertions(+), 37 deletions(-)
+ create mode 100644 drivers/net/phy/aquantia/aquantia_leds.c
+
+--- a/drivers/net/phy/aquantia/Makefile
++++ b/drivers/net/phy/aquantia/Makefile
+@@ -3,4 +3,7 @@ aquantia-objs			+= aquantia_main.o aquan
+ ifdef CONFIG_HWMON
+ aquantia-objs			+= aquantia_hwmon.o
+ endif
++ifdef CONFIG_PHYLIB_LEDS
++aquantia-objs			+= aquantia_leds.o
++endif
+ obj-$(CONFIG_AQUANTIA_PHY)	+= aquantia.o
+--- a/drivers/net/phy/aquantia/aquantia.h
++++ b/drivers/net/phy/aquantia/aquantia.h
+@@ -62,6 +62,26 @@
+ #define VEND1_THERMAL_PROV_LOW_TEMP_FAIL	0xc422
+ #define VEND1_THERMAL_PROV_HIGH_TEMP_WARN	0xc423
+ #define VEND1_THERMAL_PROV_LOW_TEMP_WARN	0xc424
++
++#define AQR_NUM_LEDS				3
++
++#define VEND1_GLOBAL_LED_PROV			0xc430
++#define AQR_LED_PROV(x)				(VEND1_GLOBAL_LED_PROV + x)
++#define VEND1_GLOBAL_LED_PROV_ACT_STRETCH	GENMASK(0, 1)
++#define VEND1_GLOBAL_LED_PROV_TX_ACT		BIT(2)
++#define VEND1_GLOBAL_LED_PROV_RX_ACT		BIT(3)
++#define VEND1_GLOBAL_LED_PROV_LINK_MASK		(GENMASK(15, 14) | GENMASK(8, 5))
++#define VEND1_GLOBAL_LED_PROV_LINK100		BIT(5)
++#define VEND1_GLOBAL_LED_PROV_LINK1000		BIT(6)
++#define VEND1_GLOBAL_LED_PROV_LINK10000		BIT(7)
++#define VEND1_GLOBAL_LED_PROV_FORCE_ON		BIT(8)
++#define VEND1_GLOBAL_LED_PROV_LINK2500		BIT(14)
++#define VEND1_GLOBAL_LED_PROV_LINK5000		BIT(15)
++
++#define VEND1_GLOBAL_LED_DRIVE			0xc438
++#define VEND1_GLOBAL_LED_DRIVE_VDD		BIT(1)
++#define AQR_LED_DRIVE(x)			(VEND1_GLOBAL_LED_DRIVE + x)
++
+ #define VEND1_THERMAL_STAT1			0xc820
+ #define VEND1_THERMAL_STAT2			0xc821
+ #define VEND1_THERMAL_STAT2_VALID		BIT(0)
+@@ -115,3 +135,23 @@ static inline int aqr_hwmon_probe(struct
+ #endif
+ 
+ int aqr_firmware_load(struct phy_device *phydev);
++
++#if IS_ENABLED(CONFIG_PHYLIB_LEDS)
++int aqr_phy_led_blink_set(struct phy_device *phydev, u8 index,
++			 unsigned long *delay_on,
++			 unsigned long *delay_off);
++
++int aqr_phy_led_brightness_set(struct phy_device *phydev,
++			       u8 index, enum led_brightness value);
++
++int aqr_phy_led_hw_is_supported(struct phy_device *phydev, u8 index,
++				unsigned long rules);
++
++int aqr_phy_led_hw_control_get(struct phy_device *phydev, u8 index,
++			       unsigned long *rules);
++
++int aqr_phy_led_hw_control_set(struct phy_device *phydev, u8 index,
++			       unsigned long rules);
++
++int aqr_phy_led_polarity_set(struct phy_device *phydev, int index, unsigned long modes);
++#endif
+--- /dev/null
++++ b/drivers/net/phy/aquantia/aquantia_leds.c
+@@ -0,0 +1,140 @@
++// SPDX-License-Identifier: GPL-2.0
++/* LED driver for Aquantia PHY
++ *
++ * Author: Daniel Golle <daniel@makrotopia.org>
++ */
++
++#include <linux/phy.h>
++
++#include "aquantia.h"
++
++int aqr_phy_led_brightness_set(struct phy_device *phydev,
++			       u8 index, enum led_brightness value)
++{
++	if (index > 2)
++		return -EINVAL;
++
++	return phy_modify_mmd(phydev, MDIO_MMD_VEND1, AQR_LED_PROV(index), VEND1_GLOBAL_LED_PROV_LINK_MASK |
++						    VEND1_GLOBAL_LED_PROV_FORCE_ON |
++						    VEND1_GLOBAL_LED_PROV_RX_ACT |
++						    VEND1_GLOBAL_LED_PROV_TX_ACT,
++						    value ? VEND1_GLOBAL_LED_PROV_FORCE_ON : 0);
++}
++
++static const unsigned long supported_triggers = (BIT(TRIGGER_NETDEV_LINK)        |
++						 BIT(TRIGGER_NETDEV_LINK_100)    |
++						 BIT(TRIGGER_NETDEV_LINK_1000)   |
++						 BIT(TRIGGER_NETDEV_LINK_2500)   |
++						 BIT(TRIGGER_NETDEV_LINK_5000)   |
++						 BIT(TRIGGER_NETDEV_LINK_10000)  |
++						 BIT(TRIGGER_NETDEV_RX)          |
++						 BIT(TRIGGER_NETDEV_TX));
++
++int aqr_phy_led_hw_is_supported(struct phy_device *phydev, u8 index,
++				unsigned long rules)
++{
++	if (index >= AQR_NUM_LEDS)
++		return -EINVAL;
++
++	/* All combinations of the supported triggers are allowed */
++	if (rules & ~supported_triggers)
++		return -EOPNOTSUPP;
++
++	return 0;
++}
++
++int aqr_phy_led_hw_control_get(struct phy_device *phydev, u8 index,
++			       unsigned long *rules)
++{
++	int val;
++
++	if (index >= AQR_NUM_LEDS)
++		return -EINVAL;
++
++	val = phy_read_mmd(phydev, MDIO_MMD_VEND1, AQR_LED_PROV(index));
++	if (val < 0)
++		return val;
++
++	*rules = 0;
++	if (val & VEND1_GLOBAL_LED_PROV_LINK100)
++		*rules |= BIT(TRIGGER_NETDEV_LINK_100);
++
++	if (val & VEND1_GLOBAL_LED_PROV_LINK1000)
++		*rules |= BIT(TRIGGER_NETDEV_LINK_1000);
++
++	if (val & VEND1_GLOBAL_LED_PROV_LINK2500)
++		*rules |= BIT(TRIGGER_NETDEV_LINK_2500);
++
++	if (val & VEND1_GLOBAL_LED_PROV_LINK5000)
++		*rules |= BIT(TRIGGER_NETDEV_LINK_5000);
++
++	if (val & VEND1_GLOBAL_LED_PROV_LINK10000)
++		*rules |= BIT(TRIGGER_NETDEV_LINK_10000);
++
++	if (val & VEND1_GLOBAL_LED_PROV_RX_ACT)
++		*rules |= BIT(TRIGGER_NETDEV_RX);
++
++	if (val & VEND1_GLOBAL_LED_PROV_TX_ACT)
++		*rules |= BIT(TRIGGER_NETDEV_TX);
++
++	return 0;
++}
++
++int aqr_phy_led_hw_control_set(struct phy_device *phydev, u8 index,
++			       unsigned long rules)
++{
++	u16 val = 0;
++
++	if (index >= AQR_NUM_LEDS)
++		return -EINVAL;
++
++	if (rules & (BIT(TRIGGER_NETDEV_LINK_100) | BIT(TRIGGER_NETDEV_LINK)))
++		val |= VEND1_GLOBAL_LED_PROV_LINK100;
++
++	if (rules & (BIT(TRIGGER_NETDEV_LINK_1000) | BIT(TRIGGER_NETDEV_LINK)))
++		val |= VEND1_GLOBAL_LED_PROV_LINK1000;
++
++	if (rules & (BIT(TRIGGER_NETDEV_LINK_2500) | BIT(TRIGGER_NETDEV_LINK)))
++		val |= VEND1_GLOBAL_LED_PROV_LINK2500;
++
++	if (rules & (BIT(TRIGGER_NETDEV_LINK_5000) | BIT(TRIGGER_NETDEV_LINK)))
++		val |= VEND1_GLOBAL_LED_PROV_LINK5000;
++
++	if (rules & (BIT(TRIGGER_NETDEV_LINK_10000) | BIT(TRIGGER_NETDEV_LINK)))
++		val |= VEND1_GLOBAL_LED_PROV_LINK10000;
++
++	if (rules & BIT(TRIGGER_NETDEV_RX))
++		val |= VEND1_GLOBAL_LED_PROV_RX_ACT;
++
++	if (rules & BIT(TRIGGER_NETDEV_TX))
++		val |= VEND1_GLOBAL_LED_PROV_TX_ACT;
++
++	return phy_modify_mmd(phydev, MDIO_MMD_VEND1, AQR_LED_PROV(index),
++						    VEND1_GLOBAL_LED_PROV_LINK_MASK |
++						    VEND1_GLOBAL_LED_PROV_FORCE_ON |
++						    VEND1_GLOBAL_LED_PROV_RX_ACT |
++						    VEND1_GLOBAL_LED_PROV_TX_ACT, val);
++}
++
++int aqr_phy_led_polarity_set(struct phy_device *phydev, int index, unsigned long modes)
++{
++	bool active_low = false;
++	u32 mode;
++
++	if (index >= AQR_NUM_LEDS)
++		return -EINVAL;
++
++	for_each_set_bit(mode, &modes, __PHY_LED_MODES_NUM) {
++		switch (mode) {
++		case PHY_LED_ACTIVE_LOW:
++			active_low = true;
++			break;
++		default:
++		return -EINVAL;
++		}
++	}
++
++	return phy_modify_mmd(phydev, MDIO_MMD_VEND1, AQR_LED_DRIVE(index),
++			      VEND1_GLOBAL_LED_DRIVE_VDD,
++			      active_low ? VEND1_GLOBAL_LED_DRIVE_VDD : 0);
++}
+--- a/drivers/net/phy/aquantia/aquantia_main.c
++++ b/drivers/net/phy/aquantia/aquantia_main.c
+@@ -740,6 +740,13 @@ static struct phy_driver aqr_driver[] =
+ 	.get_strings	= aqr107_get_strings,
+ 	.get_stats	= aqr107_get_stats,
+ 	.link_change_notify = aqr107_link_change_notify,
++#if IS_ENABLED(CONFIG_PHYLIB_LEDS)
++	.led_brightness_set = aqr_phy_led_brightness_set,
++	.led_hw_is_supported = aqr_phy_led_hw_is_supported,
++	.led_hw_control_set = aqr_phy_led_hw_control_set,
++	.led_hw_control_get = aqr_phy_led_hw_control_get,
++	.led_polarity_set = aqr_phy_led_polarity_set,
++#endif
+ },
+ {
+ 	PHY_ID_MATCH_MODEL(PHY_ID_AQCS109),
+@@ -759,6 +766,13 @@ static struct phy_driver aqr_driver[] =
+ 	.get_strings	= aqr107_get_strings,
+ 	.get_stats	= aqr107_get_stats,
+ 	.link_change_notify = aqr107_link_change_notify,
++#if IS_ENABLED(CONFIG_PHYLIB_LEDS)
++	.led_brightness_set = aqr_phy_led_brightness_set,
++	.led_hw_is_supported = aqr_phy_led_hw_is_supported,
++	.led_hw_control_set = aqr_phy_led_hw_control_set,
++	.led_hw_control_get = aqr_phy_led_hw_control_get,
++	.led_polarity_set = aqr_phy_led_polarity_set,
++#endif
+ },
+ {
+ 	PHY_ID_MATCH_MODEL(PHY_ID_AQR111),
+@@ -778,6 +792,13 @@ static struct phy_driver aqr_driver[] =
+ 	.get_strings	= aqr107_get_strings,
+ 	.get_stats	= aqr107_get_stats,
+ 	.link_change_notify = aqr107_link_change_notify,
++#if IS_ENABLED(CONFIG_PHYLIB_LEDS)
++	.led_brightness_set = aqr_phy_led_brightness_set,
++	.led_hw_is_supported = aqr_phy_led_hw_is_supported,
++	.led_hw_control_set = aqr_phy_led_hw_control_set,
++	.led_hw_control_get = aqr_phy_led_hw_control_get,
++	.led_polarity_set = aqr_phy_led_polarity_set,
++#endif
+ },
+ {
+ 	PHY_ID_MATCH_MODEL(PHY_ID_AQR111B0),
+@@ -797,6 +818,13 @@ static struct phy_driver aqr_driver[] =
+ 	.get_strings	= aqr107_get_strings,
+ 	.get_stats	= aqr107_get_stats,
+ 	.link_change_notify = aqr107_link_change_notify,
++#if IS_ENABLED(CONFIG_PHYLIB_LEDS)
++	.led_brightness_set = aqr_phy_led_brightness_set,
++	.led_hw_is_supported = aqr_phy_led_hw_is_supported,
++	.led_hw_control_set = aqr_phy_led_hw_control_set,
++	.led_hw_control_get = aqr_phy_led_hw_control_get,
++	.led_polarity_set = aqr_phy_led_polarity_set,
++#endif
+ },
+ {
+ 	PHY_ID_MATCH_MODEL(PHY_ID_AQR405),
+@@ -823,6 +851,13 @@ static struct phy_driver aqr_driver[] =
+ 	.get_strings	= aqr107_get_strings,
+ 	.get_stats	= aqr107_get_stats,
+ 	.link_change_notify = aqr107_link_change_notify,
++#if IS_ENABLED(CONFIG_PHYLIB_LEDS)
++	.led_brightness_set = aqr_phy_led_brightness_set,
++	.led_hw_is_supported = aqr_phy_led_hw_is_supported,
++	.led_hw_control_set = aqr_phy_led_hw_control_set,
++	.led_hw_control_get = aqr_phy_led_hw_control_get,
++	.led_polarity_set = aqr_phy_led_polarity_set,
++#endif
+ },
+ {
+ 	PHY_ID_MATCH_MODEL(PHY_ID_AQR412),
+@@ -841,6 +876,13 @@ static struct phy_driver aqr_driver[] =
+ 	.get_strings	= aqr107_get_strings,
+ 	.get_stats	= aqr107_get_stats,
+ 	.link_change_notify = aqr107_link_change_notify,
++#if IS_ENABLED(CONFIG_PHYLIB_LEDS)
++	.led_brightness_set = aqr_phy_led_brightness_set,
++	.led_hw_is_supported = aqr_phy_led_hw_is_supported,
++	.led_hw_control_set = aqr_phy_led_hw_control_set,
++	.led_hw_control_get = aqr_phy_led_hw_control_get,
++	.led_polarity_set = aqr_phy_led_polarity_set,
++#endif
+ },
+ {
+ 	PHY_ID_MATCH_MODEL(PHY_ID_AQR113),
+@@ -860,6 +902,13 @@ static struct phy_driver aqr_driver[] =
+ 	.get_strings    = aqr107_get_strings,
+ 	.get_stats      = aqr107_get_stats,
+ 	.link_change_notify = aqr107_link_change_notify,
++#if IS_ENABLED(CONFIG_PHYLIB_LEDS)
++	.led_brightness_set = aqr_phy_led_brightness_set,
++	.led_hw_is_supported = aqr_phy_led_hw_is_supported,
++	.led_hw_control_set = aqr_phy_led_hw_control_set,
++	.led_hw_control_get = aqr_phy_led_hw_control_get,
++	.led_polarity_set = aqr_phy_led_polarity_set,
++#endif
+ },
+ {
+ 	PHY_ID_MATCH_MODEL(PHY_ID_AQR113C),
+@@ -879,6 +928,13 @@ static struct phy_driver aqr_driver[] =
+ 	.get_strings    = aqr107_get_strings,
+ 	.get_stats      = aqr107_get_stats,
+ 	.link_change_notify = aqr107_link_change_notify,
++#if IS_ENABLED(CONFIG_PHYLIB_LEDS)
++	.led_brightness_set = aqr_phy_led_brightness_set,
++	.led_hw_is_supported = aqr_phy_led_hw_is_supported,
++	.led_hw_control_set = aqr_phy_led_hw_control_set,
++	.led_hw_control_get = aqr_phy_led_hw_control_get,
++	.led_polarity_set = aqr_phy_led_polarity_set,
++#endif
+ },
+ {
+ 	PHY_ID_MATCH_MODEL(PHY_ID_AQR114C),
+@@ -898,6 +954,13 @@ static struct phy_driver aqr_driver[] =
+ 	.get_strings    = aqr107_get_strings,
+ 	.get_stats      = aqr107_get_stats,
+ 	.link_change_notify = aqr107_link_change_notify,
++#if IS_ENABLED(CONFIG_PHYLIB_LEDS)
++	.led_brightness_set = aqr_phy_led_brightness_set,
++	.led_hw_is_supported = aqr_phy_led_hw_is_supported,
++	.led_hw_control_set = aqr_phy_led_hw_control_set,
++	.led_hw_control_get = aqr_phy_led_hw_control_get,
++	.led_polarity_set = aqr_phy_led_polarity_set,
++#endif
+ },
+ {
+ 	PHY_ID_MATCH_MODEL(PHY_ID_AQR813),
+@@ -917,6 +980,13 @@ static struct phy_driver aqr_driver[] =
+ 	.get_strings	= aqr107_get_strings,
+ 	.get_stats	= aqr107_get_stats,
+ 	.link_change_notify = aqr107_link_change_notify,
++#if IS_ENABLED(CONFIG_PHYLIB_LEDS)
++	.led_brightness_set = aqr_phy_led_brightness_set,
++	.led_hw_is_supported = aqr_phy_led_hw_is_supported,
++	.led_hw_control_set = aqr_phy_led_hw_control_set,
++	.led_hw_control_get = aqr_phy_led_hw_control_get,
++	.led_polarity_set = aqr_phy_led_polarity_set,
++#endif
+ },
+ };
+ 

--- a/target/linux/generic/pending-6.6/999-net-phy-move-LED-polarity-to-phy_init_hw.patch
+++ b/target/linux/generic/pending-6.6/999-net-phy-move-LED-polarity-to-phy_init_hw.patch
@@ -1,0 +1,100 @@
+From 6e6fff51ae5e54092611d174fa45fa78c237a415 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 21 May 2024 20:01:46 +0200
+Subject: [PATCH] net: phy: move LED polarity to phy_init_hw
+
+Some PHY reset the polarity on reset and this cause the LED to
+malfunction as LED polarity is configured only when LED is
+registered.
+
+To better handle this, move the LED polarity configuration in
+phy_init_hw to reconfigure it after PHY reset.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/net/phy/phy_device.c | 53 +++++++++++++++++++++++++-----------
+ 1 file changed, 37 insertions(+), 16 deletions(-)
+
+--- a/drivers/net/phy/phy_device.c
++++ b/drivers/net/phy/phy_device.c
+@@ -1223,6 +1223,37 @@ static int phy_poll_reset(struct phy_dev
+ 	return 0;
+ }
+ 
++static int of_phy_led_init(struct phy_device *phydev)
++{
++	struct phy_led *phyled;
++
++	list_for_each_entry(phyled, &phydev->leds, list) {
++		struct led_classdev *cdev = &phyled->led_cdev;
++		struct device_node *np = cdev->dev->of_node;
++		unsigned long modes = 0;
++		int err;
++
++		if (of_property_read_bool(np, "active-low"))
++			set_bit(PHY_LED_ACTIVE_LOW, &modes);
++		if (of_property_read_bool(np, "inactive-high-impedance"))
++			set_bit(PHY_LED_INACTIVE_HIGH_IMPEDANCE, &modes);
++
++		if (!modes)
++			continue;
++
++		/* Return error if asked to set polarity modes but not supported */
++		if (!phydev->drv->led_polarity_set)
++			return -EINVAL;
++
++		err = phydev->drv->led_polarity_set(phydev, phyled->index,
++						    modes);
++		if (err)
++			return err;
++	}
++
++	return 0;
++}
++
+ int phy_init_hw(struct phy_device *phydev)
+ {
+ 	int ret = 0;
+@@ -1259,6 +1290,12 @@ int phy_init_hw(struct phy_device *phyde
+ 			return ret;
+ 	}
+ 
++	if (IS_ENABLED(CONFIG_PHYLIB_LEDS)) {
++		ret = of_phy_led_init(phydev);
++		if (ret < 0)
++			return ret;
++	}
++
+ 	return 0;
+ }
+ EXPORT_SYMBOL(phy_init_hw);
+@@ -3204,7 +3241,6 @@ static int of_phy_led(struct phy_device
+ 	struct device *dev = &phydev->mdio.dev;
+ 	struct led_init_data init_data = {};
+ 	struct led_classdev *cdev;
+-	unsigned long modes = 0;
+ 	struct phy_led *phyled;
+ 	u32 index;
+ 	int err;
+@@ -3222,21 +3258,6 @@ static int of_phy_led(struct phy_device
+ 	if (index > U8_MAX)
+ 		return -EINVAL;
+ 
+-	if (of_property_read_bool(led, "active-low"))
+-		set_bit(PHY_LED_ACTIVE_LOW, &modes);
+-	if (of_property_read_bool(led, "inactive-high-impedance"))
+-		set_bit(PHY_LED_INACTIVE_HIGH_IMPEDANCE, &modes);
+-
+-	if (modes) {
+-		/* Return error if asked to set polarity modes but not supported */
+-		if (!phydev->drv->led_polarity_set)
+-			return -EINVAL;
+-
+-		err = phydev->drv->led_polarity_set(phydev, index, modes);
+-		if (err)
+-			return err;
+-	}
+-
+ 	phyled->index = index;
+ 	if (phydev->drv->led_brightness_set)
+ 		cdev->brightness_set_blocking = phy_led_set_brightness;

--- a/target/linux/mediatek/dts/mt7988a-smartrg-SDG-8733.dts
+++ b/target/linux/mediatek/dts/mt7988a-smartrg-SDG-8733.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2023 SmartRG Inc.
+ * Author: Chad Monroe <chad.monroe@smartrg.com>
+ */
+
+#include "mt7988a-smartrg-mt-stuart.dtsi"
+
+/ {
+	model = "SmartRG SDG-8733";
+	compatible = "smartrg,sdg-8733", "mediatek,mt7988a";
+};
+
+&gmac1 {
+	phy-connection-type = "usxgmii";
+	phy = <&phy0>;
+};

--- a/target/linux/mediatek/dts/mt7988a-smartrg-SDG-8734.dts
+++ b/target/linux/mediatek/dts/mt7988a-smartrg-SDG-8734.dts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2023 SmartRG Inc.
+ * Author: Chad Monroe <chad.monroe@smartrg.com>
+ */
+
+#include "mt7988a-smartrg-mt-stuart.dtsi"
+
+/ {
+	model = "SmartRG SDG-8734";
+	compatible = "smartrg,sdg-8734", "mediatek,mt7988a";
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		sfp_green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "sfp";
+			gpios = <&pio 69 GPIO_ACTIVE_HIGH>;
+		};
+
+		sfp_red {
+			color = <LED_COLOR_ID_RED>;
+			function = "sfp";
+			gpios = <&pio 70 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	i2c_sfp1: i2c-gpio-0 {
+		pinctrl-names = "default";
+		pinctrl-0 = <&sfp_i2c_pins>;
+
+		compatible = "i2c-gpio";
+		sda-gpios = <&pio 27 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&pio 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_sfp1>;
+		los-gpios = <&pio 32 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+		rate-select0-gpios = <&pio 34 GPIO_ACTIVE_HIGH>;
+		rate-select1-gpios = <&pio 33 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpios = <&pio 36 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpios = <&pio 37 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <4000>;
+	};
+};
+
+&gmac1 {
+	sfp = <&sfp1>;
+	managed = "in-band-status";
+};

--- a/target/linux/mediatek/dts/mt7988a-smartrg-mt-stuart.dtsi
+++ b/target/linux/mediatek/dts/mt7988a-smartrg-mt-stuart.dtsi
@@ -1,0 +1,684 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2023 SmartRG Inc.
+ * Author: Chad Monroe <chad.monroe@smartrg.com>
+ */
+
+/dts-v1/;
+#include "mt7988a.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+#include <dt-bindings/regulator/richtek,rt5190a-regulator.h>
+
+/ {
+	aliases {
+		serial0 = &uart0;
+		ethernet0 = &gmac0;
+		ethernet1 = &gmac1;
+		led-boot = &led_sys_green;
+		led-failsafe = &led_sys_blue;
+		led-running = &led_sys_white;
+		led-upgrade = &led_sys_red;
+	};
+
+	chosen {
+		stdout-path = &uart0;
+		bootargs = "console=ttyS0,115200n1 loglevel=8 pci=pcie_bus_perf root=PARTLABEL=rootfs";
+	};
+
+	memory {
+		reg = <0x0 0x40000000 0x0 0x40000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		/delete-node/ramoops@42ff0000;
+
+		bootdata@45000000 {
+			no-map;
+			reg = <0x0 0x45000000 0x0 0x00001000>;
+		};
+
+		ramoops_reserved: ramoops@45001000 {
+			no-map;
+			compatible = "ramoops";
+			reg = <0x0 0x45001000 0x0 0x00140000>;
+			ftrace-size = <0x20000>;
+			record-size = <0x20000>;
+			console-size = <0x20000>;
+			pmsg-size = <0x80000>;
+		};
+	};
+
+	reg_1p8v: regulator-1p8v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-1.8V";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-names = "default";
+		pinctrl-0 = <&button_pins>;
+
+		factory {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "sync";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		bluetooth_reset {
+			gpio-export,name = "bt_reset";
+			gpio-export,direction_may_change;
+			gpios = <&pio 20 GPIO_ACTIVE_HIGH>;
+		};
+
+		bluetooth_txrx_ctl {
+			gpio-export,name = "bt_txrx_ctl";
+			gpio-export,direction_may_change;
+			gpios = <&pio 74 GPIO_ACTIVE_HIGH>;
+		};
+
+		gps_enable {
+			gpio-export,name = "gps_enable";
+			gpio-export,output = <1>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		slic_interrupt {
+			gpio-export,name = "slic_interrupt";
+			gpio-export,direction_may_change;
+			gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
+		};
+
+		slic_reset {
+			gpio-export,name = "slic_reset";
+			gpio-export,output = <0>;
+			gpios = <&pio 72 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb_enable {
+			gpio-export,name = "usb_enable";
+			gpio-export,output = <1>;
+			gpios = <&pio 63 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&cpu0 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu1 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu2 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu3 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cci {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu_thermal {
+	/delete-node/cooling-maps;
+	/delete-node/trips;
+
+	trips {
+		cpu_trip_crit: crit {
+			temperature = <125000>;
+			hysteresis = <2000>;
+			type = "critical";
+		};
+
+		cpu_trip_hot: hot {
+			temperature = <120000>;
+			hysteresis = <2000>;
+			type = "hot";
+		};
+
+		cpu_trip_active_high: active-high {
+			temperature = <110000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_trip_active_med: active-med {
+			temperature = <80000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_trip_active_low: active-low {
+			temperature = <60000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_trip_active_silent: active-silent {
+			temperature = <40000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		cpu-active-high {
+			/* active: set fan to cooling level 3 */
+			cooling-device = <&fan 3 3>;
+			trip = <&cpu_trip_active_high>;
+		};
+
+		cpu-active-med {
+			/* active: set fan to cooling level 2 */
+			cooling-device = <&fan 2 2>;
+			trip = <&cpu_trip_active_med>;
+		};
+
+		cpu-active-low {
+			/* active: set fan to cooling level 1 */
+			cooling-device = <&fan 1 1>;
+			trip = <&cpu_trip_active_low>;
+		};
+
+		cpu-active-silent {
+			/* active: set fan to cooling level 0 */
+			cooling-device = <&fan 0 0>;
+			trip = <&cpu_trip_active_silent>;
+		};
+	};
+};
+
+&eth {
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&fan {
+	pwms = <&pwm 0 40000 0>;
+
+	/**
+	 * set fan speed
+	 *
+	 * 0 = off
+	 * 61 = 24% duty cycle
+	 * 77 = 30% duty cycle
+	 * 102 = 40% duty cycle
+	 * 128 - 50% duty cycle
+	 * 255 = 100% duty cycle
+	 */
+	cooling-levels = <61 77 102 128>;
+
+	interrupt-parent = <&pio>;
+	interrupts = <21 IRQ_TYPE_EDGE_FALLING>;
+	pulses-per-revolution = <2>;
+
+	status = "okay";
+};
+
+&gmac0 {
+	status = "okay";
+};
+
+&gmac1 {
+	label = "wan";
+	status = "okay";
+	phy-mode = "usxgmii";
+};
+
+&gmac2 {
+	label = "lan1";
+	status = "okay";
+	phy-mode = "usxgmii";
+	phy-connection-type = "usxgmii";
+	phy = <&phy8>;
+};
+
+&gsw_phy0 {
+	status = "disabled";
+};
+
+&gsw_phy1 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe1_led0_pins>, <&gbe1_led1_pins>;
+};
+
+&gsw_phy1_led0 {
+	status = "okay";
+	color = <LED_COLOR_ID_GREEN>;
+};
+
+&gsw_phy1_led1 {
+	status = "okay";
+	color = <LED_COLOR_ID_AMBER>;
+};
+
+&gsw_phy2 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe2_led0_pins>, <&gbe2_led1_pins>;
+};
+
+&gsw_phy2_led0 {
+	status = "okay";
+	color = <LED_COLOR_ID_GREEN>;
+};
+
+&gsw_phy2_led1 {
+	status = "okay";
+	color = <LED_COLOR_ID_AMBER>;
+};
+
+&gsw_phy3 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe3_led0_pins>, <&gbe3_led1_pins>;
+};
+
+&gsw_phy3_led0 {
+	status = "okay";
+	color = <LED_COLOR_ID_GREEN>;
+};
+
+&gsw_phy3_led1 {
+	status = "okay";
+	color = <LED_COLOR_ID_AMBER>;
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+	status = "okay";
+
+	rt5190a_64: rt5190a@64 {
+		compatible = "richtek,rt5190a";
+		reg = <0x64>;
+		/*interrupts-extended = <&gpio26 0 IRQ_TYPE_LEVEL_LOW>;*/
+		vin2-supply = <&rt5190_buck1>;
+		vin3-supply = <&rt5190_buck1>;
+		vin4-supply = <&rt5190_buck1>;
+
+		regulators {
+			rt5190_buck1: buck1 {
+				regulator-name = "rt5190a-buck1";
+				regulator-min-microvolt = <5090000>;
+				regulator-max-microvolt = <5090000>;
+				regulator-allowed-modes =
+				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			buck2 {
+				regulator-name = "vcore";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			rt5190_buck3: buck3 {
+				regulator-name = "vproc";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+			};
+			buck4 {
+				regulator-name = "rt5190a-buck4";
+				regulator-min-microvolt = <850000>;
+				regulator-max-microvolt = <850000>;
+				regulator-allowed-modes =
+				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			ldo {
+				regulator-name = "rt5190a-ldo";
+				regulator-min-microvolt = <1200000>;
+				regulator-max-microvolt = <1200000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+		};
+	};
+};
+
+&i2c1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c1_pins>;
+	status = "okay";
+
+	system-leds {
+		compatible = "srg,sysled";
+		reg = <0x30>;
+
+		led_sys_red: system_red {
+			label = "red";
+			reg = <1>;
+		};
+
+		led_sys_green: system_green {
+			label = "green";
+			reg = <2>;
+		};
+
+		led_sys_blue: system_blue {
+			label = "blue";
+			reg = <3>;
+		};
+
+		led_sys_white: system_white {
+			label = "white";
+			reg = <4>;
+		};
+	};
+};
+
+&mdio_bus {
+	phy0: ethernet-phy@0 {
+		/* AQR113C */
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <0>;
+
+		reset-gpios = <&pio 62 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <1000000>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				function = LED_FUNCTION_WAN;
+				color = <LED_COLOR_ID_GREEN>;
+			};
+
+			led@1 {
+				reg = <1>;
+				function = LED_FUNCTION_WAN;
+				color = <LED_COLOR_ID_ORANGE>;
+			};
+
+			led@2 {
+				reg = <2>;
+				function = LED_FUNCTION_WAN;
+				color = <LED_COLOR_ID_WHITE>;
+				active-low;
+			};
+		};
+	};
+
+	phy8: ethernet-phy@8 {
+		/* AQR113C */
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <8>;
+
+		reset-gpios = <&pio 71 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <1000000>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				function = LED_FUNCTION_LAN;
+				color = <LED_COLOR_ID_GREEN>;
+			};
+
+			led@1 {
+				reg = <1>;
+				function = LED_FUNCTION_LAN;
+				color = <LED_COLOR_ID_ORANGE>;
+			};
+
+			led@2 {
+				reg = <2>;
+				function = LED_FUNCTION_LAN;
+				color = <LED_COLOR_ID_WHITE>;
+				active-low;
+			};
+		};
+	};
+};
+
+&mmc0 {
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc0_pins_emmc_51>;
+	pinctrl-1 = <&mmc0_pins_emmc_51>;
+	bus-width = <8>;
+	max-frequency = <200000000>;
+	cap-mmc-highspeed;
+	mmc-hs200-1_8v;
+	mmc-hs400-1_8v;
+	hs400-ds-delay = <0x12814>;
+	vmmc-supply = <&reg_3p3v>;
+	vqmmc-supply = <&reg_1p8v>;
+	non-removable;
+	no-sd;
+	no-sdio;
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	card@0 {
+		#address-cells = <0>;
+		#size-cells = <0>;
+		compatible = "mmc-card";
+		reg = <0>;
+
+		block {
+			compatible = "block-device";
+
+			partitions {
+				block-partition-factory {
+					partname = "factory";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						eeprom_factory_0: eeprom@0 {
+							reg = <0x0 0x1e00>;
+						};
+					};
+				};
+			};
+		};
+	};
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_1_pins>;
+	reset-gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+
+		mt7996@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			nvmem-cells = <&eeprom_factory_0>;
+			nvmem-cell-names = "eeprom";
+			ieee80211-freq-limit = <2400000 2500000>, <5170000 5835000>, <5945000 7125000>;
+		};
+	};
+};
+
+&pcie1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_pins>;
+	status = "okay";
+};
+
+&pcie2 {
+	status = "disabled";
+};
+
+&pcie3 {
+	status = "disabled";
+};
+
+&pio {
+	button_pins: button-pins {
+		pins = "GPIO_RESET", "GPIO_WPS";
+		mediatek,pull-down-adv = <0>; /* bias-disable */
+	};
+
+	pcie0_1_pins: pcie0-pins-g1 {
+		mux {
+			function = "pcie";
+			groups = "pcie_2l_0_pereset", "pcie_clk_req_n0_0";
+		};
+	};
+
+	pwm_pins: pwm-pins {
+		mux {
+			function = "pwm";
+			groups = "pwm0", "pwm1";
+		};
+	};
+
+	sfp_i2c_pins: sfp-i2c-pins {
+		conf-scl {
+			pins = "LED_A";
+			drive-strength =  <8>;
+			mediatek,pull-up-adv = <1>;
+		};
+		conf-sda {
+			pins = "LED_E";
+			drive-strength =  <8>;
+			mediatek,pull-up-adv = <0>;
+		};
+	};
+
+	uart1_pins: uart1-pins {
+		mux {
+			function = "uart";
+			groups = "uart1_2";
+		};
+	};
+
+	uart2_pins: uart2-pins {
+		mux {
+			function = "uart";
+			groups = "uart2";
+		};
+	};
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm_pins>;
+	status = "okay";
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "disabled";
+
+	spi_nand: spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+	};
+
+};
+
+&ssusb0 {
+	status = "okay";
+};
+
+&ssusb1 {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+
+	ports {
+		port@0 {
+			status = "disabled";
+		};
+
+		port@1 {
+			label = "lan2";
+		};
+
+		port@2 {
+			label = "lan3";
+		};
+
+		port@3 {
+			label = "lan4";
+		};
+	};
+};
+
+&tphy {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&uart1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart1_pins>;
+	status = "okay";
+
+	/* Airoha AG3352 GPS */
+};
+
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart2_pins>;
+	status = "okay";
+
+	/* DA14531MOD Bluetooth */
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&xphy {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -72,6 +72,21 @@ routerich,ax3000)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "link tx rx"
 	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "wan" "link"
 	;;
+smartrg,sdg-8733|\
+smartrg,sdg-8734)
+	ucidef_set_led_netdev "lan-1-green" "LAN1" "mdio-bus:08:green:lan" "lan1" "link_2500 link_5000"
+	ucidef_set_led_netdev "lan-1-orange" "LAN1" "mdio-bus:08:orange:lan" "lan1" "link_100 link_1000"
+	ucidef_set_led_netdev "lan-1-white" "LAN1" "mdio-bus:08:white:lan" "lan1" "link_10000"
+	ucidef_set_led_netdev "lan-2-green" "LAN2" "mt7530-0:01:green:lan" "lan2" "link_1000"
+	ucidef_set_led_netdev "lan-2-amber" "LAN2" "mt7530-0:01:amber:lan" "lan2" "link_100 link_10"
+	ucidef_set_led_netdev "lan-3-green" "LAN3" "mt7530-0:02:green:lan" "lan3" "link_1000"
+	ucidef_set_led_netdev "lan-3-amber" "LAN3" "mt7530-0:02:amber:lan" "lan3" "link_100 link_10"
+	ucidef_set_led_netdev "lan-4-green" "LAN4" "mt7530-0:03:green:lan" "lan4" "link_1000"
+	ucidef_set_led_netdev "lan-4-amber" "LAN4" "mt7530-0:03:amber:lan" "lan4" "link_100 link_10"
+	ucidef_set_led_netdev "wan-green" "WAN" "mdio-bus:00:green:wan" "wan" "link_2500 link_5000"
+	ucidef_set_led_netdev "wan-orange" "WAN" "mdio-bus:00:orange:wan" "wan" "link_100 link_1000"
+	ucidef_set_led_netdev "wan-white" "WAN" "mdio-bus:00:white:wan" "wan" "link_10000"
+	;;
 xiaomi,mi-router-wr30u-stock|\
 xiaomi,mi-router-wr30u-ubootmod)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -166,7 +166,9 @@ mediatek_setup_macs()
 	smartrg,sdg-8612|\
 	smartrg,sdg-8614|\
 	smartrg,sdg-8622|\
-	smartrg,sdg-8632)
+	smartrg,sdg-8632|\
+	smartrg,sdg-8733|\
+	smartrg,sdg-8734)
 		label_mac=$(mmc_get_mac_ascii mfginfo MFG_MAC)
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add "$label_mac" 1)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -136,6 +136,12 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "2" ] && macaddr_add $addr 4 > /sys${DEVPATH}/macaddress
 		;;
+	smartrg,sdg-8733|\
+	smartrg,sdg-8634)
+		addr=$(mmc_get_mac_ascii mfginfo MFG_MAC)
+		[ "$PHYNBR" = "0" ] && macaddr_add $addr 4 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $addr a > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "2" ] && macaddr_add $addr 6 > /sys${DEVPATH}/macaddress
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088)

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -22,7 +22,9 @@ preinit_set_mac_address() {
 		ip link set dev eth1 address "$(macaddr_add $addr 1)"
 		;;
 	smartrg,sdg-8612|\
-	smartrg,sdg-8614)
+	smartrg,sdg-8614|\
+	smartrg,sdg-8733|\
+	smartrg,sdg-8734)
 		addr=$(mmc_get_mac_ascii mfginfo MFG_MAC)
 		lan_addr=$(macaddr_add $addr 1)
 		ip link set dev wan address "$addr"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -68,7 +68,9 @@ platform_do_upgrade() {
 	smartrg,sdg-8612|\
 	smartrg,sdg-8614|\
 	smartrg,sdg-8622|\
-	smartrg,sdg-8632)
+	smartrg,sdg-8632|\
+	smartrg,sdg-8733|\
+	smartrg,sdg-8734)
 		CI_KERNPART="kernel"
 		CI_ROOTPART="rootfs"
 		emmc_do_upgrade "$1"
@@ -245,6 +247,8 @@ platform_copy_config() {
 	smartrg,sdg-8614|\
 	smartrg,sdg-8622|\
 	smartrg,sdg-8632|\
+	smartrg,sdg-8733|\
+	smartrg,sdg-8734|\
 	ubnt,unifi-6-plus)
 		emmc_copy_config
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -241,6 +241,10 @@ platform_copy_config() {
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\
 	jdcloud,re-cp-03|\
+	smartrg,sdg-8612|\
+	smartrg,sdg-8614|\
+	smartrg,sdg-8622|\
+	smartrg,sdg-8632|\
 	ubnt,unifi-6-plus)
 		emmc_copy_config
 		;;

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -140,8 +140,7 @@ TARGET_DEVICES += acer_predator-w6
 define Device/adtran_smartrg
   DEVICE_VENDOR := Adtran
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := e2fsprogs f2fsck mkf2fs kmod-hwmon-pwmfan \
-		     kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  DEVICE_PACKAGES := e2fsprogs f2fsck mkf2fs kmod-hwmon-pwmfan
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 
@@ -149,6 +148,7 @@ define Device/smartrg_sdg-8612
 $(call Device/adtran_smartrg)
   DEVICE_MODEL := SDG-8612
   DEVICE_DTS := mt7986a-smartrg-SDG-8612
+  DEVICE_PACKAGES += kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
 endef
 TARGET_DEVICES += smartrg_sdg-8612
 
@@ -156,6 +156,7 @@ define Device/smartrg_sdg-8614
 $(call Device/adtran_smartrg)
   DEVICE_MODEL := SDG-8614
   DEVICE_DTS := mt7986a-smartrg-SDG-8614
+  DEVICE_PACKAGES += kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
 endef
 TARGET_DEVICES += smartrg_sdg-8614
 
@@ -163,7 +164,7 @@ define Device/smartrg_sdg-8622
 $(call Device/adtran_smartrg)
   DEVICE_MODEL := SDG-8622
   DEVICE_DTS := mt7986a-smartrg-SDG-8622
-  DEVICE_PACKAGES += kmod-mt7915e kmod-mt7915-firmware
+  DEVICE_PACKAGES += kmod-mt7915e kmod-mt7915-firmware kmod-mt7986-firmware mt7986-wo-firmware
 endef
 TARGET_DEVICES += smartrg_sdg-8622
 
@@ -171,9 +172,25 @@ define Device/smartrg_sdg-8632
 $(call Device/adtran_smartrg)
   DEVICE_MODEL := SDG-8632
   DEVICE_DTS := mt7986a-smartrg-SDG-8632
-  DEVICE_PACKAGES += kmod-mt7915e kmod-mt7915-firmware
+  DEVICE_PACKAGES += kmod-mt7915e kmod-mt7915-firmware kmod-mt7986-firmware mt7986-wo-firmware
 endef
 TARGET_DEVICES += smartrg_sdg-8632
+
+define Device/smartrg_sdg-8733
+$(call Device/adtran_smartrg)
+  DEVICE_MODEL := SDG-8733
+  DEVICE_DTS := mt7988a-smartrg-SDG-8733
+  DEVICE_PACKAGES += kmod-mt7996-firmware kmod-phy-aquantia kmod-usb3
+endef
+TARGET_DEVICES += smartrg_sdg-8733
+
+define Device/smartrg_sdg-8734
+$(call Device/adtran_smartrg)
+  DEVICE_MODEL := SDG-8734
+  DEVICE_DTS := mt7988a-smartrg-SDG-8734
+  DEVICE_PACKAGES += kmod-mt7996-firmware kmod-phy-aquantia kmod-sfp kmod-usb3
+endef
+TARGET_DEVICES += smartrg_sdg-8734
 
 define Device/asus_rt-ax59u
   DEVICE_VENDOR := ASUS


### PR DESCRIPTION
This series adds basic support for the Adtran SmartRG [SDG 8700 Series](https://www.adtran.com/en/products-and-services/residential-solutions/mesh-wi-fi-gateways-and-satellites/service-delivery-gateways/sdg-8700-series).

Common specifications:
 * Mediatek MT7988A (4x Cortex-A73, up to 1.8 GHz clock speed)
 * 8 GiB eMMC
 * 2 GiB DDR4 RAM
 * 1x 10000M/1000M/100M, 3x 1000M/100M/10M LAN ports
 * MT7996 Tri-band (2.4GHz, 5GHz, 6GHz) 4T4R 802.11be Wi-Fi
 * Airoha AG3352 GPS
 * Renesas DA14531MOD Bluetooth
 * 2 buttons (Reset, Mesh/WPS)
 * uC-controlled color LED via I2C
 * 2x LED for each 1G port, 3x LED for each 10G port
 * USB 3.0 type A port
 * 3.3V-level 115200baud UART console via 4-pin Dupont connector exposed at the bottom of the device
 * USB-C PD power input

SDG-8733: 1x 10000M/1000M/100M WAN port
SDG-8734: 1x USXGMII/10GBase-R/5GBase-R/2500Base-X/1000Base-X/SGMII SFP+

Both models are also available in versions including 2x FXS POTS interfaces for connecting analog phones. Those interfaces are not supported by OpenWrt.