### PR TITLE
rockchip: drop redundant definitions for ROCK Pi S

### DIFF
--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -152,9 +152,7 @@ define Device/radxa_rock-pi-s
   DEVICE_VENDOR := Radxa
   DEVICE_MODEL := ROCK Pi S
   SOC := rk3308
-  DEVICE_DTS := rockchip/rk3308-rock-pi-s
   BOOT_SCRIPT := rock-pi-s
-  UBOOT_DEVICE_NAME := rock-pi-s-rk3308
   DEVICE_PACKAGES := kmod-usb-net-cdc-ncm kmod-usb-net-rndis
 endef
 TARGET_DEVICES += radxa_rock-pi-s


### PR DESCRIPTION
default values should be fine.