### PR TITLE
ath79: add support for NEC Aterm devices based on AR9344

### DIFF
--- a/package/boot/uboot-ath79/Makefile
+++ b/package/boot/uboot-ath79/Makefile
@@ -18,6 +18,15 @@ define U-Boot/Default
   HIDDEN:=1
 endef
 
+define U-Boot/ar9344_nec_aterm
+  NAME:=NEC Aterm series (AR9344)
+  BUILD_SUBTARGET:= tiny
+  BUILD_DEVICES:=nec_wg600hp nec_wr8750n nec_wr9500n
+  UBOOT_CONFIG:=nec_ar9344_aterm
+endef
+
+UBOOT_TARGETS := ar9344_nec_aterm
+
 # don't stage files to bindir, let target/linux/ath79/image/*.mk do that
 define Package/u-boot/install
 endef

--- a/package/boot/uboot-ath79/Makefile
+++ b/package/boot/uboot-ath79/Makefile
@@ -1,0 +1,30 @@
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_VERSION:=2024.07
+PKG_HASH:=f591da9ab90ef3d6b3d173766d0ddff90c4ed7330680897486117df390d83c8f
+
+UBOOT_USE_INTREE_DTC:=1
+
+include $(INCLUDE_DIR)/u-boot.mk
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+
+define U-Boot/Default
+  BUILD_TARGET:=ath79
+  BUILD_SUBTARGET:=generic
+  UBOOT_IMAGE:=u-boot.bin
+  UBOOT_CONFIG:=ap121
+  HIDDEN:=1
+endef
+
+# don't stage files to bindir, let target/linux/ath79/image/*.mk do that
+define Package/u-boot/install
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/$(UBOOT_IMAGE) $(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)-$(UBOOT_IMAGE)
+endef
+
+$(eval $(call BuildPackage/U-Boot))

