### PR TITLE
ramips: mt7620: fix lan port order for Edimax BR-6478AC v2

### DIFF
--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -150,7 +150,6 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
 		;;
-	edimax,br-6478ac-v2|\
 	lb-link,bl-w1200|\
 	tplink,archer-c2-v1)
 		ucidef_add_switch "switch0"
@@ -185,6 +184,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "5:wan" "6@eth0"
 		;;
+	edimax,br-6478ac-v2|\
 	iodata,wn-ac1167gr|\
 	iodata,wn-ac733gr3|\
 	iptime,a1004ns)


### PR DESCRIPTION
For the Edimax BR-6478AC v2 the ethernet switch port order from the back of the
device is labeled from left to right: WAN / 4 / 3 / 2 / 1
Currently this is reversed when looking at the Luci Webinterface switch numbers,
this commit make them resemble with the port numbers on the back of the device.

Signed-off-by: Walter Sonius <walterav1984@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
