### PR TITLE
kernel: Misc package fixups

### DIFF
--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -253,8 +253,6 @@ $(eval $(call nf_add,IPT_LED,CONFIG_NETFILTER_XT_TARGET_LED, $(P_XT)xt_LED))
 # tee
 
 $(eval $(call nf_add,IPT_TEE,CONFIG_NETFILTER_XT_TARGET_TEE, $(P_XT)xt_TEE))
-$(eval $(if $(NF_KMOD),$(call nf_add,IPT_TEE,CONFIG_NF_DUP_IPV4, $(P_V4)nf_dup_ipv4),))
-$(eval $(if $(NF_KMOD),$(call nf_add,IPT_TEE,CONFIG_NF_DUP_IPV6, $(P_V6)nf_dup_ipv6),))
 
 # u32
 

--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -81,6 +81,18 @@ endef
 $(eval $(call KernelPackage,crypto-authenc))
 
 
+define KernelPackage/crypto-blake2b
+  TITLE:=Support for BLAKE2b cryptographic hash function (RFC 7693)
+  DEPENDS:=+kmod-crypto-hash
+  KCONFIG:=CONFIG_CRYPTO_BLAKE2B
+  FILES:=$(LINUX_DIR)/crypto/blake2b_generic.ko
+  AUTOLOAD:=$(call AutoLoad,09,blake2b_generic)
+  $(call AddDepends/crypto)
+endef
+
+$(eval $(call KernelPackage,crypto-blake2b))
+
+
 define KernelPackage/crypto-cbc
   TITLE:=Cipher Block Chaining CryptoAPI module
   DEPENDS:=+kmod-crypto-manager

--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -1170,3 +1170,15 @@ endef
 
 $(eval $(call KernelPackage,crypto-xts))
 
+
+define KernelPackage/crypto-xxhash
+  TITLE:=xxHash non-cryptographic hash algorithm
+  DEPENDS:=+kmod-crypto-hash +kmod-lib-xxhash
+  KCONFIG:=CONFIG_CRYPTO_XXHASH
+  FILES:=$(LINUX_DIR)/crypto/xxhash_generic.ko
+  AUTOLOAD:=$(call AutoLoad,09,xxhash_generic)
+  $(call AddDepends/crypto)
+endef
+
+$(eval $(call KernelPackage,crypto-xxhash))
+

--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -67,7 +67,7 @@ $(eval $(call KernelPackage,fs-autofs4))
 define KernelPackage/fs-btrfs
   SUBMENU:=$(FS_MENU)
   TITLE:=BTRFS filesystem support
-  DEPENDS:=+kmod-lib-crc32c +kmod-lib-lzo +kmod-lib-zlib-inflate +kmod-lib-zlib-deflate +kmod-lib-raid6 +kmod-lib-xor +kmod-lib-zstd
+  DEPENDS:=+kmod-lib-crc32c +kmod-lib-lzo +kmod-lib-zlib-inflate +kmod-lib-zlib-deflate +kmod-lib-raid6 +kmod-lib-xor +kmod-lib-zstd +kmod-crypto-blake2b
   KCONFIG:=\
 	CONFIG_BTRFS_FS \
 	CONFIG_BTRFS_FS_CHECK_INTEGRITY=n

--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -67,7 +67,7 @@ $(eval $(call KernelPackage,fs-autofs4))
 define KernelPackage/fs-btrfs
   SUBMENU:=$(FS_MENU)
   TITLE:=BTRFS filesystem support
-  DEPENDS:=+kmod-lib-crc32c +kmod-lib-lzo +kmod-lib-zlib-inflate +kmod-lib-zlib-deflate +kmod-lib-raid6 +kmod-lib-xor +kmod-lib-zstd +kmod-crypto-blake2b
+  DEPENDS:=+kmod-lib-crc32c +kmod-lib-lzo +kmod-lib-zlib-inflate +kmod-lib-zlib-deflate +kmod-lib-raid6 +kmod-lib-xor +kmod-lib-zstd +kmod-crypto-blake2b +kmod-crypto-xxhash
   KCONFIG:=\
 	CONFIG_BTRFS_FS \
 	CONFIG_BTRFS_FS_CHECK_INTEGRITY=n

