### PR TITLE
ramips: Fix WiFi on Sercomm NA502 and NA502s

### DIFF
--- a/target/linux/ramips/dts/mt7621_sercomm_na502.dts
+++ b/target/linux/ramips/dts/mt7621_sercomm_na502.dts
@@ -193,7 +193,7 @@
 	status = "okay";
 };
 
-&pcie0 {
+&pcie1 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
@@ -203,7 +203,7 @@
 	};
 };
 
-&pcie1 {
+&pcie2 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;

--- a/target/linux/ramips/dts/mt7621_sercomm_na502s.dts
+++ b/target/linux/ramips/dts/mt7621_sercomm_na502s.dts
@@ -297,7 +297,7 @@
 	status = "okay";
 };
 
-&pcie0 {
+&pcie1 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
@@ -307,7 +307,7 @@
 	};
 };
 
-&pcie1 {
+&pcie2 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;


### PR DESCRIPTION
The WiFi chips are actually on PCIe1 and PCIe2, PCIe0 is empty. Fix the assignment so that WiFi works properly again.

See relevant Forum thread at https://forum.openwrt.org/t/5ghz-wifi-missing-on-sercomm-na502-mt7621-with-latest-snapshot/210461