### PR TITLE
tools/elfutils: do not link gnulib to libelf

### DIFF
--- a/tools/elfutils/Makefile
+++ b/tools/elfutils/Makefile
@@ -53,8 +53,14 @@ PKG_GNULIB_MODS = \
 
 include $(INCLUDE_DIR)/host-build.mk
 
+export $(PKG_GNULIB_BASE)=$(HOST_BUILD_DIR)/$(PKG_GNULIB_BASE)/$(PKG_GNULIB_BASE).la
+export $(PKG_GNULIB_BASE)_tsearch=$(HOST_BUILD_DIR)/$(PKG_GNULIB_BASE)/$(PKG_GNULIB_BASE)_la-tsearch.lo
+
 HOST_MAKE_FLAGS += \
 	AM_LDFLAGS='$$$$(STACK_USAGE_NO_ERROR)' \
+	LIBS+='$$$$(if $$$$(findstring $(lastword $(PKG_SUBDIRS)),$$$$(subdir)), $$$$($(PKG_GNULIB_BASE)))' \
+	LIBS+='$$$$(wildcard $$$$($(PKG_GNULIB_BASE)_tsearch))' \
+	REPLACE_FCNTL=0 REPLACE_FREE=0 REPLACE_FSTAT=0 REPLACE_OPEN=0 \
 	bin_PROGRAMS='$(PKG_PROGRAMS)' EXEEXT=
 
 ifeq ($(HOST_OS),Darwin)

--- a/tools/elfutils/Makefile
+++ b/tools/elfutils/Makefile
@@ -68,6 +68,7 @@ ifeq ($(HOST_OS),Darwin)
 endif
 
 HOST_CFLAGS += -Wno-error -fPIC
+HOST_CXXFLAGS += -O2
 
 HOST_CONFIGURE_ARGS += \
 	--without-libintl-prefix \

--- a/tools/elfutils/Makefile
+++ b/tools/elfutils/Makefile
@@ -17,6 +17,8 @@ PKG_CPE_ID:=cpe:/a:elfutils_project:elfutils
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 
+PKG_PROGRAMS:=elflint findtextrel elfcmp unstrip stack elfcompress elfclassify srcfiles
+
 PKG_SUBDIRS := \
 	libgnu \
 	config \
@@ -27,7 +29,8 @@ PKG_SUBDIRS := \
 	libebl \
 	libdwelf \
 	libdwfl \
-	libdw
+	libdw \
+	src
 
 PKG_GNULIB_BASE:=libgnu
 
@@ -41,6 +44,7 @@ PKG_GNULIB_ARGS = \
 
 PKG_GNULIB_MODS = \
 	argp \
+	fnmatch-gnu \
 	fts \
 	obstack \
 	progname \
@@ -48,6 +52,10 @@ PKG_GNULIB_MODS = \
 	tsearch
 
 include $(INCLUDE_DIR)/host-build.mk
+
+HOST_MAKE_FLAGS += \
+	AM_LDFLAGS='$$$$(STACK_USAGE_NO_ERROR)' \
+	bin_PROGRAMS='$(PKG_PROGRAMS)' EXEEXT=
 
 ifeq ($(HOST_OS),Darwin)
   HOST_CFLAGS += -I/opt/homebrew/include

--- a/tools/elfutils/patches/100-portability.patch
+++ b/tools/elfutils/patches/100-portability.patch
@@ -198,7 +198,7 @@
  pkginclude_HEADERS = elf-knowledge.h
  
 -libelf_a_SOURCES = elf_version.c elf_hash.c elf_error.c elf_fill.c \
-+libelf_la_LIBADD = ../libgnu/libgnu.la ../lib/libeu.la -lz $(zstd_LIBS) -lpthread
++libelf_la_LIBADD = ../lib/libeu.la -lz $(zstd_LIBS) -lpthread
 +libelf_la_SOURCES = elf_version.c elf_hash.c elf_error.c \
  		   elf_begin.c elf_next.c elf_rand.c elf_end.c elf_kind.c \
  		   gelf_getclass.c elf_getbase.c elf_getident.c \

