### PR TITLE
ramips: cleaning up nvmem-cells definitions

### DIFF
--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5861.dts
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5861.dts
@@ -72,9 +72,6 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
 
-	nvmem-cells = <&macaddr_factory_4>;
-	nvmem-cell-names = "mac-address";
-
 	mediatek,portmap = "llllw";
 
 	port@5 {

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
@@ -71,9 +71,6 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&rgmii1_pins &rgmii2_pins &mdio_pins>;
 
-	nvmem-cells = <&macaddr_rom_f100 0>;
-	nvmem-cell-names = "mac-address";
-
 	port@5 {
 		status = "okay";
 		mediatek,fixed-link = <1000 1 1 1>;

--- a/target/linux/ramips/dts/mt7621_cudy_x6-v1.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_x6-v1.dts
@@ -56,6 +56,6 @@
 };
 
 &wifi {
-	nvmem-cells = <&macaddr_bdinfo_de00 0>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };

--- a/target/linux/ramips/dts/mt7621_cudy_x6-v2.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_x6-v2.dts
@@ -56,6 +56,6 @@
 };
 
 &wifi {
-	nvmem-cells = <&macaddr_bdinfo_de00 0>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };

--- a/target/linux/ramips/dts/mt7621_cudy_x6.dtsi
+++ b/target/linux/ramips/dts/mt7621_cudy_x6.dtsi
@@ -104,8 +104,6 @@
 	wifi:wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_elecom_wmc-m1267gst2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wmc-m1267gst2.dts
