### PR TITLE
ipq806x: Fix default MAC addresses on MR52 by moving to `nvmem-layout`

### DIFF
--- a/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8068-mr52.dts
+++ b/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8068-mr52.dts
@@ -80,7 +80,7 @@
 	phy-mode = "sgmii";
 	phy-handle = <&phy0>;
 
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -93,9 +93,8 @@
 	phy-mode = "sgmii";
 	phy-handle = <&phy4>;
 
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &gsbi7 {
@@ -142,11 +141,17 @@
 		pagesize = <32>;
 		reg = <0x52>;
 		read-only;
-		#address-cells = <1>;
-		#size-cells = <1>;
 
-		mac_address: mac-address@66 {
-			reg = <0x66 0x6>;
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			mac_address: mac-address@66 {
+				compatible = "mac-base";
+				reg = <0x66 0x6>;
+				#nvmem-cell-cells = <1>;
+			};
 		};
 	};
 };
@@ -212,21 +217,18 @@
 };
 
 &wifi0 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 4>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <4>;
 };
 
 &wifi1 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 3>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <3>;
 };
 
 &wifi2 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 2>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <2>;
 };
 
 &hs_phy_0 {


### PR DESCRIPTION
ipq806x: Fix default MAC addresses on MR52 by moving to `nvmem-layout`

Partial, single-target update extracted from [openwrt#d264d3a6](https://github.com/openwrt/openwrt/commit/d264d3a6)

The previous `mac-address-increment` is deprecated, and in particular on
this target means that the kernel is unable to read the MAC address,
causing the system to boot with a new random MAC address each time.

Fixes: https://github.com/openwrt/openwrt/issues/15238

Signed-off-by: Rosen Penev <rosenp@gmail.com>
[rafal.boni@gmail.com: single-target-specific backport from larger change]
Signed-off-by: Rafal Boni <rafal.boni@gmail.com>