### PR TITLE
xdp-tools: build BPF objects against user headers

### DIFF
--- a/include/bpf.mk
+++ b/include/bpf.mk
@@ -42,6 +42,11 @@ BPF_TARGET:=bpf$(if $(CONFIG_BIG_ENDIAN),eb,el)
 
 BPF_HEADERS_DIR:=$(STAGING_DIR)/bpf-headers
 
+BPF_USER_INCLUDE := \
+	-nostdinc -isystem $(TOOLCHAIN_ROOT_DIR)/lib/gcc/*/*/include \
+	$(patsubst %,-isystem%,$(TOOLCHAIN_INC_DIRS)) \
+	-I$(BPF_HEADERS_DIR)/tools/lib
+
 BPF_KERNEL_INCLUDE := \
 	-nostdinc -isystem $(TOOLCHAIN_ROOT_DIR)/lib/gcc/*/*/include \
 	$(patsubst %,-isystem%,$(TOOLCHAIN_INC_DIRS)) \

--- a/package/network/utils/xdp-tools/Makefile
+++ b/package/network/utils/xdp-tools/Makefile
@@ -85,7 +85,7 @@ CONFIGURE_VARS += \
 	CFLAGS="$(TARGET_CFLAGS)" \
 	LDFLAGS="$(TARGET_LDFLAGS)" \
 	CLANG="$(CLANG)" \
-	BPF_TARGET="$(BPF_ARCH)-linux-gnu" \
+	BPF_TARGET="$(BPF_TARGET)" \
 	LLC="$(LLVM_LLC)" \
 	BPF_LDFLAGS="-march=$(BPF_TARGET) -mcpu=v3" \
 	BPFTOOL=""
@@ -100,7 +100,7 @@ MAKE_VARS += \
 
 define Build/Configure
 	$(call Build/Configure/Default)
-	echo "BPF_CFLAGS += $(BPF_CFLAGS) -Wno-error -fno-stack-protector" >> $(PKG_BUILD_DIR)/config.mk
+	echo "BPF_CFLAGS += $(BPF_USER_INCLUDE) -Wno-error -fno-stack-protector" >> $(PKG_BUILD_DIR)/config.mk
 endef
 
 define Build/InstallDev


### PR DESCRIPTION
Currently, the BPF objects of `xdp-tools` are built against the `mips` kernel headers.
The compilation runs fine (although with a few warnings), but the `xdp-filter` program cannot run because it isn't able to attach the '`xdpfilt_alw_all` BPF program: `unknown opcode 8d`.

This might be fixable, but then I also tried to compile the `xdp-bench`, `xdp-monitor`, and `xdp-trafficgen` programs (which I would also like to add in a later PR) and got a lot more build errors.

This is why I propose with this PR to build the BPF programs against user-space headers instead of the currently used kernel headers. The compilation still runs fine, even without warnings, and now the `xdp-filter` program is able to attach all its BPF programs.

<details>
<summary>Here is the full error output when I try to run the xdp-filter program</summary>

