### PR TITLE
libunwind: update to 1.8.1

### DIFF
--- a/package/libs/libunwind/Makefile
+++ b/package/libs/libunwind/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libunwind
-PKG_VERSION:=1.6.2
+PKG_VERSION:=1.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=@SAVANNAH/$(PKG_NAME)
-PKG_HASH:=4a6aec666991fb45d0889c44aede8ad6eb108071c3554fcdff671f9c94794976
+PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/v$(PKG_VERSION)/
+PKG_HASH:=ddf0e32dd5fafe5283198d37e4bf9decf7ba1770b6e7e006c33e6df79e6a6157
 
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 PKG_LICENSE:=X11

--- a/package/libs/libunwind/patches/003-fix-missing-ef_reg-defs-with-musl.patch
+++ b/package/libs/libunwind/patches/003-fix-missing-ef_reg-defs-with-musl.patch
@@ -1,6 +1,6 @@
 --- a/include/libunwind-mips.h
 +++ b/include/libunwind-mips.h
-@@ -114,6 +114,42 @@ typedef enum
+@@ -121,6 +121,42 @@ typedef enum
    }
  mips_regnum_t;
  

--- a/package/libs/libunwind/patches/004-ppc-musl.patch
+++ b/package/libs/libunwind/patches/004-ppc-musl.patch
@@ -1,6 +1,6 @@
 --- a/include/libunwind-ppc32.h
 +++ b/include/libunwind-ppc32.h
-@@ -74,6 +74,88 @@ typedef int64_t unw_sword_t;
+@@ -81,6 +81,88 @@ typedef int64_t unw_sword_t;
  
  typedef long double unw_tdep_fpreg_t;
  
@@ -91,7 +91,7 @@
      UNW_PPC32_R0,
 --- a/include/libunwind-ppc64.h
 +++ b/include/libunwind-ppc64.h
-@@ -81,6 +81,88 @@ typedef struct {
+@@ -88,6 +88,88 @@ typedef struct {
      uint64_t halves[2];
  } unw_tdep_vreg_t;
  
@@ -182,7 +182,7 @@
      UNW_PPC64_R0,
 --- a/src/ppc32/Ginit.c
 +++ b/src/ppc32/Ginit.c
-@@ -46,14 +46,19 @@ static void *
+@@ -46,10 +46,15 @@ static void *
  uc_addr (ucontext_t *uc, int reg)
  {
    void *addr;
@@ -193,191 +193,43 @@
 +#endif
  
    if ((unsigned) (reg - UNW_PPC32_R0) < 32)
+ #if defined(__linux__)
 -    addr = &uc->uc_mcontext.uc_regs->gregs[reg - UNW_PPC32_R0];
 +    addr = &mc->gregs[reg - UNW_PPC32_R0];
- 
-   else
+ #elif defined(__FreeBSD__)
+     addr = &uc->uc_mcontext.mc_gpr[reg - UNW_PPC32_R0];
+ #endif
+@@ -58,7 +63,7 @@ uc_addr (ucontext_t *uc, int reg)
    if ( ((unsigned) (reg - UNW_PPC32_F0) < 32) &&
         ((unsigned) (reg - UNW_PPC32_F0) >= 0) )
+ #if defined(__linux__)
 -    addr = &uc->uc_mcontext.uc_regs->fpregs.fpregs[reg - UNW_PPC32_F0];
 +    addr = &mc->fpregs.fpregs[reg - UNW_PPC32_F0];
- 
-   else
-     {
-@@ -76,7 +81,7 @@ uc_addr (ucontext_t *uc, int reg)
-         default:
+  #elif defined(__FreeBSD__)
+     addr = &uc->uc_mcontext.mc_fpreg[reg - UNW_PPC32_F0];
+ #endif
+@@ -85,7 +90,7 @@ uc_addr (ucontext_t *uc, int reg)
            return NULL;
          }
+ #if defined(__linux__)
 -      addr = &uc->uc_mcontext.uc_regs->gregs[gregs_idx];
 +      addr = &mc->gregs[gregs_idx];
-     }
-   return addr;
- }
+ #elif defined(__FreeBSD__)
+       addr = &uc->uc_mcontext.mc_gpr[gregs_idx];
+ #endif
 --- a/src/ppc32/ucontext_i.h
 +++ b/src/ppc32/ucontext_i.h
