### PR TITLE
package/utils/secilc: drop PKG_CPE_ID

### DIFF
--- a/package/utils/secilc/Makefile
+++ b/package/utils/secilc/Makefile
@@ -15,7 +15,6 @@ PKG_HASH:=3eebc5a1f97847fa530cf90654b9f3b8f21a13c9ea3d07495325651580cd3373
 HOST_BUILD_DEPENDS:=libsepol/host
 
 PKG_MAINTAINER:=Dominick Grift <dominick.grift@defensec.nl>
-PKG_CPE_ID:=cpe:/a:selinuxproject:secilc
 PKG_LICENSE:=BSD-2-Clause
 PKG_LICENSE_FILES:=COPYING
 


### PR DESCRIPTION
`cpe:/a:selinuxproject:secilc` is not a correct CPE ID for secilc: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:selinuxproject:secilc

Fixes: 9ee7c1ec60e23f25f5d275c6439ce93aec914e1c (secilc: adds new package)
