### PR TITLE
base-files: improve Sophos x86 products support

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/01_leds
+++ b/target/linux/x86/base-files/etc/board.d/01_leds
@@ -16,11 +16,22 @@ pc-engines-apu1|pc-engines-apu2|pc-engines-apu3|pc-engines-apu4|pc-engines-apu5|
 	ucidef_set_led_netdev "lan" "LAN" "apu:green:2" "br-lan"
 	ucidef_set_led_default "diag" "DIAG" "apu:green:1" "1"
 	;;
-sophos-sg-105wr1|sophos-sg-125wr1|sophos-sg-135wr1|sophos-xg-105wr1|sophos-xg-125wr1|sophos-xg-135wr1)
+sophos-sg-105wr1|sophos-sg-115wr1|sophos-sg-125wr1|sophos-sg-135wr1| \
+sophos-xg-105wr1|sophos-xg-115wr1|sophos-xg-125wr1|sophos-xg-135wr1)
 	ucidef_set_led_netdev "wlan" "WiFi" "ath9k-phy0" "phy0tpt"
 	;;
-sophos-sg-105wr2|sophos-sg-125wr2|sophos-sg-135wr2|sophos-xg-105wr2|sophos-xg-125wr2|sophos-xg-135wr2|\
-sophos-sg-105wr3|sophos-sg-125wr3|sophos-sg-135wr3|sophos-xg-105wr3|sophos-xg-125wr3|sophos-xg-135wr3)
+sophos-sg-105wr2|sophos-sg-115wr2|sophos-sg-125wr2|sophos-sg-135wr2| \
+sophos-xg-105wr2|sophos-xg-115wr2|sophos-xg-125wr2|sophos-xg-135wr2)
+	ucidef_set_led_netdev "wlan" "WiFi" "ath10k-phy0" "phy0tpt"
+	;;
+sophos-sg-105wr3|sophos-sg-115wr3|sophos-sg-125wr3|sophos-sg-135wr3| \
+sophos-xg-105wr3|sophos-xg-115wr3|sophos-xg-125wr3|sophos-xg-135wr3)
+	ucidef_set_led_netdev "wlan" "WiFi" "ath10k-phy0" "phy0tpt"
+	;;
+sophos-xg-85wr1|sophos-xg-86wr1)
+	ucidef_set_led_netdev "wlan" "WiFi" "ath10k-phy0" "phy0tpt"
+	;;
+sophos-xg-106wr1|sophos-xg-116wr1)
 	ucidef_set_led_netdev "wlan" "WiFi" "ath10k-phy0" "phy0tpt"
 	;;
 traverse-technologies-geos)

--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -43,31 +43,142 @@ pc-engines-apu4|pc-engines-apu6)
 roqos-roqos-core-rc10)
 	ucidef_set_interfaces_lan_wan "eth1" "eth0"
 	;;
