### PR TITLE
ramips: add support for Keenetic KN-3510

### DIFF
--- a/target/linux/ramips/dts/mt7621_keenetic_kn-3510.dts
+++ b/target/linux/ramips/dts/mt7621_keenetic_kn-3510.dts
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "keenetic,kn-3510", "mediatek,mt7621-soc";
+	model = "Keenetic KN-3510";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-1 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		fn1 {
+			label = "fn1";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &storage1 &firmware2 &storage2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x0>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "jtag";
+		function = "gpio";
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "rf-eeprom";
+			reg = <0x100000 0x80000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_a: macaddr@a {
+					reg = <0xa 0x6>;
+				};
+
+				precal_factory_e10: precal@e10 {
+					reg = <0xe10 0x19c10>;
+				};
+			};
+		};
+
+		firmware1: partition@180000 {
+			label = "firmware_1";
+			reg = <0x180000 0x1a40000>;
+		};
+
+		partition@1bc0000 {
+			label = "config_1";
+			reg = <0x1bc0000 0x20000>;
+			read-only;
+		};
+
+		partition@1dc0000 {
+			label = "storage_legacy";
+			reg = <0x1dc0000 0x20000>;
+			read-only;
+		};
+
+		partition@1fc0000 {
+			label = "dump";
+			reg = <0x1fc0000 0x40000>;
+			read-only;
+		};
+
+		storage1: partition@2000000 {
+			label = "storage_a";
+			reg = <0x2000000 0x1fc0000>;
+		};
+
+		partition@3fc0000 {
+			label = "u-state";
+			reg = <0x3fc0000 0x80000>;
+			read-only;
+		};
+
+		partition@4040000 {
+			label = "u-config_res";
+			reg = <0x4040000 0x80000>;
+			read-only;
+		};
+
+		partition@40c0000 {
+			label = "rf-eeprom_res";
+			reg = <0x40c0000 0x80000>;
+			read-only;
+		};
+
+		firmware2: partition@4140000 {
+			label = "firmware_2";
+			reg = <0x4140000 0x1a40000>;
+		};
+
+		partition@5b80000 {
+			label = "config_2";
+			reg = <0x5d00000 0x20000>;
+			read-only;
+		};
+
+		storage2: partition@5d80000 {
+			label = "storage_b";
+			reg = <0x5d80000 0x2200000>;
+		};
+	};
+};
+
+&ethphy0 {
+	/delete-property/ interrupts;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_factory_a>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@3 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
+		mediatek,disable-radar-background;
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1650,6 +1650,19 @@ define Device/keenetic_kn-3010
 endef
 TARGET_DEVICES += keenetic_kn-3010
 
+define Device/keenetic_kn-3510
+  $(Device/nand)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 121088k
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KN-3510
+  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size | zyimage -d 0x803510 -v "KN-3510"
+endef
+TARGET_DEVICES += keenetic_kn-3510
+
 define Device/lenovo_newifi-d1
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -67,6 +67,7 @@ ramips_setup_interfaces()
 		;;
 	asiarf,ap7621-001|\
 	humax,e10|\
+	keenetic,kn-3510|\
 	openfi,5pro|\
 	wavlink,ws-wn572hp3-4g|\
 	winstars,ws-wn583a6)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -126,6 +126,10 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary Factory 0x4)" > /sys${DEVPATH}/macaddress
 		;;
+	keenetic,kn-3510)
+		[ "$PHYNBR" = "1" ] && \
+			macaddr_setbit_la "$(mtd_get_mac_binary rf-eeprom 0x4)" > /sys${DEVPATH}/macaddress
+		;;
 	linksys,e5600|\
 	linksys,ea6350-v4|\
 	linksys,ea7300-v1|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -100,6 +100,7 @@ platform_do_upgrade() {
 	iptime,ax2004m|\
 	iptime,t5004|\
 	jcg,q20|\
+	keenetic,kn-3510|\
 	linksys,e5600|\
 	linksys,e7350|\
 	linksys,ea6350-v4|\


### PR DESCRIPTION
Keenetic KN-3510 is a 2.4/5 Ghz band 11ax access point

Specification:
- System-On-Chip: MT7621AT
- CPU/Speed: 880 MHz
- Flash-Chip: Macronix MX30LF1G28AD-TI
- Flash size: 128 MiB
- RAM: 256 MiB
- 2x 10/100/1000 Mbps Ethernet
- PoE, 802.3af/at
- 4x internal antennas
- UART (J1) header on PCB (115200 8n1)
- WiFi: MT7915 2x2 2.4G 573.5Mbps + 2x2 5G 1201Mbps
- 2x LED, 2x button, 1x mode switch

Notes:
- The device supports dual boot mode
- The firmware partitions were concatinated into one

Flash instruction:
The only way to flash OpenWrt image is to use tftp recovery mode in U-Boot:

1. Configure PC with static IP 192.168.1.2/24 and tftp server.
2. Rename "openwrt-ramips-mt7621-keenetic_kn-3510-squashfs-factory.bin" to "KN-3510_recovery.bin" and place it in tftp server directory.
3. Connect PC with one of LAN ports, press the reset button, power up the router and keep button pressed until power led start blinking.
4. Router will download file from server, write it to flash and reboot