### PR TITLE
uboot-rockchip: use u-boot-rockchip.bin

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -211,8 +211,7 @@ UBOOT_MAKE_FLAGS += \
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
-	$(CP) $(PKG_BUILD_DIR)/idbloader.img $(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)-idbloader.img
-	$(CP) $(PKG_BUILD_DIR)/u-boot.itb $(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)-u-boot.itb
+	$(CP) $(PKG_BUILD_DIR)/u-boot-rockchip.bin $(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)-u-boot-rockchip.bin
 endef
 
 define Package/u-boot/install/default

--- a/target/linux/rockchip/image/Makefile
+++ b/target/linux/rockchip/image/Makefile
@@ -29,7 +29,7 @@ define Build/pine64-img
 	# combining boot partition, root partition as well as the u-boot bootloader
 
 	# Generate a new partition table in $@ with 32 MiB of 
-	# alignment padding for the idbloader and u-boot to fit:
+	# alignment padding for the u-boot-rockchip.bin (idbloader + u-boot) to fit:
 	# http://opensource.rock-chips.com/wiki_Boot_option#Boot_flow
 	#
 	# U-Boot SPL expects the U-Boot ITB to be located at sector 0x4000 (8 MiB) on the MMC storage
@@ -39,9 +39,8 @@ define Build/pine64-img
 		$(CONFIG_TARGET_ROOTFS_PARTSIZE) $(IMAGE_ROOTFS) \
 		32768
 
-	# Copy the idbloader and the u-boot image to the image at sector 0x40 and 0x4000
-	dd if="$(STAGING_DIR_IMAGE)"/$(UBOOT_DEVICE_NAME)-idbloader.img of="$@" seek=64 conv=notrunc
-	dd if="$(STAGING_DIR_IMAGE)"/$(UBOOT_DEVICE_NAME)-u-boot.itb of="$@" seek=16384 conv=notrunc
+	# Copy the u-boot-rockchip.bin to the image at sector 0x40
+	dd if="$(STAGING_DIR_IMAGE)"/$(UBOOT_DEVICE_NAME)-u-boot-rockchip.bin of="$@" seek=64 conv=notrunc
 endef
 
 ### Devices ###


### PR DESCRIPTION
use u-boot-rockchip.bin to copy SPL/TPL/U-Boot to the image.

since binman was used in mainline u-boot for rockchip, we can use u-boot-rockchip.bin instead of idbloader.img and u-boot.itb.