### PR TITLE
base-files: Ignore exit code of uci.sh inclusion

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -533,4 +533,4 @@ cmdline_get_var() {
 	done
 }
 
-[ -z "$IPKG_INSTROOT" ] && [ -f /lib/config/uci.sh ] && . /lib/config/uci.sh
+[ -z "$IPKG_INSTROOT" ] && ( [ -f /lib/config/uci.sh ] && . /lib/config/uci.sh ) || true


### PR DESCRIPTION
When running unit tests this causes trouble since `/lib/config/uci.sh` isn't available in those cases. Instead exit with a clean status fo the unit test framework don't wrongly interpret things as an error.
