### PR TITLE
package/libs/pcre2: fix PKG_CPE_ID

### DIFF
--- a/package/libs/pcre2/Makefile
+++ b/package/libs/pcre2/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=8d36cd8cb6ea2a4c2bb358ff6411b0c788633a2a45dabbf1aeb4b701d1b5e840
 PKG_MAINTAINER:=Shane Peelar <lookatyouhacker@gmail.com>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENCE
-PKG_CPE_ID:=cpe:/a:pcre:pcre
+PKG_CPE_ID:=cpe:/a:pcre:pcre2
 
 PKG_CONFIG_DEPENDS:=\
 	CONFIG_PACKAGE_libpcre2-16 \


### PR DESCRIPTION
`cpe:/a:pcre:pcre2` is the correct CPE ID for pcre2: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:pcre:pcre2

Fixes: c39b0646f3f2d96d40f601209859175af8537b6d (pcre2: import pcre2 from packages feed)