### PR TITLE
mac80211: add rtw89 driver

### DIFF
--- a/package/kernel/mac80211/realtek.mk
+++ b/package/kernel/mac80211/realtek.mk
@@ -3,7 +3,8 @@ PKG_DRIVERS += \
 	rtl8192ce rtl8192se rtl8192de rtl8192cu rtl8723-common rtl8723be rtl8723bs rtl8821ae \
 	rtl8xxxu rtw88 rtw88-pci rtw88-usb rtw88-sdio rtw88-8821c rtw88-8822b rtw88-8822c \
 	rtw88-8723d rtw88-8821ce rtw88-8821cu rtw88-8822be rtw88-8822bu \
-	rtw88-8822ce rtw88-8822cu rtw88-8723de rtw88-8723ds rtw88-8723du
+	rtw88-8822ce rtw88-8822cu rtw88-8723de rtw88-8723ds rtw88-8723du \
+	rtw89 rtw89-pci rtw89-8851be rtw89-8852ae rtw89-8852be rtw89-8852ce
 
 config-$(call config_package,rtlwifi) += RTL_CARDS RTLWIFI
 config-$(call config_package,rtlwifi-pci) += RTLWIFI_PCI
@@ -45,6 +46,16 @@ config-$(call config_package,rtw88-8723ds) += RTW88_8723DS
 config-$(call config_package,rtw88-8723du) += RTW88_8723DU
 config-$(CONFIG_PACKAGE_RTW88_DEBUG) += RTW88_DEBUG
 config-$(CONFIG_PACKAGE_RTW88_DEBUGFS) += RTW88_DEBUGFS
+
+config-$(call config_package,rtw89) += RTW89 RTW89_CORE
+config-$(call config_package,rtw89-pci) += RTW89_PCI
+config-$(call config_package,rtw89-8851be) += RTW89_8851B RTW89_8851BE
+config-$(call config_package,rtw89-8852ae) += RTW89_8852A RTW89_8852AE
+config-$(call config_package,rtw89-8852be) += RTW89_8852B RTW89_8852BE
+config-$(call config_package,rtw89-8852ce) += RTW89_8852C RTW89_8852CE
+config-$(CONFIG_PACKAGE_RTW89_DEBUG) += RTW89_DEBUG
+config-$(CONFIG_PACKAGE_RTW89_DEBUGFS) += RTW89_DEBUGFS
+config-$(CONFIG_PACKAGE_RTW89_DEBUGMSG) += RTW89_DEBUGMSG
 
 define KernelPackage/rtlwifi/config
 	config PACKAGE_RTLWIFI_DEBUG
@@ -358,4 +369,84 @@ define KernelPackage/rtl8723bs/description
  This option enables support for RTL8723BS SDIO drivers, such as the wifi found
  on the 1st gen Intel Compute Stick, the CHIP and many other Intel Atom and ARM
  based devices.
+endef
+
+define KernelPackage/rtw89/config
+	config PACKAGE_RTW89_DEBUG
+		bool "Realtek wireless debugging (rtw89)"
+		depends on PACKAGE_kmod-rtw89
+		help
+		  Enable debugging output for rtw89 devices.
+
+	config PACKAGE_RTW89_DEBUGFS
+		bool "Enable rtw89 debugfs support"
+		select KERNEL_DEBUG_FS
+		depends on PACKAGE_kmod-rtw89
+		help
+		  Select this to see extensive information about
+		  the internal state of rtw89 in debugfs.
+
+	config PACKAGE_RTW89_DEBUGMSG
+		bool "Realtek rtw89 debug message support"
+		depends on PACKAGE_kmod-rtw89
+		help
+		  Enable debug message support.
+endef
+
+define KernelPackage/rtw89
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTW89 core
+  DEPENDS+= +@DRIVER_11AC_SUPPORT +@DRIVER_11AX_SUPPORT +kmod-mac80211
+  FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw89/rtw89_core.ko
+  AUTOLOAD:=$(call AutoProbe,rtw89_core)
+  HIDDEN:=1
+endef
+
+define KernelPackage/rtw89-pci
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTW89 PCI chips support
+  DEPENDS+= @PCI_SUPPORT +kmod-rtw89
+  FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw89/rtw89_pci.ko
+  AUTOLOAD:=$(call AutoProbe,rtw89_pci)
+  HIDDEN:=1
+endef
+
+define KernelPackage/rtw89-8851be
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTL8851BE support
+  DEPENDS+= +kmod-rtw89-pci +rtl8851be-firmware
+  FILES:= \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw89/rtw89_8851b.ko \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw89/rtw89_8851be.ko
+  AUTOLOAD:=$(call AutoProbe,rtw89_8851be)
+endef
+
+define KernelPackage/rtw89-8852ae
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTL8852AE support
+  DEPENDS+= +kmod-rtw89-pci +rtl8852ae-firmware
+  FILES:= \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw89/rtw89_8852a.ko \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw89/rtw89_8852ae.ko
+  AUTOLOAD:=$(call AutoProbe,rtw89_8852ae)
+endef
+
+define KernelPackage/rtw89-8852be
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTL8852BE support
+  DEPENDS+= +kmod-rtw89-pci +rtl8852be-firmware
+  FILES:= \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw89/rtw89_8852b.ko \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw89/rtw89_8852be.ko
+  AUTOLOAD:=$(call AutoProbe,rtw89_8852be)
+endef
+
+define KernelPackage/rtw89-8852ce
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Realtek RTL8852CE support
+  DEPENDS+= +kmod-rtw89-pci +rtl8852ce-firmware
+  FILES:= \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw89/rtw89_8852c.ko \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/realtek/rtw89/rtw89_8852ce.ko
+  AUTOLOAD:=$(call AutoProbe,rtw89_8852ce)
 endef


### PR DESCRIPTION
This commits  adds driver for Realtek rtw89 PCIe wireless chips  RTL8851BE  RTL8852AE  RTL8852BE and RTL8852CE.
I've tested with a RTL8852AE card
```
root@OpenWrt:~#  dmesg | grep rtw89
[   10.222411] rtw89_8852ae 0000:01:00.0: loaded firmware rtw89/rtw8852a_fw.bin
[   10.223244] rtw89_8852ae 0000:01:00.0: enabling device (0000 -> 0003)
[   10.229957] rtw89_8852ae 0000:01:00.0: Firmware version 0.13.36.0 (c33d3f88), cmd version 0, type 1
[   10.230800] rtw89_8852ae 0000:01:00.0: Firmware version 0.13.36.0 (c33d3f88), cmd version 0, type 3
[   10.250797] rtw89_8852ae 0000:01:00.0: chip rfe_type is 1
root@OpenWrt:~# iwinfo
phy0-sta0 ESSID: "RTL8852AE"
          Access Point: 00:00:00:00:00:00
          Mode: Client  Channel: 100 (5.500 GHz)  HT Mode: HE80
          Center Channel 1: 106 2: unknown
          Tx-Power: 24 dBm  Link Quality: 65/70
          Signal: -45 dBm  Noise: unknown
          Bit Rate: 1200.9 MBit/s
          Encryption: WPA3 SAE (CCMP)
          Type: nl80211  HW Mode(s): 802.11ac/ax/b/g/n
          Hardware: 10EC:8852 1E26:007F [Realtek RTL8852AE]
          TX power offset: none
          Frequency offset: none
          Supports VAPs: no  PHY name: phy0
```