### PR TITLE
ipq40xx: fix USB on Aruba AP-303H

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
@@ -64,10 +64,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -430,7 +426,16 @@
 	};
 };
 
-&usb2_hs_phy {
+&usb3 {
+	status = "okay";
+};
+
+&usb3_dwc {
+	phys = <&usb3_hs_phy>;
+	phy-names = "usb2-phy";
+};
+
+&usb3_hs_phy {
 	status = "okay";
 };
 


### PR DESCRIPTION
Disable USB 2.0 controller, enable USB 3.0 controller in device tree.

The USB 2.0 port on the AP-303H is actually connected to the USB 3.0 controller's HS phy. The SS phy must also be enabled, even though the SuperSpeed lanes aren't brought out to the connector.