--- a/tools/elfutils/patches/100-portability.patch
+++ b/tools/elfutils/patches/100-portability.patch
@@ -898,3 +898,46 @@
  #include <stddef.h>
  
  
+--- a/libebl/eblopenbackend.c
++++ b/libebl/eblopenbackend.c
+@@ -198,8 +198,6 @@ static bool default_object_note (const c
+ 				 uint32_t descsz, const char *desc);
+ static bool default_debugscn_p (const char *name);
+ static bool default_copy_reloc_p (int reloc);
+-static bool default_none_reloc_p (int reloc);
+-static bool default_relative_reloc_p (int reloc);
+ static bool default_check_special_symbol (Elf *elf,
+ 					  const GElf_Sym *sym,
+ 					  const char *name,
+@@ -251,8 +249,8 @@ fill_defaults (Ebl *result)
+   result->object_note = default_object_note;
+   result->debugscn_p = default_debugscn_p;
+   result->copy_reloc_p = default_copy_reloc_p;
+-  result->none_reloc_p = default_none_reloc_p;
+-  result->relative_reloc_p = default_relative_reloc_p;
++  result->none_reloc_p = default_copy_reloc_p;
++  result->relative_reloc_p = default_copy_reloc_p;
+   result->check_special_symbol = default_check_special_symbol;
+   result->data_marker_symbol = default_data_marker_symbol;
+   result->check_st_other_bits = default_check_st_other_bits;
+@@ -634,8 +632,6 @@ default_copy_reloc_p (int reloc __attrib
+ {
+   return false;
+ }
+-strong_alias (default_copy_reloc_p, default_none_reloc_p)
+-strong_alias (default_copy_reloc_p, default_relative_reloc_p)
+ 
+ static bool
+ default_check_special_symbol (Elf *elf __attribute__ ((unused)),
+--- a/src/srcfiles.cxx
++++ b/src/srcfiles.cxx
+@@ -78,7 +78,9 @@ ARGP_PROGRAM_VERSION_HOOK_DEF = print_ve
+ /* Bug report address.  */
+ ARGP_PROGRAM_BUG_ADDRESS_DEF = PACKAGE_BUGREPORT;
+ 
++#ifdef HAVE_LIBARCHIVE
+ constexpr size_t BUFFER_SIZE = 8192;
++#endif
+ 
+ /* Definitions of arguments for argp functions.  */
+ static const struct argp_option options[] =

--- a/tools/gnulib/patches/120-unmangle-darwin-fts-h.patch
+++ b/tools/gnulib/patches/120-unmangle-darwin-fts-h.patch
@@ -1,0 +1,19 @@
+--- /dev/null
++++ b/lib/fts.h
+@@ -0,0 +1,6 @@
++#ifdef __APPLE__
++# define _FTS_H_ 1
++# include <fts_.h>
++#else
++# include_next <fts.h>
++#endif
+--- a/modules/fts
++++ b/modules/fts
+@@ -2,6 +2,7 @@ Description:
+ Traverse a file hierarchy.
+ 
+ Files:
++lib/fts.h
+ lib/fts_.h
+ lib/fts.c
+ lib/fts-cycle.c


### PR DESCRIPTION
ping @robimarko @httpstorm @trippleflux

This is the direct/general way to stop extra symbols from being in libelf
(I also noticed that we weren't installing any binaries and found the reason for that, so lets just install the unique ones)

This is purposefully not rebased on top so that it can be shown that it also fixes openwrt/packages#24030
alongside with #15337 which just removes the actual extra definition in that specific case

Of course, this needs testing on macOS, as I have a feeling there is some other reason that they were linked together
that I just can't see because it only applies to macOS...