### PR TITLE
mac80211: realtek: rtw88: add support for RTL8723DS and RTL8723DU

### DIFF
--- a/package/kernel/mac80211/realtek.mk
+++ b/package/kernel/mac80211/realtek.mk
@@ -1,9 +1,9 @@
 PKG_DRIVERS += \
 	rtlwifi rtlwifi-pci rtlwifi-btcoexist rtlwifi-usb rtl8192c-common \
 	rtl8192ce rtl8192se rtl8192de rtl8192cu rtl8723-common rtl8723be rtl8723bs rtl8821ae \
-	rtl8xxxu rtw88 rtw88-pci rtw88-usb rtw88-8821c rtw88-8822b rtw88-8822c \
+	rtl8xxxu rtw88 rtw88-pci rtw88-usb rtw88-sdio rtw88-8821c rtw88-8822b rtw88-8822c \
 	rtw88-8723d rtw88-8821ce rtw88-8821cu rtw88-8822be rtw88-8822bu \
-	rtw88-8822ce rtw88-8822cu rtw88-8723de
+	rtw88-8822ce rtw88-8822cu rtw88-8723de rtw88-8723ds rtw88-8723du
 
 config-$(call config_package,rtlwifi) += RTL_CARDS RTLWIFI
 config-$(call config_package,rtlwifi-pci) += RTLWIFI_PCI
@@ -29,6 +29,7 @@ config-y += STAGING
 config-$(call config_package,rtw88) += RTW88 RTW88_CORE
 config-$(call config_package,rtw88-pci) += RTW88_PCI
 config-$(call config_package,rtw88-usb) += RTW88_USB
+config-$(call config_package,rtw88-sdio) += RTW88_SDIO
 config-$(call config_package,rtw88-8821c) += RTW88_8821C
 config-$(call config_package,rtw88-8821ce) += RTW88_8821CE
 config-$(call config_package,rtw88-8821cu) += RTW88_8821CU
@@ -40,6 +41,8 @@ config-$(call config_package,rtw88-8822ce) += RTW88_8822CE
 config-$(call config_package,rtw88-8822cu) += RTW88_8822CU
 config-$(call config_package,rtw88-8723d) += RTW88_8723D
 config-$(call config_package,rtw88-8723de) += RTW88_8723DE
+config-$(call config_package,rtw88-8723ds) += RTW88_8723DS
+config-$(call config_package,rtw88-8723du) += RTW88_8723DU
 config-$(CONFIG_PACKAGE_RTW88_DEBUG) += RTW88_DEBUG
 config-$(CONFIG_PACKAGE_RTW88_DEBUGFS) += RTW88_DEBUGFS
 
@@ -186,7 +189,7 @@ endef
 define KernelPackage/rtw88
   $(call KernelPackage/mac80211/Default)
   TITLE:=Realtek RTW88 common part
-  DEPENDS+= @(PCI_SUPPORT||USB_SUPPORT) +kmod-mac80211
+  DEPENDS+= +kmod-mac80211
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_core.ko
   AUTOLOAD:=$(call AutoProbe,rtw88_core)
   HIDDEN:=1
@@ -198,6 +201,15 @@ define KernelPackage/rtw88-pci
   DEPENDS+= @PCI_SUPPORT +kmod-rtw88
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_pci.ko
   AUTOLOAD:=$(call AutoProbe,rtw88_pci)
+  HIDDEN:=1
+endef
+
+define KernelPackage/rtw88-sdio
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTW88 SDIO chips support
+  DEPENDS+= +kmod-mmc +kmod-rtw88
+  FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_sdio.ko
+  AUTOLOAD:=$(call AutoProbe,rtw88_sdio)
   HIDDEN:=1
 endef
 
