### PR TITLE
generic: 6.6: add pause configuration for pcs-mtk-lynxi

### DIFF
--- a/target/linux/generic/hack-6.6/750-net-pcs-mtk-lynxi-workaround-2500BaseX-no-an.patch
+++ b/target/linux/generic/hack-6.6/750-net-pcs-mtk-lynxi-workaround-2500BaseX-no-an.patch
@@ -13,7 +13,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/pcs/pcs-mtk-lynxi.c
 +++ b/drivers/net/pcs/pcs-mtk-lynxi.c
-@@ -114,14 +114,23 @@ static void mtk_pcs_lynxi_get_state(stru
+@@ -114,14 +114,24 @@ static void mtk_pcs_lynxi_get_state(stru
  				    struct phylink_link_state *state)
  {
  	struct mtk_pcs_lynxi *mpcs = pcs_to_mtk_pcs_lynxi(pcs);
@@ -30,6 +30,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +		state->an_complete = !!(bmsr & BMSR_ANEGCOMPLETE);
 +		state->speed = SPEED_2500;
 +		state->duplex = DUPLEX_FULL;
++		state->pause = MLO_PAUSE_TX | MLO_PAUSE_RX;
 +
 +		return;
 +	}
@@ -41,7 +42,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  }
  
  static void mtk_sgmii_reset(struct mtk_pcs_lynxi *mpcs)
-@@ -142,7 +151,7 @@ static int mtk_pcs_lynxi_config(struct p
+@@ -142,7 +152,7 @@ static int mtk_pcs_lynxi_config(struct p
  {
  	struct mtk_pcs_lynxi *mpcs = pcs_to_mtk_pcs_lynxi(pcs);
  	bool mode_changed = false, changed;
@@ -50,7 +51,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	int advertise, link_timer;
  
  	advertise = phylink_mii_c22_pcs_encode_advertisement(interface,
-@@ -165,9 +174,8 @@ static int mtk_pcs_lynxi_config(struct p
+@@ -165,9 +175,8 @@ static int mtk_pcs_lynxi_config(struct p
  	if (neg_mode == PHYLINK_PCS_NEG_INBAND_ENABLED) {
  		if (interface == PHY_INTERFACE_MODE_SGMII)
  			sgm_mode |= SGMII_SPEED_DUPLEX_AN;


### PR DESCRIPTION
When the ethernet mac is configured managed = "in-band-status", the phy-handle will be bound to the internal pcs phy, and the pause configuration will be ignored. This will make some Mediatek Filogic Devices with SFP can't enable flow control by default. This patch adds the pause configuration by default. The user can still disable the flow control configuration using ethtool if needed.

Tested on: CMCC RAX3000M with a hack PCB that connects USB3.0 to SFP
cc: @dangowrt 