### PR TITLE
ramips: fix MAC address for some devices

### DIFF
--- a/target/linux/ramips/dts/mt7620a_bolt_bl100.dts
+++ b/target/linux/ramips/dts/mt7620a_bolt_bl100.dts
@@ -183,9 +183,7 @@
 					};
 
 					macaddr_factory_28: macaddr@28 {
-						compatible = "mac-base";
 						reg = <0x28 0x6>;
-						#nvmem-cell-cells = <1>;
 					};
 				};
 			};

--- a/target/linux/ramips/dts/mt7621_dlink_flash-16m-a1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_flash-16m-a1.dtsi
@@ -50,7 +50,9 @@
 					};
 
 					macaddr_factory_e006: macaddr@e006 {
+						compatible = "mac-base";
 						reg = <0xe006 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};

--- a/target/linux/ramips/dts/mt7621_dlink_flash-16m-r1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_flash-16m-r1.dtsi
@@ -56,7 +56,9 @@
 					};
 
 					macaddr_factory_e006: macaddr@e006 {
+						compatible = "mac-base";
 						reg = <0xe006 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1167gst2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1167gst2.dts
@@ -13,7 +13,7 @@
 };
 
 &gmac1 {
-	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cells = <&macaddr_factory_e006 0>;
 	nvmem-cell-names = "mac-address";
 };
 

--- a/target/linux/ramips/dts/mt7621_hanyang_hyc-g920.dts
+++ b/target/linux/ramips/dts/mt7621_hanyang_hyc-g920.dts
@@ -100,10 +100,6 @@
 						reg = <0x4 0x6>;
 						#nvmem-cell-cells = <1>;
 					};
-
-					macaddr_factory_8004: macaddr@8004 {
-						reg = <0x8004 0x6>;
-					};
 				};
 			};
 

--- a/target/linux/ramips/dts/mt7621_iptime_a3004t.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a3004t.dts
@@ -93,10 +93,6 @@
 					reg = <0x4 0x6>;
 					#nvmem-cell-cells = <1>;
 				};
-
-				macaddr_factory_8004: macaddr@8004 {
-					reg = <0x8004 0x6>;
-				};
 			};
 		};
 

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4.dtsi
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4.dtsi
@@ -73,10 +73,6 @@
 					macaddr_factory_28: macaddr@28 {
 						reg = <0x28 0x6>;
 					};
-
-					macaddr_factory_8004: macaddr@8004 {
-						reg = <0x8004 0x6>;
-					};
 				};
 			};
 


### PR DESCRIPTION
1. Remove unused macaddr NVMEM cells.
2. Fix "mac-base" compatible cells references.