### PR TITLE
e2fsprogs: Fix build failure for e2fsprogs by ensuring external UUID library is found.

### DIFF
--- a/tools/e2fsprogs/Makefile
+++ b/tools/e2fsprogs/Makefile
@@ -24,7 +24,7 @@ ifneq ($(shell $(HOSTCC) --version | grep clang),)
 endif
 HOST_CFLAGS += $(HOST_FPIC)
 
-HOST_CONFIGURE_ARGS += \
+HOST_CONFIGURE_ARGS += LDFLAGS="-lpthread" \
 	--disable-elf-shlibs \
 	--disable-libuuid \
 	--disable-tls \


### PR DESCRIPTION
*** Need to explicitly link the pthread library
````
checking for uuid_generate in -luuid... no
configure: error: external uuid library not found
Makefile:50: recipe for target '../build_dir/host/e2fsprogs-1.47.0/.configured' failed
make[3]: *** [../build_dir/host/e2fsprogs-1.47.0/.configured] Error 1
````