### PR TITLE
scripts/download.pl: use perl builtins instead of system()

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -11,6 +11,7 @@ use strict;
 use warnings;
 use File::Basename;
 use File::Copy;
+use File::Path;
 use Text::ParseWords;
 use JSON::PP;
 
@@ -173,7 +174,7 @@ sub download
 		}
 
 		if (! -d "$target") {
-			system("mkdir", "-p", "$target/");
+			make_path($target);
 		}
 
 		if (! open TMPDLS, "find $mirror -follow -name $filename 2>/dev/null |") {
@@ -244,7 +245,7 @@ sub download
 	};
 
 	unlink "$target/$filename";
-	system("mv", "$target/$filename.dl", "$target/$filename");
+	move("$target/$filename.dl", "$target/$filename");
 	cleanup();
 }
 


### PR DESCRIPTION
Perl natively supports renaming files and create directories. Do it without calling system().