### PR TITLE
treewide: remove platform_get_resoruce

### DIFF
--- a/target/linux/ath79/files/drivers/mtd/nand/raw/ar934x_nand.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/ar934x_nand.c
@@ -1359,7 +1359,6 @@ static const struct nand_controller_ops ar934x_nfc_controller_ops = {
 static int ar934x_nfc_probe(struct platform_device *pdev)
 {
 	struct ar934x_nfc *nfc;
-	struct resource *res;
 	struct mtd_info *mtd;
 	struct nand_chip *nand;
 	int ret;
@@ -1367,19 +1366,13 @@ static int ar934x_nfc_probe(struct platform_device *pdev)
 	pdev->dev.dma_mask = &ar934x_nfc_dma_mask;
 	pdev->dev.coherent_dma_mask = DMA_BIT_MASK(32);
 
-	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-	if (!res) {
-		dev_err(&pdev->dev, "failed to get I/O memory\n");
-		return -EINVAL;
-	}
-
 	nfc = devm_kzalloc(&pdev->dev, sizeof(struct ar934x_nfc), GFP_KERNEL);
 	if (!nfc) {
 		dev_err(&pdev->dev, "failed to allocate driver data\n");
 		return -ENOMEM;
 	}
 
-	nfc->base = devm_ioremap_resource(&pdev->dev, res);
+	nfc->base = devm_platform_ioremap_resource(pdev, 0);
 	if (IS_ERR(nfc->base)) {
 		dev_err(&pdev->dev, "failed to remap I/O memory\n");
 		return PTR_ERR(nfc->base);

--- a/target/linux/ipq40xx/patches-6.6/850-soc-add-qualcomm-syscon.patch
+++ b/target/linux/ipq40xx/patches-6.6/850-soc-add-qualcomm-syscon.patch
@@ -23,7 +23,7 @@ Subject: SoC: add qualcomm syscon
 +obj-$(CONFIG_QCOM_TCSR)		+= qcom_tcsr.o
 --- /dev/null
 +++ b/drivers/soc/qcom/qcom_tcsr.c
-@@ -0,0 +1,98 @@
+@@ -0,0 +1,96 @@
 +/*
 + * Copyright (c) 2014, The Linux foundation. All rights reserved.
 + *
@@ -57,13 +57,11 @@ Subject: SoC: add qualcomm syscon
 +
 +static int tcsr_probe(struct platform_device *pdev)
 +{
-+	struct resource *res;
 +	const struct device_node *node = pdev->dev.of_node;
 +	void __iomem *base;
 +	u32 val;
 +
-+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-+	base = devm_ioremap_resource(&pdev->dev, res);
++	base = devm_platform_ioremap_resource(pdev, 0);
 +	if (IS_ERR(base))
 +		return PTR_ERR(base);
 +

--- a/target/linux/ipq806x/patches-6.6/850-soc-add-qualcomm-syscon.patch
+++ b/target/linux/ipq806x/patches-6.6/850-soc-add-qualcomm-syscon.patch
@@ -28,7 +28,7 @@ Subject: SoC: add qualcomm syscon
  	depends on ARCH_QCOM || COMPILE_TEST
 --- /dev/null
 +++ b/drivers/soc/qcom/qcom_tcsr.c
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,62 @@
 +/*
 + * Copyright (c) 2014, The Linux foundation. All rights reserved.
 + *
@@ -54,13 +54,11 @@ Subject: SoC: add qualcomm syscon
 +
 +static int tcsr_probe(struct platform_device *pdev)
 +{
-+	struct resource *res;
 +	const struct device_node *node = pdev->dev.of_node;
 +	void __iomem *base;
 +	u32 val;
 +
-+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-+	base = devm_ioremap_resource(&pdev->dev, res);
++	base = devm_platform_ioremap_resource(pdev, 0);
 +	if (IS_ERR(base))
 +		return PTR_ERR(base);
 +

--- a/target/linux/lantiq/patches-6.6/0031-I2C-MIPS-lantiq-add-FALC-ON-i2c-bus-master.patch
+++ b/target/linux/lantiq/patches-6.6/0031-I2C-MIPS-lantiq-add-FALC-ON-i2c-bus-master.patch
@@ -47,7 +47,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  obj-$(CONFIG_I2C_MESON)		+= i2c-meson.o
 --- /dev/null
 +++ b/drivers/i2c/busses/i2c-lantiq.c
-@@ -0,0 +1,747 @@
+@@ -0,0 +1,746 @@
 +
 +/*
 + * Lantiq I2C bus adapter
@@ -625,14 +625,13 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	struct device_node *node = pdev->dev.of_node;
 +	struct ltq_i2c *priv;
 +	struct i2c_adapter *adap;
-+	struct resource *mmres, irqres[4];
++	struct resource irqres[4];
 +	int ret = 0;
 +
 +	dev_dbg(&pdev->dev, "probing\n");
 +
-+	mmres = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 +	ret = of_irq_to_resource_table(node, irqres, 4);
-+	if (!mmres || (ret != 4)) {
++	if (ret != 4) {
 +		dev_err(&pdev->dev, "no resources\n");
 +		return -ENODEV;
 +	}
@@ -661,7 +660,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	init_completion(&priv->cmd_complete);
 +	mutex_init(&priv->mutex);
 +
-+	priv->membase = devm_ioremap_resource(&pdev->dev, mmres);
++	priv->membase = devm_platform_ioremap_resource(pdev, 0);
 +	if (IS_ERR(priv->membase))
 +		return PTR_ERR(priv->membase);
 +

--- a/target/linux/ramips/files/drivers/mmc/host/mtk-mmc/sd.c
+++ b/target/linux/ramips/files/drivers/mmc/host/mtk-mmc/sd.c
@@ -2204,7 +2204,6 @@ static void msdc_init_gpd_bd(struct msdc_host *host, struct msdc_dma *dma)
 
 static int msdc_drv_probe(struct platform_device *pdev)
 {
-	struct resource *res;
 	__iomem void *base;
 	struct mmc_host *mmc;
 	struct msdc_host *host;
@@ -2227,8 +2226,7 @@ static int msdc_drv_probe(struct platform_device *pdev)
 	if (!mmc)
 		return -ENOMEM;
 
-	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-	base = devm_ioremap_resource(&pdev->dev, res);
+	base = devm_platform_ioremap_resource(pdev, 0);
 	if (IS_ERR(base)) {
 		ret = PTR_ERR(base);
 		goto host_free;

--- a/target/linux/ramips/files/drivers/mtd/nand/raw/mt7621_nand.c
+++ b/target/linux/ramips/files/drivers/mtd/nand/raw/mt7621_nand.c
@@ -1292,8 +1292,7 @@ static int mt7621_nfc_probe(struct platform_device *pdev)
 	if (IS_ERR(nfc->nfi_regs))
 		return PTR_ERR(nfc->nfi_regs);
 
-	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "ecc");
-	nfc->ecc_regs = devm_ioremap_resource(dev, res);
+	nfc->ecc_regs = devm_platform_ioremap_resource_byname(pdev, "ecc");
 	if (IS_ERR(nfc->ecc_regs))
 		return PTR_ERR(nfc->ecc_regs);
 

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
@@ -1387,7 +1387,6 @@ static const struct switch_dev_ops esw_ops = {
 
 static int esw_probe(struct platform_device *pdev)
 {
-	struct resource *res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 	struct device_node *np = pdev->dev.of_node;
 	const __be32 *port_map, *port_disable, *reg_init;
 	struct rt305x_esw *esw;
@@ -1398,7 +1397,7 @@ static int esw_probe(struct platform_device *pdev)
 
 	esw->dev = &pdev->dev;
 	esw->irq = irq_of_parse_and_map(np, 0);
-	esw->base = devm_ioremap_resource(&pdev->dev, res);
+	esw->base = devm_platform_ioremap_resource(pdev, 0);
 	if (IS_ERR(esw->base))
 		return PTR_ERR(esw->base);
 

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
@@ -259,14 +259,13 @@ int mtk_gsw_init(struct fe_priv *priv)
 
 static int mt7620_gsw_probe(struct platform_device *pdev)
 {
-	struct resource *res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 	struct mt7620_gsw *gsw;
 
 	gsw = devm_kzalloc(&pdev->dev, sizeof(struct mt7620_gsw), GFP_KERNEL);
 	if (!gsw)
 		return -ENOMEM;
 
-	gsw->base = devm_ioremap_resource(&pdev->dev, res);
+	gsw->base = devm_platform_ioremap_resource(pdev, 0);
 	if (IS_ERR(gsw->base))
 		return PTR_ERR(gsw->base);
 

--- a/target/linux/ramips/patches-6.6/860-ramips-add-eip93-driver.patch
+++ b/target/linux/ramips/patches-6.6/860-ramips-add-eip93-driver.patch
@@ -2256,7 +2256,7 @@
 +#endif /* _EIP93_DES_H_ */
 --- /dev/null
 +++ b/drivers/crypto/mtk-eip93/eip93-main.c
-@@ -0,0 +1,467 @@
+@@ -0,0 +1,465 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2019 - 2021
@@ -2636,7 +2636,6 @@
 +{
 +	struct device *dev = &pdev->dev;
 +	struct mtk_device *mtk;
-+	struct resource *res;
 +	int err;
 +
 +	mtk = devm_kzalloc(dev, sizeof(*mtk), GFP_KERNEL);
@@ -2646,8 +2645,7 @@
 +	mtk->dev = dev;
 +	platform_set_drvdata(pdev, mtk);
 +
-+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-+	mtk->base = devm_ioremap_resource(&pdev->dev, res);
++	mtk->base = devm_platform_ioremap_resource(pdev, 0);
 +
 +	if (IS_ERR(mtk->base))
 +		return PTR_ERR(mtk->base);

--- a/target/linux/realtek/files-6.6/drivers/i2c/busses/i2c-rtl9300.c
+++ b/target/linux/realtek/files-6.6/drivers/i2c/busses/i2c-rtl9300.c
@@ -336,7 +336,6 @@ struct i2c_adapter_quirks rtl9300_i2c_quirks = {
 
 static int rtl9300_i2c_probe(struct platform_device *pdev)
 {
-	struct resource *res;
 	struct rtl9300_i2c *i2c;
 	struct i2c_adapter *adap;
 	struct i2c_drv_data *drv_data;
@@ -351,15 +350,13 @@ static int rtl9300_i2c_probe(struct platform_device *pdev)
 		return -EINVAL;
 	}
 
-	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-
 	drv_data = (struct i2c_drv_data *) device_get_match_data(&pdev->dev);
 
 	i2c = devm_kzalloc(&pdev->dev, sizeof(struct rtl9300_i2c), GFP_KERNEL);
 	if (!i2c)
 		return -ENOMEM;
 
-	i2c->base = devm_ioremap_resource(&pdev->dev, res);
+	i2c->base = devm_platform_ioremap_resource(pdev, 0);
 	i2c->mst2_offset = drv_data->mst2_offset;
 	if (IS_ERR(i2c->base))
 		return PTR_ERR(i2c->base);


### PR DESCRIPTION
Easier to just use devm_platform_ioremap_resource.

ping @robimarko @hauke 