### PR TITLE
tools/zlib: fix PKG_CPE_ID

### DIFF
--- a/tools/zlib/Makefile
+++ b/tools/zlib/Makefile
@@ -17,7 +17,7 @@ PKG_HASH:=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
 
 PKG_LICENSE:=Zlib
 PKG_LICENSE_FILES:=README
-PKG_CPE_ID:=cpe:/a:gnu:zlib
+PKG_CPE_ID:=cpe:/a:zlib:zlib
 
 HOST_BUILD_PARALLEL:=1
 


### PR DESCRIPTION
`cpe:/a:zlib:zlib` is the correct CPE ID for zlib: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:zlib:zlib

Fixes: c61a2395140d92cdd37d3d6ee43a765427e8e318 (add PKG_CPE_ID ids to package and tools)
