### PR TITLE
ipq4019: fix even more wrong reference to USB node

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ap120c-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ap120c-ac.dts
@@ -98,19 +98,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				phys = <&usb3_hs_phy>;
-				phy-names = "usb2-phy";
-			};
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -323,8 +310,21 @@
 	status = "okay";
 };
 
+&usb2 {
+	status = "okay";
+};
+
 &usb3_hs_phy {
 	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb3_dwc {
+	phys = <&usb3_hs_phy>;
+	phy-names = "usb2-phy";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ea6350v3.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ea6350v3.dts
@@ -50,14 +50,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -307,6 +299,14 @@
 	status = "okay";
 };
 
+&usb3 {
+	status = "okay";
+};
+
 &usb2_hs_phy {
+	status = "okay";
+};
+
+&usb2 {
 	status = "okay";
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ecw5211.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ecw5211.dts
@@ -89,19 +89,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				phys = <&usb3_hs_phy>;
-				phy-names = "usb2-phy";
-			};
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -325,10 +312,23 @@
 	qcom,ath10k-calibration-variant = "ALFA-Network-AP120C-AC";
 };
 
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+};
+
 &usb3_hs_phy {
 	status = "okay";
 };
 
-&usb2_hs_phy {
+&usb3 {
 	status = "okay";
+};
+
+&usb3_dwc {
+	phys = <&usb3_hs_phy>;
+	phy-names = "usb2-phy";
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emr3500.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emr3500.dts
@@ -37,10 +37,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2_hs_phy: hsphy@a8000 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-fritzbox-4040.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-fritzbox-4040.dts
@@ -51,14 +51,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -315,7 +307,15 @@
 	status = "okay";
 };
 
+&usb3 {
+	status = "okay";
+};
+
 &usb2_hs_phy {
+	status = "okay";
+};
+
+&usb2 {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-ap1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-ap1300.dts
@@ -61,14 +61,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -261,11 +253,19 @@
 	status = "okay";
 };
 
+&usb2 {
+	status = "okay";
+};
+
 &usb3_hs_phy {
 	status = "okay";
 };
 
 &usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3 {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-hap-ac2.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-hap-ac2.dts
@@ -63,15 +63,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				phys = <&usb3_hs_phy>;
-				phy-names = "usb2-phy";
-			};
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -217,6 +208,15 @@
 
 &usb3_hs_phy {
 	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb3_dwc {
+	phys = <&usb3_hs_phy>;
+	phy-names = "usb2-phy";
 };
 
 &mdio {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-nbg6617.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-nbg6617.dts
@@ -60,39 +60,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-
-			dwc3@6000000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				usb2_port1: port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				usb3_port1: port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-
-				usb3_port2: port@2 {
-					reg = <2>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -360,6 +327,39 @@
 	status = "okay";
 };
 
+&usb3 {
+	status = "okay";
+};
+
+&usb3_dwc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	usb3_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+
+	usb3_port2: port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
+	};
+};
+
 &usb2_hs_phy {
 	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+
+	usb@6000000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		usb2_port1: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
+	};
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rt-ac58u.dts
@@ -55,25 +55,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				usb3_port1: port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-
-				usb3_port2: port@2 {
-					reg = <2>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -289,6 +270,25 @@
 
 &usb3_hs_phy {
 	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb3_dwc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	usb3_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+
+	usb3_port2: port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
+	};
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wap-ac-lte.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wap-ac-lte.dts
@@ -15,15 +15,6 @@
 			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
 			status = "okay";
 		};
-
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				phys = <&usb3_hs_phy>;
-				phy-names = "usb2-phy";
-			};
-		};
 	};
 };
 
@@ -42,4 +33,9 @@
 
 &usb3 {
 	status = "okay";
+};
+
+&usb3_dwc {
+	phys = <&usb3_hs_phy>;
+	phy-names = "usb2-phy";
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wap-r-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wap-r-ac.dts
@@ -15,15 +15,6 @@
 			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
 			status = "okay";
 		};
-
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				phys = <&usb3_hs_phy>;
-				phy-names = "usb2-phy";
-			};
-		};
 	};
 };
 
