### PR TITLE
kernel: remove unneeded dependency from kmod-dsa

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -527,7 +527,7 @@ $(eval $(call KernelPackage,phy-aquantia))
 define KernelPackage/dsa
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Distributed Switch Architecture support
-  DEPENDS:=+kmod-mdio-devres +kmod-net-selftests +kmod-phylink
+  DEPENDS:=+kmod-net-selftests +kmod-phylink
   KCONFIG:=CONFIG_NET_DSA
   FILES:=$(LINUX_DIR)/net/dsa/dsa_core.ko
 endef


### PR DESCRIPTION
It doesn't need kmod-mdio-devres.

Fixes: bdd2d685db ("kernel: netdevices: add dsa support")

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>