### PR TITLE
Zyxel GS1900 firmware partition merge

### DIFF
--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900.dtsi
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900.dtsi
@@ -91,13 +91,9 @@
 			};
 			partition@b260000 {
 				label = "firmware";
-				reg = <0x260000 0x6d0000>;
+				reg = <0x260000 0xda0000>;
 				compatible = "openwrt,uimage", "denx,uimage";
 				openwrt,ih-magic = <0x83800000>;
-			};
-			partition@930000 {
-				label = "runtime2";
-				reg = <0x930000 0x6d0000>;
 			};
 		};
 	};

--- a/target/linux/realtek/dts/rtl8393_zyxel_gs1900-48.dts
+++ b/target/linux/realtek/dts/rtl8393_zyxel_gs1900-48.dts
@@ -126,13 +126,9 @@
 			};
 			partition@260000 {
 				label = "firmware";
-				reg = <0x260000 0x6d0000>;
+				reg = <0x260000 0xda0000>;
 				compatible = "openwrt,uimage", "denx,uimage";
 				openwrt,ih-magic = <0x83800000>;
-			};
-			partition@930000 {
-				label = "runtime2";
-				reg = <0x930000 0x6d0000>;
 			};
 		};
 	};

--- a/target/linux/realtek/dts/rtl8393_zyxel_gs1900-48.dts
+++ b/target/linux/realtek/dts/rtl8393_zyxel_gs1900-48.dts
@@ -39,11 +39,6 @@
 		gpio-controller;
 	};
 
-	gpio-restart {
-		compatible = "gpio-restart";
-		gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;

--- a/target/linux/realtek/image/common.mk
+++ b/target/linux/realtek/image/common.mk
@@ -57,13 +57,17 @@ define Device/hpe_1920
 endef
 
 define Device/zyxel_gs1900
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := Dual firmware paritition merged due to size constraints. \
+	Upgrade requires a new factory install. Regular sysupgrade is not possible.
   DEVICE_VENDOR := Zyxel
-  IMAGE_SIZE := 6976k
+  IMAGE_SIZE := 13952k
   UIMAGE_MAGIC := 0x83800000
   KERNEL_INITRAMFS := \
 	kernel-bin | \
 	append-dtb | \
 	libdeflate-gzip | \
 	zyxel-vers | \
-	uImage gzip
+	uImage gzip | \
+	check-size 6976k
 endef


### PR DESCRIPTION
Merge the firmware partitions on all supported Zyxel GS1900 switches, doubling the available space to 13.9MB.

Additionally, a small (old) patch is merged to drop the wrongly defined (not present in hardware) gpio-restart node.