### PR TITLE
toolchain/nasm: fix PKG_CPE_ID

### DIFF
--- a/toolchain/nasm/Makefile
+++ b/toolchain/nasm/Makefile
@@ -10,7 +10,7 @@ PKG_VERSION:=2.16.01
 PKG_SOURCE_URL:=https://www.nasm.us/pub/nasm/releasebuilds/$(PKG_VERSION)/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_HASH:=c77745f4802375efeee2ec5c0ad6b7f037ea9c87c92b149a9637ff099f162558
-PKG_CPE_ID:=cpe:/a:nasm:nasm
+PKG_CPE_ID:=cpe:/a:nasm:netwide_assembler
 
 HOST_BUILD_PARALLEL:=1
 


### PR DESCRIPTION
`cpe:/a:nasm:netwide_assembler` is the correct CPE ID for nasm: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:nasm:netwide_assembler

Fixes: bcf02c5d3123a99c717ca33f1d7c6250acf0f33f (toolchain: assign PKG_CPE_ID)