### PR TITLE
kernel: qca-ssdk: use bash as shell

### DIFF
--- a/package/kernel/qca-ssdk/Makefile
+++ b/package/kernel/qca-ssdk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qca-ssdk
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/qca-ssdk.git
 PKG_SOURCE_PROTO:=git
@@ -45,6 +45,7 @@ MAKE_FLAGS+= \
 	GCC_VERSION=$(GCC_VERSION) \
 	EXTRA_CFLAGS="-fno-stack-protector -I$(STAGING_DIR)/usr/include" \
 	SoC=$(CONFIG_TARGET_SUBTARGET) \
+	SHELL="$(BASH)" \
 	PTP_FEATURE=disable SWCONFIG_FEATURE=disable \
 	ISISC_ENABLE=disable IN_QCA803X_PHY=FALSE \
 	IN_QCA808X_PHY=FALSE IN_MALIBU_PHY=FALSE \


### PR DESCRIPTION
Currently, trying to compile qca-ssdk on macOS will fail in a weird way: 
`make[6]: *** No rule to make target 'openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/qca-ssdk-2024.04.17~3d060f7a/-n', needed by 'openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-qualcommax_ipq807x/qca-ssdk-2024.04.17~3d060f7a/qca-ssdk.o'. Stop.`

After looking looking at `src_list.dep` from which KBuild cmd_mod will generate the list of objects to compile it looked like:
```
-n /src/adpt/adpt.c
-n
-n
```

Which was rather suspicous so after comparing to the same file but with Fedora as host:
`/src/adpt/adpt.c src/adpt/hppe/adpt_hppe_fdb.c src/adpt/hppe/adpt_hppe_mib.c`

It was clear that echo -n which was used in SSDK-s target.mk was not working as intented, and it looked like the POSIX only version of echo was being used which does not honor -n.

So, after failling to reproduce it externally, replacing the call to echo with a full path to coreutils echo fixed the compilation.

After further debugging, it was determined that SSDK does not honor CONFIG_SHELL like other kernel modules so it was defaulting to /bin/sh as the shell make was calling thus calling the /bin/sh built-in echo which on macOS is the old Bash 3.2 one and it does not respect -n.

So, we have to explicitly pass SHELL=$(BASH) to SSDK to make it use bash like kernel build or other kernel modules.

This is not an issue since on macOS we always build bash anyway.
