### PR TITLE
openssl: update to 3.0.15

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.0.14
-PKG_RELEASE:=2
+PKG_VERSION:=3.0.15
+PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_BUILD_PARALLEL:=1
@@ -19,12 +19,13 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	http://www.openssl.org/source/ \
 	http://www.openssl.org/source/old/$(PKG_BASE)/ \
+	https://github.com/openssl/openssl/releases/download/$(PKG_NAME)-$(PKG_VERSION)/ \
 	http://ftp.fi.muni.cz/pub/openssl/source/ \
 	http://ftp.fi.muni.cz/pub/openssl/source/old/$(PKG_BASE)/ \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/old/$(PKG_BASE)/
 
-PKG_HASH:=eeca035d4dd4e84fc25846d952da6297484afa0650a6f84c682e39df3a4123ca
+PKG_HASH:=23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
OpenSSL 3.0.15 is a security patch release. The most severe CVE fixed in this release is Moderate.

This release incorporates the following bug fixes and mitigations:

  * Fixed possible denial of service in X.509 name checks (CVE-2024-6119)

  * Fixed possible buffer overread in SSL_select_next_proto() (CVE-2024-5535)

compile && run tested 
  - ramips/mt7621: beeline smartbox turbo-plus, xiaomi mi router 3 pro
  - mediatek/mt7622: xiaomi redmi ax6s