### PR TITLE
kernel: gpio-cascate: use gpiochip_get_data

### DIFF
--- a/target/linux/generic/pending-6.6/801-gpio-gpio-cascade-add-generic-GPIO-cascade.patch
+++ b/target/linux/generic/pending-6.6/801-gpio-gpio-cascade-add-generic-GPIO-cascade.patch
@@ -102,7 +102,7 @@ v1 -> v2:
  obj-$(CONFIG_GPIO_CRYSTAL_COVE)		+= gpio-crystalcove.o
 --- /dev/null
 +++ b/drivers/gpio/gpio-cascade.c
-@@ -0,0 +1,117 @@
+@@ -0,0 +1,112 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + *  A generic GPIO cascade driver
@@ -141,11 +141,6 @@ v1 -> v2:
 +	struct gpio_desc	*upstream_line;
 +};
 +
-+static struct gpio_cascade *chip_to_cascade(struct gpio_chip *gc)
-+{
-+	return container_of(gc, struct gpio_cascade, gpio_chip);
-+}
-+
 +static int gpio_cascade_get_direction(struct gpio_chip *gc, unsigned int offset)
 +{
 +	return GPIO_LINE_DIRECTION_IN;
@@ -153,7 +148,7 @@ v1 -> v2:
 +
 +static int gpio_cascade_get_value(struct gpio_chip *gc, unsigned int offset)
 +{
-+	struct gpio_cascade *cas = chip_to_cascade(gc);
++	struct gpio_cascade *cas = gpiochip_get_data(gc);
 +	int ret;
 +
 +	ret = mux_control_select(cas->mux_control, offset);
@@ -199,7 +194,7 @@ v1 -> v2:
 +	gc->owner = THIS_MODULE;
 +
 +	platform_set_drvdata(pdev, cas);
-+	return devm_gpiochip_add_data(dev, &cas->gpio_chip, NULL);
++	return devm_gpiochip_add_data(dev, &cas->gpio_chip, cas);
 +}
 +
 +static const struct of_device_id gpio_cascade_id[] = {


### PR DESCRIPTION
Instead of passing NULL to gpiochip_add_data, we can populate the parameter and use gpiochip_get_data instead of a custom function.

ping @hauke 