### PR TITLE
openssl: update to 3.0.14

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.0.13
+PKG_VERSION:=3.0.14
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
@@ -24,7 +24,7 @@ PKG_SOURCE_URL:= \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/old/$(PKG_BASE)/
 
-PKG_HASH:=88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313
+PKG_HASH:=eeca035d4dd4e84fc25846d952da6297484afa0650a6f84c682e39df3a4123ca
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Major changes between OpenSSL 3.0.13 and OpenSSL 3.0.14 [04-Jun-2024]

* Fixed potential use after free after SSL_free_buffers() is called. [CVE-2024-4741]
* Fixed checking excessively long DSA keys or parameters may be very slow. [CVE-2024-4603]
* Fixed an issue where some non-default TLS server configurations can cause unbounded memory growth when processing TLSv1.3 sessions. An attacker may exploit certain server configurations to trigger unbounded memory growth that would lead to a Denial of Service.  [CVE-2024-2511]
* New atexit configuration switch, which controls whether the OPENSSL_cleanup is registered when libcrypto is unloaded. This can be used on platforms where using atexit() from shared libraries causes crashes on exit

Build system: x86/64
Build-tested: x86/64/AMD Cezanne

Maintainer: @cotequeiroz