### PR TITLE
ath11k-firmware: update IPQ8074 and QCN9074 to 2.9.0.1-02146

### DIFF
--- a/package/firmware/ath11k-firmware/Makefile
+++ b/package/firmware/ath11k-firmware/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ath11k-firmware
-PKG_SOURCE_DATE:=2024-03-14
-PKG_SOURCE_VERSION:=795809c7041582bd51bdfaa1f548b916ae8d4382
-PKG_MIRROR_HASH:=d93edc651b641a97ec4f5ed329e15ac110928f863b4afbaae7fcb25953d04544
-PKG_RELEASE:=2
+PKG_SOURCE_DATE:=2024-10-14
+PKG_SOURCE_VERSION:=15f050122da5ef5bef2cc8c7c19dfb7f98060a49
+PKG_MIRROR_HASH:=e7a89d1570f32552ade539376181494724b5eafb31d00451ff2dcf5a2922a0cb
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/quic/upstream-wifi-fw.git
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/ath-firmware/ath11k-firmware.git
 
 PKG_LICENSE_FILES:=LICENSE.qca_firmware
 
@@ -51,38 +51,27 @@ define Build/Compile
 
 endef
 
-QCN9074_BOARD_REV:=8e140c65f36137714b6d8934e09dcd73cb05c2f6
-QCN9074_BOARD_FILE:=board-2.bin.$(QCN9074_BOARD_REV)
-
-define Download/qcn9074-board
-  URL:=https://git.codelinaro.org/clo/ath-firmware/ath11k-firmware/-/raw/main/QCN9074/hw1.0/
-  URL_FILE:=board-2.bin
-  FILE:=$(QCN9074_BOARD_FILE)
-  HASH:=dbf0ca14aa1229eccd48f26f1026901b9718b143bd30b51b8ea67c84ba6207f1
-endef
-$(eval $(call Download,qcn9074-board))
-
 define Package/ath11k-firmware-ipq6018/install
 	$(INSTALL_DIR) $(1)/lib/firmware/IPQ6018
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/ath11k-firmware/IPQ6018/hw1.0/2.5.0.1/WLAN.HK.2.5.0.1-03982-QCAHKSWPL_SILICONZ-3/* \
+		$(PKG_BUILD_DIR)/IPQ6018/hw1.0/2.5.0.1/WLAN.HK.2.5.0.1-03982-QCAHKSWPL_SILICONZ-3/* \
 		$(1)/lib/firmware/IPQ6018/
 endef
 
 define Package/ath11k-firmware-ipq8074/install
 	$(INSTALL_DIR) $(1)/lib/firmware/IPQ8074
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/ath11k-firmware/IPQ8074/hw2.0/2.9.0.1/WLAN.HK.2.9.0.1-01977-QCAHKSWPL_SILICONZ-1/* \
+		$(PKG_BUILD_DIR)/IPQ8074/hw2.0/2.9.0.1/WLAN.HK.2.9.0.1-02146-QCAHKSWPL_SILICONZ-1/* \
 		$(1)/lib/firmware/IPQ8074/
 endef
 
 define Package/ath11k-firmware-qcn9074/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/QCN9074/hw1.0
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/ath11k-firmware/QCN9074/hw1.0/2.9.0.1/WLAN.HK.2.9.0.1-01977-QCAHKSWPL_SILICONZ-1/* \
+		$(PKG_BUILD_DIR)/QCN9074/hw1.0/2.9.0.1/WLAN.HK.2.9.0.1-02146-QCAHKSWPL_SILICONZ-1/* \
 		$(1)/lib/firmware/ath11k/QCN9074/hw1.0/
 	$(INSTALL_BIN) \
-		$(DL_DIR)/$(QCN9074_BOARD_FILE) $(1)/lib/firmware/ath11k/QCN9074/hw1.0/board-2.bin
+		$(PKG_BUILD_DIR)/QCN9074/hw1.0/board-2.bin $(1)/lib/firmware/ath11k/QCN9074/hw1.0/board-2.bin
 endef
 
 $(eval $(call BuildPackage,ath11k-firmware-ipq6018))


### PR DESCRIPTION
After a long time QCA has pushed an updated release of 2.9.0.1 firmware for IPQ8074 and QCN9074, so lets update to 2.9.0.1-02146.

Sadly, still nothing new for IPQ6018.

QCA has also moved the repository where they will be posting firmware to their CodeLinaro instance, so we move to using that and it allows us to remove the manual download of QCN9074 board-2.bin.
