### PR TITLE
mpc85xx: refresh patches

### DIFF
--- a/target/linux/mpc85xx/patches-6.1/100-powerpc-85xx-tl-wdr4900-v1-support.patch
+++ b/target/linux/mpc85xx/patches-6.1/100-powerpc-85xx-tl-wdr4900-v1-support.patch
@@ -27,7 +27,7 @@ Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
  
-@@ -359,7 +360,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
+@@ -360,7 +361,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
  image-$(CONFIG_TQM8555)			+= cuImage.tqm8555
  image-$(CONFIG_TQM8560)			+= cuImage.tqm8560
  image-$(CONFIG_KSI8560)			+= cuImage.ksi8560
@@ -38,7 +38,7 @@ Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
  
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -341,6 +341,11 @@ adder875-redboot)
+@@ -346,6 +346,11 @@ adder875-redboot)
      platformo="$object/fixed-head.o $object/redboot-8xx.o"
      binary=y
      ;;

--- a/target/linux/mpc85xx/patches-6.1/101-powerpc-85xx-hiveap-330-support.patch
+++ b/target/linux/mpc85xx/patches-6.1/101-powerpc-85xx-hiveap-330-support.patch
@@ -38,7 +38,7 @@
  src-plat-$(CONFIG_TL_WDR4900_V1) += simpleboot.c fixed-head.S
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
-@@ -360,6 +361,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
+@@ -361,6 +362,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
  image-$(CONFIG_TQM8555)			+= cuImage.tqm8555
  image-$(CONFIG_TQM8560)			+= cuImage.tqm8560
  image-$(CONFIG_KSI8560)			+= cuImage.ksi8560
@@ -48,7 +48,7 @@
  image-$(CONFIG_MVME7100)                += dtbImage.mvme7100
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -341,6 +341,7 @@ adder875-redboot)
+@@ -346,6 +346,7 @@ adder875-redboot)
      platformo="$object/fixed-head.o $object/redboot-8xx.o"
      binary=y
      ;;

--- a/target/linux/mpc85xx/patches-6.1/106-powerpc-85xx-ws-ap3710i-support.patch
+++ b/target/linux/mpc85xx/patches-6.1/106-powerpc-85xx-ws-ap3710i-support.patch
@@ -38,7 +38,7 @@
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
  
-@@ -363,6 +364,7 @@ image-$(CONFIG_TQM8560)			+= cuImage.tqm
+@@ -364,6 +365,7 @@ image-$(CONFIG_TQM8560)			+= cuImage.tqm
  image-$(CONFIG_KSI8560)			+= cuImage.ksi8560
  image-$(CONFIG_HIVEAP_330)		+= simpleImage.hiveap-330
  image-$(CONFIG_TL_WDR4900_V1)		+= simpleImage.tl-wdr4900-v1
@@ -48,7 +48,7 @@
  
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -342,7 +342,8 @@ adder875-redboot)
+@@ -347,7 +347,8 @@ adder875-redboot)
      binary=y
      ;;
  simpleboot-hiveap-330|\

--- a/target/linux/mpc85xx/patches-6.1/107-powerpc-85xx-add-ws-ap3825i-support.patch
+++ b/target/linux/mpc85xx/patches-6.1/107-powerpc-85xx-add-ws-ap3825i-support.patch
@@ -45,7 +45,7 @@ WS-AP3825i AP.
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
  
-@@ -365,6 +366,7 @@ image-$(CONFIG_KSI8560)			+= cuImage.ksi
+@@ -366,6 +367,7 @@ image-$(CONFIG_KSI8560)			+= cuImage.ksi
  image-$(CONFIG_HIVEAP_330)		+= simpleImage.hiveap-330
  image-$(CONFIG_TL_WDR4900_V1)		+= simpleImage.tl-wdr4900-v1
  image-$(CONFIG_WS_AP3710I)		+= simpleImage.ws-ap3710i
