### PR TITLE
ramips: mt7620: disable building re200-v1, re210-v1

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1253,6 +1253,7 @@ define Device/tplink_re200-v1
   IMAGE_SIZE := 7936k
   TPLINK_HWID := 0x02000001
   TPLINK_FLASHLAYOUT := 8Mmtk
+  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_re200-v1
 
@@ -1265,6 +1266,7 @@ define Device/tplink_re210-v1
   IMAGE_SIZE := 7936k
   TPLINK_HWID := 0x02100001
   TPLINK_FLASHLAYOUT := 8Mmtk
+  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_re210-v1
 


### PR DESCRIPTION
The TP-Link RE200 v1 and RE210 v1 were reported to be bricked by recent releases. Stop building them to prevent further bricks. Devices get stuck at "Starting kernel ..."
There is no known way of recovery for bricked devices currently. Affected are atleast: 23.05.3, 23.05.4 and 22.03.7

[1] https://forum.openwrt.org/t/tp-link-re200-v1-seemingly-bricked-after-sysupgrade/199277
[2] https://github.com/openwrt/openwrt/issues/16296
[3] https://lists.openwrt.org/pipermail/openwrt-devel/2024-September/043130.html

Reported-by: Andreas Böhler <dev@aboehler.at>

This commit could be backported to openwrt-22.03.
Built images for the release tags 23.05.3, 23.05.4 and 22.03.7 should be removed from the Firmware Selector and https://downloads.openwrt.org/ consequently.

The info should be added to "Known Issues" for affected releases as well.
https://openwrt.org/releases/start

The commit shall be reverted once the issue is fixed for both release branches.
edit: According to the reporter @noobtheproswag snapshots are not affected currently. Either the issue has been fixed on snapshots already or was only introduced for older Kernels like 5.15 and 5.10