### PR TITLE
wifi-scripts: ensure get_freq returns int (iw-6.9)

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -1021,7 +1021,7 @@ $1 ~ /Band/ {
 }
 
 band_match && $3 == "MHz" && $4 == channel {
-	print $2
+	print int($2)
 	exit
 }
 '


### PR DESCRIPTION
With `iw` version 6.9 frequencies are now being reported as float, which is incompatible with wpa_supplicant's config option 'frequency' which expects an integer.

iwinfo phy0 info output:

Version: 5.19
```
Frequencies:
  * 5180 MHz [36] (30.0 dBm)
  * 5200 MHz [40] (30.0 dBm)
  * 5220 MHz [44] (30.0 dBm)
  * 5240 MHz [48] (30.0 dBm)
  * 5260 MHz [52] (24.0 dBm)
  * 5280 MHz [56] (24.0 dBm)
  * 5300 MHz [60] (24.0 dBm)
  * 5320 MHz [64] (24.0 dBm)
  * 5500 MHz [100] (24.0 dBm)
  * 5520 MHz [104] (24.0 dBm)
  * 5540 MHz [108] (24.0 dBm)
  * 5560 MHz [112] (24.0 dBm)
  * 5580 MHz [116] (24.0 dBm)
  * 5600 MHz [120] (24.0 dBm)
  * 5620 MHz [124] (24.0 dBm)
  * 5640 MHz [128] (24.0 dBm)
  * 5660 MHz [132] (24.0 dBm)
  * 5680 MHz [136] (24.0 dBm)
  * 5700 MHz [140] (24.0 dBm)
  * 5720 MHz [144] (24.0 dBm)
  * 5745 MHz [149] (30.0 dBm)
  * 5765 MHz [153] (30.0 dBm)
  * 5785 MHz [157] (30.0 dBm)
  * 5805 MHz [161] (30.0 dBm)
  * 5825 MHz [165] (30.0 dBm)
  * 5845 MHz [169] (disabled)
  * 5865 MHz [173] (disabled)
  * 5885 MHz [177] (disabled)
```

Version: 6.9
```
Frequencies:
  * 5180.0 MHz [36] (30.0 dBm)
  * 5200.0 MHz [40] (30.0 dBm)
  * 5220.0 MHz [44] (30.0 dBm)
  * 5240.0 MHz [48] (30.0 dBm)
  * 5260.0 MHz [52] (24.0 dBm)
  * 5280.0 MHz [56] (24.0 dBm)
  * 5300.0 MHz [60] (24.0 dBm)
  * 5320.0 MHz [64] (24.0 dBm)
  * 5500.0 MHz [100] (24.0 dBm)
  * 5520.0 MHz [104] (24.0 dBm)
  * 5540.0 MHz [108] (24.0 dBm)
  * 5560.0 MHz [112] (24.0 dBm)
  * 5580.0 MHz [116] (24.0 dBm)
  * 5600.0 MHz [120] (24.0 dBm)
  * 5620.0 MHz [124] (24.0 dBm)
  * 5640.0 MHz [128] (24.0 dBm)
  * 5660.0 MHz [132] (24.0 dBm)
  * 5680.0 MHz [136] (24.0 dBm)
  * 5700.0 MHz [140] (24.0 dBm)
  * 5720.0 MHz [144] (24.0 dBm)
  * 5745.0 MHz [149] (30.0 dBm)
  * 5765.0 MHz [153] (30.0 dBm)
  * 5785.0 MHz [157] (30.0 dBm)
  * 5805.0 MHz [161] (30.0 dBm)
  * 5825.0 MHz [165] (30.0 dBm)
  * 5845.0 MHz [169] (disabled)
  * 5865.0 MHz [173] (disabled)
  * 5885.0 MHz [177] (disabled)
```

The changeset causing this is: [iw: S1G: add list command support for 802.11ah](https://git.kernel.org/pub/scm/linux/kernel/git/jberg/iw.git/commit/info.c?id=f2d9f5b52677f5414dc194be94b5916d2b080eab)

Error reported from wpa_supplicant
```console
Fri Jun 21 14:07:22 2024 daemon.err wpa_supplicant[2866]: Line 10: invalid number "5320.0"
Fri Jun 21 14:07:22 2024 daemon.err wpa_supplicant[2866]: Line 10: failed to parse frequency '5320.0'.
Fri Jun 21 14:07:22 2024 daemon.err wpa_supplicant[2866]: Line 16: failed to parse network block.
Fri Jun 21 14:07:22 2024 daemon.err wpa_supplicant[2866]: Failed to read or parse configuration '/var/run/wpa_supplicant-phy1-mesh0.conf'.
```
 
This affects mesh, adhoc, and client-mode WDS.

Until hostapd/wpa_supplicant is updated (or patched) to support float frequencies, ensure `get_freq` prints out an integer.

Reported On
Platform: Qualcommax