### PR TITLE
[22.03] tools: fix compilation on macOS 14

### DIFF
--- a/tools/coreutils/patches/0001-obstack-Fix-a-clang-warning.patch
+++ b/tools/coreutils/patches/0001-obstack-Fix-a-clang-warning.patch
@@ -1,0 +1,21 @@
+From 0cc39712803ade7b2d4b89c36b143dad72404063 Mon Sep 17 00:00:00 2001
+From: Bruno Haible <bruno@clisp.org>
+Date: Sun, 18 Oct 2020 14:37:13 +0200
+Subject: [PATCH] obstack: Fix a clang warning.
+
+* lib/obstack.c (print_and_abort): Mark as __attribute_noreturn__.
+---
+ lib/obstack.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/lib/obstack.c
++++ b/lib/obstack.c
+@@ -326,7 +326,7 @@ int obstack_exit_failure = EXIT_FAILURE;
+ #   include <libio/iolibio.h>
+ #  endif
+ 
+-static _Noreturn void
++static __attribute_noreturn__ void
+ print_and_abort (void)
+ {
+   /* Don't change any of these strings.  Yes, it would be possible to add

--- a/tools/cpio/patches/002-obstack-Fix-a-clang-warning.patch
+++ b/tools/cpio/patches/002-obstack-Fix-a-clang-warning.patch
@@ -1,0 +1,21 @@
+From 0cc39712803ade7b2d4b89c36b143dad72404063 Mon Sep 17 00:00:00 2001
+From: Bruno Haible <bruno@clisp.org>
+Date: Sun, 18 Oct 2020 14:37:13 +0200
+Subject: [PATCH] obstack: Fix a clang warning.
+
+* gnu/obstack.c (print_and_abort): Mark as __attribute_noreturn__.
+---
+ gnu/obstack.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/gnu/obstack.c
++++ b/gnu/obstack.c
+@@ -326,7 +326,7 @@ int obstack_exit_failure = EXIT_FAILURE;
+ #   include <libio/iolibio.h>
+ #  endif
+ 
+-static _Noreturn void
++static __attribute_noreturn__ void
+ print_and_abort (void)
+ {
+   /* Don't change any of these strings.  Yes, it would be possible to add

--- a/tools/sed/patches/0001-obstack-Fix-a-clang-warning.patch
+++ b/tools/sed/patches/0001-obstack-Fix-a-clang-warning.patch
@@ -1,0 +1,21 @@
+From 0cc39712803ade7b2d4b89c36b143dad72404063 Mon Sep 17 00:00:00 2001
+From: Bruno Haible <bruno@clisp.org>
+Date: Sun, 18 Oct 2020 14:37:13 +0200
+Subject: [PATCH] obstack: Fix a clang warning.
+
+* lib/obstack.c (print_and_abort): Mark as __attribute_noreturn__.
+---
+ lib/obstack.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/lib/obstack.c
++++ b/lib/obstack.c
+@@ -326,7 +326,7 @@ int obstack_exit_failure = EXIT_FAILURE;
+ #   include <libio/iolibio.h>
+ #  endif
+ 
+-static _Noreturn void
++static __attribute_noreturn__ void
+ print_and_abort (void)
+ {
+   /* Don't change any of these strings.  Yes, it would be possible to add


### PR DESCRIPTION
Current multiple tools in 22.03 will fail to compile when using macOS 14 with: 
```
depbase=`echo lib/obstack.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
gcc -DHAVE_CONFIG_H -I.  -I. -I./lib -I./lib -I./sed -I/Volumes/OpenWrt/openwrt/staging_dir/host/include   -O2 -I/Volumes/OpenWrt/openwrt/staging_dir/host/include  -MT lib/obstack.o -MD -MP -MF $depbase.Tpo -c -o lib/obstack.o lib/obstack.c &&\
mv -f $depbase.Tpo $depbase.Po
lib/obstack.c:351:31: error: incompatible function pointer types initializing 'void (*)(void) __attribute__((noreturn))' with an expression of type 'void (void)' [-Wincompatible-function-pointer-types]
__attribute_noreturn__ void (*obstack_alloc_failed_handler) (void)
                              ^
1 error generated.
make[5]: *** [Makefile:2781: lib/obstack.o] Error 1
```

Backporting gnulib commit ("obstack: Fix a clang warning") fixes this.

Fixes: #15270 