### PR TITLE
mvebu: devm for mutex_init

### DIFF
--- a/target/linux/mvebu/patches-6.6/902-drivers-mfd-Add-a-driver-for-IEI-WT61P803-PUZZLE-MCU.patch
+++ b/target/linux/mvebu/patches-6.6/902-drivers-mfd-Add-a-driver-for-IEI-WT61P803-PUZZLE-MCU.patch
@@ -54,7 +54,7 @@ Cc: Robert Marko <robert.marko@sartura.hr>
  obj-$(CONFIG_INTEL_SOC_PMIC_BXTWC)	+= intel_soc_pmic_bxtwc.o
 --- /dev/null
 +++ b/drivers/mfd/iei-wt61p803-puzzle.c
-@@ -0,0 +1,908 @@
+@@ -0,0 +1,912 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/* IEI WT61P803 PUZZLE MCU Driver
 + * System management microcontroller for fan control, temperature sensor reading,
@@ -894,8 +894,12 @@ Cc: Robert Marko <robert.marko@sartura.hr>
 +	mcu->serdev = serdev;
 +	mcu->dev = dev;
 +	init_completion(&mcu->reply->received);
-+	mutex_init(&mcu->reply_lock);
-+	mutex_init(&mcu->lock);
++	ret = devm_mutex_init(dev, &mcu->reply_lock);
++	if (ret)
++		return ret;
++	ret = devm_mutex_init(dev, &mcu->lock);
++	if (ret)
++		return ret;
 +
 +	/* Setup UART interface */
 +	serdev_device_set_drvdata(serdev, mcu);

--- a/target/linux/mvebu/patches-6.6/903-drivers-hwmon-Add-the-IEI-WT61P803-PUZZLE-HWMON-driv.patch
+++ b/target/linux/mvebu/patches-6.6/903-drivers-hwmon-Add-the-IEI-WT61P803-PUZZLE-HWMON-driv.patch
@@ -53,7 +53,7 @@ Cc: Robert Marko <robert.marko@sartura.hr>
  obj-$(CONFIG_SENSORS_IBMPOWERNV)+= ibmpowernv.o
 --- /dev/null
 +++ b/drivers/hwmon/iei-wt61p803-puzzle-hwmon.c
-@@ -0,0 +1,445 @@
+@@ -0,0 +1,447 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/* IEI WT61P803 PUZZLE MCU HWMON Driver
 + *
@@ -457,7 +457,9 @@ Cc: Robert Marko <robert.marko@sartura.hr>
 +
 +	mcu_hwmon->mcu = mcu;
 +	platform_set_drvdata(pdev, mcu_hwmon);
-+	mutex_init(&mcu_hwmon->lock);
++	ret = devm_mutex_init(dev, &mcu_hwmon->lock);
++	if (ret)
++		return ret;
 +
 +	hwmon_dev = devm_hwmon_device_register_with_info(dev, "iei_wt61p803_puzzle",
 +							 mcu_hwmon,

--- a/target/linux/mvebu/patches-6.6/910-drivers-leds-wt61p803-puzzle-improvements.patch
+++ b/target/linux/mvebu/patches-6.6/910-drivers-leds-wt61p803-puzzle-improvements.patch
@@ -47,7 +47,7 @@
  
  	ret = iei_wt61p803_puzzle_write_command(priv->mcu, led_power_cmd,
  						sizeof(led_power_cmd),
-@@ -90,39 +106,166 @@ static enum led_brightness iei_wt61p803_
+@@ -90,39 +106,168 @@ static enum led_brightness iei_wt61p803_
  	return led_state;
  }
  
@@ -194,7 +194,9 @@
 +			goto put_child_node;
 +		}
 +
-+		mutex_init(&priv->lock);
++		ret = devm_mutex_init(dev, &priv->lock);
++		if (ret)
++			goto put_child_node;
 +
 +		dev_set_drvdata(dev, priv);
 +


### PR DESCRIPTION
It's common to avoid calling mutex_destroy when done. It's not correct strictly speaking.

ping @robimarko @hauke 