### PR TITLE
scripts/feeds: Add feed update options for git rebase and autostash

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -159,6 +159,7 @@ my %update_method = (
 		'init_branch'   => "git clone --depth 1 --branch '%s' '%s' '%s'",
 		'init_commit'   => "git clone '%s' '%s' && cd '%s' && git checkout -b '%s' '%s' && cd -",
 		'update'	=> "git pull --ff-only",
+		'update_rebase'	=> "git pull --rebase=merges",
 		'update_force'	=> "git pull --ff-only || (git reset --hard HEAD; git pull --ff-only; exit 1)",
 		'post_update'	=> "git submodule update --init --recursive",
 		'controldir'	=> ".git",
@@ -168,6 +169,7 @@ my %update_method = (
 		'init_branch'   => "git clone --branch '%s' '%s' '%s'",
 		'init_commit'   => "git clone '%s' '%s' && cd '%s' && git checkout -b '%s' '%s' && cd -",
 		'update'	=> "git pull --ff-only",
+		'update_rebase'	=> "git pull --rebase=merges",
 		'update_force'	=> "git pull --ff-only || (git reset --hard HEAD; git pull --ff-only; exit 1)",
 		'post_update'	=> "git submodule update --init --recursive",
 		'controldir'	=> ".git",
@@ -194,12 +196,13 @@ my %update_method = (
 # src-git: pull broken
 # src-cpy: broken if `basename $src` != $name
 
-sub update_feed_via($$$$$) {
+sub update_feed_via($$$$$$) {
 	my $type = shift;
 	my $name = shift;
 	my $src = shift;
 	my $relocate = shift;
 	my $force = shift;
+	my $rebase = shift;
 
 	my $m = $update_method{$type};
 	my $localpath = "./feeds/$name";
@@ -223,6 +226,9 @@ sub update_feed_via($$$$$) {
 		my $update_cmd = $m->{'update'};
 		if ($force && exists $m->{'update_force'}) {
 			$update_cmd = $m->{'update_force'};
+		}
+		if ($rebase && exists $m->{'update_rebase'}) {
+			$update_cmd = $m->{'update_rebase'};
 		}
 		system("cd '$safepath'; $update_cmd") == 0 or return 1;
 	}
@@ -776,12 +782,13 @@ sub uninstall {
 	return 0;
 }
 
-sub update_feed($$$$)
+sub update_feed($$$$$)
 {
 	my $type=shift;
 	my $name=shift;
 	my $src=shift;
 	my $force_update=shift;
+	my $rebase_update=shift;
 	my $force_relocate=update_location( $name, "@$src" );
 	my $rv=0;
 
@@ -796,7 +803,7 @@ sub update_feed($$$$)
 	my $failed = 1;
 	foreach my $feedsrc (@$src) {
 		warn "Updating feed '$name' from '$feedsrc' ...\n";
-		if (update_feed_via($type, $name, $feedsrc, $force_relocate, $force_update) != 0) {
+		if (update_feed_via($type, $name, $feedsrc, $force_relocate, $force_update, $rebase_update) != 0) {
 			if ($force_update) {
 				$rv=1;
 				$failed=0;
@@ -822,12 +829,17 @@ sub update {
 	$ENV{SCAN_COOKIE} = $$;
 	$ENV{OPENWRT_VERBOSE} = 's';
 
-	getopts('ahif', \%opts);
+	getopts('ahifr', \%opts);
 	%argv_feeds = map { $_ => 1 } @ARGV;
 
 	if ($opts{h}) {
 		usage();
 		return 0;
+	}
+
+	if ($opts{f} && $opts{r}) {
+		warn "Force and rebase are incompatible update options.\n";;
+		return 1;
 	}
 
 	-d "feeds" or do {
@@ -839,7 +851,7 @@ sub update {
 		my ($type, $name, $src) = @$feed;
 		next unless $#ARGV == -1 or $opts{a} or $argv_feeds{$name};
 		if (not $opts{i}) {
-			update_feed($type, $name, $src, $opts{f}) == 0 or $failed=1;
+			update_feed($type, $name, $src, $opts{f}, $opts{r}) == 0 or $failed=1;
 		}
 		push @index_feeds, $name;
 	}
@@ -904,6 +916,7 @@ Commands:
 	update -a|<feedname(s)>: Update packages and lists of feeds in feeds.conf .
 	Options:
 	    -a :           Update all feeds listed within feeds.conf. Otherwise the specified feeds will be updated.
+	    -r :           Update by rebase. (git only. Useful if local commits exist)
 	    -i :           Recreate the index only. No feed update from repository is performed.
 	    -f :           Force updating feeds even if there are changed, uncommitted files.
 

--- a/scripts/feeds
+++ b/scripts/feeds
@@ -160,6 +160,7 @@ my %update_method = (
 		'init_commit'   => "git clone '%s' '%s' && cd '%s' && git checkout -b '%s' '%s' && cd -",
 		'update'	=> "git pull --ff-only",
 		'update_rebase'	=> "git pull --rebase=merges",
+		'update_stash'	=> "git pull --rebase=merges --autostash",
 		'update_force'	=> "git pull --ff-only || (git reset --hard HEAD; git pull --ff-only; exit 1)",
 		'post_update'	=> "git submodule update --init --recursive",
 		'controldir'	=> ".git",
@@ -170,6 +171,7 @@ my %update_method = (
 		'init_commit'   => "git clone '%s' '%s' && cd '%s' && git checkout -b '%s' '%s' && cd -",
 		'update'	=> "git pull --ff-only",
 		'update_rebase'	=> "git pull --rebase=merges",
+		'update_stash'	=> "git pull --rebase=merges --autostash",
 		'update_force'	=> "git pull --ff-only || (git reset --hard HEAD; git pull --ff-only; exit 1)",
 		'post_update'	=> "git submodule update --init --recursive",
 		'controldir'	=> ".git",
@@ -196,13 +198,14 @@ my %update_method = (
 # src-git: pull broken
 # src-cpy: broken if `basename $src` != $name
 
-sub update_feed_via($$$$$$) {
+sub update_feed_via($$$$$$$) {
 	my $type = shift;
 	my $name = shift;
 	my $src = shift;
 	my $relocate = shift;
 	my $force = shift;
 	my $rebase = shift;
+	my $stash = shift;
 
 	my $m = $update_method{$type};
 	my $localpath = "./feeds/$name";
@@ -229,6 +232,9 @@ sub update_feed_via($$$$$$) {
 		}
 		if ($rebase && exists $m->{'update_rebase'}) {
 			$update_cmd = $m->{'update_rebase'};
+		}
+		if ($stash && exists $m->{'update_stash'}) {
+			$update_cmd = $m->{'update_stash'};
 		}
 		system("cd '$safepath'; $update_cmd") == 0 or return 1;
 	}
@@ -782,13 +788,14 @@ sub uninstall {
 	return 0;
 }
 
-sub update_feed($$$$$)
+sub update_feed($$$$$$)
 {
 	my $type=shift;
 	my $name=shift;
 	my $src=shift;
 	my $force_update=shift;
 	my $rebase_update=shift;
+	my $stash_update=shift;
 	my $force_relocate=update_location( $name, "@$src" );
 	my $rv=0;
 
@@ -803,7 +810,7 @@ sub update_feed($$$$$)
 	my $failed = 1;
 	foreach my $feedsrc (@$src) {
 		warn "Updating feed '$name' from '$feedsrc' ...\n";
-		if (update_feed_via($type, $name, $feedsrc, $force_relocate, $force_update, $rebase_update) != 0) {
+		if (update_feed_via($type, $name, $feedsrc, $force_relocate, $force_update, $rebase_update, $stash_update) != 0) {
 			if ($force_update) {
 				$rv=1;
 				$failed=0;
@@ -829,7 +836,7 @@ sub update {
 	$ENV{SCAN_COOKIE} = $$;
 	$ENV{OPENWRT_VERBOSE} = 's';
 
-	getopts('ahifr', \%opts);
+	getopts('ahifrs', \%opts);
 	%argv_feeds = map { $_ => 1 } @ARGV;
 
 	if ($opts{h}) {
@@ -837,8 +844,8 @@ sub update {
 		return 0;
 	}
 
-	if ($opts{f} && $opts{r}) {
-		warn "Force and rebase are incompatible update options.\n";;
+	if ($opts{f} && ($opts{r} || $opts{s})) {
+		warn "Force and rebase/stash are incompatible update options.\n";;
 		return 1;
 	}
 
@@ -851,7 +858,7 @@ sub update {
 		my ($type, $name, $src) = @$feed;
 		next unless $#ARGV == -1 or $opts{a} or $argv_feeds{$name};
 		if (not $opts{i}) {
-			update_feed($type, $name, $src, $opts{f}, $opts{r}) == 0 or $failed=1;
+			update_feed($type, $name, $src, $opts{f}, $opts{r}, $opts{s}) == 0 or $failed=1;
 		}
 		push @index_feeds, $name;
 	}
@@ -917,6 +924,7 @@ Commands:
 	Options:
 	    -a :           Update all feeds listed within feeds.conf. Otherwise the specified feeds will be updated.
 	    -r :           Update by rebase. (git only. Useful if local commits exist)
+	    -s :           Update by rebase and autostash. (git only. Useful if local commits and uncommited changes exist)
 	    -i :           Recreate the index only. No feed update from repository is performed.
 	    -f :           Force updating feeds even if there are changed, uncommitted files.
 


### PR DESCRIPTION
Enhance feed update options for git repositories: enable `git pull --rebase` and also `--autostash`.

Our current feed update has been strictly `git pull --ff-only` for a few years since git started to require explicit git pull style to be selected. That fastforward-only requirement prevents updating feeds while there are local commits. In addition, during development there may also be uncommited changes.

This PR has two commits that enhance the feeds update with two options:
* '-r' does the update with `git pull --rebase` allowing local commits to be rebased on top of the updated commits pulled from upstream.
* '-s' does the update with `git pull --rebase --autostash` allowing local uncommited changes to be first stashed, local commits to be rebased on top of the updated commits pulled from upstream, and finally stash is popped. 

Keeping the default update style as fastforward-only is good and easy for casual OpenWrt compilers/users, but providing enhanced rebase-style options would be useful for more advanced users that have development commits in their feed repos. Note that both new options may require some merge-conflict work, so using them requires some git knowledge.

Some examples:

Plain pull fails but rebase works:
```
perus@ub2404:/OpenWrt/koe2/main$ ./scripts/feeds update
Updating feed 'packages' from 'https://git.openwrt.org/feed/packages.git' ...
remote: Enumerating objects: 169011, done.
remote: Counting objects: 100% (169010/169010), done.
remote: Compressing objects: 100% (69718/69718), done.
remote: Total 164629 (delta 97255), reused 151194 (delta 85965), pack-reused 0
Receiving objects: 100% (164629/164629), 33.13 MiB | 9.88 MiB/s, done.
Resolving deltas: 100% (97255/97255), completed with 2247 local objects.
From https://git.openwrt.org/feed/packages
   2750b16b4..5181ce4a4 master     -> origin/master
hint: Diverging branches can't be fast-forwarded, you need to either:
hint: 
hint: 	git merge --no-ff
hint: 
hint: or:
hint: 
hint: 	git rebase
hint: 
hint: Disable this message with "git config advice.diverging false"
fatal: Not possible to fast-forward, aborting.
failed.
...

perus@ub2404:/OpenWrt/koe2/main$ ./scripts/feeds update -r
Updating feed 'packages' from 'https://git.openwrt.org/feed/packages.git' ...
Successfully rebased and updated refs/heads/master.
```

Both local commits and uncommited changes present, so rebase will fail, but git pull rebase autostash works:
```
perus@ub2404:/OpenWrt/koe2/main$ ./scripts/feeds update -r
Updating feed 'packages' from 'https://git.openwrt.org/feed/packages.git' ...
Current branch master is up to date.
Updating feed 'luci' from 'https://git.openwrt.org/project/luci.git' ...
error: cannot pull with rebase: Your index contains uncommitted changes.
error: Please commit or stash them.
failed.
Updating feed 'routing' from 'https://git.openwrt.org/feed/routing.git' ...
...

perus@ub2404:/OpenWrt/koe2/main$ ./scripts/feeds update -s
Updating feed 'packages' from 'https://git.openwrt.org/feed/packages.git' ...
Current branch master is up to date.
Updating feed 'luci' from 'https://git.openwrt.org/project/luci.git' ...
Created autostash: 44b7207f29
Applied autostash.
Successfully rebased and updated refs/heads/master.
Updating feed 'routing' from 'https://git.openwrt.org/feed/routing.git' ...
...
```



