### PR TITLE
rockchip: stop "heartbeat" LED for Radxa CM3I(E25)

### DIFF
--- a/target/linux/rockchip/patches-6.6/112-radxa-e25-add-led-aliases-and-stop-heartbeat.patch
+++ b/target/linux/rockchip/patches-6.6/112-radxa-e25-add-led-aliases-and-stop-heartbeat.patch
@@ -22,3 +22,14 @@ Signed-off-by: Marius Durbaca <mariusd84@gmail.com>
  	};
  
  	pwm-leds {
+--- a/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3i.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3i.dtsi
+@@ -23,7 +23,7 @@
+ 			gpios = <&gpio0 RK_PA6 GPIO_ACTIVE_HIGH>;
+ 			function = LED_FUNCTION_HEARTBEAT;
+ 			color = <LED_COLOR_ID_GREEN>;
+-			linux,default-trigger = "heartbeat";
++			default-state = "on";
+ 			pinctrl-names = "default";
+ 			pinctrl-0 = <&led_user_en>;
+ 		};


### PR DESCRIPTION
stop "heartbeat" which happens before OpenWrt controls LED. instead, just turn LED on.