### PR TITLE
[22.03] Add EnGenius EAP1300EXT support

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -443,6 +443,8 @@ define Device/engenius_eap1300
 	$(call Device/FitImage)
 	DEVICE_VENDOR := EnGenius
 	DEVICE_MODEL := EAP1300
+	DEVICE_ALT0_VENDOR := EnGenius
+	DEVICE_ALT0_MODEL := EAP1300EXT
 	DEVICE_DTS_CONFIG := config@4
 	BOARD_NAME := eap1300
 	SOC := qcom-ipq4018


### PR DESCRIPTION
The EnGenius EAP1300 and EAP1300EXT use identical boards and firmware (as flashed) from the vendor.

As with the EAP1300, the EAP1300EXT requires a specific firmware version to flash OpenWRT. Unfortunately, the required firmware is truncated on the vendor's website.

A working file can be created as follows:

```
curl \
https://www.engeniustech.com/wp_firmware/eap1300-all-v3.5.3.5_c1.9.04.bin \
| perl -pe 's/\x09EAP1300_A/\x0cEAP1300EXT_A/' \
> eap1300ext-all-v3.5.3.5_c1.9.04.bin
```

The file should have sha256:
`58a1197a426139a12b03fd432334e677124cbe3384349bd7337f2ee71f1dcfd4`.

Please see commit 2b4ac79 for further
details.

The vendor firmware must be decrypted before it can be flashed from OpenWRT. A tool able to do that is available from:

https://github.com/ryancdotorg/enfringement/blob/main/decrypt.py