### PR TITLE
qualcommax: ipq807x: add support for Linksys MX4300 (LN1301)

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq807x
@@ -37,6 +37,11 @@ linksys,mx8500)
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000" "2"
 	;;
+linksys,mx4300)
+	idx="$(find_mtd_index u_env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x40000" "1"
+	;;
 netgear,sxr80|\
 netgear,sxs80|\
 tplink,eap620hd-v1|\

--- a/package/system/mtd/src/linksys_bootcount.c
+++ b/package/system/mtd/src/linksys_bootcount.c
@@ -69,12 +69,10 @@ struct bootcounter {
 	uint32_t checksum;
 };
 
-static char page[2048];
-
 int mtd_resetbc(const char *mtd)
 {
 	struct mtd_info_user mtd_info;
-	struct bootcounter *curr = (struct bootcounter *)page;
+	struct bootcounter *curr = NULL;
 	unsigned int i;
 	unsigned int bc_offset_increment;
 	int last_count = 0;
@@ -108,23 +106,22 @@ int mtd_resetbc(const char *mtd)
 	}
 
 	num_bc = mtd_info.size / bc_offset_increment;
+        curr = malloc(bc_offset_increment);
 
 	for (i = 0; i < num_bc; i++) {
-		pread(fd, curr, sizeof(*curr), i * bc_offset_increment);
+		pread(fd, curr, sizeof(struct bootcounter), i * bc_offset_increment);
 
 		/* Existing code assumes erase is to 0xff; left as-is (2019) */
+		if (curr->magic == 0xffffffff)
+			break;
 
-		if (curr->magic != BOOTCOUNT_MAGIC &&
-		    curr->magic != 0xffffffff) {
-			DLOG_ERR("Unexpected magic %08x at offset %08x; aborting.",
-				 curr->magic, i * bc_offset_increment);
+		if (curr->magic != BOOTCOUNT_MAGIC || curr->checksum != curr->magic + curr->count) {
+			DLOG_ERR("Unexpected boot-count log at offset %08x: magic %08x boot count %08x checksum %08x; aborting.",
+				 i * bc_offset_increment, curr->magic, curr->count, curr->checksum);
 
 			retval = -2;
 			goto out;
 		}
-
-		if (curr->magic == 0xffffffff)
-			break;
 
 		last_count = curr->count;
 	}
@@ -182,6 +179,7 @@ int mtd_resetbc(const char *mtd)
 	}
 
 out:
+	if (curr != NULL) free(curr);
 	close(fd);
 	return retval;
 }

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200.dtsi
@@ -1,79 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /* Copyright (c) 2023, Mohammad Sayful Islam <Sayf.mohammad01@gmail.com> */
 
