### PR TITLE
ramips: ethernet: use devm for request_irq

### DIFF
--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
@@ -245,7 +245,7 @@ int mtk_gsw_init(struct fe_priv *priv)
 	mt7620_ephy_init(gsw);
 
 	if (gsw->irq) {
-		ret = request_irq(gsw->irq, gsw_interrupt_mt7620, 0,
+		ret = devm_request_irq(&pdev->dev, gsw->irq, gsw_interrupt_mt7620, 0,
 				  "gsw", priv);
 		if (ret) {
 			dev_err(&pdev->dev, "Failed to request irq");

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -1414,7 +1414,6 @@ static void fe_uninit(struct net_device *dev)
 	fe_mdio_cleanup(priv);
 
 	fe_reg_w32(0, FE_REG_FE_INT_ENABLE);
-	free_irq(dev->irq, dev);
 }
 
 static int fe_do_ioctl(struct net_device *dev, struct ifreq *ifr, int cmd)


### PR DESCRIPTION
Allows removing free_irq. Simpler.

Oddly enough the other switch code already does this.

ping @DragonBluep 