### PR TITLE
qualcommax: ipq60xx: add support for Cambium Networks XE3-4

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq60xx
@@ -9,7 +9,8 @@ board=$(board_name)
 
 case "$board" in
 8devices,mango-dvk|\
-8devices,mango-dvk-sfp)
+8devices,mango-dvk-sfp|\
+cambiumnetworks,xe3-4)
 	idx="$(find_mtd_index 0:APPSBLENV)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000"

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -31,6 +31,7 @@ ALLWIFIBOARDS:= \
 	arcadyan_aw1000 \
 	asus_rt-ax89x \
 	buffalo_wxr-5950ax12 \
+	cambiumnetworks_xe34 \
 	cmcc_rm2-6 \
 	compex_wpq873 \
 	dynalink_dl-wrx36 \
@@ -155,6 +156,7 @@ $(eval $(call generate-ipq-wifi-package,8devices_mango,8devices Mango))
 $(eval $(call generate-ipq-wifi-package,arcadyan_aw1000,Arcadyan AW1000))
 $(eval $(call generate-ipq-wifi-package,asus_rt-ax89x,Asus RT-AX89X))
 $(eval $(call generate-ipq-wifi-package,buffalo_wxr-5950ax12,Buffalo WXR-5950AX12))
+$(eval $(call generate-ipq-wifi-package,cambiumnetworks_xe34,Cambium Networks XE3-4))
 $(eval $(call generate-ipq-wifi-package,cmcc_rm2-6,CMCC RM2-6))
 $(eval $(call generate-ipq-wifi-package,compex_wpq873,Compex WPQ-873))
 $(eval $(call generate-ipq-wifi-package,dynalink_dl-wrx36,Dynalink DL-WRX36))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-xe3-4.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-xe3-4.dts