-#include "ipq8074.dtsi"
-#include "ipq8074-ac-cpu.dtsi"
-#include "ipq8074-ess.dtsi"
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
+#include "ipq8174-mx4x00.dtsi"
 
 / {
-
 	aliases {
-		serial0 = &blsp1_uart5;
-		serial1 = &blsp1_uart3;
-		/*
-		 * Aliases as required by u-boot
-		 * to patch MAC addresses
-		 */
-		ethernet1 = &dp2;
-		ethernet2 = &dp3;
 		ethernet3 = &dp4;
 		ethernet4 = &dp5;
-		led-boot = &led_system_blue;
-		led-running = &led_system_blue;
-		led-failsafe = &led_system_red;
-		led-upgrade = &led_system_green;
-	};
-
-	chosen {
-		stdout-path = "serial0:115200n8";
-	};
-
-	keys {
-		compatible = "gpio-keys";
-		pinctrl-0 = <&button_pins>;
-		pinctrl-names = "default";
-
-		reset-button {
-			label = "reset";
-			gpios = <&tlmm 52 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-
-		wps-button {
-			label = "wps";
-			gpios = <&tlmm 67 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WPS_BUTTON>;
-		};
 	};
 };
 
 &tlmm {
-	button_pins: button-state {
-		pins = "gpio52", "gpio67";
-		function = "gpio";
-		drive-strength = <8>;
-		bias-pull-up;
-	};
-
-	mdio_pins: mdio-state {
-		mdc-pins {
-			pins = "gpio68";
-			function = "mdc";
-			drive-strength = <8>;
-			bias-pull-up;
-		};
-
-		mdio-pins {
-			pins = "gpio69";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-pull-up;
-		};
-	};
-
 	iot_pins: iot-state {
 		recovery-pins {
 			pins = "gpio22";
@@ -96,26 +33,6 @@
 	pinctrl-names = "default";
 
 	/* Silicon Labs EFR32MG21 IoT */
-};
-
-&blsp1_uart5 {
-	status = "okay";
-};
-
-&prng {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
-&qpic_bam {
-	status = "okay";
 };
 
 &qpic_nand {
@@ -288,21 +205,25 @@
 				label = "alt_rootfs";
 				reg = <0xac80000 0x9000000>;
 			};
+
 			partition@13c80000 {
 				label = "sysdiag";
 				reg = <0x13c80000 0x200000>;
 				read-only;
 			};
+
 			partition@13e80000 {
 				label = "0:ethphyfw";
 				reg = <0x13e80000 0x80000>;
 				read-only;
 			};
+
 			partition@13f00000 {
 				label = "syscfg";
 				reg = <0x13f00000 0xb800000>;
 				read-only;
 			};
+
 			partition@1f700000 {
 				label = "0:wififw";
 				reg = <0x1f700000 0x900000>;
@@ -310,102 +231,6 @@
 			};
 		};
 	};
-};
-
-&blsp1_i2c2 {
-	status = "okay";
-
-	led-controller@62 {
-		compatible = "nxp,pca9633";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <0x62>;
-		nxp,hw-blink;
-
-		led_system_red: led@0 {
-			reg = <0>;
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_STATUS;
-		};
-
-		led_system_green: led@1 {
-			reg = <1>;
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-		};
-
-		led_system_blue: led@2 {
-			reg = <2>;
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_STATUS;
-		};
-	};
-};
-
-&mdio {
-	status = "okay";
-
-	pinctrl-0 = <&mdio_pins>;
-	pinctrl-names = "default";
-	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
-
-	ethernet-phy-package@0 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		compatible = "qcom,qca8075-package";
-		reg = <0>;
-
-		qca8075_1: ethernet-phy@1 {
-			compatible = "ethernet-phy-ieee802.3-c22";
-			reg = <1>;
-		};
-
-		qca8075_2: ethernet-phy@2 {
-			compatible = "ethernet-phy-ieee802.3-c22";
-			reg = <2>;
-		};
-
-		qca8075_3: ethernet-phy@3 {
-			compatible = "ethernet-phy-ieee802.3-c22";
-			reg = <3>;
-		};
-
-		qca8075_4: ethernet-phy@4 {
-			compatible = "ethernet-phy-ieee802.3-c22";
-			reg = <4>;
-		};
-	};
-};
-
-&switch {
-	status = "okay";
-
-	switch_lan_bmp = <(ESS_PORT3 | ESS_PORT4 | ESS_PORT5)>; /* lan port bitmap */
-	switch_wan_bmp = <ESS_PORT2>; /* wan port bitmap */
-	switch_mac_mode = <MAC_MODE_PSGMII>; /* mac mode for uniphy instance0*/
-
-	qcom,port_phyinfo {
-		port@2 {
-			port_id = <2>;
-			phy_address = <1>;
-		};
-		port@3 {
-			port_id = <3>;
-			phy_address = <2>;
-		};
-		port@4 {
-			port_id = <4>;
-			phy_address = <3>;
-		};
-		port@5 {
-			port_id = <5>;
-			phy_address = <4>;
-		};
-	};
-};
-
-&edma {
-	status = "okay";
 };
 
 &dp2 {
@@ -431,16 +256,3 @@
 	phy-handle = <&qca8075_4>;
 	label = "lan3";
 };
