### PR TITLE
mt7621: Fix EX400 imagebuilder

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -180,10 +180,6 @@ define Build/iodata-mstc-header2
 	mv $@.new $@
 endef
 
-define Build/kernel-initramfs-bin
-	$(CP) $(KDIR)/vmlinux-initramfs $@
-endef
-
 define Build/znet-header
 	$(eval version=$(word 1,$(1)))
 	$(eval magic=$(if $(word 2,$(1)),$(word 2,$(1)),ZNET))
@@ -1093,8 +1089,8 @@ define Device/dna_valokuitu-plus-ex400
   DEVICE_MODEL := Valokuitu Plus EX400
   KERNEL := kernel-bin | lzma | uImage lzma
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | uImage lzma
-  IMAGES := factory.bin sysupgrade.bin
-  IMAGE/factory.bin := kernel-initramfs-bin | lzma | uImage lzma | \
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-image-stage initramfs-kernel.bin | \
                        dna-bootfs with-initrd | dna-header | \
                        append-md5sum-ascii-salted
   IMAGE/sysupgrade.bin := dna-bootfs | sysupgrade-tar kernel=$$$$@ | check-size | \


### PR DESCRIPTION
A factory image for this device depends on an initramfs image and they were explicitly removed from the imagebuilder recently. Now the factory image creation fails miserably and it also affects custom image creation with the firmware selector.

Add the initramfs kernel to the staging so that it's shipped with the
imagebuilder. Also remove a image build target added solely for DNA EX400.

Tested by creating a factory and syspupgrade images locally with
the imagebuilder and verified their functionality.

Related work
  c85348d9abf4 ("imagebuilder: remove initramfs image files")

Fixes: fea2264d9fdd ("ramips: mt7621: Add DNA Valokuitu Plus EX400")