### PR TITLE
archs38: enable features rootfs-part

### DIFF
--- a/target/linux/archs38/generic/target.mk
+++ b/target/linux/archs38/generic/target.mk
@@ -1,5 +1,5 @@
 BOARDNAME:=Generic
-FEATURES += ext4 usb ramdisk
+FEATURES += ext4 usb ramdisk rootfs-part
 
 define Target/Description
 	Build firmware images for ARC HS38 based boards.


### PR DESCRIPTION
target/linux/archs38/image/Makefile calls gen_axs10x_sdcard_img.sh with $(CONFIG_TARGET_ROOTFS_PARTSIZE).
Make sure a rootfs partition is built and usable.
