### PR TITLE
bcm63xx: add support for TP-Link TD-W8968-v3

### DIFF
--- a/target/linux/bcm63xx/base-files/etc/board.d/01_leds
+++ b/target/linux/bcm63xx/base-files/etc/board.d/01_leds
@@ -94,6 +94,10 @@ sercomm,h500-s-vfes)
 telsey,cpva502plus)
 	ucidef_set_led_netdev "lan" "LAN" "amber:link" "eth0"
 	;;
+tplink,td-w8968-v3)
+	ucidef_set_led_netdev "wan" "WAN" "green:inet" "eth0.2"
+	ucidef_set_led_usbdev "usb" "USB" "green:usb" "1-1"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/bcm63xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm63xx/base-files/etc/board.d/02_network
@@ -142,7 +142,8 @@ netgear,dgnd3700-v1)
 	;;
 sagem,fast-2704n|\
 sercomm,ad1018|\
-sercomm,ad1018-nor)
+sercomm,ad1018-nor|\
+tplink,td-w8968-v3)
 	ucidef_add_switch "switch0" \
 		"1:lan:3" "2:lan:2" "3:lan:1" "0:wan" "8t@eth0"
 	;;

--- a/target/linux/bcm63xx/dts/bcm6318-tplink-td-w8968-v3.dts
+++ b/target/linux/bcm63xx/dts/bcm6318-tplink-td-w8968-v3.dts
@@ -1,0 +1,127 @@
+#include "bcm6318.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "TP-Link TD-W8968 v3";
+	compatible = "tplink,td-w8968-v3", "brcm,bcm6318";
+
+	aliases {
+		led-boot = &dsl_green;
+		led-failsafe = &dsl_green;
+		led-running = &dsl_green;
+		led-upgrade = &dsl_green;
+	};
+
+	chosen {
+		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		wlan {
+			label = "wlan";
+			gpios = <&pinctrl 9 1>;
+			linux,code = <KEY_WLAN>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&pinctrl 1 1>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&pinctrl 2 1>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps_green {
+			label = "green:wps";
+			gpios = <&pinctrl 2 1>;
+		};
+		lan1_green {
+			label = "green:lan1";
+			gpios = <&pinctrl 4 1>;
+		};
+		lan2_green {
+			label = "green:lan2";
+			gpios = <&pinctrl 5 1>;
+		};
+		lan3_green {
+			label = "green:lan3";
+			gpios = <&pinctrl 6 1>;
+		};
+		lan4_green {
+			label = "green:lan4";
+			gpios = <&pinctrl 7 1>;
+		};
+		inet_green {
+			label = "green:inet";
+			gpios = <&pinctrl 8 1>;
+		};
+		dsl_green: dsl_green {
+			label = "green:dsl";
+			gpios = <&pinctrl 10 1>;
+		};
+		usb_green {
+			label = "green:usb";
+			gpios = <&pinctrl 13 1>;
+		};
+	};
+};
+
+&hsspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <62500000>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cfe@0 {
+				reg = <0x000000 0x010000>;
+				label = "cfe";
+				read-only;
+			};
+
+			linux@10000 {
+				reg = <0x010000 0x7e0000>;
+				label = "linux";
+				compatible = "brcm,bcm963xx-imagetag";
+			};
+
+			nvram@7f0000 {
+				reg = <0x7f0000 0x010000>;
+				label = "nvram";
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/target/linux/bcm63xx/image/bcm63xx.mk
+++ b/target/linux/bcm63xx/image/bcm63xx.mk
@@ -1231,6 +1231,22 @@ define Device/tp-link_td-w8900gb
 endef
 TARGET_DEVICES += tp-link_td-w8900gb
 
+define Device/tplink_td-w8968-v3
+  $(Device/bcm63xx)
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := W8968
+  DEVICE_VARIANT := v3
+  DEVICE_ALT0_VENDOR := TP-Link
+  DEVICE_ALT0_MODEL := W8968
+  DEVICE_ALT0_VARIANT := v4
+  CFE_BOARD_ID := TD-W8968
+  CHIP_ID := 6318
+  FLASH_MB := 8
+  DEVICE_PACKAGES := $(B43_PACKAGES) $(USB2_PACKAGES)
+  DEFAULT := n
+endef
+TARGET_DEVICES += tplink_td-w8968-v3
+
 ### USRobotics ###
 define Device/usrobotics_usr9108
   $(Device/bcm63xx-legacy)

--- a/target/linux/bcm63xx/patches-5.15/511-board_bcm6318.patch
+++ b/target/linux/bcm63xx/patches-5.15/511-board_bcm6318.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -44,6 +44,263 @@ static struct board_info __initdata boar
+@@ -44,6 +44,306 @@ static struct board_info __initdata boar
  #endif /* CONFIG_BCM63XX_CPU_3368 */
  
  /*
@@ -258,13 +258,56 @@
 +		.pci_dev = 0,
 +	},
 +};
++
++static struct board_info __initdata board_tdw8968 = {
++	.name = "TD-W8968",
++	.expected_cpu_id = 0x6318,
++
++	.has_pci = 1,
++	.has_ohci0 = 1,
++	.has_ehci0 = 1,
++	.num_usbh_ports = 1,
++
++	.has_enetsw = 1,
++	.enetsw = {
++		.used_ports = {
++			[0] = {
++				.used = 1,
++				.phy_id = 1,
++				.name = "Port 1",
++			},
++			[1] = {
++				.used = 1,
++				.phy_id = 2,
++				.name = "Port 2",
++			},
++			[2] = {
++				.used = 1,
++				.phy_id = 3,
++				.name = "Port 3",
++			},
++			[3] = {
++				.used = 1,
++				.phy_id = 4,
++				.name = "Port 4",
++			},
++		},
++	},
++
++	.use_fallback_sprom = 1,
++	.fallback_sprom = {
++		.type = SPROM_BCM43217,
++		.pci_bus = 1,
++		.pci_dev = 0,
++	},
++};
 +#endif /* CONFIG_BCM63XX_CPU_6318 */
 +
 +/*
   * known 6328 boards
   */
  #ifdef CONFIG_BCM63XX_CPU_6328
-@@ -423,6 +680,13 @@ static const struct board_info __initcon
+@@ -423,6 +723,14 @@ static const struct board_info __initcon
  #ifdef CONFIG_BCM63XX_CPU_3368
  	&board_cvg834g,
  #endif /* CONFIG_BCM63XX_CPU_3368 */
@@ -274,11 +317,12 @@
 +	&board_AR5315u,
 +	&board_dsl_2751b_d1,
 +	&board_FAST2704N,
++	&board_tdw8968,
 +#endif /* CONFIG_BCM63XX_CPU_6318 */
  #ifdef CONFIG_BCM63XX_CPU_6328
  	&board_96328avng,
  #endif /* CONFIG_BCM63XX_CPU_6328 */
-@@ -457,6 +721,11 @@ static struct of_device_id const bcm963x
+@@ -457,6 +765,12 @@ static struct of_device_id const bcm963x
  	{ .compatible = "netgear,cvg834g", .data = &board_cvg834g, },
  #endif /* CONFIG_BCM63XX_CPU_3368 */
  #ifdef CONFIG_BCM63XX_CPU_6318
@@ -287,6 +331,7 @@
 +	{ .compatible = "comtrend,ar-5315u", .data = &board_AR5315u, },
 +	{ .compatible = "d-link,dsl-275xb-d1", .data = &board_dsl_2751b_d1, },
 +	{ .compatible = "sagem,fast-2704n", .data = &board_FAST2704N, },
++	{ .compatible = "tplink,td-w8968-v3", .data = &board_tdw8968, },
  #endif /* CONFIG_BCM63XX_CPU_6318 */
  #ifdef CONFIG_BCM63XX_CPU_6328
  	{ .compatible = "brcm,bcm96328avng", .data = &board_96328avng, },


### PR DESCRIPTION
This is almost the same as the PlusNet 2704N, such that this is just a lot of copy paste excepts that the LEDs are adjusted based on the W8968 patch on this page:
https://openwrt.org/toh/tp-link/td-w8960n_v5

Note that I've tested this on a v4, but the original patch was targeted at the v3, so I'm fairly confident it applies to both.

I realise that this has been dropped in master; mostly pushing this as somewhere easy to share this.

EDIT: made a build if anyone just wants to try it out easily https://github.com/wryun/openwrt/releases/tag/23.05.4-with-w8968v3