### PR TITLE
Kroks: bring model names to correspondence with Wiki

### DIFF
--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -521,7 +521,7 @@ TARGET_DEVICES += keenetic_kn-3211
 define Device/kroks_kndrt31r16
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Kroks
-  DEVICE_MODEL := Rt-Cse5 UW DRSIM
+  DEVICE_MODEL := Rt-Cse SIM Injector DS
   DEVICE_ALT0_VENDOR := Kroks
   DEVICE_ALT0_MODEL := KNdRt31R16
   DEVICE_PACKAGES := kmod-usb2
@@ -532,7 +532,7 @@ TARGET_DEVICES += kroks_kndrt31r16
 define Device/kroks_kndrt31r19
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Kroks
-  DEVICE_MODEL := Rt-Pot mXw DS RSIM
+  DEVICE_MODEL := Rt-Brd RSIM DS eQ-EP
   DEVICE_ALT0_VENDOR := Kroks
   DEVICE_ALT0_MODEL := KNdRt31R19
   DEVICE_PACKAGES := kmod-usb2 uqmi


### PR DESCRIPTION
The Wiki pages contain actual data for the model names:
https://openwrt.org/toh/hwdata/kroks/kroks_rt-cse
https://openwrt.org/toh/hwdata/kroks/kroks_rt-pot-mxw