### PR TITLE
ncurses: disable extended color

### DIFF
--- a/package/libs/ncurses/Makefile
+++ b/package/libs/ncurses/Makefile
@@ -82,6 +82,7 @@ CONFIGURE_VARS += \
 HOST_CFLAGS += $(HOST_FPIC)
 
 HOST_CONFIGURE_ARGS += \
+	--disable-ext-colors \
 	--without-cxx \
 	--without-cxx-binding \
 	--without-ada \


### PR DESCRIPTION
It seems that when built static, extended color is not included in the library. And whenever packages such as Python try to use it extended_color_content shows up as an undefined symbol.

Disable it to avoid linking errors like these.

Should partially fix https://github.com/openwrt/packages/pull/24486