### PR TITLE
siflower: sf21a6826: new subtarget

### DIFF
--- a/package/kernel/linux/modules/i2c.mk
+++ b/package/kernel/linux/modules/i2c.mk
@@ -127,6 +127,22 @@ endef
 $(eval $(call KernelPackage,i2c-designware-pci))
 
 
+I2C_DWPLATFORM_MODULES:= \
+  CONFIG_I2C_DESIGNWARE_PLATFORM:drivers/i2c/busses/i2c-designware-platform
+
+define KernelPackage/i2c-designware-platform
+  $(call i2c_defaults,$(I2C_DWPLATFORM_MODULES),59)
+  TITLE:=Synopsys DesignWare Platform
+  DEPENDS:=+kmod-i2c-designware-core
+endef
+
+define KernelPackage/i2c-designware-platform/description
+ Synopsys DesignWare I2C Platform driver.
+endef
+
+$(eval $(call KernelPackage,i2c-designware-platform))
+
+
 I2C_GPIO_MODULES:= \
   CONFIG_I2C_GPIO:drivers/i2c/busses/i2c-gpio
 

--- a/target/linux/siflower/dts/sf19a2890.dtsi
+++ b/target/linux/siflower/dts/sf19a2890.dtsi
@@ -232,6 +232,7 @@
 
 			gpio-controller;
 			#gpio-cells = <2>;
+			ngpios = <49>;
 			gpio-ranges = <&pinctrl 0 0 49>;
 
 			interrupt-controller;

--- a/target/linux/siflower/files-6.6/drivers/gpio/gpio-siflower.c
+++ b/target/linux/siflower/files-6.6/drivers/gpio/gpio-siflower.c
@@ -257,7 +257,10 @@ static int sf_gpio_probe(struct platform_device *pdev)
 	u32 ngpios, ngroups;
 	int ret, i;
 
-	ngpios = (unsigned int) device_get_match_data(dev);
+	ret = of_property_read_u32(pdev->dev.of_node, "ngpios", &ngpios);
+	if (ret)
+		return ret;
+
 	ngroups = DIV_ROUND_UP(ngpios, GPIOS_PER_GROUP);
 	priv = devm_kzalloc(dev, struct_size(priv, irq, ngroups), GFP_KERNEL);
 	if (!priv)
@@ -325,7 +328,7 @@ static int sf_gpio_remove(struct platform_device *pdev)
 }
 
 static const struct of_device_id sf_gpio_ids[] = {
-	{ .compatible = "siflower,sf19a2890-gpio", .data = (void *)49 },
+	{ .compatible = "siflower,sf19a2890-gpio" },
 	{},
 };
 MODULE_DEVICE_TABLE(of, sf_gpio_ids);

--- a/target/linux/siflower/image/Makefile
+++ b/target/linux/siflower/image/Makefile
@@ -2,27 +2,6 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
-KERNEL_LOADADDR := 0x80100000
-
-define Device/Default
-  PROFILES := Default
-  BLOCKSIZE := 64k
-  FILESYSTEMS := squashfs
-  DEVICE_DTS_DIR := ../dts
-  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma
-  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | uImage lzma
-  IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin = append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | append-metadata
-endef
-
-define Device/siflower_sf19a2890-evb
-  DEVICE_VENDOR := Siflower
-  DEVICE_MODEL := SF19A2890 EVB
-  BOARD_NAME := siflower,sf19a2890-evb
-  DEVICE_DTS := sf19a2890_evb
-  DEVICE_PACKAGES := kmod-switch-rtl8367b swconfig
-endef
-TARGET_DEVICES += siflower_sf19a2890-evb
+include $(SUBTARGET).mk
 
 $(eval $(call BuildImage))

--- a/target/linux/siflower/image/sf19a2890.mk
+++ b/target/linux/siflower/image/sf19a2890.mk
@@ -1,0 +1,22 @@
+KERNEL_LOADADDR := 0x80100000
+
+define Device/Default
+  PROFILES := Default
+  BLOCKSIZE := 64k
+  FILESYSTEMS := squashfs
+  DEVICE_DTS_DIR := ../dts
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | uImage lzma
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin = append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | append-metadata
+endef
+
+define Device/siflower_sf19a2890-evb
+  DEVICE_VENDOR := Siflower
+  DEVICE_MODEL := SF19A2890 EVB
+  BOARD_NAME := siflower,sf19a2890-evb
+  DEVICE_DTS := sf19a2890_evb
+  DEVICE_PACKAGES := kmod-switch-rtl8367b swconfig
+endef
+TARGET_DEVICES += siflower_sf19a2890-evb


### PR DESCRIPTION
Siflower SF21A6826/SF21H8898 are a family of RISC-V SoCs with:

 * Quad-core T-Head C908 (1.125G for SF21A6826, 1.25G for SF21H8898)
 * DDR3/DDR4 memory controller
 * 1 QSGMII 4x1G
 * 1 SGMII/2500Base-X 2.5G
 * 1 additional RGMII on SF21H8898
 * Network offloading engine for L2 switching and L3 NAT
 * 2 PCIE Gen2 lanes, operating in either one PCIE Gen2x2 or two PCIE Gen2x1 mode
 * 1 USB2.0

The boards added in this PR aren't the final ones. The two boards currently added in this PR are the EVB and a not-yet-ready board from Banana Pi.

TODO:
* update missing kconfig symbols for sf19a28
* ethernet driver from siflower networking team
* PCIE driver