### PR TITLE
kernel: ubnt-ledbar: use dev_err_probe

### DIFF
--- a/package/kernel/ubnt-ledbar/src/leds-ubnt-ledbar.c
+++ b/package/kernel/ubnt-ledbar/src/leds-ubnt-ledbar.c
@@ -149,7 +149,6 @@ static int ubnt_ledbar_init_led(struct device_node *np, struct ubnt_ledbar *ledb
 				struct led_classdev *led_cdev)
 {
 	struct led_init_data init_data = {};
-	int ret;
 
 	if (!np)
 		return 0;
@@ -158,12 +157,7 @@ static int ubnt_ledbar_init_led(struct device_node *np, struct ubnt_ledbar *ledb
 
 	led_cdev->max_brightness = UBNT_LEDBAR_MAX_BRIGHTNESS;
 
-	ret = devm_led_classdev_register_ext(&ledbar->client->dev, led_cdev,
-					     &init_data);
-	if (ret)
-		dev_err(&ledbar->client->dev, "led register err: %d\n", ret);
-
-	return ret;
+	return devm_led_classdev_register_ext(&ledbar->client->dev, led_cdev, &init_data);
 }
 
 static int ubnt_ledbar_probe(struct i2c_client *client)

--- a/package/kernel/ubnt-ledbar/src/leds-ubnt-ledbar.c
+++ b/package/kernel/ubnt-ledbar/src/leds-ubnt-ledbar.c
@@ -170,7 +170,6 @@ static int ubnt_ledbar_probe(struct i2c_client *client)
 {
 	struct device_node *np = client->dev.of_node;
 	struct ubnt_ledbar *ledbar;
-	int ret;
 
 	ledbar = devm_kzalloc(&client->dev, sizeof(*ledbar), GFP_KERNEL);
 	if (!ledbar)
@@ -178,19 +177,13 @@ static int ubnt_ledbar_probe(struct i2c_client *client)
 
 	ledbar->enable_gpio = devm_gpiod_get(&client->dev, "enable", GPIOD_OUT_LOW);
 
-	if (IS_ERR(ledbar->enable_gpio)) {
-		ret = PTR_ERR(ledbar->enable_gpio);
-		dev_err(&client->dev, "Failed to get enable gpio: %d\n", ret);
-		return ret;
-	}
+	if (IS_ERR(ledbar->enable_gpio))
+		return dev_err_probe(&client->dev, PTR_ERR(ledbar->enable_gpio), "Failed to get enable gpio");
 
 	ledbar->reset_gpio = devm_gpiod_get_optional(&client->dev, "reset", GPIOD_OUT_LOW);
 
-	if (IS_ERR(ledbar->reset_gpio)) {
-		ret = PTR_ERR(ledbar->reset_gpio);
-		dev_err(&client->dev, "Failed to get reset gpio: %d\n", ret);
-		return ret;
-	}
+	if (IS_ERR(ledbar->reset_gpio))
+		return dev_err_probe(&client->dev, PTR_ERR(ledbar->reset_gpio), "Failed to get reset gpio");
 
 	ledbar->led_count = 1;
 	of_property_read_u32(np, "led-count", &ledbar->led_count);


### PR DESCRIPTION
Handles EPROBE_DEFER and simplifies the code.