### PR TITLE
iproute2: fix compilation with GCC14

### DIFF
--- a/package/network/utils/iproute2/Makefile
+++ b/package/network/utils/iproute2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iproute2
 PKG_VERSION:=6.7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/net/iproute2

--- a/package/network/utils/iproute2/patches/210-gcc-14-compatibility.patch
+++ b/package/network/utils/iproute2/patches/210-gcc-14-compatibility.patch
@@ -1,0 +1,20 @@
+--- a/lib/bpf_legacy.c
++++ b/lib/bpf_legacy.c
+@@ -16,6 +16,7 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <stdarg.h>
++#include <libgen.h>
+ #include <limits.h>
+ #include <assert.h>
+ 
+--- a/include/json_print.h
++++ b/include/json_print.h
+@@ -8,6 +8,7 @@
+ #ifndef _JSON_PRINT_H_
+ #define _JSON_PRINT_H_
+ 
++#include <sys/time.h>
+ #include "json_writer.h"
+ #include "color.h"
+ 


### PR DESCRIPTION
Fixes:
``` C
bpf_legacy.c:974:26: error: implicit declaration of function 'basename' [-Wimplicit-function-declaration]
  974 |                          basename(cfg->object), cfg->mode == EBPF_PINNED ?
      |                          ^~~~~~~~
```

Fixes:
``` C
../include/json_print.h:80:30: warning: 'struct timeval' declared inside parameter list will not be visible outside of this definition or declaration
   80 | _PRINT_FUNC(tv, const struct timeval *)
      |                              ^~~~~~~
...
../include/json_print.h:58:48: error: passing argument 5 of 'print_color_tv' from incompatible pointer type [-Wincompatible-pointer-types]
   58 |                                                value);                  \
      |                                                ^~~~~
      |                                                |
      |                                                const struct timeval *
```

Compile tested: WRT3200ACM

Maintainer: @RussellSenior 
@neheb @robimarko @1715173329 @PolynomialDivision @hauke @Ansuel @nbd168 