### PR TITLE
kernel: gpio-nct5104d: use devm

### DIFF
--- a/package/kernel/gpio-nct5104d/Makefile
+++ b/package/kernel/gpio-nct5104d/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=gpio-nct5104d
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_MAINTAINER:=Florian Eckert <Eckert.Florian@googlemail.com>
 PKG_LICENSE:=GPL-2.0

--- a/package/kernel/gpio-nct5104d/src/gpio-nct5104d.c
+++ b/package/kernel/gpio-nct5104d/src/gpio-nct5104d.c
@@ -153,8 +153,7 @@ static struct nct5104d_gpio_bank nct5104d_gpio_bank[] = {
 static int nct5104d_gpio_direction_in(struct gpio_chip *chip, unsigned offset)
 {
 	int err;
-	struct nct5104d_gpio_bank *bank =
-		container_of(chip, struct nct5104d_gpio_bank, chip);
+	struct nct5104d_gpio_bank *bank = gpiochip_get_data(chip);
 	struct nct5104d_sio *sio = bank->data->sio;
 	u8 dir;
 
@@ -175,8 +174,7 @@ static int nct5104d_gpio_direction_in(struct gpio_chip *chip, unsigned offset)
 static int nct5104d_gpio_get(struct gpio_chip *chip, unsigned offset)
 {
 	int err;
-	struct nct5104d_gpio_bank *bank =
-		container_of(chip, struct nct5104d_gpio_bank, chip);
+	struct nct5104d_gpio_bank *bank = gpiochip_get_data(chip);
 	struct nct5104d_sio *sio = bank->data->sio;
 	u8 data;
 
@@ -196,8 +194,7 @@ static int nct5104d_gpio_direction_out(struct gpio_chip *chip,
 				     unsigned offset, int value)
 {
 	int err;
-	struct nct5104d_gpio_bank *bank =
-		container_of(chip, struct nct5104d_gpio_bank, chip);
+	struct nct5104d_gpio_bank *bank = gpiochip_get_data(chip);
 	struct nct5104d_sio *sio = bank->data->sio;
 	u8 dir, data_out;
 
@@ -225,8 +222,7 @@ static int nct5104d_gpio_direction_out(struct gpio_chip *chip,
 static void nct5104d_gpio_set(struct gpio_chip *chip, unsigned offset, int value)
 {
 	int err;
-	struct nct5104d_gpio_bank *bank =
-		container_of(chip, struct nct5104d_gpio_bank, chip);
+	struct nct5104d_gpio_bank *bank = gpiochip_get_data(chip);
 	struct nct5104d_sio *sio = bank->data->sio;
 	u8 data_out;
 
@@ -270,8 +266,6 @@ static int nct5104d_gpio_probe(struct platform_device *pdev)
 	}
 	data->sio = sio;
 
-	platform_set_drvdata(pdev, data);
-
 	/* For each GPIO bank, register a GPIO chip. */
 	for (i = 0; i < data->nr_bank; i++) {
 		struct nct5104d_gpio_bank *bank = &data->bank[i];
@@ -279,36 +273,10 @@ static int nct5104d_gpio_probe(struct platform_device *pdev)
 		bank->chip.parent = &pdev->dev;
 		bank->data = data;
 
-		err = gpiochip_add(&bank->chip);
-		if (err) {
-			dev_err(&pdev->dev,
-				"Failed to register gpiochip %d: %d\n",
-				i, err);
-			goto err_gpiochip;
-		}
-	}
-
-	return 0;
-
-err_gpiochip:
-	for (i = i - 1; i >= 0; i--) {
-		struct nct5104d_gpio_bank *bank = &data->bank[i];
-
-		gpiochip_remove (&bank->chip);
-	}
-
-	return err;
-}
-
-static int nct5104d_gpio_remove(struct platform_device *pdev)
-{
-	int i;
-	struct nct5104d_gpio_data *data = platform_get_drvdata(pdev);
-
-	for (i = 0; i < data->nr_bank; i++) {
-		struct nct5104d_gpio_bank *bank = &data->bank[i];
-
-		gpiochip_remove (&bank->chip);
+		err = devm_gpiochip_add_data(&pdev->dev, &bank->chip, bank);
+		if (err)
+			return dev_err_probe(&pdev->dev, err,
+				"Failed to register gpiochip %d", err);
 	}
 
 	return 0;
@@ -402,7 +370,6 @@ static struct platform_driver nct5104d_gpio_driver = {
 		.name	= DRVNAME,
 	},
 	.probe		= nct5104d_gpio_probe,
-	.remove		= nct5104d_gpio_remove,
 };
 
 static int __init nct5104d_gpio_init(void)


### PR DESCRIPTION
Allows removal of the remove function by letting devm handle everything.

Avoids gotos as well.