### PR TITLE
opkg: fix stray \ warnings with grep-3.8

### DIFF
--- a/package/system/opkg/files/20_migrate-feeds
+++ b/package/system/opkg/files/20_migrate-feeds
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -f /etc/opkg.conf ] && grep -q "src\/" /etc/opkg.conf || exit 0
+[ -f /etc/opkg.conf ] && grep -q "src/" /etc/opkg.conf || exit 0
 
 echo -e "# Old feeds from previous image\n# Uncomment to reenable\n" >> /etc/opkg/customfeeds.conf
 sed -n "s/.*\(src\/.*\)/# \1/p" /etc/opkg.conf >> /etc/opkg/customfeeds.conf


### PR DESCRIPTION
We simply grep for `src/`. So no need for `\/`.
Furthermore, since `grep-3.8` this creates warnings.

As written in the `grep-3.8` announcement:
  Regular expressions with stray backslashes now cause warnings, as
  their unspecified behavior can lead to unexpected results.
  For example, `\a` and `a` are not always equivalent
  <https://bugs.gnu.org/39678>.

Fixes a warning during the first boot:
```
grep: warning: stray \ before /
```

Build and run tested: x64, WRT3200ACM, TL-WRT1043ND v4
Host tested: macOS 14.4.1

Based on https://github.com/openwrt/openwrt/commit/a29d3bc48c40c6a2a93ae1806bea2ac26455cdbb

@PolynomialDivision @Ansuel @robimarko @aparcar @1715173329 @hauke @mpratt14