### PR TITLE
realtek: default to 6.6

### DIFF
--- a/target/linux/realtek/Makefile
+++ b/target/linux/realtek/Makefile
@@ -9,8 +9,7 @@ DEVICE_TYPE:=basic
 FEATURES:=ramdisk squashfs
 SUBTARGETS:=rtl838x rtl839x rtl930x rtl931x
 
-KERNEL_PATCHVER:=5.15
-KERNEL_TESTING_PATCHVER:=6.6
+KERNEL_PATCHVER:=6.6
 
 define Target/Description
 	Build firmware images for Realtek RTL83xx based boards.


### PR DESCRIPTION
Now that there is 6.6 support for realtek, lets encourage testing it by making it default so 5.15 can be dropped ASAP.
