### PR TITLE
map: Add SNAT fix option for specific ISP and displaying portsets in luci

### DIFF
--- a/package/network/ipv6/map/Makefile
+++ b/package/network/ipv6/map/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=map
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
1. Ensure that the multiple port ranges used with specific ISP MAP-E implementation are actually SNAT-ed correctly. 
from: https://github.com/fakemanhk/openwrt-jp-ipoe

2.add support for displaying portsets in luci.
![2](https://github.com/user-attachments/assets/2b4f8533-a043-4e93-91c9-fce3cf331a9c)

Dependent PR: https://github.com/openwrt/luci/pull/7301
