### PR TITLE
ath79: fix I2C pins on GL-AR750

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts
@@ -63,8 +63,8 @@
 	i2c {
 		compatible = "i2c-gpio";
 
-		sda-gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
-		scl-gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		sda-gpios = <&gpio  1 GPIO_ACTIVE_HIGH>;
+		scl-gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
 	};
 };
 


### PR DESCRIPTION
Change I2C pin flags to GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN, and change SDA to GPIO1.

On my late production GL-AR750 (purchased 2024):
SCL = GPIO16
SDA = GPIO1

Bug report:
I2C bus doesn't work in GL-AR750
https://github.com/openwrt/openwrt/issues/16319
