### PR TITLE
bcm27xx: correct cmdline.txt consoles for procd

### DIFF
--- a/target/linux/bcm27xx/image/cmdline.txt
+++ b/target/linux/bcm27xx/image/cmdline.txt
@@ -1,1 +1,1 @@
-console=serial0,115200 console=tty1 root=@ROOT@ rootfstype=squashfs,ext4 rootwait
+console=tty1 console=serial0,115200 root=@ROOT@ rootfstype=squashfs,ext4 rootwait


### PR DESCRIPTION
Commit [ca8c30208d5e][1] updates procd to handle muliple "console=" on the kernel command line. This affects Raspberry Pi builds because cmdline.txt specifies a UART console and a virtual console on HDMI, in that order.

When procd finds multiple consoles on the command line, it attempts to open /dev/console. Linux uses the [last console][2] for /dev/console, so procd opens the virtual console on Raspberry Pi. This completely disables the UART console and causes [strange behavior][3] on the virtual console. Prior to ca8c30208d5e, procd would always open the first console, which is the UART console.

The simplest fix without reverting ca8c30208d5e is to swap the order of console options in cmdline.txt. By putting the UART console last, procd handles the serial console correctly as before.

This pull request also resolves issue https://github.com/openwrt/openwrt/issues/15125.

[1]: https://git.openwrt.org/?p=project/procd.git;a=commit;h=ca8c30208d5e1aaa2c0e3f732c4c9944735e9850
[2]: https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html
[3]: https://forum.openwrt.org/t/rasberry-pi-4-model-b-keyboards-gone-wild/195594