### PR TITLE
ath79: Really fix 5GHz on QCA9886 variant of ZTE MF286

### DIFF
--- a/target/linux/ath79/dts/qca9563_zte_mf286.dts
+++ b/target/linux/ath79/dts/qca9563_zte_mf286.dts
@@ -70,12 +70,19 @@
 				#address-cells = <1>;
 				#size-cells = <1>;
 
+				/* ath9k */
 				cal_caldata_1000: cal@1000 {
 					reg = <0x1000 0x440>;
 				};
 
+				/* ath10k wave1 in plain MF286 */
 				cal_caldata_5000: cal@5000 {
 					reg = <0x5000 0x844>;
+				};
+
+				/* ath10k wave2 in early MF286A */
+				precal_caldata_5000: precal@5000 {
+					reg = <0x5000 0x2f20>;
 				};
 			};
 		};
@@ -128,7 +135,7 @@
 };
 
 &wifi_ath10k {
-	nvmem-cells = <&macaddr_mac_0 1>, <&cal_caldata_5000>, <&cal_caldata_5000>;
+	nvmem-cells = <&macaddr_mac_0 1>, <&cal_caldata_5000>, <&precal_caldata_5000>;
 	nvmem-cell-names = "mac-address", "calibration", "pre-calibration";
 };
 


### PR DESCRIPTION
Fix in commit 25eead21c5ab ("ath79: fix 5GHz on QCA9886 variant of ZTE MF286") was incomplete. A user of such variant popped up, and in the boot log after installation, we discovered that QCA9886 expects different pre-calibration data size, than the older QCA9880 variant:

```
ath10k_pci 0000:00:00.0: qca9888 hw2.0 target 0x01000000 chip_id 0x00000000 sub 0000:0000
ath10k_pci 0000:00:00.0: kconfig debug 0 debugfs 1 tracing 0 dfs 1 testmode 0
ath10k_pci 0000:00:00.0: firmware ver 10.4b-ct-9888-fW-13-5ae337bb1 api 5 features mfp,peer-flow-ctrl,txstatus-noack,wmi-10.x-CT,ratemask-CT,regdump-CT,txrate-CT,flush-all-CT,pingpong-CT,ch-regs-CT,nop-CT,set-special-CT,tx-rc-CT,cust-stats-CT,txrate2-CT,beacon-cb-CT,wmi-block-ack-CT,wmi-bcn-rc-CT crc32 59e741e7
ath10k_pci 0000:00:00.0: invalid calibration data length in nvmem-cell 'pre-calibration': 2116 != 12064
ath10k_pci 0000:00:00.0: Loading BDF type 0
ath10k_pci 0000:00:00.0: failed to fetch board data for bus=pci,vendor=168c,device=0056,subsystem-vendor=0000,subsystem-device=0000 from ath10k/QCA9888/hw2.0/board-2.bin
ath10k_pci 0000:00:00.0: failed to fetch board-2.bin or board.bin from ath10k/QCA9888/hw2.0
ath10k_pci 0000:00:00.0: failed to fetch board file: -12
ath10k_pci 0000:00:00.0: could not probe fw (-12)
```

Explicitly define a pre-calibration nvmem-cell for this variant, and use it instead of the calibration one, which is shorter.

Fixes: 25eead21c5ab ("ath79: fix 5GHz on QCA9886 variant of ZTE MF286")
