### PR TITLE
kernel: armsr: Renesas: RZ: Ethernet:  Add kernel module

### DIFF
--- a/target/linux/armsr/base-files/etc/inittab
+++ b/target/linux/armsr/base-files/etc/inittab
@@ -7,3 +7,4 @@ hvc0::askfirst:/usr/libexec/login.sh
 ttymxc0::askfirst:/usr/libexec/login.sh
 ttymxc1::askfirst:/usr/libexec/login.sh
 ttymxc2::askfirst:/usr/libexec/login.sh
+ttySC0::askfirst:/usr/libexec/login.sh

--- a/target/linux/armsr/image/Makefile
+++ b/target/linux/armsr/image/Makefile
@@ -108,7 +108,7 @@ define Device/generic
 	kmod-fsl-enetc-net kmod-dwmac-imx kmod-fsl-fec kmod-thunderx-net \
 	kmod-dwmac-rockchip kmod-dwmac-sun8i kmod-phy-aquantia kmod-phy-broadcom \
 	kmod-phy-marvell kmod-phy-marvell-10g kmod-sfp kmod-atlantic \
-	kmod-bcmgenet kmod-octeontx2-net
+	kmod-bcmgenet kmod-octeontx2-net kmod-renesas-net-avb
 endef
 TARGET_DEVICES += generic
 

--- a/target/linux/armsr/modules.mk
+++ b/target/linux/armsr/modules.mk
@@ -288,6 +288,21 @@ define KernelPackage/octeontx2-net
 endef
 $(eval $(call KernelPackage,octeontx2-net))
 
+define KernelPackage/renesas-net-avb
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Renesas network drivers
+  DEPENDS:=@(TARGET_armsr_armv8) +kmod-phylink +kmod-mii +kmod-ptp +kmod-libphy +kmod-mdio-gpio
+  KCONFIG:=CONFIG_RAVB
+  FILES=$(LINUX_DIR)/drivers/net/ethernet/renesas/ravb.ko
+  AUTOLOAD:=$(call AutoProbe,ravb)
+endef
+ 
+define KernelPackage/renesas-net-avb/description
+  Support Renesas RZ platform Ethernet module
+endef
+ 
+$(eval $(call KernelPackage,renesas-net-avb))
+
 define KernelPackage/wdt-sp805
   SUBMENU:=$(OTHER_MENU)
   TITLE:=ARM SP805 Watchdog


### PR DESCRIPTION
The issue related to the changes https://github.com/openwrt/openwrt/issues/15284
Serial driver enabling  for Renesas RZ platform
Ethernet driver added as kernel module
inittab fix for ttySC0