### PR TITLE
mediatek: Ruijie RG-X60 Pro: Add kmod-mt7915e

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1080,7 +1080,7 @@ define Device/ruijie_rg-x60-pro
   DEVICE_MODEL := RG-X60 Pro
   DEVICE_DTS := mt7986a-ruijie-rg-x60-pro
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7986-firmware mt7986-wo-firmware
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += ruijie_rg-x60-pro


### PR DESCRIPTION
Add the kmod-mt7915e wifi driver to the default packages for the Ruijie RG-X60 Pro. kmod-mt7915e has to be added recently and was not done before merging the support for Ruijie RG-X60 Pro.

Fixes: 3de3c2bdfa6b ("mediatek: add support for Ruijie RG-X60 Pro")