### PR TITLE
package/network/services/dropbear: fix PKG_CPE_ID

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -19,7 +19,7 @@ PKG_HASH:=bc5a121ffbc94b5171ad5ebe01be42746d50aa797c9549a4639894a16749443b
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE libtomcrypt/LICENSE libtommath/LICENSE
-PKG_CPE_ID:=cpe:/a:matt_johnston:dropbear_ssh_server
+PKG_CPE_ID:=cpe:/a:dropbear_ssh_project:dropbear_ssh
 
 PKG_BUILD_PARALLEL:=1
 PKG_ASLR_PIE_REGULAR:=1


### PR DESCRIPTION
`cpe:/a:dropbear_ssh_project:dropbear_ssh` is the correct CPE ID for dropbear: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:dropbear_ssh_project:dropbear_ssh

Fixes: c61a2395140d92cdd37d3d6ee43a765427e8e318 (add PKG_CPE_ID ids to package and tools)