### PR TITLE
mediatek: correct address of MT753x switch IC

### DIFF
--- a/target/linux/mediatek/dts/mt7622-netgear-wax206.dts
+++ b/target/linux/mediatek/dts/mt7622-netgear-wax206.dts
@@ -143,13 +143,13 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		switch@0 {
+		switch@1f {
 			compatible = "mediatek,mt7531";
+			reg = <31>;
 			#interrupt-cells = <1>;
 			interrupt-controller;
 			interrupt-parent = <&pio>;
 			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
-			reg = <0>;
 			reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
 
 			ports {

--- a/target/linux/mediatek/dts/mt7623a-unielec-u7623-02.dtsi
+++ b/target/linux/mediatek/dts/mt7623a-unielec-u7623-02.dtsi
@@ -121,17 +121,16 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		mt7530: switch@0 {
-			compatible = "mediatek,mt7530";
+		mt7530: switch@1f {
 		};
 	};
 };
 
 &mt7530 {
 	compatible = "mediatek,mt7530";
+	reg = <31>;
 	#address-cells = <1>;
 	#size-cells = <0>;
-	reg = <0>;
 	pinctrl-names = "default";
 	mediatek,mcm;
 	resets = <&ethsys 2>;


### PR DESCRIPTION
Continuation of commit 8b66f1a. Set the switch address on the MDIO bus to 31.
This is required for all boards currently working with the mt7530 DSA driver.

Fixes: #15419