@@ -55,7 +55,7 @@ WS-AP3825i AP.
  
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -343,7 +343,8 @@ adder875-redboot)
+@@ -348,7 +348,8 @@ adder875-redboot)
      ;;
  simpleboot-hiveap-330|\
  simpleboot-tl-wdr4900-v1|\

--- a/target/linux/mpc85xx/patches-6.1/109-powerpc-85xx-add-ws-ap3715i-support.patch
+++ b/target/linux/mpc85xx/patches-6.1/109-powerpc-85xx-add-ws-ap3715i-support.patch
@@ -38,7 +38,7 @@
  src-plat-$(CONFIG_WS_AP3825I) += simpleboot.c fixed-head.S
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
-@@ -366,6 +367,7 @@ image-$(CONFIG_KSI8560)			+= cuImage.ksi
+@@ -367,6 +368,7 @@ image-$(CONFIG_KSI8560)			+= cuImage.ksi
  image-$(CONFIG_HIVEAP_330)		+= simpleImage.hiveap-330
  image-$(CONFIG_TL_WDR4900_V1)		+= simpleImage.tl-wdr4900-v1
  image-$(CONFIG_WS_AP3710I)		+= simpleImage.ws-ap3710i

--- a/target/linux/mpc85xx/patches-6.1/110-powerpc-85xx-br200-wp-support.patch
+++ b/target/linux/mpc85xx/patches-6.1/110-powerpc-85xx-br200-wp-support.patch
@@ -37,7 +37,7 @@
  src-plat-$(CONFIG_HIVEAP_330) += simpleboot.c fixed-head.S
  src-plat-$(CONFIG_TL_WDR4900_V1) += simpleboot.c fixed-head.S
  src-plat-$(CONFIG_WS_AP3710I) += simpleboot.c fixed-head.S
-@@ -364,6 +365,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
+@@ -365,6 +366,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
  image-$(CONFIG_TQM8555)			+= cuImage.tqm8555
  image-$(CONFIG_TQM8560)			+= cuImage.tqm8560
  image-$(CONFIG_KSI8560)			+= cuImage.ksi8560
@@ -47,7 +47,7 @@
  image-$(CONFIG_WS_AP3710I)		+= simpleImage.ws-ap3710i
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -341,6 +341,7 @@ adder875-redboot)
+@@ -346,6 +346,7 @@ adder875-redboot)
      platformo="$object/fixed-head.o $object/redboot-8xx.o"
      binary=y
      ;;

--- a/target/linux/mpc85xx/patches-6.1/900-powerpc-bootwrapper-disable-uImage-generation.patch
+++ b/target/linux/mpc85xx/patches-6.1/900-powerpc-bootwrapper-disable-uImage-generation.patch
@@ -24,7 +24,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  image-$(CONFIG_EPAPR_BOOT)		+= zImage.epapr
  
  #
