### PR TITLE
ramips:  TP-Link EC220-G5 v2: swap WLAN leds assignment

### DIFF
--- a/target/linux/ramips/dts/mt7620a_tplink_ec220-g5-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_ec220-g5-v2.dts
@@ -47,14 +47,14 @@
 			function = LED_FUNCTION_WLAN_2GHZ;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
+			linux,default-trigger = "phy1tpt";
 		};
 
 		led-5 {
 			function = LED_FUNCTION_WLAN_5GHZ;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led-6 {


### PR DESCRIPTION
Swap incorrect WLAN leds assignment between WLAN 2.4 and 5 GHz for TP-Link EC220-G5 v2

The correct ones are:
LED_FUNCTION_WLAN_2GHZ -> "phy1tpt"
LED_FUNCTION_WLAN_5GHZ -> "phy0tpt"

I also found the same setting in files created by another developer for version 19.07 on the website: https://github.com/anlix-io/openwrt/commit/5f6799fb3cfaee3a2c1093bacef72e27497b3355
