### PR TITLE
Add RSS variants to Realtek PCI ethernet drivers

### DIFF
--- a/package/kernel/r8125/Makefile
+++ b/package/kernel/r8125/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8125
 PKG_VERSION:=9.013.02
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/Noltari/rtl8125/releases/download/$(PKG_VERSION)
@@ -22,12 +22,25 @@ define KernelPackage/r8125
   FILES:=$(PKG_BUILD_DIR)/src/r8125.ko
   AUTOLOAD:=$(call AutoProbe,r8125)
   PROVIDES:=kmod-r8169
+  VARIANT:=regular
 endef
+
+define KernelPackage/r8125-rss
+$(call KernelPackage/r8125)
+  TITLE+= (RSS)
+  VARIANT:=rss
+endef
+
+ifeq ($(BUILD_VARIANT),rss)
+  PKG_MAKE_FLAGS += ENABLE_RSS_SUPPORT=y
+endif
 
 define Build/Compile
 	+$(KERNEL_MAKE) $(PKG_JOBS) \
+		$(PKG_MAKE_FLAGS) \
 		M="$(PKG_BUILD_DIR)/src" \
 		modules
 endef
 
 $(eval $(call KernelPackage,r8125))
+$(eval $(call KernelPackage,r8125-rss))

--- a/package/kernel/r8126/Makefile
+++ b/package/kernel/r8126/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8126
 PKG_VERSION:=10.013.00
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/Noltari/rtl8126/releases/download/$(PKG_VERSION)
@@ -22,12 +22,25 @@ define KernelPackage/r8126
   FILES:=$(PKG_BUILD_DIR)/src/r8126.ko
   AUTOLOAD:=$(call AutoProbe,r8126)
   PROVIDES:=kmod-r8169
+  VARIANT:=regular
 endef
+
+define KernelPackage/r8126-rss
+$(call KernelPackage/r8126)
+  TITLE+= (RSS)
+  VARIANT:=rss
+endef
+
+ifeq ($(BUILD_VARIANT),rss)
+  PKG_MAKE_FLAGS += ENABLE_RSS_SUPPORT=y
+endif
 
 define Build/Compile
 	+$(KERNEL_MAKE) $(PKG_JOBS) \
+		$(PKG_MAKE_FLAGS) \
 		M="$(PKG_BUILD_DIR)/src" \
 		modules
 endef
 
 $(eval $(call KernelPackage,r8126))
+$(eval $(call KernelPackage,r8126-rss))


### PR DESCRIPTION
Instead of enabling RSS support, let's introduce build variants and let users choose between them since RSS support can cause network issues.
