### PR TITLE
CI: update actions/labeler to v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,137 +1,227 @@
 # target/*
 "target/airoha":
-  - "target/linux/airoha/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/airoha/**"
 "target/apm821xx":
-  - "target/linux/apm821xx/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/apm821xx/**"
 "target/archs38":
-  - "target/linux/archs38/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/archs38/**"
 "target/armsr":
-  - "target/linux/armsr/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/armsr/**"
 "target/at91":
-  - "target/linux/at91/**"
-  - "package/boot/at91bootstrap/**"
-  - "package/boot/uboot-at91/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/at91/**"
+    - "package/boot/at91bootstrap/**"
+    - "package/boot/uboot-at91/**"
 "target/ath79":
-  - "target/linux/ath79/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/ath79/**"
 "target/bcm27xx":
-  - "target/linux/bcm27xx/**"
-  - "package/kernel/bcm27xx-gpu-fw/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/bcm27xx/**"
+    - "package/kernel/bcm27xx-gpu-fw/**"
 "target/bcm47xx":
-  - "target/linux/bcm47xx/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/bcm47xx/**"
 "target/bcm4908":
-  - "target/linux/bcm4908/**"
-  - "package/boot/uboot-bcm4908/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/bcm4908/**"
+    - "package/boot/uboot-bcm4908/**"
 "target/bcm53xx":
-  - "target/linux/bcm53xx/**"
-  - "package/boot/uboot-bcm53xx/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/bcm53xx/**"
+    - "package/boot/uboot-bcm53xx/**"
 "target/bcm63xx":
-  - "target/linux/bcm63xx/**"
-  - "package/kernel/bcm63xx-cfe/**"
-  - "package/boot/arm-trusted-firmware-bcm63xx/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/bcm63xx/**"
+    - "package/kernel/bcm63xx-cfe/**"
+    - "package/boot/arm-trusted-firmware-bcm63xx/**"
 "target/bmips":
-  - "target/linux/bmips/**"
-  - "package/boot/uboot-bmips/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/bmips/**"
+    - "package/boot/uboot-bmips/**"
 "target/d1":
-  - "target/linux/d1/**"
-  - "package/boot/uboot-d1/**"
-  - "package/boot/opensbi/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/d1/**"
+    - "package/boot/uboot-d1/**"
+    - "package/boot/opensbi/**"
 "target/gemini":
-  - "target/linux/gemini/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/gemini/**"
 "target/imx":
-  - "target/linux/imx/**"
-  - "package/boot/imx-bootlets/**"
-  - "package/boot/uboot-imx/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/imx/**"
+    - "package/boot/imx-bootlets/**"
+    - "package/boot/uboot-imx/**"
 "target/ipq40xx":
-  - "target/linux/ipq40xx/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/ipq40xx/**"
 "target/ipq806x":
-  - "target/linux/ipq806x/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/ipq806x/**"
 "target/qualcommax":
-  - "target/linux/qualcommax/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/qualcommax/**"
 "target/kirkwood":
-  - "target/linux/kirkwood/**"
-  - "package/boot/uboot-kirkwood/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/kirkwood/**"
+    - "package/boot/uboot-kirkwood/**"
 "target/lantiq":
-  - "target/linux/lantiq/**"
-  - "package/kernel/lantiq/**"
-  - "package/firmware/lantiq/**"
-  - "package/boot/uboot-lantiq/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/lantiq/**"
+    - "package/kernel/lantiq/**"
+    - "package/firmware/lantiq/**"
+    - "package/boot/uboot-lantiq/**"
 "target/layerscape":
-  - "target/linux/layerscape/**"
-  - "package/firmware/layerscape/**"
-  - "package/boot/tfa-layerscape/**"
-  - "package/boot/uboot-layerscape/**"
-  - "package/network/utils/layerscape/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/layerscape/**"
+    - "package/firmware/layerscape/**"
+    - "package/boot/tfa-layerscape/**"
+    - "package/boot/uboot-layerscape/**"
+    - "package/network/utils/layerscape/**"
 "target/malta":
-  - "target/linux/malta/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/malta/**"
 "target/mediatek":
-  - "target/linux/mediatek/**"
-  - "package/boot/arm-trusted-firmware-mediatek/**"
-  - "package/boot/uboot-mediatek/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/mediatek/**"
+    - "package/boot/arm-trusted-firmware-mediatek/**"
+    - "package/boot/uboot-mediatek/**"
 "target/mpc85xx":
