### PR TITLE
generic: replace spi Silicon Labs patch with upstream version

### DIFF
--- a/target/linux/generic/backport-5.15/412-v6.3-01-spidev-Add-Silicon-Labs-EM3581-device-compatible.patch
+++ b/target/linux/generic/backport-5.15/412-v6.3-01-spidev-Add-Silicon-Labs-EM3581-device-compatible.patch
@@ -1,13 +1,13 @@
-From f7982c726e02001afc19052fe48f642dfcbc00b2 Mon Sep 17 00:00:00 2001
+From c67d90e058550403a3e6f9b05bfcdcfa12b1815c Mon Sep 17 00:00:00 2001
 From: Vincent Tremblay <vincent@vtremblay.dev>
-Date: Mon, 26 Dec 2022 21:10:37 -0500
-Subject: [PATCH 1/2] spidev: Add Silicon Labs EM3581 device compatible
+Date: Mon, 26 Dec 2022 21:35:48 -0500
+Subject: [PATCH] spidev: Add Silicon Labs EM3581 device compatible
 
 Add compatible string for Silicon Labs EM3581 device.
 
-Note: This patch is adapted from a patch submitted to the for-next branch (v6.3).
-
 Signed-off-by: Vincent Tremblay <vincent@vtremblay.dev>
+Link: https://lore.kernel.org/r/20221227023550.569547-2-vincent@vtremblay.dev
+Signed-off-by: Mark Brown <broonie@kernel.org>
 ---
  drivers/spi/spidev.c | 2 ++
  1 file changed, 2 insertions(+)

--- a/target/linux/generic/backport-5.15/412-v6.3-02-spidev-Add-Silicon-Labs-SI3210-device-compatible.patch
+++ b/target/linux/generic/backport-5.15/412-v6.3-02-spidev-Add-Silicon-Labs-SI3210-device-compatible.patch
@@ -1,13 +1,13 @@
-From 536581825219e97fa2ae0c4de35605d2f6311416 Mon Sep 17 00:00:00 2001
+From 6c9d1fd52956c3148e847a214bae9102b1811de5 Mon Sep 17 00:00:00 2001
 From: Vincent Tremblay <vincent@vtremblay.dev>
-Date: Tue, 27 Dec 2022 09:00:58 -0500
-Subject: [PATCH 2/2] spidev: Add Silicon Labs SI3210 device compatible
+Date: Tue, 27 Dec 2022 09:10:08 -0500
+Subject: [PATCH] spidev: Add Silicon Labs SI3210 device compatible
 
 Add compatible string for Silicon Labs SI3210 device.
 
-Note: This patch is adapted from a patch submitted to the for-next branch (v6.3).
-
 Signed-off-by: Vincent Tremblay <vincent@vtremblay.dev>
+Link: https://lore.kernel.org/r/20221227141011.111410-2-vincent@vtremblay.dev
+Signed-off-by: Mark Brown <broonie@kernel.org>
 ---
  drivers/spi/spidev.c | 2 ++
  1 file changed, 2 insertions(+)

--- a/target/linux/generic/backport-6.1/412-v6.3-01-spidev-Add-Silicon-Labs-EM3581-device-compatible.patch
+++ b/target/linux/generic/backport-6.1/412-v6.3-01-spidev-Add-Silicon-Labs-EM3581-device-compatible.patch
@@ -1,13 +1,13 @@
-From f7982c726e02001afc19052fe48f642dfcbc00b2 Mon Sep 17 00:00:00 2001
+From c67d90e058550403a3e6f9b05bfcdcfa12b1815c Mon Sep 17 00:00:00 2001
 From: Vincent Tremblay <vincent@vtremblay.dev>
-Date: Mon, 26 Dec 2022 21:10:37 -0500
-Subject: [PATCH 1/2] spidev: Add Silicon Labs EM3581 device compatible
+Date: Mon, 26 Dec 2022 21:35:48 -0500
+Subject: [PATCH] spidev: Add Silicon Labs EM3581 device compatible
 
 Add compatible string for Silicon Labs EM3581 device.
 
-Note: This patch is adapted from a patch submitted to the for-next branch (v6.3).
-
 Signed-off-by: Vincent Tremblay <vincent@vtremblay.dev>
+Link: https://lore.kernel.org/r/20221227023550.569547-2-vincent@vtremblay.dev
+Signed-off-by: Mark Brown <broonie@kernel.org>
 ---
  drivers/spi/spidev.c | 2 ++
  1 file changed, 2 insertions(+)

--- a/target/linux/generic/backport-6.1/412-v6.3-02-spidev-Add-Silicon-Labs-SI3210-device-compatible.patch
+++ b/target/linux/generic/backport-6.1/412-v6.3-02-spidev-Add-Silicon-Labs-SI3210-device-compatible.patch
@@ -1,13 +1,13 @@
-From 536581825219e97fa2ae0c4de35605d2f6311416 Mon Sep 17 00:00:00 2001
+From 6c9d1fd52956c3148e847a214bae9102b1811de5 Mon Sep 17 00:00:00 2001
 From: Vincent Tremblay <vincent@vtremblay.dev>
-Date: Tue, 27 Dec 2022 09:00:58 -0500
-Subject: [PATCH 2/2] spidev: Add Silicon Labs SI3210 device compatible
+Date: Tue, 27 Dec 2022 09:10:08 -0500
+Subject: [PATCH] spidev: Add Silicon Labs SI3210 device compatible
 
 Add compatible string for Silicon Labs SI3210 device.
 
-Note: This patch is adapted from a patch submitted to the for-next branch (v6.3).
-
 Signed-off-by: Vincent Tremblay <vincent@vtremblay.dev>
+Link: https://lore.kernel.org/r/20221227141011.111410-2-vincent@vtremblay.dev
+Signed-off-by: Mark Brown <broonie@kernel.org>
 ---
  drivers/spi/spidev.c | 2 ++
  1 file changed, 2 insertions(+)


### PR DESCRIPTION
Move the patches to the correct backport folder