### PR TITLE
bcm27xx-gpu-fw: update to latest version

### DIFF
--- a/package/kernel/bcm27xx-gpu-fw/Makefile
+++ b/package/kernel/bcm27xx-gpu-fw/Makefile
@@ -2,130 +2,20 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=bcm27xx-gpu-fw
-PKG_RELEASE_HASH:=969420b4121b522ab33c5001074cc4c2547dafaf
-PKG_VERSION:=2024.04.24~$(PKG_RELEASE_HASH)
+PKG_VERSION:=2024.10.08
+PKG_VERSION_REAL:=1.$(subst .,,$(PKG_VERSION))
 PKG_RELEASE:=1
 
-PKG_BUILD_DIR:=$(KERNEL_BUILD_DIR)/$(PKG_NAME)/rpi-firmware-$(PKG_RELEASE_HASH)
+PKG_SOURCE:=raspi-firmware_$(PKG_VERSION_REAL).orig.tar.xz
+PKG_SOURCE_URL:=https://github.com/raspberrypi/firmware/releases/download/$(PKG_VERSION_REAL)
+PKG_HASH:=11e7bedcd0f52729bbc82ae8de3cb3f52eb4ae3d6bdb3e11fbfdbea9c4a2b1c3
 
 PKG_FLAGS:=nonshared
 
 include $(INCLUDE_DIR)/package.mk
 
-RPI_FIRMWARE_URL:=@GITHUB/raspberrypi/firmware/$(PKG_RELEASE_HASH)/boot/
-RPI_FIRMWARE_FILE:=rpi-firmware-$(PKG_RELEASE_HASH)
-
-define Download/LICENCE_broadcom
-  FILE:=$(RPI_FIRMWARE_FILE)-LICENCE.broadcom
-  URL:=$(RPI_FIRMWARE_URL)
-  URL_FILE:=LICENCE.broadcom
-  HASH:=c7283ff51f863d93a275c66e3b4cb08021a5dd4d8c1e7acc47d872fbe52d3d6b
-endef
-$(eval $(call Download,LICENCE_broadcom))
-
-define Download/bootcode_bin
-  FILE:=$(RPI_FIRMWARE_FILE)-bootcode.bin
-  URL:=$(RPI_FIRMWARE_URL)
-  URL_FILE:=bootcode.bin
-  HASH:=af603ebd97e7b692c30195563f7b25656eb05d57838cf1a715ebb470d1614ce4
-endef
-$(eval $(call Download,bootcode_bin))
-
-define Download/fixup_dat
-  FILE:=$(RPI_FIRMWARE_FILE)-fixup.dat
-  URL:=$(RPI_FIRMWARE_URL)
-  URL_FILE:=fixup.dat
-  HASH:=94ae3ff8363a6a2832f173241597b6500cf67044d34155a1251fe58671dd6ce7
-endef
-$(eval $(call Download,fixup_dat))
-
-define Download/fixup_cd_dat
-  FILE:=$(RPI_FIRMWARE_FILE)-fixup_cd.dat
-  URL:=$(RPI_FIRMWARE_URL)
-  URL_FILE:=fixup_cd.dat
-  HASH:=2d7c19e46780ef29867f8ed200a94bb77a7982f5bc41219afe864d2303ba3084
-endef
-$(eval $(call Download,fixup_cd_dat))
-
-define Download/fixup_x_dat
-  FILE:=$(RPI_FIRMWARE_FILE)-fixup_x.dat
-  URL:=$(RPI_FIRMWARE_URL)
-  URL_FILE:=fixup_x.dat
-  HASH:=692393562d0650f7d1891ba0143ad0500ccf07129947d386d56350e7ca204d16
-endef
-$(eval $(call Download,fixup_x_dat))
-
-define Download/fixup4_dat
-  FILE:=$(RPI_FIRMWARE_FILE)-fixup4.dat
-  URL:=$(RPI_FIRMWARE_URL)
-  URL_FILE:=fixup4.dat
-  HASH:=63a4a8f356e2b8ed2850d68b9adf21008ef1dfa7743b22ddc26987e4d3171302
-endef
-$(eval $(call Download,fixup4_dat))
-
-define Download/fixup4cd_dat
-  FILE:=$(RPI_FIRMWARE_FILE)-fixup4cd.dat
-  URL:=$(RPI_FIRMWARE_URL)
-  URL_FILE:=fixup4cd.dat
-  HASH:=2d7c19e46780ef29867f8ed200a94bb77a7982f5bc41219afe864d2303ba3084
-endef
-$(eval $(call Download,fixup4cd_dat))
-
-define Download/fixup4x_dat
-  FILE:=$(RPI_FIRMWARE_FILE)-fixup4x.dat
-  URL:=$(RPI_FIRMWARE_URL)
-  URL_FILE:=fixup4x.dat
-  HASH:=41328f6587c0cd47ae7fa7edab4bf62730dda54caf52ffaa3bfb24ff93b8348b
-endef
-$(eval $(call Download,fixup4x_dat))
-
-define Download/start_elf
-  FILE:=$(RPI_FIRMWARE_FILE)-start.elf
-  URL:=$(RPI_FIRMWARE_URL)
-  URL_FILE:=start.elf
-  HASH:=8637fb847ff62f69fbb8b98b1beff685b47cf4095580e830724f6a27fb20fee0
-endef
-$(eval $(call Download,start_elf))
-
-define Download/start_cd_elf
-  FILE:=$(RPI_FIRMWARE_FILE)-start_cd.elf
-  URL:=$(RPI_FIRMWARE_URL)
-  URL_FILE:=start_cd.elf
-  HASH:=6832f57236f6c453cd72eac1f0ab53e265037fb75fc41301448fedb8d505f2b3
-endef
-$(eval $(call Download,start_cd_elf))
-
-define Download/start_x_elf
-  FILE:=$(RPI_FIRMWARE_FILE)-start_x.elf
-  URL:=$(RPI_FIRMWARE_URL)
-  URL_FILE:=start_x.elf
-  HASH:=6f72a3fda8cbdacb340676e18a8468b9edd89458173b5ecf3c12b00c147dce40
-endef
-$(eval $(call Download,start_x_elf))
-
-define Download/start4_elf
-  FILE:=$(RPI_FIRMWARE_FILE)-start4.elf
-  URL:=$(RPI_FIRMWARE_URL)
-  URL_FILE:=start4.elf
-  HASH:=badf4cd8822d1b85ad56ddb9e32e9b4220c88099c8cc0c3e70ae77190571c8ef
-endef
-$(eval $(call Download,start4_elf))
-
-define Download/start4cd_elf
-  FILE:=$(RPI_FIRMWARE_FILE)-start4cd.elf
-  URL:=$(RPI_FIRMWARE_URL)
-  URL_FILE:=start4cd.elf
-  HASH:=7d3f13c8412c6b0efdbd3b53439776f3552621cc28ee887caaac539fb063ad8a
-endef
-$(eval $(call Download,start4cd_elf))
-
-define Download/start4x_elf
-  FILE:=$(RPI_FIRMWARE_FILE)-start4x.elf
-  URL:=$(RPI_FIRMWARE_URL)
-  URL_FILE:=start4x.elf
-  HASH:=c30fbdfedad7180245ff567ccdea953fc1816d0da3ff4701b15071c6f8b47a89
-endef
-$(eval $(call Download,start4x_elf))
+TAR_OPTIONS+=--strip-components 1
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
 define Package/bcm27xx-gpu-fw
   SECTION:=boot
