### PR TITLE
procd: make mDNS TXT record parsing more solid

### DIFF
--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -592,18 +592,21 @@ _procd_set_config_changed() {
 }
 
 procd_add_mdns_service() {
-	local service proto port
+	local service proto port txt_count=0
 	service=$1; shift
 	proto=$1; shift
 	port=$1; shift
 	json_add_object "${service}_$port"
 	json_add_string "service" "_$service._$proto.local"
 	json_add_int port "$port"
-	[ -n "$1" ] && {
-		json_add_array txt
-		for txt in "$@"; do json_add_string "" "$txt"; done
-		json_select ..
-	}
+	for txt in "$@"; do
+		[ -z "$txt" ] && continue
+		txt_count=$((txt_count+1))
+		[ $txt_count -eq 1 ] && json_add_array txt
+		json_add_string "" "$txt"
+	done
+	[ $txt_count -gt 0 ] && json_select ..
+
 	json_select ..
 }
 


### PR DESCRIPTION
mDNS broadcast can't accept empty TXT record and would fail registration.

Current procd_add_mdns_service checks only if the first passed arg is empty but don't make any verification on the other args permittins insertion of empty values in TXT record.

Example:

	procd_add_mdns "blah" \
				"tcp" "50" \
				"1" \
				"" \
				"3"

Produce:

`{ "blah_50": { "service": "_blah._tcp.local", "port": 50, "txt": [ "1", "", "3" ] } }`

The middle empty TXT record should never be included as it's empty.

This can happen with scripts that make fragile parsing and include variables even if they are empty.

Prevent this and make the TXT record more solid by checking every provided TXT record and include only the non-empty ones.

The fixed JSON is the following:

`{ "blah_50": { "service": "_blah._tcp.local", "port": 50, "txt": [ "1", "3" ] } }`

Fixes: b0d9dcf84dd0 ("procd: update to latest git HEAD")
Reported-by: Paul Donald <newtwen@gmail.com>