### PR TITLE
rockchip: fix baudrate for Radxa E25

### DIFF
--- a/package/boot/rkbin/Makefile
+++ b/package/boot/rkbin/Makefile
@@ -37,9 +37,33 @@ define Trusted-Firmware-A/rk3568
   TPL:=rk35/rk3568_ddr_1560MHz_v1.21.bin
 endef
 
+define Trusted-Firmware-A/rk3568-e25
+  NAME:=Radxa E25 board
+  BUILD_SUBTARGET:=armv8
+  ATF:=rk35/rk3568_bl31_v1.44.elf
+  TPL:=rk35/rk3568_ddr_1560MHz_uart2_m0_115200_v1.21.bin
+endef
+
 TFA_TARGETS:= \
 	rk3566 \
-	rk3568
+	rk3568 \
+	rk3568-e25
+
+ifeq ($(BUILD_VARIANT),rk3568-e25)
+  TPL_FILE:=rk3568_ddr_1560MHz_uart2_m0_115200_v1.21.bin
+  define Download/rk3568-tpl-e25
+    FILE:=$(TPL_FILE)
+    URL:=https://github.com/radxa/rkbin/raw/5696fab20dcac57c1458f72dc7604ba60e553adf/bin/rk35/
+    HASH:=1815f9649dc5661a3ef184b052da39286e51453a66f6ff53cc3e345d65dfabd4
+  endef
+
+  define Build/Prepare
+	$(eval $(call Download,rk3568-tpl-e25))
+	$(call Build/Prepare/Default)
+
+	$(CP) $(DL_DIR)/$(TPL_FILE) $(PKG_BUILD_DIR)/bin/rk35/
+  endef
+endif
 
 define Build/Compile
 endef

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -174,6 +174,8 @@ endef
 
 define U-Boot/radxa-e25-rk3568
   $(U-Boot/rk3568/Default)
+  DEPENDS:=+PACKAGE_u-boot-$(1):trusted-firmware-a-rk3568-e25
+  TPL:=rk3568_ddr_1560MHz_uart2_m0_115200_v1.21.bin
   NAME:=E25
   BUILD_DEVICES:= \
     radxa_e25

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -109,6 +109,7 @@ define Device/radxa_e25
   DEVICE_MODEL := E25
   SOC := rk3568
   DEVICE_DTS := rockchip/rk3568-radxa-e25
+  BOOT_SCRIPT := radxa-e25
   UBOOT_DEVICE_NAME := radxa-e25-rk3568
   DEVICE_PACKAGES := kmod-r8169 kmod-ata-ahci-platform
 endef

--- a/target/linux/rockchip/image/radxa-e25.bootscript
+++ b/target/linux/rockchip/image/radxa-e25.bootscript
@@ -1,0 +1,7 @@
+part uuid ${devtype} ${devnum}:2 uuid
+
+setenv bootargs "console=ttyS2,115200 earlycon=uart8250,mmio32,0xfe660000 root=PARTUUID=${uuid} rw rootwait";
+
+load ${devtype} ${devnum}:1 ${kernel_addr_r} kernel.img
+
+bootm ${kernel_addr_r}


### PR DESCRIPTION
```
According to the documentation[1], the serial baudrate of E25 is
115.2 Kbps, and setting it to 1.5 Mbps will cause onboard CH340B
USB-UART chip unstable.

Since mainline TPL is yet available, download patched TPL binary
from Radxa.

1. https://wiki.radxa.com/Rock3/CM/CM3I/E25/getting_started

Fixes: https://github.com/openwrt/openwrt/issues/15814
Fixes: f7c732bf9ed9 ("rockchip: add Radxa E25 board support")
```

Cc: @maurerr
Cc: @RadxaNaoki