### PR TITLE
tools/flex: fix PKG_CPE_ID

### DIFF
--- a/tools/flex/Makefile
+++ b/tools/flex/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=flex
-PKG_CPE_ID:=cpe:/a:flex_project:flex
+PKG_CPE_ID:=cpe:/a:westes:flex
 PKG_VERSION:=2.6.4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz


### PR DESCRIPTION
`cpe:/a:westes:flex` is the correct CPE ID for flex: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:westes:flex

Fixes: c61a2395140d92cdd37d3d6ee43a765427e8e318 (add PKG_CPE_ID ids to package and tools )
