### PR TITLE
qualcommax: use ath11k_patch_mac for ZBT-Z800AX

### DIFF
--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -27,7 +27,6 @@ case "$FIRMWARE" in
 	xiaomi,ax3600|\
 	xiaomi,ax9000|\
 	yuncore,ax880|\
-	zbtlink,zbt-z800ax|\
 	zte,mf269)
 		caldata_extract "0:art" 0x1000 0x20000
 		;;
@@ -55,6 +54,13 @@ case "$FIRMWARE" in
 	prpl,haze|\
 	spectrum,sax1v1k)
 		caldata_extract_mmc "0:ART" 0x1000 0x20000
+		;;
+	zbtlink,zbt-z800ax)
+		caldata_extract "0:art" 0x1000 0x20000
+		label_mac=$(get_mac_label)
+		ath11k_patch_mac $(macaddr_add $label_mac -1) 0
+		ath11k_patch_mac $(macaddr_add $label_mac -2) 1
+		ath11k_set_macflag
 		;;
 	zyxel,nbg7815)
 		caldata_extract "0:art" 0x1000 0x20000

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -30,8 +30,4 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(get_mac_label) > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "2" ] && mtd_get_mac_binary boarddata1 0x12 > /sys${DEVPATH}/macaddress
 		;;
-	zbtlink,zbt-z800ax)
-		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label) -1 > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && macaddr_add $(get_mac_label) -2 > /sys${DEVPATH}/macaddress
-		;;
 esac


### PR DESCRIPTION
Use ath11k_patch_mac and ath11k_set_macflag functions instead of fix_wifi_mac script.