### PR TITLE
tools: mtd-utils: update to 2.2.0

### DIFF
--- a/tools/mtd-utils/Makefile
+++ b/tools/mtd-utils/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mtd-utils
-PKG_VERSION:=2.1.6
+PKG_VERSION:=2.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://infraroot.at/pub/mtd/
-PKG_HASH:=c1d853bc4adf83bcabd2792fc95af33bdd8643c97e8f7b3f0180af36af76f0e5
+PKG_HASH:=250d082f67375ca8451b5fcfc9a23a53ced3ebebd8312c288daf2507bbab1324
 PKG_CPE_ID:=cpe:/a:mtd-utils_project:mtd-utils
 
 PKG_FIXUP:=autoreconf
@@ -37,7 +37,8 @@ HOST_CONFIGURE_ARGS+= \
 	--without-crypto \
 	--without-xattr \
 	--without-zstd \
-	--without-lzo
+	--without-lzo \
+	--with-lzma
 
 HOST_MAKE_FLAGS += \
 	PROGRAMS="mkfs.jffs2 ubinize mkfs.ubifs"

--- a/tools/mtd-utils/Makefile
+++ b/tools/mtd-utils/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mtd-utils
 PKG_VERSION:=2.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://infraroot.at/pub/mtd/
@@ -33,7 +33,7 @@ HOST_CONFIGURE_VARS+= \
 	UUID_CFLAGS="-I$(STAGING_DIR_HOST)/include/e2fsprogs/uuid"
 
 HOST_CONFIGURE_ARGS+= \
-	--disable-tests \
+	--without-tests \
 	--without-crypto \
 	--without-xattr \
 	--without-zstd \

--- a/tools/mtd-utils/patches/110-portability.patch
+++ b/tools/mtd-utils/patches/110-portability.patch
@@ -1,9 +1,9 @@
 --- a/jffsX-utils/compr_lzo.c
 +++ b/jffsX-utils/compr_lzo.c
-@@ -26,7 +26,6 @@
+@@ -24,7 +24,6 @@
+ #include <stdint.h>
+ #include <stdio.h>
  #include <string.h>
- 
- #ifndef WITHOUT_LZO
 -#include <asm/types.h>
  #include <linux/jffs2.h>
  #include <lzo/lzo1x.h>
@@ -70,7 +70,7 @@
  #include <sys/types.h>
 --- a/ubifs-utils/mkfs.ubifs/mkfs.ubifs.c
 +++ b/ubifs-utils/mkfs.ubifs/mkfs.ubifs.c
