### PR TITLE
base-files: increase default system log size to 128 kB

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -314,7 +314,7 @@ generate_static_system() {
 		set system.@system[-1].hostname='OpenWrt'
 		set system.@system[-1].timezone='UTC'
 		set system.@system[-1].ttylogin='0'
-		set system.@system[-1].log_size='64'
+		set system.@system[-1].log_size='128'
 		set system.@system[-1].urandom_seed='0'
 
 		delete system.ntp


### PR DESCRIPTION
Increase the default system log buffer size option in /etc/config/system from 64 kB to 128 kB.

64 kB is barely enough for the boot items of a modern router with a few add-on packages, but any subsequent logging will quickly cause the early boot items to get overwritten in the round-robin log buffer. Double the buffer size to 128 kB.

(Note: built-in default in ubox logd itself is still 16 kB)

The default log size was previously increased by me in year 2016 with commit df7581e4c096. Routers have got much more verbose during the 8 years since then (while their RAM has also grown so much that overzealous log memory constraints aren't that necessary any more)
 
I have been configuring log size to 192 kB in my own routers for some years now, but I propose here just 128 kB as the new global default.
