### PR TITLE
utils: mtd-utils: update to 2.2.0

### DIFF
--- a/package/utils/mtd-utils/Makefile
+++ b/package/utils/mtd-utils/Makefile
@@ -16,7 +16,6 @@ PKG_SOURCE_URL:=https://infraroot.at/pub/mtd/
 PKG_HASH:=c1d853bc4adf83bcabd2792fc95af33bdd8643c97e8f7b3f0180af36af76f0e5
 
 PKG_INSTALL:=1
-PKG_FIXUP:=autoreconf
 
 PKG_FLAGS:=nonshared
 PKG_BUILD_FLAGS:=gc-sections

--- a/package/utils/mtd-utils/Makefile
+++ b/package/utils/mtd-utils/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mtd-utils
-PKG_VERSION:=2.1.6
-PKG_RELEASE:=3
+PKG_VERSION:=2.2.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://infraroot.at/pub/mtd/
-PKG_HASH:=c1d853bc4adf83bcabd2792fc95af33bdd8643c97e8f7b3f0180af36af76f0e5
+PKG_HASH:=250d082f67375ca8451b5fcfc9a23a53ced3ebebd8312c288daf2507bbab1324
 
 PKG_INSTALL:=1
 
@@ -62,7 +62,8 @@ CONFIGURE_ARGS += \
 	--without-crypto \
 	--without-xattr \
 	--without-zstd \
-	--without-lzo
+	--without-lzo \
+	--without-zlib
 
 define Package/ubi-utils/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
Release notes:
https://lists.infradead.org/pipermail/linux-mtd/2024-March/104058.html

mtd-utils are currently depending on zlib, however it is not expressed as a dependency and it is somehow being only pulled-in by libncurses-devel so mtd-utils were able to compile.

Since 2.2.0 zlib is optional so lets disable support for it like for other compressors since we dont package the mkfs.ubifs or mkfs.jffs2 that are only users of compressors anyway.
