### PR TITLE
realtek: add support for L2 port isolation

### DIFF
--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1078,6 +1078,7 @@ struct rtl838x_switch_priv {
 	u32 lag_primary[MAX_LAGS];
 	u32 is_lagmember[57];
 	u64 lagmembers;
+	u64 isolated_ports;
 	struct notifier_block nb;  /* TODO: change to different name */
 	struct notifier_block ne_nb;
 	struct notifier_block fib_nb;

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -626,9 +626,9 @@ enum pbvlan_mode {
 
 struct rtl838x_port {
 	bool enable;
-	u64 pm;
 	u16 pvid;
 	bool eee_enabled;
+	u64 bridge_neighbors;
 	enum phy_type phy;
 	bool phy_is_integrated;
 	bool is10G;

--- a/target/linux/realtek/patches-5.15/600-net-bridge-offload-BR_ISOLATED-port-flag.patch
+++ b/target/linux/realtek/patches-5.15/600-net-bridge-offload-BR_ISOLATED-port-flag.patch
@@ -1,0 +1,26 @@
+From 757d95dbcee53c6c34ecbca325f2c6bf9c495eb3 Mon Sep 17 00:00:00 2001
+From: sudoBash418 <sudoBash418@gmail.com>
+Date: Thu, 13 Jun 2024 18:08:51 -0600
+Subject: [PATCH] net: bridge: offload `BR_ISOLATED` port flag
+
+This commit allows switch drivers to offload port isolation to hardware.
+
+Superseded by upstream commit `c3976a3f8445`.
+
+Signed-off-by: sudoBash418 <sudoBash418@gmail.com>
+---
+ net/bridge/br_switchdev.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/net/bridge/br_switchdev.c
++++ b/net/bridge/br_switchdev.c
+@@ -71,7 +71,8 @@ bool nbp_switchdev_allowed_egress(const
+ 
+ /* Flags that can be offloaded to hardware */
+ #define BR_PORT_FLAGS_HW_OFFLOAD (BR_LEARNING | BR_FLOOD | \
+-				  BR_MCAST_FLOOD | BR_BCAST_FLOOD)
++                                  BR_MCAST_FLOOD | BR_BCAST_FLOOD | \
++                                  BR_ISOLATED)
+ 
+ int br_switchdev_set_port_flag(struct net_bridge_port *p,
+ 			       unsigned long flags,

--- a/target/linux/realtek/patches-5.15/601-net-dsa-sync-BR_ISOLATED-brport-flag-to-drivers.patch
+++ b/target/linux/realtek/patches-5.15/601-net-dsa-sync-BR_ISOLATED-brport-flag-to-drivers.patch
@@ -1,0 +1,33 @@
+From 38cb32377fbd75ac26e585cc3ee1fca5eecec38a Mon Sep 17 00:00:00 2001
+From: sudoBash418 <sudoBash418@gmail.com>
+Date: Thu, 13 Jun 2024 18:25:52 -0600
+Subject: [PATCH] net: dsa: sync BR_ISOLATED brport flag to drivers
+
+Ensure that DSA switch drivers are notified of changes to the
+BR_ISOLATED port flag for offloading port isolation.
+
+Signed-off-by: sudoBash418 <sudoBash418@gmail.com>
+---
+ net/dsa/port.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/net/dsa/port.c
++++ b/net/dsa/port.c
+@@ -195,7 +195,7 @@ static int dsa_port_inherit_brport_flags
+ 					 struct netlink_ext_ack *extack)
+ {
+ 	const unsigned long mask = BR_LEARNING | BR_FLOOD | BR_MCAST_FLOOD |
+-				   BR_BCAST_FLOOD;
++	                           BR_BCAST_FLOOD | BR_ISOLATED;
+ 	struct net_device *brport_dev = dsa_port_to_bridge_port(dp);
+ 	int flag, err;
+ 
+@@ -219,7 +219,7 @@ static void dsa_port_clear_brport_flags(
+ {
+ 	const unsigned long val = BR_FLOOD | BR_MCAST_FLOOD | BR_BCAST_FLOOD;
+ 	const unsigned long mask = BR_LEARNING | BR_FLOOD | BR_MCAST_FLOOD |
+-				   BR_BCAST_FLOOD;
++	                           BR_BCAST_FLOOD | BR_ISOLATED;
+ 	int flag, err;
+ 
+ 	for_each_set_bit(flag, &mask, 32) {


### PR DESCRIPTION
This PR adds support for L2 port isolation to the `rtl83xx` DSA driver.

With this PR, enabling port isolation on two ports within the same bridge (via LuCI or otherwise) should result in no traffic being forwarded between the two ports.

I've tested these changes on my Zyxel GS1900-24E (RTL8382M).  
Testing on other devices (especially other SoCs) would be greatly appreciated :)

---

Questions:
- Does this work correctly on RTL931X devices?
I'm not sure if the `BUG: This does not work on RTL931X` comment is still accurate; if so, what exactly does not work? (I'd like to make the comment more specific at least)
- Is `6xx` the correct patch number for the kernel patch?