### PR TITLE
[23.05]: mbedtls: Update to 2.28.9

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=2.28.8
+PKG_VERSION:=2.28.9
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ARMmbed/mbedtls/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=4fef7de0d8d542510d726d643350acb3cdb9dc76ad45611b59c9aa08372b4213
+PKG_HASH:=e4dbcf86a4fb31506482888560f02b161e0ecfb82fee0643abcfc86abee5817e
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=gpl-2.0.txt

--- a/package/libs/mbedtls/patches/100-x509-crt-verify-SAN-iPAddress.patch
+++ b/package/libs/mbedtls/patches/100-x509-crt-verify-SAN-iPAddress.patch
@@ -22,7 +22,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
   *                 If the verification couldn't be completed, the flag value is
 --- a/library/x509_crt.c
 +++ b/library/x509_crt.c
-@@ -45,6 +45,10 @@
+@@ -46,6 +46,10 @@
  
  #if defined(MBEDTLS_HAVE_TIME)
  #if defined(_WIN32) && !defined(EFIX64) && !defined(EFI32)
@@ -33,7 +33,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
  #include <windows.h>
  #else
  #include <time.h>
-@@ -2990,6 +2994,61 @@ find_parent:
+@@ -2991,6 +2995,61 @@ find_parent:
      }
  }
  
@@ -95,7 +95,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
  /*
   * Check for CN match
   */
-@@ -3010,24 +3069,51 @@ static int x509_crt_check_cn(const mbedt
+@@ -3011,24 +3070,51 @@ static int x509_crt_check_cn(const mbedt
      return -1;
  }
  
@@ -158,7 +158,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
  }
  
  /*
-@@ -3038,31 +3124,23 @@ static void x509_crt_verify_name(const m
+@@ -3039,31 +3125,23 @@ static void x509_crt_verify_name(const m
                                   uint32_t *flags)
  {
      const mbedtls_x509_name *name;


### PR DESCRIPTION
This contains a fix for:
CVE-2024-45157:
Unlike previously documented, enabling MBEDTLS_PSA_HMAC_DRBG_MD_TYPE does not cause the PSA subsystem to use HMAC_DRBG: it uses HMAC_DRBG only when MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG and MBEDTLS_CTR_DRBG_C are disabled.