### PR TITLE
uboot-envtools: Add support for Orange Pi R1 Plus & LTS

### DIFF
--- a/package/boot/uboot-envtools/files/rockchip_armv8
+++ b/package/boot/uboot-envtools/files/rockchip_armv8
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2024 OpenWrt.org
+#
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+xunlong,orangepi-r1-plus|\
+xunlong,orangepi-r1-plus-lts)
+	ubootenv_add_uci_config "/dev/mmcblk0" "0x3f8000" "0x8000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config
+
+exit 0


### PR DESCRIPTION
Add support this boards to envtools config
This changes integrates the latest changes from new U-Boot, which includes important updates to the DTSI files for the Orange Pi R1 Plus and Orange Pi R1 Plus LTS boards.
