### PR TITLE
hostapd: add support for SAE in PPSK option

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -659,12 +659,12 @@ hostapd_set_bss_options() {
 		sae|owe|eap2|eap192)
 			set_default ieee80211w 2
 			set_default sae_require_mfp 1
-			set_default sae_pwe 2
+			[ "$ppsk" -eq 0 ] && set_default sae_pwe 2
 		;;
 		psk-sae|eap-eap2)
 			set_default ieee80211w 1
 			set_default sae_require_mfp 1
-			set_default sae_pwe 2
+			[ "$ppsk" -eq 0 ] && set_default sae_pwe 2
 		;;
 	esac
 	[ -n "$sae_require_mfp" ] && append bss_conf "sae_require_mfp=$sae_require_mfp" "$N"
@@ -687,7 +687,7 @@ hostapd_set_bss_options() {
 		;;
 		psk|sae|psk-sae)
 			json_get_vars key wpa_psk_file
-			if [ "$auth_type" = "psk" ] && [ "$ppsk" -ne 0 ] ; then
+			if [ "$ppsk" -ne 0 ]; then
 				json_get_vars auth_secret auth_port
 				set_default auth_port 1812
 				json_for_each_item append_auth_server auth_server


### PR DESCRIPTION
This patch allows the use of SAE when using PPSK after
https://w1.fi/cgit/hostap/commit/?id=fcbdaae8a52e542705a651ee78b39b02935fda20
added support for it.

It also implements a fix so that this option works with SAE. The reason this
doesn't work out of the box is because OpenWRT deviates from hostapd defaults
by setting `sae_pwe` option to 2 which makes this mode not function properly
(results in every auth attempt being denied).

That issue was addressed by not overriding hostapd's default for the `sae_pwe`
option when the PPSK option is in use. This should be fine because hostapd's
test cases specifically test this mode with the default SAE parameters. See:
https://w1.fi/cgit/hostap/commit/?id=c34b35b54e81dbacd9dee513b74604c87f93f6a3
