### PR TITLE
mediatek: fix backup configs not restored correctly during eMMC sysupgrade

### DIFF
--- a/package/base-files/files/lib/upgrade/emmc.sh
+++ b/package/base-files/files/lib/upgrade/emmc.sh
@@ -41,7 +41,7 @@ emmc_upgrade_fit() {
 	[ "$CI_KERNPART" -a -z "$EMMC_KERN_DEV" ] && export EMMC_KERN_DEV="$(find_mmc_part $CI_KERNPART $CI_ROOTDEV)"
 
 	if [ "$EMMC_KERN_DEV" ]; then
-		export EMMC_KERNEL_BLOCKS=$(($(get_image "$fit_file" | fwtool -i /dev/null -T - | dd of="$EMMC_KERN_DEV" bs=512 2>&1 | grep "records out" | cut -d' ' -f1)))
+		export EMMC_KERNEL_BLOCKS=$(($(get_image "$fit_file" | fitstrip - - | dd of="$EMMC_KERN_DEV" bs=512 2>&1 | grep "records out" | cut -d' ' -f1)))
 
 		[ -z "$UPGRADE_BACKUP" ] && dd if=/dev/zero of="$EMMC_KERN_DEV" bs=512 seek=$EMMC_KERNEL_BLOCKS count=8
 	fi

--- a/package/utils/fitstrip/Makefile
+++ b/package/utils/fitstrip/Makefile
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2007-2008 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fitstrip
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0-only
+PKG_MAINTAINER:=Weijie Gao <hackpascal@gmail.com>
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+PKG_FLAGS:=nonshared
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/fitstrip
+  HIDDEN:=1
+  SECTION:=base
+  CATEGORY:=Base system
+  TITLE:=FIT image stripping tool
+  DEPENDS:=+libfdt
+endef
+
+define Package/fitstrip/description
+Remove trailing data from FIT image
+endef
+
+define Package/fitstrip/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/fitstrip $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,fitstrip))

