### PR TITLE
unify fitblk sysupgrade

### DIFF
--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -165,23 +165,6 @@ part_magic_fat() {
 	[ "$magic" = "FAT" ] || [ "$magic_fat32" = "FAT32" ]
 }
 
-fitblk_get_bootdev() {
-	[ -e /sys/firmware/devicetree/base/chosen/rootdisk ] || return
-
-	local rootdisk="$(cat /sys/firmware/devicetree/base/chosen/rootdisk)"
-	local handle bootdev
-	for handle in /sys/class/block/*/of_node/phandle /sys/class/block/*/device/of_node/phandle; do
-		[ ! -e "$handle" ] && continue
-		if [ "$rootdisk" = "$(cat $handle)" ]; then
-			bootdev="${handle%/of_node/phandle}"
-			bootdev="${bootdev%/device}"
-			bootdev="${bootdev#/sys/class/block/}"
-			echo "$bootdev"
-			break
-		fi
-	done
-}
-
 export_bootdevice() {
 	local cmdline uuid blockdev uevent line class
 	local MAJOR MINOR DEVNAME DEVTYPE

--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -41,17 +41,17 @@ bananapi,bpi-r3-mini|\
 bananapi,bpi-r4|\
 bananapi,bpi-r4-poe|\
 jdcloud,re-cp-03)
-	. /lib/upgrade/common.sh
-
-	bootdev="$(fitblk_get_bootdev)"
-	case "$bootdev" in
-	ubi*)
+	. /lib/upgrade/fit.sh
+	export_fitblk_bootdev
+	case "$CI_METHOD" in
+	ubi)
 		ubootenv_add_ubi_default
 		;;
-	mmc*)
-		ubootenv_add_mmc_default "${bootdev%%p[0-9]*}"
+	emmc)
+		bootdev=${EMMC_KERN_DEV%%p[0-9]*}
+		ubootenv_add_mmc_default "${bootdev#/dev/}"
 		;;
-	mtd*)
+	default)
 		ubootenv_add_nor_default
 		;;
 	esac

--- a/package/boot/uboot-envtools/files/mediatek_mt7622
+++ b/package/boot/uboot-envtools/files/mediatek_mt7622
@@ -31,17 +31,16 @@ dlink,eagle-pro-ai-m32-a1|\
 dlink,eagle-pro-ai-r32-a1)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x2000" "0x2000"
 	;;
+bananapi,bpi-r64|\
 linksys,e8450-ubi)
-	ubootenv_add_ubi_default
-	;;
-bananapi,bpi-r64)
-	. /lib/upgrade/common.sh
-	bootdev="$(fitblk_get_bootdev)"
-	case "$bootdev" in
-	mmc*)
-		ubootenv_add_mmc_default "${bootdev%p[0-9]*}"
+	. /lib/upgrade/fit.sh
+	export_fitblk_bootdev
+	case "$CI_METHOD" in
+	emmc)
+		bootdev=${EMMC_KERN_DEV%%p[0-9]*}
+		ubootenv_add_mmc_default "${bootdev#/dev/}"
 		;;
-	ubi*)
+	ubi)
 		ubootenv_add_ubi_default
 		;;
 	esac

--- a/package/utils/fitblk/Makefile
+++ b/package/utils/fitblk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fitblk
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0-only
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 
@@ -36,6 +36,8 @@ endef
 define Package/fitblk/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/fitblk $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/lib/upgrade
+	$(INSTALL_DATA) ./files/fit.sh $(1)/lib/upgrade
 endef
 
 $(eval $(call BuildPackage,fitblk))

