### PR TITLE
toolchain/gcc: change default to version 14

### DIFF
--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -2,7 +2,7 @@
 
 choice
 	prompt "GCC compiler Version" if TOOLCHAINOPTS
-	default GCC_USE_VERSION_13
+	default GCC_USE_VERSION_14
 	help
 	  Select the version of gcc you wish to use.
 


### PR DESCRIPTION
toolchain/gcc change default to version 14.

I have been building successfully using GCC 14.2.0 with no issue, and I think it is time to change the default to version 14 and ditch version 13. Leaving the default as version 13 when using GCC 14.2.0 will make 2 directories in the staging folder on for GCC 13 and other for GCC 14
