### PR TITLE
ncurses: Fix path in ncursesw.pc

### DIFF
--- a/package/libs/ncurses/Makefile
+++ b/package/libs/ncurses/Makefile
@@ -181,6 +181,8 @@ define Build/InstallDev
 	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' -e 's/$$$$INCS //g' \
 		$(2)/bin/ncursesw6-config
 	ln -sf $(STAGING_DIR)/host/bin/ncursesw6-config $(1)/usr/bin/ncursesw6-config
+	$(SED) 's,$(TOOLCHAIN_DIR),$(STAGING_DIR),g' \
+		$(1)/usr/lib/pkgconfig/ncursesw.pc
 endef
 
 define Host/Compile


### PR DESCRIPTION
The file contains the the /usr/lib path from the toolchain directory and not from the target directory. The /usr/lib directory for the toolchain is empty and the shared library is not in the specified paths. On RISCV the linker of util-linux was finding the libncursesw.so in my host system, tried to link against it and failed. Fix the .pc file.

Fixes: #15942