### PR TITLE
malta: enable VM targets again

### DIFF
--- a/target/linux/malta/be64/target.mk
+++ b/target/linux/malta/be64/target.mk
@@ -1,7 +1,6 @@
 ARCH:=mips64
 CPU_TYPE:=mips64r2
 SUBTARGET:=be64
-FEATURES+=source-only
 BOARDNAME:=Big Endian (64-bits)
 
 define Target/Description

--- a/target/linux/malta/le/target.mk
+++ b/target/linux/malta/le/target.mk
@@ -1,7 +1,6 @@
 ARCH:=mipsel
 CPU_TYPE:=24kc
 SUBTARGET:=le
-FEATURES+=source-only
 BOARDNAME:=Little Endian
 
 define Target/Description

--- a/target/linux/malta/le64/target.mk
+++ b/target/linux/malta/le64/target.mk
@@ -1,7 +1,6 @@
 ARCH:=mips64el
 CPU_TYPE:=mips64r2
 SUBTARGET:=le64
-FEATURES+=source-only
 BOARDNAME:=Little Endian (64-bits)
 
 define Target/Description


### PR DESCRIPTION
These targets are interesting for automated testing. The currently available targets are from 2017 and either we should enable them again or delete the remaining files on the download servers.