### PR TITLE
uboot-mediatek: add PCI support to MT7981

### DIFF
--- a/package/boot/uboot-mediatek/patches/290-01-phy-phy-mtk-tphy-add-support-for-phy-type-switch.patch
+++ b/package/boot/uboot-mediatek/patches/290-01-phy-phy-mtk-tphy-add-support-for-phy-type-switch.patch
@@ -1,0 +1,154 @@
+From 1322c231a65422171d7ff9498b69d3b762c0d605 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 28 May 2024 23:17:03 +0200
+Subject: [PATCH 1/4] phy: phy-mtk-tphy: add support for phy type switch
+
+Add support for PHY type switch via the mediatek topmisc syscon.
+
+This is needed on mt7981 to make the PCIe correctly work and display
+LinkUp.
+
+Follow the same implementation done on Linux kernel with the usage of
+the mediatek,syscon-type property.
+
+Example:
+
+u3port0: usb-phy@11e10700 {
+	reg = <0x11e10700 0x900>;
+	clocks = <&topckgen CK_TOP_USB3_PHY_SEL>;
+	clock-names = "ref";
+	#phy-cells = <1>;
+	mediatek,syscon-type = <&topmisc 0x218 0>;
+	status = "okay";
+};
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/phy/phy-mtk-tphy.c | 80 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 80 insertions(+)
+
+--- a/drivers/phy/phy-mtk-tphy.c
++++ b/drivers/phy/phy-mtk-tphy.c
+@@ -11,6 +11,8 @@
+ #include <generic-phy.h>
+ #include <malloc.h>
+ #include <mapmem.h>
++#include <regmap.h>
++#include <syscon.h>
+ #include <asm/io.h>
+ #include <dm/device_compat.h>
+ #include <dm/devres.h>
+@@ -209,6 +211,14 @@
+ #define ANA_EQ_EYE_CTRL_SIGNAL5		0xdc
+ #define RG_CDR_BIRLTD0_GEN3_MSK		GENMASK(4, 0)
+ 
++/* PHY switch between pcie/usb3/sgmii/sata */
++#define USB_PHY_SWITCH_CTRL	0x0
++#define RG_PHY_SW_TYPE		GENMASK(3, 0)
++#define RG_PHY_SW_PCIE		0x0
++#define RG_PHY_SW_USB3		0x1
++#define RG_PHY_SW_SGMII		0x2
++#define RG_PHY_SW_SATA		0x3
++
+ enum mtk_phy_version {
+ 	MTK_TPHY_V1 = 1,
+ 	MTK_TPHY_V2,
+@@ -250,6 +260,10 @@ struct mtk_phy_instance {
+ 	struct clk da_ref_clk;	/* reference clock of analog phy */
+ 	u32 index;
+ 	u32 type;
++
++	struct regmap *type_sw;
++	u32 type_sw_reg;
++	u32 type_sw_index;
+ };
+ 
+ struct mtk_tphy {
+@@ -564,6 +578,67 @@ static void phy_v2_banks_init(struct mtk
+ 	}
+ }
+ 
++/* type switch for usb3/pcie/sgmii/sata */
++static int phy_type_syscon_get(struct udevice *dev, struct mtk_phy_instance *instance,
++			       ofnode dn)
++{
++	struct ofnode_phandle_args args;
++	int err;
++
++	if (!ofnode_read_bool(dn, "mediatek,syscon-type"))
++		return 0;
++
++	err = ofnode_parse_phandle_with_args(dn, "mediatek,syscon-type",
++					     NULL, 2, 0, &args);
++	if (err)
++		return err;
++
++	instance->type_sw_reg = args.args[0];
++	instance->type_sw_index = args.args[1] & 0x3; /* <=3 */
++	instance->type_sw = syscon_node_to_regmap(args.node);
++	if (IS_ERR(instance->type_sw))
++		return PTR_ERR(instance->type_sw);
++
++	debug("phy-%s.%d: type_sw - reg %#x, index %d\n",
++	      dev->name, instance->index, instance->type_sw_reg,
++	      instance->type_sw_index);
++
++	return 0;
++}
++
++static int phy_type_set(struct mtk_phy_instance *instance)
++{
++	int type;
++	u32 offset;
++
++	if (!instance->type_sw)
++		return 0;
++
++	switch (instance->type) {
++	case PHY_TYPE_USB3:
++		type = RG_PHY_SW_USB3;
++		break;
++	case PHY_TYPE_PCIE:
++		type = RG_PHY_SW_PCIE;
++		break;
++	case PHY_TYPE_SGMII:
++		type = RG_PHY_SW_SGMII;
++		break;
++	case PHY_TYPE_SATA:
++		type = RG_PHY_SW_SATA;
++		break;
++	case PHY_TYPE_USB2:
++	default:
++		return 0;
++	}
++
++	offset = instance->type_sw_index * BITS_PER_BYTE;
++	regmap_update_bits(instance->type_sw, instance->type_sw_reg,
++			   RG_PHY_SW_TYPE << offset, type << offset);
++
++	return 0;
++}
++
+ static int mtk_phy_init(struct phy *phy)
+ {
+ 	struct mtk_tphy *tphy = dev_get_priv(phy->dev);
+@@ -692,6 +767,8 @@ static int mtk_phy_xlate(struct phy *phy
+ 		return -EINVAL;
+ 	}
+ 
++	phy_type_set(instance);
++
+ 	return 0;
+ }
+ 
+@@ -752,6 +829,10 @@ static int mtk_tphy_probe(struct udevice
+ 						     &instance->da_ref_clk);
+ 		if (err)
+ 			return err;
++
++		err = phy_type_syscon_get(dev, instance, subnode);
++		if (err)
++			return err;
+ 	}
+ 
+ 	return 0;

