### PR TITLE
libjson-c: update to 0.18

### DIFF
--- a/package/libs/libjson-c/Makefile
+++ b/package/libs/libjson-c/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=json-c
-PKG_VERSION:=0.17
+PKG_VERSION:=0.18
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-nodoc.tar.gz
 PKG_SOURCE_URL:=https://s3.amazonaws.com/json-c_releases/releases/
-PKG_HASH:=8df3b66597333dd365762cab2de2ff68e41e3808a04b692e696e0550648eefaa
+PKG_HASH:=602cdefc1d2aab8318fc0814b7ce7d59e72514d4276ca3eff92f35f86cf1c160
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=MIT

--- a/package/libs/libjson-c/patches/001-dont-build-docs.patch
+++ b/package/libs/libjson-c/patches/001-dont-build-docs.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -451,8 +451,6 @@ configure_file(json.h.cmakein ${PROJECT_
+@@ -449,8 +449,6 @@ configure_file(json.h.cmakein ${PROJECT_
  include_directories(${PROJECT_SOURCE_DIR})
  include_directories(${PROJECT_BINARY_DIR})
  


### PR DESCRIPTION
Release Notes:
https://github.com/json-c/json-c/blob/json-c-0.18-20240915/ChangeLog

I tested this on the OpenWrt One and on MIPS BE 32 in qemu.
