### PR TITLE
treewide: gpio to gpios

### DIFF
--- a/target/linux/ath79/dts/qca955x_elecom_wab.dtsi
+++ b/target/linux/ath79/dts/qca955x_elecom_wab.dtsi
@@ -74,7 +74,7 @@
 		regulator-name = "usb-vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-always-on;
 	};

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-mf287pro.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-mf287pro.dts
@@ -16,7 +16,7 @@
 		regulator-max-microvolt = <5000000>;
 		regulator-always-on;
 		regulator-boot-on;
-		gpio = <&tlmm 25 GPIO_ACTIVE_LOW>;
+		gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
@@ -59,7 +59,7 @@
 		regulator-max-microvolt = <5000000>;
 		regulator-always-on;
 		regulator-boot-on;
-		gpio = <&tlmm 68 GPIO_ACTIVE_LOW>;
+		gpios = <&tlmm 68 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/kirkwood/files-6.1/arch/arm/boot/dts/kirkwood-dns320l.dts
+++ b/target/linux/kirkwood/files-6.1/arch/arm/boot/dts/kirkwood-dns320l.dts
@@ -117,7 +117,7 @@
 			enable-active-high;
 			regulator-always-on;
 			regulator-boot-on;
-			gpio = <&gpio0 24 0>;
+			gpios = <&gpio0 24 0>;
 		};
 	};
 };

--- a/target/linux/kirkwood/files-6.1/arch/arm/boot/dts/kirkwood-goflexhome.dts
+++ b/target/linux/kirkwood/files-6.1/arch/arm/boot/dts/kirkwood-goflexhome.dts
@@ -96,7 +96,7 @@
 			enable-active-high;
 			regulator-always-on;
 			regulator-boot-on;
-			gpio = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/kirkwood/files-6.1/arch/arm/boot/dts/kirkwood-nas1.dts
+++ b/target/linux/kirkwood/files-6.1/arch/arm/boot/dts/kirkwood-nas1.dts
@@ -110,7 +110,7 @@
 			regulator-max-microvolt = <5000000>;
 			enable-active-high;
 			regulator-always-on;
-			gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/kirkwood/files-6.6/arch/arm/boot/dts/marvell/kirkwood-dns320l.dts
+++ b/target/linux/kirkwood/files-6.6/arch/arm/boot/dts/marvell/kirkwood-dns320l.dts
@@ -117,7 +117,7 @@
 			enable-active-high;
 			regulator-always-on;
 			regulator-boot-on;
-			gpio = <&gpio0 24 0>;
+			gpios = <&gpio0 24 0>;
 		};
 	};
 };

--- a/target/linux/kirkwood/files-6.6/arch/arm/boot/dts/marvell/kirkwood-goflexhome.dts
+++ b/target/linux/kirkwood/files-6.6/arch/arm/boot/dts/marvell/kirkwood-goflexhome.dts
@@ -96,7 +96,7 @@
 			enable-active-high;
 			regulator-always-on;
 			regulator-boot-on;
-			gpio = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/kirkwood/files-6.6/arch/arm/boot/dts/marvell/kirkwood-nas1.dts
+++ b/target/linux/kirkwood/files-6.6/arch/arm/boot/dts/marvell/kirkwood-nas1.dts
@@ -110,7 +110,7 @@
 			regulator-max-microvolt = <5000000>;
 			enable-active-high;
 			regulator-always-on;
-			gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/kirkwood/patches-6.1/002-6.2-ARM-dts-kirkwood-Add-Zyxel-NSA310S-board.patch
+++ b/target/linux/kirkwood/patches-6.1/002-6.2-ARM-dts-kirkwood-Add-Zyxel-NSA310S-board.patch
@@ -160,7 +160,7 @@ Signed-off-by: Gregory CLEMENT <gregory.clement@bootlin.com>
 +		regulator-max-microvolt = <5000000>;
 +		regulator-always-on;
 +		regulator-boot-on;
