### PR TITLE
mbedtls: update to 3.6.2

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=3.6.1
+PKG_VERSION:=3.6.2
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL=https://github.com/Mbed-TLS/$(PKG_NAME)/releases/download/$(PKG_NAME)-$(PKG_VERSION)
-PKG_HASH:=fc8bef0991b43629b7e5319de6f34f13359011105e08e3e16eed3a9fe6ffd3a3
+PKG_HASH:=8b54fb9bcf4d5a7078028e0520acddefb7900b3e66fec7f7175bb5b7d85ccdca
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Fixes the following security problem:
* CVE-2024-49195: Fix a buffer underrun in mbedtls_pk_write_key_der() when called on an opaque key, MBEDTLS_USE_PSA_CRYPTO is enabled, and the output buffer is smaller than the actual output. Fix a related buffer underrun in mbedtls_pk_write_key_pem() when called on an opaque RSA key, MBEDTLS_USE_PSA_CRYPTO is enabled and MBEDTLS_MPI_MAX_SIZE is smaller than needed for a 4096-bit RSA key.

I used LuCI with https in mips malta 32 BE and also used wget.