### PR TITLE
ath79: add support for Ditel DT-ACU100

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -29,6 +29,7 @@ asus,zenwifi-cd6n|\
 asus,zenwifi-cd6r|\
 buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\
+ditel,dt-acu100|\
 engenius,eap300-v2|\
 engenius,eap350-v1|\
 engenius,eap600|\

--- a/target/linux/ath79/dts/qca9531_ditel_dt-acu100.dts
+++ b/target/linux/ath79/dts/qca9531_ditel_dt-acu100.dts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "ditel,dt-acu100", "qca,qca9531";
+	model = "Ditel DT-ACU100";
+
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+		label-mac-device = &eth1;
+		serial0 = &uart;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: status {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <12000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			firmware: partition@50000 {
+				label = "firmware";
+				reg = <0x050000 0xf90000>;
+				compatible = "denx,uimage";
+			};
+
+			ditel: partition@fe0000 {
+				label = "ditel";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+				};
+			};
+		};
+	};
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth1 {
+	phy-handle = <&swphy4>;
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
+};
+

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -540,6 +540,9 @@ wd,mynet-wifi-rangeextender)
 xiaomi,aiot-ac2350)
 	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x02"
 	;;
+ditel,dt-acu100)
+	ucidef_set_led_netdev "wan" "WAN" "red:wan" "eth1"
+	;;
 yuncore,a770)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x10"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -472,6 +472,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan"
 		;;
+	ditel,dt-acu100)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0u@eth0" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
+		;;
 	phicomm,k2t)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "3:lan:1" "5:lan:2" "4:wan"

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -3237,6 +3237,15 @@ define Device/xiaomi_mi-router-4q
 endef
 TARGET_DEVICES += xiaomi_mi-router-4q
 
+define Device/ditel_dt-acu100
+  SOC := qca9531
+  DEVICE_VENDOR := Ditel
+  DEVICE_MODEL := DT-ACU100
+  DEVICE_PACKAGES := kmod-usb2
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += ditel_dt-acu100
+
 define Device/yuncore_a770
   SOC := qca9531
   DEVICE_VENDOR := YunCore


### PR DESCRIPTION
Ditel DT-ACU100 is a ceiling mount Router with PoE support, based on Qualcomm/Atheros QCA9531@650MHz SoC.

Short specification:

- QCA9531 650 MHz SoC
- 1x 10/100/1000 Mbps Ethernet (wan/eth1)
- 1x 10/100/1000 Mbps Ethernet (lan/eth0)
- 128MB of DDR2 RAM (Winbond W971GG6SB)
- 16 MB of FLASH (Winbond W25Q128FV)
- 2T2R 2.4 GHz, 802.11b/g/n (wlan2g)
- 1x RGB LED, 1x button
- UART header on PCB with proper labelling

Initial flashing instructions:

Original firmware is based on OpenWrt.

a) Use sysupgrade image directly in vendor GUI.

b) Or via tftp:

  ipaddr=192.168.1.1 serverip=192.168.1.10 bootfile="firmware.bin"

c) Or possibly via u-boot's `httpd` command.

MAC-address mapping follows original firmware:

* eth1 (wan) is the lowest mac address (art @ 0x0)
* eth0 (lan) uses eth1 + 1 (art @ 0x1000)
* wlan2g (phy0) uses eth1 + 2 (art @ 0x06)
* unused MAC (eth1 + 3) (art @ 0x5006)

Art dump (`hexdump /dev/mtd1 |grep ZZZZ`):

0000000 ZZZZ XXXX XXX0 ZZZZ XXXX XXX2 ffff ffff
0001000 0202 ZZZZ XXXX XXX1 0000 0000 0000 0000
0005000 202f bd21 0101 ZZZZ XXXX XXX3 0000 2000

flash Stock :

0x000000-0x040000(u-boot)
00x000000-0x050000(u-boot-env)
0x050000-0xfe0000(firmware)
0xfe0000-0xff0000(ditel)
0xff0000-0x1000000(art)

dev:    size   erasesize  name
mtd0: 00040000 00010000 "u-boot"
mtd1: 00010000 00010000 "u-boot-env"
mtd2: 00f90000 00010000 "firmware"
mtd3: 00290000 00010000 "kernel"
mtd4: 00d00000 00010000 "rootfs"
mtd5: 00190000 00010000 "rootfs_data"
mtd6: 00010000 00010000 "ditel"
mtd7: 00010000 00010000 "art"

Root access to original firmware (only via UART) can be achieved by making a backup of configuration from web interface. Backup contains whole `/etc` directory...

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

