### PR TITLE
f2fs-tools: Add missing 'f2fslabel' symlink

### DIFF
--- a/package/utils/f2fs-tools/Makefile
+++ b/package/utils/f2fs-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=f2fs-tools
 PKG_VERSION:=1.16.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/snapshot/
@@ -137,6 +137,7 @@ define Package/f2fsck/install
 	$(LN) ../sbin/fsck.f2fs $(1)/usr/sbin/dump.f2fs
 	$(LN) ../sbin/fsck.f2fs $(1)/usr/sbin/sload.f2fs
 	$(LN) ../sbin/fsck.f2fs $(1)/usr/sbin/resize.f2fs
+	$(LN) ../sbin/fsck.f2fs $(1)/usr/sbin/f2fslabel
 endef
 
 Package/f2fsck-selinux/install = $(Package/f2fsck/install)


### PR DESCRIPTION
`f2fslabel` is already built into `f2fs.fsck`, but is missing its symlink in the final package.

Build files:
```bash
❯ cd build_dir/target-aarch64_cortex-a53_musl/f2fs-tools-default/f2fs-tools-1.16.0/ipkg-install/usr/sbin
```

```bash
❯ find * -maxdepth 1 -type l -exec ls -l {} +
lrwxrwxrwx 1 builder builder 9 Jul  1 14:14 defrag.f2fs -> fsck.f2fs
lrwxrwxrwx 1 builder builder 9 Jul  1 14:14 dump.f2fs -> fsck.f2fs
lrwxrwxrwx 1 builder builder 9 Jul  1 14:14 f2fslabel -> fsck.f2fs
lrwxrwxrwx 1 builder builder 9 Jul  1 14:14 resize.f2fs -> fsck.f2fs
lrwxrwxrwx 1 builder builder 9 Jul  1 14:14 sload.f2fs -> fsck.f2fs
```