### PR TITLE
ramips: mt76x8: sync Cudy TR1200 v1 naming

### DIFF
--- a/target/linux/ramips/dts/mt7628an_cudy_tr1200-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_tr1200-v1.dts
@@ -7,8 +7,8 @@
 #include <dt-bindings/leds/common.h>
 
 / {
-	compatible = "cudy,tr1200", "mediatek,mt7628an-soc";
-	model = "Cudy TR1200";
+	compatible = "cudy,tr1200-v1", "mediatek,mt7628an-soc";
+	model = "Cudy TR1200 v1";
 
 	aliases {
 		led-boot = &led_status;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -94,7 +94,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"4:lan" "6@eth0"
 		;;
-	cudy,tr1200)
+	cudy,tr1200-v1)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:wan" "6@eth0"
 		;;


### PR DESCRIPTION
Cudy assigns hardware versions to its devices on its website, and the Cudy TR1200 router is now Cudy TR1200 v1.
OpenWrt currently uses both variants, and this commit removes inconsistencies using only the new name.

