### PR TITLE
ipq807x: add support for TP-Link EAP660 HD v1

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq807x
@@ -38,7 +38,8 @@ linksys,mx8500)
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000" "2"
 	;;
 netgear,sxr80|\
-netgear,sxs80)
+netgear,sxs80|\
+tplink,eap660hd-v1)
 	idx="$(find_mtd_index 0:appsblenv)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000"

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -52,6 +52,7 @@ ALLWIFIBOARDS:= \
 	qnap_301w \
 	redmi_ax6 \
 	spectrum_sax1v1k \
+	tplink_eap660hd-v1 \
 	wallys_dr40x9 \
 	xiaomi_ax3600 \
 	xiaomi_ax9000 \
@@ -177,6 +178,7 @@ $(eval $(call generate-ipq-wifi-package,qnap_301w,QNAP 301w))
 $(eval $(call generate-ipq-wifi-package,prpl_haze,prpl Haze))
 $(eval $(call generate-ipq-wifi-package,redmi_ax6,Redmi AX6))
 $(eval $(call generate-ipq-wifi-package,spectrum_sax1v1k,Spectrum SAX1V1K))
+$(eval $(call generate-ipq-wifi-package,tplink_eap660hd-v1,TP-Link EAP660 HD v1))
 $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax3600,Xiaomi AX3600))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax9000,Xiaomi AX9000))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-eap660hd-v1.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-eap660hd-v1.dts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR BSD-2-Clause
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	model = "TP-Link EAP660 HD v1";
+	compatible = "tplink,eap660hd-v1", "qcom,ipq8074";
+
+	aliases {
+		serial0 = &blsp1_uart5;
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+	};
+
+	chosen {
+		stdout-path = "serial0,115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status-blue {
+			function = LED_FUNCTION_STATUS;
+			gpios = <&tlmm 42 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+		};
+	};
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
+	
+	qca8081_28: ethernet-phy@28 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <28>;
+	};
+};
+
+&dp5 {
+	status = "okay";
+	phy-mode = "sgmii";
+	phy-handle = <&qca8081_28>;
+	label = "lan";
+};
+
+&switch {
+	status = "okay";
+	switch_lan_bmp = <ESS_PORT5>;
+	switch_mac_mode1 = <MAC_MODE_SGMII_PLUS>;
+
+	qcom,port_phyinfo {
+		port@5 {
+			phy_address = <28>;
+			port_id = <5>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+	qcom,ath11k-calibration-variant = "TP-Link-EAP660-HD-v1";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -344,6 +344,20 @@ define Device/spectrum_sax1v1k
 endef
 TARGET_DEVICES += spectrum_sax1v1k
 
+define Device/tplink_eap660hd-v1
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := TP-Link
+	DEVICE_MODEL := EAP660 HD
+	DEVICE_VARIANT := v1
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	SOC := ipq8072
+	DEVICE_PACKAGES := ipq-wifi-tplink_eap660hd-v1
+	TPLINK_SUPPORT_STRING := SupportList:\r\nEAP660 HD(TP-Link|UN|AX3600-D):1.0\r\n
+endef
+TARGET_DEVICES += tplink_eap660hd-v1
+
 define Device/xiaomi_ax3600
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -60,6 +60,9 @@ ipq807x_setup_interfaces()
 	qnap,301w)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 10g-2" "10g-1"
 		;;
+	tplink,eap660hd-v1)
+		ucidef_set_interface_lan "lan" "dhcp"
+		;;
 	zyxel,nbg7815)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 10g" "wan"
 		;;
@@ -88,6 +91,10 @@ ipq807x_setup_macs()
 			label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 			lan_mac=$(macaddr_add $label_mac 1)
 			wan_mac=$label_mac
+		;;
+		tplink,eap660hd-v1)
+			label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
+			lan_mac=$label_mac
 		;;
 	esac
 

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -80,6 +80,13 @@ case "$FIRMWARE" in
 	spectrum,sax1v1k)
 		caldata_extract_mmc "0:ART" 0x1000 0x20000
 		;;
+	tplink,eap660hd-v1)
+		caldata_from_file "/tmp/factory_data/radio" 0 0x20000
+		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
+		ath11k_patch_mac $label_mac 1
+		ath11k_patch_mac $(macaddr_add $label_mac 1) 0
+		ath11k_set_macflag
+		;;
 	zbtlink,zbt-z800ax)
 		caldata_extract "0:art" 0x1000 0x20000
 		label_mac=$(get_mac_label)

--- a/target/linux/qualcommax/ipq807x/base-files/lib/preinit/09_mount_factory_data
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/preinit/09_mount_factory_data
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+preinit_mount_factory_data() {
+	local mtd_path
+
+	. /lib/functions.sh
+	. /lib/functions/system.sh
+
+	case $(board_name) in
+	tplink,eap660hd-v1)
+		mtd_path=$(find_mtd_chardev "factory_data")
+		ubiattach --dev-path="$mtd_path" --devn=1
+		mkdir /tmp/factory_data
+		mount -o ro,noatime -t ubifs ubi1:ubi_factory_data /tmp/factory_data
+		;;
+	esac
+}
+
+boot_hook_add preinit_main preinit_mount_factory_data


### PR DESCRIPTION
Specifications:
* SoC: Qualcomm IPQ8072A (64-bit Quad-core Arm Cortex-A53 @ 1651MHz)
* Memory: 2x ESMT M15T4G16256A-DEBG2G (1 GiB DDR3-1866 13-13-13)
* Serial Port: 3v3 TTL 115200n8
* Wi-Fi: QCN5054 (4x4 5 GHz 802.11ax)
* Wi-Fi: QCN5024 (4x4 2.4 GHz 802.11b/g/n/ax)
* Ethernet: QCA8081 (10/100/1000/2.5GBASE-T)
* Flash: Winbond W29N01HZSINF (128 MiB)
* LEDs: 1x Blue Status (GPIO 42 Active High)
* Buttons: 1x Reset (GPIO 50 Active Low)

Installation Instructions (Serial+TFTP):
1. Solder 4 pin header to JP1 and bridge pads of R58 and R62.
2. Connect 3V3 TTL port to TX, RX, and GND, which are positions 1, 2, and 3 respectively. Be sure to crossover TX and RX.
3. Copy RAM firmware image openwrt-qualcommax-ipq807x-tplink_eap660hd-v1-initramfs-uImage.itb to TFTP server root, available at 192.168.10.1.
4. Connect PoE ethernet cable to the RJ45 port and hold Ctrl+B in the serial console (115200 baud) until autoboot is halted.
5. Run the following commands in the U-boot prompt: 
    ```
    tftpboot 0x44000000 openwrt-qualcommax-ipq807x-tplink_eap660hd-v1-initramfs-uImage.itb
    bootm
    ```
    You may need to type Ctrl+C and Enter before running these commands to clear invisible characters from the buffer.
6. Run the following command in a terminal to copy the sysupgrade image to be installed:
    ```
    scp openwrt-qualcommax-ipq807x-tplink_eap660hd-v1-squashfs-sysupgrade.bin root@192.168.1.1:/tmp/
    ```
7. Activate the OpenWrt serial console and run the following commands:
    ```
    cd /tmp
    sysupgrade -n openwrt-qualcommax-ipq807x-tplink_eap660hd-v1-squashfs-sysupgrade.bin
    ```
8. The AP will reboot and OpenWrt will be successfully installed.