### PR TITLE
hostapd: don't ignore probe-requests with invalid DSSS params 

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/patches/762-AP-don-t-ignore-probe-requests-with-invalid-DSSS-par.patch
+++ b/package/network/services/hostapd/patches/762-AP-don-t-ignore-probe-requests-with-invalid-DSSS-par.patch
@@ -1,0 +1,44 @@
+From a329773522953892d9bb4548482d42fc93fea329 Mon Sep 17 00:00:00 2001
+From: David Bauer <mail@david-bauer.net>
+Date: Thu, 27 Jun 2024 18:45:19 +0200
+Subject: [PATCH] AP: don't ignore probe-requests with invalid DSSS params
+
+Don't ignore probe requests which contain an invalid DS parameter for the
+current operating channel.
+
+As the comment outlines, the drop shall only apply if
+dot11RadioMeasurementActivated is set to 1.
+
+However, it was observed Linux clients (Debian 12 / NixOS 23.11)
+with an Intel 8265 NIC may generate a probe request frame with
+dot11RadioMeasurementActivated set to false and an invalid DSSS
+parameter.
+
+These were also dropped even though they should not have been. They
+however should not have contained this parameter in the first place.
+
+Don't drop Probe Requests which contain such an invalid field. This may
+lead to more probe responses being sent, however it does fix very
+frequent connection issues for these clients on 2.4 GHz.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+---
+ src/ap/beacon.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ap/beacon.c b/src/ap/beacon.c
+index 8cd1c4170..bb9329085 100644
+--- a/src/ap/beacon.c
++++ b/src/ap/beacon.c
+@@ -905,7 +905,7 @@ void handle_probe_req(struct hostapd_data *hapd,
+ 	 * is less likely to see them (Probe Request frame sent on a
+ 	 * neighboring, but partially overlapping, channel).
+ 	 */
+-	if (elems.ds_params &&
++	if (elems.ds_params && 0 &&
+ 	    hapd->iface->current_mode &&
+ 	    (hapd->iface->current_mode->mode == HOSTAPD_MODE_IEEE80211G ||
+ 	     hapd->iface->current_mode->mode == HOSTAPD_MODE_IEEE80211B) &&
+-- 
+2.43.0
+


### PR DESCRIPTION
Don't ignore probe requests which contain an invalid DS parameter for the
current operating channel.

As the comment outlines, the drop shall only apply if
dot11RadioMeasurementActivated is set to 1.

However, it was observed Linux clients (Debian 12 / NixOS 23.11)
with an Intel 8265 NIC may generate a probe request frame with
dot11RadioMeasurementActivated set to false and an invalid DSSS
parameter.

These were also dropped even though they should not have been. They
however should not have contained this parameter in the first place.

Don't drop Probe Requests which contain such an invalid field. This may
lead to more probe responses being sent, however it does fix very
frequent connection issues for these clients on 2.4 GHz.