### PR TITLE
Qualcommax: IPQ807x: Add support for TP-Link Deco X80-5G

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq807x
@@ -39,6 +39,7 @@ netgear,sxs80|\
 netgear,wax218|\
 netgear,wax620|\
 netgear,wax630|\
+tplink,deco-x80-5g|\
 tplink,eap620hd-v1|\
 tplink,eap660hd-v1)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -67,6 +67,7 @@ ALLWIFIBOARDS:= \
 	redmi_ax6 \
 	skspruce_wia3300-20 \
 	spectrum_sax1v1k \
+	tplink_deco-x80-5g \
 	tplink_eap610-outdoor \
 	tplink_eap620hd-v1 \
 	tplink_eap623od-hd-v1 \
@@ -217,6 +218,7 @@ $(eval $(call generate-ipq-wifi-package,prpl_haze,prpl Haze))
 $(eval $(call generate-ipq-wifi-package,redmi_ax6,Redmi AX6))
 $(eval $(call generate-ipq-wifi-package,skspruce_wia3300-20,SKSpruce WIA3300-20))
 $(eval $(call generate-ipq-wifi-package,spectrum_sax1v1k,Spectrum SAX1V1K))
+$(eval $(call generate-ipq-wifi-package,tplink_deco-x80-5g,TP-Link Deco X80-5G))
 $(eval $(call generate-ipq-wifi-package,tplink_eap610-outdoor,TPLink EAP610-Outdoor))
 $(eval $(call generate-ipq-wifi-package,tplink_eap620hd-v1,TP-Link EAP620 HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_eap623od-hd-v1,TP-Link EAP623-Outdoor HD v1))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-deco-x80-5g.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-deco-x80-5g.dts
