### PR TITLE
mt7981b: hide bogus local-mac-address to enable nvmem assignment

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-m3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-m3000-v1.dts
@@ -9,7 +9,6 @@
 	compatible = "cudy,m3000-v1", "mediatek,mt7981-spim-snand-rfb";
 
 	aliases {
-		ethernet0 = &gmac0;
 		label-mac-device = &gmac0;
 		led-boot = &led_status;
 		led-failsafe = &led_status;
@@ -87,7 +86,8 @@
 		phy-mode = "2500base-x";
 		phy-handle = <&rtl8221b_phy>;
 
-		/* the MAC address assignment using nvmem-cells doesn't work, so it's done through 02_network */
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_bdinfo_de00 1>;
 	};
 
 	gmac1: mac@1 {

--- a/target/linux/mediatek/dts/mt7981b-yuncore-ax835.dts
+++ b/target/linux/mediatek/dts/mt7981b-yuncore-ax835.dts
@@ -9,7 +9,6 @@
 	model = "YunCore AX835";
 
 	aliases {
-		ethernet0 = &gmac0;
 		led-boot = &led_system;
 		led-failsafe = &led_system;
 		led-running = &led_system;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -137,9 +137,6 @@ mediatek_setup_macs()
 		;;
 		esac
 		;;
-	cudy,m3000-v1)
-		wan_mac=$(macaddr_add $(cat /sys/class/net/eth1/address) 1)
-		;;
 	h3c,magic-nx30-pro)
 		wan_mac=$(mtd_get_mac_ascii pdt_data_1 ethaddr)
 		lan_mac=$(macaddr_add "$wan_mac" 1)


### PR DESCRIPTION
This fixes https://github.com/openwrt/openwrt/issues/15507.
I wasn't confident enough to do a `Fixes:` because I don't know whether/how it works if two commits are required.