### PR TITLE
rockchip: add support for Radxa ROCK Pi E v3.0

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -106,6 +106,13 @@ define U-Boot/rock-pi-e-rk3328
     radxa_rock-pi-e
 endef
 
+define U-Boot/rock-pi-e-v3-rk3328
+  $(U-Boot/rk3328/Default)
+  NAME:=ROCK Pi E v3.0
+  BUILD_DEVICES:= \
+    radxa_rock-pi-e-v3
+endef
+
 # RK3399 boards
 
 define U-Boot/rk3399/Default
@@ -220,6 +227,7 @@ UBOOT_TARGETS := \
   roc-cc-rk3328 \
   rock64-rk3328 \
   rock-pi-e-rk3328 \
+  rock-pi-e-v3-rk3328 \
   radxa-cm3-io-rk3566 \
   bpi-r2-pro-rk3568 \
   nanopi-r5c-rk3568 \

--- a/package/boot/uboot-rockchip/patches/000-rockchip-add-support-for-Radxa-ROCK-Pi-E-v3.0.patch
+++ b/package/boot/uboot-rockchip/patches/000-rockchip-add-support-for-Radxa-ROCK-Pi-E-v3.0.patch
@@ -1,0 +1,248 @@
+From 8ca5e0e4d6ed084d2321584e8cdc8105c60b9aa1 Mon Sep 17 00:00:00 2001
+From: FUKAUMI Naoki <naoki@radxa.com>
+Date: Tue, 25 Jun 2024 05:45:29 +0900
+Subject: [PATCH] rockchip: add support for Radxa ROCK Pi E v3.0
+
+ROCK Pi E v3.0 uses DDR4 SDRAM instead of DDR3 SDRAM used in v1.2x.
+
+prepare new rk3328-rock-pi-e-v3.dts in u-boot which just includes
+upstream rk3328-rock-pi-e.dts.
+
+defconfig still uses
+ CONFIG_DEFAULT_FDT_FILE="rockchip/rk3328-rock-pi-e.dtb"
+
+because v3.0 and prior are compatible.
+
+Suggested-by: Jonas Karlman <jonas@kwiboo.se>
+Signed-off-by: FUKAUMI Naoki <naoki@radxa.com>
+Reviewed-by: Kever Yang <kever.yang@rock-chips.com>
+---
+ ...dtsi => rk3328-rock-pi-e-base-u-boot.dtsi} |  1 -
+ arch/arm/dts/rk3328-rock-pi-e-u-boot.dtsi     | 47 +--------
+ arch/arm/dts/rk3328-rock-pi-e-v3-u-boot.dtsi  |  4 +
+ arch/arm/dts/rk3328-rock-pi-e-v3.dts          |  4 +
+ board/rockchip/evb_rk3328/MAINTAINERS         |  4 +-
+ configs/rock-pi-e-v3-rk3328_defconfig         | 97 +++++++++++++++++++
+ 6 files changed, 111 insertions(+), 46 deletions(-)
+ copy arch/arm/dts/{rk3328-rock-pi-e-u-boot.dtsi => rk3328-rock-pi-e-base-u-boot.dtsi} (94%)
+ rewrite arch/arm/dts/rk3328-rock-pi-e-u-boot.dtsi (88%)
+ create mode 100644 arch/arm/dts/rk3328-rock-pi-e-v3-u-boot.dtsi
+ create mode 100644 arch/arm/dts/rk3328-rock-pi-e-v3.dts
+ create mode 100644 configs/rock-pi-e-v3-rk3328_defconfig
+
+--- a/arch/arm/dts/rk3328-rock-pi-e-u-boot.dtsi
++++ b/arch/arm/dts/rk3328-rock-pi-e-u-boot.dtsi
+@@ -1,43 +1,4 @@
+ // SPDX-License-Identifier: GPL-2.0+
+-/*
+- * (C) Copyright 2020 Radxa
+- */
+ 
+-#include "rk3328-u-boot.dtsi"
++#include "rk3328-rock-pi-e-base-u-boot.dtsi"
+ #include "rk3328-sdram-ddr3-666.dtsi"
+-
+-/ {
+-	smbios {
+-		compatible = "u-boot,sysinfo-smbios";
+-
+-		smbios {
+-			system {
+-				manufacturer = "radxa";
+-				product = "rock-pi-e_rk3328";
+-			};
+-
+-			baseboard {
+-				manufacturer = "radxa";
+-				product = "rock-pi-e_rk3328";
+-			};
+-
+-			chassis {
+-				manufacturer = "radxa";
+-				product = "rock-pi-e_rk3328";
+-			};
+-		};
+-	};
+-};
+-
+-&u2phy_host {
+-	phy-supply = <&vcc_host_5v>;
+-};
+-
+-&vcc_host_5v {
+-	/delete-property/ regulator-always-on;
+-	/delete-property/ regulator-boot-on;
+-};
+-
+-&vcc_sd {
+-	bootph-pre-ram;
+-};
+--- /dev/null
++++ b/arch/arm/dts/rk3328-rock-pi-e-base-u-boot.dtsi
+@@ -0,0 +1,42 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * (C) Copyright 2020 Radxa
++ */
++
++#include "rk3328-u-boot.dtsi"
++
++/ {
++	smbios {
++		compatible = "u-boot,sysinfo-smbios";
++
++		smbios {
++			system {
++				manufacturer = "radxa";
++				product = "rock-pi-e_rk3328";
++			};
++
++			baseboard {
++				manufacturer = "radxa";
++				product = "rock-pi-e_rk3328";
++			};
++
++			chassis {
++				manufacturer = "radxa";
++				product = "rock-pi-e_rk3328";
++			};
++		};
++	};
++};
++
++&u2phy_host {
++	phy-supply = <&vcc_host_5v>;
++};
++
++&vcc_host_5v {
++	/delete-property/ regulator-always-on;
++	/delete-property/ regulator-boot-on;
++};
++
++&vcc_sd {
++	bootph-pre-ram;
++};
+--- /dev/null
++++ b/arch/arm/dts/rk3328-rock-pi-e-v3-u-boot.dtsi
+@@ -0,0 +1,4 @@
++// SPDX-License-Identifier: GPL-2.0+
++
++#include "rk3328-rock-pi-e-base-u-boot.dtsi"
++#include "rk3328-sdram-ddr4-666.dtsi"
+--- /dev/null
++++ b/arch/arm/dts/rk3328-rock-pi-e-v3.dts
+@@ -0,0 +1,4 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++#include "rk3328-rock-pi-e.dts"
+--- a/board/rockchip/evb_rk3328/MAINTAINERS
++++ b/board/rockchip/evb_rk3328/MAINTAINERS
+@@ -64,5 +64,5 @@ M:      Banglang Huang <banglang.huang@f
+ R:      Jonas Karlman <jonas@kwiboo.se>
+ S:      Maintained
+ F:      configs/rock-pi-e-rk3328_defconfig
+-F:      arch/arm/dts/rk3328-rock-pi-e.dts
+-F:      arch/arm/dts/rk3328-rock-pi-e-u-boot.dtsi
++F:      configs/rock-pi-e-v3-rk3328_defconfig
++F:      arch/arm/dts/rk3328-rock-pi-e*
+--- /dev/null
++++ b/configs/rock-pi-e-v3-rk3328_defconfig
+@@ -0,0 +1,97 @@
++CONFIG_ARM=y
++CONFIG_SKIP_LOWLEVEL_INIT=y
++CONFIG_COUNTER_FREQUENCY=24000000
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SPL_GPIO=y
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_SF_DEFAULT_SPEED=20000000
++CONFIG_ENV_OFFSET=0x3F8000
++CONFIG_DEFAULT_DEVICE_TREE="rk3328-rock-pi-e-v3"
++CONFIG_DM_RESET=y
++CONFIG_ROCKCHIP_RK3328=y
++CONFIG_DEBUG_UART_BASE=0xFF130000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_SYS_LOAD_ADDR=0x800800
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_FIT_SIGNATURE=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_LEGACY_IMAGE_FORMAT=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3328-rock-pi-e.dtb"
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++CONFIG_SPL_MAX_SIZE=0x40000
++CONFIG_SPL_PAD_TO=0x7f8000
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_POWER=y
++CONFIG_SPL_ATF=y
++CONFIG_SPL_ATF_NO_PLATFORM_PARAM=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_TIME=y
++CONFIG_CMD_REGULATOR=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_TPL_OF_CONTROL=y
++# CONFIG_OF_UPSTREAM is not set
++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_TPL_OF_PLATDATA=y
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_SYS_MMC_ENV_DEV=1
++CONFIG_TPL_DM=y
++CONFIG_SPL_DM_SEQ_ALIAS=y
++CONFIG_REGMAP=y
++CONFIG_SPL_REGMAP=y
++CONFIG_TPL_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_SPL_SYSCON=y
++CONFIG_TPL_SYSCON=y
++CONFIG_CLK=y
++CONFIG_SPL_CLK=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_PHY_REALTEK=y
++CONFIG_DM_MDIO=y
++CONFIG_DM_ETH_PHY=y
++CONFIG_PHY_GIGE=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PINCTRL=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_SPL_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_SPL_DM_REGULATOR_FIXED=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM=y
++CONFIG_SPL_RAM=y
++CONFIG_TPL_RAM=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_ROCKCHIP=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYS_NS16550_MEM32=y
++CONFIG_SYSINFO=y
++CONFIG_SYSINFO_SMBIOS=y
++CONFIG_SYSRESET=y
++# CONFIG_TPL_SYSRESET is not set
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_OHCI_GENERIC=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_TPL_TINY_MEMSET=y
++CONFIG_ERRNO_STR=y

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -12,6 +12,7 @@ rockchip_setup_interfaces()
 	friendlyarm,nanopi-r2s|\
 	friendlyarm,nanopi-r4s|\
 	friendlyarm,nanopi-r4s-enterprise|\
