### PR TITLE
CI: labeler: add bcm27xx-utils

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -30,6 +30,7 @@
   - any-glob-to-any-file:
     - "target/linux/bcm27xx/**"
     - "package/kernel/bcm27xx-gpu-fw/**"
+    - "package/utils/bcm27xx-utils/**"
 "target/bcm47xx":
 - changed-files:
   - any-glob-to-any-file:


### PR DESCRIPTION
bcm27xx-utils can only be built for bcm27xx target.