### PR TITLE
xz: update to 5.6.3

### DIFF
--- a/tools/xz/Makefile
+++ b/tools/xz/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xz
-PKG_VERSION:=5.4.6
+PKG_VERSION:=5.6.3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/lzmautils \
 		http://tukaani.org/xz
-PKG_HASH:=913851b274e8e1d31781ec949f1c23e8dbcf0ecf6e73a2436dc21769dd3e6f49
+PKG_HASH:=a95a49147b2dbb5487517acc0adcd77f9c2032cf00664eeae352405357d14a6c
 PKG_CPE_ID:=cpe:/a:tukaani:xz
 
 HOST_BUILD_PARALLEL:=1


### PR DESCRIPTION
xz: update to 5.6.3.

Changes: https://github.com/tukaani-project/xz/releases/

Maintainer: me / @ynezz @PolynomialDivision 
Compile tested: Model ASUS RT-AC88U
Architecture ARMv7 Processor rev 0 (v7l)
BCM53xx / arm_cortex-a9.
Kernel Version 6.6.53
main branch
Run tested: Using GCC 14.2.0 and binutils 2.43.1