--- a/package/utils/fitblk/files/fit.sh
+++ b/package/utils/fitblk/files/fit.sh
@@ -1,0 +1,63 @@
+export_fitblk_bootdev() {
+	[ -e /sys/firmware/devicetree/base/chosen/rootdisk ] || return
+
+	local rootdisk="$(cat /sys/firmware/devicetree/base/chosen/rootdisk)"
+	local handle bootdev
+
+	for handle in /sys/class/mtd/mtd*/of_node/volumes/*/phandle; do
+		[ ! -e "$handle" ] && continue
+		if [ "$rootdisk" = "$(cat "$handle")" ]; then
+			if [ -e "${handle%/phandle}/volname" ]; then
+				export CI_KERNPART="$(cat "${handle%/phandle}/volname")"
+			elif [ -e "${handle%/phandle}/volid" ]; then
+				export CI_KERNVOLID="$(cat "${handle%/phandle}/volid")"
+			else
+				return
+			fi
+			export CI_UBIPART="$(cat "${handle%%/of_node*}/name")"
+			export CI_METHOD="ubi"
+			return
+		fi
+	done
+
+	for handle in /sys/class/mtd/mtd*/of_node/phandle; do
+		[ ! -e "$handle" ] && continue
+		if [ "$rootdisk" = "$(cat $handle)" ]; then
+			bootdev="${handle%/of_node/phandle}"
+			bootdev="${bootdev#/sys/class/mtd/}"
+			export PART_NAME="/dev/$bootdev"
+			export CI_METHOD="default"
+			return
+		fi
+	done
+
+	for handle in /sys/class/block/*/of_node/phandle; do
+		[ ! -e "$handle" ] && continue
+		if [ "$rootdisk" = "$(cat $handle)" ]; then
+			bootdev="${handle%/of_node/phandle}"
+			bootdev="${bootdev#/sys/class/block/}"
+			export EMMC_KERN_DEV="/dev/$bootdev"
+			export CI_METHOD="emmc"
+			return
+		fi
+	done
+}
+
+fit_do_upgrade() {
+	export_fitblk_bootdev
+	[ -n "$CI_METHOD" ] || return 1
+	[ -e /dev/fit0 ] && fitblk /dev/fit0
+	[ -e /dev/fitrw ] && fitblk /dev/fitrw
+
+	case "$CI_METHOD" in
+	emmc)
+		emmc_do_upgrade "$1"
+		;;
+	default)
+		default_do_upgrade "$1"
+		;;
+	ubi)
+		nand_do_upgrade "$1"
+		;;
+	esac
+}

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -88,24 +88,13 @@ platform_do_upgrade() {
 	bananapi,bpi-r4-poe|\
 	jdcloud,re-cp-03|\
 	mediatek,mt7988a-rfb|\
-	openwrt,one)
-		[ -e /dev/fit0 ] && fitblk /dev/fit0
-		[ -e /dev/fitrw ] && fitblk /dev/fitrw
-		bootdev="$(fitblk_get_bootdev)"
-		case "$bootdev" in
-		mmcblk*)
-			EMMC_KERN_DEV="/dev/$bootdev"
-			emmc_do_upgrade "$1"
-			;;
-		mtdblock*)
-			PART_NAME="/dev/mtd${bootdev:8}"
-			default_do_upgrade "$1"
-			;;
-		ubiblock*)
-			CI_KERNPART="fit"
-			nand_do_upgrade "$1"
-			;;
-		esac
+	nokia,ea0326gmp|\
+	openwrt,one|\
+	tplink,tl-xdr4288|\
+	tplink,tl-xdr6086|\
+	tplink,tl-xdr6088|\
+	xiaomi,redmi-router-ax6000-ubootmod)
+		fit_do_upgrade "$1"
 		;;
 	cmcc,rax3000m)
 		case "$(cmdline_get_var root)" in
@@ -145,16 +134,6 @@ platform_do_upgrade() {
 	mercusys,mr90x-v1|\
 	tplink,re6000xd)
 		CI_UBIPART="ubi0"
-		nand_do_upgrade "$1"
-		;;
-	nokia,ea0326gmp|\
-	tplink,tl-xdr4288|\
-	tplink,tl-xdr6086|\
-	tplink,tl-xdr6088|\
-	xiaomi,redmi-router-ax6000-ubootmod)
-		[ -e /dev/fit0 ] && fitblk /dev/fit0
-		[ -e /dev/fitrw ] && fitblk /dev/fitrw
-		CI_KERNPART="fit"
 		nand_do_upgrade "$1"
 		;;
 	ubnt,unifi-6-plus)

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
@@ -12,25 +12,8 @@ platform_do_upgrade() {
 	ubnt,unifi-6-lr-v2-ubootmod|\
 	ubnt,unifi-6-lr-v3-ubootmod|\
 	xiaomi,redmi-router-ax6s)
-		[ -e /dev/fit0 ] && fitblk /dev/fit0
-		[ -e /dev/fitrw ] && fitblk /dev/fitrw
-		bootdev="$(fitblk_get_bootdev)"
-		case "$bootdev" in
-		mmcblk*)
-			EMMC_KERN_DEV="/dev/$bootdev"
-			emmc_do_upgrade "$1"
-			;;
-		mtdblock*)
-			PART_NAME="/dev/mtd${bootdev:8}"
-			default_do_upgrade "$1"
-			;;
-		ubiblock*)
-			CI_KERNPART="fit"
-			nand_do_upgrade "$1"
-			;;
-		esac
+		fit_do_upgrade "$1"
 		;;
-
 	buffalo,wsr-2533dhp2|\
 	buffalo,wsr-3200ax4s)
 		local magic="$(get_magic_long "$1")"


### PR DESCRIPTION
 * Improve `fitblk_get_bootdev()` function to also work in case an ubi volume or ubiblock device has not yet been created.

 * Move shell functions needed for sysupgrade on devices using unified uImage.FIT (ie. `fitblk` driver) from `/lib/upgrade/common.sh` into new file `/lib/upgrade/fit.sh` which is shipped by the `fitblk` package.

 * Make use of the above in uboot-envtools and mediatek target.