### PR TITLE
ramips: move RB760iGS PoE Passthrough GPIO export to DT

### DIFF
--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-760igs.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-760igs.dts
@@ -38,6 +38,14 @@
 	};
 };
 
+&gpio_export {
+	poe_passthrough {
+		gpio-export,name = "poe_passthrough";
+		gpio-export,output = <0>;
+		gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+	};
+};
+
 &mdio {
 	ephy7: ethernet-phy@7 {
 		reg = <7>;

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-7xx.dtsi
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-7xx.dtsi
@@ -3,7 +3,7 @@
 #include "mt7621_mikrotik.dtsi"
 
 / {
-	gpio_export {
+	gpio_export: gpio_export {
 		compatible = "gpio-export";
 		#size-cells = <0>;
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -7,7 +7,7 @@ board=$(board_name)
 
 case "$board" in
 mikrotik,routerboard-760igs)
-	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "497"
+	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "poe_passthrough"
 	;;
 telco-electronics,x1)
 	ucidef_add_gpio_switch "modem_reset" "Modem Reset" "496"


### PR DESCRIPTION
I'm unsure if it is due to the switch to kernel v6.6, but the GPIO export in /etc/board.d does not fit in the allocated GPIOs, because likely the GPIO base has changed due to the kernel update. To avoid this issue in the future, move the GPIO export to the DT, to be independent of the GPIO base.