### PR TITLE
ath10k-ct: select mac80211 debugfs support

### DIFF
--- a/package/kernel/ath10k-ct/Makefile
+++ b/package/kernel/ath10k-ct/Makefile
@@ -29,7 +29,7 @@ include $(INCLUDE_DIR)/package.mk
 define KernelPackage/ath10k-ct
   SUBMENU:=Wireless Drivers
   TITLE:=ath10k-ct driver optimized for CT ath10k firmware
-  DEPENDS:=+kmod-mac80211 +kmod-ath +@DRIVER_11AC_SUPPORT @PCI_SUPPORT +kmod-hwmon-core
+  DEPENDS:=+kmod-mac80211 +kmod-ath +@DRIVER_11AC_SUPPORT @PCI_SUPPORT +kmod-hwmon-core +@PACKAGE_MAC80211_DEBUGFS
   FILES:=\
 	$(PKG_BUILD_DIR)/ath10k$(CT_KVER)/ath10k_pci.ko \
 	$(PKG_BUILD_DIR)/ath10k$(CT_KVER)/ath10k_core.ko


### PR DESCRIPTION
Trying to compile ath10k-ct without mac80211 debugfs support will result in:
```
openwrt/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/linux-ipq806x_generic/ath10k-ct-regular/ath10k-ct-2024.07.30~ac71b14d/ath10k-6.10/wmi.h:8083:2: error: #warning Please enable ATH10K-DEBUGFS kernel option for optimal support for CT firmware. [-Werror=cpp]
 8083 | #warning Please enable ATH10K-DEBUGFS kernel option for optimal support for CT firmware.
      |  ^~~~~~~
cc1: all warnings being treated as errors
```

Fixes: #16302 
So, since the driver itself is saying that debugfs is required, then lets make ath10k-ct select mac80211 debugfs support which is selected by default anyway.