### PR TITLE
Revert "ipq806x: swap lan leds for Meraki MR52"

### DIFF
--- a/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8068-mr52.dts
+++ b/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8068-mr52.dts
@@ -46,12 +46,12 @@
 
 		lan1_green {
 			label = "green:lan1";
-			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
+			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_HIGH>;
 		};
 
 		lan2_green {
 			label = "green:lan2";
-			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_HIGH>;
+			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_active: active {
@@ -61,12 +61,12 @@
 
 		lan1_orange {
 			label = "orange:lan1";
-			gpios = <&qcom_pinmux 60 GPIO_ACTIVE_HIGH>;
+			gpios = <&qcom_pinmux 62 GPIO_ACTIVE_HIGH>;
 		};
 
 		lan2_orange {
 			label = "orange:lan2";
-			gpios = <&qcom_pinmux 62 GPIO_ACTIVE_HIGH>;
+			gpios = <&qcom_pinmux 60 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };


### PR DESCRIPTION
This reverts commit ec8f647d168fa8f3b1eedd9b5fe665f793f3a659, as with the current kernel version, the change actually causes the same bug it once may have fixed -- that is, the leds are now again reversed.

I suspect this was due to a switch to a newer kernel version between when the patch was submitted and now reversing the order of the interfaces, so that eth0 / the LAN interface is also the interface used for PoE, and eth1 / the WAN interface is the non-PoE interface.