-  - "target/linux/mpc85xx/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/mpc85xx/**"
 "target/mvebu":
-  - "target/linux/mvebu/**"
-  - "package/boot/arm-trusted-firmware-mvebu/**"
-  - "package/boot/uboot-mvebu/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/mvebu/**"
+    - "package/boot/arm-trusted-firmware-mvebu/**"
+    - "package/boot/uboot-mvebu/**"
 "target/mxs":
-  - "target/linux/mxs/**"
-  - "package/boot/uboot-mxs/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/mxs/**"
+    - "package/boot/uboot-mxs/**"
 "target/octeon":
-  - "target/linux/octeon/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/octeon/**"
 "target/omap":
-  - "target/linux/omap/**"
-  - "package/boot/uboot-omap/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/omap/**"
+    - "package/boot/uboot-omap/**"
 "target/pistachio":
-  - "target/linux/pistachio/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/pistachio/**"
 "target/qoriq":
-  - "target/linux/qoriq/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/qoriq/**"
 "target/ramips":
-  - "target/linux/ramips/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/ramips/**"
 "target/realtek":
-  - "target/linux/realtek/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/realtek/**"
 "target/rockchip":
-  - "target/linux/rockchip/**"
-  - "package/boot/arm-trusted-firmware-rockchip/**"
-  - "package/boot/uboot-rockchip/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/rockchip/**"
+    - "package/boot/arm-trusted-firmware-rockchip/**"
+    - "package/boot/uboot-rockchip/**"
 "target/sifiveu":
-  - "target/linux/sifiveu/**"
-  - "package/boot/uboot-sifiveu/**"
-  - "package/boot/opensbi/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/sifiveu/**"
+    - "package/boot/uboot-sifiveu/**"
+    - "package/boot/opensbi/**"
 "target/sunxi":
-  - "target/linux/sunxi/**"
-  - "package/boot/arm-trusted-firmware-sunxi/**"
-  - "package/boot/uboot-sunxi/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/sunxi/**"
+    - "package/boot/arm-trusted-firmware-sunxi/**"
+    - "package/boot/uboot-sunxi/**"
 "target/tegra":
-  - "target/linux/tegra/**"
-  - "package/boot/uboot-tegra/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/tegra/**"
+    - "package/boot/uboot-tegra/**"
 "target/uml":
-  - "target/linux/uml/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/uml/**"
 "target/x86":
-  - "target/linux/x86/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/x86/**"
 "target/zynq":
-  - "target/linux/zynq/**"
-  - "package/boot/uboot-zynq/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/zynq/**"
+    - "package/boot/uboot-zynq/**"
 # target/imagebuilder
 "target/imagebuilder":
-  - "target/imagebuilder/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/imagebuilder/**"
 # kernel
 "kernel":
-  - "target/linux/generic/**"
-  - "target/linux/**/config-*"
-  - "target/linux/**/patches-*"
-  - "target/linux/**/files/**"
-  - "package/kernel/linux/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "target/linux/generic/**"
+    - "target/linux/**/config-*"
+    - "target/linux/**/patches-*"
+    - "target/linux/**/files/**"
+    - "package/kernel/linux/**"
 # core packages
 "core packages":
-  - "package/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "package/**"
 # build/scripts/tools
 "build/scripts/tools":
-  - "include/**"
-  - "scripts/**"
-  - "tools/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "include/**"
+    - "scripts/**"
+    - "tools/**"
 # toolchain
 "toolchain":
-  - "toolchain/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - "toolchain/**"
 # GitHub/CI
 "GitHub/CI":
-  - ".github/**"
+- changed-files:
+  - any-glob-to-any-file:
+    - ".github/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,7 +14,7 @@ jobs:
     name: Pull Request Labeler
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@v5
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
 
@@ -25,7 +25,7 @@ jobs:
               echo "release-tag=$(echo ${{ github.base_ref }} | sed 's/openwrt-/release\//')" >> $GITHUB_OUTPUT
           fi
 
-      - uses: buildsville/add-remove-label@v2.0.0
+      - uses: buildsville/add-remove-label@v2.0.1
         if: ${{ steps.check-branch.outputs.release-tag }}
         with:
           token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
* Version 5 of this action updated the runtime to Node.js 20. All scripts are now run with Node.js 20 instead of Node.js 16 and are affected by any breaking changes between Node.js 16 and 20.

Follow-up to #16251 as this was reverted with b870c16534c05ddc94149c6ff56976d8de8a353f
Signed-off-by: Goetz Goerisch <ggoerisch@gmail.com>

