### PR TITLE
[23.05] ramips: limit max spi clock frequency to 50 MHz

### DIFF
--- a/target/linux/ramips/dts/mt7620a_dlink_dch-m225.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dch-m225.dts
@@ -98,7 +98,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
@@ -93,7 +93,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7620a_domywifi.dtsi
+++ b/target/linux/ramips/dts/mt7620a_domywifi.dtsi
@@ -93,7 +93,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
@@ -31,7 +31,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7620a_netcore_nw5212.dts
+++ b/target/linux/ramips/dts/mt7620a_netcore_nw5212.dts
@@ -73,7 +73,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <70000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7620a_phicomm_k2x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_phicomm_k2x.dtsi
@@ -48,7 +48,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions: partitions {

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
@@ -53,7 +53,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7620a_sercomm_cpj.dtsi
+++ b/target/linux/ramips/dts/mt7620a_sercomm_cpj.dtsi
@@ -160,7 +160,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <70000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
+++ b/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
@@ -78,7 +78,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <70000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
@@ -59,7 +59,7 @@
 	flash0: flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7621_arcadyan_we420223-99.dts
+++ b/target/linux/ramips/dts/mt7621_arcadyan_we420223-99.dts
@@ -105,7 +105,7 @@
 		compatible = "jedec,spi-nor";
 
 		reg = <0>;
-		spi-max-frequency = <70000000>;
+		spi-max-frequency = <50000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7621_iptime_a6004ns-m.dtsi
+++ b/target/linux/ramips/dts/mt7621_iptime_a6004ns-m.dtsi
@@ -65,7 +65,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7621_jcg_jhr-ac876m.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_jhr-ac876m.dts
@@ -63,7 +63,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7621_jcg_y2.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_y2.dts
@@ -41,7 +41,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-lite.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-lite.dts
@@ -55,7 +55,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <104000000>;
+		spi-max-frequency = <50000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
@@ -96,7 +96,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7621_tplink_mr600-v2-eu.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_mr600-v2-eu.dts
@@ -88,7 +88,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dtsi
+++ b/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dtsi
@@ -42,7 +42,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7621_winstars_ws-wn583a6.dts
+++ b/target/linux/ramips/dts/mt7621_winstars_ws-wn583a6.dts
@@ -63,7 +63,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <104000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
@@ -87,7 +87,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7621_yuncore_fap640.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_fap640.dts
@@ -95,7 +95,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7621_yuncore_fap690.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_fap690.dts
@@ -65,7 +65,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7628an_duzun_dm06.dts
+++ b/target/linux/ramips/dts/mt7628an_duzun_dm06.dts
@@ -96,7 +96,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <60000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5x61a.dtsi
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5x61a.dtsi
@@ -36,7 +36,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7628an_motorola_mwr03.dts
+++ b/target/linux/ramips/dts/mt7628an_motorola_mwr03.dts
@@ -47,7 +47,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7628an_netgear_r6xxx.dtsi
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6xxx.dtsi
@@ -65,7 +65,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <86000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions: partitions {

--- a/target/linux/ramips/dts/rt5350_zyxel_keenetic-lite-b.dts
+++ b/target/linux/ramips/dts/rt5350_zyxel_keenetic-lite-b.dts
@@ -53,7 +53,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <60000000>;
+		spi-max-frequency = <50000000>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
Snapshot PR: https://github.com/openwrt/openwrt/pull/15897

------

In the past few years, we have received several reports about SPI Flash not working properly. This is caused by excessively fast clock frequency. It's really annoying to fix them one by one. Let's reduce these aggressive frequencies to 50 MHz. This is a safe and suggested value in the vendor SDK.

Signed-off-by: Shiji Yang <yangshiji66@qq.com>
(cherry picked from commit 73eeac49be566d389df728b5335f7146d03d2f90)