### PR TITLE
wifi-scripts: add missing dependency on ucode-mod-rtnl

### DIFF
--- a/package/network/config/wifi-scripts/Makefile
+++ b/package/network/config/wifi-scripts/Makefile
@@ -19,7 +19,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/wifi-scripts
   SECTION:=utils
   CATEGORY:=Base system
-  DEPENDS:=+netifd +ucode +ucode-mod-nl80211 +ucode-mod-ubus +ucode-mod-uci
+  DEPENDS:=+netifd +ucode +ucode-mod-nl80211 +ucode-mod-rtnl +ucode-mod-ubus +ucode-mod-uci
   TITLE:=Wi-Fi configuration scripts
   PKGARCH:=all
 endef


### PR DESCRIPTION
rtnl is used in hostap/common.uc.

$ grep -r rtnl files
files/usr/share/hostap/common.uc:import * as rtnl from "rtnl";
files/usr/share/hostap/common.uc:	     rtnl.request(rtnl.const.RTM_SETLINK, 0, { dev: reuse_ifname, ifname: name}) != false))
files/usr/share/hostap/common.uc:	rtnl.request(rtnl.const.RTM_SETLINK, 0, { dev: name, change: 1, flags: up ? 1 : 0 });