### PR TITLE
Adds support for DTS_DIR to Image Builder

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -49,6 +49,7 @@ image:
 	make image PACKAGES="<pkg1> [<pkg2> [<pkg3> ...]]" # include extra packages
 	make image FILES="<path>" # include extra files from <path>
 	make image BIN_DIR="<path>" # alternative output directory for the images
+	make image DTS_DIR="<path>" # alternative directory to look for device tree files
 	make image EXTRA_IMAGE_NAME="<string>" # Add this to the output image filename (sanitized)
 	make image DISABLED_SERVICES="<svc1> [<svc2> [<svc3> ..]]" # Which services in /etc/init.d/ should be disabled
 	make image ADD_LOCAL_KEY=1 # store locally generated signing key in built images
@@ -247,9 +248,11 @@ build_image: FORCE
 	if [ -d "target/linux/feeds/$(BOARD)" ]; then \
 		$(NO_TRACE_MAKE) -C target/linux/feeds/$(BOARD)/image install TARGET_BUILD=1 IB=1 EXTRA_IMAGE_NAME="$(EXTRA_IMAGE_NAME)" \
 			$(if $(USER_PROFILE),PROFILE="$(USER_PROFILE)"); \
+			$(if $(DTS_DIR),DTS_DIR="$(DTS_DIR)"); \
 	else \
 		$(NO_TRACE_MAKE) -C target/linux/$(BOARD)/image install TARGET_BUILD=1 IB=1 EXTRA_IMAGE_NAME="$(EXTRA_IMAGE_NAME)" \
 			$(if $(USER_PROFILE),PROFILE="$(USER_PROFILE)"); \
+			$(if $(DTS_DIR),DTS_DIR="$(DTS_DIR)"); \
 	fi
 
 $(BIN_DIR)/profiles.json: FORCE
@@ -313,6 +316,7 @@ image:
 		$(if $(FILES),USER_FILES="$(FILES)") \
 		$(if $(PACKAGES),USER_PACKAGES="$(PACKAGES)") \
 		$(if $(BIN_DIR),BIN_DIR="$(BIN_DIR)") \
+		$(if $(DTS_DIR),DTS_DIR="$(DTS_DIR)") \
 		$(if $(DISABLED_SERVICES),DISABLED_SERVICES="$(DISABLED_SERVICES)") \
 		$(if $(ROOTFS_PARTSIZE),CONFIG_TARGET_ROOTFS_PARTSIZE="$(ROOTFS_PARTSIZE)"))
 


### PR DESCRIPTION
Introduces a DTS_DIR option that is currently recognized by target Makefiles when building images.

Have been tested with "Orange Pi R1".

Example usage:
```
cp build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/linux-sunxi_cortexa7/linux-5.15.167/arch/arm/boot/dts/sun8i-h2-plus-orangepi-r1.dtb tmp/dt-modified/
make DTS_DIR=`pwd`/tmp/dt-modified
```