### PR TITLE
ramips: mt7621: add support for Wodesys WD-R1802U

### DIFF
--- a/target/linux/ramips/dts/mt7621_wodesys_wd-r1802u.dts
+++ b/target/linux/ramips/dts/mt7621_wodesys_wd-r1802u.dts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "wodesys,wd-r1802u", "mediatek,mt7621-soc";
+	model = "Wodesys WD-R1802U";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_blue;
+		led-failsafe = &led_red;
+		led-running = &led_green;
+		led-upgrade = &led_blue;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		key-0 {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_green: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_blue: led-1 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_red: led-2 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
+		mediatek,disable-radar-background;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x00000 0x30000>;
+				read-only;
+			};
+
+			/* 0x30000-0x4ffff are unused
+                           (flash contents is 0xff) */
+
+			partition@50000 {
+				label = "factory";
+				reg = <0x50000 0x40000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+
+					macaddr_factory_4: macaddr@4 { // wifi 2.4
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					precal_factory_e10: precal@e10 {
+						reg = <0xe10 0x19c10>;
+					};
+				};
+			};
+
+			partition@90000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x90000 0xf70000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@4 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2898,6 +2898,17 @@ define Device/winstars_ws-wn583a6
 endef
 TARGET_DEVICES += winstars_ws-wn583a6
 
+define Device/wodesys_wd-r1802u
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 15808k
+  DEVICE_VENDOR := Wodesys
+  DEVICE_MODEL := WD-R1802U
+  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  SUPPORTED_DEVICES += mt7621-rfb-ax-nor
+endef
+TARGET_DEVICES += wodesys_wd-r1802u
+
 define Device/xiaomi_nand_separate
   $(Device/nand)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -61,6 +61,7 @@ ramips_setup_interfaces()
 	ubnt,unifi-nanohd|\
 	yuncore,fap690|\
 	wavlink,wl-wn573hx1|\
+	wodesys,wd-r1802u|\
 	zyxel,nwa50ax|\
 	zyxel,nwa55axe)
 		ucidef_set_interface_lan "lan"


### PR DESCRIPTION
This commit adds support for a dual-band AX1800 wall plug manufactured by Shenzhen Century Xinyang Tech Co., Ltd.

* **CPU**:	Mediatek MT7621A (2 cores, 4 threads)
* **RAM**:	256 MiB DDR3 (Samsung K4B2G1646F-BCNB)
* **ROM**:	16 MiB SPI NOR (Winbond W25Q128JVPQ)
* **Wired**:	one gigabit RJ45 port (with green/yellow non-GPIO LEDs)
* **WiFi**:	Mediatek MT7905DAN + MT7975DN (DBDC 2x 2T2R)
* **Ant.**:	four 2 dBi external antennas (two 2.4GHz, two 5 GHz)
* **GPIO**:
  * tri-color status LED (GPIO 13, 14, 16);
  * reset button (GPIO 18)
* **Power**:
  * 12V 2-pin JST-XH on main PCB
  * 110/220V AC to 12V1A DC on auxiliary PCB
* **UART**:
  * 115200 8n1, SMD pads available on the PCB as J4
  * pinout is [3v3] (Rx) (Tx) (Gnd)
* **MAC**:
  `1C:BF:CE:xx:xx:xx    `	(2.4 GHz, label)
  `1C:BF:CE:xx:xx:xx + 1`	(ethernet [1])
  `1C:BF:CE:xx:xx:xx + 2`	(5 GHz)

Original firmware is LEDE Reboot 17.01-SNAPSHOT (kernel 4.4.198) with a few custom packages and a non-LuCI web interface. Telnet and SSH are enabled, requiring an unknown root password [2].
Root password is also needed to access the router via UART console, but passwordless telnet can be enabled via a trivial web exploit [3] and then the root password can be removed by editing `/etc/shadow`.

**Installation**:  First upload `sysupgrade` binary via web interface at `http://192.168.188.1/settings.shtml` and wait until getting back to the home screen ("select network to extend"). The installation fails since the original firmware uses `swconfig` and recent versions of OpenWrt use DSA. However, the sysupgrade file is uploaded correctly and stored at `/tmp/upgrade.bin`, so it can be written to flash via the web exploit [4] (both `mtd -r write` and `sysupgrade -Fn` work fine). Passwordless telnet/ssh is not needed for installation.
Alternatively, use u-boot menu to load image via TFTP.

**Notes**:
- Device model in LEDE is "MediaTek MT7621 RFB (802.11ax,SNOR)".
- It is sold under several names, among them are Wodesys WD-R1802U, Fenvi F-AX1802U, and EDUP EP-2971; the Wodesys brand was selected since it is referenced in `/etc/banner` and `/etc/hosts`, and the PCB is marked "WD518A V1.0".
- Instead of a standard ethernet transformer, the PCB has a few tiny SMD coils.

[1] Original firmware sets ethernet MAC to 1C:BF:CE:E7:62:1D based on offset `0x3fff4` in the Factory partition; since this is the same MAC for all units, whereas WiFi MACs stored at offsets `0x6` and `0xc`  are unique, it was decided to use <label MAC + 1> for ethernet.
[2] ```root:$1$7rmMiPJj$91iv9LWhfkZE/t7aCBdo.0:18388:0:99999:7:::```
[3] ```curl -X POST http://192.168.188.1/cgi-bin/adm.cgi -d page=Lang -d langType="en;killall telnetd;telnetd -l /bin/sh"```
[4] ```curl -X POST http://192.168.188.1/cgi-bin/adm.cgi -d page=Lang -d langType="en;mtd -r write /tmp/upgrade.bin firmware"```