### PR TITLE
ipq40xx: fixup remaining devices that dont use QCA807x PHY

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
@@ -243,6 +243,18 @@
 
 &mdio {
 	status = "okay";
+
+	ar8035: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&qca807x {
+	status = "disabled";
+};
+
+&ethphy0 {
+	status = "disabled";
 };
 
 &ethphy1 {
@@ -279,6 +291,6 @@
 	status = "okay";
 
 	label = "lan";
-	phy-handle = <&ethphy0>;
+	phy-handle = <&ar8035>;
 	phy-mode = "rgmii-id";
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-aruba-glenmorangie.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-aruba-glenmorangie.dtsi
@@ -232,6 +232,10 @@
 	phy-mode = "rgmii-id";
 };
 
+&qca807x {
+	status = "disabled";
+};
+
 &ethphy0 {
 	status = "disabled";
 };

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
@@ -401,6 +401,10 @@
 	status = "okay";
 	pinctrl-0 = <&mdio_pins>;
 	pinctrl-names = "default";
+
+	ar8035: ethernet-phy@1 {
+		reg = <1>;
+	};
 };
 
 &gmac {
@@ -419,11 +423,19 @@
 	status = "okay";
 
 	label = "lan";
-	phy-handle = <&ethphy1>;
+	phy-handle = <&ar8035>;
 	phy-mode = "rgmii-rxid";
 };
 
+&qca807x {
+	status = "disabled";
+};
+
 &ethphy0 {
+	status = "disabled";
+};
+
+&ethphy1 {
 	status = "disabled";
 };
 


### PR DESCRIPTION
Like AVM 1200 these devices also do not use QCA807x PHY at all and thus they disables all of the individual PHY nodes, however this is not enough anymore since the conversion to PHY package.

Now its now enough to disable the PHY-s in the package alone, but the PHY package node itself must also be disabled.

Fixes: 1b931c33a28e ("ipq40xx: adapt to new Upstream QCA807x PHY driver")