-@@ -1542,6 +1542,7 @@ static int add_inode(struct stat *st, in
+@@ -1554,6 +1554,7 @@ static int add_inode(struct stat *st, in
  
  	if (c->default_compr != UBIFS_COMPR_NONE)
  		use_flags |= UBIFS_COMPR_FL;
@@ -78,7 +78,7 @@
  	if (flags & FS_COMPR_FL)
  		use_flags |= UBIFS_COMPR_FL;
  	if (flags & FS_SYNC_FL)
-@@ -1554,6 +1555,7 @@ static int add_inode(struct stat *st, in
+@@ -1566,6 +1567,7 @@ static int add_inode(struct stat *st, in
  		use_flags |= UBIFS_DIRSYNC_FL;
  	if (fctx)
  		use_flags |= UBIFS_CRYPT_FL;
@@ -86,7 +86,7 @@
  	memset(ino, 0, UBIFS_INO_NODE_SZ);
  
  	ino_key_init(&key, inum);
-@@ -1639,7 +1641,9 @@ static int add_dir_inode(const char *pat
+@@ -1651,7 +1653,9 @@ static int add_dir_inode(const char *pat
  		fd = dirfd(dir);
  		if (fd == -1)
  			return sys_err_msg("dirfd failed");
@@ -96,23 +96,23 @@
  			flags = 0;
  	}
  
-@@ -1850,6 +1854,7 @@ static int add_file(const char *path_nam
+@@ -1862,6 +1866,7 @@ static int add_file(const char *path_nam
  		dn->ch.node_type = UBIFS_DATA_NODE;
  		key_write(&key, &dn->key);
  		out_len = NODE_BUFFER_SIZE - UBIFS_DATA_NODE_SZ;
 +#ifndef NO_NATIVE_SUPPORT
  		if (c->default_compr == UBIFS_COMPR_NONE &&
  		    !c->encrypted && (flags & FS_COMPR_FL))
- #ifdef WITHOUT_LZO
-@@ -1858,6 +1863,7 @@ static int add_file(const char *path_nam
- 			use_compr = UBIFS_COMPR_LZO;
+ #ifdef WITH_LZO
+@@ -1872,6 +1877,7 @@ static int add_file(const char *path_nam
+ 			use_compr = UBIFS_COMPR_NONE;
  #endif
  		else
 +#endif
  			use_compr = c->default_compr;
  		compr_type = compress_data(buf, bytes_read, &dn->data,
  					   &out_len, use_compr);
-@@ -1917,7 +1923,9 @@ static int add_non_dir(const char *path_
+@@ -1931,7 +1937,9 @@ static int add_non_dir(const char *path_
  		if (fd == -1)
  			return sys_err_msg("failed to open file '%s'",
  					   path_name);

--- a/tools/mtd-utils/patches/130-lzma_jffs2.patch
+++ b/tools/mtd-utils/patches/130-lzma_jffs2.patch
@@ -1,25 +1,9 @@
 --- a/jffsX-utils/Makemodule.am
 +++ b/jffsX-utils/Makemodule.am
-@@ -4,7 +4,10 @@ mkfs_jffs2_SOURCES = \
- 	jffsX-utils/compr_zlib.c \
- 	jffsX-utils/compr.h \
- 	jffsX-utils/rbtree.c \
--	jffsX-utils/compr_lzo.c \
-+	jffsX-utils/compr_lzma.c \
-+	jffsX-utils/lzma/LzFind.c \
-+	jffsX-utils/lzma/LzmaEnc.c \
-+	jffsX-utils/lzma/LzmaDec.c \
- 	jffsX-utils/compr.c \
- 	jffsX-utils/compr_rtime.c \
- 	jffsX-utils/compr.h \
-@@ -12,8 +15,13 @@ mkfs_jffs2_SOURCES = \
+@@ -10,8 +10,9 @@ mkfs_jffs2_SOURCES = \
  	jffsX-utils/summary.h \
  	include/linux/jffs2.h \
  	include/mtd/jffs2-user.h
-+
-+if !WITHOUT_LZO
-+mkfs_jffs2_SOURCES += jffsX-utils/compr_lzo.c
-+endif
 +
  mkfs_jffs2_LDADD = libmtd.a $(ZLIB_LIBS) $(LZO_LIBS)
 -mkfs_jffs2_CPPFLAGS = $(AM_CPPFLAGS) $(ZLIB_CFLAGS) $(LZO_CFLAGS)
@@ -27,36 +11,45 @@
  
  jffs2reader_SOURCES = jffsX-utils/jffs2reader.c	include/mtd/jffs2-user.h
  jffs2reader_LDADD = libmtd.a $(ZLIB_LIBS) $(LZO_LIBS)
+@@ -33,6 +34,14 @@ if WITH_ZLIB
+ mkfs_jffs2_SOURCES += jffsX-utils/compr_zlib.c
+ endif
+ 
++if WITH_LZMA
++mkfs_jffs2_SOURCES += \
++	jffsX-utils/compr_lzma.c \
++	jffsX-utils/lzma/LzFind.c \
++	jffsX-utils/lzma/LzmaEnc.c \
++	jffsX-utils/lzma/LzmaDec.c
++endif
++
+ EXTRA_DIST += jffsX-utils/device_table.txt jffsX-utils/mkfs.jffs2.1
+ 
+ dist_man1_MANS += jffsX-utils/mkfs.jffs2.1
 --- a/jffsX-utils/compr.c
 +++ b/jffsX-utils/compr.c
 @@ -520,6 +520,9 @@ int jffs2_compressors_init(void)
- #ifdef CONFIG_JFFS2_LZO
+ #ifdef WITH_LZO
  	jffs2_lzo_init();
  #endif
-+#ifdef CONFIG_JFFS2_LZMA
++#ifdef WITH_LZMA
 +	jffs2_lzma_init();
 +#endif
  	return 0;
  }
  
 @@ -534,5 +537,8 @@ int jffs2_compressors_exit(void)
- #ifdef CONFIG_JFFS2_LZO
+ #ifdef WITH_LZO
  	jffs2_lzo_exit();
  #endif
-+#ifdef CONFIG_JFFS2_LZMA
++#ifdef WITH_LZMA
 +	jffs2_lzma_exit();
 +#endif
  	return 0;
  }
 --- a/jffsX-utils/compr.h
 +++ b/jffsX-utils/compr.h
-@@ -18,13 +18,14 @@
- 
- #define CONFIG_JFFS2_ZLIB
- #define CONFIG_JFFS2_RTIME
--#define CONFIG_JFFS2_LZO
-+#define CONFIG_JFFS2_LZMA
- 
+@@ -21,8 +21,9 @@
  #define JFFS2_RUBINMIPS_PRIORITY 10
  #define JFFS2_DYNRUBIN_PRIORITY  20
  #define JFFS2_RTIME_PRIORITY     50
@@ -68,11 +61,11 @@
  
  #define JFFS2_COMPR_MODE_NONE       0
  #define JFFS2_COMPR_MODE_PRIORITY   1
-@@ -115,5 +116,10 @@ void jffs2_rtime_exit(void);
+@@ -113,5 +114,10 @@ void jffs2_rtime_exit(void);
  int jffs2_lzo_init(void);
  void jffs2_lzo_exit(void);
  #endif
-+#ifdef CONFIG_JFFS2_LZMA
++#ifdef WITH_LZMA
 +int jffs2_lzma_init(void);
 +void jffs2_lzma_exit(void);
 +#endif
@@ -5036,3 +5029,45 @@
  						  }
  						  break;
  					  }
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -19,6 +19,10 @@ if WITH_ZSTD
+ AM_CPPFLAGS += -DWITH_ZSTD
+ endif
+ 
++if WITH_LZMA
++AM_CPPFLAGS += -DWITH_LZMA
++endif
++
+ if WITH_SELINUX
+ AM_CPPFLAGS += -DWITH_SELINUX
+ endif
+--- a/configure.ac
++++ b/configure.ac
+@@ -96,6 +96,10 @@ AC_ARG_WITH([zstd],
+ 	[AS_HELP_STRING([--with-zstd], [Support for ZSTD compression])],
+ 	[], [with_zstd="check"])
+ 
++AC_ARG_WITH([lzma],
++	[AS_HELP_STRING([--with-lzma], [Support for LZMA compression])],
++	[], [with_lzma="check"])
++
+ AC_ARG_WITH([selinux],
+ 	[AS_HELP_STRING([--with-selinux],
+ 		[Support for selinux extended attributes])],
+@@ -268,6 +272,7 @@ fi
+ AM_CONDITIONAL([WITH_LZO], [test "x$with_lzo" = "xyes"])
+ AM_CONDITIONAL([WITH_ZLIB], [test "x$with_zlib" = "xyes"])
+ AM_CONDITIONAL([WITH_ZSTD], [test "x$with_zstd" = "xyes"])
++AM_CONDITIONAL([WITH_LZMA], [test "x$with_lzma" = "xyes"])
+ AM_CONDITIONAL([WITH_XATTR], [test "x$with_xattr" = "xyes"])
+ AM_CONDITIONAL([WITH_SELINUX], [test "x$with_selinux" = "xyes"])
+ AM_CONDITIONAL([WITH_CRYPTO], [test "x$with_crypto" = "xyes"])
+@@ -312,6 +317,7 @@ AC_MSG_RESULT([
+ 	lzo support:       ${with_lzo}
+ 	zlib support:      ${with_zlib}
+ 	zstd support:      ${with_zstd}
++	lzma support:      ${with_lzma}
+ 	xattr/acl support: ${with_xattr}
+ 	SELinux support:   ${with_selinux}
+ 	fscrypt support:   ${with_crypto}


### PR DESCRIPTION
Release notes:
https://lists.infradead.org/pipermail/linux-mtd/2024-March/104058.html

Manually refresh the portability and JFFS2 LZMA patches.

Since mtd-utils have converted most of the JFFS2 compressors to be compile
time configurable and manual refreshing of JFFS2 LZMA was needed I also
converted it to a compile time option and enabled the new --with-lzma
option.

While I was doing the updated, I also fixed the broken test compilation disable.
