### PR TITLE
ramips: m4r v4: fix typo

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_deco-m4r-v4.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_deco-m4r-v4.dts
@@ -35,7 +35,7 @@
 		led {
 			label = "led";
 			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
-			debounce_interval = <60>;
+			debounce-interval = <60>;
 			linux,code = <KEY_BRIGHTNESS_TOGGLE>;
 		};
 


### PR DESCRIPTION
It should be debounce-interval, as with the others.