### PR TITLE
mac80211: iwlwifi: unlock 320MHz bandwidth

### DIFF
--- a/package/kernel/mac80211/Makefile
+++ b/package/kernel/mac80211/Makefile
@@ -354,6 +354,7 @@ define Build/Patch
 	$(call PatchDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/mwl,mwl/)
 	$(call PatchDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/brcm,brcm/)
 	$(call PatchDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/rtl,rtl/)
+	$(call PatchDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/iwlwifi,iwlwifi/)
 	$(if $(QUILT),touch $(PKG_BUILD_DIR)/.quilt_used)
 endef
 
@@ -371,6 +372,7 @@ define Quilt/Refresh/Package
 	$(call Quilt/RefreshDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/mwl,mwl/)
 	$(call Quilt/RefreshDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/brcm,brcm/)
 	$(call Quilt/RefreshDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/rtl,rtl/)
+	$(call Quilt/RefreshDir,$(PKG_BUILD_DIR),$(PATCH_DIR)/iwlwifi,iwlwifi/)
 endef
 
 define Build/Compile

--- a/package/kernel/mac80211/patches/iwlwifi/001-iwlwifi-unblock-320MHz.patch
+++ b/package/kernel/mac80211/patches/iwlwifi/001-iwlwifi-unblock-320MHz.patch
@@ -1,0 +1,12 @@
+--- a/drivers/net/wireless/intel/iwlwifi/iwl-nvm-parse.c
++++ b/drivers/net/wireless/intel/iwlwifi/iwl-nvm-parse.c
+@@ -917,6 +917,9 @@ iwl_nvm_fixup_sband_iftd(struct iwl_tran
+ 		 trans->pcie_link_speed < PCI_EXP_LNKSTA_CLS_8_0GB) ||
+ 		 trans->reduced_cap_sku;
+ 
++	/* Unlock 320MHz */
++	no_320 = false;
++
+ 	if (!data->sku_cap_11be_enable || iwlwifi_mod_params.disable_11be)
+ 		iftype_data->eht_cap.has_eht = false;
+ 


### PR DESCRIPTION
This patch mainly skip community patch.

Description of original one:
If a discrete NIC is connected to a PCIe link hat isn't at least Gen3 (8.0 GT/s), then we cannot sustain 320 MHz traffic, so remove that from EHT capabilities in that case.

While at it, also move setting 320 MHz beamformee to the right place in the code so it's not set while not supporting 320 MHz.

In my noisy environtment I still have better results for 320 MHz:
  (6g/1/EHT320): ping pkt loss ap->sta: 0%, sta->ap: 0%
  (6g/1/EHT320): ap->sta: 1453 Mbits/sec, sta->ap: 2097 Mbits/sec

  (6g/1/EHT160): ping pkt loss ap->sta: 0%, sta->ap: 0%
  (6g/1/EHT160): ap->sta: 1266 Mbits/sec, sta->ap: 1706 Mbits/sec
