### PR TITLE
ipq806x: fix MAC address on Meraki MR52 and MR42 after nvmem-layout

### DIFF
--- a/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8068-mr42.dts
+++ b/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8068-mr42.dts
@@ -58,7 +58,7 @@
 	phy-mode = "sgmii";
 	phy-handle = <&phy2>;
 
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -84,11 +84,16 @@
 		pagesize = <32>;
 		reg = <0x56>;
 		read-only;
-		#address-cells = <1>;
-		#size-cells = <1>;
 
-		mac_address: mac-address@66 {
-			reg = <0x66 0x6>;
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			mac_address: mac-address@66 {
+				compatible = "mac-base";
+				reg = <0x66 0x6>;
+				#nvmem-cell-cells = <1>;
+			};
 		};
 	};
 };
@@ -186,21 +191,18 @@
 };
 
 &wifi0 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &wifi1 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 2>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <2>;
 };
 
 &wifi2 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 3>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <3>;
 };
 
 &hs_phy_0 {

--- a/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8068-mr52.dts
+++ b/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8068-mr52.dts
@@ -80,7 +80,7 @@
 	phy-mode = "sgmii";
 	phy-handle = <&phy0>;
 
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -93,9 +93,8 @@
 	phy-mode = "sgmii";
 	phy-handle = <&phy4>;
 
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &gsbi7 {
@@ -142,11 +141,16 @@
 		pagesize = <32>;
 		reg = <0x52>;
 		read-only;
-		#address-cells = <1>;
-		#size-cells = <1>;
 
-		mac_address: mac-address@66 {
-			reg = <0x66 0x6>;
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			mac_address: mac-address@66 {
+				compatible = "mac-base";
+				reg = <0x66 0x6>;
+				#nvmem-cell-cells = <1>;
+			};
 		};
 	};
 };
@@ -212,21 +216,18 @@
 };
 
 &wifi0 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 4>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <4>;
 };
 
 &wifi1 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 3>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <3>;
 };
 
 &wifi2 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 2>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <2>;
 };
 
 &hs_phy_0 {


### PR DESCRIPTION
Based on similar fixes in https://github.com/openwrt/openwrt/pull/16624

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
