### PR TITLE
ipq40xx: make GL.iNet A1300 switch functional

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-a1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-a1300.dts
@@ -59,10 +59,11 @@
 			linux,code = <KEY_RESTART>;
 		};
 
-		switch {
-			label = "switch-button";
+		rfkill {
+			label = "WiFi on/off switch";
 			gpios = <&tlmm 0 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_SETUP>;
+			linux,code = <KEY_RFKILL>;
+			linux,input-type = <EV_SW>;
 		};
 	};
 


### PR DESCRIPTION
Set the physical switch to KEY_RFKILL, since its previous value
(KEY_SETUP) is unsupported. This should also make the KEY_RESET button
functional, by allowing the gpio-button-hotplug kmod to load.

Addresses: https://github.com/openwrt/openwrt/issues/16557

Signed-off-by: Chris Jones <cmsj@tenshu.net>