--- a/package/boot/uboot-mediatek/patches/290-02-clk-mediatek-mt7981-add-missing-clock-for-infra_ipci.patch
+++ b/package/boot/uboot-mediatek/patches/290-02-clk-mediatek-mt7981-add-missing-clock-for-infra_ipci.patch
@@ -1,0 +1,36 @@
+From 5d48f531145eae07c471e759b332490567f18539 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 28 May 2024 23:26:14 +0200
+Subject: [PATCH 2/4] clk: mediatek: mt7981: add missing clock for
+ infra_ipcie_pipe
+
+Add missing clock for infra_ipcie_pipe to make PCIe correctly work. This
+clock is a parent of the fixed clock from topckgen cb_cksq_40m.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/clk/mediatek/clk-mt7981.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/clk/mediatek/clk-mt7981.c
++++ b/drivers/clk/mediatek/clk-mt7981.c
+@@ -515,6 +515,7 @@ static const struct mtk_gate infracfg_ao
+ 	GATE_INFRA2(CK_INFRA_IUSB_CK, "infra_iusb", CK_INFRA_USB_CK, 3),
+ 	GATE_INFRA2(CK_INFRA_IPCIE_CK, "infra_ipcie",
+ 		    CK_INFRA_PCIE_GFMUX_TL_O_PRE, 12),
++	GATE_INFRA2(CK_INFRA_IPCIE_PIPE_CK, "infra_ipcie_pipe", CK_TOP_CB_CKSQ_40M, 13),
+ 	GATE_INFRA2(CK_INFRA_IPCIER_CK, "infra_ipcier", CK_INFRA_F26M_CK0, 14),
+ 	GATE_INFRA2(CK_INFRA_IPCIEB_CK, "infra_ipcieb", CK_INFRA_133M_PHCK, 15),
+ };
+--- a/include/dt-bindings/clock/mt7981-clk.h
++++ b/include/dt-bindings/clock/mt7981-clk.h
+@@ -226,7 +226,8 @@
+ #define CK_INFRA_IPCIE_CK		(54 - INFRACFG_AO_OFFSET)
+ #define CK_INFRA_IPCIER_CK		(55 - INFRACFG_AO_OFFSET)
+ #define CK_INFRA_IPCIEB_CK		(56 - INFRACFG_AO_OFFSET)
+-#define CLK_INFRA_AO_NR_CLK		(57 - INFRACFG_AO_OFFSET)
++#define CK_INFRA_IPCIE_PIPE_CK		(57 - INFRACFG_AO_OFFSET)
++#define CLK_INFRA_AO_NR_CLK		(58 - INFRACFG_AO_OFFSET)
+ 
+ /* APMIXEDSYS */
+ 

--- a/package/boot/uboot-mediatek/patches/290-03-arm-dts-mediatek-add-USB-nodes-for-MT7981.patch
+++ b/package/boot/uboot-mediatek/patches/290-03-arm-dts-mediatek-add-USB-nodes-for-MT7981.patch
@@ -1,12 +1,16 @@
-From cca5775031e4890f195246772e00f7f4ae7438f6 Mon Sep 17 00:00:00 2001
+From 18db482848b18a99bd0cc1ad9906db54f1f80b30 Mon Sep 17 00:00:00 2001
 From: John Crispin <john@phrozen.org>
 Date: Mon, 19 Feb 2024 05:52:24 +0100
-Subject: [PATCH 1/2] mt7981.dtsi: add USB nodes
+Subject: [PATCH 3/4] arm: dts: mediatek: add USB nodes for MT7981
+
+Add USB PHY nodes for MT7981. These are needed for USB support and also
+for PCIe support as the u3 PHY can also be used for PHY.
 
 Signed-off-by: John Crispin <john@phrozen.org>
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 ---
- arch/arm/dts/mt7981.dtsi | 47 ++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 47 insertions(+)
+ arch/arm/dts/mt7981.dtsi | 48 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 48 insertions(+)
 
 --- a/arch/arm/dts/mt7981.dtsi
 +++ b/arch/arm/dts/mt7981.dtsi
@@ -18,7 +22,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
  #include <dt-bindings/clock/mt7981-clk.h>
  #include <dt-bindings/reset/mt7629-reset.h>
  #include <dt-bindings/pinctrl/mt65xx.h>
-@@ -342,4 +343,50 @@
+@@ -342,4 +343,51 @@
  		status = "disabled";
  	};
  
@@ -65,6 +69,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +			clocks = <&topckgen CK_TOP_USB3_PHY_SEL>;
 +			clock-names = "ref";
 +			#phy-cells = <1>;
++			mediatek,syscon-type = <&topmisc 0x218 0>;
 +			status = "okay";
 +		};
 +	};

