### PR TITLE
rockchip: add support for nanopc t6

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -230,6 +230,13 @@ define U-Boot/rock5b-rk3588
     radxa_rock-5b
 endef
 
+define U-Boot/nanopc-t6-rk3588
+  $(U-Boot/rk3588/Default)
+  NAME:=NanoPC T6
+  BUILD_DEVICES:= \
+    friendlyarm_nanopc-t6
+endef
+
 
 # RK3588S boards
 
@@ -269,6 +276,7 @@ UBOOT_TARGETS := \
   radxa-e25-rk3568 \
   rock-3a-rk3568 \
   rock5b-rk3588 \
+  nanopc-t6-rk3588 \
   nanopi-r6s-rk3588s \
   rock5a-rk3588s
 

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -7,6 +7,11 @@ rockchip_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
+	friendlyarm,nanopc-t6|\
+	friendlyarm,nanopi-r5c|\
+	radxa,e25)
+		ucidef_set_interfaces_lan_wan 'eth0' 'eth1'
+		;;
 	friendlyarm,nanopi-r2c|\
 	friendlyarm,nanopi-r2c-plus|\
 	friendlyarm,nanopi-r2s|\
@@ -16,10 +21,6 @@ rockchip_setup_interfaces()
 	xunlong,orangepi-r1-plus|\
 	xunlong,orangepi-r1-plus-lts)
 		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
-		;;
-	friendlyarm,nanopi-r5c|\
-	radxa,e25)
-		ucidef_set_interfaces_lan_wan 'eth0' 'eth1'
 		;;
 	friendlyarm,nanopi-r5s)
 		ucidef_set_interfaces_lan_wan 'eth1 eth2' 'eth0'
@@ -44,6 +45,7 @@ rockchip_setup_macs()
 	local label_mac=""
 
 	case "$board" in
+	friendlyarm,nanopc-t6|\
 	friendlyarm,nanopi-r2c|\
 	friendlyarm,nanopi-r2s)
 		wan_mac=$(macaddr_generate_from_mmc_cid mmcblk0)

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -29,6 +29,13 @@ set_interface_core() {
 }
 
 case "$(board_name)" in
+friendlyarm,nanopc-t6|\
+friendlyarm,nanopi-r5c|\
+radxa,e25|\
+sinovoip,rk3568-bpi-r2pro)
+	set_interface_core 2 "eth0"
+	set_interface_core 4 "eth1"
+	;;
 friendlyarm,nanopi-r2c|\
 friendlyarm,nanopi-r2c-plus|\
 friendlyarm,nanopi-r2s|\
@@ -42,12 +49,6 @@ friendlyarm,nanopi-r4s|\
 friendlyarm,nanopi-r4s-enterprise)
 	set_interface_core 10 "eth0"
 	set_interface_core 20 "eth1"
-	;;
-friendlyarm,nanopi-r5c|\
-radxa,e25|\
-sinovoip,rk3568-bpi-r2pro)
-	set_interface_core 2 "eth0"
-	set_interface_core 4 "eth1"
 	;;
 friendlyarm,nanopi-r5s|\
 friendlyarm,nanopi-r6s)

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -22,6 +22,14 @@ define Device/friendlyarm_nanopc-t4
 endef
 TARGET_DEVICES += friendlyarm_nanopc-t4
 
+define Device/friendlyarm_nanopc-t6
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPC T6
+  SOC := rk3588
+  DEVICE_PACKAGES := kmod-r8169
+endef
+TARGET_DEVICES += friendlyarm_nanopc-t6
+
 define Device/friendlyarm_nanopi-r2c
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R2C

