### PR TITLE
mediatek: fix wrong compatible string

### DIFF
--- a/target/linux/mediatek/dts/mt7622-linksys-e8450-ubi.dts
+++ b/target/linux/mediatek/dts/mt7622-linksys-e8450-ubi.dts
@@ -38,14 +38,14 @@
 				ubi-volume-ubootenv {
 					volname = "ubootenv";
 					nvmem-layout {
-						compatible = "u-boot,env-redundant-bool-layout";
+						compatible = "u-boot,env-redundant-bool";
 					};
 				};
 
 				ubi-volume-ubootenv2 {
 					volname = "ubootenv2";
 					nvmem-layout {
-						compatible = "u-boot,env-redundant-bool-layout";
+						compatible = "u-boot,env-redundant-bool";
 					};
 				};
 

--- a/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
+++ b/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
@@ -349,14 +349,14 @@
 				ubi-volume-ubootenv {
 					volname = "ubootenv";
 					nvmem-layout {
-						compatible = "u-boot,env-redundant-bool-layout";
+						compatible = "u-boot,env-redundant-bool";
 					};
 				};
 
 				ubi-volume-ubootenv2 {
 					volname = "ubootenv2";
 					nvmem-layout {
-						compatible = "u-boot,env-redundant-bool-layout";
+						compatible = "u-boot,env-redundant-bool";
 					};
 				};
 

--- a/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-rfb-spim-nand.dtso
+++ b/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-rfb-spim-nand.dtso
@@ -44,14 +44,14 @@
 							ubi-volume-ubootenv {
 								volname = "ubootenv";
 								nvmem-layout {
-									compatible = "u-boot,env-redundant-bool-layout";
+									compatible = "u-boot,env-redundant-bool";
 								};
 							};
 
 							ubi-volume-ubootenv2 {
 								volname = "ubootenv2";
 								nvmem-layout {
-									compatible = "u-boot,env-redundant-bool-layout";
+									compatible = "u-boot,env-redundant-bool";
 								};
 							};
 

--- a/target/linux/mediatek/patches-6.6/911-dts-mt7622-bpi-r64-add-rootdisk.patch
+++ b/target/linux/mediatek/patches-6.6/911-dts-mt7622-bpi-r64-add-rootdisk.patch
@@ -85,14 +85,14 @@
 +					ubi-volume-ubootenv {
 +						volname = "ubootenv";
 +						nvmem-layout {
-+							compatible = "u-boot,env-redundant-bool-layout";
++							compatible = "u-boot,env-redundant-bool";
 +						};
 +					};
 +
 +					ubi-volume-ubootenv2 {
 +						volname = "ubootenv2";
 +						nvmem-layout {
-+							compatible = "u-boot,env-redundant-bool-layout";
++							compatible = "u-boot,env-redundant-bool";
 +						};
 +					};
 +


### PR DESCRIPTION
The u-boot,env driver does not have layout in compatible.

ping @dangowrt 

I have no idea where this compatible is from.