### PR TITLE
lantiq: arv7525pw: use nvmem for eeprom

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7525pw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7525pw.dts
@@ -135,6 +135,10 @@
 					macaddr_boardconfig_16: macaddr@16 {
 						reg = <0x16 0x6>;
 					};
+
+					eeprom_boardconfig_410: eeprom@410 {
+						reg = <0x410 0x200>;
+					};
 				};
 			};
 		};
@@ -152,7 +156,8 @@
 	wifi@0,0 {
 		compatible = "pci0,0";
 		reg = <0x7000 0 0 0 0>;
-		ralink,mtd-eeprom = <&boardconfig 0x410>;
+		nvmem-cells = <&eeprom_boardconfig_410>;
+		nvmem-cell-names = "eeprom";
 	};
 };
 


### PR DESCRIPTION
NVMEM is the upstream replacement for this. ralink,mtd-eeprom is deprecated. The others need to stay as there's byte swapping going on.

ping @DragonBluep 

I got the EEPROM size from https://github.com/openwrt/openwrt/commit/7fd5171a3445b1f0b3aaa45f6c43550758547f2c#diff-39ecee1701c9308a388e4a9e7f1af7867ad1e137aaa3582f1724843d6c00c992