### PR TITLE
mediatek: fix broken PCIe caused by update to 6.6.30

### DIFF
--- a/target/linux/mediatek/patches-6.6/710-pci-pcie-mediatek-add-support-for-coherent-DMA.patch
+++ b/target/linux/mediatek/patches-6.6/710-pci-pcie-mediatek-add-support-for-coherent-DMA.patch
@@ -30,6 +30,15 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  		#interrupt-cells = <1>;
  		interrupt-map-mask = <0 0 0 7>;
+@@ -937,7 +943,7 @@
+ 	};
+ 
+ 	hifsys: clock-controller@1af00000 {
+-		compatible = "mediatek,mt7622-hifsys";
++		compatible = "mediatek,mt7622-hifsys", "syscon";
+ 		reg = <0 0x1af00000 0 0x70>;
+ 		#clock-cells = <1>;
+ 	};
 --- a/drivers/pci/controller/pcie-mediatek.c
 +++ b/drivers/pci/controller/pcie-mediatek.c
 @@ -20,6 +20,7 @@


### PR DESCRIPTION
The patch "710-pci-pcie-mediatek-add-support-for-coherent-DMA.patch" makes use of "syscon_regmap_lookup_by_phandle" which requires that "syscon" be in the compatible list.

Without this patch, PCIe probe will fail with the following error:

```
[    1.287467] mtk-pcie 1a143000.pcie: host bridge /pcie@1a143000 ranges:
[    1.294019] mtk-pcie 1a143000.pcie: Parsing ranges property...
[    1.299901] mtk-pcie 1a143000.pcie:      MEM 0x0020000000..0x0027ffffff -> 0x0020000000
[    1.307954] mtk-pcie 1a143000.pcie: missing hifsys node
[    1.313185] mtk-pcie: probe of 1a143000.pcie failed with error -22
```

Fixes: 4c6e9a9 ("kernel: bump 6.6 to 6.6.30")