### PR TITLE
mediatek: ASUS TUF-AX6000: Add Green & Red LEDs

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
@@ -70,6 +70,16 @@
 			label = "blue:cover";
 			gpios = <&pio 20 GPIO_ACTIVE_HIGH>;
 		};
+
+		cover-red {
+			label = "red:cover";
+			gpios = <&pio 21 GPIO_ACTIVE_HIGH>;
+		};
+
+		cover-green {
+			label = "green:cover";
+			gpios = <&pio 22 GPIO_ACTIVE_HIGH>;
+		};
 	};
 
 	reg_3p3v: regulator-3p3v {


### PR DESCRIPTION
Beside the already existing control of the
Blue cover LED, this will also add the
Green and the Red cover LEDS available in the
Asus TUF-AX6000.
Signed-off-by: Magnus Sandin <magnus.sandin@gmail.com>