### PR TITLE
ramips: rename interfaces for tplink er605v2

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
@@ -84,7 +84,7 @@
 
 &gmac1 {
 	status = "okay";
-	label = "eth0";
+	label = "wan1";
 	phy-handle = <&ethphy0>;
 };
 
@@ -97,22 +97,22 @@
 
 		port@1 {
 			status = "okay";
-			label = "eth1";
+			label = "lan2";
 		};
 
 		port@2 {
 			status = "okay";
-			label = "eth2";
+			label = "lan3";
 		};
 
 		port@3 {
 			status = "okay";
-			label = "eth3";
+			label = "lan4";
 		};
 
 		port@4 {
 			status = "okay";
-			label = "eth4";
+			label = "lan5";
 		};
 	};
 };

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2732,6 +2732,8 @@ TARGET_DEVICES += tplink_ec330-g5u-v1
 
 define Device/tplink_er605-v2
   $(Device/nand)
+  DEVICE_COMPAT_VERSION := 1.2
+  DEVICE_COMPAT_MESSAGE := Config cannot be migrated because interface names have changed
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := ER605
   DEVICE_VARIANT := v2

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -148,7 +148,7 @@ ramips_setup_interfaces()
 		ucidef_set_interface_lan "lan0 lan1 lan2 lan3"
 		;;
 	tplink,er605-v2)
-		ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4" "eth0"
+		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan1"
 		;;
 	tplink,tl-wpa8631p-v3)
 		ucidef_set_interface_lan "lan1 lan2 lan3 plc0"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
@@ -11,6 +11,9 @@ case "$(board_name)" in
 	iptime,ax2004m)
 		ucidef_set_compat_version "2.0"
 		;;
+	tplink,er605-v2)
+		ucidef_set_compat_version "1.2"
+		;;
 	*)
 		ucidef_set_compat_version "1.1"
 		;;


### PR DESCRIPTION
Currently eth1 (which is the first "lan" interface) doesn't work on this device. During boot the following can be seen in logs:

```
[    2.252804] mt7530-mdio mdio-bus:1f: MT7530 adapts as multi-chip module
[    2.266060] mtk_soc_eth 1e100000.ethernet eth0: mediatek frame engine at 0xbe100000, irq 19
[    2.277889] mtk_soc_eth 1e100000.ethernet eth1: mediatek frame engine at 0xbe100000, irq 19
...
[    2.355157] mt7530-mdio mdio-bus:1f: MT7530 adapts as multi-chip module
[    2.390312] mt7530-mdio mdio-bus:1f: configuring for fixed/rgmii link mode
[    2.398597] mt7530-mdio mdio-bus:1f: Link is Up - 1Gbps/Full - flow control rx/tx
[    2.403872] mt7530-mdio mdio-bus:1f eth1 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7530 PHY] (irq=21)
[    2.416988] mtk_soc_eth 1e100000.ethernet eth0: error -17 registering interface eth1
[    2.426973] mt7530-mdio mdio-bus:1f eth2 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7530 PHY] (irq=22)
[    2.440996] mt7530-mdio mdio-bus:1f eth3 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7530 PHY] (irq=23)
[    2.454405] mt7530-mdio mdio-bus:1f eth4 (uninitialized): PHY [mt7530-0:04] driver [MediaTek MT7530 PHY] (irq=24)
[    2.467198] mtk_soc_eth 1e100000.ethernet eth0: entered promiscuous mode
[    2.474117] DSA: tree 0 setup
...
[    6.820998] mtk_soc_eth 1e100000.ethernet dsa: renamed from eth0
[    6.919904] mtk_soc_eth 1e100000.ethernet wan: renamed from eth1
```

So the problem seems to be the fact that built-in gmacs get default names (eth0/eth1) and are renamed after switch ports are initialized. This means that when switch port with name `eth1` is brought up this name is still used by gmac1 causing switch port's init to fail.

This patch just renames the ports to avoid name collision. Note: this will break existing configs for this device because it renames all the ports. This should not be major problem because this device doesn't have a proper OEM image and is only flashable with serial access, meaning there should not be many users.

