### PR TITLE
tools/libressl: update to 3.9.2

### DIFF
--- a/tools/libressl/Makefile
+++ b/tools/libressl/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libressl
-PKG_VERSION:=3.7.3
-PKG_HASH:=7948c856a90c825bd7268b6f85674a8dcd254bae42e221781b24e3f8dc335db3
+PKG_VERSION:=3.9.2
+PKG_HASH:=7b031dac64a59eb6ee3304f7ffb75dad33ab8c9d279c847f92c89fb846068f97
 
 PKG_CPE_ID:=cpe:/a:openbsd:libressl
 


### PR DESCRIPTION
Release Notes:
https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.8.0-relnotes.txt https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.8.1-relnotes.txt https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.8.2-relnotes.txt https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.9.0-relnotes.txt https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.9.1-relnotes.txt https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.9.2-relnotes.txt
