### PR TITLE
ath79: add support for 8Devices Carambola3 board

### DIFF
--- a/target/linux/ath79/dts/qca9531_8dev_carambola3.dts
+++ b/target/linux/ath79/dts/qca9531_8dev_carambola3.dts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "8dev,carambola3", "qca,qca9531";
+	model = "8devices Carambola3";
+
+	aliases {
+		label-mac-device = &wmac;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "green:lan";
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan {
+			label = "green:wan";
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&usb0 {
+	status = "okay";
+
+	dr_mode = "host";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&wdt {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	/* Winbond W25Q256 SPI flash */
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <45000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x040000>;
+			};
+
+			art: partition@80000 {
+				label = "art";
+				reg = <0x080000 0x040000>;
+				read-only;
+
+				nvmem-layout {
+			     		compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
+			};
+
+			partition@c0000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x0c0000 0xf40000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-addr-swap = <1>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&eth1 {
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -10,6 +10,10 @@ case "$board" in
 	ucidef_set_led_netdev "lan" "LAN" "orange:eth0" "eth0"
 	ucidef_set_led_switch "wan" "WAN" "orange:eth1" "switch0" "0x04"
 	;;
+8dev,carambola3)
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0" "link"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1" "link"
+	;;
 alcatel,hh40v)
 	ucidef_set_led_netdev "lan_data" "LAN Data" "green:lan" "eth1" "tx rx"
 	ucidef_set_led_netdev "lan_link" "LAN Link" "orange:lan" "eth1" "link"

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -9,6 +9,7 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath9k-eeprom-ahb-18100000.wmac.bin")
 	case $board in
+	8dev,carambola3|\
 	8dev,lima)
 		caldata_extract "art" 0x1000 0x800
 		;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -204,6 +204,16 @@ define Device/8dev_carambola2
 endef
 TARGET_DEVICES += 8dev_carambola2
 
+define Device/8dev_carambola3
+  SOC := qca9531
+  DEVICE_VENDOR := 8devices
+  DEVICE_MODEL := Carambola3
+  DEVICE_PACKAGES := kmod-usb2
+  IMAGE_SIZE := 32768k
+  SUPPORTED_DEVICES += carambola3
+endef
+TARGET_DEVICES += 8dev_carambola3
+
 define Device/8dev_lima
   SOC := qca9531
   DEVICE_VENDOR := 8devices


### PR DESCRIPTION
Carambola3 is a WiFi module based on Qualcomm/Atheros QCA4531 http://wiki.8devices.com/carambola3

Specification:

    - 650/600/216 MHz (CPU/DDR/AHB)
    - 128 MB of RAM (DDR2)
    - 32 MB of FLASH
    - 2T2R 2.4 GHz
    - 2x 10/100 Mbps Ethernet
    - 1x USB 2.0 Host socket
    - UART for serial console
    - 12x GPIO

Flash instructions:

    Upgrading from ar71xx target:
    - Upload image into the board:
        scp openwrt-ath79-generic-8dev_carambola3-squashfs-sysupgrade.bin \
          root@192.168.1.1/tmp/
    - Run sysupgrade
        sysupgrade -F /tmp/openwrt-ath79-generic-8dev_carambola3-squashfs-sysupgrade.bin

Upgrading from u-boot:
    - Set up tftp server with openwrt-ath79-generic-8dev_carambola3-initramfs-kernel.bin
    - Go to u-boot (reboot and press ESC when prompted)
    - Set TFTP server IP
        setenv serverip 192.168.1.254
    - Set device ip from the same subnet
        setenv ipaddr 192.168.1.1
    - Copy new firmware to board
        tftpboot 0x82000000 initramfs.bin
    - Boot OpenWRT
        bootm 0x82000000
    - Upload image openwrt-ath79-generic-8dev_carambola3-squashfs-sysupgrade.bin into the board
    - Run sysupgrade.

