### PR TITLE
base-files: Reapply fixed "Ignore exit code of uci.sh inclusion"

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -533,4 +533,4 @@ cmdline_get_var() {
 	done
 }
 
-[ -z "$IPKG_INSTROOT" ] && [ -f /lib/config/uci.sh ] && . /lib/config/uci.sh
+[ -z "$IPKG_INSTROOT" ] && [ -f /lib/config/uci.sh ] && . /lib/config/uci.sh || true


### PR DESCRIPTION
This reverts commit 80d1c353b79e6c216dcb2534420470e3e6ed5d60 with the fix which won't break running systems. A logic error on how shell handles && and || more the init process.
