### PR TITLE
ath79: gpio-latch-mikrotik: use dev_err_probe

### DIFF
--- a/target/linux/ath79/files/drivers/gpio/gpio-latch-mikrotik.c
+++ b/target/linux/ath79/files/drivers/gpio/gpio-latch-mikrotik.c
@@ -155,17 +155,7 @@ static int gpio_latch_probe(struct platform_device *pdev)
 	gc->direction_output = gpio_latch_direction_output;
 	gc->fwnode = fwnode;
 
-	platform_set_drvdata(pdev, glc);
-
-	return gpiochip_add(&glc->gc);
-}
-
-static int gpio_latch_remove(struct platform_device *pdev)
-{
-	struct gpio_latch_chip *glc = platform_get_drvdata(pdev);
-
-	gpiochip_remove(&glc->gc);
-	return 0;
+	return devm_gpiochip_add_data(dev, gc, glc);
 }
 
 static const struct of_device_id gpio_latch_match[] = {
@@ -177,7 +167,6 @@ MODULE_DEVICE_TABLE(of, gpio_latch_match);
 
 static struct platform_driver gpio_latch_driver = {
 	.probe = gpio_latch_probe,
-	.remove = gpio_latch_remove,
 	.driver = {
 		.name = GPIO_LATCH_DRIVER_NAME,
 		.owner = THIS_MODULE,

--- a/target/linux/ath79/files/drivers/gpio/gpio-latch-mikrotik.c
+++ b/target/linux/ath79/files/drivers/gpio/gpio-latch-mikrotik.c
@@ -110,7 +110,6 @@ static int gpio_latch_probe(struct platform_device *pdev)
 	struct gpio_latch_chip *glc;
 	struct gpio_chip *gc;
 	struct device *dev = &pdev->dev;
-	struct fwnode_handle *fwnode = dev->fwnode;
 	int i, n;
 
 	glc = devm_kzalloc(dev, sizeof(*glc), GFP_KERNEL);
@@ -147,13 +146,13 @@ static int gpio_latch_probe(struct platform_device *pdev)
 
 	gc = &glc->gc;
 	gc->label = GPIO_LATCH_DRIVER_NAME;
+	gc->parent = dev;
 	gc->can_sleep = true;
 	gc->base = -1;
 	gc->ngpio = GPIO_LATCH_LINES;
 	gc->get = gpio_latch_get;
 	gc->set = gpio_latch_set;
 	gc->direction_output = gpio_latch_direction_output;
-	gc->fwnode = fwnode;
 
 	return devm_gpiochip_add_data(dev, gc, glc);
 }


### PR DESCRIPTION
It automatically adds the error code at the end of the message. It also deals with -EPROBE_DEFER automatically (doesn't output). Simpler code.