### PR TITLE
mediatek/filogic: Make BY25Q128AS work with spi-nor-generic

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-wavlink-wl-wn586x3.dts
+++ b/target/linux/mediatek/dts/mt7981b-wavlink-wl-wn586x3.dts
@@ -135,9 +135,9 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 
-		spi-max-frequency = <25000000>;
-		spi-tx-bus-width = <4>;
-		spi-rx-bus-width = <4>;
+		spi-max-frequency = <50000000>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
BY25Q128AS in wl-wn586x3 was not being recognised by spi-nor-generic
with the error:
[    2.920569] spi-nor: probe of spi0.0 failed with error -5
Newer kernels use 16-bit status register writes by default
(spi_nor_write_16bit_cr_and_check) to set the quad mode, but this is
not supported by BY25Q128AS, so use dual mode (for now). And use 50
MHz bus speed - the original firmware uses 52 MHz actually.

Tested on wl-wn586x3.