### PR TITLE
dnsmasq: Add EDNS0 Upstream support

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.90
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1108,6 +1108,9 @@ dnsmasq_start()
 		[ "$addmac" = "1" ] && addmac=
 		xappend "--add-mac${addmac:+="$addmac"}"
 	}
+	append_bool "$cfg" stripmac "--strip-mac"
+	append_parm "$cfg" addsubnet "--add-subnet"
+	append_bool "$cfg" stripsubnet "--strip-subnet"
 
 	dhcp_option_add "$cfg" "" 0
 	dhcp_option_add "$cfg" "" 2


### PR DESCRIPTION
Forward client mac address and subnet on dns queries. Pi-hole and Adguard use this feature to send the originators ip address/subnet so it can be logged and not just the nat address of the router. This feature has been added since version 2.56 of dnsmasq and would be nice to expose this feature in openwrt.

This replaces https://github.com/openwrt/openwrt/pull/14349 which is not updated by the original author.

Supported options:

`addmac` - already supported and unchanged
`stripmac` (bool) - will add `--strip_mac`
`addsubnet` -  will add `--add-subnet=<value>`
`stripsubnet` (bool) - will add `--strip_subnet`

Patch for luci is https://github.com/openwrt/luci/pull/7198