### PR TITLE
fix compatible string for Radxa ROCK 5A

### DIFF
--- a/target/linux/rockchip/patches-6.6/116-arm64-dts-rockchip-Update-LED-properties-for-Radxa-Ro.patch
+++ b/target/linux/rockchip/patches-6.6/116-arm64-dts-rockchip-Update-LED-properties-for-Radxa-Ro.patch
@@ -11,13 +11,7 @@ Signed-off-by: Tianling Shen <cnsztl@gmail.com>
 
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
-@@ -9,11 +9,16 @@
- 
- / {
- 	model = "Radxa ROCK 5A";
--	compatible = "radxa,rock-5a", "rockchip,rk3588s";
-+	compatible = "radxa,rock-5a", "rockchip,rk3588";
- 
+@@ -14,6 +14,11 @@
  	aliases {
  		mmc0 = &sdhci;
  		mmc1 = &sdmmc;


### PR DESCRIPTION
- fix unwanted change for compatible string
- ~turn status LED on at boot~