### PR TITLE
[23.05]: openssl: update to 3.0.14

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.0.13
+PKG_VERSION:=3.0.14
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
@@ -24,7 +24,7 @@ PKG_SOURCE_URL:= \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/old/$(PKG_BASE)/
 
-PKG_HASH:=88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313
+PKG_HASH:=eeca035d4dd4e84fc25846d952da6297484afa0650a6f84c682e39df3a4123ca
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE

--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_VERSION:=3.0.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_BUILD_PARALLEL:=1
@@ -416,6 +416,8 @@ define Package/libopenssl-conf/install
 	$(INSTALL_BIN) ./files/openssl.init $(1)/etc/init.d/openssl
 	$(SED) 's!%ENGINES_DIR%!/usr/lib/$(ENGINES_DIR)!' $(1)/etc/init.d/openssl
 	touch $(1)/etc/config/openssl
+	$(if $(CONFIG_OPENSSL_ENGINE),,
+		$(SED) 's!engines = engines_sect!#&!' $(1)/etc/ssl/openssl.cnf)
 	$(if $(CONFIG_OPENSSL_ENGINE_BUILTIN_DEVCRYPTO),
 		$(CP) ./files/devcrypto.cnf $(1)/etc/ssl/modules.cnf.d/
 		echo -e "config engine 'devcrypto'\n\toption enabled '1'\n\toption builtin '1'" >> $(1)/etc/config/openssl)


### PR DESCRIPTION
 * openssl: update to 3.0.14
    
    Major changes between OpenSSL 3.0.13 and OpenSSL 3.0.14 [04-Jun-2024]
    
    * Fixed potential use after free after SSL_free_buffers() is called.
      [CVE-2024-4741]
    * Fixed checking excessively long DSA keys or parameters may be very slow.
      [CVE-2024-4603]
    * Fixed an issue where some non-default TLS server configurations can cause
      unbounded memory growth when processing TLSv1.3 sessions. An attacker may
      exploit certain server configurations to trigger unbounded memory growth that
      would lead to a Denial of Service.  [CVE-2024-2511]
    * New atexit configuration switch, which controls whether the OPENSSL_cleanup
      is registered when libcrypto is unloaded. This can be used on platforms
      where using atexit() from shared libraries causes crashes on exit
    
    Signed-off-by: John Audia <therealgraysky@proton.me>
    
    Build system: x86/64
    Build-tested: x86/64/AMD Cezanne
    
    (cherry picked from commit bac2f1bed6db5da166aad7b1091c2e9af0ffef5d)

 * openssl: conditionally disable engine section
    
    Currently, the build option to enable/disable engine support isn't
    reflected in the final '/etc/ssl/openssl.cnf' config. It assumes `engines`
    is always enabled, producing an error whenever running any
    commands in openssl util or programs that explicitly use settings
    from '/etc/ssl/openssl.cnf'.
    
    ```
    ➤ openssl version
    FATAL: Startup failure (dev note: apps_startup()) for openssl
    307D1EA97F000000:error:12800067:lib(37):dlfcn_load:reason(103):crypto/dso/dso_dlfcn.c:118:filename(libengines.so):
    Error loading shared library libengines.so: No such file or directory
    307D1EA97F000000:error:12800067:lib(37):DSO_load:reason(103):crypto/dso/dso_lib.c:152:
    307D1EA97F000000:error:0700006E:lib(14):module_load_dso:reason(110):crypto/conf/conf_mod.c:321:module=engines, path=engines
    307D1EA97F000000:error:07000071:lib(14):module_run:reason(113):crypto/conf/conf_mod.c:266:module=engines
    ```
    
    Build should check for the `CONFIG_OPENSSL_ENGINE` option, and comment out `engines`
    if not explicitly enabled.
    
    Example:
    ```
    [openssl_init]
    providers = provider_sect
    ```
    
    After this change, openssl util works correctly.
    
    ```
    ➤ openssl version
    OpenSSL 3.0.14 4 Jun 2024 (Library: OpenSSL 3.0.14 4 Jun 2024)
    ```
    
    Signed-off-by: Sean Khan <datapronix@protonmail.com>
    Link: https://github.com/openwrt/openwrt/pull/15661
    Signed-off-by: Robert Marko <robimarko@gmail.com>
    (cherry picked from commit 31ec4515c3c14704d669156d87e2af5eeb5420e4)
