### PR TITLE
build: include tests/Makefile if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ else
   include tools/Makefile
   include toolchain/Makefile
 
+# Include the test suite Makefile if it exists
+-include tests/Makefile
+
 $(toolchain/stamp-compile): $(tools/stamp-compile) $(if $(CONFIG_BUILDBOT),toolchain_rebuild_check)
 $(target/stamp-compile): $(toolchain/stamp-compile) $(tools/stamp-compile) $(BUILD_DIR)/.prepared
 $(package/stamp-compile): $(target/stamp-compile) $(package/stamp-cleanup)


### PR DESCRIPTION
Testing OpenWrt is important, and there is a test suite in the making.
For maximum convenience and minimal CI over-usage, make it simple to run
tests locally. The main Makefile now attempts to include
`tests/Makefile` and silently fails if it doesn't.

While the test suite[1] is still young, it provides good examples of how
to test things around OpenWrt: starting with shell scripts using
`bats`[2], followed by QEMU tests, and finally real device tests using
LabGrid[3]. This could lead to the creation of the best OpenWrt version
yet.

Please consult the `openwrt-tests.git` README.md for details on the
setup. Once installed you may run commands like the following:

* make tests/shell  # run shell tests
* make tests/x86-64 # run  and test x86/64 in QEMU

[1]: http://github.com/aparcar/openwrt-tests/
[2]: https://bats-core.readthedocs.io/
[3]: https://labgrid.readthedocs.io/