--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -148,7 +148,7 @@ define KernelPackage/hwmon-gsc
 	$(LINUX_DIR)/drivers/mfd/gateworks-gsc.ko \
 	$(LINUX_DIR)/drivers/hwmon/gsc-hwmon.ko
   AUTOLOAD:=$(call AutoLoad,20,gsc-hwmon,1)
-  $(call AddDepends/hwmon,+kmod-i2c-core)
+  $(call AddDepends/hwmon,+kmod-i2c-core +kmod-mfd)
 endef
 
 define KernelPackage/hwmon-gsc/description

--- a/package/kernel/linux/modules/lib.mk
+++ b/package/kernel/linux/modules/lib.mk
@@ -147,21 +147,28 @@ endef
 $(eval $(call KernelPackage,lib-zstd))
 
 
+define KernelPackage/lib-lz4-decompress
+  SUBMENU:=$(LIB_MENU)
+  TITLE:=LZ4 decompress
+  HIDDEN:=1
+  KCONFIG:=CONFIG_LZ4_DECOMPRESS
+  FILES:=$(LINUX_DIR)/lib/lz4/lz4_decompress.ko
+endef
+
+$(eval $(call KernelPackage,lib-lz4-decompress))
+
+
 define KernelPackage/lib-lz4
   SUBMENU:=$(LIB_MENU)
   TITLE:=LZ4 support
-  DEPENDS:=+kmod-crypto-acompress
+  DEPENDS:=+kmod-crypto-acompress +kmod-lib-lz4-decompress
   KCONFIG:= \
 	CONFIG_CRYPTO_LZ4 \
-	CONFIG_CRYPTO_LZ4HC \
-	CONFIG_LZ4_COMPRESS \
-	CONFIG_LZ4_DECOMPRESS
+	CONFIG_LZ4_COMPRESS
   FILES:= \
 	$(LINUX_DIR)/crypto/lz4.ko \
-	$(LINUX_DIR)/lib/lz4/lz4_compress.ko \
-	$(LINUX_DIR)/lib/lz4/lz4hc_compress.ko \
-	$(LINUX_DIR)/lib/lz4/lz4_decompress.ko
-  AUTOLOAD:=$(call AutoProbe,lz4 lz4_compress lz4hc_compress lz4_decompress)
+	$(LINUX_DIR)/lib/lz4/lz4_compress.ko
+  AUTOLOAD:=$(call AutoProbe,lz4 lz4_compress)
 endef
 
 define KernelPackage/lib-lz4/description
@@ -169,6 +176,26 @@ define KernelPackage/lib-lz4/description
 endef
 
 $(eval $(call KernelPackage,lib-lz4))
+
+
+define KernelPackage/lib-lz4hc
+  SUBMENU:=$(LIB_MENU)
+  TITLE:=LZ4HC support
+  DEPENDS:=+kmod-crypto-acompress +kmod-lib-lz4-decompress
+  KCONFIG:= \
+	CONFIG_CRYPTO_LZ4HC \
+	CONFIG_LZ4HC_COMPRESS
+  FILES:= \
+	$(LINUX_DIR)/crypto/lz4hc.ko \
+	$(LINUX_DIR)/lib/lz4/lz4hc_compress.ko
+  AUTOLOAD:=$(call AutoProbe,lz4hc lz4hc_compress)
+endef
+
+define KernelPackage/lib-lz4hc/description
+ Kernel module for LZ4HC compression/decompression support
+endef
+
+$(eval $(call KernelPackage,lib-lz4hc))
 
 
 define KernelPackage/lib-842

--- a/package/kernel/linux/modules/lib.mk
+++ b/package/kernel/linux/modules/lib.mk
@@ -122,22 +122,31 @@ endef
 $(eval $(call KernelPackage,lib-lzo))
 
 
+define KernelPackage/lib-xxhash
+  SUBMENU:=$(LIB_MENU)
+  TITLE:=xxhash support
+  HIDDEN:=1
+  KCONFIG:=CONFIG_XXHASH
+  FILES:=$(LINUX_DIR)/lib/xxhash.ko
+endef
+
+$(eval $(call KernelPackage,lib-xxhash))
+
+
 define KernelPackage/lib-zstd
   SUBMENU:=$(LIB_MENU)
   TITLE:=ZSTD support