-@@ -430,15 +429,6 @@ $(obj)/dtbImage.%: vmlinux $(wrapperbits
+@@ -431,15 +430,6 @@ $(obj)/dtbImage.%: vmlinux $(wrapperbits
  $(obj)/vmlinux.strip: vmlinux
  	$(STRIP) -s -R .comment $< -o $@
  

--- a/target/linux/mpc85xx/patches-6.6/010-powerpc-add-compressed-zImage-for-mpc85xx.patch
+++ b/target/linux/mpc85xx/patches-6.6/010-powerpc-add-compressed-zImage-for-mpc85xx.patch
@@ -16,17 +16,17 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 
 --- a/arch/powerpc/boot/Makefile
 +++ b/arch/powerpc/boot/Makefile
-@@ -345,6 +345,7 @@ image-$(CONFIG_MPC836x_MDS)		+= cuImage.
+@@ -342,6 +342,7 @@ image-$(CONFIG_MPC834x_ITX)		+= cuImage.
  image-$(CONFIG_ASP834x)			+= dtbImage.asp834x-redboot
  
  # Board ports in arch/powerpc/platform/85xx/Kconfig
 +image-y					+= zImage.la3000000
- image-$(CONFIG_MPC8540_ADS)		+= cuImage.mpc8540ads
- image-$(CONFIG_MPC8560_ADS)		+= cuImage.mpc8560ads
- image-$(CONFIG_MPC85xx_CDS)		+= cuImage.mpc8541cds \
+ image-$(CONFIG_MPC85xx_MDS)		+= cuImage.mpc8568mds
+ image-$(CONFIG_MPC85xx_DS)		+= cuImage.mpc8544ds \
+ 					   cuImage.mpc8572ds
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -254,6 +254,11 @@ if [ -n "$esm_blob" -a "$platform" != "p
+@@ -258,6 +258,11 @@ if [ -n "$esm_blob" -a "$platform" != "p
  fi
  
  case "$platform" in

--- a/target/linux/mpc85xx/patches-6.6/100-powerpc-85xx-tl-wdr4900-v1-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/100-powerpc-85xx-tl-wdr4900-v1-support.patch
@@ -27,7 +27,7 @@ Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
  
-@@ -351,7 +352,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
+@@ -352,7 +353,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
  image-$(CONFIG_TQM8555)			+= cuImage.tqm8555
  image-$(CONFIG_TQM8560)			+= cuImage.tqm8560
  image-$(CONFIG_KSI8560)			+= cuImage.ksi8560
@@ -38,7 +38,7 @@ Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
  
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -345,6 +345,11 @@ adder875-redboot)
+@@ -350,6 +350,11 @@ adder875-redboot)
      platformo="$object/fixed-head.o $object/redboot-8xx.o"
      binary=y
      ;;

--- a/target/linux/mpc85xx/patches-6.6/101-powerpc-85xx-hiveap-330-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/101-powerpc-85xx-hiveap-330-support.patch
@@ -38,7 +38,7 @@
  src-plat-$(CONFIG_TL_WDR4900_V1) += simpleboot.c fixed-head.S
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
-@@ -352,6 +353,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
+@@ -353,6 +354,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
  image-$(CONFIG_TQM8555)			+= cuImage.tqm8555
  image-$(CONFIG_TQM8560)			+= cuImage.tqm8560
  image-$(CONFIG_KSI8560)			+= cuImage.ksi8560
@@ -48,7 +48,7 @@
  image-$(CONFIG_MVME7100)                += dtbImage.mvme7100
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -345,6 +345,7 @@ adder875-redboot)
+@@ -350,6 +350,7 @@ adder875-redboot)
      platformo="$object/fixed-head.o $object/redboot-8xx.o"
      binary=y
      ;;

--- a/target/linux/mpc85xx/patches-6.6/106-powerpc-85xx-ws-ap3710i-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/106-powerpc-85xx-ws-ap3710i-support.patch
@@ -38,7 +38,7 @@
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
  
-@@ -355,6 +356,7 @@ image-$(CONFIG_TQM8560)			+= cuImage.tqm
+@@ -356,6 +357,7 @@ image-$(CONFIG_TQM8560)			+= cuImage.tqm
  image-$(CONFIG_KSI8560)			+= cuImage.ksi8560
  image-$(CONFIG_HIVEAP_330)		+= simpleImage.hiveap-330
  image-$(CONFIG_TL_WDR4900_V1)		+= simpleImage.tl-wdr4900-v1
@@ -48,7 +48,7 @@
  
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -346,7 +346,8 @@ adder875-redboot)
+@@ -351,7 +351,8 @@ adder875-redboot)
      binary=y
      ;;
  simpleboot-hiveap-330|\

--- a/target/linux/mpc85xx/patches-6.6/107-powerpc-85xx-add-ws-ap3825i-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/107-powerpc-85xx-add-ws-ap3825i-support.patch
@@ -45,7 +45,7 @@ WS-AP3825i AP.
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
  
