### PR TITLE
xfrm: remove requirement for underlying device

### DIFF
--- a/package/network/config/xfrm/Makefile
+++ b/package/network/config/xfrm/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xfrm
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/network/config/xfrm/files/xfrm.sh
+++ b/package/network/config/xfrm/files/xfrm.sh
@@ -14,19 +14,11 @@ proto_xfrm_setup() {
 	local tunlink ifid mtu zone multicast
 	json_get_vars tunlink ifid mtu zone multicast
 
-	[ -z "$tunlink" ] && {
-		proto_notify_error "$cfg" NO_TUNLINK
-		proto_block_restart "$cfg"
-		exit
-	}
-
 	[ -z "$ifid" ] && {
 		proto_notify_error "$cfg" NO_IFID
 		proto_block_restart "$cfg"
 		exit
 	}
-
-	( proto_add_host_dependency "$cfg" '' "$tunlink" )
 
 	proto_init_update "$cfg" 1
 
@@ -34,7 +26,10 @@ proto_xfrm_setup() {
 	json_add_string mode "$mode"
 	json_add_int mtu "${mtu:-1280}"
 
-	json_add_string link "$tunlink"
+	[ -n "$tunlink" ] && {
+		( proto_add_host_dependency "$cfg" '' "$tunlink" )
+		json_add_string link "$tunlink"
+	}
 
 	json_add_boolean multicast "${multicast:-1}"
 


### PR DESCRIPTION
Since kernel 5.3, phydev (dev) is no longer required

   torvalds/linux@22d6552

This allows the xfrm interface to come up without being tied to a specific interface (such as multiple wan interfaces).

Separately, luci description will need to be updated to reflect this field is now optional.