### PR TITLE
mediatek: change Routerich AX3000 ubi size

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-routerich-ax3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-routerich-ax3000.dts
@@ -226,25 +226,7 @@
 
 			partition@580000 {
 				label = "ubi";
-				reg = <0x580000 0x4000000>;
-			};
-
-			partition@4580000 {
-				label = "firmware_backup";
-				reg = <0x4580000 0x2000000>;
-				read-only;
-			};
-
-			partition@6580000 {
-				label = "zrsave";
-				reg = <0x6580000 0x100000>;
-				read-only;
-			};
-
-			partition@6680000 {
-				label = "config2";
-				reg = <0x6680000 0x100000>;
-				read-only;
+				reg = <0x580000 0x7000000>;
 			};
 		};
 	};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/05_compat-version
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/05_compat-version
@@ -8,6 +8,9 @@ case "$(board_name)" in
 	bananapi,bpi-r3)
 		ucidef_set_compat_version "1.2"
 		;;
+	routerich,ax3000)
+		ucidef_set_compat_version "1.1"
+		;;
 esac
 
 board_config_flush

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1173,6 +1173,11 @@ define Device/routerich_ax3000
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := Partition layout has been changed. Bootloader MUST be \
+	upgraded to avoid data corruption and getting bricked. \
+	Please, contact your vendor and follow the guide: \
+	https://openwrt.org/toh/routerich/ax3000#web_ui_method
 endef
 TARGET_DEVICES += routerich_ax3000
 


### PR DESCRIPTION
All new routers are shipped with ubi size 112MB since early September.

Bootloader update required (ask vendor , see wiki)

These partitions weren't used:
firmware_backup
zrsave
config2