### PR TITLE
uboot-envtools: add env settings for ubnt,unifi-6-lr-v3

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_mt7622
+++ b/package/boot/uboot-envtools/files/mediatek_mt7622
@@ -56,7 +56,8 @@ ubnt,unifi-6-lr-v2-ubootmod|\
 ubnt,unifi-6-lr-v3-ubootmod)
 	ubootenv_add_uci_config "/dev/mtd$(find_mtd_index "u-boot-env")" "0x0" "0x4000" "0x1000"
 	;;
-ubnt,unifi-6-lr-v2)
+ubnt,unifi-6-lr-v2|\
+ubnt,unifi-6-lr-v3)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x1000" "0x1000" "1"
 	;;
 xiaomi,redmi-router-ax6s)


### PR DESCRIPTION
Related to #13897.

My Unifi 6-LRv2s had to be RMA'ed. The replacements I got were v3s. Using the same configuration as my the v2s:

```bash
$ cat /etc/fw_env.config
/dev/mtd3 0x0 0x1000 0x1000 1
$ fw_printenv
arch=arm
baudrate=115200
board=mt7622_evb
board_name=mt7622_evb
bootcmd=bootubnt
bootdelay=3
bootfile=uImage
cpu=armv7
device_model=U6-LR
ethact=mtk_eth
ethaddr=<redacted>
ipaddr=<redacted>
is_ble_stp=true
is_default=true
loadaddr=0x5007FF28
macaddr=<redacted>
serverip=<redacted>
soc=mt7622
stderr=serial
stdin=serial
stdout=serial
vendor=mediatek
```