--- a/package/utils/fitstrip/src/Makefile
+++ b/package/utils/fitstrip/src/Makefile
@@ -1,0 +1,24 @@
+
+OBJS := fitstrip.o
+LIBS := -Wl,-Bstatic -lfdt -Wl,-Bdynamic
+DEPS := $(OBJS:%.o=%.d)
+
+CC ?= gcc
+CFLAGS ?= -O2 -ffunction-sections -fdata-sections -Wall -Werror
+LDFLAGS ?= -Wl,--gc-sections
+OPTFLAGS ?= -ggdb
+
+all: fitstrip
+
+fitstrip: $(OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
+
+$(OBJS): %.o: %.c
+	$(CC) $(CFLAGS) $(OPTFLAGS) -MD -c -o $@ $<
+
+clean:
+	rm -f fitstrip $(OBJS) $(DEPS)
+
+.PHONY: clean
+
+-include $(DEPS)

--- a/package/utils/fitstrip/src/fitstrip.c
+++ b/package/utils/fitstrip/src/fitstrip.c
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <malloc.h>
+#include <endian.h>
+#include <libfdt.h>
+
+/* Max fdt size allowed for processing */
+#define MAX_FDT_LEN			(64 << 10)
+
+/* Min buffer size for streaming */
+#define MIN_BUF_LEN			(4 << 10)
+
+/* FIT images path */
+#define FIT_IMAGES_PATH			"/images"
+
+/* FIT image node properties */
+#define FIT_DATA_POSITION_PROP		"data-position"
+#define FIT_DATA_OFFSET_PROP		"data-offset"
+#define FIT_DATA_SIZE_PROP		"data-size"
+
+static FILE *infile, *outfile;
+static void *cache;
+
+static void error(const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	(void)vfprintf(stderr, fmt, args);
+	va_end(args);
+}
+
+static int read_chunk(void *buf, size_t size, size_t *retlen)
+{
+	size_t len, total = 0;
+
+	while (size) {
+		len = fread(buf, 1, size, infile);
+		if (len < size) {
+			*retlen = total;
+
+			if (ferror(infile)) {
+				error("Failed to read input data\n");
+				return -EIO;
+			}
+
+			if (feof(infile))
+				return 0;
+		}
+
+		buf += len;
+		size -= len;
+		total += len;
+	}
+
+	*retlen = total;
+	return 0;
+}
+
+static int write_chunk(const void *buf, size_t size)
+{
+	size_t len;
+
+	while (size) {
+		len = fwrite(buf, 1, size, outfile);
+		if (len < size) {
+			if (ferror(outfile)) {
+				error("Failed to write output data\n");
+				return -EIO;
+			}
+
+			if (feof(outfile)) {
+				error("Incomplete write to output data\n");
+				return -EOF;
+			}
+		}
+
+		buf += len;
+		size -= len;
+	}
+
+	fflush(outfile);
+
+	return 0;
+}
+
+static int fit_image_size(const void *fit, size_t *retsize)
+{
+	const uint32_t *image_offset_be, *image_len_be, *image_pos_be;
+	uint32_t image_pos, image_len, image_end = 0;
+	int ret, node, images;
+
+	/* 0 means not FIT image */
+	*retsize = 0;
+
+	/* get images path in FIT image */
+	images = fdt_path_offset(fit, FIT_IMAGES_PATH);
+	if (images < 0)
+		return 0;
+
+	/* iterate over image nodes in FIT image */
+	fdt_for_each_subnode(node, fit, images) {
+		image_offset_be = fdt_getprop(fit, node, FIT_DATA_OFFSET_PROP, NULL);
+		image_pos_be = fdt_getprop(fit, node, FIT_DATA_POSITION_PROP, NULL);
+		image_len_be = fdt_getprop(fit, node, FIT_DATA_SIZE_PROP, NULL);
+
+		image_len = be32toh(*image_len_be);
+		if (!image_len)
+			continue;
+
+		if (image_offset_be)
+			image_pos = be32toh(*image_offset_be) + fdt_totalsize(fit);
+		else if (image_pos_be)
+			image_pos = be32toh(*image_pos_be);
+		else
+			continue;
+
+		if (image_pos + image_len > image_end)
+			image_end = image_pos + image_len;
+	}
+
+	*retsize = image_end;
+	return 0;
+}
+
+static int fit_image_stream_process(void)
+{
+	size_t len, chklen, fdtlen, fitlen, remained = 0;
+	struct fdt_header hdr;
+	bool unlimited = true;
+	int ret;
+
+	/* Read fdt header */
+	ret = read_chunk(&hdr, sizeof(hdr), &len);
+	if (ret)
+		return ret;
+
+	if (len < sizeof(hdr)) {
+		/* Not a fdt header */
+		return write_chunk(&hdr, len);
+	}
+
+	if (fdt_check_header(&hdr)) {
+		/* Not a valid fdt header */
+		ret = write_chunk(&hdr, len);
+		if (ret)
+			return ret;
+
+		goto streaming_remained;
+	}
+
+	fdtlen = fdt_totalsize(&hdr);
+	if (fdtlen > MAX_FDT_LEN) {
+		/* Too large fdt for processing */
+		ret = write_chunk(&hdr, len);
+		if (ret)
+			return ret;
+
+		goto streaming_remained;
+	}
+
+	/* Make sure cache is large enough for streaming */
+	len = fdtlen;
+	if (len < MIN_BUF_LEN)
+		len = MIN_BUF_LEN;
+
+	cache = malloc(len);
+	if (!cache) {
+		error("No memory for complete fdt data\n");
+		return -ENOMEM;
+	}
+
+	/* Store fdt header */
+	memcpy(cache, &hdr, sizeof(hdr));
+
+	ret = read_chunk(cache + sizeof(hdr), fdtlen - sizeof(hdr), &len);
+	if (ret)
+		return ret;
+
+	if (len < fdtlen - sizeof(hdr)) {
+		error("Incomplete fdt data\n");
+		return write_chunk(cache, fdtlen);
+	}
+
+	/* Now calculate the total size of FIT image */
+	ret = fit_image_size(cache, &fitlen);
+	if (ret)
+		return ret;
+
+	if (!fitlen)
+		fitlen = fdtlen;
+
+	if (fitlen < fdtlen) {
+		/* Invalid FIT image size */
+		error("Invalid FIT image size\n");
+		return -EINVAL;
+	}
+
+	/* Write fdt part */
+	ret = write_chunk(cache, fdtlen);
+	if (ret)
+		return ret;
+
+	remained = fitlen - fdtlen;
+	unlimited = false;
+
+	/* Stream remained data */
+streaming_remained:
+	while (unlimited || remained) {
+		if (unlimited || remained >= MIN_BUF_LEN)
+			chklen = MIN_BUF_LEN;
+		else
+			chklen = remained;
+
+		ret = read_chunk(cache, chklen, &len);
+		if (ret)
+			return ret;
+
+		ret = write_chunk(cache, len);
+		if (ret)
+			return ret;
+
+		if (!unlimited)
+			remained -= len;
+	}
+
+	return 0;
+}
+
+static int open_file(FILE **f, const char *file, bool read)
+{
+	int ret;
+
+	if (!strcmp(file, "-")) {
+		if (read)
+			*f = stdin;
+		else
+			*f = stdout;
+
+		return 0;
+	}
+
+	*f = fopen(file, read ? "rb" : "wb");
+	if (!*f) {
+		ret = errno;
+
+		error("Unable to open %s file '%s': %s\n",
+		      read ? "input" : "output", file, strerror(ret));
+
+		return -ret;
+	}
+
+	return 0;
+}
+
+static void close_file(FILE *f, bool read)
+{
+	if (read) {
+		if (f != stdin)
+			fclose(f);
+	} else {
+		fflush(f);
+
+		if (f != stdout)
+			fclose(f);
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	char *end;
+	int ret;
+
+	if (argc != 3) {
+		error("Remove trailing data from FIT image\n");
+		error("Usage: %s <infile> <outfile>\n", argv[0]);
+		return -EINVAL;
+	}
+
+	ret = open_file(&infile, argv[1], true);
+	if (ret)
+		return ret;
+
+	ret = open_file(&outfile, argv[2], false);
+	if (ret)
+		return ret;
+
+	ret = fit_image_stream_process();
+
+	if (cache)
+		free(cache);
+
+	close_file(infile, true);
+	close_file(outfile, false);
+
+	return ret;
+}

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -1,5 +1,5 @@
 REQUIRE_IMAGE_METADATA=1
-RAMFS_COPY_BIN='fitblk'
+RAMFS_COPY_BIN='fitblk fitstrip'
 
 asus_initial_setup()
 {

--- a/target/linux/mediatek/filogic/target.mk
+++ b/target/linux/mediatek/filogic/target.mk
@@ -2,7 +2,7 @@ ARCH:=aarch64
 SUBTARGET:=filogic
 BOARDNAME:=Filogic 8x0 (MT798x)
 CPU_TYPE:=cortex-a53
-DEFAULT_PACKAGES += fitblk kmod-phy-aquantia kmod-crypto-hw-safexcel wpad-basic-mbedtls uboot-envtools
+DEFAULT_PACKAGES += fitblk fitstrip kmod-phy-aquantia kmod-crypto-hw-safexcel wpad-basic-mbedtls uboot-envtools
 KERNELNAME:=Image dtbs
 
 define Target/Description

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
@@ -1,5 +1,5 @@
 REQUIRE_IMAGE_METADATA=1
-RAMFS_COPY_BIN='fitblk'
+RAMFS_COPY_BIN='fitblk fitstrip'
 
 platform_do_upgrade() {
 	local board=$(board_name)

--- a/target/linux/mediatek/mt7622/target.mk
+++ b/target/linux/mediatek/mt7622/target.mk
@@ -2,7 +2,7 @@ ARCH:=aarch64
 SUBTARGET:=mt7622
 BOARDNAME:=MT7622
 CPU_TYPE:=cortex-a53
-DEFAULT_PACKAGES += fitblk kmod-mt7622-firmware wpad-basic-mbedtls uboot-envtools
+DEFAULT_PACKAGES += fitblk fitstrip kmod-mt7622-firmware wpad-basic-mbedtls uboot-envtools
 KERNELNAME:=Image dtbs
 
 define Target/Description


### PR DESCRIPTION
The *.itb firmware image has the following structure:
```
-----------------------------------------
| uImage.FIT | jffs2 padding | metadata |
-----------------------------------------
```

Currently during sysupgrade, the whole firmware image will be written to eMMC partition, and the tarball of backup configs will be appended to the firmware image:
```
----------------------------------------------------------
| uImage.FIT | jffs2 padding | metadata | config tarball |
----------------------------------------------------------
```

The fitblk driver will create /dev/fitrw* to make use of all free spaces of the partition:
```
----------------------------------------------------------
| uImage.FIT | jffs2 padding | metadata | config tarball |
|------------|-------------------------------------------|
|            |         rootfs_data (/dev/fitrw*)         |
----------------------------------------------------------
```

It's obvious the config tarball is not at the start of rootfs_data, thus fstools will not going to restore settings.

So this PR introduces a tool name fitstrip. It will use the *.itb firmware image as input and write only uImage.FIT to output. This will make sure config tarball always at the start of rootfs_data:
```
------------------------------------------
| uImage.FIT |       config tarball      |
|------------|---------------------------|
|            | rootfs_data (/dev/fitrw*) |
------------------------------------------
```

Tested on BPI-R4