### PR TITLE
base-files: /etc/sysctl.conf: clarity in comment

### DIFF
--- a/package/base-files/files/etc/sysctl.conf
+++ b/package/base-files/files/etc/sysctl.conf
@@ -1,1 +1,2 @@
-# Defaults are configured in /etc/sysctl.d/* and can be customized in this file
+# User defined entries should be added to this file not to /etc/sysctl.d/* as
+# that directory is not backed-up by default and will not survive a reimage


### PR DESCRIPTION
Make it clear to users that they should not place a custom file in /etc/sysctl.d/ for their values and expect it to survive a reimage.

This change is needed since these directories (/etc/foo.d/) are generally where such files are placed on other distros.