### PR TITLE
x86: remove trailing garbage from generated gzip archives

### DIFF
--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -102,7 +102,7 @@ DEVICE_VARS += GRUB2_VARIANT
 define Device/Default
   ARTIFACT/image.iso := grub-config iso | iso
   IMAGE/combined.img := grub-config pc | combined | grub-install | append-metadata
-  IMAGE/combined.img.gz := grub-config pc | combined | grub-install | gzip | append-metadata
+  IMAGE/combined.img.gz := grub-config pc | combined | grub-install | append-metadata | gzip
   IMAGE/combined.vdi := grub-config pc | combined | grub-install | qemu-image vdi
   IMAGE/combined.vmdk := grub-config pc | combined | grub-install | qemu-image vmdk
   IMAGE/combined.vhdx := grub-config pc | combined | grub-install | qemu-image vhdx -o subformat=dynamic
@@ -110,7 +110,7 @@ define Device/Default
   IMAGE/rootfs.img.gz := append-rootfs | pad-to $(ROOTFS_PARTSIZE) | gzip
   ARTIFACT/image-efi.iso := grub-config iso | iso efi
   IMAGE/combined-efi.img := grub-config efi | combined efi | grub-install efi | append-metadata
-  IMAGE/combined-efi.img.gz := grub-config efi | combined efi | grub-install efi | gzip | append-metadata
+  IMAGE/combined-efi.img.gz := grub-config efi | combined efi | grub-install efi | append-metadata | gzip 
   IMAGE/combined-efi.vdi := grub-config efi | combined efi | grub-install efi | qemu-image vdi
   IMAGE/combined-efi.vmdk := grub-config efi | combined efi | grub-install efi | qemu-image vmdk
   IMAGE/combined-efi.vhdx := grub-config efi | combined efi | grub-install efi | qemu-image vhdx -o subformat=dynamic


### PR DESCRIPTION
Follow-up fix to f814121600e5cf43fd75fe93e5b1b54f65b71bcd

Sure, you can 'append-metadata' to IMAGES, but don't append GARBAGE to gzip archives. Opportunistic gzip made from piped data have no header to determine when the file archive correctly ends and the garbage starts, so some unarchivers fail to decompress.

The 'metadata' appended is anyway useless. E.g. for 23.05.5 release:

```
Hex View  00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F

00B011B0  00 C0 41 F0 B5 48 21 00  7E 84 07 23 20 66 61 6B  ..A..H!.~..# fak
00B011C0  65 20 63 65 72 74 69 66  69 63 61 74 65 46 57 78  e certificateFWx
00B011D0  30 76 5A EE B8 00 00 00  00 00 00 00 22           0vZ........."
```

@aparcar @dangowrt @robimarko