### PR TITLE
ramips: add support for ELECOM WMC-X1800GST/WSC-X1800GS

### DIFF
--- a/target/linux/ramips/dts/mt7621_elecom_wmc-x1800gst.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wmc-x1800gst.dts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_elecom_wxc-x1800gsx.dtsi"
+
+/ {
+	compatible = "elecom,wmc-x1800gst", "mediatek,mt7621-soc";
+	model = "ELECOM WMC-X1800GST";
+
+	aliases {
+		label-mac-device = &gmac1;
+	};
+};
+
+&keys {
+	switch-ap {
+		label = "ap";
+		gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		linux,code = <BTN_0>;
+		linux,input-type = <EV_SW>;
+	};
+
+	switch-router {
+		label = "router";
+		gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		linux,code = <BTN_1>;
+		linux,input-type = <EV_SW>;
+	};
+
+	switch-extender {
+		label = "extender";
+		gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		linux,code = <BTN_2>;
+		linux,input-type = <EV_SW>;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_factory_3fffa>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy0 {
+	/delete-property/ interrupts;
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart3", "uart2", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&wifi {
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 1>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wsc-x1800gs.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wsc-x1800gs.dts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_elecom_wxc-x1800gsx.dtsi"
+
+/ {
+	compatible = "elecom,wsc-x1800gs", "mediatek,mt7621-soc";
+	model = "ELECOM WSC-X1800GS";
+
+	aliases {
+		label-mac-device = &wifi_band1;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "uart2", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&wifi {
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 (-1)>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	wifi_band1: band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 0>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wxc-x1800gsx.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wxc-x1800gsx.dtsi
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	chosen {
+		bootargs-override = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+		};
+
+		led-1 {
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led_power_green: led-2 {
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		led-3 {
+			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		led-4 {
+			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+		};
+
+		led-5 {
+			gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+		};
+
+		led-6 {
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+		};
+
+		led-7 {
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_power_red: led-8 {
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
+		};
+	};
+
+	keys: keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		button-wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_3fff4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&nand {
+	status = "okay";
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				precal_factory_e10: precal@e10 {
+					reg = <0xe10 0x19c10>;
+				};
+
+				macaddr_factory_4: mac-address@4 {
+					compatible = "mac-base";
+					reg = <0x4 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+
+				macaddr_factory_3fff4: mac-address@3fff4 {
+					reg = <0x3fff4 0x6>;
+				};
+
+				macaddr_factory_3fffa: mac-address@3fffa {
+					reg = <0x3fffa 0x6>;
+				};
+			};
+		};
+
+		/* stock: "firmware" */
+		partition@180000 {
+			reg = <0x180000 0xf00000>;
+			label = "kernel";
+		};
+
+		partition@1080000 {
+			label = "user_data";
+			reg = <0x1080000 0x500000>;
+			read-only;
+		};
+
+		partition@1580000 {
+			label = "tm_pattern";
+			reg = <0x1580000 0x500000>;
+			read-only;
+		};
+
+		partition@1a80000 {
+			label = "tm_key";
+			reg = <0x1a80000 0x100000>;
+			read-only;
+		};
+
+		/* stock: (unused) */
+		partition@1b80000 {
+			label = "ubi";
+			reg = <0x1b80000 0x6480000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
+		mediatek,disable-radar-background;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart3", "uart2", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&uartlite {
+	pinctrl-0 = <&uart1_pins>;
+	pinctrl-names = "default";
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1315,6 +1315,24 @@ endif
 endef
 TARGET_DEVICES += elecom_wrc-x1800gs
 
+define Device/elecom_wsc-x1800gs
+  $(Device/nand)
+  DEVICE_VENDOR := ELECOM
+  DEVICE_MODEL := WSC-X1800GS
+  KERNEL_SIZE := 15360k
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  ARTIFACTS := initramfs-factory.bin
+  ARTIFACT/initramfs-factory.bin := append-image-stage initramfs-kernel.bin | \
+	check-size $$$$(KERNEL_SIZE) | elecom-wrc-gs-factory WMC-2LX 0.00 -N | \
+	append-string MT7621_ELECOM_WMC-2LX
+endif
+  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+endef
+TARGET_DEVICES += elecom_wsc-x1800gs
+
 define Device/etisalat_s3
   $(Device/sercomm_dxx)
   IMAGE_SIZE := 32768k

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1164,6 +1164,24 @@ define Device/elecom_wmc-s1267gs2
 endef
 TARGET_DEVICES += elecom_wmc-s1267gs2
 
+define Device/elecom_wmc-x1800gst
+  $(Device/nand)
+  DEVICE_VENDOR := ELECOM
+  DEVICE_MODEL := WMC-X1800GST
+  KERNEL_SIZE := 15360k
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  ARTIFACTS := initramfs-factory.bin
+  ARTIFACT/initramfs-factory.bin := append-image-stage initramfs-kernel.bin | \
+	check-size $$$$(KERNEL_SIZE) | elecom-wrc-gs-factory WMC-2LX 0.00 -N | \
+	append-string MT7621_ELECOM_WMC-2LX
+endif
+  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+endef
+TARGET_DEVICES += elecom_wmc-x1800gst
+
 define Device/elecom_wrc-1167ghbk2-s
   $(Device/dsa-migration)
   IMAGE_SIZE := 15488k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -78,6 +78,7 @@ ramips_setup_interfaces()
 	asiarf,ap7621-nv1|\
 	beeline,smartbox-flash|\
 	beeline,smartbox-giga|\
+	elecom,wmc-x1800gst|\
 	elecom,wrc-x1800gs|\
 	glinet,gl-mt1300|\
 	iodata,wn-deax1800gr|\

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -117,6 +117,9 @@ ramips_setup_interfaces()
 	zyxel,lte3301-plus)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
+	elecom,wsc-x1800gs)
+		ucidef_set_interface_lan "lan1 lan2"
+		;;
 	gnubee,gb-pc1)
 		ucidef_set_interface_lan "ethblack ethblue"
 		;;

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -91,6 +91,7 @@ platform_do_upgrade() {
 	dlink,dir-3060-a1|\
 	dlink,dir-853-a3|\
 	elecom,wmc-x1800gst|\
+	elecom,wsc-x1800gs|\
 	etisalat,s3|\
 	h3c,tx1800-plus|\
 	h3c,tx1801-plus|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -90,6 +90,7 @@ platform_do_upgrade() {
 	dlink,dir-3040-a1|\
 	dlink,dir-3060-a1|\
 	dlink,dir-853-a3|\
+	elecom,wmc-x1800gst|\
 	etisalat,s3|\
 	h3c,tx1800-plus|\
 	h3c,tx1801-plus|\


### PR DESCRIPTION
This patch series adds the following ELECOM devices:

- WMC-X1800GST (Mesh Router)
- WSC-X1800GS (Mesh Extender)