### PR TITLE
ncurses: enable pc files in the host build

### DIFF
--- a/package/libs/ncurses/Makefile
+++ b/package/libs/ncurses/Makefile
@@ -82,6 +82,7 @@ CONFIGURE_VARS += \
 HOST_CFLAGS += $(HOST_FPIC)
 
 HOST_CONFIGURE_ARGS += \
+	--enable-pc-files \
 	--without-cxx \
 	--without-cxx-binding \
 	--without-ada \

--- a/package/libs/readline/Makefile
+++ b/package/libs/readline/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=readline
 PKG_VERSION:=8.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/readline
@@ -51,6 +51,7 @@ CONFIGURE_ARGS += --with-curses --disable-install-examples
 CONFIGURE_VARS += \
 	bash_cv_wcwidth_broken=no \
 	bash_cv_func_sigsetjmp=yes \
+	bash_cv_termcap_lib=libncursesw
 
 TARGET_CFLAGS += $(FPIC)
 HOST_CFLAGS += $(FPIC)

--- a/package/libs/readline/patches/010-ncursesw-first.patch
+++ b/package/libs/readline/patches/010-ncursesw-first.patch
@@ -1,0 +1,20 @@
+--- a/configure
++++ b/configure
+@@ -7305,6 +7305,9 @@ TERMCAP_DEP=
+ elif test $bash_cv_termcap_lib = libncurses; then
+ TERMCAP_LIB=-lncurses
+ TERMCAP_DEP=
++elif test $bash_cv_termcap_lib = libncursesw; then
++TERMCAP_LIB=-lncursesw
++TERMCAP_DEP=
+ elif test $bash_cv_termcap_lib = libc; then
+ TERMCAP_LIB=
+ TERMCAP_DEP=
+@@ -7340,6 +7343,7 @@ case "$TERMCAP_LIB" in
+ -ltinfo)  TERMCAP_PKG_CONFIG_LIB=tinfo ;;
+ -lcurses) TERMCAP_PKG_CONFIG_LIB=ncurses ;;
+ -lncurses) TERMCAP_PKG_CONFIG_LIB=ncurses ;;
++-lncursesw) TERMCAP_PKG_CONFIG_LIB=ncursesw ;;
+ -ltermcap) TERMCAP_PKG_CONFIG_LIB=termcap ;;
+ *) TERMCAP_PKG_CONFIG_LIB=termcap ;;
+ esac


### PR DESCRIPTION
Needed for things such as readline that depend on ncurses.

Found as a result of https://github.com/openwrt/packages/pull/24486