### PR TITLE
ramips: mt7621: add support for Gemtek WVRTM-127ACN and WVRTM-130ACN

### DIFF
--- a/target/linux/ramips/dts/mt7621_gemtek_wvrtm-127acn.dts
+++ b/target/linux/ramips/dts/mt7621_gemtek_wvrtm-127acn.dts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_gemtek_wvrtm-1xxacn.dtsi"
+
+/ {
+	compatible = "gemtek,wvrtm-127acn", "mediatek,mt7621-soc";
+	model = "Gemtek WVRTM-127ACN";
+};
+
+&nvmem_layout {
+	eeprom_factory_8000: eeprom@8000 {
+		reg = <0x8000 0x200>;
+	};
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		led {
+			led-sources = <0>;
+			led-active-low;
+		};
+	};
+};
+
+&ports {
+	port@2 {
+		status = "okay";
+		label = "lan2";
+	};
+
+	port@3 {
+		status = "okay";
+		label = "lan1";
+	};
+};

--- a/target/linux/ramips/dts/mt7621_gemtek_wvrtm-130acn.dts
+++ b/target/linux/ramips/dts/mt7621_gemtek_wvrtm-130acn.dts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_gemtek_wvrtm-1xxacn.dtsi"
+
+/ {
+	compatible = "gemtek,wvrtm-130acn", "mediatek,mt7621-soc";
+	model = "Gemtek WVRTM-130ACN";
+};
+
+&eeprom_factory_0 {
+	reg = <0x0 0x4da8>;
+};
+
+&macaddr_factory_4 {
+	compatible = "mac-base";
+	#nvmem-cell-cells = <1>;
+};
+
+&keys {
+	button-2 {
+		label = "power";
+		gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		linux,code = <KEY_POWER>;
+	};				
+};
+
+&leds {
+	led-7 {
+		gpios = <&gpio_hc595 7 GPIO_ACTIVE_HIGH>;
+		function = LED_FUNCTION_WPS;
+		color = <LED_COLOR_ID_GREEN>;
+	};
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		#address-cells = <2>;
+		#size-cells = <0>;
+		
+		band@0 {
+			/* 2.4 GHz */
+			reg = <0>;
+			nvmem-cells = <&macaddr_factory_4 (-1)>;
+			nvmem-cell-names = "mac-address";
+			/* led_pin 0 */
+		};
+
+		band@1 {
+			/* 5 GHz */
+			reg = <1>;
+			nvmem-cells = <&macaddr_factory_4 0>;
+			nvmem-cell-names = "mac-address";
+			/* led_pin 2 */
+		};
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&ports {
+	port@0 {
+		status = "okay";
+		label = "lan1";
+	};
+
+	port@1 {
+		status = "okay";
+		label = "lan2";
+	};
+
+	port@2 {
+		status = "okay";
+		label = "lan3";
+	};
+
+	port@3 {
+		status = "okay";
+		label = "lan4";
+	};
+};

--- a/target/linux/ramips/dts/mt7621_gemtek_wvrtm-1xxacn.dtsi
+++ b/target/linux/ramips/dts/mt7621_gemtek_wvrtm-1xxacn.dtsi
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs-override = "console=ttyS0,115200n1";
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		poe_24v_port4 {
+			gpio-export,name = "24v-poe:port4";
+			gpio-export,output = <0>;
+			gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys: keys {
+		compatible = "gpio-keys";
+
+		button-0 {
+			label = "wps";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		button-1 {
+			label = "reset";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	led_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		num-chipselects = <0>;
+
+		gpio_hc595: gpio_hc595@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <1>;
+			spi-max-frequency = <1000000>;
+		};
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			gpios = <&gpio_hc595 0 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_INDICATOR;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <0>;
+		};
+
+		led-1 {
+			gpios = <&gpio_hc595 1 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_INDICATOR;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <1>;
+		};
+
+		led-2 {
+			gpios = <&gpio_hc595 2 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_INDICATOR;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <2>;
+		};
+
+		led-3 {
+			gpios = <&gpio_hc595 3 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_INDICATOR;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <3>;
+		};
+
+		led-4 {
+			gpios = <&gpio_hc595 4 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_INDICATOR;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <4>;
+		}; 
+
+		led_power: led-5 {
+			gpios = <&gpio_hc595 5 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+
+		led-6 {
+			gpios = <&gpio_hc595 6 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	reg_usb_vbus: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1 &ubiconcat2 &ubiconcat3>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x7380000>;
+			};
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x100000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "u-boot2";
+			reg = <0x100000 0x100000>;
+			read-only;
+		};
+
+		partition@200000 {	
+			label = "factory";
+			reg = <0x200000 0x100000>;
+			read-only;
+
+			nvmem_layout: nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x200>;
+				};
+
+				macaddr_factory_4: eeprom@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+			};
+		};
+
+		partition@300000 {
+			label = "u-boot-env";
+			reg = <0x300000 0x280000>;
+			read-only;
+		};
+
+		partition@580000 {
+			label = "u-boot-env2";
+			reg = <0x580000 0x280000>;
+			read-only;
+		};
+
+		partition@800000 {
+			label = "firmware";
+			reg = <0x800000 0x2000000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			ubiconcat0: partition@400000 {
+				label = "ubiconcat0";
+				reg = <0x400000 0x1c00000>;
+			};			
+		};
+
+		ubiconcat1: partition@2800000 {
+			label = "Kernel2";
+			reg = <0x2800000 0x2000000>;
+		};
+
+		ubiconcat2: partition@4800000 {
+			label = "Storage1";
+			reg = <0x4800000 0x1c00000>;
+		};
+
+		ubiconcat3: partition@6400000 {
+			label = "Storage2";
+			reg = <0x6400000 0x1b80000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&state_default {
+	gpio {
+		groups = "rgmii2", "uart3";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports: ports {
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e000>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&xhci {
+	vbus-supply = <&reg_usb_vbus>;
+	vusb33-supply = <&reg_3p3v>;
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1382,6 +1382,29 @@ define Device/gehua_ghl-r-001
 endef
 TARGET_DEVICES += gehua_ghl-r-001
 
+define Device/gemtek_wvrtm-1xxacn
+  $(Device/nand)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 122368k
+  DEVICE_VENDOR := Gemtek
+  DEVICE_PACKAGES := kmod-gpio-nxp-74hc164 kmod-spi-gpio \
+  kmod-usb3 -uboot-envtools 
+endef
+
+define Device/gemtek_wvrtm-127acn
+  $(Device/gemtek_wvrtm-1xxacn)
+  DEVICE_MODEL := WVRTM-127ACN
+  DEVICE_PACKAGES += kmod-mt7603 kmod-mt76x2
+endef
+TARGET_DEVICES += gemtek_wvrtm-127acn
+
+define Device/gemtek_wvrtm-130acn
+  $(Device/gemtek_wvrtm-1xxacn)
+  DEVICE_MODEL := WVRTM-130ACN
+  DEVICE_PACKAGES += kmod-mt7615-firmware
+endef
+TARGET_DEVICES += gemtek_wvrtm-130acn
+
 define Device/glinet_gl-mt1300
   $(Device/dsa-migration)
   IMAGE_SIZE := 32448k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -80,6 +80,7 @@ ramips_setup_interfaces()
 	beeline,smartbox-giga|\
 	elecom,wmc-x1800gst|\
 	elecom,wrc-x1800gs|\
+	gemtek,wvrtm-127acn|\
 	glinet,gl-mt1300|\
 	iodata,wn-deax1800gr|\
 	iptime,a3002mesh|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -99,6 +99,8 @@ platform_do_upgrade() {
 	h3c,tx1806|\
 	haier,har-20s2u1|\
 	hiwifi,hc5962|\
+	gemtek,wvrtm-127acn|\
+	gemtek,wvrtm-130acn|\
 	iptime,a3004t|\
 	iptime,ax2004m|\
 	iptime,t5004|\


### PR DESCRIPTION
The Gemtek WVRTM-127ACN is an indoor dual band wifi router with internal antennas and 3 Gigabit Ethernet ports.

The Gemtek WVRTM-130ACN is an indoor dual band wifi router with external antennas and 5 Gigabit Ethernet ports.

Hardware of WVRTM-127ACN:
- SoC: Mediatek MT7621AT (880 MHz, dual core)
- RAM: 128 MB
- Storage: 128 MB NAND SLC
- Ethernet: 3x 10/100/1000 Mbps LAN1,LAN2 & WAN
- Wireless: 2.4GHz: Mediatek MT7603EN (802.11b/g/n)
- Wireless: 5GHz: Mediatek MT7612EN (802.11n/ac)
- LEDs: 11x
- Buttons: 2x WPS, reset
- USB: 1x 3.0
- Power: 56 VDC, 0.54 A, PoE+ IN (WAN)
- PoE: 1x PoE+ 802.3af/at (WAN)
- Uart: GND RX TX VCC - J2 (GND near WAN)
- Board silkscreen: "WVRTM-127ACN_V02" "19K-513-8500R" "RoHS" "1717"

Hardware of WVRTM-130ACN:
- SoC: Mediatek MT7621AT (880 MHz, dual core)
- RAM: 128 MB (Kioxia TC58BVG0S3HTA00)
- Storage: 128 MB NAND SLC (Winbond W971GG6SB-25)
- Ethernet: 5x 10/100/1000 Mbps LAN1,LAN2,LAN3,LAN4 & WAN
- Wireless: 2.4GHz and 5GHz Mediatek MT7615DN (802.11ac/b/g/n) (DBDC)
- LEDs: 10x
- Buttons: 3x Power, WPS, reset
- USB: 1x 3.0
- Power: 56 VDC, 0.54 A, PoE+ (WAN)
- PoE: 1x PoE+ 802.3af/at (WAN)
- Uart: GND RX TX VCC - J2 (GND near WAN)
- Board silkscreen: "WVRTM-130ACN_V01" "19K-515-4500R" "RoHS" "2112"

Enable access to uboot menu (needed in wvrtm-130acn):
- The access to uboot menu is blocked by `bootdelay = 0` set in ubootenv. With stock firmware version 01.01.02.163 and previous, you can use CVE 2020-24365 command injection https://nvd.nist.gov/vuln/detail/CVE-2020-24365
    python3 exploit.py -t 192.168.1.1 -c "fw_setenv bootdelay 3; fw_saveenv"

Backup the stock firmware:
- Connect via uart
- Connect via ethernet and assign your pc the address 192.168.15.x/24
- Power on the device; and start typing '4' to enter uboot menu
- Set factory mode and boot MT7621 # setenv factory 2; saveenv MT7621 # nand read 2800000 2000000 81000000; bootm
- Telnet and copy all mtd blocks telnet 192.168.15.1
- Copy all mtd blocks and start webserver for N in $(seq 0 6); do dd if=/dev/mtd$N of=/tmp/eeprom_mtd$N.bin; done mount -o bind /tmp /www lighttpd -f /etc/lighttpd.conf
- Backup stock rootfs_data (optional) dd if=/dev/mtd7 of=/tmp/eeprom_mtd7.bin dd if=/dev/mtd8 of=/tmp/eeprom_mtd8.bin
- Download to your pc from http://192.168.15.1/eeprom_mtd$N.bin

Installation:
- Connect via uart
- Connect via ethernet and assign your pc the address 10.10.10.3/24
- Start a tftp server and serve the image initramfs-kernel.bin mkdir /tmp/ftpd; cp initramfs-kernel.bin /tmp/ftpd/kernel.bin dnsmasq --enable-tftp --tftp-root=/tmp/ftpd
- Power on the device; and start typing '4' to halt the bootloader
- Change the active mtd partition from mtd6 to mtd5 to follow new layout (optional: uboot checks both and then save a flag in ubootenv es. Image1Stable=1)
    MT7621 # setenv mtddevnum 5; saveenv
- Write the openwrt initramfs in ram via tftp and boot it MT7621 # tftpboot 81000000 kernel.bin; bootm
- From the initramfs create the ubi device and install openwrt via sysupgrade ubiformat /dev/mtd11 -y sysupgrade -n -v /tmp/sysupgrade.bin

Recovery:
Restore the stock firmware from the backup of the mtd blocks
    mtd write eeprom_mtd5.bin firmware
    mtd write eeprom_mtd6.bin Kernel2
    mtd write eeprom_mtd7.bin Storage1
    mtd write eeprom_mtd8.bin Storage2
    ubiformat /dev/mtd8 -y
    reboot

Links to previous works on wvrtm-127acn:
https://github.com/digiampietro/hacking-gemtek
https://forum.openwrt.org/t/add-support-for-gemtek-wvrtm-127acn-linkem-provider/168757
