### PR TITLE
ramips: Add support for Ruijie RG-EW1200G PRO v1.1

### DIFF
--- a/target/linux/ramips/dts/mt7621_ruijie_rg-ew1200g-pro-v1.1.dts
+++ b/target/linux/ramips/dts/mt7621_ruijie_rg-ew1200g-pro-v1.1.dts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "ruijie,rg-ew1200g-pro-v1.1", "mediatek,mt7621-soc";
+	model = "Ruijie RG-EW1200G PRO v.1.1";
+
+	aliases {
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_blue;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_blue: power_blue {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x50000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "u-boot-env";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "factory";
+				reg = <0x60000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>;
+					};
+				};
+			};
+
+			partition@70000 {
+				label = "product_info";
+				reg = <0x70000 0x10000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "kdump";
+				reg = <0x80000 0x10000>;
+				read-only;
+			};
+
+			partition@90000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x90000 0xf70000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2428,6 +2428,17 @@ define Device/rostelecom_rt-sf-1
 endef
 TARGET_DEVICES += rostelecom_rt-sf-1
 
+define Device/ruijie_rg-ew1200g-pro-v1.1
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 15808k
+  DEVICE_VENDOR := Ruijie
+  DEVICE_MODEL := RG-EW1200G PRO
+  DEVICE_VARIANT := v1.1
+  DEVICE_PACKAGES := kmod-mt7615-firmware
+endef
+TARGET_DEVICES += ruijie_rg-ew1200g-pro-v1.1
+
 define Device/samknows_whitebox-v8
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -173,6 +173,9 @@ ramips_setup_interfaces()
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		ucidef_set_interface "qtn" ifname "eth1" protocol "static" ipaddr "1.1.1.1" netmask "255.255.255.0"
 		;;
+	ruijie,rg-ew1200g-pro-v1.1)
+		ucidef_set_interfaces_lan_wan "lan3 lan2 lan1" "wan"
+		;;
 	comfast,cf-e390ax|\
 	comfast,cf-ew72-v2|\
 	meig,slt866)
@@ -318,6 +321,11 @@ ramips_setup_macs()
 		label_mac=$(cat "/sys/firmware/mikrotik/hard_config/mac_base")
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add $label_mac 1)
+		;;
+	ruijie,rg-ew1200g-pro-v1.1)
+		lan_mac=$(mtd_get_mac_ascii product_info ethaddr)
+		wan_mac=$(macaddr_add "$lan_mac" 8)
+		label_mac=$lan_mac
 		;;
 	mts,wg430223)
 		wan_mac=$(mtd_get_mac_encrypted_arcadyan "board_data")

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -193,6 +193,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && \
 			macaddr_setbit_la "$(get_mac_label)" > /sys${DEVPATH}/macaddress
 		;;
+	ruijie,rg-ew1200g-pro-v1.1)
+		hw_mac_addr="$(mtd_get_mac_ascii product_info ethaddr)"
+		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
+		;;
 	snr,snr-cpe-me2-sfp)
 		hw_mac_addr="$(mtd_get_mac_binary factory 0x8004)"
 		[ "$PHYNBR" = "1" ] &&  echo -n "$hw_mac_addr" > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
ramips: add support for Ruijie RG-EW1200G PRO

    SoC: MediaTek MT7621
    Flash: 16MB (Macronix MX25L12805D)
    RAM: 128MB
    Serial: As marked on PCB, baudrate is 57600, DO NOT CONNECT 3.3V!!!
    Ethernet: 4x 10/100/1000 Mbps (3x LAN + WAN)
    WIFI0: MT7615 2.4GHz 802.11b/g/n
    WIFI1: MT7615 5GHz 802.11ac
    Antennas: 6x external (3 per radio), non-detachable
    LEDs: Programmable power-LED (blue-colored)
    Buttons: Reset

INSTALLATION:

    Get rootshell using insructions from https://gist.github.com/ZIKH26/18693c67ee7d2f8d2c60231b19194c37

    Download and flash image
    On computer:
    python -m http.server
    On router:
    cd /tmp
    wget http://:8000/factory.bin
    mtd -r write factory.bin firmware

Device should reboot at this point.

Reverting to stock:
Download archive with firmware from Ruijie's site and get .bin file from it. Then write that binary to firmware partition. After reboot, factory-reset the router using reset button.

Signed-off-by: Yahor Leonenka <staryjakau@gmail.com>