### PR TITLE
wolfssl: Update to version 5.7.2

### DIFF
--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wolfssl
-PKG_VERSION:=5.7.0-stable
+PKG_VERSION:=5.7.2-stable
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/wolfSSL/wolfssl/archive/v$(PKG_VERSION)
-PKG_HASH:=2de93e8af588ee856fe67a6d7fce23fc1b226b74d710b0e3946bc8061f6aa18f
+PKG_HASH:=0f2ed82e345b833242705bbc4b08a2a2037a33f7bf9c610efae6464f6b10e305
 
 PKG_FIXUP:=libtool libtool-abiver
 PKG_INSTALL:=1
@@ -50,6 +50,8 @@ PKG_CONFIG_DEPENDS+=\
 	CONFIG_WOLFSSL_HAS_DEVCRYPTO_FULL
 
 include $(INCLUDE_DIR)/package.mk
+
+DISABLE_NLS:=
 
 define Package/libwolfssl/Default
   SECTION:=libs

--- a/package/libs/wolfssl/patches/100-disable-hardening-check.patch
+++ b/package/libs/wolfssl/patches/100-disable-hardening-check.patch
@@ -1,6 +1,6 @@
 --- a/wolfssl/wolfcrypt/settings.h
 +++ b/wolfssl/wolfcrypt/settings.h
-@@ -2945,7 +2945,7 @@ extern void uITRON4_free(void *p) ;
+@@ -3046,7 +3046,7 @@ extern void uITRON4_free(void *p) ;
  
  /* warning for not using harden build options (default with ./configure) */
  /* do not warn if big integer support is disabled */


### PR DESCRIPTION
This fixes multiple security problems:
 * [Medium] CVE-2024-1544 Potential ECDSA nonce side channel attack in versions of wolfSSL before 5.6.6 with wc_ecc_sign_hash calls.

 * [Medium] CVE-2024-5288 A private key blinding operation, enabled by defining the macro WOLFSSL_BLIND_PRIVATE_KEY, was added to mitigate a potential row hammer attack on ECC operations.

 * [Low] When parsing a provided maliciously crafted certificate directly using wolfSSL API, outside of a TLS connection, a certificate with an excessively large number of extensions could lead to a potential DoS.

 * [Low] CVE-2024-5991 In the function MatchDomainName(), input param str is treated as a NULL terminated string despite being user provided and unchecked.

 * [Medium] CVE-2024-5814 A malicious TLS1.2 server can force a TLS1.3 client with downgrade capability to use a ciphersuite that it did not agree to and achieve a successful connection.

 * [Medium] OCSP stapling version 2 response verification bypass issue when a crafted response of length 0 is received.

 * [Medium] OCSP stapling version 2 revocation bypass with a retry of a TLS connection attempt.
