### PR TITLE
package: add kmod-r8168 ethernet driver

### DIFF
--- a/package/kernel/r8168/Makefile
+++ b/package/kernel/r8168/Makefile
@@ -1,0 +1,33 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=r8168
+PKG_VERSION:=8.053.00
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://github.com/Noltari/rtl8168/releases/download/$(PKG_VERSION)
+PKG_HASH:=52f1e6200672b598a04d4ac21ac92a8a9e128b38208c7b03a464bfa93bbfcc8f
+
+PKG_BUILD_PARALLEL:=1
+PKG_LICENSE:=GPLv2
+PKG_MAINTAINER:=Alvaro Fernandez Rojas <noltari@gmail.com>
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/r8168
+  SUBMENU:=Network Devices
+  TITLE:=Realtek RTL8168 PCI Gigabit Ethernet driver
+  DEPENDS:=@PCI_SUPPORT
+  FILES:=$(PKG_BUILD_DIR)/src/r8168.ko
+  AUTOLOAD:=$(call AutoProbe,r8168)
+  PROVIDES:=kmod-r8169
+endef
+
+define Build/Compile
+	+$(KERNEL_MAKE) $(PKG_JOBS) \
+		M="$(PKG_BUILD_DIR)/src" \
+		modules
+endef
+
+$(eval $(call KernelPackage,r8168))

--- a/package/kernel/r8168/patches/0001-r8168_n-fix-proc_dump_rx_desc_2-on-32-bits.patch
+++ b/package/kernel/r8168/patches/0001-r8168_n-fix-proc_dump_rx_desc_2-on-32-bits.patch
@@ -1,0 +1,28 @@
+From c0e1ae03f564f0e3db492ef2f25357b5da7977d7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
+Date: Sat, 10 Aug 2024 20:12:40 +0200
+Subject: [PATCH] r8168_n: fix proc_dump_rx_desc_2 on 32 bits
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+---
+ src/r8168_n.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/src/r8168_n.c
++++ b/src/r8168_n.c
+@@ -1655,9 +1655,9 @@ static int proc_dump_rx_desc_2(struct se
+                                                           j, k);
+                         for (i=0; i<(tp->RxDescLength/4); i++) {
+                                 if (!(i % 4))
+-                                        seq_printf(m, "\n%04llx ",
+-                                                   ((u64)pdword + (i * 4) -
+-                                                    (u64)tp->RxDescArray));
++                                        seq_printf(m, "\n%04x ",
++                                                   (u32) ((uintptr_t)pdword + (i * 4) -
++                                                    (uintptr_t)tp->RxDescArray));
+                                 seq_printf(m, "%08x ", pdword[i]);
+                         }
+                 }


### PR DESCRIPTION
r8168 is an out of tree driver provided by Realtek for RTL8168 devices.
This is an alternative driver for the upstream r8169 driver.