### PR TITLE
sdk: fix APK key creation

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -85,6 +85,10 @@ ifneq ($(CONFIG_USE_APK),)
 else
   $(curdir)/compile: $(curdir)/system/opkg/host/compile
 endif
+else
+ifneq ($(CONFIG_USE_APK),)
+  $(curdir)/compile: $(BUILD_KEY_APK_SEC) $(BUILD_KEY_APK_PUB)
+endif
 endif
 
 $(curdir)/install: $(TMP_DIR)/.build $(curdir)/merge $(curdir)/merge-index


### PR DESCRIPTION
The keys are created differently compared to the old OPKG keys. Instead of being part of base-files/configure, they are created as a Makefile requirement of `package/compile`, which is a cleaner solution.

This requirement would only be added to non SDK environments, however APK always requires keys to be available. Add an `else` case for the SDK and create keys.