### PR TITLE
usbmode: add Huawei E5785

### DIFF
--- a/package/utils/usbmode/data/3426-1f01
+++ b/package/utils/usbmode/data/3426-1f01
@@ -1,0 +1,4 @@
+# Huawei E5785
+TargetVendor=0x3426
+TargetProduct=0x14db
+HuaweiNewMode=1


### PR DESCRIPTION
This 4G/LTE modem is a WiFi hotspot, and also works as `cdc_ether` modem when plugged over USB. It needs usb-modeswitching. With `HuaweiNewMode`, it will modeswitch from `3426:1f01` (mass-storage) to `3426:14db` (cdc_ether).
