### PR TITLE
ath79: fix wrong mac address for ecb1xx0

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -55,7 +55,7 @@ case "$board" in
 	engenius,ecb1200|\
 	engenius,ecb1750)
 		[ "$PHYNBR" -eq 0 ] && \
-		mtd_get_mac_ascii u-boot-env ethaddr > /sys${DEVPATH}/macaddress
+			mtd_get_mac_ascii u-boot-env athaddr > /sys${DEVPATH}/macaddress
 		;;
 	engenius,epg5000|\
 	engenius,esr1200|\


### PR DESCRIPTION
0db4f9785ca30f79fa1abbffb0fab5a6053f68f5 changed the variable name from athaddr to ethaddr. Restore.

ping @DragonBluep @mpratt14 