### PR TITLE
Delete invalid u3port status in mt7981.dtsi

### DIFF
--- a/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7981.dtsi
+++ b/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7981.dtsi
@@ -719,7 +719,6 @@
 			clock-names = "ref";
 			#phy-cells = <1>;
 			mediatek,syscon-type = <&topmisc 0x218 0>;
-			status = "okay";
 		};
 	};
 


### PR DESCRIPTION
In the device tree file mt7981.dtsi, already set the status of the parent device usb-phy to disabled, the child device u3port setting to okay is invalid. This submission has removed this invalid setting.