--- a/package/boot/uboot-mediatek/patches/290-04-pci_mediatek_add-PCIe-controller-support-for-filogic-silicon.patch
+++ b/package/boot/uboot-mediatek/patches/290-04-pci_mediatek_add-PCIe-controller-support-for-filogic-silicon.patch
@@ -1,0 +1,423 @@
+From: John Crispin <john@phrozen.org>
+Date: Tue, 28 May 2024 07:55:43 +0200
+Subject: [PATCH 2/2] pci: mediatek: add PCIe controller support for filogic silicon
+
+Add MediaTek GEN3 PCIe controller support for filogic silicon
+This is adapted from the Linux version of the driver.
+
+Signed-off-by: John Crispin <john@phrozen.org>
+---
+ drivers/pci/Kconfig              |   7 +
+ drivers/pci/Makefile             |   1 +
+ drivers/pci/pcie_mediatek_gen3.c | 379 +++++++++++++++++++++++++++++++
+ 3 files changed, 387 insertions(+)
+ create mode 100644 drivers/pci/pcie_mediatek_gen3.c
+
+--- a/drivers/pci/Kconfig
++++ b/drivers/pci/Kconfig
+@@ -350,6 +350,13 @@ config PCIE_MEDIATEK
+ 	  Say Y here if you want to enable Gen2 PCIe controller,
+ 	  which could be found on MT7623 SoC family.
+ 
++config PCIE_MEDIATEK_GEN3
++	bool "MediaTek PCIe Gen3 controller"
++	depends on ARCH_MEDIATEK
++	help
++	  Say Y here if you want to enable Gen3 PCIe controller,
++	  which could be found on the Mediatek Filogic SoC family.
++
+ config PCIE_DW_MESON
+ 	bool "Amlogic Meson DesignWare based PCIe controller"
+ 	depends on ARCH_MESON
+--- a/drivers/pci/Makefile
++++ b/drivers/pci/Makefile
+@@ -42,6 +42,7 @@ obj-$(CONFIG_PCIE_INTEL_FPGA) += pcie_in
+ obj-$(CONFIG_PCIE_DW_COMMON) += pcie_dw_common.o
+ obj-$(CONFIG_PCI_KEYSTONE) += pcie_dw_ti.o
+ obj-$(CONFIG_PCIE_MEDIATEK) += pcie_mediatek.o
++obj-$(CONFIG_PCIE_MEDIATEK_GEN3) += pcie_mediatek_gen3.o
+ obj-$(CONFIG_PCIE_ROCKCHIP) += pcie_rockchip.o
+ obj-$(CONFIG_PCIE_DW_ROCKCHIP) += pcie_dw_rockchip.o
+ obj-$(CONFIG_PCIE_DW_MESON) += pcie_dw_meson.o
+--- /dev/null
++++ b/drivers/pci/pcie_mediatek_gen3.c
+@@ -0,0 +1,379 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * MediaTek PCIe host controller driver.
++ *
++ * Copyright (c) 2023 John Crispin <john@phrozen.org>
++ * Driver is based on u-boot gen1/2 and upstream linux gen3 code
++ */
++
++#include <common.h>
++#include <clk.h>
++#include <dm.h>
++#include <generic-phy.h>
++#include <log.h>
++#include <malloc.h>
++#include <pci.h>
++#include <reset.h>
++#include <asm/io.h>
++#include <dm/devres.h>
++#include <linux/bitops.h>
++#include <linux/iopoll.h>
++#include <linux/list.h>
++#include "pci_internal.h"
++
++/* PCIe shared registers */
++#define PCIE_CFG_ADDR			0x20
++#define PCIE_CFG_DATA			0x24
++
++#define PCIE_SETTING_REG		0x80
++
++#define PCIE_PCI_IDS_1			0x9c
++#define PCIE_RC_MODE			BIT(0)
++#define PCI_CLASS(class)		(class << 8)
++
++#define PCIE_CFGNUM_REG			0x140
++#define PCIE_CFG_DEVFN(devfn)		((devfn) & GENMASK(7, 0))
++#define PCIE_CFG_BUS(bus)		(((bus) << 8) & GENMASK(15, 8))
++#define PCIE_CFG_BYTE_EN(bytes)		(((bytes) << 16) & GENMASK(19, 16))
++#define PCIE_CFG_FORCE_BYTE_EN		BIT(20)
++#define PCIE_CFG_OFFSET_ADDR		0x1000
++#define PCIE_CFG_HEADER(bus, devfn)	(PCIE_CFG_BUS(bus) | PCIE_CFG_DEVFN(devfn))
++
++#define PCIE_RST_CTRL_REG		0x148
++#define PCIE_MAC_RSTB			BIT(0)
++#define PCIE_PHY_RSTB			BIT(1)
++#define PCIE_BRG_RSTB			BIT(2)
++#define PCIE_PE_RSTB			BIT(3)
++
++#define PCIE_LINK_STATUS_REG		0x154
++#define PCIE_PORT_LINKUP		BIT(8)
++
++#define PCIE_INT_ENABLE_REG		0x180
++
++#define PCIE_MISC_CTRL_REG		0x348
++#define PCIE_DISABLE_DVFSRC_VLT_REQ	BIT(1)
++
++#define PCIE_TRANS_TABLE_BASE_REG       0x800
++#define PCIE_ATR_SRC_ADDR_MSB_OFFSET    0x4
++#define PCIE_ATR_TRSL_ADDR_LSB_OFFSET   0x8
++#define PCIE_ATR_TRSL_ADDR_MSB_OFFSET   0xc
++#define PCIE_ATR_TRSL_PARAM_OFFSET      0x10
++#define PCIE_ATR_TLB_SET_OFFSET         0x20
++
++#define PCIE_MAX_TRANS_TABLES           8
++#define PCIE_ATR_EN                     BIT(0)
++#define PCIE_ATR_SIZE(size) \
++        (((((size) - 1) << 1) & GENMASK(6, 1)) | PCIE_ATR_EN)
++#define PCIE_ATR_ID(id)                 ((id) & GENMASK(3, 0))
++#define PCIE_ATR_TYPE_MEM               PCIE_ATR_ID(0)
++#define PCIE_ATR_TYPE_IO                PCIE_ATR_ID(1)
++#define PCIE_ATR_TLP_TYPE(type)         (((type) << 16) & GENMASK(18, 16))
++#define PCIE_ATR_TLP_TYPE_MEM           PCIE_ATR_TLP_TYPE(0)
++#define PCIE_ATR_TLP_TYPE_IO            PCIE_ATR_TLP_TYPE(2)
++
++struct mtk_pcie {
++	void __iomem *base;
++	void *priv;
++	struct clk pl_250m_ck;
++	struct clk tl_26m_ck;
++	struct clk peri_26m_ck;
++	struct clk top_133m_ck;
++	struct reset_ctl reset_phy;
++	struct reset_ctl reset_mac;
++	struct phy phy;
++};
++
++static void mtk_pcie_config_tlp_header(const struct udevice *bus,
++				       pci_dev_t devfn,
++				       int where, int size)
++{
++	struct mtk_pcie *pcie = dev_get_priv(bus);
++	int bytes;
++	u32 val;
++
++	size = 1 << size;
++	bytes = (GENMASK(size - 1, 0) & 0xf) << (where & 0x3);
++
++	val = PCIE_CFG_FORCE_BYTE_EN | PCIE_CFG_BYTE_EN(bytes) |
++	      PCIE_CFG_HEADER(PCI_BUS(devfn), (devfn >> 8));
++
++	writel(val, pcie->base + PCIE_CFGNUM_REG);
++}
++
++static int mtk_pcie_config_address(const struct udevice *udev, pci_dev_t bdf,
++				   uint offset, void **paddress)
++{
++	struct mtk_pcie *pcie = dev_get_priv(udev);
++
++	*paddress = pcie->base + PCIE_CFG_OFFSET_ADDR + offset;
++
++	return 0;
++}
++
++static int mtk_pcie_read_config(const struct udevice *bus, pci_dev_t bdf,
++				uint offset, ulong *valuep,
++				enum pci_size_t size)
++{
++	int ret;
++
++
++	mtk_pcie_config_tlp_header(bus, bdf, offset, size);
++	ret = pci_generic_mmap_read_config(bus, mtk_pcie_config_address,
++					    bdf, offset, valuep, size);
++	return ret;
++}
++
++static int mtk_pcie_write_config(struct udevice *bus, pci_dev_t bdf,
++				 uint offset, ulong value,
++				 enum pci_size_t size)
++{
++	mtk_pcie_config_tlp_header(bus, bdf, offset, size);
++
++	switch (size) {
++	case PCI_SIZE_8:
++	case PCI_SIZE_16:
++		value <<= (offset & 0x3) * 8;
++	case PCI_SIZE_32:
++		break;
++	default:
++		return -EINVAL;
++	}
++
++	return pci_generic_mmap_write_config(bus, mtk_pcie_config_address,
++					     bdf, (offset & ~0x3), value, PCI_SIZE_32);
++}
++
++static const struct dm_pci_ops mtk_pcie_ops = {
++	.read_config	= mtk_pcie_read_config,
++	.write_config	= mtk_pcie_write_config,
++};
++
++static int mtk_pcie_set_trans_table(struct mtk_pcie *pcie, u64 cpu_addr,
++				    u64 pci_addr, u64 size,
++                                    unsigned long type, int num)
++{
++	void __iomem *table;
++	u32 val;
++
++	if (num >= PCIE_MAX_TRANS_TABLES) {
++		printf("not enough translate table for addr: %#llx, limited to [%d]\n",
++		       (unsigned long long)cpu_addr, PCIE_MAX_TRANS_TABLES);
++		return -ENODEV;
++	}
++
++	printf("set trans table %d: %#llx %#llx, %#llx\n", num, cpu_addr, pci_addr, size);
++	table = pcie->base + PCIE_TRANS_TABLE_BASE_REG +
++		num * PCIE_ATR_TLB_SET_OFFSET;
++
++	writel(lower_32_bits(cpu_addr) | PCIE_ATR_SIZE(fls(size) - 1), table);
++	writel(upper_32_bits(cpu_addr), table + PCIE_ATR_SRC_ADDR_MSB_OFFSET);
++	writel(lower_32_bits(pci_addr), table + PCIE_ATR_TRSL_ADDR_LSB_OFFSET);
++	writel(upper_32_bits(pci_addr), table + PCIE_ATR_TRSL_ADDR_MSB_OFFSET);
++
++	if (type == PCI_REGION_IO)
++		val = PCIE_ATR_TYPE_IO | PCIE_ATR_TLP_TYPE_IO;
++	else
++		val = PCIE_ATR_TYPE_MEM | PCIE_ATR_TLP_TYPE_MEM;
++	writel(val, table + PCIE_ATR_TRSL_PARAM_OFFSET);
++
++	return 0;
++}
++
++static int mtk_pcie_startup_port(struct udevice *dev)
++{
++	struct mtk_pcie *pcie = dev_get_priv(dev);
++	struct udevice *ctlr = pci_get_controller(dev);
++	struct pci_controller *hose = dev_get_uclass_priv(ctlr);
++	u32 val;
++	int i, err;
++
++	/* Set as RC mode */
++	val = readl(pcie->base + PCIE_SETTING_REG);
++	val |= PCIE_RC_MODE;
++	writel(val, pcie->base + PCIE_SETTING_REG);
++
++        /* setup RC BARs */
++        writel(PCI_BASE_ADDRESS_MEM_TYPE_64,
++               pcie->base + PCI_BASE_ADDRESS_0);
++        writel(0x0, pcie->base + PCI_BASE_ADDRESS_1);
++
++        /* setup interrupt pins */
++        clrsetbits_le32(pcie->base + PCI_INTERRUPT_LINE,
++                        0xff00, 0x100);
++
++        /* setup bus numbers */
++        clrsetbits_le32(pcie->base + PCI_PRIMARY_BUS,
++                        0xffffff, 0x00ff0100);
++
++        /* setup command register */
++        clrsetbits_le32(pcie->base + PCI_PRIMARY_BUS,
++                        0xffff,
++                        PCI_COMMAND_IO | PCI_COMMAND_MEMORY |
++                        PCI_COMMAND_MASTER | PCI_COMMAND_SERR);
++
++	/* Set class code */
++	val = readl(pcie->base + PCIE_PCI_IDS_1);
++	val &= ~GENMASK(31, 8);
++	val |= PCI_CLASS(PCI_CLASS_BRIDGE_PCI << 8);
++	writel(val, pcie->base + PCIE_PCI_IDS_1);
++
++	/* Mask all INTx interrupts */
++	val = readl(pcie->base + PCIE_INT_ENABLE_REG);
++	val &= ~0xFF000000;;
++	writel(val, pcie->base + PCIE_INT_ENABLE_REG);
++
++	/* Disable DVFSRC voltage request */
++	val = readl(pcie->base + PCIE_MISC_CTRL_REG);
++	val |= PCIE_DISABLE_DVFSRC_VLT_REQ;
++	writel(val, pcie->base + PCIE_MISC_CTRL_REG);
++
++	/* Assert all reset signals */
++	val = readl(pcie->base + PCIE_RST_CTRL_REG);
++	val |= PCIE_MAC_RSTB | PCIE_PHY_RSTB | PCIE_BRG_RSTB | PCIE_PE_RSTB;
++	writel(val, pcie->base + PCIE_RST_CTRL_REG);
++
++	/*
++	 * Described in PCIe CEM specification sections 2.2 (PERST# Signal)
++	 * and 2.2.1 (Initial Power-Up (G3 to S0)).
++	 * The deassertion of PERST# should be delayed 100ms (TPVPERL)
++	 * for the power and clock to become stable.
++	 */
++	mdelay(100);
++
++	/* De-assert reset signals */
++	val &= ~(PCIE_MAC_RSTB | PCIE_PHY_RSTB | PCIE_BRG_RSTB);
++	writel(val, pcie->base + PCIE_RST_CTRL_REG);
++
++	mdelay(100);
++	
++	/* De-assert PERST# signals */
++	val &= ~(PCIE_PE_RSTB);
++        writel(val, pcie->base + PCIE_RST_CTRL_REG);
++
++	/* 100ms timeout value should be enough for Gen1/2 training */
++	err = readl_poll_timeout(pcie->base + PCIE_LINK_STATUS_REG, val,
++				 !!(val & PCIE_PORT_LINKUP),
++				 100 * 1000);
++	if (err) {
++		printf("%s:%s[%d] no card detected\n", __FILE__, __func__, __LINE__);
++		return -ETIMEDOUT;
++	} 
++	printf("%s:%s[%d] detected a card\n", __FILE__, __func__, __LINE__);
++
++	for (i = 0; i < hose->region_count; i++) {
++		struct pci_region *reg = &hose->regions[i];
++
++		if (reg->flags != PCI_REGION_MEM) 
++			continue;
++
++		mtk_pcie_set_trans_table(pcie, reg->bus_start, reg->phys_start,
++					 reg->size, reg->flags, 0);
++	}
++
++	return 0;
++}
++
++static int mtk_pcie_power_on(struct udevice *dev)
++{
++	struct mtk_pcie *pcie = dev_get_priv(dev);
++	int err;
++
++	pcie->base = dev_remap_addr_name(dev, "pcie-mac");
++	if (!pcie->base)
++		return -ENOENT;
++
++	pcie->priv = dev;
++
++	err = generic_phy_get_by_name(dev, "pcie-phy", &pcie->phy);
++	if (err)
++		return err;
++
++	err = clk_get_by_name(dev, "pl_250m", &pcie->pl_250m_ck);
++	if (err)
++		return err;
++
++	err = clk_get_by_name(dev, "tl_26m", &pcie->tl_26m_ck);
++	if (err)
++		return err;
++
++	err = clk_get_by_name(dev, "peri_26m", &pcie->peri_26m_ck);
++	if (err)
++		return err;
++
++	err = clk_get_by_name(dev, "top_133m", &pcie->top_133m_ck);
++	if (err)
++		return err;
++	
++	err = generic_phy_init(&pcie->phy);
++	if (err)
++		return err;
++
++	err = generic_phy_power_on(&pcie->phy);
++	if (err)
++		goto err_phy_on;
++
++	err = clk_enable(&pcie->pl_250m_ck);
++	if (err)
++		goto err_clk_pl_250m;
++
++	err = clk_enable(&pcie->tl_26m_ck);
++	if (err)
++		goto err_clk_tl_26m;
++
++	err = clk_enable(&pcie->peri_26m_ck);
++	if (err)
++		goto err_clk_peri_26m;
++
++	err = clk_enable(&pcie->top_133m_ck);
++	if (err)
++		goto err_clk_top_133m;
++
++	err = mtk_pcie_startup_port(dev);
++	if (err)
++		goto err_startup;
++
++	return 0;
++
++err_startup:
++err_clk_top_133m:
++	clk_disable(&pcie->top_133m_ck);
++err_clk_peri_26m:
++	clk_disable(&pcie->peri_26m_ck);
++err_clk_tl_26m:
++	clk_disable(&pcie->tl_26m_ck);
++err_clk_pl_250m:
++	clk_disable(&pcie->pl_250m_ck);
++err_phy_on:
++	generic_phy_exit(&pcie->phy);
++
++	return err;
++}
++
++static int mtk_pcie_probe(struct udevice *dev)
++{
++	struct mtk_pcie *pcie = dev_get_priv(dev);
++	int err;
++
++	pcie->priv = dev;
++
++	err = mtk_pcie_power_on(dev);
++	if (err)
++		return err;
++
++	return 0;
++}
++
++
++static const struct udevice_id mtk_pcie_ids[] = {
++	{ .compatible = "mediatek,mt8192-pcie" },
++	{ }
++};
++
++U_BOOT_DRIVER(pcie_mediatek_gen3) = {
++	.name		= "pcie_mediatek_gen3",
++	.id		= UCLASS_PCI,
++	.of_match	= mtk_pcie_ids,
++	.ops		= &mtk_pcie_ops,
++	.probe		= mtk_pcie_probe,
++	.priv_auto	= sizeof(struct mtk_pcie),
++};

