### PR TITLE
kernel: rework Initramfs locking logic

### DIFF
--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -48,42 +48,56 @@ endif
 ifeq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),y)
   ifeq ($(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE),y)
     define Kernel/SetInitramfs/PreConfigure
-	grep -v -e CONFIG_BLK_DEV_INITRD $(2)/.config.old > $(2)/.config
-	echo 'CONFIG_BLK_DEV_INITRD=y' >> $(2)/.config
-	echo 'CONFIG_INITRAMFS_SOURCE=""' >> $(2)/.config
+	{ \
+		grep -v -e CONFIG_BLK_DEV_INITRD $(2)/.config.old > $(2)/.config; \
+		echo 'CONFIG_BLK_DEV_INITRD=y' >> $(2)/.config; \
+		echo 'CONFIG_INITRAMFS_SOURCE=""' >> $(2)/.config; \
+	}
     endef
   else
-  ifeq ($(strip $(CONFIG_EXTERNAL_CPIO)),"")
-    define Kernel/SetInitramfs/PreConfigure
-	grep -v -e INITRAMFS -e CONFIG_RD_ -e CONFIG_BLK_DEV_INITRD $(2)/.config.old > $(2)/.config
-	echo 'CONFIG_BLK_DEV_INITRD=y' >> $(2)/.config
-	echo 'CONFIG_INITRAMFS_SOURCE="$(strip $(1) $(INITRAMFS_EXTRA_FILES))"' >> $(2)/.config
-    endef
-  else
-    define Kernel/SetInitramfs/PreConfigure
-	grep -v INITRAMFS $(2)/.config.old > $(2)/.config
-	echo 'CONFIG_INITRAMFS_SOURCE="$(call qstrip,$(CONFIG_EXTERNAL_CPIO))"' >> $(2)/.config
-    endef
+    ifeq ($(strip $(CONFIG_EXTERNAL_CPIO)),"")
+      define Kernel/SetInitramfs/PreConfigure
+	{ \
+		grep -v -e INITRAMFS -e CONFIG_RD_ -e CONFIG_BLK_DEV_INITRD $(2)/.config.old > $(2)/.config; \
+		echo 'CONFIG_BLK_DEV_INITRD=y' >> $(2)/.config; \
+		echo 'CONFIG_INITRAMFS_SOURCE="$(strip $(1) $(INITRAMFS_EXTRA_FILES))"' >> $(2)/.config; \
+	}
+      endef
+    else
+      define Kernel/SetInitramfs/PreConfigure
+	{ \
+		grep -v INITRAMFS $(2)/.config.old > $(2)/.config; \
+		echo 'CONFIG_INITRAMFS_SOURCE="$(call qstrip,$(CONFIG_EXTERNAL_CPIO))"' >> $(2)/.config; \
+	}
+      endef
+    endif
   endif
-endif
 
   define Kernel/SetInitramfs
-	rm -f $(2)/.config.prev
-	mv $(2)/.config $(2)/.config.old
-	$(call Kernel/SetInitramfs/PreConfigure,$(1),$(2))
-	echo "# CONFIG_INITRAMFS_PRESERVE_MTIME is not set" >> $(2)/.config
-  ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE),y)
-	echo 'CONFIG_INITRAMFS_ROOT_UID=$(shell id -u)' >> $(2)/.config
-	echo 'CONFIG_INITRAMFS_ROOT_GID=$(shell id -g)' >> $(2)/.config
-	echo "$(if $(CONFIG_TARGET_INITRAMFS_FORCE),CONFIG_INITRAMFS_FORCE=y,# CONFIG_INITRAMFS_FORCE is not set)" >> $(2)/.config
-  else
-	echo "# CONFIG_INITRAMFS_FORCE is not set" >> $(2)/.config
-  endif
-	echo "$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_NONE),CONFIG_INITRAMFS_COMPRESSION_NONE=y,# CONFIG_INITRAMFS_COMPRESSION_NONE is not set)" >> $(2)/.config
-	$(foreach ALGO,GZIP BZIP2 LZMA LZO XZ LZ4 ZSTD, \
-		$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_$(ALGO)),\
-			echo -e "CONFIG_INITRAMFS_COMPRESSION_$(ALGO)=y\nCONFIG_RD_$(ALGO)=y" >> $(2)/.config;,\
-			echo -e "# CONFIG_INITRAMFS_COMPRESSION_$(ALGO) is not set\n# CONFIG_RD_$(ALGO) is not set" >> $(2)/.config;))
+	{ \
+		rm -f $(2)/.config.prev; \
+		mv $(2)/.config $(2)/.config.old; \
+		$(call Kernel/SetInitramfs/PreConfigure,$(1),$(2)); \
+		echo "# CONFIG_INITRAMFS_PRESERVE_MTIME is not set" >> $(2)/.config; \
+		$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE),,echo "CONFIG_INITRAMFS_ROOT_UID=$(shell id -u)" >> $(2)/.config;) \
+		$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE),,echo "CONFIG_INITRAMFS_ROOT_GID=$(shell id -g)" >> $(2)/.config;) \
+		$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE), \
+			echo "# CONFIG_INITRAMFS_FORCE is not set" >> $(2)/.config;, \
+			$(if $(CONFIG_TARGET_INITRAMFS_FORCE), \
+				echo "CONFIG_INITRAMFS_FORCE=y" >> $(2)/.config;, \
+				echo "# CONFIG_INITRAMFS_FORCE is not set" >> $(2)/.config;)) \
+		$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_NONE), \
+			echo "CONFIG_INITRAMFS_COMPRESSION_NONE=y" >> $(2)/.config;, \
+			echo "# CONFIG_INITRAMFS_COMPRESSION_NONE is not set" >> $(2)/.config; ) \
+		$(foreach ALGO,GZIP BZIP2 LZMA LZO XZ LZ4 ZSTD, \
+			$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_$(ALGO)), \
+				echo "CONFIG_INITRAMFS_COMPRESSION_$(ALGO)=y" >> $(2)/.config; $\, \
+				echo "# CONFIG_INITRAMFS_COMPRESSION_$(ALGO) is not set" >> $(2)/.config; $\) \
+			$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_$(ALGO)), \
+				echo "CONFIG_RD_$(ALGO)=y" >> $(2)/.config; $\, \
+				echo "# CONFIG_RD_$(ALGO) is not set" >> $(2)/.config; $\) \
+		) \
+	}
   endef
 else
 endif
