### PR TITLE
firmware: omnia-mcu-firmware: Bump to 4.1

### DIFF
--- a/package/firmware/omnia-mcu-firmware/Makefile
+++ b/package/firmware/omnia-mcu-firmware/Makefile
@@ -9,13 +9,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=omnia-mcu-firmware
 PKG_DISTNAME:=omnia_hw_ctrl
-PKG_VERSION:=4.0
+PKG_VERSION:=4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_SUBDIR:=$(PKG_DISTNAME)-binaries-v$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_SOURCE_SUBDIR).tar.bz2
 PKG_SOURCE_URL:=https://gitlab.nic.cz/turris/hw/$(PKG_DISTNAME)/-/releases/v$(PKG_VERSION)/downloads/
-PKG_HASH:=64b6010f587d89c192685d152644075a5e0abf431eb069ac42981524065a0053
+PKG_HASH:=9c6a3d88ae2ca093dd35aace040f0b1eb1cb5c1141575b45623bdd64d733c59f
 
 PKG_MAINTAINER:=Marek Mojik <marek.mojik@nic.cz>
 PKG_LICENSE:=GPL-3.0-or-later


### PR DESCRIPTION
Bump `omnia-mcu-firmware` to version 4.1.

This version fixes the following issue on boards with GD32 MCU:
* the user has old GD32 MCU bootloader and application (version 2.0)
* the user upgraded MCU application firmware to newer version (from 2.99 to 4.0)
* the user wants to upgrade application again, but it is impossible, because when MCU application firmware jumps into the old MCU bootloader firmware (2.0), the old bootloader firmware gets stuck in exception
* the user has to restart the board and upgrade the bootloader firmware first, which is not ideal, since if bootloader firmware upgrade is interrupted, the board gets bricked

Therefore the `omnia-mcutool` utility version 0.3-rc3 will refuse to upgrade MCU application firmware to versions 2.99 to 4.0 if the MCU bootloader firmware is at version 2.0.

For users to be able to upgrade MCU application firmware on GD32 boards, they will need this new 4.1 version.

Users that already upgraded the MCU application firmware to a version version between 2.99 and 4.0 (using a previous version of the `omnia-mcutool` utility) have no other choice but to upgrade MCU bootloader firmware as well.