### PR TITLE
ag71xx: remove phy_dev from ag struct

### DIFF
--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
@@ -176,8 +176,6 @@ struct ag71xx {
 	struct ag71xx_desc	*stop_desc;
 	dma_addr_t		stop_desc_dma;
 
-	struct phy_device	*phy_dev;
-	void			*phy_priv;
 	phy_interface_t		phy_if_mode;
 
 	unsigned int		link;
@@ -210,7 +208,6 @@ extern struct ethtool_ops ag71xx_ethtool_ops;
 void ag71xx_link_adjust(struct ag71xx *ag);
 
 int ag71xx_phy_connect(struct ag71xx *ag);
-void ag71xx_phy_disconnect(struct ag71xx *ag);
 
 static inline int ag71xx_desc_empty(struct ag71xx_desc *desc)
 {

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ethtool.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ethtool.c
@@ -145,8 +145,7 @@ ag71xx_ethtool_set_ringparam(struct net_device *dev,
 
 static int ag71xx_ethtool_nway_reset(struct net_device *dev)
 {
-	struct ag71xx *ag = netdev_priv(dev);
-	struct phy_device *phydev = ag->phy_dev;
+	struct phy_device *phydev = dev->phydev;
 
 	if (!phydev)
 		return -ENODEV;

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -1013,7 +1013,7 @@ static int ag71xx_open(struct net_device *dev)
 	if (ret)
 		goto err;
 
-	phy_start(ag->phy_dev);
+	phy_start(dev->phydev);
 
 	return 0;
 
@@ -1028,7 +1028,7 @@ static int ag71xx_stop(struct net_device *dev)
 	struct ag71xx *ag = netdev_priv(dev);
 
 	netif_carrier_off(dev);
-	phy_stop(ag->phy_dev);
+	phy_stop(dev->phydev);
 
 	spin_lock_irqsave(&ag->lock, flags);
 	if (ag->link) {
@@ -1156,16 +1156,6 @@ err_drop:
 
 	dev_kfree_skb(skb);
 	return NETDEV_TX_OK;
-}
-
-static int ag71xx_do_ioctl(struct net_device *dev, struct ifreq *ifr, int cmd)
-{
-	struct ag71xx *ag = netdev_priv(dev);
-
-	if (ag->phy_dev == NULL)
-		return -ENODEV;
-
-	return phy_mii_ioctl(ag->phy_dev, ifr, cmd);
 }
 
 static void ag71xx_oom_timer_handler(struct timer_list *t)
@@ -1478,7 +1468,7 @@ static const struct net_device_ops ag71xx_netdev_ops = {
 	.ndo_open		= ag71xx_open,
 	.ndo_stop		= ag71xx_stop,
 	.ndo_start_xmit		= ag71xx_hard_start_xmit,
-	.ndo_eth_ioctl		= ag71xx_do_ioctl,
+	.ndo_eth_ioctl		= phy_do_ioctl,
 	.ndo_tx_timeout		= ag71xx_tx_timeout,
 	.ndo_change_mtu		= ag71xx_change_mtu,
 	.ndo_set_mac_address	= eth_mac_addr,
@@ -1727,7 +1717,7 @@ static int ag71xx_probe(struct platform_device *pdev)
 	return 0;
 
 err_phy_disconnect:
-	ag71xx_phy_disconnect(ag);
+	phy_disconnect(dev->phydev);
 	return err;
 }
 
@@ -1741,7 +1731,7 @@ static int ag71xx_remove(struct platform_device *pdev)
 
 	ag = netdev_priv(dev);
 	ag71xx_debugfs_exit(ag);
-	ag71xx_phy_disconnect(ag);
+	phy_disconnect(dev->phydev);
 	unregister_netdev(dev);
 	platform_set_drvdata(pdev, NULL);
 	return 0;

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_phy.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_phy.c
@@ -17,7 +17,7 @@
 static void ag71xx_phy_link_adjust(struct net_device *dev)
 {
 	struct ag71xx *ag = netdev_priv(dev);
-	struct phy_device *phydev = ag->phy_dev;
+	struct phy_device *phydev = dev->phydev;
 	unsigned long flags;
 	int status_change = 0;
 
@@ -47,6 +47,7 @@ int ag71xx_phy_connect(struct ag71xx *ag)
 {
 	struct device_node *np = ag->pdev->dev.of_node;
 	struct device_node *phy_node;
+	struct phy_device *phydev;
 	int ret;
 
 	if (of_phy_is_fixed_link(np)) {
@@ -68,25 +69,20 @@ int ag71xx_phy_connect(struct ag71xx *ag)
 		return -ENODEV;
 	}
 
-	ag->phy_dev = of_phy_connect(ag->dev, phy_node, ag71xx_phy_link_adjust,
+	phydev = of_phy_connect(ag->dev, phy_node, ag71xx_phy_link_adjust,
 				     0, ag->phy_if_mode);
 
 	of_node_put(phy_node);
 
-	if (!ag->phy_dev) {
+	if (!phydev) {
 		dev_err(&ag->pdev->dev,
 			"Could not connect to PHY device. Deferring probe.\n");
 		return -EPROBE_DEFER;
 	}
 
 	dev_info(&ag->pdev->dev, "connected to PHY at %s [uid=%08x, driver=%s]\n",
-		    phydev_name(ag->phy_dev),
-		    ag->phy_dev->phy_id, ag->phy_dev->drv->name);
+		    phydev_name(phydev),
+		    phydev->phy_id, phydev->drv->name);
 
 	return 0;
-}
-
-void ag71xx_phy_disconnect(struct ag71xx *ag)
-{
-	phy_disconnect(ag->phy_dev);
 }


### PR DESCRIPTION
Do as upstream does and use net_device phydev.

Get rid of phy_priv too. Unused.