### PR TITLE
lantiq: ltq-atm: use reset_control_get_optional

### DIFF
--- a/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_amazon_se.c
+++ b/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_amazon_se.c
@@ -263,7 +263,7 @@ extern void ase_fw_ver(unsigned int *major, unsigned int *minor)
     *minor = FW_VER_ID->minor;
 }
 
-void ase_init(struct platform_device *pdev)
+int ase_init(struct platform_device *pdev)
 {
     init_pmu();
 
@@ -276,6 +276,8 @@ void ase_init(struct platform_device *pdev)
     init_atm_tc();
 
     clear_share_buffer();
+
+    return 0;
 }
 
 void ase_shutdown(void)

--- a/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_ar9.c
+++ b/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_ar9.c
@@ -194,13 +194,15 @@ void ar9_fw_ver(unsigned int *major, unsigned int *minor)
     *minor = FW_VER_ID->minor;
 }
 
-void ar9_init(struct platform_device *pdev)
+int ar9_init(struct platform_device *pdev)
 {
 	init_pmu();
 	reset_ppe(pdev);
 	init_ema();
 	init_mailbox();
 	clear_share_buffer();
+
+	return 0;
 }
 
 void ar9_shutdown(void)

--- a/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_core.h
+++ b/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_core.h
@@ -32,7 +32,7 @@
 #define SET_BITS(x, msb, lsb, value)    (((x) & ~(((1 << ((msb) + 1)) - 1) ^ ((1 << (lsb)) - 1))) | (((value) & ((1 << (1 + (msb) - (lsb))) - 1)) << (lsb)))
 
 struct ltq_atm_ops {
-	void (*init)(struct platform_device *pdev);
+	int (*init)(struct platform_device *pdev);
 	void (*shutdown)(void);
 
 	int (*start)(int pp32);

--- a/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_danube.c
+++ b/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_danube.c
@@ -141,7 +141,7 @@ static void danube_fw_ver(unsigned int *major, unsigned int *minor)
 	*minor = FW_VER_ID->minor;
 }
 
-static void danube_init(struct platform_device *pdev)
+static int danube_init(struct platform_device *pdev)
 {
             volatile u32 *p = SB_RAM0_ADDR(0);
     unsigned int i;
@@ -190,6 +190,8 @@ static void danube_init(struct platform_device *pdev)
 
     for ( i = 0; i < SB_RAM0_DWLEN + SB_RAM1_DWLEN + SB_RAM2_DWLEN + SB_RAM3_DWLEN; i++ )
         IFX_REG_W32(0, p++);
+
+    return 0;
 }
 
 static void danube_shutdown(void)

--- a/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_vr9.c
+++ b/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_vr9.c
@@ -58,7 +58,7 @@
 #define IFX_PMU_MODULE_AHBS       BIT(13)
 #define IFX_PMU_MODULE_DSL_DFE    BIT(9)
 
-static inline void vr9_reset_ppe(struct platform_device *pdev)
+static inline int vr9_reset_ppe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
 	struct reset_control *dsp;
@@ -66,25 +66,16 @@ static inline void vr9_reset_ppe(struct platform_device *pdev)
 	struct reset_control *tc;
 
 	dsp = devm_reset_control_get(dev, "dsp");
-	if (IS_ERR(dsp)) {
-		if (PTR_ERR(dsp) != -EPROBE_DEFER)
-			dev_err(dev, "Failed to lookup dsp reset\n");
-// 		return PTR_ERR(dsp);
-	}
+	if (IS_ERR(dsp))
+		return dev_err_probe(dev, PTR_ERR(dsp), "Failed to lookup dsp reset");
 
 	dfe = devm_reset_control_get(dev, "dfe");
-	if (IS_ERR(dfe)) {
-		if (PTR_ERR(dfe) != -EPROBE_DEFER)
-			dev_err(dev, "Failed to lookup dfe reset\n");
-// 		return PTR_ERR(dfe);
-	}
+	if (IS_ERR(dfe))
+		return dev_err_probe(dev, PTR_ERR(dfe), "Failed to lookup dfe reset");
 
 	tc = devm_reset_control_get(dev, "tc");
