### PR TITLE
base-files: fix cleanup after settings restore

### DIFF
--- a/package/base-files/files/etc/init.d/done
+++ b/package/base-files/files/etc/init.d/done
@@ -5,6 +5,7 @@ START=95
 boot() {
 	mount_root done
 	rm -f /sysupgrade.tgz && sync
+	rm -f /tmp/sysupgrade.tar && sync
 
 	# process user commands
 	[ -f /etc/rc.local ] && {


### PR DESCRIPTION
Some devices use file '/tmp/sysupgrade.tar' during settings restore and this potentially big file was not being cleaned up from RAM afterwards.

See: do_mount_root() (base-files/files/lib/preinit/80_mount_root)

notes:
- this happens for example in eMMC devices after a sysupgrade with settings retention.
- i chose to leave the `&& sync` not because the ramdrive requires syncing, but because all the settings previously persisted from the ramdrive might.