### PR TITLE
uhttpd, px5g-mbedtls: Support x509v3 subjectAltName etc. in self-signed SSL certificates

### DIFF
--- a/package/network/services/uhttpd/Makefile
+++ b/package/network/services/uhttpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uhttpd
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uhttpd.git

--- a/package/network/services/uhttpd/files/uhttpd.config
+++ b/package/network/services/uhttpd/files/uhttpd.config
@@ -123,8 +123,8 @@ config uhttpd main
 # Defaults for automatic certificate and key generation
 config cert defaults
 
-	# Validity time
-	option days		730
+	# Validity time, 397 days is maximum allowed by CA/Browser forum
+	option days		397
 
 	# key type: rsa or ec
 	option key_type		ec

--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -57,7 +57,8 @@ generate_keys() {
 	[ -n "$GENKEY_CMD" ] && {
 		$GENKEY_CMD \
 			-days ${days:-730} -newkey ${KEY_OPTS} -keyout "${UHTTPD_KEY}.new" -out "${UHTTPD_CERT}.new" \
-			-subj /C="${country:-ZZ}"/ST="${state:-Somewhere}"/L="${location:-Unknown}"/O="${organization:-OpenWrt$UNIQUEID}"/CN="${commonname:-OpenWrt}"
+			-subj /C="${country:-ZZ}"/ST="${state:-Somewhere}"/L="${location:-Unknown}"/O="${organization:-OpenWrt$UNIQUEID}"/CN="${commonname:-OpenWrt}" \
+			-addext extendedKeyUsage=serverAuth -addext subjectAltName=DNS:"${commonname:-OpenWrt}"
 		sync
 		mv "${UHTTPD_KEY}.new" "${UHTTPD_KEY}"
 		mv "${UHTTPD_CERT}.new" "${UHTTPD_CERT}"

--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -56,7 +56,7 @@ generate_keys() {
 	[ -x "$PX5G_BIN" ] && GENKEY_CMD="$PX5G_BIN selfsigned -der"
 	[ -n "$GENKEY_CMD" ] && {
 		$GENKEY_CMD \
-			-days ${days:-730} -newkey ${KEY_OPTS} -keyout "${UHTTPD_KEY}.new" -out "${UHTTPD_CERT}.new" \
+			-days ${days:-397} -newkey ${KEY_OPTS} -keyout "${UHTTPD_KEY}.new" -out "${UHTTPD_CERT}.new" \
 			-subj /C="${country:-ZZ}"/ST="${state:-Somewhere}"/L="${location:-Unknown}"/O="${organization:-OpenWrt$UNIQUEID}"/CN="${commonname:-OpenWrt}" \
 			-addext extendedKeyUsage=serverAuth -addext subjectAltName=DNS:"${commonname:-OpenWrt}"
 		sync

--- a/package/utils/px5g-mbedtls/Makefile
+++ b/package/utils/px5g-mbedtls/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=px5g-mbedtls
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 PKG_LICENSE:=LGPL-2.1
 
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
Browsers are increasingly picky about the attributes included in the SSL certificates. The self-signed certificates generated by uhttpd for LuCI usage cause warnings due to the self-signed status, and especially the missing "subjectAltName" can be difficult with some browsers.

Reference to discussion in https://github.com/openwrt/luci/issues/6701  and forum search https://forum.openwrt.org/search?q=ERR_CERT_INVALID

OpenSSL has supported the extended attributes for some time, as has also the wolfssl library and our related px5g-wolfssl certificate generating tool. The recent upgrade of mbedTLS to 3.6 finally enables also mbedTLS to more easily provide certificates with those attributes.

This PR 
* modifies px5g-mbedtls to support the needed extended x509v3 attributes. The initial draft for implementation was started some months ago by @systemcrash and I have finalized the implementation.
   (Note: OpenSSL backend and px5g-wolfssl required no modifications. Same parameter suits all three SSL implementations)

* modifies uhttpd init script to include also `Subject Alternative Name` and `Extended Key Usage` in the certificate.  
   I took a really old commit from @jow- staging repo where Pat Fruth proposed the parameters already in 2019

* also modifies uhttpd default for certificate lifetime to match the current CA/Browser forum recommendation/requirement of max. 397 days. Reference to https://cabforum.org/working-groups/server/baseline-requirements/
   >  6.3.2 Certificate operational periods and key pair usage periods:  Subscriber Certificates issued on or after 1 September 2020  SHOULD NOT have a Validity Period greater than 397 days and  MUST NOT have a Validity Period greater than 398 days.

Certificates will now have these new attributes:
```
            X509v3 Extended Key Usage:
                TLS Web Server Authentication
            X509v3 Subject Alternative Name:
                DNS:OpenWrt
```

Tested with mediatek filogic MT6000 running r26117-5c833329ce,  all three certificate variants.

Examples below:

OpenSSL:
```
root@router6000:/etc# rm /etc/uhttpd.*
root@router6000:/etc# /etc/init.d/uhttpd restart
4+0 records in
4+0 records out
-----

root@router6000:/etc# openssl x509 -text -noout -in /etc/uhttpd.crt
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            14:50:f9:6c:1b:a0:34:97:8f:f2:3a:4b:92:18:67:e0:1f:27:56:d8
        Signature Algorithm: ecdsa-with-SHA256
        Issuer: C = ZZ, ST = Somewhere, L = Unknown, O = OpenWrtc895345d, CN = OpenWrt
        Validity
            Not Before: May  2 17:19:55 2024 GMT
            Not After : Jun  3 17:19:55 2025 GMT
        Subject: C = ZZ, ST = Somewhere, L = Unknown, O = OpenWrtc895345d, CN = OpenWrt
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:95:29:6d:fc:4e:28:c5:36:0a:e5:d2:1e:12:5d:
                    b5:2c:99:00:9d:19:ac:d5:75:92:93:45:23:d6:30:
                    9f:34:4a:9b:f1:9b:7b:55:db:b4:13:ce:6c:5d:6f:
                    38:83:19:c2:95:b6:64:58:f1:c1:fe:08:f6:fc:39:
                    b5:2a:46:29:5c
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Subject Key Identifier:
                E7:34:31:F3:45:88:3A:24:A5:2B:AC:48:51:A1:BA:A9:DC:2A:35:6C
            X509v3 Authority Key Identifier:
                E7:34:31:F3:45:88:3A:24:A5:2B:AC:48:51:A1:BA:A9:DC:2A:35:6C
            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Extended Key Usage:
                TLS Web Server Authentication
            X509v3 Subject Alternative Name:
                DNS:OpenWrt
    Signature Algorithm: ecdsa-with-SHA256
    Signature Value:
        30:45:02:20:61:53:c7:b7:96:a2:3f:9e:1c:f6:a4:e0:2f:29:
        1b:25:d7:08:86:2e:7c:9b:b8:32:69:54:13:8a:6a:ed:b1:54:
        02:21:00:c5:69:70:9e:70:22:7c:1a:84:34:6b:27:95:e8:77:
        48:da:e1:08:84:5c:51:4a:50:1c:80:84:fe:9d:05:dc:69
```

mbedTLS
```
root@router6000:/etc# opkg install -force-reinstall --force-overwrite /etc/px5g-mbedtls_11_aarch64_cortex-a53.ipk
No packages removed.
Installing px5g-mbedtls (11) to root...
Configuring px5g-mbedtls.
root@router6000:/etc# rm /etc/uhttpd.*
root@router6000:/etc# /etc/init.d/uhttpd restart
4+0 records in
4+0 records out
Generating EC private key
Generating selfsigned certificate with subject 'C=ZZ,ST=Somewhere,L=Unknown,O=OpenWrtf8ae1403,CN=OpenWrt,' and validity 20240502172239-20250603172239
root@router6000:/etc# openssl x509 -text -noout -in /etc/uhttpd.crt
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 4882544200690792491 (0x43c24814ea51782b)
        Signature Algorithm: ecdsa-with-SHA256
        Issuer: C = ZZ, ST = Somewhere, L = Unknown, O = OpenWrtf8ae1403, CN = OpenWrt
        Validity
            Not Before: May  2 17:22:39 2024 GMT
            Not After : Jun  3 17:22:39 2025 GMT
        Subject: C = ZZ, ST = Somewhere, L = Unknown, O = OpenWrtf8ae1403, CN = OpenWrt
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:0c:03:0f:d6:32:17:8f:0a:6f:e8:3c:47:6d:46:
                    b8:df:d9:86:e4:f5:d5:bb:41:c7:70:48:3d:b4:5e:
                    d4:2d:65:f1:b8:35:1d:03:70:b0:98:08:24:9a:a1:
                    17:c3:59:f2:9f:9f:ca:8f:fd:c7:57:0d:0c:3b:ea:
                    17:11:ef:d3:d6
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Basic Constraints:
                CA:FALSE
            X509v3 Subject Key Identifier:
                63:C0:F6:A8:71:62:A3:CD:E7:78:03:F1:B6:D1:6A:8E:66:74:12:7E
            X509v3 Authority Key Identifier:
                63:C0:F6:A8:71:62:A3:CD:E7:78:03:F1:B6:D1:6A:8E:66:74:12:7E
            X509v3 Subject Alternative Name:
                DNS:OpenWrt
            X509v3 Extended Key Usage: critical
                TLS Web Server Authentication
    Signature Algorithm: ecdsa-with-SHA256
    Signature Value:
        30:44:02:20:1e:cb:72:56:e8:b9:be:f7:87:b4:83:eb:a4:1b:
        51:f2:75:9e:3b:27:65:4c:36:7a:bb:36:20:65:05:44:23:83:
        02:20:13:75:83:8b:90:2d:28:61:86:8f:5f:94:c1:b6:f1:26:
        fd:c6:f7:64:ca:25:42:43:05:33:85:d9:29:fc:9c:01
```

WolfSSL
```
root@router6000:/etc# opkg install -force-reinstall --force-overwrite /etc/px5g-wolfssl_9_aarch64_cortex-a53.ipk
No packages removed.
Installing px5g-wolfssl (9) to root...
Configuring px5g-wolfssl.
root@router6000:/etc# rm /etc/uhttpd.*
root@router6000:/etc# /etc/init.d/uhttpd restart
4+0 records in
4+0 records out
Generating EC private key
Generating selfsigned certificate with subject '/C=ZZ/ST=Somewhere/L=Unknown/O=OpenWrt2ddb3f07/CN=OpenWrt' and validity 20240502172412-20250603172412
root@router6000:/etc# openssl x509 -text -noout -in /etc/uhttpd.crt
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            07:00:5f:27:83:f2:3a:2d:1b:a1:d2:fa:85:88:78:35
        Signature Algorithm: ecdsa-with-SHA256
        Issuer: C = ZZ, ST = Somewhere, L = Unknown, O = OpenWrt2ddb3f07, CN = OpenWrt
        Validity
            Not Before: May  1 17:24:12 2024 GMT
            Not After : Jun  3 17:24:12 2025 GMT
        Subject: C = ZZ, ST = Somewhere, L = Unknown, O = OpenWrt2ddb3f07, CN = OpenWrt
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:b1:00:03:2c:30:4a:fe:ad:77:17:98:95:56:43:
                    ee:7c:63:09:df:d1:ae:2f:d3:4b:4c:36:8b:c3:28:
                    2b:49:ba:9a:50:81:6e:1c:14:e4:1b:ea:5a:c6:9c:
                    a3:c0:5a:b3:8d:a9:ae:38:59:10:83:e7:3f:84:df:
                    20:ce:30:cb:ff
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Subject Alternative Name:
                DNS:OpenWrt
            X509v3 Key Usage: critical
                Digital Signature, Non Repudiation, Key Encipherment
            X509v3 Extended Key Usage:
                TLS Web Server Authentication
    Signature Algorithm: ecdsa-with-SHA256
    Signature Value:
        30:45:02:20:59:24:c3:9e:9f:74:86:91:1f:a0:3d:1d:d4:a5:
        b4:9d:61:f6:6d:4f:76:7d:0d:53:8b:65:83:94:c6:d5:9c:2e:
        02:21:00:fe:7b:d4:3c:75:23:71:07:0d:2b:13:0b:3c:2a:be:
        67:20:09:f7:7b:0d:ca:69:72:6e:c7:a3:f2:f2:77:04:17
```

For reference, a current cert generated by uhttpd with OpenSSL without the new parameters:
```
root@router4:~# openssl x509 -text -noout -in /etc/uhttpd.crt
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            61:0b:8d:7a:fd:d1:da:33:01:c3:71:57:f0:56:2e:03:eb:39:73:bf
        Signature Algorithm: ecdsa-with-SHA256
        Issuer: C = ZZ, ST = Somewhere, L = Unknown, O = OpenWrt08f8a59c, CN = OpenWrt
        Validity
            Not Before: Jun 17 15:48:27 2021 GMT
            Not After : Jun 17 15:48:27 2023 GMT
        Subject: C = ZZ, ST = Somewhere, L = Unknown, O = OpenWrt08f8a59c, CN = OpenWrt
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:64:d6:31:2b:a1:73:dc:ef:ac:62:1b:31:79:72:
                    83:61:26:41:c0:fd:ec:83:e1:92:f6:a7:69:3e:b8:
                    a3:58:e0:c1:d2:5c:4f:80:3d:64:12:ac:0d:cb:c3:
                    da:0b:3d:6f:19:fb:f0:e9:69:5c:17:84:17:fa:c1:
                    af:ba:b3:fa:87
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Subject Key Identifier:
                29:10:B0:92:63:2A:E4:DC:39:2B:3D:1D:C8:62:93:78:D3:83:4A:31
            X509v3 Authority Key Identifier:
                29:10:B0:92:63:2A:E4:DC:39:2B:3D:1D:C8:62:93:78:D3:83:4A:31
            X509v3 Basic Constraints: critical
                CA:TRUE
    Signature Algorithm: ecdsa-with-SHA256
    Signature Value:
        30:45:02:20:78:56:3f:10:9a:e4:6f:92:90:ef:08:06:26:b2:
        5b:d6:64:6e:fc:c6:2c:f8:1e:96:c7:83:e6:aa:d8:22:f2:f7:
        02:21:00:cc:14:86:1c:22:e3:9b:8c:42:39:58:61:f1:7a:cb:
        cc:c7:2c:a7:f9:92:d5:89:ce:d8:ae:bf:23:f4:b4:2e:39
```