### PR TITLE
[23.05] ipq806x: rt4230w-rev6: backport status LED fix

### DIFF
--- a/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8065-rt4230w-rev6.dts
+++ b/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8065-rt4230w-rev6.dts
@@ -13,10 +13,10 @@
 	};
 
 	aliases {
-		led-boot = &ledctrl3;
+		led-boot = &ledctrl1;
 		led-failsafe = &ledctrl1;
-		led-running = &ledctrl2;
-		led-upgrade = &ledctrl3;
+		led-running = &ledctrl3;
+		led-upgrade = &ledctrl1;
 	};
 
 	chosen {
@@ -54,6 +54,7 @@
 		ledctrl2: ledctrl2 {
 			label = "ledctrl2";
 			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "default-on";
 		};
 
 		ledctrl3: ledctrl3 {


### PR DESCRIPTION
backport of: https://github.com/openwrt/openwrt/pull/15440

---

There is a custom LED controller between the 3 SoC GPIO outputs and the red and blue LEDs of the device. It implements a strange mapping that includes fixed, flashing, and breathing modes.

The current DTS configuration causes OpenWrt to flash the LEDs over the controller's own flashing, resulting in chaotic output in boot, failsafe, and upgrade modes.

This change fixes the LEDs in the best way possible as long as each OpenWrt running state is limited to be signaled by a single led.

Signed-off-by: Rodrigo Balerdi <lanchon@gmail.com>
Link: https://github.com/openwrt/openwrt/pull/15440
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
(cherry picked from commit 0868268c9fd4397411e9629eedda35b1547e798e)

