### PR TITLE
kernel: mtd: ubi: avoid attaching "linux,ubi" mtd again

### DIFF
--- a/target/linux/generic/pending-6.6/490-ubi-auto-attach-mtd-device-named-ubi-or-data-on-boot.patch
+++ b/target/linux/generic/pending-6.6/490-ubi-auto-attach-mtd-device-named-ubi-or-data-on-boot.patch
@@ -8,7 +8,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/mtd/ubi/build.c
 +++ b/drivers/mtd/ubi/build.c
-@@ -1258,6 +1258,74 @@ static struct mtd_notifier ubi_mtd_notif
+@@ -1258,6 +1258,80 @@ static struct mtd_notifier ubi_mtd_notif
  	.remove = ubi_notify_remove,
  };
  
@@ -21,6 +21,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +{
 +	int err;
 +	struct mtd_info *mtd;
++	struct device_node *np;
 +	loff_t offset = 0;
 +	size_t len;
 +	char magic[4];
@@ -32,6 +33,11 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +
 +	if (IS_ERR(mtd))
 +		return;
++
++	/* skip "linux,ubi" mtd as it has already been attached */
++	np = mtd_get_of_node(mtd);
++	if (of_device_is_compatible(np, "linux,ubi"))
++		goto cleanup;
 +
 +	/* get the first not bad block */
 +	if (mtd_can_have_bb(mtd))
@@ -83,7 +89,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static int __init ubi_init_attach(void)
  {
  	int err, i, k;
-@@ -1308,6 +1376,12 @@ static int __init ubi_init_attach(void)
+@@ -1308,6 +1382,12 @@ static int __init ubi_init_attach(void)
  		}
  	}
  


### PR DESCRIPTION
"linux,ubi" compatible MTD device can be automatically attached early since commit fc153aa8d94f. Therefore, there is no need to attach MTD devices named "ubi" or "data" again.

cc @dangowrt

I guess we can drop this patch in the future.