### PR TITLE
base-files: add additional ucidef options for /etc/board.json

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -91,12 +91,12 @@ generate_static_network() {
 
 addr_offset=2
 generate_network() {
-	local ports device macaddr protocol type ipaddr netmask vlan
+	local ports device macaddr protocol type ipaddr netmask vlan force_link
 	local bridge=$2
 
 	json_select network
 		json_select "$1"
-			json_get_vars device macaddr metric protocol ipaddr netmask vlan
+			json_get_vars device macaddr metric protocol ipaddr netmask vlan force_link
 			json_get_values ports ports
 		json_select ..
 	json_select ..
@@ -174,6 +174,7 @@ generate_network() {
 				set network.$1.netmask='$netm'
 			EOF
 			[ -e /proc/sys/net/ipv6 ] && uci set network.$1.ip6assign='60'
+			[ -n "$force_link" ] && uci set network.$1.force_link="${force_link}"
 		;;
 
 		dhcp)

--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -340,6 +340,41 @@ generate_static_system() {
 				uci -q set "system.@system[-1].hostname=$hostname"
 			fi
 
+			local conloglevel
+			if json_get_var conloglevel conloglevel; then
+				uci -q set "system.@system[-1].conloglevel=$conloglevel"
+			fi
+
+			local ttylogin
+			if json_get_var ttylogin ttylogin; then
+				uci -q set "system.@system[-1].ttylogin=$ttylogin"
+			fi
+
+			local zonename
+			if json_get_var zonename zonename; then
+				uci -q set "system.@system[-1].zonename=$zonename"
+			fi
+
+			local timezone
+			if json_get_var timezone timezone; then
+				uci -q set "system.@system[-1].timezone=$timezone"
+			fi
+
+			local cronloglevel
+			if json_get_var cronloglevel cronloglevel; then
+				uci -q set "system.@system[-1].cronloglevel=$cronloglevel"
+			fi
+
+			local log_size
+			if json_get_var log_size log_size; then
+				uci -q set "system.@system[-1].log_size=$log_size"
+			fi
+
+			local log_file
+			if json_get_var log_file log_file; then
+				uci -q set "system.@system[-1].log_file=$log_file"
+			fi
+
 			local compat_version
 			if json_get_var compat_version compat_version; then
 				uci -q set "system.@system[-1].compat_version=$compat_version"

--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -91,12 +91,12 @@ generate_static_network() {
 
 addr_offset=2
 generate_network() {
-	local ports device macaddr protocol type ipaddr netmask vlan force_link
+	local ports device macaddr protocol type ipaddr netmask vlan force_link auto
 	local bridge=$2
 
 	json_select network
 		json_select "$1"
-			json_get_vars device macaddr metric protocol ipaddr netmask vlan force_link
+			json_get_vars device macaddr metric protocol ipaddr netmask vlan force_link auto
 			json_get_values ports ports
 		json_select ..
 	json_select ..
@@ -189,6 +189,7 @@ generate_network() {
 					set network.${1}6.device='$device'
 					set network.${1}6.proto='dhcpv6'
 				EOF
+				[ -n "$auto" ] && uci -q set network.${1}6.auto="${auto}"
 			}
 		;;
 
@@ -206,6 +207,7 @@ generate_network() {
 					set network.${1}6.device='@${1}'
 					set network.${1}6.proto='dhcpv6'
 				EOF
+				[ -n "$auto" ] && uci -q set network.${1}6.auto="${auto}"
 			}
 		;;
 
@@ -218,6 +220,8 @@ generate_network() {
 			EOF
 		;;
 	esac
+
+	[ -n "$auto" ] && uci -q set network.${1}.auto="${auto}"
 }
 
 generate_switch_vlans_ports() {

--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -642,8 +642,18 @@ ucidef_add_gpio_switch() {
 ucidef_set_hostname() {
 	local hostname="$1"
 
+	ucidef_set_system "hostname" "$hostname"
+}
+
+ucidef_set_system() {
 	json_select_object system
-		json_add_string hostname "$hostname"
+	while [ -n "$1" ]; do
+		local opt=$1; shift
+		local val=$1; shift
+
+		[ -n "$opt" -a -n "$val" ] || break
+			json_add_string "$opt" "$val"
+	done
 	json_select ..
 }
 

--- a/target/linux/lantiq/base-files/lib/functions/lantiq.sh
+++ b/target/linux/lantiq/base-files/lib/functions/lantiq.sh
@@ -14,5 +14,5 @@ lantiq_setup_dsl_helper() {
 		ucidef_add_adsl_modem "$annex" "/lib/firmware/adsl.bin"
 	fi
 
-	ucidef_set_interface_wan "dsl0" "pppoe"
+	ucidef_set_interface "wan" device "dsl0" protocol "pppoe" auto "0"
 }


### PR DESCRIPTION
The file '/etc/board.json' is used to create a uci default configuration during firstboot via [/bin/config_generate](https://github.com/openwrt/openwrt/blob/master/package/base-files/files/bin/config_generate) for `/etc/config/network` and `/etc/config/system` if this files does not exist. However, not all uci options can be configured. This PR adds missing options to customize the default configuration at first boot in '/etc/board.json'.

In my setup I want to set the uci option to [auto](https://openwrt.org/docs/guide-user/network/ucicheatsheet#section_interface) '0' so that it does start a connection via netifd, because no valid credentials have been entered yet for my DSL connection. I also don't want that the option [ttylogin](https://openwrt.org/docs/guide-user/base-system/system_configuration#system_section) is set default '0' so that  at firstboot no password is requested for my system. I want to set ttylogin to '1' so my default password must be entered to get a getty via serial tty.