### PR TITLE
mt76: add missing eeprom for mt7992 firmware

### DIFF
--- a/package/kernel/mt76/Makefile
+++ b/package/kernel/mt76/Makefile
@@ -659,6 +659,7 @@ define KernelPackage/mt7992-firmware/install
 	cp \
 		$(PKG_BUILD_DIR)/firmware/mt7996/mt7992_dsp.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7996/mt7992_eeprom.bin \
+		$(PKG_BUILD_DIR)/firmware/mt7996/mt7992_eeprom_2i5i.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7996/mt7992_rom_patch.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7996/mt7992_wa.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7996/mt7992_wm.bin \
@@ -670,7 +671,7 @@ define KernelPackage/mt7992-23-firmware/install
 	cp \
 		$(PKG_BUILD_DIR)/firmware/mt7996/mt7992_dsp_23.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7996/mt7992_eeprom_23.bin \
-		$(PKG_BUILD_DIR)/firmware/mt7996/mt7992_eeprom_23.bin \
+		$(PKG_BUILD_DIR)/firmware/mt7996/mt7992_eeprom_23_2i5i.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7996/mt7992_rom_patch_23.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7996/mt7992_wa_23.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7996/mt7992_wm_23.bin \


### PR DESCRIPTION
Avoid the following errors:
[    9.219272] mt7996e 0000:01:00.0: Direct firmware load for mediatek/mt7996/mt7992_eeprom_2i5i.bin failed with error -2
[    9.229975] mt7996e 0000:01:00.0: Falling back to sysfs fallback for: mediatek/mt7996/mt7992_eeprom_2i5i.bin