+	radxa,rockpi-e|\
 	xunlong,orangepi-r1-plus|\
 	xunlong,orangepi-r1-plus-lts)
 		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -139,6 +139,15 @@ define Device/radxa_rock-pi-e
 endef
 TARGET_DEVICES += radxa_rock-pi-e
 
+define Device/radxa_rock-pi-e-v3
+  DEVICE_VENDOR := Radxa
+  DEVICE_MODEL := ROCK Pi E v3.0
+  SOC := rk3328
+  DEVICE_DTS := rockchip/rk3328-rock-pi-e
+  DEVICE_PACKAGES := kmod-usb-net-cdc-ncm kmod-usb-net-rndis
+endef
+TARGET_DEVICES += radxa_rock-pi-e-v3
+
 define Device/radxa_rock-pi-s
   DEVICE_VENDOR := Radxa
   DEVICE_MODEL := ROCK Pi S

--- a/target/linux/rockchip/patches-6.6/114-rock-pi-e-add-led-aliases-and-stop-heartbeat.patch
+++ b/target/linux/rockchip/patches-6.6/114-rock-pi-e-add-led-aliases-and-stop-heartbeat.patch
@@ -1,0 +1,27 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
+@@ -23,6 +23,10 @@
+ 	aliases {
+ 		mmc0 = &sdmmc;
+ 		mmc1 = &emmc;
++		led-boot = &led_blue;
++		led-failsafe = &led_blue;
++		led-running = &led_blue;
++		led-upgrade = &led_blue;
+ 	};
+ 
+ 	chosen {
+@@ -55,10 +59,11 @@
+ 		pinctrl-0 = <&led_pin>;
+ 		pinctrl-names = "default";
+ 
+-		led-0 {
++		led_blue: led-0 {
+ 			color = <LED_COLOR_ID_BLUE>;
++			default-state = "on";
++			function = LED_FUNCTION_HEARTBEAT;
+ 			gpios = <&gpio3 RK_PA5 GPIO_ACTIVE_LOW>;
+-			linux,default-trigger = "heartbeat";
+ 		};
+ 	};
+ 


### PR DESCRIPTION
Radxa ROCK Pi E v3.0 is a compact networking SBC[1] using the Rockchip RK3328 SoC.

Hardware
--------
- Rockchip RK3328 SoC
- Quad A53 CPU
- 512MB/1GB/2GB DDR4 RAM
- 4/8/16/32GB eMMC
- Micro SD Card slot
- WiFi 4 and BT 4, or WiFi 5 and BT 5 (not supported yet)
- 1x 1000M Ethernet with PoE support (additional PoE HAT required)
- 1x 100M Ethernet
- 1x USB 3.0 Type-A port (Host)
- 1x 4-ring 3.5mm headphone jack
- 40 Pin GPIO header

[1] https://radxa.com/products/rockpi/pie

Installation
------------
Uncompress the OpenWrt sysupgrade and write it to a micro SD card or internal eMMC using dd.