-+		gpio = <&gpio0 21 GPIO_ACTIVE_HIGH>;
++		gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
 +	};
 +
 +	sata1_power: regulator@2 {
@@ -171,7 +171,7 @@ Signed-off-by: Gregory CLEMENT <gregory.clement@bootlin.com>
 +		regulator-max-microvolt = <5000000>;
 +		regulator-always-on;
 +		regulator-boot-on;
-+		gpio = <&gpio1 1 GPIO_ACTIVE_HIGH>;
++		gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
 +	};
 +
 +	thermal-zones {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7320.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7320.dts
@@ -82,7 +82,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 50 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 50 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 
@@ -94,7 +94,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 51 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 51 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_bt_homehub-v3a.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_bt_homehub-v3a.dts
@@ -101,7 +101,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 33 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 33 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_buffalo_wbmr-hp-g300h.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_buffalo_wbmr-hp-g300h.dts
@@ -108,7 +108,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 36 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 36 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_zte_h201l.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_zte_h201l.dts
@@ -116,7 +116,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 36 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 36 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_zyxel_p-2601hn.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_zyxel_p-2601hn.dts
@@ -106,7 +106,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4518pwr01.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4518pwr01.dtsi
@@ -105,7 +105,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4519pw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4519pw.dts
@@ -121,7 +121,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4520pw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4520pw.dts
@@ -125,7 +125,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 28 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 28 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv452cqw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv452cqw.dts
@@ -139,7 +139,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 28 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 28 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7510pw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7510pw22.dts
@@ -80,7 +80,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7518pw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7518pw.dts
@@ -120,7 +120,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw.dts
@@ -118,7 +118,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpiomm 0 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpiomm 0 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw22.dts
@@ -134,7 +134,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpiomm 0 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpiomm 0 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv8539pw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv8539pw22.dts
@@ -87,7 +87,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_audiocodes_mp-252.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_audiocodes_mp-252.dts
@@ -21,7 +21,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_siemens_gigaset-sx76x.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_siemens_gigaset-sx76x.dts
@@ -45,7 +45,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 29 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_arv7519rw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_arv7519rw22.dts
@@ -92,7 +92,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 32 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 32 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
@@ -106,7 +106,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 47 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 47 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519.dtsi
@@ -126,7 +126,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 32 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 32 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vrv9510kwac23.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vrv9510kwac23.dts
@@ -159,7 +159,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 32 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 32 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2.dtsi
@@ -102,7 +102,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 
@@ -114,7 +114,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
@@ -93,7 +93,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 
@@ -105,7 +105,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7430.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7430.dts
@@ -90,7 +90,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_bt_homehub-v5a.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_bt_homehub-v5a.dts
@@ -113,7 +113,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 33 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 33 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_buffalo_wbmr-300hpd.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_buffalo_wbmr-300hpd.dts
@@ -150,7 +150,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 33 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 33 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920.dtsi
@@ -96,7 +96,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 33 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 33 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_tdw89x0.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_tdw89x0.dtsi
@@ -107,7 +107,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 33 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 33 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_vr200.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_vr200.dtsi
@@ -99,7 +99,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 33 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 33 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-fx.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-fx.dtsi
@@ -110,7 +110,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&gpio 33 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 33 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/mediatek/dts/mt7622-elecom-wrc-2533gent.dts
+++ b/target/linux/mediatek/dts/mt7622-elecom-wrc-2533gent.dts
@@ -130,7 +130,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&pio 22 GPIO_ACTIVE_LOW>;
+		gpios = <&pio 22 GPIO_ACTIVE_LOW>;
 		enable-active-high;
 	};
 

--- a/target/linux/mediatek/dts/mt7981a-glinet-gl-x3000-xe3000-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981a-glinet-gl-x3000-xe3000-common.dtsi
@@ -31,7 +31,7 @@
 		regulator-name = "fan";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&pio 28 GPIO_ACTIVE_HIGH>;
+		gpios = <&pio 28 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 

--- a/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dts
@@ -65,7 +65,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&pio 9 GPIO_ACTIVE_LOW>;
+		gpios = <&pio 9 GPIO_ACTIVE_LOW>;
 		regulator-boot-on;
 	};
 };

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500.dts
@@ -57,7 +57,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 
-		gpio = <&pio 12 GPIO_ACTIVE_HIGH>;
+		gpios = <&pio 12 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 	};

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt3000.dts
@@ -56,7 +56,7 @@
 		regulator-name = "fan";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&pio 28 GPIO_ACTIVE_HIGH>;
+		gpios = <&pio 28 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 	};
@@ -66,7 +66,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&pio 12 GPIO_ACTIVE_HIGH>;
+		gpios = <&pio 12 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 	};

--- a/target/linux/mediatek/dts/mt7981b-yuncore-ax835.dts
+++ b/target/linux/mediatek/dts/mt7981b-yuncore-ax835.dts
@@ -36,7 +36,7 @@
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
 		regulator-always-on;
-		gpio = <&pio 5 GPIO_ACTIVE_HIGH>;
+		gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
 	};
 
 	leds {

--- a/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-wifi-mt7996a.dtso
+++ b/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-wifi-mt7996a.dtso
@@ -15,7 +15,7 @@
 				regulator-name = "wifi";
 				regulator-min-microvolt = <12000000>;
 				regulator-max-microvolt = <12000000>;
-				gpio = <&pio 4 GPIO_ACTIVE_HIGH>;
+				gpios = <&pio 4 GPIO_ACTIVE_HIGH>;
 				enable-active-high;
 				regulator-always-on;
 			};

