### PR TITLE
lantiq: use NVMEM for mac addresses

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
@@ -169,6 +169,9 @@
 		label = "wan";
 		phy-mode = "mii";
 		phy-handle = <&phy1>;
+
+		nvmem-cells = <&macaddr_boardconfig_16 2>;
+		nvmem-cell-names = "mac-address";
 	};
 	port@2 {
 		reg = <2>;

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -110,10 +110,6 @@ lantiq_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
-	arcadyan,vgv7510kw22-brn|\
-	arcadyan,vgv7510kw22-nor)
-		wan_mac=$(macaddr_add "$(mtd_get_mac_binary board_config 0x16)" 2)
-		;;
 	arcadyan,vgv7519-brn|\
 	arcadyan,vgv7519-nor|\
 	arcadyan,vrv9510kwac23)


### PR DESCRIPTION
Userspace handling is deprecated.

I have no idea who to ping for this.

@hauke @abajk @xdarklight maybe