### PR TITLE
tools/expat: fix PKG_CPE_ID

### DIFF
--- a/tools/expat/Makefile
+++ b/tools/expat/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
-PKG_CPE_ID:=cpe:/a:libexpat:expat
+PKG_CPE_ID:=cpe:/a:libexpat:libexpat
 PKG_VERSION:=2.6.2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz


### PR DESCRIPTION
`cpe:/a:libexpat_project:libexpat` is the correct CPE ID for expat: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:libexpat:libexpat

Fixes: c61a2395140d92cdd37d3d6ee43a765427e8e318 (add PKG_CPE_ID ids to package and tools)
