### PR TITLE
ramips: add support for 7Links WLR-1230 and WLR-1240

### DIFF
--- a/target/linux/ramips/dts/mt7628an_7links_wlr-1230.dts
+++ b/target/linux/ramips/dts/mt7628an_7links_wlr-1230.dts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_7links_wlr-12xx.dtsi"
+
+/ {
+	compatible = "7links,wlr-1230", "mediatek,mt7628an-soc";
+	model = "7Links WLR-1230";
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_res: res {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	aliases {
+		led-boot = &led_res;
+		led-failsafe = &led_res;
+		led-running = &led_res;
+		led-upgrade = &led_res;
+		label-mac-device = &ethernet;
+	};
+};

--- a/target/linux/ramips/dts/mt7628an_7links_wlr-1240.dts
+++ b/target/linux/ramips/dts/mt7628an_7links_wlr-1240.dts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_7links_wlr-12xx.dtsi"
+
+/ {
+	compatible = "7links,wlr-1240", "mediatek,mt7628an-soc";
+	model = "7Links WLR-1240";
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status_red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: status_blue {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: status_green {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_red;
+		label-mac-device = &ethernet;
+	};
+};

--- a/target/linux/ramips/dts/mt7628an_7links_wlr-12xx.dtsi
+++ b/target/linux/ramips/dts/mt7628an_7links_wlr-12xx.dtsi
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+				compatible = "denx,uimage";
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "gpio", "refclk", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portdisable = <0x2f>;
+};
+
+&wmac {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&usbphy {
+	status = "disabled";
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -29,6 +29,20 @@ define Build/ravpower-wd009-factory
 endef
 
 
+define Device/7links_wlr-12xx
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := 7Links
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | append-metadata
+endef
+
+define Device/7links_wlr-1230
+  $(Device/7links_wlr-12xx)
+  DEVICE_MODEL := WLR-1230
+endef
+TARGET_DEVICES += 7links_wlr-1230
+
 define Device/alfa-network_awusfree1
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := ALFA Network

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -43,6 +43,12 @@ define Device/7links_wlr-1230
 endef
 TARGET_DEVICES += 7links_wlr-1230
 
+define Device/7links_wlr-1240
+  $(Device/7links_wlr-12xx)
+  DEVICE_MODEL := WLR-1240
+endef
+TARGET_DEVICES += 7links_wlr-1240
+
 define Device/alfa-network_awusfree1
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := ALFA Network

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -7,6 +7,9 @@ board=$(board_name)
 board_config_update
 
 case $board in
+7links,wlr-1230)
+	ucidef_set_led_switch "lan" "lan" "orange:lan" "switch0" "0x10"
+	;;
 alfa-network,awusfree1)
 	ucidef_set_led_netdev "wifi_led" "wifi" "blue:wlan" "wlan0"
 	;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -8,6 +8,7 @@ ramips_setup_interfaces()
 	local board="$1"
 
 	case $board in
+	7links,wlr-1230|\
 	alfa-network,awusfree1|\
 	d-team,pbr-d1|\
 	dlink,dap-1325-a1|\

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -9,6 +9,7 @@ ramips_setup_interfaces()
 
 	case $board in
 	7links,wlr-1230|\
+	7links,wlr-1240|\
 	alfa-network,awusfree1|\
 	d-team,pbr-d1|\
 	dlink,dap-1325-a1|\


### PR DESCRIPTION
The WLR-1230 (ZX-5207) is an AC1200 Wave 2 outdoor repeater
with sector antennas for wall or pole mounting.

The WLR-1240 (ZX-5434) is an AC1200 Wave 2 outdoor repeater
with omnidirectional antennas for wall or pole mounting.

The devices are manufactured by Todaair and meant to be used with
a tuya-based app, there is no webinterface for configuration.

Specifications:
- MT7628AN, 8 MiB SPI NOR flash, 64 MiB RAM, 2x2 802.11n
- MT7613 2x2 802.11ac Wave 2
- 802.3af PoE or 12V 1A 5.5x2.1 power supply (included)
WLR-1230:
- 3 LEDs WLAN, LAN, RES; PWR LED is not software-controllable
WLR-1240
- top RGB LED ring

TFTP installation:
- rename sysupgrade to `firmware_auto.bin`
- provide at 192.168.1.10 during boot

HTTP installation:
- keep reset button pressed for 5 seconds during power on (LEDs
  flash slowly, then quickly to confirm, then remain steady on)
- recovery web interface is at 192.168.1.1, upload sysupgrade

Opening WLR-1230:
- two screws are located in the bottom left and right corners
  underneath the label, inner tray slides out easily

Opening WLR-1240:
- use suction cup to remove top cap within LED ring
- two screws are located in holes underneath silicone sealant
- two further screws are located at the bottom
  
initramfs boot
- open device, connect serial console (pins are labelled)
- keep pressing `4` during second tftp attempt to enter uboot shell
- run `tftpboot 82000000` to avoid memory overlap, then `bootm`


--------------------------------

The LAN LED on WLR-1230 only shows link state, but does not flash on activity.
Is this intentional or did I miss something in the configuration?

For both devices, LuCI would complain `switch0 has an unknown topology` and all ports are shown,
although only port 4 is exposed. I'm not sure how to avoid this using dts (`portmap` / `portdisable`) or `02_network`.

--------------------------------

The devices are imported to Germany by Pearl, order numbers and current prices are:

WLR-1230 (flat design, sector antenna)
- ZX-5207 single pack (new) € 69,99
- ZX-5225 double pack (new) € 129,99
- REF-52078 single pack (refurbished) € 56,99

WLR-1240 (cylindric design, omnidirectional antenna)
- ZX-5434 single pack (new) € 58,99
- ZX-5435 double pack (new)	€ 115,99
- REF-54348 single pack (refurbished) € 51,91

They might be interesting for use with gluon, I will prepare and test a backport to 23.05.