### PR TITLE
realtek: LLDP trapping

### DIFF
--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
@@ -155,6 +155,12 @@ static void rtl83xx_setup_bpdu_traps(struct rtl838x_switch_priv *priv)
 		priv->r->set_receive_management_action(i, BPDU, TRAP2CPU);
 }
 
+static void rtl83xx_setup_lldp_traps(struct rtl838x_switch_priv *priv)
+{
+	for (int i = 0; i < priv->cpu_port; i++)
+		priv->r->set_receive_management_action(i, LLDP, TRAP2CPU);
+}
+
 static void rtl83xx_port_set_salrn(struct rtl838x_switch_priv *priv,
 				   int port, bool enable)
 {
@@ -207,6 +213,7 @@ static int rtl83xx_setup(struct dsa_switch *ds)
 	rtl83xx_vlan_setup(priv);
 
 	rtl83xx_setup_bpdu_traps(priv);
+	rtl83xx_setup_lldp_traps(priv);
 
 	ds->configure_vlan_while_not_filtering = true;
 

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1678,9 +1678,9 @@ void rtl838x_set_receive_management_action(int port, rma_ctrl_t type, action_typ
 		sw_w32_mask(3 << ((port & 0xf) << 1), (action & 0x3) << ((port & 0xf) << 1),
 			    RTL838X_RMA_PTP_CTRL + ((port >> 4) << 2));
 		break;
-	case LLTP:
+	case LLDP:
 		sw_w32_mask(3 << ((port & 0xf) << 1), (action & 0x3) << ((port & 0xf) << 1),
-			    RTL838X_RMA_LLTP_CTRL + ((port >> 4) << 2));
+			    RTL838X_RMA_LLDP_CTRL + ((port >> 4) << 2));
 		break;
 	default:
 		break;

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -425,7 +425,7 @@ typedef enum {
 	PTP,
 	PTP_UDP,
 	PTP_ETH2,
-	LLTP,
+	LLDP,
 	EAPOL,
 	GRATARP,
 } rma_ctrl_t;
@@ -449,10 +449,10 @@ typedef enum {
 #define RTL930X_RMA_PTP_CTRL			(0x9E88)
 #define RTL931X_RMA_PTP_CTRL			(0x8834)
 
-#define RTL838X_RMA_LLTP_CTRL			(0x4340)
-#define RTL839X_RMA_LLTP_CTRL			(0x124C)
-#define RTL930X_RMA_LLTP_CTRL			(0x9EFC)
-#define RTL931X_RMA_LLTP_CTRL			(0x8918)
+#define RTL838X_RMA_LLDP_CTRL			(0x4340)
+#define RTL839X_RMA_LLDP_CTRL			(0x124C)
+#define RTL930X_RMA_LLDP_CTRL			(0x9EFC)
+#define RTL931X_RMA_LLDP_CTRL			(0x8918)
 
 #define RTL930X_RMA_EAPOL_CTRL			(0x9F08)
 #define RTL931X_RMA_EAPOL_CTRL			(0x8930)

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -1814,9 +1814,9 @@ void rtl839x_set_receive_management_action(int port, rma_ctrl_t type, action_typ
 		sw_w32_mask(3 << ((port & 0xf) << 1), (action & 0x3) << ((port & 0xf) << 1),
 			    RTL839X_RMA_PTP_CTRL + ((port >> 4) << 2));
 		break;
-	case LLTP:
+	case LLDP:
 		sw_w32_mask(3 << ((port & 0xf) << 1), (action & 0x3) << ((port & 0xf) << 1),
-			    RTL839X_RMA_LLTP_CTRL + ((port >> 4) << 2));
+			    RTL839X_RMA_LLDP_CTRL + ((port >> 4) << 2));
 		break;
 	default:
 		break;

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -516,8 +516,8 @@ void rtl931x_set_receive_management_action(int port, rma_ctrl_t type, action_typ
 	case PTP_ETH2:
 		sw_w32_mask(3, value, RTL931X_RMA_PTP_CTRL + (port << 2));
 	break;
-	case LLTP:
-		sw_w32_mask(7 << ((port % 10) * 3), value << ((port % 10) * 3), RTL931X_RMA_LLTP_CTRL + ((port / 10) << 2));
+	case LLDP:
+		sw_w32_mask(7 << ((port % 10) * 3), value << ((port % 10) * 3), RTL931X_RMA_LLDP_CTRL + ((port / 10) << 2));
 	break;
 	case EAPOL:
 		sw_w32_mask(7 << ((port % 10) * 3), value << ((port % 10) * 3), RTL931X_RMA_EAPOL_CTRL + ((port / 10) << 2));


### PR DESCRIPTION
We should setup the registers for trapping LLDP (Link Layer Discovery Protocol) packets to the CPU.
Currently, these packets are forwarded to all ports which is not desired
behaviour.

Before this patch, every LLDP capable device connected to the switch discovered the switch and all other devices connected to the switch as neighbors. With this patch, only the switch is discovered.