--- a/package/boot/uboot-mediatek/patches/290-05-arm-dts-mediatek-add-PCIe-node-for-MT7981.patch
+++ b/package/boot/uboot-mediatek/patches/290-05-arm-dts-mediatek-add-PCIe-node-for-MT7981.patch
@@ -1,0 +1,57 @@
+From 8983b7465df1324e8b97e6a720204b426c52deb0 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 28 May 2024 23:35:38 +0200
+Subject: [PATCH 4/4] arm: dts: mediatek: add PCIe node for MT7981
+
+Add PCIe node for MT7981 with all the required properties to make PCIe
+work.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ arch/arm/dts/mt7981.dtsi | 35 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+
+--- a/arch/arm/dts/mt7981.dtsi
++++ b/arch/arm/dts/mt7981.dtsi
+@@ -366,6 +366,41 @@
+ 		status = "okay";
+ 	};
+ 
++	pcie: pcie@11280000 {
++		compatible = "mediatek,mt8192-pcie";
++		device_type = "pci";
++		reg = <0x11280000 0x4000>;
++		reg-names = "pcie-mac";
++		#address-cells = <3>;
++		#size-cells = <2>;
++		interrupts = <GIC_SPI 168 IRQ_TYPE_LEVEL_HIGH>;
++		clocks = <&infracfg_ao CK_INFRA_IPCIE_CK>,
++				<&infracfg_ao CK_INFRA_IPCIE_PIPE_CK>,
++				<&infracfg_ao CK_INFRA_IPCIER_CK>,
++				<&infracfg_ao CK_INFRA_IPCIEB_CK>;
++		clock-names = "pl_250m", "tl_26m", "peri_26m", "top_133m";
++		phys = <&u3port0 PHY_TYPE_PCIE>;
++		phy-names = "pcie-phy";
++		bus-range = <0x00 0xff>;
++		ranges = <0x82000000 0 0x20000000 0x20000000 0 0x10000000>;
++
++		#interrupt-cells = <1>;
++
++		interrupt-map-mask = <0 0 0 7>;
++		interrupt-map = <0 0 0 1 &pcie_intc 0>,
++			<0 0 0 2 &pcie_intc 1>,
++			<0 0 0 3 &pcie_intc 2>,
++			<0 0 0 4 &pcie_intc 3>;
++
++		status = "disabled";
++
++		pcie_intc: interrupt-controller {
++			interrupt-controller;
++			#interrupt-cells = <1>;
++			#address-cells = <0>;
++		};
++	};
++
+ 	usbtphy: usb-phy@11e10000 {
+ 		compatible = "mediatek,mt7981",
+ 			     "mediatek,generic-tphy-v2";

--- a/package/boot/uboot-mediatek/patches/453-add-openwrt-one.patch
+++ b/package/boot/uboot-mediatek/patches/453-add-openwrt-one.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ b/arch/arm/dts/openwrt-one.dts
-@@ -0,0 +1,203 @@
+@@ -0,0 +1,220 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (c) 2024 John Crispin <john@phrozen.org>
@@ -116,6 +116,23 @@
 +			bias-pull-down = <MTK_PUPD_SET_R1R0_00>;
 +		};
 +	};
