### PR TITLE
mediatek: filogic: add support for ipTIME AX3000M

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -81,7 +81,8 @@ jdcloud,re-cp-03)
 		;;
 	esac
 	;;
-comfast,cf-e393ax)
+comfast,cf-e393ax|\
+iptime,ax3000m)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x80000"
 	;;
 cetron,ct3003|\

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000m.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000m.dts
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include "mt7981b.dtsi"
+
+/ {
+	model = "ipTIME AX3000M";
+	compatible = "iptime,ax3000m", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " ubi.mtd=ubi rootfstype=squashfs";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x10000000>;
+		device_type = "memory";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: cpu {
+			function = LED_FUNCTION_CPU;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			function = "LED_FUNCTION_WLAN_2GHZ";
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g {
+			function = "LED_FUNCTION_WLAN_5GHZ";
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&pio 0 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&pio {
+	nand_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins &gbe_led0_pins>;
+
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cells = <&macaddr_factory_4 3>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		label = "wan";
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+
+		nvmem-cells = <&macaddr_factory_4 1>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan4";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan3";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan1";
+			};
+
+			port@6 {
+				reg = <6>;
+				ethernet = <&gmac0>;
+				phy-mode = "2500base-x";
+
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
+				};
+			};
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&nand_pins>;
+
+	spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+		mediatek,bmt-remap-range = <0x000000 0x580000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x6e00000>;
+			};
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 0>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -119,6 +119,7 @@ case "$board" in
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $addr > /sys${DEVPATH}/macaddress
 		;;
+	iptime,ax3000m|\
 	iptime,ax3000sm)
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_setbit $addr 26) 25) 27) 28) > \

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1273,6 +1273,26 @@ define Device/iptime_ax3000sm
 endef
 TARGET_DEVICES += iptime_ax3000sm
 
+define Device/iptime_ax3000m
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := AX3000M
+  DEVICE_DTS := mt7981b-iptime-ax3000m
+  DEVICE_DTS_DIR := ../dts
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 32768k
+  KERNEL := kernel-bin | lzma | \
+	    fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax3000m
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
+endef
+TARGET_DEVICES += iptime_ax3000m
+
 define Device/jcg_q30-pro
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := Q30 PRO


### PR DESCRIPTION
ipTIME AX3000M is an 802.11ax (Wi-Fi 6) router, based on MediaTek
MT7981B. (Filogic 820)

Specifications:
* SoC: MetiaTek MT7981B
* RAM: 256MiB
* Flash: ESMT SPI-NAND F50L1G41LB 128MiB
* Wi-Fi:
  * MediaTek MT7915E: 2.4GHz and 5GHz
* Ethernet: 5x 1GbE
  * Switch: MediaTek MT7531
* USB: 1x 3.0
* UART: J4 (115200 baud)
* LED:
  * PWR: VCC
  * CPU, 2.4G, 5G: GPIO
  * LAN 1-4, WAN: Controlled by Switch

MAC Addresses:
* 2.4G, 5G: B0:XX:XX:04:2A:60 (factory 0x4)
* WAN: B0:XX:XX:04:2A:61 (factory 0x4, +1)
* LAN: B0:XX:XX:04:2A:63 (factory 0x4, +3)

MTD Partitions:
* 0x000000000000-0x000000100000 : "BL2"
* 0x000000100000-0x000000180000 : "u-boot-env"
* 0x000000180000-0x000000380000 : "Factory"
* 0x000000380000-0x000000580000 : "FIP"
* 0x000000580000-0x000007380000 : "ubi"

UBI Partitions (Dynamic):
* id: 0, kernel2
* id: 1, kernel
* id: 2, rootfs
* id: 3, rootfs_data
* id: 4, rootfs2

Installation:
* Upload factory image through the tftp recovery mode.

Notes:
* This device has a dual-boot partition scheme, if installing with the
stock web interface method will flash only on the inactive ubi partitions
which are kernel and rootfs, newly flashed kernel didn't know the proper
rootfs partition so the booted kernel will panic.

<details>
<summary>boot log</summary>

