### PR TITLE
ramips: Add support for D-Link DIR-2150-A1

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-2150-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-2150-a1.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_dlink_dir_nand_128m.dtsi"
+
+/ {
+	compatible = "dlink,dir-2150-a1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-2150 A1";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -769,6 +769,16 @@ define Device/dlink_dir-1960-a1
 endef
 TARGET_DEVICES += dlink_dir-1960-a1
 
+define Device/dlink_dir-2150-a1
+  $(Device/dlink_dir_nand_128m)
+  DEVICE_MODEL := DIR-2150
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES += kmod-mt7603 -kmod-usb3 -kmod-usb-ledtrig-usbport
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(IMAGE/recovery.bin) | dlink-sge-image $$(DEVICE_MODEL)
+endef
+TARGET_DEVICES += dlink_dir-2150-a1
+
 define Device/dlink_dir-2640-a1
   $(Device/dlink_dir_nand_128m)
   DEVICE_MODEL := DIR-2640

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -92,6 +92,7 @@ dlink,dap-x1860-a1)
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan1" "76" "100"
 	;;
 dlink,dir-1960-a1|\
+dlink,dir-2150-a1|\
 dlink,dir-2640-a1|\
 dlink,dir-2660-a1)
 	ucidef_set_led_netdev "wan" "wan" "white:wan" "wan"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -71,6 +71,7 @@ platform_do_upgrade() {
 	dlink,covr-x1860-a1|\
 	dlink,dap-x1860-a1|\
 	dlink,dir-1960-a1|\
+	dlink,dir-2150-a1|\
 	dlink,dir-2640-a1|\
 	dlink,dir-2660-a1|\
 	dlink,dir-3040-a1|\


### PR DESCRIPTION
Hardware Specification:
SoC: Mediatek MT7621DAT (MIPS1004Kc 880 MHz, dual core)
RAM: 128 MB
Storage: 128 MB NAND flash
Ethernet: 5x 10/100/1000 Mbps LAN1,LAN2,LAN3,LAN4 & WAN 
Wireless: 2.4GHz: Mediatek MT7603EN up to 300Mbps (802.11b/g/n MIMO 2x2) 
Wireless: 5GHz: Mediatek MT7615N up to 1733Mbps (802.11n/ac MU-MIMO 4x4) 
LEDs: Power (white & amber), Internet (white & amber) 
LEDs: 2.4G (White), 5Ghz (White)
Buttons: WPS, Reset

MAC Table
Label	xx:xx:xx:xx:xx:EB
LAN         xx:xx:xx:xx:xx:EB
2.4Ghz	xx:xx:xx:xx:xx:EC
5Ghz	xx:xx:xx:xx:xx:ED
WAN	xx:xx:xx:xx:xx:EE

Flash instructions:
D-Link normal OEM firmware update page
	1. upload OpenWRT factory.bin like any D-Link upgrade image

D-Link Recovery GUI:
    1. Push and hold reset button (on the bottom of the device) until power led starts flashing (about 10 secs or so) while plugging in the power cable.
    2. Give it ~30 seconds, to boot the recovery mode GUI
    3. Connect your client computer to LAN1 of the device
    4. Set your client IP address manually to 192.168.0.2 / 255.255.255.0
    5. Call the recovery page for the device at http://192.168.0.1/
    6. Use the provided emergency web GUI to upload the recovery.bin to the device

Firefox on Windows in a Private Window (incognito) works me
Internet Explorer mode in Microsoft Edge works for others
seems to not work in Linux or virtual machine on Linux for most
some see success using 'curl -v -i -F "firmware=@file.bin" 192.168.0.1'

Thanks to @frkca and @rodneyrod for testing and pushing for its creation

Successor of PR https://github.com/openwrt/openwrt/pull/15275
update of https://github.com/openwrt/openwrt/pull/12624