### PR TITLE
Add some packages from feed

### DIFF
--- a/package/libs/libev/Makefile
+++ b/package/libs/libev/Makefile
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2014-2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libev
+PKG_VERSION:=4.33
+PKG_RELEASE:=2
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://dist.schmorp.de/libev/Attic/
+PKG_HASH:=507eb7b8d1015fbec5b935f34ebed15bf346bed04a11ab82b8eee848c4205aea
+PKG_LICENSE:=BSD-2-Clause or GPL-2.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Karl Palsson <karlp@tweak.net.au>
+
+PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_FLAGS:=no-mips16
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libev
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=High-performance event loop
+  URL:=http://software.schmorp.de/pkg/libev.html
+endef
+
+define Package/libev/description
+ A full-featured and high-performance event loop that is loosely modelled after
+ libevent, but without its limitations and bugs.
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+CONFIGURE_ARGS += \
+	--enable-shared \
+	--enable-static \
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/event.h $(1)/usr/include/ev_event_compat.h
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/ev.h $(1)/usr/include/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/ev++.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libev.{a,so*} $(1)/usr/lib/
+endef
+
+define Package/libev/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libev.so* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libev))

--- a/package/libs/libpam/Makefile
+++ b/package/libs/libpam/Makefile
@@ -1,0 +1,83 @@
+#
+# Copyright (C) 2006-2014 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libpam
+PKG_VERSION:=1.5.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=Linux-PAM-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=https://github.com/linux-pam/linux-pam/releases/download/v$(PKG_VERSION)
+PKG_HASH:=e4ec7131a91da44512574268f493c6d8ca105c87091691b8e9b56ca685d4f94d
+PKG_BUILD_DIR:=$(BUILD_DIR)/Linux-PAM-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
+PKG_LICENSE:=BSD-3c GPL
+PKG_LICENSE_FILES:=COPYING Copyright
+PKG_CPE_ID:=cpe:/a:linux-pam:linux-pam
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libpam
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=the Linux-PAM libraries and modules.
+  URL:=http://www.kernel.org/pub/linux/libs/pam
+endef
+
+define Package/libpam/description
+	The Linux-PAM Pluggable Authentication Modules.
+endef
+
+CONFIGURE_ARGS += \
+	--enable-pamlocking \
+	--enable-shared \
+	--enable-static \
+	--disable-audit \
+	--disable-cracklib \
+	--disable-db \
+	--disable-debug \
+	--disable-doc \
+	--disable-econf \
+	--disable-lckpwdf \
+	--disable-nis \
+	--disable-prelude \
+	--disable-regenerate-docu \
+	--disable-rpath \
+	--disable-selinux \
+	--disable-Werror \
+	--with-gnu-ld \
+	--without-mailspool \
+	--without-xauth
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
+endef
+
+define Package/libpam/install
+	$(INSTALL_DIR) $(1)/etc $(1)/etc/pam.d
+	$(INSTALL_DIR) $(1)/usr/lib $(1)/usr/lib/security $(1)/usr/lib/security/pam_filter
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/etc/* $(1)/etc/
+	$(CP) ./files/* $(1)/etc/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/security/*.so* $(1)/usr/lib/security/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/security/pam_filter/* $(1)/usr/lib/security/pam_filter/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/* $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*.pc $(1)/usr/lib/pkgconfig/
+endef
+
+$(eval $(call BuildPackage,libpam))

--- a/package/libs/libpam/files/pam.conf
+++ b/package/libs/libpam/files/pam.conf
@@ -1,0 +1,15 @@
+# ---------------------------------------------------------------------------#
+# /etc/pam.conf								     #
+# ---------------------------------------------------------------------------#
+#
+# NOTE
+# ----
+#
+# NOTE: Most program use a file under the /etc/pam.d/ directory to setup their
+# PAM service modules. This file is used only if that directory does not exist.
+# ---------------------------------------------------------------------------#
+
+# Format:
+# serv.	module	   ctrl	      module [path]	...[args..]		     #
+# name	type	   flag							     #
+

--- a/package/libs/libpam/files/pam.d/common-account
+++ b/package/libs/libpam/files/pam.d/common-account
@@ -1,0 +1,20 @@
+#
+# /etc/pam.d/common-account - authorization settings common to all services
+#
+# This file is included from other service-specific PAM config files,
+# and should contain a list of the authorization modules that define
+# the central access policy for use on the system.  The default is to
+# only deny service to users whose accounts are expired in /etc/shadow.
+#
+
+# here are the per-package modules (the "Primary" block)
+account	[success=1 new_authtok_reqd=done default=ignore]	pam_unix.so 
+# here's the fallback if no module succeeds
+account	requisite			pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+account	required			pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+
+# end of pam-auth-update config

--- a/package/libs/libpam/files/pam.d/common-auth
+++ b/package/libs/libpam/files/pam.d/common-auth
@@ -1,0 +1,21 @@
+#
+# /etc/pam.d/common-auth - authentication settings common to all services
+#
+# This file is included from other service-specific PAM config files,
+# and should contain a list of the authentication modules that define
+# the central authentication scheme for use on the system
+# (e.g., /etc/shadow, LDAP, Kerberos, etc.).  The default is to use the
+# traditional Unix authentication mechanisms.
+#
+
+# here are the per-package modules (the "Primary" block)
+auth	[success=1 default=ignore]	pam_unix.so nullok_secure
+# here's the fallback if no module succeeds
+auth	requisite			pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+auth	required			pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+
+# end of pam-auth-update config

--- a/package/libs/libpam/files/pam.d/common-password
+++ b/package/libs/libpam/files/pam.d/common-password
@@ -1,0 +1,28 @@
+#
+# /etc/pam.d/common-password - password-related modules common to all services
+#
+# This file is included from other service-specific PAM config files,
+# and should contain a list of modules that define the services to be
+# used to change user passwords.  The default is pam_unix.
+
+# Explanation of pam_unix options:
+#
+# The "sha512" option enables salted SHA512 passwords.  Without this option,
+# the default is Unix crypt.  Prior releases used the option "md5".
+#
+# The "obscure" option replaces the old `OBSCURE_CHECKS_ENAB' option in
+# login.defs.
+#
+# See the pam_unix manpage for other options.
+
+# here are the per-package modules (the "Primary" block)
+password	[success=1 default=ignore]	pam_unix.so obscure sha512
+# here's the fallback if no module succeeds
+password	requisite			pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+password	required			pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+
+# end of pam-auth-update config

--- a/package/libs/libpam/files/pam.d/common-session
+++ b/package/libs/libpam/files/pam.d/common-session
@@ -1,0 +1,25 @@
+#
+# /etc/pam.d/common-session - session-related modules common to all services
+#
+# This file is included from other service-specific PAM config files,
+# and should contain a list of modules that define tasks to be performed
+# at the start and end of sessions of *any* kind (both interactive and
+# non-interactive).
+#
+
+# here are the per-package modules (the "Primary" block)
+session	[default=1]			pam_permit.so
+# here's the fallback if no module succeeds
+session	requisite			pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+session	required			pam_permit.so
+# The pam_umask module will set the umask according to the system default in
+# /etc/login.defs and user settings, solving the problem of different
+# umask settings with different shells, display managers, remote sessions etc.
+# See "man pam_umask".
+session optional			pam_umask.so
+# and here are more per-package modules (the "Additional" block)
+session	required			pam_unix.so 
+# end of pam-auth-update config

--- a/package/libs/libpam/files/pam.d/common-session-noninteractive
+++ b/package/libs/libpam/files/pam.d/common-session-noninteractive
@@ -1,0 +1,25 @@
+#
+# /etc/pam.d/common-session-noninteractive - session-related modules
+# common to all non-interactive services
+#
+# This file is included from other service-specific PAM config files,
+# and should contain a list of modules that define tasks to be performed
+# at the start and end of all non-interactive sessions.
+#
+
+# here are the per-package modules (the "Primary" block)
+session	[default=1]			pam_permit.so
+# here's the fallback if no module succeeds
+session	requisite			pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+session	required			pam_permit.so
+# The pam_umask module will set the umask according to the system default in
+# /etc/login.defs and user settings, solving the problem of different
+# umask settings with different shells, display managers, remote sessions etc.
+# See "man pam_umask".
+session optional			pam_umask.so
+# and here are more per-package modules (the "Additional" block)
+session	required			pam_unix.so 
+# end of pam-auth-update config

--- a/package/libs/libpam/files/pam.d/other
+++ b/package/libs/libpam/files/pam.d/other
@@ -1,0 +1,16 @@
+#
+# /etc/pam.d/other - specify the PAM fallback behaviour
+#
+# Note that this file is used for any unspecified service; for example
+#if /etc/pam.d/cron  specifies no session modules but cron calls
+#pam_open_session, the session module out of /etc/pam.d/other is
+#used.  If you really want nothing to happen then use pam_permit.so or
+#pam_deny.so as appropriate.
+
+# We fall back to the system default in /etc/pam.d/common-*
+# 
+
+auth       include      common-auth
+account    include      common-account
+password   include      common-password
+session    include      common-session

--- a/package/libs/libpam/patches/0001-build-always-use-lib-instead-of-lib64.patch
+++ b/package/libs/libpam/patches/0001-build-always-use-lib-instead-of-lib64.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -25,7 +25,7 @@ dnl If we use /usr as prefix, use /etc f
+         then
+                 sysconfdir="/etc"
+         fi
+-	if test ${libdir} = '${exec_prefix}/lib'
++	if false
+ 	then
+ 		case "$host_cpu" in
+ 		    x86_64|ppc64|s390x|sparc64)

--- a/package/network/utils/net-snmp/Config.in.wut
+++ b/package/network/utils/net-snmp/Config.in.wut
@@ -1,0 +1,14 @@
+menu "Configuration"
+        depends on PACKAGE_libnetsnmp 
+
+config SNMP_WITH_PERL_EMBEDDED
+	bool
+	default n
+	prompt "Enable embedded perl in the SNMP agent and snmptrapd."
+
+config SNMP_WITH_PERL_MODULES
+	bool
+	default n
+	prompt "Install perl modules"
+
+endmenu

--- a/package/network/utils/net-snmp/Makefile
+++ b/package/network/utils/net-snmp/Makefile
@@ -1,0 +1,293 @@
+#
+# Copyright (C) 2006-2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=net-snmp
+PKG_VERSION:=5.9.4
+PKG_RELEASE:=3
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@SF/net-snmp
+PKG_HASH:=8b4de01391e74e3c7014beb43961a2d6d6fa03acc34280b9585f4930745b0544
+PKG_MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
+PKG_LICENSE:=MIT BSD-3-Clause-Clear
+PKG_CPE_ID:=cpe:/a:net-snmp:net-snmp
+
+PKG_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/net-snmp/Default
+  SECTION:=net
+  CATEGORY:=Network
+  URL:=http://www.net-snmp.org/
+endef
+
+define Package/net-snmp/Default/description
+ Simple Network Management Protocol (SNMP) is a widely used protocol for
+ monitoring the health and welfare of network equipment (eg. routers),
+ computer equipment and even devices like UPSs. Net-SNMP is a suite of
+ applications used to implement SNMP v1, SNMP v2c and SNMP v3 using both
+ IPv4 and IPv6.
+endef
+
+
+define Package/libnetsnmp
+$(call Package/net-snmp/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+libnl-tiny +libpci +libpcre2
+  TITLE:=Open source SNMP implementation (libraries)
+endef
+
+define Package/libnetsnmp/description
+$(call Package/net-snmp/Default/description)
+ .
+ This package contains shared libraries, needed by other programs.
+endef
+
+
+define Package/snmp-mibs
+$(call Package/net-snmp/Default)
+  TITLE:=Open source SNMP implementation (MIB-files)
+endef
+
+define Package/snmp-mibs/description
+$(call Package/net-snmp/Default/description)
+ .
+ This package contains SNMP MIB-Files.
+endef
+
+
+define Package/snmp-utils
+$(call Package/net-snmp/Default)
+  DEPENDS:=+libnetsnmp
+  TITLE:=Open source SNMP implementation (utilities)
+endef
+
+define Package/snmp-utils/description
+$(call Package/net-snmp/Default/description)
+ .
+ This package contains SNMP client utilities:
+   - snmpget
+   - snmpset
+   - snmpstatus
+   - snmptest
+   - snmptrap
+   - snmpwalk
+endef
+
+
+define Package/snmpd
+$(call Package/net-snmp/Default)
+  DEPENDS:=+libnetsnmp
+  TITLE:=Open source SNMP implementation (daemon)
+endef
+
+define Package/snmpd/description
+$(call Package/net-snmp/Default/description)
+ .
+ This package contains the SNMP agent, dynamically linked.
+endef
+
+
+define Package/snmpd-static
+$(call Package/net-snmp/Default)
+  DEPENDS:=+snmpd
+  TITLE:=Open source SNMP implementation (daemon)
+  BUILDONLY:=1
+endef
+
+
+define Package/snmptrapd
+$(call Package/net-snmp/Default)
+  DEPENDS:=+libnetsnmp
+  TITLE:=Open source SNMP implementation (notification receiver)
+endef
+
+define Package/snmptrapd/description
+$(call Package/net-snmp/Default/description)
+ .
+ This package contains the SNMP notification receiver.
+endef
+
+
+SNMP_MIB_MODULES_INCLUDED = \
+	agent/extend \
+	agentx \
+	host/hr_device \
+	host/hr_disk \
+	host/hr_filesys \
+	host/hr_network \
+	host/hr_partition \
+	host/hr_proc \
+	host/hr_storage \
+	host/hr_system \
+	ieee802dot11 \
+	if-mib/ifXTable \
+	ip-mib/ipAddressTable \
+	ip-mib/inetNetToMediaTable \
+	ip-forward-mib/inetCidrRouteTable \
+	ip-forward-mib/ipCidrRouteTable \
+	mibII/at \
+	mibII/icmp \
+	mibII/ifTable \
+	mibII/ip \
+	mibII/snmp_mib \
+	mibII/sysORTable \
+	mibII/system_mib \
+	mibII/tcp \
+	mibII/udp \
+	mibII/vacm_context \
+	mibII/vacm_vars \
+	snmpv3/snmpEngine \
+	snmpv3/snmpMPDStats \
+	snmpv3/usmConf \
+	snmpv3/usmStats \
+	snmpv3/usmUser \
+	tunnel \
+	ucd-snmp/disk_hw \
+	ucd-snmp/dlmod \
+	ucd-snmp/extensible \
+	ucd-snmp/loadave \
+	ucd-snmp/memory \
+	ucd-snmp/pass \
+	ucd-snmp/pass_persist \
+	ucd-snmp/proc \
+	ucd-snmp/vmstat \
+	util_funcs \
+	utilities/execute \
+
+SNMP_MIB_MODULES_EXCLUDED = \
+	agent_mibs \
+	disman/event \
+	disman/schedule \
+	hardware \
+	host \
+	if-mib \
+	ip-mib \
+	mibII \
+	notification \
+	notification-log-mib \
+	snmpv3mibs \
+	target \
+	tcp-mib \
+	ucd_snmp \
+	udp-mib \
+	utilities \
+
+SNMP_TRANSPORTS_INCLUDED = Callback UDP Unix
+
+SNMP_TRANSPORTS_EXCLUDED = TCP TCPIPv6
+
+TARGET_CFLAGS += $(FPIC)
+TARGET_CPPFLAGS += -I$(STAGING_DIR)/usr/include/libnl-tiny
+
+CONFIGURE_ARGS += \
+	--enable-mfd-rewrites \
+	--enable-shared \
+	--enable-static \
+	--with-endianness=$(if $(CONFIG_BIG_ENDIAN),big,little) \
+	--with-logfile=/var/log/snmpd.log \
+	--with-persistent-directory=/usr/lib/snmp/ \
+	--with-default-snmp-version=1 \
+	--with-sys-contact=root@localhost \
+	--with-sys-location=Unknown \
+	--enable-applications \
+	--disable-debugging \
+	--disable-manuals \
+	--disable-scripts \
+	--with-out-mib-modules="$(SNMP_MIB_MODULES_EXCLUDED)" \
+	--with-mib-modules="$(SNMP_MIB_MODULES_INCLUDED)" \
+	--with-out-transports="$(SNMP_TRANSPORTS_EXCLUDED)" \
+	--with-transports="$(SNMP_TRANSPORTS_INCLUDED)" \
+	--without-openssl \
+	--without-libwrap \
+	--without-mysql \
+	--without-rpm \
+	--without-zlib \
+	--with-pcre2-8 \
+	--with-nl \
+	 $(call autoconf_bool,CONFIG_IPV6,ipv6) \
+	--disable-perl-cc-checks \
+	--disable-embedded-perl \
+	--without-perl-modules
+
+CONFIGURE_VARS += \
+	ac_cv_header_netlink_netlink_h=yes \
+	netsnmp_cv_func_nl_connect_LIBS=-lnl-tiny \
+
+ifeq ($(CONFIG_IPV6),y)
+SNMP_TRANSPORTS_INCLUDED+= UDPIPv6
+endif
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		INSTALL_PREFIX="$(PKG_INSTALL_DIR)" \
+		LDFLAGS="$(TARGET_LDFLAGS) -lm -lc" \
+		all install
+endef
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(2)/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/net-snmp-config $(2)/bin/
+	$(SED) 's,=/usr,=$(STAGING_DIR)/usr,g' $(2)/bin/net-snmp-config
+	$(INSTALL_DIR) $(STAGING_DIR)/usr/bin
+	$(LN) $(STAGING_DIR)/host/bin/net-snmp-config $(STAGING_DIR)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/net-snmp $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetsnmp{,agent,helpers,mibs}.{a,so*} $(1)/usr/lib/
+endef
+
+define Package/libnetsnmp/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetsnmp{,agent,helpers,mibs}.so.* $(1)/usr/lib/
+endef
+
+define Package/snmp-mibs/install
+	$(INSTALL_DIR) $(1)/usr/share/snmp/mibs
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/snmp/mibs/* $(1)/usr/share/snmp/mibs/
+endef
+
+define Package/snmp-utils/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/snmp{get,set,status,test,trap,walk} $(1)/usr/bin/
+endef
+
+define Package/snmpd/conffiles
+/etc/config/snmpd
+endef
+
+define Package/snmpd/install
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/snmpd.conf $(1)/etc/config/snmpd
+	$(INSTALL_DIR) $(1)/etc/snmp
+	$(LN) /var/run/snmpd.conf $(1)/etc/snmp/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/snmpd.init $(1)/etc/init.d/snmpd
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/snmpd $(1)/usr/sbin/snmpd
+endef
+
+define Package/snmptrapd/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/snmptrapd.init $(1)/etc/init.d/snmptrapd
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnetsnmptrapd.so.* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/snmptrapd $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,libnetsnmp))
+$(eval $(call BuildPackage,snmp-mibs))
+$(eval $(call BuildPackage,snmp-utils))
+$(eval $(call BuildPackage,snmpd))
+$(eval $(call BuildPackage,snmpd-static))
+$(eval $(call BuildPackage,snmptrapd))

--- a/package/network/utils/net-snmp/files/snmpd.conf
+++ b/package/network/utils/net-snmp/files/snmpd.conf
@@ -1,0 +1,130 @@
+config agent
+	option agentaddress UDP:161,UDP6:161
+
+config agentx
+	option agentxsocket /var/run/agentx.sock
+
+config com2sec public
+	option secname ro
+	option source default
+	option community public
+
+config com2sec private
+	option secname rw
+	option source localhost
+	option community private
+
+config com2sec6 public6
+	option secname ro
+	option source default
+	option community public
+
+config com2sec6 private6
+	option secname rw
+	option source localhost
+	option community private
+
+config group public_v1
+	option group public
+	option version v1
+	option secname ro
+
+config group public_v2c
+	option group public
+	option version v2c
+	option secname ro
+
+config group public_usm
+	option group public
+	option version usm
+	option secname ro
+
+config group private_v1
+	option group private
+	option version v1
+	option secname rw
+
+config group private_v2c
+	option group private
+	option version v2c
+	option secname rw
+
+config group private_usm
+	option group private
+	option version usm
+	option secname rw
+
+config view all
+	option viewname all
+	option type included
+	option oid .1
+
+config access public_access
+	option group public
+	option context none
+	option version any
+	option level noauth
+	option prefix exact
+	option read all
+	option write none
+	option notify none
+
+config access private_access
+	option group private
+	option context none
+	option version any
+	option level noauth
+	option prefix exact
+	option read all
+	option write all
+	option notify all
+
+config system
+	option sysLocation	'office'
+	option sysContact	'bofh@example.com'
+	option sysName		'HeartOfGold'
+#	option sysServices	72
+#	option sysDescr		'adult playground'
+#	option sysObjectID	'1.2.3.4'
+
+config exec
+	option name	filedescriptors
+	option prog	/bin/cat
+	option args	/proc/sys/fs/file-nr
+#	option miboid	1.2.3.4
+
+config engineid
+#	option engineid 'LEDE'
+	option engineidtype '3'
+	option engineidnic 'eth0'
+
+#config trapcommunity 'trapcommunity'
+#	option community 'public'
+
+#config trapsink
+#	option host 'nms.system.com'
+#	option community 'public'
+#	option port '162'
+
+#config trap2sink
+#	option host 'nms.system.com'
+#	option community 'secret'
+#	option port '162'
+
+#config informsink
+#	option host 'nms.sytem.com'
+#	option community 'public'
+#	option port '162'
+
+#config authtrapenable 'authtrapenable'
+#	option enable '1'
+
+#config v1trapaddress 'v1trapaddress'
+#	option host '1.2.3.4'
+
+#config trapsess 'trapsess'
+#	option trapsess	'-v 3 -e 0x80001f88808c18d3f7b0000 -u trapuser -a MD5 -A administrator -l authPriv -x DES -X rootpasswd udp:127.0.0.1:162'
+
+config snmpd general
+	option enabled '1'
+#	list network 'wan'

--- a/package/network/utils/net-snmp/files/snmpd.init
+++ b/package/network/utils/net-snmp/files/snmpd.init
@@ -1,0 +1,362 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2008 OpenWrt.org
+START=99
+
+USE_PROCD=1
+PROG="/usr/sbin/snmpd"
+
+CONFIGFILE="/var/run/snmpd.conf"
+
+snmpd_agent_add() {
+	local cfg="$1"
+
+	config_get agentaddress "$cfg" agentaddress
+	[ -n "$agentaddress" ] || return 0
+	echo "agentaddress $agentaddress" >> $CONFIGFILE
+}
+
+snmpd_agentx_add() {
+	local cfg="$1"
+	echo "master agentx" >> $CONFIGFILE
+	config_get agentxsocket "$cfg" agentxsocket
+	[ -n "$agentxsocket" ] && echo "agentXSocket $agentxsocket" >> $CONFIGFILE
+}
+
+snmpd_system_add() {
+	local cfg="$1"
+	local hostname
+
+	config_get syslocation "$cfg" sysLocation
+	[ -n "$syslocation" ] && echo "sysLocation $syslocation" >> $CONFIGFILE
+	config_get syscontact "$cfg" sysContact
+	[ -n "$syscontact" ] && echo "sysContact $syscontact" >> $CONFIGFILE
+	config_get sysname "$cfg" sysName
+	[ -n "$sysname" ] && echo "sysName $sysname" >> $CONFIGFILE
+	[ -z "$sysname" ] && hostname=$(uci_get system.@system[0].hostname) && echo "sysName $hostname" >> $CONFIGFILE
+	config_get sysservice "$cfg" sysService
+	[ -n "$sysservice" ] && echo "sysService $sysservice" >> $CONFIGFILE
+	config_get sysdescr "$cfg" sysDescr
+	[ -n "$sysdescr" ] && echo "sysDescr $sysdescr" >> $CONFIGFILE
+	config_get sysobjectid "$cfg" sysObjectID
+	[ -n "$sysobjectid" ] && echo "sysObjectID $sysobjectid" >> $CONFIGFILE
+}
+
+snmpd_com2sec_add() {
+	local cfg="$1"
+	config_get secname "$cfg" secname
+	[ -n "$secname" ] || return 0
+	config_get source "$cfg" source
+	[ -n "$source" ] || return 0
+	config_get community "$cfg" community
+	[ -n "$community" ] || return 0
+	echo "com2sec $secname $source $community" >> $CONFIGFILE
+}
+
+snmpd_com2sec6_add() {
+	local cfg="$1"
+	config_get secname "$cfg" secname
+	[ -n "$secname" ] || return 0
+	config_get source "$cfg" source
+	[ -n "$source" ] || return 0
+	config_get community "$cfg" community
+	[ -n "$community" ] || return 0
+	echo "com2sec6 $secname $source $community" >> $CONFIGFILE
+}
+
+snmpd_group_add() {
+	local cfg="$1"
+	config_get group "$cfg" group
+	[ -n "$group" ] || return 0
+	config_get version "$cfg" version
+	[ -n "$version" ] || return 0
+	config_get secname "$cfg" secname
+	[ -n "$secname" ] || return 0
+	echo "group $group $version $secname" >> $CONFIGFILE
+}
+
+snmpd_view_add() {
+	local cfg="$1"
+	config_get viewname "$cfg" viewname
+	[ -n "$viewname" ] || return 0
+	config_get type "$cfg" type
+	[ -n "$type" ] || return 0
+	config_get oid "$cfg" oid
+	[ -n "$oid" ] || return 0
+	# optional mask
+	config_get mask "$cfg" mask
+	echo "view $viewname $type $oid $mask" >> $CONFIGFILE
+}
+
+snmpd_access_add() {
+	local cfg="$1"
+	config_get group "$cfg" group
+	[ -n "$group" ] || return 0
+	config_get context "$cfg" context
+	[ -n $context ] || return 0
+	[ "$context" == "none" ] && context='""'
+	config_get version "$cfg" version
+	[ -n "$version" ] || return 0
+	config_get level "$cfg" level
+	[ -n "$level" ] || return 0
+	config_get prefix "$cfg" prefix
+	[ -n "$prefix" ] || return 0
+	config_get read "$cfg" read
+	[ -n "$read" ] || return 0
+	config_get write "$cfg" write
+	[ -n "$write" ] || return 0
+	config_get notify "$cfg" notify
+	[ -n "$notify" ] || return 0
+	echo "access $group $context $version $level $prefix $read $write $notify" >> $CONFIGFILE
+}
+
+snmpd_trap_hostname_add() {
+	local cfg="$1"
+	config_get hostname "$cfg" HostName
+	config_get port "$cfg" Port
+	config_get community "$cfg" Community
+	config_get type "$cfg" Type
+	echo "$type $hostname $community $port" >> $CONFIGFILE
+}
+
+snmpd_trap_ip_add() {
+	local cfg="$1"
+	config_get host_ip "$cfg" HostIP
+	config_get port "$cfg" Port
+	config_get community "$cfg" Community
+	config_get type "$cfg" Type
+	echo "$type $host_ip $community $port" >> $CONFIGFILE
+}
+
+snmpd_access_default_add() {
+	local cfg="$1"
+	config_get mode "$cfg" Mode
+	config_get community "$cfg" CommunityName
+	config_get oidrestrict "$cfg" RestrictOID
+	config_get oid "$cfg" RestrictedOID
+	echo -n "$mode $community default" >> $CONFIGFILE
+	[ "$oidrestrict" == "yes" ] && echo " $oid" >> $CONFIGFILE
+	[ "$oidrestrict" == "no" ] && echo "" >> $CONFIGFILE
+}
+
+snmpd_access_HostName_add() {
+	local cfg="$1"
+	config_get hostname "$cfg" HostName
+	config_get mode "$cfg" Mode
+	config_get community "$cfg" CommunityName
+	config_get oidrestrict "$cfg" RestrictOID
+	config_get oid "$cfg" RestrictedOID
+	echo -n "$mode $community $hostname" >> $CONFIGFILE
+	[ "$oidrestrict" == "yes" ] && echo " $oid" >> $CONFIGFILE
+	[ "$oidrestrict" == "no" ] && echo "" >> $CONFIGFILE
+}
+
+snmpd_access_HostIP_add() {
+	local cfg="$1"
+	config_get host_ip "$cfg" HostIP
+	config_get ip_mask "$cfg" IPMask
+	config_get mode "$cfg" Mode
+	config_get community "$cfg" CommunityName
+	config_get oidrestrict "$cfg" RestrictOID
+	config_get oid "$cfg" RestrictedOID
+	echo -n "$mode $community $host_ip/$ip_mask" >> $CONFIGFILE
+	[ "$oidrestrict" == "yes" ] && echo " $oid" >> $CONFIGFILE
+	[ "$oidrestrict" == "no" ] && echo "" >> $CONFIGFILE
+}
+
+snmpd_pass_add() {
+	local cfg="$1"
+	local pass='pass'
+
+	config_get miboid "$cfg" miboid
+	[ -n "$miboid" ] || return 0
+	config_get prog "$cfg" prog
+	[ -n "$prog" ] || return 0
+	config_get_bool persist "$cfg" persist 0
+	[ $persist -ne 0 ] && pass='pass_persist'
+	config_get priority "$cfg" priority
+	priority=${priority:+-p $priority}
+	echo "$pass $priority $miboid $prog" >> $CONFIGFILE
+}
+
+snmpd_exec_add() {
+	local cfg="$1"
+
+	config_get name "$cfg" name
+	[ -n "$name" ] || return 0
+	config_get prog "$cfg" prog
+	[ -n "$prog" ] || return 0
+	config_get args "$cfg" args
+	config_get miboid "$cfg" miboid
+	echo "exec $miboid $name $prog $args" >> $CONFIGFILE
+}
+
+snmpd_extend_add() {
+	local cfg="$1"
+
+	config_get name "$cfg" name
+	[ -n "$name" ] || return 0
+	config_get prog "$cfg" prog
+	[ -n "$prog" ] || return 0
+	config_get args "$cfg" args
+	config_get miboid "$cfg" miboid
+	echo "extend $miboid $name $prog $args" >> $CONFIGFILE
+}
+
+snmpd_disk_add() {
+	local cfg="$1"
+	local disk='disk'
+
+	config_get partition "$cfg" partition
+	[ -n "$partition" ] || return 0
+	config_get size "$cfg" size
+	[ -n "$size" ] || return 0
+	echo "$disk $partition $size" >> $CONFIGFILE
+}
+
+snmpd_engineid_add() {
+	local cfg="$1"
+
+	config_get engineid "$cfg" engineid
+	[ -n "$engineid" ] && echo "engineID $engineid" >> $CONFIGFILE
+	config_get engineidtype "$cfg" engineidtype
+	[ "$engineidtype" -ge 1 -a "$engineidtype" -le 3 ] && \
+		echo "engineIDType $engineidtype" >> $CONFIGFILE
+	config_get engineidnic "$cfg" engineidnic
+	[ -n "$engineidnic" ] && echo "engineIDNic $engineidnic" >> $CONFIGFILE
+}
+
+snmpd_sink_add() {
+	local cfg="$1"
+	local section="$2"
+	local community
+	local port
+	local host
+
+	config_get host "$cfg" host
+	[ -n "section" -a -n "$host" ] || return 0
+	# optional community
+	config_get community "$cfg" community
+	# optional port
+	config_get port "$cfg" port
+	port=${port:+:$port}
+	echo "$section $host$port $community" >> $CONFIGFILE
+}
+
+append_parm() {
+	local section="$1"
+	local option="$2"
+	local switch="$3"
+	local _loctmp
+	config_get _loctmp "$section" "$option"
+	[ -z "$_loctmp" ] && return 0
+	echo "$switch $_loctmp" >> $CONFIGFILE
+}
+
+append_authtrapenable() {
+	local section="$1"
+	local option="$2"
+	local switch="$3"
+	local _loctmp
+	config_get_bool _loctmp "$section" "$option"
+	[ -z "$_loctmp" ] && return 0
+	[ "$_loctmp" -gt 0 ] && echo "$switch $_loctmp" >> $CONFIGFILE
+}
+
+snmpd_setup_fw_rules() {
+	local net="$1"
+	local zone
+
+	zone=$(fw3 -q network "$net" 2>/dev/null)
+
+	local handled_zone
+	for handled_zone in $HANDLED_SNMP_ZONES; do
+		[ "$handled_zone" = "$zone" ] && return
+	done
+
+	json_add_object ""
+	json_add_string type rule
+	json_add_string src "$zone"
+	json_add_string proto udp
+	json_add_string dest_port 161
+	json_add_string target ACCEPT
+	json_close_object
+
+	HANDLED_SNMP_ZONES="$HANDLED_SNMP_ZONES $zone"
+}
+
+start_service() {
+	[ -f "$CONFIGFILE" ] && rm -f "$CONFIGFILE"
+
+	config_load snmpd
+
+	config_get_bool snmp_enabled general enabled 1
+	[ "$snmp_enabled" -eq 0 ] && return
+
+	procd_open_instance
+
+	config_foreach snmpd_agent_add agent
+	config_foreach snmpd_agentx_add agentx
+	config_foreach snmpd_system_add system
+	config_foreach snmpd_com2sec_add com2sec
+	config_foreach snmpd_com2sec6_add com2sec6
+	config_foreach snmpd_group_add group
+	config_foreach snmpd_view_add view
+	config_foreach snmpd_access_add access
+	config_foreach snmpd_trap_hostname_add trap_HostName
+	config_foreach snmpd_trap_ip_add trap_HostIP
+	config_foreach snmpd_access_default_add access_default
+	config_foreach snmpd_access_HostName_add access_HostName
+	config_foreach snmpd_access_HostIP_add access_HostIP
+	config_foreach snmpd_pass_add pass
+	config_foreach snmpd_exec_add exec
+	config_foreach snmpd_extend_add extend
+	config_foreach snmpd_disk_add disk
+	config_foreach snmpd_engineid_add engineid
+	append_parm trapcommunity community trapcommunity
+	config_foreach snmpd_sink_add trapsink trapsink
+	config_foreach snmpd_sink_add trap2sink trap2sink
+	config_foreach snmpd_sink_add informsink informsink
+	append_authtrapenable authtrapenable enable authtrapenable
+	append_parm v1trapaddress host v1trapaddress
+	append_parm trapsess trapsess trapsess
+
+	procd_set_param command $PROG -Lf /dev/null -f -r
+	procd_set_param file $CONFIGFILE
+	procd_set_param respawn
+
+	for iface in $(ls /sys/class/net 2>/dev/null); do
+		procd_append_param netdev "$iface"
+	done
+
+	procd_open_data
+
+	json_add_array firewall
+	config_list_foreach general network snmpd_setup_fw_rules
+	json_close_array
+
+	procd_close_data
+
+	procd_close_instance
+}
+
+service_stopped() {
+	[ -f "$CONFIGFILE" ] || return
+	rm -f "$CONFIGFILE"
+	procd_set_config_changed firewall
+}
+
+service_triggers(){
+	local script=$(readlink "$initscript")
+	local name=$(basename ${script:-$initscript})
+
+	procd_open_trigger
+	procd_add_raw_trigger "interface.*" 2000 /etc/init.d/$name reload
+	procd_close_trigger
+
+	procd_add_reload_trigger 'snmpd'
+}
+
+service_started() {
+	[ "$snmp_enabled" -eq 0 ] && return
+	procd_set_config_changed firewall
+}

--- a/package/network/utils/net-snmp/files/snmptrapd.init
+++ b/package/network/utils/net-snmp/files/snmptrapd.init
@@ -1,0 +1,15 @@
+#!/bin/sh /etc/rc.common
+
+START=50
+
+USE_PROCD=1
+PROG="/usr/sbin/snmptrapd"
+
+start_service() {
+	procd_open_instance
+
+	procd_set_param command $PROG -Lf /dev/null -f
+	procd_set_param respawn
+
+	procd_close_instance
+}

--- a/package/network/utils/net-snmp/patches/000-cross-compile.patch
+++ b/package/network/utils/net-snmp/patches/000-cross-compile.patch
@@ -1,0 +1,47 @@
+From: Jo-Philipp Wich <jo@mein.io>
+Date: Fri, 6 Jan 2017 13:41:00 +0100
+Subject: [PATCH] configure: allow overriding hardcoded /usr/include/libnl3
+
+In a cross-compile setting we do not want to probe the host systems
+/usr/include path, therfore allow to disable this include path by passing
+ac_cv_header_netlink_netlink_h=yes to configure.
+
+Also disable the testing for libraries providing nl_connect when
+netsnmp_cv_func_nl_connect_LIBS is predefined since the proprietary
+NETSNMP_SEARCH_LIBS() macro will clobber the internal link flags upon
+encountering predefined cache variables, causing all subsequent configure
+link tests to fail due to a stray "no" word getting passed to the linker.
+
+Signed-off-by: Jo-Philipp Wich <jo@mein.io>
+--- a/configure.d/config_os_libs2
++++ b/configure.d/config_os_libs2
+@@ -252,14 +252,22 @@ if test "x$with_nl" != "xno"; then
+     case $target_os in
+     linux*) # Check for libnl (linux)
+         netsnmp_save_CPPFLAGS="$CPPFLAGS"
+-        CPPFLAGS="${LIBNL3_CFLAGS} ${LIBNLROUTE3_CFLAGS} $CPPFLAGS"
+-        NETSNMP_SEARCH_LIBS(nl_connect, nl-3,
+-            [AC_CHECK_HEADERS(netlink/netlink.h)
+-            EXTERNAL_MIBGROUP_INCLUDES="$EXTERNAL_MIBGROUP_INCLUDES ${LIBNL3_CFLAGS}"],
+-            [CPPFLAGS="$netsnmp_save_CPPFLAGS"], [], [LMIBLIBS])
++        netsnmp_netlink_include_flags=""
+         if test "x$ac_cv_header_netlink_netlink_h" != xyes; then
+-            NETSNMP_SEARCH_LIBS(nl_connect, nl, [
+-                AC_CHECK_HEADERS(netlink/netlink.h)], [], [], LMIBLIBS)
++            netsnmp_netlink_include_flags="-I/usr/include/libnl3"
++        fi
++        CPPFLAGS="$netsnmp_netlink_include_flags $CPPFLAGS"
++        if test "x$netsnmp_cv_func_nl_connect_LIBS" = x; then
++            NETSNMP_SEARCH_LIBS(nl_connect, nl-3,
++                [AC_CHECK_HEADERS(netlink/netlink.h)
++                EXTERNAL_MIBGROUP_INCLUDES="$EXTERNAL_MIBGROUP_INCLUDES $netsnmp_netlink_include_flags"],
++                [CPPFLAGS="$netsnmp_save_CPPFLAGS"], [], [], [LMIBLIBS])
++            if test "x$ac_cv_header_netlink_netlink_h" != xyes; then
++                NETSNMP_SEARCH_LIBS(nl_connect, nl, [
++                    AC_CHECK_HEADERS(netlink/netlink.h)], [], [], LMIBLIBS)
++            fi
++        else
++            LMIBLIBS="$LMIBLIBS $netsnmp_cv_func_nl_connect_LIBS"
+         fi
+         if test "x$ac_cv_header_netlink_netlink_h" = xyes; then
+             AC_EGREP_HEADER([nl_socket_free], [netlink/socket.h],

--- a/package/network/utils/net-snmp/patches/010-HOST-MIB-hr_filesys-fix-compile-error.patch
+++ b/package/network/utils/net-snmp/patches/010-HOST-MIB-hr_filesys-fix-compile-error.patch
@@ -1,0 +1,34 @@
+From 9588b5c9c27239b1f8c02f0bf417f13735e93225 Mon Sep 17 00:00:00 2001
+From: Stijn Tintel <stijn@linux-ipv6.be>
+Date: Sat, 26 Sep 2020 04:34:18 +0300
+Subject: [PATCH] HOST-MIB, hr_filesys: fix compile error
+
+On non-AIX systems without getfsstat, a variable is being declared right
+after a label. This is a violation of the C language standard, and
+causes the following compile error:
+
+host/hr_filesys.c: In function 'Get_Next_HR_FileSys':
+host/hr_filesys.c:752:5: error: a label can only be part of a statement and a declaration is not a statement
+     const char    **cpp;
+          ^~~~~
+
+Fix the problem by adding an empty statement after the label.
+
+Fixes: 22e1371bb1fd ("HOST-MIB, hr_filesys: Convert recursion into iteration")
+
+Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>
+---
+ agent/mibgroup/host/hr_filesys.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/agent/mibgroup/host/hr_filesys.c
++++ b/agent/mibgroup/host/hr_filesys.c
+@@ -718,7 +718,7 @@ static const char *HRFS_ignores[] = {
+ int
+ Get_Next_HR_FileSys(void)
+ {
+-next:
++next: ;
+ #ifdef HAVE_GETFSSTAT
+     if (HRFS_index >= fscount)
+         return -1;

--- a/package/network/utils/net-snmp/patches/100-debian-statistics.patch
+++ b/package/network/utils/net-snmp/patches/100-debian-statistics.patch
@@ -1,0 +1,13 @@
+--- a/agent/mibgroup/mibII/interfaces.c
++++ b/agent/mibgroup/mibII/interfaces.c
+@@ -1586,6 +1586,10 @@ Interface_Scan_Init(void)
+         char           *stats, *ifstart = line;
+         size_t          len;
+ 
++	/* Ignore interfaces with no statistics. */
++	if (strstr(line, "No statistics available."))
++	continue;
++
+         len = strlen(line);
+         if (len && line[len - 1] == '\n')
+             line[len - 1] = '\0';

--- a/package/network/utils/net-snmp/patches/110-debian-makefiles.patch
+++ b/package/network/utils/net-snmp/patches/110-debian-makefiles.patch
@@ -1,0 +1,40 @@
+--- a/local/Makefile.in
++++ b/local/Makefile.in
+@@ -101,7 +101,7 @@ tkmib.made: $(srcdir)/tkmib
+ 
+ mib2c.made: $(srcdir)/mib2c
+ 	if test "x$(PERL)" != "x" ; then \
+-	  $(PERL) -p -e 's%^#!.*/perl.*%#!$(PERL)%;s#/usr/local/share/snmp#$(snmplibdir)#;' ${srcdir}/mib2c > mib2c.made; \
++	  $(PERL) -p -e 's%^#!.*/perl.*%#!$(PERL)%;s#/usr/local/share/snmp#$(snmplibdir)#;s#/usr/local/etc/snmp#$(SNMPCONFPATH)#;' ${srcdir}/mib2c > mib2c.made; \
+ 	else \
+ 	  touch mib2c.made; \
+         fi
+--- a/Makefile.top
++++ b/Makefile.top
+@@ -28,6 +28,7 @@ man8dir		= $(mandir)/man8
+ snmplibdir	= $(datadir)/snmp
+ mibdir		= $(snmplibdir)/mibs
+ persistentdir	= @PERSISTENT_DIRECTORY@
++sysconfdir	= @sysconfdir@
+ DESTDIR         = @INSTALL_PREFIX@
+ INSTALL_PREFIX  = $(DESTDIR)
+ 
+--- a/mibs/Makefile.in
++++ b/mibs/Makefile.in
+@@ -47,11 +47,15 @@ NETSNMPMIBS = NET-SNMP-TC.txt NET-SNMP-M
+ UCDMIBS = UCD-SNMP-MIB.txt UCD-DEMO-MIB.txt UCD-IPFWACC-MIB.txt \
+ 	UCD-DLMOD-MIB.txt UCD-DISKIO-MIB.txt
+ 
++EXTRAMIBS = BGP4-MIB.txt BRIDGE-MIB.txt GNOME-SMI.txt OSPF-MIB.txt \
++	OSPF-TRAP-MIB.txt RIPv2-MIB.txt SOURCE-ROUTING-MIB.txt \
++	LM-SENSORS-MIB.txt
++
+ DEFAULTMIBS = @default_mibs_install@
+ 
+ MIBS	= $(V1MIBS) $(V2MIBS) $(V3MIBS) $(RFCMIBS) \
+ 	$(AGENTMIBS) $(IANAMIBS) \
+-	$(NETSNMPMIBS) $(UCDMIBS) $(DEFAULTMIBS)
++	$(NETSNMPMIBS) $(UCDMIBS) $(DEFAULTMIBS) $(EXTRAMIBS)
+ 
+ all: standardall
+ 

--- a/package/network/utils/net-snmp/patches/120-debian-searchdirs.patch
+++ b/package/network/utils/net-snmp/patches/120-debian-searchdirs.patch
@@ -1,0 +1,14 @@
+--- a/local/mib2c
++++ b/local/mib2c
+@@ -61,8 +61,9 @@ $currentlevel = -1;
+ if($ENV{MIB2C_DIR}) {
+    push @def_search_dirs, split(/:/, $ENV{MIB2C_DIR});
+ }
+-push @def_search_dirs, "/usr/local/share/snmp/";
+-push @def_search_dirs, "/usr/local/share/snmp/mib2c-data";
++push @def_search_dirs, "/etc/snmp/";
++push @def_search_dirs, "/usr/share/snmp/";
++push @def_search_dirs, "/usr/share/snmp/mib2c-data";
+ push @def_search_dirs, "./mib2c-conf.d";
+ 
+ sub usage {

--- a/package/network/utils/net-snmp/patches/130-debian-extramibs.patch
+++ b/package/network/utils/net-snmp/patches/130-debian-extramibs.patch
@@ -1,0 +1,5183 @@
+--- /dev/null
++++ b/mibs/BGP4-MIB.txt
+@@ -0,0 +1,929 @@
++    BGP4-MIB DEFINITIONS ::= BEGIN
++
++        IMPORTS
++            MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
++            IpAddress, Integer32, Counter32, Gauge32, mib-2
++                FROM SNMPv2-SMI
++            MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
++                FROM SNMPv2-CONF;
++
++        bgp MODULE-IDENTITY
++            LAST-UPDATED "9902100000Z"
++            ORGANIZATION "IETF IDR Working Group"
++            CONTACT-INFO "E-mail:  idr@merit.net
++
++                          Susan Hares  (Editor)
++                          Merit Network
++                          4251 Plymouth Road
++                          Suite C
++                          Ann Arbor, MI 48105-2785
++                          Tel: +1 734 936 2095
++                          Fax: +1 734 647 3185
++                          E-mail: skh@merit.edu
++
++                          Jeff Johnson (Editor)
++                          RedBack Networks, Inc.
++                          1389 Moffett Park Drive
++                          Sunnyvale, CA  94089-1134
++                          Tel: +1 408 548 3516
++                          Fax: +1 408 548 3599
++                          E-mail: jeff@redback.com"
++            DESCRIPTION
++                    "The MIB module for BGP-4."
++            REVISION    "9902100000Z"
++            DESCRIPTION
++                    "Corrected duplicate OBJECT IDENTIFIER
++                     assignment in the conformance information."
++            REVISION    "9601080000Z"
++            DESCRIPTION
++                    "1) Fixed the definitions of the traps to
++                     make them equivalent to their initial
++                     definition in RFC 1269.
++                     2) Added compliance and conformance info."
++            ::= { mib-2 15 }
++
++        bgpVersion OBJECT-TYPE
++            SYNTAX     OCTET STRING (SIZE (1..255))
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "Vector of supported BGP protocol version
++                    numbers.  Each peer negotiates the version
++                    from this vector.  Versions are identified
++                    via the string of bits contained within this
++                    object.  The first octet contains bits 0 to
++                    7, the second octet contains bits 8 to 15,
++                    and so on, with the most significant bit
++                    referring to the lowest bit number in the
++                    octet (e.g., the MSB of the first octet
++                    refers to bit 0).  If a bit, i, is present
++                    and set, then the version (i+1) of the BGP
++                    is supported."
++            ::= { bgp 1 }
++
++        bgpLocalAs OBJECT-TYPE
++            SYNTAX     INTEGER (0..65535)
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The local autonomous system number."
++            ::= { bgp 2 }
++
++
++
++        -- BGP Peer table.  This table contains, one entry per BGP
++        -- peer, information about the BGP peer.
++
++        bgpPeerTable OBJECT-TYPE
++            SYNTAX     SEQUENCE OF BgpPeerEntry
++            MAX-ACCESS not-accessible
++            STATUS     current
++            DESCRIPTION
++                    "BGP peer table.  This table contains,
++                    one entry per BGP peer, information about the
++                    connections with BGP peers."
++            ::= { bgp 3 }
++
++        bgpPeerEntry OBJECT-TYPE
++            SYNTAX     BgpPeerEntry
++            MAX-ACCESS not-accessible
++            STATUS     current
++            DESCRIPTION
++                    "Entry containing information about the
++                    connection with a BGP peer."
++            INDEX { bgpPeerRemoteAddr }
++            ::= { bgpPeerTable 1 }
++
++        BgpPeerEntry ::= SEQUENCE {
++                bgpPeerIdentifier
++                    IpAddress,
++                bgpPeerState
++                    INTEGER,
++                bgpPeerAdminStatus
++                    INTEGER,
++                bgpPeerNegotiatedVersion
++                    Integer32,
++                bgpPeerLocalAddr
++                    IpAddress,
++                bgpPeerLocalPort
++                    INTEGER,
++                bgpPeerRemoteAddr
++                    IpAddress,
++                bgpPeerRemotePort
++                    INTEGER,
++                bgpPeerRemoteAs
++                    INTEGER,
++                bgpPeerInUpdates
++                    Counter32,
++                bgpPeerOutUpdates
++                    Counter32,
++                bgpPeerInTotalMessages
++                    Counter32,
++                bgpPeerOutTotalMessages
++                    Counter32,
++                bgpPeerLastError
++                    OCTET STRING,
++                bgpPeerFsmEstablishedTransitions
++                    Counter32,
++                bgpPeerFsmEstablishedTime
++                    Gauge32,
++                bgpPeerConnectRetryInterval
++                    INTEGER,
++                bgpPeerHoldTime
++                    INTEGER,
++                bgpPeerKeepAlive
++                    INTEGER,
++                bgpPeerHoldTimeConfigured
++                    INTEGER,
++                bgpPeerKeepAliveConfigured
++                    INTEGER,
++                bgpPeerMinASOriginationInterval
++                    INTEGER,
++                bgpPeerMinRouteAdvertisementInterval
++                    INTEGER,
++                bgpPeerInUpdateElapsedTime
++                    Gauge32
++                }
++
++        bgpPeerIdentifier OBJECT-TYPE
++            SYNTAX     IpAddress
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The BGP Identifier of this entry's BGP peer."
++            ::= { bgpPeerEntry 1 }
++
++        bgpPeerState OBJECT-TYPE
++            SYNTAX     INTEGER {
++                                idle(1),
++                                connect(2),
++                                active(3),
++                                opensent(4),
++                                openconfirm(5),
++                                established(6)
++                       }
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The BGP peer connection state."
++            ::= { bgpPeerEntry 2 }
++
++        bgpPeerAdminStatus OBJECT-TYPE
++            SYNTAX     INTEGER {
++                                stop(1),
++                                start(2)
++                       }
++            MAX-ACCESS read-write
++            STATUS     current
++            DESCRIPTION
++                    "The desired state of the BGP connection.  A
++                    transition from 'stop' to 'start' will cause
++                    the BGP Start Event to be generated.  A
++                    transition from 'start' to 'stop' will cause
++                    the BGP Stop Event to be generated.  This
++                    parameter can be used to restart BGP peer
++                    connections.  Care should be used in providing
++                    write access to this object without adequate
++                    authentication."
++            ::= { bgpPeerEntry 3 }
++
++        bgpPeerNegotiatedVersion OBJECT-TYPE
++            SYNTAX     Integer32
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The negotiated version of BGP running between
++                    the two peers."
++            ::= { bgpPeerEntry 4 }
++
++        bgpPeerLocalAddr OBJECT-TYPE
++            SYNTAX     IpAddress
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The local IP address of this entry's BGP
++                    connection."
++            ::= { bgpPeerEntry 5 }
++
++        bgpPeerLocalPort OBJECT-TYPE
++            SYNTAX     INTEGER (0..65535)
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The local port for the TCP connection between
++                    the BGP peers."
++            ::= { bgpPeerEntry 6 }
++
++        bgpPeerRemoteAddr OBJECT-TYPE
++            SYNTAX     IpAddress
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The remote IP address of this entry's BGP
++                    peer."
++            ::= { bgpPeerEntry 7 }
++
++        bgpPeerRemotePort OBJECT-TYPE
++            SYNTAX     INTEGER (0..65535)
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The remote port for the TCP connection between
++                    the BGP peers.  Note that the objects
++                    bgpPeerLocalAddr, bgpPeerLocalPort,
++                    bgpPeerRemoteAddr and bgpPeerRemotePort
++                    provide the appropriate reference to the
++                    standard MIB TCP connection table."
++            ::= { bgpPeerEntry 8 }
++
++        bgpPeerRemoteAs OBJECT-TYPE
++            SYNTAX     INTEGER (0..65535)
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The remote autonomous system number."
++            ::= { bgpPeerEntry 9 }
++
++        bgpPeerInUpdates OBJECT-TYPE
++            SYNTAX     Counter32
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The number of BGP UPDATE messages received on
++                    this connection.  This object should be
++                    initialized to zero (0) when the connection is
++                    established."
++            ::= { bgpPeerEntry 10 }
++
++        bgpPeerOutUpdates OBJECT-TYPE
++            SYNTAX     Counter32
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The number of BGP UPDATE messages transmitted
++                    on this connection.  This object should be
++                    initialized to zero (0) when the connection is
++                    established."
++            ::= { bgpPeerEntry 11 }
++
++        bgpPeerInTotalMessages OBJECT-TYPE
++            SYNTAX     Counter32
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The total number of messages received from the
++                    remote peer on this connection.  This object
++                    should be initialized to zero when the
++                    connection is established."
++            ::= { bgpPeerEntry 12 }
++
++        bgpPeerOutTotalMessages OBJECT-TYPE
++            SYNTAX     Counter32
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The total number of messages transmitted to
++                    the remote peer on this connection.  This object
++                    should be initialized to zero when the
++                    connection is established."
++            ::= { bgpPeerEntry 13 }
++
++        bgpPeerLastError OBJECT-TYPE
++            SYNTAX     OCTET STRING (SIZE (2))
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The last error code and subcode seen by this
++                    peer on this connection.  If no error has
++                    occurred, this field is zero.  Otherwise, the
++                    first byte of this two byte OCTET STRING
++                    contains the error code, and the second byte
++                    contains the subcode."
++            ::= { bgpPeerEntry 14 }
++
++        bgpPeerFsmEstablishedTransitions OBJECT-TYPE
++            SYNTAX     Counter32
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The total number of times the BGP FSM
++                    transitioned into the established state."
++            ::= { bgpPeerEntry 15 }
++
++        bgpPeerFsmEstablishedTime OBJECT-TYPE
++            SYNTAX     Gauge32
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "This timer indicates how long (in seconds) this
++                    peer has been in the Established state or how long
++                    since this peer was last in the Established state.
++                    It is set to zero when a new peer is configured or
++                    the router is booted."
++            ::= { bgpPeerEntry 16 }
++
++        bgpPeerConnectRetryInterval OBJECT-TYPE
++            SYNTAX     INTEGER (1..65535)
++            MAX-ACCESS read-write
++            STATUS     current
++            DESCRIPTION
++                    "Time interval in seconds for the ConnectRetry
++                    timer.  The suggested value for this timer is
++                    120 seconds."
++            ::= { bgpPeerEntry 17 }
++
++        bgpPeerHoldTime OBJECT-TYPE
++            SYNTAX     INTEGER  ( 0 | 3..65535 )
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "Time interval in seconds for the Hold Timer
++                    established with the peer.  The value of this
++                    object is calculated by this BGP speaker by
++                    using the smaller of the value in
++                    bgpPeerHoldTimeConfigured and the Hold Time
++                    received in the OPEN message.  This value
++                    must be at lease three seconds if it is not
++                    zero (0) in which case the Hold Timer has
++                    not been established with the peer, or, the
++                    value of bgpPeerHoldTimeConfigured is zero (0)."
++            ::= { bgpPeerEntry 18 }
++
++        bgpPeerKeepAlive OBJECT-TYPE
++            SYNTAX     INTEGER ( 0 | 1..21845 )
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "Time interval in seconds for the KeepAlive
++                    timer established with the peer.  The value of
++                    this object is calculated by this BGP speaker
++                    such that, when compared with bgpPeerHoldTime,
++                    it has the same proportion as what
++                    bgpPeerKeepAliveConfigured has when compared
++                    with bgpPeerHoldTimeConfigured.  If the value
++                    of this object is zero (0), it indicates that
++                    the KeepAlive timer has not been established
++                    with the peer, or, the value of
++                    bgpPeerKeepAliveConfigured is zero (0)."
++            ::= { bgpPeerEntry 19 }
++
++        bgpPeerHoldTimeConfigured OBJECT-TYPE
++            SYNTAX     INTEGER ( 0 | 3..65535 )
++            MAX-ACCESS read-write
++            STATUS     current
++            DESCRIPTION
++                    "Time interval in seconds for the Hold Time
++                    configured for this BGP speaker with this peer.
++                    This value is placed in an OPEN message sent to
++                    this peer by this BGP speaker, and is compared
++                    with the Hold Time field in an OPEN message
++                    received from the peer when determining the Hold
++                    Time (bgpPeerHoldTime) with the peer.  This value
++                    must not be less than three seconds if it is not
++                    zero (0) in which case the Hold Time is NOT to be
++                    established with the peer.  The suggested value for
++                    this timer is 90 seconds."
++            ::= { bgpPeerEntry 20 }
++
++        bgpPeerKeepAliveConfigured OBJECT-TYPE
++            SYNTAX     INTEGER ( 0 | 1..21845 )
++            MAX-ACCESS read-write
++            STATUS     current
++            DESCRIPTION
++                    "Time interval in seconds for the KeepAlive timer
++                    configured for this BGP speaker with this peer.
++                    The value of this object will only determine the
++                    KEEPALIVE messages' frequency relative to the value
++                    specified in bgpPeerHoldTimeConfigured; the actual
++                    time interval for the KEEPALIVE messages is
++                    indicated by bgpPeerKeepAlive.  A reasonable
++                    maximum value for this timer would be configured to
++                    be one third of that of bgpPeerHoldTimeConfigured.
++                    If the value of this object is zero (0), no
++                    periodical KEEPALIVE messages are sent to the peer
++                    after the BGP connection has been established.  The
++                    suggested value for this timer is 30 seconds."
++            ::= { bgpPeerEntry 21 }
++
++        bgpPeerMinASOriginationInterval OBJECT-TYPE
++            SYNTAX     INTEGER (1..65535)
++            MAX-ACCESS read-write
++            STATUS     current
++            DESCRIPTION
++                    "Time interval in seconds for the
++                    MinASOriginationInterval timer.
++                    The suggested value for this timer is 15 seconds."
++            ::= { bgpPeerEntry 22 }
++
++        bgpPeerMinRouteAdvertisementInterval OBJECT-TYPE
++            SYNTAX     INTEGER (1..65535)
++            MAX-ACCESS read-write
++            STATUS     current
++            DESCRIPTION
++                    "Time interval in seconds for the
++                    MinRouteAdvertisementInterval timer.
++                    The suggested value for this timer is 30 seconds."
++            ::= { bgpPeerEntry 23 }
++
++        bgpPeerInUpdateElapsedTime OBJECT-TYPE
++            SYNTAX     Gauge32
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "Elapsed time in seconds since the last BGP
++                    UPDATE message was received from the peer.
++                    Each time bgpPeerInUpdates is incremented,
++                    the value of this object is set to zero (0)."
++            ::= { bgpPeerEntry 24 }
++
++
++
++        bgpIdentifier OBJECT-TYPE
++            SYNTAX     IpAddress
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The BGP Identifier of local system."
++            ::= { bgp 4 }
++
++
++
++        -- Received Path Attribute Table.  This table contains,
++        -- one entry per path to a network, path attributes
++        -- received from all peers running BGP version 3 or less.
++        -- This table is obsolete, having been replaced in
++        -- functionality with the bgp4PathAttrTable.
++
++        bgpRcvdPathAttrTable OBJECT-TYPE
++            SYNTAX     SEQUENCE OF BgpPathAttrEntry
++            MAX-ACCESS not-accessible
++            STATUS     obsolete
++            DESCRIPTION
++                    "The BGP Received Path Attribute Table contains
++                    information about paths to destination networks
++                    received from all peers running BGP version 3 or
++                    less."
++            ::= { bgp 5 }
++
++        bgpPathAttrEntry OBJECT-TYPE
++            SYNTAX     BgpPathAttrEntry
++            MAX-ACCESS not-accessible
++            STATUS     obsolete
++            DESCRIPTION
++                    "Information about a path to a network."
++            INDEX { bgpPathAttrDestNetwork,
++                    bgpPathAttrPeer        }
++            ::= { bgpRcvdPathAttrTable 1 }
++
++        BgpPathAttrEntry ::= SEQUENCE {
++            bgpPathAttrPeer
++                 IpAddress,
++            bgpPathAttrDestNetwork
++                 IpAddress,
++            bgpPathAttrOrigin
++                 INTEGER,
++            bgpPathAttrASPath
++                 OCTET STRING,
++            bgpPathAttrNextHop
++                 IpAddress,
++            bgpPathAttrInterASMetric
++                 Integer32
++        }
++
++        bgpPathAttrPeer OBJECT-TYPE
++            SYNTAX     IpAddress
++            MAX-ACCESS read-only
++            STATUS     obsolete
++            DESCRIPTION
++                    "The IP address of the peer where the path
++                    information was learned."
++            ::= { bgpPathAttrEntry 1 }
++
++        bgpPathAttrDestNetwork OBJECT-TYPE
++            SYNTAX     IpAddress
++            MAX-ACCESS read-only
++            STATUS     obsolete
++            DESCRIPTION
++                    "The address of the destination network."
++            ::= { bgpPathAttrEntry 2 }
++
++        bgpPathAttrOrigin OBJECT-TYPE
++            SYNTAX     INTEGER {
++                           igp(1),-- networks are interior
++                           egp(2),-- networks learned via EGP
++                           incomplete(3) -- undetermined
++                       }
++            MAX-ACCESS read-only
++            STATUS     obsolete
++            DESCRIPTION
++                 "The ultimate origin of the path information."
++            ::= { bgpPathAttrEntry 3 }
++
++        bgpPathAttrASPath OBJECT-TYPE
++            SYNTAX     OCTET STRING (SIZE (2..255))
++            MAX-ACCESS read-only
++            STATUS     obsolete
++            DESCRIPTION
++                    "The set of ASs that must be traversed to reach
++                    the network.  This object is probably best
++                    represented as SEQUENCE OF INTEGER.  For SMI
++                    compatibility, though, it is represented as
++                    OCTET STRING.  Each AS is represented as a pair
++                    of octets according to the following algorithm:
++
++                        first-byte-of-pair = ASNumber / 256;
++                        second-byte-of-pair = ASNumber & 255;"
++            ::= { bgpPathAttrEntry 4 }
++
++        bgpPathAttrNextHop OBJECT-TYPE
++            SYNTAX     IpAddress
++            MAX-ACCESS read-only
++            STATUS     obsolete
++            DESCRIPTION
++                    "The address of the border router that should
++                    be used for the destination network."
++            ::= { bgpPathAttrEntry 5 }
++
++        bgpPathAttrInterASMetric OBJECT-TYPE
++            SYNTAX     Integer32
++            MAX-ACCESS read-only
++            STATUS     obsolete
++            DESCRIPTION
++                    "The optional inter-AS metric.  If this
++                    attribute has not been provided for this route,
++                    the value for this object is 0."
++            ::= { bgpPathAttrEntry 6 }
++
++
++
++        -- BGP-4 Received Path Attribute Table.  This table contains,
++        -- one entry per path to a network, path attributes
++        -- received from all peers running BGP-4.
++
++        bgp4PathAttrTable OBJECT-TYPE
++            SYNTAX     SEQUENCE OF Bgp4PathAttrEntry
++            MAX-ACCESS not-accessible
++            STATUS     current
++            DESCRIPTION
++                    "The BGP-4 Received Path Attribute Table contains
++                    information about paths to destination networks
++                    received from all BGP4 peers."
++            ::= { bgp 6 }
++
++        bgp4PathAttrEntry OBJECT-TYPE
++            SYNTAX     Bgp4PathAttrEntry
++            MAX-ACCESS not-accessible
++            STATUS     current
++            DESCRIPTION
++                    "Information about a path to a network."
++            INDEX { bgp4PathAttrIpAddrPrefix,
++                    bgp4PathAttrIpAddrPrefixLen,
++                    bgp4PathAttrPeer            }
++            ::= { bgp4PathAttrTable 1 }
++
++        Bgp4PathAttrEntry ::= SEQUENCE {
++            bgp4PathAttrPeer
++                 IpAddress,
++            bgp4PathAttrIpAddrPrefixLen
++                 INTEGER,
++            bgp4PathAttrIpAddrPrefix
++                 IpAddress,
++            bgp4PathAttrOrigin
++                 INTEGER,
++            bgp4PathAttrASPathSegment
++                 OCTET STRING,
++            bgp4PathAttrNextHop
++                 IpAddress,
++            bgp4PathAttrMultiExitDisc
++                 INTEGER,
++            bgp4PathAttrLocalPref
++                 INTEGER,
++            bgp4PathAttrAtomicAggregate
++                 INTEGER,
++            bgp4PathAttrAggregatorAS
++                 INTEGER,
++            bgp4PathAttrAggregatorAddr
++                 IpAddress,
++            bgp4PathAttrCalcLocalPref
++                 INTEGER,
++            bgp4PathAttrBest
++                 INTEGER,
++            bgp4PathAttrUnknown
++                 OCTET STRING
++        }
++
++        bgp4PathAttrPeer OBJECT-TYPE
++            SYNTAX     IpAddress
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The IP address of the peer where the path
++                    information was learned."
++            ::= { bgp4PathAttrEntry 1 }
++        bgp4PathAttrIpAddrPrefixLen OBJECT-TYPE
++            SYNTAX     INTEGER (0..32)
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "Length in bits of the IP address prefix in the
++                    Network Layer Reachability Information field."
++            ::= { bgp4PathAttrEntry 2 }
++
++        bgp4PathAttrIpAddrPrefix OBJECT-TYPE
++            SYNTAX     IpAddress
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "An IP address prefix in the Network Layer
++                    Reachability Information field.  This object
++                    is an IP address containing the prefix with
++                    length specified by bgp4PathAttrIpAddrPrefixLen.
++                    Any bits beyond the length specified by
++                    bgp4PathAttrIpAddrPrefixLen are zeroed."
++            ::= { bgp4PathAttrEntry 3 }
++
++        bgp4PathAttrOrigin OBJECT-TYPE
++            SYNTAX     INTEGER {
++                                 igp(1),-- networks are interior
++                                 egp(2),-- networks learned via EGP
++                                 incomplete(3) -- undetermined
++                               }
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The ultimate origin of the path information."
++            ::= { bgp4PathAttrEntry 4 }
++
++        bgp4PathAttrASPathSegment OBJECT-TYPE
++            SYNTAX     OCTET STRING (SIZE (2..255))
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The sequence of AS path segments.  Each AS
++                    path segment is represented by a triple
++                    <type, length, value>.
++
++                    The type is a 1-octet field which has two
++                    possible values:
++                         1      AS_SET: unordered set of ASs a
++                                     route in the UPDATE message
++                                     has traversed
++                         2      AS_SEQUENCE: ordered set of ASs
++                                     a route in the UPDATE message
++                                     has traversed.
++
++                    The length is a 1-octet field containing the
++                    number of ASs in the value field.
++
++                    The value field contains one or more AS
++                    numbers, each AS is represented in the octet
++                    string as a pair of octets according to the
++                    following algorithm:
++
++                        first-byte-of-pair = ASNumber / 256;
++                        second-byte-of-pair = ASNumber & 255;"
++            ::= { bgp4PathAttrEntry 5 }
++
++        bgp4PathAttrNextHop OBJECT-TYPE
++            SYNTAX     IpAddress
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The address of the border router that should
++                    be used for the destination network."
++            ::= { bgp4PathAttrEntry 6 }
++
++        bgp4PathAttrMultiExitDisc OBJECT-TYPE
++            SYNTAX     INTEGER (-1..2147483647)
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "This metric is used to discriminate between
++                    multiple exit points to an adjacent autonomous
++                    system.  A value of -1 indicates the absence of
++                    this attribute."
++            ::= { bgp4PathAttrEntry 7 }
++
++        bgp4PathAttrLocalPref OBJECT-TYPE
++            SYNTAX     INTEGER (-1..2147483647)
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The originating BGP4 speaker's degree of
++                    preference for an advertised route.  A value of
++                    -1 indicates the absence of this attribute."
++            ::= { bgp4PathAttrEntry 8 }
++
++        bgp4PathAttrAtomicAggregate OBJECT-TYPE
++            SYNTAX     INTEGER {
++                           lessSpecificRrouteNotSelected(1),
++                           lessSpecificRouteSelected(2)
++                       }
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "Whether or not a system has selected
++                    a less specific route without selecting a
++                    more specific route."
++            ::= { bgp4PathAttrEntry 9 }
++
++        bgp4PathAttrAggregatorAS OBJECT-TYPE
++            SYNTAX     INTEGER (0..65535)
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The AS number of the last BGP4 speaker that
++                    performed route aggregation.  A value of zero (0)
++                    indicates the absence of this attribute."
++            ::= { bgp4PathAttrEntry 10 }
++
++        bgp4PathAttrAggregatorAddr OBJECT-TYPE
++            SYNTAX     IpAddress
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The IP address of the last BGP4 speaker that
++                     performed route aggregation.  A value of
++                     0.0.0.0 indicates the absence of this attribute."
++            ::= { bgp4PathAttrEntry 11 }
++
++        bgp4PathAttrCalcLocalPref OBJECT-TYPE
++            SYNTAX     INTEGER (-1..2147483647)
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "The degree of preference calculated by the
++                    receiving BGP4 speaker for an advertised route.
++                    A value of -1 indicates the absence of this
++                    attribute."
++            ::= { bgp4PathAttrEntry 12 }
++
++        bgp4PathAttrBest OBJECT-TYPE
++            SYNTAX     INTEGER {
++                           false(1),-- not chosen as best route
++                           true(2) -- chosen as best route
++                       }
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "An indication of whether or not this route
++                    was chosen as the best BGP4 route."
++            ::= { bgp4PathAttrEntry 13 }
++
++        bgp4PathAttrUnknown OBJECT-TYPE
++            SYNTAX     OCTET STRING (SIZE(0..255))
++            MAX-ACCESS read-only
++            STATUS     current
++            DESCRIPTION
++                    "One or more path attributes not understood
++                     by this BGP4 speaker.  Size zero (0) indicates
++                     the absence of such attribute(s).  Octets
++                     beyond the maximum size, if any, are not
++                     recorded by this object."
++            ::= { bgp4PathAttrEntry 14 }
++
++
++        -- Traps.
++
++        -- note that in RFC 1657, bgpTraps was incorrectly
++        -- assigned a value of { bgp 7 }, and each of the
++        -- traps had the bgpPeerRemoteAddr object inappropriately
++        -- removed from their OBJECTS clause.  The following
++        -- definitions restore the semantics of the traps as
++        -- they were initially defined in RFC 1269.
++
++        -- { bgp 7 } is unused
++
++        bgpTraps          OBJECT IDENTIFIER ::= { bgp 0 }
++
++        bgpEstablished NOTIFICATION-TYPE
++            OBJECTS { bgpPeerRemoteAddr,
++                      bgpPeerLastError,
++                      bgpPeerState      }
++            STATUS  current
++            DESCRIPTION
++                    "The BGP Established event is generated when
++                    the BGP FSM enters the ESTABLISHED state."
++            ::= { bgpTraps 1 }
++
++        bgpBackwardTransition NOTIFICATION-TYPE
++            OBJECTS { bgpPeerRemoteAddr,
++                      bgpPeerLastError,
++                      bgpPeerState      }
++            STATUS  current
++            DESCRIPTION
++                    "The BGPBackwardTransition Event is generated
++                    when the BGP FSM moves from a higher numbered
++                    state to a lower numbered state."
++            ::= { bgpTraps 2 }
++
++        -- conformance information
++
++        bgpMIBConformance OBJECT IDENTIFIER ::= { bgp 8 }
++        bgpMIBCompliances OBJECT IDENTIFIER ::= { bgpMIBConformance 1 }
++        bgpMIBGroups      OBJECT IDENTIFIER ::= { bgpMIBConformance 2 }
++
++        -- compliance statements
++
++        bgpMIBCompliance MODULE-COMPLIANCE
++            STATUS  current
++            DESCRIPTION
++                    "The compliance statement for entities which
++                     implement the BGP4 mib."
++            MODULE  -- this module
++                MANDATORY-GROUPS { bgp4MIBGlobalsGroup,
++                                   bgp4MIBPeerGroup,
++                                   bgp4MIBPathAttrGroup,
++                                   bgp4MIBNotificationGroup }
++            ::= { bgpMIBCompliances 1 }
++
++        -- units of conformance
++
++        bgp4MIBGlobalsGroup OBJECT-GROUP
++            OBJECTS { bgpVersion,
++                      bgpLocalAs,
++                      bgpIdentifier }
++            STATUS  current
++            DESCRIPTION
++                    "A collection of objects providing information
++                     on global BGP state."
++            ::= { bgpMIBGroups 1 }
++
++        bgp4MIBPeerGroup OBJECT-GROUP
++            OBJECTS { bgpPeerIdentifier,
++                      bgpPeerState,
++                      bgpPeerAdminStatus,
++                      bgpPeerNegotiatedVersion,
++                      bgpPeerLocalAddr,
++                      bgpPeerLocalPort,
++                      bgpPeerRemoteAddr,
++                      bgpPeerRemotePort,
++                      bgpPeerRemoteAs,
++                      bgpPeerInUpdates,
++                      bgpPeerOutUpdates,
++                      bgpPeerInTotalMessages,
++                      bgpPeerOutTotalMessages,
++                      bgpPeerLastError,
++                      bgpPeerFsmEstablishedTransitions,
++                      bgpPeerFsmEstablishedTime,
++                      bgpPeerConnectRetryInterval,
++                      bgpPeerHoldTime,
++                      bgpPeerKeepAlive,
++                      bgpPeerHoldTimeConfigured,
++                      bgpPeerKeepAliveConfigured,
++                      bgpPeerMinASOriginationInterval,
++                      bgpPeerMinRouteAdvertisementInterval,
++                      bgpPeerInUpdateElapsedTime }
++            STATUS  current
++            DESCRIPTION
++                    "A collection of objects for managing
++                     BGP peers."
++            ::= { bgpMIBGroups 2 }
++
++        bgp4MIBRcvdPathAttrGroup OBJECT-GROUP
++            OBJECTS { bgpPathAttrPeer,
++                      bgpPathAttrDestNetwork,
++                      bgpPathAttrOrigin,
++                      bgpPathAttrASPath,
++                      bgpPathAttrNextHop,
++                      bgpPathAttrInterASMetric }
++            STATUS  obsolete
++            DESCRIPTION
++                    "A collection of objects for managing BGP
++                     path entries.
++
++                     This conformance group is obsolete,
++                     replaced by bgp4MIBPathAttrGroup."
++            ::= { bgpMIBGroups 3 }
++
++        bgp4MIBPathAttrGroup OBJECT-GROUP
++            OBJECTS { bgp4PathAttrPeer,
++                      bgp4PathAttrIpAddrPrefixLen,
++                      bgp4PathAttrIpAddrPrefix,
++                      bgp4PathAttrOrigin,
++                      bgp4PathAttrASPathSegment,
++                      bgp4PathAttrNextHop,
++                      bgp4PathAttrMultiExitDisc,
++                      bgp4PathAttrLocalPref,
++                      bgp4PathAttrAtomicAggregate,
++                      bgp4PathAttrAggregatorAS,
++                      bgp4PathAttrAggregatorAddr,
++                      bgp4PathAttrCalcLocalPref,
++                      bgp4PathAttrBest,
++                      bgp4PathAttrUnknown }
++            STATUS  current
++            DESCRIPTION
++                    "A collection of objects for managing
++                     BGP path entries."
++            ::= { bgpMIBGroups 4 }
++
++        bgp4MIBNotificationGroup NOTIFICATION-GROUP
++            NOTIFICATIONS { bgpEstablished,
++                            bgpBackwardTransition }
++            STATUS  current
++            DESCRIPTION
++                    "A collection of notifications for signaling
++                    changes in BGP peer relationships."
++            ::= { bgpMIBGroups 5 }
++
++    END
+--- /dev/null
++++ b/mibs/GNOME-SMI.txt
+@@ -0,0 +1,88 @@
++GNOME-SMI DEFINITIONS ::= BEGIN
++
++IMPORTS
++	MODULE-IDENTITY,
++	OBJECT-IDENTITY,
++	enterprises
++		FROM SNMPv2-SMI;
++
++gnome MODULE-IDENTITY
++	LAST-UPDATED "200709070000Z"
++	ORGANIZATION "GNOME project"
++	CONTACT-INFO
++		"GNU Network Object Model Environment project
++		
++		see http://www.gnome.org for contact persons of a particular
++		area or subproject of GNOME.
++
++		Administrative contact for MIB module:
++
++		Jochen Friedrich
++		Ramsaystr. 9
++		63450 Hanau
++		Germany 
++
++		email: jochen@scram.de"
++	DESCRIPTION
++		"The Structure of GNOME."
++
++	-- revision history
++
++	REVISION "200709070000Z"  -- Sep 07, 2007
++	DESCRIPTION
++		"Fixed wrong enterprise number (how comes this
++		typo was unnoticed for so long?)."
++
++	REVISION "200505070000Z"  -- May 07, 2005
++	DESCRIPTION
++		"Added gnomeLDAP subtree for LDAP definitions."
++
++	REVISION "200312070000Z"  -- December 07, 2003
++	DESCRIPTION
++		"Added gnomeSysadmin subtree for GNOME project system administration.
++		Updated contact info."
++
++	REVISION "9809010000Z"  -- September 01, 1998
++	DESCRIPTION
++		"Initial version."
++
++	::= { enterprises 3319 }	-- assigned by IANA
++
++gnomeProducts OBJECT-IDENTITY
++	STATUS	current
++	DESCRIPTION
++		"gnomeProducts is the root OBJECT IDENTIFIER from
++		which sysObjectID values are assigned."
++	::= { gnome 1 }
++
++gnomeMgmt OBJECT-IDENTITY
++	STATUS  current
++	DESCRIPTION
++		"gnomeMgmt defines the subtree for production GNOME related
++		MIB registrations."
++	::= { gnome 2 }
++
++gnomeTest OBJECT-IDENTITY
++	STATUS  current
++	DESCRIPTION
++		"gnomeTest defines the subtree for testing GNOME related
++		MIB registrations."
++	::= { gnome 3 }
++
++gnomeSysadmin OBJECT-IDENTITY
++	STATUS  current
++	DESCRIPTION
++		"gnomeSysadmin defines the subtree for GNOME related Sysadmin
++		MIB registrations."
++	::= { gnome 4 }
++
++gnomeLDAP OBJECT-IDENTITY
++	STATUS  current
++	DESCRIPTION
++		"gnomeLDAP defines the subtree for GNOME related LDAP
++		registrations."
++	::= { gnome 5 }
++
++-- more to come if necessary.
++
++END
+--- /dev/null
++++ b/mibs/OSPF-MIB.txt
+@@ -0,0 +1,2723 @@
++OSPF-MIB DEFINITIONS ::= BEGIN
++
++    IMPORTS
++            MODULE-IDENTITY, OBJECT-TYPE, Counter32, Gauge32,
++            Integer32, IpAddress
++                FROM SNMPv2-SMI
++            TEXTUAL-CONVENTION, TruthValue, RowStatus
++                FROM SNMPv2-TC
++            MODULE-COMPLIANCE, OBJECT-GROUP          FROM SNMPv2-CONF
++            mib-2                                    FROM RFC1213-MIB;
++
++--  This MIB module uses the extended OBJECT-TYPE macro as
++--  defined in [9].
++
++ospf MODULE-IDENTITY
++        LAST-UPDATED "9501201225Z" -- Fri Jan 20 12:25:50 PST 1995
++        ORGANIZATION "IETF OSPF Working Group"
++        CONTACT-INFO
++       "       Fred Baker
++       Postal: Cisco Systems
++               519 Lado Drive
++               Santa Barbara, California 93111
++       Tel:    +1 805 681 0115
++       E-Mail: fred@cisco.com
++
++               Rob Coltun
++       Postal: RainbowBridge Communications
++       Tel:    (301) 340-9416
++       E-Mail: rcoltun@rainbow-bridge.com"
++    DESCRIPTION
++       "The MIB module to describe the OSPF Version 2
++       Protocol"
++    ::= { mib-2 14 }
++
++--  The Area ID, in OSPF, has the same format as an IP Address,
++--  but has the function of defining a summarization point for
++--  Link State Advertisements
++
++AreaID ::= TEXTUAL-CONVENTION
++    STATUS      current
++    DESCRIPTION
++       "An OSPF Area Identifier."
++    SYNTAX      IpAddress
++
++
++--  The Router ID, in OSPF, has the same format as an IP Address,
++--  but identifies the router independent of its IP Address.
++
++RouterID ::= TEXTUAL-CONVENTION
++    STATUS      current
++    DESCRIPTION
++       "A OSPF Router Identifier."
++    SYNTAX      IpAddress
++
++
++--  The OSPF Metric is defined as an unsigned value in the range
++
++Metric ::= TEXTUAL-CONVENTION
++    STATUS      current
++    DESCRIPTION
++       "The OSPF Internal Metric."
++    SYNTAX      Integer32 (0..'FFFF'h)
++
++BigMetric ::= TEXTUAL-CONVENTION
++    STATUS      current
++    DESCRIPTION
++       "The OSPF External Metric."
++    SYNTAX      Integer32 (0..'FFFFFF'h)
++
++--  Status Values
++
++Status ::= TEXTUAL-CONVENTION
++    STATUS      current
++    DESCRIPTION
++       "The status of an interface: 'enabled' indicates that
++       it is willing to communicate with other OSPF Routers,
++       while 'disabled' indicates that it is not."
++    SYNTAX      INTEGER { enabled (1), disabled (2) }
++
++--  Time Durations measured in seconds
++
++PositiveInteger ::= TEXTUAL-CONVENTION
++    STATUS      current
++    DESCRIPTION
++       "A positive integer. Values in excess are precluded as
++       unnecessary and prone to interoperability issues."
++    SYNTAX      Integer32 (0..'7FFFFFFF'h)
++
++HelloRange ::= TEXTUAL-CONVENTION
++    STATUS      current
++    DESCRIPTION
++       "The range of intervals on which hello messages are
++       exchanged."
++    SYNTAX      Integer32 (1..'FFFF'h)
++
++UpToMaxAge ::= TEXTUAL-CONVENTION
++    STATUS      current
++    DESCRIPTION
++       "The values that one might find or configure for
++       variables bounded by the maximum age of an LSA."
++    SYNTAX      Integer32 (0..3600)
++
++
++--  The range of ifIndex
++
++InterfaceIndex ::= TEXTUAL-CONVENTION
++    STATUS      current
++    DESCRIPTION
++       "The range of ifIndex."
++    SYNTAX      Integer32
++
++
++--  Potential Priorities for the Designated Router Election
++
++DesignatedRouterPriority ::= TEXTUAL-CONVENTION
++    STATUS      current
++    DESCRIPTION
++       "The values defined for the priority of a system for
++       becoming the designated router."
++    SYNTAX      Integer32 (0..'FF'h)
++
++TOSType ::= TEXTUAL-CONVENTION
++    STATUS      current
++    DESCRIPTION
++       "Type of Service is defined as a mapping to the IP Type of
++       Service Flags as defined in the IP Forwarding Table MIB
++
++       +-----+-----+-----+-----+-----+-----+-----+-----+
++       |                 |                       |     |
++       |   PRECEDENCE    |    TYPE OF SERVICE    |  0  |
++       |                 |                       |     |
++       +-----+-----+-----+-----+-----+-----+-----+-----+
++
++                IP TOS                IP TOS
++           Field     Policy      Field     Policy
++
++           Contents    Code      Contents    Code
++           0 0 0 0  ==>   0      0 0 0 1  ==>   2
++           0 0 1 0  ==>   4      0 0 1 1  ==>   6
++           0 1 0 0  ==>   8      0 1 0 1  ==>  10
++           0 1 1 0  ==>  12      0 1 1 1  ==>  14
++           1 0 0 0  ==>  16      1 0 0 1  ==>  18
++           1 0 1 0  ==>  20      1 0 1 1  ==>  22
++           1 1 0 0  ==>  24      1 1 0 1  ==>  26
++           1 1 1 0  ==>  28      1 1 1 1  ==>  30
++
++       The remaining values are left for future definition."
++    SYNTAX      Integer32 (0..30)
++
++
++--  OSPF General Variables
++
++--      These parameters apply globally to the Router's
++--      OSPF Process.
++
++ospfGeneralGroup OBJECT IDENTIFIER ::= { ospf 1 }
++
++
++    ospfRouterId OBJECT-TYPE
++        SYNTAX   RouterID
++        MAX-ACCESS   read-write
++        STATUS   current
++        DESCRIPTION
++           "A  32-bit  integer  uniquely  identifying  the
++           router in the Autonomous System.
++
++           By  convention,  to  ensure  uniqueness,   this
++           should  default  to  the  value  of  one of the
++           router's IP interface addresses."
++       REFERENCE
++          "OSPF Version 2, C.1 Global parameters"
++      ::= { ospfGeneralGroup 1 }
++
++
++    ospfAdminStat OBJECT-TYPE
++        SYNTAX   Status
++        MAX-ACCESS   read-write
++        STATUS   current
++        DESCRIPTION
++           "The  administrative  status  of  OSPF  in  the
++           router.   The  value 'enabled' denotes that the
++           OSPF Process is active on at least  one  inter-
++           face;  'disabled'  disables  it  on  all inter-
++           faces."
++       ::= { ospfGeneralGroup 2 }
++
++    ospfVersionNumber OBJECT-TYPE
++        SYNTAX   INTEGER    { version2 (2) }
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The current version number of the OSPF  proto-
++           col is 2."
++       REFERENCE
++          "OSPF Version 2, Title"
++      ::= { ospfGeneralGroup 3 }
++
++
++    ospfAreaBdrRtrStatus OBJECT-TYPE
++        SYNTAX   TruthValue
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "A flag to note whether this router is an  area
++           border router."
++       REFERENCE
++          "OSPF Version 2, Section 3 Splitting the AS into
++          Areas"
++      ::= { ospfGeneralGroup 4 }
++
++
++    ospfASBdrRtrStatus OBJECT-TYPE
++        SYNTAX   TruthValue
++        MAX-ACCESS   read-write
++        STATUS   current
++        DESCRIPTION
++           "A flag to note whether this router is  config-
++           ured as an Autonomous System border router."
++       REFERENCE
++          "OSPF Version 2, Section 3.3  Classification  of
++          routers"
++      ::= { ospfGeneralGroup 5 }
++
++    ospfExternLsaCount OBJECT-TYPE
++        SYNTAX   Gauge32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of external (LS type 5)  link-state
++           advertisements in the link-state database."
++       REFERENCE
++          "OSPF Version 2, Appendix A.4.5 AS external link
++          advertisements"
++      ::= { ospfGeneralGroup 6 }
++
++
++    ospfExternLsaCksumSum OBJECT-TYPE
++        SYNTAX   Integer32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The 32-bit unsigned sum of the LS checksums of
++           the  external  link-state  advertisements  con-
++           tained in the link-state  database.   This  sum
++           can  be  used  to determine if there has been a
++           change in a router's link state  database,  and
++           to  compare  the  link-state  database  of  two
++           routers."
++       ::= { ospfGeneralGroup 7 }
++
++
++    ospfTOSSupport OBJECT-TYPE
++        SYNTAX   TruthValue
++        MAX-ACCESS   read-write
++        STATUS   current
++        DESCRIPTION
++           "The router's support for type-of-service rout-
++           ing."
++       REFERENCE
++          "OSPF Version 2,  Appendix  F.1.2  Optional  TOS
++          support"
++      ::= { ospfGeneralGroup 8 }
++
++    ospfOriginateNewLsas OBJECT-TYPE
++        SYNTAX   Counter32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of  new  link-state  advertisements
++           that  have been originated.  This number is in-
++           cremented each time the router originates a new
++           LSA."
++       ::= { ospfGeneralGroup 9 }
++
++
++    ospfRxNewLsas OBJECT-TYPE
++        SYNTAX   Counter32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of  link-state  advertisements  re-
++           ceived  determined  to  be  new instantiations.
++           This number does not include  newer  instantia-
++           tions  of self-originated link-state advertise-
++           ments."
++       ::= { ospfGeneralGroup 10 }
++
++    ospfExtLsdbLimit OBJECT-TYPE
++        SYNTAX   Integer32 (-1..'7FFFFFFF'h)
++        MAX-ACCESS   read-write
++        STATUS   current
++        DESCRIPTION
++           "The  maximum   number   of   non-default   AS-
++           external-LSAs entries that can be stored in the
++           link-state database.  If the value is -1,  then
++           there is no limit.
++
++           When the number of non-default AS-external-LSAs
++           in   a  router's  link-state  database  reaches
++           ospfExtLsdbLimit, the router  enters  Overflow-
++           State.   The   router  never  holds  more  than
++           ospfExtLsdbLimit  non-default  AS-external-LSAs
++           in  its  database. OspfExtLsdbLimit MUST be set
++           identically in all routers attached to the OSPF
++           backbone  and/or  any regular OSPF area. (i.e.,
++           OSPF stub areas and NSSAs are excluded)."
++       DEFVAL { -1 }
++       ::= { ospfGeneralGroup 11 }
++
++    ospfMulticastExtensions OBJECT-TYPE
++        SYNTAX   Integer32
++        MAX-ACCESS   read-write
++        STATUS   current
++        DESCRIPTION
++           "A Bit Mask indicating whether  the  router  is
++           forwarding  IP  multicast  (Class  D) datagrams
++           based on the algorithms defined in  the  Multi-
++           cast Extensions to OSPF.
++
++           Bit 0, if set, indicates that  the  router  can
++           forward  IP multicast datagrams in the router's
++           directly attached areas (called intra-area mul-
++           ticast routing).
++
++           Bit 1, if set, indicates that  the  router  can
++           forward  IP  multicast  datagrams  between OSPF
++           areas (called inter-area multicast routing).
++
++           Bit 2, if set, indicates that  the  router  can
++           forward  IP  multicast  datagrams between Auto-
++           nomous Systems (called inter-AS multicast rout-
++           ing).
++
++           Only certain combinations of bit  settings  are
++           allowed,  namely: 0 (no multicast forwarding is
++           enabled), 1 (intra-area multicasting  only),  3
++           (intra-area  and  inter-area  multicasting),  5
++           (intra-area and inter-AS  multicasting)  and  7
++           (multicasting  everywhere). By default, no mul-
++           ticast forwarding is enabled."
++       DEFVAL { 0 }
++       ::= { ospfGeneralGroup 12 }
++
++    ospfExitOverflowInterval OBJECT-TYPE
++        SYNTAX   PositiveInteger
++        MAX-ACCESS   read-write
++        STATUS   current
++        DESCRIPTION
++           "The number of  seconds  that,  after  entering
++           OverflowState,  a  router will attempt to leave
++           OverflowState. This allows the router to  again
++           originate  non-default  AS-external-LSAs.  When
++           set to 0, the router will not  leave  Overflow-
++           State until restarted."
++       DEFVAL { 0 }
++       ::= { ospfGeneralGroup 13 }
++
++
++    ospfDemandExtensions OBJECT-TYPE
++        SYNTAX   TruthValue
++        MAX-ACCESS   read-write
++        STATUS   current
++        DESCRIPTION
++           "The router's support for demand routing."
++       REFERENCE
++          "OSPF Version 2, Appendix on Demand Routing"
++      ::= { ospfGeneralGroup 14 }
++
++
++--      The OSPF Area Data Structure contains information
++--      regarding the various areas. The interfaces and
++--      virtual links are configured as part of these areas.
++--      Area 0.0.0.0, by definition, is the Backbone Area
++
++
++    ospfAreaTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF OspfAreaEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "Information describing the configured  parame-
++           ters  and cumulative statistics of the router's
++           attached areas."
++       REFERENCE
++          "OSPF Version 2, Section 6  The Area Data Struc-
++          ture"
++      ::= { ospf 2 }
++
++
++    ospfAreaEntry OBJECT-TYPE
++        SYNTAX   OspfAreaEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "Information describing the configured  parame-
++           ters  and  cumulative  statistics of one of the
++           router's attached areas."
++       INDEX { ospfAreaId }
++       ::= { ospfAreaTable 1 }
++
++OspfAreaEntry ::=
++    SEQUENCE {
++        ospfAreaId
++            AreaID,
++        ospfAuthType
++            Integer32,
++        ospfImportAsExtern
++            INTEGER,
++        ospfSpfRuns
++            Counter32,
++        ospfAreaBdrRtrCount
++            Gauge32,
++        ospfAsBdrRtrCount
++            Gauge32,
++        ospfAreaLsaCount
++            Gauge32,
++        ospfAreaLsaCksumSum
++            Integer32,
++        ospfAreaSummary
++            INTEGER,
++        ospfAreaStatus
++            RowStatus
++              }
++
++    ospfAreaId OBJECT-TYPE
++        SYNTAX   AreaID
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "A 32-bit integer uniquely identifying an area.
++           Area ID 0.0.0.0 is used for the OSPF backbone."
++       REFERENCE
++          "OSPF Version 2, Appendix C.2 Area parameters"
++      ::= { ospfAreaEntry 1 }
++
++
++    ospfAuthType OBJECT-TYPE
++        SYNTAX   Integer32
++                    -- none (0),
++                    -- simplePassword (1)
++                    -- md5 (2)
++                    -- reserved for specification by IANA (> 2)
++        MAX-ACCESS   read-create
++        STATUS   obsolete
++        DESCRIPTION
++           "The authentication type specified for an area.
++           Additional authentication types may be assigned
++           locally on a per Area basis."
++       REFERENCE
++          "OSPF Version 2, Appendix E Authentication"
++      DEFVAL { 0 }        -- no authentication, by default
++      ::= { ospfAreaEntry 2 }
++
++    ospfImportAsExtern OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                    importExternal (1),
++                    importNoExternal (2),
++                    importNssa (3)
++                  }
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The area's support for importing  AS  external
++           link- state advertisements."
++       REFERENCE
++          "OSPF Version 2, Appendix C.2 Area parameters"
++      DEFVAL { importExternal }
++      ::= { ospfAreaEntry 3 }
++
++
++    ospfSpfRuns OBJECT-TYPE
++        SYNTAX   Counter32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of times that the intra-area  route
++           table  has  been  calculated  using this area's
++           link-state database.  This  is  typically  done
++           using Dijkstra's algorithm."
++       ::= { ospfAreaEntry 4 }
++
++
++    ospfAreaBdrRtrCount OBJECT-TYPE
++        SYNTAX   Gauge32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The total number of area border routers reach-
++           able within this area.  This is initially zero,
++           and is calculated in each SPF Pass."
++       ::= { ospfAreaEntry 5 }
++
++    ospfAsBdrRtrCount OBJECT-TYPE
++        SYNTAX   Gauge32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The total number of Autonomous  System  border
++           routers  reachable  within  this area.  This is
++           initially zero, and is calculated in  each  SPF
++           Pass."
++       ::= { ospfAreaEntry 6 }
++
++
++    ospfAreaLsaCount OBJECT-TYPE
++        SYNTAX   Gauge32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The total number of link-state  advertisements
++           in  this  area's link-state database, excluding
++           AS External LSA's."
++       ::= { ospfAreaEntry 7 }
++
++
++    ospfAreaLsaCksumSum OBJECT-TYPE
++        SYNTAX   Integer32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The 32-bit unsigned sum of the link-state  ad-
++           vertisements'  LS  checksums  contained in this
++           area's link-state database.  This sum  excludes
++           external (LS type 5) link-state advertisements.
++           The sum can be used to determine if  there  has
++           been  a  change  in a router's link state data-
++           base, and to compare the link-state database of
++           two routers."
++       DEFVAL   { 0 }
++       ::= { ospfAreaEntry 8 }
++
++    ospfAreaSummary OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                    noAreaSummary (1),
++                    sendAreaSummary (2)
++                  }
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The variable ospfAreaSummary controls the  im-
++           port  of  summary LSAs into stub areas.  It has
++           no effect on other areas.
++
++           If it is noAreaSummary, the router will neither
++           originate  nor  propagate summary LSAs into the
++           stub area.  It will rely entirely  on  its  de-
++           fault route.
++
++           If it is sendAreaSummary, the router will  both
++           summarize and propagate summary LSAs."
++       DEFVAL   { noAreaSummary }
++       ::= { ospfAreaEntry 9 }
++
++
++    ospfAreaStatus OBJECT-TYPE
++        SYNTAX   RowStatus
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "This variable displays the status of  the  en-
++           try.  Setting it to 'invalid' has the effect of
++           rendering it inoperative.  The internal  effect
++           (row removal) is implementation dependent."
++       ::= { ospfAreaEntry 10 }
++
++
++--  OSPF Area Default Metric Table
++
++--      The OSPF Area Default Metric Table describes the metrics
++--      that a default Area Border Router will advertise into a
++--      Stub area.
++
++
++    ospfStubAreaTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF OspfStubAreaEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "The set of metrics that will be advertised  by
++           a default Area Border Router into a stub area."
++       REFERENCE
++          "OSPF Version 2, Appendix C.2, Area Parameters"
++      ::= { ospf 3 }
++
++
++    ospfStubAreaEntry OBJECT-TYPE
++        SYNTAX   OspfStubAreaEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "The metric for a given Type  of  Service  that
++           will  be  advertised  by  a default Area Border
++           Router into a stub area."
++       REFERENCE
++          "OSPF Version 2, Appendix C.2, Area Parameters"
++      INDEX { ospfStubAreaId, ospfStubTOS }
++      ::= { ospfStubAreaTable 1 }
++
++OspfStubAreaEntry ::=
++    SEQUENCE {
++        ospfStubAreaId
++            AreaID,
++        ospfStubTOS
++            TOSType,
++        ospfStubMetric
++            BigMetric,
++        ospfStubStatus
++            RowStatus,
++        ospfStubMetricType
++            INTEGER
++              }
++
++    ospfStubAreaId OBJECT-TYPE
++        SYNTAX   AreaID
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The 32 bit identifier for the Stub  Area.   On
++           creation,  this  can  be  derived  from the in-
++           stance."
++       ::= { ospfStubAreaEntry 1 }
++
++
++    ospfStubTOS OBJECT-TYPE
++        SYNTAX   TOSType
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The  Type  of  Service  associated  with   the
++           metric.   On creation, this can be derived from
++           the instance."
++       ::= { ospfStubAreaEntry 2 }
++
++
++    ospfStubMetric OBJECT-TYPE
++        SYNTAX   BigMetric
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The metric value applied at the indicated type
++           of  service.  By default, this equals the least
++           metric at the type of service among the  inter-
++           faces to other areas."
++       ::= { ospfStubAreaEntry 3 }
++
++
++    ospfStubStatus OBJECT-TYPE
++        SYNTAX   RowStatus
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "This variable displays the status of  the  en-
++           try.  Setting it to 'invalid' has the effect of
++           rendering it inoperative.  The internal  effect
++           (row removal) is implementation dependent."
++       ::= { ospfStubAreaEntry 4 }
++
++    ospfStubMetricType OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                    ospfMetric (1),                -- OSPF Metric
++                    comparableCost (2),        -- external type 1
++                    nonComparable  (3)        -- external type 2
++                  }
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "This variable displays the type of metric  ad-
++           vertised as a default route."
++       DEFVAL   { ospfMetric }
++       ::= { ospfStubAreaEntry 5 }
++
++--  OSPF Link State Database
++
++--      The Link State Database contains the Link State
++--      Advertisements from throughout the areas that the
++--      device is attached to.
++
++
++    ospfLsdbTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF OspfLsdbEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "The OSPF Process's Link State Database."
++       REFERENCE
++          "OSPF Version 2, Section 12  Link  State  Adver-
++          tisements"
++      ::= { ospf 4 }
++
++
++    ospfLsdbEntry OBJECT-TYPE
++        SYNTAX   OspfLsdbEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "A single Link State Advertisement."
++       INDEX { ospfLsdbAreaId, ospfLsdbType,
++               ospfLsdbLsid, ospfLsdbRouterId }
++       ::= { ospfLsdbTable 1 }
++
++OspfLsdbEntry ::=
++    SEQUENCE {
++        ospfLsdbAreaId
++            AreaID,
++        ospfLsdbType
++            INTEGER,
++        ospfLsdbLsid
++            IpAddress,
++        ospfLsdbRouterId
++            RouterID,
++        ospfLsdbSequence
++            Integer32,
++        ospfLsdbAge
++            Integer32,
++        ospfLsdbChecksum
++            Integer32,
++        ospfLsdbAdvertisement
++            OCTET STRING
++              }
++    ospfLsdbAreaId OBJECT-TYPE
++        SYNTAX   AreaID
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The 32 bit identifier of the Area  from  which
++           the LSA was received."
++       REFERENCE
++          "OSPF Version 2, Appendix C.2 Area parameters"
++      ::= { ospfLsdbEntry 1 }
++
++-- External Link State Advertisements are permitted
++-- for backward compatibility, but should be displayed in
++-- the ospfExtLsdbTable rather than here.
++
++    ospfLsdbType OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                    routerLink (1),
++                    networkLink (2),
++                    summaryLink (3),
++                    asSummaryLink (4),
++                    asExternalLink (5), -- but see ospfExtLsdbTable
++                    multicastLink (6),
++                    nssaExternalLink (7)
++                  }
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The type  of  the  link  state  advertisement.
++           Each  link state type has a separate advertise-
++           ment format."
++       REFERENCE
++          "OSPF Version 2, Appendix A.4.1 The  Link  State
++          Advertisement header"
++      ::= { ospfLsdbEntry 2 }
++
++    ospfLsdbLsid OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The Link State ID is an LS Type Specific field
++           containing either a Router ID or an IP Address;
++           it identifies the piece of the  routing  domain
++           that is being described by the advertisement."
++       REFERENCE
++          "OSPF Version 2, Section 12.1.4 Link State ID"
++      ::= { ospfLsdbEntry 3 }
++    ospfLsdbRouterId OBJECT-TYPE
++        SYNTAX   RouterID
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The 32 bit number that uniquely identifies the
++           originating router in the Autonomous System."
++       REFERENCE
++          "OSPF Version 2, Appendix C.1 Global parameters"
++      ::= { ospfLsdbEntry 4 }
++
++--  Note that the OSPF Sequence Number is a 32 bit signed
++--  integer.  It starts with the value '80000001'h,
++--  or -'7FFFFFFF'h, and increments until '7FFFFFFF'h
++--  Thus, a typical sequence number will be very negative.
++
++    ospfLsdbSequence OBJECT-TYPE
++        SYNTAX   Integer32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The sequence number field is a  signed  32-bit
++           integer.   It  is used to detect old and dupli-
++           cate link state advertisements.  The  space  of
++           sequence  numbers  is  linearly  ordered.   The
++           larger the sequence number the more recent  the
++           advertisement."
++       REFERENCE
++          "OSPF Version  2,  Section  12.1.6  LS  sequence
++          number"
++      ::= { ospfLsdbEntry 5 }
++
++
++    ospfLsdbAge OBJECT-TYPE
++        SYNTAX   Integer32    -- Should be 0..MaxAge
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "This field is the age of the link state adver-
++           tisement in seconds."
++       REFERENCE
++          "OSPF Version 2, Section 12.1.1 LS age"
++      ::= { ospfLsdbEntry 6 }
++
++    ospfLsdbChecksum OBJECT-TYPE
++        SYNTAX   Integer32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "This field is the  checksum  of  the  complete
++           contents  of  the  advertisement, excepting the
++           age field.  The age field is excepted  so  that
++           an   advertisement's  age  can  be  incremented
++           without updating the  checksum.   The  checksum
++           used  is  the same that is used for ISO connec-
++           tionless datagrams; it is commonly referred  to
++           as the Fletcher checksum."
++       REFERENCE
++          "OSPF Version 2, Section 12.1.7 LS checksum"
++      ::= { ospfLsdbEntry 7 }
++
++
++    ospfLsdbAdvertisement OBJECT-TYPE
++        SYNTAX   OCTET STRING (SIZE (1..65535))
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The entire Link State Advertisement, including
++           its header."
++       REFERENCE
++          "OSPF Version 2, Section 12  Link  State  Adver-
++          tisements"
++      ::= { ospfLsdbEntry 8 }
++
++
++--  Address Range Table
++
++--      The Address Range Table acts as an adjunct to the Area
++--      Table; It describes those Address Range Summaries that
++--      are configured to be propagated from an Area to reduce
++--      the amount of information about it which is known beyond
++--      its borders.
++
++    ospfAreaRangeTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF OspfAreaRangeEntry
++        MAX-ACCESS   not-accessible
++        STATUS   obsolete
++        DESCRIPTION
++           "A range if IP addresses  specified  by  an  IP
++           address/IP  network  mask  pair.   For example,
++           class B address range of X.X.X.X with a network
++           mask  of  255.255.0.0 includes all IP addresses
++           from X.X.0.0 to X.X.255.255"
++       REFERENCE
++          "OSPF Version 2, Appendix C.2  Area parameters"
++      ::= { ospf 5 }
++    ospfAreaRangeEntry OBJECT-TYPE
++        SYNTAX   OspfAreaRangeEntry
++        MAX-ACCESS   not-accessible
++        STATUS   obsolete
++        DESCRIPTION
++           "A range if IP addresses  specified  by  an  IP
++           address/IP  network  mask  pair.   For example,
++           class B address range of X.X.X.X with a network
++           mask  of  255.255.0.0 includes all IP addresses
++           from X.X.0.0 to X.X.255.255"
++       REFERENCE
++          "OSPF Version 2, Appendix C.2  Area parameters"
++      INDEX { ospfAreaRangeAreaId, ospfAreaRangeNet }
++      ::= { ospfAreaRangeTable 1 }
++
++OspfAreaRangeEntry ::=
++    SEQUENCE {
++        ospfAreaRangeAreaId
++            AreaID,
++        ospfAreaRangeNet
++            IpAddress,
++        ospfAreaRangeMask
++            IpAddress,
++        ospfAreaRangeStatus
++            RowStatus,
++        ospfAreaRangeEffect
++            INTEGER
++              }
++
++    ospfAreaRangeAreaId OBJECT-TYPE
++        SYNTAX   AreaID
++        MAX-ACCESS   read-only
++        STATUS   obsolete
++        DESCRIPTION
++           "The Area the Address  Range  is  to  be  found
++           within."
++       REFERENCE
++          "OSPF Version 2, Appendix C.2 Area parameters"
++      ::= { ospfAreaRangeEntry 1 }
++
++
++    ospfAreaRangeNet OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   obsolete
++        DESCRIPTION
++           "The IP Address of the Net or Subnet  indicated
++           by the range."
++       REFERENCE
++          "OSPF Version 2, Appendix C.2 Area parameters"
++      ::= { ospfAreaRangeEntry 2 }
++
++
++    ospfAreaRangeMask OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-create
++        STATUS   obsolete
++        DESCRIPTION
++           "The Subnet Mask that pertains to  the  Net  or
++           Subnet."
++       REFERENCE
++          "OSPF Version 2, Appendix C.2 Area parameters"
++      ::= { ospfAreaRangeEntry 3 }
++
++    ospfAreaRangeStatus OBJECT-TYPE
++        SYNTAX   RowStatus
++        MAX-ACCESS   read-create
++        STATUS   obsolete
++        DESCRIPTION
++           "This variable displays the status of  the  en-
++           try.  Setting it to 'invalid' has the effect of
++           rendering it inoperative.  The internal  effect
++           (row removal) is implementation dependent."
++       ::= { ospfAreaRangeEntry 4 }
++
++
++    ospfAreaRangeEffect OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                    advertiseMatching (1),
++                    doNotAdvertiseMatching (2)
++                  }
++        MAX-ACCESS   read-create
++        STATUS   obsolete
++        DESCRIPTION
++           "Subnets subsumed by ranges either trigger  the
++           advertisement  of the indicated summary (adver-
++           tiseMatching), or result in  the  subnet's  not
++           being advertised at all outside the area."
++       DEFVAL   { advertiseMatching }
++       ::= { ospfAreaRangeEntry 5 }
++
++
++
++--  OSPF Host Table
++
++--      The Host/Metric Table indicates what hosts are directly
++--      attached to the Router, and what metrics and types of
++--      service should be advertised for them.
++
++    ospfHostTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF OspfHostEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "The list of Hosts, and their metrics, that the
++           router will advertise as host routes."
++       REFERENCE
++          "OSPF Version 2, Appendix C.6  Host route param-
++          eters"
++      ::= { ospf 6 }
++
++
++    ospfHostEntry OBJECT-TYPE
++        SYNTAX   OspfHostEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "A metric to be advertised, for a given type of
++           service, when a given host is reachable."
++       INDEX { ospfHostIpAddress, ospfHostTOS }
++       ::= { ospfHostTable 1 }
++
++OspfHostEntry ::=
++    SEQUENCE {
++        ospfHostIpAddress
++            IpAddress,
++        ospfHostTOS
++            TOSType,
++        ospfHostMetric
++            Metric,
++        ospfHostStatus
++            RowStatus,
++        ospfHostAreaID
++            AreaID
++              }
++
++    ospfHostIpAddress OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The IP Address of the Host."
++       REFERENCE
++          "OSPF Version 2, Appendix C.6 Host route parame-
++          ters"
++      ::= { ospfHostEntry 1 }
++
++
++    ospfHostTOS OBJECT-TYPE
++        SYNTAX   TOSType
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The Type of Service of the route being config-
++           ured."
++       REFERENCE
++          "OSPF Version 2, Appendix C.6 Host route parame-
++          ters"
++      ::= { ospfHostEntry 2 }
++
++
++    ospfHostMetric OBJECT-TYPE
++        SYNTAX   Metric
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The Metric to be advertised."
++       REFERENCE
++          "OSPF Version 2, Appendix C.6 Host route parame-
++          ters"
++      ::= { ospfHostEntry 3 }
++
++    ospfHostStatus OBJECT-TYPE
++        SYNTAX   RowStatus
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "This variable displays the status of  the  en-
++           try.  Setting it to 'invalid' has the effect of
++           rendering it inoperative.  The internal  effect
++           (row removal) is implementation dependent."
++       ::= { ospfHostEntry 4 }
++
++
++    ospfHostAreaID OBJECT-TYPE
++        SYNTAX   AreaID
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The Area the Host Entry is to be found within.
++           By  default, the area that a subsuming OSPF in-
++           terface is in, or 0.0.0.0"
++       REFERENCE
++          "OSPF Version 2, Appendix C.2 Area parameters"
++      ::= { ospfHostEntry 5 }
++
++
++--  OSPF Interface Table
++
++--      The OSPF Interface Table augments the ipAddrTable
++--             with OSPF specific information.
++
++    ospfIfTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF OspfIfEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "The OSPF Interface Table describes the  inter-
++           faces from the viewpoint of OSPF."
++       REFERENCE
++          "OSPF Version 2, Appendix C.3  Router  interface
++          parameters"
++      ::= { ospf 7 }
++
++
++    ospfIfEntry OBJECT-TYPE
++        SYNTAX   OspfIfEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "The OSPF Interface Entry describes one  inter-
++           face from the viewpoint of OSPF."
++       INDEX { ospfIfIpAddress, ospfAddressLessIf }
++       ::= { ospfIfTable 1 }
++
++OspfIfEntry ::=
++    SEQUENCE {
++        ospfIfIpAddress
++            IpAddress,
++        ospfAddressLessIf
++            Integer32,
++        ospfIfAreaId
++            AreaID,
++        ospfIfType
++            INTEGER,
++        ospfIfAdminStat
++            Status,
++        ospfIfRtrPriority
++            DesignatedRouterPriority,
++        ospfIfTransitDelay
++            UpToMaxAge,
++        ospfIfRetransInterval
++            UpToMaxAge,
++        ospfIfHelloInterval
++            HelloRange,
++        ospfIfRtrDeadInterval
++            PositiveInteger,
++        ospfIfPollInterval
++            PositiveInteger,
++        ospfIfState
++            INTEGER,
++        ospfIfDesignatedRouter
++            IpAddress,
++        ospfIfBackupDesignatedRouter
++            IpAddress,
++        ospfIfEvents
++            Counter32,
++        ospfIfAuthType
++            INTEGER,
++        ospfIfAuthKey
++            OCTET STRING,
++        ospfIfStatus
++            RowStatus,
++        ospfIfMulticastForwarding
++            INTEGER,
++        ospfIfDemand
++            TruthValue
++              }
++
++    ospfIfIpAddress OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The IP address of this OSPF interface."
++       ::= { ospfIfEntry 1 }
++
++    ospfAddressLessIf OBJECT-TYPE
++        SYNTAX   Integer32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "For the purpose of easing  the  instancing  of
++           addressed   and  addressless  interfaces;  This
++           variable takes the value 0 on  interfaces  with
++           IP  Addresses,  and  the corresponding value of
++           ifIndex for interfaces having no IP Address."
++       ::= { ospfIfEntry 2 }
++    ospfIfAreaId OBJECT-TYPE
++        SYNTAX   AreaID
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "A 32-bit integer uniquely identifying the area
++           to  which  the  interface  connects.   Area  ID
++           0.0.0.0 is used for the OSPF backbone."
++       DEFVAL   { '00000000'H }    -- 0.0.0.0
++       ::= { ospfIfEntry 3 }
++
++    ospfIfType OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                    broadcast (1),
++                    nbma (2),
++                    pointToPoint (3),
++                    pointToMultipoint (5)
++                  }
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The OSPF interface type.
++
++           By way of a default, this field may be intuited
++           from the corresponding value of ifType.  Broad-
++           cast LANs, such as  Ethernet  and  IEEE  802.5,
++           take  the  value  'broadcast', X.25 and similar
++           technologies take the value 'nbma',  and  links
++           that  are  definitively point to point take the
++           value 'pointToPoint'."
++       ::= { ospfIfEntry 4 }
++
++
++    ospfIfAdminStat OBJECT-TYPE
++        SYNTAX   Status
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The OSPF  interface's  administrative  status.
++           The  value formed on the interface, and the in-
++           terface will be advertised as an internal route
++           to  some  area.   The  value 'disabled' denotes
++           that the interface is external to OSPF."
++       DEFVAL { enabled }
++       ::= { ospfIfEntry 5 }
++
++    ospfIfRtrPriority OBJECT-TYPE
++        SYNTAX   DesignatedRouterPriority
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The  priority  of  this  interface.   Used  in
++           multi-access  networks,  this  field is used in
++           the designated router election algorithm.   The
++           value 0 signifies that the router is not eligi-
++           ble to become the  designated  router  on  this
++           particular  network.   In the event of a tie in
++           this value, routers will use their Router ID as
++           a tie breaker."
++       DEFVAL { 1 }
++       ::= { ospfIfEntry 6 }
++
++
++    ospfIfTransitDelay OBJECT-TYPE
++        SYNTAX   UpToMaxAge
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The estimated number of seconds  it  takes  to
++           transmit  a  link state update packet over this
++           interface."
++       DEFVAL { 1 }
++       ::= { ospfIfEntry 7 }
++
++
++    ospfIfRetransInterval OBJECT-TYPE
++        SYNTAX   UpToMaxAge
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The number of seconds between  link-state  ad-
++           vertisement  retransmissions,  for  adjacencies
++           belonging to this  interface.   This  value  is
++           also used when retransmitting database descrip-
++           tion and link-state request packets."
++       DEFVAL { 5 }
++       ::= { ospfIfEntry 8 }
++
++
++    ospfIfHelloInterval OBJECT-TYPE
++        SYNTAX   HelloRange
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The length of time, in  seconds,  between  the
++           Hello  packets that the router sends on the in-
++           terface.  This value must be the same  for  all
++           routers attached to a common network."
++       DEFVAL { 10 }
++       ::= { ospfIfEntry 9 }
++
++
++    ospfIfRtrDeadInterval OBJECT-TYPE
++        SYNTAX   PositiveInteger
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The number of seconds that  a  router's  Hello
++           packets  have  not been seen before it's neigh-
++           bors declare the router down.  This  should  be
++           some  multiple  of  the  Hello  interval.  This
++           value must be the same for all routers attached
++           to a common network."
++       DEFVAL { 40 }
++       ::= { ospfIfEntry 10 }
++
++
++    ospfIfPollInterval OBJECT-TYPE
++        SYNTAX   PositiveInteger
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The larger time interval, in seconds,  between
++           the  Hello  packets  sent  to  an inactive non-
++           broadcast multi- access neighbor."
++       DEFVAL { 120 }
++       ::= { ospfIfEntry 11 }
++
++
++    ospfIfState OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                    down (1),
++                    loopback (2),
++                    waiting (3),
++                    pointToPoint (4),
++                    designatedRouter (5),
++                    backupDesignatedRouter (6),
++                    otherDesignatedRouter (7)
++                  }
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The OSPF Interface State."
++       DEFVAL { down }
++       ::= { ospfIfEntry 12 }
++
++
++    ospfIfDesignatedRouter OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The IP Address of the Designated Router."
++       DEFVAL   { '00000000'H }    -- 0.0.0.0
++       ::= { ospfIfEntry 13 }
++
++
++    ospfIfBackupDesignatedRouter OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The  IP  Address  of  the  Backup   Designated
++           Router."
++       DEFVAL   { '00000000'H }    -- 0.0.0.0
++       ::= { ospfIfEntry 14 }
++
++    ospfIfEvents OBJECT-TYPE
++        SYNTAX   Counter32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of times this  OSPF  interface  has
++           changed its state, or an error has occurred."
++       ::= { ospfIfEntry 15 }
++
++
++    ospfIfAuthKey OBJECT-TYPE
++        SYNTAX   OCTET STRING (SIZE (0..256))
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The Authentication Key.  If the Area's Author-
++           ization  Type  is  simplePassword,  and the key
++           length is shorter than 8 octets, the agent will
++           left adjust and zero fill to 8 octets.
++
++           Note that unauthenticated  interfaces  need  no
++           authentication key, and simple password authen-
++           tication cannot use a key of more  than  8  oc-
++           tets.  Larger keys are useful only with authen-
++           tication mechanisms not specified in this docu-
++           ment.
++
++           When read, ospfIfAuthKey always returns an  Oc-
++           tet String of length zero."
++       REFERENCE
++          "OSPF Version 2, Section 9  The  Interface  Data
++          Structure"
++      DEFVAL   { '0000000000000000'H }    -- 0.0.0.0.0.0.0.0
++      ::= { ospfIfEntry 16 }
++
++    ospfIfStatus OBJECT-TYPE
++        SYNTAX   RowStatus
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "This variable displays the status of  the  en-
++           try.  Setting it to 'invalid' has the effect of
++           rendering it inoperative.  The internal  effect
++           (row removal) is implementation dependent."
++       ::= { ospfIfEntry 17 }
++
++
++    ospfIfMulticastForwarding OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                            blocked (1),        -- no multicast forwarding
++                            multicast (2),        -- using multicast address
++                            unicast (3)        -- to each OSPF neighbor
++                  }
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The way multicasts should  forwarded  on  this
++           interface;  not  forwarded,  forwarded  as data
++           link multicasts, or forwarded as data link uni-
++           casts.   Data link multicasting is not meaning-
++           ful on point to point and NBMA interfaces,  and
++           setting ospfMulticastForwarding to 0 effective-
++           ly disables all multicast forwarding."
++       DEFVAL { blocked }
++       ::= { ospfIfEntry 18 }
++
++
++    ospfIfDemand OBJECT-TYPE
++        SYNTAX   TruthValue
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "Indicates whether Demand OSPF procedures (hel-
++           lo supression to FULL neighbors and setting the
++           DoNotAge flag on proogated LSAs) should be per-
++           formed on this interface."
++       DEFVAL { false }
++       ::= { ospfIfEntry 19 }
++
++
++    ospfIfAuthType OBJECT-TYPE
++        SYNTAX   INTEGER (0..255)
++                    -- none (0),
++                    -- simplePassword (1)
++                    -- md5 (2)
++                    -- reserved for specification by IANA (> 2)
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The authentication type specified for  an  in-
++           terface.   Additional  authentication types may
++           be assigned locally."
++       REFERENCE
++          "OSPF Version 2, Appendix E Authentication"
++      DEFVAL { 0 }        -- no authentication, by default
++      ::= { ospfIfEntry 20 }
++
++
++--  OSPF Interface Metric Table
++
++--      The Metric Table describes the metrics to be advertised
++--      for a specified interface at the various types of service.
++--      As such, this table is an adjunct of the OSPF Interface
++--      Table.
++
++-- Types of service, as defined by RFC 791, have the ability
++-- to request low delay, high bandwidth, or reliable linkage.
++
++-- For the purposes of this specification, the measure of
++-- bandwidth
++
++--      Metric = 10^8 / ifSpeed
++
++-- is the default value.  For multiple link interfaces, note
++-- that ifSpeed is the sum of the individual link speeds.
++-- This yields a number having the following typical values:
++
++--      Network Type/bit rate   Metric
++
++--      >= 100 MBPS                 1
++--      Ethernet/802.3             10
++--      E1                         48
++--      T1 (ESF)                   65
++--       64 KBPS                 1562
++--       56 KBPS                 1785
++--       19.2 KBPS               5208
++--        9.6 KBPS              10416
++
++-- Routes that are not specified use the default (TOS 0) metric
++
++    ospfIfMetricTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF OspfIfMetricEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "The TOS metrics for  a  non-virtual  interface
++           identified by the interface index."
++       REFERENCE
++          "OSPF Version 2, Appendix C.3  Router  interface
++          parameters"
++      ::= { ospf 8 }
++
++    ospfIfMetricEntry OBJECT-TYPE
++        SYNTAX   OspfIfMetricEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "A particular TOS metric for a non-virtual  in-
++           terface identified by the interface index."
++       REFERENCE
++          "OSPF Version 2, Appendix C.3  Router  interface
++          parameters"
++      INDEX { ospfIfMetricIpAddress,
++  ospfIfMetricAddressLessIf,
++  ospfIfMetricTOS }
++      ::= { ospfIfMetricTable 1 }
++
++OspfIfMetricEntry ::=
++    SEQUENCE {
++        ospfIfMetricIpAddress
++            IpAddress,
++        ospfIfMetricAddressLessIf
++            Integer32,
++        ospfIfMetricTOS
++            TOSType,
++        ospfIfMetricValue
++            Metric,
++        ospfIfMetricStatus
++            RowStatus
++              }
++
++    ospfIfMetricIpAddress OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The IP address of this OSPF interface.  On row
++           creation,  this  can  be  derived  from the in-
++           stance."
++       ::= { ospfIfMetricEntry 1 }
++
++    ospfIfMetricAddressLessIf OBJECT-TYPE
++        SYNTAX   Integer32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "For the purpose of easing  the  instancing  of
++           addressed   and  addressless  interfaces;  This
++           variable takes the value 0 on  interfaces  with
++           IP  Addresses, and the value of ifIndex for in-
++           terfaces having no IP Address.   On  row  crea-
++           tion, this can be derived from the instance."
++       ::= { ospfIfMetricEntry 2 }
++
++
++    ospfIfMetricTOS OBJECT-TYPE
++        SYNTAX   TOSType
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The type of service metric  being  referenced.
++           On  row  creation, this can be derived from the
++           instance."
++       ::= { ospfIfMetricEntry 3 }
++
++
++    ospfIfMetricValue OBJECT-TYPE
++        SYNTAX   Metric
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The metric of using this type  of  service  on
++           this interface.  The default value of the TOS 0
++           Metric is 10^8 / ifSpeed."
++       ::= { ospfIfMetricEntry 4 }
++
++    ospfIfMetricStatus OBJECT-TYPE
++        SYNTAX   RowStatus
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "This variable displays the status of  the  en-
++           try.  Setting it to 'invalid' has the effect of
++           rendering it inoperative.  The internal  effect
++           (row removal) is implementation dependent."
++       ::= { ospfIfMetricEntry 5 }
++
++
++--  OSPF Virtual Interface Table
++
++--      The Virtual Interface Table describes the virtual
++--      links that the OSPF Process is configured to
++--      carry on.
++
++    ospfVirtIfTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF OspfVirtIfEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "Information about this router's virtual inter-
++           faces."
++       REFERENCE
++          "OSPF Version  2,  Appendix  C.4   Virtual  link
++          parameters"
++      ::= { ospf 9 }
++
++
++    ospfVirtIfEntry OBJECT-TYPE
++        SYNTAX   OspfVirtIfEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "Information about a single Virtual Interface."
++       INDEX { ospfVirtIfAreaId, ospfVirtIfNeighbor }
++       ::= { ospfVirtIfTable 1 }
++
++OspfVirtIfEntry ::=
++    SEQUENCE {
++        ospfVirtIfAreaId
++            AreaID,
++        ospfVirtIfNeighbor
++            RouterID,
++        ospfVirtIfTransitDelay
++            UpToMaxAge,
++        ospfVirtIfRetransInterval
++            UpToMaxAge,
++        ospfVirtIfHelloInterval
++            HelloRange,
++        ospfVirtIfRtrDeadInterval
++            PositiveInteger,
++        ospfVirtIfState
++            INTEGER,
++        ospfVirtIfEvents
++            Counter32,
++        ospfVirtIfAuthType
++            INTEGER,
++        ospfVirtIfAuthKey
++            OCTET STRING,
++        ospfVirtIfStatus
++            RowStatus
++              }
++
++    ospfVirtIfAreaId OBJECT-TYPE
++        SYNTAX   AreaID
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The  Transit  Area  that  the   Virtual   Link
++           traverses.  By definition, this is not 0.0.0.0"
++       ::= { ospfVirtIfEntry 1 }
++
++
++    ospfVirtIfNeighbor OBJECT-TYPE
++        SYNTAX   RouterID
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The Router ID of the Virtual Neighbor."
++       ::= { ospfVirtIfEntry 2 }
++
++
++    ospfVirtIfTransitDelay OBJECT-TYPE
++        SYNTAX   UpToMaxAge
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The estimated number of seconds  it  takes  to
++           transmit  a link- state update packet over this
++           interface."
++       DEFVAL { 1 }
++       ::= { ospfVirtIfEntry 3 }
++
++
++    ospfVirtIfRetransInterval OBJECT-TYPE
++        SYNTAX   UpToMaxAge
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The number of seconds between  link-state  ad-
++           vertisement  retransmissions,  for  adjacencies
++           belonging to this  interface.   This  value  is
++           also used when retransmitting database descrip-
++           tion  and  link-state  request  packets.   This
++           value  should  be well over the expected round-
++           trip time."
++       DEFVAL { 5 }
++       ::= { ospfVirtIfEntry 4 }
++
++
++    ospfVirtIfHelloInterval OBJECT-TYPE
++        SYNTAX   HelloRange
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The length of time, in  seconds,  between  the
++           Hello  packets that the router sends on the in-
++           terface.  This value must be the same  for  the
++           virtual neighbor."
++       DEFVAL { 10 }
++       ::= { ospfVirtIfEntry 5 }
++
++
++    ospfVirtIfRtrDeadInterval OBJECT-TYPE
++        SYNTAX   PositiveInteger
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The number of seconds that  a  router's  Hello
++           packets  have  not been seen before it's neigh-
++           bors declare the router down.  This  should  be
++           some  multiple  of  the  Hello  interval.  This
++           value must be the same for the  virtual  neigh-
++           bor."
++       DEFVAL { 60 }
++       ::= { ospfVirtIfEntry 6 }
++
++
++    ospfVirtIfState OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                    down (1),            -- these use the same encoding
++                    pointToPoint (4)     -- as the ospfIfTable
++                  }
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "OSPF virtual interface states."
++       DEFVAL   { down }
++       ::= { ospfVirtIfEntry 7 }
++
++
++    ospfVirtIfEvents OBJECT-TYPE
++        SYNTAX   Counter32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of state changes or error events on
++           this Virtual Link"
++       ::= { ospfVirtIfEntry 8 }
++
++
++    ospfVirtIfAuthKey OBJECT-TYPE
++        SYNTAX   OCTET STRING (SIZE(0..256))
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "If Authentication Type is simplePassword,  the
++           device  will left adjust and zero fill to 8 oc-
++           tets.
++
++           Note that unauthenticated  interfaces  need  no
++           authentication key, and simple password authen-
++           tication cannot use a key of more  than  8  oc-
++           tets.  Larger keys are useful only with authen-
++           tication mechanisms not specified in this docu-
++           ment.
++
++           When  read,  ospfVifAuthKey  always  returns  a
++           string of length zero."
++       REFERENCE
++          "OSPF Version 2, Section 9  The  Interface  Data
++          Structure"
++      DEFVAL   { '0000000000000000'H }    -- 0.0.0.0.0.0.0.0
++      ::= { ospfVirtIfEntry 9 }
++
++
++    ospfVirtIfStatus OBJECT-TYPE
++        SYNTAX   RowStatus
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "This variable displays the status of  the  en-
++           try.  Setting it to 'invalid' has the effect of
++           rendering it inoperative.  The internal  effect
++           (row removal) is implementation dependent."
++       ::= { ospfVirtIfEntry 10 }
++
++
++    ospfVirtIfAuthType OBJECT-TYPE
++        SYNTAX   INTEGER (0..255)
++                    -- none (0),
++                    -- simplePassword (1)
++                    -- md5 (2)
++                    -- reserved for specification by IANA (> 2)
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The authentication type specified for a virtu-
++           al  interface.  Additional authentication types
++           may be assigned locally."
++       REFERENCE
++          "OSPF Version 2, Appendix E Authentication"
++      DEFVAL { 0 }        -- no authentication, by default
++      ::= { ospfVirtIfEntry 11 }
++
++
++--  OSPF Neighbor Table
++
++--      The OSPF Neighbor Table describes all neighbors in
++--      the locality of the subject router.
++
++    ospfNbrTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF OspfNbrEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "A table of non-virtual neighbor information."
++       REFERENCE
++          "OSPF Version 2, Section 10  The  Neighbor  Data
++          Structure"
++      ::= { ospf 10 }
++
++
++    ospfNbrEntry OBJECT-TYPE
++        SYNTAX   OspfNbrEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "The information regarding a single neighbor."
++       REFERENCE
++          "OSPF Version 2, Section 10  The  Neighbor  Data
++          Structure"
++      INDEX { ospfNbrIpAddr, ospfNbrAddressLessIndex }
++      ::= { ospfNbrTable 1 }
++
++OspfNbrEntry ::=
++    SEQUENCE {
++        ospfNbrIpAddr
++            IpAddress,
++        ospfNbrAddressLessIndex
++            InterfaceIndex,
++        ospfNbrRtrId
++            RouterID,
++        ospfNbrOptions
++            Integer32,
++        ospfNbrPriority
++            DesignatedRouterPriority,
++        ospfNbrState
++            INTEGER,
++        ospfNbrEvents
++            Counter32,
++        ospfNbrLsRetransQLen
++            Gauge32,
++        ospfNbmaNbrStatus
++            RowStatus,
++        ospfNbmaNbrPermanence
++            INTEGER,
++        ospfNbrHelloSuppressed
++            TruthValue
++              }
++
++    ospfNbrIpAddr OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The IP address this neighbor is using  in  its
++           IP  Source  Address.  Note that, on addressless
++           links, this will not be 0.0.0.0,  but  the  ad-
++           dress of another of the neighbor's interfaces."
++       ::= { ospfNbrEntry 1 }
++
++
++    ospfNbrAddressLessIndex OBJECT-TYPE
++        SYNTAX   InterfaceIndex
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "On an interface having an  IP  Address,  zero.
++           On  addressless  interfaces,  the corresponding
++           value of ifIndex in the Internet Standard  MIB.
++           On  row  creation, this can be derived from the
++           instance."
++       ::= { ospfNbrEntry 2 }
++
++
++    ospfNbrRtrId OBJECT-TYPE
++        SYNTAX   RouterID
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "A 32-bit integer (represented as a type  IpAd-
++           dress)  uniquely  identifying  the  neighboring
++           router in the Autonomous System."
++       DEFVAL   { '00000000'H }    -- 0.0.0.0
++       ::= { ospfNbrEntry 3 }
++
++
++    ospfNbrOptions OBJECT-TYPE
++        SYNTAX   Integer32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "A Bit Mask corresponding to the neighbor's op-
++           tions field.
++
++           Bit 0, if set, indicates that the  system  will
++           operate  on  Type of Service metrics other than
++           TOS 0.  If zero, the neighbor will  ignore  all
++           metrics except the TOS 0 metric.
++
++           Bit 1, if set, indicates  that  the  associated
++           area  accepts and operates on external informa-
++           tion; if zero, it is a stub area.
++
++           Bit 2, if set, indicates that the system is ca-
++           pable  of routing IP Multicast datagrams; i.e.,
++           that it implements the Multicast Extensions  to
++           OSPF.
++
++           Bit 3, if set, indicates  that  the  associated
++           area  is  an  NSSA.  These areas are capable of
++           carrying type 7 external advertisements,  which
++           are  translated into type 5 external advertise-
++           ments at NSSA borders."
++       REFERENCE
++          "OSPF Version 2, Section 12.1.2 Options"
++      DEFVAL { 0 }
++      ::= { ospfNbrEntry 4 }
++
++
++    ospfNbrPriority OBJECT-TYPE
++        SYNTAX   DesignatedRouterPriority
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The priority of this neighbor in the designat-
++           ed router election algorithm.  The value 0 sig-
++           nifies that the neighbor is not eligible to be-
++           come  the  designated router on this particular
++           network."
++       DEFVAL { 1 }
++       ::= { ospfNbrEntry 5 }
++
++
++    ospfNbrState OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                    down (1),
++                    attempt (2),
++                    init (3),
++                    twoWay (4),
++                    exchangeStart (5),
++                    exchange (6),
++                    loading (7),
++                    full (8)
++                  }
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The State of the relationship with this Neigh-
++           bor."
++       REFERENCE
++          "OSPF Version 2, Section 10.1 Neighbor States"
++      DEFVAL   { down }
++      ::= { ospfNbrEntry 6 }
++
++
++    ospfNbrEvents OBJECT-TYPE
++        SYNTAX   Counter32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of times this neighbor relationship
++           has changed state, or an error has occurred."
++       ::= { ospfNbrEntry 7 }
++
++
++    ospfNbrLsRetransQLen OBJECT-TYPE
++        SYNTAX   Gauge32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The  current  length  of  the   retransmission
++           queue."
++       ::= { ospfNbrEntry 8 }
++
++
++    ospfNbmaNbrStatus OBJECT-TYPE
++        SYNTAX   RowStatus
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "This variable displays the status of  the  en-
++           try.  Setting it to 'invalid' has the effect of
++           rendering it inoperative.  The internal  effect
++           (row removal) is implementation dependent."
++       ::= { ospfNbrEntry 9 }
++
++
++    ospfNbmaNbrPermanence OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                    dynamic (1),        -- learned through protocol
++                    permanent (2)       -- configured address
++                  }
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "This variable displays the status of  the  en-
++           try.   'dynamic'  and  'permanent' refer to how
++           the neighbor became known."
++       DEFVAL { permanent }
++       ::= { ospfNbrEntry 10 }
++
++
++    ospfNbrHelloSuppressed OBJECT-TYPE
++        SYNTAX   TruthValue
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "Indicates whether Hellos are being  suppressed
++           to the neighbor"
++       ::= { ospfNbrEntry 11 }
++
++
++--  OSPF Virtual Neighbor Table
++
++--      This table describes all virtual neighbors.
++--      Since Virtual Links are configured in the
++--      virtual interface table, this table is read-only.
++
++    ospfVirtNbrTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF OspfVirtNbrEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "A table of virtual neighbor information."
++       REFERENCE
++          "OSPF Version 2, Section 15  Virtual Links"
++      ::= { ospf 11 }
++
++
++    ospfVirtNbrEntry OBJECT-TYPE
++        SYNTAX   OspfVirtNbrEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "Virtual neighbor information."
++       INDEX { ospfVirtNbrArea, ospfVirtNbrRtrId }
++       ::= { ospfVirtNbrTable 1 }
++
++OspfVirtNbrEntry ::=
++    SEQUENCE {
++        ospfVirtNbrArea
++            AreaID,
++        ospfVirtNbrRtrId
++            RouterID,
++        ospfVirtNbrIpAddr
++            IpAddress,
++        ospfVirtNbrOptions
++            Integer32,
++        ospfVirtNbrState
++            INTEGER,
++        ospfVirtNbrEvents
++            Counter32,
++        ospfVirtNbrLsRetransQLen
++            Gauge32,
++        ospfVirtNbrHelloSuppressed
++                TruthValue
++              }
++
++    ospfVirtNbrArea OBJECT-TYPE
++        SYNTAX   AreaID
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The Transit Area Identifier."
++       ::= { ospfVirtNbrEntry 1 }
++
++
++    ospfVirtNbrRtrId OBJECT-TYPE
++        SYNTAX   RouterID
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "A  32-bit  integer  uniquely  identifying  the
++           neighboring router in the Autonomous System."
++       ::= { ospfVirtNbrEntry 2 }
++
++
++    ospfVirtNbrIpAddr OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The IP address this Virtual  Neighbor  is  us-
++           ing."
++       ::= { ospfVirtNbrEntry 3 }
++
++
++    ospfVirtNbrOptions OBJECT-TYPE
++        SYNTAX   Integer32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "A Bit Mask corresponding to the neighbor's op-
++           tions field.
++
++           Bit 1, if set, indicates that the  system  will
++           operate  on  Type of Service metrics other than
++           TOS 0.  If zero, the neighbor will  ignore  all
++           metrics except the TOS 0 metric.
++
++           Bit 2, if set, indicates  that  the  system  is
++           Network  Multicast  capable; ie, that it imple-
++           ments OSPF Multicast Routing."
++       ::= { ospfVirtNbrEntry 4 }
++    ospfVirtNbrState OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                    down (1),
++                    attempt (2),
++                    init (3),
++                    twoWay (4),
++                    exchangeStart (5),
++                    exchange (6),
++                    loading (7),
++                    full (8)
++                  }
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The state of the  Virtual  Neighbor  Relation-
++           ship."
++       ::= { ospfVirtNbrEntry 5 }
++
++
++    ospfVirtNbrEvents OBJECT-TYPE
++        SYNTAX   Counter32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of  times  this  virtual  link  has
++           changed its state, or an error has occurred."
++       ::= { ospfVirtNbrEntry 6 }
++
++
++    ospfVirtNbrLsRetransQLen OBJECT-TYPE
++        SYNTAX   Gauge32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The  current  length  of  the   retransmission
++           queue."
++       ::= { ospfVirtNbrEntry 7 }
++
++
++    ospfVirtNbrHelloSuppressed OBJECT-TYPE
++        SYNTAX   TruthValue
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "Indicates whether Hellos are being  suppressed
++           to the neighbor"
++       ::= { ospfVirtNbrEntry 8 }
++
++--  OSPF Link State Database, External
++
++--      The Link State Database contains the Link State
++--      Advertisements from throughout the areas that the
++--      device is attached to.
++
++--             This table is identical to the OSPF LSDB Table in
++--      format, but contains only External Link State
++--             Advertisements.  The purpose is to allow external
++--      LSAs to be displayed once for the router rather
++--      than once in each non-stub area.
++
++    ospfExtLsdbTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF OspfExtLsdbEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "The OSPF Process's Links State Database."
++       REFERENCE
++          "OSPF Version 2, Section 12  Link  State  Adver-
++          tisements"
++      ::= { ospf 12 }
++
++
++    ospfExtLsdbEntry OBJECT-TYPE
++        SYNTAX   OspfExtLsdbEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "A single Link State Advertisement."
++       INDEX { ospfExtLsdbType, ospfExtLsdbLsid, ospfExtLsdbRouterId }
++       ::= { ospfExtLsdbTable 1 }
++
++OspfExtLsdbEntry ::=
++    SEQUENCE {
++        ospfExtLsdbType
++            INTEGER,
++        ospfExtLsdbLsid
++            IpAddress,
++        ospfExtLsdbRouterId
++            RouterID,
++        ospfExtLsdbSequence
++            Integer32,
++        ospfExtLsdbAge
++            Integer32,
++        ospfExtLsdbChecksum
++            Integer32,
++        ospfExtLsdbAdvertisement
++            OCTET STRING
++              }
++
++    ospfExtLsdbType OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                    asExternalLink (5)
++                  }
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The type  of  the  link  state  advertisement.
++           Each  link state type has a separate advertise-
++           ment format."
++       REFERENCE
++          "OSPF Version 2, Appendix A.4.1 The  Link  State
++          Advertisement header"
++      ::= { ospfExtLsdbEntry 1 }
++
++
++    ospfExtLsdbLsid OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The Link State ID is an LS Type Specific field
++           containing either a Router ID or an IP Address;
++           it identifies the piece of the  routing  domain
++           that is being described by the advertisement."
++       REFERENCE
++          "OSPF Version 2, Section 12.1.4 Link State ID"
++      ::= { ospfExtLsdbEntry 2 }
++
++
++    ospfExtLsdbRouterId OBJECT-TYPE
++        SYNTAX   RouterID
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The 32 bit number that uniquely identifies the
++           originating router in the Autonomous System."
++       REFERENCE
++          "OSPF Version 2, Appendix C.1 Global parameters"
++      ::= { ospfExtLsdbEntry 3 }
++
++--  Note that the OSPF Sequence Number is a 32 bit signed
++--  integer.  It starts with the value '80000001'h,
++--  or -'7FFFFFFF'h, and increments until '7FFFFFFF'h
++--  Thus, a typical sequence number will be very negative.
++    ospfExtLsdbSequence OBJECT-TYPE
++        SYNTAX   Integer32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The sequence number field is a  signed  32-bit
++           integer.   It  is used to detect old and dupli-
++           cate link state advertisements.  The  space  of
++           sequence  numbers  is  linearly  ordered.   The
++           larger the sequence number the more recent  the
++           advertisement."
++       REFERENCE
++          "OSPF Version  2,  Section  12.1.6  LS  sequence
++          number"
++      ::= { ospfExtLsdbEntry 4 }
++
++
++    ospfExtLsdbAge OBJECT-TYPE
++        SYNTAX   Integer32    -- Should be 0..MaxAge
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "This field is the age of the link state adver-
++           tisement in seconds."
++       REFERENCE
++          "OSPF Version 2, Section 12.1.1 LS age"
++      ::= { ospfExtLsdbEntry 5 }
++
++
++    ospfExtLsdbChecksum OBJECT-TYPE
++        SYNTAX   Integer32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "This field is the  checksum  of  the  complete
++           contents  of  the  advertisement, excepting the
++           age field.  The age field is excepted  so  that
++           an   advertisement's  age  can  be  incremented
++           without updating the  checksum.   The  checksum
++           used  is  the same that is used for ISO connec-
++           tionless datagrams; it is commonly referred  to
++           as the Fletcher checksum."
++       REFERENCE
++          "OSPF Version 2, Section 12.1.7 LS checksum"
++      ::= { ospfExtLsdbEntry 6 }
++
++
++    ospfExtLsdbAdvertisement OBJECT-TYPE
++        SYNTAX   OCTET STRING (SIZE(36))
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The entire Link State Advertisement, including
++           its header."
++       REFERENCE
++          "OSPF Version 2, Section 12  Link  State  Adver-
++          tisements"
++      ::= { ospfExtLsdbEntry 7 }
++
++
++--  OSPF Use of the CIDR Route Table
++
++ospfRouteGroup           OBJECT IDENTIFIER ::= { ospf 13 }
++
++-- The IP Forwarding Table defines a number of objects for use by
++-- the routing protocol to externalize its information.  Most of
++-- the variables (ipForwardDest, ipForwardMask, ipForwardPolicy,
++-- ipForwardNextHop, ipForwardIfIndex, ipForwardType,
++-- ipForwardProto, ipForwardAge, and ipForwardNextHopAS) are
++-- defined there.
++
++-- Those that leave some discretion are defined here.
++
++-- ipCidrRouteProto is, of course, ospf (13).
++
++-- ipCidrRouteAge is the time since the route was first calculated,
++-- as opposed to the time since the last SPF run.
++
++-- ipCidrRouteInfo is an OBJECT IDENTIFIER for use by the routing
++-- protocol.  The following values shall be found there depending
++-- on the way the route was calculated.
++
++ospfIntraArea      OBJECT IDENTIFIER ::= { ospfRouteGroup 1 }
++ospfInterArea      OBJECT IDENTIFIER ::= { ospfRouteGroup 2 }
++ospfExternalType1  OBJECT IDENTIFIER ::= { ospfRouteGroup 3 }
++ospfExternalType2  OBJECT IDENTIFIER ::= { ospfRouteGroup 4 }
++
++-- ipCidrRouteMetric1 is, by definition, the primary routing
++-- metric.  Therefore, it should be the metric that route
++-- selection is based on.  For intra-area and inter-area routes,
++-- it is an OSPF metric.  For External Type 1 (comparable value)
++-- routes, it is an OSPF metric plus the External Metric.  For
++-- external Type 2 (non-comparable value) routes, it is the
++-- external metric.
++
++-- ipCidrRouteMetric2 is, by definition, a secondary routing
++-- metric.  Therefore, it should be the metric that breaks a tie
++-- among routes having equal metric1 values and the same
++-- calculation rule.  For intra-area, inter-area routes, and
++-- External Type 1 (comparable value) routes, it is unused.  For
++-- external Type 2 (non-comparable value) routes, it is the metric
++-- to the AS border router.
++
++-- ipCidrRouteMetric3, ipCidrRouteMetric4, and ipCidrRouteMetric5 are
++-- unused.
++
++--
++--      The OSPF Area Aggregate Table
++--
++--      This table replaces the OSPF Area Summary Table, being an
++--      extension of that for CIDR routers.
++
++    ospfAreaAggregateTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF OspfAreaAggregateEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "A range of IP addresses  specified  by  an  IP
++           address/IP  network  mask  pair.   For example,
++           class B address range of X.X.X.X with a network
++           mask  of  255.255.0.0 includes all IP addresses
++           from X.X.0.0  to  X.X.255.255.   Note  that  if
++           ranges  are configured such that one range sub-
++           sumes  another  range  (e.g.,   10.0.0.0   mask
++           255.0.0.0  and  10.1.0.0 mask 255.255.0.0), the
++           most specific match is the preferred one."
++       REFERENCE
++          "OSPF Version 2, Appendix C.2  Area parameters"
++      ::= { ospf 14 }
++
++
++    ospfAreaAggregateEntry OBJECT-TYPE
++        SYNTAX   OspfAreaAggregateEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "A range of IP addresses  specified  by  an  IP
++           address/IP  network  mask  pair.   For example,
++           class B address range of X.X.X.X with a network
++           mask  of  255.255.0.0 includes all IP addresses
++           from X.X.0.0  to  X.X.255.255.   Note  that  if
++           ranges are range configured such that one range
++           subsumes another  range  (e.g.,  10.0.0.0  mask
++           255.0.0.0  and  10.1.0.0 mask 255.255.0.0), the
++           most specific match is the preferred one."
++       REFERENCE
++          "OSPF Version 2, Appendix C.2  Area parameters"
++      INDEX { ospfAreaAggregateAreaID, ospfAreaAggregateLsdbType,
++              ospfAreaAggregateNet, ospfAreaAggregateMask }
++      ::= { ospfAreaAggregateTable 1 }
++
++
++OspfAreaAggregateEntry ::=
++    SEQUENCE {
++        ospfAreaAggregateAreaID
++            AreaID,
++        ospfAreaAggregateLsdbType
++            INTEGER,
++        ospfAreaAggregateNet
++            IpAddress,
++        ospfAreaAggregateMask
++            IpAddress,
++        ospfAreaAggregateStatus
++            RowStatus,
++        ospfAreaAggregateEffect
++            INTEGER
++              }
++
++    ospfAreaAggregateAreaID OBJECT-TYPE
++        SYNTAX   AreaID
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The Area the Address Aggregate is to be  found
++           within."
++       REFERENCE
++          "OSPF Version 2, Appendix C.2 Area parameters"
++      ::= { ospfAreaAggregateEntry 1 }
++
++
++    ospfAreaAggregateLsdbType OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                    summaryLink (3),
++                    nssaExternalLink (7)
++                  }
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The type of the Address Aggregate.  This field
++           specifies  the  Lsdb type that this Address Ag-
++           gregate applies to."
++       REFERENCE
++          "OSPF Version 2, Appendix A.4.1 The  Link  State
++          Advertisement header"
++      ::= { ospfAreaAggregateEntry 2 }
++
++
++    ospfAreaAggregateNet OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The IP Address of the Net or Subnet  indicated
++           by the range."
++       REFERENCE
++          "OSPF Version 2, Appendix C.2 Area parameters"
++      ::= { ospfAreaAggregateEntry 3 }
++
++
++    ospfAreaAggregateMask OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The Subnet Mask that pertains to  the  Net  or
++           Subnet."
++       REFERENCE
++          "OSPF Version 2, Appendix C.2 Area parameters"
++      ::= { ospfAreaAggregateEntry 4 }
++
++
++    ospfAreaAggregateStatus OBJECT-TYPE
++        SYNTAX   RowStatus
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "This variable displays the status of  the  en-
++           try.  Setting it to 'invalid' has the effect of
++           rendering it inoperative.  The internal  effect
++           (row removal) is implementation dependent."
++       ::= { ospfAreaAggregateEntry 5 }
++
++
++    ospfAreaAggregateEffect OBJECT-TYPE
++        SYNTAX   INTEGER    {
++                    advertiseMatching (1),
++                    doNotAdvertiseMatching (2)
++                  }
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "Subnets subsumed by ranges either trigger  the
++           advertisement  of  the indicated aggregate (ad-
++           vertiseMatching), or result in the subnet's not
++           being advertised at all outside the area."
++       DEFVAL   { advertiseMatching }
++       ::= { ospfAreaAggregateEntry 6 }
++
++
++-- conformance information
++
++ospfConformance OBJECT IDENTIFIER ::= { ospf 15 }
++
++ospfGroups      OBJECT IDENTIFIER ::= { ospfConformance 1 }
++ospfCompliances OBJECT IDENTIFIER ::= { ospfConformance 2 }
++
++-- compliance statements
++
++    ospfCompliance MODULE-COMPLIANCE
++        STATUS  current
++        DESCRIPTION
++           "The compliance statement "
++       MODULE  -- this module
++       MANDATORY-GROUPS {
++                    ospfBasicGroup,
++                    ospfAreaGroup,
++                    ospfStubAreaGroup,
++                    ospfIfGroup,
++                    ospfIfMetricGroup,
++                    ospfVirtIfGroup,
++                    ospfNbrGroup,
++                    ospfVirtNbrGroup,
++                    ospfAreaAggregateGroup
++           }
++       ::= { ospfCompliances 1 }
++
++
++-- units of conformance
++
++    ospfBasicGroup    OBJECT-GROUP
++        OBJECTS {
++                    ospfRouterId,
++                    ospfAdminStat,
++                    ospfVersionNumber,
++                    ospfAreaBdrRtrStatus,
++                    ospfASBdrRtrStatus,
++                    ospfExternLsaCount,
++                    ospfExternLsaCksumSum,
++                    ospfTOSSupport,
++                    ospfOriginateNewLsas,
++                    ospfRxNewLsas,
++                    ospfExtLsdbLimit,
++                    ospfMulticastExtensions,
++                    ospfExitOverflowInterval,
++                    ospfDemandExtensions
++        }
++        STATUS  current
++        DESCRIPTION
++           "These objects are required for OSPF systems."
++       ::= { ospfGroups 1 }
++
++
++    ospfAreaGroup    OBJECT-GROUP
++        OBJECTS {
++                    ospfAreaId,
++                    ospfImportAsExtern,
++                    ospfSpfRuns,
++                    ospfAreaBdrRtrCount,
++                    ospfAsBdrRtrCount,
++                    ospfAreaLsaCount,
++                    ospfAreaLsaCksumSum,
++                    ospfAreaSummary,
++                    ospfAreaStatus
++        }
++        STATUS  current
++        DESCRIPTION
++           "These objects are required  for  OSPF  systems
++           supporting areas."
++       ::= { ospfGroups 2 }
++
++
++    ospfStubAreaGroup    OBJECT-GROUP
++        OBJECTS {
++                    ospfStubAreaId,
++                    ospfStubTOS,
++                    ospfStubMetric,
++                    ospfStubStatus,
++                    ospfStubMetricType
++        }
++        STATUS  current
++        DESCRIPTION
++           "These objects are required  for  OSPF  systems
++           supporting stub areas."
++       ::= { ospfGroups 3 }
++
++
++    ospfLsdbGroup    OBJECT-GROUP
++        OBJECTS {
++                    ospfLsdbAreaId,
++                    ospfLsdbType,
++                    ospfLsdbLsid,
++                    ospfLsdbRouterId,
++                    ospfLsdbSequence,
++                    ospfLsdbAge,
++                    ospfLsdbChecksum,
++                    ospfLsdbAdvertisement
++        }
++        STATUS  current
++        DESCRIPTION
++           "These objects are required  for  OSPF  systems
++           that display their link state database."
++       ::= { ospfGroups 4 }
++
++
++    ospfAreaRangeGroup    OBJECT-GROUP
++        OBJECTS {
++                    ospfAreaRangeAreaId,
++                    ospfAreaRangeNet,
++                    ospfAreaRangeMask,
++                    ospfAreaRangeStatus,
++                    ospfAreaRangeEffect
++        }
++        STATUS  obsolete
++        DESCRIPTION
++           "These objects are required for  non-CIDR  OSPF
++           systems that support multiple areas."
++       ::= { ospfGroups 5 }
++
++
++    ospfHostGroup    OBJECT-GROUP
++        OBJECTS {
++                    ospfHostIpAddress,
++                    ospfHostTOS,
++                    ospfHostMetric,
++                    ospfHostStatus,
++                    ospfHostAreaID
++        }
++        STATUS  current
++        DESCRIPTION
++           "These objects are required  for  OSPF  systems
++           that support attached hosts."
++       ::= { ospfGroups 6 }
++
++
++    ospfIfGroup    OBJECT-GROUP
++        OBJECTS {
++                    ospfIfIpAddress,
++                    ospfAddressLessIf,
++                    ospfIfAreaId,
++                    ospfIfType,
++                    ospfIfAdminStat,
++                    ospfIfRtrPriority,
++                    ospfIfTransitDelay,
++                    ospfIfRetransInterval,
++                    ospfIfHelloInterval,
++                    ospfIfRtrDeadInterval,
++                    ospfIfPollInterval,
++                    ospfIfState,
++                    ospfIfDesignatedRouter,
++                    ospfIfBackupDesignatedRouter,
++                    ospfIfEvents,
++                    ospfIfAuthType,
++                    ospfIfAuthKey,
++                    ospfIfStatus,
++                    ospfIfMulticastForwarding,
++                    ospfIfDemand
++        }
++        STATUS  current
++        DESCRIPTION
++           "These objects are required for OSPF systems."
++       ::= { ospfGroups 7 }
++
++
++    ospfIfMetricGroup    OBJECT-GROUP
++        OBJECTS {
++                    ospfIfMetricIpAddress,
++                    ospfIfMetricAddressLessIf,
++                    ospfIfMetricTOS,
++                    ospfIfMetricValue,
++                    ospfIfMetricStatus
++        }
++        STATUS  current
++        DESCRIPTION
++           "These objects are required for OSPF systems."
++       ::= { ospfGroups 8 }
++
++
++    ospfVirtIfGroup    OBJECT-GROUP
++        OBJECTS {
++                    ospfVirtIfAreaId,
++                    ospfVirtIfNeighbor,
++                    ospfVirtIfTransitDelay,
++                    ospfVirtIfRetransInterval,
++                    ospfVirtIfHelloInterval,
++                    ospfVirtIfRtrDeadInterval,
++                    ospfVirtIfState,
++                    ospfVirtIfEvents,
++                    ospfVirtIfAuthType,
++                    ospfVirtIfAuthKey,
++                    ospfVirtIfStatus
++        }
++        STATUS  current
++        DESCRIPTION
++           "These objects are required for OSPF systems."
++       ::= { ospfGroups 9 }
++
++
++    ospfNbrGroup    OBJECT-GROUP
++        OBJECTS {
++                    ospfNbrIpAddr,
++                    ospfNbrAddressLessIndex,
++                    ospfNbrRtrId,
++                    ospfNbrOptions,
++                    ospfNbrPriority,
++                    ospfNbrState,
++                    ospfNbrEvents,
++                    ospfNbrLsRetransQLen,
++                    ospfNbmaNbrStatus,
++                    ospfNbmaNbrPermanence,
++                    ospfNbrHelloSuppressed
++        }
++        STATUS  current
++        DESCRIPTION
++           "These objects are required for OSPF systems."
++       ::= { ospfGroups 10 }
++
++
++    ospfVirtNbrGroup    OBJECT-GROUP
++        OBJECTS {
++                    ospfVirtNbrArea,
++                    ospfVirtNbrRtrId,
++                    ospfVirtNbrIpAddr,
++                    ospfVirtNbrOptions,
++                    ospfVirtNbrState,
++                    ospfVirtNbrEvents,
++                    ospfVirtNbrLsRetransQLen,
++                    ospfVirtNbrHelloSuppressed
++        }
++        STATUS  current
++        DESCRIPTION
++           "These objects are required for OSPF systems."
++       ::= { ospfGroups 11 }
++
++
++    ospfExtLsdbGroup    OBJECT-GROUP
++        OBJECTS {
++                    ospfExtLsdbType,
++                    ospfExtLsdbLsid,
++                    ospfExtLsdbRouterId,
++                    ospfExtLsdbSequence,
++                    ospfExtLsdbAge,
++                    ospfExtLsdbChecksum,
++                    ospfExtLsdbAdvertisement
++        }
++        STATUS  current
++        DESCRIPTION
++           "These objects are required  for  OSPF  systems
++           that display their link state database."
++       ::= { ospfGroups 12 }
++
++
++    ospfAreaAggregateGroup    OBJECT-GROUP
++        OBJECTS {
++                    ospfAreaAggregateAreaID,
++                    ospfAreaAggregateLsdbType,
++                    ospfAreaAggregateNet,
++                    ospfAreaAggregateMask,
++                    ospfAreaAggregateStatus,
++                    ospfAreaAggregateEffect
++        }
++        STATUS  current
++        DESCRIPTION
++           "These objects are required for OSPF systems."
++       ::= { ospfGroups 13 }
++
++END
+--- /dev/null
++++ b/mibs/OSPF-TRAP-MIB.txt
+@@ -0,0 +1,443 @@
++OSPF-TRAP-MIB DEFINITIONS ::= BEGIN
++
++    IMPORTS
++            MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE, IpAddress
++                FROM SNMPv2-SMI
++            MODULE-COMPLIANCE, OBJECT-GROUP
++                FROM SNMPv2-CONF
++            ospfRouterId, ospfIfIpAddress, ospfAddressLessIf, ospfIfState,
++            ospfVirtIfAreaId, ospfVirtIfNeighbor, ospfVirtIfState,
++            ospfNbrIpAddr, ospfNbrAddressLessIndex, ospfNbrRtrId,
++            ospfNbrState, ospfVirtNbrArea, ospfVirtNbrRtrId, ospfVirtNbrState,
++            ospfLsdbType, ospfLsdbLsid, ospfLsdbRouterId, ospfLsdbAreaId,
++            ospfExtLsdbLimit, ospf
++                FROM OSPF-MIB;
++
++    ospfTrap MODULE-IDENTITY
++           LAST-UPDATED "9501201225Z" -- Fri Jan 20 12:25:50 PST 1995
++           ORGANIZATION "IETF OSPF Working Group"
++           CONTACT-INFO
++           "                      Fred Baker
++           Postal:                Cisco Systems
++                                  519 Lado Drive
++                                  Santa Barbara, California 93111
++           Tel:                   +1 805 681 0115
++           E-Mail:                fred@cisco.com
++
++                                  Rob Coltun
++           Postal:                RainbowBridge Communications
++           Tel:                   (301) 340-9416
++           E-Mail:                rcoltun@rainbow-bridge.com"
++       DESCRIPTION
++          "The MIB module to describe traps for  the  OSPF
++          Version 2 Protocol."
++      ::= { ospf 16 }
++
++-- Trap Support Objects
++
++--         The following are support objects for the OSPF traps.
++
++ospfTrapControl OBJECT IDENTIFIER ::= { ospfTrap 1 }
++ospfTraps OBJECT IDENTIFIER ::= { ospfTrap 2 }
++
++    ospfSetTrap OBJECT-TYPE
++        SYNTAX   OCTET STRING (SIZE(4))
++        MAX-ACCESS   read-write
++        STATUS   current
++        DESCRIPTION
++           "A four-octet string serving as a bit  map  for
++           the trap events defined by the OSPF traps. This
++           object is used to enable and  disable  specific
++           OSPF   traps   where  a  1  in  the  bit  field
++           represents enabled.  The right-most bit  (least
++           significant) represents trap 0."
++       ::= { ospfTrapControl 1 }
++
++
++    ospfConfigErrorType OBJECT-TYPE
++        SYNTAX   INTEGER   {
++                    badVersion (1),
++                    areaMismatch (2),
++                    unknownNbmaNbr (3), -- Router is Dr eligible
++                    unknownVirtualNbr (4),
++                    authTypeMismatch(5),
++                    authFailure (6),
++                    netMaskMismatch (7),
++                    helloIntervalMismatch (8),
++                    deadIntervalMismatch (9),
++                    optionMismatch (10) }
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "Potential types  of  configuration  conflicts.
++           Used  by the ospfConfigError and ospfConfigVir-
++           tError traps."
++   ::= { ospfTrapControl 2 }
++
++
++    ospfPacketType OBJECT-TYPE
++        SYNTAX   INTEGER   {
++                    hello (1),
++                    dbDescript (2),
++                    lsReq (3),
++                    lsUpdate (4),
++                    lsAck (5) }
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "OSPF packet types."
++   ::= { ospfTrapControl 3 }
++
++
++    ospfPacketSrc OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The IP address of an inbound packet that  can-
++           not be identified by a neighbor instance."
++       ::= { ospfTrapControl 4 }
++
++
++-- Traps
++
++
++    ospfIfStateChange NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfIfIpAddress,
++                    ospfAddressLessIf,
++                    ospfIfState   -- The new state
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfIfStateChange trap signifies that there
++           has been a change in the state of a non-virtual
++           OSPF interface. This trap should  be  generated
++           when  the interface state regresses (e.g., goes
++           from Dr to Down) or progresses  to  a  terminal
++           state  (i.e.,  Point-to-Point, DR Other, Dr, or
++           Backup)."
++   ::= { ospfTraps 16 }
++
++
++    ospfVirtIfStateChange NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfVirtIfAreaId,
++                    ospfVirtIfNeighbor,
++                    ospfVirtIfState  -- The new state
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfIfStateChange trap signifies that there
++           has  been a change in the state of an OSPF vir-
++           tual interface.
++           This trap should be generated when  the  inter-
++           face  state  regresses  (e.g., goes from Point-
++           to-Point to Down) or progresses to  a  terminal
++           state (i.e., Point-to-Point)."
++   ::= { ospfTraps 1 }
++
++
++    ospfNbrStateChange NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfNbrIpAddr,
++                    ospfNbrAddressLessIndex,
++                    ospfNbrRtrId,
++                    ospfNbrState  -- The new state
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An  ospfNbrStateChange  trap  signifies   that
++           there  has been a change in the state of a non-
++           virtual OSPF neighbor.   This  trap  should  be
++           generated  when  the  neighbor  state regresses
++           (e.g., goes from Attempt or Full  to  1-Way  or
++           Down)  or progresses to a terminal state (e.g.,
++           2-Way or Full).  When an  neighbor  transitions
++           from  or  to Full on non-broadcast multi-access
++           and broadcast networks, the trap should be gen-
++           erated  by the designated router.  A designated
++           router transitioning to Down will be  noted  by
++           ospfIfStateChange."
++   ::= { ospfTraps 2 }
++
++
++    ospfVirtNbrStateChange NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfVirtNbrArea,
++                    ospfVirtNbrRtrId,
++                    ospfVirtNbrState  -- The new state
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfIfStateChange trap signifies that there
++           has  been a change in the state of an OSPF vir-
++           tual neighbor.  This trap should  be  generated
++           when  the  neighbor state regresses (e.g., goes
++           from Attempt or  Full  to  1-Way  or  Down)  or
++           progresses to a terminal state (e.g., Full)."
++   ::= { ospfTraps 3 }
++    ospfIfConfigError NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfIfIpAddress,
++                    ospfAddressLessIf,
++                    ospfPacketSrc,  -- The source IP address
++                    ospfConfigErrorType, -- Type of error
++                    ospfPacketType
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfIfConfigError  trap  signifies  that  a
++           packet  has  been received on a non-virtual in-
++           terface  from  a  router  whose   configuration
++           parameters  conflict  with this router's confi-
++           guration parameters.  Note that the  event  op-
++           tionMismatch  should  cause  a  trap only if it
++           prevents an adjacency from forming."
++                  ::= { ospfTraps 4 }
++
++
++    ospfVirtIfConfigError NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfVirtIfAreaId,
++                    ospfVirtIfNeighbor,
++                    ospfConfigErrorType, -- Type of error
++                    ospfPacketType
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfConfigError trap signifies that a pack-
++           et  has  been  received  on a virtual interface
++           from a router  whose  configuration  parameters
++           conflict   with   this  router's  configuration
++           parameters.  Note that the event optionMismatch
++           should  cause a trap only if it prevents an ad-
++           jacency from forming."
++   ::= { ospfTraps 5 }
++
++
++    ospfIfAuthFailure NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfIfIpAddress,
++                    ospfAddressLessIf,
++                    ospfPacketSrc,  -- The source IP address
++                    ospfConfigErrorType, -- authTypeMismatch or
++                                         -- authFailure
++                    ospfPacketType
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfIfAuthFailure  trap  signifies  that  a
++           packet  has  been received on a non-virtual in-
++           terface from a router whose authentication  key
++           or  authentication  type  conflicts  with  this
++           router's authentication key  or  authentication
++           type."
++   ::= { ospfTraps 6 }
++
++
++    ospfVirtIfAuthFailure NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfVirtIfAreaId,
++                    ospfVirtIfNeighbor,
++                    ospfConfigErrorType, -- authTypeMismatch or
++                                         -- authFailure
++                    ospfPacketType
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfVirtIfAuthFailure trap signifies that a
++           packet has been received on a virtual interface
++           from a router whose authentication key  or  au-
++           thentication  type conflicts with this router's
++           authentication key or authentication type."
++   ::= { ospfTraps 7 }
++
++
++    ospfIfRxBadPacket NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfIfIpAddress,
++                    ospfAddressLessIf,
++                    ospfPacketSrc,  -- The source IP address
++                    ospfPacketType
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfIfRxBadPacket trap  signifies  that  an
++           OSPF  packet has been received on a non-virtual
++           interface that cannot be parsed."
++   ::= { ospfTraps 8 }
++
++    ospfVirtIfRxBadPacket NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfVirtIfAreaId,
++                    ospfVirtIfNeighbor,
++                    ospfPacketType
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfRxBadPacket trap signifies that an OSPF
++           packet has been received on a virtual interface
++           that cannot be parsed."
++   ::= { ospfTraps 9 }
++
++
++    ospfTxRetransmit NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfIfIpAddress,
++                    ospfAddressLessIf,
++                    ospfNbrRtrId, -- Destination
++                    ospfPacketType,
++                    ospfLsdbType,
++                    ospfLsdbLsid,
++                    ospfLsdbRouterId
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfTxRetransmit  trap  signifies  than  an
++           OSPF  packet  has  been retransmitted on a non-
++           virtual interface.  All packets that may be re-
++           transmitted  are associated with an LSDB entry.
++           The LS type, LS ID, and Router ID are  used  to
++           identify the LSDB entry."
++   ::= { ospfTraps 10 }
++
++
++    ospfVirtIfTxRetransmit NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfVirtIfAreaId,
++                    ospfVirtIfNeighbor,
++                    ospfPacketType,
++                    ospfLsdbType,
++                    ospfLsdbLsid,
++                    ospfLsdbRouterId
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfTxRetransmit  trap  signifies  than  an
++           OSPF packet has been retransmitted on a virtual
++           interface.  All packets that may be retransmit-
++           ted  are  associated with an LSDB entry. The LS
++           type, LS ID, and Router ID are used to identify
++           the LSDB entry."
++   ::= { ospfTraps 11 }
++
++
++    ospfOriginateLsa NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfLsdbAreaId,  -- 0.0.0.0 for AS Externals
++                    ospfLsdbType,
++                    ospfLsdbLsid,
++                    ospfLsdbRouterId
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfOriginateLsa trap signifies that a  new
++           LSA  has  been originated by this router.  This
++           trap should not be invoked for simple refreshes
++           of  LSAs  (which happesn every 30 minutes), but
++           instead will only be invoked  when  an  LSA  is
++           (re)originated due to a topology change.  Addi-
++           tionally, this trap does not include LSAs  that
++           are  being  flushed  because  they have reached
++           MaxAge."
++   ::= { ospfTraps 12 }
++
++
++    ospfMaxAgeLsa NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfLsdbAreaId,  -- 0.0.0.0 for AS Externals
++                    ospfLsdbType,
++                    ospfLsdbLsid,
++                    ospfLsdbRouterId
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfMaxAgeLsa trap signifies  that  one  of
++           the LSA in the router's link-state database has
++           aged to MaxAge."
++   ::= { ospfTraps 13 }
++
++
++    ospfLsdbOverflow NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfExtLsdbLimit
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfLsdbOverflow trap  signifies  that  the
++           number of LSAs in the router's link-state data-
++           base has exceeded ospfExtLsdbLimit."
++   ::= { ospfTraps 14 }
++
++
++    ospfLsdbApproachingOverflow NOTIFICATION-TYPE
++        OBJECTS {
++                    ospfRouterId, -- The originator of the trap
++                    ospfExtLsdbLimit
++                  }
++        STATUS             current
++        DESCRIPTION
++           "An ospfLsdbApproachingOverflow trap  signifies
++           that  the  number of LSAs in the router's link-
++           state database has exceeded ninety  percent  of
++           ospfExtLsdbLimit."
++   ::= { ospfTraps 15 }
++
++
++-- conformance information
++
++ospfTrapConformance OBJECT IDENTIFIER ::= { ospfTrap 3 }
++
++ospfTrapGroups      OBJECT IDENTIFIER ::= { ospfTrapConformance 1 }
++ospfTrapCompliances OBJECT IDENTIFIER ::= { ospfTrapConformance 2 }
++
++-- compliance statements
++
++    ospfTrapCompliance MODULE-COMPLIANCE
++        STATUS  current
++        DESCRIPTION
++           "The compliance statement "
++       MODULE  -- this module
++       MANDATORY-GROUPS { ospfTrapControlGroup }
++
++
++        GROUP       ospfTrapControlGroup
++        DESCRIPTION
++           "This group is optional but recommended for all
++           OSPF systems"
++       ::= { ospfTrapCompliances 1 }
++
++
++-- units of conformance
++
++    ospfTrapControlGroup    OBJECT-GROUP
++        OBJECTS {
++                           ospfSetTrap,
++                           ospfConfigErrorType,
++                           ospfPacketType,
++                           ospfPacketSrc
++        }
++        STATUS  current
++        DESCRIPTION
++           "These objects are required  to  control  traps
++           from OSPF systems."
++       ::= { ospfTrapGroups 1 }
++
++
++END
+--- /dev/null
++++ b/mibs/RIPv2-MIB.txt
+@@ -0,0 +1,530 @@
++   RIPv2-MIB DEFINITIONS ::= BEGIN
++
++   IMPORTS
++       MODULE-IDENTITY, OBJECT-TYPE, Counter32,
++       TimeTicks, IpAddress                     FROM SNMPv2-SMI
++       TEXTUAL-CONVENTION, RowStatus            FROM SNMPv2-TC
++       MODULE-COMPLIANCE, OBJECT-GROUP          FROM SNMPv2-CONF
++       mib-2                                    FROM RFC1213-MIB;
++
++   --  This MIB module uses the extended OBJECT-TYPE macro as
++   --  defined in [9].
++
++   rip2  MODULE-IDENTITY
++           LAST-UPDATED "9407272253Z"      -- Wed Jul 27 22:53:04 PDT 1994
++           ORGANIZATION "IETF RIP-II Working Group"
++           CONTACT-INFO
++          "       Fred Baker
++          Postal: Cisco Systems
++                  519 Lado Drive
++                  Santa Barbara, California 93111
++          Tel:    +1 805 681 0115
++          E-Mail: fbaker@cisco.com
++
++          Postal: Gary Malkin
++                  Xylogics, Inc.
++                  53 Third Avenue
++                  Burlington, MA  01803
++
++          Phone:  (617) 272-8140
++          EMail:  gmalkin@Xylogics.COM"
++      DESCRIPTION
++         "The MIB module to describe the RIP2 Version 2 Protocol"
++     ::= { mib-2 23 }
++
++ --  RIP-2 Management Information Base
++
++ -- the RouteTag type represents the contents of the
++ -- Route Domain field in the packet header or route entry.
++ -- The use of the Route Domain is deprecated.
++
++ RouteTag ::= TEXTUAL-CONVENTION
++     STATUS      current
++     DESCRIPTION
++        "the RouteTag type represents the contents of the Route Domain
++        field in the packet header or route entry"
++    SYNTAX      OCTET STRING (SIZE (2))
++
++--4.1 Global Counters
++
++--      The RIP-2 Globals Group.
++--      Implementation of this group is mandatory for systems
++--      which implement RIP-2.
++
++-- These counters are intended to facilitate debugging quickly
++-- changing routes or failing neighbors
++
++rip2Globals OBJECT IDENTIFIER ::= { rip2 1 }
++
++    rip2GlobalRouteChanges OBJECT-TYPE
++        SYNTAX   Counter32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of route changes made to the IP Route
++           Database by RIP.  This does not include the refresh
++           of a route's age."
++       ::= { rip2Globals 1 }
++
++    rip2GlobalQueries OBJECT-TYPE
++        SYNTAX   Counter32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of responses sent to RIP queries
++           from other systems."
++       ::= { rip2Globals 2 }
++
++--4.2 RIP Interface Tables
++
++--  RIP Interfaces Groups
++--  Implementation of these Groups is mandatory for systems
++--  which implement RIP-2.
++
++-- The RIP Interface Status Table.
++
++    rip2IfStatTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF Rip2IfStatEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "A list of subnets which require separate
++           status monitoring in RIP."
++       ::= { rip2 2 }
++
++   rip2IfStatEntry OBJECT-TYPE
++       SYNTAX   Rip2IfStatEntry
++       MAX-ACCESS   not-accessible
++       STATUS   current
++       DESCRIPTION
++          "A Single Routing Domain in a single Subnet."
++      INDEX { rip2IfStatAddress }
++      ::= { rip2IfStatTable 1 }
++
++    Rip2IfStatEntry ::=
++        SEQUENCE {
++            rip2IfStatAddress
++                IpAddress,
++            rip2IfStatRcvBadPackets
++                Counter32,
++            rip2IfStatRcvBadRoutes
++                Counter32,
++            rip2IfStatSentUpdates
++                Counter32,
++            rip2IfStatStatus
++                RowStatus
++    }
++
++    rip2IfStatAddress OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The IP Address of this system on the indicated
++           subnet. For unnumbered interfaces, the value 0.0.0.N,
++           where the least significant 24 bits (N) is the ifIndex
++           for the IP Interface in network byte order."
++       ::= { rip2IfStatEntry 1 }
++
++    rip2IfStatRcvBadPackets OBJECT-TYPE
++        SYNTAX   Counter32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of RIP response packets received by
++           the RIP process which were subsequently discarded
++           for any reason (e.g. a version 0 packet, or an
++           unknown command type)."
++       ::= { rip2IfStatEntry 2 }
++
++    rip2IfStatRcvBadRoutes OBJECT-TYPE
++        SYNTAX   Counter32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of routes, in valid RIP packets,
++           which were ignored for any reason (e.g. unknown
++           address family, or invalid metric)."
++       ::= { rip2IfStatEntry 3 }
++
++    rip2IfStatSentUpdates OBJECT-TYPE
++        SYNTAX   Counter32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of triggered RIP updates actually
++           sent on this interface.  This explicitly does
++           NOT include full updates sent containing new
++           information."
++       ::= { rip2IfStatEntry 4 }
++
++    rip2IfStatStatus OBJECT-TYPE
++        SYNTAX   RowStatus
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "Writing invalid has the effect of deleting
++           this interface."
++       ::= { rip2IfStatEntry 5 }
++
++-- The RIP Interface Configuration Table.
++
++    rip2IfConfTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF Rip2IfConfEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "A list of subnets which require separate
++           configuration in RIP."
++       ::= { rip2 3 }
++
++   rip2IfConfEntry OBJECT-TYPE
++       SYNTAX   Rip2IfConfEntry
++       MAX-ACCESS   not-accessible
++       STATUS   current
++       DESCRIPTION
++          "A Single Routing Domain in a single Subnet."
++      INDEX { rip2IfConfAddress }
++      ::= { rip2IfConfTable 1 }
++
++    Rip2IfConfEntry ::=
++        SEQUENCE {
++            rip2IfConfAddress
++                IpAddress,
++            rip2IfConfDomain
++                RouteTag,
++            rip2IfConfAuthType
++                INTEGER,
++            rip2IfConfAuthKey
++                OCTET STRING (SIZE(0..16)),
++            rip2IfConfSend
++                INTEGER,
++            rip2IfConfReceive
++                INTEGER,
++            rip2IfConfDefaultMetric
++                INTEGER,
++            rip2IfConfStatus
++                RowStatus,
++            rip2IfConfSrcAddress
++                IpAddress
++    }
++
++    rip2IfConfAddress OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The IP Address of this system on the indicated
++           subnet.  For unnumbered interfaces, the value 0.0.0.N,
++           where the least significant 24 bits (N) is the ifIndex
++           for the IP Interface in network byte order."
++       ::= { rip2IfConfEntry 1 }
++
++    rip2IfConfDomain OBJECT-TYPE
++        SYNTAX   RouteTag
++        MAX-ACCESS   read-create
++        STATUS   obsolete
++        DESCRIPTION
++           "Value inserted into the Routing Domain field
++           of all RIP packets sent on this interface."
++       DEFVAL { '0000'h }
++       ::= { rip2IfConfEntry 2 }
++
++    rip2IfConfAuthType OBJECT-TYPE
++        SYNTAX   INTEGER {
++                    noAuthentication (1),
++                    simplePassword (2),
++                    md5 (3)
++                 }
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The type of Authentication used on this
++           interface."
++       DEFVAL { noAuthentication }
++       ::= { rip2IfConfEntry 3 }
++
++    rip2IfConfAuthKey OBJECT-TYPE
++        SYNTAX   OCTET STRING (SIZE(0..16))
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The value to be used as the Authentication Key
++           whenever the corresponding instance of
++           rip2IfConfAuthType has a value other than
++           noAuthentication.  A modification of the corresponding
++           instance of rip2IfConfAuthType does not modify
++           the rip2IfConfAuthKey value.  If a string shorter
++           than 16 octets is supplied, it will be left-
++           justified and padded to 16 octets, on the right,
++           with nulls (0x00).
++
++           Reading this object always results in an  OCTET
++           STRING of length zero; authentication may not
++           be bypassed by reading the MIB object."
++       DEFVAL { ''h }
++       ::= { rip2IfConfEntry 4 }
++
++    rip2IfConfSend OBJECT-TYPE
++        SYNTAX   INTEGER {
++                    doNotSend (1),
++                    ripVersion1 (2),
++                    rip1Compatible (3),
++                    ripVersion2 (4),
++                    ripV1Demand (5),
++                    ripV2Demand (6)
++                 }
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "What the router sends on this interface.
++           ripVersion1 implies sending RIP updates compliant
++           with  RFC  1058.   rip1Compatible implies
++           broadcasting RIP-2 updates using RFC 1058 route
++           subsumption rules.  ripVersion2 implies
++           multicasting RIP-2 updates.  ripV1Demand indicates
++           the use of Demand RIP on a WAN interface under RIP
++           Version 1 rules.  ripV2Demand indicates the use of
++           Demand RIP on a WAN interface under Version 2 rules."
++       DEFVAL { rip1Compatible }
++       ::= { rip2IfConfEntry 5 }
++
++    rip2IfConfReceive OBJECT-TYPE
++        SYNTAX   INTEGER {
++                    rip1 (1),
++                    rip2 (2),
++                    rip1OrRip2 (3),
++                    doNotRecieve (4)
++                 }
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "This indicates which version of RIP updates
++           are to be accepted.  Note that rip2 and
++           rip1OrRip2 implies reception of multicast
++           packets."
++       DEFVAL { rip1OrRip2 }
++       ::= { rip2IfConfEntry 6 }
++
++    rip2IfConfDefaultMetric OBJECT-TYPE
++        SYNTAX   INTEGER ( 0..15 )
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "This variable indicates the metric that is to
++           be used for the default route entry in RIP updates
++           originated on this interface.  A value of zero
++           indicates that no default route should be
++           originated; in this case, a default route via
++           another router may be propagated."
++       ::= { rip2IfConfEntry 7 }
++
++    rip2IfConfStatus OBJECT-TYPE
++        SYNTAX   RowStatus
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "Writing invalid has  the  effect  of  deleting
++           this interface."
++       ::= { rip2IfConfEntry 8 }
++
++    rip2IfConfSrcAddress OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-create
++        STATUS   current
++        DESCRIPTION
++           "The IP Address this system will use as a source
++            address on this interface.  If it is a numbered
++            interface, this MUST be the same value as
++            rip2IfConfAddress.  On unnumbered interfaces,
++            it must be the value of rip2IfConfAddress for
++            some interface on the system."
++       ::= { rip2IfConfEntry 9 }
++
++--4.3 Peer Table
++
++--  Peer Table
++
++--      The RIP Peer Group
++--      Implementation of this Group is Optional
++
++--      This group provides information about active peer
++--      relationships intended to assist in debugging.  An
++--      active peer is a router from which a valid RIP
++--      updated has been heard in the last 180 seconds.
++
++    rip2PeerTable OBJECT-TYPE
++        SYNTAX   SEQUENCE OF Rip2PeerEntry
++        MAX-ACCESS   not-accessible
++        STATUS   current
++        DESCRIPTION
++           "A list of RIP Peers."
++       ::= { rip2 4 }
++
++   rip2PeerEntry OBJECT-TYPE
++       SYNTAX   Rip2PeerEntry
++       MAX-ACCESS   not-accessible
++       STATUS   current
++       DESCRIPTION
++          "Information regarding a single routing peer."
++      INDEX { rip2PeerAddress, rip2PeerDomain }
++      ::= { rip2PeerTable 1 }
++
++    Rip2PeerEntry ::=
++        SEQUENCE {
++            rip2PeerAddress
++                IpAddress,
++            rip2PeerDomain
++                RouteTag,
++            rip2PeerLastUpdate
++                TimeTicks,
++            rip2PeerVersion
++                INTEGER,
++            rip2PeerRcvBadPackets
++                Counter32,
++            rip2PeerRcvBadRoutes
++                Counter32
++            }
++
++    rip2PeerAddress OBJECT-TYPE
++        SYNTAX   IpAddress
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The IP Address that the peer is using as its source
++            address.  Note that on an unnumbered link, this may
++            not be a member of any subnet on the system."
++       ::= { rip2PeerEntry 1 }
++
++    rip2PeerDomain OBJECT-TYPE
++        SYNTAX   RouteTag
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The value in the Routing Domain field  in  RIP
++           packets received from the peer.  As domain suuport
++           is deprecated, this must be zero."
++       ::= { rip2PeerEntry 2 }
++
++    rip2PeerLastUpdate OBJECT-TYPE
++        SYNTAX   TimeTicks
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The value of sysUpTime when the most recent
++           RIP update was received from this system."
++       ::= { rip2PeerEntry 3 }
++
++    rip2PeerVersion OBJECT-TYPE
++        SYNTAX   INTEGER ( 0..255 )
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The RIP version number in the header of the
++           last RIP packet received."
++       ::= { rip2PeerEntry 4 }
++
++    rip2PeerRcvBadPackets OBJECT-TYPE
++        SYNTAX   Counter32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of RIP response packets from this
++           peer discarded as invalid."
++       ::= { rip2PeerEntry 5 }
++
++
++    rip2PeerRcvBadRoutes OBJECT-TYPE
++        SYNTAX   Counter32
++        MAX-ACCESS   read-only
++        STATUS   current
++        DESCRIPTION
++           "The number of routes from this peer that were
++           ignored because the entry format was invalid."
++       ::= { rip2PeerEntry 6 }
++
++-- conformance information
++
++rip2Conformance OBJECT IDENTIFIER ::= { rip2 5 }
++
++rip2Groups      OBJECT IDENTIFIER ::= { rip2Conformance 1 }
++rip2Compliances OBJECT IDENTIFIER ::= { rip2Conformance 2 }
++
++-- compliance statements
++rip2Compliance MODULE-COMPLIANCE
++    STATUS  current
++    DESCRIPTION
++       "The compliance statement "
++    MODULE  -- this module
++    MANDATORY-GROUPS {
++                 rip2GlobalGroup,
++                 rip2IfStatGroup,
++                 rip2IfConfGroup,
++                 rip2PeerGroup
++        }
++    GROUP       rip2GlobalGroup
++    DESCRIPTION
++       "This group defines global controls for RIP-II systems."
++    GROUP       rip2IfStatGroup
++    DESCRIPTION
++       "This group defines interface statistics for RIP-II systems."
++    GROUP       rip2IfConfGroup
++    DESCRIPTION
++       "This group defines interface configuration for RIP-II systems."
++    GROUP       rip2PeerGroup
++    DESCRIPTION
++       "This group defines peer information for RIP-II systems."
++    ::= { rip2Compliances 1 }
++
++-- units of conformance
++
++rip2GlobalGroup    OBJECT-GROUP
++    OBJECTS {
++                rip2GlobalRouteChanges,
++                rip2GlobalQueries
++    }
++    STATUS  current
++    DESCRIPTION
++       "This group defines global controls for RIP-II systems."
++    ::= { rip2Groups 1 }
++rip2IfStatGroup    OBJECT-GROUP
++    OBJECTS {
++            rip2IfStatAddress,
++            rip2IfStatRcvBadPackets,
++            rip2IfStatRcvBadRoutes,
++            rip2IfStatSentUpdates,
++            rip2IfStatStatus
++    }
++    STATUS  current
++    DESCRIPTION
++       "This group defines interface statistics for RIP-II systems."
++    ::= { rip2Groups 2 }
++rip2IfConfGroup    OBJECT-GROUP
++    OBJECTS {
++            rip2IfConfAddress,
++            rip2IfConfAuthType,
++            rip2IfConfAuthKey,
++            rip2IfConfSend,
++            rip2IfConfReceive,
++            rip2IfConfDefaultMetric,
++            rip2IfConfStatus,
++            rip2IfConfSrcAddress
++    }
++    STATUS  current
++    DESCRIPTION
++       "This group defines interface configuration for RIP-II systems."
++    ::= { rip2Groups 3 }
++rip2PeerGroup    OBJECT-GROUP
++    OBJECTS {
++            rip2PeerAddress,
++            rip2PeerDomain,
++            rip2PeerLastUpdate,
++            rip2PeerVersion,
++            rip2PeerRcvBadPackets,
++            rip2PeerRcvBadRoutes
++    }
++    STATUS  current
++    DESCRIPTION
++       "This group defines peer information for RIP-II systems."
++    ::= { rip2Groups 4 }
++END
+--- /dev/null
++++ b/mibs/SOURCE-ROUTING-MIB.txt
+@@ -0,0 +1,452 @@
++SOURCE-ROUTING-MIB DEFINITIONS ::= BEGIN
++
++IMPORTS
++        Counter, Gauge
++                FROM RFC1155-SMI
++        dot1dBridge, dot1dSr
++                FROM BRIDGE-MIB
++        OBJECT-TYPE
++                FROM RFC-1212;
++
++-- groups in the SR MIB
++
++-- dot1dSr is imported from the Bridge MIB
++
++dot1dPortPair   OBJECT IDENTIFIER ::= { dot1dBridge 10 }
++
++-- the dot1dSr group
++
++-- this group is implemented by those bridges that
++-- support the source route bridging mode, including Source
++-- Routing and SRT bridges.
++
++dot1dSrPortTable OBJECT-TYPE
++    SYNTAX  SEQUENCE OF Dot1dSrPortEntry
++    ACCESS  not-accessible
++    STATUS  mandatory
++    DESCRIPTION
++            "A table that contains information about every
++            port that is associated with this source route
++            bridge."
++    ::= { dot1dSr 1 }
++
++dot1dSrPortEntry OBJECT-TYPE
++    SYNTAX  Dot1dSrPortEntry
++    ACCESS  not-accessible
++    STATUS  mandatory
++    DESCRIPTION
++            "A list of information for each port of a source
++            route bridge."
++    INDEX   { dot1dSrPort }
++
++    ::= { dot1dSrPortTable 1 }
++
++Dot1dSrPortEntry ::=
++    SEQUENCE {
++        dot1dSrPort
++            INTEGER,
++        dot1dSrPortHopCount
++            INTEGER,
++        dot1dSrPortLocalSegment
++            INTEGER,
++        dot1dSrPortBridgeNum
++            INTEGER,
++        dot1dSrPortTargetSegment
++            INTEGER,
++        dot1dSrPortLargestFrame
++            INTEGER,
++        dot1dSrPortSTESpanMode
++            INTEGER,
++        dot1dSrPortSpecInFrames
++            Counter,
++        dot1dSrPortSpecOutFrames
++            Counter,
++        dot1dSrPortApeInFrames
++            Counter,
++        dot1dSrPortApeOutFrames
++            Counter,
++        dot1dSrPortSteInFrames
++            Counter,
++        dot1dSrPortSteOutFrames
++            Counter,
++        dot1dSrPortSegmentMismatchDiscards
++            Counter,
++        dot1dSrPortDuplicateSegmentDiscards
++            Counter,
++        dot1dSrPortHopCountExceededDiscards
++            Counter,
++        dot1dSrPortDupLanIdOrTreeErrors
++            Counter,
++        dot1dSrPortLanIdMismatches
++            Counter
++    }
++
++dot1dSrPort OBJECT-TYPE
++    SYNTAX  INTEGER (1..65535)
++    ACCESS  read-only
++    STATUS  mandatory
++    DESCRIPTION
++            "The port number of the port for which this entry
++
++            contains Source Route management information."
++    ::= { dot1dSrPortEntry 1 }
++
++dot1dSrPortHopCount OBJECT-TYPE
++    SYNTAX  INTEGER
++    ACCESS  read-write
++    STATUS  mandatory
++    DESCRIPTION
++            "The maximum number of routing descriptors allowed
++            in an All Paths or Spanning Tree Explorer frames."
++    ::= { dot1dSrPortEntry 2 }
++
++dot1dSrPortLocalSegment OBJECT-TYPE
++    SYNTAX  INTEGER
++    ACCESS  read-write
++    STATUS  mandatory
++    DESCRIPTION
++            "The segment number that uniquely identifies the
++            segment to which this port is connected. Current
++            source routing protocols limit this value to the
++            range: 0 through 4095. (The value 0 is used by
++            some management applications for special test
++            cases.) A value of 65535 signifies that no segment
++            number is assigned to this port."
++    ::= { dot1dSrPortEntry 3 }
++
++dot1dSrPortBridgeNum OBJECT-TYPE
++    SYNTAX  INTEGER
++    ACCESS  read-write
++    STATUS  mandatory
++    DESCRIPTION
++            "A bridge number uniquely identifies a bridge when
++            more than one bridge is used to span the same two
++            segments.  Current source routing protocols limit
++            this value to the range: 0 through 15. A value of
++            65535 signifies that no bridge number is assigned
++            to this bridge."
++    ::= { dot1dSrPortEntry 4 }
++
++dot1dSrPortTargetSegment OBJECT-TYPE
++    SYNTAX  INTEGER
++    ACCESS  read-write
++    STATUS  mandatory
++    DESCRIPTION
++            "The segment number that corresponds to the target
++            segment this port is considered to be connected to
++            by the bridge.  Current source routing protocols
++            limit this value to the range: 0 through 4095.
++
++            (The value 0 is used by some management
++            applications for special test cases.) A value of
++            65535 signifies that no target segment is assigned
++            to this port."
++    ::= { dot1dSrPortEntry 5 }
++
++-- It would be nice if we could use ifMtu as the size of the
++-- largest frame, but we can't because ifMtu is defined to be
++-- the size that the (inter-)network layer can use which can
++-- differ from the MAC layer (especially if several layers of
++-- encapsulation are used).
++
++dot1dSrPortLargestFrame OBJECT-TYPE
++    SYNTAX  INTEGER
++    ACCESS  read-write
++    STATUS  mandatory
++    DESCRIPTION
++            "The maximum size of the INFO field (LLC and
++            above) that this port can send/receive.  It does
++            not include any MAC level (framing) octets.  The
++            value of this object is used by this bridge to
++            determine whether a modification of the
++            LargestFrame (LF, see [14]) field of the Routing
++            Control field of the Routing Information Field is
++            necessary.
++
++            64 valid values are defined by the IEEE 802.5M SRT
++            Addendum: 516, 635, 754, 873, 993, 1112, 1231,
++            1350, 1470, 1542, 1615, 1688, 1761, 1833, 1906,
++            1979, 2052, 2345, 2638, 2932, 3225, 3518, 3812,
++            4105, 4399, 4865, 5331, 5798, 6264, 6730, 7197,
++            7663, 8130, 8539, 8949, 9358, 9768, 10178, 10587,
++            10997, 11407, 12199, 12992, 13785, 14578, 15370,
++            16163, 16956, 17749, 20730, 23711, 26693, 29674,
++            32655, 35637, 38618, 41600, 44591, 47583, 50575,
++            53567, 56559, 59551, and 65535.
++
++            An illegal value will not be accepted by the
++            bridge."
++    ::= { dot1dSrPortEntry 6 }
++
++dot1dSrPortSTESpanMode OBJECT-TYPE
++    SYNTAX  INTEGER {
++                auto-span(1),
++                disabled(2),
++                forced(3)
++            }
++    ACCESS  read-write
++    STATUS  mandatory
++    DESCRIPTION
++            "Determines how this port behaves when presented
++            with a Spanning Tree Explorer frame.  The value
++            'disabled(2)' indicates that the port will not
++            accept or send Spanning Tree Explorer packets; any
++            STE packets received will be silently discarded.
++            The value 'forced(3)' indicates the port will
++            always accept and propagate Spanning Tree Explorer
++            frames.  This allows a manually configured
++            Spanning Tree for this class of packet to be
++            configured.  Note that unlike transparent
++            bridging, this is not catastrophic to the network
++            if there are loops.  The value 'auto-span(1)' can
++            only be returned by a bridge that both implements
++            the Spanning Tree Protocol and has use of the
++            protocol enabled on this port. The behavior of the
++            port for Spanning Tree Explorer frames is
++            determined by the state of dot1dStpPortState.  If
++            the port is in the 'forwarding' state, the frame
++            will be accepted or propagated.  Otherwise, it
++            will be silently discarded."
++    ::= { dot1dSrPortEntry 7 }
++
++dot1dSrPortSpecInFrames OBJECT-TYPE
++    SYNTAX  Counter
++    ACCESS  read-only
++    STATUS  mandatory
++    DESCRIPTION
++            "The number of Specifically Routed frames, also
++            referred to as Source Routed Frames, that have
++            been received from this port's segment."
++    ::= { dot1dSrPortEntry 8 }
++
++dot1dSrPortSpecOutFrames OBJECT-TYPE
++    SYNTAX  Counter
++    ACCESS  read-only
++    STATUS  mandatory
++    DESCRIPTION
++            "The number of Specifically Routed frames, also
++            referred to as Source Routed Frames, that this
++            port has transmitted on its segment."
++    ::= { dot1dSrPortEntry 9 }
++
++dot1dSrPortApeInFrames OBJECT-TYPE
++    SYNTAX  Counter
++    ACCESS  read-only
++    STATUS  mandatory
++    DESCRIPTION
++            "The number of All Paths Explorer frames, also
++            referred to as All Routes Explorer frames, that
++            have been received by this port from its segment."
++    ::= { dot1dSrPortEntry 10 }
++
++dot1dSrPortApeOutFrames OBJECT-TYPE
++    SYNTAX  Counter
++    ACCESS  read-only
++    STATUS  mandatory
++    DESCRIPTION
++            "The number of all Paths Explorer Frames, also
++            referred to as All Routes Explorer frames, that
++            have been transmitted by this port on its
++            segment."
++    ::= { dot1dSrPortEntry 11 }
++
++dot1dSrPortSteInFrames OBJECT-TYPE
++    SYNTAX  Counter
++    ACCESS  read-only
++    STATUS  mandatory
++    DESCRIPTION
++            "The number of spanning tree explorer frames that
++            have been received by this port from its segment."
++    ::= { dot1dSrPortEntry 12 }
++
++dot1dSrPortSteOutFrames OBJECT-TYPE
++    SYNTAX  Counter
++    ACCESS  read-only
++    STATUS  mandatory
++    DESCRIPTION
++            "The number of spanning tree explorer frames that
++            have been transmitted by this port on its
++            segment."
++    ::= { dot1dSrPortEntry 13 }
++
++dot1dSrPortSegmentMismatchDiscards OBJECT-TYPE
++    SYNTAX  Counter
++    ACCESS  read-only
++    STATUS  mandatory
++    DESCRIPTION
++            "The number of explorer frames that have been
++            discarded by this port because the routing
++            descriptor field contained an invalid adjacent
++            segment value."
++    ::= { dot1dSrPortEntry 14 }
++
++dot1dSrPortDuplicateSegmentDiscards OBJECT-TYPE
++    SYNTAX  Counter
++    ACCESS  read-only
++    STATUS  mandatory
++    DESCRIPTION
++            "The number of frames that have been discarded by
++            this port because the routing descriptor field
++            contained a duplicate segment identifier."
++    ::= { dot1dSrPortEntry 15 }
++
++dot1dSrPortHopCountExceededDiscards OBJECT-TYPE
++    SYNTAX  Counter
++    ACCESS  read-only
++    STATUS  mandatory
++    DESCRIPTION
++            "The number of explorer frames that have been
++            discarded by this port because the Routing
++            Information Field has exceeded the maximum route
++            descriptor length."
++    ::= { dot1dSrPortEntry 16 }
++
++dot1dSrPortDupLanIdOrTreeErrors OBJECT-TYPE
++    SYNTAX  Counter
++    ACCESS  read-only
++    STATUS  mandatory
++    DESCRIPTION
++            "The number of duplicate LAN IDs or Tree errors.
++            This helps in detection of problems in networks
++            containing older IBM Source Routing Bridges."
++    ::= { dot1dSrPortEntry 17 }
++
++dot1dSrPortLanIdMismatches OBJECT-TYPE
++    SYNTAX  Counter
++    ACCESS  read-only
++    STATUS  mandatory
++    DESCRIPTION
++            "The number of ARE and STE frames that were
++            discarded because the last LAN ID in the routing
++            information field did not equal the LAN-in ID.
++            This error can occur in implementations which do
++            only a LAN-in ID and Bridge Number check instead
++            of a LAN-in ID, Bridge Number, and LAN-out ID
++            check before they forward broadcast frames."
++    ::= { dot1dSrPortEntry 18 }
++
++-- scalar object in dot1dSr
++
++dot1dSrBridgeLfMode OBJECT-TYPE
++    SYNTAX  INTEGER {
++                mode3(1),
++                mode6(2)
++            }
++    ACCESS  read-write
++    STATUS  mandatory
++    DESCRIPTION
++            "Indicates whether the bridge operates using older
++            3 bit length negotiation fields or the newer 6 bit
++            length field in its RIF."
++    ::= { dot1dSr 2 }
++
++-- The Port-Pair Database
++
++-- Implementation of this group is optional.
++
++-- This group is implemented by those bridges that support
++-- the direct multiport model of the source route bridging
++-- mode as defined in the IEEE 802.5 SRT Addendum to
++-- 802.1d.
++
++-- Bridges implementing this group may report 65535 for
++-- dot1dSrPortBridgeNumber and dot1dSrPortTargetSegment,
++-- indicating that those objects are not applicable.
++
++dot1dPortPairTableSize OBJECT-TYPE
++    SYNTAX  Gauge
++    ACCESS  read-only
++    STATUS  mandatory
++    DESCRIPTION
++            "The total number of entries in the Bridge Port
++            Pair Database."
++    ::= { dot1dPortPair 1 }
++
++-- the Bridge Port-Pair table
++
++-- this table represents port pairs within a bridge forming
++-- a unique bridge path, as defined in the IEEE 802.5M SRT
++-- Addendum.
++
++dot1dPortPairTable OBJECT-TYPE
++    SYNTAX  SEQUENCE OF Dot1dPortPairEntry
++    ACCESS  not-accessible
++    STATUS  mandatory
++    DESCRIPTION
++            "A table that contains information about every
++
++            port pair database entity associated with this
++            source routing bridge."
++    ::= { dot1dPortPair 2 }
++
++dot1dPortPairEntry OBJECT-TYPE
++    SYNTAX  Dot1dPortPairEntry
++    ACCESS  not-accessible
++    STATUS  mandatory
++    DESCRIPTION
++            "A list of information for each port pair entity
++            of a bridge."
++    INDEX   { dot1dPortPairLowPort, dot1dPortPairHighPort }
++    ::= { dot1dPortPairTable 1 }
++
++Dot1dPortPairEntry ::=
++    SEQUENCE {
++        dot1dPortPairLowPort
++            INTEGER,
++        dot1dPortPairHighPort
++            INTEGER,
++        dot1dPortPairBridgeNum
++            INTEGER,
++        dot1dPortPairBridgeState
++            INTEGER
++    }
++
++dot1dPortPairLowPort OBJECT-TYPE
++    SYNTAX  INTEGER (1..65535)
++    ACCESS  read-write
++    STATUS  mandatory
++    DESCRIPTION
++            "The port number of the lower numbered port for
++            which this entry contains port pair database
++            information."
++    ::= { dot1dPortPairEntry 1 }
++
++dot1dPortPairHighPort OBJECT-TYPE
++    SYNTAX  INTEGER (1..65535)
++    ACCESS  read-write
++    STATUS  mandatory
++    DESCRIPTION
++            "The port number of the higher numbered port for
++            which this entry contains port pair database
++            information."
++    ::= { dot1dPortPairEntry 2 }
++
++dot1dPortPairBridgeNum OBJECT-TYPE
++    SYNTAX  INTEGER
++
++    ACCESS  read-write
++    STATUS  mandatory
++    DESCRIPTION
++            "A bridge number that uniquely identifies the path
++            provided by this source routing bridge between the
++            segments connected to dot1dPortPairLowPort and
++            dot1dPortPairHighPort.  The purpose of bridge
++            number is to disambiguate between multiple paths
++            connecting the same two LANs."
++    ::= { dot1dPortPairEntry 3 }
++
++dot1dPortPairBridgeState OBJECT-TYPE
++    SYNTAX  INTEGER {
++                enabled(1),
++                disabled(2),
++                invalid(3)
++            }
++    ACCESS  read-write
++    STATUS  mandatory
++    DESCRIPTION
++            "The state of dot1dPortPairBridgeNum.  Writing
++            'invalid(3)' to this object removes the
++            corresponding entry."
++    ::= { dot1dPortPairEntry 4 }
++
++END

--- a/package/network/utils/net-snmp/patches/160-no_ldconfig.patch
+++ b/package/network/utils/net-snmp/patches/160-no_ldconfig.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -16599,7 +16599,7 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu
+   need_version=no
+   library_names_spec='$libname$release$shared_ext$versuffix $libname$release$shared_ext$major $libname$shared_ext'
+   soname_spec='$libname$release$shared_ext$major'
+-  finish_cmds='PATH="\$PATH:/sbin" ldconfig -n $libdir'
++  finish_cmds=''
+   shlibpath_var=LD_LIBRARY_PATH
+   shlibpath_overrides_runpath=no
+ 

--- a/package/network/utils/net-snmp/patches/161-project_types.patch
+++ b/package/network/utils/net-snmp/patches/161-project_types.patch
@@ -1,0 +1,11 @@
+--- a/configure.d/config_project_types
++++ b/configure.d/config_project_types
+@@ -66,7 +66,7 @@ netsnmp_save_CFLAGS=$CFLAGS
+ CFLAGS="$CFLAGS -Werror"
+ 
+ AC_MSG_CHECKING([for the type of fd_set::fds_bits])
+-for type in __fd_mask __int32_t unknown; do
++for type in fd_mask int32_t size_t; do
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+ #include <sys/select.h>
+ #include <stddef.h>

--- a/package/network/utils/net-snmp/patches/170-ldflags.patch
+++ b/package/network/utils/net-snmp/patches/170-ldflags.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.top
++++ b/Makefile.top
+@@ -87,7 +87,7 @@ LIBCURRENT  = 42
+ LIBAGE      = 2
+ LIBREVISION = 1
+ 
+-LIB_LD_CMD      = $(LIBTOOL) --mode=link $(LINKCC) $(CFLAGS) -rpath $(libdir) -version-info $(LIBCURRENT):$(LIBREVISION):$(LIBAGE) @LD_NO_UNDEFINED@ -o
++LIB_LD_CMD      = $(LIBTOOL) --mode=link $(LINKCC) $(CFLAGS) -rpath $(libdir) $(LDFLAGS) -version-info $(LIBCURRENT):$(LIBREVISION):$(LIBAGE) @LD_NO_UNDEFINED@ -o
+ LIB_EXTENSION   = la
+ LIB_VERSION     =
+ LIB_LDCONFIG_CMD = $(LIBTOOL) --mode=finish $(INSTALL_PREFIX)$(libdir)

--- a/package/network/utils/net-snmp/patches/200-add-pcre2-support.patch
+++ b/package/network/utils/net-snmp/patches/200-add-pcre2-support.patch
@@ -1,0 +1,407 @@
+From d3e95c87b32397815f6d5bcfc844259f2552697a Mon Sep 17 00:00:00 2001
+From: gagan sidhu <gagan@hotmail.com>
+Date: Sun, 21 May 2023 15:47:36 -0600
+Subject: [PATCH] add pcre2 support
+
+---
+ agent/mibgroup/host/data_access/swrun.c       | 29 ++++++++++--
+ agent/mibgroup/if-mib/data_access/interface.c | 47 ++++++++++++++++---
+ agent/mibgroup/struct.h                       |  2 +-
+ agent/mibgroup/ucd-snmp/proc.c                | 32 +++++++++----
+ agent/mibgroup/ucd-snmp/proc.h                |  2 +-
+ configure.d/config_os_libs1                   | 27 +++++++++++
+ configure.d/config_project_with_enable        |  4 ++
+ include/net-snmp/data_access/interface.h      |  9 +++-
+ include/net-snmp/data_access/swrun.h          |  2 +-
+ include/net-snmp/types.h                      |  2 +-
+ 10 files changed, 132 insertions(+), 24 deletions(-)
+
+--- a/agent/mibgroup/host/data_access/swrun.c
++++ b/agent/mibgroup/host/data_access/swrun.c
+@@ -17,7 +17,10 @@
+ #include "swrun.h"
+ #include "swrun_private.h"
+ 
+-#ifdef HAVE_PCRE_H
++#if defined(HAVE_PCRE2_H)
++#define PCRE2_CODE_UNIT_WIDTH 8
++#include <pcre2.h>
++#elif defined(HAVE_PCRE_H)
+ #include <pcre.h>
+ #endif
+ 
+@@ -100,32 +103,52 @@ swrun_max_processes( void )
+ #endif /* NETSNMP_FEATURE_REMOVE_SWRUN_MAX_PROCESSES */
+ 
+ #ifndef NETSNMP_FEATURE_REMOVE_SWRUN_COUNT_PROCESSES_BY_REGEX
+-#ifdef HAVE_PCRE_H
++#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
+ int
+ swrun_count_processes_by_regex( char *name, netsnmp_regex_ptr regexp )
+ {
+     netsnmp_swrun_entry *entry;
+     netsnmp_iterator  *it;
+     int i = 0;
++#ifdef HAVE_PCRE2_H
++    pcre2_match_data *ndx_match;
++    int *found_ndx;
++    ndx_match = pcre2_match_data_create(30, NULL);
++    found_ndx = pcre2_get_ovector_pointer(ndx_match);
++#elif defined(HAVE_PCRE_H)
+     int found_ndx[30];
++#endif
+     int found;
+     char fullCommand[64 + 128 + 128 + 3];
+ 
+     netsnmp_cache_check_and_reload(swrun_cache);
+     if ( !swrun_container || !name || !regexp.regex_ptr )
++#ifdef HAVE_PCRE2_H
++      { 
++        pcre2_match_data_free(ndx_match);
++        return 0;
++      }
++#else 
+         return 0;    /* or -1 */
++#endif
+ 
+     it = CONTAINER_ITERATOR( swrun_container );
+     while ((entry = (netsnmp_swrun_entry*)ITERATOR_NEXT( it )) != NULL) {
+         /* need to assemble full command back so regexps can get full picture */
+         sprintf(fullCommand, "%s %s", entry->hrSWRunPath, entry->hrSWRunParameters);
++#ifdef HAVE_PCRE2_H
++        found = pcre2_match(regexp.regex_ptr, fullCommand, strlen(fullCommand), 0, 0, ndx_match, NULL);
++#elif  HAVE_PCRE_H
+         found = pcre_exec(regexp.regex_ptr, NULL, fullCommand, strlen(fullCommand), 0, 0, found_ndx, 30);
++#endif
+         if (found > 0) {
+             i++;
+         }
+     }
+     ITERATOR_RELEASE( it );
+-
++#ifdef HAVE_PCRE2_H
++    pcre2_match_data_free(ndx_match);
++#endif
+     return i;
+ }
+ #endif /* HAVE_PCRE_H */
+--- a/agent/mibgroup/if-mib/data_access/interface.c
++++ b/agent/mibgroup/if-mib/data_access/interface.c
+@@ -16,7 +16,11 @@
+ #include "if-mib/ifTable/ifTable.h"
+ #include "if-mib/data_access/interface.h"
+ #include "interface_private.h"
+-#if defined(HAVE_PCRE_H)
++
++#if defined(HAVE_PCRE2_H)
++#define PCRE2_CODE_UNIT_WIDTH 8
++#include <pcre2.h>
++#elif defined(HAVE_PCRE_H)
+ #include <pcre.h>
+ #elif defined(HAVE_REGEX_H)
+ #include <sys/types.h>
+@@ -824,7 +828,13 @@ int netsnmp_access_interface_max_reached
+ int netsnmp_access_interface_include(const char *name)
+ {
+     netsnmp_include_if_list *if_ptr;
+-#ifdef HAVE_PCRE_H
++#if defined(HAVE_PCRE2_H) 
++    //pcre_exec->pcre2_match
++    //ovector->pcre2_match_data
++    pcre2_match_data *ndx_match;
++    ndx_match = pcre2_match_data_create(3, NULL);
++    int *found_ndx = pcre2_get_ovector_pointer(ndx_match);
++#elif defined(HAVE_PCRE_H)
+     int                      found_ndx[3];
+ #endif
+ 
+@@ -840,7 +850,13 @@ int netsnmp_access_interface_include(con
+ 
+ 
+     for (if_ptr = include_list; if_ptr; if_ptr = if_ptr->next) {
+-#if defined(HAVE_PCRE_H)
++#if defined(HAVE_PCRE2_H)
++        if (pcre2_match(if_ptr->regex_ptr, name, strlen(name), 0, 0, 
++                                ndx_match, NULL) >= 0)  {
++                pcre2_match_data_free(ndx_match);
++                return TRUE;
++        }
++#elif defined(HAVE_PCRE_H)
+         if (pcre_exec(if_ptr->regex_ptr, NULL, name, strlen(name), 0, 0,
+                       found_ndx, 3) >= 0)
+             return TRUE;
+@@ -853,6 +869,9 @@ int netsnmp_access_interface_include(con
+ #endif
+     }
+ 
++#if defined(HAVE_PCRE2_H)
++    pcre2_match_data_free(ndx_match);
++#endif
+     return FALSE;
+ }
+ 
+@@ -964,7 +983,13 @@ _parse_include_if_config(const char *tok
+ {
+     netsnmp_include_if_list *if_ptr, *if_new;
+     char                    *name, *st;
+-#if defined(HAVE_PCRE_H)
++#if defined(HAVE_PCRE2_H)
++    //we can only get the message upon calling pcre2_error_message.
++    // so an additional variable is required.
++    int                     pcre2_err_code;
++    unsigned char           pcre2_error[128];
++    int                     pcre2_error_offset;
++#elif defined(HAVE_PCRE_H)
+     const char              *pcre_error;
+     int                     pcre_error_offset;
+ #elif defined(HAVE_REGEX_H)
+@@ -996,7 +1021,15 @@ _parse_include_if_config(const char *tok
+             config_perror("Out of memory");
+             goto err;
+         }
+-#if defined(HAVE_PCRE_H)
++#if defined(HAVE_PCRE2_H)
++        if_new->regex_ptr = pcre2_compile(if_new->name, PCRE2_ZERO_TERMINATED, 0,
++                         &pcre2_err_code, &pcre2_error_offset, NULL);
++        if (!if_new->regex_ptr) {
++            pcre2_get_error_message(pcre2_err_code, pcre2_error, 128);
++            config_perror(pcre2_error);
++            goto err;
++        }
++#elif defined(HAVE_PCRE_H)
+         if_new->regex_ptr = pcre_compile(if_new->name, 0,  &pcre_error,
+                                          &pcre_error_offset, NULL);
+         if (!if_new->regex_ptr) {
+@@ -1032,7 +1065,7 @@ _parse_include_if_config(const char *tok
+ 
+ err:
+     if (if_new) {
+-#if defined(HAVE_PCRE_H) || defined(HAVE_REGEX_H)
++#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H) || defined(HAVE_REGEX_H)
+         free(if_new->regex_ptr);
+ #endif
+         free(if_new->name);
+@@ -1047,7 +1080,7 @@ _free_include_if_config(void)
+ 
+     while (if_ptr) {
+         if_next = if_ptr->next;
+-#if defined(HAVE_PCRE_H)
++#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
+         free(if_ptr->regex_ptr);
+ #elif defined(HAVE_REGEX_H)
+         regfree(if_ptr->regex_ptr);
+--- a/agent/mibgroup/struct.h
++++ b/agent/mibgroup/struct.h
+@@ -30,7 +30,7 @@ struct extensible {
+ 
+ struct myproc {
+     char            name[STRMAX];
+-#ifdef HAVE_PCRE_H
++#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
+     netsnmp_regex_ptr regexp;
+ #endif
+     char            fixcmd[STRMAX];
+--- a/agent/mibgroup/ucd-snmp/proc.c
++++ b/agent/mibgroup/ucd-snmp/proc.c
+@@ -39,7 +39,10 @@
+ #  include <time.h>
+ # endif
+ #endif
+-#ifdef HAVE_PCRE_H
++#ifdef HAVE_PCRE2_H
++#define PCRE2_CODE_UNIT_WIDTH 8
++#include <pcre2.h>
++#elifdef HAVE_PCRE_H
+ #include <pcre.h>
+ #endif
+ 
+@@ -108,7 +111,7 @@ init_proc(void)
+     REGISTER_MIB("ucd-snmp/proc", extensible_proc_variables, variable2,
+                  proc_variables_oid);
+ 
+-#ifdef HAVE_PCRE_H
++#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
+ #define proc_parse_usage "process-name [max-num] [min-num] [regexp]"
+ #else
+ #define proc_parse_usage "process-name [max-num] [min-num]"
+@@ -134,7 +137,7 @@ proc_free_config(void)
+     for (ptmp = procwatch; ptmp != NULL;) {
+         ptmp2 = ptmp;
+         ptmp = ptmp->next;
+-#ifdef HAVE_PCRE_H
++#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
+         free(ptmp2->regexp.regex_ptr);
+ #endif
+         free(ptmp2);
+@@ -208,7 +211,7 @@ proc_parse_config(const char *token, cha
+     if (*procp == NULL)
+         return;                 /* memory alloc error */
+     numprocs++;
+-#ifdef HAVE_PCRE_H
++#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
+     (*procp)->regexp.regex_ptr = NULL;
+ #endif
+     /*
+@@ -220,18 +223,31 @@ proc_parse_config(const char *token, cha
+         cptr = skip_not_white(cptr);
+         if ((cptr = skip_white(cptr))) {
+             (*procp)->min = atoi(cptr);
+-#ifdef HAVE_PCRE_H
++#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
+             cptr = skip_not_white(cptr);
+             if ((cptr = skip_white(cptr))) {
++                DEBUGMSGTL(("ucd-snmp/regexp_proc", "Loading regex %s\n", cptr));
++#ifdef HAVE_PCRE2_H
++                unsigned char pcre2_error_msg[128];
++                int pcre2_err_code;
++                int pcre2_error_offset;
++
++                (*procp)->regexp.regex_ptr =
++                    pcre2_compile(cptr, PCRE2_ZERO_TERMINATED, 0, &pcre2_err_code, &pcre2_error_offset, NULL);
++                pcre2_get_error_message(pcre2_err_code, pcre2_error_msg, 128);
++                if ((*procp)->regexp.regex_ptr == NULL) {
++                    config_perror(pcre2_error_msg);
++                }
++#elifdef HAVE_PCRE_H
+                 const char *pcre_error;
+                 int pcre_error_offset;
+ 
+-                DEBUGMSGTL(("ucd-snmp/regexp_proc", "Loading regex %s\n", cptr));
+                 (*procp)->regexp.regex_ptr =
+                     pcre_compile(cptr, 0,  &pcre_error, &pcre_error_offset, NULL);
+                 if ((*procp)->regexp.regex_ptr == NULL) {
+                     config_perror(pcre_error);
+                 }
++#endif
+             }
+ #endif
+         } else
+@@ -390,7 +406,7 @@ sh_count_myprocs(struct myproc *proc)
+     if (proc == NULL)
+         return 0;
+ 
+-#if defined(USING_HOST_DATA_ACCESS_SWRUN_MODULE) && defined(HAVE_PCRE_H)
++#if defined(USING_HOST_DATA_ACCESS_SWRUN_MODULE) && (defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H))
+     if (proc->regexp.regex_ptr != NULL)
+       return sh_count_procs_by_regex(proc->name, proc->regexp);
+ #endif
+@@ -406,7 +422,7 @@ sh_count_procs(char *procname)
+   return swrun_count_processes_by_name( procname );
+ }
+ 
+-#ifdef HAVE_PCRE_H
++#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
+ netsnmp_feature_require(swrun_count_processes_by_regex);
+ int
+ sh_count_procs_by_regex(char *procname, netsnmp_regex_ptr regexp)
+--- a/agent/mibgroup/ucd-snmp/proc.h
++++ b/agent/mibgroup/ucd-snmp/proc.h
+@@ -12,7 +12,7 @@ config_require(util_funcs);
+      extern WriteMethod fixProcError;
+      int sh_count_myprocs(struct myproc *);
+      int             sh_count_procs(char *);
+-#ifdef HAVE_PCRE_H
++#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
+      int sh_count_procs_by_regex(char *, netsnmp_regex_ptr);
+ #endif
+ 
+--- a/configure.d/config_os_libs1
++++ b/configure.d/config_os_libs1
+@@ -97,6 +97,32 @@ LIBS="$netsnmp_save_LIBS"
+ #
+ #   regex in process table
+ #
++if test "x$with_pcre2" != "xno"; then
++  AC_CHECK_HEADER([pcre2.h], [
++      AC_DEFINE([HAVE_PCRE2_H], [1], [Define to 1 if you have <pcre2.h>.])
++      pcre2_h=yes
++    ],
++    [pcre2_h=no], [#define PCRE2_CODE_UNIT_WIDTH 8]
++  )
++fi
++if test "x$pcre2header_h" = "xno" -o "x$pcre2_h" = "xno" ; then
++  if test "x$with_pcre2" = "xyes" ; then
++    AC_MSG_ERROR([Could not find the pcre2 header file needed and was specifically asked to use pcre2 support])
++  else
++    with_pcre2=no
++  fi
++fi
++
++if test "x$with_pcre2" != "xno"; then
++  NETSNMP_SEARCH_LIBS([pcre2_match_8], [pcre2-8], [
++    LMIBLIBS="$LMIBLIBS -lpcre2-8"
++    ],,, LAGENTLIBS)
++  AC_SUBST(LAGENTLIBS)
++  AC_SUBST(LMIBLIBS)
++fi
++
++if test "x$with_pcre2" != "xyes"; then
++
+ if test "x$with_pcre" != "xno"; then
+   AC_CHECK_HEADER([pcre.h], [
+       AC_DEFINE([HAVE_PCRE_H], [1], [Define to 1 if you have <pcre.h>.])
+@@ -123,3 +149,4 @@ if test "x$with_pcre" != "xno"; then
+   AC_SUBST(LAGENTLIBS)
+   AC_SUBST(LMIBLIBS)
+ fi
++fi
+--- a/configure.d/config_project_with_enable
++++ b/configure.d/config_project_with_enable
+@@ -160,6 +160,10 @@ NETSNMP_ARG_WITH(rpm,
+                                   management system when building the host MIB
+                                   module.])
+ 
++NETSNMP_ARG_WITH(pcre2-8,
++[  --without-pcre2                  Don't include pcre2 process searching
++                                  support in the agent.],
++      with_pcre2="$withval", with_pcre2="maybe")
+ 
+ NETSNMP_ARG_WITH(pcre,
+ [  --without-pcre                  Don't include pcre process searching
+--- a/include/net-snmp/data_access/interface.h
++++ b/include/net-snmp/data_access/interface.h
+@@ -10,7 +10,10 @@
+ extern          "C" {
+ #endif
+ 
+-#if defined(HAVE_PCRE_H)
++#if defined(HAVE_PCRE2_H)
++#define PCRE2_CODE_UNIT_WIDTH 8
++#include <pcre2.h>
++#elif defined(HAVE_PCRE_H)
+ #include <pcre.h>
+ #elif defined(HAVE_REGEX_H)
+ #include <regex.h>
+@@ -211,7 +214,9 @@ typedef struct _conf_if_list {
+     typedef netsnmp_conf_if_list conf_if_list; /* backwards compat */
+ 
+ typedef struct _include_if_list {
+-#if defined(HAVE_PCRE_H)
++#if defined(HAVE_PCRE2_H)
++    pcre2_code              *regex_ptr;
++#elif defined(HAVE_PCRE_H)
+     pcre                    *regex_ptr;
+ #elif defined(HAVE_REGEX_H)
+     regex_t                 *regex_ptr;
+--- a/include/net-snmp/data_access/swrun.h
++++ b/include/net-snmp/data_access/swrun.h
+@@ -90,7 +90,7 @@ extern "C" {
+     int  swrun_count_processes_by_name( char *name );
+ 
+ #if !defined(NETSNMP_FEATURE_REMOVE_SWRUN_COUNT_PROCESSES_BY_REGEX) \
+-    && defined(HAVE_PCRE_H)
++    && (defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H))
+     int  swrun_count_processes_by_regex(char *name, netsnmp_regex_ptr regexp);
+ #endif
+ 
+--- a/include/net-snmp/types.h
++++ b/include/net-snmp/types.h
+@@ -63,7 +63,7 @@ typedef long ssize_t;
+ typedef unsigned long int nfds_t;
+ #endif
+ 
+-#ifdef HAVE_PCRE_H
++#if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
+ /*
+  * Abstract the pcre typedef such that not all *.c files have to include
+  * <pcre.h>.

--- a/package/network/utils/net-snmp/patches/201-Run-autoreconf.patch
+++ b/package/network/utils/net-snmp/patches/201-Run-autoreconf.patch
@@ -1,0 +1,185 @@
+From 48b313ca34dbdf303fb232191d4f74e1d0fc9f06 Mon Sep 17 00:00:00 2001
+From: Bart Van Assche <bvanassche@acm.org>
+Date: Sun, 21 May 2023 16:20:15 -0700
+Subject: [PATCH] Run autoreconf
+
+---
+ configure                             | 126 ++++++++++++++++++++++++++
+ include/net-snmp/net-snmp-config.h.in |   3 +
+ 2 files changed, 129 insertions(+)
+
+--- a/configure
++++ b/configure
+@@ -928,6 +928,8 @@ with_dnssec
+ enable_dnssec
+ with_rpm
+ enable_rpm
++with_pcre2_8
++enable_pcre2_8
+ with_pcre
+ enable_pcre
+ with_install_prefix
+@@ -1851,6 +1853,8 @@ Compiler Options:
+   --without-rpm                   Don't include support for the RPM package
+                                   management system when building the host MIB
+                                   module.
++  --without-pcre2                  Don't include pcre2 process searching
++                                  support in the agent.
+   --without-pcre                  Don't include pcre process searching
+                                   support in the agent.
+   --with-install-prefix=PATH      Just for installing, prefix all
+@@ -5259,6 +5263,21 @@ fi
+ 
+ 
+ 
++# Check whether --with-pcre2-8 was given.
++if test ${with_pcre2_8+y}
++then :
++  withval=$with_pcre2_8; with_pcre2="$withval"
++else $as_nop
++  with_pcre2="maybe"
++fi
++
++   # Check whether --enable-pcre2-8 was given.
++if test ${enable_pcre2_8+y}
++then :
++  enableval=$enable_pcre2_8; as_fn_error $? "Invalid option. Use --with-pcre2-8/--without-pcre2-8 instead" "$LINENO" 5
++fi
++
++
+ 
+ # Check whether --with-pcre was given.
+ if test ${with_pcre+y}
+@@ -26477,6 +26496,112 @@ LIBS="$netsnmp_save_LIBS"
+ #
+ #   regex in process table
+ #
++if test "x$with_pcre2" != "xno"; then
++  ac_fn_c_check_header_compile "$LINENO" "pcre2.h" "ac_cv_header_pcre2_h" "#define PCRE2_CODE_UNIT_WIDTH 8
++
++"
++if test "x$ac_cv_header_pcre2_h" = xyes
++then :
++
++
++printf "%s\n" "#define HAVE_PCRE2_H 1" >>confdefs.h
++
++      pcre2_h=yes
++
++else $as_nop
++  pcre2_h=no
++fi
++
++fi
++if test "x$pcre2header_h" = "xno" -o "x$pcre2_h" = "xno" ; then
++  if test "x$with_pcre2" = "xyes" ; then
++    as_fn_error $? "Could not find the pcre2 header file needed and was specifically asked to use pcre2 support" "$LINENO" 5
++  else
++    with_pcre2=no
++  fi
++fi
++
++if test "x$with_pcre2" != "xno"; then
++
++ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing pcre2_match_8" >&5
++printf %s "checking for library containing pcre2_match_8... " >&6; }
++if test ${netsnmp_cv_func_pcre2_match_8_LAGENTLIBS+y}
++then :
++  printf %s "(cached) " >&6
++else $as_nop
++  netsnmp_func_search_save_LIBS="$LIBS"
++     netsnmp_target_val="$LAGENTLIBS"
++          netsnmp_temp_LIBS="${netsnmp_target_val}  ${LIBS}"
++     netsnmp_result=no
++     LIBS="${netsnmp_temp_LIBS}"
++     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++/* Override any GCC internal prototype to avoid an error.
++   Use char because int might match the return type of a GCC
++   builtin and then its argument prototype would still apply.  */
++char pcre2_match_8 ();
++int
++main (void)
++{
++return pcre2_match_8 ();
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"
++then :
++  netsnmp_result="none required"
++else $as_nop
++  for netsnmp_cur_lib in pcre2-8 ; do
++              LIBS="-l${netsnmp_cur_lib} ${netsnmp_temp_LIBS}"
++              cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++/* Override any GCC internal prototype to avoid an error.
++   Use char because int might match the return type of a GCC
++   builtin and then its argument prototype would still apply.  */
++char pcre2_match_8 ();
++int
++main (void)
++{
++return pcre2_match_8 ();
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_c_try_link "$LINENO"
++then :
++  netsnmp_result=-l${netsnmp_cur_lib}
++                   break
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
++    conftest$ac_exeext conftest.$ac_ext
++          done
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.beam \
++    conftest$ac_exeext conftest.$ac_ext
++     LIBS="${netsnmp_func_search_save_LIBS}"
++     netsnmp_cv_func_pcre2_match_8_LAGENTLIBS="${netsnmp_result}"
++fi
++{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $netsnmp_cv_func_pcre2_match_8_LAGENTLIBS" >&5
++printf "%s\n" "$netsnmp_cv_func_pcre2_match_8_LAGENTLIBS" >&6; }
++ if test "${netsnmp_cv_func_pcre2_match_8_LAGENTLIBS}" != "no" ; then
++    if test "${netsnmp_cv_func_pcre2_match_8_LAGENTLIBS}" != "none required" ; then
++       LAGENTLIBS="${netsnmp_result} ${netsnmp_target_val}"
++    fi
++
++    LMIBLIBS="$LMIBLIBS -lpcre2-8"
++
++
++ fi
++
++
++
++fi
++
++if test "x$with_pcre2" != "xyes"; then
++
+ if test "x$with_pcre" != "xno"; then
+   ac_fn_c_check_header_compile "$LINENO" "pcre.h" "ac_cv_header_pcre_h" "$ac_includes_default"
+ if test "x$ac_cv_header_pcre_h" = xyes
+@@ -31486,6 +31611,7 @@ printf "%s\n" "#define pid_t $ac_pid_typ
+ 
+ 
+ fi
++fi
+ 
+ 
+ 
+--- a/include/net-snmp/net-snmp-config.h.in
++++ b/include/net-snmp/net-snmp-config.h.in
+@@ -727,6 +727,9 @@
+ /* Define to 1 if you have the <pci/pci.h> header file. */
+ #undef HAVE_PCI_PCI_H
+ 
++/* Define to 1 if you have <pcre2.h>. */
++#undef HAVE_PCRE2_H
++
+ /* Define to 1 if you have <pcre.h>. */
+ #undef HAVE_PCRE_H
+ 

--- a/package/network/utils/net-snmp/patches/202-Improve-pcre2-support.patch
+++ b/package/network/utils/net-snmp/patches/202-Improve-pcre2-support.patch
@@ -1,0 +1,152 @@
+From 346b6f8959513320e5b674fd670c49ba2cd43af5 Mon Sep 17 00:00:00 2001
+From: Bart Van Assche <bvanassche@acm.org>
+Date: Sun, 21 May 2023 16:18:56 -0700
+Subject: [PATCH] Improve pcre2 support
+
+Fix compiler warnings. Convert C++ comments to C comments. Make sure that
+declarations occur before statements.
+---
+ agent/mibgroup/host/data_access/swrun.c       | 17 ++++------
+ agent/mibgroup/if-mib/data_access/interface.c | 32 ++++++++++---------
+ agent/mibgroup/ucd-snmp/proc.c                | 13 +++++---
+ 3 files changed, 31 insertions(+), 31 deletions(-)
+
+--- a/agent/mibgroup/host/data_access/swrun.c
++++ b/agent/mibgroup/host/data_access/swrun.c
+@@ -111,10 +111,7 @@ swrun_count_processes_by_regex( char *na
+     netsnmp_iterator  *it;
+     int i = 0;
+ #ifdef HAVE_PCRE2_H
+-    pcre2_match_data *ndx_match;
+-    int *found_ndx;
+-    ndx_match = pcre2_match_data_create(30, NULL);
+-    found_ndx = pcre2_get_ovector_pointer(ndx_match);
++    pcre2_match_data *ndx_match = pcre2_match_data_create(30, NULL);
+ #elif defined(HAVE_PCRE_H)
+     int found_ndx[30];
+ #endif
+@@ -122,22 +119,20 @@ swrun_count_processes_by_regex( char *na
+     char fullCommand[64 + 128 + 128 + 3];
+ 
+     netsnmp_cache_check_and_reload(swrun_cache);
+-    if ( !swrun_container || !name || !regexp.regex_ptr )
++    if ( !swrun_container || !name || !regexp.regex_ptr ) {
+ #ifdef HAVE_PCRE2_H
+-      { 
+         pcre2_match_data_free(ndx_match);
+-        return 0;
+-      }
+-#else 
+-        return 0;    /* or -1 */
+ #endif
++        return 0;    /* or -1 */
++    }
+ 
+     it = CONTAINER_ITERATOR( swrun_container );
+     while ((entry = (netsnmp_swrun_entry*)ITERATOR_NEXT( it )) != NULL) {
+         /* need to assemble full command back so regexps can get full picture */
+         sprintf(fullCommand, "%s %s", entry->hrSWRunPath, entry->hrSWRunParameters);
+ #ifdef HAVE_PCRE2_H
+-        found = pcre2_match(regexp.regex_ptr, fullCommand, strlen(fullCommand), 0, 0, ndx_match, NULL);
++        found = pcre2_match(regexp.regex_ptr, (unsigned char *)fullCommand,
++                            strlen(fullCommand), 0, 0, ndx_match, NULL);
+ #elif  HAVE_PCRE_H
+         found = pcre_exec(regexp.regex_ptr, NULL, fullCommand, strlen(fullCommand), 0, 0, found_ndx, 30);
+ #endif
+--- a/agent/mibgroup/if-mib/data_access/interface.c
++++ b/agent/mibgroup/if-mib/data_access/interface.c
+@@ -828,12 +828,8 @@ int netsnmp_access_interface_max_reached
+ int netsnmp_access_interface_include(const char *name)
+ {
+     netsnmp_include_if_list *if_ptr;
+-#if defined(HAVE_PCRE2_H) 
+-    //pcre_exec->pcre2_match
+-    //ovector->pcre2_match_data
+-    pcre2_match_data *ndx_match;
+-    ndx_match = pcre2_match_data_create(3, NULL);
+-    int *found_ndx = pcre2_get_ovector_pointer(ndx_match);
++#if defined(HAVE_PCRE2_H)
++    pcre2_match_data *ndx_match = pcre2_match_data_create(3, NULL);
+ #elif defined(HAVE_PCRE_H)
+     int                      found_ndx[3];
+ #endif
+@@ -851,8 +847,8 @@ int netsnmp_access_interface_include(con
+ 
+     for (if_ptr = include_list; if_ptr; if_ptr = if_ptr->next) {
+ #if defined(HAVE_PCRE2_H)
+-        if (pcre2_match(if_ptr->regex_ptr, name, strlen(name), 0, 0, 
+-                                ndx_match, NULL) >= 0)  {
++        if (pcre2_match(if_ptr->regex_ptr, (const unsigned char *)name,
++                        strlen(name), 0, 0, ndx_match, NULL) >= 0)  {
+                 pcre2_match_data_free(ndx_match);
+                 return TRUE;
+         }
+@@ -984,11 +980,13 @@ _parse_include_if_config(const char *tok
+     netsnmp_include_if_list *if_ptr, *if_new;
+     char                    *name, *st;
+ #if defined(HAVE_PCRE2_H)
+-    //we can only get the message upon calling pcre2_error_message.
+-    // so an additional variable is required.
++    /*
++     * We can only get the message upon calling pcre2_error_message.
++     * so an additional variable is required.
++     */
+     int                     pcre2_err_code;
+-    unsigned char           pcre2_error[128];
+-    int                     pcre2_error_offset;
++    char                    pcre2_error[128];
++    size_t                  pcre2_error_offset;
+ #elif defined(HAVE_PCRE_H)
+     const char              *pcre_error;
+     int                     pcre_error_offset;
+@@ -1022,10 +1020,14 @@ _parse_include_if_config(const char *tok
+             goto err;
+         }
+ #if defined(HAVE_PCRE2_H)
+-        if_new->regex_ptr = pcre2_compile(if_new->name, PCRE2_ZERO_TERMINATED, 0,
+-                         &pcre2_err_code, &pcre2_error_offset, NULL);
++        if_new->regex_ptr = pcre2_compile((const unsigned char *)if_new->name,
++                                          PCRE2_ZERO_TERMINATED, 0,
++                                          &pcre2_err_code, &pcre2_error_offset,
++                                          NULL);
+         if (!if_new->regex_ptr) {
+-            pcre2_get_error_message(pcre2_err_code, pcre2_error, 128);
++            pcre2_get_error_message(pcre2_err_code,
++                                    (unsigned char *)pcre2_error,
++                                    sizeof(pcre2_error));
+             config_perror(pcre2_error);
+             goto err;
+         }
+--- a/agent/mibgroup/ucd-snmp/proc.c
++++ b/agent/mibgroup/ucd-snmp/proc.c
+@@ -226,15 +226,17 @@ proc_parse_config(const char *token, cha
+ #if defined(HAVE_PCRE2_H) || defined(HAVE_PCRE_H)
+             cptr = skip_not_white(cptr);
+             if ((cptr = skip_white(cptr))) {
+-                DEBUGMSGTL(("ucd-snmp/regexp_proc", "Loading regex %s\n", cptr));
+ #ifdef HAVE_PCRE2_H
+-                unsigned char pcre2_error_msg[128];
++                char pcre2_error_msg[128];
+                 int pcre2_err_code;
+-                int pcre2_error_offset;
++                size_t pcre2_error_offset;
+ 
++                DEBUGMSGTL(("ucd-snmp/regexp_proc", "Loading regex %s\n", cptr));
+                 (*procp)->regexp.regex_ptr =
+-                    pcre2_compile(cptr, PCRE2_ZERO_TERMINATED, 0, &pcre2_err_code, &pcre2_error_offset, NULL);
+-                pcre2_get_error_message(pcre2_err_code, pcre2_error_msg, 128);
++                    pcre2_compile((const unsigned char *)cptr, PCRE2_ZERO_TERMINATED, 0, &pcre2_err_code, &pcre2_error_offset, NULL);
++                pcre2_get_error_message(pcre2_err_code,
++                                        (unsigned char *)pcre2_error_msg,
++                                        sizeof(pcre2_error_msg));
+                 if ((*procp)->regexp.regex_ptr == NULL) {
+                     config_perror(pcre2_error_msg);
+                 }
+@@ -242,6 +244,7 @@ proc_parse_config(const char *token, cha
+                 const char *pcre_error;
+                 int pcre_error_offset;
+ 
++                DEBUGMSGTL(("ucd-snmp/regexp_proc", "Loading regex %s\n", cptr));
+                 (*procp)->regexp.regex_ptr =
+                     pcre_compile(cptr, 0,  &pcre_error, &pcre_error_offset, NULL);
+                 if ((*procp)->regexp.regex_ptr == NULL) {

--- a/package/network/utils/net-snmp/patches/203-if-mib-data_access-interface.c-plug-a-leak-with-pcre.patch
+++ b/package/network/utils/net-snmp/patches/203-if-mib-data_access-interface.c-plug-a-leak-with-pcre.patch
@@ -1,0 +1,30 @@
+From e5aadf1e78c624a8e4147d4b70a7795497a50e73 Mon Sep 17 00:00:00 2001
+From: Niels Baggesen <nba@users.sourceforge.net>
+Date: Mon, 22 May 2023 18:44:36 +0200
+Subject: [PATCH] if-mib/data_access/interface.c: plug a leak with pcre2
+
+---
+ agent/mibgroup/if-mib/data_access/interface.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/agent/mibgroup/if-mib/data_access/interface.c
++++ b/agent/mibgroup/if-mib/data_access/interface.c
+@@ -829,7 +829,7 @@ int netsnmp_access_interface_include(con
+ {
+     netsnmp_include_if_list *if_ptr;
+ #if defined(HAVE_PCRE2_H)
+-    pcre2_match_data *ndx_match = pcre2_match_data_create(3, NULL);
++    pcre2_match_data *ndx_match;
+ #elif defined(HAVE_PCRE_H)
+     int                      found_ndx[3];
+ #endif
+@@ -844,6 +844,9 @@ int netsnmp_access_interface_include(con
+          */
+         return TRUE;
+ 
++#if defined(HAVE_PCRE2_H)
++    ndx_match = pcre2_match_data_create(3, NULL);
++#endif
+ 
+     for (if_ptr = include_list; if_ptr; if_ptr = if_ptr->next) {
+ #if defined(HAVE_PCRE2_H)

--- a/package/network/utils/net-snmp/patches/750-ieee802dot11.patch
+++ b/package/network/utils/net-snmp/patches/750-ieee802dot11.patch
@@ -1,0 +1,6166 @@
+--- /dev/null
++++ b/agent/mibgroup/ieee802dot11.c
+@@ -0,0 +1,4916 @@
++/****************************************************************************
++*                                                                           *
++*  File Name:           ieee802dot11.c                                      *
++*  Used By:                                                                 *
++*                                                                           *
++*  Operating System:                                                        *
++*  Purpose:                                                                 *
++*                                                                           *
++*  Comments:                                                                *
++*                                                                           *
++*  Author:              Larry Simmons                                       *
++*                       lsimmons@avantcom.com                               *
++*                       www.avantcom.com                                    *
++*                                                                           *
++*  Creation Date:       09/02/03                                            *
++*                                                                           *
++*   Ver    Date   Inits Modification                                        *
++*  ----- -------- ----- ------------                                        *
++*  0.0.1 09/02/03  LRS  created                                             *
++*  0.0.2 09/24/03  LRS  wouldn't build after fresh ./configure              *
++****************************************************************************/
++/****************************************************************************
++*                               Includes                                    *
++****************************************************************************/
++#include <net-snmp/net-snmp-config.h>
++#include <net-snmp/net-snmp-includes.h>
++#include <net-snmp/agent/net-snmp-agent-includes.h>
++#include "ieee802dot11.h"
++#include "iwlib.h"
++#include "util_funcs/header_generic.h"
++
++/****************************************************************************
++*                                Defines                                    *
++****************************************************************************/
++#define DISPLAYWIEXT                        // display wireless ext info
++#define TABLE_SIZE   1
++//#define MINLOADFREQ 15                    // min reload frequency in seconds
++#define MINLOADFREQ 5                       // min reload frequency in seconds      // for testing
++#define PROC_NET_DEV      "/proc/net/dev"
++#define PROC_NET_WIRELESS "/proc/net/wireless"
++
++#ifndef UCHAR
++  typedef unsigned char UCHAR;
++#endif
++
++/****************************************************************************
++*                            Private Functions                              *
++****************************************************************************/
++static void loadTables();
++static void loadWiExt ( int, char *, struct wireless_info * );
++static void load80211Structs ( int, char *, struct wireless_info * );
++static void initStructs();
++
++// Wireless Extensions Specific Functions
++static void loadWiExtTo80211Structs ( int, char *, struct wireless_info * );
++static void displayWiExt ( struct wireless_info );
++
++// Linked List Functions
++static void addList ( char *, char *, int );
++static void initLists();                    // initialize all the linked lists
++static void flushLists();                   // flush all the linked lists
++static void flushList ( char * );           // flush a single linked list
++
++// Utility Functions
++static int  openSocket ( void );
++static int  mWatt2dbm ( int );
++static char *htob ( char * );
++static int  hasChanged ( char *, int );
++
++/****************************************************************************
++*                            Private Variables                              *
++****************************************************************************/
++static unsigned long lastLoad = 0;          // ET in secs at last table load
++
++static struct avNode *lastNode, *newNode, *np;
++
++/****************************************************************************
++*                            External Functions                             *
++****************************************************************************/
++
++/****************************************************************************
++*   ieee802dot11_variables_oid:                                             *
++*       this is the top level oid that we want to register under.  This     *
++*       is essentially a prefix, with the suffix appearing in the           *
++*       variable below.                                                     *
++****************************************************************************/
++oid ieee802dot11_variables_oid[] = { 1,2,840,10036 };
++
++/****************************************************************************
++*   variable7 ieee802dot11_variables:                                       *
++*     this variable defines function callbacks and type return information  *
++*     for the ieee802dot11 mib section                                      *
++****************************************************************************/
++struct variable7 ieee802dot11_variables[] = {
++/*  magic number        , variable type , ro/rw , callback fn  , L, oidsuffix */
++#define   DOT11STATIONID        3
++  { DOT11STATIONID      , ASN_OCTET_STR , RWRITE, var_dot11StationConfigTable, 4, { 1,1,1,1 } },
++#define   DOT11MEDIUMOCCUPANCYLIMIT  4
++  { DOT11MEDIUMOCCUPANCYLIMIT, ASN_INTEGER   , RWRITE, var_dot11StationConfigTable, 4, { 1,1,1,2 } },
++#define   DOT11CFPOLLABLE       5
++  { DOT11CFPOLLABLE     , ASN_INTEGER   , RONLY , var_dot11StationConfigTable, 4, { 1,1,1,3 } },
++#define   DOT11CFPPERIOD        6
++  { DOT11CFPPERIOD      , ASN_INTEGER   , RWRITE, var_dot11StationConfigTable, 4, { 1,1,1,4 } },
++#define   DOT11CFPMAXDURATION   7
++  { DOT11CFPMAXDURATION , ASN_INTEGER   , RWRITE, var_dot11StationConfigTable, 4, { 1,1,1,5 } },
++#define   DOT11AUTHENTICATIONRESPONSETIMEOUT  8
++  { DOT11AUTHENTICATIONRESPONSETIMEOUT, ASN_INTEGER   , RWRITE, var_dot11StationConfigTable, 4, { 1,1,1,6 } },
++#define   DOT11PRIVACYOPTIONIMPLEMENTED  9
++  { DOT11PRIVACYOPTIONIMPLEMENTED, ASN_INTEGER   , RONLY , var_dot11StationConfigTable, 4, { 1,1,1,7 } },
++#define   DOT11POWERMANAGEMENTMODE  10
++  { DOT11POWERMANAGEMENTMODE, ASN_INTEGER   , RWRITE, var_dot11StationConfigTable, 4, { 1,1,1,8 } },
++#define   DOT11DESIREDSSID      11
++  { DOT11DESIREDSSID    , ASN_OCTET_STR , RWRITE, var_dot11StationConfigTable, 4, { 1,1,1,9 } },
++#define   DOT11DESIREDBSSTYPE   12
++  { DOT11DESIREDBSSTYPE , ASN_INTEGER   , RWRITE, var_dot11StationConfigTable, 4, { 1,1,1,10 } },
++#define   DOT11OPERATIONALRATESET  13
++  { DOT11OPERATIONALRATESET, ASN_OCTET_STR , RWRITE, var_dot11StationConfigTable, 4, { 1,1,1,11 } },
++#define   DOT11BEACONPERIOD     14
++  { DOT11BEACONPERIOD   , ASN_INTEGER   , RWRITE, var_dot11StationConfigTable, 4, { 1,1,1,12 } },
++#define   DOT11DTIMPERIOD       15
++  { DOT11DTIMPERIOD     , ASN_INTEGER   , RWRITE, var_dot11StationConfigTable, 4, { 1,1,1,13 } },
++#define   DOT11ASSOCIATIONRESPONSETIMEOUT  16
++  { DOT11ASSOCIATIONRESPONSETIMEOUT, ASN_INTEGER   , RWRITE, var_dot11StationConfigTable, 4, { 1,1,1,14 } },
++#define   DOT11DISASSOCIATEREASON  17
++  { DOT11DISASSOCIATEREASON, ASN_INTEGER   , RONLY , var_dot11StationConfigTable, 4, { 1,1,1,15 } },
++#define   DOT11DISASSOCIATESTATION  18
++  { DOT11DISASSOCIATESTATION, ASN_OCTET_STR , RONLY , var_dot11StationConfigTable, 4, { 1,1,1,16 } },
++#define   DOT11DEAUTHENTICATEREASON  19
++  { DOT11DEAUTHENTICATEREASON, ASN_INTEGER   , RONLY , var_dot11StationConfigTable, 4, { 1,1,1,17 } },
++#define   DOT11DEAUTHENTICATESTATION  20
++  { DOT11DEAUTHENTICATESTATION, ASN_OCTET_STR , RONLY , var_dot11StationConfigTable, 4, { 1,1,1,18 } },
++#define   DOT11AUTHENTICATEFAILSTATUS  21
++  { DOT11AUTHENTICATEFAILSTATUS, ASN_INTEGER   , RONLY , var_dot11StationConfigTable, 4, { 1,1,1,19 } },
++#define   DOT11AUTHENTICATEFAILSTATION  22
++  { DOT11AUTHENTICATEFAILSTATION, ASN_OCTET_STR , RONLY , var_dot11StationConfigTable, 4, { 1,1,1,20 } },
++
++#define   DOT11AUTHENTICATIONALGORITHM  26
++  { DOT11AUTHENTICATIONALGORITHM, ASN_INTEGER   , RONLY , var_dot11AuthenticationAlgorithmsTable, 4, { 1,2,1,2 } },
++#define   DOT11AUTHENTICATIONALGORITHMSENABLE  27
++  { DOT11AUTHENTICATIONALGORITHMSENABLE, ASN_INTEGER   , RWRITE, var_dot11AuthenticationAlgorithmsTable, 4, { 1,2,1,3 } },
++
++#define   DOT11WEPDEFAULTKEYVALUE  31
++  { DOT11WEPDEFAULTKEYVALUE, ASN_OCTET_STR , RWRITE, var_dot11WEPDefaultKeysTable, 4, { 1,3,1,2 } },
++
++#define   DOT11WEPKEYMAPPINGADDRESS  35
++  { DOT11WEPKEYMAPPINGADDRESS, ASN_OCTET_STR , RWRITE, var_dot11WEPKeyMappingsTable, 4, { 1,4,1,2 } },
++#define   DOT11WEPKEYMAPPINGWEPON  36
++  { DOT11WEPKEYMAPPINGWEPON, ASN_INTEGER   , RWRITE, var_dot11WEPKeyMappingsTable, 4, { 1,4,1,3 } },
++#define   DOT11WEPKEYMAPPINGVALUE  37
++  { DOT11WEPKEYMAPPINGVALUE, ASN_OCTET_STR , RWRITE, var_dot11WEPKeyMappingsTable, 4, { 1,4,1,4 } },
++#define   DOT11WEPKEYMAPPINGSTATUS  38
++  { DOT11WEPKEYMAPPINGSTATUS, ASN_INTEGER   , RWRITE, var_dot11WEPKeyMappingsTable, 4, { 1,4,1,5 } },
++
++#define   DOT11PRIVACYINVOKED   41
++  { DOT11PRIVACYINVOKED , ASN_INTEGER   , RWRITE, var_dot11PrivacyTable, 4, { 1,5,1,1 } },
++#define   DOT11WEPDEFAULTKEYID  42
++  { DOT11WEPDEFAULTKEYID, ASN_INTEGER   , RWRITE, var_dot11PrivacyTable, 4, { 1,5,1,2 } },
++#define   DOT11WEPKEYMAPPINGLENGTH  43
++  { DOT11WEPKEYMAPPINGLENGTH, ASN_INTEGER   , RWRITE, var_dot11PrivacyTable, 4, { 1,5,1,3 } },
++#define   DOT11EXCLUDEUNENCRYPTED  44
++  { DOT11EXCLUDEUNENCRYPTED, ASN_INTEGER   , RWRITE, var_dot11PrivacyTable, 4, { 1,5,1,4 } },
++#define   DOT11WEPICVERRORCOUNT  45
++  { DOT11WEPICVERRORCOUNT, ASN_COUNTER   , RONLY , var_dot11PrivacyTable, 4, { 1,5,1,5 } },
++#define   DOT11WEPEXCLUDEDCOUNT  46
++  { DOT11WEPEXCLUDEDCOUNT, ASN_COUNTER   , RONLY , var_dot11PrivacyTable, 4, { 1,5,1,6 } },
++
++#define   DOT11MACADDRESS       49
++  { DOT11MACADDRESS     , ASN_OCTET_STR , RONLY , var_dot11OperationTable, 4, { 2,1,1,1 } },
++#define   DOT11RTSTHRESHOLD     50
++  { DOT11RTSTHRESHOLD   , ASN_INTEGER   , RWRITE, var_dot11OperationTable, 4, { 2,1,1,2 } },
++#define   DOT11SHORTRETRYLIMIT  51
++  { DOT11SHORTRETRYLIMIT, ASN_INTEGER   , RWRITE, var_dot11OperationTable, 4, { 2,1,1,3 } },
++#define   DOT11LONGRETRYLIMIT   52
++  { DOT11LONGRETRYLIMIT , ASN_INTEGER   , RWRITE, var_dot11OperationTable, 4, { 2,1,1,4 } },
++#define   DOT11FRAGMENTATIONTHRESHOLD  53
++  { DOT11FRAGMENTATIONTHRESHOLD, ASN_INTEGER   , RWRITE, var_dot11OperationTable, 4, { 2,1,1,5 } },
++#define   DOT11MAXTRANSMITMSDULIFETIME  54
++  { DOT11MAXTRANSMITMSDULIFETIME, ASN_INTEGER   , RWRITE, var_dot11OperationTable, 4, { 2,1,1,6 } },
++#define   DOT11MAXRECEIVELIFETIME  55
++  { DOT11MAXRECEIVELIFETIME, ASN_INTEGER   , RWRITE, var_dot11OperationTable, 4, { 2,1,1,7 } },
++#define   DOT11MANUFACTURERID   56
++  { DOT11MANUFACTURERID , ASN_OCTET_STR , RONLY , var_dot11OperationTable, 4, { 2,1,1,8 } },
++#define   DOT11PRODUCTID        57
++  { DOT11PRODUCTID      , ASN_OCTET_STR , RONLY , var_dot11OperationTable, 4, { 2,1,1,9 } },
++
++#define   DOT11TRANSMITTEDFRAGMENTCOUNT  60
++  { DOT11TRANSMITTEDFRAGMENTCOUNT, ASN_COUNTER   , RONLY , var_dot11CountersTable, 4, { 2,2,1,1 } },
++#define   DOT11MULTICASTTRANSMITTEDFRAMECOUNT  61
++  { DOT11MULTICASTTRANSMITTEDFRAMECOUNT, ASN_COUNTER   , RONLY , var_dot11CountersTable, 4, { 2,2,1,2 } },
++#define   DOT11FAILEDCOUNT      62
++  { DOT11FAILEDCOUNT    , ASN_COUNTER   , RONLY , var_dot11CountersTable, 4, { 2,2,1,3 } },
++#define   DOT11RETRYCOUNT       63
++  { DOT11RETRYCOUNT     , ASN_COUNTER   , RONLY , var_dot11CountersTable, 4, { 2,2,1,4 } },
++#define   DOT11MULTIPLERETRYCOUNT  64
++  { DOT11MULTIPLERETRYCOUNT, ASN_COUNTER   , RONLY , var_dot11CountersTable, 4, { 2,2,1,5 } },
++#define   DOT11FRAMEDUPLICATECOUNT  65
++  { DOT11FRAMEDUPLICATECOUNT, ASN_COUNTER   , RONLY , var_dot11CountersTable, 4, { 2,2,1,6 } },
++#define   DOT11RTSSUCCESSCOUNT  66
++  { DOT11RTSSUCCESSCOUNT, ASN_COUNTER   , RONLY , var_dot11CountersTable, 4, { 2,2,1,7 } },
++#define   DOT11RTSFAILURECOUNT  67
++  { DOT11RTSFAILURECOUNT, ASN_COUNTER   , RONLY , var_dot11CountersTable, 4, { 2,2,1,8 } },
++#define   DOT11ACKFAILURECOUNT  68
++  { DOT11ACKFAILURECOUNT, ASN_COUNTER   , RONLY , var_dot11CountersTable, 4, { 2,2,1,9 } },
++#define   DOT11RECEIVEDFRAGMENTCOUNT  69
++  { DOT11RECEIVEDFRAGMENTCOUNT, ASN_COUNTER   , RONLY , var_dot11CountersTable, 4, { 2,2,1,10 } },
++#define   DOT11MULTICASTRECEIVEDFRAMECOUNT  70
++  { DOT11MULTICASTRECEIVEDFRAMECOUNT, ASN_COUNTER   , RONLY , var_dot11CountersTable, 4, { 2,2,1,11 } },
++#define   DOT11FCSERRORCOUNT    71
++  { DOT11FCSERRORCOUNT  , ASN_COUNTER   , RONLY , var_dot11CountersTable, 4, { 2,2,1,12 } },
++#define   DOT11TRANSMITTEDFRAMECOUNT  72
++  { DOT11TRANSMITTEDFRAMECOUNT, ASN_COUNTER   , RONLY , var_dot11CountersTable, 4, { 2,2,1,13 } },
++#define   DOT11WEPUNDECRYPTABLECOUNT  73
++  { DOT11WEPUNDECRYPTABLECOUNT, ASN_COUNTER   , RONLY , var_dot11CountersTable, 4, { 2,2,1,14 } },
++
++#define   DOT11ADDRESS          77
++  { DOT11ADDRESS        , ASN_OCTET_STR , RWRITE, var_dot11GroupAddressesTable, 4, { 2,3,1,2 } },
++#define   DOT11GROUPADDRESSESSTATUS  78
++  { DOT11GROUPADDRESSESSTATUS, ASN_INTEGER   , RWRITE, var_dot11GroupAddressesTable, 4, { 2,3,1,3 } },
++
++#define   DOT11RESOURCETYPEIDNAME  79
++  { DOT11RESOURCETYPEIDNAME, ASN_OCTET_STR , RONLY , var_ieee802dot11, 3, { 3,1,1 } },
++#define   DOT11MANUFACTUREROUI  82
++  { DOT11MANUFACTUREROUI, ASN_OCTET_STR , RONLY , var_dot11ResourceInfoTable, 5, { 3,1,2,1,1 } },
++#define   DOT11MANUFACTURERNAME  83
++  { DOT11MANUFACTURERNAME, ASN_OCTET_STR , RONLY , var_dot11ResourceInfoTable, 5, { 3,1,2,1,2 } },
++#define   DOT11MANUFACTURERPRODUCTNAME  84
++  { DOT11MANUFACTURERPRODUCTNAME, ASN_OCTET_STR , RONLY , var_dot11ResourceInfoTable, 5, { 3,1,2,1,3 } },
++#define   DOT11MANUFACTURERPRODUCTVERSION  85
++  { DOT11MANUFACTURERPRODUCTVERSION, ASN_OCTET_STR , RONLY , var_dot11ResourceInfoTable, 5, { 3,1,2,1,4 } },
++
++#define   DOT11PHYTYPE          88
++  { DOT11PHYTYPE        , ASN_INTEGER   , RONLY , var_dot11PhyOperationTable, 4, { 4,1,1,1 } },
++#define   DOT11CURRENTREGDOMAIN  89
++  { DOT11CURRENTREGDOMAIN, ASN_INTEGER   , RWRITE, var_dot11PhyOperationTable, 4, { 4,1,1,2 } },
++#define   DOT11TEMPTYPE         90
++  { DOT11TEMPTYPE       , ASN_INTEGER   , RONLY , var_dot11PhyOperationTable, 4, { 4,1,1,3 } },
++#define   DOT11CURRENTTXANTENNA  93
++  { DOT11CURRENTTXANTENNA, ASN_INTEGER   , RWRITE, var_dot11PhyAntennaTable, 4, { 4,2,1,1 } },
++#define   DOT11DIVERSITYSUPPORT  94
++  { DOT11DIVERSITYSUPPORT, ASN_INTEGER   , RONLY , var_dot11PhyAntennaTable, 4, { 4,2,1,2 } },
++#define   DOT11CURRENTRXANTENNA  95
++  { DOT11CURRENTRXANTENNA, ASN_INTEGER   , RWRITE, var_dot11PhyAntennaTable, 4, { 4,2,1,3 } },
++#define   DOT11NUMBERSUPPORTEDPOWERLEVELS  98
++  { DOT11NUMBERSUPPORTEDPOWERLEVELS, ASN_INTEGER   , RONLY , var_dot11PhyTxPowerTable, 4, { 4,3,1,1 } },
++#define   DOT11TXPOWERLEVEL1    99
++  { DOT11TXPOWERLEVEL1  , ASN_INTEGER   , RONLY , var_dot11PhyTxPowerTable, 4, { 4,3,1,2 } },
++#define   DOT11TXPOWERLEVEL2    100
++  { DOT11TXPOWERLEVEL2  , ASN_INTEGER   , RONLY , var_dot11PhyTxPowerTable, 4, { 4,3,1,3 } },
++#define   DOT11TXPOWERLEVEL3    101
++  { DOT11TXPOWERLEVEL3  , ASN_INTEGER   , RONLY , var_dot11PhyTxPowerTable, 4, { 4,3,1,4 } },
++#define   DOT11TXPOWERLEVEL4    102
++  { DOT11TXPOWERLEVEL4  , ASN_INTEGER   , RONLY , var_dot11PhyTxPowerTable, 4, { 4,3,1,5 } },
++#define   DOT11TXPOWERLEVEL5    103
++  { DOT11TXPOWERLEVEL5  , ASN_INTEGER   , RONLY , var_dot11PhyTxPowerTable, 4, { 4,3,1,6 } },
++#define   DOT11TXPOWERLEVEL6    104
++  { DOT11TXPOWERLEVEL6  , ASN_INTEGER   , RONLY , var_dot11PhyTxPowerTable, 4, { 4,3,1,7 } },
++#define   DOT11TXPOWERLEVEL7    105
++  { DOT11TXPOWERLEVEL7  , ASN_INTEGER   , RONLY , var_dot11PhyTxPowerTable, 4, { 4,3,1,8 } },
++#define   DOT11TXPOWERLEVEL8    106
++  { DOT11TXPOWERLEVEL8  , ASN_INTEGER   , RONLY , var_dot11PhyTxPowerTable, 4, { 4,3,1,9 } },
++#define   DOT11CURRENTTXPOWERLEVEL  107
++  { DOT11CURRENTTXPOWERLEVEL, ASN_INTEGER   , RWRITE, var_dot11PhyTxPowerTable, 4, { 4,3,1,10 } },
++
++#define   DOT11HOPTIME          110
++  { DOT11HOPTIME        , ASN_INTEGER   , RONLY , var_dot11PhyFHSSTable, 4, { 4,4,1,1 } },
++#define   DOT11CURRENTCHANNELNUMBER  111
++  { DOT11CURRENTCHANNELNUMBER, ASN_INTEGER   , RWRITE, var_dot11PhyFHSSTable, 4, { 4,4,1,2 } },
++#define   DOT11MAXDWELLTIME     112
++  { DOT11MAXDWELLTIME   , ASN_INTEGER   , RONLY , var_dot11PhyFHSSTable, 4, { 4,4,1,3 } },
++#define   DOT11CURRENTDWELLTIME  113
++  { DOT11CURRENTDWELLTIME, ASN_INTEGER   , RWRITE, var_dot11PhyFHSSTable, 4, { 4,4,1,4 } },
++#define   DOT11CURRENTSET       114
++  { DOT11CURRENTSET     , ASN_INTEGER   , RWRITE, var_dot11PhyFHSSTable, 4, { 4,4,1,5 } },
++#define   DOT11CURRENTPATTERN   115
++  { DOT11CURRENTPATTERN , ASN_INTEGER   , RWRITE, var_dot11PhyFHSSTable, 4, { 4,4,1,6 } },
++#define   DOT11CURRENTINDEX     116
++  { DOT11CURRENTINDEX   , ASN_INTEGER   , RWRITE, var_dot11PhyFHSSTable, 4, { 4,4,1,7 } },
++
++#define   DOT11CURRENTCHANNEL   119
++  { DOT11CURRENTCHANNEL , ASN_INTEGER   , RWRITE, var_dot11PhyDSSSTable, 4, { 4,5,1,1 } },
++#define   DOT11CCAMODESUPPORTED  120
++  { DOT11CCAMODESUPPORTED, ASN_INTEGER   , RONLY , var_dot11PhyDSSSTable, 4, { 4,5,1,2 } },
++#define   DOT11CURRENTCCAMODE   121
++  { DOT11CURRENTCCAMODE , ASN_INTEGER   , RWRITE, var_dot11PhyDSSSTable, 4, { 4,5,1,3 } },
++#define   DOT11EDTHRESHOLD      122
++  { DOT11EDTHRESHOLD    , ASN_INTEGER   , RWRITE, var_dot11PhyDSSSTable, 4, { 4,5,1,4 } },
++
++#define   DOT11CCAWATCHDOGTIMERMAX  125
++  { DOT11CCAWATCHDOGTIMERMAX, ASN_INTEGER   , RWRITE, var_dot11PhyIRTable, 4, { 4,6,1,1 } },
++#define   DOT11CCAWATCHDOGCOUNTMAX  126
++  { DOT11CCAWATCHDOGCOUNTMAX, ASN_INTEGER   , RWRITE, var_dot11PhyIRTable, 4, { 4,6,1,2 } },
++#define   DOT11CCAWATCHDOGTIMERMIN  127
++  { DOT11CCAWATCHDOGTIMERMIN, ASN_INTEGER   , RWRITE, var_dot11PhyIRTable, 4, { 4,6,1,3 } },
++#define   DOT11CCAWATCHDOGCOUNTMIN  128
++  { DOT11CCAWATCHDOGCOUNTMIN, ASN_INTEGER   , RWRITE, var_dot11PhyIRTable, 4, { 4,6,1,4 } },
++
++#define   DOT11REGDOMAINSSUPPORTVALUE  132
++  { DOT11REGDOMAINSSUPPORTVALUE, ASN_INTEGER   , RONLY , var_dot11RegDomainsSupportedTable, 4, { 4,7,1,2 } },
++
++#define   DOT11SUPPORTEDTXANTENNA  136
++  { DOT11SUPPORTEDTXANTENNA, ASN_INTEGER   , RWRITE, var_dot11AntennasListTable, 4, { 4,8,1,2 } },
++#define   DOT11SUPPORTEDRXANTENNA  137
++  { DOT11SUPPORTEDRXANTENNA, ASN_INTEGER   , RWRITE, var_dot11AntennasListTable, 4, { 4,8,1,3 } },
++#define   DOT11DIVERSITYSELECTIONRX  138
++  { DOT11DIVERSITYSELECTIONRX, ASN_INTEGER   , RWRITE, var_dot11AntennasListTable, 4, { 4,8,1,4 } },
++
++#define   DOT11SUPPORTEDDATARATESTXVALUE  142
++  { DOT11SUPPORTEDDATARATESTXVALUE, ASN_INTEGER   , RONLY , var_dot11SupportedDataRatesTxTable, 4, { 4,9,1,2 } },
++
++#define   DOT11SUPPORTEDDATARATESRXVALUE  146
++  { DOT11SUPPORTEDDATARATESRXVALUE, ASN_INTEGER   , RONLY , var_dot11SupportedDataRatesRxTable, 4, { 4,10,1,2 } },
++};
++// ( L = length of the oidsuffix )
++
++/****************************************************************************
++*                                                                           *
++*         init_ieee802dot11() - perform any required initialization         *
++*                                                                           *
++****************************************************************************/
++void init_ieee802dot11 ( void ) {
++
++  /* register ourselves with the agent to handle our mib tree */
++  REGISTER_MIB("ieee802dot11", ieee802dot11_variables, variable7,
++               ieee802dot11_variables_oid);
++
++  initLists();
++}
++
++/****************************************************************************
++*                                                                           *
++*    shutdown_ieee802dot11() - perform any required cleanup @ shutdown      *
++*                                                                           *
++****************************************************************************/
++void shutdown_ieee802dot11 ( void )
++{
++  flushLists();
++}
++
++/****************************************************************************
++*                                                                           *
++*   var_ieee802dot11() -                                                    *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_ieee802dot11 ( struct variable *vp, 
++                    oid     *name, 
++                    size_t  *length, 
++                    int     exact, 
++                    size_t  *var_len, 
++                    WriteMethod **write_method)
++{
++  loadTables();                                               
++
++  if ( header_generic ( vp, name, length, exact,var_len,write_method )
++                                  == MATCH_FAILED )
++    return NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11RESOURCETYPEIDNAME:
++      if ( !haveResourceTypeIDName )
++        return NULL;
++      *var_len = strlen ( resourceTypeIDName );
++      return ( UCHAR * ) resourceTypeIDName;
++
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*  var_dot11StationConfigTable() - return a variable value from the table   *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11StationConfigTable ( struct variable *vp,
++                              oid     *name,
++                              size_t  *length,
++                              int     exact,
++                              size_t  *var_len,
++                              WriteMethod **write_method )
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++  static char MACWork[17];
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &scList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    sc = ( struct scTbl_data * ) np->data;
++    rName[vp->namelen] = sc->ifIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) == 0 )) || 
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) >  0 ))) {
++
++      switch ( vp->magic ) {      // found requested OID, now check for requested variable
++        case DOT11STATIONID: 
++          if ( sc->haveStationID                     ) found = TRUE; break;
++        case DOT11MEDIUMOCCUPANCYLIMIT:
++          if ( sc->haveMediumOccupancyLimit          ) found = TRUE; break;
++        case DOT11CFPOLLABLE:
++          if ( sc->haveCFPPollable                   ) found = TRUE; break;
++        case DOT11CFPPERIOD:
++          if ( sc->haveCFPPeriod                     ) found = TRUE; break;
++        case DOT11CFPMAXDURATION:
++          if ( sc->haveMaxDuration                   ) found = TRUE; break;
++        case DOT11AUTHENTICATIONRESPONSETIMEOUT:
++          if ( sc->haveAuthenticationResponseTimeOut ) found = TRUE; break;
++        case DOT11PRIVACYOPTIONIMPLEMENTED:
++          if ( sc->havePrivacyOptionImplemented      ) found = TRUE; break;
++        case DOT11POWERMANAGEMENTMODE:
++          if ( sc->havePowerManagementMode           ) found = TRUE; break;
++        case DOT11DESIREDSSID:
++          if ( sc->haveDesiredSSID                   ) found = TRUE; break;
++        case DOT11DESIREDBSSTYPE:
++          if ( sc->haveDesiredBSSType                ) found = TRUE; break;
++        case DOT11OPERATIONALRATESET:
++          if ( sc->haveOperationalRateSet            ) found = TRUE; break;
++        case DOT11BEACONPERIOD: 
++          if ( sc->haveBeaconPeriod                  ) found = TRUE; break;
++        case DOT11DTIMPERIOD:
++          if ( sc->haveDTIMPeriod                    ) found = TRUE; break;
++        case DOT11ASSOCIATIONRESPONSETIMEOUT:
++          if ( sc->haveAssociationResponseTimeOut    ) found = TRUE; break;
++        case DOT11DISASSOCIATEREASON:
++          if ( sc->disAssociationReason              ) found = TRUE; break;
++        case DOT11DISASSOCIATESTATION:
++          if ( sc->haveDisAssociationStation         ) found = TRUE; break;
++        case DOT11DEAUTHENTICATEREASON:
++          if ( sc->deAuthenticationReason            ) found = TRUE; break;
++        case DOT11DEAUTHENTICATESTATION:
++          if ( sc->haveDeAuthenticationStation       ) found = TRUE; break;
++        case DOT11AUTHENTICATEFAILSTATUS:
++          if ( sc->authenticateFailStatus            ) found = TRUE; break;
++        case DOT11AUTHENTICATEFAILSTATION:
++          if ( sc->haveAuthenticateFailStation       ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 1 ) * sizeof ( oid ));
++  *length = vp->namelen + 1;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11STATIONID: 
++//    *write_method = write_dot11StationID;
++      MACWork[ 0] = sc->stationID [ 0];
++      MACWork[ 1] = sc->stationID [ 1];
++      MACWork[ 2] = sc->stationID [ 3];
++      MACWork[ 3] = sc->stationID [ 4];
++      MACWork[ 4] = sc->stationID [ 6];
++      MACWork[ 5] = sc->stationID [ 7];
++      MACWork[ 6] = sc->stationID [ 9];
++      MACWork[ 7] = sc->stationID [10];
++      MACWork[ 8] = sc->stationID [12];
++      MACWork[ 9] = sc->stationID [13];
++      MACWork[10] = sc->stationID [15];
++      MACWork[11] = sc->stationID [16];
++      MACWork[12] = '\0';
++      *var_len = 6;
++      return ( UCHAR * ) htob ( MACWork );
++
++    case DOT11MEDIUMOCCUPANCYLIMIT:
++//    *write_method = write_dot11MediumOccupancyLimit;
++      sc->mediumOccupancyLimit = 5;
++      return ( UCHAR * ) &sc->mediumOccupancyLimit;
++
++    case DOT11CFPOLLABLE:
++      return ( UCHAR * ) &sc->CFPPollable;
++
++    case DOT11CFPPERIOD:
++//    *write_method = write_dot11CFPPeriod;
++      return ( UCHAR * ) &sc->CFPPeriod;
++
++    case DOT11CFPMAXDURATION:
++//    *write_method = write_dot11CFPMaxDuration;
++      return ( UCHAR * ) &sc->maxDuration;
++
++    case DOT11AUTHENTICATIONRESPONSETIMEOUT:
++//    *write_method = write_dot11AuthenticationResponseTimeOut;
++      return ( UCHAR * ) &sc->authenticationResponseTimeOut;
++
++    case DOT11PRIVACYOPTIONIMPLEMENTED:
++      return ( UCHAR * ) &sc->privacyOptionImplemented;
++
++    case DOT11POWERMANAGEMENTMODE:
++//    *write_method = write_dot11PowerManagementMode;
++      return ( UCHAR * ) &sc->powerManagementMode;
++
++    case DOT11DESIREDSSID:
++//    *write_method = write_dot11DesiredSSID;
++      *var_len = strlen ( sc->desiredSSID );
++      return ( UCHAR * ) sc->desiredSSID;
++
++    case DOT11DESIREDBSSTYPE:
++//    *write_method = write_dot11DesiredBSSType;
++      return ( UCHAR * ) &sc->desiredBSSType;
++
++    case DOT11OPERATIONALRATESET:
++//    *write_method = write_dot11OperationalRateSet;
++      *var_len = strlen ( sc->operationalRateSet );
++      return ( UCHAR * ) sc->operationalRateSet;
++
++    case DOT11BEACONPERIOD: 
++//    *write_method = write_dot11BeaconPeriod;
++      return ( UCHAR * ) &sc->beaconPeriod;
++
++    case DOT11DTIMPERIOD:
++//    *write_method = write_dot11DTIMPeriod;
++      return ( UCHAR * ) &sc->DTIMPeriod;
++
++    case DOT11ASSOCIATIONRESPONSETIMEOUT:
++//    *write_method = write_dot11AssociationResponseTimeOut;
++      return ( UCHAR * ) &sc->associationResponseTimeOut;
++
++    case DOT11DISASSOCIATEREASON:
++      return ( UCHAR * ) &sc->disAssociationReason;
++
++    case DOT11DISASSOCIATESTATION:
++      MACWork[ 0] = sc->disAssociationStation[ 0];
++      MACWork[ 1] = sc->disAssociationStation[ 1];
++      MACWork[ 2] = sc->disAssociationStation[ 3];
++      MACWork[ 3] = sc->disAssociationStation[ 4];
++      MACWork[ 4] = sc->disAssociationStation[ 6];
++      MACWork[ 5] = sc->disAssociationStation[ 7];
++      MACWork[ 6] = sc->disAssociationStation[ 9];
++      MACWork[ 7] = sc->disAssociationStation[10];
++      MACWork[ 8] = sc->disAssociationStation[12];
++      MACWork[ 9] = sc->disAssociationStation[13];
++      MACWork[10] = sc->disAssociationStation[15];
++      MACWork[11] = sc->disAssociationStation[16];
++      MACWork[12] = '\0';
++      *var_len = 6;
++      return ( UCHAR * ) htob ( MACWork );
++
++    case DOT11DEAUTHENTICATEREASON:
++      return ( UCHAR * ) &sc->deAuthenticationReason;
++
++    case DOT11DEAUTHENTICATESTATION:
++      MACWork[ 0] = sc->deAuthenticationStation[ 0];
++      MACWork[ 1] = sc->deAuthenticationStation[ 1];
++      MACWork[ 2] = sc->deAuthenticationStation[ 3];
++      MACWork[ 3] = sc->deAuthenticationStation[ 4];
++      MACWork[ 4] = sc->deAuthenticationStation[ 6];
++      MACWork[ 5] = sc->deAuthenticationStation[ 7];
++      MACWork[ 6] = sc->deAuthenticationStation[ 9];
++      MACWork[ 7] = sc->deAuthenticationStation[10];
++      MACWork[ 8] = sc->deAuthenticationStation[12];
++      MACWork[ 9] = sc->deAuthenticationStation[13];
++      MACWork[10] = sc->deAuthenticationStation[15];
++      MACWork[11] = sc->deAuthenticationStation[16];
++      MACWork[12] = '\0';
++      *var_len = 6;
++      return ( UCHAR * ) htob ( MACWork );
++
++    case DOT11AUTHENTICATEFAILSTATUS:
++      return ( UCHAR * ) &sc->authenticateFailStatus;
++
++    case DOT11AUTHENTICATEFAILSTATION:
++      MACWork[ 0] = sc->authenticateFailStation[ 0];
++      MACWork[ 1] = sc->authenticateFailStation[ 1];
++      MACWork[ 2] = sc->authenticateFailStation[ 3];
++      MACWork[ 3] = sc->authenticateFailStation[ 4];
++      MACWork[ 4] = sc->authenticateFailStation[ 6];
++      MACWork[ 5] = sc->authenticateFailStation[ 7];
++      MACWork[ 6] = sc->authenticateFailStation[ 9];
++      MACWork[ 7] = sc->authenticateFailStation[10];
++      MACWork[ 8] = sc->authenticateFailStation[12];
++      MACWork[ 9] = sc->authenticateFailStation[13];
++      MACWork[10] = sc->authenticateFailStation[15];
++      MACWork[11] = sc->authenticateFailStation[16];
++      MACWork[12] = '\0';
++      *var_len = 6;
++      return ( UCHAR * ) htob ( MACWork );
++
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*  var_dot11AuthenticationAlgorithmsTable() -                               *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11AuthenticationAlgorithmsTable (  struct variable *vp,
++                                          oid     *name,
++                                          size_t  *length,
++                                          int     exact,
++                                          size_t  *var_len,
++                                          WriteMethod **write_method )
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &aaList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    aa = ( struct aaTbl_data * ) np->data;
++    rName[vp->namelen + 0] = aa->ifIndex;
++    rName[vp->namelen + 1] = aa->authenticationAlgorithmsIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11AUTHENTICATIONALGORITHM:
++          if ( aa->haveAuthenticationAlgorithm    ) found = TRUE; break;
++        case DOT11AUTHENTICATIONALGORITHMSENABLE:
++          if ( aa->authenticationAlgorithmsEnable ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 2 ) * sizeof ( oid ));
++  *length = vp->namelen + 2;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11AUTHENTICATIONALGORITHM:
++      return ( UCHAR * ) &aa->authenticationAlgorithm;
++        
++    case DOT11AUTHENTICATIONALGORITHMSENABLE:
++//    *write_method = write_dot11AuthenticationAlgorithmsEnable;
++      return ( UCHAR * ) &aa->authenticationAlgorithmsEnable;
++
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*  var_dot11WEPDefaultKeysTable() -                                         *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11WEPDefaultKeysTable ( struct variable *vp,
++                                oid     *name,
++                                size_t  *length,
++                                int     exact,
++                                size_t  *var_len,
++                                WriteMethod **write_method )
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &dfList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    df = ( struct dfTbl_data * ) np->data;
++    rName[vp->namelen + 0] = df->ifIndex;
++    rName[vp->namelen + 1] = df->WEPDefaultKeyIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11WEPDEFAULTKEYVALUE:
++          if ( df->haveWEPDefaultKeyValue ) found = TRUE; break;
++      }          
++    }          
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 2 ) * sizeof ( oid ));
++  *length = vp->namelen + 2;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11WEPDEFAULTKEYVALUE:
++//    *write_method = write_dot11WEPDefaultKeyValue;
++      *var_len = strlen ( df->WEPDefaultKeyValue );
++      return ( UCHAR * ) df->WEPDefaultKeyValue;
++
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*  var_dot11WEPKeyMappingsTable() -                                         *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11WEPKeyMappingsTable ( struct variable *vp,
++                                oid     *name,
++                                size_t  *length,
++                                int     exact,
++                                size_t  *var_len,
++                                WriteMethod **write_method)
++{
++  static char MACWork[17];
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &kmList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    km = ( struct kmTbl_data * ) np->data;
++    rName[vp->namelen + 0] = km->ifIndex;
++    rName[vp->namelen + 1] = km->WEPKeyMappingIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11WEPKEYMAPPINGADDRESS:
++          if ( km->haveWEPKeyMappingAddress ) found = TRUE; break;
++        case DOT11WEPKEYMAPPINGWEPON:
++          if ( km->haveWEPKeyMappingWEPOn   ) found = TRUE; break;
++        case DOT11WEPKEYMAPPINGVALUE:
++          if ( km->haveWEPKeyMappingValue   ) found = TRUE; break;
++        case DOT11WEPKEYMAPPINGSTATUS:
++          if ( km->haveWEPKeyMappingStatus  ) found = TRUE; break; 
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 2 ) * sizeof ( oid ));
++  *length = vp->namelen + 2;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11WEPKEYMAPPINGADDRESS:
++//    *write_method = write_dot11WEPKeyMappingAddress;
++      MACWork[ 0] = km->WEPKeyMappingAddress[ 0];
++      MACWork[ 1] = km->WEPKeyMappingAddress[ 1];
++      MACWork[ 2] = km->WEPKeyMappingAddress[ 3];
++      MACWork[ 3] = km->WEPKeyMappingAddress[ 4];
++      MACWork[ 4] = km->WEPKeyMappingAddress[ 6];
++      MACWork[ 5] = km->WEPKeyMappingAddress[ 7];
++      MACWork[ 6] = km->WEPKeyMappingAddress[ 9];
++      MACWork[ 7] = km->WEPKeyMappingAddress[10];
++      MACWork[ 8] = km->WEPKeyMappingAddress[12];
++      MACWork[ 9] = km->WEPKeyMappingAddress[13];
++      MACWork[10] = km->WEPKeyMappingAddress[15];
++      MACWork[11] = km->WEPKeyMappingAddress[16];
++      MACWork[12] = '\0';
++      *var_len = 6;
++      return ( UCHAR * ) htob ( MACWork );
++
++    case DOT11WEPKEYMAPPINGWEPON:
++//    *write_method = write_dot11WEPKeyMappingWEPOn;
++      return ( UCHAR * ) &km->WEPKeyMappingWEPOn;
++
++    case DOT11WEPKEYMAPPINGVALUE:
++//    *write_method = write_dot11WEPKeyMappingValue;
++      *var_len = strlen ( km->WEPKeyMappingValue );
++      return ( UCHAR * ) km->WEPKeyMappingValue;
++
++    case DOT11WEPKEYMAPPINGSTATUS:
++//    *write_method = write_dot11WEPKeyMappingStatus;
++      return ( UCHAR * ) &km->WEPKeyMappingStatus;
++
++    default:
++      ERROR_MSG ( "" );
++  }
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*   var_dot11PrivacyTable() -                                               *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11PrivacyTable ( struct variable *vp,
++                        oid     *name,
++                        size_t  *length,
++                        int     exact,
++                        size_t  *var_len,
++                        WriteMethod **write_method )
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &prList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    pr = ( struct prTbl_data * ) np->data;
++    rName[vp->namelen] = pr->ifIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11PRIVACYINVOKED:
++          if ( pr->havePrivacyInvoked      ) found = TRUE; break;
++        case DOT11WEPDEFAULTKEYID:
++          if ( pr->haveWEPDefaultKeyID     ) found = TRUE; break;
++        case DOT11WEPKEYMAPPINGLENGTH:
++          if ( pr->haveWEPKeyMappingLength ) found = TRUE; break;
++        case DOT11EXCLUDEUNENCRYPTED:
++          if ( pr->haveExcludeUnencrypted  ) found = TRUE; break;
++        case DOT11WEPICVERRORCOUNT:
++          if ( pr->haveWEPICVErrorCount    ) found = TRUE; break;
++        case DOT11WEPEXCLUDEDCOUNT:
++          if ( pr->haveWEPExcludedCount    ) found = TRUE; break;
++      }      
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 1 ) * sizeof ( oid ));
++  *length = vp->namelen + 1;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11PRIVACYINVOKED:
++//    *write_method = write_dot11PrivacyInvoked;
++      return ( UCHAR * ) &pr->privacyInvoked;
++
++    case DOT11WEPDEFAULTKEYID:
++//    *write_method = write_dot11WEPDefaultKeyID;
++      return ( UCHAR * ) &pr->WEPDefaultKeyID;
++
++    case DOT11WEPKEYMAPPINGLENGTH:
++//    *write_method = write_dot11WEPKeyMappingLength;
++      return ( UCHAR * ) &pr->WEPKeyMappingLength;
++
++    case DOT11EXCLUDEUNENCRYPTED:
++//    *write_method = write_dot11ExcludeUnencrypted;
++      return ( UCHAR * ) &pr->excludeUnencrypted;
++
++    case DOT11WEPICVERRORCOUNT:
++      return ( UCHAR * ) &pr->WEPICVErrorCount;
++        
++    case DOT11WEPEXCLUDEDCOUNT:
++      return ( UCHAR * ) &pr->WEPExcludedCount;
++        
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*   var_dot11OperationTable() -                                             *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11OperationTable ( struct variable *vp,
++                          oid     *name,
++                          size_t  *length,
++                          int     exact,
++                          size_t  *var_len,
++                          WriteMethod **write_method )
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++  static char MACWork[17];
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &opList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    op = ( struct opTbl_data * ) np->data;
++    rName[vp->namelen] = op->ifIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) >  0 ))) {
++
++      switch ( vp->magic ) {      // found requested OID, now check for requested variable
++        case DOT11MACADDRESS:             
++          if ( op->haveMACAddress              ) found = TRUE; break;
++        case DOT11RTSTHRESHOLD:           
++          if ( op->haveRTSThreshold            ) found = TRUE; break;
++        case DOT11SHORTRETRYLIMIT: 
++          if ( op->haveShortRetryLimit         ) found = TRUE; break;
++        case DOT11LONGRETRYLIMIT:
++          if ( op->haveLongRetryLimit          ) found = TRUE; break;
++        case DOT11FRAGMENTATIONTHRESHOLD: 
++          if ( op->haveFragmentationThreshold  ) found = TRUE; break;
++        case DOT11MAXTRANSMITMSDULIFETIME: 
++          if ( op->haveMaxTransmitMSDULifetime ) found = TRUE; break;
++        case DOT11MAXRECEIVELIFETIME:
++          if ( op->haveMaxReceiveLifetime      ) found = TRUE; break;
++        case DOT11MANUFACTURERID:
++          if ( op->haveManufacturerID          ) found = TRUE; break;
++        case DOT11PRODUCTID:
++          if ( op->haveProductID               ) found = TRUE; break;
++      }
++    }
++    if ( found ) 
++      break;
++  }
++
++  if ( !found )
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 1 ) * sizeof ( oid ));
++  *length = vp->namelen + 1;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11MACADDRESS:
++      MACWork[ 0] = op->MACAddress[ 0];
++      MACWork[ 1] = op->MACAddress[ 1];
++      MACWork[ 2] = op->MACAddress[ 3];
++      MACWork[ 3] = op->MACAddress[ 4];
++      MACWork[ 4] = op->MACAddress[ 6];
++      MACWork[ 5] = op->MACAddress[ 7];
++      MACWork[ 6] = op->MACAddress[ 9];
++      MACWork[ 7] = op->MACAddress[10];
++      MACWork[ 8] = op->MACAddress[12];
++      MACWork[ 9] = op->MACAddress[13];
++      MACWork[10] = op->MACAddress[15];
++      MACWork[11] = op->MACAddress[16];
++      MACWork[12] = '\0';
++      *var_len = 6;
++      return ( UCHAR * ) htob ( MACWork );
++        
++    case DOT11RTSTHRESHOLD:
++//    *write_method = write_dot11RTSThreshold;
++      return ( UCHAR * ) &op->RTSThreshold;
++
++    case DOT11SHORTRETRYLIMIT:
++//    *write_method = write_dot11ShortRetryLimit;
++      return ( UCHAR * ) &op->shortRetryLimit;
++
++    case DOT11LONGRETRYLIMIT:
++//    *write_method = write_dot11LongRetryLimit;
++      return ( UCHAR * ) &op->longRetryLimit;
++
++    case DOT11FRAGMENTATIONTHRESHOLD:
++//    *write_method = write_dot11FragmentationThreshold;
++      return ( UCHAR * ) &op->fragmentationThreshold;
++
++    case DOT11MAXTRANSMITMSDULIFETIME:
++//    *write_method = write_dot11MaxTransmitMSDULifetime;
++      return ( UCHAR * ) &op->maxTransmitMSDULifetime;
++
++    case DOT11MAXRECEIVELIFETIME:
++//    *write_method = write_dot11MaxReceiveLifetime;
++      return ( UCHAR * ) &op->maxReceiveLifetime;
++
++    case DOT11MANUFACTURERID:
++      *var_len = strlen ( op->manufacturerID );
++      return ( UCHAR * ) op->manufacturerID;
++
++    case DOT11PRODUCTID:
++      *var_len = strlen ( op->productID );
++      return ( UCHAR * ) op->productID;
++        
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*   var_dot11CountersTable() -                                              *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11CountersTable(struct variable *vp,
++          oid     *name,
++          size_t  *length,
++          int     exact,
++          size_t  *var_len,
++          WriteMethod **write_method)
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &coList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    co = ( struct coTbl_data * ) np->data;
++    rName[vp->namelen] = co->ifIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11TRANSMITTEDFRAGMENTCOUNT:
++          if ( co->haveTransmittedFragmentCount    ) found = TRUE; break;
++        case DOT11MULTICASTTRANSMITTEDFRAMECOUNT:
++          if ( co->haveTransmittedFrameCount       ) found = TRUE; break;
++        case DOT11FAILEDCOUNT:
++          if ( co->haveFailedCount                 ) found = TRUE; break;
++        case DOT11RETRYCOUNT:
++          if ( co->haveRetryCount                  ) found = TRUE; break;
++        case DOT11MULTIPLERETRYCOUNT:
++          if ( co->haveMultipleRetryCount          ) found = TRUE; break;
++        case DOT11FRAMEDUPLICATECOUNT:
++          if ( co->haveFrameDuplicateCount         ) found = TRUE; break;
++        case DOT11RTSSUCCESSCOUNT:
++          if ( co->haveRTSSuccessCount             ) found = TRUE; break;
++        case DOT11RTSFAILURECOUNT:
++          if ( co->haveRTSFailureCount             ) found = TRUE; break;
++        case DOT11ACKFAILURECOUNT:
++          if ( co->haveACKFailureCount             ) found = TRUE; break;
++        case DOT11RECEIVEDFRAGMENTCOUNT:
++          if ( co->haveReceivedFragmentCount       ) found = TRUE; break;
++        case DOT11MULTICASTRECEIVEDFRAMECOUNT:
++          if ( co->haveMulticastReceivedFrameCount ) found = TRUE; break;
++        case DOT11FCSERRORCOUNT:
++          if ( co->haveFCSErrorCount               ) found = TRUE; break;
++        case DOT11TRANSMITTEDFRAMECOUNT:
++          if ( co->haveTransmittedFrameCount       ) found = TRUE; break;
++        case DOT11WEPUNDECRYPTABLECOUNT:
++          if ( co->haveWEPUndecryptableCount       ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 1 ) * sizeof ( oid ));
++  *length = vp->namelen + 1;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11TRANSMITTEDFRAGMENTCOUNT:       return ( UCHAR * ) &co->transmittedFragmentCount;
++    case DOT11MULTICASTTRANSMITTEDFRAMECOUNT: return ( UCHAR * ) &co->transmittedFrameCount;
++    case DOT11FAILEDCOUNT:                    return ( UCHAR * ) &co->failedCount;
++    case DOT11RETRYCOUNT:                     return ( UCHAR * ) &co->retryCount;
++    case DOT11MULTIPLERETRYCOUNT:             return ( UCHAR * ) &co->multipleRetryCount;
++    case DOT11FRAMEDUPLICATECOUNT:            return ( UCHAR * ) &co->frameDuplicateCount;
++    case DOT11RTSSUCCESSCOUNT:                return ( UCHAR * ) &co->RTSSuccessCount;
++    case DOT11RTSFAILURECOUNT:                return ( UCHAR * ) &co->RTSFailureCount;
++    case DOT11ACKFAILURECOUNT:                return ( UCHAR * ) &co->ACKFailureCount;
++    case DOT11RECEIVEDFRAGMENTCOUNT:          return ( UCHAR * ) &co->receivedFragmentCount;
++    case DOT11MULTICASTRECEIVEDFRAMECOUNT:    return ( UCHAR * ) &co->multicastReceivedFrameCount;
++    case DOT11FCSERRORCOUNT:                  return ( UCHAR * ) &co->FCSErrorCount;
++    case DOT11TRANSMITTEDFRAMECOUNT:          return ( UCHAR * ) &co->transmittedFrameCount;
++    case DOT11WEPUNDECRYPTABLECOUNT:          return ( UCHAR * ) &co->WEPUndecryptableCount;
++        
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*   var_dot11GroupAddressesTable() -                                        *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11GroupAddressesTable(struct variable *vp,
++          oid     *name,
++          size_t  *length,
++          int     exact,
++          size_t  *var_len,
++          WriteMethod **write_method)
++{
++  static char MACWork[17];
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &gaList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    ga = ( struct gaTbl_data * ) np->data;
++    rName[vp->namelen + 0] = ga->ifIndex;
++    rName[vp->namelen + 1] = ga->groupAddressesIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11ADDRESS:
++          if ( ga->haveAddress              ) found = TRUE; break;
++        case DOT11GROUPADDRESSESSTATUS:
++          if ( ga->haveGroupAddressesStatus ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 2 ) * sizeof ( oid ));
++  *length = vp->namelen + 2;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11ADDRESS:
++//    *write_method = write_dot11Address;
++      MACWork[ 0] = ga->address[ 0];
++      MACWork[ 1] = ga->address[ 1];
++      MACWork[ 2] = ga->address[ 3];
++      MACWork[ 3] = ga->address[ 4];
++      MACWork[ 4] = ga->address[ 6];
++      MACWork[ 5] = ga->address[ 7];
++      MACWork[ 6] = ga->address[ 9];
++      MACWork[ 7] = ga->address[10];
++      MACWork[ 8] = ga->address[12];
++      MACWork[ 9] = ga->address[13];
++      MACWork[10] = ga->address[15];
++      MACWork[11] = ga->address[16];
++      MACWork[12] = '\0';
++      *var_len = 6;
++      return ( UCHAR * ) htob ( MACWork );
++
++    case DOT11GROUPADDRESSESSTATUS:
++//    *write_method = write_dot11GroupAddressesStatus;
++      return ( UCHAR * ) &ga->groupAddressesStatus;
++
++    default:
++      ERROR_MSG ( "" );
++  }
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*   var_dot11ResourceInfoTable() -                                          *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11ResourceInfoTable ( struct variable *vp,
++                              oid     *name,
++                              size_t  *length,
++                              int     exact,
++                              size_t  *var_len,
++                              WriteMethod **write_method )
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &riList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    ri = ( struct riTbl_data * ) np->data;
++    rName[vp->namelen] = ri->ifIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11MANUFACTUREROUI:
++          if ( ri->haveManufacturerOUI            ) found = TRUE; break;
++        case DOT11MANUFACTURERNAME:
++          if ( ri->haveManufacturerName           ) found = TRUE; break;
++        case DOT11MANUFACTURERPRODUCTNAME:
++          if ( ri->haveManufacturerProductName    ) found = TRUE; break;
++        case DOT11MANUFACTURERPRODUCTVERSION:
++          if ( ri->haveManufacturerProductVersion ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 1 ) * sizeof ( oid ));
++  *length = vp->namelen + 1;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11MANUFACTUREROUI:
++      *var_len = strlen ( ri->manufacturerOUI );
++      return ( UCHAR * ) ri->manufacturerOUI;
++        
++    case DOT11MANUFACTURERNAME:
++      *var_len = strlen ( ri->manufacturerName );
++      return ( UCHAR * ) ri->manufacturerName;
++        
++    case DOT11MANUFACTURERPRODUCTNAME:
++      *var_len = strlen ( ri->manufacturerProductName );
++      return ( UCHAR * ) ri->manufacturerProductName;
++        
++    case DOT11MANUFACTURERPRODUCTVERSION:
++      *var_len = strlen ( ri->manufacturerProductVersion );
++      return ( UCHAR * ) ri->manufacturerProductVersion;
++        
++    default: 
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*   var_dot11PhyOperationTable() -                                          *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11PhyOperationTable ( struct variable *vp,
++                              oid     *name,
++                              size_t  *length,
++                              int     exact,
++                              size_t  *var_len,
++                              WriteMethod **write_method )
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &poList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    po = ( struct poTbl_data * ) np->data;
++    rName[vp->namelen] = po->ifIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11PHYTYPE:
++          if ( po->havePHYType          ) found = TRUE; break;
++        case DOT11CURRENTREGDOMAIN:
++          if ( po->haveCurrentRegDomain ) found = TRUE; break;
++        case DOT11TEMPTYPE:
++          if ( po->haveTempType         ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 1 ) * sizeof ( oid ));
++  *length = vp->namelen + 1;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11PHYTYPE:
++      return ( UCHAR * ) &po->PHYType;
++        
++    case DOT11CURRENTREGDOMAIN:
++//    *write_method = write_dot11CurrentRegDomain;
++      return ( UCHAR * ) &po->currentRegDomain;
++
++    case DOT11TEMPTYPE:
++      return ( UCHAR * ) &po->tempType;
++        
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*   var_dot11PhyAntennaTable() -                                            *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11PhyAntennaTable ( struct variable *vp,
++                            oid     *name,
++                            size_t  *length,
++                            int     exact,
++                            size_t  *var_len,
++                            WriteMethod **write_method )
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &paList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    pa = ( struct paTbl_data * ) np->data;
++    rName[vp->namelen] = pa->ifIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11CURRENTTXANTENNA:
++          if ( pa->haveCurrentTxAntenna ) found = TRUE; break;
++        case DOT11DIVERSITYSUPPORT:
++          if ( pa->haveDiversitySupport ) found = TRUE; break;
++        case DOT11CURRENTRXANTENNA:
++          if ( pa->haveCurrentRxAntenna ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 1 ) * sizeof ( oid ));
++  *length = vp->namelen + 1;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11CURRENTTXANTENNA:
++//    *write_method = write_dot11CurrentTxAntenna;
++      return ( UCHAR * ) &pa->currentTxAntenna;
++
++    case DOT11DIVERSITYSUPPORT:
++      return ( UCHAR * ) &pa->diversitySupport;
++        
++    case DOT11CURRENTRXANTENNA:
++//    *write_method = write_dot11CurrentRxAntenna;
++      return ( UCHAR * ) &pa->currentRxAntenna;
++
++    default:
++      ERROR_MSG ( "" );
++  }
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*   var_dot11PhyTxPowerTable() -                                            *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11PhyTxPowerTable ( struct variable *vp,
++                            oid     *name,
++                            size_t  *length,
++                            int     exact,
++                            size_t  *var_len,
++                            WriteMethod **write_method )
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &ptList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    pt = ( struct ptTbl_data * ) np->data;
++    rName[vp->namelen] = pt->ifIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11NUMBERSUPPORTEDPOWERLEVELS:
++          if ( pt->haveNumberSupportedPowerLevels ) found = TRUE; break;
++        case DOT11TXPOWERLEVEL1:
++          if ( pt->haveTxPowerLevel1   ) found = TRUE; break;
++        case DOT11TXPOWERLEVEL2:
++          if ( pt->haveTxPowerLevel2   ) found = TRUE; break;
++        case DOT11TXPOWERLEVEL3:
++          if ( pt->haveTxPowerLevel3   ) found = TRUE; break;
++        case DOT11TXPOWERLEVEL4:
++          if ( pt->haveTxPowerLevel4   ) found = TRUE; break;
++        case DOT11TXPOWERLEVEL5:
++          if ( pt->haveTxPowerLevel5   ) found = TRUE; break;
++        case DOT11TXPOWERLEVEL6:
++          if ( pt->haveTxPowerLevel6   ) found = TRUE; break;
++        case DOT11TXPOWERLEVEL7:
++          if ( pt->haveTxPowerLevel7   ) found = TRUE; break;
++        case DOT11TXPOWERLEVEL8:
++          if ( pt->haveTxPowerLevel8   ) found = TRUE; break;
++        case DOT11CURRENTTXPOWERLEVEL:
++          if ( pt->currentTxPowerLevel ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 1 ) * sizeof ( oid ));
++  *length = vp->namelen + 1;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11NUMBERSUPPORTEDPOWERLEVELS: 
++      return ( UCHAR * ) &pt->numberSupportedPowerLevels;
++
++    case DOT11TXPOWERLEVEL1: return ( UCHAR * ) &pt->TxPowerLevel1;
++    case DOT11TXPOWERLEVEL2: return ( UCHAR * ) &pt->TxPowerLevel2;
++    case DOT11TXPOWERLEVEL3: return ( UCHAR * ) &pt->TxPowerLevel3;
++    case DOT11TXPOWERLEVEL4: return ( UCHAR * ) &pt->TxPowerLevel4;
++    case DOT11TXPOWERLEVEL5: return ( UCHAR * ) &pt->TxPowerLevel5;
++    case DOT11TXPOWERLEVEL6: return ( UCHAR * ) &pt->TxPowerLevel6;
++    case DOT11TXPOWERLEVEL7: return ( UCHAR * ) &pt->TxPowerLevel7;
++    case DOT11TXPOWERLEVEL8: return ( UCHAR * ) &pt->TxPowerLevel8;
++        
++    case DOT11CURRENTTXPOWERLEVEL:
++//    *write_method = write_dot11CurrentTxPowerLevel;
++      return ( UCHAR * ) &pt->currentTxPowerLevel;
++
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*     var_dot11PhyFHSSTable() -                                             *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11PhyFHSSTable ( struct variable *vp,
++                        oid     *name,
++                        size_t  *length,
++                        int     exact,
++                        size_t  *var_len,
++                        WriteMethod **write_method )
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &pfList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    pf = ( struct pfTbl_data * ) np->data;
++    rName[vp->namelen] = pf->ifIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11HOPTIME:
++          if ( pf->haveHopTime              ) found = TRUE; break;
++        case DOT11CURRENTCHANNELNUMBER:
++          if ( pf->haveCurrentChannelNumber ) found = TRUE; break;
++        case DOT11MAXDWELLTIME:
++          if ( pf->haveMaxDwellTime         ) found = TRUE; break;
++        case DOT11CURRENTDWELLTIME:
++          if ( pf->haveCurrentDwellTime     ) found = TRUE; break;
++        case DOT11CURRENTSET:
++          if ( pf->haveCurrentSet           ) found = TRUE; break;
++        case DOT11CURRENTPATTERN:
++          if ( pf->haveCurrentPattern       ) found = TRUE; break;
++        case DOT11CURRENTINDEX:
++          if ( pf->haveCurrentIndex         ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 1 ) * sizeof ( oid ));
++  *length = vp->namelen + 1;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11HOPTIME:
++      return ( UCHAR * ) &pf->hopTime;
++        
++    case DOT11CURRENTCHANNELNUMBER:
++//    *write_method = write_dot11CurrentChannelNumber;
++      return ( UCHAR * ) &pf->currentChannelNumber;
++
++    case DOT11MAXDWELLTIME:
++      return ( UCHAR * ) &pf->maxDwellTime;
++        
++    case DOT11CURRENTDWELLTIME:
++//    *write_method = write_dot11CurrentDwellTime;
++      return ( UCHAR * ) &pf->currentDwellTime;
++
++    case DOT11CURRENTSET:
++//    *write_method = write_dot11CurrentSet;
++      return ( UCHAR * ) &pf->currentSet;
++
++    case DOT11CURRENTPATTERN:
++//    *write_method = write_dot11CurrentPattern;
++      return ( UCHAR * ) &pf->currentPattern;
++
++    case DOT11CURRENTINDEX:
++//    *write_method = write_dot11CurrentIndex;
++      return ( UCHAR * ) &pf->currentIndex;
++
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*     var_dot11PhyDSSSTable() -                                             *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11PhyDSSSTable ( struct variable *vp,
++                        oid     *name,
++                        size_t  *length,
++                        int     exact,
++                        size_t  *var_len,
++                        WriteMethod **write_method )
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &pdList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    pd = ( struct pdTbl_data * ) np->data;
++    rName[vp->namelen] = pd->ifIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11CURRENTCHANNEL:
++          if ( pd->haveCurrentChannel   ) found = TRUE; break;
++        case DOT11CCAMODESUPPORTED:
++          if ( pd->haveCCAModeSupported ) found = TRUE; break;
++        case DOT11CURRENTCCAMODE:
++          if ( pd->haveCurrentCCAMode   ) found = TRUE; break;
++        case DOT11EDTHRESHOLD:
++          if ( pd->haveEDThreshold      ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 1 ) * sizeof ( oid ));
++  *length = vp->namelen + 1;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11CURRENTCHANNEL:
++//    *write_method = write_dot11CurrentChannel;
++      return ( UCHAR * ) &pd->currentChannel;
++
++    case DOT11CCAMODESUPPORTED:
++      return ( UCHAR * ) &pd->CCAModeSupported;
++        
++    case DOT11CURRENTCCAMODE:
++//    *write_method = write_dot11CurrentCCAMode;
++      return ( UCHAR * ) &pd->currentCCAMode;
++
++    case DOT11EDTHRESHOLD:
++//    *write_method = write_dot11EDThreshold;
++      return ( UCHAR * ) &pd->EDThreshold;
++
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*     var_dot11PhyIRTable() -                                             *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11PhyIRTable ( struct variable *vp,
++                      oid     *name,
++                      size_t  *length,
++                      int     exact,
++                      size_t  *var_len,
++                      WriteMethod **write_method)
++{
++
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &piList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    pi = ( struct piTbl_data * ) np->data;
++    rName[vp->namelen] = pi->ifIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 1, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11CCAWATCHDOGTIMERMAX:
++          if ( pi->CCAWatchdogTimerMax ) found = TRUE; break;
++        case DOT11CCAWATCHDOGCOUNTMAX:
++          if ( pi->CCAWatchdogCountMax ) found = TRUE; break;
++        case DOT11CCAWATCHDOGTIMERMIN:
++          if ( pi->CCAWatchdogTimerMin ) found = TRUE; break;
++        case DOT11CCAWATCHDOGCOUNTMIN:
++          if ( pi->CCAWatchdogCountMin ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 1 ) * sizeof ( oid ));
++  *length = vp->namelen + 1;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11CCAWATCHDOGTIMERMAX:
++//    *write_method = write_dot11CCAWatchdogTimerMax;
++      return ( UCHAR * ) &pi->CCAWatchdogTimerMax;
++
++    case DOT11CCAWATCHDOGCOUNTMAX:
++//   *write_method = write_dot11CCAWatchdogCountMax;
++      return ( UCHAR * ) &pi->CCAWatchdogCountMax;
++
++    case DOT11CCAWATCHDOGTIMERMIN:
++//    *write_method = write_dot11CCAWatchdogTimerMin;
++      return ( UCHAR * ) &pi->CCAWatchdogTimerMin;
++
++    case DOT11CCAWATCHDOGCOUNTMIN:
++//    *write_method = write_dot11CCAWatchdogCountMin;
++      return ( UCHAR * ) &pi->CCAWatchdogCountMin;
++
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*     var_dot11RegDomainsSupportedTable() -                                 *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11RegDomainsSupportedTable ( struct variable *vp,
++                                    oid     *name,
++                                    size_t  *length,
++                                    int     exact,
++                                    size_t  *var_len,
++                                    WriteMethod **write_method)
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &rdList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    rd = ( struct rdTbl_data * ) np->data;
++    rName[vp->namelen + 0] = rd->ifIndex;
++    rName[vp->namelen + 1] = rd->regDomainsSupportIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11REGDOMAINSSUPPORTVALUE:
++          if ( rd->haveRegDomainsSupportValue ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 2 ) * sizeof ( oid ));
++  *length = vp->namelen + 2;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11REGDOMAINSSUPPORTVALUE:
++      return ( UCHAR * ) &rd->regDomainsSupportValue;
++        
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*     var_dot11AntennasListTable() -                                        *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11AntennasListTable(struct variable *vp,
++          oid     *name,
++          size_t  *length,
++          int     exact,
++          size_t  *var_len,
++          WriteMethod **write_method)
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &alList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    al = ( struct alTbl_data * ) np->data;
++    rName[vp->namelen + 0] = al->ifIndex;
++    rName[vp->namelen + 1] = al->antennaListIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11SUPPORTEDTXANTENNA:
++          if ( al->haveSupportedTxAntenna   ) found = TRUE; break;
++        case DOT11SUPPORTEDRXANTENNA:
++          if ( al->haveSupportedRxAntenna   ) found = TRUE; break;
++        case DOT11DIVERSITYSELECTIONRX:
++          if ( al->haveDiversitySelectionRx ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 2 ) * sizeof ( oid ));
++  *length = vp->namelen + 2;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11SUPPORTEDTXANTENNA:
++//    *write_method = write_dot11SupportedTxAntenna;
++      return ( UCHAR * ) &al->supportedTxAntenna;
++
++    case DOT11SUPPORTEDRXANTENNA:
++//    *write_method = write_dot11SupportedRxAntenna;
++      return ( UCHAR * ) &al->supportedRxAntenna;
++
++    case DOT11DIVERSITYSELECTIONRX:
++//    *write_method = write_dot11DiversitySelectionRx;
++      return ( UCHAR * ) &al->diversitySelectionRx;
++
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*     var_dot11SupportedDataRatesTxTable() -                                *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11SupportedDataRatesTxTable ( struct variable *vp,
++                                      oid     *name,
++                                      size_t  *length,
++                                      int     exact,
++                                      size_t  *var_len,
++                                      WriteMethod **write_method )
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &rtList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    rt = ( struct rtTbl_data * ) np->data;
++    rName[vp->namelen + 0] = rt->ifIndex;
++    rName[vp->namelen + 1] = rt->supportedDataRatesTxIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++         case DOT11SUPPORTEDDATARATESTXVALUE:
++          if ( rt->haveSupportedDataRatesTxValue ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 2 ) * sizeof ( oid ));
++  *length = vp->namelen + 2;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11SUPPORTEDDATARATESTXVALUE:
++      return ( UCHAR * ) &rt->supportedDataRatesTxValue;
++        
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++*     var_dot11SupportedDataRatesRxTable() -                                *
++*                                                                           *
++****************************************************************************/
++unsigned char *
++var_dot11SupportedDataRatesRxTable ( struct variable *vp,
++                                      oid     *name,
++                                      size_t  *length,
++                                      int     exact,
++                                      size_t  *var_len,
++                                      WriteMethod **write_method )
++{
++  int found = FALSE;
++  oid rName [ MAX_OID_LEN ];                            // OID to be returned
++
++  loadTables();
++  memcpy (( char * ) rName, ( char * ) vp->name, ( int ) vp->namelen * sizeof ( oid ));
++  for ( np = LIST_FIRST ( &rrList ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    rr = ( struct rrTbl_data * ) np->data;
++    rName[vp->namelen + 0] = rr->ifIndex;
++    rName[vp->namelen + 1] = rr->supportedDataRatesRxIndex;
++    if ((  exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) == 0 )) ||
++        ( !exact && ( snmp_oid_compare ( rName, vp->namelen + 2, name, *length ) >  0 ))) {
++      switch ( vp->magic ) {
++        case DOT11SUPPORTEDDATARATESRXVALUE:
++          if ( rr->haveSupportedDataRatesRxValue ) found = TRUE; break;
++      }
++    }
++    if ( found )
++      break;
++  }
++
++  if ( !found ) 
++    return NULL;
++
++  memcpy (( char * ) name, ( char * ) rName, ( vp->namelen + 2 ) * sizeof ( oid ));
++  *length = vp->namelen + 2;
++  *var_len = sizeof ( long );
++  *write_method = NULL;
++
++  switch ( vp->magic ) {
++
++    case DOT11SUPPORTEDDATARATESRXVALUE:
++      return ( UCHAR * ) &rr->supportedDataRatesRxValue;
++        
++    default:
++      ERROR_MSG ( "" );
++  }
++
++  return NULL;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11StationID(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static unsigned char string[SPRINT_MAX_LEN];
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_OCTET_STR ) {
++        fprintf ( stderr, "write to dot11StationID not ASN_OCTET_STR\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( string )) {
++        fprintf ( stderr,"write to dot11StationID: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11MediumOccupancyLimit(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11MediumOccupancyLimit not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr,"write to dot11MediumOccupancyLimit: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CFPPeriod(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CFPPeriod not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11CFPPeriod: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CFPMaxDuration(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CFPMaxDuration not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11CFPMaxDuration: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11AuthenticationResponseTimeOut(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11AuthenticationResponseTimeOut not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11AuthenticationResponseTimeOut: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11PowerManagementMode(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11PowerManagementMode not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )) {
++        fprintf ( stderr, "write to dot11PowerManagementMode: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11DesiredSSID(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static unsigned char string[SPRINT_MAX_LEN];
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_OCTET_STR ) {
++        fprintf ( stderr, "write to dot11DesiredSSID not ASN_OCTET_STR\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( string )){
++        fprintf ( stderr, "write to dot11DesiredSSID: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11DesiredBSSType(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11DesiredBSSType not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11DesiredBSSType: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11OperationalRateSet(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static unsigned char string[SPRINT_MAX_LEN];
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_OCTET_STR ) {
++        fprintf ( stderr, "write to dot11OperationalRateSet not ASN_OCTET_STR\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( string )){
++        fprintf ( stderr, "write to dot11OperationalRateSet: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11BeaconPeriod(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11BeaconPeriod not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr,"write to dot11BeaconPeriod: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11DTIMPeriod(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11DTIMPeriod not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr,"write to dot11DTIMPeriod: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11AssociationResponseTimeOut(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11AssociationResponseTimeOut not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )) {
++        fprintf ( stderr,"write to dot11AssociationResponseTimeOut: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11AuthenticationAlgorithmsEnable(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11AuthenticationAlgorithmsEnable not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr,"write to dot11AuthenticationAlgorithmsEnable: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11WEPDefaultKeyValue(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static unsigned char string[SPRINT_MAX_LEN];
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_OCTET_STR ) {
++        fprintf ( stderr, "write to dot11WEPDefaultKeyValue not ASN_OCTET_STR\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( string )){
++        fprintf ( stderr,"write to dot11WEPDefaultKeyValue: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11WEPKeyMappingAddress(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static unsigned char string[SPRINT_MAX_LEN];
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_OCTET_STR ) {
++        fprintf ( stderr, "write to dot11WEPKeyMappingAddress not ASN_OCTET_STR\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( string )) {
++        fprintf ( stderr,"write to dot11WEPKeyMappingAddress: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11WEPKeyMappingWEPOn(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11WEPKeyMappingWEPOn not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11WEPKeyMappingWEPOn: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11WEPKeyMappingValue(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static unsigned char string[SPRINT_MAX_LEN];
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_OCTET_STR ) {
++        fprintf ( stderr, "write to dot11WEPKeyMappingValue not ASN_OCTET_STR\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( string )) {
++        fprintf ( stderr, "write to dot11WEPKeyMappingValue: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11WEPKeyMappingStatus(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11WEPKeyMappingStatus not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11WEPKeyMappingStatus: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11PrivacyInvoked(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11PrivacyInvoked not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11PrivacyInvoked: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11WEPDefaultKeyID(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11WEPDefaultKeyID not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11WEPDefaultKeyID: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11WEPKeyMappingLength(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11WEPKeyMappingLength not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11WEPKeyMappingLength: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11ExcludeUnencrypted(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11ExcludeUnencrypted not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr,"write to dot11ExcludeUnencrypted: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11RTSThreshold(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ){
++        fprintf ( stderr, "write to dot11RTSThreshold not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11RTSThreshold: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11ShortRetryLimit(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11ShortRetryLimit not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11ShortRetryLimit: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11LongRetryLimit(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11LongRetryLimit not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr,"write to dot11LongRetryLimit: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11FragmentationThreshold(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11FragmentationThreshold not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr,"write to dot11FragmentationThreshold: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11MaxTransmitMSDULifetime(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11MaxTransmitMSDULifetime not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11MaxTransmitMSDULifetime: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11MaxReceiveLifetime(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11MaxReceiveLifetime not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11MaxReceiveLifetime: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11Address(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static unsigned char string[SPRINT_MAX_LEN];
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_OCTET_STR ) {
++        fprintf ( stderr, "write to dot11Address not ASN_OCTET_STR\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( string )){
++        fprintf ( stderr, "write to dot11Address: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11GroupAddressesStatus(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11GroupAddressesStatus not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr,"write to dot11GroupAddressesStatus: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CurrentRegDomain(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CurrentRegDomain not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11CurrentRegDomain: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CurrentTxAntenna(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CurrentTxAntenna not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11CurrentTxAntenna: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CurrentRxAntenna(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CurrentRxAntenna not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr,"write to dot11CurrentRxAntenna: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CurrentTxPowerLevel(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CurrentTxPowerLevel not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11CurrentTxPowerLevel: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CurrentChannelNumber(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CurrentChannelNumber not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr,"write to dot11CurrentChannelNumber: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CurrentDwellTime(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CurrentDwellTime not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11CurrentDwellTime: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CurrentSet(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CurrentSet not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11CurrentSet: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CurrentPattern(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CurrentPattern not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11CurrentPattern: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CurrentIndex(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CurrentIndex not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11CurrentIndex: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CurrentChannel(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CurrentChannel not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11CurrentChannel: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CurrentCCAMode(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CurrentCCAMode not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr,"write to dot11CurrentCCAMode: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11EDThreshold(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11EDThreshold not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11EDThreshold: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CCAWatchdogTimerMax(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CCAWatchdogTimerMax not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11CCAWatchdogTimerMax: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CCAWatchdogCountMax(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CCAWatchdogCountMax not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11CCAWatchdogCountMax: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CCAWatchdogTimerMin(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CCAWatchdogTimerMin not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11CCAWatchdogTimerMin: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11CCAWatchdogCountMin(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11CCAWatchdogCountMin not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11CCAWatchdogCountMin: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11SupportedTxAntenna(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11SupportedTxAntenna not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11SupportedTxAntenna: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11SupportedRxAntenna(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11SupportedRxAntenna not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr,"write to dot11SupportedRxAntenna: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++int
++write_dot11DiversitySelectionRx(int      action,
++            u_char   *var_val,
++            u_char   var_val_type,
++            size_t   var_val_len,
++            u_char   *statP,
++            oid      *name,
++            size_t   name_len)
++{
++  static long *long_ret;
++  int size;
++
++  switch ( action ) {
++
++    case RESERVE1:
++      if ( var_val_type != ASN_INTEGER ) {
++        fprintf ( stderr, "write to dot11DiversitySelectionRx not ASN_INTEGER\n" );
++        return SNMP_ERR_WRONGTYPE;
++      }
++      if ( var_val_len > sizeof ( long_ret )){
++        fprintf ( stderr, "write to dot11DiversitySelectionRx: bad length\n" );
++        return SNMP_ERR_WRONGLENGTH;
++      }
++      break;
++
++    case RESERVE2:
++    case FREE:
++    case ACTION:
++    case UNDO:
++      break;
++
++    case COMMIT:
++      break;
++  }
++
++  return SNMP_ERR_NOERROR;
++}
++
++/****************************************************************************
++*                                                                           *
++*                      loadTables() - Load the Tables                       *
++*                                                                           *
++****************************************************************************/
++static void loadTables()
++{
++  int skfd;                               // generic raw socket desc
++  struct iwreq wrq;                       // ioctl request structure
++  struct ifreq ifr;
++  struct timeval et;                      // elapsed time
++  struct wireless_info info;              // workarea for wireless ioctl information
++  FILE *fp;
++  char  bfr[1024], ifName[1024];
++  char *s, *t;
++
++  gettimeofday ( &et, ( struct timezone * ) 0 );  // get time-of-day
++  if ( et.tv_sec < lastLoad + MINLOADFREQ )       // only reload so often
++    return;
++  lastLoad = et.tv_sec;
++
++  skfd = openSocket();                            // open socket
++  if ( skfd < 0 ) {
++    syslog ( LOG_ERR, "SNMP ieee802dot11.loadTables() - %s\n", "socket open failure" );
++    return;
++  }
++
++  flushLists();
++
++  // find interfaces in /proc/net/dev and find the wireless interfaces
++  fp = fopen ( PROC_NET_DEV, "r" );
++  if ( fp ) {
++    while ( fgets ( bfr, sizeof ( bfr ), fp )) {
++      if ( strstr ( bfr, ":" )) {
++        s = bfr; t = ifName;
++        while ( isspace ( *s ))                     // discard white space
++          *s++;
++        while ( *s != ':' )                         // get interface name
++          *t++ = *s++;
++        *t = '\0';
++
++        // verify as a wireless device
++        memset (( char * ) &info, 0, sizeof ( struct wireless_info ));
++        strncpy ( wrq.ifr_name, ifName, IFNAMSIZ );
++        if ( ioctl ( skfd, SIOCGIWNAME, &wrq ) >= 0 ) {
++          printf ( "%s ifName: %s\n", "loadTables() -", ifName );
++          initStructs();
++          loadWiExt( skfd, ifName, &info );
++          displayWiExt ( info );
++          load80211Structs ( skfd, ifName, &info );
++        }
++      }
++    }
++    fclose ( fp );
++  }
++
++  close ( skfd );
++}
++
++/****************************************************************************
++*                                                                           *
++*              load80211Structs() - load the 802.11 structures              *
++*                                                                           *
++****************************************************************************/
++static void 
++load80211Structs ( int skfd, char *ifName, struct wireless_info *wi )
++{
++  int rc, ifIndex = 0;
++  struct ifreq ifr;
++  char  MACAddress [ MACADDR_LEN + 1 ];
++
++  strcpy ( ifr.ifr_name, ifName );
++  rc = ioctl ( skfd, SIOCGIFHWADDR, &ifr );
++  if ( rc >= 0 ) {
++
++    sprintf ( MACAddress, "%02X:%02X:%02X:%02X:%02X:%02X", 
++                 ( UCHAR ) ifr.ifr_hwaddr.sa_data[0], ( UCHAR ) ifr.ifr_hwaddr.sa_data[1], 
++                 ( UCHAR ) ifr.ifr_hwaddr.sa_data[2], ( UCHAR ) ifr.ifr_hwaddr.sa_data[3], 
++                 ( UCHAR ) ifr.ifr_hwaddr.sa_data[4], ( UCHAR ) ifr.ifr_hwaddr.sa_data[5] );
++
++    nSc.haveStationID = TRUE;
++    strcpy  ( nSc.stationID, MACAddress );
++    nOp.haveMACAddress = TRUE;
++    strcpy  ( nOp.MACAddress, MACAddress );
++    nRi.haveManufacturerOUI = TRUE;
++    strncpy ( nRi.manufacturerOUI, MACAddress, MAN_OUI_LEN ); 
++
++    ifIndex = if_nametoindex ( ifName );
++    if ( !ifIndex ) {
++      syslog ( LOG_ERR, "SNMP %s - %s %s\n", 
++        "ieee802dot11.load80211Structs()", ifName, "has no ifIndex" );
++      return;
++    }
++
++    loadWiExtTo80211Structs ( ifIndex, ifName, wi );
++
++    if ( hasChanged (( char * ) &nSc, sizeof ( nSc ))) {
++      nSc.ifIndex = ifIndex;
++      sprintf ( nSc.UID, "%04ld", nSc.ifIndex );
++      strcpy ( nSc.ifName, ifName );
++      addList (( char * ) &scList, ( char * ) &nSc, sizeof ( nSc ));
++    }
++
++    if ( hasChanged (( char * ) &nPr, sizeof ( nPr ))) {
++      nPr.ifIndex = ifIndex;
++      sprintf ( nPr.UID, "%04ld", nPr.ifIndex );
++      strcpy ( nPr.ifName, ifName );
++      addList (( char * ) &prList, ( char * ) &nPr, sizeof ( nPr ));
++    }
++
++    if ( hasChanged (( char * ) &nOp, sizeof ( nOp ))) {
++      nOp.ifIndex = ifIndex;
++      sprintf ( nOp.UID, "%04ld", nOp.ifIndex );
++      strcpy ( nOp.ifName, ifName );
++      addList (( char * ) &opList, ( char * ) &nOp, sizeof ( nOp ));
++    }
++
++    if ( hasChanged (( char * ) &nCo, sizeof ( nCo ))) {
++      nCo.ifIndex = ifIndex;
++      sprintf ( nCo.UID, "%04ld", nCo.ifIndex );
++      strcpy ( nCo.ifName, ifName );
++      addList (( char * ) &coList, ( char * ) &nCo, sizeof ( nCo ));
++    }
++
++    if ( hasChanged (( char * ) &nRi, sizeof ( nRi ))) {
++      nRi.ifIndex = ifIndex;
++      sprintf ( nRi.UID, "%04ld", nRi.ifIndex );
++      strcpy ( nRi.ifName, ifName );
++      addList (( char * ) &riList, ( char * ) &nRi, sizeof ( nRi ));
++    }
++
++    if ( hasChanged (( char * ) &nPo, sizeof ( nPo ))) {
++      nPo.ifIndex = ifIndex;
++      sprintf ( nPo.UID, "%04ld", nPo.ifIndex );
++      strcpy ( nPo.ifName, ifName );
++      addList (( char * ) &poList, ( char * ) &nPo, sizeof ( nPo ));
++    }
++
++    if ( hasChanged (( char * ) &nPa, sizeof ( nPa ))) {
++      nPa.ifIndex = ifIndex;
++      sprintf ( nPa.UID, "%04ld", nPa.ifIndex );
++      strcpy ( nPa.ifName, ifName );
++      addList (( char * ) &paList, ( char * ) &nPa, sizeof ( nPa ));
++    }
++
++    if ( hasChanged (( char * ) &nPt, sizeof ( nPt ))) {
++      nPt.ifIndex = ifIndex;
++      sprintf ( nPt.UID, "%04ld", nPt.ifIndex );
++      strcpy ( nPt.ifName, ifName );
++      addList (( char * ) &ptList, ( char * ) &nPt, sizeof ( nPt ));
++    }
++
++    if ( hasChanged (( char * ) &nPf, sizeof ( nPf ))) {
++      nPf.ifIndex = ifIndex;
++      sprintf ( nPf.UID, "%04ld", nPf.ifIndex );
++      strcpy ( nPf.ifName, ifName );
++      addList (( char * ) &pfList, ( char * ) &nPf, sizeof ( nPf ));
++    }
++
++    if ( hasChanged (( char * ) &nPd, sizeof ( nPd ))) {
++      nPd.ifIndex = ifIndex;
++      sprintf ( nPd.UID, "%04ld", nPd.ifIndex );
++      strcpy ( nPd.ifName, ifName );
++      addList (( char * ) &pdList, ( char * ) &nPd, sizeof ( nPd ));
++    }
++
++    if ( hasChanged (( char * ) &nPi, sizeof ( nPi ))) {
++      nPi.ifIndex = ifIndex;
++      sprintf ( nPi.UID, "%04ld", nPi.ifIndex );
++      strcpy ( nPi.ifName, ifName );
++      addList (( char * ) &piList, ( char * ) &nPi, sizeof ( nPi ));
++    }
++  }
++
++//printf ( "%s - ifIndex: %ld ifName: %s UID: %s\n", 
++//         "load80211Structs() - HASCHANGED", ifIndex, ifName, nSc.UID );
++}
++
++/****************************************************************************
++*                                                                           *
++*                     initStructs() - initialize structures                 *
++*                                                                           *
++****************************************************************************/
++static void initStructs()
++{
++  int i;
++
++  // 802.11 MIB Stuctures
++  memset (( char * ) &nSc, 0, sizeof ( nSc ));  memset (( char * ) &nAa, 0, sizeof ( nAa ));
++  memset (( char * ) &nDf, 0, sizeof ( nDf ));  memset (( char * ) &nKm, 0, sizeof ( nKm ));
++  memset (( char * ) &nPr, 0, sizeof ( nPr ));  memset (( char * ) &nOp, 0, sizeof ( nOp ));
++  memset (( char * ) &nCo, 0, sizeof ( nCo ));  memset (( char * ) &nGa, 0, sizeof ( nGa ));
++  memset (( char * ) &nRi, 0, sizeof ( nRi ));  memset (( char * ) &nPo, 0, sizeof ( nPo ));
++  memset (( char * ) &nPa, 0, sizeof ( nPa ));  memset (( char * ) &nPt, 0, sizeof ( nPt ));
++  memset (( char * ) &nPf, 0, sizeof ( nPf ));  memset (( char * ) &nPd, 0, sizeof ( nPd ));
++  memset (( char * ) &nPi, 0, sizeof ( nPi ));  memset (( char * ) &nRd, 0, sizeof ( nRd ));
++  memset (( char * ) &nAl, 0, sizeof ( nAl ));  memset (( char * ) &nRt, 0, sizeof ( nRt ));
++  memset (( char * ) &nRr, 0, sizeof ( nRr ));
++
++  // Wireless Extensions
++  wepCurrentKey = 0;
++  haveWepCurrentKey = FALSE;
++  for ( i = 0; i < MAX_WEP_KEYS; i++ ) {
++    wep[i].len = 0;
++    wep[i].key[0] = '\0';
++    wep[i].haveKey = FALSE;
++  }
++}
++
++/****************************************************************************
++*                                                                           *
++*                Wireless Extensions Specific Functions                     *
++*                                                                           *
++****************************************************************************/
++/****************************************************************************
++*                                                                           *
++* loadWiExtTo80211Structs() - load wireless extensions to 802.11 structures *
++*                                                                           *
++****************************************************************************/
++static void 
++loadWiExtTo80211Structs ( int ifIndex, char *ifName, struct wireless_info *wi )
++{
++  int i, j = 0;
++
++  // dot11Smt Group
++  // dot11StationConfigTable
++  nSc.havePrivacyOptionImplemented = TRUE;
++  nSc.privacyOptionImplemented = 1;           // assume we support WEP
++
++  if ( wi->has_power ) {
++    nSc.havePowerManagementMode = TRUE;
++    nSc.powerManagementMode = 1;              // assume power is active
++    if ( !wi->power.disabled && 
++          wi->power.flags & IW_POWER_MIN )
++      nSc.powerManagementMode = 2;            // power save mode
++  }
++
++  if ( wi->has_essid && strlen ( wi->essid )) {
++    nSc.haveDesiredSSID = TRUE;
++    strcpy ( nSc.desiredSSID, wi->essid ); 
++  }
++
++  if ( wi->has_mode ) {
++    nSc.haveDesiredBSSType = TRUE;
++    if ( wi->mode == IW_MODE_ADHOC ) 
++      nSc.desiredBSSType = 2;         // independent
++    else if ( wi->has_ap_addr )
++      nSc.desiredBSSType = 1;         // infrastructure
++    else
++      nSc.desiredBSSType = 3;         // any
++  }
++
++  if ( wi->has_range ) {
++    for ( i = 0; i < wi->range.num_bitrates && j < 126; i++ ) {
++      nSc.haveOperationalRateSet = TRUE;
++      nSc.operationalRateSet[j++] = ( char ) ( wi->range.bitrate[i] / 500000L );
++    }
++  }
++
++  // dot11AuthenticationAlgorithmsTable
++  nAa.haveAuthenticationAlgorithm = TRUE;           // it's a rule to always have 
++  nAa.haveAuthenticationAlgorithmsEnable = TRUE;    //    'open' supported
++  nAa.ifIndex = ifIndex;
++  nAa.authenticationAlgorithmsIndex = 1;            // index number one
++  nAa.authenticationAlgorithm = 1;                  // 1 => open key
++  sprintf ( nAa.UID, "%04ld%04ld", nAa.ifIndex, nAa.authenticationAlgorithmsIndex );
++  nAa.authenticationAlgorithmsEnable = 1;           // enabled by default
++  if ( ( wi->has_key                        ) &&
++       ( wi->key_size  != 0                 ) &&
++      !( wi->key_flags & IW_ENCODE_DISABLED ))
++    nAa.authenticationAlgorithmsEnable = 2;
++  addList (( char * ) &aaList, ( char * ) &nAa, sizeof ( nAa ));
++
++  nAa.haveAuthenticationAlgorithm = TRUE;           // I'm gonna assume we always support WEP
++  nAa.haveAuthenticationAlgorithmsEnable = TRUE;
++  nAa.ifIndex = ifIndex;
++  nAa.authenticationAlgorithmsIndex = 2;            // index number 2
++  nAa.authenticationAlgorithm = 2;                  // 2 => shared key
++  sprintf ( nAa.UID, "%04ld%04ld", nAa.ifIndex, nAa.authenticationAlgorithmsIndex );
++  nAa.authenticationAlgorithmsEnable = 2;
++  if ( ( wi->has_key                        ) &&
++       ( wi->key_size  != 0                 ) &&
++      !( wi->key_flags & IW_ENCODE_DISABLED ))
++    nAa.authenticationAlgorithmsEnable = 1;         // disabled by default
++  addList (( char * ) &aaList, ( char * ) &nAa, sizeof ( nAa ));
++
++  //dot11WEPDefaultKeysTable
++  if ( wi->has_range ) {
++    for ( i = 0; i < MAX_WEP_KEYS; i++ ) {
++      nDf.haveWEPDefaultKeyValue = TRUE;
++      nDf.ifIndex = ifIndex;
++      nDf.WEPDefaultKeyIndex = i + 1;               // index number
++      sprintf ( nDf.UID, "%04ld%04ld", nDf.ifIndex, nDf.WEPDefaultKeyIndex );
++      if ( wep[i].haveKey )
++        strcpy ( nDf.WEPDefaultKeyValue, "*****" );
++      else
++        nDf.WEPDefaultKeyValue[0] = '\0';
++      addList (( char * ) &dfList, ( char * ) &nDf, sizeof ( nDf ));
++    }
++  }
++
++  // dot11PrivacyTable
++  nPr.havePrivacyInvoked = TRUE;
++  nPr.privacyInvoked = 2;                   // 2 => FALSE
++  nPr.haveWEPDefaultKeyID = TRUE;
++  nPr.WEPDefaultKeyID = 0;
++  nPr.haveExcludeUnencrypted = TRUE;
++  nPr.excludeUnencrypted = 2;               // 2 => FALSE
++  if ( wi->has_range ) {
++    if ( ( wi->key_size != 0 ) &&
++        !( wi->key_flags & IW_ENCODE_DISABLED )) {
++       nPr.privacyInvoked = 1;
++       if ( wi->key_flags & IW_ENCODE_RESTRICTED )
++          nPr.excludeUnencrypted = 1;
++       nPr.WEPDefaultKeyID = wepCurrentKey;
++    }
++  }
++
++  // dot11Mac Group
++  // dot11OperationTable
++  if ( wi->has_range ) {
++    nOp.haveRTSThreshold = TRUE;
++    nOp.RTSThreshold = wi->range.max_rts;
++  }
++
++  if ( wi->has_frag && wi->frag.value ) {
++    nOp.haveFragmentationThreshold = TRUE;
++    nOp.fragmentationThreshold = wi->frag.value;
++  }
++
++  // dot11Phy Group
++  // dot11PhyOperationTable
++  if ( strstr ( wi->name, "IEEE 802.11-FS"      )) nPo.PHYType = 1;   // So what if I
++  if ( strstr ( wi->name, "IEEE 802.11-DS"      )) nPo.PHYType = 2;   // made up a couple?
++  if ( strstr ( wi->name, "IEEE 802.11-IR"      )) nPo.PHYType = 3;   
++  if ( strstr ( wi->name, "IEEE 802.11-OFDM"    )) nPo.PHYType = 4;   // 802.11a
++  if ( strstr ( wi->name, "IEEE 802.11-OFDM/DS" )) nPo.PHYType = 5;   // 802.11g
++  if ( strstr ( wi->name, "IEEE 802.11-TURBO"   )) nPo.PHYType = 6;   // Atheros TURBO mode
++  if ( nPo.PHYType ) nPo.havePHYType = TRUE;
++
++  // dot11PhyDSSSTable
++  if ( wi->has_range ) { // && wi->freq <= ( double ) 2483000000 ) {  // DSSS frequencies only
++    for ( i = 0; i < wi->range.num_frequency; i++ ) {
++      if ((( double ) ( wi->range.freq[i].e * 10 ) * ( double ) wi->range.freq[i].m ) == wi->freq ) {
++        nPd.haveCurrentChannel = TRUE;
++        nPd.currentChannel = wi->range.freq[i].i; 
++      }
++    }
++  }
++
++  // dot11SupportedDataRatesTxTable
++  if ( wi->has_range ) {
++    for ( i = 0; i < wi->range.num_bitrates; i++ ) {
++      nRt.ifIndex = ifIndex;
++      nRt.supportedDataRatesTxIndex = i + 1;
++      nRt.supportedDataRatesTxValue = wi->range.bitrate[i] / 500000L;
++      nRt.haveSupportedDataRatesTxValue = TRUE;
++      sprintf ( nRt.UID, "%04ld%04ld", nRt.ifIndex, nRt.supportedDataRatesTxIndex );
++      strcpy ( nRt.ifName, ifName );
++      addList (( char * ) &rtList, ( char * ) &nRt, sizeof ( nRt ));
++    }
++  }
++
++  // dot11SupportedDataRatesRxTable
++  if ( wi->has_range ) {
++    for ( i = 0; i < wi->range.num_bitrates; i++ ) {
++      nRr.ifIndex = ifIndex;
++      nRr.supportedDataRatesRxIndex = i + 1;
++      nRr.supportedDataRatesRxValue = wi->range.bitrate[i] / 500000L;
++      nRr.haveSupportedDataRatesRxValue = TRUE;
++      sprintf ( nRr.UID, "%04ld%04ld", nRr.ifIndex, nRr.supportedDataRatesRxIndex );
++      strcpy ( nRr.ifName, ifName );
++      addList (( char * ) &rrList, ( char * ) &nRr, sizeof ( nRr ));
++    }
++  }
++
++//printf ( "%s max_encoding_tokens: %d\n", 
++//          "loadWiExtTo80211Structs() - ", wi->range.max_encoding_tokens );
++}
++
++/****************************************************************************
++*                                                                           *
++*      loadWiExt() - load wireless extensions structures;                   *
++*                    use ioctl calls and read /proc/net/wireless            *
++*                                                                           *
++****************************************************************************/
++static void loadWiExt ( int skfd, char *ifname, struct wireless_info *wi )
++{
++  struct iwreq wrq;                       // ioctl request structure
++  FILE *fp;
++  char  bfr[1024];
++  char  buffer[sizeof ( iwrange ) * 2]; /* Large enough */
++  char *s, *t;
++  int i, j;
++
++  strncpy ( wrq.ifr_name, ifname, IFNAMSIZ );
++
++  /* Get wireless name */
++  if ( ioctl ( skfd, SIOCGIWNAME, &wrq ) >= 0 ) {
++    strncpy ( wi->name, wrq.u.name, IFNAMSIZ );
++    wi->name[IFNAMSIZ] = '\0';
++  }
++
++  /* Get ranges */    // NOTE: some version checking in iwlib.c
++  memset ( buffer, 0, sizeof ( buffer ));
++  wrq.u.data.pointer = ( caddr_t ) &buffer;
++  wrq.u.data.length = sizeof ( buffer );
++  wrq.u.data.flags = 0;
++  if ( ioctl ( skfd, SIOCGIWRANGE, &wrq ) >= 0 ) {
++    memcpy (( char * ) &wi->range, buffer, sizeof ( iwrange ));
++    wi->has_range = 1;
++  }
++
++  /* Get network ID */
++  if ( ioctl ( skfd, SIOCGIWNWID, &wrq ) >= 0 ) {
++    memcpy ( &wi->nwid, &wrq.u.nwid, sizeof ( iwparam ));
++    wi->has_nwid = 1;
++  }
++
++  /* Get frequency / channel */         // THIS NUMBER LOOKS FUNNY
++  if ( ioctl ( skfd, SIOCGIWFREQ, &wrq ) >= 0 ) {
++    wi->has_freq = 1;
++    wi->freq = (( double ) wrq.u.freq.m ) * pow ( 10, wrq.u.freq.e );
++  }
++
++  /* Get sensitivity */
++  if ( ioctl ( skfd, SIOCGIWSENS, &wrq ) >= 0 ) {
++    wi->has_sens = 1;
++    memcpy ( &wi->sens, &wrq.u.sens, sizeof ( iwparam ));
++  }
++
++  /* Get encryption information */
++  wrq.u.data.pointer = ( caddr_t ) &wi->key;
++  wrq.u.data.length = IW_ENCODING_TOKEN_MAX;
++  wrq.u.data.flags = 0;
++  if ( ioctl ( skfd, SIOCGIWENCODE, &wrq ) >= 0 ) {
++    wi->has_key = 1;
++    wi->key_size = wrq.u.data.length;
++    wi->key_flags = wrq.u.data.flags;
++    wepCurrentKey = wrq.u.data.flags & IW_ENCODE_INDEX;
++  }
++
++  for ( i = 0; i < wi->range.max_encoding_tokens; i++ ) {
++    wrq.u.data.pointer = ( caddr_t ) &wi->key;
++    wrq.u.data.length = IW_ENCODING_TOKEN_MAX;
++    wrq.u.data.flags = i;
++    if ( ioctl ( skfd, SIOCGIWENCODE, &wrq ) >= 0 ) {
++      if ( ( wrq.u.data.length != 0 ) &&
++          !( wrq.u.data.flags & IW_ENCODE_DISABLED )) {
++        wep[i].len = wrq.u.data.length;
++        wep[i].haveKey = TRUE;
++        t = wep[i].key;
++        for ( j = 0; j < wrq.u.data.length; j++ ) {
++          if (( j & 0x1 ) == 0 && j != 0 )
++        	  strcpy ( t++, "-");
++          sprintf ( t, "%.2X", wi->key[j] );
++          t += 2;
++        }
++        t = '\0';
++      }
++    }
++  }
++
++  /* Get ESSID */
++  wrq.u.essid.pointer = ( caddr_t ) &wi->essid;
++  wrq.u.essid.length = IW_ESSID_MAX_SIZE + 1;
++  wrq.u.essid.flags = 0;
++  if ( ioctl ( skfd, SIOCGIWESSID, &wrq ) >= 0 ) {
++    wi->has_essid = 1;
++    wi->essid_on = wrq.u.data.flags;
++  }
++
++  /* Get AP address */
++  if ( ioctl ( skfd, SIOCGIWAP, &wrq ) >= 0 ) {
++    wi->has_ap_addr = 1;
++    memcpy ( &wi->ap_addr, &wrq.u.ap_addr, sizeof ( sockaddr ));
++  }
++
++  /* Get NickName */
++  wrq.u.essid.pointer = ( caddr_t ) &wi->nickname;
++  wrq.u.essid.length = IW_ESSID_MAX_SIZE + 1;
++  wrq.u.essid.flags = 0;
++  if ( ioctl ( skfd, SIOCGIWNICKN, &wrq ) >= 0 ) {
++    if ( wrq.u.data.length > 1 )
++      wi->has_nickname = 1;
++  }
++
++  /* Get bit rate */
++  if ( ioctl ( skfd, SIOCGIWRATE, &wrq ) >= 0 ) {
++    wi->has_bitrate = 1;
++    memcpy ( &wi->bitrate, &wrq.u.bitrate, sizeof ( iwparam ));
++  }
++
++  /* Get RTS threshold */
++  if ( ioctl ( skfd, SIOCGIWRTS, &wrq ) >= 0 ) {
++    wi->has_rts = 1;
++    memcpy ( &wi->rts, &wrq.u.rts, sizeof ( iwparam ));
++  }
++
++  /* Get fragmentation threshold */
++  if ( ioctl ( skfd, SIOCGIWFRAG, &wrq ) >= 0 ) {
++      wi->has_frag = 1;
++      memcpy ( &wi->frag, &wrq.u.frag, sizeof ( iwparam ));
++    }
++
++  /* Get operation mode */
++  if ( ioctl ( skfd, SIOCGIWMODE, &wrq ) >= 0 ) {
++      wi->mode = wrq.u.mode;
++      if ( wi->mode < IW_NUM_OPER_MODE && wi->mode >= 0 )
++        wi->has_mode = 1;
++  }
++
++  /* Get Power Management settings */                 // #if WIRELESS_EXT > 9
++  wrq.u.power.flags = 0;
++  if ( ioctl ( skfd, SIOCGIWPOWER, &wrq ) >= 0 ) {
++    wi->has_power = 1;
++    memcpy ( &wi->power, &wrq.u.power, sizeof ( iwparam ));
++  }
++
++  /* Get retry limit/lifetime */                      // #if WIRELESS_EXT > 10
++  if ( ioctl ( skfd, SIOCGIWRETRY, &wrq ) >= 0 ) {    
++    wi->has_retry = 1;
++    memcpy ( &wi->retry, &wrq.u.retry, sizeof ( iwparam ));
++  }
++
++  /* Get stats */                                     // #if WIRELESS_EXT > 11
++  wrq.u.data.pointer = ( caddr_t ) &wi->stats;
++  wrq.u.data.length = 0;
++  wrq.u.data.flags = 1;   /* Clear updated flag */
++  if ( ioctl ( skfd, SIOCGIWSTATS, &wrq ) < 0 )
++    wi->has_stats = 1;
++
++  if ( !wi->has_stats ) {                        // no ioctl support, go to file
++    fp = fopen ( PROC_NET_WIRELESS, "r" );
++    if ( fp ) {
++      while ( fgets ( bfr, sizeof ( bfr ), fp )) {
++        bfr [ sizeof ( bfr ) - 1 ] = '\0';        // no buffer overruns here!
++        strtok (( char * ) &bfr, "\n" );          // '\n' => '\0'
++        if ( strstr ( bfr, ifname ) && strstr ( bfr, ":" )) {
++          wi->has_stats = 1;
++          s = bfr;
++          s = strchr ( s, ':' ); s++;             /* Skip ethX:   */
++          s = strtok ( s, " " );                  /* ' ' => '\0'  */
++          sscanf ( s, "%hX", &wi->stats.status ); // status 
++
++          s = strtok ( NULL, " " );               // link quality
++          if ( strchr ( s, '.' ) != NULL )
++            wi->stats.qual.updated |= 1;
++          sscanf ( s, "%hhd", &wi->stats.qual.qual );
++
++          s = strtok ( NULL, " " );               // signal level
++          if ( strchr ( s,'.' ) != NULL )
++            wi->stats.qual.updated |= 2;
++          sscanf ( s, "%hhd", &wi->stats.qual.level );
++
++          s = strtok ( NULL, " " );               // noise level
++          if ( strchr ( s, '.' ) != NULL )
++            wi->stats.qual.updated += 4;
++          sscanf ( s, "%hhd", &wi->stats.qual.noise );
++
++          s = strtok ( NULL, " " ); sscanf ( s, "%d", &wi->stats.discard.nwid     );
++          s = strtok ( NULL, " " ); sscanf ( s, "%d", &wi->stats.discard.code     );
++          s = strtok ( NULL, " " ); sscanf ( s, "%d", &wi->stats.discard.fragment );
++          s = strtok ( NULL, " " ); sscanf ( s, "%d", &wi->stats.discard.retries  );
++          s = strtok ( NULL, " " ); sscanf ( s, "%d", &wi->stats.discard.misc     );
++          s = strtok ( NULL, " " ); sscanf ( s, "%d", &wi->stats.miss.beacon      );
++        }
++      }
++      fclose ( fp );
++    }
++  }
++
++// printf ( "%s bfr: %s\n", "loadTables()", bfr );
++}
++
++/****************************************************************************
++*                                                                           *
++*       displayWiExt() - show what I got from Wireless Extensions           *
++*                                                                           *
++****************************************************************************/
++static void displayWiExt ( struct wireless_info info )
++{
++#ifdef DISPLAYWIEXT
++  int i;
++  char title[] = "displayWiExt() -";
++
++  printf ( "========================================\n" );
++  printf ( "===> Wireless Extension IOCTL calls <===\n" );
++  printf ( "========================================\n" );
++
++  if ( strlen ( info.name ))
++    printf ( "%s name: %s\n", "SIOCGIWNAME", info.name );
++  else
++    printf ( "%s\n", "no info.name support" );
++
++  if ( info.has_nickname = 1 )
++    printf ( "%s nickname: %s\n", "SIOCGIWNICKN", info.nickname );
++  else
++    printf ( "%s %s\n", "SIOCGIWNICKN", " ===> no info.nickname support" );
++
++  if ( info.has_essid ) 
++    printf ( "%s essid_on: %d essid: %s\n", "SIOCGIWESSID", info.essid_on, info.essid );
++  else
++    printf ( "%s %s\n", "SIOCGIWESSID", " ===> no info.essid support" );
++
++  if ( info.has_range ) {
++    printf ( "%s throughput: %d\n",           "SIOCGIWRANGE", info.range.throughput );
++    printf ( "%s min_nwid: %d\n",             "SIOCGIWRANGE", info.range.min_nwid  );
++    printf ( "%s max_nwid: %d\n",             "SIOCGIWRANGE", info.range.max_nwid  );
++    printf ( "%s sensitivity: %d\n",          "SIOCGIWRANGE", info.range.sensitivity );
++    printf ( "%s num_bitrates: %d\n",         "SIOCGIWRANGE", info.range.num_bitrates );
++    for ( i = 0; i < info.range.num_bitrates; i++ ) 
++      printf ( "%s bitrate[%d]: %d\n",        "SIOCGIWRANGE", i, info.range.bitrate[i]  );
++    printf ( "%s min_rts: %d\n",              "SIOCGIWRANGE", info.range.min_rts );
++    printf ( "%s max_rts: %d\n",              "SIOCGIWRANGE", info.range.max_rts );
++    printf ( "%s min_frag: %d\n",             "SIOCGIWRANGE", info.range.min_frag );
++    printf ( "%s max_frag: %d\n",             "SIOCGIWRANGE", info.range.max_frag );
++    printf ( "%s min_pmp: %d\n",              "SIOCGIWRANGE", info.range.min_pmp );
++    printf ( "%s max_pmp: %d\n",              "SIOCGIWRANGE", info.range.max_pmp );
++    printf ( "%s min_pmt: %d\n",              "SIOCGIWRANGE", info.range.min_pmt );
++    printf ( "%s max_pmt: %d\n",              "SIOCGIWRANGE", info.range.max_pmt );
++    printf ( "%s pmp_flags: %d\n",            "SIOCGIWRANGE", info.range.pmp_flags );
++    printf ( "%s pmt_flags: %d\n",            "SIOCGIWRANGE", info.range.pmt_flags );
++    printf ( "%s pm_capa: %d\n",              "SIOCGIWRANGE", info.range.pm_capa );
++    printf ( "%s num_encoding_sizes: %d\n",   "SIOCGIWRANGE", info.range.num_encoding_sizes );
++    for ( i = 0; i < info.range.num_encoding_sizes; i++ ) 
++      printf ( "%s encoding_size[%d]: %d\n",  "SIOCGIWRANGE", i, info.range.encoding_size[i]  );
++    printf ( "%s max_encoding_tokens: %d\n",  "SIOCGIWRANGE", info.range.max_encoding_tokens );
++//  printf ( "%s encoding_login_index: %d\n", "SIOCGIWRANGE", info.range.encoding_login_index );
++    printf ( "%s txpower_capa: %d\n",         "SIOCGIWRANGE", info.range.txpower_capa );
++    printf ( "%s num_txpower: %d dBm\n",      "SIOCGIWRANGE", info.range.num_txpower );
++    for ( i = 0; i < info.range.num_txpower; i++ ) 
++      printf ( "%s txpower[%d]: %d\n",        "SIOCGIWRANGE", i, info.range.txpower[i]  );
++    printf ( "%s we_version_compiled: %d\n",  "SIOCGIWRANGE", info.range.we_version_compiled );
++    printf ( "%s we_version_source: %d\n",    "SIOCGIWRANGE", info.range.we_version_source );
++    printf ( "%s retry_capa: %d\n",           "SIOCGIWRANGE", info.range.retry_capa );
++    printf ( "%s retry_flags: %d\n",          "SIOCGIWRANGE", info.range.retry_flags );
++    printf ( "%s r_time_flags: %d\n",         "SIOCGIWRANGE", info.range.r_time_flags );
++    printf ( "%s min_retry: %d\n",            "SIOCGIWRANGE", info.range.min_retry );
++    printf ( "%s max_retry: %d\n",            "SIOCGIWRANGE", info.range.max_retry );
++    printf ( "%s min_r_time: %d\n",           "SIOCGIWRANGE", info.range.min_r_time );
++    printf ( "%s max_r_time: %d\n",           "SIOCGIWRANGE", info.range.max_r_time );
++    printf ( "%s num_channels: %d\n",         "SIOCGIWRANGE", info.range.num_channels );
++    printf ( "%s num_frequency: %d\n",        "SIOCGIWRANGE", info.range.num_frequency );
++    for ( i = 0; i < info.range.num_frequency; i++ ) 
++      printf ( "%s freq[%d].i: %d freq[%d].e: %d freq[%d].m: %d\n", "SIOCGIWRANGE", 
++                i, info.range.freq[i].i, i, info.range.freq[i].e, i, info.range.freq[i].m );
++  }
++  else
++    printf ( "%s %s\n", "SIOCGIWRANGE", " ===> no info.range support" );
++
++  if ( info.has_nwid ) 
++    printf ( "%s nwid - disabled: %d value: %X\n", "SIOCGIWNWID", info.nwid.disabled, info.nwid.value );
++  else
++    printf ( "%s %s\n", "SIOCGIWNWID", " ===> no info.nwid support" );
++
++  if ( info.has_freq ) {
++//  printf ( "%s freq: %g\n", "SIOCGIWFREQ", info.freq / GIGA );
++    printf ( "%s freq: %g\n", "SIOCGIWFREQ", info.freq );
++  }
++  else
++    printf ( "%s %s\n", "SIOCGIWFREQ", " ===> no info.freq support" );
++
++  if ( info.has_sens )
++    printf ( "%s sens: %" PRIdPTR "\n", "SIOCGIWSENS", *(intptr_t *)&info.sens );
++  else
++    printf ( "%s %s\n", "SIOCGIWSENS", " ===> no info.sens support" );
++
++  if ( info.has_key ) {
++    printf ( "%s key_size: %d key_flags: %d wepCurrentKey: %ld\n", 
++              "SIOCGIWENCODE", info.key_size, info.key_flags, wepCurrentKey );
++    printf ( "%s MODE: %d DISABLED: %d INDEX: %d OPEN: %d RESTRICTED: %d NOKEY: %d TEMP: %d\n",
++              "SIOCGIWENCODE",                           info.key_flags & IW_ENCODE_MODE,
++              info.key_flags & IW_ENCODE_DISABLED ? 1:0, info.key_flags & IW_ENCODE_INDEX,
++              info.key_flags & IW_ENCODE_OPEN     ? 1:0, info.key_flags & IW_ENCODE_RESTRICTED ? 1:0,
++              info.key_flags & IW_ENCODE_NOKEY    ? 1:0, info.key_flags & IW_ENCODE_TEMP       ? 1:0 );
++  }
++  else
++    printf ( "%s %s\n", "SIOCGIWENCODE", " ===> no info.key support" );
++
++  for ( i = 0; i < MAX_WEP_KEYS; i++ ) {
++    if ( wep[i].haveKey )
++      printf ( "%s wep[%d].len: %ld wep[%d].key: %s\n", 
++                "SIOCGIWENCODE", i, wep[i].len, i, wep[i].key );
++  }
++
++  if ( info.has_ap_addr )
++    printf ( "%s ap_addr.sa_data: %02X:%02X:%02X:%02X:%02X:%02X ap_addr.sa_family: %d\n", 
++              "SIOCGIWAP",  ( UCHAR ) info.ap_addr.sa_data[0], ( UCHAR ) info.ap_addr.sa_data[1], 
++                            ( UCHAR ) info.ap_addr.sa_data[2], ( UCHAR ) info.ap_addr.sa_data[3], 
++                            ( UCHAR ) info.ap_addr.sa_data[4], ( UCHAR ) info.ap_addr.sa_data[5], 
++                                      info.ap_addr.sa_family );
++  else
++    printf ( "%s %s\n", "SIOCGIWAP", " ===> no ap_addr information" );
++
++  if ( info.has_bitrate )
++    printf ( "%s bitrate: %" PRIdPTR " value: %d fixed: %d disabled: %d flags: %d\n", 
++              "SIOCGIWRATE", *(intptr_t *)&info.bitrate, info.bitrate.value, info.bitrate.fixed, 
++                             info.bitrate.disabled, info.bitrate.flags );
++  else
++    printf ( "%s %s\n", "SIOCGIWRATE", " ===> no info.bitrate support" );
++
++  if ( info.has_rts )
++    printf ( "%s rts: %" PRIdPTR "\n", "SIOCGIWRTS", *(intptr_t *)&info.rts );
++  else
++    printf ( "%s %s\n", "SIOCGIWRTS", " ===> no info.rts support" );
++
++  if ( info.has_frag )
++    printf ( "%s frag: %" PRIdPTR "\n", "SIOCGIWFRAG", *(intptr_t *)&info.frag );
++  else
++    printf ( "%s %s\n", "SIOCGIWFRAG", " ===> no info.frag support" );
++
++  if ( info.has_mode ) 
++    printf ( "%s mode: %d\n", "SIOCGIWMODE", info.mode );
++  else
++    printf ( "%s %s\n", "SIOCGIWMODE", " ===> no info.mode support" );
++
++  if ( info.has_power ) {
++    printf ( "%s power: %" PRIdPTR "\n", "SIOCGIWPOWER", *(intptr_t *)&info.power );
++    printf ( "%s disabled: %d MIN: %d MAX: %d TIMEOUT: %d RELATIVE: %d\n",
++              "SIOCGIWPOWER",
++              info.power.disabled                  ? 1:0, 
++              info.power.flags & IW_POWER_MIN      ? 1:0, 
++              info.power.flags & IW_POWER_MAX      ? 1:0, 
++              info.power.flags & IW_POWER_TIMEOUT  ? 1:0, 
++              info.power.flags & IW_POWER_RELATIVE ? 1:0 ); 
++    printf ( "%s UNICAST: %d MULTICAST: %d ALL: %d FORCE: %d REPEATER: %d\n",
++              "SIOCGIWPOWER",
++              info.power.flags & IW_POWER_UNICAST_R   ? 1:0, 
++              info.power.flags & IW_POWER_MULTICAST_R ? 1:0, 
++              info.power.flags & IW_POWER_ALL_R       ? 1:0, 
++              info.power.flags & IW_POWER_FORCE_S     ? 1:0, 
++              info.power.flags & IW_POWER_REPEATER    ? 1:0 ); 
++  }
++  else
++    printf ( "%s %s\n", "SIOCGIWPOWER", " ===> no info.power support" );
++
++  if ( info.has_retry )
++    printf ( "%s retry: %" PRIdPTR "\n", "SIOCGIWRETRY", *(intptr_t *)&info.retry );
++  else
++    printf ( "%s %s\n", "SIOCGIWRETRY", " ===> no info.retry support" );
++
++  if ( info.has_stats ) {
++    printf ( "%s status: %d\n",           "SIOCGIWSTATS", info.stats.status           );
++    printf ( "%s qual.level: %d\n",       "SIOCGIWSTATS", info.stats.qual.level       );
++    printf ( "%s qual.noise: %d\n",       "SIOCGIWSTATS", info.stats.qual.noise       );
++    printf ( "%s qual.qual: %d\n",        "SIOCGIWSTATS", info.stats.qual.qual        );
++    printf ( "%s qual.updated: %d\n",     "SIOCGIWSTATS", info.stats.qual.updated     );
++    printf ( "%s discard.code: %d\n",     "SIOCGIWSTATS", info.stats.discard.code     );
++    printf ( "%s discard.fragment: %d\n", "SIOCGIWSTATS", info.stats.discard.fragment );
++    printf ( "%s discard.misc: %d\n",     "SIOCGIWSTATS", info.stats.discard.misc     );
++    printf ( "%s discard.nwid: %d\n",     "SIOCGIWSTATS", info.stats.discard.nwid     );
++    printf ( "%s discard.retries: %d\n",  "SIOCGIWSTATS", info.stats.discard.retries  );
++    printf ( "%s miss.beacon: %d\n",      "SIOCGIWSTATS", info.stats.miss.beacon      );
++  }
++  else
++    printf ( "%s %s\n", "SIOCGIWSTATS", " ===> no info.stats support" );
++
++  if ( info.txpower.flags & IW_TXPOW_MWATT )
++    printf ( "%s txpower1: %d dBm disabled: %d fixed: %d flags: %d\n", "SIOCGIWRANGE", 
++      mWatt2dbm ( info.txpower.value ), info.txpower.disabled, info.txpower.fixed, info.txpower.flags);
++  else
++    printf ( "%s txpower2: %d dBm disabled: %d fixed: %d flags: %d\n", "SIOCGIWRANGE", info.txpower.value, info.txpower.disabled, info.txpower.fixed, info.txpower.flags );
++
++  if ( info.has_range ) 
++    if ( info.sens.value < 0 )
++      printf ( "%s sens: %d dBm\n", "SIOCGIWRANGE", info.sens.value );
++    else
++      printf ( "%s sens: %d/%d\n", "SIOCGIWRANGE", info.sens.value, info.range.sensitivity );
++
++  if ( info.has_range && ( info.stats.qual.level != 0 ))
++      if ( info.stats.qual.level > info.range.max_qual.level )
++        /* Statistics are in dBm (absolute power measurement) */
++        printf ( "%s Quality: %d/%d Signal level: %d dBm Noise level: %d dBm\n",
++                  "SIOCGIWRANGE",
++                  info.stats.qual.qual, info.range.max_qual.qual,
++                  info.stats.qual.level - 0x100,
++                  info.stats.qual.noise - 0x100 );
++      else
++        printf (  "%s Quality: %d/%d Signal level: %d/%d Noise level: %d/%d",
++                  "SIOCGIWRANGE",
++                  info.stats.qual.qual,  info.range.max_qual.qual,
++                  info.stats.qual.level, info.range.max_qual.level,
++                  info.stats.qual.noise, info.range.max_qual.noise );
++
++#endif // #ifdef DISPLAYWIEXT
++}
++
++/****************************************************************************
++*                                                                           *
++*                        Linked List Functions                              *
++*                                                                           *
++****************************************************************************/
++/****************************************************************************
++*                                                                           *
++*                addList() - add an entry to a linked list                  *
++*                                                                           *
++****************************************************************************/
++static void 
++addList ( char *l, char *data, int len  )
++{
++  char uid[256];
++  avList_t *list;       
++
++  // NOTE: this assumes the UID is at the beginning of the 
++  //       data structure and that UIDs are strings
++  
++  list = ( avList_t * ) l;            // NOTE: don't know how to get 
++  strcpy ( uid, data );                             //  rid of compiler warning on
++                                                    //  LISTHEAD typecast
++  // create a new node and the data that goes in it
++  newNode = malloc ( sizeof ( struct avNode ));
++  newNode->data = malloc ( len );
++  memcpy ( newNode->data, data, len );
++
++  // this deals with an empty list
++  if ( LIST_EMPTY ( list )) {
++    LIST_INSERT_HEAD ( list, newNode, nodes );
++    return;
++  }
++
++  // this deals with UIDs that match
++  for ( np = LIST_FIRST ( list ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    if ( strncmp ( uid, np->data, strlen ( uid )) == 0 ) {                      // found matching UID
++      LIST_INSERT_AFTER ( np, newNode, nodes );
++      if ( np->data )
++        free ( np->data );
++      LIST_REMOVE ( np, nodes );
++      free ( np );
++      return;
++    }
++  }
++
++  // this deals with inserting a new UID in the list
++  for ( np = LIST_FIRST ( list ); np != NULL; np = LIST_NEXT ( np, nodes )) {
++    lastNode = np;
++    if ( strncmp ( np->data, uid, strlen ( uid )) > 0 ) {                       // old ID > new ID AND
++      LIST_INSERT_BEFORE ( np, newNode, nodes );
++      return;
++    }
++  }
++
++  // this deals with a UID that needs to go on the end of the list
++  LIST_INSERT_AFTER ( lastNode, newNode, nodes );
++
++  return;
++}
++
++/****************************************************************************
++*                                                                           *
++*              initLists() - initialize all the linked lists                *
++*                                                                           *
++****************************************************************************/
++static void initLists()
++{
++  LIST_INIT ( &scList );  LIST_INIT ( &aaList );  LIST_INIT ( &dfList );
++  LIST_INIT ( &kmList );  LIST_INIT ( &prList );
++  LIST_INIT ( &opList );  LIST_INIT ( &coList );
++  LIST_INIT ( &gaList );  LIST_INIT ( &riList );  LIST_INIT ( &poList );
++  LIST_INIT ( &paList );  LIST_INIT ( &ptList );  LIST_INIT ( &pfList );
++  LIST_INIT ( &pdList );  LIST_INIT ( &piList );  LIST_INIT ( &rdList );
++  LIST_INIT ( &alList );  LIST_INIT ( &rtList );  LIST_INIT ( &rrList );
++}
++/****************************************************************************
++*                                                                           *
++*                 flushLists() - flush all linked lists                     *
++*                                                                           *
++****************************************************************************/
++static void flushLists()
++{
++  flushList (( char * ) &scList );  flushList (( char * ) &aaList );
++  flushList (( char * ) &dfList );  flushList (( char * ) &kmList );
++  flushList (( char * ) &prList );
++  flushList (( char * ) &opList );  flushList (( char * ) &coList );
++  flushList (( char * ) &gaList );  flushList (( char * ) &riList );
++  flushList (( char * ) &poList );  flushList (( char * ) &paList );
++  flushList (( char * ) &ptList );  flushList (( char * ) &pfList );
++  flushList (( char * ) &pdList );  flushList (( char * ) &piList );
++  flushList (( char * ) &rdList );  flushList (( char * ) &alList );
++  flushList (( char * ) &rtList );  flushList (( char * ) &rrList );
++}
++
++/****************************************************************************
++*                                                                           *
++*                   flushList() - flush a linked list                       *
++*                                                                           *
++****************************************************************************/
++static void flushList ( char *l )
++{
++  avList_t *list;
++  
++  list = ( avList_t * ) l;    // NOTE: don't know how to get 
++  while ( !LIST_EMPTY ( list )) {           //  rid of compiler warning on
++    np = LIST_FIRST ( list );               //  LISTHEAD typecast
++    if ( np->data )
++      free ( np->data );
++    LIST_REMOVE ( np, nodes );
++    free ( np );
++  }
++}
++
++/****************************************************************************
++*                                                                           *
++*                            Utility Functions                              *
++*                                                                           *
++****************************************************************************/
++/****************************************************************************
++*                                                                           *
++*        The following two routines were taken directly from iwlib.c        *
++*                                                                           *
++****************************************************************************/
++ /*
++ * Open a socket.
++ * Depending on the protocol present, open the right socket. The socket
++ * will allow us to talk to the driver.
++ */
++static int openSocket ( void )
++{
++  static const int families[] = {
++    AF_INET, AF_IPX, AF_AX25, AF_APPLETALK
++  };
++  unsigned int  i;
++  int   sock;
++
++  /*
++   * Now pick any (exisiting) useful socket family for generic queries
++   * Note : don't open all the socket, only returns when one matches,
++   * all protocols might not be valid.
++   * Workaround by Jim Kaba <jkaba@sarnoff.com>
++   * Note : in 99% of the case, we will just open the inet_sock.
++   * The remaining 1% case are not fully correct...
++   */
++
++  /* Try all families we support */
++  for(i = 0; i < sizeof(families)/sizeof(int); ++i) {
++      /* Try to open the socket, if success returns it */
++      sock = socket(families[i], SOCK_DGRAM, 0);
++      if(sock >= 0)
++  return sock;
++  }
++
++  return -1;
++}
++
++/*------------------------------------------------------------------*/
++/*
++ * Convert a value in milliWatt to a value in dBm.
++ */
++static int mWatt2dbm ( int in )
++{
++#ifdef WE_NOLIBM
++  /* Version without libm : slower */
++  double  fin = (double) in;
++  int   res = 0;
++
++  /* Split integral and floating part to avoid accumulating rounding errors */
++  while(fin > 10.0)
++    {
++      res += 10;
++      fin /= 10.0;
++    }
++  while(fin > 1.000001) /* Eliminate rounding errors, take ceil */
++    {
++      res += 1;
++      fin /= LOG10_MAGIC;
++    }
++  return(res);
++#else /* WE_NOLIBM */
++  /* Version with libm : faster */
++  return((int) (ceil(10.0 * log10((double) in))));
++#endif  /* WE_NOLIBM */
++}
++
++/****************************************************************************
++*                                                                           *
++*                 htob - converts hex string to binary                      *
++*                                                                           *
++****************************************************************************/
++static char *htob ( char *s )
++{
++    char nibl, *byt;
++    static char bin[20];
++
++    byt = bin;
++
++    while ((nibl = *s++) && nibl != ' ') {    /* While not end of string. */
++      nibl -= ( nibl > '9') ?  ('A' - 10): '0';
++      *byt = nibl << 4;                              /* place high nibble */
++      if((nibl = *s++) && nibl != ' ') {
++        nibl -= ( nibl > '9') ?  ('A' - 10): '0';
++        *byt |= nibl;                                /*  place low nibble */
++      }
++      else break;
++      ++byt;
++    }
++    *++byt = '\0';
++    return ( bin );
++}
++
++/****************************************************************************
++*                                                                           *
++*           hasChanged() - see if area has been changed from NULLs          *
++*                                                                           *
++****************************************************************************/
++static int hasChanged ( char *loc, int len )
++{
++  char *wrk;
++  int changed = TRUE;
++
++  wrk = malloc ( len );
++  memset ( wrk, 0, len );
++  if ( memcmp ( loc, wrk, len ) == 0 )
++    changed = FALSE;
++  free ( wrk );
++
++  return ( changed );
++}
++
+--- /dev/null
++++ b/agent/mibgroup/ieee802dot11.h
+@@ -0,0 +1,732 @@
++/****************************************************************************
++*                                                                           *
++*  File Name:           ieee802dot11.h                                      *
++*  Used By:                                                                 *
++*                                                                           *
++*  Operating System:                                                        *
++*  Purpose:                                                                 *
++*                                                                           *
++*  Comments:                                                                *
++*                                                                           *
++*  Author:              Larry Simmons                                       *
++*                       lsimmons@avantcom.com                               *
++*                       www.avantcom.com                                    *
++*                                                                           *
++*  Creation Date:       09/02/03                                            *
++*                                                                           *
++*   Ver    Date   Inits Modification                                        *
++*  ----- -------- ----- ------------                                        *
++*  0.0.1 09/02/03  LRS  created                                             *
++*  0.0.2 09/24/03  LRS  wouldn't build after fresh ./configure              *
++****************************************************************************/
++/* This file was generated by mib2c and is intended for use as a mib module
++  for the ucd-snmp snmpd agent. */
++#ifndef _MIBGROUP_IEEE802DOT11_H
++#define _MIBGROUP_IEEE802DOT11_H
++/* we may use header_generic and header_simple_table from the util_funcs module */
++
++/****************************************************************************
++*                               Includes                                    *
++****************************************************************************/
++#include <sys/queue.h>
++
++/****************************************************************************
++*                             Linked List Defines                           *
++****************************************************************************/
++// here are some Linked List MACROS I wanted to use, 
++// but curiously were not in /usr/includes/sys/queue.h
++
++#ifndef LIST_EMPTY
++  #define	LIST_EMPTY(head)	((head)->lh_first == NULL)
++#endif
++
++#ifndef LIST_NEXT
++  #define	LIST_NEXT(elm, field)	((elm)->field.le_next)
++#endif
++
++#ifndef LIST_INSERT_BEFORE
++  #define	LIST_INSERT_BEFORE(listelm, elm, field) do {			\
++	  (elm)->field.le_prev = (listelm)->field.le_prev;		\
++	  LIST_NEXT((elm), field) = (listelm);				\
++	  *(listelm)->field.le_prev = (elm);				\
++	  (listelm)->field.le_prev = &LIST_NEXT((elm), field);		\
++  } while (0)
++#endif
++
++#ifndef LIST_FIRST
++  #define	LIST_FIRST(head)	((head)->lh_first)
++#endif
++
++/****************************************************************************
++*                             802.11 MIB Defines                            *
++****************************************************************************/
++#define SYS_STRING_LEN                     256
++#define MACADDR_LEN                        ( 6 * 2 ) + 5
++#define OPER_RATE_SET_LEN                  126
++#define MAN_OUI_LEN                        ( 3 * 2 ) + 2
++#define WEP_STR_LEN                         64
++#define SNMP_STR_LEN                       128
++#define TEXT_LEN                            80
++#define IFINDEX_LEN                          4
++#define IFNAME_LEN                          16
++#define MAX_WEP_KEYS                         4
++
++#define AUTHENICATION_ALGORITHMS_INDEX_LEN   4
++#define WEP_DEFAULT_KEY_INDEX_LEN            4
++#define WEP_KEY_MAPPING_INDEX_LEN            4
++#define GROUP_ADDRESS_INDEX_LEN              4
++#define REG_DOMAIN_SUPPORT_INDEX_LEN         4
++#define ANTENNA_LIST_INDEX_LEN               4
++#define SUPPORTED_DATA_RATES_TX_INDEX_LEN    4
++#define SUPPORTED_DATA_RATES_RX_INDEX_LEN    4
++
++#define SC_UID_LEN  IFINDEX_LEN
++#define AA_UID_LEN  IFINDEX_LEN + AUTHENICATION_ALGORITHMS_INDEX_LEN
++#define DF_UID_LEN  IFINDEX_LEN + WEP_DEFAULT_KEY_INDEX_LEN
++#define KM_UID_LEN  IFINDEX_LEN + WEP_KEY_MAPPING_INDEX_LEN
++#define PR_UID_LEN  IFINDEX_LEN
++#define OP_UID_LEN  IFINDEX_LEN
++#define CO_UID_LEN  IFINDEX_LEN
++#define GA_UID_LEN  IFINDEX_LEN + GROUP_ADDRESS_INDEX_LEN
++#define RI_UID_LEN  IFINDEX_LEN
++#define PO_UID_LEN  IFINDEX_LEN
++#define PA_UID_LEN  IFINDEX_LEN
++#define PT_UID_LEN  IFINDEX_LEN
++#define PF_UID_LEN  IFINDEX_LEN
++#define PD_UID_LEN  IFINDEX_LEN
++#define PI_UID_LEN  IFINDEX_LEN
++#define RD_UID_LEN  IFINDEX_LEN + REG_DOMAIN_SUPPORT_INDEX_LEN
++#define AL_UID_LEN  IFINDEX_LEN + ANTENNA_LIST_INDEX_LEN
++#define RT_UID_LEN  IFINDEX_LEN + SUPPORTED_DATA_RATES_TX_INDEX_LEN
++#define RR_UID_LEN  IFINDEX_LEN + SUPPORTED_DATA_RATES_RX_INDEX_LEN
++
++/****************************************************************************
++*                           Linked List Structure                           *
++****************************************************************************/
++struct avNode {  
++  LIST_ENTRY ( avNode ) nodes; 
++  char *data;                                 // pointer to data
++};
++
++typedef LIST_HEAD ( , avNode ) avList_t;
++
++/****************************************************************************
++*                          802.11 MIB structures                            *
++****************************************************************************/
++/****************************************************************************
++*                             dot11Smt Group                                *
++****************************************************************************/
++/****************************************************************************
++*                          dot11StationConfigTable                          *
++****************************************************************************/
++static struct scTbl_data {
++
++  char  UID       [ SC_UID_LEN + 1 ];               // unique ID
++  char  ifName    [ IFNAME_LEN + 1 ];               // ifName of card
++
++  long  ifIndex;                                    // ifindex of card
++
++  char  stationID [ MACADDR_LEN + 1 ];              // Default actual MacAddr
++  long  mediumOccupancyLimit;
++  long  CFPPollable;
++  long  CFPPeriod;
++  long  maxDuration;
++  long  authenticationResponseTimeOut;
++  long  privacyOptionImplemented;
++  long  powerManagementMode;
++  char  desiredSSID             [ SNMP_STR_LEN + 1 ];
++  long  desiredBSSType;
++  char  operationalRateSet      [ OPER_RATE_SET_LEN + 1];
++  long  beaconPeriod;
++  long  DTIMPeriod;
++  long  associationResponseTimeOut;
++  long  disAssociationReason;
++  char  disAssociationStation   [ MACADDR_LEN + 1 ];
++  long  deAuthenticationReason;
++  char  deAuthenticationStation [ MACADDR_LEN + 1 ];
++  long  authenticateFailStatus;
++  char  authenticateFailStation [ MACADDR_LEN + 1 ];
++
++  long  haveStationID;
++  long  haveMediumOccupancyLimit;
++  long  haveCFPPollable;
++  long  haveCFPPeriod;
++  long  haveMaxDuration;
++  long  haveAuthenticationResponseTimeOut;
++  long  havePrivacyOptionImplemented;
++  long  havePowerManagementMode;
++  long  haveDesiredSSID;
++  long  haveDesiredBSSType;
++  long  haveOperationalRateSet;
++  long  haveBeaconPeriod;
++  long  haveDTIMPeriod;
++  long  haveAssociationResponseTimeOut;
++  long  haveDisAssociationReason;
++  long  haveDisAssociationStation;
++  long  haveDeAuthenticationReason;
++  long  haveDeAuthenticationStation;
++  long  haveAuthenticateFailStatus;
++  long  haveAuthenticateFailStation;
++
++} nSc, *sc = &nSc;
++
++static avList_t scList;
++
++/****************************************************************************
++*                    dot11AuthenticationAlgorithmsTable                     *
++****************************************************************************/
++static struct aaTbl_data {
++
++  char  UID       [ AA_UID_LEN + 1 ];
++  char  ifName    [ IFNAME_LEN + 1 ];               // ifName of card
++
++  long  ifIndex;                                    // ifindex of card
++  long  authenticationAlgorithmsIndex;
++
++  long  authenticationAlgorithm;
++  long  authenticationAlgorithmsEnable;
++
++  long  haveAuthenticationAlgorithm;
++  long  haveAuthenticationAlgorithmsEnable;
++
++} nAa, *aa = &nAa;
++
++static avList_t aaList;
++
++/****************************************************************************
++*                           dot11WEPDefaultKeysTable                        *
++****************************************************************************/
++static struct dfTbl_data {
++
++  char  UID       [ DF_UID_LEN + 1 ];
++  char  ifName    [ IFNAME_LEN + 1 ];
++
++  long  ifIndex;                                    // ifindex of card
++  long  WEPDefaultKeyIndex;
++
++  char  WEPDefaultKeyValue [ WEP_STR_LEN + 1 ];
++  long  haveWEPDefaultKeyValue;
++
++} nDf, *df = &nDf;
++
++static avList_t dfList;
++
++/****************************************************************************
++*                          dot11WEPKeyMappingsTable                         *
++****************************************************************************/
++static struct kmTbl_data {
++
++  char  UID       [ KM_UID_LEN + 1 ];
++  char  ifName    [ IFNAME_LEN + 1 ];
++
++  long  ifIndex;
++  long  WEPKeyMappingIndex;
++
++  char  WEPKeyMappingAddress  [ MACADDR_LEN + 1 ];
++  long  WEPKeyMappingWEPOn;
++  char  WEPKeyMappingValue    [ WEP_STR_LEN + 1 ];
++  long  WEPKeyMappingStatus;
++
++  long  haveWEPKeyMappingIndex;
++  long  haveWEPKeyMappingAddress;
++  long  haveWEPKeyMappingWEPOn;
++  long  haveWEPKeyMappingValue;
++  long  haveWEPKeyMappingStatus;
++
++} nKm, *km = &nKm;
++
++static avList_t kmList;
++
++/****************************************************************************
++*                                dot11PrivacyTable                          *
++****************************************************************************/
++static struct prTbl_data {
++
++  char          UID       [ PR_UID_LEN + 1 ];
++  char          ifName    [ IFNAME_LEN + 1 ];
++
++  long          ifIndex;
++
++  long          privacyInvoked;
++  long          WEPDefaultKeyID;
++  long          WEPKeyMappingLength;
++  long          excludeUnencrypted;
++  unsigned long WEPICVErrorCount;
++  unsigned long WEPExcludedCount;
++
++  long          havePrivacyInvoked;
++  long          haveWEPDefaultKeyID;
++  long          haveWEPKeyMappingLength;
++  long          haveExcludeUnencrypted;
++  long          haveWEPICVErrorCount;
++  long          haveWEPExcludedCount;
++
++} nPr, *pr = &nPr;
++
++static avList_t prList;
++
++/****************************************************************************
++*                               dot11Mac Group                              *
++****************************************************************************/
++/****************************************************************************
++*                              dot11OperationTable                          *
++****************************************************************************/
++static struct opTbl_data {
++
++  char  UID       [ OP_UID_LEN + 1 ];                 // unique ID
++  char  ifName    [ IFNAME_LEN + 1 ];                 // ifName of card
++
++  long  ifIndex;                                      // ifindex of card
++
++  char  MACAddress      [ MACADDR_LEN + 1 ];
++  long  RTSThreshold;
++  long  shortRetryLimit;
++  long  longRetryLimit;
++  long  fragmentationThreshold;
++  long  maxTransmitMSDULifetime;
++  long  maxReceiveLifetime;
++  char  manufacturerID  [ SNMP_STR_LEN + 1 ];
++  char  productID       [ SNMP_STR_LEN + 1 ];
++
++  long  haveMACAddress;
++  long  haveRTSThreshold;
++  long  haveShortRetryLimit;
++  long  haveLongRetryLimit;
++  long  haveFragmentationThreshold;
++  long  haveMaxTransmitMSDULifetime;
++  long  haveMaxReceiveLifetime;
++  long  haveManufacturerID;
++  long  haveProductID;
++
++} nOp, *op = &nOp;
++
++static avList_t opList;
++
++/****************************************************************************
++*                            dot11CountersTable                             *
++****************************************************************************/
++static struct coTbl_data {
++
++  char          UID       [ CO_UID_LEN + 1 ];     // unique ID
++  char          ifName    [ IFNAME_LEN + 1 ];     // ifName of card
++
++  long          ifIndex;                          // ifindex of card
++
++  unsigned long  transmittedFragmentCount;
++  unsigned long  multicastTransmittedFrameCount;
++  unsigned long  failedCount;
++  unsigned long  retryCount;
++  unsigned long  multipleRetryCount;
++  unsigned long  frameDuplicateCount;
++  unsigned long  RTSSuccessCount;
++  unsigned long  RTSFailureCount;
++  unsigned long  ACKFailureCount;
++  unsigned long  receivedFragmentCount;
++  unsigned long  multicastReceivedFrameCount;
++  unsigned long  FCSErrorCount;
++  unsigned long  transmittedFrameCount;
++  unsigned long  WEPUndecryptableCount;
++
++  long           haveTransmittedFragmentCount;
++  long           haveMulticastTransmittedFrameCount;
++  long           haveFailedCount;
++  long           haveRetryCount;
++  long           haveMultipleRetryCount;
++  long           haveFrameDuplicateCount;
++  long           haveRTSSuccessCount;
++  long           haveRTSFailureCount;
++  long           haveACKFailureCount;
++  long           haveReceivedFragmentCount;
++  long           haveMulticastReceivedFrameCount;
++  long           haveFCSErrorCount;
++  long           haveTransmittedFrameCount;
++  long           haveWEPUndecryptableCount;
++
++} nCo, *co = &nCo;
++
++static avList_t coList;
++
++/****************************************************************************
++*                        dot11GroupAddressesTable                           *
++****************************************************************************/
++static struct gaTbl_data {
++
++  char  UID       [ GA_UID_LEN + 1 ];
++  char  ifName    [ IFNAME_LEN + 1 ];
++
++  long  ifIndex;                                    // ifindex of card
++  long  groupAddressesIndex;
++
++  char  address   [ MACADDR_LEN + 1 ];
++  long  groupAddressesStatus;
++
++  long  haveAddress;
++  long  haveGroupAddressesStatus;
++
++} nGa, *ga = &nGa;
++
++static avList_t gaList;
++
++/****************************************************************************
++*                               dot11Res Group                              *
++****************************************************************************/
++static char  resourceTypeIDName[] = "RTID";
++static long  haveResourceTypeIDName = 1;
++
++/****************************************************************************
++*                           dot11ResourceInfoTable                          *
++****************************************************************************/
++static struct riTbl_data {
++
++  char  UID       [ RI_UID_LEN + 1 ];               // unique ID
++  char  ifName    [ IFNAME_LEN + 1 ];               // ifName of card
++
++  long  ifIndex;                                    // ifindex of card
++
++  char  manufacturerOUI            [ MAN_OUI_LEN    + 1 ];
++  char  manufacturerName           [ SYS_STRING_LEN + 1 ];
++  char  manufacturerProductName    [ SYS_STRING_LEN + 1 ];
++  char  manufacturerProductVersion [ SYS_STRING_LEN + 1 ];
++
++  char  haveManufacturerOUI;
++  char  haveManufacturerName;
++  char  haveManufacturerProductName;
++  char  haveManufacturerProductVersion;
++
++} nRi, *ri = &nRi;
++
++static avList_t riList;
++
++/****************************************************************************
++*                               dot11Phy Group                              *
++****************************************************************************/
++/****************************************************************************
++*                           dot11PhyOperationTable                          *
++****************************************************************************/
++static struct poTbl_data {
++
++  char  UID       [ PO_UID_LEN + 1 ];               // unique ID
++  char  ifName    [ IFNAME_LEN + 1 ];               // ifName of card
++
++  long  ifIndex;                                    // ifindex of card
++
++  long  PHYType;
++  long  currentRegDomain;
++  long  tempType;
++
++  long  havePHYType;
++  long  haveCurrentRegDomain;
++  long  haveTempType;
++
++} nPo, *po = &nPo;
++
++static avList_t poList;
++
++/****************************************************************************
++*                           dot11PhyAntennaEntry                            *
++****************************************************************************/
++static struct paTbl_data {
++
++  char  UID       [ PA_UID_LEN + 1 ];               // unique ID
++  char  ifName    [ IFNAME_LEN + 1 ];               // ifName of card
++
++  long  ifIndex;                                    // ifindex of card
++
++  long  currentTxAntenna;
++  long  diversitySupport;
++  long  currentRxAntenna;
++
++  long  haveCurrentTxAntenna;
++  long  haveDiversitySupport;
++  long  haveCurrentRxAntenna;
++
++} nPa, *pa = &nPa;
++
++static avList_t paList;
++
++/****************************************************************************
++*                             dot11PhyTxPowerTable                          *
++****************************************************************************/
++static struct ptTbl_data {
++
++  char  UID       [ PT_UID_LEN + 1 ];               // unique ID
++  char  ifName    [ IFNAME_LEN + 1 ];               // ifName of card
++
++  long  ifIndex;                                    // ifindex of card
++
++  long  numberSupportedPowerLevels;
++  long  TxPowerLevel1;
++  long  TxPowerLevel2;
++  long  TxPowerLevel3;
++  long  TxPowerLevel4;
++  long  TxPowerLevel5;
++  long  TxPowerLevel6;
++  long  TxPowerLevel7;
++  long  TxPowerLevel8;
++  long  currentTxPowerLevel;
++
++  long  haveNumberSupportedPowerLevels;
++  long  haveTxPowerLevel1;
++  long  haveTxPowerLevel2;
++  long  haveTxPowerLevel3;
++  long  haveTxPowerLevel4;
++  long  haveTxPowerLevel5;
++  long  haveTxPowerLevel6;
++  long  haveTxPowerLevel7;
++  long  haveTxPowerLevel8;
++  long  haveCurrentTxPowerLevel ;
++
++} nPt, *pt = &nPt;
++
++static avList_t ptList;
++
++/****************************************************************************
++*                               dot11PhyFHSSTable                           *
++****************************************************************************/
++static struct pfTbl_data {
++
++  char  UID       [ PF_UID_LEN + 1 ];              // unique ID
++  char  ifName    [ IFNAME_LEN + 1 ];              // ifName of card
++
++  long  ifIndex;                                    // ifindex of card
++
++  long  hopTime;
++  long  currentChannelNumber;
++  long  maxDwellTime;
++  long  currentDwellTime;
++  long  currentSet;
++  long  currentPattern;
++  long  currentIndex;
++
++  long  haveHopTime;
++  long  haveCurrentChannelNumber;
++  long  haveMaxDwellTime;
++  long  haveCurrentDwellTime;
++  long  haveCurrentSet;
++  long  haveCurrentPattern;
++  long  haveCurrentIndex;
++
++} nPf, *pf = &nPf;
++
++static avList_t pfList;
++
++/****************************************************************************
++*                              dot11PhyDSSSTable                            *
++****************************************************************************/
++static struct pdTbl_data {
++
++  char  UID       [ PD_UID_LEN + 1 ];               // unique ID
++  char  ifName    [ IFNAME_LEN + 1 ];               // ifName of card
++
++  long  ifIndex;                                    // ifindex of card
++
++  long  currentChannel;
++  long  CCAModeSupported;
++  long  currentCCAMode;
++  long  EDThreshold;
++
++  long  haveCurrentChannel;
++  long  haveCCAModeSupported ;
++  long  haveCurrentCCAMode;
++  long  haveEDThreshold;
++
++} nPd, *pd = &nPd;
++
++static avList_t pdList;
++
++/****************************************************************************
++*                              dot11PhyIRTable                              *
++****************************************************************************/
++static struct piTbl_data {
++
++  char  UID       [ PI_UID_LEN + 1 ];               // unique ID
++  char  ifName    [ IFNAME_LEN + 1 ];               // ifName of card
++
++  long  ifIndex;                                    // ifindex of card
++
++  long  CCAWatchdogTimerMax;
++  long  CCAWatchdogCountMax;
++  long  CCAWatchdogTimerMin;
++  long  CCAWatchdogCountMin;
++
++  long  haveCCAWatchdogTimerMax;
++  long  haveCCAWatchdogCountMax;
++  long  haveCCAWatchdogTimerMin;
++  long  haveCCAWatchdogCountMin;
++
++} nPi, *pi = &nPi;
++
++static avList_t piList;
++
++/****************************************************************************
++*                      dot11RegDomainsSupportedTable                        *
++****************************************************************************/
++static struct rdTbl_data {
++
++  char  UID       [ RD_UID_LEN + 1 ];
++  char  ifName    [ IFNAME_LEN + 1 ];
++
++  long  ifIndex;                                    // ifindex of card
++  long  regDomainsSupportIndex;
++
++  long  regDomainsSupportValue;
++  long  haveRegDomainsSupportValue;
++
++} nRd, *rd = &nRd;
++
++static avList_t rdList;
++
++/****************************************************************************
++*                             dot11AntennasListTable                        *
++****************************************************************************/
++static struct alTbl_data {
++
++  char  UID       [ AL_UID_LEN + 1 ];
++  char  ifName    [ IFNAME_LEN + 1 ];
++
++  long  ifIndex;                                    // ifindex of card
++  long  antennaListIndex;
++
++  long  supportedTxAntenna;
++  long  supportedRxAntenna;
++  long  diversitySelectionRx ;
++
++  long  haveSupportedTxAntenna;
++  long  haveSupportedRxAntenna;
++  long  haveDiversitySelectionRx ;
++
++} nAl, *al = &nAl;
++
++static avList_t alList;
++
++/****************************************************************************
++*                    dot11SupportedDataRatesTxTable                         *
++****************************************************************************/
++static struct rtTbl_data {
++
++  char  UID       [ RT_UID_LEN + 1 ];
++  char  ifName    [ IFNAME_LEN + 1 ];
++
++  long  ifIndex;                                    // ifindex of card
++  long  supportedDataRatesTxIndex;
++
++  long  supportedDataRatesTxValue;
++  long  haveSupportedDataRatesTxValue;
++
++} nRt, *rt = &nRt;
++
++static avList_t rtList;
++
++/****************************************************************************
++*                    dot11SupportedDataRatesRxTable                         *
++****************************************************************************/
++static struct rrTbl_data {
++
++  char  UID       [ RR_UID_LEN + 1 ];
++  char  ifName    [ IFNAME_LEN + 1 ];
++
++  long  ifIndex;                                    // ifindex of card
++  long  supportedDataRatesRxIndex;
++
++  long  supportedDataRatesRxValue;
++  long  haveSupportedDataRatesRxValue;
++
++} nRr, *rr = &nRr;
++
++static avList_t rrList;
++
++/****************************************************************************
++*                       Wireless Extensions Structures                      *
++****************************************************************************/
++static long wepCurrentKey;
++static long haveWepCurrentKey;
++static struct wepTbl_data {
++
++  long len;
++  char key [ WEP_STR_LEN + 1 ];
++  long haveKey;
++
++} wep[4];
++
++/****************************************************************************
++*                                                                           *
++****************************************************************************/
++config_require(util_funcs)
++
++/* function prototypes */
++
++void   init_ieee802dot11 ( void );
++FindVarMethod var_ieee802dot11;
++FindVarMethod var_dot11StationConfigTable;
++FindVarMethod var_dot11AuthenticationAlgorithmsTable;
++FindVarMethod var_dot11WEPDefaultKeysTable;
++FindVarMethod var_dot11WEPKeyMappingsTable;
++FindVarMethod var_dot11PrivacyTable;
++FindVarMethod var_dot11OperationTable;
++FindVarMethod var_dot11CountersTable;
++FindVarMethod var_dot11GroupAddressesTable;
++FindVarMethod var_dot11ResourceInfoTable;
++FindVarMethod var_dot11PhyOperationTable;
++FindVarMethod var_dot11PhyAntennaTable;
++FindVarMethod var_dot11PhyTxPowerTable;
++FindVarMethod var_dot11PhyFHSSTable;
++FindVarMethod var_dot11PhyDSSSTable;
++FindVarMethod var_dot11PhyIRTable;
++FindVarMethod var_dot11RegDomainsSupportedTable;
++FindVarMethod var_dot11AntennasListTable;
++FindVarMethod var_dot11SupportedDataRatesTxTable;
++FindVarMethod var_dot11SupportedDataRatesRxTable;
++
++WriteMethod write_dot11StationID;
++WriteMethod write_dot11MediumOccupancyLimit;
++WriteMethod write_dot11CFPPeriod;
++WriteMethod write_dot11CFPMaxDuration;
++WriteMethod write_dot11AuthenticationResponseTimeOut;
++WriteMethod write_dot11PowerManagementMode;
++WriteMethod write_dot11DesiredSSID;
++WriteMethod write_dot11DesiredBSSType;
++WriteMethod write_dot11OperationalRateSet;
++WriteMethod write_dot11BeaconPeriod;
++WriteMethod write_dot11DTIMPeriod;
++WriteMethod write_dot11AssociationResponseTimeOut;
++WriteMethod write_dot11AuthenticationAlgorithmsEnable;
++WriteMethod write_dot11WEPDefaultKeyValue;
++WriteMethod write_dot11WEPKeyMappingAddress;
++WriteMethod write_dot11WEPKeyMappingWEPOn;
++WriteMethod write_dot11WEPKeyMappingValue;
++WriteMethod write_dot11WEPKeyMappingStatus;
++WriteMethod write_dot11PrivacyInvoked;
++WriteMethod write_dot11WEPDefaultKeyID;
++WriteMethod write_dot11WEPKeyMappingLength;
++WriteMethod write_dot11ExcludeUnencrypted;
++WriteMethod write_dot11RTSThreshold;
++WriteMethod write_dot11ShortRetryLimit;
++WriteMethod write_dot11LongRetryLimit;
++WriteMethod write_dot11FragmentationThreshold;
++WriteMethod write_dot11MaxTransmitMSDULifetime;
++WriteMethod write_dot11MaxReceiveLifetime;
++WriteMethod write_dot11Address;
++WriteMethod write_dot11GroupAddressesStatus;
++WriteMethod write_dot11CurrentRegDomain;
++WriteMethod write_dot11CurrentTxAntenna;
++WriteMethod write_dot11CurrentRxAntenna;
++WriteMethod write_dot11CurrentTxPowerLevel;
++WriteMethod write_dot11CurrentChannelNumber;
++WriteMethod write_dot11CurrentDwellTime;
++WriteMethod write_dot11CurrentSet;
++WriteMethod write_dot11CurrentPattern;
++WriteMethod write_dot11CurrentIndex;
++WriteMethod write_dot11CurrentChannel;
++WriteMethod write_dot11CurrentCCAMode;
++WriteMethod write_dot11EDThreshold;
++WriteMethod write_dot11CCAWatchdogTimerMax;
++WriteMethod write_dot11CCAWatchdogCountMax;
++WriteMethod write_dot11CCAWatchdogTimerMin;
++WriteMethod write_dot11CCAWatchdogCountMin;
++WriteMethod write_dot11SupportedTxAntenna;
++WriteMethod write_dot11SupportedRxAntenna;
++WriteMethod write_dot11DiversitySelectionRx;
++
++void shutdown_ieee802dot11 ( void );
++
++#endif /* _MIBGROUP_IEEE802DOT11_H */
+--- /dev/null
++++ b/agent/mibgroup/iwlib.h
+@@ -0,0 +1,509 @@
++/*
++ *	Wireless Tools
++ *
++ *		Jean II - HPLB 97->99 - HPL 99->02
++ *
++ * Common header for the Wireless Extension library...
++ *
++ * This file is released under the GPL license.
++ *     Copyright (c) 1997-2002 Jean Tourrilhes <jt@hpl.hp.com>
++ */
++
++#ifndef IWLIB_H
++#define IWLIB_H
++
++/*#include "CHANGELOG.h"*/
++
++/***************************** INCLUDES *****************************/
++
++/* Standard headers */
++#include <sys/types.h>
++#include <sys/ioctl.h>
++#include <stdio.h>
++#include <math.h>
++#include <errno.h>
++#include <fcntl.h>
++#include <ctype.h>
++#include <stdlib.h>
++#include <string.h>
++#include <unistd.h>
++#include <netdb.h>		/* gethostbyname, getnetbyname */
++#include <net/ethernet.h>	/* struct ether_addr */
++#ifdef HAVE_NET_IF_H
++#include <net/if.h>
++#endif
++#include <sys/time.h>		/* struct timeval */
++#include <unistd.h>
++
++/* This is our header selection. Try to hide the mess and the misery :-(
++ * Don't look, you would go blind ;-) */
++
++#ifndef LINUX_VERSION_CODE
++#include <linux/version.h>
++#endif
++
++/* Kernel headers 2.4.X + Glibc 2.2 - Mandrake 8.0, Debian 2.3, RH 7.1
++ * Kernel headers 2.2.X + Glibc 2.2 - Slackware 8.0 */
++#if defined(__GLIBC__) \
++    && __GLIBC__ == 2 \
++    && __GLIBC_MINOR__ >= 2 \
++    && LINUX_VERSION_CODE >= KERNEL_VERSION(2,2,0)
++//#define GLIBC22_HEADERS
++#define GENERIC_HEADERS
++
++/* Kernel headers 2.4.X + Glibc 2.1 - Debian 2.2 upgraded, RH 7.0
++ * Kernel headers 2.2.X + Glibc 2.1 - Debian 2.2, RH 6.1 */
++#elif defined(__GLIBC__) \
++      && __GLIBC__ == 2 \
++      && __GLIBC_MINOR__ == 1 \
++      && LINUX_VERSION_CODE >= KERNEL_VERSION(2,2,0)
++//#define GLIBC_HEADERS
++#define GENERIC_HEADERS
++
++/* Kernel headers 2.2.X + Glibc 2.0 - Debian 2.1 */
++#elif defined(__GLIBC__) \
++      && __GLIBC__ == 2 \
++      && __GLIBC_MINOR__ == 0 \
++      && LINUX_VERSION_CODE >= KERNEL_VERSION(2,0,0) \
++      && LINUX_VERSION_CODE < KERNEL_VERSION(2,1,0)
++#define GLIBC_HEADERS
++#define KLUDGE_HEADERS
++
++/* Note : is it really worth supporting kernel 2.0.X, knowing that
++ * we require WE v9, which is only available in 2.2.X and higher ?
++ * I guess one could use 2.0.x with an upgraded wireless.h... */
++
++/* Kernel headers 2.0.X + Glibc 2.0 - Debian 2.0, RH 5 */
++#elif defined(__GLIBC__) \
++      && __GLIBC__ == 2 \
++      && __GLIBC_MINOR__ == 0 \
++      && LINUX_VERSION_CODE < KERNEL_VERSION(2,1,0) \
++      && LINUX_VERSION_CODE >= KERNEL_VERSION(2,0,0)
++#define GLIBC_HEADERS
++
++/* Kernel headers 2.0.X + libc5 - old systems */
++#elif defined(_LINUX_C_LIB_VERSION_MAJOR) \
++      && _LINUX_C_LIB_VERSION_MAJOR == 5 \
++      && LINUX_VERSION_CODE >= KERNEL_VERSION(2,0,0) \
++      && LINUX_VERSION_CODE < KERNEL_VERSION(2,1,0)
++#define LIBC5_HEADERS
++
++/* Musl */
++#elif !defined(__GLIBC__) && LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)
++#define GENERIC_HEADERS
++
++/* Unsupported combination */
++#else
++#error "Your kernel/libc combination is not supported"
++#endif
++
++#ifdef GENERIC_HEADERS 
++/* Proposed by Dr. Michael Rietz <rietz@mail.amps.de>, 27.3.2 */
++/* If this works for all, it might be more stable on the long term - Jean II */
++#include <net/if_arp.h>		/* For ARPHRD_ETHER */
++#include <sys/socket.h>		/* For AF_INET & struct sockaddr */
++#include <netinet/in.h>         /* For struct sockaddr_in */
++#include <netinet/if_ether.h>
++#endif /* GENERIC_HEADERS */    
++
++#ifdef GLIBC22_HEADERS 
++/* Added by Ross G. Miller <Ross_Miller@baylor.edu>, 3/28/01 */
++#include <linux/if_arp.h> 	/* For ARPHRD_ETHER */
++#include <linux/socket.h>	/* For AF_INET & struct sockaddr */
++#include <sys/socket.h>
++#endif /* GLIBC22_HEADERS */    
++
++#ifdef KLUDGE_HEADERS
++#include <socketbits.h>
++#endif	/* KLUDGE_HEADERS */
++
++#ifdef GLIBC_HEADERS
++#include <linux/if_arp.h>	/* For ARPHRD_ETHER */
++#include <linux/socket.h>	/* For AF_INET & struct sockaddr */
++#include <linux/in.h>		/* For struct sockaddr_in */
++#endif	/* KLUDGE_HEADERS || GLIBC_HEADERS */
++
++#ifdef LIBC5_HEADERS
++#include <sys/socket.h>		/* For AF_INET & struct sockaddr & socket() */
++#include <linux/if_arp.h>	/* For ARPHRD_ETHER */
++#include <linux/in.h>		/* For struct sockaddr_in */
++#endif	/* LIBC5_HEADERS */
++
++/* Those 3 headers were previously included in wireless.h */
++#include <linux/types.h>		/* for "caddr_t" et al		*/
++#include <linux/socket.h>		/* for "struct sockaddr" et al	*/
++#include <linux/if.h>			/* for IFNAMSIZ and co... */
++
++#ifdef WEXT_HEADER
++/* Private copy of Wireless extensions */
++#include WEXT_HEADER
++#else	/* !WEXT_HEADER */
++/* System wide Wireless extensions */
++#include <linux/wireless.h>
++#endif	/* !WEXT_HEADER */
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++/****************************** DEBUG ******************************/
++
++
++/************************ CONSTANTS & MACROS ************************/
++
++/* Paths */
++#define PROC_NET_WIRELESS	"/proc/net/wireless"
++#define PROC_NET_DEV		"/proc/net/dev"
++
++/* Some useful constants */
++#define KILO	1e3
++#define MEGA	1e6
++#define GIGA	1e9
++/* For doing log10/exp10 without libm */
++#define LOG10_MAGIC	1.25892541179
++
++/* Backward compatibility for Wireless Extension 9 */
++#ifndef IW_POWER_MODIFIER
++#define IW_POWER_MODIFIER	0x000F	/* Modify a parameter */
++#define IW_POWER_MIN		0x0001	/* Value is a minimum  */
++#define IW_POWER_MAX		0x0002	/* Value is a maximum */
++#define IW_POWER_RELATIVE	0x0004	/* Value is not in seconds/ms/us */
++#endif /* IW_POWER_MODIFIER */
++
++#ifndef IW_ENCODE_NOKEY
++#define IW_ENCODE_NOKEY         0x0800  /* Key is write only, so not here */
++#define IW_ENCODE_MODE		0xF000	/* Modes defined below */
++#endif /* IW_ENCODE_NOKEY */
++#ifndef IW_ENCODE_TEMP
++#define IW_ENCODE_TEMP		0x0400  /* Temporary key */
++#endif /* IW_ENCODE_TEMP */
++
++/* More backward compatibility */
++#ifndef SIOCSIWCOMMIT
++#define SIOCSIWCOMMIT	SIOCSIWNAME
++#endif /* SIOCSIWCOMMIT */
++
++/****************************** TYPES ******************************/
++
++/* Shortcuts */
++typedef struct iw_statistics	iwstats;
++typedef struct iw_range		iwrange;
++typedef struct iw_param		iwparam;
++typedef struct iw_freq		iwfreq;
++typedef struct iw_quality	iwqual;
++typedef struct iw_priv_args	iwprivargs;
++typedef struct sockaddr		sockaddr;
++
++/* Structure for storing all wireless information for each device
++ * This is pretty exhaustive... */
++typedef struct wireless_info
++{
++  char		name[IFNAMSIZ + 1];	/* Wireless/protocol name */
++  int		has_nwid;
++  iwparam	nwid;			/* Network ID */
++  int		has_freq;
++  double	freq;			/* Frequency/channel */
++  int		has_sens;
++  iwparam	sens;			/* sensitivity */
++  int		has_key;
++  unsigned char	key[IW_ENCODING_TOKEN_MAX];	/* Encoding key used */
++  int		key_size;		/* Number of bytes */
++  int		key_flags;		/* Various flags */
++  int		has_essid;
++  int		essid_on;
++  char		essid[IW_ESSID_MAX_SIZE + 1];	/* ESSID (extended network) */
++  int		has_nickname;
++  char		nickname[IW_ESSID_MAX_SIZE + 1]; /* NickName */
++  int		has_ap_addr;
++  sockaddr	ap_addr;		/* Access point address */
++  int		has_bitrate;
++  iwparam	bitrate;		/* Bit rate in bps */
++  int		has_rts;
++  iwparam	rts;			/* RTS threshold in bytes */
++  int		has_frag;
++  iwparam	frag;			/* Fragmentation threshold in bytes */
++  int		has_mode;
++  int		mode;			/* Operation mode */
++  int		has_power;
++  iwparam	power;			/* Power management parameters */
++  int		has_txpower;
++  iwparam	txpower;		/* Transmit Power in dBm */
++  int		has_retry;
++  iwparam	retry;			/* Retry limit or lifetime */
++
++  /* Stats */
++  iwstats	stats;
++  int		has_stats;
++  iwrange	range;
++  int		has_range;
++} wireless_info;
++
++/* Structure for storing all wireless information for each device
++ * This is a cut down version of the one above, containing only
++ * the things *truly* needed to configure a card.
++ * Don't add other junk, I'll remove it... */
++typedef struct wireless_config
++{
++  char		name[IFNAMSIZ + 1];	/* Wireless/protocol name */
++  int		has_nwid;
++  iwparam	nwid;			/* Network ID */
++  int		has_freq;
++  double	freq;			/* Frequency/channel */
++  int		has_key;
++  unsigned char	key[IW_ENCODING_TOKEN_MAX];	/* Encoding key used */
++  int		key_size;		/* Number of bytes */
++  int		key_flags;		/* Various flags */
++  int		has_essid;
++  int		essid_on;
++  char		essid[IW_ESSID_MAX_SIZE + 1];	/* ESSID (extended network) */
++  int		has_mode;
++  int		mode;			/* Operation mode */
++} wireless_config;
++
++typedef struct stream_descr
++{
++  char *	end;		/* End of the stream */
++  char *	current;	/* Current event in stream of events */
++  char *	value;		/* Current value in event */
++} stream_descr;
++
++/* Prototype for handling display of each single interface on the
++ * system - see iw_enum_devices() */
++typedef int (*iw_enum_handler)(int	skfd,
++			       char *	ifname,
++			       char *	args[],
++			       int	count);
++
++/**************************** PROTOTYPES ****************************/
++/*
++ * All the functions in iwcommon.c
++ */
++
++/* ---------------------- SOCKET SUBROUTINES -----------------------*/
++int
++	iw_sockets_open(void);
++void
++	iw_enum_devices(int		skfd,
++			iw_enum_handler fn,
++			char *		args[],
++			int		count);
++/* --------------------- WIRELESS SUBROUTINES ----------------------*/
++int
++	iw_get_range_info(int		skfd,
++			  char *	ifname,
++			  iwrange *	range);
++int
++	iw_print_version_info(char *	toolname);
++int
++	iw_get_priv_info(int		skfd,
++			 char *		ifname,
++			 iwprivargs *	priv,
++			 int		maxpriv);
++int
++	iw_get_basic_config(int			skfd,
++			    char *		ifname,
++			    wireless_config *	info);
++int
++	iw_set_basic_config(int			skfd,
++			    char *		ifname,
++			    wireless_config *	info);
++/* --------------------- PROTOCOL SUBROUTINES --------------------- */
++int
++	iw_protocol_compare(char *	protocol1,
++			    char *	protocol2);
++/* -------------------- FREQUENCY SUBROUTINES --------------------- */
++void
++	iw_float2freq(double	in,
++		   iwfreq *	out);
++double
++	iw_freq2float(iwfreq *	in);
++void
++	iw_print_freq(char *	buffer,
++		      double	freq);
++int
++	iw_freq_to_channel(double		freq,
++			   struct iw_range *	range);
++void
++	iw_print_bitrate(char *	buffer,
++			 int	bitrate);
++/* ---------------------- POWER SUBROUTINES ----------------------- */
++int
++	iw_dbm2mwatt(int	in);
++int
++	iw_mwatt2dbm(int	in);
++/* -------------------- STATISTICS SUBROUTINES -------------------- */
++int
++	iw_get_stats(int	skfd,
++		     char *	ifname,
++		     iwstats *	stats);
++void
++	iw_print_stats(char *		buffer,
++		       iwqual *		qual,
++		       iwrange *	range,
++		       int		has_range);
++/* --------------------- ENCODING SUBROUTINES --------------------- */
++void
++	iw_print_key(char *		buffer,
++		     unsigned char *	key,
++		     int		key_size,
++		     int		key_flags);
++int
++	iw_in_key(char *		input,
++		  unsigned char *	key);
++int
++	iw_in_key_full(int		skfd,
++		       char *		ifname,
++		       char *		input,
++		       unsigned char *	key,
++		       __u16 *		flags);
++/* ----------------- POWER MANAGEMENT SUBROUTINES ----------------- */
++void
++	iw_print_pm_value(char *	buffer,
++			  int		value,
++			  int		flags);
++void
++	iw_print_pm_mode(char *		buffer,
++			 int		flags);
++/* --------------- RETRY LIMIT/LIFETIME SUBROUTINES --------------- */
++#if WIRELESS_EXT > 10
++void
++	iw_print_retry_value(char *	buffer,
++			     int	value,
++			     int	flags);
++#endif
++/* ----------------------- TIME SUBROUTINES ----------------------- */
++void
++	iw_print_timeval(char *			buffer,
++			 const struct timeval *	time);
++/* --------------------- ADDRESS SUBROUTINES ---------------------- */
++int
++	iw_check_mac_addr_type(int	skfd,
++			       char *	ifname);
++int
++	iw_check_if_addr_type(int	skfd,
++			      char *	ifname);
++#if 0
++int
++	iw_check_addr_type(int		skfd,
++			   char *	ifname);
++#endif
++void
++	iw_ether_ntop(const struct ether_addr* eth, char* buf);
++char*
++	iw_ether_ntoa(const struct ether_addr* eth);
++int
++	iw_ether_aton(const char* bufp, struct ether_addr* eth);
++int
++	iw_in_inet(char *bufp, struct sockaddr *sap);
++int
++	iw_in_addr(int			skfd,
++		   char *		ifname,
++		   char *		bufp,
++		   struct sockaddr *	sap);
++/* ----------------------- MISC SUBROUTINES ------------------------ */
++int
++	iw_get_priv_size(int		args);
++
++#if WIRELESS_EXT > 13
++/* ---------------------- EVENT SUBROUTINES ---------------------- */
++void
++	iw_init_event_stream(struct stream_descr *	stream,
++			     char *			data,
++			     int			len);
++int
++	iw_extract_event_stream(struct stream_descr *	stream,
++				struct iw_event *	iwe);
++#endif /* WIRELESS_EXT > 13 */
++
++/**************************** VARIABLES ****************************/
++
++extern const char * const	iw_operation_mode[];
++#define IW_NUM_OPER_MODE	7
++
++/************************* INLINE FUNTIONS *************************/
++/*
++ * Functions that are so simple that it's more efficient inlining them
++ */
++
++/*
++ * Note : I've defined wrapper for the ioctl request so that
++ * it will be easier to migrate to other kernel API if needed
++ */
++
++/*------------------------------------------------------------------*/
++/*
++ * Wrapper to push some Wireless Parameter in the driver
++ */
++static inline int
++iw_set_ext(int			skfd,		/* Socket to the kernel */
++	   char *		ifname,		/* Device name */
++	   int			request,	/* WE ID */
++	   struct iwreq *	pwrq)		/* Fixed part of the request */
++{
++  /* Set device name */
++  strncpy(pwrq->ifr_name, ifname, IFNAMSIZ);
++  /* Do the request */
++  return(ioctl(skfd, request, pwrq));
++}
++
++/*------------------------------------------------------------------*/
++/*
++ * Wrapper to extract some Wireless Parameter out of the driver
++ */
++static inline int
++iw_get_ext(int			skfd,		/* Socket to the kernel */
++	   char *		ifname,		/* Device name */
++	   int			request,	/* WE ID */
++	   struct iwreq *	pwrq)		/* Fixed part of the request */
++{
++  /* Set device name */
++  strncpy(pwrq->ifr_name, ifname, IFNAMSIZ);
++  /* Do the request */
++  return(ioctl(skfd, request, pwrq));
++}
++
++/*------------------------------------------------------------------*/
++/* Backwards compatibility
++ * Actually, those form are much easier to use when dealing with
++ * struct sockaddr... */
++static inline char*
++iw_pr_ether(char* bufp, const unsigned char* addr)
++{
++  iw_ether_ntop((const struct ether_addr *) addr, bufp);
++  return bufp;
++}
++/* Backwards compatibility */
++static inline int
++iw_in_ether(const char *bufp, struct sockaddr *sap)
++{
++  sap->sa_family = ARPHRD_ETHER;
++  return iw_ether_aton(bufp, (struct ether_addr *) sap->sa_data) ? 0 : -1;
++}
++
++/*------------------------------------------------------------------*/
++/*
++ * Create an Ethernet broadcast address
++ */
++static inline void
++iw_broad_ether(struct sockaddr *sap)
++{
++  sap->sa_family = ARPHRD_ETHER;
++  memset((char *) sap->sa_data, 0xFF, ETH_ALEN);
++}
++
++/*------------------------------------------------------------------*/
++/*
++ * Create an Ethernet NULL address
++ */
++static inline void
++iw_null_ether(struct sockaddr *sap)
++{
++  sap->sa_family = ARPHRD_ETHER;
++  memset((char *) sap->sa_data, 0x00, ETH_ALEN);
++}
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif	/* IWLIB_H */

--- a/package/network/utils/net-snmp/patches/751-gcc-14-fix.patch
+++ b/package/network/utils/net-snmp/patches/751-gcc-14-fix.patch
@@ -1,0 +1,10 @@
+--- a/agent/mib_modules.c
++++ b/agent/mib_modules.c
+@@ -42,6 +42,7 @@
+ #include <net-snmp/agent/table.h>
+ #include <net-snmp/agent/table_iterator.h>
+ #include "mib_module_includes.h"
++#include "mibgroup/ieee802dot11.h"
+ 
+ static int need_shutdown = 0;
+ 

--- a/package/network/utils/net-snmp/patches/900-musl-compat.patch
+++ b/package/network/utils/net-snmp/patches/900-musl-compat.patch
@@ -1,0 +1,13 @@
+--- a/agent/mibgroup/iwlib.h
++++ b/agent/mibgroup/iwlib.h
+@@ -92,6 +92,10 @@
+ #elif !defined(__GLIBC__) && LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)
+ #define GENERIC_HEADERS
+ 
++/* Musl */
++#elif !defined(__GLIBC__) && LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,0)
++#define GENERIC_HEADERS
++
+ /* Unsupported combination */
+ #else
+ #error "Your kernel/libc combination is not supported"

--- a/package/network/utils/net-snmp/patches/990-remove-semicolon-check-in-macros.patch
+++ b/package/network/utils/net-snmp/patches/990-remove-semicolon-check-in-macros.patch
@@ -1,0 +1,130 @@
+--- a/configure.d/config_modules_agent
++++ b/configure.d/config_modules_agent
+@@ -27,8 +27,6 @@ done
+ #
+ AC_MSG_CHECKING([for and configuring mib modules to use])
+ 
+-AH_TOP([#define NETSNMP_REQUIRE_SEMICOLON extern void netsnmp_unused_function(void)])
+-
+ # set up the CPP command
+ MODULECPP="$CPP $PARTIALTARGETFLAGS $CPPFLAGS -DNETSNMP_FEATURE_CHECKING -I${srcdir}/include -I${srcdir}/agent/mibgroup"
+ if test "x$enable_mfd_rewrites" = "xyes"; then
+@@ -194,7 +192,7 @@ while test "x$new_module_list" != "x"; d
+     #     - mib_module   => libnetsnmpmibs   (default)
+     #     - agent_module => libnetsnmpagent
+     #
+-    AH_TOP([#define config_belongs_in(x) NETSNMP_REQUIRE_SEMICOLON])
++    AH_TOP([#define config_belongs_in(x)])
+     module_type=mib_module
+     if test -f $srcdir/$mibdir/$i.h; then
+       changequote(, )
+@@ -279,7 +277,7 @@ while test "x$new_module_list" != "x"; d
+       	#
+         # check if $i has any conflicts
+         #
+-        AH_TOP([#define config_exclude(x) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_exclude(x)])
+         new_list_excl=`$MODULECPP module_tmp_header.h | \
+                        $SED -n 's/.*config_exclude(\(.*\)).*/\1/p'`
+ 	if test "x$new_list_excl" != "x"; then
+@@ -308,7 +306,7 @@ while test "x$new_module_list" != "x"; d
+         #
+         # check if $i has any architecture specific requirements
+         #
+-        AH_TOP([#define config_arch_require(x,y) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_arch_require(x,y)])
+         changequote(, )
+         new_list_arch=`$MODULECPP module_tmp_header.h | \
+                        $SED -n 's/.*config_arch_require( *\([^ ]*\) *, *\([^ ]*\) *).*/\1-xarchx-\2/p'`
+@@ -330,7 +328,7 @@ while test "x$new_module_list" != "x"; d
+       	# macro: config_version_require((base, version, version-modules, ...))
+       	#  - lists alternative modules used from different versions.
+         #
+-        AH_TOP([#define config_version_require(x) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_version_require(x)])
+         [new_list_alt3=`$MODULECPP module_tmp_header.h | \
+             $AWK '
+                 BEGIN {
+@@ -372,7 +370,7 @@ while test "x$new_module_list" != "x"; d
+         #
+         # check if $i has any other required modules
+         #
+-        AH_TOP([#define config_require(x) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_require(x)])
+         new_list="$new_list `$MODULECPP module_tmp_header.h | \
+                   $SED -n 's/.*config_require(\(.*\)).*/\1/p'`"
+         AC_MSG_MODULE_DBG(" $i will test: $new_list")
+@@ -409,7 +407,7 @@ while test "x$new_module_list" != "x"; d
+         #
+         # check if $i has any mibs to add
+         #
+-        AH_TOP([#define config_add_mib(x) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_add_mib(x)])
+         new_mibs=`$MODULECPP module_tmp_header.h | \
+                   $SED -n 's/.*config_add_mib(\(.*\)).*/\1/p'`
+ 	if test "x$new_mibs" != "x"; then
+@@ -456,7 +454,7 @@ while test "x$new_module_list" != "x"; d
+         # check for config_parse_dot_conf
+         #  (generally not used any longer; old auto-load a .conf token)
+         #
+-        AH_TOP([#define config_parse_dot_conf(w,x,y,z) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_parse_dot_conf(w,x,y,z)])
+         changequote(, )
+         $MODULECPP module_tmp_header.h | \
+         $SED -n 's@.*config_parse_dot_conf(\([^)]*\), *\([^),]*\), *\([^),]*\), *\([^),]*\)).*@register_config_handler("snmpd",\1, \2, \3, \4);@p' >> $mibdir/mib_module_dot_conf.h
+@@ -468,7 +466,7 @@ while test "x$new_module_list" != "x"; d
+         #
+         # check if $i has any errors, or warnings
+         #
+-        AH_TOP([#define config_error(x) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_error(x)])
+         error=`$MODULECPP module_tmp_header.h | \
+                $SED -n 's/.*config_error(\(.*\)).*/\1/p'`
+ 	if test "x$error" != "x"; then
+@@ -481,7 +479,7 @@ while test "x$new_module_list" != "x"; d
+       	# macro: config_warning(warning text)
+       	#  - used to signal a configuration "warning" to be printed to the user
+         #
+-        AH_TOP([#define config_warning(x) NETSNMP_REQUIRE_SEMICOLON])
++        AH_TOP([#define config_warning(x)])
+         warning=`$MODULECPP module_tmp_header.h | \
+                  $SED -n 's/.*config_warning(\(.*\)).*/\1/p'`
+ 	if test "x$warning" != "x"; then
+--- a/include/net-snmp/net-snmp-config.h.in
++++ b/include/net-snmp/net-snmp-config.h.in
+@@ -36,25 +36,25 @@
+ 
+ /* definitions added by configure on-the-fly */
+ 
+-#define config_parse_dot_conf(w,x,y,z) NETSNMP_REQUIRE_SEMICOLON
++#define config_parse_dot_conf(w,x,y,z)
+ 
+-#define config_error(x) NETSNMP_REQUIRE_SEMICOLON
++#define config_error(x)
+ 
+-#define config_warning(x) NETSNMP_REQUIRE_SEMICOLON
++#define config_warning(x)
+ 
+-#define NETSNMP_REQUIRE_SEMICOLON extern void netsnmp_unused_function(void)
++#define extern void netsnmp_unused_function(void)
+ 
+-#define config_belongs_in(x) NETSNMP_REQUIRE_SEMICOLON
++#define config_belongs_in(x)
+ 
+-#define config_exclude(x) NETSNMP_REQUIRE_SEMICOLON
++#define config_exclude(x)
+ 
+-#define config_arch_require(x,y) NETSNMP_REQUIRE_SEMICOLON
++#define config_arch_require(x,y)
+ 
+-#define config_version_require(x) NETSNMP_REQUIRE_SEMICOLON
++#define config_version_require(x)
+ 
+-#define config_require(x) NETSNMP_REQUIRE_SEMICOLON
++#define config_require(x)
+ 
+-#define config_add_mib(x) NETSNMP_REQUIRE_SEMICOLON
++#define config_add_mib(x)
+ 
+ /* Define to 1 if using 'alloca.c'. */
+ #undef C_ALLOCA

--- a/package/utils/hwdata/Makefile
+++ b/package/utils/hwdata/Makefile
@@ -1,0 +1,47 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=hwdata
+PKG_VERSION:=0.387
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/vcrhonek/hwdata/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=8c6be8f0863a8ff5c83b2c46aa525b503b30d42792ed57891c40849de543e1ee
+
+PKG_MAINTAINER:=
+PKG_LICENSE:=GPL-2.0-or-later  XFree86-1.0
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/pciids
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=PCI ID list
+  URL:=https://github.com/vcrhonek/hwdata
+endef
+
+define Package/usbids
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=USB ID list
+  URL:=https://github.com/vcrhonek/hwdata
+endef
+
+define Package/pciids/install
+	$(INSTALL_DIR) $(1)/usr/share/hwdata
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/pci.ids $(1)/usr/share/hwdata
+endef
+
+define Package/usbids/install
+	$(INSTALL_DIR) $(1)/usr/share/hwdata
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/usb.ids $(1)/usr/share/hwdata
+endef
+
+$(eval $(call BuildPackage,pciids))
+$(eval $(call BuildPackage,usbids))

--- a/package/utils/kmod/Makefile
+++ b/package/utils/kmod/Makefile
@@ -1,0 +1,92 @@
+#
+# Copyright (C) 2015 Jeff Waugh
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=kmod
+PKG_VERSION:=32
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=@KERNEL/linux/utils/kernel/kmod
+PKG_HASH:=630ed0d92275a88cb9a7bf68f5700e911fdadaf02e051cf2e4680ff8480bd492
+
+PKG_MAINTAINER:=Jeff Waugh <jdub@bethesignal.org>
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:kernel:kmod
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+CONFIGURE_ARGS += --with-zlib
+
+define Package/kmod/Default
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Linux kernel module handling
+  URL:=https://www.kernel.org/pub/linux/utils/kernel/kmod/
+  DEPENDS:=+zlib
+endef
+
+
+define Package/kmod
+$(call Package/kmod/Default)
+  TITLE+= (tools)
+  ALTERNATIVES:=\
+    200:/sbin/depmod:/sbin/kmod \
+    200:/sbin/insmod:/sbin/kmod \
+    200:/sbin/lsmod:/sbin/kmod \
+    200:/sbin/modinfo:/sbin/kmod \
+    200:/sbin/modprobe:/sbin/kmod \
+    200:/sbin/rmmod:/sbin/kmod
+endef
+
+define Package/kmod/description
+Linux kernel module handling
+ kmod is a set of tools to handle common tasks with Linux kernel modules like
+ insert, remove, list, check properties, resolve dependencies and aliases.
+endef
+
+define Package/kmod/install
+	$(INSTALL_DIR) $(1)/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/kmod $(1)/sbin
+endef
+
+
+define Package/libkmod
+$(call Package/kmod/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE+= (library)
+endef
+
+define Package/libkmod/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libkmod.so.* $(1)/usr/lib/
+endef
+
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include $(1)/usr/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libkmod.{so*,la} $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libkmod.pc $(1)/usr/lib/pkgconfig/
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/libkmod.pc
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' $(1)/usr/lib/pkgconfig/libkmod.pc
+endef
+
+
+$(eval $(call BuildPackage,kmod))
+$(eval $(call BuildPackage,libkmod))

--- a/package/utils/kmod/patches/010-basename.patch
+++ b/package/utils/kmod/patches/010-basename.patch
@@ -1,0 +1,91 @@
+--- a/libkmod/libkmod-config.c
++++ b/libkmod/libkmod-config.c
+@@ -21,6 +21,7 @@
+ #include <ctype.h>
+ #include <dirent.h>
+ #include <errno.h>
++#include <libgen.h>
+ #include <stdarg.h>
+ #include <stddef.h>
+ #include <stdio.h>
+@@ -794,7 +795,9 @@ static int conf_files_insert_sorted(stru
+ 	bool is_single = false;
+ 
+ 	if (name == NULL) {
+-		name = basename(path);
++		char *pathc = strdup(path);
++		name = basename(pathc);
++		free(pathc);
+ 		is_single = true;
+ 	}
+ 
+--- a/shared/util.c
++++ b/shared/util.c
+@@ -22,6 +22,7 @@
+ #include <assert.h>
+ #include <ctype.h>
+ #include <errno.h>
++#include <libgen.h>
+ #include <stdarg.h>
+ #include <stddef.h>
+ #include <stdio.h>
+@@ -173,8 +174,10 @@ char *modname_normalize(const char *modn
+ char *path_to_modname(const char *path, char buf[static PATH_MAX], size_t *len)
+ {
+ 	char *modname;
++	char *pathc = strdup(path);
+ 
+-	modname = basename(path);
++	modname = basename(pathc);
++	free(pathc);
+ 	if (modname == NULL || modname[0] == '\0')
+ 		return NULL;
+ 
+--- a/tools/depmod.c
++++ b/tools/depmod.c
+@@ -22,6 +22,7 @@
+ #include <dirent.h>
+ #include <errno.h>
+ #include <getopt.h>
++#include <libgen.h>
+ #include <limits.h>
+ #include <regex.h>
+ #include <stdio.h>
+@@ -757,14 +758,17 @@ static int cfg_files_insert_sorted(struc
+ 	struct cfg_file **files, *f;
+ 	size_t i, n_files, namelen, dirlen;
+ 	void *tmp;
++	char *dirc;
+ 
+ 	dirlen = strlen(dir);
+ 	if (name != NULL)
+ 		namelen = strlen(name);
+ 	else {
+-		name = basename(dir);
++		dirc = strdup(dir);
++		name = basename(dirc);
+ 		namelen = strlen(name);
+ 		dirlen -= namelen + 1;
++		free(dirc);
+ 	}
+ 
+ 	n_files = *p_n_files;
+@@ -2613,7 +2617,7 @@ static int depmod_output(struct depmod *
+ 			int mode = 0644;
+ 			int fd;
+ 
+-			snprintf(tmp, sizeof(tmp), "%s.%i.%li.%li", itr->name, getpid(),
++			snprintf(tmp, sizeof(tmp), "%s.%i.%" PRId64 ".%" PRId64, itr->name, getpid(),
+ 					tv.tv_usec, tv.tv_sec);
+ 			fd = openat(dfd, tmp, flags, mode);
+ 			if (fd < 0) {
+--- a/tools/kmod.c
++++ b/tools/kmod.c
+@@ -22,6 +22,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <libgen.h>
+ 
+ #include <shared/util.h>
+ 

--- a/package/utils/pciutils/Makefile
+++ b/package/utils/pciutils/Makefile
@@ -1,0 +1,86 @@
+#
+# Copyright (C) 2007-2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pciutils
+PKG_VERSION:=3.12.0
+PKG_RELEASE:=2
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL:=@KERNEL/software/utils/pciutils
+PKG_HASH:=f185d116d5ff99b797497efce8f19f1ee8ccc5a668b97a159e3d13472f674154
+
+PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/pciutils
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=Linux PCI Utilities
+  URL:=http://mj.ucw.cz/pciutils.shtml
+  DEPENDS:=+libkmod +libpci +pciids
+endef
+
+define Package/pciutils/description
+ contains collection of programs for inspecting and manipulating configuration
+ of PCI devices
+endef
+
+define Package/libpci
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Linux PCI Libraries
+  URL:=http://mj.ucw.cz/pciutils.shtml
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+MAKE_FLAGS += \
+	CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS)" \
+	PREFIX="/usr" \
+	HOST="Linux" \
+	HWDB="no" \
+	ZLIB="no" \
+	SHARED="yes"
+
+ifneq ($(CONFIG_USE_GLIBC),)
+TARGET_LDFLAGS += -lresolv
+endif
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpci.so.3 \
+		$(PKG_INSTALL_DIR)/usr/lib/libpci.so
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_BUILD_DIR)/lib/libpci.pc $(1)/usr/lib/pkgconfig
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' $(1)/usr/lib/pkgconfig/libpci.pc
+	$(SED) 's,/usr/lib,$$$${prefix}/lib,g' $(1)/usr/lib/pkgconfig/libpci.pc
+	$(INSTALL_DIR) $(1)/usr/include/pci
+	$(CP) $(foreach i,pci.h config.h header.h types.h, \
+		$(PKG_BUILD_DIR)/lib/$(i)) $(1)/usr/include/pci
+endef
+
+define Package/pciutils/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/lspci $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/setpci $(1)/usr/sbin/
+endef
+
+define Package/libpci/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/*.so* $(1)/usr/lib/
+endef
+
+
+$(eval $(call BuildPackage,libpci))
+$(eval $(call BuildPackage,pciutils))

--- a/package/utils/pciutils/patches/101-no-strip.patch
+++ b/package/utils/pciutils/patches/101-no-strip.patch
@@ -1,0 +1,15 @@
+--- a/Makefile
++++ b/Makefile
+@@ -162,9 +162,9 @@ distclean: clean
+ install: all
+ # -c is ignored on Linux, but required on FreeBSD
+ 	$(DIRINSTALL) -m 755 $(DESTDIR)$(BINDIR) $(DESTDIR)$(SBINDIR) $(DESTDIR)$(IDSDIR) $(DESTDIR)$(MANDIR)/man8 $(DESTDIR)$(MANDIR)/man7 $(DESTDIR)$(MANDIR)/man5
+-	$(INSTALL) -c -m 755 $(STRIP) lspci$(EXEEXT) $(DESTDIR)$(LSPCIDIR)
+-	$(INSTALL) -c -m 755 $(STRIP) setpci$(EXEEXT) $(DESTDIR)$(SBINDIR)
+-	$(INSTALL) -c -m 755 $(STRIP) pcilmr$(EXEEXT) $(DESTDIR)$(SBINDIR)
++	$(INSTALL) -c -m 755 lspci$(EXEEXT) $(DESTDIR)$(LSPCIDIR)
++	$(INSTALL) -c -m 755 setpci$(EXEEXT) $(DESTDIR)$(SBINDIR)
++	$(INSTALL) -c -m 755 pcilmr$(EXEEXT) $(DESTDIR)$(SBINDIR)
+ 	$(INSTALL) -c -m 755 update-pciids $(DESTDIR)$(SBINDIR)
+ ifneq ($(IDSDIR),)
+ 	$(INSTALL) -c -m 644 $(PCI_IDS) $(DESTDIR)$(IDSDIR)

--- a/package/utils/pciutils/patches/104-resolv.patch
+++ b/package/utils/pciutils/patches/104-resolv.patch
@@ -1,0 +1,11 @@
+--- a/lib/configure
++++ b/lib/configure
+@@ -60,7 +60,7 @@ echo >>$c "#define PCI_OS_`echo $sys | t
+ echo >$m 'WITH_LIBS='
+ 
+ echo_n "Looking for access methods..."
+-LIBRESOLV=-lresolv
++LIBRESOLV=
+ LIBEXT=so
+ EXEEXT=
+ SYSINCLUDE=/usr/include

--- a/package/utils/pciutils/patches/106-hwdata.patch
+++ b/package/utils/pciutils/patches/106-hwdata.patch
@@ -1,0 +1,11 @@
+--- a/Makefile
++++ b/Makefile
+@@ -36,7 +36,7 @@ PREFIX=/usr/local
+ BINDIR=$(PREFIX)/bin
+ SBINDIR=$(PREFIX)/sbin
+ SHAREDIR=$(PREFIX)/share
+-IDSDIR=$(SHAREDIR)
++IDSDIR=$(SHAREDIR)/hwdata
+ MANDIR:=$(shell if [ -d $(PREFIX)/share/man ] ; then echo $(PREFIX)/share/man ; else echo $(PREFIX)/man ; fi)
+ INCDIR=$(PREFIX)/include
+ LIBDIR=$(PREFIX)/lib

--- a/package/utils/pciutils/patches/110-gcc14.patch
+++ b/package/utils/pciutils/patches/110-gcc14.patch
@@ -1,0 +1,10 @@
+--- a/lib/sysfs.c
++++ b/lib/sysfs.c
+@@ -20,6 +20,7 @@
+ #include <dirent.h>
+ #include <fcntl.h>
+ #include <sys/types.h>
++#include <libgen.h>
+ 
+ #include "internal.h"
+ 

--- a/package/utils/xz/Makefile
+++ b/package/utils/xz/Makefile
@@ -1,0 +1,125 @@
+#
+# Copyright (C) 2013-2015 OpenWrt.org
+# Copyright (C) 2017 Daniel Engberg <daniel.engberg.lists@pyret.net>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=xz
+PKG_VERSION:=5.6.2
+PKG_RELEASE:=2
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=@SF/lzmautils
+PKG_HASH:=e12aa03cbd200597bd4ce11d97be2d09a6e6d39a9311ce72c91ac7deacde3171
+
+PKG_MAINTAINER:=
+PKG_LICENSE:=Public-Domain LGPL-2.1-or-later GPL-2.0-or-later GPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/a:tukaani:xz
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+PKG_BUILD_FLAGS:=lto
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/xz/Default
+  SUBMENU:=Compression
+  SECTION:=utils
+  CATEGORY:=Utilities
+  URL:=https://tukaani.org/xz
+endef
+
+define Package/xz-utils
+$(call Package/xz/Default)
+  TITLE:=XZ Utils (meta)
+  MENU:=1
+endef
+
+define Package/liblzma
+$(call Package/xz/Default)
+  SECTION:=libs
+  CATEGORY:=Libraries
+  DEPENDS:=+libpthread
+  TITLE:=liblzma library from XZ Utils
+endef
+
+# $(1): package name & command in /usr/bin/
+# $(2): package dependencies
+# $(3): symbolic links to $(1) in /usr/bin/
+define BuildSubPackage
+
+  define Package/$(1)
+  $(call Package/xz/Default)
+    DEPENDS:=xz-utils $(2)
+    TITLE:=$(1) utility from XZ Utils
+    $(if $(3),ALTERNATIVES:=$(foreach f,$(1) $(3),300:/usr/bin/$(f):/usr/libexec/$(1)-lzmautils))
+  endef
+
+  define Package/$(1)/description
+   Contains: $(1) $(3)
+  endef
+
+  define Package/$(1)/install
+	$(INSTALL_DIR) $$(1)$(if $(3),/usr/libexec,/usr/bin)
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/$(1) $$(1)$(if $(3),/usr/libexec/$(1)-lzmautils,/usr/bin/$(1))
+  endef
+
+  $$(eval $$(call BuildPackage,$(1)))
+endef
+
+TARGET_LDFLAGS += -Wl,--gc-sections
+
+CONFIGURE_ARGS += \
+	--enable-small \
+	--enable-assume-ram=4 \
+	--disable-assembler \
+	--disable-debug \
+	--disable-doc \
+	--disable-rpath \
+	--disable-symbol-versions \
+	--disable-werror \
+	--with-pic
+
+CONFIGURE_VARS += \
+	gl_cv_posix_shell=/bin/sh
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/include/lzma{,.h} \
+		$(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/liblzma.{a,so*} \
+		$(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) \
+		$(PKG_INSTALL_DIR)/usr/lib/pkgconfig/liblzma.pc \
+		$(1)/usr/lib/pkgconfig/
+endef
+
+define Package/xz-utils/install
+	true
+endef
+
+define Package/liblzma/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liblzma.so.* $(1)/usr/lib/
+endef
+
+
+$(eval $(call BuildPackage,xz-utils))
+$(eval $(call BuildPackage,liblzma))
+$(eval $(call BuildSubPackage,lzmadec, +liblzma,))
+$(eval $(call BuildSubPackage,lzmainfo, +liblzma,))
+$(eval $(call BuildSubPackage,xz, +liblzma, lzcat lzma unlzma unxz xzcat))
+$(eval $(call BuildSubPackage,xzdec, +liblzma,))
+$(eval $(call BuildSubPackage,xzdiff, +xz, lzcmp lzdiff xzcmp))
+$(eval $(call BuildSubPackage,xzgrep, +xz, lzegrep lzfgrep lzgrep xzegrep xzfgrep))
+$(eval $(call BuildSubPackage,xzless, +xz, lzless))
+$(eval $(call BuildSubPackage,xzmore, +xz, lzmore))

--- a/package/utils/xz/patches/001-relative-pkg-config-paths.patch
+++ b/package/utils/xz/patches/001-relative-pkg-config-paths.patch
@@ -1,0 +1,13 @@
+--- a/src/liblzma/liblzma.pc.in
++++ b/src/liblzma/liblzma.pc.in
+@@ -3,8 +3,8 @@
+ 
+ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+-libdir=@libdir@
+-includedir=@includedir@
++libdir=${exec_prefix}/lib
++includedir=${prefix}/include
+ 
+ Name: liblzma
+ Description: General purpose data compression library

--- a/package/utils/xz/patches/010-libtool.patch
+++ b/package/utils/xz/patches/010-libtool.patch
@@ -1,0 +1,36 @@
+# Fix shared library building in XZ Utils 5.2.13, 5.4.7, and 5.6.2
+#
+# The releases were made with a development version of GNU Libtool
+# (2.5.0+1+g38c166c8). The benefit is that there tend to be fixes that
+# aren't in a stable release yet. At the same time there is a higher
+# risk of new bugs. Unfortunately there was a bug that breaks building
+# of shared libraries on some systems like mips64.
+#
+# This patch was made by taking the upstream commit to m4/libtool.m4
+# and then running "autoconf" to update the generated "configure".
+# This patch only modifies "configure" so that the changed timestamps
+# won't cause the build system to regenerate more files, which would
+# only work if one has all Autotools packages installed.
+#
+# https://git.savannah.gnu.org/cgit/libtool.git/commit/?id=9a4a02615c9e7cbcfd690ed31874822a7d6aaea2
+# https://lore.kernel.org/distributions/3299713.44csPzL39Z@pinacolada/
+
+--- a/configure
++++ b/configure
+@@ -9475,7 +9475,7 @@ do
+   esac
+     for ac_exec_ext in '' $ac_executable_extensions; do
+   if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+-    ac_cv_prog_FILECMD=":"
++    ac_cv_prog_FILECMD="file"
+     printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+     break 2
+   fi
+@@ -9483,6 +9483,7 @@ done
+   done
+ IFS=$as_save_IFS
+ 
++  test -z "$ac_cv_prog_FILECMD" && ac_cv_prog_FILECMD=":"
+ fi ;;
+ esac
+ fi


### PR DESCRIPTION
When building openwrt without installing any feed, there will be some warning showing that some packages have unsatisfied dependencies:
```
WARNING: Makefile 'package/utils/audit/Makefile' has a dependency on 'libev', which does not exist
WARNING: Makefile 'package/utils/busybox/Makefile' has a dependency on 'libpam', which does not exist
WARNING: Makefile 'package/utils/busybox/Makefile' has a dependency on 'libpam', which does not exist
WARNING: Makefile 'package/utils/busybox/Makefile' has a build dependency on 'libpam', which does not exist
WARNING: Makefile 'package/boot/kexec-tools/Makefile' has a dependency on 'liblzma', which does not exist
WARNING: Makefile 'package/network/services/lldpd/Makefile' has a dependency on 'libnetsnmp', which does not exist
WARNING: Makefile 'package/utils/policycoreutils/Makefile' has a dependency on 'libpam', which does not exist
WARNING: Makefile 'package/utils/policycoreutils/Makefile' has a dependency on 'libpam', which does not exist
WARNING: Makefile 'package/utils/policycoreutils/Makefile' has a build dependency on 'libpam', which does not exist
```

So I moved these involved packages from packages feed to OpenWrt main repo.

Related PR that deletes these packages from packages feed: https://github.com/openwrt/packages/pull/25045