### PR TITLE
uboot-tegra: Set UBOOT_USE_INTREE_DTC

### DIFF
--- a/package/boot/uboot-tegra/Makefile
+++ b/package/boot/uboot-tegra/Makefile
@@ -13,6 +13,8 @@ PKG_HASH := 18a853fe39fad7ad03a90cc2d4275aeaed6da69735defac3492b80508843dd4a
 
 PKG_MAINTAINER := Tomasz Maciej Nowak <tmn505@gmail.com>
 
+UBOOT_USE_INTREE_DTC:=1
+
 include $(INCLUDE_DIR)/u-boot.mk
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
U-Boot 2024.04 for tegra needs swig installed on the host, this dependency is only checked if UBOOT_USE_INTREE_DTC is set. add the missing definition.

Fixes: 6832faf3407e ("uboot-tegra: bump version to 2024.04")