### PR TITLE
wireless-regdb: Update to version 2024.10.07

### DIFF
--- a/package/firmware/wireless-regdb/Makefile
+++ b/package/firmware/wireless-regdb/Makefile
@@ -1,14 +1,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wireless-regdb
-PKG_VERSION:=2024.07.04
+PKG_VERSION:=2024.10.07
 PKG_RELEASE:=1
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=LICENSE
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/network/wireless-regdb/
-PKG_HASH:=9832a14e1be24abff7be30dee3c9a1afb5fdfcf475a0d91aafef039f8d85f5eb
+PKG_HASH:=f76f2bd79a653e9f9dd50548d99d03a4a4eb157da056dfd5892f403ec28fb3d5
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
Changes:

```
b66b9a1 wireless-regdb: update regulatory database based on preceding changes
5097b4a wireless-regdb: Update regulatory info for Tanzania (TZ) for 2024
29633a6 wireless-regdb: Update regulatory info for Pakistan (PK) for 2024
b44edb2 wireless-regdb: Update regulatory info for Serbia (RS) for 2024
dbfae47 Revert "wireless-regdb: Update regulatory info for Serbia (SR) for 2024"
8e3d27c wireless-regdb: Correct regulatory rules of 6GHz frequency for Türkiye (TR)
8760bc3 wireless-regdb: Update regulatory info for Honduras (HN) for 2023
3ba2c53 wireless-regdb: Update regulatory info for Israel (IL) for 2021
83c175c wireless-regdb: Update regulatory info for Kuwait (KW) for 2022
388c80c wireless-regdb: Update regulatory info for Serbia (SR) for 2024
bf55ed4 wireless-regdb: Add .b4-config
3afe172 wireless-regdb: Update .gitignore
3b34761 wireless-regdb: Correct regulatory rules for China (CN)
003c282 wireless-regdb: Update regulatory info for Philippines (PH) on 6GHz
21fcb86 wireless-regdb: Update regulatory info for Guatemala (GT) for 2020
158f105 wireless-regdb: Update regulatory info for Bahrain (BH) for 2024
218d146 wireless-regdb: Add regulatory info for Namibia (NA) for 2023
aad0c26 wireless-regdb: Update regulatory info for Togo (TG) for 2022
983f551 wireless-regdb: Update regulatory info for El Salvador (SV) on 6GHz
58575b4 wireless-regdb: Update regulatory info for Peru (PE) on 6GHz
bad3985 wireless-regdb: Update regulatory info for New Zealand (NZ) for 2022
c7d1083 wireless-regdb: Update regulatory info for Qatar (QA) on 6GHz
```