-	if (IS_ERR(tc)) {
-		if (PTR_ERR(tc) != -EPROBE_DEFER)
-			dev_err(dev, "Failed to lookup tc reset\n");
-// 		return PTR_ERR(tc);
-	}
+	if (IS_ERR(tc))
+		return dev_err_probe(dev, PTR_ERR(tc), "Failed to lookup tc reset");
 
 	reset_control_assert(dsp);
 	udelay(1000);
@@ -96,6 +87,8 @@ static inline void vr9_reset_ppe(struct platform_device *pdev)
 	udelay(1000);
 	*PP32_SRST |= 0x000303CF;
 	udelay(1000);
+
+	return 0;
 }
 
 static inline int vr9_pp32_download_code(int pp32, u32 *code_src, unsigned int code_dword_len, u32 *data_src, unsigned int data_dword_len)
@@ -132,10 +125,11 @@ static void vr9_fw_ver(unsigned int *major, unsigned int *minor)
     *minor = FW_VER_ID->minor;
 }
 
-static void vr9_init(struct platform_device *pdev)
+static int vr9_init(struct platform_device *pdev)
 {
 	volatile u32 *p;
 	unsigned int i;
+	int ret;
 
 	/* setup pmu */
 	ltq_pmu_enable(IFX_PMU_MODULE_PPE_SLL01 |
@@ -145,7 +139,9 @@ static void vr9_init(struct platform_device *pdev)
 		IFX_PMU_MODULE_AHBS |
 		IFX_PMU_MODULE_DSL_DFE);
 
-	vr9_reset_ppe(pdev);
+	ret = vr9_reset_ppe(pdev);
+	if (ret)
+		return ret;
 
 	/* pdma init */
 	IFX_REG_W32(0x08,       PDMA_CFG);
@@ -170,6 +166,8 @@ static void vr9_init(struct platform_device *pdev)
 	p = SB_RAM6_ADDR(0);
 	for ( i = 0; i < SB_RAM6_DWLEN; i++ )
 		IFX_REG_W32(0, p++);
+
+	return 0;
 }
 
 static void vr9_shutdown(void)

--- a/package/kernel/lantiq/ltq-atm/src/ltq_atm.c
+++ b/package/kernel/lantiq/ltq-atm/src/ltq_atm.c
@@ -1782,7 +1782,10 @@ static int ltq_atm_probe(struct platform_device *pdev)
 		goto INIT_PRIV_DATA_FAIL;
 	}
 
-	ops->init(pdev);
+	ret = ops->init(pdev);
+	if (ret)
+		return ret;
+
 	init_rx_tables();
 	init_tx_tables();
 

--- a/package/kernel/lantiq/ltq-ptm/Makefile
+++ b/package/kernel/lantiq/ltq-ptm/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ltq-ptm
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=John Crispin <john@phrozen.org>
 PKG_LICENSE:=GPL-2.0+

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
@@ -993,7 +993,9 @@ static int ltq_ptm_probe(struct platform_device *pdev)
         goto INIT_PRIV_DATA_FAIL;
     }
 
-    ifx_ptm_init_chip(pdev);
+    ret = ifx_ptm_init_chip(pdev);
+    if (ret)
+        goto INIT_PRIV_DATA_FAIL;
     ret = init_tables();
     if ( ret != 0 ) {
         err("INIT_TABLES_FAIL");

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.h
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.h
@@ -112,7 +112,7 @@ extern unsigned int ifx_ptm_dbg_enable;
 
 extern void ifx_ptm_get_fw_ver(unsigned int *major, unsigned int *mid, unsigned int *minor);
 
-extern void ifx_ptm_init_chip(struct platform_device *pdev);
+extern int ifx_ptm_init_chip(struct platform_device *pdev);
 extern void ifx_ptm_uninit_chip(void);
 
 extern int ifx_pp32_start(int pp32);


### PR DESCRIPTION
Based on the fact that the returns are commented out, this indicates that these are optional and as such should use the proper API.

Also simplifies error handling by using dev_err_probe and not having to handle -EPROBE_DEFER.

ping @hauke