### PR TITLE
mediatek: increase phy assert time for jdcloud re-cp-03

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-jdcloud-re-cp-03.dts
+++ b/target/linux/mediatek/dts/mt7986a-jdcloud-re-cp-03.dts
@@ -133,8 +133,8 @@
 		reg = <6>;
 
 		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
-		reset-assert-us = <10000>;
-		reset-deassert-us = <50000>;
+		reset-assert-us = <15000>;
+		reset-deassert-us = <68000>;
 		realtek,aldps-enable;
 	};
 


### PR DESCRIPTION
According to RTL8221B's datasheet, the PHY requires at least 10ms for assert and 68ms (recommended) for de-assert. So increase the assert/de-assert time to 15ms and 68ms respectively.

This fixes the issue mentioned in immortalwrt/immortalwrt#1379.
Cc: @cyyself