### PR TITLE
dnsmasq: pass-through dnsmasq environment variables to hotplug

### DIFF
--- a/package/network/services/dnsmasq/files/dhcp-script.sh
+++ b/package/network/services/dnsmasq/files/dhcp-script.sh
@@ -15,6 +15,10 @@ case "$1" in
 	;;
 esac
 
+for var in $(env | grep '^DNSMASQ_'); do
+	json_add_string "" "${var%%=*}=${var#*=}"
+done
+
 case "$1" in
 	add)
 		json_add_string "" "ACTION=add"

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1220,6 +1220,7 @@ dnsmasq_start()
 	procd_add_jail_mount $EXTRA_MOUNT $RFC6761FILE $TRUSTANCHORSFILE
 	procd_add_jail_mount $dnsmasqconffile $dnsmasqconfdir $resolvdir $user_dhcpscript
 	procd_add_jail_mount /etc/passwd /etc/group /etc/TZ /etc/hosts /etc/ethers
+	procd_add_jail_mount /usr/bin/env /bin/grep
 	procd_add_jail_mount_rw /var/run/dnsmasq/ $leasefile
 	case "$logfacility" in */*)
 		[ ! -e "$logfacility" ] && touch "$logfacility"


### PR DESCRIPTION
`dnsmasq` passes a limited amount of information via DHCP script arguments. Much more information is available through environment variables starting with `DNSMASQ_`, such as `DNSMASQ_INTERFACE`. However, when the dhcp-script builds its JSON environment and passes it to `hotplug`, all of this information is discarded since it is not copied to the JSON environment.

Personally, I have a custom-made set of DDNS scripts and rely on environment variables such as `DNSMASQ_INTERFACE` in order to determine which DNS zones to update. So, not being able to access these variables was detrimental to me. I patched in a quick copy of all DNSMASQ_* variables to the JSON environment so that they can be used in hotplug scripts. In order to do so, I also copied `/usr/bin/env` and `/bin/grep` into the chroot jail for dnsmasq to facilitate the process.

While my approach seems a bit ham-fisted probably, there is a good reason for it: certain dnsmasq environment variables (namely `DNSMASQ_USER_CLASS[n]`) don't have finite names. So, it's easy to programmatically grab everything with this approach.