### PR TITLE
mac80211: Add support for RTL8723BE

### DIFF
--- a/package/firmware/linux-firmware/realtek.mk
+++ b/package/firmware/linux-firmware/realtek.mk
@@ -87,6 +87,14 @@ define Package/rtl8723au-firmware/install
 endef
 $(eval $(call BuildPackage,rtl8723au-firmware))
 
+Package/rtl8723be-firmware = $(call Package/firmware-default,RealTek RTL8723BE firmware,,LICENCE.rtlwifi_firmware.txt)
+define Package/rtl8723be-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8723befw_36.bin $(1)/lib/firmware/rtlwifi
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/rtlwifi/rtl8723befw.bin $(1)/lib/firmware/rtlwifi
+endef
+$(eval $(call BuildPackage,rtl8723be-firmware))
+
 Package/rtl8723bu-firmware = $(call Package/firmware-default,RealTek RTL8723BU firmware,,LICENCE.rtlwifi_firmware.txt)
 define Package/rtl8723bu-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/rtlwifi

--- a/package/kernel/mac80211/realtek.mk
+++ b/package/kernel/mac80211/realtek.mk
@@ -1,6 +1,6 @@
 PKG_DRIVERS += \
 	rtlwifi rtlwifi-pci rtlwifi-btcoexist rtlwifi-usb rtl8192c-common \
-	rtl8192ce rtl8192se rtl8192de rtl8192cu rtl8723bs rtl8821ae \
+	rtl8192ce rtl8192se rtl8192de rtl8192cu rtl8723-common rtl8723be rtl8723bs rtl8821ae \
 	rtl8xxxu rtw88 rtw88-pci rtw88-usb rtw88-8821c rtw88-8822b rtw88-8822c \
 	rtw88-8723d rtw88-8821ce rtw88-8821cu rtw88-8822be rtw88-8822bu \
 	rtw88-8822ce rtw88-8822cu rtw88-8723de
@@ -19,6 +19,9 @@ config-$(CONFIG_PACKAGE_RTLWIFI_DEBUG) += RTLWIFI_DEBUG
 
 config-$(call config_package,rtl8xxxu) += RTL8XXXU
 config-y += RTL8XXXU_UNTESTED
+
+config-$(call config_package,rtl8723-common) += RTL8723_COMMON
+config-$(call config_package,rtl8723be) += RTL8723BE
 
 config-$(call config_package,rtl8723bs) += RTL8723BS
 config-y += STAGING
@@ -297,6 +300,22 @@ define KernelPackage/rtw88-8723de
   DEPENDS+= +kmod-rtw88-pci +kmod-rtw88-8723d
   FILES:= $(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8723de.ko
   AUTOLOAD:=$(call AutoProbe,rtw88_8723)
+endef
+
+define KernelPackage/rtl8723-common
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTL8723AE/RTL8723BE common support module
+  DEPENDS+= +kmod-rtlwifi
+  FILES:= $(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtlwifi/rtl8723com/rtl8723-common.ko
+  HIDDEN:=1
+endef
+
+define KernelPackage/rtl8723be
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTL8723AE/RTL8723BE support
+  DEPENDS+= +kmod-rtlwifi-btcoexist +kmod-rtlwifi-pci +kmod-rtl8723-common +rtl8723be-firmware
+  FILES:= $(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtlwifi/rtl8723be/rtl8723be.ko
+  AUTOLOAD:=$(call AutoProbe,rtl8723be)
 endef
 
 define KernelPackage/rtl8723bs


### PR DESCRIPTION
This adds support for the RTL8723BE PCIe Wi-Fi Adapter by adding backports drivers
