### PR TITLE
linux: replace nvmem-cells with nvmem-layout

### DIFF
--- a/target/linux/apm821xx/dts/meraki-mr24.dts
+++ b/target/linux/apm821xx/dts/meraki-mr24.dts
@@ -65,9 +65,12 @@
 				 * around for bad block management
 				 */
 				label = "u-boot-env";
-				compatible = "u-boot,env";
 				reg = <0x00150000 0x00010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+				};
 			};
 
 			partition@160000 {

--- a/target/linux/apm821xx/dts/meraki-mx60.dts
+++ b/target/linux/apm821xx/dts/meraki-mx60.dts
@@ -64,8 +64,11 @@
 			partition@100000 {
 				label = "u-boot-env";
 				reg = <0x00100000 0x00100000>;
-				compatible = "u-boot,env";
 				read-only;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+				};
 			};
 
 			partition@200000 {

--- a/target/linux/apm821xx/dts/netgear-wndap6x0.dtsi
+++ b/target/linux/apm821xx/dts/netgear-wndap6x0.dtsi
@@ -47,24 +47,27 @@
 			};
 
 			partition@100000 {
-				compatible = "u-boot,env";
 				label = "u-boot-env";
 				reg = <0x00100000 0x0004000>;
 				read-only;
 
-				ethaddr {
-				};
+				nvmem-layout {
+					compatible = "u-boot,env";
 
-				bootcmd {
-				};
+					ethaddr {
+					};
 
-				serno {
-				};
+					bootcmd {
+					};
 
-				ProductID {
-				};
+					serno {
+					};
 
-				HardwareVer {
+					ProductID {
+					};
+
+					HardwareVer {
+					};
 				};
 			};
 

--- a/target/linux/apm821xx/dts/netgear-wndr4700.dts
+++ b/target/linux/apm821xx/dts/netgear-wndr4700.dts
@@ -188,9 +188,12 @@
 
 				partition@40000 {
 					label = "u-boot-env-main";
-					compatible = "u-boot,env-redundant-count";
 					reg = <0x00040000 0x20000>; /* one block is 128k */
 					read-only;
+
+					nvmem-layout {
+						compatible = "u-boot,env-redundant-count";
+					};
 				};
 
 /*
@@ -199,9 +202,12 @@
  *
  *				partition@60000 {
  *					label = "u-boot-env-redundant";
- *					compatible = "u-boot,env-redundant-count";
  *					reg = <0x00060000 0x20000>;
  *					read-only;
+ *
+ *					nvmem-layout {
+ *						compatible = "u-boot,env-redundant-count";
+ *					};
  *				};
  */
 			};

--- a/target/linux/apm821xx/dts/wd-mybooklive.dts
+++ b/target/linux/apm821xx/dts/wd-mybooklive.dts
@@ -48,11 +48,14 @@
 					#size-cells = <1>;
 
 					partition@0 {
-						compatible = "u-boot,env-redundant-bool";
 						reg = <0x00000000 0x00001000>;
 						label = "u-boot-env-1";
 
-						ethaddr {
+						nvmem-layout {
+							compatible = "u-boot,env-redundant-bool";
+
+							ethaddr {
+							};
 						};
 					};
 
@@ -60,10 +63,12 @@
  * Causes the following warning: * sysfs: cannot create duplicate filename '/bus/nvmem/devices/u-boot-env0'
  *
  *					partition@1000 {
- *						compatible = "u-boot,env-redundant-bool";
  *						reg = <0x00001000 0x00001000>;
  *						label = "u-boot-env-2";
  *
+ *						nvmem-layout {
+ *							compatible = "u-boot,env-redundant-bool";
+ *						};
  *					};
  */
 				};

