### PR TITLE
mtd: fix compile warnings

### DIFF
--- a/package/utils/mtd-utils/patches/140-mtd-fix-compile-warnings.patch
+++ b/package/utils/mtd-utils/patches/140-mtd-fix-compile-warnings.patch
@@ -1,0 +1,11 @@
+--- a/include/libubigen.h
++++ b/include/libubigen.h
+@@ -26,6 +26,7 @@
+ #define __LIBUBIGEN_H__
+
+ #include <stdint.h>
++#include "ubi-media.h"
+
+ #ifdef __cplusplus
+ extern "C" {
+


### PR DESCRIPTION
ubi-mdeia.h defines 'struct ubi_vid_hdr'. It is used as parameter type of function 'ubigen_init_ec_hdr', which is declared in libubigen.h. ubiformat.c and liubigen.c uses this function. And they both have included ubi-mdeia.h and libubigen.h. However, mtdinfo.c includeds libubigen.h but not ubi-mdeia.h. This also happens to 'ubi_ec_hdr'. These issues lead to warnings:

```
In file included from ubi-utils/mtdinfo.c:34:
./include/libubigen.h:124:32: warning: 'struct ubi_ec_hdr' declared inside parameter list will not be visible outside of this definition or declaration
  124 |                         struct ubi_ec_hdr *hdr, long long ec);
      |                                ^~~~~~~~~~
./include/libubigen.h:140:33: warning: 'struct ubi_vid_hdr' declared inside parameter list will not be visible outside of this definition or declaration
  140 |                          struct ubi_vid_hdr *hdr, int lnum,
      |                                 ^~~~~~~~~~~
```

So include ubi-media.h in libubigen.h.
