### PR TITLE
ramips: Extending support for RBM33G

### DIFF
--- a/target/linux/ramips/dts/mt7621_mikrotik.dtsi
+++ b/target/linux/ramips/dts/mt7621_mikrotik.dtsi
@@ -27,6 +27,8 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <33000000>;
 
 		partitions: partitions {

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m33g-64m.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m33g-64m.dts
@@ -1,0 +1,142 @@
+#include "mt7621_mikrotik.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-m33g-64m", "mediatek,mt7621-soc";
+	model = "MikroTik RouterBOARD M33G (64 MB flash)";
+
+	aliases {
+		led-boot = &led_usr;
+		led-failsafe = &led_usr;
+		led-running = &led_usr;
+		led-upgrade = &led_usr;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_usr: usr {
+			label = "green:usr";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	pcie0_vcc_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "pcie0_vcc";
+
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	pcie1_vcc_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "pcie1_vcc";
+
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&gpio 10 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	pcie2_vcc_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "pcie2_vcc";
+
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	usb_vcc_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vcc";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
+	};
+};
+
+&spi0 {
+	flash@1 {
+		compatible = "jedec,spi-nor";
+		reg = <1>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		spi-max-frequency = <33000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			// Region <0x0 0x40000> seems reserved by OEM
+
+			partition@40000 {
+				compatible = "mikrotik,minor";
+				label = "firmware";
+				reg = <0x040000 0x03fc0000>;
+			};
+		};
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+};
+
+&mdio {
+	ethphy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "wdt";
+		function = "gpio";
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&i2c {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&uartlite3 {
+	status = "okay";
+};

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m33g.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m33g.dts
@@ -72,6 +72,8 @@
 	flash@1 {
 		compatible = "jedec,spi-nor";
 		reg = <1>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <33000000>;
 
 		partitions {

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1747,6 +1747,14 @@ define Device/mikrotik_routerboard-m33g
 endef
 TARGET_DEVICES += mikrotik_routerboard-m33g
 
+define Device/mikrotik_routerboard-m33g-64m
+  $(Device/MikroTik)
+  DEVICE_MODEL := RouterBOARD M33G (64 MB SPI flash)
+  DEVICE_PACKAGES := -wpad-basic-mbedtls
+  SUPPORTED_DEVICES += mikrotik,rbm33g-64m
+endef
+TARGET_DEVICES += mikrotik_routerboard-m33g-64m
+
 define Device/mqmaker_witi
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/patches-6.1/406-mtd-spi-nor-Add-suport-for-gd25q40c-and-w25q512jvfm.patch
+++ b/target/linux/ramips/patches-6.1/406-mtd-spi-nor-Add-suport-for-gd25q40c-and-w25q512jvfm.patch
@@ -1,0 +1,25 @@
+--- a/drivers/mtd/spi-nor/gigadevice.c
++++ b/drivers/mtd/spi-nor/gigadevice.c
+@@ -50,6 +50,10 @@
+ 		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
+ 			      SPI_NOR_QUAD_READ) },
++	{ "gd25q40c", INFO(0xc84013, 0, 64 * 1024, 8)
++		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
++		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
++			      SPI_NOR_QUAD_READ) },
+ 	{ "gd25q64", INFO(0xc84017, 0, 64 * 1024, 128)
+ 		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
+--- a/drivers/mtd/spi-nor/winbond.c
++++ b/drivers/mtd/spi-nor/winbond.c
+@@ -131,6 +131,9 @@
+ 	{ "w25q256jw", INFO(0xef6019, 0, 64 * 1024, 512)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
+ 			      SPI_NOR_QUAD_READ) },
++	{ "w25m512jvfm", INFO(0xef7020, 0, 64 * 1024, 1024)
++	    NO_SFDP_FLAGS(SECT_4K | SPI_NOR_QUAD_READ |
++	              SPI_NOR_DUAL_READ) },
+ 	{ "w25m512jv", INFO(0xef7119, 0, 64 * 1024, 1024)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_QUAD_READ |
+ 			      SPI_NOR_DUAL_READ) },

--- a/target/linux/ramips/patches-6.6/406-mtd-spi-nor-Add-suport-for-gd25q40c-and-w25q512jvfm.patch
+++ b/target/linux/ramips/patches-6.6/406-mtd-spi-nor-Add-suport-for-gd25q40c-and-w25q512jvfm.patch
@@ -1,0 +1,25 @@
+--- a/drivers/mtd/spi-nor/gigadevice.c
++++ b/drivers/mtd/spi-nor/gigadevice.c
+@@ -50,6 +50,10 @@
+ 		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
+ 			      SPI_NOR_QUAD_READ) },
++	{ "gd25q40c", INFO(0xc84013, 0, 64 * 1024, 8)
++		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
++		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
++			      SPI_NOR_QUAD_READ) },
+ 	{ "gd25q64", INFO(0xc84017, 0, 64 * 1024, 128)
+ 		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
+--- a/drivers/mtd/spi-nor/winbond.c
++++ b/drivers/mtd/spi-nor/winbond.c
+@@ -131,6 +131,9 @@
+ 	{ "w25q256jw", INFO(0xef6019, 0, 64 * 1024, 512)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
+ 			      SPI_NOR_QUAD_READ) },
++	{ "w25m512jvfm", INFO(0xef7020, 0, 64 * 1024, 1024)
++	    NO_SFDP_FLAGS(SECT_4K | SPI_NOR_QUAD_READ |
++	              SPI_NOR_DUAL_READ) },
+ 	{ "w25m512jv", INFO(0xef7119, 0, 64 * 1024, 1024)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_QUAD_READ |
+ 			      SPI_NOR_DUAL_READ) },


### PR DESCRIPTION
This PR is extending support for newer hardware revisions of RBM33G that use different flash 
for RouterBoot. It also fixes the devicetree related warning messages about bad cell count. 

Because this board can be easily modded by adding larger firmware flash on the bottom side of PCB, 
there is a commit that creates a new target with its own device tree.

Changes were successfully tested.