```
[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.6.54 (root@builder) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 13.3.0 r27593+102-7ea086bb89) 13.3.0, GNU ld (GNU Binutils) 2.42) #0 SMP Tue Oct  8 21:51:11 2024
[    0.000000] Machine model: ipTIME AX3000M
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004302ffff (192 KiB) nomap non-reusable secmon@43000000
[    0.000000] OF: reserved mem: 0x0000000047c80000..0x0000000047d7ffff (1024 KiB) nomap non-reusable wmcpu-reserved@47c80000
[    0.000000] OF: reserved mem: 0x0000000047d80000..0x0000000047dbffff (256 KiB) nomap non-reusable wo-emi@47d80000
[    0.000000] OF: reserved mem: 0x0000000047dc0000..0x0000000047ffffff (2304 KiB) nomap non-reusable wo-data@47dc0000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[    0.000000]   node   0: [mem 0x0000000043000000-0x000000004302ffff]
[    0.000000]   node   0: [mem 0x0000000043030000-0x0000000047c7ffff]
[    0.000000]   node   0: [mem 0x0000000047c80000-0x0000000047ffffff]
[    0.000000]   node   0: [mem 0x0000000048000000-0x000000004fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.2
[    0.000000] percpu: Embedded 18 pages/cpu s34600 r8192 d30936 u73728
[    0.000000] pcpu-alloc: s34600 r8192 d30936 u73728 alloc=18*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: console=ttyS0,115200 ubi.block=0,rootfs2 root=/dev/ubiblock0_4 ubi.mtd=ubi rootfstype=squashfs
[    0.000000] Dentry cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 64512
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 0MB
[    0.000000] software IO TLB: area num 2.
[    0.000000] software IO TLB: SWIOTLB bounce buffer size roundup to 0MB
[    0.000000] software IO TLB: mapped [mem 0x000000004fe48000-0x000000004fec8000] (0MB)
[    0.000000] Memory: 239568K/262144K available (8640K kernel code, 896K rwdata, 2536K rodata, 448K init, 289K bss, 22576K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu:     RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
[    0.000000]  Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 640 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: GICv3 features: 16 PPIs
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000069] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=130000)
[    0.000077] pid_max: default: 32768 minimum: 301
[    0.002982] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.002989] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.005112] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.005649] RCU Tasks Trace: Setting shift to 1 and lim to 1 rcu_task_cb_adjust=1.
[    0.005801] rcu: Hierarchical SRCU implementation.
[    0.005804] rcu:     Max phase no-delay instances is 1000.
[    0.006193] smp: Bringing up secondary CPUs ...
[    0.006550] Detected VIPT I-cache on CPU1
[    0.006593] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.006622] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.006686] smp: Brought up 1 node, 2 CPUs
[    0.006691] SMP: Total of 2 processors activated.
[    0.006694] CPU features: detected: 32-bit EL0 Support
[    0.006698] CPU features: detected: CRC32 instructions
[    0.006729] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.006733] CPU: All CPU(s) started at EL2
[    0.006734] alternatives: applying system-wide alternatives
[    0.010311] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.010328] futex hash table entries: 512 (order: 3, 32768 bytes, linear)
[    0.011582] pinctrl core: initialized pinctrl subsystem
[    0.012445] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.013055] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.013083] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.013110] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.013473] thermal_sys: Registered thermal governor 'fair_share'
[    0.013477] thermal_sys: Registered thermal governor 'bang_bang'
[    0.013479] thermal_sys: Registered thermal governor 'step_wise'
[    0.013482] thermal_sys: Registered thermal governor 'user_space'
[    0.013583] ASID allocator initialised with 65536 entries
[    0.014585] pstore: Using crash dump compression: deflate
[    0.014591] pstore: Registered ramoops as persistent store backend
[    0.014593] ramoops: using 0x10000@0x42ff0000, ecc: 0
[    0.021838] Modules: 29536 pages in range for non-PLT usage
[    0.021846] Modules: 521056 pages in range for PLT usage
[    0.022813] cryptd: max_cpu_qlen set to 1000
[    0.025025] SCSI subsystem initialized
[    0.025428] libata version 3.00 loaded.
[    0.026914] clocksource: Switched to clocksource arch_sys_counter
[    0.029233] NET: Registered PF_INET protocol family
[    0.029331] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.030443] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.030457] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.030466] TCP established hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.030484] TCP bind hash table entries: 2048 (order: 4, 65536 bytes, linear)
[    0.030533] TCP: Hash tables configured (established 2048 bind 2048)
[    0.030602] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.030626] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.030828] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.030853] PCI: CLS 0 bytes, default 64
[    0.032628] workingset: timestamp_bits=46 max_order=16 bucket_order=0
[    0.037555] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.037564] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.081825] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.083068] printk: console [ttyS0] disabled
[    0.103441] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 72, base_baud = 2500000) is a ST16650V2
[    0.103480] printk: console [ttyS0] enabled
[    0.847640] loop: module loaded
[    0.852595] spi-nand spi0.0: ESMT SPI NAND was found.
[    0.857684] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.866220] Signature found at block 1023 [0x07fe0000]
[    0.871393] NMBM management region starts at block 960 [0x07800000]
[    0.878936] First info table with writecount 0 found in block 960
[    0.887753] Second info table with writecount 0 found in block 963
[    0.893928] NMBM has been successfully attached
[    0.898795] 5 fixed-partitions partitions found on MTD device spi0.0
[    0.905151] Creating 5 MTD partitions on "spi0.0":
[    0.909942] 0x000000000000-0x000000100000 : "BL2"
[    0.915646] 0x000000100000-0x000000180000 : "u-boot-env"
[    0.921689] 0x000000180000-0x000000380000 : "Factory"
[    0.928256] 0x000000380000-0x000000580000 : "FIP"
[    0.934394] 0x000000580000-0x000007380000 : "ubi"
[    1.144328] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc081500000, irq 75
[    1.154230] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc081500000, irq 75
[    1.164035] i2c_dev: i2c /dev entries driver
[    1.170077] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    1.179097] NET: Registered PF_INET6 protocol family
[    1.185051] Segment Routing with IPv6
[    1.188777] In-situ OAM (IOAM) with IPv6
[    1.192738] NET: Registered PF_PACKET protocol family
[    1.198020] 8021q: 802.1Q VLAN Support v1.8
[    1.225690] phy phy-soc:usb-phy@11e10000.1: type_sw - reg 0x218, index 0
[    1.271806] mt7530-mdio mdio-bus:1f: no interrupt support
[    1.308290] mt7530-mdio mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.317590] mt7530-mdio mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.328125] mt7530-mdio mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7531 PHY] (irq=POLL)
[    1.350396] mt7530-mdio mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7531 PHY] (irq=POLL)
[    1.372470] mt7530-mdio mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7531 PHY] (irq=POLL)
[    1.394611] mt7530-mdio mdio-bus:1f lan0 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7531 PHY] (irq=POLL)
[    1.406230] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[    1.412990] DSA: tree 0 setup
[    1.416170] ubi0: default fastmap pool size: 40
[    1.420710] ubi0: default fastmap WL pool size: 20
[    1.425491] ubi0: attaching mtd4
[    1.798589] ubi0: scanning is finished
[    1.808622] ubi0: attached mtd4 (name "ubi", size 110 MiB)
[    1.814112] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    1.820985] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    1.827766] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    1.834714] ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
[    1.840711] ubi0: user volume: 5, internal volumes: 1, max. volumes count: 128
[    1.847922] ubi0: max/mean erase counter: 16/12, WL threshold: 4096, image sequence number: 1435324947
[    1.857216] ubi0: available PEBs: 222, total reserved PEBs: 658, PEBs reserved for bad PEB handling: 19
[    1.866598] ubi0: background thread "ubi_bgt0d" started, PID 552
[    1.867329] block ubiblock0_2: created from ubi0:2(rootfs)
[    1.878085] ubiblock: device ubiblock0_2 (rootfs) set to be root filesystem
[    1.885521] block ubiblock0_4: created from ubi0:4(rootfs2)
[    1.891210] clk: Disabling unused clocks
[    1.898989] VFS: Mounted root (squashfs filesystem) readonly on device 254:1.
[    1.906317] Freeing unused kernel memory: 448K
[    1.910892] Run /sbin/init as init process
[    1.914978]   with arguments:
[    1.917961]     /sbin/init
[    1.920655]   with environment:
[    1.923783]     HOME=/
[    1.926130]     TERM=linux
[    2.108961] init: Console is alive
[    2.112481] init: - watchdog -
[    2.776506] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    2.799291] usbcore: registered new interface driver usbfs
[    2.804828] usbcore: registered new interface driver hub
[    2.810196] usbcore: registered new device driver usb
[    2.816873] raid6: skipped pq benchmark and selected neonx8
[    2.822466] raid6: using neon recovery algorithm
[    2.828051] xor: measuring software checksum speed
[    2.834044]    8regs           :  2729 MB/sec
[    2.839611]    32regs          :  2733 MB/sec
[    2.845223]    arm64_neon      :  2588 MB/sec
[    2.849573] xor: using function: 32regs (2733 MB/sec)
[    2.866942] random: crng init done
[    2.955453] Btrfs loaded, zoned=no, fsverity=no
[    2.963077] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    2.975022] xhci-mtk 11200000.usb: supply vbus not found, using dummy regulator
[    2.983144] xhci-mtk 11200000.usb: xHCI Host Controller
[    2.988423] xhci-mtk 11200000.usb: new USB bus registered, assigned bus number 1
[    2.998824] xhci-mtk 11200000.usb: hcc params 0x01403f99 hci version 0x110 quirks 0x0000000000200010
[    3.008022] xhci-mtk 11200000.usb: irq 79, io mem 0x11200000
[    3.013767] xhci-mtk 11200000.usb: xHCI Host Controller
[    3.019000] xhci-mtk 11200000.usb: new USB bus registered, assigned bus number 2
[    3.026389] xhci-mtk 11200000.usb: Host supports USB 3.2 Enhanced SuperSpeed
[    3.033871] hub 1-0:1.0: USB hub found
[    3.037678] hub 1-0:1.0: 1 port detected
[    3.041942] usb usb2: We don't know the algorithms for LPM for this host, disabling LPM.
[    3.050456] hub 2-0:1.0: USB hub found
[    3.054242] hub 2-0:1.0: 1 port detected
[    3.064444] usbcore: registered new interface driver usb-storage
[    3.071481] usbcore: registered new interface driver uas
[    3.077050] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    3.094546] init: - preinit -
[    3.408074] mtk_soc_eth 15100000.ethernet wan: renamed from eth1
[    5.783381] UBIFS (ubi0:3): Mounting in unauthenticated mode
[    5.789155] UBIFS (ubi0:3): background thread "ubifs_bgt0_3" started, PID 736
[    5.842812] UBIFS (ubi0:3): UBIFS: mounted UBI device 0, volume 3, name "rootfs_data"
[    5.850668] UBIFS (ubi0:3): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[    5.860579] UBIFS (ubi0:3): FS size: 32378880 bytes (30 MiB, 255 LEBs), max 265 LEBs, journal size 1650688 bytes (1 MiB, 13 LEBs)
[    5.872220] UBIFS (ubi0:3): reserved for root: 1529334 bytes (1493 KiB)
[    5.878828] UBIFS (ubi0:3): media format: w5/r0 (latest is w5/r0), UUID 804863E4-9829-47CD-BFA8-91E917D58987, small LPT model
[    5.893809] mount_root: switching to ubifs overlay
[    5.902835] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
[    5.917637] urandom-seed: Seeding with /etc/urandom.seed
[    6.336249] mtdblock: MTD device 'ubi' is NAND, please consider using UBI block devices instead.
[    6.393251] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[    6.452662] mtdblock: MTD device 'BL2' is NAND, please consider using UBI block devices instead.
[    6.485877] mtdblock: MTD device 'FIP' is NAND, please consider using UBI block devices instead.
[    6.585004] mtdblock: MTD device 'u-boot-env' is NAND, please consider using UBI block devices instead.
[    6.661826] procd: - early -
[    6.664771] procd: - watchdog -
[    7.223345] procd: - watchdog -
[    7.233770] procd: - ubus -
[    7.390016] procd: - init -
[    7.694045] kmodloader: loading kernel modules from /etc/modules.d/*
[    7.737583] ntfs3: Enabled Linux POSIX ACLs support
[    7.745644] fuse: init (API version 7.39)
[    7.752787] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[    7.774066] Loading modules backported from Linux version v6.11.2-0-g7aa21fec187b
[    7.781572] Backport generated by backports.git v6.1.110-1-32-gc61f71fe0942
[    7.797451] usbcore: registered new device driver usbip-host
[    7.804130] usbcore: registered new interface driver usblp
[    7.813498] vhci_hcd vhci_hcd.0: USB/IP Virtual Host Controller
[    7.819470] vhci_hcd vhci_hcd.0: new USB bus registered, assigned bus number 3
[    7.826715] vhci_hcd: created sysfs vhci_hcd.0
[    7.831921] hub 3-0:1.0: USB hub found
[    7.835802] hub 3-0:1.0: 8 ports detected
[    7.840429] vhci_hcd vhci_hcd.0: USB/IP Virtual Host Controller
[    7.846352] vhci_hcd vhci_hcd.0: new USB bus registered, assigned bus number 4
[    7.853665] usb usb4: We don't know the algorithms for LPM for this host, disabling LPM.
[    7.862360] hub 4-0:1.0: USB hub found
[    7.866268] hub 4-0:1.0: 8 ports detected
[    7.923912] urngd: v1.0.2 started.
[    8.280488] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823161240a
[    8.280488]
[    8.464149] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823161304
[    8.560633] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823161841
[    8.657860] mt798x-wmac 18000000.wifi: registering led 'mt76-phy0'
[    8.738634] mt798x-wmac 18000000.wifi: registering led 'mt76-phy1'
[   11.000181] PPP generic driver version 2.4.2
[   11.005342] NET: Registered PF_PPPOX protocol family
[   11.022890] kmodloader: done loading kernel modules from /etc/modules.d/*
[   14.449716] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[   14.461476] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   14.482285] mt7530-mdio mdio-bus:1f lan0: configuring for phy/gmii link mode
[   15.008627] br-lan: port 1(lan0) entered blocking state
[   15.013856] br-lan: port 1(lan0) entered disabled state
[   15.019118] mt7530-mdio mdio-bus:1f lan0: entered allmulticast mode
[   15.025377] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[   15.034914] mt7530-mdio mdio-bus:1f lan0: entered promiscuous mode
[   15.053682] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[   15.065907] br-lan: port 2(lan1) entered blocking state
[   15.071208] br-lan: port 2(lan1) entered disabled state
[   15.076471] mt7530-mdio mdio-bus:1f lan1: entered allmulticast mode
[   15.084626] mt7530-mdio mdio-bus:1f lan1: entered promiscuous mode
[   15.099851] mt7530-mdio mdio-bus:1f lan2: configuring for phy/gmii link mode
[   15.111824] br-lan: port 3(lan2) entered blocking state
[   15.117102] br-lan: port 3(lan2) entered disabled state
[   15.122352] mt7530-mdio mdio-bus:1f lan2: entered allmulticast mode
[   15.130830] mt7530-mdio mdio-bus:1f lan2: entered promiscuous mode
[   15.145735] mt7530-mdio mdio-bus:1f lan3: configuring for phy/gmii link mode
[   15.158275] br-lan: port 4(lan3) entered blocking state
[   15.163511] br-lan: port 4(lan3) entered disabled state
[   15.168813] mt7530-mdio mdio-bus:1f lan3: entered allmulticast mode
[   15.177737] mt7530-mdio mdio-bus:1f lan3: entered promiscuous mode
[   15.209743] mtk_soc_eth 15100000.ethernet wan: PHY [mdio-bus:00] driver [MediaTek MT7981 PHY] (irq=POLL)
[   15.219271] mtk_soc_eth 15100000.ethernet wan: configuring for phy/gmii link mode
[   19.293241] mt7530-mdio mdio-bus:1f lan0: Link is Up - 1Gbps/Full - flow control rx/tx
[   19.295298] br-lan: port 1(lan0) entered blocking state
[   19.306377] br-lan: port 1(lan0) entered forwarding state
```
</details>