-sophos-sg-105r1|sophos-xg-105r1| \
-sophos-sg-105wr1|sophos-xg-105wr1| \
-sophos-sg-105r2|sophos-xg-105r2| \
-sophos-sg-105wr2|sophos-xg-105wr2| \
-sophos-sg-115r1|sophos-xg-115r1| \
-sophos-sg-115wr1|sophos-xg-115wr1| \
-sophos-sg-115r2|sophos-xg-115r2| \
-sophos-sg-115wr2|sophos-xg-115wr2| \
-sophos-xg-85*|sophos-xg-86*)
+sophos-sg-105r1|sophos-sg-105wr1| \
+sophos-sg-115r1|sophos-sg-115wr1)
+	ucidef_set_network_device_path "lan" "pci0000:00/0000:00:1c.0/0000:01:00.0"
+	ucidef_set_network_device_path "wan" "pci0000:00/0000:00:1c.1/0000:02:00.0"
+	ucidef_set_network_device_path "dmz" "pci0000:00/0000:00:1c.2/0000:03:00.0"
+	ucidef_set_network_device_path "ha"  "pci0000:00/0000:00:1c.3/0000:04:00.0/0000:05:01.0/0000:06:00.0"
+	ucidef_set_interfaces_lan_wan  "lan dmz ha" "wan"
+	;;
+sophos-sg-105r2|sophos-sg-105wr2| \
+sophos-sg-115r2|sophos-sg-115wr2)
+	ucidef_set_network_device_path "lan" "pci0000:00/0000:00:1c.0/0000:01:00.0"
+	ucidef_set_network_device_path "wan" "pci0000:00/0000:00:1c.1/0000:02:00.0"
+	ucidef_set_network_device_path "dmz" "pci0000:00/0000:00:1c.2/0000:03:00.0"
+	ucidef_set_network_device_path "ha"  "pci0000:00/0000:00:1c.3/0000:04:00.0/0000:05:01.0/0000:06:00.0"
+	ucidef_set_interfaces_lan_wan  "lan dmz ha" "wan"
+	;;
+sophos-sg-105wr3)
+	ucidef_set_network_device_path "lan" "pci0000:00/0000:00:13.1/0000:02:00.0"
+	ucidef_set_network_device_path "wan" "pci0000:00/0000:00:13.2/0000:03:00.0"
+	ucidef_set_network_device_path "dmz" "pci0000:00/0000:00:13.3/0000:04:00.0/0000:05:02.0/0000:07:00.0"
+	ucidef_set_network_device_path "ha"  "pci0000:00/0000:00:13.0/0000:01:00.0"
+	ucidef_set_interfaces_lan_wan  "lan dmz ha" "wan"
+	;;
+sophos-sg-115r3)
+	ucidef_set_network_device_path "lan" "pci0000:00/0000:00:13.1/0000:02:00.0"
+	ucidef_set_network_device_path "wan" "pci0000:00/0000:00:13.2/0000:03:00.0"
+	ucidef_set_network_device_path "dmz" "pci0000:00/0000:00:13.3/0000:04:00.0"
+	ucidef_set_network_device_path "ha"  "pci0000:00/0000:00:13.0/0000:01:00.0"
+	ucidef_set_interfaces_lan_wan  "lan dmz ha" "wan"
+	;;
+sophos-sg-125r1|sophos-sg-125wr1)
+	ucidef_set_network_device_path "lan"  "pci0000:00/0000:00:14.0"
+	ucidef_set_network_device_path "wan"  "pci0000:00/0000:00:14.1"
+	ucidef_set_network_device_path "dmz"  "pci0000:00/0000:00:14.2"
+	ucidef_set_network_device_path "ha"   "pci0000:00/0000:00:14.3"
+	ucidef_set_network_device_path "eth4" "pci0000:00/0000:00:01.0/0000:01:00.0/0000:02:02.0/0000:03:00.0"
+	ucidef_set_network_device_path "eth5" "pci0000:00/0000:00:01.0/0000:01:00.0/0000:02:03.0/0000:04:00.0"
+	ucidef_set_network_device_path "eth6" "pci0000:00/0000:00:02.0/0000:05:00.0/0000:06:02.0/0000:07:00.0"
+	ucidef_set_network_device_path "eth7" "pci0000:00/0000:00:02.0/0000:05:00.0/0000:06:03.0/0000:08:00.0"
+	ucidef_set_interfaces_lan_wan  "lan dmz ha eth4 eth5 eth6 eth7" "wan"
+	;;
+sophos-sg-125r2|sophos-sg-125wr2| \
+sophos-sg-135r2|sophos-sg-135wr2)
+	ucidef_set_network_device_path "lan"  "pci0000:00/0000:00:14.0"
+	ucidef_set_network_device_path "wan"  "pci0000:00/0000:00:14.1"
+	ucidef_set_network_device_path "dmz"  "pci0000:00/0000:00:14.2"
+	ucidef_set_network_device_path "ha"   "pci0000:00/0000:00:14.3"
+	ucidef_set_network_device_path "eth4" "pci0000:00/0000:00:01.0/0000:01:00.0/0000:02:02.0/0000:03:00.0"
+	ucidef_set_network_device_path "eth5" "pci0000:00/0000:00:01.0/0000:01:00.0/0000:02:03.0/0000:04:00.0"
+	ucidef_set_network_device_path "eth6" "pci0000:00/0000:00:02.0/0000:05:00.0/0000:06:02.0/0000:07:00.0"
+	ucidef_set_network_device_path "eth7" "pci0000:00/0000:00:02.0/0000:05:00.0/0000:06:03.0/0000:08:00.0"
+	ucidef_set_interfaces_lan_wan  "lan dmz ha eth4 eth5 eth6 eth7" "wan"
+	;;
+sophos-xg-85r1)
+	ucidef_set_network_device_path "lan1" "pci0000:00/0000:00:1c.0/0000:01:00.0"
+	ucidef_set_network_device_path "wan"  "pci0000:00/0000:00:1c.1/0000:02:00.0"
+	ucidef_set_network_device_path "dmz"  "pci0000:00/0000:00:1c.2/0000:03:00.0"
+	ucidef_set_network_device_path "lan4" "pci0000:00/0000:00:1c.3/0000:04:00.0"
+	ucidef_set_interfaces_lan_wan  "lan1 dmz lan4" "wan"
+	;;
+sophos-xg-85wr1)
+	ucidef_set_network_device_path "lan1" "pci0000:00/0000:00:1c.0/0000:01:00.0"
+	ucidef_set_network_device_path "wan"  "pci0000:00/0000:00:1c.1/0000:02:00.0"
+	ucidef_set_network_device_path "dmz"  "pci0000:00/0000:00:1c.2/0000:03:00.0"
+	ucidef_set_network_device_path "lan4" "pci0000:00/0000:00:1c.3/0000:04:00.0/0000:05:01.0/0000:06:00.0"
+	ucidef_set_interfaces_lan_wan  "lan1 dmz lan4" "wan"
+	;;
+sophos-xg-86r1|sophos-xg-86wr1)
+	ucidef_set_network_device_path "lan1" "pci0000:00/0000:00:13.0/0000:02:00.0"
+	ucidef_set_network_device_path "wan"  "pci0000:00/0000:00:13.1/0000:03:00.0"
+	ucidef_set_network_device_path "dmz"  "pci0000:00/0000:00:13.2/0000:04:00.0"
+	ucidef_set_network_device_path "lan4" "pci0000:00/0000:00:13.3/0000:05:00.0"
+	ucidef_set_interfaces_lan_wan  "lan1 dmz lan4" "wan"
+	;;
+sophos-xg-105r2|sophos-xg-105wr2)
+	ucidef_set_network_device_path "lan1" "pci0000:00/0000:00:1c.0/0000:01:00.0"
+	ucidef_set_network_device_path "wan"  "pci0000:00/0000:00:1c.1/0000:02:00.0"
+	ucidef_set_network_device_path "dmz"  "pci0000:00/0000:00:1c.2/0000:03:00.0"
+	ucidef_set_network_device_path "lan4" "pci0000:00/0000:00:1c.3/0000:04:00.0/0000:05:01.0/0000:06:00.0"
+	ucidef_set_interfaces_lan_wan  "lan1 dmz lan4" "wan"
+	;;
+sophos-xg-105r3|sophos-xg-115r3)
+	ucidef_set_network_device_path "lan1" "pci0000:00/0000:00:13.1/0000:02:00.0"
+	ucidef_set_network_device_path "wan"  "pci0000:00/0000:00:13.2/0000:03:00.0"
+	ucidef_set_network_device_path "dmz"  "pci0000:00/0000:00:13.3/0000:04:00.0"
+	ucidef_set_network_device_path "lan4" "pci0000:00/0000:00:13.0/0000:01:00.0"
+	ucidef_set_interfaces_lan_wan  "lan1 dmz lan4" "wan"
+	;;
+sophos-xg-106r1)
+	ucidef_set_network_device_path "lan1" "pci0000:00/0000:00:13.1/0000:02:00.0"
+	ucidef_set_network_device_path "wan"  "pci0000:00/0000:00:13.2/0000:03:00.0"
+	ucidef_set_network_device_path "dmz"  "pci0000:00/0000:00:13.3/0000:04:00.0"
+	ucidef_set_network_device_path "lan4" "pci0000:00/0000:00:13.0/0000:01:00.0"
+	ucidef_set_interfaces_lan_wan  "lan1 dmz lan4" "wan"
+	;;
+sophos-utm-110r5|sophos-utm-120r5)
+	ucidef_set_network_device_path "lan" "pci0000:00/0000:00:1c.3/0000:05:00.0"
+	ucidef_set_network_device_path "wan" "pci0000:00/0000:00:1c.2/0000:04:00.0"
+	ucidef_set_network_device_path "dmz" "pci0000:00/0000:00:1c.1/0000:03:00.0"
+	ucidef_set_network_device_path "ha"  "pci0000:00/0000:00:1c.0/0000:02:00.0"
+	ucidef_set_interfaces_lan_wan  "lan dmz ha" "wan"
+	;;
+sophos-sg-105r1|sophos-sg-105wr1| \
+sophos-sg-105r2|sophos-sg-105wr2| \
+sophos-sg-105r3|sophos-sg-105wr3| \
+sophos-sg-115r1|sophos-sg-115wr1| \
+sophos-sg-115r2|sophos-sg-115wr2| \
+sophos-sg-115r3|sophos-sg-115wr3| \
+sophos-xg-85r1|sophos-xg-85wr1| \
+sophos-xg-86r1|sophos-xg-86wr1| \
+sophos-xg-105r1|sophos-xg-105wr1| \
+sophos-xg-105r2|sophos-xg-105wr2| \
+sophos-xg-105r3|sophos-xg-105wr3| \
+sophos-xg-115r1|sophos-xg-115wr1| \
+sophos-xg-115r2|sophos-xg-115wr2| \
+sophos-xg-115r3|sophos-xg-115wr3| \
+sophos-xg-106r1|sophos-xg-106wr1| \
+sophos-xg-116r1|sophos-xg-116wr1| \
+sophos-utm-110r5|sophos-utm-120r5)
 	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3" "eth1"
 	;;
