### PR TITLE
wireless-regdb: Update to version 2024-07-04

### DIFF
--- a/package/firmware/wireless-regdb/Makefile
+++ b/package/firmware/wireless-regdb/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wireless-regdb
-PKG_VERSION:=2024.05.08
+PKG_VERSION:=2024.07.04
 PKG_RELEASE:=1
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/network/wireless-regdb/
-PKG_HASH:=9aee1d86ebebb363b714bec941b2820f31e3b7f1a485ddc9fcbd9985c7d3e7c4
+PKG_HASH:=9832a14e1be24abff7be30dee3c9a1afb5fdfcf475a0d91aafef039f8d85f5eb
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
Changes:
```
2a768c4 wireless-regdb: Update regulatory rules for Mongolia (MN) on 6GHz
04875d9 wireless-regdb: Update regulatory rules for Saudi Arabia (SA) on 6GHz
b7bced8 wireless-regdb: Update regulatory rules for South Africa (ZA) on 6GHz
7bc8615 wireless-regdb: Update regulatory info for Thailand (TH) on 6GHz
f901fa9 wireless-regdb: Update regulatory info for Malaysia (MY) for 2022
d72d288 wireless-regdb: Update regulatory info for Morocco (MA) on 6GHz
414face wireless-regdb: Update regulatory info for Chile (CL) on 6GHz
1156a08 wireless-regdb: Update regulatory info for Mexico (MX) on 6GHz
cc6cf7c wireless-regdb: Update regulatory info for Iceland (IS) on 6GHz
ce03cc0 wireless-regdb: Update regulatory info for Mauritius(MU) on 6GHz
7e37778 wireless-regdb: Update regulatory info for Argentina (AR) on 6GHz
56f3a43 wireless-regdb: Update regulatory info for United Arab Emirates (AE) on 6GHz
3cb8b91 wireless-regdb: Update regulatory info for Colombia (CO) on 6GHz
3682ce5 wireless-regdb: Update regulatory info for Costa Rica (CR) for 2021
dd4ffe7 wireless-regdb: Update regulatory info for Dominican Republic (DO) on 6GHz
f8ef7da wireless-regdb: Update regulatory info for Liechtenstein (LI) on 6GHz
a9ecabe wireless-regdb: Update regulatory info for Jordan (JO) for 2022
5a9fdad wireless-regdb: Update regulatory info for Kenya (KE) for 2022
19326c3 wireless-regdb: Update regulatory info for Macao (MO) for 2024
4838054 wireless-regdb: update regulatory database based on preceding changes
```