### PR TITLE
ath79: engenius-eXXX: use nvmem

### DIFF
--- a/target/linux/ath79/dts/qca9557_engenius_esr1200.dts
+++ b/target/linux/ath79/dts/qca9557_engenius_esr1200.dts
@@ -73,12 +73,20 @@
 	status = "okay";
 };
 
-&wmac {
-	nvmem-cells = <&calibration_art_1000>;
-	nvmem-cell-names = "calibration";
+&nvmem {
+	calibration_art_5000: calibration@5000 {
+		reg = <0x5000 0x844>;
+	};
 };
 
-&ath10k_0 {
-	nvmem-cells = <&calibration_art_5000>;
-	nvmem-cell-names = "calibration";
+&wmac {
+	nvmem-cells = <&calibration_art_1000>, <&macaddr_uboot_eth 1>;
+	nvmem-cell-names = "calibration", "mac-address";
+};
+
+&wifi0 {
+	compatible = "qcom,ath10k";
+
+	nvmem-cells = <&calibration_art_5000>, <&macaddr_uboot_eth 0>;
+	nvmem-cell-names = "calibration", "mac-address";
 };

--- a/target/linux/ath79/dts/qca9558_engenius_epg5000.dts
+++ b/target/linux/ath79/dts/qca9558_engenius_epg5000.dts
@@ -73,12 +73,20 @@
 	status = "okay";
 };
 
-&wmac {
-	nvmem-cells = <&calibration_art_1000>;
-	nvmem-cell-names = "calibration";
+&nvmem {
+	calibration_art_5000: calibration@5000 {
+		reg = <0x5000 0x844>;
+	};
 };
 
-&ath10k_0 {
-	nvmem-cells = <&calibration_art_5000>;
-	nvmem-cell-names = "calibration";
+&wmac {
+	nvmem-cells = <&calibration_art_1000>, <&macaddr_uboot_eth 1>;
+	nvmem-cell-names = "calibration", "mac-address";
+};
+
+&wifi0 {
+	compatible = "qcom,ath10k";
+
+	nvmem-cells = <&calibration_art_5000>, <&macaddr_uboot_eth 0>;
+	nvmem-cell-names = "calibration", "mac-address";
 };

--- a/target/linux/ath79/dts/qca9558_engenius_esr1750.dts
+++ b/target/linux/ath79/dts/qca9558_engenius_esr1750.dts
@@ -73,12 +73,20 @@
 	status = "okay";
 };
 
-&wmac {
-	nvmem-cells = <&calibration_art_1000>;
-	nvmem-cell-names = "calibration";
+&nvmem {
+	calibration_art_5000: calibration@5000 {
+		reg = <0x5000 0x844>;
+	};
 };
 
-&ath10k_0 {
-	nvmem-cells = <&calibration_art_5000>;
-	nvmem-cell-names = "calibration";
+&wmac {
+	nvmem-cells = <&calibration_art_1000>, <&macaddr_uboot_eth 1>;
+	nvmem-cell-names = "calibration", "mac-address";
+};
+
+&wifi0 {
+	compatible = "qcom,ath10k";
+
+	nvmem-cells = <&calibration_art_5000>, <&macaddr_uboot_eth 0>;
+	nvmem-cell-names = "calibration", "mac-address";
 };

--- a/target/linux/ath79/dts/qca9558_engenius_esr900.dts
+++ b/target/linux/ath79/dts/qca9558_engenius_esr900.dts
@@ -73,18 +73,20 @@
 	status = "okay";
 };
 
-&wmac {
-	nvmem-cells = <&calibration_art_1000>;
-	nvmem-cell-names = "calibration";
+&nvmem {
+	calibration_art_5000: calibration@5000 {
+		reg = <0x5000 0x440>;
+	};
 };
 
-&pcie0 {
-	status = "okay";
+&wmac {
+	nvmem-cells = <&calibration_art_1000>, <&macaddr_uboot_eth 0>;
+	nvmem-cell-names = "calibration", "mac-address";
+};
 
-	wifi@0,0 {
-		compatible = "pci168c,0033";
-		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&calibration_art_5000>;
-		nvmem-cell-names = "calibration";
-	};
+&wifi0 {
+	compatible = "pci168c,0033";
+
+	nvmem-cells = <&calibration_art_5000>, <&macaddr_uboot_eth 1>;
+	nvmem-cell-names = "calibration", "mac-address";
 };

--- a/target/linux/ath79/dts/qca955x_senao_router-dual.dtsi
+++ b/target/linux/ath79/dts/qca955x_senao_router-dual.dtsi
@@ -30,6 +30,9 @@
 
 	phy-handle = <&phy0>;
 	pll-data = <0xa6000000 0x00000101 0x00001616>;
+
+	nvmem-cells = <&macaddr_uboot_eth 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &mdio0 {
@@ -43,8 +46,7 @@
 &pcie0 {
 	status = "okay";
 
-	ath10k_0: wifi@0,0 {
-		compatible = "qcom,ath10k";
+	wifi0: wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
 	};
 };
@@ -72,6 +74,16 @@
 				label = "u-boot-env";
 				reg = <0x030000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_eth: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			partition@40000 {
@@ -103,17 +115,13 @@
 				reg = <0xff0000 0x010000>;
 				read-only;
 
-				nvmem-layout {
+				nvmem: nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
 
 					calibration_art_1000: calibration@1000 {
 						reg = <0x1000 0x440>;
-					};
-
-					calibration_art_5000: calibration@5000 {
-						reg = <0x5000 0x844>;
 					};
 				};
 			};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -737,7 +737,6 @@ ath79_setup_macs()
 	engenius,esr1200|\
 	engenius,esr1750|\
 	engenius,esr900)
-		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		;;
 	engenius,ews511ap)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -52,12 +52,6 @@ case "$board" in
 		[ "$PHYNBR" -eq 0 ] && \
 			mtd_get_mac_ascii u-boot-env athaddr > /sys${DEVPATH}/macaddress
 		;;
-	engenius,epg5000|\
-	engenius,esr1200|\
-	engenius,esr1750|\
-	engenius,esr900)
-		macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" "$PHYNBR" > /sys${DEVPATH}/macaddress
-		;;
 	engenius,ews511ap)
 		[ "$PHYNBR" -eq 0 ] && \
 		macaddr_add $(cat /sys/class/net/eth0/address) 1 > /sys${DEVPATH}/macaddress

--- a/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -12,12 +12,6 @@ preinit_set_mac_address() {
 		ip link set dev eth0 address $(mtd_get_mac_ascii bdcfg "lanmac")
 		ip link set dev eth1 address $(mtd_get_mac_ascii bdcfg "wanmac")
 		;;
-	engenius,epg5000|\
-	engenius,esr1200|\
-	engenius,esr1750|\
-	engenius,esr900)
-		ip link set dev eth0 address $(mtd_get_mac_ascii u-boot-env ethaddr)
-		;;
 	siemens,ws-ap3610)
 		ip link set dev eth0 address $(mtd_get_mac_ascii cfg1 ethaddr)
 		;;


### PR DESCRIPTION
Userspace handling is deprecated.

Move ath10k node out of dtsi. It's not always present. esr900 has an ath9k radio.

ping @mpratt14 

Moved out of https://github.com/openwrt/openwrt/pull/14666 to get it merged faster.