### PR TITLE
ramips: samknows whitebox v8: set wifi frequency

### DIFF
--- a/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
+++ b/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
@@ -129,6 +129,7 @@
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
 


### PR DESCRIPTION
Set the 2.4GHz frequency for WiFi.
Fixes: #15391

