### PR TITLE
qualcommax: ipq807x: NBG7815: Add thermal sensors and gpio fan to DTS

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
@@ -38,6 +38,47 @@
 			gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	fan: gpio_fan {
+		compatible = "gpio-fan";
+		pinctrl-names = "default";
+		gpios = <&tlmm 21 GPIO_ACTIVE_HIGH>;
+		gpio-fan,speed-map = <0    0>,
+				<4500 1>;
+		#cooling-cells = <2>;
+	};
+
+	thermal-zones {
+		aqr113c_thermal: aqr113c-thermal {
+			polling-delay-passive = <1000>;
+			polling-delay = <5000>;
+
+			thermal-sensors = <&aqr113c>;
+
+			trips {
+				aqr113c-crit {
+					temperature = <100000>;
+					hysteresis = <1000>;
+					type = "critical";
+				};
+			};
+		};
+
+		tmp103_board: tmp103-board {
+			polling-delay = <5000>;
+			polling-delay-passive = <2000>;
+
+			thermal-sensors = <&tmp103>;
+
+			trips {
+				tmp103-crit {
+					temperature = <90000>;
+					hysteresis = <1000>;
+					type = "critical";
+				};
+			};
+		};
+	};
 };
 
 &tlmm {
@@ -306,6 +347,7 @@
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <8>;
 		reset-gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
+		#thermal-sensor-cells = <0>;
 
 		nvmem-cells = <&aqr_fw>;
 		nvmem-cell-names = "firmware";
@@ -415,9 +457,10 @@
 	pinctrl-names = "default";
 	status = "okay";
 
-	tmp103@70 {
+	tmp103: tmp103@70 {
 		compatible = "ti,tmp103";
 		reg = <0x70>;
+		#thermal-sensor-cells = <0>;
 	};
 };
 

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -447,6 +447,6 @@ define Device/zyxel_nbg7815
 	DEVICE_DTS_CONFIG := config@nbg7815
 	SOC := ipq8074
 	DEVICE_PACKAGES := ipq-wifi-zyxel_nbg7815 kmod-ath11k-pci \
-		kmod-bluetooth kmod-hwmon-tmp103
+		kmod-bluetooth kmod-hwmon-tmp103 kmod-hwmon-gpiofan
 endef
 TARGET_DEVICES += zyxel_nbg7815


### PR DESCRIPTION
For this device we don't have any fan control beside the fact the device is running very hot. Most users doing their own builds and integrate some form of script based fan control. A better solution is not really available because the kernel is not really supporting a simple on/off fan control. There were already attempts to fix this for other devices as for this too:

https://github.com/openwrt/openwrt/pull/15075
https://github.com/openwrt/openwrt/pull/14210

But the problem is deeper and kernel/thermal related.

With this PR I want to expose the fan and the two remaining sensors aqr113c and tmp103 to the system. So that at least a not so advanced user is able to use any available simple script to enable and control the fan on any vanilla OpenWrt.
