### PR TITLE
[23.05]  ipq40xx: whw03v2: backport RGB LED fixes

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-whw03v2.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-whw03v2.dts
@@ -13,7 +13,7 @@
 	aliases {
 		led-boot = &led_blue;
 		led-failsafe = &led_red;
-		led-running = &led_green;
+		led-running = &led_blue;
 		led-upgrade = &led_red;
 	};
 

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-whw03v2.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-whw03v2.dts
@@ -278,7 +278,6 @@
 			label = "red";
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_INDICATOR;
-			linux,default-trigger = "none";
 			reg = <0>;
 		};
 
@@ -286,7 +285,6 @@
 			label = "green";
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_INDICATOR;
-			linux,default-trigger = "none";
 			reg = <1>;
 		};
 
@@ -294,7 +292,6 @@
 			label = "blue";
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_INDICATOR;
-			linux,default-trigger = "default-on";
 			reg = <2>;
 		};
 	};


### PR DESCRIPTION
@Ansuel 

WHW03 V2 was unable to control its LEDs due to a bug.

as a workaround, `linux,default-trigger = "default-on";` was added to its blue led in the DTS, to at least have a LED shining while the device was powered on. (otherwise the device would go totally dark.)

now the LED bugfix was backported to 23.05 (https://github.com/openwrt/openwrt/commit/7606dac661f60d378d2cf42c6434811e6234f252), which means that the workaround has to be removed to restore good behavior.

thanks!