### PR TITLE
ramips: ER605v2 fix LED function definition

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
@@ -30,13 +30,13 @@
 
 		led_usb: usb {
 			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
+			function = LED_FUNCTION_USB;
 			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_power: power {
 			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
+			function = LED_FUNCTION_POWER;
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};


### PR DESCRIPTION
commit 665c2154ef122d10dfffeca95538ebdff82653b5 added support for ER605v2

All three LEDs where configured with LED_FUNCTION_STATUS
which worked for 23.05 and kernel 5.15.

With the upgrade to kernel 6.6 this leads to a name collision.

Therefore the USB and Power LED now use the common.h function
LED_FUNCTION_USB and LED_FUNCTION_POWER respectivly.

* fixes https://github.com/openwrt/openwrt/issues/16596

Link: https://github.com/openwrt/openwrt/pull/16606
Signed-off-by: Goetz Goerisch <ggoerisch@gmail.com>