### PR TITLE
linux-firmware: Update to version 20240513

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
-PKG_VERSION:=20240220
+PKG_VERSION:=20240513
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=bf0f239dc0801e9d6bf5d5fb3e2f549575632cf4688f4348184199cb02c2bcd7
+PKG_HASH:=9f05edb99668135d37cedc4fdd18aac2802dc9e4566e086e6c6c2e321f3ecc4e
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
This updates the following firmware files:
airoha-en8811h-firmware/lib/firmware/airoha/EthMD32.DSP.bin
airoha-en8811h-firmware/lib/firmware/airoha/EthMD32.dm.bin
amdgpu-firmware/ (Many files)
ibt-firmware/lib/firmware/intel/ibt-0040-0041.sfi
ibt-firmware/lib/firmware/intel/ibt-0040-1020.sfi
ibt-firmware/lib/firmware/intel/ibt-0040-1050.sfi
ibt-firmware/lib/firmware/intel/ibt-0040-2120.sfi
ibt-firmware/lib/firmware/intel/ibt-0040-4150.sfi
ibt-firmware/lib/firmware/intel/ibt-0041-0041.sfi
ibt-firmware/lib/firmware/intel/ibt-0180-0041.sfi
ibt-firmware/lib/firmware/intel/ibt-0180-1050.sfi
ibt-firmware/lib/firmware/intel/ibt-0180-4150.sfi
ibt-firmware/lib/firmware/intel/ibt-0291-0291.ddc
ibt-firmware/lib/firmware/intel/ibt-0291-0291.sfi
ibt-firmware/lib/firmware/intel/ibt-1040-0041.sfi
ibt-firmware/lib/firmware/intel/ibt-1040-1020.sfi
ibt-firmware/lib/firmware/intel/ibt-1040-1050.sfi
ibt-firmware/lib/firmware/intel/ibt-1040-2120.sfi
ibt-firmware/lib/firmware/intel/ibt-1040-4150.sfi
ibt-firmware/lib/firmware/intel/ibt-17-16-1.sfi
ibt-firmware/lib/firmware/intel/ibt-17-2.sfi
ibt-firmware/lib/firmware/intel/ibt-18-16-1.sfi
ibt-firmware/lib/firmware/intel/ibt-18-2.sfi
ibt-firmware/lib/firmware/intel/ibt-19-0-0.sfi
ibt-firmware/lib/firmware/intel/ibt-19-0-1.sfi
ibt-firmware/lib/firmware/intel/ibt-19-0-4.sfi
ibt-firmware/lib/firmware/intel/ibt-19-16-4.sfi
ibt-firmware/lib/firmware/intel/ibt-19-240-1.sfi
ibt-firmware/lib/firmware/intel/ibt-19-240-4.sfi
ibt-firmware/lib/firmware/intel/ibt-19-32-0.sfi
ibt-firmware/lib/firmware/intel/ibt-19-32-1.sfi
ibt-firmware/lib/firmware/intel/ibt-19-32-4.sfi
ibt-firmware/lib/firmware/intel/ibt-20-0-3.sfi
ibt-firmware/lib/firmware/intel/ibt-20-1-3.sfi
ibt-firmware/lib/firmware/intel/ibt-20-1-4.sfi
iwlwifi-firmware-ax200/lib/firmware/iwlwifi-cc-a0-77.ucode
iwlwifi-firmware-ax201/lib/firmware/iwlwifi-QuZ-a0-hr-b0-77.ucode
iwlwifi-firmware-ax210/lib/firmware/iwlwifi-ty-a0-gf-a0.pnvm
iwlwifi-firmware-be200/lib/firmware/iwlwifi-gl-c0-fm-c0.pnvm
iwlwifi-firmware-iwl9000/lib/firmware/iwlwifi-9000-pu-b0-jf-b0-46.ucode
iwlwifi-firmware-iwl9260/lib/firmware/iwlwifi-9260-th-b0-jf-b0-46.ucode
mt7921bt-firmware/lib/firmware/mediatek/BT_RAM_CODE_MT7961_1_2_hdr.bin
mt7922bt-firmware/lib/firmware/mediatek/BT_RAM_CODE_MT7922_1_1_hdr.bin
rtl8852ce-firmware/lib/firmware/rtw89/rtw8852c_fw.bin
