### PR TITLE
hostapd: add support for rxkh_file

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -335,7 +335,7 @@ hostapd_common_add_bss_config() {
 
 	config_add_boolean ieee80211r pmk_r1_push ft_psk_generate_local ft_over_ds
 	config_add_int r0_key_lifetime reassociation_deadline
-	config_add_string mobility_domain r1_key_holder
+	config_add_string mobility_domain r1_key_holder rxkh_file
 	config_add_array r0kh r1kh
 
 	config_add_int ieee80211w_max_timeout ieee80211w_retry_timeout
@@ -565,7 +565,7 @@ hostapd_set_bss_options() {
 
 	wireless_vif_parse_encryption
 
-	local bss_conf bss_md5sum ft_key
+	local bss_conf bss_md5sum ft_key rxkhs
 	local wep_rekey wpa_group_rekey wpa_pair_rekey wpa_master_rekey wpa_key_mgmt
 
 	json_get_vars \
@@ -949,7 +949,7 @@ hostapd_set_bss_options() {
 			append bss_conf "reassociation_deadline=$reassociation_deadline" "$N"
 
 			if [ "$ft_psk_generate_local" -eq "0" ]; then
-				json_get_vars r0_key_lifetime r1_key_holder pmk_r1_push
+				json_get_vars r0_key_lifetime r1_key_holder pmk_r1_push rxkh_file
 				json_get_values r0kh r0kh
 				json_get_values r1kh r1kh
 
@@ -971,12 +971,20 @@ hostapd_set_bss_options() {
 				append bss_conf "r0_key_lifetime=$r0_key_lifetime" "$N"
 				append bss_conf "pmk_r1_push=$pmk_r1_push" "$N"
 
-				for kh in $r0kh; do
-					append bss_conf "r0kh=${kh//,/ }" "$N"
-				done
-				for kh in $r1kh; do
-					append bss_conf "r1kh=${kh//,/ }" "$N"
-				done
+				if [ -z "$rxkh_file" ]; then
+					set_default rxkh_file /var/run/hostapd-$ifname.rxkh
+					[ -e "$rxkh_file" ] && rm -f "$rxkh_file"
+					touch "$rxkh_file"
+
+					for kh in $r0kh; do
+						append rxkhs "r0kh=${kh//,/ }" "$N"
+					done
+					for kh in $r1kh; do
+						append rxkhs "r1kh=${kh//,/ }" "$N"
+					done
+					echo "$rxkhs" > "$rxkh_file"
+				fi
+				append bss_conf "rxkh_file=$rxkh_file" "$N"
 			fi
 		fi
 

--- a/package/network/services/hostapd/files/hostapd.uc
+++ b/package/network/services/hostapd/files/hostapd.uc
@@ -10,6 +10,7 @@ hostapd.data.pending_config = {};
 hostapd.data.file_fields = {
 	vlan_file: true,
 	wpa_psk_file: true,
+	rxkh_file: true,
 	accept_mac_file: true,
 	deny_mac_file: true,
 	eap_user_file: true,
@@ -309,6 +310,64 @@ function bss_reload_psk(bss, config, old_config)
 	ret ??= "failed";
 
 	hostapd.printf(`Reload WPA PSK file for bss ${config.ifname}: ${ret}`);
+}
+
+function normalize_rxkhs(txt)
+{
+	const pat = {
+		sep: "\x20",
+		mac: "([[:xdigit:]]{2}:?){5}[[:xdigit:]]{2}",
+		r0kh_id: "[\x21-\x7e]{1,48}",
+		r1kh_id: "([[:xdigit:]]{2}:?){5}[[:xdigit:]]{2}",
+		key: "[[:xdigit:]]{32,}",
+		r0kh: function() {
+			return "r0kh=" + this.mac + this.sep + this.r0kh_id;
+		},
+		r1kh: function() {
+			return "r1kh=" + this.mac + this.sep + this.r1kh_id;
+		},
+		rxkh: function() {
+			return "(" + this.r0kh() + "|" + this.r1kh() + ")" + this.sep + this.key;
+		},
+	};
+
+	let rxkhs = filter(
+		split(txt, "\n"), (line) => match(line, regexp("^" + pat.rxkh() + "$"))
+	) ?? [];
+
+	rxkhs = map(rxkhs, function(k) {
+		k = split(k, " ", 3);
+		k[0] = lc(k[0]);
+		if(match(k[0], /^r1kh/)) {
+			k[1] = lc(k[1]);
+		}
+		if(!k[2] = hostapd.rkh_derive_key(k[2])) {
+			return;
+		}
+		return join(" ", k);
+	});
+
+	return join("\n", sort(filter(rxkhs, length)));
+}
+
+function bss_reload_rxkhs(bss, config, old_config)
+{
+	let bss_rxkhs = join("\n", sort(split(bss.ctrl("GET_RXKHS"), "\n")));
+	let bss_rxkhs_hash = hostapd.sha1(bss_rxkhs);
+
+	if (is_equal(config.hash.rxkh_file, bss_rxkhs_hash)) {
+		if (is_equal(old_config.hash.rxkh_file, config.hash.rxkh_file))
+			return;
+	}
+
+	old_config.hash.rxkh_file = config.hash.rxkh_file;
+	if (!is_equal(old_config, config))
+		return;
+
+	let ret = bss.ctrl("RELOAD_RXKHS");
+	ret ??= "failed";
+
+	hostapd.printf(`Reload RxKH file for bss ${config.ifname}: ${ret}`);
 }
 
 function remove_file_fields(config)
@@ -614,6 +673,10 @@ function iface_reload_config(phydev, config, old_config)
 		if (is_equal(config.bss[i], bss_list_cfg[i]))
 			continue;
 
+		bss_reload_rxkhs(bss, config.bss[i], bss_list_cfg[i]);
+		if (is_equal(config.bss[i], bss_list_cfg[i]))
+			continue;
+
 		hostapd.printf(`Reload config for bss '${config.bss[0].ifname}' on phy '${phy}'`);
 		if (bss.set_config(config_inline, i) < 0) {
 			hostapd.printf(`Failed to set config for bss ${ifname}`);
@@ -730,8 +793,13 @@ function iface_load_config(filename)
 			continue;
 		}
 
-		if (hostapd.data.file_fields[val[0]])
-			bss.hash[val[0]] = hostapd.sha1(readfile(val[1]));
+		if (hostapd.data.file_fields[val[0]]) {
+			if (val[0] == "rxkh_file") {
+				bss.hash[val[0]] = hostapd.sha1(normalize_rxkhs(readfile(val[1])));
+			} else {
+				bss.hash[val[0]] = hostapd.sha1(readfile(val[1]));
+			}
+		}
 
 		push(bss.data, line);
 	}

--- a/package/network/services/hostapd/src/src/ap/ucode.c
+++ b/package/network/services/hostapd/src/src/ap/ucode.c
@@ -718,6 +718,7 @@ int hostapd_ucode_init(struct hapd_interfaces *ifaces)
 		{ "printf",	uc_wpa_printf },
 		{ "getpid", uc_wpa_getpid },
 		{ "sha1", uc_wpa_sha1 },
+		{ "rkh_derive_key", uc_wpa_rkh_derive_key },
 		{ "freq_info", uc_wpa_freq_info },
 		{ "add_iface", uc_hostapd_add_iface },
 		{ "remove_iface", uc_hostapd_remove_iface },

--- a/package/network/services/hostapd/src/src/utils/ucode.c
+++ b/package/network/services/hostapd/src/src/utils/ucode.c
@@ -3,6 +3,7 @@
 #include "utils/eloop.h"
 #include "crypto/crypto.h"
 #include "crypto/sha1.h"
+#include "crypto/sha256.h"
 #include "common/ieee802_11_common.h"
 #include <linux/netlink.h>
 #include <linux/genetlink.h>
@@ -234,6 +235,40 @@ uc_value_t *uc_wpa_sha1(uc_vm_t *vm, size_t nargs)
 		sprintf(hash_hex + 2 * i, "%02x", hash[i]);
 
 	return ucv_string_new_length(hash_hex, 2 * ARRAY_SIZE(hash));
+}
+
+uc_value_t *uc_wpa_rkh_derive_key(uc_vm_t *vm, size_t nargs)
+{
+	u8 oldkey[16];
+	char *oldkey_hex;
+	u8 key[SHA256_MAC_LEN];
+	size_t key_len = sizeof(key);
+	char key_hex[2 * ARRAY_SIZE(key) + 1];
+	uc_value_t *val = uc_fn_arg(0);
+	int i;
+
+	if (ucv_type(val) != UC_STRING)
+		return NULL;
+
+	oldkey_hex = ucv_string_get(val);
+
+	if (!hexstr2bin(oldkey_hex, key, key_len))
+		return ucv_string_new_length(oldkey_hex, 2 * ARRAY_SIZE(key));
+
+	if (hexstr2bin(oldkey_hex, oldkey, sizeof(oldkey))) {
+		wpa_printf(MSG_ERROR, "Invalid RxKH key: '%s'", oldkey_hex);
+		return NULL;
+	}
+
+	if (hmac_sha256_kdf(oldkey, sizeof(oldkey), "FT OLDKEY", NULL, 0, key, key_len) < 0) {
+		wpa_printf(MSG_ERROR, "Invalid RxKH key: '%s'", oldkey_hex);
+		return NULL;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(key); i++)
+		sprintf(key_hex + 2 * i, "%02x", key[i]);
+
+	return ucv_string_new_length(key_hex, 2 * ARRAY_SIZE(key));
 }
 
 uc_vm_t *wpa_ucode_create_vm(void)

--- a/package/network/services/hostapd/src/src/utils/ucode.h
+++ b/package/network/services/hostapd/src/src/utils/ucode.h
@@ -25,6 +25,7 @@ uc_value_t *uc_wpa_udebug_set(uc_vm_t *vm, size_t nargs);
 uc_value_t *uc_wpa_printf(uc_vm_t *vm, size_t nargs);
 uc_value_t *uc_wpa_getpid(uc_vm_t *vm, size_t nargs);
 uc_value_t *uc_wpa_sha1(uc_vm_t *vm, size_t nargs);
+uc_value_t *uc_wpa_rkh_derive_key(uc_vm_t *vm, size_t nargs);
 uc_value_t *uc_wpa_freq_info(uc_vm_t *vm, size_t nargs);
 
 #endif


### PR DESCRIPTION
With rxkh_file, hostapd will read a list of RxKHs from a text file.
This also makes it possible for hostapd to dynamically reload RxKHs.

RxKHs defined in rxkh_file should be formated as described in hostapd.conf,
with one entry per line.

R0KH/R1KH format:
r0kh=<MAC address> <NAS Identifier> <256-bit key as hex string>
r1kh=<MAC address> <R1KH-ID> <256-bit key as hex string>

Reworked behavior of the uci options r0kh and r1kh.

When rxkh_file is not configured:
  Instead of appending the RxKHs to the hostapd bss configuration.
  They will be added to a interface specific file with name
  /var/run/hostapd-phyX-apX.rxkh.
  This file will be used as the rxkh_file in the hostapd bss configuration.

When rxkh_file is configured:
  The specified file will be used in the hostapd bss configuration,
  and will be the only source for configured RxKHs.
  All RxKHs defined with the uci options r0kh or r1kh will be ignored.


Initial support for dynamic reload of RxKHs.

In order to check if RxKHs need reloading.
RxKHs defined in the rxkh_file first has to be parsed and formated,
the same way as hostapd will read from the file and also output,
with the command GET_RXKHS.
Then each list of RxKHs can be hashed and compared.

Ucode implementation of hostapds rkh_derive_key() function.
Hostapd converts hex keys with 128-bits or more when less than 256-bits
to 256-bits, and truncates those that are more than 256-bits.
See: https://w1.fi/cgit/hostap/commit/hostapd/config_file.c?id=245fc96e5f4b1c566b7eaa19180c774307ebed79