### PR TITLE
Rb5009 with poe

### DIFF
--- a/target/linux/mvebu/files-6.6/arch/arm64/boot/dts/marvell/armada-7040-rb5009.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm64/boot/dts/marvell/armada-7040-rb5009.dts
@@ -400,3 +400,38 @@
 		};
 	};
 };
+
+&cp0_gpio1 {
+	enable-poe-power {
+		gpio-hog;
+		gpios = <8 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "enable PoE power";
+	};
+};
+
+&cp0_pinctrl {
+    cp0_spi1_pins: cp0-spi1-pins {
+	marvell,pins = "mpp47", "mpp48", "mpp49", "mpp50";
+	marvell,function = "spi1";
+    };
+
+    /* PoE already enabled by enable-poe-power hog
+    cp0_spi1_poe_cs_pins: cp0-spi1-poe-cs-pins {
+	marvell,pins = "mpp8";
+	marvell,function = "gpio";
+    }; */
+};
+
+&cp0_spi1 {
+    status = "okay";
+
+    pinctrl-0 = <&cp0_spi1_pins>;
+    pinctrl-names = "default";
+
+    spidev@0 {
+        compatible = "mikrotik,mtpoe";
+        reg = <0>;
+        spi-max-frequency = <2000000>;
+    };
+};

--- a/target/linux/mvebu/image/cortexa72.mk
+++ b/target/linux/mvebu/image/cortexa72.mk
@@ -72,6 +72,8 @@ define Device/mikrotik_rb5009
   $(call Device/UbiFit)
   DEVICE_VENDOR := MikroTik
   DEVICE_MODEL := RB5009
+  DEVICE_ALT0_VENDOR := MikroTik
+  DEVICE_ALT0_MODEL := RB5009UPr+S+IN
   SOC := armada-7040
   KERNEL_LOADADDR := 0x22000000
   DEVICE_PACKAGES += kmod-i2c-gpio yafut

--- a/target/linux/mvebu/patches-6.6/913-drivers_spi_add_mtpoe_device_compatible.patch
+++ b/target/linux/mvebu/patches-6.6/913-drivers_spi_add_mtpoe_device_compatible.patch
@@ -1,0 +1,18 @@
+--- a/drivers/spi/spidev.c
++++ b/drivers/spi/spidev.c
+@@ -714,6 +714,7 @@ static const struct spi_device_id spidev
+ 	{ .name = "spi-authenta" },
+ 	{ .name = "em3581" },
+ 	{ .name = "si3210" },
++	{ .name = "mtpoe" },
+ 	{},
+ };
+ MODULE_DEVICE_TABLE(spi, spidev_spi_ids);
+@@ -742,6 +743,7 @@ static const struct of_device_id spidev_
+ 	{ .compatible = "semtech,sx1301", .data = &spidev_of_check },
+ 	{ .compatible = "silabs,em3581", .data = &spidev_of_check },
+ 	{ .compatible = "silabs,si3210", .data = &spidev_of_check },
++	{ .compatible = "mikrotik,mtpoe", .data = &spidev_of_check },
+ 	{},
+ };
+ MODULE_DEVICE_TABLE(of, spidev_dt_ids);


### PR DESCRIPTION
Add a PoE handling to the RB5009 model if the board is equipped with the necessary hardware.
