### PR TITLE
make shell vars in WWAN packages slightly more maintainable

### DIFF
--- a/package/network/utils/comgt/files/ncm.sh
+++ b/package/network/utils/comgt/files/ncm.sh
@@ -28,12 +28,13 @@ proto_ncm_init_config() {
 proto_ncm_setup() {
 	local interface="$1"
 
-	local manufacturer initialize setmode connect finalize devname devpath ifpath
+	local connect context_type devname devpath finalize ifpath initialize manufacturer setmode
 
-	local device ifname  apn auth username password pincode delay mode pdptype profile $PROTO_DEFAULT_OPTIONS
-	json_get_vars device ifname apn auth username password pincode delay mode pdptype sourcefilter delegate profile $PROTO_DEFAULT_OPTIONS
+	local delegate sourcefilter $PROTO_DEFAULT_OPTIONS
+	json_get_vars delegate sourcefilter $PROTO_DEFAULT_OPTIONS
 
-	local context_type
+	local apn auth delay device ifname mode password pdptype pincode profile username
+	json_get_vars apn auth delay device ifname mode password pdptype pincode profile username
 
 	[ "$metric" = "" ] && metric="0"
 

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -46,10 +46,14 @@ _proto_mbim_setup() {
 	local tid=2
 	local ret
 
-	local device apn pincode delay auth username password allow_roaming allow_partner
-	local dhcp dhcpv6 pdptype ip4table ip6table mtu $PROTO_DEFAULT_OPTIONS
-	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner
-	json_get_vars dhcp dhcpv6 sourcefilter delegate pdptype ip4table ip6table mtu $PROTO_DEFAULT_OPTIONS
+	local allow_partner allow_roaming apn auth delay device password pincode username
+	json_get_vars allow_partner allow_roaming apn auth delay device password pincode username
+
+	local dhcp dhcpv6 pdptype
+	json_get_vars dhcp dhcpv6 pdptype
+
+	local delegate ip4table ip6table mtu sourcefilter $PROTO_DEFAULT_OPTIONS
+	json_get_vars delegate ip4table ip6table mtu sourcefilter $PROTO_DEFAULT_OPTIONS
 
 	[ ! -e /proc/sys/net/ipv6 ] && ipv6=0 || json_get_var ipv6 ipv6
 

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -34,17 +34,20 @@ proto_qmi_init_config() {
 
 proto_qmi_setup() {
 	local interface="$1"
-	local dataformat connstat plmn_mode mcc mnc
-	local device apn v6apn auth username password pincode delay modes pdptype
-	local profile v6profile dhcp dhcpv6 autoconnect plmn timeout mtu $PROTO_DEFAULT_OPTIONS
-	local ip4table ip6table
-	local cid_4 pdh_4 cid_6 pdh_6
-	local ip_6 ip_prefix_length gateway_6 dns1_6 dns2_6
+
+	local connstat dataformat mcc mnc plmn_mode
+	local cid_4 cid_6 pdh_4 pdh_6
+	local dns1_6 dns2_6 gateway_6 ip_6 ip_prefix_length
 	local profile_pdptype
 
-	json_get_vars device apn v6apn auth username password pincode delay modes
-	json_get_vars pdptype profile v6profile dhcp dhcpv6 sourcefilter delegate autoconnect plmn ip4table
-	json_get_vars ip6table timeout mtu $PROTO_DEFAULT_OPTIONS
+	local delegate ip4table ip6table mtu sourcefilter $PROTO_DEFAULT_OPTIONS
+	json_get_vars delegate ip4table ip6table mtu sourcefilter $PROTO_DEFAULT_OPTIONS
+
+	local apn auth delay device modes password pdptype pincode username v6apn
+	json_get_vars apn auth delay device modes password pdptype pincode username v6apn
+
+	local profile v6profile dhcp dhcpv6 autoconnect plmn timeout
+	json_get_vars profile v6profile dhcp dhcpv6 autoconnect plmn timeout
 
 	[ "$timeout" = "" ] && timeout="10"
 


### PR DESCRIPTION
Hi :wave: 

The shell variables in some of the netifd scripts have grown to be numerous and cluttered.
This really started to irritate me while reviewing the recent implementations of `delegate`.

I've cleaned up the code fetching config vars for uqmi, mbim, and ncm (whatever that is) by grouping the declarations and the reading of config variables and sorting them.

A few minor errors have already crept in (missing local declarations). I corrected those in one sweep.
For ppp, I didn't do anything because there are no local declarations at all and I feel I'd be more than just re-arranging while simultaneously knowing little about the package (two "main"-looking setup methods?).