### PR TITLE
kexec-tools: fix multiple compile errors

### DIFF
--- a/package/boot/kexec-tools/Makefile
+++ b/package/boot/kexec-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kexec-tools
 PKG_VERSION:=2.0.28
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/kernel/kexec

--- a/package/boot/kexec-tools/patches/010-Fix-building-on-x86_64-with-binutils-2.41.patch
+++ b/package/boot/kexec-tools/patches/010-Fix-building-on-x86_64-with-binutils-2.41.patch
@@ -1,0 +1,81 @@
+From 328de8e00e298f00d7ba6b25dc3950147e9642e6 Mon Sep 17 00:00:00 2001
+From: Michel Lind <salimma@fedoraproject.org>
+Date: Tue, 30 Jan 2024 04:14:31 -0600
+Subject: [PATCH] Fix building on x86_64 with binutils 2.41
+
+Newer versions of the GNU assembler (observed with binutils 2.41) will
+complain about the ".arch i386" in files assembled with "as --64",
+with the message "Error: 64bit mode not supported on 'i386'".
+
+Fix by moving ".arch i386" below the relevant ".code32" directive, so
+that the assembler is no longer expecting 64-bit instructions to be used
+by the time that the ".arch i386" directive is encountered.
+
+Based on similar iPXE fix:
+https://github.com/ipxe/ipxe/commit/6ca597eee
+
+Signed-off-by: Michel Lind <michel@michel-slm.name>
+Signed-off-by: Simon Horman <horms@kernel.org>
+---
+ purgatory/arch/i386/entry32-16-debug.S | 2 +-
+ purgatory/arch/i386/entry32-16.S       | 2 +-
+ purgatory/arch/i386/entry32.S          | 2 +-
+ purgatory/arch/i386/setup-x86.S        | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+--- a/purgatory/arch/i386/entry32-16-debug.S
++++ b/purgatory/arch/i386/entry32-16-debug.S
+@@ -25,10 +25,10 @@
+ 	.globl entry16_debug_pre32
+ 	.globl entry16_debug_first32
+ 	.globl entry16_debug_old_first32
+-	.arch i386
+ 	.balign 16
+ entry16_debug:
+ 	.code32
++	.arch i386
+ 	/* Compute where I am running at (assumes esp valid) */
+ 	call	1f
+ 1:	popl	%ebx
+--- a/purgatory/arch/i386/entry32-16.S
++++ b/purgatory/arch/i386/entry32-16.S
+@@ -20,10 +20,10 @@
+ #undef i386	
+ 	.text
+ 	.globl entry16, entry16_regs
+-	.arch i386
+ 	.balign 16
+ entry16:
+ 	.code32
++	.arch i386
+ 	/* Compute where I am running at (assumes esp valid) */
+ 	call	1f
+ 1:	popl	%ebx
+--- a/purgatory/arch/i386/entry32.S
++++ b/purgatory/arch/i386/entry32.S
+@@ -20,10 +20,10 @@
+ #undef i386
+ 
+ 	.text
+-	.arch	i386
+ 	.globl entry32, entry32_regs
+ entry32:
+ 	.code32
++	.arch	i386
+ 
+ 	/* Setup a gdt that should that is generally usefully */
+ 	lgdt	%cs:gdt
+--- a/purgatory/arch/i386/setup-x86.S
++++ b/purgatory/arch/i386/setup-x86.S
+@@ -21,10 +21,10 @@
+ #undef i386
+ 
+ 	.text
+-	.arch	i386
+ 	.globl purgatory_start
+ purgatory_start:
+ 	.code32
++	.arch	i386
+ 
+ 	/* Load a gdt so I know what the segment registers are */
+ 	lgdt	%cs:gdt

--- a/package/boot/kexec-tools/patches/020-i386-improve-basename-compatibility.patch
+++ b/package/boot/kexec-tools/patches/020-i386-improve-basename-compatibility.patch
@@ -1,0 +1,37 @@
+From 99f62f58fac57214ecc3c9aabf6bf61ac1e1201d Mon Sep 17 00:00:00 2001
+From: Tony Ambardar <itugrok@yahoo.com>
+Date: Fri, 7 Jun 2024 21:54:56 -0700
+Subject: [PATCH] i386: improve basename() compatibility
+
+Drop usage of glibc basename() in favour of a simpler implementation that
+works across GNU and musl libc, and is similar to existing code in fs2dt.c.
+
+This fixes compile errors seen building against musl.
+
+Signed-off-by: Tony Ambardar <itugrok@yahoo.com>
+---
+ kexec/arch/i386/x86-linux-setup.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+--- a/kexec/arch/i386/x86-linux-setup.c
++++ b/kexec/arch/i386/x86-linux-setup.c
+@@ -318,6 +318,7 @@ static int add_edd_entry(struct x86_linu
+ 	uint8_t devnum, version;
+ 	uint32_t mbr_sig;
+ 	struct edd_info *edd_info;
++	char *basename = strrchr(sysfs_name,'/') + 1;
+ 
+ 	if (!current_mbr || !current_edd) {
+ 		fprintf(stderr, "%s: current_edd and current_edd "
+@@ -329,9 +330,9 @@ static int add_edd_entry(struct x86_linu
+ 	memset(edd_info, 0, sizeof(struct edd_info));
+ 
+ 	/* extract the device number */
+-	if (sscanf(basename(sysfs_name), "int13_dev%hhx", &devnum) != 1) {
++	if (sscanf(basename, "int13_dev%hhx", &devnum) != 1) {
+ 		fprintf(stderr, "Invalid format of int13_dev dir "
+-				"entry: %s\n", basename(sysfs_name));
++				"entry: %s\n", basename);
+ 		return -1;
+ 	}
+ 


### PR DESCRIPTION
Add two patches to fix compile errors being repeatedly seen on OpenWrt CI.

The first is an upstream backport to fix this i386-related error:
```
  x86_64-openwrt-linux-musl-gcc  -mcmodel=large -I./purgatory/include
  -I./purgatory/arch/x86_64/include -I./util_lib/include -I./include -Iinclude
  -I/builder/shared-workdir/build/sdk/staging_dir/toolchain-x86_64_gcc-13.3.0_musl/lib/gcc/x86_64-openwrt-linux-musl/13.3.0/include
  -c -MD -o purgatory/arch/i386/entry32-16.o purgatory/arch/i386/entry32-16.S
  purgatory/arch/i386/entry32-16.S: Assembler messages:
  purgatory/arch/i386/entry32-16.S:23: Error: 64bit mode not supported on `i386'.
```
The second addresses an error using basename() on musl libc:
```
  kexec/arch/i386/x86-linux-setup.c: In function 'add_edd_entry':
  kexec/arch/i386/x86-linux-setup.c:332:20: warning: implicit declaration of function 'basename' [-Wimplicit-function-declaration]
    332 |         if (sscanf(basename(sysfs_name), "int13_dev%hhx", &devnum) != 1) {
        |                    ^~~~~~~~
  kexec/arch/i386/x86-linux-setup.c:332:20: warning: passing argument 1 of 'sscanf' makes pointer from integer without a cast [-Wint-conversion]
    332 |         if (sscanf(basename(sysfs_name), "int13_dev%hhx", &devnum) != 1) {
        |                    ^~~~~~~~~~~~~~~~~~~~
        |                    |
        |                    int
  ...
```

Fixes: #14621