### PR TITLE
wireguard-tools: accept iproute2 as dependency

### DIFF
--- a/package/network/utils/wireguard-tools/Makefile
+++ b/package/network/utils/wireguard-tools/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=wireguard-tools
 
 PKG_VERSION:=1.0.20210914
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=wireguard-tools-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://git.zx2c4.com/wireguard-tools/snapshot/
@@ -35,8 +35,8 @@ define Package/wireguard-tools
   MAINTAINER:=Jason A. Donenfeld <Jason@zx2c4.com>
   TITLE:=WireGuard userspace control program (wg)
   DEPENDS:= \
-	  +@BUSYBOX_CONFIG_IP \
-	  +@BUSYBOX_CONFIG_FEATURE_IP_LINK \
+	  +!BUSYBOX_CONFIG_IP:ip \
+	  +!BUSYBOX_CONFIG_FEATURE_IP_LINK:ip \
 	  +kmod-wireguard
 endef
 


### PR DESCRIPTION
If the user has ip-full installed there is no need to depend on BusyBox having any form of `ip` or `ip link` applets.