### PR TITLE
base-files: fix ipcalc bound calculation for /31 prefix

### DIFF
--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -111,6 +111,8 @@ start=$((network | (start & hostmask)))
 
 if [ "$prefix" -le 30 ]; then
     upper=$(((network | hostmask) - 1))
+elif [ "$prefix" -eq 31 ]; then
+    upper=$((network | hostmask))
 else
     upper="$network"
 fi


### PR DESCRIPTION
A small regress from the translation to shell.
Fixes #12921, originally fixed in #12925 (Github).