### PR TITLE
libbpf: Update to v1.4.1

### DIFF
--- a/package/libs/libbpf/Makefile
+++ b/package/libs/libbpf/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libbpf
-PKG_VERSION:=1.4.0
+PKG_VERSION:=1.4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://github.com/libbpf/libbpf
-PKG_MIRROR_HASH:=4c37636699c604de345937bdbdf8f2e6ce69cbf768a4aa669c32b542e5302de6
+PKG_MIRROR_HASH:=46469f720ed246529e46d84a6444ae1c1a1eaf2a717a5a055c9973bb52159ec3
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=v1.4.0
+PKG_SOURCE_VERSION:=v1.4.1
 PKG_ABI_VERSION:=$(firstword $(subst .,$(space),$(PKG_VERSION)))
 
 PKG_MAINTAINER:=Tony Ambardar <itugrok@yahoo.com>


### PR DESCRIPTION
**Maintainer**: me

**Description**:
Update to the latest upstream release to include recent bugfixes.

Link: https://github.com/libbpf/libbpf/releases/tag/v1.4.1

**Testing**: Build and run-tested against `openwrt/master`, using `malta/mips64el`, with both kernel 6.1 and 6.6.

**CC**: @robimarko @PolynomialDivision 