### PR TITLE
 mediatek: ASUS TUF-AX6000: fix phy-handle numbering

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
@@ -296,26 +296,26 @@
 		#size-cells = <0>;
 
 		port@1 {
-			reg = <4>;
-			label = "lan1";
+			reg = <1>;
+			label = "lan4";
 			phy-handle = <&swphy1>;
 		};
 
 		port@2 {
-			reg = <3>;
-			label = "lan2";
+			reg = <2>;
+			label = "lan3";
 			phy-handle = <&swphy2>;
 		};
 
 		port@3 {
-			reg = <2>;
-			label = "lan3";
+			reg = <3>;
+			label = "lan2";
 			phy-handle = <&swphy3>;
 		};
 
 		port@4 {
-			reg = <1>;
-			label = "lan4";
+			reg = <4>;
+			label = "lan1";
 			phy-handle = <&swphy4>;
 		};
 


### PR DESCRIPTION
To fix issue #15304 
Correct br-lan ports 1-4 so that phy-handle matches reg nr not port label.
Signed-off-by: Magnus Lindström magnus1089@hotmail.com
