### PR TITLE
generic: fix realtek PHY detection patch

### DIFF
--- a/target/linux/generic/pending-5.15/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-5.15/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -13,7 +13,15 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
-@@ -744,6 +744,38 @@ static int rtl8226_match_phy_device(stru
+@@ -79,6 +79,7 @@
+ #define RTLGEN_SPEED_MASK			0x0630
+ 
+ #define RTL_GENERIC_PHYID			0x001cc800
++#define RTL_8221B_VB_CG_PHYID			0x001cc849
+ 
+ MODULE_DESCRIPTION("Realtek PHY driver");
+ MODULE_AUTHOR("Johnson Leung");
+@@ -744,6 +745,38 @@ static int rtl8226_match_phy_device(stru
  	       rtlgen_supports_2_5gbps(phydev);
  }
  
@@ -46,13 +54,13 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +		id |= val;
 +	}
 +
-+	return (id == 0x001cc849);
++	return (id == RTL_8221B_VB_CG_PHYID);
 +}
 +
  static int rtl822x_probe(struct phy_device *phydev)
  {
  	struct device *dev = &phydev->mdio.dev;
-@@ -1082,7 +1114,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1082,7 +1115,7 @@ static struct phy_driver realtek_drvs[]
  		.write_page     = rtl821x_write_page,
  		.soft_reset     = genphy_soft_reset,
  	}, {

--- a/target/linux/generic/pending-5.15/731-net-phy-realtek-support-interrupt-of-RTL8221B.patch
+++ b/target/linux/generic/pending-5.15/731-net-phy-realtek-support-interrupt-of-RTL8221B.patch
@@ -12,7 +12,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
 
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
-@@ -971,6 +971,51 @@ static int rtl8221b_config_init(struct p
+@@ -972,6 +972,51 @@ static int rtl8221b_config_init(struct p
  	return 0;
  }
  
@@ -64,7 +64,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  static struct phy_driver realtek_drvs[] = {
  	{
  		PHY_ID_MATCH_EXACT(0x00008201),
-@@ -1119,6 +1164,8 @@ static struct phy_driver realtek_drvs[]
+@@ -1120,6 +1165,8 @@ static struct phy_driver realtek_drvs[]
  		.get_features   = rtl822x_get_features,
  		.config_init    = rtl8221b_config_init,
  		.config_aneg    = rtl822x_config_aneg,

--- a/target/linux/generic/pending-6.1/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.1/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -13,7 +13,15 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
-@@ -754,6 +754,38 @@ static int rtl8226_match_phy_device(stru
+@@ -80,6 +80,7 @@
+ 
+ #define RTL_GENERIC_PHYID			0x001cc800
+ #define RTL_8211FVD_PHYID			0x001cc878
++#define RTL_8221B_VB_CG_PHYID			0x001cc849
+ 
+ MODULE_DESCRIPTION("Realtek PHY driver");
+ MODULE_AUTHOR("Johnson Leung");
+@@ -754,6 +755,38 @@ static int rtl8226_match_phy_device(stru
  	       rtlgen_supports_2_5gbps(phydev);
  }
  
@@ -46,13 +54,13 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +		id |= val;
 +	}
 +
-+	return (id == 0x001cc849);
++	return (id == RTL_8221B_VB_CG_PHYID);
 +}
 +
  static int rtl822x_probe(struct phy_device *phydev)
  {
  	struct device *dev = &phydev->mdio.dev;
-@@ -1104,7 +1136,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1104,7 +1137,7 @@ static struct phy_driver realtek_drvs[]
  		.write_page     = rtl821x_write_page,
  		.soft_reset     = genphy_soft_reset,
  	}, {

--- a/target/linux/generic/pending-6.1/741-net-phy-realtek-support-interrupt-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.1/741-net-phy-realtek-support-interrupt-of-RTL8221B.patch
@@ -12,7 +12,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
 
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
-@@ -981,6 +981,51 @@ static int rtl8221b_config_init(struct p
+@@ -982,6 +982,51 @@ static int rtl8221b_config_init(struct p
  	return 0;
  }
  
@@ -64,7 +64,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  static struct phy_driver realtek_drvs[] = {
  	{
  		PHY_ID_MATCH_EXACT(0x00008201),
-@@ -1141,6 +1186,8 @@ static struct phy_driver realtek_drvs[]
+@@ -1142,6 +1187,8 @@ static struct phy_driver realtek_drvs[]
  		.get_features   = rtl822x_get_features,
  		.config_init    = rtl8221b_config_init,
  		.config_aneg    = rtl822x_config_aneg,

--- a/target/linux/generic/pending-6.6/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.6/730-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -1,4 +1,4 @@
-From e52faf1564a8bcaf866f9a6c7bf0e8a8748afb15 Mon Sep 17 00:00:00 2001
+From 0de82310d2b32e78ff79d42c08b1122a6ede3778 Mon Sep 17 00:00:00 2001
 From: Daniel Golle <daniel@makrotopia.org>
 Date: Sun, 30 Apr 2023 00:15:41 +0100
 Subject: [PATCH] net: phy: realtek: detect early version of RTL8221B
@@ -10,9 +10,6 @@ Implement custom identify function using the PKGID instead of iterating
 over the implemented MMDs.
 
 Signed-off-by: Daniel Golle <daniel@makrotopia.org>
----
- drivers/net/phy/realtek.c | 50 ++++++++++++++++++++++++++++++++++++++-
- 1 file changed, 49 insertions(+), 1 deletion(-)
 
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
@@ -20,26 +17,18 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  #define RTL_GENERIC_PHYID			0x001cc800
  #define RTL_8211FVD_PHYID			0x001cc878
-+#define RTL_8221B_VB_CG				0x001cc849
++#define RTL_8221B_VB_CG_PHYID			0x001cc849
  
  MODULE_DESCRIPTION("Realtek PHY driver");
  MODULE_AUTHOR("Johnson Leung");
-@@ -801,6 +802,54 @@ static int rtl822x_probe(struct phy_devi
- 	return 0;
+@@ -782,6 +783,38 @@ static int rtl8226_match_phy_device(stru
+ 	       rtlgen_supports_2_5gbps(phydev);
  }
  
 +static int rtl8221b_vb_cg_match_phy_device(struct phy_device *phydev)
 +{
 +	int val;
 +	u32 id;
-+
-+	if (phydev->is_c45) {
-+		if (phydev->c45_ids.device_ids[1])
-+			return phydev->c45_ids.device_ids[1] == RTL_8221B_VB_CG;
-+	} else {
-+		if (phydev->phy_id)
-+			return phydev->phy_id == RTL_8221B_VB_CG;
-+	}
 +
 +	if (phydev->mdio.bus->read_c45) {
 +		val = phy_read_mmd(phydev, MDIO_MMD_PMAPMD, MDIO_PKGID1);
@@ -65,21 +54,13 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +		id |= val;
 +	}
 +
-+	if (id != RTL_8221B_VB_CG)
-+		return 0;
-+
-+	if (phydev->is_c45)
-+		phydev->c45_ids.device_ids[1] = id;
-+	else
-+		phydev->phy_id = id;
-+
-+	return 1;
++	return (id == RTL_8221B_VB_CG_PHYID);
 +}
 +
- static int rtlgen_resume(struct phy_device *phydev)
+ static int rtl822x_probe(struct phy_device *phydev)
  {
- 	int ret = genphy_resume(phydev);
-@@ -1134,7 +1183,7 @@ static struct phy_driver realtek_drvs[]
+ 	struct device *dev = &phydev->mdio.dev;
+@@ -1134,7 +1167,7 @@ static struct phy_driver realtek_drvs[]
  		.write_page     = rtl821x_write_page,
  		.soft_reset     = genphy_soft_reset,
  	}, {

--- a/target/linux/generic/pending-6.6/741-net-phy-realtek-support-interrupt-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.6/741-net-phy-realtek-support-interrupt-of-RTL8221B.patch
@@ -12,7 +12,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
 
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
-@@ -1026,6 +1026,51 @@ static int rtl8221b_config_init(struct p
+@@ -1010,6 +1010,51 @@ static int rtl8221b_config_init(struct p
  	return 0;
  }
  
@@ -64,7 +64,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  static struct phy_driver realtek_drvs[] = {
  	{
  		PHY_ID_MATCH_EXACT(0x00008201),
-@@ -1188,6 +1233,8 @@ static struct phy_driver realtek_drvs[]
+@@ -1172,6 +1217,8 @@ static struct phy_driver realtek_drvs[]
  		.get_features   = rtl822x_get_features,
  		.config_init    = rtl8221b_config_init,
  		.config_aneg    = rtl822x_config_aneg,


### PR DESCRIPTION
Fixes the issue of RTL8221B-VB-CG not being detected correctly.
Reverts changes from f6c27b2, leaving only the read_c45 test.
Additionally, the constant RTL_8221B_VB_CG_PHYID is used instead of a numeric value for all kernels.

Fixed: #15093