@@ -50,8 +50,8 @@
 };
 
 &wifi {
-	nvmem-cells = <&macaddr_factory_4 (-1)>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4 (-1)>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &factory {

--- a/target/linux/ramips/dts/mt7621_elecom_wmc-s1267gs2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wmc-s1267gs2.dts
@@ -59,8 +59,8 @@
 };
 
 &wifi {
-	nvmem-cells = <&macaddr_factory_4 (-1)>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4 (-1)>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &factory {

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1167gs2-b.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1167gs2-b.dts
@@ -50,8 +50,8 @@
 };
 
 &wifi {
-	nvmem-cells = <&macaddr_factory_4 (-1)>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4 (-1)>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &factory {

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1167gst2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1167gst2.dts
@@ -50,8 +50,8 @@
 };
 
 &wifi {
-	nvmem-cells = <&macaddr_factory_e006 1>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_e006 1>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };
 
 &factory {

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-gs-1pci.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-gs-1pci.dtsi
@@ -25,7 +25,5 @@
 	wifi: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_netgear_r6020.dts
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6020.dts
@@ -60,3 +60,8 @@
 &ohci {
 	status = "disabled";
 };
+
+&wifi5 {
+	nvmem-cells = <&eeprom_factory_8000>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/ramips/dts/mt7628an_netgear_r6080.dts
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6080.dts
@@ -40,3 +40,8 @@
 &ohci {
 	status = "disabled";
 };
+
+&wifi5 {
+	nvmem-cells = <&eeprom_factory_8000>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/ramips/dts/mt7628an_netgear_r6120.dts
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6120.dts
@@ -44,6 +44,6 @@
 };
 
 &wifi5 {
-	nvmem-cells = <&macaddr_factory_4 2>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_4 2>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };

--- a/target/linux/ramips/dts/mt7628an_netgear_r6xxx.dtsi
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6xxx.dtsi
@@ -138,8 +138,6 @@
 &pcie0 {
 	wifi5: wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_8000>;
-		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
@@ -72,8 +72,3 @@
 		};
 	};
 };
-
-&ethernet {
-	nvmem-cells = <&macaddr_factory_f100 0>;
-	nvmem-cell-names = "mac-address";
-};

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v4.dts
@@ -91,6 +91,11 @@
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
+&ethernet {
+	nvmem-cells = <&macaddr_factory_f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
 &esw {
 	mediatek,portmap = <0x3e>;
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v3.dts
@@ -97,6 +97,11 @@
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
+&ethernet {
+	nvmem-cells = <&macaddr_factory_f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
 &esw {
 	mediatek,portmap = <0x3e>;
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr3420-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr3420-v5.dts
@@ -92,6 +92,11 @@
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
+&ethernet {
+	nvmem-cells = <&macaddr_factory_f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
 &esw {
 	mediatek,portmap = <0x3e>;
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wa801nd-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wa801nd-v5.dts
@@ -87,3 +87,8 @@
 	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_factory_f100 0>;
 	nvmem-cell-names = "eeprom", "mac-address";
 };
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_f100 0>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v4.dts
@@ -80,6 +80,11 @@
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
+&ethernet {
+	nvmem-cells = <&macaddr_factory_f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
 &esw {
 	mediatek,portmap = <0x3e>;
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr841n-v13.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr841n-v13.dts
@@ -106,6 +106,11 @@
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
+&ethernet {
+	nvmem-cells = <&macaddr_factory_f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
 &esw {
 	mediatek,portmap = <0x3e>;
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr842n-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr842n-v5.dts
@@ -92,6 +92,11 @@
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
+&ethernet {
+	nvmem-cells = <&macaddr_factory_f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
 &esw {
 	mediatek,portmap = <0x3e>;
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr850n-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr850n-v2.dts
@@ -83,6 +83,11 @@
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
+&ethernet {
+	nvmem-cells = <&macaddr_factory_f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
 &esw {
 	mediatek,portmap = <0x3e>;
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr902ac-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr902ac-v3.dts
@@ -98,6 +98,11 @@
 	nvmem-cell-names = "eeprom", "mac-address";
 };
 
+&ethernet {
+	nvmem-cells = <&macaddr_factory_f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
 &pcie {
 	status = "okay";
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr902ac-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr902ac-v4.dts
@@ -111,3 +111,8 @@
 	nvmem-cells = <&eeprom_factory_28000>, <&macaddr_factory_f100 0>;
 	nvmem-cell-names = "eeprom", "mac-address";
 };
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_f100 0>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-ra75.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-ra75.dts
@@ -95,11 +95,6 @@
 	nvmem-cell-names = "mac-address";
 };
 
-&wmac {
-	nvmem-cells = <&eeprom_factory_0>;
-	nvmem-cell-names = "eeprom";
-};
-
 &esw {
 	mediatek,portmap = <0x3e>;
 	mediatek,portdisable = <0x2a>;


### PR DESCRIPTION
HiWiFi HC5861 - inside &ethernet - removed due to duplicate in mt7620a_hiwifi_hc5x61.dtsi
TP-Link Archer C2 v1 - inside &ethernet - removed due to duplication in mt7620a_tplink_8m.dtsi
Xiaomi Mi AC1200 WLAN Range Extender RA75 - inside &wmac - removed due to duplication in mt7628an_xiaomi_mi router-4.dtsi

CUDY X6 v1,
CUDY X6 v2 - inside &wifi - moved from mt7621_cudy_x6.dtsi

ELECOM WMC-M1267GST2,
ELECOM WMC-S1267GS2,
ELECOM WRC-1167GS2-B,
ELECOM WRC-1167GST2 - inside &wifi - eeprom moved from mt7621_elecom_wrc-gs-1pci.dtsi

Netgear R6020,
Netgear R6080,
Netgear R6120 - inside &wifi5 - moved from mt7628an_netgear_r6xxx.dtsi

TP-Link Archer C20 v4,
TP-Link Archer C50 v3,
TP-Link TL-MR3420 v5,
TP-Link TL-WA801ND v5,
TP-Link TL-WR840N v4,
TP-Link TL-WR841N v13,
TP-Link TL-WR842N v5,
TP-Link TL-WR850N v2,
TP-Link TL-WR902AC v3,
TP-Link TL-WR902AC v4 - inside &ethernet - moved from mt7628an_tplink_8m.dtsi 
(for compatibility with other files in which mt7628an_tplink_8m.dtsi is loaded, to avoid overwriting)
