### PR TITLE
base-files: uci-defaults mechanism to run code only after settings reset

### DIFF
--- a/package/base-files/files/etc/init.d/boot
+++ b/package/base-files/files/etc/init.d/boot
@@ -4,10 +4,18 @@
 START=10
 STOP=90
 
+is_restoring_settings() {
+	[ -f /sysupgrade.tgz -o -f /tmp/sysupgrade.tar ]
+}
+
 uci_apply_defaults() {
 	. /lib/functions/system.sh
 
 	cd /etc/uci-defaults || return 0
+	is_restoring_settings && {
+		RESTORING_SETTINGS=true
+		rm -f *_RESET
+	}
 	files="$(ls)"
 	[ -z "$files" ] && return 0
 	mkdir -p /tmp/.uci


### PR DESCRIPTION
uci-defaults runs scripts after settings are wiped but also after sysupgrade. This works fine when existing settings need to be imported, but is undesirable in situations where the intention is to provide a settings default, as sysupgrade can potentially override the user's custom settings back with the defaults. This is sometimes mitigated in an ad-hoc manner by scripts, and sometimes not at all.

This change provides 2 standardized ways to cope with this situation:

- uci-defaults scripts receive a RESTORING_SETTINGS flag that helps them skip over defaults when earlier settings are being restored, eg with:

  `[ "$RESTORING_SETTINGS" = "true" ] && exit 0`

  (Note: if the script fails, the next invocation will not be marked with the RESTORING_SETTINGS flag.)

- uci-defaults scripts whose names end with `_RESET` will never be ran when settings are restored and will only run after settings reset, regardless of their eventual exit status.

The second option is the recommended way for scripts to set defaults.

-----

please note that even the default script offered by the firmware selector suffers from this issue, and will overwrite settings during a sysupgrade. this is also problematic for ports that want to enable their wifis by default (with factory per-device SSIDs and keys).

-----

**BIG WARNING:** i read on the forums that detecting the sysupgrade.tgz file was the way to recognize whether settings were being restored.

as i've seen in the code:
- this works for eMMC (tested)
- this should work for MTD (the whole jffs2 node with the file thing)
- this should work for UBIFS (i looked into the code, but didn't test)
- would this work for a non-squashfs install? (i don't know)

in any case, the idea is that the separate `is_restoring_settings()` can be extended to detect all cases as we discover them. it is better to have something that mostly works and can be fixed than having nothing at all.