### PR TITLE
dnsmasq: fix path to default dnsmasq confdir

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1146,7 +1146,7 @@ dnsmasq_start()
 
 
 	# Create a dnsmasq.d dir for each instance
-	config_get dnsmasqconfdir "$cfg" confdir "/tmp/dnsmasq${cfg:+.$cfg}.d"
+	config_get dnsmasqconfdir "$cfg" confdir "/tmp/dnsmasq.d"
 	# Ensure dnsmasqconfdir is an absolute path
 	[ "${dnsmasqconfdir:0:1}" = '/' ] && {
 		xappend "--conf-dir=$dnsmasqconfdir"


### PR DESCRIPTION
This commit changes the default path for dnsmasq instances confdir back to `/tmp/dnsmasq.d` which some packages in openwrt/packages repo depend on. The directories other than `/tmp/dnsmasq.d` can still be set using the `confdir` option for each dnsmasq instance if needed.

Tagging author and merger of the merged PR (https://github.com/openwrt/openwrt/pull/14975) which caused broken packages: @systemcrash @hauke.

Update: a bit more elaborate explanation from https://github.com/openwrt/openwrt/pull/16890:
There are two kinds of packages in openwrt/packages which are affected and which this PR fixes in one way or another:
* packages which are not aware that instances can have their own confdir: with this PR merged, at least in the default config, the files those packages create would still be used by all instances. Ultimately packages in this group do need to be fixed to become instance-confdir-aware, but without this PR they are broken even more than with it.
* packages which are aware that instances can have their own confdir: those are still using `/tmp/dnsmasq.d/` as default, so unless the instance confdir has been explicitly declared, they are broken without this PR. While doable, having to differentiate between current release default directory for instances confdir and the snapshots default directory for instances confdir will further complicate maintaining current code in both branches.

I'm also questioning the need to have the instance confdir named `/tmp/dnsmasq.$cfg.d/`. If someone wants to manually create files for a specific instance, the `$cfg` part is not easily obtainable (outside of a script). In case of named instances (which I believe what most user guides advise to do), the `$cfg` is even further separated from a simple instance name.

Also, merging this PR does not remove an option for users to explicitly specify different confdirs for instances should they choose to.

My strong suggestion is to merge this PR and then, without a present urgency to fix broken packages, consider if/how options need to be implemented.

**UPDATE2: Didn't realize this was merged before 24.10 branching, so this will need to be cherry-picked for 24.10.**


