### PR TITLE
ramips: mt7621: mikrotik rb760igs: Include "hEX S" in model name

### DIFF
--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-760igs.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-760igs.dts
@@ -4,7 +4,7 @@
 
 / {
 	compatible = "mikrotik,routerboard-760igs", "mediatek,mt7621-soc";
-	model = "MikroTik RouterBOARD 760iGS";
+	model = "MikroTik RouterBOARD 760iGS (hEX S)";
 
 	aliases {
 		led-boot = &led_pwr;


### PR DESCRIPTION
Mikrotik seems to prefer calling this model "hEX S" in general, therefore include this also in the model name.