### PR TITLE
ipq807x: sax1v1k: fix sysupgrade not touching rootfs_data

### DIFF
--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -340,7 +340,7 @@ define Device/spectrum_sax1v1k
 	DEVICE_DTS_CONFIG := config@rt5010w-d187-rev6
 	SOC := ipq8072
 	IMAGES := sysupgrade.bin
-	DEVICE_PACKAGES := ipq-wifi-spectrum_sax1v1k
+	DEVICE_PACKAGES := kmod-fs-f2fs f2fs-tools ipq-wifi-spectrum_sax1v1k
 endef
 TARGET_DEVICES += spectrum_sax1v1k
 

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -184,8 +184,7 @@ platform_do_upgrade() {
 		nand_do_upgrade "$1"
 		;;
 	prpl,haze|\
-	qnap,301w|\
-	spectrum,sax1v1k)
+	qnap,301w)
 		kernelname="0:HLOS"
 		rootfsname="rootfs"
 		mmc_do_upgrade "$1"
@@ -211,6 +210,12 @@ platform_do_upgrade() {
 		CI_KERN_UBIPART="ubi_kernel"
 		CI_ROOT_UBIPART="rootfs"
 		nand_do_upgrade "$1"
+		;;
+	spectrum,sax1v1k)
+		CI_KERNPART="0:HLOS"
+		CI_ROOTPART="rootfs"
+		CI_DATAPART="rootfs_data"
+		emmc_do_upgrade "$1"
 		;;
 	yuncore,ax880)
 		active="$(fw_printenv -n active)"
@@ -257,6 +262,14 @@ platform_do_upgrade() {
 		;;
 	*)
 		default_do_upgrade "$1"
+		;;
+	esac
+}
+
+platform_copy_config() {
+	case "$(board_name)" in
+	spectrum,sax1v1k)
+		emmc_copy_config
 		;;
 	esac
 }


### PR DESCRIPTION
Before this commit, sysupgrade saved the settings backup data to the area following rootfs even though the device has an actual rootfs_data partition. The backup data was completely ignored on the following boot, but since rootfs_data was not being cleared during sysupgrade, the issue was not noticed earlier.

(btw, this is very dangerous: if you install a package, then do a sysupgrade, the package for the old OS will continue to be installed!)

Note that this commit changes the filesystem of rootfs_data from ext4 to F2FS (if OEM partitioning is used).