### PR TITLE
gperf: build as C++11

### DIFF
--- a/package/devel/gperf/Makefile
+++ b/package/devel/gperf/Makefile
@@ -17,6 +17,8 @@ include $(INCLUDE_DIR)/package.mk
 HOST_CPPFLAGS:=-I$(HOST_BUILD_DIR)/lib -I$(HOST_BUILD_DIR)/src $(HOST_CPPFLAGS)
 TARGET_CPPFLAGS:=-I$(PKG_BUILD_DIR)/lib -I$(PKG_BUILD_DIR)/src $(TARGET_CPPFLAGS)
 
+HOST_CXXFLAGS += -std=c++11
+
 define Package/gperf
   SECTION:=devel
   CATEGORY:=Development


### PR DESCRIPTION
Newer compilers default to building with C++17 as default, which has the register keyword removed and thus errors.

Fixes compilation on at least Fedora 40.

ping @robimarko 