### PR TITLE
qualcommax: IPQ807x: ZyXEL NBG7815: Fix random Wifi MAC

### DIFF
--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -26,8 +26,7 @@ case "$FIRMWARE" in
 	xiaomi,ax9000|\
 	yuncore,ax880|\
 	zbtlink,zbt-z800ax|\
-	zte,mf269|\
-	zyxel,nbg7815)
+	zte,mf269)
 		caldata_extract "0:art" 0x1000 0x20000
 		;;
 	linksys,mx4200v1)
@@ -53,6 +52,14 @@ case "$FIRMWARE" in
 	prpl,haze|\
 	spectrum,sax1v1k)
 		caldata_extract_mmc "0:ART" 0x1000 0x20000
+		;;
+	zyxel,nbg7815)
+		caldata_extract "0:art" 0x1000 0x20000
+		label_mac=$(get_mac_label)
+		ath11k_patch_mac $(macaddr_add $label_mac 3) 0
+		ath11k_patch_mac $(macaddr_add $label_mac 2) 1
+		ath11k_patch_mac $(macaddr_add $label_mac 4) 2
+		ath11k_set_macflag
 		;;
 	esac
 	;;


### PR DESCRIPTION
For this particualar device we get random MAC's for Wifi on each (re-)boot. This is because art partition/pre caldata do not contain valid MAC addresses.

As we have now a new/better approach with ath11k_patch_mac we can use it for this device too.

I'm using this approach for like two weeks and its working flawlessly.