### PR TITLE
package: add new poe-common package

### DIFF
--- a/package/network/config/poe-common/Makefile
+++ b/package/network/config/poe-common/Makefile
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=poe-common
+PGK_VERSION:=1
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=Sander Vanheule <sander@svanheule.net>
+PKG_LICENSE:=GPL-2.0-or-later
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/poe-common
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Common base files for PoE
+  DEPENDS:=+libubox +libuci
+endef
+
+define Package/poe-common/conffiles
+/etc/config/poe
+endef
+
+define Package/poe-common/description
+ Common base files for PoE configuration and control
+endef
+
+define Package/poe-common/install
+	$(INSTALL_DIR) $(1)/etc/uci-defaults/
+	$(INSTALL_CONF) ./files/etc/uci-defaults/30_poe $(1)/etc/uci-defaults/
+endef
+
+define Build/Compile
+endef
+
+$(eval $(call BuildPackage,poe-common))

--- a/package/network/config/poe-common/files/etc/uci-defaults/30_poe
+++ b/package/network/config/poe-common/files/etc/uci-defaults/30_poe
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+[ -e /etc/config/poe ] && exit 0
+
+. /lib/functions.sh
+. /usr/share/libubox/jshn.sh
+
+CFG=/etc/board.json
+
+json_init
+json_load_file "${CFG}"
+
+json_is_a poe object || exit 0
+
+umask 055
+touch /etc/config/poe
+
+json_select poe
+	json_get_vars budget
+
+	uci add poe global
+	uci set poe.@global[-1].budget="$budget"
+
+	if json_is_a ports array; then
+		json_get_values ports ports
+		id='1'
+
+		for port in $ports; do
+			uci -q batch <<-EOF
+				add poe port
+				set poe.@port[-1].name='$port'
+				set poe.@port[-1].id='$id'
+				set poe.@port[-1].enable='1'
+			EOF
+			let id=id+1
+		done
+	fi
+json_select ..
+
+uci commit
+
+exit 0


### PR DESCRIPTION
Appeared in a post by @svanheule [on the mailing list in January](https://lists.openwrt.org/pipermail/openwrt-devel/2024-January/042155.html?) after a thorough discussion in https://github.com/Hurricos/realtek-poe/pull/31#issuecomment-2241760274 but was not actioned. I believe this is still a valid concern and should be addressed. Currently PoE devices do not honour configuration in `board.json` and this should rectify that.

**Note - this code is purely the work of Sander and I am merely reproducing the code here for discussion.  I feel this merits discussion as we currently lack appropriate PoE config files for targets using realtek-poe; the same static file is used for all switches.**

Original explanation from Sander's post on the mailing list:

Create a new package to generate configuration files for devices capable of delivering power via PoE. The configuration file at /etc/config/poe can be used by PoE daemons to configure the hardware in an implementation specific way.

This is part of the core packages because it needs to be in sync with the format of board.json, from which the config file is generated. The config file structure is based on the current config file of the realtek-poe package, but should be (and remain) implementation independent. With a common basis, a common (LuCI) configuration interface also becomes possible in the future.

For a device with a power budget of 130W and ports lan1-lan8 mapping to PSE outputs 8-1, /etc/config/poe could look like (lan1-lan6 omitted):
```
	config global
		option budget '130'

	config port
		option name 'lan8'
		option id '1'
		option enable '1'

	config port
		option name 'lan7'
		option id '2'
		option enable '1'

	[...]
```

- Based entirely on the work of Sander Vanheule <sander@svanheule.net>
Signed-off-by: Stephen Howell <howels@allthatwemight.be>