### PR TITLE
realtek: d-link: add support for dgs-1210-28p-f

### DIFF
--- a/target/linux/generic/hack-6.6/820-hwmon-lm63-add-init-commands-to-initialize-regs.patch
+++ b/target/linux/generic/hack-6.6/820-hwmon-lm63-add-init-commands-to-initialize-regs.patch
@@ -1,0 +1,80 @@
+From 7c3953b2cd382911c21eeb9de94529d8a27f8a5e Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Tue, 24 Sep 2024 17:36:42 -0300
+Subject: [PATCH] hwmon: (lm63) add init-commands to initialize regs
+
+Normally, the lm63 is initialized by the BIOS or equivalent. However,
+in some cases like embeded devices, the OS is completely responsible for
+setting the device.
+
+The new init-commands property is an array of registers/values (reg1,
+val1, reg2, val2...) that, if present, are applied before the old
+initalization procedure.
+
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+---
+ drivers/hwmon/lm63.c | 46 ++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 46 insertions(+)
+
+--- a/drivers/hwmon/lm63.c
++++ b/drivers/hwmon/lm63.c
+@@ -1007,6 +1007,50 @@ static int lm63_detect(struct i2c_client
+ 	return 0;
+ }
+ 
++/* When the BIOS (or equivalent) does not initialize anything, "init-command"
++ * property can specify an array of [reg1 value1 reg2 value2...] up to 32
++ * elements (or 16 commands)
++ */
++static void lm63_load_init_command(struct lm63_data *data)
++{
++	struct i2c_client *client = data->client;
++	struct device *dev = &client->dev;
++	u8 init_commands[32];
++	u8 reg, value;
++	int count, err, i;
++
++	count = of_property_count_u8_elems(dev->of_node, "init-commands");
++	if (count <= 0) {
++		dev_dbg(dev, "init-commands property not found\n");
++		return;
++	}
++
++	if (count > ARRAY_SIZE(init_commands)) {
++		dev_err(dev, "init-commands larger than %ld bytes",
++			     ARRAY_SIZE(init_commands));
++		return;
++	}
++	if (count % 2) {
++		dev_err(dev,
++			"init-commands should have even number of elements");
++		return;
++	}
++
++	err = of_property_read_u8_array(dev->of_node, "init-commands",
++					init_commands, count);
++	if (err) {
++		dev_dbg(dev, "failed to load init-commands property\n");
++		return;
++	}
++
++	for (i=0; i<count; i+=2) {
++		reg = init_commands[i];
++		value = init_commands[i+1];
++		dev_dbg(dev, "Writing %02x to %02x\n", reg, value);
++		i2c_smbus_write_byte_data(client, reg, value);
++	}
++}
++
+ /*
+  * Ideally we shouldn't have to initialize anything, since the BIOS
+  * should have taken care of everything
+@@ -1017,6 +1061,8 @@ static void lm63_init_client(struct lm63
+ 	struct device *dev = &client->dev;
+ 	u8 convrate;
+ 
++	lm63_load_init_command(data);
++
+ 	data->config = i2c_smbus_read_byte_data(client, LM63_REG_CONFIG1);
+ 	data->config_fan = i2c_smbus_read_byte_data(client,
+ 						    LM63_REG_CONFIG_FAN);

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -82,6 +82,10 @@ d-link,dgs-1210-28mp-f)
 	ucidef_set_poe 370 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
 			lan22 lan21 lan20 lan19 lan18 lan17"
 	;;
+d-link,dgs-1210-28p-f)
+	ucidef_set_poe 193 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
+			lan22 lan21 lan20 lan19 lan18 lan17"
+	;;
 engenius,ews2910p)
 	ucidef_set_poe 60 "$(filter_port_list "$lan_list" "lan9 lan10")"
 	;;

--- a/target/linux/realtek/base-files/etc/uci-defaults/04_dlinkfan
+++ b/target/linux/realtek/base-files/etc/uci-defaults/04_dlinkfan
@@ -7,7 +7,7 @@
 board=$(board_name)
 
 case "$board" in
-d-link,dgs-1210-28mp-f)
+d-link,dgs-1210-28p-f|d-link,dgs-1210-28mp-f)
 	# Enable fan control
 	FAN_CTRL='/sys/class/hwmon/hwmon0'
 	echo 1 > "$FAN_PATH/pwm1_enable"

--- a/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-28p-f.dts
+++ b/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-28p-f.dts
@@ -8,7 +8,6 @@
 #include "rtl8382_d-link_dgs-1210-28p_common.dtsi"
 
 / {
-	compatible = "d-link,dgs-1210-28mp-f", "realtek,rtl8382-soc", "realtek,rtl838x-soc";
-	model = "D-Link DGS-1210-28MP F";
-
+	compatible = "d-link,dgs-1210-28p-f", "realtek,rtl8382-soc", "realtek,rtl838x-soc";
+	model = "D-Link DGS-1210-28P F";
 };

--- a/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-28p_common.dtsi
+++ b/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-28p_common.dtsi
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/ {
+	/* LM63 */
+	i2c-gpio-4 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 32 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 31 GPIO_ACTIVE_HIGH>;
+		i2c-gpio,delay-us = <2>;
+		i2c-gpio,scl-open-drain; /* should be replaced by i2c-gpio,scl-has-no-pullup in kernel 6.6 */
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		lm63@4c {
+			compatible = "national,lm63";
+			reg = <0x4c>;
+		};
+	};
+};
+
+&leds {
+	link_act {
+		label = "green:link_act";
+		gpios = <&gpio1 28 GPIO_ACTIVE_LOW>;
+	};
+
+	poe {
+		label = "green:poe";
+		gpios = <&gpio1 29 GPIO_ACTIVE_LOW>;
+	};
+
+	poe_max {
+		label = "yellow:poe_max";
+		gpios = <&gpio1 27 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&keys {
+	mode {
+		label = "mode";
+		gpios = <&gpio1 30 GPIO_ACTIVE_LOW>;
+		linux,code = <BTN_0>;
+	};
+};
+
+&uart1 {
+	status = "okay";
+};

--- a/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-28p_common.dtsi
+++ b/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-28p_common.dtsi
@@ -14,6 +14,7 @@
 		lm63@4c {
 			compatible = "national,lm63";
 			reg = <0x4c>;
+			init-commands = [ 4a 28  4b 00  4d 17  4c 1c  50 00  51 1c  52 33  53 2e  4f 03  4a 08 ];
 		};
 	};
 };

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -75,6 +75,15 @@ define Device/d-link_dgs-1210-28mp-f
 endef
 TARGET_DEVICES += d-link_dgs-1210-28mp-f
 
