### PR TITLE
linux-firmware: ath11k: use new board file for QCN9074

### DIFF
--- a/package/firmware/linux-firmware/qca_ath11k.mk
+++ b/package/firmware/linux-firmware/qca_ath11k.mk
@@ -1,3 +1,14 @@
+QCN9074_BOARD_REV:=9372f0a3be311bfaa11a214d039aa0fae5a74756
+QCN9074_BOARD_FILE:=board-2.bin.$(QCN9074_BOARD_REV)
+
+define Download/qcn9074-board
+  URL:=https://git.codelinaro.org/clo/qsdk/oss/ath11k-bdf/-/raw/NHSS.QSDK.12.5.5/QCN9074/hw1.0/WLAN.HK.2.9.0.1/WLAN.HK.2.9.0.1-01977-QCAHKSWPL_SILICONZ-1/
+  URL_FILE:=board-2.bin
+  FILE:=$(QCN9074_BOARD_FILE)
+  HASH:=2379460b1f9d44bb2d23d50712d6acf04cd067b5fd748043aeba3554190a84e9
+endef
+$(eval $(call Download,qcn9074-board))
+
 Package/ath11k-firmware-ipq5018 = $(call Package/firmware-default,IPQ5018 ath11k firmware,,LICENCE.atheros_firmware)
 define Package/ath11k-firmware-ipq5018/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/IPQ5018/hw1.0
@@ -35,6 +46,8 @@ define Package/ath11k-firmware-qcn9074/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/QCN9074/hw1.0
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/ath11k/QCN9074/hw1.0/* $(1)/lib/firmware/ath11k/QCN9074/hw1.0/
+	$(INSTALL_BIN) \
+		$(DL_DIR)/$(QCN9074_BOARD_FILE) $(1)/lib/firmware/ath11k/QCN9074/hw1.0/board-2.bin
 endef
 $(eval $(call BuildPackage,ath11k-firmware-qcn9074))
 

--- a/package/firmware/linux-firmware/qca_ath11k.mk
+++ b/package/firmware/linux-firmware/qca_ath11k.mk
@@ -1,3 +1,14 @@
+QCN9074_BOARD_REV:=9372f0a3be311bfaa11a214d039aa0fae5a74756
+QCN9074_BOARD_FILE:=board-2.bin.$(QCN9074_BOARD_REV)
+
+define Download/qcn9074-board
+  URL:=https://git.codelinaro.org/clo/qsdk/oss/ath11k-bdf/-/raw/$(QCN9074_BOARD_REV)/QCN9074/hw1.0/WLAN.HK.2.9.0.1/WLAN.HK.2.9.0.1-01977-QCAHKSWPL_SILICONZ-1/
+  URL_FILE:=board-2.bin
+  FILE:=$(QCN9074_BOARD_FILE)
+  HASH:=2379460b1f9d44bb2d23d50712d6acf04cd067b5fd748043aeba3554190a84e9
+endef
+$(eval $(call Download,qcn9074-board))
+
 Package/ath11k-firmware-ipq5018 = $(call Package/firmware-default,IPQ5018 ath11k firmware,,LICENCE.atheros_firmware)
 define Package/ath11k-firmware-ipq5018/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/IPQ5018/hw1.0
@@ -35,6 +46,8 @@ define Package/ath11k-firmware-qcn9074/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/QCN9074/hw1.0
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/ath11k/QCN9074/hw1.0/* $(1)/lib/firmware/ath11k/QCN9074/hw1.0/
+	$(INSTALL_DATA) \
+		$(DL_DIR)/$(QCN9074_BOARD_FILE) $(1)/lib/firmware/ath11k/QCN9074/hw1.0/board-2.bin
 endef
 $(eval $(call BuildPackage,ath11k-firmware-qcn9074))
 


### PR DESCRIPTION
Board file distributed with QCN9074 firmware is old (comes from firmware 2.5).
Use new board file from firmware 2.9.0.1-01977 that is available on codelinaro git repository.