### PR TITLE
kernel: packages: kmod-ramoops: set IO_STRICT_DEVMEM Kconfig option to n

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -643,14 +643,16 @@ define KernelPackage/ramoops
   TITLE:=Ramoops (pstore-ram)
   DEFAULT:=m if ALL_KMODS
   KCONFIG:=CONFIG_PSTORE_RAM \
-	CONFIG_PSTORE_CONSOLE=y
+	CONFIG_PSTORE_CONSOLE=y \
+	CONFIG_IO_STRICT_DEVMEM=n
   DEPENDS:=+kmod-pstore +kmod-reed-solomon
   FILES:= $(LINUX_DIR)/fs/pstore/ramoops.ko
   AUTOLOAD:=$(call AutoLoad,30,ramoops,1)
 endef
 
 define KernelPackage/ramoops/description
- Kernel module for pstore-ram (ramoops) crash log storage
+  Kernel module for pstore-ram (ramoops) crash log storage.
+  Disables IO_STRICT_DEVMEM.
 endef
 
 $(eval $(call KernelPackage,ramoops))


### PR DESCRIPTION
`CONFIG_IO_STRICT_DEVMEM` is set to `y` on the generic configuration for 6.6.

On some devices at least, that prevents `pstore` from working as intended when used with `ramoops`. While it seems that it's possible to write data, it cannot be retrieved with standard binaries like ls or cat using root.

While in theory it's possible to use the kernel boot parameter `iomem=relaxed` on some of these devices, it seems more reasonable to disable IO_STRICT_DEVMEM while debugging using `ramoops` than relaxing iomem on devices that are running normally.

This is how I've gone about testing this on my MX4200v2.

1. Added the following to `target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v2.dts`.
```
/ { 
	reserved-memory {
		ramoops_region: ramoops@51100000 {
			compatible = "ramoops";
			reg = <0x0 0x51100000 0x0 0x100000>;
			no-map;
			record-size = <0x10000>;
			console-size = <0x10000>;
		};
	};
};
```
2. Compiled with `kmod-ramoops` enabled.
3. Triggered a crash with `sh -c 'echo 10 > /proc/sys/kernel/panic; echo c > /proc/sysrq-trigger'`
4. Confirmed that there was nothing under `/sys/fs/pstore` after reboot.
5. Made the changes included in this PR and recompiled.
6. Triggered another crash.
7. Confirmed there was content in `/sys/fs/pstore`

`ls -lah /sys/fs/pstore/`
```
drwxr-x---    2 root     root           0 Oct  8 20:30 .
drwxr-xr-x    7 root     root           0 Jan  1  1970 ..
-r--r--r--    1 root     root       31.4K Oct  8 20:30 console-ramoops-0
-r--r--r--    1 root     root       33.8K Oct  8 20:32 dmesg-ramoops-0
```
`cat /sys/fs/pstore/dmesg-ramoops-0`
```
[...]
<6>[  134.173158] sysrq: Trigger a crash
<0>[  134.173207] Kernel panic - not syncing: sysrq triggered crash
<4>[  134.175467] CPU: 0 PID: 5126 Comm: sh Tainted: G           O       6.6.54 #0
<4>[  134.181283] Hardware name: Linksys MX4200v2 (DT)
<4>[  134.188398] Call trace:
<4>[  134.192992]  dump_backtrace+0xa0/0xe0
<4>[  134.195165]  show_stack+0x18/0x24
<4>[  134.198984]  dump_stack_lvl+0x48/0x60
<4>[  134.202283]  dump_stack+0x18/0x24
<4>[  134.205928]  panic+0x2cc/0x320
<4>[  134.209225]  send_sig_all+0x0/0xc8
<4>[  134.212179]  __handle_sysrq+0xe0/0x1c8
<4>[  134.215563]  write_sysrq_trigger+0xcc/0x134
<4>[  134.219298]  proc_reg_write+0xb0/0xf8
<4>[  134.223376]  vfs_write+0xb0/0x358
<4>[  134.227195]  ksys_write+0x5c/0xe0
<4>[  134.230494]  __arm64_sys_write+0x1c/0x28
<4>[  134.233794]  invoke_syscall.constprop.0+0x5c/0x108
<4>[  134.237789]  do_el0_svc+0x40/0xc8
<4>[  134.242385]  el0_svc+0x30/0xb8
<4>[  134.245771]  el0t_64_sync_handler+0x120/0x12c
<4>[  134.248726]  el0t_64_sync+0x178/0x17c
<2>[  134.253152] SMP: stopping secondary CPUs
<0>[  134.256803] Kernel Offset: disabled
<0>[  134.260789] CPU features: 0x0,00000000,00000000,0000400b
<0>[  134.264005] Memory Limit: none
````
`cat /sys/fs/pstore/console-ramoops-0`
```
[...]
[  134.173158] sysrq: Trigger a crash
[  134.173207] Kernel panic - not syncing: sysrq triggered crash
[  134.175467] CPU: 0 PID: 5126 Comm: sh Tainted: G           O       6.6.54 #0
[  134.181283] Hardware name: Linksys MX4200v2 (DT)
[  134.188398] Call trace:
[  134.192992]  dump_backtrace+0xa0/0xe0
[  134.195165]  show_stack+0x18/0x24
[  134.198984]  dump_stack_lvl+0x48/0x60
[  134.202283]  dump_stack+0x18/0x24
[  134.205928]  panic+0x2cc/0x320
[  134.209225]  send_sig_all+0x0/0xc8
[  134.212179]  __handle_sysrq+0xe0/0x1c8
[  134.215563]  write_sysrq_trigger+0xcc/0x134
[  134.219298]  proc_reg_write+0xb0/0xf8
[  134.223376]  vfs_write+0xb0/0x358
[  134.227195]  ksys_write+0x5c/0xe0
[  134.230494]  __arm64_sys_write+0x1c/0x28
[  134.233794]  invoke_syscall.constprop.0+0x5c/0x108
[  134.237789]  do_el0_svc+0x40/0xc8
[  134.242385]  el0_svc+0x30/0xb8
[  134.245771]  el0t_64_sync_handler+0x120/0x12c
[  134.248726]  el0t_64_sync+0x178/0x17c
[  134.253152] SMP: stopping secondary CPUs
[  134.256803] Kernel Offset: disabled
[  134.260789] CPU features: 0x0,00000000,00000000,0000400b
[  134.264005] Memory Limit: none
[  134.276124] Rebooting in 10 seconds..
```
I suspect the issues mentioned with some devices on [#15688](https://github.com/openwrt/openwrt/pull/15688) are related to this.