### PR TITLE
bmips: fix gpio-leds DTS nodes

### DIFF
--- a/target/linux/bmips/dts/bcm6358-huawei-hg556a-b.dts
+++ b/target/linux/bmips/dts/bcm6358-huawei-hg556a-b.dts
@@ -49,69 +49,69 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led@0 {
+		led-0 {
 			label = "red:message";
 			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
 		};
 
-		led@1 {
+		led-1 {
 			label = "red:hspa";
 			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
 		};
 
-		led@2 {
+		led-2 {
 			label = "red:dsl";
 			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 		};
 
-		led_power_red: led@3 {
+		led_power_red: led-3 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 		};
 
-		led@6 {
+		led-6 {
 			label = "all";
 			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};
 
-		led@12 {
+		led-12 {
 			label = "green:lan1";
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 		};
 
-		led@13 {
+		led-13 {
 			label = "red:lan1";
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
 
-		led@15 {
+		led-15 {
 			label = "green:lan2";
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
-		led@22 {
+		led-22 {
 			label = "red:lan2";
 			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
 		};
 
-		led@23 {
+		led-23 {
 			label = "green:lan3";
 			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
 		};
 
-		led@26 {
+		led-26 {
 			label = "red:lan3";
 			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
 		};
 
-		led@27 {
+		led-27 {
 			label = "green:lan4";
 			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
 		};
 
-		led@28 {
+		led-28 {
 			label = "red:lan4";
 			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
 		};
@@ -120,7 +120,7 @@
 	ath9k-leds {
 		compatible = "gpio-leds";
 
-		wlan {
+		led-2 {
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&ath9k 2 GPIO_ACTIVE_HIGH>;

--- a/target/linux/bmips/dts/bcm6362-huawei-hg253s-v2.dts
+++ b/target/linux/bmips/dts/bcm6362-huawei-hg253s-v2.dts
@@ -41,12 +41,12 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_phone_green: led@28 {
+		led_phone_green: led-28 {
 			label = "green:phone";
 			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
 		};
 
-		led@30 {
+		led-30 {
 			function = LED_FUNCTION_USB;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 30 GPIO_ACTIVE_LOW>;

--- a/target/linux/bmips/dts/bcm6362-netgear-dgnd3700-v2.dts
+++ b/target/linux/bmips/dts/bcm6362-netgear-dgnd3700-v2.dts
@@ -42,12 +42,12 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led@28 {
+		led-28 {
 			label = "green:dsl";
 			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
 		};
 
-		led_power_red: led@34 {
+		led_power_red: led-34 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;

--- a/target/linux/bmips/dts/bcm6368-actiontec-r1000h.dts
+++ b/target/linux/bmips/dts/bcm6368-actiontec-r1000h.dts
@@ -35,44 +35,44 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led@5 {
+		led-5 {
 			function = LED_FUNCTION_WAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
 		};
 
-		led@21 {
+		led-21 {
 			function = LED_FUNCTION_USB;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
 		};
 
-		led_power_green: led@22 {
+		led_power_green: led-22 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
 		};
 
-		led@23 {
+		led-23 {
 			function = LED_FUNCTION_WPS;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
 		};
 
-		led_power_red: led@24 {
+		led_power_red: led-24 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
 			panic-indicator;
 		};
 
-		led@30 {
+		led-30 {
 			function = LED_FUNCTION_WPS;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio 30 GPIO_ACTIVE_LOW>;
 		};
 
-		led@31 {
+		led-31 {
 			function = LED_FUNCTION_WAN;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio 31 GPIO_ACTIVE_HIGH>;

--- a/target/linux/bmips/dts/bcm6368-comtrend-vr-3025u.dts
+++ b/target/linux/bmips/dts/bcm6368-comtrend-vr-3025u.dts
@@ -28,30 +28,30 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led@2 {
+		led-2 {
 			label = "green:dsl";
 			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 		};
 
-		led@5 {
+		led-5 {
 			label = "green:internet";
 			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
 		};
 
-		led_power_green: led@22 {
+		led_power_green: led-22 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
 		};
 
-		led_power_red: led@24 {
+		led_power_red: led-24 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
 			panic-indicator;
 		};
 
-		led@31 {
+		led-31 {
 			label = "red:internet";
 			gpios = <&gpio 31 GPIO_ACTIVE_HIGH>;
 		};

--- a/target/linux/bmips/dts/bcm6368-comtrend-vr-3025un.dts
+++ b/target/linux/bmips/dts/bcm6368-comtrend-vr-3025un.dts
@@ -28,30 +28,30 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led@2 {
+		led-2 {
 			label = "green:dsl";
 			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 		};
 
-		led@5 {
+		led-5 {
 			label = "green:internet";
 			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
 		};
 
-		led_power_green: led@22 {
+		led_power_green: led-22 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
 		};
 
-		led_power_red: led@24 {
+		led_power_red: led-24 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
 			panic-indicator;
 		};
 
-		led@31 {
+		led-31 {
 			label = "red:internet";
 			gpios = <&gpio 31 GPIO_ACTIVE_HIGH>;
 		};

--- a/target/linux/bmips/dts/bcm6368-netgear-dgnd3700.dtsi
+++ b/target/linux/bmips/dts/bcm6368-netgear-dgnd3700.dtsi
@@ -41,66 +41,66 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led@2 {
+		led-2 {
 			label = "green:dsl";
 			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 		};
 
-		led@4 {
+		led-4 {
 			function = LED_FUNCTION_WAN;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
 		};
 
-		led@5 {
+		led-5 {
 			function = LED_FUNCTION_WAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
 		};
 
-		led@11 {
+		led-11 {
 			function = LED_FUNCTION_WPS;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 		};
 
-		led@13 {
+		led-13 {
 			/* Front USB port */
 			label = "green:usb2";
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
 
-		led@14 {
+		led-14 {
 			/* Back USB port */
 			label = "green:usb1";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
-		led_power_red: led@22 {
+		led_power_red: led-22 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
 			panic-indicator;
 		};
 
-		led@23 {
+		led-23 {
 			function = LED_FUNCTION_LAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
 		};
 
-		led_power_green: led@24 {
+		led_power_green: led-24 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
 		};
 
-		led@26 {
+		led-26 {
 			label = "green:wifi2g";
 			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
 		};
 
-		led@27 {
+		led-27 {
 			label = "blue:wifi5g";
 			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
 		};

--- a/target/linux/bmips/dts/bcm6368-observa-vh4032n.dts
+++ b/target/linux/bmips/dts/bcm6368-observa-vh4032n.dts
@@ -35,45 +35,45 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led@2 {
+		led-2 {
 			label = "blue:dsl";
 			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 		};
 
-		led@5 {
+		led-5 {
 			label = "red:dsl";
 			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
 		};
 
-		led@11 {
+		led-11 {
 			label = "blue:hspa";
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 		};
 
-		led@12 {
+		led-12 {
 			label = "red:hspa";
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 		};
 
-		led_power_blue: led@22 {
+		led_power_blue: led-22 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
 		};
 
-		led_power_red: led@24 {
+		led_power_red: led-24 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
 			panic-indicator;
 		};
 
-		led@25 {
+		led-25 {
 			label = "blue:voice";
 			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
 		};
 
-		led@26 {
+		led-26 {
 			label = "red:voice";
 			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
 		};

--- a/target/linux/bmips/dts/bcm6369-comtrend-wap-5813n.dts
+++ b/target/linux/bmips/dts/bcm6369-comtrend-wap-5813n.dts
@@ -42,37 +42,37 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led@5 {
+		led-5 {
 			label = "green:internet";
 			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
 		};
 
-		led@14 {
+		led-14 {
 			function = LED_FUNCTION_USB;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
-		led_power_green: led@22 {
+		led_power_green: led-22 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
 		};
 
-		led@23 {
+		led-23 {
 			function = LED_FUNCTION_WPS;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
 		};
 
-		led_power_red: led@24 {
+		led_power_red: led-24 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
 			panic-indicator;
 		};
 
-		led@31 {
+		led-31 {
 			label = "red:internet";
 			gpios = <&gpio 31 GPIO_ACTIVE_HIGH>;
 		};

--- a/target/linux/bmips/dts/bcm6369-netgear-evg2000.dts
+++ b/target/linux/bmips/dts/bcm6369-netgear-evg2000.dts
@@ -35,52 +35,52 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led@2 {
+		led-2 {
 			label = "green:voip2";
 			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 		};
 
-		led@4 {
+		led-4 {
 			label = "red:internet";
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
 		};
 
-		led@5 {
+		led-5 {
 			label = "green:internet";
 			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
 		};
 
-		led@14 {
+		led-14 {
 			label = "green:voip1";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
-		led@15 {
+		led-15 {
 			function = LED_FUNCTION_USB;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
-		led_power_green: led@22 {
+		led_power_green: led-22 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
 		};
 
-		led_power_red: led@23 {
+		led_power_red: led-23 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
 			panic-indicator;
 		};
 
-		led@24 {
+		led-24 {
 			function = LED_FUNCTION_LAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
 		};
 
-		led@27 {
+		led-27 {
 			function = LED_FUNCTION_WAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;


### PR DESCRIPTION
gpio-leds doesn't have reg property and pin number is not an address, so "-" should be used instead of "@".
https://github.com/torvalds/linux/blob/6e4436539ae182dc86d57d13849862bcafaa4709/Documentation/devicetree/bindings/leds/leds-gpio.yaml#L24
