### PR TITLE
kernel: enable Multi-Path TCP for !SMALL_FLASH targets

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1204,6 +1204,20 @@ config KERNEL_PAGE_POOL_STATS
 	bool "Page pool stats support"
 	depends on KERNEL_PAGE_POOL
 
+config KERNEL_MPTCP
+	bool "Multi-Path TCP support"
+	default y if !SMALL_FLASH
+	help
+	   Select this option to enable support for Multi-Path TCP.
+	   Increases the compressed kernel size by ~214kB (as of Linux 6.6).
+
+if KERNEL_IPV6
+config KERNEL_MPTCP_IPV6
+	bool "IPv6 support for Multipath TCP"
+	depends on KERNEL_MPTCP
+	default KERNEL_MPTCP
+endif
+
 #
 # NFS related symbols
 #

--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -1494,6 +1494,23 @@ endef
 $(eval $(call KernelPackage,inet-diag))
 
 
+define KernelPackage/inet-mptcp-diag
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
+  TITLE:=INET diag support for MultiPath TCP
+  DEPENDS:=@KERNEL_MPTCP +kmod-inet-diag
+  KCONFIG:=CONFIG_INET_MPTCP_DIAG
+  FILES:=$(LINUX_DIR)/net/mptcp/mptcp_diag.ko
+  AUTOLOAD:=$(call AutoProbe,mptcp_diag)
+endef
+
+define KernelPackage/inet-mptcp-diag/description
+Support for INET (MultiPath TCP) socket monitoring interface used by
+native Linux tools such as ss.
+endef
+
+$(eval $(call KernelPackage,inet-mptcp-diag))
+
+
 define KernelPackage/xdp-sockets-diag
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=PF_XDP sockets monitoring interface support for ss utility


### PR DESCRIPTION
Expose Kernel's CONFIG_MPTCP option and enable it by default for !SMALL_FLASH targets.