### PR TITLE
target.mk: fix arm architecture level detection

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -346,7 +346,15 @@ ifeq ($(DUMP),1)
     ifneq ($(CONFIG_CPU_MIPS32_R2),)
       FEATURES += mips16
     endif
-    FEATURES += $(foreach v,6 7,$(if $(CONFIG_CPU_V$(v)),arm_v$(v)))
+    ifneq ($(CONFIG_CPU_V6),)
+      FEATURES += arm_v6
+    endif
+    ifneq ($(CONFIG_CPU_V6K),)
+      FEATURES += arm_v6
+    endif
+    ifneq ($(CONFIG_CPU_V7),)
+      FEATURES += arm_v7
+    endif
 
     # remove duplicates
     FEATURES:=$(sort $(FEATURES))


### PR DESCRIPTION
Now kernel configs of armv6k CPUs don't include CONFIG_CPU_V6. So armv6k CPUs cannot be detected as arm_v6.
Fix this by adding detection for CONFIG_CPU_V6K.