@@ -136,51 +26,28 @@ define Package/bcm27xx-gpu-fw
 endef
 
 define Package/bcm27xx-gpu-fw/description
- GPU and kernel boot firmware for bcm27xx.
-endef
-
-define Build/Prepare
-	rm -rf $(PKG_BUILD_DIR)
-	mkdir -p $(PKG_BUILD_DIR)
-	$(CP) $(DL_DIR)/$(RPI_FIRMWARE_FILE)-LICENCE.broadcom $(PKG_BUILD_DIR)/LICENCE.broadcom
-	$(CP) $(DL_DIR)/$(RPI_FIRMWARE_FILE)-bootcode.bin $(PKG_BUILD_DIR)/bootcode.bin
-	$(CP) $(DL_DIR)/$(RPI_FIRMWARE_FILE)-fixup.dat $(PKG_BUILD_DIR)/fixup.dat
-	$(CP) $(DL_DIR)/$(RPI_FIRMWARE_FILE)-fixup_cd.dat $(PKG_BUILD_DIR)/fixup_cd.dat
-	$(CP) $(DL_DIR)/$(RPI_FIRMWARE_FILE)-fixup_x.dat $(PKG_BUILD_DIR)/fixup_x.dat
-	$(CP) $(DL_DIR)/$(RPI_FIRMWARE_FILE)-fixup4.dat $(PKG_BUILD_DIR)/fixup4.dat
-	$(CP) $(DL_DIR)/$(RPI_FIRMWARE_FILE)-fixup4cd.dat $(PKG_BUILD_DIR)/fixup4cd.dat
-	$(CP) $(DL_DIR)/$(RPI_FIRMWARE_FILE)-fixup4x.dat $(PKG_BUILD_DIR)/fixup4x.dat
-	$(CP) $(DL_DIR)/$(RPI_FIRMWARE_FILE)-start.elf $(PKG_BUILD_DIR)/start.elf
-	$(CP) $(DL_DIR)/$(RPI_FIRMWARE_FILE)-start_cd.elf $(PKG_BUILD_DIR)/start_cd.elf
-	$(CP) $(DL_DIR)/$(RPI_FIRMWARE_FILE)-start_x.elf $(PKG_BUILD_DIR)/start_x.elf
-	$(CP) $(DL_DIR)/$(RPI_FIRMWARE_FILE)-start4.elf $(PKG_BUILD_DIR)/start4.elf
-	$(CP) $(DL_DIR)/$(RPI_FIRMWARE_FILE)-start4cd.elf $(PKG_BUILD_DIR)/start4cd.elf
-	$(CP) $(DL_DIR)/$(RPI_FIRMWARE_FILE)-start4x.elf $(PKG_BUILD_DIR)/start4x.elf
+  GPU and kernel boot firmware for bcm27xx.
 endef
 
 define Build/Compile
 	true
 endef
 
