### PR TITLE
ramips: Fix wmac dts definition for TP-Link TL-MR6400 v4 and v5

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v4.dts
@@ -89,8 +89,10 @@
 };
 
 &wmac {
-	nvmem-cells = <&macaddr_factory_1f100>;
-	nvmem-cell-names = "mac-address";
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_factory_1f100>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &ethernet {

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v4.dts
@@ -91,12 +91,12 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_factory_1f100>;
+	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_factory_1f100 0>;
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &ethernet {
-	nvmem-cells = <&macaddr_factory_1f100>;
+	nvmem-cells = <&macaddr_factory_1f100 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -107,7 +107,9 @@
 		#size-cells = <1>;
 
 		macaddr_factory_1f100: macaddr@1f100 {
+			compatible = "mac-base";
 			reg = <0x1f100 0x6>;
+			#nvmem-cell-cells = <1>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v5.dts
@@ -89,8 +89,10 @@
 };
 
 &wmac {
-	nvmem-cells = <&macaddr_factory_1f100>;
-	nvmem-cell-names = "mac-address";
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_factory_1f100>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &ethernet {

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v5.dts
@@ -91,12 +91,12 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_factory_1f100>;
+	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_factory_1f100 0>;
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &ethernet {
-	nvmem-cells = <&macaddr_factory_1f100>;
+	nvmem-cells = <&macaddr_factory_1f100 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -107,7 +107,9 @@
 		#size-cells = <1>;
 
 		macaddr_factory_1f100: macaddr@1f100 {
+			compatible = "mac-base";
 			reg = <0x1f100 0x6>;
+			#nvmem-cell-cells = <1>;
 		};
 	};
 };


### PR DESCRIPTION
This code assumed that the mt7628an_tplink_8m.dtsi file defines mediatek,mtd-eeprom for the wmac and sets status to okay.

The mediatek,mtd-eeprom definition was removed in commit e93f41adee3e ("ramips: convert MT7628 EEPROM to NVMEM format") but the dts for these two devices was not adapted to include the eeprom position on its own.

The status = "okay" property was removed in 0a1d15642fa6 ("ramips: mt7628: use nvmem-layout"), but the property was not added to these dts files.

Without this change wifi does not work for these devices.

Fixes: e93f41adee3e ("ramips: convert MT7628 EEPROM to NVMEM format")
Fixes: 0a1d15642fa6 ("ramips: mt7628: use nvmem-layout")

The wifi problem was reported to me by someone locally. I do not own these devices and did not runtime test this.

@DragonBluep  and @neheb  please have a look. 