--- a/package/boot/uboot-ath79/patches/400-ath79-add-support-for-NEC-AR9344-Aterm-series.patch
+++ b/package/boot/uboot-ath79/patches/400-ath79-add-support-for-NEC-AR9344-Aterm-series.patch
@@ -1,0 +1,287 @@
+From 80a7688c478a6a372083c29ff0b1826db4dae5b2 Mon Sep 17 00:00:00 2001
+From: INAGAKI Hiroshi <musashino.open@gmail.com>
+Date: Wed, 24 Apr 2024 23:54:46 +0900
+Subject: [PATCH] ath79: add support for NEC AR9344 Aterm series
+
+---
+ arch/mips/dts/Makefile                |  1 +
+ arch/mips/dts/nec,ar9344-aterm.dts    | 35 +++++++++++++++
+ arch/mips/mach-ath79/Kconfig          |  5 +++
+ board/nec/ar9344_aterm/Kconfig        | 30 +++++++++++++
+ board/nec/ar9344_aterm/Makefile       |  3 ++
+ board/nec/ar9344_aterm/ar9344_aterm.c | 59 ++++++++++++++++++++++++++
+ configs/nec_ar9344_aterm_defconfig    | 61 +++++++++++++++++++++++++++
+ include/configs/nec_ar9344_aterm.h    | 28 ++++++++++++
+ 8 files changed, 222 insertions(+)
+ create mode 100644 arch/mips/dts/nec,ar9344-aterm.dts
+ create mode 100644 board/nec/ar9344_aterm/Kconfig
+ create mode 100644 board/nec/ar9344_aterm/Makefile
+ create mode 100644 board/nec/ar9344_aterm/ar9344_aterm.c
+ create mode 100644 configs/nec_ar9344_aterm_defconfig
+ create mode 100644 include/configs/nec_ar9344_aterm.h
+
+--- a/arch/mips/dts/Makefile
++++ b/arch/mips/dts/Makefile
+@@ -24,6 +24,7 @@ dtb-$(CONFIG_BOARD_GARDENA_SMART_GATEWAY
+ dtb-$(CONFIG_BOARD_LINKIT_SMART_7688) += linkit-smart-7688.dtb
+ dtb-$(CONFIG_TARGET_OCTEON_EBB7304) += mrvl,octeon-ebb7304.dtb
+ dtb-$(CONFIG_TARGET_OCTEON_NIC23) += mrvl,octeon-nic23.dtb
++dtb-$(CONFIG_BOARD_NEC_AR9344_ATERM) += nec,ar9344-aterm.dtb
+ dtb-$(CONFIG_BOARD_NETGEAR_CG3100D) += netgear,cg3100d.dtb
+ dtb-$(CONFIG_BOARD_NETGEAR_DGND3700V2) += netgear,dgnd3700v2.dtb
+ dtb-$(CONFIG_BOARD_SAGEM_FAST1704) += sagem,f@st1704.dtb
+--- /dev/null
++++ b/arch/mips/dts/nec,ar9344-aterm.dts
+@@ -0,0 +1,35 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 INAGAKI Hiroshi <musashino.open@gmail.com>
++ */
++
++/dts-v1/;
++#include "ar934x.dtsi"
++
++/ {
++	model = "NEC Aterm series (AR9344)";
++	compatible = "nec,ar9344-aterm", "qca,ar934x";
++
++	aliases {
++		serial0 = &uart0;
++	};
++
++	chosen {
++		stdout-path = "serial0:9600n8";
++	};
++};
++
++&uart0 {
++	clock-frequency = <40000000>;
++	status = "okay";
++};
++
++&xtal {
++	clock-frequency = <40000000>;
++};
++
++/* delete unused nodes to reduce dtb size */
++/delete-node/ &ehci0;
++/delete-node/ &gmac0;
++/delete-node/ &gmac1;
++/delete-node/ &spi0;
+--- a/arch/mips/mach-ath79/Kconfig
++++ b/arch/mips/mach-ath79/Kconfig
+@@ -58,6 +58,10 @@ config TARGET_AP152
+ 	bool "AP152 Reference Board"
+ 	select SOC_QCA956X
+ 
++config BOARD_NEC_AR9344_ATERM
++	bool "NEC Aterm series Boards (AR9344)"
++	select SOC_AR934X
++
+ config BOARD_TPLINK_WDR4300
+ 	bool "TP-Link WDR4300 Board"
+ 	select SOC_AR934X
+@@ -67,6 +71,7 @@ endchoice
+ source "board/qca/ap121/Kconfig"
+ source "board/qca/ap143/Kconfig"
+ source "board/qca/ap152/Kconfig"
++source "board/nec/ar9344_aterm/Kconfig"
+ source "board/tplink/wdr4300/Kconfig"
+ 
+ endmenu
+--- /dev/null
++++ b/board/nec/ar9344_aterm/Kconfig
+@@ -0,0 +1,30 @@
++if BOARD_NEC_AR9344_ATERM
++
++config SYS_VENDOR
++	default "nec"
++
++config SYS_SOC
++	default "ath79"
++
++config SYS_BOARD
++	default "ar9344_aterm"
++
++config SYS_CONFIG_NAME
++	default "nec_ar9344_aterm"
++
++config TEXT_BASE
++	default 0x9f000000
++
++config SYS_DCACHE_SIZE
++	default 32768
++
++config SYS_DCACHE_LINE_SIZE
++	default 32
++
++config SYS_ICACHE_SIZE
++	default 65536
++
++config SYS_ICACHE_LINE_SIZE
++	default 32
++
++endif
+--- /dev/null
++++ b/board/nec/ar9344_aterm/Makefile
+@@ -0,0 +1,3 @@
++# SPDX-License-Identifier: GPL-2.0+
++
++obj-y	= ar9344_aterm.o
+--- /dev/null
++++ b/board/nec/ar9344_aterm/ar9344_aterm.c
+@@ -0,0 +1,59 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 INAGAKI Hiroshi <musashino.open@gmail.com>
++ */
++
++#include <init.h>
++#include <asm/io.h>
++#include <asm/addrspace.h>
++#include <asm/types.h>
++#include <mach/ath79.h>
++#include <mach/ar71xx_regs.h>
++#include <mach/ddr.h>
++#include <debug_uart.h>
++
++static void aterm_pinmux_config(void)
++{
++	void __iomem *regs;
++
++	regs = map_physmem(AR71XX_GPIO_BASE, AR71XX_GPIO_SIZE,
++			   MAP_NOCACHE);
++
++	/* Disable JTAG */
++	writel(0x2, regs + AR934X_GPIO_REG_FUNC);
++
++	/* Configure default GPIO OE/SET regs */
++	writel(0x3db1f, regs + AR71XX_GPIO_REG_OE);
++	writel(0x142000, regs + AR71XX_GPIO_REG_SET);
++
++	/* Configure pin multiplexing */
++	writel(0x00000000, regs + AR934X_GPIO_REG_OUT_FUNC0);
++	writel(0x0b0a0900, regs + AR934X_GPIO_REG_OUT_FUNC1);
++	writel(0x00180000, regs + AR934X_GPIO_REG_OUT_FUNC2);
++	writel(0x00000000, regs + AR934X_GPIO_REG_OUT_FUNC3);
++	writel(0x2f2e0000, regs + AR934X_GPIO_REG_OUT_FUNC4);
++	writel(0x00000000, regs + AR934X_GPIO_REG_OUT_FUNC5);
++}
++
++#ifdef CONFIG_DEBUG_UART_BOARD_INIT
++void board_debug_uart_init(void)
++{
++	aterm_pinmux_config();
++}
++#endif
++
++#ifdef CONFIG_BOARD_EARLY_INIT_F
++int board_early_init_f(void)
++{
++#ifndef CONFIG_DEBUG_UART_BOARD_INIT
++	aterm_pinmux_config();
++#endif
++
++#if !CONFIG_IS_ENABLED(SKIP_LOWLEVEL_INIT)
++	ar934x_pll_init(560, 480, 240);
++	ar934x_ddr_init(560, 480, 240);
++#endif
++
++	return 0;
++}
++#endif
+--- /dev/null
++++ b/configs/nec_ar9344_aterm_defconfig
+@@ -0,0 +1,61 @@
++CONFIG_MIPS=y
++CONFIG_SYS_MALLOC_LEN=0x40000
++CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
++CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0xbd007fff
++CONFIG_ENV_SIZE=0x1000
++CONFIG_DEFAULT_DEVICE_TREE="nec,ar9344-aterm"
++CONFIG_SYS_LOAD_ADDR=0x83000000
++CONFIG_ARCH_ATH79=y
++CONFIG_BOARD_NEC_AR9344_ATERM=y
++CONFIG_SYS_MIPS_TIMER_FREQ=280000000
++CONFIG_MIPS_RELOCATION_TABLE_SIZE=0x4000
++# CONFIG_LOCALVERSION_AUTO is not set
++CONFIG_TIMESTAMP=y
++CONFIG_BOOTDELAY=3
++# CONFIG_ARCH_FIXUP_FDT_MEMORY is not set
++CONFIG_USE_BOOTARGS=y
++CONFIG_BOOTARGS="console=ttyS0,115200"
++CONFIG_USE_BOOTCOMMAND=y
++CONFIG_BOOTCOMMAND="bootm 0x9f040000"
++# CONFIG_DISPLAY_BOARDINFO is not set
++CONFIG_BOARD_EARLY_INIT_F=y
++CONFIG_SYS_MALLOC_BOOTPARAMS=y
++# CONFIG_CMDLINE_EDITING is not set
++# CONFIG_AUTO_COMPLETE is not set
++# CONFIG_SYS_LONGHELP is not set
++CONFIG_SYS_MAXARGS=32
++# CONFIG_SYS_XTRACE is not set
++# CONFIG_CMD_BDI is not set
++# CONFIG_CMD_CONSOLE is not set
++# CONFIG_BOOTM_PLAN9 is not set
++# CONFIG_BOOTM_RTEMS is not set
++# CONFIG_BOOTM_VXWORKS is not set
++# CONFIG_CMD_ELF is not set
++# CONFIG_CMD_FDT is not set
++# CONFIG_CMD_RUN is not set
++# CONFIG_CMD_XIMG is not set
++# CONFIG_CMD_EXPORTENV is not set
++# CONFIG_CMD_IMPORTENV is not set
++# CONFIG_CMD_EDITENV is not set
++# CONFIG_CMD_SAVEENV is not set
++# CONFIG_CMD_ENV_EXISTS is not set
++# CONFIG_CMD_CRC32 is not set
++# CONFIG_CMD_DM is not set
++# CONFIG_CMD_LOADS is not set
++# CONFIG_CMD_ECHO is not set
++# CONFIG_CMD_ITEST is not set
++# CONFIG_CMD_SOURCE is not set
++# CONFIG_CMD_SETEXPR is not set
++# CONFIG_CMD_SLEEP is not set
++# CONFIG_ISO_PARTITION is not set
++# CONFIG_OF_TAG_MIGRATE is not set
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++# CONFIG_NET is not set
++CONFIG_CLK=y
++# CONFIG_GPIO is not set
++# CONFIG_I2C is not set
++# CONFIG_INPUT is not set
++# CONFIG_POWER is not set
++CONFIG_DM_SERIAL=y
++CONFIG_SYS_NS16550=y
++# CONFIG_GZIP is not set
+--- /dev/null
++++ b/include/configs/nec_ar9344_aterm.h
+@@ -0,0 +1,28 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 INAGAKI Hiroshi <musashino.open@gmail.com>
++ */
++
++#ifndef __NEC_AR9344_ATERM_H
++#define __NEC_AR9344_ATERM_H
++
++#define CFG_SYS_SDRAM_BASE		0x80000000
++
++#define CFG_SYS_INIT_RAM_ADDR	0xbd000000
++#define CFG_SYS_INIT_RAM_SIZE	0x8000
++
++/*
++ * Serial Port
++ */
++#define CFG_SYS_NS16550_CLK		40000000
++
++/*
++ * Command
++ */
++/* Miscellaneous configurable options */
++
++/*
++ * Diagnostics
++ */
++
++#endif  /* __NEC_AR9344_ATERM_H */

--- a/target/linux/ath79/dts/ar9344_nec_aterm.dtsi
+++ b/target/linux/ath79/dts/ar9344_nec_aterm.dtsi
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	aliases {
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	chosen {
+		/*
+		 * don't specify bootargs property in DeviceTree to
+		 * enable a console with a default baudrate (9600)
+		 * or passed console= parameter from the bootloader
+		 */
+		/delete-property/ bootargs;
+		stdout-path = &uart;
+	};
+
+	keys: keys {
+		compatible = "gpio-keys";
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		button-eco {
+			label = "eco";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			debounce-interval = <60>;
+		};
+
+		switch-ap {
+			label = "ap";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			debounce-interval = <60>;
+		};
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		button-wps {
+			label = "wps";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	ath9k_leds: ath9k-leds {
+		/* all LEDs are connected to ath9k chip (AR938x) */
+		compatible = "gpio-leds";
+
+		led_power_green: led-0 {
+			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			default-state = "on";
+		};
+
+		led-1 {
+			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		led-2 {
+			gpios = <&ath9k 2 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN_ONLINE;
+		};
+
+		led-3 {
+			gpios = <&ath9k 3 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WAN_ONLINE;
+		};
+
+		led-4 {
+			gpios = <&ath9k 4 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-5 {
+			gpios = <&ath9k 5 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+		};
+
+		led-6 {
+			gpios = <&ath9k 6 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led-7 {
+			gpios = <&ath9k 7 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+		};
+
+		led-8 {
+			gpios = <&ath9k 12 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = "tv";
+		};
+
+		led-9 {
+			gpios = <&ath9k 13 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = "tv";
+		};
+	};
+
+	regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb-vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 20 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/*
+			 * since the OEM bootloader requires unknown
+			 * filesystem on firmware area, needs to be
+			 * replaced to u-boot before OpenWrt installation
+			 */
+			partition@0 {
+				label = "bootloader";
+				reg = <0x000000 0x020000>;
+			};
+
+			/* not compatible with u-boot */
+			partition@20000 {
+				label = "config";
+				reg = <0x020000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
+			};
+
+			partition@30000 {
+				label = "art";
+				reg = <0x030000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+					cal_art_5000: calibration@5000 {
+						reg = <0x5000 0x440>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x07a00000 /* PORT0_PAD_MODE_CTRL */
+			0x08 0x00000000 /* PORT5_PAD_MODE_CTRL */
+			0x0c 0x00000000 /* PORT6_PAD_MODE_CTRL */
+			0x10 0x81000080 /* POWER_ON_STRAP */
+			0x50 0xcf37cf37 /* LED_CTRL0 */
+			0x54 0x00000000 /* LED_CTRL1 */
+			0x58 0x00000000 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+
+	nvmem-cells = <&macaddr_config_6>;
+	nvmem-cell-names = "mac-address";
+
+	gmac-config {
+		device = <&gmac>;
+
+		rgmii-gmac0 = <1>;
+		rxdv-delay = <0>;
+		rxd-delay = <0>;
+		txd-delay = <0>;
+		txen-delay = <0>;
+	};
+};
+
+&gpio {
+	switch-reset {
+		gpio-hog;
+		gpios = <13 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,0030";
+		reg = <0x0000 0 0 0 0>;
+		#gpio-cells = <2>;
+		gpio-controller;
+
+		nvmem-cells = <&cal_art_5000>;
+		nvmem-cell-names = "calibration";
+
+		usb-hub-reset {
+			gpio-hog;
+			gpios = <10 GPIO_ACTIVE_HIGH>;
+			output-high;
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	dr_mode = "host";
+
+	/delete-node/ port@1;
+
+	/* NEC uPD720114 */
+	hub@1 {
+		compatible = "usb0409,005a";
+		reg = <1>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
+};

--- a/target/linux/ath79/dts/ar9344_nec_wg600hp.dts
+++ b/target/linux/ath79/dts/ar9344_nec_wg600hp.dts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_nec_aterm.dtsi"
+
+/ {
+	compatible = "nec,wg600hp", "qca,ar9344";
+	model = "NEC Aterm WG600HP";
+};
+
+&partitions {
+	partition@40000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x040000 0x7c0000>;
+	};
+};

--- a/target/linux/ath79/dts/ar9344_nec_wr8750n.dts
+++ b/target/linux/ath79/dts/ar9344_nec_wr8750n.dts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_nec_aterm.dtsi"
+
+/ {
+	compatible = "nec,wr8750n", "qca,ar9344";
+	model = "NEC Aterm WR8750N";
+};
+
+&partitions {
+	partition@40000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x040000 0x7c0000>;
+	};
+};

--- a/target/linux/ath79/dts/ar9344_nec_wr9500n.dts
+++ b/target/linux/ath79/dts/ar9344_nec_wr9500n.dts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_nec_aterm.dtsi"
+
+/ {
+	compatible = "nec,wr9500n", "qca,ar9344";
+	model = "NEC Aterm WR9500N";
+};
+
+&keys {
+	switch-converter {
+		label = "cnv";
+		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		linux,code = <BTN_2>;
+		debounce-interval = <60>;
+	};
+};
+
+&ath9k_leds {
+	led-10 {
+		gpios = <&ath9k 14 GPIO_ACTIVE_LOW>;
+		color = <LED_COLOR_ID_GREEN>;
+		function = "converter";
+	};
+
+	led-11 {
+		gpios = <&ath9k 15 GPIO_ACTIVE_LOW>;
+		color = <LED_COLOR_ID_RED>;
+		function = "converter";
+	};
+};
+
+&partitions {
+	partition@40000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x040000 0xfc0000>;
+	};
+};

--- a/target/linux/ath79/image/common-nec.mk
+++ b/target/linux/ath79/image/common-nec.mk
@@ -1,0 +1,25 @@
+DEVICE_VARS += NEC_FW_TYPE
+
+define Build/nec-usbaterm-fw
+  $(STAGING_DIR_HOST)/bin/nec-usbatermfw $@.new -t $(NEC_FW_TYPE) $(1)
+  mv $@.new $@
+endef
+
+define Device/nec-netbsd-aterm
+  DEVICE_VENDOR := NEC
+  LOADER_TYPE := bin
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
+  ARTIFACTS := uboot.bin
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  COMPILE := loader-$(1).bin
+  COMPILE/loader-$(1).bin := loader-okli-compile
+  ARTIFACTS += initramfs-factory.bin
+  ARTIFACT/initramfs-factory.bin := append-image-stage initramfs-kernel.bin | \
+	pad-to 4 skip=16 | \
+	nec-usbaterm-fw -f 0x0003 -d $$(KDIR)/loader-$(1).bin -d $$$$@ | check-size
+endif
+  UBOOT_PATH := $$(STAGING_DIR_IMAGE)/$$(SOC)_nec_aterm-u-boot.bin
+  ARTIFACT/uboot.bin := append-uboot | check-size 128k
+  DEVICE_PACKAGES := kmod-usb2 -uboot-envtools
+endef

--- a/target/linux/ath79/image/lzma-loader/src/board.c
+++ b/target/linux/ath79/image/lzma-loader/src/board.c
@@ -213,9 +213,74 @@ static inline void huawei_ap_init(void)
 static inline void huawei_ap_init(void) {}
 #endif
 
+#if defined(CONFIG_BOARD_NEC_WR8750N)
+
+#define AR934X_PLL_SWITCH_CLK_CTRL_REG			0x24
+#define AR934X_PLL_SWITCH_CLK_CTRL_SWITCHCLK_SEL	BIT(0)
+
+static inline void nec_aterm_init(void)
+{
+	unsigned int reg, val;
+
+	printf("NEC Aterm series (AR9344)\n");
+
+	/* set REFCLK=40MHz to switch PLL */
+	reg = KSEG1ADDR(AR71XX_PLL_BASE);
+	val = READREG(reg + AR934X_PLL_SWITCH_CLK_CTRL_REG);
+	val &= ~AR934X_PLL_SWITCH_CLK_CTRL_SWITCHCLK_SEL;
+	WRITEREG(reg + AR934X_PLL_SWITCH_CLK_CTRL_REG, val);
+
+	reg = KSEG1ADDR(AR71XX_RESET_BASE);
+#ifndef LOADADDR
+	/*
+	 * This is for initramfs-factory image.
+	 * When the system was reset by power source or FULL_CHIP_RESET
+	 * and started from the OEM bootloader with a dummy tp data
+	 * (this loader), reset again by timeout of the watchdog timer
+	 * to load an actual OpenWrt initramfs image in firmware block
+	 * in a factory image.
+	 * Note: On the stock firmware, TP block contains a POST function
+	 *       and sub commands of "tp" command.
+	 *
+	 * Behaviors of OEM bootloader:
+	 *
+	 * - reset by watchdog (ex.: rebooting on the stock firmware):
+	 *   called as "SOFT-RESET", boot a firmware without POST
+	 *
+	 * - reset by FULL_CHIP_RESET (or powering on):
+	 *   called as "HARD-RESET", run POST and boot a firmware
+	 */
+	printf("\n## booted with dummy tp (lzma-loader),"
+	       " waiting reset... (count: 0x%08x) ##\n",
+	       READREG(reg + AR71XX_RESET_REG_WDOG));
+	while (1);
+#endif
+	/*
+	 * set maximum watchdog count to avoid reset while
+	 * booting from stock bootloader
+	 */
+	WRITEREG(reg + AR71XX_RESET_REG_WDOG, 0xffffffff);
+
+	/*
+	 * deassert some RESET bits not handled by drivers
+	 * and mainline U-Boot
+	 *
+	 * - ETH_SWITCH(_ANALOG): eth0
+	 * - RTC                : wmac
+	 */
+	val = READREG(reg + AR934X_RESET_REG_RESET_MODULE);
+	val &= ~(AR934X_RESET_ETH_SWITCH | AR934X_RESET_ETH_SWITCH_ANALOG |
+		 AR934X_RESET_RTC);
+	WRITEREG(reg + AR934X_RESET_REG_RESET_MODULE, val);
+}
+#else
+static inline void nec_aterm_init(void) {}
+#endif
+
 void board_init(void)
 {
 	tlwr1043nd_init();
 	mr18_init();
 	huawei_ap_init();
+	nec_aterm_init();
 }

--- a/target/linux/ath79/image/lzma-loader/src/board.c
+++ b/target/linux/ath79/image/lzma-loader/src/board.c
@@ -213,7 +213,8 @@ static inline void huawei_ap_init(void)
 static inline void huawei_ap_init(void) {}
 #endif
 
-#if defined(CONFIG_BOARD_NEC_WR8750N) || \
+#if defined(CONFIG_BOARD_NEC_WG600HP) || \
+    defined(CONFIG_BOARD_NEC_WR8750N) || \
     defined(CONFIG_BOARD_NEC_WR9500N)
 
 #define AR934X_PLL_SWITCH_CLK_CTRL_REG			0x24

--- a/target/linux/ath79/image/lzma-loader/src/board.c
+++ b/target/linux/ath79/image/lzma-loader/src/board.c
@@ -213,7 +213,8 @@ static inline void huawei_ap_init(void)
 static inline void huawei_ap_init(void) {}
 #endif
 
-#if defined(CONFIG_BOARD_NEC_WR8750N)
+#if defined(CONFIG_BOARD_NEC_WR8750N) || \
+    defined(CONFIG_BOARD_NEC_WR9500N)
 
 #define AR934X_PLL_SWITCH_CLK_CTRL_REG			0x24
 #define AR934X_PLL_SWITCH_CLK_CTRL_SWITCHCLK_SEL	BIT(0)

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -131,6 +131,16 @@ define Device/nec_wr8750n
 endef
 TARGET_DEVICES += nec_wr8750n
 
+define Device/nec_wr9500n
+  SOC := ar9344
+  DEVICE_MODEL := Aterm WR9500N
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 16128k
+  NEC_FW_TYPE := H033
+  $(Device/nec-netbsd-aterm)
+endef
+TARGET_DEVICES += nec_wr9500n
+
 define Device/pqi_air-pen
   SOC := ar9330
   DEVICE_VENDOR := PQI

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -121,6 +121,16 @@ define Device/engenius_enh202-v1
 endef
 TARGET_DEVICES += engenius_enh202-v1
 
+define Device/nec_wg600hp
+  DEVICE_MODEL := Aterm WG600HP
+  SOC := ar9344
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 7936k
+  NEC_FW_TYPE := H044
+  $(Device/nec-netbsd-aterm)
+endef
+TARGET_DEVICES += nec_wg600hp
+
 define Device/nec_wr8750n
   SOC := ar9344
   DEVICE_MODEL := Aterm WR8750N

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -1,4 +1,5 @@
 include ./common-buffalo.mk
+include ./common-nec.mk
 include ./common-senao.mk
 
 define Device/buffalo_whr-g301n
@@ -119,6 +120,16 @@ define Device/engenius_enh202-v1
   DEFAULT := n
 endef
 TARGET_DEVICES += engenius_enh202-v1
+
+define Device/nec_wr8750n
+  SOC := ar9344
+  DEVICE_MODEL := Aterm WR8750N
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 7936k
+  NEC_FW_TYPE := H033a
+  $(Device/nec-netbsd-aterm)
+endef
+TARGET_DEVICES += nec_wr8750n
 
 define Device/pqi_air-pen
   SOC := ar9330

--- a/target/linux/ath79/patches-6.6/317-MIPS-pci-ar724x-clear-power-down-of-pll-on-AR934x.patch
+++ b/target/linux/ath79/patches-6.6/317-MIPS-pci-ar724x-clear-power-down-of-pll-on-AR934x.patch
@@ -1,0 +1,34 @@
+From f2ca10b22ace3ce53b4e3f189bf1dd53a4482475 Mon Sep 17 00:00:00 2001
+From: INAGAKI Hiroshi <musashino.open@gmail.com>
+Date: Fri, 26 Apr 2024 23:53:58 +0900
+Subject: [PATCH 1/2] MIPS: pci-ar724x: clear power down of pll on AR934x
+
+Fix PCIe initialization on AR934x by clearing PLL_PWD bit in addition to
+PPL_RESET bit of AR724x.
+
+Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+---
+
+--- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
++++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
+@@ -347,6 +347,8 @@
+ #define AR934X_PLL_CPU_DDR_CLK_CTRL_DDRCLK_FROM_DDRPLL	BIT(21)
+ #define AR934X_PLL_CPU_DDR_CLK_CTRL_AHBCLK_FROM_DDRPLL	BIT(24)
+ 
++#define AR934X_PLL_PCIE_CONFIG_PLL_PWD		BIT(30)
++
+ #define AR934X_PLL_SWITCH_CLOCK_CONTROL_MDIO_CLK_SEL	BIT(6)
+ 
+ #define QCA953X_PLL_CPU_CONFIG_REG		0x00
+--- a/arch/mips/pci/pci-ar724x.c
++++ b/arch/mips/pci/pci-ar724x.c
+@@ -360,7 +360,8 @@ static void ar724x_pci_hw_init(struct ar
+ 	} else {
+ 		/* remove the reset of the PCIE PLL */
+ 		ppl = ath79_pll_rr(AR724X_PLL_REG_PCIE_CONFIG);
+-		ppl &= ~AR724X_PLL_REG_PCIE_CONFIG_PPL_RESET;
++		ppl &= ~(AR934X_PLL_PCIE_CONFIG_PLL_PWD |
++			 AR724X_PLL_REG_PCIE_CONFIG_PPL_RESET);
+ 		ath79_pll_wr(AR724X_PLL_REG_PCIE_CONFIG, ppl);
+ 
+ 		/* deassert bypass for the PCIE PLL */

--- a/target/linux/ath79/patches-6.6/318-MIPS-pci-ar724x-deassert-the-reset-of-PCIe-endpoint.patch
+++ b/target/linux/ath79/patches-6.6/318-MIPS-pci-ar724x-deassert-the-reset-of-PCIe-endpoint.patch
@@ -1,0 +1,41 @@
+From 859c93981a8994ffa69967b44b247d2e7d6a01f1 Mon Sep 17 00:00:00 2001
+From: INAGAKI Hiroshi <musashino.open@gmail.com>
+Date: Fri, 26 Apr 2024 23:54:57 +0900
+Subject: [PATCH 2/2] MIPS: pci-ar724x: deassert the reset of PCIe endpoint
+
+Fix PCIe initialization by de-assertion of PCIe endpoint reset.
+
+Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+---
+
+--- a/arch/mips/pci/pci-ar724x.c
++++ b/arch/mips/pci/pci-ar724x.c
+@@ -25,6 +25,7 @@
+ 
+ #define AR724X_PCI_APP_LTSSM_ENABLE	BIT(0)
+ 
++#define AR724X_PCI_RESET_EP_RESET_L	BIT(2)
+ #define AR724X_PCI_RESET_LINK_UP	BIT(0)
+ 
+ #define AR724X_PCI_INT_DEV0		BIT(14)
+@@ -340,7 +341,7 @@ static void ar724x_pci_irq_init(struct a
+ 
+ static void ar724x_pci_hw_init(struct ar724x_pci_controller *apc)
+ {
+-	u32 ppl, app;
++	u32 ppl, rst, app;
+ 	int wait = 0;
+ 
+ 	/* deassert PCIe host controller and PCIe PHY reset */
+@@ -370,6 +371,11 @@ static void ar724x_pci_hw_init(struct ar
+ 		ath79_pll_wr(AR724X_PLL_REG_PCIE_CONFIG, ppl);
+ 	}
+ 
++	/* deassert the reset state of the PCIE endpoint */
++	rst = __raw_readl(apc->ctrl_base + AR724X_PCI_REG_RESET);
++	rst |= AR724X_PCI_RESET_EP_RESET_L;
++	__raw_writel(rst, apc->ctrl_base + AR724X_PCI_REG_RESET);
++
+ 	/* set PCIE Application Control to ready */
+ 	app = __raw_readl(apc->ctrl_base + AR724X_PCI_REG_APP);
+ 	app |= AR724X_PCI_APP_LTSSM_ENABLE;

--- a/target/linux/ath79/patches-6.6/330-missing-registers.patch
+++ b/target/linux/ath79/patches-6.6/330-missing-registers.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] ath79: gmac: add parsers for rxd(v)- and tx(d|en)-delay for
 
 --- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
 +++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
-@@ -1231,6 +1231,10 @@
+@@ -1233,6 +1233,10 @@
  #define AR934X_ETH_CFG_RDV_DELAY        BIT(16)
  #define AR934X_ETH_CFG_RDV_DELAY_MASK   0x3
  #define AR934X_ETH_CFG_RDV_DELAY_SHIFT  16

--- a/target/linux/ath79/patches-6.6/331-MIPS-ath79-add-missing-QCA955x-GMAC-registers.patch
+++ b/target/linux/ath79/patches-6.6/331-MIPS-ath79-add-missing-QCA955x-GMAC-registers.patch
@@ -16,7 +16,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 
 --- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
 +++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
-@@ -1251,7 +1251,12 @@
+@@ -1253,7 +1253,12 @@
   */
  
  #define QCA955X_GMAC_REG_ETH_CFG	0x00
@@ -29,7 +29,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  
  #define QCA955X_ETH_CFG_RGMII_EN	BIT(0)
  #define QCA955X_ETH_CFG_MII_GE0		BIT(1)
-@@ -1273,9 +1278,58 @@
+@@ -1275,9 +1280,58 @@
  #define QCA955X_ETH_CFG_TXE_DELAY_MASK	0x3
  #define QCA955X_ETH_CFG_TXE_DELAY_SHIFT	20
  

--- a/target/linux/ath79/patches-6.6/332-ath79-sgmii-config.patch
+++ b/target/linux/ath79/patches-6.6/332-ath79-sgmii-config.patch
@@ -21,7 +21,7 @@ Submitted-by: David Bauer <mail@david-bauer.net>
 
 --- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
 +++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
-@@ -1380,5 +1380,6 @@
+@@ -1382,5 +1382,6 @@
  
  #define QCA956X_SGMII_CONFIG_MODE_CTRL_SHIFT	0
  #define QCA956X_SGMII_CONFIG_MODE_CTRL_MASK	0x7

--- a/target/linux/ath79/patches-6.6/360-MIPS-ath79-export-UART1-reference-clock.patch
+++ b/target/linux/ath79/patches-6.6/360-MIPS-ath79-export-UART1-reference-clock.patch
@@ -45,8 +45,8 @@ Submitted-by: Daniel Golle <daniel@makrotopia.org>
  		goto err_iounmap;
 --- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
 +++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
-@@ -348,6 +348,7 @@
- #define AR934X_PLL_CPU_DDR_CLK_CTRL_AHBCLK_FROM_DDRPLL	BIT(24)
+@@ -350,6 +350,7 @@
+ #define AR934X_PLL_PCIE_CONFIG_PLL_PWD		BIT(30)
  
  #define AR934X_PLL_SWITCH_CLOCK_CONTROL_MDIO_CLK_SEL	BIT(6)
 +#define AR934X_PLL_SWITCH_CLOCK_CONTROL_UART1_CLK_SEL	BIT(7)

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -69,6 +69,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "4:lan:1"
 		;;
+	nec,wr8750n|\
+	tplink,tl-wr941n-v7-cn)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
+		;;
 	tplink,tl-mr3220-v1|\
 	tplink,tl-mr3420-v1|\
 	tplink,tl-mr3420-v3|\
@@ -104,10 +109,6 @@ ath79_setup_interfaces()
 		;;
 	tplink,tl-wr941-v2)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
-		;;
-	tplink,tl-wr941n-v7-cn)
-		ucidef_add_switch "switch0" \
-			"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
 		;;
 	ubnt,airrouter)
 		ucidef_set_interface_wan "eth1"
@@ -151,6 +152,10 @@ ath79_setup_macs()
 	ubnt,nanostation-m|\
 	ubnt,picostation-m)
 		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
+		;;
+	nec,wr8750n)
+		wan_mac=$(mtd_get_mac_binary config 0xc)
+		label_mac=$wan_mac
 		;;
 	tplink,tl-wr941-v2|\
 	tplink,tl-wr941n-v7-cn)

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -69,6 +69,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "4:lan:1"
 		;;
+	nec,wg600hp|\
 	nec,wr8750n|\
 	nec,wr9500n|\
 	tplink,tl-wr941n-v7-cn)
@@ -154,6 +155,7 @@ ath79_setup_macs()
 	ubnt,picostation-m)
 		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;
+	nec,wg600hp|\
 	nec,wr8750n|\
 	nec,wr9500n)
 		wan_mac=$(mtd_get_mac_binary config 0xc)

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -70,6 +70,7 @@ ath79_setup_interfaces()
 			"0@eth1" "4:lan:1"
 		;;
 	nec,wr8750n|\
