### PR TITLE
base-files: ipcalc.sh handle start and range being empty strings

### DIFF
--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -96,6 +96,7 @@ echo "COUNT=$count"
 
 # if there's no range, we're done
 [ $# -eq 0 ] && exit 0
+[ -z "$1$2" ] && exit 0
 
 if [ "$prefix" -le 30 ]; then
     lower=$((network + 1))


### PR DESCRIPTION
If we're being paranoid and quote all the arguments to ipcalc.sh, it's possible to pass in empty start and range arguments.  This should be handled the same as their being absent.
