### PR TITLE
generic: backport ("net: free_netdev: exit earlier if dummy")

### DIFF
--- a/target/linux/generic/backport-6.6/900-v6.11-net-free_netdev-exit-earlier-if-dummy.patch
+++ b/target/linux/generic/backport-6.6/900-v6.11-net-free_netdev-exit-earlier-if-dummy.patch
@@ -1,0 +1,35 @@
+From f8d05679fb3faae478d604177b0c188b340371cd Mon Sep 17 00:00:00 2001
+From: Breno Leitao <leitao@debian.org>
+Date: Mon, 22 Apr 2024 05:38:55 -0700
+Subject: [PATCH] net: free_netdev: exit earlier if dummy
+
+For dummy devices, exit earlier at free_netdev() instead of executing
+the whole function. This is necessary, because dummy devices are
+special, and shouldn't have the second part of the function executed.
+
+Otherwise reg_state, which is NETREG_DUMMY, will be overwritten and
+there will be no way to identify that this is a dummy device. Also, this
+device do not need the final put_device(), since dummy devices are not
+registered (through register_netdevice()), where the device reference is
+increased (at netdev_register_kobject()/device_add()).
+
+Suggested-by: Jakub Kicinski <kuba@kernel.org>
+Signed-off-by: Breno Leitao <leitao@debian.org>
+Reviewed-by: Ido Schimmel <idosch@nvidia.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ net/core/dev.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/net/core/dev.c
++++ b/net/core/dev.c
+@@ -10966,7 +10966,8 @@ void free_netdev(struct net_device *dev)
+ 	dev->xdp_bulkq = NULL;
+ 
+ 	/*  Compatibility with error handling in drivers */
+-	if (dev->reg_state == NETREG_UNINITIALIZED) {
++	if (dev->reg_state == NETREG_UNINITIALIZED ||
++	    dev->reg_state == NETREG_DUMMY) {
+ 		netdev_freemem(dev);
+ 		return;
+ 	}


### PR DESCRIPTION
Currently, when removing ath11k or any other driver that uses dummy netdev kernel will crash with:
```
[  365.004961] ------------[ cut here ]------------ [  365.004992] kernel BUG at net/core/dev.c:10979! [  365.008642] Internal error: Oops - BUG: 00000000f2000800 [#1] SMP [  365.012898] Modules linked in: pppoe ppp_async nft_fib_inet nf_flow_table_inet ath11k_ahb(O) ath11k(O) pppox ppp_generic nft_reject_ipv6 nft_reject_ipv4 nft_reject_inet nft_reject nft_redir nft_quota nft_numgen nft_nat nft_masq nft_log nft_limit nft_hash nft_flow_offload nft_fib_c
[  365.064794] CPU: 3 PID: 3896 Comm: procd Tainted: G           O       6.6.52 #0
[  365.087031] Hardware name: QNAP 301w (DT)
[  365.094058] pstate: 20400005 (nzCv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[  365.098229] pc : free_netdev+0x164/0x1a0
[  365.104994] lr : free_netdev+0xec/0x1a0
[  365.109159] sp : ffffffc081d33b90
[  365.112718] x29: ffffffc081d33b90 x28: ffffff80039d3c00 x27: ffffff800307f000
[  365.116199] x26: ffffff800538a000 x25: ffffff8005388000 x24: ffffff800538a4c0
[  365.123317] x23: 00000000000023a4 x22: ffffff8005388f68 x21: ffffff8004e37050
[  365.130434] x20: ffffff8004e37000 x19: ffffff8004e36ee8 x18: 0000000000000152
[  365.137552] x17: 63775f357636712e x16: 3030303030646320 x15: ffffffc081436e20
[  365.144670] x14: ffffff80033f261c x13: 00000000000000d9 x12: 0000000000000002
[  365.151789] x11: 0000000000000000 x10: 00000000000008a0 x9 : ffffffc081d33980
[  365.158906] x8 : ffffff80039d4500 x7 : ffffff803fdda6c0 x6 : 0000000000000007
[  365.166025] x5 : 0000000000000000 x4 : 00000000000000c1 x3 : 00000000000001f4
[  365.173143] x2 : ffffff803fdd4b78 x1 : ffffff8004e37050 x0 : 0000000000000005
[  365.180261] Call trace:
[  365.187370]  free_netdev+0x164/0x1a0
[  365.189630]  0xffffffc079b373f0
[  365.193447]  0xffffffc079b374c0
[  365.196311]  platform_shutdown+0x24/0x34
[  365.199438]  device_shutdown+0x160/0x268
[  365.203605]  kernel_restart+0x40/0xc0
[  365.207510]  __do_sys_reboot+0x104/0x220
[  365.211070]  __arm64_sys_reboot+0x24/0x30
[  365.215063]  invoke_syscall.constprop.0+0x5c/0x108
[  365.218971]  do_el0_svc+0x40/0xc8
[  365.223655]  el0_svc+0x30/0xb8
[  365.227041]  el0t_64_sync_handler+0x120/0x12c
[  365.229995]  el0t_64_sync+0x178/0x17c
[  365.234424] Code: f94013f5 a8c37bfd d50323bf d65f03c0 (d4210000)
[  365.238072] ---[ end trace 0000000000000000 ]---
```

Wireless backports include `alloc_netdev_dummy()` backport but they dont have the required free_netdev change first, so backport it.

Fixes: #16531
Fixes: 384d079fd876 ("mac80211: update to version 6.11")
