### PR TITLE
ncurses: add kitty terminfo

### DIFF
--- a/package/libs/ncurses/Makefile
+++ b/package/libs/ncurses/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=ncurses
 PKG_CPE_ID:=cpe:/a:gnu:ncurses
 PKG_VERSION:=6.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
@@ -127,6 +127,7 @@ ifneq ($(HOST_OS),FreeBSD)
 		a/alacritty \
 		d/dumb \
 		f/foot \
+		k/kitty \
 		l/linux \
 		r/rxvt \
 		r/rxvt-unicode \


### PR DESCRIPTION
Ncurses has terminfo for kitty, so lets install it in order to remove the kitty-terminfo package.
