### PR TITLE
kernel: rtl8366s: don’t handle unsupported MMD register operations

### DIFF
--- a/target/linux/generic/backport-6.6/719-v6.11-net-phy-realtek-add-support-for-RTL8366S-Gigabit-PHY.patch
+++ b/target/linux/generic/backport-6.6/719-v6.11-net-phy-realtek-add-support-for-RTL8366S-Gigabit-PHY.patch
@@ -1,0 +1,48 @@
+From 225990c487c1023e7b3aa89beb6a68011fbc0461 Mon Sep 17 00:00:00 2001
+From: Mark Mentovai <mark@mentovai.com>
+Date: Thu, 25 Jul 2024 16:41:44 -0400
+Subject: [PATCH] net: phy: realtek: add support for RTL8366S Gigabit PHY
+
+The PHY built in to the Realtek RTL8366S switch controller was
+previously supported by genphy_driver. This PHY does not implement MMD
+operations. Since commit 9b01c885be36 ("net: phy: c22: migrate to
+genphy_c45_write_eee_adv()"), MMD register reads have been made during
+phy_probe to determine EEE support. For genphy_driver, these reads are
+transformed into 802.3 annex 22D clause 45-over-clause 22
+mmd_phy_indirect operations that perform MII register writes to
+MII_MMD_CTRL and MII_MMD_DATA. This overwrites those two MII registers,
+which on this PHY are reserved and have another function, rendering the
+PHY unusable while so configured.
+
+Proper support for this PHY is restored by providing a phy_driver that
+declares MMD operations as unsupported by using the helper functions
+provided for that purpose, while remaining otherwise identical to
+genphy_driver.
+
+Fixes: 9b01c885be36 ("net: phy: c22: migrate to genphy_c45_write_eee_adv()")
+Reported-by: Russell Senior <russell@personaltelco.net>
+Closes: https://github.com/openwrt/openwrt/issues/15981
+Link: https://github.com/openwrt/openwrt/issues/15739
+Signed-off-by: Mark Mentovai <mark@mentovai.com>
+Reviewed-by: Maxime Chevallier <maxime.chevallier@bootlin.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/phy/realtek.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/drivers/net/phy/realtek.c
++++ b/drivers/net/phy/realtek.c
+@@ -1083,6 +1083,13 @@ static struct phy_driver realtek_drvs[]
+ 		.handle_interrupt = genphy_handle_interrupt_no_ack,
+ 		.suspend	= genphy_suspend,
+ 		.resume		= genphy_resume,
++	}, {
++		PHY_ID_MATCH_EXACT(0x001cc960),
++		.name		= "RTL8366S Gigabit Ethernet",
++		.suspend	= genphy_suspend,
++		.resume		= genphy_resume,
++		.read_mmd	= genphy_read_mmd_unsupported,
++		.write_mmd	= genphy_write_mmd_unsupported,
+ 	},
+ };
+ 


### PR DESCRIPTION
This is a backport of [netdev/net 225990c487c1](https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=225990c487c1/) ([netdev list thread](https://lore.kernel.org/netdev/20240725204147.69730-1-mark@mentovai.com/)), expected to be in kernel 6.11 (if not backported to a stable branch).

Since 4fdc7bb8f13f (2024-06-14, switching ath79 from kernel 6.1 to 6.6), the rtl8366s driver was made to write to bogus PHY MII registers on ath79/netgear,wndr3800 and family, and likely on other systems using this switch in a similar manner. The writes were directed to PHY 4 MII registers 0x0d (13) and 0x0e (14). The rtl8366s data sheet claims these registers are reserved. These register writes were causing the device to not maintain link, track link status, or pass traffic on eth1 (labeled WAN), as eth1 is connected to PHY 4.

0x0d is `MII_MMD_CTRL`, and 0x0e is `MII_MMD_DATA`. rtl8366s doesn’t appear to support MMD in any way, and certainly not via the IEEE 802.3 annex 22D “clause 45 over clause 22” protocol implemented by `mmd_phy_indirect`. This patch intercepts those attempted register accesses and returns `-EOPNOTSUPP` without touching the switch chip. This is implemented by defining `phy_driver::{read,write}_mmd` as `genphy_{read,write}_mmd_unsupported` for this PHY. A new PHY driver for this PHY is introduced to achieve that, because this PHY was previously using `genphy_driver`, and there is otherwise no clean way to declare lack of support for these operations.

This was caused by [kernel 9b01c885be36](https://github.com/torvalds/linux/commit/9b01c885be364526d8c05794f8358b3e563b7ff8) (2023-02-13, in 6.3). The new `genphy_c45_read_eee_abilities` call in `genphy_read_abilities` (called during `phy_probe`) was causing an attempted MMD read of (`MMIO_MMD_PCS`, `MDIO_PCS_EEE_ABLE`), which was transformed into an annex 22D `mmd_phy_indirect` operation that performed MII register writes to `MII_MMD_CTRL`, `MII_MMD_DATA`, and `MII_MMD_CTRL` again, followed by another read from `MII_MMD_DATA`. This was enough to “scramble” the state of those two MII registers, which are in fact not used for annex 22D MMD register access on this device but are reserved and have some other function, rendering the PHY unusable while so configured. The result of the bungled MMD read attempt caused the genphy driver to incorrectly believe that the PHY supported standard EEE, which led to several more attempted MMD writes and reads, in turn being transformed into writes to these two MII registers.

rtl8366s does support some pre-IEEE 802.3az EEE standard form of “Green Ethernet” which the switch driver (local to OpenWrt) already has some support for. No attempt is made to map the standard operations for this device.

Fixes: https://github.com/openwrt/openwrt/issues/15981
Link: https://github.com/openwrt/openwrt/issues/15739
Reported-by: Russell Senior <russell@personaltelco.net>