-@@ -357,6 +358,7 @@ image-$(CONFIG_KSI8560)			+= cuImage.ksi
+@@ -358,6 +359,7 @@ image-$(CONFIG_KSI8560)			+= cuImage.ksi
  image-$(CONFIG_HIVEAP_330)		+= simpleImage.hiveap-330
  image-$(CONFIG_TL_WDR4900_V1)		+= simpleImage.tl-wdr4900-v1
  image-$(CONFIG_WS_AP3710I)		+= simpleImage.ws-ap3710i
@@ -55,7 +55,7 @@ WS-AP3825i AP.
  
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -347,7 +347,8 @@ adder875-redboot)
+@@ -352,7 +352,8 @@ adder875-redboot)
      ;;
  simpleboot-hiveap-330|\
  simpleboot-tl-wdr4900-v1|\

--- a/target/linux/mpc85xx/patches-6.6/109-powerpc-85xx-add-ws-ap3715i-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/109-powerpc-85xx-add-ws-ap3715i-support.patch
@@ -38,7 +38,7 @@
  src-plat-$(CONFIG_WS_AP3825I) += simpleboot.c fixed-head.S
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
-@@ -358,6 +359,7 @@ image-$(CONFIG_KSI8560)			+= cuImage.ksi
+@@ -359,6 +360,7 @@ image-$(CONFIG_KSI8560)			+= cuImage.ksi
  image-$(CONFIG_HIVEAP_330)		+= simpleImage.hiveap-330
  image-$(CONFIG_TL_WDR4900_V1)		+= simpleImage.tl-wdr4900-v1
  image-$(CONFIG_WS_AP3710I)		+= simpleImage.ws-ap3710i

--- a/target/linux/mpc85xx/patches-6.6/110-powerpc-85xx-br200-wp-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/110-powerpc-85xx-br200-wp-support.patch
@@ -37,7 +37,7 @@
  src-plat-$(CONFIG_HIVEAP_330) += simpleboot.c fixed-head.S
  src-plat-$(CONFIG_TL_WDR4900_V1) += simpleboot.c fixed-head.S
  src-plat-$(CONFIG_WS_AP3710I) += simpleboot.c fixed-head.S
-@@ -356,6 +357,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
+@@ -357,6 +358,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
  image-$(CONFIG_TQM8555)			+= cuImage.tqm8555
  image-$(CONFIG_TQM8560)			+= cuImage.tqm8560
  image-$(CONFIG_KSI8560)			+= cuImage.ksi8560
@@ -47,7 +47,7 @@
  image-$(CONFIG_WS_AP3710I)		+= simpleImage.ws-ap3710i
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -345,6 +345,7 @@ adder875-redboot)
+@@ -350,6 +350,7 @@ adder875-redboot)
      platformo="$object/fixed-head.o $object/redboot-8xx.o"
      binary=y
      ;;

--- a/target/linux/mpc85xx/patches-6.6/900-powerpc-bootwrapper-disable-uImage-generation.patch
+++ b/target/linux/mpc85xx/patches-6.6/900-powerpc-bootwrapper-disable-uImage-generation.patch
@@ -24,7 +24,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  image-$(CONFIG_EPAPR_BOOT)		+= zImage.epapr
  
  #
-@@ -421,15 +420,6 @@ $(obj)/dtbImage.%: vmlinux $(wrapperbits
+@@ -422,15 +421,6 @@ $(obj)/dtbImage.%: vmlinux $(wrapperbits
  $(obj)/vmlinux.strip: vmlinux
  	$(STRIP) -s -R .comment $< -o $@
  


### PR DESCRIPTION
010-powerpc-add-compressed-zImage-for-mpc85xx.patch requires adaptation to 6.6. 
Other patches refreshed by 'make target/linux/refresh'

Fixes 7d768a9 compilation errors but for p2020 there is still an error:
"powerpc-openwrt-linux-musl-ld.bin: cannot find arch/powerpc/boot/fixed-head.o: No such file or directory"