+	nec,wr9500n|\
 	tplink,tl-wr941n-v7-cn)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
@@ -153,7 +154,8 @@ ath79_setup_macs()
 	ubnt,picostation-m)
 		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;
-	nec,wr8750n)
+	nec,wr8750n|\
+	nec,wr9500n)
 		wan_mac=$(mtd_get_mac_binary config 0xc)
 		label_mac=$wan_mac
 		;;

--- a/target/linux/ath79/tiny/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/tiny/base-files/lib/upgrade/platform.sh
@@ -9,7 +9,21 @@ RAMFS_COPY_BIN='fw_setenv'
 RAMFS_COPY_DATA='/etc/fw_env.config'
 
 platform_check_image() {
-	return 0
+	local board=$(board_name)
+
+	case "$board" in
+	nec,wr8750n)
+		local uboot_mtd=$(find_mtd_part "bootloader")
+
+		# check "U-Boot <year>.<month>" string in the "bootloader" partition
+		if ! grep -q "U-Boot [0-9]\{4\}\.[0-9]\{2\}" $uboot_mtd; then
+			v "The bootloader doesn't seem to be replaced to U-Boot!"
+			return 1
+		fi
+		;;
+	*)
+		return 0
+	esac
 }
 
 platform_do_upgrade() {

--- a/target/linux/ath79/tiny/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/tiny/base-files/lib/upgrade/platform.sh
@@ -12,6 +12,7 @@ platform_check_image() {
 	local board=$(board_name)
 
 	case "$board" in
+	nec,wg600hp|\
 	nec,wr8750n|\
 	nec,wr9500n)
 		local uboot_mtd=$(find_mtd_part "bootloader")

--- a/target/linux/ath79/tiny/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/tiny/base-files/lib/upgrade/platform.sh
@@ -12,7 +12,8 @@ platform_check_image() {
 	local board=$(board_name)
 
 	case "$board" in
-	nec,wr8750n)
+	nec,wr8750n|\
+	nec,wr9500n)
 		local uboot_mtd=$(find_mtd_part "bootloader")
 
 		# check "U-Boot <year>.<month>" string in the "bootloader" partition


### PR DESCRIPTION
This PR adds U-Boot package for ath79 and support for NEC Aterm devices based on AR9344.