### PR TITLE
build: add test for 64-bit time support

### DIFF
--- a/include/host-build.mk
+++ b/include/host-build.mk
@@ -67,6 +67,10 @@ HOST_CONFIGURE_ARGS = \
 	--localstatedir=$(HOST_BUILD_PREFIX)/var \
 	--sbindir=$(HOST_BUILD_PREFIX)/bin
 
+ifneq ($(YEAR_2038),y)
+  HOST_CONFIGURE_ARGS += --disable-year2038
+endif
+
 HOST_MAKE_VARS = \
 	CFLAGS="$(HOST_CFLAGS)" \
 	CPPFLAGS="$(HOST_CPPFLAGS)" \

--- a/tools/coreutils/Makefile
+++ b/tools/coreutils/Makefile
@@ -29,7 +29,6 @@ HOST_GNULIB_SKIP := \
 	lib/locale.in.h
 
 HOST_CONFIGURE_ARGS += \
-	--disable-year2038 \
 	 --enable-install-program=$(subst $(space),$(comma),$(strip $(PKG_PROGRAMS)))
 
 HOST_MAKE_FLAGS += \


### PR DESCRIPTION

this fixes some host tool builds on 32-bit arch/OS

Several GNU tools such as tar, coreutils, and findutils
now build with support for 64-bit time by default
and otherwise require reconfiguring with a flag
--disable-year2038 in order to build without 64-bit time.

This test using C code taken from largefile.m4 in gnulib
uses math and casting to check for overflow
with a macro and array pair that can only be defined
when 64-bit time support is present, and otherwise errors.
It is the exact same code used to test for 64-bit time
during the configure stage of building these tools,
so the results of this test before configure takes place
will always be in concordance with the results of
the test that takes place during the configure script.

Based on the test, the configure flag --disable-year2038
is added to every host tool build depending on the host system.