### PR TITLE
mediatek: EAP111: add label-mac-device

### DIFF
--- a/target/linux/mediatek/dts/mt7981a-edgecore-eap111.dts
+++ b/target/linux/mediatek/dts/mt7981a-edgecore-eap111.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &led_green;
 		led-running = &led_green;
 		led-upgrade = &led_green;
+		label-mac-device = &gmac1;
 	};
 
 	chosen {


### PR DESCRIPTION
Add the label-mac-device alias so that label MAC is set and can later be used in userspace.
