### PR TITLE
tools/e2fsprogs: fixup STAGING_DIR_HOST path evaluation in shell scripts

### DIFF
--- a/tools/e2fsprogs/Makefile
+++ b/tools/e2fsprogs/Makefile
@@ -39,8 +39,8 @@ endef
 
 define Host/Install
 	$(call Host/Install/Default)
-	$(SED) 's|^DIR=.*|DIR=$$$$(STAGING_DIR_HOST)/share/et|' $(STAGING_DIR_HOST)/bin/compile_et
-	$(SED) 's|^DIR=.*|DIR=$$$$(STAGING_DIR_HOST)/share/ss|' $(STAGING_DIR_HOST)/bin/mk_cmds
+	$(SED) 's|^DIR=.*|DIR=$$$${STAGING_DIR_HOST}/share/et|' $(STAGING_DIR_HOST)/bin/compile_et
+	$(SED) 's|^DIR=.*|DIR=$$$${STAGING_DIR_HOST}/share/ss|' $(STAGING_DIR_HOST)/bin/mk_cmds
 endef
 
 define Host/Uninstall


### PR DESCRIPTION
We have to use curly braces on the exported `STAGING_DIR_HOST` env variable, instead of evaluating it directly as we are not in Make but a separate shell script.

Otherwise it would fail with:
```
staging_dir/host/bin/compile_et: line 6: STAGING_DIR_HOST: command not found
staging_dir/host/bin/mk_cmds: line 5: STAGING_DIR_HOST: command not found
```

And so when krb5 tries to build it will fail as compile_et and mk_cmds will return an error.

Fixes: 55bda9863dd0 ("tools/e2fsprogs: fix shell scripts under SDK")
