### PR TITLE
rockchip: backport upstream updates for nanopc t6

### DIFF
--- a/target/linux/rockchip/patches-6.6/054-01-v6.8-arm64-dts-rockchip-Support-poweroff-on-NanoPC-T6.patch
+++ b/target/linux/rockchip/patches-6.6/054-01-v6.8-arm64-dts-rockchip-Support-poweroff-on-NanoPC-T6.patch
@@ -1,0 +1,26 @@
+From c699fbfdfd54630fc51b96da577f02e7b772eb37 Mon Sep 17 00:00:00 2001
+From: Hugh Cole-Baker <sigmaris@gmail.com>
+Date: Sat, 16 Dec 2023 21:21:34 +0000
+Subject: [PATCH] arm64: dts: rockchip: Support poweroff on NanoPC-T6
+
+The RK806 on the NanoPC-T6 can be used to power on/off the whole board.
+Mark it as the system power controller.
+
+Signed-off-by: Hugh Cole-Baker <sigmaris@gmail.com>
+Link: https://lore.kernel.org/r/20231216212134.23314-1-sigmaris@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+@@ -569,6 +569,8 @@
+ 		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
+ 			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
+ 
++		system-power-controller;
++
+ 		vcc1-supply = <&vcc4v0_sys>;
+ 		vcc2-supply = <&vcc4v0_sys>;
+ 		vcc3-supply = <&vcc4v0_sys>;

