### PR TITLE
ath79: wg800hp: convert to nvmem

### DIFF
--- a/target/linux/ath79/dts/qca9563_nec_wg800hp.dts
+++ b/target/linux/ath79/dts/qca9563_nec_wg800hp.dts
@@ -142,6 +142,24 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					macaddr_board_data_280: macaddr@280 {
+						compatible = "mac-base";
+						reg = <0x280 0x11>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_board_data_480: macaddr@480 {
+						compatible = "mac-base";
+						reg = <0x480 0x11>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_board_data_680: macaddr@680 {
+						compatible = "mac-base";
+						reg = <0x680 0x11>;
+						#nvmem-cell-cells = <1>;
+					};
+
 					macaddr_board_data_880: macaddr@880 {
 						compatible = "mac-base";
 						reg = <0x880 0x11>;
@@ -159,6 +177,10 @@
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
 
 					cal_art_5000: calibration@5000 {
 						reg = <0x5000 0x844>;
@@ -191,6 +213,9 @@
 
 	phy-mode = "sgmii";
 	phy-handle = <&phy0>;
+
+	nvmem-cells = <&macaddr_board_data_280 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &pcie {
@@ -206,5 +231,7 @@
 
 &wmac {
 	status = "okay";
-	qca,no-eeprom;
+
+	nvmem-cells = <&macaddr_board_data_680 0>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
 };

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -781,7 +781,6 @@ ath79_setup_macs()
 		label_mac=$wan_mac
 		;;
 	nec,wg800hp)
-		lan_mac=$(mtd_get_mac_text board_data 0x280)
 		wan_mac=$(mtd_get_mac_text board_data 0x480)
 		label_mac=$wan_mac
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -61,10 +61,6 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env mac_addr)
 		;;
-	nec,wg800hp)
-		caldata_extract "art" 0x1000 0x440
-		ath9k_patch_mac $(mtd_get_mac_text board_data 0x680)
-		;;
 	qihoo,c301)
 		caldata_extract "radiocfg" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii devdata "wlan24mac")


### PR DESCRIPTION
Userspace handling is deprecated.

Unused wan mac added to dts. Requires DSA to implement.

Split from https://github.com/openwrt/openwrt/pull/14666 for faster merging.

ping @musashino205 