### PR TITLE
tools/fakeroot: fix check for whether to wrap time64 functions

### DIFF
--- a/tools/fakeroot/patches/300-time64-hack.patch
+++ b/tools/fakeroot/patches/300-time64-hack.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -386,7 +386,7 @@ dnl  Digital Unix: stat
+ time64_hack=no
+ AH_TEMPLATE([TIME64_HACK], [time64 shuffle])
+ AC_MSG_CHECKING([if we need to cope with time64])
+-AC_EGREP_CPP([time64],[
++AC_EGREP_CPP([_*[a-z0-9]+_time64[^_]],[
+ #include <bits/wordsize.h>
+ #if __WORDSIZE == 32
+ #define __USE_TIME_BITS64 1


### PR DESCRIPTION
@Ansuel @PolynomialDivision @hauke @neheb 

Since updating fakeroot to 1.33, the time64 build problem is back,
however, instead of reverting again, I took a deep dive and found a real solution.

refer to:
#11886 
#11969 
#11986 

Fakeroot uses an egrep configure check to look for the string "time64" within a preprocessed include of the sys/stat.h header in order to decide whether or not to create declarations and internal functions used for wrapping the native functions stat64_time64 fstat64_time64 lstat64_time64 and fstatat64_time64.

On specific older versions of glibc these functions are not included, but there are some references to "time64" unrelated to functions, like aliasing the time64_t typedef to the standard time_t typedef when the size of a word is 64 bits or defining it if not.

In this case, a grep for "stat64"
of the preprocessed sys/stat.h header matches nothing, however, the grep for "time64" in the configure check of the preprocessed sys/stat.h header matches a line that has nothing to do with the functions
that will be wrapped as a result of successful matching.

`  __extension__ typedef __int64_t __time64_t;`

This causes the attempt to wrap the functions to occur, which fails due to some of the corresponding macros being empty since the native declarations they are based on do not exist, causing a common error claiming that a part of the syntax is missing.

`  error: expected '=', ',', ';', 'asm' or '__attribute__' before ...`

Fix this by making the testing regular expression more complex in order to match actual function names ending in "_time64" with or without a set of preceding underscores, but none after.
