### PR TITLE
udhcpc: change order of sourcing /etc/udhcpc.user to start of script

### DIFF
--- a/package/network/config/netifd/files/usr/share/udhcpc/default.script
+++ b/package/network/config/netifd/files/usr/share/udhcpc/default.script
@@ -1,6 +1,9 @@
 #!/bin/sh
 [ -z "$1" ] && echo "Error: should be run by udhcpc" && exit 1
 
+# user rules
+[ -f /etc/udhcpc.user ] && . /etc/udhcpc.user
+
 set_classless_routes() {
 	local max=128
 	local type
@@ -50,8 +53,5 @@ case "$1" in
 		setup_interface ifup
 	;;
 esac
-
-# user rules
-[ -f /etc/udhcpc.user ] && . /etc/udhcpc.user
 
 exit 0


### PR DESCRIPTION
While trying to force a gateway different from the DHCP server supplied one I noticed sourcing /etc/udhcpc.user at the end of the script does nothing. This fixes it.
