### PR TITLE
CI: update actions/labeler to v5

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,7 +14,7 @@ jobs:
     name: Pull Request Labeler
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@v5
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
 


### PR DESCRIPTION
* Version 5 of this action updated the runtime to Node.js 20. All scripts are now run with Node.js 20 instead of Node.js 16 and are affected by any breaking changes between Node.js 16 and 20.

Signed-off-by: Goetz Goerisch <ggoerisch@gmail.com>
