### PR TITLE
lantiq: disable building of ZyXEL P-2812HNU F1

### DIFF
--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -377,6 +377,7 @@ define Device/zyxel_p-2812hnu-f1
   DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport
   KERNEL_SIZE := 3072k
   SUPPORTED_DEVICES += P2812HNUF1
+  DEFAULT := n
 endef
 TARGET_DEVICES += zyxel_p-2812hnu-f1
 


### PR DESCRIPTION
Disable image building for the board, since the kernel of the main branch is to big to fit into the kernel partition.
