### PR TITLE
[23.05] generic: 5.15: add Winbond W25N01KV support

### DIFF
--- a/target/linux/generic/backport-5.15/893-v6.12-mtd-spinand-winbond-add-support-for-W25N01KV.patch
+++ b/target/linux/generic/backport-5.15/893-v6.12-mtd-spinand-winbond-add-support-for-W25N01KV.patch
@@ -1,0 +1,65 @@
+From e2a9fcb36e851adb5b25c4acea53a290fd48a636 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Mon, 5 Aug 2024 19:51:02 +0200
+Subject: [PATCH] mtd: spinand: winbond: add support for W25N01KV
+
+Add support for Winbond W25N01KV 1Gbit SPI-NAND.
+
+It has 4-bit on-die ECC.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+Signed-off-by: Miquel Raynal <miquel.raynal@bootlin.com>
+Link: https://lore.kernel.org/linux-mtd/20240805175125.6658-1-robimarko@gmail.com
+---
+ drivers/mtd/nand/spi/winbond.c | 26 ++++++++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+--- a/drivers/mtd/nand/spi/winbond.c
++++ b/drivers/mtd/nand/spi/winbond.c
+@@ -74,6 +74,18 @@ static int w25m02gv_select_target(struct
+ 	return spi_mem_exec_op(spinand->spimem, &op);
+ }
+ 
++static int w25n01kv_ooblayout_ecc(struct mtd_info *mtd, int section,
++				  struct mtd_oob_region *region)
++{
++	if (section > 3)
++		return -ERANGE;
++
++	region->offset = 64 + (8 * section);
++	region->length = 7;
++
++	return 0;
++}
++
+ static int w25n02kv_ooblayout_ecc(struct mtd_info *mtd, int section,
+ 				  struct mtd_oob_region *region)
+ {
+@@ -98,6 +110,11 @@ static int w25n02kv_ooblayout_free(struc
+ 	return 0;
+ }
+ 
++static const struct mtd_ooblayout_ops w25n01kv_ooblayout = {
++	.ecc = w25n01kv_ooblayout_ecc,
++	.free = w25n02kv_ooblayout_free,
++};
++
+ static const struct mtd_ooblayout_ops w25n02kv_ooblayout = {
+ 	.ecc = w25n02kv_ooblayout_ecc,
+ 	.free = w25n02kv_ooblayout_free,
+@@ -160,6 +177,15 @@ static const struct spinand_info winbond
+ 					      &update_cache_variants),
+ 		     0,
+ 		     SPINAND_ECCINFO(&w25m02gv_ooblayout, NULL)),
++	SPINAND_INFO("W25N01KV",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xae, 0x21),
++		     NAND_MEMORG(1, 2048, 96, 64, 1024, 20, 1, 1, 1),
++		     NAND_ECCREQ(4, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     0,
++		     SPINAND_ECCINFO(&w25n01kv_ooblayout, w25n02kv_ecc_get_status)),
+ 	SPINAND_INFO("W25N02KV",
+ 		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xaa, 0x22),
+ 		     NAND_MEMORG(1, 2048, 128, 64, 2048, 40, 1, 1, 1),


### PR DESCRIPTION
It seems that some Xiaomi AX3000T boards changed to using Winbond W25N01KV SPI-NAND which is not supported in OpenWrt 23.05 but only in main.

So, backport the support for Winbond W25N01KV from Linux 6.12 to 23.05 as well.
