### PR TITLE
Realtek PCI ethernet drivers: print link status when link up

### DIFF
--- a/package/kernel/r8125/Makefile
+++ b/package/kernel/r8125/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8125
 PKG_VERSION:=9.013.02
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/Noltari/rtl8125/releases/download/$(PKG_VERSION)

--- a/package/kernel/r8125/patches/0001-ignore-rss-log.patch
+++ b/package/kernel/r8125/patches/0001-ignore-rss-log.patch
@@ -1,0 +1,11 @@
+--- a/src/r8125_rss.c
++++ b/src/r8125_rss.c
+@@ -91,7 +91,7 @@ int rtl8125_get_rxnfc(struct net_device
+         struct rtl8125_private *tp = netdev_priv(dev);
+         int ret = -EOPNOTSUPP;
+ 
+-        netif_info(tp, drv, tp->dev, "rss get rxnfc\n");
++        netif_dbg(tp, drv, tp->dev, "rss get rxnfc\n");
+ 
+         if (!(dev->features & NETIF_F_RXHASH))
+                 return ret;

--- a/package/kernel/r8125/patches/0002-print-link-speed-and-duplex-mode.patch
+++ b/package/kernel/r8125/patches/0002-print-link-speed-and-duplex-mode.patch
@@ -1,0 +1,37 @@
+From 6b89b2bb75fd12195631b8009c0548d1d81bec99 Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Sun, 4 Aug 2024 21:16:23 +0800
+Subject: [PATCH] r8125: print link speed and duplex mode
+
+Like other Ethernet drivers, print link speed and duplex mode
+when the interface is up. Formatting output at the same time.
+
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+---
+ src/r8125_n.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+--- a/src/r8125_n.c
++++ b/src/r8125_n.c
+@@ -5116,15 +5116,19 @@ static void
+ _rtl8125_check_link_status(struct net_device *dev)
+ {
+         struct rtl8125_private *tp = netdev_priv(dev);
++        u16 status = RTL_R16(tp, PHYstatus);
+ 
+         if (tp->link_ok(dev)) {
+                 rtl8125_link_on_patch(dev);
+ 
+                 if (netif_msg_ifup(tp))
+-                        printk(KERN_INFO PFX "%s: link up\n", dev->name);
++                        printk(KERN_INFO PFX "%s: Link is Up - %dMbps/%s\n",
++                               dev->name, rtl8125_convert_link_speed(status),
++                               ((status & (_1000bpsF | _2500bpsF)) ||
++                                (status & FullDup)) ? "Full" : "Half");
+         } else {
+                 if (netif_msg_ifdown(tp))
+-                        printk(KERN_INFO PFX "%s: link down\n", dev->name);
++                        printk(KERN_INFO PFX "%s: Link is Down\n", dev->name);
+ 
+                 rtl8125_link_down_patch(dev);
+         }

--- a/package/kernel/r8126/Makefile
+++ b/package/kernel/r8126/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8126
 PKG_VERSION:=10.013.00
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/Noltari/rtl8126/releases/download/$(PKG_VERSION)

--- a/package/kernel/r8126/patches/0002-print-link-speed-and-duplex-mode.patch
+++ b/package/kernel/r8126/patches/0002-print-link-speed-and-duplex-mode.patch
@@ -1,0 +1,37 @@
+From cf8d0528db1959ae13a1ba3240e06877f06d2b16 Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Sat, 10 Aug 2024 20:16:32 +0800
+Subject: [PATCH] r8126: print link speed and duplex mode
+
+Like other Ethernet drivers, print link speed and duplex mode
+when the interface is up. Formatting output at the same time.
+
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+---
+ src/r8126_n.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+--- a/src/r8126_n.c
++++ b/src/r8126_n.c
+@@ -4744,15 +4744,19 @@ static void
+ _rtl8126_check_link_status(struct net_device *dev)
+ {
+         struct rtl8126_private *tp = netdev_priv(dev);
++        u16 status = RTL_R16(tp, PHYstatus);
+ 
+         if (tp->link_ok(dev)) {
+                 rtl8126_link_on_patch(dev);
+ 
+                 if (netif_msg_ifup(tp))
+-                        printk(KERN_INFO PFX "%s: link up\n", dev->name);
++                        printk(KERN_INFO PFX "%s: Link is Up - %dMbps/%s\n",
++                               dev->name, rtl8126_convert_link_speed(status),
++                               ((status & (_1000bpsF | _2500bpsF | _5000bpsF)) ||
++                                (status & FullDup)) ? "Full" : "Half");
+         } else {
+                 if (netif_msg_ifdown(tp))
+-                        printk(KERN_INFO PFX "%s: link down\n", dev->name);
++                        printk(KERN_INFO PFX "%s: Link is Down\n", dev->name);
+ 
+                 rtl8126_link_down_patch(dev);
+         }

--- a/package/kernel/r8168/Makefile
+++ b/package/kernel/r8168/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8168
 PKG_VERSION:=8.053.00
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/Noltari/rtl8168/releases/download/$(PKG_VERSION)

--- a/package/kernel/r8168/patches/0002-print-link-speed-and-duplex-mode.patch
+++ b/package/kernel/r8168/patches/0002-print-link-speed-and-duplex-mode.patch
@@ -1,0 +1,39 @@
+From 1e7b4b74a61c6627e1051ef67f11fa11e2c365dc Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Sun, 4 Aug 2024 16:15:12 +0800
+Subject: [PATCH] r8168: print link speed and duplex mode
+
+Like other Ethernet drivers, print link speed and duplex mode
+when the interface is up. Formatting output at the same time.
+
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+---
+ src/r8168_n.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+--- a/src/r8168_n.c
++++ b/src/r8168_n.c
+@@ -5377,6 +5377,7 @@ static void
+ rtl8168_check_link_status(struct net_device *dev)
+ {
+         struct rtl8168_private *tp = netdev_priv(dev);
++        u16 status = RTL_R8(tp, PHYstatus);
+         int link_status_on;
+ 
+ #ifdef ENABLE_FIBER_SUPPORT
+@@ -5393,10 +5394,13 @@ rtl8168_check_link_status(struct net_dev
+                         rtl8168_link_on_patch(dev);
+ 
+                         if (netif_msg_ifup(tp))
+-                                printk(KERN_INFO PFX "%s: link up\n", dev->name);
++                                printk(KERN_INFO PFX "%s: Link is Up - %dMbps/%s\n",
++                                       dev->name, rtl8168_convert_link_speed(status),
++                                       ((status & _1000bpsF) || (status & FullDup))
++                                        ? "Full" : "Half");
+                 } else {
+                         if (netif_msg_ifdown(tp))
+-                                printk(KERN_INFO PFX "%s: link down\n", dev->name);
++                                printk(KERN_INFO PFX "%s: Link is Down\n", dev->name);
+ 
+                         rtl8168_link_down_patch(dev);
+                 }


### PR DESCRIPTION
Like other Ethernet drivers, print link speed and duplex mode
when the interface is up. Formatting output at the same time.
```
[   66.204703] r8125: eth0: Link is Up - 1000Mbps/Full
[   75.666514] r8125: eth0: Link is Down
[   82.173551] r8125: eth1: Link is Up - 2500Mbps/Full
```
Tested on the r8168 and r8125 chips.
The r8126 is not tested because I don't have the hardware.