### PR TITLE
mbedtls: Update to 2.28.8

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=2.28.7
-PKG_RELEASE:=2
+PKG_VERSION:=2.28.8
+PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ARMmbed/mbedtls/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=1df6073f0cf6a4e1953890bf5e0de2a8c7e6be50d6d6c69fa9fefcb1d14e981a
+PKG_HASH:=4fef7de0d8d542510d726d643350acb3cdb9dc76ad45611b59c9aa08372b4213
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=gpl-2.0.txt

--- a/package/libs/mbedtls/patches/100-x509-crt-verify-SAN-iPAddress.patch
+++ b/package/libs/mbedtls/patches/100-x509-crt-verify-SAN-iPAddress.patch
@@ -11,7 +11,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
 
 --- a/include/mbedtls/x509_crt.h
 +++ b/include/mbedtls/x509_crt.h
-@@ -608,7 +608,7 @@ int mbedtls_x509_crt_verify_info(char *b
+@@ -596,7 +596,7 @@ int mbedtls_x509_crt_verify_info(char *b
   * \param cn       The expected Common Name. This will be checked to be
   *                 present in the certificate's subjectAltNames extension or,
   *                 if this extension is absent, as a CN component in its
@@ -22,7 +22,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
   *                 If the verification couldn't be completed, the flag value is
 --- a/library/x509_crt.c
 +++ b/library/x509_crt.c
-@@ -57,6 +57,10 @@
+@@ -45,6 +45,10 @@
  
  #if defined(MBEDTLS_HAVE_TIME)
  #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
@@ -33,7 +33,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
  #include <windows.h>
  #else
  #include <time.h>
-@@ -3002,6 +3006,61 @@ find_parent:
+@@ -2990,6 +2994,61 @@ find_parent:
      }
  }
  
@@ -95,7 +95,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
  /*
   * Check for CN match
   */
-@@ -3022,24 +3081,51 @@ static int x509_crt_check_cn(const mbedt
+@@ -3010,24 +3069,51 @@ static int x509_crt_check_cn(const mbedt
      return -1;
  }
  
@@ -158,7 +158,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
  }
  
  /*
-@@ -3050,31 +3136,23 @@ static void x509_crt_verify_name(const m
+@@ -3038,31 +3124,23 @@ static void x509_crt_verify_name(const m
                                   uint32_t *flags)
  {
      const mbedtls_x509_name *name;


### PR DESCRIPTION
This contains a fix for:
CVE-2024-28960: An issue was discovered in Mbed TLS 2.18.0 through 2.28.x before 2.28.8 and 3.x before 3.6.0, and Mbed Crypto. The PSA Crypto API mishandles shared memory.