--- a/target/linux/rockchip/patches-6.6/054-02-v6.9-arm64-dts-rockchip-nanopc-t6-sdmmc-beautification.patch
+++ b/target/linux/rockchip/patches-6.6/054-02-v6.9-arm64-dts-rockchip-nanopc-t6-sdmmc-beautification.patch
@@ -1,0 +1,33 @@
+From 9e1faff1cbc877903d019a7943d37ddc5042704d Mon Sep 17 00:00:00 2001
+From: John Clark <inindev@gmail.com>
+Date: Thu, 28 Dec 2023 17:29:35 +0000
+Subject: [PATCH] arm64: dts: rockchip: nanopc-t6 sdmmc beautification
+
+drop max-frequency = <200000000> as it is already defined in rk3588s.dtsi
+order no-sdio & no-mmc properties while we are here
+
+Signed-off-by: John Clark <inindev@gmail.com>
+Link: https://lore.kernel.org/r/20231228173011.2863-1-inindev@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+@@ -536,13 +536,12 @@
+ };
+ 
+ &sdmmc {
+-	max-frequency = <200000000>;
+-	no-sdio;
+-	no-mmc;
+ 	bus-width = <4>;
+ 	cap-mmc-highspeed;
+ 	cap-sd-highspeed;
+ 	disable-wp;
++	no-mmc;
++	no-sdio;
+ 	sd-uhs-sdr104;
+ 	vmmc-supply = <&vcc_3v3_s3>;
+ 	vqmmc-supply = <&vccio_sd_s0>;

--- a/target/linux/rockchip/patches-6.6/054-03-v6.9-arm64-dts-rockchip-correct-gpio_pwrctrl1-typo-on-nanopc-t.patch
+++ b/target/linux/rockchip/patches-6.6/054-03-v6.9-arm64-dts-rockchip-correct-gpio_pwrctrl1-typo-on-nanopc-t.patch
@@ -1,0 +1,26 @@
+From 24559788384916041a0bbf54c32e2a16b612d247 Mon Sep 17 00:00:00 2001
+From: John Clark <inindev@gmail.com>
+Date: Mon, 25 Dec 2023 22:32:16 +0000
+Subject: [PATCH] arm64: dts: rockchip: correct gpio_pwrctrl1 typo on nanopc-t6
+
+Both rk806_dvs1_null and rk806_dvs2_null duplicate gpio_pwrctrl2 and
+gpio_pwrctrl1 is not set. This patch sets gpio_pwrctrl1.
+
+Signed-off-by: John Clark <inindev@gmail.com>
+Link: https://lore.kernel.org/r/20231225223226.17690-1-inindev@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+@@ -590,7 +590,7 @@
+ 		#gpio-cells = <2>;
+ 
+ 		rk806_dvs1_null: dvs1-null-pins {
+-			pins = "gpio_pwrctrl2";
++			pins = "gpio_pwrctrl1";
+ 			function = "pin_fun0";
+ 		};
+ 

--- a/target/linux/rockchip/patches-6.6/054-04-v6.9-arm64-dts-rockchip-enable-NanoPC-T6-MiniPCIe-power.patch
+++ b/target/linux/rockchip/patches-6.6/054-04-v6.9-arm64-dts-rockchip-enable-NanoPC-T6-MiniPCIe-power.patch
@@ -1,0 +1,57 @@
+From d235e65adf00f6db09331874c5a987b7fe18023b Mon Sep 17 00:00:00 2001
+From: Hugh Cole-Baker <sigmaris@gmail.com>
+Date: Tue, 9 Jan 2024 20:27:28 +0000
+Subject: [PATCH] arm64: dts: rockchip: enable NanoPC-T6 MiniPCIe power
+
+The NanoPC-T6 has a Mini PCIe slot intended to be used for a 4G or LTE
+modem. This slot has no PCIe functionality, only USB 2.0 pins are wired
+to the SoC, and USIM pins are wired to a SIM card slot on the board.
+Define the 3.3v supply for the slot so it can be used.
+
+Signed-off-by: Hugh Cole-Baker <sigmaris@gmail.com>
+Link: https://lore.kernel.org/r/20240109202729.54292-1-sigmaris@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+@@ -159,6 +159,18 @@
+ 		regulator-max-microvolt = <3300000>;
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
++
++	vdd_4g_3v3: vdd-4g-3v3-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pin_4g_lte_pwren>;
++		regulator-name = "vdd_4g_3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
+ };
+ 
+ &combphy0_ps {
+@@ -504,6 +516,10 @@
+ 	};
+ 
+ 	usb {
++		pin_4g_lte_pwren: 4g-lte-pwren {
++			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
+ 		typec5v_pwren: typec5v-pwren {
+ 			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+@@ -884,6 +900,7 @@
+ };
+ 
+ &u2phy2_host {
++	phy-supply = <&vdd_4g_3v3>;
+ 	status = "okay";
+ };
+ 

--- a/target/linux/rockchip/patches-6.6/054-05-v6.9-arm64-dts-rockchip-add-sdmmc-card-detect-to-the-nanopc-t6.patch
+++ b/target/linux/rockchip/patches-6.6/054-05-v6.9-arm64-dts-rockchip-add-sdmmc-card-detect-to-the-nanopc-t6.patch
@@ -1,0 +1,25 @@
+From d8bb6c2311b6b2aad11b937f96db1d6c3393246a Mon Sep 17 00:00:00 2001
+From: John Clark <inindev@gmail.com>
+Date: Sat, 30 Dec 2023 11:50:53 -0500
+Subject: [PATCH] arm64: dts: rockchip: add sdmmc card detect to the nanopc-t6
+
+The nanopc-t6 has an sdmmc card detect connected to gpio0_a4 which is
+active low.
+
+Signed-off-by: John Clark <inindev@gmail.com>
+Link: https://lore.kernel.org/r/20231230165053.3781-1-inindev@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+@@ -555,6 +555,7 @@
+ 	bus-width = <4>;
+ 	cap-mmc-highspeed;
+ 	cap-sd-highspeed;
++	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
+ 	disable-wp;
+ 	no-mmc;
+ 	no-sdio;

--- a/target/linux/rockchip/patches-6.6/054-06-v6.9-arm64-dts-rockchip-fix-nanopc-t6-sdmmc-regulator.patch
+++ b/target/linux/rockchip/patches-6.6/054-06-v6.9-arm64-dts-rockchip-fix-nanopc-t6-sdmmc-regulator.patch
@@ -1,0 +1,44 @@
+From 6cb02674a061e4ef4f437ab60c91038d4c0d85ef Mon Sep 17 00:00:00 2001
+From: John Clark <inindev@gmail.com>
+Date: Tue, 2 Jan 2024 02:40:53 +0000
+Subject: [PATCH] arm64: dts: rockchip: fix nanopc-t6 sdmmc regulator
+
+sdmmc on the nanopc-t6 is powered by vcc3v3_sd_s0, not vcc_3v3_s3
+add the vcc3v3_sd_s0 regulator, and control it with gpio4_a5
+
+Signed-off-by: John Clark <inindev@gmail.com>
+Link: https://lore.kernel.org/r/20240102024054.1030313-1-inindev@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+@@ -160,6 +160,17 @@
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
++	vcc3v3_sd_s0: vcc3v3-sd-s0-regulator {
++		compatible = "regulator-fixed";
++		enable-active-low;
++		gpio = <&gpio4 RK_PA5 GPIO_ACTIVE_LOW>;
++		regulator-boot-on;
++		regulator-max-microvolt = <3300000>;
++		regulator-min-microvolt = <3300000>;
++		regulator-name = "vcc3v3_sd_s0";
++		vin-supply = <&vcc_3v3_s3>;
++	};
++
+ 	vdd_4g_3v3: vdd-4g-3v3-regulator {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+@@ -560,7 +571,7 @@
+ 	no-mmc;
+ 	no-sdio;
+ 	sd-uhs-sdr104;
+-	vmmc-supply = <&vcc_3v3_s3>;
++	vmmc-supply = <&vcc3v3_sd_s0>;
+ 	vqmmc-supply = <&vccio_sd_s0>;
+ 	status = "okay";
+ };

--- a/target/linux/rockchip/patches-6.6/054-08-v6.12-arm64-dts-rockchip-prepare-NanoPC-T6-for-LTS-board.patch
+++ b/target/linux/rockchip/patches-6.6/054-08-v6.12-arm64-dts-rockchip-prepare-NanoPC-T6-for-LTS-board.patch
@@ -1,0 +1,1916 @@
+From d14f3a4f1feabb6bb5935bf3b275a1e6bf2208eb Mon Sep 17 00:00:00 2001
+From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Date: Thu, 29 Aug 2024 14:26:53 +0200
+Subject: [PATCH] arm64: dts: rockchip: prepare NanoPC-T6 for LTS board
+
+FriendlyELEC introduced a second version of NanoPC-T6 SBC.
+
+Create common include file and make NanoPC-T6 use it. Following
+patches will add LTS version.
+
+Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Link: https://lore.kernel.org/r/20240829-friendlyelec-nanopc-t6-lts-v6-2-edff247e8c02@linaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ .../boot/dts/rockchip/rk3588-nanopc-t6.dts    | 932 +----------------
+ .../boot/dts/rockchip/rk3588-nanopc-t6.dtsi   | 945 ++++++++++++++++++
+ 2 files changed, 947 insertions(+), 930 deletions(-)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+@@ -2,944 +2,16 @@
+ /*
+  * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
+  * Copyright (c) 2023 Thomas McKahan
++ * Copyright (c) 2024 Linaro Ltd.
+  *
+  */
+ 
+ /dts-v1/;
+ 
+-#include <dt-bindings/gpio/gpio.h>
+-#include <dt-bindings/pinctrl/rockchip.h>
+-#include <dt-bindings/usb/pd.h>
+-#include "rk3588.dtsi"
++#include "rk3588-nanopc-t6.dtsi"
+ 
+ / {
+ 	model = "FriendlyElec NanoPC-T6";
+ 	compatible = "friendlyarm,nanopc-t6", "rockchip,rk3588";
+ 
+-	aliases {
+-		mmc0 = &sdhci;
+-		mmc1 = &sdmmc;
+-	};
+-
+-	chosen {
+-		stdout-path = "serial2:1500000n8";
+-	};
+-
+-	leds {
+-		compatible = "gpio-leds";
+-
+-		sys_led: led-0 {
+-			gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
+-			label = "system-led";
+-			linux,default-trigger = "heartbeat";
+-			pinctrl-names = "default";
+-			pinctrl-0 = <&sys_led_pin>;
+-		};
+-
+-		usr_led: led-1 {
+-			gpios = <&gpio2 RK_PC0 GPIO_ACTIVE_HIGH>;
+-			label = "user-led";
+-			pinctrl-names = "default";
+-			pinctrl-0 = <&usr_led_pin>;
+-		};
+-	};
+-
+-	sound {
+-		compatible = "simple-audio-card";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&hp_det>;
+-
+-		simple-audio-card,name = "realtek,rt5616-codec";
+-		simple-audio-card,format = "i2s";
+-		simple-audio-card,mclk-fs = <256>;
+-
+-		simple-audio-card,hp-det-gpio = <&gpio1 RK_PC4 GPIO_ACTIVE_LOW>;
+-		simple-audio-card,hp-pin-name = "Headphones";
+-
+-		simple-audio-card,widgets =
+-			"Headphone", "Headphones",
+-			"Microphone", "Microphone Jack";
+-		simple-audio-card,routing =
+-			"Headphones", "HPOL",
+-			"Headphones", "HPOR",
+-			"MIC1", "Microphone Jack",
+-			"Microphone Jack", "micbias1";
+-
+-		simple-audio-card,cpu {
+-			sound-dai = <&i2s0_8ch>;
+-		};
+-		simple-audio-card,codec {
+-			sound-dai = <&rt5616>;
+-		};
+-	};
+-
+-	vcc12v_dcin: vcc12v-dcin-regulator {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc12v_dcin";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <12000000>;
+-		regulator-max-microvolt = <12000000>;
+-	};
+-
+-	/* vcc5v0_sys powers peripherals */
+-	vcc5v0_sys: vcc5v0-sys-regulator {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc5v0_sys";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-		vin-supply = <&vcc12v_dcin>;
+-	};
+-
+-	/* vcc4v0_sys powers the RK806, RK860's */
+-	vcc4v0_sys: vcc4v0-sys-regulator {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc4v0_sys";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <4000000>;
+-		regulator-max-microvolt = <4000000>;
+-		vin-supply = <&vcc12v_dcin>;
+-	};
+-
+-	vcc_1v1_nldo_s3: vcc-1v1-nldo-s3-regulator {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc-1v1-nldo-s3";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <1100000>;
+-		regulator-max-microvolt = <1100000>;
+-		vin-supply = <&vcc4v0_sys>;
+-	};
+-
+-	vcc_3v3_pcie20: vcc3v3-pcie20-regulator {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc_3v3_pcie20";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		vin-supply = <&vcc_3v3_s3>;
+-	};
+-
+-	vbus5v0_typec: vbus5v0-typec-regulator {
+-		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpio = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&typec5v_pwren>;
+-		regulator-name = "vbus5v0_typec";
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-
+-	vcc3v3_pcie2x1l0: vcc3v3-pcie2x1l0-regulator {
+-		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpio = <&gpio4 RK_PC2 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pcie_m2_1_pwren>;
+-		regulator-name = "vcc3v3_pcie2x1l0";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-
+-	vcc3v3_pcie30: vcc3v3-pcie30-regulator {
+-		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpios = <&gpio2 RK_PC5 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pcie_m2_0_pwren>;
+-		regulator-name = "vcc3v3_pcie30";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-
+-	vcc3v3_sd_s0: vcc3v3-sd-s0-regulator {
+-		compatible = "regulator-fixed";
+-		enable-active-low;
+-		gpio = <&gpio4 RK_PA5 GPIO_ACTIVE_LOW>;
+-		regulator-boot-on;
+-		regulator-max-microvolt = <3300000>;
+-		regulator-min-microvolt = <3300000>;
+-		regulator-name = "vcc3v3_sd_s0";
+-		vin-supply = <&vcc_3v3_s3>;
+-	};
+-
+-	vdd_4g_3v3: vdd-4g-3v3-regulator {
+-		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpio = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pin_4g_lte_pwren>;
+-		regulator-name = "vdd_4g_3v3";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-};
+-
+-&combphy0_ps {
+-	status = "okay";
+-};
+-
+-&combphy1_ps {
+-	status = "okay";
+-};
+-
+-&combphy2_psu {
+-	status = "okay";
+-};
+-
+-&cpu_l0 {
+-	cpu-supply = <&vdd_cpu_lit_s0>;
+-};
+-
+-&cpu_l1 {
+-	cpu-supply = <&vdd_cpu_lit_s0>;
+-};
+-
+-&cpu_l2 {
+-	cpu-supply = <&vdd_cpu_lit_s0>;
+-};
+-
+-&cpu_l3 {
+-	cpu-supply = <&vdd_cpu_lit_s0>;
+-};
+-
+-&cpu_b0{
+-	cpu-supply = <&vdd_cpu_big0_s0>;
+-};
+-
+-&cpu_b1{
+-	cpu-supply = <&vdd_cpu_big0_s0>;
+-};
+-
+-&cpu_b2{
+-	cpu-supply = <&vdd_cpu_big1_s0>;
+-};
+-
+-&cpu_b3{
+-	cpu-supply = <&vdd_cpu_big1_s0>;
+-};
+-
+-&gpio0 {
+-	gpio-line-names = /* GPIO0 A0-A7 */
+-			  "", "", "", "",
+-			  "", "", "", "",
+-			  /* GPIO0 B0-B7 */
+-			  "", "", "", "",
+-			  "", "", "", "",
+-			  /* GPIO0 C0-C7 */
+-			  "", "", "", "",
+-			  "HEADER_10", "HEADER_08", "HEADER_32", "",
+-			  /* GPIO0 D0-D7 */
+-			  "", "", "", "",
+-			  "", "", "", "";
+-};
+-
+-&gpio1 {
+-	gpio-line-names = /* GPIO1 A0-A7 */
+-			  "HEADER_27", "HEADER_28", "", "",
+-			  "", "", "", "HEADER_15",
+-			  /* GPIO1 B0-B7 */
+-			  "HEADER_26", "HEADER_21", "HEADER_19", "HEADER_23",
+-			  "HEADER_24", "HEADER_22", "", "",
+-			  /* GPIO1 C0-C7 */
+-			  "", "", "", "",
+-			  "", "", "", "",
+-			  /* GPIO1 D0-D7 */
+-			  "", "", "", "",
+-			  "", "", "HEADER_05", "HEADER_03";
+-};
+-
+-&gpio2 {
+-	gpio-line-names = /* GPIO2 A0-A7 */
+-			  "", "", "", "",
+-			  "", "", "", "",
+-			  /* GPIO2 B0-B7 */
+-			  "", "", "", "",
+-			  "", "", "", "",
+-			  /* GPIO2 C0-C7 */
+-			  "", "CSI1_11", "CSI1_12", "",
+-			  "", "", "", "",
+-			  /* GPIO2 D0-D7 */
+-			  "", "", "", "",
+-			  "", "", "", "";
+-};
+-
+-&gpio3 {
+-	gpio-line-names = /* GPIO3 A0-A7 */
+-			  "HEADER_35", "HEADER_38", "HEADER_40", "HEADER_36",
+-			  "HEADER_37", "", "DSI0_12", "",
+-			  /* GPIO3 B0-B7 */
+-			  "HEADER_33", "DSI0_10", "HEADER_07", "HEADER_16",
+-			  "HEADER_18", "HEADER_29", "HEADER_31", "HEADER_12",
+-			  /* GPIO3 C0-C7 */
+-			  "DSI0_08", "DSI0_14", "HEADER_11", "HEADER_13",
+-			  "", "", "", "",
+-			  /* GPIO3 D0-D7 */
+-			  "", "", "", "",
+-			  "", "DSI1_10", "", "";
+-};
+-
+-&gpio4 {
+-	gpio-line-names = /* GPIO4 A0-A7 */
+-			  "DSI1_08", "DSI1_14", "", "DSI1_12",
+-			  "", "", "", "",
+-			  /* GPIO4 B0-B7 */
+-			  "", "", "", "",
+-			  "", "", "", "",
+-			  /* GPIO4 C0-C7 */
+-			  "", "", "", "",
+-			  "CSI0_11", "CSI0_12", "", "",
+-			  /* GPIO4 D0-D7 */
+-			  "", "", "", "",
+-			  "", "", "", "";
+-};
+-
+-&i2c0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&i2c0m2_xfer>;
+-	status = "okay";
+-
+-	vdd_cpu_big0_s0: regulator@42 {
+-		compatible = "rockchip,rk8602";
+-		reg = <0x42>;
+-		fcs,suspend-voltage-selector = <1>;
+-		regulator-name = "vdd_cpu_big0_s0";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <550000>;
+-		regulator-max-microvolt = <1050000>;
+-		regulator-ramp-delay = <2300>;
+-		vin-supply = <&vcc4v0_sys>;
+-
+-		regulator-state-mem {
+-			regulator-off-in-suspend;
+-		};
+-	};
+-
+-	vdd_cpu_big1_s0: regulator@43 {
+-		compatible = "rockchip,rk8603", "rockchip,rk8602";
+-		reg = <0x43>;
+-		fcs,suspend-voltage-selector = <1>;
+-		regulator-name = "vdd_cpu_big1_s0";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <550000>;
+-		regulator-max-microvolt = <1050000>;
+-		regulator-ramp-delay = <2300>;
+-		vin-supply = <&vcc4v0_sys>;
+-
+-		regulator-state-mem {
+-			regulator-off-in-suspend;
+-		};
+-	};
+-};
+-
+-&i2c2 {
+-	status = "okay";
+-
+-	vdd_npu_s0: regulator@42 {
+-		compatible = "rockchip,rk8602";
+-		reg = <0x42>;
+-		rockchip,suspend-voltage-selector = <1>;
+-		regulator-name = "vdd_npu_s0";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <550000>;
+-		regulator-max-microvolt = <950000>;
+-		regulator-ramp-delay = <2300>;
+-		vin-supply = <&vcc4v0_sys>;
+-
+-		regulator-state-mem {
+-			regulator-off-in-suspend;
+-		};
+-	};
+-};
+-
+-&i2c6 {
+-	clock-frequency = <200000>;
+-	status = "okay";
+-
+-	fusb302: typec-portc@22 {
+-		compatible = "fcs,fusb302";
+-		reg = <0x22>;
+-		interrupt-parent = <&gpio0>;
+-		interrupts = <RK_PD3 IRQ_TYPE_LEVEL_LOW>;
+-		pinctrl-0 = <&usbc0_int>;
+-		pinctrl-names = "default";
+-		vbus-supply = <&vbus5v0_typec>;
+-
+-		connector {
+-			compatible = "usb-c-connector";
+-			data-role = "dual";
+-			label = "USB-C";
+-			power-role = "dual";
+-			try-power-role = "sink";
+-			source-pdos = <PDO_FIXED(5000, 2000, PDO_FIXED_USB_COMM)>;
+-			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+-			op-sink-microwatt = <1000000>;
+-		};
+-	};
+-
+-	hym8563: rtc@51 {
+-		compatible = "haoyu,hym8563";
+-		reg = <0x51>;
+-		#clock-cells = <0>;
+-		clock-output-names = "hym8563";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&hym8563_int>;
+-		interrupt-parent = <&gpio0>;
+-		interrupts = <RK_PB0 IRQ_TYPE_LEVEL_LOW>;
+-		wakeup-source;
+-	};
+-};
+-
+-&i2c7 {
+-	clock-frequency = <200000>;
+-	status = "okay";
+-
+-	rt5616: codec@1b {
+-		compatible = "realtek,rt5616";
+-		reg = <0x1b>;
+-		clocks = <&cru I2S0_8CH_MCLKOUT>;
+-		clock-names = "mclk";
+-		#sound-dai-cells = <0>;
+-		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
+-		assigned-clock-rates = <12288000>;
+-
+-		port {
+-			rt5616_p0_0: endpoint {
+-				remote-endpoint = <&i2s0_8ch_p0_0>;
+-			};
+-		};
+-	};
+-
+-	/* connected with MIPI-CSI1 */
+-};
+-
+-&i2c8 {
+-	pinctrl-0 = <&i2c8m2_xfer>;
+-};
+-
+-&i2s0_8ch {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&i2s0_lrck
+-		     &i2s0_mclk
+-		     &i2s0_sclk
+-		     &i2s0_sdi0
+-		     &i2s0_sdo0>;
+-	status = "okay";
+-
+-	i2s0_8ch_p0: port {
+-		i2s0_8ch_p0_0: endpoint {
+-			dai-format = "i2s";
+-			mclk-fs = <256>;
+-			remote-endpoint = <&rt5616_p0_0>;
+-		};
+-	};
+-};
+-
+-&pcie2x1l0 {
+-	reset-gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_HIGH>;
+-	vpcie3v3-supply = <&vcc_3v3_pcie20>;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pcie2_0_rst>;
+-	status = "okay";
+-};
+-
+-&pcie2x1l1 {
+-	reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
+-	vpcie3v3-supply = <&vcc3v3_pcie2x1l0>;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pcie2_1_rst>;
+-	status = "okay";
+-};
+-
+-&pcie2x1l2 {
+-	reset-gpios = <&gpio4 RK_PA4 GPIO_ACTIVE_HIGH>;
+-	vpcie3v3-supply = <&vcc_3v3_pcie20>;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pcie2_2_rst>;
+-	status = "okay";
+-};
+-
+-&pcie30phy {
+-	status = "okay";
+-};
+-
+-&pcie3x4 {
+-	reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
+-	vpcie3v3-supply = <&vcc3v3_pcie30>;
+-	status = "okay";
+-};
+-
+-&pinctrl {
+-	gpio-leds {
+-		sys_led_pin: sys-led-pin {
+-			rockchip,pins = <2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+-		usr_led_pin: usr-led-pin {
+-			rockchip,pins = <2 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	headphone {
+-		hp_det: hp-det {
+-			rockchip,pins = <1 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	hym8563 {
+-		hym8563_int: hym8563-int {
+-			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_up>;
+-		};
+-	};
+-
+-	pcie {
+-		pcie2_0_rst: pcie2-0-rst {
+-			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+-		pcie2_1_rst: pcie2-1-rst {
+-			rockchip,pins = <4 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+-		pcie2_2_rst: pcie2-2-rst {
+-			rockchip,pins = <4 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+-		pcie_m2_0_pwren: pcie-m20-pwren {
+-			rockchip,pins = <2 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+-		pcie_m2_1_pwren: pcie-m21-pwren {
+-			rockchip,pins = <4 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	usb {
+-		pin_4g_lte_pwren: 4g-lte-pwren {
+-			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+-		typec5v_pwren: typec5v-pwren {
+-			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+-		usbc0_int: usbc0-int {
+-			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>;
+-		};
+-	};
+-};
+-
+-&pwm1 {
+-	pinctrl-0 = <&pwm1m1_pins>;
+-	status = "okay";
+-};
+-
+-&saradc {
+-	vref-supply = <&avcc_1v8_s0>;
+-	status = "okay";
+-};
+-
+-&sdhci {
+-	bus-width = <8>;
+-	no-sdio;
+-	no-sd;
+-	non-removable;
+-	max-frequency = <200000000>;
+-	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
+-	status = "okay";
+-};
+-
+-&sdmmc {
+-	bus-width = <4>;
+-	cap-mmc-highspeed;
+-	cap-sd-highspeed;
+-	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
+-	disable-wp;
+-	no-mmc;
+-	no-sdio;
+-	sd-uhs-sdr104;
+-	vmmc-supply = <&vcc3v3_sd_s0>;
+-	vqmmc-supply = <&vccio_sd_s0>;
+-	status = "okay";
+-};
+-
+-&spi2 {
+-	status = "okay";
+-	assigned-clocks = <&cru CLK_SPI2>;
+-	assigned-clock-rates = <200000000>;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
+-	num-cs = <1>;
+-
+-	pmic@0 {
+-		compatible = "rockchip,rk806";
+-		spi-max-frequency = <1000000>;
+-		reg = <0x0>;
+-
+-		interrupt-parent = <&gpio0>;
+-		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
+-
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
+-			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
+-
+-		system-power-controller;
+-
+-		vcc1-supply = <&vcc4v0_sys>;
+-		vcc2-supply = <&vcc4v0_sys>;
+-		vcc3-supply = <&vcc4v0_sys>;
+-		vcc4-supply = <&vcc4v0_sys>;
+-		vcc5-supply = <&vcc4v0_sys>;
+-		vcc6-supply = <&vcc4v0_sys>;
+-		vcc7-supply = <&vcc4v0_sys>;
+-		vcc8-supply = <&vcc4v0_sys>;
+-		vcc9-supply = <&vcc4v0_sys>;
+-		vcc10-supply = <&vcc4v0_sys>;
+-		vcc11-supply = <&vcc_2v0_pldo_s3>;
+-		vcc12-supply = <&vcc4v0_sys>;
+-		vcc13-supply = <&vcc_1v1_nldo_s3>;
+-		vcc14-supply = <&vcc_1v1_nldo_s3>;
+-		vcca-supply = <&vcc4v0_sys>;
+-
+-		gpio-controller;
+-		#gpio-cells = <2>;
+-
+-		rk806_dvs1_null: dvs1-null-pins {
+-			pins = "gpio_pwrctrl1";
+-			function = "pin_fun0";
+-		};
+-
+-		rk806_dvs2_null: dvs2-null-pins {
+-			pins = "gpio_pwrctrl2";
+-			function = "pin_fun0";
+-		};
+-
+-		rk806_dvs3_null: dvs3-null-pins {
+-			pins = "gpio_pwrctrl3";
+-			function = "pin_fun0";
+-		};
+-
+-		regulators {
+-			vdd_gpu_s0: vdd_gpu_mem_s0: dcdc-reg1 {
+-				regulator-boot-on;
+-				regulator-min-microvolt = <550000>;
+-				regulator-max-microvolt = <950000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_gpu_s0";
+-				regulator-enable-ramp-delay = <400>;
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_cpu_lit_s0: vdd_cpu_lit_mem_s0: dcdc-reg2 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <550000>;
+-				regulator-max-microvolt = <950000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_cpu_lit_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_log_s0: dcdc-reg3 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <675000>;
+-				regulator-max-microvolt = <750000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_log_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <750000>;
+-				};
+-			};
+-
+-			vdd_vdenc_s0: vdd_vdenc_mem_s0: dcdc-reg4 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <550000>;
+-				regulator-max-microvolt = <950000>;
+-				regulator-init-microvolt = <750000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_vdenc_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_ddr_s0: dcdc-reg5 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <675000>;
+-				regulator-max-microvolt = <900000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_ddr_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <850000>;
+-				};
+-			};
+-
+-			vdd2_ddr_s3: dcdc-reg6 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-name = "vdd2_ddr_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-				};
+-			};
+-
+-			vcc_2v0_pldo_s3: dcdc-reg7 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <2000000>;
+-				regulator-max-microvolt = <2000000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_2v0_pldo_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <2000000>;
+-				};
+-			};
+-
+-			vcc_3v3_s3: dcdc-reg8 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <3300000>;
+-				regulator-max-microvolt = <3300000>;
+-				regulator-name = "vcc_3v3_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <3300000>;
+-				};
+-			};
+-
+-			vddq_ddr_s0: dcdc-reg9 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-name = "vddq_ddr_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vcc_1v8_s3: dcdc-reg10 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-				regulator-name = "vcc_1v8_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <1800000>;
+-				};
+-			};
+-
+-			avcc_1v8_s0: pldo-reg1 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-				regulator-name = "avcc_1v8_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vcc_1v8_s0: pldo-reg2 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-				regulator-name = "vcc_1v8_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <1800000>;
+-				};
+-			};
+-
+-			avdd_1v2_s0: pldo-reg3 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1200000>;
+-				regulator-max-microvolt = <1200000>;
+-				regulator-name = "avdd_1v2_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vcc_3v3_s0: pldo-reg4 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <3300000>;
+-				regulator-max-microvolt = <3300000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vcc_3v3_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vccio_sd_s0: pldo-reg5 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <3300000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vccio_sd_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			pldo6_s3: pldo-reg6 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-				regulator-name = "pldo6_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <1800000>;
+-				};
+-			};
+-
+-			vdd_0v75_s3: nldo-reg1 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <750000>;
+-				regulator-max-microvolt = <750000>;
+-				regulator-name = "vdd_0v75_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <750000>;
+-				};
+-			};
+-
+-			vdd_ddr_pll_s0: nldo-reg2 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <850000>;
+-				regulator-max-microvolt = <850000>;
+-				regulator-name = "vdd_ddr_pll_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <850000>;
+-				};
+-			};
+-
+-			avdd_0v75_s0: nldo-reg3 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <750000>;
+-				regulator-max-microvolt = <750000>;
+-				regulator-name = "avdd_0v75_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_0v85_s0: nldo-reg4 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <850000>;
+-				regulator-max-microvolt = <850000>;
+-				regulator-name = "vdd_0v85_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_0v75_s0: nldo-reg5 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <750000>;
+-				regulator-max-microvolt = <750000>;
+-				regulator-name = "vdd_0v75_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-		};
+-	};
+-};
+-
+-&tsadc {
+-	status = "okay";
+-};
+-
+-&uart2 {
+-	pinctrl-0 = <&uart2m0_xfer>;
+-	status = "okay";
+-};
+-
+-&u2phy2_host {
+-	phy-supply = <&vdd_4g_3v3>;
+-	status = "okay";
+-};
+-
+-&u2phy3_host {
+-	status = "okay";
+-};
+-
+-&u2phy2 {
+-	status = "okay";
+-};
+-
+-&u2phy3 {
+-	status = "okay";
+-};
+-
+-&usb_host0_ehci {
+-	status = "okay";
+-};
+-
+-&usb_host0_ohci {
+-	status = "okay";
+-};
+-
+-&usb_host1_ehci {
+-	status = "okay";
+-};
+-
+-&usb_host1_ohci {
+-	status = "okay";
+ };
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -0,0 +1,945 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
++ * Copyright (c) 2023 Thomas McKahan
++ *
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++#include <dt-bindings/usb/pd.h>
++#include "rk3588.dtsi"
++
++/ {
++	model = "FriendlyElec NanoPC-T6";
++	compatible = "friendlyarm,nanopc-t6", "rockchip,rk3588";
++
++	aliases {
++		mmc0 = &sdhci;
++		mmc1 = &sdmmc;
++	};
++
++	chosen {
++		stdout-path = "serial2:1500000n8";
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		sys_led: led-0 {
++			gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
++			label = "system-led";
++			linux,default-trigger = "heartbeat";
++			pinctrl-names = "default";
++			pinctrl-0 = <&sys_led_pin>;
++		};
++
++		usr_led: led-1 {
++			gpios = <&gpio2 RK_PC0 GPIO_ACTIVE_HIGH>;
++			label = "user-led";
++			pinctrl-names = "default";
++			pinctrl-0 = <&usr_led_pin>;
++		};
++	};
++
++	sound {
++		compatible = "simple-audio-card";
++		pinctrl-names = "default";
++		pinctrl-0 = <&hp_det>;
++
++		simple-audio-card,name = "realtek,rt5616-codec";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <256>;
++
++		simple-audio-card,hp-det-gpio = <&gpio1 RK_PC4 GPIO_ACTIVE_LOW>;
++		simple-audio-card,hp-pin-name = "Headphones";
++
++		simple-audio-card,widgets =
++			"Headphone", "Headphones",
++			"Microphone", "Microphone Jack";
++		simple-audio-card,routing =
++			"Headphones", "HPOL",
++			"Headphones", "HPOR",
++			"MIC1", "Microphone Jack",
++			"Microphone Jack", "micbias1";
++
++		simple-audio-card,cpu {
++			sound-dai = <&i2s0_8ch>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&rt5616>;
++		};
++	};
++
++	vcc12v_dcin: vcc12v-dcin-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc12v_dcin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++	};
++
++	/* vcc5v0_sys powers peripherals */
++	vcc5v0_sys: vcc5v0-sys-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	/* vcc4v0_sys powers the RK806, RK860's */
++	vcc4v0_sys: vcc4v0-sys-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc4v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <4000000>;
++		regulator-max-microvolt = <4000000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc_1v1_nldo_s3: vcc-1v1-nldo-s3-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-1v1-nldo-s3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1100000>;
++		vin-supply = <&vcc4v0_sys>;
++	};
++
++	vcc_3v3_pcie20: vcc3v3-pcie20-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_3v3_pcie20";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_3v3_s3>;
++	};
++
++	vbus5v0_typec: vbus5v0-typec-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&typec5v_pwren>;
++		regulator-name = "vbus5v0_typec";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc3v3_pcie2x1l0: vcc3v3-pcie2x1l0-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio4 RK_PC2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie_m2_1_pwren>;
++		regulator-name = "vcc3v3_pcie2x1l0";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc3v3_pcie30: vcc3v3-pcie30-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpios = <&gpio2 RK_PC5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie_m2_0_pwren>;
++		regulator-name = "vcc3v3_pcie30";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc3v3_sd_s0: vcc3v3-sd-s0-regulator {
++		compatible = "regulator-fixed";
++		enable-active-low;
++		gpio = <&gpio4 RK_PA5 GPIO_ACTIVE_LOW>;
++		regulator-boot-on;
++		regulator-max-microvolt = <3300000>;
++		regulator-min-microvolt = <3300000>;
++		regulator-name = "vcc3v3_sd_s0";
++		vin-supply = <&vcc_3v3_s3>;
++	};
++
++	vdd_4g_3v3: vdd-4g-3v3-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pin_4g_lte_pwren>;
++		regulator-name = "vdd_4g_3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++};
++
++&combphy0_ps {
++	status = "okay";
++};
++
++&combphy1_ps {
++	status = "okay";
++};
++
++&combphy2_psu {
++	status = "okay";
++};
++
++&cpu_l0 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l1 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l2 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l3 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_b0 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++};
++
++&cpu_b1 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++};
++
++&cpu_b2 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++};
++
++&cpu_b3 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++};
++
++&gpio0 {
++	gpio-line-names = /* GPIO0 A0-A7 */
++			  "", "", "", "",
++			  "", "", "", "",
++			  /* GPIO0 B0-B7 */
++			  "", "", "", "",
++			  "", "", "", "",
++			  /* GPIO0 C0-C7 */
++			  "", "", "", "",
++			  "HEADER_10", "HEADER_08", "HEADER_32", "",
++			  /* GPIO0 D0-D7 */
++			  "", "", "", "",
++			  "", "", "", "";
++};
++
++&gpio1 {
++	gpio-line-names = /* GPIO1 A0-A7 */
++			  "HEADER_27", "HEADER_28", "", "",
++			  "", "", "", "HEADER_15",
++			  /* GPIO1 B0-B7 */
++			  "HEADER_26", "HEADER_21", "HEADER_19", "HEADER_23",
++			  "HEADER_24", "HEADER_22", "", "",
++			  /* GPIO1 C0-C7 */
++			  "", "", "", "",
++			  "", "", "", "",
++			  /* GPIO1 D0-D7 */
++			  "", "", "", "",
++			  "", "", "HEADER_05", "HEADER_03";
++};
++
++&gpio2 {
++	gpio-line-names = /* GPIO2 A0-A7 */
++			  "", "", "", "",
++			  "", "", "", "",
++			  /* GPIO2 B0-B7 */
++			  "", "", "", "",
++			  "", "", "", "",
++			  /* GPIO2 C0-C7 */
++			  "", "CSI1_11", "CSI1_12", "",
++			  "", "", "", "",
++			  /* GPIO2 D0-D7 */
++			  "", "", "", "",
++			  "", "", "", "";
++};
++
++&gpio3 {
++	gpio-line-names = /* GPIO3 A0-A7 */
++			  "HEADER_35", "HEADER_38", "HEADER_40", "HEADER_36",
++			  "HEADER_37", "", "DSI0_12", "",
++			  /* GPIO3 B0-B7 */
++			  "HEADER_33", "DSI0_10", "HEADER_07", "HEADER_16",
++			  "HEADER_18", "HEADER_29", "HEADER_31", "HEADER_12",
++			  /* GPIO3 C0-C7 */
++			  "DSI0_08", "DSI0_14", "HEADER_11", "HEADER_13",
++			  "", "", "", "",
++			  /* GPIO3 D0-D7 */
++			  "", "", "", "",
++			  "", "DSI1_10", "", "";
++};
++
++&gpio4 {
++	gpio-line-names = /* GPIO4 A0-A7 */
++			  "DSI1_08", "DSI1_14", "", "DSI1_12",
++			  "", "", "", "",
++			  /* GPIO4 B0-B7 */
++			  "", "", "", "",
++			  "", "", "", "",
++			  /* GPIO4 C0-C7 */
++			  "", "", "", "",
++			  "CSI0_11", "CSI0_12", "", "",
++			  /* GPIO4 D0-D7 */
++			  "", "", "", "",
++			  "", "", "", "";
++};
++
++&i2c0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c0m2_xfer>;
++	status = "okay";
++
++	vdd_cpu_big0_s0: regulator@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu_big0_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc4v0_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vdd_cpu_big1_s0: regulator@43 {
++		compatible = "rockchip,rk8603", "rockchip,rk8602";
++		reg = <0x43>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu_big1_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc4v0_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++};
++
++&i2c2 {
++	status = "okay";
++
++	vdd_npu_s0: regulator@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		rockchip,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_npu_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <950000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc4v0_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++};
++
++&i2c6 {
++	clock-frequency = <200000>;
++	status = "okay";
++
++	fusb302: typec-portc@22 {
++		compatible = "fcs,fusb302";
++		reg = <0x22>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PD3 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-0 = <&usbc0_int>;
++		pinctrl-names = "default";
++		vbus-supply = <&vbus5v0_typec>;
++
++		connector {
++			compatible = "usb-c-connector";
++			data-role = "dual";
++			label = "USB-C";
++			power-role = "dual";
++			try-power-role = "sink";
++			source-pdos = <PDO_FIXED(5000, 2000, PDO_FIXED_USB_COMM)>;
++			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
++			op-sink-microwatt = <1000000>;
++		};
++	};
++
++	hym8563: rtc@51 {
++		compatible = "haoyu,hym8563";
++		reg = <0x51>;
++		#clock-cells = <0>;
++		clock-output-names = "hym8563";
++		pinctrl-names = "default";
++		pinctrl-0 = <&hym8563_int>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PB0 IRQ_TYPE_LEVEL_LOW>;
++		wakeup-source;
++	};
++};
++
++&i2c7 {
++	clock-frequency = <200000>;
++	status = "okay";
++
++	rt5616: codec@1b {
++		compatible = "realtek,rt5616";
++		reg = <0x1b>;
++		clocks = <&cru I2S0_8CH_MCLKOUT>;
++		clock-names = "mclk";
++		#sound-dai-cells = <0>;
++		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
++		assigned-clock-rates = <12288000>;
++
++		port {
++			rt5616_p0_0: endpoint {
++				remote-endpoint = <&i2s0_8ch_p0_0>;
++			};
++		};
++	};
++
++	/* connected with MIPI-CSI1 */
++};
++
++&i2c8 {
++	pinctrl-0 = <&i2c8m2_xfer>;
++};
++
++&i2s0_8ch {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s0_lrck
++		     &i2s0_mclk
++		     &i2s0_sclk
++		     &i2s0_sdi0
++		     &i2s0_sdo0>;
++	status = "okay";
++
++	i2s0_8ch_p0: port {
++		i2s0_8ch_p0_0: endpoint {
++			dai-format = "i2s";
++			mclk-fs = <256>;
++			remote-endpoint = <&rt5616_p0_0>;
++		};
++	};
++};
++
++&pcie2x1l0 {
++	reset-gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc_3v3_pcie20>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie2_0_rst>;
++	status = "okay";
++};
++
++&pcie2x1l1 {
++	reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie2x1l0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie2_1_rst>;
++	status = "okay";
++};
++
++&pcie2x1l2 {
++	reset-gpios = <&gpio4 RK_PA4 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc_3v3_pcie20>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie2_2_rst>;
++	status = "okay";
++};
++
++&pcie30phy {
++	status = "okay";
++};
++
++&pcie3x4 {
++	reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie30>;
++	status = "okay";
++};
++
++&pinctrl {
++	gpio-leds {
++		sys_led_pin: sys-led-pin {
++			rockchip,pins = <2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		usr_led_pin: usr-led-pin {
++			rockchip,pins = <2 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	headphone {
++		hp_det: hp-det {
++			rockchip,pins = <1 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	hym8563 {
++		hym8563_int: hym8563-int {
++			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	pcie {
++		pcie2_0_rst: pcie2-0-rst {
++			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie2_1_rst: pcie2-1-rst {
++			rockchip,pins = <4 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie2_2_rst: pcie2-2-rst {
++			rockchip,pins = <4 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie_m2_0_pwren: pcie-m20-pwren {
++			rockchip,pins = <2 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie_m2_1_pwren: pcie-m21-pwren {
++			rockchip,pins = <4 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb {
++		pin_4g_lte_pwren: 4g-lte-pwren {
++			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		typec5v_pwren: typec5v-pwren {
++			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		usbc0_int: usbc0-int {
++			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++};
++
++&pwm1 {
++	pinctrl-0 = <&pwm1m1_pins>;
++	status = "okay";
++};
++
++&saradc {
++	vref-supply = <&avcc_1v8_s0>;
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	no-sdio;
++	no-sd;
++	non-removable;
++	max-frequency = <200000000>;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	status = "okay";
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
++	disable-wp;
++	no-mmc;
++	no-sdio;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc3v3_sd_s0>;
++	vqmmc-supply = <&vccio_sd_s0>;
++	status = "okay";
++};
++
++&spi2 {
++	status = "okay";
++	assigned-clocks = <&cru CLK_SPI2>;
++	assigned-clock-rates = <200000000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
++	num-cs = <1>;
++
++	pmic@0 {
++		compatible = "rockchip,rk806";
++		spi-max-frequency = <1000000>;
++		reg = <0x0>;
++
++		interrupt-parent = <&gpio0>;
++		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
++			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
++
++		system-power-controller;
++
++		vcc1-supply = <&vcc4v0_sys>;
++		vcc2-supply = <&vcc4v0_sys>;
++		vcc3-supply = <&vcc4v0_sys>;
++		vcc4-supply = <&vcc4v0_sys>;
++		vcc5-supply = <&vcc4v0_sys>;
++		vcc6-supply = <&vcc4v0_sys>;
++		vcc7-supply = <&vcc4v0_sys>;
++		vcc8-supply = <&vcc4v0_sys>;
++		vcc9-supply = <&vcc4v0_sys>;
++		vcc10-supply = <&vcc4v0_sys>;
++		vcc11-supply = <&vcc_2v0_pldo_s3>;
++		vcc12-supply = <&vcc4v0_sys>;
++		vcc13-supply = <&vcc_1v1_nldo_s3>;
++		vcc14-supply = <&vcc_1v1_nldo_s3>;
++		vcca-supply = <&vcc4v0_sys>;
++
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		rk806_dvs1_null: dvs1-null-pins {
++			pins = "gpio_pwrctrl1";
++			function = "pin_fun0";
++		};
++
++		rk806_dvs2_null: dvs2-null-pins {
++			pins = "gpio_pwrctrl2";
++			function = "pin_fun0";
++		};
++
++		rk806_dvs3_null: dvs3-null-pins {
++			pins = "gpio_pwrctrl3";
++			function = "pin_fun0";
++		};
++
++		regulators {
++			vdd_gpu_s0: vdd_gpu_mem_s0: dcdc-reg1 {
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_gpu_s0";
++				regulator-enable-ramp-delay = <400>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_cpu_lit_s0: vdd_cpu_lit_mem_s0: dcdc-reg2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_cpu_lit_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_log_s0: dcdc-reg3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <750000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_log_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_vdenc_s0: vdd_vdenc_mem_s0: dcdc-reg4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-init-microvolt = <750000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_vdenc_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_ddr_s0: dcdc-reg5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <900000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_ddr_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			vdd2_ddr_s3: dcdc-reg6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vdd2_ddr_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_2v0_pldo_s3: dcdc-reg7 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <2000000>;
++				regulator-max-microvolt = <2000000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_2v0_pldo_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <2000000>;
++				};
++			};
++
++			vcc_3v3_s3: dcdc-reg8 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc_3v3_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vddq_ddr_s0: dcdc-reg9 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vddq_ddr_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v8_s3: dcdc-reg10 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			avcc_1v8_s0: pldo-reg1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "avcc_1v8_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v8_s0: pldo-reg2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			avdd_1v2_s0: pldo-reg3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1200000>;
++				regulator-max-microvolt = <1200000>;
++				regulator-name = "avdd_1v2_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_3v3_s0: pldo-reg4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vcc_3v3_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vccio_sd_s0: pldo-reg5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vccio_sd_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			pldo6_s3: pldo-reg6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "pldo6_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_0v75_s3: nldo-reg1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "vdd_0v75_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_ddr_pll_s0: nldo-reg2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++				regulator-name = "vdd_ddr_pll_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			avdd_0v75_s0: nldo-reg3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "avdd_0v75_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_0v85_s0: nldo-reg4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++				regulator-name = "vdd_0v85_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_0v75_s0: nldo-reg5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "vdd_0v75_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++		};
++	};
++};
++
++&tsadc {
++	status = "okay";
++};
++
++&uart2 {
++	pinctrl-0 = <&uart2m0_xfer>;
++	status = "okay";
++};
++
++&u2phy2_host {
++	phy-supply = <&vdd_4g_3v3>;
++	status = "okay";
++};
++
++&u2phy3_host {
++	status = "okay";
++};
++
++&u2phy2 {
++	status = "okay";
++};
++
++&u2phy3 {
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	status = "okay";
++};

--- a/target/linux/rockchip/patches-6.6/054-09-v6.12-arm64-dts-rockchip-move-NanoPC-T6-parts-to-DTS.patch
+++ b/target/linux/rockchip/patches-6.6/054-09-v6.12-arm64-dts-rockchip-move-NanoPC-T6-parts-to-DTS.patch
@@ -1,0 +1,85 @@
+From aea8d84070fe0846961deb23228d9dd3f8caefb3 Mon Sep 17 00:00:00 2001
+From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Date: Thu, 29 Aug 2024 14:26:54 +0200
+Subject: [PATCH] arm64: dts: rockchip: move NanoPC-T6 parts to DTS
+
+MiniPCIe slot is present only in first version of NanoPC-T6 (2301).
+
+Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Link: https://lore.kernel.org/r/20240829-friendlyelec-nanopc-t6-lts-v6-3-edff247e8c02@linaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ .../boot/dts/rockchip/rk3588-nanopc-t6.dts    | 23 +++++++++++++++++++
+ .../boot/dts/rockchip/rk3588-nanopc-t6.dtsi   | 17 --------------
+ 2 files changed, 23 insertions(+), 17 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+@@ -14,4 +14,27 @@
+ 	model = "FriendlyElec NanoPC-T6";
+ 	compatible = "friendlyarm,nanopc-t6", "rockchip,rk3588";
+ 
++	vdd_4g_3v3: vdd-4g-3v3-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pin_4g_lte_pwren>;
++		regulator-name = "vdd_4g_3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++};
++
++&pinctrl {
++	usb {
++		pin_4g_lte_pwren: 4g-lte-pwren {
++			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&u2phy2_host {
++	phy-supply = <&vdd_4g_3v3>;
+ };
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -170,18 +170,6 @@
+ 		regulator-name = "vcc3v3_sd_s0";
+ 		vin-supply = <&vcc_3v3_s3>;
+ 	};
+-
+-	vdd_4g_3v3: vdd-4g-3v3-regulator {
+-		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpio = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pin_4g_lte_pwren>;
+-		regulator-name = "vdd_4g_3v3";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+ };
+ 
+ &combphy0_ps {
+@@ -527,10 +515,6 @@
+ 	};
+ 
+ 	usb {
+-		pin_4g_lte_pwren: 4g-lte-pwren {
+-			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+ 		typec5v_pwren: typec5v-pwren {
+ 			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+@@ -912,7 +896,6 @@
+ };
+ 
+ &u2phy2_host {
+-	phy-supply = <&vdd_4g_3v3>;
+ 	status = "okay";
+ };
+ 

--- a/target/linux/rockchip/patches-6.6/054-10-v6.12-arm64-dts-rockchip-add-SPI-flash-on-NanoPC-T6.patch
+++ b/target/linux/rockchip/patches-6.6/054-10-v6.12-arm64-dts-rockchip-add-SPI-flash-on-NanoPC-T6.patch
@@ -1,0 +1,40 @@
+From a22a629c63b1addcf2d81eaf30383c1deca5b7a9 Mon Sep 17 00:00:00 2001
+From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Date: Thu, 29 Aug 2024 14:26:56 +0200
+Subject: [PATCH] arm64: dts: rockchip: add SPI flash on NanoPC-T6
+
+FriendlyELEC NanoPC-T6 has optional SPI flash chip on-board.
+It is populated with 32MB one on LTS version.
+
+Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Reviewed-by: Jonas Karlman <jonas@kwiboo.se>
+Link: https://lore.kernel.org/r/20240829-friendlyelec-nanopc-t6-lts-v6-5-edff247e8c02@linaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ .../arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -560,6 +560,21 @@
+ 	status = "okay";
+ };
+ 
++/* optional on non-LTS, populated on LTS version */
++&sfc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&fspim1_pins>;
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <104000000>;
++		spi-rx-bus-width = <4>;
++		spi-tx-bus-width = <1>;
++	};
++};
++
+ &spi2 {
+ 	status = "okay";
+ 	assigned-clocks = <&cru CLK_SPI2>;

--- a/target/linux/rockchip/patches-6.6/054-11-v6.12-arm64-dts-rockchip-add-IR-receiver-to-NanoPC-T6.patch
+++ b/target/linux/rockchip/patches-6.6/054-11-v6.12-arm64-dts-rockchip-add-IR-receiver-to-NanoPC-T6.patch
@@ -1,0 +1,53 @@
+From b70caff0f9592719b6c977e291c33192e959c9d4 Mon Sep 17 00:00:00 2001
+From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Date: Thu, 29 Aug 2024 14:26:57 +0200
+Subject: [PATCH] arm64: dts: rockchip: add IR-receiver to NanoPC-T6
+
+FriendlyELEC NanoPC-T6 has IR receiver connected to PWM3_IR_M0 line
+which ends as GPIO0_D4.
+
+Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Link: https://lore.kernel.org/r/20240829-friendlyelec-nanopc-t6-lts-v6-6-edff247e8c02@linaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ .../arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -25,6 +25,13 @@
+ 		stdout-path = "serial2:1500000n8";
+ 	};
+ 
++	ir-receiver {
++		compatible = "gpio-ir-receiver";
++		gpios = <&gpio0 RK_PD4 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&ir_receiver_pin>;
++	};
++
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+@@ -228,7 +235,7 @@
+ 			  "HEADER_10", "HEADER_08", "HEADER_32", "",
+ 			  /* GPIO0 D0-D7 */
+ 			  "", "", "", "",
+-			  "", "", "", "";
++			  "IR receiver [PWM3_IR_M0]", "", "", "";
+ };
+ 
+ &gpio1 {
+@@ -492,6 +499,12 @@
+ 		};
+ 	};
+ 
++	ir-receiver {
++		ir_receiver_pin: ir-receiver-pin {
++			rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
+ 	pcie {
+ 		pcie2_0_rst: pcie2-0-rst {
+ 			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;

--- a/target/linux/rockchip/patches-6.6/054-12-v6.12-arm64-dts-rockchip-enable-GPU-on-NanoPC-T6.patch
+++ b/target/linux/rockchip/patches-6.6/054-12-v6.12-arm64-dts-rockchip-enable-GPU-on-NanoPC-T6.patch
@@ -1,0 +1,28 @@
+From e86cbf999cda2d44f32ec622537024e3b923080d Mon Sep 17 00:00:00 2001
+From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Date: Thu, 29 Aug 2024 14:26:58 +0200
+Subject: [PATCH] arm64: dts: rockchip: enable GPU on NanoPC-T6
+
+Enable the Mali GPU on FriendlyELEC NanoPC-T6
+
+Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Link: https://lore.kernel.org/r/20240829-friendlyelec-nanopc-t6-lts-v6-7-edff247e8c02@linaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -298,6 +298,11 @@
+ 			  "", "", "", "";
+ };
+ 
++&gpu {
++	mali-supply = <&vdd_gpu_s0>;
++	status = "okay";
++};
++
+ &i2c0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c0m2_xfer>;

--- a/target/linux/rockchip/patches-6.6/054-13-v6.12-arm64-dts-rockchip-enable-USB-C-on-NanoPC-T6.patch
+++ b/target/linux/rockchip/patches-6.6/054-13-v6.12-arm64-dts-rockchip-enable-USB-C-on-NanoPC-T6.patch
@@ -1,0 +1,130 @@
+From c9ba75320e5a12dc9d574603acf29b38a920b40c Mon Sep 17 00:00:00 2001
+From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Date: Thu, 29 Aug 2024 14:26:59 +0200
+Subject: [PATCH] arm64: dts: rockchip: enable USB-C on NanoPC-T6
+
+Enable the USB-C port on FriendlyELEC NanoPC-T6.
+
+Works one way so far but still better than before.
+
+Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Link: https://lore.kernel.org/r/20240829-friendlyelec-nanopc-t6-lts-v6-8-edff247e8c02@linaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ .../boot/dts/rockchip/rk3588-nanopc-t6.dtsi   | 76 ++++++++++++++++++-
+ 1 file changed, 72 insertions(+), 4 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -137,6 +137,8 @@
+ 		gpio = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&typec5v_pwren>;
++		regulator-always-on;
++		regulator-boot-on;
+ 		regulator-name = "vbus5v0_typec";
+ 		regulator-min-microvolt = <5000000>;
+ 		regulator-max-microvolt = <5000000>;
+@@ -381,11 +383,34 @@
+ 			compatible = "usb-c-connector";
+ 			data-role = "dual";
+ 			label = "USB-C";
+-			power-role = "dual";
+-			try-power-role = "sink";
++			power-role = "source";
+ 			source-pdos = <PDO_FIXED(5000, 2000, PDO_FIXED_USB_COMM)>;
+-			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+-			op-sink-microwatt = <1000000>;
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++					usbc0_hs: endpoint {
++						remote-endpoint = <&usb_host0_xhci_drd_sw>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++					usbc0_ss: endpoint {
++						remote-endpoint = <&usbdp_phy0_typec_ss>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++					usbc0_sbu: endpoint {
++						remote-endpoint = <&usbdp_phy0_typec_sbu>;
++					};
++				};
++			};
+ 		};
+ 	};
+ 
+@@ -928,6 +953,14 @@
+ 	status = "okay";
+ };
+ 
++&u2phy0 {
++	status = "okay";
++};
++
++&u2phy0_otg {
++	status = "okay";
++};
++
+ &u2phy2_host {
+ 	status = "okay";
+ };
+@@ -944,6 +977,29 @@
+ 	status = "okay";
+ };
+ 
++&usbdp_phy0 {
++	mode-switch;
++	orientation-switch;
++	sbu1-dc-gpios = <&gpio4 RK_PA6 GPIO_ACTIVE_HIGH>;
++	sbu2-dc-gpios = <&gpio4 RK_PA7 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		usbdp_phy0_typec_ss: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&usbc0_ss>;
++		};
++
++		usbdp_phy0_typec_sbu: endpoint@1 {
++			reg = <1>;
++			remote-endpoint = <&usbc0_sbu>;
++		};
++	};
++};
++
+ &usb_host0_ehci {
+ 	status = "okay";
+ };
+@@ -952,6 +1008,18 @@
+ 	status = "okay";
+ };
+ 
++&usb_host0_xhci {
++	dr_mode = "host";
++	status = "okay";
++	usb-role-switch;
++
++	port {
++		usb_host0_xhci_drd_sw: endpoint {
++			remote-endpoint = <&usbc0_hs>;
++		};
++	};
++};
++
+ &usb_host1_ehci {
+ 	status = "okay";
+ };

--- a/target/linux/rockchip/patches-6.6/054-14-v6.12-arm64-dts-rockchip-add-Mask-Rom-key-on-NanoPC-T6.patch
+++ b/target/linux/rockchip/patches-6.6/054-14-v6.12-arm64-dts-rockchip-add-Mask-Rom-key-on-NanoPC-T6.patch
@@ -1,0 +1,45 @@
+From da439eed06ff6806f22341ab0468226afc555305 Mon Sep 17 00:00:00 2001
+From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Date: Thu, 29 Aug 2024 14:27:00 +0200
+Subject: [PATCH] arm64: dts: rockchip: add Mask Rom key on NanoPC-T6
+
+Mask Rom key is connected to SARADC and can be read from OS.
+
+Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Link: https://lore.kernel.org/r/20240829-friendlyelec-nanopc-t6-lts-v6-9-edff247e8c02@linaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ .../arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -8,6 +8,7 @@
+ /dts-v1/;
+ 
+ #include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
+ #include <dt-bindings/pinctrl/rockchip.h>
+ #include <dt-bindings/usb/pd.h>
+ #include "rk3588.dtsi"
+@@ -21,6 +22,20 @@
+ 		mmc1 = &sdmmc;
+ 	};
+ 
++	adc-keys-0 {
++		compatible = "adc-keys";
++		io-channels = <&saradc 0>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <1800000>;
++		poll-interval = <100>;
++
++		button-maskrom {
++			label = "Mask Rom";
++			linux,code = <KEY_SETUP>;
++			press-threshold-microvolt = <2000>;
++		};
++	};
++
+ 	chosen {
+ 		stdout-path = "serial2:1500000n8";
+ 	};

--- a/target/linux/rockchip/patches-6.6/054-15-v6.12-arm64-dts-rockchip-use-correct-fcs-suspend-voltage-selecto.patch
+++ b/target/linux/rockchip/patches-6.6/054-15-v6.12-arm64-dts-rockchip-use-correct-fcs-suspend-voltage-selecto.patch
@@ -1,0 +1,28 @@
+From 170c77276d470a63d22a2634a38846dd88538637 Mon Sep 17 00:00:00 2001
+From: Heiko Stuebner <heiko@sntech.de>
+Date: Thu, 29 Aug 2024 15:20:58 +0200
+Subject: [PATCH] arm64: dts: rockchip: use correct
+ fcs,suspend-voltage-selector on NanoPC-T6
+
+A remant from moving from the vendor kernel, the regulator is using
+a fairchild fcs prefix instead of rockchip,* in the mainline kernel
+according to its binding.
+
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+Link: https://lore.kernel.org/r/20240829132100.1723127-2-heiko@sntech.de
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -366,7 +366,7 @@
+ 	vdd_npu_s0: regulator@42 {
+ 		compatible = "rockchip,rk8602";
+ 		reg = <0x42>;
+-		rockchip,suspend-voltage-selector = <1>;
++		fcs,suspend-voltage-selector = <1>;
+ 		regulator-name = "vdd_npu_s0";
+ 		regulator-always-on;
+ 		regulator-boot-on;

--- a/target/linux/rockchip/patches-6.6/120-arm64-dts-rockchip-add-led-aliases-and-stop-heartbeat-for-nanopc-t6.patch
+++ b/target/linux/rockchip/patches-6.6/120-arm64-dts-rockchip-add-led-aliases-and-stop-heartbeat-for-nanopc-t6.patch
@@ -1,6 +1,6 @@
---- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
-@@ -19,6 +19,10 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -20,6 +20,10 @@
  	aliases {
  		mmc0 = &sdhci;
  		mmc1 = &sdmmc;
@@ -10,8 +10,8 @@
 +		led-upgrade = &sys_led;
  	};
  
- 	chosen {
-@@ -31,7 +35,7 @@
+ 	adc-keys-0 {
+@@ -53,7 +57,7 @@
  		sys_led: led-0 {
  			gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
  			label = "system-led";

--- a/target/linux/rockchip/patches-6.6/121-arm64-dts-rockchip-lower-mmc-speed-for-nanopc-t6.patch
+++ b/target/linux/rockchip/patches-6.6/121-arm64-dts-rockchip-lower-mmc-speed-for-nanopc-t6.patch
@@ -1,11 +1,11 @@
---- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
-@@ -547,7 +547,7 @@
- 	cap-mmc-highspeed;
- 	cap-sd-highspeed;
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -616,7 +616,7 @@
  	disable-wp;
+ 	no-mmc;
+ 	no-sdio;
 -	sd-uhs-sdr104;
 +	sd-uhs-sdr50;
- 	vmmc-supply = <&vcc_3v3_s3>;
+ 	vmmc-supply = <&vcc3v3_sd_s0>;
  	vqmmc-supply = <&vccio_sd_s0>;
  	status = "okay";


### PR DESCRIPTION
Backport ir-receiver/minipcie/poweroff/spi/usb-c support and other minor fixes for the NanoPC T6 board.
