### PR TITLE
kernel: dts: mt7988a: Fix SPI1 clock source pll mux

### DIFF
--- a/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a.dtsi
+++ b/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a.dtsi
@@ -791,7 +791,7 @@
 			reg = <0 0x11008000 0 0x100>;
 			interrupts = <GIC_SPI 141 IRQ_TYPE_LEVEL_HIGH>;
 			clocks = <&topckgen CLK_TOP_MPLL_D2>,
-				 <&topckgen CLK_TOP_SPI_SEL>,
+				 <&topckgen CLK_TOP_SPIM_MST_SEL>,
 				 <&infracfg CLK_INFRA_104M_SPI1>,
 				 <&infracfg CLK_INFRA_66M_SPI1_HCK>;
 			clock-names = "parent-clk", "sel-clk", "spi-clk",


### PR DESCRIPTION
SPI0/2 share the same clock source PLL, and its mux is CLK_TOP_SPI_SEL.
As for SPI1, it has different mux: CLK_TOP_SPIM_MST_SEL.

With original settings, users are actually trying to switch SPI0/2's clock source pll mux.
So without this patch, users may suffer from failing to swich clock source of SPI1.