@@ -157,10 +171,10 @@ define Kernel/CompileImage/Default
 endef
 
 define Kernel/PrepareConfigPerRootfs
-	[ ! -d "$(1)" ] || rm -rf $(1)
-	mkdir $(1)
-
-	$(CP) $(LINUX_DIR)/.config $(1)
+	{ \
+		[ ! -d "$(1)" ] || rm -rf $(1); \
+		mkdir $(1) && $(CP) $(LINUX_DIR)/.config $(1); \
+	}
 endef
 
 ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
@@ -169,32 +183,37 @@ ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
 # For Separate Initramf with $2 declared, skip kernel compile, it has
 # already been done previously on generic image build
 define Kernel/CompileImage/Initramfs
-	$(if $(2),$(call Kernel/PrepareConfigPerRootfs,$(LINUX_DIR)$(2)))
-	$(call Kernel/Configure/Initramfs,$(if $(1),$(1),$(TARGET_DIR)),$(LINUX_DIR)$(2))
-	$(CP) $(GENERIC_PLATFORM_DIR)/other-files/init $(if $(1),$(1),$(TARGET_DIR))/init
-	$(if $(SOURCE_DATE_EPOCH),touch -hcd "@$(SOURCE_DATE_EPOCH)" $(if $(1),$(1),$(TARGET_DIR)) $(if $(1),$(1),$(TARGET_DIR))/init)
-ifeq ($(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE),y)
-ifneq ($(call qstrip,$(CONFIG_EXTERNAL_CPIO)),)
-	$(CP) $(CONFIG_EXTERNAL_CPIO) $(KERNEL_BUILD_DIR)/initrd.cpio$(2)
-else
-	( cd $(if $(1),$(1),$(TARGET_DIR)); find . | LC_ALL=C sort | $(STAGING_DIR_HOST)/bin/cpio --reproducible -o -H newc -R 0:0 > $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio )
-endif
-	$(if $(SOURCE_DATE_EPOCH),touch -hcd "@$(SOURCE_DATE_EPOCH)" $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio)
-	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_BZIP2),$(STAGING_DIR_HOST)/bin/bzip2 -9 -c < $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio > $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio.bzip2)
-	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_GZIP),$(STAGING_DIR_HOST)/bin/libdeflate-gzip -n -f -S .gzip -12 $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio)
-	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZ4),$(STAGING_DIR_HOST)/bin/lz4c -l -c1 -fz --favor-decSpeed $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio)
-	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZMA),$(STAGING_DIR_HOST)/bin/lzma e -lc1 -lp2 -pb2 $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio.lzma)
-	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZO),$(STAGING_DIR_HOST)/bin/lzop -9 -f $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio)
-	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_XZ),$(STAGING_DIR_HOST)/bin/xz -T$(if $(filter 1,$(NPROC)),2,0) -9 -fz --check=crc32 $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio)
-	$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_ZSTD),$(STAGING_DIR_HOST)/bin/zstd -T0 -f -o $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio.zstd $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio)
-	$(if $(2),,$(KERNEL_MAKE) $(KERNEL_MAKEOPTS_IMAGE) $(if $(KERNELNAME),$(KERNELNAME),all))
-	$(call Kernel/CopyImage,-initramfs,$(2))
-else
-	+$(call locked,$(if $(2),$(CP) $(LINUX_DIR)$(2)/.config* $(LINUX_DIR) && touch $(LINUX_DIR)/.config && )\
-		rm -rf $(LINUX_DIR)/usr/initramfs_data.cpio* $(LINUX_DIR)/.config.prev && \
-		$(KERNEL_MAKE) $(KERNEL_MAKEOPTS_IMAGE) $(if $(KERNELNAME),$(KERNELNAME),all) && \
-		{ $(call Kernel/CopyImage,-initramfs,$(2)) },gen-initramfs)
-endif
+	$(call locked,{ \
+		$(if $(2),$(call Kernel/PrepareConfigPerRootfs,$(LINUX_DIR)$(2));) \
+		$(call Kernel/Configure/Initramfs,$(if $(1),$(1),$(TARGET_DIR)),$(LINUX_DIR)$(2)); \
+		$(CP) $(GENERIC_PLATFORM_DIR)/other-files/init $(if $(1),$(1),$(TARGET_DIR))/init; \
+		$(if $(SOURCE_DATE_EPOCH),touch -hcd "@$(SOURCE_DATE_EPOCH)" $(if $(1),$(1),$(TARGET_DIR)) $(if $(1),$(1),$(TARGET_DIR))/init;) \
+		$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE), \
+			$(if $(call qstrip,$(CONFIG_EXTERNAL_CPIO)), \
+				$(CP) $(CONFIG_EXTERNAL_CPIO) $(KERNEL_BUILD_DIR)/initrd.cpio;,\
+				( cd $(if $(1),$(1),$(TARGET_DIR)); find . | LC_ALL=C sort | $(STAGING_DIR_HOST)/bin/cpio --reproducible -o -H newc -R 0:0 > $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio );) \
+			$(if $(SOURCE_DATE_EPOCH), \
+				touch -hcd "@$(SOURCE_DATE_EPOCH)" $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio;) \
+			$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_BZIP2), \
+				$(STAGING_DIR_HOST)/bin/bzip2 -9 -c < $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio > $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio.bzip2;) \
+			$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_GZIP), \
+				$(STAGING_DIR_HOST)/bin/libdeflate-gzip -n -f -S .gzip -12 $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio;) \
+			$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZ4), \
+				$(STAGING_DIR_HOST)/bin/lz4c -l -c1 -fz --favor-decSpeed $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio;) \
+			$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZMA), \
+				$(STAGING_DIR_HOST)/bin/lzma e -lc1 -lp2 -pb2 $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio.lzma;) \
+			$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZO), \
+				$(STAGING_DIR_HOST)/bin/lzop -9 -f $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio;) \
+			$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_XZ), \
+				$(STAGING_DIR_HOST)/bin/xz -T$(if $(filter 1,$(NPROC)),2,0) -9 -fz --check=crc32 $(KERNEL_BUILD_DIR)/initrd.cpio;) \
+			$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_ZSTD), \
+				$(STAGING_DIR_HOST)/bin/zstd -T0 -f -o $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio.zstd $(if $(2),$(LINUX_DIR)$(2),$(KERNEL_BUILD_DIR))/initrd.cpio;) \
+			$(if $(2),,$(KERNEL_MAKE) $(KERNEL_MAKEOPTS_IMAGE) $(if $(KERNELNAME),$(KERNELNAME),all);),\
+			$(call locked,$(if $(2),$(CP) $(LINUX_DIR)$(2)/.config* $(LINUX_DIR) && touch $(LINUX_DIR)/.config && ) \
+				rm -rf $(LINUX_DIR)/usr/initramfs_data.cpio* $(LINUX_DIR)/.config.prev && \
+				$(KERNEL_MAKE) $(KERNEL_MAKEOPTS_IMAGE) $(if $(KERNELNAME),$(KERNELNAME),all), compile-initramfs);) \
+		$(call Kernel/CopyImage,-initramfs,$(2)); \
+	}, gen-initramfs$(if $(2),-$(2)));
 endef
 else
 define Kernel/CompileImage/Initramfs


### PR DESCRIPTION
Rework CompileImage/Initramfs locking logic to fix race condition on
concurrent access/compilation.

Rework each intermediate step and group them under one single execution
block. Protect this with a new lock, 'gen-initramfs' and rename the
compile initramfs to compile-initramfs lock name.

This is done to handle corner case scenario where a rootfs with the same
hash ID is generated at the same time. To handle this, we execute
everything under lock and use a specific hash ID lock to prevent
concurrent access/compilation.

To speedup compilation of Per-Device Initramfs, copy the kernel build
directory for each rootfs ID.

This permits concurrent execution of kernel build without conflicting
with each other at the expense of additional disk space usage.

To limit disk space usage, the copied kernel directory is deleted after
the Per-Device Initramfs image is generated and saved.