### PR TITLE
[RFC]hardening.mk: expand PKG_CHECK_FORMAT_SECURITY

### DIFF
--- a/include/hardening.mk
+++ b/include/hardening.mk
@@ -11,7 +11,7 @@ PKG_RELRO ?= 1
 
 ifdef CONFIG_PKG_CHECK_FORMAT_SECURITY
   ifeq ($(strip $(PKG_CHECK_FORMAT_SECURITY)),1)
-    TARGET_CFLAGS += -Wformat -Werror=format-security
+    TARGET_CFLAGS += -Werror=format=2 -Wno-error=format-nonliteral -Wno-error=format-truncation -Wno-error=format-overflow
   endif
 endif
 ifdef CONFIG_PKG_ASLR_PIE_ALL


### PR DESCRIPTION
Since the update to musl 1.2.0, time_t is 64-bit everywhere. Not only that, format errors seem to be fatal on big endian platforms at runtime.

Error at compile time to prevent this.

Setting as draft for comments.