### PR TITLE
zram-swap: Depend on CONFIG_KERNEL_SWAP

### DIFF
--- a/package/system/zram-swap/Makefile
+++ b/package/system/zram-swap/Makefile
@@ -20,6 +20,7 @@ define Package/zram-swap
 	+@BUSYBOX_CONFIG_MKSWAP \
 	+@BUSYBOX_CONFIG_SWAPOFF \
 	+@BUSYBOX_CONFIG_SWAPON \
+	+@KERNEL_SWAP \
 	+kmod-zram
   TITLE:=ZRAM swap scripts
   PKGARCH:=all


### PR DESCRIPTION
Make zram-swap depend on CONFIG_KERNEL_SWAP. Without it, swap-support is not available in the kernel and the zram cannot be used for swap and the script would fail (/proc/swaps: No such file or directory).
