### PR TITLE
uboot-rockchip: Fix Orange Pi R1 Plus LTS incorrect boot device correspondence

### DIFF
--- a/package/boot/uboot-envtools/files/rockchip
+++ b/package/boot/uboot-envtools/files/rockchip
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2023 OpenWrt.org
+#
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+xunlong,orangepi-r1-plus|\
+xunlong,orangepi-r1-plus-lts)
+	ubootenv_add_uci_config "/dev/mmcblk0" "0x3f8000" "0x8000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config
+
+exit 0

--- a/package/boot/uboot-rockchip/patches/001-rockchip-rk3328-fix-orange-pi-r1-plus-lts-boot-and-sysupgrade.patch
+++ b/package/boot/uboot-rockchip/patches/001-rockchip-rk3328-fix-orange-pi-r1-plus-lts-boot-and-sysupgrade.patch
@@ -1,0 +1,43 @@
+From 77e187e7bae1269cb1623dc1fc064f8c88b83a03 Mon Sep 17 00:00:00 2001
+From: Pugemon <islavaivanov76@gmail.com>
+Date: Tue, 30 Jul 2024 14:27:45 +0300
+Subject: [PATCH] uboot-rockchip: Fix Orange Pi R1 Plus LTS Boot and Sysupgrade
+
+Orange Pi R1 Plus LTS don't have emmc (default mmc0 in rk3328-u-boot.dtsi)
+
+Because of this, during sysupgrade, the board cannot start up because the script that changes the boot_device to an available one does not trigger.
+
+In this patch, I am changing the alias of mmc0 from &emmc to &sdmmc. Thanks to this, the board starts correctly and sysupgrade is successfully performed.
+
+Also, thanks to this, it has become possible to save the u-boot environment using saveenv
+
+Signed-off-by: Pugemon <islavaivanov76@gmail.com>
+---
+ arch/arm/dts/rk3328-orangepi-r1-plus-lts-u-boot.dtsi | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/arch/arm/dts/rk3328-orangepi-r1-plus-lts-u-boot.dtsi b/arch/arm/dts/rk3328-orangepi-r1-plus-lts-u-boot.dtsi
+index b50c1332b8..eee55cbb3b 100644
+--- a/arch/arm/dts/rk3328-orangepi-r1-plus-lts-u-boot.dtsi
++++ b/arch/arm/dts/rk3328-orangepi-r1-plus-lts-u-boot.dtsi
+@@ -7,6 +7,17 @@
+ #include "rk3328-u-boot.dtsi"
+ #include "rk3328-sdram-lpddr3-666.dtsi"
+ 
++/ {
++	aliases {
++		mmc0 = &sdmmc;
++		spi0 = &spi0;
++	};
++
++	chosen {
++		u-boot,spl-boot-order = "same-as-spl", &sdmmc;
++	};
++};
++
+ &spi0 {
+ 	flash@0 {
+ 		bootph-pre-ram;
+-- 
+2.39.1.windows.1
+


### PR DESCRIPTION
The Orange Pi R1 Plus LTS lacks an eMMC storage option, which is the default mmc0 in the rk3328-u-boot.dtsi file. This absence leads to boot failures during system upgrades, as the script responsible for switching the boot device to an available one does not get triggered.

**Changes:**

- Updated Device Tree: Changed the alias of mmc0 from &emmc to &sdmmc. This modification ensures the system uses the correct boot device, enabling the board to boot properly post-sysupgrade.
- Functional Improvement: With this change, the saveenv command can now successfully save the U-Boot environment, as the system correctly identifies the bootable storage.

**Benefits:**

- Ensures successful booting of the board after a sysupgrade.
- Facilitates saving the U-Boot environment with the saveenv command, improving usability and flexibility in managing boot settings.

This patch addresses the boot device misidentification and resolves issues related to the absence of an eMMC. It provides a stable and reliable system upgrade process for the Orange Pi R1 Plus LTS.