@@ -42,4 +33,9 @@
 
 &usb3 {
 	status = "okay";
+};
+
+&usb3_dwc {
+	phys = <&usb3_hs_phy>;
+	phy-names = "usb2-phy";
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wrtq-329acn.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wrtq-329acn.dts
@@ -69,14 +69,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -282,11 +274,19 @@
 	status = "okay";
 };
 
+&usb2 {
+	status = "okay";
+};
+
 &usb3_hs_phy {
 	status = "okay";
 };
 
 &usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3 {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-cm520-79f.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-cm520-79f.dts
@@ -54,39 +54,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-
-			dwc3@6000000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				usb2_port1: port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				usb3_port1: port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-
-				usb3_port2: port@2 {
-					reg = <2>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -344,8 +311,41 @@
 	status = "okay";
 };
 
+&usb3 {
+	status = "okay";
+};
+
+&usb3_dwc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	usb3_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+
+	usb3_port2: port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
+	};
+};
+
 &usb2_hs_phy {
 	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+
+	usb@6000000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		usb2_port1: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
+	};
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac.dtsi
@@ -202,20 +202,20 @@
 
 &usb3 {
 	status = "okay";
+};
 
-	dwc3@8a00000 {
-		#address-cells = <1>;
-		#size-cells = <0>;
+&usb3_dwc {
+	#address-cells = <1>;
+	#size-cells = <0>;
 
-		usb3_port1: port@1 {
-			reg = <1>;
-			#trigger-source-cells = <0>;
-		};
+	usb3_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
 
-		usb3_port2: port@2 {
-			reg = <2>;
-			#trigger-source-cells = <0>;
-		};
+	usb3_port2: port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
 	};
 };
 
