### PR TITLE
octeon: ubnt-edgerouter: fix sysupgrade config backup/restore

### DIFF
--- a/target/linux/octeon/base-files/lib/preinit/79_move_config
+++ b/target/linux/octeon/base-files/lib/preinit/79_move_config
@@ -22,7 +22,8 @@ octeon_move_config() {
 		itus,shield-router)
 			move_config "/dev/mmcblk1p1"
 			;;
-		ubnt,edgerouter-4 | \
+		er|\
+		ubnt,edgerouter-4|\
 		ubnt,edgerouter-6p)
 			move_config "/dev/mmcblk0p1"
 			;;

--- a/target/linux/octeon/base-files/lib/upgrade/platform.sh
+++ b/target/linux/octeon/base-files/lib/upgrade/platform.sh
@@ -34,6 +34,7 @@ platform_copy_config() {
 	itus,shield-router)
 		platform_copy_config_helper /dev/mmcblk1p1
 		;;
+	er|\
 	ubnt,edgerouter-4|\
 	ubnt,edgerouter-6p)
 		platform_copy_config_helper /dev/mmcblk0p1


### PR DESCRIPTION
er is missing from platform_copy_config() and octeon_move_config(), so config is lost on every sysupgrade.

Tested using local patching combined with image generator.

To fix this in production, `base-files` would need to contain a fixed version of `platform.sh` before doing a sysupgrade to a fixed version. Is this possible with the way OpenWRT does releases and package updates?