### PR TITLE
ramips: use platform_get_irq

### DIFF
--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
@@ -1396,7 +1396,7 @@ static int esw_probe(struct platform_device *pdev)
 		return -ENOMEM;
 
 	esw->dev = &pdev->dev;
-	esw->irq = irq_of_parse_and_map(np, 0);
+	esw->irq = platform_get_irq(pdev, 0);
 	esw->base = devm_platform_ioremap_resource(pdev, 0);
 	if (IS_ERR(esw->base))
 		return PTR_ERR(esw->base);


### PR DESCRIPTION
No need for irq_of_parse_and_map since this is in _probe.