### PR TITLE
linux-firmware: realtek: update rtl8821ae firmware

### DIFF
--- a/package/firmware/linux-firmware/realtek.mk
+++ b/package/firmware/linux-firmware/realtek.mk
@@ -128,7 +128,7 @@ $(eval $(call BuildPackage,rtl8761bu-firmware))
 Package/rtl8821ae-firmware = $(call Package/firmware-default,RealTek RTL8821AE firmware,,LICENCE.rtlwifi_firmware.txt)
 define Package/rtl8821ae-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8821aefw.bin $(1)/lib/firmware/rtlwifi
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8821aefw_29.bin $(1)/lib/firmware/rtlwifi
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8821aefw_wowlan.bin $(1)/lib/firmware/rtlwifi
 endef
 $(eval $(call BuildPackage,rtl8821ae-firmware))


### PR DESCRIPTION
A newer version, rtl8821aefw_29.bin, has been available for over 7 years [1]. Let's use it.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=f70e4df2b384d21e36a7c30a591639592692e0ec

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>