### PR TITLE
ncurses: add foot terminfo

### DIFF
--- a/package/libs/ncurses/Makefile
+++ b/package/libs/ncurses/Makefile
@@ -126,6 +126,7 @@ ifneq ($(HOST_OS),FreeBSD)
 		a/ansi \
 		a/alacritty \
 		d/dumb \
+		f/foot \
 		l/linux \
 		r/rxvt \
 		r/rxvt-unicode \


### PR DESCRIPTION
Add terminfo file for the terminal emulator foot.

https://codeberg.org/dnkl/foot

Prior art: #12078