### PR TITLE
ramips: use function/color syntax for some dlink dir routers

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-882-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-882-a1.dts
@@ -9,15 +9,19 @@
 };
 
 &leds {
-	usb2 {
-		label = "green:usb2";
+	led-4 {
+		function = LED_FUNCTION_USB;
+		color = <LED_COLOR_ID_GREEN>;
+		function-enumerator = <2>;
 		gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		trigger-sources = <&ehci_port2>;
 		linux,default-trigger = "usbport";
 	};
 
-	usb3 {
-		label = "green:usb3";
+	led-5 {
+		function = LED_FUNCTION_USB;
+		color = <LED_COLOR_ID_GREEN>;
+		function-enumerator = <3>;
 		gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		trigger-sources = <&xhci_ehci_port1>;
 		linux,default-trigger = "usbport";

--- a/target/linux/ramips/dts/mt7621_dlink_dir-882-r1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-882-r1.dts
@@ -9,15 +9,19 @@
 };
 
 &leds {
-	usb2 {
-		label = "green:usb2";
+	led-4 {
+		function = LED_FUNCTION_USB;
+		color = <LED_COLOR_ID_GREEN>;
+		function-enumerator = <2>;
 		gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		trigger-sources = <&ehci_port2>;
 		linux,default-trigger = "usbport";
 	};
 
-	usb3 {
-		label = "green:usb3";
+	led-5 {
+		function = LED_FUNCTION_USB;
+		color = <LED_COLOR_ID_GREEN>;
+		function-enumerator = <3>;
 		gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		trigger-sources = <&xhci_ehci_port1>;
 		linux,default-trigger = "usbport";

--- a/target/linux/ramips/dts/mt7621_dlink_dir-8xx.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-8xx.dtsi
@@ -40,25 +40,27 @@
 	leds: leds {
 		compatible = "gpio-leds";
 
-		led_power_orange: power_orange {
+		led_power_orange: led-0 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_ORANGE>;
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
 		};
 
-		led_power_green: power_green {
+		led_power_green: led-1 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 
-		led_net_orange: net_orange {
-			label = "orange:net";
+		led_net_orange: led-2 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_ORANGE>;
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
 		};
 
-		net_green {
-			label = "green:net";
+		led-3 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/mt7620/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ramips/mt7620/base-files/etc/uci-defaults/04_led_migration
@@ -1,0 +1,17 @@
+. /lib/functions.sh
+. /lib/functions/migrations.sh
+
+board=$(board_name)
+
+case "$board" in
+tplink,archer-c20-v1|\
+tplink,archer-c50-v1)
+	migrate_leds ':wlan2g=:wlan-2ghz' ':wlan5g=:wlan-5ghz'
+	;;
+esac
+
+remove_devicename_leds
+
+migrations_apply system
+
+exit 0

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -91,6 +91,14 @@ dlink,dap-x1860-a1)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimedium" "wlan1" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan1" "76" "100"
 	;;
+dlink,dir-1935-a1|\
+dlink,dir-867-a1|\
+dlink,dir-878-a1|\
+dlink,dir-878-r1|\
+dlink,dir-882-a1|\
+dlink,dir-882-r1)
+	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan"
+	;;
 dlink,dir-1960-a1|\
 dlink,dir-2055-a1|\
 dlink,dir-2150-a1|\
@@ -110,12 +118,7 @@ dlink,dir-853-a3)
 dlink,dir-853-r1)
 	ucidef_set_led_netdev "internet" "internet" "blue:net" "wan"
 	;;
-dlink,dir-1935-a1|\
-dlink,dir-860l-b1|\
-dlink,dir-867-a1|\
-dlink,dir-878-a1|\
-dlink,dir-882-a1|\
-dlink,dir-882-r1)
+dlink,dir-860l-b1)
 	ucidef_set_led_netdev "wan" "wan" "green:net" "wan"
 	;;
 gnubee,gb-pc2)

--- a/target/linux/ramips/mt7621/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ramips/mt7621/base-files/etc/uci-defaults/04_led_migration
@@ -4,12 +4,21 @@
 board=$(board_name)
 
 case "$board" in
+dlink,dir-1935-a1|\
 dlink,dir-1960-a1|\
+dlink,dir-867-a1|\
+dlink,dir-878-a1|\
+dlink,dir-878-r1)
+	migrate_leds ':net=:wan'
+	;;
 dlink,dir-2640-a1|\
 dlink,dir-2660-a1|\
-dlink,dir-3040-a1|\
+dlink,dir-882-a1|\
+dlink,dir-882-r1)
+	migrate_leds ':net=:wan' ':usb2=:usb-2' ':usb3=:usb-3' 
+	;;
 dlink,dir-3060-a1)
-	migrate_leds ':net=:wan'
+	migrate_leds ':net=:wan' ':usb2=:usb-2' ':usb3=:usb-3' ':wlan2g=:wlan-2ghz' ':wlan5glb=:wlan-5ghz-0' ':wlan5ghb=:wlan-5ghz-1'
 	;;
 tplink,archer-a6-v3|\
 tplink,archer-c6-v3)


### PR DESCRIPTION
Abandoning the label and using the function/colour syntax for some d-link
dir series routers: DIR-867-A1, DIR-878-A1, DIR-878-R1, DIR-882-A1,
	DIR-882-R1 and DIR-1935-A1

tested on DIR-878-A1 and DIR-882-A1

add more led migrations for DIR-2640-A1, DIR-2660-A1, DIR-3060-A1

add migrations for archer-c20-v1, archer-c50-v1
