### PR TITLE
ramips: mt7621: Fix DNA EX400 mac address retrieval

### DIFF
--- a/package/kernel/linux/modules/nvmem.mk
+++ b/package/kernel/linux/modules/nvmem.mk
@@ -1,0 +1,38 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+NVMEM_MENU:=NVMEM Support
+
+define KernelPackage/ubi-nvmem
+  SUBMENU:=$(NVMEM_MENU)
+  TITLE:=UBI virtual NVMEM
+  KCONFIG:= \
+	CONFIG_MTD_UBI_NVMEM
+  FILES:=$(LINUX_DIR)/drivers/mtd/ubi/nvmem.ko
+  AUTOLOAD:=$(call AutoProbe,nvmem,1)
+endef
+
+define KernelPackage/ubi-nvmem/description
+  Kernel module for exposing UBI volumes as NVMEM providers.
+endef
+
+$(eval $(call KernelPackage,ubi-nvmem))
+
+
+define KernelPackage/nvmem-layout-uboot-env
+  SUBMENU:=$(NVMEM_MENU)
+  TITLE:=U-Boot environment variables layout
+  KCONFIG:= \
+	CONFIG_NVMEM_LAYOUT_U_BOOT_ENV
+  FILES:= \
+	$(LINUX_DIR)/drivers/nvmem/layouts/u-boot-env.ko
+  AUTOLOAD:=$(call AutoProbe,u-boot-env,1)
+endef
+
+define KernelPackage/nvmem-layout-uboot-env/description
+  Kernel module that exposes U-Boot environment variables through a NVMEM layout.
+endef
+
+$(eval $(call KernelPackage,nvmem-layout-uboot-env))

--- a/target/linux/ramips/dts/mt7621_dna_valokuitu-plus-ex400.dts
+++ b/target/linux/ramips/dts/mt7621_dna_valokuitu-plus-ex400.dts
@@ -77,13 +77,14 @@
 		partition@100000 {
 			reg = <0x100000 0xff00000>;
 			label = "ubi";
+			compatible = "linux,ubi";
 
 			volumes {
 				ubi-volume-env1 {
 					volname = "env1";
 
 					nvmem-layout {
-						compatible = "u-boot,env";
+						compatible = "u-boot,env-redundant-count";
 
 						ethaddr: ethaddr {
 							#nvmem-cell-cells = <1>;

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1071,7 +1071,8 @@ define Device/dna_valokuitu-plus-ex400
   IMAGE/sysupgrade.tar := dna-bootfs | sysupgrade-tar kernel=$$$$@ | check-size | \
   			  append-metadata
   DEVICE_IMG_NAME = $$(DEVICE_IMG_PREFIX)-$$(2)
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3 \
+	kmod-nvmem-layout-uboot-env kmod-ubi-nvmem
 endef
 TARGET_DEVICES += dna_valokuitu-plus-ex400
 


### PR DESCRIPTION
The initial commit where DNA Valokuitu Plus EX400 was introduced left the device with no network connectivity. To fix this create kernel modules kmod-ubi-nvmem and kmod-nvmem-uboot-env and use them for the devices. Also, repair the DTS file.