--- a/target/linux/ath79/dts/ar7161_ruckus_gd11.dtsi
+++ b/target/linux/ath79/dts/ar7161_ruckus_gd11.dtsi
@@ -201,9 +201,12 @@
 			};
 
 			partition@f80000 {
-				compatible = "u-boot,env";
 				reg = <0xf80000 0x40000>;
 				label = "u-boot-env";
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+				};
 			};
 
 			board_data: partition@fc0000 {

--- a/target/linux/ath79/dts/ar7240_ruckus_zf7025.dts
+++ b/target/linux/ath79/dts/ar7240_ruckus_zf7025.dts
@@ -146,9 +146,12 @@
 			};
 
 			partition@f80000 {
-				compatible = "u-boot,env";
 				reg = <0xf80000 0x40000>;
 				label = "u-boot-env";
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+				};
 			};
 
 			board_data: partition@fc0000 {

--- a/target/linux/ath79/dts/ar934x_ruckus_zf73xx.dtsi
+++ b/target/linux/ath79/dts/ar934x_ruckus_zf73xx.dtsi
@@ -104,9 +104,12 @@
 			};
 
 			partition@f40000 {
-				compatible = "u-boot,env";
 				label = "u-boot-env";
 				reg = <0xf40000 0x040000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+				};
 			};
 
 			board_data: partition@f80000 {

--- a/target/linux/ath79/dts/qca955x_senao_loader.dtsi
+++ b/target/linux/ath79/dts/qca955x_senao_loader.dtsi
@@ -59,9 +59,12 @@
 			};
 
 			partition@40000 {
-				compatible = "u-boot,env";
 				label = "u-boot-env";
 				reg = <0x040000 0x010000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+				};
 			};
 
 			partition@50000 {

--- a/target/linux/ath79/dts/qca9563_dlink_covr.dtsi
+++ b/target/linux/ath79/dts/qca9563_dlink_covr.dtsi
@@ -90,8 +90,6 @@
 				reg = <0xff0000 0x10000>;
 				read-only;
 
-				compatible = "nvmem-cells";
-
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;

--- a/target/linux/ath79/dts/qca9563_dlink_dap-1720-a1.dts
+++ b/target/linux/ath79/dts/qca9563_dlink_dap-1720-a1.dts
@@ -104,10 +104,13 @@
 			};
 
 			partition@40000 {
-				compatible = "u-boot,env";
 				label = "u-boot-env"; // vendor calls it `bdcfg`
 				reg = <0x040000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+				};
 			};
 
 			partition@50000 {

--- a/target/linux/ath79/dts/qca9563_dlink_dir-8x9-a1.dtsi
+++ b/target/linux/ath79/dts/qca9563_dlink_dir-8x9-a1.dtsi
@@ -56,10 +56,13 @@
 				read-only;
 			};
 
-			bdcfg: partition@40000 {
-				compatible = "u-boot,env";
+			partition@40000 {
 				label = "bdcfg";
 				reg = <0x040000 0x010000>;
+
+				bdcfg: nvmem-layout {
+					compatible = "u-boot,env";
+				};
 			};
 
 			partition@50000 {

--- a/target/linux/ath79/dts/qca9563_ubnt_amplifi-router-hd.dts
+++ b/target/linux/ath79/dts/qca9563_ubnt_amplifi-router-hd.dts
@@ -56,9 +56,12 @@
 			};
 
 			partition@60000 {
-				compatible = "u-boot,env";
 				label = "u-boot-env";
 				reg = <0x060000 0x010000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+				};
 			};
 
 			partition@70000 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-eap1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-eap1300.dts
@@ -196,12 +196,15 @@
 				reg = <0x190000 0x1dc0000>;
 			};
 			partition9@1f50000 {
-				compatible = "u-boot,env";
 				label = "u-boot-env";
 				reg = <0x01f50000 0x00010000>;
 
-				macaddr_ubootenv_ethaddr: ethaddr {
-					#nvmem-cell-cells = <1>;
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_ubootenv_ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
 				};
 			};
 			partition10@1f60000 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ws-ap391x.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ws-ap391x.dts
@@ -278,9 +278,12 @@
 
 			partition@e0000 {
 				label = "CFG1";
-				compatible = "u-boot,env-redundant-bool";
 				reg = <0xe0000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "u-boot,env-redundant-bool";
+				};
 			};
 
 			partition@f0000 {
@@ -331,9 +334,12 @@
 
 			partition@1fe0000 {
 				label = "CFG2";
-				compatible = "u-boot,env-redundant-bool";
 				reg = <0x1fe0000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "u-boot,env-redundant-bool";
+				};
 			};
 		};
 	};

--- a/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-ax3200-a1.dtsi
+++ b/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-ax3200-a1.dtsi
@@ -266,8 +266,7 @@
 				};
 			};
 
