### PR TITLE
hostapd: fix SAE H2E security vulnerability

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/patches/800-SAE-Check-for-invalid-Rejected-Groups-element-length.patch
+++ b/package/network/services/hostapd/patches/800-SAE-Check-for-invalid-Rejected-Groups-element-length.patch
@@ -1,0 +1,43 @@
+From 364c2da8741f0979dae497551e70b94c0e6c8636 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <j@w1.fi>
+Date: Sun, 7 Jul 2024 11:46:49 +0300
+Subject: [PATCH] SAE: Check for invalid Rejected Groups element length
+ explicitly
+
+Instead of practically ignoring an odd octet at the end of the element,
+check for such invalid case explicitly. This is needed to avoid a
+potential group downgrade attack.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ src/ap/ieee802_11.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+--- a/src/ap/ieee802_11.c
++++ b/src/ap/ieee802_11.c
+@@ -1229,7 +1229,7 @@ static int check_sae_rejected_groups(str
+ 				     struct sae_data *sae)
+ {
+ 	const struct wpabuf *groups;
+-	size_t i, count;
++	size_t i, count, len;
+ 	const u8 *pos;
+ 
+ 	if (!sae->tmp)
+@@ -1239,7 +1239,15 @@ static int check_sae_rejected_groups(str
+ 		return 0;
+ 
+ 	pos = wpabuf_head(groups);
+-	count = wpabuf_len(groups) / 2;
++	len = wpabuf_len(groups);
++	if (len & 1) {
++		wpa_printf(MSG_DEBUG,
++			   "SAE: Invalid length of the Rejected Groups element payload: %zu",
++			   len);
++		return 1;
++	}
++
++	count = len / 2;
+ 	for (i = 0; i < count; i++) {
+ 		int enabled;
+ 		u16 group;

--- a/package/network/services/hostapd/patches/801-SAE-Check-for-invalid-Rejected-Groups-element-length.patch
+++ b/package/network/services/hostapd/patches/801-SAE-Check-for-invalid-Rejected-Groups-element-length.patch
@@ -1,0 +1,42 @@
+From 593a7c2f8c93edd6b552f2d42e28164464b4e6ff Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <j@w1.fi>
+Date: Tue, 9 Jul 2024 23:33:38 +0300
+Subject: [PATCH] SAE: Check for invalid Rejected Groups element length
+ explicitly on STA
+
+Instead of practically ignoring an odd octet at the end of the element,
+check for such invalid case explicitly. This is needed to avoid a
+potential group downgrade attack.
+
+Fixes: 444d76f74f65 ("SAE: Check that peer's rejected groups are not enabled")
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ wpa_supplicant/sme.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+--- a/wpa_supplicant/sme.c
++++ b/wpa_supplicant/sme.c
+@@ -1561,14 +1561,21 @@ static int sme_sae_is_group_enabled(stru
+ static int sme_check_sae_rejected_groups(struct wpa_supplicant *wpa_s,
+ 					 const struct wpabuf *groups)
+ {
+-	size_t i, count;
++	size_t i, count, len;
+ 	const u8 *pos;
+ 
+ 	if (!groups)
+ 		return 0;
+ 
+ 	pos = wpabuf_head(groups);
+-	count = wpabuf_len(groups) / 2;
++	len = wpabuf_len(groups);
++	if (len & 1) {
++		wpa_printf(MSG_DEBUG,
++			   "SAE: Invalid length of the Rejected Groups element payload: %zu",
++			   len);
++		return 1;
++	}
++	count = len / 2;
+ 	for (i = 0; i < count; i++) {
+ 		int enabled;
+ 		u16 group;

--- a/package/network/services/hostapd/patches/802-SAE-Reject-invalid-Rejected-Groups-element-in-the-pa.patch
+++ b/package/network/services/hostapd/patches/802-SAE-Reject-invalid-Rejected-Groups-element-in-the-pa.patch
@@ -1,0 +1,30 @@
+From 9716bf1160beb677e965d9e6475d6c9e162e8374 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <j@w1.fi>
+Date: Tue, 9 Jul 2024 23:34:34 +0300
+Subject: [PATCH] SAE: Reject invalid Rejected Groups element in the parser
+
+There is no need to depend on all uses (i.e., both hostapd and
+wpa_supplicant) to verify that the length of the Rejected Groups field
+in the Rejected Groups element is valid (i.e., a multiple of two octets)
+since the common parser can reject the message when detecting this.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ src/common/sae.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/src/common/sae.c
++++ b/src/common/sae.c
+@@ -2120,6 +2120,12 @@ static int sae_parse_rejected_groups(str
+ 		return WLAN_STATUS_UNSPECIFIED_FAILURE;
+ 	epos++; /* skip ext ID */
+ 	len--;
++	if (len & 1) {
++		wpa_printf(MSG_DEBUG,
++			   "SAE: Invalid length of the Rejected Groups element payload: %u",
++			   len);
++		return WLAN_STATUS_UNSPECIFIED_FAILURE;
++	}
+ 
+ 	wpabuf_free(sae->tmp->peer_rejected_groups);
+ 	sae->tmp->peer_rejected_groups = wpabuf_alloc(len);


### PR DESCRIPTION
This patch backports fixes for a security vulnerability impacting the
hostapd implementation of SAE H2E.

As upgrading hostapd would require more testing, the second mitigation
step which involves backporting several patches was adopted as outlined
in the official advisory[1].

An explanation of the impact of the vulnerability is provided from the
advisory[1]:

This vulnerability allows the attacker to downgrade the negotiated group
to another enabled group if both the AP and STA have enabled SAE H2E and
multiple groups. It should be noted that the H2E option is not enabled
by default and the attack is not applicable to the default option, i.e.,
hunting-and-pecking, since it does not have any downgrade protection for
group negotiation. In addition, the default configuration for enabled
SAE groups in hostapd is to enable only a single group, so the
vulnerability is not applicable unless hostapd has been explicitly
configured to enable more groups for SAE.

[1]: https://w1.fi/security/2024-2/sae-h2h-and-incomplete-downgrade-protection-for-group-negotiation.txt
