### PR TITLE
buildsystem: improve maintainer information handling

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -279,12 +279,11 @@ endef
 define Image/Manifest
 	$(call opkg,$(TARGET_DIR_ORIG)) list-installed > \
 		$(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED)).manifest
-ifndef IB
-	$(if $(CONFIG_JSON_CYCLONEDX_SBOM), \
-		$(SCRIPT_DIR)/package-metadata.pl imgcyclonedxsbom \
-		$(TMP_DIR)/.packageinfo \
+ifneq ($(CONFIG_JSON_CYCLONEDX_SBOM),)
+	$(SCRIPT_DIR)/package-metadata.pl imgcyclonedxsbom \
+		$(if $(IB),$(TOPDIR)/.packageinfo, $(TMP_DIR)/.packageinfo) \
 		$(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED)).manifest > \
-		$(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED)).bom.cdx.json)
+		$(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED)).bom.cdx.json
 endif
 endef
 

--- a/include/package-dumpinfo.mk
+++ b/include/package-dumpinfo.mk
@@ -44,7 +44,6 @@ $(if $(KCONFIG),Kernel-Config: $(KCONFIG)
 )$(if $(BUILDONLY),Build-Only: $(BUILDONLY)
 )$(if $(HIDDEN),Hidden: $(HIDDEN)
 )Description: $(if $(Package/$(1)/description),$(Package/$(1)/description),$(TITLE))
-$(MAINTAINER)
 @@
 $(if $(Package/$(1)/config),Config:
 $(Package/$(1)/config)

--- a/include/rootfs.mk
+++ b/include/rootfs.mk
@@ -60,6 +60,12 @@ ifdef CONFIG_CLEAN_IPKG
   endef
 endif
 
+# Remove not needed information from the control file
+# 1: roofs base path
+define clean_control_file
+	-sed -i '/^Maintainer: /d' $(1)/usr/lib/opkg/info/*.control
+endef
+
 define prepare_rootfs
 	$(if $(2),@if [ -d '$(2)' ]; then \
 		$(call file_copy,$(2)/.,$(1)); \
@@ -101,6 +107,7 @@ define prepare_rootfs
 		$(1)/usr/lib/opkg/lists/* \
 		$(1)/var/lock/*.lock
 	$(call clean_ipkg,$(1))
+	$(call clean_control_file,$(1))
 	$(call mklibs,$(1))
 	$(if $(SOURCE_DATE_EPOCH),find $(1)/ -mindepth 1 -execdir touch -hcd "@$(SOURCE_DATE_EPOCH)" "{}" +)
 endef


### PR DESCRIPTION
The two commits are not dependent on each other, but affect the maintainer handling.

- @aparcar remove duplicate MAINTAINER from package-dumpinfo.mk
- @Ansuel @ynezz remove Maintainer info from ipkg control file on the target