### PR TITLE
6in4: device and nohostroute option, fqdn as endpoints

### DIFF
--- a/package/network/ipv6/6in4/Makefile
+++ b/package/network/ipv6/6in4/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=6in4
-PKG_RELEASE:=28
+PKG_RELEASE:=29
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/network/ipv6/6in4/Makefile
+++ b/package/network/ipv6/6in4/Makefile
@@ -16,7 +16,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/6in4
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=@IPV6 +kmod-sit +uclient-fetch
+  DEPENDS:=@IPV6 +kmod-sit +uclient-fetch +resolveip
   TITLE:=IPv6-in-IPv4 configuration support
   MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
   PKGARCH:=all

--- a/package/network/ipv6/6in4/files/6in4.sh
+++ b/package/network/ipv6/6in4/files/6in4.sh
@@ -45,9 +45,11 @@ proto_6in4_setup() {
 	local iface="$2"
 	local link="6in4-$cfg"
 
-	local mtu ttl tos ipaddr peeraddr ip6addr ip6prefix ip6prefixes tunlink tunnelid username password updatekey
-	json_get_vars mtu ttl tos ipaddr peeraddr ip6addr tunlink tunnelid username password updatekey
+	local mtu ttl tos ipaddr peeraddr ip6addr ip6prefix ip6prefixes tunlink tunnelid username password updatekey device
+	json_get_vars mtu ttl tos ipaddr peeraddr ip6addr tunlink tunnelid username password updatekey device
 	json_for_each_item proto_6in4_add_prefix ip6prefix ip6prefixes
+
+	[ -n "$device" ] && link="$device"
 
 	[ -z "$peeraddr" ] && {
 		proto_notify_error "$cfg" "MISSING_ADDRESS"
@@ -156,6 +158,7 @@ proto_6in4_init_config() {
 	proto_config_add_int "mtu"
 	proto_config_add_int "ttl"
 	proto_config_add_string "tos"
+	proto_config_add_string "device"
 }
 
 [ -n "$INCLUDE_ONLY" ] || {

--- a/package/network/ipv6/6in4/files/6in4.sh
+++ b/package/network/ipv6/6in4/files/6in4.sh
@@ -46,8 +46,8 @@ proto_6in4_setup() {
 	local link="6in4-$cfg"
 	local remoteip
 
-	local mtu ttl tos ipaddr peeraddr ip6addr ip6prefix ip6prefixes tunlink tunnelid username password updatekey device
-	json_get_vars mtu ttl tos ipaddr peeraddr ip6addr tunlink tunnelid username password updatekey device
+	local mtu ttl tos ipaddr peeraddr ip6addr ip6prefix ip6prefixes tunlink tunnelid username password updatekey device nohostroute
+	json_get_vars mtu ttl tos ipaddr peeraddr ip6addr tunlink tunnelid username password updatekey device nohostroute
 	json_for_each_item proto_6in4_add_prefix ip6prefix ip6prefixes
 
 	[ -n "$device" ] && link="$device"
@@ -70,7 +70,9 @@ proto_6in4_setup() {
 		break
 	done
 
-	( proto_add_host_dependency "$cfg" "$peeraddr" "$tunlink" )
+	if [ "${nohostroute}" != "1" ]; then
+		( proto_add_host_dependency "$cfg" "$peeraddr" "$tunlink" )
+	fi
 
 	[ -z "$ipaddr" ] && {
 		local wanif="$tunlink"
@@ -172,6 +174,7 @@ proto_6in4_init_config() {
 	proto_config_add_int "ttl"
 	proto_config_add_string "tos"
 	proto_config_add_string "device"
+	proto_config_add_boolean "nohostroute"
 }
 
 [ -n "$INCLUDE_ONLY" ] || {


### PR DESCRIPTION
1. 'device' option, allowing to specify custom l3 device name, instead of autogenerated one (prefix "6in4-" + interface name)
2. Support fqdn as remote tunnel endpoint. Same as fqdn support in GRE (commit a79f3d11b3) and IPIP (commit 311682905e)
3. 'nohostroute' option,  already added for for GRE tunnels (commit 0f8b9addfc) and IPIP tunnels (commit 46ce629fe0)
