### PR TITLE
[23.05] ramips: samknows whitebox v8: set wifi frequency

### DIFF
--- a/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
+++ b/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
@@ -102,6 +102,7 @@
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
 


### PR DESCRIPTION
Set the 2.4GHz frequency for WiFi.
Fixes: #15391
