### PR TITLE
realtek: relocate rtl839x ethernet address space

### DIFF
--- a/target/linux/realtek/dts/rtl839x.dtsi
+++ b/target/linux/realtek/dts/rtl839x.dtsi
@@ -313,9 +313,9 @@
 		};
 	};
 
-	ethernet0: ethernet@1b00a300 {
+	ethernet0: ethernet@1b00780c {
 		compatible = "realtek,rtl838x-eth";
-		reg = <0x1b00a300 0x100>;
+		reg = <0x1b00780c 0x74>;
 
 		interrupt-parent = <&intc>;
 		interrupts = <24 3>;


### PR DESCRIPTION
The address space of the ethernet driver in DTS was choosen to the best knowledge. On rtl839x it covers registers of the SerDes. That will be needed by a to-be-developed SerDes driver. So relocate the address range to one of the NIC_DMA areas. As the current implementation does not look at these addresses at all this does no harm.
