### PR TITLE
tools/zstd: enable position independent code compilation

### DIFF
--- a/tools/zstd/Makefile
+++ b/tools/zstd/Makefile
@@ -17,6 +17,8 @@ include $(INCLUDE_DIR)/host-build.mk
 
 HOSTCC:= $(HOSTCC_NOCACHE)
 
+HOST_CFLAGS += $(HOST_FPIC)
+
 HOST_MAKE_FLAGS += \
 	BACKTRACE=0 \
 	HAVE_THREAD=1 \


### PR DESCRIPTION
Fixes tools/llvm-bpf compilation errors

Fixes https://github.com/openwrt/openwrt/issues/15247.