### PR TITLE
xdp-tools: fix compilation when bpftool is installed

### DIFF
--- a/package/network/utils/xdp-tools/Makefile
+++ b/package/network/utils/xdp-tools/Makefile
@@ -87,7 +87,8 @@ CONFIGURE_VARS += \
 	CLANG="$(CLANG)" \
 	BPF_TARGET="$(BPF_ARCH)-linux-gnu" \
 	LLC="$(LLVM_LLC)" \
-	BPF_LDFLAGS="-march=$(BPF_TARGET) -mcpu=v3"
+	BPF_LDFLAGS="-march=$(BPF_TARGET) -mcpu=v3" \
+	BPFTOOL=""
 
 ifneq ($(findstring s,$(OPENWRT_VERBOSE)),)
 	MAKE_FLAGS+=V=1


### PR DESCRIPTION
Currently, `xdp-tools` doesn't compile on build systems where `bpftool` is installed because additional tools and BPF programs will be compiled then, which results in build errors.

This commit disables the compilation of those `bpftool`-dependent tools.
Additionally, it drops a patch to re-add the `vlan_hdr` struct because it is required for building `xdp-filter`.

This should fix #16320.

It's currently not possible to always build the `bpftool`-dependent tools because the latest release version 7.4 of `bpftool` cannot open BPF objects that don't match the host's endianness.
But this will be possible soon, as support was merged into their main branch recently: https://github.com/libbpf/bpftool/issues/81.