### PR TITLE
ipq806x: add setup_macs for wpq864

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -98,6 +98,12 @@ ipq806x_setup_macs()
 			hw_mac_addr=$(mtd_get_mac_ascii hwconfig HW.WAN.MAC.Address)
 			ucidef_set_interface_macaddr "wan" "$hw_mac_addr"
 		;;
+		compex,wpq864)
+			hw_mac_addr=$(mtd_get_mac_ascii 0:APPSBLENV ethaddr)
+			ucidef_set_interface_macaddr "wan" "$hw_mac_addr"
+			hw_mac_addr=$(mtd_get_mac_ascii 0:APPSBLENV eth1addr)
+			ucidef_set_interface_macaddr "lan" "$hw_mac_addr"
+		;;
 	esac
 }
 


### PR DESCRIPTION
Read the mac addr from uboot env.

You have to set these addr in the u-boot terminal or via fw_setenv.
fw_setenv ethaddr 00:03:7f:ba:db:01
fw_setenv eth1addr 00:03:7f:ba:db:02

Ref: https://compexsystems.freshdesk.com/support/solutions/articles/36000179507-flash-lede-firmware-on-wpq864-wpq865

Fixes: openwrt#15477

Signed-off-by: Patrick Grimm <patrick@lunatiki.de>