### PR TITLE
ipq40xx: fritzrepeater-1200: fix MDIO and PHY probing

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-1200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-1200.dts
@@ -23,16 +23,6 @@
 			status = "okay";
 		};
 
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-
-			ethphy: ethernet-phy@0 {
-				reg = <0x0>;
-			};
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -255,6 +245,16 @@
 	qcom,ath10k-calibration-variant = "AVM-FRITZRepeater-1200";
 };
 
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+
+	ethphy: ethernet-phy@0 {
+		reg = <0x0>;
+	};
+};
+
 &gmac {
 	status = "okay";
 };
@@ -271,6 +271,10 @@
 	label = "lan";
 	phy-handle = <&ethphy>;
 	phy-mode = "rgmii-id";
+};
+
+&qca807x {
+	status = "disabled";
 };
 
 &ethphy1 {

--- a/target/linux/ipq40xx/patches-6.6/709-ARM-dts-qcom-ipq4019-add-QCA8075-PHY-Package-nodes.patch
+++ b/target/linux/ipq40xx/patches-6.6/709-ARM-dts-qcom-ipq4019-add-QCA8075-PHY-Package-nodes.patch
@@ -21,7 +21,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  			status = "disabled";
  
 -			ethphy0: ethernet-phy@0 {
-+			ethernet-phy-package@0 {
++			qca807x: ethernet-phy-package@0 {
 +				#address-cells = <1>;
 +				#size-cells = <0>;
 +				compatible = "qcom,qca8075-package";


### PR DESCRIPTION
AVM FRITZ!Repeater 1200 does not use QCA807x PHY at all and thus it disables all of the individual PHY nodes, however this is not enough anymore since the conversion to PHY package.

Now its now enough to disable the PHY-s in the package alone, but the PHY package node itself must also be disabled.

Fixes: 1b931c33a28e ("ipq40xx: adapt to new Upstream QCA807x PHY driver")
Fixes: #15355 
