### PR TITLE
ath79: add support for KuWfi CPE830(D) / YunCore CPE830(D)

### DIFF
--- a/target/linux/ath79/dts/qca9533_yuncore_cpe830.dts
+++ b/target/linux/ath79/dts/qca9533_yuncore_cpe830.dts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "yuncore,cpe830", "qca,qca9533";
+	model = "YunCore/KuWfi CPE830(D)";
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	aliases {
+		label-mac-device = &wmac;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan {
+			label = "green:wlan";
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		link1 {
+			label = "green:signal0";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		link2 {
+			label = "green:signal1";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		link3 {
+			label = "green:signal2";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		link4 {
+			label = "green:signal3";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xfa0000>;
+			};
+
+			partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+					macaddr_art_wmac: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+	phy-handle = <&swphy4>;
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth1 {
+	status = "okay";
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+	nvmem-cells = <&cal_art_1000>, <&macaddr_art_wmac>;
+	nvmem-cell-names = "calibration", "mac-address";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -545,6 +545,15 @@ yuncore,a770)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x10"
 	;;
+yuncore,cpe830)
+	ucidef_set_led_netdev "wan" "WAN" "wan" "eth1"
+	ucidef_set_led_netdev "lan" "LAN" "lan" "eth0"
+	ucidef_set_rssimon "phy0-sta0" "200000" "1"
+	ucidef_set_led_rssi "wifi_low" "WIFILOW" "green:signal0" "phy0-sta0" "1" "100"
+	ucidef_set_led_rssi "wifi_mediumlow" "WIFIMEDIUMLOW" "green:signal1" "phy0-sta0" "26" "100"
+	ucidef_set_led_rssi "wifi_mediumhigh" "WIFIMEDIUMHIGH" "green:signal2" "phy0-sta0" "51" "100"
+	ucidef_set_led_rssi "wifi_high" "WIFIHIGH" "green:signal3" "phy0-sta0" "76" "100"
+	;;
 zbtlink,zbt-wd323)
 	ucidef_set_led_switch "lan1" "LAN1" "orange:lan1" "switch0" "0x10"
 	ucidef_set_led_switch "lan2" "LAN2" "orange:lan2" "switch0" "0x08"

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -3307,6 +3307,19 @@ define Device/yuncore_xd3200
 endef
 TARGET_DEVICES += yuncore_xd3200
 
+define Device/yuncore_cpe830
+  SOC := qca9533
+  DEVICE_VENDOR := YunCore
+  DEVICE_MODEL := CPE830(D)
+  DEVICE_ALT0_VENDOR = KuWfi
+  DEVICE_ALT0_MODEL = CPE830(D)
+  IMAGE_SIZE := 16000k
+  IMAGES += tftp.bin
+  IMAGE/tftp.bin := $$(IMAGE/sysupgrade.bin) | yuncore-tftp-header-16m
+  DEVICE_PACKAGES := rssileds kmod-leds-gpio kmod-ledtrig-gpio kmod-ledtrig-netdev kmod-ath9k -swconfig
+endef
+TARGET_DEVICES += yuncore_cpe830
+
 define Device/yuncore_xd4200
   SOC := qca9563
   DEVICE_VENDOR := YunCore


### PR DESCRIPTION
Short specification:
* 650/600/216 MHz (CPU/DDR/AHB)
* 2x 10/100 Mbps Ethernet, passive PoE support
* 64 MB of RAM (DDR2)
* 16 MB of FLASH
* 2T2R 2.4 GHz with external PA, up to 30 dBm (1000mW)
* 2x internal 14 dBi antennas
* 8x LED, 1x button
* No UART on PCB on some versions
* Display panel with 2x buttons (F/N) not supported (and not relevant in OpenWrt)-

Flash instructions
* Connect PC with 192.168.0.141 to WAN port
* Install a TFTP server on your PC ('atftp' is doing the job for instance)
* Copy your firmware in the TFTP folder as upgrade.bin
* Power up device pushing the 'reset' button
* The device shall upload upgrade.bin, install it and reboot
* Device shall be booting on 192.168.1.1 as default

Signed-off-by: Joan Moreau <jom@grosjo.net>