### PR TITLE
bmips: fix kernel panic caused by missing CBR address

### DIFF
--- a/target/linux/bmips/dts/bcm6358.dtsi
+++ b/target/linux/bmips/dts/bcm6358.dtsi
@@ -42,7 +42,7 @@
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
-		mips-cbr-reg = <0xff400000>;
+		brcm,bmips-cbr-reg = <0xff400000>;
 		mips-hpt-frequency = <150000000>;
 
 		cpu@0 {

--- a/target/linux/bmips/dts/bcm6368.dtsi
+++ b/target/linux/bmips/dts/bcm6368.dtsi
@@ -43,7 +43,7 @@
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;
-		mips-cbr-reg = <0xff400000>;
+		brcm,bmips-cbr-reg = <0xff400000>;
 		mips-hpt-frequency = <200000000>;
 
 		cpu@0 {


### PR DESCRIPTION
The cbr-reg DTS property uses a wrong name causing the RAC kernel panic again on BCM6358 and BCM6368 boards.

Use the correct cbr-reg name property.

Fixes: 7c9644a7b5 ("bmips: backport upstreamed RAC patches")

CC: @Noltari @Ansuel 