### PR TITLE
package: add kmod-r8125 ethernet driver

### DIFF
--- a/package/kernel/r8125/Makefile
+++ b/package/kernel/r8125/Makefile
@@ -1,0 +1,33 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=r8125
+PKG_VERSION:=9.013.02
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://github.com/Noltari/rtl8125/releases/download/$(PKG_VERSION)
+PKG_HASH:=d36410ee99c956f250d9cd08340d8c36567d190f420a8ee128ff6e51225aac0c
+
+PKG_BUILD_PARALLEL:=1
+PKG_LICENSE:=GPLv2
+PKG_MAINTAINER:=Alvaro Fernandez Rojas <noltari@gmail.com>
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/r8125
+  SUBMENU:=Network Devices
+  TITLE:=Realtek RTL8125 PCI 2.5 Gigabit Ethernet driver
+  DEPENDS:=@PCI_SUPPORT
+  FILES:=$(PKG_BUILD_DIR)/src/r8125.ko
+  AUTOLOAD:=$(call AutoProbe,r8125)
+  PROVIDES:=kmod-r8169
+endef
+
+define Build/Compile
+	+$(KERNEL_MAKE) $(PKG_JOBS) \
+		M="$(PKG_BUILD_DIR)/src" \
+		modules
+endef
+
+$(eval $(call KernelPackage,r8125))


### PR DESCRIPTION
r8125 is an out of tree driver provided by Realtek for RTL8125 devices.
This is an alternative driver for the upstream r8169 driver.