### PR TITLE
Fix model names for Radxa ROCK 3A, 5A, and 5B

### DIFF
--- a/package/boot/uboot-rockchip/patches/010-arm64-dts-rockchip-correct-the-model-name-for-Radxa-.patch
+++ b/package/boot/uboot-rockchip/patches/010-arm64-dts-rockchip-correct-the-model-name-for-Radxa-.patch
@@ -1,0 +1,29 @@
+From 626a479873b6a680b3227c4852bde4a1f2c17fdf Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Fri, 19 Apr 2024 18:30:19 +0800
+Subject: [PATCH 1/3] arm64: dts: rockchip: correct the model name for Radxa
+ ROCK 3A
+
+According to https://radxa.com/products/rock3/3a,
+the name of this board should be "Radxa ROCK 3A".
+
+Suggested-by: FUKAUMI Naoki <naoki@radxa.com>
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+Reviewed-by: Dragan Simic <dsimic@manjaro.org>
+Link: https://lore.kernel.org/r/20240419103019.992586-3-amadeus@jmu.edu.cn
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/dts/upstream/src/arm64/rockchip/rk3568-rock-3a.dts
++++ b/dts/upstream/src/arm64/rockchip/rk3568-rock-3a.dts
+@@ -8,7 +8,7 @@
+ #include "rk3568.dtsi"
+ 
+ / {
+-	model = "Radxa ROCK3 Model A";
++	model = "Radxa ROCK 3A";
+ 	compatible = "radxa,rock3a", "rockchip,rk3568";
+ 
+ 	aliases {

--- a/package/boot/uboot-rockchip/patches/011-arm64-dts-rockchip-Correct-the-model-names-for-Radxa.patch
+++ b/package/boot/uboot-rockchip/patches/011-arm64-dts-rockchip-Correct-the-model-names-for-Radxa.patch
@@ -1,0 +1,43 @@
+From 45e831033f7a00a14f64afa1e34c476a9ff0f9f0 Mon Sep 17 00:00:00 2001
+From: Dragan Simic <dsimic@manjaro.org>
+Date: Thu, 18 Apr 2024 18:26:20 +0200
+Subject: [PATCH] arm64: dts: rockchip: Correct the model names for Radxa ROCK
+ 5 boards
+
+Correct the descriptions of a few Radxa boards, according to the up-to-date
+documentation from Radxa and the detailed explanation from Naoki. [1]  To sum
+it up, the short naming, as specified by Radxa, is preferred.
+
+[1] https://lore.kernel.org/linux-rockchip/B26C732A4DCEA9B3+282b8775-601b-4d4a-a513-4924b7940076@radxa.com/
+
+Suggested-by: FUKAUMI Naoki <naoki@radxa.com>
+Signed-off-by: Dragan Simic <dsimic@manjaro.org>
+Link: https://lore.kernel.org/r/6931289a252dc2d6c7bfd2388835c5e98ba0d8c9.1713457260.git.dsimic@manjaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts  | 2 +-
+ arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- a/dts/upstream/src/arm64/rockchip/rk3588-rock-5b.dts
++++ b/dts/upstream/src/arm64/rockchip/rk3588-rock-5b.dts
+@@ -7,7 +7,7 @@
+ #include "rk3588.dtsi"
+ 
+ / {
+-	model = "Radxa ROCK 5 Model B";
++	model = "Radxa ROCK 5B";
+ 	compatible = "radxa,rock-5b", "rockchip,rk3588";
+ 
+ 	aliases {
+--- a/dts/upstream/src/arm64/rockchip/rk3588s-rock-5a.dts
++++ b/dts/upstream/src/arm64/rockchip/rk3588s-rock-5a.dts
+@@ -8,7 +8,7 @@
+ #include "rk3588s.dtsi"
+ 
+ / {
+-	model = "Radxa ROCK 5 Model A";
++	model = "Radxa ROCK 5A";
+ 	compatible = "radxa,rock-5a", "rockchip,rk3588s";
+ 
+ 	aliases {

--- a/target/linux/rockchip/patches-6.6/060-01-v6.10-arm64-dts-rockchip-correct-the-model-name-for-Radxa-.patch
+++ b/target/linux/rockchip/patches-6.6/060-01-v6.10-arm64-dts-rockchip-correct-the-model-name-for-Radxa-.patch
@@ -1,0 +1,29 @@
+From 626a479873b6a680b3227c4852bde4a1f2c17fdf Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Fri, 19 Apr 2024 18:30:19 +0800
+Subject: [PATCH] arm64: dts: rockchip: correct the model name for Radxa ROCK
+ 3A
+
+According to https://radxa.com/products/rock3/3a,
+the name of this board should be "Radxa ROCK 3A".
+
+Suggested-by: FUKAUMI Naoki <naoki@radxa.com>
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+Reviewed-by: Dragan Simic <dsimic@manjaro.org>
+Link: https://lore.kernel.org/r/20240419103019.992586-3-amadeus@jmu.edu.cn
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
+@@ -8,7 +8,7 @@
+ #include "rk3568.dtsi"
+ 
+ / {
+-	model = "Radxa ROCK3 Model A";
++	model = "Radxa ROCK 3A";
+ 	compatible = "radxa,rock3a", "rockchip,rk3568";
+ 
+ 	aliases {


### PR DESCRIPTION
this patch fixes model name in dts for u-boot and linux.