### PR TITLE
ramips: convert usb power to regulators

### DIFF
--- a/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
@@ -80,15 +80,13 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		power_usb3 {
-			gpio-export,name = "power_usb3";
-			gpio-export,output = <1>;
-			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
-		};
+	reg_power_usb3: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "power_usb3";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
 };
 
@@ -153,6 +151,10 @@
 			};
 		};
 	};
+};
+
+&xhci {
+	vbus-supply = <&reg_power_usb3>;
 };
 
 &pcie {

--- a/target/linux/ramips/dts/mt7621_humax_e10.dts
+++ b/target/linux/ramips/dts/mt7621_humax_e10.dts
@@ -19,16 +19,6 @@
 		label-mac-device = &gmac1;
 	};
 
-	gpio-export {
-		compatible = "gpio-export";
-
-		gpio-usb-power {
-			gpio-export,name = "power:usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
-		};
-	};
-
 	leds {
 		compatible = "gpio-leds";
 
@@ -64,6 +54,15 @@
 			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
+	};
+
+	reg_power_usb: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "power:usb";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
 };
 
@@ -129,6 +128,10 @@
 			};
 		};
 	};
+};
+
+&xhci {
+	vbus-supply = <&reg_power_usb>;
 };
 
 &pcie {

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-7xx.dtsi
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-7xx.dtsi
@@ -13,13 +13,20 @@
 			gpio-export,output = <0>;
 			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
 		};
-
-		usb_power {
-			gpio-export,name = "usb_power";
-			gpio-export,output = <1>;
-			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
-		};
 	};
+
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&xhci {
+	vbus-supply = <&reg_usb_power>;
 };
 
 &keys {

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
@@ -48,6 +48,15 @@
 		};
 	};
 
+	reg_power_usb: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "power_usb";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
 	watchdog {
 		compatible = "linux,wdt-gpio";
 		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
@@ -72,13 +81,11 @@
 			gpio-export,output = <1>;
 			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
 		};
-
-		ext-usb {
-			gpio-export,name = "ext-usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
-		};
 	};
+};
+
+&xhci {
+	vbus-supply = <&reg_power_usb>;
 };
 
 &sdhci {

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602.dtsi
@@ -47,6 +47,15 @@
 		};
 	};
 
+	reg_power_usb: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "power_usb";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
 	watchdog {
 		compatible = "linux,wdt-gpio";
 		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
@@ -71,13 +80,11 @@
 			gpio-export,output = <1>;
 			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
 		};
-
-		ext-usb {
-			gpio-export,name = "ext-usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
-		};
 	};
+};
+
+&xhci {
+	vbus-supply = <&reg_power_usb>;
 };
 
 &sdhci {

--- a/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
@@ -96,17 +96,18 @@
 
 	};
 
+	reg_power_usb: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "power_usb";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
-&gpio {
-	status = "okay";
-
-	enable_usb_power {
-		gpio-hog;
-		line-name = "enable USB power";
-		gpios = <7 GPIO_ACTIVE_HIGH>;
-		output-high;
-	};
+&xhci {
+	vbus-supply = <&reg_power_usb>;
 };
 
 &nand {

--- a/target/linux/ramips/dts/mt7621_zyxel_lte5398-m904.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte5398-m904.dts
@@ -92,13 +92,20 @@
 			gpio-export,output = <0>;
 			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
 		};
-
-		usb_power {
-			gpio-export,name = "usb_power";
-			gpio-export,output = <1>;
-			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
-		};
 	};
+
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		reglator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&xhci {
+	vbus-supply = <&reg_usb_power>;
 };
 
 &nand {


### PR DESCRIPTION
These things are regulators. Should silence dmesg messages about using dummy regulators.

ping @DragonBluep 
