### PR TITLE
apk: add cmd:foo provides

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -336,6 +336,13 @@ else
 		exit 1; \
 	fi
 
+	cmd_provides=""
+	for f in $$(IDIR_$(1)){,/usr}{/bin,/sbin}/*; do \
+		if [ -f $$$$f ] && [ -x $$$$f ]; then \
+			cmd_provides="$$$${cmd_provides:+$$$$cmd_provides }cmd:$$$$(basename $$$$f)=$(VERSION)"; \
+		fi; \
+	done ; echo cmd_provides=$$$$cmd_provides; \
+	\
 	$(FAKEROOT) $(STAGING_DIR_HOST)/bin/apk mkpkg \
 	  --info "name:$(1)$$(ABIV_$(1))" \
 	  --info "version:$(VERSION)" \
@@ -354,7 +361,7 @@ else
 				) \
 			) \
 		), \
-		$$(prov) )" \
+		$$(prov) ) $$$$cmd_provides" \
 	  $(if $(DEFAULT_VARIANT),--info "provider-priority:100") \
 	  --script "post-install:$$(ADIR_$(1))/post-install" \
 	  --script "pre-deinstall:$$(ADIR_$(1))/pre-deinstall" \


### PR DESCRIPTION
hello! in Alpine, packages ship with `provides:cmd:foo` if they contain, say, `/usr/bin/foo`. This is super convenient for installing tools. I noticed that OpenWrt's apk builder currently does not do this, so I set out to fix it.

This is a draft PR for now.

~~One of the commits should be upstreamed to apk-tools (which I will do) - depending on how quickly they pick it up, it can be removed here.~~ done!

I am not well-versed in writing in this mixed shell/make-environment, so it is possible that I'm not doing things optimally.

~~Need to check if the description commit handles quotes in descriptions right.~~ superseded1

A package like `gzip` will not generate a `cmd:gzip` provides, because it does not install into a bin-directory. I guess we need to parse the alternatives file to generate those entries.

~~Alpine has versioned their provides, this PR does not do that yet.~~ (it does now!) I'm not decided on whether comparing versions between semi-unrelated packages (that happen to provide binaries of the same name) is useful. Priorities could solve that instead.

That all said, this PR does work already:

```
/etc/apk # apk add cmd:atop
fetch https://buildbot.aparcar.org/targets/x86/64/kmods/6.6.50-1-279fcb9eea980f4e0bbcf84b4dcf5e20/packages.adb
WARNING: updating and opening https://buildbot.aparcar.org/targets/x86/64/kmods/6.6.50-1-279fcb9eea980f4e0bbcf84b4dcf5e20/packages.adb: remote server returned error (try 'apk update')
...
(7/7) Installing atop (2.11.0-r1)
Executing atop-2.11.0-r1.post-install
OK: 18 MiB in 137 packages
```

Any comments on purpose, goals, style, implementation are welcome.