### PR TITLE
package/libs/libsepol: update to 3.7

### DIFF
--- a/package/libs/libsepol/Makefile
+++ b/package/libs/libsepol/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsepol
-PKG_VERSION:=3.5
+PKG_VERSION:=3.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/SELinuxProject/selinux/releases/download/$(PKG_VERSION)
-PKG_HASH:=78fdaf69924db780bac78546e43d9c44074bad798c2c415d0b9bb96d065ee8a2
+PKG_HASH:=cd741e25244e7ef6cd934d633614131a266c3eaeab33d8bfa45e8a93b45cc901
 
 PKG_MAINTAINER:=Thomas Petazzoni <thomas.petazzoni@bootlin.com>
 PKG_CPE_ID:=cpe:/a:selinuxproject:libsepol


### PR DESCRIPTION
package/libs/libsepol: update to 3.7


Tested successfully for Asus RT-AC88U (arm_cortex-a9) built from scratch.