### PR TITLE
ath79: mikrotik: set compat version for NAND devices

### DIFF
--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/05_compat-version
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. /lib/functions.sh
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+case "$(board_name)" in
+	mikrotik,routerboard-493g|\
+	mikrotik,routerboard-911g-5hpacd|\
+	mikrotik,routerboard-911g-xhpnd|\
+	mikrotik,routerboard-912uag-2hpnd|\
+	mikrotik,routerboard-921gs-5hpacd-15s|\
+	mikrotik,routerboard-922uags-5hpacd|\
+	mikrotik,routerboard-951g-2hnd|\
+	mikrotik,routerboard-951ui-2hnd|\
+	mikrotik,routerboard-sxt-5nd-r2)
+		ucidef_set_compat_version "1.1"
+		;;
+esac
+
+board_config_flush
+
+exit 0


### PR DESCRIPTION
Currently, trying to upgrade on a MikroTik NAND device will force you to use `sysupgrade -n` due to:
```
upgrade: The device is supported, but the config is incompatible to the new image (1.0->1.1). Please upgrade without keeping config (sysupgrade -n). 
upgrade: NAND images switched to yafut.  If running older image, reinstall from initramfs.
```

So instead of having users manually set the new compat version lets do what other targets do and set it for all NAND devices after good boot.

@f00b4r0 
