### PR TITLE
mediatek: filogic: disable eMMC HS400 mode for Mount Stuart series

### DIFF
--- a/target/linux/mediatek/dts/mt7988a-smartrg-mt-stuart.dtsi
+++ b/target/linux/mediatek/dts/mt7988a-smartrg-mt-stuart.dtsi
@@ -481,8 +481,6 @@
 	max-frequency = <200000000>;
 	cap-mmc-highspeed;
 	mmc-hs200-1_8v;
-	mmc-hs400-1_8v;
-	hs400-ds-delay = <0x12814>;
 	vmmc-supply = <&reg_3p3v>;
 	vqmmc-supply = <&reg_1p8v>;
 	non-removable;


### PR DESCRIPTION
The eMMC chip used in a small batch of these devices has issues operating in HS400 mode. Reducing to HS200 mode works around the problem and does not cause any noticeable performance penalties as smaller chips are not fast enough to saturate the bus. Root cause analysis is pending.

cc @dangowrt