### PR TITLE
uboot-envtools: add u-boot system env config for Xiaomi Redmi AX6S

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_mt7622
+++ b/package/boot/uboot-envtools/files/mediatek_mt7622
@@ -62,6 +62,7 @@ ubnt,unifi-6-lr-v3)
 	;;
 xiaomi,redmi-router-ax6s)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x40000"
+	ubootenv_add_uci_sys_config "/dev/mtd4" "0x0" "0x10000" "0x40000"
 	;;
 esac
 


### PR DESCRIPTION
Adds u-boot config for access to system env variables on this board

Tested on my new device.