### PR TITLE
ramips: remove useless compatible strings from SoC dtsi

### DIFF
--- a/target/linux/ramips/dts/mt7620a.dtsi
+++ b/target/linux/ramips/dts/mt7620a.dtsi
@@ -48,7 +48,7 @@
 		};
 
 		timer: timer@100 {
-			compatible = "ralink,mt7620a-timer", "ralink,rt2880-timer";
+			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
 			clocks = <&sysc 5>;
@@ -58,7 +58,7 @@
 		};
 
 		watchdog: watchdog@120 {
-			compatible = "ralink,mt7620a-wdt", "ralink,rt2880-wdt";
+			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
 			clocks = <&sysc 6>;
@@ -71,7 +71,7 @@
 		};
 
 		intc: intc@200 {
-			compatible = "ralink,mt7620a-intc", "ralink,rt2880-intc";
+			compatible = "ralink,rt2880-intc";
 			reg = <0x200 0x100>;
 
 			interrupt-controller;
@@ -106,7 +106,7 @@
 		};
 
 		gpio0: gpio@600 {
-			compatible = "ralink,mt7620a-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x600 0x34>;
 
 			interrupt-parent = <&intc>;
@@ -123,7 +123,7 @@
 		};
 
 		gpio1: gpio@638 {
-			compatible = "ralink,mt7620a-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x638 0x24>;
 
 			interrupt-parent = <&intc>;
@@ -142,7 +142,7 @@
 		};
 
 		gpio2: gpio@660 {
-			compatible = "ralink,mt7620a-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x660 0x24>;
 
 			interrupt-parent = <&intc>;
@@ -161,7 +161,7 @@
 		};
 
 		gpio3: gpio@688 {
-			compatible = "ralink,mt7620a-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x688 0x24>;
 
 			interrupt-parent = <&intc>;
@@ -220,7 +220,7 @@
 		};
 
 		spi0: spi@b00 {
-			compatible = "ralink,mt7620a-spi", "ralink,rt2880-spi";
+			compatible = "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;
 
 			clocks = <&sysc 10>;
@@ -465,14 +465,14 @@
 		mediatek,switch = <&gsw>;
 
 		port@4 {
-			compatible = "mediatek,mt7620a-gsw-port", "mediatek,eth-port";
+			compatible = "mediatek,eth-port";
 			reg = <4>;
 
 			status = "disabled";
 		};
 
 		port@5 {
-			compatible = "mediatek,mt7620a-gsw-port", "mediatek,eth-port";
+			compatible = "mediatek,eth-port";
 			reg = <5>;
 
 			status = "disabled";

--- a/target/linux/ramips/dts/mt7620n.dtsi
+++ b/target/linux/ramips/dts/mt7620n.dtsi
@@ -48,7 +48,7 @@
 		};
 
 		timer: timer@100 {
-			compatible = "ralink,mt7620a-timer", "ralink,rt2880-timer";
+			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
 			clocks = <&sysc 5>;
@@ -58,7 +58,7 @@
 		};
 
 		watchdog: watchdog@120 {
-			compatible = "ralink,mt7620a-wdt", "ralink,rt2880-wdt";
+			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
 			clocks = <&sysc 6>;
@@ -71,7 +71,7 @@
 		};
 
 		intc: intc@200 {
-			compatible = "ralink,mt7620a-intc", "ralink,rt2880-intc";
+			compatible = "ralink,rt2880-intc";
 			reg = <0x200 0x100>;
 
 			interrupt-controller;
@@ -90,7 +90,7 @@
 		};
 
 		gpio0: gpio@600 {
-			compatible = "ralink,mt7620a-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x600 0x34>;
 
 			interrupt-parent = <&intc>;
@@ -107,7 +107,7 @@
 		};
 
 		gpio1: gpio@638 {
-			compatible = "ralink,mt7620a-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x638 0x24>;
 
 			interrupt-parent = <&intc>;
@@ -126,7 +126,7 @@
 		};
 
 		gpio2: gpio@660 {
-			compatible = "ralink,mt7620a-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x660 0x24>;
 
 			interrupt-parent = <&intc>;
@@ -145,7 +145,7 @@
 		};
 
 		gpio3: gpio@688 {
-			compatible = "ralink,mt7620a-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x688 0x24>;
 
 			interrupt-parent = <&intc>;
@@ -182,7 +182,7 @@
 		};
 
 		spi0: spi@b00 {
-			compatible = "ralink,mt7620a-spi", "ralink,rt2880-spi";
+			compatible = "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;
 
 			clocks = <&sysc 10>;

--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -52,7 +52,7 @@
 		};
 
 		intc: intc@200 {
-			compatible = "ralink,mt7628an-intc", "ralink,rt2880-intc";
+			compatible = "ralink,rt2880-intc";
 			reg = <0x200 0x100>;
 
 			interrupt-controller;
@@ -418,7 +418,7 @@
 	};
 
 	esw: esw@10110000 {
-		compatible = "mediatek,mt7628-esw", "ralink,rt3050-esw";
+		compatible = "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
 		resets = <&sysc 24>;

--- a/target/linux/ramips/dts/rt2880.dtsi
+++ b/target/linux/ramips/dts/rt2880.dtsi
@@ -218,7 +218,7 @@
 		status = "disabled";
 
 		port@0 {
-			compatible = "ralink,rt2880-port", "mediatek,eth-port";
+			compatible = "mediatek,eth-port";
 			reg = <0>;
 		};
 

--- a/target/linux/ramips/dts/rt3050.dtsi
+++ b/target/linux/ramips/dts/rt3050.dtsi
@@ -47,7 +47,7 @@
 		};
 
 		timer: timer@100 {
-			compatible = "ralink,rt3050-timer", "ralink,rt2880-timer";
+			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
 			clocks = <&sysc 3>;
@@ -57,7 +57,7 @@
 		};
 
 		watchdog: watchdog@120 {
-			compatible = "ralink,rt3050-wdt", "ralink,rt2880-wdt";
+			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
 			clocks = <&sysc 4>;
@@ -70,7 +70,7 @@
 		};
 
 		intc: intc@200 {
-			compatible = "ralink,rt3050-intc", "ralink,rt2880-intc";
+			compatible = "ralink,rt2880-intc";
 			reg = <0x200 0x100>;
 
 			interrupt-controller;
@@ -89,7 +89,7 @@
 		};
 
 		uart: uart@500 {
-			compatible = "ralink,rt3050-uart", "ralink,rt2880-uart", "ns16550a";
+			compatible = "ralink,rt3052-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0x500 0x100>;
 
 			clocks = <&sysc 5>;
@@ -105,7 +105,7 @@
 		};
 
 		gpio0: gpio@600 {
-			compatible = "ralink,rt3050-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x600 0x34>;
 
 			gpio-controller;
@@ -122,7 +122,7 @@
 		};
 
 		gpio1: gpio@638 {
-			compatible = "ralink,rt3050-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x638 0x24>;
 
 			gpio-controller;
@@ -138,7 +138,7 @@
 		};
 
 		gpio2: gpio@660 {
-			compatible = "ralink,rt3050-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x660 0x24>;
 
 			gpio-controller;
@@ -209,7 +209,7 @@
 		};
 
 		spi0: spi@b00 {
-			compatible = "ralink,rt3050-spi", "ralink,rt2880-spi";
+			compatible = "ralink,rt2880-spi";
 			reg = <0xb00 0x100>;
 
 			resets = <&sysc 18>;
@@ -227,7 +227,7 @@
 		};
 
 		uartlite: uartlite@c00 {
-			compatible = "ralink,rt3050-uart", "ralink,rt2880-uart", "ns16550a";
+			compatible = "ralink,rt3052-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
 
 			clocks = <&sysc 10>;

--- a/target/linux/ramips/dts/rt3352.dtsi
+++ b/target/linux/ramips/dts/rt3352.dtsi
@@ -48,7 +48,7 @@
 		};
 
 		timer: timer@100 {
-			compatible = "ralink,rt3352-timer", "ralink,rt2880-timer";
+			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
 			clocks = <&sysc 4>;
@@ -58,7 +58,7 @@
 		};
 
 		watchdog: watchdog@120 {
-			compatible = "ralink,rt3352-wdt", "ralink,rt2880-wdt";
+			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
 			clocks = <&sysc 5>;
@@ -71,7 +71,7 @@
 		};
 
 		intc: intc@200 {
-			compatible = "ralink,rt3352-intc", "ralink,rt2880-intc";
+			compatible = "ralink,rt2880-intc";
 			reg = <0x200 0x100>;
 
 			interrupt-controller;
@@ -82,7 +82,7 @@
 		};
 
 		memc: memc@300 {
-			compatible = "ralink,rt3352-memc", "ralink,rt3050-memc";
+			compatible = "ralink,rt3050-memc";
 			reg = <0x300 0x100>;
 
 			interrupt-parent = <&intc>;
@@ -90,7 +90,7 @@
 		};
 
 		uart: uart@500 {
-			compatible = "ralink,rt3352-uart", "ralink,rt2880-uart", "ns16550a";
+			compatible = "ralink,rt3052-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0x500 0x100>;
 
 			clocks = <&sysc 6>;
@@ -106,7 +106,7 @@
 		};
 
 		gpio0: gpio@600 {
-			compatible = "ralink,rt3352-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x600 0x34>;
 
 			gpio-controller;
@@ -123,7 +123,7 @@
 		};
 
 		gpio1: gpio@638 {
-			compatible = "ralink,rt3352-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x638 0x24>;
 
 			gpio-controller;
@@ -139,7 +139,7 @@
 		};
 
 		gpio2: gpio@660 {
-			compatible = "ralink,rt3352-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x660 0x24>;
 
 			gpio-controller;
@@ -195,7 +195,7 @@
 		};
 
 		spi0: spi@b00 {
-			compatible = "ralink,rt3352-spi", "ralink,rt2880-spi";
+			compatible = "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -212,7 +212,7 @@
 		};
 
 		spi1: spi@b40 {
-			compatible = "ralink,rt3352-spi", "ralink,rt2880-spi";
+			compatible = "ralink,rt2880-spi";
 			reg = <0xb40 0x60>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -227,7 +227,7 @@
 		};
 
 		uartlite: uartlite@c00 {
-			compatible = "ralink,rt3352-uart", "ralink,rt2880-uart", "ns16550a";
+			compatible = "ralink,rt3052-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
 
 			clocks = <&sysc 11>;
@@ -314,7 +314,7 @@
 	};
 
 	ethernet: ethernet@10100000 {
-		compatible = "ralink,rt3352-eth", "ralink,rt3050-eth";
+		compatible = "ralink,rt3050-eth";
 		reg = <0x10100000 0x10000>;
 
 		clocks = <&sysc 12>;
@@ -329,7 +329,7 @@
 	};
 
 	esw: esw@10110000 {
-		compatible = "ralink,rt3352-esw", "ralink,rt3050-esw";
+		compatible = "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
 		resets = <&sysc 24>;

--- a/target/linux/ramips/dts/rt3883.dtsi
+++ b/target/linux/ramips/dts/rt3883.dtsi
@@ -48,7 +48,7 @@
 		};
 
 		timer: timer@100 {
-			compatible = "ralink,rt3883-timer", "ralink,rt2880-timer";
+			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
 			clocks = <&sysc 3>;
@@ -58,7 +58,7 @@
 		};
 
 		watchdog: watchdog@120 {
-			compatible = "ralink,rt3883-wdt", "ralink,rt2880-wdt";
+			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
 			clocks = <&sysc 4>;
@@ -71,7 +71,7 @@
 		};
 
 		intc: intc@200 {
-			compatible = "ralink,rt3883-intc", "ralink,rt2880-intc";
+			compatible = "ralink,rt2880-intc";
 			reg = <0x200 0x100>;
 
 			interrupt-controller;
@@ -106,7 +106,7 @@
 		};
 
 		gpio0: gpio@600 {
-			compatible = "ralink,rt3883-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x600 0x34>;
 
 			interrupt-parent = <&intc>;
@@ -123,7 +123,7 @@
 		};
 
 		gpio1: gpio@638 {
-			compatible = "ralink,rt3883-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x638 0x24>;
 
 			gpio-controller;
@@ -139,7 +139,7 @@
 		};
 
 		gpio2: gpio@660 {
-			compatible = "ralink,rt3883-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x660 0x24>;
 
 			gpio-controller;
@@ -155,7 +155,7 @@
 		};
 
 		gpio3: gpio@688 {
-			compatible = "ralink,rt3883-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x688 0x24>;
 
 			gpio-controller;
@@ -211,7 +211,7 @@
 		};
 
 		spi0: spi@b00 {
-			compatible = "ralink,rt3883-spi", "ralink,rt2880-spi";
+			compatible = "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -228,7 +228,7 @@
 		};
 
 		spi1: spi@b40 {
-			compatible = "ralink,rt3883-spi", "ralink,rt2880-spi";
+			compatible = "ralink,rt2880-spi";
 			reg = <0xb40 0x60>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -339,7 +339,7 @@
 		interrupts = <5>;
 
 		port@0 {
-			compatible = "ralink,rt3883-port", "mediatek,eth-port";
+			compatible = "mediatek,eth-port";
 			reg = <0>;
 		};
 

--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -48,7 +48,7 @@
 		};
 
 		timer: timer@100 {
-			compatible = "ralink,rt5350-timer", "ralink,rt2880-timer";
+			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
 			clocks = <&sysc 4>;
@@ -58,7 +58,7 @@
 		};
 
 		watchdog: watchdog@120 {
-			compatible = "ralink,rt5350-wdt", "ralink,rt2880-wdt";
+			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
 			clocks = <&sysc 5>;
@@ -71,7 +71,7 @@
 		};
 
 		intc: intc@200 {
-			compatible = "ralink,rt5350-intc", "ralink,rt2880-intc";
+			compatible = "ralink,rt2880-intc";
 			reg = <0x200 0x100>;
 
 			interrupt-controller;
@@ -90,7 +90,7 @@
 		};
 
 		uart: uart@500 {
-			compatible = "ralink,rt5350-uart", "ralink,rt2880-uart", "ns16550a";
+			compatible = "ralink,rt3052-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0x500 0x100>;
 
 			clocks = <&sysc 6>;
@@ -106,7 +106,7 @@
 		};
 
 		gpio0: gpio@600 {
-			compatible = "ralink,rt5350-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x600 0x34>;
 
 			interrupt-parent = <&intc>;
@@ -123,7 +123,7 @@
 		};
 
 		gpio1: gpio@660 {
-			compatible = "ralink,rt5350-gpio", "ralink,rt2880-gpio";
+			compatible = "ralink,rt2880-gpio";
 			reg = <0x660 0x24>;
 
 			interrupt-parent = <&intc>;
@@ -182,7 +182,7 @@
 		};
 
 		spi0: spi@b00 {
-			compatible = "ralink,rt5350-spi", "ralink,rt2880-spi";
+			compatible = "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;
 
 			clocks = <&sysc 9>;
@@ -200,7 +200,7 @@
 		};
 
 		spi1: spi@b40 {
-			compatible = "ralink,rt5350-spi", "ralink,rt2880-spi";
+			compatible = "ralink,rt2880-spi";
 			reg = <0xb40 0x60>;
 
 			clocks = <&sysc 10>;
@@ -218,7 +218,7 @@
 		};
 
 		uartlite: uartlite@c00 {
-			compatible = "ralink,rt5350-uart", "ralink,rt2880-uart", "ns16550a";
+			compatible = "ralink,rt3052-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
 
 			clocks = <&sysc 11>;
@@ -350,7 +350,7 @@
 	};
 
 	esw: esw@10110000 {
-		compatible = "ralink,rt5350-esw", "ralink,rt3050-esw";
+		compatible = "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
 		resets = <&sysc 24>;

--- a/target/linux/ramips/patches-6.6/801-DT-Add-documentation-for-gpio-ralink.patch
+++ b/target/linux/ramips/patches-6.6/801-DT-Add-documentation-for-gpio-ralink.patch
@@ -40,7 +40,7 @@ Cc: linux-gpio@vger.kernel.org
 +Example:
 +
 +	gpio0: gpio@600 {
-+		compatible = "ralink,rt5350-gpio", "ralink,rt2880-gpio";
++		compatible = "ralink,rt2880-gpio";
 +
 +		#gpio-cells = <2>;
 +		gpio-controller;


### PR DESCRIPTION
These removed compatible strings do not exist in the source code nor the dt-binding documents. They are useless.
