### PR TITLE
package/network/utils/iptables: fix PKG_CPE_ID

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -23,7 +23,7 @@ PKG_INSTALL:=1
 PKG_BUILD_FLAGS:=gc-sections no-lto
 PKG_BUILD_PARALLEL:=1
 PKG_LICENSE:=GPL-2.0
-PKG_CPE_ID:=cpe:/a:netfilter_core_team:iptables
+PKG_CPE_ID:=cpe:/a:netfilter:iptables
 
 include $(INCLUDE_DIR)/package.mk
 ifeq ($(DUMP),)


### PR DESCRIPTION
`cpe:/a:netfilter:iptables` is the correct CPE ID for iptables: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:netfilter:iptables

Fixes: c61a2395140d92cdd37d3d6ee43a765427e8e318 (add PKG_CPE_ID ids to package and tools)
