### PR TITLE
ipq40xx: disable SPI DMA for Fritzbox 4040

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-fritzbox-4040.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-fritzbox-4040.dts
@@ -151,6 +151,8 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
+	/delete-property/ dmas;
+	/delete-property/ dma-names;
 	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
 
 	flash@0 {


### PR DESCRIPTION
We have seen hung devices and failures during SPI transactions on Fritzbox devices with a gluon based freifunk network. We have narrowed down that disabling DMA for spi fixes the problem, so disable dma for the SPI controller on the Fritzbox 4040.
