### PR TITLE
dnsmasq: fix truncated reponse handling

### DIFF
--- a/package/network/services/dnsmasq/patches/300-Fix-truncated-response-handling.patch
+++ b/package/network/services/dnsmasq/patches/300-Fix-truncated-response-handling.patch
@@ -1,0 +1,16 @@
+--- a/src/forward.c
++++ b/src/forward.c
+@@ -782,13 +782,6 @@
+ 	server->flags |= SERV_WARNED_RECURSIVE;
+     }  
+ 
+-  if (header->hb3 & HB3_TC)
+-    {
+-      log_query(F_UPSTREAM, NULL, NULL, "truncated", 0);
+-      header->ancount = htons(0);
+-      header->nscount = htons(0);
+-      header->arcount = htons(0);
+-    }
+ 
+   if  (!(header->hb3 & HB3_TC) && (!bogusanswer || (header->hb4 & HB4_CD)))
+     {


### PR DESCRIPTION
this seems to be a regression in dnsmasq version 2.90.

if a dns reponse with TC bit set is received, then it should be forwarded as is instead of dropping its answers.

this commit fixes the above described behaviour.

test details:
this was caught in CDrouter run of suite dns-rfc5625.tcl details of this suite are available at:
https://support.qacafe.com/cdrouter/test-summary/cdrouter-test-summary/#dns-rfc5625tcl

post this commit the test dns_rfc5625_13 passes since the response is a valid one.
