### PR TITLE
ramips: mt7621: use lzma-loader for Sercomm NA502s

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2297,6 +2297,7 @@ TARGET_DEVICES += sercomm_na502
 
 define Device/sercomm_na502s
   $(Device/nand)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 20971520
   DEVICE_VENDOR := SERCOMM
   DEVICE_MODEL := NA502S


### PR DESCRIPTION
This fixes a well-known "LZMA ERROR 1" error on Sercomm NA502s, reported on the OpneWrt forum [0].

[0] https://forum.openwrt.org/t/206640