-			config1: partition@1C0000 {
-				compatible = "nvmem-cells";
+			partition@1C0000 {
 				label = "Config1";
 				reg = <0x001C0000 0x00080000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500.dts
@@ -163,6 +163,7 @@
 			partitions {
 				block-partition-u-boot-env {
 					partname = "u-boot-env";
+
 					nvmem-layout {
 						compatible = "u-boot,env";
 					};

--- a/target/linux/mediatek/dts/mt7981b-openembed-som7981.dts
+++ b/target/linux/mediatek/dts/mt7981b-openembed-som7981.dts
@@ -164,7 +164,6 @@
 			};
 
 			partition@180000 {
-				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x180000 0x100000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-unielec-u7981-01-nand.dts
+++ b/target/linux/mediatek/dts/mt7981b-unielec-u7981-01-nand.dts
@@ -47,7 +47,6 @@
 				reg = <0x180000 0x200000>;
 				read-only;
 
-				compatible = "nvmem-cells";
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7986a-acelink-ew-7886cax.dts
+++ b/target/linux/mediatek/dts/mt7986a-acelink-ew-7886cax.dts
@@ -183,7 +183,6 @@
 			};
 
 			partition@180000 {
-				compatible = "nvmem-cells";
 				reg = <0x180000 0x200000>;
 				label = "factory";
 				read-only;

--- a/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-emmc.dtso
+++ b/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-emmc.dtso
@@ -40,6 +40,7 @@
 					partitions {
 						block-partition-env {
 							partname = "ubootenv";
+
 							nvmem-layout {
 								compatible = "u-boot,env";
 							};

--- a/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-sd.dtso
+++ b/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-sd.dtso
@@ -38,6 +38,7 @@
 					partitions {
 						block-partition-env {
 							partname = "ubootenv";
+
 							nvmem-layout {
 								compatible = "u-boot,env";
 							};

--- a/target/linux/mediatek/patches-6.6/101-dts-update-mt7629-rfb.patch
+++ b/target/linux/mediatek/patches-6.6/101-dts-update-mt7629-rfb.patch
@@ -40,21 +40,23 @@
  			};
  		};
  	};
-@@ -273,3 +282,17 @@
+@@ -273,3 +282,19 @@
  	pinctrl-0 = <&watchdog_pins>;
  	status = "okay";
  };
 +
 +&factory {
-+	compatible = "nvmem-cells";
-+	#address-cells = <1>;
-+	#size-cells = <1>;
++	nvmem-layout {
++		compatible = "fixed-layout";
++		#address-cells = <1>;
++		#size-cells = <1>;
 +
-+	macaddr_factory_24: macaddr@24 {
-+		reg = <0x24 0x6>;
-+	};
++		macaddr_factory_24: macaddr@24 {
++			reg = <0x24 0x6>;
++		};
 +
-+	macaddr_factory_2a: macaddr@2a {
-+		reg = <0x2a 0x6>;
++		macaddr_factory_2a: macaddr@2a {
++			reg = <0x2a 0x6>;
++		};
 +	};
 +};

--- a/target/linux/mvebu/files-6.6/arch/arm64/boot/dts/marvell/armada-7040-rb5009.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm64/boot/dts/marvell/armada-7040-rb5009.dts
@@ -165,9 +165,12 @@
 
 			/* Empty space on NOR repurposed for U-Boot environment */
 			partition@fe0000 {
-				compatible = "u-boot,env";
 				label = "u-boot-env";
 				reg = <0xfe0000 0x20000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+				};
 			};
 		};
 	};

--- a/target/linux/mvebu/patches-6.6/320-arm-dts-armada-370-synology-ds213j-mtd-parts.patch
+++ b/target/linux/mvebu/patches-6.6/320-arm-dts-armada-370-synology-ds213j-mtd-parts.patch
@@ -42,7 +42,7 @@
  };
  
  &pinctrl {
-@@ -259,48 +280,52 @@
+@@ -259,48 +280,50 @@
  		reg = <0>; /* Chip select 0 */
  		spi-max-frequency = <20000000>;
  
@@ -111,8 +111,6 @@
 +				reg = <0x007d0000 0x00010000>; /* 64KB */
 +				label = "vendor";
 +				read-only;
-+
-+				compatible = "nvmem-cells";
 +
 +				nvmem-layout {
 +					compatible = "fixed-layout";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-mango-dvk.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-mango-dvk.dts
@@ -161,22 +161,25 @@
 			};
 
 			partition@360000 {
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
 				label = "0:ART";
 				reg = <0x00360000 0x00040000>;
 
-				macaddr_eth0: macaddr@0 {
-					reg = <0x0 0x6>;
-				};
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				macaddr_eth1: macaddr@6 {
-					reg = <0x6 0x6>;
-				};
+					macaddr_eth0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
 
-				macaddr_eth2: macaddr@c {
-					reg = <0xc 0x6>;
+					macaddr_eth1: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+
+					macaddr_eth2: macaddr@c {
+						reg = <0xc 0x6>;
+					};
 				};
 			};
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-xe3-4.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-xe3-4.dts
@@ -353,24 +353,27 @@
 			};
 
 			partition@510000 {
-				compatible = "u-boot,env";
 				label = "0:APPSBLENV";
 				reg = <0x510000 0x10000>;
 
-				ethaddr: ethaddr {
-					#nvmem-cell-cells = <0>;
-				};
+				nvmem-layout {
+					compatible = "u-boot,env";
 
-				eth1addr: eth1addr {
-					#nvmem-cell-cells = <0>;
-				};
+					ethaddr: ethaddr {
+						#nvmem-cell-cells = <0>;
+					};
 
-				eth2addr: eth2addr {
-					#nvmem-cell-cells = <0>;
-				};
+					eth1addr: eth1addr {
+						#nvmem-cell-cells = <0>;
+					};
 
-				eth5addr: eth5addr {
-					#nvmem-cell-cells = <0>;
+					eth2addr: eth2addr {
+						#nvmem-cell-cells = <0>;
+					};
+
+					eth5addr: eth5addr {
+						#nvmem-cell-cells = <0>;
+					};
 				};
 			};
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
@@ -339,12 +339,14 @@
 				label = "0:ethphyfw1";
 				reg = <0x3b0000 0x80000>;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				aqr0_fw: firmware@0 {
-					reg = <0x0 0x5fc02>;
+					aqr0_fw: firmware@0 {
+						reg = <0x0 0x5fc02>;
+					};
 				};
 			};
 
@@ -352,12 +354,14 @@
 				label = "0:ethphyfw2";
 				reg = <0x430000 0x80000>;
 
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
-				aqr1_fw: firmware@0 {
-					reg = <0x0 0x5fc02>;
+					aqr1_fw: firmware@0 {
+						reg = <0x0 0x5fc02>;
+					};
 				};
 			};
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
@@ -193,9 +193,12 @@
 			};
 
 			partition@480000 {
-				compatible = "u-boot,env";
 				label = "0:appsblenv";
 				reg = <0x480000 0x10000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+				};
 			};
 
 			partition@490000 {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax218.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wax218.dts
@@ -167,11 +167,15 @@
 				#size-cells = <1>;
 
 				partition@0 {
-					compatible = "u-boot,env";
 					label = "env-data";
 					reg = <0x0 0x40000>;
 
-					macaddr_ubootenv_ethaddr: ethaddr {};
+					nvmem-layout {
+						compatible = "u-boot,env";
+
+						macaddr_ubootenv_ethaddr: ethaddr {
+						};
+					};
 				};
 			};
 		};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
