### PR TITLE
x86: build the initramfs-kernel image by default

### DIFF
--- a/target/linux/x86/Makefile
+++ b/target/linux/x86/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=i386
 BOARD:=x86
 BOARDNAME:=x86
-FEATURES:=squashfs ext4 vdi vmdk vhdx pcmcia targz fpu boot-part rootfs-part
+FEATURES:=squashfs ext4 vdi vmdk vhdx pcmcia targz fpu boot-part rootfs-part ramdisk
 SUBTARGETS:=generic legacy geode 64
 
 KERNEL_PATCHVER:=6.6


### PR DESCRIPTION
The intention is to make the x86/64 *-initramfs-kernel.bin images downloadable from the official OpenWrt release page.

When installing OpenWrt to disk is not desired, one can boot a single initramfs-kernel file using common PC bootloaders (e.g. grub), forming a live Linux system.

This effectively makes OpenWrt qualified to appear on this Wikipedia list: [List of Linux distributions that run from RAM](https://en.wikipedia.org/wiki/List_of_Linux_distributions_that_run_from_RAM).

This topic is also discussed on the openwrt forum: [[x86/64] Request official release of the initramfs-kernel](https://forum.openwrt.org/t/x86-64-request-official-release-of-the-initramfs-kernel/202387).
