### PR TITLE
mediatek: add kmod-thermal for BPI-R4 device

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -377,7 +377,7 @@ define Device/bananapi_bpi-r4-common
   DEVICE_DTS_LOADADDR := 0x45f00000
   DEVICE_DTS_OVERLAY:= mt7988a-bananapi-bpi-r4-emmc mt7988a-bananapi-bpi-r4-rtc mt7988a-bananapi-bpi-r4-sd mt7988a-bananapi-bpi-r4-wifi-mt7996a
   DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-i2c-mux-pca954x kmod-eeprom-at24 kmod-mt7996-firmware kmod-mt7996-233-firmware \
+  DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-thermal kmod-i2c-mux-pca954x kmod-eeprom-at24 kmod-mt7996-firmware kmod-mt7996-233-firmware \
 		     kmod-rtc-pcf8563 kmod-sfp kmod-usb3 e2fsprogs f2fsck mkf2fs mt7988-wo-firmware
   IMAGES := sysupgrade.itb
   KERNEL_LOADADDR := 0x46000000


### PR DESCRIPTION
Without adding that kmod, build fails with an error:

    Collected errors:
     * pkg_hash_check_unresolved: cannot find dependency kmod-thermal for kmod-hwmon-pwmfan
     * pkg_hash_fetch_best_installation_candidate: Packages for kmod-hwmon-pwmfan found, but incompatible with the architectures configured * opkg_install_cmd: Cannot install package kmod-hwmon-pwmfan.

It is because, the kmod-thermal is marked as module:

    CONFIG_PACKAGE_kmod-thermal=m

After adding it as dependency to the BPI-R4 device, the problem disappear.