### PR TITLE
mediatek: fix MAC addresses of BananaPi boards

### DIFF
--- a/target/linux/mediatek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr.sh
+++ b/target/linux/mediatek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr.sh
@@ -10,7 +10,8 @@ unielec,u7623-02)
 		fw_setenv ethaddr "$(cat /sys/class/net/eth0/address)"
 	;;
 bananapi,bpi-r3|\
-bananapi,bpi-r3-mini)
+bananapi,bpi-r3-mini|\
+bananapi,bpi-4)
 	[ -z "$(fw_printenv -n ethaddr 2>/dev/null)" ] &&
 		fw_setenv ethaddr "$(cat /sys/class/net/eth0/address)"
 	[ -z "$(fw_printenv -n eth1addr 2>/dev/null)" ] &&

--- a/target/linux/mediatek/files-6.1/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dts
+++ b/target/linux/mediatek/files-6.1/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dts
@@ -17,6 +17,8 @@
 		     "mediatek,mt7988a";
 
 	aliases {
+		ethernet0 = &gmac0;
+		ethernet1 = &gmac1;
 		serial0 = &uart0;
 		led-boot = &led_green;
 		led-failsafe = &led_green;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -120,7 +120,8 @@ mediatek_setup_macs()
 
 	case $board in
 	bananapi,bpi-r3|\
-	bananapi,bpi-r3-mini)
+	bananapi,bpi-r3-mini|\
+	bananapi,bpi-r4)
 		wan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)
 		;;
 	cmcc,rax3000m)

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -119,7 +119,8 @@ mediatek_setup_macs()
 	local label_mac=""
 
 	case $board in
-	bananapi,bpi-r3)
+	bananapi,bpi-r3|\
+	bananapi,bpi-r3-mini)
 		wan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)
 		;;
 	cmcc,rax3000m)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -36,7 +36,8 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_setbit_la $(macaddr_add $addr 1) > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && echo "$addr" > /sys${DEVPATH}/macaddress
 		;;
-	bananapi,bpi-r3)
+	bananapi,bpi-r3|\
+	bananapi,bpi-r3-mini)
 		addr=$(cat /sys/class/net/eth0/address)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -42,6 +42,12 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
+	bananapi,bpi-r4)
+		addr=$(cat /sys/class/net/eth0/address)
+		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "2" ] && macaddr_add $addr 4 > /sys${DEVPATH}/macaddress
+		;;
 	cetron,ct3003)
 		addr=$(mtd_get_mac_binary "art" 0)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
Store random persistent MAC addresses for WAN and WiFi for the BPi-R3-mini and BPi-R4 just like it is already done for the BPi-R3 and earlier boards.
