### PR TITLE
generic: routerbootpart: fix compilation on 64-bit

### DIFF
--- a/target/linux/generic/files/drivers/mtd/parsers/routerbootpart.c
+++ b/target/linux/generic/files/drivers/mtd/parsers/routerbootpart.c
@@ -167,7 +167,7 @@ static void routerboot_find_dynparts(struct mtd_info *master)
 	while (offset < master->size) {
 		err = mtd_read(master, offset, sizeof(buf), &bytes_read, (u8 *)&buf);
 		if (err) {
-			pr_err("%s: mtd_read error while parsing (offset: 0x%X): %d\n",
+			pr_err("%s: mtd_read error while parsing (offset: 0x%zX): %d\n",
 			       master->name, offset, err);
 			continue;
 		}


### PR DESCRIPTION
Trying to compile routerbootpart parsers on 64-bit platforms will fail:
```
drivers/mtd/parsers/routerbootpart.c: In function 'routerboot_find_dynparts': ./include/linux/kern_levels.h:5:25: error: format '%X' expects argument of type 'unsigned int', but argument 3 has type 'size_t' {aka 'long unsigned int'} [-Werror=format=]
    5 | #define KERN_SOH        "\001"          /* ASCII Start Of Header */
      |                         ^~~~~~
./include/linux/printk.h:427:25: note: in definition of macro 'printk_index_wrap'
  427 |                 _p_func(_fmt, ##__VA_ARGS__);                           \
      |                         ^~~~
./include/linux/printk.h:498:9: note: in expansion of macro 'printk'
  498 |         printk(KERN_ERR pr_fmt(fmt), ##__VA_ARGS__)
      |         ^~~~~~
./include/linux/kern_levels.h:11:25: note: in expansion of macro 'KERN_SOH'
   11 | #define KERN_ERR        KERN_SOH "3"    /* error conditions */
      |                         ^~~~~~~~
./include/linux/printk.h:498:16: note: in expansion of macro 'KERN_ERR'
  498 |         printk(KERN_ERR pr_fmt(fmt), ##__VA_ARGS__)
      |                ^~~~~~~~
drivers/mtd/parsers/routerbootpart.c:170:25: note: in expansion of macro 'pr_err'
  170 |                         pr_err("%s: mtd_read error while parsing (offset: 0x%X): %d\n",

```
So, lets simply add the length modifier 'z' to fix compilation.

@f00b4r0 
