### PR TITLE
kselftests-bpf: update for kernel 6.6

### DIFF
--- a/package/devel/kselftests-bpf/Makefile
+++ b/package/devel/kselftests-bpf/Makefile
@@ -13,7 +13,7 @@ PKG_VERSION:=$(LINUX_VERSION)
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Tony Ambardar <itugrok@yahoo.com>
 
-PKG_BUILD_FLAGS:=gc-sections lto
+PKG_BUILD_FLAGS:=no-lto
 PKG_BUILD_PARALLEL:=1
 PKG_FLAGS:=nonshared
 
@@ -23,8 +23,9 @@ include $(INCLUDE_DIR)/nls.mk
 define Package/kselftests-bpf
   SECTION:=devel
   CATEGORY:=Development
-  DEPENDS:= +libelf +zlib +libpthread +librt @!IN_SDK \
-	    @KERNEL_DEBUG_FS @KERNEL_DEBUG_INFO_BTF @KERNEL_BPF_EVENTS
+  DEPENDS:= \
+	+libelf +zlib +libpthread +librt @!IN_SDK \
+	@KERNEL_DEBUG_FS @KERNEL_DEBUG_INFO_BTF @KERNEL_BPF_EVENTS
   TITLE:=Linux Kernel Selftests (BPF)
   URL:=http://www.kernel.org
 endef
@@ -33,31 +34,40 @@ define Package/kselftests-bpf/description
   kselftests-bpf is the Linux kernel BPF test suite
 endef
 
-TEST_TARGET = test_verifier
+EXE_TARGETS = test_verifier
+
+MOD_TARGETS = $(if $(call kernel_patchver_ge,6.4),bpf_testmod.ko)
 
 MAKE_PATH:=tools/testing/selftests/bpf
 
 MAKE_VARS = \
 	ARCH="$(LINUX_KARCH)" \
 	CROSS_COMPILE="$(TARGET_CROSS)" \
-	SAN_CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS)" \
+	EXTRA_CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS)" \
 	LDLIBS="$(TARGET_LDFLAGS)" \
 	TOOLCHAIN_INCLUDE="$(TOOLCHAIN_INC_DIRS)" \
-	VMLINUX_BTF="$(LINUX_DIR)/vmlinux"
+	KBUILD_OUTPUT="$(LINUX_DIR)"
 
 MAKE_FLAGS = \
 	$(if $(findstring c,$(OPENWRT_VERBOSE)),V=1,V='') \
-	O=$(PKG_BUILD_DIR)
+	OUTPUT=$(PKG_BUILD_DIR)
 
 define Build/Compile
 	+$(MAKE_VARS) \
 	$(MAKE) $(PKG_JOBS) -C $(LINUX_DIR)/$(MAKE_PATH) \
-		$(MAKE_FLAGS) $(TEST_TARGET) ;
+		$(MAKE_FLAGS) $(EXE_TARGETS) $(MOD_TARGETS) ;
 endef
 
 define Package/kselftests-bpf/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(TEST_TARGET) $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/usr/libexec/$(PKG_NAME)
+	$(foreach tgt,$(MOD_TARGETS), \
+		$(INSTALL_DATA) \
+			$(PKG_BUILD_DIR)/$(tgt) $(1)/usr/libexec/$(PKG_NAME); \
+	)
+	$(foreach tgt,$(EXE_TARGETS), \
+		$(INSTALL_BIN) \
+			$(PKG_BUILD_DIR)/$(tgt) $(1)/usr/libexec/$(PKG_NAME); \
+)
 endef
 
 $(eval $(call BuildPackage,kselftests-bpf))

--- a/target/linux/generic/pending-6.6/360-selftests-bpf-portability-of-unprivileged-tests.patch
+++ b/target/linux/generic/pending-6.6/360-selftests-bpf-portability-of-unprivileged-tests.patch
@@ -1,0 +1,26 @@
+From ecb8f9a7d69698ce20fc6f4d107718d56fa861df Mon Sep 17 00:00:00 2001
+From: Tony Ambardar <Tony.Ambardar@gmail.com>
+Date: Sat, 9 Mar 2024 16:44:53 -0800
+Subject: [PATCH] selftests/bpf: Improve portability of unprivileged tests
+
+The addition of general support for unprivileged tests in test_loader.c
+breaks building test_verifier on non-glibc (e.g. musl) systems, due to the
+inclusion of glibc extension '<error.h>' in 'unpriv_helpers.c'. However,
+the header is actually not needed, so remove it to restore building.
+
+Fixes: 1d56ade032a4 ("selftests/bpf: Unprivileged tests for test_loader.c")
+Signed-off-by: Tony Ambardar <Tony.Ambardar@gmail.com>
+---
+ tools/testing/selftests/bpf/unpriv_helpers.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+--- a/tools/testing/selftests/bpf/unpriv_helpers.c
++++ b/tools/testing/selftests/bpf/unpriv_helpers.c
+@@ -2,7 +2,6 @@
+ 
+ #include <stdbool.h>
+ #include <stdlib.h>
+-#include <error.h>
+ #include <stdio.h>
+ 
+ #include "unpriv_helpers.h"


### PR DESCRIPTION
**Maintainer**: me

**Description**:
Update to fix building on kernel 6.6 by enabling build of multiple test programs and related kernel modules, with initial support for the bpf_testmod.ko module required since kernel 6.4. Explicitly disable LTO and clean up makefile variables and formatting.

Fix a musl-related build failure by adding a kernel 6.6 patch:
- 360-selftests-bpf-portability-of-unprivileged-tests.patch

**Testing**: Build and run-tested against `openwrt/master`, using `malta/mips64el`, with both kernel 6.1 and 6.6.

**CC**: @hauke 
