### PR TITLE
mediatek: fix wps button for nokia ea0326gmp

### DIFF
--- a/package/boot/uboot-mediatek/patches/443-add-nokia_ea0326gmp.patch
+++ b/package/boot/uboot-mediatek/patches/443-add-nokia_ea0326gmp.patch
@@ -203,7 +203,7 @@
 +		button-wps {
 +			label = "wps";
 +			linux,code = <KEY_WPS_BUTTON>;
-+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
++			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
 +		};
 +	};
 +

--- a/target/linux/mediatek/dts/mt7981b-nokia-ea0326gmp.dts
+++ b/target/linux/mediatek/dts/mt7981b-nokia-ea0326gmp.dts
@@ -40,7 +40,7 @@
 		button-wps {
 			label = "wps";
 			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&pio 0 GPIO_ACTIVE_HIGH>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
 		};
 	};
 


### PR DESCRIPTION
The gpio is actually low active, fix it.

Fixes: 40e7fab9e4a2 ("mediatek: add Nokia EA0326GMP support")