### PR TITLE
WIP: mediatek: filogic: add support for Keenetic KN-3411

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -716,6 +716,10 @@ define Build/zip
 	rm -rf $@.tmp
 endef
 
+define Build/zyimage
+	$(STAGING_DIR_HOST)/bin/zyimage $(1) $@
+endef
+
 define Build/zyxel-ras-image
 	let \
 		newsize="$(call exp_units,$(RAS_ROOTFS_SIZE))"; \

--- a/target/linux/generic/pending-6.6/489-mtd-spinand-add-support-for-HeYangTek-HYF1GQ4UDACAE.patch
+++ b/target/linux/generic/pending-6.6/489-mtd-spinand-add-support-for-HeYangTek-HYF1GQ4UDACAE.patch
@@ -1,0 +1,155 @@
+From bcda7d75e60c1a433f7146e9d30951798c1e78c3 Mon Sep 17 00:00:00 2001
+From: Maxim Anisimov <maxim.anisimov.ua@gmail.com>
+Date: Fri, 24 May 2024 11:03:17 +0300
+Subject: [PATCH] mtd: spinand: add support for HeYangTek HYF1GQ4UDACAE
+
+Add support for HeYangTek HYF1GQ4UDACAE SPI NAND.
+Datasheet:
+  https://www.heyangtek.cn/previewfile.jsp?file=ABUIABA9GAAgwsvRnwYo-eDpsgc
+
+This commit is based on https://github.com/keenetic/kernel-49/commit/bacade569fb12bc0ad31ba09bca9b890118fbca7
+
+Signed-off-by: Maxim Anisimov <maxim.anisimov.ua@gmail.com>
+---
+ drivers/mtd/nand/spi/Makefile    |   2 +-
+ drivers/mtd/nand/spi/core.c      |   1 +
+ drivers/mtd/nand/spi/heyangtek.c | 104 +++++++++++++++++++++++++++++++
+ include/linux/mtd/spinand.h      |   1 +
+ 4 files changed, 107 insertions(+), 1 deletion(-)
+ create mode 100644 drivers/mtd/nand/spi/heyangtek.c
+
+--- a/drivers/mtd/nand/spi/Makefile
++++ b/drivers/mtd/nand/spi/Makefile
+@@ -1,4 +1,4 @@
+ # SPDX-License-Identifier: GPL-2.0
+ spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o gigadevice.o
+-spinand-objs += macronix.o micron.o paragon.o toshiba.o winbond.o xtx.o
++spinand-objs += heyangtek.o macronix.o micron.o paragon.o toshiba.o winbond.o xtx.o
+ obj-$(CONFIG_MTD_SPI_NAND) += spinand.o
+--- a/drivers/mtd/nand/spi/core.c
++++ b/drivers/mtd/nand/spi/core.c
+@@ -942,6 +942,7 @@ static const struct spinand_manufacturer
+ 	&esmt_c8_spinand_manufacturer,
+ 	&etron_spinand_manufacturer,
+ 	&gigadevice_spinand_manufacturer,
++	&heyangtek_spinand_manufacturer,
+ 	&macronix_spinand_manufacturer,
+ 	&micron_spinand_manufacturer,
+ 	&paragon_spinand_manufacturer,
+--- /dev/null
++++ b/drivers/mtd/nand/spi/heyangtek.c
+@@ -0,0 +1,104 @@
++// SPDX-License-Identifier: GPL-2.0
++
++#include <linux/device.h>
++#include <linux/kernel.h>
++#include <linux/mtd/spinand.h>
++
++#define SPINAND_MFR_HEYANGTEK		0xC9
++
++#define STATUS_ECC_LIMIT_BITFLIPS	(3 << 4)
++
++static SPINAND_OP_VARIANTS(read_cache_variants,
++		SPINAND_PAGE_READ_FROM_CACHE_QUADIO_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_X4_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_DUALIO_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_X2_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_OP(true, 0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_OP(false, 0, 1, NULL, 0));
++
++static SPINAND_OP_VARIANTS(write_cache_variants,
++		SPINAND_PROG_LOAD_X4(true, 0, NULL, 0),
++		SPINAND_PROG_LOAD(true, 0, NULL, 0));
++
++static SPINAND_OP_VARIANTS(update_cache_variants,
++		SPINAND_PROG_LOAD_X4(false, 0, NULL, 0),
++		SPINAND_PROG_LOAD(false, 0, NULL, 0));
++
++static int hyfxgq4uda_ooblayout_ecc(struct mtd_info *mtd, int section,
++				   struct mtd_oob_region *region)
++{
++	if (section > 3)
++		return -ERANGE;
++
++	region->offset = section * 16 + 8;
++	region->length = 8;
++
++	return 0;
++}
++
++static int hyfxgq4uda_ooblayout_free(struct mtd_info *mtd, int section,
++				   struct mtd_oob_region *region)
++{
++	if (section > 3)
++		return -ERANGE;
++
++	/* ECC-protected user meta-data */
++	region->offset = section * 16 + 4;
++	region->length = 4;
++
++	return 0;
++}
++
++static const struct mtd_ooblayout_ops hyfxgq4uda_ooblayout = {
++	.ecc = hyfxgq4uda_ooblayout_ecc,
++	.free = hyfxgq4uda_ooblayout_free,
++};
++
++static int hyfxgq4uda_ecc_get_status(struct spinand_device *spinand,
++					u8 status)
++{
++	struct nand_device *nand = spinand_to_nand(spinand);
++
++	switch (status & STATUS_ECC_MASK) {
++	case STATUS_ECC_NO_BITFLIPS:
++		return 0;
++
++	case STATUS_ECC_UNCOR_ERROR:
++		return -EBADMSG;
++
++	case STATUS_ECC_HAS_BITFLIPS:
++		return nanddev_get_ecc_conf(nand)->strength >> 1;
++
++	case STATUS_ECC_LIMIT_BITFLIPS:
++		return nanddev_get_ecc_conf(nand)->strength;
++
++	default:
++		break;
++	}
++
++	return -EINVAL;
++}
++
++static const struct spinand_info heyangtek_spinand_table[] = {
++	SPINAND_INFO("HYF1GQ4UDACAE",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_ADDR, 0x21),
++		     NAND_MEMORG(1, 2048, 64, 64, 1024, 20, 1, 1, 1),
++		     NAND_ECCREQ(4, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&hyfxgq4uda_ooblayout,
++				     hyfxgq4uda_ecc_get_status)),
++};
++
++static const struct spinand_manufacturer_ops heyangtek_spinand_manuf_ops = {
++};
++
++const struct spinand_manufacturer heyangtek_spinand_manufacturer = {
++	.id = SPINAND_MFR_HEYANGTEK,
++	.name = "HeYangTek",
++	.chips = heyangtek_spinand_table,
++	.nchips = ARRAY_SIZE(heyangtek_spinand_table),
++	.ops = &heyangtek_spinand_manuf_ops,
++};
+--- a/include/linux/mtd/spinand.h
++++ b/include/linux/mtd/spinand.h
+@@ -265,6 +265,7 @@ extern const struct spinand_manufacturer
+ extern const struct spinand_manufacturer esmt_c8_spinand_manufacturer;
+ extern const struct spinand_manufacturer etron_spinand_manufacturer;
+ extern const struct spinand_manufacturer gigadevice_spinand_manufacturer;
++extern const struct spinand_manufacturer heyangtek_spinand_manufacturer;
+ extern const struct spinand_manufacturer macronix_spinand_manufacturer;
+ extern const struct spinand_manufacturer micron_spinand_manufacturer;
+ extern const struct spinand_manufacturer paragon_spinand_manufacturer;

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3411.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3411.dts
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+#include "mt7981.dtsi"
+
+/ {
+	model = "Keenetic KN-3411";
+	compatible = "keenetic,kn-3411", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+		label-mac-device = &gmac1;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 29 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: led-0 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-1 {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-2 {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	/* HeYang HYF1GQ4UDACAE (128M) */
+	spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* bl2 */
+			partition@0 {
+				label = "preloader";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			/* fip */
+			partition@80000 {
+				label = "u-boot";
+				reg = <0x80000 0x200000>;
+				read-only;
+			};
+
+			partition@280000 {
+				label = "u-config";
+				reg = <0x280000 0x80000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "rf-eeprom";
+				reg = <0x300000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			/* firmware_1 */
+			partition@500000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0x500000 0x3500000>;
+			};
+
+			partition@3a00000 {
+				label = "config_1";
+				reg = <0x3a00000 0x80000>;
+				read-only;
+			};
+
+			partition@3a80000 {
+				label = "dump";
+				reg = <0x3a80000 0x80000>;
+				read-only;
+			};
+
+			partition@3c00000 {
+				label = "u-state";
+				reg = <0x3c00000 0x20000>;
+				read-only;
+			};
+
+			partition@3e80000 {
+				label = "u-config_res";
+				reg = <0x3e80000 0x80000>;
+				read-only;
+			};
+
+			partition@3f00000 {
+				label = "rf-eeprom_res";
+				reg = <0x3f00000 0x200000>;
+				read-only;
+			};
+
+			/* firmware_2 */
+			partition@4100000 {
+				label = "ubi";
+				reg = <0x4140000 0x3500000>;
+			};
+
+			partition@7600000 {
+				label = "config_2";
+				reg = <0x7600000 0x80000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 0>;
+	};
+};
+
+&wifi {
+	nvmem-cell-names = "eeprom";
+	nvmem-cells = <&eeprom_factory_0>;
+	status = "okay";
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -86,6 +86,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2" eth1
 		;;
 	cudy,re3000-v1|\
+	keenetic,kn-3411|\
 	netgear,wax220|\
 	ubnt,unifi-6-plus|\
 	zyxel,nwa50ax-pro)

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/75_rootfs_prepare
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/75_rootfs_prepare
@@ -21,6 +21,39 @@ rootfs_create() {
 
 rootfs_prepare() {
 	case $(board_name) in
+	keenetic,kn-3411)
+		local mtdnum ubidev ubivol
+
+		. /lib/upgrade/nand.sh
+
+		ubidev=$(nand_find_ubi ubi)
+		if [ ! "$ubidev" ]; then
+			mtdnum=$(find_mtd_index ubi)
+			if [ ! "$mtdnum" ]; then
+				echo "Can't find mtd partition ubi"
+				return 1
+			fi
+
+			ubiformat "/dev/mtd$mtdnum" -y
+			ubiattach -m "$mtdnum"
+
+			ubidev=$(nand_find_ubi ubi)
+			if [ ! "$ubidev" ]; then
+				echo "Can't attach mtd partition ubi"
+				return 1
+			fi
+		fi
+		if ! ubinfo "/dev/$ubidev" -N rootfs_data &>/dev/null; then
+			echo "Creating \"rootfs_data\" UBI volume"
+
+			ubimkvol "/dev/$ubidev" -N rootfs_data -m
+			ubivol=$(nand_find_volume "$ubidev" rootfs_data)
+			if [ ! "$ubivol" ]; then
+				echo "Can't find ubifs data volume"
+				return 1
+			fi
+		fi
+		;;
 	netgear,wax220)
 		if ! ubinfo /dev/ubi0 -N rootfs_data &>/dev/null; then
 			echo "Creating \"rootfs_data\" UBI volume"

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -737,6 +737,21 @@ define Device/jdcloud_re-cp-03
 endef
 TARGET_DEVICES += jdcloud_re-cp-03
 
+define Device/keenetic_kn-3411
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KN-3411
+  DEVICE_DTS := mt7981b-keenetic-kn-3411
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  IMAGE_SIZE := 54272k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to 128k | append-rootfs | \
+	pad-to 128k | check-size $$(IMAGE_SIZE) | zyimage -d 0x803411 -v "KN-3411"
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | \
+        pad-to 128k | append-metadata
+endef
+TARGET_DEVICES += keenetic_kn-3411
+
 define Device/mediatek_mt7981-rfb
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7981 rfb

--- a/target/linux/mediatek/patches-6.6/330-snand-mtk-bmt-support.patch
+++ b/target/linux/mediatek/patches-6.6/330-snand-mtk-bmt-support.patch
@@ -8,7 +8,7 @@
  
  static int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
  {
-@@ -1345,6 +1346,7 @@ static int spinand_probe(struct spi_mem
+@@ -1346,6 +1347,7 @@ static int spinand_probe(struct spi_mem
  	if (ret)
  		return ret;
  
@@ -16,7 +16,7 @@
  	ret = mtd_device_register(mtd, NULL, 0);
  	if (ret)
  		goto err_spinand_cleanup;
-@@ -1352,6 +1354,7 @@ static int spinand_probe(struct spi_mem
+@@ -1353,6 +1355,7 @@ static int spinand_probe(struct spi_mem
  	return 0;
  
  err_spinand_cleanup:
@@ -24,7 +24,7 @@
  	spinand_cleanup(spinand);
  
  	return ret;
-@@ -1370,6 +1373,7 @@ static int spinand_remove(struct spi_mem
+@@ -1371,6 +1374,7 @@ static int spinand_remove(struct spi_mem
  	if (ret)
  		return ret;
  

--- a/target/linux/mediatek/patches-6.6/340-mtd-spinand-Add-support-for-the-Fidelix-FM35X1GA.patch
+++ b/target/linux/mediatek/patches-6.6/340-mtd-spinand-Add-support-for-the-Fidelix-FM35X1GA.patch
@@ -20,7 +20,7 @@ Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>
  # SPDX-License-Identifier: GPL-2.0
 -spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o gigadevice.o
 +spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o fidelix.o gigadevice.o
- spinand-objs += macronix.o micron.o paragon.o toshiba.o winbond.o xtx.o
+ spinand-objs += heyangtek.o macronix.o micron.o paragon.o toshiba.o winbond.o xtx.o
  obj-$(CONFIG_MTD_SPI_NAND) += spinand.o
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
@@ -31,7 +31,7 @@ Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>
 +	&fidelix_spinand_manufacturer,
  	&etron_spinand_manufacturer,
  	&gigadevice_spinand_manufacturer,
- 	&macronix_spinand_manufacturer,
+ 	&heyangtek_spinand_manufacturer,
 --- /dev/null
 +++ b/drivers/mtd/nand/spi/fidelix.c
 @@ -0,0 +1,76 @@
@@ -119,5 +119,5 @@ Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>
  extern const struct spinand_manufacturer etron_spinand_manufacturer;
 +extern const struct spinand_manufacturer fidelix_spinand_manufacturer;
  extern const struct spinand_manufacturer gigadevice_spinand_manufacturer;
+ extern const struct spinand_manufacturer heyangtek_spinand_manufacturer;
  extern const struct spinand_manufacturer macronix_spinand_manufacturer;
- extern const struct spinand_manufacturer micron_spinand_manufacturer;

--- a/target/linux/mediatek/patches-6.6/435-drivers-mtd-spinand-Add-calibration-support-for-spin.patch
+++ b/target/linux/mediatek/patches-6.6/435-drivers-mtd-spinand-Add-calibration-support-for-spin.patch
@@ -11,7 +11,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -979,6 +979,56 @@ static int spinand_manufacturer_match(st
+@@ -980,6 +980,56 @@ static int spinand_manufacturer_match(st
  	return -ENOTSUPP;
  }
  
@@ -68,7 +68,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
  static int spinand_id_detect(struct spinand_device *spinand)
  {
  	u8 *id = spinand->id.data;
-@@ -1229,6 +1279,10 @@ static int spinand_init(struct spinand_d
+@@ -1230,6 +1280,10 @@ static int spinand_init(struct spinand_d
  	if (!spinand->scratchbuf)
  		return -ENOMEM;
  

--- a/target/linux/mediatek/patches-6.6/436-drivers-mtd-spi-nor-Add-calibration-support-for-spi-.patch
+++ b/target/linux/mediatek/patches-6.6/436-drivers-mtd-spi-nor-Add-calibration-support-for-spi-.patch
@@ -12,7 +12,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1020,7 +1020,10 @@ int spinand_cal_read(void *priv, u32 *ad
+@@ -1021,7 +1021,10 @@ int spinand_cal_read(void *priv, u32 *ad
  	if (ret)
  		return ret;
  

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -167,10 +167,6 @@ define Build/wrg-header
 	mv $@.new $@
 endef
 
-define Build/zyimage
-	$(STAGING_DIR_HOST)/bin/zyimage $(1) $@
-endef
-
 define Device/Default
   PROFILES = Default
   BLOCKSIZE := 64k


### PR DESCRIPTION
Add Keenetic KN-3411 support
Specification:
 - MT7981 CPU using 2.4GHz and 5GHz WiFi (both AX)
 - 256MB RAM
 - 128MB SPI NAND
 - 3 LEDs (red, green, blue)
 - 1 button (reset)
 - 1 1Gbit ethernet port (integrated phy)

Serial Interface:
 - 3 Pins GND, RX, TX
 - Settings: 115200, 8N1

Notes:
 - The device supports dual boot mode
 - Factory bootloader does not support image with ubi (only kernel (fit) + squashfs is accepted)
 - Leds: green - status, red - 2.4 Ghz, blue - 5 Ghz
 - Second firmware partition (firmware_2) is used for rootfs_data and formated as ubi

Flash instruction:
The only way to flash OpenWrt image is to use tftp recovery mode in U-Boot:

1. Configure PC with static IP 192.168.1.2/24 and tftp server.
2. Rename "openwrt-mediatek-filogic-keenetic_kn-3411-squashfs-factory.bin"
   to "KN-3411_recovery.bin" and place it in tftp server directory.
3. Connect PC with ethernet port, press the reset button, power up
   the device and keep button pressed until status led start blinking.
4. Device will download file from server, write it to flash and reboot.

Signed-off-by: Maxim Anisimov <maxim.anisimov.ua@gmail.com>
