### PR TITLE
mediatek: filogic: bpi-r3-mini: Fix pwm-fan config

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-bananapi-bpi-r3-mini.dts
+++ b/target/linux/mediatek/dts/mt7986a-bananapi-bpi-r3-mini.dts
@@ -73,8 +73,8 @@
 	fan: pwm-fan {
 		compatible = "pwm-fan";
 		#cooling-cells = <2>;
-		cooling-levels = <255 128 80 0>;
-		pwms = <&pwm 0 10000 0>;
+		cooling-levels = <255 175 80 0>;
+		pwms = <&pwm 0 10000>;
 		status = "okay";
 	};
 
@@ -121,18 +121,18 @@
 
 &cpu_thermal {
 	cooling-maps {
-		cpu-active-low {
-			cooling-device = <&fan 1 1>;
+		map-cpu-active-low {
+			cooling-device = <&fan 0 1>;
 			trip = <&cpu_trip_active_low>;
 		};
 
-		cpu-active-med {
-			cooling-device = <&fan 2 2>;
+		map-cpu-active-med {
+			cooling-device = <&fan 1 2>;
 			trip = <&cpu_trip_active_med>;
 		};
 
-		cpu-active-high {
-			cooling-device = <&fan 3 3>;
+		map-cpu-active-high {
+			cooling-device = <&fan 2 3>;
 			trip = <&cpu_trip_active_high>;
 		};
 	};


### PR DESCRIPTION
This patch did multiple modifications on pwm-fan related config for Banana Pi R3-Mini.
1. Remove suffix zero on pwm-fan's pwms. [[1]](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3.dts?id=7865abbbdf1e1ee57a0bb8ec83079f8840c16854)
2. Add "map-" prefix for cooling-maps. [[2]](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3.dts?id=f8c65a5e4560781f2ea175d8f26cd75ac98e8d78)
3. Change cooling-levels for pwm-fan to make sure the fan would start spining when using Sinovoip's official case.
4. Change cooling-device level config to follow common implementation.