-@@ -46,83 +46,89 @@ WITH THE SOFTWARE OR THE USE OR OTHER DE
-    various structure members. */
- static ucontext_t dmy_ctxt UNUSED;
+@@ -44,8 +44,13 @@ WITH THE SOFTWARE OR THE USE OR OTHER DE
+ //#define MQ_IDX                36
+ #define LINK_IDX        36
  
--#define UC_MCONTEXT_GREGS_R0 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[0] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R1 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[1] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R2 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[2] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R3 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[3] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R4 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[4] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R5 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[5] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R6 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[6] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R7 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[7] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R8 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[8] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R9 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[9] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R10 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[10] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R11 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[11] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R12 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[12] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R13 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[13] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R14 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[14] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R15 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[15] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R16 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[16] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R17 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[17] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R18 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[18] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R19 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[19] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R20 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[20] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R21 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[21] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R22 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[22] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R23 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[23] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R24 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[24] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R25 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[25] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R26 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[26] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R27 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[27] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R28 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[28] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R29 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[29] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R30 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[30] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_R31 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[31] - (void *)&dmy_ctxt)
 +#ifdef __GLIBC__
-+#define UC_MCONTEXT_OFFSET(field) ((void *)&dmy_ctxt.uc_mcontext.uc_regs->field - (void *)&dmy_ctxt)
+ #define _UC_MCONTEXT_GPR(x) ( ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[x] - (void *)&dmy_ctxt) )
+ #define _UC_MCONTEXT_FPR(x) ( ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[x] - (void *)&dmy_ctxt) )
 +#else
-+#define UC_MCONTEXT_OFFSET(field) ((void *)&dmy_ctxt.uc_mcontext.field - (void *)&dmy_ctxt)
++#define _UC_MCONTEXT_GPR(x) ( ((void *)&dmy_ctxt.uc_mcontext.gregs[x] - (void *)&dmy_ctxt) )
++#define _UC_MCONTEXT_FPR(x) ( ((void *)&dmy_ctxt.uc_mcontext.fpregs.fpregs[x] - (void *)&dmy_ctxt) )
 +#endif
-+
-+#define UC_MCONTEXT_GREGS_R0 UC_MCONTEXT_OFFSET(gregs[0])
-+#define UC_MCONTEXT_GREGS_R1 UC_MCONTEXT_OFFSET(gregs[1])
-+#define UC_MCONTEXT_GREGS_R2 UC_MCONTEXT_OFFSET(gregs[2])
-+#define UC_MCONTEXT_GREGS_R3 UC_MCONTEXT_OFFSET(gregs[3])
-+#define UC_MCONTEXT_GREGS_R4 UC_MCONTEXT_OFFSET(gregs[4])
-+#define UC_MCONTEXT_GREGS_R5 UC_MCONTEXT_OFFSET(gregs[5])
-+#define UC_MCONTEXT_GREGS_R6 UC_MCONTEXT_OFFSET(gregs[6])
-+#define UC_MCONTEXT_GREGS_R7 UC_MCONTEXT_OFFSET(gregs[7])
-+#define UC_MCONTEXT_GREGS_R8 UC_MCONTEXT_OFFSET(gregs[8])
-+#define UC_MCONTEXT_GREGS_R9 UC_MCONTEXT_OFFSET(gregs[9])
-+#define UC_MCONTEXT_GREGS_R10 UC_MCONTEXT_OFFSET(gregs[10])
-+#define UC_MCONTEXT_GREGS_R11 UC_MCONTEXT_OFFSET(gregs[11])
-+#define UC_MCONTEXT_GREGS_R12 UC_MCONTEXT_OFFSET(gregs[12])
-+#define UC_MCONTEXT_GREGS_R13 UC_MCONTEXT_OFFSET(gregs[13])
-+#define UC_MCONTEXT_GREGS_R14 UC_MCONTEXT_OFFSET(gregs[14])
-+#define UC_MCONTEXT_GREGS_R15 UC_MCONTEXT_OFFSET(gregs[15])
-+#define UC_MCONTEXT_GREGS_R16 UC_MCONTEXT_OFFSET(gregs[16])
-+#define UC_MCONTEXT_GREGS_R17 UC_MCONTEXT_OFFSET(gregs[17])
-+#define UC_MCONTEXT_GREGS_R18 UC_MCONTEXT_OFFSET(gregs[18])
-+#define UC_MCONTEXT_GREGS_R19 UC_MCONTEXT_OFFSET(gregs[19])
-+#define UC_MCONTEXT_GREGS_R20 UC_MCONTEXT_OFFSET(gregs[20])
-+#define UC_MCONTEXT_GREGS_R21 UC_MCONTEXT_OFFSET(gregs[21])
-+#define UC_MCONTEXT_GREGS_R22 UC_MCONTEXT_OFFSET(gregs[22])
-+#define UC_MCONTEXT_GREGS_R23 UC_MCONTEXT_OFFSET(gregs[23])
-+#define UC_MCONTEXT_GREGS_R24 UC_MCONTEXT_OFFSET(gregs[24])
-+#define UC_MCONTEXT_GREGS_R25 UC_MCONTEXT_OFFSET(gregs[25])
-+#define UC_MCONTEXT_GREGS_R26 UC_MCONTEXT_OFFSET(gregs[26])
-+#define UC_MCONTEXT_GREGS_R27 UC_MCONTEXT_OFFSET(gregs[27])
-+#define UC_MCONTEXT_GREGS_R28 UC_MCONTEXT_OFFSET(gregs[28])
-+#define UC_MCONTEXT_GREGS_R29 UC_MCONTEXT_OFFSET(gregs[29])
-+#define UC_MCONTEXT_GREGS_R30 UC_MCONTEXT_OFFSET(gregs[30])
-+#define UC_MCONTEXT_GREGS_R31 UC_MCONTEXT_OFFSET(gregs[31])
  
