### PR TITLE
[22.03] tools: b43-tools: fix compilation with GCC14

### DIFF
--- a/tools/b43-tools/Makefile
+++ b/tools/b43-tools/Makefile
@@ -26,7 +26,7 @@ define Host/Compile
 		$(HOST_MAKE_FLAGS) \
 		$(1) QUIET_SPARSE=:
 	+$(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR)/assembler \
-		CFLAGS="$(HOST_CFLAGS) -include endian.h" \
+		CFLAGS="$(HOST_CFLAGS) -include endian.h -Wno-error=int-conversion" \
 		$(HOST_MAKE_FLAGS) \
 		LDFLAGS= \
 		$(1) QUIET_SPARSE=:


### PR DESCRIPTION
Backported from https://github.com/openwrt/openwrt/pull/15012

Fixes:
```
make[3]: Entering directory '/Volumes/OpenWrt/omnia-hbl/build/build_dir/host/b43-tools/assembler'
     DEPEND   dep/args.d
     DEPEND   dep/initvals.d
     DEPEND   dep/main.d
     DEPEND   dep/parser.d
     DEPEND   dep/scanner.d
     DEPEND   dep/util.d
: -O2 -I/Volumes/OpenWrt/omnia-hbl/build/staging_dir/host/include  -include endian.h -D__transparent_union__=__unused__ -D_STRING_ARCH_unaligned=1 -D__builtin_stpcpy=stpcpy args.c
     CC       obj/args.o
: -O2 -I/Volumes/OpenWrt/omnia-hbl/build/staging_dir/host/include  -include endian.h -D__transparent_union__=__unused__ -D_STRING_ARCH_unaligned=1 -D__builtin_stpcpy=stpcpy initvals.c
     CC       obj/initvals.o
: -O2 -I/Volumes/OpenWrt/omnia-hbl/build/staging_dir/host/include  -include endian.h -D__transparent_union__=__unused__ -D_STRING_ARCH_unaligned=1 -D__builtin_stpcpy=stpcpy main.c
     CC       obj/main.o
: -O2 -I/Volumes/OpenWrt/omnia-hbl/build/staging_dir/host/include  -include endian.h -D__transparent_union__=__unused__ -D_STRING_ARCH_unaligned=1 -D__builtin_stpcpy=stpcpy parser.c
     CC       obj/parser.o
parser.y:58:21: error: incompatible integer to pointer conversion initializing 'struct statement *' with an expression of type 'YYSTYPE' (aka 'int') [-Wint-conversion]
                struct statement *s = yyvsp[-1];
                                  ^   ~~~~~~~~~
parser.y:69:22: error: incompatible integer to pointer conversion initializing 'struct initval_op *' with an expression of type 'YYSTYPE' (aka 'int') [-Wint-conversion]
                struct initval_op *io = yyvsp[-1];
                                   ^    ~~~~~~~~~
parser.y:87:16: error: incompatible integer to pointer conversion initializing 'const char *' with an expression of type 'YYSTYPE' (aka 'int') [-Wint-conversion]
                        const char *sectname = yyvsp[-1];
                                    ^          ~~~~~~~~~
parser.y:113:10: error: incompatible pointer to integer conversion assigning to 'YYSTYPE' (aka 'int') from 'struct initval_op *' [-Wint-conversion]
                        yyval = iop;
                              ^ ~~~
parser.y:120:10: error: incompatible pointer to integer conversion assigning to 'YYSTYPE' (aka 'int') from 'struct initval_op *' [-Wint-conversion]
                        yyval = iop;
                              ^ ~~~
parser.y:127:10: error: incompatible pointer to integer conversion assigning to 'YYSTYPE' (aka 'int') from 'struct initval_op *' [-Wint-conversion]
                        yyval = iop;
                              ^ ~~~
parser.y:134:10: error: incompatible pointer to integer conversion assigning to 'YYSTYPE' (aka 'int') from 'struct initval_op *' [-Wint-conversion]
                        yyval = iop;
                              ^ ~~~
parser.y:142:10: error: incompatible pointer to integer conversion assigning to 'YYSTYPE' (aka 'int') from 'struct initval_op *' [-Wint-conversion]
                        yyval = iop;
                              ^ ~~~
parser.y:150:10: error: incompatible pointer to integer conversion assigning to 'YYSTYPE' (aka 'int') from 'struct initval_op *' [-Wint-conversion]
                        yyval = iop;
                              ^ ~~~
parser.y:157:10: error: incompatible pointer to integer conversion assigning to 'YYSTYPE' (aka 'int') from 'struct initval_op *' [-Wint-conversion]
                        yyval = iop;
                              ^ ~~~
parser.y:162:19: error: incompatible integer to pointer conversion initializing 'struct asmdir *' with an expression of type 'YYSTYPE' (aka 'int') [-Wint-conversion]
                        struct asmdir *ad = yyvsp[0];
                                       ^    ~~~~~~~~
parser.y:167:17: error: incompatible integer to pointer conversion assigning to 'struct asmdir *' from 'YYSTYPE' (aka 'int') [-Wint-conversion]
                                s->u.asmdir = yyvsp[0];
                                            ^ ~~~~~~~~
parser.y:168:11: error: incompatible pointer to integer conversion assigning to 'YYSTYPE' (aka 'int') from 'struct statement *' [-Wint-conversion]
                                yyval = s;
                                      ^ ~
parser.y:170:11: error: incompatible pointer to integer conversion assigning to 'YYSTYPE' (aka 'int') from 'void *' [-Wint-conversion]
                                yyval = NULL;
                                      ^ ~~~~
parser.y:176:15: error: incompatible integer to pointer conversion assigning to 'struct label *' from 'YYSTYPE' (aka 'int') [-Wint-conversion]
                        s->u.label = yyvsp[0];
                                   ^ ~~~~~~~~
parser.y:177:10: error: incompatible pointer to integer conversion assigning to 'YYSTYPE' (aka 'int') from 'struct statement *' [-Wint-conversion]
                        yyval = s;
                              ^ ~
parser.y:183:14: error: incompatible integer to pointer conversion assigning to 'struct instruction *' from 'YYSTYPE' (aka 'int') [-Wint-conversion]
                        s->u.insn = yyvsp[0];
                                  ^ ~~~~~~~~
parser.y:184:10: error: incompatible pointer to integer conversion assigning to 'YYSTYPE' (aka 'int') from 'struct statement *' [-Wint-conversion]
                        yyval = s;
                              ^ ~
parser.y:190:14: error: incompatible integer to pointer conversion assigning to 'struct instruction *' from 'YYSTYPE' (aka 'int') [-Wint-conversion]
                        s->u.insn = yyvsp[0];
                                  ^ ~~~~~~~~
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
make[3]: *** [Makefile:53: obj/parser.o] Error 1
make[3]: Leaving directory '/Volumes/OpenWrt/omnia-hbl/build/build_dir/host/b43-tools/assembler'
make[2]: *** [Makefile:52: /Volumes/OpenWrt/omnia-hbl/build/build_dir/host/b43-tools/.built] Error 2
make[2]: Leaving directory '/Volumes/OpenWrt/omnia-hbl/build/tools/b43-tools'
time: tools/b43-tools/compile#0.81#0.36#1.86
    ERROR: tools/b43-tools failed to build.
```

Reproduced on MacOS, Intel, version 14.4.1

cc: @robimarko 

The fix is already in OpenWrt 23.05, so only 22.03 is left. So many issues with almost deprecated 22.03 branch, though. 