### PR TITLE
kernel: Fix section mismatch in ubi

### DIFF
--- a/target/linux/generic/pending-5.15/491-ubi-auto-create-ubiblock-device-for-rootfs.patch
+++ b/target/linux/generic/pending-5.15/491-ubi-auto-create-ubiblock-device-for-rootfs.patch
@@ -24,7 +24,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	return magic == UBIFS_NODE_MAGIC;
 +}
 +
-+static void __init ubiblock_create_auto_rootfs(void)
++static void ubiblock_create_auto_rootfs(void)
 +{
 +	int ubi_num, ret, is_ubifs;
 +	struct ubi_volume_desc *desc;

--- a/target/linux/generic/pending-6.1/491-ubi-auto-create-ubiblock-device-for-rootfs.patch
+++ b/target/linux/generic/pending-6.1/491-ubi-auto-create-ubiblock-device-for-rootfs.patch
@@ -24,7 +24,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	return magic == UBIFS_NODE_MAGIC;
 +}
 +
-+static void __init ubiblock_create_auto_rootfs(struct ubi_volume_info *vi)
++static void ubiblock_create_auto_rootfs(struct ubi_volume_info *vi)
 +{
 +	int ret, is_ubifs;
 +	struct ubi_volume_desc *desc;

--- a/target/linux/generic/pending-6.6/491-ubi-auto-create-ubiblock-device-for-rootfs.patch
+++ b/target/linux/generic/pending-6.6/491-ubi-auto-create-ubiblock-device-for-rootfs.patch
@@ -24,7 +24,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	return magic == UBIFS_NODE_MAGIC;
 +}
 +
-+static void __init ubiblock_create_auto_rootfs(struct ubi_volume_info *vi)
++static void ubiblock_create_auto_rootfs(struct ubi_volume_info *vi)
 +{
 +	int ret, is_ubifs;
 +	struct ubi_volume_desc *desc;


### PR DESCRIPTION
Fix ubiblock_create_from_param() ubiblock_create_auto_rootfs section mismatch. 
Without this, the system upgrade will not work if the kernel was compiled with clang-18.

WARNING: modpost: vmlinux: section mismatch in reference: ubiblock_notify+0x190 (section: .text) -> ubiblock_create_auto_rootfs (section: .init.text)

```
[33342.080771] Call trace:
[33342.083205]  ubiblock_create_auto_rootfs+0x0/0xd0
[33342.087902]  blocking_notifier_call_chain+0xb0/0x1a0
[33342.092857]  ubi_volume_notify+0xcc/0xdc
[33342.096773]  ubi_create_volume+0x520/0x684
[33342.100861]  ubi_cdev_ioctl+0x2ac/0x834
[33342.104688]  __arm64_sys_ioctl+0x14f0/0x15f4
[33342.108947]  invoke_syscall+0x44/0xc8
[33342.112601]  do_el0_svc+0x78/0xa8
[33342.115907]  el0_svc+0x24/0x50
[33342.118951]  el0t_64_sync_handler+0x88/0xf0
[33342.123126]  el0t_64_sync+0x150/0x154
[33342.126784] Code: ???????? ???????? ???????? ???????? (????????)
```

Signed-off-by: Romanov Danila <pervokur@gmail.com>