### PR TITLE
kernel: rtc: add RTC non volatile storage support

### DIFF
--- a/package/kernel/linux/modules/rtc.mk
+++ b/package/kernel/linux/modules/rtc.mk
@@ -116,6 +116,22 @@ endef
 $(eval $(call KernelPackage,rtc-mv))
 
 
+define KernelPackage/rtc-nvmem
+  SUBMENU:=$(RTC_MENU)
+  TITLE:=RTC non volatile storage support
+  DEFAULT:=m if ALL_KMODS && RTC_SUPPORT
+  KCONFIG:=CONFIG_RTC_NVMEM=y \
+	CONFIG_NVMEM_SYSFS=y
+endef
+
+define KernelPackage/rtc-nvmem/description
+ Say yes here to add support for the non volatile (often battery
+ backed) storage present on RTCs.
+endef
+
+$(eval $(call KernelPackage,rtc-nvmem))
+
+
 define KernelPackage/rtc-pcf8563
   SUBMENU:=$(RTC_MENU)
   TITLE:=Philips PCF8563/Epson RTC8564 RTC support


### PR DESCRIPTION
@linusw 

By enabling the kmod-rtc-nvmem you enable the RTC non volatile storage support including nvmem sysfs access.

This make it possible to store some (small) information in the (often battery backed) storage present on RTCs.

If someone has a better idea of integrating this kernel option instead of creating a (dummy) KernelPackage, please let me know.