++
++	pcie_pins: pcie-pins {
++		mux {
++			function = "pcie";
++			groups = "pcie_pereset";
++		};
++	};
++};
++
++&xhci {
++       phys = <&u2port0 PHY_TYPE_USB2>;
++};
++
++&pcie {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie_pins>;
++	status = "okay";
 +};
 +
 +&spi0 {
@@ -206,14 +223,14 @@
 +};
 --- /dev/null
 +++ b/configs/mt7981_openwrt-one-nor_defconfig
-@@ -0,0 +1,1811 @@
+@@ -0,0 +1,1845 @@
 +#
 +# Automatically generated file; DO NOT EDIT.
 +# U-Boot 2024.01 Configuration
 +#
 +
 +#
-+# Compiler: aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 13.2.0 r26144+12-219018185e) 13.2.0
++# Compiler: aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 13.2.0 r0+26437-9ec3b11d37) 13.2.0
 +#
 +CONFIG_CREATE_ARCH_SYMLINK=y
 +CONFIG_SYS_CACHE_SHIFT_6=y
@@ -448,7 +465,8 @@
 +# ARM debug
 +#
 +CONFIG_BUILD_TARGET=""
-+# CONFIG_PCI is not set
++# CONFIG_SYS_PCI_64BIT is not set
++CONFIG_PCI=y
 +CONFIG_FWU_NUM_BANKS=2
 +CONFIG_FWU_NUM_IMAGES_PER_BANK=2
 +CONFIG_DEBUG_UART=y
