### PR TITLE
uboot-envtools: add ubootenv_mtdinfo for wpq864

### DIFF
--- a/package/boot/uboot-envtools/files/ipq806x
+++ b/package/boot/uboot-envtools/files/ipq806x
@@ -53,7 +53,8 @@ nokia,ac400i)
 	ubootenv_add_uci_config "/dev/mtd20" "0x0" "0x040000" "0x20000"
 	;;
 qcom,ipq8064-ap148|\
-qcom,ipq8064-db149)
+qcom,ipq8064-db149|\
+compex,wpq864)
 	ubootenv_add_uci_config $(ubootenv_mtdinfo)
 	;;
 ubnt,unifi-ac-hd|\


### PR DESCRIPTION
Fixes: openwrt#15478

Signed-off-by: Patrick Grimm <patrick@lunatiki.de>