-
-&ssphy_0 {
-	status = "okay";
-};
-
-&qusb_phy_0 {
-	status = "okay";
-};
-
-&usb_0 {
-	status = "okay";
-};
-

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200.dtsi
@@ -29,7 +29,6 @@
 
 	chosen {
 		stdout-path = "serial0:115200n8";
-		bootargs-append = " root=/dev/ubiblock0_0";
 	};
 
 	keys {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4300.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4300.dts
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq8174-mx4x00.dtsi"
+
+/ {
+	model = "Linksys MX4300";
+	compatible = "linksys,mx4300", "qcom,ipq8074";
+
+	chosen {
+		/*
+		In the kernel command line, replace the first occurence of bootargs-find-X with bootargs-replace-X.
+		If bootargs-exact-match-X is set to "y", then replacement happens only if the kernel command line
+		is identical to bootargs-find-X.
+		*/
+		bootargs-find-1 = "ubi.mtd=22,2048";
+		bootargs-replace-1 = "ubi.mtd=22,4096";
+
+		bootargs-find-2 = "ubi.mtd=24,2048";
+		bootargs-replace-2 = "ubi.mtd=24,4096";
+	};
+};
+
+&qpic_nand {
+	status = "okay";
+
+	/*
+	 * Bootloader will find the NAND DT node by the compatible and
+	 * then "fixup" it by adding the partitions from the SMEM table
+	 * using the legacy bindings thus making it impossible for us
+	 * to change the partition table or utilize NVMEM for calibration.
+	 * So add a dummy partitions node that bootloader will populate
+	 * and set it as disabled so the kernel ignores it instead of
+	 * printing warnings due to the broken way bootloader adds the
+	 * partitions.
+	 */
+	partitions {
+		status = "disabled";
+	};
+
+	nand@0 {
+		reg = <0>;
+		/*
+		 * Some devices use Micron NAND with with 8 bit ECC 
+		 * other AMD/Spansion NAND with 4 bit ECC
+		 *nand-ecc-strength = <4>;
+		 *nand-ecc-step-size = <512>;
+		 */
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:sbl1";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "0:mibib";
+				reg = <0x100000 0x100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "0:bootconfig";
+				reg = <0x200000 0x80000>;
+				read-only;
+			};
+
+			partition@280000 {
+				label = "0:bootconfig1";
+				reg = <0x280000 0x80000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "0:qsee";
+				reg = <0x300000 0x300000>;
+				read-only;
+			};
+
+			partition@600000 {
+				label = "0:qsee_1";
+				reg = <0x600000 0x300000>;
+				read-only;
+			};
+
+			partition@900000 {
+				label = "0:devcfg";
+				reg = <0x900000 0x80000>;
+				read-only;
+			};
+
+			partition@980000 {
+				label = "0:devcfg_1";
+				reg = <0x980000 0x80000>;
+				read-only;
+			};
+
+			partition@a00000 {
+				label = "0:apdp";
+				reg = <0xa00000 0x80000>;
+				read-only;
+			};
+
+			partition@a80000 {
+				label = "0:apdp_1";
+				reg = <0xa80000 0x80000>;
+				read-only;
+			};
+
+			partition@b00000 {
+				label = "0:rpm";
+				reg = <0xb00000 0x80000>;
+				read-only;
+			};
+
+			partition@b80000 {
+				label = "0:rpm_1";
+				reg = <0xb80000 0x80000>;
+				read-only;
+			};
+
+			partition@c00000 {
+				label = "0:cdt";
+				reg = <0xc00000 0x80000>;
+				read-only;
+			};
+
+			partition@c80000 {
+				label = "0:cdt_1";
+				reg = <0xc80000 0x80000>;
+				read-only;
+			};
+
+			partition@d00000 {
+				label = "0:appsblenv";
+				reg = <0xd00000 0x80000>;
+			};
+
+			partition@d80000 {
+				label = "0:appsbl";
+				reg = <0xd80000 0x100000>;
+				read-only;
+			};
+
+			partition@e80000 {
+				label = "0:appsbl_1";
+				reg = <0xe80000 0x100000>;
+				read-only;
+			};
+
+			partition@f80000 {
+				label = "0:art";
+				reg = <0xf80000 0x80000>;
+				read-only;
+			};
+
+			partition@1000000 {
+				label = "u_env";
+				reg = <0x1000000 0x100000>;
+			};
+
+			partition@1100000 {
+				label = "s_env";
+				reg = <0x1100000 0x100000>;
+			};
+
+			partition@1200000 {
+				label = "devinfo";
+				reg = <0x1200000 0x40000>;
+				read-only;
+			};
+
+			partition@1240000 {
+				label = "kernel";
+				reg = <0x1240000 0xaf40000>;
+			};
+
+			partition@1a40000 {
+				label = "rootfs";
+				reg = <0x1a40000 0xa740000>;
+			};
+
+			partition@c180000 {
+				label = "alt_kernel";
+				reg = <0xc180000 0xaf40000>;
+			};
+
+			partition@c980000 {
+				label = "alt_rootfs";
+				reg = <0xc980000 0xa740000>;
+			};
+
+			partition@170c0000 {
+				label = "sysdiag";
+				reg = <0x170c0000 0x400000>;
+				read-only;
+			};
+
+			partition@174c0000 {
+				label = "0:ethphyfw";
+				reg = <0x174c0000 0x80000>;
+				read-only;
+			};
+
+			partition@17540000 {
+				label = "syscfg";
+				reg = <0x17540000 0x79c0000>;
+				read-only;
+			};
+
+			partition@1ef00000 {
+				label = "secured_store";
+				reg = <0x1ef00000 0x400000>;
+				read-only;
+			};
+
+			partition@1f300000 {
+				label = "0:wififw";
+				reg = <0x1f300000 0x1900000>;
+				read-only;
+			};
+
+			partition@20c00000 {
+				label = "app2_data";
+				reg = <0x20c00000 0x16180000>;
+				read-only;
+			};
+
+			partition@36d80000 {
+				label = "app2";
+				reg = <0x36d80000 0x9280000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&dp2 {
+	status = "okay";
+	phy-handle = <&qca8075_1>;
+	label = "wan";
+};
+
+&dp3 {
+	status = "okay";
+	phy-handle = <&qca8075_2>;
+	label = "lan3";
+};
+
+&dp4 {
+	status = "okay";
+	phy-handle = <&qca8075_3>;
+	label = "lan2";
+};
+
+&dp5 {
+	status = "okay";
+	phy-handle = <&qca8075_4>;
+	label = "lan1";
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Linksys-MX4200v1";
+};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4x00.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4x00.dtsi
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2023, Mohammad Sayful Islam <Sayf.mohammad01@gmail.com> */
+
+#include "ipq8074.dtsi"
+#include "ipq8074-ac-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		serial0 = &blsp1_uart5;
+		serial1 = &blsp1_uart3;
+		/*
+		 * Aliases as required by u-boot
+		 * to patch MAC addresses
+		 */
+		ethernet1 = &dp2;
+		ethernet2 = &dp3;
+		led-boot = &led_system_blue;
+		led-running = &led_system_blue;
+		led-failsafe = &led_system_red;
+		led-upgrade = &led_system_green;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset-button {
+			label = "reset";
+			gpios = <&tlmm 52 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps-button {
+			label = "wps";
+			gpios = <&tlmm 67 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&tlmm {
+	button_pins: button-state {
+		pins = "gpio52", "gpio67";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+
+	mdio_pins: mdio-state {
+		mdc-pins {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio-pins {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&blsp1_i2c2 {
+	status = "okay";
+
+	led-controller@62 {
+		compatible = "nxp,pca9633";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x62>;
+		nxp,hw-blink;
+
+		led_system_red: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_green: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+
+	ethernet-phy-package@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "qcom,qca8075-package";
+		reg = <0>;
+
+		qca8075_1: ethernet-phy@1 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <1>;
+		};
+
+		qca8075_2: ethernet-phy@2 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <2>;
+		};
+
+		qca8075_3: ethernet-phy@3 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <3>;
+		};
+
+		qca8075_4: ethernet-phy@4 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <4>;
+		};
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_lan_bmp = <(ESS_PORT3 | ESS_PORT4 | ESS_PORT5)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT2>; /* wan port bitmap */
+	switch_mac_mode = <MAC_MODE_PSGMII>; /* mac mode for uniphy instance0*/
+
+	qcom,port_phyinfo {
+		port@2 {
+			port_id = <2>;
+			phy_address = <1>;
+		};
+
+		port@3 {
+			port_id = <3>;
+			phy_address = <2>;
+		};
+
+		port@4 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+
+		port@5 {
+			port_id = <5>;
+			phy_address = <4>;
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&usb_0 {
+	status = "okay";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -170,12 +170,17 @@ define Device/linksys_mx
 	DEVICE_PACKAGES := kmod-leds-pca963x
 endef
 
-define Device/linksys_mx4200v1
+define Device/linksys_mx4x00
 	$(call Device/linksys_mx)
+	SOC := ipq8174
+	DEVICE_PACKAGES += ipq-wifi-linksys_mx4200
+endef
+
+define Device/linksys_mx4200v1
+	$(call Device/linksys_mx4x00)
 	DEVICE_MODEL := MX4200
 	DEVICE_VARIANT := v1
-	SOC := ipq8174
-	DEVICE_PACKAGES += ipq-wifi-linksys_mx4200 kmod-bluetooth
+	DEVICE_PACKAGES += kmod-bluetooth
 endef
 TARGET_DEVICES += linksys_mx4200v1
 

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -190,6 +190,17 @@ define Device/linksys_mx4200v2
 endef
 TARGET_DEVICES += linksys_mx4200v2
 
+define Device/linksys_mx4300
+	$(call Device/linksys_mx4x00)
+	DEVICE_MODEL := MX4300
+	BLOCKSIZE := 256k
+	PAGESIZE := 4096
+	KERNEL_SIZE := 8192k
+	IMAGE_SIZE := 171264k
+	NAND_SIZE := 1024m
+endef
+TARGET_DEVICES += linksys_mx4300
+
 define Device/linksys_mx5300
 	$(call Device/linksys_mx)
 	DEVICE_MODEL := MX5300

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -83,10 +83,8 @@ ipq807x_setup_macs()
 	case "$board" in
 		linksys,mx4200v2)
 			label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
-			for i in $(seq 3 5); do
-				[ "$(mtd_get_mac_ascii u_env eth${i}addr)" != "$label_mac" ] && lan_mac=$label_mac
-			done
-			[ "$(mtd_get_mac_ascii u_env eth2addr)" != "$label_mac" ] && wan_mac=$label_mac
+			[ "$(mtd_get_mac_ascii u_env eth1addr)" != "$label_mac" ] && wan_mac=$label_mac
+			[ "$(mtd_get_mac_ascii u_env eth2addr)" != "$label_mac" ] && lan_mac=$label_mac
 		;;
 		linksys,mx8500)
 			label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -29,6 +29,7 @@ ipq807x_setup_interfaces()
 	compex,wpq873|\
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
+	linksys,mx4300|\
 	prpl,haze|\
 	redmi,ax6|\
 	spectrum,sax1v1k|\
@@ -81,7 +82,8 @@ ipq807x_setup_macs()
 	local label_mac=""
 
 	case "$board" in
-		linksys,mx4200v2)
+		linksys,mx4200v2|\
+		linksys,mx4300)
 			label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 			[ "$(mtd_get_mac_ascii u_env eth1addr)" != "$label_mac" ] && wan_mac=$label_mac
 			[ "$(mtd_get_mac_ascii u_env eth2addr)" != "$label_mac" ] && lan_mac=$label_mac

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -44,6 +44,14 @@ case "$FIRMWARE" in
 		ath11k_remove_regdomain
 		ath11k_set_macflag
 		;;
+	linksys,mx4300)
+		caldata_extract "0:art" 0x1000 0x20000
+		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
+		ath11k_patch_mac $(macaddr_add $label_mac 2) 0
+		ath11k_patch_mac $(macaddr_add $label_mac 1) 1
+		ath11k_patch_mac $(macaddr_add $label_mac 3) 2
+		ath11k_remove_regdomain
+		;;
 	netgear,rax120v2)
 		caldata_extract "0:art" 0x1000 0x20000
 		ath11k_patch_mac $(mtd_get_mac_binary boarddata1 0xc) 0

--- a/target/linux/qualcommax/ipq807x/base-files/etc/init.d/bootcount
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/init.d/bootcount
@@ -12,6 +12,7 @@ boot() {
 	;;
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
+	linksys,mx4300|\
 	linksys,mx5300|\
 	linksys,mx8500)
 		mtd resetbc s_env || true

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -168,6 +168,7 @@ platform_do_upgrade() {
 		;;
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
+	linksys,mx4300|\
 	linksys,mx5300|\
 	linksys,mx8500)
 		boot_part="$(fw_printenv -n boot_part)"

--- a/target/linux/qualcommax/patches-6.6/0911-arm64-cmdline-replacement.patch
+++ b/target/linux/qualcommax/patches-6.6/0911-arm64-cmdline-replacement.patch
@@ -1,0 +1,105 @@
+Subject: qualcommax: add kernel cmdline replacement hack 
+
+Add kernel command line replacement hack to qualcommax. Now we can
+find and replace arguments in the kernel command line by setting
+bootargs-find-1, bootargs-replace-1, bootargs-exact-match-1
+and bootargs-find-2, bootargs-replace-2, bootargs-exact-match-2
+under the chosen node in the device tree.
+
+This hack replaces the first occurence of bootargs-find-X with
+bootargs-replace-X. If bootargs-exact-match-X is set to "y",
+then the replacement happens only if the kernel command line is
+identical to bootargs-find-X.
+
+Signed-off-by: Qiyuan Zhang <zhang.github@outlook.com>
+---
+ drivers/of/fdt.c |   71 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 71 insertions(+)
+
+--- a/drivers/of/fdt.c
++++ b/drivers/of/fdt.c
+@@ -1158,6 +1158,14 @@ int __init early_init_dt_scan_chosen(cha
+ 	const void *rng_seed;
+ 	const void *fdt = initial_boot_params;
+ 
++	int i, cmd_len, f_len, r_len, offset, step;
++	char *s_ptr, *l_end, *r_end, *cur_ptr, *end_ptr;
++	const char *exact_match;
++	const int bootargs_replace_num = 2;
++	const char *bootargs_replace_props[2][3] =
++		{ {"bootargs-find-1", "bootargs-replace-1", "bootargs-exact-match-1"},
++		{"bootargs-find-2", "bootargs-replace-2", "bootargs-exact-match-2"} };
++
+ 	node = fdt_path_offset(fdt, "/chosen");
+ 	if (node < 0)
+ 		node = fdt_path_offset(fdt, "/chosen@0");
+@@ -1186,6 +1194,69 @@ int __init early_init_dt_scan_chosen(cha
+ 	p = of_get_flat_dt_prop(node, "bootargs", &l);
+ 	if (p != NULL && l > 0)
+ 		strscpy(cmdline, p, min(l, COMMAND_LINE_SIZE));
++
++	for(i = 0; i < bootargs_replace_num; i++) {
++		p = of_get_flat_dt_prop(node, bootargs_replace_props[i][0], &f_len);
++
++		if (p == NULL || f_len == 0 )
++			continue;
++
++		exact_match = of_get_flat_dt_prop(node, bootargs_replace_props[i][2], &l);
++
++		if (exact_match != NULL && l > 0 && exact_match[0] == 'y') {
++			if(strncmp(cmdline, p, r_len) == 0)
++				s_ptr = cmdline;
++			else
++				s_ptr = NULL;
++		} else {
++			s_ptr = strstr(cmdline, p);
++		}
++
++		if(!s_ptr)
++			continue;
++
++		p = of_get_flat_dt_prop(node, bootargs_replace_props[i][1], &r_len);
++
++		if (p == NULL || r_len == 0)
++			continue;
++
++		pr_info("Input kernel commad line: %s\n", cmdline);
++
++		cmd_len = strlen(cmdline);
++
++		if (cmd_len - f_len + r_len < COMMAND_LINE_SIZE) {
++
++			pr_info("Replace kernel command line with %s\n", bootargs_replace_props[i][1]);
++
++			offset = r_len - f_len;
++
++			if (offset != 0) {
++				l_end = s_ptr + f_len -	1;
++				r_end = cmdline + cmd_len;
++
++				if (offset > 0) {
++					step = -1;
++					cur_ptr = r_end;
++					end_ptr = l_end + step;
++				} else {
++					step = 1;
++					cur_ptr = l_end;
++					end_ptr = r_end + step;
++				}
++
++				for (; cur_ptr != end_ptr; cur_ptr += step)
++					*(cur_ptr + offset) = *cur_ptr;
++			}
++
++			strncpy(s_ptr, p, r_len - 1);
++
++			pr_info("Kernel command line after replacement: %s\n", cmdline);
++		} else {
++			pr_err("Replace kernel command line with %s failed\n", bootargs_replace_props[i][1]);
++		}
++
++	}
++
+ 	p = of_get_flat_dt_prop(node, "bootargs-append", &l);
+ 	if (p != NULL && l > 0)
+ 		strlcat(cmdline, p, min_t(int, strlen(cmdline) + (int)l, COMMAND_LINE_SIZE));


### PR DESCRIPTION
Hardware specification:
========
SoC: Qualcomm IPQ8174
Flash: 1GB (Micron MT29F8G08ABBCAH4 or AMD/Spansion S34MS08G2)
RAM: 2GB (2x Kingston B5116ECMDXGJD or ESMT M15T2G16128A DDR3L)
Ethernet: 4x 10/100/1000Mbps (Qualcomm QCA8075)
WiFi1: 5GHz ax 2x2 (Qualcomm QCN5054 + Skyworks SKY85755-11) - channels 36-64 (low band)
WiFi2: 2.4GHz ax 2x2 (Qualcomm QCN5024 + Skyworks SKY85340-11)
WiFi3: 5GHz ax 4x4 (Qualcomm QCN5054 + Skyworks SKY85755-11) - channels 100-177 (high band)
LED: 1x RGB status (NXP PCA9633)
USB: 1x USB 3.0
Button: WPS, Reset

Flash instructions:
========
1. Manually upgrade firmware using openwrt-qualcommax-ipq807x-linksys_mx4300-squashfs-factory.bin image.
    More details can be found here: https://support.linksys.com/kb/article/6564-en/
    After first boot check actual partition:
    - `fw_printenv -n boot_part`

    and install firmware on second partition using command in case of 2:
    - `mtd -r -e kernel -n write openwrt-qualcommax-ipq807x-linksys_mx4300-squashfs-factory.bin kernel`

    and in case of 1:
    - `mtd -r -e alt_kernel -n write openwrt-qualcommax-ipq807x-linksys_mx4300-squashfs-factory.bin alt_kernel`

2. Installation using serial connection from OEM firmware (default login: root, password: admin):
    - `fw_printenv -n boot_part`

    In case of 2:
    - `flash_erase /dev/mtd21 0 0`
    - `nandwrite -p /dev/mtd21 openwrt-qualcommax-ipq807x-linksys_mx4300-squashfs-factory.bin`

    or in case of 1:
    - `flash_erase /dev/mtd23 0 0`
    - `nandwrite -p /dev/mtd23 openwrt-qualcommax-ipq807x-linksys_mx4300-squashfs-factory.bin`

    After first boot install firmware on second partition:
    - `mtd -r -e kernel -n write openwrt-qualcommax-ipq807x-linksys_mx4300-squashfs-factory.bin kernel`

    or:
    - `mtd -r -e alt_kernel -n write openwrt-qualcommax-ipq807x-linksys_mx4300-squashfs-factory.bin alt_kernel`

3. Installation from initramfs image using USB drive:
    Put the initramfs image on the USB drive:
    - `dd bs=1M if=openwrt-qualcommax-ipq807x-linksys_mx4300-initramfs-uImage.itb of=/dev/sdX`

    Stop u-boot and run:
    - `usb start && usbboot $loadaddr 0 && bootm $loadaddr`

    Write firmware to the flash from initramfs:
    - `mtd -e kernel -n write openwrt-qualcommax-ipq807x-linksys_mx4300-squashfs-factory.bin kernel`

    and:
    - `mtd -r -e alt_kernel -n write openwrt-qualcommax-ipq807x-linksys_mx4300-squashfs-factory.bin alt_kernel`

4. Back to the OEM firmware:
    - `mtd -e kernel -n write FW_MX4300_1.0.4.215382_prod.img kernel`

    and:
    - `mtd -r -e alt_kernel -n write FW_MX4300_1.0.4.215382_prod.img alt_kernel`

5. USB recovery:
    Put the initramfs image on the USB:
    - `dd bs=1M if=openwrt-qualcommax-ipq807x-linksys_mx4300-initramfs-uImage.itb of=/dev/sdX`

    Set u-boot env:
    - `fw_setenv bootusb 'usb start && usbboot $loadaddr 0 && bootm $loadaddr'`
    - `fw_setenv bootcmd 'run bootusb; if test $auto_recovery = no; then bootipq; elif test $boot_part = 1; then run bootpart1; else run bootpart2; fi'`