### PR TITLE
tools/cmake: Update to 3.30.2

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
-PKG_VERSION:=3.29.5
+PKG_VERSION:=3.30.2
 PKG_VERSION_MAJOR:=$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:kitware:cmake
@@ -15,7 +15,7 @@ PKG_CPE_ID:=cpe:/a:kitware:cmake
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Kitware/CMake/releases/download/v$(PKG_VERSION)/ \
 		https://cmake.org/files/v$(PKG_VERSION_MAJOR)/
-PKG_HASH:=dd63da7d763c0db455ca232f2c443f5234fe0b11f8bd6958a81d29cc987dfd6e
+PKG_HASH:=46074c781eccebc433e98f0bbfa265ca3fd4381f245ca3b140e7711531d60db2
 
 HOST_BUILD_PARALLEL:=1
 HOST_CONFIGURE_PARALLEL:=1

--- a/tools/cmake/patches/110-liblzma.patch
+++ b/tools/cmake/patches/110-liblzma.patch
@@ -1,8 +1,8 @@
 --- a/Modules/FindLibLZMA.cmake
 +++ b/Modules/FindLibLZMA.cmake
-@@ -58,7 +58,13 @@ The following variables are provided for
- 
- #]=======================================================================]
+@@ -61,7 +61,13 @@ The following variables are provided for
+ cmake_policy(PUSH)
+ cmake_policy(SET CMP0159 NEW) # file(STRINGS) with REGEX updates CMAKE_MATCH_<n>
  
 -find_path(LIBLZMA_INCLUDE_DIR lzma.h )
 +if(UNIX)

--- a/tools/cmake/patches/120-curl-fix-libressl-linking.patch
+++ b/tools/cmake/patches/120-curl-fix-libressl-linking.patch
@@ -20,7 +20,7 @@ Signed-off-by: Jo-Philipp Wich <jo@mein.io>
 ---
 --- a/Utilities/cmcurl/CMakeLists.txt
 +++ b/Utilities/cmcurl/CMakeLists.txt
-@@ -647,6 +647,14 @@ if(CURL_USE_OPENSSL)
+@@ -648,6 +648,14 @@ if(CURL_USE_OPENSSL)
    endif()
    set(SSL_ENABLED ON)
    set(USE_OPENSSL ON)

--- a/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
+++ b/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
@@ -1,6 +1,6 @@
 --- a/bootstrap
 +++ b/bootstrap
-@@ -1493,7 +1493,10 @@ int main(){ printf("1%c", (char)0x0a); r
+@@ -1509,7 +1509,10 @@ int main(){ printf("1%c", (char)0x0a); r
  ' > "test.c"
  cmake_original_make_flags="${cmake_make_flags}"
  if test "x${cmake_parallel_make}" != "x"; then

--- a/tools/cmake/patches/140-zlib.patch
+++ b/tools/cmake/patches/140-zlib.patch
@@ -1,6 +1,6 @@
 --- a/Modules/FindZLIB.cmake
 +++ b/Modules/FindZLIB.cmake
-@@ -117,10 +117,13 @@ else()
+@@ -120,10 +120,13 @@ else()
    set(ZLIB_NAMES_DEBUG zd zlibd zdlld zlibd1 zlib1d zlibstaticd zlibwapid zlibvcd zlibstatd)
  endif()
  

--- a/tools/cmake/patches/160-disable_xcode_generator.patch
+++ b/tools/cmake/patches/160-disable_xcode_generator.patch
@@ -1,6 +1,6 @@
 --- a/Source/CMakeLists.txt
 +++ b/Source/CMakeLists.txt
-@@ -846,7 +846,7 @@ if(CMake_USE_XCOFF_PARSER)
+@@ -858,7 +858,7 @@ if(CMake_USE_XCOFF_PARSER)
  endif()
  
  # Xcode only works on Apple
@@ -11,7 +11,7 @@
      PRIVATE
 --- a/Source/cmake.cxx
 +++ b/Source/cmake.cxx
-@@ -132,7 +132,7 @@
+@@ -134,7 +134,7 @@
  #  include "cmGlobalGhsMultiGenerator.h"
  #endif
  


### PR DESCRIPTION
Update cmake to version 3.30.2
Release notes: https://cmake.org/cmake/help/v3.30/release/3.30.html

Tested by compiling mt7622/E8450