@@ -659,6 +677,7 @@
 +# CONFIG_MISC_INIT_R is not set
 +# CONFIG_SYS_MALLOC_BOOTPARAMS is not set
 +# CONFIG_ID_EEPROM is not set
++CONFIG_PCI_INIT_R=y
 +# CONFIG_RESET_PHY_R is not set
 +
 +#
@@ -829,10 +848,12 @@
 +# CONFIG_CMD_CLONE is not set
 +CONFIG_CMD_MTD=y
 +CONFIG_CMD_NAND_EXT=y
++CONFIG_CMD_NVME=y
 +# CONFIG_CMD_ONENAND is not set
 +# CONFIG_CMD_OSD is not set
 +# CONFIG_CMD_PART is not set
 +CONFIG_CMD_PCI=y
++# CONFIG_CMD_PCI_MPS is not set
 +CONFIG_CMD_PINMUX=y
 +# CONFIG_CMD_POWEROFF is not set
 +# CONFIG_CMD_READ is not set
@@ -1475,6 +1496,7 @@
 +# CONFIG_CALXEDA_XGMAC is not set
 +# CONFIG_DRIVER_DM9000 is not set
 +# CONFIG_DWC_ETH_QOS is not set
++# CONFIG_E1000 is not set
 +# CONFIG_EEPRO100 is not set
 +# CONFIG_ETH_DESIGNWARE is not set
 +# CONFIG_ETH_DESIGNWARE_MESON8B is not set
