### PR TITLE
DNSmasq: Don't forward queries for .internal

### DIFF
--- a/package/network/services/dnsmasq/files/rfc6761.conf
+++ b/package/network/services/dnsmasq/files/rfc6761.conf
@@ -9,3 +9,4 @@ server=/local/
 server=/localhost/
 server=/onion/
 server=/test/
+server=/internal/


### PR DESCRIPTION
ICANN has made it official: 
https://www.icann.org/en/board-activities-and-meetings/materials/approved-resolutions-special-meeting-of-the-icann-board-29-07-2024-en#section2.a

Acked-by: Jaykishan Mutkawoa <jay@cyberstorm.mu>

