### PR TITLE
Allow init.d services to be disabled by default; enable services after sysupgrade; deprecate some service enable/disable UCI toggles

### DIFF
--- a/include/rootfs.mk
+++ b/include/rootfs.mk
@@ -105,8 +105,8 @@ define prepare_rootfs
 		for script in ./etc/init.d/*; do \
 			grep '#!/bin/sh /etc/rc.common' $$script >/dev/null || continue; \
 			if ! echo " $(3) " | grep -q " $$(basename $$script) "; then \
-				IPKG_INSTROOT=$(1) $$(command -v bash) ./etc/rc.common $$script enable; \
-				echo "Enabling" $$(basename $$script); \
+				IPKG_INSTROOT=$(1) $$(command -v bash) ./etc/rc.common $$script _postinst; \
+				echo "Post-install enabling" $$(basename $$script); \
 			else \
 				IPKG_INSTROOT=$(1) $$(command -v bash) ./etc/rc.common $$script disable; \
 				echo "Disabling" $$(basename $$script); \

--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -53,6 +53,10 @@ enable() {
 	return $err
 }
 
+_postinst() {
+	[ "${DEFAULT_ENABLE:-1}" -ne 0 ] && enable || disable
+}
+
 enabled() {
 	name="$(basename "${initscript}")"
 	name="${name##[SK][0-9][0-9]}"
@@ -68,7 +72,7 @@ depends() {
 }
 
 ALL_HELP=""
-ALL_COMMANDS="boot shutdown depends"
+ALL_COMMANDS="boot shutdown depends _postinst"
 extra_command() {
 	local cmd="$1"
 	local help="$2"

--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -390,12 +390,12 @@ default_postinst() {
 	local shell="$(command -v bash)"
 	for i in $(grep -s "^/etc/init.d/" "$filelist"); do
 		if [ -n "$root" ]; then
-			${shell:-/bin/sh} "$root/etc/rc.common" "$root$i" enable
+			${shell:-/bin/sh} "$root/etc/rc.common" "$root$i" _postinst
 		else
 			if [ "$PKG_UPGRADE" != "1" ]; then
-				"$i" enable
+				"$i" _postinst
 			fi
-			"$i" start
+			"$i" enabled && "$i" start
 		fi
 	done
 

--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -244,7 +244,6 @@ include /lib/upgrade
 
 create_backup_archive() {
 	local conf_tar="$1"
-	local disabled
 	local err
 
 	[ "$(rootfs_type)" = "tmpfs" ] && {
@@ -265,13 +264,14 @@ create_backup_archive() {
 		local ret=0
 
 		if [ $ret -eq 0 ]; then
+			local service_actions=
 			for service in /etc/init.d/*; do
-				if ! $service enabled; then
-				disabled="$disabled$service disable\n"
-				fi
+				local action=
+				"${service}" enabled && action=enable || action=disable
+				service_actions="${service_actions}\"${service}\" ${action}\n"
 			done
-			disabled="$disabled\nexit 0"
-			tar_print_member "/etc/uci-defaults/10_disable_services" "$(echo -e $disabled)" || ret=1
+			service_actions="${service_actions}\nexit 0"
+			tar_print_member "/etc/uci-defaults/10_services" "$(echo -e ${service_actions})" || ret=1
 		fi
 
 		# Part of archive with installed packages info

--- a/package/boot/kexec-tools/Makefile
+++ b/package/boot/kexec-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kexec-tools
 PKG_VERSION:=2.0.28
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/kernel/kexec

--- a/package/boot/kexec-tools/files/kdump.config
+++ b/package/boot/kexec-tools/files/kdump.config
@@ -1,6 +1,5 @@
 
 config kdump
-	option enabled '1'
 	option save_dmesg '1'
 	option save_vmcore '0'
 # using an external partition to store vmcore is highly recommended!

--- a/package/boot/kexec-tools/files/kdump.init
+++ b/package/boot/kexec-tools/files/kdump.init
@@ -10,16 +10,17 @@ EXTRA_HELP="        status  Print crashkernel status"
 
 verify_kdump() {
 	local cfg="$1"
-	local enabled
 	local path
 	local save_vmcore
 	local save_dmesg
 
-	config_get_bool enabled "$cfg" enabled 1
 	config_get_bool save_dmesg "$cfg" save_dmesg 1
 	config_get_bool save_vmcore "$cfg" save_vmcore 0
 
-	[ "$enabled" -gt 0 ] || return 2
+	# Migration
+	local enabled
+	config_get_bool enabled "$cfg" enabled 1
+	[ "$enabled" -gt 0 ] || { disable; return 2; }
 
 	[ "$save_dmesg" -gt 0 ] || [ "$save_vmcore" -gt 0 ] || return 2
 

--- a/package/kernel/trelay/Makefile
+++ b/package/kernel/trelay/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=trelay
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/package/kernel/trelay/files/trelay.config
+++ b/package/kernel/trelay/files/trelay.config
@@ -1,4 +1,3 @@
 config trelay
-	option enabled	0
 	option dev1	eth0
 	option dev2	wlan0

--- a/package/kernel/trelay/files/trelay.init
+++ b/package/kernel/trelay/files/trelay.init
@@ -1,11 +1,13 @@
 #!/bin/sh /etc/rc.common
 START=80
+DEFAULT_ENABLE=0
 
 check_relay() {
 	local cfg="$1"
 
+	# Migration
 	config_get_bool enabled "$cfg" enabled 1
-	[ "$enabled" -gt 0 ] || return
+	[ "$enabled" -gt 0 ] || { disable; return 1; }
 
 	config_get dev1 "$cfg" dev1
 	config_get dev2 "$cfg" dev2

--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL:=https://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/files/radius.config
+++ b/package/network/services/hostapd/files/radius.config
@@ -1,5 +1,4 @@
 config radius
-	option disabled '1'
 	option ca_cert '/etc/radius/ca.pem'
 	option cert '/etc/radius/cert.pem'
 	option key '/etc/radius/key.pem'

--- a/package/network/services/hostapd/files/radius.init
+++ b/package/network/services/hostapd/files/radius.init
@@ -1,6 +1,7 @@
 #!/bin/sh /etc/rc.common
 
 START=30
+DEFAULT_ENABLE=0
 
 USE_PROCD=1
 NAME=radius
@@ -8,9 +9,9 @@ NAME=radius
 radius_start() {
 	local cfg="$1"
 
+	# Migration
 	config_get_bool disabled "$cfg" disabled 0
-
-	[ "$disabled" -gt 0 ] && return
+	[ "$disabled" -gt 0 ] && { disable; return 1; }
 
 	config_get ca "$cfg" ca_cert
 	config_get key "$cfg" key

--- a/package/network/services/uhttpd/Makefile
+++ b/package/network/services/uhttpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uhttpd
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uhttpd.git

--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -112,10 +112,11 @@ start_instance()
 	local cfg="$1"
 	local realm="$(uci_get system.@system[0].hostname)"
 	local listen http https interpreter indexes path handler httpdconf haveauth
-	local enabled
 
+	# Migration
+	local enabled
 	config_get_bool enabled "$cfg" 'enabled' 1
-	[ $enabled -gt 0 ] || return
+	[ $enabled -gt 0 ] || { disable; return 1; }
 
 	procd_open_instance
 	procd_set_param respawn

--- a/package/utils/ugps/Makefile
+++ b/package/utils/ugps/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ugps
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/ugps.git
 PKG_SOURCE_PROTO:=git

--- a/package/utils/ugps/files/gps.config
+++ b/package/utils/ugps/files/gps.config
@@ -1,4 +1,3 @@
 config gps
 	option	'tty'	'ttyACM0'
 	option	'adjust_time'	'1'
-	option	'disabled'	'1'

--- a/package/utils/ugps/files/ugps.init
+++ b/package/utils/ugps/files/ugps.init
@@ -2,6 +2,7 @@
 # Copyright (c) 2014 OpenWrt.org
 
 START=80
+DEFAULT_ENABLE=0
 
 USE_PROCD=1
 PROG=/usr/sbin/ugps
@@ -14,9 +15,11 @@ start_service() {
 	local tty="$(uci get gps.@gps[-1].tty)"
 	local baudrate="$(uci get gps.@gps[-1].baudrate || echo 0)"
 	local atime="$(uci get gps.@gps[-1].adjust_time)"
-	local disabled="$(uci get gps.@gps[-1].disabled || echo 0)"
 
-	[ "$disabled" == "0" ] || return
+	# Migration
+	local disabled="$(uci get gps.@gps[-1].disabled || echo 0)"
+	[ "$disabled" == "0" ] || { disable; return 1; }
+
 	[ "$tty" ] || return
 
 	case "$tty" in


### PR DESCRIPTION
This set of changes:
 - Allows an init.d service to be disabled by default, by setting a new `DEFAULT_ENABLE` variable therein. A default-disabled service does not run its `enable` action when installed, so it will not have symbolic links installed in /etc/rc.d and will not start automatically.
 - Extends 0ad062a21ba3 to not just preserve services’ disabled states through sysupgrade, but also services’ enabled states. Considering that services may now be default-disabled, it's also necessary to retain the user-selected enabled status of enabled (but default-disabled) services.
 - Deprecates some service enable/disable UCI toggles. When feasible, services should be enabled or disabled by running the `enable` or `disable` actions on their init.d service scripts, not by UCI toggles. It is valid for some services to be default-disabled when, for example, they are not usable without custom configuration, but such services can now be default-disabled in a persistent way by `DEFAULT_ENABLE=0` instead of a UCI toggle. Services that previously had a global UCI toggle and were configured as disabled are migrated to the init.d script disable mechanism. Services with more intricate per-instance or per-interface toggles are left as-is.

Because this builds on 0ad062a21ba3: @rmilecki, @Ansuel, @jow-, @KanjiMonster. Additional context: [1](https://lists.infradead.org/pipermail/openwrt-devel/2024-February/042290.html), [2](https://lists.infradead.org/pipermail/openwrt-devel/2024-February/042380.html).