### PR TITLE
uhttpd: restart daemon if certificate has changed

### DIFF
--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -204,6 +204,9 @@ start_instance()
 			append_arg "$cfg" cert "-C"
 			append_arg "$cfg" key  "-K"
 
+			procd_append_param file "$UHTTPD_CERT"
+			procd_append_param file "$UHTTPD_KEY"
+
 			for listen in $https; do
 				procd_append_param command -s "$listen"
 			done


### PR DESCRIPTION
Fixes #16075

When the SSL certificate used by uhttpd has been changed, calling `/etc/init.d/uhttpd reload` will now have the effect of restarting the daemon to make the change effective.
