### PR TITLE
prereq-build: add Python 3.12 support

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -182,6 +182,7 @@ $(eval $(call SetupHostCommand,perl,Please install Perl 5.x, \
 	perl --version | grep "perl.*v5"))
 
 $(eval $(call SetupHostCommand,python,Please install Python >= 3.7, \
+	python3.12 -V 2>&1 | grep 'Python 3', \
 	python3.11 -V 2>&1 | grep 'Python 3', \
 	python3.10 -V 2>&1 | grep 'Python 3', \
 	python3.9 -V 2>&1 | grep 'Python 3', \
@@ -190,6 +191,7 @@ $(eval $(call SetupHostCommand,python,Please install Python >= 3.7, \
 	python3 -V 2>&1 | grep -E 'Python 3\.([7-9]|[0-9][0-9])\.?'))
 
 $(eval $(call SetupHostCommand,python3,Please install Python >= 3.7, \
+	python3.12 -V 2>&1 | grep 'Python 3', \
 	python3.11 -V 2>&1 | grep 'Python 3', \
 	python3.10 -V 2>&1 | grep 'Python 3', \
 	python3.9 -V 2>&1 | grep 'Python 3', \
@@ -199,7 +201,8 @@ $(eval $(call SetupHostCommand,python3,Please install Python >= 3.7, \
 
 $(eval $(call TestHostCommand,python3-distutils, \
 	Please install the Python3 distutils module, \
-	$(STAGING_DIR_HOST)/bin/python3 -c 'from distutils import util'))
+	echo -e 'from sys import version_info\nif version_info < (3, 12):\n\tfrom distutils import util' | \
+		$(STAGING_DIR_HOST)/bin/python3 -))
 
 $(eval $(call TestHostCommand,python3-stdlib, \
 	Please install the Python3 stdlib module, \


### PR DESCRIPTION
After distutils had already been deprecated in Python 3.10 and 3.11, it has been removed in Python 3.12: https://peps.python.org/pep-0632/

Therefore, limit the python distutils check to Python versions <v3.12.

This commit is mostly just a combination of reverted commit 7ceb76ca3a37ba6b722df39ba0838909fa7cf7b4 "prereq-build: add Python 3.12 support"
and
commit 8e3a1e21d35229cee6f2519db5e9a3eccb275e37 "prereq-build: limit python distutils check to <v3.12"
from https://github.com/openwrt/openwrt/pull/11747

I have merely added the `-e` parameter to the `echo` command in the fixed distutils check.

Note: This does NOT magically fix code that still relies on distutils.

Co-authored-by: Rosen Penev <rosenp@gmail.com>
Co-authored-by: Andre Heider <a.heider@gmail.com>
Signed-off-by: Pascal Ernster <git@hardfalcon.net>