### PR TITLE
[23.05] toolchain: kernel-headers: backport two fixes

### DIFF
--- a/toolchain/kernel-headers/Makefile
+++ b/toolchain/kernel-headers/Makefile
@@ -93,7 +93,6 @@ define Host/Prepare
 endef
 
 define Host/Configure
-	env
 	yes '' | $(HOST_KMAKE) oldconfig
 	$(call Host/Configure/all)
 	$(call Host/Configure/post/$(ARCH))

--- a/toolchain/kernel-headers/Makefile
+++ b/toolchain/kernel-headers/Makefile
@@ -24,7 +24,10 @@ ifneq ($(call qstrip,$(CONFIG_KERNEL_GIT_CLONE_URI)),)
   PKG_SOURCE_VERSION:=$(call qstrip,$(CONFIG_KERNEL_GIT_REF))
   PKG_MIRROR_HASH:=$(call qstrip,$(CONFIG_KERNEL_GIT_MIRROR_HASH))
 ifdef CHECK
+  PLATFORM_DIR:=$(firstword $(wildcard $(TOPDIR)/target/linux/feeds/$(BOARD) $(TOPDIR)/target/linux/$(BOARD)))
+  include $(PLATFORM_DIR)/Makefile
   include $(INCLUDE_DIR)/kernel-version.mk
+  include $(INCLUDE_DIR)/kernel-build.mk
   PKG_VERSION:=$(LINUX_VERSION)
 else
   PKG_SOURCE:=$(LINUX_SOURCE)


### PR DESCRIPTION
I've just hit the issue fixed in 3552809c7c and while at it, I would like to backport def41cf2bab as well.