+define Device/d-link_dgs-1210-28p-f
+  $(Device/d-link_dgs-1210)
+  SOC := rtl8382
+  DEVICE_MODEL := DGS-1210-28P
+  DEVICE_VARIANT := F
+  DEVICE_PACKAGES += realtek-poe kmod-hwmon-lm63
+endef
+TARGET_DEVICES += d-link_dgs-1210-28p-f
+
 # The "IMG-" uImage name allows flashing the iniramfs from the vendor Web UI.
 # Avoided for sysupgrade, as the vendor FW would do an incomplete flash.
 define Device/engenius_ews2910p


### PR DESCRIPTION
General hardware info:
----------------------

D-Link DGS-1210-28P rev. F1 is a switch with 24 ethernet ports and 4 combo ports, all ports Gbit capable. It is based on a RTL8382 SoC @500MHz, DRAM 128MB and 32MB flash. 24 ethernet ports are 802.3af/at PoE capable with a total PoE power budget of 193W.

Power over Ethernet:
--------------------

The PSE hardware consists of three BCM59121 PSE chips, serving 8 ports each. They are controlled by a Nuvoton MCU.  In order to enable PoE, the realtek-poe package is required. It is installed by default, but currently it requires the manual editing of /etc/config/poe. Keep in mind that the port number assignment does not match on this switch, alway 8 ports are in reversed order: 8-1, 16-9 and 24-17.

LEDs and Buttons:
-----------------

On stock firmware, the mode button is supposed to switch the LED indicators of all port LEDs between Link Activity and PoE status. The currently selected mode is visualized using the respective LEDs. PoE Max indicates that the maximum PoE budget has been reached.  Since there is currently no support for this behavior, these LEDs and the mode button can be used independently.

Serial connection:
------------------
The UART for the SoC (115200 8N1) is available via unpopulated standard 0.1" pin header marked J6. Pin1 is marked with arrow and square.

Pin 1: Vcc 3.3V
Pin 2: Tx
Pin 3: Rx
Pin 4: Gnd

OEM installation from Web Interface:
------------------------------------

    1. Make sure you are booting using OEM in image 2 slot. If not,
       switch to
        image2 using the menus
        System > Firmware Information > Boot from image2
        Tools > reboot
    2. Upload image in vendor firmware via Tools > Backup / Upgrade
        Firmware > image1
    3. Toogle startup image via System > Firmware Information > Boot
       from
        image1
    4. Tools > reboot

Other installation methods not tested, but since the device shares the board with the DGS-1210-28, the following should work:

Boot initramfs image from U-Boot:
---------------------------------

    1. Press Escape key during `Hit Esc key to stop autoboot` prompt
    2. Press CTRL+C keys to get into real U-Boot prompt
    3. Init network with `rtk network on` command
    4. Load image with `tftpboot 0x8f000000
        openwrt-rtl838x-generic-d-link_dgs-1210-28p-f-initramfs-kernel.bin`
        command
    5. Boot the image with `bootm` command