### PR TITLE
x86: add Gowin 1U Rack Mount Router Server

### DIFF
--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -122,6 +122,11 @@ ucidef_set_network_device_path() {
 	_ucidef_set_network_device_common $1 path $2
 }
 
+ucidef_set_network_device_path_port() {
+	_ucidef_set_network_device_common $1 path $2
+	_ucidef_set_network_device_common $1 port $3
+}
+
 ucidef_set_network_device_gro() {
 	_ucidef_set_network_device_common $1 gro $2
 }

--- a/package/base-files/files/lib/preinit/10_indicate_preinit
+++ b/package/base-files/files/lib/preinit/10_indicate_preinit
@@ -65,12 +65,27 @@ preinit_config_switch() {
 
 preinit_config_port() {
 	local original
+	local dev_port
 
 	local netdev="$1"
 	local path="$2"
+	local port="$3"
 
 	[ -d "/sys/devices/$path/net" ] || return
-	original="$(ls "/sys/devices/$path/net" | head -1)"
+
+	if [ -z "$port" ]; then
+		original="$(ls "/sys/devices/$path/net" | head -1)"
+	else
+		for device in /sys/devices/$path/net/*; do
+			dev_port="$(cat "$device/dev_port")"
+			if [ "$dev_port" = "$port" ]; then
+				original="${device##*/}"
+				break
+			fi
+		done
+
+		[ -z "$original" ] && return
+	fi
 
 	[ "$netdev" = "$original" ] && return
 
@@ -109,7 +124,8 @@ preinit_config_board() {
 		json_select "network_device"
 			json_select "$netdev"
 				json_get_vars path path
-				[ -n "$path" ] && preinit_config_port "$netdev" "$path"
+				json_get_vars port port
+				[ -n "$path" ] && preinit_config_port "$netdev" "$path" "$port"
 			json_select ..
 		json_select ..
 	done

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1558,7 +1558,7 @@ define KernelPackage/mlx4-core
 	CONFIG_MLX4_CORE=y \
 	CONFIG_MLX4_CORE_GEN2=y \
 	CONFIG_MLX4_DEBUG=n
-  AUTOLOAD:=$(call AutoProbe,mlx4_core mlx4_en)
+  AUTOLOAD:=$(call AutoLoad,36,mlx4_core mlx4_en,1)
 endef
 
 define KernelPackage/mlx4-core/description
@@ -1589,7 +1589,7 @@ define KernelPackage/mlx5-core
 	CONFIG_MLX5_TC_CT=n \
 	CONFIG_MLX5_TLS=n \
 	CONFIG_MLX5_VFIO_PCI=n
-  AUTOLOAD:=$(call AutoProbe,mlx5_core)
+  AUTOLOAD:=$(call AutoLoad,36,mlx5_core,1)
 endef
 
 define KernelPackage/mlx5-core/description
@@ -1798,7 +1798,7 @@ define KernelPackage/igc
   DEPENDS:=@PCI_SUPPORT +kmod-ptp
   KCONFIG:=CONFIG_IGC
   FILES:=$(LINUX_DIR)/drivers/net/ethernet/intel/igc/igc.ko
-  AUTOLOAD:=$(call AutoProbe,igc)
+  AUTOLOAD:=$(call AutoLoad,34,igc,1)
 endef
 
 define KernelPackage/igc/description

--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -34,6 +34,32 @@ cisco-mx100-hw)
 dell-emc-edge620)
 	ucidef_set_interfaces_lan_wan "eth0 eth1 eth2 eth3 eth7" "eth6"
 	;;
+gowin-solution-co-ltd-gw-mb-u01)
+	ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:1c.0/0000:01:00.0/0000:02:02.0/0000:04:00.0"
+	ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:1c.0/0000:01:00.0/0000:02:00.0/0000:03:00.0"
+	ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:1c.2/0000:07:00.0/0000:08:02.0/0000:0a:00.0"
+	ucidef_set_network_device_path "eth4" "pci0000:00/0000:00:1c.2/0000:07:00.0/0000:08:00.0/0000:09:00.0"
+	ucidef_set_network_device_path "poe"  "pci0000:00/0000:00:1c.2/0000:07:00.0/0000:08:06.0/0000:0b:00.0"
+
+	sfp_device="pci0000:00/0000:00:1d.0"
+	sfp_device_path="/sys/devices/$sfp_device"
+
+	pci_count="$(ls -d $sfp_device_path/0000:*:00.* 2>/dev/null | wc -l)"
+	if [ "$pci_count" -eq 2 ]; then
+		sfp_port1="$(basename $sfp_device_path/0000:*:00.1)"
+		sfp_port2="$(basename $sfp_device_path/0000:*:00.0)"
+
+		ucidef_set_network_device_path "sfp1" "$sfp_device/$sfp_port1"
+		ucidef_set_network_device_path "sfp2" "$sfp_device/$sfp_port2"
+	elif [ "$pci_count" -eq 1 ]; then
+		sfp_port="$(basename $sfp_device_path/0000:*:00.0)"
+
+		ucidef_set_network_device_path_port "sfp1" "$sfp_device/$sfp_port" "1"
+		ucidef_set_network_device_path_port "sfp2" "$sfp_device/$sfp_port" "0"
+	fi
+
+	ucidef_set_interface_lan "eth1 eth2 eth3 eth4"
+	;;
 pc-engines-apu1|pc-engines-apu2|pc-engines-apu3)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
 	;;


### PR DESCRIPTION
This PR focuses on correctly labeling the ```Gowin 1U Rack Mount Boards``` network ports.
You can find a picture of the front panel network labels here:

![GoWin-1U-25GbE-Appliance-25GbE-Ports](https://github.com/user-attachments/assets/660357ef-8f2a-4d61-b2ac-3190b6952ba6)

- The ```eth1``` and ```eth2``` ports use the ```igc``` driver
- The ```eth3```, ```eth4```, and ```poe``` ports use ```igb```
- And the ```sfp1``` and ```sfp2``` ports use ```mlx4```/```mlx5```
<br>

To label them, I have added their appropriate names and PCI addresses to https://github.com/openwrt/openwrt/blob/main/target/linux/x86/base-files/etc/board.d/02_network. But the ```igc```, ```mlx4```, and ```mlx5``` drivers are currently probed after this script is called, which is why commit ff4e538524bd14e8ae32bf74d59e0a518f1b3e8f sets the boot flag for those drivers so that they are probed beforehand.

Furthermore, those boards can contain either a Mellanox ConnectX-3 10G card that uses the ```mlx4``` driver or a Mellanox ConnectX-4 25G card that uses the ```mlx5``` driver. The ConnectX-4 card maps its SFP ports to two different PCI addresses, but the ConnectX-3 card maps them to a single PCI address. Commit 8130c0771216e1896be7dc8e65fa254707782f7e adds a uci function to name network interfaces located at the same PCI address.

Commit 54e8a908b6bc2cf2348e89d5b2391100872eb968 checks whether a card with one or two PCI addresses is attached to the PCI bus and sets/bridges the interface names accordingly.