@@ -1495,6 +1517,7 @@
 +# CONFIG_PCNET is not set
 +# CONFIG_QE_UEC is not set
 +# CONFIG_RTL8139 is not set
++# CONFIG_RTL8169 is not set
 +# CONFIG_SMC911X is not set
 +# CONFIG_SUN7I_GMAC is not set
 +# CONFIG_SUN4I_EMAC is not set
@@ -1513,8 +1536,32 @@
 +CONFIG_MEDIATEK_ETH=y
 +# CONFIG_HIFEMAC_ETH is not set
 +# CONFIG_HIGMACV300_ETH is not set
-+# CONFIG_NVME is not set
++CONFIG_NVME=y
 +# CONFIG_NVME_APPLE is not set
++CONFIG_NVME_PCI=y
++# CONFIG_DM_PCI_COMPAT is not set
++CONFIG_PCI_PNP=y
++# CONFIG_PCI_REGION_MULTI_ENTRY is not set
++# CONFIG_PCI_CONFIG_HOST_BRIDGE is not set
++# CONFIG_PCI_SRIOV is not set
++CONFIG_PCI_ENHANCED_ALLOCATION=y
++# CONFIG_PCI_ARID is not set
++# CONFIG_PCIE_ECAM_GENERIC is not set
++# CONFIG_PCIE_ECAM_SYNQUACER is not set
++# CONFIG_PCI_FTPCI100 is not set
++# CONFIG_PCI_PHYTIUM is not set
++# CONFIG_PCIE_FSL is not set
++# CONFIG_PCI_MPC85XX is not set
++# CONFIG_PCI_XILINX is not set
++# CONFIG_PCIE_LAYERSCAPE_RC is not set
++# CONFIG_PCIE_LAYERSCAPE_EP is not set
++# CONFIG_PCIE_LAYERSCAPE_GEN4 is not set
++# CONFIG_PCIE_INTEL_FPGA is not set
++# CONFIG_PCIE_IPROC is not set
++# CONFIG_PCI_KEYSTONE is not set
++# CONFIG_PCIE_MEDIATEK is not set
++CONFIG_PCIE_MEDIATEK_GEN3=y
++# CONFIG_PCIE_STARFIVE_JH7110 is not set
 +
 +#
 +# PCI Endpoint
@@ -1691,6 +1738,7 @@
 +# Sound support
 +#
 +# CONFIG_SOUND is not set
++# CONFIG_SOUND_MAX98357A is not set
 +
 +#
 +# SOC (System On Chip) specific Drivers
@@ -1782,6 +1830,7 @@
 +# CONFIG_USB_XHCI_DWC3 is not set
 +# CONFIG_USB_XHCI_DWC3_OF_SIMPLE is not set
 +CONFIG_USB_XHCI_MTK=y
++# CONFIG_USB_XHCI_PCI is not set
 +# CONFIG_USB_XHCI_FSL is not set
 +# CONFIG_USB_XHCI_BRCM is not set
 +# CONFIG_USB_EHCI_HCD is not set
@@ -1841,6 +1890,8 @@
 +# VirtIO Drivers
 +#
 +# CONFIG_VIRTIO_MMIO is not set
++# CONFIG_VIRTIO_PCI is not set
++# CONFIG_VIRTIO_PCI_LEGACY is not set
 +
 +#
 +# 1-Wire support
@@ -2020,14 +2071,14 @@
 +# CONFIG_TOOLS_MKFWUMDATA is not set
 --- /dev/null
 +++ b/configs/mt7981_openwrt-one-spi-nand_defconfig
-@@ -0,0 +1,1815 @@
+@@ -0,0 +1,1849 @@
 +#
 +# Automatically generated file; DO NOT EDIT.
 +# U-Boot 2024.01 Configuration
 +#
 +
 +#
-+# Compiler: aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 12.3.0 r25206+8-d5e2177a6b) 12.3.0
++# Compiler: aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 13.2.0 r0+26437-9ec3b11d37) 13.2.0
 +#
 +CONFIG_CREATE_ARCH_SYMLINK=y
 +CONFIG_SYS_CACHE_SHIFT_6=y
@@ -2262,7 +2313,8 @@
 +# ARM debug
 +#
 +CONFIG_BUILD_TARGET=""