-sophos-sg-125r1|sophos-xg-125r1| \
-sophos-sg-125wr1|sophos-xg-125wr1| \
-sophos-sg-125r2|sophos-xg-125r2| \
-sophos-sg-125wr2|sophos-xg-125wr2| \
-sophos-sg-135r1|sophos-xg-135r1| \
-sophos-sg-135wr1|sophos-xg-135wr1| \
-sophos-sg-135r2|sophos-xg-135r2| \
-sophos-sg-135wr2|sophos-xg-135wr2)
+sophos-sg-125r1|sophos-sg-125wr1| \
+sophos-sg-125r2|sophos-sg-125wr2| \
+sophos-sg-135r1|sophos-sg-135wr1| \
+sophos-sg-135r2|sophos-sg-135wr2| \
+sophos-xg-125r1|sophos-xg-125wr1| \
+sophos-xg-125r2|sophos-xg-125wr2| \
+sophos-xg-135r1|sophos-xg-135wr1| \
+sophos-xg-135r2|sophos-xg-135wr2)
 	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3 eth4 eth5 eth6 eth7" "eth1"
 	;;
-sophos-sg-135r3|sophos-xg-135r3| \
-sophos-sg-135wr3|sophos-xg-135wr3)
+sophos-sg-135r3|sophos-sg-135wr3| \
+sophos-xg-135r3|sophos-xg-135wr3)
 	ucidef_set_interfaces_lan_wan "eth0 eth1 eth2 eth3 eth5 eth7 eth8" "eth6"
 	;;
