### PR TITLE
hostapd: fix anqp_3gpp_cell_net list delimiter

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -437,7 +437,7 @@ append_iw_anqp_3gpp_cell_net() {
 	if [ -z "$iw_anqp_3gpp_cell_net_conf" ]; then
 		iw_anqp_3gpp_cell_net_conf="$1"
 	else
-		iw_anqp_3gpp_cell_net_conf="$iw_anqp_3gpp_cell_net_conf:$1"
+		iw_anqp_3gpp_cell_net_conf="$iw_anqp_3gpp_cell_net_conf;$1"
 	fi
 }
 


### PR DESCRIPTION
This patch fixes the list delimiter between 3GPP networks passed to hostapd.

> list iw_anqp_3gpp_cell_net '262,001'
> list iw_anqp_3gpp_cell_net '262,002'

When passing a list of "iw_anqp_3gpp_cell_net" parameters via UCI, hostapd would crash at startup:
> daemon.err hostapd: Line 73: Invalid anqp_3gpp_cell_net: 262,001:262,002

Using a semicolon as a delimiter, hostapd will start as expected.