```sh
root@OpenWrt:~# xdp-filter load eth1 -vv
Current rlimit 8388608 already >= minimum 1048576
Acquired lock from /sys/fs/bpf/xdp-filter with fd 3
Couldn't open pin directory /sys/fs/bpf/xdp-filter/programs/eth1: No such file or directory
Looking for eBPF program with features tcp,udp,ipv6,ipv4,ethernet,allow
Found prog 'xdpfilt_alw_all.o' matching feature set to be loaded on interface 'eth1'.
 libxdp: Looking for './xdpfilt_alw_all.o'
 libxdp: Looking for '/usr/lib/bpf/xdpfilt_alw_all.o'
 libxdp: Loading XDP program from '/usr/lib/bpf/xdpfilt_alw_all.o' section '(unknown)'
  libbpf: loading object from /usr/lib/bpf/xdpfilt_alw_all.o
  libbpf: elf: section(2) .text, size 5328, link 0, flags 6, type=1
  libbpf: sec '.text': found program 'parse_ethhdr' at insn offset 0 (0 bytes), code size 56 insns (448 bytes)
  libbpf: sec '.text': found program 'xdp_stats_record_action' at insn offset 556 (4448 bytes), code size 37 insns (296 bytes)
  libbpf: sec '.text': found program 'lookup_verdict_ethernet' at insn offset 56 (448 bytes), code size 94 insns (752 bytes)
  libbpf: sec '.text': found program 'parse_iphdr' at insn offset 150 (1200 bytes), code size 40 insns (320 bytes)
  libbpf: sec '.text': found program 'parse_ip6hdr' at insn offset 254 (2032 bytes), code size 29 insns (232 bytes)
  libbpf: sec '.text': found program 'lookup_verdict_ipv4' at insn offset 190 (1520 bytes), code size 64 insns (512 bytes)
  libbpf: sec '.text': found program 'lookup_verdict_ipv6' at insn offset 283 (2264 bytes), code size 80 insns (640 bytes)
  libbpf: sec '.text': found program 'parse_udphdr' at insn offset 363 (2904 bytes), code size 32 insns (256 bytes)
  libbpf: sec '.text': found program 'lookup_verdict_udp' at insn offset 395 (3160 bytes), code size 64 insns (512 bytes)
  libbpf: sec '.text': found program 'parse_tcphdr' at insn offset 459 (3672 bytes), code size 33 insns (264 bytes)
  libbpf: sec '.text': found program 'lookup_verdict_tcp' at insn offset 492 (3936 bytes), code size 64 insns (512 bytes)
  libbpf: sec '.text': found program 'proto_is_vlan' at insn offset 593 (4744 bytes), code size 8 insns (64 bytes)
  libbpf: sec '.text': found program 'skip_ip6hdrext' at insn offset 601 (4808 bytes), code size 65 insns (520 bytes)
  libbpf: elf: section(3) .rel.text, size 352, link 29, flags 40, type=9
  libbpf: elf: section(4) xdp, size 672, link 0, flags 6, type=1
  libbpf: sec 'xdp': found program 'xdpfilt_alw_all' at insn offset 0 (0 bytes), code size 84 insns (672 bytes)
  libbpf: elf: section(5) .relxdp, size 176, link 29, flags 40, type=9
  libbpf: elf: section(6) license, size 4, link 0, flags 3, type=1
  libbpf: license of /usr/lib/bpf/xdpfilt_alw_all.o is GPL
  libbpf: elf: section(7) features, size 4, link 0, flags 3, type=1
  libbpf: elf: skipping unrecognized data section(7) features
  libbpf: elf: section(8) .maps, size 200, link 0, flags 3, type=1
  libbpf: elf: section(9) .xdp_run_config, size 16, link 0, flags 3, type=1
  libbpf: elf: skipping unrecognized data section(9) .xdp_run_config
  libbpf: elf: section(10) .data, size 8, link 0, flags 3, type=1
  libbpf: elf: section(20) .BTF, size 8793, link 0, flags 0, type=1
  libbpf: elf: section(22) .BTF.ext, size 5480, link 0, flags 0, type=1
  libbpf: elf: section(29) .symtab, size 2544, link 1, flags 0, type=2
  libbpf: looking for externs among 106 symbols...
  libbpf: collected 0 externs total
  libbpf: map 'xdp_stats_map': at sec_idx 8, offset 0.
  libbpf: map 'xdp_stats_map': found type = 6.
  libbpf: map 'xdp_stats_map': found key [8], sz = 4.
  libbpf: map 'xdp_stats_map': found value [11], sz = 16.
  libbpf: map 'xdp_stats_map': found max_entries = 5.
  libbpf: map 'xdp_stats_map': found pinning = 1.
  libbpf: map 'filter_ports': at sec_idx 8, offset 40.
  libbpf: map 'filter_ports': found type = 6.
  libbpf: map 'filter_ports': found key [8], sz = 4.
  libbpf: map 'filter_ports': found value [13], sz = 8.
  libbpf: map 'filter_ports': found max_entries = 65536.
  libbpf: map 'filter_ports': found pinning = 1.
  libbpf: map 'filter_ipv4': at sec_idx 8, offset 80.
  libbpf: map 'filter_ipv4': found type = 5.
  libbpf: map 'filter_ipv4': found key [8], sz = 4.
  libbpf: map 'filter_ipv4': found value [13], sz = 8.
  libbpf: map 'filter_ipv4': found max_entries = 10000.
  libbpf: map 'filter_ipv4': found pinning = 1.
  libbpf: map 'filter_ipv6': at sec_idx 8, offset 120.
  libbpf: map 'filter_ipv6': found type = 5.
  libbpf: map 'filter_ipv6': found key [30], sz = 16.
  libbpf: map 'filter_ipv6': found value [13], sz = 8.
  libbpf: map 'filter_ipv6': found max_entries = 10000.
  libbpf: map 'filter_ipv6': found pinning = 1.
  libbpf: map 'filter_ethernet': at sec_idx 8, offset 160.
  libbpf: map 'filter_ethernet': found type = 5.
  libbpf: map 'filter_ethernet': found key [44], sz = 6.
  libbpf: map 'filter_ethernet': found value [13], sz = 8.
  libbpf: map 'filter_ethernet': found max_entries = 10000.
  libbpf: map 'filter_ethernet': found pinning = 1.
  libbpf: map 'xdpfilt_.data' (global data): at sec_idx 10, offset 0, flags 0.
  libbpf: map 5 is "xdpfilt_.data"
  libbpf: sec '.rel.text': collecting relocation for section(2) '.text'
  libbpf: sec '.rel.text': relo #0: insn #76 against '.data'
  libbpf: prog 'lookup_verdict_ethernet': found data map 5 (xdpfilt_.data, sec 10, off 0) for insn 20
  libbpf: sec '.rel.text': relo #1: insn #81 against 'filter_ethernet'
  libbpf: prog 'lookup_verdict_ethernet': found map 4 (filter_ethernet, sec 8, off 160) for insn #25
  libbpf: sec '.rel.text': relo #2: insn #118 against '.data'
  libbpf: prog 'lookup_verdict_ethernet': found data map 5 (xdpfilt_.data, sec 10, off 0) for insn 62
  libbpf: sec '.rel.text': relo #3: insn #123 against 'filter_ethernet'
  libbpf: prog 'lookup_verdict_ethernet': found map 4 (filter_ethernet, sec 8, off 160) for insn #67
  libbpf: sec '.rel.text': relo #4: insn #193 against '.data'
  libbpf: prog 'lookup_verdict_ipv4': found data map 5 (xdpfilt_.data, sec 10, off 0) for insn 3
  libbpf: sec '.rel.text': relo #5: insn #198 against 'filter_ipv4'
  libbpf: prog 'lookup_verdict_ipv4': found map 2 (filter_ipv4, sec 8, off 80) for insn #8
  libbpf: sec '.rel.text': relo #6: insn #222 against '.data'
  libbpf: prog 'lookup_verdict_ipv4': found data map 5 (xdpfilt_.data, sec 10, off 0) for insn 32
  libbpf: sec '.rel.text': relo #7: insn #227 against 'filter_ipv4'
  libbpf: prog 'lookup_verdict_ipv4': found map 2 (filter_ipv4, sec 8, off 80) for insn #37
  libbpf: sec '.rel.text': relo #8: insn #294 against '.data'
  libbpf: prog 'lookup_verdict_ipv6': found data map 5 (xdpfilt_.data, sec 10, off 0) for insn 11
  libbpf: sec '.rel.text': relo #9: insn #299 against 'filter_ipv6'
  libbpf: prog 'lookup_verdict_ipv6': found map 3 (filter_ipv6, sec 8, off 120) for insn #16
  libbpf: sec '.rel.text': relo #10: insn #331 against '.data'
  libbpf: prog 'lookup_verdict_ipv6': found data map 5 (xdpfilt_.data, sec 10, off 0) for insn 48
  libbpf: sec '.rel.text': relo #11: insn #336 against 'filter_ipv6'
  libbpf: prog 'lookup_verdict_ipv6': found map 3 (filter_ipv6, sec 8, off 120) for insn #53
  libbpf: sec '.rel.text': relo #12: insn #398 against '.data'
  libbpf: prog 'lookup_verdict_udp': found data map 5 (xdpfilt_.data, sec 10, off 0) for insn 3
  libbpf: sec '.rel.text': relo #13: insn #403 against 'filter_ports'
  libbpf: prog 'lookup_verdict_udp': found map 1 (filter_ports, sec 8, off 40) for insn #8
  libbpf: sec '.rel.text': relo #14: insn #427 against '.data'
  libbpf: prog 'lookup_verdict_udp': found data map 5 (xdpfilt_.data, sec 10, off 0) for insn 32
  libbpf: sec '.rel.text': relo #15: insn #432 against 'filter_ports'
  libbpf: prog 'lookup_verdict_udp': found map 1 (filter_ports, sec 8, off 40) for insn #37
  libbpf: sec '.rel.text': relo #16: insn #495 against '.data'
  libbpf: prog 'lookup_verdict_tcp': found data map 5 (xdpfilt_.data, sec 10, off 0) for insn 3
  libbpf: sec '.rel.text': relo #17: insn #500 against 'filter_ports'
  libbpf: prog 'lookup_verdict_tcp': found map 1 (filter_ports, sec 8, off 40) for insn #8
  libbpf: sec '.rel.text': relo #18: insn #524 against '.data'
  libbpf: prog 'lookup_verdict_tcp': found data map 5 (xdpfilt_.data, sec 10, off 0) for insn 32
  libbpf: sec '.rel.text': relo #19: insn #529 against 'filter_ports'
  libbpf: prog 'lookup_verdict_tcp': found map 1 (filter_ports, sec 8, off 40) for insn #37
  libbpf: sec '.rel.text': relo #20: insn #561 against '.data'
  libbpf: prog 'xdp_stats_record_action': found data map 5 (xdpfilt_.data, sec 10, off 0) for insn 5
  libbpf: sec '.rel.text': relo #21: insn #566 against 'xdp_stats_map'
  libbpf: prog 'xdp_stats_record_action': found map 0 (xdp_stats_map, sec 8, off 0) for insn #10
  libbpf: sec '.relxdp': collecting relocation for section(4) 'xdp'
  libbpf: sec '.relxdp': relo #0: insn #12 against '.text'
  libbpf: sec '.relxdp': relo #1: insn #19 against '.text'
  libbpf: sec '.relxdp': relo #2: insn #22 against '.text'
  libbpf: sec '.relxdp': relo #3: insn #32 against '.text'
  libbpf: sec '.relxdp': relo #4: insn #43 against '.text'
  libbpf: sec '.relxdp': relo #5: insn #48 against '.text'
  libbpf: sec '.relxdp': relo #6: insn #53 against '.text'
  libbpf: sec '.relxdp': relo #7: insn #63 against '.text'
  libbpf: sec '.relxdp': relo #8: insn #67 against '.text'
  libbpf: sec '.relxdp': relo #9: insn #77 against '.text'
  libbpf: sec '.relxdp': relo #10: insn #81 against '.text'
 libxdp: Found func xdpfilt_alw_all matching xdpfilt_alw_all
 libxdp: Generating multi-prog dispatcher for 1 programs
 libxdp: Checking for kernel frags support
 libxdp: Loading XDP program 'xdp-dispatcher.o' from embedded object file
  libbpf: loading object 'xdp-dispatcher.o' from buffer
  libbpf: elf: section(2) .text, size 1320, link 0, flags 6, type=1
  libbpf: sec '.text': found program 'prog0' at insn offset 0 (0 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog1' at insn offset 15 (120 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog2' at insn offset 30 (240 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog3' at insn offset 45 (360 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog4' at insn offset 60 (480 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog5' at insn offset 75 (600 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog6' at insn offset 90 (720 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog7' at insn offset 105 (840 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog8' at insn offset 120 (960 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog9' at insn offset 135 (1080 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'compat_test' at insn offset 150 (1200 bytes), code size 15 insns (120 bytes)
  libbpf: elf: section(3) xdp, size 1120, link 0, flags 6, type=1
  libbpf: sec 'xdp': found program 'xdp_dispatcher' at insn offset 0 (0 bytes), code size 137 insns (1096 bytes)
  libbpf: sec 'xdp': found program 'xdp_pass' at insn offset 137 (1096 bytes), code size 3 insns (24 bytes)
  libbpf: elf: section(4) .relxdp, size 336, link 26, flags 40, type=9
  libbpf: elf: section(5) .rodata, size 124, link 0, flags 2, type=1
  libbpf: elf: section(6) license, size 4, link 0, flags 3, type=1
  libbpf: license of xdp-dispatcher.o is GPL
  libbpf: elf: section(7) xdp_metadata, size 8, link 0, flags 3, type=1
  libbpf: elf: skipping unrecognized data section(7) xdp_metadata
  libbpf: elf: section(17) .BTF, size 3367, link 0, flags 0, type=1
  libbpf: elf: section(19) .BTF.ext, size 2720, link 0, flags 0, type=1
  libbpf: elf: section(26) .symtab, size 1536, link 1, flags 0, type=2
  libbpf: looking for externs among 64 symbols...
  libbpf: collected 0 externs total
  libbpf: map 'xdp_disp.rodata' (global data): at sec_idx 5, offset 0, flags 80.
  libbpf: map 0 is "xdp_disp.rodata"
  libbpf: sec '.relxdp': collecting relocation for section(3) 'xdp'
  libbpf: sec '.relxdp': relo #0: insn #1 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 1
  libbpf: sec '.relxdp': relo #1: insn #7 against 'prog0'
  libbpf: sec '.relxdp': relo #2: insn #21 against 'prog1'
  libbpf: sec '.relxdp': relo #3: insn #23 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 23
  libbpf: sec '.relxdp': relo #4: insn #33 against 'prog2'
  libbpf: sec '.relxdp': relo #5: insn #35 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 35
  libbpf: sec '.relxdp': relo #6: insn #45 against 'prog3'
  libbpf: sec '.relxdp': relo #7: insn #47 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 47
  libbpf: sec '.relxdp': relo #8: insn #57 against 'prog4'
  libbpf: sec '.relxdp': relo #9: insn #59 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 59
  libbpf: sec '.relxdp': relo #10: insn #69 against 'prog5'
  libbpf: sec '.relxdp': relo #11: insn #71 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 71
  libbpf: sec '.relxdp': relo #12: insn #81 against 'prog6'
  libbpf: sec '.relxdp': relo #13: insn #83 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 83
  libbpf: sec '.relxdp': relo #14: insn #93 against 'prog7'
  libbpf: sec '.relxdp': relo #15: insn #95 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 95
  libbpf: sec '.relxdp': relo #16: insn #105 against 'prog8'
  libbpf: sec '.relxdp': relo #17: insn #107 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 107
  libbpf: sec '.relxdp': relo #18: insn #117 against 'prog9'
  libbpf: sec '.relxdp': relo #19: insn #119 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 119
  libbpf: sec '.relxdp': relo #20: insn #129 against 'compat_test'
 libxdp: DATASEC '.xdp_run_config' not found.
  libbpf: object 'xdp-dispatcher.': failed (-22) to create BPF token from '/sys/fs/bpf', skipping optional step...
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog0'
  libbpf: prog 'xdp_dispatcher': insn #7 relocated, imm 129 points to subprog 'prog0' (now at 137 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog1'
  libbpf: prog 'xdp_dispatcher': insn #21 relocated, imm 130 points to subprog 'prog1' (now at 152 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog2'
  libbpf: prog 'xdp_dispatcher': insn #33 relocated, imm 133 points to subprog 'prog2' (now at 167 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog3'
  libbpf: prog 'xdp_dispatcher': insn #45 relocated, imm 136 points to subprog 'prog3' (now at 182 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog4'
  libbpf: prog 'xdp_dispatcher': insn #57 relocated, imm 139 points to subprog 'prog4' (now at 197 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog5'
  libbpf: prog 'xdp_dispatcher': insn #69 relocated, imm 142 points to subprog 'prog5' (now at 212 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog6'
  libbpf: prog 'xdp_dispatcher': insn #81 relocated, imm 145 points to subprog 'prog6' (now at 227 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog7'
  libbpf: prog 'xdp_dispatcher': insn #93 relocated, imm 148 points to subprog 'prog7' (now at 242 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog8'
  libbpf: prog 'xdp_dispatcher': insn #105 relocated, imm 151 points to subprog 'prog8' (now at 257 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog9'
  libbpf: prog 'xdp_dispatcher': insn #117 relocated, imm 154 points to subprog 'prog9' (now at 272 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'compat_test'
  libbpf: prog 'xdp_dispatcher': insn #129 relocated, imm 157 points to subprog 'compat_test' (now at 287 offset)
  libbpf: map 'xdp_disp.rodata': created successfully, fd=4
 libxdp: Loaded XDP program xdp_pass, got fd 13
 libxdp: Duplicated fd 13 to 14 for prog xdp_pass
 libxdp: Kernel supports XDP programs with frags
 libxdp: Loading XDP program 'xdp-dispatcher.o' from embedded object file
  libbpf: loading object 'xdp-dispatcher.o' from buffer
  libbpf: elf: section(2) .text, size 1320, link 0, flags 6, type=1
  libbpf: sec '.text': found program 'prog0' at insn offset 0 (0 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog1' at insn offset 15 (120 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog2' at insn offset 30 (240 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog3' at insn offset 45 (360 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog4' at insn offset 60 (480 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog5' at insn offset 75 (600 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog6' at insn offset 90 (720 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog7' at insn offset 105 (840 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog8' at insn offset 120 (960 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog9' at insn offset 135 (1080 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'compat_test' at insn offset 150 (1200 bytes), code size 15 insns (120 bytes)
  libbpf: elf: section(3) xdp, size 1120, link 0, flags 6, type=1
  libbpf: sec 'xdp': found program 'xdp_dispatcher' at insn offset 0 (0 bytes), code size 137 insns (1096 bytes)
  libbpf: sec 'xdp': found program 'xdp_pass' at insn offset 137 (1096 bytes), code size 3 insns (24 bytes)
  libbpf: elf: section(4) .relxdp, size 336, link 26, flags 40, type=9
  libbpf: elf: section(5) .rodata, size 124, link 0, flags 2, type=1
  libbpf: elf: section(6) license, size 4, link 0, flags 3, type=1
  libbpf: license of xdp-dispatcher.o is GPL
  libbpf: elf: section(7) xdp_metadata, size 8, link 0, flags 3, type=1
  libbpf: elf: skipping unrecognized data section(7) xdp_metadata
  libbpf: elf: section(17) .BTF, size 3367, link 0, flags 0, type=1
  libbpf: elf: section(19) .BTF.ext, size 2720, link 0, flags 0, type=1
  libbpf: elf: section(26) .symtab, size 1536, link 1, flags 0, type=2
  libbpf: looking for externs among 64 symbols...
  libbpf: collected 0 externs total
  libbpf: map 'xdp_disp.rodata' (global data): at sec_idx 5, offset 0, flags 80.
  libbpf: map 0 is "xdp_disp.rodata"
  libbpf: sec '.relxdp': collecting relocation for section(3) 'xdp'
  libbpf: sec '.relxdp': relo #0: insn #1 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 1
  libbpf: sec '.relxdp': relo #1: insn #7 against 'prog0'
  libbpf: sec '.relxdp': relo #2: insn #21 against 'prog1'
  libbpf: sec '.relxdp': relo #3: insn #23 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 23
  libbpf: sec '.relxdp': relo #4: insn #33 against 'prog2'
  libbpf: sec '.relxdp': relo #5: insn #35 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 35
  libbpf: sec '.relxdp': relo #6: insn #45 against 'prog3'
  libbpf: sec '.relxdp': relo #7: insn #47 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 47
  libbpf: sec '.relxdp': relo #8: insn #57 against 'prog4'
  libbpf: sec '.relxdp': relo #9: insn #59 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 59
  libbpf: sec '.relxdp': relo #10: insn #69 against 'prog5'
  libbpf: sec '.relxdp': relo #11: insn #71 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 71
  libbpf: sec '.relxdp': relo #12: insn #81 against 'prog6'
  libbpf: sec '.relxdp': relo #13: insn #83 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 83
  libbpf: sec '.relxdp': relo #14: insn #93 against 'prog7'
  libbpf: sec '.relxdp': relo #15: insn #95 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 95
  libbpf: sec '.relxdp': relo #16: insn #105 against 'prog8'
  libbpf: sec '.relxdp': relo #17: insn #107 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 107
  libbpf: sec '.relxdp': relo #18: insn #117 against 'prog9'
  libbpf: sec '.relxdp': relo #19: insn #119 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 119
  libbpf: sec '.relxdp': relo #20: insn #129 against 'compat_test'
 libxdp: DATASEC '.xdp_run_config' not found.
 libxdp: At least one attached program doesn't support frags, disabling it for the dispatcher
 libxdp: Loading multiprog dispatcher for 1 programs without frags support
  libbpf: object 'xdp-dispatcher.': failed (-22) to create BPF token from '/sys/fs/bpf', skipping optional step...
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog0'
  libbpf: prog 'xdp_dispatcher': insn #7 relocated, imm 129 points to subprog 'prog0' (now at 137 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog1'
  libbpf: prog 'xdp_dispatcher': insn #21 relocated, imm 130 points to subprog 'prog1' (now at 152 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog2'
  libbpf: prog 'xdp_dispatcher': insn #33 relocated, imm 133 points to subprog 'prog2' (now at 167 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog3'
  libbpf: prog 'xdp_dispatcher': insn #45 relocated, imm 136 points to subprog 'prog3' (now at 182 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog4'
  libbpf: prog 'xdp_dispatcher': insn #57 relocated, imm 139 points to subprog 'prog4' (now at 197 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog5'
  libbpf: prog 'xdp_dispatcher': insn #69 relocated, imm 142 points to subprog 'prog5' (now at 212 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog6'
  libbpf: prog 'xdp_dispatcher': insn #81 relocated, imm 145 points to subprog 'prog6' (now at 227 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog7'
  libbpf: prog 'xdp_dispatcher': insn #93 relocated, imm 148 points to subprog 'prog7' (now at 242 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog8'
  libbpf: prog 'xdp_dispatcher': insn #105 relocated, imm 151 points to subprog 'prog8' (now at 257 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog9'
  libbpf: prog 'xdp_dispatcher': insn #117 relocated, imm 154 points to subprog 'prog9' (now at 272 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'compat_test'
  libbpf: prog 'xdp_dispatcher': insn #129 relocated, imm 157 points to subprog 'compat_test' (now at 287 offset)
  libbpf: map 'xdp_disp.rodata': created successfully, fd=4
 libxdp: Loaded XDP program xdp_dispatcher, got fd 12
 libxdp: Duplicated fd 12 to 14 for prog xdp_dispatcher
 libxdp: Checking dispatcher compatibility
 libxdp: Loading XDP program 'xdp-dispatcher.o' from embedded object file
  libbpf: loading object 'xdp-dispatcher.o' from buffer
  libbpf: elf: section(2) .text, size 1320, link 0, flags 6, type=1
  libbpf: sec '.text': found program 'prog0' at insn offset 0 (0 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog1' at insn offset 15 (120 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog2' at insn offset 30 (240 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog3' at insn offset 45 (360 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog4' at insn offset 60 (480 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog5' at insn offset 75 (600 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog6' at insn offset 90 (720 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog7' at insn offset 105 (840 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog8' at insn offset 120 (960 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog9' at insn offset 135 (1080 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'compat_test' at insn offset 150 (1200 bytes), code size 15 insns (120 bytes)
  libbpf: elf: section(3) xdp, size 1120, link 0, flags 6, type=1
  libbpf: sec 'xdp': found program 'xdp_dispatcher' at insn offset 0 (0 bytes), code size 137 insns (1096 bytes)
  libbpf: sec 'xdp': found program 'xdp_pass' at insn offset 137 (1096 bytes), code size 3 insns (24 bytes)
  libbpf: elf: section(4) .relxdp, size 336, link 26, flags 40, type=9
  libbpf: elf: section(5) .rodata, size 124, link 0, flags 2, type=1
  libbpf: elf: section(6) license, size 4, link 0, flags 3, type=1
  libbpf: license of xdp-dispatcher.o is GPL
  libbpf: elf: section(7) xdp_metadata, size 8, link 0, flags 3, type=1
  libbpf: elf: skipping unrecognized data section(7) xdp_metadata
  libbpf: elf: section(17) .BTF, size 3367, link 0, flags 0, type=1
  libbpf: elf: section(19) .BTF.ext, size 2720, link 0, flags 0, type=1
  libbpf: elf: section(26) .symtab, size 1536, link 1, flags 0, type=2
  libbpf: looking for externs among 64 symbols...
  libbpf: collected 0 externs total
  libbpf: map 'xdp_disp.rodata' (global data): at sec_idx 5, offset 0, flags 80.
  libbpf: map 0 is "xdp_disp.rodata"
  libbpf: sec '.relxdp': collecting relocation for section(3) 'xdp'
  libbpf: sec '.relxdp': relo #0: insn #1 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 1
  libbpf: sec '.relxdp': relo #1: insn #7 against 'prog0'
  libbpf: sec '.relxdp': relo #2: insn #21 against 'prog1'
  libbpf: sec '.relxdp': relo #3: insn #23 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 23
  libbpf: sec '.relxdp': relo #4: insn #33 against 'prog2'
  libbpf: sec '.relxdp': relo #5: insn #35 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 35
  libbpf: sec '.relxdp': relo #6: insn #45 against 'prog3'
  libbpf: sec '.relxdp': relo #7: insn #47 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 47
  libbpf: sec '.relxdp': relo #8: insn #57 against 'prog4'
  libbpf: sec '.relxdp': relo #9: insn #59 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 59
  libbpf: sec '.relxdp': relo #10: insn #69 against 'prog5'
  libbpf: sec '.relxdp': relo #11: insn #71 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 71
  libbpf: sec '.relxdp': relo #12: insn #81 against 'prog6'
  libbpf: sec '.relxdp': relo #13: insn #83 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 83
  libbpf: sec '.relxdp': relo #14: insn #93 against 'prog7'
  libbpf: sec '.relxdp': relo #15: insn #95 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 95
  libbpf: sec '.relxdp': relo #16: insn #105 against 'prog8'
  libbpf: sec '.relxdp': relo #17: insn #107 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 107
  libbpf: sec '.relxdp': relo #18: insn #117 against 'prog9'
  libbpf: sec '.relxdp': relo #19: insn #119 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 119
  libbpf: sec '.relxdp': relo #20: insn #129 against 'compat_test'
 libxdp: DATASEC '.xdp_run_config' not found.
 libxdp: Loading XDP program 'xdp-dispatcher.o' from embedded object file
  libbpf: loading object 'xdp-dispatcher.o' from buffer
  libbpf: elf: section(2) .text, size 1320, link 0, flags 6, type=1
  libbpf: sec '.text': found program 'prog0' at insn offset 0 (0 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog1' at insn offset 15 (120 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog2' at insn offset 30 (240 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog3' at insn offset 45 (360 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog4' at insn offset 60 (480 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog5' at insn offset 75 (600 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog6' at insn offset 90 (720 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog7' at insn offset 105 (840 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog8' at insn offset 120 (960 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'prog9' at insn offset 135 (1080 bytes), code size 15 insns (120 bytes)
  libbpf: sec '.text': found program 'compat_test' at insn offset 150 (1200 bytes), code size 15 insns (120 bytes)
  libbpf: elf: section(3) xdp, size 1120, link 0, flags 6, type=1
  libbpf: sec 'xdp': found program 'xdp_dispatcher' at insn offset 0 (0 bytes), code size 137 insns (1096 bytes)
  libbpf: sec 'xdp': found program 'xdp_pass' at insn offset 137 (1096 bytes), code size 3 insns (24 bytes)
  libbpf: elf: section(4) .relxdp, size 336, link 26, flags 40, type=9
  libbpf: elf: section(5) .rodata, size 124, link 0, flags 2, type=1
  libbpf: elf: section(6) license, size 4, link 0, flags 3, type=1
  libbpf: license of xdp-dispatcher.o is GPL
  libbpf: elf: section(7) xdp_metadata, size 8, link 0, flags 3, type=1
  libbpf: elf: skipping unrecognized data section(7) xdp_metadata
  libbpf: elf: section(17) .BTF, size 3367, link 0, flags 0, type=1
  libbpf: elf: section(19) .BTF.ext, size 2720, link 0, flags 0, type=1
  libbpf: elf: section(26) .symtab, size 1536, link 1, flags 0, type=2
  libbpf: looking for externs among 64 symbols...
  libbpf: collected 0 externs total
  libbpf: map 'xdp_disp.rodata' (global data): at sec_idx 5, offset 0, flags 80.
  libbpf: map 0 is "xdp_disp.rodata"
  libbpf: sec '.relxdp': collecting relocation for section(3) 'xdp'
  libbpf: sec '.relxdp': relo #0: insn #1 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 1
  libbpf: sec '.relxdp': relo #1: insn #7 against 'prog0'
  libbpf: sec '.relxdp': relo #2: insn #21 against 'prog1'
  libbpf: sec '.relxdp': relo #3: insn #23 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 23
  libbpf: sec '.relxdp': relo #4: insn #33 against 'prog2'
  libbpf: sec '.relxdp': relo #5: insn #35 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 35
  libbpf: sec '.relxdp': relo #6: insn #45 against 'prog3'
  libbpf: sec '.relxdp': relo #7: insn #47 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 47
  libbpf: sec '.relxdp': relo #8: insn #57 against 'prog4'
  libbpf: sec '.relxdp': relo #9: insn #59 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 59
  libbpf: sec '.relxdp': relo #10: insn #69 against 'prog5'
  libbpf: sec '.relxdp': relo #11: insn #71 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 71
  libbpf: sec '.relxdp': relo #12: insn #81 against 'prog6'
  libbpf: sec '.relxdp': relo #13: insn #83 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 83
  libbpf: sec '.relxdp': relo #14: insn #93 against 'prog7'
  libbpf: sec '.relxdp': relo #15: insn #95 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 95
  libbpf: sec '.relxdp': relo #16: insn #105 against 'prog8'
  libbpf: sec '.relxdp': relo #17: insn #107 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 107
  libbpf: sec '.relxdp': relo #18: insn #117 against 'prog9'
  libbpf: sec '.relxdp': relo #19: insn #119 against '.rodata'
  libbpf: prog 'xdp_dispatcher': found data map 0 (xdp_disp.rodata, sec 5, off 0) for insn 119
  libbpf: sec '.relxdp': relo #20: insn #129 against 'compat_test'
 libxdp: DATASEC '.xdp_run_config' not found.
  libbpf: object 'xdp-dispatcher.': failed (-22) to create BPF token from '/sys/fs/bpf', skipping optional step...
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog0'
  libbpf: prog 'xdp_dispatcher': insn #7 relocated, imm 129 points to subprog 'prog0' (now at 137 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog1'
  libbpf: prog 'xdp_dispatcher': insn #21 relocated, imm 130 points to subprog 'prog1' (now at 152 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog2'
  libbpf: prog 'xdp_dispatcher': insn #33 relocated, imm 133 points to subprog 'prog2' (now at 167 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog3'
  libbpf: prog 'xdp_dispatcher': insn #45 relocated, imm 136 points to subprog 'prog3' (now at 182 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog4'
  libbpf: prog 'xdp_dispatcher': insn #57 relocated, imm 139 points to subprog 'prog4' (now at 197 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog5'
  libbpf: prog 'xdp_dispatcher': insn #69 relocated, imm 142 points to subprog 'prog5' (now at 212 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog6'
  libbpf: prog 'xdp_dispatcher': insn #81 relocated, imm 145 points to subprog 'prog6' (now at 227 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog7'
  libbpf: prog 'xdp_dispatcher': insn #93 relocated, imm 148 points to subprog 'prog7' (now at 242 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog8'
  libbpf: prog 'xdp_dispatcher': insn #105 relocated, imm 151 points to subprog 'prog8' (now at 257 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog9'
  libbpf: prog 'xdp_dispatcher': insn #117 relocated, imm 154 points to subprog 'prog9' (now at 272 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'compat_test'
  libbpf: prog 'xdp_dispatcher': insn #129 relocated, imm 157 points to subprog 'compat_test' (now at 287 offset)
  libbpf: map 'xdp_disp.rodata': created successfully, fd=15
 libxdp: Loaded XDP program xdp_pass, got fd 19
 libxdp: Duplicated fd 19 to 20 for prog xdp_pass
  libbpf: object 'xdp-dispatcher.': failed (-22) to create BPF token from '/sys/fs/bpf', skipping optional step...
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog0'
  libbpf: prog 'xdp_dispatcher': insn #7 relocated, imm 129 points to subprog 'prog0' (now at 137 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog1'
  libbpf: prog 'xdp_dispatcher': insn #21 relocated, imm 130 points to subprog 'prog1' (now at 152 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog2'
  libbpf: prog 'xdp_dispatcher': insn #33 relocated, imm 133 points to subprog 'prog2' (now at 167 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog3'
  libbpf: prog 'xdp_dispatcher': insn #45 relocated, imm 136 points to subprog 'prog3' (now at 182 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog4'
  libbpf: prog 'xdp_dispatcher': insn #57 relocated, imm 139 points to subprog 'prog4' (now at 197 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog5'
  libbpf: prog 'xdp_dispatcher': insn #69 relocated, imm 142 points to subprog 'prog5' (now at 212 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog6'
  libbpf: prog 'xdp_dispatcher': insn #81 relocated, imm 145 points to subprog 'prog6' (now at 227 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog7'
  libbpf: prog 'xdp_dispatcher': insn #93 relocated, imm 148 points to subprog 'prog7' (now at 242 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog8'
  libbpf: prog 'xdp_dispatcher': insn #105 relocated, imm 151 points to subprog 'prog8' (now at 257 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'prog9'
  libbpf: prog 'xdp_dispatcher': insn #117 relocated, imm 154 points to subprog 'prog9' (now at 272 offset)
  libbpf: prog 'xdp_dispatcher': added 15 insns from sub-prog 'compat_test'
  libbpf: prog 'xdp_dispatcher': insn #129 relocated, imm 157 points to subprog 'compat_test' (now at 287 offset)
  libbpf: map 'xdp_disp.rodata': created successfully, fd=16
 libxdp: Loaded XDP program xdp_pass, got fd 23
 libxdp: Duplicated fd 23 to 24 for prog xdp_pass
 libxdp: Acquired lock from /sys/fs/bpf/xdp with fd 26
 libxdp: Released lock fd 26
 libxdp: Linking prog xdpfilt_alw_all as multiprog entry 0
  libbpf: object 'xdpfilt_alw_all': failed (-22) to create BPF token from '/sys/fs/bpf', skipping optional step...
  libbpf: prog 'xdpfilt_alw_all': added 56 insns from sub-prog 'parse_ethhdr'
  libbpf: prog 'xdpfilt_alw_all': added 8 insns from sub-prog 'proto_is_vlan'
  libbpf: prog 'parse_ethhdr': insn #32 relocated, imm 23 points to subprog 'proto_is_vlan' (now at 140 offset)
  libbpf: prog 'xdpfilt_alw_all': insn #12 relocated, imm 71 points to subprog 'parse_ethhdr' (now at 84 offset)
  libbpf: prog 'xdpfilt_alw_all': added 37 insns from sub-prog 'xdp_stats_record_action'
  libbpf: prog 'xdpfilt_alw_all': insn #19 relocated, imm 128 points to subprog 'xdp_stats_record_action' (now at 148 offset)
  libbpf: prog 'xdpfilt_alw_all': added 94 insns from sub-prog 'lookup_verdict_ethernet'
  libbpf: prog 'xdpfilt_alw_all': insn #22 relocated, imm 162 points to subprog 'lookup_verdict_ethernet' (now at 185 offset)
  libbpf: prog 'xdpfilt_alw_all': added 40 insns from sub-prog 'parse_iphdr'
  libbpf: prog 'xdpfilt_alw_all': insn #32 relocated, imm 246 points to subprog 'parse_iphdr' (now at 279 offset)
  libbpf: prog 'xdpfilt_alw_all': added 29 insns from sub-prog 'parse_ip6hdr'
  libbpf: prog 'xdpfilt_alw_all': added 65 insns from sub-prog 'skip_ip6hdrext'
  libbpf: prog 'parse_ip6hdr': insn #23 relocated, imm 5 points to subprog 'skip_ip6hdrext' (now at 348 offset)
  libbpf: prog 'xdpfilt_alw_all': insn #43 relocated, imm 275 points to subprog 'parse_ip6hdr' (now at 319 offset)
  libbpf: prog 'xdpfilt_alw_all': added 64 insns from sub-prog 'lookup_verdict_ipv4'
  libbpf: prog 'xdpfilt_alw_all': insn #48 relocated, imm 364 points to subprog 'lookup_verdict_ipv4' (now at 413 offset)
  libbpf: prog 'xdpfilt_alw_all': added 80 insns from sub-prog 'lookup_verdict_ipv6'
  libbpf: prog 'xdpfilt_alw_all': insn #53 relocated, imm 423 points to subprog 'lookup_verdict_ipv6' (now at 477 offset)
  libbpf: prog 'xdpfilt_alw_all': added 32 insns from sub-prog 'parse_udphdr'
  libbpf: prog 'xdpfilt_alw_all': insn #63 relocated, imm 493 points to subprog 'parse_udphdr' (now at 557 offset)
  libbpf: prog 'xdpfilt_alw_all': added 64 insns from sub-prog 'lookup_verdict_udp'
  libbpf: prog 'xdpfilt_alw_all': insn #67 relocated, imm 521 points to subprog 'lookup_verdict_udp' (now at 589 offset)
  libbpf: prog 'xdpfilt_alw_all': added 33 insns from sub-prog 'parse_tcphdr'
  libbpf: prog 'xdpfilt_alw_all': insn #77 relocated, imm 575 points to subprog 'parse_tcphdr' (now at 653 offset)
  libbpf: prog 'xdpfilt_alw_all': added 64 insns from sub-prog 'lookup_verdict_tcp'
  libbpf: prog 'xdpfilt_alw_all': insn #81 relocated, imm 604 points to subprog 'lookup_verdict_tcp' (now at 686 offset)
  libbpf: found no pinned map to reuse at '/sys/fs/bpf/xdp-filter/xdp_stats_map'
  libbpf: map 'xdp_stats_map': created successfully, fd=5
  libbpf: pinned map '/sys/fs/bpf/xdp-filter/xdp_stats_map'
  libbpf: found no pinned map to reuse at '/sys/fs/bpf/xdp-filter/filter_ports'
  libbpf: map 'filter_ports': created successfully, fd=6
  libbpf: pinned map '/sys/fs/bpf/xdp-filter/filter_ports'
  libbpf: found no pinned map to reuse at '/sys/fs/bpf/xdp-filter/filter_ipv4'
  libbpf: map 'filter_ipv4': created successfully, fd=7
  libbpf: pinned map '/sys/fs/bpf/xdp-filter/filter_ipv4'
  libbpf: found no pinned map to reuse at '/sys/fs/bpf/xdp-filter/filter_ipv6'
  libbpf: map 'filter_ipv6': created successfully, fd=8
  libbpf: pinned map '/sys/fs/bpf/xdp-filter/filter_ipv6'
  libbpf: found no pinned map to reuse at '/sys/fs/bpf/xdp-filter/filter_ethernet'
  libbpf: map 'filter_ethernet': created successfully, fd=9
  libbpf: pinned map '/sys/fs/bpf/xdp-filter/filter_ethernet'
  libbpf: map 'xdpfilt_.data': created successfully, fd=10
  libbpf: prog 'xdpfilt_alw_all': BPF program load failed: Invalid argument
  libbpf: prog 'xdpfilt_alw_all': -- BEGIN PROG LOAD LOG --
unknown opcode 8d
processed 0 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0
-- END PROG LOAD LOG --
  libbpf: prog 'xdpfilt_alw_all': failed to load: -22
  libbpf: unpinned map 'xdp_stats_map' from '/sys/fs/bpf/xdp-filter/xdp_stats_map'
  libbpf: unpinned map 'filter_ports' from '/sys/fs/bpf/xdp-filter/filter_ports'
  libbpf: unpinned map 'filter_ipv4' from '/sys/fs/bpf/xdp-filter/filter_ipv4'
  libbpf: unpinned map 'filter_ipv6' from '/sys/fs/bpf/xdp-filter/filter_ipv6'
  libbpf: unpinned map 'filter_ethernet' from '/sys/fs/bpf/xdp-filter/filter_ethernet'
  libbpf: failed to load object '/usr/lib/bpf/xdpfilt_alw_all.o'
 libxdp: Failed to load program xdpfilt_alw_all: Invalid argument
Couldn't attach XDP program on iface 'eth1': Invalid argument(-22)
Released lock fd 3
```
</details>