--- a/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-370-buffalo-ls220de.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-370-buffalo-ls220de.dts
@@ -192,7 +192,7 @@
 			enable-active-high;
 			regulator-always-on;
 			regulator-boot-on;
-			gpio = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
 		};
 
 		sata2_power: regulator@2 {
@@ -205,7 +205,7 @@
 			enable-active-high;
 			regulator-always-on;
 			regulator-boot-on;
-			gpio = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-370-buffalo-ls421de.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-370-buffalo-ls421de.dts
@@ -204,7 +204,7 @@
 			enable-active-high;
 			regulator-always-on;
 			regulator-boot-on;
-			gpio = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
 		};
 
 		sata1_power: regulator@1 {
@@ -217,7 +217,7 @@
 			enable-active-high;
 			regulator-always-on;
 			regulator-boot-on;
-			gpio = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
 		};
 
 		sata2_power: regulator@2 {
@@ -230,7 +230,7 @@
 			enable-active-high;
 			regulator-always-on;
 			regulator-boot-on;
-			gpio = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-380-iij-sa-w2.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-380-iij-sa-w2.dts
@@ -151,7 +151,7 @@
 		regulator-name = "vbus-usb0";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio1 20 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio1 20 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-always-on;
 	};
@@ -161,7 +161,7 @@
 		regulator-name = "vbus-usb1";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio1 21 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-always-on;
 	};

--- a/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-fortinet-fg-xxe.dtsi
+++ b/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-fortinet-fg-xxe.dtsi
@@ -151,7 +151,7 @@
 		regulator-name = "usb-vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio1 21 GPIO_ACTIVE_LOW>;
+		gpios = <&gpio1 21 GPIO_ACTIVE_LOW>;
 		regulator-always-on;
 	};
 };

--- a/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-linksys-venom.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-linksys-venom.dts
@@ -205,7 +205,7 @@
 };
 
 &usb3_1_vbus {
-	gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+	gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
 };
 
 &usb3_1_vbus_pins {

--- a/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-nas1dual.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-nas1dual.dts
@@ -124,7 +124,7 @@
 			regulator-name = "sata-power";
 			regulator-min-microvolt = <12000000>;
 			regulator-max-microvolt = <12000000>;
-			gpio = <&gpio1 20 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 20 GPIO_ACTIVE_LOW>;
 			regulator-always-on;
 		};
 	};

--- a/target/linux/mvebu/files-6.6/arch/arm64/boot/dts/marvell/armada-3720-espressobin-ultra.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm64/boot/dts/marvell/armada-3720-espressobin-ultra.dts
@@ -40,7 +40,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 		enable-active-high;
-		gpio = <&gpionb 19 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpionb 19 GPIO_ACTIVE_HIGH>;
 	};
 
 	usb3_phy: usb3-phy {

--- a/target/linux/mvebu/files-6.6/arch/arm64/boot/dts/marvell/cn9130-clearfog-pro.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm64/boot/dts/marvell/cn9130-clearfog-pro.dts
@@ -78,7 +78,7 @@
 		regulator-name = "v_5v0_usb3_hst_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&expander0 6 GPIO_ACTIVE_LOW>;
+		gpios = <&expander0 6 GPIO_ACTIVE_LOW>;
 		vin-supply = <&v_5v0>;
 	};
 

