### PR TITLE
ath79: qca9563: Ubiquiti Amplifi Router HD: add DEVICE_VENDOR Ubiquiti

### DIFF
--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -24,6 +24,7 @@ define Device/ubnt_amplifi-router-hd
   UBNT_TYPE := AFi-R
   UBNT_VERSION := 3.6.3
   SOC := qca9563
+  DEVICE_VENDOR := Ubiquiti
   DEVICE_MODEL := AmpliFi Router HD
   UBNT_CHIP := qca956x
   DEVICE_PACKAGES += kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct kmod-usb2


### PR DESCRIPTION
In make menuconfig the name is `[Amplifi Router HD]`, and is missing `Ubiquiti`. 
Lets fix that by adding `DEVICE_VENDOR := Ubiquiti` to `generic-ubnt.mk` so the name is: 
`[Ubiquiti Amplifi Router HD]`.

Signed-off-by: Kristian Skramstad <kristian+github@83.no>