### PR TITLE
.gitattributes: ignore some whitespace “violations” in .patch files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * -text
+*.patch whitespace=-indent-with-non-tab,-space-before-tab,-tab-in-indent,-trailing-space


### PR DESCRIPTION
git’s default [`core.whitespace`](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_whitespace) setting doesn’t agree with .patch files. This causes whitespace warnings when running `git apply`, (including via `git am`) and causes red highlighting when viewing diffs to .patch files via `git diff` (including via `git show`) when outputting to a terminal.

These types of whitespace “violations” will now be explicitly disabled  for .patch files in the repository-wide .gitattributes file to prevent git from suggesting that there’s anything wrong with checked-in .patch files.

A .patch file will naturally have `space-before-tab` if a context line (not a `+`/`-` line) begins with a tab character (as is common in patches to files that use the tab indent convention), and will also naturally have `trailing-space` if a context line is blank (also common).

Neither `indent-with-non-tab` nor `tab-in-indent` are enabled in core.whitespace by default, but could also occur naturally in .patch files, and are also explicitly disabled here for completeness to cover cases where they may be enabled in core.whitespace at the global or system level.

These false violations may be flagged frequently in OpenWrt, because the repository contains many .patch files. There are currently just over 5,000 .patch files, representing slightly more than half of all files.

Discussed briefly at https://github.com/openwrt/openwrt/pull/16012#pullrequestreview-2202880476.

Example (before applying this change):
```
% curl --silent https://github.com/openwrt/openwrt/commit/f7c5e98f3356ee688b41eb4be61baccb98caeb3b.patch |
  git am -
Applying: kernel: rtl8366s: don't handle unsupported MMD register operations
.git/rebase-apply/patch:47: space before tab in indent.
 		.handle_interrupt = genphy_handle_interrupt_no_ack,
.git/rebase-apply/patch:48: space before tab in indent.
 		.suspend	= genphy_suspend,
.git/rebase-apply/patch:49: space before tab in indent.
 		.resume		= genphy_resume,
.git/rebase-apply/patch:57: space before tab in indent.
 	},
.git/rebase-apply/patch:59: trailing whitespace.
 
warning: squelched 1 whitespace error
warning: 6 lines add whitespace errors.
```