### PR TITLE
mediatek: add Adtran SmartRG SDG-8733A

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -108,6 +108,7 @@ openwrt,one)
 	ubootenv_add_ubi_default
 	;;
 smartrg,sdg-8733|\
+smartrg,sdg-8733a|\
 smartrg,sdg-8734)
 	local envdev=$(find_mmc_part "u-boot-env" "mmcblk0")
 	ubootenv_add_uci_config "$envdev" "0x0" "0x8000" "0x8000"

--- a/target/linux/generic/hack-6.6/722-net-phy-aquantia-enable-AQR112-and-AQR412.patch
+++ b/target/linux/generic/hack-6.6/722-net-phy-aquantia-enable-AQR112-and-AQR412.patch
@@ -15,7 +15,7 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
 
 --- a/drivers/net/phy/aquantia/aquantia_main.c
 +++ b/drivers/net/phy/aquantia/aquantia_main.c
-@@ -90,6 +90,29 @@
+@@ -96,6 +96,29 @@
  #define AQR107_OP_IN_PROG_SLEEP		1000
  #define AQR107_OP_IN_PROG_TIMEOUT	100000
  
@@ -45,7 +45,7 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
  static int aqr107_get_sset_count(struct phy_device *phydev)
  {
  	return AQR107_SGMII_STAT_SZ;
-@@ -196,6 +219,51 @@ static int aqr_config_aneg(struct phy_de
+@@ -202,6 +225,51 @@ static int aqr_config_aneg(struct phy_de
  	return genphy_c45_check_and_restart_aneg(phydev, changed);
  }
  
@@ -97,7 +97,7 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
  static int aqr_config_intr(struct phy_device *phydev)
  {
  	bool en = phydev->interrupts == PHY_INTERRUPT_ENABLED;
-@@ -815,7 +883,7 @@ static struct phy_driver aqr_driver[] =
+@@ -848,7 +916,7 @@ static struct phy_driver aqr_driver[] =
  	PHY_ID_MATCH_MODEL(PHY_ID_AQR112),
  	.name		= "Aquantia AQR112",
  	.probe		= aqr107_probe,
@@ -106,7 +106,7 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
  	.config_intr	= aqr_config_intr,
  	.handle_interrupt = aqr_handle_interrupt,
  	.get_tunable    = aqr107_get_tunable,
-@@ -838,7 +906,7 @@ static struct phy_driver aqr_driver[] =
+@@ -871,7 +939,7 @@ static struct phy_driver aqr_driver[] =
  	PHY_ID_MATCH_MODEL(PHY_ID_AQR412),
  	.name		= "Aquantia AQR412",
  	.probe		= aqr107_probe,

--- a/target/linux/generic/hack-6.6/723-net-phy-aquantia-fix-system-side-protocol-mi.patch
+++ b/target/linux/generic/hack-6.6/723-net-phy-aquantia-fix-system-side-protocol-mi.patch
@@ -14,7 +14,7 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
 
 --- a/drivers/net/phy/aquantia/aquantia_main.c
 +++ b/drivers/net/phy/aquantia/aquantia_main.c
-@@ -252,10 +252,16 @@ static int aqr_config_aneg_set_prot(stru
+@@ -258,10 +258,16 @@ static int aqr_config_aneg_set_prot(stru
  	phy_write_mmd(phydev, MDIO_MMD_VEND1, AQUANTIA_VND1_GSTART_RATE,
  		      aquantia_syscfg[if_type].start_rate);
  

--- a/target/linux/generic/hack-6.6/725-net-phy-aquantia-add-PHY_IDs-for-AQR112-variants.patch
+++ b/target/linux/generic/hack-6.6/725-net-phy-aquantia-add-PHY_IDs-for-AQR112-variants.patch
@@ -12,7 +12,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/aquantia/aquantia_main.c
 +++ b/drivers/net/phy/aquantia/aquantia_main.c
-@@ -30,6 +30,8 @@
+@@ -31,6 +31,8 @@
  #define PHY_ID_AQR113C	0x31c31c12
  #define PHY_ID_AQR114C	0x31c31c22
  #define PHY_ID_AQR813	0x31c31cb2
@@ -21,7 +21,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  #define MDIO_PHYXS_VEND_IF_STATUS		0xe812
  #define MDIO_PHYXS_VEND_IF_STATUS_TYPE_MASK	GENMASK(7, 3)
-@@ -1022,6 +1024,30 @@ static struct phy_driver aqr_driver[] =
+@@ -1055,6 +1057,30 @@ static struct phy_driver aqr_driver[] =
  	.led_hw_control_get = aqr_phy_led_hw_control_get,
  	.led_polarity_set = aqr_phy_led_polarity_set,
  },
@@ -52,7 +52,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  };
  
  module_phy_driver(aqr_driver);
-@@ -1042,6 +1068,8 @@ static struct mdio_device_id __maybe_unu
+@@ -1075,6 +1101,8 @@ static struct mdio_device_id __maybe_unu
  	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR113C) },
  	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR114C) },
  	{ PHY_ID_MATCH_MODEL(PHY_ID_AQR813) },

