### PR TITLE
mpc85xx: fix address config for ws-ap3825i

### DIFF
--- a/target/linux/mpc85xx/image/p1020.mk
+++ b/target/linux/mpc85xx/image/p1020.mk
@@ -79,8 +79,8 @@ define Device/extreme-networks_ws-ap3825i
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
   BLOCKSIZE := 128k
   KERNEL_NAME := simpleImage.ws-ap3825i
-  KERNEL_ENTRY := 0x1000000
-  KERNEL_LOADADDR := 0x1000000
+  KERNEL_ENTRY := 0x1500000
+  KERNEL_LOADADDR := 0x1500000
   KERNEL = kernel-bin | fit none $(KDIR)/image-$$(DEVICE_DTS).dtb
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata


### PR DESCRIPTION
In commit 6a8b83159389 ("mpc85xx: p1010: change wrapper address of simple image devices"), we adjusted the wrapper address in the recipe code for all mpc85xx simpleimage devices, including the Extreme Networks WS-AP3825i. However, we did not also adjust the KERNEL_LOADADDR and KERNEL_ENTRY config values for this board. This broke the simpleimage wrapper loader, causing GitHub issue #15237.

Adjust those config values so we go back to pointing at the right address. We don't exactly need the memory, but it's also not exactly a punishment in this case.

Run-tested on a ws-ap3825i.

Fixes: commit 6a8b83159389 ("mpc85xx: p1010: change wrapper address of simple image devices")

Tested-by: Martin Kennedy <hurricos@gmail.com>

Signed-off-by: Martin Kennedy <hurricos@gmail.com>