+
 traverse-technologies-geos)
 	ucidef_set_interface_lan "eth0 eth1"
 	ucidef_add_atm_bridge "0" "35" "llc" "bridged"

--- a/target/linux/x86/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/x86/base-files/lib/preinit/01_sysinfo
@@ -38,7 +38,17 @@ do_sysinfo_x86() {
 			local product_version
 			product_version="$(cat /sys/devices/virtual/dmi/id/product_version 2>/dev/null)"
 			case "$product_version" in
-			105*|115*|125*|135*|85*|86*)
+			105*|106*|115*|116*|125*|135*|85*|86*)
+				product="${product}-${product_version}"
+				break
+				;;
+			esac
+			;;
+		"Sophos:UTM")
+			local product_version
+			product_version="$(cat /sys/devices/virtual/dmi/id/product_version 2>/dev/null)"
+			case "$product_version" in
+			110*|120*)
 				product="${product}-${product_version}"
 				break
 				;;


### PR DESCRIPTION
This change adds/improves model identification and LED configs for Sophos devices.

This change also improves the port naming on many Sophos devices:
* port names now match case markings and
* on 8-port devices the order matches the case markings

For example, the previous code resulted in the WAN port on XG-135 being named `eth6` under OpenWrt where the case markings are `eth2`/`WAN`.

The SG-line of Sophos devices have the `ethX` markings on the case, so in the case of 8-port SG devices, the markings are LAN, WAN, DMZ, HA, eth4-eth7, and this is what has been used for port naming in OpenWrt, whereas the XG-line of devices is missing the HA marking and `ethX` markings whatsoever, so the suggested naming is based on LAN: lan1, wan, dmz, lan4-lan7.

The sys/device paths were confirmed to be indentical with both UEFI and legacy boot and this was tested with OpenWrt 23.05.2 with XG-105wr2 and XG-135r3.

Thanks @Hurricos for contribution for Cisco MX-100 which inspired this.

Credits to the following OpenWrt forums users for confirming paths/case markings: 
@RaylynnKnight, @NC1, @stangri: sg-105r1,sg-105wr1,sg-115r1,sg-115wr1
@stangri, @RaylynnKnight: sg-105r2,sg-105wr2,sg-115r2,sg-115wr2
@NC1: sg-105wr3
@valknut: sg-115r3
@stangri, @RaylynnKnight: sg-125r1,sg-125wr1
@stangri, @RaylynnKnight: sg-125r2,sg-125wr2,sg-135r2,sg-135wr2
@tapper: xg-85r1
@RaylynnKnight: xg-85wr1
@RaylynnKnight, @takimata: xg-86r1,xg-86wr1
@RaylynnKnight, @stangri: xg-105r2,xg-105wr2
@RaylynnKnight: xg-105r3,xg-115r3
@RaylynnKnight: xg-106r1
@RaylynnKnight: utm-110r5,utm-120r5
