### PR TITLE
mediatek: convert eeprom/macaddr to nvmem format for jdcloud re-cp-03

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-jdcloud-re-cp-03.dts
+++ b/target/linux/mediatek/dts/mt7986a-jdcloud-re-cp-03.dts
@@ -101,6 +101,9 @@
 		reg = <0>;
 		phy-mode = "2500base-x";
 
+		nvmem-cells = <&macaddr_factory_2a 0>;
+		nvmem-cell-names = "mac-address";
+
 		fixed-link {
 			speed = <2500>;
 			full-duplex;
@@ -113,6 +116,9 @@
 		reg = <1>;
 		phy-mode = "2500base-x";
 		phy-handle = <&phy6>;
+
+		nvmem-cells = <&macaddr_factory_24 0>;
+		nvmem-cell-names = "mac-address";
 	};
 
 	mdio: mdio-bus {
@@ -166,7 +172,34 @@
 
 		block {
 			compatible = "block-device";
+
 			partitions {
+				block-partition-factory {
+					partname = "factory";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						eeprom_factory_0: eeprom@0 {
+							reg = <0x0 0x1000>;
+						};
+
+						macaddr_factory_24: macaddr@24 {
+							compatible = "mac-base";
+							reg = <0x24 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+
+						macaddr_factory_2a: macaddr@2a {
+							compatible = "mac-base";
+							reg = <0x2a 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+					};
+				};
+
 				emmc_rootdisk: block-partition-production {
 					partname = "production";
 				};
@@ -304,6 +337,8 @@
 };
 
 &wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 	pinctrl-names = "default";
 	pinctrl-0 = <&wf_2g_5g_pins>;
 	status = "okay";

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -145,11 +145,6 @@ mediatek_setup_macs()
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		label_mac=$wan_mac
 		;;
-	jdcloud,re-cp-03)
-		wan_mac=$(mmc_get_mac_binary factory 0x2a)
-		lan_mac=$(mmc_get_mac_binary factory 0x24)
-		label_mac=$lan_mac
-		;;
 	mercusys,mr90x-v1)
 		label_mac=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		lan_mac=$label_mac

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -60,13 +60,6 @@ case "$FIRMWARE" in
 		;;
 	esac
 	;;
-"mediatek/mt7986_eeprom_mt7976_dual.bin")
-	case "$board" in
-	jdcloud,re-cp-03)
-		caldata_extract_mmc "factory" 0x0 0x1000
-		;;
-	esac
-	;;
 *)
 	exit 1
 	;;


### PR DESCRIPTION
Switch to new nvmem binding.

Also fixes a issue that the MAC address assigned to lan/wan was reversed.