### PR TITLE
mac80211: fix kconf build warnings

### DIFF
--- a/package/kernel/mac80211/patches/build/005-fix-kconf-warnings.patch
+++ b/package/kernel/mac80211/patches/build/005-fix-kconf-warnings.patch
@@ -1,0 +1,76 @@
+--- a/kconf/conf.c
++++ b/kconf/conf.c
+@@ -86,7 +86,7 @@ static int conf_askvalue(struct symbol *
+ 	enum symbol_type type = sym_get_type(sym);
+ 
+ 	if (!sym_has_value(sym))
+-		printf(_("(NEW) "));
++		printf("%s", _("(NEW) "));
+ 
+ 	line[0] = '\n';
+ 	line[1] = 0;
+@@ -282,7 +282,7 @@ static int conf_choice(struct menu *menu
+ 			if (child->sym->name)
+ 				printf(" (%s)", child->sym->name);
+ 			if (!sym_has_value(child->sym))
+-				printf(_(" (NEW)"));
++				printf("%s", _(" (NEW)"));
+ 			printf("\n");
+ 		}
+ 		printf(_("%*schoice"), indent - 1, "");
+@@ -437,7 +437,7 @@ static void check_conf(struct menu *menu
+ 				}
+ 			} else {
+ 				if (!conf_cnt++)
+-					printf(_("*\n* Restart config...\n*\n"));
++					printf("%s", _("*\n* Restart config...\n*\n"));
+ 				rootEntry = menu_get_parent_menu(menu);
+ 				conf(rootEntry);
+ 			}
+@@ -614,7 +614,7 @@ int main(int ac, char **av)
+ 			name = getenv("KCONFIG_NOSILENTUPDATE");
+ 			if (name && *name) {
+ 				fprintf(stderr,
+-					_("\n*** The configuration requires explicit update.\n\n"));
++					"%s", _("\n*** The configuration requires explicit update.\n\n"));
+ 				return 1;
+ 			}
+ 		}
+@@ -666,22 +666,22 @@ int main(int ac, char **av)
+ 		 * All other commands are only used to generate a config.
+ 		 */
+ 		if (conf_get_changed() && conf_write(NULL)) {
+-			fprintf(stderr, _("\n*** Error during writing of the configuration.\n\n"));
++			fprintf(stderr, "%s", _("\n*** Error during writing of the configuration.\n\n"));
+ 			exit(1);
+ 		}
+ 		if (conf_write_autoconf()) {
+-			fprintf(stderr, _("\n*** Error during update of the configuration.\n\n"));
++			fprintf(stderr, "%s", _("\n*** Error during update of the configuration.\n\n"));
+ 			return 1;
+ 		}
+ 	} else if (input_mode == savedefconfig) {
+ 		if (conf_write_defconfig(defconfig_file)) {
+-			fprintf(stderr, _("n*** Error while saving defconfig to: %s\n\n"),
++			fprintf(stderr, _("\n*** Error while saving defconfig to: %s\n\n"),
+ 				defconfig_file);
+ 			return 1;
+ 		}
+ 	} else if (input_mode != listnewconfig) {
+ 		if (conf_write(NULL)) {
+-			fprintf(stderr, _("\n*** Error during writing of the configuration.\n\n"));
++			fprintf(stderr, "%s", _("\n*** Error during writing of the configuration.\n\n"));
+ 			exit(1);
+ 		}
+ 	}
+--- a/kconf/Makefile
++++ b/kconf/Makefile
+@@ -17,7 +17,7 @@ clean:
+ zconf.tab.c: zconf.lex.c
+ 
+ %.tab.c: %.y
+-	$(YACC) -o$@ -t -l $<
++	$(YACC) -Wno-yacc -o$@ -t -l $<
+ 
+ %.lex.c: %.l
+ 	$(LEX) -o$@ -L $<


### PR DESCRIPTION
This mostly a cosmetic fix. This patch cleans up the following warnings during build:

"warning: format not a string literal"

```make
conf.c: In function 'conf_askvalue':
conf.c:89:17: warning: format not a string literal and no format arguments [-Wformat-security]
    89 |                 printf(_("(NEW) "));
      |                 ^~~~~~
conf.c: In function 'conf_choice':
conf.c:285:33: warning: format not a string literal and no format arguments [-Wformat-security]
  285 |                                 printf(_(" (NEW)"));
      |                                 ^~~~~~
conf.c: In function 'check_conf':
conf.c:440:41: warning: format not a string literal and no format arguments [-Wformat-security]
  440 |                                         printf(_("*\n* Restart config...\n*\n"));
      |                                         ^~~~~~
conf.c: In function 'main':
conf.c:617:41: warning: format not a string literal and no format arguments [-Wformat-security]
  617 |                                         _("\n*** The configuration requires explicit update.\n\n"));
      |                                         ^
conf.c:669:25: warning: format not a string literal and no format arguments [-Wformat-security]
  669 |                         fprintf(stderr, _("\n*** Error during writing of the configuration.\n\n"));
      |                         ^~~~~~~
conf.c:673:25: warning: format not a string literal and no format arguments [-Wformat-security]
  673 |                         fprintf(stderr, _("\n*** Error during update of the configuration.\n\n"));
      |                         ^~~~~~~
conf.c:684:25: warning: format not a string literal and no format arguments [-Wformat-security]
  684 |                         fprintf(stderr, _("\n*** Error during writing of the configuration.\n\n"));
      |                         ^~~~~~~
```

And POSIX Yacc warnings
```make
lex -ozconf.lex.c -L zconf.l
yacc -ozconf.tab.c -t -l zconf.y
zconf.y:34.1-7: warning: POSIX Yacc does not support %expect [-Wyacc]
    34 | %expect 32
      | ^~~~~~~
zconf.y:97.1-11: warning: POSIX Yacc does not support %destructor [-Wyacc]
    97 | %destructor {
      | ^~~~~~~~~~~
gcc -Wall -Wmissing-prototypes -Wstrict-prototypes -O2 -fomit-frame-pointer -DKBUILD_NO_NLS   -c -o zconf.tab.o zconf.tab.c
gcc   conf.o zconf.tab.o   -o conf
```

After:
```make
gcc -Wall -Wmissing-prototypes -Wstrict-prototypes -O2 -fomit-frame-pointer -DKBUILD_NO_NLS   -c -o conf.o conf.c
yacc -Wno-yacc -ozconf.tab.c -t -l zconf.y
gcc -Wall -Wmissing-prototypes -Wstrict-prototypes -O2 -fomit-frame-pointer -DKBUILD_NO_NLS   -c -o zconf.tab.o zconf.tab.c
gcc   conf.o zconf.tab.o   -o conf
```

Shouldn't affect the output of the actual build in anyway.