### PR TITLE
mpc85xx: Improve LED support for TP-Link TL-WDR4900 V1

### DIFF
--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
@@ -118,6 +118,23 @@
 		usb@22000 {
 			phy_type = "utmi";
 			dr_mode = "host";
+
+			port@1 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				reg = <1>;
+				#trigger-source-cells = <0>;
+
+				hub_port1: port@1 {
+					reg = <1>;
+					#trigger-source-cells = <0>;
+				};
+
+				hub_port2: port@2 {
+					reg = <2>;
+					#trigger-source-cells = <0>;
+				};
+			};
 		};
 
 		mdio@24000 {
@@ -334,6 +351,8 @@
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_USB;
 			function-enumerator = <1>;
+			linux,default-trigger = "usbport";
+			trigger-sources = <&hub_port1>;
 		};
 
 		led-3 {
@@ -341,6 +360,8 @@
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_USB;
 			function-enumerator = <2>;
+			linux,default-trigger = "usbport";
+			trigger-sources = <&hub_port2>;
 		};
 	};
 

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
@@ -185,30 +185,90 @@
 
 						nvmem-cells = <&macaddr_uboot_4fc00 1>;
 						nvmem-cell-names = "mac-address";
+
+						leds {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							led@0 {
+								reg = <0>;
+								color = <LED_COLOR_ID_GREEN>;
+								function = LED_FUNCTION_WAN;
+								default-state = "keep";
+							};
+						};
 					};
 
 					port@2 {
 						reg = <2>;
 						label = "lan1";
 						phy-handle = <&phy_port2>;
+
+						leds {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							led@0 {
+								reg = <0>;
+								color = <LED_COLOR_ID_GREEN>;
+								function = LED_FUNCTION_LAN;
+								default-state = "keep";
+							};
+						};
 					};
 
 					port@3 {
 						reg = <3>;
 						label = "lan2";
 						phy-handle = <&phy_port3>;
+
+						leds {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							led@0 {
+								reg = <0>;
+								color = <LED_COLOR_ID_GREEN>;
+								function = LED_FUNCTION_LAN;
+								default-state = "keep";
+							};
+						};
 					};
 
 					port@4 {
 						reg = <4>;
 						label = "lan3";
 						phy-handle = <&phy_port4>;
+
+						leds {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							led@0 {
+								reg = <0>;
+								color = <LED_COLOR_ID_GREEN>;
+								function = LED_FUNCTION_LAN;
+								default-state = "keep";
+							};
+						};
 					};
 
 					port@5 {
 						reg = <5>;
 						label = "lan4";
 						phy-handle = <&phy_port5>;
+
+						leds {
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							led@0 {
+								reg = <0>;
+								color = <LED_COLOR_ID_GREEN>;
+								function = LED_FUNCTION_LAN;
+								default-state = "keep";
+							};
+						};
 					};
 				};
 			};

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
@@ -9,6 +9,7 @@
  * option) any later version.
  */
 
+#include <dt-bindings/leds/common.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -316,31 +317,43 @@
 	leds {
 		compatible = "gpio-leds";
 
-		wps {
+		led-0 {
 			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
-			label = "tp-link:green:wps";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
 		};
 
-		system_green: system {
+		system_green: led-1 {
 			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
-			label = "tp-link:blue:system";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
 		};
 
-		usb1 {
+		led-2 {
 			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
-			label = "tp-link:green:usb1";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			function-enumerator = <1>;
 		};
 
-		usb2 {
+		led-3 {
 			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
-			label = "tp-link:green:usb2";
-		};
-
-		usbpower {
-			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
-			label = "tp-link:usb:power";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			function-enumerator = <2>;
 		};
 	};
+
+	gpio_export {
+			compatible = "gpio-export";
+			#size-cells = <0>;
+
+			usb-pwr {
+				gpio-export,name = "usb_pwr";
+				gpio-export,output = <1>;
+				gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			};
+		};
 
 	buttons {
 		compatible = "gpio-keys";

--- a/target/linux/mpc85xx/image/p1010.mk
+++ b/target/linux/mpc85xx/image/p1010.mk
@@ -53,6 +53,7 @@ define Device/tplink_tl-wdr4900-v1
   DEVICE_VARIANT := v1
   DEVICE_COMPAT_VERSION := 1.1
   DEVICE_COMPAT_MESSAGE := Config cannot be migrated from swconfig to DSA
+  DEVICE_PACKAGES := kmod-usb-ledtrig-usbport
   TPLINK_HEADER_VERSION := 1
   TPLINK_HWID := 0x49000001
   TPLINK_HWREV := 1


### PR DESCRIPTION
This PR improves LED support in TP-Link TL-WDR4900 V1.

It introduces usb trigger support and adds LED nodes to dts.
