### PR TITLE
config: add ARM PMUv3 for kernel 6.6

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -50,6 +50,11 @@ config KERNEL_ARM_PMU
 	default y if TARGET_armsr_armv8
 	depends on (arm || aarch64)
 
+config KERNEL_ARM_PMUV3
+	bool
+	default y if TARGET_armsr_armv8
+	depends on (arm_v7 || aarch64) && LINUX_6_6
+
 config KERNEL_RISCV_PMU
 	bool
 	select KERNEL_RISCV_PMU_SBI
@@ -79,6 +84,7 @@ config KERNEL_X86_VSYSCALL_EMULATION
 config KERNEL_PERF_EVENTS
 	bool "Compile the kernel with performance events and counters"
 	select KERNEL_ARM_PMU if (arm || aarch64)
+	select KERNEL_ARM_PMUV3 if (arm_v7 || aarch64) && LINUX_6_6
 	select KERNEL_RISCV_PMU if riscv64
 
 config KERNEL_PROFILING


### PR DESCRIPTION
Kernel 6.6 has moved the ARM PMUv3 driver to drivers/perf and now once KERNEL_ARM_PMU is selected trying to build the kernel will stop with: ARM PMUv3 support (ARM_PMUV3) [N/y/?] (NEW)

So, lets enable ARM_PMUV3 for ARMv7 and ARMv8 architectures if KERNEL_PERF_EVENTS is selected.

Fixes: #15466 
