### PR TITLE
kernel: r8125/r8126: add CONFLICT to rss variant

### DIFF
--- a/package/kernel/r8125/Makefile
+++ b/package/kernel/r8125/Makefile
@@ -27,6 +27,7 @@ endef
 
 define KernelPackage/r8125-rss
 $(call KernelPackage/r8125)
+  CONFLICTS:=kmod-r8125
   TITLE+= (RSS)
   VARIANT:=rss
 endef

--- a/package/kernel/r8126/Makefile
+++ b/package/kernel/r8126/Makefile
@@ -27,6 +27,7 @@ endef
 
 define KernelPackage/r8126-rss
 $(call KernelPackage/r8126)
+  CONFLICTS:=kmod-r8126
   TITLE+= (RSS)
   VARIANT:=rss
 endef


### PR DESCRIPTION
The rss variant should conflict with the default.