### PR TITLE
build: remove ac_cv_header_netinet_sctp_h=no from pre-cached variables

### DIFF
--- a/include/site/linux
+++ b/include/site/linux
@@ -53,7 +53,6 @@ ac_cv_have_control_in_msghdr=yes
 ac_cv_have_decl_sys_siglist=no
 ac_cv_have_openpty_ctty_bug=yes
 ac_cv_have_space_d_name_in_struct_dirent=yes
-ac_cv_header_netinet_sctp_h=no
 ac_cv_header_netinet_sctp_uio_h=no
 ac_cv_int64_t=yes
 ac_cv_lbl_unaligned_fail=no


### PR DESCRIPTION
We have <netinet/sctp.h> header in `lksctp-tools` package, but having this var set to 'no' prevents other package's configure to detect it.

I've discovered this when I was trying to enable SCTP support in `erlang`.
