### PR TITLE
Build packages with Intel CPU-integrated GPU (iGPU) firmware files

### DIFF
--- a/package/firmware/linux-firmware/intel.mk
+++ b/package/firmware/linux-firmware/intel.mk
@@ -215,3 +215,30 @@ define Package/e100-firmware/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/e100/d102e_ucode.bin $(1)/lib/firmware/e100/
 endef
 $(eval $(call BuildPackage,e100-firmware))
+
+Package/intel-igpu-firmware-dmc = $(call Package/firmware-default,Intel iGPU DMC Display MC firmware)
+define Package/intel-igpu-firmware-dmc/install
+	$(INSTALL_DIR) $(1)/lib/firmware/i915
+	$(CP) \
+		$(PKG_BUILD_DIR)/i915/*_dmc_*.bin* \
+		$(1)/lib/firmware/i915/
+endef
+$(eval $(call BuildPackage,intel-igpu-firmware-dmc))
+
+Package/intel-igpu-firmware-guc = $(call Package/firmware-default,Intel iGPU GUC Graphics MC firmware)
+define Package/intel-igpu-firmware-guc/install
+	$(INSTALL_DIR) $(1)/lib/firmware/i915
+	$(CP) \
+		$(PKG_BUILD_DIR)/i915/*_guc_*.bin* \
+		$(1)/lib/firmware/i915/
+endef
+$(eval $(call BuildPackage,intel-igpu-firmware-guc))
+
+Package/intel-igpu-firmware-huc = $(call Package/firmware-default,Intel iGPU HUC H.265 MC firmware)
+define Package/intel-igpu-firmware-huc/install
+	$(INSTALL_DIR) $(1)/lib/firmware/i915
+	$(CP) \
+		$(PKG_BUILD_DIR)/i915/*_huc_*.bin* \
+		$(1)/lib/firmware/i915/
+endef
+$(eval $(call BuildPackage,intel-igpu-firmware-huc))


### PR DESCRIPTION
On latest Intel x86 CPUs, DMC firmware is required for the iGPU to reach its lowest power states. If the driver cannot load it, it will print a warning and unnecessarily make the iGPU draw a bit more power when idle.

GUC firmware (various "offload" mechanisms that deal with scheduling GPU workloads) and HUC firmware (required for accelerated media codec operations for HEVC/H.265) are probably more niche, but could also provde useful for some - for example, when building an Intel/OpenWrt-based security camera.

More info on GUC/HUC-firmware can be found at https://www.intel.com/content/www/us/en/content-details/609249/enabling-the-guc-huc-firmware-for-linux-on-new-intel-gpu-platforms.html