### PR TITLE
ramips: Add support for Gaoke FG7000N

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -57,6 +57,7 @@ wifire,s1500-nbn)
 	;;
 buffalo,wsr-1166dhp|\
 buffalo,wsr-600dhp|\
+gaoke,fg7000n|\
 kroks,kndrt31r16|\
 kroks,kndrt31r19|\
 mediatek,linkit-smart-7688|\

--- a/target/linux/ramips/dts/mt7620a_gaoke_fg7000n.dts
+++ b/target/linux/ramips/dts/mt7620a_gaoke_fg7000n.dts
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "gaoke,fg7000n", "ralink,mt7620a-soc";
+	model = "Gaoke FG7000N";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	aliases {
+		led-boot = &led_na1;
+		led-failsafe = &led_na2;
+		led-running = &led_na1;
+		led-upgrade = &led_na2;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		usb {
+			label = "green:usb";
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&ohci_port1>, <&ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		hidden {
+			label = "green:hidden";
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
+		};
+
+		led_na1: na1 {
+			label = "green:na1";
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
+		};
+
+		led_na2: na2 {
+			label = "green:na2";
+			gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
+		};
+
+		net {
+			label = "green:net";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "green:wps";
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+		};
+
+		vpn {
+			label = "green:vpn";
+			gpios = <&gpio2 5 GPIO_ACTIVE_LOW>;
+		};
+
+		3g {
+			label = "green:3g";
+			gpios = <&gpio2 6 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wlan {
+			label = "wlan";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				label = "config";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x60000 0x1FA0000>;
+			};
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &mdio_pins>;
+
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+
+	port@5 {
+		status = "okay";
+
+		phy-mode = "rgmii";
+		mediatek,fixed-link = <1000 1 1 1>;
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		ethernet-phy@0 {
+			reg = <0>;
+			phy-mode = "rgmii";
+
+			qca,ar8327-initvals = <
+				0x04 0x06600000 // PORT0_PAD_CTRL
+				0x0c 0x00000080 // PORT6_PAD_CTRL
+				0x7c 0x0000007e // PORT0_STATUS
+				0x80 0x00001280 // PORT1_STATUS
+				0x84 0x00001280 // PORT2_STATUS
+				0x88 0x00001280 // PORT3_STATUS
+				0x8c 0x00001280 // PORT4_STATUS
+				0x90 0x00001280 // PORT5_STATUS
+				0x94 0x0000037e // PORT6_STATUS
+				0xe0 0xc70167de // SGMII_CTRL
+			>;
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&gsw {
+	mediatek,ephy-base = /bits/ 8 <8>;
+};
+
+&wmac {
+	pinctrl-names = "default", "pa_gpio";
+	pinctrl-0 = <&pa_pins>;
+	pinctrl-1 = <&pa_gpio_pins>;
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -522,6 +522,16 @@ define Device/fon_fon2601
 endef
 TARGET_DEVICES += fon_fon2601
 
+define Device/gaoke_fg7000n
+  SOC := mt7620a
+  IMAGE_SIZE := 32384k
+  DEVICE_VENDOR := Gaoke
+  DEVICE_MODEL := FG7000N
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci uboot-envtools
+  SUPPORTED_DEVICES += fg7000n
+endef
+TARGET_DEVICES += gaoke_fg7000n
+
 define Device/glinet_gl-mt300a
   SOC := mt7620a
   IMAGE_SIZE := 15872k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -130,6 +130,10 @@ engenius,esr600)
 	ucidef_set_led_netdev "wlan5g" "5.0GHz" "blue:wlan5g" "wlan0"
 	ucidef_set_led_netdev "wlan2g" "2.4GHz" "blue:wlan2g" "wlan1"
 	;;
+gaoke,fg7000n)
+	ucidef_set_led_netdev "wan" "WAN" "green:net" "eth0.2" "tx rx"
+	ucidef_set_led_netdev "sfp" "SFP" "green:net" "eth0.3" "tx rx"
+	;;
 glinet,gl-mt300a|\
 glinet,gl-mt300n|\
 glinet,gl-mt750)

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -168,6 +168,13 @@ ramips_setup_interfaces()
 			"5:lan" "6@eth0"
 		ucidef_add_switch_attr "switch1" "enable" "false"
 		;;
+	gaoke,fg7000n)
+		ucidef_add_switch "switch0" \
+			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan" "6:sfp" "0@eth0"
+		ucidef_add_switch "switch1" \
+			"5:lan" "6@eth0"
+		ucidef_add_switch_attr "switch1" "enable" "false"
+		;;
 	fon,fon2601|\
 	vonets,var11n-300)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
Gaoke FG7000N is a SFP gateway/WiFi router.

Specifications:
CPU: Mediatek MT7620a
Switch: Qualcomm QCA8337
RAM: 128 MiB
Flash: 32 MiB
WiFI: 802.11n, 2x internal antennas
Ports: 4x LAN, 1x WAN, 1x SFP, 1x USB
GPIO: 2x buttons, 15x LEDs, +1 hidden inside,
      4 LAN LEDs, 1 WAN LED and 1 SFP LED are hardwired to the switch
      2 LEDs are labelled "N/A", repurposed as status indicators
UART: 5-pin header, 3.3V 115200 8N1, pins are:
      GND (marked with triangle) VCC TXD RXD GND

Notes:
WiFi is very slow, seems related to:
https://forum.openwrt.org/t/mt7620a-wifi-still-very-slow/145843/6

Back up your firmware! You can download the entire flash over SSH:
1. SSH into the device as "user" (default password "user") over LAN port 1 or WiFi (device is using old SSH, you need to specify -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa).
2. Type "enable" to enter privileged mode (default password is "super").
3. Start a TFTP server on your PC.
4. Run "tftp <your PC IP> put flash <some filename>".
5. It'll tell you it failed at the end, the file size should be exactly 32 MiB.

Flashing instructions:
1. Connect to UART, plug your PC into a LAN port.
2. Start the device.
3. When asked, press 1 to upload an image to RAM.
4. You will be asked for device IP, server IP and file name.
5. Set a static IP on your PC with the server IP you provided.
6. Start a TFTP server with the "initramfs-kernel" firmware image (use the file name you provided).
7. Wait for it to upload and start OpenWrt.
8. Wait for the "N/A" LED to stop blinking.
9. Switch your PC to DHCP, open 192.168.1.1 in your browser.
10. Flash the "squashfs-sysupgrade" image from there.
