### PR TITLE
ipq806x: mr42/mr52: fix PCIe ports

### DIFF
--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-cryptid-common.dtsi
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-cryptid-common.dtsi
@@ -73,10 +73,6 @@
 &pcie0 {
 	status = "okay";
 
-	/delete-property/ pinctrl-0;
-	/delete-property/ pinctrl-names;
-	/delete-property/ perst-gpios;
-
 	bridge@0,0 {
 		reg = <0x0 0 0 0 0>;
 		#address-cells = <3>;
@@ -94,10 +90,6 @@
 &pcie1 {
 	status = "okay";
 
-	/delete-property/ pinctrl-0;
-	/delete-property/ pinctrl-names;
-	/delete-property/ perst-gpios;
-
 	bridge@0,0 {
 		reg = <0x0 0 0 0 0>;
 		#address-cells = <3>;
@@ -114,10 +106,6 @@
 
 &pcie2 {
 	status = "okay";
-
-	/delete-property/ pinctrl-0;
-	/delete-property/ pinctrl-names;
-	/delete-property/ perst-gpios;
 
 	bridge@0,0 {
 		reg = <0x0 0 0 0 0>;


### PR DESCRIPTION
All three PCIe ports are reported non working on Meraki MR42/MR52 boards since kernel 6.1 with the issue of PCIe PHY link never coming up thus no WLAN cards are available on the boards.

After debugging it seems that PCIe worked on 5.15 and older purely by accident as device DTS was using /delete-property/ perst-gpios; in each of the 3 PCIe nodes but there was no "perst-gpios" property in the SoC DTSI as it was still using the older "perst-gpio" property so it was not getting removed from the device DTS.

However, in kernel 6.1 commit ("ARM: dts: qcom-*: replace deprecated perst-gpio with perst-gpios") updated all Qualcomm DTS-es to use the newer "perst-gpios" and thus once ipq806x moved to 6.1 PCIe stopped working as now that property was being dropped from the device DTS.

So, since the removal of PERST pins seems to have been wrong from the start lets drop the property removal from MR42/MR52.

Fixes: #15408 
