### PR TITLE
rockchip: add support for Radxa ROCK 3A

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -199,6 +199,13 @@ define U-Boot/radxa-e25-rk3568
     radxa_e25
 endef
 
+define U-Boot/rock-3a-rk3568
+  $(U-Boot/rk3568/Default)
+  NAME:=ROCK 3A
+  BUILD_DEVICES:= \
+    radxa_rock-3a
+endef
+
 UBOOT_TARGETS := \
   nanopc-t4-rk3399 \
   nanopi-r4s-rk3399 \
@@ -217,7 +224,8 @@ UBOOT_TARGETS := \
   bpi-r2-pro-rk3568 \
   nanopi-r5c-rk3568 \
   nanopi-r5s-rk3568 \
-  radxa-e25-rk3568
+  radxa-e25-rk3568 \
+  rock-3a-rk3568
 
 UBOOT_CONFIGURE_VARS += USE_PRIVATE_LIBGCC=yes
 

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -115,6 +115,14 @@ define Device/radxa_e25
 endef
 TARGET_DEVICES += radxa_e25
 
+define Device/radxa_rock-3a
+  DEVICE_VENDOR := Radxa
+  DEVICE_MODEL := ROCK 3A
+  SOC := rk3568
+  DEVICE_PACKAGES := kmod-usb-net-cdc-ncm kmod-usb-net-rndis
+endef
+TARGET_DEVICES += radxa_rock-3a
+
 define Device/radxa_rock-pi-4a
   DEVICE_VENDOR := Radxa
   DEVICE_MODEL := ROCK Pi 4A

--- a/target/linux/rockchip/patches-6.6/115-rock-3a-add-led-aliases-and-stop-heartbeat.patch
+++ b/target/linux/rockchip/patches-6.6/115-rock-3a-add-led-aliases-and-stop-heartbeat.patch
@@ -1,0 +1,29 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
+@@ -15,6 +15,10 @@
+ 		ethernet0 = &gmac1;
+ 		mmc0 = &sdhci;
+ 		mmc1 = &sdmmc0;
++		led-boot = &led_blue;
++		led-failsafe = &led_blue;
++		led-running = &led_blue;
++		led-upgrade = &led_blue;
+ 	};
+ 
+ 	chosen: chosen {
+@@ -42,11 +46,11 @@
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+-		led_user: led-0 {
+-			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
+-			function = LED_FUNCTION_HEARTBEAT;
++		led_blue: led-0 {
+ 			color = <LED_COLOR_ID_BLUE>;
+-			linux,default-trigger = "heartbeat";
++			default-state = "on";
++			function = LED_FUNCTION_HEARTBEAT;
++			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
+ 			pinctrl-names = "default";
+ 			pinctrl-0 = <&led_user_en>;
+ 		};


### PR DESCRIPTION
Radxa ROCK 3A is a credit card sized SBC with rich interfaces[1] using the Rockchip RK3328 SoC.

Hardware
--------
- Rockchip RK3568 SoC
- Quad Cortex-A55 CPU
- Mail G52 GPU
- 1 TOPs NPU
- 2/4/8GB LPDDR4 RAM
- 1x eMMC connector
- 1x M.2 M Key (2-lane PCIe 3.0) supporting NVMe SSD
- 1x Micro SD card slot
- 1x 1000M Ethernet with PoE support (additional PoE HAT required)
- 1x USB 3.0 Type-A port (Host)
- 1x USB 3.0 Type-A port (OTG)
- 2x USB 2.0 Type-A ports (Host)
- 40 pin color GPIO header

[1] https://radxa.com/products/rock3/3a

Installation
------------
Uncompress the OpenWrt sysupgrade and write it to a micro SD card or internal eMMC using dd.