-  DEPENDS:=+kmod-crypto-acompress
+  DEPENDS:=+kmod-crypto-acompress +kmod-lib-xxhash
   KCONFIG:= \
 	CONFIG_CRYPTO_ZSTD \
 	CONFIG_ZSTD_COMPRESS \
-	CONFIG_ZSTD_DECOMPRESS \
-	CONFIG_XXHASH
+	CONFIG_ZSTD_DECOMPRESS
   FILES:= \
 	$(LINUX_DIR)/crypto/zstd.ko \
-	$(LINUX_DIR)/lib/xxhash.ko \
 	$(LINUX_DIR)/lib/zstd/zstd_common.ko@ge6.1 \
 	$(LINUX_DIR)/lib/zstd/zstd_compress.ko \
 	$(LINUX_DIR)/lib/zstd/zstd_decompress.ko
-  AUTOLOAD:=$(call AutoProbe,xxhash zstd zstd_compress zstd_decompress)
+  AUTOLOAD:=$(call AutoProbe,zstd zstd_compress zstd_decompress)
 endef
 
 define KernelPackage/lib-zstd/description

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -132,6 +132,22 @@ endef
 $(eval $(call KernelPackage,nf-conntrack6))
 
 
+define KernelPackage/nf-dup-inet
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Netfilter nf_tables dup in ip/ip6/inet family support
+  HIDDEN:=1
+  DEPENDS:=+kmod-nf-conntrack +IPV6:kmod-nf-conntrack6
+  KCONFIG:= \
+	CONFIG_NF_DUP_IPV4 \
+	CONFIG_NF_DUP_IPV6
+  FILES:= \
+	$(LINUX_DIR)/net/ipv4/netfilter/nf_dup_ipv4.ko \
+	$(LINUX_DIR)/net/ipv6/netfilter/nf_dup_ipv6.ko
+endef
+
+$(eval $(call KernelPackage,nf-dup-inet))
+
+
 define KernelPackage/nf-log
   SUBMENU:=$(NF_MENU)
   TITLE:=Netfilter Logging
@@ -716,7 +732,7 @@ $(eval $(call KernelPackage,ipt-tproxy))
 
 define KernelPackage/ipt-tee
   TITLE:=TEE support
-  DEPENDS:=+kmod-ipt-conntrack
+  DEPENDS:=+kmod-ipt-conntrack +kmod-nf-dup-inet
   KCONFIG:=$(KCONFIG_IPT_TEE)
   FILES:=$(foreach mod,$(IPT_TEE-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir nf_tee $(IPT_TEE-m)))
@@ -1150,18 +1166,14 @@ $(eval $(call KernelPackage,nft-bridge))
 define KernelPackage/nft-dup-inet
   SUBMENU:=$(NF_MENU)
   TITLE:=Netfilter nf_tables dup in ip/ip6/inet family support
-  DEPENDS:=+kmod-nft-core +kmod-nf-conntrack +IPV6:kmod-nf-conntrack6
+  DEPENDS:=+kmod-nft-core +kmod-nf-dup-inet
   KCONFIG:= \
-	CONFIG_NF_DUP_IPV4 \
-	CONFIG_NF_DUP_IPV6 \
 	CONFIG_NFT_DUP_IPV4 \
 	CONFIG_NFT_DUP_IPV6
   FILES:= \
-	$(LINUX_DIR)/net/ipv4/netfilter/nf_dup_ipv4.ko \
-	$(LINUX_DIR)/net/ipv6/netfilter/nf_dup_ipv6.ko \
 	$(LINUX_DIR)/net/ipv4/netfilter/nft_dup_ipv4.ko \
 	$(LINUX_DIR)/net/ipv6/netfilter/nft_dup_ipv6.ko
-  AUTOLOAD:=$(call AutoProbe,nf_dup_ipv4 nf_dup_ipv6 nft_dup_ipv4 nft_dup_ipv6)
+  AUTOLOAD:=$(call AutoProbe,nft_dup_ipv4 nft_dup_ipv6)
 endef
 
 $(eval $(call KernelPackage,nft-dup-inet))

--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -1245,6 +1245,18 @@ endef
 $(eval $(call KernelPackage,sctp))
 
 
