### PR TITLE
rockchip: add support for Radxa ROCK 5B

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -229,6 +229,14 @@ define U-Boot/nanopi-r6s-rk3588s
     friendlyarm_nanopi-r6s
 endef
 
+define U-Boot/rock-5b-rk3588
+  $(U-Boot/Default/rk3588)
+  NAME:=ROCK 5B
+  BUILD_DEVICES:= \
+    radxa_rock-5b
+  UBOOT_CONFIG:=rock5b-rk3588
+endef
+
 UBOOT_TARGETS := \
   nanopc-t4-rk3399 \
   nanopi-r4s-rk3399 \
@@ -250,7 +258,8 @@ UBOOT_TARGETS := \
   nanopi-r5s-rk3568 \
   radxa-e25-rk3568 \
   rock-3a-rk3568 \
-  nanopi-r6s-rk3588s
+  nanopi-r6s-rk3588s \
+  rock-5b-rk3588 \
 
 UBOOT_CONFIGURE_VARS += USE_PRIVATE_LIBGCC=yes
 

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -132,6 +132,14 @@ define Device/radxa_rock-3a
 endef
 TARGET_DEVICES += radxa_rock-3a
 
+define Device/radxa_rock-5b
+  DEVICE_VENDOR := Radxa
+  DEVICE_MODEL := ROCK 5B
+  SOC := rk3588
+  DEVICE_PACKAGES := kmod-r8169 kmod-usb-net-cdc-ncm kmod-usb-net-rndis
+endef
+TARGET_DEVICES += radxa_rock-5b
+
 define Device/radxa_rock-pi-4a
   DEVICE_VENDOR := Radxa
   DEVICE_MODEL := ROCK Pi 4A


### PR DESCRIPTION
rockchip: add support for Radxa ROCK 5B

Radxa ROCK 5B is a single board computer based on the RK3588 chipset.

Hardware
--------
- Rockchip RK3588 SoC
- Quad Cortex-A76 CPU and Quad Cortex-A55 CPU
- Mali G610MP4
- 6 TOPs NPU
- 4/8/16 64 bit LPDDR4 RAM
- 1x eMMC connector
- 1x M.2 E Key (1-lane PCIe 2.1) supporting standard M.2 WiFi
- 1x M.2 M Key (4-lane PCIe 3.0) supporting NVMe SSD
- 1x Micro SD card slot
- 1x 2.5G Ethernet with PoE support (additional PoE HAT required)
- 2x USB 3.0 Type-A port (Host)
- 1x USB 3.0 Type-C port (OTG)
- 2x USB 2.0 Type-A ports (Host)
- 40 pin color GPIO header

[1] https://radxa.com/products/rock5/5b

Installation
------------
Uncompress the OpenWrt sysupgrade and write it to a micro SD card or
internal eMMC using dd.

Signed-off-by: ChenJiali <chenjiali@radxa.com>
