### PR TITLE
Dropbear: refine /etc/config/dropbear

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dropbear
 PKG_VERSION:=2024.85
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \

--- a/package/network/services/dropbear/files/dropbear.config
+++ b/package/network/services/dropbear/files/dropbear.config
@@ -1,4 +1,6 @@
-config dropbear
+# See https://openwrt.org/docs/guide-user/base-system/dropbear
+config dropbear main
+	option enable '1'
 	option PasswordAuth 'on'
 	option RootPasswordAuth 'on'
 	option Port         '22'

--- a/package/network/services/dropbear/files/dropbear.init
+++ b/package/network/services/dropbear/files/dropbear.init
@@ -361,7 +361,7 @@ dropbear_instance()
 load_interfaces()
 {
 	local enable
-	config_get enable "$1" enable 1
+	config_get_bool enable "$1" enable 1
 	[ "${enable}" = "1" ] || return 0
 
 	local direct_iface iface


### PR DESCRIPTION
Make it easier to be modified from `uci` command. As an example this will be helpful for instruction about to switching from the Dropbear to OpenSSH:

    uci set dropbear.@dropbear[-1].enable='0'

can be changed to 

    uci set dropbear.main.enable='0'

The OpenSSH option style `PasswordAuth 'on'` changed to just `PasswordAuth '1'` to avoid possible mistakes and having a same config style everywhere.

@rockdrilla @rsalvaterra @dedeckeh Please review