### PR TITLE
tools/e2fsprogs: fix shell scripts under SDK

### DIFF
--- a/tools/e2fsprogs/Makefile
+++ b/tools/e2fsprogs/Makefile
@@ -11,7 +11,6 @@ PKG_NAME:=e2fsprogs
 PKG_CPE_ID:=cpe:/a:e2fsprogs_project:e2fsprogs
 PKG_VERSION:=1.47.0
 PKG_HASH:=0b4fe723d779b0927fb83c9ae709bc7b40f66d7df36433bef143e41c54257084
-PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/people/tytso/e2fsprogs/v$(PKG_VERSION)/
@@ -36,6 +35,12 @@ HOST_CONFIGURE_ARGS += \
 define Host/Prepare
 	$(call Host/Prepare/Default)
 	rm -rf $(HOST_BUILD_DIR)/doc
+endef
+
+define Host/Install
+	$(call Host/Install/Default)
+	$(SED) 's|^DIR=.*|DIR=$$$$(STAGING_DIR_HOST)/share/et|' $(STAGING_DIR_HOST)/bin/compile_et
+	$(SED) 's|^DIR=.*|DIR=$$$$(STAGING_DIR_HOST)/share/ss|' $(STAGING_DIR_HOST)/bin/mk_cmds
 endef
 
 define Host/Uninstall


### PR DESCRIPTION
7c32295b0036be425ba0cd527eb06316a87d0ec0 exposed a problem where the SDK builds these shell scripts with a nonsensical absolute path for the DIR variable. Use sed to patch in $STAGING_DIR_HOST.

ping @robimarko 