### PR TITLE
kernel: modules: add mlx_wdt and mlxreg

### DIFF
--- a/package/kernel/linux/modules/i2c.mk
+++ b/package/kernel/linux/modules/i2c.mk
@@ -169,6 +169,24 @@ endef
 $(eval $(call KernelPackage,i2c-i801))
 
 
+I2C_MLXCPLD_MODULES:= \
+  CONFIG_I2C_MLXCPLD:drivers/i2c/busses/i2c-mlxcpld
+
+define KernelPackage/i2c-mlxcpld
+  $(call i2c_defaults,$(I2C_MLXCPLD_MODULES),59)
+  TITLE:=Mellanox I2C driver
+  DEPENDS:=@TARGET_x86_64 +kmod-regmap-core
+endef
+
+define KernelPackage/i2c-mlxcpld/description
+ This exposes the Mellanox platform I2C busses
+ to the linux I2C layer for X86 based systems.
+ Controller is implemented as CPLD logic.
+endef
+
+$(eval $(call KernelPackage,i2c-mlxcpld))
+
+
 I2C_MUX_MODULES:= \
   CONFIG_I2C_MUX:drivers/i2c/i2c-mux
 
@@ -198,6 +216,24 @@ define KernelPackage/i2c-mux-gpio/description
 endef
 
 $(eval $(call KernelPackage,i2c-mux-gpio))
+
+
+I2C_MUX_MLXCPLD_MODULES:= \
+  CONFIG_I2C_MUX_MLXCPLD:drivers/i2c/muxes/i2c-mux-mlxcpld
+
+define KernelPackage/i2c-mux-mlxcpld
+  $(call i2c_defaults,$(I2C_MUX_MLXCPLD_MODULES),51)
+  TITLE:=Mellanox CPLD based I2C multiplexer
+  DEPENDS:=+kmod-i2c-mlxcpld +kmod-i2c-mux
+endef
+
+define KernelPackage/i2c-mux-mlxcpld/description
+ This driver provides access to
+ I2C busses connected through a MUX, which is controlled
+ by a CPLD register.
+endef
+
+$(eval $(call KernelPackage,i2c-mux-mlxcpld))
 
 
 I2C_MUX_REG_MODULES:= \

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -266,6 +266,70 @@ endef
 $(eval $(call KernelPackage,mlx_wdt))
 
 
+define KernelPackage/mlxreg
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Mellanox platform register access
+  DEPENDS:=@TARGET_x86 +kmod-i2c-mux-mlxcpld
+  KCONFIG:= \
+	CONFIG_MELLANOX_PLATFORM=y \
+	CONFIG_MLX_PLATFORM \
+	CONFIG_MLXREG_HOTPLUG \
+	CONFIG_MLXREG_IO \
+	CONFIG_SENSORS_MLXREG_FAN \
+	CONFIG_LEDS_MLXREG
+  FILES:= \
+	$(LINUX_DIR)/drivers/platform/x86/mlx-platform.ko \
+	$(LINUX_DIR)/drivers/platform/mellanox/mlxreg-hotplug.ko \
+	$(LINUX_DIR)/drivers/platform/mellanox/mlxreg-io.ko \
+	$(LINUX_DIR)/drivers/hwmon/mlxreg-fan.ko \
+	$(LINUX_DIR)/drivers/leds/leds-mlxreg.ko
+  AUTOLOAD:=$(call AutoProbe,mlx-platform mlxreg-hotplug mlxreg-io mlxreg-fan leds-mlxreg)
+endef
+
+define KernelPackage/mlxreg/description
+  Allows access to Mellanox programmable device register
+  space through sysfs interface. The sets of registers for sysfs access
+  are defined per system type bases and include the registers related
+  to system resets operation, system reset causes monitoring and some
+  kinds of mux selection.
+endef
+
+$(eval $(call KernelPackage,mlxreg))
+
+
+define KernelPackage/mlxreg-lc
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Mellanox line card platform support
+  DEPENDS:=kmod-mlxreg +kmod-regmap-i2c
+  KCONFIG:=CONFIG_MLXREG_LC
+  FILES:=$(LINUX_DIR)/drivers/platform/mellanox/mlxreg-lc.ko
+  AUTOLOAD:=$(call AutoProbe,mlxreg-lc)
+endef
+
+define KernelPackage/mlxreg-lc/description
+  Provides support for the Mellanox MSN4800-XX line cards,
+  which are the part of MSN4800 Ethernet modular switch systems.
+endef
+
+$(eval $(call KernelPackage,mlxreg-lc))
+
+
+define KernelPackage/mlxreg-sn2201
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Nvidia SN2201 platform support
+  DEPENDS:=kmod-mlxreg +kmod-regmap-i2c
+  KCONFIG:=CONFIG_NVSW_SN2201
+  FILES:=$(LINUX_DIR)/drivers/platform/mellanox/nvsw-sn2201.ko
+  AUTOLOAD:=$(call AutoProbe,nvsw-sn2201)
+endef
+
+define KernelPackage/mlxreg-sn2201/description
+  Provides support for the Nvidia SN2201 platform.
+endef
+
+$(eval $(call KernelPackage,mlxreg-sn2201))
+
+
 define KernelPackage/pinctrl-mcp23s08
   SUBMENU:=$(OTHER_MENU)
   TITLE:=Microchip MCP23xxx I/O expander

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -244,6 +244,28 @@ endef
 $(eval $(call KernelPackage,lkdtm))
 
 
+define KernelPackage/mlx_wdt
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Mellanox Watchdog
+  DEPENDS:=@TARGET_x86 +kmod-regmap-core
+  KCONFIG:= \
+	CONFIG_MELLANOX_PLATFORM=y \
+	CONFIG_MLX_WDT
+  FILES:=$(LINUX_DIR)/drivers/watchdog/mlx_wdt.ko
+  AUTOLOAD:=$(call AutoProbe,mlx_wdt)
+endef
+
+define KernelPackage/mlx_wdt/description
+  This is the driver for the hardware watchdog on Mellanox systems.
+  This driver can be used together with the watchdog daemon.
+  It can also watch your kernel to make sure it doesn't freeze,
+  and if it does, it reboots your system after a certain amount of
+  time.
+endef
+
+$(eval $(call KernelPackage,mlx_wdt))
+
+
 define KernelPackage/pinctrl-mcp23s08
   SUBMENU:=$(OTHER_MENU)
   TITLE:=Microchip MCP23xxx I/O expander


### PR DESCRIPTION
This PR adds two new kernel packages and their dependencies for the Mellanox platforms, including their Spectrum Switches.

78261850cd1a151bdff8db41742fe3d94878fc9b:
Adds the <code>mlx_wdt</code> driver for the hardware watchdog on Mellanox systems.

7ab8ae3866a2e52edc27c0b28d1c6864edff997a:
Adds <code>mlxreg</code> kernel modules for thermal control and hardware management through <code>sysfs</code> on Mellanox switches.
The commit also adds the dependent Mellanox I²C drivers and support for their two "special" Spectrum Switches.