### PR TITLE
ipq40xx: fix MAC address on Meraki MR33 and MR74 after nvmem-layout

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
@@ -128,13 +128,17 @@
 		pagesize = <32>;
 		reg = <0x50>;
 		read-only; /* This holds our MAC & Meraki board-data */
-		#address-cells = <1>;
-		#size-cells = <1>;
 
-		mac_address: mac-address@66 {
-			compatible = "mac-base";
-			reg = <0x66 0x6>;
-			#nvmem-cell-cells = <1>;
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			mac_address: mac-address@66 {
+				compatible = "mac-base";
+				reg = <0x66 0x6>;
+				#nvmem-cell-cells = <1>;
+			};
 		};
 	};
 };


### PR DESCRIPTION
...conversion.
Commit 20736013e910 ("kernel: backport nvmem v6.6 fixes and v6.7 changes")
has caused the device to no longer correctly read MAC address from its
onboard 24c64 EEPROM, because "at24" driver doesn't support legacy
nvmem-cell bindings [1] - and there was an explicit config option added
to mandate that behaviour in the following patch:

820-v6.7-0002-nvmem-add-explicit-config-option-to-read-old-syntax-.patch

But some of the devices, MR33 and MR74 included, weren't converted with
that as well.
Convert the definition to use proper fixed-layout binding to fix it.

The offending change was introduced between v23.05.0 and v23.05.1, and
found by bisection:
```
git bisect start
# status: waiting for both good and bad commits
# good: [bd4f415efacfc03bbe5b79ae1d39c1451f5f7385] OpenWrt v23.05.0: adjust config defaults
git bisect good bd4f415efacfc03bbe5b79ae1d39c1451f5f7385
# status: waiting for bad commit, 1 good commit known
# bad: [a58a86693f8593974ff7c26bb42e280b62a8724c] OpenWrt v23.05.1: adjust config defaults
git bisect bad a58a86693f8593974ff7c26bb42e280b62a8724c
# good: [3d0a78add22754aa891529b6702b5e4c7b837446] qualcommax: only build initramfs if CONFIG_TARGET_ROOTFS_INITRAMFS is set
git bisect good 3d0a78add22754aa891529b6702b5e4c7b837446
# bad: [21e5db97c410f4008c8fe8515fb79a7cde368dbf] build: add CycloneDX SBOM JSON support
git bisect bad 21e5db97c410f4008c8fe8515fb79a7cde368dbf
# good: [89184b15cfce4aaffac8cda87c2fa74f829ace42] mediatek: add build for MT7981 RFB
git bisect good 89184b15cfce4aaffac8cda87c2fa74f829ace42
# bad: [41f27bbb6d0af2f37098b97cd28d5f514a6fc417] bcm53xx: add the latest fix version of brcm_nvram
git bisect bad 41f27bbb6d0af2f37098b97cd28d5f514a6fc417
# good: [b649b0bf7100bdc6adb7e857c74738cab7c47b4c] kernel: nvmem: fix "fixed-layout" & support "mac-base"
git bisect good b649b0bf7100bdc6adb7e857c74738cab7c47b4c
# bad: [20736013e91030005353b401bc4b757ba5e5fa98] kernel: backport nvmem v6.6 fixes and v6.7 changes
git bisect bad 20736013e91030005353b401bc4b757ba5e5fa98
# good: [066971615ff66512bc542b09a90be34c2afe98bb] kernel: backport v6.6 nvmem changes
git bisect good 066971615ff66512bc542b09a90be34c2afe98bb
# first bad commit: [20736013e91030005353b401bc4b757ba5e5fa98] kernel: backport nvmem v6.6 fixes and v6.7 changes
```
Link: [1] https://github.com/openwrt/openwrt/issues/15393#issuecomment-2212300849
Fixes: 20736013e910 ("kernel: backport nvmem v6.6 fixes and v6.7 changes")
Fixes: https://github.com/openwrt/openwrt/issues/15393