### PR TITLE
kernel: Delete invalid u3port status in mt7981.dtsi

### DIFF
--- a/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7981.dtsi
+++ b/target/linux/mediatek/files-5.15/arch/arm64/boot/dts/mediatek/mt7981.dtsi
@@ -719,7 +719,6 @@
 			clock-names = "ref";
 			#phy-cells = <1>;
 			mediatek,syscon-type = <&topmisc 0x218 0>;
-			status = "okay";
 		};
 	};
 


### PR DESCRIPTION
Since parent device usb-phy is set to diabled, child device u3port's status is invalid. This commission deletes the invalid status.