### PR TITLE
mediatek: bpi-r2/r4 fixes

### DIFF
--- a/target/linux/mediatek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr.sh
+++ b/target/linux/mediatek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr.sh
@@ -11,7 +11,8 @@ unielec,u7623-02)
 	;;
 bananapi,bpi-r3|\
 bananapi,bpi-r3-mini|\
-bananapi,bpi-4)
+bananapi,bpi-r4|\
+bananapi,bpi-r4-poe)
 	[ -z "$(fw_printenv -n ethaddr 2>/dev/null)" ] &&
 		fw_setenv ethaddr "$(cat /sys/class/net/eth0/address)"
 	[ -z "$(fw_printenv -n eth1addr 2>/dev/null)" ] &&

--- a/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
+++ b/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
@@ -28,7 +28,7 @@
 
 	chosen {
 		stdout-path = &uart0;
-		bootargs = "console=ttyS0,115200n1 loglevel=8 pci=pcie_bus_perf ubi.block=0,fit root=/dev/fit0";
+		bootargs = "console=ttyS0,115200n1 loglevel=8 pci=pcie_bus_perf ubi.block=0,fit root=/dev/fit0 rootwait";
 		rootdisk-spim-nand = <&ubi_rootfs>;
 	};
 

--- a/target/linux/mediatek/patches-6.6/164-dts-mt7623-bpi-r2-rootdisk-for-fitblk.patch
+++ b/target/linux/mediatek/patches-6.6/164-dts-mt7623-bpi-r2-rootdisk-for-fitblk.patch
@@ -5,7 +5,7 @@
  	chosen {
  		stdout-path = "serial2:115200n8";
 -		bootargs = "earlycon=uart8250,mmio32,0x11004000 console=ttyS2,115200n8 console=tty1";
-+		bootargs = "root=/dev/fit0 earlycon=uart8250,mmio32,0x11004000 console=ttyS2,115200n8 console=tty1";
++		bootargs = "root=/dev/fit0 rootwait earlycon=uart8250,mmio32,0x11004000 console=ttyS2,115200n8 console=tty1";
 +		rootdisk-emmc = <&emmc_rootdisk>;
 +		rootdisk-sd = <&sd_rootdisk>;
  	};


### PR DESCRIPTION
@dangowrt 
This fixes the missing "rootwait" param for bpi-r2 and bpi-r4 as well as a typo in the uci-default script for mac address storage.