### PR TITLE
sysupgrade: create 10_disable_services w/ fixed modified time

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -278,7 +278,7 @@ create_backup_archive() {
 				fi
 			done
 			disabled="$disabled\nexit 0"
-			tar_print_member "/etc/uci-defaults/10_disable_services" "$(echo -e $disabled)" || ret=1
+			tar_print_member "/etc/uci-defaults/10_disable_services" "$(echo -e $disabled)" "$(date -r /etc/rc.d "+%s")" || ret=1
 		fi
 
 		# Part of archive with installed packages info


### PR DESCRIPTION
Every time "sysupgrade -b -" runs it would generate a new (synthetic) "/etc/uci-defaults/10_disable_services" file with the current time as the modified time.  This unfortunately creates a non-deterministic tarball, so if you run a cron job to save your state, you don't have a trivial way of seeing if it changed or not without unpacking the archive, deleting this file, and comparing the entire directory tree to the previous backup.

fixes: #16145
