### PR TITLE
ipq40xx: add DSL firmware packages

### DIFF
--- a/package/firmware/lantiq/dsl_vr11_firmware_xdsl/Makefile
+++ b/package/firmware/lantiq/dsl_vr11_firmware_xdsl/Makefile
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dsl_vr11_firmware_xdsl
+PKG_VERSION:=8.13.1.5.0.7
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://gitlab.com/prpl-foundation/intel/dsl_vr11_firmware_xdsl.git
+PKG_SOURCE_VERSION:=99cf1fe7a1711b9aa128eeb8419eab698448df9f
+PKG_MIRROR_HASH:=7fb37723f8db2558d774ba972f011598d2399609158c5dbc287eca0873b040f1
+
+PKG_LICENSE:=MaxLinear-Software-License-Agreement
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+ANNEX_A_VER:=8D1507_8D0901
+
+define Package/$(PKG_NAME)
+  SECTION:=firmware
+  CATEGORY:=Firmware
+  TITLE:=VRX518 / VR11 CPE xDSL Annex A firmware
+  URL:=http://www.intel.com
+  DEPENDS:=@TARGET_ipq40xx
+endef
+
+define Package/$(PKG_NAME)/description
+  VRX518 / VR11 CPE VDSL and ADSL Annex A firmware
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/lib/firmware/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/LICENSE $(1)/lib/firmware/xcpe_$(ANNEX_A_VER).bin.LICENSE
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/xcpe_$(ANNEX_A_VER).bin $(1)/lib/firmware/
+	ln -s xcpe_$(ANNEX_A_VER).bin $(1)/lib/firmware/vdsl.bin
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/package/firmware/lantiq/vrx518_aca_fw/Makefile
+++ b/package/firmware/lantiq/vrx518_aca_fw/Makefile
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=vrx518_aca_fw
+PKG_VERSION:=1.5.0
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://gitlab.com/prpl-foundation/intel/vrx518_aca_fw.git
+PKG_SOURCE_VERSION:=c509b89c77c26a7df0f0999aabf78b82ca9c9ff0
+PKG_MIRROR_HASH:=fba91071f18599617434d93e78c67dad91b3e4c5811b77c15961e3a13b506d2e
+
+PKG_LICENSE:=MaxLinear-Software-License-Agreement
+PKG_LICENSE_FILES:=platform/xrx500/LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=firmware
+  CATEGORY:=Firmware
+  TITLE:=VRX518 ACA firmware
+  URL:=http://www.intel.com
+  DEPENDS:=@TARGET_ipq40xx
+endef
+
+define Package/$(PKG_NAME)/description
+  VRX518 ACA firmware
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/lib/firmware/09a9
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/platform/xrx500/LICENSE $(1)/lib/firmware/09a9/aca_fw.bin.LICENSE
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/platform/xrx500/aca_fw.bin $(1)/lib/firmware/09a9
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/package/firmware/lantiq/vrx518_ppe_fw/Makefile
+++ b/package/firmware/lantiq/vrx518_ppe_fw/Makefile
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=vrx518_ppe_fw
+PKG_VERSION:=1.3.7
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://gitlab.com/prpl-foundation/intel/vrx518_ppe_fw.git
+PKG_SOURCE_VERSION:=47c48d52ba59df733ab21fd0c18f6d1a7b0e7229
+PKG_MIRROR_HASH:=33dd15b6c6205b5031498aac9a5a4876f8217aefea06dc511ac60ca1343b50d1
+
+PKG_LICENSE:=MaxLinear-Software-License-Agreement
+PKG_LICENSE_FILES:=platform/xrx500/LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/$(PKG_NAME)
+  SECTION:=firmware
+  CATEGORY:=Firmware
+  TITLE:=VRX518 PPE firmware
+  URL:=http://www.intel.com
+  DEPENDS:=@TARGET_ipq40xx
+endef
+
+define Package/$(PKG_NAME)/description
+  VRX518 PPE firmware
+endef
+
+define Build/Compile
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/lib/firmware
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/platform/xrx500/LICENSE $(1)/lib/firmware/ppe_fw.bin.LICENSE
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/platform/xrx500/ppe_fw.bin $(1)/lib/firmware/
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/package/kernel/lantiq/ltq-vdsl-vr11/Makefile
+++ b/package/kernel/lantiq/ltq-vdsl-vr11/Makefile
@@ -27,13 +27,11 @@ PKG_BUILD_FLAGS:=no-mold
 
 include $(INCLUDE_DIR)/package.mk
 
