### PR TITLE
ath79: ag71xx: support probe defferal for getting MAC address

### DIFF
--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -1668,7 +1668,11 @@ static int ag71xx_probe(struct platform_device *pdev)
 	ag->stop_desc->ctrl = 0;
 	ag->stop_desc->next = (u32) ag->stop_desc_dma;
 
-	if (of_get_ethdev_address(np, dev)) {
+	err = of_get_ethdev_address(np, dev);
+	if (err) {
+		if (err == -EPROBE_DEFER)
+			return err;
+
 		dev_err(&pdev->dev, "invalid MAC address, using random address\n");
 		eth_hw_addr_random(dev);
 	}


### PR DESCRIPTION
Currently, `of_get_ethdev_address()` return is checked for any return error code which means that trying to get the MAC from NVMEM cells that is backed by MTD will fail if it was not probed before ag71xx.

So, lets check the return error code for `EPROBE_DEFER` and defer the ag71xx probe in that case until the underlying NVMEM device is live.
