### PR TITLE
ipq40xx: fix I2C pin config on Aruba AP-303H

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
@@ -71,25 +71,6 @@
 		watchdog@b017000 {
 			status = "okay";
 		};
-
-		i2c_0: i2c@78b7000 {
-			pinctrl-0 = <&i2c_0_pins>;
-			pinctrl-names = "default";
-			status = "okay";
-
-			tpm@29 {
-				/* No Driver */
-				compatible = "atmel,at97sc3203";
-				reg = <0x29>;
-				read-only;
-			};
-
-			power-monitor@40 {
-				/* No driver */
-				compatible = "isl,isl28022";
-				reg = <0x40>;
-			};
-		};
 	};
 
 	leds {
@@ -214,7 +195,7 @@
 			pins = "gpio20", "gpio21";
 			function = "blsp_i2c0";
 			drive-strength = <4>;
-			bias-disable;
+			bias-pull-up;
 		};
 	};
 
@@ -239,6 +220,28 @@
 		gpios = <23 GPIO_ACTIVE_HIGH>;
 		gpio-hog;
 		output-high;
+	};
+};
+
+&blsp1_i2c3 {
+	pinctrl-0 = <&i2c_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	clock-frequency = <400000>;
+
+	tpm@29 {
+		/* No Driver */
+		compatible = "atmel,at97sc3203";
+		reg = <0x29>;
+		read-only;
+	};
+
+	power-monitor@40 {
+		/* No driver */
+		/* Device also replies on address 0x3f, see   */
+		/* ISL28022 datasheet, "Broadcast Addressing" */
+		compatible = "isl,isl28022";
+		reg = <0x40>;
 	};
 };
 


### PR DESCRIPTION
Turn on SoC pull-ups on I2C pins, since there are no discrete pull-up resistors on the bus.

Increase clock to 400 kHz. Both chips on the bus support 400 kHz. I tested the ISL28022 at 4,000 reads/sec and didn't see any garbled output or bus hangs, even with SoC drive strength reduced to 2 for the test.