### PR TITLE
mikrotik: mtdsplit_minor: return 0 if not fatal, and accept filename "bootimage"

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_minor.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_minor.c
@@ -61,29 +61,43 @@ static int mtdsplit_parse_minor(struct mtd_info *master,
 
 	hdr_len = sizeof(hdr);
 	err = mtd_read(master, 0, hdr_len, &retlen, (void *) &hdr);
-	if (err)
+	if (err) {
+		pr_err("MiNOR mtd_read error: %d\n", err);
 		return err;
+	}
 
-	if (retlen != hdr_len)
+	if (retlen != hdr_len) {
+		pr_err("MiNOR mtd_read too short\n");
 		return -EIO;
+	}
 
 	/* match header */
-	if (hdr.yaffs_type != YAFFS_OBJECT_TYPE_FILE)
-		return -EINVAL;
+	if (hdr.yaffs_type != YAFFS_OBJECT_TYPE_FILE) {
+		pr_info("MiNOR YAFFS first type not matched\n");
+		return 0;
+	}
 
-	if (hdr.yaffs_obj_id != YAFFS_OBJECTID_ROOT)
-		return -EINVAL;
+	if (hdr.yaffs_obj_id != YAFFS_OBJECTID_ROOT) {
+		pr_info("MiNOR YAFFS first objectid not matched\n");
+		return 0;
+	}
 
-	if (hdr.yaffs_sum_unused != YAFFS_SUM_UNUSED)
-		return -EINVAL;
+	if (hdr.yaffs_sum_unused != YAFFS_SUM_UNUSED) {
+		pr_info("MiNOR YAFFS first sum not matched\n");
+		return 0;
+	}
 
-	if (memcmp(hdr.yaffs_name, YAFFS_NAME, sizeof(YAFFS_NAME)))
-		return -EINVAL;
+	if (memcmp(hdr.yaffs_name, YAFFS_NAME, sizeof(YAFFS_NAME))) {
+		pr_info("MiNOR YAFFS first name not matched\n");
+		return 0;
+	}
 
 	err = mtd_find_rootfs_from(master, master->erasesize, master->size,
 				   &rootfs_offset, NULL);
-	if (err)
-		return err;
+	if (err) {
+		pr_info("MiNOR mtd_find_rootfs_from error: %d\n", err);
+		return 0;
+	}
 
 	parts = kzalloc(MINOR_NR_PARTS * sizeof(*parts), GFP_KERNEL);
 	if (!parts)

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_minor.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_minor.c
@@ -34,7 +34,9 @@
 #define YAFFS_OBJECT_TYPE_FILE	0x1
 #define YAFFS_OBJECTID_ROOT	0x1
 #define YAFFS_SUM_UNUSED	0xFFFF
-#define YAFFS_NAME		"kernel"
+#define YAFFS_MAX_NAME_LENGTH	127
+#define YAFFS_NAME_KERNEL	"kernel"
+#define YAFFS_NAME_BOOTIMAGE	"bootimage"
 
 #define MINOR_NR_PARTS		2
 
@@ -46,7 +48,7 @@ struct minor_header {
 	int yaffs_type;
 	int yaffs_obj_id;
 	u16 yaffs_sum_unused;
-	char yaffs_name[sizeof(YAFFS_NAME)];
+	char yaffs_name[YAFFS_MAX_NAME_LENGTH];
 };
 
 static int mtdsplit_parse_minor(struct mtd_info *master,
@@ -87,7 +89,8 @@ static int mtdsplit_parse_minor(struct mtd_info *master,
 		return 0;
 	}
 
-	if (memcmp(hdr.yaffs_name, YAFFS_NAME, sizeof(YAFFS_NAME))) {
+	if ((memcmp(hdr.yaffs_name, YAFFS_NAME_KERNEL, sizeof(YAFFS_NAME_KERNEL))) &&
+	    (memcmp(hdr.yaffs_name, YAFFS_NAME_BOOTIMAGE, sizeof(YAFFS_NAME_BOOTIMAGE)))) {
 		pr_info("MiNOR YAFFS first name not matched\n");
 		return 0;
 	}


### PR DESCRIPTION
Adjust mtdsplit_minor so that it only returns an error if something fatal happens. This is required for Linux 6.7+: https://github.com/torvalds/linux/commit/5c2f7727d437

Secondly, accept the YAFFS filename `bootimage`.
This is the (Linux OpenWrt) kernel change needed for RouterBOOTv7 NOR `bootimage` to work, otherwise mtdsplit_minor will not partition to the rootfs.
With this inplace, building a RouterBOOTv7 NOR compatible image is just packing the file, which can be done later in ImageBuilder, once a process has been tidied and finalised.

@f00b4r0 @kempniu @robimarko 

---

Background:
mtdsplit_minor does very minimal checks at the start of the firmware partition to test that these bytes match what is expected for a Mikrotik NOR device with an OpenWrt kernel written to it (YAFFS filesystem with `kernel` filename in the first YAFFS object block). If successful, it then uses the OpenWrt downstream kernel function [`mtd_find_rootfs_from`](https://github.com/openwrt/openwrt/blob/27657050d02f13d1e737293ac7ad08686b4c6fd3/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit.c#L108) to walk through the NOR to find the OpenWrt rootfs magic.

RouterBOOT v7 on NOR devices no longer works with YAFFS `kernel` ELF boot. Analysis of OEM firmware on NOR found that an NPK (fairly well known Mikrotik image format) is instead copied to `bootimage` filename on YAFFS. This file is very similar to the Mikrotik (Downloads) main (upgrade) package, with some changes to the squashfs container on NOR.

An existing NPK library (https://github.com/botlabsDev/npkpy) was modified and used to test and help trial and error which parts of the NOR NPK mattered to boot a kernel, and what the minimum NPK looked like.
(Long time ago, and very rough notes, I believe this was) kernel sits ZLIB encoded within the NPK file container block. This need to detail `boot` folder, `boot/kernel` (our kernel ELF) file, and `UPGRADED` file, but there must be a squashfs block to a 0x1000 byte boundary beforehand.
Could confirm through decompiling RouterBOOT, or additional trial and error.

A rough proof of concept was put together using this tool: https://github.com/john-tho/npkpy/blob/create-npk/tools/demo_pack_kernel/poc_pack_kernel.py, integrated to OpenWrt: https://github.com/john-tho/openwrt/pull/7, but it needs more work before it could be used in the OpenWrt build system (ideally someone build a simple tool specifically to pack OpenWrt kernel to NPK).

This NPK bootimage boot method does work for RouterBOOT v6 NOR devices as well.