### PR TITLE
grub2: update to 2.12

### DIFF
--- a/package/boot/grub2/Makefile
+++ b/package/boot/grub2/Makefile
@@ -6,12 +6,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=grub
-PKG_VERSION:=2.06
-PKG_RELEASE:=6
+PKG_VERSION:=2.12
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/grub
-PKG_HASH:=b79ea44af91b93d17cd3fe80bdae6ed43770678a9a5ae192ccea803ebb657ee1
+PKG_HASH:=f3c97391f7c4eaa677a78e090c7e97e6dc47b16f655f04683ebd37bef7fe0faa
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_CPE_ID:=cpe:/a:gnu:grub2

--- a/package/boot/grub2/patches/001-add-missing-extra_deps-list.patch
+++ b/package/boot/grub2/patches/001-add-missing-extra_deps-list.patch
@@ -1,0 +1,31 @@
+From 4d4dae6a52b1749642261a15f5dcc1e3d4150b36 Mon Sep 17 00:00:00 2001
+From: Julien Olivain <ju.o@free.fr>
+Date: Fri, 22 Dec 2023 19:02:53 +0100
+Subject: [PATCH] Add missing grub-core/extra_deps.lst file in release tarball
+
+A file is missing in the grub-2.12 release tarballs (both .gz and .xz).
+See [1]. The issue was reported in [2] and fixed upstream in [3].
+
+This patch adds the missing file, on top of the release tarball. This
+patch won't apply on upstream git, since the file is present in the
+source repository. Since the issue is fixed upstream in [3], it is
+expected upcoming releases tarballs will include the file.
+
+The file content was fetched from the upstream git repo:
+https://git.savannah.gnu.org/gitweb/?p=grub.git;a=blob_plain;f=grub-core/extra_deps.lst;hb=refs/tags/grub-2.12
+
+[1] https://ftp.gnu.org/gnu/grub/grub-2.12.tar.xz
+[2] https://lists.gnu.org/archive/html/grub-devel/2023-12/msg00054.html
+[3] https://git.savannah.gnu.org/gitweb/?p=grub.git;a=commit;h=b835601c7639ed1890f2d3db91900a8506011a8e
+
+Signed-off-by: Julien Olivain <ju.o@free.fr>
+Upstream: Fixed by: https://git.savannah.gnu.org/gitweb/?p=grub.git;a=commit;h=b835601c7639ed1890f2d3db91900a8506011a8e
+---
+ grub-core/extra_deps.lst | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 100644 grub-core/extra_deps.lst
+
+--- /dev/null
++++ b/grub-core/extra_deps.lst
+@@ -0,0 +1 @@
++depends bli part_gpt

--- a/package/boot/grub2/patches/100-grub_setup_root.patch
+++ b/package/boot/grub2/patches/100-grub_setup_root.patch
@@ -1,6 +1,6 @@
 --- a/include/grub/util/install.h
 +++ b/include/grub/util/install.h
-@@ -198,13 +198,13 @@ grub_install_get_image_target (const cha
+@@ -199,13 +199,13 @@ grub_install_get_image_target (const cha
  void
  grub_util_bios_setup (const char *dir,
  		      const char *boot_file, const char *core_file,
@@ -18,7 +18,7 @@
  
 --- a/util/grub-install.c
 +++ b/util/grub-install.c
-@@ -1721,7 +1721,7 @@ main (int argc, char *argv[])
+@@ -1770,7 +1770,7 @@ main (int argc, char *argv[])
  	if (install_bootsector)
  	  {
  	    grub_util_bios_setup (platdir, "boot.img", "core.img",
@@ -27,7 +27,7 @@
  				  fs_probe, allow_floppy, add_rs_codes,
  				  !grub_install_is_short_mbrgap_supported ());
  
-@@ -1752,7 +1752,7 @@ main (int argc, char *argv[])
+@@ -1801,7 +1801,7 @@ main (int argc, char *argv[])
  	if (install_bootsector)
  	  {
  	    grub_util_sparc_setup (platdir, "boot.img", "core.img",


### PR DESCRIPTION
New in 2.12:

* GCC 13 support.
* clang 14 support.
* binutils 2.38 support.
* Unification of EFI Linux kernel loader across architectures.
* Transition to EFI Linux kernel stub loader for x86 architecture.
* Initial support for Boot Loader Interface.
* Support for dynamic GRUB runtime memory addition using firmware calls.
* PCI and MMIO UARTs support.
* SDL2 support.
* LoongArch support.
* TPM driver fixes.
* Many filesystems fixes.
* Many CVE and Coverity fixes.
* Debugging support improvements.
* Tests improvements.
* Documentation improvements.
* ...and tons of other fixes and cleanups...

Tested platforms:
| Platform | Firmware | Boot device |
| --- | --- | --- |
| x86 | CSM | USB Drive |
| x86 | CSM | CD Drive |
| x86_64 | CSM | USB Drive |
| x86_64 | CSM | CD Drive |
| x86_64 | UEFI * | USB Drive |
| x86_64 | UEFI * | CD Drive |
| loongarch64 | UEFI * | USB Drive |

\* Secure Boot disabled