### PR TITLE
realtek: scripts: fix error in belkin-header

### DIFF
--- a/scripts/belkin-header.py
+++ b/scripts/belkin-header.py
@@ -35,7 +35,7 @@ COMPANY = "belkin"
 MODULE = "IMG"
 
 def xcrc32(buf):
-    return (0xffffffff - zlib.crc32(buf, 0xffffffff)).to_bytes(4, 'big')
+    return (0xffffffff - zlib.crc32(buf, 0xffffffff)).to_bytes(4, byteorder='big')
 
 def encode_model(model):
     map = " 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
@@ -63,12 +63,12 @@ def create_header(buf, belkin_header, belkin_model):
 
     head[0:4] = int(belkin_header, 0).to_bytes(4, 'big')
     head[8:12] = int(time.time()).to_bytes(4, 'big')
-    head[12:16] = len(buf).to_bytes(4, 'big')
+    head[12:16] = len(buf).to_bytes(4, byteorder='big')
     head[24:28] = xcrc32(buf)
-    head[28:29] = VERSION1.to_bytes(1)
-    head[29:30] = VERSION2.to_bytes(1)
-    head[30:31] = VERSION3.to_bytes(1)
-    head[31:32] = VERSION4.to_bytes(1)
+    head[28:29] = VERSION1.to_bytes(1, byteorder='big')
+    head[29:30] = VERSION2.to_bytes(1, byteorder='big')
+    head[30:31] = VERSION3.to_bytes(1, byteorder='big')
+    head[31:32] = VERSION4.to_bytes(1, byteorder='big')
     head[16:16 + len(COMPANY)] = bytes(COMPANY,'ascii')
 
     mod = MODULE + "-{:1d}.{:02d}.{:02d}.{:02d}".format(VERSION1, VERSION2, VERSION3, VERSION4)


### PR DESCRIPTION
For some reason the new belkin-header.py script works without issues in a local Fedora build environment. In the OpenWrt build pipeline it produces the following errors:

Traceback (most recent call last):
  File "/builder/shared-workdir/build/scripts/belkin-header.py", line 92, in <module>
    head = create_header(buf, args.belkin_header, args.belkin_model)
  File "/builder/shared-workdir/build/scripts/belkin-header.py", line 68, in create_header
    head[28:29] = VERSION1.to_bytes(1)
TypeError: to_bytes() missing required argument 'byteorder' (pos 2)

This may be related due to different python version. Fix this by handing over the needed parameters
