### PR TITLE
firewall: add rules to access from WAN

### DIFF
--- a/package/network/config/firewall/files/firewall.config
+++ b/package/network/config/firewall/files/firewall.config
@@ -146,42 +146,48 @@ config include
 
 
 ### EXAMPLE CONFIG SECTIONS
-# do not allow a specific ip to access wan
-#config rule
-#	option src		lan
-#	option src_ip	192.168.45.2
-#	option dest		wan
-#	option proto	tcp
-#	option target	REJECT
 
-# block a specific mac on wan
-#config rule
-#	option dest		wan
-#	option src_mac	00:11:22:33:44:66
-#	option target	REJECT
+config rule 'example_block_ip'
+	option name 'Block a specific ip to access wan'
+	option enabled '0'
+	option src		'lan'
+	option src_ip	'192.168.45.2'
+	option dest		'wan'
+	option proto	'tcp'
+	option target	'REJECT'
 
-# block incoming ICMP traffic on a zone
-#config rule
-#	option src		lan
-#	option proto	ICMP
-#	option target	DROP
+config rule 'example_block_mac'
+	option name 'Block a specific mac on wan'
+	option enabled '0'
+	option dest		'wan'
+	option src_mac	'00:11:22:33:44:66'
+	option target	'REJECT'
 
-# port redirect port coming in on wan to lan
-#config redirect
-#	option src			wan
-#	option src_dport	80
-#	option dest			lan
-#	option dest_ip		192.168.16.235
-#	option dest_port	80
-#	option proto		tcp
+config rule 'example_block_icmp'
+	option name 'Block incoming ICMP traffic on a zone'
+	option enabled '0'
+	option src		'lan'
+	option proto	'ICMP'
+	option target	'DROP'
 
-# port redirect of remapped ssh port (22001) on wan
-#config redirect
-#	option src		wan
-#	option src_dport	22001
-#	option dest		lan
-#	option dest_port	22
-#	option proto		tcp
+config redirect 'example_port_forward_http'
+	option name 'Port redirect port coming in on wan to lan'
+	option enabled '0'
+	option src			'wan'
+	option src_dport	'80'
+	option dest			'lan'
+	option dest_ip		'192.168.16.235'
+	option dest_port	'80'
+	option proto		'tcp'
+
+config redirect 'example_port_forward_ssh'
+	option name 'Port redirect of remapped ssh port (22001) on wan'
+	option enabled '0'
+	option src		'wan'
+	option src_dport	'22001'
+	option dest		'lan'
+	option dest_port	'22'
+	option proto		'tcp'
 
 ### FULL CONFIG SECTIONS
 #config rule

--- a/package/network/config/firewall/files/firewall.config
+++ b/package/network/config/firewall/files/firewall.config
@@ -189,6 +189,23 @@ config redirect 'example_port_forward_ssh'
 	option dest_port	'22'
 	option proto		'tcp'
 
+config rule 'example_wan_ssh_allow'
+	option name 'Allow SSH from WAN'
+	option enabled '0'
+	option src 'wan'
+	option proto 'tcp'
+	option dest_port '22'
+	option target 'ACCEPT'
+
+config rule 'example_wan_https_allow'
+	option name 'Allow HTTP, HTTPS from WAN'
+	option enabled '0'
+	option src 'wan'
+	option proto 'tcp'
+	option dest_port '80 443'
+	option target 'ACCEPT'
+
+
 ### FULL CONFIG SECTIONS
 #config rule
 #	option src		lan


### PR DESCRIPTION
Maintainer: @jow-
The rules are disabled, but a user will see them in config or GUI and easily enable if needed.

The whole idea is to make a Luci GUI wizard to enable WAN access https://github.com/openwrt/luci/issues/7137

Similarly, I think we should add a guest zone and a network, so that users can just enable it if needed. Will you accept a PR for this?