--- a/target/linux/mvebu/files-6.6/arch/arm64/boot/dts/marvell/cn9132-puzzle-m902.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm64/boot/dts/marvell/cn9132-puzzle-m902.dts
@@ -68,7 +68,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 		enable-active-high;
-		gpio = <&cp2_gpio1 2 GPIO_ACTIVE_HIGH>;
+		gpios = <&cp2_gpio1 2 GPIO_ACTIVE_HIGH>;
 	};
 
 	cp2_usb3_0_phy0: cp2_usb3_phy0 {
@@ -82,7 +82,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 		enable-active-high;
-		gpio = <&cp2_gpio1 3 GPIO_ACTIVE_HIGH>;
+		gpios = <&cp2_gpio1 3 GPIO_ACTIVE_HIGH>;
 	};
 
 	cp2_usb3_0_phy1: cp2_usb3_phy1 {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8070-rm2-6.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8070-rm2-6.dts
@@ -57,26 +57,26 @@
 		led_status_amber: status-amber {
 			color = <LED_COLOR_ID_AMBER>;
 			function = LED_FUNCTION_STATUS;
-			gpio = <&tlmm 25 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_status_blue: status-blue {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_STATUS;
-			gpio = <&tlmm 26 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 26 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_status_red: status-red {
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_STATUS;
-			gpio = <&tlmm 31 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 31 GPIO_ACTIVE_HIGH>;
 		};
 	};
 
 	fan: gpio-fan {
 		#cooling-cells = <2>;
 		compatible = "gpio-fan";
-		gpio = <&tlmm 29 GPIO_ACTIVE_HIGH>;
+		gpios = <&tlmm 29 GPIO_ACTIVE_HIGH>;
 		gpio-fan,speed-map = <0 0>, <1 1>;
 	};
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
@@ -54,13 +54,13 @@
 
 		led_wlan2g {
 			label = "green:wlan2g";
-			gpio = <&tlmm 47 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 47 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "phy1radio";
 		};
 
 		led_wlan5g {
 			label = "green:wlan5g";
-			gpio = <&tlmm 48 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 48 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "phy0radio";
 		};
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-mf269.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-mf269.dts
@@ -51,7 +51,7 @@
 		led_power: power {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_WHITE>;
-			gpio = <&tlmm 56 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 56 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
@@ -131,7 +131,7 @@
 		regulator-name = "vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&tlmm 64 GPIO_ACTIVE_HIGH>;
+		gpios = <&tlmm 64 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-always-on;
 	};

--- a/target/linux/ramips/dts/mt7621_asus_rt-ac57u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ac57u-v1.dts
@@ -56,7 +56,7 @@
 	led-regulator {
 		compatible = "regulator-fixed";
 		regulator-name = "LED-Power";
-		gpio = <&gpio 46 GPIO_ACTIVE_LOW>;
+		gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
 		regulator-always-on;

--- a/target/linux/ramips/dts/mt7621_meig_slt866.dts
+++ b/target/linux/ramips/dts/mt7621_meig_slt866.dts
@@ -75,7 +75,7 @@
 		regulator-name = "pa-5g";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 		regulator-always-on;

--- a/target/linux/ramips/dts/mt7621_mikrotik_ltap-2hnd.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_ltap-2hnd.dts
@@ -101,7 +101,7 @@
 
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
-		gpio = <&gpio 10 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 	};
@@ -112,7 +112,7 @@
 
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
-		gpio = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 	};

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m11g.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m11g.dts
@@ -51,7 +51,7 @@
 
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
-		gpio = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 		regulator-always-on;

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m33g.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m33g.dts
@@ -26,7 +26,7 @@
 
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
-		gpio = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 		regulator-always-on;
@@ -38,7 +38,7 @@
 
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
-		gpio = <&gpio 10 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 		regulator-always-on;
@@ -50,7 +50,7 @@
 
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
-		gpio = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 		regulator-always-on;
@@ -62,7 +62,7 @@
 
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-always-on;
 	};

--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_ayx.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_ayx.dtsi
@@ -79,7 +79,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 10 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_chj.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_chj.dtsi
@@ -68,7 +68,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 10 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me1.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me1.dts
@@ -62,7 +62,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-sfp.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-sfp.dts
@@ -64,7 +64,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 

--- a/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
@@ -91,7 +91,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
@@ -64,7 +64,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 10 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3-pro.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3-pro.dts
@@ -90,7 +90,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3g.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3g.dts
@@ -63,7 +63,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_netgear_r6120.dts
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6120.dts
@@ -12,7 +12,7 @@
 		compatible = "regulator-fixed";
 
 		regulator-name = "USB-power";
-		gpio = <&gpio 45 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 45 GPIO_ACTIVE_HIGH>;
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 		enable-active-high;

--- a/target/linux/sunxi/patches-6.6/410-sunxi-add-bananapi-p2-zero.patch
+++ b/target/linux/sunxi/patches-6.6/410-sunxi-add-bananapi-p2-zero.patch
@@ -94,7 +94,7 @@
 +		regulator-always-on;
 +		regulator-boot-on;
 +		enable-active-high;
-+		gpio = <&r_pio 0 9 GPIO_ACTIVE_HIGH>; /* PL9 */
++		gpios = <&r_pio 0 9 GPIO_ACTIVE_HIGH>; /* PL9 */
 +		vin-supply = <&reg_vcc5v0>;
 +	};
 +
@@ -106,7 +106,7 @@
 +		regulator-always-on;
 +		regulator-boot-on;
 +		enable-active-high;
-+		gpio = <&r_pio 0 8 GPIO_ACTIVE_HIGH>; /* PL8 */
++		gpios = <&r_pio 0 8 GPIO_ACTIVE_HIGH>; /* PL8 */
 +		vin-supply = <&reg_vcc5v0>;
 +	};
 +


### PR DESCRIPTION
gpio is deprecated. Found with dtc's -Wdeprecated_gpio_property

Used git grep -E $'\tgpio = <' to make the changes.
