### PR TITLE
gpio-button-hotplug: use dev_err_probe

### DIFF
--- a/package/kernel/gpio-button-hotplug/Makefile
+++ b/package/kernel/gpio-button-hotplug/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=gpio-button-hotplug
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -525,10 +525,9 @@ static int gpio_keys_button_probe(struct platform_device *pdev,
 					button->active_low ? GPIOF_ACTIVE_LOW :
 					0), desc);
 				if (error) {
-					if (error != -EPROBE_DEFER) {
-						dev_err(dev, "unable to claim gpio %d, err=%d\n",
-							button->gpio, error);
-					}
+					dev_err_probe(dev, error,
+						      "unable to claim gpio %d",
+						      button->gpio);
 					goto out;
 				}
 


### PR DESCRIPTION
Avoids having to handle EPROBE_DEFER manually.

ping @hauke @robimarko 