### PR TITLE
sunxi: use CONFIG_LINUX_6_1 for dts dir condition

### DIFF
--- a/target/linux/sunxi/image/Makefile
+++ b/target/linux/sunxi/image/Makefile
@@ -34,7 +34,7 @@ define Device/Default
   KERNEL := kernel-bin | uImage none
   IMAGES := sdcard.img.gz
   IMAGE/sdcard.img.gz := sunxi-sdcard | append-metadata | gzip
-ifneq ($(LINUX_6_1),)
+ifneq ($(CONFIG_LINUX_6_1),)
   SUNXI_DTS_DIR :=
 else
   SUNXI_DTS_DIR :=allwinner/


### PR DESCRIPTION
Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