--- a/target/linux/rockchip/patches-6.6/120-arm64-dts-rockchip-add-led-aliases-and-stop-heartbeat-for-nanopc-t6.patch
+++ b/target/linux/rockchip/patches-6.6/120-arm64-dts-rockchip-add-led-aliases-and-stop-heartbeat-for-nanopc-t6.patch
@@ -1,0 +1,22 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+@@ -19,6 +19,10 @@
+ 	aliases {
+ 		mmc0 = &sdhci;
+ 		mmc1 = &sdmmc;
++		led-boot = &sys_led;
++		led-failsafe = &sys_led;
++		led-running = &sys_led;
++		led-upgrade = &sys_led;
+ 	};
+ 
+ 	chosen {
+@@ -31,7 +35,7 @@
+ 		sys_led: led-0 {
+ 			gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
+ 			label = "system-led";
+-			linux,default-trigger = "heartbeat";
++			default-state = "on";
+ 			pinctrl-names = "default";
+ 			pinctrl-0 = <&sys_led_pin>;
+ 		};

--- a/target/linux/rockchip/patches-6.6/121-arm64-dts-rockchip-lower-mmc-speed-for-nanopc-t6.patch
+++ b/target/linux/rockchip/patches-6.6/121-arm64-dts-rockchip-lower-mmc-speed-for-nanopc-t6.patch
@@ -1,0 +1,11 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+@@ -547,7 +547,7 @@
+ 	cap-mmc-highspeed;
+ 	cap-sd-highspeed;
+ 	disable-wp;
+-	sd-uhs-sdr104;
++	sd-uhs-sdr50;
+ 	vmmc-supply = <&vcc_3v3_s3>;
+ 	vqmmc-supply = <&vccio_sd_s0>;
+ 	status = "okay";


### PR DESCRIPTION
SoC: Rockchip RK3588
CPU: Quad-core ARM Cortex-A76(up to 2.4GHz) and quad-core Cortex-A55 CPU (up to 1.8GHz)
GPU: Mali-G610 MP4, compatible with OpenGLES 1.1, 2.0, and 3.2, OpenCL up to 2.2 and Vulkan1.2
VPU: 8K@60fps H.265 and VP9 decoder, 8K@30fps H.264 decoder, 4K@60fps AV1 decoder, 8K@30fps H.264 and H.265 encoder
NPU: 6TOPs, supports INT4/INT8/INT16/FP16
RAM: 64-bit 4GB/8GB/16GB LPDDR4X at 2133MHz
Flash: 32GB/64GB/256GB eMMC, at HS400 mode
microSD: support up to SDR104 mode
Ethernet: 2x PCIe 2.5G Ethernet
4G LTE: one mimiPCIe connector and one microSIM slot
USB-A: 1x USB 3.0 Type-A
USB-C: 1x Full function USB Type‑C™ port, support DP display up to 4Kp60, USB 3.0
Video input:
1x Standard HDMI input port, up to 4Kp60
2x 4-lane MIPI-CSI, compatible with MIPI V1.2
Video output:
2x Standard HDMI output ports
compatible with HDMI2.1, HDMI2.0, and HDMI1.4 operation
one support displays up to 7680x4320@60Hz, another one support up to 4Kp60
Support RGB/YUV(up to 10bit) format
2x 4-lane MIPI-DSI, compatible with MIPI DPHY 2.0 or CPHY 1.1
Audio:
3.5mm jack for stereo headphone output
2.0mm PH-2A connector for analog microphone input
GPIO:
40-pin 2.54mm header connector
up to 2x SPIs, 6x UARTs, 1x I2Cs, 8x PWMs, 2x I2Ss, 28x GPIOs
M.2 Connectors
one M.2 M-Key connector with PCIe 3.0 x4 for NVMe SSDs up to 2,500 MB/s
one M.2 E-key connector with PCIe 2.1 x1 and USB2.0 Host
others:
2 Pin 1.27/1.25mm RTC battery input connector for low power RTC IC HYM8563TS
one 38Khz IR receiver
MASK button for eMMC update, reset button, and Power button
one 5V Fan connector
Debug UART, 3-Pin 2.54mm header, 3.3V level, 1500000bps
2 x GPIO Controlled LED (SYS, LED1)
Power supply: 5.5*2.1mm DC Jack, 12VDC input.
PCB: 8 Layer, 110x80x1.6mm
Ambient Operating Temperature: 0℃ to 70℃