### PR TITLE
bmips: enet: restore netif_napi_add weight

### DIFF
--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6348-enet.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6348-enet.c
@@ -25,7 +25,6 @@
 #include <linux/phy.h>
 #include <linux/platform_device.h>
 #include <linux/reset.h>
-#include <linux/version.h>
 
 /* DMA channels */
 #define DMA_CHAN_WIDTH			0x10
@@ -1647,11 +1646,7 @@ static int bcm6348_emac_probe(struct platform_device *pdev)
 	ndev->min_mtu = ETH_ZLEN - ETH_HLEN;
 	ndev->mtu = ETH_DATA_LEN - VLAN_ETH_HLEN;
 	ndev->max_mtu = ENET_MAX_MTU - VLAN_ETH_HLEN;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
-	netif_napi_add(ndev, &emac->napi, bcm6348_emac_poll);
-#else
-	netif_napi_add(ndev, &emac->napi, bcm6348_emac_poll, 16);
-#endif
+	netif_napi_add_weight(ndev, &emac->napi, bcm6348_emac_poll, 16);
 	SET_NETDEV_DEV(ndev, dev);
 
 	ret = devm_register_netdev(dev, ndev);

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
@@ -20,7 +20,6 @@
 #include <linux/pm_domain.h>
 #include <linux/pm_runtime.h>
 #include <linux/reset.h>
-#include <linux/version.h>
 
 /* TODO: Bigger frames may work but we do not trust that they are safe on all
  * platforms so more research is needed, a max frame size of 2048 has been
@@ -1077,11 +1076,7 @@ static int bcm6368_enetsw_probe(struct platform_device *pdev)
 	ndev->min_mtu = ETH_ZLEN;
 	ndev->mtu = ETH_DATA_LEN;
 	ndev->max_mtu = ENETSW_MAX_MTU;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
-	netif_napi_add(ndev, &priv->napi, bcm6368_enetsw_poll);
-#else
-	netif_napi_add(ndev, &priv->napi, bcm6368_enetsw_poll, 16);
-#endif
+	netif_napi_add_weight(ndev, &priv->napi, bcm6368_enetsw_poll, 16);
 
 	ret = devm_register_netdev(dev, ndev);
 	if (ret) {


### PR DESCRIPTION
Switch to netif_napi_add_weight and add back weight value from <= v5.15.

Should fix https://github.com/openwrt/openwrt/issues/15848.