### PR TITLE
ath79: improve Sophos AP15 support

### DIFF
--- a/target/linux/ath79/dts/qca9557_sophos_ap15.dts
+++ b/target/linux/ath79/dts/qca9557_sophos_ap15.dts
@@ -7,7 +7,7 @@
 #include <dt-bindings/leds/common.h>
 
 / {
-	compatible = "sophos,ap15", "qca,qca9558";
+	compatible = "sophos,ap15", "qca,qca9557";
 	model = "Sophos AP15";
 
 	aliases {

--- a/target/linux/ath79/dts/qca9558_sophos_ap15.dts
+++ b/target/linux/ath79/dts/qca9558_sophos_ap15.dts
@@ -40,17 +40,6 @@
 	};
 };
 
-&pcie0 {
-	status = "okay";
-
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&cal_art_5000>;
-		nvmem-cell-names = "calibration";
-	};
-};
-
 &spi {
 	status = "okay";
 
@@ -87,10 +76,6 @@
 
 					cal_art_1000: calibration@1000 {
 						reg = <0x1000 0x440>;
-					};
-
-					cal_art_5000: calibration@5000 {
-						reg = <0x5000 0x844>;
 					};
 				};
 			};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2916,7 +2916,6 @@ define Device/sophos_ap15
   SOC := qca9558
   DEVICE_VENDOR := Sophos
   DEVICE_MODEL := AP15
-  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
   IMAGE_SIZE := 15936k
 endef
 TARGET_DEVICES += sophos_ap15

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2913,7 +2913,7 @@ endef
 TARGET_DEVICES += sitecom_wlr-8100
 
 define Device/sophos_ap15
-  SOC := qca9558
+  SOC := qca9557
   DEVICE_VENDOR := Sophos
   DEVICE_MODEL := AP15
   IMAGE_SIZE := 15936k


### PR DESCRIPTION
I recently got a Sophos AP15 and flashed it with OpenWrt.
While looking at the code I found two ways to improve support for this device in areas where the AP15 differs from AP55(C) and AP100(C):
- AP15 board does not come with an ath10k card
- AP15 uses a QCA9557 SoC (instead of QCA9558)

See also: https://wikidevi.wi-cat.ru/Sophos_AP_15 (my own AP15 looks 100% identical to the one shown in those photos)

Other notes (those probably belong into the wiki but I don't know how to put them there):
- serial pin out: (P7 connector label) TX, GND, RX, (divider line) 3V3 (bold white line)
- flashing via tftpboot - differences from 6f1efb28983758116a8ecaf9c93e1d875bb70af7
  - rename `openwrt-ath79-generic-sophos_ap15-squashfs-sysupgrade.bin` to `uImage_AP15`
  - an extra `erase 0x9f070000 +$filesize` was needed for me between `tftpboot` and `cp.b $fileaddr 0x9f070000 $filesize`