### PR TITLE
 [2305]: ath79: Revert "ath79: calibrate dlink dir-825 b1 with nvmem" 

### DIFF
--- a/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
+++ b/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
@@ -139,8 +139,7 @@
 	ath9k0: wifi@0,11 {
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
-		nvmem-cells = <&macaddr_lan>, <&cal_art_1000>;
-		nvmem-cell-names = "mac-address-ascii", "calibration";
+		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -148,9 +147,7 @@
 	ath9k1: wifi@0,12 {
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
-		nvmem-cells = <&macaddr_wan>, <&cal_art_5000>;
-		nvmem-cell-names = "mac-address-ascii", "calibration";
-		mac-address-increment = <1>;
+		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -187,28 +184,9 @@
 			};
 
 			partition@660000 {
-				compatible = "nvmem-cells";
 				label = "caldata";
 				reg = <0x660000 0x010000>;
 				read-only;
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				cal_art_1000: cal@1000 {
-					reg = <0x1000 0xeb8>;
-				};
-
-				cal_art_5000: cal@5000 {
-					reg = <0x5000 0xeb8>;
-				};
-
-				macaddr_lan: macaddr@ffa0 {
-					reg = <0xffa0 0x11>;
-				};
-
-				macaddr_wan: macaddr@ffb4 {
-					reg = <0xffb4 0x11>;
-				};
 			};
 
 			fwconcat1: partition@670000 {
@@ -224,9 +202,6 @@
 
 	pll-data = <0x11110000 0x00001099 0x00991099>;
 
-	nvmem-cells = <&macaddr_lan>;
-	nvmem-cell-names = "mac-address-ascii";
-
 	fixed-link {
 		speed = <1000>;
 		full-duplex;
@@ -238,9 +213,5 @@
 
 	pll-data = <0x11110000 0x00001099 0x00991099>;
 
-	nvmem-cells = <&macaddr_wan>;
-	nvmem-cell-names = "mac-address-ascii";
-
 	phy-handle = <&phy4>;
 };
-

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -642,6 +642,7 @@ ath79_setup_macs()
 	dlink,dir-629-a1)
 		wan_mac=$(mtd_get_mac_text "mfcdata" 0x6a)
 		;;
+	dlink,dir-825-b1|\
 	trendnet,tew-673gru)
 		lan_mac=$(mtd_get_mac_text "caldata" 0xffa0)
 		wan_mac=$(mtd_get_mac_text "caldata" 0xffb4)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -133,6 +133,7 @@ case "$FIRMWARE" in
 	buffalo,wzr-hp-ag300h)
 		caldata_extract "art" 0x1000 0xeb8
 		;;
+	dlink,dir-825-b1|\
 	trendnet,tew-673gru)
 		caldata_extract "caldata" 0x1000 0xeb8
 		ath9k_patch_mac_crc $(mtd_get_mac_text "caldata" 0xffa0) 0x20c
@@ -151,6 +152,7 @@ case "$FIRMWARE" in
 	buffalo,wzr-hp-ag300h)
 		caldata_extract "art" 0x5000 0xeb8
 		;;
+	dlink,dir-825-b1|\
 	trendnet,tew-673gru)
 		caldata_extract "caldata" 0x5000 0xeb8
 		ath9k_patch_mac_crc $(macaddr_add $(mtd_get_mac_text "caldata" 0xffb4) 1) 0x20c


### PR DESCRIPTION
DIR-852-B1 starts with random LAN & WAN MAC addresses
reverting this commit makes it the same as it's working twin
ar7161_trendnet_tew-673gru.dts

snapshot MAC addresses work this is only to fix V23.05

This reverts commit https://github.com/openwrt/openwrt/commit/de3d60b982c7b8e1821b90b312db57287e74ede3.