--#define UC_MCONTEXT_GREGS_MSR ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[MSR_IDX] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_ORIG_GPR3 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[ORIG_GPR3_IDX] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_CTR ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[CTR_IDX] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_LINK ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[LINK_IDX] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_XER ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[XER_IDX] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_CCR ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[CCR_IDX] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_SOFTE ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[SOFTE_IDX] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_TRAP ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[TRAP_IDX] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_DAR ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[DAR_IDX] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_DSISR ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[DSISR_IDX] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_GREGS_RESULT ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[RESULT_IDX] - (void *)&dmy_ctxt)
-+#define UC_MCONTEXT_GREGS_MSR UC_MCONTEXT_OFFSET(gregs[MSR_IDX])
-+#define UC_MCONTEXT_GREGS_ORIG_GPR3 UC_MCONTEXT_OFFSET(gregs[ORIG_GPR3_IDX])
-+#define UC_MCONTEXT_GREGS_CTR UC_MCONTEXT_OFFSET(gregs[CTR_IDX])
-+#define UC_MCONTEXT_GREGS_LINK UC_MCONTEXT_OFFSET(gregs[LINK_IDX])
-+#define UC_MCONTEXT_GREGS_XER UC_MCONTEXT_OFFSET(gregs[XER_IDX])
-+#define UC_MCONTEXT_GREGS_CCR UC_MCONTEXT_OFFSET(gregs[CCR_IDX])
-+#define UC_MCONTEXT_GREGS_SOFTE UC_MCONTEXT_OFFSET(gregs[SOFTE_IDX])
-+#define UC_MCONTEXT_GREGS_TRAP UC_MCONTEXT_OFFSET(gregs[TRAP_IDX])
-+#define UC_MCONTEXT_GREGS_DAR UC_MCONTEXT_OFFSET(gregs[DAR_IDX])
-+#define UC_MCONTEXT_GREGS_DSISR UC_MCONTEXT_OFFSET(gregs[DSISR_IDX])
-+#define UC_MCONTEXT_GREGS_RESULT UC_MCONTEXT_OFFSET(gregs[RESULT_IDX])
- 
--#define UC_MCONTEXT_FREGS_R0 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[0] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R1 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[1] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R2 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[2] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R3 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[3] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R4 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[4] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R5 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[5] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R6 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[6] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R7 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[7] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R8 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[8] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R9 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[9] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R10 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[10] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R11 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[11] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R12 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[12] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R13 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[13] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R14 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[14] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R15 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[15] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R16 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[16] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R17 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[17] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R18 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[18] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R19 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[19] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R20 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[20] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R21 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[21] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R22 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[22] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R23 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[23] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R24 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[24] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R25 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[25] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R26 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[26] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R27 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[27] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R28 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[28] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R29 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[29] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R30 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[30] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_R31 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[31] - (void *)&dmy_ctxt)
--#define UC_MCONTEXT_FREGS_FPSCR ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[32] - (void *)&dmy_ctxt)
-+#define UC_MCONTEXT_FREGS_R0 UC_MCONTEXT_OFFSET(fpregs.fpregs[0])
-+#define UC_MCONTEXT_FREGS_R1 UC_MCONTEXT_OFFSET(fpregs.fpregs[1])
-+#define UC_MCONTEXT_FREGS_R2 UC_MCONTEXT_OFFSET(fpregs.fpregs[2])
-+#define UC_MCONTEXT_FREGS_R3 UC_MCONTEXT_OFFSET(fpregs.fpregs[3])
-+#define UC_MCONTEXT_FREGS_R4 UC_MCONTEXT_OFFSET(fpregs.fpregs[4])
-+#define UC_MCONTEXT_FREGS_R5 UC_MCONTEXT_OFFSET(fpregs.fpregs[5])
-+#define UC_MCONTEXT_FREGS_R6 UC_MCONTEXT_OFFSET(fpregs.fpregs[6])
-+#define UC_MCONTEXT_FREGS_R7 UC_MCONTEXT_OFFSET(fpregs.fpregs[7])
-+#define UC_MCONTEXT_FREGS_R8 UC_MCONTEXT_OFFSET(fpregs.fpregs[8])
-+#define UC_MCONTEXT_FREGS_R9 UC_MCONTEXT_OFFSET(fpregs.fpregs[9])
-+#define UC_MCONTEXT_FREGS_R10 UC_MCONTEXT_OFFSET(fpregs.fpregs[10])
-+#define UC_MCONTEXT_FREGS_R11 UC_MCONTEXT_OFFSET(fpregs.fpregs[11])
-+#define UC_MCONTEXT_FREGS_R12 UC_MCONTEXT_OFFSET(fpregs.fpregs[12])
-+#define UC_MCONTEXT_FREGS_R13 UC_MCONTEXT_OFFSET(fpregs.fpregs[13])
-+#define UC_MCONTEXT_FREGS_R14 UC_MCONTEXT_OFFSET(fpregs.fpregs[14])
-+#define UC_MCONTEXT_FREGS_R15 UC_MCONTEXT_OFFSET(fpregs.fpregs[15])
-+#define UC_MCONTEXT_FREGS_R16 UC_MCONTEXT_OFFSET(fpregs.fpregs[16])
-+#define UC_MCONTEXT_FREGS_R17 UC_MCONTEXT_OFFSET(fpregs.fpregs[17])
-+#define UC_MCONTEXT_FREGS_R18 UC_MCONTEXT_OFFSET(fpregs.fpregs[18])
-+#define UC_MCONTEXT_FREGS_R19 UC_MCONTEXT_OFFSET(fpregs.fpregs[19])
-+#define UC_MCONTEXT_FREGS_R20 UC_MCONTEXT_OFFSET(fpregs.fpregs[20])
-+#define UC_MCONTEXT_FREGS_R21 UC_MCONTEXT_OFFSET(fpregs.fpregs[21])
-+#define UC_MCONTEXT_FREGS_R22 UC_MCONTEXT_OFFSET(fpregs.fpregs[22])
-+#define UC_MCONTEXT_FREGS_R23 UC_MCONTEXT_OFFSET(fpregs.fpregs[23])
-+#define UC_MCONTEXT_FREGS_R24 UC_MCONTEXT_OFFSET(fpregs.fpregs[24])
-+#define UC_MCONTEXT_FREGS_R25 UC_MCONTEXT_OFFSET(fpregs.fpregs[25])
-+#define UC_MCONTEXT_FREGS_R26 UC_MCONTEXT_OFFSET(fpregs.fpregs[26])
-+#define UC_MCONTEXT_FREGS_R27 UC_MCONTEXT_OFFSET(fpregs.fpregs[27])
-+#define UC_MCONTEXT_FREGS_R28 UC_MCONTEXT_OFFSET(fpregs.fpregs[28])
-+#define UC_MCONTEXT_FREGS_R29 UC_MCONTEXT_OFFSET(fpregs.fpregs[29])
-+#define UC_MCONTEXT_FREGS_R30 UC_MCONTEXT_OFFSET(fpregs.fpregs[30])
-+#define UC_MCONTEXT_FREGS_R31 UC_MCONTEXT_OFFSET(fpregs.fpregs[31])
-+#define UC_MCONTEXT_FREGS_FPSCR UC_MCONTEXT_OFFSET(fpregs.fpregs[32])
- 
- #endif
+ /* These are dummy structures used only for obtaining the offsets of the
+    various structure members. */


### PR DESCRIPTION
Rebased patches:
- 003-fix-missing-ef_reg-defs-with-musl.patch
- 004-ppc-musl.patch

P.S. There's plenty of release notes from 1.6.2 to 1.8.1 which can't be pasted here
Please refer to: https://github.com/libunwind/libunwind/releases