### PR TITLE
include: autotools: do not symlink files in autoreconf

### DIFF
--- a/include/autotools.mk
+++ b/include/autotools.mk
@@ -44,7 +44,7 @@ define autoreconf
 				touch NEWS AUTHORS COPYING ABOUT-NLS ChangeLog; \
 				$(AM_TOOL_PATHS) \
 					LIBTOOLIZE='$(STAGING_DIR_HOST)/bin/libtoolize --install' \
-					$(STAGING_DIR_HOST)/bin/autoreconf -v -f -i -s \
+					$(STAGING_DIR_HOST)/bin/autoreconf -v -f -i \
 					$(if $(word 2,$(3)),--no-recursive) \
 					-B $(STAGING_DIR_HOST)/share/aclocal \
 					$(patsubst %,-I %,$(5)) \

--- a/tools/libtool/Makefile
+++ b/tools/libtool/Makefile
@@ -28,6 +28,7 @@ define Host/Bootstrap
 		cd $(HOST_BUILD_DIR); \
 		$(AM_TOOL_PATHS) \
 		./bootstrap \
+			--copy \
 			--force \
 			--skip-git \
 			--skip-po \


### PR DESCRIPTION
In Gluon's Github Actions CI, we were occasionally seeing bizarre build errors that looked like a config.sub file had been corrupted, or changed while it was being executed.

The cause turned out to be an interaction of the symlinks created by autoreconf (pointing from individual tools' build dirs into `staging_dir/host/share/automake-1.16`) and OpenWrt's host-build.mk, which replaced config.guess and config.sub *after* autoreconf. The result was that the replacement of these files ended up following the symlinks and writing the files in `staging_dir/host/share/automake-1.16` instead of a package's build dir. This could cause other packages' builds to fail if they were currently executing the scripts while they were being written.

To fix this, disable autoreconf's symlinking feature, so that modifying these files in a package's build directory can't accidentally affect the staged versions.

Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>