### PR TITLE
toolchain/binutils change default to version 2.43.1

### DIFF
--- a/toolchain/binutils/Config.in
+++ b/toolchain/binutils/Config.in
@@ -2,7 +2,7 @@
 
 choice
 	prompt "Binutils Version" if TOOLCHAINOPTS
-	default BINUTILS_USE_VERSION_2_42
+	default BINUTILS_USE_VERSION_2_43
 	help
 	  Select the version of binutils you wish to use.
 


### PR DESCRIPTION
toolchain/binutils change default to version 2.43.1

I think it is time to updating to binutils  2.43.1 https://github.com/openwrt/openwrt/pull/16498 and use it as the default.