### PR TITLE
base-files: sysupgrade: Selectively restore from backups

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -22,6 +22,8 @@ CONF_BACKUP_LIST=0
 CONF_BACKUP=
 CONF_RESTORE=
 USE_CURR_PART=0
+CONF_SELECTIVE_RESTORE=
+CONF_SELECTIVE_RESTORE_FILELIST=
 NEED_IMAGE=
 HELP=0
 TEST=0
@@ -51,6 +53,7 @@ while [ -n "$1" ]; do
 		-u) SKIP_UNCHANGED=1;;
 		-b|--create-backup) CONF_BACKUP="$2" NEED_IMAGE=1; shift;;
 		-r|--restore-backup) CONF_RESTORE="$2" NEED_IMAGE=1; shift;;
+		-S|--selectively-restore-backup) CONF_SELECTIVE_RESTORE_FILELIST="$2" CONF_SELECTIVE_RESTORE="$3" NEED_IMAGE=1; shift;shift;;
 		-l|--list-backup) CONF_BACKUP_LIST=1;;
 		-f) CONF_IMAGE="$2"; shift;;
 		-s) USE_CURR_PART=1;;
@@ -103,6 +106,11 @@ backup-command:
 	             i.e. stdout, verbosity is set to 0 (i.e. quiet).
 	-r | --restore-backup <file>
 	             restore a .tar.gz created with sysupgrade -b
+	             then exit. Does not flash an image. If file is '-',
+	             the archive is read from stdin.
+	-S | --selectively-restore-backup <file-with-list-of-filenames> <file>
+	             selectively restore a .tar.gz created with sysupgrade -b
+	             by passing a file containing the desired list of filenames,
 	             then exit. Does not flash an image. If file is '-',
 	             the archive is read from stdin.
 	-l | --list-backup
@@ -347,6 +355,22 @@ if [ -n "$CONF_RESTORE" ]; then
 		platform_restore_backup "$TAR_V"
 	else
 		tar -C / -x${TAR_V}zf "$CONF_RESTORE"
+	fi
+	exit $?
+fi
+
+if [ -n "$CONF_SELECTIVE_RESTORE" ]; then
+	if [ "$CONF_SELECTIVE_RESTORE" != "-" ] && [ ! -f "$CONF_SELECTIVE_RESTORE" ]; then
+		echo "Backup archive '$CONF_SELECTIVE_RESTORE' not found." >&2
+		exit 1
+	fi
+
+	[ "$VERBOSE" -gt 1 ] && TAR_V="v" || TAR_V=""
+	v "Selectively restoring config files..."
+	if [ "$(type -t platform_restore_backup)" = 'platform_restore_backup' ]; then
+		platform_selectively_restore_backup "$TAR_V"
+	else
+		tar -C / -x"${TAR_V}"zf "$CONF_SELECTIVE_RESTORE" -T "$CONF_SELECTIVE_RESTORE_FILELIST"
 	fi
 	exit $?
 fi

--- a/target/linux/bcm27xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/bcm27xx/base-files/lib/upgrade/platform.sh
@@ -128,3 +128,10 @@ platform_restore_backup() {
 	tar -C / -x${TAR_V}zf "$CONF_RESTORE"
 	bcm27xx_set_root_part
 }
+
+platform_selectively_restore_backup() {
+	local TAR_V=$1
+
+	tar -C / -x${TAR_V}zf "$CONF_RESTORE" -T "$CONF_SELECTIVE_RESTORE_FILELIST"
+	bcm27xx_set_root_part
+}


### PR DESCRIPTION
For users who wish to restore a subset of the backup. Suitable when
importing a backup from a different architecture where certain config
files would cause problems after reboot.

The CONF_SELECTIVE_RESTORE_FILELIST `filelist.txt` content is a
simple text file, with one filename per line:

```txt
etc/config/file1
etc/config/file2
etc/config/file3
```

Tested on 23.05.5

See https://github.com/openwrt/luci/pull/7322 for an example intended usage.
