### PR TITLE
qualcommax: ipq807x: wax620 and wax630: fix wifi mac address

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax620.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax620.dts
@@ -15,6 +15,8 @@
 	aliases {
 		serial0 = &blsp1_uart5;
 		ethernet0 = &dp6;
+		label-mac-device = &dp6;
+
 		led-boot = &led_system_blue;
 		led-failsafe = &led_system_red;
 		led-running = &led_system_green;

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -20,8 +20,6 @@ case "$FIRMWARE" in
 	netgear,sxr80|\
 	netgear,sxs80|\
 	netgear,wax218|\
-	netgear,wax620|\
-	netgear,wax630|\
 	qnap,301w|\
 	redmi,ax6|\
 	xiaomi,ax3600|\
@@ -49,6 +47,21 @@ case "$FIRMWARE" in
 		ath11k_patch_mac $(mtd_get_mac_binary boarddata1 0xc) 0
 		ath11k_patch_mac $(mtd_get_mac_binary boarddata1 0x0) 1
 		ath11k_patch_mac $(mtd_get_mac_binary boarddata1 0x6) 2
+		ath11k_set_macflag
+		;;
+	netgear,wax620)
+		caldata_extract "0:art" 0x1000 0x20000
+		label_mac=$(get_mac_label)
+		ath11k_patch_mac $(macaddr_add $label_mac -31) 1
+		ath11k_patch_mac $(macaddr_add $label_mac 1) 0
+		ath11k_set_macflag
+		;;
+	netgear,wax630)
+		caldata_extract "0:art" 0x1000 0x20000
+		label_mac=$(get_mac_label)
+		ath11k_patch_mac $(macaddr_add $label_mac -31) 1
+		ath11k_patch_mac $(macaddr_add $label_mac 1) 0
+		ath11k_patch_mac $(macaddr_add $label_mac 33) 2
 		ath11k_set_macflag
 		;;
 	prpl,haze|\


### PR DESCRIPTION
The wifi radios on wax620 and wax630 got a random mac address on boot. 
So fix this by using `ath11k_patch_mac` and give a static mac address from `eth1addr`, in the `0:appsblenv` partition.

Tested and working on wax620 and wax630.

Signed-off-by: Kristian Skramstad <kristian+github@83.no>