### PR TITLE
mvebu: cortex-a9: add upgrade methode to nas1dual

### DIFF
--- a/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
@@ -75,8 +75,8 @@ platform_do_upgrade() {
 		;;
 	iptime,nas1dual)
 		PART_NAME=firmware
+		default_do_upgrade "$1"
 		;;
-
 	linksys,wrt1200ac|\
 	linksys,wrt1900ac-v1|\
 	linksys,wrt1900ac-v2|\


### PR DESCRIPTION
The blamed commit adds a upgrade recipe for nas1dual to specify the firmware partition name, but does not actually include the recipe that will be called.

Since it previously relied on the default one, add that one.

`Fixes: d21720fa90c8 ("mvebu: fix default partition name")`
