### PR TITLE
ath79: rb91x_nand: use dev_err_probe

### DIFF
--- a/target/linux/ath79/files/drivers/mtd/nand/raw/rb91x_nand.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/rb91x_nand.c
@@ -284,13 +284,8 @@ static int rb91x_nand_probe(struct platform_device *pdev)
 	platform_set_drvdata(pdev, drvdata);
 
 	gpios = gpiod_get_array(dev, NULL, GPIOD_OUT_LOW);
-	if (IS_ERR(gpios)) {
-		if (PTR_ERR(gpios) != -EPROBE_DEFER) {
-			dev_err(dev, "failed to get gpios: %ld\n",
-				PTR_ERR(gpios));
-		}
-		return PTR_ERR(gpios);
-	}
+	if (IS_ERR(gpios))
+		return dev_err_probe(dev, PTR_ERR(gpios), "failed to get gpios");
 
 	if (gpios->ndescs != RB91X_NAND_GPIOS) {
 		dev_err(dev, "expected %d gpios\n", RB91X_NAND_GPIOS);
@@ -333,16 +328,11 @@ static int rb91x_nand_probe(struct platform_device *pdev)
 
 	r = mtd_device_register(mtd, NULL, 0);
 	if (r) {
-		dev_err(dev, "mtd_device_register() failed: %d\n",
-			r);
-		goto err_release_nand;
+		rb91x_nand_release(drvdata);
+		return dev_err_probe(dev, r, "mtd_device_register() failed");
 	}
 
 	return 0;
-
-err_release_nand:
-	rb91x_nand_release(drvdata);
-	return r;
 }
 
 static int rb91x_nand_remove(struct platform_device *pdev)


### PR DESCRIPTION
Simplifies the error path and avoids having to handle -EPROBE_DEFER manually.