### PR TITLE
firewall: reload ipsets on firewall reload

### DIFF
--- a/package/network/config/firewall/files/firewall.init
+++ b/package/network/config/firewall/files/firewall.init
@@ -29,7 +29,7 @@ validate_firewall_rule()
 }
 
 service_triggers() {
-	procd_add_reload_trigger firewall	
+	procd_add_reload_trigger firewall
 
 	procd_open_validate
 	validate_firewall_redirect
@@ -50,6 +50,7 @@ stop_service() {
 }
 
 reload_service() {
+	fw3 reload-sets
 	fw3 reload
 }
 


### PR DESCRIPTION
This fixes #13028.

Currently, ipsets are not updated automatically during a firewall reload. This leads to differences between the UCI config and the live config after a firewall reload.

This is not visible to the user in LuCI, which is the reason why ipsets should also be reloaded with a firewall reload.
