### PR TITLE
bpftool: add host build

### DIFF
--- a/package/network/utils/bpftool/Makefile
+++ b/package/network/utils/bpftool/Makefile
@@ -22,8 +22,11 @@ PKG_BUILD_FLAGS:=no-mips16 gc-sections lto
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
 
+HOST_BUILD_PARALLEL:=1
+
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
+include $(INCLUDE_DIR)/host-build.mk
 
 define Package/bpftool/Default
   SECTION:=net
@@ -88,5 +91,30 @@ define Package/bpftool-$(BUILD_VARIANT)/install
 		$(1)/usr/libexec/bpftool-$(BUILD_VARIANT)
 endef
 
+HOST_MAKE_FLAGS += \
+	OUTPUT="$(HOST_BUILD_DIR)/" \
+	prefix="/usr" \
+	$(if $(findstring c,$(OPENWRT_VERBOSE)),V=1,V='') \
+	check_feat=0 \
+	feature-clang-bpf-co-re=0 \
+	feature-libbfd=1 \
+	feature-llvm=0 \
+	feature-libcap=0 \
+	feature-disassembler-four-args=1 \
+	feature-disassembler-init-styled=1
+
+HOST_MAKE_PATH = src
+
+define Host/Install
+	$(INSTALL_DIR) $(STAGING_DIR_HOST)/usr/sbin
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/bpftool \
+		$(STAGING_DIR_HOST)/usr/sbin/bpftool
+endef
+
+define Host/Clean
+	rm -f $(STAGING_DIR_HOST)/usr/sbin/bpftool
+endef
+
 $(eval $(call BuildPackage,bpftool-full))
 $(eval $(call BuildPackage,bpftool-minimal))
+$(eval $(call HostBuild))


### PR DESCRIPTION
Besides probing BPF information in running system, bpftool is also used in generating skeleton, dumping BTF, etc. that is widely used in modern BPF development. Make it available as a host tool so that we can use it in package build.

Tested build targeting malta/le on Arch Linux x86_64. bpftools currently does not support processing cross-endian BPF objects, so big-endian host is needed to build for big-endian targets using bpftools.