### PR TITLE
ath79: Add support for TP-Link CPE710v2

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_cpe710-v1.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_cpe710-v1.dts
@@ -1,151 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "qca956x.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
+#include "qca9563_tplink_cpe710.dtsi"
 
 / {
 	model = "TP-Link CPE710 v1";
 	compatible = "tplink,cpe710-v1", "qca,qca9563";
-
-	aliases {
-		label-mac-device = &eth0;
-		led-boot = &led_lan;
-		led-failsafe = &led_lan;
-		led-upgrade = &led_lan;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led_lan: lan {
-			function = LED_FUNCTION_LAN;
-			color = <LED_COLOR_ID_BLUE>;
-			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
-		};
-
-		wlan5g {
-			label = "blue:wlan5g";
-			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "Reset button";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-	};
-};
-
-&pcie {
-	status = "okay";
-
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&precal_art_5000>, <&macaddr_info_8>;
-		nvmem-cell-names = "pre-calibration", "mac-address";
-	};
-};
-
-&spi {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <40000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x000000 0x040000>;
-				read-only;
-			};
-
-			partition@40000 {
-				label = "u-boot-env";
-				reg = <0x040000 0x010000>;
-			};
-
-			partition@50000 {
-				label = "partition-table";
-				reg = <0x050000 0x010000>;
-				read-only;
-			};
-
-			info: partition@60000 {
-				label = "info";
-				reg = <0x060000 0x010000>;
-				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					macaddr_info_8: macaddr@8 {
-						reg = <0x8 0x6>;
-					};
-				};
-			};
-
-			partition@70000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x070000 0xf50000>;
-			};
-
-			partition@fc0000 {
-				label = "config";
-				reg = <0xfc0000 0x030000>;
-				read-only;
-			};
-
-			partition@ff0000 {
-				label = "art";
-				reg = <0xff0000 0x010000>;
-				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					precal_art_5000: pre-calibration@5000 {
-						reg = <0x5000 0x2f20>;
-					};
-				};
-			};
-		};
-	};
-};
-
-&pinmux {
-	mdio_pins: mdio_pins {
-		/* GPIO 10 as MDIO(0x20), GPIO 8 as MDC(0x21) */
-		pinctrl-single,bits = <0x8 0x00200021 0x00ff00ff>;
-	};
 };
 
 &mdio0 {
-	status = "okay";
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&mdio_pins>;
-
 	phy4: ethernet-phy@4 {
 		reg = <4>;
 		reset-gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
@@ -153,17 +15,6 @@
 };
 
 &eth0 {
-	status = "okay";
-
 	phy-handle = <&phy4>;
 	phy-mode = "sgmii";
-
-	nvmem-cells = <&macaddr_info_8>;
-	nvmem-cell-names = "mac-address";
-
-	qca956x-serdes-fixup;
-
-	gmac-config {
-		device = <&gmac>;
-	};
 };

--- a/target/linux/ath79/dts/qca9563_tplink_cpe710-v2.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_cpe710-v2.dts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9563_tplink_cpe710.dtsi"
+
+/ {
+	model = "TP-Link CPE710 v2";
+	compatible = "tplink,cpe710-v2", "qca,qca9563";
+};
+
+&mdio0 {
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		reset-gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&eth0 {
+	phy-handle = <&phy0>;
+	phy-mode = "sgmii";
+};

--- a/target/linux/ath79/dts/qca9563_tplink_cpe710.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_cpe710.dtsi
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_lan;
+		led-failsafe = &led_lan;
+		led-upgrade = &led_lan;
+		label-mac-device = &eth0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_lan: lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&precal_art_5000>, <&macaddr_info_8>;
+		nvmem-cell-names = "pre-calibration", "mac-address";
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "partition-table";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "info";
+				reg = <0x060000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_info_8: macaddr@8 {
+						reg = <0x8 0x6>;
+					};
+				};
+			};
+
+			partition@70000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x070000 0xf50000>;
+			};
+
+			partition@fc0000 {
+				label = "config";
+				reg = <0xfc0000 0x030000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					precal_art_5000: pre-calibration@5000 {
+						reg = <0x5000 0x2f20>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pinmux {
+	mdio_pins: mdio_pins {
+		/* GPIO 10 as MDIO(0x20), GPIO 8 as MDC(0x21) */
+		pinctrl-single,bits = <0x8 0x00200021 0x00ff00ff>;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_info_8>;
+	nvmem-cell-names = "mac-address";
+
+	qca956x-serdes-fixup;
+
+	gmac-config {
+		device = <&gmac>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -222,7 +222,8 @@ openmesh,mr900-v1|\
 openmesh,mr900-v2|\
 openmesh,mr1750-v1|\
 openmesh,mr1750-v2|\
-tplink,cpe710-v1)
+tplink,cpe710-v1|\
+tplink,cpe710-v2)
 	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0"
 	;;
 compex,wpj344-16m|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -89,6 +89,7 @@ ath79_setup_interfaces()
 	tplink,cpe610-v1|\
 	tplink,cpe610-v2|\
 	tplink,cpe710-v1|\
+	tplink,cpe710-v2|\
 	tplink,eap225-outdoor-v1|\
 	tplink,eap225-outdoor-v3|\
 	tplink,eap225-v1|\

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -391,6 +391,17 @@ define Device/tplink_cpe710-v1
 endef
 TARGET_DEVICES += tplink_cpe710-v1
 
+define Device/tplink_cpe710-v2
+  $(Device/tplink-safeloader-uimage)
+  SOC := qca9563
+  IMAGE_SIZE := 15680k
+  DEVICE_MODEL := CPE710
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  TPLINK_BOARD_ID := CPE710V2
+endef
+TARGET_DEVICES += tplink_cpe710-v2
+
 define Device/tplink-eap2x5
   $(Device/tplink-safeloader)
   LOADER_TYPE := elf


### PR DESCRIPTION
This pull request adds support for the TP-Link CPE710v2. The v2 uses the same SoC, RAM, Flash, WiFi MAC, etc., as the v1.

The differences (I spotted) to the v1 are:
* The MDIO address of the ethernet PHY changed from 0x4 to 0x0.
* The factory image updater requires the firmware version to be > 0.0.X and the compatibility level >= 1.

The pull request adding support to the tplink-safeloader in the firmware-utils repo is [here](https://github.com/openwrt/firmware-utils/pull/36).