### PR TITLE
utils: Add the `omnia-eeprom` utility

### DIFF
--- a/package/utils/omnia-eeprom/Makefile
+++ b/package/utils/omnia-eeprom/Makefile
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2024 Marek Behún <kabel@kernel.org>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=omnia-eeprom
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-v$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://gitlab.nic.cz/turris/omnia-eeprom/-/archive/v$(PKG_VERSION)/
+PKG_HASH:=6f949d0b8080adca8bae088774ce615b563ba6ec2807cce97ee6769b4eee7bbf
+
+PKG_MAINTAINER:=Marek Behun <kabel@kernel.org>
+PKG_LICENSE:=GPL-2.0-or-later
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/omnia-eeprom
+  SECTION:=utils
+  CATEGORY:=Utilities
+  URL:=https://gitlab.nic.cz/turris/omnia-eeprom
+  TITLE:=CZ.NIC Turris Omnia EEPROM accessing utility
+  DEPENDS:=@TARGET_mvebu_cortexa9_DEVICE_cznic_turris-omnia +kmod-eeprom-at24
+endef
+
+define Package/omnia-eeprom/description
+This package contains the omnia-eeprom utility, which allows you to display
+and update EEPROM fields on the Turris Omnia router.
+The EEPROM is normally not meant to be updated by users, but there are some
+exceptions where it might be useful.
+One such example is to change the DDR3 speed from the default 1600K mode to
+1333H mode, in order to solve random crashes that occur on some boards with
+newer versions of the U-Boot bootloader (because of bugs in newer versions of
+the DDR training algorithm).
+endef
+
+MAKE_VARS += OMNIA_EEPROM_VERSION="v$(PKG_VERSION)"
+
+TARGET_CFLAGS += -Wall
+
+Build/Compile = $(Build/Compile/Default)
+
+define Package/omnia-eeprom/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/omnia-eeprom $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,omnia-eeprom))

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -107,7 +107,8 @@ define Device/cznic_turris-omnia
     mkf2fs e2fsprogs kmod-fs-vfat kmod-nls-cp437 kmod-nls-iso8859-1 \
     wpad-basic-mbedtls kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct \
     kmod-mt7915-firmware partx-utils kmod-i2c-mux-pca954x kmod-leds-turris-omnia \
-    kmod-turris-omnia-mcu kmod-gpio-button-hotplug omnia-mcu-firmware omnia-mcutool
+    kmod-turris-omnia-mcu kmod-gpio-button-hotplug omnia-eeprom omnia-mcu-firmware \
+    omnia-mcutool
   IMAGES := sysupgrade.img.gz
   IMAGE/sysupgrade.img.gz := boot-scr | boot-img | sdcard-img | gzip | append-metadata
   SUPPORTED_DEVICES += armada-385-turris-omnia


### PR DESCRIPTION
Add a new utility, `omnia-eeprom`, which can be used to print / set EEPROM fields on Turris Omnia.

One example when this utility might be useful is if the board experiences random crashes due to newer versions of the DDR training algorithm in newer U-Boot. The user can change the DDR speed from 1600K to 1333H to solve these issues, with

  ```
  omnia-eeprom set ddr_speed 1333H
  ```