### PR TITLE
[22.03]: wolfssl: Update to 5.7.0

### DIFF
--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wolfssl
-PKG_VERSION:=5.6.4-stable
+PKG_VERSION:=5.6.6-stable
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/wolfSSL/wolfssl/archive/v$(PKG_VERSION)
-PKG_HASH:=031691906794ff45e1e792561cf31759f5d29ac74936bc8dffb8b14f16d820b4
+PKG_HASH:=3d2ca672d41c2c2fa667885a80d6fa03c3e91f0f4f72f87aef2bc947e8c87237
 
 PKG_FIXUP:=libtool libtool-abiver
 PKG_INSTALL:=1

--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wolfssl
-PKG_VERSION:=5.6.6-stable
+PKG_VERSION:=5.7.0-stable
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/wolfSSL/wolfssl/archive/v$(PKG_VERSION)
-PKG_HASH:=3d2ca672d41c2c2fa667885a80d6fa03c3e91f0f4f72f87aef2bc947e8c87237
+PKG_HASH:=2de93e8af588ee856fe67a6d7fce23fc1b226b74d710b0e3946bc8061f6aa18f
 
 PKG_FIXUP:=libtool libtool-abiver
 PKG_INSTALL:=1

--- a/package/libs/wolfssl/patches/100-disable-hardening-check.patch
+++ b/package/libs/wolfssl/patches/100-disable-hardening-check.patch
@@ -1,6 +1,6 @@
 --- a/wolfssl/wolfcrypt/settings.h
 +++ b/wolfssl/wolfcrypt/settings.h
-@@ -2630,7 +2630,7 @@ extern void uITRON4_free(void *p) ;
+@@ -2774,7 +2774,7 @@ extern void uITRON4_free(void *p) ;
  
  /* warning for not using harden build options (default with ./configure) */
  /* do not warn if big integer support is disabled */

--- a/package/libs/wolfssl/patches/100-disable-hardening-check.patch
+++ b/package/libs/wolfssl/patches/100-disable-hardening-check.patch
@@ -1,6 +1,6 @@
 --- a/wolfssl/wolfcrypt/settings.h
 +++ b/wolfssl/wolfcrypt/settings.h
-@@ -2774,7 +2774,7 @@ extern void uITRON4_free(void *p) ;
+@@ -2945,7 +2945,7 @@ extern void uITRON4_free(void *p) ;
  
  /* warning for not using harden build options (default with ./configure) */
  /* do not warn if big integer support is disabled */


### PR DESCRIPTION
 * wolfssl: update to 5.6.6
    
    Release Notes:
    https://github.com/wolfSSL/wolfssl/releases/tag/v5.6.6-stable
    
    Refresh patches:
    - 100-disable-hardening-check.patch
    
    Fixes: CVE-2023-6935 CVE-2023-6936 CVE-2023-6937
    Signed-off-by: Nick Hainke <vincent@systemli.org>
    (cherry picked from commit 511578c128121326a3c48fdb35e4e62f96dc7b9d)

 * wolfssl: Update to 5.7.0
    
    This fixes multiple security problems:
     * [High] CVE-2024-0901 Potential denial of service and out of bounds
       read. Affects TLS 1.3 on the server side when accepting a connection
       from a malicious TLS 1.3 client. If using TLS 1.3 on the server side
       it is recommended to update the version of wolfSSL used.
    
     * [Med] CVE-2024-1545 Fault Injection vulnerability in
       RsaPrivateDecryption function that potentially allows an attacker
       that has access to the same system with a victims process to perform
       a Rowhammer fault injection. Thanks to Junkai Liang, Zhi Zhang, Xin
       Zhang, Qingni Shen for the report (Peking University, The University
       of Western Australia)."
    
     * [Med] Fault injection attack with EdDSA signature operations. This
       affects ed25519 sign operations where the system could be susceptible
       to Rowhammer attacks. Thanks to Junkai Liang, Zhi Zhang, Xin Zhang,
       Qingni Shen for the report (Peking University, The University of
       Western Australia).
    
    Size increased a little:
    wolfssl 5.6.6:
    516880 bin/packages/mips_24kc/base/libwolfssl5.6.6.e624513f_5.6.6-stable-r1_mips_24kc.ipk
    wolfssl: 5.7.0:
    519429 bin/packages/mips_24kc/base/libwolfssl5.7.0.e624513f_5.7.0-stable-r1_mips_24kc.ipk
    
    Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
    (cherry picked from commit f475a44c03a303851959930030ab9e6acebb81a7)
