### PR TITLE
uml: fix glibc-static check with GCC14

### DIFF
--- a/target/linux/uml/image/Makefile
+++ b/target/linux/uml/image/Makefile
@@ -30,4 +30,4 @@ $(eval $(call BuildImage))
 $(eval $(call TestHostCommand,glibc-static, \
 	Please install a static glibc package. (Missing libutil.a, librt.a or libpthread.a), \
 	echo 'int main(int argc, char **argv) { login(0); timer_gettime(0, 0); return 0; }' | \
-		gcc -include utmp.h -x c -o $(TMP_DIR)/a.out - -static -lutil -lrt))
+		gcc -include utmp.h -include time.h -x c -o $(TMP_DIR)/a.out - -static -lutil -lrt))


### PR DESCRIPTION
Running the glibc-static check with GCC14 as the host compiler will fail:
`Please install a static glibc package. (Missing libutil.a, librt.a or libpthread.a)`

However, this error will get printed even with the required static libraries installed when GCC14 is used.

Manually running the check exposes the real error:
```
<stdin>: In function ‘main’:
<stdin>:1:45: error: implicit declaration of function ‘timer_gettime’ [-Wimplicit-function-declaration]
```

GCC14 now errors on implicit declarations by default, so lets add the required time.h header to fix compilation and thus the check.
