### PR TITLE
mpc85xx: remove unneeded header

### DIFF
--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/br200-wp.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/br200-wp.c
@@ -28,7 +28,7 @@
 
 #include "mpc85xx.h"
 
-void __init br200_wp_pic_init(void)
+static void __init br200_wp_pic_init(void)
 {
 	struct mpic *mpic;
 

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/br200-wp.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/br200-wp.c
@@ -66,6 +66,5 @@ define_machine(br200_wp) {
 	.pcibios_fixup_phb      = fsl_pcibios_fixup_phb,
 #endif
 	.get_irq		= mpic_get_irq,
-	.calibrate_decr		= generic_calibrate_decr,
 	.progress		= udbg_progress,
 };

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/br200-wp.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/br200-wp.c
@@ -13,7 +13,6 @@
 #include <linux/kernel.h>
 #include <linux/delay.h>
 #include <linux/interrupt.h>
-#include <linux/of_platform.h>
 
 #include <asm/time.h>
 #include <asm/machdep.h>
@@ -57,19 +56,9 @@ static void __init br200_wp_setup_arch(void)
 
 machine_arch_initcall(br200_wp, mpc85xx_common_publish_devices);
 
-/*
- * Called very early, device-tree isn't unflattened
- */
-static int __init br200_wp_probe(void)
-{
-	if (of_machine_is_compatible("aerohive,br200-wp"))
-		return 1;
-	return 0;
-}
-
 define_machine(br200_wp) {
 	.name			= "P1020 RDB",
-	.probe			= br200_wp_probe,
+	.compatible		= "aerohive,br200-wp",
 	.setup_arch		= br200_wp_setup_arch,
 	.init_IRQ		= br200_wp_pic_init,
 #ifdef CONFIG_PCI

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/firebox_t10.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/firebox_t10.c
@@ -34,7 +34,7 @@
 
 #include "mpc85xx.h"
 
-void __init firebox_t10_pic_init(void)
+static void __init firebox_t10_pic_init(void)
 {
 	struct mpic *mpic;
 

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/firebox_t10.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/firebox_t10.c
@@ -71,6 +71,5 @@ define_machine(firebox_t10) {
 	.pcibios_fixup_phb      = fsl_pcibios_fixup_phb,
 #endif
 	.get_irq		= mpic_get_irq,
-	.calibrate_decr		= generic_calibrate_decr,
 	.progress		= udbg_progress,
 };

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/firebox_t10.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/firebox_t10.c
@@ -20,7 +20,6 @@
 #include <linux/kernel.h>
 #include <linux/delay.h>
 #include <linux/interrupt.h>
-#include <linux/of_platform.h>
 
 #include <asm/time.h>
 #include <asm/machdep.h>
@@ -62,19 +61,9 @@ static void __init firebox_t10_setup_arch(void)
 
 machine_arch_initcall(firebox_t10, mpc85xx_common_publish_devices);
 
-/*
- * Called very early, device-tree isn't unflattened
- */
-static int __init firebox_t10_probe(void)
-{
-	if (of_machine_is_compatible("watchguard,firebox-t10"))
-		return 1;
-	return 0;
-}
-
 define_machine(firebox_t10) {
 	.name			= "P1010 RDB",
-	.probe			= firebox_t10_probe,
+	.compatible		= "watchguard,firebox-t10",
 	.setup_arch		= firebox_t10_setup_arch,
 	.init_IRQ		= firebox_t10_pic_init,
 #ifdef CONFIG_PCI

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/hiveap-330.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/hiveap-330.c
@@ -33,7 +33,7 @@
 
 #include "mpc85xx.h"
 
-void __init hiveap_330_pic_init(void)
+static void __init hiveap_330_pic_init(void)
 {
 	struct mpic *mpic;
 

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/hiveap-330.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/hiveap-330.c
@@ -73,6 +73,5 @@ define_machine(hiveap_330) {
 	.pcibios_fixup_phb      = fsl_pcibios_fixup_phb,
 #endif
 	.get_irq		= mpic_get_irq,
-	.calibrate_decr		= generic_calibrate_decr,
 	.progress		= udbg_progress,
 };

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/hiveap-330.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/hiveap-330.c
@@ -18,7 +18,6 @@
 #include <linux/kernel.h>
 #include <linux/delay.h>
 #include <linux/interrupt.h>
-#include <linux/of_platform.h>
 
 #include <asm/time.h>
 #include <asm/machdep.h>
@@ -64,19 +63,9 @@ static void __init hiveap_330_setup_arch(void)
 
 machine_arch_initcall(hiveap_330, mpc85xx_common_publish_devices);
 
-/*
- * Called very early, device-tree isn't unflattened
- */
-static int __init hiveap_330_probe(void)
-{
-	if (of_machine_is_compatible("aerohive,hiveap-330"))
-		return 1;
-	return 0;
-}
-
 define_machine(hiveap_330) {
 	.name			= "P1020 RDB",
-	.probe			= hiveap_330_probe,
+	.compatible		= "aerohive,hiveap-330",
 	.setup_arch		= hiveap_330_setup_arch,
 	.init_IRQ		= hiveap_330_pic_init,
 #ifdef CONFIG_PCI

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/msm460.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/msm460.c
@@ -75,6 +75,5 @@ define_machine(msm) {
 	.pcibios_fixup_phb      = fsl_pcibios_fixup_phb,
 #endif
 	.get_irq		= mpic_get_irq,
-	.calibrate_decr		= generic_calibrate_decr,
 	.progress		= udbg_progress,
 };

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/msm460.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/msm460.c
@@ -20,7 +20,6 @@
 #include <linux/kernel.h>
 #include <linux/delay.h>
 #include <linux/interrupt.h>
-#include <linux/of_platform.h>
 
 #include <asm/time.h>
 #include <asm/machdep.h>
@@ -66,19 +65,9 @@ static void __init msm_setup_arch(void)
 
 machine_arch_initcall(msm, mpc85xx_common_publish_devices);
 
-/*
- * Called very early, device-tree isn't unflattened
- */
-static int __init msm_probe(void)
-{
-	if (of_machine_is_compatible("hpe,msm460"))
-		return 1;
-	return 0;
-}
-
 define_machine(msm) {
 	.name			= "P1020 RDB",
-	.probe			= msm_probe,
+	.compatible		= "hpe,msm460",
 	.setup_arch		= msm_setup_arch,
 	.init_IRQ		= msm_pic_init,
 #ifdef CONFIG_PCI

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/msm460.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/msm460.c
@@ -35,7 +35,7 @@
 
 #include "mpc85xx.h"
 
-void __init msm_pic_init(void)
+static void __init msm_pic_init(void)
 {
 	struct mpic *mpic;
 

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/panda.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/panda.c
@@ -75,6 +75,5 @@ define_machine(panda) {
 	.pcibios_fixup_phb      = fsl_pcibios_fixup_phb,
 #endif
 	.get_irq		= mpic_get_irq,
-	.calibrate_decr		= generic_calibrate_decr,
 	.progress		= udbg_progress,
 };

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/panda.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/panda.c
@@ -20,7 +20,6 @@
 #include <linux/kernel.h>
 #include <linux/delay.h>
 #include <linux/interrupt.h>
-#include <linux/of_platform.h>
 
 #include <asm/time.h>
 #include <asm/machdep.h>
@@ -66,19 +65,9 @@ static void __init panda_setup_arch(void)
 
 machine_arch_initcall(panda, mpc85xx_common_publish_devices);
 
-/*
- * Called very early, device-tree isn't unflattened
- */
-static int __init panda_probe(void)
-{
-	if (of_machine_is_compatible("ocedo,panda"))
-		return 1;
-	return 0;
-}
-
 define_machine(panda) {
 	.name			= "P1020 RDB",
-	.probe			= panda_probe,
+	.compatible		= "ocedo,panda",
 	.setup_arch		= panda_setup_arch,
 	.init_IRQ		= panda_pic_init,
 #ifdef CONFIG_PCI

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/panda.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/panda.c
@@ -35,7 +35,7 @@
 
 #include "mpc85xx.h"
 
-void __init panda_pic_init(void)
+static void __init panda_pic_init(void)
 {
 	struct mpic *mpic;
 

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/red15w_rev1.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/red15w_rev1.c
@@ -20,7 +20,6 @@
 #include <linux/kernel.h>
 #include <linux/delay.h>
 #include <linux/interrupt.h>
-#include <linux/of_platform.h>
 
 #include <asm/time.h>
 #include <asm/machdep.h>
@@ -62,19 +61,9 @@ static void __init red_15w_rev1_setup_arch(void)
 
 machine_arch_initcall(red_15w_rev1, mpc85xx_common_publish_devices);
 
-/*
- * Called very early, device-tree isn't unflattened
- */
-static int __init red_15w_rev1_probe(void)
-{
-	if (of_machine_is_compatible("sophos,red-15w-rev1"))
-		return 1;
-	return 0;
-}
-
 define_machine(red_15w_rev1) {
 	.name			= "P1010 RDB",
-	.probe			= red_15w_rev1_probe,
+	.compatible		= "sophos,red-15w-rev1",
 	.setup_arch		= red_15w_rev1_setup_arch,
 	.init_IRQ		= red_15w_rev1_pic_init,
 #ifdef CONFIG_PCI

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/red15w_rev1.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/red15w_rev1.c
@@ -34,7 +34,7 @@
 
 #include "mpc85xx.h"
 
-void __init red_15w_rev1_pic_init(void)
+static void __init red_15w_rev1_pic_init(void)
 {
 	struct mpic *mpic;
 

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/red15w_rev1.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/red15w_rev1.c
@@ -71,6 +71,5 @@ define_machine(red_15w_rev1) {
 	.pcibios_fixup_phb      = fsl_pcibios_fixup_phb,
 #endif
 	.get_irq		= mpic_get_irq,
-	.calibrate_decr		= generic_calibrate_decr,
 	.progress		= udbg_progress,
 };

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/tl_wdr4900_v1.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/tl_wdr4900_v1.c
@@ -18,7 +18,6 @@
 #include <linux/kernel.h>
 #include <linux/delay.h>
 #include <linux/interrupt.h>
-#include <linux/of_platform.h>
 
 #include <asm/time.h>
 #include <asm/machdep.h>
@@ -59,19 +58,9 @@ static void __init tl_wdr4900_v1_setup_arch(void)
 
 machine_arch_initcall(tl_wdr4900_v1, mpc85xx_common_publish_devices);
 
-/*
- * Called very early, device-tree isn't unflattened
- */
-static int __init tl_wdr4900_v1_probe(void)
-{
-	if (of_machine_is_compatible("tplink,tl-wdr4900-v1"))
-		return 1;
-	return 0;
-}
-
 define_machine(tl_wdr4900_v1) {
 	.name			= "Freescale P1014",
-	.probe			= tl_wdr4900_v1_probe,
+	.compatible		= "tplink,tl-wdr4900-v1",
 	.setup_arch		= tl_wdr4900_v1_setup_arch,
 	.init_IRQ		= tl_wdr4900_v1_pic_init,
 #ifdef CONFIG_PCI

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/tl_wdr4900_v1.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/tl_wdr4900_v1.c
@@ -16,12 +16,9 @@
 
 #include <linux/stddef.h>
 #include <linux/kernel.h>
-#include <linux/pci.h>
 #include <linux/delay.h>
 #include <linux/interrupt.h>
 #include <linux/of_platform.h>
-#include <linux/ath9k_platform.h>
-#include <linux/leds.h>
 
 #include <asm/time.h>
 #include <asm/machdep.h>

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/tl_wdr4900_v1.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/tl_wdr4900_v1.c
@@ -67,6 +67,5 @@ define_machine(tl_wdr4900_v1) {
 	.pcibios_fixup_bus	= fsl_pcibios_fixup_bus,
 #endif
 	.get_irq		= mpic_get_irq,
-	.calibrate_decr		= generic_calibrate_decr,
 	.progress		= udbg_progress,
 };

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/tl_wdr4900_v1.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/tl_wdr4900_v1.c
@@ -32,7 +32,7 @@
 
 #include "mpc85xx.h"
 
-void __init tl_wdr4900_v1_pic_init(void)
+static void __init tl_wdr4900_v1_pic_init(void)
 {
 	struct mpic *mpic = mpic_alloc(NULL, 0, MPIC_BIG_ENDIAN |
 	  MPIC_SINGLE_DEST_CPU,

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3710i.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3710i.c
@@ -35,7 +35,7 @@
 
 #include "mpc85xx.h"
 
-void __init ws_ap3710i_pic_init(void)
+static void __init ws_ap3710i_pic_init(void)
 {
 	struct mpic *mpic;
 

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3710i.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3710i.c
@@ -20,7 +20,6 @@
 #include <linux/kernel.h>
 #include <linux/delay.h>
 #include <linux/interrupt.h>
-#include <linux/of_platform.h>
 
 #include <asm/time.h>
 #include <asm/machdep.h>
@@ -66,19 +65,9 @@ static void __init ws_ap3710i_setup_arch(void)
 
 machine_arch_initcall(ws_ap3710i, mpc85xx_common_publish_devices);
 
-/*
- * Called very early, device-tree isn't unflattened
- */
-static int __init ws_ap3710i_probe(void)
-{
-	if (of_machine_is_compatible("enterasys,ws-ap3710i"))
-		return 1;
-	return 0;
-}
-
 define_machine(ws_ap3710i) {
 	.name			= "P1020 RDB",
-	.probe			= ws_ap3710i_probe,
+	.compatible		= "enterasys,ws-ap3710i",
 	.setup_arch		= ws_ap3710i_setup_arch,
 	.init_IRQ		= ws_ap3710i_pic_init,
 #ifdef CONFIG_PCI

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3710i.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3710i.c
@@ -75,6 +75,5 @@ define_machine(ws_ap3710i) {
 	.pcibios_fixup_phb      = fsl_pcibios_fixup_phb,
 #endif
 	.get_irq		= mpic_get_irq,
-	.calibrate_decr		= generic_calibrate_decr,
 	.progress		= udbg_progress,
 };

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3715i.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3715i.c
@@ -34,7 +34,7 @@
 
 #include "mpc85xx.h"
 
-void __init wsap3715i_pic_init(void)
+static void __init wsap3715i_pic_init(void)
 {
 	struct mpic *mpic;
 

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3715i.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3715i.c
@@ -20,7 +20,6 @@
 #include <linux/kernel.h>
 #include <linux/delay.h>
 #include <linux/interrupt.h>
-#include <linux/of_platform.h>
 
 #include <asm/time.h>
 #include <asm/machdep.h>
@@ -62,19 +61,9 @@ static void __init wsap3715i_setup_arch(void)
 
 machine_arch_initcall(wsap3715i, mpc85xx_common_publish_devices);
 
-/*
- * Called very early, device-tree isn't unflattened
- */
-static int __init wsap3715i_probe(void)
-{
-	if (of_machine_is_compatible("enterasys,ws-ap3715i"))
-		return 1;
-	return 0;
-}
-
 define_machine(wsap3715i) {
 	.name			= "P1010 RDB",
-	.probe			= wsap3715i_probe,
+	.compatible		= "enterasys,ws-ap3715i",
 	.setup_arch		= wsap3715i_setup_arch,
 	.init_IRQ		= wsap3715i_pic_init,
 #ifdef CONFIG_PCI

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3715i.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3715i.c
@@ -71,6 +71,5 @@ define_machine(wsap3715i) {
 	.pcibios_fixup_phb      = fsl_pcibios_fixup_phb,
 #endif
 	.get_irq		= mpic_get_irq,
-	.calibrate_decr		= generic_calibrate_decr,
 	.progress		= udbg_progress,
 };

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3825i.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3825i.c
@@ -20,7 +20,6 @@
 #include <linux/kernel.h>
 #include <linux/delay.h>
 #include <linux/interrupt.h>
-#include <linux/of_platform.h>
 
 #include <asm/time.h>
 #include <asm/machdep.h>
@@ -66,19 +65,9 @@ static void __init ws_ap3825i_setup_arch(void)
 
 machine_arch_initcall(ws_ap3825i, mpc85xx_common_publish_devices);
 
-/*
- * Called very early, device-tree isn't unflattened
- */
-static int __init ws_ap3825i_probe(void)
-{
-	if (of_machine_is_compatible("extreme-networks,ws-ap3825i"))
-		return 1;
-	return 0;
-}
-
 define_machine(ws_ap3825i) {
 	.name			= "P1020 RDB",
-	.probe			= ws_ap3825i_probe,
+	.compatible		= "extreme-networks,ws-ap3825i",
 	.setup_arch		= ws_ap3825i_setup_arch,
 	.init_IRQ		= ws_ap3825i_pic_init,
 #ifdef CONFIG_PCI

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3825i.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3825i.c
@@ -35,7 +35,7 @@
 
 #include "mpc85xx.h"
 
-void __init ws_ap3825i_pic_init(void)
+static void __init ws_ap3825i_pic_init(void)
 {
 	struct mpic *mpic;
 

--- a/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3825i.c
+++ b/target/linux/mpc85xx/files/arch/powerpc/platforms/85xx/ws-ap3825i.c
@@ -75,6 +75,5 @@ define_machine(ws_ap3825i) {
 	.pcibios_fixup_phb      = fsl_pcibios_fixup_phb,
 #endif
 	.get_irq		= mpic_get_irq,
-	.calibrate_decr		= generic_calibrate_decr,
 	.progress		= udbg_progress,
 };


### PR DESCRIPTION
949e1a0856c4a04ac4a3fee1bd4a0cc69ac187c5 moved this code to DTS. Not needed anymore.

@CHKDSK88 @robimarko 