### PR TITLE
 [23.05] ipq40xx: re-add label MAC address for FritzBox 4040

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-fritzbox-4040.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-fritzbox-4040.dts
@@ -14,6 +14,7 @@
 		led-failsafe = &flash;
 		led-running = &power;
 		led-upgrade = &flash;
+		label-mac-device = &gmac;
 	};
 
 	soc {


### PR DESCRIPTION
This is a backport of #13240

I built openwrt with it and checked that the label mac is correct.

---

The MAC address of the GMAC is contained inside the CWMP-Account number on the label.

The label MAC address alias was defined previously, but it has been removed with the switch to IPQESS / DSA.

Restore the label MAC address alias.

Fixes: 27b441cbaf42 ("ipq40xx: drop ESSEDMA + AR40xx DTS nodes")

Reviewed-by: Robert Marko <robimarko@gmail.com>
(cherry picked from commit b22d382ae4eaa1af42930115d91855f402314cac)