### PR TITLE
wifi-scripts: fix creation of IBSS in legacy (non-HT) mode

### DIFF
--- a/package/network/services/hostapd/files/wdev.uc
+++ b/package/network/services/hostapd/files/wdev.uc
@@ -32,10 +32,11 @@ function iface_start(wdev)
 		wdev_config.macaddr = phydev.macaddr_next();
 	wdev_create(phy, ifname, wdev_config);
 	wdev_set_up(ifname, true);
+	let htmode = wdev.htmode || "NOHT";
 	if (wdev.freq)
-		system(`iw dev ${ifname} set freq ${wdev.freq} ${wdev.htmode}`);
+		system(`iw dev ${ifname} set freq ${wdev.freq} ${htmode}`);
 	if (wdev.mode == "adhoc") {
-		let cmd = ["iw", "dev", ifname, "ibss", "join", wdev.ssid, wdev.freq, wdev.htmode, "fixed-freq" ];
+		let cmd = ["iw", "dev", ifname, "ibss", "join", wdev.ssid, wdev.freq, htmode, "fixed-freq" ];
 		if (wdev.bssid)
 			push(cmd, wdev.bssid);
 		for (let key in [ "beacon-interval", "basic-rates", "mcast-rate", "keys" ])
@@ -43,7 +44,7 @@ function iface_start(wdev)
 				push(cmd, key, wdev[key]);
 		system(cmd);
 	} else if (wdev.mode == "mesh") {
-		let cmd = [ "iw", "dev", ifname, "mesh", "join", wdev.ssid, "freq", wdev.freq, wdev.htmode ];
+		let cmd = [ "iw", "dev", ifname, "mesh", "join", wdev.ssid, "freq", wdev.freq, htmode ];
 		for (let key in [ "mcast-rate", "beacon-interval" ])
 			if (wdev[key])
 				push(cmd, key, wdev[key]);


### PR DESCRIPTION
When an IBBS interface is configured for IBSS legacy mode, wdev.htmode is empty. This is empty string results in an empty positional argument to the "ibbs join" command, for example:

    iw dev phy0-ibss0 ibss join crymesh 2412 '' fixed-freq beacon-interval 100

This empty argument is interpreted as an invalid HT mode by 'iw', causing the entire command to fail and print a "usage" message:

    daemon.notice netifd: radio0 (4527): Usage:    iw [options] \
        dev <devname> ibss join <SSID> <freq in MHz> ...

Although nobody will ever need more than 640K of IBSS, explicitly use "NOHT" if an HT mode is not given. This fixes the problem.

Snapshot commit: cee9fcdb7350911f474544189817d25fd4070111

Fixes: e56c5f7b276a ("hostapd: add ucode support, use ucode for the main ubus object")