### PR TITLE
lantiq: backport latest upstream patches

### DIFF
--- a/target/linux/lantiq/patches-6.6/0025-v6.12-net-ethernet-lantiq_etop-fix-memory-disclosure.patch
+++ b/target/linux/lantiq/patches-6.6/0025-v6.12-net-ethernet-lantiq_etop-fix-memory-disclosure.patch
@@ -1,0 +1,42 @@
+From 45c0de18ff2dc9af01236380404bbd6a46502c69 Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Mon, 23 Sep 2024 23:49:49 +0200
+Subject: net: ethernet: lantiq_etop: fix memory disclosure
+
+When applying padding, the buffer is not zeroed, which results in memory
+disclosure. The mentioned data is observed on the wire. This patch uses
+skb_put_padto() to pad Ethernet frames properly. The mentioned function
+zeroes the expanded buffer.
+
+In case the packet cannot be padded it is silently dropped. Statistics
+are also not incremented. This driver does not support statistics in the
+old 32-bit format or the new 64-bit format. These will be added in the
+future. In its current form, the patch should be easily backported to
+stable versions.
+
+Ethernet MACs on Amazon-SE and Danube cannot do padding of the packets
+in hardware, so software padding must be applied.
+
+Fixes: 504d4721ee8e ("MIPS: Lantiq: Add ethernet driver")
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Reviewed-by: Jacob Keller <jacob.e.keller@intel.com>
+Reviewed-by: Florian Fainelli <florian.fainelli@broadcom.com>
+Link: https://patch.msgid.link/20240923214949.231511-2-olek2@wp.pl
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/ethernet/lantiq_etop.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/lantiq_etop.c
++++ b/drivers/net/ethernet/lantiq_etop.c
+@@ -482,7 +482,9 @@ ltq_etop_tx(struct sk_buff *skb, struct
+ 	unsigned long flags;
+ 	u32 byte_offset;
+ 
+-	len = skb->len < ETH_ZLEN ? ETH_ZLEN : skb->len;
++	if (skb_put_padto(skb, ETH_ZLEN))
++		return NETDEV_TX_OK;
++	len = skb->len;
+ 
+ 	if ((desc->ctl & (LTQ_DMA_OWN | LTQ_DMA_C)) || ch->skb[ch->dma.desc]) {
+ 		netdev_err(dev, "tx ring full\n");

--- a/target/linux/lantiq/patches-6.6/0026-v6.12-net-ethernet-lantiq_etop-remove-unused-variable.patch
+++ b/target/linux/lantiq/patches-6.6/0026-v6.12-net-ethernet-lantiq_etop-remove-unused-variable.patch
@@ -1,0 +1,24 @@
+From 1f803c95693f140bed46cd5581b97592e20b723e Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Thu, 15 Aug 2024 09:49:56 +0200
+Subject: [PATCH] net: ethernet: lantiq_etop: remove unused variable
+
+Remove a variable that has never been used.
+
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Link: https://patch.msgid.link/20240815074956.155224-1-olek2@wp.pl
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/lantiq_etop.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+--- a/drivers/net/ethernet/lantiq_etop.c
++++ b/drivers/net/ethernet/lantiq_etop.c
+@@ -95,7 +95,6 @@ struct ltq_etop_priv {
+ 	struct mii_bus *mii_bus;
+ 
+ 	struct ltq_etop_chan ch[MAX_DMA_CHAN];
+-	int tx_free[MAX_DMA_CHAN >> 1];
+ 
+ 	int tx_burst_len;
+ 	int rx_burst_len;

--- a/target/linux/lantiq/patches-6.6/0027-v6.11-net-ethernet-lantiq_etop-remove-redundant-device-nam.patch
+++ b/target/linux/lantiq/patches-6.6/0027-v6.11-net-ethernet-lantiq_etop-remove-redundant-device-nam.patch
@@ -21,7 +21,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/lantiq_etop.c
 +++ b/drivers/net/ethernet/lantiq_etop.c
-@@ -675,7 +675,6 @@ ltq_etop_probe(struct platform_device *p
+@@ -676,7 +676,6 @@ ltq_etop_probe(struct platform_device *p
  		err = -ENOMEM;
  		goto err_out;
  	}

--- a/target/linux/lantiq/patches-6.6/0028-NET-lantiq-various-etop-fixes.patch
+++ b/target/linux/lantiq/patches-6.6/0028-NET-lantiq-various-etop-fixes.patch
@@ -5,8 +5,8 @@ Subject: [PATCH 28/36] NET: lantiq: various etop fixes
 
 Signed-off-by: John Crispin <blogic@openwrt.org>
 ---
- drivers/net/ethernet/lantiq_etop.c | 530 ++++++++++++++++++++---------
- 1 file changed, 375 insertions(+), 155 deletions(-)
+ drivers/net/ethernet/lantiq_etop.c | 534 ++++++++++++++++++++---------
+ 1 file changed, 379 insertions(+), 155 deletions(-)
 
 --- a/drivers/net/ethernet/lantiq_etop.c
 +++ b/drivers/net/ethernet/lantiq_etop.c
@@ -153,7 +153,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	struct net_device *netdev;
  	struct napi_struct napi;
  	struct ltq_dma_channel dma;
-@@ -89,26 +141,39 @@ struct ltq_etop_chan {
+@@ -89,25 +141,39 @@ struct ltq_etop_chan {
  struct ltq_etop_priv {
  	struct net_device *netdev;
  	struct platform_device *pdev;
@@ -163,7 +163,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	struct mii_bus *mii_bus;
  
 -	struct ltq_etop_chan ch[MAX_DMA_CHAN];
--	int tx_free[MAX_DMA_CHAN >> 1];
 +	struct ltq_etop_chan txch;
 +	struct ltq_etop_chan rxch;
  
@@ -197,7 +196,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	if (!ch->skb[ch->dma.desc])
  		return -ENOMEM;
  	ch->dma.desc_base[ch->dma.desc].addr =
-@@ -143,8 +208,11 @@ ltq_etop_hw_receive(struct ltq_etop_chan
+@@ -142,8 +208,11 @@ ltq_etop_hw_receive(struct ltq_etop_chan
  	spin_unlock_irqrestore(&priv->lock, flags);
  
  	skb_put(skb, len);
@@ -209,7 +208,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  }
  
  static int
-@@ -152,7 +220,9 @@ ltq_etop_poll_rx(struct napi_struct *nap
+@@ -151,7 +220,9 @@ ltq_etop_poll_rx(struct napi_struct *nap
  {
  	struct ltq_etop_chan *ch = container_of(napi,
  				struct ltq_etop_chan, napi);
@@ -219,7 +218,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  	while (work_done < budget) {
  		struct ltq_dma_desc *desc = &ch->dma.desc_base[ch->dma.desc];
-@@ -164,7 +234,9 @@ ltq_etop_poll_rx(struct napi_struct *nap
+@@ -163,7 +234,9 @@ ltq_etop_poll_rx(struct napi_struct *nap
  	}
  	if (work_done < budget) {
  		napi_complete_done(&ch->napi, work_done);
@@ -229,7 +228,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	}
  	return work_done;
  }
-@@ -176,12 +248,14 @@ ltq_etop_poll_tx(struct napi_struct *nap
+@@ -175,12 +248,14 @@ ltq_etop_poll_tx(struct napi_struct *nap
  		container_of(napi, struct ltq_etop_chan, napi);
  	struct ltq_etop_priv *priv = netdev_priv(ch->netdev);
  	struct netdev_queue *txq =
@@ -245,7 +244,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  		dev_kfree_skb_any(ch->skb[ch->tx_free]);
  		ch->skb[ch->tx_free] = NULL;
  		memset(&ch->dma.desc_base[ch->tx_free], 0,
-@@ -194,7 +268,9 @@ ltq_etop_poll_tx(struct napi_struct *nap
+@@ -193,7 +268,9 @@ ltq_etop_poll_tx(struct napi_struct *nap
  	if (netif_tx_queue_stopped(txq))
  		netif_tx_start_queue(txq);
  	napi_complete(&ch->napi);
@@ -255,7 +254,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	return 1;
  }
  
-@@ -202,9 +278,11 @@ static irqreturn_t
+@@ -201,9 +278,11 @@ static irqreturn_t
  ltq_etop_dma_irq(int irq, void *_priv)
  {
  	struct ltq_etop_priv *priv = _priv;
@@ -269,7 +268,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	return IRQ_HANDLED;
  }
  
-@@ -216,7 +294,7 @@ ltq_etop_free_channel(struct net_device
+@@ -215,7 +294,7 @@ ltq_etop_free_channel(struct net_device
  	ltq_dma_free(&ch->dma);
  	if (ch->dma.irq)
  		free_irq(ch->dma.irq, priv);
@@ -278,7 +277,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  		struct ltq_dma_channel *dma = &ch->dma;
  
  		for (dma->desc = 0; dma->desc < LTQ_DESC_NUM; dma->desc++)
-@@ -228,80 +306,137 @@ static void
+@@ -227,80 +306,137 @@ static void
  ltq_etop_hw_exit(struct net_device *dev)
  {
  	struct ltq_etop_priv *priv = netdev_priv(dev);
@@ -465,7 +464,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  }
  
  static void
-@@ -320,6 +455,39 @@ static const struct ethtool_ops ltq_etop
+@@ -319,6 +455,39 @@ static const struct ethtool_ops ltq_etop
  };
  
  static int
@@ -505,7 +504,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  ltq_etop_mdio_wr(struct mii_bus *bus, int phy_addr, int phy_reg, u16 phy_data)
  {
  	u32 val = MDIO_REQUEST |
-@@ -327,9 +495,9 @@ ltq_etop_mdio_wr(struct mii_bus *bus, in
+@@ -326,9 +495,9 @@ ltq_etop_mdio_wr(struct mii_bus *bus, in
  		((phy_reg & MDIO_REG_MASK) << MDIO_REG_OFFSET) |
  		phy_data;
  
@@ -517,7 +516,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	return 0;
  }
  
-@@ -340,12 +508,12 @@ ltq_etop_mdio_rd(struct mii_bus *bus, in
+@@ -339,12 +508,12 @@ ltq_etop_mdio_rd(struct mii_bus *bus, in
  		((phy_addr & MDIO_ADDR_MASK) << MDIO_ADDR_OFFSET) |
  		((phy_reg & MDIO_REG_MASK) << MDIO_REG_OFFSET);
  
@@ -534,7 +533,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	return val;
  }
  
-@@ -361,7 +529,10 @@ ltq_etop_mdio_probe(struct net_device *d
+@@ -360,7 +529,10 @@ ltq_etop_mdio_probe(struct net_device *d
  	struct ltq_etop_priv *priv = netdev_priv(dev);
  	struct phy_device *phydev;
  
@@ -546,7 +545,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  	if (!phydev) {
  		netdev_err(dev, "no PHY found\n");
-@@ -369,14 +540,17 @@ ltq_etop_mdio_probe(struct net_device *d
+@@ -368,14 +540,17 @@ ltq_etop_mdio_probe(struct net_device *d
  	}
  
  	phydev = phy_connect(dev, phydev_name(phydev),
@@ -566,7 +565,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  	phy_attached_info(phydev);
  
-@@ -397,8 +571,13 @@ ltq_etop_mdio_init(struct net_device *de
+@@ -396,8 +571,13 @@ ltq_etop_mdio_init(struct net_device *de
  	}
  
  	priv->mii_bus->priv = dev;
@@ -582,7 +581,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	priv->mii_bus->name = "ltq_mii";
  	snprintf(priv->mii_bus->id, MII_BUS_ID_SIZE, "%s-%x",
  		 priv->pdev->name, priv->pdev->id);
-@@ -435,18 +614,21 @@ static int
+@@ -434,18 +614,21 @@ static int
  ltq_etop_open(struct net_device *dev)
  {
  	struct ltq_etop_priv *priv = netdev_priv(dev);
@@ -614,7 +613,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	netif_tx_start_all_queues(dev);
  	return 0;
  }
-@@ -455,18 +637,19 @@ static int
+@@ -454,18 +637,19 @@ static int
  ltq_etop_stop(struct net_device *dev)
  {
  	struct ltq_etop_priv *priv = netdev_priv(dev);
@@ -644,7 +643,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	return 0;
  }
  
-@@ -476,15 +659,16 @@ ltq_etop_tx(struct sk_buff *skb, struct
+@@ -475,17 +659,21 @@ ltq_etop_tx(struct sk_buff *skb, struct
  	int queue = skb_get_queue_mapping(skb);
  	struct netdev_queue *txq = netdev_get_tx_queue(dev, queue);
  	struct ltq_etop_priv *priv = netdev_priv(dev);
@@ -657,7 +656,13 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	u32 byte_offset;
 +	int len;
  
- 	len = skb->len < ETH_ZLEN ? ETH_ZLEN : skb->len;
+-	if (skb_put_padto(skb, ETH_ZLEN))
++	if (skb_put_padto(skb, ETH_ZLEN)) {
++		dev->stats.tx_dropped++;
+ 		return NETDEV_TX_OK;
++	}
++
+ 	len = skb->len;
  
 -	if ((desc->ctl & (LTQ_DMA_OWN | LTQ_DMA_C)) || ch->skb[ch->dma.desc]) {
 +	if ((desc->ctl & (LTQ_DMA_OWN | LTQ_DMA_C)) ||
@@ -665,7 +670,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  		netdev_err(dev, "tx ring full\n");
  		netif_tx_stop_queue(txq);
  		return NETDEV_TX_BUSY;
-@@ -492,7 +676,7 @@ ltq_etop_tx(struct sk_buff *skb, struct
+@@ -493,7 +681,7 @@ ltq_etop_tx(struct sk_buff *skb, struct
  
  	/* dma needs to start on a burst length value aligned address */
  	byte_offset = CPHYSADDR(skb->data) % (priv->tx_burst_len * 4);
@@ -674,7 +679,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  	netif_trans_update(dev);
  
-@@ -503,11 +687,11 @@ ltq_etop_tx(struct sk_buff *skb, struct
+@@ -504,11 +692,11 @@ ltq_etop_tx(struct sk_buff *skb, struct
  	wmb();
  	desc->ctl = LTQ_DMA_OWN | LTQ_DMA_SOP | LTQ_DMA_EOP |
  		LTQ_DMA_TX_OFFSET(byte_offset) | (len & LTQ_DMA_SIZE_MASK);
@@ -689,7 +694,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  		netif_tx_stop_queue(txq);
  
  	return NETDEV_TX_OK;
-@@ -518,11 +702,14 @@ ltq_etop_change_mtu(struct net_device *d
+@@ -519,11 +707,14 @@ ltq_etop_change_mtu(struct net_device *d
  {
  	struct ltq_etop_priv *priv = netdev_priv(dev);
  	unsigned long flags;
@@ -705,7 +710,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	spin_unlock_irqrestore(&priv->lock, flags);
  
  	return 0;
-@@ -575,6 +762,9 @@ ltq_etop_init(struct net_device *dev)
+@@ -576,6 +767,9 @@ ltq_etop_init(struct net_device *dev)
  	if (err)
  		goto err_hw;
  	ltq_etop_change_mtu(dev, 1500);
@@ -715,7 +720,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  	memcpy(&mac, &priv->pldata->mac, sizeof(struct sockaddr));
  	if (!is_valid_ether_addr(mac.sa_data)) {
-@@ -592,9 +782,10 @@ ltq_etop_init(struct net_device *dev)
+@@ -593,9 +787,10 @@ ltq_etop_init(struct net_device *dev)
  		dev->addr_assign_type = NET_ADDR_RANDOM;
  
  	ltq_etop_set_multicast_list(dev);
@@ -729,7 +734,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	return 0;
  
  err_netdev:
-@@ -614,6 +805,9 @@ ltq_etop_tx_timeout(struct net_device *d
+@@ -615,6 +810,9 @@ ltq_etop_tx_timeout(struct net_device *d
  	err = ltq_etop_hw_init(dev);
  	if (err)
  		goto err_hw;
@@ -739,7 +744,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	netif_trans_update(dev);
  	netif_wake_queue(dev);
  	return;
-@@ -637,14 +831,18 @@ static const struct net_device_ops ltq_e
+@@ -638,14 +836,18 @@ static const struct net_device_ops ltq_e
  	.ndo_tx_timeout = ltq_etop_tx_timeout,
  };
  
@@ -762,7 +767,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
  	if (!res) {
-@@ -670,18 +868,54 @@ ltq_etop_probe(struct platform_device *p
+@@ -671,18 +873,54 @@ ltq_etop_probe(struct platform_device *p
  		goto err_out;
  	}
  
@@ -823,7 +828,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	spin_lock_init(&priv->lock);
  	SET_NETDEV_DEV(dev, &pdev->dev);
  
-@@ -697,15 +931,10 @@ ltq_etop_probe(struct platform_device *p
+@@ -698,15 +936,10 @@ ltq_etop_probe(struct platform_device *p
  		goto err_free;
  	}
  
@@ -843,7 +848,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  	err = register_netdev(dev);
  	if (err)
-@@ -734,31 +963,22 @@ ltq_etop_remove(struct platform_device *
+@@ -735,31 +968,22 @@ ltq_etop_remove(struct platform_device *
  	return 0;
  }
  

--- a/target/linux/lantiq/patches-6.6/0035-owrt-lantiq-wifi-and-ethernet-eeprom-handling.patch
+++ b/target/linux/lantiq/patches-6.6/0035-owrt-lantiq-wifi-and-ethernet-eeprom-handling.patch
@@ -203,7 +203,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +early_param("ethaddr", setup_ethaddr);
 --- a/drivers/net/ethernet/lantiq_etop.c
 +++ b/drivers/net/ethernet/lantiq_etop.c
-@@ -766,7 +766,11 @@ ltq_etop_init(struct net_device *dev)
+@@ -771,7 +771,11 @@ ltq_etop_init(struct net_device *dev)
  	if (err)
  		goto err_hw;
  

--- a/target/linux/lantiq/patches-6.6/0050-v6.11-usb-dwc2-add-support-for-other-Lantiq-SoCs.patch
+++ b/target/linux/lantiq/patches-6.6/0050-v6.11-usb-dwc2-add-support-for-other-Lantiq-SoCs.patch
@@ -1,7 +1,7 @@
-From de2cad82c4d0872066f83ce59462603852b47f03 Mon Sep 17 00:00:00 2001
+From 5af43708d21c30e2f418cb25d337779c56d235f6 Mon Sep 17 00:00:00 2001
 From: Hauke Mehrtens <hauke@hauke-m.de>
-Date: Fri, 6 Jan 2017 17:55:24 +0100
-Subject: [PATCH 2/2] usb: dwc2:  add support for other Lantiq SoCs
+Date: Tue, 9 Jul 2024 00:20:54 +0200
+Subject: [PATCH] usb: dwc2: add support for other Lantiq SoCs
 
 The size of the internal RAM of the DesignWare USB controller changed
 between the different Lantiq SoCs. We have the following sizes:
@@ -16,10 +16,15 @@ and for the xrx200 and xrx300 SCs a little bit bigger periodic fifo.
 The auto detection of max_transfer_size and max_packet_count should
 work, so remove it.
 
+This patch is included in OpenWrt for many years.
+
 Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+Acked-by: Minas Harutyunyan <hminas@synopsys.com>
+Link: https://lore.kernel.org/r/20240708222054.2727789-1-hauke@hauke-m.de
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
 ---
- drivers/usb/dwc2/platform.c | 46 ++++++++++++++++++++++++++++++++++++++-------
- 1 file changed, 39 insertions(+), 7 deletions(-)
+ drivers/usb/dwc2/params.c | 30 +++++++++++++++++++++++++-----
+ 1 file changed, 25 insertions(+), 5 deletions(-)
 
 --- a/drivers/usb/dwc2/params.c
 +++ b/drivers/usb/dwc2/params.c

--- a/target/linux/lantiq/patches-6.6/0051-v6.11-MIPS-lantiq-improve-USB-initialization.patch
+++ b/target/linux/lantiq/patches-6.6/0051-v6.11-MIPS-lantiq-improve-USB-initialization.patch
@@ -1,17 +1,19 @@
-From 14909c4e4e836925668e74fc6e0e85ba0283cbf9 Mon Sep 17 00:00:00 2001
+From 9c7a86c935074525f24cc20e78a7d5150e4600e3 Mon Sep 17 00:00:00 2001
 From: Hauke Mehrtens <hauke@hauke-m.de>
-Date: Fri, 6 Jan 2017 17:40:12 +0100
-Subject: [PATCH 2/2] MIPS: lantiq: improve USB initialization
+Date: Tue, 9 Jul 2024 00:23:04 +0200
+Subject: [PATCH] MIPS: lantiq: improve USB initialization
 
 This adds code to initialize the USB controller and PHY also on Danube,
 Amazon SE and AR10. This code is based on the Vendor driver from
 different UGW versions and compared to the hardware documentation.
 
-Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
----
- arch/mips/lantiq/xway/sysctrl.c |  20 +++++++
- 2 files changed, 110 insertions(+), 30 deletions(-)
+This patch is included in OpenWrt for many years.
 
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+Signed-off-by: Thomas Bogendoerfer <tsbogend@alpha.franken.de>
+---
+ arch/mips/lantiq/xway/sysctrl.c | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
 
 --- a/arch/mips/lantiq/xway/sysctrl.c
 +++ b/arch/mips/lantiq/xway/sysctrl.c


### PR DESCRIPTION
Backport patch that fixes memory disclosure in packet padding. The downstream driver supports statistics, so when a packet cannot be padded the statistics of dropped packets are incremented. The other patches do not introduce any functional changes.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>