-+# CONFIG_PCI is not set
++# CONFIG_SYS_PCI_64BIT is not set
++CONFIG_PCI=y
 +CONFIG_FWU_NUM_BANKS=2
 +CONFIG_FWU_NUM_IMAGES_PER_BANK=2
 +CONFIG_DEBUG_UART=y
@@ -2280,7 +2332,7 @@
 +CONFIG_LOCALVERSION=""
 +CONFIG_LOCALVERSION_AUTO=y
 +CONFIG_CC_IS_GCC=y
-+CONFIG_GCC_VERSION=120300
++CONFIG_GCC_VERSION=130200
 +CONFIG_CLANG_VERSION=0
 +CONFIG_CC_OPTIMIZE_FOR_SIZE=y
 +# CONFIG_CC_OPTIMIZE_FOR_SPEED is not set
@@ -2473,6 +2525,7 @@
 +# CONFIG_MISC_INIT_R is not set
 +# CONFIG_SYS_MALLOC_BOOTPARAMS is not set
 +# CONFIG_ID_EEPROM is not set
++CONFIG_PCI_INIT_R=y
 +# CONFIG_RESET_PHY_R is not set
 +
 +#
@@ -2643,10 +2696,12 @@
 +# CONFIG_CMD_CLONE is not set
 +CONFIG_CMD_MTD=y
 +CONFIG_CMD_NAND_EXT=y
++CONFIG_CMD_NVME=y
 +# CONFIG_CMD_ONENAND is not set
 +# CONFIG_CMD_OSD is not set
 +# CONFIG_CMD_PART is not set
 +CONFIG_CMD_PCI=y
++# CONFIG_CMD_PCI_MPS is not set
 +CONFIG_CMD_PINMUX=y
 +# CONFIG_CMD_POWEROFF is not set
 +# CONFIG_CMD_READ is not set
@@ -3293,6 +3348,7 @@
 +# CONFIG_CALXEDA_XGMAC is not set
 +# CONFIG_DRIVER_DM9000 is not set
 +# CONFIG_DWC_ETH_QOS is not set
++# CONFIG_E1000 is not set
 +# CONFIG_EEPRO100 is not set
 +# CONFIG_ETH_DESIGNWARE is not set
 +# CONFIG_ETH_DESIGNWARE_MESON8B is not set
@@ -3313,6 +3369,7 @@
 +# CONFIG_PCNET is not set
 +# CONFIG_QE_UEC is not set
 +# CONFIG_RTL8139 is not set
++# CONFIG_RTL8169 is not set
 +# CONFIG_SMC911X is not set
 +# CONFIG_SUN7I_GMAC is not set
 +# CONFIG_SUN4I_EMAC is not set
@@ -3331,8 +3388,32 @@
 +CONFIG_MEDIATEK_ETH=y
 +# CONFIG_HIFEMAC_ETH is not set
 +# CONFIG_HIGMACV300_ETH is not set
-+# CONFIG_NVME is not set
++CONFIG_NVME=y
 +# CONFIG_NVME_APPLE is not set
++CONFIG_NVME_PCI=y
++# CONFIG_DM_PCI_COMPAT is not set
++CONFIG_PCI_PNP=y
++# CONFIG_PCI_REGION_MULTI_ENTRY is not set
++# CONFIG_PCI_CONFIG_HOST_BRIDGE is not set
++# CONFIG_PCI_SRIOV is not set
++CONFIG_PCI_ENHANCED_ALLOCATION=y
++# CONFIG_PCI_ARID is not set
++# CONFIG_PCIE_ECAM_GENERIC is not set
++# CONFIG_PCIE_ECAM_SYNQUACER is not set
++# CONFIG_PCI_FTPCI100 is not set
++# CONFIG_PCI_PHYTIUM is not set
++# CONFIG_PCIE_FSL is not set
++# CONFIG_PCI_MPC85XX is not set
++# CONFIG_PCI_XILINX is not set
++# CONFIG_PCIE_LAYERSCAPE_RC is not set
++# CONFIG_PCIE_LAYERSCAPE_EP is not set
++# CONFIG_PCIE_LAYERSCAPE_GEN4 is not set
++# CONFIG_PCIE_INTEL_FPGA is not set
++# CONFIG_PCIE_IPROC is not set
++# CONFIG_PCI_KEYSTONE is not set
++# CONFIG_PCIE_MEDIATEK is not set
++CONFIG_PCIE_MEDIATEK_GEN3=y
++# CONFIG_PCIE_STARFIVE_JH7110 is not set
 +
 +#
 +# PCI Endpoint
@@ -3509,6 +3590,7 @@
 +# Sound support
 +#
 +# CONFIG_SOUND is not set
++# CONFIG_SOUND_MAX98357A is not set
 +
 +#
 +# SOC (System On Chip) specific Drivers
@@ -3600,6 +3682,7 @@
 +# CONFIG_USB_XHCI_DWC3 is not set
 +# CONFIG_USB_XHCI_DWC3_OF_SIMPLE is not set
 +CONFIG_USB_XHCI_MTK=y
++# CONFIG_USB_XHCI_PCI is not set
 +# CONFIG_USB_XHCI_FSL is not set
 +# CONFIG_USB_XHCI_BRCM is not set
 +# CONFIG_USB_EHCI_HCD is not set
@@ -3659,6 +3742,8 @@
 +# VirtIO Drivers
 +#
 +# CONFIG_VIRTIO_MMIO is not set
++# CONFIG_VIRTIO_PCI is not set
++# CONFIG_VIRTIO_PCI_LEGACY is not set
 +
 +#
 +# 1-Wire support


### PR DESCRIPTION
Add PCI support to MT7981. This permits the use of NVME devices from an attached M.2 SSD on the OpenWrt One router directly in U-Boot for image loading or other task.