### PR TITLE
ramips: add support for Wi-CAT-GL

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -108,7 +108,8 @@ ubnt,edgerouter-x-sfp)
 	;;
 snr,snr-cpe-me1|\
 snr,snr-cpe-me2-sfp|\
-snr,cpe-w4n-mt)
+snr,cpe-w4n-mt|\
+synertau,wi-cat-gl)
 	idx="$(find_mtd_index uboot-env)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x1000"

--- a/target/linux/ramips/dts/mt7621_synertau_wi-cat-gl.dts
+++ b/target/linux/ramips/dts/mt7621_synertau_wi-cat-gl.dts
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "synertau,wi-cat-gl", "mediatek,mt7621-soc";
+	model = "Synertau Wi-CAT-GL Chimera (Химера)";
+
+/* 	aliases {
+		label-mac-device = &gmac1; // Проверить что на стикере
+
+		led-boot = &led_system;
+		led-failsafe = &led_wps;
+		led-running = &led_system;
+		led-upgrade = &led_wps;
+	}; */
+
+/* 	leds {  // Проверить
+		compatible = "gpio-leds";
+
+		led_system: led-0 { // System
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>; // [JTAG] JTDO
+		};
+
+		led_wps: led-1 { // WPS
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>; // [JTAG] JTCLK
+		};
+
+		led-1 { // WAN
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>; // [JTAG] JTCLK
+		};
+	}; */
+
+/* 	keys {
+		compatible = "gpio-keys";
+
+		reset {  // Проверить
+			label = "Reset Button";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>; // [JTAG] JTDI
+			linux,code = <KEY_RESTART>;
+		};
+
+		reset {  // Проверить SMART key
+			label = "SMART Button";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>; // [JTAG] JTDI
+			linux,code = <KEY_RESTART>;
+		};
+	}; */
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>; // Проверить
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_e006>; // Проверить
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy4 { // ???
+	/delete-property/ interrupts;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 { // MT7603EN
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 { // MT7613BEN
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 { // W25Q128FV
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <44000000>; // 44 MHz
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "Factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout"; // Проверить
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+
+					macaddr_factory_e000: macaddr@e000 {
+						reg = <0xe000 0x6>;
+					};
+
+					macaddr_factory_e006: macaddr@e006 {
+						reg = <0xe006 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+
+			partition@30001 { // Проверить
+				label = "uboot-env";
+				reg = <0x30000 0x1000>;
+			};
+		};
+	};
+};
+
+/* &state_default { // Проверить
+	gpio {
+		groups = "i2c", "jtag";
+		function = "gpio";
+	};
+}; */
+
+&switch0 {  // Проверить
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2361,6 +2361,17 @@ define Device/storylink_sap-g3200u3
 endef
 TARGET_DEVICES += storylink_sap-g3200u3
 
+define Device/synertau_wi-cat-gl
+	$(Device/dsa-migration)
+	$(Device/uimage-lzma-loader)
+	IMAGE_SIZE := 15040k
+	DEVICE_VENDOR := Synertau
+	DEVICE_MODEL := Wi-CAT-GL
+	UIMAGE_NAME := $$(DEVICE_MODEL)
+	DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
+endef
+TARGET_DEVICES += synertau_wi-cat-gl
+
 define Device/telco-electronics_x1
   $(Device/dsa-migration)
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -194,6 +194,9 @@ oraybox,x3a)
 snr,snr-cpe-me1)
 	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1" "usb2-port1"
 	;;
+synertau,wi-cat-gl)
+	ucidef_set_led_netdev "wan" "WAN link" "red:status" "wan"
+	;;
 tplink,archer-a6-v3|\
 tplink,archer-ax23-v1|\
 tplink,archer-c6-v3|\


### PR DESCRIPTION
Wi-CAT-GL Chimera [(Химера)](https://synertau.ru/wp-content/uploads/datasheet_wi-cat_himera.pdf) is a wireless Wi-Fi 802.11ac router manufactured by Synertau/Wireless CAT company.
```
Specification:
    - SoC           : MediaTek MT7621DA
    - RAM           : DDR3 128 MiB
    - Flash         : SPI-NOR 16 MiB (GD25Q128CSIG)
    - WLAN          : 2.4 GHz (MediaTek MT7603EN)
                      5 GHz (MediaTek MT7613BEN)
    - Ethernet      : 10/100/1000 Mbps x5
      - Switch      : MediaTek MT7530 (in SoC)
    - UART          : through-hole on PCB
      - [J4] 3.3V, RX, TX, GND (57600n8)
    - Power         : 12 VDC, 1 A
```
- [ ] GPIO LED
- [ ] GPIO Button
- [ ] Correct order of Ethernet interfaces
- [ ] Work MT7603EN
- [ ] Work MT7613BEN
- [ ] U-boot Env
- [ ] MACs interfaces
- [ ] Flash via web
```
Flash instruction via TFTP:
    1. Boot Wi-CAT-GL to recovery mode
        (hold the reset button while power on)
    2. Send firmware via TFTP client:
       TFTP Server address: 192.168.1.1
       TFTP Client address: 192.168.1.131
    3. Wait ~120 seconds to complete flashing
    4. Do sysupgrade using web-interface
```