### PR TITLE
qualcommax: ipq807x: fix sysupgrade for ZBT-Z800AX

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-zbt-z800ax.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-zbt-z800ax.dts
@@ -154,13 +154,11 @@
 			partition@60000 {
 				label = "0:bootconfig";
 				reg = <0x60000 0x20000>;
-				read-only;
 			};
 
 			partition@80000 {
 				label = "0:bootconfig1";
 				reg = <0x80000 0x20000>;
-				read-only;
 			};
 
 			partition@a0000 {

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -53,8 +53,7 @@ platform_do_upgrade() {
 	netgear,sxs80|\
 	netgear,wax218|\
 	netgear,wax620|\
-	netgear,wax630|\
-	zbtlink,zbt-z800ax)
+	netgear,wax630)
 		nand_do_upgrade "$1"
 		;;
 	buffalo,wxr-5950ax12)
@@ -130,6 +129,18 @@ platform_do_upgrade() {
 		# force altbootcmd which handles partition change in u-boot
 		fw_setenv bootcount 3
 		fw_setenv upgrade_available 1
+		nand_do_upgrade "$1"
+		;;
+	zbtlink,zbt-z800ax)
+		local mtdnum="$(find_mtd_index 0:bootconfig)"
+		local alt_mtdnum="$(find_mtd_index 0:bootconfig1)"
+		part_num="$(hexdump -e '1/1 "%01x|"' -n 1 -s 168 -C /dev/mtd$mtdnum | cut -f 1 -d "|" | head -n1)"
+		# vendor firmware may swap the rootfs partition location, u-boot append: ubi.mtd=rootfs
+		# since we use fixed-partitions, need to force boot from the first rootfs partition
+		if [ "$part_num" -eq "1" ]; then
+			mtd erase /dev/mtd$mtdnum
+			mtd erase /dev/mtd$alt_mtdnum
+		fi
 		nand_do_upgrade "$1"
 		;;
 	zte,mf269)


### PR DESCRIPTION
This router has two rootfs partitions and dualboot is used. Vendor firmware may swap the rootfs partition location, and vendor u-boot will append 'ubi.mtd=rootfs' in the end of cmdline. Since we use fixed-partitions, force boot from the first rootfs partition to avoid boot failure.
Fixes: #15622