### PR TITLE
rockchip: Add cache information to the SoC dtsi for RK356x

### DIFF
--- a/target/linux/rockchip/patches-5.15/010-v6.10-arm64-dts-rockchip-Add-cache-information-to-the-SoC-dtsi-.patch
+++ b/target/linux/rockchip/patches-5.15/010-v6.10-arm64-dts-rockchip-Add-cache-information-to-the-SoC-dtsi-.patch
@@ -1,0 +1,127 @@
+From 8612169a05c5e979af033868b7a9b177e0f9fcdf Mon Sep 17 00:00:00 2001
+From: Dragan Simic <dsimic@manjaro.org>
+Date: Sat, 9 Mar 2024 05:25:06 +0100
+Subject: [PATCH] arm64: dts: rockchip: Add cache information to the SoC dtsi
+ for RK356x
+
+Add missing cache information to the Rockchip RK356x SoC dtsi, to allow
+the userspace, which includes lscpu(1) that uses the virtual files provided
+by the kernel under the /sys/devices/system/cpu directory, to display the
+proper RK3566 and RK3568 cache information.
+
+Adding the cache information to the RK356x SoC dtsi also makes the following
+warning message in the kernel log go away:
+
+  cacheinfo: Unable to detect cache hierarchy for CPU 0
+
+The cache parameters for the RK356x dtsi were obtained and partially derived
+by hand from the cache size and layout specifications found in the following
+datasheets and technical reference manuals:
+
+  - Rockchip RK3566 datasheet, version 1.1
+  - Rockchip RK3568 datasheet, version 1.3
+  - ARM Cortex-A55 revision r1p0 TRM, version 0100-00
+  - ARM DynamIQ Shared Unit revision r4p0 TRM, version 0400-02
+
+For future reference, here's a rather detailed summary of the documentation,
+which applies to both Rockchip RK3566 and RK3568 SoCs:
+
+  - All caches employ the 64-byte cache line length
+  - Each Cortex-A55 core has 32 KB of L1 4-way, set-associative instruction
+    cache and 32 KB of L1 4-way, set-associative data cache
+  - There are no L2 caches, which are per-core and private in Cortex-A55,
+    because it belongs to the ARM DynamIQ IP core lineup
+  - The entire SoC has 512 KB of unified L3 16-way, set-associative cache,
+    which is shared among all four Cortex-A55 CPU cores
+  - Cortex-A55 cores can be configured without private per-core L2 caches,
+    in which case the shared L3 cache appears to them as an L2 cache;  this
+    is the case for the RK356x SoCs, so let's use "cache-level = <2>" to
+    prevent the "huh, no L2 caches, but an L3 cache?" confusion among the
+    users viewing the data presented to the userspace;  another option could
+    be to have additional 0 KB L2 caches defined, which may be technically
+    correct, but would probably be even more confusing
+
+Helped-by: Anand Moon <linux.amoon@gmail.com>
+Tested-By: Diederik de Haas <didi.debian@cknow.org>
+Reviewed-by: Anand Moon <linux.amoon@gmail.com>
+Signed-off-by: Dragan Simic <dsimic@manjaro.org>
+Link: https://lore.kernel.org/r/2dee6dad8460b0c5f3b5da53cf55f735840efef1.1709957777.git.dsimic@manjaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk356x.dtsi | 41 ++++++++++++++++++++++++
+ 1 file changed, 41 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
+@@ -57,6 +57,13 @@
+ 			#cooling-cells = <2>;
+ 			enable-method = "psci";
+ 			operating-points-v2 = <&cpu0_opp_table>;
++			i-cache-size = <0x8000>;
++			i-cache-line-size = <64>;
++			i-cache-sets = <128>;
++			d-cache-size = <0x8000>;
++			d-cache-line-size = <64>;
++			d-cache-sets = <128>;
++			next-level-cache = <&l3_cache>;
+ 		};
+ 
+ 		cpu1: cpu@100 {
+@@ -66,6 +73,13 @@
+ 			#cooling-cells = <2>;
+ 			enable-method = "psci";
+ 			operating-points-v2 = <&cpu0_opp_table>;
++			i-cache-size = <0x8000>;
++			i-cache-line-size = <64>;
++			i-cache-sets = <128>;
++			d-cache-size = <0x8000>;
++			d-cache-line-size = <64>;
++			d-cache-sets = <128>;
++			next-level-cache = <&l3_cache>;
+ 		};
+ 
+ 		cpu2: cpu@200 {
+@@ -75,6 +89,13 @@
+ 			#cooling-cells = <2>;
+ 			enable-method = "psci";
+ 			operating-points-v2 = <&cpu0_opp_table>;
++			i-cache-size = <0x8000>;
++			i-cache-line-size = <64>;
++			i-cache-sets = <128>;
++			d-cache-size = <0x8000>;
++			d-cache-line-size = <64>;
++			d-cache-sets = <128>;
++			next-level-cache = <&l3_cache>;
+ 		};
+ 
+ 		cpu3: cpu@300 {
+@@ -84,9 +105,29 @@
+ 			#cooling-cells = <2>;
+ 			enable-method = "psci";
+ 			operating-points-v2 = <&cpu0_opp_table>;
++			i-cache-size = <0x8000>;
++			i-cache-line-size = <64>;
++			i-cache-sets = <128>;
++			d-cache-size = <0x8000>;
++			d-cache-line-size = <64>;
++			d-cache-sets = <128>;
++			next-level-cache = <&l3_cache>;
+ 		};
+ 	};
+ 
++	/*
++	 * There are no private per-core L2 caches, but only the
++	 * L3 cache that appears to the CPU cores as L2 caches
++	 */
++	l3_cache: l3-cache {
++		compatible = "cache";
++		cache-level = <2>;
++		cache-unified;
++		cache-size = <0x80000>;
++		cache-line-size = <64>;
++		cache-sets = <512>;
++	};
++
+ 	cpu0_opp_table: opp-table-0 {
+ 		compatible = "operating-points-v2";
+ 		opp-shared;


### PR DESCRIPTION
Add missing cache information to the Rockchip RK356x SoC dtsi, to allow
the userspace, which includes lscpu(1) that uses the virtual files provided
by the kernel under the /sys/devices/system/cpu directory, to display the
proper RK3566 and RK3568 cache information.

Adding the cache information to the RK356x SoC dtsi also makes the following
warning message in the kernel log go away:

cacheinfo: Unable to detect cache hierarchy for CPU 0

The cache parameters for the RK356x dtsi were obtained and partially derived
by hand from the cache size and layout specifications found in the following
datasheets and technical reference manuals:

Rockchip RK3566 datasheet, version 1.1
Rockchip RK3568 datasheet, version 1.3
ARM Cortex-A55 revision r1p0 TRM, version 0100-00
ARM DynamIQ Shared Unit revision r4p0 TRM, version 0400-02
For future reference, here's a rather detailed summary of the documentation,
which applies to both Rockchip RK3566 and RK3568 SoCs:

All caches employ the 64-byte cache line length
Each Cortex-A55 core has 32 KB of L1 4-way, set-associative instruction
cache and 32 KB of L1 4-way, set-associative data cache
There are no L2 caches, which are per-core and private in Cortex-A55,
because it belongs to the ARM DynamIQ IP core lineup
The entire SoC has 512 KB of unified L3 16-way, set-associative cache,
which is shared among all four Cortex-A55 CPU cores
Cortex-A55 cores can be configured without private per-core L2 caches,
in which case the shared L3 cache appears to them as an L2 cache; this
is the case for the RK356x SoCs, so let's use "cache-level = <2>" to
prevent the "huh, no L2 caches, but an L3 cache?" confusion among the
users viewing the data presented to the userspace; another option could
be to have additional 0 KB L2 caches defined, which may be technically
correct, but would probably be even more confusing.


For more information, visit https://lore.kernel.org/all/2dee6dad8460b0c5f3b5da53cf55f735840efef1.1709957777.git.dsimic@manjaro.org/