### PR TITLE
build: add option KERNEL_DEBUG_INFO_BTF_MODULES

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -435,7 +435,6 @@ config KERNEL_DEBUG_INFO
 	  This will compile your kernel and modules with debug information.
 
 config KERNEL_DEBUG_INFO_BTF
-
 	bool "Enable additional BTF type information"
 	depends on !HOST_OS_MACOS
 	depends on KERNEL_DEBUG_INFO && !KERNEL_DEBUG_INFO_REDUCED
@@ -447,9 +446,13 @@ config KERNEL_DEBUG_INFO_BTF
 
 	  Required to run BPF CO-RE applications.
 
+config KERNEL_DEBUG_INFO_BTF_MODULES
+	def_bool y
+	depends on KERNEL_DEBUG_INFO_BTF
+
 config KERNEL_MODULE_ALLOW_BTF_MISMATCH
 	bool "Allow loading modules with non-matching BTF type info"
-	depends on KERNEL_DEBUG_INFO_BTF
+	depends on KERNEL_DEBUG_INFO_BTF_MODULES
 	help
 	  For modules whose split BTF does not match vmlinux, load without
 	  BTF rather than refusing to load. The default behavior with


### PR DESCRIPTION
### Description:
The recent kernel v6.6.31 update broke BTF-enabled builds since upstream Linux added a prompt for config option `DEBUG_INFO_BTF_MODULES` in commit 2166cb2e21 ("bpf, kconfig: Fix DEBUG_INFO_BTF_MODULES Kconfig definition").

Fix by updating `Config-kernel.in` to add the option, cleaning up a related dependency and whitespace also.

Fixes: 10d77b9bc3 ("kernel: bump 6.6 to 6.6.31")

### Testing:
Build and run-tested on `malta/mips64el` using `openwrt/master` with BTF debug info enabled.

CC: @hauke @PolynomialDivision @graysky2 