### PR TITLE
ipq40xx: dont panic on PSGMII calibration fail

### DIFF
--- a/target/linux/ipq40xx/patches-6.6/706-net-dsa-qca8k-add-IPQ4019-built-in-switch-support.patch
+++ b/target/linux/ipq40xx/patches-6.6/706-net-dsa-qca8k-add-IPQ4019-built-in-switch-support.patch
@@ -654,7 +654,7 @@ Signed-off-by: Robert Marko <robert.marko@sartura.hr>
 +		}
 +	}
 +
-+	panic("PSGMII work is unstable !!! "
++	dev_err(priv->dev, "PSGMII work is unstable !!! "
 +		"Repeated recalibration attempts did not help(0x%x) !\n",
 +		test_result);
 +


### PR DESCRIPTION
Currently, in case that PSGMII calibration fails it will panic the kernel which is not ideal and is preventing any debugging to be done.

So, since PGMII calibration failing only means that wired networking wont work lets convet the panic() call to dev_error.
