### PR TITLE
kernel: misc kernel package fixes

### DIFF
--- a/package/kernel/linux/modules/can.mk
+++ b/package/kernel/linux/modules/can.mk
@@ -235,9 +235,13 @@ $(eval $(call KernelPackage,can-usb-ems))
 
 define KernelPackage/can-usb-esd
   TITLE:=ESD USB/2 CAN/USB interface
-  KCONFIG:=CONFIG_CAN_ESD_USB2
-  FILES:=$(LINUX_DIR)/drivers/net/can/usb/esd_usb2.ko
-  AUTOLOAD:=$(call AutoProbe,esd_usb2)
+  KCONFIG:= \
+	CONFIG_CAN_ESD_USB2@lt6.0 \
+	CONFIG_CAN_ESD_USB@ge6.0
+  FILES:= \
+	$(LINUX_DIR)/drivers/net/can/usb/esd_usb2.ko@lt6.0 \
+	$(LINUX_DIR)/drivers/net/can/usb/esd_usb.ko@ge6.0
+  AUTOLOAD:=$(call AutoProbe,esd_usb2 esd_usb)
   $(call AddDepends/can,+kmod-usb-core)
 endef
 

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -807,7 +807,7 @@ define KernelPackage/ipt-clusterip
   KCONFIG:=$(KCONFIG_IPT_CLUSTERIP)
   FILES:=$(foreach mod,$(IPT_CLUSTERIP-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(IPT_CLUSTERIP-m)))
-  $(call AddDepends/ipt,+kmod-nf-conntrack)
+  $(call AddDepends/ipt,+kmod-nf-conntrack @LINUX_5_15||LINUX_6_1)
 endef
 
 define KernelPackage/ipt-clusterip/description


### PR DESCRIPTION
 * kernel: kmod-can-usb-esd: Fix build on kernel 6.6
    
    The kernel module and configuration option was renamed from esd_usb2.ko
    to esd_usb.ko in kernel 6.0. Adapt the kernel package.
    https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=5e910bdedc84c1f196863cebdf27c1806449c27c

 * kernel: kmod-ipt-clusterip: Depend on kernel 5.15 and 6.1
    
    The kernel module was removed in kernel 6.3.
    https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=9db5d918e2c07fa09fab18bc7addf3408da0c76f

