### PR TITLE
dnsmasq: pass environment variables to hotplug

### DIFF
--- a/package/network/services/dnsmasq/files/dhcp-script.sh
+++ b/package/network/services/dnsmasq/files/dhcp-script.sh
@@ -8,6 +8,15 @@ json_init
 json_add_array env
 hotplugobj=""
 
+oldIFS=$IFS
+IFS=$'\n'
+for var in $(env); do
+	if [ "${var}" != "${var#DNSMASQ_}" ]; then
+		json_add_string "" "${var%%=*}=${var#*=}"
+	fi
+done
+IFS=$oldIFS
+
 case "$1" in
 	add | del | old | arp-add | arp-del)
 		json_add_string "" "MACADDR=$2"

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -19,7 +19,7 @@ BASEDHCPSTAMPFILE="/var/run/dnsmasq"
 DHCPBOGUSHOSTNAMEFILE="/usr/share/dnsmasq/dhcpbogushostname.conf"
 RFC6761FILE="/usr/share/dnsmasq/rfc6761.conf"
 DHCPSCRIPT="/usr/lib/dnsmasq/dhcp-script.sh"
-DHCPSCRIPT_DEPENDS="/usr/share/libubox/jshn.sh /usr/bin/jshn /bin/ubus"
+DHCPSCRIPT_DEPENDS="/usr/share/libubox/jshn.sh /usr/bin/jshn /bin/ubus /usr/bin/env"
 
 DNSMASQ_DHCP_VER=4
 


### PR DESCRIPTION
dnsmasq passes a limited amount of information via DHCP script arguments. Much more information is available through environment variables starting with DNSMASQ_, such as DNSMASQ_INTERFACE. However, when the dhcp-script builds its JSON environment and passes it to hotplug, all of this information is discarded since it is not copied to the JSON environment.

Personally, I have a custom-made set of DDNS scripts and rely on environment variables such as DNSMASQ_INTERFACE in order to determine which DNS zones to update. So, not being able to access these variables was detrimental to me. I patched in a quick copy of all DNSMASQ_ variables to the JSON environment so that they can be used in hotplug scripts. In order to do so I also copied /usr/bin/env into dnsmasq's chroot jail.