### PR TITLE
mediatek: refresh patches

### DIFF
--- a/target/linux/mediatek/patches-6.6/041-block-fit-partition-parser.patch
+++ b/target/linux/mediatek/patches-6.6/041-block-fit-partition-parser.patch
@@ -92,7 +92,7 @@ Subject: [PATCH] kernel: add block fit partition parser
  #ifdef CONFIG_SGI_PARTITION
  	sgi_partition,
  #endif
-@@ -462,6 +468,11 @@ static struct block_device *add_partitio
+@@ -464,6 +470,11 @@ static struct block_device *add_partitio
  			goto out_del;
  	}
  
@@ -104,7 +104,7 @@ Subject: [PATCH] kernel: add block fit partition parser
  	/* everything is up and running, commence */
  	err = xa_insert(&disk->part_tbl, partno, bdev, GFP_KERNEL);
  	if (err)
-@@ -654,6 +665,11 @@ static bool blk_add_partition(struct gen
+@@ -656,6 +667,11 @@ static bool blk_add_partition(struct gen
  	    (state->parts[p].flags & ADDPART_FLAG_RAID))
  		md_autodetect_dev(part->bd_dev);
  


### PR DESCRIPTION
CI says patches need to be refreshed, so do so.

Fixes: 6bb334c5cf1c ("mediatek: fix u-boot env layout NVMEM definitions")
