### PR TITLE
gpio-nct5104d: fix compilation with kernel 6.6

### DIFF
--- a/package/kernel/gpio-nct5104d/src/gpio-nct5104d.c
+++ b/package/kernel/gpio-nct5104d/src/gpio-nct5104d.c
@@ -13,7 +13,7 @@
 #include <linux/init.h>
 #include <linux/platform_device.h>
 #include <linux/io.h>
-#include <linux/gpio.h>
+#include <linux/gpio/driver.h>
 #include <linux/version.h>
 #include <linux/dmi.h>
 #include <linux/string.h>


### PR DESCRIPTION
gpio.h has been deprecated for a while and no longer compiles with 6.6. Include the proper header.

ping @riptidewave93 @Ansuel 