### PR TITLE
ipq806x: rt4230w-rev6: fix status reporting via the LEDs

### DIFF
--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-rt4230w-rev6.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-rt4230w-rev6.dts
@@ -14,10 +14,10 @@
 	};
 
 	aliases {
-		led-boot = &ledctrl3;
+		led-boot = &ledctrl1;
 		led-failsafe = &ledctrl1;
-		led-running = &ledctrl2;
-		led-upgrade = &ledctrl3;
+		led-running = &ledctrl3;
+		led-upgrade = &ledctrl1;
 	};
 
 	chosen {
@@ -55,6 +55,7 @@
 		ledctrl2: ledctrl2 {
 			label = "ledctrl2";
 			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "default-on";
 		};
 
 		ledctrl3: ledctrl3 {


### PR DESCRIPTION
There is a custom LED controller between the 3 SoC GPIO outputs and the red and blue LEDs of the device. It implements a strange mapping that includes fixed, flashing, and breathing modes.

The current DTS configuration causes OpenWrt to flash the LEDs over the controller's own flashing, resulting in chaotic output in boot, failsafe, and upgrade modes.

This change fixes the LEDs in the best way possible as long as each OpenWrt running state is limited to be signaled by a single led.

-----

FYI, i documented the modes provided by the led controller here:
https://openwrt.org/inbox/toh/askey/rt4230w_rev6#leds

-----

### videos

these videos show the bootloader, failsafe wait, and normal boot phases of openwrt boot.

- current behavior:
  - chaotic flashing during failsafe wait and normal boot (and also during sysupgrade, not shown).
  - after boot, the device breaths in blue (solid blue was not possible with a single GPIO).

https://github.com/openwrt/openwrt/assets/3977813/392cdd4a-00cd-437b-bc43-861f7152b56c

- with this change:
  - correct flashing during all stages, including sysupgrade (but flashing must be done in red).
  - after boot, the device is solid blue.

https://github.com/openwrt/openwrt/assets/3977813/b3d873d3-d567-4dc1-8ccf-075bf4eea934
