### PR TITLE
build: some fixes for the buildsystem

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -279,12 +279,11 @@ endef
 define Image/Manifest
 	$(call opkg,$(TARGET_DIR_ORIG)) list-installed > \
 		$(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED)).manifest
-ifndef IB
-	$(if $(CONFIG_JSON_CYCLONEDX_SBOM), \
-		$(SCRIPT_DIR)/package-metadata.pl imgcyclonedxsbom \
-		$(TMP_DIR)/.packageinfo \
+ifneq ($(CONFIG_JSON_CYCLONEDX_SBOM),)
+	$(SCRIPT_DIR)/package-metadata.pl imgcyclonedxsbom \
+		$(if $(IB),$(TOPDIR)/.packageinfo, $(TMP_DIR)/.packageinfo) \
 		$(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED)).manifest > \
-		$(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED)).bom.cdx.json)
+		$(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED)).bom.cdx.json
 endif
 endef
 

--- a/include/package-dumpinfo.mk
+++ b/include/package-dumpinfo.mk
@@ -44,7 +44,6 @@ $(if $(KCONFIG),Kernel-Config: $(KCONFIG)
 )$(if $(BUILDONLY),Build-Only: $(BUILDONLY)
 )$(if $(HIDDEN),Hidden: $(HIDDEN)
 )Description: $(if $(Package/$(1)/description),$(Package/$(1)/description),$(TITLE))
-$(MAINTAINER)
 @@
 $(if $(Package/$(1)/config),Config:
 $(Package/$(1)/config)


### PR DESCRIPTION
@aparcar @Ansuel @ynezz  
build: remove duplicate MAINTAINER from package-dumpinfo.mk(https://github.com/openwrt/openwrt/commit/6a1f5f3960a4284d6f503edd25914c917fec903d)
build: also generate the CycloneDX SBOM in imagebuilder(https://github.com/openwrt/openwrt/commit/1f38d1ff02f59995833311b22bae06d98bf6ea0c)

This is a follow up PR from:
https://github.com/openwrt/openwrt/pull/15253