### PR TITLE
ath79: qca9563: add support for Amplifi Router HD

### DIFF
--- a/target/linux/ath79/dts/qca9563_ubnt_amplifi-router-hd.dts
+++ b/target/linux/ath79/dts/qca9563_ubnt_amplifi-router-hd.dts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "ubnt,amplifi-router-hd", "qca,qca9563";
+	model = "Ubiquiti AmpliFi Router HD";
+
+	aliases {
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&cal_art_5000>;
+		nvmem-cell-names = "calibration";
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x060000>;
+				read-only;
+			};
+
+			partition@60000 {
+				compatible = "u-boot,env";
+				label = "u-boot-env";
+				reg = <0x060000 0x010000>;
+			};
+
+			partition@70000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x070000 0xb00000>;
+			};
+
+			partition@b70000 {
+				label = "cfg";
+				reg = <0xb70000 0x0c0000>;
+				read-only;
+			};
+
+			partition@c30000 {
+				label = "recovery";
+				reg = <0xc30000 0x3b0000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "prst";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				/* eeprom */
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+					cal_art_5000: calibration@5000 {
+						reg = <0x5000 0x844>;
+					};
+				};
+			};
+
+			partition@1000000 {
+				label = "bs1";
+				reg = <0x1000000 0x010000>;
+			};
+
+			partition@1010000 {
+				label = "bs2";
+				reg = <0x1010000 0x010000>;
+				read-only;
+			};
+
+			partition@1020000 {
+				label = "stats";
+				reg = <0x1020000 0x400000>;
+				read-only;
+			};
+
+			partition@1420000 {
+				label = "fw_inactive";
+				reg = <0x1420000 0xb00000>;
+				read-only;
+			};
+
+			partition@1f20000 {
+				label = "reserved";
+				reg = <0x1f20000 0x0e0000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x00000080 /* AR8327_REG_PAD0_MODE */
+			0x08 0x00000000 /* PORT5 PAD MODE CTRL */
+			0x0c 0x00000000 /* PORT6 PAD MODE CTRL */
+			0x10 0x602613a0 /* AR8327_REG_POWER_ON_STRAP */
+			0x50 0xcc35cc35 /* AR8327_REG_LED_CTRL0 */
+			0x54 0xca35ca35 /* AR8327_REG_LED_CTRL1 */
+			0x58 0xc935c935 /* AR8327_REG_LED_CTRL2 */
+			0x5c 0x03ffff00 /* AR8327_REG_LED_CTRL3 */
+			0x7c 0x0000007e /* AR8327_REG_PORT_STATUS(0) */
+			0x94 0x00001080 /* AR8327_REG_PORT_STATUS(6) */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	
+	pll-data = <0x03000101 0x00000101 0x00001919>;
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+
+	nvmem-cells = <&macaddr_art_0 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0 (-2)>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -554,6 +554,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:1" "3:lan:3" "4:lan:2"
 		;;
+	ubnt,amplifi-router-hd)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan:1" "3:lan:3" "4:lan:2" "5:lan:4" "1:wan"
+		;;
 	ubnt,edgeswitch-5xp)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -18,6 +18,18 @@ define Device/ubnt_aircube-isp
 endef
 TARGET_DEVICES += ubnt_aircube-isp
 
+define Device/ubnt_amplifi-router-hd
+  IMAGE_SIZE := 11264k
+  UBNT_BOARD := AFi-R-HD
+  UBNT_TYPE := AFi-R
+  UBNT_VERSION := 3.6.3
+  SOC := qca9563
+  DEVICE_MODEL := AmpliFi Router HD
+  UBNT_CHIP := qca956x
+  DEVICE_PACKAGES += kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct kmod-usb2
+endef
+TARGET_DEVICES += ubnt_amplifi-router-hd
+
 define Device/ubnt_bullet-ac
   $(Device/ubnt-2wa)
   DEVICE_MODEL := Bullet AC


### PR DESCRIPTION
```
Hardware:
    SoC: Qualcomm Atheros QCA956X ver 1 rev 0
    CPU clock: 775.000 MHz
    Memory: 128 MB DDR2
    Flash: 32 MB SPI NOR mx25l25635e
    Switch: Atheros AR8327 rev. 4
    Ethernet: 5x 10/100/1000 Mbps (1 WAN + 4 LAN)
    Buttons: 1x Reset
    Serial: TX, RX, GND, VCC
    Baudrate: 115200
    Wifi: Qualcomm Atheros qca988x 802.11ac/n - 3x3
          Qualcomm Atheros AR9561 802.11b/g/n - 3x3
    Display: ST7789V or ILI9341V, controlled by stm32f205
```
**Not working:**
    Leds: 1x via a SPI controller
    Display: ST7789V or ILI9341V
    controlled by stm32f205.

**Note:**
    DSA changes are ready, but we have an issue with
    ports not working after 20-30 minutes. So for now
    we use swconfig.

**Installation: serial connection only**
There is a J11 four pin connector. You need to connect TX, RX and GND. You can find very good information about the device here https://github.com/alexanderhenne/AFi-R?tab=readme-ov-file#finding-j11
```
Upgrading via serial port:
1.  Download the kernel initramfs image. Copy the image to a TFTP server
2.  Connect to console on the AP, and connect the LAN1 port to your PC LAN
3.  Stop autoboot to get to U-boot shell 
    Interrupt the autoboot process by pressing any key when prompted
4.  Transfer the kernel image with TFTP 
    Set your ip address on your TFTP server to 192.168.1.254 
    # tftpboot 0x81000000 amplifi-router-hd-initramfs-kernel.bin
5.  Load the image # bootm 0x81000000
6.  SCP sysupgrade image from your PC to the Amplifi HD (If you use a newer mac use scp -O) 
    # scp openwrt-ath79-generic-ubnt_amplifi-router-hd-squashfs-sysupgrade.bin root@192.168.1.1:/tmp/
8.  Write sysupgrade to the firmware partition 
    # mtd write /tmp/openwrt-ath79-generic-ubnt_amplifi-router-hd-squashfs-sysupgrade.bin firmware
9.  Reboot your device # reboot
```
Credit to alexanderhenne for all the information.

Signed-off-by: Kristian Skramstad <kristian+github@83.no>