### PR TITLE
[23.05] ramips: add support for netis N6

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -77,6 +77,7 @@ jcg,q20|\
 linksys,e7350|\
 netgear,eax12|\
 netgear,wax202|\
+netis,n6|\
 zyxel,wsm20)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;

--- a/target/linux/ramips/dts/mt7621_netis_n6.dts
+++ b/target/linux/ramips/dts/mt7621_netis_n6.dts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "netis,n6", "mediatek,mt7621-soc";
+	model = "netis N6";
+
+	aliases {
+		label-mac-device = &gmac0;
+
+		led-boot = &led_power_green;
+		led-failsafe = &led_system_green;
+		led-running = &led_power_green;
+		led-upgrade = &led_system_green;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		key-0 {
+			label = "wps";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		key-1 {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_system_green: led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: led-4 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_7ef20 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_7ef26 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&nand {
+	status = "okay";
+
+	mediatek,nmbm;
+	mediatek,bmt-remap-range = <0x000000 0x580000>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x80000>;
+		};
+
+		partition@100000 {
+			label = "Factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				macaddr_factory_7ef20: macaddr@7ef20 {
+					reg = <0x7ef20 0x6>;
+				};
+
+				macaddr_factory_7ef26: macaddr@7ef26 {
+					reg = <0x7ef26 0x6>;
+				};
+			};
+		};
+
+		partition@180000 {
+			label = "firmware";
+			reg = <0x180000 0x7680000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7280000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+
+		/*
+		 * *** The code block below is commented out ***
+		 * Reason: Probably, original Netis N6 EEPROM has wrong
+		 *         MT_EE_WIFI_CONF value 0xd2. As a result 2.4 GHz
+		 *         doesn't start with mt76 driver. Other routers
+		 *         with the same WLAN chips (e.g., Routerich
+		 *         AX1800) have  MT_EE_WIFI_CONF = 0x92.
+		 * Workaround: Extract EEPROM to a file at the first time
+		 *             boot and change MT_EE_WIFI_CONF (offset
+		 *             0x190) value from 0xd2 to 0x92. See
+		 *             /etc/hotplug.d/firmware/11-mt76-caldata for
+		 *             details.
+		 */
+
+		/*
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		*/
+
+		mediatek,disable-radar-background;
+	};
+};
+
+&state_default {
+	gpio {
+		groups =  "i2c", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -17,6 +17,21 @@ define Build/append-dlink-covr-metadata
 	rm $@metadata.tmp
 endef
 
+define Build/append-netis-n6-metadata
+	( echo -ne '{ \
+		"up_model": "Netis-N6R", \
+		"supported_devices": ["mt7621-rfb-ax-nand"], \
+		"version": { \
+			"dist": "$(call json_quote,$(VERSION_DIST))", \
+			"version": "$(call json_quote,$(VERSION_NUMBER))", \
+			"revision": "$(call json_quote,$(REVISION))", \
+			"board": "$(call json_quote,$(BOARD))" \
+		} }' \
+	) > $@.metadata.tmp
+	fwtool -I $@.metadata.tmp $@
+	rm $@.metadata.tmp
+endef
+
 define Build/arcadyan-trx
 	echo -ne "hsqs" > $@.hsqs
 	$(eval trx_magic=$(word 1,$(1)))
@@ -1942,6 +1957,23 @@ define Device/netgear_wndr3700-v5
   SUPPORTED_DEVICES += wndr3700v5
 endef
 TARGET_DEVICES += netgear_wndr3700-v5
+
+define Device/netis_n6
+  $(Device/dsa-migration)
+  $(Device/nand)
+  IMAGE_SIZE := 121344k
+  DEVICE_VENDOR := netis
+  DEVICE_MODEL := N6
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size | append-netis-n6-metadata
+  DEVICE_PACKAGES += kmod-mt7915-firmware kmod-usb-ledtrig-usbport \
+	kmod-usb3
+endef
+TARGET_DEVICES += netis_n6
 
 define Device/netis_wf2881
   $(Device/nand)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -183,6 +183,9 @@ netgear,r7450)
 netgear,wax202)
 	ucidef_set_led_netdev "internet" "Internet" "green:net" "wan"
 	;;
+netis,n6)
+	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
+	;;
 oraybox,x3a)
 	ucidef_set_led_netdev "wan" "wan link" "red:status" "wan"
 	ucidef_set_led_netdev "lan" "lan link" "green:status" "br-lan"

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+[ -e /lib/firmware/$FIRMWARE ] && exit 0
+
+. /lib/functions/caldata.sh
+
+board=$(board_name)
+
+case "$FIRMWARE" in
+"mediatek/mt7915_eeprom_dbdc.bin")
+	case "$board" in
+	netis,n6)
+		EEPROM=/lib/firmware/$FIRMWARE
+		head -c $((0xe00)) /dev/mtd2 > $EEPROM
+		printf "\x92" | \
+			dd of=$EEPROM seek=$((0x190)) bs=1 conv=notrunc \
+			2>/dev/null
+		;;
+	esac
+	;;
+esac

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -140,6 +140,14 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 3 > /sys${DEVPATH}/macaddress
 		;;
+	netis,n6)
+		hw_mac_addr="$(mtd_get_mac_binary Factory 0x4)"
+		hw_mac_addr=$(macaddr_setbit $hw_mac_addr 28)
+		hw_mac_2g=$(macaddr_unsetbit $hw_mac_addr 26)
+		hw_mac_5g=$(macaddr_setbit $hw_mac_addr 27)
+		[ "$PHYNBR" = "0" ] && echo -n "$hw_mac_2g" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && echo -n "$hw_mac_5g" > /sys${DEVPATH}/macaddress
+		;;
 	mercusys,mr70x-v1|\
 	tplink,archer-ax23-v1)
 		hw_mac_addr="$(mtd_get_mac_binary config 0x8)"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -102,6 +102,7 @@ platform_do_upgrade() {
 	netgear,wac104|\
 	netgear,wac124|\
 	netgear,wax202|\
+	netis,n6|\
 	netis,wf2881|\
 	raisecom,msg1500-x-00|\
 	rostelecom,rt-fe-1a|\


### PR DESCRIPTION
This PR backports support for netis N6 router.

[OpenWrt wiki page](https://openwrt.org/toh/netis/n6)
----------------------

Specification
-------------
```
- SoC       : MediaTek MT7621AT, MIPS, 880 MHz
- RAM       : 256 MiB
- Flash     : NAND 128 MiB (ESMT PSU1GA30DT)
- WLAN      : MT7905DAN + MT7975DN
  - 2.4 GHz : b/g/n/ax, 574 Mbps, MIMO 2x2
  - 5 GHz   : a/n/ac/ax, 1201 Mbps, MIMO 2x2
- Ethernet  : 10/100/1000 Mbps x5 (1x WAN, 4x LAN)
- USB       : 1x 3.0
- UART      : 3.3V, 115200n8
- Buttons   : 1x Reset
              1x WPS
- LEDs      : 1x Power (green)
              1x System (green)
              1x WAN (green)
              1x WiFi 2.4 GHz (green), controlled by phy
              1x WiFi 5 GHz (green), controlled by phy
              1x WPS (green)
              1x USB (green)
              5x ethernet leds (green), controlled by switch
- Power     : 12 VDC, 1.5 A
```