+define KernelPackage/sctp-diag
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
+  TITLE:=SCTP diag support
+  DEPENDS:=+kmod-sctp +kmod-inet-diag
+  KCONFIG:=CONFIG_INET_SCTP_DIAG
+  FILES:= $(LINUX_DIR)/net/sctp/sctp_diag.ko
+  AUTOLOAD:= $(call AutoLoad,33,sctp_diag)
+endef
+
+$(eval $(call KernelPackage,sctp-diag))
+
+
 define KernelPackage/netem
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=Network emulation functionality

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -572,6 +572,18 @@ endef
 $(eval $(call KernelPackage,bcma))
 
 
+define KernelPackage/mfd
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Multifunction device drivers
+  HIDDEN:=1
+  KCONFIG:=CONFIG_MFD_CORE
+  FILES:=$(LINUX_DIR)/drivers/mfd/mfd-core.ko
+  AUTOLOAD:=$(call AutoLoad,10,mfd-core)
+endef
+
+$(eval $(call KernelPackage,mfd))
+
+
 define KernelPackage/mtdtests
   SUBMENU:=$(OTHER_MENU)
   TITLE:=MTD subsystem tests

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -577,6 +577,7 @@ define KernelPackage/mtdtests
   TITLE:=MTD subsystem tests
   KCONFIG:=CONFIG_MTD_TESTS
   FILES:=\
+	$(LINUX_DIR)/drivers/mtd/tests/mtd_nandbiterrs.ko \
 	$(LINUX_DIR)/drivers/mtd/tests/mtd_nandecctest.ko \
 	$(LINUX_DIR)/drivers/mtd/tests/mtd_oobtest.ko \
 	$(LINUX_DIR)/drivers/mtd/tests/mtd_pagetest.ko \


### PR DESCRIPTION
These are multiple independent fixes for problems I found.

I created two lists.
All .ko files build:
```
find build_dir/target-mipsel_24kc+24kf_musl/linux-pistachio_generic/linux-6.6.35/ -name '*.ko' -printf "%f\n" |sort > kernel.ko.txt
```
All .ko files packages:
```
find build_dir/target-mipsel_24kc+24kf_musl/linux-pistachio_generic/packages/ipkg-mipsel_24kc_24kf/ -name '*.ko' -printf "%f\n" |sort > package.ko.txt
```
Then I compared the two files and manually checked the result. 


 * kernel: Extract kmod-nf-dup-inet
    
    The nf_dup_ipv4.ko and nf_dup_ipv6.ko kernel module were packaged by
    kmod-ipt-tee and kamd-nft-dup-inet at the same time. Extract them into a
    separate package used by both.
    
 * kernel: Fix kmod-lib-lz4 packaging
    
    The kernel provides two variants of the lz4 compression a normal version
    and a high compression mode version. The old kmod-lib-lz4 package
    contained the normal version plus one part of the lz4hc version. There
    was already code which selected the kmod-lib-lz4hc package which did
    not exists.
    
    I split this into 3 packages. kmod-lib-lz4 and kmod-lib-lz4hc for the
    normal the and high compression algorithm which contain the specific
    code and the kmod-lib-lz4-decompress which contains the common
    decompressor.
    
    New we are also packaging lz4hc.ko
    
 * kernel: Add kmod-crypto-blake2b
    
    The kmod-fs-btrfs package has a soft dependency to kmod-crypto-blake2b
    
    The CONFIG_BTRFS_FS kernel build option selects CONFIG_CRYPTO_BLAKE2B,
    but we did not package it before.
    
 * kernel: Add kmod-crypto-xxhash
    
    kxxhash_generic.ko is a soft dependency of kmod-fs-btrfs, but we did not
    package it. Extract the kmod-lib-xxhash and then package
    xxhash_generic.ko.
    
 * kernel: Add mtd_nandbiterrs.ko to kmod-mtdtests
    
    The mtd_nandbiterrs.ko kernel module was added with kernel 3.7. We
    should package it like the other test modules.
    
 * kernel: Add kmod-mfd
    
    Package the mfd-core.ko kernel module. It is selected by the
    kmod-hwmon-gsc already.
    
 * kernel: Add kmod-sctp-diag
    
    Package the sctp_diag.ko file which already gets build when kmod-sctp
    and kmod-inet-diag are selected.
    