### PR TITLE
ramips: Flash support for RBM33G 

### DIFF
--- a/target/linux/ramips/dts/mt7621_mikrotik.dtsi
+++ b/target/linux/ramips/dts/mt7621_mikrotik.dtsi
@@ -27,6 +27,8 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <33000000>;
 
 		partitions: partitions {

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m33g.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m33g.dts
@@ -72,6 +72,8 @@
 	flash@1 {
 		compatible = "jedec,spi-nor";
 		reg = <1>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <33000000>;
 
 		partitions {

--- a/target/linux/ramips/patches-6.1/406-mtd-spi-nor-Add-suport-for-gd25q40c-and-w25q512jvfm.patch
+++ b/target/linux/ramips/patches-6.1/406-mtd-spi-nor-Add-suport-for-gd25q40c-and-w25q512jvfm.patch
@@ -1,0 +1,25 @@
+--- a/drivers/mtd/spi-nor/gigadevice.c
++++ b/drivers/mtd/spi-nor/gigadevice.c
+@@ -50,6 +50,10 @@
+ 		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
+ 			      SPI_NOR_QUAD_READ) },
++	{ "gd25q40c", INFO(0xc84013, 0, 64 * 1024, 8)
++		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
++		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
++			      SPI_NOR_QUAD_READ) },
+ 	{ "gd25q64", INFO(0xc84017, 0, 64 * 1024, 128)
+ 		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
+--- a/drivers/mtd/spi-nor/winbond.c
++++ b/drivers/mtd/spi-nor/winbond.c
+@@ -131,6 +131,9 @@
+ 	{ "w25q256jw", INFO(0xef6019, 0, 64 * 1024, 512)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
+ 			      SPI_NOR_QUAD_READ) },
++	{ "w25m512jvfm", INFO(0xef7020, 0, 64 * 1024, 1024)
++	    NO_SFDP_FLAGS(SECT_4K | SPI_NOR_QUAD_READ |
++	              SPI_NOR_DUAL_READ) },
+ 	{ "w25m512jv", INFO(0xef7119, 0, 64 * 1024, 1024)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_QUAD_READ |
+ 			      SPI_NOR_DUAL_READ) },

--- a/target/linux/ramips/patches-6.6/406-mtd-spi-nor-Add-suport-for-gd25q40c-and-w25q512jvfm.patch
+++ b/target/linux/ramips/patches-6.6/406-mtd-spi-nor-Add-suport-for-gd25q40c-and-w25q512jvfm.patch
@@ -1,0 +1,25 @@
+--- a/drivers/mtd/spi-nor/gigadevice.c
++++ b/drivers/mtd/spi-nor/gigadevice.c
+@@ -50,6 +50,10 @@
+ 		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
+ 			      SPI_NOR_QUAD_READ) },
++	{ "gd25q40c", INFO(0xc84013, 0, 64 * 1024, 8)
++		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
++		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
++			      SPI_NOR_QUAD_READ) },
+ 	{ "gd25q64", INFO(0xc84017, 0, 64 * 1024, 128)
+ 		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
+--- a/drivers/mtd/spi-nor/winbond.c
++++ b/drivers/mtd/spi-nor/winbond.c
+@@ -131,6 +131,9 @@
+ 	{ "w25q256jw", INFO(0xef6019, 0, 64 * 1024, 512)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
+ 			      SPI_NOR_QUAD_READ) },
++	{ "w25m512jvfm", INFO(0xef7020, 0, 64 * 1024, 1024)
++	    NO_SFDP_FLAGS(SECT_4K | SPI_NOR_QUAD_READ |
++	              SPI_NOR_DUAL_READ) },
+ 	{ "w25m512jv", INFO(0xef7119, 0, 64 * 1024, 1024)
+ 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_QUAD_READ |
+ 			      SPI_NOR_DUAL_READ) },


### PR DESCRIPTION
Newer hardware revisions of RBM33G started using different flash type with JEDEC ID that 
is not supported in kernel. This PR adds this support and it also fixes devicetree related 
errors during boot about bad cell count:

[    1.771926] OF: Bad cell count for /palmbus@1e000000/spi@b00/flash@1/partitions
[    1.779300] OF: Bad cell count for /palmbus@1e000000/spi@b00/flash@1/partitions