### PR TITLE
base-files: improve Dell EMC Edge620 (x86) product support

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -31,6 +31,9 @@ cisco-mx100-hw)
 	ucidef_set_network_device_path "eth11" "pci0000:00/0000:00:01.1/0000:02:00.2"
 	ucidef_set_interfaces_lan_wan "mgmt eth2 eth3 eth4 eth5 eth6 eth7 eth8 eth9 eth10 eth11" "wan"
 	;;
+dell-emc-edge620)
+	ucidef_set_interfaces_lan_wan "eth0 eth1 eth2 eth3 eth7" "eth6"
+	;;
 pc-engines-apu1|pc-engines-apu2|pc-engines-apu3)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
 	;;


### PR DESCRIPTION
This adds auto-configuration of network ports on Dell EMC Edge620 (x86) product. It is similar in specs/features to some of the Sophos x86-based appliances, but:

1. Serial console terminal is built in and requires just the micro-USB cable
2. Comes with both MMC (16Gb) and SSD (256Gb) installed
3. Comes with 6 ethernet ports all 6 are functional when no SFP is used
4. Comes with two SFP cages and not one, like some of revision 3 Sophos products
5. Unlike Sophos devices, there are no non-wireless models of Edge 620, it comes with Qualcomm Atheros QCA9880 radio

These devices can be now found both second-hand and new at online marketplaces below (sometimes well below) US $100, I believe they make great candidates for running OpenWrt.

The ethernet network ports on the case are marked GE1 thru to GE6 with the following mapping once booted into OpenWrt:

```
GE1: eth2: pci0000:00/0000:00:0b.0/0000:02:00.2
GE2: eth3: pci0000:00/0000:00:0b.0/0000:02:00.3
GE3: eth0: pci0000:00/0000:00:0b.0/0000:02:00.0
GE4: eth1: pci0000:00/0000:00:0b.0/0000:02:00.1
GE5: eth7: pci0000:00/0000:00:17.0/0000:07:00.1
GE6: eth6: pci0000:00/0000:00:17.0/0000:07:00.0
```

Dell's instructions for [standard configuration](https://infohub.delltechnologies.com/en-us/l/dell-emc-edge-620-advanced-activation-guide/dell-emc-sd-wan-edge-620-standard-configuration/) recommend using GE3, GE4, GE5, or GE6 for WAN, I've selected the GE6 as the sole WAN port under OpenWrt with the rest of ethernet ports assigned to LAN.

Please merge before 24.xx is forked and if possible, cherry-pick for 23.05 if there's no ETA for 24.xx forking.

PS. @Hurricos I'm struggling with ixgbe mappings on Sophos devices which use very similar hardware to Dell EMC, so even tho I know the sys paths for ethernet ports, I'd prefer to do a separate commit to properly map ethernet ports to match the case markings for this device at some point later.