@@ -1,0 +1,454 @@
+// SPDX-License-Identifier: (GPL-2.0+)
+
+/dts-v1/;
+
+#include "ipq6018.dtsi"
+#include "ipq6018-fixed-smps.dtsi"
+#include "ipq6018-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	/* Qualcomm Technologies, Inc. IPQ6018/AP-CP01-C3 */
+	model = "Cambium Networks XE3-4";
+	compatible = "cambiumnetworks,xe3-4", "qcom,ipq6018-cp01", "qcom,ipq6018";
+
+	aliases {
+		serial0 = &blsp1_uart3;
+		sdhc2 = &sdhc_1;
+		ethernet0 = &dp5;
+		ethernet1 = &dp4;
+		label-mac-device = &dp5;
+
+		led-boot = &led_status_amber;
+		led-failsafe = &led_status_amber;
+		led-running = &led_status_white;
+		led-upgrade = &led_status_amber;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 19 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		led_status_white: status-white {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_STATUS;
+			gpio = <&tlmm 56 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_amber: status-amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_STATUS;
+			gpio = <&tlmm 35 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	reg_sd_vmmc: regulator-sdcard-vmmc {
+		compatible = "regulator-fixed";
+		regulator-name = "sdcard-vmmc";
+		regulator-min-microvolt = <2950000>;
+		regulator-max-microvolt = <2950000>;
+
+		startup-delay-us = <200>;
+
+		gpio = <&tlmm 66 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&sd_vmmc_en_default>;
+	};
+};
+
+&blsp1_uart3 {
+	pinctrl-0 = <&serial_3_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp1_i2c3 {
+	pinctrl-0 = <&i2c_1_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&tlmm {
+	/* TZ has exclusive control over GPIO20 */
+	gpio-reserved-ranges = <20 1>;
+
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio64";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio65";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	i2c_1_pins: i2c-1-state {
+		pins = "gpio42", "gpio43";
+		function = "blsp2_i2c";
+		drive-strength = <8>;
+	};
+
+	spi_0_pins: spi-0-state {
+		pins = "gpio38", "gpio39", "gpio40", "gpio41";
+		function = "blsp0_spi";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+
+	led_pins: led_pins {
+		leds {
+			pins = "gpio35", "gpio37", "gpio50";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+	};
+
+	sd_vmmc_en_default: sd-vmmc-en-default-state {
+		pins = "gpio66";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+
+	sd_pins: sd-state {
+		pins = "gpio62";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+};
+
+&pcie_phy {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+	perst-gpio = <&tlmm 60 GPIO_ACTIVE_LOW>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			status = "okay";
+
+			/* ath11k has no DT compatible for PCI cards */
+			compatible = "pci17cb,1104";
+			reg = <0x00010000 0 0 0 0>;
+
+			qcom,ath11k-fw-memory-mode = <0>;
+			qcom,ath11k-calibration-variant = "CambiumNetworks-XE34";
+		};
+	};
+};
+
+&sdhc_1 {
+	pinctrl-0 = <&sd_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	cd-gpios = <&tlmm 62 GPIO_ACTIVE_LOW>;
+	vqmmc-supply = <&reg_sd_vmmc>;
+	bus-width = <4>;
+};
+
+&edma {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+
+	switch_lan_bmp = <(ESS_PORT4 | ESS_PORT5)>;
+	switch_mac_mode = <MAC_MODE_PSGMII>;
+	switch_mac_mode2 = <MAC_MODE_SGMII_PLUS>;
+
+	qcom,port_phyinfo {
+		port@4 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+
+		port@5 {
+			port_id = <5>;
+			phy_address = <24>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 75 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <10000>;
+	reset-post-delay-us = <50000>;
+
+	ethernet-phy-package@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "qcom,qca8075-package";
+		reg = <0>;
+
+		qcom,package-mode = "psgmii";
+
+		qca8072: ethernet-phy@3 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <3>;
+		};
+	};
+
+	qca8081: ethernet-phy@24 {
+		compatible = "ethernet-phy-id004d.d101";
+		reg = <24>;
+		reset-gpios = <&tlmm 77 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <50000>;
+	};
+};
+
+&dp4 {
+	status = "okay";
+
+	phy-handle = <&qca8072>;
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eth1addr 0>;
+	label = "lan2";
+};
+
+&dp5 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	phy-handle = <&qca8081>;
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&ethaddr 0>;
+	label = "lan1";
+};
+
+&blsp1_spi1 {
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		/*
+		 * U-boot looks for "n25q128a11" node,
+		 * if we don't have it, it will spit out the following warning:
+		 * "ipq: fdt fixup unable to find compatible node".
+		 */
+		linux,modalias = "m25p80", "mx30uf2g18ac", "n25q128a11";
+		compatible = "micron,n25q128a11", "jedec,spi-nor";
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x0 0xc0000>;
+				read-only;
+			};
+
+			partition@c0000 {
+				label = "0:MIBIB";
+				reg = <0xc0000 0x10000>;
+				read-only;
+			};
+
+			partition@d0000 {
+				label = "0:BOOTCONFIG";
+				reg = <0xd0000 0x20000>;
+				read-only;
+			};
+
+			partition@f0000 {
+				label = "0:BOOTCONFIG1";
+				reg = <0xf0000 0x20000>;
+				read-only;
+			};
+
+			partition@110000 {
+				label = "0:QSEE";
+				reg = <0x110000 0x1a0000>;
+				read-only;
+			};
+
+			partition@2b0000 {
+				label = "0:QSEE_1";
+				reg = <0x2b0000 0x1a0000>;
+				read-only;
+			};
+
+			partition@450000 {
+				label = "0:DEVCFG";
+				reg = <0x450000 0x10000>;
+				read-only;
+			};
+
+			partition@460000 {
+				label = "mfginfo";
+				reg = <0x460000 0x10000>;
+				read-only;
+			};
+
+			partition@470000 {
+				label = "0:RPM";
+				reg = <0x470000 0x40000>;
+				read-only;
+			};
+
+			partition@4b0000 {
+				label = "0:RPM_1";
+				reg = <0x4b0000 0x40000>;
+				read-only;
+			};
+
+			partition@4f0000 {
+				label = "0:CDT";
+				reg = <0x4f0000 0x10000>;
+				read-only;
+			};
+
+			partition@500000 {
+				label = "0:CDT_1";
+				reg = <0x500000 0x10000>;
+				read-only;
+			};
+
+			partition@510000 {
+				compatible = "u-boot,env";
+				label = "0:APPSBLENV";
+				reg = <0x510000 0x10000>;
+
+				ethaddr: ethaddr {
+					#nvmem-cell-cells = <0>;
+				};
+
+				eth1addr: eth1addr {
+					#nvmem-cell-cells = <0>;
+				};
+
+				eth2addr: eth2addr {
+					#nvmem-cell-cells = <0>;
+				};
+
+				eth5addr: eth5addr {
+					#nvmem-cell-cells = <0>;
+				};
+			};
+
+			partition@520000 {
+				label = "0:APPSBL";
+				reg = <0x520000 0xa0000>;
+				read-only;
+			};
+
+			partition@5c0000 {
+				label = "0:APPSBL_1";
+				reg = <0x5c0000 0xa0000>;
+				read-only;
+			};
+
+			partition@660000 {
+				label = "0:ART";
+				reg = <0x660000 0x80000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "rootfs";
+				reg = <0x0 0x6000000>;
+			};
+
+			partition@6000000 {
+				label = "rootfs_1";
+				reg = <0x6000000 0x6000000>;
+			};
+
+			partition@c000000 {
+				label = "NVRAM";
+				reg = <0xc000000 0x3000000>;
+			};
+
+			partition@f000000 {
+				label = "crashLog";
+				reg = <0xf000000 0x1000000>;
+			};
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+	qcom,ath11k-calibration-variant = "CambiumNetworks-XE34";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eth2addr>;
+};
+
+&qusb_phy_1 {
+	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-fixed-smps.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-fixed-smps.dtsi
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Board does not use companion MP5496 PMIC,
+ * but rather uses fixed external SMPS.
+ */
+
+&rpm {
+	status = "disabled";
+};
+
+&CPU0 {
+	/delete-property/ cpu-supply;
+};
+
+&CPU1 {
+	/delete-property/ cpu-supply;
+};
+
+&CPU2 {
+	/delete-property/ cpu-supply;
+};
+
+&CPU3 {
+	/delete-property/ cpu-supply;
+};
+
+&cpu_opp_table {
+	opp-864000000 {
+		opp-microvolt = <1100000>;
+	};
+
+	opp-1056000000 {
+		opp-microvolt = <1100000>;
+	};
+
+	opp-1320000000 {
+		opp-microvolt = <1100000>;
+	};
+
+	opp-1440000000 {
+		opp-microvolt = <1100000>;
+	};
+
+	opp-1608000000 {
+		opp-microvolt = <1100000>;
+	};
+
+	opp-1800000000 {
+		opp-microvolt = <1100000>;
+	};
+};

--- a/target/linux/qualcommax/image/ipq60xx.mk
+++ b/target/linux/qualcommax/image/ipq60xx.mk
@@ -11,6 +11,19 @@ define Device/8devices_mango-dvk
 endef
 TARGET_DEVICES += 8devices_mango-dvk
 
+define Device/cambiumnetworks_xe3-4
+       $(call Device/FitImage)
+       $(call Device/UbiFit)
+       DEVICE_VENDOR := Cambium Networks
+       DEVICE_MODEL := XE3-4
+       BLOCKSIZE := 128k
+       PAGESIZE := 2048
+       DEVICE_DTS_CONFIG := config@cp01-c3-xv3-4
+       SOC := ipq6010
+       DEVICE_PACKAGES := ipq-wifi-cambiumnetworks_xe34 ath11k-firmware-qcn9074 kmod-ath11k-pci
+endef
+TARGET_DEVICES += cambiumnetworks_xe3-4
+
 define Device/netgear_wax214
        $(call Device/FitImage)
        $(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
@@ -14,6 +14,9 @@ ipq60xx_setup_interfaces()
 	8devices,mango-dvk)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
+	cambiumnetworks,xe3-4)
+		ucidef_set_interface_lan "lan1 lan2" "dhcp"
+		;;
 	netgear,wax214)
 		ucidef_set_interfaces_lan_wan "lan"
 		;;

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11-caldata
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11-caldata
@@ -12,11 +12,21 @@ case "$FIRMWARE" in
 	8devices,mango-dvk)
 		caldata_extract "0:ART" 0x1000 0x20000
 		;;
+	cambiumnetworks,xe3-4)
+		caldata_extract "0:ART" 0x1000 0x10000
+		;;
 	netgear,wax214)
 		caldata_extract "0:art" 0x1000 0x10000
 		;;
 	yuncore,fap650)
 		caldata_extract "0:art" 0x1000 0x20000
