### PR TITLE
tfa-layerscape: fix fiptool's build

### DIFF
--- a/package/boot/tfa-layerscape/Makefile
+++ b/package/boot/tfa-layerscape/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tfa-layerscape
 PKG_VERSION:=6.6.23.2.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/nxp-qoriq/atf
@@ -25,7 +25,7 @@ HOST_CFLAGS += -Wall -Werror -pedantic -std=c99
 define Host/Compile
 	$(MAKE) -C \
 		$(HOST_BUILD_DIR)/tools/fiptool \
-		PLAT_FIPTOOL_HELPER_MK="$(HOST_BUILD_DIR)/tools/nxp/plat_fiptool/plat_fiptool.mk" \
+		PLAT_FIPTOOL_HELPER_MK="$(HOST_BUILD_DIR)/tools/fiptool/plat_fiptool/nxp/plat_fiptool.mk" \
 		CFLAGS="$(HOST_CFLAGS)" \
 		LDFLAGS="$(HOST_LDFLAGS)" \
 		HOSTCCFLAGS="$(HOST_CFLAGS)"


### PR DESCRIPTION
Platform specified fiptool files was moved before lf-6.6.23-2.0.0 bump. But PLAT_FIPTOOL_HELPER_MK still pointed to old location. This cause problems with ls-ddr-phy build.

This patch fix PLAT_FIPTOOL_HELPER_MK path.

Fixes: 0ec659bd2b7e ("tfa-layerscape: Bump to lf-6.6.23-2.0.0")