### PR TITLE
config: build: make STRIP_KERNEL_EXPORTS depend on BROKEN

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -233,7 +233,7 @@ menu "Global build settings"
 
 	config STRIP_KERNEL_EXPORTS
 		bool "Strip unnecessary exports from the kernel image"
-		depends on !LINUX_6_6
+		depends on BROKEN
 		help
 		  Reduces kernel size by stripping unused kernel exports from the kernel
 		  image.  Note that this might make the kernel incompatible with any kernel


### PR DESCRIPTION
`STRIP_KERNEL_EXPORTS` is currently broken on kernel 6.6 and since this is the only kernel currently supported, we should rather make it depend on BROKEN instead of a kernel version until its fixed.
