### PR TITLE
hostapd: allow (older) apple devices to join wpa3/wpa2 mixed networks

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -66,7 +66,7 @@ hostapd_append_wpa_key_mgmt() {
 		psk-sae)
 			append wpa_key_mgmt "WPA-PSK"
 			[ "${ieee80211r:-0}" -gt 0 ] && append wpa_key_mgmt "FT-PSK"
-			[ "${ieee80211w:-0}" -gt 0 ] && append wpa_key_mgmt "WPA-PSK-SHA256"
+			[ "${ieee80211w:-0}" -gt 1 ] && append wpa_key_mgmt "WPA-PSK-SHA256"
 			append wpa_key_mgmt "SAE"
 			[ "${ieee80211r:-0}" -gt 0 ] && append wpa_key_mgmt "FT-SAE"
 		;;


### PR DESCRIPTION
(Older) Apple devices can't join mixed wpa3/wpa2-networks, while other devices have no issue.

This seems to be an issue specific to apple-devices, which is triggered when the newever sha 256-cipher suite is enabled. The wpa3-part enables 802.11w, which enable the sha256-cipher suites which seems to be what is normal according to 802.11 spec, based on what I found. The newer cipher suite seems to cause this issue on apple devices.

Importance:

This issue has been reported multiple times within openwrt and I also found some similar reports outside openwrt:
- https://github.com/openwrt/openwrt/issues/7858
- https://github.com/openwrt/openwrt/issues/16039
- https://discussions.apple.com/thread/252500270?sortBy=rank
- ubiquity had similar issue: https://community.ui.com/questions/An-old-iPad-cannot-to-wifi-network-set-to-WAP-2-WAP-3/13ef3d06-576e-437b-bff4-587c6489d45a
- possibly related: https://wlan1nde.wordpress.com/2017/07/07/apple-client-fails-with-mandatory-pmf-on-802-1x-ssid/ (although eap). Seems to be ipad issue.

Impact:

- This would cause the older wpa2 ciphers to be used instead of the newer ones using sha256, and this for all connections.
- (Older) apple devices can also connect.

The best solution would seemingly be that Apple fixes this, but I think that's not a realistic scenario if I read the posts also above.

A better solution, requiring more implementation and testing work, could be, if possible, to detect wether the device is an apple device and then only remove the newer cipher suites from the offering, instead of doing this for all devices. However, I'm not sure if this adds a lot security as soon as 1 apple device joins the wifi network. Probably some, but people with more knowledge can answer this faster than me I suppose, not thinking about the work and testing required then.

The easiest for home-scenarios and the fact that probably a lot of networks are still wpa2-based anyway, is to disable this cipher suite to allow these devices to join the network.

Maybe it's an option to add an "apple-compatibility" checkbox which then adds an if-test and implements this patch, if openwrt maintainers do not want to implement this for everyone, as the current behaviour seems to be spec-compliant.

But this at least fixes the issues #7858 and #16039

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
