### PR TITLE
ipq40xx: use nvmem ethernet MACs on Aruba AP-303H

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
@@ -362,7 +362,9 @@
 					#size-cells = <1>;
 
 					macaddr_mfginfo_1d: macaddr@1d {
+						compatible = "mac-base";
 						reg = <0x1d 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 
 					macaddr_mfginfo_45: macaddr@45 {
@@ -434,6 +436,9 @@
 
 &gmac {
 	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_mfginfo_1d 1>;
 };
 
 &switch {
@@ -462,6 +467,8 @@
 	status = "okay";
 
 	label = "wan";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_mfginfo_1d 0>;
 };
 
 &wifi0 {


### PR DESCRIPTION
Use NVMEM to assign "factory sticker" MAC address to WAN ethernet interface. Set LAN address to sticker + 1.
