### PR TITLE
package: add kmod-led-group-multicolor

### DIFF
--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -22,6 +22,25 @@ endef
 
 $(eval $(call KernelPackage,leds-gpio))
 
+define KernelPackage/led-group-multicolor
+	 SUBMENU:=$(LEDS_MENU)
+	 TITLE:=LEDs group multi-color support
+	 KCONFIG:= \
+	     CONFIG_LEDS_CLASS_MULTICOLOR \
+	     CONFIG_LEDS_GROUP_MULTICOLOR
+	  FILES:=$(LINUX_DIR)/drivers/leds/rgb/leds-group-multicolor.ko
+	 AUTOLOAD:=$(call AutoProbe,led-group-multi-color)
+endef
+
+define KernelPackage/led-group-multi-color/description
+	 This option enables support for monochrome LEDs that are grouped
+	 into multicolor LEDs which is useful in the case where LEDs of
+	 different colors are physically grouped in a single multi-color LED
+	 and driven by a controller that does not have multi-color support.
+endef
+
+$(eval $(call KernelPackage,led-group-multi-color))
+
 LED_TRIGGER_DIR=$(LINUX_DIR)/drivers/leds/trigger
 
 define KernelPackage/ledtrig-activity


### PR DESCRIPTION
These drivers add suport for multicolour led's and support for combining several monochromatic LEDs into one multi-color
  LED using the multicolor LED class.
This driver is useful in the case where LEDs of
 different colors are physically grouped in a single multi-color LED

Example of use from shell:
```
echo 255 0 0 > /sys/class/leds/rgb:status/multi_intensity  (green)
echo 0 255 0 > /sys/class/leds/rgb:status/multi_intensity  (red)
echo 0 0 255 > /sys/class/leds/rgb:status/multi_intensity (blue)

```

you may simply append a line to /etc/rc.local the below will make the rgb:status led green:

`[[ -f /sys/class/leds/rgb:status/multi_intensity ]] && echo '255 0 0' > /sys/class/leds/rgb:status/multi_intensity`


Example config of dts:
 ```
	monochromatic-leds {
		compatible = "gpio-leds";

		led_system_green: green {
			gpios = <&tlmm 50 GPIO_ACTIVE_HIGH>; 
			color = <LED_COLOR_ID_GREEN>;
			function = LED_FUNCTION_STATUS;
		};

		led_system_red: red {
			gpios = <&tlmm 51 GPIO_ACTIVE_HIGH>;
			color = <LED_COLOR_ID_RED>;
			function = LED_FUNCTION_STATUS;
		};

		led_system_blue: blue {
			gpios = <&tlmm 52 GPIO_ACTIVE_HIGH>;
			color = <LED_COLOR_ID_BLUE>;
			function = LED_FUNCTION_STATUS;
		};
	};

	multicolor-led {
    compatible = "leds-group-multicolor";
		color = <LED_COLOR_ID_RGB>;
		function = LED_FUNCTION_STATUS;
		max-brightness = <256>;
		leds = <&led_system_green>,<&led_system_red>,<&led_system_blue>;
	};
```

Signed-off-by: Jonathan Brophy professor_jonny@hotmail.com

