### PR TITLE
qualcommax: ipq6018: Add Wally's Tech DR6018-v4

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -102,6 +102,7 @@ ALLWIFIBOARDS:= \
 	tplink_eap660hd-v1 \
 	tplink_tl-wa1201-v2 \
 	wallys_dr40x9 \
+	wallys_dr6018-v4 \
 	xiaomi_aiot-ac2350 \
 	xiaomi_ax3600 \
 	xiaomi_ax6000 \
@@ -299,6 +300,7 @@ $(eval $(call generate-ipq-wifi-package,tplink_eap625-outdoor-hd-v1,TP-Link EAP6
 $(eval $(call generate-ipq-wifi-package,tplink_eap660hd-v1,TP-Link EAP660 HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_tl-wa1201-v2,TP-Link TL-WA1201 V2))
 $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))
+$(eval $(call generate-ipq-wifi-package,wallys_dr6018-v4,Wallys DR6018-v4))
 $(eval $(call generate-ipq-wifi-package,xiaomi_aiot-ac2350,Xiaomi AIoT AC2350))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax3600,Xiaomi AX3600))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax6000,Xiaomi AX6000))

--- a/target/linux/qualcommax/dts/ipq6010-dr6018-v4.dts
+++ b/target/linux/qualcommax/dts/ipq6010-dr6018-v4.dts
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR BSD-3-Clause
+
+/dts-v1/;
+
+#include "ipq6018.dtsi"
+#include "ipq6018-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Wallys DR6018 v4";
+	compatible = "wallys,dr6018", "wallys,dr6018-v4", "qcom,ipq6018";
+
+	aliases {
+		serial0 = &blsp1_uart3;
+		/*
+		 * Aliases as required by u-boot
+		 * to patch MAC addresses
+		 */
+		ethernet0 = &dp1;
+		ethernet1 = &dp2;
+		ethernet2 = &dp3;
+		ethernet3 = &dp4;
+		ethernet4 = &dp5;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+
+		bootargs-append = " root=/dev/ubiblock0_1";
+
+	};
+
+	reg_sd_vmmc: regulator-sdcard-vmmc {
+		compatible = "regulator-fixed";
+		regulator-name = "sdcard-vmmc";
+		regulator-min-microvolt = <3000000>;
+		regulator-max-microvolt = <3000000>;
+
+		startup-delay-us = <200>;
+
+		gpio = <&tlmm 66 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&sd_vmmc_en_default>;
+	};
+};
+
+&tlmm {
+	/* TZ has exclusive control over GPIO20 */
+	gpio-reserved-ranges = <20 1>;
+
+	spi_0_pins: spi-0-state {
+		pins = "gpio38", "gpio39", "gpio40", "gpio41";
+		function = "blsp0_spi";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+
+	mdio_pins: mdio-state {
+		mdc {
+			pins = "gpio64";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio65";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	sd_vmmc_en_default: sd-vmmc-en-default-state {
+		pins = "gpio66";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+
+	sd_pins: sd-state {
+		pins = "gpio62";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+};
+
+/*
+ * Board does not use companion MP5496 PMIC,
+ * but rather uses fixed external SMPS.
+ */
+&rpm {
+	status = "disabled";
+};
+
+&blsp1_uart3 {
+	status = "okay";
+
+	pinctrl-0 = <&serial_3_pins>;
+	pinctrl-names = "default";
+};
+
+&blsp1_spi1 {
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <50000000>;
+	};
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+
+		nand-ecc-strength = <8>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+	};
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&qusb_phy_1 {
+	status = "disabled";
+};
+
+&usb2 {
+	status = "disabled";
+};
+
+&sdhc_1 {
+	status = "okay";
+	pinctrl-0 = <&sd_pins>;
+	pinctrl-names = "default";
+
+	cd-gpios = <&tlmm 62 GPIO_ACTIVE_LOW>;
+	wp-gpios = <&tlmm 63 GPIO_ACTIVE_HIGH>;
+	vmmc-supply = <&reg_sd_vmmc>;
+	bus-width = <4>;
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 75 GPIO_ACTIVE_LOW>;
+
+	qca8075_0: ethernet-phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0>;
+	};
+
+	qca8075_1: ethernet-phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <1>;
+	};
+
+	qca8075_2: ethernet-phy@2 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <2>;
+	};
+
+	qca8075_3: ethernet-phy@3 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <3>;
+	};
+
+	qca8075_4: ethernet-phy@4 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <4>;
+	};
+
+	qca8081: ethernet-phy@24 {
+		compatible = "ethernet-phy-id004d.d101";
+		reg = <24>;
+		reset-gpios = <&tlmm 77 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&wifi {
+        status = "okay";
+	qcom,ath11k-calibration-variant = "Wallys-DR6018";
+};
+
+&switch {
+	status = "okay";
+
+	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
+	switch_lan_bmp = <0x1e>; /* lan port bitmap */
+	switch_wan_bmp = <0x20>; /* wan port bitmap */
+	switch_inner_bmp = <0xc0>; /*inner port bitmap*/
+	switch_mac_mode = <0x0>; /* mac mode for uniphy instance0*/
+	switch_mac_mode1 = <0xf>; /* mac mode for uniphy instance1*/
+	switch_mac_mode2 = <0xff>; /* mac mode for uniphy instance2*/
+
+	qcom,port_phyinfo {
+		port@0 {
+			port_id = <1>;
+			phy_address = <0>;
+		};
+		port@1 {
+			port_id = <2>;
+			phy_address = <1>;
+		};
+		port@2 {
+			port_id = <3>;
+			phy_address = <2>;
+		};
+		port@3 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+		port@4 {
+			port_id = <5>;
+			phy_address = <24>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&dp1 {
+	status = "okay";
+
+	phy-handle = <&qca8075_0>;
+};
+
+&dp2 {
+	status = "okay";
+
+	phy-handle = <&qca8075_1>;
+};
+
+&dp3 {
+	status = "okay";
+
+	phy-handle = <&qca8075_2>;
+};
+
+&dp4 {
+	status = "okay";
+
+	phy-handle = <&qca8075_3>;
+};
+
+&dp5 {
+	status = "okay";
+
+	phy-handle = <&qca8081>;
+};

--- a/target/linux/qualcommax/dts/ipq6010-dr6018-v4.dts
+++ b/target/linux/qualcommax/dts/ipq6010-dr6018-v4.dts
@@ -17,11 +17,11 @@
 		 * Aliases as required by u-boot
 		 * to patch MAC addresses
 		 */
-		ethernet0 = &dp1;
-		ethernet1 = &dp2;
-		ethernet2 = &dp3;
-		ethernet3 = &dp4;
-		ethernet4 = &dp5;
+		ethernet0 = &swport1;
+		ethernet1 = &swport2;
+		ethernet2 = &swport3;
+		ethernet3 = &swport4;
+		ethernet4 = &wan;
 	};
 
 	chosen {
@@ -154,7 +154,7 @@
 	status = "disabled";
 };
 
-&sdhc_1 {
+&sdhc {
 	status = "okay";
 	pinctrl-0 = <&sd_pins>;
 	pinctrl-names = "default";
@@ -212,68 +212,70 @@
 	qcom,ath11k-calibration-variant = "Wallys-DR6018";
 };
 
+&uniphy0 {
+	status = "okay";
+};
+
+&uniphy1 {
+	status = "okay";
+};
+
 &switch {
 	status = "okay";
 
-	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
-	switch_lan_bmp = <0x1e>; /* lan port bitmap */
-	switch_wan_bmp = <0x20>; /* wan port bitmap */
-	switch_inner_bmp = <0xc0>; /*inner port bitmap*/
-	switch_mac_mode = <0x0>; /* mac mode for uniphy instance0*/
-	switch_mac_mode1 = <0xf>; /* mac mode for uniphy instance1*/
-	switch_mac_mode2 = <0xff>; /* mac mode for uniphy instance2*/
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-	qcom,port_phyinfo {
 		port@0 {
-			port_id = <1>;
-			phy_address = <0>;
+			reg = <0>;
+			ethernet = <&edma>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
 		};
-		port@1 {
-			port_id = <2>;
-			phy_address = <1>;
+
+		swport1: port@1 {
+			reg = <1>;
+			label = "lan1";
+			phy-handle = <&qca8075_0>;
+			phy-mode = "psgmii";
+			pcs-handle = <&uniphy0 0>;
 		};
-		port@2 {
-			port_id = <3>;
-			phy_address = <2>;
+
+		swport2: port@2 {
+			reg = <2>;
+			label = "lan2";
+			phy-handle = <&qca8075_1>;
+			phy-mode = "psgmii";
+			pcs-handle = <&uniphy0 1>;
 		};
-		port@3 {
-			port_id = <4>;
-			phy_address = <3>;
+
+		swport3: port@3 {
+			reg = <3>;
+			label = "lan3";
+			phy-handle = <&qca8075_2>;
+			phy-mode = "psgmii";
+			pcs-handle = <&uniphy0 2>;
 		};
-		port@4 {
-			port_id = <5>;
-			phy_address = <24>;
-			port_mac_sel = "QGMAC_PORT";
+
+		swport4: port@4 {
+			reg = <4>;
+			label = "lan4";
+			phy-handle = <&qca8075_3>;
+			phy-mode = "psgmii";
+			pcs-handle = <&uniphy0 3>;
+		};
+
+		wan: port@5 {
+			reg = <5>;
+			label = "wan";
+			phy-handle = <&qca8081>;
+			phy-mode = "2500base-x";
+			pcs-handle = <&uniphy1 0>;
 		};
 	};
-};
-
-&dp1 {
-	status = "okay";
-
-	phy-handle = <&qca8075_0>;
-};
-
-&dp2 {
-	status = "okay";
-
-	phy-handle = <&qca8075_1>;
-};
-
-&dp3 {
-	status = "okay";
-
-	phy-handle = <&qca8075_2>;
-};
-
-&dp4 {
-	status = "okay";
-
-	phy-handle = <&qca8075_3>;
-};
-
-&dp5 {
-	status = "okay";
-
-	phy-handle = <&qca8081>;
 };

--- a/target/linux/qualcommax/image/ipq60xx.mk
+++ b/target/linux/qualcommax/image/ipq60xx.mk
@@ -319,6 +319,23 @@ define Device/tplink_eap620-hd-v3
 endef
 TARGET_DEVICES += tplink_eap620-hd-v3
 
+define Device/wallys_dr6018-v4
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Wallys
+	DEVICE_MODEL := DR6018-V4
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	SOC := ipq6010
+	DEVICE_DTS_CONFIG := config@cp01-c4
+	IMAGES := sysupgrade.tar nand-factory.bin
+	IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
+	IMAGE/nand-factory.bin := append-ubi | qsdk-ipq-factory-nand
+	SUPPORTED_DEVICES := wallys,dr6018
+	DEVICE_PACKAGES := ath11k-wifi-wallys-dr6018-v4 uboot-envtools -kmod-usb-dwc3-of-simple kmod-usb-dwc3-qcom kmod-usb3 kmod-usb2
+endef
+TARGET_DEVICES += wallys_dr6018-v4
+
 define Device/yuncore_fap650
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
@@ -48,6 +48,9 @@ ipq60xx_setup_interfaces()
 	tplink,eap625-outdoor-hd-v1)
 		ucidef_set_interface_lan "lan" "dhcp"
 		;;
+	wallys,dr6018-v4)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
+		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"
 		;;

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -93,6 +93,9 @@ case "$FIRMWARE" in
 		ath11k_patch_mac $(macaddr_add $label_mac 1) 0
 		ath11k_set_macflag
 		;;
+	wallys,dr6018-v4)
+		caldata_extract "0:art" 0x1000 0x20000
+		;;
 	yuncore,fap650)
 		caldata_extract "0:art" 0x1000 0x20000
 		;;

--- a/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
@@ -252,6 +252,9 @@ platform_do_upgrade() {
 		fw_setenv owrt_slotactive $((1 - active))
 		nand_do_upgrade "$1"
 		;;
+	wallys,dr6018-v4)
+		nand_do_upgrade "$1"
+		;;
 	*)
 		default_do_upgrade "$1"
 		;;


### PR DESCRIPTION
Add support for Wally's Tech DR6018-v4.

Qualcomm-Atheros IPQ6010
Quad-core ARM 64bit A53 @1.8GHz Processor 
1GB DDRL3L System Memory 
32MB NOR Flash, 256MB NAND Flash 
Supports Dynamic Frequency Selection (DFS) 
2x2 On-board 2.4GHz radio, up to 573Mbps physical Data Rate 
2x2 On-board 5GHz radio, up to 1201Mbps physical Data Rate

tftpboot the factory bin image and run (in u-boot):
imxtract 0x44000000 ubi && flash rootfs && reset

sysupgrade /should/ work but is untested.

flash factory image from qsdk/chaos calmer factory webui works.