@@ -212,12 +212,15 @@
 			};
 
 			partition@600000 {
-				compatible = "u-boot,env";
 				label = "0:appsblenv";
 				reg = <0x600000 0x10000>;
 
-				macaddr_lan: ethaddr {
-					#nvmem-cell-cells = <1>;
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_lan: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
 				};
 			};
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-wxr-5950ax12.dts
@@ -195,11 +195,14 @@
 				#size-cells = <1>;
 
 				partition@0 {
-					compatible = "u-boot,env";
 					label = "env-data";
 					reg = <0x0 0x40000>;
 
-					macaddr_appsblenv_ethaddr: ethaddr {
+					nvmem-layout {
+						compatible = "u-boot,env";
+
+						macaddr_appsblenv_ethaddr: ethaddr {
+						};
 					};
 				};
 			};

--- a/target/linux/ramips/dts/mt7620a_bolt_bl100.dts
+++ b/target/linux/ramips/dts/mt7620a_bolt_bl100.dts
@@ -164,7 +164,6 @@
 			};
 
 			partition@40000 {
-				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7621_jdcloud_re-cp-02.dts
+++ b/target/linux/ramips/dts/mt7621_jdcloud_re-cp-02.dts
@@ -81,9 +81,12 @@
 			};
 
 			partition@40000 {
-				compatible = "u-boot,env";
 				label = "Config";
 				reg = <0x40000 0x10000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+				};
 			};
 
 			partition@50000 {


### PR DESCRIPTION
The latter seems to be a safer replacement for the former. It's also more flexible as mac-base can be used with it.

Some of these are leftovers from nvmem-layout conversion.