### PR TITLE
generic: phy: aquantia: fix MDI pair property parsing

### DIFF
--- a/target/linux/generic/pending-6.6/752-net-phy-aquantia-allow-forcing-order-of-MDI-pairs.patch
+++ b/target/linux/generic/pending-6.6/752-net-phy-aquantia-allow-forcing-order-of-MDI-pairs.patch
@@ -74,7 +74,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	ret = of_property_read_u32(np, "marvell,mdi-cfg-order", &mdi_conf);
 +
 +	/* Do nothing in case property "marvell,mdi-cfg-order" is not present */
-+	if (ret == -ENOENT)
++	if (ret == -EINVAL)
 +		return 0;
 +
 +	if (ret)


### PR DESCRIPTION
of_property_read_u32 returns -EINVAL when property does not exist,
according to the documentation -ENOENT is not a valid return code.

So, instead of checking for -ENOENT check for -EINVAL as otherwise the
blamed commit breaks AQR probe since it will return -EINVAL during probe.

Fixes: cb2a11f49c98 ("generic: phy: aquantia: add pending patch to force MDI pair order")