--- a/target/linux/generic/pending-6.6/752-net-phy-aquantia-allow-forcing-order-of-MDI-pairs.patch
+++ b/target/linux/generic/pending-6.6/752-net-phy-aquantia-allow-forcing-order-of-MDI-pairs.patch
@@ -1,0 +1,104 @@
+From 49d46df79404a37685e0f32deb36506f5723e3a0 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Wed, 28 Aug 2024 23:52:09 +0100
+Subject: [PATCH] net: phy: aquantia: allow forcing order of MDI pairs
+
+Despite supporting Auto MDI-X, it looks like Aquantia only supports
+swapping pair (1,2) with pair (3,6) like it used to be for MDI-X on
+100MBit/s networks.
+
+When all 4 pairs are in use (for 1000MBit/s or faster) the link does not
+come up with pair order is not configured correctly, either using
+MDI_CFG pin or using the "PMA Receive Reserved Vendor Provisioning 1"
+register.
+
+Normally, the order of MDI pairs being either ABCD or DCBA is configured
+by pulling the MDI_CFG pin.
+
+However, some hardware designs require overriding the value configured
+by that bootstrap pin. The PHY allows doing that by setting a bit in
+"PMA Receive Reserved Vendor Provisioning 1" register which allows
+ignoring the state of the MDI_CFG pin and another bit configuring
+whether the order of MDI pairs should be normal (ABCD) or reverse
+(DCBA). Pair polarity is not affected and remains identical in both
+settings.
+
+Introduce property "marvell,mdi-cfg-order" which allows forcing either
+normal or reverse order of the MDI pairs from DT.
+
+If the property isn't present, the behavior is unchanged and MDI pair
+order configuration is untouched (ie. either the result of MDI_CFG pin
+pull-up/pull-down, or pair order override already configured by the
+bootloader before Linux is started).
+
+Forcing normal pair order is required on the Adtran SDG-8733A Wi-Fi 7
+residential gateway.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ drivers/net/phy/aquantia/aquantia_main.c | 33 ++++++++++++++++++++++++
+ 1 file changed, 33 insertions(+)
+
+--- a/drivers/net/phy/aquantia/aquantia_main.c
++++ b/drivers/net/phy/aquantia/aquantia_main.c
+@@ -11,6 +11,7 @@
+ #include <linux/module.h>
+ #include <linux/delay.h>
+ #include <linux/bitfield.h>
++#include <linux/of.h>
+ #include <linux/phy.h>
+ 
+ #include "aquantia.h"
+@@ -70,6 +71,11 @@
+ #define MDIO_AN_TX_VEND_INT_MASK2		0xd401
+ #define MDIO_AN_TX_VEND_INT_MASK2_LINK		BIT(0)
+ 
++#define PMAPMD_RSVD_VEND_PROV			0xe400
++#define PMAPMD_RSVD_VEND_PROV_MDI_CONF		GENMASK(1, 0)
++#define PMAPMD_RSVD_VEND_PROV_MDI_REVERSE	BIT(0)
++#define PMAPMD_RSVD_VEND_PROV_MDI_FORCE		BIT(1)
++
+ #define MDIO_AN_RX_LP_STAT1			0xe820
+ #define MDIO_AN_RX_LP_STAT1_1000BASET_FULL	BIT(15)
+ #define MDIO_AN_RX_LP_STAT1_1000BASET_HALF	BIT(14)
+@@ -497,6 +503,29 @@ static int aqr107_wait_processor_intensi
+ 	return 0;
+ }
+ 
++static int aqr107_config_mdi(struct phy_device *phydev)
++{
++	struct device_node *np = phydev->mdio.dev.of_node;
++	u32 mdi_conf;
++	int ret;
++
++	ret = of_property_read_u32(np, "marvell,mdi-cfg-order", &mdi_conf);
++
++	/* Do nothing in case property "marvell,mdi-cfg-order" is not present */
++	if (ret == -ENOENT)
++		return 0;
++
++	if (ret)
++		return ret;
++
++	if (mdi_conf & ~PMAPMD_RSVD_VEND_PROV_MDI_REVERSE)
++		return -EINVAL;
++
++	return phy_modify_mmd(phydev, MDIO_MMD_PMAPMD, PMAPMD_RSVD_VEND_PROV,
++			      PMAPMD_RSVD_VEND_PROV_MDI_CONF,
++			      mdi_conf | PMAPMD_RSVD_VEND_PROV_MDI_FORCE);
++}
++
+ static int aqr107_config_init(struct phy_device *phydev)
+ {
+ 	struct aqr107_priv *priv = phydev->priv;
+@@ -535,6 +564,10 @@ static int aqr107_config_init(struct phy
+ 	if (ret)
+ 		return ret;
+ 
++	ret = aqr107_config_mdi(phydev);
++	if (ret)
++		return ret;
++
+ 	/* Restore LED polarity state after reset */
+ 	for_each_set_bit(led_active_low, &priv->leds_active_low, AQR_MAX_LEDS) {
+ 		ret = aqr_phy_led_active_low_set(phydev, led_active_low, true);

--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -14,7 +14,8 @@ set_preinit_iface() {
 		ifname=eth0
 		;;
 	smartrg,sdg-8622|\
-	smartrg,sdg-8632)
+	smartrg,sdg-8632|\
+	smartrg,sdg-8733a)
 		ip link set lan up
 		ifname=lan
 		;;

--- a/target/linux/mediatek/dts/mt7988a-smartrg-mt-stuart.dtsi
+++ b/target/linux/mediatek/dts/mt7988a-smartrg-mt-stuart.dtsi
@@ -451,19 +451,19 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			led@0 {
+			aqr_green_led: led@0 {
 				reg = <0>;
 				function = LED_FUNCTION_LAN;
 				color = <LED_COLOR_ID_GREEN>;
 			};
 
-			led@1 {
+			aqr_orange_led: led@1 {
 				reg = <1>;
 				function = LED_FUNCTION_LAN;
 				color = <LED_COLOR_ID_ORANGE>;
 			};
 
-			led@2 {
+			aqr_white_led: led@2 {
 				reg = <2>;
 				function = LED_FUNCTION_LAN;
 				color = <LED_COLOR_ID_WHITE>;

--- a/target/linux/mediatek/dts/mt7988d-smartrg-SDG-8733A.dts
+++ b/target/linux/mediatek/dts/mt7988d-smartrg-SDG-8733A.dts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2024 SmartRG Inc.
+ * Author: Chad Monroe <chad.monroe@smartrg.com>
+ */
+
+#include "mt7988a-smartrg-mt-stuart.dtsi"
+
+/ {
+	model = "SmartRG SDG-8733A";
+	compatible = "smartrg,sdg-8733a", "mediatek,mt7988d";
+
+	cpus {
+		/delete-node/ cpu@3;
+	};
+
+	/delete-node/ gpio-export;
+	/delete-node/ gpio-leds;
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		bluetooth_reset: bluetooth-reset {
+			gpio-export,name = "bt_reset";
+			gpio-export,direction_may_change;
+			gpios = <&pio 36 GPIO_ACTIVE_HIGH>;
+		};
+
+		bluetooth_txrx_ctl: bluetooth-txrx-ctl {
+			gpio-export,name = "bt_txrx_ctl";
+			gpio-export,direction_may_change;
+			gpios = <&pio 37 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		lan_amber {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "lan";
+			gpios = <&pio 59 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan_green {
+			color = <LED_COLOR_ID_AMBER>;
+			function = "lan";
+			gpios = <&pio 60 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&fan {
+	pwms = <&pwm 1 40000 0>;
+
+	interrupts = <57 IRQ_TYPE_EDGE_FALLING>;
+};
+
+&gmac0 {
+	status = "disabled";
+};
+
+&gmac1 {
+	label = "lan";
+	phy-mode = "internal";
+	phy-connection-type = "internal";
+	phy = <&int_2p5g_phy>;
+};
+
+&gmac2 {
+	label = "wan";
+	phy-mode = "usxgmii";
+	phy-connection-type = "usxgmii";
+	phy = <&phy8>;
+};
+
+&int_2p5g_phy {
+	pinctrl-names = "i2p5gbe-led";
+	pinctrl-0 = <&i2p5gbe_led0_pins>;
+};
+
+&mdio_bus {
+	/delete-node/ ethernet-phy@0;
+};
+
+&pio {
+	pcie3_1_pins: pcie3-pins-g1 {
+		mux {
+			function = "pcie";
+			groups = "pcie_1l_1_pereset", "pcie_clk_req_n3";
+		};
+	};
+};
+
+&pcie0 {
+	reset-gpios = <&pio 9 GPIO_ACTIVE_HIGH>;
+};
+
+&pcie1 {
+	status = "disabled";
+};
+
+&pcie3 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie3_1_pins>;
+	status = "okay";
+};
+
+&phy8 {
+	reset-gpios = <&pio 62 GPIO_ACTIVE_LOW>;
+	marvell,mdi-cfg-order = <0>;
+};
+
+&aqr_green_led {
+	function = LED_FUNCTION_WAN;
+};
+
+&aqr_orange_led {
+	function = LED_FUNCTION_WAN;
+};
+
+&aqr_white_led {
+	function = LED_FUNCTION_WAN;
+};
+
+&i2p5gbe_led0 {
+	color = <LED_COLOR_ID_GREEN>;
+	status = "okay";
+};
+
+&ssusb0 {
+	status = "disabled";
+};
+
+&ssusb1 {
+	status = "disabled";
+};
+
+&switch {
+	status = "disabled";
+};
+
+&tphy {
+	status = "disabled";
+};
+
+&uart1 {
+	status = "disabled";
+};
+
+&xphy {
+	status = "disabled";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -97,6 +97,14 @@ smartrg,sdg-8734)
 	ucidef_set_led_netdev "wan-orange" "WAN" "mdio-bus:00:orange:wan" "wan" "link_100 link_1000"
 	ucidef_set_led_netdev "wan-white" "WAN" "mdio-bus:00:white:wan" "wan" "link_10000"
 	;;
+smartrg,sdg-8733a)
+	ucidef_set_led_netdev "lan-green-act" "LAN" "mdio-bus:0f:green:lan" "lan" "link_2500"
+	ucidef_set_led_netdev "lan-amber" "LAN" "amber:lan" "lan" "link_100"
+	ucidef_set_led_netdev "lan-green" "LAN" "green:lan" "lan" "link_1000"
+	ucidef_set_led_netdev "wan-green" "WAN" "mdio-bus:08:green:wan" "wan" "link_2500 link_5000"
+	ucidef_set_led_netdev "wan-orange" "WAN" "mdio-bus:08:orange:wan" "wan" "link_100 link_1000"
+	ucidef_set_led_netdev "wan-white" "WAN" "mdio-bus:08:white:wan" "wan" "link_10000"
+	;;
 wavlink,wl-wn586x3)
 	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-2" "lan2" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -96,6 +96,7 @@ mediatek_setup_interfaces()
 		;;
 	smartrg,sdg-8622|\
 	smartrg,sdg-8632|\
+	smartrg,sdg-8733a|\
 	yuncore,ax835)
 		ucidef_set_interfaces_lan_wan lan wan
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -149,6 +149,7 @@ case "$board" in
 		[ "$PHYNBR" = "2" ] && macaddr_add $addr 4 > /sys${DEVPATH}/macaddress
 		;;
 	smartrg,sdg-8733|\
+	smartrg,sdg-8733a|\
 	smartrg,sdg-8734)
 		addr=$(mmc_get_mac_ascii mfginfo MFG_MAC)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 4 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -36,7 +36,8 @@ preinit_set_mac_address() {
 		ip link set dev lan4 address "$lan_addr"
 		;;
 	smartrg,sdg-8622|\
-	smartrg,sdg-8632)
+	smartrg,sdg-8632|\
+	smartrg,sdg-8733a)
 		addr=$(mmc_get_mac_ascii mfginfo MFG_MAC)
 		ip link set dev wan address "$addr"
 		ip link set dev lan address "$(macaddr_add $addr 1)"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -95,6 +95,7 @@ platform_do_upgrade() {
 	smartrg,sdg-8622|\
 	smartrg,sdg-8632|\
 	smartrg,sdg-8733|\
+	smartrg,sdg-8733a|\
 	smartrg,sdg-8734)
 		CI_KERNPART="kernel"
 		CI_ROOTPART="rootfs"
@@ -211,6 +212,7 @@ platform_copy_config() {
 	smartrg,sdg-8622|\
 	smartrg,sdg-8632|\
 	smartrg,sdg-8733|\
+	smartrg,sdg-8733a|\
 	smartrg,sdg-8734|\
 	ubnt,unifi-6-plus)
 		emmc_copy_config

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -208,6 +208,14 @@ $(call Device/adtran_smartrg)
 endef
 TARGET_DEVICES += smartrg_sdg-8733
 
+define Device/smartrg_sdg-8733a
+$(call Device/adtran_smartrg)
+  DEVICE_MODEL := SDG-8733A
+  DEVICE_DTS := mt7988d-smartrg-SDG-8733A
+  DEVICE_PACKAGES += mt7988-2p5g-phy-firmware kmod-mt7996-firmware kmod-phy-aquantia
+endef
+TARGET_DEVICES += smartrg_sdg-8733a
+
 define Device/smartrg_sdg-8734
 $(call Device/adtran_smartrg)
   DEVICE_MODEL := SDG-8734

--- a/target/linux/mediatek/patches-6.6/350-21-cpufreq-mediatek-Add-support-for-MT7988.patch
+++ b/target/linux/mediatek/patches-6.6/350-21-cpufreq-mediatek-Add-support-for-MT7988.patch
@@ -51,11 +51,12 @@ Signed-off-by: Sam Shih <sam.shih@mediatek.com>
  static const struct mtk_cpufreq_platform_data mt8183_platform_data = {
  	.min_volt_shift = 100000,
  	.max_volt_shift = 200000,
-@@ -740,6 +749,7 @@ static const struct of_device_id mtk_cpu
+@@ -740,6 +749,8 @@ static const struct of_device_id mtk_cpu
  	{ .compatible = "mediatek,mt2712", .data = &mt2701_platform_data },
  	{ .compatible = "mediatek,mt7622", .data = &mt7622_platform_data },
  	{ .compatible = "mediatek,mt7623", .data = &mt7623_platform_data },
 +	{ .compatible = "mediatek,mt7988a", .data = &mt7988_platform_data },
++	{ .compatible = "mediatek,mt7988d", .data = &mt7988_platform_data },
  	{ .compatible = "mediatek,mt8167", .data = &mt8516_platform_data },
  	{ .compatible = "mediatek,mt817x", .data = &mt2701_platform_data },
  	{ .compatible = "mediatek,mt8173", .data = &mt2701_platform_data },


### PR DESCRIPTION
Specification is similar to other devices of the MT Stuart series:
 * Mediatek MT7988D (3x Cortex-A73, up to 1.8 GHz clock speed)
 * 8 GiB eMMC
 * 2 GiB DDR4 RAM
 * 2500M/1000M/100M LAN port
 * 10000M/5000M/2500M/1000M/100M/10M WAN port
 * MT7992 Tri-band (2.4G, 5G, 6G) 2T2R+3T3R+3T3R 802.11be Wi-Fi
 * Renesas DA14531MOD Bluetooth
 * 2 buttons (Reset, Mesh/WPS)
 * uC-controlled RGB LED via I2C
 * 2x LED for the 2.5G port, 3x LED for the 10G port
 * 3.3V-level 115200 baud UART console via 4-pin Dupont connector
   exposed at the bottom of the device
 * USB-C PD power input

