### PR TITLE
bcm27xx: update to latest RPi patches

### DIFF
--- a/target/linux/bcm27xx/patches-6.6/950-0967-dmaengine-dw-axi-dmac-Fix-a-non-atomic-update.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-0967-dmaengine-dw-axi-dmac-Fix-a-non-atomic-update.patch
@@ -30,7 +30,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
 
 --- a/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
 +++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
-@@ -466,8 +466,6 @@ static void axi_chan_block_xfer_start(st
+@@ -389,8 +389,6 @@ static void axi_chan_block_xfer_start(st
  		return;
  	}
  

--- a/target/linux/bcm27xx/patches-6.6/950-1047-dw-axi-dmac-platform-Avoid-trampling-with-zero-lengt.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-1047-dw-axi-dmac-platform-Avoid-trampling-with-zero-lengt.patch
@@ -22,7 +22,7 @@ Signed-off-by: Dom Cobley <popcornmix@gmail.com>
 
 --- a/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
 +++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
-@@ -917,6 +917,9 @@ dw_axi_dma_chan_prep_slave_sg(struct dma
+@@ -834,6 +834,9 @@ dw_axi_dma_chan_prep_slave_sg(struct dma
  		mem = sg_dma_address(sg);
  		len = sg_dma_len(sg);
  		num_segments = DIV_ROUND_UP(sg_dma_len(sg), axi_block_len);

--- a/target/linux/bcm27xx/patches-6.6/950-1133-drivers-mmc-sdhci-brcmstb-improve-bcm2712-card-remov.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-1133-drivers-mmc-sdhci-brcmstb-improve-bcm2712-card-remov.patch
@@ -1,0 +1,52 @@
+From 5c0f94088e0694220a2f0d8ad6e8216b50a80f2e Mon Sep 17 00:00:00 2001
+From: Jonathan Bell <jonathan@raspberrypi.com>
+Date: Thu, 13 Jun 2024 15:01:02 +0100
+Subject: [PATCH 1133/1145] drivers: mmc: sdhci-brcmstb: improve bcm2712 card
+ removal handling
+
+If the controller is being reset, then the CQE needs to be reset as well.
+
+For removable cards, CQHCI_SSC1 must specify a polling mode (CBC=0)
+otherwise it's possible that the controller stops emitting periodic
+CMD13s on card removal, without raising an error status interrupt.
+
+Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
+---
+ drivers/mmc/host/sdhci-brcmstb.c | 19 ++++++++++++++++---
+ 1 file changed, 16 insertions(+), 3 deletions(-)
+
+--- a/drivers/mmc/host/sdhci-brcmstb.c
++++ b/drivers/mmc/host/sdhci-brcmstb.c
+@@ -365,8 +365,21 @@ static void sdhci_brcmstb_cqe_enable(str
+ 
+ 	sdhci_cqe_enable(mmc);
+ 
+-	/* Reset CMD13 polling timer back to eMMC specification default */
+-	cqhci_writel(cq_host, 0x00011000, CQHCI_SSC1);
++	/*
++	 * The controller resets this register to a very short default interval
++	 * whenever CQHCI is disabled.
++	 *
++	 * For removable cards CBC needs to be clear or card removal can hang
++	 * the CQE. In polling mode, a CIT of 0x4000 "cycles" seems to produce the best
++	 * throughput.
++	 *
++	 * For nonremovable cards, the specification default of CBC=1 CIT=0x1000
++	 * suffices.
++	 */
++	if (mmc->caps & MMC_CAP_NONREMOVABLE)
++		cqhci_writel(cq_host, 0x00011000, CQHCI_SSC1);
++	else
++		cqhci_writel(cq_host, 0x00004000, CQHCI_SSC1);
+ }
+ 
+ static const struct cqhci_host_ops sdhci_brcmstb_cqhci_ops = {
+@@ -386,7 +399,7 @@ static struct sdhci_ops sdhci_brcmstb_op
+ 	.set_clock = sdhci_bcm2712_set_clock,
+ 	.set_power = sdhci_brcmstb_set_power,
+ 	.set_bus_width = sdhci_set_bus_width,
+-	.reset = sdhci_reset,
++	.reset = brcmstb_reset,
+ 	.set_uhs_signaling = sdhci_set_uhs_signaling,
+ 	.init_sd_express = bcm2712_init_sd_express,
+ };

--- a/target/linux/bcm27xx/patches-6.6/950-1136-feat-Add-support-for-SunFounder-PiPower-3-overlay.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-1136-feat-Add-support-for-SunFounder-PiPower-3-overlay.patch
@@ -1,0 +1,193 @@
+From a1d3defcca200077e1e382fe049ca613d16efd2b Mon Sep 17 00:00:00 2001
+From: Cavon Lee <cavonxx@gmail.com>
+Date: Tue, 18 Jun 2024 14:01:23 +0800
+Subject: [PATCH 1136/1145] feat: Add support for SunFounder PiPower 3 overlay
+ fix: Fix wrong Pironman 5 ir default pin number fix: Change space indentation
+ to tab
+
+Signed-off-by: Cavon Lee <cavonxx@gmail.com>
+---
+ arch/arm/boot/dts/overlays/Makefile           |  1 +
+ arch/arm/boot/dts/overlays/README             |  8 +-
+ .../overlays/sunfounder-pipower3-overlay.dts  | 44 ++++++++++
+ .../overlays/sunfounder-pironman5-overlay.dts | 88 ++++++++++---------
+ 4 files changed, 98 insertions(+), 43 deletions(-)
+ create mode 100644 arch/arm/boot/dts/overlays/sunfounder-pipower3-overlay.dts
+
+--- a/arch/arm/boot/dts/overlays/Makefile
++++ b/arch/arm/boot/dts/overlays/Makefile
+@@ -275,6 +275,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
+ 	ssd1306-spi.dtbo \
+ 	ssd1331-spi.dtbo \
+ 	ssd1351-spi.dtbo \
++	sunfounder-pipower3.dtbo \
+ 	sunfounder-pironman5.dtbo \
+ 	superaudioboard.dtbo \
+ 	sx150x.dtbo \
+--- a/arch/arm/boot/dts/overlays/README
++++ b/arch/arm/boot/dts/overlays/README
+@@ -4695,11 +4695,17 @@ Params: speed                   SPI bus
+         reset_pin               GPIO pin for RESET (default 25)
+ 
+ 
++Name:   sunfounder-pipower3
++Info:   Overlay for SunFounder PiPower 3
++Load:   dtoverlay=sunfounder-pipower3,<param>=<val>
++Params: poweroff_pin            Change poweroff pin (default 26)
++
++
+ Name:   sunfounder-pironman5
+ Info:   Overlay for SunFounder Pironman 5
+ Load:   dtoverlay=sunfounder-pironman5,<param>=<val>
+ Params: ir                      Enable IR or not (on or off, default on)
+-        ir_pins                 Change IR receiver pin (default 12)
++        ir_pins                 Change IR receiver pin (default 13)
+ 
+ 
+ Name:   superaudioboard
+--- /dev/null
++++ b/arch/arm/boot/dts/overlays/sunfounder-pipower3-overlay.dts
+@@ -0,0 +1,44 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "brcm,bcm2835";
++
++	fragment@0 {
++		target-path = "/chosen";
++		__overlay__ {
++			power: power {
++				hat_current_supply = <5000>;
++			};
++		};
++	};
++	fragment@1 {
++		target = <&i2c1>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++	fragment@2 {
++		target-path = "/";
++		__overlay__ {
++			power_ctrl: power_ctrl {
++				compatible = "gpio-poweroff";
++				gpios = <&gpio 26 0>;
++				force;
++			};
++		};
++	};
++	fragment@3 {
++		target = <&gpio>;
++		__overlay__ {
++			power_ctrl_pins: power_ctrl_pins {
++				brcm,pins = <26>;
++				brcm,function = <1>; // out
++			};
++		};
++	};
++	__overrides__ {
++		poweroff_pin =	<&power_ctrl>,"gpios:4",
++						<&power_ctrl_pins>,"brcm,pins:0";
++	};
++};
+--- a/arch/arm/boot/dts/overlays/sunfounder-pironman5-overlay.dts
++++ b/arch/arm/boot/dts/overlays/sunfounder-pironman5-overlay.dts
+@@ -2,50 +2,54 @@
+ /plugin/;
+ 
+ / {
+-    compatible = "brcm,bcm2835";
++	compatible = "brcm,bcm2835";
+ 
+-    fragment@0 {
+-        target = <&i2c1>;
+-        __overlay__ {
+-            status = "okay";
+-        };
+-    };
+-    fragment@1 {
+-        target = <&spi0>;
+-        __overlay__ {
+-            status = "okay";
+-        };
+-    };
+-    fragment@2 {
+-        target-path = "/";
+-        __overlay__ {
+-            gpio_ir: ir-receiver@c {
+-                compatible = "gpio-ir-receiver";
+-                pinctrl-names = "default";
+-                pinctrl-0 = <&gpio_ir_pins>;
++	fragment@0 {
++		target = <&i2c1>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++	fragment@1 {
++		target = <&spi0>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++	fragment@2 {
++		target-path = "/";
++		__overlay__ {
++			gpio_ir: ir-receiver@d {
++				compatible = "gpio-ir-receiver";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_ir_pins>;
+ 
+-                // pin number, high or low
+-                gpios = <&gpio 12 1>;
++				// pin number, high or low
++				gpios = <&gpio 13 1>;
+ 
+-                // parameter for keymap name
+-                linux,rc-map-name = "rc-rc6-mce";
++				// parameter for keymap name
++				linux,rc-map-name = "rc-rc6-mce";
+ 
+-                status = "okay";
+-            };
+-        };
+-    };
+-    fragment@3 {
+-        target = <&gpio>;
+-        __overlay__ {
+-            gpio_ir_pins: gpio_ir_pins@c {
+-                brcm,pins = <12>;
+-                brcm,function = <0>;
+-                brcm,pull = <2>;
+-            };
+-        };
+-    };
+-    __overrides__ {
+-        ir = <&gpio_ir>,"status";
+-        ir_pins = <&gpio_ir>,"gpios:4", <&gpio_ir>,"reg:0", <&gpio_ir_pins>,"brcm,pins:0", <&gpio_ir_pins>,"reg:0";
+-    };
++				status = "okay";
++			};
++		};
++	};
++	fragment@3 {
++		target = <&gpio>;
++		__overlay__ {
++			gpio_ir_pins: gpio_ir_pins@d {
++				brcm,pins = <13>;
++				brcm,function = <0>;
++				brcm,pull = <2>;
++			};
++		};
++	};
++	__overrides__ {
++		ir = <&gpio_ir>,"status";
++		ir_pins =
++			<&gpio_ir>,"gpios:4",
++			<&gpio_ir>,"reg:0",
++			<&gpio_ir_pins>,"brcm,pins:0",
++			<&gpio_ir_pins>,"reg:0";
++	};
+ };

--- a/target/linux/bcm27xx/patches-6.6/950-1137-pwm-gpio-pwm-follow-pwm_apply_might_sleep-rename.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-1137-pwm-gpio-pwm-follow-pwm_apply_might_sleep-rename.patch
@@ -1,0 +1,32 @@
+From cd92a9591833ea06d1f12391f6b027fcecf436a9 Mon Sep 17 00:00:00 2001
+From: Ratchanan Srirattanamet <peathot@hotmail.com>
+Date: Tue, 18 Jun 2024 15:44:13 +0700
+Subject: [PATCH 1137/1145] pwm: gpio-pwm: follow pwm_apply_might_sleep()
+ rename
+
+Fixes: 03286093be68("drivers/gpio: Add a driver that wraps the PWM API as a GPIO controller")
+Signed-off-by: Ratchanan Srirattanamet <peathot@hotmail.com>
+---
+ drivers/gpio/gpio-pwm.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/drivers/gpio/gpio-pwm.c
++++ b/drivers/gpio/gpio-pwm.c
+@@ -34,7 +34,7 @@ static void pwm_gpio_set(struct gpio_chi
+ 
+ 	pwm_get_state(pwm_gpio->pwm[off], &state);
+ 	state.duty_cycle = val ? state.period : 0;
+-	pwm_apply_state(pwm_gpio->pwm[off], &state);
++	pwm_apply_might_sleep(pwm_gpio->pwm[off], &state);
+ }
+ 
+ static int pwm_gpio_parse_dt(struct pwm_gpio *pwm_gpio,
+@@ -79,7 +79,7 @@ static int pwm_gpio_parse_dt(struct pwm_
+ 		pwm_init_state(pwm_gpio->pwm[i], &state);
+ 
+ 		state.duty_cycle = 0;
+-		pwm_apply_state(pwm_gpio->pwm[i], &state);
++		pwm_apply_might_sleep(pwm_gpio->pwm[i], &state);
+ 	}
+ 
+ 	pwm_gpio->gc.ngpio = num_gpios;

--- a/target/linux/bcm27xx/patches-6.6/950-1138-drm-bridge-panel-Ensure-backlight-is-reachable.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-1138-drm-bridge-panel-Ensure-backlight-is-reachable.patch
@@ -1,0 +1,29 @@
+From da87f91ad8450ccc5274cd7b6ba8d823b396c96f Mon Sep 17 00:00:00 2001
+From: Dave Stevenson <dave.stevenson@raspberrypi.com>
+Date: Tue, 18 Jun 2024 15:33:30 +0100
+Subject: [PATCH 1138/1145] drm/bridge: panel: Ensure backlight is reachable
+
+Ensure that the various options of modules vs builtin results
+in being able to call into the backlight code.
+
+https://github.com/raspberrypi/linux/issues/6198
+
+Fixes: 573f8fd0abf1 ("drm/bridge: panel: Name an associated backlight device")
+Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>
+---
+ drivers/gpu/drm/bridge/panel.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/gpu/drm/bridge/panel.c
++++ b/drivers/gpu/drm/bridge/panel.c
+@@ -87,8 +87,10 @@ static int panel_bridge_attach(struct dr
+ 	drm_connector_attach_encoder(&panel_bridge->connector,
+ 					  bridge->encoder);
+ 
++#if IS_REACHABLE(CONFIG_BACKLIGHT_CLASS_DEVICE)
+ 	backlight_set_display_name(panel_bridge->panel->backlight,
+ 				   panel_bridge->connector.name);
++#endif
+ 
+ 	if (bridge->dev->registered) {
+ 		if (connector->funcs->reset)

--- a/target/linux/bcm27xx/patches-6.6/950-1141-fs-ntfs3-Fix-memory-corruption-when-page_size-change.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-1141-fs-ntfs3-Fix-memory-corruption-when-page_size-change.patch
@@ -1,0 +1,36 @@
+From 7af85d54e39733bb9a236b95ea5ed1ab8277d560 Mon Sep 17 00:00:00 2001
+From: Dom Cobley <popcornmix@gmail.com>
+Date: Tue, 11 Jun 2024 16:12:47 +0100
+Subject: [PATCH 1141/1145] fs/ntfs3: Fix memory corruption when page_size
+ changes
+
+The rework in fs/ntfs3: Reduce stack usage
+changes log->page_size but doesn't change the associated
+log->page_mask and log->page_bits.
+
+That results in the bytes value in read_log_page
+getting a negative value, which is bad when it is
+passed to memcpy.
+
+The kernel panic can be observed when connecting an
+ntfs formatted drive that has previously been connected
+to a Windows machine to a Raspberry Pi 5, which by defauilt
+uses a 16K kernel pagesize.
+
+Fixes: 865e7a7700d9 ("fs/ntfs3: Reduce stack usage")
+Signed-off-by: Dom Cobley <popcornmix@gmail.com>
+---
+ fs/ntfs3/fslog.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/fs/ntfs3/fslog.c
++++ b/fs/ntfs3/fslog.c
+@@ -3907,6 +3907,8 @@ check_restart_area:
+ 		log->l_size = log->orig_file_size;
+ 		log->page_size = norm_file_page(t32, &log->l_size,
+ 						t32 == DefaultLogPageSize);
++		log->page_mask = log->page_size - 1;
++		log->page_bits = blksize_bits(log->page_size);
+ 	}
+ 
+ 	if (log->page_size != t32 ||

--- a/target/linux/bcm27xx/patches-6.6/950-1142-fixup-drivers-mmc-sdhci-brcmstb-bcm2712-supports-HS4.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-1142-fixup-drivers-mmc-sdhci-brcmstb-bcm2712-supports-HS4.patch
@@ -1,0 +1,26 @@
+From d2813c02131b9ddf938277f4123da7ccbd113ea7 Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.com>
+Date: Mon, 24 Jun 2024 22:35:42 +0100
+Subject: [PATCH 1142/1145] fixup! drivers: mmc: sdhci-brcmstb: bcm2712
+ supports HS400es and clock gating
+
+Declaring auto-clockgate support for a host that can interface with
+SDIO cards is a bug.
+
+See: https://github.com/raspberrypi/linux/issues/6237
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.com>
+---
+ drivers/mmc/host/sdhci-brcmstb.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+--- a/drivers/mmc/host/sdhci-brcmstb.c
++++ b/drivers/mmc/host/sdhci-brcmstb.c
+@@ -429,7 +429,6 @@ static const struct brcmstb_match_priv m
+ };
+ 
+ static const struct brcmstb_match_priv match_priv_2712 = {
+-	.flags = BRCMSTB_MATCH_FLAGS_HAS_CLOCK_GATE,
+ 	.hs400es = sdhci_brcmstb_hs400es,
+ 	.cfginit = sdhci_brcmstb_cfginit_2712,
+ 	.ops = &sdhci_brcmstb_ops_2712,

--- a/target/linux/bcm27xx/patches-6.6/950-1144-dmaengine-dw-axi-dmac-Fixes-for-RP1.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-1144-dmaengine-dw-axi-dmac-Fixes-for-RP1.patch
@@ -1,7 +1,7 @@
-From c6cd3e6878e32548ea90c4160c534e952221c194 Mon Sep 17 00:00:00 2001
+From 3b42260d2130b5ca110c5340ab2bd055eede5968 Mon Sep 17 00:00:00 2001
 From: Phil Elwell <phil@raspberrypi.com>
 Date: Wed, 28 Apr 2021 17:46:01 +0100
-Subject: [PATCH 0536/1085] dmaengine: dw-axi-dmac: Fixes for RP1
+Subject: [PATCH 1144/1145] dmaengine: dw-axi-dmac: Fixes for RP1
 
 Don't assume that DMA addresses of devices are the same as their
 physical addresses - convert correctly.
@@ -42,9 +42,9 @@ to the source register width.
 
 Signed-off-by: Phil Elwell <phil@raspberrypi.com>
 ---
- .../dma/dw-axi-dmac/dw-axi-dmac-platform.c    | 132 +++++++++++++++---
+ .../dma/dw-axi-dmac/dw-axi-dmac-platform.c    | 136 +++++++++++++++---
  drivers/dma/dw-axi-dmac/dw-axi-dmac.h         |   1 +
- 2 files changed, 113 insertions(+), 20 deletions(-)
+ 2 files changed, 116 insertions(+), 21 deletions(-)
 
 --- a/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
 +++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
@@ -93,7 +93,15 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  	for (i = 0; i < chip->dw->hdata->nr_channels; i++) {
  		axi_chan_irq_disable(&chip->dw->chan[i], DWAXIDMAC_IRQ_ALL);
  		axi_chan_disable(&chip->dw->chan[i]);
-@@ -283,7 +306,7 @@ static struct axi_dma_lli *axi_desc_get(
+@@ -256,7 +279,6 @@ static struct axi_dma_desc *axi_desc_all
+ 		kfree(desc);
+ 		return NULL;
+ 	}
+-	desc->nr_hw_descs = num;
+ 
+ 	return desc;
+ }
+@@ -283,7 +305,7 @@ static struct axi_dma_lli *axi_desc_get(
  static void axi_desc_put(struct axi_dma_desc *desc)
  {
  	struct axi_dma_chan *chan = desc->chan;
@@ -102,7 +110,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  	struct axi_dma_hw_desc *hw_desc;
  	int descs_put;
  
-@@ -305,6 +328,48 @@ static void vchan_desc_put(struct virt_d
+@@ -305,6 +327,48 @@ static void vchan_desc_put(struct virt_d
  	axi_desc_put(vd_to_axi_desc(vdesc));
  }
  
@@ -151,7 +159,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  static enum dma_status
  dma_chan_tx_status(struct dma_chan *dchan, dma_cookie_t cookie,
  		  struct dma_tx_state *txstate)
-@@ -314,10 +379,7 @@ dma_chan_tx_status(struct dma_chan *dcha
+@@ -314,10 +378,7 @@ dma_chan_tx_status(struct dma_chan *dcha
  	enum dma_status status;
  	u32 completed_length;
  	unsigned long flags;
@@ -162,7 +170,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  
  	status = dma_cookie_status(dchan, cookie, txstate);
  	if (status == DMA_COMPLETE || !txstate)
-@@ -326,16 +388,31 @@ dma_chan_tx_status(struct dma_chan *dcha
+@@ -326,16 +387,31 @@ dma_chan_tx_status(struct dma_chan *dcha
  	spin_lock_irqsave(&chan->vc.lock, flags);
  
  	vdesc = vchan_find_desc(&chan->vc, cookie);
@@ -201,7 +209,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  
  	return status;
  }
-@@ -523,7 +600,7 @@ static void dw_axi_dma_set_hw_channel(st
+@@ -521,7 +597,7 @@ static void dw_axi_dma_set_hw_channel(st
  	unsigned long reg_value, val;
  
  	if (!chip->apb_regs) {
@@ -210,7 +218,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  		return;
  	}
  
-@@ -627,18 +704,25 @@ static int dw_axi_dma_set_hw_desc(struct
+@@ -625,18 +701,25 @@ static int dw_axi_dma_set_hw_desc(struct
  	switch (chan->direction) {
  	case DMA_MEM_TO_DEV:
  		reg_width = __ffs(chan->config.dst_addr_width);
@@ -238,7 +246,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  			DWAXIDMAC_CH_CTL_L_INC << CH_CTL_L_DST_INC_POS |
  			DWAXIDMAC_CH_CTL_L_NOINC << CH_CTL_L_SRC_INC_POS;
  		block_ts = len >> reg_width;
-@@ -674,9 +758,6 @@ static int dw_axi_dma_set_hw_desc(struct
+@@ -672,9 +755,6 @@ static int dw_axi_dma_set_hw_desc(struct
  	}
  
  	hw_desc->lli->block_ts_lo = cpu_to_le32(block_ts - 1);
@@ -248,7 +256,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  	hw_desc->lli->ctl_lo = cpu_to_le32(ctllo);
  
  	set_desc_src_master(hw_desc);
-@@ -771,6 +852,8 @@ dw_axi_dma_chan_prep_cyclic(struct dma_c
+@@ -769,6 +849,8 @@ dw_axi_dma_chan_prep_cyclic(struct dma_c
  		src_addr += segment_len;
  	}
  
@@ -257,7 +265,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  	llp = desc->hw_desc[0].llp;
  
  	/* Managed transfer list */
-@@ -850,6 +933,8 @@ dw_axi_dma_chan_prep_slave_sg(struct dma
+@@ -851,6 +933,8 @@ dw_axi_dma_chan_prep_slave_sg(struct dma
  		} while (len >= segment_len);
  	}
  
@@ -266,7 +274,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  	/* Set end-of-link to the last link descriptor of list */
  	set_desc_last(&desc->hw_desc[num_sgs - 1]);
  
-@@ -957,6 +1042,8 @@ dma_chan_prep_dma_memcpy(struct dma_chan
+@@ -958,6 +1042,8 @@ dma_chan_prep_dma_memcpy(struct dma_chan
  		num++;
  	}
  
@@ -275,7 +283,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  	/* Set end-of-link to the last link descriptor of list */
  	set_desc_last(&desc->hw_desc[num - 1]);
  	/* Managed transfer list */
-@@ -1005,7 +1092,7 @@ static void axi_chan_dump_lli(struct axi
+@@ -1006,7 +1092,7 @@ static void axi_chan_dump_lli(struct axi
  static void axi_chan_list_dump_lli(struct axi_dma_chan *chan,
  				   struct axi_dma_desc *desc_head)
  {
@@ -284,7 +292,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  	int i;
  
  	for (i = 0; i < count; i++)
-@@ -1048,11 +1135,11 @@ out:
+@@ -1049,11 +1135,11 @@ out:
  
  static void axi_chan_block_xfer_complete(struct axi_dma_chan *chan)
  {
@@ -297,7 +305,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  	u64 llp;
  	int i;
  
-@@ -1074,6 +1161,7 @@ static void axi_chan_block_xfer_complete
+@@ -1075,6 +1161,7 @@ static void axi_chan_block_xfer_complete
  	if (chan->cyclic) {
  		desc = vd_to_axi_desc(vd);
  		if (desc) {
@@ -305,7 +313,17 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  			llp = lo_hi_readq(chan->chan_regs + CH_LLP);
  			for (i = 0; i < count; i++) {
  				hw_desc = &desc->hw_desc[i];
-@@ -1323,6 +1411,10 @@ static int parse_device_properties(struc
+@@ -1095,6 +1182,9 @@ static void axi_chan_block_xfer_complete
+ 		/* Remove the completed descriptor from issued list before completing */
+ 		list_del(&vd->node);
+ 		vchan_cookie_complete(vd);
++
++		/* Submit queued descriptors after processing the completed ones */
++		axi_chan_start_first_queued(chan);
+ 	}
+ 
+ out:
+@@ -1324,6 +1414,10 @@ static int parse_device_properties(struc
  
  	chip->dw->hdata->nr_masters = tmp;
  

--- a/target/linux/bcm27xx/patches-6.6/950-1145-fixup-dmaengine-dw-axi-dmac-Fixes-for-RP1.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-1145-fixup-dmaengine-dw-axi-dmac-Fixes-for-RP1.patch
@@ -1,0 +1,89 @@
+From 769634f344626ed73bcda14c91b567067974d7b2 Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.com>
+Date: Sat, 29 Jun 2024 09:30:23 +0100
+Subject: [PATCH 1145/1145] fixup! dmaengine: dw-axi-dmac: Fixes for RP1
+
+nr_hw_descs is the upstream version of what count_hw_descs, so make
+(more) use of it instead.
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.com>
+---
+ drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c | 14 +++++++-------
+ drivers/dma/dw-axi-dmac/dw-axi-dmac.h          |  1 -
+ 2 files changed, 7 insertions(+), 8 deletions(-)
+
+--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
++++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac-platform.c
+@@ -305,7 +305,7 @@ static struct axi_dma_lli *axi_desc_get(
+ static void axi_desc_put(struct axi_dma_desc *desc)
+ {
+ 	struct axi_dma_chan *chan = desc->chan;
+-	u32 count = desc->hw_desc_count;
++	int count = desc->nr_hw_descs;
+ 	struct axi_dma_hw_desc *hw_desc;
+ 	int descs_put;
+ 
+@@ -849,7 +849,7 @@ dw_axi_dma_chan_prep_cyclic(struct dma_c
+ 		src_addr += segment_len;
+ 	}
+ 
+-	desc->hw_desc_count = total_segments;
++	desc->nr_hw_descs = total_segments;
+ 
+ 	llp = desc->hw_desc[0].llp;
+ 
+@@ -933,7 +933,7 @@ dw_axi_dma_chan_prep_slave_sg(struct dma
+ 		} while (len >= segment_len);
+ 	}
+ 
+-	desc->hw_desc_count = loop;
++	desc->nr_hw_descs = loop;
+ 
+ 	/* Set end-of-link to the last link descriptor of list */
+ 	set_desc_last(&desc->hw_desc[num_sgs - 1]);
+@@ -1042,7 +1042,7 @@ dma_chan_prep_dma_memcpy(struct dma_chan
+ 		num++;
+ 	}
+ 
+-	desc->hw_desc_count = num;
++	desc->nr_hw_descs = num;
+ 
+ 	/* Set end-of-link to the last link descriptor of list */
+ 	set_desc_last(&desc->hw_desc[num - 1]);
+@@ -1092,7 +1092,7 @@ static void axi_chan_dump_lli(struct axi
+ static void axi_chan_list_dump_lli(struct axi_dma_chan *chan,
+ 				   struct axi_dma_desc *desc_head)
+ {
+-	u32 count = desc_head->hw_desc_count;
++	int count = desc_head->nr_hw_descs;
+ 	int i;
+ 
+ 	for (i = 0; i < count; i++)
+@@ -1139,7 +1139,7 @@ static void axi_chan_block_xfer_complete
+ 	struct axi_dma_desc *desc;
+ 	struct virt_dma_desc *vd;
+ 	unsigned long flags;
+-	u32 count;
++	int count;
+ 	u64 llp;
+ 	int i;
+ 
+@@ -1161,7 +1161,7 @@ static void axi_chan_block_xfer_complete
+ 	if (chan->cyclic) {
+ 		desc = vd_to_axi_desc(vd);
+ 		if (desc) {
+-			count = desc->hw_desc_count;
++			count = desc->nr_hw_descs;
+ 			llp = lo_hi_readq(chan->chan_regs + CH_LLP);
+ 			for (i = 0; i < count; i++) {
+ 				hw_desc = &desc->hw_desc[i];
+--- a/drivers/dma/dw-axi-dmac/dw-axi-dmac.h
++++ b/drivers/dma/dw-axi-dmac/dw-axi-dmac.h
+@@ -101,7 +101,6 @@ struct axi_dma_desc {
+ 
+ 	struct virt_dma_desc		vd;
+ 	struct axi_dma_chan		*chan;
+-	u32				hw_desc_count;
+ 	u32				completed_blocks;
+ 	u32				length;
+ 	u32				period_len;


### PR DESCRIPTION
Update Raspberry Pi patches from https://github.com/raspberrypi/linux/commits/rpi-6.6.y/