### PR TITLE
bcm27xx-utils: update to latest version

### DIFF
--- a/package/utils/bcm27xx-utils/Makefile
+++ b/package/utils/bcm27xx-utils/Makefile
@@ -3,13 +3,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bcm27xx-utils
-PKG_VERSION:=2024.04.24
+PKG_VERSION:=2024.10.25
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/raspberrypi/utils.git
-PKG_SOURCE_VERSION:=451b9881b72cb994c102724b5a7d9b93f97dc315
-PKG_MIRROR_HASH:=595ad8eadd9756132dee4b7d1b2466cb9fb8efa2015e6fbd4ab983e1a00afcf4
+PKG_SOURCE_VERSION:=6a2a6becebbc38fde34a94386457ac8210f9119b
+PKG_MIRROR_HASH:=a775c7ffb9fac2d798ec8e0a4c7707eb7133cbc9c4418a1cf9434f87c42c01bb
 
 PKG_FLAGS:=nonshared
 PKG_BUILD_FLAGS:=no-lto
@@ -45,6 +45,8 @@ define Package/bcm27xx-utils/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/eepdump $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/eepflash.sh $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/eepmake $(1)/usr/bin
+
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/kdtc $(1)/usr/bin
 
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/otpset $(1)/usr/bin
 

--- a/package/utils/bcm27xx-utils/patches/0001-raspinfo-adapt-to-OpenWrt.patch
+++ b/package/utils/bcm27xx-utils/patches/0001-raspinfo-adapt-to-OpenWrt.patch
@@ -242,6 +242,15 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  else
     echo "vcdbg not found"
  fi
+@@ -275,7 +111,7 @@ echo "dmesg log"
+ echo "---------"
+ echo
+ 
+-sudo dmesg | sed -e "s/\([0-9a-fA-F]\{1,4\}:\)\{7,7\}[0-9a-fA-F]\{1,4\}/y.y.y.y.y.y.y.y/g" | sed -e "s/[0-9a-fA-F]\{1,4\}:\(:[0-9a-fA-F]\{1,4\}\)\{1,4\}/y::y.y.y.y/g" | sed -e "s/\([0-9a-fA-F]\{2,2\}\:\)\{5,5\}[0-9a-fA-F]\{2,2\}/m.m.m.m/g"
++dmesg | sed -e "s/\([0-9a-fA-F]\{1,4\}:\)\{7,7\}[0-9a-fA-F]\{1,4\}/y.y.y.y.y.y.y.y/g" | sed -e "s/[0-9a-fA-F]\{1,4\}:\(:[0-9a-fA-F]\{1,4\}\)\{1,4\}/y::y.y.y.y/g" | sed -e "s/\([0-9a-fA-F]\{2,2\}\:\)\{5,5\}[0-9a-fA-F]\{2,2\}/m.m.m.m/g"
+ 
+ 
+ if  grep -q "^Revision\s*:\s*[ 123][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]1[13457][0-9a-fA-F]$" /proc/cpuinfo
 @@ -284,5 +120,9 @@ echo
  echo "EEPROM"
  echo "------"


### PR DESCRIPTION
Fixes build with GCC 14.

Full changelog: https://github.com/raspberrypi/utils/compare/451b9881b72cb994c102724b5a7d9b93f97dc315...6a2a6becebbc38fde34a94386457ac8210f9119b

CC @graysky2 