### PR TITLE
qualcommax: ipq807x: mx4200: repurpose sysdiag as pstore partition

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200.dtsi
@@ -207,9 +207,8 @@
 			};
 
 			partition@13c80000 {
-				label = "sysdiag";
+				label = "pstore";
 				reg = <0x13c80000 0x200000>;
-				read-only;
 			};
 
 			partition@13e80000 {


### PR DESCRIPTION
`sysdiag` is seemingly the partition used by the OEM to collect diagnostics logs. However, it is empty on the (2) MX4200 devices I have access too. So let's remove the `read-only` property and rename it to `pstore` to use it to collect panics/oops based on `pstore` like other devices.