### PR TITLE
tools/flex: respect STAGING_DIR_HOST

### DIFF
--- a/tools/flex/patches/300-m4-path.patch
+++ b/tools/flex/patches/300-m4-path.patch
@@ -1,0 +1,23 @@
+--- a/src/main.c
++++ b/src/main.c
+@@ -213,6 +213,8 @@ int main (int argc, char *argv[])
+ 
+ void check_options (void)
+ {
++	const char * staging_dir = NULL;
++	char * m4_staging = NULL;
+ 	int     i;
+     const char * m4 = NULL;
+ 
+@@ -341,7 +343,10 @@ void check_options (void)
+ 
+     /* Setup the filter chain. */
+     output_chain = filter_create_int(NULL, filter_tee_header, headerfilename);
+-    if ( !(m4 = getenv("M4"))) {
++    if ( (staging_dir = getenv("STAGING_DIR_HOST"))) {
++	asprintf(&m4_staging, "%s/bin/m4", staging_dir);
++	m4 = m4_staging;
++    } else if ( !(m4 = getenv("M4"))) {
+ 	    char *slash;
+ 		m4 = M4;
+ 		if ((slash = strrchr(M4, '/')) != NULL) {


### PR DESCRIPTION
flex currently leaks the path of m4 as found on the build host. While it is possible to override this using the `M4` environment variable (which we always did for autotools based builds) when using CMake or Ninja the `M4` variable is not set.
This currently breaks packages build with the SDK if not using autotools.

One easy fix is to make flex take `STAGING_DIR_HOST` into account and expect m4 there if that variable is set in the environment.

Alternatively we could also add the M4 path in `bundle-libraries.sh`, or take care of setting the `M4` variable in `cmake.mk` like we already do in `autotools.mk`.