### PR TITLE
wpq864: add nor config and read the mac addr from uboot env

### DIFF
--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-wpq864.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-wpq864.dts
@@ -183,8 +183,11 @@
 			};
 
 			partition@1180000 {
+				compatible = "u-boot,env";
 				label = "0:APPSBLENV";
 				reg = <0x1180000 0x0080000>;
+				macaddr_ubootenv_ethaddr: ethaddr {};
+				macaddr_ubootenv_eth1addr: eth1addr {};
 			};
 
 			partition@1200000 {
@@ -380,6 +383,8 @@
 
 	phy-mode = "rgmii";
 	qcom,id = <1>;
+	nvmem-cells = <&macaddr_ubootenv_ethaddr>;
+	nvmem-cell-names = "mac-address";
 
 	fixed-link {
 		speed = <1000>;
@@ -392,6 +397,8 @@
 
 	phy-mode = "sgmii";
 	qcom,id = <2>;
+	nvmem-cells = <&macaddr_ubootenv_eth1addr>;
+	nvmem-cell-names = "mac-address";
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-wpq864.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-wpq864.dts
@@ -413,6 +413,86 @@
 
 &flash {
 	compatible = "jedec,spi-nor";
+	spi-max-frequency = <50000000>;
+	reg = <0>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "1:SBL1";
+			reg = <0x0 0x20000>;
+			read-only;
+		};
+
+		partition@20000 {
+			label = "1:MIBIB";
+			reg = <0x20000 0x20000>;
+			read-only;
+		};
+
+		partition@40000 {
+			label = "1:SBL2";
+			reg = <0x40000 0x40000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "1:SBL3";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "1:DDRCONFIG";
+			reg = <0x100000 0x10000>;
+			read-only;
+		};
+
+		partition@110000 {
+			label = "1:TZ";
+			reg = <0x110000 0x80000>;
+			read-only;
+		};
+
+		partition@190000 {
+			label = "1:RPM";
+			reg = <0x190000 0x80000>;
+			read-only;
+		};
+
+		partition@2100000 {
+			label = "1:APPSBL";
+			reg = <0x210000 0x80000>;
+			read-only;
+		};
+
+		partition@290000 {
+			label = "1:APPSBLENV";
+			reg = <0x290000 0x40000>;
+		};
+
+		partition@2d0000 {
+			label = "1:ART";
+			reg = <0x2d0000 0x40000>;
+			read-only;
+		};
+
+		partition@310000 {
+			label = "1:HLOS";
+			reg = <0x310000 0x0400000>;
+		};
+
+		partition@710000 {
+			label = "1:rootfs";
+			reg = <0x710000 0x1800000>;
+		};
+
+		/delete-node/ partition@1;
+
+	};
 };
 
 &sata_phy {


### PR DESCRIPTION
- Add the nor flash config to dts. Fixes: openwrt#15476
- Read the mac addr from uboot env. Fixes: openwrt#15477 and openwrt#15478

Signed-off-by: Patrick Grimm <patrick@lunatiki.de>
