### PR TITLE
ramips: Correct EA7300-V2 GPIO led assignments

### DIFF
--- a/target/linux/ramips/dts/mt7621_linksys_ea7300-v2.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_ea7300-v2.dts
@@ -5,6 +5,45 @@
 / {
 	compatible = "linksys,ea7300-v2", "mediatek,mt7621-soc";
 	model = "Linksys EA7300 v2";
+
+	leds {
+		compatible = "gpio-leds";
+
+		wan_green {
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1_green {
+			label = "green:lan1";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2_green {
+			label = "green:lan2";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3_green {
+			label = "green:lan3";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan4_green {
+			label = "green:lan4";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
+		};
+
+		wps {
+			function = LED_FUNCTION_WPS;
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+	};
 };
 
 /* override EEPROM size to 0x400 for MT7603 */


### PR DESCRIPTION
GPIO assignments for LEDs were incorrect, causing a conflict with USB
Fixes https://github.com/openwrt/openwrt/issues/11282

Thanks to @CeruleanSky for the initial patch