### PR TITLE
qualcommax: ipq807x: uboot-envtools: add missing settings for yuncore…

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
@@ -193,6 +193,7 @@
 			};
 
 			partition@480000 {
+				compatible = "u-boot,env";
 				label = "0:appsblenv";
 				reg = <0x480000 0x10000>;
 			};


### PR DESCRIPTION
There was no config in the uboot-envtools package, so there is no
generated /etc/fw_env.config for the fw_printenv and fw_setenv utils.
Since uboot-envtools 2024.01, there is a way to make these utils work
without /etc/fw_env.config if the DT has an env partition with the prop.:

compatible = "u-boot,env";

So, this commit adds the prop. above to the appsblenv:0 partition
in the yuncore ax880 DTS file.
