### PR TITLE
utils: omnia-mcutool: Bump to 0.3-rc3

### DIFF
--- a/package/utils/omnia-mcutool/Makefile
+++ b/package/utils/omnia-mcutool/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=omnia-mcutool
-PKG_VERSION:=0.3-rc2
+PKG_VERSION:=0.3-rc3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gitlab.nic.cz/turris/$(PKG_NAME)/-/archive/$(PKG_VERSION)/
-PKG_HASH:=68e407fca16ccaf4bd87401f710d6a4061029b4d474ac10c4c3253af73c242ac
+PKG_HASH:=80bc6a01ab86d51ebfdbddf77d74eead999a9bf7dbd08ca1fd4e8e1910eaf192
 
 PKG_MAINTAINER:=Marek Mojik <marek.mojik@nic.cz>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Bump omnia-mcutool to 0.3-rc3:

* The `--upgrade` option will now work even if MCU is in bootloader (for example if previous upgrade was aborted).

* On boards with GD32 MCUs, `omnia-mcutool` will now refuse to upgrade application firmware to version lower than 4.1 if bootloader version is 2.0 (the original for first batch of boards with GD32 MCUs) since these versions of application and bootloader are not compatible.

  If user already upgraded to such a combination, an upgrade of bootloader firmware is required.

  The `--upgrade` option will inform about this and will automatically upgrade bootloader firmware if the `--force` option is given.

  (Note that version 4.1 of the MCU firmware was will be released soon, once it is properly tested.)

* Various other improvements.