-# TODO this driver depends on the vrx518 dsl firmware, add this dependency if
-# that ever gets a compatible license
 define KernelPackage/ltq-vdsl-vr11
   TITLE:=vdsl driver
   SECTION:=sys
   SUBMENU:=Network Devices
-  DEPENDS:=@TARGET_ipq40xx +kmod-ltq-vdsl-vr11-mei
+  DEPENDS:=@TARGET_ipq40xx +kmod-ltq-vdsl-vr11-mei +dsl_vr11_firmware_xdsl
   FILES:=$(PKG_BUILD_DIR)/src/drv_dsl_cpe_api.ko
   AUTOLOAD:=$(call AutoLoad,51,drv_dsl_cpe_api)
 endef

--- a/package/kernel/lantiq/vrx518_ep/Makefile
+++ b/package/kernel/lantiq/vrx518_ep/Makefile
@@ -15,14 +15,12 @@ PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk
 
-# TODO this driver depends on the vrx518 aca firmware, add this dependency if
-# that ever gets a compatible license
 define KernelPackage/vrx518_ep
   SECTION:=sys
   CATEGORY:=Kernel modules
   SUBMENU:=Network Devices
   TITLE:=VRX518 EP Support
-  DEPENDS:=@TARGET_ipq40xx
+  DEPENDS:=@TARGET_ipq40xx +vrx518_aca_fw
   AUTOLOAD:=$(call AutoLoad,26,vrx518)
   FILES:=$(PKG_BUILD_DIR)/vrx518.ko
 endef

--- a/package/kernel/lantiq/vrx518_tc/Makefile
+++ b/package/kernel/lantiq/vrx518_tc/Makefile
@@ -28,8 +28,6 @@ include $(INCLUDE_DIR)/package.mk
 PLAT_DIR:=dcdp
 PKG_EXTMOD_SUBDIRS:=$(PLAT_DIR)
 
-# TODO this driver depends on the vrx518 ppe firmware, add this dependency if
-# that ever gets a compatible license
 define KernelPackage/$(PKG_NAME)
   SECTION:=sys
   CATEGORY:=Kernel modules
@@ -39,7 +37,7 @@ define KernelPackage/$(PKG_NAME)
     CONFIG_ATM_LANE=m \
     CONFIG_ATM_MPOA=m \
     CONFIG_ATM_MPOA_INTEL_DSL_PHY_SUPPORT=y
-  DEPENDS:=@TARGET_ipq40xx +kmod-vrx518_ep +kmod-crypto-md5 +kmod-atm +kmod-ipoa +br2684ctl
+  DEPENDS:=@TARGET_ipq40xx +kmod-vrx518_ep +vrx518_ppe_fw +kmod-crypto-md5 +kmod-atm +kmod-ipoa +br2684ctl
   AUTOLOAD:=$(call AutoLoad,27,vrx518_tc)
   FILES:=$(PKG_BUILD_DIR)/$(PLAT_DIR)/$(PKG_NAME).ko
 endef


### PR DESCRIPTION
Finally we got some movement for the firmware licenses: https://prplfoundationcloud.atlassian.net/browse/PCI-16

>2.	Grant of License.  Subject to your compliance with the restrictions set
>forth in this Agreement, MaxLinear hereby grants to you a non-exclusive,
>non-transferable license during the Term to install, copy, use, distribute in
>binary form only, and host the Software. If you received the Software from
>MaxLinear in source code format, you may also modify the Software.

IANAL, but to me this sounds like we can now bundle, ship and host the missing firmware files to provide dsl functionality out of the box.

So this adds the firmware packages and adds a slightly related patch on top