+		;;
+	esac
+	;;
+"ath11k/QCN9074/hw1.0/cal-pci-0000:01:00.0.bin")
+	case "$board" in
+	cambiumnetworks,xe3-4)
+		caldata_extract "0:ART" 0x26800 0x20000
 		;;
 	esac
 	;;

--- a/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
@@ -33,6 +33,10 @@ EOF
 
 platform_do_upgrade() {
 	case "$(board_name)" in
+	cambiumnetworks,xe3-4)
+		fw_setenv bootcount 0
+		nand_do_upgrade "$1"
+		;;
 	netgear,wax214)
 		nand_do_upgrade "$1"
 		;;


### PR DESCRIPTION
Cambium Networks XE3-4 is a tri-radio Wi-Fi 6/6E 4×4/2×2 AP.
```
Hardware:
    Model:    Cambium Networks XE3-4
    CPU:      IPQ6010/AP-CP01-C3, SoC Version: 1.0 @ 800 MHz
    Memory:   1 GiB
    Flash:    512 MiB Macronix MX30UF2G18AC + W25Q128FW
    Ethernet: 1x 1 GbE   (QCA8072)
              1x 2.5 GbE (QCA8081)
    Buttons:  1x Reset
    Serial:   TX, RX, GND
    Baudrate: 115200
    Radios:   Qualcomm Atheros IPQ6018 802.11ax - 2x2 - 2GHz
              Qualcomm Atheros IPQ6018 802.11ax - 2x2 - 5GHz
              Qualcomm Atheros QCN9074 802.11ax - 4x4 - 5GHz or 6GHz
              BLE 4.1
    Power:    32.0W 802.3bt5 PoE++
              25.5W 802.3at with USB, BT disabled
    Size:     215mm x 215mm
    Ports:    1x USB 2.0
    Antenna:  6 GHz: 6.29 dBi, Omni    30 dBm
              5 GHz: 6.12 dBi, Omni    31 dBm
              2.4 GHz: 4.85 dBi, Omni  29 dBm
    LEDs:     Multi-color status LEDs
    Mounting: Wall, ceiling or T-bar
```
**Installation: Serial connection**
```
1. Open the AP to get access to the board. Connect RX, TX and GND.
2. Power on the AP, and short the CS pin of the SPI flash with one of the APs GND pins.
3. Transfer the initramfs image with TFTP 
   (Default server IP is 192.168.0.120) 
   # tftpboot factory.ubi
5. Flash the rootfs partition 
   # flash rootfs
7. Reboot the AP 
   # reset
```

Signed-off-by: Kristian Skramstad <kristian+github@83.no>