### PR TITLE
mediatek: mt7622: build images for mtk_uartboot

### DIFF
--- a/package/boot/arm-trusted-firmware-mediatek/Makefile
+++ b/package/boot/arm-trusted-firmware-mediatek/Makefile
@@ -52,6 +52,27 @@ define Trusted-Firmware-A/mt7622-nor-2ddr
   DDR3_FLYBY:=1
 endef
 
+define Trusted-Firmware-A/mt7622-ram-1ddr
+  NAME:=MediaTek MT7622 (RAM, 1x DDR3)
+  BOOT_DEVICE:=ram
+  BUILD_SUBTARGET:=mt7622
+  PLAT:=mt7622
+  RAM_BOOT_UART_DL:=1
+  HIDDEN:=
+  DEFAULT:=TARGET_mediatek_mt7622
+endef
+
+define Trusted-Firmware-A/mt7622-ram-2ddr
+  NAME:=MediaTek MT7622 (RAM, 2x DDR3)
+  BOOT_DEVICE:=ram
+  BUILD_SUBTARGET:=mt7622
+  PLAT:=mt7622
+  DDR3_FLYBY:=1
+  RAM_BOOT_UART_DL:=1
+  HIDDEN:=
+  DEFAULT:=TARGET_mediatek_mt7622
+endef
+
 define Trusted-Firmware-A/mt7622-snand-1ddr
   NAME:=MediaTek MT7622 (SPI-NAND, 1x DDR3)
   BUILD_SUBTARGET:=mt7622
@@ -483,6 +504,8 @@ endef
 TFA_TARGETS:= \
 	mt7622-nor-1ddr \
 	mt7622-nor-2ddr \
+	mt7622-ram-1ddr \
+	mt7622-ram-2ddr \
 	mt7622-snand-1ddr \
 	mt7622-snand-ubi-1ddr \
 	mt7622-snand-2ddr \
@@ -553,6 +576,8 @@ define Package/trusted-firmware-a-ram/install
 	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/build/$(PLAT)/release/bl2.bin $(BIN_DIR)/$(BUILD_VARIANT)-bl2.bin
 endef
+Package/trusted-firmware-a-mt7622-ram-1ddr/install = $(Package/trusted-firmware-a-ram/install)
+Package/trusted-firmware-a-mt7622-ram-2ddr/install = $(Package/trusted-firmware-a-ram/install)
 Package/trusted-firmware-a-mt7981-ram-ddr3/install = $(Package/trusted-firmware-a-ram/install)
 Package/trusted-firmware-a-mt7981-ram-ddr4/install = $(Package/trusted-firmware-a-ram/install)
 Package/trusted-firmware-a-mt7986-ram-ddr3/install = $(Package/trusted-firmware-a-ram/install)

--- a/package/boot/arm-trusted-firmware-mediatek/Makefile
+++ b/package/boot/arm-trusted-firmware-mediatek/Makefile
@@ -547,7 +547,7 @@ TFA_MAKE_FLAGS += \
 	$(if $(RAM_BOOT_UART_DL),RAM_BOOT_UART_DL=1) \
 	$(if $(USE_UBI),UBI=1 $(if $(findstring mt7622,$(PLAT)),OVERRIDE_UBI_START_ADDR=0x80000)) \
 	$(if $(USE_UBI),UBI=1 $(if $(findstring mt7981,$(PLAT)),OVERRIDE_UBI_START_ADDR=0x100000)) \
-	all
+	$(if $(RAM_BOOT_UART_DL),bl2,all)
 
 define Package/trusted-firmware-a-ram/install
 	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)


### PR DESCRIPTION
Only build actually used artifacts and provide images for use with `mtk_uartboot` also for MT7622.