### PR TITLE
bpf: also include toolchain standard header as system header

### DIFF
--- a/include/bpf.mk
+++ b/include/bpf.mk
@@ -33,7 +33,8 @@ BPF_TARGET:=bpf$(if $(CONFIG_BIG_ENDIAN),eb,el)
 BPF_HEADERS_DIR:=$(STAGING_DIR)/bpf-headers
 
 BPF_KERNEL_INCLUDE := \
-	-nostdinc $(patsubst %,-isystem %,$(TOOLCHAIN_INC_DIRS)) \
+	-nostdinc -isystem $(TOOLCHAIN_ROOT_DIR)/lib/gcc/*/*/include \
+	$(patsubst %,-isystem%,$(TOOLCHAIN_INC_DIRS)) \
 	-I$(BPF_HEADERS_DIR)/arch/$(BPF_KARCH)/include \
 	-I$(BPF_HEADERS_DIR)/arch/$(BPF_KARCH)/include/asm/mach-generic \
 	-I$(BPF_HEADERS_DIR)/arch/$(BPF_KARCH)/include/generated \


### PR DESCRIPTION
Also include toolchain standard header as system header. These are required by xdp-tools that try to include stddef.h and stdbool.h for some tools. These header are usually in /lib/gcc/../include but musl also have some special variant in /include.

To fix compilation of xdp-tools, also include these standard header. These header should follow ISO C standard and should not introduce regression in bpf tools making them specific to an arch.