### PR TITLE
package/libs/libjson-c: fix PKG_CPE_ID

### DIFF
--- a/package/libs/libjson-c/Makefile
+++ b/package/libs/libjson-c/Makefile
@@ -18,7 +18,7 @@ PKG_HASH:=8df3b66597333dd365762cab2de2ff68e41e3808a04b692e696e0550648eefaa
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
-PKG_CPE_ID:=cpe:/a:json-c_project:json-c
+PKG_CPE_ID:=cpe:/a:json-c:json-c
 
 HOST_BUILD_PREFIX:=$(STAGING_DIR_HOST)
 


### PR DESCRIPTION
`cpe:/a:json-c:json-c` is the correct CPE ID for libjson-c: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:json-c:json-c

Fixes: c61a2395140d92cdd37d3d6ee43a765427e8e318 (add PKG_CPE_ID ids to package and tools)
