### PR TITLE
uboot-mediatek: enable LED boot and activity for OpenWrt One

### DIFF
--- a/package/boot/uboot-mediatek/patches/001-01-led-toggle-LED-on-initial-SW-blink.patch
+++ b/package/boot/uboot-mediatek/patches/001-01-led-toggle-LED-on-initial-SW-blink.patch
@@ -1,0 +1,43 @@
+From 5e1d4a8ca75cbb66e88ee2dc9d90f132ac3febe2 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Wed, 7 Aug 2024 13:33:10 +0200
+Subject: [PATCH 01/11] led: toggle LED on initial SW blink
+
+We currently init the LED OFF when SW blink is triggered when
+on_state_change() is called. This can be problematic for very short
+period as the ON/OFF blink might never trigger.
+
+Toggle the LED (ON if OFF, OFF if ON) on initial SW blink to handle this
+corner case and better display a LED blink from the user.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/led/led_sw_blink.c | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
+
+--- a/drivers/led/led_sw_blink.c
++++ b/drivers/led/led_sw_blink.c
+@@ -103,8 +103,21 @@ bool led_sw_on_state_change(struct udevi
+ 		return false;
+ 
+ 	if (state == LEDST_BLINK) {
+-		/* start blinking on next led_sw_blink() call */
+-		sw_blink->state = LED_SW_BLINK_ST_OFF;
++		struct led_ops *ops = led_get_ops(dev);
++
++		/*
++		 * toggle LED initially and start blinking on next
++		 * led_sw_blink() call.
++		 */
++		switch (ops->get_state(dev)) {
++		case LEDST_ON:
++			ops->set_state(dev, LEDST_OFF);
++			sw_blink->state = LED_SW_BLINK_ST_OFF;
++		default:
++			ops->set_state(dev, LEDST_ON);
++			sw_blink->state = LED_SW_BLINK_ST_ON;
++		}
++
+ 		return true;
+ 	}
+ 

--- a/package/boot/uboot-mediatek/patches/001-02-dm-core-implement-ofnode_options-helpers.patch
+++ b/package/boot/uboot-mediatek/patches/001-02-dm-core-implement-ofnode_options-helpers.patch
@@ -1,0 +1,109 @@
+From cb4e18350a434d2d8b71e15fcae3c35e6575c581 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Thu, 19 Sep 2024 21:15:57 +0200
+Subject: [PATCH 02/11] dm: core: implement ofnode_options helpers
+
+Implement ofnode_options helpers to read options in /options/u-boot to
+adapt to the new way to declare options as described in [1].
+
+[1] dtschema/schemas/options/u-boot.yaml
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+Reviewed-by: Simon Glass <sjg@chromium.org>
+---
+ drivers/core/ofnode.c | 33 +++++++++++++++++++++++++++++++++
+ include/dm/ofnode.h   | 41 +++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 74 insertions(+)
+
+--- a/drivers/core/ofnode.c
++++ b/drivers/core/ofnode.c
+@@ -1734,6 +1734,39 @@ const char *ofnode_conf_read_str(const c
+ 	return ofnode_read_string(node, prop_name);
+ }
+ 
++bool ofnode_options_read_bool(const char *prop_name)
++{
++	ofnode uboot;
++
++	uboot = ofnode_path("/options/u-boot");
++	if (!ofnode_valid(uboot))
++		return false;
++
++	return ofnode_read_bool(uboot, prop_name);
++}
++
++int ofnode_options_read_int(const char *prop_name, int default_val)
++{
++	ofnode uboot;
++
++	uboot = ofnode_path("/options/u-boot");
++	if (!ofnode_valid(uboot))
++		return default_val;
++
++	return ofnode_read_u32_default(uboot, prop_name, default_val);
++}
++
++const char *ofnode_options_read_str(const char *prop_name)
++{
++	ofnode uboot;
++
++	uboot = ofnode_path("/options/u-boot");
++	if (!ofnode_valid(uboot))
++		return NULL;
++
++	return ofnode_read_string(uboot, prop_name);
++}
++
+ int ofnode_read_bootscript_address(u64 *bootscr_address, u64 *bootscr_offset)
+ {
+ 	int ret;
+--- a/include/dm/ofnode.h
++++ b/include/dm/ofnode.h
+@@ -1588,6 +1588,47 @@ int ofnode_conf_read_int(const char *pro
+ const char *ofnode_conf_read_str(const char *prop_name);
+ 
+ /**
++ * ofnode_options_read_bool() - Read a boolean value from the U-Boot options
++ *
++ * This reads a property from the /options/u-boot/ node of the devicetree.
++ *
++ * This only works with the control FDT.
++ *
++ * See dtschema/schemas/options/u-boot.yaml in dt-schema project for bindings
++ *
++ * @prop_name:	property name to look up
++ * Return: true, if it exists, false if not
++ */
++bool ofnode_options_read_bool(const char *prop_name);
++
++/**
++ * ofnode_options_read_int() - Read an integer value from the U-Boot options
++ *
++ * This reads a property from the /options/u-boot/ node of the devicetree.
++ *
++ * See dtschema/schemas/options/u-boot.yaml in dt-schema project for bindings
++ *
++ * @prop_name: property name to look up
++ * @default_val: default value to return if the property is not found
++ * Return: integer value, if found, or @default_val if not
++ */
++int ofnode_options_read_int(const char *prop_name, int default_val);
++
++/**
++ * ofnode_options_read_str() - Read a string value from the U-Boot options
++ *
++ * This reads a property from the /options/u-boot/ node of the devicetree.
++ *
++ * This only works with the control FDT.
++ *
++ * See dtschema/schemas/options/u-boot.yaml in dt-schema project for bindings
++ *
++ * @prop_name: property name to look up
++ * Return: string value, if found, or NULL if not
++ */
++const char *ofnode_options_read_str(const char *prop_name);
++
++/**
+  * ofnode_read_bootscript_address() - Read bootscr-address or bootscr-ram-offset
+  *
+  * @bootscr_address: pointer to 64bit address where bootscr-address property value

--- a/package/boot/uboot-mediatek/patches/001-03-led-implement-LED-boot-API.patch
+++ b/package/boot/uboot-mediatek/patches/001-03-led-implement-LED-boot-API.patch
@@ -1,0 +1,235 @@
+From 431ebb379cad737e1e6ac9224573a09be1111cf5 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Sun, 23 Jun 2024 19:37:15 +0200
+Subject: [PATCH 03/11] led: implement LED boot API
+
+Implement LED boot API to signal correct boot of the system.
+
+led_boot_on/off/blink() are introduced to turn ON, OFF and BLINK the
+designated boot LED.
+
+New Kconfig is introduced, CONFIG_LED_BOOT to enable the feature.
+This makes use of the /options/u-boot property "boot-led" to the
+define the boot LED.
+It's also introduced a new /options/u-boot property "boot-led-period"
+to define the default period when the LED is set to blink mode.
+
+If "boot-led-period" is not defined, the value of 250 (ms) is
+used by default.
+
+If CONFIG_LED_BLINK or CONFIG_LED_SW_BLINK is not enabled,
+led_boot_blink call will fallback to simple LED ON.
+
+To cache the data we repurpose the now unused led_uc_priv for storage of
+global LED uclass info.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/led/Kconfig      | 11 ++++++
+ drivers/led/led-uclass.c | 85 ++++++++++++++++++++++++++++++++++++++++
+ include/led.h            | 55 +++++++++++++++++++++++++-
+ 3 files changed, 149 insertions(+), 2 deletions(-)
+
+--- a/drivers/led/Kconfig
++++ b/drivers/led/Kconfig
+@@ -9,6 +9,17 @@ config LED
+ 	  can provide access to board-specific LEDs. Use of the device tree
+ 	  for configuration is encouraged.
+ 
++config LED_BOOT
++	bool "Enable LED boot support"
++	help
++	  Enable LED boot support.
++
++	  LED boot is a specific LED assigned to signal boot operation status.
++	  Defined in Device Tree /options/u-boot node. Refer here for the supported
++	  options [1].
++
++	  [1] dtschema/schemas/options/u-boot.yaml
++
+ config LED_BCM6328
+ 	bool "LED Support for BCM6328"
+ 	depends on LED && ARCH_BMIPS
+--- a/drivers/led/led-uclass.c
++++ b/drivers/led/led-uclass.c
+@@ -94,6 +94,75 @@ int led_set_period(struct udevice *dev,
+ 	return -ENOSYS;
+ }
+ 
++#ifdef CONFIG_LED_BOOT
++static int led_boot_get(struct udevice **devp, int *period_ms)
++{
++	struct led_uc_priv *priv;
++	struct uclass *uc;
++	int ret;
++
++	ret = uclass_get(UCLASS_LED, &uc);
++	if (ret)
++		return ret;
++
++	priv = uclass_get_priv(uc);
++	if (!priv->boot_led_label)
++		return -ENOENT;
++
++	if (period_ms)
++		*period_ms = priv->boot_led_period;
++
++	return led_get_by_label(priv->boot_led_label, devp);
++}
++
++int led_boot_on(void)
++{
++	struct udevice *dev;
++	int ret;
++
++	ret = led_boot_get(&dev, NULL);
++	if (ret)
++		return ret;
++
++	return led_set_state(dev, LEDST_ON);
++}
++
++int led_boot_off(void)
++{
++	struct udevice *dev;
++	int ret;
++
++	ret = led_boot_get(&dev, NULL);
++	if (ret)
++		return ret;
++
++	return led_set_state(dev, LEDST_OFF);
++}
++
++#if defined(CONFIG_LED_BLINK) || defined(CONFIG_LED_SW_BLINK)
++int led_boot_blink(void)
++{
++	struct udevice *dev;
++	int period_ms, ret;
++
++	ret = led_boot_get(&dev, &period_ms);
++	if (ret)
++		return ret;
++
++	ret = led_set_period(dev, period_ms);
++	if (ret) {
++		if (ret != -ENOSYS)
++			return ret;
++
++		/* fallback to ON with no set_period and no SW_BLINK */
++		return led_set_state(dev, LEDST_ON);
++	}
++
++	return led_set_state(dev, LEDST_BLINK);
++}
++#endif
++#endif
++
+ static int led_post_bind(struct udevice *dev)
+ {
+ 	struct led_uc_plat *uc_plat = dev_get_uclass_plat(dev);
+@@ -158,10 +227,26 @@ static int led_post_probe(struct udevice
+ 	return ret;
+ }
+ 
++#ifdef CONFIG_LED_BOOT
++static int led_init(struct uclass *uc)
++{
++	struct led_uc_priv *priv = uclass_get_priv(uc);
++
++	priv->boot_led_label = ofnode_options_read_str("boot-led");
++	priv->boot_led_period = ofnode_options_read_int("boot-led-period", 250);
++
++	return 0;
++}
++#endif
++
+ UCLASS_DRIVER(led) = {
+ 	.id		= UCLASS_LED,
+ 	.name		= "led",
+ 	.per_device_plat_auto	= sizeof(struct led_uc_plat),
+ 	.post_bind	= led_post_bind,
+ 	.post_probe	= led_post_probe,
++#ifdef CONFIG_LED_BOOT
++	.init		= led_init,
++	.priv_auto	= sizeof(struct led_uc_priv),
++#endif
+ };
+--- a/include/led.h
++++ b/include/led.h
+@@ -9,6 +9,7 @@
+ 
+ #include <stdbool.h>
+ #include <cyclic.h>
++#include <dm/ofnode.h>
+ 
+ struct udevice;
+ 
+@@ -52,10 +53,15 @@ struct led_uc_plat {
+ /**
+  * struct led_uc_priv - Private data the uclass stores about each device
+  *
+- * @period_ms:	Flash period in milliseconds
++ * @boot_led_label:	Boot LED label
++ * @boot_led_dev:	Boot LED dev
++ * @boot_led_period:	Boot LED blink period
+  */
+ struct led_uc_priv {
+-	int period_ms;
++#ifdef CONFIG_LED_BOOT
++	const char *boot_led_label;
++	int boot_led_period;
++#endif
+ };
+ 
+ struct led_ops {
+@@ -141,4 +147,49 @@ int led_sw_set_period(struct udevice *de
+ bool led_sw_is_blinking(struct udevice *dev);
+ bool led_sw_on_state_change(struct udevice *dev, enum led_state_t state);
+ 
++#ifdef CONFIG_LED_BOOT
++
++/**
++ * led_boot_on() - turn ON the designated LED for booting
++ *
++ * Return: 0 if OK, -ve on error
++ */
++int led_boot_on(void);
++
++/**
++ * led_boot_off() - turn OFF the designated LED for booting
++ *
++ * Return: 0 if OK, -ve on error
++ */
++int led_boot_off(void);
++
++#if defined(CONFIG_LED_BLINK) || defined(CONFIG_LED_SW_BLINK)
++/**
++ * led_boot_blink() - turn ON the designated LED for booting
++ *
++ * Return: 0 if OK, -ve on error
++ */
++int led_boot_blink(void);
++
++#else
++/* If LED BLINK is not supported/enabled, fallback to LED ON */
++#define led_boot_blink led_boot_on
++#endif
++#else
++static inline int led_boot_on(void)
++{
++	return -ENOSYS;
++}
++
++static inline int led_boot_off(void)
++{
++	return -ENOSYS;
++}
++
++static inline int led_boot_blink(void)
++{
++	return -ENOSYS;
++}
++#endif
++
+ #endif

--- a/package/boot/uboot-mediatek/patches/001-04-common-board_r-rework-BOOT-LED-handling.patch
+++ b/package/boot/uboot-mediatek/patches/001-04-common-board_r-rework-BOOT-LED-handling.patch
@@ -1,0 +1,116 @@
+From be828879abedba69df35bc0cf5e0f71ca67756ac Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Sun, 23 Jun 2024 21:59:30 +0200
+Subject: [PATCH 04/11] common: board_r: rework BOOT LED handling
+
+Rework BOOT LED handling. There is currently one legacy implementation
+for BOOT LED from Status Led API.
+
+This work on ancient implementation used by BOOTP by setting the LED
+to Blink on boot and to turn it OFF when the firmware was correctly
+received by network.
+
+Now that we new LED implementation have support for LED boot, rework
+this by also set the new BOOT LED to blink and also set it to ON before
+entering main loop to confirm successful boot.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+Reviewed-by: Simon Glass <sjg@chromium.org>
+---
+ common/board_r.c     | 28 ++++++++++++++++++++--------
+ include/status_led.h | 13 +++++++++++++
+ 2 files changed, 33 insertions(+), 8 deletions(-)
+
+--- a/common/board_r.c
++++ b/common/board_r.c
+@@ -39,6 +39,7 @@
+ #include <initcall.h>
+ #include <kgdb.h>
+ #include <irq_func.h>
++#include <led.h>
+ #include <malloc.h>
+ #include <mapmem.h>
+ #include <miiphy.h>
+@@ -459,17 +460,28 @@ static int initr_malloc_bootparams(void)
+ }
+ #endif
+ 
+-#if defined(CONFIG_LED_STATUS)
+ static int initr_status_led(void)
+ {
+-#if defined(CONFIG_LED_STATUS_BOOT)
+-	status_led_set(CONFIG_LED_STATUS_BOOT, CONFIG_LED_STATUS_BLINKING);
+-#else
+ 	status_led_init();
+-#endif
++
++	return 0;
++}
++
++static int initr_boot_led_blink(void)
++{
++	status_led_boot_blink();
++
++	led_boot_blink();
++
++	return 0;
++}
++
++static int initr_boot_led_on(void)
++{
++	led_boot_on();
++
+ 	return 0;
+ }
+-#endif
+ 
+ #ifdef CONFIG_CMD_NET
+ static int initr_net(void)
+@@ -713,9 +725,8 @@ static init_fnc_t init_sequence_r[] = {
+ #if defined(CONFIG_MICROBLAZE) || defined(CONFIG_M68K)
+ 	timer_init,		/* initialize timer */
+ #endif
+-#if defined(CONFIG_LED_STATUS)
+ 	initr_status_led,
+-#endif
++	initr_boot_led_blink,
+ 	/* PPC has a udelay(20) here dating from 2002. Why? */
+ #ifdef CONFIG_BOARD_LATE_INIT
+ 	board_late_init,
+@@ -738,6 +749,7 @@ static init_fnc_t init_sequence_r[] = {
+ #if defined(CFG_PRAM)
+ 	initr_mem,
+ #endif
++	initr_boot_led_on,
+ 	run_main_loop,
+ };
+ 
+--- a/include/status_led.h
++++ b/include/status_led.h
+@@ -39,6 +39,13 @@ void status_led_init(void);
+ void status_led_tick(unsigned long timestamp);
+ void status_led_set(int led, int state);
+ 
++static inline void status_led_boot_blink(void)
++{
++#ifdef CONFIG_LED_STATUS_BOOT_ENABLE
++	status_led_set(CONFIG_LED_STATUS_BOOT, CONFIG_LED_STATUS_BLINKING);
++#endif
++}
++
+ /*****  MVS v1  **********************************************************/
+ #if (defined(CONFIG_MVS) && CONFIG_MVS < 2)
+ # define STATUS_LED_PAR		im_ioport.iop_pdpar
+@@ -72,6 +79,12 @@ void __led_blink(led_id_t mask, int freq
+ # include <asm/status_led.h>
+ #endif
+ 
++#else
++
++static inline void status_led_init(void) { }
++static inline void status_led_set(int led, int state) { }
++static inline void status_led_boot_blink(void) { }
++
+ #endif	/* CONFIG_LED_STATUS	*/
+ 
+ /*

--- a/package/boot/uboot-mediatek/patches/001-05-led-implement-LED-activity-API.patch
+++ b/package/boot/uboot-mediatek/patches/001-05-led-implement-LED-activity-API.patch
@@ -1,0 +1,239 @@
+From 5e8228346d1e4bf6a260a57905dcb062a43c9819 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Sun, 23 Jun 2024 22:12:05 +0200
+Subject: [PATCH 05/11] led: implement LED activity API
+
+Implement LED activity API similar to BOOT LED API.
+
+Usual activity might be a file transfer with TFTP, a flash write...
+
+User of this API will call led_activity_on/off/blink() to signal these
+kind of activity.
+
+New Kconfig is implemented similar to BOOT LED, LED_ACTIVITY to
+enable support for it.
+
+It's introduced a new /options/u-boot property "activity-led" and
+"activity-led-period" to define the activity LED label and the
+default period when the activity LED is set to blink mode.
+
+If "activity-led-period" is not defined, the value of 250 (ms) is
+used by default.
+
+If CONFIG_LED_BLINK or CONFIG_LED_SW_BLINK is not enabled,
+led_boot_blink call will fallback to simple LED ON.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/led/Kconfig      | 13 +++++++
+ drivers/led/led-uclass.c | 81 +++++++++++++++++++++++++++++++++++++++-
+ include/led.h            | 51 +++++++++++++++++++++++++
+ 3 files changed, 143 insertions(+), 2 deletions(-)
+
+--- a/drivers/led/Kconfig
++++ b/drivers/led/Kconfig
+@@ -20,6 +20,19 @@ config LED_BOOT
+ 
+ 	  [1] dtschema/schemas/options/u-boot.yaml
+ 
++config LED_ACTIVITY
++	bool "Enable LED activity support"
++	help
++	  Enable LED activity support.
++
++	  LED activity is a specific LED assigned to signal activity operation
++	  like file trasnfer, flash write/erase...
++
++	  Defined in Device Tree /options/u-boot node. Refer here for the supported
++	  options [1].
++
++	  [1] dtschema/schemas/options/u-boot.yaml
++
+ config LED_BCM6328
+ 	bool "LED Support for BCM6328"
+ 	depends on LED && ARCH_BMIPS
+--- a/drivers/led/led-uclass.c
++++ b/drivers/led/led-uclass.c
+@@ -163,6 +163,75 @@ int led_boot_blink(void)
+ #endif
+ #endif
+ 
++#ifdef CONFIG_LED_ACTIVITY
++static int led_activity_get(struct udevice **devp, int *period_ms)
++{
++	struct led_uc_priv *priv;
++	struct uclass *uc;
++	int ret;
++
++	ret = uclass_get(UCLASS_LED, &uc);
++	if (ret)
++		return ret;
++
++	priv = uclass_get_priv(uc);
++	if (!priv->activity_led_label)
++		return -ENOENT;
++
++	if (period_ms)
++		*period_ms = priv->activity_led_period;
++
++	return led_get_by_label(priv->activity_led_label, devp);
++}
++
++int led_activity_on(void)
++{
++	struct udevice *dev;
++	int ret;
++
++	ret = led_activity_get(&dev, NULL);
++	if (ret)
++		return ret;
++
++	return led_set_state(dev, LEDST_ON);
++}
++
++int led_activity_off(void)
++{
++	struct udevice *dev;
++	int ret;
++
++	ret = led_activity_get(&dev, NULL);
++	if (ret)
++		return ret;
++
++	return led_set_state(dev, LEDST_OFF);
++}
++
++#if defined(CONFIG_LED_BLINK) || defined(CONFIG_LED_SW_BLINK)
++int led_activity_blink(void)
++{
++	struct udevice *dev;
++	int period_ms, ret;
++
++	ret = led_activity_get(&dev, &period_ms);
++	if (ret)
++		return ret;
++
++	ret = led_set_period(dev, period_ms);
++	if (ret) {
++		if (ret != -ENOSYS)
++			return ret;
++
++		/* fallback to ON with no set_period and no SW_BLINK */
++		return led_set_state(dev, LEDST_ON);
++	}
++
++	return led_set_state(dev, LEDST_BLINK);
++}
++#endif
++#endif
++
+ static int led_post_bind(struct udevice *dev)
+ {
+ 	struct led_uc_plat *uc_plat = dev_get_uclass_plat(dev);
+@@ -227,13 +296,21 @@ static int led_post_probe(struct udevice
+ 	return ret;
+ }
+ 
+-#ifdef CONFIG_LED_BOOT
++#if defined(CONFIG_LED_BOOT) || defined(CONFIG_LED_ACTIVITY)
+ static int led_init(struct uclass *uc)
+ {
+ 	struct led_uc_priv *priv = uclass_get_priv(uc);
+ 
++#ifdef CONFIG_LED_BOOT
+ 	priv->boot_led_label = ofnode_options_read_str("boot-led");
+ 	priv->boot_led_period = ofnode_options_read_int("boot-led-period", 250);
++#endif
++
++#ifdef CONFIG_LED_ACTIVITY
++	priv->activity_led_label = ofnode_options_read_str("activity-led");
++	priv->activity_led_period = ofnode_options_read_int("activity-led-period",
++							    250);
++#endif
+ 
+ 	return 0;
+ }
+@@ -245,7 +322,7 @@ UCLASS_DRIVER(led) = {
+ 	.per_device_plat_auto	= sizeof(struct led_uc_plat),
+ 	.post_bind	= led_post_bind,
+ 	.post_probe	= led_post_probe,
+-#ifdef CONFIG_LED_BOOT
++#if defined(CONFIG_LED_BOOT) || defined(CONFIG_LED_ACTIVITY)
+ 	.init		= led_init,
+ 	.priv_auto	= sizeof(struct led_uc_priv),
+ #endif
+--- a/include/led.h
++++ b/include/led.h
+@@ -54,14 +54,21 @@ struct led_uc_plat {
+  * struct led_uc_priv - Private data the uclass stores about each device
+  *
+  * @boot_led_label:	Boot LED label
++ * @activity_led_label:	Activity LED label
+  * @boot_led_dev:	Boot LED dev
++ * @activity_led_dev:	Activity LED dev
+  * @boot_led_period:	Boot LED blink period
++ * @activity_led_period: Activity LED blink period
+  */
+ struct led_uc_priv {
+ #ifdef CONFIG_LED_BOOT
+ 	const char *boot_led_label;
+ 	int boot_led_period;
+ #endif
++#ifdef CONFIG_LED_ACTIVITY
++	const char *activity_led_label;
++	int activity_led_period;
++#endif
+ };
+ 
+ struct led_ops {
+@@ -190,6 +197,50 @@ static inline int led_boot_blink(void)
+ {
+ 	return -ENOSYS;
+ }
++#endif
++
++#ifdef CONFIG_LED_ACTIVITY
++
++/**
++ * led_activity_on() - turn ON the designated LED for activity
++ *
++ * Return: 0 if OK, -ve on error
++ */
++int led_activity_on(void);
++
++/**
++ * led_activity_off() - turn OFF the designated LED for activity
++ *
++ * Return: 0 if OK, -ve on error
++ */
++int led_activity_off(void);
++
++#if defined(CONFIG_LED_BLINK) || defined(CONFIG_LED_SW_BLINK)
++/**
++ * led_activity_blink() - turn ON the designated LED for activity
++ *
++ * Return: 0 if OK, -ve on error
++ */
++int led_activity_blink(void);
++#else
++/* If LED BLINK is not supported/enabled, fallback to LED ON */
++#define led_activity_blink led_activity_on
++#endif
++#else
++static inline int led_activity_on(void)
++{
++	return -ENOSYS;
++}
++
++static inline int led_activity_off(void)
++{
++	return -ENOSYS;
++}
++
++static inline int led_activity_blink(void)
++{
++	return -ENOSYS;
++}
+ #endif
+ 
+ #endif

--- a/package/boot/uboot-mediatek/patches/001-06-tftp-implement-support-for-LED-activity.patch
+++ b/package/boot/uboot-mediatek/patches/001-06-tftp-implement-support-for-LED-activity.patch
@@ -1,0 +1,66 @@
+From db8d0fb4923d1a5e4facba352488fd422fd3a2f8 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Sun, 2 Jun 2024 17:52:44 +0200
+Subject: [PATCH 06/11] tftp: implement support for LED activity
+
+Implement support for LED activity. If the feature is enabled,
+make the defined ACTIVITY LED to signal traffic.
+
+Also turn the ACTIVITY LED OFF if a CTRL-C is detected in the main
+net loop function.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+Reviewed-by: Simon Glass <sjg@chromium.org>
+---
+ net/net.c  | 4 ++++
+ net/tftp.c | 5 +++++
+ 2 files changed, 9 insertions(+)
+
+--- a/net/net.c
++++ b/net/net.c
+@@ -87,6 +87,7 @@
+ #include <env_internal.h>
+ #include <errno.h>
+ #include <image.h>
++#include <led.h>
+ #include <log.h>
+ #include <net.h>
+ #include <net6.h>
+@@ -659,6 +660,9 @@ restart:
+ 			/* Invalidate the last protocol */
+ 			eth_set_last_protocol(BOOTP);
+ 
++			/* Turn off activity LED if triggered */
++			led_activity_off();
++
+ 			puts("\nAbort\n");
+ 			/* include a debug print as well incase the debug
+ 			   messages are directed to stderr */
+--- a/net/tftp.c
++++ b/net/tftp.c
+@@ -10,6 +10,7 @@
+ #include <efi_loader.h>
+ #include <env.h>
+ #include <image.h>
++#include <led.h>
+ #include <lmb.h>
+ #include <log.h>
+ #include <mapmem.h>
+@@ -192,6 +193,7 @@ static void new_transfer(void)
+ #ifdef CONFIG_CMD_TFTPPUT
+ 	tftp_put_final_block_sent = 0;
+ #endif
++	led_activity_blink();
+ }
+ 
+ #ifdef CONFIG_CMD_TFTPPUT
+@@ -301,6 +303,9 @@ static void tftp_complete(void)
+ 			time_start * 1000, "/s");
+ 	}
+ 	puts("\ndone\n");
++
++	led_activity_off();
++
+ 	if (!tftp_put_active)
+ 		efi_set_bootdev("Net", "", tftp_filename,
+ 				map_sysmem(tftp_load_addr, 0),

--- a/package/boot/uboot-mediatek/patches/001-07-mtd-implement-support-for-LED-activity.patch
+++ b/package/boot/uboot-mediatek/patches/001-07-mtd-implement-support-for-LED-activity.patch
@@ -1,0 +1,63 @@
+From 91ea124d84b0db22d2bdac76c37960e97a038f3d Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Sun, 2 Jun 2024 18:11:15 +0200
+Subject: [PATCH 07/11] mtd: implement support for LED activity
+
+Implement support for LED activity. If the feature is enabled,
+make the defined ACTIVITY LED to signal mtd operations.
+
+LED activity is implemented HERE and not in the subsystem side to limit
+any performance degradation in case multiple call to MTD subsystem read/write
+are done.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ cmd/mtd.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+--- a/cmd/mtd.c
++++ b/cmd/mtd.c
+@@ -10,6 +10,7 @@
+ 
+ #include <command.h>
+ #include <console.h>
++#include <led.h>
+ #if CONFIG_IS_ENABLED(CMD_MTD_OTP)
+ #include <hexdump.h>
+ #endif
+@@ -558,6 +559,8 @@ static int do_mtd_io(struct cmd_tbl *cmd
+ 	while (mtd_block_isbad(mtd, off))
+ 		off += mtd->erasesize;
+ 
++	led_activity_blink();
++
+ 	/* Loop over the pages to do the actual read/write */
+ 	while (remaining) {
+ 		/* Skip the block if it is bad */
+@@ -585,6 +588,8 @@ static int do_mtd_io(struct cmd_tbl *cmd
+ 		io_op.oobbuf += io_op.oobretlen;
+ 	}
+ 
++	led_activity_off();
++
+ 	if (!ret && dump)
+ 		mtd_dump_device_buf(mtd, start_off, buf, len, woob);
+ 
+@@ -652,6 +657,8 @@ static int do_mtd_erase(struct cmd_tbl *
+ 	erase_op.addr = off;
+ 	erase_op.len = mtd->erasesize;
+ 
++	led_activity_blink();
++
+ 	while (len) {
+ 		if (!scrub) {
+ 			ret = mtd_block_isbad(mtd, erase_op.addr);
+@@ -680,6 +687,8 @@ static int do_mtd_erase(struct cmd_tbl *
+ 		erase_op.addr += mtd->erasesize;
+ 	}
+ 
++	led_activity_off();
++
+ 	if (ret && ret != -EIO)
+ 		ret = CMD_RET_FAILURE;
+ 	else

--- a/package/boot/uboot-mediatek/patches/100-08-common-board_r-add-support-to-initialize-NMBM-after-.patch
+++ b/package/boot/uboot-mediatek/patches/100-08-common-board_r-add-support-to-initialize-NMBM-after-.patch
@@ -13,7 +13,7 @@ Signed-off-by: Weijie Gao <weijie.gao@mediatek.com>
 
 --- a/common/board_r.c
 +++ b/common/board_r.c
-@@ -372,6 +372,20 @@ static int initr_nand(void)
+@@ -373,6 +373,20 @@ static int initr_nand(void)
  }
  #endif
  
@@ -34,7 +34,7 @@ Signed-off-by: Weijie Gao <weijie.gao@mediatek.com>
  #if defined(CONFIG_CMD_ONENAND)
  /* go init the NAND */
  static int initr_onenand(void)
-@@ -663,6 +677,9 @@ static init_fnc_t init_sequence_r[] = {
+@@ -675,6 +689,9 @@ static init_fnc_t init_sequence_r[] = {
  #ifdef CONFIG_CMD_ONENAND
  	initr_onenand,
  #endif

--- a/package/boot/uboot-mediatek/patches/100-10-cmd-mtd-add-markbad-subcommand-for-NMBM-testing.patch
+++ b/package/boot/uboot-mediatek/patches/100-10-cmd-mtd-add-markbad-subcommand-for-NMBM-testing.patch
@@ -20,7 +20,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
 
 --- a/cmd/mtd.c
 +++ b/cmd/mtd.c
-@@ -721,6 +721,42 @@ out_put_mtd:
+@@ -730,6 +730,42 @@ out_put_mtd:
  	return CMD_RET_SUCCESS;
  }
  
@@ -63,7 +63,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
  #ifdef CONFIG_AUTO_COMPLETE
  static int mtd_name_complete(int argc, char *const argv[], char last_char,
  			     int maxv, char *cmdv[])
-@@ -768,6 +804,7 @@ U_BOOT_LONGHELP(mtd,
+@@ -777,6 +813,7 @@ U_BOOT_LONGHELP(mtd,
  	"\n"
  	"Specific functions:\n"
  	"mtd bad                               <name>\n"
@@ -71,7 +71,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
  #if CONFIG_IS_ENABLED(CMD_MTD_OTP)
  	"mtd otpread                           <name> [u|f] <off> <size>\n"
  	"mtd otpwrite                          <name> <off> <hex string>\n"
-@@ -808,4 +845,6 @@ U_BOOT_CMD_WITH_SUBCMDS(mtd, "MTD utils"
+@@ -817,4 +854,6 @@ U_BOOT_CMD_WITH_SUBCMDS(mtd, "MTD utils"
  		U_BOOT_SUBCMD_MKENT_COMPLETE(erase, 4, 0, do_mtd_erase,
  					     mtd_name_complete),
  		U_BOOT_SUBCMD_MKENT_COMPLETE(bad, 2, 1, do_mtd_bad,

--- a/package/boot/uboot-mediatek/patches/412-add-ubnt-unifi-6-lr.patch
+++ b/package/boot/uboot-mediatek/patches/412-add-ubnt-unifi-6-lr.patch
@@ -909,7 +909,7 @@
 +_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"
 --- a/common/board_r.c
 +++ b/common/board_r.c
-@@ -66,6 +66,7 @@
+@@ -67,6 +67,7 @@
  #include <asm-generic/gpio.h>
  #include <efi_loader.h>
  #include <relocate.h>
@@ -917,7 +917,7 @@
  
  DECLARE_GLOBAL_DATA_PTR;
  
-@@ -396,6 +397,20 @@ static int initr_onenand(void)
+@@ -397,6 +398,20 @@ static int initr_onenand(void)
  }
  #endif
  
@@ -938,7 +938,7 @@
  #ifdef CONFIG_MMC
  static int initr_mmc(void)
  {
-@@ -680,6 +695,9 @@ static init_fnc_t init_sequence_r[] = {
+@@ -692,6 +707,9 @@ static init_fnc_t init_sequence_r[] = {
  #ifdef CONFIG_NMBM_MTD
  	initr_nmbm,
  #endif

--- a/package/boot/uboot-mediatek/patches/453-add-openwrt-one.patch
+++ b/package/boot/uboot-mediatek/patches/453-add-openwrt-one.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ b/arch/arm/dts/openwrt-one.dts
-@@ -0,0 +1,203 @@
+@@ -0,0 +1,210 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (c) 2024 John Crispin <john@phrozen.org>
@@ -20,6 +20,13 @@
 +		stdout-path = &uart0;
 +		tick-timer = &timer0;
 +	};
++
++        options {
++                u-boot {
++                        boot-led = "white";
++                        activity-led = "green";
++                };
++        };
 +
 +	memory@40000000 {
 +		device_type = "memory";
@@ -206,7 +213,7 @@
 +};
 --- /dev/null
 +++ b/configs/mt7981_openwrt-one-nor_defconfig
-@@ -0,0 +1,128 @@
+@@ -0,0 +1,131 @@
 +CONFIG_ARM=y
 +CONFIG_SYS_HAS_NONCACHED_MEMORY=y
 +CONFIG_POSITION_INDEPENDENT=y
@@ -292,8 +299,11 @@
 +CONFIG_CLK=y
 +CONFIG_GPIO_HOG=y
 +CONFIG_LED=y
++CONFIG_LED_ACTIVITY=y
 +CONFIG_LED_BLINK=y
++CONFIG_LED_BOOT=y
 +CONFIG_LED_GPIO=y
++CONFIG_LED_SW_BLINK=y
 +# CONFIG_MMC is not set
 +CONFIG_MTD=y
 +CONFIG_DM_MTD=y
@@ -337,7 +347,7 @@
 +CONFIG_LMB_MAX_REGIONS=64
 --- /dev/null
 +++ b/configs/mt7981_openwrt-one-spi-nand_defconfig
-@@ -0,0 +1,129 @@
+@@ -0,0 +1,132 @@
 +CONFIG_ARM=y
 +CONFIG_SYS_HAS_NONCACHED_MEMORY=y
 +CONFIG_POSITION_INDEPENDENT=y
@@ -426,8 +436,11 @@
 +CONFIG_CLK=y
 +CONFIG_GPIO_HOG=y
 +CONFIG_LED=y
++CONFIG_LED_ACTIVITY=y
 +CONFIG_LED_BLINK=y
++CONFIG_LED_BOOT=y
 +CONFIG_LED_GPIO=y
++CONFIG_LED_SW_BLINK=y
 +# CONFIG_MMC is not set
 +CONFIG_MTD=y
 +CONFIG_DM_MTD=y
@@ -469,7 +482,7 @@
 +CONFIG_LMB_MAX_REGIONS=64
 --- /dev/null
 +++ b/openwrt-one-nor_env
-@@ -0,0 +1,47 @@
+@@ -0,0 +1,45 @@
 +ethaddr_factory=mtd read factory 0x46000000 0x0 0x20000 && env readmem -b ethaddr 0x4600002a 0x6 ; setenv ethaddr_factory
 +bl2_mtd_write=mtd erase bl2-nor &&  mtd write bl2-nor $loadaddr 0x0 0x40000
 +bl2_tftp_write=tftpboot $loadaddr $bootfile_bl2_nor && run bl2_mtd_write
@@ -499,10 +512,8 @@
 +led_done=led green off ; led white on
 +led_loop_done=led white off ; led green on ; echo done ; while true ; do  sleep 1 ; done
 +led_loop_error=led white off ; led green off ; while true ; do led red on ; sleep 1 ; led red off ; sleep 1 ; done
-+led_boot=led green on ; led white on ; led red on
 +led_start=led green off ; led red off; led white on
 +loadaddr=0x46000000
-+preboot=run led_boot
 +recoverfile_bl2=openwrt-mediatek-filogic-openwrt_one-snand-preloader.bin
 +recoverfile_ubi=openwrt-mediatek-filogic-openwrt_one-factory.ubi
 +recovery_write_bl2=mtd erase bl2 && for offset in 0x0 0x40000 0x80000; do mtd write bl2 $loadaddr $offset 0x40000 ; done
@@ -519,7 +530,7 @@
 +_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"
 --- /dev/null
 +++ b/openwrt-one-spi-nand_env
-@@ -0,0 +1,60 @@
+@@ -0,0 +1,58 @@
 +ethaddr_factory=mtd read factory 0x46000000 0x0 0x20000 && env readmem -b ethaddr 0x4600002a 0x6 ; setenv ethaddr_factory
 +ipaddr=192.168.11.11
 +serverip=192.168.11.23
@@ -532,7 +543,7 @@
 +bootfile_bl2=openwrt-mediatek-filogic-openwrt_one-snand-preloader.bin
 +bootfile_fip=openwrt-mediatek-filogic-openwrt_one-snand-bl31-uboot.fip
 +bootfile_upg=openwrt-mediatek-filogic-openwrt_one-squashfs-sysupgrade.itb
-+bootmenu_confirm_return=askenv - Press ENTER to return to menu ; run led_boot ; bootmenu 60
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
 +bootmenu_default=0
 +bootmenu_delay=0
 +bootmenu_title=      [0;34m( ( ( [1;39mOpenWrt[0;34m ) ) )  [0;36m[SPI-NAND][0m
@@ -559,11 +570,9 @@
 +boot_tftp_write_fip=tftpboot $loadaddr $bootfile_fip && run ubi_write_fip && run reset_factory
 +boot_tftp_write_bl2=tftpboot $loadaddr $bootfile_bl2 && run snand_write_bl2
 +check_buttons=if button front ; then run boot_recovery ; run boot_tftp ; run led_loop_error ; else if button back ; then ; run usb_recover ; run led_loop_error ; fi ; fi
-+led_boot=led green on ; led white on ; led red on
 +led_done=led green on ; led white off ; led red off
 +led_loop_error=led white off ; led green off ; while true ; do led red on ; sleep 1 ; led red off ; sleep 1 ; done
 +led_start=led white on ; led green off ; led red off
-+preboot=run led_boot
 +reset_factory=mw $loadaddr 0xff 0x1f000 ; ubi write $loadaddr ubootenv 0x1f000 ; ubi write $loadaddr ubootenv2 0x1f000 ; ubi remove rootfs_data
 +snand_write_bl2=mtd erase bl2 && for offset in 0x0 0x40000 0x80000 0xc0000 ; do mtd write bl2 $loadaddr $offset 0x40000 ; done
 +ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x1f000 dynamic ; ubi check ubootenv2 || ubi create ubootenv2 0x1f000 dynamic


### PR DESCRIPTION
Backport LED boot and activity patch merged in uboot -next to permit to
configure special led to signal BOOT and ACTIVITY condition.

Enable LED boot and activity for OpenWrt One by defining the property in
DTS and enabling the required options. Also drop led_boot command from
uboot env.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

---

@dangowrt Can you check if the changes are ok related to the LED recovery procedure?