### PR TITLE
Revert "ath79: remove GPIO driver earlier registration hack"

### DIFF
--- a/target/linux/ath79/patches-6.6/340-register_gpio_driver_earlier.patch
+++ b/target/linux/ath79/patches-6.6/340-register_gpio_driver_earlier.patch
@@ -1,0 +1,26 @@
+From: John Crispin <john@phrozen.org>
+Subject: ath79: Register GPIO driver earlier
+
+HACK: register the GPIO driver earlier to ensure that gpio_request calls
+from mach files succeed.
+
+Submitted-by: John Crispin <john@phrozen.org>
+---
+ drivers/gpio/gpio-ath79.c                     | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+--- a/drivers/gpio/gpio-ath79.c
++++ b/drivers/gpio/gpio-ath79.c
+@@ -300,7 +300,11 @@ static struct platform_driver ath79_gpio
+ 	.probe = ath79_gpio_probe,
+ };
+ 
+-module_platform_driver(ath79_gpio_driver);
++static int __init ath79_gpio_init(void)
++{
++	return platform_driver_register(&ath79_gpio_driver);
++}
++postcore_initcall(ath79_gpio_init);
+ 
+ MODULE_DESCRIPTION("Atheros AR71XX/AR724X/AR913X GPIO API support");
+ MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
This reverts commit f444dea428cdcafd78fb75004a942da24cabd48c.

Impact of the initial commit is a kernel crash on some device. 
Ref: https://forum.openwrt.org/t/bump-from-6-1-to-6-failure/203939

Signed-off-by: Joan Moreau <jom@grosjo.net>