### PR TITLE
tools/elfutils: remove dirname

### DIFF
--- a/tools/elfutils/Makefile
+++ b/tools/elfutils/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=elfutils
 PKG_VERSION:=0.191
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceware.org/$(PKG_NAME)/ftp/$(PKG_VERSION)
@@ -41,7 +41,6 @@ PKG_GNULIB_ARGS = \
 
 PKG_GNULIB_MODS = \
 	argp \
-	dirname \
 	fts \
 	obstack \
 	progname \

--- a/tools/elfutils/patches/100-portability.patch
+++ b/tools/elfutils/patches/100-portability.patch
@@ -346,12 +346,11 @@
 +}
 --- a/libdwfl/libdwflP.h
 +++ b/libdwfl/libdwflP.h
-@@ -31,6 +31,8 @@
+@@ -31,6 +31,7 @@
  
  #include <libdwfl.h>
  #include <libebl.h>
 +#include <libeu.h>
-+#include <dirname.h>
  #include <assert.h>
  #include <dirent.h>
  #include <errno.h>
@@ -366,17 +365,18 @@
 +#endif
 --- a/libdw/libdwP.h
 +++ b/libdw/libdwP.h
-@@ -32,8 +32,10 @@
+@@ -32,10 +32,10 @@
  #include <stdbool.h>
  #include <pthread.h>
  
 +#include <libeu.h>
  #include <libdw.h>
  #include <dwarf.h>
-+#include <dirname.h>
  
- 
+-
  /* Known location expressions already decoded.  */
+ struct loc_s
+ {
 --- a/libdw/Makefile.am
 +++ b/libdw/Makefile.am
 @@ -34,14 +34,12 @@ endif


### PR DESCRIPTION
In the 0.191 update dirname was used instead of <libgen.h> to fix the poisoned basename error:
```
/usr/include/libgen.h:35:9: error: attempt to use poisoned "basename"
       35 | #define basename        __xpg_basename
```

However, doing this has lead to libelf.a pulling in xmalloc, xstrdup and friends and statically linking them thus leading to a symbol name conflict with FRR host build and anything else that links against libelf and uses xmalloc and friends.

Well, it turns out that upstream has added a helper[1] for basename so it can compile with musl 1.2.5 which dropped the basename declaration, but it also means that we must NOT include <libgen.h> and that poisoned error is intentional and added to prevent duplicate basename definitions. This also means that for macOS we dont need to do any additional header inclusions as the new helper takes care of basename.

So, to fix the symbol conflict we can simply drop the <dirname.h> inclusion and build from elfutils.

Tested on Fedora 40 as well as macOS 14.4.1.

[1] https://sourceware.org/git/?p=elfutils.git;a=commit;h=a2194f6b305bf0d0b9dd49dccd0a5c21994c8eea

Fixes: #24030
Fixes: b6f025b42429 ("tools/elfutils: update to 1.91")