@@ -230,7 +230,7 @@
 &usb2 {
 	status = "okay";
 
-	dwc3@6000000 {
+	usb@6000000 {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
@@ -54,10 +54,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb3@8af8800 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -263,6 +259,10 @@
 };
 
 &usb3_hs_phy {
+	status = "okay";
+};
+
+&usb3 {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-le1.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-le1.dts
@@ -269,7 +269,7 @@
 &usb2 {
 	status = "okay";
 
-	dwc3@6000000 {
+	usb@6000000 {
 		#address-cells = <1>;
 		#size-cells = <0>;
 
@@ -286,20 +286,20 @@
 
 &usb3 {
 	status = "okay";
+};
 
-	dwc3@8a00000 {
-		#address-cells = <1>;
-		#size-cells = <0>;
+&usb3_dwc {
+	#address-cells = <1>;
+	#size-cells = <0>;
 
-		usb3_port1: port@1 {
-			reg = <1>;
-			#trigger-source-cells = <0>;
-		};
+	usb3_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
 
-		usb3_port2: port@2 {
-			reg = <2>;
-			#trigger-source-cells = <0>;
-		};
+	usb3_port2: port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
 	};
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
@@ -45,10 +45,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -230,6 +226,10 @@
 
 &usb2_hs_phy {
 	/* Bluetooth module attached via USB */
+	status = "okay";
+};
+
+&usb2 {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
@@ -135,14 +135,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -449,11 +441,19 @@
 	status = "okay";
 };
 
+&usb2 {
+	status = "okay";
+};
+
 &usb3_ss_phy {
 	status = "okay";
 };
 
 &usb3_hs_phy {
+	status = "okay";
+};
+
+&usb3 {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
@@ -118,14 +118,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -423,11 +415,19 @@
 	status = "okay";
 };
 
+&usb2 {
+	status = "okay";
+};
+
 &usb3_ss_phy {
 	status = "okay";
 };
 
 &usb3_hs_phy {
+	status = "okay";
+};
+
+&usb3 {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf286d.dts
@@ -111,14 +111,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -430,11 +422,19 @@
 	status = "okay";
 };
 
+&usb2 {
+	status = "okay";
+};
+
 &usb3_ss_phy {
 	status = "okay";
 };
 
 &usb3_hs_phy {
+	status = "okay";
+};
+
+&usb3 {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-ncp-hg100-cellular.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-ncp-hg100-cellular.dts
@@ -582,15 +582,15 @@
 
 	pinctrl-0 = <&usb3_pins>, <&lte_pins>;
 	pinctrl-names = "default";
+};
 
-	dwc3@8a00000 {
-		#address-cells = <1>;
-		#size-cells = <0>;
+&usb3_dwc {
+	#address-cells = <1>;
+	#size-cells = <0>;
 
-		device@1 {
-			compatible = "usb1bc7,1900";
-			reg = <1>;
-		};
+	device@1 {
+		compatible = "usb1bc7,1900";
+		reg = <1>;
 	};
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-oap100.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-oap100.dts
@@ -53,39 +53,6 @@
 			status = "okay";
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-
-			dwc3@6000000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				usb2_port1: port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				usb3_port1: port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-
-				usb3_port2: port@2 {
-					reg = <2>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -337,6 +304,40 @@
 	status = "okay";
 };
 
+&usb3 {
+	status = "okay";
+};
+
+&usb3_dwc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	usb3_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+
+	usb3_port2: port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+
 &usb2_hs_phy {
 	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+
+	usb@6000000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		usb2_port1: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
+	};
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
@@ -53,14 +53,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -364,7 +356,15 @@
 	status = "okay";
 };
 
+&usb3 {
+	status = "okay";
+};
+
 &usb2_hs_phy {
+	status = "okay";
+};
+
+&usb2 {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rbr50.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rbr50.dts
@@ -9,22 +9,20 @@
 	chosen {
 		bootargs = "root=/dev/mmcblk0p20 blkdevparts=mmcblk0:512K@17K(0:SBL1)ro,512K(0:BOOTCONFIG)ro,512K(0:QSEE)ro,512K(0:QSEE_ALT)ro,256K(0:CDT)ro,256K(0:CDT_ALT)ro,256K(0:DDRPARAMS)ro,256K(0:APPSBLENV)ro,1M(0:APPSBL)ro,1M(0:APPSBL_ALT)ro,256K(0:ART)ro,256K(ARTMTD)ro,2M(language)ro,256K(config)ro,256K(pot)ro,256K(traffic_meter)ro,256K(pot_bak)ro,256K(traffic_meter.bak)ro,3840K(kernel),31488K(rootfs),35328K@9233K(firmware),256K(mtdoops)ro,1457651200(reserved)ro,-(unallocated) rootfstype=squashfs,ext4 rootwait";
 	};
-
-	soc {
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-		};
-	};
 };
 
 &usb3_hs_phy {
 	status = "okay";
 };
 
+&usb3 {
+	status = "okay";
+};
+
 &usb2_hs_phy {
+	status = "okay";
+};
+
+&usb2 {
 	status = "okay";
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rbs50.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rbs50.dts
@@ -9,22 +9,20 @@
 	chosen {
 		bootargs = "root=/dev/mmcblk0p20 blkdevparts=mmcblk0:512K@17K(0:SBL1)ro,512K(0:BOOTCONFIG)ro,512K(0:QSEE)ro,512K(0:QSEE_ALT)ro,256K(0:CDT)ro,256K(0:CDT_ALT)ro,256K(0:DDRPARAMS)ro,256K(0:APPSBLENV)ro,1M(0:APPSBL)ro,1M(0:APPSBL_ALT)ro,256K(0:ART)ro,256K(ARTMTD)ro,2M(language)ro,256K(config)ro,256K(pot)ro,256K(traffic_meter)ro,256K(pot_bak)ro,256K(traffic_meter.bak)ro,3840K(kernel),31488K(rootfs),35328K@9233K(firmware),256K(mtdoops)ro,1457651200(reserved)ro,-(unallocated) rootfstype=squashfs,ext4 rootwait";
 	};
-
-	soc {
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-		};
-	};
 };
 
 &usb3_hs_phy {
 	status = "okay";
 };
 
+&usb3 {
+	status = "okay";
+};
+
 &usb2_hs_phy {
+	status = "okay";
+};
+
+&usb2 {
 	status = "okay";
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
@@ -55,25 +55,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				usb3_port1: port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-
-				usb3_port2: port@2 {
-					reg = <2>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -267,6 +248,25 @@
 
 &usb3_hs_phy {
 	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb3_dwc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	usb3_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+
+	usb3_port2: port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
+	};
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
@@ -172,14 +172,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -358,11 +350,19 @@
 	status = "okay";
 };
 
+&usb2 {
+	status = "okay";
+};
+
 &usb3_ss_phy {
 	status = "okay";
 };
 
 &usb3_hs_phy {
+	status = "okay";
+};
+
+&usb3 {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-u4019.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-u4019.dtsi
@@ -46,39 +46,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-
-			dwc3@6000000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-
-				port@2 {
-					reg = <2>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
 		watchdog@b017000 {
 			status = "okay";
 		};
@@ -199,8 +166,42 @@
 	status = "okay";
 };
 
+&usb3 {
+	status = "okay";
+};
+
+&usb3_dwc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	usb3_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+
+	usb3_port2: port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+
 &usb2_hs_phy {
 	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+
+	usb@6000000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		usb2_port1: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
+	};
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
@@ -300,26 +300,6 @@
 			status = "okay";
 		};
 
-		usb3_ss_phy: ssphy@9a000 {
-			status = "okay";
-		};
-
-		usb3_hs_phy: hsphy@a6000 {
-			status = "okay";
-		};
-
-		usb3: usb3@8af8800 {
-			status = "okay";
-		};
-
-		usb2_hs_phy: hsphy@a8000 {
-			status = "okay";
-		};
-
-		usb2: usb2@60f8800 {
-			status = "okay";
-		};
-
 		cryptobam: dma@8e04000 {
 			status = "okay";
 		};
@@ -352,6 +332,26 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
 };
 
 &nand {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wtr-m2133hp.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wtr-m2133hp.dts
@@ -72,10 +72,6 @@
 		watchdog@b017000 {
 			status = "okay";
 		};
-
-		usb3@8af8800 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -468,5 +464,9 @@
 };
 
 &usb3_hs_phy {
+	status = "okay";
+};
+
+&usb3 {
 	status = "okay";
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-x1pro.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-x1pro.dtsi
@@ -56,39 +56,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-
-			dwc3@6000000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-
-				port@2 {
-					reg = <2>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
 		watchdog@b017000 {
 			status = "okay";
 		};
@@ -201,8 +168,41 @@
 	status = "okay";
 };
 
+&usb3 {
+	status = "okay";
+};
+
+&usb3_dwc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+
+	port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
+	};
+};
+
 &usb2_hs_phy {
 	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+
+	usb@6000000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
+	};
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
@@ -59,39 +59,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-
-			dwc3@6000000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				usb2_port1: port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-
-			dwc3@8a00000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				usb3_port1: port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-
-				usb3_port2: port@2 {
-					reg = <2>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -289,12 +256,45 @@
 	status = "okay";
 };
 
+&usb2 {
+	status = "okay";
+
+	usb@6000000 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		usb2_port1: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
+	};
+};
+
 &usb3_hs_phy {
 	status = "okay";
 };
 
 &usb3_ss_phy {
 	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb3_dwc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	usb3_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+
+	usb3_port2: port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
+	};
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-b1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-b1300.dts
@@ -72,14 +72,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -275,11 +267,19 @@
 	status = "okay";
 };
 
+&usb2 {
+	status = "okay";
+};
+
 &usb3_hs_phy {
 	status = "okay";
 };
 
 &usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3 {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-s1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-s1300.dts
@@ -57,14 +57,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-		};
-
-		usb3@8af8800 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -340,11 +332,19 @@
 	status = "okay";
 };
 
+&usb2 {
+	status = "okay";
+};
+
 &usb3_hs_phy {
 	status = "okay";
 };
 
 &usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3 {
 	status = "okay";
 };
 


### PR DESCRIPTION
Commit 6136ebabc5cb ("ipq40xx: 6.6: fix DTS to use reference for usb node") fixed only some of the reference to USB node but many others were still using the old broken usb3/usb2. Fix every reference to those node and move them on using the tag name.

Fixes: 6136ebabc5cb ("ipq40xx: 6.6: fix DTS to use reference for usb node")
