### PR TITLE
kernel: qca-nss-dp: add back printing attached PHY-s

### DIFF
--- a/package/kernel/qca-nss-dp/patches/0006-nss_dp_main-Use-a-phy-handle-property-to-connect-to-.patch
+++ b/package/kernel/qca-nss-dp/patches/0006-nss_dp_main-Use-a-phy-handle-property-to-connect-to-.patch
@@ -149,7 +149,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  #if defined(NSS_DP_PPE_SUPPORT)
  	uint32_t vsi_id;
  	fal_port_t port_id;
-@@ -940,22 +883,15 @@ static int32_t nss_dp_probe(struct platf
+@@ -940,22 +883,16 @@ static int32_t nss_dp_probe(struct platf
  
  	dp_priv->drv_flags |= NSS_DP_PRIV_FLAG(INIT_DONE);
  
@@ -177,6 +177,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 +			netdev_err(netdev, "failed to connect to phy device\n");
 + 			goto phy_setup_fail;
 + 		}
++ 		phy_attached_info(dp_priv->phydev);
  	}
  
  #if defined(NSS_DP_PPE_SUPPORT)

--- a/package/kernel/qca-nss-dp/patches/0011-02-nss_dp_switchdev-correctly-unregister-notifier-on-dp.patch
+++ b/package/kernel/qca-nss-dp/patches/0011-02-nss_dp_switchdev-correctly-unregister-notifier-on-dp.patch
@@ -26,7 +26,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
 --- a/nss_dp_main.c
 +++ b/nss_dp_main.c
-@@ -972,6 +972,10 @@ static int nss_dp_remove(struct platform
+@@ -970,6 +970,10 @@ static int nss_dp_remove(struct platform
  		if (!dp_priv)
  			continue;
  

--- a/package/kernel/qca-nss-dp/patches/0011-03-nss_dp_main-swap-dp_exit-function-call.patch
+++ b/package/kernel/qca-nss-dp/patches/0011-03-nss_dp_main-swap-dp_exit-function-call.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/nss_dp_main.c
 +++ b/nss_dp_main.c
-@@ -1163,6 +1163,8 @@ int __init nss_dp_init(void)
+@@ -1161,6 +1161,8 @@ int __init nss_dp_init(void)
   */
  void __exit nss_dp_exit(void)
  {
@@ -24,7 +24,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  	/*
  	 * TODO Move this to soc_ops
  	 */
-@@ -1170,8 +1172,6 @@ void __exit nss_dp_exit(void)
+@@ -1168,8 +1170,6 @@ void __exit nss_dp_exit(void)
  		nss_dp_hal_cleanup();
  		dp_global_ctx.common_init_done = false;
  	}

--- a/package/kernel/qca-nss-dp/patches/0011-04-nss_dp_main-call-unregister_netdev-first-in-dp_remov.patch
+++ b/package/kernel/qca-nss-dp/patches/0011-04-nss_dp_main-call-unregister_netdev-first-in-dp_remov.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/nss_dp_main.c
 +++ b/nss_dp_main.c
-@@ -979,6 +979,9 @@ static int nss_dp_remove(struct platform
+@@ -977,6 +977,9 @@ static int nss_dp_remove(struct platform
  		dp_ops = dp_priv->data_plane_ops;
  		hal_ops = dp_priv->gmac_hal_ops;
  
@@ -25,7 +25,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		if (dp_priv->phydev)
  			phy_disconnect(dp_priv->phydev);
  
-@@ -990,7 +993,6 @@ static int nss_dp_remove(struct platform
+@@ -988,7 +991,6 @@ static int nss_dp_remove(struct platform
  #endif
  		hal_ops->exit(dp_priv->gmac_hal_ctx);
  		dp_ops->deinit(dp_priv->dpc);

--- a/package/kernel/qca-nss-dp/patches/0011-05-nss_dp_main-use-phy_detach-instead-of-disconnect-in-.patch
+++ b/package/kernel/qca-nss-dp/patches/0011-05-nss_dp_main-use-phy_detach-instead-of-disconnect-in-.patch
@@ -15,7 +15,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/nss_dp_main.c
 +++ b/nss_dp_main.c
-@@ -983,7 +983,7 @@ static int nss_dp_remove(struct platform
+@@ -981,7 +981,7 @@ static int nss_dp_remove(struct platform
  		unregister_netdev(dp_priv->netdev);
  
  		if (dp_priv->phydev)


### PR DESCRIPTION
During the last update to 12.5.r2 printing of the attached PHY-s was removed, so lets bring it back as it is very helpfull for debugging OpenWrt issues without users having to modify NSS-DP to know if a PHY was attached.

Refresh patches since `nss_dp_main.c` was edited.
