### PR TITLE
mediatek: reset boot flag variables on Xiaomi Redmi AX6S/3200

### DIFF
--- a/target/linux/mediatek/mt7622/base-files/etc/init.d/bootcount
+++ b/target/linux/mediatek/mt7622/base-files/etc/init.d/bootcount
@@ -15,5 +15,9 @@ boot() {
 	linksys,e8450)
 		mtd erase senv || true
 		;;
+	 xiaomi,redmi-router-ax6s)
+		fw_setenv flag_try_sys1_failed 0
+		fw_setenv flag_try_sys2_failed 0
+		;;
 	esac
 }


### PR DESCRIPTION
On Xiaomi Redmi AX6S/3200 after 6 reboots bootloader switches slots. Therefore the next boot tries from booting from the overwritten second slot and router has been soft-bricked. Workaround is to reset those try_sys counters to 0. So add this command to bootcount script

Fixes: https://github.com/openwrt/openwrt/issues/16347

Tested on my device