### PR TITLE
kernel: fix x86 compilation on macOS

### DIFF
--- a/target/linux/generic/hack-6.6/200-tools_portability.patch
+++ b/target/linux/generic/hack-6.6/200-tools_portability.patch
@@ -40,7 +40,20 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  # sysroots and flags or to avoid the GCC call in pure Clang builds.
 --- a/tools/include/linux/types.h
 +++ b/tools/include/linux/types.h
-@@ -56,6 +56,7 @@ typedef __s8  s8;
+@@ -10,8 +10,12 @@
+ #define __SANE_USERSPACE_TYPES__	/* For PPC64, to get LL64 types */
+ #endif
+ 
++#ifndef __linux__
++#include <tools/linux_types.h>
++#else
+ #include <asm/types.h>
+ #include <asm/posix_types.h>
++#endif
+ 
+ struct page;
+ struct kmem_cache;
+@@ -56,6 +60,7 @@ typedef __s8  s8;
  #define __user
  #endif
  #define __must_check
@@ -95,3 +108,150 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  /**
   * skip_spaces - Removes leading whitespace from @str.
+--- a/tools/arch/x86/include/asm/insn.h
++++ b/tools/arch/x86/include/asm/insn.h
+@@ -7,7 +7,7 @@
+  * Copyright (C) IBM Corporation, 2009
+  */
+ 
+-#include <asm/byteorder.h>
++#include <linux/kernel.h>
+ /* insn_attr_t is defined in inat.h */
+ #include "inat.h" /* __ignore_sync_check__ */
+ 
+--- a/tools/arch/x86/include/asm/orc_types.h
++++ b/tools/arch/x86/include/asm/orc_types.h
+@@ -46,7 +46,6 @@
+ #define ORC_TYPE_REGS_PARTIAL		4
+ 
+ #ifndef __ASSEMBLY__
+-#include <asm/byteorder.h>
+ 
+ /*
+  * This struct is more or less a vastly simplified version of the DWARF Call
+@@ -59,12 +58,12 @@
+ struct orc_entry {
+ 	s16		sp_offset;
+ 	s16		bp_offset;
+-#if defined(__LITTLE_ENDIAN_BITFIELD)
++#if __BYTE_ORDER == __LITTLE_ENDIAN
+ 	unsigned	sp_reg:4;
+ 	unsigned	bp_reg:4;
+ 	unsigned	type:3;
+ 	unsigned	signal:1;
+-#elif defined(__BIG_ENDIAN_BITFIELD)
++#elif __BYTE_ORDER == __BIG_ENDIAN
+ 	unsigned	bp_reg:4;
+ 	unsigned	sp_reg:4;
+ 	unsigned	unused:4;
+--- a/tools/include/linux/rbtree.h
++++ b/tools/include/linux/rbtree.h
+@@ -18,7 +18,6 @@
+ #define __TOOLS_LINUX_PERF_RBTREE_H
+ 
+ #include <linux/kernel.h>
+-#include <linux/stddef.h>
+ 
+ struct rb_node {
+ 	unsigned long  __rb_parent_color;
+--- a/tools/include/tools/be_byteshift.h
++++ b/tools/include/tools/be_byteshift.h
+@@ -2,6 +2,10 @@
+ #ifndef _TOOLS_BE_BYTESHIFT_H
+ #define _TOOLS_BE_BYTESHIFT_H
+ 
++#ifndef __linux__
++#include "linux_types.h"
++#endif
++
+ #include <stdint.h>
+ 
+ static inline uint16_t __get_unaligned_be16(const uint8_t *p)
+--- a/tools/include/tools/le_byteshift.h
++++ b/tools/include/tools/le_byteshift.h
+@@ -2,6 +2,10 @@
+ #ifndef _TOOLS_LE_BYTESHIFT_H
+ #define _TOOLS_LE_BYTESHIFT_H
+ 
++#ifndef __linux__
++#include "linux_types.h"
++#endif
++
+ #include <stdint.h>
+ 
+ static inline uint16_t __get_unaligned_le16(const uint8_t *p)
+--- /dev/null
++++ b/tools/include/tools/linux_types.h
+@@ -0,0 +1,18 @@
++#ifndef __LINUX_TYPES_H
++#define __LINUX_TYPES_H
++
++#include <stdint.h>
++
++typedef int8_t __s8;
++typedef uint8_t __u8;
++
++typedef int16_t __s16;
++typedef uint16_t __u16;
++
++typedef int32_t __s32;
++typedef uint32_t __u32;
++
++typedef int64_t __s64;
++typedef uint64_t __u64;
++
++#endif
+--- a/tools/objtool/Makefile
++++ b/tools/objtool/Makefile
+@@ -39,6 +39,8 @@ OBJTOOL_LDFLAGS := $(LIBELF_LIBS) $(LIBS
+ elfshdr := $(shell echo '$(pound)include <libelf.h>' | $(HOSTCC) $(OBJTOOL_CFLAGS) -x c -E - | grep elf_getshdr)
+ OBJTOOL_CFLAGS += $(if $(elfshdr),,-DLIBELF_USE_DEPRECATED)
+ 
++OBJTOOL_CFLAGS += $(HOST_EXTRACFLAGS)
++
+ # Always want host compilation.
+ HOST_OVERRIDES := CC="$(HOSTCC)" LD="$(HOSTLD)" AR="$(HOSTAR)"
+ 
+--- a/tools/objtool/orc_dump.c
++++ b/tools/objtool/orc_dump.c
+@@ -4,10 +4,10 @@
+  */
+ 
+ #include <unistd.h>
+-#include <asm/orc_types.h>
+ #include <objtool/objtool.h>
+ #include <objtool/warn.h>
+ #include <objtool/endianness.h>
++#include <asm/orc_types.h>
+ 
+ static const char *reg_name(unsigned int reg)
+ {
+--- a/tools/objtool/orc_gen.c
++++ b/tools/objtool/orc_gen.c
+@@ -7,11 +7,11 @@
+ #include <string.h>
+ 
+ #include <linux/objtool_types.h>
+-#include <asm/orc_types.h>
+ 
+ #include <objtool/check.h>
+ #include <objtool/warn.h>
+ #include <objtool/endianness.h>
++#include <asm/orc_types.h>
+ 
+ static int init_orc_entry(struct orc_entry *orc, struct cfi_state *cfi,
+ 			  struct instruction *insn)
+--- a/tools/arch/x86/lib/insn.c
++++ b/tools/arch/x86/lib/insn.c
+@@ -15,7 +15,11 @@
+ #include "../include/asm/insn.h" /* __ignore_sync_check__ */
+ #include "../include/asm-generic/unaligned.h" /* __ignore_sync_check__ */
+ 
++#ifdef __KERNEL__
+ #include <linux/errno.h>
++#else
++#include <errno.h>
++#endif
+ #include <linux/kconfig.h>
+ 
+ #include "../include/asm/emulate_prefix.h" /* __ignore_sync_check__ */


### PR DESCRIPTION
Trying to compile x86 or x86_64 on macOS will fail with: 
`openwrt/build_dir/target-x86_64_musl/linux-x86_64/linux-6.6.36/tools/include/linux/rbtree.h:21:10: fatal error: 'linux/stddef.h' file not found`

After some digging, it seems that we dropped the old 212-tools_portability patch when 6.6 x86 support was added, then Felix added back some parts of it in ("kernel: fix tools build breakage on macos with x86") but trying to build x86 kernels will still fail.

So, lets add more of the required changes from the 212-tools_portability patch so that x86 kernels build on macOS.

Fixes: 69b145188f1a ("generic: 6.6: Removal of tools_portability.patch already included in kernel 6.6")
