### PR TITLE
ath10k-ct: switch to version 6.10

### DIFF
--- a/package/kernel/ath10k-ct/Makefile
+++ b/package/kernel/ath10k-ct/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ath10k-ct
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPLv2
 PKG_LICENSE_FILES:=
@@ -12,10 +12,10 @@ PKG_SOURCE_DATE:=2024-07-30
 PKG_SOURCE_VERSION:=ac71b14dc93aef0af6f0f24808b0afb673eaa5f5
 PKG_MIRROR_HASH:=f7774fc7002bbea450f543927acd528fb1bb6742f0e9ef28a402df3796893d93
 
-# Build the 6.9 ath10k-ct driver version.
+# Build the 6.10 ath10k-ct driver version.
 # Probably this should match as closely as
 # possible to whatever mac80211 backports version is being used.
-CT_KVER="-6.9"
+CT_KVER="-6.10"
 
 PKG_MAINTAINER:=Ben Greear <greearb@candelatech.com>
 PKG_BUILD_PARALLEL:=1

--- a/package/kernel/ath10k-ct/patches/001-patch-version.patch
+++ b/package/kernel/ath10k-ct/patches/001-patch-version.patch
@@ -1,11 +1,11 @@
---- a/ath10k-6.9/pci.c
-+++ b/ath10k-6.9/pci.c
+--- a/ath10k-6.10/pci.c
++++ b/ath10k-6.10/pci.c
 @@ -3871,7 +3871,7 @@ static int __ath10k_pci_probe(struct pci
  	int (*pci_hard_reset)(struct ath10k *ar);
  	u32 (*targ_cpu_to_ce_addr)(struct ath10k *ar, u32 addr);
  
 -	printk(KERN_INFO "ath10k 6.7 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
-+	printk(KERN_INFO "ath10k 6.9 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
++	printk(KERN_INFO "ath10k 6.10 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
  	       pci_dev->device);
  
  	switch (pci_dev->device) {

--- a/package/kernel/ath10k-ct/patches/002-ath10k-6.10-remove-unsupported-feature.patch
+++ b/package/kernel/ath10k-ct/patches/002-ath10k-6.10-remove-unsupported-feature.patch
@@ -1,0 +1,10 @@
+--- a/ath10k-6.10/mac.c
++++ b/ath10k-6.10/mac.c
+@@ -11626,7 +11626,6 @@ int ath10k_mac_register(struct ath10k *a
+ 	ar->hw->wiphy->n_cipher_suites = ar->hw_params.n_cipher_suites;
+ 
+ 	wiphy_ext_feature_set(ar->hw->wiphy, NL80211_EXT_FEATURE_CQM_RSSI_LIST);
+-	wiphy_ext_feature_set(ar->hw->wiphy, NL80211_EXT_FEATURE_ETHTOOL_VDEV_STATS);
+ 
+ 	ar->hw->weight_multiplier = ATH10K_AIRTIME_WEIGHT_MULTIPLIER;
+ 

--- a/package/kernel/ath10k-ct/patches/010-api_update.patch
+++ b/package/kernel/ath10k-ct/patches/010-api_update.patch
@@ -1,5 +1,5 @@
---- a/ath10k-6.9/mac.c
-+++ b/ath10k-6.9/mac.c
+--- a/ath10k-6.10/mac.c
++++ b/ath10k-6.10/mac.c
 @@ -1675,7 +1675,7 @@ static void ath10k_recalc_radar_detectio
  		 * by indicating that radar was detected.
  		 */
@@ -18,8 +18,8 @@
  {
  	struct ath10k *ar = hw->priv;
  	u32 opt;
---- a/ath10k-6.9/debug.c
-+++ b/ath10k-6.9/debug.c
+--- a/ath10k-6.10/debug.c
++++ b/ath10k-6.10/debug.c
 @@ -3319,7 +3319,7 @@ static ssize_t ath10k_write_simulate_rad
  	if (!arvif->is_started)
  		return -EINVAL;
@@ -29,8 +29,8 @@
  
  	return count;
  }
---- a/ath10k-6.9/wmi.c
-+++ b/ath10k-6.9/wmi.c
+--- a/ath10k-6.10/wmi.c
++++ b/ath10k-6.10/wmi.c
 @@ -4402,7 +4402,7 @@ static void ath10k_radar_detected(struct
  	if (ar->dfs_block_radar_events)
  		ath10k_info(ar, "DFS Radar detected, but ignored as requested\n");

--- a/package/kernel/ath10k-ct/patches/130-ath10k-read-qcom-coexist-support-as-a-u32.patch
+++ b/package/kernel/ath10k-ct/patches/130-ath10k-read-qcom-coexist-support-as-a-u32.patch
@@ -39,9 +39,9 @@ that the feature is properly initialized:
 
 Signed-off-by: Vincent Tremblay <vincent@vtremblay.dev>
 
---- a/ath10k-6.9/core.c
-+++ b/ath10k-6.9/core.c
-@@ -2889,14 +2889,14 @@ done:
+--- a/ath10k-6.10/core.c
++++ b/ath10k-6.10/core.c
+@@ -2871,14 +2871,14 @@ done:
  static void ath10k_core_fetch_btcoex_dt(struct ath10k *ar)
  {
  	struct device_node *node;

--- a/package/kernel/ath10k-ct/patches/201-wifi-ath10k-add-LED-and-GPIO-controlling-support-for.patch
+++ b/package/kernel/ath10k-ct/patches/201-wifi-ath10k-add-LED-and-GPIO-controlling-support-for.patch
@@ -20,24 +20,24 @@ Tested-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>
 Signed-off-by: Kalle Valo <quic_kvalo@quicinc.com>
 Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
 ---
- ath10k-6.9/Kconfig   |  6 ++
- ath10k-6.9/Makefile  |  1 +
- ath10k-6.9/core.c    | 32 ++++++++
- ath10k-6.9/core.h    |  8 ++
- ath10k-6.9/hw.h      |  1 +
- ath10k-6.9/leds.c    | 90 +++++++++++++++++++++++
- ath10k-6.9/leds.h    | 34 +++++++++
- ath10k-6.9/mac.c     |  1 +
- ath10k-6.9/wmi-ops.h | 32 ++++++++
- ath10k-6.9/wmi-tlv.c |  2 +
- ath10k-6.9/wmi.c     | 54 ++++++++++++++
- ath10k-6.9/wmi.h     | 35 +++++++++
+ ath10k-6.10/Kconfig   |  6 ++
+ ath10k-6.10/Makefile  |  1 +
+ ath10k-6.10/core.c    | 32 ++++++++
+ ath10k-6.10/core.h    |  8 ++
+ ath10k-6.10/hw.h      |  1 +
+ ath10k-6.10/leds.c    | 90 +++++++++++++++++++++++
+ ath10k-6.10/leds.h    | 34 +++++++++
+ ath10k-6.10/mac.c     |  1 +
+ ath10k-6.10/wmi-ops.h | 32 ++++++++
+ ath10k-6.10/wmi-tlv.c |  2 +
+ ath10k-6.10/wmi.c     | 54 ++++++++++++++
+ ath10k-6.10/wmi.h     | 35 +++++++++
  12 files changed, 296 insertions(+)
- create mode 100644 ath10k-6.9/leds.c
- create mode 100644 ath10k-6.9/leds.h
+ create mode 100644 ath10k-6.10/leds.c
+ create mode 100644 ath10k-6.10/leds.h
 
---- a/ath10k-6.9/Kconfig
-+++ b/ath10k-6.9/Kconfig
+--- a/ath10k-6.10/Kconfig
++++ b/ath10k-6.10/Kconfig
 @@ -68,6 +68,12 @@ config ATH10K_DEBUGFS
  
  	  If unsure, say Y to make it easier to debug problems.
@@ -51,8 +51,8 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  config ATH10K_SPECTRAL
  	bool "Atheros ath10k spectral scan support"
  	depends on ATH10K_DEBUGFS
---- a/ath10k-6.9/Makefile
-+++ b/ath10k-6.9/Makefile
+--- a/ath10k-6.10/Makefile
++++ b/ath10k-6.10/Makefile
 @@ -20,6 +20,7 @@ ath10k_core-$(CONFIG_ATH10K_SPECTRAL) +=
  ath10k_core-$(CONFIG_NL80211_TESTMODE) += testmode.o
  ath10k_core-$(CONFIG_ATH10K_TRACING) += trace.o
@@ -61,8 +61,8 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  ath10k_core-$(CONFIG_MAC80211_DEBUGFS) += debugfs_sta.o
  ath10k_core-$(CONFIG_PM) += wow.o
  ath10k_core-$(CONFIG_ATH10K_CE) += ce.o
---- a/ath10k-6.9/core.c
-+++ b/ath10k-6.9/core.c
+--- a/ath10k-6.10/core.c
++++ b/ath10k-6.10/core.c
 @@ -29,6 +29,7 @@
  #include "testmode.h"
  #include "wmi-ops.h"
@@ -79,7 +79,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_ALL,
  		.otp_exe_param = 0,
  		.channel_counters_freq_hz = 88000,
-@@ -122,6 +124,7 @@ static const struct ath10k_hw_params ath
+@@ -121,6 +123,7 @@ static const struct ath10k_hw_params ath
  		.name = "qca988x hw2.0 ubiquiti",
  		.patch_load_addr = QCA988X_HW_2_0_PATCH_LOAD_ADDR,
  		.uart_pin = 7,
@@ -87,7 +87,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_ALL,
  		.otp_exe_param = 0,
  		.channel_counters_freq_hz = 88000,
-@@ -164,6 +167,7 @@ static const struct ath10k_hw_params ath
+@@ -162,6 +165,7 @@ static const struct ath10k_hw_params ath
  		.name = "qca9887 hw1.0",
  		.patch_load_addr = QCA9887_HW_1_0_PATCH_LOAD_ADDR,
  		.uart_pin = 7,
@@ -95,7 +95,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_ALL,
  		.otp_exe_param = 0,
  		.channel_counters_freq_hz = 88000,
-@@ -206,6 +210,7 @@ static const struct ath10k_hw_params ath
+@@ -203,6 +207,7 @@ static const struct ath10k_hw_params ath
  		.name = "qca6174 hw3.2 sdio",
  		.patch_load_addr = QCA6174_HW_3_0_PATCH_LOAD_ADDR,
  		.uart_pin = 19,
@@ -103,7 +103,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.otp_exe_param = 0,
  		.channel_counters_freq_hz = 88000,
  		.max_probe_resp_desc_thres = 0,
-@@ -243,6 +248,7 @@ static const struct ath10k_hw_params ath
+@@ -239,6 +244,7 @@ static const struct ath10k_hw_params ath
  		.name = "qca6164 hw2.1",
  		.patch_load_addr = QCA6174_HW_2_1_PATCH_LOAD_ADDR,
  		.uart_pin = 6,
@@ -111,7 +111,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.otp_exe_param = 0,
  		.channel_counters_freq_hz = 88000,
  		.max_probe_resp_desc_thres = 0,
-@@ -284,6 +290,7 @@ static const struct ath10k_hw_params ath
+@@ -279,6 +285,7 @@ static const struct ath10k_hw_params ath
  		.name = "qca6174 hw2.1",
  		.patch_load_addr = QCA6174_HW_2_1_PATCH_LOAD_ADDR,
  		.uart_pin = 6,
@@ -119,7 +119,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.otp_exe_param = 0,
  		.channel_counters_freq_hz = 88000,
  		.max_probe_resp_desc_thres = 0,
-@@ -325,6 +332,7 @@ static const struct ath10k_hw_params ath
+@@ -319,6 +326,7 @@ static const struct ath10k_hw_params ath
  		.name = "qca6174 hw3.0",
  		.patch_load_addr = QCA6174_HW_3_0_PATCH_LOAD_ADDR,
  		.uart_pin = 6,
@@ -127,7 +127,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.otp_exe_param = 0,
  		.channel_counters_freq_hz = 88000,
  		.max_probe_resp_desc_thres = 0,
-@@ -366,6 +374,7 @@ static const struct ath10k_hw_params ath
+@@ -359,6 +367,7 @@ static const struct ath10k_hw_params ath
  		.name = "qca6174 hw3.2",
  		.patch_load_addr = QCA6174_HW_3_0_PATCH_LOAD_ADDR,
  		.uart_pin = 6,
@@ -135,7 +135,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.otp_exe_param = 0,
  		.channel_counters_freq_hz = 88000,
  		.max_probe_resp_desc_thres = 0,
-@@ -411,6 +420,7 @@ static const struct ath10k_hw_params ath
+@@ -403,6 +412,7 @@ static const struct ath10k_hw_params ath
  		.name = "qca99x0 hw2.0",
  		.patch_load_addr = QCA99X0_HW_2_0_PATCH_LOAD_ADDR,
  		.uart_pin = 7,
@@ -143,7 +143,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.otp_exe_param = 0x00000700,
  		.continuous_frag_desc = true,
  		.cck_rate_map_rev2 = true,
-@@ -458,6 +468,7 @@ static const struct ath10k_hw_params ath
+@@ -449,6 +459,7 @@ static const struct ath10k_hw_params ath
  		.name = "qca9984/qca9994 hw1.0",
  		.patch_load_addr = QCA9984_HW_1_0_PATCH_LOAD_ADDR,
  		.uart_pin = 7,
@@ -151,7 +151,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_EACH,
  		.otp_exe_param = 0x00000700,
  		.continuous_frag_desc = true,
-@@ -512,6 +523,7 @@ static const struct ath10k_hw_params ath
+@@ -501,6 +512,7 @@ static const struct ath10k_hw_params ath
  		.name = "qca9888 hw2.0",
  		.patch_load_addr = QCA9888_HW_2_0_PATCH_LOAD_ADDR,
  		.uart_pin = 7,
@@ -159,7 +159,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_EACH,
  		.otp_exe_param = 0x00000700,
  		.continuous_frag_desc = true,
-@@ -563,6 +575,7 @@ static const struct ath10k_hw_params ath
+@@ -551,6 +563,7 @@ static const struct ath10k_hw_params ath
  		.name = "qca9377 hw1.0",
  		.patch_load_addr = QCA9377_HW_1_0_PATCH_LOAD_ADDR,
  		.uart_pin = 6,
@@ -167,7 +167,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.otp_exe_param = 0,
  		.channel_counters_freq_hz = 88000,
  		.max_probe_resp_desc_thres = 0,
-@@ -604,6 +617,7 @@ static const struct ath10k_hw_params ath
+@@ -591,6 +604,7 @@ static const struct ath10k_hw_params ath
  		.name = "qca9377 hw1.1",
  		.patch_load_addr = QCA9377_HW_1_0_PATCH_LOAD_ADDR,
  		.uart_pin = 6,
@@ -175,7 +175,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.otp_exe_param = 0,
  		.channel_counters_freq_hz = 88000,
  		.max_probe_resp_desc_thres = 0,
-@@ -647,6 +661,7 @@ static const struct ath10k_hw_params ath
+@@ -633,6 +647,7 @@ static const struct ath10k_hw_params ath
  		.name = "qca9377 hw1.1 sdio",
  		.patch_load_addr = QCA9377_HW_1_0_PATCH_LOAD_ADDR,
  		.uart_pin = 19,
@@ -183,7 +183,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.otp_exe_param = 0,
  		.channel_counters_freq_hz = 88000,
  		.max_probe_resp_desc_thres = 0,
-@@ -681,6 +696,7 @@ static const struct ath10k_hw_params ath
+@@ -666,6 +681,7 @@ static const struct ath10k_hw_params ath
  		.name = "qca4019 hw1.0",
  		.patch_load_addr = QCA4019_HW_1_0_PATCH_LOAD_ADDR,
  		.uart_pin = 7,
@@ -191,7 +191,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_EACH,
  		.otp_exe_param = 0x0010000,
  		.continuous_frag_desc = true,
-@@ -727,6 +743,7 @@ static const struct ath10k_hw_params ath
+@@ -711,6 +727,7 @@ static const struct ath10k_hw_params ath
  		.dev_id = 0,
  		.bus = ATH10K_BUS_SNOC,
  		.name = "wcn3990 hw1.0",
@@ -199,7 +199,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		.continuous_frag_desc = true,
  		.tx_chain_mask = 0x7,
  		.rx_chain_mask = 0x7,
-@@ -4091,6 +4108,10 @@ int ath10k_core_start(struct ath10k *ar,
+@@ -4073,6 +4090,10 @@ int ath10k_core_start(struct ath10k *ar,
  			ath10k_wmi_check_apply_board_power_ctl_table(ar);
  	}
  
@@ -210,7 +210,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  	return 0;
  
  err_hif_stop:
-@@ -4352,9 +4373,18 @@ static void ath10k_core_register_work(st
+@@ -4334,9 +4355,18 @@ static void ath10k_core_register_work(st
  		goto err_spectral_destroy;
  	}
  
@@ -229,7 +229,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  err_spectral_destroy:
  	ath10k_spectral_destroy(ar);
  err_debug_destroy:
-@@ -4414,6 +4444,8 @@ void ath10k_core_unregister(struct ath10
+@@ -4396,6 +4426,8 @@ void ath10k_core_unregister(struct ath10
  	if (!test_bit(ATH10K_FLAG_CORE_REGISTERED, &ar->dev_flags))
  		return;
  
@@ -238,8 +238,8 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  	ath10k_thermal_unregister(ar);
  	/* Stop spectral before unregistering from mac80211 to remove the
  	 * relayfs debugfs file cleanly. Otherwise the parent debugfs tree
---- a/ath10k-6.9/core.h
-+++ b/ath10k-6.9/core.h
+--- a/ath10k-6.10/core.h
++++ b/ath10k-6.10/core.h
 @@ -15,6 +15,7 @@
  #include <linux/pci.h>
  #include <linux/uuid.h>
@@ -248,7 +248,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  
  #include "htt.h"
  #include "htc.h"
-@@ -1590,6 +1591,13 @@ struct ath10k {
+@@ -1592,6 +1593,13 @@ struct ath10k {
  	} testmode;
  
  	struct {
@@ -262,9 +262,9 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  		/* protected by data_lock */
  		u32 rx_crc_err_drop;
  		u32 fw_crash_counter;
---- a/ath10k-6.9/hw.h
-+++ b/ath10k-6.9/hw.h
-@@ -525,6 +525,7 @@ struct ath10k_hw_params {
+--- a/ath10k-6.10/hw.h
++++ b/ath10k-6.10/hw.h
+@@ -516,6 +516,7 @@ struct ath10k_hw_params {
  	const char *name;
  	u32 patch_load_addr;
  	int uart_pin;
@@ -273,7 +273,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  
  	/* Type of hw cycle counter wraparound logic, for more info
 --- /dev/null
-+++ b/ath10k-6.9/leds.c
++++ b/ath10k-6.10/leds.c
 @@ -0,0 +1,90 @@
 +// SPDX-License-Identifier: ISC
 +/*
@@ -366,7 +366,7 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
 +}
 +
 --- /dev/null
-+++ b/ath10k-6.9/leds.h
++++ b/ath10k-6.10/leds.h
 @@ -0,0 +1,34 @@
 +/* SPDX-License-Identifier: ISC */
 +/*
@@ -402,8 +402,8 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
 +
 +#endif
 +#endif /* _LEDS_H_ */
---- a/ath10k-6.9/mac.c
-+++ b/ath10k-6.9/mac.c
+--- a/ath10k-6.10/mac.c
++++ b/ath10k-6.10/mac.c
 @@ -26,6 +26,7 @@
  #include "wmi-tlv.h"
  #include "wmi-ops.h"
@@ -412,8 +412,8 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  
  /*********/
  /* Rates */
---- a/ath10k-6.9/wmi-ops.h
-+++ b/ath10k-6.9/wmi-ops.h
+--- a/ath10k-6.10/wmi-ops.h
++++ b/ath10k-6.10/wmi-ops.h
 @@ -228,7 +228,10 @@ struct wmi_ops {
  			 const struct wmi_bb_timing_cfg_arg *arg);
  	struct sk_buff *(*gen_per_peer_per_tid_cfg)(struct ath10k *ar,
@@ -461,8 +461,8 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  static inline int
  ath10k_wmi_dbglog_cfg(struct ath10k *ar, u64 module_enable, u32 log_level)
  {
---- a/ath10k-6.9/wmi-tlv.c
-+++ b/ath10k-6.9/wmi-tlv.c
+--- a/ath10k-6.10/wmi-tlv.c
++++ b/ath10k-6.10/wmi-tlv.c
 @@ -4606,6 +4606,8 @@ static const struct wmi_ops wmi_tlv_ops
  	.gen_echo = ath10k_wmi_tlv_op_gen_echo,
  	.gen_vdev_spectral_conf = ath10k_wmi_tlv_op_gen_vdev_spectral_conf,
@@ -472,8 +472,8 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  };
  
  static const struct wmi_peer_flags_map wmi_tlv_peer_flags_map = {
---- a/ath10k-6.9/wmi.c
-+++ b/ath10k-6.9/wmi.c
+--- a/ath10k-6.10/wmi.c
++++ b/ath10k-6.10/wmi.c
 @@ -8467,6 +8467,49 @@ ath10k_wmi_op_gen_peer_set_param(struct
  	return skb;
  }
@@ -570,8 +570,8 @@ Link: https://msgid.link/20230611080505.17393-1-ansuelsmth@gmail.com
  };
  
  int ath10k_wmi_attach(struct ath10k *ar)
---- a/ath10k-6.9/wmi.h
-+++ b/ath10k-6.9/wmi.h
+--- a/ath10k-6.10/wmi.h
++++ b/ath10k-6.10/wmi.h
 @@ -3137,6 +3137,41 @@ enum wmi_10_4_feature_mask {
  
  };

--- a/package/kernel/ath10k-ct/patches/202-ath10k-use-tpt-trigger-by-default.patch
+++ b/package/kernel/ath10k-ct/patches/202-ath10k-use-tpt-trigger-by-default.patch
@@ -14,9 +14,9 @@ Signed-off-by: Mathias Kresin <dev@kresin.me>
  ath10k-6.7/mac.c  | 2 +-
  3 files changed, 6 insertions(+), 4 deletions(-)
 
---- a/ath10k-6.9/core.h
-+++ b/ath10k-6.9/core.h
-@@ -1705,6 +1705,10 @@ struct ath10k {
+--- a/ath10k-6.10/core.h
++++ b/ath10k-6.10/core.h
+@@ -1707,6 +1707,10 @@ struct ath10k {
  	u8 csi_data[4096];
  	u16 csi_data_len;
  
@@ -27,8 +27,8 @@ Signed-off-by: Mathias Kresin <dev@kresin.me>
  	/* must be last */
  	u8 drv_priv[] __aligned(sizeof(void *));
  };
---- a/ath10k-6.9/leds.c
-+++ b/ath10k-6.9/leds.c
+--- a/ath10k-6.10/leds.c
++++ b/ath10k-6.10/leds.c
 @@ -70,7 +70,7 @@ int ath10k_leds_register(struct ath10k *
  
  	ar->leds.cdev.name = ar->leds.label;
@@ -38,8 +38,8 @@ Signed-off-by: Mathias Kresin <dev@kresin.me>
  
  	ret = led_classdev_register(wiphy_dev(ar->hw->wiphy), &ar->leds.cdev);
  	if (ret)
---- a/ath10k-6.9/mac.c
-+++ b/ath10k-6.9/mac.c
+--- a/ath10k-6.10/mac.c
++++ b/ath10k-6.10/mac.c
 @@ -11631,7 +11631,7 @@ int ath10k_mac_register(struct ath10k *a
  	ar->hw->weight_multiplier = ATH10K_AIRTIME_WEIGHT_MULTIPLIER;
  

--- a/package/kernel/ath10k-ct/patches/300-fix-fortify-checking-error.patch
+++ b/package/kernel/ath10k-ct/patches/300-fix-fortify-checking-error.patch
@@ -1,5 +1,5 @@
---- a/ath10k-6.9/wmi.h
-+++ b/ath10k-6.9/wmi.h
+--- a/ath10k-6.10/wmi.h
++++ b/ath10k-6.10/wmi.h
 @@ -6310,7 +6310,7 @@ struct qca9880_set_ctl_table_cmd {
  	__le32 ctl_len; /* in bytes.  This may be ignored in firmware,
  			 * make sure ctl_info data is sizeof(qca9880_power_ctl) */

--- a/package/kernel/ath10k-ct/patches/960-0010-ath10k-limit-htt-rx-ring-size.patch
+++ b/package/kernel/ath10k-ct/patches/960-0010-ath10k-limit-htt-rx-ring-size.patch
@@ -1,5 +1,5 @@
---- a/ath10k-6.9/htt.h
-+++ b/ath10k-6.9/htt.h
+--- a/ath10k-6.10/htt.h
++++ b/ath10k-6.10/htt.h
 @@ -238,7 +238,11 @@ enum htt_rx_ring_flags {
  };
  

--- a/package/kernel/ath10k-ct/patches/960-0011-ath10k-limit-pci-buffer-size.patch
+++ b/package/kernel/ath10k-ct/patches/960-0011-ath10k-limit-pci-buffer-size.patch
@@ -1,5 +1,5 @@
---- a/ath10k-6.9/pci.c
-+++ b/ath10k-6.9/pci.c
+--- a/ath10k-6.10/pci.c
++++ b/ath10k-6.10/pci.c
 @@ -132,7 +132,11 @@ static const struct ce_attr pci_host_ce_
  		.flags = CE_ATTR_FLAGS,
  		.src_nentries = 0,

--- a/package/kernel/ath10k-ct/patches/988-ath10k-always-use-mac80211-loss-detection.patch
+++ b/package/kernel/ath10k-ct/patches/988-ath10k-always-use-mac80211-loss-detection.patch
@@ -13,11 +13,11 @@ own loss detection mechanism.
 
 Signed-off-by: David Bauer <mail@david-bauer.net>
 ---
- ath10k-6.9/mac.c | 1 -
+ ath10k-6.10/mac.c | 1 -
  1 file changed, 1 deletion(-)
 
---- a/ath10k-6.9/mac.c
-+++ b/ath10k-6.9/mac.c
+--- a/ath10k-6.10/mac.c
++++ b/ath10k-6.10/mac.c
 @@ -11316,7 +11316,6 @@ int ath10k_mac_register(struct ath10k *a
  	ieee80211_hw_set(ar->hw, CHANCTX_STA_CSA);
  	ieee80211_hw_set(ar->hw, QUEUE_CONTROL);


### PR DESCRIPTION
Unfortunately this version didn't fix the known kernel warning on ath10k wave2 devices:
```
[   30.925606] ------------[ cut here ]------------
[   30.936592] WARNING: CPU: 3 PID: 1211 at backports-6.11/net/mac80211/main.c:270 ieee80211_do_open+0x4f4/0x5ec [mac80211]
[   30.941365] Modules linked in: pppoe ppp_async nft_fib_inet nf_flow_table_inet ath10k_pci(O) ath10k_core(O) ath(O) pppox ppp_generic nft_reject_ipv6 nft_reject_ipv4 nft_reject_inet nft_reject nft_redir nft_quota nft_numgen nft_nat nft_masq nft_log nft_limit nft_hash nft_flow_offload nft_fib_ipv6 nft_fib_ipv4 nft_fib nft_ct nft_chain_nat nf_tables nf_nat nf_flow_table nf_conntrack mac80211(O) cfg80211(O) slhc nfnetlink nf_reject_ipv6 nf_reject_ipv4 nf_log_syslog nf_defrag_ipv6 nf_defrag_ipv4 mdio_netlink(O) libcrc32c hwmon crc_ccitt compat(O) sha512_arm ghash_arm_ce cmac leds_gpio xhci_plat_hcd xhci_pci xhci_hcd dwc3 dwc3_qcom gpio_button_hotplug(O) crc32c_generic
[   30.988392] CPU: 3 PID: 1211 Comm: hostapd Tainted: G           O       6.6.52 #0
[   31.010582] Hardware name: Generic DT based system
[   31.018224]  unwind_backtrace from show_stack+0x10/0x14
[   31.022907]  show_stack from dump_stack_lvl+0x40/0x4c
[   31.028028]  dump_stack_lvl from __warn+0x94/0xbc
[   31.033235]  __warn from warn_slowpath_fmt+0x158/0x15c
[   31.037922]  warn_slowpath_fmt from ieee80211_do_open+0x4f4/0x5ec [mac80211]
[   31.042969]  ieee80211_do_open [mac80211] from ieee80211_open+0x58/0x7c [mac80211]
[   31.050167]  ieee80211_open [mac80211] from __dev_open+0xc4/0x170
[   31.057545]  __dev_open from __dev_change_flags+0x168/0x1dc
[   31.063704]  __dev_change_flags from dev_change_flags+0x18/0x54
[   31.069085]  dev_change_flags from devinet_ioctl+0x5b4/0x7ec
[   31.074990]  devinet_ioctl from inet_ioctl+0x16c/0x268
[   31.080893]  inet_ioctl from sock_ioctl+0x240/0x60c
[   31.085840]  sock_ioctl from sys_ioctl+0x25c/0xc0c
[   31.090615]  sys_ioctl from ret_fast_syscall+0x0/0x54
[   31.095474] Exception stack(0xc112ffa8 to 0xc112fff0)
[   31.100601] ffa0:                   00000010 bef00858 00000010 00008914 bef00858 00000000
[   31.105641] ffc0: 00000010 bef00858 00000010 00000036 00000001 00000001 00000000 00000020
[   31.113796] ffe0: 005d3ea4 bef00718 00550cd8 b6f2466c
[   31.122001] ---[ end trace 0000000000000000 ]---
```