### PR TITLE
Don't install WiFi USB broadcom chip firmware on PCIE routers (53xx f…

### DIFF
--- a/package/kernel/mac80211/broadcom.mk
+++ b/package/kernel/mac80211/broadcom.mk
@@ -447,6 +447,7 @@ define KernelPackage/brcmfmac/config
 	config BRCMFMAC_USB
 		bool "Enable USB bus interface support"
 		depends on USB_SUPPORT
+		default n if TARGET_bcm53xx
 		default y
 		help
 		  Supported USB connected chipsets:


### PR DESCRIPTION
…amily)

background:
https://github.com/openwrt/openwrt/issues/16423
https://github.com/openwrt/openwrt/pull/16497

TLDR: BRCMFMAC_USB will only add WiFi USB adapter driver/firmware, and it is not needed for PCIE router 53xx family

BRCMFMAC_USB will not add support for USB, it is just a driver for Broadcom USB WiFi chips and only 2 chips "brcm43143" and "brcm43236b". The USB support is added by the Linux kernel!

If needed (_and it will be not, as no one will add WiFi USB adapter and these particular broadcom chips on a router that already has a stronger PCIE WiFi chip_) then it can be installed later.

@hauke @namiltd @wigyori @nbd168 @msdos03 @Noltari 