### PR TITLE
ipq40xx: switch to zImage kernel for SKSpruce WIA3300-20

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -1093,7 +1093,7 @@ endef
 TARGET_DEVICES += qxwlan_e2600ac-c2
 
 define Device/skspruce_wia3300-20
-	$(call Device/FitImage)
+	$(call Device/FitzImage)
 	BLOCKSIZE := 64k
 	IMAGE_SIZE := 55104k
 	SOC := qcom-ipq4019


### PR DESCRIPTION
The bootloader can support zImage linux kernel which can decrease the firmware image size.