### PR TITLE
ramips: rb760igs: fix poe passthrough

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -7,7 +7,7 @@ board=$(board_name)
 
 case "$board" in
 mikrotik,routerboard-760igs)
-	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "497"
+	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "529"
 	;;
 telco-electronics,x1)
 	ucidef_add_gpio_switch "modem_reset" "Modem Reset" "496"


### PR DESCRIPTION
The gpio base on 6.6 is now 512 and the gpio for poe passthrough is 17, so use 529 instead of the previous 497
