### PR TITLE
ramips: ralink-gpio: use gpiochip_get_data

### DIFF
--- a/target/linux/ramips/patches-6.6/802-GPIO-MIPS-ralink-add-gpio-driver-for-ralink-SoC.patch
+++ b/target/linux/ramips/patches-6.6/802-GPIO-MIPS-ralink-add-gpio-driver-for-ralink-SoC.patch
@@ -41,7 +41,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  obj-$(CONFIG_GPIO_RCAR)			+= gpio-rcar.o
 --- /dev/null
 +++ b/drivers/gpio/gpio-ralink.c
-@@ -0,0 +1,273 @@
+@@ -0,0 +1,264 @@
 +/*
 + * This program is free software; you can redistribute it and/or modify it
 + * under the terms of the GNU General Public License version 2 as published
@@ -92,15 +92,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +static int irq_map_count;
 +static atomic_t irq_refcount = ATOMIC_INIT(0);
 +
-+static inline struct ralink_gpio_chip *to_ralink_gpio(struct gpio_chip *chip)
-+{
-+	struct ralink_gpio_chip *rg;
-+
-+	rg = container_of(chip, struct ralink_gpio_chip, chip);
-+
-+	return rg;
-+}
-+
 +static inline void rt_gpio_w32(struct ralink_gpio_chip *rg, u8 reg, u32 val)
 +{
 +	iowrite32(val, rg->membase + rg->regs[reg]);
@@ -113,7 +104,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +
 +static int ralink_gpio_to_irq(struct gpio_chip *chip, unsigned pin)
 +{
-+	struct ralink_gpio_chip *rg = to_ralink_gpio(chip);
++	struct ralink_gpio_chip *rg = gpiochip_get_data(chip);
 +
 +	if (rg->irq < 1)
 +		return -1;

--- a/target/linux/ramips/patches-6.6/803-gpio-ralink-Add-support-for-GPIO-as-interrupt-contro.patch
+++ b/target/linux/ramips/patches-6.6/803-gpio-ralink-Add-support-for-GPIO-as-interrupt-contro.patch
@@ -32,7 +32,7 @@ Signed-off-by: Daniel Santos <daniel.santos@pobox.com>
  
 --- a/drivers/gpio/gpio-ralink.c
 +++ b/drivers/gpio/gpio-ralink.c
-@@ -174,7 +174,7 @@ static int gpio_map(struct irq_domain *d
+@@ -165,7 +165,7 @@ static int gpio_map(struct irq_domain *d
  }
  
  static const struct irq_domain_ops irq_domain_ops = {


### PR DESCRIPTION
Oversight from devm conversion. Avoids custom function doing the same thing.

ping @hauke @robimarko 