### PR TITLE
[23.05] mediatek: Add support for D-Link EAGLE PRO AI R32

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_mt7622
+++ b/package/boot/uboot-envtools/files/mediatek_mt7622
@@ -12,6 +12,10 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 case "$board" in
+dlink,eagle-pro-ai-m32-a1|\
+dlink,eagle-pro-ai-r32-a1)
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x2000" "0x2000"
+	;;
 linksys,e8450-ubi)
 	ubootenv_add_uci_config "/dev/ubi0_0" "0x0" "0x1f000" "0x1f000" "1"
 	ubootenv_add_uci_config "/dev/ubi0_1" "0x0" "0x1f000" "0x1f000" "1"

--- a/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-ax3200-a1.dtsi
+++ b/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-ax3200-a1.dtsi
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include "mt7622.dtsi"
+#include "mt6380.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		serial0 = &uart0;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8 swiotlb=512";
+	};
+
+	cpus {
+		cpu@0 {
+			proc-supply = <&mt6380_vcpu_reg>;
+			sram-supply = <&mt6380_vm_reg>;
+		};
+
+		cpu@1 {
+			proc-supply = <&mt6380_vcpu_reg>;
+			sram-supply = <&mt6380_vm_reg>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+		};
+
+		button-wps {
+			gpios = <&pio 102 GPIO_ACTIVE_LOW>;
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x40000000>;
+	};
+};
+
+&bch {
+	status = "okay";
+};
+
+&btif {
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_pins>;
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		phy-mode = "2500base-x";
+		reg = <0>;
+		nvmem-cells = <&macaddr_odm 1>;
+		nvmem-cell-names = "mac-address";
+		fixed-link {
+			full-duplex;
+			pause;
+			speed = <2500>;
+		};
+	};
+
+	mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		switch: switch@0 {
+			compatible = "mediatek,mt7531";
+			reg = <0>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-parent = <&pio>;
+			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
+			reset-gpios = <&pio 54 0>;
+
+			ports {
+				wan: port@4 {
+					reg = <4>;
+					label = "wan";
+					nvmem-cells = <&macaddr_odm 0>;
+					nvmem-cell-names = "mac-address";
+				};
+
+				port@6 {
+					reg = <6>;
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+	status = "okay";
+};
+
+&pcie1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_pins>;
+	status = "okay";
+};
+
+&pio {
+	epa_elna_pins: epa-elna-pins {
+		mux {
+			function = "antsel";
+			groups = "antsel0", "antsel1", "antsel2", "antsel3",
+				"antsel4", "antsel5", "antsel6", "antsel7",
+				"antsel8", "antsel9", "antsel12", "antsel13",
+				"antsel14", "antsel15", "antsel16", "antsel17";
+		};
+	};
+
+	eth_pins: eth-pins {
+		mux {
+			function = "eth";
+			groups = "mdc_mdio", "rgmii_via_gmac2";
+		};
+	};
+
+	pcie0_pins: pcie0-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie0_pad_perst",
+				 "pcie0_1_waken",
+				 "pcie0_1_clkreq";
+		};
+	};
+
+	pcie1_pins: pcie1-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie1_pad_perst",
+				 "pcie1_0_waken",
+				 "pcie1_0_clkreq";
+		};
+	};
+
+	pmic_bus_pins: pmic-bus-pins {
+		mux {
+			function = "pmic";
+			groups = "pmic_bus";
+		};
+	};
+
+	/* Serial NAND is shared pin with SPI-NOR */
+	serial_nand_pins: serial-nand-pins {
+		mux {
+			function = "flash";
+			groups = "snfi";
+		};
+	};
+
+	uart0_pins: uart0-pins {
+		mux {
+			function = "uart";
+			groups = "uart0_0_tx_rx";
+		};
+	};
+
+	watchdog_pins: watchdog-pins {
+		mux {
+			function = "watchdog";
+			groups = "watchdog";
+		};
+	};
+};
+
+&pwrap {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pmic_bus_pins>;
+	status = "okay";
+};
+
+&rtc {
+	status = "disabled";
+};
+
+&sata {
+	status = "disabled";
+};
+
+&sata_phy {
+	status = "disabled";
+};
+
+&slot0 {
+	wmac1: mt7915@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		mediatek,mtd-eeprom = <&factory 0x05000>;
+		nvmem-cells = <&macaddr_odm 3>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&snfi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&serial_nand_pins>;
+	status = "okay";
+
+	snand: flash@0 {
+		compatible = "spi-nand";
+		mediatek,bmt-table-size = <0x1000>;
+		mediatek,bmt-v2;
+		nand-ecc-engine = <&snfi>;
+		reg = <0>;
+		spi-rx-bus-width = <4>;
+		spi-tx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Preloader";
+				reg = <0x00000000 0x00080000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "ATF";
+				reg = <0x00080000 0x00040000>;
+				read-only;
+			};
+
+			partition@C0000 {
+				label = "Bootloader";
+				reg = <0x000C0000 0x00080000>;
+				read-only;
+			};
+
+			partition@140000 {
+				label = "BootConfig";
+				reg = <0x00140000 0x00040000>;
+			};
+
+			partition@180000 {
+				label = "Odm";
+				reg = <0x00180000 0x00040000>;
+				read-only;
+				odm_partition: nvmem-layout {
+					compatible = "fixed-layout";
+				};
+			};
+
+			config1: partition@1C0000 {
+				compatible = "nvmem-cells";
+				label = "Config1";
+				reg = <0x001C0000 0x00080000>;
+				read-only;
+			};
+
+			partition@240000 {
+				label = "Config2";
+				reg = <0x00240000 0x00080000>;
+				read-only;
+			};
+
+			partition@2C0000 {
+				label = "Kernel1";
+				reg = <0x002C0000 0x02D00000>;
+
+				compatible = "denx,fit";
+				openwrt,cmdline-match = "boot_part=Kernel1";
+				partition@0 {
+					label = "kernel";
+					reg = <0x00000000 0x00800000>;
+				};
+
+				partition@800000 {
+					label = "ubi";
+					reg = <0x00800000 0x02500000>;
+				};
+			};
+
+			partition@2FC0000 {
+				label = "Kernel2";
+				reg = <0x02FC0000 0x02D00000>;
+
+				compatible = "denx,fit";
+				openwrt,cmdline-match = "boot_part=Kernel2";
+				partition@0 {
+					label = "kernel";
+					reg = <0x00000000 0x00800000>;
+				};
+
+				partition@800000 {
+					label = "ubi";
+					reg = <0x00800000 0x02500000>;
+				};
+			};
+
+			factory: partition@5CC0000 {
+				label = "Factory";
+				reg = <0x05CC0000 0x00100000>;
+				read-only;
+			};
+
+			partition@5DC0000 {
+				label = "Mydlink";
+				reg = <0x05DC0000 0x00200000>;
+				read-only;
+			};
+
+			partition@5FC0000 {
+				label = "Storage";
+				reg = <0x05FC0000 0x00300000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ssusb {
+	status = "disabled";
+};
+
+&u3phy {
+	status = "disabled";
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+	status = "okay";
+};
+
+&watchdog {
+	pinctrl-names = "default";
+	pinctrl-0 = <&watchdog_pins>;
+	status = "okay";
+};
+
+&wmac {
+	pinctrl-names = "default";
+	pinctrl-0 = <&epa_elna_pins>;
+	mediatek,mtd-eeprom = <&factory 0x0000>;
+	nvmem-cells = <&macaddr_odm 2>;
+	nvmem-cell-names = "mac-address";
+	status = "okay";
+};
+

--- a/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-m32-a1.dts
+++ b/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-m32-a1.dts
@@ -1,399 +1,62 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 /dts-v1/;
-#include "mt7622.dtsi"
-#include "mt6380.dtsi"
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "mt7622-dlink-eagle-pro-ai-ax3200-a1.dtsi"
+#include <dt-bindings/leds/common.h>
 
 / {
 	model = "D-Link EAGLE PRO AI M32 A1";
 	compatible = "dlink,eagle-pro-ai-m32-a1", "mediatek,mt7622";
 
 	aliases {
-		led-boot = &status_orange;
-		led-failsafe = &status_red;
-		led-running = &status_white;
-		led-upgrade = &status_red;
-		serial0 = &uart0;
-		label-mac-device = &gmac0;
-	};
-
-	chosen {
-		stdout-path = "serial0:115200n8";
-		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8 swiotlb=512";
-	};
-
-	cpus {
-		cpu@0 {
-			proc-supply = <&mt6380_vcpu_reg>;
-			sram-supply = <&mt6380_vm_reg>;
-		};
-
-		cpu@1 {
-			proc-supply = <&mt6380_vcpu_reg>;
-			sram-supply = <&mt6380_vm_reg>;
-		};
-	};
-
-	gpio-keys {
-		compatible = "gpio-keys";
-
-		reset {
-			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-		};
-
-		wps {
-			gpios = <&pio 102 GPIO_ACTIVE_LOW>;
-			label = "wps";
-			linux,code = <KEY_WPS_BUTTON>;
-		};
+		led-boot = &led_status_orange;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_white;
+		led-upgrade = &led_status_red;
 	};
 
 	leds {
 		compatible = "gpio-leds";
 
-		status_white: status_white {
-			label = "white:status";
+		led_status_white: led-status-white {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_STATUS;
 			gpios = <&pio 85 GPIO_ACTIVE_LOW>;
 		};
 
-		status_orange: status_orange {
-			label = "orange:status";
+		led_status_orange: led-status-orange {
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_STATUS;
 			gpios = <&pio 20 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};
 
-		status_red: status_red {
-			label = "red:status";
+		led_status_red: led-status-red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
 			gpios = <&pio 17 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	memory {
-		reg = <0 0x40000000 0 0x40000000>;
-	};
 };
 
-&bch {
-	status = "okay";
-};
-
-&btif {
-	status = "okay";
-};
-
-&eth {
-	pinctrl-names = "default";
-	pinctrl-0 = <&eth_pins>;
-	status = "okay";
-
-	gmac0: mac@0 {
-		compatible = "mediatek,eth-mac";
-		nvmem-cells = <&macaddr_odm_83>;
-		nvmem-cell-names = "mac-address";
-		phy-mode = "2500base-x";
-		reg = <0>;
-
-		fixed-link {
-			full-duplex;
-			pause;
-			speed = <2500>;
+&switch {
+	ports {
+		port@2 {
+			reg = <2>;
+			label = "lan2";
 		};
-	};
 
-	mdio-bus {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		switch@0 {
-			compatible = "mediatek,mt7531";
-			reg = <0>;
-			interrupt-controller;
-			#interrupt-cells = <1>;
-			interrupt-parent = <&pio>;
-			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
-			reset-gpios = <&pio 54 0>;
-
-			ports {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				port@2 {
-					reg = <2>;
-					label = "lan2";
-				};
-
-				port@3 {
-					reg = <3>;
-					label = "lan1";
-				};
-
-				wan: port@4 {
-					reg = <4>;
-					label = "wan";
-				};
-
-				port@6 {
-					reg = <6>;
-					ethernet = <&gmac0>;
-					phy-mode = "2500base-x";
-
-					fixed-link {
-						speed = <2500>;
-						full-duplex;
-						pause;
-					};
-				};
-			};
+		port@3 {
+			reg = <3>;
+			label = "lan1";
 		};
 	};
 };
 
-&pcie0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pcie0_pins>;
-	status = "okay";
-};
-
-&pcie1 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pcie1_pins>;
-	status = "okay";
-};
-
-&pio {
-    epa_elna_pins: epa-elna-pins {
-		mux {
-			function = "antsel";
-			groups = "antsel0", "antsel1", "antsel2", "antsel3",
-				  "antsel4", "antsel5", "antsel6", "antsel7",
-      				  "antsel8", "antsel9", "antsel12", "antsel13",
-    				  "antsel14", "antsel15", "antsel16", "antsel17";
-		};
-	};
-
-	eth_pins: eth-pins {
-		mux {
-			function = "eth";
-			groups = "mdc_mdio", "rgmii_via_gmac2";
-		};
-	};
-
-	pcie0_pins: pcie0-pins {
-		mux {
-			function = "pcie";
-			groups = "pcie0_pad_perst",
-				 "pcie0_1_waken",
-				 "pcie0_1_clkreq";
-		};
-	};
-
-	pcie1_pins: pcie1-pins {
-		mux {
-			function = "pcie";
-			groups = "pcie1_pad_perst",
-				 "pcie1_0_waken",
-				 "pcie1_0_clkreq";
-		};
-	};
-
-	pmic_bus_pins: pmic-bus-pins {
-		mux {
-			function = "pmic";
-			groups = "pmic_bus";
-		};
-	};
-
-	/* Serial NAND is shared pin with SPI-NOR */
-	serial_nand_pins: serial-nand-pins {
-		mux {
-			function = "flash";
-			groups = "snfi";
-		};
-	};
-
-	uart0_pins: uart0-pins {
-		mux {
-			function = "uart";
-			groups = "uart0_0_tx_rx";
-		};
-	};
-
-	watchdog_pins: watchdog-pins {
-		mux {
-			function = "watchdog";
-			groups = "watchdog";
-		};
+&odm_partition {
+	macaddr_odm: macaddr@83 {
+		compatible = "mac-base";
+		reg = <0x83 0x6>;
+		#nvmem-cell-cells = <1>;
 	};
 };
-
-&pwrap {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pmic_bus_pins>;
-	status = "okay";
-};
-
-&rtc {
-	status = "disabled";
-};
-
-&sata {
-	status = "disabled";
-};
-
-&sata_phy {
-	status = "disabled";
-};
-
-&slot0 {
-	wmac1: mt7915@0,0 {
-		reg = <0x0000 0 0 0 0>;
-		ieee80211-freq-limit = <5000000 6000000>;
-		mediatek,mtd-eeprom = <&factory 0x05000>;
-	};
-};
-
-&snfi {
-	pinctrl-names = "default";
-	pinctrl-0 = <&serial_nand_pins>;
-	status = "okay";
-
-	snand: flash@0 {
-		compatible = "spi-nand";
-		mediatek,bmt-table-size = <0x1000>;
-		mediatek,bmt-v2;
-		nand-ecc-engine = <&snfi>;
-		reg = <0>;
-		spi-rx-bus-width = <4>;
-		spi-tx-bus-width = <4>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "Preloader";
-				reg = <0x00000000 0x00080000>;
-				read-only;
-			};
-
-			partition@80000 {
-				label = "ATF";
-				reg = <0x00080000 0x00040000>;
-				read-only;
-			};
-
-			partition@C0000 {
-				label = "Bootloader";
-				reg = <0x000C0000 0x00080000>;
-				read-only;
-			};
-
-			partition@140000 {
-				label = "BootConfig";
-				reg = <0x00140000 0x00040000>;
-				read-only;
-			};
-
-			odm: partition@180000 {
-				compatible = "nvmem-cells";
-				label = "Odm";
-				reg = <0x00180000 0x00040000>;
-				read-only;
-
-				macaddr_odm_83: macaddr@83 {
-					reg = <0x83 0x6>;
-				};
-			};
-
-			config1: partition@1C0000 {
-				compatible = "nvmem-cells";
-				label = "Config1";
-				reg = <0x001C0000 0x00080000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
-				read-only;
-			};
-
-			partition@240000 {
-				label = "Config2";
-				reg = <0x00240000 0x00080000>;
-				read-only;
-			};
-
-			partition@2C0000 {
-				label = "Kernel1";
-				reg = <0x002C0000 0x02D00000>;
-
-				compatible = "fixed-partitions";
-				#address-cells = <1>;
-				#size-cells = <1>;
-				partition@0 {
-					label = "kernel";
-					reg = <0x00000000 0x00800000>;
-				};
-
-				partition@800000 {
-					label = "ubi";
-					reg = <0x00800000 0x02500000>;
-				};
-			};
-
-			partition@2FC0000 {
-				label = "Kernel2";
-				reg = <0x02FC0000 0x02D00000>;
-				read-only;
-			};
-
-			factory: partition@5CC0000 {
-				label = "Factory";
-				reg = <0x05CC0000 0x00100000>;
-				read-only;
-			};
-
-			partition@5DC0000 {
-				label = "Mydlink";
-				reg = <0x05DC0000 0x00200000>;
-				read-only;
-			};
-
-			partition@5FC0000 {
-				label = "Storage";
-				reg = <0x05FC0000 0x00300000>;
-				read-only;
-			};
-		};
-	};
-};
-
-&ssusb {
-	status = "disabled";
-};
-
-&u3phy {
-	status = "disabled";
-};
-
-&uart0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&uart0_pins>;
-	status = "okay";
-};
-
-&watchdog {
-	pinctrl-names = "default";
-	pinctrl-0 = <&watchdog_pins>;
-	status = "okay";
-};
-
-&wmac {
-	pinctrl-names = "default";
-	pinctrl-0 = <&epa_elna_pins>;
-	mediatek,mtd-eeprom = <&factory 0x0000>;
-	status = "okay";
-};
-

--- a/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-r32-a1.dts
+++ b/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-r32-a1.dts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include "mt7622-dlink-eagle-pro-ai-ax3200-a1.dtsi"
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "D-Link EAGLE PRO AI R32 A1";
+	compatible = "dlink,eagle-pro-ai-r32-a1", "mediatek,mt7622";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_orange;
+		led-running = &led_power_white;
+		led-upgrade = &led_power_orange;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: led-power-orange {
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 20 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_white: led-power-white {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 85 GPIO_ACTIVE_LOW>;
+		};
+
+		led_internet_orange: led-internet-orange {
+			color = <LED_COLOR_ID_ORANGE>;
+			function = "internet"; // LED_FUNCTION_INTERNET;
+			gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_internet_white: led-internet-white {
+			color = <LED_COLOR_ID_WHITE>;
+			function = "internet"; // LED_FUNCTION_INTERNET;
+			gpios = <&pio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&switch {
+	ports {
+		port@0 {
+			reg = <0>;
+			label = "lan4";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan3";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan2";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan1";
+		};
+	};
+};
+
+&odm_partition {
+	macaddr_odm: macaddr@81 {
+		compatible = "mac-base";
+		reg = <0x81 0x6>;
+		#nvmem-cell-cells = <1>;
+	};
+};
+

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -35,9 +35,15 @@ define Build/bl31-uboot
 	cat $(STAGING_DIR_IMAGE)/mt7622_$1-u-boot.fip >> $@
 endef
 
-# Append header to a D-Link M32 Kernel 1 partition
-define Build/m32-recovery-header-kernel1
-	echo -en "DLK6E6010001\x00\x00\xCF\x33" > "$@.header"
+# Append header to a D-Link M32/R32 Kernel 1 partition
+define Build/m32-r32-recovery-header-kernel1
+	$(eval header_start=$(word 1,$(1)))
+# create $@.header without the checksum
+	echo -en "$(header_start)\x00\x00" > "$@.header"
+# Calculate checksum over data area ($@) and append it to the header.
+# The checksum is the 2byte-sum over the whole data area.
+# Every overflow during the checksum calculation must increment the current checksum value by 1.
+	od -v -w2 -tu2 -An --endian little "$@" | awk '{ s+=$$1; } END { s%=65535; printf "%c%c",s%256,s/256; }' >> "$@.header"
 	echo -en "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x8D\x57\x30\x0B" >> "$@.header"
 # Byte 0-3: Erase Start 0x002C0000
 # Byte 4-7: Erase Length 0x02D00000
@@ -46,9 +52,11 @@ define Build/m32-recovery-header-kernel1
 	echo -en "\x00\x00\x2C\x00\x00\x00\xD0\x02\x00\x00\x2C\x00\x00\x00\xD0\x02" >> "$@.header"
 # Only zeros
 	echo -en "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" >> "$@.header"
-# Note: The last 2 bytes of the following line are the checksum of the header
-# If any data in the header will be changed, the checksum must be re-calculated
-	echo -en "\x42\x48\x02\x00\x00\x00\x08\x00\x00\x00\x00\x00\x60\x6E\x68\x61" >> "$@.header"
+# Last 16 bytes, but without checksum
+	echo -en "\x42\x48\x02\x00\x00\x00\x08\x00\x00\x00\x00\x00\x60\x6E" >> "$@.header"
+# Calculate and append checksum: The checksum must be set so that the 2byte-sum of the whole header is 0.
+# Every overflow during the checksum calculation must increment the current checksum value by 1.
+	od -v -w2 -tu2 -An --endian little "$@.header" | awk '{s+=65535-$$1;}END{s%=65535;printf "%c%c",s%256,s/256;}' >> "$@.header"
 	cat "$@.header" "$@" > "$@.new"
 	mv "$@.new" "$@"
 	rm "$@.header"
@@ -178,12 +186,10 @@ define Device/buffalo_wsr-3200ax4s
 endef
 TARGET_DEVICES += buffalo_wsr-3200ax4s
 
-define Device/dlink_eagle-pro-ai-m32-a1
+define Device/dlink_eagle-pro-ai-ax3200-a1
   IMAGE_SIZE := 46080k
   DEVICE_VENDOR := D-Link
-  DEVICE_MODEL := EAGLE PRO AI M32
   DEVICE_VARIANT := A1
-  DEVICE_DTS := mt7622-dlink-eagle-pro-ai-m32-a1
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7915-firmware
   KERNEL_SIZE := 8192k
@@ -193,9 +199,23 @@ define Device/dlink_eagle-pro-ai-m32-a1
   IMAGES += tftp.bin recovery.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/tftp.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | check-size
-  IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | pad-to $$(IMAGE_SIZE) | m32-recovery-header-kernel1
+endef
+
+define Device/dlink_eagle-pro-ai-m32-a1
+  $(Device/dlink_eagle-pro-ai-ax3200-a1)
+  DEVICE_MODEL := EAGLE PRO AI M32
+  DEVICE_DTS := mt7622-dlink-eagle-pro-ai-m32-a1
+  IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | pad-to $$(IMAGE_SIZE) | m32-r32-recovery-header-kernel1 DLK6E6010001
 endef
 TARGET_DEVICES += dlink_eagle-pro-ai-m32-a1
+
+define Device/dlink_eagle-pro-ai-r32-a1
+  $(Device/dlink_eagle-pro-ai-ax3200-a1)
+  DEVICE_MODEL := EAGLE PRO AI R32
+  DEVICE_DTS := mt7622-dlink-eagle-pro-ai-r32-a1
+  IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | pad-to $$(IMAGE_SIZE) | m32-r32-recovery-header-kernel1 DLK6E6015001
+endef
+TARGET_DEVICES += dlink_eagle-pro-ai-r32-a1
 
 define Device/elecom_wrc-2533gent
   DEVICE_VENDOR := Elecom

--- a/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
@@ -10,6 +10,7 @@ mediatek_setup_interfaces()
 	case $board in
 	bananapi,bpi-r64|\
 	buffalo,wsr-3200ax4s|\
+	dlink,eagle-pro-ai-r32-a1|\
 	elecom,wrc-x3200gst3|\
 	linksys,e8450|\
 	linksys,e8450-ubi|\
@@ -63,10 +64,6 @@ mediatek_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii board_data "mac")
 		wan_mac=$lan_mac
 		label_mac=$lan_mac
-		;;
-	dlink,eagle-pro-ai-m32-a1)
-		wan_mac=$(get_mac_label)
-		lan_mac=$(macaddr_add $(get_mac_label) 1)
 		;;
 	reyee,ax3200-e5|\
 	ruijie,rg-ew3200gx-pro)

--- a/target/linux/mediatek/mt7622/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/mt7622/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -18,10 +18,6 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $basemac 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $basemac 8 > /sys${DEVPATH}/macaddress
 		;;
-	dlink,eagle-pro-ai-m32-a1)
-		[ "$PHYNBR" = "0" ] && macaddr_add $(cat /sys/class/net/eth0/address) 2 > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && macaddr_add $(cat /sys/class/net/eth0/address) 3 > /sys${DEVPATH}/macaddress
-		;;
 	reyee,ax3200-e5|\
 	ruijie,rg-ew3200gx-pro)
 		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label) 3 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/mt7622/base-files/etc/init.d/bootcount
+++ b/target/linux/mediatek/mt7622/base-files/etc/init.d/bootcount
@@ -4,6 +4,14 @@ START=99
 
 boot() {
 	case $(board_name) in
+	dlink,eagle-pro-ai-m32-a1|\
+	dlink,eagle-pro-ai-r32-a1)
+		if grep -q boot_part=Kernel1 /proc/cmdline; then
+			fw_setenv boot_part 1
+		else
+			fw_setenv boot_part 2
+		fi
+		;;
 	linksys,e8450)
 		mtd erase senv || true
 		;;

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
@@ -35,6 +35,7 @@ platform_do_upgrade() {
 		fi
 		;;
 	dlink,eagle-pro-ai-m32-a1|\
+	dlink,eagle-pro-ai-r32-a1|\
 	elecom,wrc-x3200gst3|\
 	mediatek,mt7622-rfb1-ubi|\
 	netgear,wax206|\
@@ -73,7 +74,8 @@ platform_check_image() {
 	buffalo,wsr-3200ax4s)
 		buffalo_check_image "$board" "$magic" "$1" || return 1
 		;;
-  	dlink,eagle-pro-ai-m32-a1|\
+	dlink,eagle-pro-ai-m32-a1|\
+	dlink,eagle-pro-ai-r32-a1|\
 	elecom,wrc-x3200gst3|\
 	mediatek,mt7622-rfb1-ubi|\
 	netgear,wax206|\


### PR DESCRIPTION
R32 is like the M32 part of the EAGLE PRO AI series from D-Link.

Specification:
 - MT7622BV SoC with 2.4GHz wifi
 - MT7975AN + MT7915AN for 5GHz
 - MT7531BE Switch
 - 512MB RAM
 - 128 MB flash
 - 2 LEDs (Status and Internet, both can be either orange or white)
 - 2 buttons (WPS and Reset)

Compared to M32, the R32 has the following differences:
 - 4 LAN ports instead of 2
 - The recory image starts with DLK6E6015001 instaed of DLK6E6010001
 - Individual LEDs for power and internet
 - MAC address is stored at another offset in the ODM partition

MAC addresses:
 - WAN MAC is stored in partition "Odm" at offset 0x81
 - LAN (as printed on the device) is WAN MAC + 1
 - WLAN MAC (2.4 GHz) is WAN MAC + 2
 - WLAN MAC (5GHz) is WAN MAC + 3

Flashing via Recovery Web Interface:
 - Set your IP address to 192.168.0.10, subnetmask 255.255.255.0
 - Press the reset button while powering on the deivce
 - Keep the reset button pressed until the internet LED blinks fast
 - Open a Chromium based and goto http://192.168.0.1
 - Download openwrt-mediatek-mt7622-dlink_eagle-pro-ai-r32-a1-squashfs-recovery.bin

Flashing via uBoot:
 - Open the case, connect to the UART console
 - Set your IP address to 10.10.10.3, subnet mask 255.255.255.0. Connect to one of the LAN interfaces of the router
 - Run a tftp server which provides openwrt-mediatek-mt7622-dlink_eagle-pro-ai-r32-initramfs-kernel.bin.
 - You can rename the file to iverson_uImage (no extension), then you don't have to enter the whole file name in uboot later.
 - Power on the device and select "1. System Load Linux to SDRAM via TFTP." in the boot menu
 - Enter image file, tftp server IP and device IP (if they differ from the default).
 - TFTP download to RAM will start. After a few seconds OpenWrt initramfs should start
 - The initramfs is accessible via 192.168.1.1, change your IP address accordingly (or use multiple IP addresses on your interface)
 - Create a backup of the Kernel1 partition, this file is required if a revert to stock should be done later
 - Perform a sysupgrade using openwrt-mediatek-mt7622-dlink_eagle-pro-ai-r32-squashfs-sysupgrade.bin
 - Reboot the device. OpenWrt should start from flash now

Revert back to stock using the Recovery Web Interface:
 - Set your IP address to 192.168.0.10, subnetmask 255.255.255.0
 - Press the reset button while powering on the deivce
 - Keep the reset button pressed until the internet LED blinks fast
 - Open a Chromium based and goto http://192.168.0.1
 - Flash a decrypted firmware image from D-Link. Decrypting an firmware image is described below.

Decrypting a D-Link firmware image:
 - Download https://github.com/RolandoMagico/firmware-utils/blob/M32/src/m32-firmware-util.c
 - Compile a binary from the downloaded file, e.g. gcc m32-firmware-util.c -lcrypto -o m32-firmware-util
 - Run ./m32-firmware-util R32 --DecryptFactoryImage <OriginalFirmware> <OutputFile>
 - Example for firmware R32A1_FW103B01: ./m32-firmware-util R32 --DecryptFactoryImage R32A1_FW103B01.bin R32A1_FW103B01.decrypted.bin

Revert back to stock using uBoot:
 - Open the case, connect to the UART console
 - Set your IP address to 10.10.10.3, subnet mask 255.255.255.0. Connect to one of the LAN interfaces of the router
 - Run a tftp server which provides the previously created backup of the Kernel1 partition.
 - You can rename the file to iverson_uImage (no extension), then you don't have to enter the whole file name in uboot later.
 - Power on the device and select "2. System Load Linux Kernel then write to Flash via TFTP." in the boot menu
 - Enter image file, tftp server IP and device IP (if they differ from the default).
 - TFTP download to FLASH will start. After a few seconds the stock firmware should start again

There is also an image openwrt-mediatek-mt7622-dlink_eagle-pro-ai-r32-a1-squashfs-tftp.bin which can directly be flashed via U-Boot and TFTP. It can be used if no backup of the Kernel1 partition is reuqired.

Flahsing via OEM web interface is currently not possible, the OEM images are encrypted. Creating images is only possible manually at the moment. The support for the M32/R32 already includes support for flashing from the OEM web interface:
 - The device tree contains both partitions (Kernel1 and Kernel2) with conditions to select the correct one based on the kernel command line
 - The U-Boot variable "boot_part" is set accordingly during startup to finish the partition swap after flashing from the OEM web interface
 - OpenWrt sysupgrade flashing always uses the partition where it was initially flashed to (no partition swap)
