### PR TITLE
build: fix missing SOURCE_VERSION variable

### DIFF
--- a/include/kernel-build.mk
+++ b/include/kernel-build.mk
@@ -51,7 +51,7 @@ endif
 define Download/git-kernel
   URL:=$(call qstrip,$(CONFIG_KERNEL_GIT_CLONE_URI))
   PROTO:=git
-  VERSION:=$(CONFIG_KERNEL_GIT_REF)
+  SOURCE_VERSION:=$(CONFIG_KERNEL_GIT_REF)
   FILE:=$(LINUX_SOURCE)
   SUBDIR:=linux-$(LINUX_VERSION)
   OPTS:=$(KERNEL_GIT_OPTS)


### PR DESCRIPTION
ping @aparcar @Ansuel 

ref #15181 

The recipe Download/git-kernel uses DownloadMethod/git which now requires a definition of SOURCE_VERSION instead of VERSION due to Validate/git being used to check for the variables.

Rename the variable as intended to match with the others that were renamed in the referenced commit.
This fixes the following Makefile parse error
when downloading a specific kernel repository version when configured with the CONFIG_KERNEL_GIT_CLONE_URI option:

  Makefile:19: *** Download/git-kernel is missing the SOURCE_VERSION field..  Stop.

Fixes: 9fc79e2e2 ("download: don't overwrite VERSION variable")