### PR TITLE
tools/util-linux: build libuuid as PIC

### DIFF
--- a/tools/util-linux/Makefile
+++ b/tools/util-linux/Makefile
@@ -21,6 +21,7 @@ HOST_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/host-build.mk
 
 HOST_CONFIGURE_ARGS += \
+	--with-pic \
 	--disable-shared \
 	--disable-all-programs \
 	--enable-hexdump \


### PR DESCRIPTION
Needed to fix users of libuuid.a as autoconf applies PIC to only shared libraries by default.

Found when trying to build python3/host.

Ref: https://github.com/openwrt/packages/pull/24486