### PR TITLE
mediatek: comfast cf-e393ax: Add missing WAN port label and correct image defines

### DIFF
--- a/target/linux/mediatek/dts/mt7981a-comfast-cf-e393ax.dts
+++ b/target/linux/mediatek/dts/mt7981a-comfast-cf-e393ax.dts
@@ -216,6 +216,11 @@
 			label = "lan1";
 		};
 
+		port@1 {
+			reg = <1>;
+			label = "eth1";
+		};
+
 		port@6 {
 			reg = <6>;
 			label = "cpu";

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -472,10 +472,7 @@ define Device/comfast_cf-e393ax
   DEVICE_MODEL := CF-E393AX
   DEVICE_DTS := mt7981a-comfast-cf-e393ax
   DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x43f00000
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL_LOADADDR := 0x44000000
   KERNEL = kernel-bin | lzma | \
        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   KERNEL_INITRAMFS = kernel-bin | lzma | \


### PR DESCRIPTION

for this board

WAN port label was missing from the dts config so on intial config bootup would only set the lan port correctly.

Removing invalid image settings - DEVICE_DTC_FLAGS, DEVICE_DTS_LOADADDR and KERNEL_LOADADDR as had noticed on factory install kernel would be allocated incorrectly

