### PR TITLE
gettext-full: link libiconv when building host pkg

### DIFF
--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -25,7 +25,7 @@ PKG_INSTALL:=1
 PKG_BUILD_DEPENDS:=gettext-full/host libunistring libxml2
 PKG_BUILD_PARALLEL:=0
 
-HOST_BUILD_DEPENDS:=gperf/host libunistring/host libxml2/host
+HOST_BUILD_DEPENDS:=gperf/host libiconv-full/host libunistring/host libxml2/host
 HOST_BUILD_PARALLEL:=0
 
 PKG_SUBDIRS:= \
@@ -99,14 +99,12 @@ HOST_CONFIGURE_ARGS += \
 	--disable-java \
 	--disable-openmp \
 	--without-emacs \
+	--with-libiconv-prefix=$(STAGING_DIR_HOSTPKG) \
 	--with-libunistring-prefix=$(STAGING_DIR_HOSTPKG) \
 	--with-libxml2-prefix=$(STAGING_DIR_HOSTPKG)
 
 HOST_CONFIGURE_VARS += \
 	EMACS="no" \
-	am_cv_lib_iconv=no \
-	am_cv_func_iconv=no \
-	ac_cv_header_iconv_h=no \
 
 HOST_CFLAGS += $(HOST_FPIC)
 


### PR DESCRIPTION
On Fedora 40 system, some compile error happens when building iconv-ostream.c. Linking to libiconv-full fixes this.

Signed-off-by: Yanase Yuki <dev@zpc.st>
Signed-off-by: Robert Marko <robimarko@gmail.com>
(cherry picked from commit 63dd14b906e9eb27bc878b95ac6777a3624b1135)
