### PR TITLE
[23.05]: ramips: add support for Viettel Vap-120WD

### DIFF
--- a/target/linux/ramips/dts/mt7621_viettel_vap-120wd.dts
+++ b/target/linux/ramips/dts/mt7621_viettel_vap-120wd.dts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "viettel,vap-120wd", "mediatek,mt7621-soc";
+	model = "Viettel VAP-120WD";
+
+	aliases {
+		led-boot = &led_status_blue_north;
+		led-failsafe = &led_status_red_east;
+		led-running = &led_status_blue_north;
+		led-upgrade = &led_status_red_east;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue_east: led@3 {
+			label = "blue:east";
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red_east: led@4 {
+			label = "red:east";
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue_north: led@16 {
+			label = "blue:north";
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue_west: led@13 {
+			label = "blue:west";
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red_west: led@14 {
+			label = "red:west";
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			debounce-interval = <10>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		uboot: partition@0 {
+			label = "uboot";
+			reg = <0x00000 0x80000>;
+		};
+
+		uboot_env: partition@80000 {
+			label = "uboot_env";
+			reg = <0x80000 0x80000>;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+		};
+
+		kernel: partition@140000 {
+			label = "kernel";
+			reg = <0x140000 0x400000>;
+		};
+
+		ubi: partition@540000 {
+			label = "ubi";
+			reg = <0x540000 0x72c0000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		nvmem-cells = <&macaddr_factory_4 0>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy2>;
+
+	nvmem-cells = <&macaddr_factory_e006 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	ethphy2: ethernet-phy@2 {
+		reg = <2>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan2";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 {
+		reg = <0x4 0x6>;
+	};
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2547,6 +2547,20 @@ define Device/unielec_u7621-06-64m
 endef
 TARGET_DEVICES += unielec_u7621-06-64m
 
+define Device/viettel_vap-120wd
+  $(Device/nand)
+  $(Device/uimage-lzma-loader)
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 121600k
+  DEVICE_VENDOR := Viettel
+  DEVICE_MODEL := VAP-120WD
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size
+  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+endef
+TARGET_DEVICES += viettel_vap-120wd
+
 define Device/wavlink_wl-wn531a6
   $(Device/dsa-migration)
   DEVICE_VENDOR := Wavlink

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -77,6 +77,7 @@ ramips_setup_interfaces()
 	mts,wg430223|\
 	oraybox,x3a|\
 	renkforce,ws-wn530hp3-a|\
+	viettel,vap-120wd|\
 	xiaomi,mi-router-3g|\
 	xiaomi,mi-router-3g-v2|\
 	xiaomi,mi-router-4|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -184,6 +184,11 @@ case "$board" in
 		hw_mac_addr="$(mtd_get_mac_binary rom_file 0xf100)"
 		[ "$PHYNBR" = "1" ] &&  macaddr_add "$hw_mac_addr" 2 > "/sys${DEVPATH}/macaddress"
 		;;
+	viettel,vap-120wd)
+		[ "$PHYNBR" = "1" ] && \
+			macaddr_setbit_la "$(mtd_get_mac_binary factory 0xe000)" \
+				> /sys${DEVPATH}/macaddress
+		;;
 	yuncore,ax820|\
 	yuncore,g720)
 		[ "$PHYNBR" = "1" ] && \

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -110,6 +110,7 @@ platform_do_upgrade() {
 	sercomm,na502s|\
 	sim,simax1800t|\
 	tplink,ec330-g5u-v1|\
+	viettel,vap-120wd|\
 	wifire,s1500-nbn|\
 	xiaomi,mi-router-3g|\
 	xiaomi,mi-router-3-pro|\


### PR DESCRIPTION
Hardware Specification:
```
SoC: Mediatek MT7621AT (MIPS1004Kc 880 MHz, dual core)
RAM: 128 MB
Storage: 128 MB NAND flash
Ethernet: 3x 10/100/1000 Mbps LAN1,LAN2 & WAN
Wireless: 1x 2.4GHz & 5GHz: Mediatek MT7615DN up to 1300Mbps 
          (802.11b/g/n/ac MIMO 2x2)
LEDs: 5x North (Blue), East (Blue & Red), West (Blue & Red)
Buttons: 1x WPS/Reset
UART: yes

```
Flash Instructions:
```
1. Prepare OpenWRT factory image & TFTP server
2. Connect UART
3. Press 2 to get into bootloader firmware download mode -> press 'y'
4. Enter device's IP / TFTP server's IP / Factory image name when asked
5. Wait for device to reboot
```