### PR TITLE
tools: mold: update to 2.31.0

### DIFF
--- a/tools/mold/Makefile
+++ b/tools/mold/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mold
-PKG_VERSION:=2.30.0
+PKG_VERSION:=2.31.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL_FILE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/rui314/mold/archive/refs/tags
-PKG_HASH:=6e5178ccafe828fdb4ba0dd841d083ff6004d3cb41e56485143eb64c716345fd
+PKG_HASH:=3dc3af83a5d22a4b29971bfad17261851d426961c665480e2ca294e5c74aa1e5
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
From project's release notes:

mold 2.31.0 is a new release of the high-speed linker. It includes the following new features and bug fixes:

# New features

- mold is now up to 10% faster when linking very large, debug info-enabled executables such as Blender (~1.8 GiB) or Clang (~3.8 GiB), thanks to several improvements we've made to the string merging algorithm. ([53ebcd80](https://github.com/rui314/mold/commit/53ebcd80), [d7143011](https://github.com/rui314/mold/commit/d7143011), [40f6b17e](https://github.com/rui314/mold/commit/40f6b17e), [c9faf3d3](https://github.com/rui314/mold/commit/c9faf3d3))
- `-z start-stop-visibility=hidden` is now supported so that linker-synthesized `__start_<section-name>` and `__stop_<section-name>` symbols can be completely hidden from other ELF modules. Previously, only `-z start-stop-visibility=protected` was supported. ([99a5b154](https://github.com/rui314/mold/commit/99a5b154))
- `-Bsymbolic-non-weak` and `-Bsymbolic-non-weak-functions` options are now supported for compatibility with LLVM lld. Just like lld, these options control which symbols are exported as dynamic symbols. `-Bsymbolic-non-weak` makes the linker to export only weak symbols, whereas `-Bsymbolic-non-weak-functions` makes it to export only weak function symbols. ([7d17aa83](https://github.com/rui314/mold/commit/7d17aa83))

# Bug fixes and compatibility improvements

- Previously, if a linker script contains a newline character in the beginning four bytes of a file, it was not recognized as a linker script by mold. Now, mold allows newlines at the beginning of a file. ([ea054ccc](https://github.com/rui314/mold/commit/ea054ccc))
- Under rare circumstances, the `INPUT` linker script command may have found a different file than GNU ld would. Now, mold's behavior aligns with GNU ld's. ([163975d8](https://github.com/rui314/mold/commit/163975d8))
- Previously, the `--repro` option produced corrupted tar files. Now the bug has been fixed. ([32c4a09d](https://github.com/rui314/mold/commit/32c4a09d))
- mold generally guarantees that its output is reproducible, meaning that if you run the linker with the exact same command line options and input files, the output is guaranteed to be bit-for-bit identical to the previous outputs. However, under rare circumstances, it might produce different output due to a bug. It's reported that this nondeterminism caused random crashes for some programs (https://github.com/rui314/mold/issues/1247). This bug has been fixed. ([6463a7c4](https://github.com/rui314/mold/commit/6463a7c4))
- mold no longer sets the address of the `.text` section as the entry point address if `--entry` option is not given, just like LLVM lld. ([020b1a78](https://github.com/rui314/mold/commit/020b1a78))
- [RISC-V] `__global_pointer$` symbol is now exported from executables as required by the processor-specific ABI. ([3df7c8e8](https://github.com/rui314/mold/commit/3df7c8e8))
- [ARM32] `--long-plt` option is now recognized as known option by mold. mold ignores the option, though, because the PLTs generated by our linker is always long. ([d432e987](https://github.com/rui314/mold/commit/d432e987))
