### PR TITLE
[23.05] octeon: ubnt-edgerouter: Disable PCIe

### DIFF
--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -42,7 +42,8 @@ define Device/itus_shield-router
 endef
 TARGET_DEVICES += itus_shield-router
 
-ER_CMDLINE:=-mtdparts=phys_mapped_flash:640k(boot0)ro,640k(boot1)ro,64k(eeprom)ro root=/dev/mmcblk0p2 rootfstype=squashfs,ext4 rootwait
+# Disable PCIe on ER as it doesn't have PCIe peripherals and some devices lock up on initialization
+ER_CMDLINE:=-mtdparts=phys_mapped_flash:640k(boot0)ro,640k(boot1)ro,64k(eeprom)ro root=/dev/mmcblk0p2 rootfstype=squashfs,ext4 rootwait pcie_octeon.pcie_disable=1
 define Device/ubnt_edgerouter
   DEVICE_VENDOR := Ubiquiti
   DEVICE_MODEL := EdgeRouter


### PR DESCRIPTION
Some devices lock up on PCIe initialization:

[   64.309697] PCIe: Port 0 in endpoint mode, skipping.
[   64.320496] PCIe: Initializing port 1
[   64.325257] PCIe: BIST FAILED for port 1 (0xffffffffffffffff)
(system hangs here)

Given the ER contains no PCIe peripherals, has no way to attach any and the stock kernel doesn't have PCIe support either, just disable it.

(cherry picked from commit 308630aea6da1b5618d169d6ebf208aaa249ef72)
Signed-off-by: Jakob Haufe <sur5r@sur5r.net>