### PR TITLE
bcm27xx: fix malformed upstream arm64 DT patch

### DIFF
--- a/target/linux/bcm27xx/patches-6.6/950-0040-BCM2708-Add-core-Device-Tree-support.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-0040-BCM2708-Add-core-Device-Tree-support.patch
@@ -558,8 +558,6 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.org>
  .../boot/dts/broadcom/bcm2710-rpi-zero-2.dts  |    1 +
  .../boot/dts/broadcom/bcm2711-rpi-cm4.dts     |    1 +
  .../boot/dts/broadcom/bcm2711-rpi-cm4s.dts    |    1 +
- .../dts/broadcom/bcm283x-rpi-csi1-2lane.dtsi  |    1 +
- .../dts/broadcom/bcm283x-rpi-lan7515.dtsi     |    1 +
  arch/arm64/boot/dts/overlays                  |    1 +
  include/dt-bindings/gpio/gpio-fsm.h           |   21 +
  scripts/Makefile.dtbinst                      |    5 +-
@@ -910,8 +908,6 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.org>
  create mode 100644 arch/arm64/boot/dts/broadcom/bcm2710-rpi-zero-2.dts
  create mode 100644 arch/arm64/boot/dts/broadcom/bcm2711-rpi-cm4.dts
  create mode 100644 arch/arm64/boot/dts/broadcom/bcm2711-rpi-cm4s.dts
- create mode 120000 arch/arm64/boot/dts/broadcom/bcm283x-rpi-csi1-2lane.dtsi
- create mode 120000 arch/arm64/boot/dts/broadcom/bcm283x-rpi-lan7515.dtsi
  create mode 120000 arch/arm64/boot/dts/overlays
  create mode 100644 include/dt-bindings/gpio/gpio-fsm.h
 
@@ -38522,22 +38518,6 @@ index 000000000000..c72d752e7400
 +++ b/arch/arm64/boot/dts/broadcom/bcm2711-rpi-cm4s.dts
 @@ -0,0 +1 @@
 +#include "arm/broadcom/bcm2711-rpi-cm4s.dts"
-diff --git a/arch/arm64/boot/dts/broadcom/bcm283x-rpi-csi1-2lane.dtsi b/arch/arm64/boot/dts/broadcom/bcm283x-rpi-csi1-2lane.dtsi
-new file mode 120000
-index 000000000000..e5c400284467
---- /dev/null
-+++ b/arch/arm64/boot/dts/broadcom/bcm283x-rpi-csi1-2lane.dtsi
-@@ -0,0 +1 @@
-+../../../../arm/boot/dts/bcm283x-rpi-csi1-2lane.dtsi
-\ No newline at end of file
-diff --git a/arch/arm64/boot/dts/broadcom/bcm283x-rpi-lan7515.dtsi b/arch/arm64/boot/dts/broadcom/bcm283x-rpi-lan7515.dtsi
-new file mode 120000
-index 000000000000..fc4c05bbe7fd
---- /dev/null
-+++ b/arch/arm64/boot/dts/broadcom/bcm283x-rpi-lan7515.dtsi
-@@ -0,0 +1 @@
-+../../../../arm/boot/dts/bcm283x-rpi-lan7515.dtsi
-\ No newline at end of file
 diff --git a/arch/arm64/boot/dts/overlays b/arch/arm64/boot/dts/overlays
 new file mode 120000
 index 000000000000..ded08646b6f6


### PR DESCRIPTION
An upstream RPi patch is causing buildbot issues when copying arm64 DT files since [bcm283x-rpi-csi1-2lane.dtsi](https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm64/boot/dts/broadcom/bcm283x-rpi-csi1-2lane.dtsi) and [bcm283x-rpi-lan7515.dtsi](https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm64/boot/dts/broadcom/bcm283x-rpi-lan7515.dtsi) were linked to [../../../../arm/boot/dts/](https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm/boot/dts) instead of [../../../../arm/boot/dts/broadcom](https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm/boot/dts/broadcom).
These files aren't needed, so let's remove them instead of fixing them.

Buildbot failures:
- [bcm2710](https://buildbot.openwrt.org/images/#/builders/124/builds/267)
- [bcm2711](https://buildbot.openwrt.org/images/#/builders/142/builds/269)
- [bcm2712](https://buildbot.openwrt.org/images/#/builders/237/builds/224)

```
cp: cannot stat '/builder/shared-workdir/build/build_dir/target-aarch64_cortex-a53_musl/linux-bcm27xx_bcm2710/linux-6.6.34/arch/arm64/boot/dts/broadcom/bcm283x-rpi-csi1-2lane.dtsi': No such file or directory
cp: cannot stat '/builder/shared-workdir/build/build_dir/target-aarch64_cortex-a53_musl/linux-bcm27xx_bcm2710/linux-6.6.34/arch/arm64/boot/dts/broadcom/bcm283x-rpi-lan7515.dtsi': No such file or directory
```