### PR TITLE
openwrt-keyring: make opkg use 24.10 usign key

### DIFF
--- a/package/system/openwrt-keyring/Makefile
+++ b/package/system/openwrt-keyring/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openwrt-keyring
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/keyring.git
@@ -38,8 +38,8 @@ endef
 else
 define Package/openwrt-keyring/install
 	$(INSTALL_DIR) $(1)/etc/opkg/keys/
-	# Public usign key for unattended snapshot builds
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/usign/b5043e70f9a75cde $(1)/etc/opkg/keys/
+	# Public usign key for 24.10 release builds
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/usign/d310c6f2833e97f7 $(1)/etc/opkg/keys/
 endef
 endif
 


### PR DESCRIPTION
Official CI signs 24.10 packages with usign key for 24.10 release builds. (fingerprint d310c6f2833e97f7)

However, 24.10 images and imagebuilders are still shipped with public usign key for snapshot builds. (fingerprint b5043e70f9a75cde)

This patch make opkg usable with artifacts produced by project's buildbot.

References: 2d03f27f0f07 ("openwrt-keyring: make opkg use 22.03 usign key")