### PR TITLE
uboot-envtools: add env settings for Edgerouter-X

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -100,7 +100,9 @@ linksys,ea7300-v2|\
 linksys,ea7500-v2|\
 linksys,ea8100-v1|\
 linksys,ea8100-v2|\
-mts,wg430223)
+mts,wg430223|\
+ubnt,edgerouter-x|\
+ubnt,edgerouter-x-sfp)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
 	;;
 snr,snr-cpe-me1|\


### PR DESCRIPTION
uboot-envtools is currently missing config for Edgerouter-X and its not immediately obvious what settings to manually apply.

This PR will provide default configuration for envtools on Edgerouter-X and X-sfp. Tested on Edgerouter-X.

I have not changed the DEVICE_PACKAGES to install this by default, since it is not required by sysupgrade, so left it as optional package. 