@@ -1,0 +1,458 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2022, Robert Marko <robimarko@gmail.com>
+altered by Jonathan Brophy <professor_jonny@hotmail.com>
+to suit the TP-Link Deco X80-5G target */
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "TP-Link Deco X80-5G";
+	compatible = "tplink,deco-x80-5g", "qcom,ipq8074";
+
+	aliases {
+		 serial0 = &blsp1_uart5;
+ 	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	modem {
+		compatible = "gpio-export";
+		pinctrl-names = "default";
+		pinctrl-0 = <&modem_pins>;
+		pinctrl-1 = <&antenna_pins>;
+
+		w_disable {
+			gpio-export,name = "w_disable";
+			gpio-export,output = <1>;
+			gpios = <&tlmm 35 GPIO_ACTIVE_HIGH>; /* wwan disable output */
+		};
+
+		modem-reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <0>;
+			gpios = <&tlmm 29 GPIO_ACTIVE_HIGH>; /* reset modem output */
+		};
+
+		ext_antenna_en {
+			gpio-export,name = "ext_antenna_en";
+			gpio-export,output = <0>;
+			gpios = <&tlmm 56 GPIO_ACTIVE_HIGH>; /* select external sma antennas for wwan output */
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset_button {
+			label = "reset";
+			gpios = <&tlmm 27 GPIO_ACTIVE_LOW>; /*reset button output*/
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+		/*note the LED's defined here are not individual they are a single combined RGB element used for status functions.
+		To mimic the OEM default behaviour green and red are switched on from boot to indicate yellow (power on).*/
+
+		led_system_green: green {
+			gpios = <&tlmm 50 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			default-state = "on";
+		};
+
+		led_system_red: red {
+			gpios = <&tlmm 51 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			default-state = "on";
+		};
+
+		led_system_blue: blue {
+			gpios = <&tlmm 52 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+
+	gpio_fan: gpio-fan {
+		compatible = "gpio-fan";
+		pinctrl-0 = <&fan_pins>;
+		pinctrl-names = "default";
+		gpios = <&tlmm 42 GPIO_ACTIVE_LOW>, /* fan gpio MSB */
+			<&tlmm 41 GPIO_ACTIVE_LOW>,
+			<&tlmm 40 GPIO_ACTIVE_LOW>; /* fan gpio LSB */
+
+		/* stock fan is a Sunnon EF40201BX-Q18C-F99
+		6800 rpm
+		gpio68 seemed to be the feedback rpm of the fan.
+		no support for fan speed in kernel saved for future use.*/
+
+		/*rpm-gpios = <&tlmm 68 GPIO_ACTIVE_HIGH>; */
+		gpio-fan,speed-map = <0 0>, /* speed 0 binary drive bits 0,0,0 (idle state) */
+				<971 1>, /* speed 1 binary drive bits 0,0,1      ▼ */
+				<1942 2>, /* speed 3 binary drive bits 0,1,0 (active state) */
+				<2913 3>, /* speed 4 binary drive bits 0,1,1      ▼ */
+				<3884 4>, /* speed 5 binary drive bits 1,0,0      ▼ */
+				<4855 5>, /* speed 6 binary drive bits 1,0,1 (high state) */
+				<5826 6>, /* speed 7 binary drive bits 1,1,0      ▼ */
+				<6800 7>; /* speed 8 binary drive bits 1,1,1      ▼ */
+		#cooling-cells = <2>;  /* min followed by max */
+	};
+};
+
+&cpu0_thermal {
+	trips {
+		cpu0_high: cpu-high {
+			temperature = <70000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+		cpu0_active: cpu-active {
+			temperature = <50000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+		cpu0_idle: cpu-idle {
+			temperature = <25000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		map2 {
+			trip = <&cpu0_high>;
+			cooling-device = <&gpio_fan 5 THERMAL_NO_LIMIT>;
+		};
+		map3 {
+			trip = <&cpu0_active>;
+			cooling-device = <&gpio_fan 2 4>;
+		};
+		map4 {
+			trip = <&cpu0_idle>;
+			cooling-device = <&gpio_fan THERMAL_NO_LIMIT 1>;
+		};
+	};
+};
+
+&cpu1_thermal {
+	trips {
+		cpu1_high: cpu-high {
+			temperature = <70000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+		cpu1_active: cpu-active {
+			temperature = <50000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+		cpu1_idle: cpu-idle {
+			temperature = <25000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		map2 {
+			trip = <&cpu1_high>;
+			cooling-device = <&gpio_fan 5 THERMAL_NO_LIMIT>;
+		};
+		map3 {
+			trip = <&cpu1_active>;
+			cooling-device = <&gpio_fan 2 4>;
+		};
+		map4 {
+			trip = <&cpu1_idle>;
+			cooling-device = <&gpio_fan THERMAL_NO_LIMIT 1>;
+		};
+	};
+};
+
+&cpu2_thermal {
+	trips {
+		cpu2_high: cpu-high {
+			temperature = <70000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+		cpu2_active: cpu-active {
+			temperature = <50000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+		cpu2_idle: cpu-idle {
+			temperature = <25000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		map2 {
+			trip = <&cpu2_high>;
+			cooling-device = <&gpio_fan 5 THERMAL_NO_LIMIT>;
+		};
+		map3 {
+			trip = <&cpu2_active>;
+			cooling-device = <&gpio_fan 2 4>;
+		};
+		map4 {
+			trip = <&cpu2_idle>;
+			cooling-device = <&gpio_fan THERMAL_NO_LIMIT 1>;
+		};
+	};
+};
+
+&cpu3_thermal {
+	trips {
+		cpu3_high: cpu-high {
+			temperature = <70000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+		cpu3_active: cpu-active {
+			temperature = <50000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+		cpu3_idle: cpu-idle {
+			temperature = <25000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		map2 {
+			trip = <&cpu3_high>;
+			cooling-device = <&gpio_fan 5 THERMAL_NO_LIMIT>;
+		};
+		map3 {
+			trip = <&cpu3_active>;
+			cooling-device = <&gpio_fan 2 4>;
+		};
+		map4 {
+			trip = <&cpu3_idle>;
+			cooling-device = <&gpio_fan THERMAL_NO_LIMIT 1>;
+		};
+	};
+};
+
+
+&cluster_thermal {
+	trips {
+		cluster_high: cluster-high {
+			temperature = <70000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+		cluster_active: cluster-active {
+			temperature = <50000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+		cluster_idle: cluster-idle {
+			temperature = <25000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		map2 {
+			trip = <&cluster_high>;
+			cooling-device = <&gpio_fan 5 THERMAL_NO_LIMIT>;
+		};
+		map3 {
+			trip = <&cluster_active>;
+			cooling-device = <&gpio_fan 2 4>;
+		};
+		map4 {
+			trip = <&cluster_idle>;
+			cooling-device = <&gpio_fan THERMAL_NO_LIMIT 1>;
+		};
+	};
+};
+
+
+&tlmm {
+	button_pins: button-state {
+		pins = "gpio27";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-pull-up;
+	};
+
+	fan_pins: fan-state {
+		pins = "gpio40", "gpio41", "gpio42";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	antenna_pins: antenna-state {
+		pins = "gpio56";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	modem_pins: modem-state {
+		pins = "gpio29", "gpio55";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	led_pins: led-state {
+		pins = "gpio50", "gpio51", "gpio52";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part"; /* define SMEM partition table */
+
+		};
+	};
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&usb_0 {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+
+	qca8033: ethernet-phy@4 {
+		compatible = "ethernet-phy-ieee802.3-c22"; /* lan phy */
+		reg = <4>;
+	};
+
+	qca8081: ethernet-phy@28 {
+		compatible = "ethernet-phy-id004d.d101"; /* wan phy */
+		reg = <28>;
+		reset-deassert-us = <10000>;
+		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+	};
+};
+
+
+&switch {
+	status = "okay";
+
+	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
+	switch_lan_bmp = <ESS_PORT6>; /* lan port bitmap */
+	switch_mac_mode1 = <MAC_MODE_SGMII_PLUS>; /* mac mode for uniphy instance1*/
+	switch_mac_mode2 = <MAC_MODE_SGMII_CHANNEL0>; /* mac mode for uniphy instance2*/
+
+	qcom,port_phyinfo {
+		port@5 {
+			port_id = <5>;
+			phy_address = <28>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+		port@6 {
+			port_id = <6>;
+			phy_address = <4>;
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp5 {
+	status = "okay";
+	phy-handle = <&qca8081>;
+	label = "wan";
+};
+
+&dp6_syn {
+	status = "okay";
+	phy-handle = <&qca8033>;
+	label = "lan";
+};
+
+&wifi {
+	status = "okay";
+	qcom,ath11k-calibration-variant = "tplink_deco-x80-5g";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -392,6 +392,21 @@ define Device/spectrum_sax1v1k
 endef
 TARGET_DEVICES += spectrum_sax1v1k
 
+
+define Device/tplink_deco-x80-5g
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := TP-Link
+	DEVICE_MODEL := Deco X80-5G
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_DTS_CONFIG := config@hk01.c5
+	SOC := ipq8074
+	DEVICE_PACKAGES := kmod-hwmon-gpiofan ipq-wifi-tplink_deco-x80-5g \
+	 	 kmod-usb-serial-option kmod-usb-net-qmi-wwan
+endef
+TARGET_DEVICES += tplink_deco-x80-5g
+
 define Device/tplink_eap620hd-v1
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -13,6 +13,7 @@ ipq807x_setup_interfaces()
 	case "$board" in
 	aliyun,ap8220|\
 	edgecore,eap102|\
+	tplink,deco-x80-5g|\
 	yuncore,ax880|\
 	zte,mf269)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
@@ -97,6 +98,11 @@ ipq807x_setup_macs()
 		;;
 	linksys,mx8500)
 		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
+		lan_mac=$(macaddr_add $label_mac 1)
+		wan_mac=$label_mac
+		;;
+	tplink,deco-x80-5g)
+		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
 		lan_mac=$(macaddr_add $label_mac 1)
 		wan_mac=$label_mac
 		;;

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -96,6 +96,13 @@ case "$FIRMWARE" in
 	spectrum,sax1v1k)
 		caldata_extract_mmc "0:ART" 0x1000 0x20000
 		;;
+	tplink,deco-x80-5g)
+		caldata_extract "0:art" 0x1000 0x20000
+		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
+		ath11k_patch_mac $(macaddr_add $label_mac -1) 0
+		ath11k_patch_mac $(macaddr_add $label_mac -2) 1
+		ath11k_set_macflag
+		;;
 	tplink,eap620hd-v1|\
 	tplink,eap660hd-v1)
 		caldata_from_file "/tmp/factory_data/radio" 0 0x20000

--- a/target/linux/qualcommax/ipq807x/base-files/lib/preinit/09_mount_factory_data
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/preinit/09_mount_factory_data
@@ -1,20 +1,28 @@
 #!/bin/sh
 
-preinit_mount_factory_data() {
-	local mtd_path
+. /lib/functions.sh
+. /lib/functions/system.sh
 
-	. /lib/functions.sh
-	. /lib/functions/system.sh
+preinit_mount_factory_data() {
+	local part_name="$1"
+	local mtd_path
+	local ubi_num
+
+		mtd_path=$(find_mtd_chardev "$part_name")
+		ubi_num=$(grep $part_name /proc/mtd | cut -c 1-5 | grep -o '[0-9]*')
+		ubiattach --dev-path="$mtd_path" --devn=$ubi_num
+		mkdir /tmp/$part_name
+		mount -o ro,noatime -t ubifs ubi$ubi_num:ubi_$part_name /tmp/$part_name
+}
+
+preinit_mount_factory_partitions() {
 
 	case $(board_name) in
 	tplink,eap620hd-v1|\
 	tplink,eap660hd-v1)
-		mtd_path=$(find_mtd_chardev "factory_data")
-		ubiattach --dev-path="$mtd_path" --devn=1
-		mkdir /tmp/factory_data
-		mount -o ro,noatime -t ubifs ubi1:ubi_factory_data /tmp/factory_data
+		preinit_mount_factory_data "tp_data"
 		;;
 	esac
 }
 
-boot_hook_add preinit_main preinit_mount_factory_data
+boot_hook_add preinit_main preinit_mount_factory_partitions

--- a/target/linux/qualcommax/ipq807x/base-files/lib/preinit/09_mount_factory_data
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/preinit/09_mount_factory_data
@@ -18,6 +18,10 @@ preinit_mount_factory_data() {
 preinit_mount_factory_partitions() {
 
 	case $(board_name) in
+	tplink,deco-x80-5g)
+		preinit_mount_factory_data "factory_data"
+		preinit_mount_factory_data "runtime_data"
+		;;
 	tplink,eap620hd-v1|\
 	tplink,eap660hd-v1)
 		preinit_mount_factory_data "tp_data"

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -262,6 +262,7 @@ platform_do_upgrade() {
 		CI_DATAPART="rootfs_data"
 		emmc_do_upgrade "$1"
 		;;
+	tplink,deco-x80-5g|\
 	tplink,eap620hd-v1|\
 	tplink,eap660hd-v1)
 		tplink_do_upgrade "$1"


### PR DESCRIPTION
Qualcommax: IPQ807x: Add support for TP-Link Deco X80-5G
The TP-link Deco X80-5G is a AX WIFI router with a single 1G (LAN) and 1 2.5G (WAN) port with a built in Quectel 5G modem.

Specifications:

Architecture	ARMv8-A (aarch64 Cortex A53, 4 cores)
Vendor	Qualcomm
Bootloader	U-Boot (2016)
System-On-Chip	Qualcomm IPQ8074A (Networking Pro 1210 platform)
CPU/Speed	2.2GHZ
Flash-Chip	ESMT F59D1G81MB-45TI 1G-bit NAND
Flash MB	128MB (1Gbit)
RAM-chip	2* ESMT M15T4G16256A-DEBG2G 2Gb DDR3L (32bit)
RAM MB	512MB (4Gbit)
WLan System-On-Chip (5g)	Qualcomm QCN5054
WLan Front end modules (5g)	8* Qorvo QPF4588
WLAN (5G)	A/N/AC/AX
WLAN Antenna (int)	8* (4 shared with 2.5G)
WLan System-On-Chip (2.4G)	Qualcomm QCN5024
WLan Front end modules (2.4G)	4* Skyworks SKY85340-11
WLAN (2.4G)	B/G/N/AX
WLAN Antenna (int)	4* (shared with 5g)
Eithernet-phy (1Gbit)	Qualcomm (Atheros) AR8033-AL1A
Ethernet (1Gbit)	1*
Eithernet-phy (2.5Gbit)	Qualcomm QCA8081
Ethernet (2.5Gbit)	1*
Switch	Embedded in the SOC?
Serial	1.8v 8n1 (testpoints)
Modem System-On-Chip	Qualcomm 5G RG50xQ (Snapdragon X55 platform)
5G modem capability	5000Mbps down 900Mbps up
5G modem bands	N1/N3/N5/N7/N8/N20/N28/N38/N40/N41/N77/N78/N79
4G modem capability	4.5G LTE-Advanced Pro (Cat20 down 2Gbps) (Cat18 up 200Mbps)
4G modem FDD bands	B1/B3/B5/B7/B8/B18/B19/B20/B26/B28
4G modem TDD bands	B34/B38/B39/B40/B41/B42/B43
Modem antenna (int)	8* (5G/4G use)
Modem antenna (ext)	2* SMA connectors (5G/4G use)
SIM type	1* Nano SIM
Telephony	1* POTS RJ11
(see wiki for more info:)
https://openwrt.org/inbox/toh/tp-link/x80-5g_v1

        Notes:
Installation Instructions:

Between antennas 7 and 8 on the PCB with the RGB harness there are three test pads labelled TP1 TP2 and TP3 connections are as follows:
  |TP2|-- RX
  |TP1|-- TX
  |TP3|-- GND

RX requires an external pullup to operate somewhere around 5 K ohm but your luck may vary the Uart is 1.8v

Set a static IP and set up a tftpserver and terminal.
power the router and quickly type the magic string “tpl” and press enter to break into u-boot
in the shell set the environment variables to enable tftp booting
setenv ipaddr (routerIP)
setenv serverip (server IP)
load you initramfs:
tftpboot 0x44000000 (serverIP):openwrt-qualcommax-ipq807x-tplink_x80-5g-initramfs-uImage.itb
boot your initramfs
bootm
upload your factory image to /tmp
format and install the factory image:
ubiformat /dev/mtd12 -y -f /tmp/openwrt-qualcommax-ipq807x-tplink_x80-5g-squashfs-factory.ubi

Note as this device swaps root partitions upon update your boot partition may be set as mtd13

Update script to mount factory tplink partition's for MAC recovery and device data.
Capture Labelmac from Factory_data partition.
Patch LAN from Labelmac.
Patch ART from Labelmac.
Set GPIO to make modem operational from boot.

GPIO fan tables work like the  stock device with three fan maps high active idle with a top fan speed of 6800 RPM.

High temp 70 deg speeds 6-8
Active temp 50 deg speeds 2-5
low temp 25 degree speed 0-1

Signed-off-by: Jonathan Brophy <professor_jonny@hotmail.com>