### PR TITLE
ramips: add support for D-Link DAP-1610 A1

### DIFF
--- a/target/linux/ramips/dts/mt7628an_dlink_dap-1610-a1.dts
+++ b/target/linux/ramips/dts/mt7628an_dlink_dap-1610-a1.dts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dap-1610-a1", "mediatek,mt7628an-soc";
+	model = "D-Link DAP-1610 A1";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-high {
+			label = "green:wifi-high";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-mid {
+			label = "green:wifi-mid";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-low {
+			label = "green:wifi-low";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-verylow {
+			label = "red:wifi-verylow";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "refclk", "gpio", "wled_an", "i2s", "uart1", "wdt";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&factory 0x0>;
+
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_28: macaddr@28 {
+		reg = <0x28 0x6>;
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -206,6 +206,14 @@ define Device/dlink_dap-1325-a1
 endef
 TARGET_DEVICES += dlink_dap-1325-a1
 
+define Device/dlink_dap-1610-a1
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := D-Link
+  DEVICE_PACKAGES := kmod-mt76
+  DEVICE_MODEL := DAP-1610 A1
+endef
+TARGET_DEVICES += dlink_dap-1610-a1
+
 define Device/duzun_dm06
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := DuZun


### PR DESCRIPTION
ramips: add support for D-Link DAP-1610 A1

The following changes were made:
- Added device tree source (DTS) file for DAP-1610 A1, defining hardware components and configurations.
- Modified the mt76x8.mk file to include the DAP-1610 A1 build configuration.
- Defined factory image format and partitions specific to the device.

These changes have been tested and confirmed to work with the OpenWrt v23.05.4 release, providing full function including wireless and Ethernet interfaces.

Instructions for Upgrading to OpenWrt:
```
Through the Stock Firmware Web UI:

   - Connect your device to the network and access the web interface at `http://192.168.0.50`
   - Navigate to Management  -> Upgrade -> Select Firmware
   - Select the OpenWrt firmware file and proceed with the upgrade

2. Using the D-Link Recovery Page: 

   - Power off the repeater
   - Press and hold the reset button while powering on the device
   - Keep holding the reset button until the red light starts blinking
   - Access the recovery page at http://192.168.0.50
   - Select the OpenWrt firmware file and upload it to start the flashing

After the device reboots, OpenWrt should be running. You can access the OpenWrt web interface at http://192.168.1.1
```

Signed-off-by: Siddhesh Lokhande <135891602+LoneWolff7@users.noreply.github.com>
