### PR TITLE
iproute2: fix htobe64 declaration on musl with GCC 14.x

### DIFF
--- a/package/network/utils/iproute2/patches/165-fix-implicit-htobe64-gcc14.patch
+++ b/package/network/utils/iproute2/patches/165-fix-implicit-htobe64-gcc14.patch
@@ -1,0 +1,10 @@
+--- a/include/libnetlink.h
++++ b/include/libnetlink.h
+@@ -12,6 +12,7 @@
+ #include <linux/neighbour.h>
+ #include <linux/netconf.h>
+ #include <arpa/inet.h>
++#include <endian.h>
+ 
+ struct rtnl_handle {
+ 	int			fd;


### PR DESCRIPTION
On musl systems with GCC 14 or higher, `htobe64` is not available by default. The function is located in the `<endian.h>`. Without including this header, the following compile error occurs on iproute2 6.11+

```make
In file included from ../include/libgenl.h:5,
                 from libgenl.c:12:
../include/libnetlink.h: In function 'rta_getattr_be64':
../include/libnetlink.h:280:16: error: implicit declaration of function 'htobe64' [-Wimplicit-function-declaration]
  280 |         return htobe64(rta_getattr_u64(rta));
      |                ^~~~~~~
make[4]: *** [../config.mk:33: libgenl.o] Error 1
make[4]: *** Waiting for unfinished jobs....
In file included from ll_map.c:17:
../include/libnetlink.h: In function 'rta_getattr_be64':
../include/libnetlink.h:280:16: error: implicit declaration of function 'htobe64' [-Wimplicit-function-declaration]
  280 |         return htobe64(rta_getattr_u64(rta));
      |                ^~~~~~~
```