### PR TITLE
[23.05] ipq806x: Meraki MR52: swap lan leds

### DIFF
--- a/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8068-mr52.dts
+++ b/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8068-mr52.dts
@@ -44,13 +44,13 @@
 			gpios = <&qcom_pinmux 19 GPIO_ACTIVE_HIGH>;
 		};
 
-		lan2_green {
-			label = "green:lan2";
+		lan1_green {
+			label = "green:lan1";
 			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
 		};
 
-		lan1_green {
-			label = "green:lan1";
+		lan2_green {
+			label = "green:lan2";
 			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_HIGH>;
 		};
 
@@ -59,13 +59,13 @@
 			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_LOW>;
 		};
 
-		lan2_orange {
-			label = "orange:lan2";
+		lan1_orange {
+			label = "orange:lan1";
 			gpios = <&qcom_pinmux 60 GPIO_ACTIVE_HIGH>;
 		};
 
-		lan1_orange {
-			label = "orange:lan1";
+		lan2_orange {
+			label = "orange:lan2";
 			gpios = <&qcom_pinmux 62 GPIO_ACTIVE_HIGH>;
 		};
 	};


### PR DESCRIPTION
LAN Leds on Meraki MR52 are wrong and needs to be swapped to actually reflect real ports (lan1<->lan2).
Fixes: #15388
