### PR TITLE
kernel: KERNEL_NET_L3_MASTER_DEV default to y if !SMALL_FLASH

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1187,9 +1187,11 @@ endif
 
 config KERNEL_NET_L3_MASTER_DEV
 	bool "L3 Master device support"
+	default y if !SMALL_FLASH
 	help
 	  This module provides glue between core networking code and device
 	  drivers to support L3 master devices like VRF.
+  	  Increases the compressed kernel size by ~4kB (as of Linux 6.6).
 
 config KERNEL_XDP_SOCKETS
 	bool "XDP sockets support"


### PR DESCRIPTION
Follow-up for 45d541bb409355f090b971d96ebebd8610ef84a7

This change allows features such as kmod-vrf

```
KERNEL_NET_L3_MASTER_DEV=n

x86_64 generic
	bzImage 6,927,360 bytes
aarch64 coretex-a53
	kernel  4,268,836 bytes

KERNEL_NET_L3_MASTER_DEV=y

x86_64 generic
	bzImage 6,931,456 bytes
aarch64 coretex-a53
	kernel  4,273,042 bytes

Delta:
x86_64 generic
	+4096 bytes
aarch64 coretex-a53
	+4206 bytes

x86_64 generic vrf.ko - 258,792 bytes
aarch64 coretex-a53 vrf.ko - 263,632 bytes
```

See:
https://forum.openwrt.org/t/vrf-support-testing-out-evpn-at-home/181108
https://forum.openwrt.org/t/please-enable-net-l3-master-dev-in-kernel-build-by-default/201825

ping @hauke @Ansuel @robimarko 