-define Package/bcm27xx-gpu-fw/install
-	true
-endef
-
 define Build/InstallDev
-	$(CP) $(PKG_BUILD_DIR)/bootcode.bin $(KERNEL_BUILD_DIR)
-	$(CP) $(PKG_BUILD_DIR)/LICENCE.broadcom $(KERNEL_BUILD_DIR)
-	$(CP) $(PKG_BUILD_DIR)/start.elf $(KERNEL_BUILD_DIR)
-	$(CP) $(PKG_BUILD_DIR)/start_cd.elf $(KERNEL_BUILD_DIR)
-	$(CP) $(PKG_BUILD_DIR)/start_x.elf $(KERNEL_BUILD_DIR)
-	$(CP) $(PKG_BUILD_DIR)/start4.elf $(KERNEL_BUILD_DIR)
-	$(CP) $(PKG_BUILD_DIR)/start4cd.elf $(KERNEL_BUILD_DIR)
-	$(CP) $(PKG_BUILD_DIR)/start4x.elf $(KERNEL_BUILD_DIR)
-	$(CP) $(PKG_BUILD_DIR)/fixup.dat $(KERNEL_BUILD_DIR)
-	$(CP) $(PKG_BUILD_DIR)/fixup_cd.dat $(KERNEL_BUILD_DIR)
-	$(CP) $(PKG_BUILD_DIR)/fixup_x.dat $(KERNEL_BUILD_DIR)
-	$(CP) $(PKG_BUILD_DIR)/fixup4.dat $(KERNEL_BUILD_DIR)
-	$(CP) $(PKG_BUILD_DIR)/fixup4cd.dat $(KERNEL_BUILD_DIR)
-	$(CP) $(PKG_BUILD_DIR)/fixup4x.dat $(KERNEL_BUILD_DIR)
+	$(CP) $(PKG_BUILD_DIR)/boot/bootcode.bin $(KERNEL_BUILD_DIR)
+	$(CP) $(PKG_BUILD_DIR)/boot/LICENCE.broadcom $(KERNEL_BUILD_DIR)
+	$(CP) $(PKG_BUILD_DIR)/boot/start.elf $(KERNEL_BUILD_DIR)
+	$(CP) $(PKG_BUILD_DIR)/boot/start_cd.elf $(KERNEL_BUILD_DIR)
+	$(CP) $(PKG_BUILD_DIR)/boot/start_x.elf $(KERNEL_BUILD_DIR)
+	$(CP) $(PKG_BUILD_DIR)/boot/start4.elf $(KERNEL_BUILD_DIR)
+	$(CP) $(PKG_BUILD_DIR)/boot/start4cd.elf $(KERNEL_BUILD_DIR)
+	$(CP) $(PKG_BUILD_DIR)/boot/start4x.elf $(KERNEL_BUILD_DIR)
+	$(CP) $(PKG_BUILD_DIR)/boot/fixup.dat $(KERNEL_BUILD_DIR)
+	$(CP) $(PKG_BUILD_DIR)/boot/fixup_cd.dat $(KERNEL_BUILD_DIR)
+	$(CP) $(PKG_BUILD_DIR)/boot/fixup_x.dat $(KERNEL_BUILD_DIR)
+	$(CP) $(PKG_BUILD_DIR)/boot/fixup4.dat $(KERNEL_BUILD_DIR)
+	$(CP) $(PKG_BUILD_DIR)/boot/fixup4cd.dat $(KERNEL_BUILD_DIR)
+	$(CP) $(PKG_BUILD_DIR)/boot/fixup4x.dat $(KERNEL_BUILD_DIR)
 endef
 
 $(eval $(call BuildPackage,bcm27xx-gpu-fw))


### PR DESCRIPTION
Use release tar instead of downloading separate files.

Full changelog: https://github.com/raspberrypi/firmware/compare/1.20240424...1.20241008