### PR TITLE
rockchip: rock 3a: fix image check failed

### DIFF
--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -119,6 +119,7 @@ define Device/radxa_rock-3a
   DEVICE_VENDOR := Radxa
   DEVICE_MODEL := ROCK 3A
   SOC := rk3568
+  SUPPORTED_DEVICES := radxa,rock3a
   DEVICE_PACKAGES := kmod-usb-net-cdc-ncm kmod-usb-net-rndis
 endef
 TARGET_DEVICES += radxa_rock-3a


### PR DESCRIPTION
Fixes the image check failed error on system upgrade by adding the proper compatible device name
https://github.com/torvalds/linux/blob/d3426a6ed9d8398bfee2a1c5cd0ae50f2f4494a8/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts#L12

![21](https://github.com/user-attachments/assets/73df4bb9-0fb9-49b1-8932-eb22ba016744)

