### PR TITLE
dropbear: libtomcrypt: fix vulnerability in der_decode_utf8_string CVE-2019-17362

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dropbear
 PKG_VERSION:=2024.85
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \

--- a/package/network/services/dropbear/patches/920-libtomcrypt-fix-vulnerability-in-der_decode_utf8_str.patch
+++ b/package/network/services/dropbear/patches/920-libtomcrypt-fix-vulnerability-in-der_decode_utf8_str.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: werew <werew@ret2libc.com>
+Date: Thu, 3 Oct 2019 19:57:10 +0200
+Subject: [PATCH] libtomcrypt: fix vulnerability in der_decode_utf8_string
+ CVE-2019-17362
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+[ cherry pick of upstream commit 64d1153e5a515740ab56f39c46baf4cf6991a9d3 ]
+
+The der_decode_utf8_string function (in der_decode_utf8_string.c) does
+not properly detect certain invalid UTF-8 sequences.  This allows
+context-dependent attackers to cause a denial of service (out-of-bounds
+read and crash) or read information from other memory locations via
+carefully crafted DER-encoded data.
+
+To exploit this vulnerability an attacker must be able to provide
+crafted DER-encoded data to LibTomCrypt (e.g. by importing a X509
+certificate).  Information disclosure is made possible by a 2-steps
+attack where the imported data is later somehow re-encoded and sent to
+the attacker (e.g. import and then export X509 certificate).
+
+Fixes: CVE-2019-17362
+References: https://github.com/libtom/libtomcrypt/issues/507
+Upstream-Status: Denied [https://github.com/mkj/dropbear/pull/319]
+Signed-off-by: werew <werew@ret2libc.com>
+Signed-off-by: Petr Štetiar <ynezz@true.cz> [backport]
+---
+ libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c b/libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c
+index 195a3f50a352..b2dcf49819eb 100644
+--- a/libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c
++++ b/libtomcrypt/src/pk/asn1/der/utf8/der_decode_utf8_string.c
+@@ -76,7 +76,7 @@ int der_decode_utf8_string(const unsigned char *in,  unsigned long inlen,
+       /* count number of bytes */
+       for (z = 0; (tmp & 0x80) && (z <= 4); z++, tmp = (tmp << 1) & 0xFF);
+ 
+-      if (z > 4 || (x + (z - 1) > inlen)) {
++      if (z == 1 || z > 4 || (x + (z - 1) > inlen)) {
+          return CRYPT_INVALID_PACKET;
+       }
+ 


### PR DESCRIPTION
> [!NOTE]
> dropbear [project turned down this patch](https://github.com/mkj/dropbear/pull/319#issuecomment-2306018993) as the project is not using the affected code in the library

[ cherry pick of upstream commit 64d1153e5a515740ab56f39c46baf4cf6991a9d3 ]

The der_decode_utf8_string function (in der_decode_utf8_string.c) does not properly detect certain invalid UTF-8 sequences.  This allows context-dependent attackers to cause a denial of service (out-of-bounds read and crash) or read information from other memory locations via carefully crafted DER-encoded data.

To exploit this vulnerability an attacker must be able to provide crafted DER-encoded data to LibTomCrypt (e.g. by importing a X509 certificate).  Information disclosure is made possible by a 2-steps attack where the imported data is later somehow re-encoded and sent to the attacker (e.g. import and then export X509 certificate).

Fixes: CVE-2019-17362
References: https://github.com/libtom/libtomcrypt/issues/507
Upstream-Status: Denied [https://github.com/mkj/dropbear/pull/319]