### PR TITLE
ath79: ar7200 usb phy: simplify probe

### DIFF
--- a/target/linux/ath79/patches-6.6/700-phy-add-ath79-usb-phys.patch
+++ b/target/linux/ath79/patches-6.6/700-phy-add-ath79-usb-phys.patch
@@ -51,7 +51,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
  obj-$(CONFIG_PHY_LPC18XX_USB_OTG)	+= phy-lpc18xx-usb-otg.o
 --- /dev/null
 +++ b/drivers/phy/phy-ar7100-usb.c
-@@ -0,0 +1,140 @@
+@@ -0,0 +1,127 @@
 +/*
 + * Copyright (C) 2018 John Crispin <john@phrozen.org>
 + *
@@ -118,50 +118,38 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +static int ar7100_usb_phy_probe(struct platform_device *pdev)
 +{
 +	struct phy_provider *phy_provider;
-+	struct resource *res;
 +	struct ar7100_usb_phy *priv;
 +
 +	priv = devm_kzalloc(&pdev->dev, sizeof(*priv), GFP_KERNEL);
 +	if (!priv)
 +		return -ENOMEM;
 +
-+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-+	priv->io_base = devm_ioremap_resource(&pdev->dev, res);
++	priv->io_base = devm_platform_ioremap_resource(pdev, 0);
 +	if (IS_ERR(priv->io_base))
 +		return PTR_ERR(priv->io_base);
 +
 +	priv->rst_phy = devm_reset_control_get(&pdev->dev, "usb-phy");
-+	if (IS_ERR(priv->rst_phy)) {
-+		dev_err(&pdev->dev, "phy reset is missing\n");
-+		return PTR_ERR(priv->rst_phy);
-+	}
++	if (IS_ERR(priv->rst_phy))
++		return dev_err_probe(&pdev->dev, PTR_ERR(priv->rst_phy), "phy reset is missing");
 +
 +	priv->rst_host = devm_reset_control_get(&pdev->dev, "usb-host");
-+	if (IS_ERR(priv->rst_host)) {
-+		dev_err(&pdev->dev, "host reset is missing\n");
-+		return PTR_ERR(priv->rst_host);
-+	}
++	if (IS_ERR(priv->rst_host))
++		return dev_err_probe(&pdev->dev, PTR_ERR(priv->rst_host), "host reset is missing");
 +
 +	priv->rst_ohci_dll = devm_reset_control_get(&pdev->dev, "usb-ohci-dll");
-+	if (IS_ERR(priv->rst_ohci_dll)) {
-+		dev_err(&pdev->dev, "ohci-dll reset is missing\n");
-+		return PTR_ERR(priv->rst_host);
-+	}
++	if (IS_ERR(priv->rst_ohci_dll))
++		return dev_err_probe(&pdev->dev, PTR_ERR(priv->rst_host), "ohci-dll reset is missing");
 +
 +	priv->phy = devm_phy_create(&pdev->dev, NULL, &ar7100_usb_phy_ops);
-+	if (IS_ERR(priv->phy)) {
-+		dev_err(&pdev->dev, "failed to create PHY\n");
-+		return PTR_ERR(priv->phy);
-+	}
++	if (IS_ERR(priv->phy))
++		return dev_err_probe(&pdev->dev, PTR_ERR(priv->phy), "failed to create PHY");
 +
 +	priv->gpio = of_get_named_gpio(pdev->dev.of_node, "gpios", 0);
 +	if (gpio_is_valid(priv->gpio)) {
 +		int ret = devm_gpio_request(&pdev->dev, priv->gpio, dev_name(&pdev->dev));
++		if (ret)
++			return dev_err_probe(&pdev->dev, ret, "failed to request gpio");
 +
-+		if (ret) {
-+			dev_err(&pdev->dev, "failed to request gpio\n");
-+			return ret;
-+		}
 +		gpio_export_with_name(gpio_to_desc(priv->gpio), 0, dev_name(&pdev->dev));
 +		gpio_set_value(priv->gpio, 1);
 +	}
@@ -169,7 +157,6 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	phy_set_drvdata(priv->phy, priv);
 +
 +	phy_provider = devm_of_phy_provider_register(&pdev->dev, of_phy_simple_xlate);
-+
 +
 +	return PTR_ERR_OR_ZERO(phy_provider);
 +}
@@ -194,7 +181,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +MODULE_LICENSE("GPL");
 --- /dev/null
 +++ b/drivers/phy/phy-ar7200-usb.c
-@@ -0,0 +1,136 @@
+@@ -0,0 +1,120 @@
 +/*
 + * Copyright (C) 2015 Alban Bedel <albeu@free.fr>
 + *
@@ -264,44 +251,28 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +		return -ENOMEM;
 +
 +	priv->rst_phy = devm_reset_control_get(&pdev->dev, "usb-phy");
-+	if (IS_ERR(priv->rst_phy)) {
-+		if (PTR_ERR(priv->rst_phy) != -EPROBE_DEFER)
-+			dev_err(&pdev->dev, "phy reset is missing\n");
-+		return PTR_ERR(priv->rst_phy);
-+	}
++	if (IS_ERR(priv->rst_phy))
++		return dev_err_probe(&pdev->dev, PTR_ERR(priv->rst_phy), "phy reset is missing");
 +
 +	priv->rst_phy_analog = devm_reset_control_get_optional(
 +		&pdev->dev, "usb-phy-analog");
-+	if (IS_ERR(priv->rst_phy_analog)) {
-+		if (PTR_ERR(priv->rst_phy_analog) == -ENOENT)
-+			priv->rst_phy_analog = NULL;
-+		else
-+			return PTR_ERR(priv->rst_phy_analog);
-+	}
++	if (IS_ERR(priv->rst_phy_analog))
++		return PTR_ERR(priv->rst_phy_analog);
 +
 +	priv->suspend_override = devm_reset_control_get_optional(
 +		&pdev->dev, "usb-suspend-override");
-+	if (IS_ERR(priv->suspend_override)) {
-+		if (PTR_ERR(priv->suspend_override) == -ENOENT)
-+			priv->suspend_override = NULL;
-+		else
-+			return PTR_ERR(priv->suspend_override);
-+	}
++	if (IS_ERR(priv->suspend_override))
++		return PTR_ERR(priv->suspend_override);
 +
 +	priv->phy = devm_phy_create(&pdev->dev, NULL, &ar7200_usb_phy_ops);
-+	if (IS_ERR(priv->phy)) {
-+		dev_err(&pdev->dev, "failed to create PHY\n");
-+		return PTR_ERR(priv->phy);
-+	}
++	if (IS_ERR(priv->phy))
++		return dev_err_probe(&pdev->dev, PTR_ERR(priv->phy), "failed to create PHY");
 +
 +	priv->gpio = of_get_named_gpio(pdev->dev.of_node, "gpios", 0);
 +	if (gpio_is_valid(priv->gpio)) {
 +		int ret = devm_gpio_request(&pdev->dev, priv->gpio, dev_name(&pdev->dev));
-+
-+		if (ret) {
-+			dev_err(&pdev->dev, "failed to request gpio\n");
-+			return ret;
-+		}
++		if (ret)
++			return dev_err_probe(&pdev->dev, ret, "failed to request gpio");
 +		gpio_export_with_name(gpio_to_desc(priv->gpio), 0, dev_name(&pdev->dev));
 +		gpio_set_value(priv->gpio, 1);
 +	}


### PR DESCRIPTION
Even though optional is used, there's are still pointless NULL assignments.

Use dev_err_probe to avoid manually handling EPROBE_DEFER.

Use devm_platform_iomap_resource. No struct resource needed.

ping @DragonBluep 