### PR TITLE
kernel: r8168: ignore the rss rxnfc log

### DIFF
--- a/package/kernel/r8168/Makefile
+++ b/package/kernel/r8168/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8168
 PKG_VERSION:=8.053.00
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8168/releases/download/$(PKG_VERSION)

--- a/package/kernel/r8168/patches/100-r8168_rss-silence-rxnfc-log.patch
+++ b/package/kernel/r8168/patches/100-r8168_rss-silence-rxnfc-log.patch
@@ -1,0 +1,11 @@
+--- a/src/r8168_rss.c
++++ b/src/r8168_rss.c
+@@ -80,7 +80,7 @@ int rtl8168_get_rxnfc(struct net_device *dev, struct ethtool_rxnfc *cmd,
+         struct rtl8168_private *tp = netdev_priv(dev);
+         int ret = -EOPNOTSUPP;
+ 
+-        netif_info(tp, drv, tp->dev, "rss get rxnfc\n");
++        netif_dbg(tp, drv, tp->dev, "rss get rxnfc\n");
+ 
+         if (!(dev->features & NETIF_F_RXHASH))
+                 return ret;


### PR DESCRIPTION
refer to: https://github.com/openwrt/openwrt/commit/8d9893ff34242f887f40ca271a39e4c67c87b88d

The dmesg log output is filled with `eth1: rss get rxnfc`, just ignore this message.