### PR TITLE
ramips: add xiaomi miwifi 3a device support

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -63,6 +63,7 @@ mediatek,linkit-smart-7688|\
 samknows,whitebox-v8|\
 xiaomi,mi-router-4c|\
 xiaomi,miwifi-nano|\
+xiaomi,miwifi-3a|\
 zbtlink,zbt-wg2626|\
 zte,mf283plus)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"

--- a/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-3a.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-3a.dts
@@ -1,0 +1,157 @@
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "xiaomi,miwifi-3a", "mediatek,mt7628an-soc";
+	model = "Xiaomi Router 3A";
+
+	aliases {
+		led-boot = &led_status_amber;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_amber;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status_blue {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: status_red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_amber: status_amber {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "gpio", "refclk", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+	mediatek,portdisable = <0x2a>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					macaddr_factory_28: macaddr@28 {
+						reg = <0x28 0x6>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -1097,6 +1097,15 @@ define Device/xiaomi_miwifi-nano
 endef
 TARGET_DEVICES += xiaomi_miwifi-nano
 
+define Device/xiaomi_miwifi-3a
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := MiWiFi 3A
+  DEVICE_PACKAGES := uboot-envtools kmod-mt76x2
+  SUPPORTED_DEVICES += miwifi-3a
+endef
+TARGET_DEVICES += xiaomi_miwifi-3a
+
 define Device/xiaomi_mi-ra75
   IMAGE_SIZE := 14976k
   DEVICE_VENDOR := Xiaomi

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -200,6 +200,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:2" "2:lan:1" "4:wan" "6@eth0"
 		;;
+	xiaomi,miwifi-3a)
+		ucidef_add_switch "switch0" \
+			"0:wan" "2:lan:1" "4:lan:2" "6@eth0"
+		;;
 	zbtlink,zbt-we1226)
 		ucidef_add_switch "switch0" \
 			"0:lan:2" "1:lan:1" "4:wan" "6@eth0"

--- a/target/linux/ramips/mt76x8/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt76x8/base-files/etc/init.d/bootcount
@@ -9,7 +9,8 @@ boot() {
 			echo -e "bootcount\nbootchanged\n" | /usr/sbin/fw_setenv -s -
 		;;
 	xiaomi,mi-router-4c|\
-	xiaomi,miwifi-nano)
+	xiaomi,miwifi-nano|\
+	xiaomi,miwifi-3a)
 		fw_setenv flag_boot_success 1
 		;;
 	esac


### PR DESCRIPTION
Miwifi 3A is a 2.4/5 GHz band router, based on MediaTek MT7628A.

Processor: MT7628A
ROM: 16MB NorFlash
RAM: 64MB DDR2
2.4G WiFi 2X2 (support IEEE 802.11N protocol, up to 300Mbps)
5G WiFi 2X2 (supports IEEE 802.11AC protocol, up to 867Mbps)
Antenna: 4 external omnidirectional high-gain antennas (2 for 2.4G maximum gain 5dBi and 2 for 5G maximum gain 6dBi)
Heat dissipation system: Natural heat dissipation

2 x 10/100M adaptive LAN ports (Auto MDI/MDIX)
1 x 10/100M adaptive WAN port (Auto MDI/MDIX)
1 red/blue/yellow LED indicator
1 system reset button
1 power input port

Flash instruction using sysupgrade image:
1. Flash "Breed" firmware into device flash memory via the flash programmer.
2. Power off the device, then press and hold the reset button, meanwhile power on the device.
3. When the LED is flashing, access Web UI (192.168.1.1), then select "Firmware upgrade".
4. Upload file "openwrt-ramips-mt76x8-xiaomi_miwifi-3a-squashfs-sysupgrade.bin" via Web UI.
5. confirm the upgrade and wait for the upgrade to complete.

NOTE: Please backup your partitions and EEPROM data BEFORE you upgrade the firmware.

I have tested these changes on my device, especially the 5G WIFI function, LED mapping, and WAN/LAN port mapping.