### PR TITLE
kernel: packages: kmod-pstore: move CONFIG_PSTORE_COMPRESS to backend

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -700,9 +700,7 @@ define KernelPackage/pstore
   SUBMENU:=$(FS_MENU)
   TITLE:=Pstore file system
   DEFAULT:=m if ALL_KMODS
-  KCONFIG:= \
-	CONFIG_PSTORE \
-	CONFIG_PSTORE_COMPRESS=y
+  KCONFIG:=CONFIG_PSTORE
   FILES:= $(LINUX_DIR)/fs/pstore/pstore.ko
   AUTOLOAD:=$(call AutoLoad,30,pstore,1)
   DEPENDS:=+kmod-lib-zlib-deflate +kmod-lib-zlib-inflate

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -643,7 +643,8 @@ define KernelPackage/ramoops
   TITLE:=Ramoops (pstore-ram)
   DEFAULT:=m if ALL_KMODS
   KCONFIG:=CONFIG_PSTORE_RAM \
-	CONFIG_PSTORE_CONSOLE=y
+  CONFIG_PSTORE_CONSOLE=y \
+  CONFIG_PSTORE_COMPRESS=y
   DEPENDS:=+kmod-pstore +kmod-reed-solomon
   FILES:= $(LINUX_DIR)/fs/pstore/ramoops.ko
   AUTOLOAD:=$(call AutoLoad,30,ramoops,1)


### PR DESCRIPTION
`pstore` can be used by `ramoops` and `pstore_blk` backends. While traditionally `ramoops` has used compression, that's not the recommendation for `pstore_blk`. For one, without compression you can dump the content of the block device, say mtd partition, and read it directly. So let's move the option to use compression to the backend so `pstore_blk` can be used without it.