### PR TITLE
ramips: Add support for TP-Link Archer MR200 v6

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_archer-mr200-v6.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-mr200-v6.dts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tplink,archer-mr200-v6", "mediatek,mt7628an-soc";
+	model = "TP-Link Archer MR200 v6";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		signal1 {
+			label = "white:signal1";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		signal2 {
+			label = "white:signal2";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		signal3 {
+			label = "white:signal3";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			firmware@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x20000 0xfa0000>;
+			};
+
+			partition@fc0000 {
+				label = "config";
+				reg = <0xfc0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_f100: macaddr@f100 {
+						compatible = "mac-base";
+						reg = <0xf100 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@fd0000 {
+				label = "romfile";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "radio";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_radio_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_radio_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "p0led_an", "p1led_an", "p2led_an", "p3led_an", "p4led_an", "uart1", "wdt";
+		function = "gpio";
+	};
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_f100 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	status = "okay";
+};
+
+&esw {
+	mediatek,portdisable = <0x30>;
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_config_f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_config_f100 (-1)>;
+		nvmem-cell-names = "eeprom", "mac-address";
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -675,6 +675,22 @@ define Device/tplink_archer-mr200-v5
 endef
 TARGET_DEVICES += tplink_archer-mr200-v5
 
+define Device/tplink_archer-mr200-v6
+  $(Device/tplink-v2)
+  IMAGE_SIZE := 15936k
+  DEVICE_MODEL := Archer MR200
+  DEVICE_VARIANT := v6
+  TPLINK_FLASHLAYOUT := 16Mmtk
+  TPLINK_HWID := 0x20000006
+  TPLINK_HWREV := 0x6
+  TPLINK_HWREVADD := 0x6
+  DEVICE_PACKAGES := kmod-mt76x0e uqmi kmod-usb2 kmod-usb-serial-option
+  KERNEL := kernel-bin | append-dtb | lzma -d22
+  KERNEL_INITRAMFS := kernel-bin | append-dtb
+  IMAGES := sysupgrade.bin
+endef
+TARGET_DEVICES += tplink_archer-mr200-v6
+
 define Device/tplink_re200-v2
   $(Device/tplink-safeloader)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -89,7 +89,8 @@ tplink,archer-c50-v6)
 	ucidef_set_led_wlan "wlan2g" "wlan2g" "green:wlan2g" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "wlan5g" "green:wlan5g" "phy1tpt"
 	;;
-tplink,archer-mr200-v5)
+tplink,archer-mr200-v5|\
+tplink,archer-mr200-v6)
 	ucidef_set_led_netdev "lan" "lan" "white:lan" "eth0"
 	ucidef_set_led_netdev "wan" "wan" "white:wan" "wwan0"
 	;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -166,7 +166,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
 		;;
-	tplink,archer-mr200-v5)
+	tplink,archer-mr200-v5|\
+	tplink,archer-mr200-v6)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "6t@eth0"
 		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"


### PR DESCRIPTION
Shell access to root on vendor firmware:
admin:1234

To get U-Boot console, spam '4' into the serial console at boot.

with LEDs on the left, serial pinout is:

o - tx
o - rx
o - gnd
x - 3v3

server ip for tftpboot
192.168.0.225

The initramfs-kernel version boots without touching onboard flash with:
```
MT7628# tftpboot 0x80000000 openwrt-ramips-mt76x8-tplink_archer-mr200-v6-initramfs-kernel.bin
MT7628# bootm 0x80000000
```
Can't quite figure out the tplink header, it looks like some kind of (new) v3?

Vendor flash @0x20000 (start of kernel)
```
    00018d30  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
    *
    00020000  03 00 00 03 09 66 ab db  51 b5 5c 49 68 7f 0c 09  |.....f..Q.\Ih...|
    00020010  0c 16 7a eb 20 00 22 33  44 55 66 77 88 99 aa bb  |..z. ."3DUfw....|
    00020020  cc dd ee 0b ab 30 08 f0  04 f8 46 4d b9 3c b3 e9  |.....0....FM.<..|
    00020030  73 fa 12 49 06 21 cf 08  01 00 00 00 01 00 00 00  |s..I.!..........|
    00020040  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
    00020050  00 00 00 00 55 aa 55 aa  f1 e2 d3 c4 e5 a6 6a 5e  |....U.U.......j^|
    00020060  4c 3d 2e 1f aa 55 aa 55  00 00 00 80 50 c1 00 80  |L=...U.U....P...|
    00020070  00 00 fa 00 00 02 00 00  ad ac 12 00 00 00 20 00  |.............. .|
    00020080  00 b0 85 00 00 00 00 00  00 00 00 00 01 01 aa 55  |...............U|
    00020090  01 09 00 a5 00 00 55 45  71 a6 74 64 a9 69 00 00  |......UEq.td.i..|
    000200a0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
    *
    000200d0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
    *
    000201d0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
    *
    00020200  5d 00 00 80 00 f4 09 39  00 00 00 00 00 00 00 6f  |]......9.......o|
```

How do I complete the port?

- [x] LEDs working
- [x] Buttons working
- [x] wlan detected
- [x] wwan detected

Full boot log at https://zamaudio.com/mbox2/booted.txt

Signed-off-by: Damien Zammit <damien@zamaudio.com>

Firmware utils PR: https://github.com/openwrt/firmware-utils/pull/34
