### PR TITLE
gitignore: don't ignore files created by git conflict resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Anyone trying to add *.orig or *.rej will be slow-cooked to a boil
 *.o
 .DS_Store
 .*.swp
@@ -21,8 +22,6 @@
 /*.patch
 /llvm-bpf*
 key-build*
-*.orig
-*.rej
 *~
 .#*
 *#


### PR DESCRIPTION
Commit 1bda5f253040 ("gitignore: add *.rej and *.orig to .gitignore") told git to ignore .rej and .orig files. However, no rationale was provided for the change. As will be shown, it was a terrible idea.

When git encounters a conflict during a rebase, merge or other op, it asks the developer to intervene. Even when the conflicted file is fixed, git automatically leaves each of a *.orig and *.rej file.

It may seem perfectly innocent to ignore them, until one sees the following insanity in the boot log:

    /bin/board_detect: /etc/board.d/02_network.orig:
        line 21: syntax error: unexpected redirection (expecting ")")

Wait, where did that come from? `git show` thinks nothing of the sort is committed. `git status` sees no such uncommitted file. In fact, there isn't an easy or intuitive way for a developer to see that garbage is about to be placed on the rootfs.

Thus commit 1bda5f253040 ("gitignore: add *.rej and *.orig to .gitignore") was misguided, and is ferociosly repealed. To make sure nobody makes this mistalke again, and a comment to .gitignore.
