### PR TITLE
ipq40xx: use existing upstream node labels

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-a42.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-a42.dts
@@ -39,10 +39,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -100,6 +96,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-a42.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-a42.dts
@@ -14,10 +14,6 @@
 	compatible = "openmesh,a42";
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		tcsr@194b000 {
 			/* select hostmode */
 			compatible = "qcom,tcsr";
@@ -100,6 +96,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-a42.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-a42.dts
@@ -47,10 +47,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -101,6 +97,10 @@
 		hw_margin_ms = <60000>;
 		always-running;
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ap120c-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ap120c-ac.dts
@@ -58,13 +58,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-		};
-
 		counter@4a1000 {
 			compatible = "qcom,qca-gcnt";
 			reg = <0x4a1000 0x4>;
@@ -325,6 +318,13 @@
 &usb3_dwc {
 	phys = <&usb3_hs_phy>;
 	phy-names = "usb2-phy";
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ap120c-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ap120c-ac.dts
@@ -101,11 +101,11 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ap120c-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ap120c-ac.dts
@@ -93,10 +93,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 };
 
@@ -105,6 +101,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ap120c-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ap120c-ac.dts
@@ -58,10 +58,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 
@@ -105,6 +101,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cap-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cap-ac.dts
@@ -50,10 +50,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -115,6 +111,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cap-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cap-ac.dts
@@ -58,10 +58,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -116,6 +112,10 @@
 			gpios = <&ethphy3 1 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cap-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cap-ac.dts
@@ -28,10 +28,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		counter@4a1000 {
 			compatible = "qcom,qca-gcnt";
 			reg = <0x4a1000 0x4>;
@@ -115,6 +111,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cs-w3-wd1200g-eup.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cs-w3-wd1200g-eup.dts
@@ -18,14 +18,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-			reset-gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
-			reset-delay-us = <5000>;
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -243,6 +235,14 @@
 
 &cryptobam {
 	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <5000>;
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cs-w3-wd1200g-eup.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cs-w3-wd1200g-eup.dts
@@ -57,10 +57,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -94,6 +90,10 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cs-w3-wd1200g-eup.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cs-w3-wd1200g-eup.dts
@@ -49,10 +49,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -93,6 +89,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cs-w3-wd1200g-eup.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cs-w3-wd1200g-eup.dts
@@ -18,10 +18,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -93,6 +89,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-dap-2610.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-dap-2610.dts
@@ -36,10 +36,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		rng@22000 {
-			status = "okay";
-		};
-
 		crypto@8e3a000 {
 			status = "okay";
 		};
@@ -73,6 +69,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-dap-2610.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-dap-2610.dts
@@ -43,10 +43,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -74,6 +70,10 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp1_spi1 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-dap-2610.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-dap-2610.dts
@@ -35,10 +35,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -73,6 +69,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ea6350v3.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ea6350v3.dts
@@ -18,10 +18,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -83,6 +79,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ea6350v3.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ea6350v3.dts
@@ -53,10 +53,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -84,6 +80,10 @@
 			gpios = <&tlmm 2 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp1_uart1 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ea6350v3.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ea6350v3.dts
@@ -18,10 +18,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -93,6 +89,10 @@
 };
 
 &cryptobam {
+	status = "okay";
+};
+
+&mdio {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ea6350v3.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ea6350v3.dts
@@ -45,10 +45,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -83,6 +79,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-eap1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-eap1300.dts
@@ -11,10 +11,6 @@
 	compatible = "engenius,eap1300";
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -92,6 +88,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-eap1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-eap1300.dts
@@ -32,10 +32,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -92,6 +88,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-eap1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-eap1300.dts
@@ -11,10 +11,6 @@
 	compatible = "engenius,eap1300";
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -227,6 +223,10 @@
 };
 
 &switch {
+	status = "okay";
+};
+
+&mdio {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-eap1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-eap1300.dts
@@ -40,10 +40,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -93,6 +89,10 @@
 			gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ecw5211.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ecw5211.dts
@@ -56,10 +56,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		counter@4a1000 {
 			compatible = "qcom,qca-gcnt";
 			reg = <0x4a1000 0x4>;
@@ -96,6 +92,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ecw5211.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ecw5211.dts
@@ -84,10 +84,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 };
 
@@ -96,6 +92,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ecw5211.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ecw5211.dts
@@ -92,11 +92,11 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emd1.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emd1.dts
@@ -18,10 +18,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -198,6 +194,10 @@
 };
 
 &cryptobam {
+	status = "okay";
+};
+
+&mdio {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emd1.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emd1.dts
@@ -18,10 +18,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -88,6 +84,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emd1.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emd1.dts
@@ -47,10 +47,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -89,6 +85,10 @@
 			gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emd1.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emd1.dts
@@ -39,10 +39,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -88,6 +84,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emr3500.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emr3500.dts
@@ -11,10 +11,6 @@
 	compatible = "engenius,emr3500";
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -199,6 +195,10 @@
 };
 
 &usb2_hs_phy {
+	status = "okay";
+};
+
+&mdio {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emr3500.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emr3500.dts
@@ -40,10 +40,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -87,6 +83,10 @@
 			gpios = <&tlmm 1 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emr3500.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emr3500.dts
@@ -11,10 +11,6 @@
 	compatible = "engenius,emr3500";
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -86,6 +82,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emr3500.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-emr3500.dts
@@ -32,10 +32,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -86,6 +82,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ens620ext.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ens620ext.dts
@@ -41,10 +41,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		crypto@8e3a000 {
-			status = "okay";
-		};
-
 		/*
 		 * Disable the broken restart as a workaround for the buggy
 		 * 3.0.0/3.0.1 U-boots that ship with the device.
@@ -101,6 +97,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ens620ext.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ens620ext.dts
@@ -49,10 +49,6 @@
 			status = "okay";
 		};
 
-		watchdog@b017000 {
-			status = "okay";
-		};
-
 		/*
 		 * Disable the broken restart as a workaround for the buggy
 		 * 3.0.0/3.0.1 U-boots that ship with the device.
@@ -102,6 +98,10 @@
 			gpios = <&tlmm 0 GPIO_ACTIVE_LOW>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &cryptobam {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ens620ext.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ens620ext.dts
@@ -23,10 +23,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -101,6 +97,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ex61x0v2.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ex61x0v2.dtsi
@@ -47,10 +47,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	aliases {
@@ -154,6 +150,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ex61x0v2.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ex61x0v2.dtsi
@@ -26,10 +26,6 @@
 	compatible = "netgear,ex61x0v2";
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -332,6 +328,10 @@
 	status = "okay";
 	nvmem-cell-names = "pre-calibration", "mac-address";
 	nvmem-cells = <&precal_art_5000>, <&macaddr_dnidata_c>;
+};
+
+&mdio {
+	status = "okay";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ex61x0v2.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ex61x0v2.dtsi
@@ -26,10 +26,6 @@
 	compatible = "netgear,ex61x0v2";
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -154,6 +150,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ex61x0v2.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ex61x0v2.dtsi
@@ -55,10 +55,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	aliases {
@@ -155,6 +151,10 @@
 			gpios = <&tlmm 1 GPIO_ACTIVE_LOW>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-fritzbox-4040.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-fritzbox-4040.dts
@@ -54,10 +54,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -114,6 +110,10 @@
 			gpios = <&ethphy3 1 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-fritzbox-4040.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-fritzbox-4040.dts
@@ -46,10 +46,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -113,6 +109,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-fritzbox-4040.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-fritzbox-4040.dts
@@ -19,10 +19,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -241,6 +237,10 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&mdio {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-fritzbox-4040.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-fritzbox-4040.dts
@@ -19,10 +19,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -113,6 +109,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-ap1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-ap1300.dts
@@ -64,10 +64,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -96,6 +92,10 @@
 			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-ap1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-ap1300.dts
@@ -56,10 +56,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -99,6 +95,10 @@
 };
 
 &blsp_dma {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-ap1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-ap1300.dts
@@ -27,10 +27,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -266,6 +262,10 @@
 };
 
 &usb3 {
+	status = "okay";
+};
+
+&mdio {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-ap1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-ap1300.dts
@@ -27,10 +27,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -95,6 +91,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-hap-ac2.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-hap-ac2.dts
@@ -58,10 +58,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -103,6 +99,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-hap-ac2.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-hap-ac2.dts
@@ -66,10 +66,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -104,6 +100,10 @@
 			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-hap-ac2.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-hap-ac2.dts
@@ -28,10 +28,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		counter@4a1000 {
 			compatible = "qcom,qca-gcnt";
 			reg = <0x4a1000 0x4>;
@@ -103,6 +99,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-jalapeno.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-jalapeno.dtsi
@@ -12,10 +12,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 
@@ -61,6 +57,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-jalapeno.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-jalapeno.dtsi
@@ -49,10 +49,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 };
 
@@ -61,6 +57,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-jalapeno.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-jalapeno.dtsi
@@ -57,11 +57,11 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-jalapeno.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-jalapeno.dtsi
@@ -12,13 +12,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-		};
-
 		counter@4a1000 {
 			compatible = "qcom,qca-gcnt";
 			reg = <0x4a1000 0x4>;
@@ -224,6 +217,12 @@
 
 &cryptobam {
 	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-magic-2-wifi-next.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-magic-2-wifi-next.dts
@@ -15,10 +15,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -85,6 +81,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-magic-2-wifi-next.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-magic-2-wifi-next.dts
@@ -23,10 +23,6 @@
 			reset-delay-us = <2000>;
 		};
 
-		crypto@8e3a000 {
-			status = "okay";
-		};
-
 		gpio_export {
 			compatible = "gpio-export";
 			#size-cells = <0>;
@@ -85,6 +81,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-magic-2-wifi-next.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-magic-2-wifi-next.dts
@@ -15,14 +15,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-			reset-gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
-			reset-delay-us = <2000>;
-		};
-
 		gpio_export {
 			compatible = "gpio-export";
 			#size-cells = <0>;
@@ -232,6 +224,14 @@
 			};
 		};
 	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <2000>;
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-magic-2-wifi-next.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-magic-2-wifi-next.dts
@@ -31,10 +31,6 @@
 			status = "okay";
 		};
 
-		watchdog@b017000 {
-			status = "okay";
-		};
-
 		gpio_export {
 			compatible = "gpio-export";
 			#size-cells = <0>;
@@ -86,6 +82,10 @@
 			default-state = "keep";
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-mf287_common.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-mf287_common.dtsi
@@ -59,10 +59,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -92,6 +88,10 @@
 };
 
 &mdio {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-nbg6617.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-nbg6617.dts
@@ -28,10 +28,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -126,6 +122,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-nbg6617.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-nbg6617.dts
@@ -55,10 +55,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -126,6 +122,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-nbg6617.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-nbg6617.dts
@@ -28,10 +28,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -270,6 +266,10 @@
 };
 
 &blsp_dma {
+	status = "okay";
+};
+
+&mdio {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-nbg6617.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-nbg6617.dts
@@ -63,10 +63,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -127,6 +123,10 @@
 			gpios = <&tlmm 1 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-pa1200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-pa1200.dts
@@ -47,10 +47,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -93,6 +89,10 @@
 		};
 	};
 
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-pa1200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-pa1200.dts
@@ -14,10 +14,6 @@
 	compatible = "plasmacloud,pa1200";
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		tcsr@194b000 {
 			/* select hostmode */
 			compatible = "qcom,tcsr";
@@ -92,6 +88,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-pa1200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-pa1200.dts
@@ -39,10 +39,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -92,6 +88,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rt-ac58u.dts
@@ -50,10 +50,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -129,6 +125,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rt-ac58u.dts
@@ -58,10 +58,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -130,6 +126,10 @@
 			gpios = <&tlmm 2 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &cryptobam {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rt-ac58u.dts
@@ -23,10 +23,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -289,6 +285,10 @@
 		reg = <2>;
 		#trigger-source-cells = <0>;
 	};
+};
+
+&mdio {
+	status = "okay";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rt-ac58u.dts
@@ -23,10 +23,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -129,6 +125,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-sxtsq-5-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-sxtsq-5-ac.dts
@@ -54,10 +54,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -118,6 +114,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-sxtsq-5-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-sxtsq-5-ac.dts
@@ -28,10 +28,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -118,6 +114,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-sxtsq-5-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-sxtsq-5-ac.dts
@@ -28,10 +28,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		counter@4a1000 {
 			compatible = "qcom,qca-gcnt";
 			reg = <0x4a1000 0x4>;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-sxtsq-5-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-sxtsq-5-ac.dts
@@ -62,10 +62,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -119,6 +115,10 @@
 			gpios = <&tlmm 5 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wac510.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wac510.dts
@@ -54,10 +54,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -147,6 +143,10 @@
 			gpios = <&ssr 0 GPIO_ACTIVE_LOW>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &qpic_bam {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wac510.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wac510.dts
@@ -46,10 +46,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -146,6 +142,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wac510.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wac510.dts
@@ -24,10 +24,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		counter@4a1000 {
 			compatible = "qcom,qca-gcnt";
 			reg = <0x4a1000 0x4>;
@@ -146,6 +142,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wre6606.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wre6606.dts
@@ -66,10 +66,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -117,6 +113,10 @@
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wre6606.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wre6606.dts
@@ -58,10 +58,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -116,6 +112,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wre6606.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wre6606.dts
@@ -37,10 +37,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -116,6 +112,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wre6606.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wre6606.dts
@@ -37,10 +37,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -241,6 +237,10 @@
 };
 
 &cryptobam {
+	status = "okay";
+};
+
+&mdio {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wrtq-329acn.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wrtq-329acn.dts
@@ -41,10 +41,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -76,6 +72,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wrtq-329acn.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wrtq-329acn.dts
@@ -72,11 +72,11 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wrtq-329acn.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wrtq-329acn.dts
@@ -64,10 +64,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 };
 
@@ -76,6 +72,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
@@ -39,10 +39,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -100,6 +96,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
@@ -14,10 +14,6 @@
 	compatible = "openmesh,a62";
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		tcsr@194b000 {
 			/* select hostmode */
 			compatible = "qcom,tcsr";
@@ -100,6 +96,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
@@ -47,10 +47,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -101,6 +97,10 @@
 		hw_margin_ms = <60000>;
 		always-running;
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-cm520-79f.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-cm520-79f.dts
@@ -49,10 +49,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	led_spi {
@@ -135,6 +131,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-cm520-79f.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-cm520-79f.dts
@@ -57,10 +57,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	led_spi {
@@ -136,6 +132,10 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-cm520-79f.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-cm520-79f.dts
@@ -18,10 +18,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -135,6 +131,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-cm520-79f.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-cm520-79f.dts
@@ -18,14 +18,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-			reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
-			reset-delay-us = <1000>;
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -346,6 +338,14 @@
 			#trigger-source-cells = <0>;
 		};
 	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <1000>;
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac.dtsi
@@ -21,12 +21,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -242,4 +236,10 @@
 
 &usb2_hs_phy {
 	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac.dtsi
@@ -72,10 +72,6 @@
 			status = "okay";
 		};
 
-		crypto@8e3a000 {
-			status = "okay";
-		};
-
 		leds {
 			compatible = "gpio-leds";
 
@@ -134,6 +130,10 @@
 };
 
 &blsp_dma {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac.dtsi
@@ -53,18 +53,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		serial@78af000 {
-			pinctrl-0 = <&serial_0_pins>;
-			pinctrl-names = "default";
-			status = "okay";
-		};
-
-		serial@78b0000 {
-			pinctrl-0 = <&serial_1_pins>;
-			pinctrl-names = "default";
-			status = "okay";
-		};
-
 		i2c@78b7000 { /* BLSP1 QUP2 */
 			pinctrl-0 = <&i2c_0_pins>;
 			pinctrl-names = "default";
@@ -198,6 +186,18 @@
 			output-high;
 		};
 	};
+};
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp1_uart2 {
+	pinctrl-0 = <&serial_1_pins>;
+	pinctrl-names = "default";
+	status = "okay";
 };
 
 &usb3 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac.dtsi
@@ -53,13 +53,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		i2c@78b7000 { /* BLSP1 QUP2 */
-			pinctrl-0 = <&i2c_0_pins>;
-			pinctrl-names = "default";
-
-			status = "okay";
-		};
-
 		leds {
 			compatible = "gpio-leds";
 
@@ -196,6 +189,12 @@
 
 &blsp1_uart2 {
 	pinctrl-0 = <&serial_1_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp1_i2c3 { /* BLSP1 QUP2 */
+	pinctrl-0 = <&i2c_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac.dtsi
@@ -80,10 +80,6 @@
 			status = "okay";
 		};
 
-		watchdog@b017000 {
-			status = "okay";
-		};
-
 		leds {
 			compatible = "gpio-leds";
 
@@ -131,6 +127,10 @@
 			};
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac.dtsi
@@ -21,10 +21,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -130,6 +126,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
@@ -81,11 +81,11 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
@@ -68,12 +68,6 @@
 			gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-	};
 };
 
 &watchdog {
@@ -273,6 +267,10 @@
 			output-high;
 		};
 	};
+};
+
+&mdio {
+	status = "okay";
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
@@ -73,10 +73,6 @@
 		mdio@90000 {
 			status = "okay";
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 };
 
@@ -85,6 +81,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
@@ -70,10 +70,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -85,6 +81,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
@@ -57,10 +57,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -121,6 +117,10 @@
 			gpios = <&tlmm 45 GPIO_ACTIVE_LOW>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
@@ -22,10 +22,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -267,6 +263,10 @@
 };
 
 &qpic_bam {
+	status = "okay";
+};
+
+&mdio {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
@@ -22,10 +22,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -120,6 +116,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
@@ -49,10 +49,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -120,6 +116,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-1200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-1200.dts
@@ -19,10 +19,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -80,6 +76,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-1200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-1200.dts
@@ -36,10 +36,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	key {
@@ -80,6 +76,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-1200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-1200.dts
@@ -44,10 +44,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	key {
@@ -81,6 +77,10 @@
 			gpios = <&tlmm 49 GPIO_ACTIVE_LOW>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
@@ -18,10 +18,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -251,6 +247,10 @@
 			/* Uses the reference BDF */
 		};
 	};
+};
+
+&mdio {
+	status = "okay";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
@@ -18,10 +18,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -86,6 +82,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
@@ -39,10 +39,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	key {
@@ -86,6 +82,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
@@ -47,10 +47,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	key {
@@ -87,6 +83,10 @@
 			gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-gl-b2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-gl-b2200.dts
@@ -24,10 +24,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -354,6 +350,10 @@
 			ieee80211-freq-limit = <5450000 5900000>;
 		};
 	};
+};
+
+&mdio {
+	status = "okay";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-gl-b2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-gl-b2200.dts
@@ -53,10 +53,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -103,6 +99,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-gl-b2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-gl-b2200.dts
@@ -24,10 +24,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -104,6 +100,10 @@
 			gpios = <&tlmm 66 GPIO_ACTIVE_LOW>;
 		};
 	};
+};
+
+&prng {
+	status = "okay";
 };
 
 &vqmmc {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-habanero-dvk.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-habanero-dvk.dts
@@ -65,10 +65,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -108,6 +104,10 @@
 			linux,default-trigger = "phy1tpt";
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &vqmmc {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-habanero-dvk.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-habanero-dvk.dts
@@ -57,10 +57,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -107,6 +103,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-habanero-dvk.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-habanero-dvk.dts
@@ -20,13 +20,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-		};
-
 		counter@4a1000 {
 			compatible = "qcom,qca-gcnt";
 			reg = <0x4a1000 0x4>;
@@ -327,6 +320,12 @@
 		#size-cells = <2>;
 		ranges;
 	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-habanero-dvk.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-habanero-dvk.dts
@@ -20,10 +20,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 
@@ -107,6 +103,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-hap-ac3.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-hap-ac3.dts
@@ -66,10 +66,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -158,6 +154,10 @@
 			gpios = <&tlmm 36 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-hap-ac3.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-hap-ac3.dts
@@ -28,10 +28,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		counter@4a1000 {
 			compatible = "qcom,qca-gcnt";
 			reg = <0x4a1000 0x4>;
@@ -157,6 +153,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-hap-ac3.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-hap-ac3.dts
@@ -58,10 +58,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -157,6 +153,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
@@ -42,10 +42,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -133,6 +129,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
@@ -42,10 +42,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		counter@4a1000 {
 			compatible = "qcom,qca-gcnt";
 			reg = <0x4a1000 0x4>;
@@ -243,6 +239,10 @@
 			reg = <0x00010000 0 0 0 0>;
 		};
 	};
+};
+
+&mdio {
+	status = "okay";
 };
 
 &ethphy1 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
@@ -76,10 +76,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -134,6 +130,10 @@
 			gpios = <&tlmm 5 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
@@ -68,10 +68,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -133,6 +129,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
@@ -19,10 +19,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -68,6 +64,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
@@ -48,10 +48,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -69,6 +65,10 @@
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &nand {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
@@ -19,10 +19,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -339,6 +335,10 @@
 &blsp1_uart1 {
 	pinctrl-0 = <&serial_pins>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+&mdio {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
@@ -40,10 +40,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -68,6 +64,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
@@ -97,14 +97,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-			reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
-			reset-delay-us = <2000>;
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -227,6 +219,14 @@
 
 &cryptobam {
 	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <2000>;
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
@@ -138,11 +138,11 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
@@ -97,10 +97,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -142,6 +138,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
@@ -130,10 +130,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 };
 
@@ -142,6 +138,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
@@ -80,10 +80,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -125,6 +121,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
@@ -121,11 +121,11 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
@@ -113,10 +113,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 };
 
@@ -125,6 +121,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
@@ -80,14 +80,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-			reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
-			reset-delay-us = <2000>;
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -210,6 +202,14 @@
 
 &cryptobam {
 	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <2000>;
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf286d.dts
@@ -73,10 +73,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -118,6 +114,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf286d.dts
@@ -73,14 +73,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-			reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
-			reset-delay-us = <2000>;
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -203,6 +195,14 @@
 
 &cryptobam {
 	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <2000>;
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf286d.dts
@@ -114,11 +114,11 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf286d.dts
@@ -106,10 +106,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 };
 
@@ -118,6 +114,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-ncp-hg100-cellular.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-ncp-hg100-cellular.dts
@@ -56,10 +56,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		dma@7984000 {
-			status = "okay";
-		};
 	};
 
 	keys-repeat {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-oap100.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-oap100.dts
@@ -52,10 +52,6 @@
 			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
 			status = "okay";
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	key {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-oap100.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-oap100.dts
@@ -56,10 +56,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	key {
@@ -108,6 +104,10 @@
 			gpios = <&tlmm 45 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-oap100.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-oap100.dts
@@ -21,12 +21,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -276,6 +270,12 @@
 
 &qpic_bam {
 	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
@@ -16,10 +16,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 
@@ -123,6 +119,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
@@ -16,13 +16,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-		};
-
 		counter@4a1000 {
 			compatible = "qcom,qca-gcnt";
 			reg = <0x4a1000 0x4>;
@@ -272,6 +265,12 @@
 
 &cryptobam {
 	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
@@ -61,10 +61,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -124,6 +120,10 @@
 			gpios = <&tlmm 60 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &vqmmc {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
@@ -53,10 +53,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -123,6 +119,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
@@ -39,10 +39,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -96,6 +92,10 @@
 			gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
@@ -14,10 +14,6 @@
 	compatible = "plasmacloud,pa2200";
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -95,6 +91,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
@@ -31,10 +31,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -95,6 +91,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
@@ -48,10 +48,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -96,6 +92,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
@@ -19,12 +19,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -280,6 +274,12 @@
 			bias-disable;
 		};
 	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
 };
 
 &ethphy0 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
@@ -56,10 +56,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -97,6 +93,10 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
@@ -19,10 +19,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -96,6 +92,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
@@ -23,10 +23,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -146,6 +142,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
@@ -58,10 +58,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -147,6 +143,10 @@
 			gpios = <&tlmm 49 GPIO_ACTIVE_LOW>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &cryptobam {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
@@ -23,10 +23,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -267,6 +263,10 @@
 		reg = <2>;
 		#trigger-source-cells = <0>;
 	};
+};
+
+&mdio {
+	status = "okay";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
@@ -50,10 +50,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -146,6 +142,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
@@ -138,10 +138,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -374,6 +370,10 @@
 &wifi1 {
 	status = "okay";
 	qcom,ath10k-calibration-variant = "cellc,rtl30vw";
+};
+
+&mdio {
+	status = "okay";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
@@ -167,10 +167,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 };
 
@@ -179,6 +175,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
@@ -138,10 +138,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -179,6 +175,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
@@ -175,11 +175,11 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-u4019.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-u4019.dtsi
@@ -46,10 +46,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		watchdog@b017000 {
-			status = "okay";
-		};
-
 		aliases {
 			led-boot = &led_status;
 			led-failsafe = &led_status;
@@ -80,6 +76,10 @@
 			};
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-u4019.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-u4019.dtsi
@@ -9,14 +9,6 @@
 	compatible = "unielec,u4019","qcom,ipq4019";
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-			reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
-			reset-delay-us = <2000>;
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -202,6 +194,14 @@
 			#trigger-source-cells = <0>;
 		};
 	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <2000>;
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-u4019.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-u4019.dtsi
@@ -9,10 +9,6 @@
 	compatible = "unielec,u4019","qcom,ipq4019";
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -79,6 +75,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
@@ -269,12 +269,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		pcie0: pci@40000000 {
-			status = "okay";
-			perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
-			wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
-		};
 	};
 
 	keys {
@@ -350,6 +344,12 @@
 	pinctrl-0 = <&nand_pins>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 
 &mdio {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
@@ -284,18 +284,6 @@
 			status = "okay";
 		};
 
-		serial@78af000 {
-			pinctrl-0 = <&serial_0_pins>;
-			pinctrl-names = "default";
-			status = "okay";
-		};
-
-		serial@78b0000 {
-			pinctrl-0 = <&serial_1_pins>;
-			pinctrl-names = "default";
-			status = "okay";
-		};
-
 		pcie0: pci@40000000 {
 			status = "okay";
 			perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
@@ -315,6 +303,18 @@
 };
 
 &blsp_dma {
+	status = "okay";
+};
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp1_uart2 {
+	pinctrl-0 = <&serial_1_pins>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
@@ -53,92 +53,6 @@
 	};
 
 	soc {
-		pinctrl@1000000 {
-			mdio_pins: mdio_pinmux {
-				mux_1 {
-					pins = "gpio6";
-					function = "mdio";
-					bias-pull-up;
-				};
-
-				mux_2 {
-					pins = "gpio7";
-					function = "mdc";
-					bias-pull-up;
-				};
-			};
-
-			serial_0_pins: serial_pinmux {
-				mux {
-					pins = "gpio16", "gpio17";
-					function = "blsp_uart0";
-					bias-disable;
-				};
-			};
-
-			serial_1_pins: serial1_pinmux {
-				mux {
-					pins = "gpio8", "gpio9", "gpio10", "gpio11";
-					function = "blsp_uart1";
-					bias-disable;
-				};
-			};
-
-			spi_0_pins: spi_0_pinmux {
-				pinmux {
-					function = "blsp_spi0";
-					pins = "gpio13", "gpio14", "gpio15";
-					bias-disable;
-				};
-
-				pinmux_cs {
-					function = "gpio";
-					pins = "gpio12";
-					bias-disable;
-					output-high;
-				};
-			};
-
-			i2c_0_pins: i2c_0_pinmux {
-				mux {
-					pins = "gpio20", "gpio21";
-					function = "blsp_i2c0";
-					bias-disable;
-				};
-			};
-
-			nand_pins: nand_pins {
-				pullups {
-					pins = "gpio52", "gpio53", "gpio58", "gpio59";
-					function = "qpic";
-					bias-pull-up;
-				};
-
-				pulldowns {
-					pins = "gpio54", "gpio55", "gpio56",
-					"gpio57", "gpio60", "gpio61",
-					"gpio62", "gpio63", "gpio64",
-					"gpio65", "gpio66", "gpio67",
-					"gpio68", "gpio69";
-					function = "qpic";
-					bias-pull-down;
-				};
-			};
-
-			led_0_pins: led0_pinmux {
-				mux_1 {
-					pins = "gpio36";
-					function = "led0";
-					bias-pull-down;
-				};
-				mux_2 {
-					pins = "gpio40";
-					function = "led4";
-					bias-pull-down;
-				};
-			};
-		};
-
 		spi_0: spi@78b5000 {
 			pinctrl-0 = <&spi_0_pins>;
 			pinctrl-names = "default";
@@ -278,6 +192,92 @@
 			label = "reset";
 			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio_pinmux {
+		mux_1 {
+			pins = "gpio6";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mux_2 {
+			pins = "gpio7";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
+	serial_0_pins: serial_pinmux {
+		mux {
+			pins = "gpio16", "gpio17";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	serial_1_pins: serial1_pinmux {
+		mux {
+			pins = "gpio8", "gpio9", "gpio10", "gpio11";
+			function = "blsp_uart1";
+			bias-disable;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		pinmux {
+			function = "blsp_spi0";
+			pins = "gpio13", "gpio14", "gpio15";
+			bias-disable;
+		};
+
+		pinmux_cs {
+			function = "gpio";
+			pins = "gpio12";
+			bias-disable;
+			output-high;
+		};
+	};
+
+	i2c_0_pins: i2c_0_pinmux {
+		mux {
+			pins = "gpio20", "gpio21";
+			function = "blsp_i2c0";
+			bias-disable;
+		};
+	};
+
+	nand_pins: nand_pins {
+		pullups {
+			pins = "gpio52", "gpio53", "gpio58", "gpio59";
+			function = "qpic";
+			bias-pull-up;
+		};
+
+		pulldowns {
+			pins = "gpio54", "gpio55", "gpio56",
+			"gpio57", "gpio60", "gpio61",
+			"gpio62", "gpio63", "gpio64",
+			"gpio65", "gpio66", "gpio67",
+			"gpio68", "gpio69";
+			function = "qpic";
+			bias-pull-down;
+		};
+	};
+
+	led_0_pins: led0_pinmux {
+		mux_1 {
+			pins = "gpio36";
+			function = "led0";
+			bias-pull-down;
+		};
+		mux_2 {
+			pins = "gpio40";
+			function = "led4";
+			bias-pull-down;
 		};
 	};
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
@@ -278,12 +278,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		i2c_0: i2c@78b7000 {
-			pinctrl-0 = <&i2c_0_pins>;
-			pinctrl-names = "default";
-			status = "okay";
-		};
-
 		pcie0: pci@40000000 {
 			status = "okay";
 			perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
@@ -314,6 +308,12 @@
 
 &blsp1_uart2 {
 	pinctrl-0 = <&serial_1_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp1_i2c3 {
+	pinctrl-0 = <&i2c_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
@@ -53,111 +53,6 @@
 	};
 
 	soc {
-		spi_0: spi@78b5000 {
-			pinctrl-0 = <&spi_0_pins>;
-			pinctrl-names = "default";
-			status = "okay";
-			cs-gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>, <&tlmm 41 GPIO_ACTIVE_HIGH>;
-			num-cs = <2>;
-
-			flash0@0 {
-				reg = <0>;
-				compatible = "jedec,spi-nor";
-				spi-max-frequency = <24000000>;
-				broken-flash-reset;
-
-				partitions {
-					compatible = "fixed-partitions";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					partition@0 {
-						label = "0:SBL1";
-						reg = <0x000000 0x040000>;
-						read-only;
-					};
-
-					partition@40000 {
-						label = "0:MIBIB";
-						reg = <0x040000 0x020000>;
-						read-only;
-					};
-
-					partition@60000 {
-						label = "0:QSEE";
-						reg = <0x060000 0x060000>;
-						read-only;
-					};
-
-					partition@c0000 {
-						label = "0:CDT";
-						reg = <0x0c0000 0x010000>;
-						read-only;
-					};
-
-					partition@d0000 {
-						label = "0:DDRPARAMS";
-						reg = <0x0d0000 0x010000>;
-						read-only;
-					};
-
-					partition@e0000 {
-						label = "u-boot-env";
-						reg = <0x0e0000 0x010000>;
-					};
-
-					partition@f0000 {
-						label = "u-boot";
-						reg = <0x0f0000 0x080000>;
-						read-only;
-					};
-
-					partition@170000 {
-						label = "0:ART";
-						reg = <0x170000 0x010000>;
-						read-only;
-
-						nvmem-layout {
-							compatible = "fixed-layout";
-							#address-cells = <1>;
-							#size-cells = <1>;
-
-							precal_art_1000: precal@1000 {
-								reg = <0x1000 0x2f20>;
-							};
-
-							precal_art_5000: precal@5000 {
-								reg = <0x5000 0x2f20>;
-							};
-						};
-					};
-				};
-			};
-
-			nand@1 {
-				reg = <1>;
-				status = "okay";
-				compatible = "spi-nand";
-				spi-max-frequency = <24000000>;
-
-				partitions {
-					compatible = "fixed-partitions";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					/* The device has 128MB, but we can only address
-					 * 64MB because of the bootloader's default settings.
-					 * This is due to the old mt29f driver,
-					 * which detected the deivce with only 64MB
-					 */
-					partition@0 {
-						label = "ubi";
-						reg = <0x0000000 0x4000000>;
-					};
-				};
-			};
-		};
-
 		tcsr@194b000 {
 			/* select hostmode */
 			compatible = "qcom,tcsr";
@@ -302,6 +197,111 @@
 	pinctrl-0 = <&i2c_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&blsp1_spi1 {
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	cs-gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>, <&tlmm 41 GPIO_ACTIVE_HIGH>;
+	num-cs = <2>;
+
+	flash0@0 {
+		reg = <0>;
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <24000000>;
+		broken-flash-reset;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "0:MIBIB";
+				reg = <0x040000 0x020000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "0:QSEE";
+				reg = <0x060000 0x060000>;
+				read-only;
+			};
+
+			partition@c0000 {
+				label = "0:CDT";
+				reg = <0x0c0000 0x010000>;
+				read-only;
+			};
+
+			partition@d0000 {
+				label = "0:DDRPARAMS";
+				reg = <0x0d0000 0x010000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0x0e0000 0x010000>;
+			};
+
+			partition@f0000 {
+				label = "u-boot";
+				reg = <0x0f0000 0x080000>;
+				read-only;
+			};
+
+			partition@170000 {
+				label = "0:ART";
+				reg = <0x170000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					precal_art_1000: precal@1000 {
+						reg = <0x1000 0x2f20>;
+					};
+
+					precal_art_5000: precal@5000 {
+						reg = <0x5000 0x2f20>;
+					};
+				};
+			};
+		};
+	};
+
+	nand@1 {
+		reg = <1>;
+		status = "okay";
+		compatible = "spi-nand";
+		spi-max-frequency = <24000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* The device has 128MB, but we can only address
+			 * 64MB because of the bootloader's default settings.
+			 * This is due to the old mt29f driver,
+			 * which detected the deivce with only 64MB
+			 */
+			partition@0 {
+				label = "ubi";
+				reg = <0x0000000 0x4000000>;
+			};
+		};
+	};
 };
 
 &watchdog {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
@@ -304,10 +304,6 @@
 			status = "okay";
 		};
 
-		crypto@8e3a000 {
-			status = "okay";
-		};
-
 		qpic_bam: dma@7984000 {
 			status = "okay";
 		};
@@ -331,6 +327,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
@@ -244,14 +244,6 @@
 			};
 		};
 
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-			reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
-			reset-delay-us = <5000>;
-		};
-
 		tcsr@194b000 {
 			/* select hostmode */
 			compatible = "qcom,tcsr";
@@ -358,6 +350,14 @@
 	pinctrl-0 = <&nand_pins>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <5000>;
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
@@ -139,10 +139,6 @@
 			};
 		};
 
-		blsp_dma: dma@7884000 {
-			status = "okay";
-		};
-
 		spi_0: spi@78b5000 {
 			pinctrl-0 = <&spi_0_pins>;
 			pinctrl-names = "default";
@@ -300,14 +296,6 @@
 			status = "okay";
 		};
 
-		cryptobam: dma@8e04000 {
-			status = "okay";
-		};
-
-		qpic_bam: dma@7984000 {
-			status = "okay";
-		};
-
 		pcie0: pci@40000000 {
 			status = "okay";
 			perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
@@ -326,11 +314,19 @@
 	};
 };
 
+&blsp_dma {
+	status = "okay";
+};
+
 &watchdog {
 	status = "okay";
 };
 
 &crypto {
+	status = "okay";
+};
+
+&cryptobam {
 	status = "okay";
 };
 
@@ -351,6 +347,10 @@
 };
 
 &usb2 {
+	status = "okay";
+};
+
+&qpic_bam {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wpj419.dts
@@ -308,10 +308,6 @@
 			status = "okay";
 		};
 
-		watchdog@b017000 {
-			status = "okay";
-		};
-
 		qpic_bam: dma@7984000 {
 			status = "okay";
 		};
@@ -332,6 +328,10 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &usb3_ss_phy {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wtr-m2133hp.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wtr-m2133hp.dts
@@ -36,10 +36,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -161,6 +157,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wtr-m2133hp.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wtr-m2133hp.dts
@@ -68,10 +68,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -162,6 +158,10 @@
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wtr-m2133hp.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wtr-m2133hp.dts
@@ -60,10 +60,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -161,6 +157,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-x1pro.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-x1pro.dtsi
@@ -56,10 +56,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		watchdog@b017000 {
-			status = "okay";
-		};
-
 		leds {
 			compatible = "gpio-leds";
 			pinctrl-0 = <&led_pins>;
@@ -82,6 +78,10 @@
 			};
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-x1pro.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-x1pro.dtsi
@@ -18,14 +18,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-			reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
-			reset-delay-us = <2000>;
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -202,6 +194,14 @@
 			#trigger-source-cells = <0>;
 		};
 	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <2000>;
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-x1pro.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-x1pro.dtsi
@@ -18,11 +18,6 @@
 	};
 
 	soc {
-
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -81,6 +76,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
@@ -27,10 +27,6 @@
 
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -76,6 +72,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
@@ -62,10 +62,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	regulator-usb-vbus {
@@ -79,6 +75,9 @@
 	};
 };
 
+&watchdog {
+	status = "okay";
+};
 
 &blsp_dma {
 	status = "okay";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
@@ -54,10 +54,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	regulator-usb-vbus {
@@ -76,6 +72,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
@@ -27,10 +27,6 @@
 
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -294,6 +290,10 @@
 		reg = <2>;
 		#trigger-source-cells = <0>;
 	};
+};
+
+&mdio {
+	status = "okay";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4028-wpj428.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4028-wpj428.dts
@@ -68,10 +68,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -115,6 +111,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4028-wpj428.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4028-wpj428.dts
@@ -35,14 +35,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-			reset-gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
-			reset-delay-us = <2000>;
-		};
-
 		tcsr@194b000 {
 			/* select hostmode */
 			compatible = "qcom,tcsr";
@@ -257,6 +249,14 @@
 
 &cryptobam {
 	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <2000>;
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4028-wpj428.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4028-wpj428.dts
@@ -35,10 +35,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -115,6 +111,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4028-wpj428.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4028-wpj428.dts
@@ -76,10 +76,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -116,6 +112,10 @@
 		compatible = "gpio-beeper";
 		gpios = <&tlmm 58 GPIO_ACTIVE_HIGH>;
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
@@ -22,15 +22,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-
-			reset-gpios = <&tlmm 19 GPIO_ACTIVE_LOW>;
-			reset-delay-us = <2000>;
-		};
-
 		counter@4a1000 {
 			compatible = "qcom,qca-gcnt";
 			reg = <0x4a1000 0x4>;
@@ -440,6 +431,15 @@
 
 &usb3_hs_phy {
 	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+
+	reset-gpios = <&tlmm 19 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <2000>;
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
@@ -59,10 +59,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -117,6 +113,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
@@ -22,10 +22,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -117,6 +113,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
@@ -67,10 +67,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -118,6 +114,10 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-365.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-365.dts
@@ -67,7 +67,7 @@
 	};
 };
 
-&i2c_0 {
+&blsp1_i2c3 {
 	power-monitor@40 {
 		/* No driver */
 		compatible = "isl,isl28022";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-aruba-glenmorangie.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-aruba-glenmorangie.dtsi
@@ -12,10 +12,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -79,6 +75,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-aruba-glenmorangie.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-aruba-glenmorangie.dtsi
@@ -53,10 +53,6 @@
 			status = "okay";
 		};
 
-		watchdog@b017000 {
-			status = "okay";
-		};
-
 		i2c_0: i2c@78b7000 {
 			pinctrl-0 = <&i2c_0_pins>;
 			pinctrl-names = "default";
@@ -80,6 +76,10 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-aruba-glenmorangie.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-aruba-glenmorangie.dtsi
@@ -45,10 +45,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		crypto@8e3a000 {
-			status = "okay";
-		};
-
 		i2c_0: i2c@78b7000 {
 			pinctrl-0 = <&i2c_0_pins>;
 			pinctrl-names = "default";
@@ -79,6 +75,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-aruba-glenmorangie.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-aruba-glenmorangie.dtsi
@@ -12,16 +12,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-
-			ethphy: ethernet-phy@5 {
-				reg = <0x5>;
-			};
-		};
-
 		counter@4a1000 {
 			compatible = "qcom,qca-gcnt";
 			reg = <0x4a1000 0x4>;
@@ -211,6 +201,16 @@
 				read-only;
 			};
 		};
+	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+
+	ethphy: ethernet-phy@5 {
+		reg = <0x5>;
 	};
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-aruba-glenmorangie.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-aruba-glenmorangie.dtsi
@@ -44,19 +44,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		i2c_0: i2c@78b7000 {
-			pinctrl-0 = <&i2c_0_pins>;
-			pinctrl-names = "default";
-			status = "okay";
-
-			tpm@29 {
-				/* No Driver */
-				compatible = "atmel,at97sc3203";
-				reg = <0x29>;
-				read-only;
-			};
-		};
 	};
 
 	keys {
@@ -97,6 +84,19 @@
 	pinctrl-0 = <&serial_1_pins>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&blsp1_i2c3 {
+	pinctrl-0 = <&i2c_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	tpm@29 {
+		/* No Driver */
+		compatible = "atmel,at97sc3203";
+		reg = <0x29>;
+		read-only;
+	};
 };
 
 &cryptobam {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-b1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-b1300.dts
@@ -67,10 +67,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -117,6 +113,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-b1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-b1300.dts
@@ -75,10 +75,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -118,6 +114,10 @@
 			gpios = <&tlmm 2 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-b1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-b1300.dts
@@ -38,10 +38,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -280,6 +276,10 @@
 };
 
 &usb3 {
+	status = "okay";
+};
+
+&mdio {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-b1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-b1300.dts
@@ -38,10 +38,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -117,6 +113,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-s1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-s1300.dts
@@ -23,10 +23,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 		};
@@ -103,6 +99,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-s1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-s1300.dts
@@ -52,10 +52,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -103,6 +99,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-s1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-s1300.dts
@@ -60,10 +60,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -104,6 +100,10 @@
 			linux,default-trigger = "phy0tpt";
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &vqmmc {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-s1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-s1300.dts
@@ -23,10 +23,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -345,6 +341,10 @@
 };
 
 &usb3 {
+	status = "okay";
+};
+
+&mdio {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
@@ -74,10 +74,6 @@
 				enable-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 			};
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -107,6 +103,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
@@ -33,12 +33,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-		};
-
 		/* It is a 56-bit counter that supplies the count to the ARM arch
 		   timers and without upstream driver */
 		counter@4a1000 {
@@ -401,6 +395,12 @@
 	qcom,ath10k-calibration-variant = "Meraki-MR33";
 	nvmem-cells = <&mac_address 3>;
 	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
@@ -82,10 +82,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -108,6 +104,10 @@
 			panic-indicator;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
@@ -33,10 +33,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -107,6 +103,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
@@ -63,17 +63,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		serial@78b0000 {
-			pinctrl-0 = <&serial_1_pins>;
-			pinctrl-names = "default";
-			status = "okay";
-
-			bluetooth {
-				compatible = "ti,cc2650";
-				enable-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
-			};
-		};
 	};
 
 	keys {
@@ -118,6 +107,17 @@
 	pinctrl-0 = <&serial_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
+};
+
+&blsp1_uart2 {
+	pinctrl-0 = <&serial_1_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	bluetooth {
+		compatible = "ti,cc2650";
+		enable-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
+	};
 };
 
 &cryptobam {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ws-ap3915i.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ws-ap3915i.dts
@@ -17,12 +17,6 @@
 	};
 
 	soc {
-		mdio@90000 {
-			status = "okay";
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-		};
-
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";
 			reg = <0x1949000 0x100>;
@@ -122,6 +116,12 @@
 
 &qpic_bam {
 	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
 };
 
 &gmac {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ws-ap3915i.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ws-ap3915i.dts
@@ -40,10 +40,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
-		crypto@8e3a000 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -103,6 +99,10 @@
 };
 
 &prng {
+	status = "okay";
+};
+
+&crypto {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ws-ap3915i.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ws-ap3915i.dts
@@ -17,10 +17,6 @@
 	};
 
 	soc {
-		rng@22000 {
-			status = "okay";
-		};
-
 		mdio@90000 {
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
@@ -103,6 +99,10 @@
 };
 
 &watchdog {
+	status = "okay";
+};
+
+&prng {
 	status = "okay";
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ws-ap3915i.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ws-ap3915i.dts
@@ -48,10 +48,6 @@
 		crypto@8e3a000 {
 			status = "okay";
 		};
-
-		watchdog@b017000 {
-			status = "okay";
-		};
 	};
 
 	leds {
@@ -104,6 +100,10 @@
 			linux,code = <KEY_RESTART >;
 		};
 	};
+};
+
+&watchdog {
+	status = "okay";
 };
 
 &blsp_dma {


### PR DESCRIPTION
There are a lot of boards in ipq40xx that still manually define nodes under `soc` node for things that upstream already has existing labels so this PR converts all of them and fixes some weird stuff found along the way.