### PR TITLE
mbedtls: update to 3.6.1

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,17 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=3.6.0
+PKG_VERSION:=3.6.1
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL=https://github.com/Mbed-TLS/mbedtls.git
-PKG_SOURCE_VERSION:=2ca6c285a0dd3f33982dd57299012dacab1ff206
-PKG_MIRROR_HASH:=a684012126590b4e0b6ab41e244cc2af0d2bcfc4b6c94bf42fc37d2d08f0553e
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL=https://github.com/Mbed-TLS/$(PKG_NAME)/releases/download/$(PKG_NAME)-$(PKG_VERSION)
+PKG_HASH:=fc8bef0991b43629b7e5319de6f34f13359011105e08e3e16eed3a9fe6ffd3a3
 
 PKG_LICENSE:=GPL-2.0-or-later
-PKG_LICENSE_FILES:=gpl-2.0.txt
+PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:arm:mbed_tls
 
 MBEDTLS_BUILD_OPTS_CURVES= \
@@ -88,7 +87,7 @@ include $(INCLUDE_DIR)/cmake.mk
 
 define Package/mbedtls/Default
   TITLE:=Embedded SSL
-  URL:=https://tls.mbed.org
+  URL:=https://www.trustedfirmware.org/projects/mbed-tls/
 endef
 
 define Package/mbedtls/Default/description


### PR DESCRIPTION
- This release fixes CVE-2024-45157, CVE-2024-45158, CVE-2024-45159
- Use official release archive instead of git mirror
- Update website url

Compile tested: mvebu FG-50E
