### PR TITLE
ramips: use OKLI loader for TP-Link RE200 v1 and RE210 v1

### DIFF
--- a/target/linux/ramips/dts/mt7620a_tplink_re2x0-v1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_tplink_re2x0-v1.dtsi
@@ -4,6 +4,7 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
 
 / {
 	aliases {
@@ -63,9 +64,11 @@
 			};
 
 			partition@20000 {
-				compatible = "tplink,firmware";
+				compatible = "openwrt,uimage", "denx,uimage";
 				label = "firmware";
 				reg = <0x20000 0x7c0000>;
+				openwrt,offset = <0x1000>;
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
 			};
 
 			partition@7e0000 {

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1290,7 +1290,7 @@ endef
 TARGET_DEVICES += tplink_ec220-g5-v2
 
 define Device/tplink_re200-v1
-  $(Device/tplink-v1)
+  $(Device/tplink-v1-okli)
   SOC := mt7620a
   DEVICE_MODEL := RE200
   DEVICE_VARIANT := v1
@@ -1302,7 +1302,7 @@ endef
 TARGET_DEVICES += tplink_re200-v1
 
 define Device/tplink_re210-v1
-  $(Device/tplink-v1)
+  $(Device/tplink-v1-okli)
   SOC := mt7620a
   DEVICE_MODEL := RE210
   DEVICE_VARIANT := v1


### PR DESCRIPTION
Fixes: https://github.com/openwrt/openwrt/issues/16296

**bootlog:**
```
3: System Boot system code via Flash.
## Booting image at bc020000 ...
   Uncompressing Kernel Image ... OK
No initrd
## Transferring control to Linux (at address 80000000) ...
## Giving linux memsize in MB, 64

Starting kernel ...

OpenWrt kernel loader for MIPS based SoC
Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org>
Looking for OpenWrt image... found at 0xbc021000
Decompressing kernel... done!
Starting kernel at 80000000...

[    0.000000] Linux version 6.6.52 
```