### PR TITLE
ath79: Fix GL.iNet GL-E750 crash after restart 5g wifi

### DIFF
--- a/package/kernel/mac80211/patches/ath10k/991-ath79-adjust-ath10k-caldata.patch
+++ b/package/kernel/mac80211/patches/ath10k/991-ath79-adjust-ath10k-caldata.patch
@@ -1,0 +1,13 @@
+Index: b/drivers/net/wireless/ath/ath10k/pci.c
+===================================================================
+--- a/drivers/net/wireless/ath/ath10k/pci.c
++++ b/drivers/net/wireless/ath/ath10k/pci.c
+@@ -2246,7 +2246,7 @@ static int ath10k_pci_bmi_wait(struct at
+ 			goto out;
+ 		}
+ 
+-		schedule();
++		//schedule();
+ 	}
+ 
+ 	ret = -ETIMEDOUT;

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -190,7 +190,7 @@ define Device/glinet_gl-e750
   SOC := qca9531
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-E750
-  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct kmod-usb2 \
+  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9887 kmod-usb2 \
 	kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
   SUPPORTED_DEVICES += gl-e750
   KERNEL_SIZE := 4096k


### PR DESCRIPTION
Fixed a crash issue caused by 5g wifi startup during startup Related Forum
Links:https://forum.gl-inet.com/t/e750-5ghz-wifi-not-working-properly-stock-openwrt-23-05-2/35404
