### PR TITLE
tools: util-linux: disable NLS again

### DIFF
--- a/tools/util-linux/Makefile
+++ b/tools/util-linux/Makefile
@@ -23,6 +23,7 @@ include $(INCLUDE_DIR)/host-build.mk
 HOST_CONFIGURE_ARGS += \
 	--with-pic \
 	--disable-shared \
+	--disable-nls \
 	--disable-all-programs \
 	--enable-hexdump \
 	--enable-libuuid \


### PR DESCRIPTION
It seems that util-linux enables NLS support by default, this worked for
almost all platforms except for macOS on x86 where it seems that libintl is
preinstalled and thus it will link against gettext with libintl for NLS
support.

This would the later cause e2fsprogs and mtd-utils to fail:
```
Undefined symbols for architecture x86_64:
  "_libintl_gettext", referenced from:
      _random_tell_source in libuuid.a[13](libuuid_la-randutils.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Issue appeared after I converted the tool to use --disable-all-programs and
accidentally dropped the --disable-nls from the args.

Fixes: 54115ec22d15 ("tools: util-linux: use --disable-all-programs")
Signed-off-by: Robert Marko <robimarko@gmail.com>