### PR TITLE
valgrind: Fix build on ARMv7 

### DIFF
--- a/package/devel/valgrind/Makefile
+++ b/package/devel/valgrind/Makefile
@@ -97,6 +97,10 @@ else
 	BITS := 32bit
 endif
 
+ifeq ($(CONFIG_arm_v7),y)
+	CONFIGURE_ARGS += --host=armv7-openwrt-linux$(if $(TARGET_SUFFIX),-$(TARGET_SUFFIX))
+endif
+
 CONFIGURE_ARGS += \
 	--enable-lto \
 	--enable-tls \

--- a/package/devel/valgrind/Makefile
+++ b/package/devel/valgrind/Makefile
@@ -104,14 +104,7 @@ endif
 CONFIGURE_ARGS += \
 	--enable-lto \
 	--enable-tls \
-	--without-x \
 	--without-mpicc \
-	--without-uiout \
-	--disable-valgrindmi \
-	--disable-tui \
-	--disable-valgrindtk \
-	--without-included-gettext \
-	--with-pagesize=4 \
 
 define Package/valgrind/install
 	$(INSTALL_DIR) $(1)/usr/bin


### PR DESCRIPTION
 * valgrind: Fix build on ARMv7
    
    The valgrind configure script checks if host_cpu is set to armv7 or arm.
    By default --host is set to arm-openwrt-linux and the host_cpu variable
    is set to arm. Then the valgrind build tries to compile valgrind for
    armv6 and fails. Set it explicitly to armv7 to compile valgrind with
    armv7 support.
    
    Fixes: 1a55d90320c1 ("valgrind: Update to version 3.23")

 * valgrind: Remove unsupported configure options.
    
    These options are not recognized by the valgrind configure script,
    remove them.
