### PR TITLE
[23.05] ramips: mt7621: use lzma-loader for Sercomm NA502s

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2068,6 +2068,7 @@ TARGET_DEVICES += sercomm_na502
 
 define Device/sercomm_na502s
   $(Device/nand)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 20971520
   DEVICE_VENDOR := SERCOMM
   DEVICE_MODEL := NA502S


### PR DESCRIPTION
This fixes a well-known "LZMA ERROR 1" error on Sercomm NA502s, reported on the OpneWrt forum [0].

[0] https://forum.openwrt.org/t/206640

Backported from https://github.com/openwrt/openwrt/commit/6d89aa29878a93c744e8c752a68bc05d41252cfc