### PR TITLE
gemini: apm821xx: Ignore return value of e2fsck 

### DIFF
--- a/target/linux/apm821xx/image/Makefile
+++ b/target/linux/apm821xx/image/Makefile
@@ -17,7 +17,8 @@ define Build/boot-img
 
 	# convert it to revision 1 - needed for u-boot ext2load
 	$(STAGING_DIR_HOST)/bin/tune2fs -O filetype $@.boot
-	$(STAGING_DIR_HOST)/bin/e2fsck -pDf $@.boot > /dev/null
+	# Ignore errors because file system was intentionally broken with tune2fs
+	-$(STAGING_DIR_HOST)/bin/e2fsck -pDf $@.boot > /dev/null
 endef
 
 define Build/boot-script

--- a/target/linux/gemini/image/Makefile
+++ b/target/linux/gemini/image/Makefile
@@ -55,8 +55,8 @@ define Build/dns313-images
 		--root $@.tmp $@.tmp-boot
 
 	# The device firmware needs revision 1 of EXT2
-	tune2fs -O filetype $@.tmp-boot
-	e2fsck -pDf $@.tmp-boot > /dev/null
+	$(STAGING_DIR_HOST)/bin/tune2fs -O filetype $@.tmp-boot
+	$(STAGING_DIR_HOST)/bin/e2fsck -pDf $@.tmp-boot > /dev/null
 
 	./dns313_gen_hdd_img.sh $@ $@.tmp-boot $(IMAGE_ROOTFS) \
 		$(CONFIG_TARGET_KERNEL_PARTSIZE) \

--- a/target/linux/gemini/image/Makefile
+++ b/target/linux/gemini/image/Makefile
@@ -56,7 +56,8 @@ define Build/dns313-images
 
 	# The device firmware needs revision 1 of EXT2
 	$(STAGING_DIR_HOST)/bin/tune2fs -O filetype $@.tmp-boot
-	$(STAGING_DIR_HOST)/bin/e2fsck -pDf $@.tmp-boot > /dev/null
+	# Ignore errors because file system was intentionally broken with tune2fs
+	-$(STAGING_DIR_HOST)/bin/e2fsck -pDf $@.tmp-boot > /dev/null
 
 	./dns313_gen_hdd_img.sh $@ $@.tmp-boot $(IMAGE_ROOTFS) \
 		$(CONFIG_TARGET_KERNEL_PARTSIZE) \


### PR DESCRIPTION
 * gemini: Use absolute paths for tools
    
    Use the absolute path to access the e2fsprogs applications. It is also
    working with relative paths, but this makes sure that we use our
    versions.
    
 * gemini: apm821xx: Ignore return value of e2fsck
    
    This fixes the build of the gemini and the apm821xx target.
    The e2fsck application returns an error code now and that makes the
    build fail. The tune2fs command adds an extra option and the e2fsck
    should later fix the file system. It is intentionally broken in this
    place.
    
    e2fsprogs was patched before to ignore this error.
    
    Fixes: 95e4664b5efc ("tools: e2fsprogs: drop e2fsck patch")

It should fix these build problems:
```
copying from directory /home/hauke/openwrt/openwrt/build_dir/target-powerpc_464fp_musl/linux-apm821xx_sata/tmp/openwrt-apm821xx-sata-wd_mybooklive-ext4-factory.img.gz.bootdir
# convert it to revision 1 - needed for u-boot ext2load
/home/hauke/openwrt/openwrt/staging_dir/host/bin/tune2fs -O filetype /home/hauke/openwrt/openwrt/build_dir/target-powerpc_464fp_musl/linux-apm821xx_sata/tmp/openwrt-apm821xx-sata-wd_mybooklive-ext4-factory.img.gz.boot
tune2fs 1.47.0 (5-Feb-2023)

Please run e2fsck -f on the filesystem.

/home/hauke/openwrt/openwrt/staging_dir/host/bin/e2fsck -pDf /home/hauke/openwrt/openwrt/build_dir/target-powerpc_464fp_musl/linux-apm821xx_sata/tmp/openwrt-apm821xx-sata-wd_mybooklive-ext4-factory.img.gz.boot > /dev/null
make[5]: *** [Makefile:85: /home/hauke/openwrt/openwrt/build_dir/target-powerpc_464fp_musl/linux-apm821xx_sata/tmp/openwrt-apm821xx-sata-wd_mybooklive-ext4-factory.img.gz] Error 1
make[5]: Leaving directory '/home/hauke/openwrt/openwrt/target/linux/apm821xx/image'
```
See:
https://buildbot.openwrt.org/images/#/builders/29
https://buildbot.openwrt.org/images/#/builders/163