### PR TITLE
ipq40xx: ipqess: pass up ethdev_addr probe defer

### DIFF
--- a/target/linux/ipq40xx/patches-6.6/700-net-ipqess-introduce-the-Qualcomm-IPQESS-driver.patch
+++ b/target/linux/ipq40xx/patches-6.6/700-net-ipqess-introduce-the-Qualcomm-IPQESS-driver.patch
@@ -655,7 +655,7 @@ Signed-off-by: Maxime Chevallier <maxime.chevallier@bootlin.com>
 +	}
 +}
 +
-+static int __init ipqess_init(struct net_device *netdev)
++static int ipqess_init(struct net_device *netdev)
 +{
 +	struct ipqess *ess = netdev_priv(netdev);
 +	struct device_node *of_node = ess->pdev->dev.of_node;

--- a/target/linux/ipq40xx/patches-6.6/700-net-ipqess-introduce-the-Qualcomm-IPQESS-driver.patch
+++ b/target/linux/ipq40xx/patches-6.6/700-net-ipqess-introduce-the-Qualcomm-IPQESS-driver.patch
@@ -88,7 +88,7 @@ Signed-off-by: Maxime Chevallier <maxime.chevallier@bootlin.com>
 +ipq_ess-objs := ipqess.o ipqess_ethtool.o
 --- /dev/null
 +++ b/drivers/net/ethernet/qualcomm/ipqess/ipqess.c
-@@ -0,0 +1,1246 @@
+@@ -0,0 +1,1251 @@
 +// SPDX-License-Identifier: GPL-2.0 OR ISC
 +/* Copyright (c) 2014 - 2017, The Linux Foundation. All rights reserved.
 + * Copyright (c) 2017 - 2018, John Crispin <john@phrozen.org>
@@ -659,11 +659,6 @@ Signed-off-by: Maxime Chevallier <maxime.chevallier@bootlin.com>
 +{
 +	struct ipqess *ess = netdev_priv(netdev);
 +	struct device_node *of_node = ess->pdev->dev.of_node;
-+	int ret;
-+
-+	ret = of_get_ethdev_address(of_node, netdev);
-+	if (ret)
-+		eth_hw_addr_random(netdev);
 +
 +	return phylink_of_phy_connect(ess->phylink, of_node, 0);
 +}
@@ -1200,6 +1195,16 @@ Signed-off-by: Maxime Chevallier <maxime.chevallier@bootlin.com>
 +	spin_lock_init(&ess->stats_lock);
 +	SET_NETDEV_DEV(netdev, &pdev->dev);
 +	platform_set_drvdata(pdev, netdev);
++
++	err = of_get_ethdev_address(np, netdev);
++	if (err) {
++		dev_dbg(&pdev->dev, "failed to get MAC address from DT: %d\n", err);
++		if (err == -EPROBE_DEFER)
++			return err;
++		eth_hw_addr_random(netdev);
++		dev_info(&pdev->dev, "using random MAC address %pM\n",
++			 netdev->dev_addr);
++	}
 +
 +	ess->hw_addr = devm_platform_get_and_ioremap_resource(pdev, 0, NULL);
 +	if (IS_ERR(ess->hw_addr))

--- a/target/linux/ipq40xx/patches-6.6/702-net-ipqess-Add-out-of-band-DSA-tagging-support.patch
+++ b/target/linux/ipq40xx/patches-6.6/702-net-ipqess-Add-out-of-band-DSA-tagging-support.patch
@@ -72,7 +72,7 @@ Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
  		napi_gro_receive(&rx_ring->napi_rx, skb);
  
  		rx_ring->ess->stats.rx_packets++;
-@@ -706,6 +715,26 @@ static void ipqess_rollback_tx(struct ip
+@@ -701,6 +710,26 @@ static void ipqess_rollback_tx(struct ip
  	tx_ring->head = start_index;
  }
  
@@ -99,7 +99,7 @@ Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
  static int ipqess_tx_map_and_fill(struct ipqess_tx_ring *tx_ring,
  				  struct sk_buff *skb)
  {
-@@ -716,6 +745,8 @@ static int ipqess_tx_map_and_fill(struct
+@@ -711,6 +740,8 @@ static int ipqess_tx_map_and_fill(struct
  	u16 len;
  	int i;
  
@@ -108,7 +108,7 @@ Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
  	if (skb_is_gso(skb)) {
  		if (skb_shinfo(skb)->gso_type & SKB_GSO_TCPV4) {
  			lso_word1 |= IPQESS_TPD_IPV4_EN;
-@@ -917,6 +948,33 @@ static const struct net_device_ops ipqes
+@@ -912,6 +943,33 @@ static const struct net_device_ops ipqes
  	.ndo_tx_timeout		= ipqess_tx_timeout,
  };
  
@@ -142,7 +142,7 @@ Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
  static void ipqess_hw_stop(struct ipqess *ess)
  {
  	int i;
-@@ -1184,12 +1242,19 @@ static int ipqess_axi_probe(struct platf
+@@ -1189,12 +1247,19 @@ static int ipqess_axi_probe(struct platf
  		netif_napi_add(netdev, &ess->rx_ring[i].napi_rx, ipqess_rx_napi);
  	}
  

--- a/target/linux/ipq40xx/patches-6.6/703-net-qualcomm-ipqess-release-IRQ-s-on-network-device-.patch
+++ b/target/linux/ipq40xx/patches-6.6/703-net-qualcomm-ipqess-release-IRQ-s-on-network-device-.patch
@@ -50,7 +50,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 
 --- a/drivers/net/ethernet/qualcomm/ipqess/ipqess.c
 +++ b/drivers/net/ethernet/qualcomm/ipqess/ipqess.c
-@@ -636,9 +636,22 @@ static int ipqess_stop(struct net_device
+@@ -631,9 +631,22 @@ static int ipqess_stop(struct net_device
  	netif_tx_stop_all_queues(netdev);
  	phylink_stop(ess->phylink);
  	ipqess_irq_disable(ess);

--- a/target/linux/ipq40xx/patches-6.6/704-net-qualcomm-ipqess-enable-threaded-NAPI-by-default.patch
+++ b/target/linux/ipq40xx/patches-6.6/704-net-qualcomm-ipqess-enable-threaded-NAPI-by-default.patch
@@ -38,7 +38,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  	}
  
  	return IRQ_HANDLED;
-@@ -1264,6 +1264,8 @@ static int ipqess_axi_probe(struct platf
+@@ -1269,6 +1269,8 @@ static int ipqess_axi_probe(struct platf
  	if (err)
  		goto err_notifier_unregister;
  


### PR DESCRIPTION
Notify via dev_info when a random MAC address is set.
of_get_ethdev_address can return -EPROBE_DEFER for NVMEM devices, return this up, so that ipqess can defer as well.
Also move this MAC assignment from _init into _probe, so that this defer can happen earlier.

Before change, with MAC address allocated from a built-in NVMEM layout driver (mikrotik,routerboot-nvmem) with extra of_get_ethdev_address result and random MAC printfs:
```
[    1.197571] ipqess-edma c080000.ethernet: ipqess_init of_get_ethdev_address ret:-517, of_node: /soc/ethernet@c080000
[    1.197690] ipqess-edma c080000.ethernet: generated random MAC address 22:e7:36:e0:e4:a3
[    1.614444] ipqess-edma c080000.ethernet eth0: entered promiscuous mode
[    5.055929] ipqess-edma c080000.ethernet eth0: configuring for fixed/internal link mode
```
after change:
```
[    1.173776] ipqess-edma c080000.ethernet: of_get_ethdev_address: -517
[    1.614607] ipqess-edma c080000.ethernet eth0: entered promiscuous mode
[    5.246105] ipqess-edma c080000.ethernet eth0: configuring for fixed/internal link mode
[    5.260754] ipqess-edma c080000.ethernet eth0: Link is Up - 1Gbps/Full - flow control rx/tx
```
with extra __func__ printf to show _probe and _init:
```
[    1.173685] ipqess-edma c080000.ethernet: ipqess_axi_probe
[    1.173784] ipqess-edma c080000.ethernet: of_get_ethdev_address: -517
[    1.280347] ipqess-edma c080000.ethernet: ipqess_axi_probe
[    1.304844] ipqess-edma c080000.ethernet: ipqess_init
[    1.614664] ipqess-edma c080000.ethernet eth0: entered promiscuous mode
```