### PR TITLE
build: move mirror urls from download.pl to a separate file

### DIFF
--- a/download.json
+++ b/download.json
@@ -18,7 +18,6 @@
 		"https://mirror.navercorp.com/apache/",
 		"https://ftp.jaist.ac.jp/pub/apache/",
 		"https://apache.cs.utah.edu/apache.org/",
-		"http://apache.mirrors.ovh.net/ftp.apache.org/dist/",
 		"https://mirrors.tuna.tsinghua.edu.cn/apache/",
 		"https://mirrors.ustc.edu.cn/apache/"
 	],
@@ -43,8 +42,6 @@
 	"@KERNEL": [
 		"https://cdn.kernel.org/pub/",
 		"https://mirrors.mit.edu/kernel/",
-		"http://ftp.nara.wide.ad.jp/pub/kernel.org/",
-		"http://www.ring.gr.jp/archives/linux/kernel.org/",
 		"https://ftp.riken.jp/Linux/kernel.org/",
 		"https://www.mirrorservice.org/sites/ftp.kernel.org/pub/",
 		"https://mirrors.ustc.edu.cn/kernel.org/"
@@ -53,8 +50,6 @@
 		"https://download.gnome.org/sources/",
 		"https://mirror.csclub.uwaterloo.ca/gnome/sources/",
 		"https://ftp.acc.umu.se/pub/GNOME/sources/",
-		"http://ftp.cse.buffalo.edu/pub/Gnome/sources/",
-		"http://ftp.nara.wide.ad.jp/pub/X11/GNOME/sources/",
 		"https://mirrors.ustc.edu.cn/gnome/sources/"
 	],
 	"@OPENWRT": [

--- a/download.json
+++ b/download.json
@@ -1,0 +1,65 @@
+{
+	"@SF": [
+		"https://downloads.sourceforge.net"
+	],
+	"@DEBIAN": [
+		"https://ftp.debian.org/debian/",
+		"https://mirror.leaseweb.com/debian/",
+		"https://mirror.netcologne.de/debian/",
+		"https://mirrors.tuna.tsinghua.edu.cn/debian/",
+		"https://mirrors.ustc.edu.cn/debian/"
+	],
+	"@APACHE": [
+		"https://dlcdn.apache.org/",
+		"https://mirror.aarnet.edu.au/pub/apache/",
+		"https://mirror.csclub.uwaterloo.ca/apache/",
+		"https://archive.apache.org/dist/",
+		"https://mirror.cogentco.com/pub/apache/",
+		"https://mirror.navercorp.com/apache/",
+		"https://ftp.jaist.ac.jp/pub/apache/",
+		"https://apache.cs.utah.edu/apache.org/",
+		"http://apache.mirrors.ovh.net/ftp.apache.org/dist/",
+		"https://mirrors.tuna.tsinghua.edu.cn/apache/",
+		"https://mirrors.ustc.edu.cn/apache/"
+	],
+	"@GNU": [
+		"https://mirror.csclub.uwaterloo.ca/gnu/",
+		"https://mirror.netcologne.de/gnu/",
+		"https://ftp.kddilabs.jp/GNU/gnu/",
+		"https://www.nic.funet.fi/pub/gnu/gnu/",
+		"https://mirror.navercorp.com/gnu/",
+		"https://mirrors.rit.edu/gnu/",
+		"https://ftp.gnu.org/gnu/",
+		"https://mirrors.tuna.tsinghua.edu.cn/gnu/",
+		"https://mirrors.ustc.edu.cn/gnu/"
+	],
+	"@SAVANNAH": [
+		"https://mirror.netcologne.de/savannah/",
+		"https://mirror.csclub.uwaterloo.ca/nongnu/",
+		"https://ftp.acc.umu.se/mirror/gnu.org/savannah/",
+		"https://nongnu.uib.no/",
+		"https://cdimage.debian.org/mirror/gnu.org/savannah/"
+	],
+	"@KERNEL": [
+		"https://cdn.kernel.org/pub/",
+		"https://mirrors.mit.edu/kernel/",
+		"http://ftp.nara.wide.ad.jp/pub/kernel.org/",
+		"http://www.ring.gr.jp/archives/linux/kernel.org/",
+		"https://ftp.riken.jp/Linux/kernel.org/",
+		"https://www.mirrorservice.org/sites/ftp.kernel.org/pub/",
+		"https://mirrors.ustc.edu.cn/kernel.org/"
+	],
+	"@GNOME": [
+		"https://download.gnome.org/sources/",
+		"https://mirror.csclub.uwaterloo.ca/gnome/sources/",
+		"https://ftp.acc.umu.se/pub/GNOME/sources/",
+		"http://ftp.cse.buffalo.edu/pub/Gnome/sources/",
+		"http://ftp.nara.wide.ad.jp/pub/X11/GNOME/sources/",
+		"https://mirrors.ustc.edu.cn/gnome/sources/"
+	],
+	"@OPENWRT": [
+		"https://sources.cdn.openwrt.org",
+		"https://sources.openwrt.org",
+		"https://mirror2.openwrt.org/sources"
+	]
+}

--- a/include/download.mk
+++ b/include/download.mk
@@ -143,7 +143,7 @@ define DownloadMethod/unknown
 endef
 
 define DownloadMethod/default
-	$(SCRIPT_DIR)/download.pl "$(DL_DIR)" "$(FILE)" "$(HASH)" "$(URL_FILE)" $(foreach url,$(URL),"$(url)") \
+	$(SCRIPT_DIR)/download.pl "$(DL_DIR)" "$(FILE)" "$(HASH)" "$(TOPDIR)/download.json" "$(URL_FILE)" $(foreach url,$(URL),"$(url)") \
 	$(if $(filter check,$(1)), \
 		$(call check_hash,$(FILE),$(HASH),$(2)$(call hash_var,$(MD5SUM))) \
 		$(call check_md5,$(MD5SUM),$(2)MD5SUM,$(2)HASH) \
@@ -154,7 +154,7 @@ endef
 # $(2): "PKG_" if <name> as in Download/<name> is "default", otherwise "Download/<name>:"
 # $(3): shell command sequence to do the download
 define wrap_mirror
-$(if $(if $(MIRROR),$(filter-out x,$(MIRROR_HASH))),$(SCRIPT_DIR)/download.pl "$(DL_DIR)" "$(FILE)" "$(MIRROR_HASH)" "" || ( $(3) ),$(3)) \
+$(if $(if $(MIRROR),$(filter-out x,$(MIRROR_HASH))),$(SCRIPT_DIR)/download.pl "$(DL_DIR)" "$(FILE)" "$(MIRROR_HASH)" "$(TOPDIR)/download.json" "" || ( $(3) ),$(3)) \
 $(if $(filter check,$(1)), \
 	$(call check_hash,$(FILE),$(MIRROR_HASH),$(2)MIRROR_$(call hash_var,$(MIRROR_MD5SUM))) \
 	$(call check_md5,$(MIRROR_MD5SUM),$(2)MIRROR_MD5SUM,$(2)MIRROR_HASH) \


### PR DESCRIPTION
The URLs to be used to download source packages are currently integrated in the source code of [download.pl](https://github.com/openwrt/openwrt/blob/main/scripts/download.pl). To make it easier to change this URLs, this commit extracts the URLs into json. The second commit removes URLs the does not use https.