### PR TITLE
EAP1300 fixes

### DIFF
--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -115,6 +115,7 @@ platform_do_upgrade() {
 	cilab,meshpoint-one |\
 	edgecore,ecw5211 |\
 	edgecore,oap100 |\
+	engenius,eap1300 |\
 	engenius,eap2200 |\
 	glinet,gl-a1300 |\
 	glinet,gl-ap1300 |\

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -447,6 +447,8 @@ define Device/engenius_eap1300
 	$(call Device/FitImage)
 	DEVICE_VENDOR := EnGenius
 	DEVICE_MODEL := EAP1300
+	DEVICE_ALT0_VENDOR := EnGenius
+	DEVICE_ALT0_MODEL := EAP1300EXT
 	DEVICE_DTS_CONFIG := config@4
 	BOARD_NAME := eap1300
 	SOC := qcom-ipq4018


### PR DESCRIPTION
This re-adds the EnGenius EAP1300 to the firmware update script, and adds the EAP1300EXT as an alt model of the EAP1300.

Thanks to @cminyard for finishing the mac address fixes and DSA conversion.