### PR TITLE
 kernel: Add kmod-mfd-test for kernel 6.6 only

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -597,7 +597,7 @@ define KernelPackage/mtdtests
 	$(LINUX_DIR)/drivers/mtd/tests/mtd_speedtest.ko \
 	$(LINUX_DIR)/drivers/mtd/tests/mtd_stresstest.ko \
 	$(LINUX_DIR)/drivers/mtd/tests/mtd_subpagetest.ko \
-	$(LINUX_DIR)/drivers/mtd/tests/mtd_test.ko \
+	$(LINUX_DIR)/drivers/mtd/tests/mtd_test.ko@ge6.6 \
 	$(LINUX_DIR)/drivers/mtd/tests/mtd_torturetest.ko
 endef
 


### PR DESCRIPTION
Compilation of mtd_test.ko should be added only for kernel 6.6 or above.