### PR TITLE
bmips: bcm6328: add support for D-Link DSL-2750B rev B1

### DIFF
--- a/target/linux/bmips/bcm6328/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6328/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ inteno,xg6846)
 	;;
 comtrend,ar-5381u |\
 comtrend,ar-5387un |\
+dlink,dsl-2750b-b1 |\
 innacomm,w3400v6 |\
 nucom,r5010unv2)
 	ucidef_set_bridge_device switch

--- a/target/linux/bmips/bcm6328/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/bmips/bcm6328/base-files/etc/uci-defaults/09_fix_crc
@@ -6,6 +6,7 @@ case "$(board_name)" in
 arcadyan,ar7516 |\
 comtrend,ar-5381u |\
 comtrend,ar-5387un |\
+dlink,dsl-2750b-b1 |\
 nucom,r5010unv2)
 	mtd fixtrx firmware
 	;;

--- a/target/linux/bmips/dts/bcm6328-dlink-dsl-2750b-b1.dts
+++ b/target/linux/bmips/dts/bcm6328-dlink-dsl-2750b-b1.dts
@@ -1,0 +1,273 @@
+#include "bcm6328.dtsi"
+
+/ {
+	model = "D-Link DSL-2750B rev B1/DSL-2740B rev F1/DSL-2741B rev F1";
+	compatible = "dlink,dsl-2750b-b1", "brcm,bcm6328";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WLAN>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-31 {
+			function = LED_FUNCTION_USB;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 31 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		led-8 {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&ath9k 8 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&leds {
+	status = "okay";
+	
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_leds>;
+
+	led@2 {
+		reg = <2>;
+		active-low;
+		label = "red:internet";
+	};
+
+	led@3 {
+		reg = <3>;
+		active-low;
+		label = "green:dsl";
+	};
+
+	led_power_green: led@4 {
+		reg = <4>;
+		active-low;
+		function = LED_FUNCTION_POWER;
+		color = <LED_COLOR_ID_GREEN>;
+	};
+
+	led_power_red: led@8 {
+		reg = <8>;
+		active-low;
+		function = LED_FUNCTION_POWER;
+		color = <LED_COLOR_ID_RED>;
+		panic-indicator;
+	};
+
+	led@9 {
+		reg = <9>;
+		active-low;
+		function = LED_FUNCTION_WPS;
+		color = <LED_COLOR_ID_BLUE>;
+	};
+
+	led@11 {
+		reg = <11>;
+		active-low;
+		label = "green:internet";
+	};
+};
+
+&ehci {
+	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	ehci_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cfe_6a0 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&hsspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <16666667>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x000000 0x010000>;
+				label = "cfe";
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_cfe_6a0: macaddr@6a0 {
+						compatible = "mac-base";
+						reg = <0x6a0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@10000 {
+				reg = <0x010000 0x7c0000>;
+				label = "linux";
+				compatible = "brcm,bcm963xx-imagetag";
+			};
+
+			partition@7d0000 {
+				reg = <0x7d0000 0x010000>;
+				label = "cal_data";
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_data_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+				};
+			};
+
+			partition@7e0000 {
+				reg = <0x7e0000 0x020000>;
+				label = "nvram";
+			};
+		};
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+
+	pcie@0 {
+		reg = <0 0 0 0 0>;
+		#interrupt-cells = <1>;
+		#size-cells = <2>;
+		#address-cells = <3>;
+		device_type = "pci";
+
+		ath9k: wifi@168c,002e {
+			compatible = "pci168c,002e";
+			reg = <0 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_cfe_6a0 1>, <&cal_data_1000>;
+			nvmem-cell-names = "mac-address", "calibration";
+			
+			#gpio-cells = <2>;
+			gpio-controller;
+		};
+	};
+};
+
+&pinctrl {
+	pinctrl_leds: leds {
+		function = "led";
+		pins = "gpio2", "gpio3", "gpio4",
+		       "gpio8", "gpio9", "gpio11";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+
+			phy-handle = <&phy1>;
+			phy-mode = "mii";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+
+			phy-handle = <&phy2>;
+			phy-mode = "mii";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+
+			phy-handle = <&phy3>;
+			phy-mode = "mii";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan4";
+
+			phy-handle = <&phy4>;
+			phy-mode = "mii";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};

--- a/target/linux/bmips/image/bcm6328.mk
+++ b/target/linux/bmips/image/bcm6328.mk
@@ -39,6 +39,27 @@ define Device/comtrend_ar-5387un
 endef
 TARGET_DEVICES += comtrend_ar-5387un
 
+define Device/dlink_dsl-2750b-b1
+  $(Device/bcm63xx-cfe)
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DSL-2750B
+  DEVICE_VARIANT := B1
+  DEVICE_ALT0_VENDOR := D-Link
+  DEVICE_ALT0_MODEL := DSL-2740B
+  DEVICE_ALT0_VARIANT := F1
+  DEVICE_ALT1_VENDOR := D-Link
+  DEVICE_ALT1_MODEL := DSL-2741B
+  DEVICE_ALT1_VARIANT := F1
+  CFE_BOARD_ID := AW4339U
+  CHIP_ID := 6328
+  IMAGES := cfe-EU.bin cfe-AU.bin
+  IMAGE/cfe-AU.bin := cfe-bin --signature2 "4.06.01.AUF1" --pad 4
+  IMAGE/cfe-EU.bin := cfe-bin --signature2 "4.06.01.EUF1" --pad 4
+  DEVICE_PACKAGES += $(USB2_PACKAGES) $(ATH9K_PACKAGES) \
+    kmod-leds-gpio kmod-leds-bcm6328
+endef
+TARGET_DEVICES += dlink_dsl-2750b-b1
+
 define Device/innacomm_w3400v6
   $(Device/bcm63xx-cfe)
   DEVICE_VENDOR := Innacomm


### PR DESCRIPTION
The D-Link DSL-2750B rev B1 (AW4339U) is a wifi fast ethernet router, 2.4 GHz single band with two external antennas.

This ports the device from old target bcm63xx/generic to bmips/bcm6328. The hardware is the same of D-Link DSL-2740B rev F1 and DSL-2741B rev F1, plus a usb2 port.

Hardware:
 - SoC: Broadcom BCM63281
 - CPU: single core BMIPS4350 @ 320Mhz
 - RAM: 64 MB (Nanya NT5TU32M16DG)
 - Flash: 8 MB NOR (Macronix MX25L6406ENI-12G)
 - Ethernet LAN: 4x 100Mbit (Broadcom BCM63281)
 - Wifi 2.4 GHz: 802.11bgn (Atheros AR9287)
 - USB: 1x 2.0
 - Buttons: 3x
 - LEDs: 10x
 - UART: yes

Installation via CFE web UI:
  1. Power off the router.
  2. Press reset button near the power switch.
  3. Keep it pressed while powering up during ~20+ seconds.
  4. Browse to http://192.168.1.1 and upload the firmware.
  5. Wait a few minutes for it to finish.