@@ -299,7 +311,23 @@ define KernelPackage/rtw88-8723de
   TITLE:=Realtek RTL8723DE support
   DEPENDS+= +kmod-rtw88-pci +kmod-rtw88-8723d
   FILES:= $(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8723de.ko
-  AUTOLOAD:=$(call AutoProbe,rtw88_8723)
+  AUTOLOAD:=$(call AutoProbe,rtw88_8723de)
+endef
+
+define KernelPackage/rtw88-8723ds
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTL8723DS support
+  DEPENDS+= +kmod-rtw88-sdio +kmod-rtw88-8723d
+  FILES:= $(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8723ds.ko
+  AUTOLOAD:=$(call AutoProbe,rtw88_8723ds)
+endef
+
+define KernelPackage/rtw88-8723du
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTL8723DU support
+  DEPENDS+= +kmod-rtw88-usb +kmod-rtw88-8723d
+  FILES:= $(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw88/rtw88_8723du.ko
+  AUTOLOAD:=$(call AutoProbe,rtw88_8723du)
 endef
 
 define KernelPackage/rtl8723-common

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -144,7 +144,7 @@ define Device/radxa_rock-pi-e-v3
   DEVICE_MODEL := ROCK Pi E v3.0
   SOC := rk3328
   DEVICE_DTS := rockchip/rk3328-rock-pi-e
-  DEVICE_PACKAGES := kmod-usb-net-cdc-ncm kmod-usb-net-rndis
+  DEVICE_PACKAGES := kmod-rtw88-8723du kmod-usb-net-cdc-ncm kmod-usb-net-rndis wpad-basic-mbedtls
 endef
 TARGET_DEVICES += radxa_rock-pi-e-v3
 

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -153,7 +153,7 @@ define Device/radxa_rock-pi-s
   DEVICE_MODEL := ROCK Pi S
   SOC := rk3308
   BOOT_SCRIPT := rock-pi-s
-  DEVICE_PACKAGES := kmod-usb-net-cdc-ncm kmod-usb-net-rndis
+  DEVICE_PACKAGES := kmod-rtw88-8723ds kmod-usb-net-cdc-ncm kmod-usb-net-rndis wpad-basic-mbedtls
 endef
 TARGET_DEVICES += radxa_rock-pi-s
 

--- a/target/linux/rockchip/patches-6.6/010-next-soc-rockchip-io-domain-Add-RK3308-IO-voltage-domains.patch
+++ b/target/linux/rockchip/patches-6.6/010-next-soc-rockchip-io-domain-Add-RK3308-IO-voltage-domains.patch
@@ -1,0 +1,86 @@
+From 0536fa6e6fa3e48f4ca11855b586c277be524fbe Mon Sep 17 00:00:00 2001
+From: David Wu <david.wu@rock-chips.com>
+Date: Tue, 21 May 2024 21:10:13 +0000
+Subject: [PATCH] soc: rockchip: io-domain: Add RK3308 IO voltage domains
+
+Add IO voltage domains support for the RK3308 SoC.
+
+Signed-off-by: David Wu <david.wu@rock-chips.com>
+Signed-off-by: Jianqun Xu <jay.xu@rock-chips.com>
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+Link: https://lore.kernel.org/r/20240521211029.1236094-11-jonas@kwiboo.se
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ drivers/soc/rockchip/io-domain.c | 40 ++++++++++++++++++++++++++++++++
+ 1 file changed, 40 insertions(+)
+
+--- a/drivers/soc/rockchip/io-domain.c
++++ b/drivers/soc/rockchip/io-domain.c
+@@ -39,6 +39,10 @@
+ #define RK3288_SOC_CON2_FLASH0		BIT(7)
+ #define RK3288_SOC_FLASH_SUPPLY_NUM	2
+ 
++#define RK3308_SOC_CON0			0x300
++#define RK3308_SOC_CON0_VCCIO3		BIT(8)
++#define RK3308_SOC_VCCIO3_SUPPLY_NUM	3
++
+ #define RK3328_SOC_CON4			0x410
+ #define RK3328_SOC_CON4_VCCIO2		BIT(7)
+ #define RK3328_SOC_VCCIO2_SUPPLY_NUM	1
+@@ -229,6 +233,25 @@ static void rk3288_iodomain_init(struct
+ 		dev_warn(iod->dev, "couldn't update flash0 ctrl\n");
+ }
+ 
++static void rk3308_iodomain_init(struct rockchip_iodomain *iod)
++{
++	int ret;
++	u32 val;
++
++	/* if no vccio3 supply we should leave things alone */
++	if (!iod->supplies[RK3308_SOC_VCCIO3_SUPPLY_NUM].reg)
++		return;
++
++	/*
++	 * set vccio3 iodomain to also use this framework
++	 * instead of a special gpio.
++	 */
++	val = RK3308_SOC_CON0_VCCIO3 | (RK3308_SOC_CON0_VCCIO3 << 16);
++	ret = regmap_write(iod->grf, RK3308_SOC_CON0, val);
++	if (ret < 0)
++		dev_warn(iod->dev, "couldn't update vccio3 vsel ctrl\n");
++}
++
+ static void rk3328_iodomain_init(struct rockchip_iodomain *iod)
+ {
+ 	int ret;
+@@ -376,6 +399,19 @@ static const struct rockchip_iodomain_so
+ 	.init = rk3288_iodomain_init,
+ };
+ 
++static const struct rockchip_iodomain_soc_data soc_data_rk3308 = {
++	.grf_offset = 0x300,
++	.supply_names = {
++		"vccio0",
++		"vccio1",
++		"vccio2",
++		"vccio3",
++		"vccio4",
++		"vccio5",
++	},
++	.init = rk3308_iodomain_init,
++};
++
+ static const struct rockchip_iodomain_soc_data soc_data_rk3328 = {
+ 	.grf_offset = 0x410,
+ 	.supply_names = {
+@@ -529,6 +565,10 @@ static const struct of_device_id rockchi
+ 		.data = &soc_data_rk3288
+ 	},
+ 	{
++		.compatible = "rockchip,rk3308-io-voltage-domain",
++		.data = &soc_data_rk3308
++	},
++	{
+ 		.compatible = "rockchip,rk3328-io-voltage-domain",
+ 		.data = &soc_data_rk3328
+ 	},

--- a/target/linux/rockchip/patches-6.6/011-v6.11-arm64-dts-rockchip-Add-rk3308-IO-voltage-domains.patch
+++ b/target/linux/rockchip/patches-6.6/011-v6.11-arm64-dts-rockchip-Add-rk3308-IO-voltage-domains.patch
@@ -1,0 +1,28 @@
+From d1829ba469d5743734e37d59fece73e3668ab084 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Tue, 21 May 2024 21:10:14 +0000
+Subject: [PATCH] arm64: dts: rockchip: Add rk3308 IO voltage domains
+
+Add a disabled RK3308 IO voltage domains node to SoC DT.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+Link: https://lore.kernel.org/r/20240521211029.1236094-12-jonas@kwiboo.se
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3308.dtsi | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
+@@ -168,6 +168,11 @@
+ 		compatible = "rockchip,rk3308-grf", "syscon", "simple-mfd";
+ 		reg = <0x0 0xff000000 0x0 0x08000>;
+ 
++		io_domains: io-domains {
++			compatible = "rockchip,rk3308-io-voltage-domain";
++			status = "disabled";
++		};
++
+ 		reboot-mode {
+ 			compatible = "syscon-reboot-mode";
+ 			offset = <0x500>;

--- a/target/linux/rockchip/patches-6.6/047-v6.11-arm64-dts-rockchip-Add-io-domains-to-rk3308-rock-pi-.patch
+++ b/target/linux/rockchip/patches-6.6/047-v6.11-arm64-dts-rockchip-Add-io-domains-to-rk3308-rock-pi-.patch
@@ -1,0 +1,35 @@
+From 100b3bdee6035192f6d4a1847970fe004bb505fb Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Tue, 21 May 2024 21:10:15 +0000
+Subject: [PATCH] arm64: dts: rockchip: Add io-domains to rk3308-rock-pi-s
+
+The VCCIO4 io-domain used for WiFi/BT is using 1v8 IO signal voltage.
+
+Add io-domains node with the VCCIO supplies connected on the board.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+Link: https://lore.kernel.org/r/20240521211029.1236094-13-jonas@kwiboo.se
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
+@@ -231,6 +231,16 @@
+ 	status = "okay";
+ };
+ 
++&io_domains {
++	vccio0-supply = <&vcc_io>;
++	vccio1-supply = <&vcc_io>;
++	vccio2-supply = <&vcc_io>;
++	vccio3-supply = <&vcc_io>;
++	vccio4-supply = <&vcc_1v8>;
++	vccio5-supply = <&vcc_io>;
++	status = "okay";
++};
++
+ &pinctrl {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&rtc_32k>;

--- a/target/linux/rockchip/patches-6.6/048-v6.11-arm64-dts-rockchip-Update-WIFi-BT-related-nodes-on-r.patch
+++ b/target/linux/rockchip/patches-6.6/048-v6.11-arm64-dts-rockchip-Update-WIFi-BT-related-nodes-on-r.patch
@@ -1,0 +1,97 @@
+From 12c3ec878cbe3709782e85b88124abecc3bb8617 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Tue, 21 May 2024 21:10:16 +0000
+Subject: [PATCH] arm64: dts: rockchip: Update WIFi/BT related nodes on
+ rk3308-rock-pi-s
+
+Update WiFi SDIO and BT UART related props to better reflect details
+about the optional onboard RTL8723DS WiFi/BT module.
+
+Also correct the compatible used for bluetooth to match the WiFi/BT
+module used on the board.
+
+Fixes: bc3753aed81f ("arm64: dts: rockchip: rock-pi-s add more peripherals")
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+Link: https://lore.kernel.org/r/20240521211029.1236094-14-jonas@kwiboo.se
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ .../boot/dts/rockchip/rk3308-rock-pi-s.dts    | 40 +++++++++++++++++--
+ 1 file changed, 36 insertions(+), 4 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
+@@ -17,6 +17,7 @@
+ 		ethernet0 = &gmac;
+ 		mmc0 = &emmc;
+ 		mmc1 = &sdmmc;
++		mmc2 = &sdio;
+ 	};
+ 
+ 	chosen {
+@@ -245,6 +246,20 @@
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&rtc_32k>;
+ 
++	bluetooth {
++		bt_reg_on: bt-reg-on {
++			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		bt_wake_host: bt-wake-host {
++			rockchip,pins = <4 RK_PB4 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++
++		host_wake_bt: host-wake-bt {
++			rockchip,pins = <4 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
+ 	gmac {
+ 		mac_rst: mac-rst {
+ 			rockchip,pins = <0 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
+@@ -294,11 +309,24 @@
+ 	cap-sd-highspeed;
+ 	cap-sdio-irq;
+ 	keep-power-in-suspend;
+-	max-frequency = <1000000>;
++	max-frequency = <100000000>;
+ 	mmc-pwrseq = <&sdio_pwrseq>;
++	no-mmc;
++	no-sd;
+ 	non-removable;
+-	sd-uhs-sdr104;
++	sd-uhs-sdr50;
++	vmmc-supply = <&vcc_io>;
++	vqmmc-supply = <&vcc_1v8>;
+ 	status = "okay";
++
++	rtl8723ds: wifi@1 {
++		reg = <1>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PA0 IRQ_TYPE_LEVEL_HIGH>;
++		interrupt-names = "host-wake";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_host_wake>;
++	};
+ };
+ 
+ &sdmmc {
+@@ -330,12 +358,16 @@
+ };
+ 
+ &uart4 {
++	uart-has-rtscts;
+ 	status = "okay";
+ 
+ 	bluetooth {
+-		compatible = "realtek,rtl8723bs-bt";
+-		device-wake-gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_HIGH>;
++		compatible = "realtek,rtl8723ds-bt";
++		device-wake-gpios = <&gpio4 RK_PB2 GPIO_ACTIVE_HIGH>;
++		enable-gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_HIGH>;
+ 		host-wake-gpios = <&gpio4 RK_PB4 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&bt_reg_on &bt_wake_host &host_wake_bt>;
+ 	};
+ };
+ 

--- a/target/linux/rockchip/patches-6.6/113-rock-pi-s-add-led-aliases-and-stop-heartbeat.patch
+++ b/target/linux/rockchip/patches-6.6/113-rock-pi-s-add-led-aliases-and-stop-heartbeat.patch
@@ -1,9 +1,9 @@
 --- a/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
-@@ -17,6 +17,10 @@
- 		ethernet0 = &gmac;
+@@ -18,6 +18,10 @@
  		mmc0 = &emmc;
  		mmc1 = &sdmmc;
+ 		mmc2 = &sdio;
 +		led-boot = &blue_led;
 +		led-failsafe = &blue_led;
 +		led-running = &blue_led;
@@ -11,7 +11,7 @@
  	};
  
  	chosen {
-@@ -28,22 +32,19 @@
+@@ -29,22 +33,19 @@
  		pinctrl-names = "default";
  		pinctrl-0 = <&green_led>, <&heartbeat_led>;
  


### PR DESCRIPTION
add Realtek RTL8723DS and RTL8723DU support to rtw88 package.

currently it doesn't work on target devices. (8723DS for ROCK Pi S, 8723DU for ROCK Pi E)
kernel modules are loaded, but nothing happen. wlan device is not populated.

testers wanted.