### PR TITLE
libreadlne: add .so symlinks so -lreadline works

### DIFF
--- a/package/libs/readline/Makefile
+++ b/package/libs/readline/Makefile
@@ -69,7 +69,7 @@ endef
 
 define Package/libreadline/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{history,readline}.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib{history,readline}.so* $(1)/usr/lib/
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
Currently, libreadline only installs                                                                                                                                                           
                                                                                                                                                                                               
```                                                                                                                                                                                            
 /usr/lib/libhistory.so.8 -> libhistory.so.8.2                                                                                                                                                 
 /usr/lib/libhistory.so.8.2                                                                                                                                                                    
 /usr/lib/libreadline.so.8 -> libreadline.so.8.2                                                                                                                                               
 /usr/lib/libreadline.so.8.2                                                                                                                                                                   
```                                                                                                                                                                                            
                                                                                                                                                                                               
But there is no `libreadline.so` or `libhistory.so` available.                                                                                                                                 
                                                                                                                                                                                               
So this happens:                                                                                                                                                                               
                                                                                                                                                                                               
```                                                                                                                                                                                            
root@OpenWRT:~# cat a.c                                                                                                                                                                        
int main() {                                                                                                                                                                                   
}                                                                                                                                                                                              
root@OpenWRT:~# gcc a.c -lreadline                                                                                                                                                             
/usr/bin/ld: cannot find -lreadline: No such file or directory                                                                                                                                 
collect2: error: ld returned 1 exit status                                                                                                                                                     
```                                                                                                                                                                                            
                                                                                                                                                                                               
Unless, of course, one uses `-l:libreadline.so.8`... But that                                                                                                                                  
doesn't help with binaries that try to dynamically open                                                                                                                                        
`libreadline.so`. I have one of those here (the STklos Scheme                                                                                                                                  
compiler -- I didn't make a PR for it because it's far from                                                                                                                                    
being ready, but one issue is that it does use dlopen to use                                                                                                                                   
readline...)                                                                                                                                                                                   
                                                                                                                                                                                               
With the symlink, it works:                                                                                                                                                                    
                                                                                                                                                                                               
```                                                                                                                                                                                            
root@OpenWRT:~# ln -s /usr/lib/libreadline.so.8 /usr/lib/libreadline.so                                                                                                                        
root@OpenWRT:~#                                                                                                                                                                                
root@OpenWRT:~# gcc a.c -lreadline                                                                                                                                                             
root@OpenWRT:~#                                                                                                                                                                                
```                                                                                                                                                                                            
                                                                                                                                                                                               
Another example: when trying to package rlwrap, the build failed                                                                                                                               
complaining it could not find readline (using `-lreadline`).                                                                                                                                   
It would then be necessary to change rlwrap's `configure.ac`                                                                                                                                   
(and also in all packages that use readline), but it seems                                                                                                                                     
simpler to add the symlinks...                                                                                                                                                                 
                                                                                                                                                                                               
This PR changes the Makefile so it will include the links.                                                                                                                                     
                                                                                                                                                                                               
Signed-off-by: Jeronimo Pellegrini <j_p@aleph0.info>                                                                                                                                           
                        