### PR TITLE
openssl: Fixed a bug with loading the engine.

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_VERSION:=3.0.13
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_BUILD_PARALLEL:=1

--- a/package/libs/openssl/files/openssl.init
+++ b/package/libs/openssl/files/openssl.init
@@ -32,8 +32,8 @@ enable_module() {
 		echo "If the engine was not built-in, remove 'config builtin' from /etc/config/openssl."
 	elif [ "$force" = 1 ]; then
 		printf "[Forced] "
-	elif ! grep -q "\\[ *$1_sect *]" /etc/ssl/modules.cnf.d/*; then
-		echo "$1: Could not find section [$1] in config files."
+	elif ! grep -q "\\[ *$1_sect *]" /etc/ssl/*.cnf.d/*; then
+		echo "$1: Could not find section [$1_sect] in config files."
 		return 1
 	elif [ "$builtin" = 1 ]; then
 		printf "[Builtin] "

--- a/package/libs/openssl/patches/150-openssl.cnf-add-engines-conf.patch
+++ b/package/libs/openssl/patches/150-openssl.cnf-add-engines-conf.patch
@@ -33,7 +33,7 @@ Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
 +
 +[engines_sect]
 +.include /var/etc/ssl/engines.cnf
-+
++.include /etc/ssl/engines.cnf.d
 +.include /etc/ssl/modules.cnf.d
 +
  


### PR DESCRIPTION
The external engine does not load (for example: gost_engine):

```
Fri May 17 11:16:13 2024 daemon.notice procd: /etc/rc.d/S13openssl: Generating engines.cnf
Fri May 17 11:16:13 2024 daemon.notice procd: /etc/rc.d/S13openssl: gost: Could not find section [gost] in config files.
Fri May 17 11:16:13 2024 daemon.notice procd: /etc/rc.d/S13openssl: Generating providers.cnf
Fri May 17 11:16:13 2024 daemon.notice procd: /etc/rc.d/S13openssl: Enabling legacy
```

This is because the /etc/init.d/openssl startup script does not look through the /etc/ssl/engines.cnf.d/ directory and does not find the configuration.
It also incorrectly writes to the log which section of the configuration was not found.