### PR TITLE
scripts: ubinize-image.sh: fix support for static volume

### DIFF
--- a/scripts/ubinize-image.sh
+++ b/scripts/ubinize-image.sh
@@ -90,10 +90,10 @@ ubilayout() {
 			rootsize="$( round_up "$( stat -c%s "$2" )" 1024 )"
 			;;
 		esac
-		ubivol $vol_id rootfs "$2" "$autoresize" "$rootsize" dynamic
+		ubivol $vol_id rootfs "$2" "$autoresize" "$rootsize"
 
 		vol_id=$(( vol_id + 1 ))
-		[ "$rootfs_type" = "ubifs" ] || ubivol $vol_id rootfs_data "" 1 dymamic
+		[ "$rootfs_type" = "ubifs" ] || ubivol $vol_id rootfs_data "" 1
 	fi
 }
 


### PR DESCRIPTION
Apart from being misspelled ('dymamic' vs. 'dynamic') and a mismatch of the number of parameters, there is also simply no need to add the 'dynamic' volume type keyword as 6th parameter as that's the default anyway. Fix and simplify the ubinize-image.sh script to work as intended.

Fixes: 6c17d71973 ("scripts: ubinize-image.sh: support static volumes, make size optional")
Reported-by: @hnyman