### PR TITLE
ramips: rt1800: remove gmac1 usage and use TRGMII

### DIFF
--- a/target/linux/ramips/dts/mt7621_belkin_rt1800.dts
+++ b/target/linux/ramips/dts/mt7621_belkin_rt1800.dts
@@ -156,6 +156,10 @@
 	};
 };
 
+&gmac0 {
+	phy-mode = "trgmii";
+};
+
 &gmac1 {
 	status = "okay";
 	label = "wan";
@@ -189,6 +193,10 @@
 		port@4 {
 			status = "okay";
 			label = "lan1";
+		};
+
+		port@6 {
+			phy-mode = "trgmii";
 		};
 	};
 };


### PR DESCRIPTION
The GMAC1 trick is a nice feature, but results in higher latency. Furthermore, gmac0 supports TRGMII (1.2gbps) for units running DDR3 at 1200Mhz to et some speed back.

ping @arinc9 