### PR TITLE
ramips: Add support for D-Link DIR-2150-R1

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-2150-r1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-2150-r1.dts
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "dlink,dir-2150-r1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-2150 R1";
+
+	aliases {
+		label-mac-device = &gmac1;
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_white;
+		led-running = &led_power_white;
+		led-upgrade = &led_net_orange;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: led-0 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_white: led-1 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_net_orange: led-2 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					compatible = "mac-base";
+					reg = <0xe006 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+		
+		partition@140000 {
+			label = "firmware";
+			compatible = "denx,uimage";
+			reg = <0x140000 0x7E80000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_e006 2>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_e006 4>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e006 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_e006 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -916,6 +916,20 @@ define Device/dlink_dir-2150-a1
 endef
 TARGET_DEVICES += dlink_dir-2150-a1
 
+define Device/dlink_dir-2150-r1
+  $(Device/nand)
+  IMAGE_SIZE := 129536k
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DIR-2150
+  DEVICE_VARIANT := R1
+  DEVICE_PACKAGES :=  -uboot-envtools kmod-mt7603 kmod-mt7615-firmware kmod-usb3
+  KERNEL := $$(KERNEL)
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size | sign-dlink-ru e6587b35a6b34e07bedeca23e140322f 
+endef
+TARGET_DEVICES += dlink_dir-2150-r1
+
 define Device/dlink_dir-2640-a1
   $(Device/dlink_dir_nand_128m)
   DEVICE_MODEL := DIR-2640

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -94,6 +94,7 @@ dlink,dap-x1860-a1)
 dlink,dir-1960-a1|\
 dlink,dir-2055-a1|\
 dlink,dir-2150-a1|\
+dlink,dir-2150-r1|\
 dlink,dir-2640-a1|\
 dlink,dir-2660-a1)
 	ucidef_set_led_netdev "wan" "wan" "white:wan" "wan"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -85,6 +85,7 @@ platform_do_upgrade() {
 	dlink,dir-1960-a1|\
         dlink,dir-2055-a1|\
 	dlink,dir-2150-a1|\
+	dlink,dir-2150-r1|\
 	dlink,dir-2640-a1|\
 	dlink,dir-2660-a1|\
 	dlink,dir-3040-a1|\


### PR DESCRIPTION
Hardware Specification:
SoC: Mediatek MT7621DAT (MIPS1004Kc 880 MHz, dual core) RAM: 128 MB
Storage: 128 MB NAND flash
Ethernet: 5x 10/100/1000 Mbps LAN1,LAN2,LAN3,LAN4 & WAN Wireless: 2.4GHz: Mediatek MT7603EN up to 300Mbps (802.11b/g/n MIMO 2x2) Wireless: 5GHz: Mediatek MT7615N up to 1733Mbps (802.11n/ac MU-MIMO 4x4) LEDs: Power (white & amber), Internet (white & amber) LEDs: 2.4G (White), 5Ghz (White)
Buttons: WPS, Reset
USB: Front V3.0 & Rear V2.0

MAC Table
Label xx:xx:xx:xx:xx:38
LAN xx:xx:xx:xx:xx:39
2.4Ghz xx:xx:xx:xx:xx:3A
5Ghz xx:xx:xx:xx:xx:3C
WAN xx:xx:xx:xx:xx:38

Flash instructions:
D-Link normal OEM firmware update page
1. upload OpenWRT factory.bin like any D-Link upgrade image

D-Link Fail Safe GUI:
1. Push and hold reset button (on the bottom of the device) until power led starts flashing (about 10 secs or so) while plugging in the power cable.
2. Give it ~30 seconds, to boot the fail safe GUI
3. Connect your client computer to LAN1 of the device
4. Set your client IP address manually to 192.168.0.2 / 255.255.255.0
5. Call the fail safe page for the device at http://192.168.0.1/
6. Use the provided fail safe web GUI to upload the factory.bin to the device
