### PR TITLE
ramips: add support for JDCloud RE-CP-02

### DIFF
--- a/target/linux/ramips/dts/mt7621_jdcloud_re-cp-02.dts
+++ b/target/linux/ramips/dts/mt7621_jdcloud_re-cp-02.dts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "jdcloud,re-cp-02", "mediatek,mt7621-soc";
+	model = "JDCloud RE-CP-02";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: led-0 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-1 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "U-Boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "u-boot,env";
+				label = "Config";
+				reg = <0x40000 0x10000>;
+			};
+
+			partition@50000 {
+				label = "Factory";
+				reg = <0x50000 0x40000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+
+					macaddr_factory_3fff4: macaddr@3fff4 {
+						reg = <0x3fff4 0x6>;
+					};
+
+					macaddr_factory_3fffa: macaddr@3fffa {
+						reg = <0x3fffa 0x6>;
+					};
+				};
+			};
+
+			partition@90000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x90000 0xf70000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		mediatek,disable-radar-background;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_3fff4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_3fffa>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1534,6 +1534,15 @@ define Device/jcg_y2
 endef
 TARGET_DEVICES += jcg_y2
 
+define Device/jdcloud_re-cp-02
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 16000k
+  DEVICE_VENDOR := JD-Cloud
+  DEVICE_MODEL := RE-CP-02
+  DEVICE_PACKAGES := kmod-mt7915-firmware kmod-sdhci-mt7620
+endef
+TARGET_DEVICES += jdcloud_re-cp-02
+
 define Device/keenetic_kn-3010
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -15,6 +15,9 @@ boot() {
 			$((0xff)) ]] || printf '\xff' | dd of=/dev/mtdblock3 \
 			count=1 bs=1 seek=$((0x20001))
 		;;
+	jdcloud,re-cp-02)
+		echo -e "bootcount 0\nbootlimit 5\nupgrade_available 1"  | /usr/sbin/fw_setenv -s -
+		;;
 	linksys,e5600|\
 	linksys,ea6350-v4|\
 	linksys,ea7300-v1|\


### PR DESCRIPTION
## Specifications

- Soc: MediaTek MT7621AT
- RAM: 512 MB (DDR3)
- Flash: 16 MB (SPI NOR)
- WiFi: MediaTek MT7905DAN, MediaTek MT7975DN
- Ethernet: 1 WAN, 3 LAN (Gigabit)
- Buttons: Reset, Joylink
- LEDs: (red, blue, green), routed to one indicator in the top of the device
- Power: DC 12V 1A tip positive
- 1 TF Card Slot

The pins for the serial console are already labeled on the board J4 (V, R, T, G). Serial settings: 3.3V, 115200

MAC addresses:

|         | MAC               | Algorithm |
| ------- | ----------------- | --------- |
| label   | dc:d8:xx:xx:xx:01 | label     |
| LAN     | dc:d8:xx:xx:xx:01 | label     |
| WAN     | dc:d8:xx:xx:xx:02 | label+1   |
| WLAN 2g | dc:d8:xx:xx:xx:03 | label+2   |
| WLAN 5g | de:d8:xx:xx:xx:04 | label+3   |

## Installation

1. rename the openwrt-ramips-mt7621-jdcloud_re-cp-02-squashfs-sysupgrade.bin to JDCOS.bin

2. start a TFTP server from IP address 192.168.68.10 and serve the image named JDCOS.bin

3. connect your device to the LAN port

4. power up the router and press any key on the console to interrupt the boot process.

5. enter the following commands on the router console

   1. setenv bootcount 6

   2. saveenv

   3. reset

      > NOTE: wait for the restart, it will automatically fetch the image named JDCOS.bin from the TFTP server and write it into the flash. After the writing is completed, the router will be automatically restarted.

## Known Issues:

Unable to recognize large-capacity TF card, see #14042. But the patch [#issuecomment-1910769942](https://github.com/openwrt/openwrt/issues/14042#issuecomment-1910769942) works
