### PR TITLE
target.mk: further improve handling of default enabled SECCOMP

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -6,25 +6,6 @@
 ifneq ($(__target_inc),1)
 __target_inc=1
 
-ifneq ($(DUMP),)
-  # Parse generic config that might be set before a .config is generated to modify the
-  # default package configuration
-  # Keep DYNAMIC_DEF_PKG_CONF in sync with toplevel.mk to reflect the same configs
-  DYNAMIC_DEF_PKG_CONF := CONFIG_USE_APK CONFIG_SELINUX CONFIG_SMALL_FLASH CONFIG_SECCOMP
-  ifneq ($(wildcard $(TOPDIR)/.config),)
-    $(foreach config, $(DYNAMIC_DEF_PKG_CONF), \
-      $(eval $(config) := $(shell grep "$(config)=y" $(TOPDIR)/.config 2>/dev/null)) \
-    )
-  # Init config that are enabled by default. Dependency are checked matching the one in
-  # the config.
-  else
-    ifeq ($(filter $(BOARD), uml),)
-    ifneq ($(filter $(ARCH), aarch64 arm armeb mips mipsel mips64 mips64el i386 powerpc x86_64),)
-      CONFIG_SECCOMP := y
-    endif
-    endif
-  endif
-endif
 
 # default device type
 DEVICE_TYPE?=router
@@ -45,28 +26,6 @@ DEFAULT_PACKAGES:=\
 	uclient-fetch \
 	urandom-seed \
 	urngd
-
-ifneq ($(CONFIG_USE_APK),)
-DEFAULT_PACKAGES+=apk-mbedtls
-else
-DEFAULT_PACKAGES+=opkg
-endif
-
-ifneq ($(CONFIG_SELINUX),)
-DEFAULT_PACKAGES+=busybox-selinux procd-selinux
-else
-DEFAULT_PACKAGES+=busybox procd
-endif
-
-# include ujail on systems with enough storage
-ifeq ($(CONFIG_SMALL_FLASH),)
-DEFAULT_PACKAGES+=procd-ujail
-endif
-
-# include seccomp ld-preload hooks if kernel supports it
-ifneq ($(CONFIG_SECCOMP),)
-DEFAULT_PACKAGES+=procd-seccomp
-endif
 
 # For the basic set
 DEFAULT_PACKAGES.basic:=
@@ -116,6 +75,48 @@ else
   ifneq ($(SUBTARGET),)
     -include ./$(SUBTARGET)/target.mk
   endif
+endif
+
+ifneq ($(DUMP),)
+  # Parse generic config that might be set before a .config is generated to modify the
+  # default package configuration
+  # Keep DYNAMIC_DEF_PKG_CONF in sync with toplevel.mk to reflect the same configs
+  DYNAMIC_DEF_PKG_CONF := CONFIG_USE_APK CONFIG_SELINUX CONFIG_SMALL_FLASH CONFIG_SECCOMP
+  ifneq ($(wildcard $(TOPDIR)/.config),)
+    $(foreach config, $(DYNAMIC_DEF_PKG_CONF), \
+      $(eval $(config) := $(shell grep "$(config)=y" $(TOPDIR)/.config 2>/dev/null)) \
+    )
+  # Init config that are enabled by default. Dependency are checked matching the one in
+  # the config.
+  else
+    ifeq ($(filter $(BOARD), uml),)
+    ifneq ($(filter $(ARCH), aarch64 arm armeb mips mipsel mips64 mips64el i386 powerpc x86_64),)
+      CONFIG_SECCOMP := y
+    endif
+    endif
+  endif
+endif
+
+ifneq ($(CONFIG_USE_APK),)
+DEFAULT_PACKAGES+=apk-mbedtls
+else
+DEFAULT_PACKAGES+=opkg
+endif
+
+ifneq ($(CONFIG_SELINUX),)
+DEFAULT_PACKAGES+=busybox-selinux procd-selinux
+else
+DEFAULT_PACKAGES+=busybox procd
+endif
+
+# include ujail on systems with enough storage
+ifeq ($(CONFIG_SMALL_FLASH),)
+DEFAULT_PACKAGES+=procd-ujail
+endif
+
+# include seccomp ld-preload hooks if kernel supports it
+ifneq ($(CONFIG_SECCOMP),)
+DEFAULT_PACKAGES+=procd-seccomp
 endif
 
 # Add device specific packages (here below to allow device type set from subtarget)

--- a/include/target.mk
+++ b/include/target.mk
@@ -82,13 +82,12 @@ ifneq ($(DUMP),)
   # default package configuration
   # Keep DYNAMIC_DEF_PKG_CONF in sync with toplevel.mk to reflect the same configs
   DYNAMIC_DEF_PKG_CONF := CONFIG_USE_APK CONFIG_SELINUX CONFIG_SMALL_FLASH CONFIG_SECCOMP
-  ifneq ($(wildcard $(TOPDIR)/.config),)
-    $(foreach config, $(DYNAMIC_DEF_PKG_CONF), \
-      $(eval $(config) := $(shell grep "$(config)=y" $(TOPDIR)/.config 2>/dev/null)) \
-    )
-  # Init config that are enabled by default. Dependency are checked matching the one in
-  # the config.
-  else
+  $(foreach config, $(DYNAMIC_DEF_PKG_CONF), \
+    $(eval $(config) := $(shell grep "$(config)=y" $(TOPDIR)/.config 2>/dev/null)) \
+  )
+  # The config options that are enabled by default and where other default
+  # packages depends on needs to be set if they are missing in the .config.
+  ifeq ($(shell grep "CONFIG_SECCOMP" $(TOPDIR)/.config 2>/dev/null),)
     ifeq ($(filter $(BOARD), uml),)
     ifneq ($(filter $(ARCH), aarch64 arm armeb mips mipsel mips64 mips64el i386 powerpc x86_64),)
       CONFIG_SECCOMP := y


### PR DESCRIPTION
@Ansuel 
The fix in commit 847fad476f3d ("target.mk: improve handling of default enabled SECCOMP") unfortunately does not work for targets where the ARCH variable is set in ./$(SUBTARGET)/target.mk.

To get this working, the ./$(SUBTARGET)/target.mk must be included before the check.

In addition, the fix should not only take effect if no .config file exists, but also if a .config exists but the CONFIG_SECCOMP option is missing in the file.

This is relevant, for example, if you are working with .config templates and then want to complete the configuration using make defconfig.

