### PR TITLE
scripts: Add GNU ftp mirror redirector for GNU and Savannah

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -272,6 +272,7 @@ foreach my $mirror (@ARGV) {
 			push @mirrors, "https://raw.githubusercontent.com/$1";
 		}
 	} elsif ($mirror =~ /^\@GNU\/(.+)$/) {
+		push @mirrors, "https://ftpmirror.gnu.org/$1";
 		push @mirrors, "https://mirror.csclub.uwaterloo.ca/gnu/$1";
 		push @mirrors, "https://mirror.netcologne.de/gnu/$1";
 		push @mirrors, "https://ftp.kddilabs.jp/GNU/gnu/$1";
@@ -282,6 +283,7 @@ foreach my $mirror (@ARGV) {
 		push @mirrors, "https://mirrors.tuna.tsinghua.edu.cn/gnu/$1";
 		push @mirrors, "https://mirrors.ustc.edu.cn/gnu/$1";
 	} elsif ($mirror =~ /^\@SAVANNAH\/(.+)$/) {
+		push @mirrors, "https://download.savannah.nongnu.org/releases/$1";
 		push @mirrors, "https://mirror.netcologne.de/savannah/$1";
 		push @mirrors, "https://mirror.csclub.uwaterloo.ca/nongnu/$1";
 		push @mirrors, "https://ftp.acc.umu.se/mirror/gnu.org/savannah/$1";


### PR DESCRIPTION
Add GNU's redirector which automatically redirect user to nearby "online" mirror. Gets faster speeds due to nearby mirror.

Adding as https://github.com/openwrt/openwrt/pull/14198 was closed.
