### PR TITLE
kernel: lantiq: fix build adsl modules on 6.6

### DIFF
--- a/package/kernel/lantiq/ltq-adsl-mei/src/drv_mei_cpe.c
+++ b/package/kernel/lantiq/ltq-adsl-mei/src/drv_mei_cpe.c
@@ -2771,7 +2771,11 @@ static int ltq_mei_probe(struct platform_device *pdev)
 	IFX_MEI_DMSG("Start loopback test...\n");
 	DFE_Loopback_Test ();
 #endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
 	dsl_class = class_create(THIS_MODULE, "ifx_mei");
+#else
+	dsl_class = class_create("ifx_mei");
+#endif
 	device_create(dsl_class, NULL, MKDEV(MEI_MAJOR, 0), NULL, "ifx_mei");
 	return 0;
 }

--- a/package/kernel/lantiq/ltq-adsl/patches/100-dsl_compat.patch
+++ b/package/kernel/lantiq/ltq-adsl/patches/100-dsl_compat.patch
@@ -111,12 +111,16 @@
     DSL_int_t i;
  
     printk(DSL_DRV_CRLF DSL_DRV_CRLF "Infineon CPE API Driver version: %s" DSL_DRV_CRLF,
-@@ -1104,7 +1119,8 @@ int __init DSL_ModuleInit(void)
+@@ -1104,7 +1119,12 @@ int __init DSL_ModuleInit(void)
     }
  
     DSL_DRV_DevNodeInit();
 -
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
 +   dsl_class = class_create(THIS_MODULE, "dsl_cpe_api");
++#else
++   dsl_class = class_create("dsl_cpe_api");
++#endif
 +   device_create(dsl_class, NULL, MKDEV(DRV_DSL_CPE_API_DEV_MAJOR, 0), NULL, "dsl_cpe_api");
     return 0;
  }

--- a/package/kernel/lantiq/ltq-adsl/patches/120-platform.patch
+++ b/package/kernel/lantiq/ltq-adsl/patches/120-platform.patch
@@ -18,7 +18,7 @@
  {
     struct class *dsl_class;
     DSL_int_t i;
-@@ -1124,7 +1124,7 @@ int __init DSL_ModuleInit(void)
+@@ -1128,7 +1128,7 @@ int __init DSL_ModuleInit(void)
     return 0;
  }
  
@@ -27,7 +27,7 @@
  {
     printk("Module will be unloaded"DSL_DRV_CRLF);
  
-@@ -1139,7 +1139,7 @@ void __exit DSL_ModuleCleanup(void)
+@@ -1143,7 +1143,7 @@ void __exit DSL_ModuleCleanup(void)
                 (DSL_uint8_t**)&g_BndFpgaBase);
  #endif /* defined(INCLUDE_DSL_CPE_API_VINAX) && defined(INCLUDE_DSL_BONDING)*/
  
@@ -36,7 +36,7 @@
  }
  
  #ifndef _lint
-@@ -1155,8 +1155,30 @@ module_param(debug_level, byte, 0);
+@@ -1159,8 +1159,30 @@ module_param(debug_level, byte, 0);
  MODULE_PARM_DESC(debug_level, "set to get more (1) or fewer (4) debug outputs");
  #endif /* #ifndef DSL_DEBUG_DISABLE*/
  

--- a/package/kernel/lantiq/ltq-adsl/patches/130-linux3.8.patch
+++ b/package/kernel/lantiq/ltq-adsl/patches/130-linux3.8.patch
@@ -95,7 +95,7 @@
        &(dsl_cpe_api_version[4]));
  
     DSL_DRV_MemSet( ifxDevices, 0, sizeof(DSL_devCtx_t) * DSL_DRV_MAX_DEVICE_NUMBER );
-@@ -1124,7 +1099,7 @@ static int __devinit ltq_adsl_probe(stru
+@@ -1128,7 +1103,7 @@ static int __devinit ltq_adsl_probe(stru
     return 0;
  }
  
@@ -104,7 +104,7 @@
  {
     printk("Module will be unloaded"DSL_DRV_CRLF);
  
-@@ -1169,7 +1144,7 @@ MODULE_DEVICE_TABLE(of, ltq_adsl_match);
+@@ -1173,7 +1148,7 @@ MODULE_DEVICE_TABLE(of, ltq_adsl_match);
  
  static struct platform_driver ltq_adsl_driver = {
  	.probe = ltq_adsl_probe,


### PR DESCRIPTION
This PR fixes the build of adsl modules on kernel 6.6.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
