### PR TITLE
uboot-envtools: ath79: add Belkin F9K1115v2/F9J1108v2 u-boot env support

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -89,6 +89,8 @@ zyxel,nbg6616)
 aruba,ap-105|\
 aruba,ap-115|\
 aruba,ap-175|\
+belkin,f9j1108-v2|\
+belkin,f9k1115-v2|\
 dongwon,dw02-412h-64m|\
 dongwon,dw02-412h-128m|\
 glinet,gl-ar300m-lite|\


### PR DESCRIPTION
Add support for Belkin F9K1115v2/F9J1108v2 u-boot env