### PR TITLE
tools/expat: update to 2.6.3

### DIFF
--- a/tools/expat/Makefile
+++ b/tools/expat/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
 PKG_CPE_ID:=cpe:/a:libexpat:libexpat
-PKG_VERSION:=2.6.2
+PKG_VERSION:=2.6.3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=d4cf38d26e21a56654ffe4acd9cd5481164619626802328506a2869afab29ab3
+PKG_HASH:=17aa6cfc5c4c219c09287abfc10bc13f0c06f30bb654b28bfe6f567ca646eb79
 PKG_SOURCE_URL:=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$(PKG_VERSION))
 
 HOST_BUILD_PARALLEL:=1


### PR DESCRIPTION
This release fixes CVE-2024-45490, CVE-2024-45491 and CVE-2024-45492.

Changelog:
https://github.com/libexpat/libexpat/blob/R_2_6_3/expat/Changes

Compile tested: mvebu/FG-50E